### PR TITLE
Trigger Zephyr tests on Iris change

### DIFF
--- a/.github/workflows/zephyr-unit-tests.yaml
+++ b/.github/workflows/zephyr-unit-tests.yaml
@@ -8,6 +8,8 @@ on:
       - main
     paths:
       - lib/zephyr/**
+      # Iris is being actively developed, to avoid bugs sneaking into zephyr, we trigger zephyr tests on iris change
+      - lib/iris/**
       - uv.lock
       - .github/workflows/zephyr-unit-tests.yaml
 


### PR DESCRIPTION
Since Iris is being actively developed, to avoid bugs sneaking into iris Zephyr backend, trigger Zephyr tests on Iris change. We could revert this in the future when things stabilize.

Basically try to mitigate: https://github.com/marin-community/marin/pull/2893