### PR TITLE
update data browser so deploys work on mac

### DIFF
--- a/data_browser/conf/gcp.conf
+++ b/data_browser/conf/gcp.conf
@@ -3,3 +3,4 @@ root_paths:
 - gs://marin-us-west4
 - gs://marin-eu-west4
 - gs://marin-us-east5
+- gs://marin-us-east1

--- a/data_browser/deploy.sh
+++ b/data_browser/deploy.sh
@@ -20,7 +20,7 @@ if ! gcloud artifacts repositories describe marin-data-browser \
         --project=hai-gcp-models
 fi
 
-docker build -t marin-data-browser -f Dockerfile.prod .
+docker build --platform linux/amd64 -t marin-data-browser -f Dockerfile.prod .
 
 gcloud auth configure-docker us-central1-docker.pkg.dev
 


### PR DESCRIPTION
## Description

Fixes issue where deploy script for data browser didn't work because I was building docker with Apple Silicon / ARM. The change is just to specify docker should build for linux x86 architecture which is what the data browser VM runs on. Also adds us-east-1 to config.

## Checklist

- [x] You ran `pre-commit run --all-files` to lint your code
- [x] You ran 'pytest' to test your code