### PR TITLE
Bump the number of operations for staleness marking.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -50,7 +50,7 @@ jobs:
           remove-stale-when-updated: true
 
           # Increase operations limit for larger repos
-          operations-per-run: 100
+          operations-per-run: 300
 
           # Exempt issues/PRs with these labels from being marked stale
           exempt-issue-labels: 'pinned,security,bug,enhancement'


### PR DESCRIPTION
It wasn't hitting all of the issues successfully.