### PR TITLE
fix transform step to not rely on revision subdirectory

### DIFF
--- a/experiments/instruction_datasets.py
+++ b/experiments/instruction_datasets.py
@@ -114,10 +114,7 @@ def download_dataset_step(dataset: InstructionDatasetConfig) -> ExecutorStep:
 
 def transform_dataset_step(dataset: InstructionDatasetConfig, download_step: ExecutorStep) -> ExecutorStep:
     dataset_name = get_directory_friendly_dataset_name(dataset.hf_dataset_id)
-    download_data = output_path_of(
-        download_step,
-        f"{dataset.revision}",
-    )
+    download_data = output_path_of(download_step)
 
     # Transform the dataset
     transform_step = ExecutorStep(


### PR DESCRIPTION
## Description

Fixes #728 

Minor fix just to remove revision from expected path for transform of raw data from huggingface to openai format for marin


## Checklist

- [x] You ran `pre-commit run --all-files` to lint your code
- [x] You ran 'pytest' to test your code
