### PR TITLE
Log `get_current_tpu_is_preempted` exceptions

### DIFF
--- a/lib/fray/src/fray/v2/ray_backend/tpu.py
+++ b/lib/fray/src/fray/v2/ray_backend/tpu.py
@@ -176,6 +176,7 @@ def get_current_tpu_is_preempted() -> bool:
         response.raise_for_status()
         return response.text.lower() == "true"
     except Exception:
+        logger.exception("Error checking TPU preemption status; assuming not preempted")
         return False
 
 


### PR DESCRIPTION
 Since we return `false` in case of `get_current_tpu_is_preempted` failure, this may lead to confusing conclusions in face of metadata server failure (e.g. https://github.com/marin-community/marin/issues/3066).