### PR TITLE
Zephyr wait 6hrs for workers, nemotron `disk_cache` tokenizer

### DIFF
--- a/experiments/pretraining_datasets/nemotron.py
+++ b/experiments/pretraining_datasets/nemotron.py
@@ -64,7 +64,11 @@ def _get_nemotron_split_paths(split: str):
 
 
 def tokenize_nemotron(
-    *, tokenizer: str | None = None, window_size_bytes: int = 10_000_000_000
+    *,
+    tokenizer: str | None = None,
+    window_size_bytes: int = 10_000_000_000,
+    max_workers: int = 4096,
+    writer_batch_size: int = 65536,
 ) -> dict[str, TokenizerStep]:
     """Generate tokenization steps for all Nemotron CC dataset splits."""
     if tokenizer is None:
@@ -85,6 +89,8 @@ def tokenize_nemotron(
                 cache_path=this_output_path(),
                 tokenizer=versioned(tokenizer),
                 window_size_bytes=window_size_bytes,
+                max_workers=max_workers,
+                writer_batch_size=writer_batch_size,
             ),
         )
 

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -431,7 +431,6 @@ def tokenize(config: TokenizeConfigBase):
             resources=config.worker_resources,
             max_workers=min(config.max_workers, len(train_groups)),
             name="tokenize-train",
-            no_workers_timeout=20 * 60,
         )
         run_pipeline(ctx, train_groups, "train")
 
@@ -441,7 +440,6 @@ def tokenize(config: TokenizeConfigBase):
             resources=config.worker_resources,
             max_workers=min(config.max_workers, len(validation_groups)),
             name="tokenize-validation",
-            no_workers_timeout=20 * 60,
         )
         run_pipeline(ctx, validation_groups, "validation")
 

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -1017,7 +1017,7 @@ class ZephyrContext:
                 self.max_workers = int(env_val) if env_val else 128
 
         if self.no_workers_timeout is None:
-            self.no_workers_timeout = 600.0
+            self.no_workers_timeout = 6 * 60 * 60  # 6 hours
 
         if self.chunk_storage_prefix is None:
             temp_prefix = get_temp_bucket_path(ttl_days=3, prefix="zephyr")


### PR DESCRIPTION
 * re https://github.com/marin-community/marin/issues/2829
 * changes:
   * wait 6hrs by default for zephyr workers - this seems like a better default in our current clusters
   * use `disk_cache` for tokenizer in `tokenize` to reduce impact of https://github.com/marin-community/marin/issues/2982
     * we warm up the cache in the context, the workers just retrieve it and cache it:
       ```py
        @cache
        @disk_cache
        def get_tokenizer(tokenizer: str) -> transformers.PreTrainedTokenizer:
            return transformers.AutoTokenizer.from_pretrained(tokenizer)
       ```
   * expose a couple of flags in tokenize nemotron that I use in my experiments