### PR TITLE
Bump levanter and lm-eval versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "pyarrow", # # Only needed by Fileprovider in inference.py
     # We have levanter deps for now. @TODO :: Remove them
     "multiprocess==0.70.16",
-    "levanter>=1.2.dev1359",
+    "levanter>=1.2.dev1500",
     "haliax>=1.4.dev381",
     "sentencepiece",
     "lz4",

--- a/src/marin/evaluation/evaluators/levanter_tpu_evaluator.py
+++ b/src/marin/evaluation/evaluators/levanter_tpu_evaluator.py
@@ -19,11 +19,7 @@ class LevanterTpuEvaluator(Evaluator, ABC):
     # pip packages to install for running levanter's eval_harness on TPUs
     DEFAULT_PIP_PACKAGES: ClassVar[list[Dependency]] = [
         Dependency(name="levanter==1.2.dev1359"),
-        Dependency(
-            name=(
-                "git+https://github.com/stanford-crfm/lm-evaluation-harness.git@b1b56a3694ba53534da8445ad9a736e0887c65a5"
-            )
-        ),
+        Dependency(name=("lm-eval@git+https://github.com/stanford-crfm/lm-evaluation-harness.git")),
     ]
 
     # Where to store checkpoints, cache inference results, etc.


### PR DESCRIPTION
## Description

Fixes #(issue number)
Bumping levanter fixes the issue of the `ImportError` of `levanter.layers`. Bumping the lm-eval will allow us to run the `mmlu_sl` and `mmlu_sl_verb` tasks.


## Checklist

- [ ] You ran `pre-commit run --all-files` to lint your code
- [ ] You ran 'pytest' to test your code
- [ ] Delete this checklist