### PR TITLE
fix(iris): reduce controller log verbosity, keep actionable signals

### DIFF
--- a/lib/iris/src/iris/cluster/controller/state.py
+++ b/lib/iris/src/iris/cluster/controller/state.py
@@ -942,12 +942,12 @@ class ControllerState:
 
             self._transactions.append(txn)
 
-            # Log transaction for debugging; demote all heartbeat events to DEBUG
+            # Log transaction summary at INFO (heartbeats at DEBUG), action details always at DEBUG
             if txn.actions:
-                log = logger.debug if isinstance(event, WorkerHeartbeatEvent) else logger.info
-                log(f"Event {type(event).__name__}: {len(txn.actions)} actions")
+                summary_log = logger.debug if isinstance(event, WorkerHeartbeatEvent) else logger.info
+                summary_log(f"Event {type(event).__name__}: {len(txn.actions)} actions")
                 for action in txn.actions:
-                    log(f"  - {action.action} {action.entity_id} {action.details}")
+                    logger.debug(f"  - {action.action} {action.entity_id} {action.details}")
 
             return txn
 
@@ -1285,7 +1285,7 @@ class ControllerState:
                 is_finished,
             )
         else:
-            logger.info(
+            logger.debug(
                 "Task %s state changed: %s -> %s attempt=%d "
                 "failure_count=%d/%d preemption_count=%d/%d result=%s is_finished=%s",
                 event.task_id,


### PR DESCRIPTION
Closes #3081. Related: #3073, [#3062 investigation](https://github.com/marin-community/marin/issues/3062#issuecomment-3969700620).

## Summary

Demote three noise sources in controller logs to DEBUG. No information is deleted — ~620 noise lines per job cycle become ~82 actionable lines.

| # | Change | Lines cut |
|---|--------|---:|
| 1 | Transaction action details → `logger.debug` (summary stays INFO) | ~125/job |
| 2 | Routine task state changes → `logger.debug` (WARNING for failures/retries untouched) | ~375/job |
| 3 | Per-worker heartbeat errors → DEBUG, append `failed=[ip1, ip2]` to round summary | ~120/12min |

Unchanged: WARNING for exhausted retries, worker evictions, slow RPCs, heartbeat round timing, health summaries.

## Test plan

- [x] `pytest lib/iris/tests/cluster/controller/` — 269 passed
- [x] Pre-commit clean
- [ ] Post-merge: trigger CW canary ferry, verify `kci logs -n iris deployment/iris-controller --tail=200` shows actionable lines without scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)