### PR TITLE
fix(iris): fix parallel CLI tunnel port collisions and improve RPC retry

### DIFF
--- a/lib/iris/src/iris/cluster/client/remote_client.py
+++ b/lib/iris/src/iris/cluster/client/remote_client.py
@@ -260,9 +260,12 @@ class RemoteClusterClient:
         self._client.unregister_endpoint(request)
 
     def list_endpoints(self, prefix: str) -> list[cluster_pb2.Controller.Endpoint]:
-        request = cluster_pb2.Controller.ListEndpointsRequest(prefix=prefix)
-        response = self._client.list_endpoints(request, timeout_ms=10_000)
-        return list(response.endpoints)
+        def _call():
+            request = cluster_pb2.Controller.ListEndpointsRequest(prefix=prefix)
+            response = self._client.list_endpoints(request, timeout_ms=10_000)
+            return list(response.endpoints)
+
+        return call_with_retry("list_endpoints", _call)
 
     def list_workers(self) -> list[cluster_pb2.Controller.WorkerHealthStatus]:
         """List all workers registered with the controller."""
@@ -364,5 +367,9 @@ class RemoteClusterClient:
         Returns:
             GetAutoscalerStatusResponse proto with autoscaler status and recent actions
         """
-        request = cluster_pb2.Controller.GetAutoscalerStatusRequest()
-        return self._client.get_autoscaler_status(request)
+
+        def _call():
+            request = cluster_pb2.Controller.GetAutoscalerStatusRequest()
+            return self._client.get_autoscaler_status(request)
+
+        return call_with_retry("get_autoscaler_status", _call)

--- a/lib/iris/src/iris/cluster/platform/coreweave.py
+++ b/lib/iris/src/iris/cluster/platform/coreweave.py
@@ -1441,7 +1441,7 @@ def _coreweave_tunnel(
     exits (e.g. konnectivity timeout), it is relaunched automatically.
     """
     if local_port is None:
-        local_port = find_free_port(start=10000)
+        local_port = find_free_port()
 
     deadline = Deadline.from_seconds(timeout)
     backoff = ExponentialBackoff(initial=1.0, maximum=10.0, factor=2.0)

--- a/lib/iris/src/iris/cluster/platform/gcp.py
+++ b/lib/iris/src/iris/cluster/platform/gcp.py
@@ -1453,7 +1453,7 @@ def _gcp_tunnel(
     Picks a free port automatically if none is specified.
     """
     if local_port is None:
-        local_port = find_free_port(start=10000)
+        local_port = find_free_port()
 
     labels = Labels(label_prefix)
     label_filter = f"labels.{labels.iris_controller}=true AND status=RUNNING"

--- a/lib/iris/src/iris/rpc/errors.py
+++ b/lib/iris/src/iris/rpc/errors.py
@@ -121,7 +121,7 @@ def call_with_retry(
     call_fn: Callable[[], T],
     *,
     on_retry: Callable[[Exception], None] | None = None,
-    max_attempts: int = 5,
+    max_attempts: int = 8,
     backoff: ExponentialBackoff | None = None,
 ) -> T:
     """Execute an RPC call with exponential backoff retry.
@@ -132,10 +132,10 @@ def call_with_retry(
         on_retry: Optional callback invoked with the exception on every retryable
             failure, including the final attempt. Useful for clearing cached
             connections so subsequent calls can re-resolve endpoints.
-        max_attempts: Maximum number of attempts (default: 5)
+        max_attempts: Maximum number of attempts (default: 8)
         backoff: Backoff configuration. A fresh copy is made internally so the
             caller's instance is not mutated. Defaults to
-            ExponentialBackoff(initial=0.1, maximum=5.0, factor=2.0).
+            ExponentialBackoff(initial=0.5, maximum=10.0, factor=2.0).
 
     Returns:
         Result from call_fn
@@ -144,7 +144,7 @@ def call_with_retry(
         Exception from call_fn if all retries exhausted or error is not retryable
     """
     if backoff is None:
-        backoff = ExponentialBackoff(initial=0.1, maximum=5.0, factor=2.0)
+        backoff = ExponentialBackoff(initial=0.5, maximum=10.0, factor=2.0)
     else:
         backoff = backoff.copy()
     last_exception = None


### PR DESCRIPTION
- Use kernel-assigned ephemeral ports instead of sequential scan from 10000 to eliminate TOCTOU race when multiple CLI processes create SSH tunnels concurrently
- Increase retry budget (8 attempts, 0.5→10s backoff) to survive longer tunnel disruptions
- Add `call_with_retry` to `list_endpoints` and `get_autoscaler_status` (previously missing)

Fixes #3228
