### PR TITLE
make data browser render experiment JSONs with array values

### DIFF
--- a/data_browser/src/ExperimentPage.js
+++ b/data_browser/src/ExperimentPage.js
@@ -147,7 +147,7 @@ function renderExperimentStep(args) {
   }
 
   const configRows = Object.entries(step.version.config).map(([key, value]) => {
-    return <tr key={key}><td>{key}</td><td>: {value}</td></tr>;
+    return <tr key={key}><td>{key}</td><td>: {renderValue(value)}</td></tr>;
   });
   const configTable = configRows.length === 0 ? null :
     <table className="experiment-step-config"><tbody>{configRows}</tbody></table>;
@@ -190,4 +190,12 @@ function renderExperimentStatus(events) {
     Status: {lastStatus}{lastMessage ? ": " + lastMessage : ""}&nbsp;
     {renderDate(lastEvent.date)} &mdash; {renderDuration(duration)}
   </div>);
+}
+
+function renderValue(value) {
+  const str = JSON.stringify(value);
+  if (str.startsWith("\"") && str.endsWith("\"")) {
+    return str.slice(1, -1);
+  }
+  return str;
 }


### PR DESCRIPTION
Problem was that [this experiment JSON](https://marin-data-browser-748532799086.us-central1.run.app/experiment?path=gs%3A%2F%2Fmarin-us-east1%2Fexperiments%2Fexp963_cascade_finemath-fa55e6.json) was not loading.

One of the values was an array, which couldn't be rendered by React directly.  So it just has to be quoted.