### PR TITLE
docs: align MkDocs commands with uv run

### DIFF
--- a/docs/dev-guide/building-docs.md
+++ b/docs/dev-guide/building-docs.md
@@ -23,13 +23,13 @@ Before you begin, ensure you have the following installed:
 
 1. Start the local development server:
    ```bash
-   mkdocs serve
+   uv run mkdocs serve
    ```
    This will start a local server at `http://127.0.0.1:8000` where you can preview your changes in real-time.
 
 2. Build the documentation:
    ```bash
-   mkdocs build
+   uv run mkdocs build
    ```
    This will create a `site` directory containing the built documentation.
 
@@ -37,7 +37,7 @@ Before you begin, ensure you have the following installed:
 
 For production builds, use:
 ```bash
-mkdocs build --clean
+uv run mkdocs build --clean
 ```
 
 ## Documentation Structure
@@ -112,12 +112,12 @@ def process_data(data: List[str]) -> Dict[str, int]:
 
 1. Check for broken links:
    ```bash
-   mkdocs build --strict
+   uv run mkdocs build --strict
    ```
 
 2. Validate markdown:
    ```bash
-   mkdocs build --strict --verbose
+   uv run mkdocs build --strict --verbose
    ```
 
 ## Deployment
@@ -132,7 +132,7 @@ The documentation is automatically deployed when changes are pushed to the main 
 
 1. Create a new branch for your changes
 2. Make your changes
-3. Test locally using `mkdocs serve`
+3. Test locally using `uv run mkdocs serve`
 4. Submit a pull request
 
 ## Common Issues


### PR DESCRIPTION
## Summary
- update `docs/dev-guide/building-docs.md` to run MkDocs via `uv run`
- align local dev, build, and strict validation examples with repository command conventions
- keep contributor checklist consistent with the same command form

## Why
Most repo docs and operator guidance use `uv run ...` for Python tooling. This guide still used direct `mkdocs` invocations, which can fail when the CLI is not on PATH or when a shell does not have the expected environment activated.

Refs #12
