### PR TITLE
Re-enable daily CW GPU canary ferry schedule

### DIFF
--- a/.github/workflows/marin-canary-ferry-cw.yaml
+++ b/.github/workflows/marin-canary-ferry-cw.yaml
@@ -1,8 +1,8 @@
 name: Marin - CoreWeave GPU Canary Ferry
 
 on:
-  # schedule:
-  #   - cron: '0 10 * * *'  # Daily at 10 AM UTC — disabled until worker overwhelm is fixed (#3062)
+  schedule:
+    - cron: '0 10 * * *'  # Daily at 10 AM UTC
   workflow_dispatch:
 
 permissions:
@@ -48,8 +48,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start CoreWeave cluster
-        run: .venv/bin/iris --config=lib/iris/examples/coreweave.yaml cluster start
+        run: .venv/bin/iris -v --config=lib/iris/examples/coreweave.yaml cluster start
         env:
+          BUILDKIT_PROGRESS: plain
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
 


### PR DESCRIPTION
## Summary

- Re-enable the daily 10 AM UTC cron trigger for the CW GPU canary ferry
- Was disabled in #3088 due to worker overwhelm (#3062)
- Recent manual runs on main complete successfully (e.g. [run 22671232128](https://github.com/marin-community/marin/actions/runs/22671232128) — 1906 steps, no OOM, clean eval)

## Test plan

- [x] Manual `workflow_dispatch` run on main succeeded today
- [ ] Observe first scheduled run tomorrow at 10 AM UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)