### PR TITLE
eval: explicit batch-resource wiring and compute-axis naming

### DIFF
--- a/experiments/grug/base/model.py
+++ b/experiments/grug/base/model.py
@@ -219,6 +219,26 @@ class Transformer(eqx.Module):
             dtype=loss_dtype,
         )
 
+    def compute_next_token_loss(
+        self,
+        token_ids: Int[Array, "B S"],
+        loss_weight: Float[Array, "B S"],
+        *,
+        mask: AttentionMask | jax.Array | None = None,
+        reduction: str = "mean",
+        logsumexp_weight: float | None = None,
+        loss_dtype: jnp.dtype = jnp.float32,
+    ) -> jax.Array:
+        """Compatibility wrapper used by shared training/eval surfaces."""
+        return self.next_token_loss(
+            token_ids,
+            loss_weight,
+            mask=mask,
+            reduction=reduction,
+            logsumexp_weight=logsumexp_weight,
+            loss_dtype=loss_dtype,
+        )
+
 
 def _init_weight(key: PRNGKeyArray, shape: tuple[int, ...], std: float) -> Float[Array, "..."]:
     return std * random.truncated_normal(key, -3, 3, shape)

--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Marin Authors
+# Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -9,6 +9,7 @@ import logging
 import time
 from dataclasses import dataclass, field
 
+from fray.cluster import ResourceConfig
 import jax
 import jax.numpy as jnp
 import jmp
@@ -71,6 +72,7 @@ class GrugRunConfig:
 
     model: GrugModelConfig
     data: LmDataConfig
+    resources: ResourceConfig | None = None
     optimizer: OptimizerConfig = field(default_factory=AdamConfig)
     trainer: GrugTrainerConfig = field(default_factory=GrugTrainerConfig)
     eval: GrugEvalConfig | None = field(default_factory=GrugEvalConfig)
@@ -152,7 +154,7 @@ def build_tagged_evaluator(
         return per_pos_loss, per_pos_weight, per_pos_token_id
 
     return TaggedEvaluator(
-        EvalBatch=eval_cfg.eval_batch_size,
+        eval_batch_size=eval_cfg.eval_batch_size,
         tagged_eval_sets=tagged_eval_sets,
         loss_fn=eval_loss_fn,
         tokenizer=tokenizer,
@@ -213,6 +215,22 @@ class GrugTrainState:
     params: Transformer
     opt_state: optax.OptState
     ema_params: Transformer
+
+
+def initial_state(
+    model_config: GrugModelConfig,
+    *,
+    optimizer: optax.GradientTransformation,
+    mp: jmp.Policy,
+    key: PRNGKeyArray,
+) -> GrugTrainState:
+    params = mp.cast_to_param(Transformer.init(model_config, key=key))
+    return GrugTrainState(
+        step=jnp.array(0, dtype=jnp.int32),
+        params=params,
+        opt_state=optimizer.init(params),
+        ema_params=params,
+    )
 
 
 def _make_train_step(
@@ -330,13 +348,7 @@ def run_grug(config: GrugRunConfig) -> None:
 
         @jax.jit
         def _init_state(model_rng):
-            params = trainer.mp.cast_to_param(Transformer.init(config.model, key=model_rng))
-            return GrugTrainState(
-                step=jnp.array(0, dtype=jnp.int32),
-                params=params,
-                opt_state=optimizer.init(params),
-                ema_params=params,
-            )
+            return initial_state(config.model, optimizer=optimizer, mp=trainer.mp, key=model_rng)
 
         state = _init_state(model_key)
 
@@ -466,5 +478,6 @@ __all__ = [
     "GrugRunConfig",
     "GrugTrainState",
     "GrugTrainerConfig",
+    "initial_state",
     "run_grug",
 ]

--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -136,7 +136,6 @@ def build_tagged_evaluator(
 
     tokenizer = data_config.the_tokenizer if eval_cfg.compute_bpb else None
     batch_axis_resource = eval_cfg.eval_batch_pspec[0]
-    eval_axis_mapping = {"batch": batch_axis_resource}
     eval_array_sharding = NamedSharding(mesh, P(batch_axis_resource, None))
 
     def eval_loss_fn(model: Transformer, batch: GrugLmExample) -> tuple[jax.Array, jax.Array, jax.Array]:
@@ -158,7 +157,7 @@ def build_tagged_evaluator(
         loss_fn=eval_loss_fn,
         tokenizer=tokenizer,
         device_mesh=mesh,
-        axis_mapping=eval_axis_mapping,
+        batch_axis_resource=batch_axis_resource,
         max_examples_per_dataset=max_examples_per_dataset,
     )
 

--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -154,7 +154,7 @@ def build_tagged_evaluator(
         return per_pos_loss, per_pos_weight, per_pos_token_id
 
     return TaggedEvaluator(
-        eval_batch_size=eval_cfg.eval_batch_size,
+        EvalBatch=eval_cfg.eval_batch_size,
         tagged_eval_sets=tagged_eval_sets,
         loss_fn=eval_loss_fn,
         tokenizer=tokenizer,

--- a/lib/levanter/src/levanter/analysis/entropy.py
+++ b/lib/levanter/src/levanter/analysis/entropy.py
@@ -112,7 +112,8 @@ def cb_compute_entropies(
     test_data,
     prefix: str | None,
     batch_size: int,
-    mapping: hax.partitioning.ResourceMapping,
+    batch_axis_resource,
+    batch_axis_name: str = "batch",
     num_tokens: int = 10 * 1024 * 1024,
 ):
     """
@@ -125,7 +126,8 @@ def cb_compute_entropies(
         prefix (str | None): The key to log to the tracker. If None, "entropy" is used.
         num_tokens: The number of tokens to use.
         batch_size: The batch size to use.
-        mapping: The resource mapping
+        batch_axis_resource: Resource for sharding the batch axis.
+        batch_axis_name: Name of the batch axis in the dataset examples.
 
     Returns:
         function: A function that takes a step info and computes and visualizes the log probabilities.
@@ -134,7 +136,16 @@ def cb_compute_entropies(
         prefix = "analysis"
 
     def compute_entropy(step: StepInfo):
-        data_loader = DataLoader(test_data, batch_size=batch_size, pad_final_batch=False, axis_resources=mapping)
+        loader_axis_resources = None
+        if batch_axis_resource is not None:
+            loader_axis_resources = {batch_axis_name: batch_axis_resource}
+        data_loader = DataLoader(
+            test_data,
+            batch_size=batch_size,
+            batch_axis_name=batch_axis_name,
+            pad_final_batch=False,
+            axis_resources=loader_axis_resources,
+        )
         model = step.eval_model
 
         try:
@@ -193,14 +204,24 @@ def cb_compute_top2_gap(
     test_data,
     prefix: str | None,
     batch_size: int,
-    mapping: hax.partitioning.ResourceMapping,
+    batch_axis_resource,
+    batch_axis_name: str = "batch",
     num_tokens: int = 10 * 1024 * 1024,
 ):
     if prefix is None:
         prefix = "analysis"
 
     def compute_top2_gap(step: StepInfo):
-        data_loader = DataLoader(test_data, batch_size=batch_size, pad_final_batch=False, axis_resources=mapping)
+        loader_axis_resources = None
+        if batch_axis_resource is not None:
+            loader_axis_resources = {batch_axis_name: batch_axis_resource}
+        data_loader = DataLoader(
+            test_data,
+            batch_size=batch_size,
+            batch_axis_name=batch_axis_name,
+            pad_final_batch=False,
+            axis_resources=loader_axis_resources,
+        )
         model = step.eval_model
         try:
             top2_gap_hist = compute_top2_gap_histogram(

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -208,7 +208,7 @@ def cb_tagged_lm_evaluate(
     tagged_eval_sets: Sequence[tuple[AsyncDataset[LmEvalExample], Sequence[str]]],
     tokenizer: Optional[HfTokenizer] = None,
     device_mesh: Optional[Mesh] = None,
-    axis_mapping: ResourceMapping | None = None,
+    compute_axis_mapping: ResourceMapping | None = None,
     batch_axis_resource=None,
     max_examples_per_dataset: Optional[int] = None,
     eval_current: bool = True,
@@ -236,7 +236,7 @@ def cb_tagged_lm_evaluate(
         tagged_eval_sets: A list of datasets, each with its own domain tag
         tokenizer: The tokenizer to use for bits-per-byte evaluation (optional)
         device_mesh: The mesh to use for evaluation
-        axis_mapping: The axis mapping to use for evaluation
+        compute_axis_mapping: The axis mapping to use for evaluation
         batch_axis_resource: The explicit mesh resource to shard the eval batch axis onto.
         max_examples_per_dataset: The maximum number of examples to use from each dataset
         prefix: The prefix to use for logging the losses
@@ -254,7 +254,7 @@ def cb_tagged_lm_evaluate(
             return _default_lm_eval_loss_fn(model, batch, EvalBatch=EvalBatch, mp=mp)
 
     if batch_axis_resource is None:
-        batch_axis_resource = resolve_batch_axis_resource(EvalBatch, axis_mapping)
+        batch_axis_resource = resolve_batch_axis_resource(EvalBatch, compute_axis_mapping)
 
     evaluator = TaggedEvaluator(
         EvalBatch=EvalBatch,
@@ -262,7 +262,7 @@ def cb_tagged_lm_evaluate(
         loss_fn=loss_fn,
         tokenizer=tokenizer,
         device_mesh=device_mesh,
-        axis_mapping=axis_mapping,
+        compute_axis_mapping=compute_axis_mapping,
         batch_axis_resource=batch_axis_resource,
         max_examples_per_dataset=max_examples_per_dataset,
     )
@@ -410,15 +410,15 @@ class TaggedEvaluator(Generic[Ex, M]):
         loss_fn: Callable[[M, Ex], LossFnOutput],
         tokenizer: Optional[HfTokenizer] = None,
         device_mesh=None,
-        axis_mapping=None,
+        compute_axis_mapping=None,
         batch_axis_resource=None,
         max_examples_per_dataset=None,
     ):
         if isinstance(EvalBatch, int):
             EvalBatch = hax.Axis("batch", EvalBatch)
         if batch_axis_resource is None:
-            batch_axis_resource = resolve_batch_axis_resource(EvalBatch, axis_mapping)
-        loader_axis_resources = axis_mapping
+            batch_axis_resource = resolve_batch_axis_resource(EvalBatch, compute_axis_mapping)
+        loader_axis_resources = compute_axis_mapping
         if batch_axis_resource is not None:
             loader_axis_resources = {EvalBatch.name: batch_axis_resource}
         self.loss_fn = loss_fn
@@ -432,7 +432,7 @@ class TaggedEvaluator(Generic[Ex, M]):
         )
         self.device_mesh = device_mesh
         self.tokenizer = tokenizer
-        self.axis_mapping = axis_mapping
+        self.compute_axis_mapping = compute_axis_mapping
         self.per_pos_out_sharding = None
         if device_mesh is not None and batch_axis_resource is not None:
             if axis_resource_is_explicit(device_mesh, batch_axis_resource):

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -448,7 +448,7 @@ class TaggedEvaluator(Generic[Ex, M]):
         per_tag_out_sharding = None if self.device_mesh is None else NamedSharding(self.device_mesh, P(None))
         per_pos_out_sharding = self.per_pos_out_sharding
 
-        @hax.named_jit(axis_resources=self.axis_mapping)
+        @hax.named_jit(axis_resources=self.compute_axis_mapping)
         def accum_for_batch(model: M, state: _EvalRunningMeans, batch: Ex, tags: BatchedTagArray):
             losses, weights, token_ids = self.loss_fn(model, batch)
             weighted_loss = losses * weights  # b t

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -47,12 +47,12 @@ TagArray = Int[Array, "tag"]
 BatchedTagArray = Int[Array, "... tag"]
 
 
-def resolve_batch_axis_resource(EvalBatch: hax.Axis | int, axis_mapping: ResourceMapping | None):
-    if axis_mapping is None:
+def resolve_batch_axis_resource(EvalBatch: hax.Axis | int, compute_axis_mapping: ResourceMapping | None):
+    if compute_axis_mapping is None:
         return None
     if isinstance(EvalBatch, int):
-        return axis_mapping.get("batch")
-    return axis_mapping.get(EvalBatch.name, axis_mapping.get("batch"))
+        return compute_axis_mapping.get("batch")
+    return compute_axis_mapping.get(EvalBatch.name, compute_axis_mapping.get("batch"))
 
 
 @dataclasses.dataclass

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -47,6 +47,14 @@ TagArray = Int[Array, "tag"]
 BatchedTagArray = Int[Array, "... tag"]
 
 
+def resolve_batch_axis_resource(EvalBatch: hax.Axis | int, axis_mapping: ResourceMapping | None):
+    if axis_mapping is None:
+        return None
+    if isinstance(EvalBatch, int):
+        return axis_mapping.get("batch")
+    return axis_mapping.get(EvalBatch.name, axis_mapping.get("batch"))
+
+
 @dataclasses.dataclass
 class EvalResult:
     micro_avg_loss: float  # per token across all datasets
@@ -245,8 +253,8 @@ def cb_tagged_lm_evaluate(
         def loss_fn(model: LmHeadModel, batch: LmEvalExample) -> LossFnOutput:
             return _default_lm_eval_loss_fn(model, batch, EvalBatch=EvalBatch, mp=mp)
 
-    if batch_axis_resource is None and axis_mapping is not None:
-        batch_axis_resource = axis_mapping.get(EvalBatch.name, axis_mapping.get("batch"))
+    if batch_axis_resource is None:
+        batch_axis_resource = resolve_batch_axis_resource(EvalBatch, axis_mapping)
 
     evaluator = TaggedEvaluator(
         EvalBatch=EvalBatch,
@@ -408,8 +416,8 @@ class TaggedEvaluator(Generic[Ex, M]):
     ):
         if isinstance(EvalBatch, int):
             EvalBatch = hax.Axis("batch", EvalBatch)
-        if batch_axis_resource is None and axis_mapping is not None:
-            batch_axis_resource = axis_mapping.get(EvalBatch.name, axis_mapping.get("batch"))
+        if batch_axis_resource is None:
+            batch_axis_resource = resolve_batch_axis_resource(EvalBatch, axis_mapping)
         loader_axis_resources = axis_mapping
         if batch_axis_resource is not None:
             loader_axis_resources = {EvalBatch.name: batch_axis_resource}

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -196,7 +196,7 @@ def _default_lm_eval_loss_fn(
 
 
 def cb_tagged_lm_evaluate(
-    EvalBatch: hax.Axis,
+    EvalBatch: hax.Axis | int,
     tagged_eval_sets: Sequence[tuple[AsyncDataset[LmEvalExample], Sequence[str]]],
     tokenizer: Optional[HfTokenizer] = None,
     device_mesh: Optional[Mesh] = None,
@@ -236,6 +236,9 @@ def cb_tagged_lm_evaluate(
         eval_ema: Whether to evaluate the EMA model (or other model averaged model)
         checkpoint_path: If provided, write eval metrics to a JSONL file in this directory
     """
+
+    if isinstance(EvalBatch, int):
+        EvalBatch = hax.Axis("batch", EvalBatch)
 
     if loss_fn is None:
 

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -394,10 +394,16 @@ class TaggedEvaluator(Generic[Ex, M]):
         tokenizer: Optional[HfTokenizer] = None,
         device_mesh=None,
         axis_mapping=None,
+        batch_axis_resource=None,
         max_examples_per_dataset=None,
     ):
         if isinstance(EvalBatch, int):
             EvalBatch = hax.Axis("batch", EvalBatch)
+        if batch_axis_resource is None and axis_mapping is not None:
+            batch_axis_resource = axis_mapping.get(EvalBatch.name, axis_mapping.get("batch"))
+        loader_axis_resources = axis_mapping
+        if loader_axis_resources is None and batch_axis_resource is not None:
+            loader_axis_resources = {EvalBatch.name: batch_axis_resource}
         self.loss_fn = loss_fn
         self.dataset = DomainTaggedDataset(tagged_eval_sets, max_examples_per_dataset)
         self.loader = DataLoader(
@@ -405,15 +411,14 @@ class TaggedEvaluator(Generic[Ex, M]):
             EvalBatch,
             max_buffered_batches=100,
             mesh=device_mesh,
-            axis_resources=axis_mapping,
+            axis_resources=loader_axis_resources,
         )
         self.device_mesh = device_mesh
         self.tokenizer = tokenizer
         self.axis_mapping = axis_mapping
         self.per_pos_out_sharding = None
-        if device_mesh is not None and axis_mapping is not None:
-            batch_axis_resource = axis_mapping.get(EvalBatch.name, axis_mapping.get("batch"))
-            if batch_axis_resource is not None and axis_resource_is_explicit(device_mesh, batch_axis_resource):
+        if device_mesh is not None and batch_axis_resource is not None:
+            if axis_resource_is_explicit(device_mesh, batch_axis_resource):
                 self.per_pos_out_sharding = NamedSharding(device_mesh, P(batch_axis_resource, None))
 
         self.bytes_per_token = self._calculate_bytes_per_token_type(tokenizer)

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -201,6 +201,7 @@ def cb_tagged_lm_evaluate(
     tokenizer: Optional[HfTokenizer] = None,
     device_mesh: Optional[Mesh] = None,
     axis_mapping: ResourceMapping | None = None,
+    batch_axis_resource=None,
     max_examples_per_dataset: Optional[int] = None,
     eval_current: bool = True,
     eval_ema: bool = True,
@@ -228,6 +229,7 @@ def cb_tagged_lm_evaluate(
         tokenizer: The tokenizer to use for bits-per-byte evaluation (optional)
         device_mesh: The mesh to use for evaluation
         axis_mapping: The axis mapping to use for evaluation
+        batch_axis_resource: The explicit mesh resource to shard the eval batch axis onto.
         max_examples_per_dataset: The maximum number of examples to use from each dataset
         prefix: The prefix to use for logging the losses
         eval_current: Whether to evaluate the model's current parameters
@@ -240,6 +242,9 @@ def cb_tagged_lm_evaluate(
         def loss_fn(model: LmHeadModel, batch: LmEvalExample) -> LossFnOutput:
             return _default_lm_eval_loss_fn(model, batch, EvalBatch=EvalBatch, mp=mp)
 
+    if batch_axis_resource is None and axis_mapping is not None:
+        batch_axis_resource = axis_mapping.get(EvalBatch.name, axis_mapping.get("batch"))
+
     evaluator = TaggedEvaluator(
         EvalBatch=EvalBatch,
         tagged_eval_sets=tagged_eval_sets,
@@ -247,6 +252,7 @@ def cb_tagged_lm_evaluate(
         tokenizer=tokenizer,
         device_mesh=device_mesh,
         axis_mapping=axis_mapping,
+        batch_axis_resource=batch_axis_resource,
         max_examples_per_dataset=max_examples_per_dataset,
     )
 
@@ -402,7 +408,7 @@ class TaggedEvaluator(Generic[Ex, M]):
         if batch_axis_resource is None and axis_mapping is not None:
             batch_axis_resource = axis_mapping.get(EvalBatch.name, axis_mapping.get("batch"))
         loader_axis_resources = axis_mapping
-        if loader_axis_resources is None and batch_axis_resource is not None:
+        if batch_axis_resource is not None:
             loader_axis_resources = {EvalBatch.name: batch_axis_resource}
         self.loss_fn = loss_fn
         self.dataset = DomainTaggedDataset(tagged_eval_sets, max_examples_per_dataset)

--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -1530,7 +1530,7 @@ def run_eval_harness_main(config: EvalHarnessMainConfig):
             config.EvalBatch,
             axis_resources=compute_axis_mapping,
             mp=config.trainer.mp,
-            batch_axis_resource=resolve_batch_axis_resource(config.EvalBatch, compute_axis_mapping),
+            batch_axis_resource=config.trainer.batch_axis_resource,
             profiler_config=profiler_config,
         )
 

--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -80,6 +80,7 @@ from levanter.callbacks import StepInfo
 from levanter.checkpoint import load_checkpoint
 from levanter.data import batched
 from levanter.data.loader import stack_batches
+from levanter.eval import resolve_batch_axis_resource
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import broadcast_shard, parameter_count, use_cpu_device
@@ -225,6 +226,7 @@ class _LmEvalHarnessWorker:
         EvalPos,
         model,
         axis_resources,
+        batch_axis_resource,
         tokenizer,
         mp,
         max_packed_segments,
@@ -238,6 +240,9 @@ class _LmEvalHarnessWorker:
         self.EvalPos = EvalPos
         self.model = model
         self.axis_resources = axis_resources
+        self.batch_axis_resources = axis_resources
+        if batch_axis_resource is not None:
+            self.batch_axis_resources = {self.EvalBatch.name: batch_axis_resource}
         self.mp = mp
         self.max_packed_segments = max_packed_segments
         self._generation_kwargs = generation_kwargs or {"max_gen_toks": 256, "temperature": 0.0, "n": 1, "seed": None}
@@ -424,6 +429,7 @@ class LevanterHarnessLM(TemplateLM):
         super().__init__()
         self.leader = leader
         self.axis_resources = leader.axis_resources
+        self.batch_axis_resources = leader.batch_axis_resources
         # Storage for prompts and generations to include in outputs
         self.sample_outputs: dict[str, list[dict]] = {}
         self.sample_logging_config = leader.sample_logging_config
@@ -617,7 +623,7 @@ class LevanterHarnessLM(TemplateLM):
             # Handle profiler start/stop based on step
             self._handle_profiler_step()
 
-            batch = hax.shard(batch, self.axis_resources)
+            batch = hax.shard(batch, self.batch_axis_resources)
 
             segments_this_batch = get_segment_ids_from_batch(
                 batch, self.leader.max_packed_segments * self.EvalBatch.size
@@ -1249,6 +1255,7 @@ def run_lm_eval_harness(
     EvalBatch: haliax.Axis | int,
     axis_resources: ResourceMapping,
     mp: jmp.Policy | None,
+    batch_axis_resource=None,
     profiler_config: ProfilerConfig | None = None,
 ) -> dict | None:
     """
@@ -1261,6 +1268,7 @@ def run_lm_eval_harness(
         EvalBatch: Batch axis for evaluation, or an integer batch size.
         axis_resources: Resource mapping for distributed computation
         mp: Mixed precision policy
+        batch_axis_resource: Explicit resource to use for the eval batch axis.
         profiler_config: Optional ProfilerConfig for profiling during evaluation
 
     Returns:
@@ -1268,11 +1276,22 @@ def run_lm_eval_harness(
         - "averages": A dictionary with macro and micro averages for all metrics.
         Otherwise, returns None.
     """
+    if batch_axis_resource is None:
+        batch_axis_resource = resolve_batch_axis_resource(EvalBatch, axis_resources)
+
     # Build the tasks dictionary
     tasks_to_run = config.to_task_dict()
 
     outputs = _actually_run_eval_harness(
-        config, model, tasks_to_run, tokenizer, EvalBatch, axis_resources, mp, profiler_config
+        config,
+        model,
+        tasks_to_run,
+        tokenizer,
+        EvalBatch,
+        axis_resources,
+        mp,
+        batch_axis_resource=batch_axis_resource,
+        profiler_config=profiler_config,
     )
 
     return outputs
@@ -1286,6 +1305,7 @@ def _actually_run_eval_harness(
     EvalBatch: haliax.Axis | int,
     axis_resources: ResourceMapping,
     mp: jmp.Policy | None,
+    batch_axis_resource=None,
     profiler_config: ProfilerConfig | None = None,
 ) -> dict | None:
     """
@@ -1312,12 +1332,15 @@ def _actually_run_eval_harness(
         f" {num_parameters} parameters in the model."
     )
     logger.info("Running eval harness...")
+    if batch_axis_resource is None:
+        batch_axis_resource = resolve_batch_axis_resource(EvalBatch, axis_resources)
 
     worker = _LmEvalHarnessWorker(
         EvalBatch,
         EvalPos,
         model,
         axis_resources,
+        batch_axis_resource,
         tokenizer,
         mp,
         max_packed_segments=64,
@@ -1507,6 +1530,7 @@ def run_eval_harness_main(config: EvalHarnessMainConfig):
             config.EvalBatch,
             axis_resources=compute_axis_mapping,
             mp=config.trainer.mp,
+            batch_axis_resource=resolve_batch_axis_resource(config.EvalBatch, compute_axis_mapping),
             profiler_config=profiler_config,
         )
 
@@ -1572,6 +1596,7 @@ def lm_eval_harness(
     EvalBatch: haliax.Axis | int,
     axis_resources: ResourceMapping,
     mp: jmp.Policy | None,
+    batch_axis_resource=None,
 ):
     """
     Create a callback function for running the LM Eval Harness during training.
@@ -1582,11 +1607,14 @@ def lm_eval_harness(
         EvalBatch: Batch axis for evaluation, or an integer batch size.
         axis_resources: Resource mapping for distributed computation
         mp: Mixed precision policy
+        batch_axis_resource: Explicit resource to use for the eval batch axis.
 
     Returns:
         Callback function that can be used with the trainer
     """
     tasks_to_run = config.to_task_dict()
+    if batch_axis_resource is None:
+        batch_axis_resource = resolve_batch_axis_resource(EvalBatch, axis_resources)
 
     def lm_eval_harness(step: StepInfo, force=False):
         if step.step == 0 and not force:
@@ -1604,6 +1632,7 @@ def lm_eval_harness(
             EvalBatch,
             axis_resources,
             mp,
+            batch_axis_resource=batch_axis_resource,
             profiler_config=None,
         )
         logger.info("Finished running eval harness.")

--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -225,7 +225,7 @@ class _LmEvalHarnessWorker:
         EvalBatch,
         EvalPos,
         model,
-        axis_resources,
+        compute_axis_resources,
         batch_axis_resource,
         tokenizer,
         mp,
@@ -239,8 +239,8 @@ class _LmEvalHarnessWorker:
         self.EvalBatch = EvalBatch
         self.EvalPos = EvalPos
         self.model = model
-        self.axis_resources = axis_resources
-        self.batch_axis_resources = axis_resources
+        self.compute_axis_resources = compute_axis_resources
+        self.batch_axis_resources = compute_axis_resources
         if batch_axis_resource is not None:
             self.batch_axis_resources = {self.EvalBatch.name: batch_axis_resource}
         self.mp = mp
@@ -312,7 +312,7 @@ class _LmEvalHarnessWorker:
 
         # no sharded outputs
         self._jit_loglikelihood = hax.named_jit(
-            _eval_loglikelihood, axis_resources=axis_resources, out_axis_resources={}
+            _eval_loglikelihood, axis_resources=compute_axis_resources, out_axis_resources={}
         )
 
     @property
@@ -428,7 +428,7 @@ class LevanterHarnessLM(TemplateLM):
     def __init__(self, leader: _LmEvalHarnessWorker):
         super().__init__()
         self.leader = leader
-        self.axis_resources = leader.axis_resources
+        self.compute_axis_resources = leader.compute_axis_resources
         self.batch_axis_resources = leader.batch_axis_resources
         # Storage for prompts and generations to include in outputs
         self.sample_outputs: dict[str, list[dict]] = {}
@@ -1253,7 +1253,7 @@ def run_lm_eval_harness(
     model,
     tokenizer,
     EvalBatch: haliax.Axis | int,
-    axis_resources: ResourceMapping,
+    compute_axis_resources: ResourceMapping,
     mp: jmp.Policy | None,
     batch_axis_resource=None,
     profiler_config: ProfilerConfig | None = None,
@@ -1266,7 +1266,7 @@ def run_lm_eval_harness(
         model: The Levanter model to evaluate
         tokenizer: Tokenizer for the model
         EvalBatch: Batch axis for evaluation, or an integer batch size.
-        axis_resources: Resource mapping for distributed computation
+        compute_axis_resources: Resource mapping for distributed computation
         mp: Mixed precision policy
         batch_axis_resource: Explicit resource to use for the eval batch axis.
         profiler_config: Optional ProfilerConfig for profiling during evaluation
@@ -1277,7 +1277,7 @@ def run_lm_eval_harness(
         Otherwise, returns None.
     """
     if batch_axis_resource is None:
-        batch_axis_resource = resolve_batch_axis_resource(EvalBatch, axis_resources)
+        batch_axis_resource = resolve_batch_axis_resource(EvalBatch, compute_axis_resources)
 
     # Build the tasks dictionary
     tasks_to_run = config.to_task_dict()
@@ -1288,7 +1288,7 @@ def run_lm_eval_harness(
         tasks_to_run,
         tokenizer,
         EvalBatch,
-        axis_resources,
+        compute_axis_resources,
         mp,
         batch_axis_resource=batch_axis_resource,
         profiler_config=profiler_config,
@@ -1303,7 +1303,7 @@ def _actually_run_eval_harness(
     tasks_to_run: dict,
     tokenizer: HfTokenizer,
     EvalBatch: haliax.Axis | int,
-    axis_resources: ResourceMapping,
+    compute_axis_resources: ResourceMapping,
     mp: jmp.Policy | None,
     batch_axis_resource=None,
     profiler_config: ProfilerConfig | None = None,
@@ -1333,13 +1333,13 @@ def _actually_run_eval_harness(
     )
     logger.info("Running eval harness...")
     if batch_axis_resource is None:
-        batch_axis_resource = resolve_batch_axis_resource(EvalBatch, axis_resources)
+        batch_axis_resource = resolve_batch_axis_resource(EvalBatch, compute_axis_resources)
 
     worker = _LmEvalHarnessWorker(
         EvalBatch,
         EvalPos,
         model,
-        axis_resources,
+        compute_axis_resources,
         batch_axis_resource,
         tokenizer,
         mp,
@@ -1528,7 +1528,7 @@ def run_eval_harness_main(config: EvalHarnessMainConfig):
             model,
             tokenizer,
             config.EvalBatch,
-            axis_resources=compute_axis_mapping,
+            compute_axis_resources=compute_axis_mapping,
             mp=config.trainer.mp,
             batch_axis_resource=config.trainer.batch_axis_resource,
             profiler_config=profiler_config,
@@ -1594,7 +1594,7 @@ def lm_eval_harness(
     config: LmEvalHarnessConfig,
     tokenizer,
     EvalBatch: haliax.Axis | int,
-    axis_resources: ResourceMapping,
+    compute_axis_resources: ResourceMapping,
     mp: jmp.Policy | None,
     batch_axis_resource=None,
 ):
@@ -1605,7 +1605,7 @@ def lm_eval_harness(
         config: Configuration for the evaluation harness
         tokenizer: Tokenizer for the model
         EvalBatch: Batch axis for evaluation, or an integer batch size.
-        axis_resources: Resource mapping for distributed computation
+        compute_axis_resources: Resource mapping for distributed computation
         mp: Mixed precision policy
         batch_axis_resource: Explicit resource to use for the eval batch axis.
 
@@ -1614,7 +1614,7 @@ def lm_eval_harness(
     """
     tasks_to_run = config.to_task_dict()
     if batch_axis_resource is None:
-        batch_axis_resource = resolve_batch_axis_resource(EvalBatch, axis_resources)
+        batch_axis_resource = resolve_batch_axis_resource(EvalBatch, compute_axis_resources)
 
     def lm_eval_harness(step: StepInfo, force=False):
         if step.step == 0 and not force:
@@ -1630,7 +1630,7 @@ def lm_eval_harness(
             tasks_to_run,
             tokenizer,
             EvalBatch,
-            axis_resources,
+            compute_axis_resources,
             mp,
             batch_axis_resource=batch_axis_resource,
             profiler_config=None,

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -20,7 +20,7 @@ from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, RepoRef
 from levanter.data import DataLoader
 from levanter.data.text import LmDataConfig
-from levanter.eval import LossFnOutput, TaggedEvaluator, eval_model
+from levanter.eval import LossFnOutput, TaggedEvaluator, eval_model, resolve_batch_axis_resource
 from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.trainer import TrainerConfig
@@ -73,7 +73,7 @@ def main(config: EvalLmConfig):
 
     compute_axis_mapping = config.trainer.compute_axis_mapping
     parameter_axis_mapping = config.trainer.parameter_axis_mapping
-    batch_axis_resource = compute_axis_mapping.get(Batch.name, compute_axis_mapping.get("batch"))
+    batch_axis_resource = resolve_batch_axis_resource(Batch, compute_axis_mapping)
 
     if config.checkpoint_path is None and config.hf_checkpoint is None:
         raise ValueError("Must specify either checkpoint_path or hf_checkpoint")

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -74,6 +74,7 @@ def main(config: EvalLmConfig):
     compute_axis_mapping = config.trainer.compute_axis_mapping
     parameter_axis_mapping = config.trainer.parameter_axis_mapping
     batch_axis_resource = resolve_batch_axis_resource(Batch, compute_axis_mapping)
+    loader_axis_resources = {Batch.name: batch_axis_resource} if batch_axis_resource is not None else None
 
     if config.checkpoint_path is None and config.hf_checkpoint is None:
         raise ValueError("Must specify either checkpoint_path or hf_checkpoint")
@@ -162,7 +163,8 @@ def main(config: EvalLmConfig):
                 loader = DataLoader(
                     dataset,
                     batch_size=config.trainer.eval_batch_size,
-                    axis_resources={"batch": batch_axis_resource} if batch_axis_resource is not None else None,
+                    batch_axis_name=Batch.name,
+                    axis_resources=loader_axis_resources,
                 )
                 entropy_hist = levanter.analysis.compute_entropy_histogram(
                     model,
@@ -183,24 +185,25 @@ def main(config: EvalLmConfig):
             for name, dataset in config.data.validation_sets(Pos).items():
                 if config.trainer.max_eval_batches is not None:
                     dataset = dataset.take(config.trainer.max_eval_batches * config.trainer.eval_batch_size)
-                    loader = DataLoader(
-                        dataset,
-                        batch_size=config.trainer.eval_batch_size,
-                        axis_resources={"batch": batch_axis_resource} if batch_axis_resource is not None else None,
-                    )
-                    top2_gap_hist = levanter.analysis.compute_top2_gap_histogram(
-                        model,
-                        Vocab,
-                        compute_logits,
-                        loader,
-                    )
+                loader = DataLoader(
+                    dataset,
+                    batch_size=config.trainer.eval_batch_size,
+                    batch_axis_name=Batch.name,
+                    axis_resources=loader_axis_resources,
+                )
+                top2_gap_hist = levanter.analysis.compute_top2_gap_histogram(
+                    model,
+                    Vocab,
+                    compute_logits,
+                    loader,
+                )
 
-                    levanter.tracker.log(
-                        {
-                            f"analysis/{name}/top2_gap": top2_gap_hist,
-                        },
-                        step=0,
-                    )
+                levanter.tracker.log(
+                    {
+                        f"analysis/{name}/top2_gap": top2_gap_hist,
+                    },
+                    step=0,
+                )
 
         if config.log_param_stats:
             logger.info("Computing param stats...")

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -97,12 +97,14 @@ def main(config: EvalLmConfig):
             per_pos_token_id = jnp.roll(batch.tokens.array, -1, axis=-1)
             return per_pos_loss, per_pos_weight, per_pos_token_id
 
+        batch_axis_resource = compute_axis_mapping.get(Batch.name, compute_axis_mapping.get("batch"))
         evaluator = TaggedEvaluator(
             EvalBatch=Batch,
             tagged_eval_sets=datasets,
             loss_fn=eval_loss_fn,
             tokenizer=tokenizer,
-            axis_mapping=compute_axis_mapping,
+            device_mesh=config.trainer.device_mesh,
+            batch_axis_resource=batch_axis_resource,
             max_examples_per_dataset=max_examples,
         )
 

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -20,7 +20,7 @@ from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, RepoRef
 from levanter.data import DataLoader
 from levanter.data.text import LmDataConfig
-from levanter.eval import LossFnOutput, TaggedEvaluator, eval_model, resolve_batch_axis_resource
+from levanter.eval import LossFnOutput, TaggedEvaluator, eval_model
 from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.trainer import TrainerConfig
@@ -73,7 +73,7 @@ def main(config: EvalLmConfig):
 
     compute_axis_mapping = config.trainer.compute_axis_mapping
     parameter_axis_mapping = config.trainer.parameter_axis_mapping
-    batch_axis_resource = resolve_batch_axis_resource(Batch, compute_axis_mapping)
+    batch_axis_resource = config.trainer.batch_axis_resource
     loader_axis_resources = {Batch.name: batch_axis_resource} if batch_axis_resource is not None else None
 
     if config.checkpoint_path is None and config.hf_checkpoint is None:

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -73,6 +73,7 @@ def main(config: EvalLmConfig):
 
     compute_axis_mapping = config.trainer.compute_axis_mapping
     parameter_axis_mapping = config.trainer.parameter_axis_mapping
+    batch_axis_resource = compute_axis_mapping.get(Batch.name, compute_axis_mapping.get("batch"))
 
     if config.checkpoint_path is None and config.hf_checkpoint is None:
         raise ValueError("Must specify either checkpoint_path or hf_checkpoint")
@@ -97,7 +98,6 @@ def main(config: EvalLmConfig):
             per_pos_token_id = jnp.roll(batch.tokens.array, -1, axis=-1)
             return per_pos_loss, per_pos_weight, per_pos_token_id
 
-        batch_axis_resource = compute_axis_mapping.get(Batch.name, compute_axis_mapping.get("batch"))
         evaluator = TaggedEvaluator(
             EvalBatch=Batch,
             tagged_eval_sets=datasets,
@@ -160,7 +160,9 @@ def main(config: EvalLmConfig):
                 if config.trainer.max_eval_batches is not None:
                     dataset = dataset.take(config.trainer.max_eval_batches * config.trainer.eval_batch_size)
                 loader = DataLoader(
-                    dataset, batch_size=config.trainer.eval_batch_size, axis_resources=compute_axis_mapping
+                    dataset,
+                    batch_size=config.trainer.eval_batch_size,
+                    axis_resources={"batch": batch_axis_resource} if batch_axis_resource is not None else None,
                 )
                 entropy_hist = levanter.analysis.compute_entropy_histogram(
                     model,
@@ -182,7 +184,9 @@ def main(config: EvalLmConfig):
                 if config.trainer.max_eval_batches is not None:
                     dataset = dataset.take(config.trainer.max_eval_batches * config.trainer.eval_batch_size)
                     loader = DataLoader(
-                        dataset, batch_size=config.trainer.eval_batch_size, axis_resources=compute_axis_mapping
+                        dataset,
+                        batch_size=config.trainer.eval_batch_size,
+                        axis_resources={"batch": batch_axis_resource} if batch_axis_resource is not None else None,
                     )
                     top2_gap_hist = levanter.analysis.compute_top2_gap_histogram(
                         model,

--- a/lib/levanter/src/levanter/main/lora_lm.py
+++ b/lib/levanter/src/levanter/main/lora_lm.py
@@ -143,8 +143,8 @@ def main(config: LoraLmConfig):
                 tokenizer=tokenizer,
                 device_mesh=trainer.device_mesh,
                 axis_mapping=trainer.compute_axis_mapping,
-                batch_axis_resource=trainer.compute_axis_mapping.get(
-                    trainer.EvalBatch.name, trainer.compute_axis_mapping.get("batch")
+                batch_axis_resource=levanter.eval.resolve_batch_axis_resource(
+                    trainer.EvalBatch, trainer.compute_axis_mapping
                 ),
                 max_examples_per_dataset=max_eval_examples_per_ds,
                 mp=config.trainer.mp,

--- a/lib/levanter/src/levanter/main/lora_lm.py
+++ b/lib/levanter/src/levanter/main/lora_lm.py
@@ -137,15 +137,15 @@ def main(config: LoraLmConfig):
         if len(tagged_eval_datasets) == 0:
             logger.warning("No evaluation datasets provided.")
         else:
+            compute_axis_mapping = trainer.compute_axis_mapping
+            batch_axis_resource = levanter.eval.resolve_batch_axis_resource(trainer.EvalBatch, compute_axis_mapping)
             cb = levanter.eval.cb_tagged_lm_evaluate(
                 EvalBatch=trainer.EvalBatch,
                 tagged_eval_sets=tagged_eval_datasets,
                 tokenizer=tokenizer,
                 device_mesh=trainer.device_mesh,
-                axis_mapping=trainer.compute_axis_mapping,
-                batch_axis_resource=levanter.eval.resolve_batch_axis_resource(
-                    trainer.EvalBatch, trainer.compute_axis_mapping
-                ),
+                axis_mapping=compute_axis_mapping,
+                batch_axis_resource=batch_axis_resource,
                 max_examples_per_dataset=max_eval_examples_per_ds,
                 mp=config.trainer.mp,
             )

--- a/lib/levanter/src/levanter/main/lora_lm.py
+++ b/lib/levanter/src/levanter/main/lora_lm.py
@@ -144,7 +144,7 @@ def main(config: LoraLmConfig):
                 tagged_eval_sets=tagged_eval_datasets,
                 tokenizer=tokenizer,
                 device_mesh=trainer.device_mesh,
-                axis_mapping=compute_axis_mapping,
+                compute_axis_mapping=compute_axis_mapping,
                 batch_axis_resource=batch_axis_resource,
                 max_examples_per_dataset=max_eval_examples_per_ds,
                 mp=config.trainer.mp,

--- a/lib/levanter/src/levanter/main/lora_lm.py
+++ b/lib/levanter/src/levanter/main/lora_lm.py
@@ -138,7 +138,7 @@ def main(config: LoraLmConfig):
             logger.warning("No evaluation datasets provided.")
         else:
             compute_axis_mapping = trainer.compute_axis_mapping
-            batch_axis_resource = levanter.eval.resolve_batch_axis_resource(trainer.EvalBatch, compute_axis_mapping)
+            batch_axis_resource = trainer.batch_axis_resource
             cb = levanter.eval.cb_tagged_lm_evaluate(
                 EvalBatch=trainer.EvalBatch,
                 tagged_eval_sets=tagged_eval_datasets,

--- a/lib/levanter/src/levanter/main/lora_lm.py
+++ b/lib/levanter/src/levanter/main/lora_lm.py
@@ -138,12 +138,15 @@ def main(config: LoraLmConfig):
             logger.warning("No evaluation datasets provided.")
         else:
             cb = levanter.eval.cb_tagged_lm_evaluate(
-                trainer.EvalBatch,
-                tagged_eval_datasets,
-                tokenizer,
-                trainer.device_mesh,
-                trainer.compute_axis_mapping,
-                max_eval_examples_per_ds,
+                EvalBatch=trainer.EvalBatch,
+                tagged_eval_sets=tagged_eval_datasets,
+                tokenizer=tokenizer,
+                device_mesh=trainer.device_mesh,
+                axis_mapping=trainer.compute_axis_mapping,
+                batch_axis_resource=trainer.compute_axis_mapping.get(
+                    trainer.EvalBatch.name, trainer.compute_axis_mapping.get("batch")
+                ),
+                max_examples_per_dataset=max_eval_examples_per_ds,
                 mp=config.trainer.mp,
             )
             trainer.add_hook(cb, every=config.trainer.steps_per_eval)

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -220,7 +220,7 @@ def main(config: TrainLmConfig):
                 tagged_eval_sets=tagged_eval_datasets,
                 tokenizer=tokenizer,
                 device_mesh=trainer.device_mesh,
-                axis_mapping=compute_axis_mapping,
+                compute_axis_mapping=compute_axis_mapping,
                 batch_axis_resource=batch_axis_resource,
                 max_examples_per_dataset=max_eval_examples_per_ds,
                 mp=config.trainer.mp,

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -135,6 +135,7 @@ def main(config: TrainLmConfig):
 
         # some axes we need
         EvalBatch = config.trainer.EvalBatch
+        batch_axis_resource = levanter.eval.resolve_batch_axis_resource(EvalBatch, compute_axis_mapping)
         model_max_seq_len = config.model.max_seq_len
         train_length = config.train_seq_len
         if train_length is None:
@@ -220,7 +221,7 @@ def main(config: TrainLmConfig):
                 tokenizer=tokenizer,
                 device_mesh=trainer.device_mesh,
                 axis_mapping=compute_axis_mapping,
-                batch_axis_resource=levanter.eval.resolve_batch_axis_resource(EvalBatch, compute_axis_mapping),
+                batch_axis_resource=batch_axis_resource,
                 max_examples_per_dataset=max_eval_examples_per_ds,
                 mp=config.trainer.mp,
                 checkpoint_path=checkpoint_path,
@@ -282,7 +283,7 @@ def main(config: TrainLmConfig):
                     EvalBatch,
                     axis_resources=compute_axis_mapping,
                     mp=trainer.mp,
-                    batch_axis_resource=levanter.eval.resolve_batch_axis_resource(EvalBatch, compute_axis_mapping),
+                    batch_axis_resource=batch_axis_resource,
                 ),
                 every=config.eval_harness_steps,
             )
@@ -304,7 +305,7 @@ def main(config: TrainLmConfig):
                         dataset,
                         prefix=os.path.join("analysis", name) if name else "analysis",
                         batch_size=EvalBatch.size,
-                        mapping=compute_axis_mapping,
+                        mapping={EvalBatch.name: batch_axis_resource},
                     ),
                     every=config.trainer.steps_per_eval,
                 )

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -220,7 +220,7 @@ def main(config: TrainLmConfig):
                 tokenizer=tokenizer,
                 device_mesh=trainer.device_mesh,
                 axis_mapping=compute_axis_mapping,
-                batch_axis_resource=compute_axis_mapping.get(EvalBatch.name, compute_axis_mapping.get("batch")),
+                batch_axis_resource=levanter.eval.resolve_batch_axis_resource(EvalBatch, compute_axis_mapping),
                 max_examples_per_dataset=max_eval_examples_per_ds,
                 mp=config.trainer.mp,
                 checkpoint_path=checkpoint_path,

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -305,7 +305,8 @@ def main(config: TrainLmConfig):
                         dataset,
                         prefix=os.path.join("analysis", name) if name else "analysis",
                         batch_size=EvalBatch.size,
-                        mapping={EvalBatch.name: batch_axis_resource},
+                        batch_axis_resource=batch_axis_resource,
+                        batch_axis_name=EvalBatch.name,
                     ),
                     every=config.trainer.steps_per_eval,
                 )

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -281,7 +281,7 @@ def main(config: TrainLmConfig):
                     eval_harness,
                     tokenizer,
                     EvalBatch,
-                    axis_resources=compute_axis_mapping,
+                    compute_axis_resources=compute_axis_mapping,
                     mp=trainer.mp,
                     batch_axis_resource=batch_axis_resource,
                 ),

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -215,12 +215,13 @@ def main(config: TrainLmConfig):
                 checkpoint_path = config.trainer.checkpointer.expanded_path(trainer.run_id)
 
             cb = levanter.eval.cb_tagged_lm_evaluate(
-                EvalBatch,
-                tagged_eval_datasets,
-                tokenizer,
-                trainer.device_mesh,
-                compute_axis_mapping,
-                max_eval_examples_per_ds,
+                EvalBatch=EvalBatch,
+                tagged_eval_sets=tagged_eval_datasets,
+                tokenizer=tokenizer,
+                device_mesh=trainer.device_mesh,
+                axis_mapping=compute_axis_mapping,
+                batch_axis_resource=compute_axis_mapping.get(EvalBatch.name, compute_axis_mapping.get("batch")),
+                max_examples_per_dataset=max_eval_examples_per_ds,
                 mp=config.trainer.mp,
                 checkpoint_path=checkpoint_path,
             )

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -277,7 +277,12 @@ def main(config: TrainLmConfig):
             eval_harness = config.eval_harness
             trainer.add_hook(
                 levanter.eval_harness.lm_eval_harness(
-                    eval_harness, tokenizer, EvalBatch, compute_axis_mapping, trainer.mp
+                    eval_harness,
+                    tokenizer,
+                    EvalBatch,
+                    axis_resources=compute_axis_mapping,
+                    mp=trainer.mp,
+                    batch_axis_resource=levanter.eval.resolve_batch_axis_resource(EvalBatch, compute_axis_mapping),
                 ),
                 every=config.eval_harness_steps,
             )

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -135,7 +135,7 @@ def main(config: TrainLmConfig):
 
         # some axes we need
         EvalBatch = config.trainer.EvalBatch
-        batch_axis_resource = levanter.eval.resolve_batch_axis_resource(EvalBatch, compute_axis_mapping)
+        batch_axis_resource = trainer.batch_axis_resource
         model_max_seq_len = config.model.max_seq_len
         train_length = config.train_seq_len
         if train_length is None:

--- a/lib/levanter/src/levanter/main/viz_logprobs.py
+++ b/lib/levanter/src/levanter/main/viz_logprobs.py
@@ -19,6 +19,7 @@ from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.data import DataLoader
 from levanter.data.text import LmDataConfig
+from levanter.eval import resolve_batch_axis_resource
 from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.models.loss import next_token_loss
@@ -63,6 +64,7 @@ def main(config: VizLmConfig):
 
     compute_axis_mapping = config.trainer.compute_axis_mapping
     parameter_axis_mapping = config.trainer.parameter_axis_mapping
+    batch_axis_resource = resolve_batch_axis_resource(EvalBatch, compute_axis_mapping)
 
     with config.trainer.use_device_mesh():
         key = jax.random.PRNGKey(0)
@@ -150,8 +152,9 @@ def main(config: VizLmConfig):
             loader = DataLoader(
                 dataset,
                 config.trainer.eval_batch_size,
+                batch_axis_name=EvalBatch.name,
                 mesh=config.trainer.device_mesh,
-                axis_resources=config.trainer.compute_axis_mapping,
+                axis_resources={EvalBatch.name: batch_axis_resource},
             )
 
             if name:

--- a/lib/levanter/src/levanter/main/viz_logprobs.py
+++ b/lib/levanter/src/levanter/main/viz_logprobs.py
@@ -19,7 +19,6 @@ from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.data import DataLoader
 from levanter.data.text import LmDataConfig
-from levanter.eval import resolve_batch_axis_resource
 from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.models.loss import next_token_loss
@@ -64,7 +63,7 @@ def main(config: VizLmConfig):
 
     compute_axis_mapping = config.trainer.compute_axis_mapping
     parameter_axis_mapping = config.trainer.parameter_axis_mapping
-    batch_axis_resource = resolve_batch_axis_resource(EvalBatch, compute_axis_mapping)
+    batch_axis_resource = config.trainer.batch_axis_resource
 
     with config.trainer.use_device_mesh():
         key = jax.random.PRNGKey(0)

--- a/lib/levanter/src/levanter/models/linear.py
+++ b/lib/levanter/src/levanter/models/linear.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Levanter Authors
+# Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -644,12 +644,13 @@ class Trainer:
             batch_name = self.config.batch_axis_name
             batch_size = self.config.train_batch_size
 
+        batch_axis_resource = self.compute_axis_mapping.get(batch_name, self.config.batch_axis_resource)
         return DataLoader(
             dataset,
             batch_size=batch_size,
             max_buffered_batches=128,
             mesh=self.device_mesh,
-            axis_resources=self.compute_axis_mapping,
+            axis_resources={batch_name: batch_axis_resource},
             prefetch_size=32,
             batch_axis_name=batch_name,
             allow_nondivisible_batch_size=self.config.allow_nondivisible_batch_size,
@@ -981,7 +982,7 @@ class TrainerConfig:
     @property
     def data_axis_size(self):
         """size of the data parallel/batch parallel axis."""
-        batch_map = self.compute_axis_mapping.get(self.batch_axis_name, self.compute_axis_mapping.get("batch"))
+        batch_map = self.batch_axis_resource
         if batch_map is None:
             raise ValueError(
                 f"No mapping found for batch axis {self.batch_axis_name} in compute axis mapping."
@@ -997,6 +998,10 @@ class TrainerConfig:
         for ax in axes:
             prod_size *= self._axis_size(ax)
         return prod_size
+
+    @property
+    def batch_axis_resource(self):
+        return self.compute_axis_mapping.get(self.batch_axis_name, self.compute_axis_mapping.get("batch"))
 
     @property
     def compute_axis_mapping(self) -> ResourceMapping:

--- a/lib/levanter/tests/test_eval.py
+++ b/lib/levanter/tests/test_eval.py
@@ -52,12 +52,12 @@ def test_tagged_evaluator_accepts_grug_lm_examples():
             return per_pos_loss, named_batch.loss_weight.array, jnp.roll(named_batch.tokens.array, -1, axis=-1)
 
         evaluator = TaggedEvaluator(
-            EvalBatch=EvalBatch,
+            EvalBatch=EvalBatch.size,
             tagged_eval_sets=[(dataset, ["grug"])],
             loss_fn=loss_fn,
             tokenizer=None,
             device_mesh=mesh,
-            axis_mapping={EvalBatch.name: ResourceAxis.DATA},
+            batch_axis_resource=ResourceAxis.DATA,
         )
         result = evaluator.evaluate(model)
 

--- a/lib/levanter/tests/test_eval.py
+++ b/lib/levanter/tests/test_eval.py
@@ -105,7 +105,7 @@ def test_tagged_evaluator_accepts_mixed_lm_example_types():
             loss_fn=loss_fn,
             tokenizer=None,
             device_mesh=mesh,
-            axis_mapping={EvalBatch.name: ResourceAxis.DATA},
+            compute_axis_mapping={EvalBatch.name: ResourceAxis.DATA},
         )
         result = evaluator.evaluate(model)
 
@@ -163,7 +163,7 @@ def test_tagged_evaluator_accepts_grug_loss_protocol():
             loss_fn=loss_fn,
             tokenizer=None,
             device_mesh=mesh,
-            axis_mapping={EvalBatch.name: ResourceAxis.DATA},
+            compute_axis_mapping={EvalBatch.name: ResourceAxis.DATA},
         )
         result = evaluator.evaluate(jnp.zeros((), dtype=jnp.float32))
 

--- a/lib/levanter/tests/test_optimizer_linear_like.py
+++ b/lib/levanter/tests/test_optimizer_linear_like.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Levanter Authors
+# Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
 import equinox as eqx

--- a/tests/test_grug_base_template.py
+++ b/tests/test_grug_base_template.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Marin Authors
+# Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
 import json


### PR DESCRIPTION
## Summary
- wires explicit batch-axis resource handling through eval/train/lora/eval_harness paths
- standardizes tagged-eval naming from `axis_mapping` to `compute_axis_mapping`
- supports integer `EvalBatch` usage consistently in tagged LM evaluation

This is part of gruggification.
