### PR TITLE
docs: add macOS build instructions for SentencePiece dependencies

### DIFF
--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -9,6 +9,11 @@ Before you begin, ensure you have the following installed:
 - Python 3.11 or higher
 - uv (Python package manager)
 - Git
+- On macOS, install additional build tools for SentencePiece:
+
+    ```bash
+    brew install cmake pkg-config coreutils
+    ```
 - A [Weights & Biases](https://wandb.ai) account for experiment tracking (optional but recommended)
 
 This document focuses on basic setup and usage of Marin.


### PR DESCRIPTION
## Summary
- mention required `cmake`, `pkg-config`, and `coreutils` for macOS builds of SentencePiece

## Testing
- `uv run pre-commit run --files docs/tutorials/installation.md`
- `uv run pytest` *(fails: access to gated repos)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7e26aef48331a9c419bb8684e977