### PR TITLE
Support fluent optional `Dataset.reshard`

### DIFF
--- a/lib/zephyr/src/zephyr/dataset.py
+++ b/lib/zephyr/src/zephyr/dataset.py
@@ -611,7 +611,7 @@ class Dataset(Generic[T]):
             num_shards: Optional target number of shards, when None it's a no-op
 
         Returns:
-            New dataset with reshard operation appended
+            New dataset with reshard operation appended or self if num_shards is None
 
         Example:
             >>> backend = create_backend("ray", max_parallelism=20)

--- a/lib/zephyr/tests/test_dataset.py
+++ b/lib/zephyr/tests/test_dataset.py
@@ -300,7 +300,7 @@ def test_reshard(backend):
 
 
 def test_reshard_noop(backend):
-    """Test reshard with non-positive num_shards is a noop."""
+    """Test reshard with None is a noop, and non-positive values raise ValueError"""
 
     def yield_1(it):
         yield from [1]


### PR DESCRIPTION
## Description

Fixes https://github.com/marin-community/marin/issues/2127

Example:

```py
    Dataset.from_list(input_files)
    .flat_map(load_file)
    .reshard(num_shards=config.processes if len(input_files) > ... else None)
```

CC: @dlwh 