### PR TITLE
Revert "Make Tokenization More Robust Hopefully"

### DIFF
--- a/lib/marin/src/marin/download/huggingface/download_hf.py
+++ b/lib/marin/src/marin/download/huggingface/download_hf.py
@@ -88,7 +88,7 @@ def stream_file_to_fsspec(gcs_output_path: str, file_path: str, fsspec_file_path
     target_fs, _ = fsspec.core.url_to_fs(gcs_output_path)
     # Use 256 MB chunk size for large files
     chunk_size = 256 * 1024 * 1024
-    max_retries = 100
+    max_retries = 10
 
     # Retry when there is an error, such as hf rate limit
     for attempt in range(max_retries):
@@ -159,7 +159,7 @@ def download_hf(cfg: DownloadConfig) -> None:
             f"{cfg.gcs_output_path}/.metrics/success-part-{{shard:05d}}-of-{{total:05d}}.jsonl", skip_existing=True
         )
     )
-    Backend.execute(pipeline, max_parallelism=16)
+    Backend.execute(pipeline)
 
     # Write Provenance JSON
     write_provenance_json(

--- a/lib/zephyr/src/zephyr/backends.py
+++ b/lib/zephyr/src/zephyr/backends.py
@@ -54,12 +54,10 @@ class BackendConfig:
 
     Attributes:
         max_parallelism: Maximum number of concurrent tasks
-        max_retries_preemption: Retries per shard when Ray tasks are preempted
         dry_run: If True, show optimization plan without executing
     """
 
     max_parallelism: int = 1024
-    max_retries_preemption: int = 3
     dry_run: bool = False
 
 
@@ -382,7 +380,6 @@ class Backend:
 
         active_gens: list[tuple[Any, StageContext]] = []
         queued = list(contexts)
-        retries_left = {ctx.shard_idx: self.config.max_retries_preemption for ctx in contexts}
 
         # Start initial batch
         while len(active_gens) < self.config.max_parallelism and queued:
@@ -407,63 +404,9 @@ class Backend:
                             if queued:
                                 next_ctx = queued.pop(0)
                                 active_gens.append((self.context.run(run_stage, next_ctx, operations), next_ctx))
-                        except Exception as exc:
-                            if self._should_retry_preemption(exc, ctx, retries_left):
-                                active_gens.remove((g, ctx))
-                                results_by_shard.pop(ctx.shard_idx, None)
-                                active_gens.append((self.context.run(run_stage, ctx, operations), ctx))
-                            else:
-                                raise
                         break
 
         return results_by_shard
-
-    def _should_retry_preemption(self, exc: Exception, ctx: StageContext, retries_left: dict[int, int]) -> bool:
-        if retries_left.get(ctx.shard_idx, 0) <= 0:
-            return False
-
-        from fray.job import RayContext
-
-        if not isinstance(self.context, RayContext):
-            return False
-
-        if not self._is_ray_preemption_error(exc):
-            return False
-
-        retries_left[ctx.shard_idx] -= 1
-        logger.warning(
-            "Ray task preempted for shard %s; retrying (%d retries left)",
-            ctx.shard_idx,
-            retries_left[ctx.shard_idx],
-            exc_info=exc,
-        )
-        return True
-
-    def _is_ray_preemption_error(self, exc: Exception) -> bool:
-        """Check if a Ray exception indicates worker/node preemption or failure."""
-        from ray.exceptions import (
-            ActorDiedError,
-            ActorUnavailableError,
-            NodeDiedError,
-            OwnerDiedError,
-            RayError,
-            RayTaskError,
-            WorkerCrashedError,
-        )
-
-        if not isinstance(exc, RayError):
-            return False
-
-        # These errors indicate node/worker failures, which we treat as preemption
-        if isinstance(exc, (NodeDiedError, OwnerDiedError, ActorUnavailableError, ActorDiedError, WorkerCrashedError)):
-            return True
-
-        # Timeout errors within RayTaskError often indicate preemption
-        if isinstance(exc, RayTaskError):
-            if isinstance(exc.cause, TimeoutError) or "timed out" in str(exc):
-                return True
-
-        return False
 
     def _execute_shard_parallel(
         self,


### PR DESCRIPTION
## Description

I'm pretty sure the zephyr retry logic introduce in 41dbea37167b0bf9561925a1050b71b5af1b6baa isn't safe, afaiu we can't `results_by_shard.pop(ctx.shard_idx, None)` without risking silent data loss.

I'm also reverting changes to `download_hf`:
 * `max_parallelism` should be exposed as a parameter instead of hardcoded to 16
 * `max_retries` of 10 is reasonable - we should do better at retrying 