### PR TITLE
Remove resources/env_vars from ExecutorStep; use @remote for dispatch

### DIFF
--- a/experiments/defaults.py
+++ b/experiments/defaults.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import jmp
 from fray.v2 import ResourceConfig
+from marin.execution.remote import remote
 from haliax.partitioning import ResourceAxis
 from haliax.quantization import QuantizationConfig
 from levanter.checkpoint import CheckpointerConfig
@@ -206,16 +207,19 @@ def default_tokenize(
     return ExecutorStep(
         name=os.path.join("tokenized", name),
         description=f"Tokenize raw text using the {tokenizer} tokenizer.",
-        fn=tokenize,
+        fn=remote(
+            tokenize,
+            resources=ResourceConfig.with_cpu(cpu=4, ram="16g", disk="10g"),
+            pip_dependency_groups=["cpu"],
+            env_vars={
+                "TRANSFORMERS_NO_TORCH": "1",
+                "TRANSFORMERS_NO_TORCHVISION": "1",
+                "USE_TORCH": "0",
+                "TORCH_DISABLE_GLOBAL_DEPS": "1",
+            },
+        ),
         config=config,
-        resources=ResourceConfig.with_cpu(cpu=4, ram="16g", disk="10g"),
         pip_dependency_groups=["cpu"],
-        env_vars={
-            "TRANSFORMERS_NO_TORCH": "1",
-            "TRANSFORMERS_NO_TORCHVISION": "1",
-            "USE_TORCH": "0",
-            "TORCH_DISABLE_GLOBAL_DEPS": "1",
-        },
     )
 
 

--- a/experiments/evals/evals.py
+++ b/experiments/evals/evals.py
@@ -12,6 +12,7 @@ from collections.abc import Sequence
 from fray.cluster import ResourceConfig
 from marin.evaluation.evaluation_config import EvalTaskConfig, EvaluationConfig
 from marin.evaluation.run import evaluate
+from marin.execution.remote import remote
 from marin.execution.executor import (
     ExecutorStep,
     InputName,
@@ -437,9 +438,12 @@ def evaluate_harbor(
         }
     }
 
+    # When model_path is set, the evaluator launches a fray sub-job for vLLM serving
+    # with the correct resources. The outer executor step runs on CPU.
+    dispatch_resources = ResourceConfig.with_cpu() if model_path else resource_config
     return ExecutorStep(
         name=f"evaluation/harbor/{model_name}-{dataset}-{version}",
-        fn=evaluate,
+        fn=remote(evaluate, resources=dispatch_resources, pip_dependency_groups=["harbor"]),
         config=EvaluationConfig(
             evaluator="harbor",
             model_name=model_name,
@@ -456,9 +460,6 @@ def evaluate_harbor(
             generation_params=generation_params,
         ),
         pip_dependency_groups=["harbor"],
-        # When model_path is set, the evaluator launches a fray sub-job for vLLM serving
-        # with the correct resources. The outer executor step runs on CPU.
-        resources=ResourceConfig.with_cpu() if model_path else resource_config,
     )
 
 

--- a/experiments/grug/base/launch.py
+++ b/experiments/grug/base/launch.py
@@ -22,6 +22,7 @@ from levanter.tracker import TrackerConfig
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
 from marin.execution.executor import ExecutorStep, executor_main, this_output_path, versioned
+from marin.execution.remote import remote
 from marin.processing.tokenize import add_validation_sets_to_mixture
 
 from experiments.defaults import default_validation_sets
@@ -121,7 +122,7 @@ RESOLVED_RUN_ID = _resolve_run_id("grug-base-trial")
 
 grug_base_trial = ExecutorStep(
     name="grug/base-trial",
-    fn=run_grug_base_trial,
+    fn=remote(run_grug_base_trial, resources=ResourceConfig.with_tpu("v5p-8")),
     config=GrugBaseLaunchConfig(
         model=versioned(GRUG_130M_MODEL),
         data=NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
@@ -166,7 +167,6 @@ grug_base_trial = ExecutorStep(
             )
         ),
     ),
-    resources=ResourceConfig.with_tpu("v5p-8"),
 )
 
 

--- a/experiments/grug/moe/launch.py
+++ b/experiments/grug/moe/launch.py
@@ -22,6 +22,7 @@ from levanter.tracker import TrackerConfig
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
 from marin.execution.executor import ExecutorStep, executor_main, this_output_path, versioned
+from marin.execution.remote import remote
 from marin.processing.tokenize import add_validation_sets_to_mixture
 
 from experiments.defaults import default_validation_sets
@@ -124,7 +125,7 @@ RESOLVED_RUN_ID = _resolve_run_id("grug-moe-trial")
 
 grug_moe_trial = ExecutorStep(
     name="grug/moe-trial",
-    fn=run_grug_moe_trial,
+    fn=remote(run_grug_moe_trial, resources=ResourceConfig.with_tpu("v5p-8")),
     config=GrugMoeLaunchConfig(
         model=versioned(GRUG_MOE_TRIAL_MODEL),
         data=NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
@@ -169,7 +170,6 @@ grug_moe_trial = ExecutorStep(
             )
         ),
     ),
-    resources=ResourceConfig.with_tpu("v5p-8"),
 )
 
 

--- a/experiments/references/reference_hyperparameter_sweep.py
+++ b/experiments/references/reference_hyperparameter_sweep.py
@@ -23,6 +23,7 @@ from experiments.grug.base.train import GrugEvalConfig, GrugTrainerConfig
 from experiments.pretraining_datasets.nemotron import nemotron_mix
 from fray.cluster import ResourceConfig
 from marin.execution.executor import ExecutorStep, executor_main, this_output_path
+from marin.execution.remote import remote
 from marin.processing.tokenize import add_validation_sets_to_mixture
 
 FloatRange = tuple[float, float]
@@ -532,7 +533,7 @@ def _build_suggest_step(
     client_id = f"{SWEEP.client_id_prefix}-loop-{loop_index}"
     return ExecutorStep(
         name=f"{SWEEP.experiment_name}-suggest-loop{loop_index}",
-        fn=run_vizier_suggest,
+        fn=remote(run_vizier_suggest, resources=ResourceConfig.with_cpu(), pip_dependency_groups=["vizier"]),
         config=VizierSuggestConfig(
             study_owner=SWEEP.study_owner,
             study_id=SWEEP.study_id,
@@ -547,7 +548,6 @@ def _build_suggest_step(
             loop_index=loop_index,
         ),
         pip_dependency_groups=["vizier"],
-        resources=ResourceConfig.with_cpu(),
     )
 
 
@@ -563,7 +563,7 @@ def _build_train_step(
             "checkpoints",
             f"{SWEEP.client_id_prefix}-loop{loop_index}-trial{suggestion_index}",
         ),
-        fn=run_vizier_train,
+        fn=remote(run_vizier_train, resources=ResourceConfig.with_tpu("v4-8")),
         config=VizierTrainConfig(
             suggestions_path=suggestions_path,
             suggestion_index=suggestion_index,
@@ -573,7 +573,6 @@ def _build_train_step(
             fixed_batch_size=SWEEP.fixed_batch_size,
             loop_index=loop_index,
         ),
-        resources=ResourceConfig.with_tpu("v4-8"),
     )
 
 
@@ -587,7 +586,7 @@ def _build_update_step(
 ) -> ExecutorStep:
     return ExecutorStep(
         name=f"{SWEEP.experiment_name}-update-loop{loop_index}",
-        fn=run_vizier_update,
+        fn=remote(run_vizier_update, resources=ResourceConfig.with_cpu(), pip_dependency_groups=["vizier"]),
         config=VizierUpdateConfig(
             study_id=SWEEP.study_id,
             study_resource_name=study_resource_name,
@@ -601,7 +600,6 @@ def _build_update_step(
             loop_index=loop_index,
         ),
         pip_dependency_groups=["vizier"],
-        resources=ResourceConfig.with_cpu(),
     )
 
 
@@ -612,7 +610,7 @@ def _build_optimal_step(
 ) -> ExecutorStep:
     return ExecutorStep(
         name=f"{SWEEP.experiment_name}-optimal",
-        fn=run_vizier_optimal,
+        fn=remote(run_vizier_optimal, resources=ResourceConfig.with_cpu(), pip_dependency_groups=["vizier"]),
         config=VizierOptimalConfig(
             study_id=SWEEP.study_id,
             study_resource_name=study_resource_name,
@@ -620,7 +618,6 @@ def _build_optimal_step(
             output_path=this_output_path(),
         ),
         pip_dependency_groups=["vizier"],
-        resources=ResourceConfig.with_cpu(),
     )
 
 

--- a/experiments/references/reference_training_pipeline.py
+++ b/experiments/references/reference_training_pipeline.py
@@ -27,6 +27,7 @@ from experiments.pretraining_datasets.dclm import dclm_components_llama3
 from experiments.pretraining_datasets.dolmino import tokenize_dolmino
 from fray.cluster import ResourceConfig
 from marin.execution.executor import ExecutorStep, executor_main, this_output_path
+from marin.execution.remote import remote
 from marin.processing.tokenize import add_validation_sets_to_mixture
 from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
 
@@ -79,7 +80,7 @@ data = add_validation_sets_to_mixture(data, default_validation_sets(tokenizer=da
 # --- Training ---
 training_step = ExecutorStep(
     name="reference-pipeline",
-    fn=run_grug_base_trial,
+    fn=remote(run_grug_base_trial, resources=ResourceConfig.with_tpu("v4-8")),
     config=GrugBaseLaunchConfig(
         model=model,
         data=data,
@@ -105,7 +106,6 @@ training_step = ExecutorStep(
             steps_per_eval=500,
         ),
     ),
-    resources=ResourceConfig.with_tpu("v4-8"),
 )
 
 if __name__ == "__main__":

--- a/lib/marin/src/marin/execution/executor.py
+++ b/lib/marin/src/marin/execution/executor.py
@@ -97,7 +97,6 @@ from urllib.parse import urlparse
 import draccus
 import levanter.utils.fsspec_utils as fsspec_utils
 from iris.marin_fs import open_url
-from fray.v2.types import ResourceConfig
 from iris.marin_fs import marin_prefix
 
 from marin.execution.step_spec import StepSpec
@@ -209,17 +208,11 @@ def resolve_executor_step(
     def resolved_fn(output_path):
         return captured_fn(captured_config)
 
-    # Determine Fray config: explicit ExecutorStep.resources wins,
-    # then @remote on the original fn, then None (run locally).
+    # If the original fn was decorated with @remote, propagate the
+    # RemoteCallable wrapper (with updated inner fn) so Fray dispatch
+    # is preserved.  Plain functions run locally in-thread.
     final_fn: Callable = resolved_fn
-    if step.resources is not None:
-        final_fn = RemoteCallable(
-            fn=resolved_fn,
-            resources=step.resources,
-            env_vars=step.env_vars or {},
-            pip_dependency_groups=step.pip_dependency_groups or [],
-        )
-    elif isinstance(step.fn, RemoteCallable):
+    if isinstance(step.fn, RemoteCallable):
         final_fn = dataclasses.replace(step.fn, fn=resolved_fn)
 
     return StepSpec(
@@ -268,12 +261,6 @@ class ExecutorStep(Generic[ConfigT]):
 
     pip_dependency_groups: list[str] | None = None
     """List of `extra` dependencies from pyproject.toml to include with this step."""
-
-    resources: ResourceConfig | None = None
-    """Resource requirements for this step (GPU, TPU, CPU). If None, defaults to CPU."""
-
-    env_vars: dict[str, str] | None = None
-    """Additional environment variables to set for this step."""
 
     def cd(self, name: str) -> "InputName":
         """Refer to the `name` under `self`'s output_path."""

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -394,35 +394,35 @@ def test_resolve_executor_step_picks_up_remote_decorator():
     def my_fn(config):
         pass
 
-    step = ExecutorStep(name="test", fn=my_fn, config=None, resources=None)
+    step = ExecutorStep(name="test", fn=my_fn, config=None)
     resolved = resolve_executor_step(step, config={}, output_path="/out/test-abc")
 
     assert isinstance(resolved.fn, RemoteCallable)
     assert resolved.fn.resources == ResourceConfig.with_cpu()
 
 
-def test_explicit_resources_override_remote_decorator():
-    """ExecutorStep.resources should take precedence over @remote decorator resources."""
-    explicit = ResourceConfig.with_cpu(cpu=8, ram="32g")
+def test_remote_decorator_resources_are_preserved():
+    """@remote decorator resources should be preserved through resolve_executor_step."""
+    custom = ResourceConfig.with_cpu(cpu=8, ram="32g")
 
-    @remote(resources=ResourceConfig.with_cpu(cpu=2))
+    @remote(resources=custom)
     def my_fn(config):
         pass
 
-    step = ExecutorStep(name="test", fn=my_fn, config=None, resources=explicit)
+    step = ExecutorStep(name="test", fn=my_fn, config=None)
     resolved = resolve_executor_step(step, config={}, output_path="/out/test-abc")
 
     assert isinstance(resolved.fn, RemoteCallable)
-    assert resolved.fn.resources == explicit
+    assert resolved.fn.resources == custom
 
 
-def test_step_without_remote_or_resources_is_plain_fn():
-    """A plain function with no @remote and no ExecutorStep.resources should not be RemoteCallable."""
+def test_step_without_remote_is_plain_fn():
+    """A plain function with no @remote should not be RemoteCallable."""
 
     def my_fn(config):
         pass
 
-    step = ExecutorStep(name="test", fn=my_fn, config=None, resources=None)
+    step = ExecutorStep(name="test", fn=my_fn, config=None)
     resolved = resolve_executor_step(step, config={}, output_path="/out/test-abc")
 
     assert not isinstance(resolved.fn, RemoteCallable)


### PR DESCRIPTION
Remove `resources` and `env_vars` fields from `ExecutorStep`, making it a pure DAG scheduling abstraction. Resource dispatch is now handled exclusively via the `@remote` decorator / `remote()` wrapper on the step function.

Closes #3255