### PR TITLE
Add pseudo-dependencies / skip_parents to the Executor

### DIFF
--- a/marin/execution/executor.py
+++ b/marin/execution/executor.py
@@ -185,7 +185,7 @@ class InputName:
 
     step: ExecutorStep | None
     name: str | None
-    wait_on_step: bool = True
+    block_on_step: bool = True
     """
     If False, the step that uses this InputName
     will not block (or attempt to execute) the parent step. We use this for
@@ -217,7 +217,7 @@ class InputName:
 
          (Note that if another step depends on the parent step, it will still block on it.)
         """
-        return dataclasses.replace(self, wait_on_step=False)
+        return dataclasses.replace(self, block_on_step=False)
 
 
 def get_executor_step(run: ExecutorStep | InputName) -> ExecutorStep:
@@ -409,7 +409,7 @@ def collect_dependencies_and_version(obj: Any) -> _Dependencies:
             # Put string i for the i-th dependency
             if obj.step is not None:
                 index = len(dependencies) + len(pseudo_dependencies)
-                if not obj.wait_on_step:
+                if not obj.block_on_step:
                     pseudo_dependencies.append(obj.step)
                 else:
                     dependencies.append(obj.step)

--- a/marin/execution/executor.py
+++ b/marin/execution/executor.py
@@ -821,8 +821,8 @@ class Executor:
                     pip=pip_dependencies,
                 ),
                 # TODO: this is kind of gross, but the overhead of instantiating a separate ray task
-                # that only blocks is pretty wasteful. Would be better to not make 1 step per, but
-                # this is a good first step
+                # that only blocks is pretty wasteful. Would be better to not make 1 task per step, but
+                # this is a good first start
                 num_cpus=0.001 if isinstance(step.fn, ray.remote_function.RemoteFunction) else 1,
             ).remote(step.fn, step_name, config, dependencies, output_path, self.status_actor, force_run_failed)
         else:

--- a/marin/execution/executor.py
+++ b/marin/execution/executor.py
@@ -56,7 +56,7 @@ might be:
 
 - If you prefer to manage the output paths yourself, you can not use `versioned`
   fields and specify everything you want in the name.  Note the version will
-  still depend on upstream dependencies.
+  still depend on upstream dependencies and "pseudo-dependencies."
 
 - The pipeline might get too big and unwieldy, in which case we can cut it up by
   specifying a hard-coded path as the input to a step.  Or perhaps we can have
@@ -65,8 +65,15 @@ might be:
 
 - If we decide to rename fields, we can extend `versioned` to take a string of
   the old field name to preserve backward compatibility.
+
+- "Pseudo-dependencies" are dependencies that are not actually run, but are
+  included in the hash. This is useful for depending on checkpoints of in-progress
+  training runs, for example. When you run a step that has a pseudo-dependency,
+  it will not wait for the pseudo-dependency to finish executing (or even check if it is executing or failed)
+  before running.
 """
 
+import dataclasses
 import hashlib
 import inspect
 import json
@@ -178,12 +185,21 @@ class InputName:
 
     step: ExecutorStep | None
     name: str | None
+    should_skip_parent: bool = False
+    """
+    If True, the step will not block (or attempt to execute) the parent step. We use this for
+    documenting dependencies in the config, but that step might not have technically finished...
+
+    For instance, we sometimes use training checkpoints before the training step has finished.
+
+    These "pseudo-dependencies" still impact the hash of the step, but they don't block execution.
+    """
 
     def cd(self, name: str) -> "InputName":
         return InputName(self.step, name=os.path.join(self.name, name) if self.name else name)
 
     def __truediv__(self, other: str) -> "InputName":
-        """Alias for `cd`. That looks more Pythonic."""
+        """Alias for `cd` that looks more Pythonic."""
         return self.cd(other)
 
     @staticmethod
@@ -193,6 +209,14 @@ class InputName:
         Try to use this sparingly.
         """
         return InputName(None, name=path)
+
+    def skip_parent(self, should_skip: bool = True) -> "InputName":
+        """
+        If `should_skip` is True (default), the step will not block on (or attempt to execute) the parent step.
+
+        (Note that if another step depends on the parent step, it will still block on it.)
+        """
+        return dataclasses.replace(self, should_skip_parent=should_skip)
 
 
 def get_executor_step(run: ExecutorStep | InputName) -> ExecutorStep:
@@ -332,7 +356,7 @@ def dependency_index_str(i: int) -> str:
     return f"DEP[{i}]"
 
 
-def collect_dependencies_and_version(obj: Any, dependencies: list[ExecutorStep], version: dict[str, Any]):
+def collect_dependencies_and_version(obj: Any) -> tuple[list[ExecutorStep], dict[str, Any], list[ExecutorStep]]:
     """Recurse through `obj` to find all the versioned values, and return them
     as a dict where the key is the sequence of fields identifying where the
     value resides in obj.  Example:
@@ -344,7 +368,18 @@ def collect_dependencies_and_version(obj: Any, dependencies: list[ExecutorStep],
         {"a": 1, "b.c": 2}
 
     Along the way, compute the list of dependencies.
+
+    Returns:
+        - dependencies: list of `ExecutorStep`s that are dependencies of the
+          current step.
+        - version: dict of versioned values, where the key is the sequence of
+          fields identifying where the value resides in obj.
+        - pseudo_dependencies: list of `ExecutorStep`s that are dependencies of the step but that we won't
+            actually block on
     """
+    pseudo_dependencies: list[ExecutorStep] = []
+    dependencies: list[ExecutorStep] = []
+    version: dict[str, Any] = {}
 
     def recurse(obj: Any, prefix: str):
         new_prefix = prefix + "." if prefix else ""
@@ -356,9 +391,12 @@ def collect_dependencies_and_version(obj: Any, dependencies: list[ExecutorStep],
             version[prefix] = obj.value
         elif isinstance(obj, InputName):
             # Put string i for the i-th dependency
-            index = len(dependencies)
             if obj.step is not None:
-                dependencies.append(obj.step)
+                index = len(dependencies) + len(pseudo_dependencies)
+                if obj.should_skip_parent:
+                    pseudo_dependencies.append(obj.step)
+                else:
+                    dependencies.append(obj.step)
                 version[prefix] = dependency_index_str(index) + ("/" + obj.name if obj.name else "")
             else:
                 version[prefix] = obj.name
@@ -379,6 +417,8 @@ def collect_dependencies_and_version(obj: Any, dependencies: list[ExecutorStep],
                 recurse(x, new_prefix + i)
 
     recurse(obj, "")
+
+    return dependencies, version, pseudo_dependencies
 
 
 def instantiate_config(
@@ -450,6 +490,8 @@ class Executor:
         self.configs: dict[ExecutorStep, dataclass] = {}
         self.dependencies: dict[ExecutorStep, list[ExecutorStep]] = {}
         self.versions: dict[ExecutorStep, dict[str, Any]] = {}
+        # skippable deps are pseudo-dependencies that only impact version but not blocking
+        self.skippable: dict[ExecutorStep, bool] = {}
         self.version_strs: dict[ExecutorStep, str] = {}
         self.version_str_to_step: dict[str, ExecutorStep] = {}
         self.output_paths: dict[ExecutorStep, str] = {}
@@ -493,7 +535,7 @@ class Executor:
             if isinstance(step, InputName):  # Interpret InputName as the underlying step
                 step = step.step
             if step is not None:
-                self.compute_version(step)
+                self.compute_version(step, is_pseudo_dep=False)
 
         self.get_infos()
         logger.info(f"### Reading {len(self.steps)} statuses ###")
@@ -501,7 +543,7 @@ class Executor:
         if run_only is not None:
             steps_to_run = self._compute_transitive_deps(self.steps, run_only)
         else:
-            steps_to_run = self.steps
+            steps_to_run = [step for step in self.steps if not self.skippable[step]]
 
         if steps_to_run != self.steps:
             logger.info(f"### Running {len(steps_to_run)} steps out of {len(self.steps)} ###")
@@ -535,6 +577,8 @@ class Executor:
                 if regex.search(step.name):
                     used_regexes.add(i)
                     return True
+
+            return False
 
         # Compute the transitive dependencies of the steps that match the run_steps list
         to_run: list[ExecutorStep] = []
@@ -572,18 +616,23 @@ class Executor:
 
         return to_run
 
-    def compute_version(self, step: ExecutorStep):
+    def compute_version(self, step: ExecutorStep, is_pseudo_dep: bool):
         if step in self.versions:
+            if not is_pseudo_dep and self.skippable[step]:
+                logger.info(f"Step {step.name} was previously marked as skippable, but is not anymore.")
+                self.skippable[step] = False
+
             return
 
         # Collect dependencies and the config version
-        dependencies: list[ExecutorStep] = []
-        config_version: dict[str, Any] = {}
-        collect_dependencies_and_version(obj=step.config, dependencies=dependencies, version=config_version)
+        dependencies, config_version, pseudo_deps = collect_dependencies_and_version(obj=step.config)
 
         # Recurse on dependencies
         for dep in dependencies:
-            self.compute_version(dep)
+            self.compute_version(dep, is_pseudo_dep=is_pseudo_dep)
+
+        for dep in pseudo_deps:
+            self.compute_version(dep, is_pseudo_dep=True)
 
         # The version specifies precisely all the information that uniquely
         # identifies this step.  Note that the fn name is not part of the
@@ -593,6 +642,10 @@ class Executor:
             "config": config_version,
             "dependencies": [self.versions[dep] for dep in dependencies],
         }
+
+        if pseudo_deps:
+            # don't put this in the literal to avoid changing the hash for old pre-pseudo-dep runs
+            version["pseudo_dependencies"] = [self.versions[dep] for dep in pseudo_deps]
 
         # Compute output path
         version_str = json.dumps(version, sort_keys=True, cls=CustomJsonEncoder)
@@ -634,6 +687,7 @@ class Executor:
         self.versions[step] = version
         self.version_strs[step] = version_str
         self.output_paths[step] = output_path
+        self.skippable[step] = is_pseudo_dep
 
     def canonicalize(self, step: ExecutorStep) -> ExecutorStep:
         """Multiple instances of `ExecutorStep` might have the same version."""
@@ -750,7 +804,9 @@ class Executor:
                 runtime_env=RuntimeEnv(
                     pip=pip_dependencies,
                 ),
-                # TODO: this is kind of gross, but the overhead of
+                # TODO: this is kind of gross, but the overhead of instantiating a separate ray task
+                # that only blocks is pretty wasteful. Would be better to not make 1 step per, but
+                # this is a good first step
                 num_cpus=0.001 if isinstance(step.fn, ray.remote_function.RemoteFunction) else 1,
             ).remote(step.fn, step_name, config, dependencies, output_path, self.status_actor, force_run_failed)
         else:

--- a/marin/execution/executor.py
+++ b/marin/execution/executor.py
@@ -188,7 +188,7 @@ class InputName:
     block_on_step: bool = True
     """
     If False, the step that uses this InputName
-    will not block (or attempt to execute) the parent step. We use this for
+    will not block (or attempt to execute) `step`. We use this for
     documenting dependencies in the config, but where that step might not have technically finished...
 
     For instance, we sometimes use training checkpoints before the training step has finished.

--- a/marin/execution/executor.py
+++ b/marin/execution/executor.py
@@ -660,7 +660,7 @@ class Executor:
         }
 
         if computed_deps.pseudo_dependencies:
-            # don't put this in the literal to avoid changing the hash for old pre-pseudo-dep runs
+            # don't put this in the literal to avoid changing the hash for runs without pseudo-deps
             version["pseudo_dependencies"] = [self.versions[dep] for dep in computed_deps.pseudo_dependencies]
 
         # Compute output path

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -486,7 +486,7 @@ def test_collect_deps_skip_vs_block():
     parent = ExecutorStep(name="parent", fn=dummy_fn, config=DummyCfg(x=1))
 
     # ----- skip parent -------------------------------------------------
-    inp_skip = InputName(step=parent, name="ckpt.pt").skip_parent()
+    inp_skip = InputName(step=parent, name="ckpt.pt").nonblocking()
     deps, ver, pseudo = collect_dependencies_and_version(inp_skip)
 
     assert parent in pseudo and parent not in deps
@@ -514,7 +514,7 @@ def test_parent_version_bubbles_into_skip_child():
     with tempfile.TemporaryDirectory(prefix="executor-") as temp_dir:
         # First parent/child pair (parent.x = 1)
         parent1 = ExecutorStep(name="parent", fn=dummy_fn, config=DummyCfg(x=versioned(1)))
-        child1_cfg = DummyCfg(0, input_path=parent1.cd("dummy").skip_parent())
+        child1_cfg = DummyCfg(0, input_path=parent1.cd("dummy").nonblocking())
         child1 = ExecutorStep(
             name="child",
             fn=dummy_fn,
@@ -531,7 +531,7 @@ def test_parent_version_bubbles_into_skip_child():
         child2 = ExecutorStep(
             name="child",
             fn=dummy_fn,
-            config=DummyCfg(x=0, input_path=parent2.cd("dummy").skip_parent()),
+            config=DummyCfg(x=0, input_path=parent2.cd("dummy").nonblocking()),
         )
         executor.run(steps=[child2])
         version2 = executor.version_strs[child2]
@@ -549,7 +549,7 @@ def test_parent_doesnt_run_on_skip_parent():
         child = ExecutorStep(
             name="child",
             fn=dummy_fn,
-            config=DummyCfg(input_path=parent.cd("dummy").skip_parent()),
+            config=DummyCfg(input_path=parent.cd("dummy").nonblocking()),
         )
 
         executor = create_executor(temp_dir)
@@ -565,7 +565,7 @@ def test_skippable_parent_will_run_if_asked():
         child = ExecutorStep(
             name="child",
             fn=dummy_fn,
-            config=DummyCfg(input_path=parent.cd("dummy").skip_parent()),
+            config=DummyCfg(input_path=parent.cd("dummy").nonblocking()),
         )
 
         executor = create_executor(temp_dir)
@@ -584,7 +584,7 @@ def test_parent_will_run_if_some_child_is_not_skippable():
         child = ExecutorStep(
             name="child",
             fn=dummy_fn,
-            config=DummyCfg(input_path=parent.cd("dummy").skip_parent()),
+            config=DummyCfg(input_path=parent.cd("dummy").nonblocking()),
         )
 
         child2 = ExecutorStep(

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -524,6 +524,7 @@ def test_parent_version_bubbles_into_skip_child():
         executor = create_executor(temp_dir)
         executor.run(steps=[child1])
         version1 = executor.version_strs[child1]
+        executor = create_executor(temp_dir)
 
         # Second pair - identical except parent.x = 2
         parent2 = ExecutorStep(name="parent2", fn=dummy_fn, config=DummyCfg(x=versioned(2)))

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -10,7 +10,17 @@ import pytest
 import ray
 from draccus.utils import Dataclass
 
-from marin.execution.executor import Executor, ExecutorStep, _get_info_path, output_path_of, this_output_path, versioned
+from marin.execution import THIS_OUTPUT_PATH
+from marin.execution.executor import (
+    Executor,
+    ExecutorStep,
+    InputName,
+    _get_info_path,
+    collect_dependencies_and_version,
+    output_path_of,
+    this_output_path,
+    versioned,
+)
 from marin.execution.executor_step_status import (
     STATUS_SUCCESS,
     get_current_status,
@@ -445,3 +455,145 @@ def test_run_only_some_steps():
         results = read_log(log)
         assert len(results) == 2
         assert (results[0] is None and results[1]["m"] == 10) or (results[1] is None and results[0]["m"] == 10)
+
+
+@dataclass(frozen=True)
+class DummyCfg:
+    x: int = 0
+    input_path: str | None = None
+    output_path: str = THIS_OUTPUT_PATH
+
+
+def dummy_fn(cfg: DummyCfg):
+    # write one tiny file so the step "does something"
+    out_path = os.path.join(cfg.output_path, "dummy")
+    os.makedirs(out_path, exist_ok=True)
+    with open(os.path.join(out_path, "done.txt"), "w") as f:
+        f.write(str(cfg.x))
+    return cfg.x
+
+
+def shouldnt_run_fn(cfg: DummyCfg):
+    raise RuntimeError("This function should not run.")
+
+
+# ----------------------------------------------------------------------
+#  Unit tests for collect_dependencies_and_version
+# ----------------------------------------------------------------------
+
+
+def test_collect_deps_skip_vs_block():
+    parent = ExecutorStep(name="parent", fn=dummy_fn, config=DummyCfg(x=1))
+
+    # ----- skip parent -------------------------------------------------
+    inp_skip = InputName(step=parent, name="ckpt.pt").skip_parent()
+    deps, ver, pseudo = collect_dependencies_and_version(inp_skip)
+
+    assert parent in pseudo and parent not in deps
+    # Placeholder looks like "DEP[0]/ckpt.pt"
+    assert ver == {"": "DEP[0]/ckpt.pt"}
+
+    # ----- require parent (default) ------------------------------------
+    inp_block = InputName(step=parent, name="ckpt.pt")  # no .skip_parent()
+    deps, ver, pseudo = collect_dependencies_and_version(inp_block)
+
+    assert parent in deps and parent not in pseudo
+    assert ver == {"": "DEP[0]/ckpt.pt"}  # same placeholder, but in deps
+
+
+# ----------------------------------------------------------------------
+#  Parent-version should still affect child hash
+# ----------------------------------------------------------------------
+
+
+def test_parent_version_bubbles_into_skip_child():
+    """
+    Change parent's config ➜ child's version must change even if parent
+    is only a pseudo-dependency.
+    """
+    with tempfile.TemporaryDirectory(prefix="executor-") as temp_dir:
+        # First parent/child pair (parent.x = 1)
+        parent1 = ExecutorStep(name="parent", fn=dummy_fn, config=DummyCfg(x=versioned(1)))
+        child1_cfg = DummyCfg(0, input_path=parent1.cd("dummy").skip_parent())
+        child1 = ExecutorStep(
+            name="child",
+            fn=dummy_fn,
+            config=child1_cfg,
+        )
+
+        executor = create_executor(temp_dir)
+        executor.run(steps=[child1])
+        version1 = executor.version_strs[child1]
+
+        # Second pair - identical except parent.x = 2
+        parent2 = ExecutorStep(name="parent2", fn=dummy_fn, config=DummyCfg(x=versioned(2)))
+        child2 = ExecutorStep(
+            name="child",
+            fn=dummy_fn,
+            config=DummyCfg(x=0, input_path=parent2.cd("dummy").skip_parent()),
+        )
+        executor.run(steps=[child2])
+        version2 = executor.version_strs[child2]
+
+        # Hashes should differ
+        assert version1 != version2
+
+
+def test_parent_doesnt_run_on_skip_parent():
+    """
+    Parent should not run if child is a skip-parent.
+    """
+    with tempfile.TemporaryDirectory(prefix="executor-") as temp_dir:
+        parent = ExecutorStep(name="parent", fn=shouldnt_run_fn, config=DummyCfg(x=1))
+        child = ExecutorStep(
+            name="child",
+            fn=dummy_fn,
+            config=DummyCfg(input_path=parent.cd("dummy").skip_parent()),
+        )
+
+        executor = create_executor(temp_dir)
+        executor.run(steps=[child])
+
+
+def test_skippable_parent_will_run_if_asked():
+    """
+    Parent should run if child is a skip-parent and we ask it to.
+    """
+    with tempfile.TemporaryDirectory(prefix="executor-") as temp_dir:
+        parent = ExecutorStep(name="parent", fn=dummy_fn, config=DummyCfg(x=1))
+        child = ExecutorStep(
+            name="child",
+            fn=dummy_fn,
+            config=DummyCfg(input_path=parent.cd("dummy").skip_parent()),
+        )
+
+        executor = create_executor(temp_dir)
+        executor.run(steps=[child], run_only=["parent"])
+
+        # make sure parent ran
+        assert os.path.exists(os.path.join(executor.output_paths[parent], "dummy", "done.txt"))
+
+
+def test_parent_will_run_if_some_child_is_not_skippable():
+    """
+    Parent should run if child is a skip-parent and we ask it to.
+    """
+    with tempfile.TemporaryDirectory(prefix="executor-") as temp_dir:
+        parent = ExecutorStep(name="parent", fn=dummy_fn, config=DummyCfg(x=1))
+        child = ExecutorStep(
+            name="child",
+            fn=dummy_fn,
+            config=DummyCfg(input_path=parent.cd("dummy").skip_parent()),
+        )
+
+        child2 = ExecutorStep(
+            name="child2",
+            fn=dummy_fn,
+            config=DummyCfg(input_path=parent.cd("dummy")),  # no skip
+        )
+
+        executor = create_executor(temp_dir)
+        executor.run(steps=[child, child2])
+
+        # make sure parent ran
+        assert os.path.exists(os.path.join(executor.output_paths[parent], "dummy", "done.txt"))

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -487,7 +487,10 @@ def test_collect_deps_skip_vs_block():
 
     # ----- skip parent -------------------------------------------------
     inp_skip = InputName(step=parent, name="ckpt.pt").nonblocking()
-    deps, ver, pseudo = collect_dependencies_and_version(inp_skip)
+    computed_deps = collect_dependencies_and_version(inp_skip)
+    deps = computed_deps.dependencies
+    ver = computed_deps.version
+    pseudo = computed_deps.pseudo_dependencies
 
     assert parent in pseudo and parent not in deps
     # Placeholder looks like "DEP[0]/ckpt.pt"
@@ -495,7 +498,10 @@ def test_collect_deps_skip_vs_block():
 
     # ----- require parent (default) ------------------------------------
     inp_block = InputName(step=parent, name="ckpt.pt")  # no .skip_parent()
-    deps, ver, pseudo = collect_dependencies_and_version(inp_block)
+    computed_deps = collect_dependencies_and_version(inp_block)
+    deps = computed_deps.dependencies
+    ver = computed_deps.version
+    pseudo = computed_deps.pseudo_dependencies
 
     assert parent in deps and parent not in pseudo
     assert ver == {"": "DEP[0]/ckpt.pt"}  # same placeholder, but in deps


### PR DESCRIPTION
This allows to construct more complete experiment json's in the common case that we don't let a certain dependency finish.

We need this to get the Marin 8B run fully documented in an experiment.json