### PR TITLE
render .executor_info files as JSONs

### DIFF
--- a/data_browser/server.py
+++ b/data_browser/server.py
@@ -126,6 +126,10 @@ def view():
         if path.endswith(".executor_info"):
             return jsonify(read_json_file(path))
 
+        # render .executor_status files as jsonl
+        if path.endswith(".executor_status"):
+            return jsonify(read_text_file(path=path, get_json=True, offset=offset, count=count))
+
         # Assume text file (treated as a list of lines)
         return jsonify(read_text_file(path=path, gzipped=False, get_json=False, offset=offset, count=count))
 


### PR DESCRIPTION
Closes #425
`.executor_status` files are not valid JSON at the moment, so they error out if we try to read as JSON. But they seem to render fine, so I think there's no need to do anything about it.