### PR TITLE
Add perplexity correlations for uncheatable eval / paloma

### DIFF
--- a/experiments/exp1600_perpcorr.py
+++ b/experiments/exp1600_perpcorr.py
@@ -1,0 +1,224 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from experiments.llama import llama_3_2_1b as llama_3_2_1b_config, llama3_tokenizer, llama_8b
+from marin.evaluation.log_probs import default_lm_log_probs
+from marin.execution.executor import executor_main
+from marin.processing.tokenize.data_configs import mixture_for_evaluation
+from experiments.paloma import paloma_tokenized
+
+from dataclasses import dataclass
+from levanter.models.llama import LmConfig
+from levanter.models.olmo import Olmo2Config
+from experiments.evals.resource_configs import SINGLE_TPU_V5p_8_FULL
+from experiments.evals.task_configs import EvalTaskConfig
+from experiments.evals.evals import evaluate_levanter_lm_evaluation_harness
+from marin.execution.executor import ExecutorStep
+from experiments.models import (
+    llama_3_1_8b,
+    olmo_2_base_8b,
+    marin_8b_base,
+    llama_3_2_1b as llama_3_2_1b_model,
+    qwen3_0_6b,
+    qwen3_1_7b,
+    qwen3_4b,
+    qwen3_8b,
+    qwen3_0_6b_base,
+    qwen3_1_7b_base,
+    qwen3_4b_base,
+    qwen3_8b_base,
+)
+from experiments.qwen3 import (
+    qwen3_0_6b as qwen3_0_6b_config,
+    qwen3_1_7b as qwen3_1_7b_config,
+    qwen3_4b as qwen3_4b_config,
+    qwen3_8b as qwen3_8b_config,
+)
+from experiments.isoflop_sweep import generate_isoflop_sweep
+from experiments.tootsie.exp1295_32b import nemotron_mix
+from experiments.uncheatable_eval import uncheatable_eval_tokenized
+
+olmo_7b = Olmo2Config(
+    seq_len=4096,
+    hidden_dim=4096,
+    intermediate_dim=11008,
+    num_heads=32,
+    num_kv_heads=32,
+    num_layers=32,
+)
+
+
+@dataclass
+class ModelConfig:
+    model_name: str
+    model_config: LmConfig
+    tokenizer: str
+    model_path: ExecutorStep
+
+
+# Evaluate log probabilities of meta-llama/Llama-3.2-1B on a subset of DCLM baseline
+# Uses 1024 samples by default (adjust max_samples_per_dataset as needed)
+
+model_with_config = [
+    ModelConfig(
+        model_name="marin-community/marin-8b-base",
+        model_config=llama_8b,
+        tokenizer=llama3_tokenizer,
+        model_path=marin_8b_base,
+    ),
+    ModelConfig(
+        model_name="meta-llama/Llama-3.1-8B", model_config=llama_8b, tokenizer=llama3_tokenizer, model_path=llama_3_1_8b
+    ),
+    ModelConfig(
+        model_name="meta-llama/Llama-3.2-1B",
+        model_config=llama_3_2_1b_config,
+        tokenizer=llama3_tokenizer,
+        model_path=llama_3_2_1b_model,
+    ),
+    ModelConfig(
+        model_name="allenai/OLMo-2-1124-7B",
+        model_config=olmo_7b,
+        tokenizer="allenai/OLMo-2-1124-7B",
+        model_path=olmo_2_base_8b,
+    ),
+    ModelConfig(
+        model_name="Qwen/Qwen3-0.6B", model_config=qwen3_0_6b_config, tokenizer="Qwen/Qwen3-0.6B", model_path=qwen3_0_6b
+    ),
+    ModelConfig(
+        model_name="Qwen/Qwen3-1.7B", model_config=qwen3_1_7b_config, tokenizer="Qwen/Qwen3-1.7B", model_path=qwen3_1_7b
+    ),
+    ModelConfig(
+        model_name="Qwen/Qwen3-4B", model_config=qwen3_4b_config, tokenizer="Qwen/Qwen3-4B", model_path=qwen3_4b
+    ),
+    ModelConfig(
+        model_name="Qwen/Qwen3-8B", model_config=qwen3_8b_config, tokenizer="Qwen/Qwen3-8B", model_path=qwen3_8b
+    ),
+    ModelConfig(
+        model_name="Qwen/Qwen3-0.6B-Base",
+        model_config=qwen3_0_6b_config,
+        tokenizer="Qwen/Qwen3-0.6B",
+        model_path=qwen3_0_6b_base,
+    ),
+    ModelConfig(
+        model_name="Qwen/Qwen3-1.7B-Base",
+        model_config=qwen3_1_7b_config,
+        tokenizer="Qwen/Qwen3-1.7B",
+        model_path=qwen3_1_7b_base,
+    ),
+    ModelConfig(
+        model_name="Qwen/Qwen3-4B-Base",
+        model_config=qwen3_4b_config,
+        tokenizer="Qwen/Qwen3-4B",
+        model_path=qwen3_4b_base,
+    ),
+    ModelConfig(
+        model_name="Qwen/Qwen3-8B-Base",
+        model_config=qwen3_8b_config,
+        tokenizer="Qwen/Qwen3-8B",
+        model_path=qwen3_8b_base,
+    ),
+]
+
+
+def get_directory_friendly_name(model_name: str) -> str:
+    return model_name.replace("/", "--").replace(".", "-")
+
+
+EVAL_TASKS = [
+    EvalTaskConfig("mmlu_sl_verb", num_fewshot=5, task_alias="mmlu_sl_verb_5_shot"),
+    EvalTaskConfig("hellaswag", 10, task_alias="hellaswag_10shot"),  # 4-way MCQ commonsense reasoning dataset,
+    EvalTaskConfig("gsm8k_loss", num_fewshot=8, task_alias="gsm8k_loss_8shot"),
+    EvalTaskConfig("math_500_loss", num_fewshot=0),
+]
+
+steps = []
+isoflop_steps, isoflop_model_configs, isoflop_train_configs, isoflop_budgets = generate_isoflop_sweep(
+    nemotron_mix,
+    experiment_name="nemo-wider-depth-adapt",
+)
+for isoflop_step, isoflop_model_config, isoflop_train_config, isoflop_budget in zip(
+    isoflop_steps, isoflop_model_configs, isoflop_train_configs, isoflop_budgets, strict=False
+):
+    experiment_name = isoflop_step.name.split("/")[-1]
+    paloma_tokenized_dict = paloma_tokenized(tokenizer=llama3_tokenizer)
+    uncheatable_eval_tokenized_dict = uncheatable_eval_tokenized(tokenizer=llama3_tokenizer)
+    eval_data = mixture_for_evaluation(paloma_tokenized_dict | uncheatable_eval_tokenized_dict)
+
+    wandb_tags = (
+        f"FLOPs={isoflop_budget:.1e}",
+        f"d={isoflop_model_config.hidden_dim}",
+        f"L={isoflop_model_config.num_layers}",
+        f"B={isoflop_train_config.train_batch_size}",
+        f"steps={isoflop_train_config.num_train_steps}",
+        f"tpu={isoflop_train_config.resources.tpu_type}",
+    )
+    steps.append(
+        default_lm_log_probs(
+            checkpoint=isoflop_step,
+            model=isoflop_model_config,
+            data=eval_data,
+            checkpoint_is_hf=False,
+            per_device_batch_size=4,
+            name=f"{experiment_name}-paloma-uncheatable-eval-logprobs-v2",
+            wandb_tags=wandb_tags,
+        )
+    )
+    steps.append(
+        evaluate_levanter_lm_evaluation_harness(
+            model_name=experiment_name,
+            model_path=isoflop_step,
+            evals=EVAL_TASKS,
+            resource_config=SINGLE_TPU_V5p_8_FULL,
+            wandb_tags=wandb_tags,
+        )
+    )
+
+for model_config in model_with_config:
+    paloma_tokenized_dict = paloma_tokenized(tokenizer=model_config.tokenizer)
+    uncheatable_eval_tokenized_dict = uncheatable_eval_tokenized(tokenizer=model_config.tokenizer)
+    eval_data = mixture_for_evaluation(paloma_tokenized_dict | uncheatable_eval_tokenized_dict)
+
+    directory_friendly_name = get_directory_friendly_name(model_config.model_name)
+    steps.append(
+        default_lm_log_probs(
+            checkpoint=model_config.model_name,
+            model=model_config.model_config,
+            data=eval_data,
+            checkpoint_is_hf=True,
+            per_device_batch_size=4,
+            name=f"{directory_friendly_name}-paloma-uncheatable-eval-logprobs-v2",
+            wandb_tags=[f"M={model_config.model_name}", "eval=paloma-uncheatable-eval-bpb"],
+        )
+    )
+
+    steps.append(
+        evaluate_levanter_lm_evaluation_harness(
+            model_name=f"{directory_friendly_name}-mmlu-5shot-sl",
+            model_path=model_config.model_path,
+            evals=[
+                EvalTaskConfig("mmlu_sl_verb", num_fewshot=5, task_alias="mmlu_sl_verb_5_shot"),
+                EvalTaskConfig(
+                    "hellaswag", 10, task_alias="hellaswag_10shot"
+                ),  # 4-way MCQ commonsense reasoning dataset,
+                EvalTaskConfig("gsm8k_loss", num_fewshot=8, task_alias="gsm8k_loss_8shot"),
+                EvalTaskConfig("math_500_loss", num_fewshot=0),
+            ],
+            resource_config=SINGLE_TPU_V5p_8_FULL,
+            wandb_tags=[f"M={model_config.model_name}", "eval=mmlu-5shot-sl"],
+        )
+    )
+
+
+if __name__ == "__main__":
+    executor_main(steps=steps)

--- a/experiments/uncheatable_eval.py
+++ b/experiments/uncheatable_eval.py
@@ -1,0 +1,77 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The Paloma eval sets, downloaded and tokenized
+
+https://huggingface.co/datasets/allenai/paloma
+"""
+
+import os.path
+
+from src.marin.download.uncheatable_eval.download import make_uncheatable_eval_step
+
+# cyclic dependency
+# from experiments.llama import llama3_tokenizer
+from marin.execution.executor import ExecutorStep, executor_main
+from marin.processing.tokenize import TokenizeConfig
+from marin.processing.tokenize.data_configs import TokenizerStep
+
+llama3_tokenizer = "meta-llama/Meta-Llama-3.1-8B"
+
+
+# The datasets in the uncheatable eval set and their paths within the uncheatable eval repository
+# https://huggingface.co/datasets/allenai/paloma
+UNCHEATABLE_EVAL_TO_FILE_PATTERN = {
+    "wikipedia_arabic": "wikipedia_arabic_*.jsonl.gz",
+    "wikipedia_english": "wikipedia_english_*.jsonl.gz",
+    "wikipedia_french": "wikipedia_french_*.jsonl.gz",
+    "wikipedia_german": "wikipedia_german_*.jsonl.gz",
+    "wikipedia_japanese": "wikipedia_japanese_*.jsonl.gz",
+    "wikipedia_spanish": "wikipedia_spanish_*.jsonl.gz",
+    "github_python": "github_python_*.jsonl.gz",
+    "github_cpp": "github_cpp_*.jsonl.gz",
+    "bbc_news": "bbc_news_*.jsonl.gz",
+    "arxiv_physics": "arxiv_physics_*.jsonl.gz",
+    "arxiv_computer_science": "arxiv_computer_science_*.jsonl.gz",
+    "ao3_chinese": "ao3_chinese_*.jsonl.gz",
+    "ao3_english": "ao3_english_*.jsonl.gz",
+}
+
+uncheatable_eval = make_uncheatable_eval_step()
+
+
+def uncheatable_eval_tokenized(
+    *, base_path="tokenized/", tokenizer: str = llama3_tokenizer, uncheatable_eval_raw: ExecutorStep = uncheatable_eval
+) -> dict[str, TokenizerStep]:
+    """
+    Returns a dictionary of steps to tokenize the Paloma eval sets. Keys are the subset names (with `paloma/` prefix)
+    """
+    # avoid cyclic dependency
+    from experiments.defaults import default_tokenize
+
+    uncheatable_eval_steps: dict[str, ExecutorStep[TokenizeConfig]] = {}
+    for dataset, path_part in UNCHEATABLE_EVAL_TO_FILE_PATTERN.items():
+        uncheatable_eval_steps[os.path.join("uncheatable_eval", dataset)] = default_tokenize(
+            name=os.path.join("uncheatable_eval", dataset),
+            dataset=uncheatable_eval_raw.cd(f"{path_part}"),
+            tokenizer=tokenizer,
+            is_validation=True,
+        )
+
+    return uncheatable_eval_steps
+
+
+if __name__ == "__main__":
+    executor_main(steps=[uncheatable_eval, *uncheatable_eval_tokenized().values()])

--- a/src/marin/download/uncheatable_eval/download.py
+++ b/src/marin/download/uncheatable_eval/download.py
@@ -1,0 +1,414 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Download and normalize the latest Uncheatable Eval data dumps."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import posixpath
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any
+
+import fsspec
+import ray
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
+
+from marin.core.runtime import cached_or_construct_output, simple_backpressure
+from marin.execution import THIS_OUTPUT_PATH, ExecutorStep, VersionedValue, ensure_versioned, this_output_path
+from marin.utils import fsspec_exists, fsspec_mkdirs
+
+logger = logging.getLogger("ray")
+
+FILENAME_PATTERN = re.compile(r"^(?P<benchmark>.+)_(?P<start>\d{8})to(?P<end>\d{8})(?P<suffix>(?:\.[^.]+)*)$")
+
+TEXT_FIELD_CANDIDATES: tuple[str, ...] = (
+    "text",
+    "body",
+    "content",
+    "article",
+    "document",
+    "raw_text",
+    "code",
+    "message",
+    "description",
+    "story",
+)
+
+LIST_FIELD_CANDIDATES: tuple[str, ...] = (
+    "paragraphs",
+    "sentences",
+    "lines",
+    "messages",
+)
+
+ID_FIELD_CANDIDATES: tuple[str, ...] = (
+    "id",
+    "uuid",
+    "guid",
+    "doc_id",
+    "document_id",
+    "article_id",
+    "hash",
+    "sha",
+    "uid",
+)
+
+
+@dataclass(frozen=True)
+class UncheatableEvalDataset:
+    """Information about a single data dump file from the Uncheatable Eval repository."""
+
+    benchmark: str
+    start_date: str
+    end_date: str
+    name: str
+    download_url: str
+    sha: str | None = None
+    size: int | None = None
+
+    @property
+    def date_range(self) -> str:
+        return f"{self.start_date}to{self.end_date}"
+
+    @property
+    def source_label(self) -> str:
+        return f"{self.benchmark}:{self.date_range}"
+
+    def output_filename(self, suffix: str = ".jsonl.gz") -> str:
+        return f"{self.benchmark}_{self.date_range}{suffix}"
+
+
+@dataclass
+class UncheatableEvalDownloadConfig:
+    """Configuration for downloading and normalizing Uncheatable Eval dumps."""
+
+    output_path: str | VersionedValue[str] = THIS_OUTPUT_PATH
+    repo_owner: str | VersionedValue[str] = "Jellyfish042"
+    repo_name: str | VersionedValue[str] = "uncheatable_eval"
+    data_path: str | VersionedValue[str] = "data"
+    branch: str | VersionedValue[str] = "master"
+    max_concurrent_downloads: int = 8
+    request_timeout: int = 120
+    github_token: str | None = None
+    skip_existing: bool = True
+    metadata_filename: str = "metadata.json"
+
+
+@dataclass(frozen=True)
+class _RequestOptions:
+    headers: dict[str, str] = field(default_factory=dict)
+    timeout: int = 120
+
+
+def _build_request_options(cfg: UncheatableEvalDownloadConfig) -> _RequestOptions:
+    headers = {"Accept": "application/vnd.github+json"}
+    token = cfg.github_token or os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return _RequestOptions(headers=headers, timeout=cfg.request_timeout)
+
+
+def _fetch_directory_listing(
+    cfg: UncheatableEvalDownloadConfig, request_options: _RequestOptions
+) -> list[dict[str, Any]]:
+    """Return the list of files in the configured GitHub repository directory."""
+
+    base_url = f"https://api.github.com/repos/{cfg.repo_owner}/{cfg.repo_name}/contents/{cfg.data_path}"
+    params = {"ref": cfg.branch}
+    response = requests.get(base_url, headers=request_options.headers, params=params, timeout=request_options.timeout)
+    response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, list):
+        raise ValueError(f"Unexpected response from GitHub API: {payload!r}")
+    return payload
+
+
+def _parse_available_dumps(entries: Iterable[dict[str, Any]]) -> list[UncheatableEvalDataset]:
+    """Parse GitHub directory entries into dataset metadata."""
+
+    datasets: list[UncheatableEvalDataset] = []
+    for entry in entries:
+        name = entry.get("name")
+        if not isinstance(name, str):
+            continue
+        match = FILENAME_PATTERN.match(name)
+        if not match:
+            continue
+        benchmark = match.group("benchmark")
+        start = match.group("start")
+        end = match.group("end")
+        download_url = entry.get("download_url")
+        if not isinstance(download_url, str):
+            logger.debug("Skipping %s because it has no download_url", name)
+            continue
+        datasets.append(
+            UncheatableEvalDataset(
+                benchmark=benchmark,
+                start_date=start,
+                end_date=end,
+                name=name,
+                download_url=download_url,
+                sha=entry.get("sha"),
+                size=entry.get("size"),
+            )
+        )
+    return datasets
+
+
+def _select_latest_dumps(datasets: Iterable[UncheatableEvalDataset]) -> list[UncheatableEvalDataset]:
+    """Select the latest dump for each benchmark based on the end date (and start date as tie breaker)."""
+
+    latest: dict[str, UncheatableEvalDataset] = {}
+    for dataset in datasets:
+        existing = latest.get(dataset.benchmark)
+        if existing is None:
+            latest[dataset.benchmark] = dataset
+            continue
+        candidate_key = (dataset.end_date, dataset.start_date, dataset.name)
+        existing_key = (existing.end_date, existing.start_date, existing.name)
+        if candidate_key > existing_key:
+            latest[dataset.benchmark] = dataset
+    return sorted(latest.values(), key=lambda d: d.benchmark)
+
+
+def _extract_id(raw: Any, dataset: UncheatableEvalDataset, index: int) -> str:
+    if isinstance(raw, dict):
+        for key in ID_FIELD_CANDIDATES:
+            value = raw.get(key)
+            if value:
+                return str(value)
+        metadata = raw.get("metadata")
+        if isinstance(metadata, dict):
+            for key in ID_FIELD_CANDIDATES:
+                value = metadata.get(key)
+                if value:
+                    return str(value)
+    return f"{dataset.benchmark}_{dataset.date_range}_{index:06d}"
+
+
+def _join_list_field(value: Any) -> str | None:
+    if isinstance(value, list):
+        text_items = [str(item) for item in value if item is not None]
+        if text_items:
+            return "\n".join(text_items)
+    return None
+
+
+def _extract_text(raw: Any) -> str | None:
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, dict):
+        for key in TEXT_FIELD_CANDIDATES:
+            value = raw.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+        for key in TEXT_FIELD_CANDIDATES:
+            value = raw.get(key)
+            joined = _join_list_field(value)
+            if joined:
+                return joined
+        for key in LIST_FIELD_CANDIDATES:
+            joined = _join_list_field(raw.get(key))
+            if joined:
+                return joined
+        title = raw.get("title")
+        body = raw.get("body")
+        if isinstance(title, str) and isinstance(body, str):
+            combined = f"{title.strip()}\n\n{body.strip()}"
+            if combined.strip():
+                return combined
+        if isinstance(title, str) and title.strip():
+            return title
+        return json.dumps(raw, ensure_ascii=False)
+    return str(raw)
+
+
+def _normalize_record(raw: Any, dataset: UncheatableEvalDataset, index: int) -> dict[str, str]:
+    text = _extract_text(raw)
+    if text is None or not str(text).strip():
+        raise ValueError(f"Record {index} in {dataset.name} does not contain text")
+    record_id = _extract_id(raw, dataset, index)
+    return {"id": record_id, "text": text, "source": dataset.source_label}
+
+
+@ray.remote(max_retries=3)
+@cached_or_construct_output(success_suffix="SUCCESS")
+def _download_and_convert_single(
+    input_url: str,
+    output_file_path: str,
+    dataset: UncheatableEvalDataset,
+    request_options: _RequestOptions,
+) -> dict[str, Any]:
+    session = requests.Session()
+    retries = Retry(total=5, backoff_factor=1.0, status_forcelist=[500, 502, 503, 504], allowed_methods=["GET"])
+    adapter = HTTPAdapter(max_retries=retries)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+
+    logger.info("Downloading %s from %s", dataset.name, input_url)
+    response = session.get(input_url, headers=request_options.headers, timeout=request_options.timeout)
+    response.raise_for_status()
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise ValueError(f"Failed to decode JSON payload for {dataset.name}") from exc
+
+    if not isinstance(payload, list):
+        raise ValueError(f"Expected list in dataset {dataset.name}, found {type(payload).__name__}")
+
+    fsspec_mkdirs(os.path.dirname(output_file_path), exist_ok=True)
+
+    record_count = 0
+    with fsspec.open(output_file_path, "wt", encoding="utf-8", compression="gzip") as outfile:
+        for index, raw in enumerate(payload):
+            normalized = _normalize_record(raw, dataset, index)
+            json.dump(normalized, outfile, ensure_ascii=False)
+            outfile.write("\n")
+            record_count += 1
+
+    logger.info("Wrote %s records to %s", record_count, output_file_path)
+    return {"records": record_count, "output_file": output_file_path}
+
+
+def _generate_tasks(
+    datasets: Iterable[UncheatableEvalDataset],
+    output_path: str,
+    request_options: _RequestOptions,
+    skip_existing: bool,
+) -> tuple[list[tuple[str, str, UncheatableEvalDataset, _RequestOptions]], list[UncheatableEvalDataset]]:
+    tasks: list[tuple[str, str, UncheatableEvalDataset, _RequestOptions]] = []
+    filtered: list[UncheatableEvalDataset] = []
+    for dataset in datasets:
+        output_file = posixpath.join(output_path, dataset.output_filename())
+        success_file = f"{output_file}.SUCCESS"
+        if skip_existing and fsspec_exists(success_file):
+            logger.info("Skipping %s because output already exists", dataset.name)
+            continue
+        tasks.append((dataset.download_url, output_file, dataset, request_options))
+        filtered.append(dataset)
+    return tasks, filtered
+
+
+def _write_metadata(cfg: UncheatableEvalDownloadConfig, records: list[dict[str, Any]]) -> None:
+    if not records:
+        return
+    metadata_path = posixpath.join(str(cfg.output_path), cfg.metadata_filename)
+    with fsspec.open(metadata_path, "w", encoding="utf-8") as meta_file:
+        json.dump(records, meta_file, indent=2, ensure_ascii=False)
+    logger.info("Wrote metadata to %s", metadata_path)
+
+
+def download_latest_uncheatable_eval(cfg: UncheatableEvalDownloadConfig) -> dict[str, Any]:
+    """Download and normalize the newest Uncheatable Eval dump for each benchmark."""
+
+    request_options = _build_request_options(cfg)
+    entries = _fetch_directory_listing(cfg, request_options)
+    datasets = _parse_available_dumps(entries)
+    latest_datasets = _select_latest_dumps(datasets)
+
+    if not latest_datasets:
+        logger.warning("No datasets found that match the expected naming pattern")
+        return {"success": False, "reason": "no_datasets"}
+
+    output_path = str(cfg.output_path)
+    fsspec_mkdirs(output_path, exist_ok=True)
+
+    tasks, filtered_datasets = _generate_tasks(latest_datasets, output_path, request_options, cfg.skip_existing)
+
+    if not tasks:
+        logger.info("No new datasets to process")
+        return {"success": True, "reason": "already_processed", "skipped": True}
+
+    metadata_records: list[dict[str, Any]] = []
+
+    refs = simple_backpressure(
+        _download_and_convert_single,
+        iter(tasks),
+        max_in_flight=cfg.max_concurrent_downloads,
+        fetch_local=True,
+    )
+
+    for dataset, ref in zip(filtered_datasets, refs, strict=False):
+        try:
+            result = ray.get(ref)
+        except Exception:
+            logger.exception("Failed to process dataset %s", dataset.name)
+            raise
+
+        metadata_records.append(
+            {
+                "benchmark": dataset.benchmark,
+                "start_date": dataset.start_date,
+                "end_date": dataset.end_date,
+                "source": dataset.source_label,
+                "output_file": posixpath.join(output_path, dataset.output_filename()),
+                "records": result.get("records"),
+                "sha": dataset.sha,
+                "size": dataset.size,
+            }
+        )
+
+    _write_metadata(cfg, metadata_records)
+    return {"success": True, "processed": metadata_records}
+
+
+def make_uncheatable_eval_step(
+    *,
+    name: str = "raw/uncheatable-eval/latest",
+    repo_owner: str = "Jellyfish042",
+    repo_name: str = "uncheatable_eval",
+    data_path: str = "data",
+    branch: str = "master",
+    max_concurrent_downloads: int = 8,
+    request_timeout: int = 120,
+    github_token: str | None = None,
+    skip_existing: bool = True,
+) -> ExecutorStep[UncheatableEvalDownloadConfig]:
+    """Create an :class:`ExecutorStep` that downloads the latest Uncheatable Eval dumps."""
+
+    config = UncheatableEvalDownloadConfig(
+        output_path=this_output_path(),
+        repo_owner=ensure_versioned(repo_owner),
+        repo_name=ensure_versioned(repo_name),
+        data_path=ensure_versioned(data_path),
+        branch=ensure_versioned(branch),
+        max_concurrent_downloads=max_concurrent_downloads,
+        request_timeout=request_timeout,
+        github_token=github_token,
+        skip_existing=skip_existing,
+    )
+
+    return ExecutorStep(
+        name=name,
+        fn=download_latest_uncheatable_eval,
+        config=config,
+    )
+
+
+__all__ = [
+    "UncheatableEvalDataset",
+    "UncheatableEvalDownloadConfig",
+    "download_latest_uncheatable_eval",
+    "make_uncheatable_eval_step",
+]


### PR DESCRIPTION
## Description

Fixes #(issue number)
Add code to calculate perplexity across validation sets and accuracy across desired benchmarks. Related to issue #1600 

## Checklist

- [ ] You ran `pre-commit run --all-files` to lint your code
- [ ] You ran 'pytest' to test your code
- [ ] Delete this checklist