### PR TITLE
Improve autoscaler/reservation diagnostic logging

### DIFF
--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -1035,11 +1035,12 @@ def create_autoscaler(
         slice_template = group_config.slice_template
         cw_instance = slice_template.coreweave.instance_type if slice_template.HasField("coreweave") else ""
         logger.info(
-            "Scale group %s: device=%s:%s device_count=%d min=%d max=%d instance=%s worker_attrs=%s",
+            "Scale group %s: device=%s:%s device_count=%d num_vms=%d min=%d max=%d instance=%s worker_attrs=%s",
             name,
             resources.device_type,
             resources.device_variant,
             resources.device_count,
+            group_config.num_vms,
             group_config.min_slices,
             group_config.max_slices,
             cw_instance or "n/a",

--- a/lib/iris/src/iris/cluster/controller/autoscaler.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler.py
@@ -565,10 +565,10 @@ def route_demand(
             continue
 
         if entry.coschedule_group_id and not any(g.num_vms == len(entry.task_ids) for g in matching_groups):
-            group_sizes = [g.num_vms for g in matching_groups]
+            group_detail = ", ".join(f"{g.name}={g.num_vms}" for g in matching_groups)
             reason = (
                 f"coschedule_mismatch: job needs {len(entry.task_ids)} tasks coscheduled"
-                f" but matching groups have num_vms={group_sizes}"
+                f" but no matching group has num_vms={len(entry.task_ids)} ({group_detail})"
             )
             unmet.append(UnmetDemand(entry=entry, reason=reason))
             continue

--- a/lib/iris/src/iris/cluster/controller/pending_diagnostics.py
+++ b/lib/iris/src/iris/cluster/controller/pending_diagnostics.py
@@ -31,6 +31,16 @@ def _task_id_to_job_id(task_id: str) -> str | None:
     return parent.to_wire()
 
 
+def _group_status_detail(routing: vm_pb2.RoutingDecision, group_name: str) -> str:
+    """Extract decision/reason from GroupRoutingStatus for a given group."""
+    for gs in routing.group_statuses:
+        if gs.group == group_name:
+            if gs.reason:
+                return f"{gs.decision}: {gs.reason}"
+            return gs.decision
+    return ""
+
+
 def build_job_pending_hints(routing: vm_pb2.RoutingDecision | None) -> dict[str, str]:
     """Build autoscaler pending hints keyed by job id.
 
@@ -77,7 +87,9 @@ def build_job_pending_hints(routing: vm_pb2.RoutingDecision | None) -> dict[str,
         # Demand is routed but no new slices requested right now (for example
         # existing in-flight slices are expected to satisfy demand).
         primary_group, _ = ranked_groups[0]
-        hints[job_id] = f"Waiting for workers in scale group '{primary_group}' to become ready"
+        status_detail = _group_status_detail(routing, primary_group)
+        suffix = f" ({status_detail})" if status_detail else ""
+        hints[job_id] = f"Waiting for workers in scale group '{primary_group}' to become ready{suffix}"
 
     for job_id, reason_counts in unmet_reasons_by_job.items():
         if job_id in hints:

--- a/lib/iris/src/iris/cluster/controller/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/scaling_group.py
@@ -665,12 +665,13 @@ class ScalingGroup:
                 idle_duration = Duration.from_ms(timestamp.epoch_ms() - last_active.epoch_ms())
                 logger.info(
                     "Scale group %s: scaling down slice %s "
-                    "(idle for %dms, never_active=%s, ready=%d, pending=%d, target=%d)",
+                    "(idle for %dms, never_active=%s, ready=%d/%d, pending=%d, target=%d)",
                     self.name,
                     slice_state.handle.slice_id,
                     idle_duration.to_ms(),
                     never_active,
                     ready,
+                    self.num_vms,
                     pending,
                     target_capacity,
                 )


### PR DESCRIPTION
## Summary

- Include group names in `coschedule_mismatch` warning (e.g. `tpu_v5p_64-us-east5-a=8, tpu_v5p_64-us-central1-a=8` instead of `[8, 8]`)
- Add `num_vms` to scale group startup log so deployed config is visible without SSH
- Add group routing status (decision/reason) to "Waiting for workers" pending hint (e.g. `requesting: 2 in-flight slices provisioning`)
- Add `num_vms` denominator to scale-down ready count (`ready=1/8` vs `ready=1`)

## Context

Debugging #3435 (v5p-64 job stuck pending) surfaced several logging gaps that made it hard to diagnose the root cause.

## Test plan

- [x] `uv run pytest lib/iris/tests/ -k "autoscaler or pending_diagnostics or scaling_group or config" -x` — 304 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)