### PR TITLE
Validate --region/--zone CLI values in iris job run

### DIFF
--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -26,6 +26,8 @@ from iris.cli.main import require_controller_url
 from iris.client import IrisClient
 from iris.client.client import Job, JobFailedError
 from iris.cluster.types import (
+    REGION_ATTRIBUTE_KEY,
+    ZONE_ATTRIBUTE_KEY,
     Constraint,
     CoschedulingConfig,
     Entrypoint,
@@ -33,13 +35,11 @@ from iris.cluster.types import (
     JobName,
     ReservationEntry,
     ResourceSpec,
-    _find_closest,
     get_tpu_topology,
     gpu_device,
-    known_regions_and_zones,
     region_constraint,
-    zone_constraint,
     tpu_device,
+    zone_constraint,
 )
 from iris.rpc import cluster_pb2
 from iris.time_utils import Duration, Timestamp
@@ -233,6 +233,45 @@ def parse_gpu_spec(spec: str) -> tuple[str, int]:
     )
 
 
+def _levenshtein(a: str, b: str) -> int:
+    if len(a) < len(b):
+        return _levenshtein(b, a)
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a):
+        curr = [i + 1] + [0] * len(b)
+        for j, cb in enumerate(b):
+            curr[j + 1] = min(prev[j + 1] + 1, curr[j] + 1, prev[j] + (ca != cb))
+        prev = curr
+    return prev[-1]
+
+
+def _find_closest(value: str, known: set[str], max_distance: int = 5) -> str | None:
+    """Return the closest match from *known* by edit distance, or None."""
+    best, best_dist = None, max_distance + 1
+    for candidate in sorted(known):
+        dist = _levenshtein(value, candidate)
+        if dist < best_dist:
+            best, best_dist = candidate, dist
+    return best if best_dist <= max_distance else None
+
+
+def _known_regions_and_zones(config) -> tuple[set[str], set[str]]:
+    """Extract known regions and zones from an IrisClusterConfig proto.
+
+    Returns:
+        (regions, zones) sets derived from scale group worker attributes.
+    """
+    regions: set[str] = set()
+    zones: set[str] = set()
+    for sg in config.scale_groups.values():
+        attrs = sg.worker.attributes
+        if REGION_ATTRIBUTE_KEY in attrs:
+            regions.add(attrs[REGION_ATTRIBUTE_KEY])
+        if ZONE_ATTRIBUTE_KEY in attrs:
+            zones.add(attrs[ZONE_ATTRIBUTE_KEY])
+    return regions, zones
+
+
 def validate_region_zone(
     regions: tuple[str, ...] | None,
     zone: str | None,
@@ -246,7 +285,7 @@ def validate_region_zone(
     if config is None:
         return
 
-    known_regions, known_zones = known_regions_and_zones(config)
+    known_regions, known_zones = _known_regions_and_zones(config)
 
     if not known_regions and not known_zones:
         return

--- a/lib/iris/src/iris/cluster/types.py
+++ b/lib/iris/src/iris/cluster/types.py
@@ -656,45 +656,6 @@ def preemptible_constraint(preemptible: bool = True) -> Constraint:
     return Constraint(key=PREEMPTIBLE_ATTRIBUTE_KEY, op=ConstraintOp.EQ, value=str(preemptible).lower())
 
 
-def _find_closest(value: str, known: set[str], max_distance: int = 5) -> str | None:
-    """Return the closest match from *known* by edit distance, or None."""
-    best, best_dist = None, max_distance + 1
-    for candidate in sorted(known):
-        dist = _levenshtein(value, candidate)
-        if dist < best_dist:
-            best, best_dist = candidate, dist
-    return best if best_dist <= max_distance else None
-
-
-def _levenshtein(a: str, b: str) -> int:
-    if len(a) < len(b):
-        return _levenshtein(b, a)
-    prev = list(range(len(b) + 1))
-    for i, ca in enumerate(a):
-        curr = [i + 1] + [0] * len(b)
-        for j, cb in enumerate(b):
-            curr[j + 1] = min(prev[j + 1] + 1, curr[j] + 1, prev[j] + (ca != cb))
-        prev = curr
-    return prev[-1]
-
-
-def known_regions_and_zones(config) -> tuple[set[str], set[str]]:
-    """Extract known regions and zones from an IrisClusterConfig proto.
-
-    Returns:
-        (regions, zones) sets derived from scale group worker attributes.
-    """
-    regions: set[str] = set()
-    zones: set[str] = set()
-    for sg in config.scale_groups.values():
-        attrs = sg.worker.attributes
-        if REGION_ATTRIBUTE_KEY in attrs:
-            regions.add(attrs[REGION_ATTRIBUTE_KEY])
-        if ZONE_ATTRIBUTE_KEY in attrs:
-            zones.add(attrs[ZONE_ATTRIBUTE_KEY])
-    return regions, zones
-
-
 def zone_constraint(zone: str) -> Constraint:
     """Constraint requiring workers to be in a given zone."""
     if not zone:


### PR DESCRIPTION
## Summary
- Validates `--region` and `--zone` flags against known regions/zones from the cluster config's scale group worker attributes
- Fails fast with a clear error message and "Did you mean?" suggestion (edit distance) for typos like `eu-west4` → `europe-west4`
- Skips validation gracefully when no config is available (e.g. `--controller-url` mode)

Fixes #3304

## Test plan
- [x] Added 8 tests covering valid/invalid region, valid/invalid zone, suggestion hints, no-config skip, and no-constraint skip
- [x] All 1122 non-slow tests pass
- [x] Pre-commit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)