### PR TITLE
[grug] Add loop profiler annotations

### DIFF
--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -454,7 +454,8 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         # Main optimization loop.
         try:
             while int(state.step) < trainer.num_train_steps:
-                batch = next(iterator)
+                with jax.profiler.TraceAnnotation("load_batch"):
+                    batch = next(iterator)
                 step_start = time.perf_counter()
                 current_step = int(state.step)
                 # grad_watch runs only on its configured interval.
@@ -467,14 +468,15 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 jax.block_until_ready(metrics["train/loss"])
                 duration = time.perf_counter() - step_start
                 hook_start = time.perf_counter()
-                state_callbacks.run(state, loss=metrics["train/loss"], step_duration=duration)
-                last_loss = metrics["train/loss"]
-                last_step_duration = duration
-                levanter.tracker.log({"throughput/hook_time": time.perf_counter() - hook_start}, step=step)
-                levanter.tracker.log({"throughput/loading_time": iterator.this_load_time}, step=step)
+                with jax.profiler.TraceAnnotation("callbacks"):
+                    state_callbacks.run(state, loss=metrics["train/loss"], step_duration=duration)
+                    last_loss = metrics["train/loss"]
+                    last_step_duration = duration
+                    levanter.tracker.log({"throughput/hook_time": time.perf_counter() - hook_start}, step=step)
+                    levanter.tracker.log({"throughput/loading_time": iterator.this_load_time}, step=step)
 
-                if watch_stats is not None:
-                    levanter.tracker.log(watch_stats, step=step)
+                    if watch_stats is not None:
+                        levanter.tracker.log(watch_stats, step=step)
 
                 if checkpointer is not None:
                     checkpointer.on_step(tree={"train_state": state}, step=int(state.step))

--- a/experiments/grug/modular_opt/train.py
+++ b/experiments/grug/modular_opt/train.py
@@ -454,7 +454,8 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         # Main optimization loop.
         try:
             while int(state.step) < trainer.num_train_steps:
-                batch = next(iterator)
+                with jax.profiler.TraceAnnotation("load_batch"):
+                    batch = next(iterator)
                 step_start = time.perf_counter()
                 current_step = int(state.step)
                 # grad_watch runs only on its configured interval.
@@ -467,14 +468,15 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 jax.block_until_ready(metrics["train/loss"])
                 duration = time.perf_counter() - step_start
                 hook_start = time.perf_counter()
-                state_callbacks.run(state, loss=metrics["train/loss"], step_duration=duration)
-                last_loss = metrics["train/loss"]
-                last_step_duration = duration
-                levanter.tracker.log({"throughput/hook_time": time.perf_counter() - hook_start}, step=step)
-                levanter.tracker.log({"throughput/loading_time": iterator.this_load_time}, step=step)
+                with jax.profiler.TraceAnnotation("callbacks"):
+                    state_callbacks.run(state, loss=metrics["train/loss"], step_duration=duration)
+                    last_loss = metrics["train/loss"]
+                    last_step_duration = duration
+                    levanter.tracker.log({"throughput/hook_time": time.perf_counter() - hook_start}, step=step)
+                    levanter.tracker.log({"throughput/loading_time": iterator.this_load_time}, step=step)
 
-                if watch_stats is not None:
-                    levanter.tracker.log(watch_stats, step=step)
+                    if watch_stats is not None:
+                        levanter.tracker.log(watch_stats, step=step)
 
                 if checkpointer is not None:
                     checkpointer.on_step(tree={"train_state": state}, step=int(state.step))

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -463,7 +463,8 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         # Main optimization loop.
         try:
             while int(state.step) < trainer.num_train_steps:
-                batch = next(iterator)
+                with jax.profiler.TraceAnnotation("load_batch"):
+                    batch = next(iterator)
                 step_start = time.perf_counter()
                 current_step = int(state.step)
                 # grad_watch runs only on its configured interval.
@@ -476,19 +477,23 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 jax.block_until_ready(metrics["train/loss"])
                 duration = time.perf_counter() - step_start
                 hook_start = time.perf_counter()
-                state_callbacks.run(state, loss=metrics["train/loss"], step_duration=duration)
-                last_loss = metrics["train/loss"]
-                last_step_duration = duration
-                levanter.tracker.log({"throughput/hook_time": time.perf_counter() - hook_start}, step=step)
-                levanter.tracker.log({"throughput/loading_time": iterator.this_load_time}, step=step)
-                router_metrics = {key: value for key, value in metrics.items() if key.startswith("train/router/")}
-                if router_metrics:
-                    levanter.tracker.log(router_metrics, step=step)
-                if "train/cross_entropy_loss" in metrics:
-                    levanter.tracker.log({"train/cross_entropy_loss": metrics["train/cross_entropy_loss"]}, step=step)
+                with jax.profiler.TraceAnnotation("callbacks"):
+                    state_callbacks.run(state, loss=metrics["train/loss"], step_duration=duration)
+                    last_loss = metrics["train/loss"]
+                    last_step_duration = duration
+                    levanter.tracker.log({"throughput/hook_time": time.perf_counter() - hook_start}, step=step)
+                    levanter.tracker.log({"throughput/loading_time": iterator.this_load_time}, step=step)
+                    router_metrics = {key: value for key, value in metrics.items() if key.startswith("train/router/")}
+                    if router_metrics:
+                        levanter.tracker.log(router_metrics, step=step)
+                    if "train/cross_entropy_loss" in metrics:
+                        levanter.tracker.log(
+                            {"train/cross_entropy_loss": metrics["train/cross_entropy_loss"]},
+                            step=step,
+                        )
 
-                if watch_stats is not None:
-                    levanter.tracker.log(watch_stats, step=step)
+                    if watch_stats is not None:
+                        levanter.tracker.log(watch_stats, step=step)
 
                 if checkpointer is not None:
                     checkpointer.on_step(tree={"train_state": state}, step=int(state.step))


### PR DESCRIPTION
Add lightweight JAX profiler trace annotations to the grug training loop so profiles break out input loading and callback time in the base, moe, and modular_opt variants.

- Wrap `next(iterator)` in `jax.profiler.TraceAnnotation("load_batch")`.
- Wrap callback and logging work in `jax.profiler.TraceAnnotation("callbacks")`.
- Leave the rest of the training flow unchanged.

Fixes #3375
