### PR TITLE
Fix agent guidance for pre-commit execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,8 @@
 
 - Assume Python >=3.11.
 - Always use `uv run` for Python entry points. If that fails, try `.venv/bin/python` directly.
-- Run `./infra/pre-commit.py --all-files` before sending changes; formatting and linting are enforced with `ruff`.
+- Run `./infra/pre-commit.py --all-files --fix` before sending changes; formatting and linting are enforced with `ruff`.
+- `./infra/pre-commit.py` is the required lint entry point for this repo. Do not replace it with `uv run pre-commit ...` (the `pre-commit` CLI may be unavailable in some environments).
 - Keep type hints passing under `uv run pyrefly`; configuration lives in `pyproject.toml`.
 
 ### Communication & Commits

--- a/docs/recipes/pull-request.md
+++ b/docs/recipes/pull-request.md
@@ -56,6 +56,7 @@ If no issue exists yet, create one with `gh issue create` before opening the PR.
 Before marking a PR ready for review:
 
 - Run `./infra/pre-commit.py --all-files --fix` and fix any issues.
+- Do not substitute `uv run pre-commit ...`; use `./infra/pre-commit.py` directly so checks run in all environments.
 - Run `uv run pytest -m 'not slow'` for the relevant test directories.
 - Ensure all CI checks pass after pushing. Monitor with
   `gh pr view <number> --json statusCheckRollup`.


### PR DESCRIPTION
Fixes #3358

This updates agent-facing repo guidance so automated runs consistently execute the Marin pre-commit checks before push.

- In `AGENTS.md`, require `./infra/pre-commit.py --all-files --fix` before sending changes.
- Add an explicit exception to the generic `uv run` guidance: do not use `uv run pre-commit ...`; invoke `./infra/pre-commit.py` directly.
- Mirror that explicit instruction in `docs/recipes/pull-request.md` to keep workflow docs aligned.

Validation:
- `./infra/pre-commit.py --all-files --fix`
