### PR TITLE
Exclude pack files because git takes a lot of space

### DIFF
--- a/src/marin/run/ray_run.py
+++ b/src/marin/run/ray_run.py
@@ -97,7 +97,7 @@ async def submit_and_track_job(
     runtime_dict = {
         "working_dir": current_dir,
         "config": {"setup_timeout_seconds": 1800},
-        "excludes": [".git", "tests/", "docs/"],
+        "excludes": [".git", "tests/", "docs/", "**/*.pack"],
     }
 
     # add the TPU dependency for cluster jobs.


### PR DESCRIPTION
## Description

Fixes #(issue number)
Exclude the git pack files since these files take a lot of space and can push us over the 100MB ray file limit when uploading to the cluster.

## Checklist

- [ ] You ran `pre-commit run --all-files` to lint your code
- [ ] You ran 'pytest' to test your code
- [ ] Delete this checklist