### PR TITLE
Iris/Fray/Marin nits: simplify TPU env, separate loop intervals, improve error reporting

### DIFF
--- a/lib/fray/src/fray/v2/iris_backend.py
+++ b/lib/fray/src/fray/v2/iris_backend.py
@@ -166,6 +166,7 @@ class IrisJobHandle:
         except Exception:
             if raise_on_failure:
                 raise
+            logger.warning("Job %s failed with exception (raise_on_failure=False)", self.job_id, exc_info=True)
         return self.status()
 
     def terminate(self) -> None:

--- a/lib/iris/src/iris/cluster/runtime/docker.py
+++ b/lib/iris/src/iris/cluster/runtime/docker.py
@@ -71,14 +71,6 @@ def _build_device_flags(config: ContainerConfig) -> list[str]:
     return flags
 
 
-def _build_device_env_vars(config: ContainerConfig) -> dict[str, str]:
-    """Build device-specific environment variables for the container.
-
-    Delegates to the shared build_device_env_vars in env.py.
-    """
-    return build_device_env_vars(config)
-
-
 def _detect_mount_user(mounts: list[tuple[str, str, str]]) -> str | None:
     """Detect user to run container as based on bind mount ownership.
 
@@ -458,7 +450,7 @@ exec {quoted_cmd}
                 cmd.extend(["--memory", f"{memory_mb}m"])
 
         # Build combined environment
-        device_env = _build_device_env_vars(config) if include_resources else {}
+        device_env = build_device_env_vars(config) if include_resources else {}
         combined_env = {**device_env, **config.env}
 
         for k, v in combined_env.items():

--- a/lib/iris/src/iris/cluster/runtime/env.py
+++ b/lib/iris/src/iris/cluster/runtime/env.py
@@ -30,51 +30,13 @@ def build_device_env_vars(config: ContainerConfig) -> dict[str, str]:
     has_device = config.resources.HasField("device")
     has_tpu = has_device and config.resources.device.HasField("tpu")
 
+    # N.B. We originally set all of the TPU environment variables explicitly, but this interferes with Jax's
+    # automatic Cloud TPU detection. Forcing Jax to do Cloud TPU init is sufficient.
     if has_tpu:
         env["JAX_PLATFORMS"] = "tpu,cpu"
         env["PJRT_DEVICE"] = "TPU"
-        # Disable JAX's GCE metadata-based TPU cluster detection. Inside Docker
-        # the metadata service returns single-host info even on multi-host pods.
-        # We set the JAX distributed env vars explicitly below instead.
-        env["TPU_SKIP_MDS_QUERY"] = "1"
 
-        # libtpu uses TPU_ACCELERATOR_TYPE to infer topology for pod slices.
-        if config.worker_metadata and config.worker_metadata.device.HasField("tpu"):
-            tpu_variant = config.worker_metadata.device.tpu.variant
-            if tpu_variant:
-                env["TPU_ACCELERATOR_TYPE"] = tpu_variant
-                # TPU_TYPE is the host-level name set at bootstrap and still
-                # used by Iris topology helpers.
-                env["TPU_TYPE"] = tpu_variant
-
-        if config.worker_metadata:
-            if config.worker_metadata.tpu_name:
-                env["TPU_NAME"] = config.worker_metadata.tpu_name
-            if config.worker_metadata.tpu_worker_id:
-                env["TPU_WORKER_ID"] = config.worker_metadata.tpu_worker_id
-                # Alias variables used by some TPU runtimes and tooling.
-                env["WORKER_ID"] = config.worker_metadata.tpu_worker_id
-                env["CLOUD_TPU_TASK_ID"] = config.worker_metadata.tpu_worker_id
-            if config.worker_metadata.tpu_worker_hostnames:
-                if not config.worker_metadata.tpu_worker_id:
-                    raise ValueError(
-                        "TPU worker metadata is incomplete: TPU_WORKER_ID is required "
-                        "when TPU_WORKER_HOSTNAMES is set."
-                    )
-                env["TPU_WORKER_HOSTNAMES"] = config.worker_metadata.tpu_worker_hostnames
-                # JAX multi-host coordination: coordinator is worker-0's IP with standard port.
-                # JAX reads JAX_COORDINATOR_ADDRESS directly. For num_processes and process_id
-                # JAX relies on cluster auto-detection; with TPU_SKIP_MDS_QUERY set,
-                # GkeTpuCluster is used which reads TPU_WORKER_HOSTNAMES and TPU_WORKER_ID.
-                hostnames = config.worker_metadata.tpu_worker_hostnames.split(",")
-                env["JAX_COORDINATOR_ADDRESS"] = f"{hostnames[0]}:8476"
-                env["JAX_NUM_PROCESSES"] = str(len(hostnames))
-                env["JAX_PROCESS_ID"] = config.worker_metadata.tpu_worker_id
-            if config.worker_metadata.tpu_chips_per_host_bounds:
-                env["TPU_CHIPS_PER_HOST_BOUNDS"] = config.worker_metadata.tpu_chips_per_host_bounds
-            logger.info("TPU device env vars (with metadata): %s", env)
-        else:
-            logger.warning("TPU device requested but worker_metadata is None; TPU host env vars will be missing")
-            logger.info("TPU device env vars (no metadata): %s", env)
+        # Jax likes to ignore the fact we're on a TPU for some reason.
+        env["JAX_FORCE_TPU_INIT"] = "1"
 
     return env

--- a/lib/marin/src/marin/execution/executor.py
+++ b/lib/marin/src/marin/execution/executor.py
@@ -98,7 +98,6 @@ from urllib.parse import urlparse
 import draccus
 import fsspec
 import levanter.utils.fsspec_utils as fsspec_utils
-
 from fray.v2 import client as fray_client
 from fray.v2.client import JobHandle, JobStatus
 from fray.v2.types import Entrypoint, JobRequest, ResourceConfig, create_environment
@@ -187,9 +186,9 @@ class StepRunner:
             if self._job is None:
                 raise RuntimeError("StepRunner.wait called before launch")
             result = self._job.wait(raise_on_failure=False)
-            if result == JobStatus.FAILED:
+            if result != JobStatus.SUCCEEDED:
                 self._status_file.write_status(STATUS_FAILED)
-                raise RuntimeError(f"Job {self.job_id} failed")
+                raise RuntimeError(f"Job {self.job_id} finished with status {result}")
             self._status_file.write_status(STATUS_SUCCESS)
         except Exception:
             if self._status_file.status != STATUS_FAILED:
@@ -836,7 +835,7 @@ class Executor:
         logger.info("  output_path = %s", output_path)
         logger.info("  config = %s", json.dumps(config_version, cls=CustomJsonEncoder))
         for i, dep in enumerate(self.dependencies[step]):
-            logger.info("  %s = %s", dependency_index_str(i), self.output_paths[dep])
+            logger.debug("  %s = %s", dependency_index_str(i), self.output_paths[dep])
 
         if dry_run:
             action, reason = self._plan_dry_run(step, force_run_failed=force_run_failed)


### PR DESCRIPTION
- **env.py**: Simplify TPU env var setup — rely on JAX's Cloud TPU auto-detection (`JAX_FORCE_TPU_INIT=1`) instead of manually setting all coordination variables (worker hostnames, coordinator address, etc.)
- **controller.py**: Add separate `heartbeat_interval` config and use `autoscaler_interval` in the autoscaler loop instead of reusing `scheduler_interval_seconds` for all three loops
- **iris_backend.py**: Log a warning when swallowing exceptions in `IrisJobHandle.wait`
- **executor.py**: Report actual job status in error message instead of just "failed"; demote dependency logging to debug level
