### PR TITLE
write_infos before steps are launched (for crashes, etc)

### DIFF
--- a/marin/execution/executor.py
+++ b/marin/execution/executor.py
@@ -570,11 +570,11 @@ class Executor:
             logger.info(f"### Running {len(steps_to_run)} steps out of {len(self.steps)} ###")
 
         logger.info(f"### Launching {len(steps_to_run)} steps ###")
+        self.write_infos()
 
         self._run_steps(steps_to_run, dry_run=dry_run, force_run_failed=force_run_failed)
 
         logger.info("### Writing metadata ###")
-        self.write_infos()
 
         logger.info("### Waiting for all steps to finish ###")
         ray.get(list(self.refs.values()))

--- a/marin/execution/executor.py
+++ b/marin/execution/executor.py
@@ -569,12 +569,11 @@ class Executor:
         if steps_to_run != self.steps:
             logger.info(f"### Running {len(steps_to_run)} steps out of {len(self.steps)} ###")
 
-        logger.info(f"### Launching {len(steps_to_run)} steps ###")
+        logger.info("### Writing metadata ###")
         self.write_infos()
 
+        logger.info(f"### Launching {len(steps_to_run)} steps ###")
         self._run_steps(steps_to_run, dry_run=dry_run, force_run_failed=force_run_failed)
-
-        logger.info("### Writing metadata ###")
 
         logger.info("### Waiting for all steps to finish ###")
         ray.get(list(self.refs.values()))


### PR DESCRIPTION
we should write the infos before the experiment steps are launched in case something goes wrong.