### PR TITLE
Search all zones for the TPU

### DIFF
--- a/lib/marin/src/marin/cluster/gcp.py
+++ b/lib/marin/src/marin/cluster/gcp.py
@@ -103,8 +103,10 @@ def delete_tpu_node(node_name: str, project: str, zone: str, quiet: bool = False
     run_gcloud_command(cmd)
 
 
-def find_tpu_by_ip(target_ip: str, project: str, zone: str) -> tuple[str, str, int] | None:
+def find_tpu_by_ip(target_ip: str, project: str, zone: str = "-") -> tuple[str, str, int] | None:
     """Find TPU node by its internal IP address.
+
+    Searches all zones by default (zone="-").
 
     Returns:
         Tuple of (tpu_name, zone, worker_index) or None if not found

--- a/scripts/ray/cluster.py
+++ b/scripts/ray/cluster.py
@@ -714,23 +714,27 @@ def cluster_update_configs(ctx):
 @cli.command("ssh-tpu")
 @click.argument("target")
 @click.option("--project", help="GCP project ID")
-@click.option("--zone", help="GCP zone")
+@click.option("--zone", help="GCP zone (searches all zones by default)")
 @click.argument("extra_args", nargs=-1)
 @click.pass_context
 def ssh_connect(ctx, target, project, zone, extra_args):
-    """SSH to TPU node by IP address."""
-    project = project or gcp.get_project_id()
-    zone = zone or gcp.get_default_zone()
+    """SSH to TPU node by IP address.
 
-    if not project or not zone:
-        print("Error: Could not determine project or zone", file=sys.stderr)
+    Searches all zones for the TPU matching the given internal IP.
+    """
+    project = project or gcp.get_project_id()
+
+    if not project:
+        print("Error: Could not determine project", file=sys.stderr)
         sys.exit(1)
 
-    # Find TPU by IP and SSH to it
+    # Search all zones by default (zone="-"), matching ssh_tpu behavior
+    zone = zone or "-"
+
     tpu_result = gcp.find_tpu_by_ip(target, project, zone)
     if tpu_result:
         tpu_name, tpu_zone, worker_id = tpu_result
-        print(f"Connecting to TPU {tpu_name} worker {worker_id} at IP {target}")
+        print(f"Found TPU: {tpu_name} in zone: {tpu_zone}")
         gcp.ssh_to_tpu(tpu_name, tpu_zone, project, list(extra_args) if extra_args else None, worker_id)
     else:
         print(f"Error: No TPU found with IP {target}", file=sys.stderr)


### PR DESCRIPTION
The `uv run scripts/ray/cluster.py ssh-tpu` is useful, but it had this property where the zone was taken from local config, which would mean it often could not SSH into the TPU. This PR fixes that by searching all zones for the internal IP.