### PR TITLE
Replicate WandB info in default_train

### DIFF
--- a/experiments/defaults.py
+++ b/experiments/defaults.py
@@ -339,6 +339,7 @@ def default_train(
                 name=wandb_name,
                 tags=[*tags],
                 group=wandb_group,
+                replicate_path=this_output_path(),
             ),
             mp=jmp.get_policy("p=f32,c=bfloat16"),
             train_batch_size=train_config.train_batch_size,


### PR DESCRIPTION
Replicate path needs to be defined so that we can load the final run metrics from GCS for things like the canary. Related to #2929 

