### PR TITLE
Iris benchmark: add single-worker burst mode, require explicit subcommand

### DIFF
--- a/lib/iris/tests/e2e/benchmark_controller.py
+++ b/lib/iris/tests/e2e/benchmark_controller.py
@@ -368,9 +368,9 @@ def _make_single_worker_config() -> config_pb2.IrisClusterConfig:
     sg.num_vms = 1
     sg.min_slices = 1
     sg.max_slices = 1
-    sg.resources.cpu_millicores = 8000
-    sg.resources.memory_bytes = 16 * 1024**3
-    sg.resources.disk_bytes = 50 * 1024**3
+    sg.resources.cpu_millicores = 128 * 1000
+    sg.resources.memory_bytes = 256 * 1024**3
+    sg.resources.disk_bytes = 500 * 1024**3
     sg.slice_template.local.SetInParent()
 
     return make_local_config(config)
@@ -485,12 +485,10 @@ def run_single_worker_benchmark(num_jobs: int) -> BenchmarkMetrics:
             controller_client.close()
 
 
-@click.group(invoke_without_command=True)
-@click.pass_context
-def cli(ctx: click.Context) -> None:
+@click.group()
+def cli() -> None:
     """Benchmark Iris controller performance."""
-    if ctx.invoked_subcommand is None:
-        ctx.invoke(benchmark)
+    pass
 
 
 def _run_with_pyspy(
@@ -592,7 +590,7 @@ def _print_profile_table(speedscope_path: Path, top_n: int = 30) -> None:
     default=Path("/tmp/profiles"),
     help="Directory for profile output (default: /tmp/profiles/)",
 )
-def benchmark(
+def multi_tpu(
     num_jobs: int,
     num_slices: int,
     profile: bool = False,
@@ -601,7 +599,7 @@ def benchmark(
     """Run controller benchmark."""
     if profile:
         _run_with_pyspy(
-            "benchmark",
+            "multi_tpu",
             ["--num-jobs", str(num_jobs), "--num-slices", str(num_slices)],
             profile_output,
             "controller_benchmark.speedscope",


### PR DESCRIPTION
Add a single-worker benchmark mode that burst-submits jobs to one CPU worker
while streaming all logs concurrently, exercising the controller RPC hot-path
from #3062.

Also: require an explicit subcommand (benchmark or single-worker) instead of
silently defaulting, rename default command to multi_tpu for clarity, and bump
single-worker resource limits to match realistic node sizes.

Ref #3062