### PR TITLE
iris: fix flaky dashboard test with Playwright auto-retry

### DIFF
--- a/lib/iris/tests/e2e/conftest.py
+++ b/lib/iris/tests/e2e/conftest.py
@@ -467,11 +467,13 @@ def _is_noop_page(page) -> bool:
     return isinstance(page, _NoOpPage)
 
 
-def assert_visible(page, selector: str, *, timeout: int = 5000) -> None:
+def assert_visible(page, selector: str, *, timeout: int = 10_000) -> None:
     """Assert a selector is visible. No-op when Playwright is unavailable."""
     if _is_noop_page(page):
         return
-    assert page.locator(selector).first.is_visible(timeout=timeout)
+    from playwright.sync_api import expect
+
+    expect(page.locator(selector).first).to_be_visible(timeout=timeout)
 
 
 def dashboard_click(page, selector: str) -> None:


### PR DESCRIPTION
Fixes #3542.

The old `assert_visible` used `locator.is_visible(timeout=5000)`, but Playwright [ignores the timeout on `is_visible()`](https://playwright.dev/python/docs/api/class-locator#locator-is-visible) — it checks the DOM once and returns immediately. If the element hasn't rendered yet, the assertion fails with no retry.

Replace with Playwright's `expect().to_be_visible(timeout=10_000)`, which polls the DOM repeatedly until the element appears or the timeout expires.

## Testing

- [x] 21 e2e smoke tests pass locally