### PR TITLE
iris: fixup controller shutdown

### DIFF
--- a/lib/iris/src/iris/cluster/platform/base.py
+++ b/lib/iris/src/iris/cluster/platform/base.py
@@ -496,7 +496,7 @@ class Platform(Protocol):
 # Default stop_all implementation
 # ============================================================================
 
-TERMINATE_TIMEOUT_SECONDS = 120
+TERMINATE_TIMEOUT_SECONDS = 60
 
 
 def default_stop_all(


### PR DESCRIPTION
Fix regression from #3512 issues:
 * the controller VM had unnecessary worker suffix added to the name
 * the error to delete the VM (using wrong name) was silently ignored