### PR TITLE
Add concurrency groups to remaining CI workflows

### DIFF
--- a/.github/workflows/haliax-run_tests.yaml
+++ b/.github/workflows/haliax-run_tests.yaml
@@ -14,6 +14,10 @@ on:
       - uv.lock
       - .github/workflows/haliax-*.yaml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cpu-test:
 

--- a/.github/workflows/marin-docs.yaml
+++ b/.github/workflows/marin-docs.yaml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/marin-lint-and-format.yaml
+++ b/.github/workflows/marin-lint-and-format.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-and-format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Adds `concurrency` blocks to `haliax-run_tests`, `marin-lint-and-format`, and `marin-docs` workflows
- Uses the same pattern as existing workflows: group by workflow + PR number, cancel in-progress runs
