### PR TITLE
iris: fixup all attempts logs

### DIFF
--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -35,7 +35,7 @@ function levelPriority(lvl: string | undefined): number {
 const useRpc = props.source === 'worker' ? useWorkerRpc : useControllerRpc
 
 const taskLogState = props.taskId
-  ? useRpc<GetTaskLogsResponse>('GetTaskLogs', { id: props.taskId, maxTotalLines: tailLines.value })
+  ? useRpc<GetTaskLogsResponse>('GetTaskLogs', { id: props.taskId, maxTotalLines: tailLines.value, attemptId: -1 })
   : null
 
 const processLogState = !props.taskId


### PR DESCRIPTION
I noticed this bug in the before #3511 but according to claude it's still there - "all attempts" logs displays the 1st attempt only. When not specified the attempt in proto defaults to 0.