### PR TITLE
Fix _mk_shard_name_mapping to compute common_prefix after expand_glob

### DIFF
--- a/lib/levanter/src/levanter/data/sharded_datasource.py
+++ b/lib/levanter/src/levanter/data/sharded_datasource.py
@@ -512,13 +512,6 @@ class ParquetDataSource(UrlBackedShardedDataSource[dict]):
 
 
 def _mk_shard_name_mapping(urls):
-    _shard_name_to_url_mapping = {}
-    # remove common prefix
-    if len(urls) == 1:
-        common_prefix = os.path.dirname(urls[0])
-    else:
-        common_prefix = os.path.commonprefix(urls)
-
     missing_urls: List[str] = []
 
     old_urls = urls
@@ -526,6 +519,14 @@ def _mk_shard_name_mapping(urls):
 
     if old_urls and not urls:
         raise ValueError(f"Could not expand any of the urls: {old_urls}")
+
+    _shard_name_to_url_mapping = {}
+
+    # remove common prefix, computed on expanded urls
+    if len(urls) == 1:
+        common_prefix = os.path.dirname(urls[0])
+    else:
+        common_prefix = os.path.commonprefix(urls)
 
     for url in urls:
         if not fsspec_utils.exists(url):


### PR DESCRIPTION
## Description

Fixes #2214 -- an issue with shard name mapping when using a brace expansion pattern. 

As one of my datasets uses a brace expansion pattern, with the brace expansion if we compute common_prefix at the beginning of the function, common_prefix can be longer than the actual URL leading to an empty shard name.

It gave me an error on the Yodas data as described in the issue. A simple fix is to compute common_prefix after expanding globs