### PR TITLE
Add Meta-Llama-3.1-8B-Instruct to _KNOWN_VOCAB_SIZES to avoid HF access during dry-runs

### DIFF
--- a/lib/marin/src/marin/processing/tokenize/data_configs.py
+++ b/lib/marin/src/marin/processing/tokenize/data_configs.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 _KNOWN_VOCAB_SIZES: dict[str, int] = {
     "EleutherAI/gpt-neox-20b": 50_257,
     "meta-llama/Meta-Llama-3.1-8B": 128_256,
+    "meta-llama/Meta-Llama-3.1-8B-Instruct": 128_256,
     "stanford-crfm/marin-tokenizer": 128_256,
     "marin-community/marin-tokenizer": 128_256,
     "meta-llama/Llama-2-7b": 32_000,
@@ -341,6 +342,11 @@ def get_vocab_size_for_tokenizer(tokenizer_name: str) -> int:
     if resolved_name in _KNOWN_VOCAB_SIZES:
         return _KNOWN_VOCAB_SIZES[resolved_name]
 
+    logger.warning(
+        "Tokenizer %r not found in _KNOWN_VOCAB_SIZES; loading from HuggingFace. "
+        "Consider adding it to _KNOWN_VOCAB_SIZES in data_configs.py to avoid network calls during dry-runs.",
+        resolved_name,
+    )
     tokenizer = _load_tokenizer(resolved_name)
     return len(tokenizer)
 


### PR DESCRIPTION
The dry-run test for exp945_spoonbill_sft_sweep.py was failing because get_vocab_size_for_tokenizer() fell through to loading the tokenizer from HuggingFace when it wasn't found in _KNOWN_VOCAB_SIZES. This caused 429 rate-limit errors in CI. The Instruct variant uses the same tokenizer as the base model (128,256 vocab size).

Also adds a warning log when falling through to HF loading so future missing entries are caught early.