### PR TITLE
Fix delivery failure handling: don't count undelivered tasks against retry budgets

### DIFF
--- a/lib/iris/src/iris/cluster/controller/state.py
+++ b/lib/iris/src/iris/cluster/controller/state.py
@@ -236,7 +236,11 @@ class ControllerTask:
 
     Retry Semantics:
         - failure_count: Incremented on TASK_STATE_FAILED. Checked against max_retries_failure.
-        - preemption_count: Incremented on TASK_STATE_WORKER_FAILED. Checked against max_retries_preemption.
+        - preemption_count: Incremented on TASK_STATE_WORKER_FAILED **only if** the task
+          was confirmed by the worker (reached BUILDING or RUNNING). Checked against
+          max_retries_preemption.
+        - Delivery failures (WORKER_FAILED while still ASSIGNED) are not counted against
+          any budget — the task simply returns to PENDING for rescheduling.
 
         When a task fails with retry budget remaining, it stays in the failure state but
         can_be_scheduled() returns True. The scheduler creates a new attempt when re-dispatching.
@@ -443,12 +447,29 @@ class ControllerTask:
         Does NOT reset task state - current attempt stays terminal.
         Scheduler will create new attempt when it reassigns the task.
 
+        Counting rules:
+        - TASK_STATE_FAILED always increments failure_count (user/task bug).
+        - TASK_STATE_WORKER_FAILED increments preemption_count ONLY if the
+          worker confirmed it had the task (state progressed beyond ASSIGNED
+          to BUILDING or RUNNING). If the task was still ASSIGNED, the worker
+          never received it — this is a delivery failure and is NOT counted
+          against any budget. The task simply goes back to PENDING.
+
+        Note: self.state still holds the PRE-transition value here because
+        handle_attempt_result updates it after _handle_failure returns.
+
         Args:
             new_state: The failure state (TASK_STATE_FAILED or TASK_STATE_WORKER_FAILED)
         """
         if new_state == cluster_pb2.TASK_STATE_WORKER_FAILED:
-            self.preemption_count += 1
-            can_retry = self.preemption_count <= self.max_retries_preemption
+            if self.state in (cluster_pb2.TASK_STATE_BUILDING, cluster_pb2.TASK_STATE_RUNNING):
+                # Worker had the task and lost it → real preemption.
+                self.preemption_count += 1
+                can_retry = self.preemption_count <= self.max_retries_preemption
+            else:
+                # Task was never confirmed by the worker (still ASSIGNED).
+                # This is a delivery failure — don't count against any budget.
+                can_retry = True
         else:
             self.failure_count += 1
             can_retry = self.failure_count <= self.max_retries_failure
@@ -1945,8 +1966,40 @@ class ControllerState:
     def begin_heartbeat(self, worker_id: WorkerId) -> HeartbeatSnapshot | None:
         """Atomically snapshot worker state and drain dispatch buffers.
 
+        This is phase 1 of the heartbeat protocol. The three phases are:
+
+        Phase 1 — begin_heartbeat (under lock):
+            Snapshot running_tasks and drain pending_dispatch into an immutable
+            HeartbeatSnapshot. After this call, pending_dispatch is empty for
+            this worker.
+
+        Phase 2 — RPC (no lock):
+            Send HeartbeatRequest to the worker. The request contains:
+            - tasks_to_run: new tasks to start (from pending_dispatch)
+            - tasks_to_kill: tasks to stop
+            - expected_tasks: all tasks the controller believes are on this
+              worker (from running_tasks), used for reconciliation
+
+            Invariant: every task in tasks_to_run also appears in expected_tasks,
+            because _on_task_assigned adds the task to running_tasks (which feeds
+            expected_tasks) and buffer_dispatch adds it to pending_dispatch (which
+            feeds tasks_to_run). The worker processes tasks_to_run before
+            reconciling expected_tasks, so newly-submitted tasks will be found.
+
+        Phase 3 — complete_heartbeat or fail_heartbeat (under lock):
+            On success: process worker's response (task state changes, health).
+            On failure: revert undelivered tasks (tasks_to_run) back to PENDING
+            so the scheduler can reassign them. Increment consecutive_failures;
+            if threshold exceeded, cascade WORKER_FAILED to all tasks.
+
+        Preconditions:
+            - worker_id is registered in _workers
+        Postconditions:
+            - pending_dispatch[worker_id] is empty (drained into snapshot)
+            - Snapshot is immutable and safe to use without locks
+            - Caller MUST call exactly one of complete_heartbeat or fail_heartbeat
+
         Returns None if worker is no longer registered (removed while heartbeat pending).
-        The snapshot is immutable and can be used for RPC without holding locks.
         """
         with self._lock:
             worker = self._workers.get(worker_id)
@@ -1978,7 +2031,16 @@ class ControllerState:
         snapshot: HeartbeatSnapshot,
         response: cluster_pb2.HeartbeatResponse,
     ) -> None:
-        """Process successful heartbeat response.
+        """Process successful heartbeat response (phase 3, success path).
+
+        Preconditions:
+            - snapshot was returned by begin_heartbeat for this worker
+            - response is the worker's HeartbeatResponse
+        Postconditions:
+            - worker.healthy = True, consecutive_failures = 0
+            - Task states updated from worker reports (BUILDING, RUNNING, terminal)
+            - Terminal tasks trigger retry/cleanup via the normal state machine
+            - Worker resource metrics updated
 
         Updates worker health state and processes task state changes from the response.
         Log entries are collected under the state lock but flushed to SQLite after
@@ -2067,12 +2129,24 @@ class ControllerState:
         self._transactions.append(txn)
 
     def fail_heartbeat(self, snapshot: HeartbeatSnapshot, error: str) -> None:
-        """Handle heartbeat failure - requeue dispatches, track failures.
+        """Handle heartbeat RPC failure (phase 3, failure path).
 
-        Requeues any buffered dispatches so they can be retried on the next heartbeat.
-        Increments the worker's consecutive failure count. If the threshold is exceeded,
-        the worker will be marked as failed and pending dispatches are cleared (tasks
-        will be requeued via WORKER_FAILED state transition).
+        Preconditions:
+            - snapshot was returned by begin_heartbeat for this worker
+            - The heartbeat RPC failed (timeout, connection refused, etc.)
+        Postconditions:
+            - worker.consecutive_failures incremented
+            - If threshold exceeded: worker pruned, ALL tasks cascade to WORKER_FAILED
+            - If worker still healthy: tasks in snapshot.tasks_to_run are reverted
+              to PENDING (the worker never received them). Tasks only in
+              expected_tasks (previously confirmed) are left alone — the failure
+              may be transient and the worker may still be running them.
+            - Kill requests are re-buffered (idempotent, safe to retry)
+
+        The revert for undelivered tasks (tasks_to_run) goes through the normal
+        WORKER_FAILED state machine path. Because the task is still in ASSIGNED
+        state (never progressed to BUILDING/RUNNING), _handle_failure treats this
+        as a delivery failure: no budget is consumed, the task returns to PENDING.
         """
         with self._lock:
             worker = self._workers.get(snapshot.worker_id)
@@ -2085,13 +2159,27 @@ class ControllerState:
             self._on_worker_heartbeat_failed(txn, event)
             self._transactions.append(txn)
 
-            # Only requeue dispatches if worker is still healthy.
-            # If worker failed, tasks are already being requeued via WORKER_FAILED
-            # state transition, and we don't want stale dispatches lingering.
             if worker.healthy:
-                pd = self._pending_dispatch.setdefault(snapshot.worker_id, PendingDispatch())
-                pd.tasks_to_run.extend(snapshot.tasks_to_run)
-                pd.tasks_to_kill.extend(snapshot.tasks_to_kill)
+                # Revert undelivered task assignments: the worker never received
+                # these, so transition them back to PENDING for rescheduling.
+                # This avoids tying up resources on an unreachable worker and
+                # prevents "Task not found" reports on subsequent heartbeats.
+                for req in snapshot.tasks_to_run:
+                    task_id = JobName.from_wire(req.task_id)
+                    task = self._tasks.get(task_id)
+                    if task and not task.is_finished():
+                        revert_event = TaskStateChangedEvent(
+                            task_id=task_id,
+                            new_state=cluster_pb2.TASK_STATE_WORKER_FAILED,
+                            attempt_id=req.attempt_id,
+                            error=f"Heartbeat delivery failed: {error}",
+                        )
+                        self._on_task_state_changed(txn, revert_event)
+
+                # Requeue kills — they're idempotent and harmless to retry.
+                if snapshot.tasks_to_kill:
+                    pd = self._pending_dispatch.setdefault(snapshot.worker_id, PendingDispatch())
+                    pd.tasks_to_kill.extend(snapshot.tasks_to_kill)
             else:
                 # Worker failed - clear any pending dispatches
                 self._pending_dispatch.pop(snapshot.worker_id, None)

--- a/lib/iris/src/iris/cluster/worker/worker.py
+++ b/lib/iris/src/iris/cluster/worker/worker.py
@@ -527,12 +527,22 @@ class Worker:
     def handle_heartbeat(self, request: cluster_pb2.HeartbeatRequest) -> cluster_pb2.HeartbeatResponse:
         """Handle controller-initiated heartbeat with reconciliation.
 
-        Processes tasks_to_run and tasks_to_kill, reconciles expected_tasks against
-        actual state, and returns current running/completed tasks.
+        Processing order (sequential, not concurrent):
+        1. Submit tasks_to_run — registers each task in self._tasks
+        2. Kill tasks_to_kill — async, sets stop flag immediately
+        3. Reconcile expected_tasks — for each expected task, report its current
+           state. If not found in self._tasks, report WORKER_FAILED ("Task not
+           found on worker"). This can happen if submit_task threw in step 1.
+        4. Kill unexpected tasks — any task in self._tasks that is NOT in
+           expected_tasks or tasks_to_run is killed (controller no longer wants it)
+
+        The ordering guarantee between steps 1 and 3 is critical: a task that
+        appears in both tasks_to_run and expected_tasks (which is always the case
+        for newly-assigned tasks) will be submitted before reconciliation checks
+        for it, so it will be found.
 
         Kill operations are performed asynchronously in daemon threads to avoid
-        blocking the heartbeat RPC. The task's should_stop flag is set immediately,
-        and the container stop/wait/force-kill sequence runs in the background.
+        blocking the heartbeat RPC.
         """
         # Reset heartbeat deadline
         self._heartbeat_deadline = Deadline.from_seconds(self._config.heartbeat_timeout.to_seconds())
@@ -602,8 +612,13 @@ class Worker:
                             tasks.append(entry)
 
                     # Kill tasks not in expected_tasks - the controller has decided these
-                    # tasks should no longer run (e.g., job was killed, task was reassigned)
+                    # tasks should no longer run (e.g., job was killed, task was reassigned).
+                    # Include tasks_to_run in the expected set: these were just submitted
+                    # in this heartbeat and may not yet appear in expected_tasks if the
+                    # controller excludes unconfirmed tasks.
                     expected_keys = {(entry.task_id, entry.attempt_id) for entry in request.expected_tasks}
+                    for run_req in request.tasks_to_run:
+                        expected_keys.add((run_req.task_id, run_req.attempt_id))
                     tasks_to_kill: list[tuple[str, int]] = []
                     for key, task in self._tasks.items():
                         if key not in expected_keys and task.status not in self._TERMINAL_STATES:

--- a/lib/iris/tests/cluster/controller/test_state.py
+++ b/lib/iris/tests/cluster/controller/test_state.py
@@ -490,9 +490,12 @@ def test_dispatch_failure_marks_worker_failed_and_requeues_task(job_request, wor
     # 1. Worker marked unhealthy
     assert worker.healthy is False
 
-    # 2. Task requeued (back to PENDING for retry)
+    # 2. Task requeued (back to PENDING for retry).
+    #    Since the task was still ASSIGNED (never confirmed BUILDING/RUNNING),
+    #    this is a delivery failure — no budget consumed at all.
     assert task.state == cluster_pb2.TASK_STATE_PENDING
-    assert task.preemption_count == 1
+    assert task.preemption_count == 0
+    assert task.failure_count == 0
     assert task.can_be_scheduled()
 
     # 3. Task should be requeued for retry
@@ -2095,27 +2098,39 @@ def test_fail_heartbeat_clears_dispatch_when_worker_fails(job_request, worker_me
     )
 
 
-def test_fail_heartbeat_requeues_dispatch_when_worker_healthy(job_request, worker_metadata):
-    """Dispatch buffer is repopulated when worker remains healthy after failure.
+def test_fail_heartbeat_reverts_undelivered_assignments(job_request, worker_metadata):
+    """Undelivered task assignments are reverted to PENDING on heartbeat failure.
 
     When heartbeat fails but worker is still below failure threshold,
-    the dispatches should be requeued for the next heartbeat attempt.
+    tasks in tasks_to_run (never delivered to the worker) are reverted
+    to PENDING so the scheduler can reassign them to a reachable worker.
     """
 
     state = ControllerState()
     worker_id = register_worker(state, "w1", "host:8080", worker_metadata())
 
-    # Submit and dispatch a task
-    tasks = submit_job(state, "j1", job_request("job1"))
-    dispatch_task(state, tasks[0], worker_id)
+    # Submit a job and assign its task to the worker
+    req = job_request("job1")
+    req.max_retries_preemption = 5
+    tasks = submit_job(state, "j1", req)
+    task = tasks[0]
 
-    # Buffer a dispatch
-    fake_request = cluster_pb2.Worker.RunTaskRequest(task_id="/test-user/fake/0")
-    state.buffer_dispatch(worker_id, fake_request)
+    # Assign the task (creates attempt, commits resources)
+    state.handle_event(TaskAssignedEvent(task_id=task.task_id, worker_id=worker_id))
+    assert task.state == cluster_pb2.TASK_STATE_ASSIGNED
+    assert task.current_attempt_id == 0
 
-    # Take snapshot
+    # Buffer the dispatch for delivery
+    run_request = cluster_pb2.Worker.RunTaskRequest(
+        task_id=task.task_id.to_wire(),
+        attempt_id=0,
+    )
+    state.buffer_dispatch(worker_id, run_request)
+
+    # Take snapshot (drains buffer)
     snapshot = state.begin_heartbeat(worker_id)
     assert snapshot is not None
+    assert len(snapshot.tasks_to_run) == 1
 
     # Fail heartbeat (worker stays healthy - below threshold)
     state.fail_heartbeat(snapshot, "Timeout")
@@ -2125,9 +2140,17 @@ def test_fail_heartbeat_requeues_dispatch_when_worker_healthy(job_request, worke
     assert worker.healthy
     assert worker.consecutive_failures == 1
 
-    # Verify dispatch was requeued
-    assert worker_id in state._pending_dispatch
-    assert len(state._pending_dispatch[worker_id].tasks_to_run) == 1
+    # Verify undelivered task was reverted to PENDING (not requeued as dispatch)
+    assert task.state == cluster_pb2.TASK_STATE_PENDING
+    assert task.can_be_scheduled()
+
+    # Delivery failure: no budget consumed at all.
+    assert task.preemption_count == 0
+    assert task.failure_count == 0
+
+    # Verify dispatch was NOT requeued (task is back in scheduling queue instead)
+    pending_dispatch = state._pending_dispatch.get(worker_id)
+    assert pending_dispatch is None or len(pending_dispatch.tasks_to_run) == 0
 
 
 def test_complete_heartbeat_processes_task_states(job_request, worker_metadata):
@@ -2165,6 +2188,124 @@ def test_complete_heartbeat_processes_task_states(job_request, worker_metadata):
     # Verify job is succeeded
     job = state.get_job(tasks[0].job_id)
     assert job.state == cluster_pb2.JOB_STATE_SUCCEEDED
+
+
+def test_worker_failed_from_assigned_is_delivery_failure(job_request, worker_metadata):
+    """WORKER_FAILED on a task still in ASSIGNED state is a delivery failure.
+
+    When a task was assigned but never confirmed running (BUILDING/RUNNING),
+    a WORKER_FAILED is a delivery failure — no budget is consumed. This
+    prevents preemption count inflation from repeated 'Task not found' reports.
+    """
+    state = ControllerState()
+    worker_id = register_worker(state, "w1", "host:8080", worker_metadata())
+
+    req = job_request("job1")
+    req.max_retries_preemption = 5
+    tasks = submit_job(state, "j1", req)
+    task = tasks[0]
+
+    # Assign but do NOT transition to RUNNING
+    state.handle_event(TaskAssignedEvent(task_id=task.task_id, worker_id=worker_id))
+    assert task.state == cluster_pb2.TASK_STATE_ASSIGNED
+
+    # Worker reports WORKER_FAILED (e.g., "Task not found on worker")
+    transition_task(
+        state,
+        task.task_id,
+        cluster_pb2.TASK_STATE_WORKER_FAILED,
+        error="Task not found on worker",
+    )
+
+    # Delivery failure: no budget consumed at all
+    assert task.preemption_count == 0
+    assert task.failure_count == 0
+    assert task.state == cluster_pb2.TASK_STATE_PENDING
+    assert task.can_be_scheduled()
+
+
+def test_worker_failed_from_running_counts_as_preemption(job_request, worker_metadata):
+    """WORKER_FAILED on a task in RUNNING state counts as a preemption."""
+    state = ControllerState()
+    worker_id = register_worker(state, "w1", "host:8080", worker_metadata())
+
+    req = job_request("job1")
+    req.max_retries_preemption = 5
+    tasks = submit_job(state, "j1", req)
+    task = tasks[0]
+
+    # Full lifecycle: assign and transition to RUNNING
+    dispatch_task(state, task, worker_id)
+    assert task.state == cluster_pb2.TASK_STATE_RUNNING
+
+    # Worker dies
+    transition_task(
+        state,
+        task.task_id,
+        cluster_pb2.TASK_STATE_WORKER_FAILED,
+        error="Worker crashed",
+    )
+
+    # Real preemption: counts against preemption budget
+    assert task.preemption_count == 1
+    assert task.failure_count == 0
+    assert task.state == cluster_pb2.TASK_STATE_PENDING
+    assert task.can_be_scheduled()
+
+
+def test_worker_failed_from_building_counts_as_preemption(job_request, worker_metadata):
+    """WORKER_FAILED on a task in BUILDING state counts as a preemption."""
+    state = ControllerState()
+    worker_id = register_worker(state, "w1", "host:8080", worker_metadata())
+
+    req = job_request("job1")
+    req.max_retries_preemption = 5
+    tasks = submit_job(state, "j1", req)
+    task = tasks[0]
+
+    # Assign and transition to BUILDING (worker confirmed it received the task)
+    state.handle_event(TaskAssignedEvent(task_id=task.task_id, worker_id=worker_id))
+    transition_task(state, task.task_id, cluster_pb2.TASK_STATE_BUILDING)
+    assert task.state == cluster_pb2.TASK_STATE_BUILDING
+
+    # Worker dies
+    transition_task(
+        state,
+        task.task_id,
+        cluster_pb2.TASK_STATE_WORKER_FAILED,
+        error="Worker crashed",
+    )
+
+    # Real preemption: worker had started processing the task
+    assert task.preemption_count == 1
+    assert task.failure_count == 0
+
+
+def test_fail_heartbeat_kills_requeue_only(job_request, worker_metadata):
+    """Kill requests are still requeued on heartbeat failure (idempotent)."""
+    state = ControllerState()
+    worker_id = register_worker(state, "w1", "host:8080", worker_metadata())
+
+    tasks = submit_job(state, "j1", job_request("job1"))
+    dispatch_task(state, tasks[0], worker_id)
+
+    # Buffer a kill
+    state.buffer_kill(worker_id, tasks[0].task_id.to_wire())
+
+    snapshot = state.begin_heartbeat(worker_id)
+    assert snapshot is not None
+    assert len(snapshot.tasks_to_kill) == 1
+
+    # Fail heartbeat
+    state.fail_heartbeat(snapshot, "Timeout")
+
+    worker = state.get_worker(worker_id)
+    assert worker.healthy
+
+    # Kills should be requeued
+    pd = state._pending_dispatch.get(worker_id)
+    assert pd is not None
+    assert len(pd.tasks_to_kill) == 1
 
 
 # =============================================================================


### PR DESCRIPTION
Distinguish between delivery failures (task never reached the worker) and real preemptions (worker had the task and lost it). When a task is still in ASSIGNED state and transitions to WORKER_FAILED, it means the worker never received it — this should not consume preemption budget.

Key changes:

1. Task state machine: WORKER_FAILED only increments preemption_count if the task had progressed to BUILDING or RUNNING. If still ASSIGNED, it's treated as a delivery failure with no budget consumed.

2. Heartbeat failure handling: When an RPC fails, undelivered tasks (those in tasks_to_run that were never confirmed by the worker) are reverted to PENDING via WORKER_FAILED state transition. Because they're still ASSIGNED, the delivery failure path applies — no budget consumed.

3. Kill requests remain requeued on heartbeat failure (idempotent operation).

4. Updated docstrings to clarify the three-phase heartbeat protocol and retry semantics.

This prevents preemption count inflation from repeated "Task not found on worker" reports when a worker is unreachable, while still counting real preemptions (where the worker had the task) against the preemption budget.

https://claude.ai/code/session_018EZNPUwnpZSKQb45b9aGZV