### PR TITLE
Use ray backend by default when we're running in a Ray worker.

### DIFF
--- a/lib/zephyr/tests/test_backends.py
+++ b/lib/zephyr/tests/test_backends.py
@@ -14,7 +14,10 @@
 
 """Tests for backend implementations."""
 
-from zephyr.backends import format_shard_path
+import ray
+
+from zephyr.backend_factory import flow_backend
+from zephyr.backends import RayBackend, format_shard_path
 
 
 def test_format_shard_path_basic():
@@ -109,3 +112,16 @@ def test_write_jsonl_no_compression_without_gz_extension(tmp_path):
         assert len(lines) == 2
         assert json.loads(lines[0]) == {"id": 1, "text": "hello"}
         assert json.loads(lines[1]) == {"id": 2, "text": "world"}
+
+
+def test_flow_backend_defaults_to_ray_when_initialized():
+    """Test that flow_backend returns RayBackend when Ray is initialized."""
+    if ray.is_initialized():
+        ray.shutdown()
+
+    try:
+        ray.init(ignore_reinit_error=True)
+        backend = flow_backend()
+        assert isinstance(backend, RayBackend)
+    finally:
+        ray.shutdown()


### PR DESCRIPTION
When running inside of a Ray worker context (e.g. running a set of ExecutorSteps) we should use the Ray backend for dataflow processing by default instead of a threadpool.

Previously we'd only get the Ray backend if we were being called from the zephyr command line.