### PR TITLE
Harden Claude Code GitHub Action workflows

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -67,6 +67,7 @@ jobs:
 
             ${{ github.event_name == 'issue_comment' && format('EXTRA INSTRUCTIONS FROM COMMENT:\n{0}', github.event.comment.body) || '' }}
           claude_args: |
+            --model opus
             --max-turns 30
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           allowed_bots: 'claude[bot]'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,6 +34,7 @@ jobs:
         github.event.issue.author_association == 'MEMBER' ||
         github.event.issue.author_association == 'COLLABORATOR') &&
        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -67,5 +68,7 @@ jobs:
             actions: read
 
           claude_args: |
+            --model opus
+            --max-turns 15
             --allowedTools "Bash(git:*),Bash(./infra/pre-commit.py:*),Bash(uv:*),Bash(pytest:*),Bash(gh:*),Bash(python:*)"
             --system-prompt "Always read and follow the guidelines in AGENTS.md before starting work. You always have the ability to commit and push your changes. Use your MCP tools if available, falling back to git and gh (which you have authorization for) if needed. Before submitting any changes: 1) Run ./infra/pre-commit.py --all-files --fix and fix any issues. 2) Run uv run pytest on tests relevant to your changes. Report on the test status when you provide an update. Always commit and push changes, even if you couldn't get the tests to pass. In any follow-up comments on issues or PRs, state how you tested your changes (which tests you ran and their results)."


### PR DESCRIPTION
## Summary
- Add `timeout-minutes: 30` to `claude.yml` (was defaulting to 6 hours)
- Add `--max-turns 15` to `claude.yml` (was defaulting to 10)
- Set `--model opus` on both `claude.yml` and `claude-review.yml` (were defaulting to Sonnet)

Closes #2854

## Test plan
- [ ] Trigger `claude.yml` via an `@claude` comment on an issue and verify it uses Opus and respects the timeout/max-turns
- [ ] Open a PR and verify `claude-review.yml` review runs with Opus