### PR TITLE
Nemotron & Openthoughts3

### DIFF
--- a/experiments/exp905a_nemotron_sft_dstc.py
+++ b/experiments/exp905a_nemotron_sft_dstc.py
@@ -1,0 +1,96 @@
+# This script is a helper script to download, transform, tokenize, and count
+# tokens for SFT datasets.
+# In addition to previous SFT datasets, we include Nemotron SFT and OpenThoughts3-1.2M.
+
+import logging
+
+# Define datasets
+from exp808_sft_mixture import DATASETS as EXP808_DATASETS
+
+from experiments.data_utils.count_dataset import compile_and_store_num_rows_step, compile_and_store_num_tokens_step
+from experiments.defaults import default_tokenize
+from experiments.marin_models import marin_tokenizer
+from experiments.posttrain.instruction_datasets import (
+    INSTRUCTION_DATASET_NAME_TO_CONFIG,
+    download_dataset_step,
+    get_instruction_dataset,
+    transform_dataset_step,
+)
+from levanter.data.text import ChatLmDatasetFormat
+from marin.execution.executor import (
+    ExecutorStep,
+    executor_main,
+)
+
+logger = logging.getLogger("ray")
+
+
+########### Tokenization ###########
+def create_tokenization_step(dataset_name: str) -> ExecutorStep:
+    # This is a modified version of the `create_tokenization_step` function in exp808_sft_mixture.py
+    """
+    Creates a tokenization ExecutorStep for a given dataset.
+
+    Args:
+        dataset_name: Name of the dataset (e.g., 'TIGER-Lab/AceCode-89K', 'HuggingFaceTB/smoltalk')
+
+    Returns:
+        ExecutorStep configured for tokenizing the specified dataset
+    """
+    # Get the dataset with only train split
+    if dataset_name == "nvidia/Llama-Nemotron-Post-Training-Dataset-v1-SFT":
+        dataset = get_instruction_dataset(dataset_name, splits=["chat", "code", "math", "science", "safety"])
+    else:
+        dataset = get_instruction_dataset(dataset_name, splits=["train"])
+
+    # Get the last part of the path and clean it up
+    short_name = dataset_name.split("/")[-1].lower().replace("-", "_")
+
+    # Use .jsonl.gz extension since transform_and_write_batch produces .jsonl.gz files
+    dataset_path = dataset / "**/*.jsonl.gz"
+
+    return default_tokenize(
+        name=f"{short_name}_marin_tokenizer",
+        dataset=dataset_path,
+        tokenizer=marin_tokenizer,
+        format=ChatLmDatasetFormat(),
+    )
+
+
+DATASETS = {
+    **EXP808_DATASETS,
+    "nemotron_sft": "nvidia/Llama-Nemotron-Post-Training-Dataset-v1-SFT",
+    "openthoughts3": "open-thoughts/OpenThoughts3-1.2M",
+}
+
+
+def download_transform_tokenize_count_steps():
+    ALL_STEPS = []
+    TOKENIZATION_STEPS = dict()
+    for short_ds_name, full_ds_name in DATASETS.items():
+        # Download the dataset
+        config = INSTRUCTION_DATASET_NAME_TO_CONFIG[full_ds_name]
+        data_download_step = download_dataset_step(config)
+        # Transform the dataset
+        data_transform_step = transform_dataset_step(config, data_download_step)
+        # Tokenize the dataset
+        data_tokenize_step = create_tokenization_step(full_ds_name)
+
+        ALL_STEPS += [data_download_step, data_transform_step, data_tokenize_step]
+        TOKENIZATION_STEPS[short_ds_name] = [data_tokenize_step]
+
+    # Compile token counts
+    ALL_STEPS.append(
+        compile_and_store_num_rows_step(TOKENIZATION_STEPS, "experiments/exp905a_nemotron_sft_dstc/num_rows")
+    )
+    ALL_STEPS.append(
+        compile_and_store_num_tokens_step(TOKENIZATION_STEPS, "experiments/exp905a_nemotron_sft_dstc/num_tokens")
+    )
+
+    return ALL_STEPS
+
+
+########### Main ###########
+if __name__ == "__main__":
+    ALL_STEPS = download_transform_tokenize_count_steps()
+    executor_main(steps=ALL_STEPS)

--- a/experiments/exp905b_nemotron_sft_train.py
+++ b/experiments/exp905b_nemotron_sft_train.py
@@ -1,0 +1,151 @@
+"""
+#1237: Starling SFT
+
+SFT the Deeper Starling Iteration of Tootsie 8B Model using the Reasoning + Tulu SFT Mixture.
+This is to produce our release candidate for Marin's launch given the strength of the base model!
+
+GitHub Issue: https://github.com/marin-community/marin/issues/1237
+"""
+
+import dataclasses
+import logging
+import math
+
+from experiments.evals.evals import default_sft_eval
+
+# Dataset configurations
+from experiments.exp905a_nemotron_sft_dstc import DATASETS, create_tokenization_step
+from experiments.llama import llama_8b
+from experiments.tootsie.exp916_tootsie_spoonbill_cooldown import spoonbill_zloss_tulu3_sft_config
+from marin.execution.executor import executor_main
+from marin.processing.tokenize import lm_mixture_data_config
+from marin.resources import TpuPodConfig
+
+logger = logging.getLogger("ray")
+
+# Experiment specific settings
+EXPERIMENT_NAME = "sft/deeper_starling_sft_nemotron_and_openthoughts3"
+REGION = "us-central2"
+LAST_STEP = 1430237
+
+SFT_CONFIG = dataclasses.replace(
+    spoonbill_zloss_tulu3_sft_config,
+    learning_rate=1e-4,
+    resources=TpuPodConfig(tpu_type="v4-128", slice_count=1),
+    # initialize_from_checkpoint_path=tootsie_8b_deeper_starling.cd("checkpoints/step-1419967").nonblocking(),
+    initialize_from_checkpoint_path=f"gs://marin-{REGION}/checkpoints/sft/mixture_sft_deeper_starling_with_nemotron_and_openthoughts3_2/checkpoints/step-{LAST_STEP}",
+    steps_per_eval=5000,
+    steps_per_hf_export=1000,
+    steps_per_checkpoint=2500,
+)
+
+MODEL_CONFIG = llama_8b
+
+EXPERIMENT_TAGS = [
+    "llama",
+    "8b",
+    "tootsie",
+    "sft",
+    "starling",
+    "mixture",
+    "exp905b",
+    "nemotron+openthoughts3-1.2m",
+    f"{REGION}",
+    "v4-128",
+    "batchsize=512",
+]
+
+# Training parameters
+BATCH_SIZE = 512
+EPOCHS = 3
+
+
+tokenized_datasets = {short_name: create_tokenization_step(hf_name) for short_name, hf_name in DATASETS.items()}
+
+# Mixture weights should be read from the json file written by exp905a
+mixture_weights = {
+    "acecode_89k": 26032149,
+    "smoltalk": 883494479,
+    "verifiable_math_problems": 382056624,
+    "dolphin_r1_nonreasoning": 319820708,
+    "dolphin_r1_reasoning": 508743187,
+    "bespoke_stratos_17k": 85724829,
+    "openthoughts_114k_math": 72964948,
+    "tulu_3_sft_mixture": 749008790,
+    "natural_reasoning": 966484170,
+    "nemotron_sft": 34739443205,
+    "openthoughts3": 17449811417,
+}
+
+# Calculate the number of training steps from computed values
+total_tokens = sum(mixture_weights.values())
+num_steps = total_tokens // (BATCH_SIZE * MODEL_CONFIG.seq_len) * EPOCHS + 2 * 1419967 - LAST_STEP
+
+logger.info(f"Total tokens: {total_tokens}")
+logger.info(f"Sequence length: {MODEL_CONFIG.seq_len}")
+logger.info(f"Batch size: {BATCH_SIZE}")
+logger.info(f"Epochs: {EPOCHS}")
+logger.info(f"Number of new steps: {total_tokens // (BATCH_SIZE * MODEL_CONFIG.seq_len) * EPOCHS}")
+logger.info(f"Number of steps: {num_steps}")
+
+if __name__ == "__main__":
+    sft_mixture_llama3 = lm_mixture_data_config(
+        tokenized_datasets,
+        mixture_weights,  # Edit in create_experiment_config_step, not here.
+        shuffle=True,
+        missing_weights_are_validation=True,
+    )
+
+    _sft_config = dataclasses.replace(
+        SFT_CONFIG,
+        num_train_steps=num_steps,  # Using the values in the config file
+        train_batch_size=BATCH_SIZE,  # Using the values in the config file
+        learning_rate=SFT_CONFIG.learning_rate * math.sqrt(BATCH_SIZE / 128),
+    )
+
+    # Create a custom SFT step with evaluations enabled
+    # We need to modify the default_sft to enable evaluations
+    # Since default_sft hardcodes eval_harness_tasks=[], we'll use default_train directly
+    from experiments.defaults import default_train
+    from experiments.evals.task_configs import OPEN_LM_LEADERBOARD_MCQ
+    from experiments.simple_train_config import SimpleTrainConfig
+
+    # Convert your existing _sft_config to train config
+    normal_train_config = SimpleTrainConfig(
+        resources=_sft_config.resources,
+        train_batch_size=_sft_config.train_batch_size,
+        num_train_steps=_sft_config.num_train_steps,
+        learning_rate=_sft_config.learning_rate,
+        lr_schedule=_sft_config.lr_schedule,
+        decay=_sft_config.cooldown,
+        weight_decay=_sft_config.weight_decay,
+        min_lr_ratio=_sft_config.min_lr_ratio,
+        max_grad_norm=_sft_config.max_grad_norm,
+        warmup=_sft_config.warmup,
+        steps_per_eval=_sft_config.steps_per_eval,
+        steps_per_export=_sft_config.steps_per_checkpoint,
+        int8=_sft_config.int8,
+        steps_per_hf_export=_sft_config.steps_per_hf_export,
+        initialize_from_checkpoint_path=_sft_config.initialize_from_checkpoint_path,
+        data_seed=_sft_config.seed,
+        z_loss_weight=_sft_config.z_loss_weight,
+    )
+
+    sft_step = default_train(
+        name=EXPERIMENT_NAME,
+        tokenized=sft_mixture_llama3,
+        model_config=MODEL_CONFIG,
+        train_config=normal_train_config,
+        tags=EXPERIMENT_TAGS,
+        eval_harness_tasks=OPEN_LM_LEADERBOARD_MCQ,  # Enable evaluations during training
+        use_default_validation=False,
+    ).with_output_path(f"gs://marin-{REGION}/checkpoints/{EXPERIMENT_NAME}")
+
+    # Now run the SFT step
+    executor_main(
+        [
+            sft_step,
+            *default_sft_eval(sft_step),
+        ],
+        description="Run SFT training step",
+    )

--- a/marin/transform/conversation/adapters.py
+++ b/marin/transform/conversation/adapters.py
@@ -1,4 +1,5 @@
 import dataclasses
+import re
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
@@ -51,6 +52,125 @@ class InputDatasetFormat(str, Enum):
     INSTRUCT_MSG_RESPONSE: str = "instruct_msg_response"
 
 
+def _replace_special_keys(string: str | None, special_keys_mapping: dict[str, str]) -> str | None:
+    if (not special_keys_mapping) or (string is None):
+        return string
+    pattern = "|".join(map(re.escape, special_keys_mapping.keys()))
+    return re.sub(pattern, lambda m: special_keys_mapping[m.group(0)], string)
+
+
+def transform_instruction_response(
+    row: dict[str, dict[str, str]],
+    instruction_column: str,
+    response_column: str,
+    filter_on_key: str | None,
+    content_key: str,
+    special_keys_mapping: dict[str, str] = dataclasses.field(default_factory=dict),
+) -> list[OpenAIChatMessage] | None:
+    messages: list[OpenAIChatMessage] = []
+    instruction = row[instruction_column]
+    response = row[response_column]
+    # Check data
+    if instruction is None or response is None:
+        return None  # Do not process rows with missing data
+    if filter_on_key:
+        best_completion = None
+        best_metric = -float("inf")  # TODO: Make this a config
+
+        for completion in response:
+            if completion[filter_on_key] > best_metric:
+                best_metric = completion[filter_on_key]
+                best_completion = completion
+        response = best_completion[content_key]
+    # Replace special keys
+    instruction = _replace_special_keys(instruction, special_keys_mapping)
+    response = _replace_special_keys(response, special_keys_mapping)
+    # Save
+    messages.append(OpenAIChatMessage(role="user", content=instruction))
+    messages.append(OpenAIChatMessage(role="assistant", content=response))
+    return messages
+
+
+def transform_single_column_multi_turn(
+    row: dict[str, list[str]],
+    conversation_column: str,
+    role_key: str,
+    user_value: str,
+    assistant_value: str,
+    system_value: str,
+    content_key: str,
+    special_keys_mapping: dict[str, str] = dataclasses.field(default_factory=dict),
+) -> list[OpenAIChatMessage]:
+    messages: list[OpenAIChatMessage] = []
+    role_to_openai_role: dict[str, str] = {
+        user_value: "user",
+        assistant_value: "assistant",
+        system_value: "system",
+    }
+    conversation = row[conversation_column]
+    for conv in conversation:
+        this_role, this_content = conv[role_key], conv[content_key]
+        openai_role = role_to_openai_role[this_role]
+        # Replace special keys
+        this_content = _replace_special_keys(this_content, special_keys_mapping)
+        # if this_content is None:
+        #     raise ValueError(f"Content is None, original conv: {conv}")
+        messages.append(OpenAIChatMessage(role=openai_role, content=this_content))
+    return messages
+
+
+def transform_instruct_column_response(
+    row: dict[str, dict[str, str]],
+    instruction_column: str,
+    response_column: str,
+    content_key: str,
+    special_keys_mapping: dict[str, str] = dataclasses.field(default_factory=dict),
+) -> list[OpenAIChatMessage]:
+    messages: list[OpenAIChatMessage] = []
+    instruction = row[instruction_column]
+    responses = row[response_column]
+
+    # Get the first (and only) response from the list
+    response_dict = responses[0]
+    response_content = response_dict[content_key]
+    # Replace special keys
+    instruction = _replace_special_keys(instruction, special_keys_mapping)
+    response_content = _replace_special_keys(response_content, special_keys_mapping)
+    # Save
+    messages.append(OpenAIChatMessage(role="user", content=instruction))
+    messages.append(OpenAIChatMessage(role="assistant", content=response_content))
+    return messages
+
+
+def transform_instruct_msg_response(
+    row: dict[str, dict[str, str]],
+    instruction_column: str,
+    response_column: str,
+    role_key: str,
+    content_key: str,
+    special_keys_mapping: dict[str, str] = dataclasses.field(default_factory=dict),
+) -> list[OpenAIChatMessage] | None:
+    messages: list[OpenAIChatMessage] = []  # Initialize
+    # Get data
+    instruction = row[instruction_column]  # List of dict
+    responses = row[response_column]  # Single string
+    if (responses is None) or (len(instruction) > 1) or (role_key not in instruction[0]):
+        # We do not process rows that have more than one messages.
+        # This occurs in Dolphin-R1 reasoning, where instructions are
+        # sometimes part of the 'system' prompt instead of 'user' prompt.
+        # We handle misaligned data gracefully rather than crash.
+        return None
+    else:
+        instruction_content = instruction[0][content_key]
+        # Replace special keys
+        instruction_content = _replace_special_keys(instruction_content, special_keys_mapping)
+        responses = _replace_special_keys(responses, special_keys_mapping)
+        # Save
+        messages.append(OpenAIChatMessage(role="user", content=instruction_content))
+        messages.append(OpenAIChatMessage(role="assistant", content=responses))
+        return messages
+
+
 @dataclass
 class TransformAdapter:
     source: str
@@ -76,6 +196,7 @@ class TransformAdapter:
     assistant_value: str = ""
     system_value: str = ""
     content_key: str = ""
+    special_keys_mapping: dict[str, str] = dataclasses.field(default_factory=dict)
 
     # If specified, the key will be used to select the message with
     # best metric in multiple turn conversations
@@ -86,64 +207,42 @@ class TransformAdapter:
         row: dict[str, Any],
     ) -> list[OpenAIChatMessage]:
         if self.dataset_format == InputDatasetFormat.INSTRUCTION_RESPONSE:
-            messages = []
-            instruction = row[self.instruction_column]
-            response = row[self.response_column]
-            # Check data
-            if instruction is None or response is None:
-                return None  # Do not process rows with missing data
-            if self.filter_on_key:
-                best_completion = None
-                best_metric = -float("inf")  # TODO: Make this a config
-
-                for completion in response:
-                    if completion[self.filter_on_key] > best_metric:
-                        best_metric = completion[self.filter_on_key]
-                        best_completion = completion
-                response = best_completion[self.content_key]
-            messages.append(OpenAIChatMessage(role="user", content=instruction))
-            messages.append(OpenAIChatMessage(role="assistant", content=response))
-            return messages
+            return transform_instruction_response(
+                row,
+                self.instruction_column,
+                self.response_column,
+                self.filter_on_key,
+                self.content_key,
+                special_keys_mapping=self.special_keys_mapping,
+            )
         elif self.dataset_format == InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN:
-            messages = []
-            role_to_openai_role = {
-                self.user_value: "user",
-                self.assistant_value: "assistant",
-                self.system_value: "system",
-            }
-            conversation = row[self.conversation_column]
-            for conv in conversation:
-                role = role_to_openai_role[conv[self.role_key]]
-                messages.append(OpenAIChatMessage(role=role, content=conv[self.content_key]))
-            return messages
+            return transform_single_column_multi_turn(
+                row,
+                self.conversation_column,
+                self.role_key,
+                self.user_value,
+                self.assistant_value,
+                self.system_value,
+                self.content_key,
+                special_keys_mapping=self.special_keys_mapping,
+            )
         elif self.dataset_format == InputDatasetFormat.INSTRUCT_COLUMN_RESPONSE:
-            messages = []
-            instruction = row[self.instruction_column]
-            responses = row[self.response_column]
-
-            # Get the first (and only) response from the list
-            response_dict = responses[0]
-            response_content = response_dict[self.content_key]
-
-            messages.append(OpenAIChatMessage(role="user", content=instruction))
-            messages.append(OpenAIChatMessage(role="assistant", content=response_content))
-            return messages
+            return transform_instruct_column_response(
+                row,
+                self.instruction_column,
+                self.response_column,
+                self.content_key,
+                special_keys_mapping=self.special_keys_mapping,
+            )
         elif self.dataset_format == InputDatasetFormat.INSTRUCT_MSG_RESPONSE:
-            messages = []  # Initialize
-            # Get data
-            instruction = row[self.instruction_column]  # List of dict
-            responses = row[self.response_column]  # Single string
-            if (responses is None) or (len(instruction) > 1) or (self.role_key not in instruction[0]):
-                # We do not process rows that have more than one messages.
-                # This occurs in Dolphin-R1 reasoning, where instructions are
-                # sometimes part of the 'system' prompt instead of 'user' prompt.
-                # We handle misaligned data gracefully rather than crash.
-                return None
-            else:
-                instruction_content = instruction[0][self.content_key]
-                messages.append(OpenAIChatMessage(role="user", content=instruction_content))
-                messages.append(OpenAIChatMessage(role="assistant", content=responses))
-                return messages
+            return transform_instruct_msg_response(
+                row,
+                self.instruction_column,
+                self.response_column,
+                self.role_key,
+                self.content_key,
+                special_keys_mapping=self.special_keys_mapping,
+            )
         else:
             raise ValueError(f"Invalid dataset format: {self.dataset_format}")
 
@@ -154,7 +253,7 @@ class TransformAdapter:
 transform_templates: dict[str, TransformAdapter] = {}
 
 
-def register_adapter(adapter: TransformAdapter):
+def register_adapter(adapter: TransformAdapter) -> None:
     transform_templates[adapter.source] = adapter
 
 
@@ -361,5 +460,35 @@ register_adapter(
         dataset_format=InputDatasetFormat.INSTRUCTION_RESPONSE,
         instruction_column="question",
         response_column="model_reasoning",
+    )
+)
+
+register_adapter(
+    TransformAdapter(
+        source="open-thoughts/OpenThoughts3-1.2M",
+        dataset_format=InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN,
+        conversation_column="conversations",
+        role_key="from",
+        user_value="human",
+        assistant_value="gpt",
+        system_value="system",
+        content_key="value",
+        special_keys_mapping={
+            "<think>": "<|start_think|>",
+            "</think>": "<|end_think|>",
+        },
+    )
+)
+
+register_adapter(
+    TransformAdapter(
+        source="nvidia/Llama-Nemotron-Post-Training-Dataset-v1-SFT",
+        dataset_format=InputDatasetFormat.INSTRUCTION_RESPONSE,
+        instruction_column="input",
+        response_column="output",
+        special_keys_mapping={
+            "<think>": "<|start_think|>",
+            "</think>": "<|end_think|>",
+        },
     )
 )


### PR DESCRIPTION
## Description

Addresses #905

1. [New datasets]: Added `nvidia/Llama-Nemotron-Post-Training-Dataset-v1-SFT` and `open-thoughts/OpenThoughts3-1.2M` in `experiments/posttrain/instruction_datasets.py`
2. [New script]: `experiments/data_utils/count_dataset.py` Utils script that compiles the number of tokens in datasets and output as json
3. [Workflow] We have 2 scripts: one for processing dataset and one for training the new SFT model.
4. [Fix] In `marin/transform/conversation/transform_conversation.py`, we now do clean-up of local files. This is to prevent the disk on the cluster to be filled up causing issues system-wide.
5. [Fix] We added a `special_keys_mapping` arg in `marin/transform/conversation/adapters.py`. This is to allow easy replacement of different keywords with the same meaning across datasets. E.g., `<think>` vs `<think_start>` vs `|start_think|`

The other changes are by updates to auto-linter.