### PR TITLE
feat(zephyr): support generator reducers in group_by

### DIFF
--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -11,6 +11,7 @@ knowledge of logical operation types.
 from __future__ import annotations
 
 import heapq
+import inspect
 import logging
 import os
 import zlib
@@ -154,8 +155,12 @@ def _flatmap_gen(stream: Iterator, fn: Callable) -> Iterator:
 
 
 def _reduce_gen(shard: Any, key_fn: Callable, reducer_fn: Callable) -> Iterator:
+    is_gen = inspect.isgeneratorfunction(reducer_fn)
     for key, items_iter in _merge_sorted_chunks(shard, key_fn):
-        yield reducer_fn(key, items_iter)
+        if is_gen:
+            yield from reducer_fn(key, items_iter)
+        else:
+            yield reducer_fn(key, items_iter)
 
 
 def _select_gen(stream: Iterator, columns: tuple[str, ...]) -> Iterator:

--- a/lib/zephyr/tests/test_groupby.py
+++ b/lib/zephyr/tests/test_groupby.py
@@ -210,6 +210,37 @@ def test_group_by_with_hash_key_large(zephyr_ctx, large_document_dataset):
     assert len(set(hashes)) == 100
 
 
+def test_group_by_generator_reducer(zephyr_ctx):
+    """Test group_by with a generator reducer that yields multiple items per group."""
+    data = [
+        {"cat": "A", "val": 1},
+        {"cat": "B", "val": 2},
+        {"cat": "A", "val": 3},
+        {"cat": "B", "val": 5},
+    ]
+
+    def explode_reducer(key, items):
+        """Generator reducer: yield each item individually with group metadata."""
+        for item in items:
+            yield {"cat": key, "val": item["val"], "from_group": True}
+
+    ds = Dataset.from_list(data).group_by(
+        key=lambda x: x["cat"],
+        reducer=explode_reducer,
+    )
+
+    results = list(zephyr_ctx.execute(ds))
+
+    # Generator reducer should flatten: 4 items total (2 from A, 2 from B)
+    assert len(results) == 4
+
+    results = sorted(results, key=lambda x: (x["cat"], x["val"]))
+    assert results[0] == {"cat": "A", "val": 1, "from_group": True}
+    assert results[1] == {"cat": "A", "val": 3, "from_group": True}
+    assert results[2] == {"cat": "B", "val": 2, "from_group": True}
+    assert results[3] == {"cat": "B", "val": 5, "from_group": True}
+
+
 def test_group_by_with_none_and_filter(zephyr_ctx):
     """Test group_by with None results followed by filter operations."""
     data = [


### PR DESCRIPTION
## Summary
- When `group_by`'s reducer is a generator function, `_reduce_gen` now uses `yield from` to flatten the output instead of yielding the generator object as a single item
- Detection uses `inspect.isgeneratorfunction()` so existing non-generator reducers are unaffected

Fixes #3246

## Test plan
- [x] Added `test_group_by_generator_reducer` verifying a generator reducer that yields multiple items per group produces a flattened stream
- [x] All existing groupby tests pass (36/36)

🤖 Generated with [Claude Code](https://claude.com/claude-code)