### PR TITLE
Owner Died Preemption

### DIFF
--- a/lib/fray/src/fray/cluster/ray/tpu/execution.py
+++ b/lib/fray/src/fray/cluster/ray/tpu/execution.py
@@ -823,20 +823,26 @@ def run_on_pod_ray(
             future_to_index: dict[ray.ObjectRef, int] = {}  # maps futures to their index in the results list
             global_index = 0  # index into results list
 
-            for i, tpu_slice in enumerate(slice_pool):
-                if head_slice_info is not None:
-                    multislice_info = _multislice_info_from_head(head_slice_info, i, len(slice_pool))
-                    mxla_env = _multislice_info_to_env_vars(multislice_info)
-                else:
-                    mxla_env = {}
+            try:
+                for i, tpu_slice in enumerate(slice_pool):
+                    if head_slice_info is not None:
+                        multislice_info = _multislice_info_from_head(head_slice_info, i, len(slice_pool))
+                        mxla_env = _multislice_info_to_env_vars(multislice_info)
+                    else:
+                        mxla_env = {}
 
-                futures_for_slice = _start_fn_on_slice(tpu_slice.actor, remote_fn, mxla_env)
-                logger.info(f"Futures for slice {tpu_slice.actor_info.slice_name}: {futures_for_slice}")
+                    futures_for_slice = _start_fn_on_slice(tpu_slice.actor, remote_fn, mxla_env)
+                    logger.info(f"Futures for slice {tpu_slice.actor_info.slice_name}: {futures_for_slice}")
 
-                futures.extend(futures_for_slice)
-                for future in futures_for_slice:
-                    future_to_index[future] = global_index
-                    global_index += 1
+                    futures.extend(futures_for_slice)
+                    for future in futures_for_slice:
+                        future_to_index[future] = global_index
+                        global_index += 1
+            except RayError as e:
+                logger.exception("Failed to start remote function on slice", exc_info=e)
+                problems.append(e)
+                num_preemptions += 1
+                continue
 
             if not futures:
                 error = "Failed to schedule any futures"


### PR DESCRIPTION
## Description

Pre-emption seems to surface as this sometimes and we should handle it as pre-emption.

```
RuntimeError: Job 140208822563728 failed with status failed and error: ray::run_on_pod_ray() (pid=101181, ip=10.128.0.64)
 File "/tmp/ray/session_2026-01-02_11-56-45_289032_866/runtime_resources/working_dir_files/_ray_pkg_33b10f62e5c00319/lib/fray/src/fray/cluster/ray/tpu/execution.py", line 984, in run_on_pod_ray
 raise problem or RuntimeError("TPU job failed too many times")
 File "/tmp/ray/session_2026-01-02_11-56-45_289032_866/runtime_resources/working_dir_files/_ray_pkg_33b10f62e5c00319/lib/fray/src/fray/cluster/ray/tpu/execution.py", line 860, in run_on_pod_ray
 tpu_results[future_to_index[f]] = TpuSuccess(ray.get(f))
 ^^^^^^^^^^
 ^^^^^^^^^^^^^^^^^^^
 ^^^^^^^^^^^^^^^^^^^^^
 ^^^^^^^^^^^^^^^^^^^
ray.exceptions.OwnerDiedError: Failed to retrieve object 5fba20854cf57ce5ffffffffffffffffffffffff2f01000001000000. To see information about where this ObjectRef was created in Python, set the environment variable RAY_record_ref_creation_sites=1 during `ray start` and `ray.init()`.

The object's owner has exited. This is the Python worker that first created the ObjectRef via `.remote()` or `ray.put()`. Check cluster logs (`/tmp/ray/session_latest/logs/*202d8d4d73d80656025e3b18112905371f539bd7bfc86261a7a08aad*` at IP address 10.128.0.150) for more information about the Python worker failure.
```