### PR TITLE
Optimize Grug MoE ring EP compaction

### DIFF
--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -146,11 +146,6 @@ def _moe_mlp_ep_ring_local(
         weight_flat = combine_weights_global.reshape(assignments)
         token_flat = jnp.arange(assignments, dtype=jnp.int32) // topk
 
-        sort_idx = jnp.argsort(expert_flat, axis=0)
-        expert_sorted = jnp.take(expert_flat, sort_idx, axis=0)
-        token_sorted = jnp.take(token_flat, sort_idx, axis=0)
-        weight_sorted = jnp.take(weight_flat, sort_idx, axis=0).astype(x_local.dtype)
-
         local_experts = moe_w13_local.shape[0]
         if num_experts % local_experts != 0:
             raise ValueError(
@@ -163,18 +158,27 @@ def _moe_mlp_ep_ring_local(
 
         expert_axis = jax.lax.axis_index("expert")
         expert_start = expert_axis * local_experts
-        expert_end = expert_start + local_experts
-        local_mask = jnp.logical_and(expert_sorted >= expert_start, expert_sorted < expert_end)
-
-        local_idx = jnp.nonzero(local_mask, size=local_capacity, fill_value=0)[0]
+        local_expert = expert_flat - expert_start
+        local_mask = jnp.logical_and(local_expert >= 0, local_expert < local_experts)
         local_count = jnp.sum(local_mask, dtype=jnp.int32)
         dropped_local = jnp.maximum(local_count - local_capacity, 0)
         valid = jnp.arange(local_capacity, dtype=jnp.int32) < local_count
         valid_weight = valid.astype(jnp.float32)
 
-        token_local = jnp.take(token_sorted, local_idx, axis=0)
-        expert_local = jnp.take(expert_sorted, local_idx, axis=0) - expert_start
-        weight_local = jnp.take(weight_sorted, local_idx, axis=0)
+        # Keep only the assignments this shard will execute, ordered by
+        # (local expert id, original flat position). This avoids the global
+        # argsort + fused takes over all assignments that dominated high-EP
+        # shapes, while preserving the grouped layout expected by ragged_dot.
+        local_expert = jnp.where(local_mask, local_expert, 0)
+        flat_pos = jnp.arange(assignments, dtype=jnp.int32)
+        order_key = local_expert * assignments + flat_pos
+        max_order_key = local_experts * assignments
+        selection_key = jnp.where(local_mask, max_order_key - order_key, -1)
+        _, local_idx = jax.lax.top_k(selection_key, local_capacity)
+
+        token_local = jnp.take(token_flat, local_idx, axis=0)
+        expert_local = jnp.take(local_expert, local_idx, axis=0)
+        weight_local = jnp.take(weight_flat, local_idx, axis=0).astype(x_local.dtype)
 
         x_take = jnp.take(x_global, token_local, axis=0)
         x_dispatch = jnp.where(valid[:, None], x_take, jnp.zeros_like(x_take))


### PR DESCRIPTION
Optimize the Grug MoE ring expert-parallel local dispatch path by compacting only the assignments a shard will execute instead of globally sorting and taking all gathered assignments first. This preserves the grouped layout required by ragged_dot while removing the global argsort/full-length take sequence that dominated high-EP runs.

- Replace the global sort/filter path in _moe_mlp_ep_ring_local with local mask + ordered top_k compaction.
- Preserve local expert grouping and capacity/drop accounting.

Part of #2710