### PR TITLE
canary: switch MFU gate to p50 over trailing window

### DIFF
--- a/lib/levanter/src/levanter/callbacks/_metrics.py
+++ b/lib/levanter/src/levanter/callbacks/_metrics.py
@@ -1,8 +1,10 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import collections
 import copy
 import logging as pylogging
+import statistics
 from datetime import timedelta
 from typing import Optional
 
@@ -68,6 +70,10 @@ def log_performance_stats(
     if flops_per_example is not None:
         levanter.tracker.log_summary({wrap_key("flops_per_example"): flops_per_example})
 
+    # Accumulate MFU samples over a trailing window for robust distribution stats.
+    # 500 steps is large enough for stable percentiles while bounded in memory.
+    mfu_window: collections.deque[float] = collections.deque(maxlen=500)
+
     def log_performance_stats(step_info: StepInfo):
         dict_to_log: dict[str, float | int] = {}
 
@@ -94,9 +100,32 @@ def log_performance_stats(
                 if flops_per_device is not None:
                     mfu_instant = model_flops_instant / theoretical_flops * 100.0
                     dict_to_log["mfu"] = mfu_instant
+                    mfu_window.append(mfu_instant)
 
         dict_to_log = {wrap_key(k): v for k, v in dict_to_log.items()}
         levanter.tracker.log(dict_to_log, step=step_info.step)
+
+        if len(mfu_window) > 0:
+            n = len(mfu_window)
+            mean = statistics.mean(mfu_window)
+            med = statistics.median(mfu_window)
+            if n >= 2:
+                deciles = statistics.quantiles(mfu_window, n=10)
+                p10, p90 = deciles[0], deciles[8]
+                sd = statistics.stdev(mfu_window)
+            else:
+                p10 = p90 = mfu_window[0]
+                sd = 0.0
+            levanter.tracker.log_summary(
+                {
+                    wrap_key("p10_mfu"): p10,
+                    wrap_key("p50_mfu"): med,
+                    wrap_key("p90_mfu"): p90,
+                    wrap_key("mean_mfu"): mean,
+                    wrap_key("stddev_mfu"): sd,
+                    wrap_key("mfu_sample_count"): n,
+                }
+            )
 
     return log_performance_stats
 

--- a/scripts/canary/validate_canary_metrics.py
+++ b/scripts/canary/validate_canary_metrics.py
@@ -23,7 +23,7 @@ THRESHOLDS = [
     # (summary_key, display_name, check, threshold)
     # check(actual, threshold) → True means passing
     ("train/loss", "Final loss", operator.le, 4.0),
-    ("throughput/mfu", "MFU (%)", operator.ge, 25.0),
+    ("throughput/p50_mfu", "MFU p50 (%)", operator.ge, 22.0),
     ("_step", "Steps completed", operator.ge, 3000),
     ("_runtime", "Wall-clock (s)", operator.le, 3600),
 ]

--- a/tests/test_validate_canary_metrics.py
+++ b/tests/test_validate_canary_metrics.py
@@ -10,7 +10,7 @@ from scripts.canary.validate_canary_metrics import lookup_metric, main, read_sum
 
 HEALTHY_SUMMARY = {
     "train": {"loss": 3.75},
-    "throughput": {"mfu": 30.0},
+    "throughput": {"mfu": 30.0, "p50_mfu": 28.0},
     "_step": 3814,
     "_runtime": 2400,
 }


### PR DESCRIPTION
Ref: #3278

## Summary

- Accumulate MFU samples over a trailing window (last 500 steps) and write distribution stats (p10, p50, p90, mean, stddev, count) to the tracker summary.
- Switch the canary gate from last-step `throughput/mfu >= 25.0` to `throughput/p50_mfu >= 22.0`.

## Motivation

The canary MFU gate checks a single terminal MFU sample. At the canary's baseline throughput (~2.5 it/s on v5p-8), the expected MFU is ~24.9% — right at the 25% threshold. The gate is a coin flip on whether the last step happens to be fast or slow.

Using the median over a trailing window eliminates this sensitivity. The threshold is lowered to 22% to provide comfortable margin above noise while still catching real regressions.

## Design notes

- **Window size 500**: large enough for stable percentiles, bounded in memory. The canary runs 3814 steps, so the final window covers the last ~13% of training — well past compilation warmup.
- **`log_summary` every step**: necessary because the callback doesn't know which step is the last. The trainer calls `run_hooks(force=True)` at end of training for the final flush.
- **Threshold 22%**: historical baseline shows sustained MFU of ~24.9% at 2.5 it/s. 22% gives ~12% margin for normal variance. The p50 naturally filters outlier steps.

## Test plan

- [x] `uv run pytest tests/test_validate_canary_metrics.py` — passes
- [ ] Canary triggered on branch: https://github.com/marin-community/marin/actions/runs/22732424437
- [ ] Verify `throughput/p50_mfu` appears in `tracker_metrics.jsonl` + W&B after run

<details>
<summary><strong>Key naming: why <code>throughput/p50_mfu</code> not <code>throughput/mfu/p50</code></strong></summary>

W&B can't have `throughput/mfu` be both a scalar (per-step log) and a namespace (`throughput/mfu/p50`, ...) simultaneously. Using hierarchy would require renaming the existing per-step key, breaking `setup_wandb_workspace.py`, `parse_wandb_runs.py`, existing dashboards, and historical run data. Not worth the churn for this PR.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)