### PR TITLE
Add nvidia/OpenMathReasoning dataset (cot, tir, genselect splits)

### DIFF
--- a/experiments/posttrain/instruction_datasets.py
+++ b/experiments/posttrain/instruction_datasets.py
@@ -453,6 +453,66 @@ INSTRUCTION_DATASET_NAME_TO_CONFIG = {
         name="GeneralReasoning/GeneralThought-195K-modelreasoning",
         splits=["train"],
     ),
+    # nvidia/OpenMathReasoning - CoT split (Chain of Thought reasoning)
+    "nvidia/OpenMathReasoning/cot": InstructionDatasetConfig(
+        hf_dataset_id="nvidia/OpenMathReasoning",
+        revision="d3d0866",
+        adapter=instruction_response_adapter(
+            instruction_column="problem",
+            response_column="generated_solution",
+        ),
+        metadata_columns=[
+            "expected_answer",
+            "problem_source",
+            "problem_type",
+            "generation_model",
+            "inference_mode",
+            "pass_rate_72b_tir",
+            "used_in_kaggle",
+        ],
+        name="nvidia/OpenMathReasoning/cot",
+        splits=["cot"],
+    ),
+    # nvidia/OpenMathReasoning - TIR split (Tool-Integrated Reasoning)
+    "nvidia/OpenMathReasoning/tir": InstructionDatasetConfig(
+        hf_dataset_id="nvidia/OpenMathReasoning",
+        revision="d3d0866",
+        adapter=instruction_response_adapter(
+            instruction_column="problem",
+            response_column="generated_solution",
+        ),
+        metadata_columns=[
+            "expected_answer",
+            "problem_source",
+            "problem_type",
+            "generation_model",
+            "inference_mode",
+            "pass_rate_72b_tir",
+            "used_in_kaggle",
+        ],
+        name="nvidia/OpenMathReasoning/tir",
+        splits=["tir"],
+    ),
+    # nvidia/OpenMathReasoning - genselect split (curated subset)
+    "nvidia/OpenMathReasoning/genselect": InstructionDatasetConfig(
+        hf_dataset_id="nvidia/OpenMathReasoning",
+        revision="d3d0866",
+        adapter=instruction_response_adapter(
+            instruction_column="problem",
+            response_column="generated_solution",
+        ),
+        metadata_columns=[
+            "expected_answer",
+            "problem_source",
+            "problem_type",
+            "generation_model",
+            "inference_mode",
+            "pass_rate_72b_tir",
+            "used_in_kaggle",
+        ],
+        name="nvidia/OpenMathReasoning/genselect",
+        splits=["genselect"],
+    ),
 }
 
 for split_name in SMOLTALK2_SPLITS:


### PR DESCRIPTION
## Description

Fixes #1848(Partially)

This PR adds the nvidia/OpenMathReasoning dataset to Marin's SFT dataset collection. OpenMathReasoning is a high-quality mathematical reasoning dataset containing 5.67 million samples generated by DeepSeek-R1 and QwQ-32B models (Qwen2.5-32B-Instruct to preprocess problems, and DeepSeek-R1 and QwQ-32B to generate solutions), featuring chain-of-thought solutions to olympiad-level math problems.

### Dataset Details
- **Source**: https://huggingface.co/datasets/nvidia/OpenMathReasoning
- **License**: CC-BY-4.0
- **Revision**: d3d0866

### Splits Added
| Split | Samples | Description |
| :---: | :---: | :--- | 
| cot | 3.2M | Chain-of-thought reasoning solutions |
| tir | 1.72M | Tool-integrated reasoning (code execution) |
| genselect | 566K | Generated selection samples |

### Field Mapping
- `problem` → instruction column
- `generated_solution` → response column
- Metadata columns preserved: `expected_answer`, `problem_source`, `problem_type`, `generation_model`, `inference_mode`, `pass_rate_72b_tir`, `used_in_kaggle`
- 
### Testing Performed
- Pre-commit checks passed
- pytest: 1 passed, 3 skipped, 19 deselected
- Verified config loads correctly and matches structure of existing configs (e.g., meta-math/MetaMathQA)
- Verified dataset field names (`problem`, `generated_solution`) exist via HuggingFace streaming
- End-to-end SFT training  test with 5000 samples on 8×A800 GPUs (from distilgpt2 - 82M):
  - Loss decreased from 2.87 → 1.52 over 15 epochs
  - Model successfully learned the CoT reasoning format from training data
- **Example:**
  - **Question:** How many lines can be drawn that are equidistant from 3 non-collinear points in the plane?
  - **Before SFT:**
    <details>
    <summary>Click to view output</summary>

    ```text
    The solution is to use the plane geometry, then fill the plane.
    #include <math.h> #include <std.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.h> #include <math.
    ```
    </details>

  - **After SFT:**
    <details>
    <summary>Click to view output</summary>

    ```text
    <think>
    Okay, so I need to figure out how many lines are equidistant from three non-collinear points in the plane. Hmm, let's see. The problem is asking for the number of lines that can be drawn that are equidistant from 3 non-collinear points in the plane. The condition is that the line is equidistant from all three non-collinear points in that plane.

    First, maybe I should recall some properties of line-drawing. Since all lines have at least one intersection point, but the problem is asking for the number of lines that aren't equidistant at all, maybe there's a pattern or a way to relate these lines to other points.

    Since all lines are equidistant from all three non-collinear points, maybe the line that's equidistant from all three non-collinear points in that plane is equidistant from all three non-collinear points in that plane. Since all lines are equidistant from all three non-collinear points, that means all three non-collinear points must be equidistant from all three non-collinear points in that plane.

    I remember that when dealing with lines equidistant from a plane, the intersection points of the sides of two lines are the plane's transversals, and the line that's equidistant from all three non-
    ```
    </details>


## Checklist

- [ Passed ] You ran `uv run python infra/pre-commit.py --all-files` to lint/format your code
- [ 1 passed, 3 skipped, 19 deselected ] You ran 'pytest' to test your code





