### PR TITLE
lm_model: migrate public LM surface to array-native protocols

### DIFF
--- a/lib/levanter/src/levanter/analysis/entropy.py
+++ b/lib/levanter/src/levanter/analysis/entropy.py
@@ -66,7 +66,7 @@ def top2_gap_from_logits(logits: hax.NamedArray, axis: hax.AxisSelector) -> hax.
 def compute_entropy_histogram(
     model,
     Vocab: hax.AxisSelector,
-    logit_fn: Callable[[PyTree, B], hax.NamedArray],
+    logit_fn: Callable[[PyTree, B], hax.NamedArray | jax.Array],
     test_data,
     max_tokens: int = 1024 * 1024,
     num_bins: int = 64,
@@ -102,8 +102,11 @@ def compute_entropy_histogram(
 def _compute_entropy_on_device(logit_fn, model, batch: B, Vocab) -> jnp.ndarray:
     with jax.named_scope("logits"):
         logits = logit_fn(model, batch)
-    entropies = entropy_from_logits(logits, axis=Vocab)
-    return entropies.flatten("token").array
+    if isinstance(logits, hax.NamedArray):
+        entropies = entropy_from_logits(logits, axis=Vocab)
+        return entropies.flatten("token").array
+    entropies = _entropy_from_logits_array(logits, axis=-1)
+    return entropies.reshape(-1)
 
 
 def cb_compute_entropies(
@@ -160,7 +163,7 @@ def cb_compute_entropies(
 def compute_top2_gap_histogram(
     model,
     Vocab: hax.AxisSelector,
-    logit_fn: Callable[[PyTree, B], hax.NamedArray],
+    logit_fn: Callable[[PyTree, B], hax.NamedArray | jax.Array],
     test_data,
     max_tokens: int = 1024 * 1024,
     num_bins: int = 64,
@@ -183,8 +186,23 @@ def compute_top2_gap_histogram(
 def _compute_top2_gap_on_device(logit_fn, model, batch: B, Vocab) -> jnp.ndarray:
     with jax.named_scope("logits"):
         logits = logit_fn(model, batch)
-    gaps = top2_gap_from_logits(logits, axis=Vocab)
-    return gaps.flatten("token").array
+    if isinstance(logits, hax.NamedArray):
+        gaps = top2_gap_from_logits(logits, axis=Vocab)
+        return gaps.flatten("token").array
+    gaps = _top2_gap_from_logits_array(logits, axis=-1)
+    return gaps.reshape(-1)
+
+
+def _entropy_from_logits_array(logits: jax.Array, axis: int = -1) -> jax.Array:
+    log_z = jax.nn.logsumexp(logits, axis=axis)
+    probs = jax.nn.softmax(logits, axis=axis)
+    return log_z - jnp.sum(probs * logits, axis=axis)
+
+
+def _top2_gap_from_logits_array(logits: jax.Array, axis: int = -1) -> jax.Array:
+    moved = jnp.moveaxis(logits, axis, -1)
+    top2_vals, _ = jax.lax.top_k(moved, 2)
+    return top2_vals[..., 0] - top2_vals[..., 1]
 
 
 def cb_compute_top2_gap(

--- a/lib/levanter/src/levanter/analysis/visualization.py
+++ b/lib/levanter/src/levanter/analysis/visualization.py
@@ -15,7 +15,7 @@ from jax.experimental import multihost_utils
 
 from levanter.callbacks import StepInfo
 from levanter.data import DataLoader
-from levanter.data.text.examples import GrugLmExample
+from levanter.data.text.examples import LmLikeExample, token_ids_array_from_lm_example
 from levanter.utils.hf_utils import HfTokenizer
 
 
@@ -314,8 +314,8 @@ def _decode_tokens_pretty(tok, ids):
         return [str(t) for t in tok.decode(ids)]
 
 
-def _tokens_from_batch(batch: GrugLmExample) -> jax.Array:
-    return batch.tokens
+def _tokens_from_batch(batch: LmLikeExample) -> jax.Array:
+    return token_ids_array_from_lm_example(batch)
 
 
 def cb_compute_and_visualize_log_probs(

--- a/lib/levanter/src/levanter/analysis/visualization.py
+++ b/lib/levanter/src/levanter/analysis/visualization.py
@@ -15,6 +15,8 @@ from jax.experimental import multihost_utils
 
 from levanter.callbacks import StepInfo
 from levanter.data import DataLoader
+from levanter.data.text.examples import GrugLmExample
+from levanter.models.lm_model import LmExample
 from levanter.utils.hf_utils import HfTokenizer
 
 
@@ -113,7 +115,7 @@ def compute_and_visualize_log_probs(path: str, model, tokenizer, log_prob_fn, te
         if len(targets) * b_logprobs.shape[0] >= max_docs:
             break
     log_probs = _concatenate(log_probs)
-    targets = _concatenate([t.tokens.array for t in targets])
+    targets = _concatenate([_tokens_from_batch(t) for t in targets])
     if argmaxes:
         argmaxes_array = _concatenate(argmaxes)
     else:
@@ -292,7 +294,7 @@ def compute_and_diff_log_probs(path: str, model, comparison_model, tokenizer, lo
     log_probs_a = np.array(log_probs_a[:max_docs])
     log_probs_b = np.array(log_probs_b[:max_docs])
 
-    targets = _concatenate([t.tokens.array for t in targets])
+    targets = _concatenate([_tokens_from_batch(t) for t in targets])
     tokens = [_decode_tokens_pretty(tokenizer, t) for t in targets]
     visualize_log_prob_diff(tokens, log_probs_a, log_probs_b, path)
 
@@ -311,6 +313,12 @@ def _decode_tokens_pretty(tok, ids):
         return [str(t) for t in tok.convert_ids_to_tokens(ids)]
     else:
         return [str(t) for t in tok.decode(ids)]
+
+
+def _tokens_from_batch(batch: LmExample | GrugLmExample) -> jax.Array:
+    if isinstance(batch, LmExample):
+        return batch.tokens.array
+    return batch.tokens
 
 
 def cb_compute_and_visualize_log_probs(

--- a/lib/levanter/src/levanter/analysis/visualization.py
+++ b/lib/levanter/src/levanter/analysis/visualization.py
@@ -16,7 +16,6 @@ from jax.experimental import multihost_utils
 from levanter.callbacks import StepInfo
 from levanter.data import DataLoader
 from levanter.data.text.examples import GrugLmExample
-from levanter.models.lm_model import LmExample
 from levanter.utils.hf_utils import HfTokenizer
 
 
@@ -315,9 +314,7 @@ def _decode_tokens_pretty(tok, ids):
         return [str(t) for t in tok.decode(ids)]
 
 
-def _tokens_from_batch(batch: LmExample | GrugLmExample) -> jax.Array:
-    if isinstance(batch, LmExample):
-        return batch.tokens.array
+def _tokens_from_batch(batch: GrugLmExample) -> jax.Array:
     return batch.tokens
 
 

--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -695,20 +695,30 @@ class LmDataConfig:
         *,
         key: PRNGKeyArray,
     ) -> AsyncDataset[LmExample]:
+        grug_dataset = self.train_grug_set(seq_len=Pos.size, batch_schedule=batch_schedule, key=key)
+        return NamedLmDataset(grug_dataset, Pos)
+
+    def train_grug_set(
+        self,
+        *,
+        seq_len: int,
+        batch_schedule: BatchSchedule,
+        key: PRNGKeyArray,
+    ) -> AsyncDataset[GrugLmExample]:
+        """Build the mixed training dataset in array-first `GrugLmExample` format."""
         mix_key, shuffle_key = jax.random.split(key)
         weights = self.train_weights
         if isinstance(weights, list):
             weights = rescale_mixture_schedule_for_batch_schedule(weights, batch_schedule)
         initial_batch_size = batch_schedule.batch_size_at_step(0)
-        datasets = self.train_sets(Pos, key=shuffle_key, initial_batch_size=initial_batch_size)
-        mixture = MixtureDataset(
+        datasets = self.train_grug_sets(seq_len=seq_len, key=shuffle_key, initial_batch_size=initial_batch_size)
+        return MixtureDataset(
             datasets=datasets,
             weights=weights,
             stop_strategy=self.stop_strategy,
             key=mix_key,
             block_size=self.mixture_block_size,
         )
-        return NamedLmDataset(mixture, Pos)
 
     def train_sets(
         self,

--- a/lib/levanter/src/levanter/data/text/examples.py
+++ b/lib/levanter/src/levanter/data/text/examples.py
@@ -107,6 +107,9 @@ class GrugLmExample:
         return loss_weight
 
 
+LmLikeExample = LmExample | GrugLmExample
+
+
 def grug_attention_mask_from_named(mask: AttentionMask) -> GrugAttentionMask:
     if mask.explicit_mask is not None:
         raise NotImplementedError("Explicit attention masks are not supported by GrugAttentionMask.")
@@ -226,3 +229,19 @@ def named_lm_example_from_grug(
         loss_weight=hax.named(example.loss_weight, token_axes),
         attn_mask=named_attention_mask_from_grug(example.attn_mask, Pos, batch_axis=resolved_batch_axis),
     )
+
+
+def token_ids_array_from_lm_example(example: LmLikeExample) -> jax.Array:
+    if isinstance(example, LmExample):
+        return example.tokens.array
+    return example.tokens
+
+
+def loss_weight_array_from_lm_example(example: LmLikeExample) -> jax.Array:
+    if isinstance(example, LmExample):
+        return example.loss_weight.array
+    return example.loss_weight
+
+
+def target_token_ids_array_from_lm_example(example: LmLikeExample) -> jax.Array:
+    return jnp.roll(token_ids_array_from_lm_example(example), -1, axis=-1)

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -27,7 +27,7 @@ import levanter.tracker
 from levanter.callbacks import StepInfo
 from levanter.data import AsyncDataset, DataLoader
 from levanter.data.text.examples import GrugLmExample
-from levanter.models.lm_model import LmExample, LmHeadModel
+from levanter.models.lm_model import LmHeadModel
 from levanter.utils.hf_utils import HfTokenizer, byte_length_of_token
 from levanter.utils.jax_utils import axis_resource_is_explicit
 from levanter.utils.logging import LoadingTimeTrackerIterator
@@ -41,7 +41,6 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 M = TypeVar("M")
 Ex = TypeVar("Ex")
-LmEvalExample = LmExample | GrugLmExample
 LossFnOutput = tuple[jax.Array, jax.Array, jax.Array]
 TagArray = Int[Array, "tag"]
 BatchedTagArray = Int[Array, "... tag"]
@@ -164,7 +163,7 @@ def _join_prefix(prefix: str, tag: str) -> str:
 
 def _default_lm_eval_loss_fn(
     model: LmHeadModel,
-    batch: LmEvalExample,
+    batch: GrugLmExample,
     *,
     EvalBatch: hax.Axis,
     mp: jmp.Policy | None,
@@ -190,18 +189,14 @@ def _default_lm_eval_loss_fn(
             reduction_axis=(),
         )
 
-    if isinstance(batch, LmExample):
-        per_pos_weight = batch.loss_weight.array
-        per_pos_token_id = jnp.roll(batch.tokens.array, -1, axis=-1)
-    else:
-        per_pos_weight = batch.loss_weight
-        per_pos_token_id = jnp.roll(batch.tokens, -1, axis=-1)
+    per_pos_weight = batch.loss_weight
+    per_pos_token_id = jnp.roll(batch.tokens, -1, axis=-1)
     return per_pos_loss, per_pos_weight, per_pos_token_id
 
 
 def cb_tagged_lm_evaluate(
     EvalBatch: hax.Axis,
-    tagged_eval_sets: Sequence[tuple[AsyncDataset[LmEvalExample], Sequence[str]]],
+    tagged_eval_sets: Sequence[tuple[AsyncDataset[GrugLmExample], Sequence[str]]],
     tokenizer: Optional[HfTokenizer] = None,
     device_mesh: Optional[Mesh] = None,
     axis_mapping: ResourceMapping | None = None,
@@ -211,7 +206,7 @@ def cb_tagged_lm_evaluate(
     prefix: str = "eval",
     mp: jmp.Policy = None,
     checkpoint_path: Optional[str] = None,
-    loss_fn: Callable[[LmHeadModel, LmEvalExample], LossFnOutput] | None = None,
+    loss_fn: Callable[[LmHeadModel, GrugLmExample], LossFnOutput] | None = None,
 ) -> Callable[[StepInfo], None]:
     """
     Evaluates multiple tagged datasets using a given evaluation function.
@@ -241,7 +236,7 @@ def cb_tagged_lm_evaluate(
 
     if loss_fn is None:
 
-        def loss_fn(model: LmHeadModel, batch: LmEvalExample) -> LossFnOutput:
+        def loss_fn(model: LmHeadModel, batch: GrugLmExample) -> LossFnOutput:
             return _default_lm_eval_loss_fn(
                 model,
                 batch,

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -27,7 +27,7 @@ import levanter.tracker
 from levanter.callbacks import StepInfo
 from levanter.data import AsyncDataset, DataLoader
 from levanter.data.text.examples import GrugLmExample
-from levanter.models.lm_model import LmHeadModel
+from levanter.models.lm_model import ArrayLmHeadModel
 from levanter.utils.hf_utils import HfTokenizer, byte_length_of_token
 from levanter.utils.jax_utils import axis_resource_is_explicit
 from levanter.utils.logging import LoadingTimeTrackerIterator
@@ -162,7 +162,7 @@ def _join_prefix(prefix: str, tag: str) -> str:
 
 
 def _default_lm_eval_loss_fn(
-    model: LmHeadModel,
+    model: ArrayLmHeadModel,
     batch: GrugLmExample,
     *,
     EvalBatch: hax.Axis,
@@ -206,7 +206,7 @@ def cb_tagged_lm_evaluate(
     prefix: str = "eval",
     mp: jmp.Policy = None,
     checkpoint_path: Optional[str] = None,
-    loss_fn: Callable[[LmHeadModel, GrugLmExample], LossFnOutput] | None = None,
+    loss_fn: Callable[[ArrayLmHeadModel, GrugLmExample], LossFnOutput] | None = None,
 ) -> Callable[[StepInfo], None]:
     """
     Evaluates multiple tagged datasets using a given evaluation function.
@@ -236,7 +236,7 @@ def cb_tagged_lm_evaluate(
 
     if loss_fn is None:
 
-        def loss_fn(model: LmHeadModel, batch: GrugLmExample) -> LossFnOutput:
+        def loss_fn(model: ArrayLmHeadModel, batch: GrugLmExample) -> LossFnOutput:
             return _default_lm_eval_loss_fn(
                 model,
                 batch,

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -26,7 +26,11 @@ from haliax.partitioning import ResourceMapping
 import levanter.tracker
 from levanter.callbacks import StepInfo
 from levanter.data import AsyncDataset, DataLoader
-from levanter.data.text.examples import GrugLmExample
+from levanter.data.text.examples import (
+    LmLikeExample,
+    loss_weight_array_from_lm_example,
+    target_token_ids_array_from_lm_example,
+)
 from levanter.models.lm_model import ArrayLmHeadModel
 from levanter.utils.hf_utils import HfTokenizer, byte_length_of_token
 from levanter.utils.jax_utils import axis_resource_is_explicit
@@ -41,6 +45,7 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 M = TypeVar("M")
 Ex = TypeVar("Ex")
+LmEvalExample = LmLikeExample
 LossFnOutput = tuple[jax.Array, jax.Array, jax.Array]
 TagArray = Int[Array, "tag"]
 BatchedTagArray = Int[Array, "... tag"]
@@ -163,7 +168,7 @@ def _join_prefix(prefix: str, tag: str) -> str:
 
 def _default_lm_eval_loss_fn(
     model: ArrayLmHeadModel,
-    batch: GrugLmExample,
+    batch: LmLikeExample,
     *,
     EvalBatch: hax.Axis,
     mp: jmp.Policy | None,
@@ -189,14 +194,14 @@ def _default_lm_eval_loss_fn(
             reduction_axis=(),
         )
 
-    per_pos_weight = batch.loss_weight
-    per_pos_token_id = jnp.roll(batch.tokens, -1, axis=-1)
+    per_pos_weight = loss_weight_array_from_lm_example(batch)
+    per_pos_token_id = target_token_ids_array_from_lm_example(batch)
     return per_pos_loss, per_pos_weight, per_pos_token_id
 
 
 def cb_tagged_lm_evaluate(
     EvalBatch: hax.Axis,
-    tagged_eval_sets: Sequence[tuple[AsyncDataset[GrugLmExample], Sequence[str]]],
+    tagged_eval_sets: Sequence[tuple[AsyncDataset[LmEvalExample], Sequence[str]]],
     tokenizer: Optional[HfTokenizer] = None,
     device_mesh: Optional[Mesh] = None,
     axis_mapping: ResourceMapping | None = None,
@@ -206,7 +211,7 @@ def cb_tagged_lm_evaluate(
     prefix: str = "eval",
     mp: jmp.Policy = None,
     checkpoint_path: Optional[str] = None,
-    loss_fn: Callable[[ArrayLmHeadModel, GrugLmExample], LossFnOutput] | None = None,
+    loss_fn: Callable[[ArrayLmHeadModel, LmEvalExample], LossFnOutput] | None = None,
 ) -> Callable[[StepInfo], None]:
     """
     Evaluates multiple tagged datasets using a given evaluation function.
@@ -236,7 +241,7 @@ def cb_tagged_lm_evaluate(
 
     if loss_fn is None:
 
-        def loss_fn(model: ArrayLmHeadModel, batch: GrugLmExample) -> LossFnOutput:
+        def loss_fn(model: ArrayLmHeadModel, batch: LmEvalExample) -> LossFnOutput:
             return _default_lm_eval_loss_fn(
                 model,
                 batch,

--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -78,7 +78,7 @@ from levanter.callbacks import StepInfo
 from levanter.checkpoint import load_checkpoint
 from levanter.data import batched
 from levanter.data.loader import stack_batches
-from levanter.models.lm_model import ArrayLmHarnessModel, ArrayLmHeadModel, LmConfig, LmExample
+from levanter.models.lm_model import ArrayLmHarnessModel, LmConfig, LmExample
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import broadcast_shard, parameter_count, use_cpu_device
 from levanter.utils.py_utils import FailSafeJSONEncoder
@@ -245,7 +245,7 @@ class _LmEvalHarnessWorker:
         self._dummy_batch = _make_dummy_batch(EvalBatch, EvalPos)
 
         def _eval_loglikelihood(
-            model: ArrayLmHeadModel, packed_example: LmExample
+            model: ArrayLmHarnessModel, packed_example: LmExample
         ) -> tuple[NamedArray, NamedArray, NamedArray]:
             """
             Returns:

--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -26,7 +26,6 @@ import logging
 import random
 import tempfile
 import time
-import typing
 from dataclasses import dataclass
 from functools import cached_property
 from typing import Callable, Iterator, List, Optional, Tuple, TypeVar, Union
@@ -1465,7 +1464,7 @@ def run_eval_harness_main(config: EvalHarnessMainConfig):
                 )
             model = hax.shard(model, parameter_axis_mapping)
 
-        model = typing.cast(ArrayLmHarnessModel, inference_mode(model, True))
+        model = inference_mode(model, True)
 
         # Set up profiler configuration if enabled
         profiler_config = None

--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -79,7 +79,7 @@ from levanter.callbacks import StepInfo
 from levanter.checkpoint import load_checkpoint
 from levanter.data import batched
 from levanter.data.loader import stack_batches
-from levanter.models.lm_model import ArrayLmHeadModel, LmConfig, LmExample, LmHeadModel
+from levanter.models.lm_model import ArrayLmHarnessModel, ArrayLmHeadModel, LmConfig, LmExample
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import broadcast_shard, parameter_count, use_cpu_device
 from levanter.utils.py_utils import FailSafeJSONEncoder
@@ -1235,7 +1235,7 @@ class EvalHarnessMainConfig:
 
 def run_lm_eval_harness(
     config: LmEvalHarnessConfig,
-    model,
+    model: ArrayLmHarnessModel,
     tokenizer,
     EvalBatch: haliax.Axis | int,
     axis_resources: ResourceMapping,
@@ -1271,7 +1271,7 @@ def run_lm_eval_harness(
 
 def _actually_run_eval_harness(
     config: LmEvalHarnessConfig,
-    model: LmHeadModel,
+    model: ArrayLmHarnessModel,
     tasks_to_run: dict,
     tokenizer: HfTokenizer,
     EvalBatch: haliax.Axis | int,
@@ -1441,7 +1441,7 @@ def run_eval_harness_main(config: EvalHarnessMainConfig):
         if vocab_size != Vocab.size:
             logger.info(f"Rounding vocab size from {vocab_size} to {Vocab.size} for partitioning")
 
-        model: LmHeadModel
+        model: ArrayLmHarnessModel
 
         # initialize the model
         if config.checkpoint_is_hf:
@@ -1465,7 +1465,7 @@ def run_eval_harness_main(config: EvalHarnessMainConfig):
                 )
             model = hax.shard(model, parameter_axis_mapping)
 
-        model = typing.cast(LmHeadModel, inference_mode(model, True))
+        model = typing.cast(ArrayLmHarnessModel, inference_mode(model, True))
 
         # Set up profiler configuration if enabled
         profiler_config = None

--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -54,7 +54,6 @@ from levanter.inference.engine import Request as GenRequest
 from levanter.inference.jit_scheduler import SeqDecodingParams
 from levanter.inference.utils import INVALID
 from levanter.models.gpt2 import Gpt2Config
-from levanter.models.loss import fused_cross_entropy_loss_and_logsumexp_penalty
 from levanter.utils.background_iterable import BackgroundIterator
 from levanter.utils.hf_utils import HfTokenizer
 from levanter.utils.py_utils import set_global_rng_seeds
@@ -80,7 +79,7 @@ from levanter.callbacks import StepInfo
 from levanter.checkpoint import load_checkpoint
 from levanter.data import batched
 from levanter.data.loader import stack_batches
-from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
+from levanter.models.lm_model import ArrayLmHeadModel, LmConfig, LmExample, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import broadcast_shard, parameter_count, use_cpu_device
 from levanter.utils.py_utils import FailSafeJSONEncoder
@@ -247,7 +246,7 @@ class _LmEvalHarnessWorker:
         self._dummy_batch = _make_dummy_batch(EvalBatch, EvalPos)
 
         def _eval_loglikelihood(
-            model: LmHeadModel, packed_example: LmExample
+            model: ArrayLmHeadModel, packed_example: LmExample
         ) -> tuple[NamedArray, NamedArray, NamedArray]:
             """
             Returns:
@@ -259,30 +258,22 @@ class _LmEvalHarnessWorker:
             if self.mp is not None:
                 model = self.mp.cast_to_compute(model)
 
-            activations = model.activations(packed_example.tokens, attn_mask=packed_example.attn_mask)
-            if isinstance(activations, tuple):
-                activations, _ = activations
-
-            pred_embeddings = activations.astype(jnp.float32)
-            pred_lm_head = model.get_lm_head().astype(jnp.float32)
-            Pos = pred_embeddings.resolve_axis(self.EvalPos.name)
+            logits = model.logits_from_token_ids_array(
+                packed_example.tokens.array,
+                batch_axis=self.EvalBatch,
+            ).astype(jnp.float32)
+            Pos = packed_example.tokens.resolve_axis(self.EvalPos.name)
 
             target_y = hax.roll(packed_example.tokens, -1, Pos)
             not_last_mask = hax.logical_not(hax.nn.one_hot(-1, Pos, dtype=jnp.bool_))
             loss_weight = packed_example.loss_weight.astype(jnp.float32) * not_last_mask.astype(jnp.float32)
-
-            loss, pred_targets = fused_cross_entropy_loss_and_logsumexp_penalty(
-                pred_embeddings,
-                pred_lm_head,
-                Contract=model.Embed,
-                Label=model.Vocab,
-                target_y=target_y,
-                reduction=None,
-                weight=loss_weight,
-                logsumexp_weight=0.0,
-                return_argmax=True,
-                implementation="xla",
-            )
+            target_y_array = target_y.array.astype(jnp.int32)
+            log_probs = jax.nn.log_softmax(logits, axis=-1)
+            loss_array = -jnp.take_along_axis(log_probs, target_y_array[..., None], axis=-1).squeeze(-1)
+            loss_array = loss_array * loss_weight.array
+            pred_targets_array = jnp.argmax(logits, axis=-1).astype(target_y_array.dtype)
+            loss = hax.named(loss_array, packed_example.tokens.axes)
+            pred_targets = hax.named(pred_targets_array, packed_example.tokens.axes)
 
             # We need to compute losses and also whether or not the completion is correct
             # (i.e. the greedy prediction is the target)

--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -53,6 +53,7 @@ from levanter.inference.engine import Request as GenRequest
 from levanter.inference.jit_scheduler import SeqDecodingParams
 from levanter.inference.utils import INVALID
 from levanter.models.gpt2 import Gpt2Config
+from levanter.models.loss import fused_cross_entropy_loss_and_logsumexp_penalty
 from levanter.utils.background_iterable import BackgroundIterator
 from levanter.utils.hf_utils import HfTokenizer
 from levanter.utils.py_utils import set_global_rng_seeds
@@ -78,7 +79,7 @@ from levanter.callbacks import StepInfo
 from levanter.checkpoint import load_checkpoint
 from levanter.data import batched
 from levanter.data.loader import stack_batches
-from levanter.models.lm_model import ArrayLmHarnessModel, LmConfig, LmExample
+from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import broadcast_shard, parameter_count, use_cpu_device
 from levanter.utils.py_utils import FailSafeJSONEncoder
@@ -245,7 +246,7 @@ class _LmEvalHarnessWorker:
         self._dummy_batch = _make_dummy_batch(EvalBatch, EvalPos)
 
         def _eval_loglikelihood(
-            model: ArrayLmHarnessModel, packed_example: LmExample
+            model: LmHeadModel, packed_example: LmExample
         ) -> tuple[NamedArray, NamedArray, NamedArray]:
             """
             Returns:
@@ -257,22 +258,30 @@ class _LmEvalHarnessWorker:
             if self.mp is not None:
                 model = self.mp.cast_to_compute(model)
 
-            logits = model.logits_from_token_ids_array(
-                packed_example.tokens.array,
-                batch_axis=self.EvalBatch,
-            ).astype(jnp.float32)
-            Pos = packed_example.tokens.resolve_axis(self.EvalPos.name)
+            activations = model.activations(packed_example.tokens, attn_mask=packed_example.attn_mask)
+            if isinstance(activations, tuple):
+                activations, _ = activations
+
+            pred_embeddings = activations.astype(jnp.float32)
+            pred_lm_head = model.get_lm_head().astype(jnp.float32)
+            Pos = pred_embeddings.resolve_axis(self.EvalPos.name)
 
             target_y = hax.roll(packed_example.tokens, -1, Pos)
             not_last_mask = hax.logical_not(hax.nn.one_hot(-1, Pos, dtype=jnp.bool_))
             loss_weight = packed_example.loss_weight.astype(jnp.float32) * not_last_mask.astype(jnp.float32)
-            target_y_array = target_y.array.astype(jnp.int32)
-            log_probs = jax.nn.log_softmax(logits, axis=-1)
-            loss_array = -jnp.take_along_axis(log_probs, target_y_array[..., None], axis=-1).squeeze(-1)
-            loss_array = loss_array * loss_weight.array
-            pred_targets_array = jnp.argmax(logits, axis=-1).astype(target_y_array.dtype)
-            loss = hax.named(loss_array, packed_example.tokens.axes)
-            pred_targets = hax.named(pred_targets_array, packed_example.tokens.axes)
+
+            loss, pred_targets = fused_cross_entropy_loss_and_logsumexp_penalty(
+                pred_embeddings,
+                pred_lm_head,
+                Contract=model.Embed,
+                Label=model.Vocab,
+                target_y=target_y,
+                reduction=None,
+                weight=loss_weight,
+                logsumexp_weight=0.0,
+                return_argmax=True,
+                implementation="xla",
+            )
 
             # We need to compute losses and also whether or not the completion is correct
             # (i.e. the greedy prediction is the target)
@@ -1234,7 +1243,7 @@ class EvalHarnessMainConfig:
 
 def run_lm_eval_harness(
     config: LmEvalHarnessConfig,
-    model: ArrayLmHarnessModel,
+    model: LmHeadModel,
     tokenizer,
     EvalBatch: haliax.Axis | int,
     axis_resources: ResourceMapping,
@@ -1270,7 +1279,7 @@ def run_lm_eval_harness(
 
 def _actually_run_eval_harness(
     config: LmEvalHarnessConfig,
-    model: ArrayLmHarnessModel,
+    model: LmHeadModel,
     tasks_to_run: dict,
     tokenizer: HfTokenizer,
     EvalBatch: haliax.Axis | int,
@@ -1440,7 +1449,7 @@ def run_eval_harness_main(config: EvalHarnessMainConfig):
         if vocab_size != Vocab.size:
             logger.info(f"Rounding vocab size from {vocab_size} to {Vocab.size} for partitioning")
 
-        model: ArrayLmHarnessModel
+        model: LmHeadModel
 
         # initialize the model
         if config.checkpoint_is_hf:

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -21,7 +21,7 @@ from levanter.data.text import LmDataConfig
 from levanter.data.text.examples import GrugLmExample
 from levanter.eval import LossFnOutput, TaggedEvaluator, eval_model
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.models.lm_model import ArrayLmHeadModel, LmConfig, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
 from levanter.utils.partitioning import named_jit, round_axis_for_partitioning
@@ -90,7 +90,7 @@ def main(config: EvalLmConfig):
 
         mp: jmp.Policy = config.trainer.mp
 
-        def eval_loss_fn(model: LmHeadModel, batch: GrugLmExample) -> LossFnOutput:
+        def eval_loss_fn(model: ArrayLmHeadModel, batch: GrugLmExample) -> LossFnOutput:
             model = inference_mode(model, True)
             model = mp.cast_to_compute(model)
             with hax.axis_mapping(compute_axis_mapping):

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -56,7 +56,8 @@ def main(config: EvalLmConfig):
     tokenizer = config.data.the_tokenizer
 
     Batch = config.trainer.EvalBatch
-    Pos = config.model.max_Pos.resize(config.max_eval_length)
+    eval_length = min(config.max_eval_length, config.model.max_seq_len)
+    Pos = config.model.max_Pos.resize(eval_length)
 
     if config.eval_on_train:
         datasets_dict = config.data.train_grug_sets(seq_len=Pos.size, key=jax.random.PRNGKey(0))

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -20,6 +20,7 @@ from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, RepoRef
 from levanter.data import DataLoader
 from levanter.data.text import LmDataConfig
+from levanter.data.text.examples import GrugLmExample
 from levanter.eval import LossFnOutput, TaggedEvaluator, eval_model
 from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
@@ -29,6 +30,9 @@ from levanter.utils.tree_utils import inference_mode
 
 
 logger = logging.getLogger(__name__)
+
+
+LmEvalExample = LmExample | GrugLmExample
 
 
 @dataclass
@@ -56,11 +60,11 @@ def main(config: EvalLmConfig):
     Pos = config.model.max_Pos.resize(config.max_eval_length)
 
     if config.eval_on_train:
-        datasets_dict = config.data.train_sets(Pos, key=jax.random.PRNGKey(0))
+        datasets_dict = config.data.train_grug_sets(seq_len=Pos.size, key=jax.random.PRNGKey(0))
         # need tagged eval sets for the evaluator
         datasets = [(ds, [name]) for name, ds in datasets_dict.items()]
     else:
-        datasets = config.data.tagged_eval_sets(Pos)
+        datasets = config.data.tagged_eval_grug_sets(seq_len=Pos.size)
 
     if not datasets:
         raise ValueError("no dataset found!")
@@ -89,7 +93,7 @@ def main(config: EvalLmConfig):
 
         mp: jmp.Policy = config.trainer.mp
 
-        def eval_loss_fn(model: LmHeadModel, batch: LmExample) -> LossFnOutput:
+        def eval_loss_fn(model: LmHeadModel, batch: LmEvalExample) -> LossFnOutput:
             model = inference_mode(model, True)
             model = mp.cast_to_compute(model)
             with hax.axis_mapping(compute_axis_mapping):
@@ -99,8 +103,13 @@ def main(config: EvalLmConfig):
                     reduction=None,
                     reduction_axis=(),
                 )
-            per_pos_weight = batch.loss_weight.array
-            per_pos_token_id = jnp.roll(batch.tokens.array, -1, axis=-1)
+
+            if isinstance(batch, LmExample):
+                per_pos_weight = batch.loss_weight.array
+                per_pos_token_id = jnp.roll(batch.tokens.array, -1, axis=-1)
+            else:
+                per_pos_weight = batch.loss_weight
+                per_pos_token_id = jnp.roll(batch.tokens, -1, axis=-1)
             return per_pos_loss, per_pos_weight, per_pos_token_id
 
         evaluator = TaggedEvaluator(

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -10,10 +10,8 @@ import jax
 import jax.numpy as jnp
 import jmp
 
-import haliax
 import haliax as hax
 from haliax import Axis
-from haliax.partitioning import round_axis_for_partitioning
 
 import levanter
 from levanter.checkpoint import load_checkpoint
@@ -26,6 +24,7 @@ from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
+from levanter.utils.partitioning import named_jit, round_axis_for_partitioning
 from levanter.utils.tree_utils import inference_mode
 
 
@@ -121,19 +120,28 @@ def main(config: EvalLmConfig):
             max_examples_per_dataset=max_examples,
         )
 
-        @hax.named_jit(axis_resources=compute_axis_mapping)
+        @named_jit(axis_resources=compute_axis_mapping)
         def compute_loss(model: LmHeadModel, example: LmExample):
             model = inference_mode(model, True)
             model = mp.cast_to_compute(model)
             return model.compute_next_token_loss(example, key=None)
 
-        @hax.named_jit(axis_resources=compute_axis_mapping)
-        def compute_logits(model: LmHeadModel, example: LmExample):
+        def compute_logits(model: LmHeadModel, example: LmEvalExample):
             model = mp.cast_to_compute(model)
-            activations = model.activations(example.tokens, key=None, attn_mask=example.attn_mask)
-            head = model.get_lm_head()
-            logits = hax.dot(activations, head, axis=model.Embed)
-            return logits
+            with hax.axis_mapping(compute_axis_mapping):
+                if isinstance(example, LmExample):
+                    activations = model.activations(example.tokens, key=None, attn_mask=example.attn_mask)
+                    head = model.get_lm_head()
+                    return hax.dot(activations, head, axis=model.Embed)
+
+                logits_array = model.logits_from_token_ids_array(example.tokens, batch_axis=Batch, key=None)
+                if logits_array.ndim == 2:
+                    return hax.named(logits_array, (Pos.resize(logits_array.shape[0]), model.Vocab))
+                if logits_array.ndim == 3:
+                    batch_axis = Axis(Batch.name, logits_array.shape[0])
+                    pos_axis = Pos.resize(logits_array.shape[1])
+                    return hax.named(logits_array, (batch_axis, pos_axis, model.Vocab))
+                raise ValueError(f"Unexpected logits rank for analysis callbacks: {logits_array.ndim}")
 
         # initialize the model
         if config.checkpoint_path is not None:
@@ -169,7 +177,7 @@ def main(config: EvalLmConfig):
 
         if config.log_entropy:
             logger.info("Computing entropy...")
-            for name, dataset in config.data.validation_sets(Pos).items():
+            for name, dataset in config.data.validation_grug_sets(seq_len=Pos.size).items():
                 if config.trainer.max_eval_batches is not None:
                     dataset = dataset.take(config.trainer.max_eval_batches * config.trainer.eval_batch_size)
                 loader = DataLoader(
@@ -191,7 +199,7 @@ def main(config: EvalLmConfig):
 
         if config.log_top2_gap:
             logger.info("Computing top2_gap...")
-            for name, dataset in config.data.validation_sets(Pos).items():
+            for name, dataset in config.data.validation_grug_sets(seq_len=Pos.size).items():
                 if config.trainer.max_eval_batches is not None:
                     dataset = dataset.take(config.trainer.max_eval_batches * config.trainer.eval_batch_size)
                 loader = DataLoader(
@@ -213,7 +221,7 @@ def main(config: EvalLmConfig):
 
         if config.log_param_stats:
             logger.info("Computing param stats...")
-            log_dict = haliax.named_jit(levanter.analysis.summary_statistics_for_tree)(
+            log_dict = named_jit(levanter.analysis.summary_statistics_for_tree, axis_resources=compute_axis_mapping)(
                 "params", model, split_scan_layers=True, include_histogram=True
             )
 

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -7,7 +7,6 @@ from typing import Optional
 
 import equinox as eqx
 import jax
-import jax.numpy as jnp
 import jmp
 
 import haliax as hax
@@ -18,7 +17,12 @@ from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, RepoRef
 from levanter.data import DataLoader
 from levanter.data.text import LmDataConfig
-from levanter.data.text.examples import GrugLmExample
+from levanter.data.text.examples import (
+    LmLikeExample,
+    loss_weight_array_from_lm_example,
+    target_token_ids_array_from_lm_example,
+    token_ids_array_from_lm_example,
+)
 from levanter.eval import LossFnOutput, TaggedEvaluator, eval_model
 from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import ArrayLmHeadModel, LmConfig
@@ -31,6 +35,7 @@ from levanter.utils.tree_utils import inference_mode
 logger = logging.getLogger(__name__)
 
 
+LmEvalExample = LmLikeExample
 @dataclass
 class EvalLmConfig:
 
@@ -90,7 +95,7 @@ def main(config: EvalLmConfig):
 
         mp: jmp.Policy = config.trainer.mp
 
-        def eval_loss_fn(model: ArrayLmHeadModel, batch: GrugLmExample) -> LossFnOutput:
+        def eval_loss_fn(model: ArrayLmHeadModel, batch: LmEvalExample) -> LossFnOutput:
             model = inference_mode(model, True)
             model = mp.cast_to_compute(model)
             with hax.axis_mapping(compute_axis_mapping):
@@ -100,8 +105,8 @@ def main(config: EvalLmConfig):
                     reduction=None,
                     reduction_axis=(),
                 )
-            per_pos_weight = batch.loss_weight
-            per_pos_token_id = jnp.roll(batch.tokens, -1, axis=-1)
+            per_pos_weight = loss_weight_array_from_lm_example(batch)
+            per_pos_token_id = target_token_ids_array_from_lm_example(batch)
             return per_pos_loss, per_pos_weight, per_pos_token_id
 
         evaluator = TaggedEvaluator(
@@ -113,10 +118,11 @@ def main(config: EvalLmConfig):
             max_examples_per_dataset=max_examples,
         )
 
-        def compute_logits(model: ArrayLmHeadModel, example: GrugLmExample):
+        def compute_logits(model: ArrayLmHeadModel, example: LmEvalExample):
             model = mp.cast_to_compute(model)
             with hax.axis_mapping(compute_axis_mapping):
-                logits_array = model.logits_from_token_ids_array(example.tokens, batch_axis=Batch, key=None)
+                token_ids = token_ids_array_from_lm_example(example)
+                logits_array = model.logits_from_token_ids_array(token_ids, batch_axis=Batch, key=None)
                 if logits_array.ndim == 2:
                     return hax.named(logits_array, (Pos.resize(logits_array.shape[0]), Vocab))
                 if logits_array.ndim == 3:

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -120,16 +120,8 @@ def main(config: EvalLmConfig):
 
         def compute_logits(model: ArrayLmHeadModel, example: LmEvalExample):
             model = mp.cast_to_compute(model)
-            with hax.axis_mapping(compute_axis_mapping):
-                token_ids = token_ids_array_from_lm_example(example)
-                logits_array = model.logits_from_token_ids_array(token_ids, batch_axis=Batch, key=None)
-                if logits_array.ndim == 2:
-                    return hax.named(logits_array, (Pos.resize(logits_array.shape[0]), Vocab))
-                if logits_array.ndim == 3:
-                    batch_axis = Axis(Batch.name, logits_array.shape[0])
-                    pos_axis = Pos.resize(logits_array.shape[1])
-                    return hax.named(logits_array, (batch_axis, pos_axis, Vocab))
-                raise ValueError(f"Unexpected logits rank for analysis callbacks: {logits_array.ndim}")
+            token_ids = token_ids_array_from_lm_example(example)
+            return model.logits_from_token_ids_array(token_ids, batch_axis=Batch, key=None)
 
         # initialize the model
         if config.checkpoint_path is not None:

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -21,7 +21,7 @@ from levanter.data.text import LmDataConfig
 from levanter.data.text.examples import GrugLmExample
 from levanter.eval import LossFnOutput, TaggedEvaluator, eval_model
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import ArrayLmHeadModel, LmConfig, LmHeadModel
+from levanter.models.lm_model import ArrayLmHeadModel, LmConfig
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
 from levanter.utils.partitioning import named_jit, round_axis_for_partitioning
@@ -113,16 +113,16 @@ def main(config: EvalLmConfig):
             max_examples_per_dataset=max_examples,
         )
 
-        def compute_logits(model: LmHeadModel, example: GrugLmExample):
+        def compute_logits(model: ArrayLmHeadModel, example: GrugLmExample):
             model = mp.cast_to_compute(model)
             with hax.axis_mapping(compute_axis_mapping):
                 logits_array = model.logits_from_token_ids_array(example.tokens, batch_axis=Batch, key=None)
                 if logits_array.ndim == 2:
-                    return hax.named(logits_array, (Pos.resize(logits_array.shape[0]), model.Vocab))
+                    return hax.named(logits_array, (Pos.resize(logits_array.shape[0]), Vocab))
                 if logits_array.ndim == 3:
                     batch_axis = Axis(Batch.name, logits_array.shape[0])
                     pos_axis = Pos.resize(logits_array.shape[1])
-                    return hax.named(logits_array, (batch_axis, pos_axis, model.Vocab))
+                    return hax.named(logits_array, (batch_axis, pos_axis, Vocab))
                 raise ValueError(f"Unexpected logits rank for analysis callbacks: {logits_array.ndim}")
 
         # initialize the model

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -21,7 +21,7 @@ from levanter.data.text import LmDataConfig
 from levanter.data.text.examples import GrugLmExample
 from levanter.eval import LossFnOutput, TaggedEvaluator, eval_model
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
+from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
 from levanter.utils.partitioning import named_jit, round_axis_for_partitioning
@@ -29,9 +29,6 @@ from levanter.utils.tree_utils import inference_mode
 
 
 logger = logging.getLogger(__name__)
-
-
-LmEvalExample = LmExample | GrugLmExample
 
 
 @dataclass
@@ -93,7 +90,7 @@ def main(config: EvalLmConfig):
 
         mp: jmp.Policy = config.trainer.mp
 
-        def eval_loss_fn(model: LmHeadModel, batch: LmEvalExample) -> LossFnOutput:
+        def eval_loss_fn(model: LmHeadModel, batch: GrugLmExample) -> LossFnOutput:
             model = inference_mode(model, True)
             model = mp.cast_to_compute(model)
             with hax.axis_mapping(compute_axis_mapping):
@@ -103,13 +100,8 @@ def main(config: EvalLmConfig):
                     reduction=None,
                     reduction_axis=(),
                 )
-
-            if isinstance(batch, LmExample):
-                per_pos_weight = batch.loss_weight.array
-                per_pos_token_id = jnp.roll(batch.tokens.array, -1, axis=-1)
-            else:
-                per_pos_weight = batch.loss_weight
-                per_pos_token_id = jnp.roll(batch.tokens, -1, axis=-1)
+            per_pos_weight = batch.loss_weight
+            per_pos_token_id = jnp.roll(batch.tokens, -1, axis=-1)
             return per_pos_loss, per_pos_weight, per_pos_token_id
 
         evaluator = TaggedEvaluator(
@@ -121,20 +113,9 @@ def main(config: EvalLmConfig):
             max_examples_per_dataset=max_examples,
         )
 
-        @named_jit(axis_resources=compute_axis_mapping)
-        def compute_loss(model: LmHeadModel, example: LmExample):
-            model = inference_mode(model, True)
-            model = mp.cast_to_compute(model)
-            return model.compute_next_token_loss(example, key=None)
-
-        def compute_logits(model: LmHeadModel, example: LmEvalExample):
+        def compute_logits(model: LmHeadModel, example: GrugLmExample):
             model = mp.cast_to_compute(model)
             with hax.axis_mapping(compute_axis_mapping):
-                if isinstance(example, LmExample):
-                    activations = model.activations(example.tokens, key=None, attn_mask=example.attn_mask)
-                    head = model.get_lm_head()
-                    return hax.dot(activations, head, axis=model.Embed)
-
                 logits_array = model.logits_from_token_ids_array(example.tokens, batch_axis=Batch, key=None)
                 if logits_array.ndim == 2:
                     return hax.named(logits_array, (Pos.resize(logits_array.shape[0]), model.Vocab))

--- a/lib/levanter/src/levanter/main/lora_lm.py
+++ b/lib/levanter/src/levanter/main/lora_lm.py
@@ -15,6 +15,7 @@ import levanter.eval
 from levanter import callbacks
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.data.text import LmDataConfig
+from levanter.data.text.examples import GrugLmExample
 from levanter.lora import (
     LoraConfig,
     lora_trainable_params_filter,
@@ -22,7 +23,7 @@ from levanter.lora import (
     save_merged_hf_checkpoint_callback,
     save_peft_checkpoint_callback,
 )
-from levanter.models.lm_model import LmExample, LmHeadModel
+from levanter.models.lm_model import LmHeadModel
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
 from levanter.utils.jax_utils import parameter_count
@@ -73,26 +74,21 @@ def main(config: LoraLmConfig):
 
     optimizer = config.optimizer.build(config.trainer.num_train_steps)
 
-    def loss_fn(model: LmHeadModel, example: LmExample, *, key=None):
-        return model.compute_next_token_loss(example, key=key, axis_mapping=config.trainer.compute_axis_mapping)
+    def loss_fn(model: LmHeadModel, example: GrugLmExample, *, key=None):
+        return model.compute_next_token_loss_array(example, batch_axis=config.trainer.batch_axis_name, key=key)
 
     with Trainer(config.trainer, optimizer, loss_fn=loss_fn) as trainer:  # type: ignore[arg-type]
         # how we shard parameters across devices
         parameter_axis_mapping = config.trainer.parameter_axis_mapping
 
-        train_dataset = config.data.train_set(
-            Pos,
+        train_dataset = config.data.train_grug_set(
+            seq_len=Pos.size,
             batch_schedule=config.trainer.batch_schedule,
             key=data_key,
         )
 
         if train_dataset is None:
             raise ValueError("No training set!")
-
-        eval_datasets = config.data.validation_sets(Pos)
-
-        if len(eval_datasets) == 0:
-            logger.warning("No evaluation datasets provided.")
 
         train_loader = trainer.data_loader(train_dataset, Batch)
 
@@ -132,7 +128,7 @@ def main(config: LoraLmConfig):
         if max_eval_examples_per_ds is not None:
             max_eval_examples_per_ds *= config.trainer.eval_batch_size
 
-        tagged_eval_datasets = config.data.tagged_eval_sets(Pos)
+        tagged_eval_datasets = config.data.tagged_eval_grug_sets(seq_len=Pos.size)
 
         if len(tagged_eval_datasets) == 0:
             logger.warning("No evaluation datasets provided.")

--- a/lib/levanter/src/levanter/main/lora_lm.py
+++ b/lib/levanter/src/levanter/main/lora_lm.py
@@ -23,7 +23,7 @@ from levanter.lora import (
     save_merged_hf_checkpoint_callback,
     save_peft_checkpoint_callback,
 )
-from levanter.models.lm_model import LmHeadModel
+from levanter.models.lm_model import ArrayLmHeadModel
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
 from levanter.utils.jax_utils import parameter_count
@@ -74,7 +74,7 @@ def main(config: LoraLmConfig):
 
     optimizer = config.optimizer.build(config.trainer.num_train_steps)
 
-    def loss_fn(model: LmHeadModel, example: GrugLmExample, *, key=None):
+    def loss_fn(model: ArrayLmHeadModel, example: GrugLmExample, *, key=None):
         return model.compute_next_token_loss_array(example, batch_axis=config.trainer.batch_axis_name, key=key)
 
     with Trainer(config.trainer, optimizer, loss_fn=loss_fn) as trainer:  # type: ignore[arg-type]

--- a/lib/levanter/src/levanter/main/train_dpo.py
+++ b/lib/levanter/src/levanter/main/train_dpo.py
@@ -69,9 +69,9 @@ def dpo_loss_from_logps(
 def _logp_sum(model: LmHeadModel, example, *, key=None, axis_mapping=None) -> jnp.ndarray:
     if axis_mapping is not None:
         with hax.axis_mapping(axis_mapping):
-            nll = model.compute_next_token_loss_array(example, reduction=hax.sum, reduction_axis="position", key=key)
+            nll = model.compute_next_token_loss_array(example, reduction="sum", reduction_axis="position", key=key)
     else:
-        nll = model.compute_next_token_loss_array(example, reduction=hax.sum, reduction_axis="position", key=key)
+        nll = model.compute_next_token_loss_array(example, reduction="sum", reduction_axis="position", key=key)
     return -nll
 
 

--- a/lib/levanter/src/levanter/main/train_dpo.py
+++ b/lib/levanter/src/levanter/main/train_dpo.py
@@ -81,8 +81,14 @@ def _logp_sum(model: ArrayLmHeadModel, example, *, key=None, axis_mapping=None):
     else:
         nll = model.compute_next_token_loss_array(example, reduction="sum", reduction_axis="position", key=key)
 
-    if isinstance(example, LmExample) and not isinstance(nll, hax.NamedArray):
-        nll = hax.named(jnp.asarray(nll), ())
+    if isinstance(example, LmExample):
+        reduced_axes = tuple(ax for ax in example.tokens.axes if ax.name != "position")
+        if len(reduced_axes) == 0:
+            nll = hax.named(jnp.asarray(nll), ())
+        elif len(reduced_axes) == 1:
+            nll = hax.named(jnp.asarray(nll), reduced_axes[0])
+        else:
+            nll = hax.named(jnp.asarray(nll), reduced_axes)
 
     return -nll
 

--- a/lib/levanter/src/levanter/main/train_dpo.py
+++ b/lib/levanter/src/levanter/main/train_dpo.py
@@ -28,7 +28,7 @@ from levanter.data.text import (
     dataset_for_preference_format,
 )
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.models.lm_model import ArrayLmHeadModel, LmConfig, LmHeadModel
 from levanter.metrics import Metric, ReductionType
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
@@ -66,7 +66,7 @@ def dpo_loss_from_logps(
     return loss, metrics
 
 
-def _logp_sum(model: LmHeadModel, example, *, key=None, axis_mapping=None) -> jnp.ndarray:
+def _logp_sum(model: ArrayLmHeadModel, example, *, key=None, axis_mapping=None) -> jnp.ndarray:
     if axis_mapping is not None:
         with hax.axis_mapping(axis_mapping):
             nll = model.compute_next_token_loss_array(example, reduction="sum", reduction_axis="position", key=key)

--- a/lib/levanter/src/levanter/main/train_dpo.py
+++ b/lib/levanter/src/levanter/main/train_dpo.py
@@ -28,7 +28,7 @@ from levanter.data.text import (
     dataset_for_preference_format,
 )
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import ArrayLmHeadModel, LmConfig, LmHeadModel
+from levanter.models.lm_model import ArrayLmHeadModel, LmConfig, LmExample, LmHeadModel
 from levanter.metrics import Metric, ReductionType
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
@@ -50,28 +50,40 @@ def _policy_model_for_hf_save(model: DpoModel | LmHeadModel) -> LmHeadModel:
 
 
 def dpo_loss_from_logps(
-    delta_pi: jnp.ndarray,
-    delta_ref: jnp.ndarray,
+    delta_pi: jnp.ndarray | hax.NamedArray,
+    delta_ref: jnp.ndarray | hax.NamedArray,
     *,
     beta: float,
 ) -> tuple[jnp.ndarray, dict[str, Metric]]:
-    logits = (delta_pi - delta_ref) * beta
+    delta_pi_array = _as_array(delta_pi)
+    delta_ref_array = _as_array(delta_ref)
+    logits = (delta_pi_array - delta_ref_array) * beta
     loss = jnp.mean(jax.nn.softplus(-logits))
     metrics = {
         "dpo_loss": Metric.from_value(loss, ReductionType.MEAN),
-        "dpo_margin_policy": Metric.from_value(jnp.mean(delta_pi), ReductionType.MEAN),
-        "dpo_margin_ref": Metric.from_value(jnp.mean(delta_ref), ReductionType.MEAN),
+        "dpo_margin_policy": Metric.from_value(jnp.mean(delta_pi_array), ReductionType.MEAN),
+        "dpo_margin_ref": Metric.from_value(jnp.mean(delta_ref_array), ReductionType.MEAN),
         "dpo_accuracy": Metric.from_value(jnp.mean(logits > 0), ReductionType.MEAN),
     }
     return loss, metrics
 
 
-def _logp_sum(model: ArrayLmHeadModel, example, *, key=None, axis_mapping=None) -> jnp.ndarray:
+def _as_array(value: jnp.ndarray | hax.NamedArray) -> jnp.ndarray:
+    if isinstance(value, hax.NamedArray):
+        return value.array
+    return jnp.asarray(value)
+
+
+def _logp_sum(model: ArrayLmHeadModel, example, *, key=None, axis_mapping=None):
     if axis_mapping is not None:
         with hax.axis_mapping(axis_mapping):
             nll = model.compute_next_token_loss_array(example, reduction="sum", reduction_axis="position", key=key)
     else:
         nll = model.compute_next_token_loss_array(example, reduction="sum", reduction_axis="position", key=key)
+
+    if isinstance(example, LmExample) and not isinstance(nll, hax.NamedArray):
+        nll = hax.named(jnp.asarray(nll), ())
+
     return -nll
 
 

--- a/lib/levanter/src/levanter/main/train_dpo.py
+++ b/lib/levanter/src/levanter/main/train_dpo.py
@@ -9,6 +9,7 @@ from typing import Any, Optional, Union, cast
 
 import equinox as eqx
 import haliax as hax
+import jax
 import jax.numpy as jnp
 import jax.random as jrandom
 from haliax.partitioning import named_jit, round_axis_for_partitioning
@@ -49,26 +50,28 @@ def _policy_model_for_hf_save(model: DpoModel | LmHeadModel) -> LmHeadModel:
 
 
 def dpo_loss_from_logps(
-    delta_pi: hax.NamedArray,
-    delta_ref: hax.NamedArray,
+    delta_pi: jnp.ndarray,
+    delta_ref: jnp.ndarray,
     *,
     beta: float,
 ) -> tuple[jnp.ndarray, dict[str, Metric]]:
     logits = (delta_pi - delta_ref) * beta
-    loss = hax.mean(hax.nn.softplus(-logits)).scalar()
+    loss = jnp.mean(jax.nn.softplus(-logits))
     metrics = {
         "dpo_loss": Metric.from_value(loss, ReductionType.MEAN),
-        "dpo_margin_policy": Metric.from_value(hax.mean(delta_pi).scalar(), ReductionType.MEAN),
-        "dpo_margin_ref": Metric.from_value(hax.mean(delta_ref).scalar(), ReductionType.MEAN),
-        "dpo_accuracy": Metric.from_value(hax.mean(logits > 0).scalar(), ReductionType.MEAN),
+        "dpo_margin_policy": Metric.from_value(jnp.mean(delta_pi), ReductionType.MEAN),
+        "dpo_margin_ref": Metric.from_value(jnp.mean(delta_ref), ReductionType.MEAN),
+        "dpo_accuracy": Metric.from_value(jnp.mean(logits > 0), ReductionType.MEAN),
     }
     return loss, metrics
 
 
-def _logp_sum(model: LmHeadModel, example, *, key=None, axis_mapping=None) -> hax.NamedArray:
-    nll = model.compute_next_token_loss(
-        example, reduction=hax.sum, reduction_axis="position", key=key, axis_mapping=axis_mapping
-    )
+def _logp_sum(model: LmHeadModel, example, *, key=None, axis_mapping=None) -> jnp.ndarray:
+    if axis_mapping is not None:
+        with hax.axis_mapping(axis_mapping):
+            nll = model.compute_next_token_loss_array(example, reduction=hax.sum, reduction_axis="position", key=key)
+    else:
+        nll = model.compute_next_token_loss_array(example, reduction=hax.sum, reduction_axis="position", key=key)
     return -nll
 
 
@@ -292,8 +295,8 @@ def main(config: TrainDpoConfig):
         loss, metrics = dpo_loss_from_logps(delta_pi, delta_ref, beta=config.beta)
         chosen_reward = (logp_pi_chosen - logp_ref_chosen) * config.beta
         rejected_reward = (logp_pi_rejected - logp_ref_rejected) * config.beta
-        metrics["dpo_chosen_reward"] = Metric.from_value(hax.mean(chosen_reward).scalar(), ReductionType.MEAN)
-        metrics["dpo_rejected_reward"] = Metric.from_value(hax.mean(rejected_reward).scalar(), ReductionType.MEAN)
+        metrics["dpo_chosen_reward"] = Metric.from_value(jnp.mean(chosen_reward), ReductionType.MEAN)
+        metrics["dpo_rejected_reward"] = Metric.from_value(jnp.mean(rejected_reward), ReductionType.MEAN)
         return loss, metrics
 
     with Trainer(config.trainer, optimizer, loss_function) as trainer:

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -27,7 +27,7 @@ from levanter.data.mixture import MixtureDataset
 from levanter.data.text import LmDataConfig
 from levanter.eval_harness import LmEvalHarnessConfig
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
+from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
 from levanter.utils.jax_utils import parameter_count
@@ -287,13 +287,8 @@ def main(config: TrainLmConfig):
             )
 
         @named_jit(axis_resources=compute_axis_mapping)
-        def compute_logits(model: LmHeadModel, example: LmExample | GrugLmExample):
+        def compute_logits(model: LmHeadModel, example: GrugLmExample):
             model = trainer.mp.cast_to_compute(model)
-            if isinstance(example, LmExample):
-                activations = model.activations(example.tokens, key=None, attn_mask=example.attn_mask)
-                head = model.get_lm_head()
-                return hax.dot(activations, head, axis=model.Embed)
-
             logits_array = model.logits_from_token_ids_array(example.tokens, batch_axis=EvalBatch, key=None)
             if logits_array.ndim == 2:
                 return hax.named(logits_array, (Pos.resize(logits_array.shape[0]), model.Vocab))

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -26,7 +26,7 @@ from levanter.data.text import LmDataConfig
 from levanter.data.text.examples import GrugLmExample, LmLikeExample, token_ids_array_from_lm_example
 from levanter.eval_harness import LmEvalHarnessConfig
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import ArrayLmHeadModel, LmConfig, LmHeadModel
+from levanter.models.lm_model import ArrayLmHeadModel, LmConfig
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
 from levanter.utils.jax_utils import parameter_count

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -287,15 +287,24 @@ def main(config: TrainLmConfig):
             )
 
         @named_jit(axis_resources=compute_axis_mapping)
-        def compute_logits(model: LmHeadModel, example: LmExample):
+        def compute_logits(model: LmHeadModel, example: LmExample | GrugLmExample):
             model = trainer.mp.cast_to_compute(model)
-            activations = model.activations(example.tokens, key=None, attn_mask=example.attn_mask)
-            head = model.get_lm_head()
-            logits = hax.dot(activations, head, axis=model.Embed)
-            return logits
+            if isinstance(example, LmExample):
+                activations = model.activations(example.tokens, key=None, attn_mask=example.attn_mask)
+                head = model.get_lm_head()
+                return hax.dot(activations, head, axis=model.Embed)
+
+            logits_array = model.logits_from_token_ids_array(example.tokens, batch_axis=EvalBatch, key=None)
+            if logits_array.ndim == 2:
+                return hax.named(logits_array, (Pos.resize(logits_array.shape[0]), model.Vocab))
+            if logits_array.ndim == 3:
+                batch_axis = Axis(EvalBatch.name, logits_array.shape[0])
+                pos_axis = Pos.resize(logits_array.shape[1])
+                return hax.named(logits_array, (batch_axis, pos_axis, model.Vocab))
+            raise ValueError(f"Unexpected logits rank for analysis callbacks: {logits_array.ndim}")
 
         if config.log_entropy:
-            for name, dataset in config.data.validation_sets(Pos).items():
+            for name, dataset in config.data.validation_grug_sets(seq_len=Pos.size).items():
                 trainer.add_hook(
                     levanter.analysis.cb_compute_entropies(
                         compute_logits,

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -287,15 +287,15 @@ def main(config: TrainLmConfig):
             )
 
         @named_jit(axis_resources=compute_axis_mapping)
-        def compute_logits(model: LmHeadModel, example: GrugLmExample):
+        def compute_logits(model: ArrayLmHeadModel, example: GrugLmExample):
             model = trainer.mp.cast_to_compute(model)
             logits_array = model.logits_from_token_ids_array(example.tokens, batch_axis=EvalBatch, key=None)
             if logits_array.ndim == 2:
-                return hax.named(logits_array, (Pos.resize(logits_array.shape[0]), model.Vocab))
+                return hax.named(logits_array, (Pos.resize(logits_array.shape[0]), Vocab))
             if logits_array.ndim == 3:
                 batch_axis = Axis(EvalBatch.name, logits_array.shape[0])
                 pos_axis = Pos.resize(logits_array.shape[1])
-                return hax.named(logits_array, (batch_axis, pos_axis, model.Vocab))
+                return hax.named(logits_array, (batch_axis, pos_axis, Vocab))
             raise ValueError(f"Unexpected logits rank for analysis callbacks: {logits_array.ndim}")
 
         if config.log_entropy:

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -22,11 +22,12 @@ from levanter import callbacks
 from levanter.callbacks.tensorstore_callbacks import install_tensorstore_metrics_hook_if_enabled
 from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCompatConfig, save_hf_checkpoint_callback
+from levanter.data.text.examples import GrugLmExample
 from levanter.data.mixture import MixtureDataset
 from levanter.data.text import LmDataConfig
 from levanter.eval_harness import LmEvalHarnessConfig
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
+from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
 from levanter.utils.jax_utils import parameter_count
@@ -111,12 +112,12 @@ def main(config: TrainLmConfig):
     levanter.initialize(config)
     optimizer = config.optimizer.build(config.trainer.num_train_steps)
 
-    def loss_function(model: LmHeadModel, example: LmExample, *, key=None):
-        return model.compute_next_token_loss(
+    def loss_function(model: LmHeadModel, example: GrugLmExample, *, key=None):
+        return model.compute_next_token_loss_array(
             example,
+            batch_axis=config.trainer.batch_axis_name,
             key=key,
             logsumexp_weight=config.z_loss_weight,
-            axis_mapping=config.trainer.compute_axis_mapping,
         )
 
     # Using the trainer as a context manager does 3 things:
@@ -165,15 +166,15 @@ def main(config: TrainLmConfig):
             logger.info(f"Rounding vocab size from {vocab_size} to {Vocab.size} for partitioning")
 
         # Get the training dataset
-        train_dataset = config.data.train_set(
-            Pos,
-            config.trainer.batch_schedule,
+        train_dataset = config.data.train_grug_set(
+            seq_len=Pos.size,
+            batch_schedule=config.trainer.batch_schedule,
             key=data_key,
         )
         install_tensorstore_metrics_hook_if_enabled(trainer)
 
         # Get the tagged evaluation datasets
-        tagged_eval_datasets = config.data.tagged_eval_sets(Pos)
+        tagged_eval_datasets = config.data.tagged_eval_grug_sets(seq_len=Pos.size)
 
         state = trainer.initial_state(training_key, model_init=lambda: config.model.build(Vocab, key=model_key))
 

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -8,7 +8,6 @@ import os
 from dataclasses import dataclass, field
 from typing import Optional
 
-import haliax as hax
 import jax.numpy as jnp
 import jax.random as jrandom
 from haliax import Axis
@@ -290,14 +289,7 @@ def main(config: TrainLmConfig):
         def compute_logits(model: ArrayLmHeadModel, example: LmLikeExample):
             model = trainer.mp.cast_to_compute(model)
             token_ids = token_ids_array_from_lm_example(example)
-            logits_array = model.logits_from_token_ids_array(token_ids, batch_axis=EvalBatch, key=None)
-            if logits_array.ndim == 2:
-                return hax.named(logits_array, (Pos.resize(logits_array.shape[0]), Vocab))
-            if logits_array.ndim == 3:
-                batch_axis = Axis(EvalBatch.name, logits_array.shape[0])
-                pos_axis = Pos.resize(logits_array.shape[1])
-                return hax.named(logits_array, (batch_axis, pos_axis, Vocab))
-            raise ValueError(f"Unexpected logits rank for analysis callbacks: {logits_array.ndim}")
+            return model.logits_from_token_ids_array(token_ids, batch_axis=EvalBatch, key=None)
 
         if config.log_entropy:
             for name, dataset in config.data.validation_grug_sets(seq_len=Pos.size).items():

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -22,9 +22,9 @@ from levanter import callbacks
 from levanter.callbacks.tensorstore_callbacks import install_tensorstore_metrics_hook_if_enabled
 from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCompatConfig, save_hf_checkpoint_callback
-from levanter.data.text.examples import GrugLmExample
 from levanter.data.mixture import MixtureDataset
 from levanter.data.text import LmDataConfig
+from levanter.data.text.examples import GrugLmExample, LmLikeExample, token_ids_array_from_lm_example
 from levanter.eval_harness import LmEvalHarnessConfig
 from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import ArrayLmHeadModel, LmConfig, LmHeadModel
@@ -287,9 +287,10 @@ def main(config: TrainLmConfig):
             )
 
         @named_jit(axis_resources=compute_axis_mapping)
-        def compute_logits(model: ArrayLmHeadModel, example: GrugLmExample):
+        def compute_logits(model: ArrayLmHeadModel, example: LmLikeExample):
             model = trainer.mp.cast_to_compute(model)
-            logits_array = model.logits_from_token_ids_array(example.tokens, batch_axis=EvalBatch, key=None)
+            token_ids = token_ids_array_from_lm_example(example)
+            logits_array = model.logits_from_token_ids_array(token_ids, batch_axis=EvalBatch, key=None)
             if logits_array.ndim == 2:
                 return hax.named(logits_array, (Pos.resize(logits_array.shape[0]), Vocab))
             if logits_array.ndim == 3:

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -27,7 +27,7 @@ from levanter.data.mixture import MixtureDataset
 from levanter.data.text import LmDataConfig
 from levanter.eval_harness import LmEvalHarnessConfig
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
 from levanter.utils.jax_utils import parameter_count

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -27,7 +27,7 @@ from levanter.data.mixture import MixtureDataset
 from levanter.data.text import LmDataConfig
 from levanter.eval_harness import LmEvalHarnessConfig
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.models.lm_model import ArrayLmHeadModel, LmConfig, LmHeadModel
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
 from levanter.utils.jax_utils import parameter_count
@@ -112,7 +112,7 @@ def main(config: TrainLmConfig):
     levanter.initialize(config)
     optimizer = config.optimizer.build(config.trainer.num_train_steps)
 
-    def loss_function(model: LmHeadModel, example: GrugLmExample, *, key=None):
+    def loss_function(model: ArrayLmHeadModel, example: GrugLmExample, *, key=None):
         return model.compute_next_token_loss_array(
             example,
             batch_axis=config.trainer.batch_axis_name,

--- a/lib/levanter/src/levanter/main/viz_logprobs.py
+++ b/lib/levanter/src/levanter/main/viz_logprobs.py
@@ -3,7 +3,6 @@
 
 import logging
 import os
-import typing
 from dataclasses import dataclass, field
 
 import equinox as eqx
@@ -116,7 +115,7 @@ def main(config: VizLmConfig):
                 model = load_checkpoint(model, config.checkpoint_path, subpath="model")
             model = hax.shard(model, parameter_axis_mapping)
 
-        model = typing.cast(ArrayLmHeadModel, inference_mode(model, True))
+        model = inference_mode(model, True)
 
         if config.comparison_model_path is not None:
             if config.comparison_is_hf:
@@ -134,7 +133,7 @@ def main(config: VizLmConfig):
                     comparison_model = eqx.filter_eval_shape(config.model.build, Vocab, key=key)
                     comparison_model = load_checkpoint(comparison_model, config.comparison_model_path, subpath="model")
                 comparison_model = hax.shard(comparison_model, parameter_axis_mapping)
-            comparison_model = typing.cast(ArrayLmHeadModel, inference_mode(comparison_model, True))
+            comparison_model = inference_mode(comparison_model, True)
         else:
             comparison_model = None
 

--- a/lib/levanter/src/levanter/main/viz_logprobs.py
+++ b/lib/levanter/src/levanter/main/viz_logprobs.py
@@ -18,10 +18,10 @@ import levanter
 from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.data import DataLoader
-from levanter.data.text.examples import GrugLmExample, named_lm_example_from_grug
+from levanter.data.text.examples import GrugLmExample
 from levanter.data.text import LmDataConfig
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.models.lm_model import ArrayLmHeadModel, LmConfig, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
 from levanter.utils.partitioning import named_jit, round_axis_for_partitioning
@@ -80,7 +80,7 @@ def main(config: VizLmConfig):
         # don't want to compute the mask w.r.t. the final token
 
         @named_jit(axis_resources=compute_axis_mapping)
-        def compute_log_probs(model: LmHeadModel, example: GrugLmExample):
+        def compute_log_probs(model: ArrayLmHeadModel, example: GrugLmExample):
             model = inference_mode(model, True)
             model = mp.cast_to_compute(model)
 
@@ -90,12 +90,7 @@ def main(config: VizLmConfig):
                 reduction=None,
                 reduction_axis=(),
             )
-
-            named_example = named_lm_example_from_grug(example, Pos=Pos, batch_axis=EvalBatch)
-            activations = model.activations(named_example.tokens, named_example.attn_mask, key=key)
-            if isinstance(activations, tuple):
-                activations = activations[0]
-            logits = hax.dot(activations, model.get_lm_head(), axis=model.Embed).array
+            logits = model.logits_from_token_ids_array(example.tokens, batch_axis=EvalBatch, key=key)
 
             # Roll forward to align each prediction with its target token.
             logprobs = jnp.roll(-loss, 1, axis=-1)

--- a/lib/levanter/src/levanter/main/viz_logprobs.py
+++ b/lib/levanter/src/levanter/main/viz_logprobs.py
@@ -58,14 +58,14 @@ def main(config: VizLmConfig):
 
     # some axes we use outside the model proper
     EvalBatch = config.trainer.EvalBatch
-    Pos = config.model.max_Pos.resize(config.max_eval_length)
+    eval_length = min(config.max_eval_length, config.model.max_seq_len)
+    Pos = config.model.max_Pos.resize(eval_length)
 
     validation_sets = config.data.validation_grug_sets(seq_len=Pos.size)
 
     compute_axis_mapping = config.trainer.compute_axis_mapping
     parameter_axis_mapping = config.trainer.parameter_axis_mapping
-    batch_axis_resource = config.trainer.batch_axis_resource
-    loader_axis_resources = {EvalBatch.name: batch_axis_resource} if batch_axis_resource is not None else None
+    loader_axis_resources = compute_axis_mapping or None
 
     with config.trainer.use_device_mesh():
         key = jax.random.PRNGKey(0)

--- a/lib/levanter/src/levanter/main/viz_logprobs.py
+++ b/lib/levanter/src/levanter/main/viz_logprobs.py
@@ -21,7 +21,7 @@ from levanter.data import DataLoader
 from levanter.data.text.examples import GrugLmExample
 from levanter.data.text import LmDataConfig
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import ArrayLmHeadModel, LmConfig, LmHeadModel
+from levanter.models.lm_model import ArrayLmHeadModel, LmConfig
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
 from levanter.utils.partitioning import named_jit, round_axis_for_partitioning
@@ -97,7 +97,7 @@ def main(config: VizLmConfig):
             argmaxes = jnp.roll(jnp.argmax(logits, axis=-1), 1, axis=-1)
             return logprobs, argmaxes
 
-        model: LmHeadModel
+        model: ArrayLmHeadModel
 
         # initialize the model
         if config.checkpoint_is_hf:
@@ -116,7 +116,7 @@ def main(config: VizLmConfig):
                 model = load_checkpoint(model, config.checkpoint_path, subpath="model")
             model = hax.shard(model, parameter_axis_mapping)
 
-        model = typing.cast(LmHeadModel, inference_mode(model, True))
+        model = typing.cast(ArrayLmHeadModel, inference_mode(model, True))
 
         if config.comparison_model_path is not None:
             if config.comparison_is_hf:
@@ -134,7 +134,7 @@ def main(config: VizLmConfig):
                     comparison_model = eqx.filter_eval_shape(config.model.build, Vocab, key=key)
                     comparison_model = load_checkpoint(comparison_model, config.comparison_model_path, subpath="model")
                 comparison_model = hax.shard(comparison_model, parameter_axis_mapping)
-            comparison_model = typing.cast(LmHeadModel, inference_mode(comparison_model, True))
+            comparison_model = typing.cast(ArrayLmHeadModel, inference_mode(comparison_model, True))
         else:
             comparison_model = None
 

--- a/lib/levanter/src/levanter/main/viz_logprobs.py
+++ b/lib/levanter/src/levanter/main/viz_logprobs.py
@@ -8,22 +8,23 @@ from dataclasses import dataclass, field
 
 import equinox as eqx
 import jax
+import jax.numpy as jnp
 import jmp
 
 import haliax as hax
 from haliax import Axis
-from haliax.partitioning import round_axis_for_partitioning
 
 import levanter
 from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.data import DataLoader
+from levanter.data.text.examples import GrugLmExample, named_lm_example_from_grug
 from levanter.data.text import LmDataConfig
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
-from levanter.models.loss import next_token_loss
+from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
+from levanter.utils.partitioning import named_jit, round_axis_for_partitioning
 from levanter.utils.tree_utils import inference_mode
 from levanter.visualization import compute_and_diff_log_probs, compute_and_visualize_log_probs
 
@@ -59,10 +60,12 @@ def main(config: VizLmConfig):
     EvalBatch = config.trainer.EvalBatch
     Pos = config.model.max_Pos.resize(config.max_eval_length)
 
-    validation_sets = config.data.validation_sets(Pos)
+    validation_sets = config.data.validation_grug_sets(seq_len=Pos.size)
 
     compute_axis_mapping = config.trainer.compute_axis_mapping
     parameter_axis_mapping = config.trainer.parameter_axis_mapping
+    batch_axis_resource = config.trainer.batch_axis_resource
+    loader_axis_resources = {EvalBatch.name: batch_axis_resource} if batch_axis_resource is not None else None
 
     with config.trainer.use_device_mesh():
         key = jax.random.PRNGKey(0)
@@ -76,28 +79,28 @@ def main(config: VizLmConfig):
 
         # don't want to compute the mask w.r.t. the final token
 
-        @hax.named_jit(axis_resources=compute_axis_mapping)
-        def compute_log_probs(model: LmHeadModel, example: LmExample):
+        @named_jit(axis_resources=compute_axis_mapping)
+        def compute_log_probs(model: LmHeadModel, example: GrugLmExample):
             model = inference_mode(model, True)
             model = mp.cast_to_compute(model)
 
-            activations = model.activations(example.tokens, example.attn_mask, key=key)
-            logits = hax.dot(activations, model.get_lm_head(), axis=model.Embed)
-
-            loss = next_token_loss(
-                model.Pos,
-                model.Vocab,
-                logits=logits,
-                true_ids=example.tokens,
-                loss_weight=example.loss_weight,
+            loss = model.compute_next_token_loss_array(
+                example,
+                batch_axis=EvalBatch,
                 reduction=None,
+                reduction_axis=(),
             )
-            logprobs = -loss
-            # roll forward to get the loss for each predicted token
-            logprobs = hax.roll(logprobs, 1, Pos)
-            logits = hax.roll(logits, 1, Pos)
-            argmaxes = hax.argmax(logits, axis=Vocab)
-            return logprobs.rearrange((EvalBatch, Pos)).array, argmaxes.rearrange((EvalBatch, Pos)).array
+
+            named_example = named_lm_example_from_grug(example, Pos=Pos, batch_axis=EvalBatch)
+            activations = model.activations(named_example.tokens, named_example.attn_mask, key=key)
+            if isinstance(activations, tuple):
+                activations = activations[0]
+            logits = hax.dot(activations, model.get_lm_head(), axis=model.Embed).array
+
+            # Roll forward to align each prediction with its target token.
+            logprobs = jnp.roll(-loss, 1, axis=-1)
+            argmaxes = jnp.roll(jnp.argmax(logits, axis=-1), 1, axis=-1)
+            return logprobs, argmaxes
 
         model: LmHeadModel
 
@@ -151,7 +154,7 @@ def main(config: VizLmConfig):
                 dataset,
                 config.trainer.eval_batch_size,
                 mesh=config.trainer.device_mesh,
-                axis_resources=config.trainer.compute_axis_mapping,
+                axis_resources=loader_axis_resources,
             )
 
             if name:

--- a/lib/levanter/src/levanter/models/lm_model.py
+++ b/lib/levanter/src/levanter/models/lm_model.py
@@ -244,11 +244,7 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
             Model-native logits tensor with shape [..., Pos, Vocab]
 
         """
-        try:
-            x = self.activations(input_ids, attn_mask, key=key, pos_ids=pos_ids)
-        except TypeError:
-            # For backward compatibility with models that don't yet support pos_ids
-            x = self.activations(input_ids, attn_mask, key=key)
+        x = self.activations(input_ids, attn_mask, key=key, pos_ids=pos_ids)
 
         lm_logits = hax.dot(x, self.get_lm_head(), axis=self.Embed)
 

--- a/lib/levanter/src/levanter/models/lm_model.py
+++ b/lib/levanter/src/levanter/models/lm_model.py
@@ -3,7 +3,7 @@
 
 import abc
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generic, Optional, Type, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, Optional, Type, TypeVar, cast
 
 import draccus
 import equinox as eqx
@@ -23,6 +23,11 @@ LmT = TypeVar("LmT", bound="LmHeadModel")
 
 if TYPE_CHECKING:
     from levanter.data.text.examples import GrugLmExample
+
+
+LmTensor = Any
+LmAttentionMask = AttentionMask | Any
+LmAuxData = Any
 
 
 class LmExample(eqx.Module):
@@ -191,21 +196,22 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
 
     def __call__(
         self,
-        input_ids: NamedArray,
-        attn_mask: Optional[AttentionMask | NamedArray] = None,
+        input_ids: LmTensor,
+        attn_mask: Optional[LmAttentionMask] = None,
         *,
         key=None,
-        pos_ids: NamedArray | None = None,
-    ) -> NamedArray:
+        pos_ids: LmTensor | None = None,
+    ) -> LmTensor:
         """
-        Compute the logits for the next token in a sequence.
+        Compute next-token logits for a model-native token tensor.
+
         Args:
-            input_ids: token IDs with shape [..., Pos]
-            attn_mask: attention mask with shape [..., Pos, KeyPos]
+            input_ids: model-native token tensor with shape [..., Pos]
+            attn_mask: model-native attention mask for the same sequence
             key: PRNGKeyArray for random number generation
 
         Returns:
-            NamedArray: logits with shape [..., Pos, Vocab]
+            Model-native logits tensor with shape [..., Pos, Vocab]
 
         """
         try:
@@ -260,27 +266,28 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
     @abc.abstractmethod
     def activations(
         self,
-        input_ids: NamedArray,
-        attn_mask: Optional[AttentionMask | NamedArray] = None,
+        input_ids: LmTensor,
+        attn_mask: Optional[LmAttentionMask] = None,
         *,
         key=None,
-        pos_ids: NamedArray | None = None,
-    ) -> NamedArray | tuple[NamedArray, NamedArray | float]:
+        pos_ids: LmTensor | None = None,
+    ) -> LmTensor | tuple[LmTensor, LmAuxData]:
         """
-        Compute the activations for the next token in a sequence.
+        Compute activations for a model-native token tensor.
+
         Args:
-            input_ids: token IDs with shape {Pos}
-            attn_mask: attention mask with shape {Pos, KeyPos}
+            input_ids: model-native token tensor with shape {Pos}
+            attn_mask: model-native attention mask with shape {Pos, KeyPos}
             key: PRNGKeyArray for random number generation
 
         Returns:
-            NamedArray: activations with shape {Pos, Embed}
+            Model-native activation tensor with shape {Pos, Embed}
 
         """
         pass
 
     @abc.abstractmethod
-    def get_lm_head(self) -> hax.NamedArray:
+    def get_lm_head(self) -> LmTensor:
         """
         The language modeling head of the model. Should have shape {Embed, Vocab}.
         """
@@ -309,12 +316,12 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
         loss_dtype: Optional[jnp.dtype] = jnp.float32,
         logit_soft_cap: Optional[float] = None,
         axis_mapping: hax.partitioning.ResourceMapping | None = None,
-    ) -> jnp.ndarray | NamedArray:
+    ) -> jnp.ndarray | LmTensor:
         """
         Compute next-token cross-entropy for a language modeling example.
 
         If `reduction` is not None, the loss is reduced across `reduction_axis` (`None` means all axes).
-        If `reduction` is None, the loss is returned unreduced as a `NamedArray` with axes
+        If `reduction` is None, the loss is returned unreduced as a model-native tensor with axes
         (*batch axes, sequence_length).
         """
         activations = self.activations(example.tokens, example.attn_mask, key=key)

--- a/lib/levanter/src/levanter/models/lm_model.py
+++ b/lib/levanter/src/levanter/models/lm_model.py
@@ -36,7 +36,7 @@ class ArrayLmHeadModel(Protocol):
         *,
         batch_axis: Axis | str | None = "batch",
         key=None,
-        reduction: Optional[hax.ReductionFunction] = cast(Optional[hax.ReductionFunction], hax.mean),
+        reduction: str | hax.ReductionFunction | None = "mean",
         reduction_axis: Optional[hax.AxisSelection] = None,
         logsumexp_weight: Optional[float] = None,
         loss_dtype: Optional[jnp.dtype] = jnp.float32,
@@ -388,7 +388,7 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
         *,
         batch_axis: Axis | str | None = "batch",
         key=None,
-        reduction: Optional[hax.ReductionFunction] = cast(Optional[hax.ReductionFunction], hax.mean),
+        reduction: str | hax.ReductionFunction | None = "mean",
         reduction_axis: Optional[hax.AxisSelection] = None,
         logsumexp_weight: Optional[float] = None,
         loss_dtype: Optional[jnp.dtype] = jnp.float32,
@@ -404,7 +404,7 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
         loss = self._compute_next_token_loss_named(
             named_example,
             key=key,
-            reduction=reduction,
+            reduction=_normalize_reduction(reduction),
             reduction_axis=reduction_axis,
             logsumexp_weight=logsumexp_weight,
             loss_dtype=loss_dtype,
@@ -424,3 +424,17 @@ def _as_named_lm_example(example: Any, *, Pos: Axis, batch_axis: Axis | str | No
         return named_lm_example_from_grug(example, Pos=Pos, batch_axis=batch_axis)
 
     raise TypeError(f"Unsupported example type: {type(example)}")
+
+
+def _normalize_reduction(
+    reduction: str | hax.ReductionFunction | None,
+) -> Optional[hax.ReductionFunction]:
+    if reduction is None:
+        return None
+    if reduction == "mean":
+        return cast(hax.ReductionFunction, hax.mean)
+    if reduction == "sum":
+        return cast(hax.ReductionFunction, hax.sum)
+    if callable(reduction):
+        return cast(hax.ReductionFunction, reduction)
+    raise ValueError(f"Unsupported reduction spec: {reduction!r}")

--- a/lib/levanter/src/levanter/models/lm_model.py
+++ b/lib/levanter/src/levanter/models/lm_model.py
@@ -52,6 +52,16 @@ class ArrayLmHeadModel(Protocol):
     ) -> jax.Array: ...
 
 
+class ArrayLmHarnessModel(ArrayLmHeadModel, Protocol):
+    """Array-native model surface required by eval harness-style flows."""
+
+    @property
+    def Pos(self) -> Axis: ...
+
+    @property
+    def max_length(self) -> int: ...
+
+
 def _to_plain_jax_array(value: Any) -> jax.Array:
     """Best-effort conversion from a model-native tensor/scalar to a plain JAX array."""
     array_attr = getattr(value, "array", None)

--- a/lib/levanter/src/levanter/models/lm_model.py
+++ b/lib/levanter/src/levanter/models/lm_model.py
@@ -341,11 +341,10 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
     def vocab_size(self) -> int:
         return self.Vocab.size
 
-    def compute_next_token_loss(
+    def _compute_next_token_loss_named(
         self,
-        example: Any,
+        example: LmExample,
         *,
-        batch_axis: Axis | str | None = "batch",
         key=None,
         reduction: Optional[hax.ReductionFunction] = cast(Optional[hax.ReductionFunction], hax.mean),
         reduction_axis: Optional[hax.AxisSelection] = None,
@@ -355,14 +354,11 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
         axis_mapping: hax.partitioning.ResourceMapping | None = None,
     ) -> jnp.ndarray | LmTensor:
         """
-        Compute next-token cross-entropy for a language modeling example.
+        Compute next-token cross-entropy for a named example.
 
-        If `reduction` is not None, the loss is reduced across `reduction_axis` (`None` means all axes).
-        If `reduction` is None, the loss is returned unreduced as a model-native tensor with axes
-        (*batch axes, sequence_length).
+        Internal helper used by the array-native public surface.
         """
-        named_example = _as_named_lm_example(example, Pos=self.Pos, batch_axis=batch_axis)
-        activations = self.activations(named_example.tokens, named_example.attn_mask, key=key)
+        activations = self.activations(example.tokens, example.attn_mask, key=key)
 
         aux_loss = 0
         if isinstance(activations, tuple):
@@ -374,8 +370,8 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
             self.Vocab,
             activations,
             self.get_lm_head(),
-            named_example.tokens,
-            loss_weight=named_example.loss_weight,
+            example.tokens,
+            loss_weight=example.loss_weight,
             reduction=reduction,
             reduction_axis=reduction_axis,
             logsumexp_weight=logsumexp_weight,
@@ -404,9 +400,9 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
         This bridges array-native batches (for example `GrugLmExample`) to the legacy
         named-tensor model interface during migration.
         """
-        loss = self.compute_next_token_loss(
-            example,
-            batch_axis=batch_axis,
+        named_example = _as_named_lm_example(example, Pos=self.Pos, batch_axis=batch_axis)
+        loss = self._compute_next_token_loss_named(
+            named_example,
             key=key,
             reduction=reduction,
             reduction_axis=reduction_axis,

--- a/lib/levanter/src/levanter/models/lm_model.py
+++ b/lib/levanter/src/levanter/models/lm_model.py
@@ -3,7 +3,7 @@
 
 import abc
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generic, Optional, Type, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, Optional, Protocol, Type, TypeVar, cast
 
 import draccus
 import equinox as eqx
@@ -28,6 +28,31 @@ if TYPE_CHECKING:
 LmTensor = Any
 LmAttentionMask = AttentionMask | Any
 LmAuxData = Any
+
+
+class ArrayLmHeadModel(Protocol):
+    """Array-native LM interface used by training/eval surfaces."""
+
+    def compute_next_token_loss_array(
+        self,
+        example: "LmExample | GrugLmExample",
+        *,
+        batch_axis: Axis | str | None = "batch",
+        key=None,
+        reduction: Optional[hax.ReductionFunction] = cast(Optional[hax.ReductionFunction], hax.mean),
+        reduction_axis: Optional[hax.AxisSelection] = None,
+        logsumexp_weight: Optional[float] = None,
+        loss_dtype: Optional[jnp.dtype] = jnp.float32,
+        logit_soft_cap: Optional[float] = None,
+    ) -> jax.Array: ...
+
+    def logits_from_token_ids_array(
+        self,
+        input_ids: jax.Array,
+        *,
+        batch_axis: Axis | str | None = "batch",
+        key=None,
+    ) -> jax.Array: ...
 
 
 def _to_plain_jax_array(value: Any) -> jax.Array:

--- a/lib/levanter/src/levanter/models/lm_model.py
+++ b/lib/levanter/src/levanter/models/lm_model.py
@@ -3,7 +3,7 @@
 
 import abc
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generic, Optional, Protocol, Type, TypeVar, cast
+from typing import Any, Generic, Optional, Protocol, Type, TypeVar, cast
 
 import draccus
 import equinox as eqx
@@ -21,9 +21,6 @@ from levanter.models.loss import maybe_fused_next_token_loss
 LmConfigT = TypeVar("LmConfigT", bound="LmConfig")
 LmT = TypeVar("LmT", bound="LmHeadModel")
 
-if TYPE_CHECKING:
-    from levanter.data.text.examples import GrugLmExample
-
 
 LmTensor = Any
 LmAttentionMask = AttentionMask | Any
@@ -35,7 +32,7 @@ class ArrayLmHeadModel(Protocol):
 
     def compute_next_token_loss_array(
         self,
-        example: "LmExample | GrugLmExample",
+        example: Any,
         *,
         batch_axis: Axis | str | None = "batch",
         key=None,
@@ -340,8 +337,9 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
 
     def compute_next_token_loss(
         self,
-        example: LmExample,
+        example: Any,
         *,
+        batch_axis: Axis | str | None = "batch",
         key=None,
         reduction: Optional[hax.ReductionFunction] = cast(Optional[hax.ReductionFunction], hax.mean),
         reduction_axis: Optional[hax.AxisSelection] = None,
@@ -357,7 +355,8 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
         If `reduction` is None, the loss is returned unreduced as a model-native tensor with axes
         (*batch axes, sequence_length).
         """
-        activations = self.activations(example.tokens, example.attn_mask, key=key)
+        named_example = _as_named_lm_example(example, Pos=self.Pos, batch_axis=batch_axis)
+        activations = self.activations(named_example.tokens, named_example.attn_mask, key=key)
 
         aux_loss = 0
         if isinstance(activations, tuple):
@@ -369,8 +368,8 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
             self.Vocab,
             activations,
             self.get_lm_head(),
-            example.tokens,
-            loss_weight=example.loss_weight,
+            named_example.tokens,
+            loss_weight=named_example.loss_weight,
             reduction=reduction,
             reduction_axis=reduction_axis,
             logsumexp_weight=logsumexp_weight,
@@ -383,7 +382,7 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
 
     def compute_next_token_loss_array(
         self,
-        example: "LmExample | GrugLmExample",
+        example: Any,
         *,
         batch_axis: Axis | str | None = "batch",
         key=None,
@@ -399,18 +398,9 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
         This bridges array-native batches (for example `GrugLmExample`) to the legacy
         named-tensor model interface during migration.
         """
-        named_example: LmExample
-        if isinstance(example, LmExample):
-            named_example = example
-        else:
-            from levanter.data.text.examples import GrugLmExample, named_lm_example_from_grug
-
-            if not isinstance(example, GrugLmExample):
-                raise TypeError(f"Unsupported example type: {type(example)}")
-            named_example = named_lm_example_from_grug(example, Pos=self.Pos, batch_axis=batch_axis)
-
         loss = self.compute_next_token_loss(
-            named_example,
+            example,
+            batch_axis=batch_axis,
             key=key,
             reduction=reduction,
             reduction_axis=reduction_axis,
@@ -420,3 +410,15 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
         )
 
         return _to_plain_jax_array(loss)
+
+
+def _as_named_lm_example(example: Any, *, Pos: Axis, batch_axis: Axis | str | None = "batch") -> LmExample:
+    if isinstance(example, LmExample):
+        return example
+
+    from levanter.data.text.examples import GrugLmExample, named_lm_example_from_grug
+
+    if isinstance(example, GrugLmExample):
+        return named_lm_example_from_grug(example, Pos=Pos, batch_axis=batch_axis)
+
+    raise TypeError(f"Unsupported example type: {type(example)}")

--- a/lib/levanter/src/levanter/models/lm_model.py
+++ b/lib/levanter/src/levanter/models/lm_model.py
@@ -12,7 +12,7 @@ import jax.numpy as jnp
 from jaxtyping import PRNGKeyArray
 
 import haliax as hax
-from haliax import Axis, NamedArray, NamedOrNumeric
+from haliax import Axis, NamedOrNumeric
 
 from levanter.layers.attention import AttentionMask
 from levanter.models.loss import maybe_fused_next_token_loss
@@ -66,7 +66,7 @@ def _to_plain_jax_array(value: Any) -> jax.Array:
 class LmExample(eqx.Module):
     tokens: hax.NamedArray
     loss_weight: hax.NamedArray
-    attn_mask: AttentionMask | NamedArray = AttentionMask.causal()
+    attn_mask: AttentionMask | hax.NamedArray = AttentionMask.causal()
 
     @staticmethod
     def causal(
@@ -146,7 +146,7 @@ class LmExample(eqx.Module):
         return LmExample(tokens=tokens, loss_weight=loss_weight, attn_mask=attn_mask)
 
     @staticmethod
-    def causal_loss_mask(Pos: Axis, prompt_length: Optional[int] = None) -> NamedArray:
+    def causal_loss_mask(Pos: Axis, prompt_length: Optional[int] = None) -> hax.NamedArray:
         loss_weight = hax.logical_not(hax.nn.one_hot(-1, Pos, dtype=jnp.bool_))
 
         if prompt_length is not None:

--- a/lib/levanter/src/levanter/models/lm_model.py
+++ b/lib/levanter/src/levanter/models/lm_model.py
@@ -30,6 +30,14 @@ LmAttentionMask = AttentionMask | Any
 LmAuxData = Any
 
 
+def _to_plain_jax_array(value: Any) -> jax.Array:
+    """Best-effort conversion from a model-native tensor/scalar to a plain JAX array."""
+    array_attr = getattr(value, "array", None)
+    if array_attr is not None:
+        return jnp.asarray(array_attr)
+    return jnp.asarray(value)
+
+
 class LmExample(eqx.Module):
     tokens: hax.NamedArray
     loss_weight: hax.NamedArray
@@ -386,6 +394,4 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
             logit_soft_cap=logit_soft_cap,
         )
 
-        if isinstance(loss, hax.NamedArray):
-            return loss.array
-        return jnp.asarray(loss)
+        return _to_plain_jax_array(loss)

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -1124,4 +1124,28 @@ def _resolve_axis_in_tree(tree, axis):
             except ValueError:
                 pass
 
+    candidate_sizes: list[int] = []
+    for leaf in jax.tree_util.tree_leaves(tree):
+        shape = getattr(leaf, "shape", None)
+        if shape is None:
+            continue
+        if len(shape) >= 2:
+            candidate_sizes.append(int(shape[0]))
+
+    if not candidate_sizes:
+        for leaf in jax.tree_util.tree_leaves(tree):
+            shape = getattr(leaf, "shape", None)
+            if shape is None or len(shape) == 0:
+                continue
+            if len(shape) == 1 and tuple(shape) == (2,):
+                continue
+            candidate_sizes.append(int(shape[0]))
+
+    if candidate_sizes:
+        batch_size = candidate_sizes[0]
+        for size in candidate_sizes[1:]:
+            if size != batch_size:
+                raise ValueError(f"Inconsistent inferred batch sizes {candidate_sizes} in tree {tree}")
+        return hax.Axis(axis, batch_size)
+
     raise ValueError(f"Could not find axis {axis} in tree {tree}")

--- a/lib/levanter/src/levanter/utils/partitioning.py
+++ b/lib/levanter/src/levanter/utils/partitioning.py
@@ -1,0 +1,28 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from haliax.partitioning import (
+    current_thread_local_mapping,
+    infer_resource_partitions,
+    named_jit,
+    physical_axis_name,
+    physical_axis_size,
+    pspec_for,
+    pspec_for_axis,
+    round_axis_for_partitioning,
+    shard_map,
+    sharding_for_axis,
+)
+
+__all__ = [
+    "current_thread_local_mapping",
+    "infer_resource_partitions",
+    "named_jit",
+    "physical_axis_name",
+    "physical_axis_size",
+    "pspec_for",
+    "pspec_for_axis",
+    "round_axis_for_partitioning",
+    "shard_map",
+    "sharding_for_axis",
+]

--- a/lib/levanter/tests/test_dpo.py
+++ b/lib/levanter/tests/test_dpo.py
@@ -34,6 +34,7 @@ from levanter.data.text import (
 )
 from levanter.main.train_dpo import DpoModel, _build_dpo_dataset, _logp_sum, dpo_loss_from_logps
 from levanter.metrics import Metric
+from levanter.layers.attention import AttentionMask
 from levanter.models.gpt2 import Gpt2Config
 from levanter.models.lm_model import LmExample
 from levanter.optim import AdamConfig
@@ -260,6 +261,26 @@ def test_logp_sum_passes_key_for_dropout():
 
     out = _logp_sum(model, example, key=jrandom.PRNGKey(1))
     assert isinstance(out, hax.NamedArray)
+
+
+def test_logp_sum_preserves_batch_axis_for_batched_named_example():
+    config = Gpt2Config(max_seq_len=8, hidden_dim=16, num_layers=1, num_heads=2)
+    Vocab = hax.Axis("vocab", 32)
+    model = config.build(Vocab, key=jrandom.PRNGKey(0))
+
+    Batch = hax.Axis("batch", 2)
+    Pos = hax.Axis("position", 8)
+    tokens = hax.named(
+        jnp.arange(Batch.size * Pos.size, dtype=jnp.int32).reshape(Batch.size, Pos.size) % Vocab.size,
+        (Batch, Pos),
+    )
+    loss_weight = hax.ones((Batch, Pos), dtype=jnp.float32).at[Pos, Pos.size - 1].set(0.0)
+    example = LmExample(tokens=tokens, loss_weight=loss_weight, attn_mask=AttentionMask.causal())
+
+    out = _logp_sum(model, example)
+
+    assert isinstance(out, hax.NamedArray)
+    assert out.axes == (Batch,)
 
 
 def test_preference_chat_processor_outputs_masks(tokenizer_path: Path):

--- a/lib/levanter/tests/test_eval.py
+++ b/lib/levanter/tests/test_eval.py
@@ -13,7 +13,12 @@ from haliax import Axis
 from haliax.partitioning import ResourceAxis
 
 from levanter.data.dataset import ListAsyncDataset
-from levanter.data.text.examples import GrugLmExample, named_lm_example_from_grug
+from levanter.data.text.examples import (
+    GrugLmExample,
+    LmLikeExample,
+    loss_weight_array_from_lm_example,
+    target_token_ids_array_from_lm_example,
+)
 from levanter.eval import EvalResult, LossFnOutput, TaggedEvaluator, cb_tagged_evaluate
 from levanter.models.lm_model import LmExample
 from levanter.tracker import current_tracker
@@ -41,15 +46,15 @@ def test_tagged_evaluator_accepts_grug_lm_examples():
 
     with use_test_mesh(tensor_parallelism=1) as mesh:
 
-        def loss_fn(model, batch) -> LossFnOutput:
+        def loss_fn(model, batch: LmLikeExample) -> LossFnOutput:
             model = inference_mode(model, True)
-            if isinstance(batch, LmExample):
-                named_batch = batch
-            else:
-                named_batch = named_lm_example_from_grug(batch, Pos=model.Pos, batch_axis=EvalBatch)
             with hax.axis_mapping({EvalBatch.name: ResourceAxis.DATA}):
-                per_pos_loss = model.compute_next_token_loss(named_batch, reduction=None, reduction_axis=()).array
-            return per_pos_loss, named_batch.loss_weight.array, jnp.roll(named_batch.tokens.array, -1, axis=-1)
+                per_pos_loss = model.compute_next_token_loss_array(batch, reduction=None, reduction_axis=())
+            return (
+                per_pos_loss,
+                loss_weight_array_from_lm_example(batch),
+                target_token_ids_array_from_lm_example(batch),
+            )
 
         evaluator = TaggedEvaluator(
             EvalBatch=EvalBatch,
@@ -89,15 +94,15 @@ def test_tagged_evaluator_accepts_mixed_lm_example_types():
 
     with use_test_mesh(tensor_parallelism=1) as mesh:
 
-        def loss_fn(model, batch) -> LossFnOutput:
+        def loss_fn(model, batch: LmLikeExample) -> LossFnOutput:
             model = inference_mode(model, True)
-            if isinstance(batch, LmExample):
-                named_batch = batch
-            else:
-                named_batch = named_lm_example_from_grug(batch, Pos=model.Pos, batch_axis=EvalBatch)
             with hax.axis_mapping({EvalBatch.name: ResourceAxis.DATA}):
-                per_pos_loss = model.compute_next_token_loss(named_batch, reduction=None, reduction_axis=()).array
-            return per_pos_loss, named_batch.loss_weight.array, jnp.roll(named_batch.tokens.array, -1, axis=-1)
+                per_pos_loss = model.compute_next_token_loss_array(batch, reduction=None, reduction_axis=())
+            return (
+                per_pos_loss,
+                loss_weight_array_from_lm_example(batch),
+                target_token_ids_array_from_lm_example(batch),
+            )
 
         evaluator = TaggedEvaluator(
             EvalBatch=EvalBatch,

--- a/lib/levanter/tests/test_hf_gpt2_serialize.py
+++ b/lib/levanter/tests/test_hf_gpt2_serialize.py
@@ -155,7 +155,7 @@ def _compare_gpt2_checkpoint_gradients(model_id, revision, config: Optional[Gpt2
 
         def compute_loss(model: LmHeadModel, input_ids):
             example = LmExample.causal(input_ids, eos_id=converter.tokenizer.eos_token_id)
-            return model.compute_next_token_loss(example, key=None).scalar()
+            return model.compute_next_token_loss_array(example, key=None).item()
 
         jax_compute_grad = equinox.filter_value_and_grad(compute_loss, has_aux=False)
         jax_grad: Gpt2LMHeadModel

--- a/lib/levanter/tests/test_hf_gpt2_serialize.py
+++ b/lib/levanter/tests/test_hf_gpt2_serialize.py
@@ -155,7 +155,7 @@ def _compare_gpt2_checkpoint_gradients(model_id, revision, config: Optional[Gpt2
 
         def compute_loss(model: LmHeadModel, input_ids):
             example = LmExample.causal(input_ids, eos_id=converter.tokenizer.eos_token_id)
-            return model.compute_next_token_loss_array(example, key=None).item()
+            return model.compute_next_token_loss_array(example, key=None)
 
         jax_compute_grad = equinox.filter_value_and_grad(compute_loss, has_aux=False)
         jax_grad: Gpt2LMHeadModel

--- a/lib/levanter/tests/test_lm_model_loss.py
+++ b/lib/levanter/tests/test_lm_model_loss.py
@@ -85,7 +85,7 @@ def _toy_example(Batch: Axis, Pos: Axis, Vocab: Axis, *, key: PRNGKeyArray) -> L
     return LmExample(tokens=tokens, loss_weight=loss_weight, attn_mask=AttentionMask.causal())
 
 
-def test_compute_next_token_loss_reduction_returns_scalar():
+def test_compute_next_token_loss_array_reduction_returns_scalar():
     Vocab = Axis("vocab", 32)
     cfg = ToyLmConfig(max_seq_len=8, embed_dim=16)
     model = ToyLmHeadModel.init(Vocab, cfg, key=jax.random.PRNGKey(0))
@@ -94,12 +94,11 @@ def test_compute_next_token_loss_reduction_returns_scalar():
     Pos = cfg.max_Pos.resize(8)
     example = _toy_example(Batch, Pos, Vocab, key=jax.random.PRNGKey(1))
 
-    loss = model.compute_next_token_loss(example)
-    assert loss.axes == ()
-    assert jnp.shape(loss.array) == ()
+    loss = model.compute_next_token_loss_array(example)
+    assert jnp.shape(loss) == ()
 
 
-def test_compute_next_token_loss_unreduced_has_expected_axes():
+def test_compute_next_token_loss_array_unreduced_has_expected_shape():
     Vocab = Axis("vocab", 32)
     cfg = ToyLmConfig(max_seq_len=8, embed_dim=16)
     model = ToyLmHeadModel.init(Vocab, cfg, key=jax.random.PRNGKey(0))
@@ -108,13 +107,11 @@ def test_compute_next_token_loss_unreduced_has_expected_axes():
     Pos = cfg.max_Pos.resize(8)
     example = _toy_example(Batch, Pos, Vocab, key=jax.random.PRNGKey(1))
 
-    loss = model.compute_next_token_loss(example, reduction=None, reduction_axis=())
-    assert isinstance(loss, hax.NamedArray)
-    assert loss.resolve_axis("batch").size == Batch.size
-    assert loss.resolve_axis("position").size == Pos.size
+    loss = model.compute_next_token_loss_array(example, reduction=None, reduction_axis=())
+    assert loss.shape == (Batch.size, Pos.size)
 
 
-def test_compute_next_token_loss_includes_aux_loss():
+def test_compute_next_token_loss_array_includes_aux_loss():
     Vocab = Axis("vocab", 32)
     cfg = ToyLmConfig(max_seq_len=8, embed_dim=16)
     model = ToyLmHeadModel.init(Vocab, cfg, key=jax.random.PRNGKey(0))
@@ -123,9 +120,9 @@ def test_compute_next_token_loss_includes_aux_loss():
     Pos = cfg.max_Pos.resize(8)
     example = _toy_example(Batch, Pos, Vocab, key=jax.random.PRNGKey(1))
 
-    base = model.compute_next_token_loss(example)
+    base = model.compute_next_token_loss_array(example)
     model_with_aux = eqx.tree_at(lambda m: m.aux_loss, model, jnp.array(0.25, dtype=jnp.float32))
-    with_aux = model_with_aux.compute_next_token_loss(example)
+    with_aux = model_with_aux.compute_next_token_loss_array(example)
 
     assert pytest.approx(float(base) + 0.25, rel=1e-6, abs=1e-6) == float(with_aux)
 
@@ -140,7 +137,7 @@ def test_compute_next_token_loss_array_matches_named_for_grug_example():
     example = _toy_example(Batch, Pos, Vocab, key=jax.random.PRNGKey(1))
     grug_example = grug_lm_example_from_named(example)
 
-    named_loss = model.compute_next_token_loss(example, reduction=None, reduction_axis=()).array
+    named_loss = model.compute_next_token_loss_array(example, batch_axis=Batch, reduction=None, reduction_axis=())
     grug_loss = model.compute_next_token_loss_array(grug_example, batch_axis=Batch, reduction=None, reduction_axis=())
 
     np.testing.assert_allclose(grug_loss, named_loss, rtol=1e-5, atol=1e-6)

--- a/lib/levanter/tests/test_lm_model_loss.py
+++ b/lib/levanter/tests/test_lm_model_loss.py
@@ -9,12 +9,14 @@ from typing import Optional, Type
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 from jaxtyping import PRNGKeyArray
 
 import haliax as hax
 from haliax import Axis, NamedArray
 
+from levanter.data.text.examples import grug_lm_example_from_named
 from levanter.layers.attention import AttentionMask
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 
@@ -126,3 +128,19 @@ def test_compute_next_token_loss_includes_aux_loss():
     with_aux = model_with_aux.compute_next_token_loss(example)
 
     assert pytest.approx(float(base) + 0.25, rel=1e-6, abs=1e-6) == float(with_aux)
+
+
+def test_compute_next_token_loss_array_matches_named_for_grug_example():
+    Vocab = Axis("vocab", 32)
+    cfg = ToyLmConfig(max_seq_len=8, embed_dim=16)
+    model = ToyLmHeadModel.init(Vocab, cfg, key=jax.random.PRNGKey(0))
+
+    Batch = Axis("batch", 4)
+    Pos = cfg.max_Pos.resize(8)
+    example = _toy_example(Batch, Pos, Vocab, key=jax.random.PRNGKey(1))
+    grug_example = grug_lm_example_from_named(example)
+
+    named_loss = model.compute_next_token_loss(example, reduction=None, reduction_axis=()).array
+    grug_loss = model.compute_next_token_loss_array(grug_example, batch_axis=Batch, reduction=None, reduction_axis=())
+
+    np.testing.assert_allclose(grug_loss, named_loss, rtol=1e-5, atol=1e-6)

--- a/lib/levanter/tests/test_lm_model_loss.py
+++ b/lib/levanter/tests/test_lm_model_loss.py
@@ -144,8 +144,6 @@ def test_compute_next_token_loss_array_matches_named_for_grug_example():
     grug_loss = model.compute_next_token_loss_array(grug_example, batch_axis=Batch, reduction=None, reduction_axis=())
 
     np.testing.assert_allclose(grug_loss, named_loss, rtol=1e-5, atol=1e-6)
-
-
 def test_logits_from_token_ids_array_matches_named_logits():
     Vocab = Axis("vocab", 32)
     cfg = ToyLmConfig(max_seq_len=8, embed_dim=16)

--- a/lib/levanter/tests/test_lm_model_loss.py
+++ b/lib/levanter/tests/test_lm_model_loss.py
@@ -144,3 +144,21 @@ def test_compute_next_token_loss_array_matches_named_for_grug_example():
     grug_loss = model.compute_next_token_loss_array(grug_example, batch_axis=Batch, reduction=None, reduction_axis=())
 
     np.testing.assert_allclose(grug_loss, named_loss, rtol=1e-5, atol=1e-6)
+
+
+def test_logits_from_token_ids_array_matches_named_logits():
+    Vocab = Axis("vocab", 32)
+    cfg = ToyLmConfig(max_seq_len=8, embed_dim=16)
+    model = ToyLmHeadModel.init(Vocab, cfg, key=jax.random.PRNGKey(0))
+
+    Batch = Axis("batch", 4)
+    Pos = cfg.max_Pos.resize(8)
+    example = _toy_example(Batch, Pos, Vocab, key=jax.random.PRNGKey(1))
+
+    activations = model.activations(example.tokens)
+    if isinstance(activations, tuple):
+        activations = activations[0]
+    named_logits = hax.dot(activations, model.get_lm_head(), axis=model.Embed).array
+    array_logits = model.logits_from_token_ids_array(example.tokens.array, batch_axis=Batch)
+
+    np.testing.assert_allclose(array_logits, named_logits, rtol=1e-5, atol=1e-6)


### PR DESCRIPTION
## Summary
- makes `LmHeadModel` external loss/logit interfaces tensor-opaque and array-native
- routes train/eval/dpo/viz/eval-harness callbacks through the array LM protocol surface
- localizes NamedArray-specific typing to internal boundaries instead of public interfaces

This is part of gruggification.
