### PR TITLE
Minor fixes to hardcoded directories in tutorials

### DIFF
--- a/docs/tutorials/executor-101.md
+++ b/docs/tutorials/executor-101.md
@@ -146,7 +146,7 @@ if __name__ == "__main__":
 To run this experiment:
 
 ```bash
-python experiments/tutorials/hello_world.py --prefix local_store
+python experiments/tutorial/hello_world.py --prefix local_store
 ```
 
 This command will create several output files:

--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -96,7 +96,7 @@ Marin runs on multiple types of hardware (CPU, GPU, TPU).
 
 - **CPU**: Works out of the box, suitable for small experiments
 - **GPU**: See [Local GPU Setup](local-gpu.md) for CUDA configuration and multi-GPU support
-- **TPU**: See [TPU Setup](../tutorials/tpu-setup.md) for Google Cloud TPU configuration
+- **TPU**: See [TPU Setup](../tutorial/tpu-setup.md) for Google Cloud TPU configuration
 
 ## Trying it Out
 


### PR DESCRIPTION
## Description
Current paths to tutorial code have mistakes. Changed it so that users can copy and paste commands.

