### PR TITLE
Add daily workflow to cleanup preempted TPUs

### DIFF
--- a/.github/workflows/marin-cleanup-tpus.yaml
+++ b/.github/workflows/marin-cleanup-tpus.yaml
@@ -29,7 +29,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --all-packages --extra=tpu --no-default-groups
+        run: uv sync --all-packages --no-default-groups
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2


### PR DESCRIPTION
- add a scheduled GitHub Actions workflow to run TPU cleanup daily
- authenticate with existing GCP secrets used by Marin workflows
- run `uv run python scripts/ray/cleanup_workers.py --threshold=0`

Fixes #3070
