### PR TITLE
Print job URL after ray_run.py submits it

### DIFF
--- a/marin/run/ray_run.py
+++ b/marin/run/ray_run.py
@@ -108,6 +108,7 @@ async def submit_and_track_job(entrypoint: str, dependencies: list, env_vars: di
     # Submit the job with runtime environment and entrypoint
     submission_id = client.submit_job(entrypoint=entrypoint, runtime_env=runtime_dict)
     logger.info(f"Job submitted with ID: {submission_id}")
+    logger.info(f"Job URL: http://localhost:8265/#/jobs/{submission_id}")
 
     if no_wait:
         return


### PR DESCRIPTION
## Description

Small QOL fix so I can directly jump to the job's logs on the ray dashboard