### PR TITLE
Migrate Claude workflow prompt to system-prompt parameter

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -68,16 +68,4 @@ jobs:
 
           claude_args: |
             --allowedTools "Bash(git:*),Bash(./infra/pre-commit.py:*),Bash(uv:*),Bash(pytest:*),Bash(gh:*),Bash(python:*)"
-          prompt: |
-            Always read and follow the guidelines in AGENTS.md before starting work.
-
-            You always have the ability to commit and push your changes.
-            Use your MCP tools if available, falling back to `git` and `gh` (which you have authorization for) if needed.
-            
-            Before submitting any changes:
-            1. Run `./infra/pre-commit.py --all-files --fix` and fix any issues.
-            2. Run `uv run pytest` on tests relevant to your changes.
-            
-            Report on the test status when you provide an update.
-            Always commit and push changes, even if you couldn't get the tests to pass.
-            In any follow-up comments on issues or PRs, state how you tested your changes (which tests you ran and their results).
+            --system-prompt "Always read and follow the guidelines in AGENTS.md before starting work. You always have the ability to commit and push your changes. Use your MCP tools if available, falling back to git and gh (which you have authorization for) if needed. Before submitting any changes: 1) Run ./infra/pre-commit.py --all-files --fix and fix any issues. 2) Run uv run pytest on tests relevant to your changes. Report on the test status when you provide an update. Always commit and push changes, even if you couldn't get the tests to pass. In any follow-up comments on issues or PRs, state how you tested your changes (which tests you ran and their results)."


### PR DESCRIPTION
This change updates the Claude workflow configuration to use the `--system-prompt` parameter instead of the `prompt` parameter for specifying agent instructions.

The system prompt content remains functionally identical—it includes guidelines for reading AGENTS.md, using available tools, running pre-commit checks and tests, and reporting on test status. The change consolidates the multi-line prompt into a single-line format compatible with the `--system-prompt` parameter.

This aligns with the Claude workflow's parameter interface and ensures the agent instructions are properly recognized as system-level guidance rather than a user prompt.

https://claude.ai/code/session_014ArVshxsMCddmDyEPn7W3G