### PR TITLE
iris: add CoreWeave interruptable taint toleration to worker and task pods

### DIFF
--- a/lib/iris/src/iris/cluster/platform/coreweave.py
+++ b/lib/iris/src/iris/cluster/platform/coreweave.py
@@ -86,6 +86,14 @@ _S3_SECRET_NAME = "iris-s3-credentials"
 _CONTROLLER_CPU_REQUEST = "2"
 _CONTROLLER_MEMORY_REQUEST = "4Gi"
 
+# CoreWeave GPU nodes may carry this taint; all pods that target GPU nodes must
+# tolerate it or they will be evicted / remain Pending.
+_CW_INTERRUPTABLE_TOLERATION: dict = {
+    "key": "qos.coreweave.cloud/interruptable",
+    "operator": "Exists",
+    "effect": "NoExecute",
+}
+
 # S3-compatible endpoints that require virtual-hosted-style addressing where the
 # bucket name is a subdomain (https://<bucket>.cwobject.com). Path-style
 # requests are rejected with PathStyleRequestNotAllowed.
@@ -834,6 +842,7 @@ class CoreweavePlatform:
                 "nodeSelector": {
                     self._iris_labels.iris_scale_group: handle.scale_group,
                 },
+                "tolerations": [_CW_INTERRUPTABLE_TOLERATION],
                 "containers": [container_spec],
                 "volumes": [
                     {"name": "worker-config", "configMap": {"name": wc_cm_name}},
@@ -1388,13 +1397,7 @@ def _build_controller_deployment(
                 "spec": {
                     "serviceAccountName": "iris-controller",
                     "nodeSelector": node_selector,
-                    "tolerations": [
-                        {
-                            "key": "qos.coreweave.cloud/interruptable",
-                            "operator": "Exists",
-                            "effect": "NoExecute",
-                        },
-                    ],
+                    "tolerations": [_CW_INTERRUPTABLE_TOLERATION],
                     "containers": [
                         {
                             "name": "iris-controller",

--- a/lib/iris/src/iris/cluster/runtime/kubernetes.py
+++ b/lib/iris/src/iris/cluster/runtime/kubernetes.py
@@ -109,14 +109,16 @@ def _build_gpu_resources(config: ContainerConfig) -> dict[str, str]:
 
 
 def _build_tolerations(config: ContainerConfig) -> list[dict]:
-    """Build tolerations for GPU/RDMA node taints.
+    """Build tolerations for GPU node taints.
 
-    CoreWeave GPU nodes carry ``nvidia.com/gpu`` taints. Tolerations ensure
-    task Pods are eligible for those nodes.
+    GPU nodes may carry ``nvidia.com/gpu:NoSchedule`` and CoreWeave nodes may
+    additionally carry ``qos.coreweave.cloud/interruptable:NoExecute``. The CW
+    toleration is harmless on non-CoreWeave clusters.
     """
     tolerations: list[dict] = []
     if config.resources and config.resources.HasField("device") and get_gpu_count(config.resources.device) > 0:
         tolerations.append({"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"})
+        tolerations.append({"key": "qos.coreweave.cloud/interruptable", "operator": "Exists", "effect": "NoExecute"})
     return tolerations
 
 

--- a/lib/iris/tests/cluster/runtime/test_kubernetes_runtime.py
+++ b/lib/iris/tests/cluster/runtime/test_kubernetes_runtime.py
@@ -175,6 +175,7 @@ def test_gpu_resources_and_tolerations(monkeypatch):
 
     tolerations = manifest["spec"]["tolerations"]
     assert any(t["key"] == "nvidia.com/gpu" and t["operator"] == "Exists" for t in tolerations)
+    assert any(t["key"] == "qos.coreweave.cloud/interruptable" and t["effect"] == "NoExecute" for t in tolerations)
 
 
 def test_no_gpu_resources_when_zero_gpus(monkeypatch):


### PR DESCRIPTION
Fixes #3608

## Summary

- Add `qos.coreweave.cloud/interruptable:NoExecute` toleration to worker pods (`_create_worker_pod`) and task pods (`_build_tolerations`)
- Extract `_CW_INTERRUPTABLE_TOLERATION` constant, reuse it in the controller Deployment spec too
- Extend `test_gpu_resources_and_tolerations` to assert the CW toleration is present

## Context

The controller Deployment already had this toleration but worker and task pods did not. When CoreWeave provisions an H100 node from the interruptable pool (observed on `gd-8xh100ib-i128` instance type), the `NoExecute` taint causes worker pods to remain `Pending` indefinitely. This is intermittent -- not all CW GPU nodes carry the taint.

Reproduced via unit tests, a local kind cluster with a tainted node, and live CW cluster pod inspection. CI runs [23033099249](https://github.com/marin-community/marin/actions/runs/23033099249) and [23036200590](https://github.com/marin-community/marin/actions/runs/23036200590) show the failure in production.

The CW toleration is harmless on non-CoreWeave clusters.

<details>
<summary>Scope: which pods, which taints</summary>

Three pod types exist on CW. All three now carry the toleration:

| Pod type | Created by | Toleration |
|----------|-----------|------------|
| Controller Deployment | `_build_controller_deployment()` | Already had it (now uses shared constant) |
| Worker Pod | `_create_worker_pod()` | Added unconditionally (harmless on CPU nodes) |
| Task Pod | `_build_tolerations()` | Added when `gpu_count > 0` |

Task pods only get the toleration when GPU resources are requested. CPU task pods don't need it — they never target GPU nodes (no `nodeSelector`, no GPU resource request), so they won't land on a node carrying the interruptable taint.

Other observed CW taints (`is_gpu:PreferNoSchedule`, `DeletionCandidateOfClusterAutoscaler:PreferNoSchedule`) are soft preferences that don't block scheduling when `nodeSelector` forces placement.
</details>

## Test plan

- [x] `test_gpu_resources_and_tolerations` passes with new assertion
- [x] All 17 `test_kubernetes_runtime.py` tests pass
- [x] Pre-commit clean
- [ ] Canary ferry run on CW with an interruptable-tainted H100 node

🤖 Generated with [Claude Code](https://claude.com/claude-code)