### PR TITLE
docs: fix broken executor docs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ if __name__ == "__main__":
     ])
 ```
 
-Here, we create two [steps](docs/explanation/executor.md#steps), one for tokenizing the dataset and one for training the model.
+Here, we create two [steps](docs/explanations/executor.md#steps), one for tokenizing the dataset and one for training the model.
 The training step depends on the tokenized dataset step, so it will be executed after the tokenization step is completed.
 
 <!--marin-example-end-->


### PR DESCRIPTION
## Summary
- fix a broken README link from `docs/explanation/executor.md#steps` to `docs/explanations/executor.md#steps`
- keep docs/code parity for the executor documentation path used by the current docs tree

## Validation
- searched repo for stale `docs/explanation/` reference and confirmed none remain in docs scope

Refs #12
