### PR TITLE
Fix pyproject.toml using the forked dolma.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "wandb<=0.19.9",
     "openai",
     "fasteners>=0.19",
-    "https://github.com/marin-community/dolma",
+    "dolma @ git+https://github.com/marin-community/dolma",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
This gets us past one dependency issue.

We're still seeing duplicate ray version issues.