### PR TITLE
Fixes for GCSFuse to use local file cache

### DIFF
--- a/infra/marin-eu-west4-vllm.yaml
+++ b/infra/marin-eu-west4-vllm.yaml
@@ -27,7 +27,7 @@ docker:
     worker_run_options:
         - --privileged
         - --ulimit memlock=-1:-1  #
-        - --shm-size=32gb
+        - --shm-size=200gb
         - -v
         - "/tmp:/tmp"
         # this lets the worker run docker commands and have them run as sibling containers
@@ -59,7 +59,7 @@ setup_commands:
   - /root/gcloud/google-cloud-sdk/bin/gcloud secrets versions access latest --secret=OPENAI_API_KEY > $HOME/.cache/openai/token
   - echo 'export MARIN_PREFIX="gs://marin-eu-west4"' >> $HOME/.bashrc
   - echo 'export BUCKET="marin-eu-west4"' >> $HOME/.bashrc
-  - gcsfuse --implicit-dirs --only-dir gcsfuse_mount $BUCKET /opt/gcsfuse_mount || true
+  - gcsfuse --implicit-dirs --cache-dir /dev/shm --file-cache-max-size-mb 160000 --client-protocol grpc --only-dir gcsfuse_mount $BUCKET /opt/gcsfuse_mount || true
   - mkdir -p ~/.ssh && /root/gcloud/google-cloud-sdk/bin/gcloud compute project-info describe --format="value(commonInstanceMetadata.items[?key==\"ssh-keys\"].value)" > ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys
   # Using /home/ray/.ssh/ since auth.ssh_user is set to 'ray' and we need to ensure the key is in the correct user's home directory else we get an error
   - /root/gcloud/google-cloud-sdk/bin/gcloud secrets versions access latest --secret=RAY_CLUSTER_PUBLIC_KEY > ~/.ssh/marin_ray_cluster.pub

--- a/infra/marin-us-central2-vllm.yaml
+++ b/infra/marin-us-central2-vllm.yaml
@@ -27,7 +27,7 @@ docker:
     worker_run_options:
         - --privileged
         - --ulimit memlock=-1:-1  #
-        - --shm-size=32gb
+        - --shm-size=200gb
         - -v
         - "/tmp:/tmp"
         # this lets the worker run docker commands and have them run as sibling containers
@@ -59,7 +59,7 @@ setup_commands:
   - /root/gcloud/google-cloud-sdk/bin/gcloud secrets versions access latest --secret=OPENAI_API_KEY > $HOME/.cache/openai/token
   - echo 'export MARIN_PREFIX="gs://marin-us-central2"' >> $HOME/.bashrc
   - echo 'export BUCKET="marin-us-central2"' >> $HOME/.bashrc
-  - gcsfuse --implicit-dirs --only-dir gcsfuse_mount $BUCKET /opt/gcsfuse_mount || true
+  - gcsfuse --implicit-dirs --cache-dir /dev/shm --file-cache-max-size-mb 160000 --client-protocol grpc --only-dir gcsfuse_mount $BUCKET /opt/gcsfuse_mount || true
   - mkdir -p ~/.ssh && /root/gcloud/google-cloud-sdk/bin/gcloud compute project-info describe --format="value(commonInstanceMetadata.items[?key==\"ssh-keys\"].value)" > ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys
   # Using /home/ray/.ssh/ since auth.ssh_user is set to 'ray' and we need to ensure the key is in the correct user's home directory else we get an error
   - /root/gcloud/google-cloud-sdk/bin/gcloud secrets versions access latest --secret=RAY_CLUSTER_PUBLIC_KEY > ~/.ssh/marin_ray_cluster.pub

--- a/infra/marin-us-east1-d-vllm.yaml
+++ b/infra/marin-us-east1-d-vllm.yaml
@@ -27,7 +27,7 @@ docker:
     worker_run_options:
         - --privileged
         - --ulimit memlock=-1:-1  #
-        - --shm-size=32gb
+        - --shm-size=200gb
         - -v
         - "/tmp:/tmp"
         # this lets the worker run docker commands and have them run as sibling containers
@@ -59,7 +59,7 @@ setup_commands:
   - /root/gcloud/google-cloud-sdk/bin/gcloud secrets versions access latest --secret=OPENAI_API_KEY > $HOME/.cache/openai/token
   - echo 'export MARIN_PREFIX="gs://marin-us-east1"' >> $HOME/.bashrc
   - echo 'export BUCKET="marin-us-east1"' >> $HOME/.bashrc
-  - gcsfuse --implicit-dirs --only-dir gcsfuse_mount $BUCKET /opt/gcsfuse_mount || true
+  - gcsfuse --implicit-dirs --cache-dir /dev/shm --file-cache-max-size-mb 160000 --client-protocol grpc --only-dir gcsfuse_mount $BUCKET /opt/gcsfuse_mount || true
   - mkdir -p ~/.ssh && /root/gcloud/google-cloud-sdk/bin/gcloud compute project-info describe --format="value(commonInstanceMetadata.items[?key==\"ssh-keys\"].value)" > ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys
   # Using /home/ray/.ssh/ since auth.ssh_user is set to 'ray' and we need to ensure the key is in the correct user's home directory else we get an error
   - /root/gcloud/google-cloud-sdk/bin/gcloud secrets versions access latest --secret=RAY_CLUSTER_PUBLIC_KEY > ~/.ssh/marin_ray_cluster.pub

--- a/infra/marin-us-east5-b-vllm.yaml
+++ b/infra/marin-us-east5-b-vllm.yaml
@@ -27,7 +27,7 @@ docker:
     worker_run_options:
         - --privileged
         - --ulimit memlock=-1:-1  #
-        - --shm-size=32gb
+        - --shm-size=200gb
         - -v
         - "/tmp:/tmp"
         # this lets the worker run docker commands and have them run as sibling containers
@@ -59,7 +59,7 @@ setup_commands:
   - /root/gcloud/google-cloud-sdk/bin/gcloud secrets versions access latest --secret=OPENAI_API_KEY > $HOME/.cache/openai/token
   - echo 'export MARIN_PREFIX="gs://marin-us-east5"' >> $HOME/.bashrc
   - echo 'export BUCKET="marin-us-east5"' >> $HOME/.bashrc
-  - gcsfuse --implicit-dirs --only-dir gcsfuse_mount $BUCKET /opt/gcsfuse_mount || true
+  - gcsfuse --implicit-dirs --cache-dir /dev/shm --file-cache-max-size-mb 160000 --client-protocol grpc --only-dir gcsfuse_mount $BUCKET /opt/gcsfuse_mount || true
   - mkdir -p ~/.ssh && /root/gcloud/google-cloud-sdk/bin/gcloud compute project-info describe --format="value(commonInstanceMetadata.items[?key==\"ssh-keys\"].value)" > ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys
   # Using /home/ray/.ssh/ since auth.ssh_user is set to 'ray' and we need to ensure the key is in the correct user's home directory else we get an error
   - /root/gcloud/google-cloud-sdk/bin/gcloud secrets versions access latest --secret=RAY_CLUSTER_PUBLIC_KEY > ~/.ssh/marin_ray_cluster.pub

--- a/infra/marin-vllm-template.yaml
+++ b/infra/marin-vllm-template.yaml
@@ -23,7 +23,7 @@ docker:
     worker_run_options:
         - --privileged
         - --ulimit memlock=-1:-1  #
-        - --shm-size=32gb
+        - --shm-size=200gb
         - -v
         - "/tmp:/tmp"
         # this lets the worker run docker commands and have them run as sibling containers
@@ -55,7 +55,7 @@ setup_commands:
   - /root/gcloud/google-cloud-sdk/bin/gcloud secrets versions access latest --secret=OPENAI_API_KEY > $HOME/.cache/openai/token
   - echo 'export MARIN_PREFIX="gs://{{BUCKET}}"' >> $HOME/.bashrc
   - echo 'export BUCKET="{{BUCKET}}"' >> $HOME/.bashrc
-  - gcsfuse --implicit-dirs --only-dir gcsfuse_mount $BUCKET /opt/gcsfuse_mount || true
+  - gcsfuse --implicit-dirs --cache-dir /dev/shm --file-cache-max-size-mb 160000 --client-protocol grpc --only-dir gcsfuse_mount $BUCKET /opt/gcsfuse_mount || true
   - mkdir -p ~/.ssh && /root/gcloud/google-cloud-sdk/bin/gcloud compute project-info describe --format="value(commonInstanceMetadata.items[?key==\"ssh-keys\"].value)" > ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys
   # Using /home/ray/.ssh/ since auth.ssh_user is set to 'ray' and we need to ensure the key is in the correct user's home directory else we get an error
   - /root/gcloud/google-cloud-sdk/bin/gcloud secrets versions access latest --secret=RAY_CLUSTER_PUBLIC_KEY > ~/.ssh/marin_ray_cluster.pub


### PR DESCRIPTION
## Description

Some rough benchmarking:
Model | GCSFuse Mount with Cache Directory - grpc | GCSFuse Mount without cache directory
-- | -- | --
Llama-8b | 1 minute 37 seconds | 1 hour
Llama-70b | 14 minutes | N/A



## Checklist

- [ ] You ran `pre-commit run --all-files` to lint your code
- [ ] You ran 'pytest' to test your code
- [ ] Delete this checklist