### PR TITLE
Include thread ID in standard logging config

### DIFF
--- a/lib/iris/src/iris/logging.py
+++ b/lib/iris/src/iris/logging.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from threading import Lock
 from typing import Protocol
 
-LOG_FORMAT = "%(levelprefix)s%(asctime)s %(name)s %(message)s"
+LOG_FORMAT = "%(levelprefix)s%(asctime)s %(thread)d %(name)s %(message)s"
 LOG_DATEFMT = "%Y%m%d %H:%M:%S"
 
 # Map log level names to single-character prefixes for compact log output.


### PR DESCRIPTION
* re https://github.com/marin-community/marin/issues/3459, include thread ID in the standard logging config