### PR TITLE
Add MoE canary ferry for daily TPU regression testing

### DIFF
--- a/.github/workflows/marin-canary-ferry-moe.yaml
+++ b/.github/workflows/marin-canary-ferry-moe.yaml
@@ -1,0 +1,66 @@
+name: Marin - Canary Ferry (MoE)
+
+on:
+  schedule:
+    - cron: '0 7 * * *'  # Daily at 7 AM UTC (offset from dense canary at 6 AM)
+  workflow_dispatch:
+
+jobs:
+  canary-ferry-moe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    concurrency:
+      group: canary-ferry-moe
+      cancel-in-progress: true
+    env:
+      RUN_ID: canary-moe-${{ github.run_id }}-${{ github.run_attempt }}
+      WANDB_ENTITY: marin-community
+      WANDB_PROJECT: marin
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-packages --extra=tpu --no-default-groups
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Write SSH key and Ray token
+        run: |
+          mkdir -p ~/.ssh ~/.ray
+          echo "${{ secrets.MARIN_SSH_KEY }}" > ~/.ssh/marin_ray_cluster.pem
+          chmod 600 ~/.ssh/marin_ray_cluster.pem
+          echo "${{ secrets.RAY_AUTH_TOKEN }}" > ~/.ray/auth_token
+          chmod 600 ~/.ray/auth_token
+
+      - name: Submit MoE canary ferry to Ray cluster
+        shell: bash -l {0}
+        run: |
+          .venv/bin/python lib/marin/src/marin/run/ray_run.py \
+            --cluster us-central1 \
+            -e RUN_ID "$RUN_ID" \
+            -e WANDB_ENTITY "$WANDB_ENTITY" \
+            -e WANDB_PROJECT "$WANDB_PROJECT" \
+            -- python experiments/ferries/canary_ferry_moe.py
+        env:
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/experiments/ferries/canary_ferry_moe.py
+++ b/experiments/ferries/canary_ferry_moe.py
@@ -1,0 +1,140 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canary ferry (MoE): Grug MoE daily pretraining canary on TPU.
+
+Trains ~1B tokens on v5p-8 using the Grug MoE trial model (512 hidden,
+8 experts pick-2, 6 layers), scaled down from the ~4.2B-token trial
+template to fit a <1hr daily window.
+
+Usage:
+    python -m experiments.ferries.canary_ferry_moe
+"""
+
+import dataclasses
+import datetime
+import os
+from datetime import timedelta
+
+import jmp
+from fray.cluster import ResourceConfig
+from levanter.callbacks.profiler import ProfilerConfig
+from levanter.checkpoint import CheckpointerConfig
+from levanter.optim import AdamConfig
+from levanter.tracker import TrackerConfig
+from levanter.tracker.wandb import WandbConfig
+from levanter.trainer import TrainerConfig
+from levanter.utils.mesh import MeshConfig
+from marin.execution.executor import ExecutorStep, executor_main, this_output_path, versioned
+
+from experiments.grug.moe.launch import (
+    GRUG_MOE_TRIAL_MODEL,
+    NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
+    GrugMoeLaunchConfig,
+)
+from experiments.grug.moe.train import GrugEvalConfig, GrugRunConfig, GrugTrainerConfig, run_grug
+
+RUN_ID = os.environ.get("RUN_ID") or datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+# ~1B tokens: batch=512 * seq=4096 -> 476 steps
+BATCH_SIZE = 512
+TARGET_TOKENS = 1_000_000_000
+NUM_STEPS = TARGET_TOKENS // (BATCH_SIZE * GRUG_MOE_TRIAL_MODEL.max_seq_len)
+
+
+def _resolve_tracker(tracker: TrackerConfig, run_id: str) -> TrackerConfig:
+    if isinstance(tracker, WandbConfig):
+        return dataclasses.replace(tracker, name=run_id)
+    return tracker
+
+
+def run_canary_moe(config: GrugMoeLaunchConfig) -> None:
+    """Copy of run_grug_moe_trial with profiling enabled."""
+    trainer = TrainerConfig(
+        id=config.run_id,
+        seed=config.seed,
+        train_batch_size=config.batch_size,
+        num_train_steps=config.steps,
+        profiler=ProfilerConfig(enabled=True),
+        mp=jmp.get_policy(config.mp),
+        tracker=_resolve_tracker(config.tracker, config.run_id),
+        use_explicit_mesh_axes=True,
+        mesh=MeshConfig(axes={"expert": 1}),
+        require_accelerator=True,
+        allow_nondivisible_batch_size=False,
+        checkpointer=CheckpointerConfig(
+            base_path=os.path.join(config.output_path, "checkpoints"),
+            append_run_id_to_base_path=False,
+            save_interval=timedelta(minutes=10),
+            keep=[{"every": 1000}],
+        ),
+    )
+
+    grug_trainer = dataclasses.replace(config.grug_trainer, trainer=trainer)
+
+    run_config = GrugRunConfig(
+        model=config.model,
+        data=config.data,
+        resources=config.resources,
+        optimizer=config.optimizer,
+        trainer=grug_trainer,
+        eval=config.eval,
+    )
+    run_grug(run_config)
+
+
+canary_moe_step = ExecutorStep(
+    name=f"canary-ferry-moe-{RUN_ID}",
+    fn=run_canary_moe,
+    config=GrugMoeLaunchConfig(
+        model=versioned(GRUG_MOE_TRIAL_MODEL),
+        data=NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
+        output_path=this_output_path(),
+        run_id=RUN_ID,
+        resources=versioned(ResourceConfig.with_tpu("v5p-8")),
+        steps=versioned(NUM_STEPS),
+        batch_size=versioned(BATCH_SIZE),
+        seed=versioned(0),
+        mp=versioned("params=float32,compute=bfloat16,output=bfloat16"),
+        tracker=WandbConfig(
+            project="marin",
+            tags=["canary", "ferry", "grug", "moe"],
+            group="canary-ferry-moe",
+            name=None,
+        ),
+        optimizer=versioned(
+            AdamConfig(
+                learning_rate=3e-3,
+                weight_decay=0.1,
+                lr_schedule="cosine",
+                decay=0.2,
+                min_lr_ratio=0.1,
+                warmup=48,
+            )
+        ),
+        grug_trainer=versioned(
+            GrugTrainerConfig(
+                z_loss_weight=1e-4,
+                ema_beta=None,
+                log_every=1,
+            )
+        ),
+        eval=versioned(
+            GrugEvalConfig(
+                eval_batch_size=BATCH_SIZE,
+                steps_per_eval=240,
+                max_eval_batches=8,
+                eval_current=True,
+                eval_ema=False,
+            )
+        ),
+    ),
+)
+
+
+def main():
+    executor_main(steps=[canary_moe_step])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- `experiments/ferries/canary_ferry_moe.py` — MoE counterpart to the dense canary ferry. Grug MoE trial model (512 hidden, 8 experts pick-2, 6 layers) scaled to ~1B tokens (476 steps, batch=512, seq=4096) on v5p-8. Copies `run_grug_moe_trial` locally with profiling enabled (grug copy-first style).
- `.github/workflows/marin-canary-ferry-moe.yaml` — daily cron at 7 AM UTC (offset from dense canary at 6 AM) + `workflow_dispatch`.

Stage 4 of #2873, motivated by #2981 — the team agreed daily canaries should cover MoE since that's what we're shipping.

## Trial results

Manual trial on `us-central1` (2026-03-06, job `ray-run-romain-canary_ferry_moe-20260306-201448`):

| Metric | Value |
|--------|-------|
| Total wall-clock | **~57 min** (startup + training + eval) |
| Training time | ~47 min |
| Steady-state step rate | **4.8 s/step** (stable from step 27 onward) |
| Final train loss | **4.37** |
| Final eval loss | 4.56 (macro: 4.73) |

One node preemption mid-run — Fray auto-retried on a new node and still finished within budget.

<details>
<summary>Loss trajectory (sampled every ~13 steps)</summary>

| Step | Loss | Elapsed |
|------|------|---------|
| 1 | 12.0 | 02:26 |
| 14 | 9.37 | 06:58 |
| 27 | 8.15 | 08:01 |
| 65 | 7.13 | 11:09 |
| 130 | 6.41 | 16:21 |
| 240 | 5.52 | 26:17 (eval pause) |
| 345 | 4.94 | 34:38 |
| 476 | 4.37 | 46:45 |

</details>

<details>
<summary>Final eval losses (step 476)</summary>

**Aggregate**
| Metric | Loss |
|--------|------|
| eval loss | 4.560 |
| paloma macro | 4.759 |
| paloma micro | 4.536 |
| uncheatable_eval macro | 4.676 |
| uncheatable_eval micro | 4.756 |

**Paloma**
| Split | Loss |
|-------|------|
| 4chan | 4.358 |
| c4_100_domains | 4.431 |
| c4_en | 4.494 |
| dolma-v1_5 | 4.509 |
| dolma_100_programing_languages | 4.513 |
| dolma_100_subreddits | 4.563 |
| falcon-refinedweb | 4.615 |
| gab | 5.748 |
| m2d2_s2orc_unsplit | 4.494 |
| m2d2_wikipedia_unsplit | 4.382 |
| manosphere_meta_sep | 4.739 |
| mc4 | 4.517 |
| ptb | 5.525 |
| redpajama | 4.656 |
| twitterAAE_HELM_fixed | 5.703 |
| wikitext_103 | 4.902 |

**Uncheatable eval**
| Split | Loss |
|-------|------|
| wikipedia_english | 4.351 |
| github_python | 4.933 |
| github_cpp | 4.519 |
| bbc_news | 4.310 |
| arxiv_physics | 4.779 |
| arxiv_computer_science | 4.827 |
| ao3_english | 5.010 |

</details>

## Out of scope

**Metrics gating** — `validate_canary_metrics.py` is coupled to the dense canary: `resolve_canary_output_path` hardcodes the dense ferry's `make_training_step`, and it reads `tracker_metrics.jsonl` which the Grug trainer may not produce. A follow-up should refactor the validation script to support both ferries and wire MoE thresholds (suggested from trial: train loss < 5.0, step rate < 8.0 s/step). Without gating, the daily cron still catches infra failures (crash/OOM → non-zero exit code in GH Actions).

**Profile summarization** — profiling is enabled in the script, but the workflow does not include a summarize step yet. Need to verify that the Grug trainer's profiling artifacts are compatible with `marin.profiling.cli summarize` before wiring it in.

**CW/GPU variant** — blocked on #2828 (Levanter GPU MoE kernels).

## Test plan

- [x] `ruff check` and `actionlint` pass (same pre-existing warnings as dense canary)
- [x] Manual trial run completed successfully on `us-central1` (476/476 steps, ~57 min)
- [ ] Daily cron will trigger automatically after merge; verify first run via GH Actions