### PR TITLE
Avoid eager transformers/torch import in levanter

### DIFF
--- a/lib/levanter/src/levanter/__init__.py
+++ b/lib/levanter/src/levanter/__init__.py
@@ -1,6 +1,8 @@
 # Copyright 2025 The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib
+
 __all__ = [
     "analysis",
     "callbacks",
@@ -26,8 +28,6 @@ import levanter.checkpoint as checkpoint
 import levanter.config as config
 import levanter.data as data
 import levanter.distributed as distributed
-import levanter.eval as eval
-import levanter.eval_harness as eval_harness
 import levanter.models as models
 import levanter.optim as optim
 import levanter.tracker as tracker
@@ -36,6 +36,17 @@ import levanter.visualization as visualization
 import levanter.grug as grug
 from levanter.tracker import current_tracker
 from levanter.trainer import initialize
+
+# eval and eval_harness are loaded lazily because they transitively import
+# transformers (via levanter.data.text), which unconditionally imports torch.
+# This fails on CPU-only workers that lack CUDA libs (see #2941).
+_LAZY_SUBMODULES = {"eval", "eval_harness"}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_SUBMODULES:
+        return importlib.import_module(f"levanter.{name}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __version__ = "1.2"

--- a/lib/levanter/src/levanter/main/lora_lm.py
+++ b/lib/levanter/src/levanter/main/lora_lm.py
@@ -11,6 +11,7 @@ import jax.random as jrandom
 import haliax.random
 
 import levanter
+import levanter.eval
 from levanter import callbacks
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.data.text import LmDataConfig

--- a/lib/levanter/src/levanter/utils/hf_utils.py
+++ b/lib/levanter/src/levanter/utils/hf_utils.py
@@ -3,9 +3,7 @@
 
 import os
 import re
-from typing import TypeAlias
-
-from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 from levanter.utils.logging import silence_transformer_nag
 from levanter.utils.py_utils import logical_cpu_core_count
@@ -15,12 +13,20 @@ silence_transformer_nag()
 
 _HF_TOKENIZER_OFF_VALUES = {"off", "false", "f", "no", "n", "0"}
 
-HfTokenizer: TypeAlias = PreTrainedTokenizerFast | PreTrainedTokenizer
-"""
-Type alias for a Hugging Face tokenizer. This is a union of the two tokenizer types.
-While there is PreTrainedTokenizerBase, it doesn't have all methods that are implemented in both
-PreTrainedTokenizer and PreTrainedTokenizerFast. grumble grumble.
-"""
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
+
+    HfTokenizer: TypeAlias = PreTrainedTokenizerFast | PreTrainedTokenizer
+    """
+    Type alias for a Hugging Face tokenizer. This is a union of the two tokenizer types.
+    While there is PreTrainedTokenizerBase, it doesn't have all methods that are implemented in both
+    PreTrainedTokenizer and PreTrainedTokenizerFast. grumble grumble.
+    """
+else:
+    # Avoid importing transformers at runtime: it unconditionally imports torch, which
+    # fails on CPU-only workers that lack CUDA libs. HfTokenizer is only used in type
+    # annotations (no isinstance checks), so Any is sufficient at runtime.
+    HfTokenizer: TypeAlias = Any
 
 
 def num_cpus_used_by_tokenizer(tokenizer: HfTokenizer) -> int:

--- a/lib/levanter/src/levanter/utils/logging.py
+++ b/lib/levanter/src/levanter/utils/logging.py
@@ -96,5 +96,3 @@ def silence_transformer_nag():
     # Often we won't call this early enough, but it helps with multiprocessing stuff
     if os.getenv("TRANSFORMERS_VERBOSITY") is None:
         os.environ["TRANSFORMERS_VERBOSITY"] = "error"
-
-    import transformers  # noqa: F401


### PR DESCRIPTION
## Summary

Importing anything from `levanter` eagerly imports `transformers` → `torch`, which crashes on CPU-only environments missing CUDA libs (#2937, #2897).

Three independent chains were pulling in `transformers`:

1. **`hf_utils.py`** — `from transformers import ...` at module level to define `HfTokenizer`. No call site uses this alias at runtime (no isinstance checks), so it's now `TYPE_CHECKING`-only with `Any` at runtime.

2. **`silence_transformer_nag()`** — Did `import transformers` after setting the env var. The env var alone is sufficient.

3. **`levanter.eval` / `eval_harness`** — Reach `_batch_tokenizer.py` which has a hard runtime dependency on transformers. Now lazy-loaded via `__getattr__` in `__init__.py`.

Fixes #2941.

## Test plan

- [x] `from levanter.layers.rotary import Llama3RotaryEmbeddingsConfig` no longer imports `transformers`
- [x] Pre-commit clean
- [x] Full levanter test suite passes (844 passed, 60 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)