### PR TITLE
canary: add data loader stall diagnostics + keep_nodepool option

### DIFF
--- a/.github/workflows/marin-canary-ferry-cw.yaml
+++ b/.github/workflows/marin-canary-ferry-cw.yaml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 10 * * *'  # Daily at 10 AM UTC
   workflow_dispatch:
+    inputs:
+      keep_nodepool:
+        description: 'Keep CW node pool alive after the run (for faster re-runs)'
+        type: boolean
+        default: false
 
 permissions:
   contents: read   # actions/checkout
@@ -97,5 +102,9 @@ jobs:
         if: always()
         run: |
           .venv/bin/iris -v --config=lib/iris/examples/coreweave.yaml cluster stop || true
-          kubectl --kubeconfig ~/.kube/coreweave-iris \
-            delete nodepool -l iris-iris-managed=true
+          if [ "${{ inputs.keep_nodepool }}" != "true" ]; then
+            kubectl --kubeconfig ~/.kube/coreweave-iris \
+              delete nodepool -l iris-iris-managed=true
+          else
+            echo "Keeping node pool alive (keep_nodepool=true)"
+          fi

--- a/lib/levanter/src/levanter/data/loader.py
+++ b/lib/levanter/src/levanter/data/loader.py
@@ -261,10 +261,24 @@ class DataLoaderIterator(Iterator[Ex]):
         time_end = time.time()
         time_batch = time_end - time_mid
         if (time_end - time_start) > 0.5:
+            qsize = self._batches.qsize() if isinstance(self._batches, BackgroundIterator) else "N/A"
             if time_batch > 0.1:
-                logger.info(f"Prefetch wasn't fast enough: {time_end - time_start:.3f}. {time_batch:.3f} in batchify")
+                logger.warning(
+                    "Data loader stalled %.3fs (%.3fs in batchify). queue_size=%s prefetch_size=%d max_buffered=%s",
+                    time_end - time_start,
+                    time_batch,
+                    qsize,
+                    self.dl.prefetch_size,
+                    self.dl.max_buffered_batches,
+                )
             else:
-                logger.info(f"Prefetch wasn't fast enough: {time_end - time_start:.3f}.")
+                logger.warning(
+                    "Data loader stalled %.3fs. queue_size=%s prefetch_size=%d max_buffered=%s",
+                    time_end - time_start,
+                    qsize,
+                    self.dl.prefetch_size,
+                    self.dl.max_buffered_batches,
+                )
         return batch
 
     def __del__(self):

--- a/lib/levanter/src/levanter/utils/background_iterable.py
+++ b/lib/levanter/src/levanter/utils/background_iterable.py
@@ -90,6 +90,12 @@ class BackgroundIterator(Iterator[Ex]):
     def __del__(self):
         self.stop()
 
+    def qsize(self) -> int | None:
+        """Current number of items in the prefetch queue, or None if unbuffered."""
+        if self.thread is not None:
+            return self.q.qsize()
+        return None
+
     def stop(self, wait: bool = True):
         self._stop_event.set()
         # I'm getting an error that the thread is threading.current_thread(), which seems impossible


### PR DESCRIPTION
## Summary

- Enrich Levanter's slow-prefetch log with queue state (`queue_size`, `prefetch_size`, `max_buffered_batches`) and escalate to `logger.warning` so stalls are visible in filtered log views
- Add `BackgroundIterator.qsize()` to expose prefetch queue depth without field-peeking
- Add `keep_nodepool` workflow input to CW canary for faster iterative re-runs

## Context

The CW canary on 8xH100 (#3022) shows periodic data loader stalls. The existing log line ("Prefetch wasn't fast enough") didn't include queue state, making it impossible to distinguish buffer-drain stalls from other slowdowns.

## Experimental validation

Ran the CW canary with this change ([canary-gpu-22778297527-1](https://wandb.ai/marin-community/marin/runs/canary-gpu-22778297527-1)):

- 182 stall warnings fired, every one with `queue_size=0`
- Stall durations: 3–13s, in bursts of ~5 followed by ~30s gaps
- Pattern is consistent with prefetch buffer drain/refill at `prefetch_size=32`
- Device profile: 34% stall, 44% host, 22% compute — 78% non-compute time

This confirms the telemetry captures the right signal for #3022 triage.

## Test plan

- [x] Ran CW canary end-to-end with this change — 182 warnings fired with expected format
- [ ] Verify scheduled canary (no `keep_nodepool` input) still tears down node pools

🤖 Generated with [Claude Code](https://claude.com/claude-code)