### PR TITLE
Iris: Make logs a tab instead of separate page

### DIFF
--- a/lib/iris/scripts/screenshot-dashboard.py
+++ b/lib/iris/scripts/screenshot-dashboard.py
@@ -354,7 +354,7 @@ def capture_screenshots(dashboard_url: str, job_ids: dict[str, str], output_dir:
 
         # Screenshot controller logs page
         logger.info("Capturing controller logs page")
-        page.goto(f"{dashboard_url}/logs")
+        page.goto(f"{dashboard_url}#logs")
         page.wait_for_load_state("domcontentloaded")
         page.wait_for_function(
             "() => !document.body.textContent.includes('Loading')",

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -15,7 +15,7 @@
 """HTTP dashboard with Connect RPC and web UI.
 
 The dashboard serves:
-- Web UI at / (main dashboard)
+- Web UI at / (main dashboard with tabs: jobs, workers, endpoints, vms, autoscaler, logs)
 - Web UI at /job/{job_id} (job detail page)
 - Web UI at /vm/{vm_id} (VM detail page)
 - Connect RPC at /iris.cluster.ControllerService/* (called directly by JS)
@@ -75,7 +75,6 @@ class ControllerDashboard:
             Route("/", self._dashboard),
             Route("/job/{job_id}", self._job_detail_page),
             Route("/vm/{vm_id}", self._vm_detail_page),
-            Route("/logs", self._logs_page),
             Route("/health", self._health),
             Mount(rpc_wsgi_app.path, app=rpc_app),
             static_files_mount(),
@@ -90,9 +89,6 @@ class ControllerDashboard:
 
     def _vm_detail_page(self, _request: Request) -> HTMLResponse:
         return HTMLResponse(html_shell("VM Detail", "/static/controller/vm-detail.js"))
-
-    def _logs_page(self, _request: Request) -> HTMLResponse:
-        return HTMLResponse(html_shell("Iris Logs", "/static/controller/logs-page.js"))
 
     def _health(self, _request: Request) -> JSONResponse:
         """Health check endpoint for controller availability."""

--- a/lib/iris/src/iris/cluster/static/controller/app.js
+++ b/lib/iris/src/iris/cluster/static/controller/app.js
@@ -8,10 +8,11 @@ import { WorkersTab } from '/static/controller/workers-tab.js';
 import { EndpointsTab } from '/static/controller/endpoints-tab.js';
 import { VmsTab } from '/static/controller/vms-tab.js';
 import { AutoscalerTab } from '/static/controller/autoscaler-tab.js';
+import { LogsTab } from '/static/controller/logs-tab.js';
 
 const html = htm.bind(h);
 
-const VALID_TABS = ['jobs', 'workers', 'endpoints', 'vms', 'autoscaler'];
+const VALID_TABS = ['jobs', 'workers', 'endpoints', 'vms', 'autoscaler', 'logs'];
 
 function getInitialTab() {
   const hash = window.location.hash.slice(1);
@@ -108,6 +109,7 @@ function App() {
     endpoints: html`<${EndpointsTab} endpoints=${data.endpoints} />`,
     vms: html`<${VmsTab} groups=${(data.autoscaler.groups || [])} page=${vmsPage} onPageChange=${setVmsPage} />`,
     autoscaler: html`<${AutoscalerTab} autoscaler=${data.autoscaler} />`,
+    logs: html`<${LogsTab} />`,
   };
 
   return html`
@@ -118,7 +120,6 @@ function App() {
         <button class=${'tab-btn' + (activeTab === tab ? ' active' : '')}
                 onClick=${() => switchTab(tab)}>${tab.charAt(0).toUpperCase() + tab.slice(1)}</button>
       `)}
-      <a href="/logs" class="tab-btn" style="text-decoration:none">Logs</a>
       <button class="tab-btn" onClick=${refresh} style="margin-left:auto;font-size:14px">\u21bb Refresh</button>
     </div>
     <div class="tab-content active">

--- a/lib/iris/src/iris/cluster/static/controller/logs-tab.js
+++ b/lib/iris/src/iris/cluster/static/controller/logs-tab.js
@@ -1,10 +1,13 @@
-import { h, render } from 'preact';
+import { h } from 'preact';
 import htm from 'htm';
 import { controllerRpc } from '/static/shared/rpc.js';
 import { LogsApp } from '/static/shared/log-viewer.js';
+
 const html = htm.bind(h);
 
 const fetchLogs = (prefix, limit) =>
   controllerRpc('GetProcessLogs', { prefix, limit });
 
-render(html`<${LogsApp} fetchLogs=${fetchLogs} />`, document.getElementById('root'));
+export function LogsTab() {
+  return html`<${LogsApp} fetchLogs=${fetchLogs} />`;
+}


### PR DESCRIPTION
Convert logs from a separate page (/logs) to a client-side tab using hash-based routing (#logs). Eliminates the full page reload when navigating to logs.