### PR TITLE
Install `gdb` on the cluster

### DIFF
--- a/docker/marin/Dockerfile.cluster
+++ b/docker/marin/Dockerfile.cluster
@@ -31,6 +31,7 @@ RUN sudo rm -rf /var/lib/apt/lists/* \
       docker.io \
       fuse \
       g++ \
+      gdb \
       gnupg \
       liblz4-dev \
       libpython3.11 \

--- a/docker/marin/Dockerfile.vllm
+++ b/docker/marin/Dockerfile.vllm
@@ -31,6 +31,7 @@ RUN sudo rm -rf /var/lib/apt/lists/* \
       docker.io \
       fuse \
       g++ \
+      gdb \
       gnupg \
       liblz4-dev \
       libpython3.11 \


### PR DESCRIPTION
## Description

Re: #2096 

In this PR we install `gdb` which is required to profile memory via `memray` (which is already installed).

@dlwh @rjpower some questions:
 * is this all that is required to install system package on the cluster? 
 * I added it to both vllm and "base" docker images - is that good with you?
 * this should not break anything ™️  - but is there any canary test in place for the cluster docker images?

