### PR TITLE
Reduce e2e test timeouts and sleeps to cut idle wait time

### DIFF
--- a/lib/iris/tests/e2e/test_endpoints.py
+++ b/lib/iris/tests/e2e/test_endpoints.py
@@ -231,7 +231,7 @@ def _register_and_hold(prefix):
             metadata={"purpose": "dashboard-test"},
         )
         client.register_endpoint(request)
-        time.sleep(30)
+        time.sleep(10)
     finally:
         client.close()
 

--- a/lib/iris/tests/e2e/test_heartbeat.py
+++ b/lib/iris/tests/e2e/test_heartbeat.py
@@ -16,7 +16,7 @@ import pytest
 from iris.chaos import enable_chaos
 from iris.rpc import cluster_pb2
 
-pytestmark = [pytest.mark.e2e, pytest.mark.timeout(120)]
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(60)]
 
 # Local config sets heartbeat_failure_threshold = 3 via make_local_config().
 # Tests must use this value (not the production default of 10) since the e2e
@@ -60,7 +60,7 @@ def test_heartbeat_failures_below_threshold_recovers(cluster):
     )
 
     job = cluster.submit(quick_job, "transient-hb-fail")
-    status = cluster.wait(job, timeout=60)
+    status = cluster.wait(job, timeout=30)
     assert status.state == cluster_pb2.JOB_STATE_SUCCEEDED
 
 
@@ -73,7 +73,7 @@ def test_heartbeat_failures_at_threshold_kills_worker(cluster):
     """
 
     def slow_job():
-        time.sleep(5)
+        time.sleep(2)
         return 42
 
     enable_chaos(
@@ -84,7 +84,7 @@ def test_heartbeat_failures_at_threshold_kills_worker(cluster):
     )
 
     job = cluster.submit(slow_job, "threshold-hb-fail", max_retries_preemption=10)
-    status = cluster.wait(job, timeout=60)
+    status = cluster.wait(job, timeout=30)
     assert status.state == cluster_pb2.JOB_STATE_SUCCEEDED
 
 
@@ -101,7 +101,7 @@ def test_dispatch_cleared_on_worker_failure(cluster):
     """
 
     def slow_job():
-        time.sleep(10)
+        time.sleep(3)
         return 42
 
     enable_chaos(
@@ -112,7 +112,7 @@ def test_dispatch_cleared_on_worker_failure(cluster):
     )
 
     job = cluster.submit(slow_job, "dispatch-clear-test", max_retries_preemption=10)
-    status = cluster.wait(job, timeout=60)
+    status = cluster.wait(job, timeout=30)
     assert status.state == cluster_pb2.JOB_STATE_SUCCEEDED
 
 
@@ -133,7 +133,7 @@ def test_multiple_workers_one_fails(cluster):
     )
 
     job = cluster.submit(quick_job, "multi-worker-fail", max_retries_preemption=10)
-    status = cluster.wait(job, timeout=60)
+    status = cluster.wait(job, timeout=30)
     assert status.state == cluster_pb2.JOB_STATE_SUCCEEDED
 
 
@@ -156,5 +156,5 @@ def test_heartbeat_failure_with_pending_kills(cluster):
     )
 
     job = cluster.submit(quick_job, "kill-clear-test", max_retries_preemption=10)
-    status = cluster.wait(job, timeout=60)
+    status = cluster.wait(job, timeout=30)
     assert status.state == cluster_pb2.JOB_STATE_SUCCEEDED

--- a/lib/iris/tests/e2e/test_high_concurrency.py
+++ b/lib/iris/tests/e2e/test_high_concurrency.py
@@ -43,7 +43,7 @@ def test_128_tasks_concurrent_scheduling(multi_worker_cluster, sentinel):
         time.sleep(1.0)
         sentinel.signal()
 
-        status = multi_worker_cluster.wait(job, timeout=120)
+        status = multi_worker_cluster.wait(job, timeout=60)
         assert status.state == cluster_pb2.JOB_STATE_SUCCEEDED, f"Job failed: {status}"
     finally:
         reset_chaos()

--- a/lib/iris/tests/e2e/test_profiling.py
+++ b/lib/iris/tests/e2e/test_profiling.py
@@ -44,7 +44,7 @@ def test_profile_running_task(cluster):
     def slow_task():
         # Busy-loop with real Python work so py-spy can capture stack frames
         # (time.sleep blocks in C, producing zero Python samples)
-        end = time.monotonic() + 5
+        end = time.monotonic() + 3
         while time.monotonic() < end:
             sum(range(1000))
 
@@ -53,7 +53,7 @@ def test_profile_running_task(cluster):
 
     request = cluster_pb2.ProfileTaskRequest(
         task_id=task_id,
-        duration_seconds=2,
+        duration_seconds=1,
         profile_type=cluster_pb2.ProfileType(cpu=cluster_pb2.CpuProfile(format=cluster_pb2.CpuProfile.FLAMEGRAPH)),
     )
     response = cluster.controller_client.profile_task(request, timeout_ms=3000)
@@ -68,7 +68,7 @@ def test_profile_formats(cluster):
     """All three CPU profile formats return data."""
 
     def slow_task():
-        end = time.monotonic() + 5
+        end = time.monotonic() + 4
         while time.monotonic() < end:
             sum(range(1000))
 

--- a/lib/iris/tests/e2e/test_rpc_failures.py
+++ b/lib/iris/tests/e2e/test_rpc_failures.py
@@ -36,8 +36,8 @@ def test_dispatch_permanent_failure(cluster):
     """
     cluster.wait_for_workers(1, timeout=15)
     enable_chaos("controller.heartbeat", failure_rate=1.0)
-    job = cluster.submit(_quick, "permanent-dispatch", scheduling_timeout=Duration.from_seconds(5))
-    status = cluster.wait(job, timeout=20)
+    job = cluster.submit(_quick, "permanent-dispatch", scheduling_timeout=Duration.from_seconds(2))
+    status = cluster.wait(job, timeout=10)
     assert status.state in (cluster_pb2.JOB_STATE_FAILED, cluster_pb2.JOB_STATE_UNSCHEDULABLE)
 
 
@@ -58,8 +58,8 @@ def test_heartbeat_permanent_failure(cluster):
     """
     cluster.wait_for_workers(1, timeout=15)
     enable_chaos("worker.heartbeat", failure_rate=1.0)
-    job = cluster.submit(_slow, "perm-hb-fail", scheduling_timeout=Duration.from_seconds(5))
-    status = cluster.wait(job, timeout=20)
+    job = cluster.submit(_slow, "perm-hb-fail", scheduling_timeout=Duration.from_seconds(2))
+    status = cluster.wait(job, timeout=10)
     assert status.state in (
         cluster_pb2.JOB_STATE_FAILED,
         cluster_pb2.JOB_STATE_WORKER_FAILED,

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -58,7 +58,7 @@ def test_multiple_jobs_complete(cluster):
         assert status.state == cluster_pb2.JOB_STATE_SUCCEEDED
 
 
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(60)
 def test_command_parent_callable_child(cluster):
     """Command entrypoint parent submits a callable child job via iris_ctx().
 
@@ -76,7 +76,7 @@ def test_command_parent_callable_child(cluster):
         "ep = Entrypoint.from_callable(lambda: 'ok'); "
         "job = ctx.client.submit(ep, 'child-callable', "
         "ResourceSpec(cpu=1, memory='1g'), environment=EnvironmentSpec()); "
-        "job.wait(timeout=120, raise_on_failure=True)"
+        "job.wait(timeout=60, raise_on_failure=True)"
     )
 
     entrypoint = Entrypoint.from_command("python", "-c", parent_script)
@@ -86,7 +86,7 @@ def test_command_parent_callable_child(cluster):
         resources=ResourceSpec(cpu=1, memory="1g"),
         environment=EnvironmentSpec(),
     )
-    job.wait(timeout=90, raise_on_failure=True, stream_logs=True)
+    job.wait(timeout=60, raise_on_failure=True, stream_logs=True)
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/e2e/test_worker_failures.py
+++ b/lib/iris/tests/e2e/test_worker_failures.py
@@ -23,16 +23,16 @@ def test_worker_crash_mid_task(cluster):
     via heartbeat reconciliation or report_task_state."""
     enable_chaos("worker.task_monitor", failure_rate=1.0)
     job = cluster.submit(_quick, "crash-mid-task")
-    status = cluster.wait(job, timeout=60)
+    status = cluster.wait(job, timeout=30)
     assert status.state == cluster_pb2.JOB_STATE_FAILED
 
 
 def test_worker_delayed_registration(cluster):
-    """Worker registration delayed by 5s on first attempt. Task pends, then
+    """Worker registration delayed by 2s on first attempt. Task pends, then
     schedules once registration completes."""
-    enable_chaos("worker.register", delay_seconds=5.0, max_failures=1)
+    enable_chaos("worker.register", delay_seconds=2.0, max_failures=1)
     job = cluster.submit(_quick, "delayed-reg")
-    status = cluster.wait(job, timeout=60)
+    status = cluster.wait(job, timeout=30)
     assert status.state == cluster_pb2.JOB_STATE_SUCCEEDED
 
 
@@ -45,7 +45,7 @@ def test_worker_sequential_jobs(cluster):
         assert status.state == cluster_pb2.JOB_STATE_SUCCEEDED
 
 
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(15)
 def test_all_workers_fail(cluster):
     """All workers' registration fails permanently. With scheduling timeout,
     job transitions to FAILED/UNSCHEDULABLE when no workers register.
@@ -54,8 +54,8 @@ def test_all_workers_fail(cluster):
     scheduled on the existing workers, combined with a scheduling timeout.
     """
     enable_chaos("worker.register", failure_rate=1.0, error=RuntimeError("chaos: registration failed"))
-    job = cluster.submit(_slow, "all-workers-fail", cpu=9999, scheduling_timeout=Duration.from_seconds(15))
-    status = cluster.wait(job, timeout=30)
+    job = cluster.submit(_slow, "all-workers-fail", cpu=9999, scheduling_timeout=Duration.from_seconds(3))
+    status = cluster.wait(job, timeout=10)
     assert status.state in (cluster_pb2.JOB_STATE_FAILED, cluster_pb2.JOB_STATE_UNSCHEDULABLE)
 
 
@@ -68,7 +68,7 @@ def test_task_fails_once_then_succeeds(cluster):
         error=RuntimeError("chaos: transient container failure"),
     )
     job = cluster.submit(_quick, "retry-once", max_retries_failure=2)
-    status = cluster.wait(job, timeout=60)
+    status = cluster.wait(job, timeout=30)
     assert status.state == cluster_pb2.JOB_STATE_SUCCEEDED
 
 


### PR DESCRIPTION
Tests were spending most of their time in idle waits (sleeps, scheduling timeouts, busy loops). The local controller already uses fast timings (heartbeat_interval=0.5s, heartbeat_failure_threshold=3), so test-level timeouts can be much tighter.

Key changes:
- test_all_workers_fail: scheduling_timeout 15s→3s
- test_dispatch_cleared_on_worker_failure: sleep(10)→sleep(3)
- test_heartbeat_failures_at_threshold: sleep(5)→sleep(2)
- test_task_timeout: timeout 5s→2s
- test_dispatch_delayed: delay_seconds 3.0→1.0
- test_dispatch/heartbeat_permanent_failure: scheduling_timeout 5s→2s
- test_coscheduled_sibling_failure: scheduling_timeout 30s→5s
- profiling tests: busy loop 5s→3-4s, profile duration 2s→1s
- test_endpoints: _register_and_hold sleep 30s→10s
- test_smoke: nested job timeouts 120/90→60s
- test_high_concurrency: wait timeout 120→60s
- Reduced generous timeout=60 to timeout=30 across quick-job tests
- Module-level timeout on heartbeat tests 120s→60s