### PR TITLE
Add fsspec dependency to quality dedup group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,6 +248,7 @@ quality_dedup_consolidate = [
     "huggingface_hub",
     "datasets",
     "transformers",
+    "fsspec>=2025.3.0",
 ]
 tokenize_train = [
     "multiprocess==0.70.16",


### PR DESCRIPTION
## Summary
- add `fsspec>=2025.3.0` to the `quality_dedup_consolidate` dependency group in `pyproject.toml`

## Testing
- `pre-commit run --files pyproject.toml`


------
https://chatgpt.com/codex/tasks/task_e_68adf829e1988331938f56371adcad27