### PR TITLE
distributed_lock: read legacy worker_id lock leases

### DIFF
--- a/lib/iris/src/iris/distributed_lock.py
+++ b/lib/iris/src/iris/distributed_lock.py
@@ -36,32 +36,14 @@ HEARTBEAT_TIMEOUT = 90  # seconds before considering a lease stale
 class Lease:
     """A lease held by a lock holder."""
 
-    holder_id: str
+    worker_id: str
     timestamp: float
 
     def is_stale(self) -> bool:
         return (time.time() - self.timestamp) > HEARTBEAT_TIMEOUT
 
 
-def _lease_from_data(data: dict) -> Lease:
-    """Parse lease JSON with support for legacy lock files.
-
-    Legacy files used ``worker_id``; current files use ``holder_id``.
-    """
-    holder = data.get("holder_id")
-    if holder is None:
-        holder = data.get("worker_id")
-    if holder is None:
-        raise KeyError("Lock data missing holder_id/worker_id")
-
-    timestamp = data.get("timestamp")
-    if timestamp is None:
-        raise KeyError("Lock data missing timestamp")
-
-    return Lease(holder_id=str(holder), timestamp=float(timestamp))
-
-
-def default_holder_id() -> str:
+def default_worker_id() -> str:
     """Return a unique holder ID for the current host and thread."""
     return f"{os.uname()[1]}-{threading.get_ident()}"
 
@@ -84,12 +66,12 @@ class DistributedLock:
 
     Args:
         lock_path: Path to the lock file (``gs://...``, local, or any fsspec URL).
-        holder_id: Unique identifier for this lock holder.
+        worker_id: Unique identifier for this lock holder.
     """
 
-    def __init__(self, lock_path: str, holder_id: str | None = None):
+    def __init__(self, lock_path: str, worker_id: str | None = None):
         self.lock_path = lock_path
-        self.holder_id = holder_id or default_holder_id()
+        self.worker_id = worker_id or default_worker_id()
 
     def _read_lock_with_generation(self) -> tuple[int, Lease | None]:
         """Read lock file and its generation. Returns (0, None) if doesn't exist."""
@@ -128,7 +110,7 @@ class DistributedLock:
         if blob is None:
             return (0, None)
         data = json.loads(blob.download_as_string())
-        return (blob.generation, _lease_from_data(data))
+        return (blob.generation, Lease(**data))
 
     def _write_gcs(self, lease: Lease, if_generation_match: int) -> None:
         from google.cloud import storage
@@ -160,7 +142,7 @@ class DistributedLock:
                 if not content:
                     return (0, None)
                 data = json.loads(content)
-            return (1, _lease_from_data(data))
+            return (1, Lease(**data))
         except FileNotFoundError:
             return (0, None)
 
@@ -175,9 +157,9 @@ class DistributedLock:
             f.seek(0)
             content = f.read()
             if content:
-                current = _lease_from_data(json.loads(content))
-                if not current.is_stale() and current.holder_id != lease.holder_id:
-                    raise FileExistsError(f"Lock held by {current.holder_id}")
+                current = Lease(**json.loads(content))
+                if not current.is_stale() and current.worker_id != lease.worker_id:
+                    raise FileExistsError(f"Lock held by {current.worker_id}")
             f.seek(0)
             f.truncate()
             f.write(json.dumps(asdict(lease)))
@@ -196,7 +178,7 @@ class DistributedLock:
             if not content:
                 return (0, None)
             data = json.loads(content)
-            return (1, _lease_from_data(data))
+            return (1, Lease(**data))
         except FileNotFoundError:
             return (0, None)
 
@@ -214,8 +196,8 @@ class DistributedLock:
         try:
             with fs.open(path, "r") as f:
                 readback = json.loads(f.read())
-            if readback.get("holder_id") != lease.holder_id:
-                raise FileExistsError(f"Lock race lost to {readback.get('holder_id')}")
+            if readback.get("worker_id") != lease.worker_id:
+                raise FileExistsError(f"Lock race lost to {readback.get('worker_id')}")
         except FileNotFoundError as err:
             raise FileExistsError("Lock file disappeared after write") from err
 
@@ -226,24 +208,24 @@ class DistributedLock:
         generation, lock_data = self._read_lock_with_generation()
 
         if lock_data and not lock_data.is_stale():
-            if lock_data.holder_id == self.holder_id:
-                logger.debug("[%s] Already hold lock at %s", self.holder_id, self.lock_path)
+            if lock_data.worker_id == self.worker_id:
+                logger.debug("[%s] Already hold lock at %s", self.worker_id, self.lock_path)
                 return True
-            logger.debug("[%s] Lock %s held by %s (fresh)", self.holder_id, self.lock_path, lock_data.holder_id)
+            logger.debug("[%s] Lock %s held by %s (fresh)", self.worker_id, self.lock_path, lock_data.worker_id)
             return False
 
         if lock_data:
-            logger.debug("[%s] Found stale lock at %s from %s", self.holder_id, self.lock_path, lock_data.holder_id)
+            logger.debug("[%s] Found stale lock at %s from %s", self.worker_id, self.lock_path, lock_data.worker_id)
 
-        lease = Lease(holder_id=self.holder_id, timestamp=time.time())
+        lease = Lease(worker_id=self.worker_id, timestamp=time.time())
         try:
             self._write_lock(lease, if_generation_match=generation)
         except FileExistsError:
-            logger.debug("[%s] Lost lock race for %s", self.holder_id, self.lock_path)
+            logger.debug("[%s] Lost lock race for %s", self.worker_id, self.lock_path)
             return False
         except Exception as e:
             if _is_gcs_path(self.lock_path) and "PreconditionFailed" in type(e).__name__:
-                logger.debug("[%s] Lost lock race for %s", self.holder_id, self.lock_path)
+                logger.debug("[%s] Lost lock race for %s", self.worker_id, self.lock_path)
                 return False
             raise
 
@@ -252,19 +234,19 @@ class DistributedLock:
     def refresh(self) -> None:
         """Refresh a lock held by the current holder."""
         generation, lock_data = self._read_lock_with_generation()
-        if lock_data and lock_data.holder_id == self.holder_id:
-            self._write_lock(Lease(self.holder_id, time.time()), generation)
+        if lock_data and lock_data.worker_id == self.worker_id:
+            self._write_lock(Lease(self.worker_id, time.time()), generation)
         else:
-            current_holder = lock_data.holder_id if lock_data else "unknown"
+            current_holder = lock_data.worker_id if lock_data else "unknown"
             raise ValueError(
-                f"Cannot refresh: lock at {self.lock_path} held by {current_holder}, expected {self.holder_id}"
+                f"Cannot refresh: lock at {self.lock_path} held by {current_holder}, expected {self.worker_id}"
             )
 
     def release(self) -> None:
         """Release the lock if held by this holder."""
         try:
             _, lock_data = self._read_lock_with_generation()
-            if lock_data and lock_data.holder_id == self.holder_id:
+            if lock_data and lock_data.worker_id == self.worker_id:
                 if _is_gcs_path(self.lock_path):
                     self._delete_gcs()
                 elif _is_local_path(self.lock_path):
@@ -272,7 +254,7 @@ class DistributedLock:
                 else:
                     fs, path = self._get_fs()
                     fs.rm(path)
-                logger.debug("[%s] Released lock %s", self.holder_id, self.lock_path)
+                logger.debug("[%s] Released lock %s", self.worker_id, self.lock_path)
         except FileNotFoundError:
             pass
 

--- a/lib/iris/src/iris/mirror_fs.py
+++ b/lib/iris/src/iris/mirror_fs.py
@@ -36,7 +36,7 @@ from typing import Any
 
 import fsspec
 
-from iris.distributed_lock import DistributedLock, default_holder_id
+from iris.distributed_lock import DistributedLock, default_worker_id
 from iris.marin_fs import (
     REGION_TO_DATA_BUCKET,
     marin_prefix,
@@ -80,7 +80,7 @@ class MirrorFileSystem(fsspec.AbstractFileSystem):
         self._remote_prefixes = [p for p in _all_data_bucket_prefixes() if not self._local_prefix.startswith(p)]
         self._copy_limit_bytes = copy_limit_bytes
         self._bytes_copied: int = 0
-        self._holder_id = default_holder_id()
+        self._worker_id = default_worker_id()
 
     # -- underlying fs helpers ------------------------------------------------
 
@@ -152,7 +152,7 @@ class MirrorFileSystem(fsspec.AbstractFileSystem):
                 f"Consider running in the source region instead."
             )
 
-        lock = DistributedLock(self._lock_path_for(path), self._holder_id)
+        lock = DistributedLock(self._lock_path_for(path), self._worker_id)
 
         if not lock.try_acquire():
             for _ in range(60):

--- a/lib/iris/tests/test_distributed_lock.py
+++ b/lib/iris/tests/test_distributed_lock.py
@@ -15,24 +15,24 @@ from iris.distributed_lock import (
 
 
 def test_lease_is_stale_after_timeout():
-    lease = Lease(holder_id="worker-1", timestamp=time.time() - HEARTBEAT_TIMEOUT - 1)
+    lease = Lease(worker_id="worker-1", timestamp=time.time() - HEARTBEAT_TIMEOUT - 1)
     assert lease.is_stale()
 
 
 def test_lease_is_fresh_within_timeout():
-    lease = Lease(holder_id="worker-1", timestamp=time.time())
+    lease = Lease(worker_id="worker-1", timestamp=time.time())
     assert not lease.is_stale()
 
 
 def test_acquire_and_release_local_lock(tmp_path):
     lock_path = str(tmp_path / "test.lock")
-    lock = DistributedLock(lock_path, holder_id="holder-a")
+    lock = DistributedLock(lock_path, worker_id="holder-a")
 
     assert lock.try_acquire()
     # Lock file should exist with correct holder
     with open(lock_path) as f:
         data = json.loads(f.read())
-    assert data["holder_id"] == "holder-a"
+    assert data["worker_id"] == "holder-a"
 
     lock.release()
     assert not os.path.exists(lock_path)
@@ -40,8 +40,8 @@ def test_acquire_and_release_local_lock(tmp_path):
 
 def test_second_holder_blocked_while_lock_held(tmp_path):
     lock_path = str(tmp_path / "test.lock")
-    lock_a = DistributedLock(lock_path, holder_id="holder-a")
-    lock_b = DistributedLock(lock_path, holder_id="holder-b")
+    lock_a = DistributedLock(lock_path, worker_id="holder-a")
+    lock_b = DistributedLock(lock_path, worker_id="holder-b")
 
     assert lock_a.try_acquire()
     assert not lock_b.try_acquire()
@@ -55,19 +55,19 @@ def test_stale_lock_can_be_taken_over(tmp_path):
     lock_path = str(tmp_path / "test.lock")
 
     # Write a stale lock directly
-    stale_lease = Lease(holder_id="dead-worker", timestamp=time.time() - HEARTBEAT_TIMEOUT - 10)
+    stale_lease = Lease(worker_id="dead-worker", timestamp=time.time() - HEARTBEAT_TIMEOUT - 10)
     os.makedirs(os.path.dirname(lock_path), exist_ok=True)
     with open(lock_path, "w") as f:
-        f.write(json.dumps({"holder_id": stale_lease.holder_id, "timestamp": stale_lease.timestamp}))
+        f.write(json.dumps({"worker_id": stale_lease.worker_id, "timestamp": stale_lease.timestamp}))
 
-    lock = DistributedLock(lock_path, holder_id="new-worker")
+    lock = DistributedLock(lock_path, worker_id="new-worker")
     assert lock.try_acquire()
     lock.release()
 
 
 def test_refresh_updates_timestamp(tmp_path):
     lock_path = str(tmp_path / "test.lock")
-    lock = DistributedLock(lock_path, holder_id="holder-a")
+    lock = DistributedLock(lock_path, worker_id="holder-a")
     assert lock.try_acquire()
 
     # Read initial timestamp
@@ -86,8 +86,8 @@ def test_refresh_updates_timestamp(tmp_path):
 
 def test_refresh_fails_if_not_holder(tmp_path):
     lock_path = str(tmp_path / "test.lock")
-    lock_a = DistributedLock(lock_path, holder_id="holder-a")
-    lock_b = DistributedLock(lock_path, holder_id="holder-b")
+    lock_a = DistributedLock(lock_path, worker_id="holder-a")
+    lock_b = DistributedLock(lock_path, worker_id="holder-b")
 
     assert lock_a.try_acquire()
     with pytest.raises(ValueError, match="held by"):
@@ -97,7 +97,7 @@ def test_refresh_fails_if_not_holder(tmp_path):
 
 def test_has_active_holder(tmp_path):
     lock_path = str(tmp_path / "test.lock")
-    lock = DistributedLock(lock_path, holder_id="holder-a")
+    lock = DistributedLock(lock_path, worker_id="holder-a")
 
     assert not lock.has_active_holder()
     assert lock.try_acquire()
@@ -108,7 +108,7 @@ def test_has_active_holder(tmp_path):
 
 def test_same_holder_can_reacquire(tmp_path):
     lock_path = str(tmp_path / "test.lock")
-    lock = DistributedLock(lock_path, holder_id="holder-a")
+    lock = DistributedLock(lock_path, worker_id="holder-a")
 
     assert lock.try_acquire()
     assert lock.try_acquire()  # idempotent

--- a/lib/iris/tests/test_mirror_fs.py
+++ b/lib/iris/tests/test_mirror_fs.py
@@ -44,7 +44,7 @@ def mirror_fs(mirror_env, tmp_path):
     fs._remote_prefixes = mirror_env["remote_prefixes"]
     fs._copy_limit_bytes = MIRROR_COPY_LIMIT_BYTES
     fs._bytes_copied = 0
-    fs._holder_id = "test-holder"
+    fs._worker_id = "test-holder"
     # Override lock paths to use local tmp dir
     lock_dir = str(tmp_path / "locks")
     fs._lock_path_for = lambda path: os.path.join(lock_dir, f"{path.replace('/', '_')}.lock")

--- a/lib/marin/src/marin/execution/executor_step_status.py
+++ b/lib/marin/src/marin/execution/executor_step_status.py
@@ -7,7 +7,7 @@ We associate each `output_path` with:
 - A status file (`output_path/.executor_status`) containing simple text: SUCCESS, FAILURE, or RUNNING
 - A LOCK file (`output_path/.executor_status.lock`) for distributed locking
 
-The LOCK file contains JSON with {holder_id, timestamp} and is refreshed periodically.
+The LOCK file contains JSON with {worker_id, timestamp} and is refreshed periodically.
 On GCS, we use generation-based conditional writes for atomicity.
 """
 
@@ -23,7 +23,7 @@ from typing import TypeVar
 from iris.distributed_lock import (
     HEARTBEAT_INTERVAL,
     DistributedLock,
-    default_holder_id,
+    default_worker_id,
 )
 from iris.marin_fs import url_to_fs
 
@@ -47,7 +47,7 @@ class StatusFile:
 
     Two types of files:
     - LOCK file (JSON): Single file for distributed lock acquisition.
-      Contains {holder_id, timestamp}. Must be refreshed periodically.
+      Contains {worker_id, timestamp}. Must be refreshed periodically.
     - Status file (simple text): Final state - SUCCESS, FAILURE, or RUNNING.
 
     Lock acquisition delegates to ``iris.distributed_lock.DistributedLock``.
@@ -59,7 +59,7 @@ class StatusFile:
         self.worker_id = worker_id
         self._lock_path = self.path + ".lock"
         self.fs = url_to_fs(self.path, use_listings_cache=False)[0]
-        self._lock = DistributedLock(self._lock_path, holder_id=worker_id)
+        self._lock = DistributedLock(self._lock_path, worker_id=worker_id)
 
     @property
     def status(self) -> str | None:
@@ -144,7 +144,7 @@ class StatusFile:
 
 
 def worker_id() -> str:
-    return default_holder_id()
+    return default_worker_id()
 
 
 class PreviousTaskFailedError(Exception):

--- a/tests/execution/test_executor.py
+++ b/tests/execution/test_executor.py
@@ -624,7 +624,7 @@ def test_status_file_takeover_stale_lock_then_refresh(tmp_path):
     # Manually backdate the lock to make it stale via the underlying DistributedLock
     lock = dead_worker._lock
     generation, _ = lock._read_lock_with_generation()
-    stale_lease = Lease(holder_id="dead-worker", timestamp=time.time() - HEARTBEAT_TIMEOUT - 10)
+    stale_lease = Lease(worker_id="dead-worker", timestamp=time.time() - HEARTBEAT_TIMEOUT - 10)
     lock._write_lock(stale_lease, if_generation_match=generation)
 
     # Worker B comes along and takes over
@@ -640,12 +640,12 @@ def test_status_file_takeover_stale_lock_then_refresh(tmp_path):
 
     # Verify we now own the lock
     _, lease_after_takeover = live_worker._lock._read_lock_with_generation()
-    assert lease_after_takeover.holder_id == "live-worker"
+    assert lease_after_takeover.worker_id == "live-worker"
 
     # Now try to refresh
     time.sleep(0.1)
     live_worker.refresh_lock()
 
     _, lease_after_refresh = live_worker._lock._read_lock_with_generation()
-    assert lease_after_refresh.holder_id == "live-worker"
+    assert lease_after_refresh.worker_id == "live-worker"
     assert lease_after_refresh.timestamp > lease_after_takeover.timestamp


### PR DESCRIPTION
## Summary
- accept legacy lock payloads that use `worker_id` instead of `holder_id`
- keep writing the new `holder_id` schema
- prevent failures when reading stale pre-migration `.executor_status.lock` files

## Validation
- `uv run python -m py_compile lib/iris/src/iris/distributed_lock.py`
