### PR TITLE
Improve Fray job name in `remote` & `StepSpec`

### DIFF
--- a/lib/marin/src/marin/execution/remote.py
+++ b/lib/marin/src/marin/execution/remote.py
@@ -17,6 +17,7 @@ Usage::
 
 from __future__ import annotations
 
+import dataclasses
 import re
 import uuid
 from collections.abc import Callable
@@ -53,6 +54,12 @@ class RemoteCallable(Generic[P, R]):
     env_vars: dict[str, str] = field(default_factory=dict)
     pip_dependency_groups: list[str] = field(default_factory=list)
     name: str | None = None
+
+    def named(self, name: str) -> RemoteCallable:
+        """Noop if already has a name. Otherwise use provided name."""
+        if self.name:
+            return self
+        return dataclasses.replace(self, name=name)
 
     # TODO: JobHandle doesn't have this option now, but we could make this return the R
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> None:

--- a/lib/marin/src/marin/execution/step_spec.py
+++ b/lib/marin/src/marin/execution/step_spec.py
@@ -93,10 +93,8 @@ class StepSpec:
         )
 
         if isinstance(self.fn, RemoteCallable):
-            if not self.fn.name:
-                job_name = f"{self.name_with_hash}-{uuid.uuid4().hex[:8]}"
-                wrapped = dataclasses.replace(self.fn, fn=wrapped, name=job_name)
-            else:
-                wrapped = dataclasses.replace(self.fn, fn=wrapped)
+            job_name = f"{self.name_with_hash}-{uuid.uuid4().hex[:8]}"
+            remote_callable = self.fn.named(job_name)
+            wrapped = dataclasses.replace(remote_callable, fn=wrapped)
 
         return wrapped


### PR DESCRIPTION
* follow up to https://github.com/marin-community/marin/pull/3051
* if `name` is specified in `remote` don't change it
* if name is not specified, best effort to get base name + short uuid
  * I don't think arg hashing is worth the complexity + on restart would collide, and if the user wants name lock, they can handle it 
* `StepSpec` uses the name with hash + short uuid

This way:
 * afaiu you can get name "lock" via explicit name 
 * restart of steps should just work 
