### PR TITLE
Show reservation device in dashboard job detail

### DIFF
--- a/lib/iris/src/iris/cluster/static/controller/job-detail.js
+++ b/lib/iris/src/iris/cluster/static/controller/job-detail.js
@@ -133,6 +133,7 @@ function JobRequestDetail({ request }) {
 
   const res = request.resources || {};
   const device = formatDevice(res.device);
+  const reservation = request.reservation;
 
   return html`
     <${Collapsible} title="Job Request">
@@ -162,6 +163,26 @@ function JobRequestDetail({ request }) {
         <div style="padding:6px 0">
           <span style="color:#57606a;font-size:13px">Dockerfile</span>
           <pre style="margin:8px 0 0;padding:10px;background:#f6f8fa;border-radius:4px;font-size:12px;overflow-x:auto;white-space:pre-wrap">${dockerfile}</pre>
+        </div>
+      `}
+      ${reservation?.entries?.length > 0 && html`
+        <div style="display:flex;padding:6px 0;border-bottom:1px solid #f0f0f0">
+          <span style="color:#57606a;min-width:160px;font-size:13px">Reservation</span>
+          <div style="font-size:13px;font-family:ui-monospace,SFMono-Regular,SF Mono,Menlo,monospace;word-break:break-all">
+            ${reservation.entries.map((entry, i) => {
+              const dev = formatDevice(entry.resources?.device);
+              const entryConstraints = (entry.constraints || []).map(c => {
+                const opNames = { 0: '=', 1: '!=', 2: 'exists', 3: '!exists', 4: '>', 5: '>=', 6: '<', 7: '<=' };
+                const op = opNames[c.op] || c.op || '=';
+                const val = c.value ? (c.value.stringValue || c.value.intValue || c.value.floatValue || '') : '';
+                return `${c.key} ${op} ${val}`;
+              });
+              const constraintStr = entryConstraints.length > 0 ? ` [${entryConstraints.join(', ')}]` : '';
+              const regions = (entry.resources?.regions || []).join(', ');
+              const regionStr = regions ? ` (${regions})` : '';
+              return html`<div>${reservation.entries.length > 1 ? `Entry ${i}: ` : ''}${dev || 'unknown'}${regionStr}${constraintStr}</div>`;
+            })}
+          </div>
         </div>
       `}
     <//>
@@ -413,7 +434,7 @@ function JobDetailApp() {
         <${InfoRow} label="CPU" value=${job.resources.cpu || '-'} />
         <${InfoRow} label="Memory" value=${job.resources.memory_bytes ? formatBytes(job.resources.memory_bytes) : '-'} />
         <${InfoRow} label="Disk" value=${job.resources.disk_bytes ? formatBytes(job.resources.disk_bytes) : '-'} />
-        <${InfoRow} label="Accelerator" value=${formatDevice(job.resources.device) || '-'} />
+        <${InfoRow} label="Accelerator" value=${formatDevice(job.resources.device) || formatDevice(jobRequest?.reservation?.entries?.[0]?.resources?.device) || '-'} />
         <${InfoRow} label="Replicas" value=${tasks.length || '-'} />
       <//>
     </div>


### PR DESCRIPTION
Reservation-backed jobs (e.g. v5p-8) showed "Accelerator: -" because the dashboard only read the top-level resources.device which is empty for these jobs.

Resource Request card now falls back to reservation.entries[0].resources.device. Job Request section now renders reservation entries with device, region, and constraint details.