### PR TITLE
iris smoke-test: fix _run_iris logging format mismatch

### DIFF
--- a/lib/iris/scripts/smoke-test.py
+++ b/lib/iris/scripts/smoke-test.py
@@ -210,7 +210,7 @@ def _run_iris(*args: str, config_path: Path, timeout: float = DEFAULT_CLI_TIMEOU
     cmd = ["uv", "run", "iris", "--config", str(config_path), *args]
     result = subprocess.run(cmd, capture_output=False, text=True, cwd=str(IRIS_ROOT), timeout=timeout)
     if result.returncode != 0:
-        logger.error("Command failed (exit %d): %s\nstdout: %s\nstderr: %s", result.returncode, " ".join(cmd))
+        logger.error("Command failed (exit %d): %s", result.returncode, " ".join(cmd))
         result.check_returncode()
     return result
 


### PR DESCRIPTION
## Summary
- fix `_run_iris` failure logging in `lib/iris/scripts/smoke-test.py` so formatting matches provided arguments
- avoid raising a secondary `TypeError` while reporting a non-zero Iris CLI exit
- preserve the original command failure as the actionable error

## Why
Issue #3266 identified that `_run_iris` used a format string with four placeholders but only two values. When an Iris command failed, logging itself could fail and obscure the real root cause.

## Validation
- `uv run python -m py_compile lib/iris/scripts/smoke-test.py`

Refs #3266
