### PR TITLE
Fix Claude PR review for fork PR OIDC

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,7 +1,7 @@
 name: Claude PR Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review, reopened]
   issue_comment:
     # NOTE: there's no PR comment specific event, so instead we need to check all comments and filter in the job.
@@ -16,7 +16,7 @@ jobs:
   review:
     if: >-
       (
-        github.event_name == 'pull_request' &&
+        github.event_name == 'pull_request_target' &&
         (
           github.event.pull_request.author_association == 'OWNER' ||
           github.event.pull_request.author_association == 'MEMBER' ||
@@ -50,7 +50,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
-          track_progress: ${{ github.event_name == 'pull_request' }}
+          track_progress: ${{ github.event_name == 'pull_request_target' }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}


### PR DESCRIPTION
## Summary
- switch `.github/workflows/claude-review.yml` auto-trigger from `pull_request` to `pull_request_target`
- update event-name guards to use `pull_request_target` for the trusted auto-review path
- keep existing collaborator/owner author-association gates unchanged

Fixes #3674.

## Testing
- `./infra/pre-commit.py --all-files --fix` ✅
- `uv run pytest -m 'not slow'` ❌ (`pytest` entrypoint missing in root env)
- `uv run --package marin pytest -m 'not slow'` ❌ (`ModuleNotFoundError: dupekit` during unrelated test collection)
- `uv run --all-packages pytest -m 'not slow'` ❌ (`ModuleNotFoundError: dupekit` during unrelated test collection)
