### PR TITLE
Add ability to shuffle dataset before train/val split

### DIFF
--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -522,6 +522,7 @@ def _split_into_trainval_sets(
     When shuffle is False, the split is positional: the last
     num_validation_sequences go to validation and the rest to training.
     """
+    logger.info(f"Splitting dataset into train/val sets. Shuffle before split: {shuffle}")
     length = len(dataset.as_sync_dataset())
     if shuffle:
         split_key = jax.random.PRNGKey(0)

--- a/lib/marin/src/marin/processing/tokenize/data_configs.py
+++ b/lib/marin/src/marin/processing/tokenize/data_configs.py
@@ -124,7 +124,7 @@ def lm_mixture_data_config(
     include_raw_paths: bool = True,
     max_train_batches: dict[str, int] | None = None,
     num_validation_sequences: dict[str, int] | None = None,
-    shuffle_before_validation_split: bool = True,
+    shuffle_before_trainval_split: bool = True,
     mixture_block_size: int | None = None,
     block_cross_document_attention: bool = True,
 ) -> LmDataConfig:
@@ -140,7 +140,7 @@ def lm_mixture_data_config(
         include_raw_paths: whether to include raw paths in the dataset config. This is mostly for logging purposes.
         max_train_batches: Maximum number of batches to use for the training set per dataset.
         num_validation_sequences: Number of validation sequences to take from the training set per dataset.
-        shuffle_before_validation_split: Whether to shuffle before splitting into train/val. Defaults to True.
+        shuffle_before_trainval_split: Whether to shuffle before splitting into train/val. Defaults to True.
         block_cross_document_attention: Whether to mask attention across document boundaries.
     """
     component_configs = {
@@ -167,7 +167,7 @@ def lm_mixture_data_config(
         permutation_type=permutation_type,
         max_train_batches=max_train_batches,
         num_validation_sequences=num_validation_sequences,
-        shuffle_before_validation_split=shuffle_before_validation_split,
+        shuffle_before_trainval_split=shuffle_before_trainval_split,
         block_cross_document_attention=block_cross_document_attention,
         **kwargs,
     )


### PR DESCRIPTION
Continuation of #2700: Instead of always splitting the dataset into train/val sets before shuffling, allow the user to optionally shuffle the dataset first before it gets split into train/val sets (with shuffling set to `True` by default). This is useful for users who use `num_validation_sequences` to extract an IID validation set from a dataset that happens to be sorted in some way (e.g., chronologically). To ensure that the train and val sets are disjoint, we use the same shuffling parameters with a fixed seed when constructing the splits.

Note that this pre-split shuffling is distinct from training set shuffling; if the user specifies additional training dataset shuffling, that still proceeds as normal _after_ the dataset is split into train/val sets.

The pre-split shuffling is enabled by default. To disable it, you can set `shuffle_before_trainval_split=False` in the `lm_mixture_data_config` (the same config where you set `num_validation_sequences`).