### PR TITLE
fix: add null guards for users data in dashboard

### DIFF
--- a/lib/iris/src/iris/cluster/static/controller/app.js
+++ b/lib/iris/src/iris/cluster/static/controller/app.js
@@ -127,7 +127,7 @@ function transformOtherData(workersResp, endpointsResp, autoscalerResp, usersRes
 
   const autoscaler = autoscalerResp.status || { enabled: false, groups: [], recentActions: [] };
 
-  const users = usersResp.users;
+  const users = usersResp.users || [];
   return { workers, endpoints, autoscaler, users };
 }
 

--- a/lib/iris/src/iris/cluster/static/controller/users-tab.js
+++ b/lib/iris/src/iris/cluster/static/controller/users-tab.js
@@ -4,7 +4,7 @@ import htm from 'htm';
 const html = htm.bind(h);
 
 export function UsersTab({ users }) {
-  if (users.length === 0) {
+  if (!users || users.length === 0) {
     return html`<div class="no-jobs">No users found</div>`;
   }
 


### PR DESCRIPTION
Add fallback for `usersResp.users` in `transformOtherData` and a null guard in `UsersTab` so the Preact render tree no longer crashes when the ListUsers RPC returns an object without a `users` field.

Closes #3373