### PR TITLE
Name Ray actor processes after the actor group name

### DIFF
--- a/lib/fray/src/fray/v2/ray_backend/backend.py
+++ b/lib/fray/src/fray/v2/ray_backend/backend.py
@@ -365,7 +365,7 @@ class RayClient:
     ) -> ActorGroup:
         """Create N Ray actors named "{name}-0", "{name}-1", ...
 
-        Uses _RayActorHost to wrap actors, enabling them to access their
+        Uses _RayActorHostBase to wrap actors, enabling them to access their
         own handle via current_actor().handle during __init__.
         """
         ray_options = _actor_ray_options(resources, actor_config)
@@ -374,7 +374,8 @@ class RayClient:
         handles: list[RayActorHandle] = []
         for i in range(count):
             actor_name = f"{name}-{i}"
-            actor_ref = _RayActorHost.options(name=actor_name, **ray_options).remote(
+            host_cls = _get_named_actor_cls(actor_name)
+            actor_ref = host_cls.options(name=actor_name, **ray_options).remote(
                 actor_class, actor_name, i, name, args, kwargs
             )
             handles.append(RayActorHandle(actor_ref))
@@ -417,8 +418,7 @@ def _actor_ray_options(resources: ResourceConfig, actor_config: ActorConfig = Ac
     return options
 
 
-@ray.remote(enable_task_events=False)
-class _RayActorHost:
+class _RayActorHostBase:
     """Wrapper that sets up ActorContext before creating the real actor.
 
     This enables actors to access their own handle via current_actor().handle
@@ -426,6 +426,10 @@ class _RayActorHost:
 
     Uses _proxy_call for method dispatch since Ray doesn't support __getattr__
     for dynamic method lookup on actor handles.
+
+    Not decorated with @ray.remote directly — use _get_named_actor_host() to
+    obtain a Ray remote class whose name matches the wrapped actor class,
+    so that `ps` shows e.g. ``ray::my_workers`` instead of ``ray::_RayActorHost``.
     """
 
     def __init__(
@@ -461,10 +465,26 @@ class _RayActorHost:
         return getattr(self._instance, method_name)(*args, **kwargs)
 
 
+_named_actor_host_cache: dict[str, type] = {}
+
+
+def _get_named_actor_cls(actor_class_name: str) -> type:
+    """Return a Ray remote class named after the wrapped actor class.
+
+    Dynamically creates a subclass of _RayActorHostBase whose __name__ is
+    ``actor_class_name``, then wraps it with ``ray.remote``.  Results are
+    cached so each distinct name only triggers one ``ray.remote()`` call.
+    """
+    if actor_class_name not in _named_actor_host_cache:
+        cls = type(actor_class_name, (_RayActorHostBase,), {})
+        _named_actor_host_cache[actor_class_name] = ray.remote(enable_task_events=False)(cls)
+    return _named_actor_host_cache[actor_class_name]
+
+
 class RayActorHandle:
     """Handle to a Ray actor. Supports both direct ref and name-based lazy resolution.
 
-    All fray v2 Ray actors are wrapped by _RayActorHost, so method calls go through
+    All fray v2 Ray actors are wrapped by _RayActorHostBase, so method calls go through
     _proxy_call to reach the wrapped instance.
     """
 
@@ -505,7 +525,7 @@ class RayActorHandle:
 
 
 class RayProxyMethod:
-    """Wraps a method call that goes through _RayActorHost._proxy_call."""
+    """Wraps a method call that goes through _RayActorHostBase._proxy_call."""
 
     def __init__(self, ray_handle: ray.actor.ActorHandle, method_name: str):
         self._ray_handle = ray_handle

--- a/lib/fray/tests/test_v2_ray.py
+++ b/lib/fray/tests/test_v2_ray.py
@@ -311,3 +311,33 @@ def test_actor_options_explicit_max_restarts_overrides_preemptible():
     options = _actor_ray_options(ResourceConfig(preemptible=True), ActorConfig(max_restarts=0))
     assert options["max_restarts"] == 0
     assert "resources" not in options
+
+
+# ---------------------------------------------------------------------------
+# Named actor host (_get_named_actor_host)
+# ---------------------------------------------------------------------------
+
+
+def test_named_actor_host_uses_given_name():
+    from fray.v2.ray_backend.backend import _get_named_actor_cls
+
+    cls = _get_named_actor_cls("my_workers")
+    # ray.remote() returns an ActorClass wrapper; __ray_metadata__.class_name
+    # is what Ray uses for process titles and the dashboard.
+    assert cls.__ray_metadata__.class_name == "my_workers"
+
+
+def test_named_actor_host_caches_by_name():
+    from fray.v2.ray_backend.backend import _get_named_actor_cls
+
+    cls1 = _get_named_actor_cls("cached_test")
+    cls2 = _get_named_actor_cls("cached_test")
+    assert cls1 is cls2
+
+
+def test_named_actor_host_different_names_differ():
+    from fray.v2.ray_backend.backend import _get_named_actor_cls
+
+    cls_a = _get_named_actor_cls("group_a")
+    cls_b = _get_named_actor_cls("group_b")
+    assert cls_a is not cls_b


### PR DESCRIPTION
## Summary
- Ray actors wrapped by `_RayActorHost` now show as `ray::<group_name>` in `ps` instead of the generic `ray::_RayActorHost`
- Dynamically creates named subclasses via `_get_named_actor_host()` with per-name caching
- No behavioral changes to actor lifecycle or method dispatch

Fixes #3118

## Test plan
- [x] New tests: `test_named_actor_host_uses_given_name`, `test_named_actor_host_caches_by_name`, `test_named_actor_host_different_names_differ`
- [x] All existing fray tests pass (`uv run pytest lib/fray/tests/test_v2_ray.py`)
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)