### PR TITLE
iris: start user CLI tunnel free-port scan at 10000

### DIFF
--- a/lib/iris/src/iris/cluster/platform/coreweave.py
+++ b/lib/iris/src/iris/cluster/platform/coreweave.py
@@ -1422,7 +1422,7 @@ def _coreweave_tunnel(
 ) -> Iterator[str]:
     """kubectl port-forward to a K8s Service, yielding the local URL."""
     if local_port is None:
-        local_port = find_free_port()
+        local_port = find_free_port(start=10000)
 
     proc = kubectl.popen(
         ["port-forward", f"svc/{service_name}", f"{local_port}:{remote_port}"],

--- a/lib/iris/src/iris/cluster/platform/gcp.py
+++ b/lib/iris/src/iris/cluster/platform/gcp.py
@@ -921,7 +921,7 @@ def _gcp_tunnel(
     Picks a free port automatically if none is specified.
     """
     if local_port is None:
-        local_port = find_free_port()
+        local_port = find_free_port(start=10000)
 
     labels = Labels(label_prefix)
     label_filter = f"labels.{labels.iris_controller}=true AND status=RUNNING"


### PR DESCRIPTION
## Summary
- update GCP user tunnel port allocation to scan from 10000 when local port is not specified
- update CoreWeave user tunnel port allocation to scan from 10000 when local port is not specified

## Notes
- no behavior change when --local-port is explicitly provided
- pre-commit/commit hook currently fails on an existing pyrefly config issue unrelated to this patch