### PR TITLE
Install Python and uv in Claude Code workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,6 +47,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -58,7 +66,7 @@ jobs:
             actions: read
 
           # Allow rebase and pre-commit operations
-          claude_args: '--allowed-tools "Bash(git *)" "Bash(./infra/pre-commit.py *)" "Bash(uv *)" "Bash(pytest *)" "Bash(gh *)"'
+          claude_args: '--allowed-tools "Bash(git *)" "Bash(./infra/pre-commit.py *)" "Bash(uv *)" "Bash(pytest *)" "Bash(gh *)" "Bash(python *)"'
 
           custom_instructions: |
             Always read and follow the guidelines in AGENTS.md before starting work.


### PR DESCRIPTION
## Summary
- Add `actions/setup-python@v5` (Python 3.11) and `astral-sh/setup-uv@v5` steps before `claude-code-action` so that `uv` and `python` are available on PATH when Claude runs
- Add `"Bash(python *)"` to `claude_args` allowed tools
- Fixes the issue where Claude cannot run `uv run pytest` or `./infra/pre-commit.py` because `uv` is not installed in the GitHub Actions sandbox and Claude lacks permission to `curl | sh` to install it

## Test plan
- [ ] Trigger the workflow by tagging `@claude` on an issue or PR comment and verify Claude can run `uv run pytest` successfully
- [ ] Verify `./infra/pre-commit.py --all-files --fix` works in the sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)