### PR TITLE
GPU canary: switch from SlimPajama to Nemotron

### DIFF
--- a/experiments/ferries/canary_ferry.py
+++ b/experiments/ferries/canary_ferry.py
@@ -3,30 +3,25 @@
 
 """Canary ferry: Grug MoE daily pretraining canary.
 
-Supports TPU (v5p-8, Nemotron, ~1B tokens) and GPU (8x H100, SlimPajama, ~50 steps).
+Supports TPU (v5p-8, Nemotron, ~1B tokens) and GPU (8x H100, Nemotron, ~50 steps).
 Config is driven by env vars set in the GH Actions workflow env: block and forwarded
 to the Iris container. workflow_dispatch inputs override CANARY_TARGET_TOKENS.
 
     CANARY_ACCELERATOR   tpu | gpu
     CANARY_BATCH_SIZE    per-device batch size
-    CANARY_CACHE_COPY_MAX_WORKERS gpu-only cache-copy worker cap
     CANARY_TARGET_TOKENS total training tokens
     RUN_ID               unique run identifier
 """
 
-import dataclasses
 import datetime
 import os
 
 from fray.cluster import ResourceConfig
 from levanter.callbacks.profiler import ProfilerConfig
-from levanter.data.text import BlockShuffleConfig, TextLmDatasetFormat
 from levanter.optim import AdamConfig
 from levanter.tracker.wandb import WandbConfig
 from marin.execution.executor import ExecutorStep, executor_main, this_output_path, versioned
-from marin.processing.tokenize.data_configs import lm_data_config
 
-from experiments.defaults import default_tokenize
 from experiments.grug.moe.launch import (
     GRUG_MOE_TRIAL_MODEL,
     NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
@@ -34,7 +29,6 @@ from experiments.grug.moe.launch import (
     run_grug_moe_trial,
 )
 from experiments.grug.moe.train import GrugEvalConfig, GrugTrainerConfig
-from experiments.llama import llama3_tokenizer
 
 CANARY_OPTIMIZER = AdamConfig(
     learning_rate=3e-3,
@@ -82,28 +76,8 @@ def _build_step_from_env() -> ExecutorStep:
     else:
         multi_host = os.environ.get("CANARY_MULTI_HOST", "").lower() in ("1", "true")
         batch_size = _env_int("CANARY_BATCH_SIZE", 32)
-        cache_copy_max_workers = _env_int("CANARY_CACHE_COPY_MAX_WORKERS", 12)
         target_tokens = _env_int("CANARY_TARGET_TOKENS", batch_size * GRUG_MOE_TRIAL_MODEL.max_seq_len * 50)
-        # SlimPajama-6B with block-shuffle — small dataset, re-tokenized on first run.
-        tokenize_step = default_tokenize(
-            name="slimpajama-6b-cw",
-            dataset="DKYoon/SlimPajama-6B",
-            tokenizer=llama3_tokenizer,
-            format=TextLmDatasetFormat(),
-        )
-        tokenize_step = dataclasses.replace(
-            tokenize_step,
-            config=dataclasses.replace(
-                tokenize_step.config,
-                # SlimPajama-6B tokenization OOMs at the default 10g worker_resources.
-                worker_resources=ResourceConfig(ram="64g", disk="64g"),
-                cache_copy_max_workers=cache_copy_max_workers,
-            ),
-        )
-        data = lm_data_config(
-            training_set=tokenize_step,
-            shuffle=BlockShuffleConfig(io_block_size=256, window_blocks=256, perm_type="feistel"),
-        )
+        data = NEMOTRON_MIX_WITH_DEFAULT_VALIDATION
         if multi_host:
             name = "canary-ferry-cw-multihost"
             resources = ResourceConfig.with_gpu("H100", count=8, cpu=32, ram="256g", disk="256g", replicas=2)

--- a/experiments/ferries/nemotron_data.py
+++ b/experiments/ferries/nemotron_data.py
@@ -8,10 +8,26 @@ default validation sets — everything that NEMOTRON_MIX_WITH_DEFAULT_VALIDATION
 depends on.
 """
 
+import dataclasses
+
 from experiments.defaults import default_validation_sets
 from experiments.pretraining_datasets.dclm import dclm_components_llama3
 from experiments.pretraining_datasets.nemotron import nemotron_mix_block_shuffle, tokenize_nemotron
-from marin.execution.executor import executor_main
+from marin.execution.executor import ExecutorStep, executor_main
+from marin.processing.tokenize.tokenize import TokenizeConfigBase
+
+COREWEAVE_CACHE_COPY_MAX_WORKERS = 12
+
+
+def _with_cache_copy_max_workers(step: ExecutorStep, *, cache_copy_max_workers: int) -> ExecutorStep:
+    config = step.config
+    if not isinstance(config, TokenizeConfigBase):
+        return step
+
+    return dataclasses.replace(
+        step,
+        config=dataclasses.replace(config, cache_copy_max_workers=cache_copy_max_workers),
+    )
 
 
 def main() -> None:
@@ -21,8 +37,13 @@ def main() -> None:
         dclm_components_llama3["proofpile_2"],
     ]
     validation_steps = list(default_validation_sets(tokenizer=nemotron_mix_block_shuffle.tokenizer).values())
+    steps = nemotron_steps + dclm_steps + validation_steps
 
-    executor_main(steps=nemotron_steps + dclm_steps + validation_steps)
+    executor_main(
+        steps=[
+            _with_cache_copy_max_workers(step, cache_copy_max_workers=COREWEAVE_CACHE_COPY_MAX_WORKERS) for step in steps
+        ]
+    )
 
 
 if __name__ == "__main__":

--- a/experiments/ferries/nemotron_data.py
+++ b/experiments/ferries/nemotron_data.py
@@ -1,0 +1,29 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run only the data-preparation steps upstream of the Nemotron canary ferry.
+
+Tokenizes all Nemotron CC splits, the DCLM code/math components, and the
+default validation sets — everything that NEMOTRON_MIX_WITH_DEFAULT_VALIDATION
+depends on.
+"""
+
+from experiments.defaults import default_validation_sets
+from experiments.pretraining_datasets.dclm import dclm_components_llama3
+from experiments.pretraining_datasets.nemotron import nemotron_mix_block_shuffle, tokenize_nemotron
+from marin.execution.executor import executor_main
+
+
+def main() -> None:
+    nemotron_steps = list(tokenize_nemotron().values())
+    dclm_steps = [
+        dclm_components_llama3["starcoderdata"],
+        dclm_components_llama3["proofpile_2"],
+    ]
+    validation_steps = list(default_validation_sets(tokenizer=nemotron_mix_block_shuffle.tokenizer).values())
+
+    executor_main(steps=nemotron_steps + dclm_steps + validation_steps)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/iris/examples/coreweave-romain-nt.yaml
+++ b/lib/iris/examples/coreweave-romain-nt.yaml
@@ -1,0 +1,94 @@
+# Iris development cluster configuration for CoreWeave CKS.
+#
+# Architecture: KubernetesProvider dispatches task pods directly to the k8s API.
+# No worker daemons are needed. CoreWeave NodePool autoscaling provisions nodes
+# on demand; when pods are deleted, NodePools scale to zero automatically.
+# CPU nodes are kept always-on (min_slices=2) for monitoring software.
+#
+# Workflow:
+#
+#   1. Set S3 object storage credentials (required for s3:// storage URIs):
+#        export R2_ACCESS_KEY_ID=<your-r2-access-key-id>
+#        export R2_SECRET_ACCESS_KEY=<your-r2-secret-access-key>
+#      These are created in the Cloudflare dashboard under R2 > Manage R2 API Tokens.
+#      `iris cluster start` creates a K8s Secret from these env vars automatically.
+#
+#   2. Start the cluster (creates RBAC, shared NodePools, ConfigMap, Deployment, Service):
+#        iris --config=lib/iris/examples/coreweave-romain-nt.yaml cluster start
+#
+#   3. Use the Iris CLI:
+#        iris --config=lib/iris/examples/coreweave-romain-nt.yaml cluster status
+#        iris --config=lib/iris/examples/coreweave-romain-nt.yaml cluster dashboard
+#
+# This config file is used by:
+#   - The CLI on the operator's laptop (for `cluster start`, `cluster status`, job submission)
+#   - The controller and workers inside the cluster (mounted as ConfigMap at /etc/iris/config.yaml)
+#
+# To use a local kubeconfig (e.g. from CoreWeave Console > Tokens > Download):
+#   Set platform.coreweave.kubeconfig_path below, or:
+#   export KUBECONFIG=~/.kube/coreweave-iris
+
+platform:
+  label_prefix: iris-romain-nt
+  coreweave:
+    region: US-WEST-04A
+    namespace: iris-romain-nt
+    kubeconfig_path: ~/.kube/coreweave-iris
+    object_storage_endpoint: https://74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com
+
+storage:
+  remote_state_dir: s3://marin-na/iris/state/romain-nt
+
+kubernetes_provider:
+  namespace: iris-romain-nt
+  default_image: ghcr.io/marin-community/iris-task:latest
+  host_network: true              # Required for NCCL/IB multi-host traffic
+  cache_dir: /mnt/local/iris-cache  # NVMe; default /cache hits the 15GB ramdisk on bare-metal GPU nodes
+  controller_address: http://iris-controller-svc.iris-romain-nt.svc.cluster.local:10000
+
+controller:
+  image: ghcr.io/marin-community/iris-controller:latest
+  coreweave:
+    port: 10000
+    service_name: iris-controller-svc
+    scale_group: cpu-erapids
+
+defaults:
+  autoscaler:
+    evaluation_interval:
+      milliseconds: 10000
+    scale_up_delay:
+      milliseconds: 60000
+    scale_down_delay:
+      milliseconds: 300000
+    startup_grace_period:
+      milliseconds: 2400000    # 40 min — covers autoscaler node provisioning + Pod startup
+  worker:
+    docker_image: ghcr.io/marin-community/iris-worker:latest
+    port: 10001
+    cache_dir: /mnt/local/iris-cache
+    runtime: docker
+    default_task_image: ghcr.io/marin-community/iris-task:latest
+
+scale_groups:
+  cpu-erapids:
+    num_vms: 1
+    resources:
+      cpu: 64
+      ram: 256GB
+      disk: 1TB
+      device_type: cpu
+      preemptible: false
+    worker:
+      attributes:
+        region: US-WEST-04A
+        pool: cpu-erapids
+    min_slices: 0
+    max_slices: 10
+    priority: 50
+    slice_template:
+      num_vms: 1
+      coreweave:
+        region: US-WEST-04A
+        instance_type: cd-gp-i64-erapids
+

--- a/lib/iris/src/iris/cluster/providers/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/controller.py
@@ -41,7 +41,9 @@ _KUBECTL_TIMEOUT = 1800.0
 
 _S3_SECRET_NAME = "iris-s3-credentials"
 _CONTROLLER_CPU_REQUEST = "2"
-_CONTROLLER_MEMORY_REQUEST = "4Gi"
+# The controller enumerates cluster-wide pod state and restores from persisted
+# state snapshots; 4Gi has proven too small on busy CoreWeave clusters.
+_CONTROLLER_MEMORY_REQUEST = "16Gi"
 
 
 # S3-compatible endpoints that require virtual-hosted-style addressing where the

--- a/lib/marin/src/marin/datakit/download/nemotron_v1.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_v1.py
@@ -13,6 +13,7 @@ import zstandard
 from rigging.filesystem import open_url
 from marin.execution.step_spec import StepSpec
 from marin.utils import fsspec_exists
+from fray.cluster import ResourceConfig
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 from zephyr import Dataset, ZephyrContext
@@ -102,7 +103,9 @@ def download_nemotron_cc(output_path: str) -> None:
         .write_jsonl(os.path.join(output_path, ".metrics/download-{shard:05d}.jsonl"), skip_existing=True)
     )
 
-    ctx = ZephyrContext(name="download-nemotron-cc")
+    # Each worker downloads a ~350MB zstd file and decompresses to ~1.5-2GB in memory.
+    # Default ZephyrContext resources (1GB) causes OOMKill; 4GB gives sufficient headroom.
+    ctx = ZephyrContext(name="download-nemotron-cc", resources=ResourceConfig(cpu=1, ram="4g"))
     ctx.execute(pipeline)
 
     logger.info(f"Downloaded Nemotron CC files to {output_path}")

--- a/lib/marin/src/marin/datakit/download/nemotron_v1.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_v1.py
@@ -6,22 +6,22 @@
 import json
 import logging
 import os
+import tempfile
 from collections.abc import Iterator
 
 import requests
 import zstandard
-from rigging.filesystem import open_url
+from fray.cluster import ResourceConfig
 from marin.execution.step_spec import StepSpec
 from marin.utils import fsspec_exists
-from fray.cluster import ResourceConfig
 from requests.adapters import HTTPAdapter
+from rigging.filesystem import open_url, url_to_fs
 from urllib3.util import Retry
 from zephyr import Dataset, ZephyrContext
-from zephyr.writers import atomic_rename
 
 logger = logging.getLogger(__name__)
 
-myagent = "marin-nemotron-ingress/1.0"
+_USER_AGENT = "marin-nemotron-ingress/1.0"
 NCC_PATH_FILE_URL = "https://data.commoncrawl.org/contrib/Nemotron/Nemotron-CC/data-jsonl.paths.gz"
 
 
@@ -49,20 +49,22 @@ def _iter_jsonl_from_zstd_stream(raw_stream) -> Iterator[dict]:
 def download_single_nemotron_path(input_file_path: str, output_file_path: str) -> dict:
     """Fetches content from a Common Crawl path, streaming records to zstd output."""
     cc_url = f"https://data.commoncrawl.org/{input_file_path}"
-    logger.info(f"Downloading Nemotron CC file {cc_url} to {output_file_path}")
+    logger.info("Downloading Nemotron CC file %s to %s", cc_url, output_file_path)
 
     session = requests.Session()
-    retries = Retry(total=5, backoff_factor=1.0, status_forcelist=[500, 502, 503, 504], allowed_methods=["GET"])
+    retries = Retry(total=10, backoff_factor=2.0, status_forcelist=[500, 502, 503, 504], allowed_methods=["GET"])
     adapter = HTTPAdapter(max_retries=retries)
     session.mount("https://", adapter)
     session.mount("http://", adapter)
 
-    response = session.get(cc_url, headers={"user-agent": myagent}, stream=True)
+    response = session.get(cc_url, headers={"user-agent": _USER_AGENT}, stream=True)
     response.raise_for_status()
 
     num_records = 0
-    with atomic_rename(output_file_path) as temp_path:
-        with open_url(temp_path, "w", compression="zstd") as out:
+    # Write locally then fs.put() — R2 rejects streaming multipart with unequal part sizes.
+    with tempfile.NamedTemporaryFile(suffix=".jsonl.zst", delete=True) as local_tmp:
+        cctx = zstandard.ZstdCompressor(level=2, threads=1)
+        with cctx.stream_writer(local_tmp, closefd=False) as zst:
             for record in _iter_jsonl_from_zstd_stream(response.raw):
                 dolma_record = {
                     "id": record["warc_record_id"],
@@ -71,8 +73,13 @@ def download_single_nemotron_path(input_file_path: str, output_file_path: str) -
                     "format": "text",
                     "metadata": {f"nemotron_{k}": v for k, v in record.items() if k not in ("warc_record_id", "text")},
                 }
-                print(json.dumps(dolma_record), file=out)
+                zst.write(json.dumps(dolma_record).encode() + b"\n")
                 num_records += 1
+        local_tmp.flush()
+
+        fs, resolved_path = url_to_fs(output_file_path)
+        fs.mkdirs(os.path.dirname(resolved_path), exist_ok=True)
+        fs.put(local_tmp.name, resolved_path)
 
     return {"input_file": input_file_path, "output_file": output_file_path, "num_records": num_records}
 

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -1316,28 +1316,64 @@ def _run_coordinator_job(config_path: str, result_path: str) -> None:
     # Create workers (child jobs)
     num_shards = config.plan.num_shards
     actual_workers = min(config.max_workers, num_shards) if num_shards > 0 else 0
-    worker_group = None
-
-    if actual_workers > 0:
-        # Worker name includes attempt ID so that if a stale coordinator
-        # process from a previous attempt is still running, its shutdown
-        # targets the old name and cannot kill this attempt's workers.
-        worker_name = f"zephyr-{config.name}-p{config.pipeline_id}-workers-a{attempt_id}"
-        logger.info("Starting %d workers (max=%d, shards=%d)", actual_workers, config.max_workers, num_shards)
-        worker_group = client.create_actor_group(
-            ZephyrWorker,
-            coordinator,
-            name=worker_name,
-            count=actual_workers,
-            resources=config.worker_resources,
-            actor_config=ActorConfig(max_task_retries=10),
-        )
-        worker_group.wait_ready(count=1, timeout=3600.0)
-
-        # Let the coordinator poll worker job health in its maintenance loop
-        coordinator.set_worker_group.remote(worker_group).result()
+    worker_group: Any = None
 
     try:
+        if actual_workers > 0:
+            # Worker name includes attempt ID so that if a stale coordinator
+            # process from a previous attempt is still running, its shutdown
+            # targets the old name and cannot kill this attempt's workers.
+            worker_name = f"zephyr-{config.name}-p{config.pipeline_id}-workers-a{attempt_id}"
+            logger.info("Starting %d workers (max=%d, shards=%d)", actual_workers, config.max_workers, num_shards)
+            worker_group = client.create_actor_group(
+                ZephyrWorker,
+                coordinator,
+                name=worker_name,
+                count=actual_workers,
+                resources=config.worker_resources,
+                actor_config=ActorConfig(max_task_retries=10),
+            )
+            worker_submit_time = datetime.now(timezone.utc)
+            # Temporary: align the initial worker startup wait with the broader
+            # no-workers budget. We have seen large queues delay the first pod
+            # well past 1 hour, and timing out here leaves a pending worker job
+            # that can start crash-looping against a shutting-down coordinator.
+            try:
+                worker_group.wait_ready(count=1, timeout=config.no_workers_timeout)
+            except TimeoutError as e:
+                worker_job_id = worker_group._job_id
+                ready_count = worker_group.ready_count
+                worker_job_state = "unknown"
+                pending_reason = ""
+                status_message = ""
+                with suppress(Exception):
+                    worker_job_status = client.status(worker_job_id)
+                    worker_job_state = str(worker_job_status.state)
+                    pending_reason = worker_job_status.pending_reason
+                    status_message = worker_job_status.status_message
+                logger.error(
+                    "Initial worker startup timed out: worker_name=%s worker_job=%s submitted_at=%s "
+                    "ready=%d/%d timeout=%.1fs job_state=%s pending_reason=%r status_message=%r",
+                    worker_name,
+                    worker_job_id,
+                    worker_submit_time.isoformat(),
+                    ready_count,
+                    actual_workers,
+                    config.no_workers_timeout,
+                    worker_job_state,
+                    pending_reason,
+                    status_message,
+                )
+                raise TimeoutError(
+                    f"Initial worker startup timed out for {worker_name} after {config.no_workers_timeout}s "
+                    f"(worker_job={worker_job_id}, submitted_at={worker_submit_time.isoformat()}, "
+                    f"ready={ready_count}/{actual_workers}, job_state={worker_job_state}, "
+                    f"pending_reason={pending_reason!r}, status_message={status_message!r})"
+                ) from e
+
+            # Let the coordinator poll worker job health in its maintenance loop
+            coordinator.set_worker_group.remote(worker_group).result()
+
         results = coordinator.run_pipeline.remote(config.plan, config.execution_id).result()
 
         ensure_parent_dir(result_path)


### PR DESCRIPTION
Switch the GPU canary ferry to Nemotron and harden the supporting data path. This adds the Nemotron CC upload fix, larger download-worker memory, a helper to prebuild the upstream data steps, the romain-nt CoreWeave Iris config, and the Zephyr/Iris startup-wait mitigation discovered while debugging.