### PR TITLE
🏭 Add zephyr babysit skill

### DIFF
--- a/.agents/skills/zephyr-babysit/SKILL.md
+++ b/.agents/skills/zephyr-babysit/SKILL.md
@@ -51,15 +51,10 @@ uv run iris --config lib/iris/examples/marin.yaml job stop <JOB_ID>
 
 ### Health Checks
 
-Check the dashboard or API for child job states:
+Check child job states via the Iris CLI (returns per-task state and resourceUsage):
 ```bash
-# Navigate to: http://127.0.0.1:<DASHBOARD_PORT>/#/job/<URL_ENCODED_JOB_ID>
-
-# Or via API — returns per-task state and resourceUsage (memoryMb, diskMb, cpuPercent, etc.)
 # diskMb is updated every ~60s. On K8s it is always 0 (workdir lives inside the pod).
-curl -s -X POST 'http://127.0.0.1:<DASHBOARD_PORT>/iris.cluster.ControllerService/ListTasks' \
-  -H 'Content-Type: application/json' \
-  -d '{"jobId":"<JOB_ID>"}'
+uv run iris --config lib/iris/examples/marin.yaml rpc controller list-tasks --job-id <JOB_ID>
 ```
 
 A healthy zephyr job has:
@@ -73,11 +68,10 @@ The coordinator logs a progress line every 5s:
 [stage0-Map → Scatter] 347/1964 complete, 1617 in-flight, 0 queued, 1828/1891 workers alive, 63 dead
 ```
 
-Fetch via API:
+Fetch via the Iris CLI:
 ```bash
-curl -s -X POST 'http://127.0.0.1:<DASHBOARD_PORT>/iris.cluster.ControllerService/GetTaskLogs' \
-  -H 'Content-Type: application/json' \
-  -d '{"id":"<COORD_JOB_ID>","maxTotalLines":5000,"attemptId":-1,"tail":true}'
+uv run iris --config lib/iris/examples/marin.yaml rpc controller get-task-logs \
+  --id <COORD_JOB_ID> --max-total-lines 5000 --attempt-id -1 --tail
 ```
 
 **Caveat**: With large worker pools, `pull_task` operations flood the log buffer (#3707). Filter when parsing:
@@ -93,10 +87,8 @@ for entry in task_logs:
 
 When logs are flooded, a thread dump tells you if the coordinator is alive and working:
 ```bash
-curl -s -X POST 'http://127.0.0.1:<DASHBOARD_PORT>/iris.cluster.ControllerService/ProfileTask' \
-  -H 'Content-Type: application/json' \
-  -d '{"target":"<COORD_JOB_ID>/0","durationSeconds":1,"profileType":{"threads":{}}}' \
-  | python3 -c "import json,sys,base64; print(base64.b64decode(json.load(sys.stdin)['profileData']).decode())"
+uv run iris --config lib/iris/examples/marin.yaml rpc controller profile-task \
+  --json '{"target":"<COORD_JOB_ID>/0","durationSeconds":1,"profileType":{"threads":{}}}'
 ```
 
 Key patterns:

--- a/.agents/skills/zephyr-debugger/SKILL.md
+++ b/.agents/skills/zephyr-debugger/SKILL.md
@@ -36,17 +36,14 @@ The Iris dashboard at `http://127.0.0.1:<DASHBOARD_PORT>` proxies to the control
 
 ```bash
 # Task logs (coordinator or workers)
-curl -s -X POST 'http://127.0.0.1:<DASHBOARD_PORT>/iris.cluster.ControllerService/GetTaskLogs' \
-  -H 'Content-Type: application/json' \
-  -d '{"id":"<JOB_ID>","maxTotalLines":5000,"attemptId":-1,"tail":true}'
-# Response: {"taskLogs":[{"taskId":"...","logs":[{"timestamp":{"epochMs":"..."},"source":"stderr","data":"...","level":"INFO"}]}],"truncated":true,"cursor":123}
+# Response includes taskLogs with timestamp, source, data, level; plus truncated flag and cursor
+uv run iris --config lib/iris/examples/marin.yaml rpc controller get-task-logs \
+  --id <JOB_ID> --max-total-lines 5000 --attempt-id -1 --tail
 
 # List tasks (memory, CPU, disk, state per worker)
-curl -s -X POST 'http://127.0.0.1:<DASHBOARD_PORT>/iris.cluster.ControllerService/ListTasks' \
-  -H 'Content-Type: application/json' \
-  -d '{"jobId":"<JOB_ID>"}'
 # Each task's resourceUsage includes: memoryMb, diskMb, cpuPercent, memoryPeakMb, processCount
 # diskMb is updated every ~60s. On K8s it is always 0 (workdir lives inside the pod).
+uv run iris --config lib/iris/examples/marin.yaml rpc controller list-tasks --job-id <JOB_ID>
 ```
 
 ### Iris CLI
@@ -76,14 +73,12 @@ uv run iris process profile cpu --duration 10 --output /tmp/profile.speedscope.j
 uv run iris process profile mem --duration 10 --output /tmp/profile.html --worker <WORKER_ID>
 ```
 
-**Task-level profiling** (inside the task container) is not supported by the CLI yet. Use the dashboard buttons or call the `ProfileTask` RPC directly via curl:
+**Task-level profiling** (inside the task container) is not supported by the CLI scalar flags yet. Use the dashboard buttons or call the `ProfileTask` RPC via `--json`:
 
 ```bash
 # CPU profile a specific task (10s, speedscope JSON)
-curl -s -X POST 'http://127.0.0.1:<DASHBOARD_PORT>/iris.cluster.ControllerService/ProfileTask' \
-  -H 'Content-Type: application/json' \
-  -d '{"target":"<TASK_ID>","durationSeconds":10,"profileType":{"cpu":{"format":"SPEEDSCOPE"}}}' \
-  | python3 -c "import json,sys,base64; d=json.load(sys.stdin); open('/tmp/cpu.speedscope.json','wb').write(base64.b64decode(d['profileData'])); print('Done')"
+uv run iris --config lib/iris/examples/marin.yaml rpc controller profile-task \
+  --json '{"target":"<TASK_ID>","durationSeconds":10,"profileType":{"cpu":{"format":"SPEEDSCOPE"}}}'
 
 # Target format: /user/job-name/child-job/task-index
 # Profile types: {"threads":{}}  {"cpu":{"format":"SPEEDSCOPE"}}  {"memory":{"format":"FLAMEGRAPH"}}


### PR DESCRIPTION
Add `zephyr-babysit` skill, will babysit a zephyr pipeline for you, while you go touch some grass.

This is by no means complete skill, but it's a reasonable start.