### PR TITLE
Expose no-worker-timeout and bump to 10 minutes for Ray

### DIFF
--- a/lib/zephyr/src/zephyr/cli.py
+++ b/lib/zephyr/src/zephyr/cli.py
@@ -35,7 +35,7 @@ class CliConfig:
     cluster_config: str | None = None
     entry_point: str = "main"
     dry_run: bool = False
-    no_workers_timeout: float | None = None
+    worker_start_timeout: float | None = None
 
     ray_options: dict = field(default_factory=dict)
 
@@ -139,7 +139,7 @@ def run_local(
         max_workers=config.max_parallelism,
         resources=resources,
         name="cli",
-        no_workers_timeout=config.no_workers_timeout,
+        no_workers_timeout=config.worker_start_timeout,
     ):
         main_fn()
 
@@ -190,8 +190,8 @@ def run_ray_cluster(
         entrypoint += ["--num-cpus", str(config.num_cpus)]
     if config.num_gpus:
         entrypoint += ["--num-gpus", str(config.num_gpus)]
-    if config.no_workers_timeout is not None:
-        entrypoint += ["--no-workers-timeout", str(config.no_workers_timeout)]
+    if config.worker_start_timeout is not None:
+        entrypoint += ["--worker-start-timeout", str(config.worker_start_timeout)]
     if entry_point != "main":
         entrypoint += ["--entry-point", entry_point]
 
@@ -260,8 +260,8 @@ def run_iris_cluster(
         entrypoint += ["--num-cpus", str(config.num_cpus)]
     if config.num_gpus:
         entrypoint += ["--num-gpus", str(config.num_gpus)]
-    if config.no_workers_timeout is not None:
-        entrypoint += ["--no-workers-timeout", str(config.no_workers_timeout)]
+    if config.worker_start_timeout is not None:
+        entrypoint += ["--worker-start-timeout", str(config.worker_start_timeout)]
     if entry_point != "main":
         entrypoint += ["--entry-point", entry_point]
 
@@ -313,10 +313,10 @@ Examples:
 @click.option("--entry-point", type=str, default="main", help="Entry point function name (default: 'main')")
 @click.option("--dry-run", is_flag=True, help="Show optimization plan without executing")
 @click.option(
-    "--no-workers-timeout",
+    "--worker-start-timeout",
     type=float,
     default=None,
-    help="Seconds to wait for at least one worker before failing (default: 600s Ray, 60s otherwise)",
+    help="Seconds to wait for at least one worker before failing (default: 600s)",
 )
 @click.pass_context
 def main(
@@ -330,7 +330,7 @@ def main(
     num_gpus: float | None,
     entry_point: str,
     dry_run: bool,
-    no_workers_timeout: float,
+    worker_start_timeout: float,
 ) -> None:
     """Execute data processing pipeline script with configurable backend."""
     script_args = ctx.args
@@ -345,7 +345,7 @@ def main(
         cluster=cluster,
         cluster_config=cluster_config,
         entry_point=entry_point,
-        no_workers_timeout=no_workers_timeout,
+        worker_start_timeout=worker_start_timeout,
     )
 
     validate_backend_config(config)

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -889,8 +889,7 @@ class ZephyrContext:
         name: Descriptive name for this context, used in actor group names for debugging.
             Defaults to a random 8-character hex string.
         no_workers_timeout: Seconds to wait for at least one worker before failing a stage.
-            If None, defaults to 600s for Ray clusters or 60s otherwise.
-            Overridable via ZEPHYR_NO_WORKERS_TIMEOUT env var.
+            Defaults to 600s.
     """
 
     client: Client | None = None
@@ -923,13 +922,7 @@ class ZephyrContext:
                 self.max_workers = int(env_val) if env_val else 128
 
         if self.no_workers_timeout is None:
-            env_timeout = os.environ.get("ZEPHYR_NO_WORKERS_TIMEOUT")
-            if env_timeout is not None:
-                self.no_workers_timeout = float(env_timeout)
-            else:
-                from fray.v2.ray_backend.backend import RayClient
-
-                self.no_workers_timeout = 600.0 if isinstance(self.client, RayClient) else 60.0
+            self.no_workers_timeout = 600.0
 
         if self.chunk_storage_prefix is None:
             temp_prefix = get_temp_bucket_path(ttl_days=3, prefix="zephyr")


### PR DESCRIPTION
Context: 60 seconds on Ray clusters for no-worker-timeout is too aggressive. It would fail a bunch of jobs for me while testing tokenization in #2829.

Changes:
* expose no-worker-timeout as Zephyr config
* bump default timeout on Ray to 10 minutes