### PR TITLE
pre-release fixes to data browser

### DIFF
--- a/data_browser/conf/docker.conf
+++ b/data_browser/conf/docker.conf
@@ -1,4 +1,2 @@
 root_paths:
 - /app/var
-
-max_lines: 10000000

--- a/data_browser/conf/gcp.conf
+++ b/data_browser/conf/gcp.conf
@@ -4,4 +4,5 @@ root_paths:
 - gs://marin-us-east1
 - gs://marin-us-east5
 - gs://marin-eu-west4
-max_lines: 1000000
+max_lines: 100
+max_size: 10000000

--- a/data_browser/conf/local.conf
+++ b/data_browser/conf/local.conf
@@ -1,4 +1,2 @@
 root_paths:
 - ../local_store
-
-max_lines: 10000000

--- a/data_browser/src/ExperimentPage.js
+++ b/data_browser/src/ExperimentPage.js
@@ -333,8 +333,9 @@ function renderTrainLmStep({step, steps}) {
 
   // Initialization + training
   const trainerConfig = trainConfig.trainer;
-  const initializationSummary = trainerConfig.initialize_from ?
-    renderPath({path: trainerConfig.initialize_from, steps}) :
+  const initializeFrom = trainConfig.initialize_from_checkpoint || trainConfig.initialize_from_hf || trainerConfig.initialize_from;
+  const initializationSummary = initializeFrom ?
+    renderPath({path: initializeFrom, steps}) :
     `random(${modelConfig.initializer_range})`;
 
   const numSteps = trainerConfig.num_train_steps;

--- a/data_browser/src/utils.js
+++ b/data_browser/src/utils.js
@@ -1,19 +1,30 @@
-export function apiConfigUrl() {
-  return "/api/config";
+function getPrefix() {
+  // When we deploy the app, we have an iframe relationship between:
+  // - parent: marin.community/data-browser
+  // - child: Google Cloud Run app (marin-data-browser-*.run.app)
+  // If we detect we are running in this environment, use the parent URL.
+  if (/^marin-data-browser-.*\.run\.app$/.test(window.location.hostname)) {
+    return "https://marin.community/data-browser";
+  }
+  return "";
 }
 
-export function viewUrl(params) {
-  // Encode arrays (e.g., `paths`) as JSON
-  params = {...params, paths: JSON.stringify(params.paths)};
-  return "/view?" + new URLSearchParams(params);
+export function apiConfigUrl() {
+  return "/api/config";
 }
 
 export function apiViewUrl(params) {
   return "/api/view?" + new URLSearchParams(params);
 }
 
+export function viewUrl(params) {
+  // Encode arrays (e.g., `paths`) as JSON
+  params = {...params, paths: JSON.stringify(params.paths)};
+  return getPrefix() + "/view?" + new URLSearchParams(params);
+}
+
 export function experimentUrl(params) {
-  return "/experiment?" + new URLSearchParams(params);
+  return getPrefix() + "/experiment?" + new URLSearchParams(params);
 }
 
 export function viewSingleUrl(path) {


### PR DESCRIPTION
1. Prevent people from downloading files that are too big (limit to 10MB)
2. Prevent people from reading past the first 100 lines of a jsonl/parquet file
3. Hack to make the URL show up properly as marin.community/...
4. Show initialize_from properly for SFT models
