### PR TITLE
fix(iris): correct R2 endpoint and bucket in coreweave.yaml

### DIFF
--- a/lib/iris/examples/coreweave.yaml
+++ b/lib/iris/examples/coreweave.yaml
@@ -35,10 +35,10 @@ platform:
     region: US-WEST-04A
     namespace: iris
     kubeconfig_path: ~/.kube/coreweave-iris  # Set this to your local kubeconfig, or use KUBECONFIG env var
-    object_storage_endpoint: https://a5a1f66f973e2196a26bae21c81b899b.r2.cloudflarestorage.com
+    object_storage_endpoint: https://74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com
 
 storage:
-  remote_state_dir: s3://marin-test/iris/state
+  remote_state_dir: s3://marin-na/iris/state
 
 controller:
   image: ghcr.io/marin-community/iris-controller:latest


### PR DESCRIPTION
## Summary

Fix CW controller crash on startup after #3588 by correcting the R2 endpoint and bucket in `coreweave.yaml`.

Fixes #3628

- **R2 endpoint**: `a5a1f66f...` (wrong Cloudflare account) → `74981a43...` (matches R2 credentials)
- **Bucket**: `marin-test` (does not exist) → `marin-na` (correct bucket)

These misconfigurations predated #3588 but were harmless because the old checkpoint code used local paths for restore and `try/except` for uploads. PR #3588 made checkpoint restore a remote operation on the startup critical path, surfacing the issue as `PermissionError: Forbidden` → `CrashLoopBackOff`.

## Test plan

- [x] Local repro: `download_checkpoint_to_local` with old config → `PermissionError`
- [x] Local verify: same function with fixed config → downloads 278KB checkpoint
- [x] On-cluster repro: `iris cluster start` with old config → `CrashLoopBackOff`
- [x] On-cluster verify: `iris cluster start` with fixed config → controller starts, minimal job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)