### PR TITLE
feat(iris): parallelize scaling group restoration on startup

### DIFF
--- a/lib/iris/src/iris/cli/cluster.py
+++ b/lib/iris/src/iris/cli/cluster.py
@@ -540,20 +540,12 @@ def controller_restart(ctx, bundle_prefix: str | None):
         for name, tag in built.items():
             click.echo(f"  {name}: {tag}")
 
-    # Stop controller
+    # Restart controller in-place (re-runs bootstrap on existing VM)
     iris_config = IrisConfig(config)
     platform = iris_config.platform()
     try:
-        platform.stop_controller(config)
+        address = platform.restart_controller(config)
     except Exception as e:
-        click.echo(f"Failed to stop controller: {e}", err=True)
-        raise SystemExit(1) from e
-    click.echo("Controller stopped.")
-
-    # Start new controller (auto-restores from latest.json in storage)
-    try:
-        address = platform.start_controller(config)
-    except Exception as e:
-        click.echo(f"Failed to start controller: {e}", err=True)
+        click.echo(f"Failed to restart controller: {e}", err=True)
         raise SystemExit(1) from e
     click.echo(f"Controller restarted at {address}")

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -8,6 +8,7 @@ import queue
 import sys
 import threading
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field, replace
 from time import sleep
 from typing import Protocol
@@ -1313,8 +1314,9 @@ class Controller:
             result.endpoint_count,
         )
 
-        # Restore autoscaler scaling groups
+        # Restore autoscaler scaling groups (parallelized — each calls platform.list_slices())
         if self._autoscaler is not None:
+            groups_to_restore = []
             for group_snap in proto.scaling_groups:
                 group = self._autoscaler.groups.get(group_snap.name)
                 if group is None:
@@ -1323,21 +1325,25 @@ class Controller:
                         group_snap.name,
                     )
                     continue
-                restore_result = restore_scaling_group(
-                    group_snap,
-                    group.platform,
-                    group.config,
-                    group.label_prefix,
-                )
-                group.restore_from_snapshot(
-                    slices=restore_result.slices,
-                    consecutive_failures=restore_result.consecutive_failures,
-                    last_scale_up=restore_result.last_scale_up,
-                    last_scale_down=restore_result.last_scale_down,
-                    backoff_until=restore_result.backoff_until,
-                    quota_exceeded_until=restore_result.quota_exceeded_until,
-                    quota_reason=restore_result.quota_reason,
-                )
+                groups_to_restore.append((group_snap, group))
+
+            with ThreadPoolExecutor(max_workers=16) as executor:
+                futures = {
+                    executor.submit(restore_scaling_group, gs, g.platform, g.config, g.label_prefix): (gs, g)
+                    for gs, g in groups_to_restore
+                }
+                for future in as_completed(futures):
+                    group_snap, group = futures[future]
+                    restore_result = future.result()
+                    group.restore_from_snapshot(
+                        slices=restore_result.slices,
+                        consecutive_failures=restore_result.consecutive_failures,
+                        last_scale_up=restore_result.last_scale_up,
+                        last_scale_down=restore_result.last_scale_down,
+                        backoff_until=restore_result.backoff_until,
+                        quota_exceeded_until=restore_result.quota_exceeded_until,
+                        quota_reason=restore_result.quota_reason,
+                    )
 
             # Workers from discarded slices remain in ControllerState as healthy.
             # They will naturally fail heartbeat checks and be pruned once

--- a/lib/iris/src/iris/cluster/controller/vm_lifecycle.py
+++ b/lib/iris/src/iris/cluster/controller/vm_lifecycle.py
@@ -381,6 +381,37 @@ def start_controller(
     return address, vm
 
 
+def restart_controller(
+    platform: Platform,
+    config: config_pb2.IrisClusterConfig,
+) -> tuple[str, StandaloneWorkerHandle]:
+    """Restart controller container in-place on existing VM.
+
+    Re-runs the bootstrap script on the existing controller VM, which stops the
+    running container, pulls the latest image, and starts a new container.
+    Much faster than a full stop+start cycle since it skips VM creation.
+    """
+    label_prefix = config.platform.label_prefix or "iris"
+    zones = _controller_zones(config)
+    port = _controller_port(config)
+
+    vm = _discover_controller_vm(platform, zones, label_prefix)
+    if vm is None:
+        raise RuntimeError("No existing controller VM found. Use 'iris cluster start' to create one first.")
+
+    logger.info("Restarting controller container in-place on VM %s", vm.vm_id)
+
+    bootstrap_script = build_controller_bootstrap_script_from_config(config, platform=platform)
+    vm.bootstrap(bootstrap_script)
+
+    address = f"http://{vm.internal_address}:{port}"
+    if not wait_healthy(vm, port):
+        raise RuntimeError(f"Controller at {address} failed health check after restart")
+
+    logger.info("Controller container restarted at %s", address)
+    return address, vm
+
+
 def stop_controller(platform: Platform, config: config_pb2.IrisClusterConfig) -> None:
     """Find and terminate the controller VM."""
     label_prefix = config.platform.label_prefix or "iris"

--- a/lib/iris/src/iris/cluster/platform/base.py
+++ b/lib/iris/src/iris/cluster/platform/base.py
@@ -438,6 +438,15 @@ class Platform(Protocol):
         """
         ...
 
+    def restart_controller(self, config: config_pb2.IrisClusterConfig) -> str:
+        """Restart controller in-place without destroying underlying compute.
+
+        Re-runs the bootstrap script on the existing VM/pod to pull the latest
+        image and restart the container. Falls back to stop+start semantics on
+        platforms where in-place restart isn't meaningful (e.g. CoreWeave).
+        """
+        ...
+
     def stop_controller(self, config: config_pb2.IrisClusterConfig) -> None:
         """Stop the controller.
 

--- a/lib/iris/src/iris/cluster/platform/bootstrap.py
+++ b/lib/iris/src/iris/cluster/platform/bootstrap.py
@@ -333,8 +333,9 @@ echo "[iris-controller] [5/5] Controller container started"
 # Wait for health
 echo "[iris-controller] Waiting for controller to become healthy..."
 RESTART_COUNT=0
-for i in $(seq 1 30); do
-    echo "[iris-controller] Health check attempt $i/30 at $(date -Iseconds)..."
+MAX_ATTEMPTS=150
+for i in $(seq 1 $MAX_ATTEMPTS); do
+    echo "[iris-controller] Health check attempt $i/$MAX_ATTEMPTS at $(date -Iseconds)..."
     if curl -sf http://localhost:{{ port }}/health > /dev/null 2>&1; then
         echo "[iris-controller] ================================================"
         echo "[iris-controller] Controller is healthy! Bootstrap complete."
@@ -366,7 +367,7 @@ for i in $(seq 1 30); do
 done
 
 echo "[iris-controller] ================================================"
-echo "[iris-controller] ERROR: Controller failed to become healthy after 60 seconds"
+echo "[iris-controller] ERROR: Controller failed to become healthy after 300 seconds"
 echo "[iris-controller] ================================================"
 echo "[iris-controller] Full container logs:"
 sudo docker logs {{ container_name }} 2>&1

--- a/lib/iris/src/iris/cluster/platform/coreweave.py
+++ b/lib/iris/src/iris/cluster/platform/coreweave.py
@@ -1106,6 +1106,10 @@ class CoreweavePlatform:
 
         return self.discover_controller(config.controller)
 
+    def restart_controller(self, config: config_pb2.IrisClusterConfig) -> str:
+        """Restart controller by re-applying manifests and rolling restart."""
+        return self.start_controller(config)
+
     def stop_controller(self, config: config_pb2.IrisClusterConfig) -> None:
         """Stop the controller by deleting its K8s resources."""
         cw = config.controller.coreweave

--- a/lib/iris/src/iris/cluster/platform/gcp.py
+++ b/lib/iris/src/iris/cluster/platform/gcp.py
@@ -44,6 +44,7 @@ from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 
+from iris.cluster.controller.vm_lifecycle import restart_controller as vm_restart_controller
 from iris.cluster.controller.vm_lifecycle import start_controller as vm_start_controller
 from iris.cluster.controller.vm_lifecycle import stop_controller as vm_stop_controller
 from iris.cluster.platform._worker_base import RemoteExecWorkerBase
@@ -1334,6 +1335,11 @@ class GcpPlatform:
     def start_controller(self, config: config_pb2.IrisClusterConfig) -> str:
         """Start or discover existing controller on GCP. Returns address (host:port)."""
         address, _vm = vm_start_controller(self, config)
+        return address
+
+    def restart_controller(self, config: config_pb2.IrisClusterConfig) -> str:
+        """Restart controller container in-place on existing GCP VM."""
+        address, _vm = vm_restart_controller(self, config)
         return address
 
     def stop_controller(self, config: config_pb2.IrisClusterConfig) -> None:

--- a/lib/iris/src/iris/cluster/platform/local.py
+++ b/lib/iris/src/iris/cluster/platform/local.py
@@ -614,6 +614,9 @@ class LocalPlatform:
         self._local_controller = controller
         return address
 
+    def restart_controller(self, config: config_pb2.IrisClusterConfig) -> str:
+        raise NotImplementedError("restart_controller not supported for local clusters")
+
     def stop_controller(self, config: config_pb2.IrisClusterConfig) -> None:
         """Stop the in-process LocalController."""
         from iris.cluster.controller.local import LocalController

--- a/lib/iris/src/iris/cluster/platform/manual.py
+++ b/lib/iris/src/iris/cluster/platform/manual.py
@@ -30,6 +30,7 @@ from collections.abc import Callable
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, field
 
+from iris.cluster.controller.vm_lifecycle import restart_controller as vm_restart_controller
 from iris.cluster.controller.vm_lifecycle import start_controller as vm_start_controller
 from iris.cluster.controller.vm_lifecycle import stop_controller as vm_stop_controller
 from iris.cluster.platform._worker_base import RemoteExecWorkerBase
@@ -428,6 +429,11 @@ class ManualPlatform:
     def start_controller(self, config: config_pb2.IrisClusterConfig) -> str:
         """Start or discover existing controller on a manual host. Returns address (host:port)."""
         address, _vm = vm_start_controller(self, config)
+        return address
+
+    def restart_controller(self, config: config_pb2.IrisClusterConfig) -> str:
+        """Restart controller container in-place on the manual host."""
+        address, _vm = vm_restart_controller(self, config)
         return address
 
     def stop_controller(self, config: config_pb2.IrisClusterConfig) -> None:


### PR DESCRIPTION
- Parallelize scaling group restoration during controller startup using `ThreadPoolExecutor(max_workers=16)` — each group calls `platform.list_slices()` which is I/O bound, so running 67 groups sequentially takes ~150s, exceeding the 60s bootstrap timeout
- Increase bootstrap health check timeout from 60s to 300s as safety margin