### PR TITLE
Fix autoscaler routing demand for dead/cancelled jobs

### DIFF
--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -78,6 +78,8 @@ def compute_demand_entries(state: ControllerState) -> list:
         job = state.get_job(job_id)
         if not job:
             continue
+        if job.is_finished():
+            continue
 
         device = job.request.resources.device
         device_type = get_device_type_enum(device)

--- a/lib/iris/src/iris/cluster/controller/state.py
+++ b/lib/iris/src/iris/cluster/controller/state.py
@@ -457,9 +457,11 @@ class ControllerTask:
         """Check if task is ready to be scheduled.
 
         A task can be scheduled if:
-        - It has no attempts yet (fresh task), or
+        - It has no attempts yet (fresh task) AND is not in a terminal state, or
         - Its current attempt is terminal AND it should retry
         """
+        if self.state in TERMINAL_TASK_STATES:
+            return False
         if not self.attempts:
             return True
         return self.attempts[-1].is_terminal() and not self.is_finished()


### PR DESCRIPTION
Fixes #2777

When a job is cancelled, pending tasks (never dispatched) are killed with zero attempts. The bug was in `can_be_scheduled()` which returned True for these killed tasks because it only checked `not self.attempts` without verifying the task's terminal state.

This caused:
1. Killed tasks to appear in `peek_pending_tasks()`
2. `compute_demand_entries()` to create DemandEntry for dead tasks
3. Autoscaler dashboard to show phantom "Unmet Demand" entries forever

Applied two fixes:

**Primary fix** (state.py):
- Check terminal state before the no-attempts fast path in `can_be_scheduled()`
- Tasks in TERMINAL_TASK_STATES now correctly return False

**Secondary defense** (controller.py):
- Skip finished jobs in `compute_demand_entries()`
- Defense-in-depth to prevent demand from killed/finished jobs

Added regression test `test_cancelled_job_tasks_excluded_from_demand` that verifies killed tasks don't appear as schedulable or generate demand entries.