### PR TITLE
Add `ffmpeg` to docker image

### DIFF
--- a/docker/marin/Dockerfile.cluster
+++ b/docker/marin/Dockerfile.cluster
@@ -45,6 +45,9 @@ RUN sudo rm -rf /var/lib/apt/lists/* \
       zlib1g-dev \
  && sudo rm -rf /var/lib/apt/lists/*
 
+# Install ffmpeg
+RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
+
 # Setup gcsfuse repository and install
 RUN export GCSFUSE_REPO=gcsfuse-`lsb_release -c -s` && echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -


### PR DESCRIPTION
## Description

This PR adds an `ffmpeg` install to the cluster docker image. Avoids needing to install `ffmpeg` as a Ray runtime dependency, speeding up job setup. `ffmpeg` is required by [`torchcodec`](https://github.com/pytorch/torchcodec), which is very useful for video training.
