### PR TITLE
Fix MARIN_PREFIX autouse fixtures when env var is pre-set

### DIFF
--- a/lib/levanter/tests/conftest.py
+++ b/lib/levanter/tests/conftest.py
@@ -28,8 +28,11 @@ def local_gpt2_tokenizer(tmp_path_factory):
 @pytest.fixture(autouse=True)
 def _configure_marin_prefix():
     """Set MARIN_PREFIX to a temp directory for tests that rely on it."""
-    if "MARIN_PREFIX" not in os.environ:
-        with tempfile.TemporaryDirectory(prefix="marin_prefix") as temp_dir:
-            os.environ["MARIN_PREFIX"] = temp_dir
-            yield
-            del os.environ["MARIN_PREFIX"]
+    if "MARIN_PREFIX" in os.environ:
+        yield
+        return
+
+    with tempfile.TemporaryDirectory(prefix="marin_prefix") as temp_dir:
+        os.environ["MARIN_PREFIX"] = temp_dir
+        yield
+        del os.environ["MARIN_PREFIX"]

--- a/lib/zephyr/tests/conftest.py
+++ b/lib/zephyr/tests/conftest.py
@@ -160,11 +160,14 @@ class CallCounter:
 @pytest.fixture(autouse=True)
 def _configure_marin_prefix():
     """Set MARIN_PREFIX to a temp directory for tests that rely on it."""
-    if "MARIN_PREFIX" not in os.environ:
-        with tempfile.TemporaryDirectory(prefix="marin_prefix") as temp_dir:
-            os.environ["MARIN_PREFIX"] = temp_dir
-            yield
-            del os.environ["MARIN_PREFIX"]
+    if "MARIN_PREFIX" in os.environ:
+        yield
+        return
+
+    with tempfile.TemporaryDirectory(prefix="marin_prefix") as temp_dir:
+        os.environ["MARIN_PREFIX"] = temp_dir
+        yield
+        del os.environ["MARIN_PREFIX"]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,8 +35,11 @@ def disable_wandb(monkeypatch):
 @pytest.fixture(autouse=True)
 def _configure_marin_prefix():
     """Set MARIN_PREFIX to a temp directory for tests that rely on it."""
-    if "MARIN_PREFIX" not in os.environ:
-        with tempfile.TemporaryDirectory(prefix="marin_prefix") as temp_dir:
-            os.environ["MARIN_PREFIX"] = temp_dir
-            yield
-            del os.environ["MARIN_PREFIX"]
+    if "MARIN_PREFIX" in os.environ:
+        yield
+        return
+
+    with tempfile.TemporaryDirectory(prefix="marin_prefix") as temp_dir:
+        os.environ["MARIN_PREFIX"] = temp_dir
+        yield
+        del os.environ["MARIN_PREFIX"]


### PR DESCRIPTION
## Summary
- fix autouse `_configure_marin_prefix` fixtures to always `yield`
- if `MARIN_PREFIX` is already set (server/ray env), keep it unchanged and still run fixture teardown path cleanly
- otherwise create and clean up a temporary prefix as before

## Why
Running tests on server environments with `MARIN_PREFIX` pre-set caused fixture setup to fail with:
`ValueError: _configure_marin_prefix did not yield a value`.

## Validation
- `MARIN_PREFIX=/tmp/marin-prefix-test UV_PYTHON=3.11 uv run --package levanter --group test pytest -q -rA lib/levanter/tests/grug/test_grugformer_core.py::test_attentionmask_materialize_causal 'lib/levanter/tests/grug/test_grugformer_core.py::test_blocksparse_attention_matches_reference_on_tiny_shapes[causal_window_segments]'`
- `MARIN_PREFIX=/tmp/marin-prefix-test UV_PYTHON=3.11 uv run --package marin --group test pytest -q -rA tests/execution/test_disk_cache.py::test_decorator_auto_path_from_marin_prefix`
- `MARIN_PREFIX=/tmp/marin-prefix-test UV_PYTHON=3.11 uv run --package zephyr --group test pytest -q -rA lib/zephyr/tests/test_expr.py::TestColumnExpr::test_evaluate_existing_column`
