### PR TITLE
Add fray.v2 API surface

### DIFF
--- a/lib/fray/docs/fix-ray-local.md
+++ b/lib/fray/docs/fix-ray-local.md
@@ -1,0 +1,171 @@
+# Diagnosis: Ray local tests trigger full package installation
+
+## 1. Files that set up `runtime_env` and how
+
+### `lib/fray/src/fray/v2/ray/backend.py` — `build_runtime_env()`
+
+This is the central function (line 168). It decides between two paths:
+
+```python
+if environment.pip_packages or extras:
+    # HEAVY PATH: calls build_runtime_env_for_packages(), sets working_dir
+    runtime_env = build_runtime_env_for_packages(extra=extras, pip_packages=..., env_vars=...)
+    runtime_env["working_dir"] = environment.workspace   # <-- zips entire workspace
+    runtime_env["excludes"] = [".git", "tests/", "docs/", "**/*.pack"]
+    runtime_env["config"] = {"setup_timeout_seconds": 1800}
+else:
+    # LIGHT PATH: just env_vars + PYTHONPATH
+    runtime_env = {"env_vars": env_vars}
+```
+
+The heavy path is triggered whenever `environment.pip_packages` or `extras` is non-empty.
+
+### `lib/fray/src/fray/v2/ray/deps.py` — `build_runtime_env_for_packages()`
+
+Runs `uv export --package marin ...` to compute frozen dependencies, writes a `requirements.txt` to `/tmp`, and returns a `RuntimeEnv` dict with `pip: {"packages": "/tmp/ray_reqs_xxx.txt"}`. This is what causes Ray to create a fresh virtualenv and install all packages from scratch in worker processes.
+
+### `lib/fray/src/fray/v2/types.py` — `create_environment()`
+
+Called as the default when `JobRequest.environment` is `None`. It always sets `workspace = os.getcwd()`. It does **not** set `extras` or `pip_packages` by default, so `create_environment()` alone does not trigger the heavy path.
+
+However, `build_runtime_env()` (in `backend.py`) appends extras based on the device type:
+
+- TPU jobs: appends `"tpu"` to extras
+- GPU jobs: appends `"gpu"` to extras
+- CPU jobs: no extras added, but the `EnvironmentConfig.__post_init__` validation means `workspace` is always set
+
+So **any GPU or TPU job** always hits the heavy path. CPU-only jobs hit the heavy path only if `pip_packages` or `extras` were explicitly set.
+
+### `lib/zephyr/tests/conftest.py`
+
+The Zephyr test fixtures call `ray.init(ignore_reinit_error=True)` with no `runtime_env` — this is fine. The `create_backend_context("ray")` creates a `RayBackendContext` which uses `ray.remote()` with no `runtime_env` at all. **Zephyr tests themselves are NOT the problem.**
+
+### `tests/integration_test.py`
+
+This file does the right thing for local mode:
+```python
+ray.init(resources={"head_node": 1}, runtime_env={"working_dir": None}, num_cpus=os.cpu_count())
+```
+The `{"working_dir": None}` explicitly disables workspace zipping.
+
+## 2. Why this triggers package installation
+
+When `build_runtime_env()` produces a dict with:
+- `"pip": {"packages": "/tmp/ray_reqs_xxx.txt"}` — Ray creates an isolated virtualenv and runs `pip install -r` with hundreds of frozen packages
+- `"working_dir": environment.workspace` — Ray zips up the entire workspace directory and ships it to workers
+
+On a local single-machine Ray cluster, all workers share the same filesystem and Python environment as the driver. The `runtime_env` is completely unnecessary — workers can import packages directly from the parent process's environment.
+
+The cost is:
+1. `uv export` subprocess (~seconds)
+2. Ray zipping the workspace (~seconds for a large monorepo)
+3. Ray creating a new virtualenv and installing all packages (~minutes)
+
+This happens on every `RayClient.submit()` call, which means every test that submits a job through `RayClient` pays this cost.
+
+## 3. Concrete code changes to fix it
+
+### Option A: Skip `runtime_env` entirely for local Ray (recommended)
+
+Add a `local` flag to `RayClient` and `build_runtime_env` that bypasses the heavy path.
+
+**File: `lib/fray/src/fray/v2/ray/backend.py`**
+
+Change `build_runtime_env` signature:
+
+```python
+def build_runtime_env(request: JobRequest, cluster_spec: str, *, local: bool = False) -> dict:
+```
+
+When `local=True`, skip the pip/working_dir setup entirely:
+
+```python
+def build_runtime_env(request: JobRequest, cluster_spec: str, *, local: bool = False) -> dict:
+    environment = request.environment if request.environment else create_environment()
+    env_vars = dict(environment.env_vars)
+    extras = list(environment.extras)
+
+    # ... existing JAX_PLATFORMS logic ...
+
+    env_vars["FRAY_CLIENT_SPEC"] = cluster_spec
+
+    if local:
+        return {"env_vars": env_vars}
+
+    # ... existing pip_packages/extras logic ...
+```
+
+Add a `local` parameter to `RayClient.__init__`:
+
+```python
+class RayClient:
+    def __init__(self, address: str = "auto", namespace: str | None = None, local: bool = False):
+        self._local = local
+        # ...
+```
+
+Thread it through `_launch_binary_job`, `_launch_callable_job`, `_launch_tpu_job`:
+
+```python
+runtime_env = build_runtime_env(request, self._get_client_spec(), local=self._local)
+```
+
+**Detection heuristic**: `local=True` when `address` resolves to a local Ray instance. The simplest approach: check if `ray.is_initialized()` was called without a remote address, or let callers pass it explicitly. The integration test already does `ray.init(...)` locally, so `RayClient(local=True)` is natural.
+
+### Option B: Use `MARIN_CI_DISABLE_RUNTIME_ENVS` env var
+
+There is already a reference to this env var in `create_environment()` (line 407 of types.py), but it is only captured into `env_vars` — it is never checked to skip runtime env construction.
+
+Wire it up in `build_runtime_env`:
+
+```python
+def build_runtime_env(request: JobRequest, cluster_spec: str) -> dict:
+    environment = request.environment if request.environment else create_environment()
+    env_vars = dict(environment.env_vars)
+
+    # ... existing logic ...
+
+    env_vars["FRAY_CLIENT_SPEC"] = cluster_spec
+
+    disable_runtime_envs = os.environ.get("MARIN_CI_DISABLE_RUNTIME_ENVS", "").lower() in ("1", "true")
+    if disable_runtime_envs:
+        return {"env_vars": env_vars}
+
+    # ... rest of existing logic ...
+```
+
+This is simpler but less explicit than Option A.
+
+### Option C: Combine both
+
+Add the `local` flag (Option A) AND check the env var (Option B) as a fallback. The `local` flag is the primary mechanism; the env var is a belt-and-suspenders escape hatch for CI.
+
+### Test fixture changes
+
+For fray tests that submit jobs via `RayClient`, use:
+
+```python
+@pytest.fixture(scope="module")
+def ray_client():
+    ray.init(ignore_reinit_error=True)
+    client = RayClient(local=True)
+    yield client
+```
+
+For the integration test, change:
+```python
+set_current_client(RayClient(local=True))
+```
+
+## 4. Summary
+
+| Path | Role | Problem? |
+|------|------|----------|
+| `backend.py:build_runtime_env` | Builds runtime_env dict | Yes - always builds pip env for GPU/TPU jobs |
+| `deps.py:build_runtime_env_for_packages` | Runs `uv export`, writes requirements.txt | Yes - called by above |
+| `deps.py:build_python_path` | Builds PYTHONPATH for light path | No |
+| `context.py:RayBackendContext` | Zephyr's ray.remote wrapper | No - no runtime_env |
+| `zephyr/tests/conftest.py` | Zephyr test fixtures | No - plain ray.init() |
+| `types.py:create_environment` | Default env config | No directly, but captures unused `MARIN_CI_DISABLE_RUNTIME_ENVS` |
+
+The fix is straightforward: add a `local` mode to `RayClient` that skips `runtime_env` construction entirely, since local Ray workers inherit the driver's filesystem and packages.

--- a/lib/fray/docs/fray-lite-design.md
+++ b/lib/fray/docs/fray-lite-design.md
@@ -1,0 +1,1051 @@
+# Fray-Lite Design
+
+**Status**: Draft (v5, updated migration plan)
+**Issue**: [#2552](https://github.com/marin-community/marin/issues/2552)
+**Research**: [fray-lite-research.md](fray-lite-research.md)
+**Related**: [#2553](https://github.com/marin-community/marin/issues/2553) — Iris preemptible worker attribute (✅ done)
+
+## Overview
+
+Fray-lite is a minimal Fray V2 interface that supports our three primary
+workloads (Zephyr data processing, RL training, Levanter training) and can be
+backed by either Ray or Iris. It lives in `fray.v2` alongside the existing
+`fray` code, allowing incremental migration.
+
+## API Surface
+
+The entire public API consists of:
+
+1. **`Client`** — submit jobs and create actors
+2. **`ActorHandle`** — call actor methods with `.remote()` shim (Protocol)
+3. **`ResourceConfig`** — resource requirements per job/actor
+4. **`JobHandle`** — wait for / monitor submitted jobs
+
+### Client
+
+```python
+# fray/v2/client.py
+
+class Client(Protocol):
+    def submit(self, request: JobRequest) -> JobHandle:
+        """Submit a job for execution. Returns immediately."""
+        ...
+
+    def create_actor(
+        self,
+        actor_class: type,
+        *args,
+        name: str,
+        resources: ResourceConfig = ResourceConfig(),
+        **kwargs,
+    ) -> ActorHandle:
+        """Create a named actor instance. Returns a deferred handle immediately.
+
+        The handle is usable right away — the first .remote() call will block
+        until the actor's name is registered (i.e. the actor job has started
+        and the actor server is serving). Internally polls for name registration.
+
+        Sugar for create_actor_group(..., count=1).handles[0].
+        The caller is responsible for creating actors — there is no implicit
+        singleton/get-if-exists behavior.
+        """
+        ...
+
+    def create_actor_group(
+        self,
+        actor_class: type,
+        *args,
+        name: str,
+        count: int,
+        resources: ResourceConfig = ResourceConfig(),
+        **kwargs,
+    ) -> ActorGroup:
+        """Create N instances of an actor, returning a group handle.
+
+        Returns immediately. Each instance runs as a separate job (named
+        "{name}-0", "{name}-1", ...). The group exposes individual handles
+        as they become ready; callers use wait_ready() to block until enough
+        actors are available. Callers (e.g. Zephyr) coordinate work
+        distribution and fault tolerance themselves.
+        """
+        ...
+
+    def shutdown(self, wait: bool = True) -> None:
+        """Shutdown the client and all managed resources."""
+        ...
+
+
+def current_client() -> Client:
+    """Get the current client from context or environment.
+
+    Resolution order:
+    1. Explicitly set client (via set_current_client or context manager)
+    2. FRAY_CLIENT_SPEC environment variable (see format below)
+    3. LocalClient (default)
+
+    FRAY_CLIENT_SPEC format:
+        "local"                             → LocalClient()
+        "local?threads=4"                   → LocalClient(max_threads=4)
+        "ray"                               → RayClient(address="auto")
+        "ray?namespace=my-ns"               → RayClient(namespace="my-ns")
+        "iris://controller:10000"           → FrayIrisClient("controller:10000")
+        "iris://controller:10000?ws=/path"  → FrayIrisClient("controller:10000", workspace="/path")
+    """
+    ...
+
+
+def wait_all(
+    jobs: Sequence[JobHandle],
+    *,
+    timeout: float | None = None,
+    raise_on_failure: bool = True,
+) -> list[JobStatus]:
+    """Wait for all jobs to complete. Returns when all finish or one fails.
+
+    Unlike sequential job.wait() calls, this monitors all jobs concurrently
+    and raises immediately if any job fails (when raise_on_failure=True),
+    without waiting for earlier jobs to finish first.
+    """
+    ...
+```
+
+### ResourceConfig
+
+v2 copies the type definitions from v1 into `fray/v2/types.py`. The following
+files from v1 (`fray.cluster.base`) are copied:
+
+- `ResourceConfig`, `DeviceConfig`, `CpuConfig`, `GpuConfig`, `TpuConfig`
+- `EnvironmentConfig`
+- `Entrypoint`, `BinaryEntrypoint`, `CallableEntrypoint`
+- `JobRequest`, `JobStatus`
+
+These are standalone dataclasses with no v1 backend dependencies, so the copy is
+mechanical. After Phase 6 (cleanup), v1 types are deleted.
+
+`ResourceConfig` describes the resources for a single task/replica. The
+`replicas` field has been moved to `JobRequest` (see below) since it controls
+job-level gang scheduling, not per-task resources.
+
+Under Iris, `preemptible=False` maps to a constraint
+`Constraint(key="preemptible", op=EQ, value="false")` once workers expose
+their preemptibility as an attribute ([#2553](https://github.com/marin-community/marin/issues/2553)).
+
+```python
+@dataclass
+class ResourceConfig:
+    cpu: int = 1
+    ram: str = "128m"
+    disk: str = "1g"
+    device: DeviceConfig = field(default_factory=CpuConfig)
+    preemptible: bool = True    # Maps to Iris constraint, Ray head_node pinning
+    regions: Sequence[str] | None = None
+```
+
+### JobRequest & JobHandle
+
+```python
+# fray/v2/types.py
+
+@dataclass
+class JobRequest:
+    name: str
+    entrypoint: Entrypoint
+    resources: ResourceConfig = field(default_factory=ResourceConfig)
+    environment: EnvironmentConfig | None = None
+    replicas: int = 1  # Gang-scheduled replicas (TPU slices). Maps to Ray
+                        # run_on_pod num_slices, Iris LaunchJobRequest.replicas.
+    max_retries_failure: int = 0
+    max_retries_preemption: int = 100
+
+
+class JobHandle(Protocol):
+    @property
+    def job_id(self) -> str: ...
+
+    def wait(self, timeout: float | None = None, *, raise_on_failure: bool = True) -> JobStatus:
+        """Block until job completes. Default timeout is None (wait forever)."""
+        ...
+
+    def status(self) -> JobStatus: ...
+
+    def terminate(self) -> None: ...
+
+
+class JobStatus(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    STOPPED = "stopped"
+```
+
+### ActorHandle
+
+The `ActorHandle` provides a `.remote()` shim so existing RL code needs
+minimal changes. Under the hood, it translates to synchronous RPC calls
+(Iris ActorClient) or Ray actor refs.
+
+Both `ActorHandle` and `ActorMethod` are Protocols so that backend-specific
+implementations (Ray, Iris, Local) can be type-checked without inheritance.
+
+```python
+# fray/v2/actor.py
+
+class ActorHandle(Protocol):
+    """Handle to a remote actor with .method.remote() calling convention.
+
+    Handles are deferred: they can be created before the actor is ready.
+    The first RPC call blocks until the actor's name is registered.
+    Handles are picklable for passing to worker jobs.
+    """
+
+    def __getattr__(self, method_name: str) -> ActorMethod:
+        ...
+
+
+class ActorMethod(Protocol):
+    def remote(self, *args, **kwargs) -> ActorFuture:
+        """Invoke the method remotely. Returns a future."""
+        ...
+
+    def __call__(self, *args, **kwargs) -> Any:
+        """Invoke the method synchronously (blocking)."""
+        ...
+
+
+class ActorFuture:
+    """Future for an actor method call."""
+
+    def result(self, timeout: float | None = None) -> Any:
+        """Block until result is available."""
+        ...
+
+
+class ActorGroup:
+    """Group of actor instances. Callers coordinate work distribution themselves.
+
+    Returned immediately from create_actor_group(). Actors become available
+    asynchronously; use wait_ready() to get a stable snapshot of ready handles.
+    """
+
+    @property
+    def ready_count(self) -> int:
+        """Number of actors that have started and are available for RPC."""
+        ...
+
+    def wait_ready(self, count: int | None = None, timeout: float = 300.0) -> list[ActorHandle]:
+        """Block until `count` actors are ready (default: all).
+
+        Returns a frozen snapshot of ready handles. The returned list is stable
+        — it will not change as more actors come up. Call wait_ready() again
+        to get a new snapshot with additional actors.
+        """
+        ...
+
+    @property
+    def jobs(self) -> list[JobHandle]:
+        """Underlying job handles for lifecycle management."""
+        ...
+
+    def statuses(self) -> list[JobStatus]:
+        """Return the job status of each actor in the group.
+
+        Useful for detecting dead actors (FAILED/STOPPED) so callers can
+        reassign work or request replacement.
+        """
+        return [job.status() for job in self.jobs]
+
+    def shutdown(self) -> None:
+        """Terminate all actor jobs."""
+        for job in self.jobs:
+            job.terminate()
+```
+
+Note: `ActorGroup` is intentionally thin — it does NOT provide round-robin or
+broadcast. Callers like Zephyr implement their own dispatch, retry, and
+rebalancing logic. This avoids baking scheduling policy into the framework.
+
+## Backend Implementations
+
+### LocalClient
+
+For development and testing. Runs jobs as threads/subprocesses, actors as
+in-process objects with lock-based thread safety.
+
+```python
+class LocalClient(Client):
+    def submit(self, request: JobRequest) -> JobHandle:
+        # Run entrypoint in a thread or subprocess
+        ...
+
+    def create_actor(self, actor_class, *args, name, resources, **kwargs) -> ActorHandle:
+        # Create instance in-process, wrap with lock for thread safety
+        # Return ActorHandle that calls methods directly (no network)
+        ...
+```
+
+### RayClient
+
+Wraps Ray cluster functionality. Jobs become Ray jobs, actors become Ray actors.
+
+v2 copies the Ray integration code from v1 into `fray/v2/ray/` as a clean
+break. This avoids a layering violation (v2 depending on v1) and lets us
+mutate freely during migration. The v1 originals are deleted in Phase 6.
+
+**Files copied from v1 → v2:**
+
+| v1 source | v2 destination | What it provides |
+|-----------|---------------|------------------|
+| `fray.cluster.ray.cluster` | `fray.v2.ray.backend` | Job routing (TPU/binary/callable), runtime env setup |
+| `fray.cluster.ray.deps` | `fray.v2.ray.deps` | `build_runtime_env_for_packages`, PYTHONPATH computation |
+| `fray.cluster.ray.resources` | `fray.v2.ray.resources` | `as_remote_kwargs`, scheduling strategy helpers |
+| `fray.cluster.ray.tpu.execution` | `fray.v2.ray.tpu` | `run_on_pod_ray`, `SliceActor`, `TPUHostActor`, retry logic |
+| `fray.fn_thunk` | `fray.v2.ray.fn_thunk` | Callable → pickle → CLI entrypoint serialization |
+| `fray.cluster.ray.auth` | `fray.v2.ray.auth` | Ray token authentication |
+
+**Not copied** (unused by v2): dashboard proxy, cluster config discovery,
+`monitor()` log streaming, `Cluster` base class, `LocalCluster`.
+
+```python
+class RayClient(Client):
+    def submit(self, request: JobRequest) -> JobHandle:
+        # Routes to _launch_tpu_job / _launch_binary_job / _launch_callable_job
+        # (logic copied from v1 RayCluster.launch)
+        # Handles TPU jobs via run_on_pod
+        # JobRequest.replicas → run_on_pod num_slices
+        # max_retries = max_retries_failure + max_retries_preemption
+        ...
+
+    def create_actor(self, actor_class, *args, name, resources, **kwargs) -> ActorHandle:
+        # Returns a deferred RayActorHandle immediately
+        # Internally: ray.remote(actor_class).options(name=name, ...).remote(...)
+        # The handle wraps the Ray actor ObjectRef; first .remote() call
+        # blocks until the actor is scheduled.
+        # Map resources to Ray options:
+        #   resources.preemptible=False → {"resources": {"head_node": 0.0001}}
+        #   resources.cpu → num_cpus (default 0 for actors)
+        ...
+```
+
+### IrisClient (wraps `iris.client.IrisClient`)
+
+The fray-lite `IrisClient` sits on top of the existing Iris client library.
+The Iris client already provides job submission, endpoint registry, and
+resolver — we wrap it rather than reimplementing.
+
+`create_actor` delegates to `create_actor_group(..., count=1)`. Only
+`create_actor_group` contains Iris-specific logic.
+
+```python
+class FrayIrisClient(Client):
+    """Iris cluster backend. Wraps iris.client.IrisClient."""
+
+    def __init__(self, controller_address: str, workspace: Path | None = None):
+        self._iris = IrisClientLib.remote(controller_address, workspace=workspace)
+
+    def submit(self, request: JobRequest) -> JobHandle:
+        # Convert ResourceConfig → Iris ResourceSpec
+        #   resources.preemptible=False → Constraint(key="preemptible", op=EQ, value="false")
+        # Convert Entrypoint → Iris Entrypoint
+        # JobRequest.replicas → Iris LaunchJobRequest.replicas
+        # Submit via self._iris.submit(...)
+        # Return JobHandle wrapping iris.client.Job
+        ...
+
+    def create_actor_group(self, actor_class, *args, name, count, resources, **kwargs) -> ActorGroup:
+        # 1. Submit `count` Iris jobs, each running _host_actor entrypoint
+        #    with ports=["actor"]. Jobs named "{name}-0", "{name}-1", ...
+        # 2. Return ActorGroup immediately
+        # 3. ActorGroup.wait_ready() polls resolver for endpoint availability
+        # 4. As endpoints appear, wait_ready() returns IrisActorHandles
+        ...
+```
+
+The actor hosting entrypoint:
+
+```python
+def _host_actor(actor_class, args, kwargs, name):
+    """Entrypoint for actor-hosting Iris jobs.
+
+    If actor_class.__init__ raises, the job exits non-zero immediately
+    rather than blocking forever with a dead actor.
+    """
+    from iris.actor import ActorServer
+    from iris.client import iris_ctx
+
+    ctx = iris_ctx()
+
+    # Init outside try — let failures propagate and kill the job
+    instance = actor_class(*args, **kwargs)
+
+    server = ActorServer(host="0.0.0.0", port=ctx.get_port("actor"))
+    server.register(name, instance)
+    server.serve_background()
+
+    # Register endpoint for discovery via Iris controller
+    address = f"{_get_host_ip()}:{server.port}"
+    ctx.registry.register(name, address)
+
+    # Actor stays alive until its job is terminated via JobHandle.terminate()
+    # or ActorGroup.shutdown(). No separate control channel needed — job
+    # termination kills the container.
+    server.wait_for_termination()
+```
+
+The `ActorHandle` for Iris wraps `iris.actor.ActorClient`:
+
+```python
+class IrisActorHandle(ActorHandle):
+    """Handle to an Iris-hosted actor.
+
+    Deferred: the handle is created with just a name. On first use, it
+    resolves the name via iris_ctx().resolver to find the actor's address.
+
+    Serialization: pickles as (actor_name,). On unpickle, reconstructs
+    from the current IrisContext (available in any Iris job via iris_ctx()).
+    This means handles are only usable within the same Iris namespace —
+    which is always the case since child jobs inherit the parent's namespace.
+    """
+
+    def __init__(self, actor_name: str, client: IrisActorClient | None = None):
+        self._actor_name = actor_name
+        self._client = client  # Lazily resolved on first use if None
+
+    def _resolve(self) -> IrisActorClient:
+        if self._client is None:
+            from iris.client import iris_ctx
+            from iris.actor import ActorClient
+            ctx = iris_ctx()
+            self._client = ActorClient(ctx.resolver, self._actor_name)
+        return self._client
+
+    def __getattr__(self, method_name: str) -> ActorMethod:
+        return _IrisActorMethod(self, method_name)
+
+    def __getstate__(self):
+        return {"actor_name": self._actor_name}
+
+    def __setstate__(self, state):
+        self._actor_name = state["actor_name"]
+        self._client = None  # Will resolve lazily via iris_ctx()
+
+
+class _IrisActorMethod(ActorMethod):
+    def remote(self, *args, **kwargs) -> ActorFuture:
+        # Run the synchronous Iris RPC call in a thread pool to return
+        # a non-blocking future. The Iris ActorClient already handles
+        # timeouts internally; we use its timeout and don't add a second one.
+        client = self._handle._resolve()
+        executor = _get_shared_executor()
+        future = executor.submit(
+            lambda: getattr(client, self._method)(*args, **kwargs)
+        )
+        return ActorFuture(future)
+
+    def __call__(self, *args, **kwargs) -> Any:
+        client = self._handle._resolve()
+        return getattr(client, self._method)(*args, **kwargs)
+```
+
+## Zephyr Migration
+
+Zephyr currently uses `JobContext.put/get/run/wait` to dispatch `run_stage`
+calls to Ray workers. Under fray-lite, Zephyr will instead:
+
+1. **Launch N worker jobs** via `client.create_actor_group()`, each hosting a
+   `ZephyrWorker` actor
+2. **Dispatch `run_stage` calls** to individual workers — Zephyr coordinates
+   which worker gets which shard
+3. **Manage fault tolerance** itself — if a worker fails, retry the shard on
+   another worker
+4. **Pass data via shared storage** (GCS paths), not via RPC args — workers
+   read/write shard data from GCS, the RPC call just passes the path/metadata.
+   This avoids serializing large datasets through cloudpickle over HTTP.
+
+```python
+class ActorBackend:
+    """Distributed Zephyr backend using fray-lite actor groups.
+
+    Use as a context manager to ensure actor cleanup:
+
+        with ActorBackend(client, 8, resources) as backend:
+            backend.execute(dataset, hints)
+    """
+
+    def __init__(self, client: Client, num_workers: int, resources: ResourceConfig):
+        self.group = client.create_actor_group(
+            ZephyrWorker,
+            name="zephyr-worker",
+            count=num_workers,
+            resources=resources,
+        )
+
+    def __enter__(self) -> ActorBackend:
+        return self
+
+    def __exit__(self, *exc):
+        self.group.shutdown()
+
+    def execute(self, dataset: Dataset, hints: ExecutionHint) -> Sequence:
+        handles = self.group.wait_ready()
+        plan = compute_plan(dataset, hints)
+        shards = self._shards_from_source_items(plan.source_items)
+        for stage in plan.stages:
+            shards = self._execute_stage(stage, shards, hints, handles)
+        return list(self._materialize(shards))
+
+    def _execute_stage(self, stage, shards, hints, handles):
+        # Assign shards to workers round-robin
+        # Each worker reads shard data from shared storage, processes, writes back
+        # On worker failure, reassign shard to another worker
+        futures = []
+        for i, shard in enumerate(shards):
+            worker = handles[i % len(handles)]
+            future = worker.run_stage.remote(shard.storage_path, stage.operations)
+            futures.append((future, shard, i))
+        # Collect results, retry failures on other workers
+        ...
+
+
+class ZephyrWorker:
+    """Actor that executes Zephyr stage operations.
+
+    Workers read input from and write output to shared storage (GCS).
+    The RPC call passes storage paths, not data.
+    """
+
+    def run_stage(self, input_path: str, operations: list[PhysicalOp]) -> str:
+        """Process a shard and return the output path."""
+        data = read_from_storage(input_path)
+        result = apply_operations(data, operations)
+        output_path = write_to_storage(result)
+        return output_path
+```
+
+The existing `Backend` class with `JobContext` remains available for local/test
+use (ThreadContext, SyncContext). The `ActorBackend` is used for distributed
+execution on Iris or Ray clusters.
+
+## RL Migration
+
+### Actor creation moves to the controller job
+
+In v1, actors are created with `get_if_exists=True` — any worker can create or
+reconnect to a shared actor. In v2, actors are created **only** from the
+controller job (`rl_job.py`) and **passed to workers** as arguments. This
+eliminates the need for `get_if_exists` and makes the data flow explicit.
+
+### Before (v1) — in `curriculum.py` (called from any worker)
+
+```python
+from fray.job import get_default_job_ctx
+
+job_ctx = get_default_job_ctx()
+actor = job_ctx.create_actor(
+    Curriculum, config,
+    name="curriculum",
+    get_if_exists=True,
+    preemptible=False,
+    num_cpus=0,
+)
+future = actor.sample_lesson.remote(seed)
+result = job_ctx.get(future)
+```
+
+### After (v2) — actor created in `rl_job.py`, passed to workers
+
+```python
+# In rl_job.py (controller):
+from fray.v2 import current_client
+
+client = current_client()
+
+# create_actor returns a deferred handle immediately; first .remote()
+# call will block until the actor is registered and serving.
+curriculum_actor = client.create_actor(
+    Curriculum, config,
+    name="curriculum",
+    resources=ResourceConfig(preemptible=False),
+)
+
+# Pass the actor handle to worker entrypoints
+def make_rollout_task(curriculum: ActorHandle, worker_idx: int):
+    def task():
+        # Worker uses the handle directly — no discovery needed
+        future = curriculum.sample_lesson.remote(seed)
+        result = future.result()
+    return task
+
+for i in range(N):
+    client.submit(JobRequest(
+        name=f"rollout-{i}",
+        entrypoint=Entrypoint.from_callable(make_rollout_task(curriculum_actor, i)),
+        resources=rollout_resources,
+    ))
+```
+
+### Migration summary for RL code
+
+| v1 | v2 |
+|----|-----|
+| `get_default_job_ctx()` | `current_client()` (controller only) |
+| `ctx.create_actor(..., get_if_exists=True)` | `client.create_actor(...)` (controller creates, workers receive) |
+| `preemptible=False, num_cpus=0` | `resources=ResourceConfig(preemptible=False)` |
+| `actor.method.remote()` | `actor.method.remote()` (unchanged) |
+| `ctx.get(future)` | `future.result()` |
+
+### Job orchestration (`rl_job.py`)
+
+```python
+# Before
+cluster = current_cluster()
+jobs = []
+jobs.append(cluster.launch(JobRequest(name="train", ...)))
+for i in range(N):
+    jobs.append(cluster.launch(JobRequest(name=f"rollout-{i}", ...)))
+cluster.wait(jobs, raise_on_failure=True)
+
+# After
+client = current_client()
+
+# Create shared actors first (deferred handles — no blocking here)
+curriculum = client.create_actor(Curriculum, config, name="curriculum",
+                                  resources=ResourceConfig(preemptible=False))
+weight_coord = client.create_actor(WeightTransferCoordinator, name="wt-coord",
+                                    resources=ResourceConfig(preemptible=False))
+
+# Launch workers, passing actor handles
+jobs = []
+jobs.append(client.submit(JobRequest(name="train",
+    entrypoint=Entrypoint.from_callable(train_task, args=[curriculum, weight_coord]),
+    resources=train_resources)))
+for i in range(N):
+    jobs.append(client.submit(JobRequest(name=f"rollout-{i}",
+        entrypoint=Entrypoint.from_callable(rollout_task, args=[i, curriculum, weight_coord]),
+        resources=rollout_resources)))
+
+# Wait for all concurrently — fails fast if any job fails
+wait_all(jobs, raise_on_failure=True)
+```
+
+## Levanter Training Migration
+
+Minimal change — just swap cluster for client:
+
+```python
+# Before
+cluster = current_cluster()
+job_id = cluster.launch(JobRequest(...))
+cluster.wait(job_id, raise_on_failure=True)
+
+# After
+client = current_client()
+job = client.submit(JobRequest(...))
+job.wait(raise_on_failure=True)
+```
+
+## Migration Plan
+
+The plan follows a **spiral** approach: each phase produces independently
+testable, shippable work. We build v2 core + Ray first, migrate all three
+workloads on Ray, then add the Iris backend as a separate track. This lets us
+validate the API surface against real callers before adding a second backend.
+
+### Phase 0: Iris Prerequisites ✅ DONE
+
+Both Iris prerequisites are complete:
+
+1. **Preemptible worker attribute** ([#2553](https://github.com/marin-community/marin/issues/2553)) ✅ —
+   Workers now expose `preemptible=true|false` via `env_probe.py`. The helper
+   `preemptible_constraint()` in `iris.cluster.types` creates the scheduling
+   constraint. Detection queries GCP metadata, falls back to
+   `IRIS_WORKER_ATTRIBUTES` env var.
+
+2. **`replicas` on `ResourceSpec`** ✅ — `iris.cluster.types.ResourceSpec` has
+   `replicas: int = 0` which maps to the proto. (Note: Iris keeps `replicas`
+   on `ResourceSpec` rather than `LaunchJobRequest` — fray-lite's
+   `JobRequest.replicas` will map to `ResourceSpec.replicas` during conversion.)
+
+### Phase 1: Core Interface + LocalClient + Smoke Test
+
+**Goal**: A working `fray.v2` package that passes tests with `LocalClient`.
+This is the foundation everything else builds on.
+
+**Spiral step 1a — Types + Client protocol + LocalClient submit:**
+
+1. Create `fray/v2/` package with `__init__.py`, `types.py`, `client.py`
+2. Copy type definitions from v1 `fray.cluster.base` into `fray/v2/types.py`:
+   - `ResourceConfig` (remove `replicas` field), `DeviceConfig`, `CpuConfig`,
+     `GpuConfig`, `TpuConfig`
+   - `EnvironmentConfig`
+   - `Entrypoint`, `BinaryEntrypoint`, `CallableEntrypoint`
+   - `JobRequest` (add `replicas: int = 1`), `JobStatus`
+3. Define `Client` protocol and `JobHandle` protocol in `client.py`
+4. Implement `LocalClient.submit()` — run `CallableEntrypoint` in a thread,
+   return a `LocalJobHandle` that wraps `concurrent.futures.Future`
+5. Implement `wait_all()`
+6. Write tests: submit callable job, wait, check status transitions, wait_all
+   with mixed success/failure
+
+**Spiral step 1b — Actors:**
+
+1. Create `actor.py` with `ActorHandle`, `ActorMethod`, `ActorFuture`,
+   `ActorGroup` protocols
+2. Implement `LocalClient.create_actor()` — instantiate class in-process,
+   wrap with `threading.Lock` for thread safety, return `LocalActorHandle`
+3. Implement `LocalClient.create_actor_group()` — N in-process instances
+4. Write tests: create actor, call `.method.remote()`, verify result;
+   create group, `wait_ready()`, dispatch to multiple actors
+
+**Spiral step 1c — current_client + FRAY_CLIENT_SPEC:**
+
+1. Implement `current_client()` with context var + env var resolution
+2. Implement `set_current_client()` context manager
+3. Write tests: default → LocalClient, explicit set, env var parsing
+
+**Deliverable**: `LocalClient` passing all protocol tests. Callers can
+`pip install` and use `fray.v2` for local development immediately.
+
+### Phase 2: Ray Backend
+
+**Goal**: `RayClient` that can submit jobs and create actors on a Ray cluster.
+Validated against a local Ray cluster.
+
+**Spiral step 2a — Job submission:**
+
+1. Copy v1 Ray code into `fray/v2/ray/` (see files table above):
+   `backend.py`, `deps.py`, `resources.py`, `tpu.py`, `fn_thunk.py`, `auth.py`
+2. Implement `RayClient.submit()` — route to TPU/binary/callable launchers
+   based on device type
+3. Map `JobRequest.replicas` → `run_on_pod num_slices`
+4. Map `max_retries_failure + max_retries_preemption` → Ray retry count
+5. Implement `RayJobHandle` wrapping Ray job ID with poll-based `wait()`
+6. Test: submit a callable job to local Ray, verify completion
+
+**Spiral step 2b — Actor support:**
+
+1. Implement `RayClient.create_actor()` — `ray.remote(cls).options(...).remote()`
+2. Implement `RayActorHandle` wrapping Ray actor ObjectRef with `.remote()` shim
+3. Map `preemptible=False` → `resources={"head_node": 0.0001}`
+4. Implement `RayClient.create_actor_group()` — N Ray actors
+5. Test: create actor on local Ray, call methods, verify results
+
+**Spiral step 2c — FRAY_CLIENT_SPEC integration:**
+
+1. Wire `"ray"` and `"ray?namespace=..."` into `current_client()` resolution
+2. Test: set env var, get RayClient
+
+**Deliverable**: `RayClient` passing the same protocol tests as `LocalClient`,
+plus Ray-specific integration tests.
+
+### Phase 3: Migrate Levanter Training (simplest caller)
+
+**Goal**: `marin.training.training` uses `fray.v2` instead of `fray.cluster`.
+This is the easiest migration — pure job submission, no actors.
+
+1. Update `marin/training/training.py`:
+   - `from fray.cluster import ... current_cluster` → `from fray.v2 import ... current_client`
+   - `cluster = current_cluster()` → `client = current_client()`
+   - `cluster.launch(request)` → `client.submit(request)` (returns `JobHandle`)
+   - `cluster.wait(job_id, ...)` → `job.wait(...)`
+2. Update `ResourceConfig` usage: `replicas` moves from `ResourceConfig` to
+   `JobRequest`. v1's `ResourceConfig.with_tpu(...)` sets `replicas` based on
+   topology — v2 equivalent passes `replicas` to `JobRequest` instead.
+3. Run existing Levanter tests to verify no regression.
+
+**Deliverable**: Levanter training works on Ray via `fray.v2`. Can be tested
+end-to-end with `FRAY_CLIENT_SPEC=ray`.
+
+
+### Phase 4: Migrate Zephyr
+
+**Goal**: Zephyr uses `fray.v2` for distributed execution. `JobContext` is
+deleted — Zephyr moves to the `ActorBackend` model with long-lived worker
+actors that receive shard assignments via RPC.
+
+**Current Zephyr architecture** (from `backends.py`, `plan.py`):
+- `Backend` class wraps a `JobContext` (SyncContext, ThreadContext, or RayContext)
+- `context.put(obj)` / `context.get(ref)` — object store for data references
+- `context.run(fn, *args)` — submit a task, returns a future/generator
+- `context.wait(refs, num_returns=1)` — wait for N results, streaming style
+- `run_stage()` is the worker function that processes shards
+
+**Spiral step 4a — ActorBackend + ZephyrWorker:**
+
+1. Implement `ActorBackend` in `zephyr/backends.py` (as designed in the
+   Zephyr Migration section above) using `client.create_actor_group()`
+2. Implement `ZephyrWorker` actor that runs `run_stage` on storage paths
+3. Replace `Backend._execute_stage()` dispatch logic with actor RPC calls
+4. Wire `ActorBackend` into Zephyr's `cli.py` for distributed backends
+5. Run Zephyr test suite with `ActorBackend` + `LocalClient`
+
+**Spiral step 4b — Delete JobContext:**
+
+1. Remove `fray.job.context` (SyncContext, ThreadContext, RayContext)
+2. Remove all `fray.job` imports from Zephyr
+3. Keep a simple in-process `SyncBackend` / `ThreadBackend` for local
+   testing that doesn't use `JobContext` — these call `run_stage` directly
+4. Run full Zephyr test suite
+
+**Deliverable**: Zephyr works on Ray via `fray.v2` with `ActorBackend`.
+`
+### Phase 5: Migrate RL Training
+
+**Goal**: `marin.rl` fully migrated to `fray.v2` in one shot — job submission,
+actor creation, and all worker call sites. No mixed v1/v2 usage.
+
+**Current RL architecture** (from `rl_job.py`):
+- `RLJob.run()` calls `current_cluster().launch()` for 1 train job + N rollout jobs
+- `cluster.wait(jobs, raise_on_failure=True)` waits for all
+- Workers internally create their own actors via `fray.job.get_default_job_ctx()`
+  for `create_actor(get_if_exists=True)` and `ctx.get(future)`
+
+**All of the following ships as one change:**
+
+1. Update `rl_job.py`:
+   - `from fray.cluster import ...` → `from fray.v2 import ...`
+   - `cluster = current_cluster()` → `client = current_client()`
+   - `cluster.launch(JobRequest(...))` → `client.submit(JobRequest(...))`
+   - `cluster.wait(jobs, raise_on_failure=True)` → `wait_all(jobs, raise_on_failure=True)`
+   - Create curriculum + weight-transfer actors via `client.create_actor()`
+     and pass handles to worker entrypoints
+2. Update `curriculum.py`: remove `get_or_create_curriculum_actor`, accept
+   handle as parameter
+3. Update `weight_transfer/`: same pattern — accept handle, remove
+   `get_if_exists`
+4. Update all worker call sites: `ctx.get(future)` → `future.result()`
+5. Remove all `fray.job` imports from RL code
+6. Run RL integration tests
+
+**Deliverable**: RL training works on Ray via `fray.v2` with explicit actor
+creation from the controller. Zero v1 imports remain in `marin.rl`.JobContext` and `fray.job` are deleted. All Zephyr tests pass.
+
+### Phase 6: Iris Backend
+
+**Goal**: `FrayIrisClient` that can run all three workloads on Iris. Deferred
+until after Ray migration is complete and validated.
+
+**Spiral step 6a — Job submission:**
+
+1. Implement `FrayIrisClient` in `fray/v2/iris_backend.py`
+2. Convert `ResourceConfig` → Iris `ResourceSpec`:
+   - `preemptible=False` → `preemptible_constraint(False)` (from `iris.cluster.types`)
+   - `JobRequest.replicas` → `ResourceSpec.replicas`
+   - Device config → Iris accelerator spec
+3. Convert `Entrypoint` → Iris entrypoint format
+4. Implement `IrisJobHandle` wrapping `iris.client.Job`
+5. Test: submit job to local Iris controller
+
+**Spiral step 6b — Actor support:**
+
+1. Implement `_host_actor` entrypoint (as designed above)
+2. Implement `IrisActorHandle` with deferred name resolution via `iris_ctx()`
+3. Implement context-based pickle serialization
+4. Implement `create_actor_group()` — submit N hosting jobs, return `ActorGroup`
+5. Test: create actor on Iris, call methods
+
+**Spiral step 6c — Integration testing:**
+
+1. Wire `"iris://..."` into `current_client()` resolution
+2. Run Levanter, RL, and Zephyr integration tests against Iris backend
+3. Validate preemptible constraint enforcement
+
+**Deliverable**: All three workloads run on Iris via `fray.v2`.
+
+### Phase 7: Cleanup
+
+1. Delete `fray.cluster`, `fray.job` (v1 code)
+2. Move `fray.v2` → `fray` (top-level)
+3. Update all imports
+4. Remove `fray.queue` if no remaining users
+
+## File Layout
+
+```
+lib/fray/src/fray/v2/
+├── __init__.py          # Re-exports: Client, current_client, wait_all, JobRequest, etc.
+├── types.py             # JobRequest, JobHandle, JobStatus, Entrypoint, EnvironmentConfig
+│                        # (copied from v1 fray.cluster.base, replicas moved to JobRequest)
+├── client.py            # Client protocol, current_client(), set_current_client(), wait_all()
+├── actor.py             # ActorHandle, ActorMethod, ActorFuture, ActorGroup (all Protocols)
+├── local.py             # LocalClient implementation
+├── ray/
+│   ├── __init__.py
+│   ├── backend.py       # RayClient (copied+adapted from v1 ray.cluster)
+│   ├── deps.py          # Runtime env building (copied from v1 ray.deps)
+│   ├── resources.py     # Resource mapping helpers (copied from v1 ray.resources)
+│   ├── tpu.py           # TPU orchestration (copied from v1 ray.tpu.execution)
+│   ├── fn_thunk.py      # Callable serialization (copied from v1 fn_thunk)
+│   └── auth.py          # Ray token auth (copied from v1 ray.auth)
+└── iris_backend.py      # FrayIrisClient implementation (wraps iris.client.IrisClient)
+```
+
+## Design Decisions
+
+### Why `create_actor` and `create_actor_group`?
+
+`create_actor` is sugar for `create_actor_group(..., count=1).wait_ready()[0]`.
+It exists because singleton actors are the common case in RL (curriculum, weight
+coordinator). Forcing `group.wait_ready()[0]` for every singleton would be noisy.
+
+Both return deferred handles — the handle is usable immediately but the first
+RPC call blocks until the actor is registered. This means `create_actor` does
+not block the caller either; it returns a handle that will resolve lazily.
+
+### Why `create_actor_group` returns immediately?
+
+Actor startup is slow (job scheduling + container boot + actor init). Returning
+immediately lets callers overlap actor startup with other work. The group
+exposes `ready_count` and `wait_ready(count)` so callers choose when to block.
+Zephyr can start processing shards as soon as *some* workers are ready rather
+than waiting for all N.
+
+### Why `wait_ready()` returns handles?
+
+`wait_ready()` returns a frozen `list[ActorHandle]` snapshot rather than
+mutating a `.handles` property. This avoids races where a caller iterates
+handles while the list is growing. Callers that need more handles later call
+`wait_ready()` again for a new snapshot.
+
+### Why `ActorGroup` instead of `ActorPool`?
+
+Fray-lite provides a thin `ActorGroup` (list of handles + jobs) rather than a
+smart `ActorPool` with round-robin/broadcast. Callers like Zephyr need custom
+scheduling (retry logic, data locality, rebalancing) that a generic pool can't
+anticipate. Keeping the group dumb pushes scheduling policy to the caller.
+
+### Why actors are created only from the controller?
+
+In v1, any worker could `create_actor(..., get_if_exists=True)` to lazily
+create-or-connect. This requires a global actor registry and implicit singleton
+semantics. In v2, the controller job (`rl_job.py`) creates all actors and
+passes handles to workers explicitly. This:
+- Makes the data flow explicit and debuggable
+- Eliminates the need for `get_if_exists` / singleton semantics
+- Works naturally with Iris (actor = job + endpoint registration)
+
+### Why copy v1 Ray code instead of wrapping it?
+
+Three options were considered:
+
+1. **v2 wraps v1 directly** — fast but creates a layering violation (v2 depends
+   on v1). Deleting v1 in Phase 6 requires untangling.
+2. **Extract shared module** — no duplication, but refactoring overhead for an
+   intermediate state that's deleted in Phase 6 anyway.
+3. **Copy into v2** (chosen) — clean separation, ~6 files of code. v2 can
+   mutate freely. v1 deletion in Phase 6 is just `rm -rf`. The TPU execution
+   code (1000 lines) is the largest piece but is self-contained.
+
+### Why `replicas` on `JobRequest` instead of `ResourceConfig`?
+
+`replicas` controls gang scheduling — how many coordinated instances of a job
+run together (e.g. TPU slices in a multislice training job). This is a job-level
+concern, not a per-task resource requirement. Putting it on `JobRequest` aligns
+with the Iris model (where `replicas` belongs on `LaunchJobRequest`) and avoids
+confusion with `ResourceConfig` which describes what a single replica needs.
+
+### Why separate `max_retries_failure` and `max_retries_preemption`?
+
+Preemption and failure are different failure modes with different retry budgets.
+Preemption is expected and cheap to retry; failures may indicate a bug.
+Under Ray (which has a single retry count), we add them together.
+
+### Why `preemptible` on `ResourceConfig`?
+
+This is the caller's declaration of whether the workload can tolerate
+preemption. Backends map it to their native mechanism:
+- **Ray**: `preemptible=False` → pin to head node via `resources={"head_node": 0.0001}`
+- **Iris**: `preemptible=False` → `Constraint(key="preemptible", op=EQ, value="false")`
+  (requires [#2553](https://github.com/marin-community/marin/issues/2553))
+
+### Why Zephyr workers use shared storage instead of RPC for data?
+
+Zephyr shards can be GBs. Passing them through cloudpickle over HTTP (Iris
+actor RPC) would be slow and memory-intensive. Instead, workers read/write
+shard data from shared storage (GCS). The RPC call passes only paths and
+metadata. This matches how Zephyr's `LoadFileOp` pipelines already work.
+
+### Why `FrayIrisClient` wraps `iris.client.IrisClient`?
+
+The Iris client library already handles job submission, endpoint registry,
+namespace-based resolver, and port allocation. Wrapping it avoids reimplementing
+gRPC plumbing and keeps the fray-lite Iris backend thin. The main work is
+type conversion (`ResourceConfig` → `ResourceSpec`, `Entrypoint` mapping)
+and the actor hosting entrypoint.
+
+### Why IrisActorHandle serializes via context, not controller address?
+
+Actor handles are pickled when passed to worker jobs via `Entrypoint.from_callable`.
+On deserialization, the handle reconstructs its `ActorClient` from `iris_ctx()` —
+the Iris context already available in every Iris job. This avoids baking the
+controller address into the handle and works because child jobs inherit the
+parent's namespace (so the resolver finds the same actors).
+
+### Why no async Iris API?
+
+The `_IrisActorMethod.remote()` wraps synchronous Iris RPC calls in a thread
+pool executor to return non-blocking futures. This is sufficient — Iris's
+`ActorClient` is a simple HTTP call, and the thread pool avoids blocking the
+caller. Adding a native async API to Iris would be more complex for marginal
+benefit. Revisit only if profiling shows thread pool overhead.
+
+### Why actor termination via job kill, not a control channel?
+
+The `_host_actor` entrypoint blocks forever until its job is terminated.
+`ActorGroup.shutdown()` calls `job.terminate()` on each underlying job, which
+kills the container. No separate control RPC is needed — this is simpler and
+works identically across Ray and Iris. A graceful shutdown hook could be added
+later if actors need cleanup logic, but the current workloads don't require it.
+
+## Recommended Issues
+
+### ✅ Completed
+
+- **Iris: Expose preemptible worker attribute** ([#2553](https://github.com/marin-community/marin/issues/2553)) — Done.
+- **Iris: `replicas` on `ResourceSpec`** — Done (kept on `ResourceSpec`).
+
+### Ready to start
+
+- **Fray-lite: Phase 1 — Core interface + LocalClient** —
+  Create `fray/v2/` package. Define `Client` protocol, `ActorHandle` protocol,
+  `ActorGroup`, `JobHandle`, `wait_all()`. Copy type definitions from v1.
+  Implement `LocalClient`. Write tests. See Phase 1 spiral steps for breakdown.
+
+- **Fray-lite: Phase 2 — Ray backend** —
+  Copy v1 Ray code into `fray/v2/ray/`. Implement `RayClient` with deferred
+  actor handles. Map `JobRequest.replicas` → `run_on_pod num_slices`.
+
+### After Ray backend is ready
+
+- **Fray-lite: Phase 3 — Migrate Levanter** —
+  Swap `current_cluster()` → `current_client()` in `marin.training.training`.
+  Simplest caller, validates the API surface.
+
+- **Fray-lite: Phase 4 — Migrate RL** —
+  Single atomic migration: swap all imports, refactor actor creation to
+  controller-only, update all worker call sites. No mixed v1/v2.
+
+- **Fray-lite: Phase 5 — Migrate Zephyr** —
+  Implement `ActorBackend` with `ZephyrWorker` actors. Delete `JobContext`
+  and `fray.job`.
+
+### After all callers migrated on Ray
+
+- **Fray-lite: Phase 6 — Iris backend** —
+  Implement `FrayIrisClient` wrapping `iris.client.IrisClient`. Deferred
+  `IrisActorHandle` with context-based serialization. Run all workloads
+  against Iris.
+
+- **Fray-lite: Phase 7 — Delete v1** —
+  Remove `fray.cluster`, `fray.job`, `fray.queue`. Move `fray.v2` → `fray`.
+  Update all imports.
+
+## Recommendations
+
+### 1. Iris `replicas` field location differs from original design
+
+The original design called for moving `replicas` from `ResourceSpecProto` to
+`LaunchJobRequest`. In practice, Iris keeps `replicas` on `ResourceSpec`
+(`iris.cluster.types.ResourceSpec.replicas`). This is fine — fray-lite's
+`FrayIrisClient` will map `JobRequest.replicas` → `ResourceSpec.replicas`
+during conversion. No Iris change needed.

--- a/lib/fray/docs/fray-lite-research.md
+++ b/lib/fray/docs/fray-lite-research.md
@@ -1,0 +1,257 @@
+# Fray-Lite Research: Codebase Analysis
+
+This document captures the research phase for the Fray V2 ("fray-lite") design.
+See [GitHub #2552](https://github.com/marin-community/marin/issues/2552) for context.
+
+## Goal
+
+Define a minimal Fray interface that supports our three primary workloads
+(Zephyr data processing, RL training, Levanter training) and can be backed by
+either Ray or Iris, then migrate existing code to this interface and delete the
+v1 Fray.
+
+## Current Fray API Surface
+
+Fray today exposes three orthogonal subsystems:
+
+### 1. `fray.cluster` — Job Orchestration
+
+The `Cluster` abstract class provides:
+
+```python
+class Cluster:
+    def launch(request: JobRequest) -> JobId
+    def monitor(job_id: JobId) -> JobInfo
+    def poll(job_id: JobId) -> JobInfo
+    def terminate(job_id: JobId) -> None
+    def list_jobs() -> list[JobInfo]
+    def wait(job_id, raise_on_failure=False) -> JobInfo
+```
+
+Supporting types: `JobRequest`, `ResourceConfig`, `DeviceConfig` (CpuConfig /
+GpuConfig / TpuConfig), `EnvironmentConfig`, `Entrypoint`, `JobId`, `JobInfo`,
+`JobStatus`.
+
+Backends: `LocalCluster` (threads/subprocesses), `RayCluster` (Ray job
+submission + remote tasks + TPU gang scheduling).
+
+### 2. `fray.job` — In-Job Execution Context
+
+The `JobContext` protocol provides:
+
+```python
+class JobContext:
+    def put(obj) -> ref
+    def get(ref) -> obj
+    def run(fn, *args) -> future
+    def wait(futures, num_returns=1) -> (ready, pending)
+    def create_actor(cls, *args, name=..., get_if_exists=..., preemptible=..., num_cpus=...) -> ActorHandle
+```
+
+Backends: `SyncContext`, `ThreadContext`, `RayContext`.
+
+### 3. `fray.queue` — Distributed Queue
+
+Lease-based queue protocol with `MemoryQueue`, `FileQueue`, `HttpQueue`.
+
+## How Each Workload Uses Fray
+
+### Zephyr (Data Processing)
+
+**Imports**: `JobContext`, `get_default_job_ctx` from `fray.job`
+
+**Usage**: `zephyr/backends.py` uses `JobContext` for distributed map/reduce:
+- `context.put(data)` — store chunks in object store
+- `context.run(run_stage, ctx, ops)` — execute stage functions remotely
+- `context.wait(futures)` — wait for stage completion
+- `context.get(ref)` — retrieve results
+
+**Does NOT use**: `fray.cluster`, `fray.queue`, actors.
+
+**Key insight**: Zephyr only needs the task-dispatch portion of `JobContext`
+(put/get/run/wait). It doesn't use actors or cluster-level job management.
+
+### RL Training (marin.rl)
+
+**Imports**: Both `fray.cluster` and `fray.job`.
+
+#### Job orchestration (`rl_job.py`)
+
+Uses `fray.cluster` to launch TPU jobs:
+
+```python
+cluster = current_cluster()
+cluster.launch(JobRequest(name="train", resources=train_resources, entrypoint=...))
+cluster.launch(JobRequest(name="rollout-N", resources=rollout_resources, entrypoint=...))
+cluster.wait(jobs, raise_on_failure=True)
+```
+
+This is the "outer loop" — launching 1 train worker + N rollout workers as
+separate cluster jobs, then waiting for all to complete.
+
+#### Actor coordination (within jobs)
+
+Uses `fray.job` to create shared actors:
+
+1. **Curriculum actor** — shared between train + rollout workers via
+   `get_default_job_ctx().create_actor(Curriculum, name="curriculum",
+   get_if_exists=True, preemptible=False, num_cpus=0)`. Workers call
+   `.sample_lesson.remote()`, `.update_lesson_stats.remote()`, etc.
+
+2. **Weight transfer coordinators** — `ArrowFlightCoordinator` and
+   `WeightTransferCoordinator` created similarly with `preemptible=False,
+   num_cpus=0`. Coordinate weight sync between train and rollout workers.
+
+All actors share these properties:
+- Created with `get_if_exists=True` (singleton per name)
+- `preemptible=False` (must survive worker preemptions)
+- `num_cpus=0` (lightweight coordination, no compute)
+- Called via `.method.remote()` / `ctx.get(future)` pattern
+
+#### Data transfer (rollout storage)
+
+Does NOT use `fray.queue`. Uses custom `RolloutStorage` abstraction with
+file-based (GCS pickle files) or in-memory implementations. Rollout workers
+write `RolloutBatch` objects; train worker reads them via polling.
+
+### Levanter Training (training.py)
+
+**Imports**: `fray.cluster` only.
+
+**Usage**: Wraps `train_lm.main` in a `JobRequest` and launches via cluster:
+
+```python
+cluster = current_cluster()
+job_id = cluster.launch(JobRequest(
+    name="train_lm",
+    entrypoint=Entrypoint.from_callable(train_lm.main, args=[config]),
+    resources=config.resources,
+    environment=EnvironmentConfig.create(env_vars=env),
+))
+cluster.wait(job_id, raise_on_failure=True)
+```
+
+Levanter itself does NOT import fray at all (except `device_flops` for MFU
+logging). The training code is pure JAX/Haliax.
+
+### Experiments (100+ files)
+
+All experiment files use `ResourceConfig` to specify compute. Most never
+interact with the cluster API directly — the executor framework handles job
+submission. A few use `current_cluster()` for manual job management.
+
+### Queue Usage
+
+`fray.queue` is used **only internally** within fray tests and the queue
+module itself. No external consumer in marin, zephyr, or levanter uses it.
+The RL system has its own rollout storage. Queue can likely be left as-is
+or removed.
+
+## Iris Equivalents
+
+The Iris API (`lib/iris/src/iris/client/client.py`) provides:
+
+| Fray Concept | Iris Equivalent |
+|---|---|
+| `Cluster.launch(JobRequest)` | `IrisClient.submit(entrypoint, name, resources)` → `Job` handle |
+| `Cluster.wait(job_id)` | `Job.wait(timeout, raise_on_failure)` |
+| `Cluster.poll(job_id)` | `Job.status()` / `Job.state` |
+| `Cluster.terminate(job_id)` | `Job.terminate()` / `IrisClient.terminate(job_id)` |
+| `Cluster.list_jobs()` | `IrisClient.list_jobs()` |
+| `JobRequest.resources` | `ResourceSpec` (proto-based) |
+| `JobRequest.entrypoint` | `Entrypoint` (callable serialization) |
+| `JobContext.create_actor()` | No direct equivalent — actors are Iris jobs with endpoint registration |
+| `JobContext.put/get/run/wait` | No equivalent — Iris is job-level, not task-level |
+
+Key Iris features not in Fray:
+- **Hierarchical job IDs** (parent/child namespaces)
+- **Co-scheduling** (atomic multi-task scheduling)
+- **Endpoint registry** (actor discovery via controller)
+- **Task-level status/logs** (per-task within a job)
+- **Port allocation** for actor servers
+
+## Usage Frequency Summary
+
+| API | Files Using It | Workloads |
+|---|---|---|
+| `ResourceConfig` | ~120 | All experiments, training, eval |
+| `current_cluster()` / `Cluster.launch/wait` | ~15 | Training, RL, evaluation |
+| `JobContext.put/get/run/wait` | ~10 | Zephyr, processing |
+| `JobContext.create_actor` | ~6 | RL (curriculum, weight transfer) |
+| `fray.queue` | ~3 | Internal only |
+| `run_on_pod` (TPU gang sched) | ~5 | Training, RL, evaluation |
+
+## What Fray-Lite Must Support
+
+Based on the analysis, fray-lite needs exactly three capabilities:
+
+### 1. Job Submission & Monitoring
+
+Submit jobs with resource requirements and wait for completion. Used by
+training, RL, and evaluation code. This is the highest-traffic API
+(~120 files use `ResourceConfig`).
+
+### 2. Task Dispatch (put/get/run/wait)
+
+Distribute work across a pool of workers within a single job. Used by
+Zephyr for data processing.
+
+### 3. Named Actors
+
+Create named, persistent actor instances that multiple workers can
+discover and call. Used by RL for curriculum management and weight
+transfer coordination.
+
+## What Fray-Lite Can Drop
+
+- `fray.queue` — unused externally, RL has its own storage
+- `run_on_pod` / TPU gang scheduling internals — these become backend
+  implementation details (Ray's gang scheduling or Iris's co-scheduling)
+- `LocalCluster` subprocess isolation (`use_isolated_env`) — rarely used
+- `TemporaryVenv` — only used by isolated env mode
+- `FakeProcess` internals — implementation detail of LocalCluster
+
+## Key Design Tensions
+
+### 1. Actor model mismatch
+
+Ray actors are in-process objects living inside the Ray cluster, accessed via
+`actor.method.remote()`. Iris actors are HTTP services running in job
+containers, discovered via endpoint registry. These are fundamentally different
+models.
+
+The RL code relies heavily on the Ray actor model:
+- `get_if_exists=True` for singleton discovery
+- `preemptible=False` for persistence
+- `.remote()` / `ctx.get()` for invocation
+
+An Iris backend would need to either:
+(a) Run actors as Iris jobs with HTTP endpoints and translate `.remote()` calls
+    to RPC, or
+(b) Provide a separate actor runtime outside of Iris job management.
+
+### 2. Task dispatch scope
+
+Zephyr's `JobContext` (put/get/run/wait) dispatches tasks within a single
+process/cluster. Under Ray, tasks run on Ray workers. Under Iris, there's no
+equivalent — Iris manages jobs, not fine-grained tasks.
+
+Options:
+(a) Keep `JobContext` as-is (thread/sync/ray backends) — it's orthogonal to
+    job management and doesn't need Iris support.
+(b) Add an Iris-based task dispatch mechanism.
+
+Since Zephyr data processing currently runs within a single Ray job (not as
+separate Iris jobs), option (a) seems correct.
+
+### 3. ResourceConfig compatibility
+
+Fray's `ResourceConfig` is used by ~120 experiment files. Iris has its own
+`ResourceSpec` (proto-based). These need to be interconvertible without
+requiring changes to all experiment files.
+
+### 4. Backend selection
+
+Currently: `FRAY_CLUSTER_SPEC=ray?namespace=...` or `local`. Adding Iris:
+`iris?controller=http://...`. The `current_cluster()` pattern should continue
+to work transparently.

--- a/lib/fray/src/fray/v2/__init__.py
+++ b/lib/fray/src/fray/v2/__init__.py
@@ -1,0 +1,73 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fray v2: minimal job and actor scheduling interface."""
+
+from fray.v2.actor import ActorFuture, ActorGroup, ActorHandle, ActorMethod, FutureActorFuture
+from fray.v2.client import Client, JobFailed, JobHandle, current_client, set_current_client, wait_all
+from fray.v2.local import LocalActorHandle, LocalActorMethod, LocalClient, LocalJobHandle
+from fray.v2.types import (
+    BinaryEntrypoint,
+    CallableEntrypoint,
+    CpuConfig,
+    DeviceConfig,
+    DeviceKind,
+    Entrypoint,
+    EnvironmentConfig,
+    GpuConfig,
+    GpuType,
+    JobRequest,
+    JobStatus,
+    ResourceConfig,
+    TpuConfig,
+    TpuTopologyInfo,
+    TpuType,
+    create_environment,
+    get_tpu_topology,
+)
+
+__all__ = [
+    "ActorFuture",
+    "ActorGroup",
+    "ActorHandle",
+    "ActorMethod",
+    "BinaryEntrypoint",
+    "CallableEntrypoint",
+    "Client",
+    "CpuConfig",
+    "DeviceConfig",
+    "DeviceKind",
+    "Entrypoint",
+    "EnvironmentConfig",
+    "FutureActorFuture",
+    "GpuConfig",
+    "GpuType",
+    "JobFailed",
+    "JobHandle",
+    "JobRequest",
+    "JobStatus",
+    "LocalActorHandle",
+    "LocalActorMethod",
+    "LocalClient",
+    "LocalJobHandle",
+    "ResourceConfig",
+    "TpuConfig",
+    "TpuTopologyInfo",
+    "TpuType",
+    "create_environment",
+    "current_client",
+    "get_tpu_topology",
+    "set_current_client",
+    "wait_all",
+]

--- a/lib/fray/src/fray/v2/actor.py
+++ b/lib/fray/src/fray/v2/actor.py
@@ -1,0 +1,108 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Actor protocols for fray v2.
+
+Defines the calling convention for remote actors: handle.method.remote()
+returns an ActorFuture, handle.method() calls synchronously. ActorGroup
+holds a set of actor handles with lifecycle tied to underlying jobs.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import Future
+from typing import Any, Protocol, runtime_checkable
+
+from fray.v2.client import JobHandle
+from fray.v2.types import JobStatus
+
+
+@runtime_checkable
+class ActorFuture(Protocol):
+    """Future for an actor method call."""
+
+    def result(self, timeout: float | None = None) -> Any:
+        """Block until result is available."""
+        ...
+
+
+class FutureActorFuture:
+    """ActorFuture backed by a concurrent.futures.Future."""
+
+    def __init__(self, future: Future[Any]):
+        self._future = future
+
+    def result(self, timeout: float | None = None) -> Any:
+        return self._future.result(timeout=timeout)
+
+
+@runtime_checkable
+class ActorMethod(Protocol):
+    def remote(self, *args: Any, **kwargs: Any) -> ActorFuture:
+        """Invoke the method remotely. Returns a future."""
+        ...
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Invoke the method synchronously (blocking)."""
+        ...
+
+
+@runtime_checkable
+class ActorHandle(Protocol):
+    """Handle to a remote actor with .method.remote() calling convention."""
+
+    def __getattr__(self, method_name: str) -> ActorMethod: ...
+
+
+class ActorGroup:
+    """Group of actor instances with lifecycle tied to underlying jobs.
+
+    Returned immediately from create_actor_group(). For LocalClient all
+    actors are ready immediately; remote backends may have actors that
+    become available asynchronously.
+    """
+
+    def __init__(self, handles: list[ActorHandle], jobs: list[JobHandle]):
+        self._handles = handles
+        self._jobs = jobs
+
+    @property
+    def ready_count(self) -> int:
+        """Number of actors that are available for RPC."""
+        return len(self._handles)
+
+    def wait_ready(self, count: int | None = None, timeout: float = 300.0) -> list[ActorHandle]:
+        """Block until `count` actors are ready (default: all).
+
+        For LocalClient, all actors are immediately ready since they are
+        in-process objects. Returns a snapshot of ready handles.
+        """
+        target = count if count is not None else len(self._handles)
+        if target > len(self._handles):
+            raise ValueError(f"Requested {target} actors but group only has {len(self._handles)}")
+        return list(self._handles[:target])
+
+    @property
+    def jobs(self) -> list[JobHandle]:
+        """Underlying job handles for lifecycle management."""
+        return self._jobs
+
+    def statuses(self) -> list[JobStatus]:
+        """Return the job status of each actor in the group."""
+        return [job.status() for job in self._jobs]
+
+    def shutdown(self) -> None:
+        """Terminate all actor jobs."""
+        for job in self._jobs:
+            job.terminate()

--- a/lib/fray/src/fray/v2/client.py
+++ b/lib/fray/src/fray/v2/client.py
@@ -1,0 +1,227 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Client protocol and helpers for fray v2."""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import logging
+import os
+import time
+from collections.abc import Generator, Sequence
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from urllib.parse import parse_qs, urlparse
+
+from fray.v2.types import JobRequest, JobStatus, ResourceConfig
+
+if TYPE_CHECKING:
+    from fray.v2.actor import ActorGroup, ActorHandle
+
+logger = logging.getLogger(__name__)
+
+_current_client_var: contextvars.ContextVar[Client | None] = contextvars.ContextVar("_current_client_var", default=None)
+
+
+# ---------------------------------------------------------------------------
+# JobHandle protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class JobHandle(Protocol):
+    @property
+    def job_id(self) -> str: ...
+
+    def wait(self, timeout: float | None = None, *, raise_on_failure: bool = True) -> JobStatus:
+        """Block until job completes."""
+        ...
+
+    def status(self) -> JobStatus: ...
+
+    def terminate(self) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Client protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class Client(Protocol):
+    def submit(self, request: JobRequest) -> JobHandle:
+        """Submit a job for execution. Returns immediately."""
+        ...
+
+    def create_actor(
+        self,
+        actor_class: type,
+        *args: Any,
+        name: str,
+        resources: ResourceConfig = ResourceConfig(),
+        **kwargs: Any,
+    ) -> ActorHandle:
+        """Create a named actor instance. Returns a handle immediately."""
+        ...
+
+    def create_actor_group(
+        self,
+        actor_class: type,
+        *args: Any,
+        name: str,
+        count: int,
+        resources: ResourceConfig = ResourceConfig(),
+        **kwargs: Any,
+    ) -> ActorGroup:
+        """Create N instances of an actor, returning a group handle."""
+        ...
+
+    def shutdown(self, wait: bool = True) -> None:
+        """Shutdown the client and all managed resources."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# wait_all
+# ---------------------------------------------------------------------------
+
+
+class JobFailed(RuntimeError):
+    """Raised when a job fails during wait_all with raise_on_failure=True."""
+
+    def __init__(self, job_id: str, status: JobStatus):
+        self.job_id = job_id
+        self.failed_status = status
+        super().__init__(f"Job {job_id} finished with status {status}")
+
+
+def wait_all(
+    jobs: Sequence[JobHandle],
+    *,
+    timeout: float | None = None,
+    raise_on_failure: bool = True,
+) -> list[JobStatus]:
+    """Wait for all jobs to complete, monitoring concurrently.
+
+    Polls all jobs in a loop rather than waiting sequentially, so a failure
+    in a later job is detected without waiting for earlier jobs to finish.
+
+    Args:
+        jobs: Job handles to wait for.
+        timeout: Maximum seconds to wait. None means wait forever.
+        raise_on_failure: If True, raise JobFailed on the first failed job.
+
+    Returns:
+        Final status for each job, in the same order as the input.
+    """
+    if not jobs:
+        return []
+
+    results: list[JobStatus | None] = [None] * len(jobs)
+    remaining = set(range(len(jobs)))
+    start = time.monotonic()
+    sleep_secs = 0.05
+    max_sleep_secs = 2.0
+
+    while remaining:
+        if timeout is not None and (time.monotonic() - start) > timeout:
+            raise TimeoutError(f"wait_all timed out after {timeout}s with {len(remaining)} jobs remaining")
+
+        for i in list(remaining):
+            s = jobs[i].status()
+            if JobStatus.finished(s):
+                results[i] = s
+                remaining.discard(i)
+                if raise_on_failure and s in (JobStatus.FAILED, JobStatus.STOPPED):
+                    raise JobFailed(jobs[i].job_id, s)
+
+        if remaining:
+            time.sleep(sleep_secs)
+            sleep_secs = min(sleep_secs * 1.5, max_sleep_secs)
+
+    return results  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# current_client / set_current_client
+# ---------------------------------------------------------------------------
+
+
+def _parse_client_spec(spec: str) -> Client:
+    """Parse a FRAY_CLIENT_SPEC string into a Client instance.
+
+    Supported formats:
+        "local"              → LocalClient()
+        "local?threads=4"    → LocalClient(max_threads=4)
+        "ray"                → NotImplementedError
+        "iris://host:port"   → NotImplementedError
+    """
+    from fray.v2.local import LocalClient
+
+    parsed = urlparse(spec if "://" in spec else f"fray://{spec}")
+    scheme = parsed.scheme if "://" in spec else spec.split("?")[0]
+
+    if scheme == "local":
+        params = parse_qs(parsed.query if "://" in spec else (spec.split("?", 1)[1] if "?" in spec else ""))
+        threads = int(params["threads"][0]) if "threads" in params else 8
+        return LocalClient(max_threads=threads)
+    elif scheme == "ray":
+        from fray.v2.ray.backend import RayClient
+
+        params = parse_qs(parsed.query if "://" in spec else (spec.split("?", 1)[1] if "?" in spec else ""))
+        namespace = params["namespace"][0] if "namespace" in params else None
+        return RayClient(namespace=namespace)
+    elif scheme == "iris":
+        from pathlib import Path
+
+        from fray.v2.iris_backend import FrayIrisClient
+
+        controller_address = f"{parsed.hostname}:{parsed.port}" if parsed.port else parsed.hostname
+        params = parse_qs(parsed.query)
+        workspace = Path(params["ws"][0]) if "ws" in params else None
+        return FrayIrisClient(controller_address, workspace=workspace)
+    else:
+        raise ValueError(f"Unknown FRAY_CLIENT_SPEC scheme: {scheme!r}")
+
+
+def current_client() -> Client:
+    """Return the current fray Client.
+
+    Resolution order:
+        1. Explicitly set client (via set_current_client)
+        2. FRAY_CLIENT_SPEC environment variable
+        3. LocalClient() default
+    """
+    client = _current_client_var.get()
+    if client is not None:
+        return client
+
+    spec = os.environ.get("FRAY_CLIENT_SPEC")
+    if spec is not None:
+        return _parse_client_spec(spec)
+
+    from fray.v2.local import LocalClient
+
+    return LocalClient()
+
+
+@contextlib.contextmanager
+def set_current_client(client: Client) -> Generator[Client, None, None]:
+    """Context manager that sets the current client and restores on exit."""
+    token = _current_client_var.set(client)
+    try:
+        yield client
+    finally:
+        _current_client_var.reset(token)

--- a/lib/fray/src/fray/v2/device_flops.py
+++ b/lib/fray/src/fray/v2/device_flops.py
@@ -1,0 +1,343 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Device FLOPS data and utilities.
+
+Data originally from Mosaic SPDX-License-Identifier: Apache-2.0
+https://github.com/mosaicml/composer/blob/56ccc2ebc59a8c68a6d075c4b61735ebf089b5a2/composer/callbacks/speed_monitor.py#L23
+"""
+import logging
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+FlopDtype = Literal["bf16", "fp16", "fp32", "fp64", "tf32", "int8", "int4", "fp8"]
+
+# Peak FLOPS per device type. Keys are lowercase device identifiers.
+DEVICE_FLOPS: dict[str, dict[str, float]] = {
+    # NVIDIA GPUs
+    # source: https://resources.nvidia.com/en-us-tensor-core/nvidia-tensor-core-gpu-datasheet
+    # nvidia publishes spec sheet with a 2x sparsity factor
+    "h100": {
+        "fp64": 67e12,
+        "fp32": 67e12,
+        "tf32": 989e12 / 2,
+        "fp16": 1.979e15 / 2,
+        "bf16": 1.979e15 / 2,
+        "fp8": 3.958e15 / 2,
+        "int8": 3.958e15 / 2,
+    },
+    "h100-pcie": {
+        "fp64": 51e12,
+        "fp32": 51e12,
+        "tf32": 756e12 / 2,
+        "fp16": 1.513e15 / 2,
+        "bf16": 1.513e15 / 2,
+        "fp8": 3.026e15 / 2,
+        "int8": 3.026e15 / 2,
+    },
+    # Source: https://resources.nvidia.com/en-us-gpu-resources/hpc-datasheet-sc23
+    "h200": {
+        "fp64": 67e12,
+        "fp32": 67e12,
+        "tf32": 989e12 / 2,
+        "fp16": 1.979e15 / 2,
+        "bf16": 1.979e15 / 2,
+        "fp8": 3.958e15 / 2,
+        "int8": 3.958e15 / 2,
+    },
+    # source: https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a100/pdf/nvidia-a100-datasheet-us-nvidia-1758950-r4-web.pdf
+    "a100": {  # Alias for backwards compatibility, defaults to 40G variant
+        "fp64": 19.5e12,
+        "fp32": 19.5e12,
+        "tf32": 156e12,
+        "fp16": 312e12,
+        "bf16": 312e12,
+    },
+    "a100-40g": {
+        "fp64": 19.5e12,
+        "fp32": 19.5e12,
+        "tf32": 156e12,
+        "fp16": 312e12,
+        "bf16": 312e12,
+    },
+    "a100-80g": {
+        "fp64": 19.5e12,
+        "fp32": 19.5e12,
+        "tf32": 156e12,
+        "fp16": 312e12,
+        "bf16": 312e12,
+    },
+    # source: https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a10/pdf/a10-datasheet.pdf
+    "a10": {
+        "fp32": 31.2e12,
+        "tf32": 62.5e12,
+        "fp16": 125e12,
+        "bf16": 125e12,
+    },
+    # A10G uses same specs as A10
+    "a10g": {
+        "fp32": 31.2e12,
+        "tf32": 62.5e12,
+        "fp16": 125e12,
+        "bf16": 125e12,
+    },
+    # source: https://images.nvidia.com/content/Solutions/data-center/a40/nvidia-a40-datasheet.pdf
+    "a40": {
+        "fp32": 37.4e12,
+        "tf32": 74.8e12,
+        "fp16": 149.7e12,
+        "bf16": 149.7e12,
+    },
+    # Source: https://www.nvidia.com/content/dam/en-zz/Solutions/design-visualization/quadro-product-literature/proviz-print-nvidia-rtx-a6000-datasheet-us-nvidia-1454980-r9-web%20(1).pdf
+    "a6000": {
+        "fp32": 38.7e12 / 2,
+        "tf32": 309.7e12 / 2,
+        "fp16": 309.7e12 / 2,
+        "bf16": 309.7e12 / 2,
+    },
+    # B100 - approximate with H100 until specs available
+    "b100": {
+        "fp64": 67e12,
+        "fp32": 67e12,
+        "tf32": 989e12 / 2,
+        "fp16": 1.979e15 / 2,
+        "bf16": 1.979e15 / 2,
+        "fp8": 3.958e15 / 2,
+        "int8": 3.958e15 / 2,
+    },
+    # source: https://images.nvidia.com/content/technologies/volta/pdf/volta-v100-datasheet-update-us-1165301-r5.pdf
+    "v100": {
+        "fp64": 7e12,
+        "fp32": 14e12,
+        "fp16": 112e12,
+    },
+    "v100-sxm": {
+        "fp64": 7.8e12,
+        "fp32": 15.7e12,
+        "fp16": 125e12,
+    },
+    "v100s": {
+        "fp64": 8.2e12,
+        "fp32": 16.4e12,
+        "fp16": 130e12,
+    },
+    # source: https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/tesla-t4/t4-tensor-core-datasheet-951643.pdf
+    "t4": {
+        "fp32": 8.1e12,
+        "fp16": 65e12,
+        "int8": 130e12,
+        "int4": 260e12,
+    },
+    # source: https://images.nvidia.com/content/Solutions/data-center/vgpu-L4-background-image-background-image/l4-datasheet.pdf
+    "l4": {
+        "fp32": 30.3e12,
+        "tf32": 120e12,
+        "fp16": 242e12,
+        "bf16": 242e12,
+        "fp8": 485e12,
+        "int8": 485e12,
+    },
+    # NVIDIA GB10
+    "gb10": {
+        "bf16": 100e12,
+    },
+    # "auto" uses H100 flops for when user doesn't care about specific GPU type
+    "auto": {
+        "fp64": 67e12,
+        "fp32": 67e12,
+        "tf32": 989e12 / 2,
+        "fp16": 1.979e15 / 2,
+        "bf16": 1.979e15 / 2,
+        "fp8": 3.958e15 / 2,
+        "int8": 3.958e15 / 2,
+    },
+    # TPUs
+    # Source: https://cloud.google.com/tpu/docs/v3
+    # v3 gives "per chip" flops, so we divide by 2 since jax device is a core
+    "v3": {
+        "bf16": 123e12 / 2,
+    },
+    # Source: https://cloud.google.com/tpu/docs/v4
+    "v4": {
+        "bf16": 275e12,
+        "int8": 275e12,
+    },
+    # Source: https://cloud.google.com/tpu/docs/v5e
+    "v5litepod": {
+        "bf16": 197e12,
+        "int8": 393e12,
+    },
+    # Source: https://cloud.google.com/tpu/docs/v5p
+    "v5": {
+        "bf16": 459e12,
+    },
+    "v5p": {
+        "bf16": 459e12,
+    },
+    # Source: https://cloud.google.com/tpu/docs/v6e
+    "v6e": {
+        "bf16": 918e12,
+        "int8": 1836e12,
+    },
+    # Other accelerators
+    # source: https://aws.amazon.com/blogs/machine-learning/aws-inferentia2-builds-on-aws-inferentia1-by-delivering-4x-higher-throughput-and-10x-lower-latency/
+    # Numbers are halved as the above flops is per chip and each chip appears as 2 devices.
+    "trn1": {
+        "fp32": 47.5e12 / 2,
+        "tf32": 47.5e12 / 2,
+        "fp16": 190e12 / 2,
+        "bf16": 190e12 / 2,
+        "int8": 380e12 / 2,
+    },
+}
+
+
+def normalize_device_type(device_type: str) -> str:
+    """Normalize device type string to Fray naming convention (lowercase).
+
+    Handles fray-specific formats:
+    - TPU type strings: "v4-128" -> "v4", "v5litepod-16" -> "v5litepod"
+    - Direct names are lowercased: "H100" -> "h100"
+
+    JAX device kind strings should be normalized by the caller (e.g., Levanter)
+    before passing to this function.
+
+    Returns:
+        Normalized lowercase device type key for DEVICE_FLOPS lookup.
+    """
+    kind = device_type.lower()
+
+    # Handle TPU type strings like "v4-128" -> "v4", "v5litepod-16" -> "v5litepod"
+    if kind.startswith("v") and "-" in kind:
+        return kind.split("-")[0]
+
+    return kind
+
+
+def jax_device_kind_to_fray_device_type(kind: str) -> str:
+    """Normalize JAX device kind to Fray device type key.
+
+    Converts JAX device_kind strings (e.g., "NVIDIA H100 80GB HBM3", "TPU v4")
+    to Fray device type keys (e.g., "h100", "v4").
+
+    Args:
+        kind: JAX device kind string from device.device_kind
+
+    Returns:
+        Fray device type key suitable for DEVICE_FLOPS lookup
+    """
+    kind = kind.lower()
+
+    # TPU looks like 'tpu v4', 'tpu v5 lite', etc.
+    if kind.startswith("tpu "):
+        tpu_gen = kind[4:].strip()
+        # "v5 lite" -> "v5litepod"
+        if "5" in tpu_gen:
+            if "lite" in tpu_gen:
+                return "v5litepod"
+            else:
+                return "v5p"
+        # "v6 lite" -> "v6e"
+        if "6" in tpu_gen and "lite" in tpu_gen:
+            return "v6e"
+        # "v4" -> "v4"
+        return tpu_gen.replace(" ", "")
+
+    # NVIDIA GPUs - check more specific patterns first
+    if "h100" in kind and ("sxm" in kind or "hbm3" in kind):
+        return "h100"
+    if "h100" in kind:
+        return "h100-pcie"
+    if "h200" in kind:
+        return "h200"
+    # Check for A100 variants - JAX returns "80gb" or "40gb" (with 'b')
+    if "a100" in kind and "80g" in kind:  # Matches both "80g" and "80gb"
+        return "a100-80g"
+    if "a100" in kind and "40g" in kind:  # Matches both "40g" and "40gb"
+        return "a100-40g"
+    if "a100" in kind:  # Fallback to a100-40g if no memory size specified
+        return "a100-40g"
+    if "a10g" in kind:
+        return "a10g"
+    if "a10" in kind:
+        return "a10"
+    if "a40" in kind:
+        return "a40"
+    if "v100" in kind and "sxm" in kind:
+        return "v100-sxm"
+    if "v100s" in kind:
+        return "v100s"
+    if "v100" in kind:
+        return "v100"
+    if "t4" in kind:
+        return "t4"
+    if "a6000" in kind:
+        return "a6000"
+    if "l40s" in kind:
+        return "l40s"
+    if "l4" in kind:
+        return "l4"
+    if "gb10" in kind:
+        return "gb10"
+
+    return kind
+
+
+def normalize_dtype(dtype: str) -> str:
+    """Normalize dtype string to base form.
+
+    Strips 'amp_' prefix if present, converts to lowercase.
+    """
+    dtype = dtype.lower()
+    if dtype.startswith("amp_"):
+        return dtype[4:]
+    return dtype
+
+
+def device_flops(device_type: str, dtype: str = "bf16") -> float | None:
+    """Get peak FLOP/s for a device.
+
+    Args:
+        device_type: Fray device type (e.g., "v4", "h100", "a100")
+        dtype: Data type (e.g., "bf16", "fp16", "int8")
+
+    Returns:
+        Peak FLOP/s for a single device/chip, or None if unknown
+    """
+    normalized = normalize_device_type(device_type)
+    flops_dict = DEVICE_FLOPS.get(normalized)
+    if flops_dict is None:
+        logger.warning(f"Unknown device type: {device_type} - {normalized}")
+        return None
+
+    normalized_dtype = normalize_dtype(dtype)
+    if normalized_dtype not in flops_dict:
+        logger.warning(f"Unknown dtype: {dtype} - {normalized_dtype} for device {device_type}")
+        return None
+    return flops_dict.get(normalized_dtype)
+
+
+def device_flops_for_jax_device(jax_device_kind: str, dtype: str = "bf16") -> float | None:
+    """Get peak FLOP/s given a JAX device kind string.
+
+    Args:
+        jax_device_kind: JAX device kind string (e.g., "TPU v4", "NVIDIA H100 80GB HBM3")
+        dtype: Data type (e.g., "bf16", "fp16")
+
+    Returns:
+        Peak FLOP/s, or None if device/dtype unknown
+    """
+    fray_device_type = jax_device_kind_to_fray_device_type(jax_device_kind)
+    return device_flops(fray_device_type, dtype)

--- a/lib/fray/src/fray/v2/iris_backend.py
+++ b/lib/fray/src/fray/v2/iris_backend.py
@@ -1,0 +1,429 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Iris backend for fray v2.
+
+Wraps iris.client.IrisClient to implement the fray v2 Client protocol.
+Handles type conversion between fray v2 types and Iris types, actor hosting
+via submitted jobs, and deferred actor handle resolution.
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from iris.cluster.types import Constraint, Entrypoint as IrisEntrypoint, EnvironmentSpec, ResourceSpec
+    from iris.rpc import cluster_pb2
+
+from fray.v2.actor import ActorFuture, ActorGroup, ActorHandle, FutureActorFuture
+from fray.v2.types import (
+    CpuConfig,
+    DeviceConfig,
+    Entrypoint as Entrypoint_v2,
+    EnvironmentConfig,
+    GpuConfig,
+    JobRequest,
+    JobStatus,
+    ResourceConfig,
+    TpuConfig,
+)
+from iris.client.client import IrisClient as IrisClientLib, Job as IrisJob
+
+logger = logging.getLogger(__name__)
+
+# Shared thread pool for async actor RPC calls
+_shared_executor: ThreadPoolExecutor | None = None
+
+
+def _get_shared_executor() -> ThreadPoolExecutor:
+    global _shared_executor
+    if _shared_executor is None:
+        _shared_executor = ThreadPoolExecutor(max_workers=32)
+    return _shared_executor
+
+
+# ---------------------------------------------------------------------------
+# Type conversion: fray v2 → Iris
+# ---------------------------------------------------------------------------
+
+
+def _convert_device(device: DeviceConfig) -> cluster_pb2.DeviceConfig | None:
+    """Convert fray v2 DeviceConfig to Iris protobuf DeviceConfig."""
+    from iris.cluster.types import tpu_device
+    from iris.rpc import cluster_pb2
+
+    if isinstance(device, CpuConfig):
+        return None
+    elif isinstance(device, TpuConfig):
+        return tpu_device(device.variant)
+    elif isinstance(device, GpuConfig):
+        gpu = cluster_pb2.GpuDevice(variant=device.variant, count=device.count)
+        return cluster_pb2.DeviceConfig(gpu=gpu)
+    raise ValueError(f"Unknown device config type: {type(device)}")
+
+
+def convert_resources(resources: ResourceConfig) -> ResourceSpec:
+    """Convert fray v2 ResourceConfig to Iris ResourceSpec.
+
+    This is the primary type bridge between fray v2 and Iris. The mapping is:
+      fray cpu       → Iris cpu
+      fray ram       → Iris memory
+      fray disk      → Iris disk
+      fray device    → Iris device (TPU via tpu_device(), GPU via GpuDevice)
+    Replicas are passed separately to iris client.submit().
+    """
+    from iris.cluster.types import ResourceSpec
+
+    return ResourceSpec(
+        cpu=resources.cpu,
+        memory=resources.ram,
+        disk=resources.disk,
+        device=_convert_device(resources.device),
+        regions=resources.regions,
+    )
+
+
+def convert_constraints(resources: ResourceConfig) -> list[Constraint]:
+    """Build Iris scheduling constraints from fray v2 ResourceConfig."""
+    from iris.cluster.types import preemptible_constraint
+
+    constraints: list[Constraint] = []
+    if not resources.preemptible:
+        constraints.append(preemptible_constraint(False))
+    return constraints
+
+
+def convert_entrypoint(entrypoint: Entrypoint_v2) -> IrisEntrypoint:
+    """Convert fray v2 Entrypoint to Iris Entrypoint."""
+    from iris.cluster.types import Entrypoint as IrisEntrypoint
+
+    if entrypoint.callable_entrypoint is not None:
+        ce = entrypoint.callable_entrypoint
+        return IrisEntrypoint.from_callable(ce.callable, *ce.args, **ce.kwargs)
+    elif entrypoint.binary_entrypoint is not None:
+        be = entrypoint.binary_entrypoint
+        return IrisEntrypoint.from_command(be.command, *be.args)
+    raise ValueError("Entrypoint must have either callable_entrypoint or binary_entrypoint")
+
+
+def convert_environment(env: EnvironmentConfig | None) -> EnvironmentSpec | None:
+    """Convert fray v2 EnvironmentConfig to Iris EnvironmentSpec."""
+    if env is None:
+        return None
+    from iris.cluster.types import EnvironmentSpec
+
+    return EnvironmentSpec(
+        pip_packages=list(env.pip_packages),
+        env_vars=dict(env.env_vars),
+        extras=list(env.extras),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Job status mapping: Iris → fray v2
+# ---------------------------------------------------------------------------
+
+
+def map_iris_job_state(iris_state: int) -> JobStatus:
+    """Map Iris protobuf JobState enum to fray v2 JobStatus."""
+    from iris.rpc import cluster_pb2
+
+    _STATE_MAP = {
+        cluster_pb2.JOB_STATE_PENDING: JobStatus.PENDING,
+        cluster_pb2.JOB_STATE_RUNNING: JobStatus.RUNNING,
+        cluster_pb2.JOB_STATE_SUCCEEDED: JobStatus.SUCCEEDED,
+        cluster_pb2.JOB_STATE_FAILED: JobStatus.FAILED,
+        cluster_pb2.JOB_STATE_KILLED: JobStatus.STOPPED,
+        cluster_pb2.JOB_STATE_WORKER_FAILED: JobStatus.FAILED,
+        cluster_pb2.JOB_STATE_UNSCHEDULABLE: JobStatus.FAILED,
+    }
+    return _STATE_MAP.get(iris_state, JobStatus.PENDING)
+
+
+# ---------------------------------------------------------------------------
+# IrisJobHandle
+# ---------------------------------------------------------------------------
+
+
+class IrisJobHandle:
+    """JobHandle wrapping an iris.client.Job."""
+
+    def __init__(self, job: IrisJob):
+        self._job = job
+
+    @property
+    def job_id(self) -> str:
+        return str(self._job.job_id)
+
+    def status(self) -> JobStatus:
+        iris_status = self._job.status()
+        return map_iris_job_state(iris_status.state)
+
+    def wait(self, timeout: float | None = None, *, raise_on_failure: bool = True) -> JobStatus:
+        effective_timeout = timeout if timeout is not None else 86400.0
+        try:
+            self._job.wait(timeout=effective_timeout, raise_on_failure=raise_on_failure)
+        except Exception:
+            if raise_on_failure:
+                raise
+        return self.status()
+
+    def terminate(self) -> None:
+        self._job.terminate()
+
+
+# ---------------------------------------------------------------------------
+# Actor hosting entrypoint
+# ---------------------------------------------------------------------------
+
+
+def _get_host_ip() -> str:
+    """Get the IP address that other hosts can reach this machine on."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(("8.8.8.8", 80))
+        return s.getsockname()[0]
+    finally:
+        s.close()
+
+
+def _host_actor(actor_class: type, args: tuple, kwargs: dict, name: str) -> None:
+    """Entrypoint for actor-hosting Iris jobs.
+
+    Instantiates the actor class, creates an ActorServer, registers the
+    endpoint for discovery, and blocks until the job is terminated.
+    """
+    from iris.actor.server import ActorServer
+    from iris.client.client import iris_ctx
+
+    ctx = iris_ctx()
+
+    instance = actor_class(*args, **kwargs)
+
+    server = ActorServer(host="0.0.0.0", port=ctx.get_port("actor"))
+    server.register(name, instance)
+    server.serve_background()
+
+    address = f"{_get_host_ip()}:{server._actual_port}"
+    ctx.registry.register(name, address)
+
+    # Block forever — job termination kills the process
+    threading.Event().wait()
+
+
+# ---------------------------------------------------------------------------
+# IrisActorHandle
+# ---------------------------------------------------------------------------
+
+
+class IrisActorHandle:
+    """Handle to an Iris-hosted actor.
+
+    Deferred: created with just an actor name. On first use, resolves the
+    name via iris_ctx().resolver to find the actor's address.
+
+    Picklable: serializes as (actor_name,) and reconstructs from the current
+    IrisContext on the receiving end. This works because child jobs inherit
+    the parent's namespace.
+    """
+
+    def __init__(self, actor_name: str, client: Any = None):
+        self._actor_name = actor_name
+        self._client = client
+
+    def _resolve(self) -> Any:
+        if self._client is None:
+            from iris.actor.client import ActorClient
+            from iris.client.client import iris_ctx
+
+            ctx = iris_ctx()
+            self._client = ActorClient(ctx.resolver, self._actor_name)
+        return self._client
+
+    def __getattr__(self, method_name: str) -> _IrisActorMethod:
+        if method_name.startswith("_"):
+            raise AttributeError(method_name)
+        return _IrisActorMethod(self, method_name)
+
+    def __getstate__(self) -> dict:
+        return {"actor_name": self._actor_name}
+
+    def __setstate__(self, state: dict) -> None:
+        self._actor_name = state["actor_name"]
+        self._client = None
+
+
+class _IrisActorMethod:
+    """Wraps a method on an Iris actor. remote() dispatches via thread pool."""
+
+    def __init__(self, handle: IrisActorHandle, method_name: str):
+        self._handle = handle
+        self._method = method_name
+
+    def remote(self, *args: Any, **kwargs: Any) -> ActorFuture:
+        client = self._handle._resolve()
+        executor = _get_shared_executor()
+        future = executor.submit(lambda: getattr(client, self._method)(*args, **kwargs))
+        return FutureActorFuture(future)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        client = self._handle._resolve()
+        return getattr(client, self._method)(*args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# IrisActorGroup
+# ---------------------------------------------------------------------------
+
+
+class IrisActorGroup(ActorGroup):
+    """ActorGroup that polls the Iris resolver to discover actors as they start.
+
+    Unlike LocalClient's ActorGroup where all actors are ready immediately,
+    Iris actors become available asynchronously as their hosting jobs start
+    and register endpoints.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        count: int,
+        jobs: list[IrisJobHandle],
+        iris_client: IrisClientLib,
+    ):
+        # Start with empty handles — they'll be populated via wait_ready()
+        super().__init__(handles=[], jobs=jobs)
+        self._name = name
+        self._count = count
+        self._iris_client = iris_client
+        self._discovered_names: set[str] = set()
+
+    def wait_ready(self, count: int | None = None, timeout: float = 300.0) -> list[ActorHandle]:
+        """Block until `count` actors are discoverable via the resolver."""
+        target = count if count is not None else self._count
+        start = time.monotonic()
+        sleep_secs = 0.5
+
+        while True:
+            # Check resolver for each actor name
+            resolver = self._iris_client.resolver()
+            for i in range(self._count):
+                actor_name = f"{self._name}-{i}"
+                if actor_name in self._discovered_names:
+                    continue
+                result = resolver.resolve(actor_name)
+                if not result.is_empty:
+                    self._discovered_names.add(actor_name)
+                    handle = IrisActorHandle(actor_name)
+                    self._handles.append(handle)
+
+            if len(self._discovered_names) >= target:
+                return list(self._handles[:target])
+
+            elapsed = time.monotonic() - start
+            if elapsed >= timeout:
+                raise TimeoutError(f"Only {len(self._discovered_names)}/{target} actors ready after {timeout}s")
+
+            time.sleep(sleep_secs)
+
+
+# ---------------------------------------------------------------------------
+# FrayIrisClient
+# ---------------------------------------------------------------------------
+
+
+class FrayIrisClient:
+    """Iris cluster backend for fray v2.
+
+    Wraps iris.client.IrisClient to implement the fray v2 Client protocol.
+    Jobs are submitted via Iris, actors are hosted as Iris jobs with endpoint
+    registration for discovery.
+    """
+
+    def __init__(self, controller_address: str, workspace: Path | None = None):
+        self._iris = IrisClientLib.remote(controller_address, workspace=workspace)
+
+    def submit(self, request: JobRequest) -> IrisJobHandle:
+        iris_resources = convert_resources(request.resources)
+        iris_entrypoint = convert_entrypoint(request.entrypoint)
+        iris_environment = convert_environment(request.environment)
+        iris_constraints = convert_constraints(request.resources)
+
+        job = self._iris.submit(
+            entrypoint=iris_entrypoint,
+            name=request.name,
+            resources=iris_resources,
+            environment=iris_environment,
+            constraints=iris_constraints if iris_constraints else None,
+            replicas=request.replicas,
+        )
+        return IrisJobHandle(job)
+
+    def create_actor(
+        self,
+        actor_class: type,
+        *args: Any,
+        name: str,
+        resources: ResourceConfig = ResourceConfig(),
+        **kwargs: Any,
+    ) -> ActorHandle:
+        group = self.create_actor_group(actor_class, *args, name=name, count=1, resources=resources, **kwargs)
+        return group.wait_ready()[0]
+
+    def create_actor_group(
+        self,
+        actor_class: type,
+        *args: Any,
+        name: str,
+        count: int,
+        resources: ResourceConfig = ResourceConfig(),
+        **kwargs: Any,
+    ) -> IrisActorGroup:
+        """Submit N Iris jobs, each hosting an instance of actor_class."""
+        from iris.cluster.types import Entrypoint as IrisEntrypoint
+
+        iris_resources = convert_resources(resources)
+        iris_environment = convert_environment(None)
+        iris_constraints = convert_constraints(resources)
+
+        jobs: list[IrisJobHandle] = []
+        for i in range(count):
+            actor_name = f"{name}-{i}"
+            entrypoint = IrisEntrypoint.from_callable(_host_actor, actor_class, args, kwargs, actor_name)
+            job = self._iris.submit(
+                entrypoint=entrypoint,
+                name=actor_name,
+                resources=iris_resources,
+                environment=iris_environment,
+                ports=["actor"],
+                constraints=iris_constraints if iris_constraints else None,
+            )
+            jobs.append(IrisJobHandle(job))
+
+        return IrisActorGroup(
+            name=name,
+            count=count,
+            jobs=jobs,
+            iris_client=self._iris,
+        )
+
+    def shutdown(self, wait: bool = True) -> None:
+        self._iris.shutdown(wait=wait)

--- a/lib/fray/src/fray/v2/local.py
+++ b/lib/fray/src/fray/v2/local.py
@@ -1,0 +1,187 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LocalClient: in-process fray v2 backend for development and testing."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import threading
+import uuid
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any
+
+from fray.v2.actor import ActorFuture, ActorGroup, FutureActorFuture
+from fray.v2.types import (
+    BinaryEntrypoint,
+    CallableEntrypoint,
+    JobRequest,
+    JobStatus,
+    ResourceConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LocalJobHandle:
+    """Job handle backed by a concurrent.futures.Future."""
+
+    def __init__(self, job_id: str, future: Future[None]):
+        self._job_id = job_id
+        self._future = future
+        self._terminated = threading.Event()
+
+    @property
+    def job_id(self) -> str:
+        return self._job_id
+
+    def status(self) -> JobStatus:
+        if self._terminated.is_set():
+            return JobStatus.STOPPED
+        if not self._future.done():
+            return JobStatus.RUNNING
+        exc = self._future.exception()
+        if exc is not None:
+            return JobStatus.FAILED
+        return JobStatus.SUCCEEDED
+
+    def wait(self, timeout: float | None = None, *, raise_on_failure: bool = True) -> JobStatus:
+        """Block until the job completes or timeout expires."""
+        try:
+            self._future.result(timeout=timeout)
+        except Exception:
+            if raise_on_failure:
+                raise
+        return self.status()
+
+    def terminate(self) -> None:
+        self._terminated.set()
+        self._future.cancel()
+
+
+def _run_callable(entry: CallableEntrypoint) -> None:
+    entry.callable(*entry.args, **entry.kwargs)
+
+
+def _run_binary(entry: BinaryEntrypoint) -> None:
+    subprocess.run(
+        [entry.command, *entry.args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+class LocalClient:
+    """In-process Client implementation for development and testing.
+
+    Runs CallableEntrypoints in threads and BinaryEntrypoints as subprocesses.
+    """
+
+    def __init__(self, max_threads: int = 8):
+        self._executor = ThreadPoolExecutor(max_workers=max_threads)
+        self._jobs: list[LocalJobHandle] = []
+
+    def submit(self, request: JobRequest) -> LocalJobHandle:
+        entry = request.entrypoint
+        if entry.callable_entrypoint is not None:
+            future = self._executor.submit(_run_callable, entry.callable_entrypoint)
+        elif entry.binary_entrypoint is not None:
+            future = self._executor.submit(_run_binary, entry.binary_entrypoint)
+        else:
+            raise ValueError("JobRequest entrypoint must have either callable_entrypoint or binary_entrypoint")
+
+        job_id = f"local-{request.name}-{uuid.uuid4().hex[:8]}"
+        handle = LocalJobHandle(job_id, future)
+        self._jobs.append(handle)
+        return handle
+
+    def create_actor(
+        self,
+        actor_class: type,
+        *args: Any,
+        name: str,
+        resources: ResourceConfig = ResourceConfig(),
+        **kwargs: Any,
+    ) -> LocalActorHandle:
+        """Create an in-process actor, returning a handle immediately."""
+        group = self.create_actor_group(actor_class, *args, name=name, count=1, resources=resources, **kwargs)
+        return group.wait_ready()[0]  # type: ignore[return-value]
+
+    def create_actor_group(
+        self,
+        actor_class: type,
+        *args: Any,
+        name: str,
+        count: int,
+        resources: ResourceConfig = ResourceConfig(),
+        **kwargs: Any,
+    ) -> ActorGroup:
+        """Create N in-process actor instances, returning a group handle."""
+        handles: list[LocalActorHandle] = []
+        jobs: list[LocalJobHandle] = []
+        for i in range(count):
+            instance = actor_class(*args, **kwargs)
+            handle = LocalActorHandle(instance)
+            handles.append(handle)
+            # Create a synthetic job handle that is immediately succeeded
+            future: Future[None] = Future()
+            future.set_result(None)
+            job_id = f"local-actor-{name}-{i}-{uuid.uuid4().hex[:8]}"
+            jobs.append(LocalJobHandle(job_id, future))
+        return ActorGroup(handles, jobs)  # type: ignore[arg-type]
+
+    def shutdown(self, wait: bool = True) -> None:
+        self._executor.shutdown(wait=wait)
+
+
+class LocalActorHandle:
+    """In-process actor handle. Thread-safe via a lock around all method calls."""
+
+    def __init__(self, instance: Any):
+        self._instance = instance
+        self._lock = threading.Lock()
+        self._executor = ThreadPoolExecutor(max_workers=1)
+
+    def __getattr__(self, method_name: str) -> LocalActorMethod:
+        if method_name.startswith("_"):
+            raise AttributeError(method_name)
+        method = getattr(self._instance, method_name)
+        if not callable(method):
+            raise AttributeError(f"{method_name} is not callable on {type(self._instance).__name__}")
+        return LocalActorMethod(method, self._lock, self._executor)
+
+
+class LocalActorMethod:
+    """Wraps a method on a local actor with lock-based thread safety."""
+
+    def __init__(self, method: Any, lock: threading.Lock, executor: ThreadPoolExecutor):
+        self._method = method
+        self._lock = lock
+        self._executor = executor
+
+    def remote(self, *args: Any, **kwargs: Any) -> ActorFuture:
+        """Submit method call to thread pool, returning a future."""
+
+        def _call():
+            with self._lock:
+                return self._method(*args, **kwargs)
+
+        return FutureActorFuture(self._executor.submit(_call))
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Call method synchronously with lock."""
+        with self._lock:
+            return self._method(*args, **kwargs)

--- a/lib/fray/src/fray/v2/ray/__init__.py
+++ b/lib/fray/src/fray/v2/ray/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ray backend for fray v2."""

--- a/lib/fray/src/fray/v2/ray/auth.py
+++ b/lib/fray/src/fray/v2/ray/auth.py
@@ -1,0 +1,59 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ray token-auth utilities shared across CLI and library code."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+DEFAULT_RAY_AUTH_TOKEN_SECRET = "RAY_AUTH_TOKEN"
+
+
+def ray_auth_secret(secret_override: str | None = None) -> str:
+    """Return the Secret Manager secret name to use for Ray auth token retrieval."""
+    return secret_override or DEFAULT_RAY_AUTH_TOKEN_SECRET
+
+
+def maybe_fetch_local_ray_token(*, gcp_project: str | None = None) -> str:
+    """Ensure a Ray auth token is available locally and return a token file path.
+
+    Priority:
+    - Respect an existing RAY_AUTH_TOKEN_PATH if it points to a file.
+    - If a token exists at the default path (~/.ray/auth_token), use it.
+    - Otherwise, fetch it with `gcloud` into the default path (~/.ray/auth_token).
+    """
+    token_path_env = os.environ.get("RAY_AUTH_TOKEN_PATH")
+    if token_path_env and Path(token_path_env).expanduser().exists():
+        return str(Path(token_path_env).expanduser())
+
+    default_path = Path.home() / ".ray" / "auth_token"
+    if default_path.exists():
+        return str(default_path)
+
+    secret = ray_auth_secret()
+    default_path.parent.mkdir(parents=True, exist_ok=True)
+
+    cmd = ["gcloud", "secrets", "versions", "access", "latest", f"--secret={secret}"]
+    if gcp_project:
+        cmd.append(f"--project={gcp_project}")
+    token = subprocess.check_output(cmd, text=True).strip()
+    if not token:
+        raise RuntimeError(f"Secret {secret} returned empty token")
+
+    default_path.write_text(token)
+    default_path.chmod(0o600)
+    return str(default_path)

--- a/lib/fray/src/fray/v2/ray/backend.py
+++ b/lib/fray/src/fray/v2/ray/backend.py
@@ -1,0 +1,454 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ray backend for fray v2 Client protocol."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+import uuid
+from typing import Any
+
+import humanfriendly
+import ray
+from ray.job_submission import JobStatus as RayJobStatus
+from ray.job_submission import JobSubmissionClient
+
+from fray.v2.actor import ActorFuture, ActorGroup
+from fray.v2.ray.deps import build_python_path, build_runtime_env_for_packages
+from fray.v2.ray.tpu import run_on_pod_ray
+from fray.v2.types import (
+    CpuConfig,
+    GpuConfig,
+    JobRequest,
+    JobStatus,
+    ResourceConfig,
+    TpuConfig,
+    create_environment,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _convert_ray_status(ray_status: RayJobStatus) -> JobStatus:
+    mapping = {
+        RayJobStatus.PENDING: JobStatus.PENDING,
+        RayJobStatus.RUNNING: JobStatus.RUNNING,
+        RayJobStatus.SUCCEEDED: JobStatus.SUCCEEDED,
+        RayJobStatus.FAILED: JobStatus.FAILED,
+        RayJobStatus.STOPPED: JobStatus.STOPPED,
+    }
+    return mapping.get(ray_status, JobStatus.FAILED)
+
+
+class RayJobHandle:
+    """Job handle wrapping either a Ray ObjectRef or a Ray job submission ID.
+
+    Ray has two job models: remote tasks (ObjectRef) and submitted jobs
+    (submission ID via JobSubmissionClient). TPU and callable jobs use
+    ObjectRef; binary jobs use submission ID.
+    """
+
+    def __init__(
+        self,
+        job_id: str,
+        *,
+        ref: ray.ObjectRef | None = None,
+        submission_id: str | None = None,
+        dashboard_address: str | None = None,
+    ):
+        self._job_id = job_id
+        self._ref = ref
+        self._submission_id = submission_id
+        self._dashboard_address = dashboard_address
+
+    @property
+    def job_id(self) -> str:
+        return self._job_id
+
+    def status(self) -> JobStatus:
+        if self._ref is not None:
+            return self._poll_ref()
+        return self._poll_submission()
+
+    def _poll_ref(self) -> JobStatus:
+        ready, _ = ray.wait([self._ref], timeout=0)
+        if not ready:
+            return JobStatus.RUNNING
+        try:
+            ray.get(self._ref)
+            return JobStatus.SUCCEEDED
+        except Exception:
+            return JobStatus.FAILED
+
+    def _poll_submission(self) -> JobStatus:
+        client = JobSubmissionClient(self._dashboard_address)
+        info = client.get_job_info(self._submission_id)
+        return _convert_ray_status(info.status)
+
+    def wait(self, timeout: float | None = None, *, raise_on_failure: bool = True) -> JobStatus:
+        """Block until the job completes."""
+        if self._ref is not None:
+            return self._wait_ref(timeout, raise_on_failure)
+        return self._wait_submission(timeout, raise_on_failure)
+
+    def _wait_ref(self, timeout: float | None, raise_on_failure: bool) -> JobStatus:
+        try:
+            ray.get(self._ref, timeout=timeout)
+        except Exception:
+            if raise_on_failure:
+                raise
+        return self.status()
+
+    def _wait_submission(self, timeout: float | None, raise_on_failure: bool) -> JobStatus:
+        start = time.monotonic()
+        sleep_secs = 0.5
+        while True:
+            s = self.status()
+            if JobStatus.finished(s):
+                if raise_on_failure and s in (JobStatus.FAILED, JobStatus.STOPPED):
+                    raise RuntimeError(f"Job {self._job_id} finished with status {s}")
+                return s
+            if timeout is not None and (time.monotonic() - start) > timeout:
+                raise TimeoutError(f"Job {self._job_id} timed out after {timeout}s")
+            time.sleep(sleep_secs)
+            sleep_secs = min(sleep_secs * 1.5, 5.0)
+
+    def terminate(self) -> None:
+        if self._ref is not None:
+            ray.cancel(self._ref)
+            return
+        try:
+            client = JobSubmissionClient(self._dashboard_address)
+            client.stop_job(self._submission_id)
+        except Exception as e:
+            logger.warning("Failed to stop job %s: %s", self._job_id, e)
+
+
+def compute_ray_retry_count(request: JobRequest) -> int:
+    """Map separate failure/preemption retry counts to a single Ray retry count."""
+    return request.max_retries_failure + request.max_retries_preemption
+
+
+def get_entrypoint_params(request: JobRequest) -> dict[str, Any]:
+    """Build entrypoint resource params for Ray job submission (binary jobs)."""
+    params: dict[str, Any] = {}
+
+    if request.resources.cpu > 0:
+        params["entrypoint_num_cpus"] = float(request.resources.cpu)
+
+    if request.resources.ram:
+        params["entrypoint_memory"] = humanfriendly.parse_size(request.resources.ram, binary=True)
+
+    device = request.resources.device
+    if isinstance(device, GpuConfig):
+        params["entrypoint_num_gpus"] = float(device.count)
+    elif isinstance(device, TpuConfig):
+        params["entrypoint_resources"] = {
+            f"TPU-{device.variant}-head": 1.0,
+            "TPU": float(device.chip_count()),
+        }
+
+    return params
+
+
+def build_runtime_env(request: JobRequest, cluster_spec: str) -> dict:
+    """Build Ray runtime environment for a job request."""
+    environment = request.environment if request.environment else create_environment()
+
+    env_vars = dict(environment.env_vars)
+    extras = list(environment.extras)
+
+    if isinstance(request.resources.device, CpuConfig):
+        if "JAX_PLATFORMS" in env_vars and env_vars["JAX_PLATFORMS"] != "cpu":
+            logger.warning(
+                "Found existing JAX_PLATFORMS=%s, overriding for CPU only job.",
+                env_vars["JAX_PLATFORMS"],
+            )
+        env_vars["JAX_PLATFORMS"] = "cpu"
+    elif isinstance(request.resources.device, TpuConfig):
+        if "tpu" not in extras:
+            extras.append("tpu")
+        env_vars["JAX_PLATFORMS"] = ""
+    elif isinstance(request.resources.device, GpuConfig):
+        if "gpu" not in extras:
+            extras.append("gpu")
+        env_vars["JAX_PLATFORMS"] = ""
+
+    env_vars["FRAY_CLIENT_SPEC"] = cluster_spec
+
+    if os.environ.get("MARIN_CI_DISABLE_RUNTIME_ENVS", "").lower() in ("1", "true") or os.environ.get(
+        "PYTEST_CURRENT_TEST"
+    ):
+        logger.info("Skipping runtime_env construction for job: %s", request.name)
+        return {"env_vars": env_vars}
+
+    logger.info(
+        "Building environment with %s, extras %s for job: %s",
+        environment.pip_packages,
+        extras,
+        request.name,
+    )
+
+    if environment.pip_packages or extras:
+        runtime_env = build_runtime_env_for_packages(
+            extra=extras,
+            pip_packages=list(environment.pip_packages),
+            env_vars=env_vars,
+        )
+        runtime_env["working_dir"] = environment.workspace
+        runtime_env["excludes"] = [".git", "tests/", "docs/", "**/*.pack"]
+        runtime_env["config"] = {"setup_timeout_seconds": 1800}
+    else:
+        python_path = build_python_path(submodules_dir=os.path.join(environment.workspace, "submodules"))
+        python_path = [
+            p if os.path.isabs(p) else os.path.join(environment.workspace, p) for p in python_path if p.strip()
+        ]
+        if "PYTHONPATH" in env_vars:
+            python_path.extend([p for p in env_vars["PYTHONPATH"].split(":") if p.strip()])
+        env_vars["PYTHONPATH"] = ":".join(python_path)
+        runtime_env = {"env_vars": env_vars}
+
+    return runtime_env
+
+
+class RayClient:
+    """Ray backend for fray v2 Client protocol.
+
+    Connects to a Ray cluster and submits jobs as Ray tasks or Ray job
+    submissions depending on the entrypoint type:
+    - TPU jobs: routed through run_on_pod_ray (gang-scheduled TPU execution)
+    - Binary jobs: submitted via JobSubmissionClient
+    - Callable jobs: executed as ray.remote tasks
+    """
+
+    def __init__(self, address: str = "auto", namespace: str | None = None):
+        self._address = os.environ.get("RAY_ADDRESS", "auto") if address == "auto" else address
+        if namespace is None:
+            self._namespace = f"fray_{uuid.uuid4().hex[:8]}"
+        else:
+            self._namespace = namespace
+        self._dashboard_address = self._get_dashboard_address()
+        logger.info("RayClient connected to %s (namespace=%s)", self._address, self._namespace)
+
+    def _get_dashboard_address(self) -> str:
+        if ray.is_initialized():
+            try:
+                ctx = ray.get_runtime_context()
+                gcs_address = getattr(ctx, "gcs_address", None)
+                if gcs_address is not None:
+                    return gcs_address
+            except Exception:
+                pass
+        return self._address
+
+    def _get_client_spec(self) -> str:
+        base = "ray"
+        if self._namespace:
+            base += f"?namespace={self._namespace}"
+        return base
+
+    def submit(self, request: JobRequest) -> RayJobHandle:
+        """Submit a job, routing to TPU/binary/callable based on device type."""
+        logger.info("Submitting job: %s", request.name)
+
+        if isinstance(request.resources.device, TpuConfig):
+            return self._launch_tpu_job(request)
+
+        if request.entrypoint.binary_entrypoint is not None:
+            return self._launch_binary_job(request)
+
+        return self._launch_callable_job(request)
+
+    def _launch_binary_job(self, request: JobRequest) -> RayJobHandle:
+        entrypoint = request.entrypoint.binary_entrypoint
+        runtime_env = build_runtime_env(request, self._get_client_spec())
+        entrypoint_cmd = f"{entrypoint.command} {' '.join(entrypoint.args)}"
+        entrypoint_params = get_entrypoint_params(request)
+
+        client = JobSubmissionClient(self._dashboard_address)
+        submission_timeout_s = float(os.environ.get("FRAY_RAY_JOB_SUBMIT_TIMEOUT_S", "30"))
+        deadline = time.time() + submission_timeout_s
+        sleep_s = 0.5
+        while True:
+            try:
+                submission_id = client.submit_job(
+                    entrypoint=entrypoint_cmd,
+                    runtime_env=runtime_env,
+                    submission_id=f"{request.name}-{uuid.uuid4()}",
+                    metadata={"name": request.name},
+                    **entrypoint_params,
+                )
+                break
+            except RuntimeError as e:
+                if "No available agent to submit job" not in str(e) or time.time() >= deadline:
+                    raise
+                logger.info("Ray job agent not ready yet, retrying submit in %.1fs...", sleep_s)
+                time.sleep(sleep_s)
+                sleep_s = min(5.0, sleep_s * 1.5)
+
+        logger.info("Job submitted with ID: %s", submission_id)
+        return RayJobHandle(
+            submission_id,
+            submission_id=submission_id,
+            dashboard_address=self._dashboard_address,
+        )
+
+    def _launch_callable_job(self, request: JobRequest) -> RayJobHandle:
+        entrypoint = request.entrypoint.callable_entrypoint
+        runtime_env = build_runtime_env(request, self._get_client_spec())
+        # Strip keys that can only be set at the Job level
+        runtime_env = {k: v for k, v in runtime_env.items() if k not in ["working_dir", "excludes", "config"]}
+
+        if isinstance(request.resources.device, GpuConfig):
+            num_gpus = request.resources.device.count
+        else:
+            num_gpus = 0
+
+        remote_fn = ray.remote(num_gpus=num_gpus)(entrypoint.callable)
+        ref = remote_fn.options(runtime_env=runtime_env).remote(*entrypoint.args, **entrypoint.kwargs)
+        job_id = f"ray-callable-{request.name}-{uuid.uuid4().hex[:8]}"
+        return RayJobHandle(job_id, ref=ref)
+
+    def _launch_tpu_job(self, request: JobRequest) -> RayJobHandle:
+        callable_ep = request.entrypoint.callable_entrypoint
+        assert callable_ep is not None, "TPU jobs require callable entrypoint"
+
+        device = request.resources.device
+        runtime_env = build_runtime_env(request, self._get_client_spec())
+        runtime_env = {k: v for k, v in runtime_env.items() if k not in ["excludes", "config", "working_dir"]}
+
+        if callable_ep.args or callable_ep.kwargs:
+            remote_fn = ray.remote(max_calls=1, runtime_env=runtime_env)(
+                lambda: callable_ep.callable(*callable_ep.args, **callable_ep.kwargs)
+            )
+        else:
+            remote_fn = ray.remote(max_calls=1, runtime_env=runtime_env)(callable_ep.callable)
+
+        # JobRequest.replicas maps to num_slices for TPU gang scheduling
+        object_ref = run_on_pod_ray.remote(
+            remote_fn,
+            tpu_type=device.variant,
+            num_slices=request.replicas,
+            max_retries_preemption=request.max_retries_preemption,
+            max_retries_failure=request.max_retries_failure,
+        )
+
+        job_id = f"ray-tpu-{request.name}-{uuid.uuid4().hex[:8]}"
+        return RayJobHandle(job_id, ref=object_ref)
+
+    def create_actor(
+        self,
+        actor_class: type,
+        *args: Any,
+        name: str,
+        resources: ResourceConfig = ResourceConfig(),
+        **kwargs: Any,
+    ) -> RayActorHandle:
+        """Create a single Ray actor and return a handle immediately."""
+        group = self.create_actor_group(actor_class, *args, name=name, count=1, resources=resources, **kwargs)
+        return group.wait_ready()[0]  # type: ignore[return-value]
+
+    def create_actor_group(
+        self,
+        actor_class: type,
+        *args: Any,
+        name: str,
+        count: int,
+        resources: ResourceConfig = ResourceConfig(),
+        **kwargs: Any,
+    ) -> RayActorGroup:
+        """Create N Ray actors named "{name}-0", "{name}-1", ..."""
+        ray_options = _actor_ray_options(resources)
+        handles: list[RayActorHandle] = []
+        for i in range(count):
+            actor_name = f"{name}-{i}"
+            remote_cls = ray.remote(actor_class)
+            actor_ref = remote_cls.options(name=actor_name, **ray_options).remote(*args, **kwargs)
+            handles.append(RayActorHandle(actor_ref))
+        return RayActorGroup(handles)
+
+    def shutdown(self, wait: bool = True) -> None:
+        logger.info("RayClient shutdown (namespace=%s)", self._namespace)
+
+
+def _actor_ray_options(resources: ResourceConfig) -> dict[str, Any]:
+    """Build ray.remote().options() kwargs for an actor.
+
+    Actors default to num_cpus=0 (they don't reserve CPU cores).
+    preemptible=False pins the actor to the head node via a custom resource.
+    """
+    options: dict[str, Any] = {"num_cpus": 0}
+    if not resources.preemptible:
+        options["resources"] = {"head_node": 0.0001}
+    return options
+
+
+class RayActorHandle:
+    """Handle to a Ray actor. Attribute access returns RayActorMethod objects."""
+
+    def __init__(self, actor_ref: ray.actor.ActorHandle):
+        # Store under a mangled name so __getattr__ doesn't recurse
+        object.__setattr__(self, "_actor_ref", actor_ref)
+
+    def __getattr__(self, method_name: str) -> RayActorMethod:
+        if method_name.startswith("_"):
+            raise AttributeError(method_name)
+        ray_method = getattr(self._actor_ref, method_name)
+        return RayActorMethod(ray_method)
+
+
+class RayActorMethod:
+    """Wraps a Ray actor method with .remote() → ActorFuture and __call__ → blocking."""
+
+    def __init__(self, ray_method: Any):
+        self._ray_method = ray_method
+
+    def remote(self, *args: Any, **kwargs: Any) -> ActorFuture:
+        object_ref = self._ray_method.remote(*args, **kwargs)
+        return RayActorFuture(object_ref)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        object_ref = self._ray_method.remote(*args, **kwargs)
+        return ray.get(object_ref)
+
+
+class RayActorFuture:
+    """ActorFuture backed by a Ray ObjectRef."""
+
+    def __init__(self, object_ref: ray.ObjectRef):
+        self._object_ref = object_ref
+
+    def result(self, timeout: float | None = None) -> Any:
+        return ray.get(self._object_ref, timeout=timeout)
+
+
+class RayActorGroup(ActorGroup):
+    """ActorGroup for Ray actors. All actors are ready immediately after creation."""
+
+    def __init__(self, handles: list[RayActorHandle]):
+        # Ray actors are usable as soon as ray.remote().remote() returns,
+        # so we pass empty job lists — lifecycle is managed via ray.kill().
+        super().__init__(handles, [])  # type: ignore[arg-type]
+        self._ray_handles = handles
+
+    def shutdown(self) -> None:
+        """Kill all Ray actors."""
+        for handle in self._ray_handles:
+            try:
+                ray.kill(handle._actor_ref)
+            except Exception as e:
+                logger.warning("Failed to kill Ray actor: %s", e)

--- a/lib/fray/src/fray/v2/ray/context.py
+++ b/lib/fray/src/fray/v2/ray/context.py
@@ -1,0 +1,64 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ray-based backend context for Zephyr-style put/get/run/wait dispatch.
+
+This module isolates all direct Ray imports so that higher-level code
+(e.g. Zephyr) can use distributed execution without importing Ray itself.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import ray
+
+
+def is_ray_initialized() -> bool:
+    """Check if Ray is initialized without requiring callers to import Ray."""
+    return ray.is_initialized()
+
+
+class RayBackendContext:
+    """Ray-based distributed execution context.
+
+    Provides put/get/run/wait primitives that Zephyr's Backend uses to dispatch
+    work to Ray workers. Zephyr imports this from fray.v2.ray rather than
+    importing Ray directly.
+    """
+
+    def __init__(self, ray_options: dict | None = None):
+        self.ray_options = ray_options or {}
+
+    def put(self, obj: Any):
+        return ray.put(obj)
+
+    def get(self, ref):
+        return ray.get(ref)
+
+    def run(self, fn: Callable, *args, name: str | None = None):
+        if self.ray_options:
+            remote_fn = ray.remote(**self.ray_options)(fn)
+        else:
+            remote_fn = ray.remote(max_retries=100)(fn)
+
+        options: dict[str, Any] = {"scheduling_strategy": "SPREAD"}
+        if name:
+            options["name"] = name
+        return remote_fn.options(**options).remote(*args)
+
+    def wait(self, futures: list, num_returns: int = 1) -> tuple[list, list]:
+        ready, pending = ray.wait(futures, num_returns=num_returns, fetch_local=False)
+        return list(ready), list(pending)

--- a/lib/fray/src/fray/v2/ray/dashboard.py
+++ b/lib/fray/src/fray/v2/ray/dashboard.py
@@ -1,0 +1,455 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ray utilities for cluster management."""
+
+import json
+import logging
+import os
+import random
+import socket
+import subprocess
+import time
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import requests
+import yaml
+
+from fray.v2.ray.dashboard_proxy import ClusterInfo, DashboardProxy, RayPortMapping
+from fray.v2.ray.auth import maybe_fetch_local_ray_token
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DashboardConfig:
+    """Configuration for dashboard connections."""
+
+    cluster_configs: list[str] = field(default_factory=list)  # Empty = auto-discover
+    ray_init: bool = False  # Initialize Ray client
+    proxy_port: int = 9999  # Port for proxy dashboard when multiple clusters
+
+    @classmethod
+    def from_cluster(cls, cluster_name: str, ray_init: bool = False) -> "DashboardConfig":
+        """Create config for a single cluster by name."""
+        return cls(cluster_configs=[cluster_name], ray_init=ray_init)
+
+
+@dataclass
+class DashboardConnection:
+    """Manages SSH tunnel and proxy for one or more clusters."""
+
+    clusters: dict[str, ClusterInfo]  # cluster_name -> info
+    port_mappings: dict[str, RayPortMapping]  # cluster_name -> port mapping
+    ssh_process: subprocess.Popen
+    proxy: DashboardProxy | None = None
+
+
+def find_free_port(start_port: int = 9000, max_attempts: int = 1000) -> int:
+    for port in range(start_port, start_port + max_attempts):
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(("", port))
+                return port
+        except OSError:
+            continue
+    raise RuntimeError(f"No free port found in range {start_port}-{start_port + max_attempts}")
+
+
+def get_head_ip_from_config(cluster_config: str) -> str:
+    """Get the head node IP from cluster config using ray get_head_ip command."""
+    try:
+        result = subprocess.run(
+            ["ray", "get_head_ip", cluster_config],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+        head_ip = result.stdout.strip()
+        if not head_ip:
+            raise RuntimeError("Empty head IP returned")
+        return head_ip
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"Failed to get head IP: {e.stderr}") from e
+    except subprocess.TimeoutExpired:
+        raise RuntimeError("Timeout getting head IP") from None
+
+
+@dataclass
+class DashboardInfo:
+    dashboard_port: int
+    gcs_port: int
+    api_port: int
+    ssh_process: subprocess.Popen
+
+
+def allocate_ports(clusters: dict[str, ClusterInfo]) -> dict[str, RayPortMapping]:
+    """Allocate local ports for each cluster using Ray's traditional ports.
+
+    First cluster uses Ray defaults: 8265 (dashboard), 6379 (GCS), 10001 (API).
+    Additional clusters scan upward from these starting points.
+    """
+    port_mappings = {}
+
+    # Ray's traditional port assignments
+    next_dashboard_port = 8265
+    next_gcs_port = 6379
+    next_api_port = 10001
+
+    for cluster_name in sorted(clusters.keys()):
+        # search from the previous port to avoid accidental reusing a port
+        dashboard_port = find_free_port(next_dashboard_port)
+        gcs_port = find_free_port(next_gcs_port)
+        api_port = find_free_port(next_api_port)
+        port_mappings[cluster_name] = RayPortMapping(dashboard_port=dashboard_port, gcs_port=gcs_port, api_port=api_port)
+        next_dashboard_port = dashboard_port + 1
+        next_gcs_port = gcs_port + 1
+        next_api_port = api_port + 1
+
+    return port_mappings
+
+
+def find_config_by_cluster_name(cluster_name: str) -> str | None:
+    """Find config file for a given cluster name."""
+    # Look for config files in infra/ directory
+    infra_dir = Path("infra")
+    if not infra_dir.exists():
+        return None
+
+    for config_file in infra_dir.glob("*.yaml"):
+        try:
+            with open(config_file, "r") as f:
+                config = yaml.safe_load(f)
+                if config.get("cluster_name") == cluster_name:
+                    return str(config_file)
+        except Exception:
+            continue
+    return None
+
+
+def load_cluster_info(config_path: str) -> ClusterInfo:
+    """Load cluster info from config file."""
+    with open(config_path, "r") as f:
+        config = yaml.safe_load(f)
+
+    cluster_name = config["cluster_name"]
+    zone = config["provider"]["availability_zone"]
+    project = config["provider"].get("project_id", "")
+
+    # Get internal and external IPs from gcloud
+    try:
+        cmd = [
+            "gcloud",
+            "compute",
+            "instances",
+            "list",
+            "--filter",
+            f"labels.ray-cluster-name={cluster_name} AND labels.ray-node-type=head",
+            "--format",
+            "value(networkInterfaces[0].networkIP,networkInterfaces[0].accessConfigs[0].natIP)",
+            "--limit",
+            "1",
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)
+        ips = result.stdout.strip().split("\t")
+        if not ips or not ips[0]:
+            raise RuntimeError(f"No head node found for cluster {cluster_name}")
+        head_ip = ips[0]
+        external_ip = ips[1] if len(ips) > 1 and ips[1] else None
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        raise RuntimeError(f"Failed to get IPs for cluster {cluster_name}: {e}") from e
+
+    return ClusterInfo(
+        cluster_name=cluster_name,
+        config_path=config_path,
+        head_ip=head_ip,
+        external_ip=external_ip,
+        zone=zone,
+        project=project,
+    )
+
+
+def discover_active_clusters() -> dict[str, ClusterInfo]:
+    """Discover all active Ray clusters across all zones.
+
+    Uses gcloud to find all compute instances with ray-node-type=head label.
+    """
+    cmd = ["gcloud", "compute", "instances", "list", "--filter", "labels.ray-node-type=head", "--format", "json"]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=60)
+        instances = json.loads(result.stdout)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        raise RuntimeError(f"Failed to discover active clusters: {e}") from e
+
+    clusters = {}
+    for instance in instances:
+        # Extract cluster info from instance metadata
+        labels = instance.get("labels", {})
+        cluster_name = labels.get("ray-cluster-name")
+
+        if not cluster_name:
+            continue
+
+        # Get network info
+        internal_ip = instance["networkInterfaces"][0]["networkIP"]
+        access_configs = instance["networkInterfaces"][0].get("accessConfigs", [])
+        external_ip = access_configs[0]["natIP"] if access_configs else None
+        zone = instance["zone"].split("/")[-1]
+        project = instance["zone"].split("/")[6]
+
+        # Find corresponding config file
+        config_path = find_config_by_cluster_name(cluster_name)
+        if not config_path:
+            logger.warning(f"No config file found for cluster {cluster_name}")
+            continue
+
+        clusters[cluster_name] = ClusterInfo(
+            cluster_name=cluster_name,
+            config_path=config_path,
+            head_ip=internal_ip,
+            external_ip=external_ip,
+            zone=zone,
+            project=project,
+        )
+
+    logger.info(f"Discovered {len(clusters)} active clusters")
+    return clusters
+
+
+def create_ssh_proxy_chain(
+    clusters: dict[str, ClusterInfo], port_mappings: dict[str, RayPortMapping]
+) -> subprocess.Popen:
+    """Create single SSH connection that proxies to all cluster head nodes.
+
+    Uses the first cluster as jump host, then forwards ports to other clusters'
+    internal IPs through that connection.
+    """
+    # Sort for deterministic ordering
+    cluster_names = sorted(clusters.keys())
+
+    # Build SSH command with all port forwards
+    ssh_cmd = [
+        "ssh",
+        "-tt",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "IdentitiesOnly=yes",
+        "-o",
+        "ExitOnForwardFailure=yes",
+        "-i",
+        os.path.expanduser("~/.ssh/marin_ray_cluster.pem"),
+    ]
+
+    # Add port forwards for each cluster
+    for cluster_name in cluster_names:
+        cluster = clusters[cluster_name]
+        ports = port_mappings[cluster_name]
+        ssh_cmd.extend(
+            [
+                f"-L{ports.dashboard_port}:{cluster.head_ip}:8265",
+                f"-L{ports.gcs_port}:{cluster.head_ip}:6379",
+                f"-L{ports.api_port}:{cluster.head_ip}:10001",
+            ]
+        )
+
+    # shuffle clusters and find one we can ping
+    clusters_list = list(clusters.values())
+
+    random.shuffle(clusters_list)
+    cluster_to_use = None
+    if len(clusters_list) > 1:
+        for cluster in clusters_list:
+            if not cluster.external_ip:
+                continue
+            try:
+                subprocess.run(
+                    ["ping", "-c", "1", "-W", "2", cluster.external_ip],
+                    capture_output=False,
+                    text=True,
+                    check=True,
+                    timeout=2,
+                )
+                cluster_to_use = cluster
+                break
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+                continue
+    else:
+        cluster_to_use = clusters_list[0]
+
+    if not cluster_to_use:
+        raise RuntimeError("No reachable cluster found with external IP")
+
+    ssh_cmd.extend([f"ray@{cluster_to_use.external_ip}", "while true; do sleep 86400; done"])
+    logger.info(f"Creating SSH proxy chain through {cluster_to_use.cluster_name}")
+    logger.info(f"Tunneling to {len(clusters)} clusters. Port mapping: {port_mappings}")
+
+    return subprocess.Popen(
+        ssh_cmd,
+        stdin=subprocess.DEVNULL,
+        env={**os.environ, "TERM": "dumb"},
+    )
+
+
+def wait_for_tunnel(clusters: dict[str, ClusterInfo], port_mappings: dict[str, RayPortMapping]) -> None:
+    """Wait for SSH tunnel to be ready by testing dashboard connections."""
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    def check_dashboard(cluster_name: str, dashboard_port: int) -> tuple[str, bool]:
+        """Check if dashboard is reachable via the HTTP interface.
+
+        With token auth enabled, this may return 401/403 without a token; that's
+        still a useful signal that the tunnel is correctly targeting a live
+        dashboard process.
+        """
+        try:
+            response = requests.get(f"http://localhost:{dashboard_port}/api/version", timeout=3)
+            return (cluster_name, response.status_code in {200, 401, 403})
+        except (requests.ConnectionError, requests.Timeout):
+            return (cluster_name, False)
+
+    max_retries = 3
+    retry_delay = 1
+
+    results = {}
+    for attempt in range(max_retries):
+        # Test all dashboards concurrently
+        with ThreadPoolExecutor(max_workers=len(clusters)) as executor:
+            futures = {
+                executor.submit(check_dashboard, cluster_name, port_mappings[cluster_name].dashboard_port): cluster_name
+                for cluster_name in clusters
+            }
+
+            for future in as_completed(futures):
+                cluster_name, is_ready = future.result()
+                results[cluster_name] = is_ready
+
+        if all(results.values()):
+            logger.info("SSH tunnel is ready - all dashboards accessible")
+            return
+
+        if attempt < max_retries - 1:
+            logger.info(f"SSH tunnel not ready, retrying in {retry_delay}s... ({attempt + 1}/{max_retries})")
+            time.sleep(retry_delay)
+
+    for cluster_name, is_ready in results.items():
+        if not is_ready:
+            logger.error(f"Dashboard for cluster {cluster_name} is not accessible")
+
+
+@contextmanager
+def ray_dashboard(config: DashboardConfig) -> Generator[DashboardConnection, None, None]:
+    """Dashboard context manager supporting single and multiple clusters.
+
+    Creates a single SSH connection that can tunnel to multiple Ray clusters
+    using internal IP routing. For multiple clusters, starts a Flask proxy
+    in a background thread.
+
+    Args:
+        config: Dashboard configuration
+
+    Yields:
+        DashboardConnection with cluster details and access methods
+    """
+
+    # Determine clusters to connect to
+    if not config.cluster_configs:
+        # Auto-discover active clusters across all zones
+        clusters = discover_active_clusters()
+        if not clusters:
+            raise RuntimeError("No active Ray clusters found")
+    else:
+        # Load specified cluster configs
+        clusters = {}
+        for config_path in config.cluster_configs:
+            info = load_cluster_info(config_path)
+            clusters[info.cluster_name] = info
+
+    port_mappings = allocate_ports(clusters)
+    ssh_process = create_ssh_proxy_chain(clusters, port_mappings)
+    wait_for_tunnel(clusters, port_mappings)
+
+    proxy = None
+    if len(clusters) > 1:
+        proxy = DashboardProxy(clusters, port_mappings, config.proxy_port)
+        proxy.start()
+
+    connection = DashboardConnection(
+        clusters=clusters,
+        port_mappings=port_mappings,
+        ssh_process=ssh_process,
+        proxy=proxy,
+    )
+
+    # Save original environment variables
+    original_env = {
+        "RAY_ADDRESS": os.environ.get("RAY_ADDRESS"),
+        "RAY_DASHBOARD_ADDRESS": os.environ.get("RAY_DASHBOARD_ADDRESS"),
+        "RAY_GCS_ADDRESS": os.environ.get("RAY_GCS_ADDRESS"),
+        "RAY_AUTH_MODE": os.environ.get("RAY_AUTH_MODE"),
+        "RAY_AUTH_TOKEN_PATH": os.environ.get("RAY_AUTH_TOKEN_PATH"),
+    }
+
+    # For single cluster, set Ray environment variables
+    if len(clusters) == 1:
+        cluster_name = next(iter(clusters.keys()))
+        ports = port_mappings[cluster_name]
+
+        # Set new values
+        os.environ["RAY_ADDRESS"] = f"http://localhost:{ports.dashboard_port}"
+        os.environ["RAY_DASHBOARD_ADDRESS"] = f"http://localhost:{ports.dashboard_port}"
+        os.environ["RAY_GCS_ADDRESS"] = f"localhost:{ports.gcs_port}"
+
+    # Marin clusters assume token auth; always enable token mode client-side and
+    # ensure a token is available. We assume all Marin clusters use the same
+    # Secret Manager secret within the same GCP project, so it's OK to auto-fetch
+    # the token if it isn't already present locally.
+    gcp_project = next(iter(clusters.values())).project
+    token_path = maybe_fetch_local_ray_token(gcp_project=gcp_project)
+    os.environ["RAY_AUTH_TOKEN_PATH"] = token_path
+    os.environ["RAY_AUTH_MODE"] = "token"
+
+    try:
+        # Initialize Ray if requested
+        if config.ray_init and len(clusters) == 1:
+            import ray
+
+            cluster_name = next(iter(clusters.keys()))
+            api_port = port_mappings[cluster_name].api_port
+            ray.init(address=f"ray://localhost:{api_port}", runtime_env={"working_dir": "."})
+
+        yield connection
+
+    finally:
+        # Cleanup
+        if connection.proxy:
+            connection.proxy.stop()
+
+        if ssh_process and ssh_process.poll() is None:
+            ssh_process.terminate()
+            ssh_process.wait()
+
+        # Restore environment variables if changed
+        for key, value in original_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value

--- a/lib/fray/src/fray/v2/ray/dashboard_proxy.py
+++ b/lib/fray/src/fray/v2/ray/dashboard_proxy.py
@@ -1,0 +1,528 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Flask proxy and UI for multiplexing multiple Ray dashboards."""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+import threading
+import traceback
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime
+from html import escape as html_escape
+
+from flask import Flask, Response, request
+import requests
+from werkzeug.serving import make_server
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LogEntry:
+    """A single log entry for the dashboard."""
+
+    timestamp: datetime
+    cluster: str
+    level: str  # "error", "warning", "info"
+    message: str
+    details: str | None = None  # Full stack trace or additional details
+
+
+@dataclass
+class ResourceUsage:
+    """Resource usage information for a single resource type."""
+
+    used: str
+    total: str
+
+    def percentage(self) -> float:
+        """Calculate usage percentage, handling unit conversions."""
+        try:
+            used_val = float(self.used.replace("TiB", "").replace("GiB", "").replace("MiB", "").replace("KiB", ""))
+            total_val = float(self.total.replace("TiB", "").replace("GiB", "").replace("MiB", "").replace("KiB", ""))
+            return (used_val / total_val * 100) if total_val > 0 else 0.0
+        except (ValueError, ZeroDivisionError):
+            return 0.0
+
+
+@dataclass
+class ClusterStatus:
+    """Parsed Ray cluster status information."""
+
+    active_nodes: list[str] = field(default_factory=list)
+    pending_nodes: list[str] = field(default_factory=list)
+    resources: dict[str, ResourceUsage] = field(default_factory=dict)
+
+    def active_count(self) -> int:
+        """Number of active nodes."""
+        return len(self.active_nodes)
+
+    def pending_count(self) -> int:
+        """Number of pending nodes."""
+        return len(self.pending_nodes)
+
+
+@dataclass
+class RayPortMapping:
+    """Local port mappings for SSH tunnel to a Ray cluster."""
+
+    dashboard_port: int
+    gcs_port: int
+    api_port: int
+
+
+@dataclass
+class ClusterInfo:
+    """Information about a Ray cluster."""
+
+    cluster_name: str
+    config_path: str
+    head_ip: str
+    external_ip: str | None
+    zone: str
+    project: str
+
+
+def format_number(value_str: str) -> str:
+    """Format numbers compactly (e.g., 61680.0 -> 61.7k, 2049.0 -> 2049)."""
+    unit = ""
+    clean_str = value_str
+    for suffix in ["TiB", "GiB", "MiB", "KiB"]:
+        if value_str.endswith(suffix):
+            unit = suffix
+            clean_str = value_str[: -len(suffix)]
+            break
+
+    try:
+        num = float(clean_str)
+
+        if not unit:
+            if num >= 1_000_000:
+                formatted = f"{num / 1_000_000:.1f}"
+                formatted = formatted.rstrip("0").rstrip(".")
+                return f"{formatted}M"
+            if num >= 10_000:
+                formatted = f"{num / 1_000:.1f}"
+                formatted = formatted.rstrip("0").rstrip(".")
+                return f"{formatted}k"
+
+        if num == int(num):
+            return f"{int(num)}{unit}"
+
+        formatted = f"{num:.1f}"
+        formatted = formatted.rstrip("0").rstrip(".")
+        return f"{formatted}{unit}"
+    except ValueError:
+        return value_str
+
+
+def parse_ray_status(status_output: str) -> ClusterStatus:
+    """Parse ray status output into structured data."""
+    result = ClusterStatus()
+    lines = status_output.strip().split("\n")
+    current_section: str | None = None
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+
+        if line.startswith("Node status"):
+            current_section = "nodes"
+        elif line.startswith("Resources"):
+            current_section = "resources"
+        elif line.startswith("Active:"):
+            current_section = "active_nodes"
+        elif line.startswith("Pending:"):
+            current_section = "pending_nodes"
+        elif line.startswith("Usage:"):
+            current_section = "usage"
+        elif line.startswith(("Constraints:", "Demands:", "Recent failures:")):
+            current_section = None
+        elif current_section == "active_nodes" and not line.startswith(("-", "=")):
+            if line != "(no active nodes)":
+                result.active_nodes.append(line)
+        elif current_section == "pending_nodes" and not line.startswith(("-", "=")):
+            if line != "(no pending nodes)":
+                result.pending_nodes.append(line)
+        elif current_section == "usage":
+            match = re.match(r"([\d.]+[KMGTB]?i?B?)/([\d.]+[KMGTB]?i?B?)\s+(.+)", line)
+            if match:
+                used, total, resource_name = match.groups()
+                if resource_name == "object_store_memory":
+                    continue
+                if re.search("ray.*worker", resource_name):
+                    continue
+                result.resources[resource_name] = ResourceUsage(used=used, total=total)
+    return result
+
+
+@dataclass
+class DashboardProxy:
+    """Thread-based Flask proxy for multiple Ray dashboards."""
+
+    clusters: dict[str, ClusterInfo]
+    port_mappings: dict[str, RayPortMapping]
+    proxy_port: int
+    server: make_server | None = None
+    thread: threading.Thread | None = None
+    _logs: deque[LogEntry] = field(default_factory=lambda: deque(maxlen=100))
+    _logs_lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def _add_log(self, cluster: str, level: str, message: str, details: str | None = None) -> None:
+        entry = LogEntry(
+            timestamp=datetime.now(),
+            cluster=cluster,
+            level=level,
+            message=message,
+            details=details,
+        )
+        with self._logs_lock:
+            self._logs.append(entry)
+
+    def _get_logs(self, limit: int = 50) -> list[LogEntry]:
+        with self._logs_lock:
+            return list(self._logs)[-limit:]
+
+    def _build_status(self, cluster: str, ports: RayPortMapping) -> ClusterStatus:
+        try:
+            gcs_address = f"localhost:{ports.gcs_port}"
+            result = subprocess.run(
+                ["ray", "status", f"--address={gcs_address}"],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=15,
+            )
+            return parse_ray_status(result.stdout)
+        except subprocess.CalledProcessError as e:
+            output = e.stderr or e.stdout or ""
+            logger.error("ray status failed for %s (exit %s): %s", cluster, e.returncode, output.strip())
+            raise
+        except Exception:
+            logger.exception("Failed to fetch status for %s", cluster)
+            raise
+
+    def _render_resources(self, status: ClusterStatus) -> str:
+        if not status.resources:
+            return ""
+
+        html = '<div class="resources">'
+        for name, usage in status.resources.items():
+            percent = usage.percentage()
+            used_fmt = format_number(usage.used)
+            total_fmt = format_number(usage.total)
+            html += '<div class="resource-bar">'
+            html += f'<div class="resource-label">{name}: {used_fmt}/{total_fmt} ({percent:.1f}%)</div>'
+            html += '<div class="bar">'
+            html += f'<div class="bar-fill" style="width: {percent}%"></div>'
+            html += "</div>"
+            html += "</div>"
+        html += "</div>"
+        return html
+
+    def _build_status_html(self, cluster: str, ports: RayPortMapping) -> str:
+        try:
+            status = self._build_status(cluster, ports)
+
+            html = '<div class="status-content">'
+            html += f'<div class="stat"><strong>Nodes:</strong> {status.active_count()} active'
+            if status.pending_count() > 0:
+                html += f", {status.pending_count()} pending"
+            html += "</div>"
+            html += self._render_resources(status)
+            html += "</div>"
+            return html
+        except subprocess.TimeoutExpired as e:
+            self._add_log(
+                cluster,
+                "error",
+                "Timeout fetching status",
+                f"Command timed out after {e.timeout}s: {' '.join(e.cmd) if e.cmd else 'unknown command'}",
+            )
+            return '<div class="error">⏱ Timeout fetching status</div>'
+        except subprocess.CalledProcessError as e:
+            output = (e.stderr or e.stdout or "").strip()
+            self._add_log(
+                cluster,
+                "error",
+                f"ray status failed (exit {e.returncode})",
+                output or "no output",
+            )
+            return '<div class="error">❌ Failed to fetch status</div>'
+        except Exception as e:
+            self._add_log(
+                cluster,
+                "error",
+                f"Error: {e!s}",
+                traceback.format_exc(),
+            )
+            return '<div class="error">❌ Failed to fetch status</div>'
+
+    def _create_app(self) -> Flask:
+        app = Flask(__name__)
+
+        @app.route("/api/cluster/<cluster>/status-html")
+        def cluster_status_html(cluster: str):
+            if cluster not in self.clusters:
+                return '<div class="error">Unknown cluster</div>'
+
+            ports = self.port_mappings[cluster]
+            return self._build_status_html(cluster, ports)
+
+        @app.route("/api/logs-html")
+        def logs_html():
+            logs = self._get_logs(50)
+            if not logs:
+                return '<div class="log-empty">No logs yet</div>'
+
+            html_parts = []
+            for entry in reversed(logs):
+                timestamp = entry.timestamp.strftime("%H:%M:%S")
+                escaped_cluster = html_escape(entry.cluster)
+                escaped_message = html_escape(entry.message)
+                escaped_details = html_escape(entry.details) if entry.details else ""
+                details_str = f": {escaped_details}" if entry.details else ""
+                log_line = (
+                    f'<div class="log-line">{timestamp} [{escaped_cluster}] ' f"{escaped_message}{details_str}</div>"
+                )
+                html_parts.append(log_line)
+            return "".join(html_parts)
+
+        @app.route("/")
+        def index():
+            html = """
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Ray Clusters Dashboard</title>
+    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            background: #f5f5f5;
+            padding: 20px;
+            color: #333;
+        }
+        h1 {
+            margin-bottom: 30px;
+            color: #2c3e50;
+            font-size: 32px;
+        }
+        .clusters {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+            gap: 16px;
+        }
+        .cluster-card {
+            background: white;
+            border-radius: 8px;
+            padding: 12px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .cluster-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 10px;
+            padding-bottom: 10px;
+            border-bottom: 2px solid #e0e0e0;
+        }
+        .cluster-name {
+            font-size: 18px;
+            font-weight: 600;
+            color: #2c3e50;
+        }
+        .cluster-name a {
+            color: #3498db;
+            text-decoration: none;
+        }
+        .cluster-name a:hover {
+            text-decoration: underline;
+        }
+        .cluster-meta {
+            font-size: 11px;
+            color: #95a5a6;
+            margin-left: 8px;
+            font-weight: 400;
+        }
+        .direct-link {
+            font-size: 12px;
+            color: #3498db;
+            text-decoration: none;
+            padding: 4px 8px;
+            border: 1px solid #3498db;
+            border-radius: 4px;
+        }
+        .direct-link:hover {
+            background: #3498db;
+            color: white;
+        }
+        .status-loading {
+            color: #95a5a6;
+            font-style: italic;
+        }
+        .status-content {
+            font-size: 14px;
+        }
+        .stat {
+            margin-bottom: 8px;
+            font-size: 13px;
+        }
+        .resources {
+            margin: 10px 0;
+        }
+        .resource-bar {
+            margin-bottom: 8px;
+        }
+        .resource-label {
+            font-size: 12px;
+            margin-bottom: 3px;
+            color: #555;
+        }
+        .bar {
+            width: 100%;
+            height: 6px;
+            background: #ecf0f1;
+            border-radius: 3px;
+            overflow: hidden;
+        }
+        .bar-fill {
+            height: 100%;
+            background: linear-gradient(90deg, #3498db, #2980b9);
+            transition: width 0.3s ease;
+        }
+        .error {
+            color: #e74c3c;
+            padding: 10px;
+            background: #fee;
+            border-radius: 4px;
+            font-size: 13px;
+        }
+        .log-panel {
+            margin-top: 30px;
+            background: white;
+            border-radius: 8px;
+            padding: 12px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .log-panel h2 {
+            font-size: 18px;
+            color: #2c3e50;
+            margin-bottom: 10px;
+        }
+        .log-content {
+            max-height: 300px;
+            overflow-y: auto;
+            font-family: monospace;
+            font-size: 12px;
+        }
+        .log-empty {
+            color: #95a5a6;
+        }
+        .log-line {
+            padding: 4px 0;
+            border-bottom: 1px solid #eee;
+            color: #e74c3c;
+            word-break: break-word;
+        }
+    </style>
+</head>
+<body>
+    <h1>Ray Clusters Dashboard</h1>
+    <div class="clusters">
+"""
+            for name, info in self.clusters.items():
+                ports = self.port_mappings[name]
+                html += f"""
+        <div class="cluster-card">
+            <div class="cluster-header">
+                <div>
+                    <div class="cluster-name">
+                        <a href="/{name}/">{name}</a>
+                        <span class="cluster-meta">{info.head_ip}</span>
+                    </div>
+                </div>
+                <a href="http://localhost:{ports.dashboard_port}" class="direct-link" target="_blank">Direct</a>
+            </div>
+            <div hx-get="/api/cluster/{name}/status-html"
+                 hx-trigger="load"
+                 hx-swap="innerHTML"
+                 class="status-loading">
+                Loading status...
+            </div>
+        </div>
+"""
+            html += """
+    </div>
+    <div class="log-panel">
+        <h2>Logs</h2>
+        <div class="log-content"
+             hx-get="/api/logs-html"
+             hx-trigger="load, every 5s"
+             hx-swap="innerHTML">
+        </div>
+    </div>
+</body>
+</html>
+"""
+            return html
+
+        @app.route("/<cluster>/", defaults={"path": ""})
+        @app.route("/<cluster>/<path:path>", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
+        def proxy(cluster, path):
+            if cluster not in self.clusters:
+                return f"Unknown cluster: {cluster}", 404
+
+            ports = self.port_mappings[cluster]
+            target_url = f"http://localhost:{ports.dashboard_port}/{path}"
+            if request.query_string:
+                target_url += f"?{request.query_string.decode()}"
+
+            try:
+                resp = requests.request(
+                    method=request.method,
+                    url=target_url,
+                    headers={k: v for k, v in request.headers if k.lower() != "host"},
+                    data=request.get_data(),
+                    cookies=request.cookies,
+                    allow_redirects=False,
+                    timeout=30,
+                )
+                excluded_headers = ["content-encoding", "content-length", "transfer-encoding", "connection"]
+                headers = [(k, v) for k, v in resp.raw.headers.items() if k.lower() not in excluded_headers]
+                return Response(resp.content, resp.status_code, headers)
+            except requests.RequestException as e:
+                return f"Error connecting to cluster {cluster}: {e}", 502
+
+        return app
+
+    def start(self) -> None:
+        app = self._create_app()
+        self.server = make_server("localhost", self.proxy_port, app, threaded=True)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        logger.info("Started Ray dashboard proxy on http://localhost:%d", self.proxy_port)
+
+    def stop(self) -> None:
+        if self.server:
+            self.server.shutdown()
+        if self.thread:
+            self.thread.join(timeout=5)

--- a/lib/fray/src/fray/v2/ray/deps.py
+++ b/lib/fray/src/fray/v2/ray/deps.py
@@ -1,0 +1,209 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compute Python package dependencies for Ray jobs."""
+
+import enum
+import hashlib
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from ray.runtime_env import RuntimeEnv
+
+logger = logging.getLogger("ray")
+
+# Packages to ignore when computing the runtime environment.
+# These will always be instead sourced from the base environment.
+IGNORE_DEPS = [
+    "ray",
+    "marin",
+]
+
+
+TORCH_GPU_PACKAGE_PREFIXES = (
+    "torch",
+    "torchvision",
+    "torchaudio",
+)
+
+
+class AcceleratorType(enum.Enum):
+    NONE = "none"
+    CPU = "cpu"
+    GPU = "gpu"
+    TPU = "tpu"
+
+
+def accelerator_type_from_extra(extra: list[str] | None = None) -> AcceleratorType:
+    if not extra:
+        return AcceleratorType.NONE
+
+    extra_set = set(extra)
+    if "tpu" in extra_set:
+        return AcceleratorType.TPU
+    elif "gpu" in extra_set or "vllm" in extra_set:
+        return AcceleratorType.GPU
+    elif "cpu" in extra_set:
+        return AcceleratorType.CPU
+    else:
+        return AcceleratorType.NONE
+
+
+def extra_flags(extra: list[str] | None = None) -> list[str]:
+    if not extra:
+        extra = []
+
+    accel_type = accelerator_type_from_extra(extra)
+    if accel_type == AcceleratorType.NONE:
+        extra.append("cpu")
+
+    extra_set = set(extra)
+
+    cmd = []
+    for ex in extra_set:
+        if ex.strip():
+            cmd.append(f"--extra={ex}")
+    return cmd
+
+
+@dataclass
+class PackageSpec:
+    package_specs: list[str]
+    py_modules: list[str]
+
+
+def compute_frozen_packages(extra: list[str] | None = None) -> PackageSpec:
+    cmd = [
+        "uv",
+        "export",
+        "--package",
+        "marin",
+        "--no-default-groups",
+        "--no-annotate",
+        "--no-hashes",
+        "--prune=ray",
+        *extra_flags(extra),
+    ]
+    result = subprocess.check_output(cmd, text=True)
+
+    # Parse the requirements.txt format output
+    py_modules = []
+    package_specs = []
+    for line in result.splitlines():
+        line = line.strip()
+        # Skip comments, empty lines, and editable installs
+        if not line or line.startswith("#") or line.startswith("./"):
+            continue
+        ignored = [line.startswith(f"{dep}==") or line.startswith(f"{dep}[") for dep in IGNORE_DEPS]
+        if any(ignored):
+            continue
+        if line.startswith("-e"):
+            # convert to a py_module. this isn't used for now, instead see `build_python_path`
+            py_modules.append(line[3:].strip())
+        else:
+            package_specs.append(line)
+
+    return PackageSpec(package_specs=package_specs, py_modules=py_modules)
+
+
+def build_python_path(submodules_dir: str = "submodules") -> list[str]:
+    """Build the PYTHONPATH for the given submodules.
+
+    Ray's installation process is... non-optimal. `py_modules` just injects
+    the exact "py_module" itself into the PYTHONPATH, but not e.g. the src dir.
+
+    You would think you'd be able to resolve that yourself but cleverly doing
+    something like -e {module_path} but noooo, that would be too easy. For whatever
+    reason, at install time, the py_modules are not yet in a usable state. So instead
+    we have to just manually guess what our PYTHONPATH should be.
+    """
+    # Workspace member src directories + experiments directory
+    paths = [
+        "experiments",
+        "lib/fray/src",
+        "lib/haliax/src",
+        "lib/levanter/src",
+        "lib/marin/src",
+        "lib/zephyr/src",
+    ]
+
+    if not os.path.exists(submodules_dir):
+        return paths
+
+    for submodule in os.listdir(submodules_dir):
+        submodule_path = os.path.join(submodules_dir, submodule)
+        if os.path.isdir(submodule_path):
+            paths.append(submodule_path)
+            src_path = os.path.join(submodule_path, "src")
+            if os.path.isdir(src_path):
+                paths.append(src_path)
+
+    return paths
+
+
+def build_runtime_env_for_packages(
+    extra: list[str] | None = None,
+    pip_packages: list[str] | None = None,
+    env_vars: dict | None = None,
+) -> RuntimeEnv:
+    """Inject the appropriate UV environment for the given packages."""
+    env_vars = dict(env_vars or {})
+    pip_packages = pip_packages or []
+    extra = extra or []
+
+    python_path = build_python_path()
+    if "PYTHONPATH" in env_vars:
+        python_path.extend(env_vars["PYTHONPATH"].split(":"))
+
+    package_spec = compute_frozen_packages(extra)
+
+    requirements_txt = [
+        """
+# Generated by fray/v2/ray/deps.py
+"""
+    ]
+    # Add resiliparse custom index
+    requirements_txt.append("--extra-index-url https://marin-community.github.io/chatnoir-resiliparse/simple")
+
+    torch_pkgs = []
+    for pkg in package_spec.package_specs + pip_packages:
+        # Defer torch-family installs to the end so that the --extra-index-url only applies to them
+        if pkg.startswith(TORCH_GPU_PACKAGE_PREFIXES):
+            torch_pkgs.append(pkg)
+            continue
+        requirements_txt.append(pkg)
+
+    # Force the correct PyTorch wheel index for the requested accelerator type
+    accel_type = accelerator_type_from_extra(extra)
+    if accel_type in {AcceleratorType.CPU, AcceleratorType.TPU, AcceleratorType.NONE}:
+        requirements_txt.append("--extra-index-url https://download.pytorch.org/whl/cpu")
+    elif accel_type == AcceleratorType.GPU:
+        requirements_txt.append("--extra-index-url https://download.pytorch.org/whl/cu128")
+
+    requirements_txt.extend(torch_pkgs)
+    requirements_txt_str = "\n".join(requirements_txt)
+
+    # Ray expects a filename for the requirements txt
+    req_hash = hashlib.sha256(requirements_txt_str.encode()).hexdigest()[:16]
+    req_path = f"/tmp/ray_reqs_{req_hash}.txt"
+    Path(req_path).write_text(requirements_txt_str)
+
+    return dict(  # type: ignore[return-value]
+        env_vars=env_vars | {"PYTHONPATH": ":".join(python_path)},
+        pip={"packages": req_path},
+        pip_check=False,
+    )

--- a/lib/fray/src/fray/v2/ray/fn_thunk.py
+++ b/lib/fray/src/fray/v2/ray/fn_thunk.py
@@ -1,0 +1,113 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Function thunk helper for executing cloudpickled callables.
+
+This is primarily used to convert function invocations into Ray jobs -- the Ray
+"job" entrypoint only accepts a command to run, not callables.
+
+Usage as CLI:
+    python -m fray.v2.ray.fn_thunk <fsspec-path>
+
+Usage as library:
+    >>> from fray.v2.ray.fn_thunk import create_thunk_entrypoint
+    >>> def my_fn():
+    ...     return "hello"
+    >>> entrypoint = create_thunk_entrypoint(my_fn, prefix="/tmp/job")
+    >>> # entrypoint is an Entrypoint(binary_entrypoint=BinaryEntrypoint(...))
+"""
+
+import logging
+import sys
+import tempfile
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import click
+import cloudpickle
+import fsspec
+
+from fray.v2.types import Entrypoint
+
+logger = logging.getLogger(__name__)
+
+
+def create_thunk_entrypoint(
+    callable_fn: Callable[..., Any],
+    prefix: str,
+    args: Sequence[Any] = (),
+    kwargs: dict[str, Any] | None = None,
+) -> Entrypoint:
+    """Serialize a callable and its arguments to a temporary file and return an Entrypoint.
+
+    Args:
+        callable_fn: Callable to serialize
+        prefix: File prefix for the pickled callable
+        args: Positional arguments to pass to callable
+        kwargs: Keyword arguments to pass to callable
+
+    Returns:
+        Entrypoint configured to execute the callable via fray.v2.ray.fn_thunk
+    """
+    if " " in prefix:
+        raise ValueError("prefix must not contain spaces")
+
+    with tempfile.NamedTemporaryFile(mode="wb", suffix=".pkl", prefix=prefix + "_", delete=False) as f:
+        cloudpickle.dump((callable_fn, args, kwargs or {}), f, protocol=cloudpickle.DEFAULT_PROTOCOL)
+        pickle_path = f.name
+
+    return Entrypoint.from_binary("python", ["-m", "fray.v2.ray.fn_thunk", pickle_path])
+
+
+@click.command()
+@click.argument("path", type=str)
+def main(path: str):
+    """Execute a cloudpickled callable from an fsspec-compatible path.
+
+    Args:
+        path: fsspec-compatible path to the cloudpickled callable
+    """
+    logging.basicConfig(
+        level=logging.INFO, format="%(filename)s:%(lineno)d %(asctime)s %(levelname)s %(message)s", stream=sys.stderr
+    )
+    try:
+        logger.info("Loading callable from %s", path)
+        with fsspec.open(path, "rb") as f:
+            payload = cloudpickle.load(f)
+            if isinstance(payload, tuple) and len(payload) == 3:
+                callable_fn, args, kwargs = payload
+            elif isinstance(payload, tuple) and len(payload) == 2:
+                # Legacy format: (callable, function_args_dict)
+                callable_fn, kwargs = payload
+                args = ()
+            else:
+                callable_fn = payload
+                args = ()
+                kwargs = {}
+    except Exception as e:
+        logger.error("Failed to load callable from %s: %s", path, e)
+        raise
+
+    try:
+        logger.info("Calling user entrypoint %s with args=%s, kwargs=%s", callable_fn, args, kwargs)
+        result = callable_fn(*args, **(kwargs or {}))
+        logger.info("Callable executed successfully. Result: %s", result)
+        return 0
+    except Exception as e:
+        logger.error("Failed to run callable: %s", e, exc_info=True)
+        return 1
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/fray/src/fray/v2/ray/resources.py
+++ b/lib/fray/src/fray/v2/ray/resources.py
@@ -1,0 +1,70 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ray-specific resource utilities for job scheduling."""
+
+from typing import Any
+
+import ray
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+
+from fray.v2.types import GpuConfig, ResourceConfig, TpuConfig
+
+
+def as_remote_kwargs(
+    config: ResourceConfig,
+    env_vars: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Get kwargs for ray.remote() decoration.
+
+    Args:
+        config: Resource configuration
+        env_vars: Optional environment variables for runtime_env
+    """
+    runtime_env = {"env_vars": env_vars} if env_vars else None
+
+    if isinstance(config.device, TpuConfig):
+        out: dict[str, Any] = {"num_cpus": 8}
+    elif isinstance(config.device, GpuConfig):
+        out = {"num_gpus": config.device.count}
+        if config.device.variant != "auto":
+            out["accelerator_type"] = config.device.variant
+    else:
+        out = {"num_cpus": 1}
+
+    if runtime_env:
+        out["runtime_env"] = runtime_env
+    return out
+
+
+def get_scheduling_strategy(config: ResourceConfig) -> PlacementGroupSchedulingStrategy | None:
+    """Create TPU placement group scheduling strategy."""
+    if not isinstance(config.device, TpuConfig):
+        return None
+
+    tpu_type_head = f"TPU-{config.device.variant}-head"
+    bundles: list[dict[str, int]] = [{"TPU": 1, "CPU": 1}] * config.chip_count()
+    bundles.append({tpu_type_head: 1})
+
+    pg = ray.util.placement_group(bundles, strategy="STRICT_PACK")
+    return PlacementGroupSchedulingStrategy(pg, placement_group_capture_child_tasks=True)
+
+
+def accelerator_descriptor(config: ResourceConfig) -> str | None:
+    """Get accelerator type string (e.g., 'v4-8', 'H100') for logging/tracking."""
+    if isinstance(config.device, TpuConfig):
+        return config.device.variant
+    elif isinstance(config.device, GpuConfig):
+        return config.device.variant
+    return None

--- a/lib/fray/src/fray/v2/ray/tpu.py
+++ b/lib/fray/src/fray/v2/ray/tpu.py
@@ -1,0 +1,911 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""TPU execution functions with gang scheduling and retry logic."""
+
+import logging
+import os
+import socket
+import time
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+import mergedeep
+import ray
+import requests
+from ray._private.accelerators import TPUAcceleratorManager
+from ray.actor import ActorHandle
+from ray.dag import FunctionNode
+from ray.exceptions import (
+    ActorDiedError,
+    ActorUnavailableError,
+    GetTimeoutError,
+    NodeDiedError,
+    OwnerDiedError,
+    RayActorError,
+    RayError,
+    RaySystemError,
+    RayTaskError,
+    WorkerCrashedError,
+)
+from ray.remote_function import RemoteFunction
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+from fray.v2.types import get_tpu_topology
+
+logger = logging.getLogger(__name__)
+
+# Timeouts (in seconds)
+HEALTH_CHECK_TIMEOUT = 60
+TEARDOWN_ACTOR_TIMEOUT = 5 * 60
+CANCEL_TASK_TIMEOUT = 4 * 60
+TERMINATE_ACTOR_TIMEOUT = 5 * 60
+START_ACTOR_TIMEOUT = 7 * 24 * 60 * 60  # 1 week
+
+# Intervals (in seconds)
+SCALE_UP_MULTISLICE_CHECK_INTERVAL = 3 * 60 * 60  # 3 hours
+SCALE_UP_MULTISLICE_INTERVAL = 12 * 60 * 60  # 12 hours
+
+
+def _get_current_tpu_pod_type() -> str:
+    """Return the TPU pod type for the current node across Ray versions."""
+
+    if hasattr(TPUAcceleratorManager, "_get_current_node_tpu_pod_type"):
+        return TPUAcceleratorManager._get_current_node_tpu_pod_type()
+    if hasattr(TPUAcceleratorManager, "get_current_node_tpu_pod_type"):
+        return TPUAcceleratorManager.get_current_node_tpu_pod_type()
+    raise AttributeError("TPUAcceleratorManager is missing TPU pod type helpers")
+
+
+def _get_current_node_tpu_worker_id() -> int | None:
+    """Return the TPU worker ID for the current node across Ray versions."""
+    if hasattr(TPUAcceleratorManager, "_get_current_node_tpu_worker_id"):
+        return TPUAcceleratorManager._get_current_node_tpu_worker_id()
+    if hasattr(TPUAcceleratorManager, "get_current_node_tpu_worker_id"):
+        return TPUAcceleratorManager.get_current_node_tpu_worker_id()
+    raise AttributeError("TPUAcceleratorManager is missing TPU worker ID helpers")
+
+
+@dataclass
+class SliceInfo:
+    """Information about a TPU slice."""
+
+    slice_name: str
+    num_vms: int
+    ip_address: str
+    num_tpus_per_vm: int
+
+
+@dataclass
+class MultisliceInfo:
+    """Information about a TPU multislice."""
+
+    coordinator_ip: str
+    slice_id: int
+    num_slices: int
+    port: int = 8081
+
+
+def _multislice_info_from_head(head: SliceInfo, slice_id: int, num_slices: int) -> MultisliceInfo:
+    return MultisliceInfo(
+        coordinator_ip=head.ip_address,
+        slice_id=slice_id,
+        num_slices=num_slices,
+        port=8081,
+    )
+
+
+def _multislice_info_to_env_vars(multislice: MultisliceInfo) -> dict[str, str]:
+    if multislice is not None:
+        mxla_env = {
+            "MEGASCALE_COORDINATOR_ADDRESS": f"{multislice.coordinator_ip}:{multislice.port}",
+            "MEGASCALE_NUM_SLICES": str(multislice.num_slices),
+            "MEGASCALE_PORT": f"{multislice.port}",
+            "MEGASCALE_SLICE_ID": str(multislice.slice_id),
+        }
+    else:
+        mxla_env = {}
+    return mxla_env
+
+
+@dataclass
+class _TpuRunResult:
+    """Internal class to hold the result of a TPU job."""
+
+    pass
+
+
+@dataclass
+class TpuSuccess(_TpuRunResult):
+    result: object
+
+
+@dataclass
+class TpuPreempted(_TpuRunResult):
+    error: Exception
+
+
+@dataclass
+class TpuFailed(_TpuRunResult):
+    error: Exception
+
+
+@dataclass
+class TpuRunError(_TpuRunResult):
+    error: Exception
+
+
+@dataclass
+class TpuCancelled(_TpuRunResult):
+    error: Exception
+
+
+@dataclass(frozen=True)
+class TPUHostInfo:
+    slice_name: str
+    worker_index: int
+    node_id: str
+    num_tpus: int
+
+
+ActorInfoT = TypeVar("ActorInfoT")
+
+
+@dataclass(frozen=True)
+class ActorPoolMember(Generic[ActorInfoT]):
+    actor: ActorHandle
+    actor_info: ActorInfoT
+
+
+SliceResource = ActorPoolMember[SliceInfo]
+
+
+def get_current_tpu_is_preempted() -> bool:
+    """Returns True if the current TPU is being preempted.
+
+    Queries the GCE metadata service to determine preemption status.
+    """
+    try:
+        response = requests.get(
+            "http://metadata.google.internal/computeMetadata/v1/instance/preempted",
+            headers={"Metadata-Flavor": "Google"},
+            timeout=5,
+        )
+        response.raise_for_status()
+        return response.text.lower() == "true"
+    except Exception:
+        return False
+
+
+def _handle_ray_error(e: RayError):
+    """Handle a Ray error from a TPU pod, classifying it as preemption, failure, or run error."""
+    if isinstance(e, NodeDiedError):
+        logger.exception("Node died", exc_info=e)
+        return TpuPreempted(e)
+    elif isinstance(e, OwnerDiedError):
+        logger.exception("Owner died", exc_info=e)
+        return TpuPreempted(e)
+    elif isinstance(e, ActorUnavailableError | ActorDiedError):
+        logger.exception("Actor died", exc_info=e)
+        return TpuPreempted(e)
+    elif isinstance(e, WorkerCrashedError):
+        logger.exception("Worker crashed", exc_info=e)
+        return TpuPreempted(e)
+    elif isinstance(e, RaySystemError):
+        logger.exception("System error", exc_info=e)
+        return TpuRunError(e)
+    elif isinstance(e, RayTaskError):
+        if get_current_tpu_is_preempted():
+            logger.exception("Preempted", exc_info=e)
+            return TpuPreempted(e)
+
+        logger.exception(f"Task error {e}", exc_info=e)
+        if isinstance(e.cause, TimeoutError) or "timed out" in str(e):
+            logger.exception("Timeout error. Assuming preempted", exc_info=e)
+            return TpuPreempted(e)
+        return TpuRunError(e)
+
+    else:
+        logger.exception("Unknown error", exc_info=e)
+        return TpuRunError(e)
+
+
+def _hacky_remove_tpu_lockfile():
+    """Remove the libtpu lockfile that persists across Ray tasks on non-Docker hosts."""
+    if os.path.exists("/tmp/libtpu_lockfile"):
+        try:
+            os.unlink("/tmp/libtpu_lockfile")
+        except FileNotFoundError:
+            pass
+        except PermissionError:
+            logger.warning("Failed to remove lockfile")
+            try:
+                os.system("sudo rm /tmp/libtpu_lockfile")
+            except Exception as ex:
+                logger.warning(f"Unexpected error removing lockfile with sudo: {ex}")
+
+
+def _validate_num_slices(num_slices: int | Sequence[int]):
+    if isinstance(num_slices, int):
+        is_valid = num_slices > 0
+    elif isinstance(num_slices, list):
+        is_valid = len(num_slices) > 0 and all(isinstance(n, int) and n > 0 for n in num_slices)
+    else:
+        is_valid = False
+    if not is_valid:
+        msg = (
+            f"num_slices must be a positive integer or non-empty list of positive integers, "
+            f"but instead it was {num_slices}"
+        )
+        raise Exception(msg)
+
+
+def _stop_actor(actor: ActorHandle) -> None:
+    try:
+        ray.get(actor.teardown.remote(), timeout=TEARDOWN_ACTOR_TIMEOUT)
+        ray.get(actor.__ray_terminate__.remote(), timeout=TERMINATE_ACTOR_TIMEOUT)
+    except (ActorDiedError, ActorUnavailableError):
+        pass
+    except GetTimeoutError as e:
+        logger.warning(
+            f"Failed to gracefully shut down actor in {TERMINATE_ACTOR_TIMEOUT} seconds; killing it instead: {e}"
+        )
+    finally:
+        ray.kill(actor)
+
+
+def _cancel_tasks_and_wait(tasks: list[ray.ObjectRef]) -> None:
+    _, tasks = ray.wait(tasks, timeout=0)
+    if not tasks:
+        return
+    logger.info(f"Cancelling {len(tasks)} tasks")
+    try:
+        for task in tasks:
+            ray.cancel(task, force=True, recursive=True)
+    except Exception as exc:
+        message = f"Failed to cancel {len(tasks)} tasks"
+        logger.error(message)
+        raise Exception(message) from exc
+    logger.info(f"Waiting for {len(tasks)} tasks to be cancelled.")
+    cancel_ready, cancel_unready = ray.wait(tasks, num_returns=len(tasks), timeout=CANCEL_TASK_TIMEOUT)
+    if cancel_unready:
+        message = f"Cancelled {len(cancel_ready)} tasks; could not cancel {len(cancel_unready)} tasks"
+        logger.error(message)
+        raise Exception(message)
+    else:
+        logger.info(f"Cancelled {len(cancel_ready)} tasks")
+
+
+def _start_fn_on_slice(
+    slice_actor: ActorHandle, remote_fn: RemoteFunction, mxla_env: dict | None
+) -> list[ray.ObjectRef]:
+    """Start the remote function on a slice of the TPU pod."""
+    runtime_env = remote_fn._runtime_env or {}
+    if mxla_env is not None:
+        mxla_env = dict(env_vars=mxla_env)
+        runtime_env = mergedeep.merge({}, runtime_env, mxla_env, strategy=mergedeep.Strategy.ADDITIVE)
+    futures_for_slice = ray.get(slice_actor.run_remote_fn.remote(remote_fn, runtime_env))
+    return futures_for_slice
+
+
+class ResourcePoolManager(ABC):
+    def __init__(self):
+        self._actor_pool: list[ActorPoolMember] = []
+
+    @abstractmethod
+    def get_actor_pool_name(self) -> str:
+        return str(self)
+
+    @abstractmethod
+    def get_actor_name_from_actor_info(self, actor_info) -> str:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def create_actor(self) -> ActorHandle:
+        raise NotImplementedError()
+
+    def get_all_actors_in_pool(self) -> list[ActorHandle]:
+        return [member.actor for member in self._actor_pool]
+
+    def get_all_pool_members(self) -> list[ActorPoolMember]:
+        return self._actor_pool.copy()
+
+    def _remove_unhealthy_members_from_actor_pool(self) -> None:
+        pool_name = self.get_actor_pool_name()
+        member_names = [self.get_actor_name_from_actor_info(m.actor_info) for m in self._actor_pool]
+        logger.info(f"{pool_name} actor pool members before removing unhealthy members: {member_names}")
+        members_and_health = [(member, member.actor.healthy.remote()) for member in self._actor_pool]
+        healthy_members: list[ActorPoolMember] = []
+        unhealthy_members: list[ActorPoolMember] = []
+        ray.wait(
+            [health for _, health in members_and_health],
+            num_returns=len(members_and_health),
+            timeout=HEALTH_CHECK_TIMEOUT,
+        )
+        for member, health in members_and_health:
+            try:
+                if ray.get(health, timeout=0):
+                    healthy_members.append(member)
+                else:
+                    pool_name = self.get_actor_pool_name()
+                    actor_name = self.get_actor_name_from_actor_info(member.actor_info)
+                    logger.warning(f"{pool_name} actor pool member {actor_name} is unhealthy. Removing from actor pool.")
+                    unhealthy_members.append(member)
+            except (
+                RayActorError,
+                RayTaskError,
+                ActorDiedError,
+                ActorUnavailableError,
+                GetTimeoutError,
+            ) as e:
+                pool_name = self.get_actor_pool_name()
+                actor_name = self.get_actor_name_from_actor_info(member.actor_info)
+                logger.warning(
+                    f"{pool_name} actor pool member {actor_name} is dead or unavailable. "
+                    f"Removing from actor pool. Error: {e}"
+                )
+                unhealthy_members.append(member)
+
+        for unhealthy_member in unhealthy_members:
+            _stop_actor(unhealthy_member.actor)
+
+        self._actor_pool = healthy_members
+        pool_name = self.get_actor_pool_name()
+        member_names = [self.get_actor_name_from_actor_info(m.actor_info) for m in self._actor_pool]
+        logger.info(f"{pool_name} actor pool members after unhealthy members: {member_names}")
+
+    def _add_members_to_actor_pool(self, desired_num_actors: int) -> None:
+        pool_name = self.get_actor_pool_name()
+        member_names = [self.get_actor_name_from_actor_info(m.actor_info) for m in self._actor_pool]
+        logger.info(
+            f"{pool_name} actor pool has {len(self._actor_pool)} members, "
+            f"scaling up to {desired_num_actors} members; current members: {member_names}"
+        )
+        actors = [self.create_actor() for _ in range(desired_num_actors - len(self._actor_pool))]
+        actors_and_actor_info_awaitables = [(actor, actor.get_info.remote()) for actor in actors]
+        logger.info(f"{self.get_actor_pool_name()} actor pool waiting for {len(actors)} new actors to start...")
+        ray.wait(
+            [actor_info_awaitable for _, actor_info_awaitable in actors_and_actor_info_awaitables],
+            num_returns=len(actors_and_actor_info_awaitables),
+            timeout=START_ACTOR_TIMEOUT,
+        )
+        for actor, actor_info_awaitable in actors_and_actor_info_awaitables:
+            try:
+                actor_info = ray.get(actor_info_awaitable, timeout=0)
+            except Exception as e:
+                pool_name = self.get_actor_pool_name()
+                logger.exception(f"{pool_name} actor pool actor {actor} failed to start: {e}")
+                _stop_actor(actor)
+                continue
+            pool_name = self.get_actor_pool_name()
+            actor_name = self.get_actor_name_from_actor_info(actor_info)
+            logger.info(f"{pool_name} actor pool member {actor_name} started.")
+            self._actor_pool.append(ActorPoolMember(actor, actor_info))
+        pool_name = self.get_actor_pool_name()
+        member_names = [self.get_actor_name_from_actor_info(m.actor_info) for m in self._actor_pool]
+        logger.info(f"{pool_name} actor pool scaled up to {len(self._actor_pool)} members: {member_names}")
+
+    def _remove_members_from_actor_pool(self, desired_num_actors: int) -> None:
+        pool_name = self.get_actor_pool_name()
+        member_names = [self.get_actor_name_from_actor_info(m.actor_info) for m in self._actor_pool]
+        logger.info(
+            f"{pool_name} actor pool has {len(self._actor_pool)} members; "
+            f"scaling down to {desired_num_actors} members; current members: {member_names}"
+        )
+        members_to_remove = self._actor_pool[desired_num_actors:]
+        self._actor_pool = self._actor_pool[:desired_num_actors]
+        for member in members_to_remove:
+            pool_name = self.get_actor_pool_name()
+            actor_name = self.get_actor_name_from_actor_info(member.actor_info)
+            logger.info(f"{pool_name} actor pool member {actor_name} stopping.")
+            _stop_actor(member.actor)
+        pool_name = self.get_actor_pool_name()
+        member_names = [self.get_actor_name_from_actor_info(m.actor_info) for m in self._actor_pool]
+        logger.info(f"{pool_name} actor pool scaled down to {len(self._actor_pool)} members: {member_names}")
+
+    def _scale_actor_pool(self, desired_num_actors: int) -> None:
+        if self._actor_pool:
+            self._remove_unhealthy_members_from_actor_pool()
+        if len(self._actor_pool) < desired_num_actors:
+            self._add_members_to_actor_pool(desired_num_actors)
+        elif len(self._actor_pool) > desired_num_actors:
+            self._remove_members_from_actor_pool(desired_num_actors)
+        else:
+            pool_name = self.get_actor_pool_name()
+            logger.info(
+                f"{pool_name} actor pool already has {len(self._actor_pool)} members, "
+                f"and we wanted {desired_num_actors}. Skipping scaling."
+            )
+            return
+        if len(self._actor_pool) != desired_num_actors:
+            pool_name = self.get_actor_pool_name()
+            msg = (
+                f"{pool_name} actor pool wanted to scale to {desired_num_actors} actors, "
+                f"but scaled to {len(self._actor_pool)} actors instead"
+            )
+            raise Exception(msg)
+
+    def drain_actor_pool(self) -> None:
+        logger.info(f"{self.get_actor_pool_name()} actor pool members draining.")
+        self._remove_members_from_actor_pool(0)
+        logger.info(f"{self.get_actor_pool_name()} actor pool drained.")
+
+
+class SlicePoolManager(ResourcePoolManager):
+    def __init__(self, tpu_type: str):
+        super().__init__()
+        self._tpu_type = tpu_type
+        self._last_scale_multislice_time: float | None = None
+        self._last_check_should_scale_up_multislice_time: float | None = None
+
+    def get_actor_pool_name(self) -> str:
+        return f"{self._tpu_type} slices"
+
+    def get_actor_name_from_actor_info(self, actor_info: SliceInfo) -> str:
+        return str(actor_info.slice_name)
+
+    def create_actor(self) -> ActorHandle:
+        return SliceActor.options(resources={f"TPU-{self._tpu_type}-head": 1}).remote()  # type: ignore
+
+    def scale_multislice(self, num_slices: int | Sequence[int]) -> None:
+        self._last_scale_multislice_time = time.time()
+
+        if isinstance(num_slices, int):
+            self._scale_actor_pool(num_slices)
+            return
+
+        sorted_valid_sizes = sorted(num_slices)
+        max_valid_size = sorted_valid_sizes[-1]
+
+        logger.info(
+            f"Attempting to scale to {max_valid_size} slices based on the maximum of valid sizes: {sorted_valid_sizes}"
+        )
+        try:
+            self._scale_actor_pool(max_valid_size)
+        except Exception as e:
+            logger.warning(f"Error when scaling to {max_valid_size} slices: {e}")
+
+        if len(self._actor_pool) in num_slices:
+            return
+
+        current_size = len(self._actor_pool)
+        feasible_sizes = [size for size in sorted_valid_sizes if size <= current_size]
+
+        if not feasible_sizes:
+            raise Exception(
+                f"Only got {current_size} slices, which is not enough for minimum of valid sizes: {sorted_valid_sizes}"
+            )
+
+        max_feasible_size = feasible_sizes[-1]
+        logger.warning(
+            f"Attempting to scale to {max_feasible_size} slices "
+            f"based on a feasible size in valid sizes: {sorted_valid_sizes}"
+        )
+        try:
+            self._scale_actor_pool(max_feasible_size)
+        except Exception as e:
+            logger.warning(f"Error when scaling to {max_feasible_size} slices: {e}")
+
+        if len(self._actor_pool) not in num_slices:
+            raise Exception(f"Could not scale to {max_feasible_size} slices")
+
+    def check_should_scale_up_multislice(self, num_slices: int | Sequence[int]) -> bool:
+        if isinstance(num_slices, int):
+            return False
+
+        current_time = time.time()
+        last_check_time = self._last_check_should_scale_up_multislice_time
+        self._last_check_should_scale_up_multislice_time = current_time
+        if last_check_time is None or current_time - last_check_time < SCALE_UP_MULTISLICE_CHECK_INTERVAL:
+            return False
+
+        if (
+            self._last_scale_multislice_time is None
+            or current_time - self._last_scale_multislice_time < SCALE_UP_MULTISLICE_INTERVAL
+        ):
+            return False
+
+        sorted_valid_sizes = sorted(num_slices)
+        current_size = len(self._actor_pool)
+        larger_sizes = [size for size in sorted_valid_sizes if size > current_size]
+        if not larger_sizes:
+            return False
+        next_larger_size = larger_sizes[0]
+
+        previous_size = len(self._actor_pool)
+        logger.info(
+            f"Currently have {previous_size} slices; next larger size is {next_larger_size} "
+            f"(valid sizes: {num_slices}). Trying to acquire more slices."
+        )
+        self._add_members_to_actor_pool(next_larger_size)
+        if len(self._actor_pool) == next_larger_size:
+            logger.info(f"Successfully acquired more slices; now have {next_larger_size} slices.")
+            return True
+        else:
+            logger.info(
+                f"Wanted {next_larger_size} slices but could only get {len(self._actor_pool)} slices; "
+                f"scaling slices back down to previous size {previous_size}."
+            )
+            self._remove_members_from_actor_pool(previous_size)
+            return False
+
+
+@ray.remote
+class SliceActor(ResourcePoolManager):
+    """Actor that manages a single TPU slice."""
+
+    def __init__(self):
+        super().__init__()
+        self._failed = False
+        self._slice_info: SliceInfo | None = None
+
+    def healthy(self) -> bool:
+        return not self._failed and not self.is_being_preempted()
+
+    def is_being_preempted(self) -> bool:
+        return get_current_tpu_is_preempted()
+
+    def get_actor_pool_name(self) -> str:
+        assert self._slice_info
+        return f"slice {self._slice_info.slice_name}"
+
+    def get_actor_name_from_actor_info(self, actor_info: TPUHostInfo) -> str:
+        return str(actor_info.worker_index)
+
+    def create_actor(self) -> ActorHandle:
+        assert self._slice_info
+        slice_name = self._slice_info.slice_name
+        return TPUHostActor.options(resources={slice_name: 1}, num_cpus=0.0).remote(self._slice_info)  # type: ignore
+
+    def get_info(self) -> SliceInfo:
+        pod_name = ray.util.accelerators.tpu.get_current_pod_name()
+        tpe = _get_current_tpu_pod_type()
+
+        config = get_tpu_topology(tpe)
+
+        ip_address = socket.gethostbyname(socket.gethostname())
+
+        logger.info(f"TPU type: {tpe}, {config}")
+
+        self._slice_info = SliceInfo(
+            slice_name=pod_name,
+            num_vms=config.vm_count,
+            num_tpus_per_vm=config.chips_per_vm,
+            ip_address=ip_address,
+        )
+        self._scale_actor_pool(config.vm_count)
+        return self._slice_info
+
+    def run_remote_fn(self, remote_fn: RemoteFunction, runtime_env: dict) -> list[ray.ObjectRef]:
+        """Run the remote function on this slice."""
+        actors = self.get_all_actors_in_pool()
+        if not self._slice_info or len(actors) < self._slice_info.num_vms:
+            raise Exception("Insufficient host actors; call setup() before calling run_remote_fn()")
+        futures_of_futures: list[ray.ObjectRef] = [
+            actor.run_remote_fn.remote(remote_fn, runtime_env) for actor in actors
+        ]
+        return [ray.get(future_of_future) for future_of_future in futures_of_futures]
+
+    def teardown(self):
+        self.drain_actor_pool()
+        self._slice_info = None
+
+
+@ray.remote
+class TPUHostActor:
+    """Actor that manages a single TPU host."""
+
+    def __init__(self, slice_info: SliceInfo):
+        self._awaitable: ray.ObjectRef | None = None
+        self._host_info: TPUHostInfo | None = None
+        self._slice_info = slice_info
+
+    def healthy(self) -> bool:
+        return not self.is_being_preempted()
+
+    def is_being_preempted(self) -> bool:
+        return get_current_tpu_is_preempted()
+
+    def get_info(self) -> TPUHostInfo:
+        if self._host_info:
+            return self._host_info
+
+        worker_id = _get_current_node_tpu_worker_id()
+        if worker_id is None:
+            raise Exception("Could not get TPU worker ID. This should never happen.")
+        self._host_info = TPUHostInfo(
+            slice_name=self._slice_info.slice_name,
+            worker_index=worker_id,
+            node_id=ray.get_runtime_context().get_node_id(),
+            num_tpus=self._slice_info.num_tpus_per_vm,
+        )
+        return self._host_info
+
+    def run_remote_fn(self, remote_fn: RemoteFunction, runtime_env: dict) -> ray.ObjectRef:
+        """Run the remote function on this host."""
+        if not self._host_info:
+            raise Exception("Call setup() before calling run_remote_fn()")
+
+        if self._awaitable:
+            _cancel_tasks_and_wait([self._awaitable])
+        _hacky_remove_tpu_lockfile()
+
+        self._awaitable = remote_fn.options(
+            scheduling_strategy=NodeAffinitySchedulingStrategy(self._host_info.node_id, soft=False),
+            resources={
+                "TPU": self._host_info.num_tpus,
+            },
+            num_cpus=8,
+            num_gpus=0,
+            memory=20e9,
+            runtime_env=runtime_env,
+        ).remote()
+        return self._awaitable
+
+    def teardown(self) -> None:
+        if self._awaitable:
+            _cancel_tasks_and_wait([self._awaitable])
+        self._awaitable = None
+        self._host_info = None
+
+
+def run_on_pod(
+    remote_fn: RemoteFunction | Callable,
+    tpu_type: str,
+    *,
+    num_slices: int | Sequence[int] = 1,
+    max_retries_preemption=10000,
+    max_retries_failure=10,
+):
+    """Repeatedly run a function on a TPU pod until it succeeds or max retries reached.
+
+    This function blocks until completion. Use run_on_pod_ray for async.
+    """
+    _validate_num_slices(num_slices)
+
+    return ray.get(run_on_pod_ray.remote(remote_fn, tpu_type, num_slices, max_retries_preemption, max_retries_failure))
+
+
+@ray.remote(num_cpus=0.1, max_retries=-1, retry_exceptions=False)
+def run_on_pod_ray(
+    remote_fn: RemoteFunction,
+    tpu_type: str,
+    num_slices: int | Sequence[int] = 1,
+    max_retries_preemption: int = 10000,
+    max_retries_failure: int = 10,
+):
+    """Repeatedly run a function on a TPU pod until it succeeds or max retries reached.
+
+    This is a Ray remote function callable from anywhere in the cluster.
+    """
+    _validate_num_slices(num_slices)
+
+    num_failures = 0
+    num_preemptions = 0
+
+    slice_pool: list[SliceResource] = []
+    problems: list[Exception] = []
+    problem: Exception | None
+
+    if isinstance(remote_fn, FunctionNode):
+        raise ValueError(
+            "Remote function must be a Ray remote function or a plain function, not a FunctionNode. Don't use bind."
+        )
+    elif not isinstance(remote_fn, RemoteFunction):
+        remote_fn = ray.remote(max_calls=1)(remote_fn)
+    elif remote_fn._default_options.get("max_calls") is None:
+        raise ValueError("Remote function must have max_calls set to 1 for TPU workloads.")
+
+    slice_pool_manager = SlicePoolManager(tpu_type)
+
+    try:
+        while num_failures <= max_retries_failure and num_preemptions <= max_retries_preemption:
+            logger.info(
+                f"Running on {num_slices} x TPU {tpu_type}. "
+                f"Previous failures: {num_failures}. Previous pre-emptions: {num_preemptions}."
+            )
+            problems.clear()
+
+            try:
+                slice_pool_manager.scale_multislice(num_slices)
+                slice_pool = slice_pool_manager.get_all_pool_members()
+            except Exception as e:
+                logger.exception("Failed to prune dead slices or create new actors", exc_info=e)
+                problems.append(e)
+                num_preemptions += 1
+                continue
+
+            head_slice_info = slice_pool[0].actor_info if len(slice_pool) > 1 else None
+
+            futures: list[ray.ObjectRef] = []
+            future_to_index: dict[ray.ObjectRef, int] = {}
+            global_index = 0
+
+            try:
+                for i, tpu_slice in enumerate(slice_pool):
+                    if head_slice_info is not None:
+                        multislice_info = _multislice_info_from_head(head_slice_info, i, len(slice_pool))
+                        mxla_env = _multislice_info_to_env_vars(multislice_info)
+                    else:
+                        mxla_env = {}
+
+                    futures_for_slice = _start_fn_on_slice(tpu_slice.actor, remote_fn, mxla_env)
+                    logger.info(f"Futures for slice {tpu_slice.actor_info.slice_name}: {futures_for_slice}")
+
+                    futures.extend(futures_for_slice)
+                    for future in futures_for_slice:
+                        future_to_index[future] = global_index
+                        global_index += 1
+            except RayError as e:
+                logger.exception("Failed to start remote function on slice", exc_info=e)
+                problems.append(e)
+                num_preemptions += 1
+                continue
+
+            if not futures:
+                error = "Failed to schedule any futures"
+                exception = RuntimeError(error)
+                logger.exception(error, exc_info=exception)
+                problems.append(exception)
+                break
+
+            tpu_results: list[_TpuRunResult | None] = [None] * len(futures)
+
+            pending_futures = list(futures)
+            had_a_failure = False
+            should_scale_up_multislice = False
+
+            actor_health_futures = [tpu_slice.actor.healthy.remote() for tpu_slice in slice_pool]
+
+            while pending_futures:
+                finished, pending_futures = ray.wait(pending_futures, num_returns=1, timeout=10.0)
+
+                for f in finished:
+                    try:
+                        tpu_results[future_to_index[f]] = TpuSuccess(ray.get(f))
+                    except RayError as e:
+                        had_a_failure = True
+                        problems.append(e)
+                        tpu_results[future_to_index[f]] = _handle_ray_error(e)
+                    except Exception as e:
+                        logger.warning(f"Task {f} failed with unexpected error {e}. Will retry.")
+                        had_a_failure = True
+                        tpu_results[future_to_index[f]] = TpuRunError(e)
+
+                if had_a_failure:
+                    break
+
+                try:
+                    actor_healths = ray.get(actor_health_futures, timeout=HEALTH_CHECK_TIMEOUT)
+                except RayError as e:
+                    logger.warning("Failed to get actor healths", exc_info=e)
+                    had_a_failure = True
+                else:
+                    for i, healthy in enumerate(actor_healths):
+                        if not healthy:
+                            logger.warning(f"Actor {slice_pool[i]} is unhealthy. Will retry.")
+                            had_a_failure = True
+
+                if had_a_failure:
+                    break
+
+                should_scale_up_multislice = slice_pool_manager.check_should_scale_up_multislice(num_slices)
+                if should_scale_up_multislice:
+                    break
+
+            if pending_futures:
+                logger.info(f"Failure detected. Cancelling {len(pending_futures)} pending futures.")
+                try:
+                    _cancel_tasks_and_wait(pending_futures)
+                except Exception as e:
+                    logger.error(f"Could not cancel all pending futures: {e}")
+                for f in pending_futures:
+                    index = future_to_index.get(f)
+                    if index is not None:
+                        tpu_results[index] = TpuCancelled(
+                            RuntimeError("Task was cancelled due to a failure in another task")
+                        )
+                    else:
+                        logger.warning(f"Future {f} was not found in future_to_index. Skipping.")
+
+            out_results: list = []
+            any_preempted = False
+            any_failed = False
+            any_cancelled = False
+
+            for result in tpu_results:
+                if isinstance(result, TpuSuccess):
+                    out_results.append(result.result)
+                elif isinstance(result, TpuPreempted):
+                    problems.append(result.error)
+                    any_preempted = True
+                elif isinstance(result, TpuFailed):
+                    any_preempted = True
+                    problems.append(result.error)
+                    logger.warning(f"TPU node failure. Treating as preempted: {num_preemptions} times")
+                elif isinstance(result, TpuRunError):
+                    problems.append(result.error)
+                    any_failed = True
+                elif isinstance(result, TpuCancelled):
+                    logger.info("TPU job was cancelled, probably because something else failed.")
+                    any_cancelled = True
+                elif result is None:
+                    raise AssertionError("We should never have None results here.")
+                else:
+                    raise RuntimeError(f"Unexpected result: {result}")
+
+            if any_preempted:
+                problem = problems[0] if problems else RuntimeError("TPU job was preempted")
+                num_preemptions += 1
+                if any_failed:
+                    logger.exception(
+                        f"Preempted {num_preemptions} times. "
+                        "Got some failures, but assuming they are due to preemption.",
+                        exc_info=problem,
+                    )
+                else:
+                    logger.warning(f"Preempted {num_preemptions} times. Continuing to retry.", exc_info=problem)
+                continue
+            elif any_failed:
+                problem = problems[0] if problems else RuntimeError("TPU job failed")
+                num_failures += 1
+                logger.warning(f"Failed {num_failures} times. Continuing to retry.", exc_info=problem)
+                continue
+            elif any_cancelled:
+                logger.info("A slice's task was cancelled, probably due to another slice's failure. Retrying.")
+                continue
+            elif should_scale_up_multislice:
+                logger.info("Additional slices are available. Increasing the number of slices and retrying.")
+                num_preemptions += 1
+                continue
+            else:
+                logger.info("All slices succeeded. Returning results.")
+                return out_results
+    except Exception as e:
+        logger.exception("Unexpected error. This is a bug in fray. Please report it.", exc_info=e)
+        raise
+    finally:
+        logger.info("Cleaning up actors")
+        slice_pool_manager.drain_actor_pool()
+
+    problem = problems[0] if problems else None
+
+    if num_preemptions > max_retries_preemption:
+        logger.exception("Preempted too many times", exc_info=problem)
+        raise RuntimeError("TPU job was preempted too many times") from problem
+    elif num_failures >= max_retries_failure:
+        logger.exception("Failed too many times", exc_info=problem)
+        raise problem or RuntimeError("TPU job failed too many times")
+    else:
+        raise RuntimeError("Unknown error occurred during TPU job") from problem
+
+
+def run_on_pod_multislice(
+    remote_fn: RemoteFunction | Callable, tpu_type: str, num_slices: Sequence[int]
+) -> list[ray.ObjectRef]:
+    """Run a remote function on multiple TPU slices."""
+    return ray.get(
+        run_on_pod(
+            remote_fn,
+            tpu_type,
+            num_slices=num_slices,
+            max_retries_failure=0,
+            max_retries_preemption=0,
+        )
+    )

--- a/lib/fray/src/fray/v2/types.py
+++ b/lib/fray/src/fray/v2/types.py
@@ -1,0 +1,501 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Type definitions for fray v2.
+
+Standalone dataclasses with no v1 backend dependencies. Copied from
+fray.cluster.base with one structural change: `replicas` moves from
+ResourceConfig to JobRequest (it's a job-level gang-scheduling concern,
+not a per-task resource requirement).
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Literal, Self
+
+# ---------------------------------------------------------------------------
+# TPU topology
+# ---------------------------------------------------------------------------
+
+TpuType = Literal[
+    "v4-8",
+    "v4-16",
+    "v4-32",
+    "v4-64",
+    "v4-128",
+    "v4-256",
+    "v4-512",
+    "v4-1024",
+    "v4-2048",
+    "v4-4096",
+    "v5litepod-1",
+    "v5litepod-4",
+    "v5litepod-8",
+    "v5litepod-16",
+    "v5litepod-32",
+    "v5litepod-64",
+    "v5litepod-128",
+    "v5litepod-256",
+    "v5p-8",
+    "v5p-16",
+    "v5p-32",
+    "v5p-64",
+    "v5p-128",
+    "v5p-256",
+    "v5p-384",
+    "v5p-512",
+    "v5p-640",
+    "v5p-768",
+    "v5p-896",
+    "v5p-1024",
+    "v5p-1152",
+    "v5p-1280",
+    "v5p-1408",
+    "v5p-1536",
+    "v5p-1664",
+    "v5p-1792",
+    "v5p-1920",
+    "v5p-2048",
+    "v5p-2176",
+    "v5p-2304",
+    "v5p-2432",
+    "v5p-2560",
+    "v5p-2688",
+    "v5p-2816",
+    "v5p-2944",
+    "v5p-3072",
+    "v5p-3200",
+    "v5p-3328",
+    "v5p-3456",
+    "v5p-3584",
+    "v5p-3712",
+    "v5p-3840",
+    "v5p-3968",
+    "v5p-4096",
+    "v5p-4224",
+    "v5p-4352",
+    "v5p-4480",
+    "v5p-4608",
+    "v5p-4736",
+    "v5p-4864",
+    "v5p-4992",
+    "v5p-5120",
+    "v5p-5248",
+    "v5p-5376",
+    "v5p-5504",
+    "v5p-5632",
+    "v5p-5760",
+    "v5p-5888",
+    "v5p-6016",
+    "v5p-6144",
+    "v5p-6272",
+    "v5p-6400",
+    "v5p-6528",
+    "v5p-6656",
+    "v5p-6784",
+    "v5p-6912",
+    "v5p-7040",
+    "v5p-7168",
+    "v5p-7296",
+    "v5p-7424",
+    "v5p-7552",
+    "v5p-7680",
+    "v5p-7808",
+    "v5p-7936",
+    "v5p-8064",
+    "v5p-8192",
+    "v5p-8320",
+    "v5p-8448",
+    "v5p-8576",
+    "v5p-8704",
+    "v5p-8832",
+    "v5p-8960",
+    "v5p-9088",
+    "v5p-9216",
+    "v5p-9344",
+    "v5p-9472",
+    "v5p-9600",
+    "v5p-9728",
+    "v5p-9856",
+    "v5p-9984",
+    "v5p-10240",
+    "v5p-10368",
+    "v5p-10496",
+    "v5p-10624",
+    "v5p-10752",
+    "v5p-10880",
+    "v5p-11008",
+    "v5p-11136",
+    "v5p-11264",
+    "v5p-11392",
+    "v5p-11520",
+    "v5p-11648",
+    "v5p-11776",
+    "v5p-11904",
+    "v5p-12032",
+    "v5p-12160",
+    "v5p-12288",
+    "v6e-1",
+    "v6e-4",
+    "v6e-8",
+    "v6e-16",
+    "v6e-32",
+    "v6e-64",
+    "v6e-128",
+    "v6e-256",
+]
+
+GpuType = Literal[
+    "A10",
+    "A100-40G",
+    "A100-80G",
+    "A10G",
+    "B100",
+    "H100",
+    "H200",
+    "L4",
+    "T4",
+    "V100",
+    "auto",
+]
+
+
+@dataclass(frozen=True)
+class TpuTopologyInfo:
+    name: str
+    chip_count: int
+    host_count: int
+    vm_count: int
+    chips_per_vm: int
+
+
+TPU_TOPOLOGIES: list[TpuTopologyInfo] = [
+    TpuTopologyInfo("v4-8", 4, 1, 1, 4),
+    TpuTopologyInfo("v4-16", 8, 2, 2, 4),
+    TpuTopologyInfo("v4-32", 16, 4, 4, 4),
+    TpuTopologyInfo("v4-64", 32, 8, 8, 4),
+    TpuTopologyInfo("v4-128", 64, 16, 16, 4),
+    TpuTopologyInfo("v4-256", 128, 32, 32, 4),
+    TpuTopologyInfo("v4-512", 256, 64, 64, 4),
+    TpuTopologyInfo("v4-1024", 512, 128, 128, 4),
+    TpuTopologyInfo("v4-2048", 1024, 256, 256, 4),
+    TpuTopologyInfo("v4-4096", 2048, 512, 512, 4),
+    TpuTopologyInfo("v5litepod-1", 1, 1, 1, 1),
+    TpuTopologyInfo("v5litepod-2", 2, 1, 1, 2),
+    TpuTopologyInfo("v5litepod-4", 4, 1, 1, 4),
+    TpuTopologyInfo("v5litepod-8", 8, 1, 1, 8),
+    TpuTopologyInfo("v5litepod-16", 16, 2, 4, 4),
+    TpuTopologyInfo("v5litepod-32", 32, 4, 8, 4),
+    TpuTopologyInfo("v5litepod-64", 64, 8, 16, 4),
+    TpuTopologyInfo("v5litepod-128", 128, 16, 32, 4),
+    TpuTopologyInfo("v5litepod-256", 256, 32, 64, 4),
+    TpuTopologyInfo("v5p-8", 4, 1, 1, 4),
+    TpuTopologyInfo("v5p-16", 8, 2, 2, 4),
+    TpuTopologyInfo("v5p-32", 16, 4, 4, 4),
+    TpuTopologyInfo("v5p-64", 32, 8, 8, 4),
+    TpuTopologyInfo("v5p-128", 64, 16, 16, 4),
+    TpuTopologyInfo("v5p-256", 128, 32, 32, 4),
+    TpuTopologyInfo("v5p-512", 256, 64, 64, 4),
+    TpuTopologyInfo("v5p-1024", 512, 128, 128, 4),
+    TpuTopologyInfo("v5p-2048", 1024, 256, 256, 4),
+    TpuTopologyInfo("v5p-4096", 2048, 512, 512, 4),
+    TpuTopologyInfo("v5p-8192", 4096, 1024, 1024, 4),
+    TpuTopologyInfo("v5p-12288", 6144, 1536, 1536, 4),
+    TpuTopologyInfo("v6e-1", 1, 1, 1, 1),
+    TpuTopologyInfo("v6e-4", 4, 1, 1, 4),
+    TpuTopologyInfo("v6e-8", 8, 1, 1, 8),
+    TpuTopologyInfo("v6e-16", 16, 4, 4, 4),
+    TpuTopologyInfo("v6e-32", 32, 8, 8, 4),
+    TpuTopologyInfo("v6e-64", 64, 16, 16, 4),
+    TpuTopologyInfo("v6e-128", 128, 32, 32, 4),
+    TpuTopologyInfo("v6e-256", 256, 64, 64, 4),
+]
+
+
+def get_tpu_topology(tpu_type: str) -> TpuTopologyInfo:
+    """Get TPU topology by type name."""
+    for config in TPU_TOPOLOGIES:
+        if config.name == tpu_type:
+            return config
+    raise ValueError(f"Unknown TPU type: {tpu_type}")
+
+
+DeviceKind = Literal["cpu", "gpu", "tpu"]
+
+
+@dataclass(frozen=True)
+class CpuConfig:
+    """CPU-only device configuration."""
+
+    kind: DeviceKind = "cpu"
+    variant: str = "cpu"
+
+    def chip_count(self) -> int:
+        return 0
+
+    def device_flops(self, dtype: str = "bf16") -> float:
+        raise NotImplementedError("CPU FLOPS not available")
+
+
+@dataclass(frozen=True)
+class GpuConfig:
+    """GPU device configuration."""
+
+    variant: GpuType
+    kind: DeviceKind = "gpu"
+    count: int = 1
+
+    def chip_count(self) -> int:
+        return self.count
+
+    def device_flops(self, dtype: str = "bf16") -> float:
+        from fray.v2.device_flops import device_flops
+
+        flops = device_flops(self.variant, dtype)
+        if flops is None:
+            raise ValueError(f"Unknown device/dtype: {self.variant}/{dtype}")
+        return flops
+
+    def total_flops(self, dtype: str = "bf16") -> float:
+        return self.device_flops(dtype) * self.count
+
+
+@dataclass(frozen=True)
+class TpuConfig:
+    """TPU device configuration.
+
+    Args:
+        variant: TPU accelerator type (e.g., "v5litepod-16", "v4-8")
+        topology: Optional topology specification (e.g., "2x2x1")
+    """
+
+    variant: TpuType
+    kind: DeviceKind = "tpu"
+    topology: str | None = None
+
+    def chip_count(self) -> int:
+        return get_tpu_topology(self.variant).chip_count
+
+    def vm_count(self) -> int:
+        return get_tpu_topology(self.variant).vm_count
+
+    def device_flops(self, dtype: str = "bf16") -> float:
+        from fray.v2.device_flops import device_flops
+
+        flops = device_flops(self.variant, dtype)
+        if flops is None:
+            raise ValueError(f"Unknown device/dtype: {self.variant}/{dtype}")
+        return flops
+
+    def total_flops(self, dtype: str = "bf16") -> float:
+        return self.device_flops(dtype) * self.chip_count()
+
+
+DeviceConfig = CpuConfig | GpuConfig | TpuConfig
+
+
+@dataclass
+class ResourceConfig:
+    """Resource requirements for a single task/replica.
+
+    `replicas` specifies gang-scheduled replica count (e.g. TPU slices for
+    multislice training). It is also on JobRequest; when both are set,
+    JobRequest.replicas takes precedence. This field exists here so that
+    convenience builders like `with_tpu(..., slice_count=4)` can carry the
+    replica count alongside the resource spec.
+    """
+
+    cpu: int = 1
+    ram: str = "128m"
+    disk: str = "1g"
+    device: DeviceConfig = field(default_factory=CpuConfig)
+    preemptible: bool = True
+    regions: Sequence[str] | None = None
+    replicas: int = 1
+
+    def chip_count(self) -> int:
+        return self.device.chip_count()
+
+    def device_flops(self, dtype: str = "bf16") -> float:
+        return self.device.device_flops(dtype)
+
+    def total_flops(self, dtype: str = "bf16") -> float:
+        if isinstance(self.device, CpuConfig):
+            return 100e9
+        return self.device_flops(dtype) * self.chip_count()
+
+    @staticmethod
+    def with_tpu(tpu_type: str, *, slice_count: int = 1, **kwargs: Any) -> ResourceConfig:
+        device = TpuConfig(variant=tpu_type)
+        return ResourceConfig(device=device, replicas=slice_count, **kwargs)
+
+    @staticmethod
+    def with_gpu(gpu_type: str = "auto", count: int = 1, **kwargs: Any) -> ResourceConfig:
+        device = GpuConfig(variant=gpu_type, count=count)
+        return ResourceConfig(device=device, **kwargs)
+
+    @staticmethod
+    def with_cpu(**kwargs: Any) -> ResourceConfig:
+        return ResourceConfig(device=CpuConfig(), **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Environment
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EnvironmentConfig:
+    """Job environment configuration.
+
+    Args:
+        workspace: Path to workspace root for uv-based execution
+        docker_image: Docker image for containerized execution
+        pip_packages: Additional pip packages to install
+        env_vars: Environment variables to set
+        extras: Extra dependency groups for uv (e.g., ["tpu", "eval"])
+    """
+
+    workspace: str | None = None
+    docker_image: str | None = None
+    pip_packages: Sequence[str] = field(default_factory=list)
+    env_vars: dict[str, str] = field(default_factory=dict)
+    extras: Sequence[str] = field(default_factory=list)
+
+    def __post_init__(self):
+        if self.workspace and self.docker_image:
+            raise ValueError("Cannot specify both workspace and docker_image")
+        if not self.workspace and not self.docker_image:
+            raise ValueError("Must specify either workspace or docker_image")
+
+
+def create_environment(
+    workspace: str | None = None,
+    docker_image: str | None = None,
+    pip_packages: Sequence[str] | None = None,
+    env_vars: dict[str, str] | None = None,
+    extras: Sequence[str] | None = None,
+) -> EnvironmentConfig:
+    """Create an EnvironmentConfig with sensible defaults.
+
+    Sets HF_DATASETS_TRUST_REMOTE_CODE, TOKENIZERS_PARALLELISM, HF_TOKEN,
+    and WANDB_API_KEY from the current environment by default.
+    """
+    if workspace is None and docker_image is None:
+        workspace = os.getcwd()
+
+    default_env_vars = {
+        "HF_DATASETS_TRUST_REMOTE_CODE": "1",
+        "TOKENIZERS_PARALLELISM": "false",
+        "HF_TOKEN": os.getenv("HF_TOKEN"),
+        "WANDB_API_KEY": os.getenv("WANDB_API_KEY"),
+        "MARIN_CI_DISABLE_RUNTIME_ENVS": os.getenv("MARIN_CI_DISABLE_RUNTIME_ENVS"),
+    }
+
+    merged_env_vars = {k: v for k, v in {**default_env_vars, **(env_vars or {})}.items() if v is not None}
+
+    return EnvironmentConfig(
+        workspace=workspace,
+        docker_image=docker_image,
+        pip_packages=list(pip_packages or []),
+        env_vars=merged_env_vars,
+        extras=list(extras or []),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entrypoints
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BinaryEntrypoint:
+    command: str
+    args: Sequence[str]
+
+
+@dataclass(frozen=True)
+class CallableEntrypoint:
+    callable: Callable[..., Any]
+    args: Sequence[Any] = field(default_factory=tuple)
+    kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Entrypoint:
+    callable_entrypoint: CallableEntrypoint | None = None
+    binary_entrypoint: BinaryEntrypoint | None = None
+
+    @staticmethod
+    def from_callable(
+        c: Callable[..., Any],
+        args: Sequence[Any] = (),
+        kwargs: dict[str, Any] | None = None,
+    ) -> Self:
+        return Entrypoint(callable_entrypoint=CallableEntrypoint(callable=c, args=args, kwargs=kwargs or {}))
+
+    @staticmethod
+    def from_binary(command: str, args: Sequence[str]) -> Self:
+        return Entrypoint(binary_entrypoint=BinaryEntrypoint(command=command, args=args))
+
+
+# ---------------------------------------------------------------------------
+# Job
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class JobRequest:
+    """Complete job specification for submission.
+
+    Args:
+        name: Human-readable job name (no spaces)
+        entrypoint: Job entrypoint (command-line or callable)
+        resources: Resource requirements per replica
+        environment: Environment configuration (dependencies, env vars)
+        replicas: Gang-scheduled replicas (e.g. TPU slices for multislice training)
+        max_retries_failure: Max retries on failure
+        max_retries_preemption: Max retries on preemption
+    """
+
+    name: str
+    entrypoint: Entrypoint
+    resources: ResourceConfig = field(default_factory=ResourceConfig)
+    environment: EnvironmentConfig | None = None
+    replicas: int | None = None
+    max_retries_failure: int = 0
+    max_retries_preemption: int = 100
+
+    def __post_init__(self):
+        if " " in self.name:
+            raise ValueError("Job name must not contain spaces")
+        if self.replicas is None:
+            # Pick up replicas from ResourceConfig (set by e.g. with_tpu slice_count)
+            self.replicas = self.resources.replicas
+
+
+class JobStatus(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    STOPPED = "stopped"
+
+    @staticmethod
+    def finished(status: JobStatus) -> bool:
+        return status in (JobStatus.SUCCEEDED, JobStatus.FAILED, JobStatus.STOPPED)

--- a/lib/fray/tests/test_v2_actor.py
+++ b/lib/fray/tests/test_v2_actor.py
@@ -1,0 +1,138 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for fray v2 actor support via LocalClient."""
+
+import threading
+
+import pytest
+
+from fray.v2 import JobStatus, LocalClient
+
+
+class Counter:
+    def __init__(self, start: int = 0):
+        self._value = start
+
+    def increment(self, amount: int = 1) -> int:
+        self._value += amount
+        return self._value
+
+    def get(self) -> int:
+        return self._value
+
+
+class Adder:
+    def add(self, a: int, b: int) -> int:
+        return a + b
+
+
+@pytest.fixture
+def client():
+    c = LocalClient(max_threads=4)
+    yield c
+    c.shutdown(wait=True)
+
+
+def test_create_actor_and_call_remote(client: LocalClient):
+    actor = client.create_actor(Counter, name="counter")
+    result = actor.increment.remote(5).result()
+    assert result == 5
+    assert actor.get.remote().result() == 5
+
+
+def test_create_actor_synchronous_call(client: LocalClient):
+    actor = client.create_actor(Counter, start=10, name="counter")
+    assert actor.get() == 10
+    actor.increment(3)
+    assert actor.get() == 13
+
+
+def test_create_actor_with_args(client: LocalClient):
+    actor = client.create_actor(Counter, 42, name="counter")
+    assert actor.get.remote().result() == 42
+
+
+def test_actor_group_create_and_wait_ready(client: LocalClient):
+    group = client.create_actor_group(Counter, name="counters", count=3)
+    assert group.ready_count == 3
+    handles = group.wait_ready()
+    assert len(handles) == 3
+
+    for i, h in enumerate(handles):
+        h.increment.remote(i + 1).result()
+
+    values = [h.get.remote().result() for h in handles]
+    assert values == [1, 2, 3]
+
+
+def test_actor_group_wait_ready_partial(client: LocalClient):
+    group = client.create_actor_group(Counter, name="counters", count=5)
+    handles = group.wait_ready(count=2)
+    assert len(handles) == 2
+
+
+def test_actor_group_wait_ready_too_many(client: LocalClient):
+    group = client.create_actor_group(Counter, name="counters", count=2)
+    with pytest.raises(ValueError, match="Requested 5"):
+        group.wait_ready(count=5)
+
+
+def test_actor_group_statuses(client: LocalClient):
+    group = client.create_actor_group(Counter, name="counters", count=3)
+    statuses = group.statuses()
+    assert all(s == JobStatus.SUCCEEDED for s in statuses)
+
+
+def test_actor_group_shutdown(client: LocalClient):
+    group = client.create_actor_group(Counter, name="counters", count=2)
+    group.shutdown()
+    statuses = group.statuses()
+    assert all(s == JobStatus.STOPPED for s in statuses)
+
+
+def test_actor_group_jobs(client: LocalClient):
+    group = client.create_actor_group(Counter, name="counters", count=3)
+    assert len(group.jobs) == 3
+    for job in group.jobs:
+        assert "counters" in job.job_id
+
+
+def test_concurrent_remote_calls_thread_safety(client: LocalClient):
+    """Multiple threads calling .remote() on the same actor should be safe."""
+    actor = client.create_actor(Counter, name="counter")
+    num_threads = 10
+    results: list[int] = [0] * num_threads
+    barrier = threading.Barrier(num_threads)
+
+    def worker(idx: int):
+        barrier.wait()
+        results[idx] = actor.increment.remote(1).result()
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(num_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Each increment adds 1, so final value should be num_threads.
+    # Individual results should be unique values 1..num_threads (serialized by lock).
+    assert actor.get() == num_threads
+    assert sorted(results) == list(range(1, num_threads + 1))
+
+
+def test_actor_method_with_kwargs(client: LocalClient):
+    actor = client.create_actor(Adder, name="adder")
+    assert actor.add.remote(a=3, b=4).result() == 7
+    assert actor.add(a=10, b=20) == 30

--- a/lib/fray/tests/test_v2_client.py
+++ b/lib/fray/tests/test_v2_client.py
@@ -1,0 +1,141 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for fray v2 Client protocol, LocalClient, and wait_all."""
+
+import threading
+import time
+
+import pytest
+
+from fray.v2 import (
+    Entrypoint,
+    JobFailed,
+    JobRequest,
+    JobStatus,
+    LocalClient,
+    wait_all,
+)
+
+
+@pytest.fixture
+def client():
+    c = LocalClient(max_threads=4)
+    yield c
+    c.shutdown(wait=True)
+
+
+def _noop():
+    pass
+
+
+def _sleep_then_succeed():
+    time.sleep(0.1)
+
+
+def _fail():
+    raise RuntimeError("intentional failure")
+
+
+def _return_value():
+    return 42
+
+
+def test_submit_callable_succeeds(client: LocalClient):
+    handle = client.submit(JobRequest(name="ok", entrypoint=Entrypoint.from_callable(_noop)))
+    status = handle.wait()
+    assert status == JobStatus.SUCCEEDED
+
+
+def test_submit_callable_failure(client: LocalClient):
+    handle = client.submit(JobRequest(name="fail", entrypoint=Entrypoint.from_callable(_fail)))
+    status = handle.wait(raise_on_failure=False)
+    assert status == JobStatus.FAILED
+
+
+def test_submit_callable_failure_raises(client: LocalClient):
+    handle = client.submit(JobRequest(name="fail", entrypoint=Entrypoint.from_callable(_fail)))
+    with pytest.raises(RuntimeError, match="intentional failure"):
+        handle.wait(raise_on_failure=True)
+
+
+def test_job_id_contains_name(client: LocalClient):
+    handle = client.submit(JobRequest(name="my-job", entrypoint=Entrypoint.from_callable(_noop)))
+    assert "my-job" in handle.job_id
+    handle.wait()
+
+
+def test_status_transitions(client: LocalClient):
+    handle = client.submit(JobRequest(name="slow", entrypoint=Entrypoint.from_callable(_sleep_then_succeed)))
+    # Should be running or pending initially
+    initial = handle.status()
+    assert initial in (JobStatus.PENDING, JobStatus.RUNNING)
+    handle.wait()
+    assert handle.status() == JobStatus.SUCCEEDED
+
+
+def test_terminate():
+    """Terminate marks a job as STOPPED even if the underlying thread is still running."""
+    stop = threading.Event()
+
+    def hang():
+        stop.wait(10)
+
+    c = LocalClient(max_threads=4)
+    handle = c.submit(JobRequest(name="hang", entrypoint=Entrypoint.from_callable(hang)))
+    time.sleep(0.05)
+    handle.terminate()
+    assert handle.status() == JobStatus.STOPPED
+    stop.set()  # unblock the thread so the executor can shut down
+    c.shutdown(wait=True)
+
+
+def test_wait_all_all_succeed(client: LocalClient):
+    handles = [client.submit(JobRequest(name=f"ok-{i}", entrypoint=Entrypoint.from_callable(_noop))) for i in range(3)]
+    statuses = wait_all(handles)
+    assert all(s == JobStatus.SUCCEEDED for s in statuses)
+
+
+def test_wait_all_mixed_failure(client: LocalClient):
+    h_ok = client.submit(JobRequest(name="ok", entrypoint=Entrypoint.from_callable(_noop)))
+    h_fail = client.submit(JobRequest(name="fail", entrypoint=Entrypoint.from_callable(_fail)))
+    with pytest.raises(JobFailed):
+        wait_all([h_ok, h_fail], raise_on_failure=True)
+
+
+def test_wait_all_no_raise(client: LocalClient):
+    h_ok = client.submit(JobRequest(name="ok", entrypoint=Entrypoint.from_callable(_noop)))
+    h_fail = client.submit(JobRequest(name="fail", entrypoint=Entrypoint.from_callable(_fail)))
+    statuses = wait_all([h_ok, h_fail], raise_on_failure=False)
+    assert statuses[0] == JobStatus.SUCCEEDED
+    assert statuses[1] == JobStatus.FAILED
+
+
+def test_wait_all_empty():
+    assert wait_all([]) == []
+
+
+def test_wait_all_timeout():
+    stop = threading.Event()
+
+    def hang():
+        stop.wait(10)
+
+    c = LocalClient(max_threads=4)
+    handle = c.submit(JobRequest(name="hang", entrypoint=Entrypoint.from_callable(hang)))
+    with pytest.raises(TimeoutError):
+        wait_all([handle], timeout=0.2)
+    handle.terminate()
+    stop.set()
+    c.shutdown(wait=True)

--- a/lib/fray/tests/test_v2_current_client.py
+++ b/lib/fray/tests/test_v2_current_client.py
@@ -1,0 +1,88 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for current_client() and set_current_client()."""
+
+import pytest
+
+from fray.v2.client import current_client, set_current_client
+from fray.v2.local import LocalClient
+
+
+def test_default_returns_local_client():
+    client = current_client()
+    assert isinstance(client, LocalClient)
+
+
+def test_set_current_client_context_manager():
+    explicit = LocalClient(max_threads=2)
+    with set_current_client(explicit) as c:
+        assert c is explicit
+        assert current_client() is explicit
+    # After exiting, should return a fresh default
+    assert current_client() is not explicit
+
+
+def test_set_current_client_restores_on_exception():
+    explicit = LocalClient(max_threads=2)
+    with pytest.raises(RuntimeError):
+        with set_current_client(explicit):
+            raise RuntimeError("boom")
+    assert current_client() is not explicit
+
+
+def test_env_var_local(monkeypatch):
+    monkeypatch.setenv("FRAY_CLIENT_SPEC", "local")
+    client = current_client()
+    assert isinstance(client, LocalClient)
+
+
+def test_env_var_local_with_threads(monkeypatch):
+    monkeypatch.setenv("FRAY_CLIENT_SPEC", "local?threads=4")
+    client = current_client()
+    assert isinstance(client, LocalClient)
+    assert client._executor._max_workers == 4
+
+
+def test_env_var_ray_returns_ray_client(monkeypatch):
+    from fray.v2.ray.backend import RayClient
+
+    monkeypatch.setenv("FRAY_CLIENT_SPEC", "ray")
+    client = current_client()
+    assert isinstance(client, RayClient)
+
+
+def test_env_var_iris_creates_client(monkeypatch):
+    from unittest.mock import patch
+
+    monkeypatch.setenv("FRAY_CLIENT_SPEC", "iris://host:1234")
+    with patch("fray.v2.iris_backend.IrisClientLib"):
+        from fray.v2.iris_backend import FrayIrisClient
+
+        client = current_client()
+        assert isinstance(client, FrayIrisClient)
+
+
+def test_explicit_client_overrides_env_var(monkeypatch):
+    monkeypatch.setenv("FRAY_CLIENT_SPEC", "ray")
+    explicit = LocalClient(max_threads=1)
+    with set_current_client(explicit):
+        # Should not raise NotImplementedError because explicit takes priority
+        assert current_client() is explicit
+
+
+def test_unknown_spec_raises(monkeypatch):
+    monkeypatch.setenv("FRAY_CLIENT_SPEC", "unknown_backend")
+    with pytest.raises(ValueError, match="Unknown FRAY_CLIENT_SPEC"):
+        current_client()

--- a/lib/fray/tests/test_v2_iris.py
+++ b/lib/fray/tests/test_v2_iris.py
@@ -1,0 +1,213 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the fray v2 Iris backend.
+
+Tests type conversions and handle serialization without requiring an Iris cluster.
+Integration tests that need a running cluster are marked with @pytest.mark.iris.
+"""
+
+import pickle
+
+
+from fray.v2.iris_backend import (
+    IrisActorHandle,
+    convert_constraints,
+    convert_entrypoint,
+    convert_resources,
+    map_iris_job_state,
+)
+from fray.v2.types import (
+    CpuConfig,
+    Entrypoint,
+    GpuConfig,
+    JobStatus,
+    ResourceConfig,
+    TpuConfig,
+)
+
+# ---------------------------------------------------------------------------
+# ResourceConfig → ResourceSpec conversion
+# ---------------------------------------------------------------------------
+
+
+class TestConvertResources:
+    def test_cpu_defaults(self):
+        resources = ResourceConfig()
+        spec = convert_resources(resources)
+        assert spec.cpu == 1
+        assert spec.memory == "128m"
+        assert spec.disk == "1g"
+        assert spec.device is None
+
+    def test_tpu_device(self):
+        resources = ResourceConfig(device=TpuConfig(variant="v5litepod-16"))
+        spec = convert_resources(resources)
+        assert spec.device is not None
+        assert spec.device.HasField("tpu")
+        assert spec.device.tpu.variant == "v5litepod-16"
+
+    def test_gpu_device(self):
+        resources = ResourceConfig(device=GpuConfig(variant="H100", count=8))
+        spec = convert_resources(resources)
+        assert spec.device is not None
+        assert spec.device.HasField("gpu")
+        assert spec.device.gpu.variant == "H100"
+        assert spec.device.gpu.count == 8
+
+    def test_cpu_device_produces_no_device(self):
+        resources = ResourceConfig(device=CpuConfig())
+        spec = convert_resources(resources)
+        assert spec.device is None
+
+    def test_regions_passed_through(self):
+        resources = ResourceConfig(regions=["us-central1", "us-east1"])
+        spec = convert_resources(resources)
+        assert list(spec.regions) == ["us-central1", "us-east1"]
+
+
+# ---------------------------------------------------------------------------
+# Constraints
+# ---------------------------------------------------------------------------
+
+
+class TestConvertConstraints:
+    def test_preemptible_true_produces_no_constraints(self):
+        resources = ResourceConfig(preemptible=True)
+        constraints = convert_constraints(resources)
+        assert constraints == []
+
+    def test_preemptible_false_adds_constraint(self):
+        resources = ResourceConfig(preemptible=False)
+        constraints = convert_constraints(resources)
+        assert len(constraints) == 1
+        c = constraints[0]
+        assert c.key == "preemptible"
+        assert c.value == "false"
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint conversion
+# ---------------------------------------------------------------------------
+
+
+def _dummy_fn(x: int) -> int:
+    return x + 1
+
+
+class TestConvertEntrypoint:
+    def test_callable_entrypoint(self):
+        entry = Entrypoint.from_callable(_dummy_fn, args=(42,))
+        iris_entry = convert_entrypoint(entry)
+        assert iris_entry.is_callable
+
+    def test_binary_entrypoint(self):
+        entry = Entrypoint.from_binary("python", ["-c", "print('hi')"])
+        iris_entry = convert_entrypoint(entry)
+        assert iris_entry.is_command
+        assert iris_entry.command == ["python", "-c", "print('hi')"]
+
+
+# ---------------------------------------------------------------------------
+# JobStatus mapping
+# ---------------------------------------------------------------------------
+
+
+class TestMapIrisJobState:
+    def test_succeeded(self):
+        from iris.rpc import cluster_pb2
+
+        assert map_iris_job_state(cluster_pb2.JOB_STATE_SUCCEEDED) == JobStatus.SUCCEEDED
+
+    def test_failed(self):
+        from iris.rpc import cluster_pb2
+
+        assert map_iris_job_state(cluster_pb2.JOB_STATE_FAILED) == JobStatus.FAILED
+
+    def test_killed_maps_to_stopped(self):
+        from iris.rpc import cluster_pb2
+
+        assert map_iris_job_state(cluster_pb2.JOB_STATE_KILLED) == JobStatus.STOPPED
+
+    def test_running(self):
+        from iris.rpc import cluster_pb2
+
+        assert map_iris_job_state(cluster_pb2.JOB_STATE_RUNNING) == JobStatus.RUNNING
+
+    def test_pending(self):
+        from iris.rpc import cluster_pb2
+
+        assert map_iris_job_state(cluster_pb2.JOB_STATE_PENDING) == JobStatus.PENDING
+
+    def test_worker_failed_maps_to_failed(self):
+        from iris.rpc import cluster_pb2
+
+        assert map_iris_job_state(cluster_pb2.JOB_STATE_WORKER_FAILED) == JobStatus.FAILED
+
+    def test_unschedulable_maps_to_failed(self):
+        from iris.rpc import cluster_pb2
+
+        assert map_iris_job_state(cluster_pb2.JOB_STATE_UNSCHEDULABLE) == JobStatus.FAILED
+
+
+# ---------------------------------------------------------------------------
+# IrisActorHandle pickle round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestIrisActorHandlePickle:
+    def test_pickle_roundtrip_preserves_name(self):
+        handle = IrisActorHandle("my-actor")
+        data = pickle.dumps(handle)
+        restored = pickle.loads(data)
+        assert restored._actor_name == "my-actor"
+        assert restored._client is None
+
+    def test_pickle_drops_client(self):
+        """Client is transient state — pickle should not carry it."""
+        handle = IrisActorHandle("my-actor", client="fake-client")
+        data = pickle.dumps(handle)
+        restored = pickle.loads(data)
+        assert restored._client is None
+
+
+# ---------------------------------------------------------------------------
+# FRAY_CLIENT_SPEC parsing for iris://
+# ---------------------------------------------------------------------------
+
+
+class TestIrisClientSpec:
+    def test_iris_spec_parses(self):
+        """Verify iris:// spec creates FrayIrisClient (mocked — no real controller)."""
+        from unittest.mock import patch
+
+        with patch("fray.v2.iris_backend.IrisClientLib") as mock_iris:
+            from fray.v2.client import _parse_client_spec
+            from fray.v2.iris_backend import FrayIrisClient
+
+            client = _parse_client_spec("iris://controller:10000")
+            assert isinstance(client, FrayIrisClient)
+            mock_iris.remote.assert_called_once_with("controller:10000", workspace=None)
+
+    def test_iris_spec_with_workspace(self):
+        from pathlib import Path
+        from unittest.mock import patch
+
+        with patch("fray.v2.iris_backend.IrisClientLib") as mock_iris:
+            from fray.v2.client import _parse_client_spec
+            from fray.v2.iris_backend import FrayIrisClient
+
+            client = _parse_client_spec("iris://controller:10000?ws=/tmp/my-workspace")
+            assert isinstance(client, FrayIrisClient)
+            mock_iris.remote.assert_called_once_with("controller:10000", workspace=Path("/tmp/my-workspace"))

--- a/lib/fray/tests/test_v2_ray.py
+++ b/lib/fray/tests/test_v2_ray.py
@@ -1,0 +1,286 @@
+# Copyright 2025 The Marin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the fray v2 Ray backend that run WITHOUT a real Ray cluster.
+
+Tests resource mapping, entrypoint routing, retry count calculation, and
+runtime environment building logic.
+"""
+
+import pytest
+
+from fray.v2.types import (
+    CpuConfig,
+    Entrypoint,
+    GpuConfig,
+    JobRequest,
+    ResourceConfig,
+    TpuConfig,
+)
+
+# ---------------------------------------------------------------------------
+# compute_ray_retry_count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "max_failure, max_preemption, expected",
+    [
+        (0, 100, 100),
+        (3, 10, 13),
+        (0, 0, 0),
+        (5, 0, 5),
+    ],
+)
+def test_compute_ray_retry_count(max_failure, max_preemption, expected):
+    from fray.v2.ray.backend import compute_ray_retry_count
+
+    request = JobRequest(
+        name="test",
+        entrypoint=Entrypoint.from_callable(lambda: None),
+        max_retries_failure=max_failure,
+        max_retries_preemption=max_preemption,
+    )
+    assert compute_ray_retry_count(request) == expected
+
+
+# ---------------------------------------------------------------------------
+# get_entrypoint_params — resource mapping
+# ---------------------------------------------------------------------------
+
+
+def test_entrypoint_params_cpu():
+    from fray.v2.ray.backend import get_entrypoint_params
+
+    request = JobRequest(
+        name="cpu-job",
+        entrypoint=Entrypoint.from_binary("echo", ["hello"]),
+        resources=ResourceConfig(cpu=4, ram="2g"),
+    )
+    params = get_entrypoint_params(request)
+    assert params["entrypoint_num_cpus"] == 4.0
+    assert "entrypoint_num_gpus" not in params
+    assert params["entrypoint_memory"] > 0
+
+
+def test_entrypoint_params_gpu():
+    from fray.v2.ray.backend import get_entrypoint_params
+
+    request = JobRequest(
+        name="gpu-job",
+        entrypoint=Entrypoint.from_binary("train", []),
+        resources=ResourceConfig(device=GpuConfig(variant="H100", count=4)),
+    )
+    params = get_entrypoint_params(request)
+    assert params["entrypoint_num_gpus"] == 4.0
+
+
+def test_entrypoint_params_tpu():
+    from fray.v2.ray.backend import get_entrypoint_params
+
+    request = JobRequest(
+        name="tpu-job",
+        entrypoint=Entrypoint.from_binary("train", []),
+        resources=ResourceConfig(device=TpuConfig(variant="v4-8")),
+    )
+    params = get_entrypoint_params(request)
+    assert "entrypoint_resources" in params
+    assert params["entrypoint_resources"]["TPU-v4-8-head"] == 1.0
+    assert params["entrypoint_resources"]["TPU"] == 4.0  # v4-8 has 4 chips
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint routing logic
+# ---------------------------------------------------------------------------
+
+
+def test_routing_tpu_job_requires_callable():
+    """TPU jobs must have a callable entrypoint."""
+    request = JobRequest(
+        name="tpu-binary",
+        entrypoint=Entrypoint.from_binary("train", []),
+        resources=ResourceConfig(device=TpuConfig(variant="v4-8")),
+    )
+    # The submit method checks isinstance(device, TpuConfig) and then
+    # asserts callable_entrypoint is not None. We verify the assertion
+    # would be hit by checking the entrypoint directly.
+    assert request.entrypoint.callable_entrypoint is None
+    assert request.entrypoint.binary_entrypoint is not None
+
+
+def test_routing_binary_job():
+    """Binary entrypoint routes to _launch_binary_job."""
+    request = JobRequest(
+        name="binary-job",
+        entrypoint=Entrypoint.from_binary("echo", ["hello"]),
+        resources=ResourceConfig(device=CpuConfig()),
+    )
+    assert request.entrypoint.binary_entrypoint is not None
+    assert not isinstance(request.resources.device, TpuConfig)
+
+
+def test_routing_callable_job():
+    """Callable entrypoint on non-TPU device routes to _launch_callable_job."""
+    request = JobRequest(
+        name="callable-job",
+        entrypoint=Entrypoint.from_callable(lambda: 42),
+        resources=ResourceConfig(device=CpuConfig()),
+    )
+    assert request.entrypoint.callable_entrypoint is not None
+    assert request.entrypoint.binary_entrypoint is None
+    assert not isinstance(request.resources.device, TpuConfig)
+
+
+# ---------------------------------------------------------------------------
+# Replicas mapping
+# ---------------------------------------------------------------------------
+
+
+def test_replicas_on_job_request():
+    """JobRequest.replicas is the gang-scheduling count (maps to num_slices for TPU)."""
+    request = JobRequest(
+        name="multi-slice",
+        entrypoint=Entrypoint.from_callable(lambda: None),
+        resources=ResourceConfig(device=TpuConfig(variant="v4-8")),
+        replicas=4,
+    )
+    assert request.replicas == 4
+
+
+# ---------------------------------------------------------------------------
+# Resource mapping helpers (fray.v2.ray.resources)
+# ---------------------------------------------------------------------------
+
+
+def test_as_remote_kwargs_cpu():
+    from fray.v2.ray.resources import as_remote_kwargs
+
+    config = ResourceConfig(device=CpuConfig())
+    kwargs = as_remote_kwargs(config)
+    assert kwargs == {"num_cpus": 1}
+
+
+def test_as_remote_kwargs_gpu():
+    from fray.v2.ray.resources import as_remote_kwargs
+
+    config = ResourceConfig(device=GpuConfig(variant="H100", count=2))
+    kwargs = as_remote_kwargs(config)
+    assert kwargs["num_gpus"] == 2
+    assert kwargs["accelerator_type"] == "H100"
+
+
+def test_as_remote_kwargs_gpu_auto():
+    from fray.v2.ray.resources import as_remote_kwargs
+
+    config = ResourceConfig(device=GpuConfig(variant="auto", count=1))
+    kwargs = as_remote_kwargs(config)
+    assert kwargs["num_gpus"] == 1
+    assert "accelerator_type" not in kwargs
+
+
+def test_as_remote_kwargs_tpu():
+    from fray.v2.ray.resources import as_remote_kwargs
+
+    config = ResourceConfig(device=TpuConfig(variant="v4-32"))
+    kwargs = as_remote_kwargs(config)
+    assert kwargs["num_cpus"] == 8
+
+
+def test_as_remote_kwargs_with_env_vars():
+    from fray.v2.ray.resources import as_remote_kwargs
+
+    config = ResourceConfig(device=CpuConfig())
+    kwargs = as_remote_kwargs(config, env_vars={"FOO": "bar"})
+    assert kwargs["runtime_env"] == {"env_vars": {"FOO": "bar"}}
+
+
+def test_accelerator_descriptor():
+    from fray.v2.ray.resources import accelerator_descriptor
+
+    assert accelerator_descriptor(ResourceConfig(device=TpuConfig(variant="v4-8"))) == "v4-8"
+    assert accelerator_descriptor(ResourceConfig(device=GpuConfig(variant="H100"))) == "H100"
+    assert accelerator_descriptor(ResourceConfig(device=CpuConfig())) is None
+
+
+# ---------------------------------------------------------------------------
+# Runtime env building — JAX_PLATFORMS logic
+# ---------------------------------------------------------------------------
+
+
+def test_build_runtime_env_cpu_sets_jax_platforms():
+    from fray.v2.ray.backend import build_runtime_env
+
+    request = JobRequest(
+        name="cpu-test",
+        entrypoint=Entrypoint.from_callable(lambda: None),
+        resources=ResourceConfig(device=CpuConfig()),
+    )
+    env = build_runtime_env(request, "ray")
+    assert env["env_vars"]["JAX_PLATFORMS"] == "cpu"
+
+
+def test_build_runtime_env_tpu_clears_jax_platforms():
+    from fray.v2.ray.backend import build_runtime_env
+
+    request = JobRequest(
+        name="tpu-test",
+        entrypoint=Entrypoint.from_callable(lambda: None),
+        resources=ResourceConfig(device=TpuConfig(variant="v4-8")),
+    )
+    env = build_runtime_env(request, "ray")
+    assert env["env_vars"]["JAX_PLATFORMS"] == ""
+
+
+def test_build_runtime_env_gpu_clears_jax_platforms():
+    from fray.v2.ray.backend import build_runtime_env
+
+    request = JobRequest(
+        name="gpu-test",
+        entrypoint=Entrypoint.from_callable(lambda: None),
+        resources=ResourceConfig(device=GpuConfig(variant="H100")),
+    )
+    env = build_runtime_env(request, "ray")
+    assert env["env_vars"]["JAX_PLATFORMS"] == ""
+
+
+def test_build_runtime_env_sets_fray_client_spec():
+    from fray.v2.ray.backend import build_runtime_env
+
+    request = JobRequest(
+        name="spec-test",
+        entrypoint=Entrypoint.from_callable(lambda: None),
+    )
+    env = build_runtime_env(request, "ray?namespace=test-ns")
+    assert env["env_vars"]["FRAY_CLIENT_SPEC"] == "ray?namespace=test-ns"
+
+
+# ---------------------------------------------------------------------------
+# Actor resource mapping (_actor_ray_options)
+# ---------------------------------------------------------------------------
+
+
+def test_actor_options_default_preemptible():
+    from fray.v2.ray.backend import _actor_ray_options
+
+    options = _actor_ray_options(ResourceConfig())
+    assert options["num_cpus"] == 0
+    assert "resources" not in options
+
+
+def test_actor_options_non_preemptible_pins_head_node():
+    from fray.v2.ray.backend import _actor_ray_options
+
+    options = _actor_ray_options(ResourceConfig(preemptible=False))
+    assert options["num_cpus"] == 0
+    assert options["resources"] == {"head_node": 0.0001}


### PR DESCRIPTION
- Adds `fray/v2/` package alongside existing `fray.cluster`/`fray.job` code (purely additive, no existing code changed)
- Defines `Client`, `ActorHandle`, `ActorGroup`, `JobHandle` protocols
- Implements `LocalClient`, `RayClient`, `FrayIrisClient` backends
- Includes `current_client()` with `FRAY_CLIENT_SPEC` env var resolution
- Adds design docs and research notes

Partially handles #2552 