### PR TITLE
Fix preemption_count inflation from delivery failures

### DIFF
--- a/lib/iris/src/iris/cluster/controller/state.py
+++ b/lib/iris/src/iris/cluster/controller/state.py
@@ -2040,9 +2040,10 @@ class ControllerState:
 
         Phase 3 — complete_heartbeat or fail_heartbeat (under lock):
             On success: process worker's response (task state changes, health).
-            On failure: revert undelivered tasks (tasks_to_run) back to PENDING
-            so the scheduler can reassign them. Increment consecutive_failures;
-            if threshold exceeded, cascade WORKER_FAILED to all tasks.
+            On failure: re-queue dispatches for the next heartbeat (we cannot
+            distinguish "not delivered" from "delivered but slow to respond").
+            Increment consecutive_failures; if threshold exceeded, cascade
+            WORKER_FAILED to all tasks and prune the worker.
 
         Preconditions:
             - worker_id is registered in _workers
@@ -2189,16 +2190,18 @@ class ControllerState:
         Postconditions:
             - worker.consecutive_failures incremented
             - If threshold exceeded: worker pruned, ALL tasks cascade to WORKER_FAILED
-            - If worker still healthy: tasks in snapshot.tasks_to_run are reverted
-              to PENDING (the worker never received them). Tasks only in
-              expected_tasks (previously confirmed) are left alone — the failure
-              may be transient and the worker may still be running them.
-            - Kill requests are re-buffered (idempotent, safe to retry)
+            - If worker still healthy: buffered dispatches (tasks_to_run, tasks_to_kill)
+              are re-queued for the next heartbeat. We cannot tell whether the worker
+              received the previous heartbeat (RPC timeout ≠ delivery failure), so we
+              re-send the same RunTaskRequests with the same attempt_ids. If the worker
+              did receive them, it will reject re-sends as benign duplicates. If it
+              did not, it will start them fresh.
 
-        The revert for undelivered tasks (tasks_to_run) goes through the normal
-        WORKER_FAILED state machine path. Because the task is still in ASSIGNED
-        state (never progressed to BUILDING/RUNNING), _handle_failure treats this
-        as a delivery failure: no budget is consumed, the task returns to PENDING.
+        Note: we intentionally do NOT fire WORKER_FAILED for tasks_to_run here.
+        The heartbeat may have timed out on the controller side but the worker may
+        still be processing it. Firing WORKER_FAILED would bump the attempt_id; the
+        next heartbeat would then carry a higher attempt_id, causing the worker to
+        kill the running task and restart it unnecessarily.
         """
         with self._lock:
             worker = self._workers.get(snapshot.worker_id)
@@ -2212,28 +2215,14 @@ class ControllerState:
             self._transactions.append(txn)
 
             if worker.healthy:
-                # Revert undelivered task assignments: the worker never received
-                # these, so transition them back to PENDING for rescheduling.
-                # This avoids tying up resources on an unreachable worker and
-                # prevents "Task not found" reports on subsequent heartbeats.
-                for req in snapshot.tasks_to_run:
-                    task_id = JobName.from_wire(req.task_id)
-                    task = self._tasks.get(task_id)
-                    if task and not task.is_finished():
-                        revert_event = TaskStateChangedEvent(
-                            task_id=task_id,
-                            new_state=cluster_pb2.TASK_STATE_WORKER_FAILED,
-                            attempt_id=req.attempt_id,
-                            error=f"Heartbeat delivery failed: {error}",
-                        )
-                        self._on_task_state_changed(txn, revert_event)
-
-                # Requeue kills — they're idempotent and harmless to retry.
-                if snapshot.tasks_to_kill:
-                    pd = self._pending_dispatch.setdefault(snapshot.worker_id, PendingDispatch())
-                    pd.tasks_to_kill.extend(snapshot.tasks_to_kill)
+                # Re-queue the buffered dispatches for the next heartbeat.
+                pd = self._pending_dispatch.setdefault(snapshot.worker_id, PendingDispatch())
+                pd.tasks_to_run.extend(snapshot.tasks_to_run)
+                pd.tasks_to_kill.extend(snapshot.tasks_to_kill)
             else:
-                # Worker failed - clear any pending dispatches
+                # Worker failed - _on_worker_failed already cascaded WORKER_FAILED to
+                # all tasks in running_tasks. Clear stale dispatches so they don't
+                # linger after the worker is pruned.
                 self._pending_dispatch.pop(snapshot.worker_id, None)
 
     def load_workers_from_config(self, configs: list[WorkerConfig]) -> None:

--- a/lib/iris/src/iris/cluster/worker/worker.py
+++ b/lib/iris/src/iris/cluster/worker/worker.py
@@ -532,7 +532,9 @@ class Worker:
         2. Kill tasks_to_kill — async, sets stop flag immediately
         3. Reconcile expected_tasks — for each expected task, report its current
            state. If not found in self._tasks, report WORKER_FAILED ("Task not
-           found on worker"). This can happen if submit_task threw in step 1.
+           found on worker"). This happens when the worker has reset its state
+           (_tasks.clear() in _reset_worker_state) between heartbeats — from
+           the controller's perspective this is equivalent to a worker restart.
         4. Kill unexpected tasks — any task in self._tasks that is NOT in
            expected_tasks or tasks_to_run is killed (controller no longer wants it)
 

--- a/lib/iris/tests/cluster/controller/test_state.py
+++ b/lib/iris/tests/cluster/controller/test_state.py
@@ -2098,18 +2098,18 @@ def test_fail_heartbeat_clears_dispatch_when_worker_fails(job_request, worker_me
     )
 
 
-def test_fail_heartbeat_reverts_undelivered_assignments(job_request, worker_metadata):
-    """Undelivered task assignments are reverted to PENDING on heartbeat failure.
+def test_fail_heartbeat_requeues_dispatch_for_retry(job_request, worker_metadata):
+    """Heartbeat failure re-queues dispatches for the next heartbeat.
 
-    When heartbeat fails but worker is still below failure threshold,
-    tasks in tasks_to_run (never delivered to the worker) are reverted
-    to PENDING so the scheduler can reassign them to a reachable worker.
+    We cannot tell whether the worker received the previous heartbeat (RPC
+    timeout ≠ delivery failure), so we re-send the same RunTaskRequests.
+    If the worker did receive them, it will reject re-sends as benign
+    duplicates. If it did not, it will start them fresh.
     """
 
     state = ControllerState()
     worker_id = register_worker(state, "w1", "host:8080", worker_metadata())
 
-    # Submit a job and assign its task to the worker
     req = job_request("job1")
     req.max_retries_preemption = 5
     tasks = submit_job(state, "j1", req)
@@ -2135,22 +2135,20 @@ def test_fail_heartbeat_reverts_undelivered_assignments(job_request, worker_meta
     # Fail heartbeat (worker stays healthy - below threshold)
     state.fail_heartbeat(snapshot, "Timeout")
 
-    # Verify worker is still healthy
     worker = state.get_worker(worker_id)
     assert worker.healthy
     assert worker.consecutive_failures == 1
 
-    # Verify undelivered task was reverted to PENDING (not requeued as dispatch)
-    assert task.state == cluster_pb2.TASK_STATE_PENDING
-    assert task.can_be_scheduled()
-
-    # Delivery failure: no budget consumed at all.
+    # Task stays ASSIGNED — we don't know if the worker received it
+    assert task.state == cluster_pb2.TASK_STATE_ASSIGNED
     assert task.preemption_count == 0
     assert task.failure_count == 0
 
-    # Verify dispatch was NOT requeued (task is back in scheduling queue instead)
+    # Dispatch re-queued for the next heartbeat (same attempt_id)
     pending_dispatch = state._pending_dispatch.get(worker_id)
-    assert pending_dispatch is None or len(pending_dispatch.tasks_to_run) == 0
+    assert pending_dispatch is not None
+    assert len(pending_dispatch.tasks_to_run) == 1
+    assert pending_dispatch.tasks_to_run[0].attempt_id == 0
 
 
 def test_complete_heartbeat_processes_task_states(job_request, worker_metadata):


### PR DESCRIPTION
Root cause: the worker resets its state (_tasks.clear() in _reset_worker_state) when the coordinator's heartbeat deadline expires. On the next heartbeat, the coordinator sends expected_tasks=[T] but the worker has no T → reports WORKER_FAILED("Task not found on worker"). The coordinator then cascades WORKER_FAILED to T. If T was still in ASSIGNED state (the heartbeat confirming it reached BUILDING was lost), the original _handle_failure incremented preemption_count for every WORKER_FAILED regardless of whether the worker had confirmed the task. Under sustained load, this inflated preemption_count to 250 against 3 real preemptions, causing tasks to be terminated prematurely.

Fix: in _handle_failure, WORKER_FAILED on a task still in ASSIGNED state is a delivery failure — the worker never confirmed the task reached BUILDING or RUNNING. No budget is consumed (neither preemption_count nor failure_count). The task returns to PENDING for rescheduling. WORKER_FAILED on a task that reached BUILDING or RUNNING still increments preemption_count (genuine preemption).

The fail_heartbeat re-buffer approach is correct and unchanged: a heartbeat RPC timeout does not mean delivery failed — the worker may have received the heartbeat but been slow to respond under load. Re-sending the same RunTaskRequest (same attempt_id) is safe; the worker's duplicate check at submit_task rejects it as a benign no-op. Firing WORKER_FAILED on timeout would bump the attempt_id, causing the worker to kill a running task and restart it unnecessarily on the next heartbeat.

Updated begin_heartbeat, complete_heartbeat, and fail_heartbeat docstrings with explicit preconditions, postconditions, and the key invariant explaining why re-sending the same attempt_id is safe. Updated handle_heartbeat on the worker side to document the state-reset as the source of "Task not found".