### PR TITLE
Luxical embedding experiment for quality & topic eval

### DIFF
--- a/experiments/embed_everything/__init__.py
+++ b/experiments/embed_everything/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/experiments/embed_everything/embed.py
+++ b/experiments/embed_everything/embed.py
@@ -1,0 +1,82 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Batch embedding computation using sentence-transformers.
+
+Computes embeddings for documents in a JSONL file and saves them as a .npz archive.
+Model-agnostic: defaults to Luxical but supports any HuggingFace embedding model.
+"""
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EmbedResult:
+    """Artifact returned by embed_documents."""
+
+    path: str
+    """Path to the output .npz file containing embeddings, ids, and labels."""
+    n_docs: int
+    """Number of documents embedded."""
+    embedding_dim: int
+    """Dimensionality of the embeddings."""
+
+
+def embed_documents(
+    output_path: str,
+    input_path: str,
+    model_name: str = "DatologyAI/luxical-one",
+    batch_size: int = 64,
+    max_length: int = 512,
+) -> EmbedResult:
+    """Embed documents from a JSONL file using a sentence-transformer model.
+
+    Args:
+        output_path: Directory to write the output .npz file.
+        input_path: Path to a JSONL file with at minimum "id", "text", and "label" fields.
+        model_name: HuggingFace model name for sentence-transformers.
+        batch_size: Encoding batch size.
+        max_length: Maximum token length for truncation.
+
+    Returns:
+        EmbedResult with path to the .npz file and metadata.
+    """
+    from sentence_transformers import SentenceTransformer
+
+    os.makedirs(output_path, exist_ok=True)
+
+    ids: list[str] = []
+    texts: list[str] = []
+    labels: list[str] = []
+
+    with open(input_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            doc = json.loads(line)
+            ids.append(doc["id"])
+            texts.append(doc.get("text", ""))
+            labels.append(doc.get("label", ""))
+
+    logger.info(f"Loaded {len(texts)} documents from {input_path}")
+    logger.info(f"Loading model {model_name}")
+    model = SentenceTransformer(model_name)
+    model.max_seq_length = max_length
+
+    logger.info(f"Encoding {len(texts)} documents with batch_size={batch_size}")
+    embeddings = model.encode(texts, batch_size=batch_size, show_progress_bar=True, normalize_embeddings=True)
+    embeddings = np.array(embeddings, dtype=np.float32)
+
+    out_file = os.path.join(output_path, "embeddings.npz")
+    np.savez(out_file, embeddings=embeddings, ids=np.array(ids), labels=np.array(labels))
+
+    logger.info(f"Saved embeddings ({embeddings.shape}) to {out_file}")
+    return EmbedResult(path=out_file, n_docs=len(ids), embedding_dim=embeddings.shape[1])

--- a/experiments/embed_everything/evaluate.py
+++ b/experiments/embed_everything/evaluate.py
@@ -13,12 +13,6 @@ import os
 from dataclasses import asdict, dataclass
 
 import numpy as np
-from scipy.stats import kendalltau, spearmanr
-from sklearn.cluster import KMeans
-from sklearn.linear_model import RidgeCV
-from sklearn.metrics import adjusted_rand_score, normalized_mutual_info_score
-from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import LabelEncoder
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +57,12 @@ def evaluate_quality_probe(
     Returns:
         QualityProbeResult with correlation metrics.
     """
+    # Optional deps — guarded because sklearn is in the `embedding` extra
+    from scipy.stats import kendalltau, spearmanr
+    from sklearn.linear_model import RidgeCV
+    from sklearn.model_selection import train_test_split
+    from sklearn.preprocessing import LabelEncoder
+
     os.makedirs(output_path, exist_ok=True)
 
     data = np.load(embeddings_path, allow_pickle=True)
@@ -116,6 +116,10 @@ def evaluate_topic_clusters(
     Returns:
         TopicClusterResult with ARI and NMI metrics.
     """
+    # Optional deps — guarded because sklearn is in the `embedding` extra
+    from sklearn.cluster import KMeans
+    from sklearn.metrics import adjusted_rand_score, normalized_mutual_info_score
+
     os.makedirs(output_path, exist_ok=True)
 
     data = np.load(embeddings_path, allow_pickle=True)

--- a/experiments/embed_everything/evaluate.py
+++ b/experiments/embed_everything/evaluate.py
@@ -1,0 +1,143 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Evaluation of embedding quality for quality classification and topic clustering.
+
+Quality probe: ridge regression on embeddings → ordinal quality labels.
+Topic clustering: K-Means on embeddings, evaluated against ground-truth topic labels.
+"""
+
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass
+
+import numpy as np
+from scipy.stats import kendalltau, spearmanr
+from sklearn.cluster import KMeans
+from sklearn.linear_model import RidgeCV
+from sklearn.metrics import adjusted_rand_score, normalized_mutual_info_score
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import LabelEncoder
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class QualityProbeResult:
+    """Artifact returned by evaluate_quality_probe."""
+
+    spearman_rho: float
+    kendall_tau: float
+    n_train: int
+    n_test: int
+
+
+@dataclass
+class TopicClusterResult:
+    """Artifact returned by evaluate_topic_clusters."""
+
+    ari: float
+    nmi: float
+    n_clusters: int
+    n_docs: int
+
+
+def evaluate_quality_probe(
+    output_path: str,
+    embeddings_path: str,
+    test_size: float = 0.2,
+    seed: int = 42,
+) -> QualityProbeResult:
+    """Train a linear probe on embeddings to predict ordinal quality labels.
+
+    Loads embeddings from a .npz file, splits into train/test, fits a ridge regression,
+    and reports Spearman rank correlation and Kendall's Tau on the test set.
+
+    Args:
+        output_path: Directory to write results JSON.
+        embeddings_path: Path to .npz file with "embeddings" and "labels" arrays.
+        test_size: Fraction of data for test split.
+        seed: Random seed for train/test split.
+
+    Returns:
+        QualityProbeResult with correlation metrics.
+    """
+    os.makedirs(output_path, exist_ok=True)
+
+    data = np.load(embeddings_path, allow_pickle=True)
+    embeddings = data["embeddings"]
+    labels = data["labels"]
+
+    # Convert string labels to ordinal values
+    le = LabelEncoder()
+    y = le.fit_transform(labels).astype(float)
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        embeddings, y, test_size=test_size, random_state=seed, stratify=labels
+    )
+
+    model = RidgeCV(alphas=[0.01, 0.1, 1.0, 10.0, 100.0])
+    model.fit(X_train, y_train)
+    preds = model.predict(X_test)
+
+    rho, _ = spearmanr(y_test, preds)
+    tau, _ = kendalltau(y_test, preds)
+
+    result = QualityProbeResult(
+        spearman_rho=float(rho),
+        kendall_tau=float(tau),
+        n_train=len(X_train),
+        n_test=len(X_test),
+    )
+
+    results_file = os.path.join(output_path, "results.json")
+    with open(results_file, "w") as f:
+        json.dump(asdict(result), f, indent=2)
+
+    logger.info(f"Quality probe: Spearman={rho:.3f}, Kendall={tau:.3f}")
+    return result
+
+
+def evaluate_topic_clusters(
+    output_path: str,
+    embeddings_path: str,
+    n_clusters: int,
+    seed: int = 42,
+) -> TopicClusterResult:
+    """Run K-Means on embeddings and evaluate cluster quality against ground-truth labels.
+
+    Args:
+        output_path: Directory to write results JSON.
+        embeddings_path: Path to .npz file with "embeddings" and "labels" arrays.
+        n_clusters: Number of clusters for K-Means.
+        seed: Random seed for K-Means initialization.
+
+    Returns:
+        TopicClusterResult with ARI and NMI metrics.
+    """
+    os.makedirs(output_path, exist_ok=True)
+
+    data = np.load(embeddings_path, allow_pickle=True)
+    embeddings = data["embeddings"]
+    labels = data["labels"]
+
+    km = KMeans(n_clusters=n_clusters, random_state=seed, n_init=10)
+    predicted = km.fit_predict(embeddings)
+
+    ari = adjusted_rand_score(labels, predicted)
+    nmi = normalized_mutual_info_score(labels, predicted)
+
+    result = TopicClusterResult(
+        ari=float(ari),
+        nmi=float(nmi),
+        n_clusters=n_clusters,
+        n_docs=len(labels),
+    )
+
+    results_file = os.path.join(output_path, "results.json")
+    with open(results_file, "w") as f:
+        json.dump(asdict(result), f, indent=2)
+
+    logger.info(f"Topic clustering: ARI={ari:.3f}, NMI={nmi:.3f}")
+    return result

--- a/experiments/embed_everything/exp3049_luxical_embeddings.py
+++ b/experiments/embed_everything/exp3049_luxical_embeddings.py
@@ -1,0 +1,177 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test Luxical as a General Tool for Data Integration Pipelines (issue #3049).
+
+This experiment evaluates whether Luxical embeddings encode sufficient signal for:
+1. Quality classification — linear probe on embeddings vs Nemotron quality labels
+2. Topic clustering — K-Means on embeddings vs Dolma source labels
+
+The DAG:
+    sample_quality → ┬─ oracle_quality ─┐
+                     └─ embed_quality  ─┤→ eval_quality
+    sample_topic   → ┬─ oracle_topic  ─┐
+                     └─ embed_topic   ─┤→ eval_topic
+"""
+
+from experiments.embed_everything.embed import embed_documents
+from experiments.embed_everything.evaluate import evaluate_quality_probe, evaluate_topic_clusters
+from experiments.embed_everything.oracle import label_quality, label_topics
+from experiments.embed_everything.sample import sample_documents
+from experiments.pretraining_datasets.dolma import DOLMA_DATASETS, _DOLMA_V1_7_PATH
+from experiments.pretraining_datasets.nemotron import _nemotron_cc_path
+from marin.execution.artifact import Artifact
+from marin.execution.step_runner import StepRunner
+from marin.execution.step_spec import StepSpec
+
+# -- Config -------------------------------------------------------------------
+
+EMBEDDING_MODEL = "DatologyAI/luxical-one"
+N_PER_SOURCE = 25
+SEED = 42
+ORACLE_BACKEND = "claude"
+
+# -- Nemotron quality bucket paths (actual only, skip synthetic) ---------------
+# Maps quality label → glob pattern for JSONL files
+NEMOTRON_QUALITY_BUCKETS = {
+    "high": "quality=high/kind=actual/**/*.jsonl.gz",
+    "medium_high": "quality=medium-high/**/*.jsonl.gz",
+    "medium": "quality=medium/**/*.jsonl.gz",
+    "medium_low": "quality=medium-low/**/*.jsonl.gz",
+    "low": "quality=low/kind=actual/**/*.jsonl.gz",
+}
+
+# -- Dolma source paths -------------------------------------------------------
+DOLMA_SOURCE_SPLITS = list(DOLMA_DATASETS.keys())
+
+
+def _nemotron_quality_paths() -> dict[str, str]:
+    """Build {label: glob_pattern} for Nemotron quality buckets."""
+    base = _nemotron_cc_path
+    return {label: f"{base}/{pattern}" for label, pattern in NEMOTRON_QUALITY_BUCKETS.items()}
+
+
+def _dolma_topic_paths() -> dict[str, str]:
+    """Build {label: glob_pattern} for Dolma source splits."""
+    base = str(_DOLMA_V1_7_PATH)
+    paths = {}
+    for source, file_patterns in DOLMA_DATASETS.items():
+        # Use first pattern per source as representative
+        paths[source] = f"{base}/{file_patterns[0]}"
+    return paths
+
+
+def build_steps() -> list[StepSpec]:
+    """Build the full StepSpec DAG for the Luxical embedding experiment."""
+    nemotron_paths = _nemotron_quality_paths()
+    dolma_paths = _dolma_topic_paths()
+
+    # ---- Quality classification pipeline ----
+
+    sample_quality = StepSpec(
+        name="embed_everything/sample_quality",
+        hash_attrs={"n_per_source": N_PER_SOURCE, "buckets": sorted(nemotron_paths.keys()), "seed": SEED},
+        fn=lambda output_path: sample_documents(
+            output_path=output_path,
+            source_paths=nemotron_paths,
+            n_per_source=N_PER_SOURCE,
+            seed=SEED,
+        ),
+    )
+
+    oracle_quality = StepSpec(
+        name="embed_everything/oracle_quality",
+        hash_attrs={"backend": ORACLE_BACKEND, "prompt_version": "v1"},
+        deps=[sample_quality],
+        fn=lambda output_path: label_quality(
+            output_path=output_path,
+            input_path=Artifact.load(sample_quality.output_path).path,
+            backend=ORACLE_BACKEND,
+            prompt_version="v1",
+        ),
+    )
+
+    embed_quality = StepSpec(
+        name="embed_everything/embed_quality",
+        hash_attrs={"model": EMBEDDING_MODEL},
+        deps=[sample_quality],
+        fn=lambda output_path: embed_documents(
+            output_path=output_path,
+            input_path=Artifact.load(sample_quality.output_path).path,
+            model_name=EMBEDDING_MODEL,
+        ),
+    )
+
+    eval_quality = StepSpec(
+        name="embed_everything/eval_quality",
+        deps=[oracle_quality, embed_quality],
+        fn=lambda output_path: evaluate_quality_probe(
+            output_path=output_path,
+            embeddings_path=Artifact.load(embed_quality.output_path).path,
+        ),
+    )
+
+    # ---- Topic clustering pipeline ----
+
+    sample_topic = StepSpec(
+        name="embed_everything/sample_topic",
+        hash_attrs={"n_per_source": N_PER_SOURCE, "sources": sorted(dolma_paths.keys()), "seed": SEED},
+        fn=lambda output_path: sample_documents(
+            output_path=output_path,
+            source_paths=dolma_paths,
+            n_per_source=N_PER_SOURCE,
+            seed=SEED,
+        ),
+    )
+
+    oracle_topic = StepSpec(
+        name="embed_everything/oracle_topic",
+        hash_attrs={"backend": ORACLE_BACKEND, "prompt_version": "v1"},
+        deps=[sample_topic],
+        fn=lambda output_path: label_topics(
+            output_path=output_path,
+            input_path=Artifact.load(sample_topic.output_path).path,
+            backend=ORACLE_BACKEND,
+            prompt_version="v1",
+        ),
+    )
+
+    embed_topic = StepSpec(
+        name="embed_everything/embed_topic",
+        hash_attrs={"model": EMBEDDING_MODEL},
+        deps=[sample_topic],
+        fn=lambda output_path: embed_documents(
+            output_path=output_path,
+            input_path=Artifact.load(sample_topic.output_path).path,
+            model_name=EMBEDDING_MODEL,
+        ),
+    )
+
+    n_topics = len(DOLMA_SOURCE_SPLITS)
+    eval_topic = StepSpec(
+        name="embed_everything/eval_topic",
+        hash_attrs={"n_clusters": n_topics},
+        deps=[oracle_topic, embed_topic],
+        fn=lambda output_path: evaluate_topic_clusters(
+            output_path=output_path,
+            embeddings_path=Artifact.load(embed_topic.output_path).path,
+            n_clusters=n_topics,
+        ),
+    )
+
+    return [
+        sample_quality,
+        oracle_quality,
+        embed_quality,
+        eval_quality,
+        sample_topic,
+        oracle_topic,
+        embed_topic,
+        eval_topic,
+    ]
+
+
+if __name__ == "__main__":
+    steps = build_steps()
+    runner = StepRunner()
+    runner.run(steps)

--- a/experiments/embed_everything/exp3049_match_halves.py
+++ b/experiments/embed_everything/exp3049_match_halves.py
@@ -1,0 +1,357 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reproduce Test Case 1 from the Luxical blog post: matching document halves.
+
+Methodology (from https://www.datologyai.com/blog/introducing-luxical-embeddings):
+1. Sample N documents from FineWeb.
+2. Split each document at the midpoint into two halves → 2N half-documents.
+3. Embed all halves with each model.
+4. For each half, rank all other halves by cosine similarity.
+5. Measure how often the matching half appears in the top-k nearest neighbors
+   at various retrieval windows (top-1, top-0.01%, top-0.1%, top-1%).
+6. Compare retrieval accuracy and throughput across models.
+
+Usage:
+    # Run locally (small sample for testing):
+    uv run python experiments/embed_everything/exp3049_match_halves.py --n_docs 100
+
+    # Full reproduction:
+    uv run python experiments/embed_everything/exp3049_match_halves.py --n_docs 50000
+
+    # With StepSpec DAG:
+    uv run python experiments/embed_everything/exp3049_match_halves.py --use_steps
+"""
+
+import argparse
+import json
+import logging
+import os
+import time
+from dataclasses import asdict, dataclass
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODELS = [
+    "DatologyAI/luxical-one",
+    "sentence-transformers/all-MiniLM-L6-v2",
+]
+
+RETRIEVAL_WINDOWS = [1, 0.01, 0.1, 1.0]
+"""Retrieval windows: top-1 (absolute), then top-x% of the corpus."""
+
+
+@dataclass
+class HalfDocument:
+    doc_id: str
+    half: str  # "a" or "b"
+    text: str
+
+
+@dataclass
+class MatchHalvesResult:
+    """Results for a single model on the match-halves benchmark."""
+
+    model_name: str
+    n_docs: int
+    n_halves: int
+    embedding_dim: int
+    embed_time_seconds: float
+    throughput_docs_per_sec: float
+    retrieval_accuracy: dict[str, float]
+    """Maps window label (e.g. "top-1", "top-0.01%") to accuracy (fraction of correct matches)."""
+
+
+def sample_fineweb_documents(n_docs: int, seed: int = 42, min_chars: int = 200) -> list[dict]:
+    """Stream n_docs documents from FineWeb, filtering for minimum length.
+
+    Args:
+        n_docs: Number of documents to sample.
+        seed: Random seed for shuffling.
+        min_chars: Minimum character length to include a document.
+
+    Returns:
+        List of dicts with "id" and "text" fields.
+    """
+    import datasets
+
+    datasets.disable_caching()
+    logger.info(f"Streaming {n_docs} documents from FineWeb (min_chars={min_chars})")
+
+    ds = datasets.load_dataset(
+        "HuggingFaceFW/fineweb",
+        name="sample-10BT",
+        split="train",
+        streaming=True,
+    )
+    ds = ds.shuffle(seed=seed, buffer_size=10_000)
+
+    docs = []
+    for row in ds:
+        text = row.get("text", "")
+        if len(text) < min_chars:
+            continue
+        docs.append({"id": row.get("id", f"doc-{len(docs)}"), "text": text})
+        if len(docs) >= n_docs:
+            break
+
+    logger.info(f"Sampled {len(docs)} documents from FineWeb")
+    return docs
+
+
+def split_into_halves(docs: list[dict]) -> list[HalfDocument]:
+    """Split each document at the character midpoint into two halves.
+
+    Returns a list of 2*len(docs) HalfDocument objects. The two halves of
+    document i have doc_id=docs[i]["id"] and half="a"/"b".
+    """
+    halves = []
+    for doc in docs:
+        text = doc["text"]
+        mid = len(text) // 2
+        halves.append(HalfDocument(doc_id=doc["id"], half="a", text=text[:mid]))
+        halves.append(HalfDocument(doc_id=doc["id"], half="b", text=text[mid:]))
+    return halves
+
+
+def embed_halves(
+    halves: list[HalfDocument],
+    model_name: str,
+    batch_size: int = 64,
+) -> tuple[np.ndarray, float]:
+    """Embed all half-documents and return (embeddings, elapsed_seconds).
+
+    Args:
+        halves: List of HalfDocument objects.
+        model_name: HuggingFace model name for sentence-transformers.
+        batch_size: Encoding batch size.
+
+    Returns:
+        Tuple of (embeddings array [N, D], time in seconds).
+    """
+    from sentence_transformers import SentenceTransformer
+
+    logger.info(f"Loading model {model_name}")
+    model = SentenceTransformer(model_name)
+
+    texts = [h.text for h in halves]
+    logger.info(f"Encoding {len(texts)} half-documents with {model_name}")
+
+    start = time.monotonic()
+    embeddings = model.encode(texts, batch_size=batch_size, show_progress_bar=True, normalize_embeddings=True)
+    elapsed = time.monotonic() - start
+
+    return np.array(embeddings, dtype=np.float32), elapsed
+
+
+def evaluate_retrieval(
+    embeddings: np.ndarray,
+    halves: list[HalfDocument],
+    windows: list[float] = RETRIEVAL_WINDOWS,
+) -> dict[str, float]:
+    """Evaluate retrieval accuracy: how often the matching half is in the top-k.
+
+    For each half-document, we rank all *other* halves by cosine similarity
+    (embeddings are assumed to be L2-normalized, so dot product = cosine).
+    We check whether the matching half (same doc_id, opposite half label)
+    appears within the top-k nearest neighbors at each retrieval window.
+
+    Args:
+        embeddings: L2-normalized embeddings, shape [2N, D].
+        halves: Corresponding HalfDocument objects.
+        windows: List of retrieval windows. Values >= 1 are treated as absolute
+            counts (e.g. 1 = top-1). Values < 1 are treated as percentages of
+            the corpus (e.g. 0.01 = top 0.01%).
+
+    Returns:
+        Dict mapping window label to accuracy (fraction of halves whose match
+        was found within the window).
+    """
+    n = len(halves)
+    assert embeddings.shape[0] == n
+
+    # Build ground-truth match index: for each half i, match_idx[i] is the
+    # index of its matching half (same doc_id, opposite half label).
+    doc_id_to_indices: dict[str, list[int]] = {}
+    for i, h in enumerate(halves):
+        doc_id_to_indices.setdefault(h.doc_id, []).append(i)
+
+    match_idx = np.full(n, -1, dtype=np.int64)
+    for indices in doc_id_to_indices.values():
+        assert len(indices) == 2, f"Expected exactly 2 halves per doc, got {len(indices)}"
+        match_idx[indices[0]] = indices[1]
+        match_idx[indices[1]] = indices[0]
+
+    assert np.all(match_idx >= 0), "Some halves have no match"
+
+    # Compute cosine similarity matrix (dot product of normalized vectors)
+    # Process in chunks to avoid OOM on large corpora
+    chunk_size = 1000
+    results: dict[str, int] = {_window_label(w): 0 for w in windows}
+
+    for start in range(0, n, chunk_size):
+        end = min(start + chunk_size, n)
+        # [chunk_size, D] @ [D, N] → [chunk_size, N]
+        sims = embeddings[start:end] @ embeddings.T
+
+        for i_local in range(end - start):
+            i_global = start + i_local
+            row = sims[i_local].copy()
+            # Exclude self-similarity
+            row[i_global] = -np.inf
+
+            # Argsort descending
+            ranked = np.argsort(-row)
+            target = match_idx[i_global]
+            rank_of_target = int(np.where(ranked == target)[0][0])
+
+            for w in windows:
+                k = _window_to_k(w, n - 1)  # n-1 because we exclude self
+                if rank_of_target < k:
+                    results[_window_label(w)] += 1
+
+    accuracy = {label: count / n for label, count in results.items()}
+    return accuracy
+
+
+def _window_to_k(window: float, corpus_size: int) -> int:
+    """Convert a retrieval window to an absolute k value."""
+    if window >= 1:
+        return int(window)
+    return max(1, int(corpus_size * window / 100))
+
+
+def _window_label(window: float) -> str:
+    if window >= 1:
+        return f"top-{int(window)}"
+    return f"top-{window}%"
+
+
+def run_match_halves(
+    output_path: str,
+    n_docs: int = 50_000,
+    models: list[str] | None = None,
+    batch_size: int = 64,
+    seed: int = 42,
+) -> list[MatchHalvesResult]:
+    """Run the full match-halves benchmark.
+
+    Args:
+        output_path: Directory to write results.
+        n_docs: Number of FineWeb documents to sample.
+        models: List of HuggingFace model names. Defaults to DEFAULT_MODELS.
+        batch_size: Encoding batch size.
+        seed: Random seed for document sampling.
+
+    Returns:
+        List of MatchHalvesResult, one per model.
+    """
+    if models is None:
+        models = list(DEFAULT_MODELS)
+
+    os.makedirs(output_path, exist_ok=True)
+
+    # Step 1: Sample documents
+    docs = sample_fineweb_documents(n_docs=n_docs, seed=seed)
+
+    # Step 2: Split into halves
+    halves = split_into_halves(docs)
+    logger.info(f"Created {len(halves)} half-documents from {len(docs)} documents")
+
+    # Save halves for reproducibility
+    halves_file = os.path.join(output_path, "halves.jsonl")
+    with open(halves_file, "w") as f:
+        for h in halves:
+            f.write(json.dumps(asdict(h)) + "\n")
+
+    all_results = []
+
+    for model_name in models:
+        logger.info(f"\n{'='*60}\nEvaluating {model_name}\n{'='*60}")
+
+        # Step 3: Embed
+        embeddings, elapsed = embed_halves(halves, model_name, batch_size=batch_size)
+        throughput = len(halves) / elapsed
+
+        # Step 4: Evaluate retrieval
+        accuracy = evaluate_retrieval(embeddings, halves)
+
+        result = MatchHalvesResult(
+            model_name=model_name,
+            n_docs=len(docs),
+            n_halves=len(halves),
+            embedding_dim=embeddings.shape[1],
+            embed_time_seconds=round(elapsed, 2),
+            throughput_docs_per_sec=round(throughput, 1),
+            retrieval_accuracy=accuracy,
+        )
+        all_results.append(result)
+
+        logger.info(f"Model: {model_name}")
+        logger.info(f"  Throughput: {throughput:.1f} docs/sec ({elapsed:.2f}s for {len(halves)} halves)")
+        for label, acc in accuracy.items():
+            logger.info(f"  {label}: {acc:.4f} ({acc*100:.2f}%)")
+
+    # Save results
+    results_file = os.path.join(output_path, "results.json")
+    with open(results_file, "w") as f:
+        json.dump([asdict(r) for r in all_results], f, indent=2)
+    logger.info(f"\nResults saved to {results_file}")
+
+    return all_results
+
+
+def build_steps(
+    n_docs: int = 50_000,
+    models: list[str] | None = None,
+    batch_size: int = 64,
+    seed: int = 42,
+) -> list:
+    """Build StepSpec DAG for the match-halves benchmark."""
+    from marin.execution.step_spec import StepSpec
+
+    if models is None:
+        models = list(DEFAULT_MODELS)
+
+    return [
+        StepSpec(
+            name="embed_everything/match_halves",
+            hash_attrs={"n_docs": n_docs, "models": models, "seed": seed},
+            fn=lambda output_path: run_match_halves(
+                output_path=output_path,
+                n_docs=n_docs,
+                models=models,
+                batch_size=batch_size,
+                seed=seed,
+            ),
+        )
+    ]
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+    parser = argparse.ArgumentParser(description="Reproduce Luxical blog Test Case 1: match document halves")
+    parser.add_argument("--n_docs", type=int, default=50_000, help="Number of FineWeb documents to sample")
+    parser.add_argument("--models", nargs="+", default=None, help="Models to evaluate (HuggingFace names)")
+    parser.add_argument("--batch_size", type=int, default=64, help="Encoding batch size")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    parser.add_argument("--output_path", type=str, default="output/match_halves", help="Output directory")
+    parser.add_argument("--use_steps", action="store_true", help="Run via StepSpec DAG instead of directly")
+    args = parser.parse_args()
+
+    if args.use_steps:
+        from marin.execution.step_runner import StepRunner
+
+        steps = build_steps(n_docs=args.n_docs, models=args.models, batch_size=args.batch_size, seed=args.seed)
+        StepRunner().run(steps)
+    else:
+        run_match_halves(
+            output_path=args.output_path,
+            n_docs=args.n_docs,
+            models=args.models,
+            batch_size=args.batch_size,
+            seed=args.seed,
+        )

--- a/experiments/embed_everything/oracle.py
+++ b/experiments/embed_everything/oracle.py
@@ -1,0 +1,272 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Oracle labeling via LLM APIs (Claude, OpenAI).
+
+Labels documents with quality scores (discrete 0-5 rubric) or topic classifications
+using Claude or OpenAI as the oracle. Supports batch processing with rate limiting.
+"""
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# FineWeb-Edu style quality rubric prompt
+QUALITY_PROMPT_V1 = """\
+Evaluate the quality of the following document on a scale from 0 to 5.
+
+Score guidelines:
+0 - Incoherent, spam, or machine-generated noise with no meaningful content.
+1 - Very low quality: poorly written, mostly boilerplate, ads, or navigation text.
+2 - Low quality: some meaningful content but poorly structured, many errors, or very shallow.
+3 - Medium quality: coherent and readable but not particularly informative or well-written.
+4 - High quality: well-written, informative, and well-structured content.
+5 - Exceptional quality: expertly written, deeply informative, educational, or reference-grade.
+
+Respond with ONLY a single integer from 0 to 5.
+
+Document:
+{text}
+"""
+
+# Topic classification prompt
+TOPIC_PROMPT_V1 = """\
+Classify the following document into exactly one of these topics:
+
+- science (natural sciences, physics, chemistry, biology)
+- technology (computing, engineering, software)
+- mathematics (pure math, statistics, applied math)
+- medicine (health, clinical, biomedical)
+- law (legal documents, regulations, case law)
+- finance (economics, business, markets)
+- humanities (philosophy, history, literature, arts)
+- education (teaching materials, textbooks, tutorials)
+- news (journalism, current events, reporting)
+- social_media (forums, discussions, comments, social posts)
+- reference (encyclopedias, wikis, documentation)
+- code (source code, programming, scripts)
+- creative_writing (fiction, poetry, storytelling)
+- government (policy, public administration)
+- other (anything that doesn't fit above)
+
+Respond with ONLY the topic label (one of the words before the parentheses).
+
+Document:
+{text}
+"""
+
+QUALITY_PROMPTS = {"v1": QUALITY_PROMPT_V1}
+TOPIC_PROMPTS = {"v1": TOPIC_PROMPT_V1}
+
+VALID_TOPICS = {
+    "science",
+    "technology",
+    "mathematics",
+    "medicine",
+    "law",
+    "finance",
+    "humanities",
+    "education",
+    "news",
+    "social_media",
+    "reference",
+    "code",
+    "creative_writing",
+    "government",
+    "other",
+}
+
+
+@dataclass
+class OracleResult:
+    """Artifact returned by label_quality / label_topics."""
+
+    path: str
+    """Path to the output JSONL with oracle labels."""
+    n_labeled: int
+    n_failed: int
+    backend: str
+
+
+def _truncate_text(text: str, max_chars: int = 4000) -> str:
+    """Truncate text to fit within API context limits."""
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + "\n[...truncated]"
+
+
+def _call_claude(prompt: str, model: str = "claude-sonnet-4-20250514") -> str:
+    """Call Claude API and return the text response."""
+    import anthropic
+
+    client = anthropic.Anthropic()
+    response = client.messages.create(
+        model=model,
+        max_tokens=16,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.content[0].text.strip()
+
+
+def _call_openai(prompt: str, model: str = "gpt-4o-mini") -> str:
+    """Call OpenAI API and return the text response."""
+    import openai
+
+    client = openai.OpenAI()
+    response = client.chat.completions.create(
+        model=model,
+        max_tokens=16,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message.content.strip()
+
+
+def _call_backend(prompt: str, backend: str) -> str:
+    if backend == "claude":
+        return _call_claude(prompt)
+    elif backend == "openai":
+        return _call_openai(prompt)
+    else:
+        raise ValueError(f"Unknown backend: {backend!r}. Use 'claude' or 'openai'.")
+
+
+def label_quality(
+    output_path: str,
+    input_path: str,
+    backend: str = "claude",
+    prompt_version: str = "v1",
+    max_retries: int = 3,
+    rate_limit_delay: float = 0.5,
+) -> OracleResult:
+    """Score each document with an oracle quality rubric (0-5).
+
+    Args:
+        output_path: Directory to write the labeled JSONL.
+        input_path: Path to JSONL with sampled documents (must have "id", "text" fields).
+        backend: "claude" or "openai".
+        prompt_version: Version key for the quality prompt template.
+        max_retries: Retries per document on API failure.
+        rate_limit_delay: Seconds to wait between API calls.
+
+    Returns:
+        OracleResult with path to labeled JSONL.
+    """
+    os.makedirs(output_path, exist_ok=True)
+    prompt_template = QUALITY_PROMPTS[prompt_version]
+    out_file = os.path.join(output_path, "oracle_quality.jsonl")
+
+    docs = []
+    with open(input_path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                docs.append(json.loads(line))
+
+    n_labeled = 0
+    n_failed = 0
+
+    with open(out_file, "w") as f:
+        for doc in docs:
+            text = _truncate_text(doc.get("text", ""))
+            prompt = prompt_template.format(text=text)
+
+            score = None
+            for attempt in range(max_retries):
+                try:
+                    response = _call_backend(prompt, backend)
+                    parsed = int(response)
+                    if 0 <= parsed <= 5:
+                        score = parsed
+                        break
+                except (ValueError, TypeError):
+                    logger.warning(f"Failed to parse quality score for doc {doc['id']}: {response!r}")
+                except Exception as e:
+                    logger.warning(f"API error for doc {doc['id']} (attempt {attempt + 1}): {e}")
+                    time.sleep(rate_limit_delay * (attempt + 1))
+
+            labeled_doc = {**doc, "oracle_quality_score": score}
+            f.write(json.dumps(labeled_doc) + "\n")
+
+            if score is not None:
+                n_labeled += 1
+            else:
+                n_failed += 1
+                logger.warning(f"Failed to label doc {doc['id']} after {max_retries} attempts")
+
+            time.sleep(rate_limit_delay)
+
+    logger.info(f"Quality labeling complete: {n_labeled} labeled, {n_failed} failed")
+    return OracleResult(path=out_file, n_labeled=n_labeled, n_failed=n_failed, backend=backend)
+
+
+def label_topics(
+    output_path: str,
+    input_path: str,
+    backend: str = "claude",
+    prompt_version: str = "v1",
+    max_retries: int = 3,
+    rate_limit_delay: float = 0.5,
+) -> OracleResult:
+    """Assign a topic label to each document using an LLM oracle.
+
+    Args:
+        output_path: Directory to write the labeled JSONL.
+        input_path: Path to JSONL with sampled documents.
+        backend: "claude" or "openai".
+        prompt_version: Version key for the topic prompt template.
+        max_retries: Retries per document on API failure.
+        rate_limit_delay: Seconds to wait between API calls.
+
+    Returns:
+        OracleResult with path to labeled JSONL.
+    """
+    os.makedirs(output_path, exist_ok=True)
+    prompt_template = TOPIC_PROMPTS[prompt_version]
+    out_file = os.path.join(output_path, "oracle_topics.jsonl")
+
+    docs = []
+    with open(input_path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                docs.append(json.loads(line))
+
+    n_labeled = 0
+    n_failed = 0
+
+    with open(out_file, "w") as f:
+        for doc in docs:
+            text = _truncate_text(doc.get("text", ""))
+            prompt = prompt_template.format(text=text)
+
+            topic = None
+            for attempt in range(max_retries):
+                try:
+                    response = _call_backend(prompt, backend)
+                    response_lower = response.lower().strip()
+                    if response_lower in VALID_TOPICS:
+                        topic = response_lower
+                        break
+                    else:
+                        logger.warning(f"Invalid topic {response!r} for doc {doc['id']}")
+                except Exception as e:
+                    logger.warning(f"API error for doc {doc['id']} (attempt {attempt + 1}): {e}")
+                    time.sleep(rate_limit_delay * (attempt + 1))
+
+            labeled_doc = {**doc, "oracle_topic_label": topic}
+            f.write(json.dumps(labeled_doc) + "\n")
+
+            if topic is not None:
+                n_labeled += 1
+            else:
+                n_failed += 1
+                logger.warning(f"Failed to label doc {doc['id']} after {max_retries} attempts")
+
+            time.sleep(rate_limit_delay)
+
+    logger.info(f"Topic labeling complete: {n_labeled} labeled, {n_failed} failed")
+    return OracleResult(path=out_file, n_labeled=n_labeled, n_failed=n_failed, backend=backend)

--- a/experiments/embed_everything/sample.py
+++ b/experiments/embed_everything/sample.py
@@ -1,0 +1,88 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stratified document sampling from JSONL files.
+
+Reads documents from multiple sources (e.g. Nemotron quality buckets, Dolma source splits)
+and samples N documents per source, preserving a label field for downstream evaluation.
+"""
+
+import glob
+import json
+import logging
+import os
+import random
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SampleResult:
+    """Artifact returned by sample_documents."""
+
+    path: str
+    """Path to the output JSONL file."""
+    n_docs: int
+    """Total number of sampled documents."""
+    n_per_label: dict[str, int]
+    """Number of documents sampled per label."""
+
+
+def sample_documents(
+    output_path: str,
+    source_paths: dict[str, str],
+    n_per_source: int,
+    seed: int = 42,
+) -> SampleResult:
+    """Sample documents from multiple JSONL sources with stratification.
+
+    Args:
+        output_path: Directory to write the sampled documents.
+        source_paths: Mapping from label → glob pattern for JSONL files.
+            Each matched file is read, and up to n_per_source documents are sampled
+            for that label.
+        n_per_source: Target number of documents to sample per source/label.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        SampleResult with path to the output JSONL and counts.
+    """
+    rng = random.Random(seed)
+    os.makedirs(output_path, exist_ok=True)
+    out_file = os.path.join(output_path, "sampled_docs.jsonl")
+
+    all_sampled: list[dict] = []
+    n_per_label: dict[str, int] = {}
+
+    for label, pattern in sorted(source_paths.items()):
+        files = sorted(glob.glob(pattern))
+        if not files:
+            logger.warning(f"No files matched pattern {pattern!r} for label {label!r}")
+            continue
+
+        docs = []
+        for fpath in files:
+            with open(fpath) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    doc = json.loads(line)
+                    doc["label"] = label
+                    docs.append(doc)
+
+        if len(docs) <= n_per_source:
+            sampled = docs
+        else:
+            sampled = rng.sample(docs, n_per_source)
+
+        all_sampled.extend(sampled)
+        n_per_label[label] = len(sampled)
+        logger.info(f"Sampled {len(sampled)} docs for label {label!r} (from {len(docs)} available)")
+
+    with open(out_file, "w") as f:
+        for doc in all_sampled:
+            f.write(json.dumps(doc) + "\n")
+
+    return SampleResult(path=out_file, n_docs=len(all_sampled), n_per_label=n_per_label)

--- a/lib/marin/pyproject.toml
+++ b/lib/marin/pyproject.toml
@@ -177,6 +177,12 @@ dedup = [
     "dupekit",
 ]
 
+embedding = [
+    "anthropic",
+    "scikit-learn",
+    "sentence-transformers",
+]
+
 math = ["pylatexenc", "sympy"]
 
 [[tool.uv.index]]

--- a/tests/embed_everything/__init__.py
+++ b/tests/embed_everything/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/embed_everything/test_embed.py
+++ b/tests/embed_everything/test_embed.py
@@ -1,0 +1,42 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+
+import numpy as np
+import pytest
+
+from experiments.embed_everything.embed import embed_documents
+
+
+def _write_jsonl(path: str, docs: list[dict]):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        for doc in docs:
+            f.write(json.dumps(doc) + "\n")
+
+
+@pytest.mark.slow
+def test_embed_documents_produces_embeddings(tmp_path):
+    """Embeds documents and saves .npz with correct shapes."""
+    docs = [
+        {"id": f"doc-{i}", "text": f"This is test document number {i}.", "label": f"label_{i % 3}"} for i in range(10)
+    ]
+    input_path = str(tmp_path / "input" / "docs.jsonl")
+    _write_jsonl(input_path, docs)
+
+    output_path = str(tmp_path / "output")
+    result = embed_documents(
+        output_path=output_path,
+        input_path=input_path,
+        model_name="DatologyAI/luxical-one",
+        batch_size=4,
+    )
+
+    assert os.path.exists(result.path)
+    data = np.load(result.path)
+    assert data["embeddings"].shape[0] == 10
+    assert data["embeddings"].shape[1] > 0
+    assert len(data["ids"]) == 10
+    assert len(data["labels"]) == 10

--- a/tests/embed_everything/test_evaluate.py
+++ b/tests/embed_everything/test_evaluate.py
@@ -1,0 +1,102 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+
+import numpy as np
+
+from experiments.embed_everything.evaluate import evaluate_quality_probe, evaluate_topic_clusters
+
+
+def _write_embeddings(path: str, embeddings: np.ndarray, ids: list[str], labels: list[str]):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    np.savez(path, embeddings=embeddings, ids=np.array(ids), labels=np.array(labels))
+
+
+def test_evaluate_quality_probe_perfect_signal(tmp_path):
+    """A linearly separable quality signal should yield high Spearman/Kendall."""
+    rng = np.random.default_rng(42)
+    n = 200
+    # Quality labels 0-4, embeddings are just the label value + noise
+    labels = np.repeat(np.arange(5), n // 5).astype(float)
+    embeddings = np.column_stack([labels + rng.normal(0, 0.1, n), rng.normal(0, 0.1, n)])
+    ids = [f"doc-{i}" for i in range(n)]
+    label_strs = [str(int(l)) for l in labels]
+
+    emb_path = str(tmp_path / "embeddings.npz")
+    _write_embeddings(emb_path, embeddings, ids, label_strs)
+
+    output_path = str(tmp_path / "output")
+    result = evaluate_quality_probe(output_path=output_path, embeddings_path=emb_path, test_size=0.2, seed=42)
+
+    assert result.spearman_rho > 0.8
+    assert result.kendall_tau > 0.7
+
+
+def test_evaluate_quality_probe_random_signal(tmp_path):
+    """Random embeddings should yield low correlation."""
+    rng = np.random.default_rng(42)
+    n = 200
+    labels = np.repeat(np.arange(5), n // 5).astype(float)
+    embeddings = rng.normal(0, 1, (n, 32))
+    ids = [f"doc-{i}" for i in range(n)]
+    label_strs = [str(int(l)) for l in labels]
+
+    emb_path = str(tmp_path / "embeddings.npz")
+    _write_embeddings(emb_path, embeddings, ids, label_strs)
+
+    output_path = str(tmp_path / "output")
+    result = evaluate_quality_probe(output_path=output_path, embeddings_path=emb_path, test_size=0.2, seed=42)
+
+    assert abs(result.spearman_rho) < 0.5
+
+
+def test_evaluate_topic_clusters_separable(tmp_path):
+    """Well-separated clusters should yield high ARI/NMI."""
+    rng = np.random.default_rng(42)
+    n_per_topic = 40
+    n_topics = 5
+    n = n_per_topic * n_topics
+
+    labels = []
+    embeddings_list = []
+    for i in range(n_topics):
+        center = np.zeros(10)
+        center[i] = 5.0
+        embeddings_list.append(center + rng.normal(0, 0.3, (n_per_topic, 10)))
+        labels.extend([f"topic_{i}"] * n_per_topic)
+
+    embeddings = np.vstack(embeddings_list)
+    ids = [f"doc-{i}" for i in range(n)]
+
+    emb_path = str(tmp_path / "embeddings.npz")
+    _write_embeddings(emb_path, embeddings, ids, labels)
+
+    output_path = str(tmp_path / "output")
+    result = evaluate_topic_clusters(output_path=output_path, embeddings_path=emb_path, n_clusters=n_topics, seed=42)
+
+    assert result.ari > 0.7
+    assert result.nmi > 0.7
+
+
+def test_evaluate_topic_clusters_writes_results(tmp_path):
+    """Results are persisted as JSON."""
+    rng = np.random.default_rng(42)
+    n = 60
+    embeddings = rng.normal(0, 1, (n, 5))
+    labels = [f"t{i % 3}" for i in range(n)]
+    ids = [f"doc-{i}" for i in range(n)]
+
+    emb_path = str(tmp_path / "embeddings.npz")
+    _write_embeddings(emb_path, embeddings, ids, labels)
+
+    output_path = str(tmp_path / "output")
+    evaluate_topic_clusters(output_path=output_path, embeddings_path=emb_path, n_clusters=3, seed=42)
+
+    results_file = os.path.join(output_path, "results.json")
+    assert os.path.exists(results_file)
+    with open(results_file) as f:
+        saved = json.load(f)
+    assert "ari" in saved
+    assert "nmi" in saved

--- a/tests/embed_everything/test_evaluate.py
+++ b/tests/embed_everything/test_evaluate.py
@@ -5,8 +5,11 @@ import json
 import os
 
 import numpy as np
+import pytest
 
-from experiments.embed_everything.evaluate import evaluate_quality_probe, evaluate_topic_clusters
+sklearn = pytest.importorskip("sklearn")
+
+from experiments.embed_everything.evaluate import evaluate_quality_probe, evaluate_topic_clusters  # noqa: E402
 
 
 def _write_embeddings(path: str, embeddings: np.ndarray, ids: list[str], labels: list[str]):

--- a/tests/embed_everything/test_match_halves.py
+++ b/tests/embed_everything/test_match_halves.py
@@ -1,0 +1,65 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+
+from experiments.embed_everything.exp3049_match_halves import (
+    HalfDocument,
+    evaluate_retrieval,
+    split_into_halves,
+)
+
+
+def test_split_into_halves():
+    docs = [
+        {"id": "doc-0", "text": "AAAABBBB"},
+        {"id": "doc-1", "text": "CCCCDDDD"},
+    ]
+    halves = split_into_halves(docs)
+    assert len(halves) == 4
+    assert halves[0] == HalfDocument(doc_id="doc-0", half="a", text="AAAA")
+    assert halves[1] == HalfDocument(doc_id="doc-0", half="b", text="BBBB")
+    assert halves[2] == HalfDocument(doc_id="doc-1", half="a", text="CCCC")
+    assert halves[3] == HalfDocument(doc_id="doc-1", half="b", text="DDDD")
+
+
+def test_evaluate_retrieval_perfect_embeddings():
+    """When matching halves have identical embeddings, retrieval accuracy should be 1.0."""
+    # 4 docs → 8 halves. Each pair (a,b) shares the same embedding.
+    halves = []
+    embeddings_list = []
+    rng = np.random.default_rng(42)
+
+    for i in range(4):
+        vec = rng.normal(0, 1, 16).astype(np.float32)
+        vec /= np.linalg.norm(vec)
+        halves.append(HalfDocument(doc_id=f"doc-{i}", half="a", text=f"text-{i}-a"))
+        halves.append(HalfDocument(doc_id=f"doc-{i}", half="b", text=f"text-{i}-b"))
+        # Both halves get the same embedding
+        embeddings_list.append(vec)
+        embeddings_list.append(vec + rng.normal(0, 0.001, 16).astype(np.float32))
+
+    embeddings = np.array(embeddings_list)
+    # Re-normalize
+    embeddings = embeddings / np.linalg.norm(embeddings, axis=1, keepdims=True)
+
+    accuracy = evaluate_retrieval(embeddings, halves, windows=[1])
+    # With near-identical embeddings for each pair, top-1 accuracy should be perfect
+    assert accuracy["top-1"] == 1.0
+
+
+def test_evaluate_retrieval_random_embeddings():
+    """Random embeddings should have low top-1 retrieval accuracy."""
+    rng = np.random.default_rng(42)
+    n_docs = 50
+    halves = []
+    for i in range(n_docs):
+        halves.append(HalfDocument(doc_id=f"doc-{i}", half="a", text=f"a-{i}"))
+        halves.append(HalfDocument(doc_id=f"doc-{i}", half="b", text=f"b-{i}"))
+
+    embeddings = rng.normal(0, 1, (n_docs * 2, 32)).astype(np.float32)
+    embeddings = embeddings / np.linalg.norm(embeddings, axis=1, keepdims=True)
+
+    accuracy = evaluate_retrieval(embeddings, halves, windows=[1])
+    # With random embeddings and 100 halves, top-1 accuracy should be ~1/99 ≈ 0.01
+    assert accuracy["top-1"] < 0.1

--- a/tests/embed_everything/test_sample.py
+++ b/tests/embed_everything/test_sample.py
@@ -1,0 +1,82 @@
+# Copyright 2025 The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+
+from experiments.embed_everything.sample import sample_documents
+
+
+def _write_jsonl(path: str, docs: list[dict]):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        for doc in docs:
+            f.write(json.dumps(doc) + "\n")
+
+
+def _make_docs(source: str, n: int) -> list[dict]:
+    return [{"id": f"{source}-{i}", "text": f"Document {i} from {source}.", "source": source} for i in range(n)]
+
+
+def test_sample_documents_basic(tmp_path):
+    """Samples the requested number of docs per source."""
+    source_a = tmp_path / "source_a"
+    source_b = tmp_path / "source_b"
+    _write_jsonl(str(source_a / "data.jsonl"), _make_docs("a", 50))
+    _write_jsonl(str(source_b / "data.jsonl"), _make_docs("b", 50))
+
+    output_path = str(tmp_path / "output")
+    result = sample_documents(
+        output_path=output_path,
+        source_paths={"label_a": str(source_a / "*.jsonl"), "label_b": str(source_b / "*.jsonl")},
+        n_per_source=10,
+        seed=42,
+    )
+
+    assert os.path.exists(result.path)
+    with open(result.path) as f:
+        docs = [json.loads(line) for line in f]
+
+    assert len(docs) == 20
+    labels = {d["label"] for d in docs}
+    assert labels == {"label_a", "label_b"}
+    assert sum(1 for d in docs if d["label"] == "label_a") == 10
+    assert sum(1 for d in docs if d["label"] == "label_b") == 10
+
+
+def test_sample_documents_caps_at_available(tmp_path):
+    """If a source has fewer docs than requested, returns all available."""
+    source = tmp_path / "small_source"
+    _write_jsonl(str(source / "data.jsonl"), _make_docs("small", 3))
+
+    output_path = str(tmp_path / "output")
+    result = sample_documents(
+        output_path=output_path,
+        source_paths={"small": str(source / "*.jsonl")},
+        n_per_source=100,
+        seed=42,
+    )
+
+    with open(result.path) as f:
+        docs = [json.loads(line) for line in f]
+
+    assert len(docs) == 3
+
+
+def test_sample_documents_deterministic(tmp_path):
+    """Same seed produces same sample."""
+    source = tmp_path / "source"
+    _write_jsonl(str(source / "data.jsonl"), _make_docs("det", 50))
+
+    out1 = str(tmp_path / "out1")
+    out2 = str(tmp_path / "out2")
+
+    r1 = sample_documents(output_path=out1, source_paths={"det": str(source / "*.jsonl")}, n_per_source=10, seed=42)
+    r2 = sample_documents(output_path=out2, source_paths={"det": str(source / "*.jsonl")}, n_per_source=10, seed=42)
+
+    with open(r1.path) as f:
+        docs1 = [json.loads(line) for line in f]
+    with open(r2.path) as f:
+        docs2 = [json.loads(line) for line in f]
+
+    assert [d["id"] for d in docs1] == [d["id"] for d in docs2]

--- a/uv.lock
+++ b/uv.lock
@@ -5067,6 +5067,11 @@ cpu = [
 dedup = [
     { name = "dupekit" },
 ]
+embedding = [
+    { name = "anthropic" },
+    { name = "scikit-learn" },
+    { name = "sentence-transformers" },
+]
 eval = [
     { name = "lm-eval", extra = ["api", "math"] },
 ]
@@ -5184,6 +5189,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", marker = "extra == 'embedding'" },
     { name = "antlr4-python3-runtime", marker = "extra == 'evalchemy'", specifier = "==4.11" },
     { name = "bespokelabs-curator", marker = "extra == 'evalchemy'" },
     { name = "braceexpand" },
@@ -5229,6 +5235,8 @@ requires-dist = [
     { name = "requests" },
     { name = "resiliparse", specifier = ">=0.17.2", index = "https://marin-community.github.io/chatnoir-resiliparse/simple" },
     { name = "s3fs", specifier = ">=2024" },
+    { name = "scikit-learn", marker = "extra == 'embedding'" },
+    { name = "sentence-transformers", marker = "extra == 'embedding'" },
     { name = "sqlalchemy", marker = "extra == 'evalchemy'" },
     { name = "sympy", marker = "extra == 'evalchemy'", specifier = ">=1.12.1,<1.14" },
     { name = "sympy", marker = "extra == 'math'" },
@@ -5252,7 +5260,7 @@ requires-dist = [
     { name = "warcio" },
     { name = "zephyr", editable = "lib/zephyr" },
 ]
-provides-extras = ["gpu", "tpu", "cpu", "rl", "eval", "evalchemy", "vllm", "harbor", "dedup", "math"]
+provides-extras = ["gpu", "tpu", "cpu", "rl", "eval", "evalchemy", "vllm", "harbor", "dedup", "embedding", "math"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -9335,6 +9343,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", hash = "sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459", size = 17255, upload-time = "2026-01-14T06:27:36.056Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", hash = "sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c", size = 17610, upload-time = "2026-01-14T06:27:35.218Z" },
+]
+
+[[package]]
+name = "sentence-transformers"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "torch", version = "2.9.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'extra-5-marin-cpu') or (platform_machine != 'arm64' and extra == 'extra-5-marin-cpu' and extra == 'extra-5-marin-gpu') or (platform_machine != 'arm64' and extra == 'extra-5-marin-cpu' and extra == 'extra-5-marin-vllm') or (platform_machine != 'arm64' and extra == 'extra-5-marin-cpu' and extra == 'extra-8-levanter-gpu' and extra == 'extra-8-levanter-tpu') or (platform_machine != 'arm64' and extra == 'extra-5-marin-cuda12' and extra != 'extra-5-marin-tpu' and extra == 'extra-5-marin-vllm') or (platform_machine != 'arm64' and extra != 'extra-5-marin-tpu' and extra == 'extra-8-levanter-gpu' and extra == 'extra-8-levanter-tpu') or (sys_platform != 'darwin' and extra == 'extra-5-marin-cpu' and extra == 'extra-5-marin-gpu') or (sys_platform != 'darwin' and extra == 'extra-5-marin-cpu' and extra == 'extra-5-marin-vllm') or (sys_platform != 'darwin' and extra == 'extra-5-marin-cuda12' and extra == 'extra-5-marin-vllm') or (sys_platform != 'darwin' and extra == 'extra-5-marin-gpu' and extra == 'extra-5-marin-tpu') or (sys_platform != 'darwin' and extra == 'extra-8-levanter-gpu' and extra == 'extra-8-levanter-tpu') or (sys_platform == 'darwin' and extra != 'extra-5-marin-cpu' and extra == 'extra-5-marin-tpu') or (extra != 'extra-5-marin-cpu' and extra == 'extra-5-marin-cuda12' and extra != 'extra-5-marin-tpu' and extra == 'extra-5-marin-vllm') or (extra != 'extra-5-marin-cpu' and extra != 'extra-5-marin-tpu' and extra == 'extra-8-levanter-gpu' and extra == 'extra-8-levanter-tpu')" },
+    { name = "torch", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and extra == 'extra-5-marin-gpu') or (extra == 'extra-5-marin-cpu' and extra == 'extra-5-marin-gpu') or (extra == 'extra-5-marin-cpu' and extra == 'extra-5-marin-vllm') or (extra == 'extra-5-marin-gpu' and extra == 'extra-5-marin-tpu') or (extra == 'extra-5-marin-cpu' and extra == 'extra-8-levanter-gpu' and extra == 'extra-8-levanter-tpu') or (extra == 'extra-5-marin-cuda12' and extra == 'extra-5-marin-gpu' and extra == 'extra-5-marin-vllm') or (extra == 'extra-5-marin-cuda12' and extra == 'extra-5-marin-tpu' and extra == 'extra-5-marin-vllm') or (extra == 'extra-5-marin-gpu' and extra == 'extra-8-levanter-gpu' and extra == 'extra-8-levanter-tpu') or (extra == 'extra-5-marin-tpu' and extra == 'extra-8-levanter-gpu' and extra == 'extra-8-levanter-tpu') or (extra != 'extra-5-marin-cpu' and extra != 'extra-5-marin-gpu' and extra != 'extra-5-marin-tpu')" },
+    { name = "torch", version = "2.9.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'arm64' and extra == 'extra-5-marin-cpu') or (sys_platform != 'darwin' and extra == 'extra-5-marin-cpu') or (sys_platform != 'darwin' and extra == 'extra-5-marin-tpu') or (extra == 'extra-5-marin-cpu' and extra == 'extra-5-marin-gpu') or (extra == 'extra-5-marin-cpu' and extra == 'extra-5-marin-vllm') or (extra == 'extra-5-marin-cuda12' and extra == 'extra-5-marin-vllm') or (extra == 'extra-5-marin-gpu' and extra == 'extra-5-marin-tpu') or (extra == 'extra-8-levanter-gpu' and extra == 'extra-8-levanter-tpu')" },
+    { name = "torch", version = "2.9.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-5-marin-gpu') or (extra == 'extra-5-marin-gpu' and extra == 'extra-5-marin-tpu') or (extra == 'extra-5-marin-cpu' and extra == 'extra-5-marin-gpu') or (extra == 'extra-5-marin-cpu' and extra == 'extra-5-marin-vllm') or (extra == 'extra-5-marin-cuda12' and extra == 'extra-5-marin-vllm') or (extra == 'extra-8-levanter-gpu' and extra == 'extra-8-levanter-tpu')" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/30/21664028fc0776eb1ca024879480bbbab36f02923a8ff9e4cae5a150fa35/sentence_transformers-5.2.3.tar.gz", hash = "sha256:3cd3044e1f3fe859b6a1b66336aac502eaae5d3dd7d5c8fc237f37fbf58137c7", size = 381623, upload-time = "2026-02-17T14:05:20.238Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/9f/dba4b3e18ebbe1eaa29d9f1764fbc7da0cd91937b83f2b7928d15c5d2d36/sentence_transformers-5.2.3-py3-none-any.whl", hash = "sha256:6437c62d4112b615ddebda362dfc16a4308d604c5b68125ed586e3e95d5b2e30", size = 494225, upload-time = "2026-02-17T14:05:18.596Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `experiments/embed_everything/` with a `StepSpec`-based DAG to evaluate Luxical embeddings for quality classification (linear probe → Spearman/Kendall) and topic clustering (K-Means → ARI/NMI)
- Includes oracle labeling via Claude/OpenAI (`oracle.py`), stratified document sampling from Nemotron quality buckets and Dolma source splits (`sample.py`), batch embedding computation (`embed.py`), and evaluation metrics (`evaluate.py`)
- Adds `embedding` optional dependency group (`anthropic`, `scikit-learn`, `sentence-transformers`)

Closes #3049

## Test plan

- [x] 7 unit tests covering sampling, quality probe, and topic clustering on synthetic data
- [x] All existing `pytest -m 'not slow'` tests pass (6 pre-existing failures unrelated to this change)
- [x] `pre-commit.py --all-files` passes
- [ ] CI: unit tests
- [ ] CI: lint-and-format

🤖 Generated with [Claude Code](https://claude.com/claude-code)