### PR TITLE
Move tokenize stats out of Zephyr writer into tokenize top-level

### DIFF
--- a/lib/zephyr/tests/test_writers.py
+++ b/lib/zephyr/tests/test_writers.py
@@ -3,7 +3,6 @@
 
 """Tests for writers module."""
 
-import json
 import tempfile
 from pathlib import Path
 
@@ -167,7 +166,6 @@ def test_write_levanter_cache_resumes_from_partial_tmp_end_to_end():
         output_path = str(Path(tmpdir) / "cache")
         tmp_output_path = f"{output_path}.tmp"
         records = _make_levanter_records(8)
-        expected_token_count = sum(len(record["input_ids"]) for record in records)
 
         with SerialCacheWriter(
             tmp_output_path, records[0], shard_name=output_path, metadata=CacheMetadata({}), mode="w"
@@ -178,12 +176,7 @@ def test_write_levanter_cache_resumes_from_partial_tmp_end_to_end():
 
         assert result["path"] == output_path
         assert result["count"] == len(records)
-        assert result["token_count"] == expected_token_count
         assert Path(output_path, ".success").exists()
-
-        stats = json.loads(Path(output_path, ".stats.json").read_text())
-        assert stats["count"] == len(records)
-        assert stats["token_count"] == expected_token_count
 
         store = TreeStore.open(records[0], output_path, mode="r", cache_metadata=False)
         assert len(store) == len(records)


### PR DESCRIPTION
## Summary
- Removes tokenization-specific side effects from `write_levanter_cache` in `lib/zephyr/src/zephyr/writers.py` (token counting via `input_ids` and `.stats.json` writing)
- Computes stats at the tokenize orchestration level using the `CacheLedger` (for element count) and `TreeStore.input_ids.data_size` (for token count) — data already tracked by Levanter's cache format
- Makes `write_levanter_cache` consistent with other writers (`write_jsonl_file`, `write_parquet_file`) that return only `{"path", "count"}`

Fixes #2454

## Test plan
- [x] All 12 writer tests pass (`lib/zephyr/tests/test_writers.py`)
- [x] Integration test tokenize step completes successfully with correct stats (263 tokens, 11 docs)
- [x] 363 non-slow tests pass (1 pre-existing error unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)