### PR TITLE
feat: Validate training URLs for forbidden patterns

### DIFF
--- a/marin/processing/tokenize/tokenize.py
+++ b/marin/processing/tokenize/tokenize.py
@@ -129,7 +129,10 @@ def _validate_train_urls(train_paths: list[str | InputName]):
             url_or_name_to_check = item.name
 
         if url_or_name_to_check:
-            if re.search(r"\btest\b", url_or_name_to_check) or re.search(r"validation", url_or_name_to_check):
+            # \b doesn't work because of underscores
+            if re.search(r"[^a-zA-Z]test[^a-zA-Z]", url_or_name_to_check) or re.search(
+                r"validation", url_or_name_to_check
+            ):
                 raise ValueError(
                     f"Error: Training data URL or InputName '{url_or_name_to_check}' contains a forbidden pattern "
                     "('test' or 'validation'). "

--- a/marin/processing/tokenize/tokenize.py
+++ b/marin/processing/tokenize/tokenize.py
@@ -77,6 +77,11 @@ class TokenizeConfig(TokenizeConfigBase):
     The format of the dataset. This is used to determine how to tokenize the data.
     See Levanter's documentation for more details.
     """
+    allow_test_in_train: bool = False
+    """
+    If True, allows 'test' or 'validation' in the train_paths. This is useful for datasets that have
+    'test' or 'validation' in the file names, but are not actually test or validation sets.
+    """
 
     def as_lm_dataset_source_config(
         self, actual_output_path: str | InputName | None, *, include_raw_paths=True
@@ -113,10 +118,10 @@ class TokenizeConfig(TokenizeConfigBase):
         if isinstance(self.validation_paths, Sequence):
             assert "/" not in self.validation_paths, "don't use the entire fs for validation paths!"
 
-        _validate_train_urls(self.train_paths)
+        _validate_train_urls(self.train_paths, self.allow_test_in_train)
 
 
-def _validate_train_urls(train_paths: list[str | InputName]):
+def _validate_train_urls(train_paths: list[str | InputName], warn):
     """
     Validates the training data URLs or InputName attributes to ensure they do not contain forbidden patterns.
     Raises a ValueError if a forbidden pattern is found.
@@ -125,7 +130,7 @@ def _validate_train_urls(train_paths: list[str | InputName]):
         url_or_name_to_check = None
         if isinstance(item, str):
             url_or_name_to_check = item
-        elif hasattr(item, "name") and isinstance(item.name, str):
+        elif isinstance(item, InputName):
             url_or_name_to_check = item.name
 
         if url_or_name_to_check:
@@ -133,11 +138,16 @@ def _validate_train_urls(train_paths: list[str | InputName]):
             if re.search(r"[^a-zA-Z]test[^a-zA-Z]", url_or_name_to_check) or re.search(
                 r"validation", url_or_name_to_check
             ):
-                raise ValueError(
-                    f"Error: Training data URL or InputName '{url_or_name_to_check}' contains a forbidden pattern "
-                    "('test' or 'validation'). "
-                    "Please ensure training data does not include test or validation sets."
-                )
+                if warn:
+                    logger.warning(
+                        f"Warning: Training data URL or InputName '{url_or_name_to_check}' contains a forbidden pattern "
+                    )
+                else:
+                    raise ValueError(
+                        f"Error: Training data URL or InputName '{url_or_name_to_check}' contains a forbidden pattern "
+                        "('test' or 'validation'). "
+                        "Please ensure training data does not include test or validation sets."
+                    )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -166,13 +176,13 @@ class HfTokenizeConfig(TokenizeConfigBase):
         )
 
 
-def _expand_directories(config: UrlDatasetSourceConfig) -> UrlDatasetSourceConfig:
+def _expand_directories(config: UrlDatasetSourceConfig, allow_test_in_train) -> UrlDatasetSourceConfig:
     """
     Expand directories in the config to globs.
     """
 
     train_paths = _get_filepaths_to_tokenize(config.train_urls)
-    _validate_train_urls(train_paths)
+    _validate_train_urls(train_paths, allow_test_in_train)
     validation_paths = _get_filepaths_to_tokenize(config.validation_urls)
 
     return dataclasses.replace(config, train_urls=train_paths, validation_urls=validation_paths)
@@ -186,7 +196,7 @@ def tokenize(config: TokenizeConfigBase):
     if isinstance(config, TokenizeConfig):
         # TODO: Levanter doesn't automatically expand directories to globs, but by convention we do in Marin
         # we should backport this to Levanter
-        source_config = _expand_directories(source_config)
+        source_config = _expand_directories(source_config, config.allow_test_in_train)
 
     train_source = source_config.get_shard_source("train")
     validation_source = source_config.get_shard_source("validation")

--- a/marin/processing/tokenize/tokenize.py
+++ b/marin/processing/tokenize/tokenize.py
@@ -109,7 +109,7 @@ class TokenizeConfig(TokenizeConfigBase):
             url_or_name_to_check = None
             if isinstance(item, str):
                 url_or_name_to_check = item
-            elif hasattr(item, 'name') and isinstance(item.name, str):
+            elif hasattr(item, "name") and isinstance(item.name, str):
                 url_or_name_to_check = item.name
             # If item is neither a string nor has a .name attribute,
             # url_or_name_to_check remains None and it's skipped, as per instructions.
@@ -117,7 +117,8 @@ class TokenizeConfig(TokenizeConfigBase):
             if url_or_name_to_check:
                 if re.search(r"\btest\b", url_or_name_to_check) or re.search(r"validation", url_or_name_to_check):
                     raise ValueError(
-                        f"Error: Training data URL or InputName '{url_or_name_to_check}' contains a forbidden pattern ('test' or 'validation'). "
+                        f"Error: Training data URL or InputName '{url_or_name_to_check}' contains a forbidden pattern "
+                        "('test' or 'validation'). "
                         "Please ensure training data does not include test or validation sets."
                     )
 

--- a/marin/processing/tokenize/tokenize.py
+++ b/marin/processing/tokenize/tokenize.py
@@ -100,28 +100,6 @@ class TokenizeConfig(TokenizeConfigBase):
             format=self.format,
         )
 
-    def validate_train_urls(self):
-        """
-        Validates the training data URLs or InputName attributes to ensure they do not contain forbidden patterns.
-        Raises a ValueError if a forbidden pattern is found.
-        """
-        for item in self.train_paths:
-            url_or_name_to_check = None
-            if isinstance(item, str):
-                url_or_name_to_check = item
-            elif hasattr(item, "name") and isinstance(item.name, str):
-                url_or_name_to_check = item.name
-            # If item is neither a string nor has a .name attribute,
-            # url_or_name_to_check remains None and it's skipped, as per instructions.
-
-            if url_or_name_to_check:
-                if re.search(r"\btest\b", url_or_name_to_check) or re.search(r"validation", url_or_name_to_check):
-                    raise ValueError(
-                        f"Error: Training data URL or InputName '{url_or_name_to_check}' contains a forbidden pattern "
-                        "('test' or 'validation'). "
-                        "Please ensure training data does not include test or validation sets."
-                    )
-
     def __post_init__(self):
         if not self.train_paths and not self.validation_paths:
             raise ValueError("At least one of train_paths or validation_paths must be specified")
@@ -135,7 +113,28 @@ class TokenizeConfig(TokenizeConfigBase):
         if isinstance(self.validation_paths, Sequence):
             assert "/" not in self.validation_paths, "don't use the entire fs for validation paths!"
 
-        self.validate_train_urls()
+        _validate_train_urls(self.train_paths)
+
+
+def _validate_train_urls(train_paths: list[str | InputName]):
+    """
+    Validates the training data URLs or InputName attributes to ensure they do not contain forbidden patterns.
+    Raises a ValueError if a forbidden pattern is found.
+    """
+    for item in train_paths:
+        url_or_name_to_check = None
+        if isinstance(item, str):
+            url_or_name_to_check = item
+        elif hasattr(item, "name") and isinstance(item.name, str):
+            url_or_name_to_check = item.name
+
+        if url_or_name_to_check:
+            if re.search(r"\btest\b", url_or_name_to_check) or re.search(r"validation", url_or_name_to_check):
+                raise ValueError(
+                    f"Error: Training data URL or InputName '{url_or_name_to_check}' contains a forbidden pattern "
+                    "('test' or 'validation'). "
+                    "Please ensure training data does not include test or validation sets."
+                )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -170,6 +169,7 @@ def _expand_directories(config: UrlDatasetSourceConfig) -> UrlDatasetSourceConfi
     """
 
     train_paths = _get_filepaths_to_tokenize(config.train_urls)
+    _validate_train_urls(train_paths)
     validation_paths = _get_filepaths_to_tokenize(config.validation_urls)
 
     return dataclasses.replace(config, train_urls=train_paths, validation_urls=validation_paths)

--- a/tests/processing/tokenize/test_tokenize.py
+++ b/tests/processing/tokenize/test_tokenize.py
@@ -26,6 +26,7 @@ def test_valid_train_url():
     except ValueError:
         pytest.fail("ValueError raised for a valid train URL")
 
+
 def test_train_url_with_test_whole_word():
     """Tests that a train URL with '\\btest\\b' raises a ValueError."""
     with pytest.raises(ValueError) as excinfo:
@@ -37,6 +38,7 @@ def test_train_url_with_test_whole_word():
         )
     assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
     assert "gs://bucket/data/test/file.jsonl" in str(excinfo.value)
+
 
 def test_train_url_with_validation():
     """Tests that a train URL with 'validation' raises a ValueError."""
@@ -50,6 +52,7 @@ def test_train_url_with_validation():
     assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
     assert "gs://bucket/data/validation/file.jsonl" in str(excinfo.value)
 
+
 def test_train_url_with_test_substring_not_whole_word():
     """Tests that 'test' as a substring (not whole word) does not raise an error."""
     try:
@@ -61,6 +64,7 @@ def test_train_url_with_test_substring_not_whole_word():
         )
     except ValueError:
         pytest.fail("ValueError raised for 'test' as a substring, not a whole word")
+
 
 def test_multiple_train_urls_one_invalid():
     """Tests that if one of multiple URLs is invalid, a ValueError is raised."""
@@ -78,12 +82,13 @@ def test_multiple_train_urls_one_invalid():
     assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
     assert "gs://bucket/data/test/file2.jsonl" in str(excinfo.value)
 
+
 def test_empty_train_paths_no_error():
     """Tests that if train_paths is empty, no validation error occurs (other validation might fail)."""
     try:
         TokenizeConfig(
             train_paths=[],
-            validation_paths=DUMMY_VALIDATION_PATHS, # Must provide validation_paths if train_paths is empty
+            validation_paths=DUMMY_VALIDATION_PATHS,  # Must provide validation_paths if train_paths is empty
             cache_path=DUMMY_CACHE_PATH,
             tokenizer=DUMMY_TOKENIZER,
         )
@@ -91,6 +96,7 @@ def test_empty_train_paths_no_error():
         # We only care about the custom URL validation, not the check for empty paths
         if "contains a forbidden pattern" in str(e):
             pytest.fail("ValueError for forbidden pattern raised with empty train_paths")
+
 
 def test_train_url_with_test_in_filename():
     """Tests that a train URL with 'test' in the filename raises a ValueError."""
@@ -103,6 +109,7 @@ def test_train_url_with_test_in_filename():
         )
     assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
     assert "gs://bucket/data/train/file_test.jsonl" in str(excinfo.value)
+
 
 def test_train_url_with_validation_in_filename():
     """Tests that a train URL with 'validation' in the filename raises a ValueError."""
@@ -129,6 +136,7 @@ def test_valid_train_inputname():
     except ValueError:
         pytest.fail("ValueError raised for a valid train InputName.name")
 
+
 def test_train_inputname_with_test_whole_word():
     """Tests that a train InputName.name with '\\btest\\b' raises a ValueError."""
     with pytest.raises(ValueError) as excinfo:
@@ -141,6 +149,7 @@ def test_train_inputname_with_test_whole_word():
     assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
     assert "gs://bucket/data/test/file.jsonl" in str(excinfo.value)
 
+
 def test_train_inputname_with_validation():
     """Tests that a train InputName.name with 'validation' raises a ValueError."""
     with pytest.raises(ValueError) as excinfo:
@@ -152,6 +161,7 @@ def test_train_inputname_with_validation():
         )
     assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
     assert "gs://bucket/data/validation/file.jsonl" in str(excinfo.value)
+
 
 def test_mixed_paths_one_invalid_inputname():
     """Tests mixed paths with one invalid InputName.name, expecting ValueError."""
@@ -169,6 +179,7 @@ def test_mixed_paths_one_invalid_inputname():
     assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
     assert "gs://bucket/data/test/file2.jsonl" in str(excinfo.value)
 
+
 def test_inputname_with_test_substring_not_whole_word():
     """Tests that 'test' as a substring in InputName.name (not whole word) does not raise an error."""
     try:
@@ -181,6 +192,7 @@ def test_inputname_with_test_substring_not_whole_word():
     except ValueError:
         pytest.fail("ValueError raised for 'test' as a substring in InputName.name")
 
+
 def test_inputname_with_test_in_filename():
     """Tests that an InputName.name with 'test' in the filename raises a ValueError."""
     with pytest.raises(ValueError) as excinfo:
@@ -192,6 +204,7 @@ def test_inputname_with_test_in_filename():
         )
     assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
     assert "gs://bucket/data/train/file_test.jsonl" in str(excinfo.value)
+
 
 def test_inputname_with_validation_in_filename():
     """Tests that an InputName.name with 'validation' in the filename raises a ValueError."""

--- a/tests/processing/tokenize/test_tokenize.py
+++ b/tests/processing/tokenize/test_tokenize.py
@@ -1,0 +1,206 @@
+import pytest
+
+from marin.processing.tokenize.tokenize import TokenizeConfig
+
+
+class MockInputName:
+    def __init__(self, name: str):
+        self.name = name
+
+
+# Dummy values for other required TokenizeConfig fields
+DUMMY_CACHE_PATH = "/dummy/cache"
+DUMMY_TOKENIZER = "dummy_tokenizer"
+DUMMY_VALIDATION_PATHS = []
+
+
+def test_valid_train_url():
+    """Tests that a valid train URL does not raise an error."""
+    try:
+        TokenizeConfig(
+            train_paths=["gs://bucket/data/train/file.jsonl"],
+            validation_paths=DUMMY_VALIDATION_PATHS,
+            cache_path=DUMMY_CACHE_PATH,
+            tokenizer=DUMMY_TOKENIZER,
+        )
+    except ValueError:
+        pytest.fail("ValueError raised for a valid train URL")
+
+def test_train_url_with_test_whole_word():
+    """Tests that a train URL with '\\btest\\b' raises a ValueError."""
+    with pytest.raises(ValueError) as excinfo:
+        TokenizeConfig(
+            train_paths=["gs://bucket/data/test/file.jsonl"],
+            validation_paths=DUMMY_VALIDATION_PATHS,
+            cache_path=DUMMY_CACHE_PATH,
+            tokenizer=DUMMY_TOKENIZER,
+        )
+    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
+    assert "gs://bucket/data/test/file.jsonl" in str(excinfo.value)
+
+def test_train_url_with_validation():
+    """Tests that a train URL with 'validation' raises a ValueError."""
+    with pytest.raises(ValueError) as excinfo:
+        TokenizeConfig(
+            train_paths=["gs://bucket/data/validation/file.jsonl"],
+            validation_paths=DUMMY_VALIDATION_PATHS,
+            cache_path=DUMMY_CACHE_PATH,
+            tokenizer=DUMMY_TOKENIZER,
+        )
+    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
+    assert "gs://bucket/data/validation/file.jsonl" in str(excinfo.value)
+
+def test_train_url_with_test_substring_not_whole_word():
+    """Tests that 'test' as a substring (not whole word) does not raise an error."""
+    try:
+        TokenizeConfig(
+            train_paths=["gs://bucket/data/latest_updates/file.jsonl"],
+            validation_paths=DUMMY_VALIDATION_PATHS,
+            cache_path=DUMMY_CACHE_PATH,
+            tokenizer=DUMMY_TOKENIZER,
+        )
+    except ValueError:
+        pytest.fail("ValueError raised for 'test' as a substring, not a whole word")
+
+def test_multiple_train_urls_one_invalid():
+    """Tests that if one of multiple URLs is invalid, a ValueError is raised."""
+    with pytest.raises(ValueError) as excinfo:
+        TokenizeConfig(
+            train_paths=[
+                "gs://bucket/data/train/file1.jsonl",
+                "gs://bucket/data/test/file2.jsonl",
+                "gs://bucket/data/train/file3.jsonl",
+            ],
+            validation_paths=DUMMY_VALIDATION_PATHS,
+            cache_path=DUMMY_CACHE_PATH,
+            tokenizer=DUMMY_TOKENIZER,
+        )
+    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
+    assert "gs://bucket/data/test/file2.jsonl" in str(excinfo.value)
+
+def test_empty_train_paths_no_error():
+    """Tests that if train_paths is empty, no validation error occurs (other validation might fail)."""
+    try:
+        TokenizeConfig(
+            train_paths=[],
+            validation_paths=DUMMY_VALIDATION_PATHS, # Must provide validation_paths if train_paths is empty
+            cache_path=DUMMY_CACHE_PATH,
+            tokenizer=DUMMY_TOKENIZER,
+        )
+    except ValueError as e:
+        # We only care about the custom URL validation, not the check for empty paths
+        if "contains a forbidden pattern" in str(e):
+            pytest.fail("ValueError for forbidden pattern raised with empty train_paths")
+
+def test_train_url_with_test_in_filename():
+    """Tests that a train URL with 'test' in the filename raises a ValueError."""
+    with pytest.raises(ValueError) as excinfo:
+        TokenizeConfig(
+            train_paths=["gs://bucket/data/train/file_test.jsonl"],
+            validation_paths=DUMMY_VALIDATION_PATHS,
+            cache_path=DUMMY_CACHE_PATH,
+            tokenizer=DUMMY_TOKENIZER,
+        )
+    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
+    assert "gs://bucket/data/train/file_test.jsonl" in str(excinfo.value)
+
+def test_train_url_with_validation_in_filename():
+    """Tests that a train URL with 'validation' in the filename raises a ValueError."""
+    with pytest.raises(ValueError) as excinfo:
+        TokenizeConfig(
+            train_paths=["gs://bucket/data/train/file_validation.jsonl"],
+            validation_paths=DUMMY_VALIDATION_PATHS,
+            cache_path=DUMMY_CACHE_PATH,
+            tokenizer=DUMMY_TOKENIZER,
+        )
+    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
+    assert "gs://bucket/data/train/file_validation.jsonl" in str(excinfo.value)
+
+
+def test_valid_train_inputname():
+    """Tests that a valid train InputName.name does not raise an error."""
+    try:
+        TokenizeConfig(
+            train_paths=[MockInputName("gs://bucket/data/train/file.jsonl")],
+            validation_paths=DUMMY_VALIDATION_PATHS,
+            cache_path=DUMMY_CACHE_PATH,
+            tokenizer=DUMMY_TOKENIZER,
+        )
+    except ValueError:
+        pytest.fail("ValueError raised for a valid train InputName.name")
+
+def test_train_inputname_with_test_whole_word():
+    """Tests that a train InputName.name with '\\btest\\b' raises a ValueError."""
+    with pytest.raises(ValueError) as excinfo:
+        TokenizeConfig(
+            train_paths=[MockInputName("gs://bucket/data/test/file.jsonl")],
+            validation_paths=DUMMY_VALIDATION_PATHS,
+            cache_path=DUMMY_CACHE_PATH,
+            tokenizer=DUMMY_TOKENIZER,
+        )
+    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
+    assert "gs://bucket/data/test/file.jsonl" in str(excinfo.value)
+
+def test_train_inputname_with_validation():
+    """Tests that a train InputName.name with 'validation' raises a ValueError."""
+    with pytest.raises(ValueError) as excinfo:
+        TokenizeConfig(
+            train_paths=[MockInputName("gs://bucket/data/validation/file.jsonl")],
+            validation_paths=DUMMY_VALIDATION_PATHS,
+            cache_path=DUMMY_CACHE_PATH,
+            tokenizer=DUMMY_TOKENIZER,
+        )
+    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
+    assert "gs://bucket/data/validation/file.jsonl" in str(excinfo.value)
+
+def test_mixed_paths_one_invalid_inputname():
+    """Tests mixed paths with one invalid InputName.name, expecting ValueError."""
+    with pytest.raises(ValueError) as excinfo:
+        TokenizeConfig(
+            train_paths=[
+                "gs://bucket/data/train/file1.jsonl",
+                MockInputName("gs://bucket/data/test/file2.jsonl"),
+                "gs://bucket/data/train/file3.jsonl",
+            ],
+            validation_paths=DUMMY_VALIDATION_PATHS,
+            cache_path=DUMMY_CACHE_PATH,
+            tokenizer=DUMMY_TOKENIZER,
+        )
+    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
+    assert "gs://bucket/data/test/file2.jsonl" in str(excinfo.value)
+
+def test_inputname_with_test_substring_not_whole_word():
+    """Tests that 'test' as a substring in InputName.name (not whole word) does not raise an error."""
+    try:
+        TokenizeConfig(
+            train_paths=[MockInputName("gs://bucket/data/latest_updates/file.jsonl")],
+            validation_paths=DUMMY_VALIDATION_PATHS,
+            cache_path=DUMMY_CACHE_PATH,
+            tokenizer=DUMMY_TOKENIZER,
+        )
+    except ValueError:
+        pytest.fail("ValueError raised for 'test' as a substring in InputName.name")
+
+def test_inputname_with_test_in_filename():
+    """Tests that an InputName.name with 'test' in the filename raises a ValueError."""
+    with pytest.raises(ValueError) as excinfo:
+        TokenizeConfig(
+            train_paths=[MockInputName("gs://bucket/data/train/file_test.jsonl")],
+            validation_paths=DUMMY_VALIDATION_PATHS,
+            cache_path=DUMMY_CACHE_PATH,
+            tokenizer=DUMMY_TOKENIZER,
+        )
+    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
+    assert "gs://bucket/data/train/file_test.jsonl" in str(excinfo.value)
+
+def test_inputname_with_validation_in_filename():
+    """Tests that an InputName.name with 'validation' in the filename raises a ValueError."""
+    with pytest.raises(ValueError) as excinfo:
+        TokenizeConfig(
+            train_paths=[MockInputName("gs://bucket/data/train/file_validation.jsonl")],
+            validation_paths=DUMMY_VALIDATION_PATHS,
+            cache_path=DUMMY_CACHE_PATH,
+            tokenizer=DUMMY_TOKENIZER,
+        )
+    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
+    assert "gs://bucket/data/train/file_validation.jsonl" in str(excinfo.value)

--- a/tests/processing/tokenize/test_tokenize.py
+++ b/tests/processing/tokenize/test_tokenize.py
@@ -1,12 +1,7 @@
 import pytest
 
+from marin.execution import InputName
 from marin.processing.tokenize.tokenize import TokenizeConfig
-
-
-class MockInputName:
-    def __init__(self, name: str):
-        self.name = name
-
 
 # Dummy values for other required TokenizeConfig fields
 DUMMY_CACHE_PATH = "/dummy/cache"
@@ -14,162 +9,91 @@ DUMMY_TOKENIZER = "dummy_tokenizer"
 DUMMY_VALIDATION_PATHS = []
 
 
-def test_valid_train_url():
-    """Tests that a valid train URL does not raise an error."""
-    try:
-        TokenizeConfig(
-            train_paths=["gs://bucket/data/train/file.jsonl"],
-            validation_paths=DUMMY_VALIDATION_PATHS,
-            cache_path=DUMMY_CACHE_PATH,
-            tokenizer=DUMMY_TOKENIZER,
-        )
-    except ValueError:
-        pytest.fail("ValueError raised for a valid train URL")
-
-
-def test_train_url_with_test_whole_word():
-    """Tests that a train URL with '\\btest\\b' raises a ValueError."""
-    with pytest.raises(ValueError) as excinfo:
-        TokenizeConfig(
-            train_paths=["gs://bucket/data/test/file.jsonl"],
-            validation_paths=DUMMY_VALIDATION_PATHS,
-            cache_path=DUMMY_CACHE_PATH,
-            tokenizer=DUMMY_TOKENIZER,
-        )
-    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
-    assert "gs://bucket/data/test/file.jsonl" in str(excinfo.value)
-
-
-def test_train_url_with_validation():
-    """Tests that a train URL with 'validation' raises a ValueError."""
-    with pytest.raises(ValueError) as excinfo:
-        TokenizeConfig(
-            train_paths=["gs://bucket/data/validation/file.jsonl"],
-            validation_paths=DUMMY_VALIDATION_PATHS,
-            cache_path=DUMMY_CACHE_PATH,
-            tokenizer=DUMMY_TOKENIZER,
-        )
-    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
-    assert "gs://bucket/data/validation/file.jsonl" in str(excinfo.value)
-
-
-def test_train_url_with_test_substring_not_whole_word():
-    """Tests that 'test' as a substring (not whole word) does not raise an error."""
-    try:
-        TokenizeConfig(
-            train_paths=["gs://bucket/data/latest_updates/file.jsonl"],
-            validation_paths=DUMMY_VALIDATION_PATHS,
-            cache_path=DUMMY_CACHE_PATH,
-            tokenizer=DUMMY_TOKENIZER,
-        )
-    except ValueError:
-        pytest.fail("ValueError raised for 'test' as a substring, not a whole word")
-
-
-def test_multiple_train_urls_one_invalid():
-    """Tests that if one of multiple URLs is invalid, a ValueError is raised."""
-    with pytest.raises(ValueError) as excinfo:
-        TokenizeConfig(
-            train_paths=[
+@pytest.mark.parametrize(
+    "train_paths, should_error, expected_error_path",
+    [
+        (["gs://bucket/data/train/file.jsonl"], False, None),
+        (["gs://bucket/data/test/file.jsonl"], True, "gs://bucket/data/test/file.jsonl"),
+        (["gs://bucket/data/validation/file.jsonl"], True, "gs://bucket/data/validation/file.jsonl"),
+        (["gs://bucket/data/latest_updates/file.jsonl"], False, None),
+        (
+            [
                 "gs://bucket/data/train/file1.jsonl",
                 "gs://bucket/data/test/file2.jsonl",
                 "gs://bucket/data/train/file3.jsonl",
             ],
-            validation_paths=DUMMY_VALIDATION_PATHS,
-            cache_path=DUMMY_CACHE_PATH,
-            tokenizer=DUMMY_TOKENIZER,
-        )
-    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
-    assert "gs://bucket/data/test/file2.jsonl" in str(excinfo.value)
+            True,
+            "gs://bucket/data/test/file2.jsonl",
+        ),
+        ([], False, None),
+    ],
+)
+def test_train_paths_variants(train_paths, should_error, expected_error_path):
+    if should_error:
+        with pytest.raises(ValueError) as excinfo:
+            TokenizeConfig(
+                train_paths=train_paths,
+                validation_paths=DUMMY_VALIDATION_PATHS,
+                cache_path=DUMMY_CACHE_PATH,
+                tokenizer=DUMMY_TOKENIZER,
+            )
+        assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
+        if expected_error_path:
+            assert expected_error_path in str(excinfo.value)
+    else:
+        try:
+            TokenizeConfig(
+                train_paths=train_paths,
+                validation_paths=DUMMY_VALIDATION_PATHS,
+                cache_path=DUMMY_CACHE_PATH,
+                tokenizer=DUMMY_TOKENIZER,
+            )
+        except ValueError as e:
+            if "contains a forbidden pattern" in str(e):
+                pytest.fail("Unexpected ValueError for valid path")
 
 
-def test_empty_train_paths_no_error():
-    """Tests that if train_paths is empty, no validation error occurs (other validation might fail)."""
-    try:
-        TokenizeConfig(
-            train_paths=[],
-            validation_paths=DUMMY_VALIDATION_PATHS,  # Must provide validation_paths if train_paths is empty
-            cache_path=DUMMY_CACHE_PATH,
-            tokenizer=DUMMY_TOKENIZER,
-        )
-    except ValueError as e:
-        # We only care about the custom URL validation, not the check for empty paths
-        if "contains a forbidden pattern" in str(e):
-            pytest.fail("ValueError for forbidden pattern raised with empty train_paths")
-
-
-def test_train_url_with_test_in_filename():
-    """Tests that a train URL with 'test' in the filename raises a ValueError."""
-    with pytest.raises(ValueError) as excinfo:
-        TokenizeConfig(
-            train_paths=["gs://bucket/data/train/file_test.jsonl"],
-            validation_paths=DUMMY_VALIDATION_PATHS,
-            cache_path=DUMMY_CACHE_PATH,
-            tokenizer=DUMMY_TOKENIZER,
-        )
-    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
-    assert "gs://bucket/data/train/file_test.jsonl" in str(excinfo.value)
-
-
-def test_train_url_with_validation_in_filename():
-    """Tests that a train URL with 'validation' in the filename raises a ValueError."""
-    with pytest.raises(ValueError) as excinfo:
-        TokenizeConfig(
-            train_paths=["gs://bucket/data/train/file_validation.jsonl"],
-            validation_paths=DUMMY_VALIDATION_PATHS,
-            cache_path=DUMMY_CACHE_PATH,
-            tokenizer=DUMMY_TOKENIZER,
-        )
-    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
-    assert "gs://bucket/data/train/file_validation.jsonl" in str(excinfo.value)
-
-
-def test_valid_train_inputname():
-    """Tests that a valid train InputName.name does not raise an error."""
-    try:
-        TokenizeConfig(
-            train_paths=[MockInputName("gs://bucket/data/train/file.jsonl")],
-            validation_paths=DUMMY_VALIDATION_PATHS,
-            cache_path=DUMMY_CACHE_PATH,
-            tokenizer=DUMMY_TOKENIZER,
-        )
-    except ValueError:
-        pytest.fail("ValueError raised for a valid train InputName.name")
-
-
-def test_train_inputname_with_test_whole_word():
-    """Tests that a train InputName.name with '\\btest\\b' raises a ValueError."""
-    with pytest.raises(ValueError) as excinfo:
-        TokenizeConfig(
-            train_paths=[MockInputName("gs://bucket/data/test/file.jsonl")],
-            validation_paths=DUMMY_VALIDATION_PATHS,
-            cache_path=DUMMY_CACHE_PATH,
-            tokenizer=DUMMY_TOKENIZER,
-        )
-    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
-    assert "gs://bucket/data/test/file.jsonl" in str(excinfo.value)
-
-
-def test_train_inputname_with_validation():
-    """Tests that a train InputName.name with 'validation' raises a ValueError."""
-    with pytest.raises(ValueError) as excinfo:
-        TokenizeConfig(
-            train_paths=[MockInputName("gs://bucket/data/validation/file.jsonl")],
-            validation_paths=DUMMY_VALIDATION_PATHS,
-            cache_path=DUMMY_CACHE_PATH,
-            tokenizer=DUMMY_TOKENIZER,
-        )
-    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
-    assert "gs://bucket/data/validation/file.jsonl" in str(excinfo.value)
+@pytest.mark.parametrize(
+    "input_name, should_error",
+    [
+        (InputName.hardcoded("gs://bucket/data/train/file.jsonl"), False),
+        (InputName.hardcoded("gs://bucket/data/test/file.jsonl"), True),
+        (InputName.hardcoded("gs://bucket/data/validation/file.jsonl"), True),
+        (InputName.hardcoded("gs://bucket/data/latest_updates/file.jsonl"), False),
+        (InputName.hardcoded("gs://bucket/data/train/file_test.jsonl"), True),
+        (InputName.hardcoded("gs://bucket/data/train/file_validation.jsonl"), True),
+    ],
+)
+def test_inputname_variants(input_name, should_error):
+    if should_error:
+        with pytest.raises(ValueError) as excinfo:
+            TokenizeConfig(
+                train_paths=[input_name],
+                validation_paths=DUMMY_VALIDATION_PATHS,
+                cache_path=DUMMY_CACHE_PATH,
+                tokenizer=DUMMY_TOKENIZER,
+            )
+        assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
+        assert input_name.name in str(excinfo.value)
+    else:
+        try:
+            TokenizeConfig(
+                train_paths=[input_name],
+                validation_paths=DUMMY_VALIDATION_PATHS,
+                cache_path=DUMMY_CACHE_PATH,
+                tokenizer=DUMMY_TOKENIZER,
+            )
+        except ValueError as e:
+            if "contains a forbidden pattern" in str(e):
+                pytest.fail("Unexpected ValueError for valid InputName")
 
 
 def test_mixed_paths_one_invalid_inputname():
-    """Tests mixed paths with one invalid InputName.name, expecting ValueError."""
     with pytest.raises(ValueError) as excinfo:
         TokenizeConfig(
             train_paths=[
                 "gs://bucket/data/train/file1.jsonl",
-                MockInputName("gs://bucket/data/test/file2.jsonl"),
+                InputName.hardcoded("gs://bucket/data/test/file2.jsonl"),
                 "gs://bucket/data/train/file3.jsonl",
             ],
             validation_paths=DUMMY_VALIDATION_PATHS,
@@ -178,42 +102,3 @@ def test_mixed_paths_one_invalid_inputname():
         )
     assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
     assert "gs://bucket/data/test/file2.jsonl" in str(excinfo.value)
-
-
-def test_inputname_with_test_substring_not_whole_word():
-    """Tests that 'test' as a substring in InputName.name (not whole word) does not raise an error."""
-    try:
-        TokenizeConfig(
-            train_paths=[MockInputName("gs://bucket/data/latest_updates/file.jsonl")],
-            validation_paths=DUMMY_VALIDATION_PATHS,
-            cache_path=DUMMY_CACHE_PATH,
-            tokenizer=DUMMY_TOKENIZER,
-        )
-    except ValueError:
-        pytest.fail("ValueError raised for 'test' as a substring in InputName.name")
-
-
-def test_inputname_with_test_in_filename():
-    """Tests that an InputName.name with 'test' in the filename raises a ValueError."""
-    with pytest.raises(ValueError) as excinfo:
-        TokenizeConfig(
-            train_paths=[MockInputName("gs://bucket/data/train/file_test.jsonl")],
-            validation_paths=DUMMY_VALIDATION_PATHS,
-            cache_path=DUMMY_CACHE_PATH,
-            tokenizer=DUMMY_TOKENIZER,
-        )
-    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
-    assert "gs://bucket/data/train/file_test.jsonl" in str(excinfo.value)
-
-
-def test_inputname_with_validation_in_filename():
-    """Tests that an InputName.name with 'validation' in the filename raises a ValueError."""
-    with pytest.raises(ValueError) as excinfo:
-        TokenizeConfig(
-            train_paths=[MockInputName("gs://bucket/data/train/file_validation.jsonl")],
-            validation_paths=DUMMY_VALIDATION_PATHS,
-            cache_path=DUMMY_CACHE_PATH,
-            tokenizer=DUMMY_TOKENIZER,
-        )
-    assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
-    assert "gs://bucket/data/train/file_validation.jsonl" in str(excinfo.value)


### PR DESCRIPTION
Adds validation to `TokenizeConfig` to prevent accidental inclusion of
test or validation datasets in training data.

The validation checks if any of the `train_paths` in `TokenizeConfig`
contain the whole word "test" (e.g., "/test/") or "validation"
(e.g., "/validation/"). If such a pattern is found, a `ValueError`
is raised.

Unit tests have been added to `tests/processing/tokenize/test_tokenize.py`
to cover various scenarios, ensuring the validation works as expected and
does not incorrectly flag valid URLs.