### PR TITLE
Fix claude-review workflow cancelling itself on first run

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -9,7 +9,7 @@ on:
     types: [created]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

- Add `github.event_name` to the concurrency group key in `claude-review.yml` so that `pull_request` and `issue_comment` triggered runs no longer share the same group
- This prevents the progress comment posted by `claude-code-action` (`track_progress: true`) from cancelling the original automated review

Closes #2878

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Open a test PR and confirm the automated Claude review completes without self-cancelling

🤖 Generated with [Claude Code](https://claude.com/claude-code)