### PR TITLE
iris: classify pod-not-found as infra with retry window

### DIFF
--- a/lib/iris/src/iris/cluster/runtime/types.py
+++ b/lib/iris/src/iris/cluster/runtime/types.py
@@ -18,11 +18,21 @@ too many concurrent uv sync operations.
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from enum import StrEnum
 from pathlib import Path
 from typing import Protocol
 
 from iris.cluster.worker.worker_types import LogLine, TaskLogs
 from iris.rpc import cluster_pb2
+
+
+class ContainerErrorKind(StrEnum):
+    """Structured category for container/runtime errors."""
+
+    NONE = "none"
+    USER_CODE = "user_code"
+    INFRA_NOT_FOUND = "infra_not_found"
+    RUNTIME_ERROR = "runtime_error"
 
 
 @dataclass
@@ -38,6 +48,7 @@ class ContainerConfig:
     mounts: list[tuple[str, str, str]] = field(default_factory=list)  # (host, container, mode)
     network_mode: str = "host"  # e.g. "host" for --network=host
     task_id: str | None = None
+    attempt_id: int | None = None
     job_id: str | None = None
     worker_metadata: cluster_pb2.WorkerMetadata | None = None
 
@@ -83,6 +94,7 @@ class ContainerStatus:
     running: bool
     exit_code: int | None = None
     error: str | None = None
+    error_kind: ContainerErrorKind = ContainerErrorKind.NONE
     oom_killed: bool = False
 
 

--- a/lib/iris/src/iris/cluster/worker/task_attempt.py
+++ b/lib/iris/src/iris/cluster/worker/task_attempt.py
@@ -18,7 +18,13 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from iris.chaos import chaos, chaos_raise
-from iris.cluster.runtime.types import ContainerConfig, ContainerHandle, ContainerRuntime, RuntimeLogReader
+from iris.cluster.runtime.types import (
+    ContainerConfig,
+    ContainerErrorKind,
+    ContainerHandle,
+    ContainerRuntime,
+    RuntimeLogReader,
+)
 from google.protobuf import json_format
 
 from iris.cluster.types import (
@@ -534,6 +540,7 @@ class TaskAttempt:
             timeout_seconds=timeout_seconds,
             mounts=mounts,
             task_id=self.task_id.to_wire(),
+            attempt_id=self.attempt_id,
             job_id=job_id.to_wire(),
             worker_metadata=self._worker_metadata,
         )
@@ -643,11 +650,10 @@ class TaskAttempt:
 
                 # Container has stopped
                 if status.error:
-                    self.transition_to(
-                        cluster_pb2.TASK_STATE_FAILED,
-                        error=status.error,
-                        exit_code=status.exit_code or -1,
-                    )
+                    failure_state = cluster_pb2.TASK_STATE_FAILED
+                    if status.error_kind == ContainerErrorKind.INFRA_NOT_FOUND:
+                        failure_state = cluster_pb2.TASK_STATE_WORKER_FAILED
+                    self.transition_to(failure_state, error=status.error, exit_code=status.exit_code or -1)
                 elif status.exit_code == 0:
                     self.transition_to(cluster_pb2.TASK_STATE_SUCCEEDED, exit_code=0)
                 else:


### PR DESCRIPTION
## Problem

`Pod not found` from the Kubernetes runtime was reported as a generic task failure, which consumed user failure budget (`TASK_STATE_FAILED`) instead of preemption/infra retry budget. In transient CoreWeave/Kubernetes control-plane races, this can incorrectly surface as user failure.

## Approach

Add structured runtime error classification and route infra disappearance through the worker-failure path.

- Introduce `ContainerErrorKind` on runtime status.
- Make Kubernetes pod lookup use a transient grace policy (3 misses / 15s) before terminal classification.
- Emit a specific pod-missing diagnostic message with pod/task/attempt context.
- In task monitoring, map infra-not-found errors to `TASK_STATE_WORKER_FAILED`.

## Key Changes

- `lib/iris/src/iris/cluster/runtime/types.py`
  - Added `ContainerErrorKind` and `ContainerStatus.error_kind`.
  - Added `ContainerConfig.attempt_id` for diagnostics.
- `lib/iris/src/iris/cluster/runtime/kubernetes.py`
  - Added transient retry window for missing task pods (3 observations within 15s).
  - Added structured terminal classification `INFRA_NOT_FOUND` with detailed error text.
- `lib/iris/src/iris/cluster/worker/task_attempt.py`
  - Classifies `INFRA_NOT_FOUND` as `TASK_STATE_WORKER_FAILED` (retryable preemption path).
- `lib/iris/src/iris/cluster/runtime/docker.py`
  - Propagates structured `error_kind` for inspect/not-found/runtime parse errors.

## Testing

- `uv run pytest lib/iris/tests/cluster/runtime/test_kubernetes_runtime.py -o "addopts="`
  - Validates transient pod-miss retries.
  - Validates persistent pod-miss maps to structured `INFRA_NOT_FOUND`.
- `uv run pytest lib/iris/tests/cluster/worker/test_worker.py -o "addopts="`
  - Validates infra-not-found is surfaced as `TASK_STATE_WORKER_FAILED`.

