### PR TITLE
Fix device flop calculation.

### DIFF
--- a/lib/fray/src/fray/cluster/base.py
+++ b/lib/fray/src/fray/cluster/base.py
@@ -272,7 +272,10 @@ class GpuConfig:
         """Peak FLOP/s for a single GPU."""
         from fray.cluster.device_flops import device_flops
 
-        return device_flops(self.type, dtype)
+        flops = device_flops(self.type, dtype)
+        if flops is None:
+            raise ValueError(f"Unknown device/dtype: {self.type}/{dtype}")
+        return flops
 
     def total_flops(self, dtype: str = "bf16") -> float:
         """Total peak FLOP/s across all GPUs."""
@@ -303,7 +306,10 @@ class TpuConfig:
         """Peak FLOP/s for a single TPU chip."""
         from fray.cluster.device_flops import device_flops
 
-        return device_flops(self.type, dtype)
+        flops = device_flops(self.type, dtype)
+        if flops is None:
+            raise ValueError(f"Unknown device/dtype: {self.type}/{dtype}")
+        return flops
 
     def total_flops(self, dtype: str = "bf16") -> float:
         """Total peak FLOP/s across all TPU chips."""

--- a/lib/fray/src/fray/cluster/device_flops.py
+++ b/lib/fray/src/fray/cluster/device_flops.py
@@ -17,8 +17,10 @@
 Data originally from Mosaic SPDX-License-Identifier: Apache-2.0
 https://github.com/mosaicml/composer/blob/56ccc2ebc59a8c68a6d075c4b61735ebf089b5a2/composer/callbacks/speed_monitor.py#L23
 """
-
+import logging
 from typing import Literal
+
+logger = logging.getLogger(__name__)
 
 FlopDtype = Literal["bf16", "fp16", "fp32", "fp64", "tf32", "int8", "int4", "fp8"]
 
@@ -164,6 +166,9 @@ DEVICE_FLOPS: dict[str, dict[str, float]] = {
         "int8": 393e12,
     },
     # Source: https://cloud.google.com/tpu/docs/v5p
+    "v5": {
+        "bf16": 459e12,
+    },
     "v5p": {
         "bf16": 459e12,
     },
@@ -225,12 +230,15 @@ def jax_device_kind_to_fray_device_type(kind: str) -> str:
     if kind.startswith("tpu "):
         tpu_gen = kind[4:].strip()
         # "v5 lite" -> "v5litepod"
-        if "5" in tpu_gen and "lite" in tpu_gen:
-            return "v5litepod"
+        if "5" in tpu_gen:
+            if "lite" in tpu_gen:
+                return "v5litepod"
+            else:
+                return "v5p"
         # "v6 lite" -> "v6e"
         if "6" in tpu_gen and "lite" in tpu_gen:
             return "v6e"
-        # "v4" -> "v4", "v5p" -> "v5p"
+        # "v4" -> "v4"
         return tpu_gen.replace(" ", "")
 
     # NVIDIA GPUs - check more specific patterns first
@@ -279,27 +287,38 @@ def normalize_dtype(dtype: str) -> str:
     return dtype
 
 
-def device_flops(device_type: str, dtype: str = "bf16") -> float:
+def device_flops(device_type: str, dtype: str = "bf16") -> float | None:
     """Get peak FLOP/s for a device.
 
     Args:
-        device_type: Device type (e.g., "h100", "v4-128", "tpu v4")
+        device_type: Fray device type (e.g., "v4", "h100", "a100")
         dtype: Data type (e.g., "bf16", "fp16", "int8")
 
     Returns:
-        Peak FLOP/s for a single device/chip
-
-    Raises:
-        ValueError: If device type or dtype is unknown
+        Peak FLOP/s for a single device/chip, or None if unknown
     """
     normalized = normalize_device_type(device_type)
     flops_dict = DEVICE_FLOPS.get(normalized)
     if flops_dict is None:
-        raise ValueError(f"Unknown device type: {device_type} (normalized: {normalized})")
+        logger.warning(f"Unknown device type: {device_type} - {normalized}")
+        return None
 
     normalized_dtype = normalize_dtype(dtype)
-    flops = flops_dict.get(normalized_dtype)
-    if flops is None:
-        raise ValueError(f"No FLOPS data for {normalized} with dtype {dtype}")
+    if normalized_dtype not in flops_dict:
+        logger.warning(f"Unknown dtype: {dtype} - {normalized_dtype} for device {device_type}")
+        return None
+    return flops_dict.get(normalized_dtype)
 
-    return flops
+
+def device_flops_for_jax_device(jax_device_kind: str, dtype: str = "bf16") -> float | None:
+    """Get peak FLOP/s given a JAX device kind string.
+
+    Args:
+        jax_device_kind: JAX device kind string (e.g., "TPU v4", "NVIDIA H100 80GB HBM3")
+        dtype: Data type (e.g., "bf16", "fp16")
+
+    Returns:
+        Peak FLOP/s, or None if device/dtype unknown
+    """
+    fray_device_type = jax_device_kind_to_fray_device_type(jax_device_kind)
+    return device_flops(fray_device_type, dtype)

--- a/lib/levanter/src/levanter/callbacks/_metrics.py
+++ b/lib/levanter/src/levanter/callbacks/_metrics.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 from typing import Optional
 
 import jax
+from fray.cluster.device_flops import device_flops_for_jax_device
 from tqdm_loggable.auto import tqdm
 from tqdm_loggable.tqdm_logging import tqdm_logging
 
@@ -16,7 +17,6 @@ from levanter.callbacks import StepInfo
 from levanter.data import AsyncDataset
 from levanter.schedule import BatchSchedule
 from levanter.tracker import log_optimizer_hyperparams
-from levanter.utils import flop_utils
 from levanter.utils.jax_utils import jnp_to_python
 
 logger = pylogging.getLogger(__name__)
@@ -96,7 +96,7 @@ def log_performance_stats(
     device_count = jax.device_count()
     device = jax.devices()[0]
 
-    flops_per_device = flop_utils.device_hardware_flops(device)
+    flops_per_device = device_flops_for_jax_device(device.device_kind)
     levanter.tracker.log_summary(
         {
             wrap_key("device_kind"): device.device_kind,

--- a/lib/levanter/src/levanter/utils/flop_utils.py
+++ b/lib/levanter/src/levanter/utils/flop_utils.py
@@ -1,9 +1,6 @@
 # Copyright 2025 The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import jax
-from jax import numpy as jnp
-
 
 def lm_flops_per_token(
     hidden_dim: int,
@@ -34,54 +31,3 @@ def lm_flops_per_token(
     attn = seq_flops / seq_len
     lm_head = 2 * hidden_dim * vocab_size
     return num_layers * (mlp + qkv_proj + dense_proj + attn) + lm_head
-
-
-def _canonical_dtype(dtype: jnp.dtype) -> str:
-    """Convert JAX dtype to string for FLOPS lookup."""
-    if dtype == jnp.float64:
-        return "fp64"
-    if dtype == jnp.float32:
-        return "fp32"
-    if dtype == jnp.float16:
-        return "fp16"
-    if dtype == jnp.bfloat16:
-        return "bf16"
-    if dtype == jnp.int8:
-        return "int8"
-    if dtype == jnp.int4:
-        return "int4"
-    if dtype in [
-        jnp.float8_e4m3b11fnuz,
-        jnp.float8_e5m2,
-        jnp.float8_e4m3fn,
-        jnp.float8_e4m3fn,
-        jnp.float8_e4m3fnuz,
-        jnp.float8_e5m2fnuz,
-    ]:
-        return "fp8"
-
-    raise ValueError(f"Unsupported dtype: {dtype}")
-
-
-def device_hardware_flops(device: jax.Device, dtype: jnp.dtype = jnp.bfloat16) -> float | None:
-    """Returns the hardware flops of a device.
-
-    Args:
-        device: JAX device
-        dtype: Data type for FLOPS lookup
-
-    Returns:
-        Peak FLOP/s for the device, or None if device is not recognized
-    """
-    from fray.cluster.device_flops import DEVICE_FLOPS, jax_device_kind_to_fray_device_type, normalize_dtype
-
-    kind = jax_device_kind_to_fray_device_type(device.device_kind)
-    dtype_str = _canonical_dtype(dtype)
-
-    flop_dict = DEVICE_FLOPS.get(kind)
-
-    if flop_dict is None:
-        return None
-
-    normalized_dtype = normalize_dtype(dtype_str)
-    return flop_dict.get(normalized_dtype)


### PR DESCRIPTION
This also consolidates the various flop calculation bits in Fray.

There was a bug in handling v5p clusters, JAX references them as "v5", whereas externally they are "v5p" (vs "v5 lite" -> "v5litepod").