### PR TITLE
Add Nemotron Pretraining Code v1 to pretraining dataset registry

### DIFF
--- a/experiments/pretraining_datasets/__init__.py
+++ b/experiments/pretraining_datasets/__init__.py
@@ -83,6 +83,11 @@ DATASETS = {
         "download": simple_downloads["proofpile_2"],
         "tokenize_fn": lambda: {"proofpile_2/all": simple_tokenized["proofpile_2"]},
     },
+    "nemotron_pretraining_code_v1": {
+        "subsets": ["all"],
+        "download": simple_downloads["nemotron_pretraining_code_v1"],
+        "tokenize_fn": lambda: {"nemotron_pretraining_code_v1/all": simple_tokenized["nemotron_pretraining_code_v1"]},
+    },
     "slimpajama_6b": {
         "subsets": ["all"],
         "download": simple_downloads["slimpajama_6b"],

--- a/experiments/pretraining_datasets/simple.py
+++ b/experiments/pretraining_datasets/simple.py
@@ -177,6 +177,20 @@ downloads = {
             override_output_path="raw/proof-pile-2-f1b1d8",
         ).cd("901a927/huggingface.co/datasets/EleutherAI/proof-pile-2/resolve/901a927")
     ),
+    "nemotron_pretraining_code_v1": (
+        ExecutorStep(
+            name="raw/Nemotron-Pretraining-Code-v1",
+            fn=download_hf,
+            config=DownloadConfig(
+                hf_dataset_id="nvidia/Nemotron-Pretraining-Code-v1",
+                revision="01393d3",
+                hf_urls_glob=["Synthetic-Code/*.parquet", "README.md", "LICENSE.md"],
+                gcs_output_path=this_output_path(),
+                wait_for_completion=True,
+            ),
+            override_output_path="raw/Nemotron-Pretraining-Code-v1-01393d3",
+        ).cd("Synthetic-Code")
+    ),
     "the_pile_openwebtext2": (
         ExecutorStep(
             name="raw/the_pile_openwebtext2",
@@ -229,6 +243,11 @@ tokenized = {
         downloads["proofpile_2"],
         tokenizer=llama3_tokenizer,
         override_path="tokenized/proofpile_2-4a35c7/",
+    ),
+    "nemotron_pretraining_code_v1": _tokenize_simple(
+        "nemotron-pretraining-code-v1",
+        downloads["nemotron_pretraining_code_v1"],
+        tokenizer=llama3_tokenizer,
     ),
     "slimpajama_6b": _tokenize_simple(
         "SlimPajama-6B",


### PR DESCRIPTION
This adds wiring for `nvidia/Nemotron-Pretraining-Code-v1` in the pretraining dataset registry so it can be downloaded and tokenized through the standard `experiments/pretraining_datasets` CLI.

The new dataset entry targets the `Synthetic-Code` config (the only config with a `text` field) and excludes the metadata-only config by restricting HF download globs to `Synthetic-Code/*.parquet` plus dataset docs.

Changes:
- add `downloads["nemotron_pretraining_code_v1"]` in `experiments/pretraining_datasets/simple.py`
- add `tokenized["nemotron_pretraining_code_v1"]` in `experiments/pretraining_datasets/simple.py`
- register `nemotron_pretraining_code_v1` in `experiments/pretraining_datasets/__init__.py`

Validation:
- `uv run experiments/pretraining_datasets/main.py list`
- `./infra/pre-commit.py experiments/pretraining_datasets/simple.py experiments/pretraining_datasets/__init__.py`
- `uv run python - <<'PY' ... get_steps(['nemotron_pretraining_code_v1'], download=True, tokenize=True) ... PY`
