### PR TITLE
fix data browser URL in experiment script output

### DIFF
--- a/marin/execution/executor.py
+++ b/marin/execution/executor.py
@@ -606,7 +606,7 @@ class Executor:
         """Return the URL where the experiment can be viewed."""
         # TODO: remove hardcoding
         if self.prefix.startswith("gs://"):
-            host = "https://marlin-subtle-barnacle.ngrok-free.app"
+            host = "https://crfm.stanford.edu/marin/data_browser"
         else:
             host = "http://localhost:5000"
 


### PR DESCRIPTION
## Description

Fixes #786 

Example experiment script URL I tested this update on (this experiment script itself isn't pushed yet): https://marin.community/data-browser/experiment/?path=gs%3A//marin-us-central2/experiments/exp780_dolma_suite-f8518c.json