### PR TITLE
chore: disable daily CW canary ferry schedule

### DIFF
--- a/.github/workflows/marin-canary-ferry-cw.yaml
+++ b/.github/workflows/marin-canary-ferry-cw.yaml
@@ -1,8 +1,8 @@
 name: Marin - CoreWeave GPU Canary Ferry
 
 on:
-  schedule:
-    - cron: '0 10 * * *'  # Daily at 10 AM UTC
+  # schedule:
+  #   - cron: '0 10 * * *'  # Daily at 10 AM UTC — disabled until worker overwhelm is fixed (#3062)
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Disable the daily 10 AM UTC cron trigger for the CW GPU canary ferry
- Manual trigger via `workflow_dispatch` still works

The ferry currently spawns 125+ task pods simultaneously, overwhelming the worker and causing an infinite eviction/retry loop ([#3062 investigation](https://github.com/marin-community/marin/issues/3062#issuecomment-3969700620)). Until that's fixed, the daily run wastes CW bare-metal resources (~30 min of H100 + CPU nodes per failed attempt).

## Test plan
- [x] Verify `workflow_dispatch` trigger remains available

🤖 Generated with [Claude Code](https://claude.com/claude-code)