### PR TITLE
Add script to consolidate open-web-math and fineweb-edu shards

### DIFF
--- a/scripts/open-web-math/consolidate_open_web_math_shards.py
+++ b/scripts/open-web-math/consolidate_open_web_math_shards.py
@@ -114,6 +114,7 @@ def consolidate_html(cfg: ConsolidationConfig):
     _ = ray.get(get_shards_indices_to_process.remote(cfg.input_path, shard_indices_to_process_path))
     with fsspec.open(shard_indices_to_process_path, "rt", compression="gzip") as f:
         shard_indices = json.load(f)
+    logger.info(f"Found {len(shard_indices)} to process")
 
     # Group into chunks of 1000 WARCs each
     # open-web-math has ~3M WARCs in total, which yields 3000 resharded chunks.


### PR DESCRIPTION
## Description

Re-shards open-web-math so we don't have 3M files on GCS, and instead have 3000. This script should also work for the fineweb-edu HTML, since it's the same format.