### PR TITLE
Use SSH BatchMode to force errors on missing keys

### DIFF
--- a/lib/iris/src/iris/cluster/platform/gcp.py
+++ b/lib/iris/src/iris/cluster/platform/gcp.py
@@ -1609,6 +1609,8 @@ def _gcp_tunnel(
             f"127.0.0.1:{local_port}:localhost:10000",
             "-N",
             "-o",
+            "BatchMode=yes",
+            "-o",
             "StrictHostKeyChecking=no",
             "-o",
             "UserKnownHostsFile=/dev/null",

--- a/lib/iris/src/iris/cluster/platform/remote_exec.py
+++ b/lib/iris/src/iris/cluster/platform/remote_exec.py
@@ -104,6 +104,7 @@ class GcloudRemoteExec:
             f"--project={self.project_id}",
             f"--worker={self.worker_index}",
             "--quiet",
+            "--ssh-flag=-oBatchMode=yes",
             "--command",
             command,
         ]
@@ -153,6 +154,7 @@ class GceRemoteExec:
             f"--zone={self.zone}",
             f"--project={self.project_id}",
             "--quiet",
+            "--ssh-flag=-oBatchMode=yes",
             "--command",
             command,
         ]


### PR DESCRIPTION
## Summary
- Adds `BatchMode=yes` to SSH commands in GCP tunnel and remote exec paths
- This prevents SSH from silently falling back to password prompts when keys are missing, instead failing fast with a clear error

## Test plan
- [x] Verify SSH connections fail immediately with a clear error when keys are missing
- [x] Verify normal SSH connections with valid keys still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)