### PR TITLE
Fix controller FD exhaustion under load

### DIFF
--- a/lib/iris/src/iris/cluster/platform/bootstrap.py
+++ b/lib/iris/src/iris/cluster/platform/bootstrap.py
@@ -333,6 +333,7 @@ sudo docker run -d --name {{ container_name }} \\
     --network=host \\
     --restart=unless-stopped \\
     --ulimit nofile=65536:524288 \\
+    --ulimit core=0:0 \\
     -v /var/cache/iris:/var/cache/iris \\
     {{ config_volume }} \\
     {{ docker_image }} \\


### PR DESCRIPTION
- Raise the controller container's open-file soft limit from 1024 to 65536 (`--ulimit nofile=65536:524288`)
- Disable core dumps (`--ulimit core=0:0`) to match the worker container

The controller was hitting `[Errno 24] Too many open files` when many worker tasks made concurrent RPCs (RegisterEndpoint, ListEndpoints, heartbeats) combined with gcloud subprocesses from the autoscaler. The default Docker soft limit of 1024 FDs is far too low.

Fixes #3388