### PR TITLE
Test performance improvements.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "lz4",
     "wandb<=0.19.9",
     "openai",
+    "fasteners>=0.19",
 ]
 
 [dependency-groups]
@@ -47,6 +48,7 @@ test = [
     "pytest>=8.3.2",
     "pytest-asyncio",
     "pytest-xdist",
+    "pytest-timeout",
     "pytest-cov",
     # need this for integration tests
     "pip",
@@ -335,3 +337,6 @@ exclude = [
 
 [tool.uv_build]
 package-dir = "src"
+
+[tool.pytest.ini_options]
+timeout = 300

--- a/src/marin/core/runtime.py
+++ b/src/marin/core/runtime.py
@@ -11,7 +11,13 @@ import ray
 from ray import ObjectRef
 from ray.remote_function import RemoteFunction
 
-from marin.utils import fsspec_exists, fsspec_get_curr_subdirectories, fsspec_glob, fsspec_mkdirs, rebase_file_path
+from marin.utils import (
+    fsspec_exists,
+    fsspec_get_curr_subdirectories,
+    fsspec_glob,
+    fsspec_mkdirs,
+    rebase_file_path,
+)
 
 logger = logging.getLogger("ray")
 
@@ -19,9 +25,6 @@ logger = logging.getLogger("ray")
 @dataclass
 class RayConfig:
     address: str | None = None
-
-    def initialize(self):
-        ray.init(address=self.address)
 
 
 def cached_or_construct_output(success_suffix="success", verbose=True):

--- a/src/marin/execution/executor.py
+++ b/src/marin/execution/executor.py
@@ -1082,6 +1082,7 @@ def executor_main(config: ExecutorMainConfig, steps: list[ExecutorStep], descrip
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
     time_in = time.time()
+
     ray.init(
         namespace="marin",
         ignore_reinit_error=True,

--- a/src/marin/markdown/markdown.py
+++ b/src/marin/markdown/markdown.py
@@ -285,8 +285,8 @@ class MyMarkdownConverter(MarkdownConverter):
 
     def _compute_num_cols(self, el):
         length_of_cells = 0
-        prev_td = el.findAll("td", recursive=False)
-        prev_th = el.findAll("th", recursive=False)
+        prev_td = el.find_all("td", recursive=False)
+        prev_th = el.find_all("th", recursive=False)
         length = len(prev_td) + len(prev_th)
         for td in prev_td:
             if "colspan" in td.attrs:
@@ -300,8 +300,8 @@ class MyMarkdownConverter(MarkdownConverter):
             _count = 1
             while prev:
                 if prev.name == "tr":
-                    prev_td = prev.findAll("td", recursive=False)
-                    prev_th = prev.findAll("th", recursive=False)
+                    prev_td = prev.find_all("td", recursive=False)
+                    prev_th = prev.find_all("th", recursive=False)
                     length = len(prev_td) + len(prev_th)
                     for td in prev_td:
                         if "colspan" in td.attrs:
@@ -320,7 +320,7 @@ class MyMarkdownConverter(MarkdownConverter):
             count = 1
             while prev:
                 if prev.name == "tr":
-                    prev_td = prev.findAll("td", recursive=False)
+                    prev_td = prev.find_all("td", recursive=False)
                     i = 0
                     for td in prev_td:
                         if "rowspan" in td.attrs and _try_convert_int(td["rowspan"], 1) > count:
@@ -329,7 +329,7 @@ class MyMarkdownConverter(MarkdownConverter):
                             i += _try_convert_int(td["colspan"], 1)
                         else:
                             i += 1
-                    prev_th = prev.findAll("th", recursive=False)
+                    prev_th = prev.find_all("th", recursive=False)
                     i = 0
                     for th in prev_th:
                         if "rowspan" in th.attrs and _try_convert_int(th["rowspan"], 1) > count:

--- a/src/marin/processing/classification/dedupe.py
+++ b/src/marin/processing/classification/dedupe.py
@@ -308,9 +308,7 @@ def dolma_dedup(
             node_id=ray.get_runtime_context().get_node_id(),
             soft=False,
         ),
-        "runtime_env": {
-            "pip": ["dolma", "transformers==4.44.0"],
-        },
+        "runtime_env": {"uv": {"packages": ["dolma", "transformers==4.44.0"]}},
     }
     bloom_filter_file = "decontaminated_bloom_filter.bin"
     remote_bloom_filter_path = os.path.join(bloom_filter_path, bloom_filter_file)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
 import os
+import sys
 import time
+from pathlib import Path
 
+import fasteners
 import pytest
 import ray
+from pydantic import BaseModel
 
 from marin.evaluation.evaluators.evaluator import ModelConfig
 
@@ -14,6 +18,11 @@ default_generation_params = {"max_tokens": 16}
 
 DEFAULT_BUCKET_NAME = "marin-us-east5"
 DEFAULT_DOCUMENT_PATH = "documents/test-document-path"
+
+
+class WorkerConfig(BaseModel):
+    worker_count: int = 0
+    cluster_address: str | None = None
 
 
 @pytest.fixture(scope="module")
@@ -56,14 +65,82 @@ def current_date_time():
     return formatted_time
 
 
-@pytest.fixture(scope="module")
-def ray_tpu_cluster():
-    print("Starting RAY", os.getenv("START_RAY_TPU_CLUSTER"), os.getenv("START_RAY_CPU_CLUSTER"))
-    if os.getenv("START_RAY_TPU_CLUSTER") == "true":
-        ray.init(resources={"TPU": 8, "TPU-v6e-8-head": 1}, num_cpus=120, ignore_reinit_error=True)
-    elif os.getenv("START_RAY_CPU_CLUSTER") == "true":
-        ray.init(num_cpus=8, ignore_reinit_error=True)
-    else:
-        ray.init(num_cpus=8, ignore_reinit_error=True)
+@pytest.fixture(scope="session")
+def ray_tpu_cluster(tmp_path_factory, worker_id):
+    root_tmp_dir = tmp_path_factory.getbasetemp().parent
+    config_file = Path(root_tmp_dir) / "ray_cluster_config.json"
+    lock_file = Path(root_tmp_dir) / "ray_cluster_config.lock"
+    rw_lock = fasteners.InterProcessReaderWriterLock(str(lock_file))
+
+    def _start_cluster():
+        print(f"Worker {worker_id} starting Ray cluster...", file=sys.stderr)
+
+        if os.getenv("START_RAY_TPU_CLUSTER") == "true":
+            ray.init(
+                namespace="marin",
+                resources={"TPU": 8, "TPU-v6e-8-head": 1, "head_node": 1},
+                num_cpus=120,
+                ignore_reinit_error=True,
+            )
+        elif os.getenv("START_RAY_CPU_CLUSTER") == "true":
+            ray.init(namespace="marin", num_cpus=8, resources={"head_node": 1}, ignore_reinit_error=True)
+        else:
+            ray.init(namespace="marin", num_cpus=8, resources={"head_node": 1}, ignore_reinit_error=True)
+        return ray.worker._global_node.address
+
+    def _init_worker():
+        with rw_lock.write_lock():
+            if not config_file.exists():
+                # First worker to acquire lock - initialize cluster
+                config = WorkerConfig(cluster_address=_start_cluster(), worker_count=1)
+                with open(config_file, "w") as f:
+                    f.write(config.model_dump_json())
+                return config
+
+            # Config file exists, increment worker count and connect to existing cluster
+            with open(config_file, "r") as f:
+                content = f.read().strip()
+            current_config = WorkerConfig.model_validate_json(content)
+            current_config.worker_count += 1
+
+            # Connect to the existing cluster
+            ray.init(
+                address=current_config.cluster_address,
+                resources={"head_node": 1},
+                namespace="marin",
+                ignore_reinit_error=True,
+            )
+
+            print(
+                f"Worker {worker_id} connected to cluster at {current_config.cluster_address}, "
+                f"worker count {current_config.worker_count}",
+                file=sys.stderr,
+            )
+            with open(config_file, "w") as f:
+                f.write(current_config.model_dump_json())
+
+            return current_config
+
+    def _shutdown_worker():
+        with rw_lock.write_lock():
+            with open(config_file, "r") as f:
+                content = f.read().strip()
+            current_config = WorkerConfig.model_validate_json(content)
+            current_config.worker_count -= 1
+            print(
+                f"Worker {worker_id} shutting down... worker count {current_config.worker_count}",
+                file=sys.stderr,
+            )
+            if current_config.worker_count == 0:
+                # Delete file under lock
+                config_file.unlink()
+                print("Last worker shutting down Ray cluster...", file=sys.stderr)
+                ray.shutdown()
+            else:
+                with open(config_file, "w") as f:
+                    f.write(current_config.model_dump_json())
+
+    config = _init_worker()
+    os.environ["RAY_ADDRESS"] = config.cluster_address
     yield
-    ray.shutdown()
+    _shutdown_worker()

--- a/tests/deduplication/test_dedupe.py
+++ b/tests/deduplication/test_dedupe.py
@@ -11,13 +11,6 @@ BASE_INPUT_DIR = "gs://marin-us-east1/documents/test-data/deduplication"
 BASE_ATTRIBUTE_OUTPUT_DIR = "gs://marin-us-east1/attributes/test-data/deduplication"
 
 
-@pytest.fixture(scope="module", autouse=True)
-def ray_start():
-    ray.init(namespace="marin", ignore_reinit_error=True, resources={"head_node": 1})
-    yield
-    ray.shutdown()  # teardown
-
-
 @pytest.fixture
 def sample_documents():
     """Create sample documents with duplicates for testing"""

--- a/tests/test_classification_inference_empty_glob.py
+++ b/tests/test_classification_inference_empty_glob.py
@@ -4,14 +4,7 @@ import ray
 from marin.processing.classification.inference import InferenceConfig, run_inference
 
 
-@pytest.fixture(autouse=True)
-def ray_start():
-    ray.init(namespace="marin", ignore_reinit_error=True, resources={"head_node": 1})
-    yield
-    ray.shutdown()
-
-
-def test_run_inference_raises_for_empty_glob(tmp_path):
+def test_run_inference_raises_for_empty_glob(tmp_path, ray_tpu_cluster):
     config = InferenceConfig(
         input_path=str(tmp_path),
         output_path=str(tmp_path / "out"),

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -5,18 +5,10 @@ import tempfile
 from pathlib import Path
 
 import pytest
-import ray
 
 from tests.test_utils import parameterize_with_configs
 
 logger = logging.getLogger(__name__)
-
-
-@pytest.fixture
-def ray_start():
-    ray.init(namespace="marin", ignore_reinit_error=True)
-    yield
-    ray.shutdown()  # teardown
 
 
 marin_root = Path(__file__).parent.parent

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -29,11 +29,10 @@ from marin.execution.executor_step_status import (
 )
 
 
+# Re-use the shared Ray TPU cluster for tests
 @pytest.fixture(scope="module", autouse=True)
-def ray_start():
-    ray.init(namespace="marin", ignore_reinit_error=True, resources={"head_node": 1})
+def ray_start(ray_tpu_cluster):
     yield
-    ray.shutdown()  # teardown
 
 
 @dataclass(frozen=True)
@@ -211,89 +210,94 @@ def test_force_run_failed():
     cleanup_log(log)
 
 
-def test_status_actor():
-    """Test the status actor that keeps track of statuses."""
+@pytest.mark.skipif(
+    lambda: int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", "0")) > 1,
+    reason="Ray can't handle multiple clusters.",
+)
+def test_status_actor_one_executor_waiting_for_another():
+    # Test when 2 experiments have a step in common and one waits for another to finish
+    with tempfile.NamedTemporaryFile() as file:
+        with open(file.name, "w") as f:
+            f.write("0")
 
-    def test_one_executor_waiting_for_another():
-        # Test when 2 experiments have a step in common and one waits for another to finish
-        with tempfile.NamedTemporaryFile() as file:
-            with open(file.name, "w") as f:
-                f.write("0")
+        @dataclass
+        class Config:
+            number: int
+            path: str
+            wait: int
+            input_path: str
 
-            @dataclass
-            class Config:
-                number: int
-                path: str
-                wait: int
-                input_path: str
+        def fn(config: Config):
+            time.sleep(config.wait)
+            with open(config.path, "r") as f:
+                number = int(f.read())
+            with open(config.path, "w") as f:
+                f.write(str(number + config.number))
 
-            def fn(config: Config):
-                time.sleep(config.wait)
-                with open(config.path, "r") as f:
-                    number = int(f.read())
-                with open(config.path, "w") as f:
-                    f.write(str(number + config.number))
+        a = ExecutorStep(name="a", fn=fn, config=Config(versioned(1), file.name, 2, ""))
+        b = ExecutorStep(name="b", fn=fn, config=Config(versioned(2), file.name, 0, output_path_of(a)))
 
-            a = ExecutorStep(name="a", fn=fn, config=Config(versioned(1), file.name, 2, ""))
-            b = ExecutorStep(name="b", fn=fn, config=Config(versioned(2), file.name, 0, output_path_of(a)))
+        @ray.remote
+        def run_fn(executor, steps):
+            executor.run(steps=steps)
 
-            @ray.remote
-            def run_fn(executor, steps):
-                executor.run(steps=steps)
+        with tempfile.TemporaryDirectory(prefix="executor-") as temp_dir:
+            executor1 = create_executor(temp_dir)
+            executor2 = create_executor(temp_dir)
 
-            with tempfile.TemporaryDirectory(prefix="executor-") as temp_dir:
-                executor1 = create_executor(temp_dir)
-                executor2 = create_executor(temp_dir)
+            run1 = run_fn.remote(executor1, [a])
+            run2 = run_fn.remote(executor2, [a, b])
 
-                run1 = run_fn.remote(executor1, [a])
-                run2 = run_fn.remote(executor2, [a, b])
+            ray.get([run1, run2])
 
-                ray.get([run1, run2])
-
-                with open(file.name, "r") as f:
-                    assert int(f.read()) == 3
-
-    test_one_executor_waiting_for_another()
-
-    def test_multiple_steps_race_condition():
-        # Test when there are many steps trying to run simultaneously.
-        # Open a temp dir, make a step that write a random file in that temp dir. Make 10 of these steps and run them
-        # in parallel. Check that only one of them runs
-        with tempfile.TemporaryDirectory(prefix="output_path") as output_path:
-
-            @dataclass
-            class Config:
-                path: str
-
-            def fn(config: Config):
-                random_str = str(random.randint(0, 1000))
-                time.sleep(2)
-                with open(os.path.join(config.path, random_str), "w") as f:
-                    f.write("1")
-
-            @ray.remote
-            def run_fn(executor, steps):
-                executor.run(steps=steps)
-
-            with tempfile.TemporaryDirectory(prefix="executor-") as temp_dir:
-
-                executor_refs = []
-                for _ in range(10):
-                    executor = create_executor(temp_dir)
-                    executor_refs.append(
-                        run_fn.remote(executor, [ExecutorStep(name="step", fn=fn, config=Config(output_path))])
-                    )
-
-                ray.get(executor_refs)
-
-                files = os.listdir(output_path)
-                print(files)
-                assert len(files) == 1
-                os.unlink(os.path.join(output_path, files[0]))
-
-    test_multiple_steps_race_condition()
+            with open(file.name, "r") as f:
+                assert int(f.read()) == 3
 
 
+@pytest.mark.skipif(
+    lambda: int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", "0")) > 1,
+    reason="Ray can't handle multiple clusters.",
+)
+def test_status_actor_multiple_steps_race_condition():
+    # Test when there are many steps trying to run simultaneously.
+    # Open a temp dir, make a step that write a random file in that temp dir. Make 10 of these steps and run them
+    # in parallel. Check that only one of them runs
+    with tempfile.TemporaryDirectory(prefix="output_path") as output_path:
+
+        @dataclass
+        class Config:
+            path: str
+
+        def fn(config: Config):
+            random_str = str(random.randint(0, 1000))
+            time.sleep(2)
+            with open(os.path.join(config.path, random_str), "w") as f:
+                f.write("1")
+
+        @ray.remote
+        def run_fn(executor, steps):
+            executor.run(steps=steps)
+
+        with tempfile.TemporaryDirectory(prefix="executor-") as temp_dir:
+            executor_refs = []
+            for _ in range(10):
+                executor = create_executor(temp_dir)
+                executor_refs.append(
+                    run_fn.remote(executor, [ExecutorStep(name="step", fn=fn, config=Config(output_path))])
+                )
+
+            ray.get(executor_refs)
+
+            files = os.listdir(output_path)
+            print(files)
+            assert len(files) == 1
+            os.unlink(os.path.join(output_path, files[0]))
+
+
+@pytest.mark.skipif(
+    lambda: int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", "0")) > 1,
+    reason="Overloaded cluster makes this test flaky.",
+)
 def test_parallelism():
     """Make sure things that parallel execution is possible."""
     log = create_log()

--- a/tests/test_integration_test.py
+++ b/tests/test_integration_test.py
@@ -3,18 +3,10 @@ import subprocess
 import tempfile
 
 import pytest
-import ray
-
-
-@pytest.fixture
-def ray_start():
-    ray.init(namespace="marin")  # setup
-    yield
-    ray.shutdown()  # teardown
 
 
 @pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip this test in CI, since we run it as a separate worflow.")
-def test_integration_test_run():
+def test_integration_test_run(ray_tpu_cluster):
     MARIN_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
     """Test the dry runs of experiment scripts"""
     # Emulate running tests/integration_test.py on the cmdline

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,15 +10,7 @@ import ray
 from marin.utils import asdict_excluding, remove_tpu_lockfile_on_exit
 
 
-def setup_module(module):
-    ray.init(namespace="marin")
-
-
-def teardown_module(module):
-    ray.shutdown()
-
-
-def test_remove_tpu_lockfile_on_exit_works_with_ray_remote():
+def test_remove_tpu_lockfile_on_exit_works_with_ray_remote(ray_tpu_cluster):
     @ray.remote
     @remove_tpu_lockfile_on_exit
     def test_fn():

--- a/uv.lock
+++ b/uv.lock
@@ -6641,6 +6641,7 @@ dependencies = [
     { name = "datasets" },
     { name = "deepdiff" },
     { name = "draccus" },
+    { name = "fasteners" },
     { name = "gcsfs" },
     { name = "google-api-python-client" },
     { name = "google-cloud-storage" },
@@ -6810,6 +6811,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "readabilipy" },
     { name = "readability-lxml" },
@@ -6855,6 +6857,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
 ]
 transform-test-deps = [
@@ -6889,6 +6892,7 @@ requires-dist = [
     { name = "dolma", marker = "extra == 'quality-dedup-consolidate'" },
     { name = "draccus", specifier = ">=0.11.5" },
     { name = "einops", marker = "extra == 'post-training'" },
+    { name = "fasteners", specifier = ">=0.19" },
     { name = "fastparquet", marker = "extra == 'crawl'" },
     { name = "fastparquet", marker = "extra == 'download-transform'" },
     { name = "fasttext", marker = "extra == 'quality-dedup-consolidate'" },
@@ -7012,6 +7016,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "readabilipy" },
     { name = "readability-lxml" },
@@ -7055,6 +7060,7 @@ test = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
 ]
 transform-test-deps = [
@@ -9422,7 +9428,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux' or (extra == 'extra-5-marin-crawl' and extra == 'extra-5-marin-download-transform') or (extra == 'extra-5-marin-crawl' and extra == 'extra-5-marin-post-training') or (extra == 'extra-5-marin-crawl' and extra == 'group-5-marin-dev') or (extra == 'extra-5-marin-crawl' and extra == 'group-5-marin-transform-test-deps')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/93/a201a12d3ec1caa8c6ac34c1c2f9eeb696b886f0c36ff23c638b46603bd0/nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:9fd4584468533c61873e5fda8ca41bac3a38bcb2d12350830c69b0a96a7e4def", size = 570523509, upload-time = "2024-10-25T19:53:03.148Z" },
@@ -9458,7 +9464,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or (extra == 'extra-5-marin-crawl' and extra == 'extra-5-marin-download-transform') or (extra == 'extra-5-marin-crawl' and extra == 'extra-5-marin-post-training') or (extra == 'extra-5-marin-crawl' and extra == 'group-5-marin-dev') or (extra == 'extra-5-marin-crawl' and extra == 'group-5-marin-transform-test-deps')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/37/c50d2b2f2c07e146776389e3080f4faf70bcc4fa6e19d65bb54ca174ebc3/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d16079550df460376455cba121db6564089176d9bac9e4f360493ca4741b22a6", size = 200164144, upload-time = "2024-11-20T17:40:58.288Z" },
@@ -9494,9 +9500,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux' or (extra == 'extra-5-marin-crawl' and extra == 'extra-5-marin-download-transform') or (extra == 'extra-5-marin-crawl' and extra == 'extra-5-marin-post-training') or (extra == 'extra-5-marin-crawl' and extra == 'group-5-marin-dev') or (extra == 'extra-5-marin-crawl' and extra == 'group-5-marin-transform-test-deps')" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux' or (extra == 'extra-5-marin-crawl' and extra == 'extra-5-marin-download-transform') or (extra == 'extra-5-marin-crawl' and extra == 'extra-5-marin-post-training') or (extra == 'extra-5-marin-crawl' and extra == 'group-5-marin-dev') or (extra == 'extra-5-marin-crawl' and extra == 'group-5-marin-transform-test-deps')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or (extra == 'extra-5-marin-crawl' and extra == 'extra-5-marin-download-transform') or (extra == 'extra-5-marin-crawl' and extra == 'extra-5-marin-post-training') or (extra == 'extra-5-marin-crawl' and extra == 'group-5-marin-dev') or (extra == 'extra-5-marin-crawl' and extra == 'group-5-marin-transform-test-deps')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/17/dbe1aa865e4fdc7b6d4d0dd308fdd5aaab60f939abfc0ea1954eac4fb113/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0ce237ef60acde1efc457335a2ddadfd7610b892d94efee7b776c64bb1cac9e0", size = 157833628, upload-time = "2024-10-01T17:05:05.591Z" },
@@ -9511,7 +9517,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or (extra == 'extra-5-marin-crawl' and extra == 'extra-5-marin-download-transform') or (extra == 'extra-5-marin-crawl' and extra == 'extra-5-marin-post-training') or (extra == 'extra-5-marin-crawl' and extra == 'group-5-marin-dev') or (extra == 'extra-5-marin-crawl' and extra == 'group-5-marin-transform-test-deps')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/eb/6681efd0aa7df96b4f8067b3ce7246833dd36830bb4cec8896182773db7d/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d25b62fb18751758fe3c93a4a08eff08effedfe4edf1c6bb5afd0890fe88f887", size = 216451147, upload-time = "2024-11-20T17:44:18.055Z" },
@@ -10786,6 +10792,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/99/668cade231f434aaa59bbfbf49469068d2ddd945000621d3d165d2e7dd7b/pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2", size = 69432, upload-time = "2025-06-12T10:47:47.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/16/4ea354101abb1287856baa4af2732be351c7bee728065aed451b678153fd/pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5", size = 24644, upload-time = "2025-06-12T10:47:45.932Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]
@@ -13927,7 +13945,7 @@ name = "triton"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools" },
+    { name = "setuptools", marker = "sys_platform == 'linux' or (extra == 'extra-5-marin-crawl' and extra == 'extra-5-marin-download-transform') or (extra == 'extra-5-marin-crawl' and extra == 'extra-5-marin-post-training') or (extra == 'extra-5-marin-crawl' and extra == 'group-5-marin-dev') or (extra == 'extra-5-marin-crawl' and extra == 'group-5-marin-transform-test-deps')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/a9/549e51e9b1b2c9b854fd761a1d23df0ba2fbc60bd0c13b489ffa518cfcb7/triton-3.3.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b74db445b1c562844d3cfad6e9679c72e93fdfb1a90a24052b03bb5c49d1242e", size = 155600257, upload-time = "2025-05-29T23:39:36.085Z" },


### PR DESCRIPTION
## Description

Fix tests that were broken under xdist. uv run pytest -n 4 (or auto) now works as expected.

* Initialize a single Ray cluster across tests.

This re-uses the cluster across multiple testing jobs. There's a tradeoff that a previous module might leave Ray in a dirty state, but we should be able to rely on Ray's own isolation to deal with this.  When running with xdist, construct the cluster on worker 0 (or master if no parallelism is enabled). This reduces the risk of "multiple Ray clusters found" race condition when initializing the Ray client.

We need to disable 3 tests in xdist mode due to Ray weirdness.

* Switch runtime initialization for dedupe to use `uv` for initialization. i

This speeds up duplicate tests significantly and is ~50% faster to initialize. It's still slow.

* Fix deprecated findAll -> find_all

