### PR TITLE
Only Schedule Jobs on the Head Node on Purpose

### DIFF
--- a/infra/marin-asia-northeast1.yaml
+++ b/infra/marin-asia-northeast1.yaml
@@ -81,7 +81,7 @@ available_node_types:
   head_default:
     min_workers: 0
     max_workers: 0
-    resources: {"CPU": 1}
+    resources: {"CPU": 0, "head_node": 1}
 
     # GCP-Specific Configuration; by default, Ray will configure unspecified fields (e.g., subnets, ssh-keys)
     #   => Ref: https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert

--- a/infra/marin-big-run.yaml
+++ b/infra/marin-big-run.yaml
@@ -81,7 +81,7 @@ available_node_types:
   head_default:
     min_workers: 0
     max_workers: 0
-    resources: {"CPU": 1}
+    resources: {"CPU": 0, "head_node": 1}
 
     # GCP-Specific Configuration; by default, Ray will configure unspecified fields (e.g., subnets, ssh-keys)
     #   => Ref: https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert

--- a/infra/marin-cluster-template.yaml
+++ b/infra/marin-cluster-template.yaml
@@ -77,7 +77,7 @@ available_node_types:
   head_default:
     min_workers: 0
     max_workers: 0
-    resources: {"CPU": 1}
+    resources: {"CPU": 0, "head_node": 1}
 
     # GCP-Specific Configuration; by default, Ray will configure unspecified fields (e.g., subnets, ssh-keys)
     #   => Ref: https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert

--- a/infra/marin-eu-west4-a.yaml
+++ b/infra/marin-eu-west4-a.yaml
@@ -81,7 +81,7 @@ available_node_types:
   head_default:
     min_workers: 0
     max_workers: 0
-    resources: {"CPU": 1}
+    resources: {"CPU": 0, "head_node": 1}
 
     # GCP-Specific Configuration; by default, Ray will configure unspecified fields (e.g., subnets, ssh-keys)
     #   => Ref: https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert

--- a/infra/marin-eu-west4.yaml
+++ b/infra/marin-eu-west4.yaml
@@ -81,7 +81,7 @@ available_node_types:
   head_default:
     min_workers: 0
     max_workers: 0
-    resources: {"CPU": 1}
+    resources: {"CPU": 0, "head_node": 1}
 
     # GCP-Specific Configuration; by default, Ray will configure unspecified fields (e.g., subnets, ssh-keys)
     #   => Ref: https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert

--- a/infra/marin-us-central1.yaml
+++ b/infra/marin-us-central1.yaml
@@ -81,7 +81,7 @@ available_node_types:
   head_default:
     min_workers: 0
     max_workers: 0
-    resources: {"CPU": 1}
+    resources: {"CPU": 0, "head_node": 1}
 
     # GCP-Specific Configuration; by default, Ray will configure unspecified fields (e.g., subnets, ssh-keys)
     #   => Ref: https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert
@@ -136,7 +136,7 @@ available_node_types:
 
   tpu_slice_v5p_32:
     max_workers: 1024
-    min_workers: 0
+    min_workers: 8
     node_config:
       acceleratorType: v5p-32
       runtimeVersion: v2-alpha-tpuv5
@@ -184,7 +184,7 @@ available_node_types:
 
   tpu_slice_v5p_512:
     max_workers: 1024
-    min_workers: 16
+    min_workers: 0
     node_config:
       acceleratorType: v5p-512
       runtimeVersion: v2-alpha-tpuv5

--- a/infra/marin-us-central2-compress.yaml
+++ b/infra/marin-us-central2-compress.yaml
@@ -81,7 +81,7 @@ available_node_types:
   head_default:
     min_workers: 0
     max_workers: 0
-    resources: {"CPU": 1}
+    resources: {"CPU": 0, "head_node": 1}
 
     # GCP-Specific Configuration; by default, Ray will configure unspecified fields (e.g., subnets, ssh-keys)
     #   => Ref: https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert

--- a/infra/marin-us-central2.yaml
+++ b/infra/marin-us-central2.yaml
@@ -81,7 +81,7 @@ available_node_types:
   head_default:
     min_workers: 0
     max_workers: 0
-    resources: {"CPU": 1}
+    resources: {"CPU": 0, "head_node": 1}
 
     # GCP-Specific Configuration; by default, Ray will configure unspecified fields (e.g., subnets, ssh-keys)
     #   => Ref: https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert

--- a/infra/marin-us-east1.yaml
+++ b/infra/marin-us-east1.yaml
@@ -81,7 +81,7 @@ available_node_types:
   head_default:
     min_workers: 0
     max_workers: 0
-    resources: {"CPU": 1}
+    resources: {"CPU": 0, "head_node": 1}
 
     # GCP-Specific Configuration; by default, Ray will configure unspecified fields (e.g., subnets, ssh-keys)
     #   => Ref: https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert

--- a/infra/marin-us-east5.yaml
+++ b/infra/marin-us-east5.yaml
@@ -81,7 +81,7 @@ available_node_types:
   head_default:
     min_workers: 0
     max_workers: 0
-    resources: {"CPU": 1}
+    resources: {"CPU": 0, "head_node": 1}
 
     # GCP-Specific Configuration; by default, Ray will configure unspecified fields (e.g., subnets, ssh-keys)
     #   => Ref: https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert

--- a/infra/marin-us-west4.yaml
+++ b/infra/marin-us-west4.yaml
@@ -81,7 +81,7 @@ available_node_types:
   head_default:
     min_workers: 0
     max_workers: 0
-    resources: {"CPU": 1}
+    resources: {"CPU": 0, "head_node": 1}
 
     # GCP-Specific Configuration; by default, Ray will configure unspecified fields (e.g., subnets, ssh-keys)
     #   => Ref: https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert

--- a/infra/update-cluster-configs.py
+++ b/infra/update-cluster-configs.py
@@ -37,7 +37,7 @@ configs = {
         "tpu_generation": "v5p",
         "min_workers": 1,
         "worker_targets": {
-            "v5p-512": 16,
+            "v5p-32": 8,
         },
     },
     "marin-big-run": {

--- a/marin/execution/status_actor.py
+++ b/marin/execution/status_actor.py
@@ -2,7 +2,7 @@ import ray
 from ray.util import state  # noqa
 
 
-@ray.remote
+@ray.remote(num_cpus=0, resources={"head_node": 0.0001})
 class StatusActor:
     """
     This class is used to keep track of the status and reference of each output path across various experiments.


### PR DESCRIPTION
## Description

This resets to the Ray best practices of giving the head node 0 CPUs to keep it free for scheduling. However, since the head node is one of the few non-preemptible instances in our cluster we want some things to be able to schedule on it e.g. the status actor. Therefore, this also creates a custom resource to allow things to specially request being scheduled on the head node.