### PR TITLE
Add --no-sync flag to dev_tpu execute

### DIFF
--- a/docs/dev-guide/dev_tpu.md
+++ b/docs/dev-guide/dev_tpu.md
@@ -10,7 +10,7 @@ or if you want to run a long experiment and not worry about the TPU going away.
 
 - `allocate`: reserves a TPU VM and keeps it alive while the command runs. It also creates an SSH alias for the TPU and writes config to `~/.ssh/config` so you can connect easily.
 - `connect`: opens an interactive shell on the TPU.
-- `execute`: rsyncs local files to remote `~/marin/`, then runs one command.
+- `execute`: syncs local files to remote `~/marin/` (unless `--no-sync`), then runs one command.
 - `watch`: rsync + restart on local file changes.
 
 ## Prerequisites
@@ -100,7 +100,16 @@ Notes:
 
 ### 2) Fast inner loop without repeated sync
 
-`execute` always rsyncs first. For iterative profiling/tuning, SSH directly:
+For iterative profiling/tuning, either skip sync with `--no-sync` or SSH directly:
+
+```bash
+RAY_AUTH_MODE=token uv run scripts/ray/dev_tpu.py \
+  --config infra/marin-us-east5-a.yaml \
+  --tpu-name "$TPU_NAME" \
+  execute --no-sync -- uv run --package levanter --group test pytest lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
+```
+
+Or SSH directly:
 
 ```bash
 ssh "dev-tpu-${TPU_NAME}"
@@ -158,7 +167,7 @@ Then rerun your command.
 
 ### `execute` feels slow
 
-It syncs files every time by design (using rsync). Use direct SSH for repeated runs.
+By default it syncs files before each run (using rsync). Use `--no-sync` or direct SSH for repeated runs.
 
 ## Reference examples
 

--- a/scripts/ray/dev_tpu.py
+++ b/scripts/ray/dev_tpu.py
@@ -750,20 +750,22 @@ def setup_env(ctx):
 @click.argument("command", nargs=-1, required=True)
 @click.option("--username", help="Username to use for ssh", default=getpass.getuser())
 @click.option("--sync-path", default=".", help="Local path to sync")
+@click.option("--no-sync", is_flag=True, help="Skip syncing local files before running the command")
 @click.option("--env", "-e", multiple=True, help="Environment variables to forward (KEY=VALUE or KEY)")
 @click.option("--forward-all-env", is_flag=True, help="Forward all environment variables")
 @click.pass_context
-def execute(ctx, command, username, sync_path, env, forward_all_env):
+def execute(ctx, command, username, sync_path, no_sync, env, forward_all_env):
     """Execute a command on the development TPU.
 
     This command will:
-    1. Sync any local changes to the TPU
+    1. Sync any local changes to the TPU (unless --no-sync is passed)
     2. Execute the provided command in the /home/$USER/marin directory
     3. Return the exit code from the remote command
 
     Examples:
         uv run scripts/ray/dev_tpu.py execute -- uv run python train.py
         uv run scripts/ray/dev_tpu.py execute -- uv run pytest tests/ -v
+        uv run scripts/ray/dev_tpu.py execute --no-sync -- uv run pytest tests/ -v
     """
     if not username:
         username = getpass.getuser()
@@ -777,9 +779,11 @@ def execute(ctx, command, username, sync_path, env, forward_all_env):
         print(f"You need to run 'allocate --tpu-name {tpu_name}' first to set up the TPU", file=sys.stderr)
         sys.exit(1)
 
-    # Sync files
-    print(f"Syncing local changes to {host_alias}...")
-    sync_to_remote(host_alias, sync_path)
+    if no_sync:
+        print("Skipping file sync (--no-sync).")
+    else:
+        print(f"Syncing local changes to {host_alias}...")
+        sync_to_remote(host_alias, sync_path)
 
     # Build environment variables
     env_dict = build_env_dict(extra_env=list(env), forward_all=forward_all_env)


### PR DESCRIPTION
## Summary
- add a `--no-sync` flag to `scripts/ray/dev_tpu.py execute`
- preserve current default behavior (sync before execute) unless `--no-sync` is set
- update TPU dev docs to describe and exemplify the new fast-loop option

## Testing
- uvx ruff@0.14.3 check scripts/ray/dev_tpu.py
- python -m py_compile scripts/ray/dev_tpu.py
