### PR TITLE
Refactor rollout & inference context code.

### DIFF
--- a/docs/design/rl-rollout-metadata-migration.md
+++ b/docs/design/rl-rollout-metadata-migration.md
@@ -192,7 +192,7 @@ class ReplayBufferConfig:
 class ReplayBuffer:
     capacity: int
     local_batch_size: int
-    recency_alpha: float
+    alpha: float
     total_processes: int
     process_id: int
     max_samples: int
@@ -299,7 +299,7 @@ Update ReplayBuffer instantiation to use renamed parameter:
 self.replay_buffer = ReplayBuffer(
     capacity=config.replay_buffer.capacity,
     local_batch_size=config.trainer.train_batch_size,
-    recency_alpha=config.replay_buffer.alpha,
+    alpha=config.replay_buffer.alpha,
     total_processes=jax.process_count(),
     process_id=jax.process_index(),
     max_samples=config.replay_buffer.max_samples,
@@ -391,7 +391,7 @@ Also update all ReplayBuffer instantiations in tests to use the new parameter na
 replay_buffer = ReplayBuffer(
     capacity=100,
     local_batch_size=4,
-    recency_alpha=3.0,
+    alpha=3.0,
     total_processes=1,
     process_id=0,
     max_samples=-1,

--- a/docs/design/rl-rollout-metadata-migration.md
+++ b/docs/design/rl-rollout-metadata-migration.md
@@ -1,0 +1,462 @@
+# RL Rollout Metadata Migration
+
+## Motivation
+
+Currently, rollout metadata (worker_id, timestamp, weight_step) lives at the batch level in `RolloutMetadata`, attached to `RolloutBatch`. This creates several issues:
+
+1. **Replay buffer filtering is imprecise**: When filtering stale rollouts by timestamp or weight_step, we can only filter entire batches, not individual rollouts
+2. **Metadata is per-batch, not per-rollout**: All rollouts in a batch share the same metadata, but conceptually each rollout has its own creation context
+3. **Incomplete timestamp filtering**: The `max_rollout_timestamp_delay` feature is partially implemented but not fully functional
+
+This migration moves metadata from the batch level to the rollout level, enabling precise filtering and completing the timestamp-based staleness detection.
+
+## Design
+
+### Current Structure
+
+```python
+@dataclass
+class RolloutMetadata:
+    worker_id: str
+    timestamp: float
+    weight_step: int
+
+class Rollout(eqx.Module):
+    env_name: str
+    env_example_id: str
+    prompt_tokens: jax.Array
+    response_tokens: jax.Array
+    response_logprobs: jax.Array
+    token_rewards: jax.Array
+    episode_reward: float
+    # No metadata
+
+class RolloutBatch(eqx.Module):
+    groups: list[RolloutGroup]
+    metadata: RolloutMetadata  # Batch-level metadata
+```
+
+### Proposed Structure
+
+```python
+@dataclass
+class RolloutMetadata:
+    """Metadata about when/where a rollout was generated."""
+    worker_id: str
+    timestamp: float
+    weight_step: int
+
+class Rollout(eqx.Module):
+    """A single rollout: one prompt + one generated response + rewards."""
+
+    env_name: str
+    env_example_id: str
+    prompt_tokens: jax.Array
+    response_tokens: jax.Array
+    response_logprobs: jax.Array
+    token_rewards: jax.Array
+    episode_reward: float
+
+    metadata: RolloutMetadata  # Now on each rollout
+
+class RolloutBatch(eqx.Module):
+    """A batch of rollout groups with metadata."""
+
+    groups: list[RolloutGroup]
+    metadata: RolloutMetadata  # Kept for backward compatibility (redundant)
+```
+
+### Key Principles
+
+1. **Environments don't know about metadata**: The environment interface remains clean and focused on domain logic
+2. **Worker attaches metadata**: After getting rollouts from environment, the rollout worker wraps each with metadata
+3. **Replay buffer reads from rollout**: Filtering logic uses `rollout.metadata` instead of `batch.metadata`
+4. **Backward compatible**: Keep `RolloutBatch.metadata` during transition to avoid breaking serialized data
+
+## Implementation Plan
+
+### Phase 1: Add metadata field to Rollout
+
+**File:** `src/marin/rl/types.py`
+
+```python
+class Rollout(eqx.Module):
+    """A single rollout: one prompt + one generated response + rewards."""
+
+    env_name: str
+    env_example_id: str
+    prompt_tokens: jax.Array
+    response_tokens: jax.Array
+    response_logprobs: jax.Array
+    token_rewards: jax.Array
+    episode_reward: float
+
+    # Metadata about when/where this rollout was generated
+    metadata: RolloutMetadata
+```
+
+Keep `RolloutMetadata` and `RolloutBatch` unchanged.
+
+### Phase 2: Update rollout worker to attach metadata
+
+**File:** `src/marin/rl/rollout_worker.py`
+
+The rollout worker should:
+1. Generate rollouts from environment (environment stays unchanged)
+2. Create metadata once per batch
+3. Attach metadata to each rollout
+4. Create RolloutBatch (with duplicate metadata for backward compat)
+
+```python
+def _sample_batch(self, lesson_id: str, mode: str, rng) -> tuple[RolloutBatch | None, dict | None]:
+    """Sample a batch of rollouts from the environment for the given lesson ID."""
+
+    # ... existing setup code ...
+
+    # Generate rollouts from environment (no metadata needed here)
+    with (
+        self.config.trainer.device_mesh,
+        hax.axis_mapping(self.config.trainer.compute_axis_mapping),
+    ):
+        rollout_groups, metrics = env.sample(
+            inference_ctx=policy_ctx,
+            n_examples=n_examples,
+            n_generations=n_generations,
+            temperature=temperature,
+            prng_key=rng,
+            mode=mode,
+        )
+
+    if len(rollout_groups) == 0:
+        logger.warning("No valid rollouts generated in this batch...")
+        return None, None
+
+    # Create metadata once for this batch
+    batch_metadata = RolloutMetadata(
+        worker_id=f"{socket.gethostname()}_{os.getpid()}",
+        timestamp=time.time(),
+        weight_step=self._current_weight_step,
+    )
+
+    # Attach metadata to each rollout in each group
+    rollout_groups_with_metadata = []
+    for group in rollout_groups:
+        rollouts_with_metadata = []
+        for rollout in group.rollouts:
+            # Create new rollout with metadata attached
+            rollout_with_meta = eqx.tree_at(
+                lambda r: r.metadata,
+                rollout,
+                batch_metadata
+            )
+            rollouts_with_metadata.append(rollout_with_meta)
+
+        rollout_groups_with_metadata.append(
+            RolloutGroup(rollouts=rollouts_with_metadata)
+        )
+
+    rollout_batch = RolloutBatch(
+        groups=rollout_groups_with_metadata,
+        metadata=batch_metadata,  # Keep for backward compatibility
+    )
+
+    return rollout_batch, metrics
+```
+
+### Phase 3: Update replay buffer to read from rollout metadata
+
+**File:** `src/marin/rl/replay_buffer.py`
+
+#### Update config
+
+```python
+@dataclass
+class ReplayBufferConfig:
+    """Configuration for the replay buffer."""
+
+    capacity: int
+    alpha: float
+    max_samples: int
+
+    max_rollout_step_delay: int
+    """Maximum age of rollouts in training steps."""
+
+    max_rollout_timestamp_delay: float = 3600.0
+    """Maximum age of rollouts in seconds."""
+```
+
+#### Update ReplayBuffer fields
+
+```python
+@dataclass
+class ReplayBuffer:
+    capacity: int
+    local_batch_size: int
+    recency_alpha: float
+    total_processes: int
+    process_id: int
+    max_samples: int
+    max_rollout_step_delay: int
+    max_rollout_timestamp_delay: float  # Renamed for clarity
+    loss_module: RLLossModule
+    # ... rest unchanged ...
+```
+
+#### Update set_current_step to use rollout.metadata
+
+```python
+def set_current_step(self, step: int) -> None:
+    """Set current training step and filter stale rollouts."""
+    self._current_step = step
+    min_time = time.time() - self.max_rollout_timestamp_delay
+    min_step = step - self.max_rollout_step_delay
+
+    logger.info(
+        "Discarding rollouts older than step %d or timestamp %.0f (current step %d)",
+        min_step, min_time, step
+    )
+
+    with self._lock:
+        total_removed = 0
+        for env_name in self.rollout_storage:
+            rollouts = self.rollout_storage[env_name]
+            before = len(rollouts)
+
+            # Filter using rollout.metadata instead of batch metadata
+            self.rollout_storage[env_name] = [
+                r for r in rollouts
+                if (r.rollout.metadata.weight_step >= min_step and
+                    r.rollout.metadata.timestamp > min_time)
+            ]
+
+            total_removed += before - len(self.rollout_storage[env_name])
+
+        total_remaining = sum(len(rollouts) for rollouts in self.rollout_storage.values())
+
+        if total_removed > 0:
+            logger.info(
+                f"Filtered {total_removed} stale rollouts "
+                f"(min_step={min_step}, min_time={min_time:.0f}), "
+                f"{total_remaining} remaining"
+            )
+```
+
+#### Update add_batches to read from rollout.metadata
+
+```python
+def add_batches(self, new_batches: list[RolloutBatch]) -> None:
+    """Add new rollout batches into the replay buffer."""
+    env_examples: dict[str, list[RolloutWithCount]] = defaultdict(list)
+
+    for batch in new_batches:
+        if not batch.groups or not batch.groups[0].rollouts:
+            continue
+
+        # Read weight_step from first rollout's metadata
+        first_rollout = batch.groups[0].rollouts[0]
+        weight_step = first_rollout.metadata.weight_step
+
+        if weight_step < self._current_step - self.max_rollout_step_delay:
+            logger.info(
+                f"Skipping stale rollout batch "
+                f"(weight_step={weight_step}, current_step={self._current_step})"
+            )
+            continue
+
+        self._total_batches_added += 1
+
+        for group in batch.groups:
+            advantages = self.loss_module.compute_advantages(group.rollouts)
+            for rollout, advantage in zip(group.rollouts, advantages, strict=True):
+                individual = RolloutWithCount(
+                    rollout=rollout,
+                    advantage=advantage,
+                    usage_count=0,
+                    weight_step=weight_step,
+                )
+                env_examples[rollout.env_name].append(individual)
+
+    with self._lock:
+        for env_name, examples in env_examples.items():
+            if env_name in self.rollout_storage:
+                self.rollout_storage[env_name].extend(examples)
+            else:
+                self.rollout_storage[env_name] = examples
+
+            if len(self.rollout_storage[env_name]) > self.capacity:
+                self.rollout_storage[env_name] = (
+                    self.rollout_storage[env_name][-self.capacity:]
+                )
+```
+
+### Phase 4: Update train_worker.py
+
+**File:** `src/marin/rl/train_worker.py`
+
+Update ReplayBuffer instantiation to use renamed parameter:
+
+```python
+self.replay_buffer = ReplayBuffer(
+    capacity=config.replay_buffer.capacity,
+    local_batch_size=config.trainer.train_batch_size,
+    recency_alpha=config.replay_buffer.alpha,
+    total_processes=jax.process_count(),
+    process_id=jax.process_index(),
+    max_samples=config.replay_buffer.max_samples,
+    max_rollout_step_delay=config.replay_buffer.max_rollout_step_delay,
+    max_rollout_timestamp_delay=config.replay_buffer.max_rollout_timestamp_delay,
+    loss_module=self.loss_module,
+)
+```
+
+### Phase 5: Update rl_job.py config
+
+**File:** `src/marin/rl/rl_job.py`
+
+Add timestamp delay parameter:
+
+```python
+@dataclass
+class TrainParams:
+    """RL-specific training configuration parameters."""
+
+    optimizer: OptimizerConfig
+    rl_loss: "RLLossModule"
+
+    max_samples_per_rollout: int = 1
+    max_rollout_delay: int = 1
+
+    max_rollout_timestamp_delay: float = 3600.0
+    """Maximum age of rollouts in seconds. Negative means no limit."""
+
+    replay_buffer_capacity: int = 4096
+    replay_buffer_alpha: float = 3.0
+```
+
+Wire it through to ReplayBufferConfig:
+
+```python
+replay_buffer = ReplayBufferConfig(
+    capacity=self.config.train_params.replay_buffer_capacity,
+    alpha=self.config.train_params.replay_buffer_alpha,
+    max_samples=self.config.train_params.max_samples_per_rollout,
+    max_rollout_step_delay=self.config.train_params.max_rollout_delay,
+    max_rollout_timestamp_delay=self.config.train_params.max_rollout_timestamp_delay,
+)
+```
+
+### Phase 6: Update all test files
+
+Update test helpers to create rollouts with metadata:
+
+**Pattern:**
+
+```python
+# Before: Rollout without metadata
+rollout = Rollout(
+    env_name="test_env",
+    env_example_id="example_1",
+    prompt_tokens=prompt_tokens,
+    response_tokens=response_tokens,
+    response_logprobs=response_logprobs,
+    token_rewards=token_rewards,
+    episode_reward=episode_reward,
+)
+
+# After: Rollout with metadata
+rollout = Rollout(
+    env_name="test_env",
+    env_example_id="example_1",
+    prompt_tokens=prompt_tokens,
+    response_tokens=response_tokens,
+    response_logprobs=response_logprobs,
+    token_rewards=token_rewards,
+    episode_reward=episode_reward,
+    metadata=RolloutMetadata(
+        worker_id="test_worker",
+        timestamp=time.time(),
+        weight_step=0,
+    ),
+)
+```
+
+**Files to update:**
+- `tests/rl/test_replay_buffer.py` - Update `create_test_batch` helper
+- `tests/rl/test_rollout_storage.py` - Update `create_test_rollout` helper
+- `tests/rl/integration/tasks.py` - Update both task helpers
+
+Also update all ReplayBuffer instantiations in tests to use the new parameter name:
+
+```python
+replay_buffer = ReplayBuffer(
+    capacity=100,
+    local_batch_size=4,
+    recency_alpha=3.0,
+    total_processes=1,
+    process_id=0,
+    max_samples=-1,
+    max_rollout_step_delay=1000,
+    max_rollout_timestamp_delay=3600.0,  # New parameter name
+    loss_module=RLOOLoss(),
+)
+```
+
+### Phase 7: Update environment implementations
+
+Since environments don't need to know about metadata in this design, no changes are required to:
+- `src/marin/rl/environments/base.py`
+- `src/marin/rl/environments/mock_env.py`
+- `src/marin/rl/environments/prime_intellect_env.py`
+
+The environment interface stays clean and focused on domain logic.
+
+## Testing Strategy
+
+Run tests in this order to validate the migration:
+
+```bash
+# 1. Test storage layer (simplest)
+uv run pytest tests/rl/test_rollout_storage.py -v
+
+# 2. Test replay buffer functionality
+uv run pytest tests/rl/test_replay_buffer.py -v
+
+# 3. Test integration
+uv run pytest tests/rl/integration/ -v
+```
+
+Key test scenarios:
+1. **Timestamp filtering**: Verify old rollouts are filtered by timestamp
+2. **Step filtering**: Verify old rollouts are filtered by weight_step
+3. **Both filters**: Verify both filters work together correctly
+4. **Serialization**: Verify rollouts with metadata can be pickled/unpickled
+5. **Backward compatibility**: Verify reading old RolloutBatch with batch-level metadata still works (if needed)
+
+## Benefits
+
+1. **Precise filtering**: Can filter individual rollouts by age, not just entire batches
+2. **Complete timestamp feature**: Fully implements `max_rollout_timestamp_delay`
+3. **Clean separation**: Environments don't need to know about worker metadata
+4. **Backward compatible**: Keeps RolloutBatch.metadata for transition period
+5. **Better data model**: Metadata naturally belongs to each rollout, not the batch
+
+## Future Work
+
+After this migration is complete and stable:
+
+1. **Remove RolloutBatch.metadata**: Once we're confident in the migration, remove the redundant batch-level metadata field
+2. **Per-rollout timestamps**: Consider making timestamp/worker_id unique per rollout rather than shared across a batch
+3. **Metadata versioning**: Add version field to RolloutMetadata for future schema evolution
+
+## Migration Checklist
+
+- [ ] Update `Rollout` to include `metadata: RolloutMetadata` field
+- [ ] Update rollout worker to attach metadata after env.sample
+- [ ] Update replay buffer config: rename parameter to `max_rollout_timestamp_delay`
+- [ ] Update replay buffer: read from `rollout.metadata` instead of `batch.metadata`
+- [ ] Update train_worker.py: use new parameter name
+- [ ] Update rl_job.py: add timestamp delay to TrainParams
+- [ ] Update test helpers: create rollouts with metadata
+- [ ] Run all tests and verify they pass
+- [ ] Update integration tests if needed
+- [ ] Document the change in release notes

--- a/experiments/exp1247_rl_async.py
+++ b/experiments/exp1247_rl_async.py
@@ -220,7 +220,7 @@ def main():
         return
 
     experiments = [
-        rl_train(name="llama-1b-math-rl-test-power-016"),
+        rl_train(name="llama-1b-math-rl-test-power-017"),
     ]
 
     executor_main(

--- a/experiments/exp1247_rl_async.py
+++ b/experiments/exp1247_rl_async.py
@@ -34,6 +34,7 @@ from marin.execution.executor import (
 )
 from marin.rl.curriculum import CurriculumConfig, LessonConfig, LessonDependency
 from marin.rl.environments import EnvConfig
+from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_job import RLJob, RLJobConfig, RunConfig, TrainParams
 from marin.rl.rl_losses import RLOOLoss
 from marin.rl.rollout_storage import RolloutStorageConfig, StorageType
@@ -182,10 +183,12 @@ def rl_train(name: str) -> ExecutorStep:
         train_params=TrainParams(
             optimizer=opt_config,
             rl_loss=RLOOLoss(kl_coef=0.05, clip_epsilon=0.2),
-            replay_buffer_capacity=4096,
-            replay_buffer_alpha=3,
-            max_samples_per_rollout=1,
-            max_rollout_delay=4,
+            replay_buffer=ReplayBufferConfig(
+                capacity=4096,
+                alpha=3,
+                max_samples=1,
+                max_rollout_step_delay=1,
+            ),
         ),
         curriculum=curriculum_config,
         tokenizer=MODEL_TOKENIZER,

--- a/experiments/exp1247_rl_async.py
+++ b/experiments/exp1247_rl_async.py
@@ -66,8 +66,8 @@ def create_math_curriculum(run_id: str) -> CurriculumConfig:
     # Default sampling params for all lessons
     default_sampling = SamplingParams(
         temperature=0.7,
-        n_prompts=16,
-        n_generations_per_prompt=16,
+        n_prompts=8,
+        n_generations_per_prompt=8,
         max_tokens=MAX_TOKENS,
         stop_tokens=stop_tokens(MODEL_TOKENIZER),
     )
@@ -217,7 +217,7 @@ def main():
         return
 
     experiments = [
-        rl_train(name="llama-1b-math-rl-test-power-014"),
+        rl_train(name="llama-1b-math-rl-test-power-016"),
     ]
 
     executor_main(

--- a/src/marin/rl/environments/mock_env.py
+++ b/src/marin/rl/environments/mock_env.py
@@ -327,7 +327,6 @@ class MockEnv(MarinEnv):
         )
 
         # Evaluate and create rollouts
-        max_input_length = 2048  # Default, will use what we can get from responses
         rollout_groups = []
         correct_count = 0
         total_count = 0
@@ -337,8 +336,6 @@ class MockEnv(MarinEnv):
             rollouts = []
 
             for choice in response.choices:
-                # Extract response text (already decoded by inference context)
-                # Note: response_text may include the prompt, so extract the actual response
                 if choice.response_text.startswith(example["prompt"]):
                     actual_response = choice.response_text[len(example["prompt"]) :]
                 else:
@@ -348,7 +345,7 @@ class MockEnv(MarinEnv):
                 reward = self.task.compute_reward(example["answer"], actual_response, tokenizer=inference_ctx.tokenizer)
 
                 # Create rollout
-                prompt_tokens = response.prompt_tokens[-max_input_length:]
+                prompt_tokens = response.prompt_tokens
                 token_rewards = jnp.full(len(choice.response_tokens), reward, dtype=jnp.float32)
 
                 rollout = Rollout(
@@ -394,7 +391,7 @@ class MockEnv(MarinEnv):
             yield MockEnvExample(
                 raw_prompt=example["prompt"],
                 raw_answer=example["answer"],
-                processed_prompt=example["prompt"],  # MockEnv doesn't transform
+                processed_prompt=example["prompt"],
                 processed_answer=example["answer"],
                 metadata={"task_type": self.task_type},
             )
@@ -405,7 +402,7 @@ class MockEnv(MarinEnv):
             yield MockEnvExample(
                 raw_prompt=example["prompt"],
                 raw_answer=example["answer"],
-                processed_prompt=example["prompt"],  # MockEnv doesn't transform
+                processed_prompt=example["prompt"],
                 processed_answer=example["answer"],
                 metadata={"task_type": self.task_type},
             )

--- a/src/marin/rl/environments/mock_env.py
+++ b/src/marin/rl/environments/mock_env.py
@@ -143,14 +143,13 @@ class NumberComparisonTask:
         return examples
 
     def compute_reward(self, correct_answer: str, actual_response: str, tokenizer=None) -> float:
-        format_score = 1.0 if actual_response.strip().isdigit() else 0.0
-        return 0.1 * format_score + 0.9 * compute_soft_reward(correct_answer, actual_response)
+        return compute_soft_reward(correct_answer, actual_response)
 
 
 def compute_soft_reward(correct_answer: str, actual_response: str) -> float:
     """Compute soft reward with partial credit for correctness and format."""
     if not actual_response:
-        return 0.0
+        return 0
 
     # remove commas from numbers
     correct_answer = correct_answer.replace(",", "").lower()
@@ -164,8 +163,7 @@ def compute_soft_reward(correct_answer: str, actual_response: str) -> float:
             correct_score = 1
             break
 
-    format_score = min(1.0, 1 / max(len(tokens), 1))
-    return correct_score + 0.2 * format_score
+    return correct_score / len(tokens)
 
 
 class MoarCatsTask:

--- a/src/marin/rl/replay_buffer.py
+++ b/src/marin/rl/replay_buffer.py
@@ -95,6 +95,39 @@ class ReplayBuffer:
     def __post_init__(self):
         self._rng = np.random.default_rng(seed=self.process_id + 42)
 
+    @classmethod
+    def from_config(
+        cls,
+        config: ReplayBufferConfig,
+        local_batch_size: int,
+        total_processes: int,
+        process_id: int,
+        loss_module: RLLossModule,
+    ) -> "ReplayBuffer":
+        """Create ReplayBuffer from configuration.
+
+        Args:
+            config: Replay buffer configuration.
+            local_batch_size: Batch size for sampling.
+            total_processes: Total number of processes.
+            process_id: ID of this process.
+            loss_module: Loss module for computing advantages.
+
+        Returns:
+            Configured ReplayBuffer instance.
+        """
+        return cls(
+            capacity=config.capacity,
+            local_batch_size=local_batch_size,
+            alpha=config.alpha,
+            total_processes=total_processes,
+            process_id=process_id,
+            max_samples=config.max_samples,
+            max_rollout_step_delay=config.max_rollout_step_delay,
+            max_rollout_timestamp_delay=config.max_rollout_timestamp_delay,
+            loss_module=loss_module,
+        )
+
     def set_current_step(self, step: int) -> None:
         """Set current training step and filter stale rollouts."""
         self._current_step = step

--- a/src/marin/rl/replay_buffer.py
+++ b/src/marin/rl/replay_buffer.py
@@ -77,7 +77,7 @@ class ReplayBuffer:
 
     capacity: int
     local_batch_size: int
-    recency_alpha: float
+    alpha: float
     total_processes: int
     process_id: int
     max_samples: int
@@ -220,7 +220,7 @@ class ReplayBuffer:
             for env_name, count in env_count.items():
                 rollouts = self.rollout_storage[env_name]
                 weights = np.arange(len(rollouts)) + 1
-                weights = weights**self.recency_alpha
+                weights = weights**self.alpha
                 weights = weights / weights.sum()
 
                 # Sample rollout index

--- a/src/marin/rl/rl_job.py
+++ b/src/marin/rl/rl_job.py
@@ -90,6 +90,9 @@ class TrainParams:
     max_rollout_delay: int = 1
     """Max age of rollouts in steps."""
 
+    max_rollout_timestamp_delay: float = 3600.0
+    """Maximum age of rollouts in seconds."""
+
     replay_buffer_capacity: int = 4096
     """How many examples to store per environment in the replay buffer."""
     replay_buffer_alpha: float = 3.0
@@ -229,13 +232,14 @@ class RLJob:
             capacity=self.config.train_params.replay_buffer_capacity,
             alpha=self.config.train_params.replay_buffer_alpha,
             max_samples=self.config.train_params.max_samples_per_rollout,
-            max_rollout_delay=self.config.train_params.max_rollout_delay,
+            max_rollout_step_delay=self.config.train_params.max_rollout_delay,
+            max_rollout_timestamp_delay=self.config.train_params.max_rollout_timestamp_delay,
         )
 
-        # Scan over sampling params for max seqs
+        # Scan over sampling params for max seqs, must be able to fit a single lesson prompt
         max_seqs = 0
         for lesson in self.config.curriculum.lessons.values():
-            total_seqs = lesson.sampling_params.n_generations_per_prompt * lesson.sampling_params.n_prompts
+            total_seqs = lesson.sampling_params.n_generations_per_prompt
             max_seqs = max(max_seqs, total_seqs)
 
         max_tokens = self.config.curriculum.max_tokens

--- a/src/marin/rl/rl_losses.py
+++ b/src/marin/rl/rl_losses.py
@@ -114,7 +114,7 @@ def rloo_loss_with_importance_sampling(
     reinforce_loss = jnp.sum(weighted_loss) / jnp.sum(loss_masks_array)
 
     # KL regularization
-    kl_penalty = jnp.exp(current_logprobs) * (current_logprobs - reference_logprobs_array)
+    kl_penalty = current_logprobs - reference_logprobs_array
     kl_loss = kl_coef * jnp.sum(kl_penalty * loss_masks_array) / jnp.sum(loss_masks_array)
 
     loss = reinforce_loss + kl_loss

--- a/src/marin/rl/train_worker.py
+++ b/src/marin/rl/train_worker.py
@@ -147,15 +147,11 @@ class TrainWorker:
 
         self.rollout_reader = config.rollout_storage.create_reader()
 
-        self.replay_buffer = ReplayBuffer(
-            capacity=config.replay_buffer.capacity,
+        self.replay_buffer = ReplayBuffer.from_config(
+            config=config.replay_buffer,
             local_batch_size=config.trainer.train_batch_size,
-            alpha=config.replay_buffer.alpha,
             total_processes=jax.process_count(),
             process_id=jax.process_index(),
-            max_samples=config.replay_buffer.max_samples,
-            max_rollout_step_delay=config.replay_buffer.max_rollout_step_delay,
-            max_rollout_timestamp_delay=config.replay_buffer.max_rollout_timestamp_delay,
             loss_module=self.loss_module,
         )
 

--- a/src/marin/rl/train_worker.py
+++ b/src/marin/rl/train_worker.py
@@ -150,7 +150,7 @@ class TrainWorker:
         self.replay_buffer = ReplayBuffer(
             capacity=config.replay_buffer.capacity,
             local_batch_size=config.trainer.train_batch_size,
-            recency_alpha=config.replay_buffer.alpha,
+            alpha=config.replay_buffer.alpha,
             total_processes=jax.process_count(),
             process_id=jax.process_index(),
             max_samples=config.replay_buffer.max_samples,

--- a/src/marin/rl/train_worker.py
+++ b/src/marin/rl/train_worker.py
@@ -148,11 +148,15 @@ class TrainWorker:
         self.rollout_reader = config.rollout_storage.create_reader()
 
         self.replay_buffer = ReplayBuffer(
-            config=config.replay_buffer,
-            loss_module=self.loss_module,
+            capacity=config.replay_buffer.capacity,
             local_batch_size=config.trainer.train_batch_size,
-            process_id=jax.process_index(),
+            recency_alpha=config.replay_buffer.alpha,
             total_processes=jax.process_count(),
+            process_id=jax.process_index(),
+            max_samples=config.replay_buffer.max_samples,
+            max_rollout_step_delay=config.replay_buffer.max_rollout_step_delay,
+            max_rollout_timestamp_delay=config.replay_buffer.max_rollout_timestamp_delay,
+            loss_module=self.loss_module,
         )
 
         self.replay_loader = ReplayDataLoader(

--- a/src/marin/rl/types.py
+++ b/src/marin/rl/types.py
@@ -29,6 +29,7 @@ import haliax.haxtyping as ht
 import jax
 import numpy as np
 from haliax import NamedArray
+from openai import AsyncOpenAI
 from transformers import PreTrainedTokenizer
 
 
@@ -72,7 +73,7 @@ class InferenceContext(Protocol):
         """
         ...
 
-    def openai_client(self):
+    def openai_client(self) -> "AsyncOpenAI":
         """Return an OpenAI-compatible client for environments that need it.
 
         Returns:
@@ -88,6 +89,20 @@ class RolloutStats:
     episode_reward: float
     env_example_id: str
     lesson_id: str
+
+
+@dataclass(frozen=True)
+class RolloutMetadata:
+    """Metadata about when/where rollouts were generated."""
+
+    worker_id: str = ""
+    """Worker that generated the rollout."""
+
+    timestamp: float = 0.0
+    """The timestamp at which the rollout was generated."""
+
+    weight_step: int = -1
+    """The step at which the model weights were used to generate this rollout."""
 
 
 class Rollout(eqx.Module):
@@ -114,22 +129,14 @@ class Rollout(eqx.Module):
     episode_reward: float
     """The overall reward for the episode."""
 
+    metadata: RolloutMetadata = RolloutMetadata()
+    """Metadata about when/where this rollout was generated."""
+
 
 class RolloutGroup(eqx.Module):
     """Multiple rollouts for the same prompt (e.g., n_generations samples)."""
 
     rollouts: list[Rollout]
-
-
-@dataclass
-class RolloutMetadata:
-    """Metadata about when/where rollouts were generated."""
-
-    worker_id: str
-    timestamp: float
-
-    """The step at which the model weights were used to generate this rollout."""
-    weight_step: int
 
 
 class RolloutBatch(eqx.Module):

--- a/src/marin/rl/weight_transfer/base.py
+++ b/src/marin/rl/weight_transfer/base.py
@@ -68,10 +68,10 @@ class WeightUpdate:
 class WeightTransferConfig:
     mode: WeightTransferMode = WeightTransferMode.ARROW_FLIGHT
     # Common settings
-    sync_interval_steps: int = 4
+    sync_interval_steps: int = 1
     coordinator_name: str = "weight_transfer_coordinator"
 
-    transfer_timeout: float = 10.0
+    transfer_timeout: float = 30.0
 
     # GCS Checkpoint specific
     checkpoint_dir: str = ""

--- a/tests/rl/environments/test_mock_env.py
+++ b/tests/rl/environments/test_mock_env.py
@@ -61,14 +61,12 @@ def test_compute_soft_reward_format_loss():
     assert compute_soft_reward("42", "42") > compute_soft_reward("42", "42 extra words")
     assert compute_soft_reward("42", "42") > compute_soft_reward("42", "wrong")
 
-    assert compute_soft_reward("42", "42") == pytest.approx(1.2)
-    assert compute_soft_reward("42", "wrong") == pytest.approx(0.2)
+    assert compute_soft_reward("42", "42") == pytest.approx(1.0)
+    assert compute_soft_reward("42", "wrong") == pytest.approx(0.0)
 
     short_format_score = compute_soft_reward("42", "43")
     long_format_score = compute_soft_reward("42", "43 with lots of extra words")
-    assert short_format_score > long_format_score
-    assert short_format_score == pytest.approx(0.2)
-    assert long_format_score == pytest.approx(0.2 / 6)
+    assert short_format_score == long_format_score == 0.0
 
 
 def test_addition_task_reward():
@@ -77,10 +75,10 @@ def test_addition_task_reward():
     assert len(examples) == 10
     assert all("+" in ex["prompt"] for ex in examples)
 
-    assert task.compute_reward("42", "42") == pytest.approx(1.2)
-    assert task.compute_reward("42", "43") == pytest.approx(0.2)
-    assert task.compute_reward("42", "-") == pytest.approx(0.2)
-    assert task.compute_reward("42", "-2") == pytest.approx(0.2)
+    assert task.compute_reward("42", "42") == pytest.approx(1.0)
+    assert task.compute_reward("42", "43") == pytest.approx(0.0)
+    assert task.compute_reward("42", "-") == pytest.approx(0.0)
+    assert task.compute_reward("42", "-2") == pytest.approx(0.0)
 
 
 def test_opposites_task_reward():
@@ -88,8 +86,8 @@ def test_opposites_task_reward():
     examples = task.generate_examples(10, np.random.default_rng(42))
     assert len(examples) == 10
 
-    assert task.compute_reward("cold", "cold") == pytest.approx(1.2)
-    assert task.compute_reward("cold", "warm") == pytest.approx(0.2)
+    assert task.compute_reward("cold", "cold") == pytest.approx(1.0)
+    assert task.compute_reward("cold", "warm") == pytest.approx(0.0)
 
 
 def test_number_comparison_task_format_bonus():
@@ -99,8 +97,8 @@ def test_number_comparison_task_format_bonus():
     non_digit_reward = task.compute_reward("42", "forty-two")
 
     assert digit_reward > non_digit_reward
-    assert digit_reward == pytest.approx(1.18)
-    assert non_digit_reward == pytest.approx(0.18)
+    assert digit_reward == pytest.approx(1.0)
+    assert non_digit_reward == pytest.approx(0.0)
 
 
 def test_cats_task_reward():

--- a/tests/rl/integration/config.py
+++ b/tests/rl/integration/config.py
@@ -206,7 +206,7 @@ def create_test_curriculum_config(actor_name: str = "test_curriculum"):
                     env_class="marin.rl.environments.mock_env.MockEnv",
                     env_args={"task_type": "cats", "seed": 42},
                 ),
-                sampling_params=SamplingParams(temperature=1.0, n_prompts=8, n_generations_per_prompt=4, max_tokens=64),
+                sampling_params=SamplingParams(temperature=1.0, n_prompts=8, n_generations_per_prompt=4, max_tokens=32),
             )
         },
         eval_frequency=100,
@@ -229,7 +229,7 @@ def create_nano_train_worker_config(rollout_storage: RolloutStorageConfig, outpu
             capacity=2048,
             alpha=3.0,
             max_samples=1,
-            max_rollout_delay=2,
+            max_rollout_step_delay=2,
         ),
         loss=RLOOLoss(kl_coef=0.0, clip_epsilon=5.0),
         initial_checkpoint=None,

--- a/tests/rl/integration/tasks.py
+++ b/tests/rl/integration/tasks.py
@@ -122,6 +122,11 @@ def create_cats_rollout_batch(
             response_logprobs=individual_logprobs,
             token_rewards=token_rewards,
             episode_reward=episode_reward,
+            metadata=RolloutMetadata(
+                worker_id=worker_id,
+                timestamp=time.time(),
+                weight_step=10000,
+            ),
         )
         rollouts.append(rollout)
 
@@ -306,6 +311,11 @@ def create_sequential_digits_rollout_batch(
             response_logprobs=individual_logprobs,
             token_rewards=token_rewards,
             episode_reward=episode_reward,
+            metadata=RolloutMetadata(
+                worker_id=worker_id,
+                timestamp=time.time(),
+                weight_step=10000,
+            ),
         )
         rollouts.append(rollout)
 

--- a/tests/rl/integration/test_cats_integration.py
+++ b/tests/rl/integration/test_cats_integration.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
 from marin.rl.rl_losses import RLOOLoss
 from tests.rl.integration.config import (
@@ -63,9 +64,12 @@ def test_train_worker_with_manual_cats_rollout(ray_tpu_cluster, tmp_path):
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
             rl_loss=RLOOLoss(kl_coef=0.0, clip_epsilon=0.2),
-            replay_buffer_capacity=2048,
-            replay_buffer_alpha=3.0,
-            max_samples_per_rollout=4,
+            replay_buffer=ReplayBufferConfig(
+                capacity=2048,
+                alpha=3.0,
+                max_samples=4,
+                max_rollout_step_delay=1,
+            ),
         ),
         curriculum=create_test_curriculum_config(),
         tokenizer=tokenizer,
@@ -118,8 +122,12 @@ def test_full_integration_moar_cats(ray_tpu_cluster, tmp_path):
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
             rl_loss=RLOOLoss(kl_coef=0.0, clip_epsilon=0.2),
-            max_samples_per_rollout=4,
-            max_rollout_delay=4,
+            replay_buffer=ReplayBufferConfig(
+                capacity=4096,
+                alpha=3.0,
+                max_samples=4,
+                max_rollout_step_delay=4,
+            ),
         ),
         curriculum=create_test_curriculum_config(),
         tokenizer=DummyTokenizer(),

--- a/tests/rl/integration/test_sequential_digits_integration.py
+++ b/tests/rl/integration/test_sequential_digits_integration.py
@@ -24,6 +24,7 @@ import pytest
 
 from marin.rl.curriculum import CurriculumConfig, LessonConfig, SamplingParams
 from marin.rl.environments import EnvConfig
+from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
 from marin.rl.rl_losses import RLOOLoss
 from tests.rl.integration.config import (
@@ -82,10 +83,12 @@ def test_train_worker_with_sequential_digits(ray_tpu_cluster, tmp_path):
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
             rl_loss=RLOOLoss(kl_coef=0.0, clip_epsilon=0.2),
-            replay_buffer_capacity=2048,
-            replay_buffer_alpha=3.0,
-            max_samples_per_rollout=1,
-            max_rollout_delay=1,
+            replay_buffer=ReplayBufferConfig(
+                capacity=2048,
+                alpha=3.0,
+                max_samples=1,
+                max_rollout_step_delay=1,
+            ),
         ),
         curriculum=curriculum_config,
         tokenizer=tokenizer,
@@ -155,8 +158,12 @@ def test_full_integration_sequential_digits(ray_tpu_cluster, tmp_path):
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
             rl_loss=RLOOLoss(kl_coef=0.0, clip_epsilon=1.0),
-            max_samples_per_rollout=1,
-            max_rollout_delay=2,
+            replay_buffer=ReplayBufferConfig(
+                capacity=4096,
+                alpha=3.0,
+                max_samples=1,
+                max_rollout_step_delay=2,
+            ),
         ),
         curriculum=curriculum_config,
         tokenizer=DummyTokenizer(),

--- a/tests/rl/integration/test_sequential_digits_integration.py
+++ b/tests/rl/integration/test_sequential_digits_integration.py
@@ -125,7 +125,7 @@ def test_train_worker_with_sequential_digits(ray_tpu_cluster, tmp_path):
 def test_full_integration_sequential_digits(ray_tpu_cluster, tmp_path):
     """Full integration test with rollout and train workers for sequential digits task."""
     rollout_storage_config = create_test_rollout_storage_config()
-    target_steps = 100
+    target_steps = 500
 
     # Create curriculum with sequential digits task
     test_id = uuid.uuid4().hex[:8]
@@ -154,9 +154,9 @@ def test_full_integration_sequential_digits(ray_tpu_cluster, tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            rl_loss=RLOOLoss(kl_coef=0.0, clip_epsilon=0.2),
+            rl_loss=RLOOLoss(kl_coef=0.0, clip_epsilon=1.0),
             max_samples_per_rollout=1,
-            max_rollout_delay=1,
+            max_rollout_delay=2,
         ),
         curriculum=curriculum_config,
         tokenizer=DummyTokenizer(),
@@ -170,7 +170,7 @@ def test_full_integration_sequential_digits(ray_tpu_cluster, tmp_path):
 
     # Apply test-specific overrides
     inference_runner.rollout_worker_config.weight_transfer.sync_interval_steps = 1
-    inference_runner.rollout_worker_config.max_rollouts = 200
+    inference_runner.rollout_worker_config.max_rollouts = 2000
 
     with training_runner, inference_runner:
         while not training_runner.done.is_set():

--- a/tests/rl/test_replay_buffer.py
+++ b/tests/rl/test_replay_buffer.py
@@ -110,7 +110,7 @@ def test_replay_buffer():
     replay_buffer = ReplayBuffer(
         capacity=100,
         local_batch_size=4,
-        recency_alpha=3.0,
+        alpha=3.0,
         total_processes=1,
         process_id=0,
         max_samples=-1,
@@ -161,7 +161,7 @@ def test_replay_buffer_recency_bias():
     replay_buffer = ReplayBuffer(
         capacity=100,
         local_batch_size=50,
-        recency_alpha=10.0,
+        alpha=10.0,
         total_processes=1,
         process_id=0,
         max_samples=-1,
@@ -196,7 +196,7 @@ def test_replay_buffer_capacity_eviction():
     replay_buffer = ReplayBuffer(
         capacity=3,
         local_batch_size=4,
-        recency_alpha=2.0,
+        alpha=2.0,
         total_processes=1,
         process_id=0,
         max_samples=-1,
@@ -223,7 +223,7 @@ def test_replay_buffer_max_resamples():
     replay_buffer = ReplayBuffer(
         capacity=100,
         local_batch_size=2,
-        recency_alpha=1.0,
+        alpha=1.0,
         total_processes=1,
         process_id=0,
         max_samples=3,
@@ -261,7 +261,7 @@ def test_replay_buffer_max_resamples_disabled():
     replay_buffer = ReplayBuffer(
         capacity=100,
         local_batch_size=2,
-        recency_alpha=1.0,
+        alpha=1.0,
         total_processes=1,
         process_id=0,
         max_samples=-1,
@@ -295,7 +295,7 @@ def test_replay_buffer_max_resamples_multiple_envs():
     replay_buffer = ReplayBuffer(
         capacity=100,
         local_batch_size=3,
-        recency_alpha=1.0,
+        alpha=1.0,
         total_processes=1,
         process_id=0,
         max_samples=2,
@@ -335,7 +335,7 @@ def test_replay_buffer_weight_step_filtering():
     replay_buffer = ReplayBuffer(
         capacity=100,
         local_batch_size=4,
-        recency_alpha=2.0,
+        alpha=2.0,
         total_processes=1,
         process_id=0,
         max_samples=-1,
@@ -378,7 +378,7 @@ def test_replay_buffer_rollout_delay_progressive():
     replay_buffer = ReplayBuffer(
         capacity=100,
         local_batch_size=2,
-        recency_alpha=2.0,
+        alpha=2.0,
         total_processes=1,
         process_id=0,
         max_samples=-1,

--- a/tests/rl/test_replay_buffer.py
+++ b/tests/rl/test_replay_buffer.py
@@ -21,7 +21,7 @@ import pytest
 
 try:
     from marin.rl import train_batch
-    from marin.rl.replay_buffer import ReplayBuffer, ReplayBufferConfig, ReplayDataLoader
+    from marin.rl.replay_buffer import ReplayBuffer, ReplayDataLoader
     from marin.rl.rl_losses import RLOOLoss
 except ImportError:
     pytest.skip("Post training imports unavailable", allow_module_level=True)
@@ -41,11 +41,23 @@ def rollouts_to_training_batch(rollouts, max_tokens=32, pad_token_id=0):
     return train_batch.create_training_batch_from_rollouts(rollouts, max_tokens, pad_token_id)
 
 
-def create_test_batch(idx: int, batch_size: int = 2, max_seq_len: int = 16, env_name: str | None = None) -> RolloutBatch:
+def create_test_batch(
+    idx: int,
+    batch_size: int = 2,
+    max_seq_len: int = 16,
+    env_name: str | None = None,
+    weight_step: int = 0,
+    timestamp: float | None = None,
+) -> RolloutBatch:
     """Helper to create test batches with identifiable tokens for testing."""
     rng = np.random.default_rng(42 + idx)
     if env_name is None:
         env_name = f"test_env_{idx}"
+    if timestamp is None:
+        timestamp = time.time()
+
+    # Create batch metadata
+    batch_metadata = RolloutMetadata(worker_id="test_worker", timestamp=timestamp, weight_step=weight_step)
 
     # Create individual rollouts with identifiable tokens
     rollouts = []
@@ -72,6 +84,7 @@ def create_test_batch(idx: int, batch_size: int = 2, max_seq_len: int = 16, env_
             response_logprobs=response_logprobs,
             token_rewards=token_rewards,
             episode_reward=episode_reward,
+            metadata=batch_metadata,
         )
         rollouts.append(rollout)
 
@@ -79,8 +92,7 @@ def create_test_batch(idx: int, batch_size: int = 2, max_seq_len: int = 16, env_
     group = RolloutGroup(rollouts=rollouts)
 
     # Create batch
-    metadata = RolloutMetadata(worker_id="test_worker", timestamp=time.time(), weight_step=0)
-    return RolloutBatch(groups=[group], metadata=metadata)
+    return RolloutBatch(groups=[group], metadata=batch_metadata)
 
 
 def test_replay_buffer():
@@ -96,11 +108,15 @@ def test_replay_buffer():
             writer.write_batch(batch)
 
     replay_buffer = ReplayBuffer(
-        config=ReplayBufferConfig(capacity=100, alpha=3.0, max_samples=-1, max_rollout_delay=1000),
-        loss_module=RLOOLoss(),
+        capacity=100,
         local_batch_size=4,
-        process_id=0,
+        recency_alpha=3.0,
         total_processes=1,
+        process_id=0,
+        max_samples=-1,
+        max_rollout_step_delay=1000,
+        max_rollout_timestamp_delay=3600.0,
+        loss_module=RLOOLoss(),
     )
 
     # Add batches to replay buffer
@@ -143,13 +159,15 @@ def test_replay_buffer_recency_bias():
         batches.append(batch)
 
     replay_buffer = ReplayBuffer(
-        config=ReplayBufferConfig(
-            capacity=100, alpha=10.0, max_samples=-1, max_rollout_delay=1000
-        ),  # Very strong recency bias
-        loss_module=RLOOLoss(),
+        capacity=100,
         local_batch_size=50,
-        process_id=0,
+        recency_alpha=10.0,
         total_processes=1,
+        process_id=0,
+        max_samples=-1,
+        max_rollout_step_delay=1000,
+        max_rollout_timestamp_delay=3600.0,
+        loss_module=RLOOLoss(),
     )
     replay_buffer.add_batches(batches)
 
@@ -176,11 +194,15 @@ def test_replay_buffer_recency_bias():
 def test_replay_buffer_capacity_eviction():
     """Test that replay buffer respects capacity limits and evicts old data."""
     replay_buffer = ReplayBuffer(
-        config=ReplayBufferConfig(capacity=3, alpha=2.0, max_samples=-1, max_rollout_delay=1000),
-        loss_module=RLOOLoss(),
+        capacity=3,
         local_batch_size=4,
-        process_id=0,
+        recency_alpha=2.0,
         total_processes=1,
+        process_id=0,
+        max_samples=-1,
+        max_rollout_step_delay=1000,
+        max_rollout_timestamp_delay=3600.0,
+        loss_module=RLOOLoss(),
     )
 
     for i in range(5):
@@ -199,13 +221,15 @@ def test_replay_buffer_capacity_eviction():
 def test_replay_buffer_max_resamples():
     """Test that examples are retired after max_resamples uses."""
     replay_buffer = ReplayBuffer(
-        config=ReplayBufferConfig(
-            capacity=100, alpha=1.0, max_samples=3, max_rollout_delay=1000
-        ),  # Uniform sampling for predictable behavior
-        loss_module=RLOOLoss(),
+        capacity=100,
         local_batch_size=2,
-        process_id=0,
+        recency_alpha=1.0,
         total_processes=1,
+        process_id=0,
+        max_samples=3,
+        max_rollout_step_delay=1000,
+        max_rollout_timestamp_delay=3600.0,
+        loss_module=RLOOLoss(),
     )
 
     # Create batch with identifiable examples (already has identifiable tokens)
@@ -235,11 +259,15 @@ def test_replay_buffer_max_resamples():
 def test_replay_buffer_max_resamples_disabled():
     """Test that max_resamples=-1 disables retirement."""
     replay_buffer = ReplayBuffer(
-        config=ReplayBufferConfig(capacity=100, alpha=1.0, max_samples=-1, max_rollout_delay=1000),  # Disabled
-        loss_module=RLOOLoss(),
+        capacity=100,
         local_batch_size=2,
-        process_id=0,
+        recency_alpha=1.0,
         total_processes=1,
+        process_id=0,
+        max_samples=-1,
+        max_rollout_step_delay=1000,
+        max_rollout_timestamp_delay=3600.0,
+        loss_module=RLOOLoss(),
     )
 
     # Add small batch
@@ -265,11 +293,15 @@ def test_replay_buffer_max_resamples_disabled():
 def test_replay_buffer_max_resamples_multiple_envs():
     """Test max_resamples with multiple environments."""
     replay_buffer = ReplayBuffer(
-        config=ReplayBufferConfig(capacity=100, alpha=1.0, max_samples=2, max_rollout_delay=1000),
-        loss_module=RLOOLoss(),
+        capacity=100,
         local_batch_size=3,
-        process_id=0,
+        recency_alpha=1.0,
         total_processes=1,
+        process_id=0,
+        max_samples=2,
+        max_rollout_step_delay=1000,
+        max_rollout_timestamp_delay=3600.0,
+        loss_module=RLOOLoss(),
     )
 
     # Add batches from different environments (identifiable tokens already set)
@@ -301,19 +333,21 @@ def test_replay_buffer_max_resamples_multiple_envs():
 
 def test_replay_buffer_weight_step_filtering():
     replay_buffer = ReplayBuffer(
-        config=ReplayBufferConfig(capacity=100, alpha=2.0, max_samples=-1, max_rollout_delay=30),
-        loss_module=RLOOLoss(),
+        capacity=100,
         local_batch_size=4,
-        process_id=0,
+        recency_alpha=2.0,
         total_processes=1,
+        process_id=0,
+        max_samples=-1,
+        max_rollout_step_delay=30,
+        max_rollout_timestamp_delay=3600.0,
+        loss_module=RLOOLoss(),
     )
 
     # Create batches with weight_steps 50, 100, 150
     for weight_step in [50, 100, 150]:
-        batch = create_test_batch(weight_step, batch_size=4, max_seq_len=16, env_name="test_env")
-        batch = RolloutBatch(
-            groups=batch.groups,
-            metadata=RolloutMetadata(worker_id="test", timestamp=time.time(), weight_step=weight_step),
+        batch = create_test_batch(
+            weight_step, batch_size=4, max_seq_len=16, env_name="test_env", weight_step=weight_step
         )
         replay_buffer.add_batches([batch])
 
@@ -328,10 +362,7 @@ def test_replay_buffer_weight_step_filtering():
     assert replay_buffer.size() == 4
 
     # Add new batch with weight_step=180
-    new_batch = create_test_batch(180, batch_size=3, max_seq_len=16, env_name="test_env")
-    new_batch = RolloutBatch(
-        groups=new_batch.groups, metadata=RolloutMetadata(worker_id="test", timestamp=time.time(), weight_step=180)
-    )
+    new_batch = create_test_batch(180, batch_size=3, max_seq_len=16, env_name="test_env", weight_step=180)
     replay_buffer.add_batches([new_batch])
 
     # Should now have 7 total (4 from weight_step=150 + 3 from weight_step=180)
@@ -345,19 +376,20 @@ def test_replay_buffer_weight_step_filtering():
 def test_replay_buffer_rollout_delay_progressive():
     """Test rollout delay with progressive step advancement and stale batch rejection."""
     replay_buffer = ReplayBuffer(
-        config=ReplayBufferConfig(capacity=100, alpha=2.0, max_samples=-1, max_rollout_delay=10),
-        loss_module=RLOOLoss(),
+        capacity=100,
         local_batch_size=2,
-        process_id=0,
+        recency_alpha=2.0,
         total_processes=1,
+        process_id=0,
+        max_samples=-1,
+        max_rollout_step_delay=10,
+        max_rollout_timestamp_delay=3600.0,
+        loss_module=RLOOLoss(),
     )
 
     # Add initial batches at steps 0, 5, 10
     for step in [0, 5, 10]:
-        batch = create_test_batch(step, batch_size=2, max_seq_len=16, env_name="test_env")
-        batch = RolloutBatch(
-            groups=batch.groups, metadata=RolloutMetadata(worker_id="test", timestamp=time.time(), weight_step=step)
-        )
+        batch = create_test_batch(step, batch_size=2, max_seq_len=16, env_name="test_env", weight_step=step)
         replay_buffer.add_batches([batch])
 
     assert replay_buffer.size() == 6
@@ -367,18 +399,12 @@ def test_replay_buffer_rollout_delay_progressive():
     assert replay_buffer.size() == 4
 
     # Try to add a stale batch (step 3 < min_step=5), should be rejected
-    stale_batch = create_test_batch(3, batch_size=2, max_seq_len=16, env_name="test_env")
-    stale_batch = RolloutBatch(
-        groups=stale_batch.groups, metadata=RolloutMetadata(worker_id="test", timestamp=time.time(), weight_step=3)
-    )
+    stale_batch = create_test_batch(3, batch_size=2, max_seq_len=16, env_name="test_env", weight_step=3)
     replay_buffer.add_batches([stale_batch])
     assert replay_buffer.size() == 4  # Size unchanged
 
     # Add a fresh batch (step 14 >= min_step=5), should be accepted
-    fresh_batch = create_test_batch(14, batch_size=3, max_seq_len=16, env_name="test_env")
-    fresh_batch = RolloutBatch(
-        groups=fresh_batch.groups, metadata=RolloutMetadata(worker_id="test", timestamp=time.time(), weight_step=14)
-    )
+    fresh_batch = create_test_batch(14, batch_size=3, max_seq_len=16, env_name="test_env", weight_step=14)
     replay_buffer.add_batches([fresh_batch])
     assert replay_buffer.size() == 7
 

--- a/tests/rl/test_rollout_storage.py
+++ b/tests/rl/test_rollout_storage.py
@@ -55,6 +55,11 @@ def create_test_rollout(idx: int) -> Rollout:
         response_logprobs=response_logprobs,
         token_rewards=token_rewards,
         episode_reward=episode_reward,
+        metadata=RolloutMetadata(
+            worker_id="test_worker",
+            timestamp=time.time(),
+            weight_step=0,
+        ),
     )
 
 


### PR DESCRIPTION
This moves rollout metadata onto the individual rollouts, which will eventually let us track rollout weight_ids separately from their group or batch. (For now we tag rollouts with the weight_id after the batch is complete).

This reduces the need to track the batch metadata around as we move rollouts as well.

We additionally add a max_timestamp_delay field to the replay buffer. This discards rollouts which are read from the rollout storage that happen to have an old timestamp even if they have a valid step id. This guards against restoring from a checkpoint and pulling stale rollouts from the storage.

We also move the inference context out of the rollout worker, as its only dependency is on a tokenizer and an API server address, and it's more associated with the environments.
