### PR TITLE
Always run Zephyr CI on merge to main

### DIFF
--- a/.github/workflows/zephyr-unit-tests.yaml
+++ b/.github/workflows/zephyr-unit-tests.yaml
@@ -3,10 +3,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - lib/zephyr/**
-      - uv.lock
-      - .github/workflows/zephyr-unit-tests.yaml
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary
- Remove path filters from the `push` trigger in `zephyr-unit-tests.yaml` so Zephyr tests always run on merge to main
- PR CI remains path-filtered (only runs when `lib/zephyr/**`, `uv.lock`, or the workflow file changes)
- Matches the pattern already used by Iris CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Re: https://github.com/marin-community/marin/pull/2757#issuecomment-3888067610