### PR TITLE
fix(fray): early-exit discover_new when target count is reached

### DIFF
--- a/lib/fray/src/fray/v2/iris_backend.py
+++ b/lib/fray/src/fray/v2/iris_backend.py
@@ -363,17 +363,23 @@ class IrisActorGroup:
         """Number of actors that are available for RPC."""
         return len(self._handles)
 
-    def discover_new(self) -> list[ActorHandle]:
+    def discover_new(self, target: int | None = None) -> list[ActorHandle]:
         """Probe for newly available actors without blocking.
 
         Returns only the handles discovered during this call (not previously
         known ones). Call repeatedly to pick up workers as they come online.
+
+        Args:
+            target: Stop probing once this many total actors are discovered.
+                If None, probes all indices.
         """
         client = self._get_client()
         resolver = client.resolver_for_job(self._job_id)
 
         newly_discovered: list[ActorHandle] = []
         for i in range(self._count):
+            if target is not None and len(self._discovered_names) >= target:
+                break
             # Absolute endpoint name matches what _host_actor registers
             endpoint_name = f"{self._job_id}/{self._name}-{i}"
             if endpoint_name in self._discovered_names:
@@ -407,7 +413,7 @@ class IrisActorGroup:
         sleep_secs = 0.5
 
         while True:
-            self.discover_new()
+            self.discover_new(target=target)
 
             if len(self._discovered_names) >= target:
                 return list(self._handles[:target])


### PR DESCRIPTION
## Summary

- `IrisActorGroup.discover_new()` probes all worker indices via `resolver.resolve()` (~1s each), so `wait_ready(count=1)` on a 2000-worker group blocks for ~30 min
- Pass the `target` from `wait_ready()` into `discover_new()` so it breaks out of the probe loop once enough workers are found
- Backward-compatible: `target=None` (default) preserves the old scan-all behavior

Fixes #3687

## Test plan

- [x] Existing `test_actor_group_wait_ready_partial` covers the `wait_ready(count=N)` contract via `LocalClient`
- [ ] No new test: the optimization is in the Iris resolver loop (I/O boundary); testing it would require mocking the resolver for a trivial early-break check

🤖 Generated with [Claude Code](https://claude.com/claude-code)