### PR TITLE
docs: tighten scrub artifact dedupe guidance

### DIFF
--- a/.agents/skills/scrub-reflection-self-improvement/SKILL.md
+++ b/.agents/skills/scrub-reflection-self-improvement/SKILL.md
@@ -26,9 +26,10 @@ Use this skill on scheduled scrub turns to identify and land high-leverage impro
 Run a lightweight, repeatable scan before choosing work:
 
 1. Review recent open issues and open PRs for repeated friction clusters.
-2. Review the latest commits on `main` for changes that imply follow-on docs/workflow updates.
-3. Search `AGENTS.md`, `.agents/skills/`, and docs for stale workflow guidance related to those clusters.
-4. De-duplicate against existing issues/PRs before creating new artifacts.
+2. Explicitly check for already-open scrub-generated issues/PRs touching the same area; prefer advancing or deferring to that existing artifact instead of creating a parallel one.
+3. Review the latest commits on `main` for changes that imply follow-on docs/workflow updates.
+4. Search `AGENTS.md`, `.agents/skills/`, and docs for stale workflow guidance related to those clusters.
+5. De-duplicate against existing issues/PRs before creating new artifacts.
 
 When possible, prefer improvements that remove recurring operator time (for example,
 turning ad-hoc scrub judgment into explicit repeatable guidance).
@@ -36,6 +37,7 @@ turning ad-hoc scrub judgment into explicit repeatable guidance).
 ## Decision Heuristics
 
 - Pick the highest-leverage change with the lowest coordination overhead.
+- Treat open scrub-generated issues/PRs as first-class prior art during triage; if one already covers the candidate improvement, avoid opening a second artifact unless the new scope is clearly distinct.
 - De-duplicate against existing issues/PRs before opening new work.
 - When an improvement changes recurring workflow guidance, codify it in durable repo instructions:
   `AGENTS.md` for cross-cutting agent behavior, or `.agents/skills/` for repeatable task workflows.


### PR DESCRIPTION
## Summary
- require scrub triage to explicitly scan already-open scrub-generated issues and PRs before choosing new work
- clarify that open scrub-generated artifacts count as first-class prior art and should block parallel duplicate artifacts unless the scope is clearly distinct

## Why
This scrub run found active contributor-workflow artifacts already in flight, but the skill only had a generic de-duplication rule. Making the prior-art check explicit reduces duplicate scrub PRs/issues and keeps future runs focused on uncovered gaps.

## Validation
- `git diff --check`
