### PR TITLE
Update job-monitoring loop for Ray and Iris tracks

### DIFF
--- a/.agents/docs/job-monitoring-loop.md
+++ b/.agents/docs/job-monitoring-loop.md
@@ -1,42 +1,57 @@
 # Job Monitoring Loop
 
-Monitor a Ray job, automatically restarting the **job** on failure.
+Monitor a job continuously and recover on failure. For active jobs, recovery is stop then submit again. This playbook now has two tracks:
 
-## Before Starting
-
-When the user asks you to start a monitoring loop, gather the required information first:
-
-1. **job_id** - What is the Ray job ID? (e.g., `ray-run-held-isoflop_sweep-20260131-051716`)
-2. **cluster** - Which cluster is it running on? (e.g., `us-east5-a`, `us-central2`)
-3. **experiment** - What is the experiment script path? (e.g., `experiments/isoflop_sweep.py`)
+- `ray` track: Ray Jobs API (`scripts/ray/cluster.py`, `ray_run.py`)
+- `iris` track: Iris Jobs API (`uv run iris ... job ...`)
 
 Cluster-level actions are out of scope for this loop. Do not restart, recreate, or otherwise mutate the cluster (including head-node restart) unless the user gives explicit consent in the current thread, except for the TPU bad-node recovery flow documented below.
 
-Ask the user for any missing information before proceeding. Example:
+## Before Starting
 
-> "I need a few details to start the monitoring loop:
-> - Job ID?
-> - Cluster?
-> - Experiment script path?"
+When the user asks to start monitoring, first choose a track and gather required info.
 
-Once you have all three, write the state file and begin the loop.
+### Track Selection
+
+Ask:
+
+> "Should I monitor this as `ray` or `iris`?"
+
+### Required Info: Ray Track
+
+1. `job_id` - Ray job ID (e.g., `ray-run-held-isoflop_sweep-20260131-051716`)
+2. `cluster` - cluster name/alias for `scripts/ray/cluster.py` (e.g., `us-east5-a`, `us-central2`)
+3. `experiment` - script path used for resubmission (e.g., `experiments/isoflop_sweep.py`)
+
+### Required Info: Iris Track
+
+1. `job_id` - Iris job ID in canonical format `/<user>/<job>` (e.g., `/dlwh/iris-run-train_tiny_model_tpu-20260302-185630`)
+2. `config` - Iris config path (e.g., `lib/iris/examples/marin.yaml`)
+3. `resubmit_command` - exact Iris submit command for resubmission; must include `--no-wait`
+4. For Marin TPU training jobs, use `--extra marin:tpu` (not `--extra marin:cpu`)
+
+Example Iris resubmit command:
+`uv run iris --config lib/iris/examples/marin.yaml job run --no-wait --extra marin:tpu --reserve=v5litepod-16 -- python experiments/tutorials/train_tiny_model_tpu.py`
+
+If any required field is missing, ask for it before proceeding.
 
 ## Monitoring Ownership and Duration
 
 - Assign a single monitoring owner when the loop starts.
 - Keep this loop running until one of the following:
-  - the job reaches terminal state (`SUCCEEDED`, `FAILED`, or `STOPPED`) and the user has acknowledged next action
+  - the job reaches a terminal state and the user has acknowledged next action
   - a user-specified stopping point is reached
   - an unrecoverable error is found and reported to the user
 - Do not stop early after seeing first loss lines, first eval, or first W&B link.
 - Expect monitoring to commonly take 4-5 hours for ferry-scale runs.
-- For GPT Codex specifically: if the user requests continuous monitoring, do not end the turn while monitoring is active; continue until terminal state, a user-specified stopping point, or an unrecoverable error.
-- If handoff is needed, transfer ownership explicitly with: current `job_id`, cluster, latest error/signal, and W&B link(s).
+- For GPT Codex specifically: unless otherwise directed, do not end your turn just to give a status update; keep monitoring until terminal state or until the user's goal is reached.
+- If the user requests continuous monitoring, do not end the turn while monitoring is active; continue until terminal state, a user-specified stopping point, or an unrecoverable error.
+- If handoff is needed, transfer ownership explicitly with: track, current `job_id`, latest error/signal, W&B link(s), and resubmission metadata.
 
 ## Cadence and Tooling Notes
 
 - Cadence default after startup stabilization is `sleep 570`.
-- Startup stabilization sequence (after submit/restart):
+- Startup stabilization sequence (after submit/resubmit):
   - once the job is submitted, sleep `120` and check for immediate failure
   - if still alive, switch to the normal `570` cadence
 - Tool-runtime workaround:
@@ -48,10 +63,13 @@ Once you have all three, write the state file and begin the loop.
 
 ## State File
 
-Write to a local file (e.g., `monitoring_state.json` in the scratchpad):
+Write to `monitoring_state.json` in scratchpad/workspace.
+
+### Ray State File
 
 ```json
 {
+  "track": "ray",
   "job_id": "<JOB_ID>",
   "cluster": "<CLUSTER>",
   "experiment": "<EXPERIMENT_PATH>",
@@ -59,122 +77,167 @@ Write to a local file (e.g., `monitoring_state.json` in the scratchpad):
 }
 ```
 
-## Loop
+### Iris State File
+
+```json
+{
+  "track": "iris",
+  "job_id": "<JOB_ID>",
+  "config": "<IRIS_CONFIG_PATH>",
+  "resubmit_command": "<IRIS_JOB_RUN_COMMAND_WITH_NO_WAIT>",
+  "restart_count": 0
+}
+```
+
+## Loop (Interleaved By Track)
+
+Use one shared loop and branch commands/status handling by `track`.
 
 ```
 1. SLEEP
    - if just submitted/restarted: sleep 120 once
    - otherwise: sleep 570
 
-2. CHECK
-   uv run scripts/ray/cluster.py --cluster <CLUSTER> job-logs -n 200 -g "loss\|error\|Error\|Traceback\|RESOURCE_EXHAUSTED\|compiler_base.cc:2587\|Program hbm requirement\|Largest program allocations" <JOB_ID>
+2. CHECK LOGS
+   - if track=ray:
+     uv run scripts/ray/cluster.py --cluster <CLUSTER> job-logs -n 200 -g "loss\|error\|Error\|Traceback\|RESOURCE_EXHAUSTED\|compiler_base.cc:2587\|Program hbm requirement\|Largest program allocations" <JOB_ID>
+   - if track=iris:
+     uv run iris --config <CONFIG> job logs --since-seconds 900 --include-children <JOB_ID> | rg -i -e "loss|error|traceback|exception|resource_exhausted|oom|compiler_base\.cc:2587|program hbm requirement|largest program allocations|ownerdiederror|dead node|node death|autoscaler unsatisfied resources|no accelerator found|failed_precondition|device or resource busy"
 
-3. CHECK TERMINAL STATUS (RAY)
-   - Determine job completion by Ray terminal status (`SUCCEEDED`/`FAILED`/`STOPPED`), not by train-step counts.
-   - Treat Ray `RUNNING` as "controller process is running" only; it does **not** guarantee that TPU resources have been allocated yet.
-   - Best signal that the job is actually allocated: confirm the expected job id appears in W&B for this launch.
+3. CHECK STATUS
+   - if track=ray:
+     - terminal success: `SUCCEEDED`
+     - terminal non-success: `FAILED`, `STOPPED`
+     - non-terminal: `PENDING`, `RUNNING`
+   - if track=iris:
+     - query:
+       uv run iris --config <CONFIG> job list --json --prefix <JOB_ID>
+     - terminal success: `JOB_STATE_SUCCEEDED`
+     - terminal non-success: `JOB_STATE_FAILED`, `JOB_STATE_KILLED`, `JOB_STATE_WORKER_FAILED`, `JOB_STATE_UNSCHEDULABLE`
+     - non-terminal: `JOB_STATE_PENDING`, `JOB_STATE_BUILDING`, `JOB_STATE_RUNNING`
+     - if `pending_reason` indicates worker scale-up/capacity wait, treat it as scheduler capacity wait:
+       - do not run cluster update/recreate/restart actions
+       - continue waiting on cadence, or stop+resubmit only if user explicitly asks
+   - In both tracks, treat `RUNNING` as controller-level signal only; confirm allocation via expected W&B run when possible.
 
 4. PRINT W&B RUN IDS/LINKS
-   - Inspect recent logs for W&B run URLs / IDs (for example lines containing `wandb: 🚀 View run` or `/runs/<RUN_ID>`).
-   - Print the run id(s) and full W&B run link(s) once per training run.
-   - If a restart creates a new training run, print the new run id(s)/link(s) once.
+   - Inspect logs for W&B URL/ID (`wandb: 🚀 View run`, `/runs/<RUN_ID>`).
+   - Print run id(s) and full link(s) once per training run.
+   - If resubmission creates a new run, print new id/link once.
 
 5. REPORT PROGRESS
-   - When progress is visible, report as `~<current>/<exact_max>`.
+   - Report as `~<current>/<exact_max>`.
    - Example: `~4600/5155`.
-   - Never present rounded values (for example `5.16k`) as exact max.
-   - If max is unknown, report `~<current>/unknown`.
+   - Never present rounded max as exact.
+   - If max unknown, report `~<current>/unknown`.
 
 6. EVALUATE
-   - If a user-specified stopping point has been reached → summarize status and exit loop.
-   - If the job is terminal and successful (`SUCCEEDED`) → report completion and exit loop.
-   - If the job is terminal and not successful (`FAILED`/`STOPPED`) → go to step 7 unless user says otherwise.
-   - If output contains "error" or "Error" or "Traceback" → go to step 7
-   - Treat TPU/XLA HBM reports as failures even when "OOM" is not present. In particular, if logs include:
+   - If user stop point reached -> summarize and exit.
+   - If terminal success -> report completion and exit.
+   - If terminal non-success -> go to step 7 unless user says otherwise.
+   - If output contains `error`/`Error`/`Traceback` -> go to step 7.
+   - Treat TPU/XLA HBM reports as failure even without literal OOM:
      - `Program hbm requirement ...`
      - `Largest program allocations in hbm`
-     then treat this as an OOM/resource-exhaustion event and go to step 7.
-   - If progress does not advance for multiple 570-second intervals and logs show signals such as:
-     - `OwnerDiedError`
-     - dead node / node death
-     - autoscaler unsatisfied resources
-     then flag the run as `degraded` and notify the user immediately.
-   - If output contains "loss" lines → go to step 1
-   - If no output (job dead) → go to step 7
+   - If progress stalls across multiple intervals with `OwnerDiedError`, dead node, or unsatisfied resources -> mark `degraded` and notify user.
+   - If loss/progress lines are present and status non-terminal -> go to step 1.
+   - If no output and status non-terminal -> go to step 1.
 
-7. RESTART
-   - This step restarts only the Ray job. Never restart/recreate/mutate the cluster here without explicit human consent in this thread, except for TPU bad-node recovery below.
-   uv run lib/marin/src/marin/run/ray_run.py --no_wait --cluster <CLUSTER> -- python <EXPERIMENT_PATH>
+7. RECOVER (STOP -> RESUBMIT)
+   - Recover only the job (never mutate cluster without explicit consent, except TPU bad-node flow below).
+   - If current job is still non-terminal, stop it first:
+     - if track=ray:
+       uv run scripts/ray/cluster.py --cluster <CLUSTER> stop-job <JOB_ID>
+     - if track=iris:
+       uv run iris --config <CONFIG> job stop <JOB_ID>
+   - Then resubmit:
+     - if track=ray:
+       uv run lib/marin/src/marin/run/ray_run.py --no_wait --cluster <CLUSTER> -- python <EXPERIMENT_PATH>
+     - if track=iris:
+       <RESUBMIT_COMMAND>
 
-   - Capture new job_id from output
-   - Update state file: job_id = <NEW_JOB_ID>, restart_count += 1
-   - Go to step 1
+   - Capture `job_id` from output.
+     - Ray: from submit output / returned submission id.
+     - Iris: line like `Job submitted: /<user>/<job>`.
+   - Iris nuance:
+     - if `resubmit_command` omits `--job-name`, Iris auto-generates a fresh id each resubmission.
+     - if `resubmit_command` uses a fixed `--job-name`, Iris may reuse the same id after terminal completion by replacing the finished job.
+   - Update state file: `job_id=<NEW_JOB_ID>`, `restart_count += 1`.
+   - Go to step 1.
 ```
 
 ## Cluster Mutation Guardrail
 
 - Default rule: never restart, recreate, or otherwise mutate the cluster without explicit human consent in this thread.
+- This includes "cluster update" style actions; do not use them in Iris monitoring by default.
 
 ## Fixing Small Bugs
 
-When step 6 (EVALUATE) detects an error, before restarting:
+When EVALUATE detects an error, before recovery:
 
-1. **Analyze the error** in the logs:
-   - Look for `Traceback`, `Error`, `Exception`
-   - Identify the file and line number
+1. Analyze logs:
+   - Look for `Traceback`, `Error`, `Exception`.
+   - Identify file and line number.
+2. If it is a small fix (typo, missing import, wrong variable name):
+   - Read the file.
+   - Make the fix.
+   - Proceed to RECOVER for the active track.
+3. If it is complex (architectural, unclear cause, broad investigation):
+   - Do not auto-fix.
+   - Report to user and exit loop.
 
-2. **If it's a small fix** (typo, missing import, wrong variable name):
-   - Read the relevant file
-   - Make the fix with Edit tool
-   - Proceed to step 7 (RESTART)
+Small-fix examples:
+- `NameError: name 'foo' is not defined`
+- `ImportError: cannot import 'bar'`
+- `SyntaxError` from missing comma/bracket/colon
+- obvious wrong `KeyError` key
 
-3. **If it's a complex issue** (architectural, unclear cause, requires investigation):
-   - Do NOT attempt to fix automatically
-   - Report to user and exit the loop
-
-Examples of small fixes:
-- `NameError: name 'foo' is not defined` → typo in variable name
-- `ImportError: cannot import 'bar'` → missing or misspelled import
-- `SyntaxError` → missing comma, bracket, colon
-- `KeyError` → wrong dict key name (if obvious from context)
-
-Examples of complex issues (do not auto-fix):
+Complex examples:
 - OOM errors
-- TPU/XLA HBM exhaustion signatures such as `Program hbm requirement` and `Largest program allocations in hbm`
-- Distributed training failures
-- Data loading issues
-- Unclear stack traces spanning multiple files
+- TPU/XLA HBM exhaustion signatures (`Program hbm requirement`, `Largest program allocations in hbm`)
+- distributed training failures
+- data loading issues
+- unclear stack traces spanning multiple files
 
 ## TPU Bad-Node Recovery
 
-Special note: for TPU-related errors such as:
+For TPU-related errors such as:
 - `RuntimeError: No accelerator found. Please run on a TPU or GPU.`
 - `Failed to cleanup driver after error: INTERNAL: FAILED_PRECONDITION`
 - `Device or resource busy`
 
-Treat this as a bad TPU node:
-1. Identify the bad TPU worker IP from logs.
-2. Find the TPU VM name for that IP.
-3. Delete the bad TPU VM and let the cluster replace it.
+Treat as bad TPU node:
+
+1. Identify bad TPU worker IP from logs.
+2. Find TPU VM name for that IP.
+3. Delete bad TPU VM and let cluster replace it.
    - `gcloud compute tpus tpu-vm delete <TPU_VM_NAME> --zone <ZONE> --quiet`
-4. Restart the job.
+4. Recover the job (stop then resubmit) using the active track.
 
 ## Notes
 
-- Sleep must be foreground (max ~10 min due to tool timeout)
-- The loop is controlled at the agent level, not bash
-- Track restart_count to detect flapping jobs
-- State file allows resuming if context resets
-- The loop is expected to run for the full job duration (often 4-5 hours for ferries, but potentially days for longer jobs)
-- If the same error occurs after a fix attempt, do not retry - report to user
-- Never restart/recreate/mutate the cluster (including restarting the head node) without explicit human consent in this thread, except for the TPU bad-node recovery flow above
+- Sleep must be foreground (max ~10 min due to tool timeout).
+- Loop control is at agent level, not bash.
+- Track `restart_count` to detect flapping.
+- State file allows resume after context reset.
+- Ray and Iris status enums are not identical:
+  - Ray: `PENDING`, `RUNNING`, `STOPPED`, `SUCCEEDED`, `FAILED`
+  - Iris: `JOB_STATE_PENDING`, `JOB_STATE_BUILDING`, `JOB_STATE_RUNNING`, `JOB_STATE_SUCCEEDED`, `JOB_STATE_FAILED`, `JOB_STATE_KILLED`, `JOB_STATE_WORKER_FAILED`, `JOB_STATE_UNSCHEDULABLE`
+  - Practical mapping:
+    - Ray `STOPPED` ~= Iris `JOB_STATE_KILLED`
+    - Iris `JOB_STATE_WORKER_FAILED` and `JOB_STATE_UNSCHEDULABLE` have no direct Ray `JobStatus` equivalent and should be treated as terminal failures.
+- Iris `job list --prefix` requires canonical job names (`/<user>/<job>`), not short names.
+- Iris monitoring is job-level; cluster updates are not part of normal recovery.
+- Loop duration can be hours to days.
+- If same error repeats after one fix attempt, do not retry blindly; report to user.
 
 ## Optional Todo Pattern
 
-If the agent supports a todo list, this pattern works well:
+If the agent supports todos:
 
 - [ ] sleep 570
-- [ ] check cluster logs with `cluster.py`
-- [ ] print relevant logs/status (including progress and W&B links)
-- [ ] evaluate state and take actions
-- [ ] if not done, recreate this todo list and keep going
+- [ ] check logs for active track (`scripts/ray/cluster.py job-logs` or `iris job logs`)
+- [ ] check status for active track (`ray list jobs` via helper or `iris job list --json --prefix`)
+- [ ] print relevant logs/status (progress and W&B links)
+- [ ] evaluate and take action
+- [ ] recreate todo list if loop continues


### PR DESCRIPTION
## Summary
- split the playbook into explicit Ray and Iris monitoring tracks
- add interleaved loop guidance with track-specific log/status/recovery commands
- document Iris job-state handling, stop->resubmit semantics, and required `--extra marin:tpu` usage for Marin TPU jobs
- restore the interleaved loop section wording and add explicit Codex guidance to avoid ending turn for status-only updates unless directed

## Validation
- docs-only change
