### PR TITLE
Direct the `uv sync` to the right directory

### DIFF
--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -12,7 +12,7 @@ git clone https://github.com/marin-community/marin.git
 cd marin
 uv venv --python 3.11
 source .venv/bin/activate
-uv sync --group dev --directory lib/marin
+uv sync --package marin --group dev
 pre-commit install
 ```
 


### PR DESCRIPTION
## Description

The dependency groups that `--group dev` refers to now live in `lib/marin/pyproject.toml`, not in the top-level.

As a result, the command only worked for me when I directed it to this directory.

With that change, I was able to pull dependencies and run tests using the setup instructions here.