### PR TITLE
Add logging panel to dashboard proxy with error tracking

### DIFF
--- a/lib/fray/src/fray/cluster/ray/dashboard_proxy.py
+++ b/lib/fray/src/fray/cluster/ray/dashboard_proxy.py
@@ -300,8 +300,7 @@ class DashboardProxy:
                 escaped_details = html_escape(entry.details) if entry.details else ""
                 details_str = f": {escaped_details}" if entry.details else ""
                 log_line = (
-                    f'<div class="log-line">{timestamp} [{escaped_cluster}] '
-                    f"{escaped_message}{details_str}</div>"
+                    f'<div class="log-line">{timestamp} [{escaped_cluster}] ' f"{escaped_message}{details_str}</div>"
                 )
                 html_parts.append(log_line)
             return "".join(html_parts)


### PR DESCRIPTION
This adds a logging system to the dashboard proxy that captures and displays errors, warnings, and info messages from cluster status operations. The logs are displayed in a new panel on the dashboard UI that auto-refreshes every 5 seconds.

It turns out the proxy warnings were due to mismatching Ray versions between the local client and those Ray clusters -- we have a bunch of stale Ray clusters.