### PR TITLE
fix author info of all parallel llama runs

### DIFF
--- a/experiments/speedrun/parallel_llama/130m/speedrun_results.json
+++ b/experiments/speedrun/parallel_llama/130m/speedrun_results.json
@@ -3,9 +3,9 @@
     {
       "run_info": {
         "author": {
-          "affiliation": "Stanford University",
-          "name": "Calvin Xu",
-          "url": "https://pinlinxu.com"
+          "affiliation": "Independent",
+          "name": "Harry Shin",
+          "url": "https://www.linkedin.com/in/harry-shin-34743216a/"
         },
         "description": "Hackable Transformer (130m); Attention with parallel MLP (Muon)",
         "device_flops": 459000000000000.0,

--- a/experiments/speedrun/parallel_llama/1_2b/speedrun_results.json
+++ b/experiments/speedrun/parallel_llama/1_2b/speedrun_results.json
@@ -3,9 +3,9 @@
     {
       "run_info": {
         "author": {
-          "affiliation": "Stanford University",
-          "name": "Calvin Xu",
-          "url": "https://pinlinxu.com"
+          "affiliation": "Independent",
+          "name": "Harry Shin",
+          "url": "https://www.linkedin.com/in/harry-shin-34743216a/"
         },
         "description": "Hackable Transformer (1_2b); Attention with parallel MLP (Muon)",
         "device_flops": 459000000000000.0,

--- a/experiments/speedrun/parallel_llama/300m/speedrun_results.json
+++ b/experiments/speedrun/parallel_llama/300m/speedrun_results.json
@@ -3,9 +3,9 @@
     {
       "run_info": {
         "author": {
-          "affiliation": "Stanford University",
-          "name": "Calvin Xu",
-          "url": "https://pinlinxu.com"
+          "affiliation": "Independent",
+          "name": "Harry Shin",
+          "url": "https://www.linkedin.com/in/harry-shin-34743216a/"
         },
         "description": "Hackable Transformer (300m); Attention with parallel MLP (Muon)",
         "device_flops": 459000000000000.0,

--- a/experiments/speedrun/parallel_llama/520m/speedrun_results.json
+++ b/experiments/speedrun/parallel_llama/520m/speedrun_results.json
@@ -3,9 +3,9 @@
     {
       "run_info": {
         "author": {
-          "affiliation": "Stanford University",
-          "name": "Calvin Xu",
-          "url": "https://pinlinxu.com"
+          "affiliation": "Independent",
+          "name": "Harry Shin",
+          "url": "https://www.linkedin.com/in/harry-shin-34743216a/"
         },
         "description": "Hackable Transformer (520m); Attention with parallel MLP (Muon)",
         "device_flops": 459000000000000.0,


### PR DESCRIPTION
## Description

Chore. Noticed this got reverted again in the speedrun repo: https://github.com/marin-community/speedrun/commit/16a2add539d178205fc18fa7e023315870c7ca0f

<img width="828" height="840" alt="image" src="https://github.com/user-attachments/assets/893e9d0b-8f20-4641-bffc-2be16e065a63" />