### PR TITLE
Use GCS compilation cache for CW canary ferry

### DIFF
--- a/.github/workflows/marin-canary-ferry-cw.yaml
+++ b/.github/workflows/marin-canary-ferry-cw.yaml
@@ -62,9 +62,12 @@ jobs:
             -e CANARY_DATE "$(date -u +%Y-%m-%d)" \
             -e WANDB_API_KEY "$WANDB_API_KEY" \
             -e HF_TOKEN "$HF_TOKEN" \
+            -e GCP_SA_KEY "$GCP_SA_KEY" \
+            -e JAX_COMPILATION_CACHE_DIR "gs://marin-tmp-us-west4/ttl=30d/compilation-cache" \
             -- python -m experiments.ferries.canary_ferry_cw
         env:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}

--- a/lib/fray/src/fray/v2/types.py
+++ b/lib/fray/src/fray/v2/types.py
@@ -436,6 +436,7 @@ def create_environment(
         "HF_TOKEN": os.getenv("HF_TOKEN"),
         "WANDB_API_KEY": os.getenv("WANDB_API_KEY"),
         "MARIN_CI_DISABLE_RUNTIME_ENVS": os.getenv("MARIN_CI_DISABLE_RUNTIME_ENVS"),
+        "GCP_SA_KEY": os.getenv("GCP_SA_KEY"),
     }
 
     merged_env_vars = {k: v for k, v in {**default_env_vars, **(env_vars or {})}.items() if v is not None}

--- a/lib/iris/src/iris/cluster/runtime/entrypoint.py
+++ b/lib/iris/src/iris/cluster/runtime/entrypoint.py
@@ -63,6 +63,12 @@ def build_runtime_entrypoint(
 
     setup_commands = [
         "cd /app",
+        # Materialize GCP service account credentials from env var if present.
+        # This enables GCS access (e.g. JAX compilation cache) on non-GCP clusters
+        # where the metadata server is unavailable.
+        '[ -n "$GCP_SA_KEY" ] && echo "$GCP_SA_KEY" > /tmp/gcp-sa-key.json'
+        " && export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-sa-key.json"
+        ' && echo "GCP credentials materialized"',
     ]
     # Use --link-mode symlink to reference cached wheels directly from .venv,
     # avoiding redundant installation. Symlinks work across bind mounts.

--- a/lib/marin/src/marin/training/training.py
+++ b/lib/marin/src/marin/training/training.py
@@ -414,6 +414,11 @@ def _add_run_env_variables(env: dict):
     if "TPU_STDERR_LOG_LEVEL" not in env:
         env["TPU_STDERR_LOG_LEVEL"] = "2"
 
+    # Allow the caller (or iris -e) to override the compilation cache dir.
+    if "JAX_COMPILATION_CACHE_DIR" not in env:
+        if val := os.environ.get("JAX_COMPILATION_CACHE_DIR"):
+            env["JAX_COMPILATION_CACHE_DIR"] = val
+
     return env
 
 


### PR DESCRIPTION
## Summary

- Use GCS (`gs://marin-tmp-us-west4`) for JAX compilation cache on CW instead of ephemeral `/tmp`
- On CW, XLA compilation takes ~60 min cold. With a persistent GCS cache, subsequent runs skip recompilation
- JAX natively supports GCS for compilation cache but not S3, so CW jobs were falling back to `/tmp` (lost on pod termination)

## Changes

- **Iris entrypoint**: materialize `GCP_SA_KEY` env var to a credential file in setup_commands, enabling GCS access on non-GCP clusters
- **Fray**: auto-forward `GCP_SA_KEY` to sub-tasks (like `HF_TOKEN`, `WANDB_API_KEY`)
- **training.py**: forward `JAX_COMPILATION_CACHE_DIR` from parent env so callers can override the S3→`/tmp` fallback
- **CW canary ferry workflow**: pass `GCP_SA_KEY` and `JAX_COMPILATION_CACHE_DIR` to the job

Related: #3022, #2318

## Validation

Tested end-to-end on CW with a CPU-only probe job (`iris-run-job-20260303-010132`): credential file materialized, GCS write succeeded via `gcsfs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)