### PR TITLE
step_runner: preserve underlying step failure cause

### DIFF
--- a/lib/marin/src/marin/execution/step_runner.py
+++ b/lib/marin/src/marin/execution/step_runner.py
@@ -139,11 +139,21 @@ class StepRunner:
                 time.sleep(1)
             for path in done:
                 handle = running.pop(path)
-                status = handle.wait(raise_on_failure=False)
-                if status == JobStatus.FAILED:
-                    logger.error(f"Step failed: {_display_name(path)}")
+                step_name = _display_name(path)
+                try:
+                    status = handle.wait(raise_on_failure=True)
+                except Exception as exc:
+                    logger.exception("Step failed: %s", step_name)
                     failed.add(path)
-                    failures.append(RuntimeError(f"Step failed: {_display_name(path)}"))
+                    wrapped = RuntimeError(f"Step failed: {step_name}")
+                    wrapped.__cause__ = exc
+                    failures.append(wrapped)
+                    continue
+
+                if status in (JobStatus.FAILED, JobStatus.STOPPED):
+                    logger.error("Step failed: %s (status=%s)", step_name, status.value)
+                    failed.add(path)
+                    failures.append(RuntimeError(f"Step failed: {step_name}; status={status.value}"))
                 else:
                     completed.add(path)
 

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from dataclasses import dataclass
 
+import pytest
 from fray.v2.types import ResourceConfig
 
 from marin.execution.artifact import Artifact, PathMetadata
@@ -330,6 +331,29 @@ def test_runner_max_concurrent(tmp_path: Path):
 
     train_artifact = Artifact.load(steps[2].output_path, TrainMetadata)
     assert train_artifact.tokens_seen > 0
+
+
+def test_runner_preserves_underlying_step_exception(tmp_path: Path):
+    """The top-level runner error should retain the original failing exception as a cause."""
+
+    def failing_step(_output_path: str) -> None:
+        raise ValueError("sentinel step failure")
+
+    step = StepSpec(
+        name="failing_step",
+        override_output_path=(tmp_path / "failing_step").as_posix(),
+        fn=failing_step,
+    )
+
+    runner = StepRunner()
+    with pytest.raises(RuntimeError, match=r"1 step\(s\) failed") as exc_info:
+        runner.run([step])
+
+    step_failure = exc_info.value.__cause__
+    assert isinstance(step_failure, RuntimeError)
+    assert "Step failed: failing_step" in str(step_failure)
+    assert isinstance(step_failure.__cause__, ValueError)
+    assert "sentinel step failure" in str(step_failure.__cause__)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- preserve original step exceptions in `StepRunner` instead of collapsing to generic runtime errors
- keep top-level `RuntimeError("N step(s) failed")` while preserving cause chain for root-cause debugging
- add regression coverage asserting the nested cause includes the original failure exception

## Changes
- in `_harvest`, wait with `raise_on_failure=True` and catch/log the real exception
- wrap with `RuntimeError("Step failed: ...")` and keep the original exception as `__cause__`
- retain explicit handling for terminal non-success statuses (`FAILED`, `STOPPED`)
- add `test_runner_preserves_underlying_step_exception`

## Validation
- `./infra/pre-commit.py lib/marin/src/marin/execution/step_runner.py tests/execution/test_step_runner.py`
- `uv run python -m py_compile lib/marin/src/marin/execution/step_runner.py tests/execution/test_step_runner.py`

## Notes
- `pytest` was not available in this minimal worktree venv, so full test execution was not run in this PR worktree.
