### PR TITLE
Switch docs and tooling to uv

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Install MkDocs and plugins
         run: |
-          python -m pip install --upgrade pip
-          pip install mkdocs mkdocs-material mkdocstrings[python] mkdocs-include-markdown-plugin
+          python -m pip install uv
+          uv pip install mkdocs mkdocs-material mkdocstrings[python] mkdocs-include-markdown-plugin
 
       - name: Build documentation
         run: |

--- a/.github/workflows/lint-and-format.yaml
+++ b/.github/workflows/lint-and-format.yaml
@@ -18,8 +18,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install pre-commit
+        python -m pip install uv
+        uv pip install pre-commit
 
     - name: Run pre-commit
       run: pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/metrics.yaml
+++ b/.github/workflows/metrics.yaml
@@ -42,7 +42,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate marin_metrics_env
-          pip install -e .[extras,metrics]
+          uv pip install -e .[extras,metrics]
           
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/.github/workflows/quickstart.yaml
+++ b/.github/workflows/quickstart.yaml
@@ -43,8 +43,8 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          python -m pip install --upgrade pip
-          pip install uv==0.5.11 toml
+          python -m pip install uv
+          uv pip install toml
           python scripts/install_all_pip_dep.py
 
       # Start Ray cluster locally; We give cpus as 64 since we don't want Ray to get stuck in infinite loop trying to

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -61,8 +61,8 @@ jobs:
         run: |
           conda install -c conda-forge pandoc
           npm install -g pandiff
-          python -m pip install --upgrade pip
-          pip install uv==0.5.11 toml
+          python -m pip install uv
+          uv pip install toml
           python scripts/install_all_pip_dep.py
       
 #      - name: Install Resiliparse DOM

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ init:
 	conda install -c conda-forge pandoc
 	npm install -g pandiff
 	pre-commit install
-	pip install -e ".[dev,download_transform]"
+        uv pip install -e ".[dev,download_transform]"
 	huggingface-cli login
 
 clean:

--- a/docker/marin/Dockerfile.cluster
+++ b/docker/marin/Dockerfile.cluster
@@ -3,6 +3,7 @@ ARG VLLM_VERSION=0.6.6.post1
 
 # Install general dependencies
 RUN sudo apt-get update && sudo apt-get install -y clang curl g++ vim libpython3.11 libpython3.11-dev docker.io cmake
+RUN pip install uv
 
 # Setup gcsfuse
 RUN sudo apt install lsb-release -y
@@ -67,11 +68,11 @@ RUN conda install -c conda-forge ncurses -y
 
 # Install Jax for TPU usage, fsspec for GCS access, and transformers for OLMO
 WORKDIR /tmp/
-RUN pip install --no-cache-dir -U pip setuptools wheel
-RUN pip install --no-cache-dir torch==2.7.0 jax[tpu]==0.5.1 -f https://download.pytorch.org/whl/nightly/cpu -f https://storage.googleapis.com/libtpu-releases/index.html
+RUN uv pip install --no-cache-dir -U pip setuptools wheel
+RUN uv pip install --no-cache-dir torch==2.7.0 jax[tpu]==0.5.1 -f https://download.pytorch.org/whl/nightly/cpu -f https://storage.googleapis.com/libtpu-releases/index.html
 COPY pyproject.toml /tmp/
 # re-specify jax/torch/torch_xla to ensure they still work if we bump versions in pyproject.toml
-RUN pip install --no-cache-dir -e . -f https://download.pytorch.org/whl/cpu jax[tpu] torch -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+RUN uv pip install --no-cache-dir -e . -f https://download.pytorch.org/whl/cpu jax[tpu] torch -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
 
 # Installing all the core dependencies
 # ['draccus>=0.8.0', 'google-api-python-client~=2.0', 'ray', 'gcsfs', 'google-cloud-storage',

--- a/docker/marin/Dockerfile.vllm
+++ b/docker/marin/Dockerfile.vllm
@@ -6,6 +6,9 @@ FROM vllm/vllm-tpu:nightly
 RUN apt-get update && apt-get install lsb-release rsync docker.io -y
 RUN usermod -aG docker $(whoami)
 
+# Install uv for faster dependency management
+RUN pip install uv
+
 RUN export GCSFUSE_REPO=gcsfuse-`lsb_release -c -s` && echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | tee /etc/apt/sources.list.d/gcsfuse.list
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 RUN apt-get update && apt-get install fuse gcsfuse -y
@@ -18,7 +21,7 @@ RUN curl -sSL https://sdk.cloud.google.com > /tmp/gcl && \
     && chown -R $(whoami) /root/gcloud
 
 # Install core dependencies
-RUN pip install --no-cache-dir draccus==0.11.5 google-api-python-client~=2.0 gcsfs google-cloud-storage google-cloud-storage-transfer s3fs regex requests braceexpand deepdiff tqdm tqdm-loggable levanter==1.2.dev1190 haliax==1.4.dev327
+RUN uv pip install --no-cache-dir draccus==0.11.5 google-api-python-client~=2.0 gcsfs google-cloud-storage google-cloud-storage-transfer s3fs regex requests braceexpand deepdiff tqdm tqdm-loggable levanter==1.2.dev1190 haliax==1.4.dev327
 
 # NOTE(chris): We fix the lm-evaluation-harness commit hash for now since the newest main is broken because of
 # the new eval_logger change they made
@@ -29,10 +32,10 @@ cd /opt/lm_eval && \
 git clone --depth 1 https://github.com/EleutherAI/lm-evaluation-harness && \
 cd lm-evaluation-harness && \
 git fetch origin $LM_EVAL_EVAL_COMMIT_HASH && \
-git checkout $LM_EVAL_EVAL_COMMIT_HASH && pip install --no-cache-dir -e ".[ifeval, math]"
+git checkout $LM_EVAL_EVAL_COMMIT_HASH && uv pip install --no-cache-dir -e ".[ifeval, math]"
 
 # Need the latest accelerate due to some deprecations in the newest pytorch
-RUN pip install --no-cache-dir https://github.com/huggingface/accelerate/archive/refs/heads/main.zip
+RUN uv pip install --no-cache-dir https://github.com/huggingface/accelerate/archive/refs/heads/main.zip
 
 # Add /usr/lib/x86_64-linux-gnu/ to LD_LIBRARY_PATH so that bash prefers the systems
 # libtinfo.so over the conda-provided version. Using the conda-provided libtinfo.so

--- a/docs/dev-guide/building-docs.md
+++ b/docs/dev-guide/building-docs.md
@@ -7,14 +7,14 @@ This guide explains how to build, test, and maintain the Marin documentation.
 Before you begin, ensure you have the following installed:
 
 - Python 3.12 or higher
-- pip (Python package manager)
+- uv (Python dependency manager)
 - Git
 
 ## Installation
 
 1. Install the documentation dependencies:
    ```bash
-   pip install -e ".[docs]"
+   uv pip install -e ".[docs]"
    ```
 
 ## Building Documentation

--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -10,9 +10,9 @@
 ```bash
 git clone https://github.com/marin-community/marin.git
 cd marin
-python -m venv venv
+uv venv venv
 source venv/bin/activate
-pip install -e .[dev]
+uv pip install -e .[dev]
 pre-commit install
 ```
 

--- a/docs/explanations/executor.md
+++ b/docs/explanations/executor.md
@@ -48,7 +48,7 @@ The environment will have the following packages installed:
   not interfere with other steps.
 
 For example, to install the dependencies specified in the
-`quality_dedup_consolidate` groups and also pip install `google-cloud-logging`,
+`quality_dedup_consolidate` groups and also uv pip install `google-cloud-logging`,
 one can do:
 
 ```python

--- a/docs/explanations/marin-prefix.md
+++ b/docs/explanations/marin-prefix.md
@@ -49,12 +49,12 @@ Marin leverages the `fsspec` library, allowing you to use various storage backen
 *   **Amazon S3:**
     *   `--prefix s3://your-s3-bucket/path/to/output`
     *   `export MARIN_PREFIX=s3://your-s3-bucket/path/to/output`
-    (Requires appropriate AWS credentials and `s3fs` library installed: `pip install s3fs`)
+    (Requires appropriate AWS credentials and `s3fs` library installed: `uv pip install s3fs`)
 
 *   **Google Cloud Storage (GCS):**
     *   `--prefix gs://your-gcs-bucket/path/to/output`
     *   `export MARIN_PREFIX=gs://your-gcs-bucket/path/to/output`
-    (Requires appropriate GCP credentials and `gcsfs` library installed: `pip install gcsfs`)
+    (Requires appropriate GCP credentials and `gcsfs` library installed: `uv pip install gcsfs`)
 
 ## Important Considerations for Distributed Environments
 

--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -25,7 +25,7 @@ If you want to set up a TPU cluster, see [TPU Setup](tpu-cluster-setup.md).
 
 2. Create and activate a virtual environment:
    ```bash
-   virtualenv venv           # Alternative: python -m venv venv
+   uv venv venv              # Alternative: python -m venv venv
    source venv/bin/activate  # On Windows: venv\Scripts\activate
    ```
 
@@ -37,7 +37,7 @@ If you want to set up a TPU cluster, see [TPU Setup](tpu-cluster-setup.md).
 
 3. Install the package (this might take a while, which is something we should fix):
    ```bash
-   pip install -e .
+   uv pip install -e .
    ```
 
 4. Setup [Weights and Biases (WandB)](https://wandb.ai) so you can monitor your runs:
@@ -60,7 +60,7 @@ Marin runs on multiple types of hardware (CPU, GPU, TPU).
 
     === "CPU"
         ```bash
-        pip install -e "."
+        uv pip install -e "."
         ```
 
     === "GPU"
@@ -85,13 +85,13 @@ Marin runs on multiple types of hardware (CPU, GPU, TPU).
          Finally we'll install the correct libraries for GPU setup:
 
          ```bash
-         pip install -e ".[cuda12]"
+         uv pip install -e ".[cuda12]"
          ```
 
     === "TPU"
 
         ```bash
-        pip install -e ".[tpu]"
+        uv pip install -e ".[tpu]"
         ```
 
 - **CPU**: Works out of the box, suitable for small experiments

--- a/docs/tutorials/tpu-cluster-setup.md
+++ b/docs/tutorials/tpu-cluster-setup.md
@@ -51,7 +51,7 @@ We use docker images to run the jobs inside the ray cluster. We provide a convie
 
 1. Install Marin with TPU support:
    ```bash
-   pip install -e ".[tpu]"
+   uv pip install -e ".[tpu]"
    ```
 
 2. Set up your GCP environment:

--- a/scripts/generate_experiment_summary.py
+++ b/scripts/generate_experiment_summary.py
@@ -6,7 +6,7 @@ This script:
 - Writes the summary to `docs/reports/summary.md`.
 
 Usage:
-pip install PyGithub openai
+uv pip install PyGithub openai
 python scripts/generate_experiment_summary.py
 """
 

--- a/scripts/pm/itemize_experiment_issues.py
+++ b/scripts/pm/itemize_experiment_issues.py
@@ -3,7 +3,7 @@
 This script updates the `docs/reports/index.md` file with new experiment GitHub issues.
 
 Usage:
-pip install PyGithub
+uv pip install PyGithub
 python scripts/itemize_experiment_issues.py
 """
 

--- a/scripts/pm/replace_crfm_links.py
+++ b/scripts/pm/replace_crfm_links.py
@@ -9,7 +9,7 @@ Usage:
     python scripts/replace_crfm_links.py [--dry-run]
 
 Requires:
-    pip install PyGithub
+    uv pip install PyGithub
     export GITHUB_TOKEN=your_token
 """
 

--- a/scripts/pm/replace_wandb_links.py
+++ b/scripts/pm/replace_wandb_links.py
@@ -8,7 +8,7 @@ Usage:
     python scripts/replace_wandb_links.py [--dry-run]
 
 Requires:
-    pip install PyGithub
+    uv pip install PyGithub
     export GITHUB_TOKEN=your_token
 """
 


### PR DESCRIPTION
## Summary
- prefer `uv` over `pip` in docs
- update Makefile to use `uv`
- install dependencies with `uv` in Dockerfiles
- update GitHub workflows to use `uv`
- tweak helper scripts to show `uv pip install`

## Testing
- `pre-commit run --files .github/workflows/docs.yaml .github/workflows/unit-tests.yaml .github/workflows/lint-and-format.yaml .github/workflows/quickstart.yaml .github/workflows/metrics.yaml Makefile docker/marin/Dockerfile.cluster docker/marin/Dockerfile.vllm docs/dev-guide/building-docs.md docs/dev-guide/contributing.md docs/explanations/executor.md docs/explanations/marin-prefix.md docs/tutorials/installation.md docs/tutorials/tpu-cluster-setup.md scripts/generate_experiment_summary.py scripts/pm/itemize_experiment_issues.py scripts/pm/replace_crfm_links.py scripts/pm/replace_wandb_links.py`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686bfd0ad4588331ba1b0519a6ce8674