### PR TITLE
Fix broken doc link

### DIFF
--- a/docs/tutorials/add-optimizer.md
+++ b/docs/tutorials/add-optimizer.md
@@ -158,7 +158,7 @@ if __name__ == "__main__":
 ```
 
 🎉 That’s it! You can now define new optimizers in this manner and train models using them, all within Marin. For optimizers that are widely useful or “standard,” consider submitting a pull request to Levanter.
-See a full working example [in this GitHub link](https://github.com/marin-community/marin/blob/main/experiments/speedrun/llama_75m_fineweb_edu_adamax/llama_75m_fineweb_edu_adamax.py).
+See a full working example [in this GitHub link](https://github.com/marin-community/marin/blob/main/experiments/speedrun/llama_75m_adamax/llama_75m_adamax.py).
 
 Further reading:
 


### PR DESCRIPTION
## Summary
- correct path to speedrun example in add-optimizer tutorial

fixes #1467

------
https://chatgpt.com/codex/tasks/task_e_687feb09f3288331a7c78bec3c1672cf