### PR TITLE
Fix TPU chip counts in cluster configs by deriving from topology

### DIFF
--- a/infra/marin-eu-west4-a.yaml
+++ b/infra/marin-eu-west4-a.yaml
@@ -151,7 +151,7 @@ available_node_types:
         preemptible: true
     resources:
       CPU: 120
-      TPU: 4
+      TPU: 8
 
   tpu_slice_v6e_16:
     max_workers: 1024

--- a/infra/marin-eu-west4-vllm.yaml
+++ b/infra/marin-eu-west4-vllm.yaml
@@ -149,7 +149,7 @@ available_node_types:
         preemptible: true
     resources:
       CPU: 120
-      TPU: 4
+      TPU: 8
 
   tpu_slice_v5e_16:
     max_workers: 1024

--- a/infra/marin-eu-west4.yaml
+++ b/infra/marin-eu-west4.yaml
@@ -151,7 +151,7 @@ available_node_types:
         preemptible: true
     resources:
       CPU: 120
-      TPU: 4
+      TPU: 8
 
   tpu_slice_v5e_16:
     max_workers: 1024

--- a/infra/marin-us-east1.yaml
+++ b/infra/marin-us-east1.yaml
@@ -151,7 +151,7 @@ available_node_types:
         preemptible: true
     resources:
       CPU: 120
-      TPU: 4
+      TPU: 8
 
   tpu_slice_v6e_16:
     max_workers: 1024

--- a/infra/marin-us-east5.yaml
+++ b/infra/marin-us-east5.yaml
@@ -151,7 +151,7 @@ available_node_types:
         preemptible: true
     resources:
       CPU: 120
-      TPU: 4
+      TPU: 8
 
   tpu_slice_v6e_16:
     max_workers: 1024

--- a/infra/marin-us-west4.yaml
+++ b/infra/marin-us-west4.yaml
@@ -151,7 +151,7 @@ available_node_types:
         preemptible: true
     resources:
       CPU: 120
-      TPU: 4
+      TPU: 8
 
   tpu_slice_v5e_16:
     max_workers: 1024


### PR DESCRIPTION
## Summary
- The TPU chip count per VM (`TPU` resource) was specified incorrectly in several cluster YAML configs (e.g., 4 for `v6e-8` when it should be 8, since `v6e-8` has 8 chips per VM).
- Replaced the static `num_tpus` fields in `GENERATION_CONFIGS` with a dynamic lookup via `get_tpu_topology(accelerator_type).chips_per_vm`, so the correct chip count is always derived from the accelerator type.
- Updated 6 cluster YAML files (`eu-west4-a`, `eu-west4-vllm`, `eu-west4`, `us-east1`, `us-east5`, `us-west4`) where the base worker TPU count was wrong (4 → 8).

(I noticed this issue while trying to run an experiment that used all 8 chips on a v6e-8 node but realized that the cluster thought that there were only 4 chips on this node. For example, if there was a `0.0/1.0 TPU-v6e-8-head` available on a cluster, then I'd see `0.0/4.0 TPU` on the resources overview instead of `0.0/8.0 TPU`, and my job requesting `TPU: 8.0` would not get scheduled as a result.)