### PR TITLE
Stream Docker build/push output in verbose mode

### DIFF
--- a/lib/iris/src/iris/cli/build.py
+++ b/lib/iris/src/iris/cli/build.py
@@ -11,6 +11,15 @@ import click
 GHCR_DEFAULT_ORG = "marin-community"
 
 
+def _is_verbose(ctx: click.Context) -> bool:
+    """Walk up the Click context chain to find the top-level --verbose flag."""
+    while ctx:
+        if "verbose" in (ctx.params or {}):
+            return ctx.params["verbose"]
+        ctx = ctx.parent  # type: ignore[assignment]
+    return False
+
+
 def get_git_sha() -> str:
     """Get a short hash representing the current working tree state.
 
@@ -107,6 +116,7 @@ def push_to_ghcr(
     ghcr_org: str = GHCR_DEFAULT_ORG,
     image_name: str | None = None,
     version: str | None = None,
+    verbose: bool = False,
 ) -> None:
     """Push a local Docker image to GitHub Container Registry (ghcr.io)."""
     image_name, version = _resolve_image_name_and_version(source_tag, image_name, version)
@@ -120,13 +130,20 @@ def push_to_ghcr(
         raise SystemExit(1)
 
     click.echo(f"Pushing to {dest_tag}...")
-    result = subprocess.run(["docker", "push", "--quiet", dest_tag], capture_output=True, text=True)
+    push_cmd = ["docker", "push", dest_tag]
+    if not verbose:
+        push_cmd.insert(2, "--quiet")
+    if verbose:
+        result = subprocess.run(push_cmd)
+    else:
+        result = subprocess.run(push_cmd, capture_output=True, text=True)
     if result.returncode != 0:
         click.echo(f"Failed to push to {dest_tag}", err=True)
-        if result.stdout:
-            click.echo(result.stdout, err=True)
-        if result.stderr:
-            click.echo(result.stderr, err=True)
+        if not verbose:
+            if result.stdout:
+                click.echo(result.stdout, err=True)
+            if result.stderr:
+                click.echo(result.stderr, err=True)
         raise SystemExit(1)
 
     click.echo(f"Successfully pushed to {dest_tag}")
@@ -139,6 +156,7 @@ def push_to_gcp_registries(
     project: str,
     image_name: str | None = None,
     version: str | None = None,
+    verbose: bool = False,
 ) -> None:
     """Push a local Docker image to multiple GCP Artifact Registry regions."""
     image_name, version = _resolve_image_name_and_version(source_tag, image_name, version)
@@ -166,13 +184,20 @@ def push_to_gcp_registries(
             continue
 
         click.echo(f"Pushing to {r}...")
-        result = subprocess.run(["docker", "push", "--quiet", dest_tag], capture_output=True, text=True)
+        push_cmd = ["docker", "push", dest_tag]
+        if not verbose:
+            push_cmd.insert(2, "--quiet")
+        if verbose:
+            result = subprocess.run(push_cmd)
+        else:
+            result = subprocess.run(push_cmd, capture_output=True, text=True)
         if result.returncode != 0:
             click.echo(f"Failed to push to {r}", err=True)
-            if result.stdout:
-                click.echo(result.stdout, err=True)
-            if result.stderr:
-                click.echo(result.stderr, err=True)
+            if not verbose:
+                if result.stdout:
+                    click.echo(result.stdout, err=True)
+                if result.stderr:
+                    click.echo(result.stderr, err=True)
             continue
 
         click.echo(f"Successfully pushed to {dest_tag}")
@@ -188,14 +213,17 @@ def _push_image(
     ghcr_org: str = GHCR_DEFAULT_ORG,
     gcp_regions: tuple[str, ...] = (),
     gcp_project: str = "hai-gcp-models",
+    verbose: bool = False,
 ) -> None:
     """Push a local Docker image to the specified registry."""
     if registry == "ghcr":
-        push_to_ghcr(source_tag, ghcr_org=ghcr_org, image_name=image_name, version=version)
+        push_to_ghcr(source_tag, ghcr_org=ghcr_org, image_name=image_name, version=version, verbose=verbose)
     elif registry == "gcp":
         if not gcp_regions:
             raise click.ClickException("--region is required when pushing to GCP Artifact Registry")
-        push_to_gcp_registries(source_tag, gcp_regions, gcp_project, image_name=image_name, version=version)
+        push_to_gcp_registries(
+            source_tag, gcp_regions, gcp_project, image_name=image_name, version=version, verbose=verbose
+        )
     else:
         raise click.ClickException(f"Unknown registry: {registry}. Use 'ghcr' or 'gcp'.")
 
@@ -211,6 +239,7 @@ def build_image(
     ghcr_org: str,
     gcp_regions: tuple[str, ...],
     gcp_project: str,
+    verbose: bool = False,
 ) -> None:
     """Build a Docker image for Iris (worker or controller).
 
@@ -251,13 +280,17 @@ def build_image(
     click.echo(f"Context: {context_path}")
     click.echo()
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    if verbose:
+        result = subprocess.run(cmd)
+    else:
+        result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
         click.echo("Build failed", err=True)
-        if result.stdout:
-            click.echo(result.stdout, err=True)
-        if result.stderr:
-            click.echo(result.stderr, err=True)
+        if not verbose:
+            if result.stdout:
+                click.echo(result.stdout, err=True)
+            if result.stderr:
+                click.echo(result.stderr, err=True)
         raise SystemExit(1)
 
     # buildx --output=docker only loads one name; tag the rest manually
@@ -275,6 +308,7 @@ def build_image(
             ghcr_org=ghcr_org,
             gcp_regions=gcp_regions,
             gcp_project=gcp_project,
+            verbose=verbose,
         )
         _push_image(
             latest_tag,
@@ -282,6 +316,7 @@ def build_image(
             ghcr_org=ghcr_org,
             gcp_regions=gcp_regions,
             gcp_project=gcp_project,
+            verbose=verbose,
         )
 
 
@@ -306,6 +341,7 @@ def _build_all(
     ghcr_org: str,
     gcp_regions: tuple[str, ...],
     gcp_project: str,
+    verbose: bool = False,
 ) -> None:
     """Build all Iris images (worker, controller, task).
 
@@ -316,7 +352,9 @@ def _build_all(
 
     for image_type in ("worker", "controller"):
         tag = _default_versioned_tag(f"iris-{image_type}")
-        build_image(image_type, tag, push, None, None, platform, registry, ghcr_org, gcp_regions, gcp_project)
+        build_image(
+            image_type, tag, push, None, None, platform, registry, ghcr_org, gcp_regions, gcp_project, verbose=verbose
+        )
         click.echo()
 
     task_dockerfile = str(iris_root / "Dockerfile.task")
@@ -331,6 +369,7 @@ def _build_all(
         ghcr_org,
         gcp_regions,
         gcp_project,
+        verbose=verbose,
     )
 
 
@@ -345,16 +384,18 @@ def build(ctx, push: bool, platform: str, registry: str, ghcr_org: str, region: 
     When invoked without a subcommand, builds all images (worker, controller, task).
     """
     if ctx.invoked_subcommand is None:
-        _build_all(push, platform, registry, ghcr_org, gcp_regions=region, gcp_project=project)
+        _build_all(push, platform, registry, ghcr_org, gcp_regions=region, gcp_project=project, verbose=_is_verbose(ctx))
 
 
 @build.command("all")
 @click.option("--push", is_flag=True, help="Push images to registry after building")
 @click.option("--platform", default="linux/amd64", help="Target platform")
 @_add_registry_options
-def build_all(push: bool, platform: str, registry: str, ghcr_org: str, region: tuple[str, ...], project: str):
+@click.pass_context
+def build_all(ctx, push: bool, platform: str, registry: str, ghcr_org: str, region: tuple[str, ...], project: str):
     """Build all Iris images (worker, controller, task)."""
-    _build_all(push, platform, registry, ghcr_org, gcp_regions=region, gcp_project=project)
+    verbose = _is_verbose(ctx)
+    _build_all(push, platform, registry, ghcr_org, gcp_regions=region, gcp_project=project, verbose=verbose)
 
 
 @build.command("worker-image")
@@ -364,7 +405,9 @@ def build_all(push: bool, platform: str, registry: str, ghcr_org: str, region: t
 @click.option("--context", type=click.Path(exists=True), help="Build context directory")
 @click.option("--platform", default="linux/amd64", help="Target platform")
 @_add_registry_options
+@click.pass_context
 def build_worker_image(
+    ctx,
     tag: str,
     push: bool,
     dockerfile: str | None,
@@ -376,8 +419,9 @@ def build_worker_image(
     project: str,
 ):
     """Build Docker image for Iris worker."""
+    verbose = _is_verbose(ctx)
     tag = tag or _default_versioned_tag("iris-worker")
-    build_image("worker", tag, push, dockerfile, context, platform, registry, ghcr_org, region, project)
+    build_image("worker", tag, push, dockerfile, context, platform, registry, ghcr_org, region, project, verbose=verbose)
 
 
 @build.command("controller-image")
@@ -387,7 +431,9 @@ def build_worker_image(
 @click.option("--context", type=click.Path(exists=True), help="Build context directory")
 @click.option("--platform", default="linux/amd64", help="Target platform")
 @_add_registry_options
+@click.pass_context
 def build_controller_image(
+    ctx,
     tag: str,
     push: bool,
     dockerfile: str | None,
@@ -399,8 +445,11 @@ def build_controller_image(
     project: str,
 ):
     """Build Docker image for Iris controller."""
+    verbose = _is_verbose(ctx)
     tag = tag or _default_versioned_tag("iris-controller")
-    build_image("controller", tag, push, dockerfile, context, platform, registry, ghcr_org, region, project)
+    build_image(
+        "controller", tag, push, dockerfile, context, platform, registry, ghcr_org, region, project, verbose=verbose
+    )
 
 
 @build.command("task-image")
@@ -409,7 +458,9 @@ def build_controller_image(
 @click.option("--dockerfile", type=click.Path(exists=True), help="Custom Dockerfile path")
 @click.option("--platform", default="linux/amd64", help="Target platform")
 @_add_registry_options
+@click.pass_context
 def build_task_image(
+    ctx,
     tag: str,
     push: bool,
     dockerfile: str | None,
@@ -431,6 +482,7 @@ def build_task_image(
     if not dockerfile_path.exists():
         raise click.ClickException(f"Dockerfile not found: {dockerfile_path}")
 
+    verbose = _is_verbose(ctx)
     resolved_tag = tag or _default_versioned_tag("iris-task")
 
     build_image(
@@ -444,6 +496,7 @@ def build_task_image(
         ghcr_org,
         region,
         project,
+        verbose=verbose,
     )
 
 
@@ -455,7 +508,9 @@ def build_task_image(
 @click.option("--project", default="hai-gcp-models", help="GCP project ID")
 @click.option("--image-name", help="Image name in registry (default: derived from source tag)")
 @click.option("--version", help="Version tag (default: derived from source tag)")
+@click.pass_context
 def build_push(
+    ctx,
     source_tag: str,
     registry: str,
     ghcr_org: str,
@@ -474,6 +529,7 @@ def build_push(
 
         iris build push iris-task:v1.0 --registry gcp --region us-central1
     """
+    verbose = _is_verbose(ctx)
     _push_image(
         source_tag,
         registry=registry,
@@ -482,4 +538,5 @@ def build_push(
         ghcr_org=ghcr_org,
         gcp_regions=region,
         gcp_project=project,
+        verbose=verbose,
     )


### PR DESCRIPTION

- Thread the top-level `iris -v` flag into all build/push commands so Docker output streams to the terminal in real time
- When verbose: `docker buildx build` and `docker push` write directly to stdout/stderr (no `capture_output`, no `--quiet`)
- When not verbose: behavior is unchanged (output captured, shown only on failure)