### PR TITLE
docs: recommend python 3.13

### DIFF
--- a/docs/dev-guide/building-docs.md
+++ b/docs/dev-guide/building-docs.md
@@ -6,7 +6,7 @@ This guide explains how to build, test, and maintain the Marin documentation.
 
 Before you begin, ensure you have the following installed:
 
-- Python 3.11 or higher
+- Python 3.13 or higher
 - uv (Python package manager)
 - Git
 

--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -10,7 +10,7 @@
 ```bash
 git clone https://github.com/marin-community/marin.git
 cd marin
-uv venv --python 3.11
+uv venv --python 3.13
 source .venv/bin/activate
 uv sync --group dev
 pre-commit install

--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -6,7 +6,7 @@ In this tutorial, you will install Marin on your local machine.
 
 Before you begin, ensure you have the following installed:
 
-- Python 3.11 or higher
+- Python 3.13 or higher
 - uv (Python package manager)
 - Git
 - On macOS, install additional build tools for SentencePiece:
@@ -30,13 +30,13 @@ If you want to set up a TPU cluster, see [TPU Setup](tpu-cluster-setup.md).
 
 2. Create and activate a virtual environment:
    ```bash
-   uv venv --python 3.11
+   uv venv --python 3.13
    source .venv/bin/activate  # On Windows: .venv\Scripts\activate
    ```
 
    or with conda:
    ```bash
-   conda create --name marin python=3.11 pip
+   conda create --name marin python=3.13 pip
    conda activate marin
    ```
 


### PR DESCRIPTION
## Summary
- update documentation prerequisites to recommend Python 3.13 or newer
- adjust virtual environment setup instructions to use Python 3.13, including conda examples

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d5ce3d45848322b4d8cd759cd731a3