### PR TITLE
⛴️ - Comparing Linear + AdamW with Feistel + MuonH

### DIFF
--- a/experiments/ferries/ferry_10_31_muonh_feistel.py
+++ b/experiments/ferries/ferry_10_31_muonh_feistel.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""MuonH + Feistel Ferry incorporating shuffle-failure fixes and Kaiyue When's
+(@whenwhen) experiments/speedrun/muonh_qwen3_scaling/muonh_sweep.py learnings."""
+
 import dataclasses
 
 from levanter.optim import MuonHConfig
@@ -92,6 +95,7 @@ ferry_model_1b = default_train(
     model_config=qwen3_1_7b,
     train_config=train_config_1b,
     eval_harness_tasks=[],
+    override_output_path="checkpoints/ferry_muonh_qwen3_1_7b_feistel-b5c378",
 )
 
 ferry_model_8b = default_train(
@@ -100,6 +104,7 @@ ferry_model_8b = default_train(
     model_config=qwen3_8b,
     train_config=train_config_8b,
     eval_harness_tasks=[],
+    override_output_path="checkpoints/ferry_muonh_qwen3_8b_feistel-515e16",
 )
 
 

--- a/experiments/ferries/initial_ferry.py
+++ b/experiments/ferries/initial_ferry.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Idealized Ferry baseline mirroring docs/reports/marin-32b-retro.md."""
+
 import math
 
 from experiments.defaults import SimpleTrainConfig, default_train
@@ -190,6 +192,7 @@ ferry_model_1b = default_train(
     model_config=qwen3_1_7b,
     train_config=train_config_1b,
     eval_harness_tasks=[],
+    override_output_path="checkpoints/ferry_qwen3_1_7b_pt_to_cooldown-027563",
 )
 
 ferry_model_8b = default_train(
@@ -198,6 +201,7 @@ ferry_model_8b = default_train(
     model_config=qwen3_8b,
     train_config=train_config_8b,
     eval_harness_tasks=[],
+    override_output_path="checkpoints/ferry_qwen3_8b_pt_to_cooldown-1fc2cb",
 )
 
 # Main execution block


### PR DESCRIPTION
## Description

Creates a new folder "ferries" (our proposed name for runs which leave on a regular basis and are meant to test all of our latest and greatest inventions). Unlike experiments (which should be issue driven and carefully controlled to answer a scientific question) or Speedruns (which are method driven but controlled to avoid confounds from data etc.), the intent with ferries is that they simply run on time and pick up anything/everything that has been validated and is ready to ride. 

By tracking our ferry progress, we want to get a quantifiable metric of the progress we are making overall across all tracks.

I'm kicking things off with two relatively large runs based on the DCLM tracks (1b1x and 7b1x) for simplicity, but would like to eventually move to a principled scaling suite based on #1460.

Initial Ferry: A Roughly Scaled Down Model of our recipe from #1295.
Our October 31st Ferry: Adapting this recipe to move to our Feistel shuffle (which we mostly ablated with our issues #1529 and use @WhenWen's MuonH which has been ablated in #1405.

Stylistically, I imported things that didn't change from the previous ferry so that each new one is the minimal set of changes from the previous ferry, although I suspect I may get over-ruled on that in this PR review.