### PR TITLE
add support for pushing docker image to ghcr, bump jax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ cluster_docker_ghcr_push: cluster_docker_build
 	$(foreach version,$(TAG_VERSIONS), \
 		docker tag '$(DOCKER_IMAGE_NAME):latest' 'ghcr.io/stanford-crfm/marin/$(DOCKER_IMAGE_NAME):$(version)';)
 
+	$(foreach version,$(TAG_VERSIONS), \
+		docker push 'ghcr.io/stanford-crfm/marin/$(DOCKER_IMAGE_NAME):$(version)';)
+
 
 # Meta-target that builds and then pushes the Docker images
 cluster_docker: cluster_docker_build cluster_docker_push

--- a/docker/marin/Dockerfile.cluster
+++ b/docker/marin/Dockerfile.cluster
@@ -66,13 +66,13 @@ RUN conda install -c conda-forge ncurses -y
 #RUN VLLM_TARGET_DEVICE="tpu" python3 setup.py develop
 
 # Install Jax for TPU usage, fsspec for GCS access, and transformers for OLMO
-RUN pip install --no-cache-dir -U jax[tpu]==0.4.36 -f https://storage.googleapis.com/jax-releases/libtpu_releases.html fsspec==2024.9.0 transformers==4.47.0
+RUN pip install --no-cache-dir -U jax[tpu]==0.5.1 -f https://storage.googleapis.com/jax-releases/libtpu_releases.html fsspec==2024.9.0 transformers==4.47.0
 
 # Installing all the core dependencies
 # ['draccus>=0.8.0', 'google-api-python-client~=2.0', 'ray', 'gcsfs', 'google-cloud-storage',
 # 'google-cloud-storage-transfer', 's3fs', 'regex', 'requests', 'numpy', 'torch', 'braceexpand', 'deepdiff', 'tqdm',
 # 'tqdm-loggable', 'toml', 'pandas', 'pyarrow', 'jax==0.4.35', 'multiprocess==0.70.16', 'levanter>=1.2.dev1163']
-RUN pip install --no-cache-dir -U draccus==0.10 google-api-python-client~=2.0 gcsfs google-cloud-storage google-cloud-storage-transfer s3fs regex requests numpy torch braceexpand deepdiff tqdm tqdm-loggable toml pandas pyarrow levanter==1.2.dev1190
+RUN pip install --no-cache-dir -U draccus==0.10 google-api-python-client~=2.0 gcsfs google-cloud-storage google-cloud-storage-transfer s3fs regex requests numpy torch braceexpand deepdiff tqdm tqdm-loggable toml pandas pyarrow "levanter>=1.2.dev1207" "haliax>=1.4dev330"
 
 
 # NOTE: Try to keep as much "heavy" stuff as possible before this line to avoid re-installing


### PR DESCRIPTION
For release and to let others dogfood, we want people to be able to use our docker container. Putting in ghcr is an easy way to do this.

Also bumps the jax and levanter deps...