### PR TITLE
fix: detect missing proto outputs in iris hatch build hook

### DIFF
--- a/lib/iris/hatch_build.py
+++ b/lib/iris/hatch_build.py
@@ -52,9 +52,14 @@ def _oldest_mtime(root: Path, globs: list[str]) -> float:
     return oldest if found else 0.0
 
 
-def _outputs_exist(root: Path, output_globs: list[str]) -> bool:
-    """Return True if at least one output file exists."""
-    return _oldest_mtime(root, output_globs) > 0.0
+def _has_missing_outputs(root: Path, source_globs: list[str]) -> bool:
+    """Return True if any .proto source is missing its corresponding _pb2.py."""
+    for pattern in source_globs:
+        for proto_path in root.glob(pattern):
+            pb2_path = proto_path.with_name(proto_path.stem + "_pb2.py")
+            if not pb2_path.exists():
+                return True
+    return False
 
 
 def _needs_rebuild(root: Path, source_globs: list[str], output_globs: list[str]) -> bool:
@@ -77,15 +82,15 @@ class CustomBuildHook(BuildHookInterface):
         self._maybe_generate_protos(root)
 
     def _maybe_generate_protos(self, root: Path) -> None:
-        outputs_present = _outputs_exist(root, _PROTO_OUTPUT_GLOBS)
+        outputs_complete = not _has_missing_outputs(root, _PROTO_SOURCE_GLOBS)
 
-        if outputs_present and not _needs_rebuild(root, _PROTO_SOURCE_GLOBS, _PROTO_OUTPUT_GLOBS):
+        if outputs_complete and not _needs_rebuild(root, _PROTO_SOURCE_GLOBS, _PROTO_OUTPUT_GLOBS):
             logger.info("Protobuf outputs are up-to-date, skipping generation")
             return
 
         generate_script = root / "scripts" / "generate_protos.py"
         if not generate_script.exists():
-            if not outputs_present:
+            if not outputs_complete:
                 raise RuntimeError(
                     "Protobuf outputs are missing and scripts/generate_protos.py not found. "
                     "Cannot build iris without generated protobuf files."
@@ -94,7 +99,7 @@ class CustomBuildHook(BuildHookInterface):
             return
 
         if shutil.which("npx") is None:
-            if not outputs_present:
+            if not outputs_complete:
                 raise RuntimeError(
                     "Protobuf outputs are missing and npx is not installed. "
                     "Install Node.js (which provides npx) to generate protobuf files: "

--- a/lib/iris/src/iris/rpc/__init__.py
+++ b/lib/iris/src/iris/rpc/__init__.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Import order matters for proto descriptor pool: each module must be loaded
-# after its dependencies. Chain: time → config → vm → cluster.
+# after its dependencies. Chain: time → config → vm → query → cluster.
 from iris.rpc import time_pb2 as time_pb2
 from iris.rpc import config_pb2 as config_pb2
 from iris.rpc import vm_pb2 as vm_pb2
+from iris.rpc import query_pb2 as query_pb2
 from iris.rpc import cluster_pb2 as cluster_pb2


### PR DESCRIPTION
## Summary

- The hatch build hook only compared timestamps to decide if proto regeneration was needed. Adding `query.proto` (#3649) without a matching `query_pb2.py` broke all local `iris` CLI usage with `ImportError: cannot import name 'query_pb2'`.
- Add `_has_missing_outputs()` to detect `.proto` files without a corresponding `_pb2.py`, and use it in the rebuild decision and fallback paths (missing `npx`/generate script) so they raise instead of silently continuing with incomplete outputs.
- Add the missing `query_pb2` import to `rpc/__init__.py` (descriptor pool load order requires it before `cluster_pb2`).

Fixes #3709

## Test plan

- [x] Reproduced `ImportError` on main, confirmed fix resolves it
- [x] Verified `uv run iris --help` loads cleanly after fix
- [x] Verified `_has_missing_outputs` correctly returns `True` when a `_pb2.py` is absent and `False` when all are present
- [x] Pre-commit passes on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)