### PR TITLE
ci: run PR checks on all target branches, not just main

### DIFF
--- a/.github/workflows/dupekit-unit-tests.yaml
+++ b/.github/workflows/dupekit-unit-tests.yaml
@@ -4,8 +4,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
     paths:
       - lib/dupekit/**
       - .github/workflows/dupekit-unit-tests.yaml

--- a/.github/workflows/fray-unit-tests.yaml
+++ b/.github/workflows/fray-unit-tests.yaml
@@ -4,8 +4,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
     paths:
       - lib/fray/**
       - .github/workflows/fray-unit-tests.yaml

--- a/.github/workflows/grug-variant-diff.yaml
+++ b/.github/workflows/grug-variant-diff.yaml
@@ -2,7 +2,6 @@ name: Grug Variant Diff
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - experiments/grug/**
       - scripts/grug_dir_diff.py

--- a/.github/workflows/iris-unit-tests.yaml
+++ b/.github/workflows/iris-unit-tests.yaml
@@ -4,8 +4,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
     paths:
       - lib/iris/**
       - .github/workflows/iris-unit-tests.yaml

--- a/.github/workflows/levanter-tests.yaml
+++ b/.github/workflows/levanter-tests.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/marin-codeql.yml
+++ b/.github/workflows/marin-codeql.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
   schedule:
     - cron: '45 17 * * 2'
 jobs:

--- a/.github/workflows/marin-docs.yaml
+++ b/.github/workflows/marin-docs.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/marin-itest.yaml
+++ b/.github/workflows/marin-itest.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 

--- a/.github/workflows/marin-lint-and-format.yaml
+++ b/.github/workflows/marin-lint-and-format.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/marin-unit-tests.yaml
+++ b/.github/workflows/marin-unit-tests.yaml
@@ -4,8 +4,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 
 concurrency:

--- a/.github/workflows/zephyr-unit-tests.yaml
+++ b/.github/workflows/zephyr-unit-tests.yaml
@@ -4,8 +4,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
     paths:
       - lib/zephyr/**
       # Iris is being actively developed, to avoid bugs sneaking into zephyr, we trigger zephyr tests on iris change


### PR DESCRIPTION
## Summary

- Remove `branches: [main]` filter from `pull_request:` triggers in all 11 CI workflow files
- `push:` triggers still filter on `main` — no change to post-merge behavior
- Enables CI checks on stacked PRs (PRs targeting a feature branch instead of `main`)

## Motivation

When stacking PRs (PR B targets PR A's branch instead of `main`), GitHub Actions skips all checks because every workflow has `pull_request: branches: [main]`. This means stacked PRs get merged without CI validation.

The `branches` filter on `pull_request` is unnecessary for protection — branch protection rules on `main` already gate merges. The filter only prevents CI from running on PRs that target non-main branches, which is the exact workflow stacked PRs use.

## Test plan

- [ ] Open a stacked PR targeting a non-main branch and verify CI triggers
- [ ] Verify `push:` workflows still only run on merges to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)