### PR TITLE
Cluster changes for DP + more autoscaling

### DIFF
--- a/infra/marin-cluster.yaml
+++ b/infra/marin-cluster.yaml
@@ -2,7 +2,7 @@
 cluster_name: marin-data
 
 # Maximum Workers (excluding Head Node)
-max_workers: 145
+max_workers: 1024
 
 # List of Available Node Types
 available_node_types:
@@ -31,8 +31,8 @@ available_node_types:
   # Worker Nodes =>> Preemptible TPU v4-8 VMs
   tpu_worker:
     min_workers: 4
-    max_workers: 145
-    resources: {"CPU": 120, "TPU": 1}
+    max_workers: 1024
+    resources: {"CPU": 120, "TPU": 4}
 
     # GCP-Specific Configuration; setup for TPU V4-8 VMs (in `us-central2-b`)
     node_config:


### PR DESCRIPTION
Changing TPU from 1 to 4 makes it so the 4 chips on a v4-8 are all visible to the user. 

Changed autoscaling from 145 to 1024 because we can. We have a much bigger quota in us-central-2.