### PR TITLE
update docs to use uv sync, ensured reproducibility on MacOS

### DIFF
--- a/docs/dev-guide/building-docs.md
+++ b/docs/dev-guide/building-docs.md
@@ -14,7 +14,7 @@ Before you begin, ensure you have the following installed:
 
 1. Install the documentation dependencies:
    ```bash
-   uv pip install -e ".[docs]"
+   uv sync --group docs
    ```
 
 ## Building Documentation

--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -4,7 +4,7 @@
 
 1. Clone the repository
 2. Create and activate a virtual environment
-3. Install the package
+3. Install dependencies
 4. Set up pre-commit hooks
 
 ```bash
@@ -12,7 +12,7 @@ git clone https://github.com/marin-community/marin.git
 cd marin
 uv venv --python 3.11
 source .venv/bin/activate
-uv pip install -e .[dev]
+uv sync --group dev
 pre-commit install
 ```
 

--- a/docs/recipes/add_dataset.md
+++ b/docs/recipes/add_dataset.md
@@ -7,7 +7,7 @@ This recipe guides agents and humans in inspecting Hugging Face dataset schemas 
 - Install the [Hugging Face `datasets` library](https://huggingface.co/docs/datasets/) (e.g., `pip install datasets`).
 - For YAML output, install `pyyaml` (e.g., `pip install pyyaml`).
 - Ensure access to the dataset: Hugging Face Hub ID, local path, or other supported formats.
-- Use `uv run marin/tools/get_hf_dataset_schema.py` for direct execution, or install Marin in editable mode (`pip install -e .`) for CLI access.
+- Use `uv run marin/tools/get_hf_dataset_schema.py` for direct execution, or install Marin with `uv sync` for CLI access.
 
 ## Guidelines for Humans
 

--- a/docs/tutorials/co-develop.md
+++ b/docs/tutorials/co-develop.md
@@ -1,6 +1,8 @@
 # Co-develop Marin and Levanter (as a Submodule)
 
-If you need to co-develop [Levanter](https://github.com/stanford-crfm/levanter) and marin, you can checkout levanter as a submodule within marin following these steps:
+If you need to co-develop [Levanter](https://github.com/stanford-crfm/levanter) and Marin, you can check out Levanter as a working tree inside Marin and install it in editable mode.
+
+## Set up the submodule working tree
 ```
 # Run from ROOT_DIR
 git clone https://github.com/stanford-crfm/levanter
@@ -14,12 +16,29 @@ git worktree add ROOT_DIR/marin/submodules/levanter LEVANTER_BRANCH
 cd ..
 ```
 
-Note that this is not the same as `git submodule add` because it does not modify the marin repository. We find this workflow more convenient for local development.
+Note that this is not the same as `git submodule add` because it does not modify the Marin repository. We find this workflow more convenient for local development.
 
-Change `LEVANTER_BRANCH` to the branch name in `levanter` you are developing. Now, you can make changes to the `LEVANTER_BRANCH` of levanter by making edits in `ROOT_DIR/marin/submodules/levanter`. After making changes, you can run
+## Install Levanter (editable)
+
+- Marin itself is installed by `uv sync` during normal installation; you do NOT need `pip install -e .` for Marin.
+- To develop Levanter alongside Marin, install the submodule in editable mode:
+
+```
+cd marin
+uv pip install -e submodules/levanter
+```
+
+This ensures changes in `submodules/levanter` are immediately importable in your environment.
+
+## Commit changes to your Levanter branch
+
+Change `LEVANTER_BRANCH` to the branch name in `levanter` you are developing. Now, you can make changes to the `LEVANTER_BRANCH` of levanter by editing files in `ROOT_DIR/marin/submodules/levanter`. After making changes, you can run:
 ```
 cd marin/submodules/levanter
 git add .
 git commit -m "Update LEVANTER_BRANCH branch with new changes"
 ```
-This will commit the change to the `LEVANTER_BRANCH` branch of levanter.
+
+This commits the changes to the `LEVANTER_BRANCH` branch of Levanter.
+
+Tip: When submitting Ray jobs via `marin/run/ray_run.py`, the runtime automatically includes `submodules/*` and their `src/` in `PYTHONPATH`, which also supports co-development on cluster jobs.

--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -40,8 +40,16 @@ If you want to set up a TPU cluster, see [TPU Setup](tpu-cluster-setup.md).
    conda activate marin
    ```
 
-3. Install the package (this might take a while, which is something we should fix):
+3. Install the package and dependencies
+
+   === "Recommended"
+   `uv sync` for dependencies and an editable install for the local package:
+
    ```bash
+   # Resolve+install dependencies for your accelerator
+   uv sync
+
+   # Install the local package in editable mode so code changes reflect immediately
    uv pip install -e .
    ```
 
@@ -65,6 +73,10 @@ Marin runs on multiple types of hardware (CPU, GPU, TPU).
 
     === "CPU"
         ```bash
+        # Recommended
+        uv sync --extra=cpu
+
+        # Alternative (pip-style)
         uv pip install -e "."
         ```
 
@@ -87,17 +99,29 @@ Marin runs on multiple types of hardware (CPU, GPU, TPU).
          ```bash
          nvcc --version
          ```
-         Finally we'll install the correct libraries for GPU setup:
+         Finally install Python deps for GPU setup:
 
          ```bash
+         # Recommended
+         uv sync --extra=cuda12
+
+         # Alternative (pip-style)
          uv pip install -e ".[cuda12]"
          ```
 
     === "TPU"
 
         ```bash
+        # Recommended
+        uv sync --extra=tpu
+
+        # Alternative (pip-style)
         uv pip install -e ".[tpu]"
         ```
+
+### Notes on Ray jobs and code changes
+- When using `marin/run/ray_run.py`, the current working directory is uploaded as the job’s `working_dir`, and the runtime sets `PYTHONPATH` to include `src/` and `experiments/`. Your code snapshot at submission time is used on the cluster. If you make further local changes, re‑submit the job to pick them up.
+- For local runs and tests, editable installs (`uv pip install -e .`) ensure changes under `src/` are immediately visible without reinstalling.
 
 - **CPU**: Works out of the box, suitable for small experiments
 - **GPU**: See [Local GPU Setup](local-gpu.md) for CUDA configuration and multi-GPU support

--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -43,14 +43,11 @@ If you want to set up a TPU cluster, see [TPU Setup](tpu-cluster-setup.md).
 3. Install the package and dependencies
 
    === "Recommended"
-   `uv sync` for dependencies and an editable install for the local package:
+   Use `uv sync` to install dependencies and the local Marin package (editable) in one step:
 
    ```bash
-   # Resolve+install dependencies for your accelerator
+   # Resolve and install dependencies + local package (editable)
    uv sync
-
-   # Install the local package in editable mode so code changes reflect immediately
-   uv pip install -e .
    ```
 
 4. Setup [Weights and Biases (WandB)](https://wandb.ai) so you can monitor your runs:
@@ -73,11 +70,8 @@ Marin runs on multiple types of hardware (CPU, GPU, TPU).
 
     === "CPU"
         ```bash
-        # Recommended
+        # Install CPU-specific dependencies (local package included)
         uv sync --extra=cpu
-
-        # Alternative (pip-style)
-        uv pip install -e "."
         ```
 
     === "GPU"
@@ -102,26 +96,20 @@ Marin runs on multiple types of hardware (CPU, GPU, TPU).
          Finally install Python deps for GPU setup:
 
          ```bash
-         # Recommended
+         # Install GPU-specific dependencies (local package included)
          uv sync --extra=cuda12
-
-         # Alternative (pip-style)
-         uv pip install -e ".[cuda12]"
          ```
 
     === "TPU"
 
         ```bash
-        # Recommended
+        # Install TPU-specific dependencies (local package included)
         uv sync --extra=tpu
-
-        # Alternative (pip-style)
-        uv pip install -e ".[tpu]"
         ```
 
 ### Notes on Ray jobs and code changes
 - When using `marin/run/ray_run.py`, the current working directory is uploaded as the job’s `working_dir`, and the runtime sets `PYTHONPATH` to include `src/` and `experiments/`. Your code snapshot at submission time is used on the cluster. If you make further local changes, re‑submit the job to pick them up.
-- For local runs and tests, editable installs (`uv pip install -e .`) ensure changes under `src/` are immediately visible without reinstalling.
+- For local runs and tests, `uv sync` installs Marin in editable mode by default, so changes under `src/` are immediately visible without reinstalling.
 
 - **CPU**: Works out of the box, suitable for small experiments
 - **GPU**: See [Local GPU Setup](local-gpu.md) for CUDA configuration and multi-GPU support

--- a/docs/tutorials/local-gpu.md
+++ b/docs/tutorials/local-gpu.md
@@ -43,10 +43,10 @@ nvcc --version
 ```
 
 Marin uses [JAX](https://jax.readthedocs.io/en/latest/index.html) as a core library.
-Install JAX with the CUDA 12.9.0 backend:
+Install Python dependencies for CUDA 12.x via uv:
 
 ```bash
-pip3 install -e . jax[cuda12]
+uv sync --extra=cuda12
 ```
 
 See [JAX's installation guide](https://jax.readthedocs.io/en/latest/installation.html) for more options.

--- a/docs/tutorials/tpu-cluster-setup.md
+++ b/docs/tutorials/tpu-cluster-setup.md
@@ -51,7 +51,7 @@ We use docker images to run the jobs inside the ray cluster. We provide a convie
 
 1. Install Marin with TPU support:
    ```bash
-   uv pip install -e ".[tpu]"
+   uv sync --extra=tpu
    ```
 
 2. Set up your GCP environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,6 @@ torch = [
     # CUDA12 index only when --extra cuda12
     { index = "pytorch-cu128", extra = "cuda12" },
 ]
-sentencepiece = { git = "https://github.com/google/sentencepiece/", subdirectory = "python" }
 
 
 resiliparse-dom = { git = "https://github.com/stanford-crfm/chatnoir-resiliparse", subdirectory = "resiliparse_dom", rev = "da2ff85fe51310484cf9435565b2bdde2a23708b" }


### PR DESCRIPTION
## Description

Update installation docs to use uv sync first and then pip install -e, and removed a build requirement for sentence piece that failed when I spun up new clusters. The install doc workflow should be working and verified for MacOS now