### PR TITLE
Fix Iris transactions tab to show newest first and limit to 100

### DIFF
--- a/lib/iris/src/iris/cluster/static/controller/transactions-tab.js
+++ b/lib/iris/src/iris/cluster/static/controller/transactions-tab.js
@@ -36,14 +36,15 @@ export function TransactionsTab() {
 
   const fetchTransactions = async () => {
     try {
-      const resp = await controllerRpc('GetTransactions', { limit: 200 });
+      const resp = await controllerRpc('GetTransactions', { limit: 100 });
       const actions = (resp.actions || []).map(action => ({
         timestamp: timestampFromProto(action.timestamp),
         action: action.action,
         entity_id: action.entityId,
         details: action.details
       }));
-      setTransactions(actions);
+      // Reverse to show newest first
+      setTransactions(actions.reverse());
       setError(null);
     } catch (e) {
       setError('Failed to load transactions: ' + e.message);


### PR DESCRIPTION
- Changed limit from 200 to 100 transactions
- Reversed transaction order to show newest first

Fixes #2752
