### PR TITLE
Bump canary ferry timeout from 2h to 4h

### DIFF
--- a/.github/workflows/marin-canary-ferry.yaml
+++ b/.github/workflows/marin-canary-ferry.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   canary-ferry:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 240
     concurrency:
       group: canary-ferry
       cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Bump canary ferry GHA job timeout from 2h to 4h
- The last 5 daily runs (Feb 26 – Mar 2) all hit the 2h timeout — cold XLA compilation (~60-90 min) + full training (~23 min) + eval + overhead exceeds 2h when the run can't resume from a checkpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)