### PR TITLE
Update requirements so that marin works with Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "gcsfs",
     "google-cloud-storage",
     "google-cloud-storage-transfer",
-    "s3fs",
+    "s3fs>=2024",
     "regex",
     "requests",
     "numpy",


### PR DESCRIPTION
## Description

Fixes #1195 

Issue was that s3fs clashes with gcsfs. Now forcing s3fs to be >=2024, which resolves the error.

Fix was tested on EC2 g6dn.2xlarge running on Ubuntu 24.04.2 LTS. Packages that were installed:
- gcsfs==2025.3.0 
- s3fs==2025.3.0
