### PR TITLE
Speedrun: LLaMA-1.4B dense + bilinear MLP + 100B composite mix

### DIFF
--- a/lib/levanter/src/levanter/utils/activation.py
+++ b/lib/levanter/src/levanter/utils/activation.py
@@ -16,6 +16,7 @@ ActivationFunction = typing.Callable[[_A], _A]
 
 
 class ActivationFunctionEnum(str, enum.Enum):
+    linear = "linear"
     relu = "relu"
     silu = "silu"
     swish = "swish"
@@ -33,6 +34,7 @@ class ActivationFunctionEnum(str, enum.Enum):
 
 # type: ignore
 TO_FN: dict[ActivationFunctionEnum, ActivationFunction] = {
+    ActivationFunctionEnum.linear: lambda x: x,
     ActivationFunctionEnum.relu: hnn.relu,
     ActivationFunctionEnum.silu: hnn.silu,
     ActivationFunctionEnum.swish: hnn.swish,


### PR DESCRIPTION
This PR keeps the diff minimal (2 files):

- `experiments/speedrun/olmoe_1b7b_nemotron_40b.py`
  - Adds dense model option `--model llama_1_4b`.
  - Adds bilinear MLP variant `--model llama_1_4b_bilinear` (no SiLU gate; bilinear hadamard `(W1x) * (W3x)`).
  - Adds composite dataset preset `--dataset nemotron_dclm_fineweb_10b`.
  - Sets composite mixture ratios to Nemotron/FineWeb/DCLM = 0.4/0.1/0.5 and defaults to 100B total tokens for that dataset.

- `lib/levanter/src/levanter/utils/activation.py`
  - Adds `ActivationFunctionEnum.linear` (identity) to support the bilinear MLP variant.

Notes:
- For the bilinear model, HF export is disabled (`steps_per_export=-1`) since HF config doesn't understand the custom activation.