### PR TITLE
Fix filename rebase bug in dedupe

### DIFF
--- a/lib/marin/src/marin/processing/classification/dedupe.py
+++ b/lib/marin/src/marin/processing/classification/dedupe.py
@@ -294,7 +294,7 @@ def _record_id(record: dict) -> str:
 
 
 def _get_extension(file_path: str) -> str:
-    for ext in SUPPORTED_EXTENSIONS:
+    for ext in sorted(SUPPORTED_EXTENSIONS, key=len, reverse=True):
         if file_path.endswith(ext):
             return ext
     raise ValueError(f"Unsupported extension: {file_path}.")

--- a/lib/zephyr/src/zephyr/readers.py
+++ b/lib/zephyr/src/zephyr/readers.py
@@ -129,23 +129,19 @@ def load_parquet(file_path: str, **kwargs) -> Iterator[dict]:
 
 
 SUPPORTED_EXTENSIONS = tuple(
-    sorted(
-        [
-            ".json",
-            ".json.gz",
-            ".json.xz",
-            ".json.zst",
-            ".json.zstd",
-            ".jsonl",
-            ".jsonl.gz",
-            ".jsonl.xz",
-            ".jsonl.zst",
-            ".jsonl.zstd",
-            ".parquet",
-        ],
-        key=len,
-        reverse=True,
-    )
+    [
+        ".json",
+        ".json.gz",
+        ".json.xz",
+        ".json.zst",
+        ".json.zstd",
+        ".jsonl",
+        ".jsonl.gz",
+        ".jsonl.xz",
+        ".jsonl.zst",
+        ".jsonl.zstd",
+        ".parquet",
+    ]
 )
 
 


### PR DESCRIPTION
@rjpower 

This PR fixes a small bug in `lmarin/processing/classification/dedupe.py`: The json files written by the pipeline keep the original input file extension (it's how `rebase_file_path` is designed to work). So if we feed the pipeline a bunch of parquet files, the output files will have a `.parquet` extension (even though their content is jsonl). 

cc: @ravwojdyla 