### PR TITLE
Rm  `dev_tpu.py` "src" imports using `cloudpickle` registration

### DIFF
--- a/scripts/ray/dev_tpu.py
+++ b/scripts/ray/dev_tpu.py
@@ -62,11 +62,16 @@ import threading
 import time
 import yaml
 
-# N.B. We have to import from "src" as we are using the `ray.remote` directly from our `uv run`
-# script instead of launching a driver job. This confuses cloudpickle for some reason.
-from src.marin.cluster import ray as ray_utils
-from src.marin.cluster.config import RayClusterConfig, find_config_by_region
-from src.marin.utils import _hacky_remove_tpu_lockfile
+import ray.cloudpickle as cloudpickle
+
+import marin.utils
+from marin.cluster import ray as ray_utils
+from marin.cluster.config import RayClusterConfig, find_config_by_region
+from marin.utils import _hacky_remove_tpu_lockfile
+
+# Register `marin.utils` by value, so it can work over `ray.remote` without `marin` being installed on the worker.
+# See also #1786 / #1789.
+cloudpickle.register_pickle_by_value(marin.utils)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Second attempt at #1786 (this part was reverted in #1789).

Remove the `src.` import prefix workaround, use `cloudpickle.register_pickle_by_value(marin.utils)` instead. This allows `ray.remote` to serialize the `marin.utils` module by value rather than by reference, enabling it to work on remote Ray workers without requiring the marin package to be installed.

Given the "workspace" plan (#1773), this seems better than changing these imports to `from lib.marin.src.marin…`.

I tested:
```bash
uv run scripts/ray/dev_tpu.py --config infra/marin-us-east1.yaml allocate
```
with just the `s/src\.//` change (confirmed it doesn't work), then with this fix (confirmed it works).
