### PR TITLE
Add GHCR push support for iris Docker images

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -148,6 +148,54 @@ jobs:
           branch: actions/update-docker-image-tag
           body: Auto-generated from GitHub Actions.
 
+  # Iris Images - Worker, controller, and task images pushed to GHCR
+  iris-images:
+    # Run on: manual trigger OR weekly schedule (02:00 UTC on Sundays)
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.event.schedule == '0 2 * * 0')
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - image: iris-worker
+            dockerfile: lib/iris/Dockerfile.worker
+            context: lib/iris
+          - image: iris-controller
+            dockerfile: lib/iris/Dockerfile.controller
+            context: lib/iris
+          - image: iris-task
+            dockerfile: lib/iris/Dockerfile.task
+            context: .
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set tags
+        id: set-tags
+        run: |
+          echo "DATE_TAG=`date -u +"%Y%m%d"`" >> "$GITHUB_OUTPUT"
+          echo "HASH_TAG=`git rev-parse --short HEAD`" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push ${{ matrix.image }}
+        run: |
+          docker buildx build --file ${{ matrix.dockerfile }} \
+            --provenance=false \
+            --tag ghcr.io/marin-community/${{ matrix.image }}:latest \
+            --tag ghcr.io/marin-community/${{ matrix.image }}:${{ steps.set-tags.outputs.DATE_TAG }} \
+            --tag ghcr.io/marin-community/${{ matrix.image }}:${{ steps.set-tags.outputs.HASH_TAG }} \
+            --push ${{ matrix.context }}
+
   # Marin TPU CI Images - For self-hosted TPU CI runners
   marin-tpu-ci-images:
     # Run on: manual trigger OR daily schedule (03:00 UTC) OR push to docker files

--- a/lib/iris/Dockerfile.controller
+++ b/lib/iris/Dockerfile.controller
@@ -5,6 +5,9 @@
 #
 FROM python:3.11-slim
 
+LABEL org.opencontainers.image.source="https://github.com/marin-community/marin"
+LABEL org.opencontainers.image.description="Iris controller image"
+
 # Install system dependencies (openssh-client required for gcloud TPU SSH)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \

--- a/lib/iris/Dockerfile.task
+++ b/lib/iris/Dockerfile.task
@@ -9,6 +9,9 @@
 
 FROM python:3.12
 
+LABEL org.opencontainers.image.source="https://github.com/marin-community/marin"
+LABEL org.opencontainers.image.description="Iris task base image"
+
 RUN sed -i 's|deb.debian.org|cdn-fastly.deb.debian.org|g' /etc/apt/sources.list.d/*.sources 2>/dev/null; \
     sed -i 's|deb.debian.org|cdn-fastly.deb.debian.org|g' /etc/apt/sources.list 2>/dev/null; \
     apt-get update && apt-get install -y --no-install-recommends git curl build-essential \

--- a/lib/iris/Dockerfile.worker
+++ b/lib/iris/Dockerfile.worker
@@ -8,6 +8,9 @@
 #
 FROM python:3.11-slim
 
+LABEL org.opencontainers.image.source="https://github.com/marin-community/marin"
+LABEL org.opencontainers.image.description="Iris worker image"
+
 # Install system dependencies (docker.io on Debian doesn't include CLI, need docker-ce-cli)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \

--- a/lib/iris/src/iris/cli/cluster.py
+++ b/lib/iris/src/iris/cli/cluster.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import click
 from connectrpc.errors import ConnectError
 
-from iris.cli.build import _build_image, _find_iris_root, _find_marin_root, _push_to_registries
+from iris.cli.build import _build_image, _find_iris_root, _find_marin_root, _push_to_gcp_registries
 from iris.cli.debug import debug
 from iris.cli.main import require_controller_url
 from iris.client import IrisClient
@@ -127,11 +127,13 @@ def _build_and_push_image(params: _ImageBuildParams) -> None:
         dockerfile=params.dockerfile,
         context=params.context,
         platform="linux/amd64",
-        region=(),
-        project=params.project,
+        registry="gcp",
+        ghcr_org="",
+        gcp_regions=(),
+        gcp_project=params.project,
     )
     click.echo()
-    _push_to_registries(
+    _push_to_gcp_registries(
         source_tag=params.local_tag,
         regions=(params.region,),
         project=params.project,


### PR DESCRIPTION
## Problem

Iris Docker images (worker, controller, task) can only be pushed to GCP Artifact Registry.
For the CoreWeave integration ([design doc](https://github.com/marin-community/marin/pull/2853)),
images need to be publicly available on GHCR (`ghcr.io/marin-community/`).

The `iris build push` command required `--region` (GCP-only), and there was no CI job
to automatically build and publish iris images to GHCR.

## Approach

1. Add GHCR as the default push target in the iris build CLI (`lib/iris/src/iris/cli/build.py`).
   A `--registry` flag (choices: `ghcr`, `gcp`) defaults to `ghcr`. GCP remains available
   via `--registry gcp --region <region>`.

2. Add an `iris-images` job to `.github/workflows/docker-images.yaml` that builds all
   three images in parallel via matrix strategy and pushes to GHCR with `latest`, date,
   and git-hash tags.

3. Add OCI `org.opencontainers.image.source` labels to all three Dockerfiles so GitHub
   automatically links packages to this repository.

## Key changes

**`lib/iris/src/iris/cli/build.py`** — Core registry dispatch:

```python
GHCR_DEFAULT_ORG = "marin-community"

def _push_image(source_tag, registry, ...):
    if registry == "ghcr":
        _push_to_ghcr(source_tag, ghcr_org=ghcr_org, ...)
    elif registry == "gcp":
        _push_to_gcp_registries(source_tag, gcp_regions, gcp_project, ...)
```

- `_push_to_ghcr()`: docker tag + docker push to `ghcr.io/{org}/{image}:{version}`
- `_push_to_gcp_registries()`: renamed from `_push_to_registries`, unchanged logic
- `_resolve_image_name_and_version()`: shared helper extracted from GCP path
- `_add_registry_options`: decorator applying shared `--registry`/`--ghcr-org`/`--region`/`--project` options to all build subcommands

**`lib/iris/src/iris/cli/cluster.py`** — Updated import and call site to use renamed `_push_to_gcp_registries` and new `_build_image` signature.

**`.github/workflows/docker-images.yaml`** — New `iris-images` job:
- Matrix: `iris-worker`, `iris-controller`, `iris-task`
- Triggers: weekly (Sundays 2 AM UTC) + manual dispatch
- Tags: `latest`, `YYYYMMDD`, short git hash

**Dockerfiles** — Added OCI labels to all three (`Dockerfile.worker`, `Dockerfile.controller`, `Dockerfile.task`).

## Testing

All three images were built and pushed end-to-end to `ghcr.io/marin-community/`:
- `ghcr.io/marin-community/iris-worker:latest`
- `ghcr.io/marin-community/iris-controller:latest`
- `ghcr.io/marin-community/iris-task:latest`

The GCP push path (`--registry gcp`) was verified to still work through the existing
`cluster.py` code path which calls `_push_to_gcp_registries` directly.