### PR TITLE
Zephyr CLI `backend` argument should be respected?

### DIFF
--- a/lib/zephyr/src/zephyr/cli.py
+++ b/lib/zephyr/src/zephyr/cli.py
@@ -241,6 +241,7 @@ def main(
         num_gpus=num_gpus,
         cluster=cluster,
         entry_point=entry_point,
+        backend=backend,
     )
 
     # in cluster mode: submit via ray_run.py


### PR DESCRIPTION
## Description

It looks like https://github.com/marin-community/marin/pull/2014 has removed backend from the zephyr CLI config, which means that Zephyr CLI is always in `threadpool` mode?

If on the end hand this is expected behavior, I am happy to change this PR to remove the `backend` CLI argument.

To reproduce this problem try:

> uv run lib/zephyr/src/zephyr/cli.py --backend=ray <script>

<hr>

If this is in fact a bug, I was wonder how could this have been avoided, one idea is to enable `ARG` linter - https://docs.astral.sh/ruff/rules/unused-function-argument/#unused-function-argument-arg001. Here's incomplete change for reference:

```diff
diff --git i/pyproject.toml w/pyproject.toml
index 545b35a43..5173830c6 100644
--- i/pyproject.toml
+++ w/pyproject.toml
@@ -59,11 +59,13 @@ target-version = "py310"
 extend-exclude = ["scripts/"]
 
 [tool.ruff.lint]
-select = ["A", "B", "E", "F", "I", "NPY", "RUF", "UP", "W"]
+select = ["A", "ARG", "B", "E", "F", "I", "NPY", "RUF", "UP", "W"]
 ignore = ["F722", "B008", "UP015", "A005", "I001"]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402", "F401"]
+"test_**.py" = ["ARG"]
+"tests/**" = ["ARG"]
 
 
 [tool.mypy]
```