### PR TITLE
Add AGENTS rule for storage transfer service consent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ uv run pyrefly
 - Python >=3.11. Use `uv run` for entry points; fall back to `.venv/bin/python` if needed.
 - NEVER stop, restart, or bounce a Ray or Iris cluster unless the user gives express permission.
 - In general, never read or write large amounts of data across GCS regions or to the open internet; storage and bandwidth are major cost drivers for this project.
+- do not use storage transfer service to move files from one region to another unless the user says "I personally will write grants for Percy to pay for this"
 
 ## Communication & Commits
 


### PR DESCRIPTION
Add a Development guideline in AGENTS.md requiring explicit user consent before using Storage Transfer Service to move files between regions. This makes the existing cost-control guidance concrete and sets a hard gate for cross-region transfer operations.

- Add one policy line with the exact required consent phrase.

Fixes #3624