### PR TITLE
Add inline cache to Iris image publishes

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -187,9 +187,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Build and push ${{ matrix.image }}
+      - name: Build and push ${{ matrix.image }} with inline cache
         run: |
           docker buildx build --file ${{ matrix.dockerfile }} \
+            --cache-to type=inline \
             --provenance=false \
             --tag ghcr.io/marin-community/${{ matrix.image }}:latest \
             --tag ghcr.io/marin-community/${{ matrix.image }}:${{ steps.set-tags.outputs.DATE_TAG }} \


### PR DESCRIPTION
Add inline cache metadata to the weekly GHCR `iris-images` publish workflow so fresh GitHub runners can reuse `iris-worker`, `iris-controller`, and `iris-task` more effectively through the existing `--cache-from ...:latest` path used by `iris cluster start`.

- Add `--cache-to type=inline` to the GHCR `iris-images` build step.
- Rename the workflow step to make the inline-cache intent explicit.
- Leave the CW canary workflow and Iris runtime/build logic unchanged.

The CW GPU canary cache probe showed that `iris-task` on a fresh GitHub runner rebuilt in `43s` with `0` cached steps without inline cache, and in `24s` with `5` cached steps with inline cache.

Fixes #3238
