### PR TITLE
update docs on rust version for dedupe

### DIFF
--- a/docs/explanations/executor.md
+++ b/docs/explanations/executor.md
@@ -4,6 +4,8 @@ Marin's executor framework manages the execution of experiments.
 This document is more about the mechanics, read [this](../explanations/experiments.md) to
 learn more about the conventions.
 
+## Steps
+
 An **experiment** is a sequence (really, a DAG) of steps, where each **step** is
 specified by the following:
 - **name**: an identifier describing the function (and its version)

--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -9,7 +9,7 @@ Before you begin, ensure you have the following installed:
 - Python 3.11 or higher
 - uv (Python package manager)
 - Git
-- Rust toolchain via [rustup](https://rustup.rs) (needed for `lib/dupekit`, which is built with Maturin; see [`lib/dupekit/README.md`](../../lib/dupekit/README.md) for background)
+- Rust toolchain via [rustup](https://rustup.rs) (needed for `lib/dupekit`, which is built with Maturin; see [`lib/dupekit/README.md`](https://github.com/marin-community/marin/blob/main/lib/dupekit/README.md) for background)
     - Recommended: `rustup toolchain install 1.91.0 && rustup default 1.91.0` (matches the Docker pin)
     - If you hit an `edition2024` error from Cargo (e.g., when building Arrow), use nightly: `rustup default nightly`
 - On macOS, install additional build tools for SentencePiece:


### PR DESCRIPTION
## Description

Quick PR pointing out the correct version of RUST to use with new dedupe library. Without this on mac-os using `uv run` commands throw the following error


```bash
ahmed@Ahmeds-MacBook-Pro-3 marin % uv run scripts/ray/cluster.py dashboard
        Built marin-root @ file:///Users/ahmed/code/marin
        Built levanter @ file:///Users/ahmed/code/marin/lib/levanter
        Built fray @ file:///Users/ahmed/code/marin/lib/fray
        Built marin @ file:///Users/ahmed/code/marin/lib/marin
        Built zephyr @ file:///Users/ahmed/code/marin/lib/zephyr
  × Failed to build `dupekit @ file:///Users/ahmed/code/marin/lib/dupekit`
    ├─▶ The build backend returned an error
    ╰─▶ Call to `maturin.build_editable` failed (exit status: 1)

        [stdout]
        Running `maturin pep517 build-wheel -i /Users/ahmed/Library/Caches/uv/builds-
  v0/.tmp0kvfDt/bin/python --compatibility off --editable`

        [stderr]
          Downloaded csv-core v0.1.13
          Downloaded arrow-csv v57.1.0
        error: failed to parse manifest at `/Users/ahmed/.cargo/registry/src/index.crates.io-
  6f17d22bba15001f/arrow-csv-57.1.0/Cargo.toml`

        Caused by:
          feature `edition2024` is required

          The package requires the Cargo feature called `edition2024`, but that feature is not
  stabilized in this version of Cargo (1.80.1 (376290515 2024-07-16)).
          Consider trying a newer version of Cargo (this may require the nightly release).
          See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for
  more information about the status of this feature.
        💥 maturin failed
          Caused by: Cargo metadata failed. Does your crate compile with `cargo build`?
          Caused by: `cargo metadata` exited with an error:
        Error: command ['maturin', 'pep517', 'build-wheel', '-i', '/Users/ahmed/Library/Caches/
  uv/builds-v0/.tmp0kvfDt/bin/python', '--compatibility', 'off', '--editable'] returned non-
  zero exit status 1

        hint: This usually indicates a problem with the package or the build environment.
    help: `dupekit` was included because `marin-root` (v0.1.0) depends on `dupekit`
    ```

## Checklist

- [x] You ran `uv run python infra/pre-commit.py --all-files` to lint/format your code
- [x] You ran 'pytest' to test your code
