### PR TITLE
Iris: prefer KUBECONFIG env var over config kubeconfig_path

### DIFF
--- a/lib/iris/src/iris/cluster/platform/coreweave.py
+++ b/lib/iris/src/iris/cluster/platform/coreweave.py
@@ -328,7 +328,8 @@ class CoreweavePlatform:
         self._iris_labels = Labels(label_prefix)
         self._kubectl = Kubectl(
             namespace=self._namespace,
-            kubeconfig_path=os.environ.get("KUBECONFIG") or config.kubeconfig_path or None,
+            # Let kubectl handle KUBECONFIG natively; only pass --kubeconfig when no env override is present.
+            kubeconfig_path=None if os.environ.get("KUBECONFIG") else (config.kubeconfig_path or None),
             timeout=_KUBECTL_TIMEOUT,
         )
         self._poll_interval = poll_interval


### PR DESCRIPTION
Fixes #3047

Prefer `KUBECONFIG` env var over `config.kubeconfig_path` when constructing the `Kubectl` client in `CoreweavePlatform`. CI workflows that write a kubeconfig to a runtime path can now set `KUBECONFIG` without needing to modify the checked-in `coreweave.yaml`.