### PR TITLE
Improve HF download retry

### DIFF
--- a/lib/marin/src/marin/download/huggingface/download_hf.py
+++ b/lib/marin/src/marin/download/huggingface/download_hf.py
@@ -65,7 +65,7 @@ class DownloadConfig:
         # spaces/ for spaces, and models do not need a prefix in the URL.
     )
 
-    zephyr_max_parallelism: int = 1024
+    zephyr_max_parallelism: int = 512
     """Maximum parallelism of the Zephyr download job"""
 
 
@@ -116,7 +116,7 @@ def stream_file_to_fsspec(gcs_output_path: str, file_path: str, fsspec_file_path
                     try:
                         wait_base += int(e.response.headers["RateLimit"].split(";")[-1].split("=")[-1])
                     except Exception:
-                        logger.exception("Failed to parse RateLimit header")
+                        logger.warning("Failed to parse rate limit header, using default wait period")
 
             jitter = random.uniform(0, wait_base)
             wait_time = wait_base + jitter


### PR DESCRIPTION
## Description

Re: https://github.com/marin-community/marin/pull/2394

Two related changes:
 * configurable parallelism of the HF download
 * improve the retry/sleep of the HF fetch, utilize the backoff info from the response + jitter
   * this doesn't completely alleviate the failures, but the job is a little bit more "persistent" 
 * log via `logger.exception` to include the traceback 
