### PR TITLE
Fix levanter required checks blocking unrelated PRs

### DIFF
--- a/.github/workflows/levanter-tests.yaml
+++ b/.github/workflows/levanter-tests.yaml
@@ -5,11 +5,8 @@ on:
     branches:
       - main
   pull_request:
-    paths:
-      - lib/haliax/**
-      - lib/levanter/**
-      - uv.lock
-      - .github/workflows/levanter-tests.yaml
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -156,9 +153,9 @@ jobs:
 #          CUDA_VISIBLE_DEVICES="" PYTHONPATH=tests:src:. uv run --package levanter --frozen --extra torch_test pytest tests -m "torch" --durations=20
 
   tpu-tests:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [tpu-ci]
     timeout-minutes: 15
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Branch protection requires `cpu-unit-tests (3.11, 0.8.0)` and `cpu-entry-tests (3.11)` to pass, but these jobs live in `levanter-tests.yaml` which had a workflow-level `paths:` filter. PRs that don't touch `lib/levanter/`, `lib/haliax/`, or `uv.lock` never triggered the workflow, leaving those checks permanently pending and blocking merge (e.g. PR #3005).
- Remove the `paths:` filter so the workflow triggers on all PRs to `main`. The CPU tests take ~5 min on free GitHub runners — acceptable overhead to keep CI simple.

## Test plan
- [x] `actionlint` passes (only pre-existing `tpu-ci` label warning)
- [x] The levanter checks on this PR report a status instead of being absent
- [x] Verify a PR that touches `lib/levanter/` still runs the full test suite

---

**Why not skip jobs conditionally?** The alternative is to keep the workflow triggering on all PRs but add a [`dorny/paths-filter`](https://github.com/dorny/paths-filter) `changes` job, then gate every test job with `needs: [changes]` + `if: needs.changes.outputs.levanter == 'true'`. Skipped jobs report as "skipped" to GitHub, which satisfies required checks. We didn't go this route because it adds a third-party action dependency and ~2 lines of boilerplate per job, all to save ~5 min of free GitHub-hosted runner time. If CI cost becomes a concern we can revisit, but for now simplicity wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)