### PR TITLE
Move MinHashLSH logic to Rust

### DIFF
--- a/lib/dupekit/Cargo.lock
+++ b/lib/dupekit/Cargo.lock
@@ -523,6 +523,9 @@ dependencies = [
  "hex",
  "parquet",
  "pyo3",
+ "rand",
+ "rand_pcg",
+ "regex",
  "xxhash-rust",
 ]
 
@@ -918,6 +921,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1013,45 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "regex"

--- a/lib/dupekit/Cargo.toml
+++ b/lib/dupekit/Cargo.toml
@@ -18,4 +18,7 @@ pyo3 = { version = "0.26", features = [
     "extension-module",
     "abi3-py311",
 ] } # stable ABI with minimum Python version 3.11
+rand = "0.8"
+rand_pcg = "0.3"
+regex = "1.10"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }

--- a/lib/dupekit/README.md
+++ b/lib/dupekit/README.md
@@ -32,6 +32,7 @@ uv run pytest lib/dupekit/tests/bench/test_marshaling.py --run-benchmark
 uv run pytest lib/dupekit/tests/bench/test_batch_tuning.py --run-benchmark
 uv run pytest lib/dupekit/tests/bench/test_io.py --run-benchmark
 uv run pytest lib/dupekit/tests/bench/test_hashing.py --run-benchmark
+uv run pytest lib/dupekit/tests/bench/test_minhash.py --run-benchmark
 ```
 Note: Run separated by type of benchmark (otherwise results are mixed within one table)
 

--- a/lib/dupekit/dupekit.pyi
+++ b/lib/dupekit/dupekit.pyi
@@ -141,6 +141,35 @@ class Transformation:
         """Projects the batch to keep only the specified columns."""
         ...
 
+    @staticmethod
+    def CleanText(input_col: str, output_col: str) -> "Transformation":
+        """Normalizes text (lowercase, remove punctuation, normalize whitespace)."""
+        ...
+
+    @staticmethod
+    def MinHash(input_col: str, output_col: str, num_perms: int, ngram_size: int, seed: int) -> "Transformation":
+        """Computes MinHash signatures for the input text using fused shingling/hashing.
+
+        Args:
+            input_col: Column containing text.
+            output_col: Column to store signature (List[uint64]).
+            num_perms: Number of permutation functions (length of signature).
+            ngram_size: Size of char-ngrams for shingling.
+            seed: Random seed for permutation coefficients.
+        """
+        ...
+
+    @staticmethod
+    def MinHashLSH(input_col: str, output_col: str, num_bands: int) -> "Transformation":
+        """Computes LSH buckets from a MinHash signature.
+
+        Args:
+            input_col: Column containing signatures (List[uint64]).
+            output_col: Column to store buckets (List[uint64]).
+            num_bands: Number of LSH bands.
+        """
+        ...
+
 def transform(batch: pa.RecordBatch, steps: list[Transformation]) -> pa.RecordBatch: ...
 def mark_paragraph_duplicates(
     batch: pa.RecordBatch,

--- a/lib/dupekit/src/lib.rs
+++ b/lib/dupekit/src/lib.rs
@@ -4,6 +4,7 @@ mod bloom;
 mod dedupe;
 mod hashing;
 mod marshaling;
+mod minhash_ops;
 mod ops;
 mod pipeline;
 

--- a/lib/dupekit/src/minhash_ops.rs
+++ b/lib/dupekit/src/minhash_ops.rs
@@ -1,0 +1,160 @@
+use arrow::array::{Array, ListArray, ListBuilder, StringArray, StringBuilder, UInt64Builder};
+use arrow::datatypes::{DataType, Field};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use rand::{Rng, SeedableRng};
+use rand_pcg::Pcg64;
+use regex::Regex;
+use std::sync::Arc;
+use xxhash_rust::xxh3;
+
+/// Clean text using the SlimPajama text cleaning process.
+/// 1. Lowercase
+/// 2. Remove punctuation
+/// 3. Replace multiple whitespace with single space
+/// 4. Trim
+pub fn clean_text(arr: &StringArray) -> PyResult<Arc<StringArray>> {
+    let mut builder = StringBuilder::with_capacity(arr.len(), arr.len() * 50);
+    let whitespace_re = Regex::new(r"\s+").map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let punctuation: &[char] = &[
+        '!', '"', '#', '$', '%', '&', '\'', '(', ')', '*', '+', ',', '-', '.', '/', ':', ';', '<',
+        '=', '>', '?', '@', '[', '\\', ']', '^', '_', '`', '{', '|', '}', '~',
+    ];
+
+    for i in 0..arr.len() {
+        if arr.is_null(i) {
+            builder.append_null();
+            continue;
+        }
+
+        let text = arr.value(i);
+        let lower = text.to_lowercase();
+        let no_punct: String = lower.chars().filter(|c| !punctuation.contains(c)).collect();
+        let normalized = whitespace_re.replace_all(&no_punct, " ");
+        builder.append_value(normalized.trim());
+    }
+
+    Ok(Arc::new(builder.finish()))
+}
+
+/// Fused operation: Shingling -> Hashing -> Permutation -> Min extraction
+pub fn compute_minhash(
+    arr: &StringArray,
+    num_perms: usize,
+    ngram_size: usize,
+    seed: u64,
+) -> PyResult<Arc<dyn Array>> {
+    // Generate permutations using Duplodocus strategy (Single u128 coefficient)
+    let mut rng = Pcg64::seed_from_u64(seed);
+    let mut coeffs = Vec::with_capacity(num_perms);
+
+    for _ in 0..num_perms {
+        // Duplodocus ensures coefficients are odd to preserve properties of the permutation group
+        let mut c = rng.gen::<u128>();
+        if c % 2 == 0 {
+            c = c.wrapping_add(1);
+        }
+        coeffs.push(c);
+    }
+
+    let mut values_builder = UInt64Builder::with_capacity(arr.len() * num_perms);
+    let mut list_builder = ListBuilder::new(values_builder);
+
+    for i in 0..arr.len() {
+        if arr.is_null(i) {
+            list_builder.append_null();
+            continue;
+        }
+
+        let text = arr.value(i);
+        let chars: Vec<char> = text.chars().collect();
+        let mut signature = vec![u64::MAX; num_perms];
+
+        if chars.len() < ngram_size {
+            let hash = xxh3::xxh3_64(text.as_bytes()) as u128;
+            update_signature(&mut signature, hash, &coeffs);
+        } else {
+            for window in chars.windows(ngram_size) {
+                let s: String = window.iter().collect();
+                let hash = xxh3::xxh3_64(s.as_bytes()) as u128;
+                update_signature(&mut signature, hash, &coeffs);
+            }
+        }
+        list_builder.values().append_slice(&signature);
+        list_builder.append(true);
+    }
+    Ok(Arc::new(list_builder.finish()))
+}
+
+#[inline(always)]
+fn update_signature(signature: &mut [u64], hash: u128, coeffs: &[u128]) {
+    // Logic: (hash * coeff) >> 64. Similar to Duplodocus
+    for (sig_val, &coeff) in signature.iter_mut().zip(coeffs) {
+        let permuted_hash = (hash.wrapping_mul(coeff) >> 64) as u64;
+        if permuted_hash < *sig_val {
+            *sig_val = permuted_hash;
+        }
+    }
+}
+
+pub fn compute_lsh(input_col: &dyn Array, num_bands: usize) -> PyResult<Arc<dyn Array>> {
+    let list_arr = input_col
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .ok_or_else(|| {
+            PyValueError::new_err("Input to MinHashLSH must be a ListArray of UInt64")
+        })?;
+
+    let values_arr = list_arr
+        .values()
+        .as_any()
+        .downcast_ref::<arrow::array::UInt64Array>()
+        .ok_or_else(|| PyValueError::new_err("Inner array must be UInt64"))?;
+
+    let mut out_values_builder = UInt64Builder::with_capacity(list_arr.len() * num_bands);
+    let mut out_list_builder = ListBuilder::new(out_values_builder);
+
+    for i in 0..list_arr.len() {
+        if list_arr.is_null(i) {
+            out_list_builder.append_null();
+            continue;
+        }
+
+        let start = list_arr.value_offsets()[i] as usize;
+        let end = list_arr.value_offsets()[i + 1] as usize;
+        let sig_len = end - start;
+
+        if sig_len == 0 {
+            // Empty signature
+            out_list_builder.append(true);
+            continue;
+        }
+
+        if sig_len % num_bands != 0 {
+            return Err(PyValueError::new_err(format!(
+                "Signature length {} is not divisible by num_bands {}",
+                sig_len, num_bands
+            )));
+        }
+
+        let rows_per_band = sig_len / num_bands;
+        let slice = &values_arr.values()[start..end];
+
+        for band_idx in 0..num_bands {
+            let band_start = band_idx * rows_per_band;
+            let band_end = band_start + rows_per_band;
+            let band_data = &slice[band_start..band_end];
+            let band_bytes: &[u8] = unsafe {
+                std::slice::from_raw_parts(
+                    band_data.as_ptr() as *const u8,
+                    band_data.len() * std::mem::size_of::<u64>(),
+                )
+            };
+            let bucket_hash = xxh3::xxh3_64(band_bytes);
+            out_list_builder.values().append_value(bucket_hash);
+        }
+        out_list_builder.append(true);
+    }
+
+    Ok(Arc::new(out_list_builder.finish()))
+}

--- a/lib/dupekit/tests/bench/conftest.py
+++ b/lib/dupekit/tests/bench/conftest.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import pytest
+import pyarrow as pa
+import pyarrow.parquet as pq
 from typing import Any
 from huggingface_hub import hf_hub_download
 
@@ -33,6 +35,47 @@ def parquet_file() -> str:
             pass
 
     return file_path
+
+
+@pytest.fixture(scope="session")
+def small_parquet_path(tmp_path_factory: pytest.TempPathFactory, parquet_file: str) -> str:
+    """
+    Creates a smaller slice (250k rows) of the main parquet file for faster benchmarking
+    and I/O tests.
+    """
+    fn = tmp_path_factory.mktemp("data_io") / "subset.parquet"
+    pf = pq.ParquetFile(parquet_file)
+    # 250k rows is substantial enough for I/O throughput tests
+    first_batch = next(pf.iter_batches(batch_size=250_000))
+    table = pa.Table.from_batches([first_batch])
+    pq.write_table(table, fn)
+    path_str = str(fn)
+
+    # Warm up OS cache for this new file
+    with open(path_str, "rb") as f:
+        while f.read(1024**2):
+            pass
+
+    return path_str
+
+
+@pytest.fixture(scope="session")
+def in_memory_table(small_parquet_path: str) -> pa.Table:
+    """
+    Loads 250k rows into memory once. Used for marshaling and batch size tuning benchmarks.
+    """
+    return pq.read_table(small_parquet_path)
+
+
+@pytest.fixture(scope="session")
+def sample_batch(parquet_file: str) -> pa.RecordBatch:
+    """
+    Loads a single batch (10k rows) for algorithm benchmarks (hashing, dedupe logic).
+    Columns are restricted to ensure we have 'text' and 'id'.
+    """
+    pf = pq.ParquetFile(parquet_file)
+    # Ensure we get necessary columns if they exist, though 'iter_batches' defaults to all.
+    return next(pf.iter_batches(batch_size=10_000))
 
 
 def pytest_addoption(parser: Any) -> None:

--- a/lib/dupekit/tests/bench/test_hashing.py
+++ b/lib/dupekit/tests/bench/test_hashing.py
@@ -16,16 +16,9 @@ from typing import Any
 from collections.abc import Callable
 
 import pytest
-import pyarrow.parquet as pq
+import pyarrow as pa
 import hashlib
 import dupekit
-
-
-@pytest.fixture(scope="module")
-def text_samples(parquet_file: str) -> list[bytes]:
-    table = pq.read_table(parquet_file)
-    texts = table["text"][:10000].to_pylist()
-    return [t.encode("utf-8") for t in texts]
 
 
 def _py_blake2b(text: bytes) -> bytes:
@@ -43,7 +36,9 @@ def _py_blake2b(text: bytes) -> bytes:
         pytest.param(dupekit.hash_xxh3_64_batch, "batch", id="rust_xxh3_64_batch"),
     ],
 )
-def test_hashing_throughput(benchmark: Any, text_samples: list[bytes], func: Callable, mode: str) -> None:
+def test_hashing_throughput(benchmark: Any, sample_batch: pa.RecordBatch, func: Callable, mode: str) -> None:
+    # Use the sample_batch fixture (10k rows) and convert to bytes
+    text_samples = [t.as_py().encode("utf-8") for t in sample_batch["text"]]
 
     def _run() -> list[Any]:
         if mode == "batch":

--- a/lib/dupekit/tests/bench/test_marshaling.py
+++ b/lib/dupekit/tests/bench/test_marshaling.py
@@ -18,20 +18,9 @@ Benchmarks include the cost of converting Arrow data to target format (Dicts, St
 """
 
 import pytest
-import pyarrow.parquet as pq
 import pyarrow as pa
 from typing import Any
 import dupekit
-
-
-@pytest.fixture(scope="module")
-def in_memory_table(tmp_path_factory: pytest.TempPathFactory, parquet_file: str) -> pa.Table:
-    """
-    Loads 250k rows into memory once.
-    """
-    pf = pq.ParquetFile(parquet_file)
-    first_batch = next(pf.iter_batches(batch_size=250_000))
-    return pa.Table.from_batches([first_batch])
 
 
 @pytest.mark.parametrize(

--- a/lib/dupekit/tests/bench/test_minhash.py
+++ b/lib/dupekit/tests/bench/test_minhash.py
@@ -1,0 +1,58 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+import pyarrow as pa
+from typing import Any
+import dupekit
+from dupekit import Transformation
+
+try:
+    # Use the internal _minhash_lsh function to benchmark the Datasketch logic directly
+    # without the Zephyr Dataset API wrapper overhead or type checks.
+    from marin.processing.classification.deduplication.minhash_lsh import _minhash_lsh
+except ImportError:
+    # These benchmark tests are parsed by no run by the build
+    logging.warn("Couldn't import marin")
+
+# Python is slow, can't use too many rows
+BENCHMARK_ROWS = 1000
+
+
+def rust_minhash_pipeline(batch: pa.RecordBatch) -> int:
+    pipeline = [
+        Transformation.CleanText(input_col="text", output_col="clean"),
+        Transformation.MinHash(input_col="clean", output_col="sig", num_perms=286, ngram_size=5, seed=42),
+        Transformation.MinHashLSH(input_col="sig", output_col="buckets", num_bands=26),
+    ]
+    res = dupekit.transform(batch, pipeline)
+    return len(res)
+
+
+def python_minhash_pipeline_wrapper(batch: pa.RecordBatch) -> int:
+    records = batch.to_pylist()
+    count = 0
+    for _ in _minhash_lsh(records, vector_length=286, num_bands=26, shingle_size=5):
+        count += 1
+    return count
+
+
+def test_bench_rust_minhash(benchmark: Any, sample_batch: pa.RecordBatch) -> None:
+    batch = sample_batch.slice(length=BENCHMARK_ROWS)
+    benchmark(rust_minhash_pipeline, batch)
+
+
+def test_bench_python_minhash(benchmark: Any, sample_batch: pa.RecordBatch) -> None:
+    batch = sample_batch.slice(length=BENCHMARK_ROWS)
+    benchmark(python_minhash_pipeline_wrapper, batch)

--- a/lib/dupekit/tests/test_minhash.py
+++ b/lib/dupekit/tests/test_minhash.py
@@ -1,0 +1,68 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pyarrow as pa
+from dupekit import Transformation, transform
+
+
+def test_clean_text():
+    """Test text cleaning (lowercase, punct removal, whitespace norm)."""
+    text = "Hello,   World! This is a test."
+    expected = "hello world this is a test"
+    batch = pa.RecordBatch.from_pydict({"text": [text, None, "   "]})
+    pipeline = [Transformation.CleanText(input_col="text", output_col="clean")]
+    clean = transform(batch, pipeline)["clean"]
+    assert clean[0].as_py() == expected
+    assert clean[1].as_py() is None
+    assert clean[2].as_py() == ""
+
+
+def test_minhash_dimensions():
+    """Test that MinHash output has correct dimensions."""
+    texts = ["doc one", "doc two"]
+    num_perms = 128
+    batch = pa.RecordBatch.from_pydict({"text": texts})
+    pipeline = [Transformation.MinHash(input_col="text", output_col="sig", num_perms=num_perms, ngram_size=3, seed=42)]
+    sigs = transform(batch, pipeline)["sig"]
+    for sig in sigs:
+        assert len(sig.as_py()) == num_perms
+        assert all(isinstance(x, int) for x in sig.as_py())
+
+
+def test_minhash_lsh_dimensions():
+    """Test LSH banding logic."""
+    num_bands = 26
+    sig = list(range(286))
+    batch = pa.RecordBatch.from_pydict({"sig": [sig]}, schema=pa.schema([("sig", pa.list_(pa.uint64()))]))
+    pipeline = [Transformation.MinHashLSH(input_col="sig", output_col="buckets", num_bands=num_bands)]
+    res = transform(batch, pipeline)
+    buckets = res["buckets"][0].as_py()
+    assert len(buckets) == num_bands
+    res2 = transform(batch, pipeline)
+    assert buckets == res2["buckets"][0].as_py()
+
+
+def test_full_pipeline_determinism():
+    """Test that the full MinHash pipeline produces deterministic results."""
+    text = "The quick brown fox jumps over the lazy dog."
+    batch = pa.RecordBatch.from_pydict({"text": [text, text]})
+    pipeline = [
+        Transformation.CleanText(input_col="text", output_col="clean"),
+        Transformation.MinHash(input_col="clean", output_col="sig", num_perms=20, ngram_size=5, seed=1),
+        Transformation.MinHashLSH(input_col="sig", output_col="buckets", num_bands=4),
+    ]
+    res = transform(batch, pipeline)
+    b0 = res["buckets"][0].as_py()
+    b1 = res["buckets"][1].as_py()
+    assert b0 == b1

--- a/lib/marin/src/marin/processing/classification/deduplication/connected_components.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/connected_components.py
@@ -1,0 +1,250 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from functools import partial
+import logging
+from typing import Any, TypedDict
+from collections.abc import Sequence
+
+from dupekit import hash_xxh3_128
+from marin.processing.classification.deduplication.minhash_lsh import MinHashLshOutputRecord
+from zephyr.backends import Backend
+from zephyr.dataset import Dataset
+from zephyr.readers import load_file
+
+logger = logging.getLogger(__name__)
+
+
+# TODO (rav): can we have just a single id that's expected to be clean on the inputs?
+class RecordId(TypedDict):
+    record_id: Any
+    record_id_norm: str
+
+
+# TODO: dataclasses are not writable to parquet ATM, is there something better than TypedDict that works out of the box?
+class CCNode(TypedDict):
+    node_id: RecordId
+    adjacency_list: list[str]
+    component_id: str
+    changed: bool
+
+
+@dataclass
+class CCMessage: ...
+
+
+@dataclass
+class SelfMessage(CCMessage):
+    node: CCNode
+
+
+@dataclass
+class CompMessage(CCMessage):
+    component_id: str
+
+
+# TODO: what's the best way to model the input type? Probably don't need this if
+# we move stuff to rust anyway.
+CCInput = MinHashLshOutputRecord
+
+
+def _internal_orderable_id(record_id: dict) -> str:
+    """
+    We need an id that has a total ordering for connected components. If the id is an int,
+    we can use it as is. If it's a string, we hash it and convert it to string. We convert
+    to string to make internal zephyr/ray/pyarrow serde happy.
+    """
+    if isinstance(record_id, int):
+        record_id_norm = str(record_id)
+    elif isinstance(record_id, str):
+        record_id_norm = str(hash_xxh3_128(record_id.encode()))
+    else:
+        raise ValueError(f"Unsupported id type: {type(record_id)}")
+    return record_id_norm
+
+
+class BucketWithIds(TypedDict):
+    bucket: str
+    ids: list[RecordId]
+
+
+# TODO (rav): instead of a single cc function that requires a backend, do we want to split it up
+# into more functional core functions that can be composed into an imperative flow externally?
+def connected_components(
+    ds: Dataset[CCInput],
+    *,
+    backend: Backend,
+    output_dir: str,
+    max_iterations: int = 10,
+    preserve_singletons: bool = True,
+) -> tuple[bool, Sequence[str]]:
+    """
+    Connected Components implementation using Zephyr Dataset API and Hash-to-Min algorithm (https://arxiv.org/abs/1203.5387)
+
+    Args:
+        ds: Input dataset containing 'bucket' and 'ids' fields, most likely from MinHash LSH output
+        backend: Zephyr backend to execute the connected components algorithm
+        output_dir: Directory to write intermediate and final output files
+        max_iterations: Maximum number of iterations to run the connected components algorithm
+        preserve_singletons: Whether to preserve single-node buckets in the output
+    """
+
+    curr_it = backend.execute(
+        ds
+        # Group nodes in buckets
+        .group_by(
+            lambda x: x["bucket"],
+            _reduce_buckets,
+        )
+        # Go from bucket -> links
+        .flat_map(partial(_gen_links_within_buckets, preserve_singletons=preserve_singletons))
+        # Construct Node state, init with:
+        #  * each node is its own component
+        #  * adjacency list from links
+        .group_by(
+            lambda x: x[0]["record_id_norm"],
+            _build_adjacency,
+        ).write_parquet(f"{output_dir}/it_0/part-{{shard:05d}}.parquet")
+    )
+
+    converged = False
+    for i in range(1, max_iterations + 1):  # type: ignore[bad-assignment]
+        logger.info(f"Connected components iteration {i}...")
+        curr_it = backend.execute(
+            Dataset.from_list(curr_it)
+            .flat_map(load_file)
+            .map(lambda record: CCNode(**record))
+            .flat_map(_emit_messages)
+            .group_by(key=lambda x: x[0], reducer=_reduce_node_step)
+            # NOTE: parquet built-in does not support list of int :/
+            .write_parquet(f"{output_dir}/it_{i}/part-{{shard:05d}}.parquet")
+        )
+
+        # Check for convergence
+        changes = backend.execute(
+            Dataset.from_list(curr_it)
+            .flat_map(lambda f: load_file(f, columns=["changed"]))
+            .filter(lambda node: node["changed"])
+            # TODO: why is there no .count() method?
+            .map(lambda _: 1)
+            .reduce(sum)
+        )
+
+        num_changes = changes[0]
+
+        if num_changes == 0:
+            converged = True
+            logger.info(f"Connected components converged after {i} iterations.")
+            break
+        else:
+            logger.info(f"Connected components iteration {i} found {num_changes} changes.")
+
+    return converged, curr_it
+
+
+def _reduce_buckets(bucket: str, items: Iterator[CCInput]) -> BucketWithIds:
+    # TODO: do we want/need this optimization?
+    # if len(all_items) <= 1:
+    #    return None  # No duplicates in this bucket
+    return {
+        "bucket": bucket,
+        "ids": [RecordId(record_id=item["id"], record_id_norm=_internal_orderable_id(item["id"])) for item in items],
+    }
+
+
+def _gen_links_within_buckets(
+    record: MinHashLshOutputRecord, *, preserve_singletons: bool
+) -> Iterator[tuple[RecordId, RecordId]]:
+    ids = record.get("ids", [])
+
+    norm_ids = [i["record_id_norm"] for i in ids]
+    # TODO: this will materialize ids!
+    if len(norm_ids) != len(set(norm_ids)):
+        raise ValueError("Duplicate para_ids found in bucket during link_reduce.!")
+
+    if preserve_singletons and len(ids) == 1:
+        yield (ids[0], ids[0])
+        return
+
+    # Emit all pairwise links
+    for i in range(len(ids)):
+        for j in range(i + 1, len(ids)):
+            if ids[i] == ids[j]:
+                continue
+
+            yield (ids[i], ids[j])
+            yield (ids[j], ids[i])
+
+
+def _build_adjacency(node_id: RecordId, links: Iterator[tuple[RecordId, RecordId]]) -> CCNode:
+    all_links = list(links)
+    return CCNode(
+        node_id=all_links[0][0],
+        adjacency_list=list(set([link[1]["record_id_norm"] for link in all_links])),
+        # init with own id as component
+        component_id=node_id,
+        changed=True,
+    )
+
+
+def _emit_messages(node: CCNode) -> Iterator[tuple[str, CCMessage]]:
+    """
+    1. Emit the node structure to itself (to preserve graph topology).
+    2. Emit the current component ID to all neighbors.
+    """
+    # 1. Preserve structure
+    yield (node["node_id"]["record_id_norm"], SelfMessage(node=node))
+
+    # 2. Propagate component ID to neighbors
+    # (Optimization: Only send if we changed recently, but strictly Hash-to-Min sends always)
+    msg = CompMessage(component_id=node["component_id"])
+    for neighbor_id in node["adjacency_list"]:
+        yield (neighbor_id, msg)
+
+
+def _reduce_node_step(key: str, incoming: Iterator[tuple[str, CCMessage]]) -> CCNode:
+    """
+    1. Recover NodeState.
+    2. Find minimum component ID from messages.
+    3. Update state if a smaller ID is found.
+    """
+    # NOTE: init the minimum component ID with the current key
+    min_comp = key
+    node_structure: CCNode | None = None
+
+    # Iterate through mixed stream of structure and messages
+    for _, msg in incoming:
+        if isinstance(msg, SelfMessage):
+            node_structure = msg.node
+            if node_structure["component_id"] < min_comp:
+                min_comp = node_structure["component_id"]
+        else:
+            assert isinstance(msg, CompMessage)
+            remote_comp = msg.component_id
+            if remote_comp < min_comp:
+                min_comp = remote_comp
+
+    if node_structure is None or min_comp is None:
+        # Should technically not happen if graph is well-formed
+        raise ValueError(f"Lost/corrupted structure for node {key}")
+
+    if min_comp < node_structure["component_id"]:
+        node_structure["component_id"] = min_comp
+        node_structure["changed"] = True
+    else:
+        node_structure["changed"] = False
+
+    return node_structure

--- a/lib/marin/src/marin/processing/classification/deduplication/connected_components.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/connected_components.py
@@ -61,7 +61,7 @@ class CompMessage(CCMessage):
 CCInput = MinHashLshOutputRecord
 
 
-def _internal_orderable_id(record_id: dict) -> str:
+def _internal_orderable_id(record_id: Any) -> str:
     """
     We need an id that has a total ordering for connected components. If the id is an int,
     we can use it as is. If it's a string, we hash it and convert it to string. We convert
@@ -173,7 +173,8 @@ def _gen_links_within_buckets(
     norm_ids = [i["record_id_norm"] for i in ids]
     # TODO: this will materialize ids!
     if len(norm_ids) != len(set(norm_ids)):
-        raise ValueError("Duplicate para_ids found in bucket during link_reduce.!")
+        duplicate_ids = [x for x in norm_ids if norm_ids.count(x) > 1]
+        raise ValueError(f"Duplicate found in bucket during link_reduce: {duplicate_ids}")
 
     if preserve_singletons and len(ids) == 1:
         yield (ids[0], ids[0])
@@ -237,7 +238,7 @@ def _reduce_node_step(key: str, incoming: Iterator[tuple[str, CCMessage]]) -> CC
             if remote_comp < min_comp:
                 min_comp = remote_comp
 
-    if node_structure is None or min_comp is None:
+    if node_structure is None:
         # Should technically not happen if graph is well-formed
         raise ValueError(f"Lost/corrupted structure for node {key}")
 

--- a/lib/marin/src/marin/processing/classification/deduplication/minhash.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/minhash.py
@@ -1,0 +1,75 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import cache
+from random import Random
+
+from dupekit import hash_xxh3_128
+
+# NOTE: adapted from https://stackoverflow.com/a/52534632, the purpose is not to
+# be fast, but rather to have a baseline for the rust implementation. We could not
+# use use datasketch because of numpy dependency issues.
+
+
+def minhash(s: set[str], vector_length: int = 128, prime=4294967311) -> list[int]:
+    """
+    Given a set `s`, pass each member of the set through all permutation functions,
+    and set the `ith` position of `vec` to the `ith` permutation function's output if
+    that output is smaller than `vec[i]`.
+
+    Args:
+        s: set of strings to compute the minhash for
+        vector_length: length of the minhash vector
+
+        prime: a large prime number for the hash functions
+
+    Returns:
+        A list of ints representing the minhash of the set `s`.
+    """
+    # initialize a minhash of length N with positive infinity values
+    vec = [float("inf") for i in range(vector_length)]
+
+    for val_str in s:
+        val = hash_xxh3_128(val_str.encode())
+
+        # loop over each "permutation function"
+        for perm_idx, perm_vals in enumerate(_minhash_perms(vector_length)):
+            a, b = perm_vals
+
+            # pass `val` through the `ith` permutation function
+            output = (a * val + b) % prime
+
+            # conditionally update the `ith` value of vec
+            if vec[perm_idx] > output:
+                vec[perm_idx] = output
+
+    # the returned vector represents the minimum hash of the set s
+    return vec  # type: ignore[bad-return]
+
+
+@cache
+def _minhash_perms(vector_length: int, max_val: int = (2**32) - 1, seed: int = 42) -> list[tuple[int, int]]:
+    """
+    Generate permutation coefficients for MinHash.
+
+    Args:
+        vector_length: Number of permutation functions to generate
+        max_val: Maximum value for random coefficients
+        seed: Random seed for reproducibility (default: 42)
+
+    Returns:
+        List of (a, b) coefficient tuples for permutation functions
+    """
+    rng = Random(seed)
+    return [(rng.randint(0, max_val), rng.randint(0, max_val)) for _ in range(vector_length)]

--- a/lib/marin/src/marin/processing/classification/deduplication/minhash_lsh.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/minhash_lsh.py
@@ -49,7 +49,7 @@ def minhash_lsh(
         shingle_size: Size of character shingles to extract from text (default: 5)
 
     Returns:
-        A dataset of MinHash LSH output records containing 'bucket' and 'ids' fields
+        A dataset of MinHash LSH output records containing 'bucket' and 'id' fields
     """
 
     assert (
@@ -110,7 +110,11 @@ def _minhash_lsh(
 
             bucket = sig[start:end]
             # TODO: is hashing the bucket necessary here?
-            bucket_bytes = struct.pack(f"{len(bucket)}d", *bucket)
+            # TODO: Is Q (unsigned long long) the right format?
+            assert all(
+                isinstance(x, int) and x >= 0 for x in bucket
+            ), f"Non-integer or negative value in bucket: {bucket}"
+            bucket_bytes = struct.pack(f"{len(bucket)}Q", *bucket)
             bucket_hash = str(hash_xxh3_128(bucket_bytes))
 
             yield {"bucket": bucket_hash, "id": record_id}

--- a/lib/marin/src/marin/processing/classification/deduplication/minhash_lsh.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/minhash_lsh.py
@@ -1,0 +1,80 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Iterator
+import struct
+from typing import Any, TypeVar, TypedDict
+from dupekit import hash_xxh3_128
+from marin.processing.classification.deduplication.minhash import minhash
+from marin.processing.classification.deduplication.text_cleaning import clean_text
+from zephyr.dataset import Dataset
+
+T = TypeVar("T")
+
+
+class MinHashLshInputRecord(TypedDict):
+    text: str
+    id: Any
+
+
+class MinHashLshOutputRecord(TypedDict):
+    bucket: str
+    id: Any
+
+
+# NOTE: defaults are from http://allenai.org/papers/olmo3
+# > We then apply a MinHash localitysensitive hashing scheme with 26 bands of size 11,
+# > configured to target a Jaccard similarity threshold of 0.80.
+def minhash_lsh(
+    ds: Dataset[MinHashLshInputRecord], *, vector_length: int = 286, num_bands: int = 26
+) -> Dataset[MinHashLshOutputRecord]:
+    """
+    Vanilla MinHashLSH implementation using zephyr Dataset API
+
+    Args:
+        ds: Input dataset with records containing 'text' and 'id' fields
+        vector_length: Length of the MinHash signature vector
+        num_bands: Number of bands to split the MinHash signature into for LSH
+
+    Returns:
+        A dataset of MinHash LSH output records containing 'bucket' and 'ids' fields
+    """
+
+    assert (
+        vector_length % num_bands == 0
+    ), f"vector_length must be divisible by num_bands, got {vector_length} and {num_bands}"
+
+    return ds.flat_map(lambda record: _minhash_lsh(record, vector_length, num_bands))
+
+
+def _minhash_lsh(record: MinHashLshInputRecord, vector_length: int, num_bands: int) -> Iterator[MinHashLshOutputRecord]:
+    text = record["text"]
+    # TODO: for now assume `id` exists!
+    record_id = record["id"]
+
+    text = clean_text(text)
+
+    sig = minhash(set(text.split()), vector_length=vector_length)
+
+    rows_per_band = len(sig) // num_bands
+
+    for band in range(num_bands):
+        start = band * rows_per_band
+        end = start + rows_per_band
+
+        bucket = sig[start:end]
+        bucket_bytes = struct.pack(f"{len(bucket)}d", *bucket)
+        bucket_hash = str(hash_xxh3_128(bucket_bytes))
+
+        yield {"bucket": bucket_hash, "id": record_id}

--- a/lib/marin/src/marin/processing/classification/deduplication/pipeline.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/pipeline.py
@@ -432,8 +432,9 @@ def _run_doc_deduplication(config: DedupeConfig):
     converged, cc_files = connected_components(
         doc_minhash_lsh, backend=backend, output_dir=f"{config.output_path}/metadata/cc"
     )
-    # NOTE: it's probably fine if this doesn't converge in general, but for now we assert
-    assert converged, "Connected components did not converge!"
+    if not converged:
+        # TODO (rav): log the number of changed nodes?
+        logger.warning("Connected components did not converge")
     fuzzy_dup_shards = backend.execute(
         Dataset.from_list(cc_files)
         .flat_map(load_file)

--- a/lib/marin/src/marin/processing/classification/deduplication/pipeline.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/pipeline.py
@@ -458,7 +458,7 @@ def _run_doc_deduplication(config: DedupeConfig):
     if wandb.run:
         wandb.log(exact_cnts.to_dict() | fuzzy_cnt.to_dict())
 
-    def mark_exact_dups_documents(batches: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
+    def mark_exact_dups_documents(batches: Iterator[pa.RecordBatch]) -> Iterator[dict]:
         """Mark exact duplicate documents using exact hash matching."""
         dup_map = _load_dupe_map_shard(duplicate_key_shards)
         fuzzy_dup_map = _load_fuzzy_dupe_map_shard(fuzzy_dup_shards)

--- a/lib/marin/src/marin/processing/classification/deduplication/pipeline.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/pipeline.py
@@ -43,7 +43,7 @@ from marin.utilities.wandb_utils import WANDB_PROJECT, WANDB_ENTITY
 from marin.utils import fsspec_glob, rebase_file_path
 from zephyr import Dataset, flow_backend, load_parquet
 from zephyr.backend_factory import create_backend
-from zephyr.readers import open_file, SUPPORTED_EXTENSIONS
+from zephyr.readers import load_file, open_file, SUPPORTED_EXTENSIONS
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/processing/classification/deduplication/pipeline.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/pipeline.py
@@ -30,6 +30,8 @@ from enum import StrEnum, auto
 import typing
 
 from marin.execution.executor import THIS_OUTPUT_PATH
+from marin.processing.classification.deduplication.connected_components import connected_components
+from marin.processing.classification.deduplication.minhash_lsh import minhash_lsh
 from marin.utilities.time_logger import log_time
 import pyarrow as pa
 import pyarrow.json as pa_json
@@ -48,7 +50,7 @@ logger = logging.getLogger(__name__)
 
 class DedupMode(StrEnum):
     DEDUPLICATE = auto()
-    EXACT_DOC_DEDUPLICATE = auto()
+    DOC_DEDUPLICATE = auto()
 
 
 @dataclass(frozen=True)
@@ -169,28 +171,61 @@ def _load_dupe_map_shard(shards: list[str]) -> dict[str, dict[str, str]]:
 
 
 @dataclass
-class Counters:
+class DupCounters:
+    # TODO (rav): make both method and level Enums
+    method: str
+    level: str
     total: int = 0
+    dups: int = 0
     unique: int = 0
-    unique_dups: int = 0
+    dup_clusters: int = 0
 
-    def __add__(self, other: "Counters") -> "Counters":
-        assert isinstance(other, Counters)
+    def __add__(self, other: "DupCounters") -> "DupCounters":
+        assert isinstance(other, DupCounters)
 
-        return Counters(
+        return DupCounters(
+            method=self.method,
+            level=self.level,
             total=self.total + other.total,
+            dups=self.dups + other.dups,
             unique=self.unique + other.unique,
-            unique_dups=self.unique_dups + other.unique_dups,
+            dup_clusters=self.dup_clusters + other.dup_clusters,
         )
 
+    def __str__(self) -> str:
+        if self.total == 0:
+            return f"{self.level} total: 0"
+        return (
+            f"{self.method.capitalize()} {self.level.lower()} total: {self.total:,}, "
+            f"dups: {self.dups:,} ({self.dups/self.total:.2%}), unique: {self.unique:,}, "
+            f"dup_clusters: {self.dup_clusters:,}"
+        )
 
-def _compute_dedup_stats(shards: list[str]) -> Counters:
+    def to_dict(self):
+        return {
+            f"dedup/{self.method}/{self.level}/total": self.total,
+            f"dedup/{self.method}/{self.level}/dups": self.dups,
+            f"dedup/{self.method}/{self.level}/unique": self.unique,
+            f"dedup/{self.method}/{self.level}/dup_clusters": self.dup_clusters,
+        }
+
+
+def _compute_dedup_stats(shards: list[str], method: str, level: str) -> DupCounters:
     with log_time(f"Compute deduplication stats from {len(shards)} shards"):
-        result: Counters = create_backend("threadpool").execute(  # type: ignore[bad-assignment]
+        result: DupCounters = create_backend("threadpool").execute(  # type: ignore[bad-assignment]
             Dataset.from_list(shards)
             .flat_map(lambda p: load_parquet(p, columns=["cnt"]))
-            .map(lambda c: Counters(total=c["cnt"], unique=int(c["cnt"] == 1), unique_dups=int(c["cnt"] > 1)))
-            .reduce(partial(sum, start=Counters()))
+            .map(
+                lambda c: DupCounters(
+                    method=method,
+                    level=level,
+                    total=c["cnt"],
+                    dups=c["cnt"] if c["cnt"] > 1 else 0,
+                    unique=int(c["cnt"] == 1),
+                    dup_clusters=int(c["cnt"] > 1),
+                )
+            )
+            .reduce(partial(sum, start=DupCounters(method=method, level=level)))
         )[0]
     return result
 
@@ -265,17 +300,11 @@ def _run_deduplication(config: DedupeConfig):
         )
     )
 
-    cnts = _compute_dedup_stats(duplicate_key_shards)
-    logger.info(f"Stats: {cnts.total=:,} paragraphs, {cnts.unique=:,} unique, {cnts.unique_dups=:,} dups.")
+    exact_cnts = _compute_dedup_stats(duplicate_key_shards, method="exact", level="paragraph")
+    logger.info(str(exact_cnts))
 
     if wandb.run:
-        wandb.log(
-            {
-                "dedup/total": cnts.total,
-                "dedup/unique": cnts.unique,
-                "dedup/unique_dups": cnts.unique_dups,
-            }
-        )
+        wandb.log(exact_cnts.to_dict())
 
     def mark_exact_dups_paragraphs(batches: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
         """Mark duplicate paragraphs in a single record using exact hash matching."""
@@ -310,17 +339,48 @@ def _run_deduplication(config: DedupeConfig):
     if wandb.run:
         wandb.finish()
 
-    return {
-        "success": True,
-        "mode": "deduplication",
-        "level": "paragraph",
-        "total": cnts.total,
-        "unique": cnts.unique,
-        "unique_dups": cnts.unique_dups,
-    }
+    return {"success": True, "mode": "deduplication"} | exact_cnts.to_dict()
 
 
-def _run_exact_doc_deduplication(config: DedupeConfig):
+def _compute_fuzzy_dedup_stats(shards: list[str], method: str, level: str) -> DupCounters:
+    with log_time(f"Compute fuzzy deduplication stats from {len(shards)} shards"):
+        result: DupCounters = create_backend("threadpool").execute(  # type: ignore[bad-assignment]
+            Dataset.from_list(shards)
+            .flat_map(load_parquet)
+            .group_by(
+                key=lambda r: r["component_id"],
+                reducer=lambda _, items: DupCounters(
+                    method=method,
+                    level=level,
+                    total=(total := sum(1 for _ in items)),
+                    dups=total if total > 1 else 0,
+                    unique=1,
+                    dup_clusters=int(total > 1),
+                ),
+            )
+            .reduce(partial(sum, start=DupCounters(method=method, level=level)))
+        )[0]
+    return result
+
+
+def _load_fuzzy_dupe_map_shard(shards: list[str]) -> dict[str, bool]:
+    if not shards:
+        logger.warning("No fuzzy duplicate documents found.")
+        return {}
+
+    # Map record ID -> is duplicate (bool)
+    shard_dup_map = {}
+
+    def add_to_dup_map(record: dict):
+        shard_dup_map[record["id"]] = record["fuzzy_duplicate"]
+
+    with log_time(f"Load fuzzy duplicate map from {len(shards)} shards"):
+        create_backend("threadpool").execute(Dataset.from_list(shards).flat_map(load_parquet).map(add_to_dup_map))
+
+    return shard_dup_map
+
+
+def _run_doc_deduplication(config: DedupeConfig):
     """
     Exact document deduplication: identify duplicate documents based on full text hash.
     This is a temporary implementation, primarily to compare directly with the Ai2 duplodocus.
@@ -361,22 +421,46 @@ def _run_exact_doc_deduplication(config: DedupeConfig):
         )
     )
 
-    cnts = _compute_dedup_stats(duplicate_key_shards)
-    logger.info(f"Stats: {cnts.total=:,} documents, {cnts.unique=:,} unique, {cnts.unique_dups=:,} dups.")
+    exact_cnts = _compute_dedup_stats(duplicate_key_shards, method="exact", level="document")
+    logger.info(str(exact_cnts))
 
-    if wandb.run:
-        wandb.log(
-            {
-                "dedup/total": cnts.total,
-                "dedup/unique": cnts.unique,
-                "dedup/unique_dups": cnts.unique_dups,
+    doc_minhash_lsh = minhash_lsh(
+        Dataset.from_list(input_files)
+        .flat_map(load_file)
+        .reshard(num_shards=config.processes if len(input_files) < 42 else None)
+    )
+    converged, cc_files = connected_components(
+        doc_minhash_lsh, backend=backend, output_dir=f"{config.output_path}/metadata/cc"
+    )
+    # NOTE: it's probably fine if this doesn't converge in general, but for now we assert
+    assert converged, "Connected components did not converge!"
+    fuzzy_dup_shards = backend.execute(
+        Dataset.from_list(cc_files)
+        .flat_map(load_file)
+        .map(
+            lambda r: {
+                "id": r["node_id"]["record_id"],
+                "fuzzy_duplicate": r["component_id"] != r["node_id"]["record_id_norm"],
             }
         )
+        .reshard(num_shards=42)
+        .write_parquet(f"{config.output_path}/metadata/fuzzy-dup-key-{{shard:05d}}-of-{{total:05d}}.parquet")
+    )
+
+    fuzzy_cnt = _compute_fuzzy_dedup_stats(cc_files, method="fuzzy", level="document")
+    logger.info(str(fuzzy_cnt))
+
+    assert (
+        exact_cnts.total == fuzzy_cnt.total
+    ), f"Exact ({exact_cnts.total}) and fuzzy ({fuzzy_cnt.total}) dedup counts do not match!"
+
+    if wandb.run:
+        wandb.log(exact_cnts.to_dict() | fuzzy_cnt.to_dict())
 
     def mark_exact_dups_documents(batches: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
         """Mark exact duplicate documents using exact hash matching."""
-
         dup_map = _load_dupe_map_shard(duplicate_key_shards)
+        fuzzy_dup_map = _load_fuzzy_dupe_map_shard(fuzzy_dup_shards)
 
         for batch in batches:
             prepared_batch = dupekit.transform(
@@ -388,16 +472,19 @@ def _run_exact_doc_deduplication(config: DedupeConfig):
                     ),
                 ],
             )
-            yield dupekit.mark_document_duplicates(prepared_batch, dup_map, config.attribute_name, hash_col="hash")
+            b = dupekit.mark_document_duplicates(prepared_batch, dup_map, config.attribute_name, hash_col="hash")
+            for r in b.to_pylist():
+                is_fuzzy_dup = fuzzy_dup_map.get(r["id"], False)
+                # TODO: accept fuzzy_duplicate as config option?
+                r["attributes"]["fuzzy_duplicate"] = is_fuzzy_dup
+                yield r
 
     base_path = _find_base_path(config.input_path, input_files)
     backend.execute(
         Dataset.from_list(input_files).flat_map(_load_batches)
         # NOTE/TODO: we can't reshard here to increase parallelism because afaiu we want to match
         # the shards of the input files for rebase_file_path to work correctly.
-        .map_shard(mark_exact_dups_documents)
-        .flat_map(lambda batch: batch.to_pylist())
-        .write_jsonl(
+        .map_shard(mark_exact_dups_documents).write_jsonl(
             output_pattern=lambda shard_idx, total: rebase_file_path(
                 base_path,
                 input_files[shard_idx],
@@ -412,22 +499,15 @@ def _run_exact_doc_deduplication(config: DedupeConfig):
     if wandb.run:
         wandb.finish()
 
-    return {
-        "success": True,
-        "mode": "exact_doc_deduplication",
-        "level": "document",
-        "total": cnts.total,
-        "unique": cnts.unique,
-        "unique_dups": cnts.unique_dups,
-    }
+    return {"success": True, "mode": "exact_doc_deduplication"} | exact_cnts.to_dict() | fuzzy_cnt.to_dict()
 
 
 def deduplicate(config: DedupeConfig):
     """Main entry point for deduplication workflows."""
     if config.mode == DedupMode.DEDUPLICATE:
         return _run_deduplication(config)
-    elif config.mode == DedupMode.EXACT_DOC_DEDUPLICATE:
-        return _run_exact_doc_deduplication(config)
+    elif config.mode == DedupMode.DOC_DEDUPLICATE:
+        return _run_doc_deduplication(config)
     else:
         raise ValueError(f"Unknown mode {config.mode}")
 

--- a/lib/marin/src/marin/processing/classification/deduplication/vendor/__init__.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/vendor/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lib/marin/src/marin/processing/classification/deduplication/vendor/datasketch/README.md
+++ b/lib/marin/src/marin/processing/classification/deduplication/vendor/datasketch/README.md
@@ -1,0 +1,23 @@
+Sourced from https://github.com/ekzhu/datasketch
+
+The MIT License (MIT)
+
+Copyright (c) 2015 ekzhu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/lib/marin/src/marin/processing/classification/deduplication/vendor/datasketch/hashfunc.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/vendor/datasketch/hashfunc.py
@@ -1,0 +1,29 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import struct
+
+
+def sha1_hash32(data):
+    """A 32-bit hash function based on SHA1.
+
+    Args:
+        data (bytes): the data to generate 32-bit integer hash from.
+
+    Returns:
+        int: an integer hash value that can be encoded using 32 bits.
+
+    """
+    return struct.unpack("<I", hashlib.sha1(data).digest()[:4])[0]

--- a/lib/marin/src/marin/processing/classification/deduplication/vendor/datasketch/minhash.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/vendor/datasketch/minhash.py
@@ -1,0 +1,545 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import copy
+import warnings
+from collections.abc import Generator, Iterable
+from collections.abc import Callable
+
+try:
+    from typing import Literal  # py3.8+; if older, you can fallback to typing_extensions
+except Exception:
+    from typing import Literal
+
+import numpy as np
+
+# GPU backend
+try:
+    import cupy as cp
+except ImportError:
+    cp = None
+
+from .hashfunc import sha1_hash32
+
+# The size of a hash value in number of bytes
+hashvalue_byte_size = len(bytes(np.int64(42).data))
+
+# http://en.wikipedia.org/wiki/Mersenne_prime
+_mersenne_prime = np.uint64((1 << 61) - 1)
+_max_hash = np.uint64((1 << 32) - 1)
+_hash_range = 1 << 32
+
+
+_GPU_OK_CACHE: bool | None = None
+
+
+def _gpu_available() -> bool:
+    global _GPU_OK_CACHE
+    if cp is None:
+        return False
+    if _GPU_OK_CACHE is not None:
+        return _GPU_OK_CACHE
+    try:
+        _GPU_OK_CACHE = cp.cuda.runtime.getDeviceCount() > 0
+    except Exception:
+        _GPU_OK_CACHE = False
+    return _GPU_OK_CACHE
+
+
+class MinHash:
+    """MinHash is a probabilistic data structure for computing
+    `Jaccard similarity`_ between sets.
+
+    Args:
+        num_perm (int): Number of random permutation functions.
+            It will be ignored if `hashvalues` is not None.
+        seed (int): The random seed controls the set of random
+            permutation functions generated for this MinHash.
+        gpu_mode : {'disable', 'detect', 'always'}, default 'disable'
+            Controls GPU use in :meth:`update_batch`.
+
+            - ``'disable'`` — always CPU.
+            - ``'detect'`` — use GPU if available, otherwise CPU.
+            - ``'always'`` — require GPU; raise ``RuntimeError`` if CuPy/CUDA
+            is unavailable.
+        hashfunc (Callable): The hash function used by
+            this MinHash.
+            It takes the input passed to the :meth:`update` method and
+            returns an integer that can be encoded with 32 bits.
+            The default hash function is based on SHA1 from hashlib_.
+            Users can use `farmhash` for better performance.
+            See the example in :meth:`update`.
+        hashobj (**deprecated**): This argument is deprecated since version
+            1.4.0. It is a no-op and has been replaced by `hashfunc`.
+        hashvalues (Optional[Iterable]): The hash values is
+            the internal state of the MinHash. It can be specified for faster
+            initialization using the existing :attr:`hashvalues` of another MinHash.
+        permutations (Optional[Tuple[Iterable, Iterable]]): The permutation
+            function parameters as a tuple of two lists. This argument
+            can be specified for faster initialization using the existing
+            :attr:`permutations` from another MinHash.
+
+    Note:
+        Hashing and permutation *generation* always run on CPU to preserve
+        existing semantics; only the permutation application and the
+        columnwise min-reduction inside :meth:`update_batch` may run on GPU.
+
+    Note:
+        To save memory usage, consider using :class:`datasketch.LeanMinHash`.
+
+    Note:
+        Since version 1.1.1, MinHash will only support serialization using
+        pickle_. ``serialize`` and ``deserialize`` methods are removed,
+        and are supported in :class:`datasketch.LeanMinHash` instead.
+        MinHash serialized before version 1.1.1 cannot be deserialized properly
+        in newer versions (`need to migrate? <https://github.com/ekzhu/datasketch/issues/18>`_).
+
+    Note:
+        Since version 1.1.3, MinHash uses Numpy's random number generator
+        instead of Python's built-in random package. This change makes the
+        hash values consistent across different Python versions.
+        The side-effect is that now MinHash created before version 1.1.3 won't
+        work (i.e., :meth:`jaccard`, :meth:`merge` and :meth:`union`)
+        with those created after.
+
+    .. _`Jaccard similarity`: https://en.wikipedia.org/wiki/Jaccard_index
+    .. _hashlib: https://docs.python.org/3.5/library/hashlib.html
+    .. _`pickle`: https://docs.python.org/3/library/pickle.html
+
+    """
+
+    def __init__(
+        self,
+        num_perm: int = 128,
+        seed: int = 1,
+        gpu_mode: Literal["disable", "detect", "always"] = "disable",
+        hashfunc: Callable = sha1_hash32,
+        hashobj: object | None = None,  # Deprecated.
+        hashvalues: Iterable | None = None,
+        permutations: tuple[Iterable, Iterable] | None = None,
+    ) -> None:
+        if hashvalues is not None:
+            num_perm = len(hashvalues)
+        if num_perm > _hash_range:
+            # Because 1) we don't want the size to be too large, and
+            # 2) we are using 4 bytes to store the size value
+            raise ValueError(f"Cannot have more than {_hash_range} number of permutation functions")
+        self.seed = seed
+        self.num_perm = num_perm
+        # Check the hash function.
+        if not callable(hashfunc):
+            raise ValueError("The hashfunc must be a callable.")
+        self.hashfunc = hashfunc
+        # Check for use of hashobj and issue warning.
+        if hashobj is not None:
+            warnings.warn("hashobj is deprecated, use hashfunc instead.", DeprecationWarning, stacklevel=2)
+        # Initialize hash values
+        if hashvalues is not None:
+            self.hashvalues = self._parse_hashvalues(hashvalues)
+        else:
+            self.hashvalues = self._init_hashvalues(num_perm)
+        # Initalize permutation function parameters
+        if permutations is not None:
+            self.permutations = permutations
+        else:
+            self.permutations = self._init_permutations(num_perm)
+        if len(self) != len(self.permutations[0]):
+            raise ValueError("Numbers of hash values and permutations mismatch")
+
+        # GPU state
+        self._gpu_mode: Literal["disable", "detect", "always"] = gpu_mode
+        self._a_gpu = None
+        self._b_gpu = None
+
+    def _ensure_gpu_caches(self) -> None:
+        """Cache permutation arrays on device. Call only when GPU is available."""
+        if self._a_gpu is None or self._b_gpu is None:
+            a, b = self.permutations
+            self._a_gpu = cp.asarray(a, dtype=cp.uint64)
+            self._b_gpu = cp.asarray(b, dtype=cp.uint64)
+
+    def _init_hashvalues(self, num_perm: int) -> np.ndarray:
+        return np.ones(num_perm, dtype=np.uint64) * _max_hash
+
+    def _init_permutations(self, num_perm: int) -> np.ndarray:
+        # Create parameters for a random bijective permutation function
+        # that maps a 32-bit hash value to another 32-bit hash value.
+        # http://en.wikipedia.org/wiki/Universal_hashing
+        gen = np.random.RandomState(self.seed)
+        return np.array(
+            [
+                (
+                    gen.randint(1, _mersenne_prime, dtype=np.uint64),
+                    gen.randint(0, _mersenne_prime, dtype=np.uint64),
+                )
+                for _ in range(num_perm)
+            ],
+            dtype=np.uint64,
+        ).T
+
+    def _parse_hashvalues(self, hashvalues):
+        return np.array(hashvalues, dtype=np.uint64)
+
+    def update(self, b) -> None:
+        """Update this MinHash with a new value.
+        The value will be hashed using the hash function specified by
+        the `hashfunc` argument in the constructor.
+
+        Args:
+            b: The value to be hashed using the hash function specified.
+
+        Example:
+            To update with a new string value (using the default SHA1 hash
+            function, which requires bytes as input):
+
+            .. code-block:: python
+
+                minhash = Minhash()
+                minhash.update("new value".encode("utf-8"))
+
+            We can also use a different hash function, for example, `pyfarmhash`:
+
+            .. code-block:: python
+
+                import farmhash
+
+
+                def _hash_32(b):
+                    return farmhash.hash32(b)
+
+
+                minhash = MinHash(hashfunc=_hash_32)
+                minhash.update("new value")
+
+        """
+        hv = self.hashfunc(b)
+        a, b = self.permutations
+        phv = np.bitwise_and((a * hv + b) % _mersenne_prime, _max_hash)
+        self.hashvalues = np.minimum(phv, self.hashvalues)
+
+    def update_batch(self, b: Iterable) -> None:
+        """Update this MinHash with new values.
+        The values will be hashed using the hash function specified by
+        the `hashfunc` argument in the constructor.
+
+        Notes:
+            - Hashing of input values always runs on CPU.
+            - Permutation application + min-reduction may run on GPU
+            depending on `gpu_mode`:
+                'disable' : CPU
+                'detect'  : GPU if available else CPU
+                'always'  : GPU (error if unavailable)
+
+        Args:
+            b (Iterable): Values to be hashed using the hash function specified.
+
+        Examples:
+            Basic usage with string values (default SHA1 hash, requires bytes):
+
+            .. code-block:: python
+
+                from datasketch import MinHash
+
+                m = MinHash()
+                m.update_batch([s.encode("utf-8") for s in ["token1", "token2"]])
+
+            Using GPU mode if available:
+
+            .. code-block:: python
+
+                from datasketch import MinHash
+
+                m = MinHash(num_perm=256, gpu_mode="detect")
+                m.update_batch([b"token1", b"token2"])
+
+        """
+        # Hash on CPU to preserve hashfunc semantics
+        hv_list = [self.hashfunc(_b) for _b in b]
+        # Optimization: empty batch is a no-op (preserves original behavior)
+        if not hv_list:
+            return
+
+        a, b = self.permutations  # np.ndarray[uint64]
+
+        # Decide backend
+        use_gpu = False
+        if self._gpu_mode == "always":
+            if not _gpu_available():
+                raise RuntimeError("GPU mode 'always' requested but CuPy/CUDA device is unavailable.")
+            use_gpu = True
+        elif self._gpu_mode == "detect":
+            use_gpu = _gpu_available()
+        else:  # 'disable'
+            use_gpu = False
+
+        if use_gpu:
+            # GPU path (keep indentation minimal as requested)
+            self._ensure_gpu_caches()
+            hv_gpu = cp.asarray(hv_list, dtype=cp.uint64).reshape(-1, 1)
+            phv_gpu = (hv_gpu * self._a_gpu + self._b_gpu) % cp.uint64(_mersenne_prime)
+            phv_gpu = cp.bitwise_and(phv_gpu, cp.uint64(_max_hash))
+            base_gpu = cp.asarray(self.hashvalues, dtype=cp.uint64)
+            # column-wise min without extra vstack
+            col_min = cp.minimum(base_gpu, cp.min(phv_gpu, axis=0))
+            self.hashvalues = cp.asnumpy(col_min).astype(np.uint64, copy=False)
+            return
+
+        # CPU path
+        hv = np.array(hv_list, dtype=np.uint64, ndmin=2).T
+        phv = (hv * a + b) % _mersenne_prime
+        phv = np.bitwise_and(phv, _max_hash)
+        self.hashvalues = np.minimum(self.hashvalues, phv.min(axis=0))
+
+    def jaccard(self, other: MinHash) -> float:
+        """Estimate the `Jaccard similarity`_ (resemblance) between the sets
+        represented by this MinHash and the other.
+
+        Args:
+            other (MinHash): The other MinHash.
+
+        Returns:
+            float: The Jaccard similarity, which is between 0.0 and 1.0.
+
+        Raises:
+            ValueError: If the two MinHashes have different numbers of
+                permutation functions or different seeds.
+
+        """
+        if other.seed != self.seed:
+            raise ValueError(
+                "Cannot compute Jaccard given MinHash with\
+                    different seeds"
+            )
+        if len(self) != len(other):
+            raise ValueError(
+                "Cannot compute Jaccard given MinHash with\
+                    different numbers of permutation functions"
+            )
+        return float(np.count_nonzero(self.hashvalues == other.hashvalues)) / float(len(self))
+
+    def count(self) -> float:
+        """Estimate the cardinality count based on the technique described in
+        `this paper <http://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=365694>`_.
+
+        Returns:
+            int: The estimated cardinality of the set represented by this MinHash.
+
+        """
+        k = len(self)
+        return float(k) / np.sum(self.hashvalues / float(_max_hash)) - 1.0
+
+    def merge(self, other: MinHash) -> None:
+        """Merge the other MinHash with this one, making this one the union
+        of both.
+
+        Args:
+            other (MinHash): The other MinHash.
+
+        Raises:
+            ValueError: If the two MinHashes have different numbers of
+                permutation functions or different seeds.
+
+        """
+        if other.seed != self.seed:
+            raise ValueError(
+                "Cannot merge MinHash with\
+                    different seeds"
+            )
+        if len(self) != len(other):
+            raise ValueError(
+                "Cannot merge MinHash with\
+                    different numbers of permutation functions"
+            )
+        self.hashvalues = np.minimum(other.hashvalues, self.hashvalues)
+
+    def digest(self) -> np.ndarray:
+        """Export the hash values, which is the internal state of the
+        MinHash.
+
+        Returns:
+            numpy.ndarray: The hash values which is a Numpy array.
+
+        """
+        return copy.copy(self.hashvalues)
+
+    def is_empty(self) -> bool:
+        """Returns:
+        bool: If the current MinHash is empty - at the state of just
+            initialized.
+
+        """
+        return not np.any(self.hashvalues != _max_hash)
+
+    def clear(self) -> None:
+        """Clear the current state of the MinHash.
+        All hash values are reset.
+        """
+        self.hashvalues = self._init_hashvalues(len(self))
+
+    def copy(self) -> MinHash:
+        """Return a copy; preserves gpu_mode (rehydrates caches lazily)."""
+        return MinHash(
+            seed=self.seed,
+            hashfunc=self.hashfunc,
+            hashvalues=self.digest(),
+            permutations=self.permutations,
+            gpu_mode=self._gpu_mode,
+        )
+
+    def __len__(self) -> int:
+        """Returns:
+        int: The number of hash values.
+
+        """
+        return len(self.hashvalues)
+
+    def __eq__(self, other: MinHash) -> bool:
+        """Returns:
+        bool: If their seeds and hash values are both equal then two are equivalent.
+
+        """
+        return (
+            type(self) is type(other) and self.seed == other.seed and np.array_equal(self.hashvalues, other.hashvalues)
+        )
+
+    @classmethod
+    def union(cls, *mhs: MinHash) -> MinHash:
+        """Create a MinHash which is the union of the MinHash objects passed as arguments.
+
+        Args:
+            *mhs (MinHash): The MinHash objects to be united. The argument list length is variable,
+                but must be at least 2.
+
+        Returns:
+            MinHash: a new union MinHash.
+
+        Raises:
+            ValueError: If the number of MinHash objects passed as arguments is less than 2,
+                or if the MinHash objects passed as arguments have different seeds or
+                different numbers of permutation functions.
+
+        Example:
+
+            .. code-block:: python
+
+                from datasketch import MinHash
+                import numpy as np
+
+                m1 = MinHash(num_perm=128)
+                m1.update_batch(np.random.randint(low=0, high=30, size=10))
+
+                m2 = MinHash(num_perm=128)
+                m2.update_batch(np.random.randint(low=0, high=30, size=10))
+
+                # Union m1 and m2.
+                m = MinHash.union(m1, m2)
+
+        """
+        if len(mhs) < 2:
+            raise ValueError("Cannot union less than 2 MinHash")
+        num_perm = len(mhs[0])
+        seed = mhs[0].seed
+        if any((seed != m.seed or num_perm != len(m)) for m in mhs):
+            raise ValueError(
+                "The unioning MinHash must have the\
+                    same seed and number of permutation functions"
+            )
+        hashvalues = np.minimum.reduce([m.hashvalues for m in mhs])
+        permutations = mhs[0].permutations
+        return cls(
+            num_perm=num_perm,
+            seed=seed,
+            hashvalues=hashvalues,
+            permutations=permutations,
+        )
+
+    @classmethod
+    def bulk(cls, b: Iterable, **minhash_kwargs) -> list[MinHash]:
+        """Compute MinHashes in bulk. This method avoids unnecessary
+        overhead when initializing many minhashes by reusing the initialized
+        state.
+
+        Args:
+            b (Iterable): An Iterable of lists of bytes, each list is
+                hashed in to one MinHash in the output.
+            **minhash_kwargs: Keyword arguments used to initialize MinHash,
+                will be used for all minhashes.
+
+        Returns:
+            list[datasketch.MinHash]: A list of computed MinHashes.
+
+        Example:
+
+            .. code-block:: python
+
+                from datasketch import MinHash
+
+                data = [[b"token1", b"token2", b"token3"], [b"token4", b"token5", b"token6"]]
+                minhashes = MinHash.bulk(data, num_perm=64)
+
+        """
+        return list(cls.generator(b, **minhash_kwargs))
+
+    @classmethod
+    def generator(cls, b: Iterable, **minhash_kwargs) -> Generator[MinHash, None, None]:
+        """Compute MinHashes in a generator. This method avoids unnecessary
+        overhead when initializing many minhashes by reusing the initialized
+        state.
+
+        Args:
+            b (Iterable): An Iterable of lists of bytes, each list is
+                hashed in to one MinHash in the output.
+            minhash_kwargs: Keyword arguments used to initialize MinHash,
+                will be used for all minhashes.
+
+        Returns:
+            Generator[MinHash, None, None]: a generator of computed MinHashes.
+
+        Example:
+
+            .. code-block:: python
+
+                from datasketch import MinHash
+
+                data = [[b"token1", b"token2", b"token3"], [b"token4", b"token5", b"token6"]]
+                for minhash in MinHash.generator(data, num_perm=64):
+                    # do something useful
+                    minhash
+
+        """
+        m = cls(**minhash_kwargs)
+        for _b in b:
+            _m = m.copy()
+            _m.update_batch(_b)
+            yield _m
+
+    # NOTE:
+    # CuPy device arrays (`_a_gpu`, `_b_gpu`) are not reliably picklable across
+    # environments and can inflate pickle size or fail on machines without CUDA.
+    # We therefore drop device state on pickle so round-tripped MinHash objects
+    # remain portable; callers can still use `gpu_mode="detect"` to re-enable GPU.
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # Drop device arrays; keep gpu_mode as-is (portable across envs).
+        state["_a_gpu"] = None
+        state["_b_gpu"] = None
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        # After unpickling we remain on CPU until update_batch decides backend.
+
+    # Caches will be recreated on first GPU use via _ensure_gpu_caches().

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ project-excludes = [
     "examples/**",           # Example code doesn't need strict typing
     "lib/**/crawl/**",       # Crawl scripts have library typing issues with smart_open
     "lib/**/post_training/**",  # No longer used
+    "lib/marin/src/marin/processing/classification/deduplication/vendor", # Exclude vendor stuff in dedupe
 ]
 
 # Disable specific error codes that are primarily noise from missing type stubs

--- a/tests/processing/classification/deduplication/__init__.py
+++ b/tests/processing/classification/deduplication/__init__.py
@@ -11,20 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-import pytest
-import pyarrow as pa
-from typing import Any
-import dupekit
-
-
-@pytest.mark.parametrize("batch_size", [1, 128, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072])
-def test_arrow_batch_sizes(benchmark: Any, in_memory_table: pa.Table, batch_size: int) -> None:
-    """
-    Benchmarks the effect of PyArrow batch size on marshaling throughput.
-    """
-
-    def _pipeline() -> int:
-        return sum(len(dupekit.process_arrow_batch(b)) for b in in_memory_table.to_batches(max_chunksize=batch_size))
-
-    assert benchmark(_pipeline) > 0

--- a/tests/processing/classification/deduplication/conftest.py
+++ b/tests/processing/classification/deduplication/conftest.py
@@ -1,0 +1,31 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+import pytest
+from zephyr.backend_factory import create_backend
+
+
+@pytest.fixture(scope="module")
+def sync_backend():
+    return create_backend("sync")
+
+
+@pytest.fixture(scope="module")
+def docs():
+    test_resources = Path(__file__).parent.joinpath("resources", "docs")
+    docs = {}
+    for doc_file in test_resources.glob("*.txt"):
+        docs[doc_file.stem] = doc_file.read_text()
+    return docs

--- a/tests/processing/classification/deduplication/resources/docs/doc_1.txt
+++ b/tests/processing/classification/deduplication/resources/docs/doc_1.txt
@@ -1,0 +1,58 @@
+On the resemblance and containment of documents
+Andrei Z. Broder
+digital Systems Research Center
+130 Lytton Avenue, Palo Alto, CA 94301, USA
+broder@pa.dec.com
+Abstract
+Given two documents A and B we define two mathematical notions: their
+resemblance r(A, B) and their containment c(A, B) that seem to capture well
+the informal notions of “roughly the same” and “roughly contained.”
+The basic idea is to reduce these issues to set intersection problems that can
+be easily evaluated by a process of random sampling that can be done independently for each document. Furthermore, the resemblance can be evaluated
+using a fixed size sample for each document.
+This paper discusses the mathematical properties of these measures and the
+efficient implementation of the sampling process using Rabin fingerprints.
+1 Introduction
+The on-line information explosion, and in particular the World Wide Web, has led a
+proliferation of documents that are identical or almost identical. In many situations it
+is necessary to determine whether two documents are “roughly the same” or “roughly
+contained” in each other.
+These informal concepts do not seem to be well captured by any of the standard
+distances defined on strings (Hamming, Levenshtein, etc.). Furthermore the computation of these distances usually requires the pairwise comparison of entire documents.
+For a very large collection of documents this is not feasible, and a sampling mechanism
+per document is necessary.
+To attack this problem we use two mathematical concepts resemblance and containment defined precisely below.
+The resemblance r(A, B) of two documents, A and B, is a number between 0 and
+1, such that when the resemblance is close to 1 it is likely that the documents are
+roughly the same. Similarly, the containment c(A, B) of A in B is a number between
+0 and 1 that, when close to 1, indicates that A is roughly contained within B. The
+resemblance has the additional property that d(A, B)=1 − r(A, B), is a metric
+(obeys the triangle inequality), which is useful for the design of algorithms intended
+to cluster a collection of documents into sets of closely resembling documents.
+1
+To compute the resemblance and/or the containment of two documents it suffices
+to keep for each document a relatively small sketch. The sketches can be computed
+fairly fast (linear in the size of the documents) and given two sketches the resemblance
+or the containment of the corresponding documents can be computed in linear time
+in the size of the sketches. For computing resemblance, it suffices to keep a fixed size
+sketch. For computing containment, we need a sketch proportional to the size of the
+underlying document; however as it will be explained this problem can be finessed at
+the cost of a loss of precision.
+Our approach to determining syntactic similarity is related to the sampling approach developed independently by Heintze [6], though there are differences in detail
+and in the precise definition of the measures used. Related sampling mechanisms for
+determining similarity were also developed by Manber [7] and within the Stanford
+SCAM project [2, 8, 9].
+We tested the ideas discussed above by building a clustering of a collection of over
+30,000,000 documents into sets of closely resembling document. The documents were
+retrieved from a walk of the World Wide Web performed by the Alta Vista search
+engine. The total input data was over 150 Gbytes. We calculated our clusters based on
+a 50% resemblance. We found 3.6 million clusters containing a total of 12.3 million
+documents. Of these, 2.1 million clusters contained only identical documents (5.3
+million documents). The remaining 1.5 million clusters contained 7 million documents
+(a mixture of exact duplicates and similar). For further details see [5].
+The basic approach has two aspects: First, resemblance and containment are
+expressed as set intersection problems (this is explained in Section 2) and second,
+the relative size of these intersections is evaluated by a process of random sampling
+that can be done independently for each document (this is explained in Section 3).
+This process of estimating the relative size of intersection of sets can be applied to
+arbitrary sets, and thus might be of independent interest.

--- a/tests/processing/classification/deduplication/resources/docs/doc_1_diff_header.txt
+++ b/tests/processing/classification/deduplication/resources/docs/doc_1_diff_header.txt
@@ -1,0 +1,72 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+On the resemblance and containment of documents
+Andrei Z. Broder
+digital Systems Research Center
+130 Lytton Avenue, Palo Alto, CA 94301, USA
+broder@pa.dec.com
+Abstract
+Given two documents A and B we define two mathematical notions: their
+resemblance r(A, B) and their containment c(A, B) that seem to capture well
+the informal notions of “roughly the same” and “roughly contained.”
+The basic idea is to reduce these issues to set intersection problems that can
+be easily evaluated by a process of random sampling that can be done independently for each document. Furthermore, the resemblance can be evaluated
+using a fixed size sample for each document.
+This paper discusses the mathematical properties of these measures and the
+efficient implementation of the sampling process using Rabin fingerprints.
+1 Introduction
+The on-line information explosion, and in particular the World Wide Web, has led a
+proliferation of documents that are identical or almost identical. In many situations it
+is necessary to determine whether two documents are “roughly the same” or “roughly
+contained” in each other.
+These informal concepts do not seem to be well captured by any of the standard
+distances defined on strings (Hamming, Levenshtein, etc.). Furthermore the computation of these distances usually requires the pairwise comparison of entire documents.
+For a very large collection of documents this is not feasible, and a sampling mechanism
+per document is necessary.
+To attack this problem we use two mathematical concepts resemblance and containment defined precisely below.
+The resemblance r(A, B) of two documents, A and B, is a number between 0 and
+1, such that when the resemblance is close to 1 it is likely that the documents are
+roughly the same. Similarly, the containment c(A, B) of A in B is a number between
+0 and 1 that, when close to 1, indicates that A is roughly contained within B. The
+resemblance has the additional property that d(A, B)=1 − r(A, B), is a metric
+(obeys the triangle inequality), which is useful for the design of algorithms intended
+to cluster a collection of documents into sets of closely resembling documents.
+1
+To compute the resemblance and/or the containment of two documents it suffices
+to keep for each document a relatively small sketch. The sketches can be computed
+fairly fast (linear in the size of the documents) and given two sketches the resemblance
+or the containment of the corresponding documents can be computed in linear time
+in the size of the sketches. For computing resemblance, it suffices to keep a fixed size
+sketch. For computing containment, we need a sketch proportional to the size of the
+underlying document; however as it will be explained this problem can be finessed at
+the cost of a loss of precision.
+Our approach to determining syntactic similarity is related to the sampling approach developed independently by Heintze [6], though there are differences in detail
+and in the precise definition of the measures used. Related sampling mechanisms for
+determining similarity were also developed by Manber [7] and within the Stanford
+SCAM project [2, 8, 9].
+We tested the ideas discussed above by building a clustering of a collection of over
+30,000,000 documents into sets of closely resembling document. The documents were
+retrieved from a walk of the World Wide Web performed by the Alta Vista search
+engine. The total input data was over 150 Gbytes. We calculated our clusters based on
+a 50% resemblance. We found 3.6 million clusters containing a total of 12.3 million
+documents. Of these, 2.1 million clusters contained only identical documents (5.3
+million documents). The remaining 1.5 million clusters contained 7 million documents
+(a mixture of exact duplicates and similar). For further details see [5].
+The basic approach has two aspects: First, resemblance and containment are
+expressed as set intersection problems (this is explained in Section 2) and second,
+the relative size of these intersections is evaluated by a process of random sampling
+that can be done independently for each document (this is explained in Section 3).
+This process of estimating the relative size of intersection of sets can be applied to
+arbitrary sets, and thus might be of independent interest.

--- a/tests/processing/classification/deduplication/resources/docs/doc_2.txt
+++ b/tests/processing/classification/deduplication/resources/docs/doc_2.txt
@@ -1,0 +1,72 @@
+Finding Near-Duplicate Web Pages: A Large-Scale
+Evaluation of Algorithms
+Monika Henzinger
+Google Inc. & Ecole Fed´ er´ ale de Lausanne (EPFL)
+monika@google.com
+
+ABSTRACT
+Broder et al.’s [3] shingling algorithm and Charikar’s [4] random projection based approach are considered “state-of-theart” algorithms for finding near-duplicate web pages. Both
+algorithms were either developed at or used by popular web
+search engines. We compare the two algorithms on a very
+large scale, namely on a set of 1.6B distinct web pages. The
+results show that neither of the algorithms works well for
+finding near-duplicate pairs on the same site, while both
+achieve high precision for near-duplicate pairs on different
+sites. Since Charikar’s algorithm finds more near-duplicate
+pairs on different sites, it achieves a better precision overall,
+namely 0.50 versus 0.38 for Broder et al. ’s algorithm. We
+present a combined algorithm which achieves precision 0.79
+with 79% of the recall of the other algorithms.
+
+1. INTRODUCTION
+Duplicate and near-duplicate web pages are creating large
+problems for web search engines: They increase the space
+needed to store the index, either slow down or increase the
+cost of serving results, and annoy the users. Thus, algorithms for detecting these pages are needed.
+A naive solution is to compare all pairs to documents.
+Since this is prohibitively expensive on large datasets, Manber [11] and Heintze [9] proposed first algorithms for detecting near-duplicate documents with a reduced number
+of comparisons. Both algorithms work on sequences of adjacent characters. Brin et al. [1] started to use word sequences to detect copyright violations. Shivakumar and
+Garcia-Molina [13, 14] continued this research and focused
+on scaling it up to multi-gigabyte databases [15]. Broder
+et al. [3] also used word sequences to efficiently find nearduplicate web pages. Later, Charikar [4] developed an approach based on random projections of the words in a document. Recently Hoad and Zobel [10] developed and compared methods for identifying versioned and plagiarised documents.
+Both Broder et al. ’s and Charikar’s algorithm have elegant theoretical justifications, but neither has been experimentally evaluated and it is not known which algorithm
+performs better in practice. In this paper we evaluate both
+algorithms on a very large real-world data set, namely on
+1.6B distinct web pages. We chose these two algorithms as
+both were developed at or used by successful web search engines and are considered “state-of-the-art” in finding nearduplicate web pages. We call them Algorithm B and C.
+We set all parameters in Alg. B as suggested in the literature. Then we chose the parameters in Alg. C so that it
+uses the same amount of space per document and returns
+about the same number of correct near-duplicate pairs, i.e.,
+has about the same recall. We compared the algorithms according to three criteria: (1) precision on a random subset,
+(2) the distribution of the number of term differences per
+near-duplicate pair, and (3) the distribution of the number
+of near-duplicates per page The results are: (1) Alg. C has precision 0.50 and Alg. B
+0.38. Both algorithms perform about the same for pairs
+on the same site (low precision) and for pairs on different
+sites (high precision.) However, 92% of the near-duplicate
+pairs found by Alg. B belong to the same site, but only 74%
+of Alg. C. Thus, Alg. C finds more of the pairs for which
+precision is high and hence has an overall higher precision.
+(2) The number of term differences per near-duplicate pair
+are very similar for the two algorithms, but Alg. B returns
+fewer pairs with extremely large term differences. (3) The
+distribution of the number of near-duplicates per page follows a power-law for both algorithms. However, Alg. B has
+a higher “spread” around the power-law curve. A possible
+reason for that “noise” is that the bit string representing
+a page in Alg. B is based on a randomly selected subset
+of terms in the page. Thus, there might be “lucky” and
+“unlucky” choices, leading to pages with an artificially high
+or low number of near-duplicates. Alg. C does not select a
+subset of terms but is based on all terms in the page.
+Finally, we present a combined algorithm that allows for
+different precision-recall tradeoffs. The precision of one tradeoff is 0.79 with 79% of the recall of Alg. B.
+It is notoriously hard to determine which pages belong
+to the same site. Thus we use the following simplified approach. The site of a page is (1) the domain name of the
+page if the domain name has at most one dot, i.e., at most
+two levels; and (2) it is the domain name minus the string
+before the first dot, if the domain name has two or more
+dots, i.e., three or more levels. For example, the site of
+www.cs.berkeley.edu/index.html is cs.berkeley.edu.
+The paper is organized as follows: Section 2 describes the
+algorithms in detail. Section 3 presents the experiments and
+the evaluation results. We conclude in Section 4.

--- a/tests/processing/classification/deduplication/test_connected_components.py
+++ b/tests/processing/classification/deduplication/test_connected_components.py
@@ -1,0 +1,40 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from marin.processing.classification.deduplication.connected_components import connected_components
+from marin.processing.classification.deduplication.minhash_lsh import minhash_lsh
+from zephyr.backends import defaultdict
+from zephyr.dataset import Dataset
+from zephyr.readers import load_file
+
+
+def test_connected_components_happy_path(sync_backend, docs, tmp_path):
+    input_data = [{"text": text, "id": doc_id} for doc_id, text in docs.items()]
+
+    ds = Dataset.from_list(input_data)
+
+    lsh_result = minhash_lsh(ds)
+
+    converged, output_path = connected_components(
+        lsh_result, backend=sync_backend, output_dir=tmp_path.as_posix(), max_iterations=5
+    )
+    assert converged
+    results = sync_backend.execute(Dataset.from_list(output_path).flat_map(load_file))
+    assert len(results) == len(docs)
+
+    components = defaultdict(list)
+    for r in results:
+        components[r["component_id"]].append(r["node_id"]["record_id"])
+
+    assert sorted(components.values()) == [["doc_1_diff_header", "doc_1"], ["doc_2"]]

--- a/tests/processing/classification/deduplication/test_minhash.py
+++ b/tests/processing/classification/deduplication/test_minhash.py
@@ -1,0 +1,51 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from marin.processing.classification.deduplication.minhash import minhash
+import pytest
+
+
+def test_minhash_exact_equal():
+    assert minhash({"foo"}) == minhash({"foo"})
+
+
+def test_minhash_different():
+    assert minhash({"foo"}) != minhash({"bar"})
+
+
+def test_minhash_empty():
+    assert minhash(set()) == [float("inf")] * 128
+
+
+def test_minhash_similar():
+    set1 = {"the", "quick", "brown", "fox"}
+    set2 = {"the", "quick", "brown", "fox", "jumps"}
+    hash1, hash2 = minhash(set1), minhash(set2)
+    assert hash1 != hash2
+    # Since the sets are similar, their minhashes should also be similar
+    similarity = sum(1 for a, b in zip(hash1, hash2, strict=True) if a == b) / len(hash1)
+    assert similarity > 0.7
+
+
+def test_jaccard_similarity():
+    set1 = {"apple", "banana", "cherry"}
+    set2 = {"banana", "cherry", "date"}
+    intersection = len(set1.intersection(set2))
+    union = len(set1.union(set2))
+    jaccard_sim = intersection / union
+    assert jaccard_sim == 0.5
+    hash1, hash2 = minhash(set1), minhash(set2)
+    estimated_similarity = sum(1 for a, b in zip(hash1, hash2, strict=True) if a == b) / len(hash1)
+    # The estimated similarity should be close to the actual Jaccard similarity
+    assert pytest.approx(estimated_similarity, rel=0.3) == jaccard_sim

--- a/tests/processing/classification/deduplication/test_minhash_lsh.py
+++ b/tests/processing/classification/deduplication/test_minhash_lsh.py
@@ -1,0 +1,77 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Iterator
+from marin.processing.classification.deduplication.minhash_lsh import minhash_lsh
+from zephyr.dataset import Dataset
+
+
+def _get_ids_per_bucket(_: str, records: Iterator[dict]) -> set:
+    return {record["id"] for record in records}
+
+
+def test_minhash_lsh_happy_path(sync_backend):
+    input_data = [
+        {"text": "the quick brown fox", "id": 1},
+        {"text": "the quick brown fox jumps", "id": 2},
+        {"text": "lorem ipsum dolor sit amet", "id": 3},
+        {"text": "the quick brown fox", "id": 4},
+    ]
+
+    ds = Dataset.from_list(input_data)
+
+    num_bands = 32
+    lsh_result = minhash_lsh(ds, vector_length=128, num_bands=num_bands)
+
+    output = sync_backend.execute(lsh_result)
+    assert len(output) == len(input_data) * num_bands
+
+    bucketized = sync_backend.execute(lsh_result.group_by(lambda x: x["bucket"], _get_ids_per_bucket))
+
+    connected_1_and_4 = 0
+    connected_1_2 = 0
+    connected_1_3 = 0
+
+    for b in bucketized:
+        if {1, 4}.issubset(b):
+            connected_1_and_4 += 1
+        if {1, 2}.issubset(b):
+            connected_1_2 += 1
+        if {1, 3}.issubset(b):
+            connected_1_3 += 1
+
+    assert connected_1_and_4 == num_bands  # docs 1 and 4 are identical, should hash to same bucket in all bands
+    assert connected_1_2 > 0  # docs 1 and 2 should hash to the same bucket in some bands
+    assert connected_1_3 == 0  # docs 1 and 3 should not collide
+
+
+def test_minhash_docs(sync_backend, docs):
+    input_data = [{"text": text, "id": doc_id} for doc_id, text in docs.items()]
+
+    ds = Dataset.from_list(input_data)
+
+    lsh_result = minhash_lsh(ds, vector_length=128, num_bands=32).group_by(lambda x: x["bucket"], _get_ids_per_bucket)
+
+    output = sync_backend.execute(lsh_result)
+
+    similar_doc_collisions = 0
+    different_doc_collisions = 0
+    for b in output:
+        if {"doc_1", "doc_1_diff_header"} == b:
+            similar_doc_collisions += 1
+        if {"doc_2"}.issubset(b) and b.intersection({"doc_1", "doc_1_diff_header"}):
+            different_doc_collisions += 1
+
+    assert similar_doc_collisions > 0  # doc_1 and doc_1_diff_header should collide in some buckets
+    assert different_doc_collisions == 0  # doc_2 should not collide with doc_1 or doc_1_diff_header

--- a/tests/processing/classification/deduplication/test_pipeline.py
+++ b/tests/processing/classification/deduplication/test_pipeline.py
@@ -83,7 +83,7 @@ def test_exact_deduplication_document(fox_corpus):
         input_path=fox_corpus["test_dir"],
         output_path=fox_corpus["output_dir"],
         attribute_name="is_duplicate",
-        mode=DedupMode.EXACT_DOC_DEDUPLICATE,
+        mode=DedupMode.DOC_DEDUPLICATE,
         processes=1,
     )
 


### PR DESCRIPTION
## Description

Add MinHashLSH code to dupekit (Mirror the duplodocus fuzzy matching approach, excluding the file I/O and the tiktokenization).  In isolation, Rust appears to be ~5x faster than the datasketch (i.e. non-naive) python implementation. 

Rebased on: https://github.com/marin-community/marin/pull/2190
Ref: https://github.com/marin-community/marin/issues/2147

____

Benchmark Rust vs. Python (datasketch implementation)
```
-------------------------------------------------------------------------------------------- benchmark: 2 tests -------------------------------------------------------------------------------------------
Name (time in ms)                    Min                   Max                  Mean              StdDev                Median                IQR            Outliers     OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_bench_rust_minhash         842.3364 (1.0)      1,082.2033 (1.0)        891.6355 (1.0)      106.5386 (2.10)       845.2306 (1.0)      61.6109 (1.0)           1;1  1.1215 (1.0)           5           1
test_bench_python_minhash     4,626.4153 (5.49)     4,751.8897 (4.39)     4,674.4283 (5.24)      50.8137 (1.0)      4,649.2194 (5.50)     70.7439 (1.15)          1;0  0.2139 (0.19)          5           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```


