### PR TITLE
Tweaks to the RL experiment template and plateau detection

### DIFF
--- a/experiments/exp1247_rl_async.py
+++ b/experiments/exp1247_rl_async.py
@@ -288,6 +288,8 @@ def rl_train(name: str) -> ExecutorStep:
             alpha=3,
             # Don't allow resampling.
             max_samples=1,
+            # Explicitly drop rollouts from old weights.
+            max_rollout_delay=32,
         ),
         kl_coef=0.05,
         initial_checkpoint=MODEL_NAME,
@@ -305,7 +307,7 @@ def rl_train(name: str) -> ExecutorStep:
         max_output_length=MAX_OUTPUT_TOKENS,
         pad_token_id=(tokenizer.pad_token_id if tokenizer.pad_token_id is not None else tokenizer.eos_token_id),
         n_prompts_per_step=16,
-        n_generations=4,
+        n_generations=16,
         temperature=0.7,
         log_freq=5,
         max_rollouts=100000,
@@ -340,7 +342,7 @@ def main():
         return
 
     experiments = [
-        rl_train(name="llama-1b-math-rl-test-011"),
+        rl_train(name="llama-1b-math-rl-test-power-012"),
     ]
 
     executor_main(

--- a/src/marin/rl/rl_losses.py
+++ b/src/marin/rl/rl_losses.py
@@ -177,17 +177,7 @@ def rloo_loss_with_importance_sampling(
 
 
 def compute_rloo_advantages(rollouts: list[Rollout]) -> np.ndarray:
-    """Compute RLOO (Reward Leave-One-Out) advantages for a group of rollouts.
-
-    This is a standalone version of RolloutGroup.compute_rloo_advantages() that
-    can be used independently.
-
-    Args:
-        rollouts: List of rollouts to compute advantages for
-
-    Returns:
-        Array of advantages, one per rollout
-    """
+    """Compute RLOO (Reward Leave-One-Out) advantages for a group of rollouts."""
     rewards = np.array([r.episode_reward for r in rollouts])
     n = len(rewards)
     if n <= 1:


### PR DESCRIPTION
* Set an explicit rollout delay to avoid training on old batches.

This should be captured implicitly by the `alpha` parameter on the replay buffer, but that only takes into account when the training worker ingested the data, not the training weight it came from. Dropping older buffers is a sanity check against rollout workers which have fallen behind for some reason.

The weight used to tag a batch is the weight the worker has loaded when the batch _finishes_, so we shouldn't accidentally throw away any batches that simply took a while to produce.

* Up the default number of generations to 16 to get a better RLOO advantage sample.
* Use the mean over abs(rewards) when computing plateaus.

We end up with plateaus which look like:

<img width="2076" height="2401" alt="image" src="https://github.com/user-attachments/assets/1e7e4c80-ea7a-4f91-95d7-07d4ae0216b4" />

I'm not totally happy with this but it's better than before, and someone can probably do this better than me anyway...