### PR TITLE
Iris: disable httpx logging by default

### DIFF
--- a/lib/iris/src/iris/logging.py
+++ b/lib/iris/src/iris/logging.py
@@ -109,4 +109,7 @@ def configure_logging(level: int = logging.INFO) -> LogRingBuffer:
     ring_handler.setFormatter(formatter)
     root.addHandler(ring_handler)
 
+    # Suppress noisy httpx logging
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
     return _global_buffer


### PR DESCRIPTION
Suppress noisy httpx INFO logs in controller/worker by setting the httpx logger to WARNING level in configure_logging().

Fixes #2606