### PR TITLE
fix(iris): retry DEADLINE_EXCEEDED in call_with_retry

### DIFF
--- a/lib/iris/src/iris/rpc/errors.py
+++ b/lib/iris/src/iris/rpc/errors.py
@@ -109,13 +109,14 @@ def is_retryable_error(exc: Exception) -> bool:
     Retries on:
     - ConnectError with Code.UNAVAILABLE (controller temporarily down)
     - ConnectError with Code.INTERNAL (network errors bubble up as INTERNAL)
+    - ConnectError with Code.DEADLINE_EXCEEDED (client-side httpx read timeout)
 
     Does not retry on:
     - Application errors (NOT_FOUND, INVALID_ARGUMENT, ALREADY_EXISTS, etc.)
     - These indicate issues with the request itself, not transient failures
     """
     if isinstance(exc, ConnectError):
-        return exc.code in (Code.UNAVAILABLE, Code.INTERNAL)
+        return exc.code in (Code.UNAVAILABLE, Code.INTERNAL, Code.DEADLINE_EXCEEDED)
     return False
 
 


### PR DESCRIPTION
Fixes #3062.

`is_retryable_error()` retries `UNAVAILABLE` and `INTERNAL` but not `DEADLINE_EXCEEDED`. A slow controller response (30s httpx timeout) becomes a non-retryable error — `call_with_retry` gives up immediately, and after 5 consecutive timeouts `wait_for_job_with_streaming` crashes the job monitor.

Hit in production: [CW canary ferry](https://github.com/marin-community/marin/actions/runs/22451321269/job/65020282778).

## Change

Add `Code.DEADLINE_EXCEEDED` to the retryable set in `is_retryable_error()`. Existing retry budgets (5 attempts per RPC + 5 consecutive poll failures) already bound total retry time.

## Testing

- Unit: 2 new tests in `test_errors.py` (12/12 pass)
- Manual: forced `DEADLINE_EXCEEDED` against live CW controller with `timeout_ms=1` — confirmed 5/5 retries
- Post-merge: re-trigger canary ferry workflow

<details><summary>Context</summary>

`DEADLINE_EXCEEDED` always originates from client-side httpx timeouts (confirmed in `connectrpc` source), not server-side rejections — same class of transient failure as `UNAVAILABLE`.

Retry logic was added in #2813 but omitted this code. Broader controller latency tracked in #2809.

</details>