### PR TITLE
iris: increase uvicorn timeout_keep_alive to 120s

### DIFF
--- a/lib/iris/src/iris/actor/server.py
+++ b/lib/iris/src/iris/actor/server.py
@@ -223,6 +223,7 @@ class ActorServer:
             host=self._host,
             port=self._actual_port,
             log_level="error",
+            timeout_keep_alive=120,
         )
         self._server = uvicorn.Server(config)
 

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -277,11 +277,15 @@ class Controller:
 
         # Create and start uvicorn server via spawn_server, which bridges the
         # ManagedThread stop_event to server.should_exit automatically.
+        # timeout_keep_alive: uvicorn defaults to 5s, which races with client polling
+        # intervals of the same length, causing TCP resets on idle connections. Use 120s
+        # to safely cover long polling gaps during job waits.
         server_config = uvicorn.Config(
             self._dashboard._app,
             host=self._config.host,
             port=self._config.port,
             log_level="error",
+            timeout_keep_alive=120,
         )
         self._server = uvicorn.Server(server_config)
         self._threads.spawn_server(self._server, name="controller-server")

--- a/lib/iris/src/iris/cluster/worker/worker.py
+++ b/lib/iris/src/iris/cluster/worker/worker.py
@@ -100,12 +100,15 @@ class Worker:
         self._cleanup_all_iris_containers()
 
         # Start HTTP server
+        # timeout_keep_alive=120: default 5s races with controller heartbeat intervals,
+        # causing TCP resets on idle connections.
         self._server = uvicorn.Server(
             uvicorn.Config(
                 self._dashboard._app,
                 host=self._config.host,
                 port=self._config.port,
                 log_level="error",
+                timeout_keep_alive=120,
             )
         )
         self._threads.spawn_server(self._server, name="worker-server")


### PR DESCRIPTION
- Bump `timeout_keep_alive` from the default 5s to 120s on all three uvicorn servers (actor, controller, worker)
- The default 5s races with client polling intervals of the same length, causing TCP resets on idle connections