### PR TITLE
fix quickstart workflow

### DIFF
--- a/.github/workflows/quickstart.yaml
+++ b/.github/workflows/quickstart.yaml
@@ -21,6 +21,7 @@ jobs:
         with:
           python-version: '3.10'
           cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
 
       - name: Install dependencies
         run: pip install .[extras]


### PR DESCRIPTION
There were two problems:
- typo: "run" should have been "name"
- Need to tell it that we're using pyproject.toml