### PR TITLE
Add Ray cluster safety rule to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,3 +118,4 @@ DO NOT:
 ## Environment
 
 - Prefer to use `uv` when possible. If you can't (for instance, due to sandbox restrictions) you can use `.venv/bin/python`
+- NEVER EVER stop, restart, or otherwise bounce a Ray cluster unless the user has given express permission for that exact action.


### PR DESCRIPTION
Add an explicit safety rule to the repository agent instructions forbidding agents from stopping or restarting a Ray cluster without the user’s express permission. This makes the constraint visible in the default operating guidance so cluster-disruptive actions are not taken implicitly.

- Add a Ray-specific operational safety bullet to `AGENTS.md`.

Fixes #3336
