### PR TITLE
Fix invalid escape sequences in `gh_issues_from_markdown.py`

### DIFF
--- a/scripts/pm/gh_issues_from_markdown.py
+++ b/scripts/pm/gh_issues_from_markdown.py
@@ -74,15 +74,15 @@ For example, given this markdown:
  * Documentation
     * Note: we’re mostly following the diataxis framework
     * Your goal is to go through existing docs
-    * README \#p0
+    * README \\#p0
     * Tutorials
-      * Set up Marin \#p1 \[May 1\]
-      * Launch a basic hello world experiment \#p1 \[May 1\]
+      * Set up Marin \\#p1 \\[May 1\\]
+      * Launch a basic hello world experiment \\#p1 \\[May 1\\]
     * How To
-      * Add an HF dataset \#p1 \[May 4\] \- Chris
-      * Training a model \- Will
-        * Replicate DCLM 1b/1x \#p1 \[May 4\] 72\_baselines.py Will
-        * Replicate DCLM 7b/1x \#p2 \[May 4\] Will
+      * Add an HF dataset \\#p1 \\[May 4\\] \\- Chris
+      * Training a model \\- Will
+        * Replicate DCLM 1b/1x \\#p1 \\[May 4\\] 72\\_baselines.py Will
+        * Replicate DCLM 7b/1x \\#p2 \\[May 4\\] Will
 ```
 
 The output should be:
@@ -184,7 +184,7 @@ def create_issue(title: str, body: str, labels: List[str], milestone_id: int, as
     url = f"https://api.github.com/repos/{GITHUB_REPO}/issues"
     data = {
         "title": title,
-        "body": f"\[Created by Marin Auto-PM at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\]\n\n{body}",
+        "body": f"\\[Created by Marin Auto-PM at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\\]\n\n{body}",
         "labels": labels,
         "milestone": milestone_id,
         "assignee": assignee,


### PR DESCRIPTION
I saw warnings from `pre-commit run -a -v`:

```console
$ pre-commit run -a -v
...
check python ast.........................................................Passed
- hook id: check-ast
- duration: 0.15s

scripts/pm/gh_issues_from_markdown.py:77: SyntaxWarning: invalid escape sequence '\#'
  * README \#p0
scripts/pm/gh_issues_from_markdown.py:187: SyntaxWarning: invalid escape sequence '\['
  "body": f"\[Created by Marin Auto-PM at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\]\n\n{body}",
scripts/pm/gh_issues_from_markdown.py:187: SyntaxWarning: invalid escape sequence '\]'
  "body": f"\[Created by Marin Auto-PM at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\]\n\n{body}",
...
```

CI doesn't log these ([e.g.][ci]), I think `-v` surfaces them (which I run by habit/alias). Seems worth fixing anyway.

[ci]: https://github.com/marin-community/marin/actions/runs/18568901806/job/52937422138#step:5:28