### PR TITLE
Fix trailing whitespace lint failure

### DIFF
--- a/docs/dev-guide/coding-standards.md
+++ b/docs/dev-guide/coding-standards.md
@@ -12,7 +12,7 @@ Every rule includes a rationale and a concrete bad/good example.
 
 ### 1.1 Imports
 
-All imports at the top of the file. No mid-function imports 
+All imports at the top of the file. No mid-function imports
 except to guard optional third-party packages. Fix circular imports
 by refactoring to a common package instead of hacking around them.
 


### PR DESCRIPTION
## Summary
- Remove trailing whitespace on line 15 of `docs/dev-guide/coding-standards.md` that was causing the pre-commit trailing whitespace check to fail on main.

## Test plan
- [x] `./infra/pre-commit.py --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)