### PR TITLE
Expose trainer profiler options

### DIFF
--- a/experiments/defaults.py
+++ b/experiments/defaults.py
@@ -316,6 +316,9 @@ def default_train(
             quantization=QuantizationConfig(int8=train_config.int8) if train_config.int8 else None,
             initialize_from=None if train_config.reset_data_loader_on_init else checkpoint_path_to_load_from,
             watch=train_config.watch,
+            profiler=train_config.profiler,
+            profiler_start_step=train_config.profiler_start_step,
+            profiler_num_steps=train_config.profiler_num_steps,
             axis_resources={
                 # Special axes for MoEs
                 "token": (ResourceAxis.REPLICA, ResourceAxis.DATA),

--- a/experiments/simple_train_config.py
+++ b/experiments/simple_train_config.py
@@ -73,6 +73,14 @@ class SimpleTrainConfig:
     watch: WatchConfig = dataclasses.field(default_factory=WatchConfig)
     """Config for watching gradients, parameters, etc. Default is to log norms of gradients and parameters."""
 
+    # profiler-related configuration
+    profiler: bool = False
+    """Whether to run the JAX profiler during training."""
+    profiler_start_step: int = 5
+    """Which step to start profiling."""
+    profiler_num_steps: int = 100
+    """How many steps to profile for once started."""
+
     @property
     def tpu_type(self) -> str | None:
         """For backward compatibility."""


### PR DESCRIPTION
## Summary
- allow SimpleTrainConfig to configure the JAX profiler
- propagate profiler options to Levanter TrainerConfig

## Testing
- `pre-commit run --files experiments/simple_train_config.py experiments/defaults.py`
- `make test` *(fails: network access to huggingface blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687ddb548f20833186a9643ce1859967