### PR TITLE
main: default train/eval/lora/viz to array-first Grug datasets

### DIFF
--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -231,7 +231,7 @@ def initial_state(
         step=jnp.array(0, dtype=jnp.int32),
         params=params,
         opt_state=optimizer.init(params),
-        ema_params=params if ema_beta is not None else None,
+        ema_params=jax.tree_util.tree_map(lambda x: jnp.array(x, copy=True), params) if ema_beta is not None else None,
     )
 
 

--- a/experiments/grug/modular_opt/train.py
+++ b/experiments/grug/modular_opt/train.py
@@ -240,7 +240,7 @@ def initial_state(
         step=jnp.array(0, dtype=jnp.int32),
         params=params,
         opt_state=optimizer.init(params),
-        ema_params=params if ema_beta is not None else None,
+        ema_params=jax.tree_util.tree_map(lambda x: jnp.array(x, copy=True), params) if ema_beta is not None else None,
     )
 
 

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -248,7 +248,7 @@ def initial_state(
         step=jnp.array(0, dtype=jnp.int32),
         params=params,
         opt_state=optimizer.init(params),
-        ema_params=params if ema_beta is not None else None,
+        ema_params=jax.tree_util.tree_map(lambda x: jnp.array(x, copy=True), params) if ema_beta is not None else None,
     )
 
 

--- a/lib/iris/scripts/generate_protos.py
+++ b/lib/iris/scripts/generate_protos.py
@@ -10,8 +10,8 @@ import sys
 from pathlib import Path
 
 
-def fix_imports(file_path: Path) -> None:
-    """Fix imports in generated Python files for local package layout."""
+def fix_generated_python(file_path: Path) -> None:
+    """Fix generated Python files for local package layout and pinned dependencies."""
     content = file_path.read_text()
 
     # Pattern 1: import <name>_pb2 as <name>__pb2 (used in _pb2.py files)
@@ -30,10 +30,22 @@ def fix_imports(file_path: Path) -> None:
         "from connectrpc.compression import Compression",
         "from connectrpc._compression import Compression",
     )
+    new_content = new_content.replace(
+        "from connectrpc._compression import Compression\n",
+        "",
+    )
+    new_content = new_content.replace(
+        ", compressions: Iterable[Compression] | None = None",
+        "",
+    )
+    new_content = new_content.replace(
+        ",\n            compressions=compressions",
+        "",
+    )
 
     if new_content != content:
         file_path.write_text(new_content)
-        print(f"✓ Fixed imports in {file_path.name}")
+        print(f"✓ Fixed generated Python in {file_path.name}")
     else:
         print(f"✓ No changes needed in {file_path.name}")
 
@@ -66,11 +78,11 @@ def main():
     # Fix imports in all generated Python files (both _pb2.py and _connect.py)
     print("\nFixing imports in generated files...")
     for pb2_file in rpc_dir.glob("*_pb2.py"):
-        fix_imports(pb2_file)
+        fix_generated_python(pb2_file)
     for connect_file in rpc_dir.glob("*_connect.py"):
-        fix_imports(connect_file)
+        fix_generated_python(connect_file)
     for pyi_file in rpc_dir.glob("*_pb2.pyi"):
-        fix_imports(pyi_file)
+        fix_generated_python(pyi_file)
 
     print("\n✓ Generation complete!")
 

--- a/lib/iris/scripts/generate_protos.py
+++ b/lib/iris/scripts/generate_protos.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 
 def fix_imports(file_path: Path) -> None:
-    """Fix imports in generated Python files to use relative imports."""
+    """Fix imports in generated Python files for local package layout."""
     content = file_path.read_text()
 
     # Pattern 1: import <name>_pb2 as <name>__pb2 (used in _pb2.py files)
@@ -26,6 +26,10 @@ def fix_imports(file_path: Path) -> None:
 
     new_content = re.sub(pattern1, replacement1, content, flags=re.MULTILINE)
     new_content = re.sub(pattern2, replacement2, new_content, flags=re.MULTILINE)
+    new_content = new_content.replace(
+        "from connectrpc.compression import Compression",
+        "from connectrpc._compression import Compression",
+    )
 
     if new_content != content:
         file_path.write_text(new_content)

--- a/lib/levanter/src/levanter/analysis/visualization.py
+++ b/lib/levanter/src/levanter/analysis/visualization.py
@@ -15,7 +15,6 @@ from jax.experimental import multihost_utils
 
 from levanter.callbacks import StepInfo
 from levanter.data import DataLoader
-from levanter.data.text.examples import GrugLmExample
 from levanter.utils.hf_utils import HfTokenizer
 
 
@@ -114,7 +113,7 @@ def compute_and_visualize_log_probs(path: str, model, tokenizer, log_prob_fn, te
         if len(targets) * b_logprobs.shape[0] >= max_docs:
             break
     log_probs = _concatenate(log_probs)
-    targets = _concatenate([_tokens_from_batch(t) for t in targets])
+    targets = _concatenate([t.tokens for t in targets])
     if argmaxes:
         argmaxes_array = _concatenate(argmaxes)
     else:
@@ -293,7 +292,7 @@ def compute_and_diff_log_probs(path: str, model, comparison_model, tokenizer, lo
     log_probs_a = np.array(log_probs_a[:max_docs])
     log_probs_b = np.array(log_probs_b[:max_docs])
 
-    targets = _concatenate([_tokens_from_batch(t) for t in targets])
+    targets = _concatenate([t.tokens for t in targets])
     tokens = [_decode_tokens_pretty(tokenizer, t) for t in targets]
     visualize_log_prob_diff(tokens, log_probs_a, log_probs_b, path)
 
@@ -312,10 +311,6 @@ def _decode_tokens_pretty(tok, ids):
         return [str(t) for t in tok.convert_ids_to_tokens(ids)]
     else:
         return [str(t) for t in tok.decode(ids)]
-
-
-def _tokens_from_batch(batch: GrugLmExample) -> jax.Array:
-    return batch.tokens
 
 
 def cb_compute_and_visualize_log_probs(

--- a/lib/levanter/src/levanter/analysis/visualization.py
+++ b/lib/levanter/src/levanter/analysis/visualization.py
@@ -15,6 +15,8 @@ from jax.experimental import multihost_utils
 
 from levanter.callbacks import StepInfo
 from levanter.data import DataLoader
+from levanter.data.text.examples import GrugLmExample
+from levanter.models.lm_model import LmExample
 from levanter.utils.hf_utils import HfTokenizer
 
 
@@ -113,7 +115,7 @@ def compute_and_visualize_log_probs(path: str, model, tokenizer, log_prob_fn, te
         if len(targets) * b_logprobs.shape[0] >= max_docs:
             break
     log_probs = _concatenate(log_probs)
-    targets = _concatenate([t.tokens.array for t in targets])
+    targets = _concatenate([_tokens_from_batch(t) for t in targets])
     if argmaxes:
         argmaxes_array = _concatenate(argmaxes)
     else:
@@ -292,7 +294,7 @@ def compute_and_diff_log_probs(path: str, model, comparison_model, tokenizer, lo
     log_probs_a = np.array(log_probs_a[:max_docs])
     log_probs_b = np.array(log_probs_b[:max_docs])
 
-    targets = _concatenate([t.tokens.array for t in targets])
+    targets = _concatenate([_tokens_from_batch(t) for t in targets])
     tokens = [_decode_tokens_pretty(tokenizer, t) for t in targets]
     visualize_log_prob_diff(tokens, log_probs_a, log_probs_b, path)
 
@@ -311,6 +313,12 @@ def _decode_tokens_pretty(tok, ids):
         return [str(t) for t in tok.convert_ids_to_tokens(ids)]
     else:
         return [str(t) for t in tok.decode(ids)]
+
+
+def _tokens_from_batch(batch: LmExample | GrugLmExample) -> jax.Array:
+    if isinstance(batch, LmExample):
+        return batch.tokens.array
+    return batch.tokens
 
 
 def cb_compute_and_visualize_log_probs(

--- a/lib/levanter/src/levanter/analysis/visualization.py
+++ b/lib/levanter/src/levanter/analysis/visualization.py
@@ -16,7 +16,6 @@ from jax.experimental import multihost_utils
 from levanter.callbacks import StepInfo
 from levanter.data import DataLoader
 from levanter.data.text.examples import GrugLmExample
-from levanter.models.lm_model import LmExample
 from levanter.utils.hf_utils import HfTokenizer
 
 
@@ -315,9 +314,7 @@ def _decode_tokens_pretty(tok, ids):
         return [str(t) for t in tok.decode(ids)]
 
 
-def _tokens_from_batch(batch: LmExample | GrugLmExample) -> jax.Array:
-    if isinstance(batch, LmExample):
-        return batch.tokens.array
+def _tokens_from_batch(batch: GrugLmExample) -> jax.Array:
     return batch.tokens
 
 

--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -695,20 +695,30 @@ class LmDataConfig:
         *,
         key: PRNGKeyArray,
     ) -> AsyncDataset[LmExample]:
+        grug_dataset = self.train_grug_set(seq_len=Pos.size, batch_schedule=batch_schedule, key=key)
+        return NamedLmDataset(grug_dataset, Pos)
+
+    def train_grug_set(
+        self,
+        *,
+        seq_len: int,
+        batch_schedule: BatchSchedule,
+        key: PRNGKeyArray,
+    ) -> AsyncDataset[GrugLmExample]:
+        """Build the mixed training dataset in array-first `GrugLmExample` format."""
         mix_key, shuffle_key = jax.random.split(key)
         weights = self.train_weights
         if isinstance(weights, list):
             weights = rescale_mixture_schedule_for_batch_schedule(weights, batch_schedule)
         initial_batch_size = batch_schedule.batch_size_at_step(0)
-        datasets = self.train_sets(Pos, key=shuffle_key, initial_batch_size=initial_batch_size)
-        mixture = MixtureDataset(
+        datasets = self.train_grug_sets(seq_len=seq_len, key=shuffle_key, initial_batch_size=initial_batch_size)
+        return MixtureDataset(
             datasets=datasets,
             weights=weights,
             stop_strategy=self.stop_strategy,
             key=mix_key,
             block_size=self.mixture_block_size,
         )
-        return NamedLmDataset(mixture, Pos)
 
     def train_sets(
         self,

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -27,7 +27,7 @@ import levanter.tracker
 from levanter.callbacks import StepInfo
 from levanter.data import AsyncDataset, DataLoader
 from levanter.data.text.examples import GrugLmExample
-from levanter.models.lm_model import LmExample, LmHeadModel
+from levanter.models.lm_model import LmHeadModel
 from levanter.utils.hf_utils import HfTokenizer, byte_length_of_token
 from levanter.utils.jax_utils import axis_resource_is_explicit
 from levanter.utils.logging import LoadingTimeTrackerIterator
@@ -41,7 +41,6 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 M = TypeVar("M")
 Ex = TypeVar("Ex")
-LmEvalExample = LmExample | GrugLmExample
 LossFnOutput = tuple[jax.Array, jax.Array, jax.Array]
 TagArray = Int[Array, "tag"]
 BatchedTagArray = Int[Array, "... tag"]
@@ -164,7 +163,7 @@ def _join_prefix(prefix: str, tag: str) -> str:
 
 def _default_lm_eval_loss_fn(
     model: LmHeadModel,
-    batch: LmEvalExample,
+    batch: GrugLmExample,
     *,
     EvalBatch: hax.Axis,
     mp: jmp.Policy | None,
@@ -190,18 +189,14 @@ def _default_lm_eval_loss_fn(
             reduction_axis=(),
         )
 
-    if isinstance(batch, LmExample):
-        per_pos_weight = batch.loss_weight.array
-        per_pos_token_id = jnp.roll(batch.tokens.array, -1, axis=-1)
-    else:
-        per_pos_weight = batch.loss_weight
-        per_pos_token_id = jnp.roll(batch.tokens, -1, axis=-1)
+    per_pos_weight = batch.loss_weight
+    per_pos_token_id = jnp.roll(batch.tokens, -1, axis=-1)
     return per_pos_loss, per_pos_weight, per_pos_token_id
 
 
 def cb_tagged_lm_evaluate(
     EvalBatch: hax.Axis,
-    tagged_eval_sets: Sequence[tuple[AsyncDataset[LmEvalExample], Sequence[str]]],
+    tagged_eval_sets: Sequence[tuple[AsyncDataset[GrugLmExample], Sequence[str]]],
     tokenizer: Optional[HfTokenizer] = None,
     device_mesh: Optional[Mesh] = None,
     axis_mapping: ResourceMapping | None = None,
@@ -211,7 +206,7 @@ def cb_tagged_lm_evaluate(
     prefix: str = "eval",
     mp: jmp.Policy = None,
     checkpoint_path: Optional[str] = None,
-    loss_fn: Callable[[LmHeadModel, LmEvalExample], LossFnOutput] | None = None,
+    loss_fn: Callable[[LmHeadModel, GrugLmExample], LossFnOutput] | None = None,
 ) -> Callable[[StepInfo], None]:
     """
     Evaluates multiple tagged datasets using a given evaluation function.
@@ -241,7 +236,7 @@ def cb_tagged_lm_evaluate(
 
     if loss_fn is None:
 
-        def loss_fn(model: LmHeadModel, batch: LmEvalExample) -> LossFnOutput:
+        def loss_fn(model: LmHeadModel, batch: GrugLmExample) -> LossFnOutput:
             return _default_lm_eval_loss_fn(
                 model,
                 batch,

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -117,7 +117,12 @@ def main(config: EvalLmConfig):
         def compute_logits(model: LmHeadModel, example: GrugLmExample):
             model = mp.cast_to_compute(model)
             with hax.axis_mapping(compute_axis_mapping):
-                logits_array = model.logits_from_token_ids_array(example.tokens, batch_axis=Batch, key=None)
+                logits_array = model.logits_from_token_ids_array(
+                    example.tokens,
+                    attn_mask=example.attn_mask,
+                    batch_axis=Batch,
+                    key=None,
+                )
                 if logits_array.ndim == 2:
                     return hax.named(logits_array, (Pos.resize(logits_array.shape[0]), model.Vocab))
                 if logits_array.ndim == 3:

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -113,6 +113,7 @@ def main(config: EvalLmConfig):
             max_examples_per_dataset=max_examples,
         )
 
+        @named_jit(axis_resources=compute_axis_mapping)
         def compute_logits(model: LmHeadModel, example: GrugLmExample):
             model = mp.cast_to_compute(model)
             with hax.axis_mapping(compute_axis_mapping):

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -56,7 +56,8 @@ def main(config: EvalLmConfig):
     tokenizer = config.data.the_tokenizer
 
     Batch = config.trainer.EvalBatch
-    Pos = config.model.max_Pos.resize(config.max_eval_length)
+    eval_length = min(config.max_eval_length, config.model.max_seq_len)
+    Pos = config.model.max_Pos.resize(eval_length)
 
     if config.eval_on_train:
         datasets_dict = config.data.train_grug_sets(seq_len=Pos.size, key=jax.random.PRNGKey(0))

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -20,6 +20,7 @@ from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, RepoRef
 from levanter.data import DataLoader
 from levanter.data.text import LmDataConfig
+from levanter.data.text.examples import GrugLmExample
 from levanter.eval import LossFnOutput, TaggedEvaluator, eval_model
 from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
@@ -29,6 +30,9 @@ from levanter.utils.tree_utils import inference_mode
 
 
 logger = logging.getLogger(__name__)
+
+
+LmEvalExample = LmExample | GrugLmExample
 
 
 @dataclass
@@ -56,11 +60,11 @@ def main(config: EvalLmConfig):
     Pos = config.model.max_Pos.resize(config.max_eval_length)
 
     if config.eval_on_train:
-        datasets_dict = config.data.train_sets(Pos, key=jax.random.PRNGKey(0))
+        datasets_dict = config.data.train_grug_sets(seq_len=Pos.size, key=jax.random.PRNGKey(0))
         # need tagged eval sets for the evaluator
         datasets = [(ds, [name]) for name, ds in datasets_dict.items()]
     else:
-        datasets = config.data.tagged_eval_sets(Pos)
+        datasets = config.data.tagged_eval_grug_sets(seq_len=Pos.size)
 
     if not datasets:
         raise ValueError("no dataset found!")
@@ -89,7 +93,7 @@ def main(config: EvalLmConfig):
 
         mp: jmp.Policy = config.trainer.mp
 
-        def eval_loss_fn(model: LmHeadModel, batch: LmExample) -> LossFnOutput:
+        def eval_loss_fn(model: LmHeadModel, batch: LmEvalExample) -> LossFnOutput:
             model = inference_mode(model, True)
             model = mp.cast_to_compute(model)
             with hax.axis_mapping(compute_axis_mapping):
@@ -99,8 +103,13 @@ def main(config: EvalLmConfig):
                     reduction=None,
                     reduction_axis=(),
                 )
-            per_pos_weight = batch.loss_weight.array
-            per_pos_token_id = jnp.roll(batch.tokens.array, -1, axis=-1)
+
+            if isinstance(batch, LmExample):
+                per_pos_weight = batch.loss_weight.array
+                per_pos_token_id = jnp.roll(batch.tokens.array, -1, axis=-1)
+            else:
+                per_pos_weight = batch.loss_weight
+                per_pos_token_id = jnp.roll(batch.tokens, -1, axis=-1)
             return per_pos_loss, per_pos_weight, per_pos_token_id
 
         evaluator = TaggedEvaluator(

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -10,10 +10,8 @@ import jax
 import jax.numpy as jnp
 import jmp
 
-import haliax
 import haliax as hax
 from haliax import Axis
-from haliax.partitioning import round_axis_for_partitioning
 
 import levanter
 from levanter.checkpoint import load_checkpoint
@@ -26,6 +24,7 @@ from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
+from levanter.utils.partitioning import named_jit, round_axis_for_partitioning
 from levanter.utils.tree_utils import inference_mode
 
 
@@ -121,19 +120,28 @@ def main(config: EvalLmConfig):
             max_examples_per_dataset=max_examples,
         )
 
-        @hax.named_jit(axis_resources=compute_axis_mapping)
+        @named_jit(axis_resources=compute_axis_mapping)
         def compute_loss(model: LmHeadModel, example: LmExample):
             model = inference_mode(model, True)
             model = mp.cast_to_compute(model)
             return model.compute_next_token_loss(example, key=None)
 
-        @hax.named_jit(axis_resources=compute_axis_mapping)
-        def compute_logits(model: LmHeadModel, example: LmExample):
+        def compute_logits(model: LmHeadModel, example: LmEvalExample):
             model = mp.cast_to_compute(model)
-            activations = model.activations(example.tokens, key=None, attn_mask=example.attn_mask)
-            head = model.get_lm_head()
-            logits = hax.dot(activations, head, axis=model.Embed)
-            return logits
+            with hax.axis_mapping(compute_axis_mapping):
+                if isinstance(example, LmExample):
+                    activations = model.activations(example.tokens, key=None, attn_mask=example.attn_mask)
+                    head = model.get_lm_head()
+                    return hax.dot(activations, head, axis=model.Embed)
+
+                logits_array = model.logits_from_token_ids_array(example.tokens, batch_axis=Batch, key=None)
+                if logits_array.ndim == 2:
+                    return hax.named(logits_array, (Pos.resize(logits_array.shape[0]), model.Vocab))
+                if logits_array.ndim == 3:
+                    batch_axis = Axis(Batch.name, logits_array.shape[0])
+                    pos_axis = Pos.resize(logits_array.shape[1])
+                    return hax.named(logits_array, (batch_axis, pos_axis, model.Vocab))
+                raise ValueError(f"Unexpected logits rank for analysis callbacks: {logits_array.ndim}")
 
         # initialize the model
         if config.checkpoint_path is not None:
@@ -169,7 +177,7 @@ def main(config: EvalLmConfig):
 
         if config.log_entropy:
             logger.info("Computing entropy...")
-            for name, dataset in config.data.validation_sets(Pos).items():
+            for name, dataset in config.data.validation_grug_sets(seq_len=Pos.size).items():
                 if config.trainer.max_eval_batches is not None:
                     dataset = dataset.take(config.trainer.max_eval_batches * config.trainer.eval_batch_size)
                 loader = DataLoader(
@@ -191,7 +199,7 @@ def main(config: EvalLmConfig):
 
         if config.log_top2_gap:
             logger.info("Computing top2_gap...")
-            for name, dataset in config.data.validation_sets(Pos).items():
+            for name, dataset in config.data.validation_grug_sets(seq_len=Pos.size).items():
                 if config.trainer.max_eval_batches is not None:
                     dataset = dataset.take(config.trainer.max_eval_batches * config.trainer.eval_batch_size)
                 loader = DataLoader(
@@ -213,7 +221,7 @@ def main(config: EvalLmConfig):
 
         if config.log_param_stats:
             logger.info("Computing param stats...")
-            log_dict = haliax.named_jit(levanter.analysis.summary_statistics_for_tree)(
+            log_dict = named_jit(levanter.analysis.summary_statistics_for_tree, axis_resources=compute_axis_mapping)(
                 "params", model, split_scan_layers=True, include_histogram=True
             )
 

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -21,7 +21,7 @@ from levanter.data.text import LmDataConfig
 from levanter.data.text.examples import GrugLmExample
 from levanter.eval import LossFnOutput, TaggedEvaluator, eval_model
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
+from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
 from levanter.utils.partitioning import named_jit, round_axis_for_partitioning
@@ -29,9 +29,6 @@ from levanter.utils.tree_utils import inference_mode
 
 
 logger = logging.getLogger(__name__)
-
-
-LmEvalExample = LmExample | GrugLmExample
 
 
 @dataclass
@@ -93,7 +90,7 @@ def main(config: EvalLmConfig):
 
         mp: jmp.Policy = config.trainer.mp
 
-        def eval_loss_fn(model: LmHeadModel, batch: LmEvalExample) -> LossFnOutput:
+        def eval_loss_fn(model: LmHeadModel, batch: GrugLmExample) -> LossFnOutput:
             model = inference_mode(model, True)
             model = mp.cast_to_compute(model)
             with hax.axis_mapping(compute_axis_mapping):
@@ -103,13 +100,8 @@ def main(config: EvalLmConfig):
                     reduction=None,
                     reduction_axis=(),
                 )
-
-            if isinstance(batch, LmExample):
-                per_pos_weight = batch.loss_weight.array
-                per_pos_token_id = jnp.roll(batch.tokens.array, -1, axis=-1)
-            else:
-                per_pos_weight = batch.loss_weight
-                per_pos_token_id = jnp.roll(batch.tokens, -1, axis=-1)
+            per_pos_weight = batch.loss_weight
+            per_pos_token_id = jnp.roll(batch.tokens, -1, axis=-1)
             return per_pos_loss, per_pos_weight, per_pos_token_id
 
         evaluator = TaggedEvaluator(
@@ -121,20 +113,9 @@ def main(config: EvalLmConfig):
             max_examples_per_dataset=max_examples,
         )
 
-        @named_jit(axis_resources=compute_axis_mapping)
-        def compute_loss(model: LmHeadModel, example: LmExample):
-            model = inference_mode(model, True)
-            model = mp.cast_to_compute(model)
-            return model.compute_next_token_loss(example, key=None)
-
-        def compute_logits(model: LmHeadModel, example: LmEvalExample):
+        def compute_logits(model: LmHeadModel, example: GrugLmExample):
             model = mp.cast_to_compute(model)
             with hax.axis_mapping(compute_axis_mapping):
-                if isinstance(example, LmExample):
-                    activations = model.activations(example.tokens, key=None, attn_mask=example.attn_mask)
-                    head = model.get_lm_head()
-                    return hax.dot(activations, head, axis=model.Embed)
-
                 logits_array = model.logits_from_token_ids_array(example.tokens, batch_axis=Batch, key=None)
                 if logits_array.ndim == 2:
                     return hax.named(logits_array, (Pos.resize(logits_array.shape[0]), model.Vocab))

--- a/lib/levanter/src/levanter/main/lora_lm.py
+++ b/lib/levanter/src/levanter/main/lora_lm.py
@@ -15,6 +15,7 @@ import levanter.eval
 from levanter import callbacks
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.data.text import LmDataConfig
+from levanter.data.text.examples import GrugLmExample
 from levanter.lora import (
     LoraConfig,
     lora_trainable_params_filter,
@@ -22,7 +23,7 @@ from levanter.lora import (
     save_merged_hf_checkpoint_callback,
     save_peft_checkpoint_callback,
 )
-from levanter.models.lm_model import LmExample, LmHeadModel
+from levanter.models.lm_model import LmHeadModel
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
 from levanter.utils.jax_utils import parameter_count
@@ -73,26 +74,21 @@ def main(config: LoraLmConfig):
 
     optimizer = config.optimizer.build(config.trainer.num_train_steps)
 
-    def loss_fn(model: LmHeadModel, example: LmExample, *, key=None):
-        return model.compute_next_token_loss(example, key=key, axis_mapping=config.trainer.compute_axis_mapping)
+    def loss_fn(model: LmHeadModel, example: GrugLmExample, *, key=None):
+        return model.compute_next_token_loss_array(example, batch_axis=config.trainer.batch_axis_name, key=key)
 
     with Trainer(config.trainer, optimizer, loss_fn=loss_fn) as trainer:  # type: ignore[arg-type]
         # how we shard parameters across devices
         parameter_axis_mapping = config.trainer.parameter_axis_mapping
 
-        train_dataset = config.data.train_set(
-            Pos,
+        train_dataset = config.data.train_grug_set(
+            seq_len=Pos.size,
             batch_schedule=config.trainer.batch_schedule,
             key=data_key,
         )
 
         if train_dataset is None:
             raise ValueError("No training set!")
-
-        eval_datasets = config.data.validation_sets(Pos)
-
-        if len(eval_datasets) == 0:
-            logger.warning("No evaluation datasets provided.")
 
         train_loader = trainer.data_loader(train_dataset, Batch)
 
@@ -132,7 +128,7 @@ def main(config: LoraLmConfig):
         if max_eval_examples_per_ds is not None:
             max_eval_examples_per_ds *= config.trainer.eval_batch_size
 
-        tagged_eval_datasets = config.data.tagged_eval_sets(Pos)
+        tagged_eval_datasets = config.data.tagged_eval_grug_sets(seq_len=Pos.size)
 
         if len(tagged_eval_datasets) == 0:
             logger.warning("No evaluation datasets provided.")

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -289,7 +289,12 @@ def main(config: TrainLmConfig):
         @named_jit(axis_resources=compute_axis_mapping)
         def compute_logits(model: LmHeadModel, example: GrugLmExample):
             model = trainer.mp.cast_to_compute(model)
-            logits_array = model.logits_from_token_ids_array(example.tokens, batch_axis=EvalBatch, key=None)
+            logits_array = model.logits_from_token_ids_array(
+                example.tokens,
+                attn_mask=example.attn_mask,
+                batch_axis=EvalBatch,
+                key=None,
+            )
             if logits_array.ndim == 2:
                 return hax.named(logits_array, (Pos.resize(logits_array.shape[0]), model.Vocab))
             if logits_array.ndim == 3:

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -27,7 +27,7 @@ from levanter.data.mixture import MixtureDataset
 from levanter.data.text import LmDataConfig
 from levanter.eval_harness import LmEvalHarnessConfig
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
+from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
 from levanter.utils.jax_utils import parameter_count
@@ -287,13 +287,8 @@ def main(config: TrainLmConfig):
             )
 
         @named_jit(axis_resources=compute_axis_mapping)
-        def compute_logits(model: LmHeadModel, example: LmExample | GrugLmExample):
+        def compute_logits(model: LmHeadModel, example: GrugLmExample):
             model = trainer.mp.cast_to_compute(model)
-            if isinstance(example, LmExample):
-                activations = model.activations(example.tokens, key=None, attn_mask=example.attn_mask)
-                head = model.get_lm_head()
-                return hax.dot(activations, head, axis=model.Embed)
-
             logits_array = model.logits_from_token_ids_array(example.tokens, batch_axis=EvalBatch, key=None)
             if logits_array.ndim == 2:
                 return hax.named(logits_array, (Pos.resize(logits_array.shape[0]), model.Vocab))

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -287,15 +287,24 @@ def main(config: TrainLmConfig):
             )
 
         @named_jit(axis_resources=compute_axis_mapping)
-        def compute_logits(model: LmHeadModel, example: LmExample):
+        def compute_logits(model: LmHeadModel, example: LmExample | GrugLmExample):
             model = trainer.mp.cast_to_compute(model)
-            activations = model.activations(example.tokens, key=None, attn_mask=example.attn_mask)
-            head = model.get_lm_head()
-            logits = hax.dot(activations, head, axis=model.Embed)
-            return logits
+            if isinstance(example, LmExample):
+                activations = model.activations(example.tokens, key=None, attn_mask=example.attn_mask)
+                head = model.get_lm_head()
+                return hax.dot(activations, head, axis=model.Embed)
+
+            logits_array = model.logits_from_token_ids_array(example.tokens, batch_axis=EvalBatch, key=None)
+            if logits_array.ndim == 2:
+                return hax.named(logits_array, (Pos.resize(logits_array.shape[0]), model.Vocab))
+            if logits_array.ndim == 3:
+                batch_axis = Axis(EvalBatch.name, logits_array.shape[0])
+                pos_axis = Pos.resize(logits_array.shape[1])
+                return hax.named(logits_array, (batch_axis, pos_axis, model.Vocab))
+            raise ValueError(f"Unexpected logits rank for analysis callbacks: {logits_array.ndim}")
 
         if config.log_entropy:
-            for name, dataset in config.data.validation_sets(Pos).items():
+            for name, dataset in config.data.validation_grug_sets(seq_len=Pos.size).items():
                 trainer.add_hook(
                     levanter.analysis.cb_compute_entropies(
                         compute_logits,

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -22,11 +22,12 @@ from levanter import callbacks
 from levanter.callbacks.tensorstore_callbacks import install_tensorstore_metrics_hook_if_enabled
 from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCompatConfig, save_hf_checkpoint_callback
+from levanter.data.text.examples import GrugLmExample
 from levanter.data.mixture import MixtureDataset
 from levanter.data.text import LmDataConfig
 from levanter.eval_harness import LmEvalHarnessConfig
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
+from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
 from levanter.utils.jax_utils import parameter_count
@@ -111,12 +112,12 @@ def main(config: TrainLmConfig):
     levanter.initialize(config)
     optimizer = config.optimizer.build(config.trainer.num_train_steps)
 
-    def loss_function(model: LmHeadModel, example: LmExample, *, key=None):
-        return model.compute_next_token_loss(
+    def loss_function(model: LmHeadModel, example: GrugLmExample, *, key=None):
+        return model.compute_next_token_loss_array(
             example,
+            batch_axis=config.trainer.batch_axis_name,
             key=key,
             logsumexp_weight=config.z_loss_weight,
-            axis_mapping=config.trainer.compute_axis_mapping,
         )
 
     # Using the trainer as a context manager does 3 things:
@@ -165,15 +166,15 @@ def main(config: TrainLmConfig):
             logger.info(f"Rounding vocab size from {vocab_size} to {Vocab.size} for partitioning")
 
         # Get the training dataset
-        train_dataset = config.data.train_set(
-            Pos,
-            config.trainer.batch_schedule,
+        train_dataset = config.data.train_grug_set(
+            seq_len=Pos.size,
+            batch_schedule=config.trainer.batch_schedule,
             key=data_key,
         )
         install_tensorstore_metrics_hook_if_enabled(trainer)
 
         # Get the tagged evaluation datasets
-        tagged_eval_datasets = config.data.tagged_eval_sets(Pos)
+        tagged_eval_datasets = config.data.tagged_eval_grug_sets(seq_len=Pos.size)
 
         state = trainer.initial_state(training_key, model_init=lambda: config.model.build(Vocab, key=model_key))
 

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -27,7 +27,7 @@ from levanter.data.mixture import MixtureDataset
 from levanter.data.text import LmDataConfig
 from levanter.eval_harness import LmEvalHarnessConfig
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
 from levanter.utils.jax_utils import parameter_count

--- a/lib/levanter/src/levanter/main/viz_logprobs.py
+++ b/lib/levanter/src/levanter/main/viz_logprobs.py
@@ -18,9 +18,10 @@ import levanter
 from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.data import DataLoader
-from levanter.data.text.examples import GrugLmExample, named_lm_example_from_grug
 from levanter.data.text import LmDataConfig
+from levanter.data.text.examples import GrugLmExample, named_lm_example_from_grug
 from levanter.models.llama import LlamaConfig
+from levanter.models.loss import next_token_loss
 from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
@@ -84,22 +85,24 @@ def main(config: VizLmConfig):
             model = inference_mode(model, True)
             model = mp.cast_to_compute(model)
 
-            loss = model.compute_next_token_loss_array(
-                example,
-                batch_axis=EvalBatch,
-                reduction=None,
-                reduction_axis=(),
-            )
-
             named_example = named_lm_example_from_grug(example, Pos=Pos, batch_axis=EvalBatch)
             activations = model.activations(named_example.tokens, named_example.attn_mask, key=key)
             if isinstance(activations, tuple):
                 activations = activations[0]
-            logits = hax.dot(activations, model.get_lm_head(), axis=model.Embed).array
+            logits = hax.dot(activations, model.get_lm_head(), axis=model.Embed)
+            loss = next_token_loss(
+                model.Pos,
+                model.Vocab,
+                logits=logits,
+                true_ids=named_example.tokens,
+                loss_weight=named_example.loss_weight,
+                reduction=None,
+                reduction_axis=(),
+            )
 
             # Roll forward to align each prediction with its target token.
-            logprobs = jnp.roll(-loss, 1, axis=-1)
-            argmaxes = jnp.roll(jnp.argmax(logits, axis=-1), 1, axis=-1)
+            logprobs = jnp.roll(-loss.array, 1, axis=-1)
+            argmaxes = jnp.roll(hax.argmax(logits, axis=model.Vocab).array, 1, axis=-1)
             return logprobs, argmaxes
 
         model: LmHeadModel

--- a/lib/levanter/src/levanter/main/viz_logprobs.py
+++ b/lib/levanter/src/levanter/main/viz_logprobs.py
@@ -58,14 +58,14 @@ def main(config: VizLmConfig):
 
     # some axes we use outside the model proper
     EvalBatch = config.trainer.EvalBatch
-    Pos = config.model.max_Pos.resize(config.max_eval_length)
+    eval_length = min(config.max_eval_length, config.model.max_seq_len)
+    Pos = config.model.max_Pos.resize(eval_length)
 
     validation_sets = config.data.validation_grug_sets(seq_len=Pos.size)
 
     compute_axis_mapping = config.trainer.compute_axis_mapping
     parameter_axis_mapping = config.trainer.parameter_axis_mapping
-    batch_axis_resource = config.trainer.batch_axis_resource
-    loader_axis_resources = {EvalBatch.name: batch_axis_resource} if batch_axis_resource is not None else None
+    loader_axis_resources = compute_axis_mapping or None
 
     with config.trainer.use_device_mesh():
         key = jax.random.PRNGKey(0)

--- a/lib/levanter/src/levanter/main/viz_logprobs.py
+++ b/lib/levanter/src/levanter/main/viz_logprobs.py
@@ -8,22 +8,23 @@ from dataclasses import dataclass, field
 
 import equinox as eqx
 import jax
+import jax.numpy as jnp
 import jmp
 
 import haliax as hax
 from haliax import Axis
-from haliax.partitioning import round_axis_for_partitioning
 
 import levanter
 from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.data import DataLoader
+from levanter.data.text.examples import GrugLmExample, named_lm_example_from_grug
 from levanter.data.text import LmDataConfig
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
-from levanter.models.loss import next_token_loss
+from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
+from levanter.utils.partitioning import named_jit, round_axis_for_partitioning
 from levanter.utils.tree_utils import inference_mode
 from levanter.visualization import compute_and_diff_log_probs, compute_and_visualize_log_probs
 
@@ -59,10 +60,12 @@ def main(config: VizLmConfig):
     EvalBatch = config.trainer.EvalBatch
     Pos = config.model.max_Pos.resize(config.max_eval_length)
 
-    validation_sets = config.data.validation_sets(Pos)
+    validation_sets = config.data.validation_grug_sets(seq_len=Pos.size)
 
     compute_axis_mapping = config.trainer.compute_axis_mapping
     parameter_axis_mapping = config.trainer.parameter_axis_mapping
+    batch_axis_resource = config.trainer.batch_axis_resource
+    loader_axis_resources = {EvalBatch.name: batch_axis_resource} if batch_axis_resource is not None else None
 
     with config.trainer.use_device_mesh():
         key = jax.random.PRNGKey(0)
@@ -76,28 +79,28 @@ def main(config: VizLmConfig):
 
         # don't want to compute the mask w.r.t. the final token
 
-        @hax.named_jit(axis_resources=compute_axis_mapping)
-        def compute_log_probs(model: LmHeadModel, example: LmExample):
+        @named_jit(axis_resources=compute_axis_mapping)
+        def compute_log_probs(model: LmHeadModel, example: GrugLmExample):
             model = inference_mode(model, True)
             model = mp.cast_to_compute(model)
 
-            activations = model.activations(example.tokens, example.attn_mask, key=key)
-            logits = hax.dot(activations, model.get_lm_head(), axis=model.Embed)
-
-            loss = next_token_loss(
-                model.Pos,
-                model.Vocab,
-                logits=logits,
-                true_ids=example.tokens,
-                loss_weight=example.loss_weight,
+            loss = model.compute_next_token_loss_array(
+                example,
+                batch_axis=EvalBatch,
                 reduction=None,
+                reduction_axis=(),
             )
-            logprobs = -loss
-            # roll forward to get the loss for each predicted token
-            logprobs = hax.roll(logprobs, 1, Pos)
-            logits = hax.roll(logits, 1, Pos)
-            argmaxes = hax.argmax(logits, axis=Vocab)
-            return logprobs.rearrange((EvalBatch, Pos)).array, argmaxes.rearrange((EvalBatch, Pos)).array
+
+            named_example = named_lm_example_from_grug(example, Pos=Pos, batch_axis=EvalBatch)
+            activations = model.activations(named_example.tokens, named_example.attn_mask, key=key)
+            if isinstance(activations, tuple):
+                activations = activations[0]
+            logits = hax.dot(activations, model.get_lm_head(), axis=model.Embed).array
+
+            # Roll forward to align each prediction with its target token.
+            logprobs = jnp.roll(-loss, 1, axis=-1)
+            argmaxes = jnp.roll(jnp.argmax(logits, axis=-1), 1, axis=-1)
+            return logprobs, argmaxes
 
         model: LmHeadModel
 
@@ -151,7 +154,7 @@ def main(config: VizLmConfig):
                 dataset,
                 config.trainer.eval_batch_size,
                 mesh=config.trainer.device_mesh,
-                axis_resources=config.trainer.compute_axis_mapping,
+                axis_resources=loader_axis_resources,
             )
 
             if name:

--- a/lib/levanter/src/levanter/models/lm_model.py
+++ b/lib/levanter/src/levanter/models/lm_model.py
@@ -222,6 +222,7 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
         self,
         input_ids: jax.Array,
         *,
+        attn_mask: Optional[AttentionMask | NamedArray] = None,
         batch_axis: Axis | str | None = "batch",
         key=None,
     ) -> jax.Array:
@@ -231,6 +232,7 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
         This adapter is intended for migration paths that avoid named tensors at
         call sites while keeping existing model internals unchanged.
         """
+        resolved_batch_axis: Axis | None = None
         if input_ids.ndim == 1:
             Pos = self.Pos.resize(input_ids.shape[0])
             named_input_ids = hax.named(input_ids, Pos)
@@ -245,13 +247,21 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
                     raise ValueError(
                         f"Batch axis size ({Batch.size}) must match input batch size ({input_ids.shape[0]})."
                     )
+            resolved_batch_axis = Batch
 
             Pos = self.Pos.resize(input_ids.shape[1])
             named_input_ids = hax.named(input_ids, (Batch, Pos))
         else:
             raise ValueError(f"input_ids must have rank 1 or 2, got rank={input_ids.ndim}")
 
-        activations = self.activations(named_input_ids, key=key)
+        if attn_mask is not None:
+            from levanter.data.text.examples import named_attention_mask_from_grug
+            from levanter.grug.attention import AttentionMask as GrugAttentionMask
+
+            if isinstance(attn_mask, GrugAttentionMask):
+                attn_mask = named_attention_mask_from_grug(attn_mask, Pos, batch_axis=resolved_batch_axis)
+
+        activations = self.activations(named_input_ids, attn_mask=attn_mask, key=key)
         if isinstance(activations, tuple):
             activations, _ = activations
         logits = hax.dot(activations, self.get_lm_head(), axis=self.Embed)
@@ -367,7 +377,8 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
 
             if not isinstance(example, GrugLmExample):
                 raise TypeError(f"Unsupported example type: {type(example)}")
-            named_example = named_lm_example_from_grug(example, Pos=self.Pos, batch_axis=batch_axis)
+            Pos = self.Pos.resize(example.tokens.shape[-1])
+            named_example = named_lm_example_from_grug(example, Pos=Pos, batch_axis=batch_axis)
 
         loss = self.compute_next_token_loss(
             named_example,

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -59,6 +59,7 @@ from levanter.checkpoint import CheckpointerConfig, is_checkpoint_path, load_che
 from levanter.config import JsonAtom
 from levanter.data import AsyncDataset, DataLoader
 from levanter.data.loader import _round_to_nearest_multiple
+from levanter.data.text.examples import GrugLmExample
 from levanter.distributed import DistributedConfig, RayConfig
 from levanter.grad_accum import microbatched
 from levanter.metrics import Metric, auto_metric_from_name, unwrap_metrics
@@ -1115,7 +1116,11 @@ def _ensure_scalar(x: hax.types.Scalar | hax.NamedArray) -> hax.types.Scalar:
 
 def _resolve_axis_in_tree(tree, axis):
     """
-    Resolves an axis in a tree of NamedArrays. This is useful for finding the batch axis in a batch of data.
+    Resolves an axis in a batch pytree.
+
+    NamedArray batches carry axis metadata directly. Array-first grug batches do not, so we
+    recover the leading batch dimension from `GrugLmExample.tokens` when the trainer is given
+    batched grug examples.
     """
     for leaf in haliax.tree_util.tree_leaves(tree):
         if isinstance(leaf, haliax.NamedArray):
@@ -1124,28 +1129,16 @@ def _resolve_axis_in_tree(tree, axis):
             except ValueError:
                 pass
 
-    candidate_sizes: list[int] = []
-    for leaf in jax.tree_util.tree_leaves(tree):
-        shape = getattr(leaf, "shape", None)
-        if shape is None:
-            continue
-        if len(shape) >= 2:
-            candidate_sizes.append(int(shape[0]))
+    grug_batch_sizes: list[int] = []
+    for leaf in jax.tree_util.tree_leaves(tree, is_leaf=lambda x: isinstance(x, GrugLmExample)):
+        if isinstance(leaf, GrugLmExample) and leaf.tokens.ndim >= 2:
+            grug_batch_sizes.append(int(leaf.tokens.shape[0]))
 
-    if not candidate_sizes:
-        for leaf in jax.tree_util.tree_leaves(tree):
-            shape = getattr(leaf, "shape", None)
-            if shape is None or len(shape) == 0:
-                continue
-            if len(shape) == 1 and tuple(shape) == (2,):
-                continue
-            candidate_sizes.append(int(shape[0]))
-
-    if candidate_sizes:
-        batch_size = candidate_sizes[0]
-        for size in candidate_sizes[1:]:
+    if grug_batch_sizes:
+        batch_size = grug_batch_sizes[0]
+        for size in grug_batch_sizes[1:]:
             if size != batch_size:
-                raise ValueError(f"Inconsistent inferred batch sizes {candidate_sizes} in tree {tree}")
+                raise ValueError(f"Inconsistent inferred batch sizes {grug_batch_sizes} in tree {tree}")
         return hax.Axis(axis, batch_size)
 
     raise ValueError(f"Could not find axis {axis} in tree {tree}")

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -1124,4 +1124,28 @@ def _resolve_axis_in_tree(tree, axis):
             except ValueError:
                 pass
 
+    candidate_sizes: list[int] = []
+    for leaf in jax.tree_util.tree_leaves(tree):
+        shape = getattr(leaf, "shape", None)
+        if shape is None:
+            continue
+        if len(shape) >= 2:
+            candidate_sizes.append(int(shape[0]))
+
+    if not candidate_sizes:
+        for leaf in jax.tree_util.tree_leaves(tree):
+            shape = getattr(leaf, "shape", None)
+            if shape is None or len(shape) == 0:
+                continue
+            if len(shape) == 1 and tuple(shape) == (2,):
+                continue
+            candidate_sizes.append(int(shape[0]))
+
+    if candidate_sizes:
+        batch_size = candidate_sizes[0]
+        for size in candidate_sizes[1:]:
+            if size != batch_size:
+                raise ValueError(f"Inconsistent inferred batch sizes {candidate_sizes} in tree {tree}")
+        return hax.Axis(axis, batch_size)
+
     raise ValueError(f"Could not find axis {axis} in tree {tree}")

--- a/lib/levanter/src/levanter/utils/partitioning.py
+++ b/lib/levanter/src/levanter/utils/partitioning.py
@@ -1,0 +1,28 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from haliax.partitioning import (
+    current_thread_local_mapping,
+    infer_resource_partitions,
+    named_jit,
+    physical_axis_name,
+    physical_axis_size,
+    pspec_for,
+    pspec_for_axis,
+    round_axis_for_partitioning,
+    shard_map,
+    sharding_for_axis,
+)
+
+__all__ = [
+    "current_thread_local_mapping",
+    "infer_resource_partitions",
+    "named_jit",
+    "physical_axis_name",
+    "physical_axis_size",
+    "pspec_for",
+    "pspec_for_axis",
+    "round_axis_for_partitioning",
+    "shard_map",
+    "sharding_for_axis",
+]

--- a/lib/levanter/src/levanter/utils/partitioning.py
+++ b/lib/levanter/src/levanter/utils/partitioning.py
@@ -1,6 +1,8 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+"""Stable Levanter import surface for partitioning helpers."""
+
 from haliax.partitioning import (
     current_thread_local_mapping,
     infer_resource_partitions,

--- a/lib/levanter/tests/test_lm_model_loss.py
+++ b/lib/levanter/tests/test_lm_model_loss.py
@@ -15,6 +15,8 @@ from jaxtyping import PRNGKeyArray
 import haliax as hax
 from haliax import Axis, NamedArray
 
+from levanter.data.text.examples import GrugLmExample
+from levanter.grug.attention import AttentionMask as GrugAttentionMask
 from levanter.layers.attention import AttentionMask
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 
@@ -63,8 +65,11 @@ class ToyLmHeadModel(LmHeadModel[ToyLmConfig]):
         key=None,
         pos_ids: NamedArray | None = None,
     ) -> NamedArray | tuple[NamedArray, NamedArray | float]:
-        del attn_mask, key, pos_ids
+        del key, pos_ids
         hidden = self.embed_weight.take(self.Vocab, input_ids)
+        if isinstance(attn_mask, AttentionMask) and attn_mask.segment_ids is not None:
+            q_segment_ids, _ = attn_mask.segment_ids
+            hidden = hidden + q_segment_ids.astype(hidden.dtype).broadcast_axis(self.Embed)
         return hidden, self.aux_loss
 
     def get_lm_head(self) -> NamedArray:
@@ -126,3 +131,38 @@ def test_compute_next_token_loss_includes_aux_loss():
     with_aux = model_with_aux.compute_next_token_loss(example)
 
     assert pytest.approx(float(base) + 0.25, rel=1e-6, abs=1e-6) == float(with_aux)
+
+
+def test_compute_next_token_loss_array_accepts_shorter_grug_sequence():
+    Vocab = Axis("vocab", 32)
+    cfg = ToyLmConfig(max_seq_len=8, embed_dim=16)
+    model = ToyLmHeadModel.init(Vocab, cfg, key=jax.random.PRNGKey(0))
+
+    Batch = Axis("batch", 4)
+    short_seq_len = 4
+    tokens = jax.random.randint(jax.random.PRNGKey(1), (Batch.size, short_seq_len), 0, Vocab.size)
+    loss_weight = jnp.ones_like(tokens, dtype=jnp.float32).at[:, -1].set(0.0)
+    example = GrugLmExample(tokens=tokens, loss_weight=loss_weight, attn_mask=GrugAttentionMask.causal())
+
+    loss = model.compute_next_token_loss_array(example, batch_axis=Batch)
+
+    assert jnp.shape(loss) == ()
+
+
+def test_logits_from_token_ids_array_passes_grug_attention_mask():
+    Vocab = Axis("vocab", 32)
+    cfg = ToyLmConfig(max_seq_len=8, embed_dim=16)
+    model = ToyLmHeadModel.init(Vocab, cfg, key=jax.random.PRNGKey(0))
+
+    Batch = Axis("batch", 2)
+    tokens = jax.random.randint(jax.random.PRNGKey(1), (Batch.size, 4), 0, Vocab.size)
+    segment_ids = jnp.array([[0, 0, 1, 1], [0, 1, 1, 2]], dtype=jnp.int32)
+
+    unmasked_logits = model.logits_from_token_ids_array(tokens, batch_axis=Batch)
+    masked_logits = model.logits_from_token_ids_array(
+        tokens,
+        attn_mask=GrugAttentionMask.causal().with_segment_ids(segment_ids),
+        batch_axis=Batch,
+    )
+
+    assert not jnp.allclose(unmasked_logits, masked_logits)

--- a/lib/levanter/tests/test_lm_model_loss.py
+++ b/lib/levanter/tests/test_lm_model_loss.py
@@ -9,12 +9,14 @@ from typing import Optional, Type
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 from jaxtyping import PRNGKeyArray
 
 import haliax as hax
 from haliax import Axis, NamedArray
 
+from levanter.data.text.examples import grug_lm_example_from_named
 from levanter.layers.attention import AttentionMask
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 
@@ -126,3 +128,19 @@ def test_compute_next_token_loss_includes_aux_loss():
     with_aux = model_with_aux.compute_next_token_loss(example)
 
     assert pytest.approx(float(base) + 0.25, rel=1e-6, abs=1e-6) == float(with_aux)
+
+
+def test_compute_next_token_loss_array_matches_named_for_grug_example():
+    Vocab = Axis("vocab", 32)
+    cfg = ToyLmConfig(max_seq_len=8, embed_dim=16)
+    model = ToyLmHeadModel.init(Vocab, cfg, key=jax.random.PRNGKey(0))
+
+    Batch = Axis("batch", 4)
+    Pos = cfg.max_Pos.resize(8)
+    example = _toy_example(Batch, Pos, Vocab, key=jax.random.PRNGKey(1))
+    grug_example = grug_lm_example_from_named(example)
+
+    named_loss = model.compute_next_token_loss(example, reduction=None, reduction_axis=()).array
+    grug_loss = model.compute_next_token_loss_array(grug_example, batch_axis=Batch, reduction=None, reduction_axis=())
+
+    np.testing.assert_allclose(grug_loss, named_loss, rtol=1e-5, atol=1e-6)

--- a/lib/levanter/tests/test_lm_model_loss.py
+++ b/lib/levanter/tests/test_lm_model_loss.py
@@ -144,3 +144,21 @@ def test_compute_next_token_loss_array_matches_named_for_grug_example():
     grug_loss = model.compute_next_token_loss_array(grug_example, batch_axis=Batch, reduction=None, reduction_axis=())
 
     np.testing.assert_allclose(grug_loss, named_loss, rtol=1e-5, atol=1e-6)
+
+
+def test_logits_from_token_ids_array_matches_named_logits():
+    Vocab = Axis("vocab", 32)
+    cfg = ToyLmConfig(max_seq_len=8, embed_dim=16)
+    model = ToyLmHeadModel.init(Vocab, cfg, key=jax.random.PRNGKey(0))
+
+    Batch = Axis("batch", 4)
+    Pos = cfg.max_Pos.resize(8)
+    example = _toy_example(Batch, Pos, Vocab, key=jax.random.PRNGKey(1))
+
+    activations = model.activations(example.tokens)
+    if isinstance(activations, tuple):
+        activations = activations[0]
+    named_logits = hax.dot(activations, model.get_lm_head(), axis=model.Embed).array
+    array_logits = model.logits_from_token_ids_array(example.tokens.array, batch_axis=Batch)
+
+    np.testing.assert_allclose(array_logits, named_logits, rtol=1e-5, atol=1e-6)

--- a/lib/levanter/tests/test_lm_model_loss.py
+++ b/lib/levanter/tests/test_lm_model_loss.py
@@ -9,14 +9,12 @@ from typing import Optional, Type
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-import numpy as np
 import pytest
 from jaxtyping import PRNGKeyArray
 
 import haliax as hax
 from haliax import Axis, NamedArray
 
-from levanter.data.text.examples import grug_lm_example_from_named
 from levanter.layers.attention import AttentionMask
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 
@@ -128,37 +126,3 @@ def test_compute_next_token_loss_includes_aux_loss():
     with_aux = model_with_aux.compute_next_token_loss(example)
 
     assert pytest.approx(float(base) + 0.25, rel=1e-6, abs=1e-6) == float(with_aux)
-
-
-def test_compute_next_token_loss_array_matches_named_for_grug_example():
-    Vocab = Axis("vocab", 32)
-    cfg = ToyLmConfig(max_seq_len=8, embed_dim=16)
-    model = ToyLmHeadModel.init(Vocab, cfg, key=jax.random.PRNGKey(0))
-
-    Batch = Axis("batch", 4)
-    Pos = cfg.max_Pos.resize(8)
-    example = _toy_example(Batch, Pos, Vocab, key=jax.random.PRNGKey(1))
-    grug_example = grug_lm_example_from_named(example)
-
-    named_loss = model.compute_next_token_loss(example, reduction=None, reduction_axis=()).array
-    grug_loss = model.compute_next_token_loss_array(grug_example, batch_axis=Batch, reduction=None, reduction_axis=())
-
-    np.testing.assert_allclose(grug_loss, named_loss, rtol=1e-5, atol=1e-6)
-
-
-def test_logits_from_token_ids_array_matches_named_logits():
-    Vocab = Axis("vocab", 32)
-    cfg = ToyLmConfig(max_seq_len=8, embed_dim=16)
-    model = ToyLmHeadModel.init(Vocab, cfg, key=jax.random.PRNGKey(0))
-
-    Batch = Axis("batch", 4)
-    Pos = cfg.max_Pos.resize(8)
-    example = _toy_example(Batch, Pos, Vocab, key=jax.random.PRNGKey(1))
-
-    activations = model.activations(example.tokens)
-    if isinstance(activations, tuple):
-        activations = activations[0]
-    named_logits = hax.dot(activations, model.get_lm_head(), axis=model.Embed).array
-    array_logits = model.logits_from_token_ids_array(example.tokens.array, batch_axis=Batch)
-
-    np.testing.assert_allclose(array_logits, named_logits, rtol=1e-5, atol=1e-6)

--- a/tests/test_grug_base_template.py
+++ b/tests/test_grug_base_template.py
@@ -77,7 +77,7 @@ def _build_state(params: DummyModel, optimizer: optax.GradientTransformation) ->
         step=jnp.array(0, dtype=jnp.int32),
         params=params,
         opt_state=optimizer.init(params),
-        ema_params=params,
+        ema_params=jax.tree_util.tree_map(lambda x: jnp.array(x, copy=True), params),
     )
 
 
@@ -93,12 +93,12 @@ def test_grug_base_train_step_with_watch_matches_base_step():
         attn_mask=GrugAttentionMask.causal(),
     )
 
-    base_step = _make_train_step(optimizer, mp, z_loss_weight=0.0, ema_beta=None)
+    base_step = _make_train_step(optimizer, mp, z_loss_weight=0.0, ema_beta=0.9)
     watch_step = _make_train_step(
         optimizer,
         mp,
         z_loss_weight=0.0,
-        ema_beta=None,
+        ema_beta=0.9,
         watch_config=WatchConfig(
             watch_targets=["grads", "params", "updates"],
             include_norms=True,


### PR DESCRIPTION
## Summary
- switches train/eval/lora default dataset paths to array-first Grug examples
- migrates visualization and eval diagnostics to Grug validation datasets
- routes analysis callbacks through the array-logits path used by default training/eval flows

This is part of gruggification.
