### PR TITLE
agents: prefer explicit gh issue/pr view fields

### DIFF
--- a/.agents/skills/handle-gh-scrub/SKILL.md
+++ b/.agents/skills/handle-gh-scrub/SKILL.md
@@ -10,6 +10,7 @@ Use this skill for scheduled scrub turns.
 ## Workflow
 
 1. Read the requested `scrub-*` skill and apply it for this run.
+   - When inspecting GitHub issues or PRs during triage, use `gh ... --json <fields>` or other explicit narrow flags instead of plain `gh issue view` / `gh pr view`.
 2. Decide whether useful progress is available now.
 3. If useful work exists, implement and validate it.
 4. Publish outcomes before ending the run:

--- a/.agents/skills/scrub-experiment-issue-tldrs/SKILL.md
+++ b/.agents/skills/scrub-experiment-issue-tldrs/SKILL.md
@@ -51,7 +51,7 @@ One short newcomer-friendly summary paragraph.
 ## Label And Edit Guidance
 
 - The selector script output is the source of truth for candidate order and provided thread context.
-- Use `gh issue view`, `gh pr view`, and `gh api` to inspect related issues, PRs, or comments when the provided context is not enough.
+- Use `gh issue view --json <fields>`, `gh pr view --json <fields>`, explicit narrow flags such as `--comments`, and `gh api` to inspect related issues, PRs, or comments when the provided context is not enough.
 - Skip issues whose body already matches the desired managed block content.
 - The `tldr` label means the issue now has an adequate newcomer-friendly summary plus enough supporting links to dig deeper.
 - Add the `tldr` label when the issue now meets that bar. Remove it when the issue no longer meets that bar.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ uv run pyrefly
 - NEVER credit yourself in commits.
 - When an agent creates a PR or issue, add the `agent-generated` label.
 - Agent comments on PRs/issues must begin with `🤖` unless the exact text was explicitly approved by the user.
+- When using `gh` to inspect issues or PRs, prefer `--json <fields>` or explicit narrow flags such as `--comments`; avoid plain `gh issue view` / `gh pr view`, which can fail on this repo because GitHub classic project fields are deprecated.
 
 ## Code Style
 


### PR DESCRIPTION
Fixes #3523

Codify a repo-local GitHub CLI rule for agents: use explicit `--json` fields or other narrow flags when inspecting issues and PRs instead of relying on default `gh issue view` / `gh pr view` output. This avoids the classic-project GraphQL failure that now interrupts scrub and triage workflows in this repository.

- add the rule to `AGENTS.md` so it applies across agent workflows
- reinforce the rule in the base scrub skill used by scheduled runs
- update the experiment TL;DR scrub skill to use explicit `gh` inspection commands

Validation:
- `git diff --check`
