### PR TITLE
Evalchemy new evals and fixes

### DIFF
--- a/experiments/evals/evalchemy_task_configs.py
+++ b/experiments/evals/evalchemy_task_configs.py
@@ -17,6 +17,7 @@ from marin.evaluation.evaluation_config import EvalTaskConfig
 __all__ = [
     "AIME24",
     "AIME25",
+    "AIME26",
     "ALICE_IN_WONDERLAND",
     "AMC23",
     "BIGCODEBENCH",
@@ -34,8 +35,10 @@ __all__ = [
     "JEEBENCH",
     "LIVECODEBENCH",
     "LIVECODEBENCH_V5_OFFICIAL",
+    "LIVECODEBENCH_V6_OFFICIAL",
     "MATH500",
     "MBPP_PLUS",
+    "OLYMPIADBENCH",
 ]
 
 # =============================================================================
@@ -49,10 +52,12 @@ __all__ = [
 # seeds from Marin instead, to avoid a hidden seeds x n_repeat multiplier on iteration count.
 AIME24 = EvalTaskConfig(name="AIME24", num_fewshot=0, task_alias="AIME24", task_kwargs={"n_repeat": 1})
 AIME25 = EvalTaskConfig(name="AIME25", num_fewshot=0, task_alias="AIME25", task_kwargs={"n_repeat": 1})
+AIME26 = EvalTaskConfig(name="AIME26", num_fewshot=0, task_alias="AIME26", task_kwargs={"n_repeat": 1})
 AMC23 = EvalTaskConfig(name="AMC23", num_fewshot=0, task_alias="AMC23", task_kwargs={"n_repeat": 1})
 
 MATH500 = EvalTaskConfig(name="MATH500", num_fewshot=0, task_alias="MATH500")
 HMMT = EvalTaskConfig(name="HMMT", num_fewshot=0, task_alias="HMMT", task_kwargs={"n_repeat": 1})
+OLYMPIADBENCH = EvalTaskConfig(name="OlympiadBench", num_fewshot=0, task_alias="OlympiadBench")
 
 # =============================================================================
 # Code tasks
@@ -64,6 +69,9 @@ LIVECODEBENCH = EvalTaskConfig(
 )
 LIVECODEBENCH_V5_OFFICIAL = EvalTaskConfig(
     name="LiveCodeBenchv5_official", num_fewshot=0, task_alias="LiveCodeBenchv5_official", task_kwargs={"n_repeat": 1}
+)
+LIVECODEBENCH_V6_OFFICIAL = EvalTaskConfig(
+    name="LiveCodeBenchv6_official", num_fewshot=0, task_alias="LiveCodeBenchv6_official", task_kwargs={"n_repeat": 1}
 )
 BIGCODEBENCH = EvalTaskConfig(name="BigCodeBench", num_fewshot=0, task_alias="BigCodeBench")
 CODEFORCES = EvalTaskConfig(name="CodeForces", num_fewshot=0, task_alias="CodeForces", task_kwargs={"n_repeat": 1})
@@ -84,12 +92,13 @@ HUMANITYS_LAST_EXAM = EvalTaskConfig(name="HLE", num_fewshot=0, task_alias="HLE"
 # =============================================================================
 # Task groups
 # =============================================================================
-EVALCHEMY_MATH_TASKS = (AIME24, AIME25, AMC23, MATH500, HMMT)
+EVALCHEMY_MATH_TASKS = (AIME24, AIME25, AIME26, AMC23, MATH500, HMMT, OLYMPIADBENCH)
 EVALCHEMY_CODE_TASKS = (
     HUMANEVAL_PLUS,
     MBPP_PLUS,
     LIVECODEBENCH,
     LIVECODEBENCH_V5_OFFICIAL,
+    LIVECODEBENCH_V6_OFFICIAL,
     BIGCODEBENCH,
     CODEFORCES,
     CODEELO,

--- a/lib/marin/src/marin/evaluation/evaluators/evalchemy_evaluator.py
+++ b/lib/marin/src/marin/evaluation/evaluators/evalchemy_evaluator.py
@@ -45,8 +45,8 @@ from marin.evaluation.utils import is_remote_path, upload_to_gcs
 logger = logging.getLogger(__name__)
 
 # Evalchemy git repo and commit to use
-EVALCHEMY_REPO = "https://github.com/mlfoundations/evalchemy.git"
-EVALCHEMY_COMMIT = "6ed674159b37f740f2353a86f596f49f6ac13c19"  # 2025-01-08
+EVALCHEMY_REPO = "https://github.com/teetone/evalchemy.git"
+EVALCHEMY_COMMIT = "010412c"  # 2026-03-14 commit
 
 
 # Evalchemy benchmarks that have hardcoded n_repeat values and their paths.
@@ -61,11 +61,14 @@ N_REPEAT_BENCHMARK_PATHS = {
     "HMMT": "eval/chat_benchmarks/HMMT/eval_instruct.py",
     "LiveCodeBench": "eval/chat_benchmarks/LiveCodeBench/eval_instruct.py",
     "LiveCodeBenchv5_official": "eval/chat_benchmarks/LiveCodeBenchv5_official/eval_instruct.py",
+    "LiveCodeBenchv6_official": "eval/chat_benchmarks/LiveCodeBenchv6_official/eval_instruct.py",
     "CodeForces": "eval/chat_benchmarks/CodeForces/eval_instruct.py",
     "CodeElo": "eval/chat_benchmarks/CodeElo/eval_instruct.py",
     "GPQADiamond": "eval/chat_benchmarks/GPQADiamond/eval_instruct.py",
     "JEEBench": "eval/chat_benchmarks/JEEBench/eval_instruct.py",
     "HLE": "eval/chat_benchmarks/HLE/eval_instruct.py",
+    "AIME26": "eval/chat_benchmarks/AIME26/eval_instruct.py",
+    "OlympiadBench": "eval/chat_benchmarks/OlympiadBench/eval_instruct.py",
 }
 
 


### PR DESCRIPTION
The Evalchemy evaluator now uses [a fork](https://github.com/teetone/evalchemy.git) with the following changes.

### New evals

- AIME26
- OlympiadBench (math)
- LiveCodeBench v6

### Fixes

- Fix the error when writing long numbers out to the results JSON
- Fail fast when writing results to JSON instead of swallowing errors. This caused jobs to finish successfully, but skipped writing the results out to disk.