### PR TITLE
Update docs links to use src directory

### DIFF
--- a/docs/explanations/evaluation.md
+++ b/docs/explanations/evaluation.md
@@ -26,7 +26,7 @@ The list of tasks we evaluate models on is configured in [`task_configs.py`](htt
 
 !!! note
 
-    See [`levanter_lm_eval_evaluator.py`](https://github.com/marin-community/marin/blob/main/marin/evaluation/evaluators/levanter_lm_eval_evaluator.py) for the default evaluator code. For other evaluators, including running `lm-evaluation-harness` on GPU, HELM, and Alpaca, see [evaluators](https://github.com/marin-community/marin/tree/main/marin/evaluation/evaluators).
+    See [`levanter_lm_eval_evaluator.py`](https://github.com/marin-community/marin/blob/main/src/marin/evaluation/evaluators/levanter_lm_eval_evaluator.py) for the default evaluator code. For other evaluators, including running `lm-evaluation-harness` on GPU, HELM, and Alpaca, see [evaluators](https://github.com/marin-community/marin/tree/main/marin/evaluation/evaluators).
 
 #### Evaluation Metrics
 

--- a/docs/explanations/executor.md
+++ b/docs/explanations/executor.md
@@ -27,7 +27,7 @@ config (at least the part of it that's explicitly versioned) and all its depende
 In the [hello world example](../tutorials/executor-101.md), we have two steps,
 generating data and compute statistics.
 
-See the documentation in [`executor.py`](https://github.com/marin-community/marin/blob/main/marin/execution/executor.py) for more details.
+See the documentation in [`executor.py`](https://github.com/marin-community/marin/blob/main/src/marin/execution/executor.py) for more details.
 
 ## Ray
 
@@ -60,7 +60,7 @@ number_of_restarts = ExecutorStep(
 )
 ```
 
-Finally, to launch an experiment, use [`ray_run.py`](https://github.com/marin-community/marin/blob/main/marin/run/ray_run.py), which
+Finally, to launch an experiment, use [`ray_run.py`](https://github.com/marin-community/marin/blob/main/src/marin/run/ray_run.py), which
 launches jobs to the Ray cluster:
 
 ```bash

--- a/docs/explanations/speedrun-flops-accounting.md
+++ b/docs/explanations/speedrun-flops-accounting.md
@@ -20,7 +20,7 @@ where:
 
 ## Model FLOPs
 
-We also track model FLOPs, which is the total number of FLOPs required to train the model. The definition/code for this can be found in the [compute_model_flops()](https://github.com/marin-community/marin/blob/main/marin/speedrun/speedrun.py#L116) function.
+We also track model FLOPs, which is the total number of FLOPs required to train the model. The definition/code for this can be found in the [compute_model_flops()](https://github.com/marin-community/marin/blob/main/src/marin/speedrun/speedrun.py#L116) function.
 
 
 Before running a speedrun, we can use the model FLOPs to give you a rough estimate of the estimated training HW FLOPs, by computing the ratio of model FLOPs to the assumed model FLOPs utilization (MFU). We plug in a couple of plausible MFU values (0.2 and 0.5) to give you a rough sense of how many hardware FLOPs your training run will use.
@@ -29,4 +29,4 @@ $$
 F_{total} = \frac{F_{model}}{MFU}
 $$
 
-This estimate is shown both when calling [speedrun_config.print_run_info()](https://github.com/marin-community/marin/blob/main/marin/speedrun/speedrun.py#L76), which you can call before running training, and is also logged when running the speedrun (i.e., training). It can be used to guide your choice of model, training hyperparameters, and hardware configuration.
+This estimate is shown both when calling [speedrun_config.print_run_info()](https://github.com/marin-community/marin/blob/main/src/marin/speedrun/speedrun.py#L76), which you can call before running training, and is also logged when running the speedrun (i.e., training). It can be used to guide your choice of model, training hyperparameters, and hardware configuration.

--- a/docs/reports/markdownified-datasets.md
+++ b/docs/reports/markdownified-datasets.md
@@ -13,7 +13,7 @@ This dataset collection consists of several large-scale text corpora that have b
 
 ## Processing Methodology
 
-These datasets were processed using our [custom fork of Resiliparse](https://github.com/stanford-crfm/chatnoir-resiliparse) which simplified the raw HTML DOM, the simplified DOM was then processed by our [custom implementation](https://github.com/marin-community/marin/blob/main/marin/markdown/markdown.py#L145-L650) of [Markdownify](https://github.com/matthewwithanm/python-markdownify). The exact modifications and enhancements made to the [original Resiliparse](https://github.com/chatnoir-eu/chatnoir-resiliparse) are documented in the next section, the processing pipeline appears to have:
+These datasets were processed using our [custom fork of Resiliparse](https://github.com/stanford-crfm/chatnoir-resiliparse) which simplified the raw HTML DOM, the simplified DOM was then processed by our [custom implementation](https://github.com/marin-community/marin/blob/main/src/marin/markdown/markdown.py#L145-L650) of [Markdownify](https://github.com/matthewwithanm/python-markdownify). The exact modifications and enhancements made to the [original Resiliparse](https://github.com/chatnoir-eu/chatnoir-resiliparse) are documented in the next section, the processing pipeline appears to have:
 
 1. Extracted text from various sources (Wikipedia, Ar5iv, Stack Exchange)
 2. Simplified the raw HTML DOM through our custom fork of Resiliparse

--- a/docs/tutorials/submitting-speedrun.md
+++ b/docs/tutorials/submitting-speedrun.md
@@ -120,7 +120,7 @@ Before you get started, you will need the following:
 
     To see examples of other speedruns and configurations, check out the [speedrun directory](https://github.com/marin-community/marin/tree/main/experiments/speedrun). You can also [add new optimizers](https://github.com/marin-community/marin/blob/main/docs/tutorials/add-optimizer.md), change learning rate schedules, play with hyperparameters, etc.
 
-3. Before running your speedrun, you may find it helpful to call [speedrun_config.print_run_info()](https://github.com/marin-community/marin/blob/main/marin/speedrun/speedrun.py#L76) to see the estimated training HW FLOPs, model FLOPs, model size, and your speedrun configs displayed. This will help you sanity-check your run, and also can be helpful in estimating the resources needed for your run.
+3. Before running your speedrun, you may find it helpful to call [speedrun_config.print_run_info()](https://github.com/marin-community/marin/blob/main/src/marin/speedrun/speedrun.py#L76) to see the estimated training HW FLOPs, model FLOPs, model size, and your speedrun configs displayed. This will help you sanity-check your run, and also can be helpful in estimating the resources needed for your run.
 
 4. Set relevant environment variables needed for the run:
 


### PR DESCRIPTION
## Description
Some doc links were broken in [the move to the `/src/` layout](https://github.com/marin-community/marin/pull/1453). This updates all the `main/blob/marin/*` links in `docs/`.