### PR TITLE
Handle pallas_tpu autotune misses under mosaic partitioning

### DIFF
--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
@@ -150,9 +150,6 @@ def _maybe_wrap_loss_in_shard_map_for_benchmark(
     labels: jax.Array,
     w: jax.Array,
 ) -> Callable[[jax.Array, jax.Array, jax.Array], jax.Array]:
-    if jax.default_backend() != "tpu":
-        return fn
-
     x_sharding = _named_sharding_of(x)
     labels_sharding = _named_sharding_of(labels)
     w_sharding = _named_sharding_of(w)

--- a/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
+++ b/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
@@ -974,7 +974,7 @@ def test_pallas_autotune_skipped_when_tuned_match_exists(monkeypatch: pytest.Mon
     assert seen_block_sizes == [inferred]
 
 
-def test_pallas_tpu_autotune_benchmark_wraps_in_shard_map_when_named_sharding_present(
+def test_autotune_benchmark_wraps_in_shard_map_when_named_sharding_present(
     monkeypatch: pytest.MonkeyPatch,
 ):
     x = jnp.ones((4, 8), dtype=jnp.float32)
@@ -1001,7 +1001,7 @@ def test_pallas_tpu_autotune_benchmark_wraps_in_shard_map_when_named_sharding_pr
         calls.append((mesh, in_specs, out_specs, check_vma))
         return fn
 
-    monkeypatch.setattr(fused_api.jax, "default_backend", lambda: "tpu")
+    monkeypatch.setattr(fused_api.jax, "default_backend", lambda: "gpu")
     monkeypatch.setattr(fused_api, "_named_sharding_of", fake_named_sharding_of)
     monkeypatch.setattr(fused_api.jax, "shard_map", fake_shard_map)
 


### PR DESCRIPTION
## Summary
- run fused CE autotune candidate benchmarking under `jax.shard_map` when inputs carry `NamedSharding` on TPU, so candidate lowering happens in an explicit shard-map partitioning context
- plumb input sharding into autotune abstract arguments (`ShapeDtypeStruct(..., sharding=...)`) to preserve staging context
- add regression coverage that asserts benchmark wrapping uses the expected mesh/spec wiring for `(x, labels, w)`

## Testing
- `uv run --project lib/levanter --group test pytest -o addopts='' lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py -q`
- `./infra/pre-commit.py --all-files --fix`
- `uv run --project lib/marin --group test pytest -o addopts='' -m 'not slow'` *(fails in collection due missing optional dependency `dupekit` in unrelated tests)*

Closes #3667
