### PR TITLE
[iris] Fix checkpoint restore and worker metadata e2e tests

### DIFF
--- a/lib/iris/src/iris/cluster/controller/local.py
+++ b/lib/iris/src/iris/cluster/controller/local.py
@@ -180,7 +180,7 @@ class LocalController:
         controller_threads = self._threads.create_child("controller") if self._threads else None
         autoscaler_threads = controller_threads.create_child("autoscaler") if controller_threads else None
 
-        db = ControllerDB(db_path=Path(self._temp_dir.name) / "controller.sqlite3")
+        db = ControllerDB(db_path=Path(self._db_dir.name) / "controller.sqlite3")
 
         # Autoscaler creates its own temp dirs for worker resources
         self._autoscaler, self._autoscaler_temp_dir = create_local_autoscaler(

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -757,6 +757,7 @@ def test_gpu_worker_metadata(tmp_path):
                 port=0,
                 cache_dir=cache_dir,
                 controller_address=url,
+                worker_id=f"test-gpu-worker-{uuid.uuid4().hex[:8]}",
                 poll_interval=Duration.from_seconds(0.1),
             )
             worker = Worker(


### PR DESCRIPTION
Two e2e smoke tests broken by #3512 (controller owns log_store refactor):

- `test_checkpoint_restore`: SQLite DB was created in a temp dir that gets destroyed on `stop()`. Moved DB path to the persistent `_db_dir` in `LocalSupervisor`.
- `test_gpu_worker_metadata`: Test omitted `worker_id` in `WorkerConfig`, causing the controller to reject the worker. Added explicit `worker_id`.

Fixes #3512