### PR TITLE
Update latest Docker image to 20260129 to update pandas to 3.0.0

### DIFF
--- a/infra/marin-big-run.yaml
+++ b/infra/marin-big-run.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-central2-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260118"
+    image: "us-central2-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260129"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-eu-west4-a.yaml
+++ b/infra/marin-eu-west4-a.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "europe-west4-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260118"
+    image: "europe-west4-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260129"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-eu-west4.yaml
+++ b/infra/marin-eu-west4.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "europe-west4-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260118"
+    image: "europe-west4-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260129"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-us-central1.yaml
+++ b/infra/marin-us-central1.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-central1-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260118"
+    image: "us-central1-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260129"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-us-central2.yaml
+++ b/infra/marin-us-central2.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-central2-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260118"
+    image: "us-central2-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260129"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-us-east1.yaml
+++ b/infra/marin-us-east1.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-east1-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260118"
+    image: "us-east1-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260129"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-us-east5-a.yaml
+++ b/infra/marin-us-east5-a.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-east5-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260118"
+    image: "us-east5-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260129"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-us-east5.yaml
+++ b/infra/marin-us-east5.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-east5-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260118"
+    image: "us-east5-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260129"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/infra/marin-us-west4.yaml
+++ b/infra/marin-us-west4.yaml
@@ -24,7 +24,7 @@ provider:
 
 
 docker:
-    image: "us-west4-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260118"
+    image: "us-west4-docker.pkg.dev/hai-gcp-models/marin/marin_cluster:20260129"
     container_name: "ray_docker"
     pull_before_run: true
     worker_run_options:

--- a/lib/marin/src/marin/cluster/config.py
+++ b/lib/marin/src/marin/cluster/config.py
@@ -22,7 +22,7 @@ import jinja2
 import yaml
 
 # Cluster configuration constants and templates
-LATEST = "20260104"  # The latest docker tag used for the clusters
+LATEST = "20260129"  # The latest docker tag used for the clusters
 LATEST_VLLM = "20251209"
 DOCKER_TAG_TESTING = "latest"
 DEFAULT_IMAGE_NAME = "marin_cluster"


### PR DESCRIPTION
Fixes #2389 (#2421 tried to address it, but the changes weren't actually being reflected on the Ray clusters, so users still encountered the numpy/pandas incompatibility errors).

Context: The previous Docker image used pandas==1.5.3 which was incompatible with the current numpy version, causing runtime errors when importing pandas (or any libraries that imported pandas). This PR updates the base Docker image, which now uses pandas==3.0.0.

Built the Docker image (`20260129`) from main (commit 6c7fec054d3b6c29f3fa4e5420bf57584a9e1365). Tested on marin-us-east5-a-vllm (temporarily rebooted the cluster with this new Docker image and tested that training and vLLM-based evals both work).