### PR TITLE
Remove unused _pip_packages and extras fields from Evalutor.

### DIFF
--- a/src/marin/evaluation/evaluators/evaluator.py
+++ b/src/marin/evaluation/evaluators/evaluator.py
@@ -16,7 +16,6 @@ import os
 import shutil
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import ClassVar
 
 from experiments.evals.resource_configs import ResourceConfig
 from marin.evaluation.evaluation_config import EvalTaskConfig
@@ -85,9 +84,6 @@ class ModelConfig:
 
 
 class Evaluator(ABC):
-
-    _pip_packages: ClassVar[list[Dependency]]
-    _py_modules: ClassVar[list[Dependency]]
 
     def _get_scheduling_strategy(self, resource_config: ResourceConfig | None):
         if resource_config is None:

--- a/src/marin/evaluation/evaluators/helm_evaluator.py
+++ b/src/marin/evaluation/evaluators/helm_evaluator.py
@@ -54,7 +54,7 @@ class HELMEvaluator(VllmTpuEvaluator):
         Returns the runtime environment to run the evaluator on the Ray cluster.
         """
         return build_runtime_env_for_packages(
-            pip_packages=["crfm-helm@git+https://github.com/stanford-crfm/helm.git@local_vllm"]
+            extra=["eval", "tpu"], pip_packages=["crfm-helm@git+https://github.com/stanford-crfm/helm.git@local_vllm"]
         )
 
     @staticmethod

--- a/src/marin/evaluation/evaluators/levanter_lm_eval_evaluator.py
+++ b/src/marin/evaluation/evaluators/levanter_lm_eval_evaluator.py
@@ -43,7 +43,7 @@ class LevanterLmEvalEvaluator(LevanterTpuEvaluator):
         Returns the runtime environment to run the evaluator on the Ray cluster.
         """
         return build_runtime_env_for_packages(
-            extra=[],
+            extra=["eval", "tpu"],
             pip_packages=["statsmodels==0.14.4"],
             env_vars={
                 "TOKENIZERS_PARALLELISM": "false",

--- a/src/marin/evaluation/evaluators/levanter_tpu_evaluator.py
+++ b/src/marin/evaluation/evaluators/levanter_tpu_evaluator.py
@@ -60,7 +60,7 @@ class LevanterTpuEvaluator(Evaluator, ABC):
         Returns the runtime environment to run the evaluator on the Ray cluster.
         """
         return build_runtime_env_for_packages(
-            extra=["eval"],
+            extra=["eval", "tpu"],
             env_vars={
                 "HF_DATASETS_TRUST_REMOTE_CODE": "1",
                 "TOKENIZERS_PARALLELISM": "false",

--- a/src/marin/evaluation/evaluators/vllm_tpu_evaluator.py
+++ b/src/marin/evaluation/evaluators/vllm_tpu_evaluator.py
@@ -122,7 +122,7 @@ class VllmTpuEvaluator(Evaluator, ABC):
         """
         Returns the runtime environment to run the evaluator on the Ray cluster.
         """
-        return build_runtime_env_for_packages()
+        return build_runtime_env_for_packages(extra=["eval", "tpu"])
 
     def launch_evaluate_with_ray(
         self,


### PR DESCRIPTION
Fix dependencies for the LevanterLM evaluator. It inherits from the LevanterTpuEvaluator which correctly requests the "eval" extra, but this is overridden by the LmEvaluator and the dependency is lost.

The only use of LevanterTpu evaluator seems to be to be subclassed by the lm_eval evaluator, perhaps we should remove it?

Fixes #1666 (needs verification).