### PR TITLE
Remove dead job transition retry path in controller state

### DIFF
--- a/lib/iris/src/iris/cluster/controller/state.py
+++ b/lib/iris/src/iris/cluster/controller/state.py
@@ -92,19 +92,16 @@ WORKER_REPORTED_TERMINAL_STATES: frozenset[int] = frozenset(
 
 
 class TaskTransitionResult(Enum):
-    """Result of a task state transition."""
+    """Result of a task state transition.
 
-    COMPLETE = "complete"
+    APPLIED: Transition processed. No special caller action needed.
+    SHOULD_RETRY: Task failed but has retry budget. Caller should requeue.
+    EXCEEDED_RETRY_LIMIT: Task failed and exhausted retries. Terminal.
+    """
+
+    APPLIED = "applied"
     SHOULD_RETRY = "should_retry"
     EXCEEDED_RETRY_LIMIT = "exceeded_retry_limit"
-
-
-class JobTransitionResult(Enum):
-    """Result of a state transition."""
-
-    COMPLETE = "complete"  # Transition succeeded, no action needed
-    SHOULD_RETRY = "should_retry"  # Job should be re-queued for retry
-    EXCEEDED_RETRY_LIMIT = "exceeded_retry_limit"  # Exceeded retry limit, stay in terminal state
 
 
 # =============================================================================
@@ -324,7 +321,7 @@ class ControllerTask:
 
         Updates both the attempt and task-level state. Handles retry logic:
         - If retriable failure: returns SHOULD_RETRY, task state reflects failure but is schedulable
-        - If terminal success: returns COMPLETE, task state is terminal
+        - If terminal success: returns APPLIED, task state is terminal
         - If exhausted retries: returns EXCEEDED_RETRY_LIMIT, task state is terminal
 
         Does NOT create new attempts - that's the scheduler's job.
@@ -347,7 +344,7 @@ class ControllerTask:
                 self.finished_at = Timestamp.now()
                 self.error = error
                 self.exit_code = exit_code
-            return TaskTransitionResult.COMPLETE
+            return TaskTransitionResult.APPLIED
 
         attempt = self.attempts[-1]
 
@@ -385,7 +382,7 @@ class ControllerTask:
             self.exit_code = final_exit_code
             self.error = error
             self.finished_at = Timestamp.now()
-            return TaskTransitionResult.COMPLETE
+            return TaskTransitionResult.APPLIED
 
         # For other terminal states (KILLED, UNSCHEDULABLE)
         if new_state in (cluster_pb2.TASK_STATE_KILLED, cluster_pb2.TASK_STATE_UNSCHEDULABLE):
@@ -402,7 +399,7 @@ class ControllerTask:
             self.error = actual_error
             self.exit_code = exit_code
             self.finished_at = Timestamp.now()
-            return TaskTransitionResult.COMPLETE
+            return TaskTransitionResult.APPLIED
 
         # Non-terminal states (BUILDING, RUNNING)
         attempt.transition(
@@ -412,7 +409,7 @@ class ControllerTask:
         )
         # Update task-level state for non-terminal transitions
         self.state = new_state
-        return TaskTransitionResult.COMPLETE
+        return TaskTransitionResult.APPLIED
 
     def _handle_failure(self, new_state: int) -> TaskTransitionResult:
         """Determine if task should retry after a failure.
@@ -480,32 +477,16 @@ class ControllerTask:
 
 @dataclass
 class ControllerJob:
-    """Job with self-contained state transitions.
+    """Controller representation of a job.
 
-    State transitions are handled via transition(), which updates internal
-    state and returns a JobTransitionResult indicating what the caller should do.
-
-    Example:
-        job = ControllerJob(job_id=..., request=...)
-
-        # Job starts running when first task starts
-        job.mark_dispatched()
-
-        # Task reports failure
-        result = job.transition(JOB_STATE_FAILED, is_worker_failure=False)
-        if result == JobTransitionResult.SHOULD_RETRY:
-            queue.add(job)  # Caller handles re-queueing
+    Job state is derived from task-state counts via on_task_transition()
+    and _compute_job_state(); it is not managed by a standalone job.transition()
+    retry state machine.
     """
 
     job_id: JobName
     request: cluster_pb2.Controller.LaunchJobRequest
     state: int = cluster_pb2.JOB_STATE_PENDING
-
-    # Retry tracking
-    failure_count: int = 0
-    preemption_count: int = 0
-    max_retries_failure: int = 0
-    max_retries_preemption: int = DEFAULT_MAX_RETRIES_PREEMPTION
 
     # Timestamps
     submitted_at: Timestamp = field(default_factory=lambda: Timestamp.from_ms(0))
@@ -522,105 +503,6 @@ class ControllerJob:
     # Incremental task state tracking
     num_tasks: int = 0
     task_state_counts: Counter[int] = field(default_factory=Counter)
-
-    # --- State Transitions ---
-
-    def mark_dispatched(self) -> None:
-        """Mark job as running. Called when first task starts."""
-        self.state = cluster_pb2.JOB_STATE_RUNNING
-        self.started_at = Timestamp.now()
-
-    def revert_dispatch(self) -> None:
-        """Revert dispatch if no tasks actually started."""
-        self.state = cluster_pb2.JOB_STATE_PENDING
-        self.started_at = None
-
-    def transition(
-        self,
-        new_state: int,
-        *,
-        is_worker_failure: bool = False,
-        error: str | None = None,
-        exit_code: int | None = None,
-    ) -> JobTransitionResult:
-        """Transition to a new state.
-
-        For failure states, handles retry logic internally:
-        - Increments appropriate counter (failure_count or preemption_count)
-        - If retries remaining: resets to PENDING, returns SHOULD_RETRY
-        - If no retries: stays in failure state, returns EXCEEDED_RETRY_LIMIT
-
-        Args:
-            new_state: Target state
-            is_worker_failure: True if failure due to worker death (preemption)
-            error: Error message for failure states
-            exit_code: Exit code for completed jobs
-
-        Returns:
-            JobTransitionResult indicating what caller should do
-        """
-        # Handle failure states with retry logic
-        if new_state == cluster_pb2.JOB_STATE_FAILED:
-            return self._handle_failure(is_worker_failure, error, exit_code)
-
-        now = Timestamp.now()
-
-        # Non-failure terminal states
-        if new_state == cluster_pb2.JOB_STATE_SUCCEEDED:
-            self.state = new_state
-            self.finished_at = now
-            self.exit_code = exit_code or 0
-            return JobTransitionResult.COMPLETE
-
-        if new_state == cluster_pb2.JOB_STATE_KILLED:
-            self.state = new_state
-            self.finished_at = now
-            self.error = error
-            return JobTransitionResult.COMPLETE
-
-        if new_state == cluster_pb2.JOB_STATE_UNSCHEDULABLE:
-            self.state = new_state
-            self.finished_at = now
-            if self.request.HasField("scheduling_timeout"):
-                timeout = Duration.from_proto(self.request.scheduling_timeout)
-            else:
-                timeout = None
-            self.error = error or f"Scheduling timeout exceeded ({timeout})"
-            return JobTransitionResult.COMPLETE
-
-        # Non-terminal states (BUILDING, RUNNING)
-        self.state = new_state
-        return JobTransitionResult.COMPLETE
-
-    def _handle_failure(
-        self,
-        is_worker_failure: bool,
-        error: str | None,
-        exit_code: int | None,
-    ) -> JobTransitionResult:
-        """Handle failure with retry logic. Either resets for retry or marks as terminal failure."""
-        if is_worker_failure:
-            self.preemption_count += 1
-            can_retry = self.preemption_count <= self.max_retries_preemption
-        else:
-            self.failure_count += 1
-            can_retry = self.failure_count <= self.max_retries_failure
-
-        if can_retry:
-            # Reset state for retry
-            self.state = cluster_pb2.JOB_STATE_PENDING
-            self.started_at = None
-            self.finished_at = None
-            self.error = None
-            self.exit_code = None
-            return JobTransitionResult.SHOULD_RETRY
-        else:
-            # Terminal failure
-            self.state = cluster_pb2.JOB_STATE_FAILED
-            self.finished_at = Timestamp.now()
-            self.error = error
-            self.exit_code = exit_code
-            return JobTransitionResult.EXCEEDED_RETRY_LIMIT
 
     # --- Task State Tracking ---
 
@@ -690,17 +572,6 @@ class ControllerJob:
             cluster_pb2.JOB_STATE_UNSCHEDULABLE,
         )
 
-    def can_retry_failure(self) -> bool:
-        return self.failure_count < self.max_retries_failure
-
-    def can_retry_preemption(self) -> bool:
-        return self.preemption_count < self.max_retries_preemption
-
-    @property
-    def total_attempts(self) -> int:
-        """Total number of retries (failure + preemption retries)."""
-        return self.failure_count + self.preemption_count
-
     @property
     def is_coscheduled(self) -> bool:
         """Whether this job uses coscheduling (all tasks assigned atomically)."""
@@ -748,8 +619,8 @@ def expand_job_to_tasks(job: ControllerJob) -> list[ControllerTask]:
         task = ControllerTask(
             task_id=task_id,
             job_id=job.job_id,
-            max_retries_failure=job.max_retries_failure,
-            max_retries_preemption=job.max_retries_preemption,
+            max_retries_failure=job.request.max_retries_failure,
+            max_retries_preemption=job.request.max_retries_preemption,
             submitted_at=job.submitted_at,
         )
         tasks.append(task)
@@ -1185,16 +1056,10 @@ class ControllerState:
     # -------------------------------------------------------------------------
 
     def _on_job_submitted(self, txn: TransactionLog, event: JobSubmittedEvent) -> None:
-        # Read retry limits from request, using defaults if not set
-        max_retries_failure = event.request.max_retries_failure  # proto default: 0
-        max_retries_preemption = event.request.max_retries_preemption
-
         job = ControllerJob(
             job_id=event.job_id,
             request=event.request,
             submitted_at=event.timestamp,
-            max_retries_failure=max_retries_failure,
-            max_retries_preemption=max_retries_preemption,
         )
         if job.request.HasField("scheduling_timeout") and job.request.scheduling_timeout.milliseconds > 0:
             job.scheduling_deadline = Deadline.from_now(Duration.from_proto(job.request.scheduling_timeout))

--- a/lib/iris/tests/cluster/controller/test_job.py
+++ b/lib/iris/tests/cluster/controller/test_job.py
@@ -1,11 +1,11 @@
 # Copyright 2025 The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for Job state transitions and retries."""
+"""Tests for job state derivation and job-to-task expansion."""
 
 import pytest
 
-from iris.cluster.controller.state import ControllerJob, JobTransitionResult, expand_job_to_tasks
+from iris.cluster.controller.state import ControllerJob, expand_job_to_tasks
 from iris.cluster.types import JobName
 from iris.rpc import cluster_pb2
 
@@ -31,173 +31,6 @@ def make_job_request():
         )
 
     return _make
-
-
-# --- Job State Transitions ---
-
-
-@pytest.mark.parametrize(
-    "target_state,exit_code,error",
-    [
-        (cluster_pb2.JOB_STATE_SUCCEEDED, 0, None),
-        (cluster_pb2.JOB_STATE_KILLED, None, "Terminated by user"),
-        (cluster_pb2.JOB_STATE_UNSCHEDULABLE, None, None),
-    ],
-)
-def test_job_terminal_transitions(make_job_request, target_state, exit_code, error):
-    """Job transitions to terminal states (SUCCEEDED, KILLED, UNSCHEDULABLE) with appropriate metadata."""
-    job = ControllerJob(job_id=JobName.root("test"), request=make_job_request())
-    job.mark_dispatched()
-
-    result = job.transition(target_state, exit_code=exit_code, error=error)
-
-    assert result == JobTransitionResult.COMPLETE
-    assert job.state == target_state
-    assert job.finished_at is not None and job.finished_at.epoch_ms() > 0
-    assert job.is_finished()
-
-
-def test_unschedulable_includes_timeout_in_error(make_job_request):
-    """UNSCHEDULABLE state includes scheduling timeout in error message."""
-    from iris.time_utils import Duration
-
-    request = make_job_request()
-    request.scheduling_timeout.CopyFrom(Duration.from_seconds(300).to_proto())
-    job = ControllerJob(job_id=JobName.root("test"), request=request)
-
-    result = job.transition(cluster_pb2.JOB_STATE_UNSCHEDULABLE)
-
-    assert result == JobTransitionResult.COMPLETE
-    assert job.state == cluster_pb2.JOB_STATE_UNSCHEDULABLE
-    assert job.error is not None
-    assert "300" in job.error
-
-
-# --- Job Retry Behavior ---
-
-
-def test_failure_with_retries_available(make_job_request):
-    """Job failure returns SHOULD_RETRY when retries available and resets to PENDING."""
-    job = ControllerJob(
-        job_id=JobName.root("test"),
-        request=make_job_request(),
-        max_retries_failure=2,
-    )
-    job.mark_dispatched()
-
-    result = job.transition(
-        cluster_pb2.JOB_STATE_FAILED,
-        error="oops",
-    )
-
-    assert result == JobTransitionResult.SHOULD_RETRY
-    assert job.state == cluster_pb2.JOB_STATE_PENDING
-    assert job.failure_count == 1
-    assert job.started_at is None
-    assert not job.is_finished()
-
-
-def test_failure_exceeds_retry_limit(make_job_request):
-    """Job failure returns EXCEEDED_RETRY_LIMIT when retry limit exceeded."""
-    job = ControllerJob(
-        job_id=JobName.root("test"),
-        request=make_job_request(),
-        max_retries_failure=1,
-    )
-    job.mark_dispatched()
-
-    # First failure - retry
-    result = job.transition(cluster_pb2.JOB_STATE_FAILED)
-    assert result == JobTransitionResult.SHOULD_RETRY
-    assert job.failure_count == 1
-
-    # Dispatch again
-    job.mark_dispatched()
-
-    # Second failure - no more retries
-    result = job.transition(cluster_pb2.JOB_STATE_FAILED, error="final error")
-    assert result == JobTransitionResult.EXCEEDED_RETRY_LIMIT
-    assert job.state == cluster_pb2.JOB_STATE_FAILED
-    assert job.failure_count == 2
-    assert job.finished_at is not None and job.finished_at.epoch_ms() > 0
-    assert job.is_finished()
-
-
-def test_worker_failure_uses_separate_retry_counter(make_job_request):
-    """Worker failure increments preemption_count, not failure_count."""
-    job = ControllerJob(
-        job_id=JobName.root("test"),
-        request=make_job_request(),
-        max_retries_preemption=1,
-    )
-    job.mark_dispatched()
-
-    # First preemption - retry
-    result = job.transition(
-        cluster_pb2.JOB_STATE_FAILED,
-        is_worker_failure=True,
-    )
-    assert result == JobTransitionResult.SHOULD_RETRY
-    assert job.preemption_count == 1
-    assert job.failure_count == 0
-
-    # Dispatch again
-    job.mark_dispatched()
-
-    # Second preemption - no more retries
-    result = job.transition(
-        cluster_pb2.JOB_STATE_FAILED,
-        is_worker_failure=True,
-    )
-    assert result == JobTransitionResult.EXCEEDED_RETRY_LIMIT
-    assert job.state == cluster_pb2.JOB_STATE_FAILED
-    assert job.preemption_count == 2
-
-
-@pytest.mark.parametrize(
-    "failure_type,max_retries,expected_attempts",
-    [
-        ("job_failure", 0, 1),  # Default: no retries means one attempt
-        ("job_failure", 1, 2),  # 1 retry = 2 attempts
-        ("job_failure", 3, 4),  # 3 retries = 4 attempts
-        ("worker_failure", 100, 101),  # Default preemption: 100 retries
-    ],
-)
-def test_retry_count_limits(make_job_request, failure_type, max_retries, expected_attempts):
-    """Job respects retry limits for both failure types."""
-    if failure_type == "job_failure":
-        job = ControllerJob(
-            job_id=JobName.root("test"),
-            request=make_job_request(),
-            max_retries_failure=max_retries,
-        )
-        state = cluster_pb2.JOB_STATE_FAILED
-        is_worker_failure = False
-    else:
-        job = ControllerJob(
-            job_id=JobName.root("test"),
-            request=make_job_request(),
-            max_retries_preemption=max_retries,
-        )
-        state = cluster_pb2.JOB_STATE_FAILED
-        is_worker_failure = True
-
-    # Attempt up to the limit
-    for _ in range(max_retries):
-        job.mark_dispatched()
-        result = job.transition(state, is_worker_failure=is_worker_failure)
-        assert result == JobTransitionResult.SHOULD_RETRY
-
-    # Final attempt should fail
-    job.mark_dispatched()
-    result = job.transition(state, is_worker_failure=is_worker_failure)
-    assert result == JobTransitionResult.EXCEEDED_RETRY_LIMIT
-    assert job.is_finished()
-    # expected_attempts = max_retries + 1 (original attempt + retries)
-    if failure_type == "job_failure":
-        assert job.failure_count == expected_attempts
-    else:
-        assert job.preemption_count == expected_attempts
 
 
 # --- Task State Tracking ---
@@ -309,6 +142,22 @@ def test_job_expands_to_correct_number_of_tasks(make_job_request):
     for i, task in enumerate(tasks):
         assert task.task_index == i
         assert task.job_id == job.job_id
+
+
+def test_job_expands_tasks_with_retry_limits_from_request(make_job_request):
+    """expand_job_to_tasks reads per-task retry limits from LaunchJobRequest."""
+    request = make_job_request()
+    request.replicas = 2
+    request.max_retries_failure = 3
+    request.max_retries_preemption = 7
+    job = ControllerJob(job_id=JobName.root("test-job"), request=request)
+
+    tasks = expand_job_to_tasks(job)
+
+    assert len(tasks) == 2
+    for task in tasks:
+        assert task.max_retries_failure == 3
+        assert task.max_retries_preemption == 7
 
 
 def test_job_becomes_unschedulable_when_task_unschedulable(make_job_request):


### PR DESCRIPTION
## Problem
`ControllerJob.transition()` and `JobTransitionResult` are unused in production, but kept a parallel retry state machine that diverges from the real task-driven path. `TaskTransitionResult.COMPLETE` also reads as terminal completion even for non-terminal transitions.

## Approach
Use task-driven state as the single source of truth: remove dead job transition/retry APIs, rename `TaskTransitionResult.COMPLETE` to `APPLIED`, and source task retry limits directly from `LaunchJobRequest` during job expansion.

## Key Changes
- `TaskTransitionResult.COMPLETE -> APPLIED` in controller task transition handling.
- Removed `JobTransitionResult` and dead `ControllerJob` retry/transition members (`transition`, `_handle_failure`, retry counters/helpers, `revert_dispatch`).
- `expand_job_to_tasks()` now reads retries from `job.request.max_retries_failure` and `job.request.max_retries_preemption`.
- Simplified `_on_job_submitted()` to construct `ControllerJob` without retry passthrough fields.
- Removed dead `test_job.py` coverage for `ControllerJob.transition()` and added:
  - retry propagation test in job expansion
  - unschedulable integration-path coverage in `test_state.py`

## Tests
- `uv run pytest lib/iris/tests/cluster/controller/test_job.py lib/iris/tests/cluster/controller/test_state.py` (pass)
- `uv run pytest lib/iris/tests/ -m "e2e and not docker" -n8` (fails only in CoreWeave-live environment tests due local kubectl/S3 creds, unrelated to this diff)
- `./infra/pre-commit.py --all-files` (fails on existing pyrefly project-excludes config behavior)
