### PR TITLE
trainer/runtime: bind execution to explicit mesh resources

### DIFF
--- a/experiments/grug/base/model.py
+++ b/experiments/grug/base/model.py
@@ -219,6 +219,26 @@ class Transformer(eqx.Module):
             dtype=loss_dtype,
         )
 
+    def compute_next_token_loss(
+        self,
+        token_ids: Int[Array, "B S"],
+        loss_weight: Float[Array, "B S"],
+        *,
+        mask: AttentionMask | jax.Array | None = None,
+        reduction: str = "mean",
+        logsumexp_weight: float | None = None,
+        loss_dtype: jnp.dtype = jnp.float32,
+    ) -> jax.Array:
+        """Compatibility wrapper used by shared training/eval surfaces."""
+        return self.next_token_loss(
+            token_ids,
+            loss_weight,
+            mask=mask,
+            reduction=reduction,
+            logsumexp_weight=logsumexp_weight,
+            loss_dtype=loss_dtype,
+        )
+
 
 def _init_weight(key: PRNGKeyArray, shape: tuple[int, ...], std: float) -> Float[Array, "..."]:
     return std * random.truncated_normal(key, -3, 3, shape)

--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Marin Authors
+# Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -155,7 +155,7 @@ def build_tagged_evaluator(
         return per_pos_loss, per_pos_weight, per_pos_token_id
 
     return TaggedEvaluator(
-        eval_batch_size=eval_cfg.eval_batch_size,
+        EvalBatch=eval_cfg.eval_batch_size,
         tagged_eval_sets=tagged_eval_sets,
         loss_fn=eval_loss_fn,
         tokenizer=tokenizer,

--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -9,6 +9,7 @@ import logging
 import time
 from dataclasses import dataclass, field
 
+from fray.cluster import ResourceConfig
 import jax
 import jax.numpy as jnp
 import jmp
@@ -71,6 +72,7 @@ class GrugRunConfig:
 
     model: GrugModelConfig
     data: LmDataConfig
+    resources: ResourceConfig | None = None
     optimizer: OptimizerConfig = field(default_factory=AdamConfig)
     trainer: GrugTrainerConfig = field(default_factory=GrugTrainerConfig)
     eval: GrugEvalConfig | None = field(default_factory=GrugEvalConfig)
@@ -153,7 +155,7 @@ def build_tagged_evaluator(
         return per_pos_loss, per_pos_weight, per_pos_token_id
 
     return TaggedEvaluator(
-        EvalBatch=eval_cfg.eval_batch_size,
+        eval_batch_size=eval_cfg.eval_batch_size,
         tagged_eval_sets=tagged_eval_sets,
         loss_fn=eval_loss_fn,
         tokenizer=tokenizer,
@@ -214,6 +216,22 @@ class GrugTrainState:
     params: Transformer
     opt_state: optax.OptState
     ema_params: Transformer
+
+
+def initial_state(
+    model_config: GrugModelConfig,
+    *,
+    optimizer: optax.GradientTransformation,
+    mp: jmp.Policy,
+    key: PRNGKeyArray,
+) -> GrugTrainState:
+    params = mp.cast_to_param(Transformer.init(model_config, key=key))
+    return GrugTrainState(
+        step=jnp.array(0, dtype=jnp.int32),
+        params=params,
+        opt_state=optimizer.init(params),
+        ema_params=params,
+    )
 
 
 def _make_train_step(
@@ -331,13 +349,7 @@ def run_grug(config: GrugRunConfig) -> None:
 
         @jax.jit
         def _init_state(model_rng):
-            params = trainer.mp.cast_to_param(Transformer.init(config.model, key=model_rng))
-            return GrugTrainState(
-                step=jnp.array(0, dtype=jnp.int32),
-                params=params,
-                opt_state=optimizer.init(params),
-                ema_params=params,
-            )
+            return initial_state(config.model, optimizer=optimizer, mp=trainer.mp, key=model_rng)
 
         state = _init_state(model_key)
 
@@ -467,5 +479,6 @@ __all__ = [
     "GrugRunConfig",
     "GrugTrainState",
     "GrugTrainerConfig",
+    "initial_state",
     "run_grug",
 ]

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -17,7 +17,6 @@ from typing import Callable, List, Optional, ParamSpec, Sequence, TypeVar, Union
 
 import equinox
 import fsspec
-import haliax.partitioning
 import jax
 import jax.numpy as jnp
 from draccus import field
@@ -33,6 +32,7 @@ from levanter.tensorstore_serialization import (
 )
 from levanter.utils import fsspec_utils
 from levanter.utils.jax_utils import broadcast_one_to_all
+from levanter.utils.partitioning import named_jit
 from levanter.utils.types import FilterSpec, ResourceMapping
 
 logger = logging.getLogger(__name__)
@@ -485,7 +485,7 @@ def load_checkpoint_or_initialize(
 
     # some state might not be initialized, so we need to initialize it
     # JAX will be smart and only do the compute for things we actually need
-    @haliax.named_jit(
+    @named_jit(
         axis_resources=axis_mapping,
         out_axis_resources=axis_mapping,
         donate_args=donate_args,

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -24,6 +24,7 @@ from draccus import field
 from fsspec import AbstractFileSystem
 from haliax.jax_utils import is_in_jit, is_jax_array_like
 from jax.experimental.array_serialization.serialization import GlobalAsyncCheckpointManager
+from jax.sharding import Mesh
 from jaxtyping import PyTree
 
 from levanter.tensorstore_serialization import (
@@ -32,7 +33,7 @@ from levanter.tensorstore_serialization import (
 )
 from levanter.utils import fsspec_utils
 from levanter.utils.jax_utils import broadcast_one_to_all
-from levanter.utils.types import FilterSpec
+from levanter.utils.types import FilterSpec, ResourceMapping
 
 logger = logging.getLogger(__name__)
 
@@ -140,8 +141,8 @@ class Checkpointer:
         path: Optional[PathLike] = None,
         *,
         discover_latest: bool = True,
-        axis_mapping: Optional[haliax.partitioning.ResourceMapping] = None,
-        mesh: Optional[haliax.partitioning.Mesh] = None,
+        axis_mapping: Optional[ResourceMapping] = None,
+        mesh: Optional[Mesh] = None,
     ) -> Optional[M]:
         if path is None:
             path = self.base_path
@@ -153,8 +154,8 @@ class Checkpointer:
         path: Optional[str] = None,
         *,
         discover_latest: bool = True,
-        axis_mapping: Optional[haliax.partitioning.ResourceMapping] = None,
-        mesh: Optional[haliax.partitioning.Mesh] = None,
+        axis_mapping: Optional[ResourceMapping] = None,
+        mesh: Optional[Mesh] = None,
     ) -> Optional[M]:
         """
         Convenience method/holdover from  previous API for loading checkpoints.
@@ -373,8 +374,8 @@ def load_checkpoint(
     *,
     subpath: Optional[str] = None,
     discover_latest=True,
-    axis_mapping: Optional[haliax.partitioning.ResourceMapping] = None,
-    mesh: Optional[jax.sharding.Mesh] = None,
+    axis_mapping: Optional[ResourceMapping] = None,
+    mesh: Optional[Mesh] = None,
     allow_partial: bool = False,
 ) -> M:
     """
@@ -436,8 +437,8 @@ def load_checkpoint_or_initialize(
     *,
     subpath: Optional[str] = None,
     discover_latest=True,
-    axis_mapping: Optional[haliax.partitioning.ResourceMapping] = None,
-    mesh: Optional[jax.sharding.Mesh] = None,
+    axis_mapping: Optional[ResourceMapping] = None,
+    mesh: Optional[Mesh] = None,
     is_checkpointed: FilterSpec = True,
     donate_args: FilterSpec = True,
     donate_kwargs: Optional[FilterSpec] = None,

--- a/lib/levanter/src/levanter/compat/hf_checkpoints.py
+++ b/lib/levanter/src/levanter/compat/hf_checkpoints.py
@@ -35,7 +35,6 @@ from fsspec.asyn import get_loop
 from fsspec.asyn import sync as fsspec_sync
 from haliax import Axis
 from haliax.jax_utils import is_jax_array_like
-from haliax.partitioning import ResourceMapping
 from haliax.state_dict import (
     StateDict,
     flatten_modules_for_export,
@@ -64,6 +63,7 @@ from levanter.utils.jax_utils import best_effort_sharding, sync_global_devices, 
 from levanter.utils.json_utils import ConfigJSONEncoder
 from levanter.utils.logging import silence_transformer_nag
 from levanter.utils.py_utils import dataclass_with_default_init
+from levanter.utils.types import ResourceMapping
 
 silence_transformer_nag()
 from transformers import (  # noqa: E402  # noqa: E402

--- a/lib/levanter/src/levanter/compat/hf_checkpoints.py
+++ b/lib/levanter/src/levanter/compat/hf_checkpoints.py
@@ -47,7 +47,6 @@ from huggingface_hub.errors import HfHubHTTPError
 from huggingface_hub.file_download import repo_folder_name
 from huggingface_hub.utils import EntryNotFoundError, GatedRepoError, HFValidationError
 from jax import ShapeDtypeStruct
-from jax._src.mesh import get_concrete_mesh
 from jax.random import PRNGKey
 from jax.sharding import PartitionSpec
 from jaxtyping import Array, PRNGKeyArray
@@ -62,6 +61,7 @@ from levanter.utils.hf_utils import HfTokenizer
 from levanter.utils.jax_utils import best_effort_sharding, sync_global_devices, use_cpu_device
 from levanter.utils.json_utils import ConfigJSONEncoder
 from levanter.utils.logging import silence_transformer_nag
+from levanter.utils.mesh import get_active_mesh
 from levanter.utils.py_utils import dataclass_with_default_init
 from levanter.utils.types import ResourceMapping
 
@@ -272,7 +272,7 @@ def _load_safe_tensors(path, dtype, fs: AbstractFileSystem | None = None):
         except AttributeError:
             pass
 
-    mesh = get_concrete_mesh()
+    mesh = get_active_mesh()
 
     loop = get_loop()
     bes = functools.partial(best_effort_sharding, mesh=mesh)

--- a/lib/levanter/src/levanter/compat/hf_checkpoints.py
+++ b/lib/levanter/src/levanter/compat/hf_checkpoints.py
@@ -62,6 +62,7 @@ from levanter.utils.jax_utils import best_effort_sharding, sync_global_devices, 
 from levanter.utils.json_utils import ConfigJSONEncoder
 from levanter.utils.logging import silence_transformer_nag
 from levanter.utils.mesh import get_active_mesh
+from levanter.utils.partitioning import named_jit
 from levanter.utils.py_utils import dataclass_with_default_init
 from levanter.utils.types import ResourceMapping
 
@@ -807,7 +808,7 @@ class HFCheckpointConverter(Generic[LevConfig]):
 
             return lev_model
 
-        load_from_state_dict = haliax.named_jit(
+        load_from_state_dict = named_jit(
             load_from_state_dict, axis_resources=axis_mapping, out_axis_resources=axis_mapping, donate_args=(True,)
         )
         lev_model = eqx.filter_eval_shape(lm_model_cls.init, Vocab, config, key=PRNGKey(0))
@@ -1307,7 +1308,7 @@ def _patch_missing_buffers_for_deser(lev_model, lm_model_cls, Vocab, config, key
 
     # ok, we now want to re-initialize the buffers by running the constructor for real, getting only the missing
     # arrays. We're relying on jit to do all the work in eliminating the unnecessary computation/memory
-    @haliax.named_jit(axis_resources=axis_mapping)
+    @named_jit(axis_resources=axis_mapping)
     def _init_buffers():
         new_model = lm_model_cls.init(Vocab, config, key=key)
 

--- a/lib/levanter/src/levanter/data/loader.py
+++ b/lib/levanter/src/levanter/data/loader.py
@@ -27,7 +27,6 @@ from optax.tree_utils import tree_zeros_like
 
 import haliax as hax
 from haliax import is_named_array
-from haliax.partitioning import ResourceMapping
 
 from levanter.data.dataset import AsyncDataset
 from levanter.data.utils import batched
@@ -39,6 +38,7 @@ from levanter.utils.background_iterable import BackgroundIterator
 from levanter.utils.jax_utils import local_cpu_mesh
 from levanter.utils.py_utils import index_where
 from levanter.utils.thread_utils import AsyncIteratorWrapper, blocking_wait
+from levanter.utils.types import ResourceMapping
 
 
 Ex = TypeVar("Ex")

--- a/lib/levanter/src/levanter/data/loader.py
+++ b/lib/levanter/src/levanter/data/loader.py
@@ -36,6 +36,7 @@ from levanter.schedule import BatchSchedule, IntSchedule
 from levanter.shapes import NamedShapeSpec, ShapeSpec, to_raw_shape
 from levanter.utils.background_iterable import BackgroundIterator
 from levanter.utils.jax_utils import local_cpu_mesh
+from levanter.utils.mesh import activate_mesh
 from levanter.utils.py_utils import index_where
 from levanter.utils.thread_utils import AsyncIteratorWrapper, blocking_wait
 from levanter.utils.types import ResourceMapping
@@ -120,7 +121,7 @@ class DataLoader(Iterable[Ex]):
             self.scheduler = BatchSchedule(batch_size)
 
         self._batch_sharding = hax.partitioning.sharding_for_axis(self.batch_axis_name, axis_resources, mesh)
-        with haliax.partitioning.set_mesh(mesh):
+        with activate_mesh(mesh):
             self._data_axis_size = hax.partitioning.physical_axis_size(self.batch_axis_name, axis_resources)
 
         assert self._data_axis_size is not None, "Data axis size must be known. Make sure you're passing in a mesh"

--- a/lib/levanter/src/levanter/data/loader.py
+++ b/lib/levanter/src/levanter/data/loader.py
@@ -18,7 +18,6 @@ import numpy
 from jax import Array
 from jax import numpy as jnp
 from jax import tree_util as jtu
-from jax._src.mesh import get_concrete_mesh
 from jax.experimental import multihost_utils
 from jax.sharding import Mesh, PartitionSpec
 from jaxtyping import PyTree
@@ -35,7 +34,7 @@ from levanter.schedule import BatchSchedule, IntSchedule
 from levanter.shapes import NamedShapeSpec, ShapeSpec, to_raw_shape
 from levanter.utils.background_iterable import BackgroundIterator
 from levanter.utils.jax_utils import local_cpu_mesh
-from levanter.utils.mesh import activate_mesh
+from levanter.utils.mesh import activate_mesh, get_active_mesh
 from levanter.utils.partitioning import (
     current_thread_local_mapping,
     physical_axis_name,
@@ -115,7 +114,7 @@ class DataLoader(Iterable[Ex]):
         self.data_store = data
 
         if mesh is None:
-            mesh = get_concrete_mesh()
+            mesh = get_active_mesh()
         self.mesh = mesh
 
         if isinstance(batch_size, hax.Axis):
@@ -125,6 +124,9 @@ class DataLoader(Iterable[Ex]):
         else:
             self.batch_axis_name = batch_axis_name or "batch"
             self.scheduler = BatchSchedule(batch_size)
+
+        if mesh is None:
+            raise ValueError("DataLoader requires an explicit mesh or an active mesh context.")
 
         self._batch_sharding = sharding_for_axis(self.batch_axis_name, axis_resources, mesh)
         with activate_mesh(mesh):

--- a/lib/levanter/src/levanter/data/loader.py
+++ b/lib/levanter/src/levanter/data/loader.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import Generic, TypeVar
 
-import haliax.partitioning
 import jax
 import numpy
 from jax import Array
@@ -37,6 +36,13 @@ from levanter.shapes import NamedShapeSpec, ShapeSpec, to_raw_shape
 from levanter.utils.background_iterable import BackgroundIterator
 from levanter.utils.jax_utils import local_cpu_mesh
 from levanter.utils.mesh import activate_mesh
+from levanter.utils.partitioning import (
+    current_thread_local_mapping,
+    physical_axis_name,
+    physical_axis_size,
+    pspec_for_axis,
+    sharding_for_axis,
+)
 from levanter.utils.py_utils import index_where
 from levanter.utils.thread_utils import AsyncIteratorWrapper, blocking_wait
 from levanter.utils.types import ResourceMapping
@@ -120,9 +126,9 @@ class DataLoader(Iterable[Ex]):
             self.batch_axis_name = batch_axis_name or "batch"
             self.scheduler = BatchSchedule(batch_size)
 
-        self._batch_sharding = hax.partitioning.sharding_for_axis(self.batch_axis_name, axis_resources, mesh)
+        self._batch_sharding = sharding_for_axis(self.batch_axis_name, axis_resources, mesh)
         with activate_mesh(mesh):
-            self._data_axis_size = hax.partitioning.physical_axis_size(self.batch_axis_name, axis_resources)
+            self._data_axis_size = physical_axis_size(self.batch_axis_name, axis_resources)
 
         assert self._data_axis_size is not None, "Data axis size must be known. Make sure you're passing in a mesh"
 
@@ -245,7 +251,7 @@ class DataLoaderIterator(Iterator[Ex]):
         self._start_from_batch = start_from_batch
         self.mapping = self.dl.axis_resources
         if self.mapping is None:
-            self.mapping = hax.partitioning.current_thread_local_mapping()
+            self.mapping = current_thread_local_mapping()
 
         buffered_batches = self.dl.max_buffered_batches
         self._batches: Iterator[Ex]
@@ -478,10 +484,10 @@ class DataLoaderIterator(Iterator[Ex]):
 
     def _pspec_for(self, shape_spec: ShapeSpec | NamedShapeSpec) -> PartitionSpec:
         if isinstance(shape_spec, ShapeSpec):  # type: ignore
-            batch_name = hax.partitioning.physical_axis_name(self.dl.batch_axis_name, self.dl.axis_resources)
+            batch_name = physical_axis_name(self.dl.batch_axis_name, self.dl.axis_resources)
             return PartitionSpec(batch_name, *((None,) * (len(shape_spec.shape) - 1)))
         else:
-            return hax.partitioning.pspec_for_axis(shape_spec.shape, self.dl.axis_resources)  # type: ignore
+            return pspec_for_axis(shape_spec.shape, self.dl.axis_resources)  # type: ignore
 
     async def run_and_report_slowness(self, coro, description: str):
         threshold = 10.0

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -427,7 +427,7 @@ class TaggedEvaluator(Generic[Ex, M]):
         per_tag_out_sharding = None if self.device_mesh is None else NamedSharding(self.device_mesh, P(None))
         per_pos_out_sharding = self.per_pos_out_sharding
 
-        @named_jit(axis_resources=self.compute_axis_mapping)
+        @named_jit(axis_resources=self.axis_mapping)
         def accum_for_batch(model: M, state: _EvalRunningMeans, batch: Ex, tags: BatchedTagArray):
             losses, weights, token_ids = self.loss_fn(model, batch)
             weighted_loss = losses * weights  # b t

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -30,6 +30,7 @@ from levanter.models.lm_model import LmExample, LmHeadModel
 from levanter.utils.hf_utils import HfTokenizer, byte_length_of_token
 from levanter.utils.jax_utils import axis_resource_is_explicit
 from levanter.utils.logging import LoadingTimeTrackerIterator
+from levanter.utils.partitioning import named_jit
 from levanter.utils.stat_utils import RunningMean
 from levanter.utils.tree_utils import inference_mode
 from levanter.utils.types import ResourceMapping
@@ -426,7 +427,7 @@ class TaggedEvaluator(Generic[Ex, M]):
         per_tag_out_sharding = None if self.device_mesh is None else NamedSharding(self.device_mesh, P(None))
         per_pos_out_sharding = self.per_pos_out_sharding
 
-        @hax.named_jit(axis_resources=self.axis_mapping)
+        @named_jit
         def accum_for_batch(model: M, state: _EvalRunningMeans, batch: Ex, tags: BatchedTagArray):
             losses, weights, token_ids = self.loss_fn(model, batch)
             weighted_loss = losses * weights  # b t

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -427,7 +427,7 @@ class TaggedEvaluator(Generic[Ex, M]):
         per_tag_out_sharding = None if self.device_mesh is None else NamedSharding(self.device_mesh, P(None))
         per_pos_out_sharding = self.per_pos_out_sharding
 
-        @named_jit
+        @named_jit(axis_resources=self.compute_axis_mapping)
         def accum_for_batch(model: M, state: _EvalRunningMeans, batch: Ex, tags: BatchedTagArray):
             losses, weights, token_ids = self.loss_fn(model, batch)
             weighted_loss = losses * weights  # b t

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -21,7 +21,6 @@ from jaxtyping import Array, Float, Int
 from tqdm_loggable.auto import tqdm
 
 import haliax as hax
-from haliax.partitioning import ResourceMapping
 
 import levanter.tracker
 from levanter.callbacks import StepInfo
@@ -33,6 +32,7 @@ from levanter.utils.jax_utils import axis_resource_is_explicit
 from levanter.utils.logging import LoadingTimeTrackerIterator
 from levanter.utils.stat_utils import RunningMean
 from levanter.utils.tree_utils import inference_mode
+from levanter.utils.types import ResourceMapping
 
 
 logger = logging.getLogger(__name__)

--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -82,7 +82,7 @@ from levanter.data.loader import stack_batches
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import broadcast_shard, parameter_count, use_cpu_device
-from levanter.utils.partitioning import round_axis_for_partitioning
+from levanter.utils.partitioning import infer_resource_partitions, round_axis_for_partitioning
 from levanter.utils.py_utils import FailSafeJSONEncoder
 from levanter.utils.tree_utils import inference_mode
 from levanter.utils.types import ResourceMapping
@@ -348,7 +348,7 @@ class _LmEvalHarnessWorker:
     def _receive_payload(self):
         payload = broadcast_shard(
             self._dummy_batch,
-            hax.partitioning.infer_resource_partitions(self._dummy_batch),
+            infer_resource_partitions(self._dummy_batch),
         )
         return payload
 
@@ -359,7 +359,7 @@ class _LmEvalHarnessWorker:
 
     def _send_payload(self, payload):
         assert jax.process_index() == 0
-        out = broadcast_shard(payload, hax.partitioning.infer_resource_partitions(payload))
+        out = broadcast_shard(payload, infer_resource_partitions(payload))
         return out
 
     def process_loglikelihood(self, packed_request):

--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -72,7 +72,7 @@ except ImportError:
     postprocess_generated_text = None
 
 import haliax as hax
-from haliax.partitioning import ResourceMapping, round_axis_for_partitioning
+from haliax.partitioning import round_axis_for_partitioning
 from tqdm_loggable.auto import tqdm
 
 import levanter.config
@@ -85,6 +85,7 @@ from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import broadcast_shard, parameter_count, use_cpu_device
 from levanter.utils.py_utils import FailSafeJSONEncoder
 from levanter.utils.tree_utils import inference_mode
+from levanter.utils.types import ResourceMapping
 
 logger = logging.getLogger(__name__)
 

--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -82,7 +82,7 @@ from levanter.data.loader import stack_batches
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import broadcast_shard, parameter_count, use_cpu_device
-from levanter.utils.partitioning import infer_resource_partitions, round_axis_for_partitioning
+from levanter.utils.partitioning import infer_resource_partitions, named_jit, round_axis_for_partitioning
 from levanter.utils.py_utils import FailSafeJSONEncoder
 from levanter.utils.tree_utils import inference_mode
 from levanter.utils.types import ResourceMapping
@@ -307,8 +307,8 @@ class _LmEvalHarnessWorker:
             return segments, -losses, correct
 
         # no sharded outputs
-        self._jit_loglikelihood = hax.named_jit(
-            _eval_loglikelihood, axis_resources=axis_resources, out_axis_resources={}
+        self._jit_loglikelihood = named_jit(
+            _eval_loglikelihood, axis_resources=compute_axis_resources, out_axis_resources={}
         )
 
     @property

--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -72,7 +72,6 @@ except ImportError:
     postprocess_generated_text = None
 
 import haliax as hax
-from haliax.partitioning import round_axis_for_partitioning
 from tqdm_loggable.auto import tqdm
 
 import levanter.config
@@ -83,6 +82,7 @@ from levanter.data.loader import stack_batches
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import broadcast_shard, parameter_count, use_cpu_device
+from levanter.utils.partitioning import round_axis_for_partitioning
 from levanter.utils.py_utils import FailSafeJSONEncoder
 from levanter.utils.tree_utils import inference_mode
 from levanter.utils.types import ResourceMapping

--- a/lib/levanter/src/levanter/grad_accum.py
+++ b/lib/levanter/src/levanter/grad_accum.py
@@ -18,6 +18,7 @@ from levanter.metrics import Metric
 from levanter.metrics import fold as fold_metric
 from levanter.utils.jax_utils import zeros_like_tree
 from levanter.utils.mesh import DATA_AXIS
+from levanter.utils.partitioning import physical_axis_name, physical_axis_size
 
 Args = ParamSpec("Args")
 R = TypeVar("R")
@@ -70,11 +71,11 @@ def microbatched(
         accumulates the results.
     """
     batch_size = Batch.size
-    data_axis_size = hax.partitioning.physical_axis_size(Batch, compute_axis_mapping)
+    data_axis_size = physical_axis_size(Batch, compute_axis_mapping)
     if data_axis_size is None:
         raise ValueError(f"{Batch} axis must be sharded")
-    physical_axis_name = hax.partitioning.physical_axis_name(Batch, compute_axis_mapping)
-    assert physical_axis_name is not None
+    axis_name = physical_axis_name(Batch, compute_axis_mapping)
+    assert axis_name is not None
 
     if microbatch_size <= 0:
         raise ValueError(f"Bad value for {microbatch_size=}")

--- a/lib/levanter/src/levanter/grad_accum.py
+++ b/lib/levanter/src/levanter/grad_accum.py
@@ -10,7 +10,6 @@ import haliax as hax
 import jax
 import jax.numpy as jnp
 from haliax import Axis
-from haliax.partitioning import ResourceAxis
 from haliax.util import is_named_array
 from jax.lax import with_sharding_constraint
 from jax.sharding import PartitionSpec
@@ -18,6 +17,7 @@ from jax.sharding import PartitionSpec
 from levanter.metrics import Metric
 from levanter.metrics import fold as fold_metric
 from levanter.utils.jax_utils import zeros_like_tree
+from levanter.utils.mesh import DATA_AXIS
 
 Args = ParamSpec("Args")
 R = TypeVar("R")
@@ -179,7 +179,7 @@ def _reshape_for_microbatch(Batch: Axis, Microbatch: Axis, AccumStep: Axis, inpu
             return hax.shard(x, axis_mapping)
         elif isinstance(x, jnp.ndarray):
             x = x.reshape((AccumStep.size, Microbatch.size) + x.shape[1:])
-            return with_sharding_constraint(x, PartitionSpec(None, ResourceAxis.DATA, *(None,) * (len(x.shape) - 2)))
+            return with_sharding_constraint(x, PartitionSpec(None, DATA_AXIS, *(None,) * (len(x.shape) - 2)))
         else:
             # assert jnp.isscalar(x)
             return x

--- a/lib/levanter/src/levanter/grug/attention.py
+++ b/lib/levanter/src/levanter/grug/attention.py
@@ -7,13 +7,13 @@ from dataclasses import dataclass
 
 import equinox as eqx
 import jax
-from jax._src.mesh import get_concrete_mesh
 from jax import numpy as jnp
 from jax import shard_map
 from jax.sharding import NamedSharding, PartitionSpec as P
 from jaxtyping import Array, Bool, Float, Int
 
 from haliax.jax_utils import named_call
+from levanter.utils.mesh import get_active_mesh
 
 
 _SHARD_MAP_CHECK_KWARG = "check_vma" if "check_vma" in inspect.signature(shard_map).parameters else "check_rep"
@@ -230,7 +230,7 @@ def _tpu_splash_attention(
 
     q_ = q_ * (1.0 / math.sqrt(D))
 
-    mesh = get_concrete_mesh()
+    mesh = get_active_mesh()
     if mesh is None or mesh.empty:
         raise RuntimeError("TPU splash attention requires a JAX mesh context.")
 

--- a/lib/levanter/src/levanter/grug/model_moe.py
+++ b/lib/levanter/src/levanter/grug/model_moe.py
@@ -12,11 +12,11 @@ import jax.scipy as jsp
 import levanter.tracker
 from einops import rearrange
 from haliax.jax_utils import named_call
-from jax._src.mesh import get_concrete_mesh
 from jax import random
 from jax.experimental.shard_map import shard_map
 from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, Float, Int, PRNGKeyArray
+from levanter.utils.mesh import get_active_mesh
 
 from .attention import AttentionMask, RotaryConfig, apply_rotary_embedding, attention
 from .loss import fused_linear_softmax_cross_entropy_loss
@@ -159,7 +159,7 @@ class MOE(eqx.Module):
         router_logits = jnp.einsum("td,de->te", x_flat, self.router_w)
         topk_weights, topk_idx, router_probs = self._route(router_logits)
         topk_idx_flat = jnp.reshape(topk_idx, (B * S * self.cfg.num_experts_per_tok,))
-        mesh = get_concrete_mesh()
+        mesh = get_active_mesh()
         if mesh is None:
             raise RuntimeError("MOE computation requires an active concrete mesh context.")
 

--- a/lib/levanter/src/levanter/inference/engine.py
+++ b/lib/levanter/src/levanter/inference/engine.py
@@ -654,7 +654,7 @@ def _handle_clones(
     # Device-side release of finished sequences (jit-safe)
     return gen_state, outputs
 
-
+# @named_jit(donate_args=(True, False, False))
 @functools.partial(jax.jit, static_argnums=(3, 4), donate_argnames=("gen_state",))
 def _run_generation_loop(
     gen_state: GenState,

--- a/lib/levanter/src/levanter/inference/engine.py
+++ b/lib/levanter/src/levanter/inference/engine.py
@@ -19,7 +19,6 @@ import jax.numpy as jnp
 import numpy as np
 from haliax import NamedArray
 from haliax.jax_utils import is_jax_array_like
-from haliax.partitioning import ResourceMapping
 
 import levanter.tracker
 from levanter.inference.jit_scheduler import (
@@ -653,6 +652,7 @@ def _handle_clones(
 
     # Device-side release of finished sequences (jit-safe)
     return gen_state, outputs
+
 
 # @named_jit(donate_args=(True, False, False))
 @functools.partial(jax.jit, static_argnums=(3, 4), donate_argnames=("gen_state",))

--- a/lib/levanter/src/levanter/inference/engine.py
+++ b/lib/levanter/src/levanter/inference/engine.py
@@ -34,6 +34,7 @@ from levanter.layers.kv_cache import PageCache
 from levanter.layers.sampler import Sampler
 from levanter.models.lm_model import LmHeadModel
 from levanter.utils.jax_utils import estimated_free_device_memory, sharded_tree_size
+from levanter.utils.partitioning import named_jit
 
 logger = logging.getLogger(__name__)
 
@@ -814,9 +815,7 @@ class InferenceEngine:
         assert config.max_pages is not None
 
         table = PageTable.init(config.max_pages, config.max_seqs, config.page_size, max_pages_per_seq)
-        cache = hax.named_jit(model.initial_cache, axis_resources=axis_resources)(
-            table.spec(), dtype=config.compute_dtype
-        )
+        cache = named_jit(model.initial_cache, axis_resources=axis_resources)(table.spec(), dtype=config.compute_dtype)
         decode_state = DecodeState.init(
             table,
             max_stop_seqs=config.max_stop_seqs,

--- a/lib/levanter/src/levanter/inference/engine.py
+++ b/lib/levanter/src/levanter/inference/engine.py
@@ -35,6 +35,7 @@ from levanter.layers.sampler import Sampler
 from levanter.models.lm_model import LmHeadModel
 from levanter.utils.jax_utils import estimated_free_device_memory, sharded_tree_size
 from levanter.utils.partitioning import named_jit
+from levanter.utils.types import ResourceMapping
 
 logger = logging.getLogger(__name__)
 

--- a/lib/levanter/src/levanter/inference/openai.py
+++ b/lib/levanter/src/levanter/inference/openai.py
@@ -41,6 +41,7 @@ from levanter.inference.jit_scheduler import SeqDecodingParams
 from levanter.models.lm_model import LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.hf_utils import HfTokenizer
+from levanter.utils.mesh import activate_mesh
 
 logger = logging.getLogger(__name__)
 
@@ -251,7 +252,7 @@ class InferenceContext:
 
             start = time.time()
             with (
-                hax.partitioning.set_mesh(self.config.trainer.device_mesh),
+                activate_mesh(self.config.trainer.device_mesh),
                 hax.axis_mapping(self.config.trainer.compute_axis_mapping),
             ):
                 self.model = weight_callback(self.model)
@@ -353,7 +354,7 @@ class InferenceContext:
                 batch = self.batch_queue.get(timeout=1)
                 with (
                     self.model_lock,
-                    hax.partitioning.set_mesh(self.config.trainer.device_mesh),
+                    activate_mesh(self.config.trainer.device_mesh),
                     hax.axis_mapping(self.config.trainer.compute_axis_mapping),
                 ):
                     self._execute_batch(batch)

--- a/lib/levanter/src/levanter/inference/openai.py
+++ b/lib/levanter/src/levanter/inference/openai.py
@@ -251,10 +251,7 @@ class InferenceContext:
             logger.info(f"Acquired model lock after {lock_wait_time}, reloading weights...")
 
             start = time.time()
-            with (
-                activate_mesh(self.config.trainer.device_mesh),
-                hax.axis_mapping(self.config.trainer.compute_axis_mapping),
-            ):
+            with activate_mesh(self.config.trainer.device_mesh):
                 self.model = weight_callback(self.model)
                 self.engine = InferenceEngine.from_model_with_config(
                     model=self.model,
@@ -352,11 +349,7 @@ class InferenceContext:
         while not self.shutdown_event.is_set():
             try:
                 batch = self.batch_queue.get(timeout=1)
-                with (
-                    self.model_lock,
-                    activate_mesh(self.config.trainer.device_mesh),
-                    hax.axis_mapping(self.config.trainer.compute_axis_mapping),
-                ):
+                with self.model_lock, activate_mesh(self.config.trainer.device_mesh):
                     self._execute_batch(batch)
             except queue.Empty:
                 continue

--- a/lib/levanter/src/levanter/layers/attention.py
+++ b/lib/levanter/src/levanter/layers/attention.py
@@ -33,7 +33,6 @@ from haliax import Axis, AxisSelection, AxisSelector, NamedArray, axis_name
 from haliax.jax_utils import maybe_rng_split, named_call
 from haliax.nn.attention import causal_mask, combine_masks_and, combine_masks_or
 from haliax.nn.normalization import LayerNormBase
-from haliax.partitioning import pspec_for_axis, shard_map
 from haliax.types import PrecisionLike
 from jax.sharding import PartitionSpec
 from jaxtyping import PRNGKeyArray
@@ -46,6 +45,7 @@ else:
     _SPLASH_KERNEL_SUPPORTS_SINKS = "sinks" in inspect.signature(_splash_attention).parameters
 
 from ..inference.page_table import PageBatchInfo, PageTableSpec
+from ..utils.partitioning import pspec_for_axis, shard_map
 from .kv_cache import KvPageCache
 from .normalization import LayerNormConfigBase
 from .rotary import RotaryEmbeddings, RotaryEmbeddingsConfig

--- a/lib/levanter/src/levanter/layers/attention.py
+++ b/lib/levanter/src/levanter/layers/attention.py
@@ -2121,11 +2121,11 @@ def _do_tpu_ragged_paged_attention(
         _rpa_with_runtime_scale,
         mesh=jax.sharding.get_abstract_mesh(),
         in_specs=(
-            haliax.partitioning.pspec_for_axis(q_flat.axes),
-            haliax.partitioning.pspec_for_axis(kv_pages_padded.axes),
-            haliax.partitioning.pspec_for_axis(kv_lens.axes),
-            haliax.partitioning.pspec_for_axis(page_indices.axes),
-            haliax.partitioning.pspec_for_axis(cu_q_lens.axes),
+            pspec_for_axis(q_flat.axes),
+            pspec_for_axis(kv_pages_padded.axes),
+            pspec_for_axis(kv_lens.axes),
+            pspec_for_axis(page_indices.axes),
+            pspec_for_axis(cu_q_lens.axes),
             PartitionSpec(),  # num_seqs
         ),
         out_specs=pspec_for_axis(

--- a/lib/levanter/src/levanter/lora.py
+++ b/lib/levanter/src/levanter/lora.py
@@ -72,6 +72,7 @@ from levanter.compat.hf_checkpoints import HFCheckpointConverter, RepoRef, uploa
 from levanter.utils.cloud_utils import temp_dir_before_upload
 from levanter.utils.jax_utils import join_key, key_iterator, leaf_key_paths
 from levanter.utils.logging import silence_transformer_nag
+from levanter.utils.partitioning import named_jit
 
 
 silence_transformer_nag()
@@ -294,7 +295,7 @@ def _loraize(model: M, config: LoraConfig, key: jax.random.PRNGKey, prefix: str,
     )
 
 
-@hax.named_jit  # needs to be inside (named) jit s.t. it works with sharded parameters
+@named_jit  # needs to be inside (named) jit s.t. it works with sharded parameters
 def merge_lora_modules(module: M) -> M:
     """
     Merges LoRA modules into their wrapped modules. That is, it adds the LoRA parameters to the wrapped weights,

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -13,7 +13,6 @@ import jmp
 import haliax
 import haliax as hax
 from haliax import Axis
-from haliax.partitioning import round_axis_for_partitioning
 
 import levanter
 from levanter.checkpoint import load_checkpoint
@@ -25,6 +24,7 @@ from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
+from levanter.utils.partitioning import round_axis_for_partitioning
 from levanter.utils.tree_utils import inference_mode
 
 

--- a/lib/levanter/src/levanter/main/export_lm_to_hf.py
+++ b/lib/levanter/src/levanter/main/export_lm_to_hf.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import Optional
 
 import equinox as eqx
-import haliax
 import jax
 
 from haliax import Axis
@@ -59,16 +58,19 @@ def main(config: ConvertLmConfig):
     if config.use_cpu:
         exit_stack.enter_context(local_cpu_mesh())
     else:
-        # exit_stack.enter_context(Mesh(jax.local_devices(), "dev"))
-        exit_stack.enter_context(config.trainer.device_mesh)
-        exit_stack.enter_context(haliax.axis_mapping(config.trainer.parameter_axis_mapping))
+        exit_stack.enter_context(config.trainer.use_device_mesh())
 
     with exit_stack:
         model: LmHeadModel = eqx.filter_eval_shape(config.model.build, Vocab, key=key)
         trainable, non_trainable = eqx.partition(model, is_inexact_arrayish)
         # TODO: don't load the entire checkpoint into CPU memory when we only need our share of the model
         logger.info(f"Loading checkpoint from {config.checkpoint_path}...")
-        trainable = load_checkpoint(trainable, config.checkpoint_path, subpath="model")
+        trainable = load_checkpoint(
+            trainable,
+            config.checkpoint_path,
+            subpath="model",
+            axis_mapping=config.trainer.parameter_axis_mapping,
+        )
 
         assert trainable is not None
         model = eqx.combine(trainable, non_trainable)

--- a/lib/levanter/src/levanter/main/inference_repl.py
+++ b/lib/levanter/src/levanter/main/inference_repl.py
@@ -29,7 +29,6 @@ import jax
 import jax.random as jrandom
 import jmp
 from haliax import Axis
-from haliax.partitioning import round_axis_for_partitioning
 from prompt_toolkit import prompt
 from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.history import FileHistory
@@ -53,6 +52,7 @@ from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
 from levanter.utils.mesh import MeshConfig
+from levanter.utils.partitioning import round_axis_for_partitioning
 
 logger = logging.getLogger(__name__)
 console = Console()

--- a/lib/levanter/src/levanter/main/lora_lm.py
+++ b/lib/levanter/src/levanter/main/lora_lm.py
@@ -8,8 +8,6 @@ from typing import Optional
 
 import jax.random as jrandom
 
-import haliax.random
-
 import levanter
 import levanter.eval
 from levanter import callbacks
@@ -26,6 +24,7 @@ from levanter.models.lm_model import LmExample, LmHeadModel
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
 from levanter.utils.jax_utils import parameter_count
+from levanter.utils.partitioning import named_jit
 
 
 logger = logging.getLogger(__name__)
@@ -65,11 +64,11 @@ def main(config: LoraLmConfig):
     # randomness in jax is tightly controlled by "keys" which are the states of the random number generators
     # this makes deterministic training pretty easy
     seed = config.trainer.seed
-    data_key, loader_key, model_key, lora_key, training_key = jrandom.split(jrandom.PRNGKey(seed), 5)
+    data_key, model_key, lora_key, training_key = jrandom.split(jrandom.PRNGKey(seed), 4)
 
     # some axes we need
     Batch = config.trainer.TrainBatch
-    Pos = model_config.max_Pos.resize(config.max_train_length)
+    Pos = model_config.max_Pos.resize(config.train_seq_len)
 
     optimizer = config.optimizer.build(config.trainer.num_train_steps)
 
@@ -102,7 +101,7 @@ def main(config: LoraLmConfig):
             model_config.model_type, axis_mapping=parameter_axis_mapping, dtype=trainer.mp.compute_dtype
         )
 
-        @haliax.named_jit(axis_resources=parameter_axis_mapping, donate_args=(True))
+        @named_jit(axis_resources=parameter_axis_mapping, donate_args=(True))
         def loraize_hf_model(model):
             return loraize(model, config.lora, key=lora_key)
 

--- a/lib/levanter/src/levanter/main/sample_lm.py
+++ b/lib/levanter/src/levanter/main/sample_lm.py
@@ -11,7 +11,6 @@ import haliax as hax
 import jax.numpy as jnp
 import jax.random as jrandom
 from haliax import Axis
-from haliax.partitioning import round_axis_for_partitioning
 
 import levanter
 from levanter.callbacks import profile_ctx
@@ -24,6 +23,7 @@ from levanter.models.llama import LlamaConfig, LlamaLMHeadModel
 from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
+from levanter.utils.partitioning import round_axis_for_partitioning
 
 logger = logging.getLogger(__name__)
 

--- a/lib/levanter/src/levanter/main/train_asr.py
+++ b/lib/levanter/src/levanter/main/train_asr.py
@@ -12,7 +12,6 @@ import jax.random as jrandom
 
 import haliax as hax
 from haliax import Axis
-from haliax.partitioning import named_jit, round_axis_for_partitioning
 
 import levanter
 from levanter import callbacks
@@ -23,6 +22,7 @@ from levanter.models.whisper import WhisperConfig
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
 from levanter.utils.jax_utils import parameter_count
+from levanter.utils.partitioning import named_jit, round_axis_for_partitioning
 
 
 logger = logging.getLogger(__name__)

--- a/lib/levanter/src/levanter/main/train_asr.py
+++ b/lib/levanter/src/levanter/main/train_asr.py
@@ -97,10 +97,9 @@ def main(config: TrainASRConfig):
     ) -> jax.numpy.ndarray | hax.NamedArray:
         return m.compute_loss(example, key=key, reduction=reduction, reduction_axis=reduction_axis)
 
-    # Using the trainer as a context manager does 3 things:
+    # Using the trainer as a context manager does 2 things:
     # 1. Sets the device mesh
-    # 2. Sets the axis mapping (for fsdp)
-    # 3. Sets the global metrics tracker
+    # 2. Sets the global metrics tracker
     with Trainer(config.trainer, optimizer, compute_loss) as trainer:  # type: ignore
         # randomness in jax is tightly controlled by "keys" which are the states of the random number generators
         # this makes deterministic training pretty easy

--- a/lib/levanter/src/levanter/main/train_dpo.py
+++ b/lib/levanter/src/levanter/main/train_dpo.py
@@ -12,7 +12,6 @@ import haliax as hax
 import jax.numpy as jnp
 import jax.random as jrandom
 from haliax import Axis
-from haliax.partitioning import named_jit, round_axis_for_partitioning
 
 import levanter
 import levanter.callbacks
@@ -33,6 +32,7 @@ from levanter.metrics import Metric, ReductionType
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
 from levanter.utils.jax_utils import parameter_count, use_cpu_device
+from levanter.utils.partitioning import named_jit, round_axis_for_partitioning
 from levanter.utils.tree_utils import inference_mode
 
 logger = logging.getLogger(__name__)

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -12,7 +12,6 @@ import haliax as hax
 import jax.numpy as jnp
 import jax.random as jrandom
 from haliax import Axis
-from haliax.partitioning import named_jit, round_axis_for_partitioning
 
 import levanter
 import levanter.callbacks
@@ -30,6 +29,7 @@ from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
 from levanter.utils.jax_utils import parameter_count
+from levanter.utils.partitioning import named_jit, round_axis_for_partitioning
 
 logger = logging.getLogger(__name__)
 

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -114,10 +114,9 @@ def main(config: TrainLmConfig):
     def loss_function(model: LmHeadModel, example: LmExample, *, key=None):
         return model.compute_next_token_loss(example, key=key, logsumexp_weight=config.z_loss_weight)
 
-    # Using the trainer as a context manager does 3 things:
+    # Using the trainer as a context manager does 2 things:
     # 1. Sets the device mesh
-    # 2. Sets the axis mapping (for fsdp)
-    # 3. Sets the global metrics tracker
+    # 2. Sets the global metrics tracker
     with Trainer(config.trainer, optimizer, loss_function) as trainer:
         # randomness in jax is tightly controlled by "keys" which are the states of the random number generators
         # this makes deterministic training pretty easy

--- a/lib/levanter/src/levanter/main/viz_logprobs.py
+++ b/lib/levanter/src/levanter/main/viz_logprobs.py
@@ -12,7 +12,6 @@ import jmp
 
 import haliax as hax
 from haliax import Axis
-from haliax.partitioning import round_axis_for_partitioning
 
 import levanter
 from levanter.checkpoint import load_checkpoint
@@ -24,6 +23,7 @@ from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.models.loss import next_token_loss
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
+from levanter.utils.partitioning import round_axis_for_partitioning
 from levanter.utils.tree_utils import inference_mode
 from levanter.visualization import compute_and_diff_log_probs, compute_and_visualize_log_probs
 

--- a/lib/levanter/src/levanter/models/apertus.py
+++ b/lib/levanter/src/levanter/models/apertus.py
@@ -13,7 +13,6 @@ import jax.numpy as jnp
 import jax.random as jrandom
 from haliax import Axis, AxisSpec, NamedArray
 from haliax.jax_utils import maybe_rng_split, named_call, shaped_rng_split
-from haliax.nn.scan import Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
@@ -23,6 +22,7 @@ from levanter.layers.kv_cache import KvPageCache, ListCache
 from levanter.layers.rotary import Llama3RotaryEmbeddingsConfig, RotaryEmbeddingsConfig
 from levanter.models.llama import LlamaConfig, LlamaEmbedding
 from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.models.scan_layers import init_scan_foldable
 from levanter.utils.activation import ActivationFunctionEnum
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.logging import silence_transformer_nag
@@ -323,14 +323,12 @@ class ApertusTransformer(eqx.Module):
 
     @staticmethod
     def init(config: ApertusConfig, *, key) -> "ApertusTransformer":
-        S = Stacked
-        if not config.scan_layers:
-            from haliax.nn.scan import BlockSeq
-
-            S = BlockSeq
-
-        layers = S.init(config.Layers, ApertusDecoderLayer, gradient_checkpointing=config.gradient_checkpointing)(
+        layers = init_scan_foldable(
+            config.Layers,
+            ApertusDecoderLayer,
             config,
+            scan_layers=config.scan_layers,
+            gradient_checkpointing=config.gradient_checkpointing,
             key=shaped_rng_split(key, config.num_layers),
         )
         ln_f = config.mk_LayerNorm(config.Embed)

--- a/lib/levanter/src/levanter/models/gemma.py
+++ b/lib/levanter/src/levanter/models/gemma.py
@@ -13,7 +13,6 @@ import jax.random as jrandom
 from haliax import Axis, AxisSpec, NamedArray
 from haliax.jax_utils import maybe_rng_split, named_call, shaped_rng_split
 from haliax.nn.normalization import LayerNormBase
-from haliax.nn.scan import Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
@@ -25,6 +24,7 @@ from levanter.models.llama import (  # Gemma attention and MLP is identical to L
     LlamaMlp,
 )
 from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.models.scan_layers import init_scan_foldable
 from levanter.utils.activation import ActivationFunctionEnum
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.logging import silence_transformer_nag
@@ -344,14 +344,12 @@ class GemmaTransformer(ModuleWithStateDictSerialization):
 
     @staticmethod
     def init(config: GemmaConfig, *, key) -> "GemmaTransformer":
-        S = Stacked
-        if not config.scan_layers:
-            from haliax.nn.scan import BlockSeq
-
-            S = BlockSeq
-
-        layers = S.init(config.Layers, GemmaDecoderLayer, gradient_checkpointing=config.gradient_checkpointing)(
+        layers = init_scan_foldable(
+            config.Layers,
+            GemmaDecoderLayer,
             config,
+            scan_layers=config.scan_layers,
+            gradient_checkpointing=config.gradient_checkpointing,
             key=shaped_rng_split(key, config.num_layers),
         )
         ln_f = config.mk_LayerNorm(config.Embed)
@@ -681,15 +679,12 @@ class Gemma2Transformer(ModuleWithStateDictSerialization):
 
     @staticmethod
     def init(config: Gemma2Config, *, key):
-        # Choose "Stacked" vs "BlockSeq" depending on scan_layers like the original implementation
-        S = Stacked
-        if not config.scan_layers:
-            from haliax.nn.scan import BlockSeq
-
-            S = BlockSeq
-
-        layers = S.init(config.Layers, Gemma2DecoderLayer, gradient_checkpointing=config.gradient_checkpointing)(
+        layers = init_scan_foldable(
+            config.Layers,
+            Gemma2DecoderLayer,
             config,
+            scan_layers=config.scan_layers,
+            gradient_checkpointing=config.gradient_checkpointing,
             key=shaped_rng_split(key, config.num_layers),
         )
         ln_f = config.mk_LayerNorm(config.Embed)

--- a/lib/levanter/src/levanter/models/gpt2.py
+++ b/lib/levanter/src/levanter/models/gpt2.py
@@ -3,7 +3,7 @@
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Callable, Dict, Optional, Type, Union
+from typing import Callable, Dict, Optional, Type, Union, cast
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -15,7 +15,6 @@ import haliax.jax_utils
 import haliax.nn as hnn
 from haliax import Axis, NamedArray
 from haliax.jax_utils import named_call, shaped_rng_split
-from haliax.nn.scan import Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig, LmWithHfSerializationMixin
@@ -25,6 +24,7 @@ from levanter.models.scan_layers import init_scan_foldable
 from levanter.utils.activation import ActivationFunctionEnum
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.logging import silence_transformer_nag
+from levanter.utils.types import BlockFoldable
 
 
 silence_transformer_nag()
@@ -252,7 +252,7 @@ class Gpt2Block(eqx.Module):
 
 class Gpt2Transformer(ModuleWithStateDictSerialization):
     config: Gpt2Config = eqx.field(static=True)
-    blocks: Stacked[Gpt2Block]
+    blocks: BlockFoldable[Gpt2Block]
     ln_f: hnn.LayerNorm
 
     @staticmethod
@@ -272,7 +272,7 @@ class Gpt2Transformer(ModuleWithStateDictSerialization):
     @named_call
     def __call__(self, x: NamedArray, attn_mask: Optional[AttentionMask | NamedArray], *, key=None) -> NamedArray:
         keys = hax.jax_utils.maybe_rng_split(key, self.config.num_layers) if key is not None else None
-        x = self.blocks.fold(x, attn_mask, hax.arange(self.config.Layers), key=keys)
+        x = cast(NamedArray, self.blocks.fold(x, attn_mask, hax.arange(self.config.Layers), key=keys))
         x = self.ln_f(x)
 
         return x

--- a/lib/levanter/src/levanter/models/gpt2.py
+++ b/lib/levanter/src/levanter/models/gpt2.py
@@ -21,6 +21,7 @@ from haliax.state_dict import ModuleWithStateDictSerialization
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig, LmWithHfSerializationMixin
 from levanter.layers.attention import AttentionBackend, AttentionMask, dot_product_attention
 from levanter.models.lm_model import LmConfig
+from levanter.models.scan_layers import init_scan_foldable
 from levanter.utils.activation import ActivationFunctionEnum
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.logging import silence_transformer_nag
@@ -256,9 +257,12 @@ class Gpt2Transformer(ModuleWithStateDictSerialization):
 
     @staticmethod
     def init(config: Gpt2Config, *, key):
-        # vectorize the blocks
-        blocks = Stacked.init(config.Layers, Gpt2Block, gradient_checkpointing=config.gradient_checkpointing)(
+        blocks = init_scan_foldable(
+            config.Layers,
+            Gpt2Block,
             config,
+            scan_layers=True,
+            gradient_checkpointing=config.gradient_checkpointing,
             key=shaped_rng_split(key, config.num_layers),
         )
         ln_f = hnn.LayerNorm.init(config.Embed, eps=config.layer_norm_epsilon, use_bias=config.use_bias)

--- a/lib/levanter/src/levanter/models/gpt2_hyena.py
+++ b/lib/levanter/src/levanter/models/gpt2_hyena.py
@@ -24,6 +24,7 @@ from levanter.layers.attention import AttentionMask
 from levanter.models.gpt2 import Gpt2Embeddings, Gpt2Mlp
 from levanter.models.hyena import HyenaConfig, HyenaOperator
 from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.models.scan_layers import init_scan_foldable
 
 
 @LmConfig.register_subclass("gpt2_hyena")
@@ -117,9 +118,12 @@ class Gpt2HyenaBackbone(ModuleWithStateDictSerialization):
 
     @staticmethod
     def init(config: Gpt2HyenaConfig, *, key):
-        # vectorize the blocks
-        blocks = Stacked.init(config.Layers, Gpt2HyenaBlock, gradient_checkpointing=config.gradient_checkpointing)(
+        blocks = init_scan_foldable(
+            config.Layers,
+            Gpt2HyenaBlock,
             config,
+            scan_layers=True,
+            gradient_checkpointing=config.gradient_checkpointing,
             key=shaped_rng_split(key, config.num_layers),
         )
         ln_f = hnn.LayerNorm.init(config.Embed, eps=config.layer_norm_epsilon, use_bias=config.hyena.use_bias)

--- a/lib/levanter/src/levanter/models/gpt2_hyena.py
+++ b/lib/levanter/src/levanter/models/gpt2_hyena.py
@@ -5,7 +5,7 @@
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Dict, Optional, Type
+from typing import Dict, Optional, Type, cast
 
 import equinox as eqx
 import jax
@@ -17,7 +17,6 @@ import haliax.jax_utils
 import haliax.nn as hnn
 from haliax import Axis, NamedArray
 from haliax.jax_utils import named_call, shaped_rng_split
-from haliax.nn.scan import Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.layers.attention import AttentionMask
@@ -25,6 +24,7 @@ from levanter.models.gpt2 import Gpt2Embeddings, Gpt2Mlp
 from levanter.models.hyena import HyenaConfig, HyenaOperator
 from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.models.scan_layers import init_scan_foldable
+from levanter.utils.types import BlockFoldable
 
 
 @LmConfig.register_subclass("gpt2_hyena")
@@ -113,7 +113,7 @@ class Gpt2HyenaBlock(eqx.Module):
 
 class Gpt2HyenaBackbone(ModuleWithStateDictSerialization):
     config: Gpt2HyenaConfig = eqx.field(static=True)
-    blocks: Stacked[Gpt2HyenaBlock]
+    blocks: BlockFoldable[Gpt2HyenaBlock]
     ln_f: hnn.LayerNorm
 
     @staticmethod
@@ -133,7 +133,7 @@ class Gpt2HyenaBackbone(ModuleWithStateDictSerialization):
     @named_call
     def __call__(self, x: NamedArray, *, key=None) -> NamedArray:
         keys = hax.jax_utils.maybe_rng_split(key, self.config.num_layers) if key is not None else None
-        x = self.blocks.fold(x, key=keys)
+        x = cast(NamedArray, self.blocks.fold(x, key=keys))
         x = self.ln_f(x)
 
         return x

--- a/lib/levanter/src/levanter/models/linear.py
+++ b/lib/levanter/src/levanter/models/linear.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Levanter Authors
+# Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/lib/levanter/src/levanter/models/llama.py
+++ b/lib/levanter/src/levanter/models/llama.py
@@ -14,7 +14,6 @@ import haliax as hax
 import haliax.nn as hnn
 from haliax import Axis, AxisSpec, NamedArray
 from haliax.jax_utils import maybe_rng_split, named_call, shaped_rng_split
-from haliax.nn.scan import ScanCheckpointPolicy
 from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
@@ -28,7 +27,7 @@ from levanter.models.scan_layers import init_scan_foldable
 from levanter.utils.activation import ActivationFunctionEnum
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.logging import silence_transformer_nag
-from levanter.utils.types import BlockFoldable
+from levanter.utils.types import BlockFoldable, ScanCheckpointPolicy
 
 silence_transformer_nag()
 from transformers import LlamaConfig as HfLlamaConfig  # noqa: E402

--- a/lib/levanter/src/levanter/models/llama.py
+++ b/lib/levanter/src/levanter/models/llama.py
@@ -14,7 +14,7 @@ import haliax as hax
 import haliax.nn as hnn
 from haliax import Axis, AxisSpec, NamedArray
 from haliax.jax_utils import maybe_rng_split, named_call, shaped_rng_split
-from haliax.nn.scan import ScanCheckpointPolicy, Stacked
+from haliax.nn.scan import ScanCheckpointPolicy
 from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
@@ -24,6 +24,7 @@ from levanter.layers.attention import Attention, AttentionBackend, AttentionConf
 from levanter.layers.kv_cache import KvPageCache, ListCache
 from levanter.layers.rotary import DefaultRotaryEmbeddingsConfig, RotaryEmbeddingsConfig
 from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.models.scan_layers import init_scan_foldable
 from levanter.utils.activation import ActivationFunctionEnum
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.logging import silence_transformer_nag
@@ -390,14 +391,12 @@ class LlamaTransformer(eqx.Module):
 
     @staticmethod
     def init(config: LlamaConfig, *, key) -> "LlamaTransformer":
-        S = Stacked
-        if not config.scan_layers:
-            from haliax.nn.scan import BlockSeq
-
-            S = BlockSeq
-
-        layers = S.init(config.Layers, LlamaDecoderLayer, gradient_checkpointing=config.gradient_checkpointing)(
+        layers = init_scan_foldable(
+            config.Layers,
+            LlamaDecoderLayer,
             config,
+            scan_layers=config.scan_layers,
+            gradient_checkpointing=config.gradient_checkpointing,
             key=shaped_rng_split(key, config.num_layers),
         )
         ln_f = config.mk_LayerNorm(config.Embed)

--- a/lib/levanter/src/levanter/models/loss.py
+++ b/lib/levanter/src/levanter/models/loss.py
@@ -10,10 +10,10 @@ import haliax as hax
 from haliax import NamedArray
 from haliax.core import flatten_all_axes_but
 from haliax.nn import cross_entropy_loss_and_log_normalizers
-from haliax.partitioning import current_thread_local_mapping, shard_map
 from levanter.kernels.pallas.fused_cross_entropy_loss import (
     fused_cross_entropy_loss_and_logsumexp_penalty as fused_cross_entropy_loss_and_logsumexp_penalty_kernel,
 )
+from levanter.utils.partitioning import current_thread_local_mapping, shard_map
 
 DEFAULT_REDUCTION = cast(hax.ReductionFunction, hax.mean)
 

--- a/lib/levanter/src/levanter/models/mixtral.py
+++ b/lib/levanter/src/levanter/models/mixtral.py
@@ -11,7 +11,6 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jax.random as jrandom
-from jax._src.mesh import get_concrete_mesh
 from jax import Array
 from jax import shard_map
 
@@ -33,6 +32,7 @@ from levanter.models.scan_layers import init_scan_foldable
 from levanter.utils.activation import ActivationFunctionEnum
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.logging import silence_transformer_nag
+from levanter.utils.mesh import get_active_mesh
 from levanter.utils.partitioning import pspec_for_axis
 from levanter.utils.types import BlockFoldable
 
@@ -340,7 +340,7 @@ class MixtralSparseMoeBlock(eqx.Module):
     def _route(self, router_probs: NamedArray, Token: Axis, TopExperts: Axis):
         @partial(
             shard_map,
-            mesh=get_concrete_mesh(),
+            mesh=get_active_mesh(),
             in_specs=pspec_for_axis(router_probs.axes),
             out_specs=(
                 pspec_for_axis((Token, TopExperts)),
@@ -367,7 +367,7 @@ class MixtralSparseMoeBlock(eqx.Module):
 
         @partial(
             shard_map,
-            mesh=get_concrete_mesh(),
+            mesh=get_active_mesh(),
             in_specs=(
                 pspec_for_axis(x_flat.axes),
                 pspec_for_axis(topk_idx_flat.axes),
@@ -405,7 +405,7 @@ class MixtralSparseMoeBlock(eqx.Module):
     ):
         @partial(
             shard_map,
-            mesh=get_concrete_mesh(),
+            mesh=get_active_mesh(),
             in_specs=(
                 pspec_for_axis(out_repeat_sort.axes),
                 pspec_for_axis(sort_idx.axes),

--- a/lib/levanter/src/levanter/models/mixtral.py
+++ b/lib/levanter/src/levanter/models/mixtral.py
@@ -33,6 +33,7 @@ from levanter.models.scan_layers import init_scan_foldable
 from levanter.utils.activation import ActivationFunctionEnum
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.logging import silence_transformer_nag
+from levanter.utils.partitioning import pspec_for_axis
 from levanter.utils.types import BlockFoldable
 
 
@@ -340,10 +341,10 @@ class MixtralSparseMoeBlock(eqx.Module):
         @partial(
             shard_map,
             mesh=get_concrete_mesh(),
-            in_specs=hax.partitioning.pspec_for_axis(router_probs.axes),
+            in_specs=pspec_for_axis(router_probs.axes),
             out_specs=(
-                hax.partitioning.pspec_for_axis((Token, TopExperts)),
-                hax.partitioning.pspec_for_axis((Token, TopExperts)),
+                pspec_for_axis((Token, TopExperts)),
+                pspec_for_axis((Token, TopExperts)),
             ),
             **_SHARD_MAP_CHECK_KWARGS,
         )
@@ -368,13 +369,13 @@ class MixtralSparseMoeBlock(eqx.Module):
             shard_map,
             mesh=get_concrete_mesh(),
             in_specs=(
-                hax.partitioning.pspec_for_axis(x_flat.axes),
-                hax.partitioning.pspec_for_axis(topk_idx_flat.axes),
+                pspec_for_axis(x_flat.axes),
+                pspec_for_axis(topk_idx_flat.axes),
             ),
             out_specs=(
-                hax.partitioning.pspec_for_axis((TokenRepeat, self.config.Embed)),
-                hax.partitioning.pspec_for_axis((Experts,)),
-                hax.partitioning.pspec_for_axis((TokenRepeat,)),
+                pspec_for_axis((TokenRepeat, self.config.Embed)),
+                pspec_for_axis((Experts,)),
+                pspec_for_axis((TokenRepeat,)),
             ),
             **_SHARD_MAP_CHECK_KWARGS,
         )
@@ -406,10 +407,10 @@ class MixtralSparseMoeBlock(eqx.Module):
             shard_map,
             mesh=get_concrete_mesh(),
             in_specs=(
-                hax.partitioning.pspec_for_axis(out_repeat_sort.axes),
-                hax.partitioning.pspec_for_axis(sort_idx.axes),
+                pspec_for_axis(out_repeat_sort.axes),
+                pspec_for_axis(sort_idx.axes),
             ),
-            out_specs=hax.partitioning.pspec_for_axis((Token, TopExperts, self.config.Embed)),
+            out_specs=pspec_for_axis((Token, TopExperts, self.config.Embed)),
             **_SHARD_MAP_CHECK_KWARGS,
         )
         def unpermute_sharded(out_repeat_sort_: Array, sort_idx_: Array):

--- a/lib/levanter/src/levanter/models/mixtral.py
+++ b/lib/levanter/src/levanter/models/mixtral.py
@@ -20,7 +20,6 @@ import haliax.nn as hnn
 from haliax import Axis, AxisSpec, NamedArray
 from haliax.jax_utils import maybe_rng_split, named_call, shaped_rng_split
 from haliax.nn.normalization import LayerNormBase
-from haliax.nn.scan import Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization, StateDict
 
 import levanter.tracker
@@ -30,6 +29,7 @@ from levanter.layers.rotary import DefaultRotaryEmbeddingsConfig, RotaryEmbeddin
 from levanter.models.llama import LlamaEmbedding, LlamaMlp
 from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.models.mistral import MistralConfig
+from levanter.models.scan_layers import init_scan_foldable
 from levanter.utils.activation import ActivationFunctionEnum
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.logging import silence_transformer_nag
@@ -530,14 +530,12 @@ class MixtralTransformer(eqx.Module):
 
     @staticmethod
     def init(config: MistralConfig, *, key) -> "MixtralTransformer":
-        S = Stacked
-        if not config.scan_layers:
-            from haliax.nn.scan import BlockSeq
-
-            S = BlockSeq
-
-        layers = S.init(config.Layers, MixtralDecoderLayer, gradient_checkpointing=config.gradient_checkpointing)(
+        layers = init_scan_foldable(
+            config.Layers,
+            MixtralDecoderLayer,
             config,
+            scan_layers=config.scan_layers,
+            gradient_checkpointing=config.gradient_checkpointing,
             key=shaped_rng_split(key, config.num_layers),
         )
         ln_f = config.mk_LayerNorm(config.Embed)

--- a/lib/levanter/src/levanter/models/olmo.py
+++ b/lib/levanter/src/levanter/models/olmo.py
@@ -28,6 +28,7 @@ from levanter.layers.attention import (
 )
 from levanter.layers.rotary import DefaultRotaryEmbeddingsConfig, RotaryEmbeddingsConfig
 from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.models.scan_layers import init_scan_foldable
 from levanter.utils.activation import ActivationFunctionEnum
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.logging import silence_transformer_nag
@@ -441,14 +442,12 @@ class Olmo2Transformer(ModuleWithStateDictSerialization, eqx.Module):
 
     @staticmethod
     def init(config: Olmo2Config, *, key) -> "Olmo2Transformer":
-        S = Stacked
-        if not config.scan_layers:
-            from haliax.nn.scan import BlockSeq
-
-            S = BlockSeq
-
-        layers = S.init(config.Layers, Olmo2DecoderLayer, gradient_checkpointing=config.gradient_checkpointing)(
+        layers = init_scan_foldable(
+            config.Layers,
+            Olmo2DecoderLayer,
             config,
+            scan_layers=config.scan_layers,
+            gradient_checkpointing=config.gradient_checkpointing,
             key=shaped_rng_split(key, config.num_layers),
         )
         ln_f = config.mk_LayerNorm(config.Embed)

--- a/lib/levanter/src/levanter/models/olmo.py
+++ b/lib/levanter/src/levanter/models/olmo.py
@@ -3,7 +3,7 @@
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Callable, Dict, Optional, Type, Union
+from typing import Callable, Dict, Optional, Type, Union, cast
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -14,7 +14,6 @@ import haliax as hax
 import haliax.nn as hnn
 from haliax import Axis, AxisSpec, NamedArray
 from haliax.jax_utils import maybe_rng_split, named_call, shaped_rng_split
-from haliax.nn.scan import Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
@@ -32,6 +31,7 @@ from levanter.models.scan_layers import init_scan_foldable
 from levanter.utils.activation import ActivationFunctionEnum
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.logging import silence_transformer_nag
+from levanter.utils.types import BlockFoldable
 
 
 silence_transformer_nag()
@@ -437,7 +437,7 @@ class Olmo2DecoderLayer(ModuleWithStateDictSerialization, eqx.Module):
 
 class Olmo2Transformer(ModuleWithStateDictSerialization, eqx.Module):
     config: Olmo2Config = eqx.field(static=True)
-    layers: Stacked[Olmo2DecoderLayer]
+    layers: BlockFoldable[Olmo2DecoderLayer]
     norm: hnn.RmsNorm
 
     @staticmethod
@@ -459,7 +459,7 @@ class Olmo2Transformer(ModuleWithStateDictSerialization, eqx.Module):
         self, x: NamedArray, attn_mask: Optional[NamedArray | AttentionMask], *, key, pos_ids: NamedArray | None = None
     ) -> NamedArray:
         keys = maybe_rng_split(key, self.config.num_layers) if key is not None else None
-        x = self.layers.fold(x, mask=attn_mask, key=keys, pos_ids=pos_ids)
+        x = cast(NamedArray, self.layers.fold(x, mask=attn_mask, key=keys, pos_ids=pos_ids))
         x = self.norm(x)
         return x
 

--- a/lib/levanter/src/levanter/models/olmo3.py
+++ b/lib/levanter/src/levanter/models/olmo3.py
@@ -20,7 +20,6 @@ import haliax as hax
 import haliax.nn as hnn
 from haliax import Axis, AxisSpec, NamedArray
 from haliax.jax_utils import maybe_rng_split, named_call, shaped_rng_split
-from haliax.nn.scan import BlockSeq, ScanCheckpointPolicy
 from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
@@ -30,7 +29,7 @@ from levanter.layers.rotary import DefaultRotaryEmbeddingsConfig, RotaryEmbeddin
 from levanter.models.llama import LlamaMlp
 from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.models.olmo import Olmo2Embedding
-from levanter.models.scan_layers import init_scan_foldable
+from levanter.models.scan_layers import init_blockseq_from_blocks, init_scan_foldable
 from levanter.utils.activation import ActivationFunctionEnum
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.logging import silence_transformer_nag
@@ -314,7 +313,11 @@ class Olmo3Transformer(ModuleWithStateDictSerialization, eqx.Module):
             # to avoid JAX tracing issues during eval_shape
             keys = shaped_rng_split(key, config.num_layers)
             blocks = [Olmo3DecoderLayer.init(config, layer_idx=i, key=keys[i]) for i in range(config.num_layers)]
-            layers = BlockSeq(blocks, config.Layers, ScanCheckpointPolicy._mk(config.gradient_checkpointing))
+            layers = init_blockseq_from_blocks(
+                blocks,
+                config.Layers,
+                gradient_checkpointing=config.gradient_checkpointing,
+            )
 
         ln_f = config.mk_LayerNorm(config.Embed)
         return Olmo3Transformer(config, layers, ln_f)

--- a/lib/levanter/src/levanter/models/olmo3.py
+++ b/lib/levanter/src/levanter/models/olmo3.py
@@ -20,7 +20,7 @@ import haliax as hax
 import haliax.nn as hnn
 from haliax import Axis, AxisSpec, NamedArray
 from haliax.jax_utils import maybe_rng_split, named_call, shaped_rng_split
-from haliax.nn.scan import BlockSeq, ScanCheckpointPolicy, Stacked
+from haliax.nn.scan import BlockSeq, ScanCheckpointPolicy
 from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
@@ -28,8 +28,9 @@ from levanter.layers import RmsNormConfig
 from levanter.layers.attention import Attention, AttentionBackend, AttentionConfig, AttentionMask
 from levanter.layers.rotary import DefaultRotaryEmbeddingsConfig, RotaryEmbeddingsConfig
 from levanter.models.llama import LlamaMlp
-from levanter.models.olmo import Olmo2Embedding
 from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.models.olmo import Olmo2Embedding
+from levanter.models.scan_layers import init_scan_foldable
 from levanter.utils.activation import ActivationFunctionEnum
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.logging import silence_transformer_nag
@@ -298,12 +299,14 @@ class Olmo3Transformer(ModuleWithStateDictSerialization, eqx.Module):
         use_stacked = config.scan_layers and Olmo3Transformer._can_scan(layer_types)
 
         if use_stacked:
-            # All layers same type
-            layers = Stacked.init(
-                config.Layers, Olmo3DecoderLayer, gradient_checkpointing=config.gradient_checkpointing
-            )(
+            # All layers same type.
+            layers = init_scan_foldable(
+                config.Layers,
+                Olmo3DecoderLayer,
                 config,
                 layer_idx=0,
+                scan_layers=True,
+                gradient_checkpointing=config.gradient_checkpointing,
                 key=shaped_rng_split(key, config.num_layers),
             )
         else:

--- a/lib/levanter/src/levanter/models/qwen.py
+++ b/lib/levanter/src/levanter/models/qwen.py
@@ -12,7 +12,6 @@ import haliax as hax
 import haliax.nn as hnn
 from haliax import Axis, NamedArray
 from haliax.jax_utils import maybe_rng_split, named_call, shaped_rng_split
-from haliax.nn.scan import Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
@@ -20,6 +19,7 @@ from levanter.layers.attention import Attention, AttentionConfig, AttentionMask
 from levanter.layers.rotary import RotaryEmbeddingsConfig
 from levanter.models.llama import LlamaConfig, LlamaEmbedding, LlamaLMHeadModel, LlamaMlp, LlamaTransformer
 from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.models.scan_layers import init_scan_foldable
 from levanter.utils.activation import ActivationFunctionEnum
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.logging import silence_transformer_nag
@@ -194,15 +194,13 @@ class QwenTransformer(LlamaTransformer):
 
     @staticmethod
     def init(config: QwenConfig, *, key) -> "QwenTransformer":
-        S = Stacked
-        if not config.scan_layers:
-            from haliax.nn.scan import BlockSeq
-
-            S = BlockSeq
-
-        # Initialize layers with their indices
-        layers = S.init(config.Layers, QwenDecoderLayer, gradient_checkpointing=config.gradient_checkpointing)(
+        # Initialize layers with their indices.
+        layers = init_scan_foldable(
+            config.Layers,
+            QwenDecoderLayer,
             config,
+            scan_layers=config.scan_layers,
+            gradient_checkpointing=config.gradient_checkpointing,
             key=shaped_rng_split(key, config.num_layers),
         )
 

--- a/lib/levanter/src/levanter/models/scan_layers.py
+++ b/lib/levanter/src/levanter/models/scan_layers.py
@@ -16,6 +16,13 @@ def _scan_stack_cls(scan_layers: bool):
     return BlockSeq
 
 
+def is_scan_container(x: object) -> bool:
+    """Return True for Haliax scan containers used for stacked transformer blocks."""
+    from haliax.nn.scan import BlockSeq, Stacked
+
+    return isinstance(x, (Stacked, BlockSeq))
+
+
 def init_scan_foldable(
     Layers: Axis,
     BlockType: Any,

--- a/lib/levanter/src/levanter/models/scan_layers.py
+++ b/lib/levanter/src/levanter/models/scan_layers.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright 2025 The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 

--- a/lib/levanter/src/levanter/models/scan_layers.py
+++ b/lib/levanter/src/levanter/models/scan_layers.py
@@ -6,7 +6,14 @@ from __future__ import annotations
 from typing import Any
 
 from haliax import Axis
-from haliax.nn.scan import Stacked
+
+
+def _scan_stack_cls(scan_layers: bool):
+    from haliax.nn.scan import BlockSeq, Stacked
+
+    if scan_layers:
+        return Stacked
+    return BlockSeq
 
 
 def init_scan_foldable(
@@ -24,11 +31,7 @@ def init_scan_foldable(
     This keeps stack selection (`Stacked` vs `BlockSeq`) centralized so models
     can migrate off Haliax scan containers in one place.
     """
-    stack_cls = Stacked
-    if not scan_layers:
-        from haliax.nn.scan import BlockSeq
-
-        stack_cls = BlockSeq
+    stack_cls = _scan_stack_cls(scan_layers)
 
     return stack_cls.init(
         Layers,
@@ -39,3 +42,15 @@ def init_scan_foldable(
         key=key,
         **init_kwargs,
     )
+
+
+def init_blockseq_from_blocks(
+    blocks: list[Any],
+    Layers: Axis,
+    *,
+    gradient_checkpointing: bool | str,
+):
+    """Construct a `BlockSeq` with centralized checkpoint-policy resolution."""
+    from haliax.nn.scan import BlockSeq, ScanCheckpointPolicy
+
+    return BlockSeq(blocks, Layers, ScanCheckpointPolicy._mk(gradient_checkpointing))

--- a/lib/levanter/src/levanter/models/scan_layers.py
+++ b/lib/levanter/src/levanter/models/scan_layers.py
@@ -1,0 +1,41 @@
+# Copyright 2025 The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+from haliax import Axis
+from haliax.nn.scan import Stacked
+
+
+def init_scan_foldable(
+    Layers: Axis,
+    BlockType: Any,
+    *init_args,
+    scan_layers: bool,
+    gradient_checkpointing: bool | str,
+    key,
+    **init_kwargs,
+):
+    """
+    Initialize a scan-capable block container with a single call-site shape.
+
+    This keeps stack selection (`Stacked` vs `BlockSeq`) centralized so models
+    can migrate off Haliax scan containers in one place.
+    """
+    stack_cls = Stacked
+    if not scan_layers:
+        from haliax.nn.scan import BlockSeq
+
+        stack_cls = BlockSeq
+
+    return stack_cls.init(
+        Layers,
+        BlockType,
+        gradient_checkpointing=gradient_checkpointing,
+    )(
+        *init_args,
+        key=key,
+        **init_kwargs,
+    )

--- a/lib/levanter/src/levanter/models/whisper.py
+++ b/lib/levanter/src/levanter/models/whisper.py
@@ -22,6 +22,7 @@ from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
 from levanter.layers.attention import AttentionBackend, AttentionMask, dot_product_attention
 from levanter.models.asr_model import ASRConfig, ASRMixin
 from levanter.models.lm_model import LmConfig
+from levanter.models.scan_layers import init_scan_foldable
 from levanter.utils.activation import ActivationFunctionEnum
 from levanter.utils.logging import silence_transformer_nag
 
@@ -281,13 +282,16 @@ class WhisperTransformer(ModuleWithStateDictSerialization):
 
     @staticmethod
     def init(Layer: Axis, Heads: Axis, HeadSize: Axis, Mlp: Axis, config: WhisperConfig, has_cross: bool, *, key):
-        # vectorize the blocks
-        layers = Stacked.init(Layer, WhisperLayer, gradient_checkpointing=config.gradient_checkpointing)(
+        layers = init_scan_foldable(
+            Layer,
+            WhisperLayer,
             Heads,
             HeadSize,
             Mlp,
             config,
             has_cross=has_cross,
+            scan_layers=True,
+            gradient_checkpointing=config.gradient_checkpointing,
             key=shaped_rng_split(key, Layer.size),
         )
         layer_norm = hnn.LayerNorm.init(config.Embed, eps=config.layer_norm_epsilon, use_bias=config.use_bias)

--- a/lib/levanter/src/levanter/models/whisper.py
+++ b/lib/levanter/src/levanter/models/whisper.py
@@ -3,7 +3,7 @@
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Callable, Dict, Optional, Type
+from typing import Callable, Dict, Optional, Type, cast
 
 import equinox as eqx
 import jax
@@ -15,7 +15,6 @@ import haliax.jax_utils
 import haliax.nn as hnn
 from haliax import Axis, NamedArray
 from haliax.jax_utils import named_call, shaped_rng_split
-from haliax.nn.scan import Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig, ModelWithHfSerializationMixin
@@ -25,6 +24,7 @@ from levanter.models.lm_model import LmConfig
 from levanter.models.scan_layers import init_scan_foldable
 from levanter.utils.activation import ActivationFunctionEnum
 from levanter.utils.logging import silence_transformer_nag
+from levanter.utils.types import BlockFoldable
 
 
 silence_transformer_nag()
@@ -276,7 +276,7 @@ class WhisperLayer(ModuleWithStateDictSerialization, eqx.Module):
 
 
 class WhisperTransformer(ModuleWithStateDictSerialization):
-    layers: Stacked[WhisperLayer]
+    layers: BlockFoldable[WhisperLayer]
     Layer: Axis
     layer_norm: hnn.LayerNorm
 
@@ -308,7 +308,7 @@ class WhisperTransformer(ModuleWithStateDictSerialization):
         key=None,
     ) -> NamedArray:
         keys = hax.jax_utils.maybe_rng_split(key, self.Layer.size) if key is not None else None
-        x = self.layers.fold(x, xa, attn_mask, key=keys)
+        x = cast(NamedArray, self.layers.fold(x, xa, attn_mask, key=keys))
         x = self.layer_norm(x)
 
         return x

--- a/lib/levanter/src/levanter/optim/config.py
+++ b/lib/levanter/src/levanter/optim/config.py
@@ -15,13 +15,20 @@ import numpy as np
 import optax
 from jax import numpy as jnp
 
-import haliax
-
 import levanter.tracker
 from levanter.optim.clip_update_norm import ClipUpdateNormConfig
 from levanter.optim.skipstep import SkipStepConfig
 from levanter.optim.util import log_norm_passthrough, scan_aware_clip_by_block_rms
 from levanter.utils.jax_utils import leaf_key_paths
+
+
+def _is_named_array_like(x) -> bool:
+    # NamedArray duck-typing keeps this module independent of Haliax imports.
+    return hasattr(x, "axes") and hasattr(x, "array")
+
+
+def _is_jax_or_named_array_like(x) -> bool:
+    return eqx.is_array(x) or _is_named_array_like(x)
 
 
 @dataclass(frozen=True)
@@ -168,7 +175,7 @@ class OptimizerConfig(draccus.ChoiceRegistry, abc.ABC):
             )
 
             def is_leaf(x):
-                return eqx.is_array(x) or isinstance(x, eqx.Module) or haliax.is_named_array(x)
+                return eqx.is_array(x) or isinstance(x, eqx.Module) or _is_named_array_like(x)
 
             # mask based on regex or module path
             def _apply_on(decayed_paths, x, from_root_key_path, from_class_keypath):
@@ -187,7 +194,7 @@ class OptimizerConfig(draccus.ChoiceRegistry, abc.ABC):
                         is_leaf=lambda y: x is not y and is_leaf(y),
                     )
                     return this_mask
-                elif not haliax.util.is_jax_or_hax_array_like(x):
+                elif not _is_jax_or_named_array_like(x):
                     return x
 
                 should_decay = None

--- a/lib/levanter/src/levanter/optim/kron.py
+++ b/lib/levanter/src/levanter/optim/kron.py
@@ -22,6 +22,7 @@ from optax._src.numerics import safe_int32_increment
 from optax._src.utils import canonicalize_dtype
 
 from levanter.optim.config import OptimizerConfig
+from levanter.utils.mesh import DATA_AXIS
 
 # Define type variables for the pytree structure
 T = TypeVar("T")
@@ -1118,7 +1119,7 @@ def _init_Q_exprs(
                             mesh = None
                         # get fsdp mesh axis
                         if mesh is not None:
-                            fsdp_axis_name = hax.partitioning.ResourceAxis.DATA
+                            fsdp_axis_name = DATA_AXIS
                             fsdp_axis = mesh.axis_names.index(fsdp_axis_name)
                             fsdp_size = mesh.devices.shape[fsdp_axis]
                             if size % fsdp_size == 0:

--- a/lib/levanter/src/levanter/optim/kron.py
+++ b/lib/levanter/src/levanter/optim/kron.py
@@ -21,6 +21,7 @@ from optax._src.combine import chain
 from optax._src.numerics import safe_int32_increment
 from optax._src.utils import canonicalize_dtype
 
+from levanter.models.scan_layers import is_scan_container
 from levanter.optim.config import OptimizerConfig
 from levanter.utils.mesh import DATA_AXIS
 
@@ -284,9 +285,9 @@ def scale_by_kron(
                 # this does not support nested stacks
                 if scanned_layers_ is None:
                     scanned_layers_ = jax.tree.map(
-                        lambda x: (jax.tree.map(lambda _: True, x) if isinstance(x, hax.nn.Stacked) else False),
+                        lambda x: (jax.tree.map(lambda _: True, x) if is_scan_container(x) else False),
                         params,
-                        is_leaf=lambda x: isinstance(x, hax.nn.Stacked),
+                        is_leaf=lambda x: is_scan_container(x),
                     )
                 if params_sharding_ is None:
                     params_sharding_ = hax.partitioning.infer_resource_partitions(params)
@@ -501,9 +502,9 @@ def scale_by_kron(
                 # this does not support nested stacks
                 if scanned_layers_ is None:
                     scanned_layers_ = jax.tree.map(
-                        lambda x: (jax.tree.map(lambda _: True, x) if isinstance(x, hax.nn.Stacked) else False),
+                        lambda x: (jax.tree.map(lambda _: True, x) if is_scan_container(x) else False),
                         updates,
-                        is_leaf=lambda x: isinstance(x, hax.nn.Stacked),
+                        is_leaf=lambda x: is_scan_container(x),
                     )
                 if params_sharding_ is None:
                     params_sharding_ = hax.partitioning.infer_resource_partitions(updates)

--- a/lib/levanter/src/levanter/optim/kron.py
+++ b/lib/levanter/src/levanter/optim/kron.py
@@ -23,7 +23,7 @@ from optax._src.utils import canonicalize_dtype
 
 from levanter.models.scan_layers import is_scan_container
 from levanter.optim.config import OptimizerConfig
-from levanter.utils.mesh import DATA_AXIS
+from levanter.utils.mesh import DATA_AXIS, get_active_mesh
 from levanter.utils.partitioning import infer_resource_partitions
 
 # Define type variables for the pytree structure
@@ -1116,9 +1116,7 @@ def _init_Q_exprs(
                     if have_hax:
                         # if we're in haliax we can grab fsdp axis and shard accordingly
                         # get current mesh
-                        mesh = jax._src.mesh.get_concrete_mesh()
-                        if mesh.devices.shape == ():
-                            mesh = None
+                        mesh = get_active_mesh()
                         # get fsdp mesh axis
                         if mesh is not None:
                             fsdp_axis_name = DATA_AXIS

--- a/lib/levanter/src/levanter/optim/kron.py
+++ b/lib/levanter/src/levanter/optim/kron.py
@@ -24,6 +24,7 @@ from optax._src.utils import canonicalize_dtype
 from levanter.models.scan_layers import is_scan_container
 from levanter.optim.config import OptimizerConfig
 from levanter.utils.mesh import DATA_AXIS
+from levanter.utils.partitioning import infer_resource_partitions
 
 # Define type variables for the pytree structure
 T = TypeVar("T")
@@ -290,7 +291,7 @@ def scale_by_kron(
                         is_leaf=lambda x: is_scan_container(x),
                     )
                 if params_sharding_ is None:
-                    params_sharding_ = hax.partitioning.infer_resource_partitions(params)
+                    params_sharding_ = infer_resource_partitions(params)
                     params_sharding_ = jax.tree.map(lambda x: x.spec, params_sharding_)
                 params, params_struct = jax.tree.flatten(params)
                 scanned_layers_ = jax.tree.leaves(scanned_layers_)
@@ -507,7 +508,7 @@ def scale_by_kron(
                         is_leaf=lambda x: is_scan_container(x),
                     )
                 if params_sharding_ is None:
-                    params_sharding_ = hax.partitioning.infer_resource_partitions(updates)
+                    params_sharding_ = infer_resource_partitions(updates)
                     params_sharding_ = jax.tree.map(lambda x: x.spec, params_sharding_)
                 updates, updates_struct = jax.tree.flatten(updates)
                 scanned_layers_ = jax.tree.leaves(scanned_layers_)

--- a/lib/levanter/src/levanter/optim/muon.py
+++ b/lib/levanter/src/levanter/optim/muon.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright 2025 The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 

--- a/lib/levanter/src/levanter/optim/muonh.py
+++ b/lib/levanter/src/levanter/optim/muonh.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright 2025 The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 

--- a/lib/levanter/src/levanter/optim/namo.py
+++ b/lib/levanter/src/levanter/optim/namo.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright 2025 The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 

--- a/lib/levanter/src/levanter/optim/scion.py
+++ b/lib/levanter/src/levanter/optim/scion.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright 2025 The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 

--- a/lib/levanter/src/levanter/optim/soap.py
+++ b/lib/levanter/src/levanter/optim/soap.py
@@ -23,6 +23,7 @@ from optax import GradientTransformation, Updates
 from optax._src.utils import canonicalize_dtype
 
 from levanter.optim.config import OptimizerConfig
+from levanter.utils.mesh import DATA_AXIS
 
 
 @OptimizerConfig.register_subclass("soap")
@@ -842,7 +843,7 @@ def init_conditioner(p_shape, max_precond_dim: int, dtype: Optional[Union[str, j
         mesh = None
     # get fsdp mesh axis
     if mesh is not None:
-        fsdp_axis_name = hax.partitioning.ResourceAxis.DATA
+        fsdp_axis_name = DATA_AXIS
         fsdp_axis = mesh.axis_names.index(fsdp_axis_name)
         fsdp_size = mesh.devices.shape[fsdp_axis]
 

--- a/lib/levanter/src/levanter/optim/soap.py
+++ b/lib/levanter/src/levanter/optim/soap.py
@@ -22,6 +22,7 @@ from jaxtyping import Array
 from optax import GradientTransformation, Updates
 from optax._src.utils import canonicalize_dtype
 
+from levanter.models.scan_layers import is_scan_container
 from levanter.optim.config import OptimizerConfig
 from levanter.utils.mesh import DATA_AXIS
 
@@ -150,11 +151,11 @@ def scale_by_soap(
         scanned_layers_ = jax.tree.map(
             lambda x: (
                 jax.tree.map(lambda _: True, x, is_leaf=lambda x: isinstance(x, jax.Array))
-                if isinstance(x, hax.nn.Stacked)
+                if is_scan_container(x)
                 else jax.tree.map(lambda _: False, x, is_leaf=lambda x: isinstance(x, jax.Array))
             ),
             params,
-            is_leaf=lambda x: isinstance(x, hax.nn.Stacked),
+            is_leaf=lambda x: is_scan_container(x),
         )
         params_sharding_ = hax.partitioning.infer_resource_partitions(params)
         params_sharding_ = jax.tree.map(lambda x: x.spec, params_sharding_)
@@ -677,11 +678,11 @@ def scale_by_soap(
         scanned_layers_ = jax.tree.map(
             lambda x: (
                 jax.tree.map(lambda _: True, x, is_leaf=lambda x: isinstance(x, jax.Array))
-                if isinstance(x, hax.nn.Stacked)
+                if is_scan_container(x)
                 else jax.tree.map(lambda _: False, x, is_leaf=lambda x: isinstance(x, jax.Array))
             ),
             params,
-            is_leaf=lambda x: isinstance(x, hax.nn.Stacked),
+            is_leaf=lambda x: is_scan_container(x),
         )
 
         updates, new_state = jax.lax.cond(

--- a/lib/levanter/src/levanter/optim/soap.py
+++ b/lib/levanter/src/levanter/optim/soap.py
@@ -23,7 +23,7 @@ from optax._src.utils import canonicalize_dtype
 
 from levanter.models.scan_layers import is_scan_container
 from levanter.optim.config import OptimizerConfig
-from levanter.utils.mesh import DATA_AXIS
+from levanter.utils.mesh import DATA_AXIS, get_active_mesh
 from levanter.utils.partitioning import infer_resource_partitions
 
 
@@ -839,9 +839,7 @@ def init_conditioner(p_shape, max_precond_dim: int, dtype: Optional[Union[str, j
         return ([jnp.zeros((p_shape[0], p_shape[0]), dtype=dtype)], [PartitionSpec()])
 
     # sharding purpose
-    mesh = jax._src.mesh.get_concrete_mesh()
-    if mesh.devices.shape == ():
-        mesh = None
+    mesh = get_active_mesh()
     # get fsdp mesh axis
     if mesh is not None:
         fsdp_axis_name = DATA_AXIS

--- a/lib/levanter/src/levanter/optim/soap.py
+++ b/lib/levanter/src/levanter/optim/soap.py
@@ -7,7 +7,6 @@ from functools import partial
 from itertools import chain
 from typing import List, Optional, Tuple, Union
 
-import haliax as hax
 import jax
 import jax.numpy as jnp
 import jax.tree_util as jtu
@@ -25,6 +24,7 @@ from optax._src.utils import canonicalize_dtype
 from levanter.models.scan_layers import is_scan_container
 from levanter.optim.config import OptimizerConfig
 from levanter.utils.mesh import DATA_AXIS
+from levanter.utils.partitioning import infer_resource_partitions
 
 
 @OptimizerConfig.register_subclass("soap")
@@ -157,7 +157,7 @@ def scale_by_soap(
             params,
             is_leaf=lambda x: is_scan_container(x),
         )
-        params_sharding_ = hax.partitioning.infer_resource_partitions(params)
+        params_sharding_ = infer_resource_partitions(params)
         params_sharding_ = jax.tree.map(lambda x: x.spec, params_sharding_)
         shapes = jax.tree.map(lambda p, s: p.shape[int(s) :], params, scanned_layers_)
 

--- a/lib/levanter/src/levanter/optim/util.py
+++ b/lib/levanter/src/levanter/optim/util.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright 2025 The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -25,6 +25,7 @@ from jax.sharding import Mesh, Sharding
 from jaxtyping import PyTree
 
 from levanter.utils import fsspec_utils, jax_utils
+from levanter.utils.partitioning import sharding_for_axis
 from levanter.utils.types import ResourceMapping
 
 logger = logging.getLogger(__name__)
@@ -175,7 +176,7 @@ def _sharding_from_leaf(leaf, axis_mapping, mesh) -> Optional[jax.sharding.Shard
     if is_named_array(leaf):
         if not is_jax_array_like(leaf.array):
             return None
-        return hax.partitioning.sharding_for_axis(leaf.axes, axis_mapping, mesh)
+        return sharding_for_axis(leaf.axes, axis_mapping, mesh)
     elif hasattr(leaf, "sharding") and getattr(leaf, "sharding") is not None:
         return _concretize_sharding(leaf.sharding)
     elif is_jax_array_like(leaf):
@@ -188,7 +189,7 @@ def _sharding_from_leaf(leaf, axis_mapping, mesh) -> Optional[jax.sharding.Shard
 
 
 def _fully_replicated_sharding(mesh):
-    return hax.partitioning.sharding_for_axis((), {}, mesh)
+    return sharding_for_axis((), {}, mesh)
 
 
 def _restore_ocdbt(

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -20,12 +20,12 @@ import jax.tree_util as jtu
 import numpy as np
 import tensorstore as ts
 from haliax.jax_utils import is_jax_array_like
-from haliax.partitioning import ResourceMapping
 from haliax.util import is_named_array
 from jax.sharding import Mesh, Sharding
 from jaxtyping import PyTree
 
 from levanter.utils import fsspec_utils, jax_utils
+from levanter.utils.types import ResourceMapping
 
 logger = logging.getLogger(__name__)
 

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -25,6 +25,7 @@ from jax.sharding import Mesh, Sharding
 from jaxtyping import PyTree
 
 from levanter.utils import fsspec_utils, jax_utils
+from levanter.utils.mesh import get_active_mesh
 from levanter.utils.partitioning import sharding_for_axis
 from levanter.utils.types import ResourceMapping
 
@@ -162,12 +163,10 @@ def _sharding_from_leaf(leaf, axis_mapping, mesh) -> Optional[jax.sharding.Shard
         # `eqx.filter_eval_shape` can produce `NamedSharding(mesh=AbstractMesh(...))`, but JAX array
         # deserialization requires a concrete device assignment (i.e., a concrete Mesh).
         if isinstance(sharding, jax.sharding.NamedSharding) and isinstance(sharding.mesh, jax.sharding.AbstractMesh):
-            from jax._src.mesh import get_concrete_mesh
-
-            concrete_mesh = mesh or get_concrete_mesh()
+            concrete_mesh = mesh or get_active_mesh()
             if isinstance(concrete_mesh, jax.sharding.AbstractMesh) or concrete_mesh is None or concrete_mesh.empty:
                 # Fall back to JAX's concrete mesh getter when available.
-                concrete_mesh = get_concrete_mesh()
+                concrete_mesh = get_active_mesh()
 
             if concrete_mesh is not None and not concrete_mesh.empty:
                 return jax.sharding.NamedSharding(concrete_mesh, sharding.spec)

--- a/lib/levanter/src/levanter/tracker/histogram.py
+++ b/lib/levanter/src/levanter/tracker/histogram.py
@@ -12,7 +12,7 @@ from jaxtyping import ArrayLike, Scalar
 import haliax as hax
 from haliax import NamedArray
 from levanter.kernels.pallas.cost_estimate_utils import with_io_bytes_accessed
-from levanter.utils.partitioning import shard_map
+from levanter.utils.partitioning import pspec_for_axis, shard_map
 
 
 class Histogram(equinox.Module):
@@ -119,7 +119,7 @@ def _single_shard_histogram(a: NamedArray, bin_edges, reduce_mesh):
 
 
 def _shardmap_histogram(a: NamedArray, bins):
-    spec = hax.partitioning.pspec_for_axis(a.axes)
+    spec = pspec_for_axis(a.axes)
     flattened_spec = _flattened_spec(spec)
 
     def _wrapped_hist(arr):

--- a/lib/levanter/src/levanter/tracker/histogram.py
+++ b/lib/levanter/src/levanter/tracker/histogram.py
@@ -11,8 +11,8 @@ from jaxtyping import ArrayLike, Scalar
 
 import haliax as hax
 from haliax import NamedArray
-from haliax.partitioning import shard_map
 from levanter.kernels.pallas.cost_estimate_utils import with_io_bytes_accessed
+from levanter.utils.partitioning import shard_map
 
 
 class Histogram(equinox.Module):

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -38,7 +38,6 @@ import jmp
 import numpy as np
 from draccus import field
 from haliax import Axis
-from haliax.partitioning import named_jit
 from haliax.quantization import QuantizationConfig
 from haliax.types import Scalar
 from jax.experimental import multihost_utils
@@ -70,6 +69,7 @@ from levanter.trainer_state import InsideJitInfo, TrainerState, saveable_trainin
 from levanter.utils import cloud_utils, fsspec_utils
 from levanter.utils.jax_utils import zeros_like_tree
 from levanter.utils.mesh import MeshConfig, activate_mesh, create_mesh_from_axis_specs
+from levanter.utils.partitioning import named_jit
 from levanter.utils.tree_utils import inference_mode
 from levanter.utils.types import ComputeLossFunction, FilterSpec, ResourceMapping
 

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -69,7 +69,7 @@ from levanter.tracker.wandb import WandbConfig
 from levanter.trainer_state import InsideJitInfo, TrainerState, saveable_training_mask
 from levanter.utils import cloud_utils, fsspec_utils
 from levanter.utils.jax_utils import zeros_like_tree
-from levanter.utils.mesh import MeshConfig, create_mesh_from_axis_specs
+from levanter.utils.mesh import MeshConfig, activate_mesh, create_mesh_from_axis_specs
 from levanter.utils.tree_utils import inference_mode
 from levanter.utils.types import ComputeLossFunction, FilterSpec, ResourceMapping
 
@@ -368,7 +368,7 @@ class Trainer:
 
         self._cmanagers = [
             levanter.current_tracker(self.tracker),
-            haliax.partitioning.set_mesh(self.device_mesh),
+            activate_mesh(self.device_mesh),
             hax.axis_mapping(self.parameter_axis_mapping),
         ]
 
@@ -948,7 +948,7 @@ class TrainerConfig:
         In recent jax, this is the same as `jax.set_mesh(self.device_mesh)`, but we use Haliax's wrapper for
         compatibility with older jax versions.
         """
-        return haliax.partitioning.set_mesh(self.device_mesh)
+        return activate_mesh(self.device_mesh)
 
     @property
     def eval_batch_size(self):

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -602,10 +602,9 @@ class Trainer:
 
         if eval_loader and (self.config.max_eval_batches is None or self.config.max_eval_batches > 0):
 
-            @eqx.filter_jit
+            @named_jit(axis_resources=self.compute_axis_mapping)
             def eval_loss(model, *batch, **batch_kwargs):
-                with hax.axis_mapping(self.compute_axis_mapping):
-                    return self.loss_fn(model, *batch, **batch_kwargs, key=None)
+                return self.loss_fn(model, *batch, **batch_kwargs, key=None)
 
             self.add_hook(
                 callbacks.compute_validation_loss(

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -675,14 +675,15 @@ class Trainer:
         )
 
         # Some optimizers need to be able to access the loss function
+        jitted_raw_loss = named_jit(self._raw_loss_function, axis_resources=self.compute_axis_mapping)
+
         def obj_fun(trainable_model):
             model = eqx.combine(trainable_model, state.model)
-            with hax.axis_mapping(self.compute_axis_mapping):
-                model = self.mp.cast_to_compute(model)
-                result = self._raw_loss_function(model, *batch, **batch_kwargs, key=key)
-                # result is (loss, metrics) tuple
-                loss_for_opt, _metrics = result
-                return loss_for_opt.scalar()
+            model = self.mp.cast_to_compute(model)
+            result = jitted_raw_loss(model, *batch, **batch_kwargs, key=key)
+            # result is (loss, metrics) tuple
+            loss_for_opt, _metrics = result
+            return loss_for_opt.scalar()
 
         new_state, updates = state.take_step(grads, obj_fun=obj_fun, loss=loss, key=new_key)
         new_state = hax.shard(new_state, self.parameter_axis_mapping)

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -189,7 +189,7 @@ class WrappedLossFunction:
     """
     Wrapper around a loss function that provides a uniform interface.
 
-    Handles casting & executing in the proper axis mapping.
+    Handles model casting and metric normalization.
 
     Always returns (loss, wrapped_metrics_dict). The user loss function
     may return `Metric` objects or floats. Floats are automatically coerced to Metrics
@@ -198,32 +198,27 @@ class WrappedLossFunction:
 
     _raw_fn: ComputeLossFunction
     _mp: jmp.Policy
-    _compute_axis_mapping: ResourceMapping
 
     def __init__(
         self,
         raw_fn: ComputeLossFunction,
         mp: jmp.Policy,
-        compute_axis_mapping: ResourceMapping,
     ):
         """
         Args:
             raw_fn: The underlying loss function
             mp: Mixed precision policy for casting
-            compute_axis_mapping: Axis mapping for compute
         """
         self._raw_fn = raw_fn
         self._mp = mp
-        self._compute_axis_mapping = compute_axis_mapping
 
     def __call__(self, model, *batch, **batch_kwargs) -> Tuple[Scalar, Dict[str, Metric]]:
         """
-        Call the loss function with model casting and axis mapping.
+        Call the loss function with model casting.
         Always returns (loss, wrapped_metrics) where metrics are Metric objects.
         """
-        with hax.axis_mapping(self._compute_axis_mapping):
-            model = self._mp.cast_to_compute(model)
-            result = self._raw_fn(model, *batch, **batch_kwargs)
+        model = self._mp.cast_to_compute(model)
+        result = self._raw_fn(model, *batch, **batch_kwargs)
 
         if isinstance(result, tuple) and len(result) == 2:
             loss, metrics = result
@@ -301,12 +296,11 @@ class Trainer:
     def loss_fn(self) -> WrappedLossFunction:
         """
         Wrapped loss function that always returns (loss, metrics_dict).
-        Casts the model to compute precision and sets the context axis mapping to compute.
+        Casts the model to compute precision and normalizes metric values.
         """
         return WrappedLossFunction(
             self._raw_loss_function,
             self.mp,
-            self.compute_axis_mapping,
         )
 
     @property
@@ -610,8 +604,8 @@ class Trainer:
 
             @eqx.filter_jit
             def eval_loss(model, *batch, **batch_kwargs):
-                model = self.mp.cast_to_compute(model)
-                return self.loss_fn(model, *batch, **batch_kwargs, key=None)
+                with hax.axis_mapping(self.compute_axis_mapping):
+                    return self.loss_fn(model, *batch, **batch_kwargs, key=None)
 
             self.add_hook(
                 callbacks.compute_validation_loss(

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -189,7 +189,7 @@ class WrappedLossFunction:
     """
     Wrapper around a loss function that provides a uniform interface.
 
-    Handles model casting and metric normalization.
+    Handles model casting, axis-mapping context, and metric normalization.
 
     Always returns (loss, wrapped_metrics_dict). The user loss function
     may return `Metric` objects or floats. Floats are automatically coerced to Metrics
@@ -198,27 +198,32 @@ class WrappedLossFunction:
 
     _raw_fn: ComputeLossFunction
     _mp: jmp.Policy
+    _compute_axis_mapping: ResourceMapping
 
     def __init__(
         self,
         raw_fn: ComputeLossFunction,
         mp: jmp.Policy,
+        compute_axis_mapping: ResourceMapping,
     ):
         """
         Args:
             raw_fn: The underlying loss function
             mp: Mixed precision policy for casting
+            compute_axis_mapping: Axis mapping for compute
         """
         self._raw_fn = raw_fn
         self._mp = mp
+        self._compute_axis_mapping = compute_axis_mapping
 
     def __call__(self, model, *batch, **batch_kwargs) -> Tuple[Scalar, Dict[str, Metric]]:
         """
-        Call the loss function with model casting.
+        Call the loss function with model casting and axis mapping.
         Always returns (loss, wrapped_metrics) where metrics are Metric objects.
         """
-        model = self._mp.cast_to_compute(model)
-        result = self._raw_fn(model, *batch, **batch_kwargs)
+        with hax.axis_mapping(self._compute_axis_mapping):
+            model = self._mp.cast_to_compute(model)
+            result = self._raw_fn(model, *batch, **batch_kwargs)
 
         if isinstance(result, tuple) and len(result) == 2:
             loss, metrics = result
@@ -301,6 +306,7 @@ class Trainer:
         return WrappedLossFunction(
             self._raw_loss_function,
             self.mp,
+            self.compute_axis_mapping,
         )
 
     @property
@@ -808,7 +814,7 @@ class TrainerConfig:
 
     # config related to partitioning
     mesh: MeshConfig = MeshConfig()
-    use_explicit_mesh_axes: bool = True
+    use_explicit_mesh_axes: bool = False
     """If True, build the device mesh with `AxisType.Explicit` axes.
 
     This is required for code paths that call `jax.sharding.reshard(..., PartitionSpec(...))`,
@@ -1110,5 +1116,32 @@ def _resolve_axis_in_tree(tree, axis):
                 return leaf.resolve_axis(axis)
             except ValueError:
                 pass
+
+    # Fallback for array-native batch structures (for example GrugLmExample),
+    # which do not carry NamedArray axes but do preserve leading batch shape.
+    candidate_sizes: list[int] = []
+    for leaf in jax.tree_util.tree_leaves(tree):
+        shape = getattr(leaf, "shape", None)
+        if shape is None:
+            continue
+        if len(shape) >= 2:
+            candidate_sizes.append(int(shape[0]))
+
+    if not candidate_sizes:
+        for leaf in jax.tree_util.tree_leaves(tree):
+            shape = getattr(leaf, "shape", None)
+            if shape is None or len(shape) == 0:
+                continue
+            # Skip PRNG keys and similar scalar-control vectors.
+            if len(shape) == 1 and tuple(shape) == (2,):
+                continue
+            candidate_sizes.append(int(shape[0]))
+
+    if candidate_sizes:
+        batch_size = candidate_sizes[0]
+        for size in candidate_sizes[1:]:
+            if size != batch_size:
+                raise ValueError(f"Inconsistent inferred batch sizes {candidate_sizes} in tree {tree}")
+        return hax.Axis(axis, batch_size)
 
     raise ValueError(f"Could not find axis {axis} in tree {tree}")

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -816,7 +816,7 @@ class TrainerConfig:
 
     # config related to partitioning
     mesh: MeshConfig = MeshConfig()
-    use_explicit_mesh_axes: bool = False
+    use_explicit_mesh_axes: bool = True
     """If True, build the device mesh with `AxisType.Explicit` axes.
 
     This is required for code paths that call `jax.sharding.reshard(..., PartitionSpec(...))`,

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -726,8 +726,8 @@ class Trainer:
                 self.compute_axis_mapping,
             )
 
-        with hax.axis_mapping(self.compute_axis_mapping):
-            (loss, metrics), grads = grad_fn(model, *batch, **batch_kwargs)
+        grad_fn = named_jit(grad_fn, axis_resources=self.compute_axis_mapping)
+        (loss, metrics), grads = grad_fn(model, *batch, **batch_kwargs)
 
         return loss, grads, metrics
 

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -934,10 +934,7 @@ class TrainerConfig:
 
     def use_device_mesh(self) -> ContextManager[None]:
         """
-        Context manager that sets the device mesh for jax, using Haliax's wrapper.
-
-        In recent jax, this is the same as `jax.set_mesh(self.device_mesh)`, but we use Haliax's wrapper for
-        compatibility with older jax versions.
+        Context manager that sets the process-wide JAX mesh.
         """
         return activate_mesh(self.device_mesh)
 

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -38,7 +38,7 @@ import jmp
 import numpy as np
 from draccus import field
 from haliax import Axis
-from haliax.partitioning import ResourceMapping, named_jit
+from haliax.partitioning import named_jit
 from haliax.quantization import QuantizationConfig
 from haliax.types import Scalar
 from jax.experimental import multihost_utils
@@ -71,7 +71,7 @@ from levanter.utils import cloud_utils, fsspec_utils
 from levanter.utils.jax_utils import zeros_like_tree
 from levanter.utils.mesh import MeshConfig, create_mesh_from_axis_specs
 from levanter.utils.tree_utils import inference_mode
-from levanter.utils.types import ComputeLossFunction, FilterSpec
+from levanter.utils.types import ComputeLossFunction, FilterSpec, ResourceMapping
 
 logger = pylogging.getLogger(__name__)
 

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -689,9 +689,8 @@ class Trainer:
 
         hook_infos = None
         if not _no_hooks:
-            with hax.axis_mapping(self.parameter_axis_mapping):
-                jit_info: InsideJitInfo = InsideJitInfo(grads=grads, updates=updates)
-                hook_infos = self.hooks.run_jit_hooks(state, jit_info, force=False)
+            jit_info: InsideJitInfo = InsideJitInfo(grads=grads, updates=updates)
+            hook_infos = self.hooks.run_jit_hooks(state, jit_info, force=False)
 
         # extract plain metrics and prefix their keys
         plain_metrics = unwrap_metrics(wrapped_metrics)

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -363,7 +363,6 @@ class Trainer:
         self._cmanagers = [
             levanter.current_tracker(self.tracker),
             activate_mesh(self.device_mesh),
-            hax.axis_mapping(self.parameter_axis_mapping),
         ]
 
         for cmanager in self._cmanagers:

--- a/lib/levanter/src/levanter/utils/jax_utils.py
+++ b/lib/levanter/src/levanter/utils/jax_utils.py
@@ -11,7 +11,6 @@ from typing import Any, Callable, Optional, TypeVar
 
 import equinox as eqx
 import haliax as hax
-import haliax.partitioning
 import jax
 import numpy as np
 from haliax import is_named_array
@@ -30,6 +29,7 @@ from levanter.utils.mesh import (
     activate_mesh,
     create_mesh_from_axis_specs,
 )
+from levanter.utils.partitioning import current_thread_local_mapping, pspec_for
 from levanter.utils.py_utils import index_where
 from levanter.utils.tree_utils import key_path_to_str, tree_flatten_one_level_with_keys
 from levanter.utils.types import ResourceMapping
@@ -570,7 +570,7 @@ def sync_global_devices(name: str):
 
 
 def sharded_tree_size(
-    tree, mesh: Optional[haliax.partitioning.MeshLike] | None = None, mapping: ResourceMapping | None = None
+    tree, mesh: Optional[Mesh | jax.sharding.AbstractMesh] = None, mapping: ResourceMapping | None = None
 ) -> int:
     """
     Returns the size of a sharded tree, in bytes. If the tree is sharded, this returns the size of a per-device shard.
@@ -591,7 +591,7 @@ def sharded_tree_size(
         mesh = jax.sharding.get_abstract_mesh()
 
     if mapping is None:
-        mapping = haliax.partitioning.current_thread_local_mapping()
+        mapping = current_thread_local_mapping()
 
     def _mesh_axis_size(axis_name) -> int:
         if mesh is None:
@@ -615,7 +615,7 @@ def sharded_tree_size(
 
     def _size(x):
         if isinstance(x, hax.NamedArray):
-            pspec = haliax.partitioning.pspec_for(x, mapping)
+            pspec = pspec_for(x, mapping)
             num_shards = _shards_for_pspec(pspec)
             x_a = x.array
             if hasattr(x_a, "nbytes"):

--- a/lib/levanter/src/levanter/utils/jax_utils.py
+++ b/lib/levanter/src/levanter/utils/jax_utils.py
@@ -16,7 +16,6 @@ import numpy as np
 from haliax import is_named_array
 from haliax.jax_utils import is_jax_array_like
 from jax import numpy as jnp
-from jax._src.mesh import get_concrete_mesh
 from jax.experimental.multihost_utils import host_local_array_to_global_array
 from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec
 from jaxtyping import PRNGKeyArray, PyTree
@@ -28,6 +27,7 @@ from levanter.utils.mesh import (
     REPLICA_AXIS,
     activate_mesh,
     create_mesh_from_axis_specs,
+    get_active_mesh,
 )
 from levanter.utils.partitioning import current_thread_local_mapping, pspec_for
 from levanter.utils.py_utils import index_where
@@ -336,9 +336,7 @@ def best_effort_sharding(shape, *, devices=None, mesh=None):
 
     if mesh is None:
         # TODO: we shouldn't be getting a concrete mesh here. Need to fix/remove this whole function
-        mesh = get_concrete_mesh()
-        if mesh is not None and mesh.shape == ():
-            mesh = None
+        mesh = get_active_mesh()
 
     if mesh is None:
         device_shape = (len(devices),)
@@ -448,7 +446,7 @@ def broadcast_shard(x: T, out_axis_specs: Any, source: int = 0) -> T:
      2. Then, inside jit, we select the source'th element of the array, then reshard with the out_axis_specs
 
     """
-    current_mesh = get_concrete_mesh()
+    current_mesh = get_active_mesh()
     if current_mesh is None:
         raise ValueError("broadcast_shard requires an active concrete mesh")
 

--- a/lib/levanter/src/levanter/utils/jax_utils.py
+++ b/lib/levanter/src/levanter/utils/jax_utils.py
@@ -16,7 +16,6 @@ import jax
 import numpy as np
 from haliax import is_named_array
 from haliax.jax_utils import is_jax_array_like
-from haliax.partitioning import ResourceMapping
 from jax import numpy as jnp
 from jax._src.mesh import get_concrete_mesh
 from jax.experimental.multihost_utils import host_local_array_to_global_array
@@ -26,6 +25,7 @@ from jaxtyping import PRNGKeyArray, PyTree
 from levanter.utils.mesh import CONTEXT_AXIS, DATA_AXIS, MODEL_AXIS, REPLICA_AXIS, create_mesh_from_axis_specs
 from levanter.utils.py_utils import index_where
 from levanter.utils.tree_utils import key_path_to_str, tree_flatten_one_level_with_keys
+from levanter.utils.types import ResourceMapping
 
 X = TypeVar("X")
 T = TypeVar("T", bound=PyTree)

--- a/lib/levanter/src/levanter/utils/jax_utils.py
+++ b/lib/levanter/src/levanter/utils/jax_utils.py
@@ -22,7 +22,14 @@ from jax.experimental.multihost_utils import host_local_array_to_global_array
 from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec
 from jaxtyping import PRNGKeyArray, PyTree
 
-from levanter.utils.mesh import CONTEXT_AXIS, DATA_AXIS, MODEL_AXIS, REPLICA_AXIS, create_mesh_from_axis_specs
+from levanter.utils.mesh import (
+    CONTEXT_AXIS,
+    DATA_AXIS,
+    MODEL_AXIS,
+    REPLICA_AXIS,
+    activate_mesh,
+    create_mesh_from_axis_specs,
+)
 from levanter.utils.py_utils import index_where
 from levanter.utils.tree_utils import key_path_to_str, tree_flatten_one_level_with_keys
 from levanter.utils.types import ResourceMapping
@@ -63,7 +70,7 @@ def local_cpu_mesh():
         dcn_axes={},
         devices=[cpu],
     )
-    with use_cpu_device(), haliax.partitioning.set_mesh(mesh):
+    with use_cpu_device(), activate_mesh(mesh):
         yield mesh
 
 
@@ -543,7 +550,7 @@ def broadcast_one_to_all(in_tree: Any, is_source: bool | None = None) -> Any:
     def post_jit(x):
         return jax.device_get(x.addressable_data(0))
 
-    with haliax.partitioning.set_mesh(global_mesh):
+    with activate_mesh(global_mesh):
         in_tree = jax.tree.map(pre_jit, in_tree)
         out_tree = jax.jit(_psum, out_shardings=jax.sharding.NamedSharding(global_mesh, PartitionSpec()))(in_tree)
         return jax.tree.map(post_jit, out_tree)

--- a/lib/levanter/src/levanter/utils/jax_utils.py
+++ b/lib/levanter/src/levanter/utils/jax_utils.py
@@ -16,14 +16,14 @@ import jax
 import numpy as np
 from haliax import is_named_array
 from haliax.jax_utils import is_jax_array_like
-from haliax.partitioning import ResourceAxis, ResourceMapping
+from haliax.partitioning import ResourceMapping
 from jax import numpy as jnp
 from jax._src.mesh import get_concrete_mesh
 from jax.experimental.multihost_utils import host_local_array_to_global_array
 from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec
 from jaxtyping import PRNGKeyArray, PyTree
 
-from levanter.utils.mesh import create_mesh_from_axis_specs
+from levanter.utils.mesh import CONTEXT_AXIS, DATA_AXIS, MODEL_AXIS, REPLICA_AXIS, create_mesh_from_axis_specs
 from levanter.utils.py_utils import index_where
 from levanter.utils.tree_utils import key_path_to_str, tree_flatten_one_level_with_keys
 
@@ -55,10 +55,10 @@ def local_cpu_mesh():
     cpu = jax.local_devices(backend="cpu")[0]
     mesh = create_mesh_from_axis_specs(
         ici_axes={
-            ResourceAxis.REPLICA: 1,
-            ResourceAxis.DATA: 1,
-            ResourceAxis.MODEL: 1,
-            ResourceAxis.CONTEXT: 1,
+            REPLICA_AXIS: 1,
+            DATA_AXIS: 1,
+            MODEL_AXIS: 1,
+            CONTEXT_AXIS: 1,
         },
         dcn_axes={},
         devices=[cpu],
@@ -353,7 +353,7 @@ def best_effort_sharding(shape, *, devices=None, mesh=None):
         return sharding
     else:
         # get the existing mesh and find the FSDP axis
-        num_devices = mesh.shape[hax.partitioning.ResourceAxis.DATA]
+        num_devices = mesh.shape[DATA_AXIS]
 
         for i in range(len(shape) - 1, -1, -1):
             shape_i = shape[i]
@@ -364,7 +364,7 @@ def best_effort_sharding(shape, *, devices=None, mesh=None):
             return NamedSharding(mesh, PartitionSpec(None))
 
         axis_sharding: list[str | None] = [None] * len(shape)
-        axis_sharding[sharded_axis] = hax.partitioning.ResourceAxis.DATA
+        axis_sharding[sharded_axis] = DATA_AXIS
         sharding = NamedSharding(mesh, PartitionSpec(*axis_sharding))
 
         return sharding

--- a/lib/levanter/src/levanter/utils/mesh.py
+++ b/lib/levanter/src/levanter/utils/mesh.py
@@ -195,10 +195,8 @@ def create_mesh_from_axis_specs(
 
 
 def activate_mesh(mesh: Mesh):
-    """Activate the process-wide mesh context used by Haliax partitioning."""
-    import haliax.partitioning
-
-    return haliax.partitioning.set_mesh(mesh)
+    """Activate the process-wide mesh context."""
+    return jax.set_mesh(mesh)
 
 
 def get_active_mesh() -> Mesh | None:

--- a/lib/levanter/src/levanter/utils/mesh.py
+++ b/lib/levanter/src/levanter/utils/mesh.py
@@ -13,10 +13,16 @@ import jax
 from jax.experimental import mesh_utils
 from jax.sharding import AxisType, Mesh
 
-DEFAULT_DP_AXES = ("replica_dcn", "replica", "data")
-DEFAULT_ICI_AXIS_SPEC = {"data": -1, "replica": 1, "model": 1}
-DEFAULT_DCN_AXIS_SPEC = {"replica_dcn": -1}
-DEFAULT_SHARED_MAPPING: Dict[str, str | Tuple[str, ...]] = {"mlp": "model", "heads": "model"}
+REPLICA_DCN_AXIS = "replica_dcn"
+REPLICA_AXIS = "replica"
+DATA_AXIS = "data"
+MODEL_AXIS = "model"
+CONTEXT_AXIS = "context"
+
+DEFAULT_DP_AXES = (REPLICA_DCN_AXIS, REPLICA_AXIS, DATA_AXIS)
+DEFAULT_ICI_AXIS_SPEC = {DATA_AXIS: -1, REPLICA_AXIS: 1, MODEL_AXIS: 1}
+DEFAULT_DCN_AXIS_SPEC = {REPLICA_DCN_AXIS: -1}
+DEFAULT_SHARED_MAPPING: Dict[str, str | Tuple[str, ...]] = {"mlp": MODEL_AXIS, "heads": MODEL_AXIS}
 
 
 @dataclass(frozen=True)
@@ -37,7 +43,7 @@ class MeshConfig:
     batch_axis_name: str | None = "batch"
     shared_mapping: Mapping[str, list[str] | str] = field(default_factory=lambda: {})
     compute_mapping: Mapping[str, list[str] | str] = field(default_factory=lambda: {})
-    param_mapping: Mapping[str, list[str] | str] = field(default_factory=lambda: {"embed": "data"})
+    param_mapping: Mapping[str, list[str] | str] = field(default_factory=lambda: {"embed": DATA_AXIS})
 
     @cached_property
     def resolved_compute_mapping(self) -> ResourceMapping:
@@ -82,22 +88,22 @@ class MeshConfig:
 
         per_slice = num_devices // num_slices
 
-        default_axes = {"data": -1, "replica": 1, "model": 1}
-        default_dcn_axes = {"replica_dcn": -1}
+        default_axes = {DATA_AXIS: -1, REPLICA_AXIS: 1, MODEL_AXIS: 1}
+        default_dcn_axes = {REPLICA_DCN_AXIS: -1}
 
         axes = dict(default_axes)
         axes.update(self.axes)
 
         absorbers = [k for k, v in axes.items() if v == -1]
-        if len(absorbers) > 1 and "data" in axes and "data" not in self.axes:
-            axes["data"] = 1
+        if len(absorbers) > 1 and DATA_AXIS in axes and DATA_AXIS not in self.axes:
+            axes[DATA_AXIS] = 1
 
         dcn_axes = dict(default_dcn_axes)
         dcn_axes.update(self.dcn_axes)
 
         dcn_absorbers = [k for k, v in dcn_axes.items() if v == -1]
-        if len(dcn_absorbers) > 1 and "replica_dcn" in dcn_axes and "replica_dcn" not in self.dcn_axes:
-            dcn_axes["replica_dcn"] = 1
+        if len(dcn_absorbers) > 1 and REPLICA_DCN_AXIS in dcn_axes and REPLICA_DCN_AXIS not in self.dcn_axes:
+            dcn_axes[REPLICA_DCN_AXIS] = 1
 
         if set(axes.keys()) & set(dcn_axes.keys()):
             overlap = set(axes.keys()) & set(dcn_axes.keys())

--- a/lib/levanter/src/levanter/utils/mesh.py
+++ b/lib/levanter/src/levanter/utils/mesh.py
@@ -201,6 +201,21 @@ def activate_mesh(mesh: Mesh):
     return haliax.partitioning.set_mesh(mesh)
 
 
+def get_active_mesh() -> Mesh | None:
+    """Return the active concrete mesh, or None when no mesh is set."""
+    from jax._src.mesh import get_concrete_mesh
+
+    mesh = get_concrete_mesh()
+    if mesh is None or getattr(mesh, "empty", False):
+        return None
+
+    shape = getattr(mesh, "shape", None)
+    if shape == () or shape == {}:
+        return None
+
+    return mesh
+
+
 def _norm(v: Union[str, Sequence[str]]) -> Union[str, Tuple[str, ...]]:
     if isinstance(v, (list, tuple)):
         v = tuple(v)

--- a/lib/levanter/src/levanter/utils/mesh.py
+++ b/lib/levanter/src/levanter/utils/mesh.py
@@ -8,10 +8,11 @@ from typing import Union, Sequence, Tuple, Mapping, Dict
 
 from draccus import field
 
-from haliax.partitioning import ResourceMapping
 import jax
 from jax.experimental import mesh_utils
 from jax.sharding import AxisType, Mesh
+
+from levanter.utils.types import ResourceMapping
 
 REPLICA_DCN_AXIS = "replica_dcn"
 REPLICA_AXIS = "replica"

--- a/lib/levanter/src/levanter/utils/mesh.py
+++ b/lib/levanter/src/levanter/utils/mesh.py
@@ -194,6 +194,13 @@ def create_mesh_from_axis_specs(
     return Mesh(device_mesh, tuple(axis_names), axis_types=axis_types)
 
 
+def activate_mesh(mesh: Mesh):
+    """Activate the process-wide mesh context used by Haliax partitioning."""
+    import haliax.partitioning
+
+    return haliax.partitioning.set_mesh(mesh)
+
+
 def _norm(v: Union[str, Sequence[str]]) -> Union[str, Tuple[str, ...]]:
     if isinstance(v, (list, tuple)):
         v = tuple(v)

--- a/lib/levanter/src/levanter/utils/partitioning.py
+++ b/lib/levanter/src/levanter/utils/partitioning.py
@@ -1,6 +1,18 @@
 # Copyright 2025 The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from haliax.partitioning import named_jit, round_axis_for_partitioning
+from haliax.partitioning import (
+    current_thread_local_mapping,
+    named_jit,
+    pspec_for_axis,
+    round_axis_for_partitioning,
+    shard_map,
+)
 
-__all__ = ["named_jit", "round_axis_for_partitioning"]
+__all__ = [
+    "current_thread_local_mapping",
+    "named_jit",
+    "pspec_for_axis",
+    "round_axis_for_partitioning",
+    "shard_map",
+]

--- a/lib/levanter/src/levanter/utils/partitioning.py
+++ b/lib/levanter/src/levanter/utils/partitioning.py
@@ -3,16 +3,26 @@
 
 from haliax.partitioning import (
     current_thread_local_mapping,
+    infer_resource_partitions,
     named_jit,
+    physical_axis_name,
+    physical_axis_size,
+    pspec_for,
     pspec_for_axis,
     round_axis_for_partitioning,
+    sharding_for_axis,
     shard_map,
 )
 
 __all__ = [
     "current_thread_local_mapping",
+    "infer_resource_partitions",
     "named_jit",
+    "physical_axis_name",
+    "physical_axis_size",
+    "pspec_for",
     "pspec_for_axis",
     "round_axis_for_partitioning",
+    "sharding_for_axis",
     "shard_map",
 ]

--- a/lib/levanter/src/levanter/utils/partitioning.py
+++ b/lib/levanter/src/levanter/utils/partitioning.py
@@ -1,0 +1,6 @@
+# Copyright 2025 The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from haliax.partitioning import named_jit, round_axis_for_partitioning
+
+__all__ = ["named_jit", "round_axis_for_partitioning"]

--- a/lib/levanter/src/levanter/utils/partitioning.py
+++ b/lib/levanter/src/levanter/utils/partitioning.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright 2025 The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 

--- a/lib/levanter/src/levanter/utils/token_init.py
+++ b/lib/levanter/src/levanter/utils/token_init.py
@@ -14,6 +14,7 @@ from lenses import lens
 import haliax as hax
 
 from levanter.utils.hf_utils import HfTokenizer
+from levanter.utils.partitioning import named_jit
 
 
 def reinitialize_some_tokens(
@@ -50,7 +51,7 @@ def reinitialize_some_tokens(
     ):
         raise ValueError("One or more tokens are not in the tokenizer vocabulary")
 
-    @hax.named_jit(donate_args=(donate,))
+    @named_jit(donate_args=(donate,))
     def _reinit_tokens(model):
         Embed = model.embeddings.Embed
         new_vocab = model.Vocab.resize(len(ids_to_reinit))

--- a/lib/levanter/src/levanter/utils/types.py
+++ b/lib/levanter/src/levanter/utils/types.py
@@ -1,7 +1,7 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Callable, Optional, Protocol, Tuple, TypeVar, Union, cast
+from typing import Any, Callable, Mapping, Optional, Protocol, Sequence, Tuple, TypeAlias, TypeVar, Union, cast
 
 from jaxtyping import PyTree
 
@@ -26,10 +26,8 @@ except ImportError:
         pass
 
 
-try:
-    from haliax.partitioning import ResourceMapping
-except ImportError:
-    ResourceMapping = dict[str, Any]  # type: ignore[assignment]
+PhysicalAxisSpec: TypeAlias = str | Sequence[str]
+ResourceMapping: TypeAlias = Mapping[str, PhysicalAxisSpec]
 
 
 class ValAndGradFn(Protocol[M, X]):

--- a/lib/levanter/src/levanter/utils/types.py
+++ b/lib/levanter/src/levanter/utils/types.py
@@ -14,13 +14,16 @@ M_con = TypeVar("M_con", contravariant=True)  # Model
 X = TypeVar("X", contravariant=True)  # Input
 
 try:
-    from haliax.nn.scan import BlockFoldable
+    from haliax.nn.scan import BlockFoldable, ScanCheckpointPolicy
 except ImportError:
 
     class BlockFoldable(Protocol[M]):  # type: ignore
         def fold(self, *args, **kwargs): ...
 
         def scan(self, *args, **kwargs): ...
+
+    class ScanCheckpointPolicy(Protocol):  # type: ignore
+        pass
 
 
 class ValAndGradFn(Protocol[M, X]):

--- a/lib/levanter/src/levanter/utils/types.py
+++ b/lib/levanter/src/levanter/utils/types.py
@@ -26,6 +26,12 @@ except ImportError:
         pass
 
 
+try:
+    from haliax.partitioning import ResourceMapping
+except ImportError:
+    ResourceMapping = dict[str, Any]  # type: ignore[assignment]
+
+
 class ValAndGradFn(Protocol[M, X]):
     def __call__(self, model: M, *inputs: X, **input_kwargs) -> Tuple[Scalar, M]: ...
 

--- a/lib/levanter/tests/test_optimizer_linear_like.py
+++ b/lib/levanter/tests/test_optimizer_linear_like.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Levanter Authors
+# Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
 import equinox as eqx

--- a/tests/test_grug_base_template.py
+++ b/tests/test_grug_base_template.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Marin Authors
+# Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
 import json


### PR DESCRIPTION
## Summary
- makes trainer runtime default to explicit mesh axes and removes ambient parameter-axis mapping dependence
- binds optimizer objective, gradient, eval-hook, inference, and export paths to explicit axis resources
- keeps mesh activation and runtime sharding decisions explicit at call boundaries

This is part of gruggification.
