### PR TITLE
Fix ResourceSpec regions argument after Iris multi-region migration

### DIFF
--- a/lib/fray/src/fray/v2/iris_backend.py
+++ b/lib/fray/src/fray/v2/iris_backend.py
@@ -89,17 +89,19 @@ def convert_resources(resources: ResourceConfig) -> ResourceSpec:
         memory=resources.ram,
         disk=resources.disk,
         device=_convert_device(resources.device),
-        regions=resources.regions,
     )
 
 
 def convert_constraints(resources: ResourceConfig) -> list[Constraint]:
     """Build Iris scheduling constraints from fray v2 ResourceConfig."""
-    from iris.cluster.types import preemptible_constraint
+    from iris.cluster.types import preemptible_constraint, region_constraint
 
     constraints: list[Constraint] = []
     if not resources.preemptible:
         constraints.append(preemptible_constraint(False))
+    if resources.regions:
+        for region in resources.regions:
+            constraints.append(region_constraint(region))
     return constraints
 
 


### PR DESCRIPTION
## Summary
- Iris removed the `regions` field from `ResourceSpec` in favor of constraint-based region filtering (#2870), breaking Zephyr's Iris backend tests with `TypeError: ResourceSpec.__init__() got an unexpected keyword argument 'regions'`
- Removed the stale `regions=` kwarg from `convert_resources()` and added `region_constraint()` conversion in `convert_constraints()` so region preferences are still honored

## Test plan
- [x] `uv run pytest tests/test_execution.py` in `lib/zephyr` — all 51 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)