### PR TITLE
docs: add contributing pre-PR checklist

### DIFF
--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -22,13 +22,29 @@ package with `make init`.
 ### Linting
 
 The Git hook configured above runs `./infra/pre-commit.py` before each commit so that the repo-standard lint/format checks pass.
-You can also run them manually with `./infra/pre-commit.py --all-files` or via `make lint`.
+You can also run them manually with `./infra/pre-commit.py --all-files --fix` or via `make lint`.
 
 ### Testing
 
-You can run the tests with `make test`.
+For most changes, start with targeted fast tests:
+
+```bash
+uv run pytest -m 'not slow' <relevant test paths>
+```
+
+Use `make test` when you need the full default test suite.
 
 *Note* that to run the unit tests, you must not have set `RAY_ADDRESS`. You can unset it with `unset RAY_ADDRESS` or `export RAY_ADDRESS=""`.
+
+### Opening a pull request
+
+Before opening a pull request:
+
+1. Run `./infra/pre-commit.py --all-files --fix`.
+2. Run `uv run pytest -m 'not slow'` for the files or packages you changed.
+3. Make sure the PR body references an issue with `Fixes #NNNN` or `Part of #NNNN`.
+
+For the end-to-end branch and fork workflow, see [Submitting a pull request](../tutorials/submitting-pr.md).
 
 ## Guidelines
 


### PR DESCRIPTION
Keep the contributor guide aligned with the repo's actual pre-PR workflow by documenting the required lint pass, the recommended fast pytest command, and the expectation that every PR links an issue.

- switch the manual lint command to `./infra/pre-commit.py --all-files --fix`
- recommend `uv run pytest -m 'not slow'` for targeted fast checks before opening a PR
- add an explicit PR checklist section that points contributors to the full submission tutorial

Fixes #3518
