### PR TITLE
Add integration test for LLama

### DIFF
--- a/tests/rl/integration/test_llama_math_integration.py
+++ b/tests/rl/integration/test_llama_math_integration.py
@@ -85,6 +85,7 @@ def create_simple_math_curriculum(run_id: str) -> CurriculumConfig:
         actor_name=f"test-curriculum-{run_id}",
     )
 
+
 @pytest.mark.slow("Integration test with real model")
 def test_llama_math_integration(ray_tpu_cluster, tmp_path):
     """Test full integration with Llama-3.2-1B and math curriculum.

--- a/tests/rl/test_chat_template.py
+++ b/tests/rl/test_chat_template.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 
-import pytest
 from levanter.inference.openai import ChatMessage
 from transformers import AutoTokenizer
 


### PR DESCRIPTION
This adds a manual integration test to exercise the rollout worker with a LLama 1B model.

This can be used to isolate tokenization or modeling issues affecting RL.