### PR TITLE
Consolidate CI to run all tests on TPU worker

### DIFF
--- a/.github/workflows/marin-unit-tests.yaml
+++ b/.github/workflows/marin-unit-tests.yaml
@@ -15,62 +15,48 @@ concurrency:
 
 jobs:
   cpu-unit-test:
-    runs-on: ubuntu-latest
+    runs-on: [tpu-ci]
     timeout-minutes: 10
-    strategy:
-      matrix:
-        python-version: ["3.12"]
-        node-version: ["20.10.0"]
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
-      
-      - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-      
-      - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
-        with:
-          pandoc-version: '3.1.11'  # Pin version for cache consistency
-      
-      - name: Cache dependencies
-        id: cache-deps
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/pip
-            ~/.cache/uv
-            ~/.npm
-            ~/node_modules
-          key: ${{ runner.os }}-deps-v1-${{ hashFiles('uv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-deps-v1-
-      
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install "uv>=0.7.19" toml
-          npm install -g pandiff
-          uv sync --package marin --extra cpu --group test --frozen
+          ref: ${{ (github.event_name == 'pull_request_review' && format('refs/pull/{0}/merge', github.event.pull_request.number)) || '' }}
 
-      - name: Test with pytest
+      - name: Run CPU tests in Docker
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          CI: true
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
         run: |
-          PYTHONPATH=tests:. uv run --frozen pytest -n3 --durations=5 --tb=short -m 'not slow and not tpu_ci' -v tests/
+          bash infra/tpu-ci/clean-tpu.sh
 
-  tpu-test:
+          DOCKER_IMAGE="ghcr.io/marin-community/marin/tpu-ci:latest"
+          echo "Using Docker image: $DOCKER_IMAGE"
+
+          # Create UV cache directory
+          mkdir -p /tmp/uv-cache
+          chmod 777 /tmp/uv-cache
+
+          docker run --rm \
+            --shm-size=100g \
+            --stop-timeout=5 \
+            -e JAX_PLATFORMS=cpu \
+            -e PYTHONPATH=/workspace \
+            -e HF_TOKEN \
+            -e WANDB_API_KEY \
+            -e WANDB_MODE=offline \
+            -e UV_CACHE_DIR=/tmp/uv-cache \
+            -v ${{ github.workspace }}:/workspace-src:ro \
+            -v /tmp/uv-cache:/tmp/uv-cache:rw \
+            -w /workspace \
+            $DOCKER_IMAGE \
+            bash -c "cp -a /workspace-src/. /workspace/ && cd /workspace && timeout --kill-after=5 --signal=TERM 590 uv run --package marin --extra cpu --group test --frozen pytest -n16 --durations=5 --tb=short -m 'not slow and not tpu_ci' -v tests/"
+
+  tpu-unit-test:
     runs-on: [tpu-ci]
     timeout-minutes: 10
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -113,4 +99,4 @@ jobs:
             -v /tmp/uv-cache:/tmp/uv-cache:rw \
             -w /workspace \
             $DOCKER_IMAGE \
-            bash -c "cp -a /workspace-src/. /workspace/ && cd /workspace && timeout --kill-after=5 --signal=TERM 590 uv run --package marin --extra tpu --group test --frozen pytest tests/tpu -m tpu_ci -v --tb=short -s --log-cli-level=INFO"
+            bash -c "cp -a /workspace-src/. /workspace/ && cd /workspace && timeout --kill-after=5 --signal=TERM 590 uv run --package marin --extra tpu --group test --frozen pytest -n16 --durations=5 --tb=short -m 'tpu_ci and not slow' -v tests/"

--- a/tests/evals/test_lm_eval.py
+++ b/tests/evals/test_lm_eval.py
@@ -33,6 +33,7 @@ def model_config():
     config.destroy()
 
 
+@pytest.mark.slow
 @pytest.mark.tpu_ci
 def test_lm_eval_harness_levanter(current_date_time, ray_tpu_cluster, model_config):
     mmlu_config = EvalTaskConfig("mmlu", 0, task_alias="mmlu_0shot")
@@ -49,6 +50,7 @@ def test_lm_eval_harness_levanter(current_date_time, ray_tpu_cluster, model_conf
     evaluate(config=config)
 
 
+@pytest.mark.slow
 @pytest.mark.tpu_ci
 def test_lm_eval_harness(current_date_time, ray_tpu_cluster, model_config):
     gsm8k_config = EvalTaskConfig(name="gsm8k_cot", num_fewshot=8)
@@ -65,6 +67,7 @@ def test_lm_eval_harness(current_date_time, ray_tpu_cluster, model_config):
     evaluate(config=config)
 
 
+@pytest.mark.slow
 @pytest.mark.tpu_ci
 def test_alpaca_eval(current_date_time, ray_tpu_cluster, model_config):
     config = EvaluationConfig(

--- a/tests/modernbert/test_flash_attn_monkeypatch.py
+++ b/tests/modernbert/test_flash_attn_monkeypatch.py
@@ -69,6 +69,7 @@ def _test_modernbert_flash_attn():
     assert all_close, f"Max diff: {torch.max(torch.abs(ref_model_output - patched_model_output))}"
 
 
+@pytest.mark.slow
 @pytest.mark.tpu_ci
 def test_modernbert_flash_attn(ray_tpu_cluster):
     ray.get(_test_modernbert_flash_attn.remote())

--- a/tests/ray-data/test_batch_llm_inference.py
+++ b/tests/ray-data/test_batch_llm_inference.py
@@ -22,6 +22,7 @@ from marin.generation.pipeline import vLLMTextGeneration
 TEST_OUTPUT_PATH = "gs://marin-us-east5/documents/ray-data-test-llama-200m"
 
 
+@pytest.mark.slow
 @pytest.mark.tpu_ci
 def test_ray_data(test_crawl_file_path):
     gcsfuse_mount_model_path = "/opt/gcsfuse_mount/perplexity-models/llama-200m"

--- a/tests/vllm/test_llm_inference.py
+++ b/tests/vllm/test_llm_inference.py
@@ -43,6 +43,7 @@ def run_vllm_inference(model_path, **model_init_kwargs):
     return generated_texts
 
 
+@pytest.mark.slow
 @pytest.mark.tpu_ci
 def test_local_llm_inference(ray_tpu_cluster):
     config = ModelConfig(
@@ -56,6 +57,7 @@ def test_local_llm_inference(ray_tpu_cluster):
     shutil.rmtree("/tmp/test-llama-eval")
 
 
+@pytest.mark.slow
 @pytest.mark.tpu_ci
 def test_large_model_inference():
     gcsfuse_mount_llama_70b_model_path = "/opt/gcsfuse_mount/models/meta-llama--Llama-3-3-70B-Instruct"


### PR DESCRIPTION
Removes separate CPU and TPU test jobs and consolidates tests onto the TPU worker.