### PR TITLE
Avoid traf from crashing in missing title

### DIFF
--- a/marin/web/convert.py
+++ b/marin/web/convert.py
@@ -38,6 +38,7 @@ def convert_page_with_trafilatura(
         case str():
             content = extract(
                 html,
+                **asdict(TrafilaturaConfig.get_preset_config(config)),
             )
         case TrafilaturaConfig():
             content = extract(


### PR DESCRIPTION
Add fix so trafilatura doesn't crash the code for missing title in HTML.

Content for such broken HTML is still empty but it doesn't crash:
```
In [6]: html = """<div>this is text</div>"""

In [7]: extract(html)

In [8]: html = """<div>The capital of <a href=\"https://en.wikipedia.org/wiki/Spain\">Spain</a> is <b>Madrid</b>.</div> This page was last edite
   ...: d on 28 September 2024."""

In [9]: extract(html)

```