### PR TITLE
Fix logging - threat thread id as string

### DIFF
--- a/lib/iris/src/iris/logging.py
+++ b/lib/iris/src/iris/logging.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from threading import Lock
 from typing import Protocol
 
-LOG_FORMAT = "%(levelprefix)s%(asctime)s %(thread)d %(name)s %(message)s"
+LOG_FORMAT = "%(levelprefix)s%(asctime)s %(thread)s %(name)s %(message)s"
 LOG_DATEFMT = "%Y%m%d %H:%M:%S"
 
 # Map log level names to single-character prefixes for compact log output.


### PR DESCRIPTION
* follow up https://github.com/marin-community/marin/pull/3464, turns out on Linux thread id can't be safely formatted as int, in which case it won't appear 🤷‍♂️ 