### PR TITLE
Use human-readable slice names instead of epoch milliseconds

### DIFF
--- a/lib/iris/src/iris/cluster/platform/base.py
+++ b/lib/iris/src/iris/cluster/platform/base.py
@@ -28,9 +28,11 @@ provider's view of resources, distinct from the Iris lifecycle states in vm.prot
 
 from __future__ import annotations
 
+import datetime
 import logging
 import socket
 import threading
+import uuid
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
@@ -41,6 +43,19 @@ from iris.rpc import config_pb2
 from iris.time_utils import Deadline, Duration, Timestamp
 
 logger = logging.getLogger(__name__)
+
+
+def generate_slice_suffix() -> str:
+    """Generate a human-readable, unique suffix for slice IDs.
+
+    Returns a string like ``20260307-1755-a3b1c9d2`` (date-HHMM-uuid8).
+    The 8-char UUID suffix guarantees uniqueness even when multiple slices
+    are created within the same minute.
+    """
+    now = datetime.datetime.now(datetime.timezone.utc)
+    short_uuid = uuid.uuid4().hex[:8]
+    return f"{now.strftime('%Y%m%d-%H%M')}-{short_uuid}"
+
 
 # ============================================================================
 # Label Keys

--- a/lib/iris/src/iris/cluster/platform/coreweave.py
+++ b/lib/iris/src/iris/cluster/platform/coreweave.py
@@ -60,6 +60,7 @@ from iris.cluster.platform.base import (
     StandaloneWorkerHandle,
     WorkerStatus,
     find_free_port,
+    generate_slice_suffix,
 )
 from iris.rpc import config_pb2
 from iris.time_utils import Deadline, Duration, ExponentialBackoff, Timestamp
@@ -629,7 +630,7 @@ class CoreweavePlatform:
         # the scale-group label to just sg_name. The nodeSelector must match the
         # NodePool's nodeLabels, which use the bare scale-group name.
         scale_group_name = config.name_prefix
-        slice_id = f"{self._label_prefix}-{scale_group_name}-{Timestamp.now().epoch_ms()}"
+        slice_id = f"{self._label_prefix}-{scale_group_name}-{generate_slice_suffix()}"
         labels = self._resource_labels(scale_group_name, slice_id)
 
         if config.labels:

--- a/lib/iris/src/iris/cluster/platform/gcp.py
+++ b/lib/iris/src/iris/cluster/platform/gcp.py
@@ -59,6 +59,7 @@ from iris.cluster.platform.base import (
     WorkerStatus,
     default_stop_all,
     find_free_port,
+    generate_slice_suffix,
 )
 from iris.cluster.platform.bootstrap import (
     build_worker_bootstrap_script,
@@ -170,9 +171,8 @@ def _build_label_filter(labels: dict[str, str]) -> str:
     return " AND ".join(parts)
 
 
-def _build_vm_slice_id(name_prefix: str, epoch_ms: int) -> str:
+def _build_vm_slice_id(name_prefix: str, suffix: str) -> str:
     """Build a bounded VM slice id valid for both GCE instance names and labels."""
-    suffix = str(epoch_ms)
     max_prefix_len = _GCE_NAME_MAX_LEN - len(suffix) - 1
     if max_prefix_len <= 0:
         raise ValueError("Timestamp suffix leaves no room for VM slice id prefix")
@@ -901,7 +901,7 @@ class GcpPlatform:
         is monitored via health endpoint polling rather than SSH.
         """
         gcp = config.gcp
-        slice_id = f"{config.name_prefix}-{Timestamp.now().epoch_ms()}"
+        slice_id = f"{config.name_prefix}-{generate_slice_suffix()}"
 
         # Pre-render bootstrap script for metadata embedding.
         startup_script: str | None = None
@@ -996,7 +996,7 @@ class GcpPlatform:
         root-container SSH identity bug.
         """
         gcp = config.gcp
-        slice_id = _build_vm_slice_id(config.name_prefix, Timestamp.now().epoch_ms())
+        slice_id = _build_vm_slice_id(config.name_prefix, generate_slice_suffix())
         vm_name = slice_id
         machine_type = gcp.machine_type or DEFAULT_MACHINE_TYPE
         boot_disk_size = config.disk_size_gb or DEFAULT_BOOT_DISK_SIZE_GB

--- a/lib/iris/src/iris/cluster/platform/local.py
+++ b/lib/iris/src/iris/cluster/platform/local.py
@@ -49,6 +49,7 @@ from iris.cluster.platform.base import (
     WorkerStatus,
     default_stop_all,
     find_free_port,
+    generate_slice_suffix,
 )
 from iris.cluster.worker.port_allocator import PortAllocator
 from iris.managed_thread import ThreadContainer
@@ -386,7 +387,7 @@ class LocalPlatform:
         that register with the controller (E2E mode). Otherwise creates in-memory
         stubs (unit test mode).
         """
-        slice_id = f"{config.name_prefix}-{Timestamp.now().epoch_ms()}"
+        slice_id = f"{config.name_prefix}-{generate_slice_suffix()}"
         num_vms = config.num_vms or 1
 
         if self._controller_address is not None:

--- a/lib/iris/src/iris/cluster/platform/manual.py
+++ b/lib/iris/src/iris/cluster/platform/manual.py
@@ -42,6 +42,7 @@ from iris.cluster.platform.base import (
     SliceStatus,
     WorkerStatus,
     default_stop_all,
+    generate_slice_suffix,
 )
 from iris.cluster.platform.bootstrap import build_worker_bootstrap_script
 from iris.cluster.platform.remote_exec import (
@@ -273,7 +274,7 @@ class ManualPlatform:
         bootstrap state with the base state.
         """
         manual = config.manual
-        slice_id = f"{config.name_prefix}-{Timestamp.now().epoch_ms()}"
+        slice_id = f"{config.name_prefix}-{generate_slice_suffix()}"
 
         # Use explicitly listed hosts if provided, otherwise draw from pool
         if manual.hosts:

--- a/lib/iris/tests/cluster/platform/test_platform.py
+++ b/lib/iris/tests/cluster/platform/test_platform.py
@@ -328,13 +328,14 @@ def test_gcp_create_vm_slice_mode_produces_single_worker_slice():
 
 
 def test_gcp_build_vm_slice_id_bounds_and_normalizes():
+    suffix = "20260307-1755-a3b1c9d2"
     slice_id = _build_vm_slice_id(
         "smoke-cpu_vm_e2_standard_4_ondemand-europe-west4-b",
-        1772123761944,
+        suffix,
     )
     assert len(slice_id) <= 63
     assert "_" not in slice_id
-    assert slice_id.endswith("-1772123761944")
+    assert slice_id.endswith(f"-{suffix}")
 
 
 def test_gcp_create_vm_slice_mode_with_long_prefix_uses_valid_slice_id():


### PR DESCRIPTION
Replaces epoch-ms suffixes (e.g. 1772905933623) with YYYYMMDD-HHMM-uuid8 format (e.g. 20260307-1755-a3b1c9d2) for slice IDs across all platform backends (GCP, CoreWeave, Manual, Local).

The old epoch-ms format was hard to read in logs and could produce near-duplicate names when multiple slices were created within the same millisecond, causing ALREADY_EXISTS errors from GCP.

The 8-char UUID suffix guarantees uniqueness regardless of timing.

Old: marin-tpu_v6e_4-europe-west4-a-1772905933623
New: marin-tpu_v6e_4-europe-west4-a-20260307-1755-a3b1c9d2

🤖 Generated with Claude Code