### PR TITLE
feat(iris): support --locals flag in py-spy thread dumps

### DIFF
--- a/lib/iris/dashboard/src/components/controller/ThreadDump.vue
+++ b/lib/iris/dashboard/src/components/controller/ThreadDump.vue
@@ -50,6 +50,7 @@ const threadDump = ref('')
 const loading = ref(false)
 const error = ref<string | null>(null)
 const lastFetched = ref<string | null>(null)
+const includeLocals = ref(false)
 
 async function fetchThreadDump() {
   const t = target.value
@@ -63,7 +64,7 @@ async function fetchThreadDump() {
     const body = {
       target: t,
       durationSeconds: 10,
-      profileType: { threads: {} },
+      profileType: { threads: { locals: includeLocals.value } },
     }
     const resp = await rpcCall.value<{ profileData?: string; error?: string }>('ProfileTask', body)
     if (resp.error) {
@@ -95,6 +96,14 @@ onMounted(fetchThreadDump)
       >
         {{ loading ? '⏳ Fetching...' : '↻ Refresh' }}
       </button>
+      <label class="flex items-center gap-1.5 text-xs text-text-secondary cursor-pointer select-none">
+        <input
+          v-model="includeLocals"
+          type="checkbox"
+          class="rounded border-surface-border"
+        />
+        Include locals
+      </label>
       <span v-if="lastFetched" class="text-xs text-text-muted">
         Last fetched: {{ lastFetched }}
       </span>

--- a/lib/iris/src/iris/cli/process_status.py
+++ b/lib/iris/src/iris/cli/process_status.py
@@ -109,15 +109,16 @@ def logs(ctx, worker: str | None, level: str, follow: bool, max_lines: int, subs
 @click.argument("profiler", type=click.Choice(["threads", "cpu", "mem"]))
 @click.option("--duration", "-d", default=10, help="Profiling duration in seconds")
 @click.option("--output", "-o", default=None, help="Output file path")
+@click.option("--locals", "include_locals", is_flag=True, help="Include local variables in thread dump")
 @click.pass_context
-def profile(ctx, worker: str | None, profiler: str, duration: int, output: str | None):
+def profile(ctx, worker: str | None, profiler: str, duration: int, output: str | None, include_locals: bool):
     """Profile the process (threads, cpu, or mem)."""
     url = require_controller_url(ctx)
     client = ControllerServiceClientSync(url)
 
     # Build profile type
     if profiler == "threads":
-        profile_type = cluster_pb2.ProfileType(threads=cluster_pb2.ThreadsProfile())
+        profile_type = cluster_pb2.ProfileType(threads=cluster_pb2.ThreadsProfile(locals=include_locals))
     elif profiler == "cpu":
         profile_type = cluster_pb2.ProfileType(cpu=cluster_pb2.CpuProfile(format=cluster_pb2.CpuProfile.SPEEDSCOPE))
     elif profiler == "mem":

--- a/lib/iris/src/iris/cluster/runtime/docker.py
+++ b/lib/iris/src/iris/cluster/runtime/docker.py
@@ -392,7 +392,7 @@ exec {quoted_cmd}
         profile_id = uuid.uuid4().hex[:8]
 
         if profile_type.HasField("threads"):
-            return self._profile_threads(container_id)
+            return self._profile_threads(container_id, include_locals=profile_type.threads.locals)
         elif profile_type.HasField("cpu"):
             return self._profile_cpu(container_id, duration_seconds, profile_type.cpu, profile_id)
         elif profile_type.HasField("memory"):
@@ -400,9 +400,9 @@ exec {quoted_cmd}
         else:
             raise RuntimeError("ProfileType must specify cpu, memory, or threads profiler")
 
-    def _profile_threads(self, container_id: str) -> bytes:
+    def _profile_threads(self, container_id: str, *, include_locals: bool = False) -> bytes:
         """Collect thread stacks from the container using py-spy dump."""
-        cmd = build_pyspy_dump_cmd(pid="1", py_spy_bin="/app/.venv/bin/py-spy")
+        cmd = build_pyspy_dump_cmd(pid="1", py_spy_bin="/app/.venv/bin/py-spy", include_locals=include_locals)
         result = self._docker_exec(container_id, cmd, capture_output=True, text=True, timeout=30)
         if result.returncode != 0:
             raise RuntimeError(f"py-spy dump failed: {result.stderr}")

--- a/lib/iris/src/iris/cluster/runtime/kubernetes.py
+++ b/lib/iris/src/iris/cluster/runtime/kubernetes.py
@@ -501,7 +501,7 @@ class KubernetesContainerHandle:
         profile_id = uuid.uuid4().hex[:8]
 
         if profile_type.HasField("threads"):
-            return self._profile_threads()
+            return self._profile_threads(include_locals=profile_type.threads.locals)
         elif profile_type.HasField("cpu"):
             return self._profile_cpu(duration_seconds, profile_type.cpu, profile_id)
         elif profile_type.HasField("memory"):
@@ -509,9 +509,9 @@ class KubernetesContainerHandle:
         else:
             raise RuntimeError("ProfileType must specify cpu, memory, or threads profiler")
 
-    def _profile_threads(self) -> bytes:
+    def _profile_threads(self, *, include_locals: bool = False) -> bytes:
         """Collect thread stacks from the pod using py-spy dump."""
-        cmd = build_pyspy_dump_cmd(pid="1", py_spy_bin="py-spy")
+        cmd = build_pyspy_dump_cmd(pid="1", py_spy_bin="py-spy", include_locals=include_locals)
         result = self.kubectl.exec(self._pod_name, self._wrap_in_venv_shell(cmd), container="task", timeout=30)
         if result.returncode != 0:
             raise RuntimeError(f"py-spy dump failed: {result.stderr}")

--- a/lib/iris/src/iris/cluster/runtime/process.py
+++ b/lib/iris/src/iris/cluster/runtime/process.py
@@ -492,7 +492,7 @@ class ProcessContainerHandle:
 
         if profile_type.HasField("threads"):
             pid = str(self._container._process.pid)
-            return run_pyspy_dump(pid)
+            return run_pyspy_dump(pid, include_locals=profile_type.threads.locals)
         elif profile_type.HasField("cpu"):
             return self._profile_cpu(duration_seconds, profile_type.cpu)
         elif profile_type.HasField("memory"):

--- a/lib/iris/src/iris/cluster/runtime/profile.py
+++ b/lib/iris/src/iris/cluster/runtime/profile.py
@@ -135,9 +135,12 @@ def build_memray_transform_cmd(spec: MemoryProfileSpec, memray_bin: str, trace_p
         raise RuntimeError(f"Unknown memray reporter: {spec.reporter}")
 
 
-def build_pyspy_dump_cmd(pid: str, py_spy_bin: str = "py-spy") -> list[str]:
+def build_pyspy_dump_cmd(pid: str, py_spy_bin: str = "py-spy", *, include_locals: bool = False) -> list[str]:
     """Build a py-spy dump command for thread-level stack traces."""
-    return [py_spy_bin, "dump", "--pid", pid]
+    cmd = [py_spy_bin, "dump", "--pid", pid]
+    if include_locals:
+        cmd.append("--locals")
+    return cmd
 
 
 def profile_local_process(duration_seconds: int, profile_type: cluster_pb2.ProfileType) -> bytes:
@@ -150,7 +153,7 @@ def profile_local_process(duration_seconds: int, profile_type: cluster_pb2.Profi
 
     if profile_type.HasField("threads"):
         _check_tool("py-spy")
-        return run_pyspy_dump(pid)
+        return run_pyspy_dump(pid, include_locals=profile_type.threads.locals)
     elif profile_type.HasField("cpu"):
         _check_tool("py-spy")
         return _run_pyspy_record(pid, duration_seconds, profile_type.cpu)
@@ -161,9 +164,9 @@ def profile_local_process(duration_seconds: int, profile_type: cluster_pb2.Profi
         raise RuntimeError("ProfileType must specify cpu, memory, or threads profiler")
 
 
-def run_pyspy_dump(pid: str, py_spy_bin: str = "py-spy") -> bytes:
+def run_pyspy_dump(pid: str, py_spy_bin: str = "py-spy", *, include_locals: bool = False) -> bytes:
     """Run py-spy dump to collect thread stacks from a process."""
-    cmd = build_pyspy_dump_cmd(pid, py_spy_bin)
+    cmd = build_pyspy_dump_cmd(pid, py_spy_bin, include_locals=include_locals)
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
     if result.returncode != 0:
         raise RuntimeError(f"py-spy dump failed: {result.stderr}")

--- a/lib/iris/src/iris/rpc/cluster.proto
+++ b/lib/iris/src/iris/rpc/cluster.proto
@@ -109,8 +109,10 @@ message MemoryProfile {
   bool leaks = 2;       // Focus on potential memory leaks
 }
 
-// Thread dump configuration (no additional options needed)
-message ThreadsProfile {}
+// Thread dump configuration
+message ThreadsProfile {
+  bool locals = 1;  // Include local variables in the dump (--locals flag)
+}
 
 // Profile type selector
 message ProfileType {


### PR DESCRIPTION
Add `locals` field to `ThreadsProfile` proto and wire it through the full profiling stack so `py-spy dump --locals` is used when requested. This includes the profile module, docker/process/kubernetes runtimes, CLI (`iris process profile threads --locals`), and dashboard toggle.

Closes #3728
