### PR TITLE
ci: delete CW NodePools after canary ferry workflow

### DIFF
--- a/.github/workflows/marin-canary-ferry-cw.yaml
+++ b/.github/workflows/marin-canary-ferry-cw.yaml
@@ -74,6 +74,8 @@ jobs:
       # CW autoscaler to scale down. Delete them explicitly to avoid lingering
       # H100 costs. We attempt both even if one fails — cost protection matters
       # more than clean state.
+      # TODO(#3277): Move NodePool teardown into Iris (e.g. `iris cluster stop
+      # --delete-nodepools`) so CI doesn't leak the `iris-iris-managed` label.
       - name: Tear down CoreWeave cluster
         if: always()
         run: |


### PR DESCRIPTION
## Summary

Delete CW NodePools at the end of the canary workflow (`if: always()`), even on failure. Without this, NodePools survive indefinitely — CW's autoscaler never scales them down due to system pods pinning the node (see #3276).

Steps: `cluster stop` (removes Pods so the autoscaler won't fight), then `kubectl delete nodepool` (waits for completion so deletion is visible in the workflow logs; the 180-min job timeout is the backstop).

## Alternative: move NodePool deletion into Iris? (@rjpower)

This leaks the `iris-iris-managed` label convention into CI. Would you prefer we own this in Iris instead? Some options:

1. **`iris cluster stop --delete-nodepools`** — opt-in flag keeping current default. CW-specific, so the CLI would call a dedicated `CoreWeavePlatform.delete_nodepools()` after the generic `stop_all` rather than threading the param through every platform.
2. **`iris cluster destroy`** — new command: `stop` + delete all provisioned infra (NodePools, RBAC, etc.). Cleaner semantics but more surface area.
3. **Always delete NodePools in `cluster stop`** — simplest, but changes behavior for long-lived clusters.

Happy to go with any of these instead, or keep the current approach if this is good enough.

## Test plan

- [x] `workflow_dispatch` and verify both teardown steps run
- [x] Confirm no NodePools remain: `kubectl --kubeconfig ~/.kube/coreweave-iris get nodepool`
- [x] Verify teardown runs on job failure (cancel mid-run)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)