### PR TITLE
Local Fix

### DIFF
--- a/marin/execution/executor.py
+++ b/marin/execution/executor.py
@@ -115,6 +115,7 @@ from marin.execution.executor_step_status import (
 from marin.execution.status_actor import PreviousTaskFailedError, StatusActor
 from marin.utilities.executor_utils import get_pip_dependencies
 from marin.utilities.json_encoder import CustomJsonEncoder
+from marin.utilities.ray_utils import is_local_ray_cluster
 
 logger = logging.getLogger("ray")
 
@@ -1076,7 +1077,9 @@ def executor_main(config: ExecutorMainConfig, steps: list[ExecutorStep], descrip
 
     time_in = time.time()
     ray.init(
-        namespace="marin", ignore_reinit_error=True
+        namespace="marin",
+        ignore_reinit_error=True,
+        resources={"head_node": 1} if is_local_ray_cluster() else None,
     )  # We need to init ray here to make sure we have the correct namespace for actors
     # (status_actor in particular)
     time_out = time.time()

--- a/marin/utilities/ray_utils.py
+++ b/marin/utilities/ray_utils.py
@@ -1,6 +1,8 @@
 import os
+from pathlib import Path
 
 
 def is_local_ray_cluster():
     address = os.environ.get("RAY_ADDRESS")
-    return address is None or address == "local"
+    cluster_file = Path("/tmp/ray/ray_current_cluster")
+    return (address is None and not cluster_file.exists()) or address == "local"


### PR DESCRIPTION
## Description

Fixes #1408 

The change to prevent other jobs besides StatusActor from running on the head node was causing issues in the local setting where the local device was not set to have the correct resources. This changes to check whether we are running in a local ray setting and add the appropriate resources if so.