### PR TITLE
docs: align contributing guide data browser workflow

### DIFF
--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -55,11 +55,20 @@ Please see the [guidelines](../explanations/guidelines.md) for principles and pr
 
 Marin comes with a [data browser](https://github.com/marin-community/marin/tree/main/data_browser) that makes it easy to
 view datasets (in various formats) and experiments produced by the executor.
-After installing the necessary dependencies, run:
+After installing the necessary dependencies, the recommended development loop is:
 
 ```bash
 cd data_browser
-python server.py --config conf/local.conf
+uv sync
+npm install
+uv run python run-dev.py --config conf/local.conf
 ```
 
-For more information, see the [data browser](https://github.com/marin-community/marin/tree/main/data_browser).
+If you only need the backend API, run:
+
+```bash
+cd data_browser
+DEV=true uv run python server.py --config conf/local.conf
+```
+
+For more details, see the [data browser tutorial](../tutorials/data-browser.md).


### PR DESCRIPTION
## Summary
- align the contributing guide's data browser commands with the current `uv run` workflow
- recommend `run-dev.py` for the normal frontend+backend loop
- keep the backend-only `server.py` command documented with the required `DEV=true` env var

## Validation
- `git diff --check`
