### PR TITLE
Set TPU VMEM defaults for v5e/v5litepod and v6e

### DIFF
--- a/lib/fray/src/fray/v1/cluster/base.py
+++ b/lib/fray/src/fray/v1/cluster/base.py
@@ -319,8 +319,10 @@ class TpuConfig:
 
     def default_env_vars(self) -> dict[str, str]:
         defaults: dict[str, str] = {"JAX_PLATFORMS": ""}
-        if self.variant.startswith(("v5p-", "v6e-")):
+        if self.variant.startswith(("v5litepod-", "v5e-", "v5p-")):
             defaults["LIBTPU_INIT_ARGS"] = "--xla_tpu_scoped_vmem_limit_kib=50000"
+        elif self.variant.startswith("v6e-"):
+            defaults["LIBTPU_INIT_ARGS"] = "--xla_tpu_scoped_vmem_limit_kib=98304"
         return defaults
 
 

--- a/lib/fray/src/fray/v2/types.py
+++ b/lib/fray/src/fray/v2/types.py
@@ -303,8 +303,10 @@ class TpuConfig:
 
     def default_env_vars(self) -> dict[str, str]:
         defaults: dict[str, str] = {"JAX_PLATFORMS": ""}
-        if self.variant.startswith(("v5p-", "v6e-")):
+        if self.variant.startswith(("v5litepod-", "v5e-", "v5p-")):
             defaults["LIBTPU_INIT_ARGS"] = "--xla_tpu_scoped_vmem_limit_kib=50000"
+        elif self.variant.startswith("v6e-"):
+            defaults["LIBTPU_INIT_ARGS"] = "--xla_tpu_scoped_vmem_limit_kib=98304"
         return defaults
 
 

--- a/lib/fray/tests/test_v2_ray.py
+++ b/lib/fray/tests/test_v2_ray.py
@@ -231,7 +231,10 @@ def test_build_runtime_env_tpu_clears_jax_platforms():
     assert env["env_vars"]["JAX_PLATFORMS"] == ""
 
 
-@pytest.mark.parametrize("tpu_type", ["v5p-8", "v6e-8"])
+@pytest.mark.parametrize(
+    "tpu_type",
+    ["v5litepod-8", "v5p-8", "v6e-8"],
+)
 def test_build_runtime_env_tpu_sets_default_libtpu_init_args(tpu_type):
     from fray.v2.ray_backend.backend import build_runtime_env
 


### PR DESCRIPTION
## Summary
- apply default LIBTPU_INIT_ARGS=--xla_tpu_scoped_vmem_limit_kib=50000 to TPU variants v5litepod-*, v5e-*, and v5p-*
- set default LIBTPU_INIT_ARGS=--xla_tpu_scoped_vmem_limit_kib=98304 for TPU variants v6e-*
- expand v2 runtime-env test coverage to include v5litepod-8 and keep asserting LIBTPU_INIT_ARGS is present for v5/v6e TPU launch paths

## Testing
- uv run --package fray pytest lib/fray/tests/test_v2_ray.py -k libtpu_init_args
