### PR TITLE
Allow slice_count in TPUPodConfig to be a list of allowed counts

### DIFF
--- a/src/marin/resources.py
+++ b/src/marin/resources.py
@@ -184,7 +184,7 @@ class TpuPodConfig(ResourceConfig):
 
     tpu_type: str
     """Type of TPU to use, e.g. v4-128."""
-    slice_count: int = 1
+    slice_count: int | list[int] = 1
     """Number of TPU slices for training."""
 
     runtime_env: RuntimeEnv = dataclasses.field(default_factory=lambda: RuntimeEnv())
@@ -221,7 +221,9 @@ class TpuPodConfig(ResourceConfig):
 
         # Get the number of devices for this TPU configuration
         _, num_devices = get_tpu_type_and_chips(self.tpu_type)
-        return self.slice_count * num_devices
+
+        slice_count = self.slice_count if isinstance(self.slice_count, int) else max(self.slice_count)
+        return slice_count * num_devices
 
     def as_json_dict(self) -> dict:
         """Convert TpuPodConfig to a JSON-serializable dictionary."""


### PR DESCRIPTION
Addresses #470

This enables Marin to use Levanter's variable multislice functionality (https://github.com/stanford-crfm/levanter/pull/1126) by setting `slice_count` to a list of allowed sizes. Levanter will pick an allowed size based on how many slices are actually available.