### PR TITLE
More spoonbill

### DIFF
--- a/experiments/defaults.py
+++ b/experiments/defaults.py
@@ -319,6 +319,9 @@ def default_sft(
         An ExecutorStep configured for supervised fine-tuning.
     """
     # Set up common configurations
+    if "sft" not in tags:
+        tags = [*tags, "sft"]
+
     tracker_config = WandbConfig(
         project="marin",
         tags=[*tags],

--- a/experiments/exp227_sft.py
+++ b/experiments/exp227_sft.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 
 import jmp
-from instruction_datasets import get_instruction_dataset
 from levanter.checkpoint import CheckpointerConfig
 from levanter.data.text import LMSupervisedDatasetConfig
 from levanter.models.llama import LlamaConfig
@@ -9,6 +8,7 @@ from levanter.optim import AdamConfig
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
 
+from experiments.instruction_datasets import get_instruction_dataset
 from marin.execution.executor import ExecutorStep, executor_main, output_path_of, this_output_path
 from marin.processing.tokenize.tokenize import TokenizeConfig, levanter_tokenize_sft
 from marin.training.training import TrainSFTOnPodConfig, run_levanter_sft

--- a/experiments/exp606_sft.py
+++ b/experiments/exp606_sft.py
@@ -1,7 +1,6 @@
-from instruction_datasets import get_instruction_dataset
-
 from experiments.defaults import default_sft
-from experiments.llama import llama3_tokenizer, llama_8b
+from experiments.instruction_datasets import get_instruction_dataset
+from experiments.llama import llama3_instruct_tokenizer, llama_8b
 from experiments.simple_sft_config import SimpleSFTConfig
 from marin.execution.executor import ExecutorStep, executor_main, output_path_of, this_output_path
 from marin.processing.tokenize.tokenize import TokenizeConfig, levanter_tokenize_sft
@@ -19,13 +18,13 @@ NUM_TRAIN_STEPS = NUM_TRAIN_TOKENS // (128 * 4096) * 3  # 2 epochs
 
 # Create tokenization step for Tulu-3 dataset
 tulu3_llama_tokenize_step = ExecutorStep(
-    name="tokenized/tulu_sft_v3_llama3_tokenizer",
+    name="tokenized/tulu_sft_v3_llama3_instruct_tokenizer",
     fn=levanter_tokenize_sft,
     config=TokenizeConfig(
         train_paths=[output_path_of(tulu_3_dataset, "**/*.jsonl.gz")],
         validation_paths=[],
         cache_path=this_output_path(),
-        tokenizer=llama3_tokenizer,
+        tokenizer=llama3_instruct_tokenizer,
         input_field="user",
         output_field="assistant",
     ),
@@ -37,7 +36,7 @@ tulu_sft_config = SimpleSFTConfig(
     num_train_steps=NUM_TRAIN_STEPS,  # Adjust as needed.
     learning_rate=5e-6,
     tpu_type="v4-128",
-    tokenizer=llama3_tokenizer,
+    tokenizer=llama3_instruct_tokenizer,
     model_name_or_path="meta-llama/Llama-3.1-8B",
     max_seq_len=4096,
     seed=1,

--- a/experiments/exp727_synthetic_instruction_sft.py
+++ b/experiments/exp727_synthetic_instruction_sft.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 
 import jmp
-from instruction_datasets import get_instruction_dataset
 from levanter.checkpoint import CheckpointerConfig
 from levanter.data.text import LMSupervisedDatasetConfig
 from levanter.models.llama import LlamaConfig
@@ -10,6 +9,7 @@ from levanter.optim import AdamConfig
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
 
+from experiments.instruction_datasets import get_instruction_dataset
 from experiments.llama import llama3_tokenizer
 from marin.execution.executor import ExecutorStep, executor_main, output_path_of, this_output_path
 from marin.processing.tokenize.tokenize import TokenizeConfig, levanter_tokenize_sft

--- a/experiments/exp758_openthought_sft.py
+++ b/experiments/exp758_openthought_sft.py
@@ -1,6 +1,5 @@
-from instruction_datasets import get_instruction_dataset
-
 from experiments.defaults import default_sft
+from experiments.instruction_datasets import get_instruction_dataset
 from experiments.llama import llama3_tokenizer, llama_8b
 from experiments.simple_sft_config import SimpleSFTConfig
 from marin.execution.executor import ExecutorStep, executor_main, output_path_of, this_output_path

--- a/experiments/exp808_sft_mixture.py
+++ b/experiments/exp808_sft_mixture.py
@@ -7,10 +7,10 @@ different number of datasets you will need to change the number of training step
 accordingly.
 """
 
-from instruction_datasets import get_instruction_dataset
 from levanter.data.text import SupervisedUrlSourceConfig
 
 from experiments.defaults import default_sft
+from experiments.instruction_datasets import get_instruction_dataset
 from experiments.llama import llama_8b
 from experiments.simple_sft_config import SimpleSFTConfig
 from marin.execution.executor import ExecutorStep, executor_main, output_path_of, this_output_path

--- a/experiments/llama.py
+++ b/experiments/llama.py
@@ -9,6 +9,7 @@ from experiments.simple_train_config import SimpleTrainConfig
 
 llama3_tokenizer = "meta-llama/Meta-Llama-3.1-8B"
 llama3_tokenizer_vocab_size = 128_256
+llama3_instruct_tokenizer = "meta-llama/Meta-Llama-3.1-8B-Instruct"
 
 llama_150m = LlamaConfig(
     seq_len=1024,

--- a/experiments/test_hf_subsets.py
+++ b/experiments/test_hf_subsets.py
@@ -1,5 +1,4 @@
-from instruction_datasets import get_instruction_dataset
-
+from experiments.instruction_datasets import get_instruction_dataset
 from experiments.llama import llama3_tokenizer
 from marin.execution.executor import ExecutorStep, executor_main, output_path_of, this_output_path
 from marin.processing.tokenize.tokenize import TokenizeConfig, levanter_tokenize_sft

--- a/experiments/tootsie/exp916_tootsie_spoonbill_cooldown.py
+++ b/experiments/tootsie/exp916_tootsie_spoonbill_cooldown.py
@@ -13,8 +13,9 @@ import dataclasses
 from levanter.callbacks.watch import WatchConfig
 
 from experiments.dclm.tokenize_dclm import DCLM_MIXTURE_WEIGHTS
-from experiments.defaults import default_train
+from experiments.defaults import default_sft, default_train
 from experiments.dolmino.tokenize_dolmino import get_dolmino_step
+from experiments.exp606_sft import tulu3_llama_tokenize_step, tulu_sft_config
 from experiments.instruction_datasets import (
     tulu3_flat_llama_tokenized_as_train,
     tulu3_flat_llama_tokenized_as_validation,
@@ -214,6 +215,35 @@ tootsie_8b_deeper_spoonbill = dataclasses.replace(
     override_output_path="checkpoints/tootsie-8b-deeper-spoonbill-2",
 )
 
+# do some sfts
+
+spoonbill_zloss_tulu3_sft_config = dataclasses.replace(
+    tulu_sft_config,
+    model_name_or_path=output_path_of(norm_tootsie_8b_focused_spoonbill_zloss, "hf/step-829999/"),
+)
+
+
+sft_tulu3_spoonbill_zloss = default_sft(
+    name="sft/tulu3_tootsie_sft_spoonbill_zloss",
+    tokenized=tulu3_llama_tokenize_step,
+    model_config=llama_8b_fp32_attn,
+    sft_config=spoonbill_zloss_tulu3_sft_config,
+    tags=["llama", "8b", "exp916", "tootsie", "sft", "spoonbill"],
+).with_output_path("checkpoints/sft/tulu3_tootsie_sft_spoonbill_zloss")
+
+
+sft_tulu3_deeper_spoonbill = default_sft(
+    name="sft/tulu3_tootsie_deeper_spoonbill",
+    tokenized=tulu3_llama_tokenize_step,
+    model_config=llama_8b_fp32_attn,
+    sft_config=dataclasses.replace(
+        spoonbill_zloss_tulu3_sft_config,
+        model_name_or_path=output_path_of(tootsie_8b_deeper_spoonbill, "hf/step-839999/"),
+    ),
+    tags=["llama", "8b", "exp916", "tootsie", "sft", "spoonbill"],
+).with_output_path("checkpoints/sft/tulu3_tootsie_sft_deeper_spoonbill_zloss")
+
+
 if __name__ == "__main__":
     executor_main(
         [
@@ -222,6 +252,8 @@ if __name__ == "__main__":
             norm_tootsie_8b_focused_spoonbill_fp32_attention,
             norm_tootsie_8b_focused_spoonbill_zloss,
             tootsie_8b_deeper_spoonbill,
+            sft_tulu3_spoonbill_zloss,
+            sft_tulu3_deeper_spoonbill,
         ],
         description="Cooldown run for tootsie-8b model with some flan and tulu",
     )

--- a/marin/execution/executor.py
+++ b/marin/execution/executor.py
@@ -161,6 +161,10 @@ class ExecutorStep(Generic[ConfigT]):
         """Hash based on the ID (every object is different)."""
         return hash(id(self))
 
+    def with_output_path(self, output_path: str) -> "ExecutorStep":
+        """Return a copy of the step with the given output_path."""
+        return replace(self, override_output_path=output_path)
+
 
 @dataclass(frozen=True)
 class InputName:


### PR DESCRIPTION
## Description

Part of #916 : add auto-sft to the spoonbill models.

Also:

* changes the tokenizer for SFT to be the instruct tokenizer, per @ahmeda14960 
* fixes import paths for instruction_datasets
* add with_output_path as sugar for the oft-used dataclasses.replace(..., override_output_path=...)


still running tokenization