### PR TITLE
update configs and robustify for adding manual workers

### DIFF
--- a/infra/marin-big-run.yaml
+++ b/infra/marin-big-run.yaml
@@ -21,6 +21,7 @@ provider:
   region: us-central2
   availability_zone: us-central2-b
   project_id: hai-gcp-models
+  gcsfuse_bucket: marin-us-central2
 
 
 docker:
@@ -29,8 +30,7 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=on-failure
-      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
+      - --restart=always
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-big-run.yaml
+++ b/infra/marin-big-run.yaml
@@ -30,7 +30,8 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=always
+      - --restart=on-failure
+      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-cluster-template.yaml
+++ b/infra/marin-cluster-template.yaml
@@ -26,7 +26,8 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=always
+      - --restart=on-failure
+      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-cluster-template.yaml
+++ b/infra/marin-cluster-template.yaml
@@ -17,6 +17,7 @@ provider:
   region: {{REGION}}
   availability_zone: {{ZONE}}
   project_id: hai-gcp-models
+  gcsfuse_bucket: {{BUCKET}}
 
 
 docker:
@@ -25,8 +26,7 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=on-failure
-      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
+      - --restart=always
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-eu-west4-a.yaml
+++ b/infra/marin-eu-west4-a.yaml
@@ -21,6 +21,7 @@ provider:
   region: europe-west4
   availability_zone: europe-west4-a
   project_id: hai-gcp-models
+  gcsfuse_bucket: marin-eu-west4
 
 
 docker:
@@ -29,8 +30,7 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=on-failure
-      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
+      - --restart=always
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-eu-west4-a.yaml
+++ b/infra/marin-eu-west4-a.yaml
@@ -30,7 +30,8 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=always
+      - --restart=on-failure
+      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-eu-west4-vllm.yaml
+++ b/infra/marin-eu-west4-vllm.yaml
@@ -19,6 +19,7 @@ provider:
   region: europe-west4
   availability_zone: europe-west4-b
   project_id: hai-gcp-models
+  gcsfuse_bucket: marin-eu-west4
 
 docker:
     image: "europe-west4-docker.pkg.dev/hai-gcp-models/marin/marin_vllm:7fab502e"

--- a/infra/marin-eu-west4.yaml
+++ b/infra/marin-eu-west4.yaml
@@ -30,7 +30,8 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=always
+      - --restart=on-failure
+      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-eu-west4.yaml
+++ b/infra/marin-eu-west4.yaml
@@ -21,6 +21,7 @@ provider:
   region: europe-west4
   availability_zone: europe-west4-b
   project_id: hai-gcp-models
+  gcsfuse_bucket: marin-eu-west4
 
 
 docker:
@@ -29,8 +30,7 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=on-failure
-      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
+      - --restart=always
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-us-central1.yaml
+++ b/infra/marin-us-central1.yaml
@@ -21,6 +21,7 @@ provider:
   region: us-central1
   availability_zone: us-central1-a
   project_id: hai-gcp-models
+  gcsfuse_bucket: marin-us-central1
 
 
 docker:
@@ -29,8 +30,7 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=on-failure
-      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
+      - --restart=always
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-us-central1.yaml
+++ b/infra/marin-us-central1.yaml
@@ -30,7 +30,8 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=always
+      - --restart=on-failure
+      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-us-central2-compress.yaml
+++ b/infra/marin-us-central2-compress.yaml
@@ -21,6 +21,7 @@ provider:
   region: us-central2
   availability_zone: us-central2-b
   project_id: hai-gcp-models
+  gcsfuse_bucket: marin-us-central2
 
 
 docker:
@@ -29,8 +30,7 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=on-failure
-      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
+      - --restart=always
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-us-central2-compress.yaml
+++ b/infra/marin-us-central2-compress.yaml
@@ -30,7 +30,8 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=always
+      - --restart=on-failure
+      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-us-central2-vllm.yaml
+++ b/infra/marin-us-central2-vllm.yaml
@@ -19,6 +19,7 @@ provider:
   region: us-central2
   availability_zone: us-central2-b
   project_id: hai-gcp-models
+  gcsfuse_bucket: marin-us-central2
 
 docker:
     image: "us-central2-docker.pkg.dev/hai-gcp-models/marin/marin_vllm:6e804a10"

--- a/infra/marin-us-central2.yaml
+++ b/infra/marin-us-central2.yaml
@@ -21,6 +21,7 @@ provider:
   region: us-central2
   availability_zone: us-central2-b
   project_id: hai-gcp-models
+  gcsfuse_bucket: marin-us-central2
 
 
 docker:
@@ -29,8 +30,7 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=on-failure
-      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
+      - --restart=always
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-us-central2.yaml
+++ b/infra/marin-us-central2.yaml
@@ -30,7 +30,8 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=always
+      - --restart=on-failure
+      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-us-east1-d-vllm.yaml
+++ b/infra/marin-us-east1-d-vllm.yaml
@@ -19,6 +19,7 @@ provider:
   region: us-east1
   availability_zone: us-east1-d
   project_id: hai-gcp-models
+  gcsfuse_bucket: marin-us-east1
 
 docker:
     image: "us-east1-docker.pkg.dev/hai-gcp-models/marin/marin_vllm:6e804a10"

--- a/infra/marin-us-east1.yaml
+++ b/infra/marin-us-east1.yaml
@@ -30,7 +30,8 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=always
+      - --restart=on-failure
+      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-us-east1.yaml
+++ b/infra/marin-us-east1.yaml
@@ -21,6 +21,7 @@ provider:
   region: us-east1
   availability_zone: us-east1-d
   project_id: hai-gcp-models
+  gcsfuse_bucket: marin-us-east1
 
 
 docker:
@@ -29,8 +30,7 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=on-failure
-      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
+      - --restart=always
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-us-east5-a.yaml
+++ b/infra/marin-us-east5-a.yaml
@@ -21,6 +21,7 @@ provider:
   region: us-east5
   availability_zone: us-east5-a
   project_id: hai-gcp-models
+  gcsfuse_bucket: marin-us-east5
 
 
 docker:
@@ -29,8 +30,7 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=on-failure
-      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
+      - --restart=always
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576
@@ -109,7 +109,7 @@ available_node_types:
             sourceImage: projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts
   tpu_worker:
     max_workers: 1024
-    min_workers: 8
+    min_workers: 4
     node_config:
       acceleratorType: v5p-8
       runtimeVersion: v2-alpha-tpuv5
@@ -157,7 +157,7 @@ available_node_types:
 
   tpu_slice_v5p_64:
     max_workers: 1024
-    min_workers: 4
+    min_workers: 0
     node_config:
       acceleratorType: v5p-64
       runtimeVersion: v2-alpha-tpuv5
@@ -217,7 +217,7 @@ available_node_types:
 
   tpu_slice_v5p_2048:
     max_workers: 1024
-    min_workers: 0
+    min_workers: 2
     node_config:
       acceleratorType: v5p-2048
       runtimeVersion: v2-alpha-tpuv5

--- a/infra/marin-us-east5-a.yaml
+++ b/infra/marin-us-east5-a.yaml
@@ -30,7 +30,8 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=always
+      - --restart=on-failure
+      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-us-east5-b-vllm.yaml
+++ b/infra/marin-us-east5-b-vllm.yaml
@@ -19,6 +19,7 @@ provider:
   region: us-east5
   availability_zone: us-east5-b
   project_id: hai-gcp-models
+  gcsfuse_bucket: marin-us-east5
 
 docker:
     image: "us-east5-docker.pkg.dev/hai-gcp-models/marin/marin_vllm:6e804a10"

--- a/infra/marin-us-east5.yaml
+++ b/infra/marin-us-east5.yaml
@@ -30,7 +30,8 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=always
+      - --restart=on-failure
+      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-us-east5.yaml
+++ b/infra/marin-us-east5.yaml
@@ -21,6 +21,7 @@ provider:
   region: us-east5
   availability_zone: us-east5-b
   project_id: hai-gcp-models
+  gcsfuse_bucket: marin-us-east5
 
 
 docker:
@@ -29,8 +30,7 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=on-failure
-      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
+      - --restart=always
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-us-west4.yaml
+++ b/infra/marin-us-west4.yaml
@@ -30,7 +30,8 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=always
+      - --restart=on-failure
+      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-us-west4.yaml
+++ b/infra/marin-us-west4.yaml
@@ -21,6 +21,7 @@ provider:
   region: us-west4
   availability_zone: us-west4-a
   project_id: hai-gcp-models
+  gcsfuse_bucket: marin-us-west4
 
 
 docker:
@@ -29,8 +30,7 @@ docker:
     pull_before_run: true
     worker_run_options:
       # always restart the worker if it happens to crash
-      - --restart=on-failure
-      - --rm=0  # Ray likes to add --rm which doesn't work with --restart=on-failure
+      - --restart=always
       - --privileged
       - --ulimit memlock=-1:-1  #
       - --ulimit nofile=1048576:1048576

--- a/infra/marin-vllm-template.yaml
+++ b/infra/marin-vllm-template.yaml
@@ -15,6 +15,7 @@ provider:
   region: {{REGION}}
   availability_zone: {{ZONE}}
   project_id: hai-gcp-models
+  gcsfuse_bucket: {{BUCKET}}
 
 docker:
     image: "{{REGION}}-docker.pkg.dev/hai-gcp-models/marin/{% if VLLM %}marin_vllm{% else %}marin_cluster{% endif %}:{{DOCKER_TAG}}"

--- a/src/marin/cluster/ray.py
+++ b/src/marin/cluster/ray.py
@@ -686,27 +686,10 @@ def initialize_manual_worker(config_file: str, tpu_name: str) -> None:
     print(f"Container name: {docker_container_name}")
     print(f"Docker image: {docker_image}")
 
-    provider_cfg = cluster_config.get("provider", {})
-    bucket = provider_cfg.get("gcsfuse_bucket")
     if not bucket:
         raise ValueError("Cluster config must define provider.gcsfuse_bucket for manual worker setup.")
 
     setup_commands = "\n".join(setup_commands)
-
-    # entry_script_content = f"""#!/bin/bash
-
-    # {setup_commands}
-
-    # # Entry and setup commands will automatically re-run if the container is restarted
-
-    # echo 'Checking for head node IP...'
-    # gcloud compute instances list --filter="labels.ray-node-name:{cluster_name}-head" --format=text > /tmp/instances
-    # cat /tmp/instances | grep networkIp | awk '{{print $2}}' > /tmp/head_ip
-    # echo 'Found head node IP: ' $(cat /tmp/head_ip)
-    # ray start --address=$(cat /tmp/head_ip):6379 --block
-    # echo "Ray worker crashed. Sleeping 10 seconds to avoid rapid restart..."
-    # sleep 10
-    #     """
 
     entry_script_content = f"""#!/bin/bash
 


### PR DESCRIPTION
## Description

Fixes a weird issue where gcloud seems to have changed (??)


right now when we set up the container for the workers we run a gcloud command and grep for network ip so we can attach to the ray headnode using a chained grep awk workflow

When trying this on us-central2 with a manual worker however, it failed
```bash
ahmed@t1v-n-55c2081b-w-0:~$ sudo docker exec -it ray_docker /bin/bash -lc "gcloud compute instances list \\
    --filter=\"labels.ray-node-name:marin-us-central2-memorize-head\" \\
    --format=text" | grep networkIp | awk '{print $2}'
    ```
    
    But the following suggestion from codex and seems like brittle
    
    ```
    ahmed@t1v-n-55c2081b-w-0:~$ sudo docker exec -it ray_docker /bin/bash -lc "gcloud compute instances list \\
    --filter=\"labels.ray-node-name:marin-us-central2-memorize-head\" \\
    --format=text" | grep -i 'networkip' | awk '{print $2}'
10.130.0.119
```


Also made slight quality of life improvements to the script setting up manual workers / cluster work flow

1) `set -eo pipefail` keeps the shell from silently plowing ahead if a command. This way we can immediately tell that setup failed because the docker container will crash, rather than what happened before which are long retries with the silent error
2) explicitly add gcsfuse mount bucket because that was silently failing as well. Now it will be required and the script fails otherwise, added a reasonable default to all yaml configs.... technically this makes our setup yamls less general purpose but we only use GCP anyway