### PR TITLE
Fix pytest.mark.skipif condition to use bool instead of string

### DIFF
--- a/tests/rl/integration/test_cats_integration.py
+++ b/tests/rl/integration/test_cats_integration.py
@@ -42,7 +42,7 @@ from tests.rl.integration.config import (
 )
 from tests.rl.integration.tasks import create_cats_rollout_batch, validate_cats_model
 
-pytestmark = pytest.mark.skipif(os.environ.get("CI"), reason="Skipping integration tests on CI environment")
+pytestmark = pytest.mark.skipif(os.environ.get("CI") is not None, reason="Skipping integration tests on CI environment")
 
 logger = logging.getLogger(__name__)
 

--- a/tests/rl/integration/test_checkpoint_restart.py
+++ b/tests/rl/integration/test_checkpoint_restart.py
@@ -35,7 +35,7 @@ from tests.rl.integration.config import (
 )
 from tests.rl.integration.tasks import create_cats_rollout_batch
 
-pytestmark = pytest.mark.skipif(os.environ.get("CI"), reason="Skipping integration tests on CI environment")
+pytestmark = pytest.mark.skipif(os.environ.get("CI") is not None, reason="Skipping integration tests on CI environment")
 
 
 @pytest.mark.slow("Integration test with checkpoint restart")

--- a/tests/rl/integration/test_llama_math_integration.py
+++ b/tests/rl/integration/test_llama_math_integration.py
@@ -41,7 +41,7 @@ from tests.rl.integration.config import (
     create_test_rollout_storage_config,
 )
 
-pytestmark = pytest.mark.skipif(os.environ.get("CI"), reason="Skipping integration tests on CI environment")
+pytestmark = pytest.mark.skipif(os.environ.get("CI") is not None, reason="Skipping integration tests on CI environment")
 
 logger = logging.getLogger(__name__)
 

--- a/tests/rl/integration/test_rollout_worker.py
+++ b/tests/rl/integration/test_rollout_worker.py
@@ -31,7 +31,7 @@ from tests.rl.integration.config import (
     create_test_rollout_storage_config,
 )
 
-pytestmark = pytest.mark.skipif(os.environ.get("CI"), reason="Skipping integration tests on CI environment")
+pytestmark = pytest.mark.skipif(os.environ.get("CI") is not None, reason="Skipping integration tests on CI environment")
 
 
 @pytest.mark.slow("Integration test.")

--- a/tests/rl/integration/test_sequential_digits_integration.py
+++ b/tests/rl/integration/test_sequential_digits_integration.py
@@ -38,7 +38,7 @@ from tests.rl.integration.config import (
 )
 from tests.rl.integration.tasks import create_sequential_digits_rollout_batch, validate_sequential_digits_model
 
-pytestmark = pytest.mark.skipif(os.environ.get("CI"), reason="Skipping integration tests on CI environment")
+pytestmark = pytest.mark.skipif(os.environ.get("CI") is not None, reason="Skipping integration tests on CI environment")
 
 logger = logging.getLogger(__name__)
 

--- a/tests/rl/integration/test_train_worker.py
+++ b/tests/rl/integration/test_train_worker.py
@@ -32,7 +32,7 @@ from tests.rl.integration.config import (
 )
 from tests.rl.integration.tasks import create_cats_rollout_batch
 
-pytestmark = pytest.mark.skipif(os.environ.get("CI"), reason="Skipping integration tests on CI environment")
+pytestmark = pytest.mark.skipif(os.environ.get("CI") is not None, reason="Skipping integration tests on CI environment")
 
 
 @pytest.mark.slow("Integration test.")

--- a/tests/rl/integration/test_weight_sync.py
+++ b/tests/rl/integration/test_weight_sync.py
@@ -33,7 +33,7 @@ from tests.rl.integration.config import (
     create_test_rollout_storage_config,
 )
 
-pytestmark = pytest.mark.skipif(os.environ.get("CI"), reason="Skipping integration tests on CI environment")
+pytestmark = pytest.mark.skipif(os.environ.get("CI") is not None, reason="Skipping integration tests on CI environment")
 
 
 @pytest.mark.slow("Integration test.")


### PR DESCRIPTION
## Summary
- `os.environ.get("CI")` returns a string (e.g. `"true"`) when set, which `pytest.mark.skipif` interprets as a Python expression to `eval()` rather than a boolean condition — causing a `NameError` and the tests never being skipped on CI.
- Changed all 7 affected files to use `os.environ.get("CI") is not None`, which always produces a proper `bool`.

Fixes #2451

## Test plan
- [x] Verified the bug with: `CI=true uv run python -c "import os; eval(os.environ.get('CI'))"`
- [x] Confirmed tests are correctly skipped when `CI=true` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)