### PR TITLE
Pick These Up Automatically since you basically have to pass them anyhow

### DIFF
--- a/lib/marin/src/marin/run/ray_run.py
+++ b/lib/marin/src/marin/run/ray_run.py
@@ -275,6 +275,10 @@ def main():
         except Exception as e:
             logger.warning(f"Failed to parse {marin_yaml}: {e}")
 
+    for key in ("HF_TOKEN", "WANDB_API_KEY"):
+        if key not in env_vars and os.environ.get(key) is not None:
+            env_vars[key] = os.environ[key]
+
     if args.env_vars:
         for item in args.env_vars:
             if len(item) > 2:


### PR DESCRIPTION
As a user, you either have to or basically should always pass these environment variables to ray_run. Adds functionality to automatically fetch them from the local environment if they are set.