### PR TITLE
Set replicate_path on grug WandbConfig so tracker_metrics.jsonl is written

### DIFF
--- a/experiments/grug/base/launch.py
+++ b/experiments/grug/base/launch.py
@@ -141,6 +141,7 @@ grug_base_trial = ExecutorStep(
             tags=["grug", "template"],
             group="grug-base-trial",
             name=None,  # filled from run_id in _resolve_tracker
+            replicate_path=this_output_path(),
         ),
         optimizer=versioned(
             AdamConfig(

--- a/experiments/grug/modular_opt/launch.py
+++ b/experiments/grug/modular_opt/launch.py
@@ -247,6 +247,7 @@ grug_modular_opt_trial = ExecutorStep(
             tags=["grug", "template", "modular_opt", "issue-3075"],
             group="grug-modular-opt-trial",
             name=None,  # filled from run_id in _resolve_tracker
+            replicate_path=this_output_path(),
         ),
         optimizer=versioned(
             GrugParamGroupAdamConfig(

--- a/experiments/grug/moe/launch.py
+++ b/experiments/grug/moe/launch.py
@@ -146,6 +146,7 @@ grug_moe_trial = ExecutorStep(
             tags=["grug", "template", "moe"],
             group="grug-moe-trial",
             name=None,  # filled from run_id in _resolve_tracker
+            replicate_path=this_output_path(),
         ),
         optimizer=versioned(
             AdamConfig(


### PR DESCRIPTION
Fixes #3602.

## Summary

- Set `replicate_path=this_output_path()` on `WandbConfig` in all three grug launch templates (moe, base, modular_opt), matching `experiments/defaults.py`
- Without this, `WandbTracker.finish()` skips writing `tracker_metrics.jsonl`, causing `validate_canary_metrics.py` to fail with `FileNotFoundError`
- Training metrics in W&B are unaffected; only the file replication was missing

## Test plan

- [x] Local repro script confirms `replicate_path` is no longer `None` after fix
- [x] Pre-commit passes
- [ ] Run a grug MoE training job and verify `tracker_metrics.jsonl` exists in the output directory
- [ ] Run `validate_canary_metrics.py` against the output to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)