### PR TITLE
uv cache in Iris worker

### DIFF
--- a/lib/iris/src/iris/cluster/client/local_client.py
+++ b/lib/iris/src/iris/cluster/client/local_client.py
@@ -223,13 +223,11 @@ class _LocalImageProvider:
         base_image: str,
         extras: list[str],
         job_id: str,
-        deps_hash: str,
         task_logs=None,
     ) -> BuildResult:
         del bundle_path, base_image, extras, job_id, task_logs
         return BuildResult(
             image_tag="local:latest",
-            deps_hash=deps_hash,
             build_time_ms=0,
             from_cache=True,
         )

--- a/lib/iris/src/iris/cluster/worker/builder.py
+++ b/lib/iris/src/iris/cluster/worker/builder.py
@@ -16,6 +16,8 @@
 
 import hashlib
 import logging
+import random
+import string
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -31,35 +33,9 @@ def _find_all_recursive(bundle_path: Path, pattern: str) -> list[Path]:
     return list(bundle_path.rglob(pattern))
 
 
-class VenvCache:
-    """Utility for computing dependency hashes for cache invalidation.
-
-    UV handles dependency caching natively via BuildKit cache mounts with
-    explicit global cache ID (iris-uv-global). This ensures all workspaces
-    share the same BuildKit-managed cache for dependency reuse.
-
-    This class provides utilities for computing dependency hashes from
-    pyproject.toml and uv.lock files to determine when Docker image layers
-    can be reused.
-    """
-
-    def compute_deps_hash(self, bundle_path: Path) -> str:
-        h = hashlib.sha256()
-        for fname in ["pyproject.toml", "uv.lock"]:
-            at_least_one_found = False
-            for fpath in _find_all_recursive(bundle_path, fname):
-                if fpath.exists():
-                    h.update(fpath.read_bytes())
-                    at_least_one_found = True
-            if not at_least_one_found:
-                logger.warning(f"File {fname} not found inside {bundle_path}")
-        return h.hexdigest()
-
-
 @dataclass
 class BuildResult:
     image_tag: str
-    deps_hash: str
     build_time_ms: int
     from_cache: bool
 
@@ -73,7 +49,6 @@ class ImageProvider(Protocol):
         base_image: str,
         extras: list[str],
         job_id: str,
-        deps_hash: str,
         task_logs: TaskLogs | None = None,
     ) -> BuildResult: ...
 
@@ -120,7 +95,7 @@ RUN uv pip install cloudpickle
 class ImageCache:
     """Manages Docker image building with caching.
 
-    Image tag: {registry}/iris-job-{job_id}:{deps_hash[:8]}
+    Image tag: {registry}/iris-job-{job_id}:{uv_locks_hash[:8]}
     Uses Docker BuildKit cache mounts with explicit global cache ID
     (iris-uv-global) to ensure all workspaces share the same UV cache.
 
@@ -128,6 +103,7 @@ class ImageCache:
     - All builds use id=iris-uv-global for the UV cache mount
     - Different workspaces reuse cached dependencies automatically
     - BuildKit manages cache storage in /var/lib/buildkit/
+    - If there's no uv lock files (pyproject, uv.lock), use random image tag
 
     Delegates actual Docker operations to DockerImageBuilder, keeping
     caching logic separate from container runtime specifics.
@@ -164,13 +140,25 @@ class ImageCache:
         base_image: str,
         extras: list[str],
         job_id: str,
-        deps_hash: str,
         task_logs: TaskLogs | None = None,
     ) -> BuildResult:
-        if self._registry:
-            image_tag = f"{self._registry}/iris-job-{job_id}:{deps_hash[:8]}"
+        uv_locks_files = _find_all_recursive(bundle_path, "pyproject.toml") + _find_all_recursive(bundle_path, "uv.lock")
+
+        tag_len = 8
+        if not uv_locks_files:
+            tag = "".join(random.choices(string.ascii_lowercase, k=tag_len))
+            logger.warning(f"No pyproject.toml or uv.lock files found in the bundle path, using tag: {tag}")
         else:
-            image_tag = f"iris-job-{job_id}:{deps_hash[:8]}"
+            h = hashlib.sha256()
+            for f in uv_locks_files:
+                with open(f, "rb") as fd:
+                    h.update(fd.read())
+            tag = h.hexdigest()[:tag_len]
+
+        if self._registry:
+            image_tag = f"{self._registry}/iris-job-{job_id}:{tag}"
+        else:
+            image_tag = f"iris-job-{job_id}:{tag}"
 
         # Check if image exists locally
         if self._docker.exists(image_tag):
@@ -178,7 +166,6 @@ class ImageCache:
                 task_logs.add("build", f"Using cached image: {image_tag}")
             return BuildResult(
                 image_tag=image_tag,
-                deps_hash=deps_hash,
                 build_time_ms=0,
                 from_cache=True,
             )
@@ -186,10 +173,6 @@ class ImageCache:
         # Build image
         start = time.time()
         extras_flags = " ".join(f"--extra {e}" for e in extras) if extras else ""
-
-        uv_locks_files = _find_all_recursive(bundle_path, "pyproject.toml") + _find_all_recursive(bundle_path, "uv.lock")
-        if not uv_locks_files:
-            logger.warning("No pyproject.toml or uv.lock files found in the bundle path")
 
         pyproject_mounts = " \\\n".join(
             f"--mount=type=bind,source={f.relative_to(bundle_path)},target={f.relative_to(bundle_path)}"
@@ -199,6 +182,7 @@ class ImageCache:
         dockerfile = DOCKERFILE_TEMPLATE.format(
             base_image=base_image, extras_flags=extras_flags, pyproject_mounts=pyproject_mounts
         )
+        # TODO (rav): does there need to be a lock around docker build?
         self._docker.build(bundle_path, dockerfile, image_tag, task_logs)
         build_time_ms = int((time.time() - start) * 1000)
 
@@ -206,7 +190,6 @@ class ImageCache:
 
         return BuildResult(
             image_tag=image_tag,
-            deps_hash=deps_hash,
             build_time_ms=build_time_ms,
             from_cache=False,
         )

--- a/lib/iris/tests/cluster/worker/test_dashboard.py
+++ b/lib/iris/tests/cluster/worker/test_dashboard.py
@@ -25,7 +25,7 @@ from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from connectrpc.request import RequestContext
 
-from iris.cluster.worker.builder import BuildResult, ImageCache, VenvCache
+from iris.cluster.worker.builder import BuildResult, ImageCache
 from iris.cluster.worker.bundle_cache import BundleCache
 from iris.cluster.worker.dashboard import WorkerDashboard
 from iris.cluster.worker.docker import ContainerStats, ContainerStatus, DockerRuntime
@@ -49,21 +49,12 @@ def mock_bundle_cache():
 
 
 @pytest.fixture
-def mock_venv_cache():
-    """Create mock VenvCache."""
-    cache = Mock(spec=VenvCache)
-    cache.compute_deps_hash = Mock(return_value="abc123")
-    return cache
-
-
-@pytest.fixture
 def mock_image_cache():
     """Create mock ImageCache."""
     cache = Mock(spec=ImageCache)
     cache.build = Mock(
         return_value=BuildResult(
             image_tag="test-image:latest",
-            deps_hash="abc123",
             build_time_ms=1000,
             from_cache=False,
         )
@@ -102,7 +93,7 @@ def mock_runtime():
 
 
 @pytest.fixture
-def worker(mock_bundle_cache, mock_venv_cache, mock_image_cache, mock_runtime):
+def worker(mock_bundle_cache, mock_image_cache, mock_runtime):
     """Create Worker with mocked dependencies."""
     config = WorkerConfig(
         port=0,


### PR DESCRIPTION
Fixes https://github.com/marin-community/marin/issues/2366

 * update `VenvCache` to compute hash over all "lock files"[^1] inside the bundle not only the root directory
 * keep the uv cache docker cache mount, BUT change the `sharing=shared` - it should be fine https://docs.astral.sh/uv/concepts/cache/#cache-safety ?
 * mount the lock files and resolve the venv as part of the job image build
   * this will leverage the "global"[^2] uv cache and docker cache

So if there's no change in the lock files across bundles, job images will not recreate the venv layer. If at least one of them change, the whole layer needs to be recreated, I think we could improve this, but we can leave that for later.

[^1]: here defined as pyproject and uv lock
[^2]: within instance/machine 