### PR TITLE
docs: align contributing hook setup with Makefile target

### DIFF
--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -13,13 +13,7 @@ cd marin
 uv venv --python 3.11
 source .venv/bin/activate
 uv sync --package marin --group dev
-cat <<'EOF' > .git/hooks/pre-commit
-#!/bin/sh
-set -e
-cd "$(git rev-parse --show-toplevel)"
-./infra/pre-commit.py --fix
-EOF
-chmod +x .git/hooks/pre-commit
+make setup_pre_commit
 ```
 
 Alternatively, you can install all the core dependencies and build `marin` as a Python


### PR DESCRIPTION
## Summary
- update contributing setup instructions to use `make setup_pre_commit`
- remove the inline heredoc hook script now that the Makefile target exists
- keep docs aligned with the maintained operator workflow in `Makefile`

## Why
`docs/dev-guide/contributing.md` documented a manual pre-commit hook install flow, while the repo now provides `make setup_pre_commit` for this exact task. This creates docs/code drift and duplicates logic.

Refs #12
