### PR TITLE
Fix robust actor.

### DIFF
--- a/src/marin/rl/curriculum.py
+++ b/src/marin/rl/curriculum.py
@@ -28,7 +28,6 @@ from dataclasses import dataclass, field
 
 import fsspec
 import numpy as np
-import ray
 
 from marin.rl.environments.base import EnvConfig
 from marin.rl.robust_actor import RobustActor
@@ -621,7 +620,7 @@ def get_or_create_curriculum_actor(config: CurriculumConfig, checkpoint_path: st
     # Auto-restore from checkpoint if path provided
     if checkpoint_path:
         try:
-            ray.get(actor.restore_checkpoint.remote(checkpoint_path))
+            actor.restore_checkpoint.call(checkpoint_path)
         except Exception as e:
             logger.warning(f"Failed to restore curriculum checkpoint from {checkpoint_path}: {e}, starting fresh")
 

--- a/src/marin/rl/rl_losses.py
+++ b/src/marin/rl/rl_losses.py
@@ -137,7 +137,7 @@ def rloo_loss_with_importance_sampling(
     reinforce_loss = jnp.sum(weighted_loss) / jnp.sum(loss_masks_array)
 
     # KL regularization
-    log_ratio = current_logprobs - reference_logprobs_array * loss_masks_array
+    log_ratio = (current_logprobs - reference_logprobs_array) * loss_masks_array
     # https://github.com/openai/lm-human-preferences/blob/cbfd210bb8b08f6bc5c26878c10984b90f516c66/lm_human_preferences/train_policy.py#L151
     kl_penalty = log_ratio**2
     kl_loss = kl_coef * jnp.sum(kl_penalty * loss_masks_array) / jnp.sum(loss_masks_array)

--- a/src/marin/rl/train_worker.py
+++ b/src/marin/rl/train_worker.py
@@ -265,7 +265,7 @@ class TrainWorker:
         def _curriculum_checkpoint_hook(info: levanter.callbacks.StepInfo):
             checkpoint_dir = self.config.trainer.checkpointer.expanded_path(self.config.run_id)
             try:
-                self._curriculum_actor.save_checkpoint.remote(checkpoint_dir)
+                self._curriculum_actor.save_checkpoint.call(checkpoint_dir)
             except Exception as e:
                 logger.error(f"Failed to save curriculum checkpoint: {e}")
 

--- a/src/marin/rl/weight_transfer/arrow_flight.py
+++ b/src/marin/rl/weight_transfer/arrow_flight.py
@@ -397,7 +397,7 @@ class ArrowFlightServer(WeightTransferServer):
                 param_names = list(params_dict.keys())
                 actual_host = self.config.flight_host if self.config.flight_host != "0.0.0.0" else socket.gethostname()
                 server_locations = [(actual_host, server.port) for server in self._flight_servers]
-                ray.get(self._coordinator.update_server.remote(weight_id, param_names, server_locations))
+                self._coordinator.update_server.call(weight_id, param_names, server_locations)
                 update_time = time.time()
 
                 self.metrics.successful_transfers += 1
@@ -512,7 +512,7 @@ class ArrowFlightClient(WeightTransferClient):
             start_time = time.time()
 
             # Fetch server info from coordinator
-            server_info = ray.get(self._coordinator.fetch_server.remote())
+            server_info = self._coordinator.fetch_server.call()
 
             if not server_info:
                 logger.info("No Arrow Flight server info available from coordinator.")

--- a/src/marin/rl/weight_transfer/jax.py
+++ b/src/marin/rl/weight_transfer/jax.py
@@ -370,7 +370,7 @@ class JAXTransferServer(WeightTransferServer):
 
         # Start transfer server and register its address with coordinator
         self.transfer_server = start_transfer_server()
-        self.coordinator.register_transfer_server.remote(self.transfer_server.address())
+        self.coordinator.register_transfer_server.call(self.transfer_server.address())
         self._setup_cpu_transfer()
 
         # Single-item queue for polling
@@ -494,7 +494,7 @@ class JAXTransferClient(WeightTransferClient):
 
         # First check if new weights are available without blocking
         try:
-            latest_weight_id, server_address = ray.get(self.coordinator.get_transfer_info.remote())
+            latest_weight_id, server_address = self.coordinator.get_transfer_info.call()
             logger.info(
                 "Current weight id %s, Latest weight ID: %s, Server address: %s",
                 self._last_received_weight_id,


### PR DESCRIPTION
Actor failures are only discovered when the user calls ray.get.

This adds a `.call` API to the actor to handle the common case where we want the result.