### PR TITLE
docs: refresh dev_tpu guide and add nav entry

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
   - Developer Guide:
       - Contributing: dev-guide/contributing.md
       - Deployment: dev-guide/deployment.md
+      - Dev TPU: dev-guide/dev_tpu.md
       - Tutorial Guidelines: dev-guide/tutorial-guidelines.md
       - Internal Guidelines: dev-guide/guidelines-internal.md
       - Building Docs: dev-guide/building-docs.md


### PR DESCRIPTION
## What
- refresh `docs/dev-guide/dev_tpu.md` with updated `dev_tpu.py` usage and troubleshooting
- add `Dev TPU` page to developer guide nav in `mkdocs.yml`
- keep explicit note that humans using one TPU per region can skip `--tpu-name` and rely on default naming

## Scope
- docs-only change
- includes only:
  - `docs/dev-guide/dev_tpu.md`
  - `mkdocs.yml`
