### PR TITLE
Add entrypoint resource options and TPU flag to ray_run

### DIFF
--- a/tests/test_ray_run.py
+++ b/tests/test_ray_run.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-from marin.run.ray_run import parse_pip_requirements
+import pytest
+
+from marin.run.ray_run import parse_pip_requirements, tpus_per_node
 
 
 def test_parse_pip_requirements():
@@ -21,3 +23,12 @@ def test_parse_pip_requirements():
         "datatrove[io,processing] @ git+https://github.com/nelson-liu/datatrove@tqdm_loggable",
         "scipy",
     ]
+
+
+def test_tpus_per_node():
+    assert tpus_per_node("v4-8") == 4
+    assert tpus_per_node("v5p-8") == 4
+    assert tpus_per_node("v5e-4") == 4
+    assert tpus_per_node("v5e-2") == 2
+    with pytest.raises(ValueError):
+        tpus_per_node("v5e-16")


### PR DESCRIPTION
## Summary
- allow specifying entrypoint resource requirements in `ray_run`
- support TPU resources via new `--tpu` option
- implement `tpus_per_node` helper
- test TPU parsing logic

## Testing
- `pre-commit run --files marin/run/ray_run.py tests/test_ray_run.py`
- `pytest tests/test_ray_run.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6873e200a3308331aafefd8af434ca14