### PR TITLE
Fix no `track_progress` on labeled event

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -45,7 +45,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
-          track_progress: true
+          track_progress: ${{ github.event.action != 'labeled' }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Fix for https://github.com/marin-community/marin/actions/runs/22108656247

> Action failed with error: track_progress for pull_request events is only supported for actions: opened, synchronize, ready_for_review, reopened. Current action: labeled