### PR TITLE
Update cluster docker image to `20260104`

### DIFF
--- a/infra/marin-big-run.yaml
+++ b/infra/marin-big-run.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-central2-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260102"
+    image: "us-central2-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260104"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-eu-west4-a.yaml
+++ b/infra/marin-eu-west4-a.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "europe-west4-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260102"
+    image: "europe-west4-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260104"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-eu-west4.yaml
+++ b/infra/marin-eu-west4.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "europe-west4-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260102"
+    image: "europe-west4-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260104"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-us-central1.yaml
+++ b/infra/marin-us-central1.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-central1-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260102"
+    image: "us-central1-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260104"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-us-central2.yaml
+++ b/infra/marin-us-central2.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-central2-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260102"
+    image: "us-central2-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260104"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-us-east1.yaml
+++ b/infra/marin-us-east1.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-east1-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260102"
+    image: "us-east1-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260104"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-us-east5-a.yaml
+++ b/infra/marin-us-east5-a.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-east5-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260102"
+    image: "us-east5-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260104"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-us-east5.yaml
+++ b/infra/marin-us-east5.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-east5-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260102"
+    image: "us-east5-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260104"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-us-west4.yaml
+++ b/infra/marin-us-west4.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-west4-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260102"
+    image: "us-west4-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260104"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/lib/marin/src/marin/cluster/config.py
+++ b/lib/marin/src/marin/cluster/config.py
@@ -22,7 +22,7 @@ import jinja2
 import yaml
 
 # Cluster configuration constants and templates
-LATEST = "20260102"  # The latest docker tag used for the clusters
+LATEST = "20260104"  # The latest docker tag used for the clusters
 LATEST_VLLM = "20251209"
 DOCKER_TAG_TESTING = "latest"
 DEFAULT_IMAGE_NAME = "marin_cluster"


### PR DESCRIPTION
## Description

Re: https://discord.com/channels/1354881461060243556/1364827114670657616/1458644843810001016


* `20260102` is missing dupekit for some reason (tbd why), it's not clear to me what build this image because I can't see it in the Actions workflows 🤔 
* update to latest docker image `20260104`