### PR TITLE
Add daily canary ferry workflow (#2873)

### DIFF
--- a/.github/workflows/marin-canary-ferry.yaml
+++ b/.github/workflows/marin-canary-ferry.yaml
@@ -1,0 +1,59 @@
+name: Marin - Canary Ferry
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 6 AM UTC
+  workflow_dispatch:
+
+jobs:
+  canary-ferry:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    concurrency:
+      group: canary-ferry
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-packages --extra=tpu --no-default-groups
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Write SSH key and Ray token
+        run: |
+          mkdir -p ~/.ssh ~/.ray
+          echo "${{ secrets.MARIN_SSH_KEY }}" > ~/.ssh/marin_ray_cluster.pem
+          chmod 600 ~/.ssh/marin_ray_cluster.pem
+          echo "${{ secrets.RAY_AUTH_TOKEN }}" > ~/.ray/auth_token
+          chmod 600 ~/.ray/auth_token
+
+      - name: Submit canary ferry to Ray cluster
+        shell: bash -l {0}
+        run: |
+          .venv/bin/python lib/marin/src/marin/run/ray_run.py \
+            --cluster us-central1 \
+            -- python experiments/ferries/canary_ferry.py
+        env:
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/experiments/ferries/canary_ferry.py
+++ b/experiments/ferries/canary_ferry.py
@@ -1,7 +1,10 @@
 # Copyright 2025 The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Reference small train: Qwen3 ~30M (hid512) with optimal AdamH hparams from mega sweep.
+"""Canary ferry: Qwen3 ~30M (hid512) daily pretraining canary.
+
+Trains to 1B tokens on v5p-8 with AdamH. Designed to run daily to catch infra
+and pretraining regressions early. See #2873 for the proposal.
 
 Optimal hyperparameters from mega-sweep-bs64-1b-hid512-v3 (trial 26, macro_loss=3.754):
   lr=0.00864, beta1=0.894, adam_lr=0.000502, beta2=0.999, eps=2.32e-07,
@@ -59,11 +62,11 @@ train_config = SimpleTrainConfig(
 )
 
 training_step = default_train(
-    name="reference-small-train",
+    name="canary-ferry",
     tokenized=nemotron_mix,
     model_config=model,
     train_config=train_config,
-    tags=["reference", "small-train", "qwen3", "adamh", "hid512", "1b"],
+    tags=["canary", "ferry", "qwen3", "adamh", "hid512", "1b"],
     eval_harness_tasks=[],
 )
 


### PR DESCRIPTION
<!--
General notes:
- You target audience are humans. Consequently, you must optimize your writing style for clarity and high signal to noise ratio.
- Leverage GH flavored markdown features to enhance the redability of the content you output (.e.g by leveraging collapsed sections for optional details and enable easier glancing).
-->

## 0. Relevant Context

<details>
<summary>Key entities, prior art, and links</summary>

This PR implements **Stages 1 & 2** of the [Daily Canary Ferry proposal (#2873)](https://github.com/marin-community/marin/issues/2873), which itself addresses [#2833 (Establish daily canary training runs)](https://github.com/marin-community/marin/issues/2833) — a P0 item in the [Mar 31 MoE Epic (#2836)](https://github.com/marin-community/marin/issues/2836).

### Key entities

| Entity | Description | Location |
|--------|-------------|----------|
| **Ferry** | The evolving "best recipe" for pretraining, run periodically at 1B/8B scale. | [`experiments/ferries/initial_ferry.py`](https://github.com/marin-community/marin/blob/main/experiments/ferries/initial_ferry.py), [`ferry_10_31_muonh_feistel.py`](https://github.com/marin-community/marin/blob/main/experiments/ferries/ferry_10_31_muonh_feistel.py) |
| **Reference canary train** | A ~30M Qwen3 model (hid512) with sweep-optimized AdamH hparams, merged in [PR #2876](https://github.com/marin-community/marin/pull/2876). Trains to 1B tokens on v5p-8. | [`experiments/references/canary_train.py`](https://github.com/marin-community/marin/blob/main/experiments/references/canary_train.py) |
| **`executor_main`** | Standard experiment entrypoint — resolves step dependencies, manages output paths, and dispatches to Fray (Ray or Iris). | [`marin/execution/executor.py`](https://github.com/marin-community/marin/blob/main/lib/marin/src/marin/execution/executor.py) |
| **`default_train`** | Helper that wires a `SimpleTrainConfig` + model config + data into an `ExecutorStep` with WandB tracking, eval, and checkpointing. | [`experiments/defaults.py`](https://github.com/marin-community/marin/blob/main/experiments/defaults.py) |
| **`ray_run.py`** | CLI to submit Ray jobs from a local machine (SSH port-forward + Ray Jobs API). Used in `uv run lib/marin/src/marin/run/ray_run.py -- python <experiment>.py`. | [`lib/marin/src/marin/run/ray_run.py`](https://github.com/marin-community/marin/blob/main/lib/marin/src/marin/run/ray_run.py) |
| **`ResourceConfig`** | Fray abstraction for TPU/GPU/CPU resource requirements. `ResourceConfig.with_tpu("v5p-8")` is the smallest TPU config. | [`lib/fray/src/fray/v2/types.py`](https://github.com/marin-community/marin/blob/main/lib/fray/src/fray/v2/types.py) |

### Prior art

- The existing ferries (`initial_ferry.py`, `ferry_10_31_muonh_feistel.py`) train Qwen3 1.7B/8B models at 34B/160B tokens. They haven't been run since [Dec 9, 2025](https://github.com/marin-community/marin/pull/1839#issuecomment-3634559585).
- PR #2876 added `experiments/references/canary_train.py` — a ~30M Qwen3 model training to 1B tokens on v5p-8. This provides a validated model config and hyperparameter set for a small canary.
- No scheduled training workflows exist today. The closest pattern is [`marin-itest.yaml`](https://github.com/marin-community/marin/blob/main/.github/workflows/marin-itest.yaml), which runs an integration test on every push/PR using `.venv/bin/python` (not `uv run`, due to a [Ray bug](https://github.com/ray-project/ray/issues/54344)).

</details>

## 1. Problem Statement

There is no automated daily training run in Marin ([#2833](https://github.com/marin-community/marin/issues/2833)). This creates two gaps:

1. **Infra breakage goes undetected.** ~3 months of executor, training, and data pipeline changes have landed since the last ferry run (Dec 2025). There is no mechanism to catch regressions — a broken data path, a failing checkpoint, or a misconfigured cluster — until someone manually kicks off a full-scale ferry.

2. **No shared canary between infra and pretraining.** [#2873](https://github.com/marin-community/marin/issues/2873) identifies that both teams need a daily signal but monitor different dimensions: infra cares about crash/OOM/scheduling failures, pretraining cares about loss/throughput regressions. Without a shared job, each team would build redundant infrastructure.

The recently merged [PR #2876](https://github.com/marin-community/marin/pull/2876) provides a validated small model config (`canary_train.py`) but stops short of:
- Placing the canary in the ferry lineage (it lives in `experiments/references/`, not `experiments/ferries/`)
- Wiring up daily automated execution
- Adding failure alerting

## 2. Assumptions

| # | Under-specified area | Assumption | Rationale |
|---|---------------------|------------|-----------|
| A1 | **Model config** — #2833 asks for ~300M MoE, #2873 proposes dense for Stage 1 and MoE in Stage 4. | Use the ~30M Qwen3 from `canary_train.py` (PR #2876) as-is. | Helw150 validated it via hyperparameter sweep. It's tiny enough to finish fast, and exercises the full pipeline. MoE is explicitly deferred to Stage 4. |
| A2 | **Data mix** — the ferries use a complex varying Nemotron+code+HQ mixture; the reference canary uses `nemotron_mix`. | Use `nemotron_mix` (static mix from `exp1295_32b`). | Simpler, already validated, sufficient for a canary. The varying mixture is a pretraining concern, not an infra canary concern. |
| A3 | **Data already tokenized** — the dry run resolves 37 data-prep steps before the training step. | All `nemotron_mix` tokenization steps already exist in GCS under `gs://marin-us-central1` (the v5p cluster). The executor will skip them. | These datasets were tokenized for the Tootsie/ferry runs on the us-central1 cluster. The canary should not re-tokenize data — it only trains. |
| A4 | **Backend** — Fray supports both Ray and Iris. | Target Ray for Stages 1 & 2. | Per #2873: "start on Ray (proven path) and migrate to Iris once that backend has stabilized." Iris migration is Stage 3. |
| A5 | **Daily trigger mechanism** — #2833 says "GitHub Actions schedule or Iris-native scheduled job". | Use a GitHub Actions scheduled workflow that submits a Ray job to the cluster via `ray_run.py`. | No Iris scheduling exists yet. GH Actions is the existing CI platform and provides built-in failure notifications. |
| A6 | **Alerting** — #2833 says "Report failures to Slack/Discord or create GitHub issue." | Stage 2 relies on GH Actions' built-in failure notifications (email to committers + optional Slack via existing GH integration). No custom Slack bot. | Simplest path. Custom alerting can be layered on later. |
| A7 | **Script location** — `canary_train.py` lives in `experiments/references/`. The #2873 proposal specifies `experiments/ferries/canary_ferry.py`. | Move `canary_train.py` to `experiments/ferries/canary_ferry.py` and delete the original. | The reference was created specifically for the canary (PR #2876 title: "Reference for Canary Training"). A wrapper would add indirection with no reuse benefit. Sweep provenance is preserved in the docstring and git history. |
| A8 | **WandB project & tags** | Tag canary runs with `["canary", "ferry", "qwen3", "adamh", "hid512", "1b"]` in WandB project `"marin"`. | `canary` + `ferry` for dashboard filtering (consistent with the proposal). Original metadata tags (`qwen3`, `adamh`, `hid512`, `1b`) retained for model/optimizer/size filtering. |

## 3. Solution Summary

Two deliverables, one per stage:

**Stage 1 — `experiments/ferries/canary_ferry.py`**

A new experiment script that adapts the validated ~30M Qwen3 config from `canary_train.py` (PR #2876) into the ferry lineage. It trains on `nemotron_mix` for ~3800 steps (1B tokens) on a single v5p-8 slice, with Paloma validation and WandB tracking tagged `["canary", "ferry", "qwen3", "adamh", "hid512", "1b"]`. Target: <1 hour wall time on `us-central1`.

This directly addresses Problem 1 (infra breakage) by exercising the full executor pipeline — data loading, training, checkpointing, and eval — at a scale small enough to run daily.

**Stage 2 — `.github/workflows/marin-canary-ferry.yaml`**

A GitHub Actions workflow with a daily cron schedule that submits `canary_ferry.py` as a Ray job to the `us-central1` cluster. On failure, GH Actions notifies committers via its built-in mechanisms.

This addresses Problem 2 (no shared canary) by giving infra and pretraining a single daily job: infra monitors the workflow for crashes/failures, pretraining monitors WandB for loss/throughput regressions. Neither team needs to coordinate with the other to update their monitoring.

## 4. Design & Architecture

### Stage 1 — `experiments/ferries/canary_ferry.py`

**Move** `experiments/references/canary_train.py` → `experiments/ferries/canary_ferry.py` and update naming/tags. The reference was created specifically for this canary purpose ([PR #2876](https://github.com/marin-community/marin/pull/2876): "Reference for Canary Training") — keeping it as a separate file would add indirection with no reuse benefit. The sweep provenance is preserved in the docstring and git history.

Changes from the original `canary_train.py`:
- **`name`**: `"reference-small-train"` → `"canary-ferry"`
- **`tags`**: `["reference", "small-train", ...]` → `["canary", "ferry", "qwen3", "adamh", "hid512", "1b"]`

Everything else (model config, optimizer, data mix, resource config) stays identical.

### Stage 2 — `.github/workflows/marin-canary-ferry.yaml`

```
+-------------------+    SSH tunnel + Ray Jobs API    +------------------------+
|  GH Actions       | -----------------------------> |  us-central1 cluster   |
|  (cron: daily)    |  ray_run.py --cluster           |  (v5p-8 TPU)           |
|                   |           us-central1           |                        |
|  1. checkout      |                                 |  executor_main()       |
|  2. install deps  | <---- submission_id ----------- |    +-- canary_step     |
|  3. submit job    |                                 |                        |
|  4. stream logs   | ---- poll until SUCCEEDED/ ---> |                        |
|  5. exit 0 or 1   |           FAILED                |                        |
+-------------------+                                 +------------------------+
```

**Workflow steps:**

1. **Trigger**: `schedule: cron: '0 6 * * *'` (daily 6 AM UTC) + `workflow_dispatch` for manual runs.
2. **Checkout + install**: Same pattern as `marin-itest.yaml` — `uv sync --all-packages --extra=tpu --no-default-groups`.
3. **GCP auth**: Authenticate via `GCP_SA_KEY` — needed for `gcloud compute instances list` (cluster head node discovery by `ray_run.py`).
4. **Secrets setup**: Write SSH key and Ray auth token from GH secrets to disk.
5. **Submit**: `.venv/bin/python lib/marin/src/marin/run/ray_run.py --cluster us-central1 -- python experiments/ferries/canary_ferry.py`. No `--no_wait` — the workflow streams logs and exits with the job's exit code. `ray_run.py` handles its own SSH tunnel when `--cluster` is provided ([`ray_run.py:385-387`](https://github.com/marin-community/marin/blob/main/lib/marin/src/marin/run/ray_run.py#L385-L387)).
6. **Failure notification**: GH Actions' built-in email notification on workflow failure.

<details>
<summary>GH secrets</summary>

| GH Secret | Purpose | Status |
|-----------|---------|--------|
| `GCP_SA_KEY` | GCP auth — cluster head node discovery via `gcloud` | Already exists |
| `GCP_PROJECT_ID` | GCP project for `gcloud` | Already exists |
| `WANDB_API_KEY` | WandB logging | Already exists |
| `HF_TOKEN` | HuggingFace access | Already exists |
| `MARIN_SSH_KEY` | SSH key for Ray cluster head node | Created (see below) |
| `RAY_AUTH_TOKEN` | Ray dashboard auth token | Created (see below) |

The two new secrets hold the same values as the GCP Secret Manager entries `RAY_CLUSTER_PRIVATE_KEY` and `RAY_AUTH_TOKEN`. Storing them as GH secrets avoids granting the GH Actions SA `secretmanager.versions.access` ([decision](https://github.com/marin-community/marin/issues/2873#issuecomment-3930688441)).

Commands used to create them (from a machine with `make dev_setup` already run):

```bash
gh secret set MARIN_SSH_KEY --repo marin-community/marin < ~/.ssh/marin_ray_cluster.pem
gh secret set RAY_AUTH_TOKEN --repo marin-community/marin < ~/.ray/auth_token
```

</details>

<details>
<summary>Why not <code>--no_wait</code> (fire-and-forget)?</summary>

With `--no_wait`, the GH Action would exit immediately after submission — it couldn't report training failures. By waiting, the workflow exit code reflects whether the training actually succeeded, which is the whole point of an infra canary. The job targets <1 hour, well within GH Actions' 6-hour default timeout.

</details>

### Non-goals (deferred to later stages per #2873)

- **Iris migration** (Stage 3): the script is already backend-agnostic via Fray; only the trigger changes.
- **MoE variant** (Stage 4): add/switch to a small MoE config once GPU MoE training stabilizes (#2828).
- **Custom Slack/Discord alerting**: GH Actions notifications are sufficient for Stage 2.
- **Pretraining quality dashboards**: pretraining team configures WandB alerts on their own schedule.


## 5. Testing

### Automated (CI)

- **Dry-run test**: `canary_ferry.py` is automatically picked up by the existing [`test_dry_run.py`](https://github.com/marin-community/marin/blob/main/tests/test_dry_run.py) parametrized test, which discovers all `experiments/**/*.py` files containing `executor_main(`. This validates that imports resolve, the executor step graph is well-formed, and no config errors exist. Already runs on every PR via `marin-unit-tests.yaml`.

### Pre-merge validation (done)

The full workflow was tested on the `romain/canary-ferry` branch using a temporary `push` trigger:

- **GH Actions run** (all steps green, 32m43s): [run 22205911336](https://github.com/marin-community/marin/actions/runs/22205911336)
- **WandB dashboard**: [canary-ferry-9ce09e](https://wandb.ai/stanford-mercury/marin/runs/canary-ferry-9ce09e)

Key metrics from the run:
| Metric | Value |
|--------|-------|
| State | finished |
| Steps | 3813 (expected ~3814) |
| Total tokens | 999,817,216 (~1B) |
| Train loss | 3.674 |
| Paloma macro loss | 3.942 |
| MFU | 35.2% |
| Runtime | ~25 min |

### Manual (pre-merge)

- **Cluster run**: Submit `canary_ferry.py` to the `us-central1` cluster and verify the acceptance criteria below.

  <details>
  <summary>Agent instructions: how to verify each acceptance criterion</summary>

  **Prerequisites** — establish a dashboard connection in a background terminal:
  ```bash
  uv run scripts/ray/cluster.py --cluster us-central1 dashboard
  ```

  **Submit the job:**
  ```bash
  uv run lib/marin/src/marin/run/ray_run.py \
    --cluster us-central1 \
    --no_wait \
    --env_vars WANDB_API_KEY=${WANDB_API_KEY} \
    -- python experiments/ferries/canary_ferry.py \
    2>&1 | tee /tmp/canary_ferry_submit.log
  ```
  Extract the `submission_id` from the output (line matching `Job submitted with ID: ...`).

  **1. Job completes successfully:**
  ```bash
  # Poll until terminal state (SUCCEEDED / FAILED / STOPPED)
  uv run scripts/ray/cluster.py --cluster us-central1 wait-job <submission_id>
  ```
  Expect: status = `SUCCEEDED`.

  **2. Data-prep steps skipped (already tokenized):**
  ```bash
  # Check Ray job logs for "already done" / "skipping" messages on data steps
  uv run scripts/ray/cluster.py --cluster us-central1 job-logs <submission_id> \
    | grep -c "already done\|Skipping"
  ```
  Expect: count matching the ~37 data-prep steps.

  **3. Checkpoint written to GCS:**
  ```bash
  gcloud storage ls "gs://marin-us-central1/checkpoints/canary-ferry*/"
  ```
  Expect: non-empty listing with checkpoint files.

  **4. Paloma validation ran:**
  ```bash
  # Paloma eval results appear in the job logs
  uv run scripts/ray/cluster.py --cluster us-central1 job-logs <submission_id> \
    | grep -i "paloma"
  ```
  Expect: lines showing Paloma evaluation metrics.

  **5. WandB run with correct tags:**
  ```python
  # Using the wandb API (available in .venv)
  import wandb
  api = wandb.Api()
  runs = api.runs("marin", filters={"tags": {"$in": ["canary"]}}, order="-created_at")
  run = next(iter(runs))
  assert "canary" in run.tags and "ferry" in run.tags
  print(f"Run: {run.name}, Tags: {run.tags}, State: {run.state}, URL: {run.url}")
  ```

  **6. Wall time < 1 hour:**
  ```bash
  # From the list-jobs output, check start_time and end_time
  uv run scripts/ray/cluster.py --cluster us-central1 list-jobs \
    | python3 -c "
  import json, sys
  jobs = json.load(sys.stdin)
  for j in jobs:
      if '<submission_id>' in (j.get('submission_id') or ''):
          dt = (j['end_time'] - j['start_time']) / 1000
          print(f'Duration: {dt/60:.1f} min')
          assert dt < 3600, f'Exceeded 1h: {dt/60:.1f} min'
  "
  ```

  </details>

### Post-merge

- **Workflow smoke test**: Trigger `marin-canary-ferry.yaml` manually via `workflow_dispatch` and verify end-to-end.
- **Cron verification**: Confirm the first scheduled run (next day, 6 AM UTC) completes successfully.

  <details>
  <summary>Agent instructions: how to verify the workflow</summary>

  **1. Trigger the workflow manually:**
  ```bash
  gh workflow run marin-canary-ferry.yaml --repo marin-community/marin
  ```

  **2. Wait for it to appear and track its status:**
  ```bash
  # List recent runs of this workflow
  gh run list --workflow=marin-canary-ferry.yaml --repo marin-community/marin --limit 1

  # Watch the run (use the run ID from the listing above)
  gh run watch <run_id> --repo marin-community/marin
  ```
  Expect: status = `completed`, conclusion = `success`.

  **3. If the run fails, inspect logs:**
  ```bash
  gh run view <run_id> --repo marin-community/marin --log-failed
  ```
  Common failure modes:
  - GCP auth error → check `GCP_SA_KEY` secret is valid
  - SSH tunnel timeout → check cluster head node is up (`gcloud compute instances list --filter="name~marin-us-central1"`)
  - Ray auth rejected → check `RAY_AUTH_TOKEN` secret in Secret Manager matches the cluster's token
  - Ray job FAILED → same debugging as manual pre-merge run (check Ray logs, WandB)

  **4. Verify the cron schedule (next day):**
  ```bash
  # After 6 AM UTC the next day, check for a scheduled trigger
  gh run list --workflow=marin-canary-ferry.yaml --repo marin-community/marin --limit 3
  ```
  Expect: a run with event = `schedule` and conclusion = `success`.

  **5. Verify the full pipeline completed (same checks as pre-merge):**
  - GCS checkpoint: `gcloud storage ls "gs://marin-us-central1/checkpoints/canary-ferry*/"`
  - WandB run with tags:
    ```python
    import wandb
    api = wandb.Api()
    runs = api.runs("marin", filters={"tags": {"$in": ["canary"]}}, order="-created_at")
    run = next(iter(runs))
    assert "canary" in run.tags and "ferry" in run.tags
    print(f"Run: {run.name}, State: {run.state}, URL: {run.url}")
    ```

  </details>
