### PR TITLE
iris: fix checkpoint/restore and gpu_worker_metadata e2e tests

### DIFF
--- a/lib/iris/src/iris/cluster/controller/local.py
+++ b/lib/iris/src/iris/cluster/controller/local.py
@@ -180,7 +180,7 @@ class LocalController:
         controller_threads = self._threads.create_child("controller") if self._threads else None
         autoscaler_threads = controller_threads.create_child("autoscaler") if controller_threads else None
 
-        db = ControllerDB(db_path=Path(self._temp_dir.name) / "controller.sqlite3")
+        db = ControllerDB(db_path=Path(self._db_dir.name) / "controller.sqlite3")
 
         # Autoscaler creates its own temp dirs for worker resources
         self._autoscaler, self._autoscaler_temp_dir = create_local_autoscaler(

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -757,6 +757,7 @@ def test_gpu_worker_metadata(tmp_path):
                 port=0,
                 cache_dir=cache_dir,
                 controller_address=url,
+                worker_id=f"test-gpu-worker-{uuid.uuid4().hex[:8]}",
                 poll_interval=Duration.from_seconds(0.1),
             )
             worker = Worker(


### PR DESCRIPTION
## Summary

Fixes two e2e smoke test failures introduced by the worker-ID-centric API rename in #3512:

- **test_checkpoint_restore**: `LocalController` stored its SQLite DB in `_temp_dir` which is cleaned up on `stop()`, so the DB (and its checkpoints) were lost across `restart()`. Moved the DB to `_db_dir` which persists across stop/start cycles, matching the docstring's stated intent.
- **test_gpu_worker_metadata**: The manually-created `Worker` had no `worker_id` configured. Since the test doesn't run on GCP/TPU, `infer_worker_id()` returns `None`, and the controller now rejects registration without a worker_id. Added an explicit `worker_id` to the `WorkerConfig`.

## Test plan

- [x] `uv run pytest lib/iris/tests/ -m "not e2e" -o "addopts=" -x -q` passes (1132 tests)
- [x] `./infra/pre-commit.py --all-files --fix` passes
- [ ] E2E smoke tests pass with these fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)