### PR TITLE
iris: send tail=true for GetTaskLogs RPC

### DIFF
--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -42,6 +42,7 @@ const taskLogState = props.taskId
       id: props.taskId,
       maxTotalLines: tailLines.value || undefined,
       attemptId: selectedAttemptId.value >= 0 ? selectedAttemptId.value : -1,
+      tail: true,
     }))
   : null
 


### PR DESCRIPTION
## Summary
- Send `tail: true` in the `GetTaskLogs` RPC params so task logs return the **last** N lines instead of the first N.

Fixes #3671

## Test plan
- [ ] Verify task log viewer shows most recent logs when line count exceeds limit
- [ ] Verify process logs (FetchLogs) behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)