### PR TITLE
[grug/moe] Select TPU fused CE backend in MoE loss path

### DIFF
--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -457,6 +457,7 @@ class Transformer(eqx.Module):
             reduction=reduction,
             logsumexp_weight=logsumexp_weight,
             dtype=loss_dtype,
+            implementation="pallas_tpu" if jax.default_backend() == "tpu" else None,
         )
         # Keep router metrics raw and apply coefficients only at the final
         # objective composition step (same separation as MaxText/Megatron).

--- a/lib/levanter/src/levanter/grug/loss.py
+++ b/lib/levanter/src/levanter/grug/loss.py
@@ -57,6 +57,7 @@ def fused_linear_softmax_cross_entropy_loss(
     logsumexp_weight: float | None = None,
     dtype: jnp.dtype = jnp.float32,
     precision: jax.lax.PrecisionLike = None,
+    implementation: str | tuple[str, ...] | None = None,
 ) -> jax.Array:
     """Compute cross-entropy loss via the fused kernel path.
 
@@ -69,6 +70,7 @@ def fused_linear_softmax_cross_entropy_loss(
         logsumexp_weight: Optional z-loss weight (logsumexp^2 term).
         dtype: Accumulator dtype for logits/logsumexp.
         precision: Optional matmul precision override for XLA/reference paths.
+        implementation: Optional fused CE backend selection override.
 
     Returns:
         If reduction=="none": array with shape labels.shape.
@@ -112,8 +114,7 @@ def fused_linear_softmax_cross_entropy_loss(
             dtype=dtype,
             logit_soft_cap=None,
             precision=precision,
-            # implementation="reference"
-            # implementation="xla"
+            implementation=implementation,
         )
 
         if reduction_mode is None:


### PR DESCRIPTION
Select the TPU fused cross-entropy backend explicitly for Grug MoE training while preserving existing behavior off TPU. This avoids accidentally taking the XLA CE path in the MoE model path and keeps backend selection explicit at the Grug loss helper boundary.

- Add an optional `implementation` override to `fused_linear_softmax_cross_entropy_loss()` and pass it through to fused CE.
- In `experiments/grug/moe/model.py`, set `implementation="pallas_tpu"` when running on TPU, otherwise keep default behavior.

Validation:
- `./infra/pre-commit.py --all-files --fix`
- `uv run python -m py_compile experiments/grug/moe/model.py lib/levanter/src/levanter/grug/loss.py`
- `uv run python -m pytest ...` could not run because `pytest` is not installed in this environment.

Part of #2167
