### PR TITLE
iris: default endpoints tab to 100 rows with prefix search

### DIFF
--- a/lib/iris/src/iris/cluster/static/controller/app.js
+++ b/lib/iris/src/iris/cluster/static/controller/app.js
@@ -161,6 +161,9 @@ function App() {
   const [fleetPage, setFleetPage] = useState(0);
   const [error, setError] = useState(null);
 
+  // Endpoints prefix search state
+  const [endpointsPrefix, setEndpointsPrefix] = useState('');
+
   // Jobs pagination and sorting state
   const [jobsPage, setJobsPage] = useState(0);
   const [jobsSortField, setJobsSortField] = useState('date');
@@ -184,11 +187,11 @@ function App() {
   }, []);
 
   // Fetch other data (workers, endpoints, autoscaler)
-  const fetchOtherData = useCallback(async () => {
+  const fetchOtherData = useCallback(async (prefix) => {
     try {
       const [workersResp, endpointsResp, autoscalerResp, usersResp] = await Promise.all([
         controllerRpc('ListWorkers'),
-        controllerRpc('ListEndpoints', { prefix: '' }),
+        controllerRpc('ListEndpoints', { prefix: prefix || '' }),
         controllerRpc('GetAutoscalerStatus'),
         controllerRpc('ListUsers', {}),
       ]);
@@ -201,15 +204,15 @@ function App() {
 
   // Initial load
   useEffect(() => {
-    fetchOtherData();
+    fetchOtherData(endpointsPrefix);
     fetchJobs(jobsPage, jobsSortField, jobsSortDir, jobsNameFilter);
-  }, [fetchOtherData, fetchJobs, jobsPage, jobsSortField, jobsSortDir, jobsNameFilter]);
+  }, [fetchOtherData, fetchJobs, jobsPage, jobsSortField, jobsSortDir, jobsNameFilter, endpointsPrefix]);
 
   // Full refresh
   const refresh = useCallback(() => {
-    fetchOtherData();
+    fetchOtherData(endpointsPrefix);
     fetchJobs(jobsPage, jobsSortField, jobsSortDir, jobsNameFilter);
-  }, [fetchOtherData, fetchJobs, jobsPage, jobsSortField, jobsSortDir, jobsNameFilter]);
+  }, [fetchOtherData, fetchJobs, jobsPage, jobsSortField, jobsSortDir, jobsNameFilter, endpointsPrefix]);
 
   // Auto-refresh every 30s
   const refreshRef = useRef(refresh);
@@ -269,7 +272,11 @@ function App() {
       page=${fleetPage}
       onPageChange=${setFleetPage}
     />`,
-    endpoints: html`<${EndpointsTab} endpoints=${otherData.endpoints} />`,
+    endpoints: html`<${EndpointsTab}
+      endpoints=${otherData.endpoints}
+      prefix=${endpointsPrefix}
+      onPrefixChange=${setEndpointsPrefix}
+    />`,
     autoscaler: html`<${AutoscalerTab} autoscaler=${otherData.autoscaler} />`,
     logs: html`<${LogsTab} />`,
     transactions: html`<${TransactionsTab} />`,

--- a/lib/iris/src/iris/cluster/static/controller/endpoints-tab.js
+++ b/lib/iris/src/iris/cluster/static/controller/endpoints-tab.js
@@ -1,18 +1,71 @@
 import { h } from 'preact';
+import { useState, useRef } from 'preact/hooks';
 import htm from 'htm';
 
 const html = htm.bind(h);
 
-export function EndpointsTab({ endpoints }) {
+const DEFAULT_PAGE_SIZE = 100;
+
+export function EndpointsTab({ endpoints, prefix, onPrefixChange }) {
+  const [showAll, setShowAll] = useState(false);
+  const [localPrefix, setLocalPrefix] = useState(prefix || '');
+  const filterInputRef = useRef(null);
+
   if (!endpoints || endpoints.length === 0) {
-    return html`<div class="no-jobs">No endpoints registered</div>`;
+    return html`
+      <div style="margin-bottom:15px;display:flex;align-items:center;gap:10px">
+        <form onSubmit=${handleFilterSubmit} style="display:flex;gap:8px">
+          <input
+            ref=${filterInputRef}
+            type="text"
+            placeholder="Filter by prefix..."
+            value=${localPrefix}
+            onInput=${e => setLocalPrefix(e.target.value)}
+            style="padding:6px 10px;border:1px solid #d1d9e0;border-radius:4px;font-size:13px;width:250px"
+          />
+          <button type="submit" style="padding:6px 12px;font-size:13px">Filter</button>
+          ${prefix && html`<button type="button" onClick=${handleFilterClear} style="padding:6px 12px;font-size:13px">Clear</button>`}
+        </form>
+      </div>
+      <div class="no-jobs">No endpoints${prefix ? ' matching prefix' : ' registered'}</div>`;
   }
 
+  function handleFilterSubmit(e) {
+    e.preventDefault();
+    setShowAll(false);
+    onPrefixChange(localPrefix);
+  }
+
+  function handleFilterClear() {
+    setLocalPrefix('');
+    setShowAll(false);
+    onPrefixChange('');
+  }
+
+  const totalCount = endpoints.length;
+  const displayEndpoints = showAll ? endpoints : endpoints.slice(0, DEFAULT_PAGE_SIZE);
+  const hasMore = totalCount > DEFAULT_PAGE_SIZE && !showAll;
+
   return html`
+    <div style="margin-bottom:15px;display:flex;align-items:center;gap:10px">
+      <form onSubmit=${handleFilterSubmit} style="display:flex;gap:8px">
+        <input
+          ref=${filterInputRef}
+          type="text"
+          placeholder="Filter by prefix..."
+          value=${localPrefix}
+          onInput=${e => setLocalPrefix(e.target.value)}
+          style="padding:6px 10px;border:1px solid #d1d9e0;border-radius:4px;font-size:13px;width:250px"
+        />
+        <button type="submit" style="padding:6px 12px;font-size:13px">Filter</button>
+        ${prefix && html`<button type="button" onClick=${handleFilterClear} style="padding:6px 12px;font-size:13px">Clear</button>`}
+      </form>
+      <span style="color:#57606a;font-size:13px">${totalCount} endpoint${totalCount !== 1 ? 's' : ''}${!showAll && hasMore ? ', showing ' + DEFAULT_PAGE_SIZE : ''}</span>
+    </div>
     <table>
       <thead><tr><th>Name</th><th>Address</th><th>Job</th><th>Metadata</th></tr></thead>
       <tbody>
-        ${endpoints.map(e => {
+        ${displayEndpoints.map(e => {
           const metaStr = e.metadata
             ? Object.entries(e.metadata).map(([k, v]) => k + '=' + v).join(', ')
             : '-';
@@ -24,5 +77,12 @@ export function EndpointsTab({ endpoints }) {
           </tr>`;
         })}
       </tbody>
-    </table>`;
+    </table>
+    ${hasMore && html`
+      <div style="margin-top:10px;display:flex;align-items:center;gap:10px">
+        <button onClick=${() => setShowAll(true)} style="padding:6px 12px;font-size:13px">
+          Show all ${totalCount} endpoints
+        </button>
+      </div>
+    `}`;
 }


### PR DESCRIPTION
The endpoints dashboard tab now defaults to showing 100 endpoints instead of all of them, with a "Show all" button to expand. Adds a prefix search input that filters endpoints server-side via the existing ListEndpoints RPC prefix parameter.

Fixes #3384