### PR TITLE
Fix levanter torch CI to install locked CPU torch wheel

### DIFF
--- a/.github/workflows/levanter-tests.yaml
+++ b/.github/workflows/levanter-tests.yaml
@@ -126,19 +126,21 @@ jobs:
 
       - name: Install locked CPU torch wheel
         run: |
-          TORCH_CPU_VERSION=$(python - <<'PY'
+          TORCH_CPU_VERSION=$(python3 - <<'PY'
           import tomllib
           from pathlib import Path
 
           lock = tomllib.loads(Path("../../uv.lock").read_text())
-          versions = sorted(
-              {
-                  package["version"]
-                  for package in lock.get("package", [])
-                  if package.get("name") == "torch" and package.get("version", "").endswith("+cpu")
-              }
-          )
-          print(versions[-1] if versions else "")
+          versions = {
+              package["version"]
+              for package in lock.get("package", [])
+              if package.get("name") == "torch" and package.get("version", "").endswith("+cpu")
+          }
+          if len(versions) != 1:
+              raise SystemExit(
+                  f"Expected exactly one torch +cpu version in uv.lock, found {len(versions)}: {sorted(versions)}"
+              )
+          print(next(iter(versions)))
           PY
           )
           echo "Using torch ${TORCH_CPU_VERSION}"


### PR DESCRIPTION
## Summary
- prevent `uv sync` in `cpu-torch-tests` from installing torch directly by adding `--no-install-package torch`
- install torch explicitly from the CPU index using the `+cpu` version parsed from `uv.lock`
- keep the torch test suite execution unchanged

## Why
The previous flow installed `torch==2.9.0` during sync, which resolved CUDA-related packages on Linux before the later override step.

## Validation
- ran `./infra/pre-commit.py --all-files`
- lint/format/YAML checks passed
- repo-wide Pyrefly step failed due to an existing project configuration/exclude issue unrelated to this workflow change
