### PR TITLE
Fix RESOURCE_EXHAUSTED: add NVIDIA weight tile limit for Pallas CE kernel

### DIFF
--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_gpu.py
@@ -17,8 +17,11 @@ from .reference import linear_softmax_cross_entropy_loss_reference
 from .xla import linear_softmax_cross_entropy_loss_xla
 
 
-# Empirical GB10 launch guardrail from repeated Triton shared-memory launch failures.
-_GB10_WEIGHT_TILE_BYTES_LIMIT = 101_376
+# Empirical launch guardrails from Triton shared-memory launch failures.
+# H100 has 232,448 bytes per-SM shared memory; kernel overhead (input tiles,
+# accumulators, Triton metadata) consumes ~131 KB, leaving 101,376 bytes for
+# the weight tile.  Same limit applies to all NVIDIA GPUs including GB10.
+_NVIDIA_WEIGHT_TILE_BYTES_LIMIT = 101_376
 # Compile-time safety cap observed to avoid pathological GB10 H-tiling compile behavior.
 _GB10_MAX_H_TILES = 512
 _GB10_FULL_MATMUL_MAX_OUTPUT_ELEMENTS = 67_108_864
@@ -56,8 +59,8 @@ def _gb10_native_forward_opt_in_enabled() -> bool:
 
 
 def _max_weight_tile_bytes_for_device(device_kind: str) -> Optional[int]:
-    if "gb10" in device_kind:
-        return _GB10_WEIGHT_TILE_BYTES_LIMIT
+    if "nvidia" in device_kind:
+        return _NVIDIA_WEIGHT_TILE_BYTES_LIMIT
     return None
 
 


### PR DESCRIPTION
Fixes #3159

Extend `_max_weight_tile_bytes_for_device` to return the 101,376-byte limit
for all NVIDIA GPUs (not just GB10).  This causes `PallasUnsupportedError`
before kernel launch, and the API falls back to XLA.

The limit is derived from the crash data: 232,448 (H100 shmem) − 131,072
(kernel overhead) = 101,376 bytes — matching the existing GB10 limit.

**Changes:**

- `pallas_gpu.py`: collapse `_GB10_WEIGHT_TILE_BYTES_LIMIT` and
  `_NVIDIA_WEIGHT_TILE_BYTES_LIMIT` into a single `_NVIDIA_WEIGHT_TILE_BYTES_LIMIT`,
  simplify `_max_weight_tile_bytes_for_device` to one `"nvidia"` check

**Validation:**

- Verified on 8×H100 80GB HBM3 via `iris job run --gpu=H100x8 --extra gpu`:
  - `PallasUnsupportedError` raised for oversized block sizes (v_block=2048)
  - Full API at canary-scale (B=32768, H=512, V=128256) falls back to XLA,
    produces correct `loss=99.84`
- End-to-end canary ferry
  [run 22558210064](https://github.com/marin-community/marin/actions/runs/22558210064):
  training step 1 completed (loss=12.3), step 29 reached (loss=8.06),
  checkpoint saved — previously crashed at this point
- All 17 existing Pallas CE tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)