### PR TITLE
Fix rollout-restart race in CW controller startup

### DIFF
--- a/lib/iris/src/iris/cluster/platform/coreweave.py
+++ b/lib/iris/src/iris/cluster/platform/coreweave.py
@@ -1100,6 +1100,11 @@ class CoreweavePlatform:
         # Wait for Deployment to be available (returns immediately if already up)
         self._wait_for_deployment_ready()
 
+        # Wait for the rollout to fully complete (all old pods terminated).
+        # Without this, a port-forward through the Service can land on a
+        # dying pod from the previous ReplicaSet and get connection-refused.
+        self._kubectl.rollout_status("deployment", "iris-controller", namespaced=True)
+
         return self.discover_controller(config.controller)
 
     def stop_controller(self, config: config_pb2.IrisClusterConfig) -> None:


### PR DESCRIPTION
## Summary

Fixes #3145

Wait for the rollout to fully complete before discovering the controller.
One-line addition: `kubectl rollout status deployment/iris-controller` after
`_wait_for_deployment_ready()`.

## Changes

- `coreweave.py`: add `rollout_status()` call after deployment ready check

## Validation

- E2e test (`test_rollout_restart_race.py`) against real K8s:
  - Proves `availableReplicas >= 1` passes while >1 pods are alive (the bug)
  - Proves `kubectl rollout status` blocks until exactly 1 pod serves traffic (the fix)
- Requires `kubectl` + any K8s cluster (kind, minikube, etc); marked `@pytest.mark.slow`

cc @rjpower — the test is there mostly as an example; happy to drop it if the
utility-to-bulk ratio is too low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)