### PR TITLE
Use GHCR weekly image as Docker build cache source

### DIFF
--- a/lib/iris/src/iris/cli/build.py
+++ b/lib/iris/src/iris/cli/build.py
@@ -189,6 +189,12 @@ def build_image(
     for t in all_tags:
         cmd.extend(["-t", t])
     cmd.extend(["-f", str(dockerfile_path)])
+
+    # Use the weekly GHCR image as a build cache source so that cold builds
+    # (new runner, branch switch) only rebuild layers that actually changed.
+    cache_ref = f"ghcr.io/{ghcr_org}/iris-{image_type}:latest"
+    cmd.extend(["--cache-from", f"type=registry,ref={cache_ref}"])
+
     cmd.extend(["--output", f"type=docker,compression=zstd,compression-level=1,name={tag}"])
     cmd.append(str(context_path))
 


### PR DESCRIPTION
## Summary

- Add `--cache-from type=registry,ref=ghcr.io/.../iris-{type}:latest` to `build_image()` so cold Docker builds pull cached layers from the weekly GHCR image instead of rebuilding from scratch.

Cold `iris cluster start` drops from **~23 min to ~5 min** (matching warm-build times).

This also benefits local `iris job run` usage: `build_image()` is the shared build path for all iris Docker images, so anyone with a cold local Docker cache (after a prune, branch switch, or fresh checkout) will pull cached layers from GHCR instead of rebuilding ~20 min of base/dependency layers from scratch.

## Verification

Nuked both CW nodepools and the stale node, then triggered a fresh canary run ([run 22652302115](https://github.com/marin-community/marin/actions/runs/22652302115)). Docker build completed in ~5 min on a completely cold cluster.

| Run | Cluster start | Cache state |
|-----|:---:|-------------|
| [22527166946](https://github.com/marin-community/marin/actions/runs/22527166946) | 21 min | Cold (before this fix) |
| [22629113509](https://github.com/marin-community/marin/actions/runs/22629113509) | 23 min | Cold (before this fix) |
| 22652302115 | ~5 min | Cold (with this fix, nuked nodepools) |

## Note on `--cache-to type=inline`

Local experiments with an isolated `docker-container` BuildKit builder suggested that `--cache-from` would not work without also adding `--cache-to type=inline` to the weekly image workflow. The end-to-end test above shows that the production builder path matches layers from the registry image without inline metadata. `--cache-to type=inline` is a nice-to-have for robustness but not required for the observed speedup.

## Test plan

- [ ] CI passes (iris tests, pre-commit)
- [ ] Verify on next cold CW canary run that cluster start stays ~5 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)