### PR TITLE
Fix #2405: Update the marin cluster image tags

### DIFF
--- a/infra/marin-big-run.yaml
+++ b/infra/marin-big-run.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-central2-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260104"
+    image: "us-central2-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260118"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-eu-west4-a.yaml
+++ b/infra/marin-eu-west4-a.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "europe-west4-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260104"
+    image: "europe-west4-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260118"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-eu-west4.yaml
+++ b/infra/marin-eu-west4.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "europe-west4-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260104"
+    image: "europe-west4-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260118"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-us-central1.yaml
+++ b/infra/marin-us-central1.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-central1-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260104"
+    image: "us-central1-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260118"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-us-central2.yaml
+++ b/infra/marin-us-central2.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-central2-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260104"
+    image: "us-central2-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260118"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-us-east1.yaml
+++ b/infra/marin-us-east1.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-east1-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260104"
+    image: "us-east1-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260118"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-us-east5-a.yaml
+++ b/infra/marin-us-east5-a.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-east5-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260104"
+    image: "us-east5-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260118"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-us-east5.yaml
+++ b/infra/marin-us-east5.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-east5-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260104"
+    image: "us-east5-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260118"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-us-west4.yaml
+++ b/infra/marin-us-west4.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-west4-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260104"
+    image: "us-west4-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260118"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:


### PR DESCRIPTION
Updated all cluster configuration files to use the latest image tag 20260118 which includes recent dupekit changes. Only cluster images were updated; vLLM images were left unchanged as intended.

Files updated:
- infra/marin-big-run.yaml
- infra/marin-eu-west4-a.yaml
- infra/marin-eu-west4.yaml
- infra/marin-us-central1.yaml
- infra/marin-us-central2.yaml
- infra/marin-us-east1.yaml
- infra/marin-us-east5-a.yaml
- infra/marin-us-east5.yaml
- infra/marin-us-west4.yaml

Fixes #2405
