### PR TITLE
docs: align ray_run and docs build commands with current repo layout

### DIFF
--- a/docs/dev-guide/building-docs.md
+++ b/docs/dev-guide/building-docs.md
@@ -14,7 +14,7 @@ Before you begin, ensure you have the following installed:
 
 1. Install the documentation dependencies:
    ```bash
-   uv sync --group docs
+   uv sync --package marin --group docs
    ```
 
 ## Building Documentation

--- a/docs/explanations/executor.md
+++ b/docs/explanations/executor.md
@@ -69,7 +69,7 @@ Finally, to launch an experiment, use [`ray_run.py`](https://github.com/marin-co
 launches jobs to the Ray cluster:
 
 ```bash
-python marin/run/ray_run.py -- python experiments/hello_world.py
+uv run lib/marin/src/marin/run/ray_run.py -- python experiments/hello_world.py
 ```
 
 This script ensure that:

--- a/docs/tutorials/tpu-cluster-setup.md
+++ b/docs/tutorials/tpu-cluster-setup.md
@@ -98,15 +98,15 @@ to setup the required keys for accessing the Marin Ray clusters.
    ```bash
    ray dashboard infra/marin-$REGION.yaml
    ```
-2. We have made a thin wrapper on top of `ray submit` called [ray-run](https://github.com/marin-community/tree/main/marin/run/ray_run.py) which can be used to easily specify the additional pip requirements and environment variables (Apart from those specified in the Dockerfile or cluster config). Ray run ensures following stuff:
+2. We have made a thin wrapper on top of `ray submit` called [ray-run](https://github.com/marin-community/marin/blob/main/lib/marin/src/marin/run/ray_run.py) which can be used to easily specify additional dependency extras/packages and environment variables (apart from those specified in the Dockerfile or cluster config). Ray run ensures the following:
    - All the dependencies in pyproject.toml are installed
-   - Some of the necessary environment variables are set from file [vars.py](https://github.com/marin-community/tree/main/marin/run/vars.py)
+   - Some necessary environment defaults are set directly in `ray_run.py`
    - `src` directories of submodules are added to `PYTHONPATH`.
 
 
-You can use `--env_vars` and `--pip_deps` to specify additional environment variables and pip dependencies. For example, to run a job with additional pip dependencies `jax==0.4.35 and async-lru, along with the environment variable WANDB_API_KEY, you can use:
+You can use `--env_vars` and `--extra` to specify additional environment variables and dependency extras/packages. For example, to run a job with an additional package (`async-lru`) and the environment variable `WANDB_API_KEY`, you can use:
 ```bash
-python marin/run/ray_run.py --env_vars WANDB_API_KEY ${WANDB_API_KEY}  --pip_deps jax==0.4.35,async-lru --  python experiments/tutorials/hello_world.py
+uv run lib/marin/src/marin/run/ray_run.py --env_vars WANDB_API_KEY ${WANDB_API_KEY} --extra async-lru -- python experiments/tutorials/hello_world.py
 ```
 
 ## Managing the Cluster

--- a/docs/tutorials/train-an-lm.md
+++ b/docs/tutorials/train-an-lm.md
@@ -139,7 +139,7 @@ The `default_train` function creates a training pipeline that:
 To train the model with experiment tracking:
 
 ```bash
-python marin/run/ray_run.py --env_vars WANDB_API_KEY ${YOUR_WANDB_API_KEY} -- python experiments/${YOUR_EXPERIMENT_SCRIPT}.py
+uv run lib/marin/src/marin/run/ray_run.py --env_vars WANDB_API_KEY ${YOUR_WANDB_API_KEY} -- python experiments/${YOUR_EXPERIMENT_SCRIPT}.py
 ```
 
 Following Marin's guidelines, name your experiment script `experiments/exp{GITHUB_ISSUE_NUMBER}_{DESCRIPTOR}.py`, where `GITHUB_ISSUE_NUMBER` is the issue number for your experiment and `DESCRIPTOR` is a brief description.


### PR DESCRIPTION
## Summary
- update stale `ray_run.py` command paths in docs to `lib/marin/src/marin/run/ray_run.py`
- update TPU setup tutorial to use current `ray_run.py` flag (`--extra` instead of removed `--pip_deps`)
- fix docs build setup command to `uv sync --package marin --group docs` (repo root has no `dependency-groups.docs`)

## Validation
- `uv run mkdocs build --strict`

Refs #12
