### PR TITLE
Add fray to the ray dep list.

### DIFF
--- a/lib/marin/src/marin/run/ray_deps.py
+++ b/lib/marin/src/marin/run/ray_deps.py
@@ -130,6 +130,7 @@ def build_python_path(submodules_dir: str = "submodules") -> list[str]:
         "lib/marin/src",
         "lib/levanter/src",
         "lib/zephyr/src",
+        "lib/fray/src",
         "lib/haliax/src",
         "experiments",
     ]


### PR DESCRIPTION
Ray can't find workspace packages by default.