### PR TITLE
Allow to filter iris logs by level in CLI

### DIFF
--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -830,6 +830,12 @@ def list_jobs(ctx, state: str | None, prefix: str | None, json_output: bool) -> 
 )
 @click.option("--follow", "-f", is_flag=True, help="Stream logs continuously.")
 @click.option(
+    "--level",
+    type=click.Choice(["debug", "info", "warning", "error", "critical"], case_sensitive=False),
+    default=None,
+    help="Minimum log level to display (e.g., --level warning).",
+)
+@click.option(
     "--include-children/--no-include-children",
     default=False,
     help="Include logs from child jobs (nested submissions).",
@@ -841,6 +847,7 @@ def logs(
     since_ms: int | None,
     since_seconds: int | None,
     follow: bool,
+    level: str | None,
     include_children: bool,
 ) -> None:
     """Stream task logs for a job using batch log fetching."""
@@ -856,6 +863,8 @@ def logs(
     start_since_ms = since_ms or 0
     job_name = JobName.from_wire(job_id)
 
+    min_level = level.upper() if level else ""
+
     if follow:
         job = Job(client, job_name)
         job.wait(
@@ -863,6 +872,7 @@ def logs(
             include_children=include_children,
             timeout=float("inf"),
             raise_on_failure=False,
+            min_level=min_level,
         )
         return
 
@@ -870,6 +880,7 @@ def logs(
         job_name,
         include_children=include_children,
         start=Timestamp.from_ms(start_since_ms) if start_since_ms > 0 else None,
+        min_level=min_level,
     )
     for entry in entries:
         ts = entry.timestamp.as_short_time()

--- a/lib/iris/src/iris/client/client.py
+++ b/lib/iris/src/iris/client/client.py
@@ -281,6 +281,7 @@ class Job:
         raise_on_failure: bool = True,
         stream_logs: bool = False,
         include_children: bool = False,
+        min_level: str = "",
     ) -> cluster_pb2.JobStatus:
         """Wait for job to complete.
 
@@ -289,6 +290,7 @@ class Job:
             poll_interval: Maximum time between status checks
             raise_on_failure: If True, raise JobFailedError on any non-SUCCESS terminal state
             stream_logs: If True, stream logs from all tasks interleaved
+            min_level: Minimum log level filter (DEBUG/INFO/WARNING/ERROR/CRITICAL)
 
         Returns:
             Final JobStatus
@@ -300,7 +302,7 @@ class Job:
         if not stream_logs:
             status = self._client._cluster_client.wait_for_job(self._job_id, timeout, poll_interval)
         else:
-            status = self._wait_with_multi_task_streaming(timeout, poll_interval, include_children)
+            status = self._wait_with_multi_task_streaming(timeout, poll_interval, include_children, min_level)
 
         if raise_on_failure and status.state != cluster_pb2.JOB_STATE_SUCCEEDED:
             raise JobFailedError(self._job_id, status)
@@ -312,6 +314,7 @@ class Job:
         timeout: float,
         poll_interval: float,
         include_children: bool,
+        min_level: str = "",
     ) -> cluster_pb2.JobStatus:
         """Wait while streaming logs from all tasks using batch log fetching.
 
@@ -326,6 +329,7 @@ class Job:
             include_children=include_children,
             since_ms=0,
             state_logger=DefaultTaskStateLogger(),
+            min_level=min_level,
         )
 
     def terminate(self) -> None:
@@ -818,6 +822,7 @@ class IrisClient:
         max_lines: int = 0,
         regex: str | None = None,
         attempt_id: int = -1,
+        min_level: str = "",
     ) -> list[TaskLogEntry]:
         """Fetch logs for a task or job.
 
@@ -828,6 +833,7 @@ class IrisClient:
             max_lines: Maximum number of log lines to return (0 = unlimited)
             regex: Regex filter for log content
             attempt_id: Filter to specific attempt (-1 = all attempts)
+            min_level: Minimum log level filter (DEBUG/INFO/WARNING/ERROR/CRITICAL)
 
         Returns:
             List of TaskLogEntry objects, sorted by timestamp
@@ -839,6 +845,7 @@ class IrisClient:
             max_total_lines=max_lines,
             regex=regex,
             attempt_id=attempt_id,
+            min_level=min_level,
         )
 
         result: list[TaskLogEntry] = []

--- a/lib/iris/src/iris/cluster/client/protocol.py
+++ b/lib/iris/src/iris/cluster/client/protocol.py
@@ -72,6 +72,7 @@ class ClusterClient(Protocol):
         include_children: bool,
         since_ms: int = 0,
         state_logger: TaskStateLogger | None = None,
+        min_level: str = "",
     ) -> cluster_pb2.JobStatus: ...
 
     def terminate_job(self, job_id: JobName) -> None: ...
@@ -105,6 +106,7 @@ class ClusterClient(Protocol):
         max_total_lines: int = 0,
         regex: str | None = None,
         attempt_id: int = -1,
+        min_level: str = "",
     ) -> cluster_pb2.Controller.GetTaskLogsResponse: ...
 
     def get_autoscaler_status(self) -> cluster_pb2.Controller.GetAutoscalerStatusResponse: ...

--- a/lib/iris/src/iris/cluster/client/remote_client.py
+++ b/lib/iris/src/iris/cluster/client/remote_client.py
@@ -150,6 +150,7 @@ class RemoteClusterClient:
         include_children: bool,
         since_ms: int = 0,
         state_logger: TaskStateLogger | None = None,
+        min_level: str = "",
     ) -> cluster_pb2.JobStatus:
         """Wait for job completion while streaming task logs via the controller RPC.
 
@@ -185,6 +186,7 @@ class RemoteClusterClient:
                     include_children=include_children,
                     since_ms=last_timestamp_ms,
                     resume_offsets=resume_offsets,
+                    min_level=min_level,
                 )
                 consecutive_log_failures = 0
                 log_fetch_backoff.reset()
@@ -338,6 +340,7 @@ class RemoteClusterClient:
         regex: str | None = None,
         attempt_id: int = -1,
         resume_offsets: dict[str, int] | None = None,
+        min_level: str = "",
     ) -> cluster_pb2.Controller.GetTaskLogsResponse:
         """Fetch logs for a task or job via the controller RPC.
 
@@ -352,6 +355,7 @@ class RemoteClusterClient:
             regex: Regex filter for log content
             attempt_id: Filter to specific attempt (-1 = all attempts)
             resume_offsets: Per-attempt line offset cursors from previous response
+            min_level: Minimum log level filter (DEBUG/INFO/WARNING/ERROR/CRITICAL)
         """
         request = cluster_pb2.Controller.GetTaskLogsRequest(
             id=target.to_wire(),
@@ -361,6 +365,7 @@ class RemoteClusterClient:
             regex=regex or "",
             attempt_id=attempt_id,
             resume_offsets=resume_offsets or {},
+            min_level=min_level,
         )
 
         def _call():


### PR DESCRIPTION
 * Allow to filter iris logs by level in CLI
 * Add `--level` flag to `iris job logs` to filter by minimum log level (e.g., `--level warning`). Threads through client, protocol, and remote client to the controller RPC.
