### PR TITLE
docs,scripts: Add Windows/Linux setup helpers and README warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ The documentation for Marin is available on [ReadTheDocs](https://marin.readthed
 
 To get started with Marin:
 
+> [!WARNING]
+> **Windows Users**: Marin currently relies on libraries (e.g., `vortex-data`) that may not support native Windows. We strongly recommend using [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) or Docker to run Marin.
+
 - [Install](docs/tutorials/installation.md) Marin.
+
 - Train a [tiny language model](docs/tutorials/first-experiment.md) using Marin.
 - See how to run a much larger [DCLM 1B/1x](docs/tutorials/train-an-lm.md) experiment using Marin.
 - See a [summary of the experiments](docs/reports/index.md) we've run.

--- a/scripts/setup_marin.ps1
+++ b/scripts/setup_marin.ps1
@@ -1,0 +1,58 @@
+<#
+.SYNOPSIS
+    Setup helper for Marin on Windows.
+.DESCRIPTION
+    Checks for prerequisites (uv, Python) and validates platform compatibility.
+    Warns about known issues (e.g., vortex-data on Windows).
+#>
+
+Write-Host "🌊 Marin Setup Helper" -ForegroundColor Cyan
+Write-Host "=====================" -ForegroundColor Cyan
+
+# 1. Check for Python
+Write-Host "[1/3] Checking Python..." -NoNewline
+if (Get-Command "python" -ErrorAction SilentlyContinue) {
+    $pyVersion = python --version 2>&1
+    Write-Host " OK ($pyVersion)" -ForegroundColor Green
+} else {
+    Write-Host " MISSING" -ForegroundColor Red
+    Write-Host "Error: Python is not found in PATH."
+    exit 1
+}
+
+# 2. Check for uv
+Write-Host "[2/3] Checking uv..." -NoNewline
+if (Get-Command "uv" -ErrorAction SilentlyContinue) {
+    $uvVersion = uv --version 2>&1
+    Write-Host " OK ($uvVersion)" -ForegroundColor Green
+} else {
+    # Check common user install correctness
+    $userPath = "$env:APPDATA\Python\Python311\Scripts\uv.exe"
+    if (Test-Path $userPath) {
+        Write-Host " FOUND (Not in PATH)" -ForegroundColor Yellow
+        Write-Host "Warning: 'uv' is installed at '$userPath' but not in your PATH."
+        Write-Host "Please add it to your PATH to use 'uv' commands directly."
+        # Alias for this session to continue
+        New-Alias -Name uv -Value $userPath -Force
+    } else {
+        Write-Host " MISSING" -ForegroundColor Red
+        Write-Host "Error: 'uv' is not installed. Run 'pip install uv'."
+        exit 1
+    }
+}
+
+# 3. Check Platform Compatibility
+Write-Host "[3/3] Checking Platform Compatibility..." -NoNewline
+$osDetails = Get-CimInstance Win32_OperatingSystem
+if ($osDetails.Caption -match "Windows") {
+    Write-Host " WARNING" -ForegroundColor Yellow
+    Write-Host "`n[!] CRITICAL COMPATIBILITY NOTICE:" -ForegroundColor Red
+    Write-Host "    Marin currently depends on 'vortex-data', which does not have pre-built binaries for Windows."
+    Write-Host "    You may encounter installation errors."
+    Write-Host "    RECOMMENDATION: Use WSL2 (Windows Subsystem for Linux) or Docker for a smooth experience."
+    Write-Host "    See: https://learn.microsoft.com/en-us/windows/wsl/install"
+} else {
+    Write-Host " OK" -ForegroundColor Green
+}
+
+Write-Host "`nSetup check complete."

--- a/scripts/setup_marin.sh
+++ b/scripts/setup_marin.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Setup helper for Marin on Linux/macOS.
+# Checks for prerequisites (uv, Python) and validates platform compatibility.
+#
+
+set -e
+
+echo "🌊 Marin Setup Helper"
+echo "====================="
+
+# 1. Check for Python
+echo -n "[1/3] Checking Python... "
+if command -v python3 &> /dev/null; then
+    PY_VERSION=$(python3 --version 2>&1)
+    echo "OK ($PY_VERSION)"
+else
+    echo "MISSING"
+    echo "Error: Python 3 is not found in PATH."
+    exit 1
+fi
+
+# 2. Check for uv
+echo -n "[2/3] Checking uv... "
+if command -v uv &> /dev/null; then
+    UV_VERSION=$(uv --version 2>&1)
+    echo "OK ($UV_VERSION)"
+else
+    echo "MISSING"
+    echo "Error: 'uv' is not installed. Install with: pip install uv"
+    exit 1
+fi
+
+# 3. Check Platform Compatibility
+echo -n "[3/3] Checking Platform Compatibility... "
+OS="$(uname -s)"
+case "$OS" in
+    Linux|Darwin)
+        echo "OK ($OS)"
+        ;;
+    MINGW*|CYGWIN*|MSYS*)
+        echo "WARNING"
+        echo ""
+        echo "[!] CRITICAL COMPATIBILITY NOTICE:"
+        echo "    Marin currently depends on 'vortex-data', which does not have pre-built binaries for Windows."
+        echo "    You may encounter installation errors."
+        echo "    RECOMMENDATION: Use WSL2 (Windows Subsystem for Linux) or Docker for a smooth experience."
+        echo "    See: https://learn.microsoft.com/en-us/windows/wsl/install"
+        ;;
+    *)
+        echo "UNKNOWN ($OS)"
+        echo "Warning: Untested platform. Proceed with caution."
+        ;;
+esac
+
+echo ""
+echo "Setup check complete."


### PR DESCRIPTION
## Summary
This PR improves the developer onboarding experience for Windows users by:
1. Adding a clear warning to [README.md](cci:7://file:///c:/Users/iredd/Desktop/opensource/marin/README.md:0:0-0:0) about Windows compatibility.
2. Introducing helper scripts ([setup_marin.ps1](cci:7://file:///C:/Users/iredd/Desktop/opensource/marin/scripts/setup_marin.ps1:0:0-0:0) for Windows, [setup_marin.sh](cci:7://file:///C:/Users/iredd/Desktop/opensource/marin/scripts/setup_marin.sh:0:0-0:0) for Linux/macOS) to diagnose common setup issues.

## Motivation
While attempting to run the tutorial on Windows, I encountered a blocking issue: `vortex-data` (a dependency of `lib/zephyr`) does not provide Windows wheels. This leads to a cryptic installation error that can waste hours of a new contributor's time.

This PR addresses the problem at the documentation and tooling level, making the limitation explicit and providing guidance *before* users hit the wall.

## Changes

### [README.md](cci:7://file:///c:/Users/iredd/Desktop/opensource/marin/README.md:0:0-0:0)
- Added a `[!WARNING]` block advising Windows users to use WSL2 or Docker.

### [scripts/setup_marin.ps1](cci:7://file:///C:/Users/iredd/Desktop/opensource/marin/scripts/setup_marin.ps1:0:0-0:0) (New - Windows)
- Checks for Python and `uv` installation.
- Detects if `uv` is installed but not in PATH.
- Warns Windows users about the `vortex-data` incompatibility.

### [scripts/setup_marin.sh](cci:7://file:///C:/Users/iredd/Desktop/opensource/marin/scripts/setup_marin.sh:0:0-0:0) (New - Linux/macOS)
- Bash script providing the same checks for Unix-like systems.
- Ensures cross-platform parity for the setup helper.

## Testing
Ran `powershell -ExecutionPolicy Bypass -File scripts/setup_marin.ps1` on Windows 11.
- ✅ Detected Python
- ✅ Found `uv` (even when not in PATH)
- ✅ Displayed compatibility warning

## Checklist
- [x] We have read [CONTRIBUTING.md](docs/dev-guide/contributing.md).
- [x] Our changes follow the project's guidelines.
- [x] We have tested my changes locally.
- [x] This is a small, focused PR addressing a single issue.

## Work Done by 
- Ireddi Rakshitha
- Yaswanth Devavarapu