### PR TITLE
fix(iris): remove misleading 'All' log option and increase default max lines

### DIFF
--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -119,7 +119,6 @@ const filteredLogs = computed(() => {
         <option :value="1000">1,000 lines</option>
         <option :value="5000">5,000 lines</option>
         <option :value="10000">10,000 lines</option>
-        <option :value="0">All</option>
       </select>
       <select
         v-if="attempts && attempts.length > 0"

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -80,7 +80,7 @@ from iris.time_utils import Timestamp, Timer
 logger = logging.getLogger(__name__)
 
 DEFAULT_TRANSACTION_LIMIT = 50
-DEFAULT_MAX_TOTAL_LINES = 10000
+DEFAULT_MAX_TOTAL_LINES = 100000
 
 # Maximum bundle size in bytes (25 MB) - matches client-side limit
 MAX_BUNDLE_SIZE_BYTES = 25 * 1024 * 1024


### PR DESCRIPTION
Drop the 'All' option from the LogViewer dropdown since it was capped at DEFAULT_MAX_TOTAL_LINES anyway. Increase DEFAULT_MAX_TOTAL_LINES from 10k to 100k so CLI users can fetch more logs when needed.

Fixes #3672