### PR TITLE
Fix train and val set overlap bug by splitting before shuffling

### DIFF
--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -659,6 +659,16 @@ class LmDataConfig:
         doc_caches = self.build_caches("train")
         datasets = self.build_token_datasets(doc_caches, Pos, split="train")
 
+        # Slice off validation sequences before shuffling so that the train/val split is
+        # determined by position in the original (unshuffled) cache. This avoids overlap
+        # between the training set and the validation set produced by validation_sets().
+        if self.num_validation_sequences is not None:
+            for name, ds in datasets.items():
+                if name in self.num_validation_sequences:
+                    num_sequences = self.num_validation_sequences[name]
+                    len_dataset = len(ds.as_sync_dataset())
+                    datasets[name] = ds.slice_dataset(start_index=0, end_index=len_dataset - num_sequences)
+
         if key is None:
             key = jax.random.PRNGKey(0)
 
@@ -694,13 +704,6 @@ class LmDataConfig:
                 simulated_length_of_dataset = int(true_length_of_dataset * simulated_data_ratio)
                 sliced_datasets[name] = ds.slice_dataset(end_index=simulated_length_of_dataset)
             datasets = sliced_datasets
-
-        if self.num_validation_sequences is not None:
-            for name, ds in datasets.items():
-                if name in self.num_validation_sequences:
-                    num_sequences = self.num_validation_sequences[name]
-                    len_dataset = len(ds.as_sync_dataset())
-                    datasets[name] = ds.slice_dataset(start_index=0, end_index=len_dataset - num_sequences)
 
         if self.max_train_batches is not None:
             assert (


### PR DESCRIPTION
Previously, when splitting a dataset into training and validation sets via `num_validation_sequences`, the two sets were overlapping (some samples show up in both sets). This happened because during training set construction the dataset was first shuffled and then sliced, while during validation set construction the dataset was sliced without shuffling. We fix the bug by simply slicing the dataset before shuffling while constructing the training set.