### PR TITLE
docs: align docs build guide with current PR checklist

### DIFF
--- a/docs/dev-guide/building-docs.md
+++ b/docs/dev-guide/building-docs.md
@@ -132,8 +132,13 @@ The documentation is automatically deployed when changes are pushed to the main 
 
 1. Create a new branch for your changes
 2. Make your changes
-3. Test locally using `uv run mkdocs serve`
-4. Submit a pull request
+3. Preview the docs locally with `uv run mkdocs serve`
+4. Run `./infra/pre-commit.py --all-files --fix`
+5. Run `uv run mkdocs build --strict`
+6. Submit a pull request whose body references an issue with `Fixes #NNNN` or `Part of #NNNN`
+
+For the full contributor workflow, including targeted test guidance, see
+[Contributing to Marin](contributing.md).
 
 ## Common Issues
 


### PR DESCRIPTION
Align the docs build guide's contributor checklist with current Marin PR expectations so docs-only contributors run the same local validation and issue-linking steps as other contributors.

- add `./infra/pre-commit.py --all-files --fix` to the docs guide's contributing checklist
- add `uv run mkdocs build --strict` before PR submission
- require issue linkage in the PR body and point readers to the main contributing guide for the broader workflow

Fixes #3550
