### PR TITLE
iris: disable coredumps in worker and task containers

### DIFF
--- a/lib/iris/src/iris/cluster/platform/bootstrap.py
+++ b/lib/iris/src/iris/cluster/platform/bootstrap.py
@@ -182,6 +182,7 @@ fi
 # Start worker container without restart policy first (fail fast during bootstrap)
 sudo docker run -d --name iris-worker \\
     --network=host \\
+    --ulimit core=0:0 \\
     -v {{ cache_dir }}:{{ cache_dir }} \\
     -v /dev/shm/iris:/dev/shm/iris \\
     -v /var/run/docker.sock:/var/run/docker.sock \\

--- a/lib/iris/src/iris/cluster/runtime/docker.py
+++ b/lib/iris/src/iris/cluster/runtime/docker.py
@@ -498,6 +498,8 @@ exec {quoted_cmd}
             "create",
             "--security-opt",
             "no-new-privileges",
+            "--ulimit",
+            "core=0:0",
             "-w",
             config.workdir,
         ]

--- a/lib/iris/src/iris/cluster/runtime/kubernetes.py
+++ b/lib/iris/src/iris/cluster/runtime/kubernetes.py
@@ -74,6 +74,7 @@ def _build_task_script(config: ContainerConfig) -> str:
     """Build a shell script that prepares workdir, then runs the task."""
     lines = [
         "set -e",
+        "ulimit -c 0",
         'echo "iris-task starting (git_hash=${IRIS_GIT_HASH:-unknown})"',
         f"mkdir -p {shlex.quote(config.workdir)}",
         f"cd {shlex.quote(config.workdir)}",


### PR DESCRIPTION
Closes #3383

Core dumps from TPU crashes fill up disk (more RAM than disk), causing "No space left on device" errors. Disable them via ulimit in all three container launch paths:

- Docker runtime: `--ulimit core=0:0` in `_docker_create`
- Kubernetes runtime: `ulimit -c 0` in task script preamble
- Worker bootstrap: `--ulimit core=0:0` in `docker run`

Generated with [Claude Code](https://claude.ai/code)