### PR TITLE
Add chunking support for inference

### DIFF
--- a/tests/test_chunk_text.py
+++ b/tests/test_chunk_text.py
@@ -8,6 +8,7 @@ def test_chunk_text_char_strategy():
     chunks = chunk_text(example, ChunkStrategy.CHAR, chunk_size=10)
     assert [c["text"] for c in chunks] == ["abcdefghij", "klmnopqrst", "uvwxyz"]
     assert [c["id"] for c in chunks] == ["doc_0", "doc_1", "doc_2"]
+    assert [c["metadata"]["source_document_id"] for c in chunks] == ["doc", "doc", "doc"]
 
 
 def test_chunk_text_paragraph_strategy():
@@ -15,6 +16,7 @@ def test_chunk_text_paragraph_strategy():
     chunks = chunk_text(example, ChunkStrategy.PARAGRAPH)
     assert [c["text"] for c in chunks] == ["para1", "para2", "para3"]
     assert [c["id"] for c in chunks] == ["doc_0", "doc_1", "doc_2"]
+    assert [c["metadata"]["source_document_id"] for c in chunks] == ["doc", "doc", "doc"]
 
 
 @pytest.mark.parametrize("strategy", [ChunkStrategy.CHAR, ChunkStrategy.PARAGRAPH])


### PR DESCRIPTION
## Summary
Goal: I want to prepare for chunking a source document into multiple chunks. The motivation is given some long document, it should be chunked into multiple documents so that we can do source-rephrasing. The reason we can't have the entire document in the rephrasing is because 1. might not fit in the LLM context window 2. LLM rephrasing degrades as we increase the chunk size.

- allow chunking inputs by characters or paragraphs before inference
- use `ChunkStrategy` StrEnum instead of raw strings
- add tests for new `chunk_text` utility

## Testing
- `pre-commit run --files src/marin/generation/inference.py tests/test_chunk_text.py`
- `PYTHONPATH=src pytest tests/test_chunk_text.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9024a4a4083288cb67dff8883095f