### PR TITLE
Avoid eager tokenizer fetch on test collection

### DIFF
--- a/tests/test_scaling_laws.py
+++ b/tests/test_scaling_laws.py
@@ -27,14 +27,13 @@ from marin.scaling_laws.isoflop_analysis import (
     robust_quad_logx,
 )
 
-# Import the concrete recipe and transform function from experiments
-from experiments.isoflop_sweep import Marin2025Recipe, parse_isoflop_run_name, transform_levanter_metrics
-
 # --- Run name parsing tests ---
 
 
 def test_parse_isoflop_run_name():
     """Test parsing isoflop run names extracts experiment names."""
+    from experiments.isoflop_sweep import parse_isoflop_run_name
+
     # New format: isoflop-{budget}-N{params}-B{batch}-{experiment_name}
     assert parse_isoflop_run_name("isoflop-1e+18-N1e+08-B128-nemo-wider-depth-adapt") == "nemo-wider-depth-adapt"
     assert parse_isoflop_run_name("isoflop-1e+18-N1e+08-B128-dclm-a1b2c3") == "dclm"  # hash stripped
@@ -53,6 +52,8 @@ def test_parse_isoflop_run_name():
 
 def test_candidate_configs_within_tolerance():
     """Test that generated configs achieve the target FLOP budget within tolerance."""
+    from experiments.isoflop_sweep import Marin2025Recipe
+
     recipe = Marin2025Recipe()
     budget = 1e19
     flop_tolerance = 0.01
@@ -107,6 +108,8 @@ def test_candidates_for_budget_snapshot():
 
     This ensures reproducibility of the config generation algorithm.
     """
+    from experiments.isoflop_sweep import Marin2025Recipe
+
     recipe = Marin2025Recipe()
     result = list(recipe.candidates_for_budget(budget=3e18))
 
@@ -195,6 +198,7 @@ def test_end_to_end_analysis_pipeline():
     pipeline: metrics transformation -> curve fitting -> scaling law extraction.
     """
     from marin.scaling_laws import round_flops_to_bucket
+    from experiments.isoflop_sweep import transform_levanter_metrics
 
     # Transform metrics using the Levanter transform function
     records = transform_levanter_metrics(SAMPLE_METRICS_DATA, "eval/paloma/c4_en/bpb")


### PR DESCRIPTION
## Description

Fixes https://github.com/marin-community/marin/issues/2428

This is really just a quickfix, but there's a larger problem with the use of module-level/global variables, that's obviously out of scope of this PR.

@Helw150 I'm curious if there's a better way to handle this.
