### PR TITLE
Iris: add validation for config loading

### DIFF
--- a/lib/iris/src/iris/cluster/controller/config.py
+++ b/lib/iris/src/iris/cluster/controller/config.py
@@ -24,7 +24,13 @@ This module provides factory functions for creating autoscalers:
 import logging
 from pathlib import Path
 
-from iris.cluster.config import DEFAULT_CONFIG, ScaleGroupSpec, _scale_groups_to_config, _validate_autoscaler_config
+from iris.cluster.config import (
+    DEFAULT_CONFIG,
+    ScaleGroupSpec,
+    _scale_groups_to_config,
+    _validate_autoscaler_config,
+    validate_config,
+)
 from iris.cluster.controller.scaling_group import DEFAULT_HEARTBEAT_GRACE, DEFAULT_STARTUP_GRACE, ScalingGroup
 from iris.cluster.vm.gcp_tpu_platform import TpuVmManager
 from iris.cluster.vm.managed_vm import SshConfig, TrackedVmFactory, VmRegistry
@@ -61,9 +67,7 @@ def create_autoscaler(
 
     # Validate autoscaler config before using it
     _validate_autoscaler_config(autoscaler_config, context="create_autoscaler")
-    from iris.cluster.config import _validate_scale_group_resources
-
-    _validate_scale_group_resources(_scale_groups_to_config(scale_groups))
+    validate_config(_scale_groups_to_config(scale_groups))
 
     # Create shared infrastructure
     vm_registry = VmRegistry()
@@ -141,9 +145,7 @@ def create_autoscaler_from_specs(
     vm_registry = VmRegistry()
     vm_factory = TrackedVmFactory(vm_registry)
 
-    from iris.cluster.config import _validate_scale_group_resources
-
-    _validate_scale_group_resources(_scale_groups_to_config({name: spec.config for name, spec in specs.items()}))
+    validate_config(_scale_groups_to_config({name: spec.config for name, spec in specs.items()}))
 
     # Use provided config or DEFAULT_CONFIG
     if autoscaler_config is None:

--- a/lib/iris/src/iris/cluster/manager.py
+++ b/lib/iris/src/iris/cluster/manager.py
@@ -25,7 +25,7 @@ import logging
 from collections.abc import Iterator
 from contextlib import contextmanager
 
-from iris.cluster.config import IrisConfig
+from iris.cluster.config import IrisConfig, validate_config
 from iris.cluster.controller.lifecycle import create_controller_vm
 from iris.cluster.vm.controller_vm import ControllerProtocol
 from iris.managed_thread import ThreadContainer, get_thread_container
@@ -58,6 +58,7 @@ class ClusterManager:
         config: config_pb2.IrisClusterConfig,
         threads: ThreadContainer | None = None,
     ):
+        validate_config(config)
         self._config = config
         self._threads = threads if threads is not None else get_thread_container()
         self._controller: ControllerProtocol | None = None

--- a/lib/iris/tests/cluster/vm/test_config.py
+++ b/lib/iris/tests/cluster/vm/test_config.py
@@ -27,6 +27,7 @@ from iris.cluster.config import (
     config_to_dict,
     get_ssh_config,
     load_config,
+    validate_config,
 )
 from iris.cluster.controller.config import create_autoscaler
 from iris.cluster.vm.platform import create_platform
@@ -722,3 +723,70 @@ scale_groups:
             # Verify fast timings applied
             assert local_config.defaults.autoscaler.evaluation_interval.milliseconds == 500
             assert local_config.defaults.autoscaler.scale_up_delay.milliseconds == 1000
+
+
+def _valid_scale_group() -> config_pb2.ScaleGroupConfig:
+    """Create a valid ScaleGroupConfig for use in validation tests."""
+    return config_pb2.ScaleGroupConfig(
+        name="test",
+        vm_type=config_pb2.VM_TYPE_MANUAL_VM,
+        accelerator_type=config_pb2.ACCELERATOR_TYPE_CPU,
+        slice_size=1,
+        resources=config_pb2.ScaleGroupResources(cpu=8, memory_bytes=16 * 1024**3),
+    )
+
+
+def _config_with(**overrides) -> config_pb2.IrisClusterConfig:
+    """Build an IrisClusterConfig with a single scale group, overriding fields."""
+    sg = _valid_scale_group()
+    for key, value in overrides.items():
+        if key == "resources":
+            sg.resources.CopyFrom(value)
+        else:
+            setattr(sg, key, value)
+    config = config_pb2.IrisClusterConfig()
+    config.scale_groups["test"].CopyFrom(sg)
+    return config
+
+
+class TestConfigValidation:
+    """Tests for validate_config: the consolidated entry point for config validation."""
+
+    def test_valid_config_accepted(self):
+        validate_config(_config_with())
+
+    def test_rejects_missing_resources(self):
+        config = config_pb2.IrisClusterConfig()
+        sg = config.scale_groups["test"]
+        sg.name = "test"
+        sg.vm_type = config_pb2.VM_TYPE_MANUAL_VM
+        sg.accelerator_type = config_pb2.ACCELERATOR_TYPE_CPU
+        sg.slice_size = 1
+        with pytest.raises(ValueError, match="must set resources"):
+            validate_config(config)
+
+    def test_rejects_missing_slice_size(self):
+        config = config_pb2.IrisClusterConfig()
+        sg = config.scale_groups["test"]
+        sg.name = "test"
+        sg.vm_type = config_pb2.VM_TYPE_MANUAL_VM
+        sg.accelerator_type = config_pb2.ACCELERATOR_TYPE_CPU
+        sg.resources.CopyFrom(config_pb2.ScaleGroupResources(cpu=8, memory_bytes=16 * 1024**3))
+        with pytest.raises(ValueError, match="must set slice_size"):
+            validate_config(config)
+
+    def test_rejects_zero_slice_size(self):
+        with pytest.raises(ValueError, match="invalid slice_size"):
+            validate_config(_config_with(slice_size=0))
+
+    def test_rejects_unspecified_accelerator_type(self):
+        with pytest.raises(ValueError, match="must set accelerator_type"):
+            validate_config(_config_with(accelerator_type=config_pb2.ACCELERATOR_TYPE_UNSPECIFIED))
+
+    def test_rejects_unspecified_vm_type(self):
+        with pytest.raises(ValueError, match="must set vm_type"):
+            validate_config(_config_with(vm_type=config_pb2.VM_TYPE_UNSPECIFIED))
+
+    def test_rejects_negative_cpu(self):
+        with pytest.raises(ValueError, match="invalid cpu"):
+            validate_config(_config_with(resources=config_pb2.ScaleGroupResources(cpu=-1, memory_bytes=16 * 1024**3)))


### PR DESCRIPTION
Consolidate config validation into a single `validate_config()` public entry point, and add early validation in `ClusterManager.__init__` to catch programmatic errors before cluster operations begin.

- Add `validate_config()` that calls `_validate_accelerator_types`, `_validate_vm_types`, and `_validate_scale_group_resources`
- Call `validate_config()` in `ClusterManager.__init__` for early error detection
- Replace scattered internal validation calls in `load_config`, `create_autoscaler`, `create_autoscaler_from_specs` with `validate_config()`
- Rewrite validation tests with helper fixtures for cleaner test code

**Removed broken protovalidate approach:** The original commit added `protovalidate` as a dependency and proto-level validation constraints. This was broken because `protovalidate` requires `buf.validate` Python stubs that aren't available as a pip package (they must be generated and vendored). The proto, buf.yaml, and pyproject.toml changes have been reverted.

Fixes #2699