### PR TITLE
docs: fix ray dashboard command reference

### DIFF
--- a/scripts/ray/README.md
+++ b/scripts/ray/README.md
@@ -171,11 +171,11 @@ uv run scripts/ray/cluster.py clean-tpu-processes [--tpu-type v4-8]
 
 - Submits cleanup job for specified TPU type
 
-#### `open-dashboard`
+#### `dashboard`
 Open Ray dashboard with port forwarding.
 
 ```bash
-uv run scripts/ray/cluster.py --config infra/marin-us-central1.yaml open-dashboard
+uv run scripts/ray/cluster.py --config infra/marin-us-central1.yaml dashboard
 ```
 
 #### `auth`
@@ -241,7 +241,7 @@ uv run scripts/ray/cluster.py --cluster us-central1 get-status
 uv run scripts/ray/cluster.py --cluster us-central1 submit-job "python my_script.py"
 
 # Monitor in dashboard
-uv run scripts/ray/cluster.py --cluster us-central1 open-dashboard
+uv run scripts/ray/cluster.py --cluster us-central1 dashboard
 
 # Stop cluster
 uv run scripts/ray/cluster.py --cluster us-central1 stop-cluster


### PR DESCRIPTION
## Summary
- fix the Ray CLI README to use the implemented `dashboard` command name
- update both the command reference section and the quick-start example

## Validation
- confirmed `scripts/ray/cluster.py` registers `@cli.command("dashboard")`
- checked `scripts/ray/README.md` for remaining `open-dashboard` references

Refs #12
