### PR TITLE
[Dependency] Add `readability-lxml==0.8.1`

### DIFF
--- a/infra/marin-cluster.yaml
+++ b/infra/marin-cluster.yaml
@@ -77,6 +77,7 @@ setup_commands:
     "ray[default]==2.22.0" 
     "rbloom==1.5.0" 
     "readabilipy==0.2.0" 
+    "readability-lxml==0.8.1" 
     "regex==2024.4.16" 
     "requests" 
     "tensorflow==2.16.1" 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "ray[default]==2.22.0",
     "rbloom==1.5.0",
     "readabilipy==0.2.0",
+    "readability-lxml==0.8.1",
     "regex==2024.4.16",
     "requests",
     "tensorflow==2.16.1",


### PR DESCRIPTION
Add `readability-lxml` and restart Ray cluster.

(Should find a better way of doing this... @dlwh mentioned just running an editable install on each job start. Ray also has native Docker support).