### PR TITLE
Simplify Grug MoE ring EP local counts

### DIFF
--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -120,6 +120,16 @@ def _batch_spec_from_x(x: jax.Array, mesh: jax.sharding.AbstractMesh | None) -> 
     return _batch_spec(mesh)
 
 
+def _prefix_cap_counts(counts: Int[Array, "E"], *, capacity: int) -> Int[Array, "E"]:
+    accepted = []
+    remaining = jnp.array(capacity, dtype=jnp.int32)
+    for expert in range(int(counts.shape[0])):
+        take = jnp.minimum(counts[expert], remaining)
+        accepted.append(take)
+        remaining = jnp.maximum(remaining - take, 0)
+    return jnp.stack(accepted, axis=0)
+
+
 def _moe_mlp_ep_ring_local(
     x_local: Float[Array, "TL D"],
     selected_experts_local: Int[Array, "TL K"],
@@ -144,7 +154,6 @@ def _moe_mlp_ep_ring_local(
         assignments = tokens * topk
         expert_flat = selected_experts_global.reshape(assignments)
         weight_flat = combine_weights_global.reshape(assignments)
-        token_flat = jnp.arange(assignments, dtype=jnp.int32) // topk
 
         local_experts = moe_w13_local.shape[0]
         if num_experts % local_experts != 0:
@@ -160,32 +169,39 @@ def _moe_mlp_ep_ring_local(
         expert_start = expert_axis * local_experts
         local_expert = expert_flat - expert_start
         local_mask = jnp.logical_and(local_expert >= 0, local_expert < local_experts)
-        local_count = jnp.sum(local_mask, dtype=jnp.int32)
-        dropped_local = jnp.maximum(local_count - local_capacity, 0)
-        valid = jnp.arange(local_capacity, dtype=jnp.int32) < local_count
-        valid_weight = valid.astype(jnp.float32)
 
         # Keep only the assignments this shard will execute, ordered by
         # (local expert id, original flat position). This avoids the global
         # argsort + fused takes over all assignments that dominated high-EP
         # shapes, while preserving the grouped layout expected by ragged_dot.
         local_expert = jnp.where(local_mask, local_expert, 0)
+        # TPU lowers this small-expert count reduction better as a dense
+        # compare+sum than as `bincount`.
+        expert_ids = jnp.arange(local_experts, dtype=jnp.int32)
+        local_mask_i32 = local_mask.astype(jnp.int32)
+        counts = jnp.sum(
+            (local_expert[:, None] == expert_ids[None, :]).astype(jnp.int32) * local_mask_i32[:, None],
+            axis=0,
+            dtype=jnp.int32,
+        )
+        accepted_counts = _prefix_cap_counts(counts, capacity=local_capacity)
+        accepted_total = jnp.sum(accepted_counts, dtype=jnp.int32)
+        dropped_local = jnp.sum(counts, dtype=jnp.int32) - accepted_total
+        valid = jnp.arange(local_capacity, dtype=jnp.int32) < accepted_total
+
         flat_pos = jnp.arange(assignments, dtype=jnp.int32)
         order_key = local_expert * assignments + flat_pos
         max_order_key = local_experts * assignments
         selection_key = jnp.where(local_mask, max_order_key - order_key, -1)
         _, local_idx = jax.lax.top_k(selection_key, local_capacity)
 
-        token_local = jnp.take(token_flat, local_idx, axis=0)
-        expert_local = jnp.take(local_expert, local_idx, axis=0)
+        token_local = jnp.floor_divide(local_idx, topk)
         weight_local = jnp.take(weight_flat, local_idx, axis=0).astype(x_local.dtype)
 
         x_take = jnp.take(x_global, token_local, axis=0)
         x_dispatch = jnp.where(valid[:, None], x_take, jnp.zeros_like(x_take))
         weight_dispatch = jnp.where(valid, weight_local, jnp.zeros_like(weight_local))
-        expert_local = jnp.where(valid, expert_local, 0)
-
-    group_sizes = jnp.bincount(expert_local, weights=valid_weight, length=local_experts).astype(jnp.int32)
+    group_sizes = accepted_counts
     # `local_idx` pads by appending invalid rows at the end; keep GMM segment
     # boundaries aligned by attributing padding to the final expert segment.
     group_sizes = group_sizes.at[-1].add(local_capacity - jnp.sum(group_sizes, dtype=jnp.int32))


### PR DESCRIPTION
Tighten the ring EP local dispatch path in `lib/levanter/src/levanter/grug/grug_moe.py` by reconstructing cheap metadata locally and replacing the small per-expert `bincount` with a dense compare+sum reduction. This removes extra gathers and takes from the hot local selection path without changing routing semantics.

- compute `token_local` from `local_idx // topk` instead of gathering `token_flat`
- derive accepted per-expert counts directly and reuse them as `group_sizes`
- keep the existing ring EP structure and tests intact

On a healthy v5p-8 filter for the target shape, this reduced `EP=4` `forward_backward` time from `32.67/32.63 ms` to `31.57/31.63 ms` for `random/runs`.

Part of #2710