### PR TITLE
zephyr: suppress spurious heartbeat timeout warnings for shut-down workers

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -408,6 +408,7 @@ class ZephyrCoordinator:
             self._worker_states[worker_id] = WorkerState.READY
 
             if self._shutdown:
+                self._worker_states[worker_id] = WorkerState.DEAD
                 return "SHUTDOWN"
 
             if self._fatal_error:
@@ -415,6 +416,7 @@ class ZephyrCoordinator:
 
             if not self._task_queue:
                 if self._is_last_stage:
+                    self._worker_states[worker_id] = WorkerState.DEAD
                     return "SHUTDOWN"
                 return None
 


### PR DESCRIPTION
When pull_task returns SHUTDOWN to a worker (either because the coordinator is shutting down or because the last stage has no remaining tasks), mark the worker as DEAD immediately. The heartbeat checker already skips DEAD workers, so this prevents confusing "failed to heartbeat within timeout" warnings for workers that were explicitly told to exit.