### PR TITLE
Change RayConfig default to not auto-start cluster

### DIFF
--- a/lib/levanter/docs/reference/Configuration.md
+++ b/lib/levanter/docs/reference/Configuration.md
@@ -283,16 +283,16 @@ trainer:
 
 ## Ray Config
 
-Levanter will by default automatically start a Ray cluster with all
-the machines being used for training. This is useful for distributed
-preprocessing. You can disable this behavior using `auto_start_cluster: false`.
+Levanter does not automatically start a Ray cluster by default. You can enable
+this behavior using `auto_start_cluster: true`, which will start a Ray cluster
+with all the machines being used for training for distributed preprocessing.
 
 
 | Parameter            | Description                                                             | Default |
 |----------------------|-------------------------------------------------------------------------|---------|
 | `address`            | The address of the Ray cluster to connect to.                           | `None`  |
 | `start_workers`      | Whether to start Ray workers. If `False`, you must start them yourself. | `True`  |
-| `auto_start_cluster` | Whether to start a Ray cluster automatically.                           | `True`  |
+| `auto_start_cluster` | Whether to start a Ray cluster automatically.                           | `False` |
 
 
 ## Distributed Config

--- a/lib/levanter/src/levanter/distributed.py
+++ b/lib/levanter/src/levanter/distributed.py
@@ -391,7 +391,7 @@ class DistributedConfig:
 class RayConfig:
     address: Optional[str] = None
     start_workers: bool = True
-    auto_start_cluster: bool = True
+    auto_start_cluster: bool = False
 
     def initialize(self):
         if self.auto_start_cluster:


### PR DESCRIPTION
Change `auto_start_cluster` default from `True` to `False` in levanter's `RayConfig`. Updated documentation to reflect the new default.

Closes #3099

Generated with [Claude Code](https://claude.ai/code)