### PR TITLE
modified hello_word for gcs

### DIFF
--- a/experiments/tutorials/hello_world.py
+++ b/experiments/tutorials/hello_world.py
@@ -58,7 +58,7 @@ def compute_stats(config: ComputeStatsConfig):
         "max": max(numbers),
     }
     stats_path = os.path.join(config.output_path, "stats.json")
-    with open(stats_path, "w") as f:
+    with fsspec.open(stats_path, "w") as f:
         json.dump(stats, f)
 
 


### PR DESCRIPTION
## Description

Fixed experiments/tutorials/hello_world.py which was not working on GCP due to the use of open instead of fsspec.open to read from a GCS bucket.