### PR TITLE
pyrefly: disable ignore-file filtering in workspace config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ disable-search-path-heuristics = true
 # Prevent pyrefly from querying the Python interpreter for site-packages
 # which would auto-detect workspace members as site packages and exclude them
 skip-interpreter-query = true
+use-ignore-files = false
 
 # Exclude non-production code from type checking
 project-excludes = [
@@ -120,6 +121,9 @@ project-excludes = [
     "examples/**",           # Example code doesn't need strict typing
     "lib/**/crawl/**",       # Crawl scripts have library typing issues with smart_open
     "lib/iris/src/iris/rpc/*_pb2*",  # Generated protobuf files
+    # Do not exclude all hidden-path ancestors; this repo is often checked out under
+    # directories such as `.codex/worktrees/...`, and pyrefly evaluates globs on
+    # absolute paths during project mode.
 ]
 
 # Disable specific error codes that are primarily noise from missing type stubs


### PR DESCRIPTION
## Summary
- set `use-ignore-files = false` in root `[tool.pyrefly]`
- keep pyrefly project checks independent of local/global git ignore state
- add a brief comment clarifying why hidden-path ancestor excludes are problematic in worktree environments

## Validation
- ./infra/pre-commit.py --all-files