### PR TITLE
Pin `levanter[serve]` to `775ac7c6`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "google-cloud-storage-transfer",
     "jax==0.6.2",
     "haliax>=1.4.dev381",
-    "levanter[serve]@git+https://github.com/marin-community/levanter.git",
+    "levanter[serve]@git+https://github.com/marin-community/levanter.git@775ac7c6c",
     "lz4",
     "multiprocess==0.70.16",
     "numpy",


### PR DESCRIPTION
- Since Sept '24[^1], Marin's Levanter dep was a "pin" of the form `>=1.2.devNNNN`
  - When Levanter PRs land, `1.2.devNNNN` versions are published by [publish_dev.yml]
    - e.g. [levanter#1127] → [publish_dev#315] → [1.2.dev1500]
  - If Marin needs the changes, it may bump its pin
    - e.g. [marin#1522][#1522] / [pin][`levanter>=1.2.dev1500` pin]
    - Marin may have frequently skipped a Levanter bump, when it actually needed more recent changes, since the convention was use `>=` rather than `==`
- [#1591] moved to a `==` pin ([`levanter==1.2.dev1535`])
- [#1616] moved to a "floating" dep (against [levanter@main])

It would be good to properly pin this dep, and get a better sense of how "linked" PRs to each repo tend to be.
- If Marin PRs frequently require a corresponding Levanter PR, we may want to move Levanter src into this repo.
- [openathena.s3.amazonaws.com/marin-levanter.html] implies that 5-10% of PRs in each repo are linked in this way, but it may have false-negatives that rely on the `>=`.

The current floating dep (and previous `>=`) can cause a given Marin SHA to behave differently (or break) over time. `uv.lock` might mitigate this, but I'd like to try properly pinning the Marin→Levanter dep, to get some real data about how synced the 2 repos are (and keep things repro-able / deterministic, and shore up DX / dep-mgmt issues that the floating pins were working around).

To that end, this pins https://github.com/marin-community/levanter/commit/775ac7c6c6f913fd9fed263b26bdb7169df349cc (current [levanter@main]).

[openathena.s3.amazonaws.com/marin-levanter.html]: https://openathena.s3.amazonaws.com/marin-levanter.html

[publish_dev.yml]: https://github.com/marin-community/levanter/actions/workflows/publish_dev.yaml
[Levanter PyPI]: https://pypi.org/project/levanter/
[levanter#1127]: https://github.com/marin-community/levanter/pull/1127
[publish_dev#315]: https://github.com/marin-community/levanter/actions/runs/16916902862
[1.2.dev1500]: https://pypi.org/project/levanter/1.2.dev1500/

[#224]: https://github.com/marin-community/marin/pull/224
[#1522]: https://github.com/marin-community/marin/pull/1522
[#1591]: https://github.com/marin-community/marin/pull/1591
[#1616]: https://github.com/marin-community/marin/pull/1616

[`levanter==1.2.dev1500`]: https://pypi.org/project/levanter/1.2.dev1500/
[`levanter>=1.2.dev1500` pin]: https://github.com/marin-community/marin/pull/1522/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R36
[`levanter==1.2.dev1535`]: https://github.com/marin-community/marin/pull/1591/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R25
[`levanter>=1.1.dev992`]: https://github.com/marin-community/marin/pull/224/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R38

[^1]: Since [#224] / [`levanter>=1.1.dev992`], Sept '24

[marin-community/marin#1646]: https://github.com/marin-community/marin/pull/1646
[levanter@main]: https://github.com/marin-community/levanter

<!-- Synced with https://gist.github.com/ecea42bb2f3cb15a0a895f73cfb06c4d/81872e99d8cd280ae8d35b5d566553c0b0d9b6b9 via [github-pr.py](https://github.com/ryan-williams/git-helpers/blob/main/github/github-pr.py) -->