### PR TITLE
fix(iris): CW RBAC and controller scheduling fixes (#3091, #3102)

### DIFF
--- a/lib/iris/src/iris/cluster/platform/coreweave.py
+++ b/lib/iris/src/iris/cluster/platform/coreweave.py
@@ -391,6 +391,11 @@ class CoreweavePlatform:
                     "resources": ["configmaps"],
                     "verbs": ["get", "list", "watch", "create", "update", "patch", "delete"],
                 },
+                {
+                    "apiGroups": ["metrics.k8s.io"],
+                    "resources": ["pods"],
+                    "verbs": ["get", "list"],
+                },
             ],
         }
 
@@ -1443,6 +1448,13 @@ def _build_controller_deployment(
                 "spec": {
                     "serviceAccountName": "iris-controller",
                     "nodeSelector": node_selector,
+                    "tolerations": [
+                        {
+                            "key": "qos.coreweave.cloud/interruptable",
+                            "operator": "Exists",
+                            "effect": "NoExecute",
+                        },
+                    ],
                     "containers": [
                         {
                             "name": "iris-controller",


### PR DESCRIPTION
## Summary

- **Configmap RBAC** (#3091): grant iris-controller SA full CRUD on configmaps (was `get` only, broke worker bootstrap)
- **Interruptable toleration** (#3102): controller can now schedule on CW CPU nodes with `qos.coreweave.cloud/interruptable` taint (~14min cold start fix)
- **Metrics RBAC** (#3102): grant `get`/`list` on `pods.metrics.k8s.io` so `kubectl top pod` works (removes log noise)

All three are one-line additions in `coreweave.py:ensure_rbac()` and `_build_controller_deployment()`.

## Test plan

- [ ] `iris cluster start` on CW succeeds without manual RBAC patching
- [ ] Controller pod schedules on interruptable CPU nodes
- [ ] `kubectl top pod` from controller SA no longer returns Forbidden

Closes #3091
Closes #3102

🤖 Generated with [Claude Code](https://claude.ai/claude-code)