### PR TITLE
Add Iris OPS.md for operational guidance

### DIFF
--- a/lib/iris/AGENTS.md
+++ b/lib/iris/AGENTS.md
@@ -48,6 +48,10 @@ Documentation should be kept up-to-date as code changes. When implementing new f
 
 @README.md - Main overview, CLI reference, and quick start
 
+## Operations
+
+When troubleshooting, monitoring, or deploying a live Iris cluster, read [OPS.md](OPS.md) first.
+
 ## Protocols and Testing
 
 Non-trivial public classes should define a protocol which represents their

--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -1,0 +1,16 @@
+# Iris Operations
+
+All Iris operations are available via the CLI:
+
+```bash
+uv run iris --help
+```
+
+## Connectivity
+
+`iris --config=... cluster dashboard` establishes an SSH tunnel to the controller and prints the dashboard URL. Keep the terminal open.
+
+Controller and worker both expose a `/health` endpoint:
+
+- **Controller** (`http://localhost:10000/health`): `{"status": "ok", "workers": <int>, "jobs": <int>}`
+- **Worker**: `{"status": "healthy"}`


### PR DESCRIPTION
Closes #2838. Unblocks #2930 (live monitoring) and #2926 (Levanter health check).

## Problem

Iris has operational tooling (health endpoints, log querying, autoscaler status, profiling RPCs, dashboard) but no documentation telling an operator — human or agent — how to use it.

## Changes

- **`lib/iris/OPS.md`** (new): Minimal ops doc. Points to `uv run iris --help` for self-discovery; documents only what's not discoverable via `--help` (SSH tunnel behavior, `/health` response shapes).
- **`lib/iris/AGENTS.md`**: Adds `## Operations` section that conditionally directs agents to `OPS.md` when operating a live cluster.

## Design decisions

- **Standalone `OPS.md`** rather than inlining into `AGENTS.md` — grep-friendly, independently discoverable. Per issue thread consensus with @rjpower.
- **Workflow-oriented, not exhaustive CLI reference** — that already lives in `README.md`.
- **GCP-focused initially.** CoreWeave ops workflows deferred to a separate PR.

## Testing

Verified locally — booted a local cluster and curled the health endpoints:
- Controller: `{"status": "ok", "workers": 6, "jobs": 0}` — matches OPS.md
- Worker: `{"status": "healthy"}` — matches OPS.md
- `uv run iris --help` and `iris cluster --help` both show documented commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)