### PR TITLE
Cache per-window layout and permutations in BlockShufflingDataset

### DIFF
--- a/lib/levanter/src/levanter/data/permutation.py
+++ b/lib/levanter/src/levanter/data/permutation.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Optional, Sequence
 
 import jax.random
@@ -274,6 +275,7 @@ class BlockShufflingDataset(AsyncDataset[T_co]):
             raise RuntimeError("BlockShufflingDataset is not initialized")
         return self._state
 
+    @lru_cache(maxsize=4)
     def _window_layout(self, window_id: int) -> _WindowLayout:
         state = self._state_or_error()
         if window_id < 0 or window_id >= state.num_windows:
@@ -300,6 +302,7 @@ class BlockShufflingDataset(AsyncDataset[T_co]):
             full_blocks=tuple(physical_full_blocks), full_region_size=full_region_size, tail_size=tail_size
         )
 
+    @lru_cache(maxsize=4)
     def _window_full_region_permutation(self, window_id: int) -> Optional[Permutation]:
         layout = self._window_layout(window_id)
         if layout.full_region_size <= 1:
@@ -307,6 +310,7 @@ class BlockShufflingDataset(AsyncDataset[T_co]):
         key = _fold_in_on_local_cpu(self._window_full_key, window_id)
         return Permutation.make(self._perm_type, layout.full_region_size, key)
 
+    @lru_cache(maxsize=4)
     def _window_tail_region_permutation(self, window_id: int) -> Optional[Permutation]:
         layout = self._window_layout(window_id)
         if layout.tail_size <= 1:


### PR DESCRIPTION
## Summary

- Add `@lru_cache(maxsize=4)` to three per-window methods in `BlockShufflingDataset`:
  `_window_layout`, `_window_full_region_permutation`, `_window_tail_region_permutation`

Without caching, every `_map_index()` call recomputes the window layout (iterating blocks through the Feistel permutation) and constructs a new `Permutation` object. On resume with `batch_size=4096` and `prefetch_size=32`, the first loader fill maps 131,072 examples — all hitting the same few windows — causing a ~46 min CPU spin that presents as a training hang.

`maxsize=4` matches the sequential window access pattern (consistent with the existing `alru_cache(maxsize=4)` on `EraShufflingDataset` in the same file).

**Benchmarked improvement** (from #3210): 131K index mappings go from ~2,756s → ~49s.

Fixes #3210

## Test plan

- [x] `uv run pytest lib/levanter/tests/test_newdataset.py -k block_shuffl` — 3/3 pass
- [x] Canary ferry run confirmed training progresses past data load (previously hung)

🤖 Generated with [Claude Code](https://claude.com/claude-code)