### PR TITLE
Add tensor-opaque LM model adapters for array migration

### DIFF
--- a/lib/levanter/src/levanter/models/lm_model.py
+++ b/lib/levanter/src/levanter/models/lm_model.py
@@ -26,6 +26,14 @@ LmAttentionMask = AttentionMask | Any
 LmAuxData = Any
 
 
+def _to_plain_jax_array(value: Any) -> jax.Array:
+    """Best-effort conversion from a model-native tensor/scalar to a plain JAX array."""
+    array_attr = getattr(value, "array", None)
+    if array_attr is not None:
+        return jnp.asarray(array_attr)
+    return jnp.asarray(value)
+
+
 class LmExample(eqx.Module):
     tokens: hax.NamedArray
     loss_weight: hax.NamedArray
@@ -302,3 +310,42 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
         )
 
         return loss + aux_loss
+    def compute_next_token_loss_array(
+        self,
+        example: "LmExample | GrugLmExample",
+        *,
+        batch_axis: Axis | str | None = "batch",
+        key=None,
+        reduction: Optional[hax.ReductionFunction] = cast(Optional[hax.ReductionFunction], hax.mean),
+        reduction_axis: Optional[hax.AxisSelection] = None,
+        logsumexp_weight: Optional[float] = None,
+        loss_dtype: Optional[jnp.dtype] = jnp.float32,
+        logit_soft_cap: Optional[float] = None,
+    ) -> jax.Array:
+        """
+        Compute next-token cross-entropy and always return a plain JAX array.
+
+        This bridges array-native batches (for example `GrugLmExample`) to the legacy
+        named-tensor model interface during migration.
+        """
+        named_example: LmExample
+        if isinstance(example, LmExample):
+            named_example = example
+        else:
+            from levanter.data.text.examples import GrugLmExample, named_lm_example_from_grug
+
+            if not isinstance(example, GrugLmExample):
+                raise TypeError(f"Unsupported example type: {type(example)}")
+            named_example = named_lm_example_from_grug(example, Pos=self.Pos, batch_axis=batch_axis)
+
+        loss = self.compute_next_token_loss(
+            named_example,
+            key=key,
+            reduction=reduction,
+            reduction_axis=reduction_axis,
+            logsumexp_weight=logsumexp_weight,
+            loss_dtype=loss_dtype,
+            logit_soft_cap=logit_soft_cap,
+        )
+
+        return _to_plain_jax_array(loss)

--- a/lib/levanter/src/levanter/models/lm_model.py
+++ b/lib/levanter/src/levanter/models/lm_model.py
@@ -3,7 +3,7 @@
 
 import abc
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generic, Optional, Type, TypeVar, cast
+from typing import Any, Generic, Optional, Type, TypeVar, cast
 
 import draccus
 import equinox as eqx
@@ -310,6 +310,7 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
         )
 
         return loss + aux_loss
+
     def compute_next_token_loss_array(
         self,
         example: "LmExample | GrugLmExample",

--- a/lib/levanter/src/levanter/models/lm_model.py
+++ b/lib/levanter/src/levanter/models/lm_model.py
@@ -3,7 +3,7 @@
 
 import abc
 from dataclasses import dataclass
-from typing import Generic, Optional, Type, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, Optional, Type, TypeVar, cast
 
 import draccus
 import equinox as eqx
@@ -19,6 +19,11 @@ from levanter.models.loss import maybe_fused_next_token_loss
 
 LmConfigT = TypeVar("LmConfigT", bound="LmConfig")
 LmT = TypeVar("LmT", bound="LmHeadModel")
+
+
+LmTensor = Any
+LmAttentionMask = AttentionMask | Any
+LmAuxData = Any
 
 
 class LmExample(eqx.Module):
@@ -187,21 +192,22 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
 
     def __call__(
         self,
-        input_ids: NamedArray,
-        attn_mask: Optional[AttentionMask | NamedArray] = None,
+        input_ids: LmTensor,
+        attn_mask: Optional[LmAttentionMask] = None,
         *,
         key=None,
-        pos_ids: NamedArray | None = None,
-    ) -> NamedArray:
+        pos_ids: LmTensor | None = None,
+    ) -> LmTensor:
         """
-        Compute the logits for the next token in a sequence.
+        Compute next-token logits for a model-native token tensor.
+
         Args:
-            input_ids: token IDs with shape [..., Pos]
-            attn_mask: attention mask with shape [..., Pos, KeyPos]
+            input_ids: model-native token tensor with shape [..., Pos]
+            attn_mask: model-native attention mask for the same sequence
             key: PRNGKeyArray for random number generation
 
         Returns:
-            NamedArray: logits with shape [..., Pos, Vocab]
+            Model-native logits tensor with shape [..., Pos, Vocab]
 
         """
         try:
@@ -217,27 +223,28 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
     @abc.abstractmethod
     def activations(
         self,
-        input_ids: NamedArray,
-        attn_mask: Optional[AttentionMask | NamedArray] = None,
+        input_ids: LmTensor,
+        attn_mask: Optional[LmAttentionMask] = None,
         *,
         key=None,
-        pos_ids: NamedArray | None = None,
-    ) -> NamedArray | tuple[NamedArray, NamedArray | float]:
+        pos_ids: LmTensor | None = None,
+    ) -> LmTensor | tuple[LmTensor, LmAuxData]:
         """
-        Compute the activations for the next token in a sequence.
+        Compute activations for a model-native token tensor.
+
         Args:
-            input_ids: token IDs with shape {Pos}
-            attn_mask: attention mask with shape {Pos, KeyPos}
+            input_ids: model-native token tensor with shape {Pos}
+            attn_mask: model-native attention mask with shape {Pos, KeyPos}
             key: PRNGKeyArray for random number generation
 
         Returns:
-            NamedArray: activations with shape {Pos, Embed}
+            Model-native activation tensor with shape {Pos, Embed}
 
         """
         pass
 
     @abc.abstractmethod
-    def get_lm_head(self) -> hax.NamedArray:
+    def get_lm_head(self) -> LmTensor:
         """
         The language modeling head of the model. Should have shape {Embed, Vocab}.
         """
@@ -265,12 +272,12 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
         logsumexp_weight: Optional[float] = None,
         loss_dtype: Optional[jnp.dtype] = jnp.float32,
         logit_soft_cap: Optional[float] = None,
-    ) -> jnp.ndarray | NamedArray:
+    ) -> jnp.ndarray | LmTensor:
         """
         Compute next-token cross-entropy for a language modeling example.
 
         If `reduction` is not None, the loss is reduced across `reduction_axis` (`None` means all axes).
-        If `reduction` is None, the loss is returned unreduced as a `NamedArray` with axes
+        If `reduction` is None, the loss is returned unreduced as a model-native tensor with axes
         (*batch axes, sequence_length).
         """
         activations = self.activations(example.tokens, example.attn_mask, key=key)


### PR DESCRIPTION
## Summary
- makes the LmHeadModel surface tensor-opaque so callers no longer need to assume named-tensor inputs/outputs
- adds an array-native next-token-loss adapter that bridges array-first batches to existing model internals
- keeps existing named loss path behavior intact while introducing the migration surface incrementally

This is part of gruggification.