### PR TITLE
Make gpu_type required in ResourceConfig.with_gpu()

### DIFF
--- a/experiments/ferries/canary_ferry.py
+++ b/experiments/ferries/canary_ferry.py
@@ -57,7 +57,7 @@ NUM_STEPS = TARGET_TOKENS // (BATCH_SIZE * SEQ_LEN)
 
 def _resources(accelerator: str) -> ResourceConfig:
     if accelerator == "gpu":
-        return ResourceConfig.with_gpu(count=8, cpu=128, ram="256g", disk="256g")
+        return ResourceConfig.with_gpu("H100", count=8, cpu=128, ram="256g", disk="256g")
     elif accelerator == "tpu":
         return ResourceConfig.with_tpu("v5p-8")
     else:

--- a/experiments/ferries/canary_ferry_cw.py
+++ b/experiments/ferries/canary_ferry_cw.py
@@ -58,7 +58,7 @@ data_config = lm_data_config(
 )
 
 train_config = SimpleTrainConfig(
-    resources=ResourceConfig.with_gpu(count=8, cpu=32, ram="256g", disk="256g"),
+    resources=ResourceConfig.with_gpu("H100", count=8, cpu=32, ram="256g", disk="256g"),
     train_batch_size=BATCH_SIZE,
     num_train_steps=NUM_STEPS,
     learning_rate=3e-3,

--- a/experiments/tutorials/train_125m_fineweb_edu_gpu.py
+++ b/experiments/tutorials/train_125m_fineweb_edu_gpu.py
@@ -19,7 +19,7 @@ from experiments.simple_train_config import SimpleTrainConfig
 from experiments.speedrun.prebuilt_caches import fineweb_edu_subcache_10M
 
 llama_150m_train_config = SimpleTrainConfig(
-    resources=ResourceConfig.with_gpu(count=1),
+    resources=ResourceConfig.with_gpu("H100", count=1),
     train_batch_size=32,
     num_train_steps=1000,
     learning_rate=3e-4,

--- a/experiments/tutorials/train_tiny_model_gpu.py
+++ b/experiments/tutorials/train_tiny_model_gpu.py
@@ -36,7 +36,7 @@ wikitext_tokenized = default_tokenize(
 
 nano_train_config = SimpleTrainConfig(
     # Here we define the hardware resources we need.
-    resources=ResourceConfig.with_gpu(count=8, cpu=32, disk="128G", ram="128G"),
+    resources=ResourceConfig.with_gpu("H100", count=8, cpu=32, disk="128G", ram="128G"),
     train_batch_size=256,
     num_train_steps=100,
     learning_rate=6e-4,

--- a/lib/fray/src/fray/v1/cluster/base.py
+++ b/lib/fray/src/fray/v1/cluster/base.py
@@ -372,7 +372,7 @@ class ResourceConfig:
         return ResourceConfig(device=device, replicas=slice_count, **kwargs)
 
     @staticmethod
-    def with_gpu(gpu_type: str = "auto", count: int = 1, **kwargs) -> ResourceConfig:
+    def with_gpu(gpu_type: str, count: int = 1, **kwargs) -> ResourceConfig:
         device = GpuConfig(variant=gpu_type, count=count)
         return ResourceConfig(device=device, **kwargs)
 

--- a/lib/fray/src/fray/v2/types.py
+++ b/lib/fray/src/fray/v2/types.py
@@ -357,7 +357,7 @@ class ResourceConfig:
         return ResourceConfig(device=device, replicas=replicas, **kwargs)
 
     @staticmethod
-    def with_gpu(gpu_type: str = "auto", count: int = 1, **kwargs: Any) -> ResourceConfig:
+    def with_gpu(gpu_type: str, count: int = 1, **kwargs: Any) -> ResourceConfig:
         device = GpuConfig(variant=gpu_type, count=count)
         return ResourceConfig(device=device, **kwargs)
 


### PR DESCRIPTION
## Summary

- Make `gpu_type` a required argument in `ResourceConfig.with_gpu()` (remove `"auto"` default)
- Fix 4 call sites that relied on the default: `canary_ferry_cw.py`, `canary_ferry.py`, `train_125m_fineweb_edu_gpu.py`, `train_tiny_model_gpu.py`

## Problem

`ResourceConfig.with_gpu(count=8)` defaults `gpu_type="auto"`. This works inside the Iris scheduler ([`scheduler.py:318`](https://github.com/marin-community/marin/blob/main/lib/iris/src/iris/cluster/controller/scheduler.py#L318) — `auto` skips variant matching, job runs on any GPU worker). But on CW, when no workers are running and the K8s autoscaler needs to provision nodes, `gpu:auto` doesn't map to any node pool — the job hangs silently.

Only 4 call sites use the `auto` default. All target known GPU types:

| File | Current | Should be |
|---|---|---|
| `canary_ferry_cw.py` | `with_gpu(count=8, ...)` | `with_gpu("H100", count=8, ...)` |
| `canary_ferry.py` | `with_gpu(count=8, ...)` | `with_gpu("H100", count=8, ...)` |
| `train_125m_fineweb_edu_gpu.py` | `with_gpu(count=1)` | `with_gpu("H100", count=1)` |
| `train_tiny_model_gpu.py` | `with_gpu(count=8, ...)` | `with_gpu("H100", count=8, ...)` |

<details>
<summary>Why remove the default vs. other approaches</summary>

- **Warn/fail-fast in Iris controller**: Requires the controller to know the cluster topology at scheduling time, distinguish warm vs cold cluster, and handle multi-GPU-type clusters. Significant complexity, and the ambiguity remains in the config — users still write `gpu:auto` and discover the issue at runtime.
- **Resolve `auto` to concrete type in controller**: If only one GPU type is configured, resolve automatically. But this adds implicit behavior that varies by cluster — same config works on one cluster and fails on another. Harder to reason about.
- **Remove the default** (proposed): One-line change in Fray, 4 call site updates. Makes the footgun impossible. The GPU type is always known at config time — there's no valid use case for "I want a GPU but don't care which kind."

</details>

## Test plan

- [x] CW canary ferry [run 22634254731](https://github.com/marin-community/marin/actions/runs/22634254731) scheduled on 8xH100 with explicit `"H100"`, training reached step 51/238
- [x] `grep -r 'with_gpu(count=' --include='*.py'` confirms no other call sites rely on the default
- [x] Pre-commit passes (ruff, pyrefly type check)
- [x] Fray unit tests (140 passed)
- [x] Iris unit tests (930 passed)
- K8s autoscaler behavior can't be unit-tested — validated by prior canary runs (failure with `auto`, success with `"H100"`)
- [ ] Post-merge: CW canary ferry runs successfully with updated code

🤖 Generated with [Claude Code](https://claude.com/claude-code)