### PR TITLE
iris: always use py-spy --nonblocking

### DIFF
--- a/lib/iris/src/iris/cluster/runtime/profile.py
+++ b/lib/iris/src/iris/cluster/runtime/profile.py
@@ -103,6 +103,7 @@ def build_pyspy_cmd(spec: CpuProfileSpec, py_spy_bin: str, output_path: str) -> 
         "--output",
         output_path,
         "--subprocesses",
+        "--nonblocking",
         *(["--native"] if spec.native else []),
     ]
 


### PR DESCRIPTION
## Summary
- Always pass `--nonblocking` to py-spy to avoid pausing target processes during sampling
- Applies to both on-demand `iris job profile` and background `ProfileCapture`
- The accuracy tradeoff is negligible for stack sampling, and blocking mode can cause jitter in production tasks

## Test plan
- [x] Profile unit tests pass (14 tests)
- [x] Profiling e2e tests pass (3 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)