### PR TITLE
fix(levanter): catch autotune ExceptionGroup so fused CE falls back to XLA

### DIFF
--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
@@ -626,18 +626,25 @@ def fused_cross_entropy_loss_and_logsumexp_penalty(
             elif has_tuned_match:
                 block_sizes_for_impl = inferred
             else:
-                block_sizes_for_impl = _autotune_block_sizes_on_miss(
-                    impl_name=impl_for_call,
-                    fn=fn,
-                    x=x,
-                    labels=labels,
-                    w=w,
-                    inferred=inferred,
-                    dtype=dtype,
-                    logit_soft_cap=logit_soft_cap,
-                    precision=precision,
-                    return_argmax=return_argmax,
-                )
+                try:
+                    block_sizes_for_impl = _autotune_block_sizes_on_miss(
+                        impl_name=impl_for_call,
+                        fn=fn,
+                        x=x,
+                        labels=labels,
+                        w=w,
+                        inferred=inferred,
+                        dtype=dtype,
+                        logit_soft_cap=logit_soft_cap,
+                        precision=precision,
+                        return_argmax=return_argmax,
+                    )
+                except Exception as exc:
+                    if explicit:
+                        raise
+                    _warn_pallas_fallback_once(exc)
+                    errors.append(exc)
+                    continue
         else:
             block_sizes_for_impl = infer_block_sizes(
                 x.shape[0],


### PR DESCRIPTION
Fixes #3604

## Summary

- Wrap the `_autotune_block_sizes_on_miss()` call in the same try/except/continue pattern used by the kernel-execution fallback blocks below it, so that autotune failures fall through to the next implementation (XLA) instead of crashing

## Context

`fused_cross_entropy_loss_and_logsumexp_penalty` already iterates over implementations (default: `("pallas_gpu", "xla")`) and catches kernel failures to fall through to the next one — the Pallas GPU kernel is a performance optimization, and XLA streaming is the correct fallback when it can't run. The try/except blocks at lines 674-713 handle `PallasUnsupportedError`, `NotImplementedError`, and VMEM compile errors for exactly this purpose.

The bug: `_autotune_block_sizes_on_miss()` at line 629 executes **before** those catch blocks. When all autotune candidates fail (e.g. `hidden_dim=512` with float32 weights on H100, where even the smallest tile `512*64*4 = 131072 B` exceeds the 101376 B shared-memory budget), its `ExceptionGroup` escapes the fallback chain and crashes training instead of falling through to XLA.

<details>
<summary>Reproduction on 8xH100</summary>

```python
# float32 weights with hidden_dim=512, vocab=128256
x = jnp.ones((64, 512), dtype=jnp.float32)
w = jnp.ones((512, 128_256), dtype=jnp.float32)
labels = jnp.zeros(64, dtype=jnp.int32)

fused_cross_entropy_loss_and_logsumexp_penalty(x, labels, w, dtype=jnp.float32)
# Before fix: ExceptionGroup (crash)
# After fix:  RuntimeWarning, falls back to XLA, returns correct loss
```

</details>

## Test plan

- [x] Local CPU repro with monkeypatched backend: ExceptionGroup no longer escapes, XLA fallback produces correct result
- [x] Real GPU repro on 8xH100 via Iris: ExceptionGroup crash confirmed on current main
- [x] `test_pallas_fused_cross_entropy_loss.py`: 29 passed, 4 skipped (GPU/TPU)
- [x] `test_loss.py`: 9 passed
- [x] Pre-commit clean