### PR TITLE
Fix Qwen3Config to set head_dim to 128 (matched with official Qwen3)

### DIFF
--- a/experiments/qwen3.py
+++ b/experiments/qwen3.py
@@ -19,6 +19,7 @@ Specifies a sequence of Llama 3 models from small to large.
 from levanter.layers.rotary import Llama3RotaryEmbeddingsConfig
 from levanter.models.qwen import Qwen3Config, QwenConfig
 
+# default head_dim = hidden_dim // num_heads = 64, mismatch with "Qwen/Qwen3-0.6B"
 qwen3_0_6b = Qwen3Config(
     seq_len=4096,
     hidden_dim=1024,
@@ -28,6 +29,19 @@ qwen3_0_6b = Qwen3Config(
     num_layers=28,
     rope=Llama3RotaryEmbeddingsConfig(),
     tie_word_embeddings=True,
+)
+
+# qwen3_0_6b_hd128: head_dim=128, identical to "Qwen/Qwen3-0.6B"
+qwen3_0_6b_hd128 = Qwen3Config(
+    seq_len=4096,
+    hidden_dim=1024,
+    intermediate_dim=3072,
+    num_heads=16,
+    num_kv_heads=8,
+    num_layers=28,
+    rope=Llama3RotaryEmbeddingsConfig(),
+    tie_word_embeddings=True,
+    head_dim=128,
 )
 
 qwen3_1_7b = Qwen3Config(
@@ -41,6 +55,7 @@ qwen3_1_7b = Qwen3Config(
     tie_word_embeddings=True,
 )
 
+# default head_dim = hidden_dim // num_heads = 80, mismatch with "Qwen/Qwen3-4B"
 qwen3_4b = Qwen3Config(
     seq_len=4096,
     hidden_dim=2560,
@@ -50,6 +65,19 @@ qwen3_4b = Qwen3Config(
     num_layers=36,
     rope=Llama3RotaryEmbeddingsConfig(),
     tie_word_embeddings=True,
+)
+
+# qwen3_4b_hd128: head_dim=128, identical to "Qwen/Qwen3-4B"
+qwen3_4b_hd128 = Qwen3Config(
+    seq_len=4096,
+    hidden_dim=2560,
+    intermediate_dim=9728,
+    num_heads=32,
+    num_kv_heads=8,
+    num_layers=36,
+    rope=Llama3RotaryEmbeddingsConfig(),
+    tie_word_embeddings=True,
+    head_dim=128,
 )
 
 qwen3_8b = Qwen3Config(


### PR DESCRIPTION
## Description

Fixes #2098

- Add `qwen3_0_6b_hd128` and `qwen3_4b_hd128` for the two sizes where the current Qwen3 configs do not match with Qwen3 on HF. 
- Leave the current Qwen3 config the same (for backward compat) + leave comments so that if someone tries to load weights from HF (e.g., warm-start exp) to Qwen3-0.6B and Qwen3-4B, they can see the mismatch