### PR TITLE
Allow to override num shard in `tokenize`

### DIFF
--- a/lib/marin/src/marin/processing/tokenize/download_pretokenized.py
+++ b/lib/marin/src/marin/processing/tokenize/download_pretokenized.py
@@ -28,7 +28,7 @@ from marin.processing.tokenize.tokenize import TokenizeConfigBase
 logger = logging.getLogger(__name__)
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class PretokenizedCacheDownloadConfig(TokenizeConfigBase):
     """Configuration for downloading a pre-existing Levanter cache from Hugging Face."""
 

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -59,6 +59,7 @@ class HfDatasetSpec:
     name: str | None = None
 
 
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class TokenizeConfigBase(abc.ABC):
     """Base class for tokenize configs."""
 

--- a/lib/marin/src/marin/tokenize/slice_cache.py
+++ b/lib/marin/src/marin/tokenize/slice_cache.py
@@ -35,7 +35,7 @@ from marin.processing.tokenize.tokenize import TokenizeConfigBase
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(frozen=True)
 class SliceCacheConfig(TokenizeConfigBase):
     """Configuration for slicing a Levanter cache."""
 


### PR DESCRIPTION
Follow up to #3012, allow to override the number of shards. This could be useful if you want more shards the max workers for example to mitigate the cost of retry on a single shard.