### PR TITLE
iris: release committed worker resources on job cancellation

### DIFF
--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -523,8 +523,10 @@ class ControllerTransitions:
             subtree_ids = [str(row["job_id"]) for row in subtree]
             placeholders = ",".join("?" for _ in subtree_ids)
             running_rows = cur.execute(
-                f"SELECT t.task_id FROM tasks t "
+                f"SELECT t.task_id, a.worker_id, j.request_proto, j.is_reservation_holder "
+                f"FROM tasks t "
                 f"JOIN task_attempts a ON a.task_id = t.task_id AND a.attempt_id = t.current_attempt_id "
+                f"JOIN jobs j ON j.job_id = t.job_id "
                 f"WHERE t.job_id IN ({placeholders}) "
                 "AND t.state IN (?, ?, ?) "
                 "AND a.worker_id IS NOT NULL",
@@ -536,6 +538,15 @@ class ControllerTransitions:
                 ),
             ).fetchall()
             tasks_to_kill = {JobName.from_wire(str(row["task_id"])) for row in running_rows}
+            # Decommit resources for each active task on its assigned worker.
+            # cancel_job marks tasks as KILLED, but apply_heartbeat skips
+            # already-finished tasks (is_finished() check), so the normal
+            # heartbeat decommit path never fires for cancelled tasks.
+            for row in running_rows:
+                if not int(row["is_reservation_holder"]):
+                    job_req = cluster_pb2.Controller.LaunchJobRequest()
+                    job_req.ParseFromString(row["request_proto"])
+                    _decommit_worker_resources(cur, str(row["worker_id"]), job_req.resources)
             now_ms = Timestamp.now().epoch_ms()
             task_terminal_placeholders = ",".join("?" for _ in TERMINAL_TASK_STATES)
             cur.execute(

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -560,6 +560,45 @@ def test_job_cancellation_kills_all_tasks(job_request, worker_metadata):
         assert _query_task(state, task.task_id).state == cluster_pb2.TASK_STATE_KILLED
 
 
+def test_cancel_job_releases_committed_worker_resources(job_request, worker_metadata):
+    """cancel_job must decommit resources on workers that had active tasks.
+
+    Regression: cancel_job marked tasks KILLED without calling _decommit_worker_resources.
+    apply_heartbeat then skipped the update (task already finished), so committed resources
+    were never released, permanently blocking scheduling on those workers.
+    """
+    state = _make_state()
+
+    w1 = register_worker(state, "w1", "host1:8080", worker_metadata())
+    w2 = register_worker(state, "w2", "host2:8080", worker_metadata())
+
+    req = job_request("test-job")
+    req.replicas = 3
+    tasks = submit_job(state, "j1", req)
+
+    # Dispatch 2 tasks to different workers, leave 1 pending
+    dispatch_task(state, tasks[0], w1)
+    dispatch_task(state, tasks[1], w2)
+
+    # Verify resources are committed
+    assert _query_worker(state, w1).committed_cpu_millicores == 1000
+    assert _query_worker(state, w1).committed_mem == 1024**3
+    assert _query_worker(state, w2).committed_cpu_millicores == 1000
+
+    # Cancel job
+    state.cancel_job(JobName.root("test-user", "j1"), reason="User cancelled")
+
+    # Resources must be fully released on both workers
+    assert _query_worker(state, w1).committed_cpu_millicores == 0, "w1 leaked committed_cpu_millicores"
+    assert _query_worker(state, w1).committed_mem == 0, "w1 leaked committed_mem"
+    assert _query_worker(state, w2).committed_cpu_millicores == 0, "w2 leaked committed_cpu_millicores"
+    assert _query_worker(state, w2).committed_mem == 0, "w2 leaked committed_mem"
+
+    # No active tasks on either worker
+    assert len(_worker_running_tasks(state, w1)) == 0
+    assert len(_worker_running_tasks(state, w2)) == 0
+
+
 def test_cancelled_job_tasks_excluded_from_demand(job_request, worker_metadata):
     """Regression test for issue #2777: Killed tasks with no attempts should not appear in demand entries."""
     state = _make_state()


### PR DESCRIPTION
`cancel_job()` marked tasks as `KILLED` without calling `_decommit_worker_resources()`. The normal decommit path in `apply_heartbeat()` never fired because it skips already-finished tasks (`is_finished()` returns True for KILLED). This leaked committed_cpu_millicores/mem_bytes/gpu/tpu on workers permanently, blocking future scheduling on those workers.

Add decommit loop in `cancel_job()` for all active tasks with assigned workers.