### PR TITLE
Restrict Claude Code Action to claude[bot] user

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,3 +36,4 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prompt.outputs.review_prompt }}
           claude_args: '--max-turns 3'
+          allowed_bots: 'claude[bot]'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,6 +60,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'claude[bot]'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
This change restricts the Claude Code Action workflows to only accept commands from the `claude[bot]` user by adding the `allowed_bots` parameter to both the review and main Claude Code Action steps.

This is a security improvement that ensures only the official Claude bot can trigger automated code actions in the repository, preventing potential misuse from other bots or users.

**Changes:**
- Added `allowed_bots: 'claude[bot]'` to the claude-review workflow
- Added `allowed_bots: 'claude[bot]'` to the claude workflow

https://claude.ai/code/session_01XWtHZnBuvzPAsietdV71Hn