### PR TITLE
docs: require docs source-link validation

### DIFF
--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -63,6 +63,8 @@ Before marking a PR ready for review:
 - Run `./infra/pre-commit.py --all-files --fix` and fix any issues.
 - Do not substitute `uv run pre-commit ...`; use `./infra/pre-commit.py` directly so checks run in all environments.
 - Run `uv run pytest -m 'not slow'` for the relevant test directories.
+- When a PR adds, deletes, renames, or rewires docs pages or docs-owned links, run `uv run python infra/check_docs_source_links.py` before pushing so stale GitHub source links fail locally instead of in CI.
+- For docs-heavy changes, also run `uv run mkdocs build --strict`.
 - Ensure all CI checks pass after pushing. Monitor with
   `gh pr view <number> --json statusCheckRollup`.
 - If CI fails, investigate and push fixes. Do not consider the PR complete

--- a/docs/dev-guide/building-docs.md
+++ b/docs/dev-guide/building-docs.md
@@ -115,7 +115,12 @@ def process_data(data: List[str]) -> Dict[str, int]:
    uv run mkdocs build --strict
    ```
 
-2. Validate markdown:
+2. Check GitHub source links after moving, deleting, or relinking docs pages:
+   ```bash
+   uv run python infra/check_docs_source_links.py
+   ```
+
+3. Validate markdown:
    ```bash
    uv run mkdocs build --strict --verbose
    ```
@@ -145,7 +150,8 @@ For the full contributor workflow, including targeted test guidance, see
 ### Broken Links
 - Use relative links for internal documentation
 - Use absolute URLs for external links
-- Test links after making changes
+- Run `uv run python infra/check_docs_source_links.py` after moving, deleting, or relinking docs pages that reference GitHub paths
+- Run `uv run mkdocs build --strict` after docs edits to catch navigation and Markdown link failures
 
 ### Build Errors
 - Check for syntax errors in markdown


### PR DESCRIPTION
Require docs source-link validation when docs pages move or links change. The PR workflow skill now calls out `uv run python infra/check_docs_source_links.py` for docs navigation/link edits, and the docs maintenance guide documents that check alongside `mkdocs build --strict` so stale GitHub source links fail locally instead of only in CI.

- add docs-specific validation guidance to `.agents/skills/pull-request/SKILL.md`
- document the source-link checker in `docs/dev-guide/building-docs.md`

Fixes #3606
