### PR TITLE
add highlighting ability to data browser (showing only a subset of the data)

### DIFF
--- a/data_browser/src/index.css
+++ b/data_browser/src/index.css
@@ -70,3 +70,7 @@ tr {
   border-top: 2px solid lightgray;
   padding-top: 10px;
 }
+
+.disabled {
+  color: gray;
+}


### PR DESCRIPTION
Add functionality to the data browser to enable showing a subset of the fields (e.g., only the text part of records).  This reduces clutter and makes it easier to compare fields by fitting them on a screen.

Example use case: showing the text field when comparing the output of multiple html->text transforms.