### PR TITLE
Iris: Fix infinite refresh loop in job detail page

### DIFF
--- a/lib/iris/src/iris/cluster/static/controller/job-detail.js
+++ b/lib/iris/src/iris/cluster/static/controller/job-detail.js
@@ -36,12 +36,7 @@ function JobDetailApp() {
   const [selectedTaskIndex, setSelectedTaskIndex] = useState(null);
   const [taskLogs, setTaskLogs] = useState('Loading logs...');
   const [taskLogStatus, setTaskLogStatus] = useState('');
-  const autoSelectedRef = useRef(false);
-  const selectedTaskIndexRef = useRef(null);
-
-  useEffect(() => {
-    selectedTaskIndexRef.current = selectedTaskIndex;
-  }, [selectedTaskIndex]);
+  const tasksRef = useRef([]);
 
   const fetchTaskLogs = useCallback(async (taskIndex, tasksList) => {
     if (taskIndex === null || taskIndex === undefined || isNaN(taskIndex)) {
@@ -50,7 +45,7 @@ function JobDetailApp() {
       return;
     }
 
-    const selected = (tasksList || tasks).find(t => t.task_index === taskIndex);
+    const selected = tasksList.find(t => t.task_index === taskIndex);
     if (selected && (selected.state === 'pending' || selected.state === 'building')) {
       const label = selected.state === 'pending' ? 'Waiting to be scheduled' : 'Building container image';
       setTaskLogStatus(html`<span style="color:#9a6700;font-weight:500">${label}</span>`);
@@ -73,71 +68,69 @@ function JobDetailApp() {
       setTaskLogs('Failed to load logs: ' + e.message);
       setTaskLogStatus('');
     }
-  }, [tasks]);
+  }, []);
 
-  const refresh = useCallback(async () => {
-    try {
-      const [jobsResp, tasksResp] = await Promise.all([
-        controllerRpc('ListJobs'),
-        controllerRpc('ListTasks', { jobId }),
-      ]);
+  useEffect(() => {
+    async function load() {
+      try {
+        const [jobsResp, tasksResp] = await Promise.all([
+          controllerRpc('ListJobs'),
+          controllerRpc('ListTasks', { jobId }),
+        ]);
 
-      const jobs = (jobsResp.jobs || []).map(j => ({
-        job_id: j.jobId,
-        name: j.name || '',
-        state: stateToName(j.state),
-        failure_count: j.failureCount || 0,
-        error: j.error,
-        started_at_ms: parseInt(j.startedAtMs || 0),
-        finished_at_ms: parseInt(j.finishedAtMs || 0),
-        resources: {
-          cpu: j.resources ? j.resources.cpu : 0,
-          memory_bytes: j.resources ? parseInt(j.resources.memoryBytes || 0) : 0,
-        },
-      }));
+        const jobs = (jobsResp.jobs || []).map(j => ({
+          job_id: j.jobId,
+          name: j.name || '',
+          state: stateToName(j.state),
+          failure_count: j.failureCount || 0,
+          error: j.error,
+          started_at_ms: parseInt(j.startedAtMs || 0),
+          finished_at_ms: parseInt(j.finishedAtMs || 0),
+          resources: {
+            cpu: j.resources ? j.resources.cpu : 0,
+            memory_bytes: j.resources ? parseInt(j.resources.memoryBytes || 0) : 0,
+          },
+        }));
 
-      const tasksList = (tasksResp.tasks || []).map(t => ({
-        task_id: t.taskId,
-        task_index: t.taskIndex,
-        state: stateToName(t.state),
-        worker_id: t.workerId || '',
-        started_at_ms: parseInt(t.startedAtMs || 0),
-        finished_at_ms: parseInt(t.finishedAtMs || 0),
-        exit_code: t.exitCode,
-        error: t.error || '',
-        num_attempts: (t.attempts || []).length || 1,
-        pending_reason: t.pendingReason || '',
-      }));
+        const tasksList = (tasksResp.tasks || []).map(t => ({
+          task_id: t.taskId,
+          task_index: t.taskIndex,
+          state: stateToName(t.state),
+          worker_id: t.workerId || '',
+          started_at_ms: parseInt(t.startedAtMs || 0),
+          finished_at_ms: parseInt(t.finishedAtMs || 0),
+          exit_code: t.exitCode,
+          error: t.error || '',
+          num_attempts: (t.attempts || []).length || 1,
+          pending_reason: t.pendingReason || '',
+        }));
 
-      const found = jobs.find(j => j.job_id === jobId);
-      if (!found) {
-        setError('Job not found');
-        return;
-      }
-      setJob(found);
-      setTasks(tasksList);
-      setError(null);
-
-      // Auto-select most interesting task on first load
-      if (!autoSelectedRef.current && tasksList.length > 0) {
-        autoSelectedRef.current = true;
-        const failedTask = tasksList.find(t => t.state === 'failed' || t.state === 'worker_failed');
-        const runningTask = tasksList.find(t => t.state === 'running' || t.state === 'building');
-        const autoTask = failedTask || runningTask || tasksList[0];
-        if (autoTask !== undefined) {
-          setSelectedTaskIndex(autoTask.task_index);
-          fetchTaskLogs(autoTask.task_index, tasksList);
+        const found = jobs.find(j => j.job_id === jobId);
+        if (!found) {
+          setError('Job not found');
+          return;
         }
-      } else if (selectedTaskIndexRef.current !== null) {
-        // Re-fetch logs for currently selected task on refresh
-        fetchTaskLogs(selectedTaskIndexRef.current, tasksList);
-      }
-    } catch (e) {
-      setError('Failed to load job details: ' + e.message);
-    }
-  }, [fetchTaskLogs]);
+        setJob(found);
+        setTasks(tasksList);
+        tasksRef.current = tasksList;
+        setError(null);
 
-  useEffect(() => { refresh(); }, [refresh]);
+        // Auto-select most interesting task
+        if (tasksList.length > 0) {
+          const failedTask = tasksList.find(t => t.state === 'failed' || t.state === 'worker_failed');
+          const runningTask = tasksList.find(t => t.state === 'running' || t.state === 'building');
+          const autoTask = failedTask || runningTask || tasksList[0];
+          if (autoTask !== undefined) {
+            setSelectedTaskIndex(autoTask.task_index);
+            fetchTaskLogs(autoTask.task_index, tasksList);
+          }
+        }
+      } catch (e) {
+        setError('Failed to load job details: ' + e.message);
+      }
+    }
+    load();
+  }, [fetchTaskLogs]);
 
   const logsPreRef = useRef(null);
   useEffect(() => {
@@ -208,7 +201,7 @@ function JobDetailApp() {
       <select value=${selectedTaskIndex ?? ''} onChange=${e => {
         const idx = parseInt(e.target.value);
         setSelectedTaskIndex(isNaN(idx) ? null : idx);
-        fetchTaskLogs(isNaN(idx) ? null : idx, tasks);
+        fetchTaskLogs(isNaN(idx) ? null : idx, tasksRef.current);
       }}>
         <option value="">Select a task...</option>
         ${tasks.map(t => html`<option value=${t.task_index}>Task ${t.task_index} (${t.state})</option>`)}


### PR DESCRIPTION
- Fix infinite re-render loop in job detail page caused by circular `useCallback` dependency chain (`tasks` → `fetchTaskLogs` → `refresh` → `useEffect`). Each refresh set `tasks` state, recreating the entire chain and re-triggering the effect — causing constant flashing and killed jobs appearing as "404".
- Inline fetch logic into a single `useEffect` with stable dependencies that runs once on mount.
- Add a killed job scenario to the screenshot script for visual regression coverage.