### PR TITLE
Add tqdm-loggable to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "braceexpand",
     "deepdiff",
     "tqdm",
+    "tqdm-loggable",
     "toml",
     "pandas", # Only needed by Fileprovider in inference.py
     "pyarrow", # # Only needed by Fileprovider in inference.py


### PR DESCRIPTION
## Description

Seems like my imports are failing with `ray_run`, so adding it to `pyproject.toml`
