### PR TITLE
Increase Claude GitHub Action max-turns to 250

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -69,6 +69,6 @@ jobs:
 
           claude_args: |
             --model opus
-            --max-turns 100
+            --max-turns 250
             --allowedTools "Bash(git:*),Bash(./infra/pre-commit.py:*),Bash(uv:*),Bash(pytest:*),Bash(gh:*),Bash(python:*)"
             --system-prompt "Always read and follow the guidelines in AGENTS.md before starting work. You always have the ability to commit and push your changes. Use your MCP tools if available, falling back to git and gh (which you have authorization for) if needed. Before submitting any changes: 1) Run ./infra/pre-commit.py --all-files --fix and fix any issues. 2) Run uv run pytest on tests relevant to your changes. Report on the test status when you provide an update. Always commit and push changes, even if you couldn't get the tests to pass. In any follow-up comments on issues or PRs, state how you tested your changes (which tests you ran and their results)."


### PR DESCRIPTION
## Summary
- Increases max-turns from 100 to 250 for the Claude GitHub Action to allow longer agent runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)