### PR TITLE
zephyr: pack pickle inside parquet shuffle

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -236,7 +236,7 @@ def _make_pickle_envelope(items: list, target_shard: int, chunk_idx: int) -> lis
         {
             _ZEPHYR_SHUFFLE_SHARD_IDX_COL: target_shard,
             _ZEPHYR_SHUFFLE_CHUNK_IDX_COL: chunk_idx,
-            _ZEPHYR_SHUFFLE_PICKLED_COL: pickle.dumps(item),
+            _ZEPHYR_SHUFFLE_PICKLED_COL: cloudpickle.dumps(item),
         }
         for item in items
     ]

--- a/lib/zephyr/tests/test_groupby.py
+++ b/lib/zephyr/tests/test_groupby.py
@@ -333,8 +333,8 @@ def test_group_by_non_vortex_serializable(zephyr_ctx):
     """Shuffle with items that Vortex/Arrow cannot serialize uses pickle-in-parquet.
 
     Uses frozenset (not Arrow-serializable) so the pickle envelope path is
-    exercised. Items are serialized via cloudpickle into a ``__pickle__``
-    binary column inside Parquet, avoiding the N*M pickle file blowup.
+    exercised. Items are serialized via cloudpickle into a binary ``__pickle__``
+    column inside Parquet, avoiding the N*M pickle file blowup.
     """
 
     from zephyr.writers import infer_arrow_schema


### PR DESCRIPTION
## Summary
- When scatter items aren't Arrow-serializable, serialize them via `pickle.dumps()` into a binary `pickled` column in Parquet instead of falling back to per-chunk `.pkl` files
- Eliminates the M×RxC file blowup in pickle mode while preserving single-file-per-shard compactness and predicate pushdown
- Adds `is_pickled` field to `ParquetDiskChunk` for transparent deserialization on read

Fixes #3640

## Test plan
- [x] Existing `test_group_by_non_vortex_serializable` passes on all 3 backends (local, iris, ray) — exercises the full pickle-in-parquet scatter+reduce path with `frozenset` items
- [x] New `test_parquet_disk_chunk_pickle_roundtrip` — unit test for pickle envelope write/read
- [x] All 49 groupby tests pass, all 61 execution tests pass
- [x] Pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)