### PR TITLE
[jules] Docs: Clarify MARIN_PREFIX usage in first-experiment tutorial

### DIFF
--- a/docs/explanations/marin-prefix.md
+++ b/docs/explanations/marin-prefix.md
@@ -1,0 +1,66 @@
+# Understanding `MARIN_PREFIX` and `--prefix`
+
+Marin uses a designated storage location, referred to as a "prefix," to save all outputs from experiments. This includes tokenized data, model checkpoints, experiment logs, and other artifacts. You can specify this location using either the `MARIN_PREFIX` environment variable or the `--prefix` command-line argument when running experiment scripts.
+
+## What is the Prefix Used For?
+
+The prefix defines the root directory where Marin will store:
+-   **Tokenized Datasets:** Processed datasets ready for training.
+-   **Model Checkpoints:** Saved states of your models during and after training.
+-   **Experiment Configurations and Logs:** JSON files detailing experiment setups, along with other logs.
+-   **Evaluation Results:** Outputs from evaluation harnesses.
+
+## Specifying the Prefix
+
+You have two ways to specify this output location:
+
+1.  **`--prefix` Command-Line Argument:**
+    You can directly provide the path when running an experiment script:
+    ```bash
+    python experiments/your_experiment.py --prefix /path/to/your/output_directory
+    ```
+    Or for a cloud storage bucket:
+    ```bash
+    python experiments/your_experiment.py --prefix s3://your-bucket-name/path/to/output
+    ```
+
+2.  **`MARIN_PREFIX` Environment Variable:**
+    Alternatively, you can set the `MARIN_PREFIX` environment variable in your shell. Marin will automatically use this path if `--prefix` is not provided.
+    ```bash
+    export MARIN_PREFIX="/path/to/your/output_directory"
+    # Now you can run your script without --prefix
+    python experiments/your_experiment.py
+    ```
+
+    This method is convenient if you consistently use the same output location for multiple experiments.
+
+**Precedence:** If both the `MARIN_PREFIX` environment variable is set and the `--prefix` command-line argument is provided, the `--prefix` argument will always take precedence.
+
+## Acceptable Storage Backends and Paths
+
+Marin leverages the `fsspec` library, allowing you to use various storage backends. The path you provide should be a URI understandable by `fsspec`. Common examples include:
+
+*   **Local Filesystem:**
+    *   `--prefix /path/to/local/directory`
+    *   `export MARIN_PREFIX=/path/to/local/directory`
+    *   `--prefix ./relative/path/to/output` (relative to where you run the script)
+    *   `export MARIN_PREFIX=./relative/path/to/output`
+
+*   **Amazon S3:**
+    *   `--prefix s3://your-s3-bucket/path/to/output`
+    *   `export MARIN_PREFIX=s3://your-s3-bucket/path/to/output`
+    (Requires appropriate AWS credentials and `s3fs` library installed: `pip install s3fs`)
+
+*   **Google Cloud Storage (GCS):**
+    *   `--prefix gs://your-gcs-bucket/path/to/output`
+    *   `export MARIN_PREFIX=gs://your-gcs-bucket/path/to/output`
+    (Requires appropriate GCP credentials and `gcsfs` library installed: `pip install gcsfs`)
+
+## Important Considerations for Distributed Environments
+
+When running Marin in a distributed setup (e.g., across multiple nodes or with Ray), it is **critical** that the specified prefix path (whether via `MARIN_PREFIX` or `--prefix`):
+
+*   **Is accessible by all worker nodes:** Each machine involved in the experiment must have the necessary permissions and network access to read from and write to this location.
+*   **Points to the same shared storage location for all workers:** Using a local path like `/tmp/marin_output` on each machine will result in data being scattered and inaccessible, not a unified output. You must use a shared filesystem (like NFS) or a cloud storage solution (S3, GCS) for distributed runs.
+
+Choosing a suitable shared storage solution is crucial for the successful execution and reproducibility of your experiments in a distributed setting.

--- a/docs/tutorials/first-experiment.md
+++ b/docs/tutorials/first-experiment.md
@@ -202,6 +202,31 @@ To run the experiment locally, we can run the script directly:
 The `--prefix` argument specifies the output directory for the experiment. It can be a local directory or anything [fsspec](https://filesystem-spec.readthedocs.io/en/latest/) supports,
 such as `s3://` or `gs://`.
 
+### Using the `MARIN_PREFIX` Environment Variable
+
+As an alternative to the `--prefix` command-line argument, you can use the `MARIN_PREFIX` environment variable to specify the root output directory for your experiments. This is particularly useful if you prefer to set this path once for your environment rather than specifying it for each command.
+
+Here's how you can set the `MARIN_PREFIX` environment variable:
+
+*   For a local directory:
+    ```bash
+    export MARIN_PREFIX=./local_store
+    ```
+    or
+    ```bash
+    export MARIN_PREFIX=/path/to/your/output_directory
+    ```
+*   For an S3 bucket:
+    ```bash
+    export MARIN_PREFIX=s3://your-bucket-name/path/to/output
+    ```
+*   For a Google Cloud Storage bucket:
+    ```bash
+    export MARIN_PREFIX=gs://your-bucket-name/path/to/output
+    ```
+
+If both the `--prefix` command-line argument is provided and the `MARIN_PREFIX` environment variable is set, the `--prefix` argument will take precedence.
+
 This will take a few minutes to run. (Marin isn't optimized for low latency and Ray can take a while to schedule tasks initially...)
 
 At the end, you should see a message like this:

--- a/docs/tutorials/first-experiment.md
+++ b/docs/tutorials/first-experiment.md
@@ -201,31 +201,7 @@ To run the experiment locally, we can run the script directly:
 
 The `--prefix` argument specifies the output directory for the experiment. It can be a local directory or anything [fsspec](https://filesystem-spec.readthedocs.io/en/latest/) supports,
 such as `s3://` or `gs://`.
-
-### Using the `MARIN_PREFIX` Environment Variable
-
-As an alternative to the `--prefix` command-line argument, you can use the `MARIN_PREFIX` environment variable to specify the root output directory for your experiments. This is particularly useful if you prefer to set this path once for your environment rather than specifying it for each command.
-
-Here's how you can set the `MARIN_PREFIX` environment variable:
-
-*   For a local directory:
-    ```bash
-    export MARIN_PREFIX=./local_store
-    ```
-    or
-    ```bash
-    export MARIN_PREFIX=/path/to/your/output_directory
-    ```
-*   For an S3 bucket:
-    ```bash
-    export MARIN_PREFIX=s3://your-bucket-name/path/to/output
-    ```
-*   For a Google Cloud Storage bucket:
-    ```bash
-    export MARIN_PREFIX=gs://your-bucket-name/path/to/output
-    ```
-
-If both the `--prefix` command-line argument is provided and the `MARIN_PREFIX` environment variable is set, the `--prefix` argument will take precedence.
+Alternatively, you can set the `MARIN_PREFIX` environment variable to achieve the same. For a detailed explanation of both methods and important considerations for choosing your output path, please see [Understanding `MARIN_PREFIX` and `--prefix`](../explanations/marin-prefix.md).
 
 This will take a few minutes to run. (Marin isn't optimized for low latency and Ray can take a while to schedule tasks initially...)
 

--- a/docs/tutorials/submitting-speedrun.md
+++ b/docs/tutorials/submitting-speedrun.md
@@ -142,7 +142,7 @@ It is important that the Speedrun leaderboard span multiple compute scales, sinc
 
     `MARIN_PREFIX` tells Marin where to put artifacts generated during the execution of any steps.
     For examples, training checkpoints usually will be written to `${MARIN_PREFIX}/checkpoints/`.
-    You can set this to an fsspec-recognizable path eg. a GCS bucket, or a directory on your machine.
+    You can set this to an fsspec-recognizable path eg. a GCS bucket, or a directory on your machine. (For a detailed explanation of `MARIN_PREFIX` and other ways to specify the output path, see [Understanding `MARIN_PREFIX` and `--prefix`](../explanations/marin-prefix.md).)
 
 5. Train your model:
    ```bash


### PR DESCRIPTION
Explained the MARIN_PREFIX environment variable as an alternative to the --prefix command-line argument for specifying the output directory.

Added examples for local, S3, and GCS paths, and clarified that --prefix takes precedence if both are set. This addresses confusion reported in issue #1277.

## Description

Fixes #(issue number)

[Please include a summary of the changes and the related issue.]


## Checklist

- [ ] You ran `pre-commit run --all-files` to lint your code
- [ ] You ran 'pytest' to test your code
- [ ] Delete this checklist