### PR TITLE
iris: copy hatch_build.py into Docker images

### DIFF
--- a/lib/iris/Dockerfile.controller
+++ b/lib/iris/Dockerfile.controller
@@ -42,8 +42,8 @@ COPY --from=ghcr.io/astral-sh/uv:0.10.3 /uv /uvx /bin/
 
 WORKDIR /app
 
-# Copy pyproject.toml first and sync dependencies (cached layer)
-COPY pyproject.toml ./
+# Copy pyproject.toml and build hook first and sync dependencies (cached layer)
+COPY pyproject.toml hatch_build.py ./
 RUN uv sync --no-install-project
 
 # Copy source and install the project

--- a/lib/iris/Dockerfile.worker
+++ b/lib/iris/Dockerfile.worker
@@ -57,9 +57,9 @@ COPY --from=ghcr.io/astral-sh/uv:0.10.3 /uv /uvx /bin/
 
 WORKDIR /app
 
-# Copy pyproject first so the heavy dependency install is cached
-# independently of source changes.
-COPY pyproject.toml ./
+# Copy pyproject and build hook first so the heavy dependency install is
+# cached independently of source changes.
+COPY pyproject.toml hatch_build.py ./
 RUN uv sync --no-install-project
 
 # Copy source and install the project itself (fast, deps already installed above)


### PR DESCRIPTION
- Dockerfile.worker and Dockerfile.controller now `COPY hatch_build.py` alongside `pyproject.toml` so the custom hatch build hook (added in #3631) is present when `uv sync` runs during the Docker build.
- Without this, the build fails with `OSError: Build script does not exist: hatch_build.py`.
- Dockerfile.task is unaffected (it doesn't run `uv sync` at build time, and already has nodejs/npx for proto generation at runtime).