### PR TITLE
docs: fix stale README tutorial script path

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Marin experiments are defined as a set of steps that can depend on each other an
 like a Makefile.
 
 As a brief example of how you can use Marin, here is a complete script for training a tiny model on [TinyStories](https://huggingface.co/datasets/roneneldan/TinyStories).
-You can check out the [full script](https://github.com/marin-community/marin/blob/main/experiments/tutorial/train_tiny_model_cpu.py) for more details.
+You can check out the [full script](https://github.com/marin-community/marin/blob/main/experiments/tutorials/train_tiny_model_cpu.py) for more details.
 
 <!--marin-example-start-->
 


### PR DESCRIPTION
## Summary
- fix README's tiny model example link to the current script path under `experiments/tutorials/`

## Why
- docs/code parity: the README linked to `experiments/tutorial/train_tiny_model_cpu.py`, but repository code uses `experiments/tutorials/train_tiny_model_cpu.py`

Refs #12
