### PR TITLE
Add Playwright browser installation to CI workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,6 +55,12 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
+      - name: Install Playwright browsers
+        run: |
+          cd lib/iris
+          uv sync --group dev
+          uv run playwright install --with-deps chromium
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
This adds a setup step to install Playwright browsers (specifically Chromium) with dependencies in the CI workflow before running Claude Code. This ensures that any browser automation tests or scripts that depend on Playwright will have the necessary browser binaries available.

The change:
- Installs dev dependencies via `uv sync --group dev`
- Installs Chromium browser with system dependencies via `playwright install --with-deps chromium`
- Runs in the `lib/iris` directory where the project is located

This prevents potential failures in downstream steps that may require Playwright browser functionality.

https://claude.ai/code/session_01UeL5bF15QpChBwqc4R5C6i