### PR TITLE
iris: disable gzip compression for actor RPC responses

### DIFF
--- a/lib/iris/src/iris/actor/client.py
+++ b/lib/iris/src/iris/actor/client.py
@@ -116,6 +116,7 @@ class ActorClient:
         self._rpc_client = ActorServiceClientSync(
             address=url,
             timeout_ms=None if self._call_timeout is None else int(self._call_timeout * 1000),
+            accept_compression=[],
         )
         return self._rpc_client
 

--- a/lib/iris/src/iris/actor/pool.py
+++ b/lib/iris/src/iris/actor/pool.py
@@ -132,6 +132,7 @@ class ActorPool(Generic[T]):
             client = ActorServiceClientSync(
                 address=url,
                 timeout_ms=int(self._timeout * 1000),
+                accept_compression=[],
             )
             self._clients[url] = client
             return client


### PR DESCRIPTION
## Summary

- Disable ConnectRPC gzip compression for actor RPC clients by passing `accept_compression=[]`
- Actor responses carry cloudpickle-serialized binary data that doesn't compress (ratio 1.000), so gzip burns CPU and memory for zero benefit

## Evidence

**Remote profiling** (memray attach on live worker, 30s capture):
- `gzip.compress` accounted for 34.2 GB / 35.6 GB total allocations (96%)
- 682K gzip calls in 30s, consuming 89% of server-side wall time
- Rapid alloc/free cycle fragments jemalloc heap (VmSize 10.2 GB vs RSS 3.5 GB)

**Local reproduction** (500 calls returning 256KB blobs):

| | Before (gzip) | After (identity) |
|---|---|---|
| Throughput | 302 calls/sec | **4,258 calls/sec** |
| gzip wall time | 1.47s (89%) | 0 |
| Compression ratio | 1.000 | N/A |

## Test plan

- [x] All 14 actor tests pass (`lib/iris/tests/actor/`)
- [x] Local reproduction script confirms 0 gzip calls after fix

Fixes #3659

🤖 Generated with [Claude Code](https://claude.com/claude-code)