### PR TITLE
Fix Arrow RPC issue with large buffers

### DIFF
--- a/experiments/exp1247_rl_async.py
+++ b/experiments/exp1247_rl_async.py
@@ -186,7 +186,7 @@ def rl_train(name: str) -> ExecutorStep:
             logdir=OutputName("tblogs"),
         ),
         mp=jmp.get_policy("p=f32,c=bfloat16"),
-        train_batch_size=256,
+        train_batch_size=8,
         num_train_steps=50000,
         steps_per_eval=100,
         checkpointer=CheckpointerConfig(
@@ -275,7 +275,7 @@ def rl_train(name: str) -> ExecutorStep:
         rollout_worker_config=rollout_worker,
         train_worker_config=train_worker,
         inference_tpu_type="v5litepod-4",
-        train_tpu_type="v5litepod-128",
+        train_tpu_type="v5litepod-4",
         num_inference_workers=1,
         num_train_slices=1,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -315,8 +315,6 @@ packages = ["src/marin", "experiments"]
 
 [tool.pytest.ini_options]
 timeout = 300
-# Make sure we timeout before CI kills us
-session-timeout=500
 filterwarnings = ["ignore::DeprecationWarning"]
 log_format = "%(asctime)s %(levelname)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"
@@ -325,5 +323,5 @@ markers = [
     "slow: mark tests as slow for CI - use -m 'not slow'"
 ]
 
-# pytest-xdist defaults
-dist = "worksteal"
+# Make sure we timeout before CI kills us
+addopts = "--session-timeout=500 --dist=worksteal"

--- a/src/marin/post_training/weight_transfer/arrow_flight.py
+++ b/src/marin/post_training/weight_transfer/arrow_flight.py
@@ -398,7 +398,6 @@ class ArrowFlightClient(WeightTransferClient):
 
             # Read the record batches
             table = flight_reader.read_all()
-            print(table.schema)
             print(table.schema.metadata)
             # Use the actual weight ID from the server, not the requested one
             received_weight_id = int(table.schema.metadata[b"weight_id"].decode("utf-8"))

--- a/src/marin/post_training/weight_transfer/ray.py
+++ b/src/marin/post_training/weight_transfer/ray.py
@@ -22,11 +22,9 @@ high-performance distributed communication between training and inference worker
 import logging
 import time
 
-import haliax as hax
 import jax
-import numpy as np
 import ray
-from haliax.util import is_named_array
+from haliax import state_dict as hsd
 from jaxtyping import PyTree
 from levanter.utils.jax_utils import barrier_sync
 
@@ -80,27 +78,17 @@ class RayRemotingServer(WeightTransferServer):
             logger.info(f"Serving weights for weight_id {weight_id} via Ray remoting...")
             barrier_sync()
 
-            # Convert Levanter model params (NamedArrays) to numpy arrays for Ray
-            def convert_to_numpy(x):
-                if is_named_array(x):
-                    return np.array(x.array)
-                elif hasattr(x, "shape"):
-                    return np.array(x)
-                else:
-                    return x
+            state_dict = hsd.to_numpy_state_dict(model)
 
-            numpy_pytree = jax.tree.map(convert_to_numpy, model)
             barrier_sync()
 
             if jax.process_index() == 0:
                 logger.info(f"Updating Ray object store with new weights at weight_id {weight_id}...")
-                leaves, treedef = jax.tree.flatten(numpy_pytree)
-                weight_refs = {
-                    "leaves": [ray.put(leaf) for leaf in leaves],
-                    "treedef": ray.put(treedef),
-                }
-                ray.get(self.coordinator.put_weight_refs.remote(weight_id, weight_refs))
-                del weight_refs
+                ref_dict = {}
+                for k, v in state_dict.items():
+                    ref_dict[k] = ray.put(v)
+
+                ray.get(self.coordinator.put_weight_refs.remote(weight_id, ref_dict))
                 self.metrics.successful_transfers += 1
 
                 logger.info(f"Served weights for weight_id {weight_id} via Ray remoting (process {jax.process_index()})")
@@ -127,9 +115,7 @@ class RayRemotingClient(WeightTransferClient):
         config: WeightTransferConfig,
     ):
         self.config = config
-
         self.coordinator = get_or_create_actor(RayWeightCoordinator, config.coordinator_name)
-
         self.last_weight_id = None
 
         # Metrics tracking
@@ -146,41 +132,19 @@ class RayRemotingClient(WeightTransferClient):
             if weight_refs is None or weight_id == self.last_weight_id:
                 return None
 
-            # Get individual leaf arrays and treedef from object store
-            leaf_refs = weight_refs["leaves"]
-            treedef_ref = weight_refs["treedef"]
+            state_dict = {}
+            for k, ref in weight_refs.items():
+                array = ray.get(ref)
+                state_dict[k] = array
 
-            # Get all leaves and treedef
-            leaves = [ray.get(ref) for ref in leaf_refs]
-            treedef = ray.get(treedef_ref)
-
-            # Reconstruct the pytree from numpy arrays
-            numpy_pytree = jax.tree.unflatten(treedef, leaves)
-
-            # Convert back to JAX arrays and reconstruct NamedArrays structure
-            if old_model is not None:
-
-                def convert_from_numpy(numpy_val, target_val=None):
-                    if target_val is not None and is_named_array(target_val):
-                        # Reconstruct NamedArray with same axes as target
-                        return hax.named(jax.numpy.array(numpy_val), target_val.axes)
-                    else:
-                        return jax.numpy.array(numpy_val)
-
-                def _convert_tree(numpy_tree, target_tree):
-                    return jax.tree.map(convert_from_numpy, numpy_tree, target_tree)
-
-                levanter_pytree = _convert_tree(numpy_pytree, old_model)
-            else:
-                # Without old_model, just convert to JAX arrays (lose NamedArray structure)
-                levanter_pytree = jax.tree.map(lambda x: jax.numpy.array(x), numpy_pytree)
+            model = hsd.from_state_dict(old_model, state_dict)
 
             self.metrics.successful_receives += 1
             self.last_weight_id = weight_id
 
             logger.info(f"Received weights for weight_id {weight_id} via Ray remoting")
 
-            return levanter_pytree
+            return model
 
         except Exception as e:
             self.metrics.failed_receives += 1


### PR DESCRIPTION
Ran into 2 issues:

* The default Arrow binary type only supports 2GB arrays (we're serializing our state dict into a set of binary scalars)
* Switching to the large_binary type works but yields a separate issue that a single RecordBatch has a 2GB limit

So we bite the bullet and chunk the arrays 32M element boundaries instead. We end up with a second memory copy of the arrays as a result of this, which may be painful for larger models. It might be possible to restore directly into device memory with a more clever implementation...