### PR TITLE
Allow to debug uv sync

### DIFF
--- a/lib/iris/src/iris/cluster/runtime/entrypoint.py
+++ b/lib/iris/src/iris/cluster/runtime/entrypoint.py
@@ -61,6 +61,9 @@ def build_runtime_entrypoint(
     python_version = env_config.python_version
     python_flag = f"--python {python_version}" if python_version else ""
 
+    # Suppress uv output by default; set IRIS_DEBUG_UV_SYNC=1 in env_vars for verbose output.
+    quiet_flag = "" if env_config.env_vars.get("IRIS_DEBUG_UV_SYNC") else "--quiet"
+
     setup_commands = [
         "cd /app",
     ]
@@ -69,12 +72,12 @@ def build_runtime_entrypoint(
     link_mode_flag = "--link-mode symlink"
     setup_commands.append("echo 'syncing deps'")
     if uv_sync_flags:
-        setup_commands.append(f"uv sync --quiet {link_mode_flag} {python_flag} {uv_sync_flags}".strip())
+        setup_commands.append(f"uv sync {quiet_flag} {link_mode_flag} {python_flag} {uv_sync_flags}".strip())
     else:
-        setup_commands.append(f"uv sync --quiet {link_mode_flag} {python_flag}".strip())
+        setup_commands.append(f"uv sync {quiet_flag} {link_mode_flag} {python_flag}".strip())
     setup_commands.append("echo 'installing pip deps'")
     if pip_install_args:
-        setup_commands.append(f"uv pip install {link_mode_flag} {pip_install_args}")
+        setup_commands.append(f"uv pip install {quiet_flag} {link_mode_flag} {pip_install_args}")
     setup_commands.append("echo 'activating venv'")
     setup_commands.append("source .venv/bin/activate")
     setup_commands.append('echo "python=$(which python)"')


### PR DESCRIPTION
* allow to opt-in to print uv sync logs in the build stage via `IRIS_DEBUG_UV_SYNC` env var