### PR TITLE
Turn on xdist in CI.

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -71,4 +71,4 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           CI: true
         run: |
-          PYTHONPATH=tests:. uv run --extra=cpu pytest --durations=5 --tb=no -m 'not slow' -vv tests/
+          PYTHONPATH=tests:. uv run --extra=cpu pytest -n4 --durations=5 --tb=no -m 'not slow' -vv tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -315,6 +315,8 @@ packages = ["src/marin", "experiments"]
 
 [tool.pytest.ini_options]
 timeout = 300
+# Make sure we timeout before CI kills us
+session-timeout=500
 filterwarnings = ["ignore::DeprecationWarning"]
 log_format = "%(asctime)s %(levelname)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"


### PR DESCRIPTION
Also set the overall test session timeout to lower than the Github CI timeout.

This ensures we get a log of the failing/hung tests before the runner is terminated.