### PR TITLE
Iris: Fix background thread logging errors during test teardown

### DIFF
--- a/lib/iris/src/iris/cluster/vm/scaling_group.py
+++ b/lib/iris/src/iris/cluster/vm/scaling_group.py
@@ -570,6 +570,14 @@ class ScalingGroup:
         """Whether this group can accept demand for waterfall routing."""
         return self.availability(timestamp_ms).status == GroupAvailability.AVAILABLE
 
+    def terminate_all(self) -> None:
+        """Terminate all VM groups in this scale group."""
+        with self._vm_groups_lock:
+            snapshot = list(self._vm_groups.values())
+            self._vm_groups.clear()
+        for vm_group in snapshot:
+            vm_group.terminate()
+
     def to_status(self) -> vm_pb2.ScaleGroupStatus:
         """Build a ScaleGroupStatus proto for the status API."""
         with self._vm_groups_lock:

--- a/lib/iris/tests/cli/test_cli.py
+++ b/lib/iris/tests/cli/test_cli.py
@@ -100,7 +100,8 @@ def _create_test_autoscaler(scale_group_name: str = "test-group"):
 def test_autoscaler():
     """Create a test Autoscaler for CLI testing."""
     autoscaler, fake_manager = _create_test_autoscaler()
-    return autoscaler, fake_manager
+    yield autoscaler, fake_manager
+    autoscaler.shutdown()
 
 
 @pytest.fixture


### PR DESCRIPTION
- Fix noisy `ValueError: I/O operation on closed file` errors from background threads during test teardown
- `Autoscaler.shutdown()` now terminates all VM groups (which stops worker heartbeat threads) after waiting for in-flight scale-ups
- Add `ScalingGroup.terminate_all()` for clean shutdown of all VM groups in a scale group
- Add context manager support to `Autoscaler` for use in tests
- Convert test fixtures to yield+shutdown for proper cleanup