### PR TITLE
Add script to kill any processes lingering on a TPU node.

### DIFF
--- a/src/marin/run/clean_ray_tpus.py
+++ b/src/marin/run/clean_ray_tpus.py
@@ -19,31 +19,54 @@ import json
 import os
 import re
 import subprocess
+import time
+
+import ray
 
 
-def tpus_per_node(tpu_type: str) -> int:
+def parse_tpu_type(tpu_type: str) -> tuple[int, int]:
     """Return the number of TPU chips per node for a given TPU type."""
     if tpu_type in {"v4-8", "v5p-8"}:
-        return 4
+        return 4, 1
     match = re.search(r"-(\d+)$", tpu_type)
     if not match:
         raise ValueError(f"Cannot parse TPU type: {tpu_type}")
     chips = int(match.group(1))
-    if chips > 8:
-        raise ValueError("Only single tpu nodes are supported with the CLI")
-    return chips
+    assert chips > 0
+    assert chips % 5 > 0
+    assert chips // 4 > 0
+
+    # TPU names don't make any sense
+    return chips % 5, chips // 8
 
 
-def cleanup_tpu_process(target_pid: int):
+@ray.remote
+class GangSchedulingActor:
+    def __init__(self, num_workers: int):
+        self.count = 0
+        self.num_workers = num_workers
+
+    def wait_for_everyone(self):
+        self.count += 1
+        while True:
+            if self.count >= self.num_workers:
+                break
+            time.sleep(1)
+
+
+@ray.remote(resources={"TPU": 1})
+def cleanup_tpu_process(target_pid: int, worker_id: int, counter):
     """Check and kill a specific PID if it's holding TPU resources."""
-    print(f"Checking if PID {target_pid} is holding TPU resources...")
+    print(f"Worker {worker_id}: Checking if PID {target_pid} is holding TPU resources...")
 
     import glob
 
     for device in glob.glob("/dev/accel*"):
-        print(f"Found device: {device}")
+        print(f"Worker {worker_id}: Found device: {device}")
 
     result = subprocess.run(["lsof", "/dev/accel*"], capture_output=True, text=True, timeout=10, shell=True)
+
+    found_processes = 0
     if result.returncode == 0:
         lines = result.stdout.strip().split("\n")
         for line in lines[1:]:  # Skip header
@@ -51,15 +74,37 @@ def cleanup_tpu_process(target_pid: int):
             if len(parts) >= 2:
                 pid = int(parts[1])
                 if pid == target_pid:
-                    # Found the target process using TPU
-                    print(f"Found PID {target_pid} holding TPU, killing it...")
+                    print(f"Worker {worker_id}: Found PID {target_pid} holding TPU, killing it...")
                     os.kill(target_pid, 9)  # SIGKILL
-                    print(f"Successfully killed process {target_pid} holding TPU")
-                    return
-    print(f"Process {target_pid} not found holding TPU resources")
+                    print(f"Worker {worker_id}: Successfully killed process {target_pid}")
+                    found_processes += 1
+
+    print(f"Worker {worker_id}: Process {target_pid} not found holding TPU resources")
+    counter.wait_for_everyone.remote()
+    return found_processes
 
 
-async def submit_cleanup_job(target_pid: int, tpu_type: str, num_jobs: int):
+def run_cleanup_on_all_workers(tpu_type: str, target_pid: int):
+    """Run cleanup on all workers in the cluster."""
+    _, num_workers = parse_tpu_type(tpu_type)
+    ray.init(address="auto")
+
+    counter = GangSchedulingActor.remote(num_workers)
+
+    futures = []
+    for worker_id in range(num_workers):
+        future = cleanup_tpu_process.remote(target_pid, worker_id, counter)
+        futures.append(future)
+    results = ray.get(futures)
+
+    # Report results
+    killed_count = sum(1 for r in results if r)
+    print(f"\nCleanup complete: killed process on {killed_count}/{num_workers} workers")
+
+    ray.shutdown()
+
+
+async def submit_cleanup_job(tpu_type: str, target_pid: int):
     """Submit cleanup job to Ray cluster."""
     from ray.job_submission import JobSubmissionClient
 
@@ -67,9 +112,12 @@ async def submit_cleanup_job(target_pid: int, tpu_type: str, num_jobs: int):
 
     client = JobSubmissionClient(REMOTE_DASHBOARD_URL)
 
-    # Set up job resources to require TPU
-    chips = tpus_per_node(tpu_type)
-    entrypoint_resources = {f"TPU-{tpu_type}-head": 1, "TPU": chips}
+    # Calculate total TPU resources needed
+    chips_per_node, num_workers = parse_tpu_type(tpu_type)
+    total_chips = chips_per_node * num_workers
+
+    # Request resources for the entire slice
+    entrypoint_resources = {f"TPU-{tpu_type}-head": 1}
 
     runtime_dict = {
         "working_dir": "src/marin/run/",
@@ -78,35 +126,32 @@ async def submit_cleanup_job(target_pid: int, tpu_type: str, num_jobs: int):
 
     # Call this script with --internal-run flag
     script_path = "./clean_ray_tpus.py"
-    entrypoint = f"python {script_path} --internal-run --pid {target_pid}"
+    entrypoint = f"python {script_path} --internal-run --pid {target_pid} --tpu-type {tpu_type}"
 
     print(f"Submitting TPU cleanup job for PID {target_pid} on {tpu_type}")
+    print(f"Workers: {num_workers}, Total TPU chips: {total_chips}")
     print(f"Entrypoint: {entrypoint}")
     print(f"Resources: {json.dumps(entrypoint_resources, indent=2)}")
 
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    submission_id = f"tpu_cleanup-{timestamp}"
 
-    # Submit the job
-    job_ids = []
-    for worker_id in range(num_jobs):
-        submission_id = f"tpu_cleanup-{worker_id}-{timestamp}"
-        client.submit_job(
-            submission_id=submission_id,
-            entrypoint=entrypoint,
-            runtime_env=runtime_dict,
-            entrypoint_resources=entrypoint_resources,
-        )
-        print(f"Job submitted with ID: {submission_id}")
-        print(f"Job URL: http://localhost:8265/#/jobs/{submission_id}")
-        job_ids.append(submission_id)
+    # Submit single job that will spawn tasks on all workers
+    client.submit_job(
+        submission_id=submission_id,
+        entrypoint=entrypoint,
+        runtime_env=runtime_dict,
+        entrypoint_resources=entrypoint_resources,
+    )
+    print(f"Job submitted with ID: {submission_id}")
+    print(f"Job URL: http://localhost:8265/#/jobs/{submission_id}")
 
-    # Stream logs asynchronously
-    for submission_id in job_ids:
-        async for lines in client.tail_job_logs(submission_id):
-            print(lines, end="")
+    # Stream logs
+    async for lines in client.tail_job_logs(submission_id):
+        print(lines, end="")
 
-        result = client.get_job_status(submission_id)
-        print(f"Job {submission_id} finished with status: {result}")
+    result = client.get_job_status(submission_id)
+    print(f"Job finished with status: {result}")
 
 
 def main():
@@ -114,7 +159,6 @@ def main():
         description="Clean up TPU processes by killing a specific PID if it holds TPU resources"
     )
     parser.add_argument("--pid", type=int, required=True, help="Process ID to kill")
-    parser.add_argument("--num-jobs", type=int, default=1, help="Number of Ray jobs to spawn (default: 1)")
     parser.add_argument(
         "--tpu-type",
         type=str,
@@ -125,13 +169,14 @@ def main():
     parser.add_argument("--internal-run", action="store_true", help="Internal flag to run cleanup directly")
 
     args = parser.parse_args()
+    parse_tpu_type(args.tpu_type)  # Validate TPU type
 
     if args.internal_run:
-        # Run the cleanup function directly
-        cleanup_tpu_process(args.pid)
+        # Run cleanup on all workers
+        run_cleanup_on_all_workers(args.tpu_type, args.pid)
     else:
-        # Submit cleanup job asynchronously
-        asyncio.run(submit_cleanup_job(args.pid, args.tpu_type, args.num_jobs))
+        # Submit cleanup job
+        asyncio.run(submit_cleanup_job(args.tpu_type, args.pid))
 
 
 if __name__ == "__main__":

--- a/src/marin/run/clean_ray_tpus.py
+++ b/src/marin/run/clean_ray_tpus.py
@@ -1,0 +1,138 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import asyncio
+import datetime
+import json
+import os
+import re
+import subprocess
+
+
+def tpus_per_node(tpu_type: str) -> int:
+    """Return the number of TPU chips per node for a given TPU type."""
+    if tpu_type in {"v4-8", "v5p-8"}:
+        return 4
+    match = re.search(r"-(\d+)$", tpu_type)
+    if not match:
+        raise ValueError(f"Cannot parse TPU type: {tpu_type}")
+    chips = int(match.group(1))
+    if chips > 8:
+        raise ValueError("Only single tpu nodes are supported with the CLI")
+    return chips
+
+
+def cleanup_tpu_process(target_pid: int):
+    """Check and kill a specific PID if it's holding TPU resources."""
+    print(f"Checking if PID {target_pid} is holding TPU resources...")
+
+    import glob
+
+    for device in glob.glob("/dev/accel*"):
+        print(f"Found device: {device}")
+
+    result = subprocess.run(["lsof", "/dev/accel*"], capture_output=True, text=True, timeout=10, shell=True)
+    if result.returncode == 0:
+        lines = result.stdout.strip().split("\n")
+        for line in lines[1:]:  # Skip header
+            parts = line.split()
+            if len(parts) >= 2:
+                pid = int(parts[1])
+                if pid == target_pid:
+                    # Found the target process using TPU
+                    print(f"Found PID {target_pid} holding TPU, killing it...")
+                    os.kill(target_pid, 9)  # SIGKILL
+                    print(f"Successfully killed process {target_pid} holding TPU")
+                    return
+    print(f"Process {target_pid} not found holding TPU resources")
+
+
+async def submit_cleanup_job(target_pid: int, tpu_type: str, num_jobs: int):
+    """Submit cleanup job to Ray cluster."""
+    from ray.job_submission import JobSubmissionClient
+
+    from marin.run.vars import REMOTE_DASHBOARD_URL
+
+    client = JobSubmissionClient(REMOTE_DASHBOARD_URL)
+
+    # Set up job resources to require TPU
+    chips = tpus_per_node(tpu_type)
+    entrypoint_resources = {f"TPU-{tpu_type}-head": 1, "TPU": chips}
+
+    runtime_dict = {
+        "working_dir": "src/marin/run/",
+        "config": {"setup_timeout_seconds": 1800},
+    }
+
+    # Call this script with --internal-run flag
+    script_path = "./clean_ray_tpus.py"
+    entrypoint = f"python {script_path} --internal-run --pid {target_pid}"
+
+    print(f"Submitting TPU cleanup job for PID {target_pid} on {tpu_type}")
+    print(f"Entrypoint: {entrypoint}")
+    print(f"Resources: {json.dumps(entrypoint_resources, indent=2)}")
+
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    # Submit the job
+    job_ids = []
+    for worker_id in range(num_jobs):
+        submission_id = f"tpu_cleanup-{worker_id}-{timestamp}"
+        client.submit_job(
+            submission_id=submission_id,
+            entrypoint=entrypoint,
+            runtime_env=runtime_dict,
+            entrypoint_resources=entrypoint_resources,
+        )
+        print(f"Job submitted with ID: {submission_id}")
+        print(f"Job URL: http://localhost:8265/#/jobs/{submission_id}")
+        job_ids.append(submission_id)
+
+    # Stream logs asynchronously
+    for submission_id in job_ids:
+        async for lines in client.tail_job_logs(submission_id):
+            print(lines, end="")
+
+        result = client.get_job_status(submission_id)
+        print(f"Job {submission_id} finished with status: {result}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Clean up TPU processes by killing a specific PID if it holds TPU resources"
+    )
+    parser.add_argument("--pid", type=int, required=True, help="Process ID to kill")
+    parser.add_argument("--num-jobs", type=int, default=1, help="Number of Ray jobs to spawn (default: 1)")
+    parser.add_argument(
+        "--tpu-type",
+        type=str,
+        default="v4-8",
+        help="TPU type to target (default: v4-8)",
+    )
+    parser.add_argument("--no-wait", action="store_true", help="Don't wait for job to complete")
+    parser.add_argument("--internal-run", action="store_true", help="Internal flag to run cleanup directly")
+
+    args = parser.parse_args()
+
+    if args.internal_run:
+        # Run the cleanup function directly
+        cleanup_tpu_process(args.pid)
+    else:
+        # Submit cleanup job asynchronously
+        asyncio.run(submit_cleanup_job(args.pid, args.tpu_type, args.num_jobs))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/marin/run/clean_ray_tpus.py
+++ b/src/marin/run/clean_ray_tpus.py
@@ -17,56 +17,21 @@ import asyncio
 import datetime
 import json
 import os
-import re
 import subprocess
-import time
 
 os.environ["RAY_DEDUP_LOGS"] = "0"
 
 import ray
 
 
-def parse_tpu_type(tpu_type: str) -> tuple[int, int]:
-    """Return the number of TPU chips per node for a given TPU type."""
-    if tpu_type in {"v4-8", "v5p-8"}:
-        return 4, 1
-    match = re.search(r"-(\d+)$", tpu_type)
-    if not match:
-        raise ValueError(f"Cannot parse TPU type: {tpu_type}")
-    chips = int(match.group(1))
-    assert chips > 0
-    assert chips % 5 > 0
-    assert chips // 4 > 0
-
-    # TPU names don't make any sense
-    return chips % 5, chips // 8
-
-
-@ray.remote
-class GangSchedulingActor:
-    def __init__(self, num_workers: int):
-        self.count = 0
-        self.num_workers = num_workers
-
-    def wait_for_everyone(self):
-        self.count += 1
-        while True:
-            if self.count >= self.num_workers:
-                break
-            time.sleep(1)
-
-
-@ray.remote(resources={"TPU": 4})
-def cleanup_tpu_process(target_pid: int, worker_id: int, counter):
+def cleanup_tpu_process(target_pid: int):
     """Check and kill a specific PID if it's holding TPU resources."""
-    print(f"Worker {worker_id}: Checking if PID {target_pid} is holding TPU resources...")
-
     import glob
 
     hostname = os.uname().nodename
 
     for device in glob.glob("/dev/accel*"):
-        print(f"Worker {hostname} ({worker_id}): Found device: {device}")
+        print(f"Worker {hostname}: Found device: {device}")
 
     result = subprocess.run(["lsof", "/dev/accel*"], capture_output=True, text=True, timeout=10, shell=True)
 
@@ -84,27 +49,24 @@ def cleanup_tpu_process(target_pid: int, worker_id: int, counter):
                     found_processes += 1
 
     print(f"Worker {hostname}: Process {target_pid} not found holding TPU resources")
-    counter.wait_for_everyone.remote()
     return found_processes
 
 
 def run_cleanup_on_all_workers(tpu_type: str, target_pid: int):
     """Run cleanup on all workers in the cluster."""
-    _, num_workers = parse_tpu_type(tpu_type)
-    ray.init(address="auto")
+    from levanter.infra.ray_tpu import run_on_pod
 
-    counter = GangSchedulingActor.remote(num_workers)
+    @ray.remote(max_calls=1)
+    def _cleanup_tpu_process():
+        cleanup_tpu_process(target_pid)
 
-    futures = []
-    for worker_id in range(num_workers):
-        future = cleanup_tpu_process.remote(target_pid, worker_id, counter)
-        futures.append(future)
-    results = ray.get(futures)
-
-    # Report results
-    killed_count = sum(1 for r in results if r)
-    print(f"\nCleanup complete: killed process on {killed_count}/{num_workers} workers")
-
+    run_on_pod(
+        _cleanup_tpu_process,
+        tpu_type,
+        num_slices=1,
+        max_retries_failure=0,
+        max_retries_preemption=0,
+    )
     ray.shutdown()
 
 
@@ -115,10 +77,6 @@ async def submit_cleanup_job(tpu_type: str, target_pid: int):
     from marin.run.vars import REMOTE_DASHBOARD_URL
 
     client = JobSubmissionClient(REMOTE_DASHBOARD_URL)
-
-    # Calculate total TPU resources needed
-    chips_per_node, num_workers = parse_tpu_type(tpu_type)
-    total_chips = chips_per_node * num_workers
 
     # Request resources for the entire slice
     entrypoint_resources = {f"TPU-{tpu_type}-head": 1}
@@ -133,7 +91,6 @@ async def submit_cleanup_job(tpu_type: str, target_pid: int):
     entrypoint = f"python {script_path} --internal-run --pid {target_pid} --tpu-type {tpu_type}"
 
     print(f"Submitting TPU cleanup job for PID {target_pid} on {tpu_type}")
-    print(f"Workers: {num_workers}, Total TPU chips: {total_chips}")
     print(f"Entrypoint: {entrypoint}")
     print(f"Resources: {json.dumps(entrypoint_resources, indent=2)}")
 
@@ -173,7 +130,6 @@ def main():
     parser.add_argument("--internal-run", action="store_true", help="Internal flag to run cleanup directly")
 
     args = parser.parse_args()
-    parse_tpu_type(args.tpu_type)  # Validate TPU type
 
     if args.internal_run:
         # Run cleanup on all workers


### PR DESCRIPTION
We could potentially run this in a "cron" job on Ray to cleanup periodically.

Example usage:

`uv run src/marin/run/clean_ray_tpus.py --pid=99999 --num-jobs=4 --tpu-type=v4-8`