### PR TITLE
Add multi-host FP32 tensor-parallel sliding logits

### DIFF
--- a/docs/tutorials/sliding_logits.md
+++ b/docs/tutorials/sliding_logits.md
@@ -244,3 +244,15 @@ if __name__ == "__main__":
 This setup provides a complete pipeline for analyzing how large language models process and predict text, revealing insights into their internal representations and decision-making processes. 
 
  python marin/run/ray_run.py  --env_vars XLA_USE_F16 1 --env_vars XLA_USE_BF16 0 --env_vars XLA_DOWNCAST_BF16 0  --env_vars HF_TOKEN $HF_TOKEN   --env_vars WANDB_API_KEY $WANDB_API_KEY  -- python experiments/tutorials/exp1353_sliding_logits_tp_70b.py --force_run_failed True 
+
+For multi-host slices such as a v6e-16, use the FP32 variant:
+
+```bash
+python marin/run/ray_run.py \
+    --env_vars XLA_USE_F16 0 \
+    --env_vars XLA_USE_BF16 0 \
+    --env_vars XLA_DOWNCAST_BF16 0 \
+    --env_vars HF_TOKEN $HF_TOKEN \
+    --env_vars WANDB_API_KEY $WANDB_API_KEY \
+    -- python experiments/tutorials/exp1354_sliding_logits_tp_fp32_multi.py --force_run_failed True
+```

--- a/experiments/tutorials/exp1354_sliding_logits_tp_fp32_multi.py
+++ b/experiments/tutorials/exp1354_sliding_logits_tp_fp32_multi.py
@@ -1,0 +1,75 @@
+"""
+python marin/run/ray_run.py \
+    --env_vars XLA_USE_F16 0 \
+    --env_vars XLA_USE_BF16 0 \
+    --env_vars XLA_DOWNCAST_BF16 0 \
+    --env_vars HF_TOKEN $HF_TOKEN \
+    --env_vars WANDB_API_KEY $WANDB_API_KEY \
+    --pip_deps '--find-links https://storage.googleapis.com/libtpu-releases/index.html,\
+                --find-links https://storage.googleapis.com/libtpu-wheels/index.html,\
+                torch~=2.6.0,torch_xla[tpu]~=2.6.0,transformers~=4.53.0,matplotlib' \
+    -- \
+    python experiments/tutorials/exp1354_sliding_logits_tp_fp32_multi.py --force_run_failed True
+"""
+
+from experiments.models import get_model_local_path, llama_3_1_70b
+from marin.execution.executor import ExecutorStep, executor_main, this_output_path
+from marin.generation.plot_sliding_logits import PlotSlidingLogitsConfig, create_sliding_logits_plot
+from marin.generation.sliding_logits_tp_fp32 import (
+    Precision,
+    SlidingLogitsTPFP32Config,
+    compute_sliding_logits_tp_fp32_remote,
+)
+
+# -----------------------------------------------------------------------------
+# Step 1: Tensor-parallel sliding-window forward pass + logits extraction
+# -----------------------------------------------------------------------------
+
+sliding_logits_tp_fp32_step = ExecutorStep(
+    name="extraction/sliding-forward-logits-tp_70b_fp32_multi",
+    description="Run tensor-parallel sliding-window LM forward pass on a v6e-16 slice.",
+    fn=compute_sliding_logits_tp_fp32_remote,
+    config=SlidingLogitsTPFP32Config(
+        model_name=get_model_local_path(llama_3_1_70b),
+        input_path="gs://marin-us-central2/documents/books_txt/gatsby.txt",
+        output_dir=this_output_path(),
+        batch_size=1,
+        chunk_size=100,
+        slice_length=2000,
+        cursor_inc=10,
+        max_length=100,
+        prompt_tokens=50,
+        precision=Precision.FLOAT32,
+        num_devices=16,
+        mesh_shape=(1, 16),
+        uncompress=True,
+        batches_per_save=1,
+        background_queue=True,
+        num_background_writers=4,
+        debug=False,
+    ),
+)
+
+# -----------------------------------------------------------------------------
+# Step 2: Plot generation from sliding logits results
+# -----------------------------------------------------------------------------
+
+plot_step = ExecutorStep(
+    name="visualization/sliding-logits-plot-tp_70b_fp32_multi",
+    description="Create heatmap from tensor-parallel FP32 sliding logits results.",
+    fn=create_sliding_logits_plot,
+    config=PlotSlidingLogitsConfig(
+        input_path=sliding_logits_tp_fp32_step,
+        original_text_path="gs://marin-us-central2/documents/books_txt/gatsby.txt",
+        output_path=this_output_path(),
+        plot_title="TP FP32 Sliding Logits: Great Gatsby (70B)",
+        colormap="Blues",
+        figsize=(20, 3),
+        dpi=300,
+        save_combined_arrays=True,
+        compute_extraction_stats=True,
+    ),
+)
+
+if __name__ == "__main__":
+    executor_main([sliding_logits_tp_fp32_step, plot_step])

--- a/marin/generation/sliding_logits_tp_fp32.py
+++ b/marin/generation/sliding_logits_tp_fp32.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import ray
+
+from marin.generation.sliding_logits_tp import (
+    Precision,
+    SlidingLogitsTPConfig,
+    compute_sliding_logits_tp,
+)
+from marin.utils import remove_tpu_lockfile_on_exit
+
+
+@dataclass
+class SlidingLogitsTPFP32Config(SlidingLogitsTPConfig):
+    """Configuration for FP32 tensor-parallel sliding logits on multi-host TPUs."""
+
+    precision: Precision = Precision.FLOAT32
+    num_devices: int | None = 16
+    mesh_shape: tuple[int, int] | None = (1, 16)
+
+
+@remove_tpu_lockfile_on_exit
+def compute_sliding_logits_tp_fp32(cfg: SlidingLogitsTPFP32Config) -> None:
+    """Run tensor-parallel sliding window forward pass with FP32 precision."""
+
+    compute_sliding_logits_tp(cfg)
+
+
+compute_sliding_logits_tp_fp32_remote = ray.remote(
+    # 70B model with FP32 requires more memory
+    memory=256 * 1024 * 1024 * 1024,  # 256 GB
+    resources={"TPU": 16, "TPU-v6e-16-head": 1},
+)(compute_sliding_logits_tp_fp32)


### PR DESCRIPTION
## Summary
- add `sliding_logits_tp_fp32.py` to support FP32 tensor parallelism on v6e-16 slices
- create `exp1354_sliding_logits_tp_fp32_multi.py` demonstration experiment
- document multi-host FP32 usage in sliding logits tutorial

## Testing
- `black marin/generation/sliding_logits_tp_fp32.py experiments/tutorials/exp1354_sliding_logits_tp_fp32_multi.py`
- `ruff check marin/generation/sliding_logits_tp_fp32.py experiments/tutorials/exp1354_sliding_logits_tp_fp32_multi.py --fix`
- `mypy marin/generation/sliding_logits_tp_fp32.py experiments/tutorials/exp1354_sliding_logits_tp_fp32_multi.py` *(failed: missing stubs in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68750c1742088327b598514afd41021d