### PR TITLE
[Iris] Clarify TPU job submission vs reservation

### DIFF
--- a/.agents/docs/job-monitoring-loop.md
+++ b/.agents/docs/job-monitoring-loop.md
@@ -29,9 +29,11 @@ Ask:
 2. `config` - Iris config path (e.g., `lib/iris/examples/marin.yaml`)
 3. `resubmit_command` - exact Iris submit command for resubmission; must include `--no-wait`
 4. For Marin TPU training jobs, use `--extra marin:tpu` (not `--extra marin:cpu`)
+5. For TPU jobs, the resubmit command must request TPU resources with `--tpu <variant>`.
+   `--reserve <variant>` only holds capacity; it does not attach TPU devices to the task container.
 
 Example Iris resubmit command:
-`uv run iris --config lib/iris/examples/marin.yaml job run --no-wait --extra marin:tpu --reserve=v5litepod-16 -- python experiments/tutorials/train_tiny_model_tpu.py`
+`uv run iris --config lib/iris/examples/marin.yaml job run --no-wait --extra marin:tpu --tpu v5litepod-16 -- python experiments/tutorials/train_tiny_model_tpu.py`
 
 If any required field is missing, ask for it before proceeding.
 

--- a/lib/iris/README.md
+++ b/lib/iris/README.md
@@ -42,6 +42,9 @@ job = client.submit(
 job.wait()
 ```
 
+For accelerator jobs, request the accelerator on the task itself with `--tpu ...` or `--gpu ...`.
+`--reserve ...` only holds capacity for scheduling and does not attach accelerator devices to the task container.
+
 ## Architecture
 
 ```

--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -630,7 +630,11 @@ Examples:
 @click.option(
     "--reserve",
     multiple=True,
-    help="Reserve workers before scheduling. Format: [COUNT:]DEVICE (e.g., 4:H100x8, v5litepod-16). Can be repeated.",
+    help=(
+        "Reserve workers before scheduling. Format: [COUNT:]DEVICE "
+        "(e.g., 4:H100x8, v5litepod-16). Can be repeated. Reservation does not "
+        "attach accelerator devices to the task; use --tpu/--gpu for accelerator jobs."
+    ),
 )
 @click.option(
     "--include-children-logs/--no-include-children-logs",


### PR DESCRIPTION
Clarify a TPU submission footgun in the Iris docs and CLI help. TPU training jobs must request TPU resources on the task with `--tpu ...`; `--reserve ...` only holds capacity and does not attach TPU devices to the task container, which leads to confusing TPU init failures.

- Fix the TPU example in the job monitoring playbook.
- Add the same note to the Iris README.
- Warn in `iris job run --help` that `--reserve` does not attach accelerators.

Fixes #3547