### PR TITLE
Change linter config for backward compatability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,7 @@ extend-exclude = ["scripts/"]
 
 [tool.ruff.lint]
 select = ["A", "B", "E", "F", "I", "NPY", "RUF", "UP", "W"]
-ignore = ["F722", "B008", "UP015", "A005"]
+ignore = ["F722", "B008", "UP015", "A005", "I001"]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402", "F401"]


### PR DESCRIPTION
**Describe the bug**
Running `pre-commit run --all-files` passes on local but fails on Github CI.
Running `uv run pre-commit run --all-files` results in the same issue.

**Additional context**
When the command is run on local, ruff seems to sort the imports alphabetically. Github CI seem to be enforcing another behavior. While I have verified that the local version of ruff is the same, this behavior still occurs. We ignore "I001" to make local ruff compatible with the Github CI version
