### PR TITLE
Fix ExponentialBackoff overflow on high attempt counts

### DIFF
--- a/lib/iris/tests/test_time_utils.py
+++ b/lib/iris/tests/test_time_utils.py
@@ -5,7 +5,7 @@ import time
 
 import pytest
 
-from iris.time_utils import Deadline, Duration, RateLimiter, Timestamp
+from iris.time_utils import Deadline, Duration, ExponentialBackoff, RateLimiter, Timestamp
 
 
 def test_deadline_expires():
@@ -208,3 +208,24 @@ def test_expired_deadline_remaining_is_zero():
     assert deadline.expired()
     assert deadline.remaining_ms() == 0
     assert deadline.remaining_seconds() == 0.0
+
+
+def test_exponential_backoff_does_not_overflow_at_high_attempt_counts():
+    """Backoff returns the maximum interval instead of overflowing when attempt count is large.
+
+    Reproduces the bug where idle Zephyr workers poll for ~30 min without a
+    task, accumulating ~1800 attempts. With default params (factor=1.5),
+    1.5**1755 exceeds float64 max and raises OverflowError.
+    """
+    backoff = ExponentialBackoff(initial=0.05, maximum=1.0, jitter=0.0)
+
+    # Simulate 2000 consecutive polls with no reset — well past the overflow
+    # threshold of ~1755 attempts for factor=1.5.
+    backoff._attempt = 2000
+    interval = backoff.next_interval()
+    assert interval == 1.0
+
+    # Also verify at an extreme count
+    backoff._attempt = 100_000
+    interval = backoff.next_interval()
+    assert interval == 1.0


### PR DESCRIPTION
## Summary

- Cap the effective attempt count in `ExponentialBackoff.next_interval()` to prevent `OverflowError` when idle workers poll without receiving tasks for extended periods (~30+ minutes)
- Precompute max useful attempt in `__init__` — beyond this point the interval is always clamped to `maximum` anyway, so larger exponents are pointless and overflow `float64`
- Add regression test that directly exercises the overflow path

Fixes #2867

## Test plan

- [x] New test `test_exponential_backoff_does_not_overflow_at_high_attempt_counts` — sets attempt to 2000 and 100,000, verifies `next_interval()` returns `maximum` instead of raising `OverflowError`
- [x] All 559 Iris unit tests pass
- [x] Pre-commit (ruff, pyrefly, formatting) passes