### PR TITLE
Clarify ray_run `auto-stop` help - only the job is stopped

### DIFF
--- a/lib/marin/src/marin/run/ray_run.py
+++ b/lib/marin/src/marin/run/ray_run.py
@@ -205,7 +205,11 @@ def main():
         default=None,
         help="Custom submission ID for the job. If not provided, a default ID will be generated.",
     )
-    parser.add_argument("--auto-stop", action="store_true", help="Automatically stop the cluster on shutdown.")
+    parser.add_argument(
+        "--auto-stop",
+        action="store_true",
+        help="Automatically stop the submitted job on exit (including ctrl+c interrupt).",
+    )
     parser.add_argument("cmd", help="The command to run in the Ray cluster.", nargs=argparse.REMAINDER)
 
     args = parser.parse_args()


### PR DESCRIPTION
## Description

`auto-stop` on `ray_run` is very useful. I was initially worried after reading the help string:

> Automatically stop the cluster on shutdown. 

It reads as if the cluster would be stopped, but of course it's only the submitted job that is stopped, this PR simply updates the help string.

cc: @yonromai 