### PR TITLE
docs: fix first experiment rerun guidance

### DIFF
--- a/docs/tutorials/first-experiment.md
+++ b/docs/tutorials/first-experiment.md
@@ -277,12 +277,12 @@ To force it to rerun a step, you can use the `--force_run_failed true` flag.
 
 === "CPU"
     ```bash
-    python experiments/tutorials/train_tiny_model_cpu.py --prefix local_store --force_run_failed true
+    uv run python experiments/tutorials/train_tiny_model_cpu.py --prefix local_store --force_run_failed true
     ```
 
 === "GPU"
     ```bash
-    python experiments/tutorials/train_tiny_model_gpu.py --prefix local_store --force_run_failed true
+    uv run python experiments/tutorials/train_tiny_model_gpu.py --prefix local_store --force_run_failed true
     ```
 
 ### I want to rerun the step after it succeeded, how do I do that?
@@ -292,7 +292,7 @@ The easiest way to do this is to remove the output directory for the step.
 For instance, if the step is named `marin-nano-tinystories-b4157e`, you can remove the output directory with:
 
 ```bash
-rm -rf local_store/marin-nano-tinystories-b4157e
+rm -rf local_store/checkpoints/marin-nano-tinystories-b4157e
 ```
 
 Note, however, that WandB does not like reusing the same run ID, so you may need to change the `name` argument to `default_train` to a new value.


### PR DESCRIPTION
## Summary
- fix the first experiment troubleshooting rerun commands to keep using `uv run`
- correct the example checkpoint removal path to `local_store/checkpoints/...`

## Validation
- verified the tutorial diff against the earlier commands and artifact layout in the same doc

Refs #12
