### PR TITLE
Revamp issue triage workflow: skip non-code issues, add research reports

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -129,14 +129,9 @@ jobs:
             config tweaks) or whether it requires broader design work.
 
             ## Step 3a: Small Fix
-            If the change is small and self-contained:
-            - Create branch agent/YYYYMMDD-fix-{issue_number}
-            - If applicable, write a failing test first
-            - Implement the fix, run ./infra/pre-commit.py --all-files --fix
-            - Run appropriate tests, validate your fix
-            - Find the right reviewer using git log to identify editors of affected files
-            - Open a PR tagging that reviewer via `gh pr create --reviewer <username>`
-            - Post a brief comment on the issue summarizing your fix and linking the PR
+            If the change is small and self-contained, follow the fix-issue skill workflow
+            (already loaded above). Post a brief comment on the issue summarizing your fix
+            and linking the PR when done.
 
             ## Step 3b: Research Report
             If the change is larger or needs design input:


### PR DESCRIPTION
## Summary
- Triage bot now exits silently for non-code issues (experiments, research questions, operational requests)
- Small self-contained fixes: bot creates a PR with tests, tags the appropriate reviewer
- Larger changes: bot posts a research report (affected files, design directions, recommendation) instead of attempting implementation

Replaces the old TRIVIAL/NON-TRIVIAL classification with a more natural workflow.

## Test plan
- [ ] Open a non-code issue (e.g. "run experiment X") and verify no bot comment
- [ ] Open a small bug report and verify bot creates a PR
- [ ] Open a larger feature request and verify bot posts a research report