### PR TITLE
Disable WANDB logging during pytest runs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,3 +34,9 @@ def fray_cluster():
     set_current_cluster(create_cluster("local"))
     yield
     set_current_cluster(None)
+
+
+@pytest.fixture(autouse=True)
+def disable_wandb(monkeypatch):
+    """Disable WANDB logging during tests."""
+    monkeypatch.setenv("WANDB_MODE", "disabled")


### PR DESCRIPTION
## Summary
- Add autouse pytest fixture to `tests/conftest.py` that sets `WANDB_MODE=disabled`
- This prevents `_init_wandb` from logging to WANDB when running tests, even if `WANDB_API_KEY` is set in the environment
- The wandb library natively respects the `WANDB_MODE` environment variable

## Test plan
- [x] Verified tests run without WANDB logging when `WANDB_API_KEY` is set (ran `test_decontamination` with fake key - passed without auth errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)