### PR TITLE
WIP: fix(iris): keep tasks in BUILDING until K8S pod reaches Running phase

### DIFF
--- a/lib/iris/docs/coreweave.md
+++ b/lib/iris/docs/coreweave.md
@@ -183,7 +183,7 @@ in `CoreweavePlatform`):
 | `compute.coreweave.com` | `nodepools` | get, list, watch, create, update, patch, delete |
 | core (`""`) | `pods`, `pods/exec`, `pods/log` | get, list, watch, create, update, patch, delete |
 | core (`""`) | `nodes` | get, list, watch |
-| core (`""`) | `configmaps` | get |
+| core (`""`) | `configmaps` | get, list, watch, create, update, patch, delete |
 
 ## 6. Configuration Reference
 

--- a/lib/iris/src/iris/cli/main.py
+++ b/lib/iris/src/iris/cli/main.py
@@ -65,6 +65,7 @@ def require_controller_url(ctx: click.Context) -> str:
 
         iris_config = IrisConfig(config)
         platform = iris_config.platform()
+        ctx.obj["platform"] = platform
 
         if iris_config.proto.controller.WhichOneof("controller") == "local":
             from iris.cluster.controller.local import LocalController

--- a/lib/iris/src/iris/cluster/platform/coreweave.py
+++ b/lib/iris/src/iris/cluster/platform/coreweave.py
@@ -1270,6 +1270,36 @@ class CoreweavePlatform:
     # a couple of attempts in case the first crash was transient.
     _CRASH_LOOP_MIN_RESTARTS = 2
 
+    def controller_post_mortem(self) -> None:
+        """Log controller pod termination reason and previous container logs."""
+        pods = self._kubectl.list_json("pods", labels={"app": "iris-controller"})
+        if not pods:
+            logger.warning("Post-mortem: no controller pods found")
+            return
+
+        for pod in pods:
+            name = pod.get("metadata", {}).get("name", "unknown")
+            phase = pod.get("status", {}).get("phase", "Unknown")
+
+            for cs in pod.get("status", {}).get("containerStatuses", []):
+                restarts = cs.get("restartCount", 0)
+                terminated = cs.get("lastState", {}).get("terminated", {})
+                if terminated:
+                    logger.warning(
+                        "Post-mortem %s: phase=%s reason=%s exitCode=%s restarts=%d",
+                        name,
+                        phase,
+                        terminated.get("reason"),
+                        terminated.get("exitCode"),
+                        restarts,
+                    )
+                else:
+                    logger.warning("Post-mortem %s: phase=%s restarts=%d", name, phase, restarts)
+
+            prev_logs = self._kubectl.logs(name, tail=50, previous=True)
+            if prev_logs:
+                logger.warning("Post-mortem %s previous logs:\n%s", name, prev_logs)
+
     def _check_controller_pods_health(self) -> None:
         """Check controller Pods for fatal conditions and fail fast.
 

--- a/lib/iris/src/iris/cluster/platform/coreweave.py
+++ b/lib/iris/src/iris/cluster/platform/coreweave.py
@@ -389,7 +389,7 @@ class CoreweavePlatform:
                 {
                     "apiGroups": [""],
                     "resources": ["configmaps"],
-                    "verbs": ["get"],
+                    "verbs": ["get", "list", "watch", "create", "update", "patch", "delete"],
                 },
             ],
         }

--- a/lib/iris/src/iris/cluster/runtime/__init__.py
+++ b/lib/iris/src/iris/cluster/runtime/__init__.py
@@ -15,6 +15,7 @@ from iris.cluster.runtime.kubernetes import KubernetesRuntime
 from iris.cluster.runtime.types import (
     ContainerConfig,
     ContainerHandle,
+    ContainerPhase,
     ContainerResult,
     ContainerRuntime,
     ContainerStats,
@@ -26,6 +27,7 @@ from iris.cluster.runtime.types import (
 __all__ = [
     "ContainerConfig",
     "ContainerHandle",
+    "ContainerPhase",
     "ContainerResult",
     "ContainerRuntime",
     "ContainerStats",

--- a/lib/iris/src/iris/cluster/runtime/kubernetes.py
+++ b/lib/iris/src/iris/cluster/runtime/kubernetes.py
@@ -350,7 +350,7 @@ class KubernetesContainerHandle:
                     self._pod_not_found_count,
                     _POD_NOT_FOUND_RETRY_COUNT,
                 )
-                return ContainerStatus(running=True)
+                return ContainerStatus(running=True, ready=False)
 
             attempt = self.config.attempt_id if self.config.attempt_id is not None else -1
             return ContainerStatus(
@@ -369,8 +369,10 @@ class KubernetesContainerHandle:
         self._pod_not_found_deadline = None
 
         phase = pod.get("status", {}).get("phase", "")
-        if phase in ("Pending", "Running"):
-            return ContainerStatus(running=True)
+        if phase == "Pending":
+            return ContainerStatus(running=True, ready=False)
+        if phase == "Running":
+            return ContainerStatus(running=True, ready=True)
 
         statuses = pod.get("status", {}).get("containerStatuses", [])
         terminated = {}

--- a/lib/iris/src/iris/cluster/runtime/process.py
+++ b/lib/iris/src/iris/cluster/runtime/process.py
@@ -42,7 +42,7 @@ from iris.cluster.runtime.profile import (
     resolve_cpu_spec,
     resolve_memory_spec,
 )
-from iris.cluster.runtime.types import ContainerConfig, ContainerStats, ContainerStatus, RuntimeLogReader
+from iris.cluster.runtime.types import ContainerConfig, ContainerPhase, ContainerStats, ContainerStatus, RuntimeLogReader
 from iris.cluster.worker.worker_types import LogLine
 from iris.managed_thread import ManagedThread, get_thread_container
 from iris.rpc import cluster_pb2
@@ -515,9 +515,9 @@ class ProcessContainerHandle:
     def status(self) -> ContainerStatus:
         """Check container status (running, exit code, error)."""
         if not self._container:
-            return ContainerStatus(running=False, error="Container not started")
+            return ContainerStatus(phase=ContainerPhase.STOPPED, error="Container not started")
         return ContainerStatus(
-            running=self._container._running,
+            phase=ContainerPhase.RUNNING if self._container._running else ContainerPhase.STOPPED,
             exit_code=self._container._exit_code,
             error=self._container._error,
         )

--- a/lib/iris/src/iris/cluster/runtime/types.py
+++ b/lib/iris/src/iris/cluster/runtime/types.py
@@ -92,6 +92,7 @@ class ContainerStatus:
     """Container state from runtime inspection."""
 
     running: bool
+    ready: bool = True
     exit_code: int | None = None
     error: str | None = None
     error_kind: ContainerErrorKind = ContainerErrorKind.NONE

--- a/lib/iris/src/iris/cluster/runtime/types.py
+++ b/lib/iris/src/iris/cluster/runtime/types.py
@@ -35,6 +35,19 @@ class ContainerErrorKind(StrEnum):
     RUNTIME_ERROR = "runtime_error"
 
 
+class ContainerPhase(StrEnum):
+    """Lifecycle phase of a container from the runtime's perspective.
+
+    PENDING: container created but not yet executing (K8s pod scheduling, image pull).
+    RUNNING: container is executing the main command.
+    STOPPED: container has exited (check exit_code/error for details).
+    """
+
+    PENDING = "pending"
+    RUNNING = "running"
+    STOPPED = "stopped"
+
+
 @dataclass
 class ContainerConfig:
     """Configuration for running a container."""
@@ -91,8 +104,7 @@ class ContainerStats:
 class ContainerStatus:
     """Container state from runtime inspection."""
 
-    running: bool
-    ready: bool = True
+    phase: ContainerPhase
     exit_code: int | None = None
     error: str | None = None
     error_kind: ContainerErrorKind = ContainerErrorKind.NONE

--- a/lib/iris/src/iris/cluster/worker/task_attempt.py
+++ b/lib/iris/src/iris/cluster/worker/task_attempt.py
@@ -22,6 +22,7 @@ from iris.cluster.runtime.types import (
     ContainerConfig,
     ContainerErrorKind,
     ContainerHandle,
+    ContainerPhase,
     ContainerRuntime,
     RuntimeLogReader,
 )
@@ -620,13 +621,13 @@ class TaskAttempt:
             # Check container status
             status = handle.status()
 
-            if self.status == cluster_pb2.TASK_STATE_BUILDING and status.running and status.ready:
+            if self.status == cluster_pb2.TASK_STATE_BUILDING and status.phase == ContainerPhase.RUNNING:
                 building_duration = time.monotonic() - self._building_start_monotonic
                 logger.info("Task %s BUILDING→RUNNING after %.1fs", self.task_id, building_duration)
                 self.transition_to(cluster_pb2.TASK_STATE_RUNNING)
                 self._report_state()
 
-            if not status.running:
+            if status.phase == ContainerPhase.STOPPED:
                 logger.info(
                     "Container exited for task %s (container_id=%s, exit_code=%s, error=%s)",
                     self.task_id,

--- a/lib/iris/src/iris/cluster/worker/task_attempt.py
+++ b/lib/iris/src/iris/cluster/worker/task_attempt.py
@@ -620,7 +620,7 @@ class TaskAttempt:
             # Check container status
             status = handle.status()
 
-            if self.status == cluster_pb2.TASK_STATE_BUILDING and status.ready:
+            if self.status == cluster_pb2.TASK_STATE_BUILDING and status.running and status.ready:
                 building_duration = time.monotonic() - self._building_start_monotonic
                 logger.info("Task %s BUILDING→RUNNING after %.1fs", self.task_id, building_duration)
                 self.transition_to(cluster_pb2.TASK_STATE_RUNNING)

--- a/lib/iris/src/iris/cluster/worker/task_attempt.py
+++ b/lib/iris/src/iris/cluster/worker/task_attempt.py
@@ -432,6 +432,7 @@ class TaskAttempt:
         """
         self.transition_to(cluster_pb2.TASK_STATE_BUILDING, message="downloading bundle")
         self.started_at = Timestamp.now()
+        self._building_start_monotonic = time.monotonic()
         self._report_state()  # Report BUILDING state to controller
 
         download_start = time.monotonic()
@@ -561,14 +562,8 @@ class TaskAttempt:
             logger.info("Build phase completed for task %s", self.task_id)
 
     def _run_container(self) -> None:
-        """Start the main command during RUNNING state.
-
-        Non-blocking - returns immediately after starting.
-        """
+        """Start the container. Task stays in BUILDING until _monitor() confirms readiness."""
         assert self._container_handle is not None
-
-        self.transition_to(cluster_pb2.TASK_STATE_RUNNING)
-        self._report_state()
 
         self._container_handle.run()
         logger.info(
@@ -624,6 +619,13 @@ class TaskAttempt:
 
             # Check container status
             status = handle.status()
+
+            if self.status == cluster_pb2.TASK_STATE_BUILDING and status.ready:
+                building_duration = time.monotonic() - self._building_start_monotonic
+                logger.info("Task %s BUILDING→RUNNING after %.1fs", self.task_id, building_duration)
+                self.transition_to(cluster_pb2.TASK_STATE_RUNNING)
+                self._report_state()
+
             if not status.running:
                 logger.info(
                     "Container exited for task %s (container_id=%s, exit_code=%s, error=%s)",

--- a/lib/iris/tests/cluster/worker/test_dashboard.py
+++ b/lib/iris/tests/cluster/worker/test_dashboard.py
@@ -15,7 +15,7 @@ from iris.time_utils import Duration
 from iris.cluster.worker.bundle_cache import BundleCache
 from iris.cluster.worker.dashboard import WorkerDashboard
 from iris.cluster.runtime.docker import DockerRuntime
-from iris.cluster.runtime.types import ContainerStats, ContainerStatus
+from iris.cluster.runtime.types import ContainerPhase, ContainerStats, ContainerStatus
 from iris.cluster.worker.service import WorkerServiceImpl
 from iris.cluster.worker.worker import Worker, WorkerConfig
 from iris.rpc import cluster_pb2
@@ -48,7 +48,7 @@ def create_mock_container_handle():
     handle.container_id = "container123"
     handle.build = Mock(return_value=[])
     handle.run = Mock()
-    handle.status = Mock(return_value=ContainerStatus(running=False, exit_code=0))
+    handle.status = Mock(return_value=ContainerStatus(phase=ContainerPhase.STOPPED, exit_code=0))
     handle.stop = Mock()
     handle.logs = Mock(return_value=[])
     handle.stats = Mock(return_value=ContainerStats(memory_mb=100, cpu_percent=50, process_count=1, available=True))

--- a/lib/iris/tests/cluster/worker/test_task_attempt.py
+++ b/lib/iris/tests/cluster/worker/test_task_attempt.py
@@ -1,0 +1,152 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for TaskAttempt._monitor() BUILDING→RUNNING transition."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from iris.cluster.runtime.types import ContainerStats, ContainerStatus
+from iris.cluster.types import Entrypoint, JobName
+from iris.cluster.worker.port_allocator import PortAllocator
+from iris.cluster.worker.task_attempt import TaskAttempt, TaskAttemptConfig
+from iris.rpc import cluster_pb2
+
+
+def _make_request():
+    def noop():
+        pass
+
+    ep = Entrypoint.from_callable(noop).to_proto()
+    return cluster_pb2.Worker.RunTaskRequest(
+        task_id=JobName.root("test").task(0).to_wire(),
+        num_tasks=1,
+        attempt_id=0,
+        entrypoint=ep,
+        bundle_gcs_path="gs://test/bundle",
+    )
+
+
+def _make_mock_handle(status_sequence):
+    """Create a mock ContainerHandle with a scripted status() sequence."""
+    handle = Mock()
+    handle.container_id = "test-container"
+    handle.build = Mock(return_value=[])
+    handle.run = Mock()
+    handle.stop = Mock()
+    handle.cleanup = Mock()
+
+    call_count = [0]
+
+    def status_fn():
+        idx = min(call_count[0], len(status_sequence) - 1)
+        call_count[0] += 1
+        return status_sequence[idx]
+
+    handle.status = Mock(side_effect=status_fn)
+
+    log_reader = Mock()
+    log_reader.read = Mock(return_value=[])
+    log_reader.read_all = Mock(return_value=[])
+    handle.log_reader = Mock(return_value=log_reader)
+    handle.stats = Mock(return_value=ContainerStats(memory_mb=0, cpu_percent=0, process_count=0, available=False))
+
+    return handle
+
+
+def _make_task(tmp_path, mock_handle, *, task_ref=None):
+    """Construct a TaskAttempt wired to a mock handle.
+
+    If task_ref (a one-element list) is provided, the status() side-effect
+    is wrapped to record task.status at each poll for later assertion.
+    """
+    states_during_polls: list[int] = []
+
+    if task_ref is not None:
+        original_side_effect = mock_handle.status.side_effect
+
+        def capturing_status():
+            if task_ref[0] is not None:
+                states_during_polls.append(task_ref[0].status)
+            return original_side_effect()
+
+        mock_handle.status = Mock(side_effect=capturing_status)
+
+    mock_runtime = Mock()
+    mock_runtime.create_container = Mock(return_value=mock_handle)
+    mock_runtime.stage_bundle = Mock()
+
+    mock_log_sink = Mock()
+    mock_log_sink.log_path = str(tmp_path / "logs")
+
+    workdir = tmp_path / "workdir"
+    workdir.mkdir(exist_ok=True)
+
+    config = TaskAttemptConfig(
+        task_id=JobName.root("test").task(0),
+        num_tasks=1,
+        attempt_id=0,
+        request=_make_request(),
+        ports={},
+        workdir=workdir,
+        cache_dir=tmp_path / "cache",
+    )
+
+    task = TaskAttempt(
+        config=config,
+        bundle_provider=Mock(),
+        container_runtime=mock_runtime,
+        worker_metadata=cluster_pb2.WorkerMetadata(),
+        worker_id="test-worker",
+        controller_address=None,
+        default_task_env={},
+        default_task_image="test-image",
+        resolve_image=lambda x: x,
+        port_allocator=PortAllocator(port_range=(40000, 40100)),
+        report_state=lambda: None,
+        log_sink=mock_log_sink,
+        poll_interval_seconds=0.001,
+    )
+
+    if task_ref is not None:
+        task_ref[0] = task
+
+    return task, states_during_polls
+
+
+@pytest.mark.parametrize("pending_polls", [0, 3], ids=["immediate_ready", "deferred_ready"])
+def test_monitor_defers_running_until_container_ready(tmp_path, pending_polls):
+    """_monitor() keeps the task in BUILDING until the container reports ready=True.
+
+    pending_polls=0 simulates process/docker runtime (ready from the start).
+    pending_polls=3 simulates K8S where the pod spends time in Pending phase.
+
+    We capture task.status at each handle.status() call (before the monitor
+    processes the result), then verify BUILDING is held during ready=False
+    polls and RUNNING appears only after the first ready=True poll.
+    """
+    status_seq = (
+        [ContainerStatus(running=True, ready=False)] * pending_polls
+        + [ContainerStatus(running=True, ready=True)]
+        + [ContainerStatus(running=False, exit_code=0)]
+    )
+
+    task_ref = [None]
+    mock_handle = _make_mock_handle(status_seq)
+    task, states = _make_task(tmp_path, mock_handle, task_ref=task_ref)
+
+    task.run()
+
+    assert task.status == cluster_pb2.TASK_STATE_SUCCEEDED
+    assert task.exit_code == 0
+
+    # During ready=False polls AND the ready=True poll (captured before
+    # transition_to runs), the task must still be in BUILDING.
+    for i in range(pending_polls + 1):
+        assert (
+            states[i] == cluster_pb2.TASK_STATE_BUILDING
+        ), f"Poll {i}: expected BUILDING, got {cluster_pb2.TaskState.Name(states[i])}"
+
+    # On the next poll (running=False), the transition to RUNNING has fired.
+    assert states[pending_polls + 1] == cluster_pb2.TASK_STATE_RUNNING

--- a/lib/iris/tests/cluster/worker/test_task_attempt.py
+++ b/lib/iris/tests/cluster/worker/test_task_attempt.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from iris.cluster.runtime.types import ContainerStats, ContainerStatus
+from iris.cluster.runtime.types import ContainerPhase, ContainerStats, ContainerStatus
 from iris.cluster.types import Entrypoint, JobName
 from iris.cluster.worker.port_allocator import PortAllocator
 from iris.cluster.worker.task_attempt import TaskAttempt, TaskAttemptConfig
@@ -127,9 +127,9 @@ def test_monitor_defers_running_until_container_ready(tmp_path, pending_polls):
     polls and RUNNING appears only after the first ready=True poll.
     """
     status_seq = (
-        [ContainerStatus(running=True, ready=False)] * pending_polls
-        + [ContainerStatus(running=True, ready=True)]
-        + [ContainerStatus(running=False, exit_code=0)]
+        [ContainerStatus(phase=ContainerPhase.PENDING)] * pending_polls
+        + [ContainerStatus(phase=ContainerPhase.RUNNING)]
+        + [ContainerStatus(phase=ContainerPhase.STOPPED, exit_code=0)]
     )
 
     task_ref = [None]

--- a/lib/iris/tests/e2e/test_building_backpressure.py
+++ b/lib/iris/tests/e2e/test_building_backpressure.py
@@ -1,0 +1,120 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backpressure test: slow-starting containers must not exceed max_building_tasks_per_worker."""
+
+import time
+from pathlib import Path
+
+import pytest
+from iris.client.client import IrisClient
+from iris.cluster.config import load_config, make_local_config
+from iris.cluster.manager import connect_cluster
+from iris.cluster.runtime.process import ProcessContainerHandle
+from iris.cluster.runtime.types import ContainerStatus
+from iris.rpc import cluster_pb2, config_pb2
+from iris.rpc.cluster_connect import ControllerServiceClientSync
+
+from .conftest import TestCluster
+from .helpers import _quick
+
+pytestmark = pytest.mark.e2e
+
+IRIS_ROOT = Path(__file__).resolve().parents[2]
+READY_DELAY = 3.0
+NUM_TASKS = 20
+MAX_BUILDING = 4  # default max_building_tasks_per_worker
+
+
+@pytest.fixture
+def single_worker_cluster():
+    """Single-worker cluster so building backpressure is observable."""
+    config = load_config(IRIS_ROOT / "examples" / "demo.yaml")
+    config.scale_groups.clear()
+    sg = config.scale_groups["local-cpu"]
+    sg.name = "local-cpu"
+    sg.accelerator_type = config_pb2.ACCELERATOR_TYPE_CPU
+    sg.num_vms = 1
+    sg.min_slices = 1
+    sg.max_slices = 1
+    sg.resources.cpu_millicores = 8000
+    sg.resources.memory_bytes = 16 * 1024**3
+    sg.resources.disk_bytes = 50 * 1024**3
+    sg.slice_template.local.SetInParent()
+    config = make_local_config(config)
+    with connect_cluster(config) as url:
+        client = IrisClient.remote(url, workspace=IRIS_ROOT)
+        controller_client = ControllerServiceClientSync(address=url, timeout_ms=30000)
+        tc = TestCluster(url=url, client=client, controller_client=controller_client)
+        tc.wait_for_workers(1, timeout=30)
+        yield tc
+        controller_client.close()
+
+
+def test_building_backpressure_with_slow_starting_containers(single_worker_cluster, monkeypatch):
+    """With slow-starting containers, at most max_building_tasks_per_worker tasks
+    should be in BUILDING/ASSIGNED at any time.
+
+    Monkeypatches ProcessContainerHandle.status() to return ready=False for
+    READY_DELAY seconds after run(), simulating K8S pod pending phase.
+    """
+    cluster = single_worker_cluster
+    original_run = ProcessContainerHandle.run
+    original_status = ProcessContainerHandle.status
+    run_times: dict[int, float] = {}
+
+    def patched_run(self):
+        run_times[id(self)] = time.monotonic()
+        return original_run(self)
+
+    def patched_status(self) -> ContainerStatus:
+        result = original_status(self)
+        run_time = run_times.get(id(self))
+        if run_time is not None and result.running:
+            elapsed = time.monotonic() - run_time
+            if elapsed < READY_DELAY:
+                result = ContainerStatus(
+                    running=result.running,
+                    ready=False,
+                    exit_code=result.exit_code,
+                    error=result.error,
+                    error_kind=result.error_kind,
+                    oom_killed=result.oom_killed,
+                )
+        return result
+
+    monkeypatch.setattr(ProcessContainerHandle, "run", patched_run)
+    monkeypatch.setattr(ProcessContainerHandle, "status", patched_status)
+
+    jobs = [cluster.submit(_quick, f"burst-{i}", cpu=0) for i in range(NUM_TASKS)]
+
+    peak_building = 0
+    all_done = False
+    deadline = time.monotonic() + 120
+
+    while not all_done and time.monotonic() < deadline:
+        building_count = 0
+        all_done = True
+        for job in jobs:
+            status = cluster.status(job)
+            for task in status.tasks:
+                if task.state in (cluster_pb2.TASK_STATE_BUILDING, cluster_pb2.TASK_STATE_ASSIGNED):
+                    building_count += 1
+            if not status.state or status.state in (
+                cluster_pb2.JOB_STATE_PENDING,
+                cluster_pb2.JOB_STATE_RUNNING,
+            ):
+                all_done = False
+
+        peak_building = max(peak_building, building_count)
+        time.sleep(0.3)
+
+    # Allow +1 slack for race between scheduling and heartbeat reporting
+    assert peak_building <= MAX_BUILDING + 1, (
+        f"Peak building count {peak_building} exceeded limit {MAX_BUILDING}. " f"Backpressure is not working."
+    )
+
+    # All jobs should eventually succeed
+    for job in jobs:
+        status = cluster.wait(job, timeout=120)
+        assert status.state == cluster_pb2.JOB_STATE_SUCCEEDED

--- a/lib/iris/tests/e2e/test_building_backpressure.py
+++ b/lib/iris/tests/e2e/test_building_backpressure.py
@@ -11,7 +11,7 @@ from iris.client.client import IrisClient
 from iris.cluster.config import load_config, make_local_config
 from iris.cluster.manager import connect_cluster
 from iris.cluster.runtime.process import ProcessContainerHandle
-from iris.cluster.runtime.types import ContainerStatus
+from iris.cluster.runtime.types import ContainerPhase, ContainerStatus
 from iris.rpc import cluster_pb2, config_pb2
 from iris.rpc.cluster_connect import ControllerServiceClientSync
 
@@ -70,12 +70,11 @@ def test_building_backpressure_with_slow_starting_containers(single_worker_clust
     def patched_status(self) -> ContainerStatus:
         result = original_status(self)
         run_time = run_times.get(id(self))
-        if run_time is not None and result.running:
+        if run_time is not None and result.phase == ContainerPhase.RUNNING:
             elapsed = time.monotonic() - run_time
             if elapsed < READY_DELAY:
                 result = ContainerStatus(
-                    running=result.running,
-                    ready=False,
+                    phase=ContainerPhase.PENDING,
                     exit_code=result.exit_code,
                     error=result.error,
                     error_kind=result.error_kind,


### PR DESCRIPTION
## Problem

On K8S, the `max_building_tasks_per_worker=4` backpressure is useless. Each task spends ~milliseconds in BUILDING because both [`build()`](https://github.com/marin-community/marin/blob/e7c1e953b/lib/iris/src/iris/cluster/runtime/kubernetes.py#L180-L185) and [`stage_bundle()`](https://github.com/marin-community/marin/blob/e7c1e953b/lib/iris/src/iris/cluster/runtime/kubernetes.py#L533-L542) are no-ops, and [`_run_container()`](https://github.com/marin-community/marin/blob/e7c1e953b/lib/iris/src/iris/cluster/worker/task_attempt.py#L570) transitions to RUNNING before `kubectl apply` even runs. Result: 125 tasks → 31 rapid-fire batches of 4 → pod creation storm → worker overwhelm ([#3062](https://github.com/marin-community/marin/issues/3062)).[^1]

[^1]: The causal chain (ineffective backpressure → pod storm) is from code analysis, not production telemetry. The [#3062 investigation](https://github.com/marin-community/marin/issues/3062#issuecomment-3969700620) confirmed the worker was overwhelmed by 125+ pods and that lock contention was not the bottleneck, but BUILDING duration wasn't measured. rjpower [could not reproduce](https://github.com/marin-community/marin/pull/3084) the full controller wipe-out and noted it could also be networking or CPU starvation. The burst test validates this hypothesis pre-merge; change D adds a BUILDING duration log so the first CW deployment confirms it from production logs.

Short-term fix toward [#2944](https://github.com/marin-community/marin/issues/2944). All code touched here is in the layer #2944 would replace.

## Solution

Keep tasks in **BUILDING** until the K8S Pod actually reaches the `Running` phase. Four changes across 3 files:

| # | File | Change |
|---|------|--------|
| A | `runtime/types.py` | Add `ready: bool = True` to `ContainerStatus` (default preserves process/docker behavior) |
| B | `runtime/kubernetes.py` | `Pending` and transient pod-not-found → `ready=False`. `Running` → `ready=True`. |
| C | `worker/task_attempt.py:563` | Remove `transition_to(RUNNING)` from `_run_container()` |
| D | `worker/task_attempt.py:600` | In `_monitor()` poll loop: transition to RUNNING when `status.ready` is True. Log BUILDING duration. |

> **Review question — naming**: `ready` could be confused with K8S readiness probes (different concept). Alternative: `started`. Preference?

<details>
<summary>Detailed diffs and rationale for A–D</summary>

**A. `ContainerStatus.ready`** — `True` by default so process/docker are unaffected (a running process is by definition ready). Only `KubernetesContainerHandle.status()` sets it to `False` while the pod hasn't reached `Running` phase.

**B. `KubernetesContainerHandle.status()`** — Three return paths need `ready=False`:

```python
# Transient pod-not-found (line 353): K8S API hasn't indexed the pod yet.
# Without this, the first poll after kubectl apply can transition to RUNNING
# immediately, defeating the entire fix.
return ContainerStatus(running=True, ready=False)

# ...

# Pod found, phase handling (lines 371-373):
if phase == "Pending":
    return ContainerStatus(running=True, ready=False)
if phase == "Running":
    return ContainerStatus(running=True, ready=True)
```

`running=True` preserved for both `Pending` and transient-not-found so the monitor doesn't interpret them as container termination.

**C. `_run_container()`** — Becomes just `self._container_handle.run()`. No state transition, no report. Task stays in BUILDING after pod creation.

**D. `_monitor()` poll loop** — New check before the existing `if not status.running` block:
```python
if self.status == cluster_pb2.TASK_STATE_BUILDING and status.ready:
    building_duration = time.monotonic() - self._building_start_monotonic
    logger.info("Task %s BUILDING→RUNNING after %.1fs", self.task_id, building_duration)
    self.transition_to(cluster_pb2.TASK_STATE_RUNNING)
    self._report_state()
```
For process/docker: `ready` is always `True` → fires on first poll iteration, before any sleep (equivalent to current behavior).
For K8S: deferred until pod reaches `Running` phase → task holds its building slot.

The BUILDING duration log directly validates the hypothesis in [^1]: on K8S before this fix it would show ~milliseconds; after, it shows the actual pod scheduling time.


</details>

<details>
<summary>Assumptions</summary>

1. **"Ready" = K8S `Running` phase.** Not a readiness probe or output check — `Running` means the container entrypoint has started.
2. **Process runtime path is unchanged.** `ready` defaults to `True`, so the RUNNING transition fires on the first monitor poll iteration (before any sleep) — equivalent to the current immediate transition in `_run_container()`.
3. **Polling is sufficient.** The monitor loop already polls `status()`; no need for K8S watches.

</details>

<details>
<summary>Alternatives considered</summary>

- **Rate-limit dispatch (1 task/s):** Time-based, not capacity-based. Doesn't cap steady-state. The "right" rate is unknowable.
- **Block in `KubernetesRuntime.run()`:** Prevents cancellation and log streaming during startup. Violates the non-blocking `run()` contract.
- **New `wait_until_ready()` protocol method:** Adds API surface only one runtime needs. `ready` field achieves the same thing.

</details>

<details>
<summary>Non-goals / future work</summary>

- Changing `max_building_tasks_per_worker` default (4 is fine; the problem was tasks not staying in BUILDING).
- Total concurrent-tasks-per-worker cap (separate concern).
- Controller CPU reservation / Guaranteed QoS (orthogonal, separate PR).
- [#2944](https://github.com/marin-community/marin/issues/2944): Provider abstraction (long-term replacement for this code path).

</details>

## Testing

**Integration** — E2E burst test: 1 worker, 20 tasks, monkeypatch `ProcessContainerHandle.status()` to return `ready=False` for 3s (simulating K8S `Pending` phase). Poll building counts throughout. **Assert: peak building count ≤ 4.** Validates the mechanism (scheduler actually throttles when BUILDING is slow), not the diagnosis.

**Regression** — `uv run pytest lib/iris/tests/e2e/test_task_lifecycle.py -x` locally, then CI via `iris-unit-tests` workflow (triggers automatically on PR, runs full suite excluding `slow`/`docker`)

**Pre-merge validation (validates the diagnosis)** — Trigger [`marin-canary-ferry-cw`](https://github.com/marin-community/marin/actions/workflows/marin-canary-ferry-cw.yaml) workflow via `workflow_dispatch` on the PR branch. This runs the actual CW canary workload (the one that triggered #3062). Change D's BUILDING duration log is the key signal: seconds/minutes confirms the fix is effective; ~milliseconds would mean the hypothesis is wrong.

<details>
<summary>Unit tests (mechanical correctness)</summary>

- `test_kubernetes_runtime.py`: one test mocking kubectl `Pending` → `Running`, asserting `ready=False` → `ready=True`. Extend existing `test_status_retries_transient_pod_not_found` to assert `ready=False` during transient window.
- `test_task_attempt.py`: one parametrized test (`pending_polls ∈ {0, 3}`) validating `_monitor()` defers RUNNING until `ready=True`.

</details>