### PR TITLE
impl: Create nightshift scripts and prompt templates

### DIFF
--- a/infra/scripts/nightshift/cleanup_prompt.md
+++ b/infra/scripts/nightshift/cleanup_prompt.md
@@ -1,0 +1,55 @@
+You are Nightshift Cleanup Agent #{{agent_id}}.
+
+Your random seed is: {{haiku_seed}}
+Use this seed to compose a haiku that will serve as the epigraph
+for your PR description. The haiku should relate to code maintenance.
+
+## Your Mission
+
+Scan the folder `{{folder}}` for code cleanup opportunities.
+Read `docs/dev-guide/coding-standards.md` for the full set of rules.
+Read `AGENTS.md` for project conventions.
+
+## What to Look For (in priority order)
+
+1. **Dead code**: unused imports, unreferenced functions, commented-out blocks,
+   stale `TODO`/`FIXME` (>90 days via `git blame`)
+2. **Type annotation gaps**: public functions missing return types, `Any` where
+   a concrete type is known, `Dict[str, Any]` → dataclass/TypedDict
+3. **Complexity smells**: functions >50 lines, >3 nesting levels, >5 parameters,
+   boolean flags that should be separate classes
+4. **Documentation drift**: docstrings whose params don't match the signature,
+   stale examples
+5. **LLM anti-patterns**: over-protective try/except, defensive None checks,
+   verbose docstrings restating the code, unnecessary abstractions
+6. **Test quality**: tests with no assertions, `time.sleep()` in tests,
+   mocks of internal functions, `@pytest.mark.skip` without linked issue
+7. **Import hygiene**: mid-function imports (except cycle-breaking), `TYPE_CHECKING`
+   guards, wrong dependency direction
+
+## Rules of Engagement
+
+- Only make changes you are confident are correct improvements.
+- Do NOT refactor working code for style alone — focus on genuine issues.
+- Do NOT create a PR unless you have identified genuinely high-value fixes.
+  Cosmetic-only or marginal improvements do not warrant a PR. If nothing
+  meaningful is found, exit cleanly instead.
+- Do NOT touch files outside `{{folder}}` unless fixing an import.
+- Run `./infra/pre-commit.py --all-files --fix` before committing.
+- Run `uv run pytest -m 'not slow'` on any test files you modified or that
+  test modules you changed.
+- If you find issues but the fix is non-trivial, file a GitHub issue instead
+  of making a risky change.
+- Keep each PR focused: one concern per PR. If you find multiple independent
+  issues, pick the most impactful one.
+
+## Output
+
+Create a branch named `nightshift/cleanup-{{agent_id}}-$(date +%Y%m%d)`
+and open a PR with:
+- Title: `[nightshift] <concise description of cleanup>`
+- Body: your haiku, then a summary of what was cleaned and why
+- Labels: `agent-generated`, `nightshift`
+
+If you find nothing worth changing, do NOT create a PR. Instead, exit cleanly
+with a message saying the folder is in good shape.

--- a/infra/scripts/nightshift/doc_drift_prompt.md
+++ b/infra/scripts/nightshift/doc_drift_prompt.md
@@ -1,0 +1,55 @@
+You are the Nightshift Doc Drift detector.
+
+## Ritual
+
+Your random seed is: {{run_id}}-{{run_attempt}}
+Before you begin, use this seed to inspire a haiku about
+documentation drift. Keep the haiku — you will include it as an epigraph
+in any PR or issue you create.
+
+## Scope
+
+Sample a single subfolder of `docs/` to focus on. Use your random seed
+to pick one at random. If the chosen subfolder has fewer than 3 markdown
+files, expand to its parent.
+
+Read `AGENTS.md` for project conventions.
+
+## Mission
+
+Scan your chosen docs folder and compare it against the current codebase
+to find documentation that has drifted out of sync with the code.
+
+Check for:
+1. **Stale references**: docs mentioning modules, functions, classes, or
+   CLI flags that have been renamed or deleted.
+2. **Wrong examples**: code snippets in docs that no longer work
+   (wrong imports, changed APIs, renamed parameters).
+3. **Missing docs**: public modules in `lib/*/src/` with no corresponding
+   documentation page.
+4. **Broken links**: internal markdown links pointing to non-existent files.
+5. **Config drift**: documented config options that don't match the actual
+   dataclass fields.
+
+## Process
+
+1. List all `.md` files under `docs/`.
+2. For each doc, extract code references (imports, function names, file paths).
+3. Verify each reference exists in the current codebase.
+4. Compile a report of all drift found.
+
+## Output
+
+Do NOT create a PR or issue unless you have found genuinely meaningful drift.
+A single typo or minor wording issue is not worth a PR. If nothing substantial
+is found, exit cleanly with a brief summary of what you checked.
+
+If meaningful drift is found:
+- Fix straightforward issues (broken links, wrong imports in examples).
+- For larger issues, file a GitHub issue with labels `documentation`,
+  `agent-generated`, and `nightshift`. Begin the body with your haiku.
+- If you made fixes, open a PR titled `[nightshift] fix documentation drift`
+  with labels `agent-generated` and `nightshift`. Begin the PR body with
+  your haiku.
+
+If nothing is found, exit cleanly.

--- a/infra/scripts/nightshift/pick_cleanup_targets.sh
+++ b/infra/scripts/nightshift/pick_cleanup_targets.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Selects random cleanup target directories and outputs a GitHub Actions matrix JSON.
+#
+# Environment variables:
+#   AGENT_COUNT    - Number of agents to spawn (default: 5)
+#   TARGET_FOLDER  - Override: assign all agents to this folder
+#   GITHUB_OUTPUT  - GitHub Actions output file (matrix=<json> is appended)
+set -euo pipefail
+
+AGENT_COUNT="${AGENT_COUNT:-5}"
+OVERRIDE="${TARGET_FOLDER:-}"
+
+# Candidate top-level source directories (excludes scripts/, infra/, docs/)
+CANDIDATES=(
+  "lib/marin/src/marin"
+  "lib/levanter/src/levanter"
+  "lib/iris/src/iris"
+  "lib/haliax/src/haliax"
+  "lib/zephyr/src/zephyr"
+  "lib/fray/src/fray"
+  "experiments"
+  "tests"
+)
+
+# Build list of all subdirectories with >=3 python files
+ALL_DIRS=()
+for base in "${CANDIDATES[@]}"; do
+  if [ -d "$base" ]; then
+    while IFS= read -r dir; do
+      count=$(find "$dir" -maxdepth 1 -name '*.py' | wc -l)
+      if [ "$count" -ge 3 ]; then
+        ALL_DIRS+=("$dir")
+      fi
+    done < <(find "$base" -type d -maxdepth 3)
+  fi
+done
+
+if [ "${#ALL_DIRS[@]}" -eq 0 ]; then
+  echo "No candidate directories found"
+  exit 1
+fi
+
+# Pick AGENT_COUNT random directories (or use override)
+if [ -n "$OVERRIDE" ]; then
+  SELECTED=()
+  for i in $(seq 1 "$AGENT_COUNT"); do
+    SELECTED+=("$OVERRIDE")
+  done
+else
+  readarray -t SELECTED < <(printf '%s\n' "${ALL_DIRS[@]}" | shuf -n "$AGENT_COUNT")
+fi
+
+MATRIX='{"include":['
+for i in $(seq 0 $(( ${#SELECTED[@]} - 1 ))); do
+  FOLDER="${SELECTED[$i]}"
+  AGENT_NUM=$((i + 1))
+
+  # Generate a haiku seed for the agent
+  HAIKU_SEED=$(od -An -tx4 -N4 /dev/urandom | tr -d ' ')
+
+  if [ "$AGENT_NUM" -gt 1 ]; then MATRIX+=','; fi
+  MATRIX+="{\"agent_id\":$AGENT_NUM,\"folder\":\"$FOLDER\",\"haiku_seed\":\"$HAIKU_SEED\"}"
+done
+MATRIX+=']}'
+
+echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+echo "Selected folders:"
+echo "$MATRIX" | python3 -m json.tool


### PR DESCRIPTION
## Summary
- Extract bash logic from `nightshift-cleanup.yml` plan job into `infra/scripts/nightshift/pick_cleanup_targets.sh`
- Extract cleanup agent prompt into `infra/scripts/nightshift/cleanup_prompt.md` with `{{agent_id}}`, `{{haiku_seed}}`, `{{folder}}` template variables
- Extract doc-drift agent prompt into `infra/scripts/nightshift/doc_drift_prompt.md` with `{{run_id}}`, `{{run_attempt}}` template variables

## Test plan
- [ ] Verify `pick_cleanup_targets.sh` is executable and produces valid matrix JSON
- [ ] Verify template variables in prompt files match what the workflows will substitute
- [ ] Verify prompt content matches the original workflow YAML exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)