### PR TITLE
iris: fleet view shows zone from worker attributes

### DIFF
--- a/lib/iris/dashboard/src/components/controller/FleetTab.vue
+++ b/lib/iris/dashboard/src/components/controller/FleetTab.vue
@@ -79,7 +79,7 @@ const columns: Column[] = [
 
         <template #cell-zone="{ row }">
           <span class="text-xs font-mono">
-            {{ (row as WorkerHealthStatus).metadata?.gceZone ?? '-' }}
+            {{ (row as WorkerHealthStatus).metadata?.attributes?.zone?.stringValue ?? '-' }}
           </span>
         </template>
 

--- a/lib/iris/dashboard/src/components/controller/WorkerDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/WorkerDetail.vue
@@ -150,8 +150,8 @@ function attributeDisplay(val: { stringValue?: string; intValue?: string; floatV
           <InfoRow label="Address">
             <span class="font-mono">{{ worker?.address ?? '-' }}</span>
           </InfoRow>
-          <InfoRow v-if="worker?.metadata?.gceZone" label="Zone">
-            <span class="font-mono">{{ worker.metadata.gceZone }}</span>
+          <InfoRow v-if="worker?.metadata?.attributes?.zone" label="Zone">
+            <span class="font-mono">{{ worker.metadata.attributes.zone.stringValue }}</span>
           </InfoRow>
           <InfoRow v-if="worker?.metadata?.gceInstanceName" label="Instance">
             <span class="font-mono">{{ worker.metadata.gceInstanceName }}</span>


### PR DESCRIPTION
## Summary
- Fleet table and worker detail Identity card read `metadata.gceZone`, which is never populated by `build_worker_metadata()` — zone always shows `-`
- Zone info lives in `metadata.attributes["zone"]` (set via scale group worker attributes)
- Read from the attributes map instead so the zone column displays correctly

## Changes
- `FleetTab.vue:82` — `metadata?.gceZone` → `metadata?.attributes?.zone?.stringValue`
- `WorkerDetail.vue:153-155` — same fix for the Identity card's Zone row

## Test plan
- [x] `npm run build:check` passes (vue-tsc + rsbuild)
- [x] `./infra/pre-commit.py --all-files --fix` passes
- [ ] Verify zone column populates on a live cluster with workers that have zone attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)