### PR TITLE
Add PII exposure scanner with allowlist

### DIFF
--- a/scripts/security/__init__.py
+++ b/scripts/security/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/scripts/security/pii_allowlist.yaml
+++ b/scripts/security/pii_allowlist.yaml
@@ -1,0 +1,67 @@
+# PII scanner allowlist for the Marin codebase.
+#
+# Each entry suppresses findings matching a file glob + pattern type.
+# All entries here have been audited and are known-acceptable:
+# - contributor attribution in open-source projects
+# - academic author emails from public arxiv papers in test fixtures
+# - public web content in test fixture snapshots
+# - GCP service account identifiers (not credentials) in deployment docs
+# - documentation placeholder emails
+
+allowlist:
+  # --- Contributor attribution (standard open-source practice) ---
+  - file_glob: "**/CONTRIBUTORS.md"
+    pattern_name: email
+    reason: Public contributor attribution with commit counts
+
+  # --- Package author metadata ---
+  - file_glob: "**/pyproject.toml"
+    pattern_name: email
+    reason: Standard pyproject.toml author fields
+
+  # --- Test fixture snapshots from public arxiv papers ---
+  - file_glob: "tests/snapshots/ar5iv/**"
+    pattern_name: email
+    reason: Academic author emails from publicly published arxiv papers
+
+  # --- Test fixture snapshots from public web crawls (DCLM) ---
+  - file_glob: "tests/snapshots/dclm_hq/**"
+    pattern_name: email
+    reason: Emails from public websites in DCLM web crawl test fixtures
+
+  # --- Test fixture snapshots from public web pages ---
+  - file_glob: "tests/snapshots/web/**"
+    pattern_name: email
+    reason: Journalist/author emails from public web pages
+
+  # --- Test resources for deduplication (public RFCs/documents) ---
+  - file_glob: "tests/processing/**/resources/**"
+    pattern_name: email
+    reason: Emails from public RFC documents used as dedup test data
+
+  # --- Documentation and deployment (GCP service account identifiers) ---
+  - file_glob: "docs/**"
+    pattern_name: email
+    reason: GCP service account identifiers and placeholder emails in docs
+
+  - file_glob: "data_browser/**"
+    pattern_name: email
+    reason: GCP service account identifier in deployment script
+
+  - file_glob: ".github/**"
+    pattern_name: email
+    reason: GCP service account identifier in CI workflow
+
+  # --- Levanter library docs (code snippets with @-syntax) ---
+  - file_glob: "lib/levanter/docs/**"
+    pattern_name: email
+    reason: False positives from hax.named decorator syntax in code examples
+
+  # --- PII scanner's own test file (contains dummy PII for testing allowlist logic) ---
+  - file_glob: "tests/test_pii_scanner.py"
+    pattern_name: email
+    reason: Dummy email addresses used in allowlist matching unit tests
+
+  - file_glob: "tests/test_pii_scanner.py"
+    pattern_name: api_key
+    reason: Dummy API key pattern used in allowlist matching unit tests

--- a/scripts/security/scan_pii.py
+++ b/scripts/security/scan_pii.py
@@ -1,0 +1,214 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Lightweight PII scanner for the Marin codebase.
+
+Scans git-tracked files for patterns that may indicate PII exposure:
+email addresses, hardcoded API keys/tokens, private key material, and SSN patterns.
+
+Uses a YAML allowlist to suppress known-acceptable findings (e.g., contributor
+attribution in CONTRIBUTORS.md, academic emails in test fixtures from public
+arxiv papers).
+
+Usage:
+    uv run scripts/security/scan_pii.py
+    uv run scripts/security/scan_pii.py --allowlist scripts/security/pii_allowlist.yaml
+"""
+
+import argparse
+import fnmatch
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+PII_PATTERNS: dict[str, re.Pattern[str]] = {
+    "email": re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"),
+    "api_key": re.compile(
+        r"(?:"
+        r"sk-[a-zA-Z0-9]{20,}"  # OpenAI-style
+        r"|ghp_[a-zA-Z0-9]{36,}"  # GitHub PAT
+        r"|glpat-[a-zA-Z0-9\-]{20,}"  # GitLab PAT
+        r"|AKIA[0-9A-Z]{16}"  # AWS access key
+        r"|xox[bprs]-[a-zA-Z0-9\-]+"  # Slack tokens
+        r")"
+    ),
+    "private_key": re.compile(r"-----BEGIN\s+(?:RSA\s+|EC\s+|DSA\s+|OPENSSH\s+)?PRIVATE\s+KEY-----"),
+    "ssn": re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
+}
+
+SKIP_EXTENSIONS = frozenset(
+    {
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".ico",
+        ".svg",
+        ".webp",
+        ".woff",
+        ".woff2",
+        ".ttf",
+        ".eot",
+        ".zip",
+        ".tar",
+        ".gz",
+        ".bz2",
+        ".xz",
+        ".pyc",
+        ".pyo",
+        ".so",
+        ".dylib",
+        ".dll",
+        ".pdf",
+        ".parquet",
+        ".arrow",
+        ".npy",
+        ".npz",
+        ".mov",
+        ".mp4",
+        ".avi",
+        ".mkv",
+        ".lock",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    file: str
+    line_number: int
+    pattern_name: str
+    matched_text: str
+
+    @property
+    def key(self) -> str:
+        """Stable key used for allowlist matching: file::pattern_name::matched_text."""
+        return f"{self.file}::{self.pattern_name}::{self.matched_text}"
+
+
+@dataclass(frozen=True)
+class AllowlistEntry:
+    file_glob: str
+    pattern_name: str
+    reason: str
+
+
+def load_allowlist(path: Path) -> list[AllowlistEntry]:
+    if not path.exists():
+        return []
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    if not data or "allowlist" not in data:
+        return []
+    return [
+        AllowlistEntry(
+            file_glob=entry["file_glob"],
+            pattern_name=entry["pattern_name"],
+            reason=entry.get("reason", ""),
+        )
+        for entry in data["allowlist"]
+    ]
+
+
+def is_allowed(finding: Finding, allowlist: list[AllowlistEntry]) -> bool:
+    for entry in allowlist:
+        if entry.pattern_name != finding.pattern_name:
+            continue
+        if fnmatch.fnmatch(finding.file, entry.file_glob):
+            return True
+    return False
+
+
+def git_tracked_files(repo_root: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [f for f in result.stdout.strip().split("\n") if f]
+
+
+def scan_file(filepath: Path, relative: str) -> list[Finding]:
+    if filepath.suffix.lower() in SKIP_EXTENSIONS:
+        return []
+    try:
+        content = filepath.read_text(errors="ignore")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    findings: list[Finding] = []
+    for line_number, line in enumerate(content.splitlines(), start=1):
+        for pattern_name, pattern in PII_PATTERNS.items():
+            for match in pattern.finditer(line):
+                findings.append(
+                    Finding(
+                        file=relative,
+                        line_number=line_number,
+                        pattern_name=pattern_name,
+                        matched_text=match.group(0),
+                    )
+                )
+    return findings
+
+
+def scan_repo(
+    repo_root: Path,
+    allowlist_path: Path | None = None,
+) -> tuple[list[Finding], list[Finding]]:
+    """Scan the repo and return (unallowed_findings, allowed_findings)."""
+    if allowlist_path is None:
+        allowlist_path = repo_root / "scripts" / "security" / "pii_allowlist.yaml"
+    allowlist = load_allowlist(allowlist_path)
+    files = git_tracked_files(repo_root)
+
+    all_findings: list[Finding] = []
+    for relative in files:
+        filepath = repo_root / relative
+        all_findings.extend(scan_file(filepath, relative))
+
+    unallowed = [f for f in all_findings if not is_allowed(f, allowlist)]
+    allowed = [f for f in all_findings if is_allowed(f, allowlist)]
+    return unallowed, allowed
+
+
+def main() -> int:
+
+    parser = argparse.ArgumentParser(description="Scan for PII in tracked files")
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        default=REPO_ROOT / "scripts" / "security" / "pii_allowlist.yaml",
+        help="Path to YAML allowlist file",
+    )
+    parser.add_argument("--show-allowed", action="store_true", help="Also print allowed findings")
+    args = parser.parse_args()
+
+    unallowed, allowed = scan_repo(REPO_ROOT, args.allowlist)
+
+    if args.show_allowed and allowed:
+        print(f"\n--- {len(allowed)} allowed findings (suppressed by allowlist) ---")
+        for f in allowed:
+            print(f"  {f.file}:{f.line_number} [{f.pattern_name}] {f.matched_text}")
+
+    if unallowed:
+        print(f"\n!!! {len(unallowed)} PII finding(s) NOT in allowlist !!!\n")
+        for f in unallowed:
+            print(f"  {f.file}:{f.line_number} [{f.pattern_name}] {f.matched_text}")
+        print("\nTo suppress a finding, add it to the allowlist YAML file.")
+        return 1
+
+    print(f"PII scan passed. {len(allowed)} findings suppressed by allowlist, 0 new findings.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_pii_scanner.py
+++ b/tests/test_pii_scanner.py
@@ -1,0 +1,75 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Regression test for PII exposure in the Marin codebase.
+
+Runs the PII scanner against all git-tracked files and asserts that no
+new unallowed PII patterns have been introduced. Existing acceptable
+findings (contributor emails, test fixtures from public data) are
+suppressed via the allowlist.
+"""
+
+from pathlib import Path
+
+from scripts.security.scan_pii import Finding, is_allowed, load_allowlist, scan_repo
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ALLOWLIST_PATH = REPO_ROOT / "scripts" / "security" / "pii_allowlist.yaml"
+
+
+def test_no_new_pii_findings():
+    """Fail if any PII finding is not covered by the allowlist."""
+    unallowed, _allowed = scan_repo(REPO_ROOT, ALLOWLIST_PATH)
+    if unallowed:
+        details = "\n".join(f"  {f.file}:{f.line_number} [{f.pattern_name}] {f.matched_text}" for f in unallowed)
+        raise AssertionError(
+            f"{len(unallowed)} PII finding(s) not in allowlist:\n{details}\n\n"
+            "If these are acceptable, add them to scripts/security/pii_allowlist.yaml"
+        )
+
+
+def test_allowlist_suppresses_known_findings():
+    """Verify the allowlist is actually suppressing findings (not vacuously passing)."""
+    _, allowed = scan_repo(REPO_ROOT, ALLOWLIST_PATH)
+    assert len(allowed) > 0, "Expected allowlist to suppress at least some findings"
+
+
+def test_allowlist_matching():
+    """Verify allowlist glob matching works for representative patterns."""
+    allowlist = load_allowlist(ALLOWLIST_PATH)
+    assert len(allowlist) > 0
+
+    contributor_finding = Finding(
+        file="lib/levanter/CONTRIBUTORS.md",
+        line_number=5,
+        pattern_name="email",
+        matched_text="test@example.com",
+    )
+    assert is_allowed(contributor_finding, allowlist)
+
+    snapshot_finding = Finding(
+        file="tests/snapshots/ar5iv/inputs/arxiv_1.html",
+        line_number=100,
+        pattern_name="email",
+        matched_text="author@university.edu",
+    )
+    assert is_allowed(snapshot_finding, allowlist)
+
+    # An email in application source code should NOT be allowed
+    src_finding = Finding(
+        file="lib/marin/src/marin/processing/some_module.py",
+        line_number=10,
+        pattern_name="email",
+        matched_text="leaked@personal.com",
+    )
+    assert not is_allowed(src_finding, allowlist)
+
+    # An API key anywhere should NOT be allowed (no api_key entries in allowlist)
+    api_key_finding = Finding(
+        file="lib/levanter/CONTRIBUTORS.md",
+        line_number=1,
+        pattern_name="api_key",
+        matched_text="sk-abcdefghijklmnopqrstuvwxyz",
+    )
+    assert not is_allowed(api_key_finding, allowlist)


### PR DESCRIPTION
## Summary

- Adds a lightweight PII scanner (`scripts/security/scan_pii.py`) that detects email addresses, hardcoded API keys/tokens, private key material, and SSN patterns across all git-tracked files
- Includes a YAML allowlist (`scripts/security/pii_allowlist.yaml`) documenting all known-acceptable findings
- Adds a regression test (`tests/test_pii_scanner.py`) that fails if any new unallowed PII is introduced

## Scan Findings

**No credentials or secrets exposed. No PII in application code.**

All 112 findings are benign and documented in the allowlist:
- Contributor emails in `CONTRIBUTORS.md` files (standard open-source practice)
- Package author emails in `pyproject.toml` files
- Academic author emails in ar5iv test fixtures (from public arxiv papers)
- Journalist/author emails in DCLM and web crawl test fixtures (from public websites)
- GCP service account identifiers in deployment docs (not credentials)
- Documentation placeholder emails

The ar5iv processing pipeline correctly strips author PII via `remove_authors()`.

## Test plan

- [x] `uv run pytest tests/test_pii_scanner.py -v` — 3 tests pass
- [x] `uv run scripts/security/scan_pii.py` — 0 new findings, 112 suppressed
- [x] `./infra/pre-commit.py --all-files` — all checks pass


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: pii-scanner:/home/power/code/marin
task-type: pii-scanner
task-title: PII Exposure Scanner
provider: claude
score: 3.0
cost-tier: Medium (50-150k)
iterations: 1
duration: 16m43s
run-started: 2026-02-18T12:57:21-08:00
nightshift:metadata -->
