### PR TITLE
Grug: only store EMA params when EMA is enabled

### DIFF
--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -224,7 +224,7 @@ class GrugTrainState:
     step: jax.Array
     params: Transformer
     opt_state: optax.OptState
-    ema_params: Transformer
+    ema_params: Transformer | None
 
 
 def initial_state(
@@ -233,13 +233,14 @@ def initial_state(
     optimizer: optax.GradientTransformation,
     mp: jmp.Policy,
     key: PRNGKeyArray,
+    ema_beta: float | None,
 ) -> GrugTrainState:
     params = mp.cast_to_param(Transformer.init(model_config, key=key))
     return GrugTrainState(
         step=jnp.array(0, dtype=jnp.int32),
         params=params,
         opt_state=optimizer.init(params),
-        ema_params=params,
+        ema_params=params if ema_beta is not None else None,
     )
 
 
@@ -278,8 +279,10 @@ def _make_train_step(
         params = optax.apply_updates(state.params, updates)
 
         if ema_beta is None:
-            ema_params = params
+            ema_params = None
         else:
+            if state.ema_params is None:
+                raise ValueError("ema_params must be initialized when ema_beta is set.")
             ema_params = jax.tree_util.tree_map(
                 lambda old, new: ema_beta * old + (1.0 - ema_beta) * new,
                 state.ema_params,
@@ -363,6 +366,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 optimizer=optimizer,
                 mp=trainer.mp,
                 key=model_rng,
+                ema_beta=config.trainer.ema_beta,
             )
 
         state = _init_state(model_key)
@@ -414,7 +418,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         state_callbacks = StateCallbackRunner[GrugTrainState](
             step_getter=lambda s: s.step,
             model_getter=lambda s: s.params,
-            eval_model_getter=lambda s: s.ema_params,
+            eval_model_getter=lambda s: s.ema_params if s.ema_params is not None else s.params,
             opt_state_getter=lambda s: s.opt_state,
         )
         state_callbacks.add_hook(

--- a/experiments/grug/modular_opt/train.py
+++ b/experiments/grug/modular_opt/train.py
@@ -224,7 +224,7 @@ class GrugTrainState:
     step: jax.Array
     params: Transformer
     opt_state: optax.OptState
-    ema_params: Transformer
+    ema_params: Transformer | None
 
 
 def initial_state(
@@ -233,13 +233,14 @@ def initial_state(
     optimizer: optax.GradientTransformation,
     mp: jmp.Policy,
     key: PRNGKeyArray,
+    ema_beta: float | None,
 ) -> GrugTrainState:
     params = mp.cast_to_param(Transformer.init(model_config, key=key))
     return GrugTrainState(
         step=jnp.array(0, dtype=jnp.int32),
         params=params,
         opt_state=optimizer.init(params),
-        ema_params=params,
+        ema_params=params if ema_beta is not None else None,
     )
 
 
@@ -278,8 +279,10 @@ def _make_train_step(
         params = optax.apply_updates(state.params, updates)
 
         if ema_beta is None:
-            ema_params = params
+            ema_params = None
         else:
+            if state.ema_params is None:
+                raise ValueError("ema_params must be initialized when ema_beta is set.")
             ema_params = jax.tree_util.tree_map(
                 lambda old, new: ema_beta * old + (1.0 - ema_beta) * new,
                 state.ema_params,
@@ -363,6 +366,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 optimizer=optimizer,
                 mp=trainer.mp,
                 key=model_rng,
+                ema_beta=config.trainer.ema_beta,
             )
 
         state = _init_state(model_key)
@@ -414,7 +418,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         state_callbacks = StateCallbackRunner[GrugTrainState](
             step_getter=lambda s: s.step,
             model_getter=lambda s: s.params,
-            eval_model_getter=lambda s: s.ema_params,
+            eval_model_getter=lambda s: s.ema_params if s.ema_params is not None else s.params,
             opt_state_getter=lambda s: s.opt_state,
         )
         state_callbacks.add_hook(

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -232,7 +232,7 @@ class GrugTrainState:
     step: jax.Array
     params: Transformer
     opt_state: optax.OptState
-    ema_params: Transformer
+    ema_params: Transformer | None
 
 
 def initial_state(
@@ -241,13 +241,14 @@ def initial_state(
     optimizer: optax.GradientTransformation,
     mp: jmp.Policy,
     key: PRNGKeyArray,
+    ema_beta: float | None,
 ) -> GrugTrainState:
     params = mp.cast_to_param(Transformer.init(model_config, key=key))
     return GrugTrainState(
         step=jnp.array(0, dtype=jnp.int32),
         params=params,
         opt_state=optimizer.init(params),
-        ema_params=params,
+        ema_params=params if ema_beta is not None else None,
     )
 
 
@@ -288,8 +289,10 @@ def _make_train_step(
         params = optax.apply_updates(state.params, updates)
 
         if ema_beta is None:
-            ema_params = params
+            ema_params = None
         else:
+            if state.ema_params is None:
+                raise ValueError("ema_params must be initialized when ema_beta is set.")
             ema_params = jax.tree_util.tree_map(
                 lambda old, new: ema_beta * old + (1.0 - ema_beta) * new,
                 state.ema_params,
@@ -373,6 +376,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 optimizer=optimizer,
                 mp=trainer.mp,
                 key=model_rng,
+                ema_beta=config.trainer.ema_beta,
             )
 
         state = _init_state(model_key)
@@ -424,7 +428,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         state_callbacks = StateCallbackRunner[GrugTrainState](
             step_getter=lambda s: s.step,
             model_getter=lambda s: s.params,
-            eval_model_getter=lambda s: s.ema_params,
+            eval_model_getter=lambda s: s.ema_params if s.ema_params is not None else s.params,
             opt_state_getter=lambda s: s.opt_state,
         )
         state_callbacks.add_hook(

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -135,7 +135,7 @@ def test_grug_variant_one_step_contract_lowers_with_default_ctor(variant: str):
             tokens=jax.sharding.reshard(batch.tokens, token_pspec),
             loss_weight=jax.sharding.reshard(batch.loss_weight, token_pspec),
         )
-        state = initial_state(cfg, optimizer=optimizer, mp=mp, key=jax.random.PRNGKey(0))
+        state = initial_state(cfg, optimizer=optimizer, mp=mp, key=jax.random.PRNGKey(0), ema_beta=None)
         return train_step(state, sharded_batch, compute_watch=False)
 
     with _reset_abstract_mesh(), use_abstract_mesh(mesh):
@@ -145,6 +145,38 @@ def test_grug_variant_one_step_contract_lowers_with_default_ctor(variant: str):
     assert "train/loss" in out_metrics_shape
     assert out_metrics_shape["train/loss"].shape == ()
     assert out_watch_shape is None
+
+
+@pytest.mark.parametrize(
+    "variant",
+    _discover_grug_variants_with_model_and_train(),
+)
+def test_grug_variant_initial_state_only_stores_ema_when_enabled(variant: str):
+    train_module = importlib.import_module(_variant_module_name(variant, "train"))
+    model_module = importlib.import_module(_variant_module_name(variant, "model"))
+    model_config_cls = model_module.GrugModelConfig
+    initial_state = train_module.initial_state
+    mesh_fn = getattr(model_module, "debug_mesh_and_token_pspec", None)
+    if mesh_fn is None:
+        raise AssertionError(f"{_variant_module_name(variant, 'model')} must define debug_mesh_and_token_pspec")
+
+    cfg = model_config_cls(vocab_size=1024)
+    optimizer = optax.adam(1e-2)
+    mp = jmp.get_policy("f32")
+    mesh, _ = mesh_fn(num_devices=4)
+
+    def init_state_shape(*, ema_beta: float | None):
+        def build():
+            return initial_state(cfg, optimizer=optimizer, mp=mp, key=jax.random.PRNGKey(0), ema_beta=ema_beta)
+
+        with _reset_abstract_mesh(), use_abstract_mesh(mesh):
+            return eqx.filter_eval_shape(build)
+
+    no_ema_state_shape = init_state_shape(ema_beta=None)
+    assert no_ema_state_shape.ema_params is None
+
+    with_ema_state_shape = init_state_shape(ema_beta=0.999)
+    assert with_ema_state_shape.ema_params is not None
 
 
 def test_grug_base_run_emits_expected_metrics_with_json_tracker(tmp_path: Path):


### PR DESCRIPTION
## Summary
- make `GrugTrainState.ema_params` optional in all Grug trainers (`base`, `moe`, `modular_opt`)
- only initialize/update EMA params when `ema_beta` is configured
- use current params for callback eval model when EMA is disabled
- add variant contract coverage that `initial_state` stores EMA params only when EMA is enabled

## Why
With `ema_beta=None`, storing `ema_params` in train state can materialize a second full parameter tree under JIT, increasing memory usage.

Closes #3668.

## Testing
- `uv run --with pytest --with pytest-timeout python -m pytest tests/test_grug_variant_contracts.py`
- `./infra/pre-commit.py --all-files --fix`
