### PR TITLE
iris/zephyr: use worker prefix for worker endpoint lookup

### DIFF
--- a/lib/fray/src/fray/v2/iris_backend.py
+++ b/lib/fray/src/fray/v2/iris_backend.py
@@ -186,8 +186,8 @@ def _host_actor(actor_class: type, args: tuple, kwargs: dict, name_prefix: str) 
     Instantiates the actor class, creates an ActorServer, registers the
     endpoint for discovery, and blocks until the job is terminated.
 
-    All replicas register under the same endpoint name so the resolver
-    returns the full set of workers for the group.
+    For multi-replica jobs, each replica gets a unique actor name based on
+    its task index. Uses absolute endpoint names: "/{job_id}/{name_prefix}-{task_index}".
     """
 
     ctx = iris_ctx()
@@ -195,9 +195,9 @@ def _host_actor(actor_class: type, args: tuple, kwargs: dict, name_prefix: str) 
     if job_info is None:
         raise RuntimeError("_host_actor must run inside an Iris job but get_job_info() returned None")
 
-    # All replicas share the same endpoint name; the controller stores each
-    # as a separate endpoint (unique endpoint_id + address).
-    actor_name = f"{ctx.job_id}/{name_prefix}"
+    # Absolute endpoint name - bypasses namespace prefix in resolver
+    # JobName.__str__ already includes leading slash
+    actor_name = f"{ctx.job_id}/{name_prefix}-{job_info.task_index}"
     logger.info(f"Starting actor: {actor_name} (job_id={ctx.job_id})")
 
     # Create handle BEFORE instance so actor can access it during __init__
@@ -332,7 +332,7 @@ class IrisActorGroup:
         self._count = count
         self._job_id = job_id
         self._handles: list[ActorHandle] = []
-        self._discovered_urls: set[str] = set()
+        self._discovered_names: set[str] = set()
 
     def __getstate__(self) -> dict:
         # Serialize only the discovery parameters - discovery state resets on deserialize
@@ -347,7 +347,7 @@ class IrisActorGroup:
         self._count = state["count"]
         self._job_id = state["job_id"]
         self._handles = []
-        self._discovered_urls = set()
+        self._discovered_names = set()
 
     def _get_client(self) -> IrisClientLib:
         """Get IrisClient from context."""
@@ -369,33 +369,34 @@ class IrisActorGroup:
         Returns only the handles discovered during this call (not previously
         known ones). Call repeatedly to pick up workers as they come online.
 
-        All replicas register under the same endpoint name, so a single
-        ``resolve()`` returns every worker in the group.
+        Uses a single prefix-match RPC to discover all actors whose endpoint
+        names start with ``{job_id}/{name}-``.
 
         Args:
             target: Stop probing once this many total actors are discovered.
                 If None, probes all indices.
         """
         client = self._get_client()
-        resolver = client.resolver_for_job(self._job_id)
-        result = resolver.resolve(self._name)
+        # Single RPC: prefix match all actors for this group
+        # _host_actor registers endpoints as "{job_id}/{name}-{task_index}"
+        prefix = f"{self._job_id}/{self._name}-"
+        endpoints = client._cluster_client.list_endpoints(prefix=prefix, exact=False)
 
         newly_discovered: list[ActorHandle] = []
-        for ep in result.endpoints:
-            if target is not None and len(self._discovered_urls) >= target:
+        for ep in endpoints:
+            if target is not None and len(self._discovered_names) >= target:
                 break
-            if ep.url in self._discovered_urls:
+            if ep.name in self._discovered_names:
                 continue
-            self._discovered_urls.add(ep.url)
-            handle = IrisActorHandle(self._name)
+            self._discovered_names.add(ep.name)
+            handle = IrisActorHandle(ep.name)
             self._handles.append(handle)
             newly_discovered.append(handle)
             logger.info(
-                "discover_new: found actor=%s url=%s job_id=%s (%d/%d ready)",
-                self._name,
-                ep.url,
+                "discover_new: found actor=%s job_id=%s (%d/%d ready)",
+                ep.name,
                 self._job_id,
-                len(self._discovered_urls),
+                len(self._discovered_names),
                 self._count,
             )
 
@@ -415,7 +416,7 @@ class IrisActorGroup:
         while True:
             self.discover_new(target=target)
 
-            if len(self._discovered_urls) >= target:
+            if len(self._discovered_names) >= target:
                 return list(self._handles[:target])
 
             # Fail fast if the underlying job has terminated (e.g. crash, OOM,
@@ -427,13 +428,13 @@ class IrisActorGroup:
                 error = job_status.error or "unknown error"
                 raise RuntimeError(
                     f"Actor job {self._job_id} finished before all actors registered "
-                    f"({len(self._discovered_urls)}/{target} ready). "
+                    f"({len(self._discovered_names)}/{target} ready). "
                     f"Job state={job_status.state}, error={error}"
                 )
 
             elapsed = time.monotonic() - start
             if elapsed >= timeout:
-                raise TimeoutError(f"Only {len(self._discovered_urls)}/{target} actors ready after {timeout}s")
+                raise TimeoutError(f"Only {len(self._discovered_names)}/{target} actors ready after {timeout}s")
 
             time.sleep(sleep_secs)
 


### PR DESCRIPTION
Follow up: https://github.com/marin-community/marin/pull/3688#discussion_r2936024865