### PR TITLE
Iris: fix autoscaler dashboard and add slice visibility

### DIFF
--- a/lib/iris/src/iris/cluster/controller/autoscaler.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler.py
@@ -699,6 +699,9 @@ class Autoscaler:
                 e,
             )
             group.mark_slice_failed(handle.slice_id)
+            self._log_action(
+                "slice_failed", group.name, handle.slice_id, reason=f"bootstrap failed: {e}", status="failed"
+            )
             group.scale_down(handle.slice_id)
             self._unregister_slice_vms(handle.slice_id)
             group.record_failure()
@@ -720,6 +723,9 @@ class Autoscaler:
         if group:
             vm_addresses = [vm.internal_address for vm in handle.describe().vms]
             group.mark_slice_ready(handle.slice_id, vm_addresses)
+            self._log_action(
+                "slice_ready", scale_group, handle.slice_id, reason=f"bootstrap completed ({len(vm_addresses)} VMs)"
+            )
 
     def _register_slice_vms(
         self,

--- a/lib/iris/src/iris/cluster/static/controller/autoscaler-tab.js
+++ b/lib/iris/src/iris/cluster/static/controller/autoscaler-tab.js
@@ -10,25 +10,23 @@ const html = htm.bind(h);
  * Compute per-slice state counts from an array of SliceInfo objects.
  * Each slice is categorized by the aggregate state of its VMs.
  */
+function computeSliceState(slice) {
+  const vms = slice.vms || [];
+  if (vms.length === 0) return 'unknown';
+  if (vms.every(vm => vm.state === 'VM_STATE_TERMINATED')) return 'terminated';
+  if (vms.some(vm => vm.state === 'VM_STATE_FAILED' || vm.state === 'VM_STATE_PREEMPTED')) return 'failed';
+  if (vms.every(vm => vm.state === 'VM_STATE_READY')) return 'ready';
+  if (vms.some(vm => vm.state === 'VM_STATE_REQUESTING')) return 'requesting';
+  if (vms.some(vm => vm.state === 'VM_STATE_INITIALIZING')) return 'initializing';
+  if (vms.some(vm => vm.state === 'VM_STATE_BOOTING')) return 'booting';
+  return 'unknown';
+}
+
 function computeSliceStateCounts(slices) {
   const counts = { requesting: 0, booting: 0, initializing: 0, ready: 0, failed: 0 };
   for (const s of slices) {
-    const vms = s.vms || [];
-    if (vms.length === 0) continue;
-    if (vms.every(vm => vm.state === 'VM_STATE_TERMINATED')) continue;
-    const anyFailed = vms.some(vm => vm.state === 'VM_STATE_FAILED' || vm.state === 'VM_STATE_PREEMPTED');
-    const allReady = vms.every(vm => vm.state === 'VM_STATE_READY');
-    if (anyFailed) {
-      counts.failed++;
-    } else if (allReady) {
-      counts.ready++;
-    } else if (vms.some(vm => vm.state === 'VM_STATE_REQUESTING')) {
-      counts.requesting++;
-    } else if (vms.some(vm => vm.state === 'VM_STATE_INITIALIZING')) {
-      counts.initializing++;
-    } else if (vms.some(vm => vm.state === 'VM_STATE_BOOTING')) {
-      counts.booting++;
-    }
+    const state = computeSliceState(s);
+    if (state in counts) counts[state]++;
   }
   return counts;
 }
@@ -45,7 +43,7 @@ function AutoscalerLogs() {
   const [logs, setLogs] = useState('Loading logs...');
 
   useEffect(() => {
-    controllerRpc('GetProcessLogs', { prefix: 'iris.cluster.controller.slice_status', limit: 200 })
+    controllerRpc('GetProcessLogs', { prefix: 'iris.cluster.controller.autoscaler', limit: 200 })
       .then(data => {
         const records = data.records || [];
         if (records.length > 0) {
@@ -229,18 +227,34 @@ export function AutoscalerTab({ autoscaler }) {
     <table class="scale-groups-table">
       <thead><tr><th>Group</th><th>Booting</th><th>Init</th><th>Ready</th><th>Failed</th><th>Demand</th><th>Status</th></tr></thead>
       <tbody>
-        ${groups.map(g => {
-          const counts = computeSliceStateCounts(g.slices || []);
+        ${groups.flatMap(g => {
+          const slices = g.slices || [];
+          const counts = computeSliceStateCounts(slices);
           const [statusClass, statusText] = groupStatusText(g, counts);
-          return html`<tr>
-            <td><strong>${g.name}</strong></td>
-            <td>${counts.booting || 0}</td>
-            <td>${counts.initializing || 0}</td>
-            <td>${counts.ready || 0}</td>
-            <td>${counts.failed || 0}</td>
-            <td>${g.currentDemand || 0}</td>
-            <td><span class="group-status"><span class=${'group-status-dot ' + statusClass}></span> ${statusText}</span></td>
-          </tr>`;
+          return [
+            html`<tr>
+              <td><strong>${g.name}</strong></td>
+              <td>${counts.booting || 0}</td>
+              <td>${counts.initializing || 0}</td>
+              <td>${counts.ready || 0}</td>
+              <td>${counts.failed || 0}</td>
+              <td>${g.currentDemand || 0}</td>
+              <td><span class="group-status"><span class=${'group-status-dot ' + statusClass}></span> ${statusText}</span></td>
+            </tr>`,
+            ...slices.map(s => {
+              const state = computeSliceState(s);
+              const truncId = s.sliceId ? s.sliceId.slice(0, 24) + (s.sliceId.length > 24 ? '...' : '') : 'unknown';
+              const created = s.createdAt ? formatRelativeTime(timestampFromProto(s.createdAt)) : '-';
+              return html`<tr style="background:#f6f8fa;font-size:12px">
+                <td style="padding-left:28px;color:#57606a">${truncId}</td>
+                <td colSpan="3">
+                  <span class=${'vm-state-indicator ' + state}></span>${' '}${state}
+                </td>
+                <td>${(s.vms || []).length} VMs</td>
+                <td colSpan="2">${created}</td>
+              </tr>`;
+            })
+          ];
         })}
       </tbody>
     </table>

--- a/lib/iris/src/iris/cluster/static/shared/styles.css
+++ b/lib/iris/src/iris/cluster/static/shared/styles.css
@@ -396,6 +396,8 @@ button:not(.tab-btn):disabled { color: #8c959f; cursor: default; background: #f6
 .action-type.quota_exceeded { background: #ffebe9; color: #cf222e; }
 .action-type.backoff_triggered { background: #fff8c5; color: #9a6700; }
 .action-type.worker_failed { background: #ffebe9; color: #cf222e; }
+.action-type.slice_ready { background: #dafbe1; color: #1a7f37; }
+.action-type.slice_failed { background: #ffebe9; color: #cf222e; }
 
 .future-feature {
   color: #57606a;

--- a/lib/iris/tests/e2e/test_autoscaler_dashboard.py
+++ b/lib/iris/tests/e2e/test_autoscaler_dashboard.py
@@ -1,0 +1,141 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for the autoscaler dashboard tab with a 2-group TPU config.
+
+Boots a local cluster with two scale groups (v5litepod-16 and v5litepod-32)
+and validates that the autoscaler tab correctly renders scale group info,
+slice state, recent actions, and logs.
+"""
+
+import time
+
+import pytest
+from iris.client.client import IrisClient
+from iris.cluster.config import load_config, make_local_config
+from iris.cluster.manager import connect_cluster
+from iris.rpc import config_pb2
+from iris.rpc.cluster_connect import ControllerServiceClientSync
+
+from .conftest import (
+    IRIS_ROOT,
+    TestCluster,
+    _is_noop_page,
+    assert_visible,
+    dashboard_click,
+    wait_for_dashboard_ready,
+)
+
+DEFAULT_CONFIG = IRIS_ROOT / "examples" / "demo.yaml"
+
+pytestmark = pytest.mark.e2e
+
+
+def _add_scale_group(
+    config: config_pb2.IrisClusterConfig,
+    name: str,
+    variant: str,
+    num_vms: int,
+) -> None:
+    sg = config.scale_groups[name]
+    sg.name = name
+    sg.accelerator_type = config_pb2.ACCELERATOR_TYPE_TPU
+    sg.accelerator_variant = variant
+    sg.num_vms = num_vms
+    sg.min_slices = 1
+    sg.max_slices = 2
+    sg.resources.cpu = 128
+    sg.resources.memory_bytes = 128 * 1024**3
+    sg.resources.disk_bytes = 1024 * 1024**3
+    sg.slice_template.preemptible = True
+    sg.slice_template.num_vms = num_vms
+    sg.slice_template.accelerator_type = config_pb2.ACCELERATOR_TYPE_TPU
+    sg.slice_template.accelerator_variant = variant
+    sg.slice_template.local.SetInParent()
+
+
+def _make_two_group_config() -> config_pb2.IrisClusterConfig:
+    config = load_config(DEFAULT_CONFIG)
+    config.scale_groups.clear()
+    _add_scale_group(config, "tpu_v5e_16", "v5litepod-16", num_vms=2)
+    _add_scale_group(config, "tpu_v5e_32", "v5litepod-32", num_vms=4)
+    return make_local_config(config)
+
+
+@pytest.fixture(scope="module")
+def cluster():
+    """Boots a local cluster with two TPU scale groups for autoscaler dashboard tests."""
+    config = _make_two_group_config()
+    with connect_cluster(config) as url:
+        client = IrisClient.remote(url, workspace=IRIS_ROOT)
+        controller_client = ControllerServiceClientSync(address=url, timeout_ms=30000)
+        tc = TestCluster(url=url, client=client, controller_client=controller_client)
+        # min_slices=1 each: 2 VMs for v5e_16 + 4 VMs for v5e_32 = 6 workers
+        tc.wait_for_workers(6, timeout=30)
+        yield tc
+        controller_client.close()
+
+
+def _click_autoscaler_tab(page, cluster):
+    """Navigate to dashboard root and open the Autoscaler tab."""
+    if not _is_noop_page(page):
+        page.goto(f"{cluster.url}/")
+    wait_for_dashboard_ready(page)
+    dashboard_click(page, 'button.tab-btn:has-text("Autoscaler")')
+    if not _is_noop_page(page):
+        time.sleep(0.5)
+
+
+def test_autoscaler_tab_shows_scale_groups(cluster, page, screenshot):
+    """Both scale groups appear in the Autoscaler tab's Scale Groups table."""
+    _click_autoscaler_tab(page, cluster)
+
+    assert_visible(page, "text=tpu_v5e_16")
+    assert_visible(page, "text=tpu_v5e_32")
+
+    screenshot("autoscaler-scale-groups")
+
+
+def test_autoscaler_tab_shows_slices(cluster, page, screenshot):
+    """Slice sub-rows with VM state indicators and VM counts are rendered."""
+    _click_autoscaler_tab(page, cluster)
+
+    if not _is_noop_page(page):
+        page.wait_for_selector(".vm-state-indicator", timeout=10000)
+        indicators = page.locator(".vm-state-indicator")
+        assert indicators.count() >= 2, f"Expected at least 2 vm-state-indicator elements, got {indicators.count()}"
+
+        vm_cells = page.locator("text=/\\d+ VMs/")
+        assert vm_cells.count() >= 2, f"Expected at least 2 VM count cells, got {vm_cells.count()}"
+
+    screenshot("autoscaler-slices")
+
+
+def test_autoscaler_tab_recent_actions(cluster, page, screenshot):
+    """Recent Actions section shows scale_up entries from initial boot."""
+    _click_autoscaler_tab(page, cluster)
+
+    if not _is_noop_page(page):
+        assert_visible(page, "text=scale up", timeout=10000)
+
+    screenshot("autoscaler-recent-actions")
+
+
+def test_autoscaler_tab_logs_section_rendered(cluster, page, screenshot):
+    """Autoscaler logs section is rendered with a heading and pre element.
+
+    The local platform does not configure a LogBuffer, so the logs section
+    will show either real logs or the empty-state message depending on
+    environment. We just verify the section itself renders correctly.
+    """
+    _click_autoscaler_tab(page, cluster)
+
+    if not _is_noop_page(page):
+        page.wait_for_selector("h3:has-text('Autoscaler Logs')", timeout=10000)
+        logs_pre = page.locator("h3:has-text('Autoscaler Logs') + pre")
+        logs_pre.wait_for(timeout=10000)
+        content = logs_pre.text_content(timeout=5000)
+        assert content is not None and len(content) > 0, "Autoscaler logs pre element is empty"
+        assert content != "Loading logs...", "Logs section still showing loading state"
+
+    screenshot("autoscaler-logs")


### PR DESCRIPTION
## Summary
- **Fix logger prefix**: The autoscaler logs section was querying `iris.cluster.controller.slice_status` (nonexistent) instead of `iris.cluster.controller.autoscaler`, causing "No recent autoscaler logs" to always show
- **Inline slice rows**: Scale Groups table now shows individual slices under each group with state dot, VM count, and creation time (data was already available via `g.slices` but wasn't rendered)
- **Slice lifecycle actions**: `slice_ready` and `slice_failed` transitions are now logged as autoscaler actions, visible in the Recent Actions section
- **E2E test**: New test with 2-group TPU config (`tpu_v5e_16` + `tpu_v5e_32`) validating all dashboard sections

## Test plan
- [x] `uv run pytest lib/iris/tests/e2e/test_autoscaler_dashboard.py -x -o "addopts="` — 4/4 pass
- [x] `uv run pytest lib/iris/tests/e2e/test_dashboard.py -x -o "addopts="` — 5/5 pass (no regressions)