### PR TITLE
Run on Pod on Head

### DIFF
--- a/lib/fray/src/fray/cluster/ray/tpu/execution.py
+++ b/lib/fray/src/fray/cluster/ray/tpu/execution.py
@@ -758,7 +758,7 @@ def run_on_pod(
     return ray.get(run_on_pod_ray.remote(remote_fn, tpu_type, num_slices, max_retries_preemption, max_retries_failure))
 
 
-@ray.remote(num_cpus=0.01)
+@ray.remote(num_cpus=0.0, resources={"head_node": 0.001})
 def run_on_pod_ray(
     remote_fn: RemoteFunction,
     tpu_type: str,


### PR DESCRIPTION
## Description

run_on_pod was being scheduled on arbitrary nodes, including preemptible TPU nodes. Since these preemptible nodes always cycle over after 24 hours, this caused long-running jobs to fail when the node hosting run_on_pod was reclaimed.

This just moves run_on_pod to run on the head node so that our jobs should be more long-lived as long as the head node doesn't die.