### PR TITLE
fix(iris): exclude e2e tests from cpu-test CI job

### DIFF
--- a/.github/workflows/iris-unit-tests.yaml
+++ b/.github/workflows/iris-unit-tests.yaml
@@ -42,7 +42,7 @@ jobs:
         env:
           PYTHONASYNCIODEBUG: "1"
         run: |
-          cd lib/iris && uv run --group dev python -m pytest -n4 --durations=5 --tb=short -m 'not slow and not docker' tests/
+          cd lib/iris && uv run --group dev python -m pytest -n4 --durations=5 --tb=short -m 'not slow and not docker and not e2e' tests/
 
   e2e-smoke-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- The iris smoke tests (marked `e2e`) were running in both the `cpu-test` job and the dedicated `e2e-smoke-test` / `cloud-smoke-test` jobs
- Added `not e2e` to the `cpu-test` pytest marker filter so e2e tests only run in their dedicated CI jobs

## Test plan
- [x] Verified the marker filter change is correct
- CI should show `cpu-test` collecting fewer tests (no e2e tests), while `e2e-smoke-test` and `cloud-smoke-test` remain unchanged