### PR TITLE
Fix canary ferry UTC date mismatch

### DIFF
--- a/experiments/ferries/canary_ferry.py
+++ b/experiments/ferries/canary_ferry.py
@@ -35,7 +35,7 @@ from experiments.defaults import default_train
 from experiments.simple_train_config import SimpleTrainConfig
 from experiments.tootsie.exp1295_32b import nemotron_mix
 
-CANARY_DATE = os.environ.get("CANARY_DATE", datetime.date.today().isoformat())
+CANARY_DATE = os.environ.get("CANARY_DATE", datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"))
 
 # --- Model: Qwen3 ~30M (hidden_dim=512) ---
 model = Qwen3Config(


### PR DESCRIPTION
Fixes #3002.

## Problem

`canary_ferry.py` resolves `CANARY_DATE` via `datetime.date.today()` at module import. The Submit step runs on a Ray worker (`America/Los_Angeles`), while the Validate step re-imports the module on the GH Actions runner (`UTC`).

The cron fires at 06:00 UTC (= 22:00 Pacific) — the two sides disagree on the date, producing different output paths. The worker writes to yesterday's path; the validator looks for today's path → `FileNotFoundError`.

The canary ferry has not had a successful scheduled run since the date fix (#2937) landed.

## Fix

One-line change: replace `datetime.date.today()` with `datetime.datetime.now(datetime.timezone.utc)` so both sides resolve to the same UTC date.

## Testing

**Pre-merge** — both timezones produce identical output:

```bash
$ TZ=UTC python3 -c "from experiments.ferries.canary_ferry import CANARY_DATE; print(CANARY_DATE)"
2026-02-24
$ TZ=America/Los_Angeles python3 -c "from experiments.ferries.canary_ferry import CANARY_DATE; print(CANARY_DATE)"
2026-02-24
```

- [x] **Pre-merge (end-to-end)** — triggered `workflow_dispatch` of `marin-canary-ferry.yaml` on the PR branch ([run](https://github.com/marin-community/marin/actions/runs/22370317062)): Validate step passed.