### PR TITLE
Handle empty glob in classification inference

### DIFF
--- a/marin/processing/classification/inference.py
+++ b/marin/processing/classification/inference.py
@@ -186,6 +186,10 @@ def run_inference(inference_config: InferenceConfig):
     logger.info(f"Running inference for {inference_config.input_path} to {inference_config.output_path}")
     filepaths, process_filepath_func = get_filepaths_and_process_filepath_func(inference_config)
 
+    if len(filepaths) == 0:
+        pattern = f"**/*.{inference_config.filetype}"
+        raise FileNotFoundError(f"No files found in {inference_config.input_path} with pattern {pattern}")
+
     input_path = inference_config.input_path
     output_path = inference_config.output_path
     responses = []

--- a/tests/test_classification_inference_empty_glob.py
+++ b/tests/test_classification_inference_empty_glob.py
@@ -1,0 +1,24 @@
+import pytest
+import ray
+
+from marin.processing.classification.inference import InferenceConfig, run_inference
+
+
+@pytest.fixture(autouse=True)
+def ray_start():
+    ray.init(namespace="marin", ignore_reinit_error=True, resources={"head_node": 1})
+    yield
+    ray.shutdown()
+
+
+def test_run_inference_raises_for_empty_glob(tmp_path):
+    config = InferenceConfig(
+        input_path=str(tmp_path),
+        output_path=str(tmp_path / "out"),
+        model_name="dummy",
+        model_type="fasttext",
+        attribute_name="test",
+    )
+
+    with pytest.raises(FileNotFoundError):
+        ray.get(run_inference.remote(config))


### PR DESCRIPTION
## Summary
- raise `FileNotFoundError` when `run_inference` receives no input files
- test that run_inference errors on empty input

## Testing
- `pre-commit run --files marin/processing/classification/inference.py tests/test_classification_inference_empty_glob.py`
- `make test` *(fails: huggingface.co blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68854bd014dc8331b727b7de4bfbf02e