### PR TITLE
feat(iris): add request-level observability to controller RPCs

### DIFF
--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -27,6 +27,7 @@ from iris.cluster.controller.service import ControllerServiceImpl
 from iris.cluster.dashboard_common import html_shell, static_files_mount
 from iris.rpc import cluster_pb2
 from iris.rpc.cluster_connect import ControllerServiceWSGIApplication
+from iris.rpc.interceptors import RequestTimingInterceptor
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +58,7 @@ class ControllerDashboard:
         return self._port
 
     def _create_app(self) -> Starlette:
-        rpc_wsgi_app = ControllerServiceWSGIApplication(service=self._service)
+        rpc_wsgi_app = ControllerServiceWSGIApplication(service=self._service, interceptors=[RequestTimingInterceptor()])
         rpc_app = WSGIMiddleware(rpc_wsgi_app)
 
         routes = [

--- a/lib/iris/src/iris/rpc/interceptors.py
+++ b/lib/iris/src/iris/rpc/interceptors.py
@@ -1,0 +1,29 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+from iris.time_utils import Timer
+
+logger = logging.getLogger(__name__)
+
+_SLOW_RPC_THRESHOLD_MS = 1000
+
+
+class RequestTimingInterceptor:
+    """Logs method name + duration for every unary RPC."""
+
+    def intercept_unary_sync(self, call_next, request, ctx):
+        method = ctx.method().name
+        timer = Timer()
+        try:
+            response = call_next(request, ctx)
+            elapsed = timer.elapsed_ms()
+            if elapsed > _SLOW_RPC_THRESHOLD_MS:
+                logger.warning("RPC %s completed in %dms (slow)", method, elapsed)
+            else:
+                logger.debug("RPC %s completed in %dms", method, elapsed)
+            return response
+        except Exception as e:
+            logger.warning("RPC %s failed after %dms: %s", method, timer.elapsed_ms(), e)
+            raise

--- a/lib/iris/tests/rpc/test_interceptors.py
+++ b/lib/iris/tests/rpc/test_interceptors.py
@@ -1,0 +1,38 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+from unittest.mock import Mock
+
+import pytest
+
+from iris.rpc.interceptors import RequestTimingInterceptor
+
+
+@dataclass(frozen=True)
+class FakeMethodInfo:
+    name: str
+
+
+def _make_ctx(method_name: str):
+    ctx = Mock()
+    ctx.method.return_value = FakeMethodInfo(name=method_name)
+    return ctx
+
+
+def test_interceptor_passes_through_response():
+    interceptor = RequestTimingInterceptor()
+    ctx = _make_ctx("GetTaskLogs")
+    result = interceptor.intercept_unary_sync(lambda req, ctx: "ok", "request", ctx)
+    assert result == "ok"
+
+
+def test_interceptor_reraises_exceptions():
+    interceptor = RequestTimingInterceptor()
+    ctx = _make_ctx("LaunchJob")
+
+    def failing_handler(req, ctx):
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        interceptor.intercept_unary_sync(failing_handler, "request", ctx)


### PR DESCRIPTION
Fixes #3071. Related: #3062 (incident), #3067 (retry fix), #2809 (threading survey), #2964 (lock contention).

## Problem

When the GPU canary ferry hit `DEADLINE_EXCEEDED` (#3062), the controller was alive but we had **no way to tell why `GetTaskLogs` took 30s+**. The retry fix (#3067) treats the symptom. We need observability to find the root cause next time.

Today: zero RPC durations, zero storage latency measurements, zero heartbeat round timings, no periodic health snapshot.

## Changes

Five logging hooks — one new file (`interceptors.py`), edits to three existing files. Logging only, no metrics infra. All thresholds are hardcoded initial guesses.

| # | Change | Key output |
|---|--------|------------|
| 1 | RPC timing interceptor (`UnaryInterceptorSync`) | `WARN RPC GetTaskLogs completed in 31204ms (slow)` |
| 2 | Storage read timing in `get_task_logs` | `WARN Storage read for job/0 attempt 0: 28500ms (slow)` |
| 3 | Heartbeat + scheduling phase-level timing | `DEBUG Heartbeat round: 128 workers, 3 failed, 4200ms (snapshot: 3100ms)` |
| 4 | Periodic health summary (~30s) | `INFO Controller status: 128 workers (2 failed), 2 active jobs, 0 pending` |
| 5 | Uvicorn log level `"error"` → `"warning"` | Surfaces connection warnings from GH Actions |

The snapshot sub-timing in Change 3 disambiguates lock contention from slow RPCs: if `snapshot_ms` dominates the round time, the `ControllerState` RLock is contended. If `elapsed >> snapshot_ms`, slow worker RPCs are the cause.

**Diagnostic trail — slow storage:**
```
INFO  Controller status: 128 workers (0 failed), 2 active jobs, 0 pending tasks
DEBUG Heartbeat round: 128 workers, 3 failed, 4200ms (snapshot: 45ms)
WARN  Storage read for job/0/0 attempt 0: 28500ms (slow)
WARN  RPC GetTaskLogs completed in 31204ms (slow)
```
**Diagnostic trail — lock contention:**
```
WARN  Heartbeat round: 128 workers, 0 failed, 6200ms (snapshot: 5800ms)
WARN  RPC GetTaskLogs completed in 31204ms (slow)
```

<details><summary>Scope boundaries</summary>

- **Logging only** — no Prometheus/OTel. A metrics stack is a separate effort (#2826).
- **Hardcoded thresholds** (RPC: 1s, storage: 2s, heartbeat: 5s) — tunable later once we have baseline data.
- **Phase-level timing as lock-contention proxy** — we time the lock-acquiring phases from outside rather than instrumenting `ControllerState`'s RLock (too invasive, too noisy).
- **`DEBUG` for normal, `WARNING` for slow/errored** — no `INFO`-level RPC logging (too noisy at 128 workers × 1s polling).
- **Not in scope**: performance fixes, K8s CPU allocation ([per @rjpower](https://github.com/marin-community/marin/issues/3071#issuecomment-3969131830)), structured logging format.

</details>

## Test plan

- [x] Unit tests for `RequestTimingInterceptor` (pass-through + re-raise contract)
- [x] Existing controller tests pass (268 tests)
- [ ] Post-merge: verify `DEBUG RPC ...` on dashboard navigation, `DEBUG Heartbeat round:` every ~5s, `INFO Controller status:` every ~30s, no `WARNING` under normal load