### PR TITLE
Add removing gcloud log to cleaning script

### DIFF
--- a/scripts/maintenance/cleaning_script.sh
+++ b/scripts/maintenance/cleaning_script.sh
@@ -7,6 +7,9 @@ echo "Script started at: $(date)"
 # clean up cache directory
 rm -rf /home/shared/.cache
 
+# clean up gcloud log
+rm -rf /home/shared/.config/gcloud/logs
+
 # clean up old docker image
 bash /home/shared/maintenance/delete_old_docker_images.sh
 


### PR DESCRIPTION
gcloud's log is secretly taking up our disk space: 

<img width="1899" alt="image" src="https://github.com/user-attachments/assets/3febc9fb-ff8b-4243-b2fb-87e9df5addbd">
