### PR TITLE
Only accept scalars & numpy values to the curriculum actor

### DIFF
--- a/scripts/ray/cluster.py
+++ b/scripts/ray/cluster.py
@@ -363,8 +363,18 @@ def init_worker(ctx, name):
 @cli.command("dashboard")
 @click.option("--port", default=9999, help="Proxy dashboard port")
 @click.pass_context
-def open_multi_dashboard(ctx, port):
+def open_dashboard(ctx, port):
     """Open dashboard for all active Ray clusters."""
+    config_obj = ctx.obj.config_obj
+    if config_obj:
+        with ray.ray_dashboard(ray.DashboardConfig.from_cluster(ctx.obj.config_file)) as dashboard:
+            print(f"Connected to {config_obj.cluster_name} dashboard at {dashboard.get_dashboard_url()}")
+            try:
+                time.sleep(86400)
+            except KeyboardInterrupt:
+                print("\nShutting down...")
+        return
+
     with ray.ray_dashboard(ray.DashboardConfig(proxy_port=port)) as conn:
         if not conn.clusters:
             print("No active clusters found")
@@ -382,8 +392,7 @@ def open_multi_dashboard(ctx, port):
             print("\nPress Ctrl+C to stop")
 
             try:
-                while True:
-                    time.sleep(1)
+                time.sleep(86400)
             except KeyboardInterrupt:
                 print("\nShutting down...")
 

--- a/src/marin/rl/curriculum.py
+++ b/src/marin/rl/curriculum.py
@@ -27,8 +27,6 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 
 import fsspec
-import jax
-import jax.numpy as jnp
 import numpy as np
 
 from marin.rl.environments.base import EnvConfig
@@ -357,11 +355,11 @@ class Curriculum:
         weights = {k: v / total for k, v in weights.items()}
         return weights
 
-    def sample_lesson(self, prng_key: jax.Array) -> str:
+    def sample_lesson(self, seed: int) -> str:
         """Sample a lesson for training based on current weights.
 
         Args:
-            prng_key: Random key for sampling.
+            seed: Integer seed for random sampling.
 
         Returns:
             Lesson ID string.
@@ -371,9 +369,11 @@ class Curriculum:
             raise RuntimeError("No active lessons available for sampling")
 
         lesson_ids = list(weights.keys())
-        probs = jnp.array([weights[lesson_id] for lesson_id in lesson_ids])
-        idx = jax.random.choice(prng_key, len(lesson_ids), p=probs)
-        lesson_id = lesson_ids[int(idx)]
+        probs = np.array([weights[lesson_id] for lesson_id in lesson_ids])
+
+        rng = np.random.default_rng(seed)
+        idx = rng.choice(len(lesson_ids), p=probs)
+        lesson_id = lesson_ids[idx]
 
         return lesson_id
 

--- a/src/marin/rl/rollout_worker.py
+++ b/src/marin/rl/rollout_worker.py
@@ -483,7 +483,8 @@ class RolloutWorker:
                     self.tracker.log(log_metrics, step=step)
 
             logger.info("Generating rollout batch...")
-            rng, seed = jax.random.split(rng)
+            rng, seed_key = jax.random.split(rng)
+            seed = int(seed_key[0])
             lesson_id = ray.get(self.curriculum_actor.sample_lesson.remote(seed))
             logger.info(f"Sampled lesson '{lesson_id}' from curriculum")
 

--- a/tests/rl/test_curriculum.py
+++ b/tests/rl/test_curriculum.py
@@ -14,7 +14,6 @@
 
 """Tests for adaptive curriculum learning system."""
 
-import jax
 import numpy as np
 import pytest
 
@@ -93,7 +92,7 @@ def test_single_lesson_curriculum():
     assert abs(weights["only_lesson"] - 1.0) < 0.01
 
     # Should be able to sample
-    lesson_name = curriculum.sample_lesson(prng_key=jax.random.PRNGKey(0))
+    lesson_name = curriculum.sample_lesson(seed=0)
     assert lesson_name == "only_lesson"
 
 
@@ -202,7 +201,7 @@ def test_sampling_distribution():
     # Sample many times and check distribution
     samples = []
     for i in range(1000):
-        lesson_name = curriculum.sample_lesson(prng_key=jax.random.PRNGKey(i))
+        lesson_name = curriculum.sample_lesson(seed=i)
         samples.append(lesson_name)
 
     # Count samples


### PR DESCRIPTION
We were inadvertently using jax.random.choice for sampling, which by default attempts to grab access to the TPU device. As the curriculum actor doesn't declare a TPU resource, this results in a conflict with whatever other task is on the machine.