### PR TITLE
Fix claude yaml (base -> bash). Try to add `gh` access.

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,4 +61,5 @@ jobs:
           # prompt: 'Update the pull request description to include a summary of changes.'
 
           # Allow rebase and pre-commit operations
-          claude_args: '--allowed-tools "Bash(git rebase:*)" "Bash(git fetch:*)" "Bash(./infra/pre-commit.py:*)" "Bash(uv run:*)" Base(uv run --script:*)"'
+          claude_args: '--allowed-tools "Bash(git *)" "Bash(./infra/pre-commit.py:*)" "Bash(uv *)" "Bash(pytest *)" "Bash(gh *)"'
+


### PR DESCRIPTION
I've been trying to offload little tasks to the Claude helper, and realized I had broken the "uv" access string. I don't think there's harm it in having access to git (inside of it's VM), but let me know.