### PR TITLE
Set max_task_retries=10 for Zephyr workers to survive transient errors

### DIFF
--- a/lib/fray/src/fray/v2/iris_backend.py
+++ b/lib/fray/src/fray/v2/iris_backend.py
@@ -503,6 +503,11 @@ class FrayIrisClient:
         # Create a single job with N replicas
         # Each replica will run _host_actor with a unique task-based actor name
         entrypoint = IrisEntrypoint.from_callable(_host_actor, actor_class, args, kwargs, name)
+
+        retry_kwargs: dict[str, Any] = {}
+        if actor_config.max_task_retries is not None:
+            retry_kwargs["max_retries_failure"] = actor_config.max_task_retries
+
         job = self._iris.submit(
             entrypoint=entrypoint,
             name=name,
@@ -511,6 +516,7 @@ class FrayIrisClient:
             constraints=iris_constraints if iris_constraints else None,
             coscheduling=coscheduling,
             replicas=count,  # Create N replicas in a single job
+            **retry_kwargs,
         )
 
         return IrisActorGroup(

--- a/lib/fray/src/fray/v2/ray_backend/backend.py
+++ b/lib/fray/src/fray/v2/ray_backend/backend.py
@@ -413,6 +413,8 @@ def _actor_ray_options(resources: ResourceConfig, actor_config: ActorConfig = Ac
     # initialization beyond __init__.
     if actor_config.max_restarts is not None:
         options["max_restarts"] = actor_config.max_restarts
+    if actor_config.max_task_retries is not None:
+        options["max_task_retries"] = actor_config.max_task_retries
     if actor_config.max_concurrency > 1:
         options["max_concurrency"] = actor_config.max_concurrency
     return options

--- a/lib/fray/src/fray/v2/types.py
+++ b/lib/fray/src/fray/v2/types.py
@@ -377,12 +377,17 @@ class ActorConfig:
     `max_restarts` overrides the backend default for automatic actor restarts.
     Set to 0 for actors that must NOT auto-restart on preemption because they
     require remote initialization beyond __init__.
+
+    `max_task_retries` controls how many times a failed task (or actor
+    initialisation) is retried before being marked as permanently failed.
+    Maps to Ray's ``max_task_retries`` and Iris's ``max_retries_failure``.
     """
 
     max_concurrency: int = 1
     # TODO: max_restarts is conceptually a job-level property, revisit when we
     # drop Ray support.
     max_restarts: int | None = None
+    max_task_retries: int | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -1208,6 +1208,7 @@ class ZephyrContext:
             name=f"zephyr-{self.name}-p{self._pipeline_id}-a{attempt}-workers",
             count=actual_workers,
             resources=self.resources,
+            actor_config=ActorConfig(max_task_retries=10),
         )
 
         self._worker_count = actual_workers


### PR DESCRIPTION
Workers can fail during initialization due to transient connection errors (e.g. coordinator not ready yet). Adding max_task_retries to ActorConfig and setting it to 10 for Zephyr workers allows the backend to automatically retry failed tasks instead of permanently killing the worker.

Closes #3203

Generated with [Claude Code](https://claude.ai/code)