### PR TITLE
Replace `from src.marin` imports with `from marin`

### DIFF
--- a/experiments/evals/exp1600_uncheatable_evals.py
+++ b/experiments/evals/exp1600_uncheatable_evals.py
@@ -34,7 +34,7 @@ from marin.evaluation.log_probs import default_lm_log_probs
 from marin.execution.executor import executor_main, ExecutorStep, output_path_of
 from marin.processing.tokenize import TokenizeConfig
 from marin.processing.tokenize.data_configs import mixture_for_evaluation, TokenizerStep
-from src.marin.download.uncheatable_eval.download import make_uncheatable_eval_step
+from marin.download.uncheatable_eval.download import make_uncheatable_eval_step
 from experiments.defaults import default_tokenize
 from experiments.evals.resource_configs import SINGLE_TPU_V5p_8_FULL
 from experiments.models import ModelConfig as HFModelConfig, download_model_step

--- a/scripts/ray/cluster.py
+++ b/scripts/ray/cluster.py
@@ -33,8 +33,8 @@ from pathlib import Path
 
 import click
 
-from src.marin.cluster import cleanup, gcp, monitoring, ray
-from src.marin.cluster.config import (
+from marin.cluster import cleanup, gcp, monitoring, ray
+from marin.cluster.config import (
     RayClusterConfig,
     find_config_by_region,
     list_available_configs,

--- a/scripts/ray/dev_tpu.py
+++ b/scripts/ray/dev_tpu.py
@@ -64,9 +64,9 @@ import yaml
 
 # N.B. We have to import from "src" as we are using the `ray.remote` directly from our `uv run`
 # script instead of launching a driver job. This confuses cloudpickle for some reason.
-from src.marin.cluster import ray as ray_utils
-from src.marin.cluster.config import RayClusterConfig, find_config_by_region
-from src.marin.utils import _hacky_remove_tpu_lockfile
+from marin.cluster import ray as ray_utils
+from marin.cluster.config import RayClusterConfig, find_config_by_region
+from marin.utils import _hacky_remove_tpu_lockfile
 
 logger = logging.getLogger(__name__)
 
@@ -458,7 +458,7 @@ def hold_tpu_allocation(
     config_obj = yaml.safe_load(open(config_file).read())
     zone = config_obj["provider"]["availability_zone"]
 
-    from src.marin.cluster.ray import DashboardConfig
+    from marin.cluster.ray import DashboardConfig
 
     with ray_utils.ray_dashboard(DashboardConfig.from_cluster(config_file, ray_init=True)):
         try:


### PR DESCRIPTION
There's no good reason for `from src.marin`, afaict, and that form makes less sense in #1690 / #1773 world.