### PR TITLE
Iris: use --link-mode copy for uv sync in Dockerfiles

### DIFF
--- a/lib/iris/Dockerfile.controller
+++ b/lib/iris/Dockerfile.controller
@@ -30,11 +30,11 @@ WORKDIR /app
 
 # Copy pyproject.toml first and sync dependencies (cached layer)
 COPY pyproject.toml ./
-RUN uv sync --no-install-project
+RUN uv sync --link-mode copy --no-install-project
 
 # Copy source and install the project
 COPY src/ ./src/
-RUN uv sync
+RUN uv sync --link-mode copy
 
 # Default cache directory
 RUN mkdir -p /var/cache/iris

--- a/lib/iris/Dockerfile.worker
+++ b/lib/iris/Dockerfile.worker
@@ -43,11 +43,11 @@ WORKDIR /app
 
 # Copy pyproject.toml first and sync dependencies (cached layer)
 COPY pyproject.toml ./
-RUN uv sync --no-install-project
+RUN uv sync --link-mode copy --no-install-project
 
 # Copy source and install the project
 COPY src/ ./src/
-RUN uv sync
+RUN uv sync --link-mode copy
 
 # Default cache directory
 RUN mkdir -p /var/cache/iris


### PR DESCRIPTION
The uv cache and target venv in Docker builds can be on different filesystems, causing hardlink failures that fall back to full copy with a noisy warning. entrypoint.py already passes --link-mode copy for task containers; apply the same flag to the controller and worker Dockerfiles for consistency and to suppress the warning.

https://claude.ai/code/session_01TuLshHJod4487JPyB3CPxF
