### PR TITLE
gruggification: decouple eval and inference surface from model.Pos

### DIFF
--- a/lib/levanter/src/levanter/inference/engine.py
+++ b/lib/levanter/src/levanter/inference/engine.py
@@ -870,7 +870,7 @@ class InferenceEngine:
 
         decode_state = self.gen_state.decode_state
         max_seqs_in_prefill = self.config.max_seqs_in_prefill
-        max_prefill_size = self.config.max_prefill_size or self.model.Pos.size
+        max_prefill_size = self.config.max_prefill_size or self.model.max_length
         max_seq_len = decode_state.tokens.axis_size("position")
         max_slots = decode_state.max_seqs
 


### PR DESCRIPTION
## Summary
- removes `model.Pos` dependency in eval-harness setup by deriving position axis from `max_length`
- removes `model.Pos` dependency in inference prefill sizing in favor of `model.max_length`
- narrows non-model API coupling to named-axis internals

This is part of gruggification.

## Validation
- pre-commit on changed files
- targeted eval, lm-model-loss, and inference server tests