### PR TITLE
Clean up GCS region helper after concurrent PRs

### DIFF
--- a/lib/iris/src/iris/marin_fs.py
+++ b/lib/iris/src/iris/marin_fs.py
@@ -13,6 +13,7 @@ Resolution chain for the storage prefix:
   3. ``/tmp/marin`` (local fallback)
 """
 
+import dataclasses
 import logging
 import os
 import pathlib
@@ -22,8 +23,6 @@ import urllib.request
 from collections.abc import Callable, Sequence
 from pathlib import PurePath
 from typing import Any
-
-import dataclasses
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/training/training.py
+++ b/lib/marin/src/marin/training/training.py
@@ -26,7 +26,7 @@ from levanter.main.train_dpo import TrainDpoConfig
 from levanter.main.train_lm import TrainLmConfig
 from mergedeep import mergedeep
 
-from iris.marin_fs import check_gcs_paths_same_region, check_path_in_region, marin_region, marin_temp_bucket
+from iris.marin_fs import check_gcs_paths_same_region, marin_temp_bucket
 
 logger = logging.getLogger(__name__)
 
@@ -330,8 +330,6 @@ def _doublecheck_paths(config: TrainOnPodConfigT):
     check_gcs_paths_same_region(
         config.train_config,
         local_ok=local_ok,
-        region_getter=marin_region,
-        path_checker=check_path_in_region,
     )
     return config
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -53,7 +53,7 @@ class MockNestedConfig:
 def test_lm_config_with_train_urls_allowed_out_of_region(trainer_config):
     """train/validation source URLs are exempt from region checks."""
     with (
-        patch("marin.training.training.marin_region", return_value="us-central1"),
+        patch("iris.marin_fs.marin_region", return_value="us-central1"),
         patch("iris.marin_fs.get_bucket_location", return_value="us-east1"),
     ):
         config = TrainLmOnPodConfig(
@@ -69,7 +69,7 @@ def test_lm_config_with_train_urls_allowed_out_of_region(trainer_config):
 def test_recursive_path_checking(trainer_config):
     """Paths are checked recursively in nested structures."""
     with (
-        patch("marin.training.training.marin_region", return_value="us-central1"),
+        patch("iris.marin_fs.marin_region", return_value="us-central1"),
         patch("iris.marin_fs.get_bucket_location", return_value="us-east1"),
     ):
         nested_data = MockNestedDataConfig(
@@ -89,7 +89,7 @@ def test_recursive_path_checking(trainer_config):
 def test_dataclass_recursive_checking(trainer_config):
     """Paths are checked recursively in dataclass objects."""
     with (
-        patch("marin.training.training.marin_region", return_value="us-central1"),
+        patch("iris.marin_fs.marin_region", return_value="us-central1"),
         patch("iris.marin_fs.get_bucket_location", return_value="us-east1"),
     ):
         config = TrainLmOnPodConfig(
@@ -106,7 +106,7 @@ def test_dataclass_recursive_checking(trainer_config):
 def test_pathlib_path_handling(trainer_config):
     """pathlib.Path objects that represent GCS URIs are handled correctly."""
     with (
-        patch("marin.training.training.marin_region", return_value="us-central1"),
+        patch("iris.marin_fs.marin_region", return_value="us-central1"),
         patch("iris.marin_fs.get_bucket_location", return_value="us-east1"),
     ):
         config = TrainLmOnPodConfig(


### PR DESCRIPTION
## Summary
- Fix stdlib import ordering in `marin_fs.py`
- Remove redundant explicit default args from `_doublecheck_paths`
- Drop unused imports from `training.py`
- Update test mocks to patch at source

Follows up on #3031 and #3026 which were merged concurrently.

Generated with [Claude Code](https://claude.ai/code)