### PR TITLE
Tune XLA fused CE inferred v-block cap to reduce OOM risk

### DIFF
--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/tuned_block_sizes.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/tuned_block_sizes.py
@@ -429,8 +429,13 @@ def infer_xla_v_block_size(
     device_kind: Optional[str] = None,
 ) -> int:
     """Heuristic v-block size for the XLA streaming path."""
-    del b, h, dtype, device_kind  # currently unused
-    target = min(v, 32768)
+    del b, h, dtype
+    # Larger v-tiles improve throughput, but very large blocks can trigger OOM
+    # in full training runs because backward materializes [B, v_block] temporaries.
+    # Keep TPU v5p a bit larger (16384) and use 8192 elsewhere for safer memory.
+    device_key = _device_key(device_kind)
+    max_v_block_size = 16384 if device_key == "TPU v5p" else 8192
+    target = min(v, max_v_block_size)
     if target <= 0:
         return 1
     # Keep the block size <= v to avoid excess padding work.


### PR DESCRIPTION
## Summary
- Adjust XLA fused CE inferred `v_block_size` cap by TPU type.
- Use max `16384` on TPU v5p.
- Use max `8192` on all other TPU types.

## Why
Large XLA vocab tiles can trigger memory pressure in full training runs because backward materializes large `[B, v_block]` temporaries.
This keeps v5p relatively aggressive while using a safer default elsewhere.

## Scope
- Single-file change:
  - `lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/tuned_block_sizes.py`
- No test changes.
- No benchmark scratch files.
