### PR TITLE
docs: normalize Iris proto regeneration guidance

### DIFF
--- a/.agents/docs/smoke-test-dry-run.md
+++ b/.agents/docs/smoke-test-dry-run.md
@@ -651,7 +651,7 @@ The `run-local` command becomes a thin wrapper around `ClusterManager` with
 
 **Files changed:**
 - `src/iris/rpc/config.proto` — add `LocalProvider`, `LocalControllerConfig`
-- `lib/iris/scripts/generate_protos.py` — run
+- `uv run python lib/iris/scripts/generate_protos.py` — run from the repo root
 - `src/iris/cluster/vm/controller.py` — add `LocalController`
 - `src/iris/cluster/vm/config.py` — add local provider branch
 - `src/iris/cluster/vm/local_platform.py` — add `_create_local_autoscaler()`

--- a/lib/iris/AGENTS.md
+++ b/lib/iris/AGENTS.md
@@ -50,7 +50,7 @@ Always run `build:check` after editing `.vue` or `.ts` files to catch type error
 ## Code Conventions
 
 - Use Connect/RPC for APIs and dashboards. Do not use `httpx` or raw HTTP.
-- After changing `.proto` files, regenerate via `lib/iris/scripts/generate_protos.py` (from the repo root).
+- After changing `.proto` files, regenerate from the repo root with `uv run python lib/iris/scripts/generate_protos.py`.
 - Prefer shallow, functional code that returns control quickly; avoid callback-heavy or inheritance-driven designs.
 - Dashboards must be a thin UI over the RPC API, not a second implementation path.
 - Use `iris.time_utils` for all time-related operations (`Timestamp`, `Duration`, `Deadline`, `Timer`, `ExponentialBackoff`) instead of raw `datetime` or `time`.

--- a/lib/iris/docs/resultectomy.md
+++ b/lib/iris/docs/resultectomy.md
@@ -105,7 +105,7 @@ The simpler path is to remove the dead plumbing.
 - `Worker.GetTaskStatusRequest.include_result` (line 703): Remove field 2. Mark it
   `reserved`.
 
-Regenerate proto files via `scripts/generate_protos.py` after proto changes.
+Regenerate proto files from the repo root via `uv run python lib/iris/scripts/generate_protos.py` after proto changes.
 
 ### Files that need no changes (but are worth noting)
 


### PR DESCRIPTION
## Summary
- normalize Iris proto-regeneration guidance to a single repo-root command
- update durable agent/docs references that still used older path-only variants

## Validation
- `rg -n "scripts/generate_protos\\.py|lib/iris/scripts/generate_protos\\.py" lib/iris/AGENTS.md lib/iris/docs/resultectomy.md .agents/docs/smoke-test-dry-run.md`
- confirmed no open PR already targeted this `generate_protos` workflow fix
