### PR TITLE
docs: align local GPU tutorial with uv

### DIFF
--- a/docs/tutorials/local-gpu.md
+++ b/docs/tutorials/local-gpu.md
@@ -53,9 +53,10 @@ See [JAX's installation guide](https://jax.readthedocs.io/en/latest/installation
 
 !!! tip
 If you are using a DGX Spark or similar machine with unified memory, you may need to dramatically reduce the memory that XLA preallocates for itself. You can do this by setting the `XLA_PYTHON_CLIENT_MEM_FRACTION` variable, to something like 0.5:
-`bash
-    export XLA_PYTHON_CLIENT_MEM_FRACTION=0.5
-    `
+
+```bash
+export XLA_PYTHON_CLIENT_MEM_FRACTION=0.5
+```
 
     You can also set this in your `.bashrc` or `.zshrc` file.
     ```bash
@@ -72,7 +73,7 @@ Let's start by running the tiny model training script (GPU version) [`experiment
 ```bash
 export MARIN_PREFIX=local_store
 export WANDB_ENTITY=...
-python3 experiments/tutorials/train_tiny_model_gpu.py --prefix local_store
+uv run python experiments/tutorials/train_tiny_model_gpu.py --prefix local_store
 ```
 
 The `prefix` is the directory where the output will be saved. It can be a local directory or anything fsspec supports,


### PR DESCRIPTION
## Summary
- switch the local GPU tutorial example to `uv run python ...` to match the repos documented execution flow
- fix the malformed fenced code block for `XLA_PYTHON_CLIENT_MEM_FRACTION` in the same tutorial section

## Validation
- `uv sync --package marin --group docs`
- `uv run mkdocs build --strict`

Refs #12
