### PR TITLE
Retry Zephyr pipeline on coordinator death

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -890,6 +890,9 @@ class ZephyrContext:
             Defaults to a random 8-character hex string.
         no_workers_timeout: Seconds to wait for at least one worker before failing a stage.
             Defaults to 600s.
+        max_execution_retries: Maximum number of times to retry a pipeline execution after
+            an infrastructure failure (e.g., coordinator VM preemption). Application errors
+            (ZephyrWorkerError) are never retried. Defaults to 3.
     """
 
     client: Client | None = None
@@ -898,6 +901,7 @@ class ZephyrContext:
     chunk_storage_prefix: str | None = None
     name: str = ""
     no_workers_timeout: float | None = None
+    max_execution_retries: int = 3
 
     _shared_data: dict[str, Any] = field(default_factory=dict, repr=False)
     _coordinator: ActorHandle | None = field(default=None, repr=False)
@@ -958,32 +962,54 @@ class ZephyrContext:
         """Execute a dataset pipeline on the worker pool.
 
         Workers persist across execute() calls, so cached state (tokenizers,
-        models) will be reused.
+        models) will be reused. If the coordinator dies mid-execution (e.g.,
+        VM preemption), the pipeline is retried with a fresh coordinator and
+        worker pool up to ``max_execution_retries`` times. Application errors
+        (``ZephyrWorkerError``) are never retried.
         """
         plan = compute_plan(dataset, hints)
         if dry_run:
             _print_plan(dataset.operations, plan)
             return []
 
-        execution_id = _generate_execution_id()
-        logger.info("Starting zephyr pipeline: %s", execution_id)
+        last_exception: Exception | None = None
+        for attempt in range(self.max_execution_retries + 1):
+            execution_id = _generate_execution_id()
+            logger.info("Starting zephyr pipeline: %s (attempt %d)", execution_id, attempt)
 
-        try:
-            self._ensure_coordinator()
-            self._ensure_workers(plan.num_shards)
+            try:
+                self._ensure_coordinator()
+                self._ensure_workers(plan.num_shards)
 
-            # Run pipeline on coordinator (blocking call)
-            results = self._coordinator.run_pipeline.remote(plan, self._shared_data, execution_id, hints).result()
+                # Run pipeline on coordinator (blocking call)
+                results = self._coordinator.run_pipeline.remote(plan, self._shared_data, execution_id, hints).result()
 
-            return results
+                return results
 
-        except Exception:
-            # Re-raise without cleanup - workers will be reused
-            raise
+            except ZephyrWorkerError:
+                raise
 
-        finally:
-            # Clean up chunks for this execution only (workers persist)
-            _cleanup_execution(self.chunk_storage_prefix, execution_id)
+            except Exception as e:
+                last_exception = e
+                if attempt >= self.max_execution_retries:
+                    raise
+
+                logger.warning(
+                    "Pipeline attempt %d/%d failed, retrying with fresh coordinator: %s",
+                    attempt + 1,
+                    self.max_execution_retries,
+                    e,
+                )
+                # Tear down dead coordinator and orphaned workers so
+                # _ensure_coordinator / _ensure_workers create fresh ones.
+                self.shutdown()
+
+            finally:
+                # Clean up chunks for this execution only (workers persist)
+                _cleanup_execution(self.chunk_storage_prefix, execution_id)
+
+        # Should be unreachable, but just in case
+        raise last_exception  # type: ignore[misc]
 
     def _ensure_coordinator(self) -> None:
         """Create coordinator if not already initialized."""


### PR DESCRIPTION
## Summary
- When the Zephyr coordinator is killed (e.g., VM preemption), `ZephyrContext.execute()` now retries by tearing down the dead coordinator and orphaned workers, then recreating them fresh
- Application errors (`ZephyrWorkerError`) are never retried — only infrastructure failures trigger the retry loop
- Adds `max_execution_retries` parameter to `ZephyrContext` (default: 3)

Fixes #2927

## Test plan
- [x] `test_execute_retries_on_coordinator_death` — simulates coordinator death by removing it from the local actor registry, verifies retry succeeds
- [x] `test_execute_does_not_retry_worker_errors` — verifies `ZephyrWorkerError` (application errors) fail fast without retries
- [x] All 177 zephyr tests pass (local, iris, ray backends)
- [x] Pre-commit checks pass