### PR TITLE
fix: use :path converter for hierarchical IDs in controller dashboard

### DIFF
--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -73,8 +73,8 @@ class ControllerDashboard:
 
         routes = [
             Route("/", self._dashboard),
-            Route("/job/{job_id}", self._job_detail_page),
-            Route("/vm/{vm_id}", self._vm_detail_page),
+            Route("/job/{job_id:path}", self._job_detail_page),
+            Route("/vm/{vm_id:path}", self._vm_detail_page),
             Route("/health", self._health),
             Mount(rpc_wsgi_app.path, app=rpc_app),
             static_files_mount(),


### PR DESCRIPTION
Changed controller dashboard routes to use Starlette's `:path` converter for job and VM IDs, allowing them to contain slashes. This fixes 404 errors when navigating to child job detail pages with hierarchical IDs like `parent-id/child-name`.

The worker dashboard already used this pattern correctly.

Fixes #2633