### PR TITLE
[iris] Fix dashboard job tree by including descendants in ListJobs

### DIFF
--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -397,6 +397,21 @@ def _jobs_paginated(
     return jobs, total
 
 
+def _descendants_for_roots(db: ControllerDB, root_job_ids: list[str]) -> list[Job]:
+    """Fetch all descendant jobs (depth > 1) for the given root job IDs in a single query."""
+    if not root_job_ids:
+        return []
+    placeholders = ",".join("?" for _ in root_job_ids)
+    sql = f"""
+        SELECT j.*
+        FROM jobs j
+        WHERE j.root_job_id IN ({placeholders}) AND j.depth > 1
+    """
+    with db.read_snapshot() as q:
+        rows = q.execute_sql(sql, tuple(root_job_ids)).fetchall()
+    return [db.decode_job(row) for row in rows]
+
+
 def _task_summaries_for_jobs(db: ControllerDB, job_ids: set[JobName] | None = None) -> dict[JobName, TaskJobSummary]:
     """Aggregate task counts per job using SQL GROUP BY instead of Python-side iteration."""
     if job_ids is not None:
@@ -958,8 +973,11 @@ class ControllerServiceImpl:
             offset=offset,
             limit=limit,
         )
-        task_summaries = _task_summaries_for_jobs(self._db, {j.job_id for j in jobs})
-        all_jobs = self._jobs_to_protos(jobs, task_summaries, autoscaler_pending_hints)
+        # Also fetch descendants so the dashboard can build the job tree.
+        descendants = _descendants_for_roots(self._db, [j.job_id.to_wire() for j in jobs])
+        all_db_jobs = jobs + descendants
+        task_summaries = _task_summaries_for_jobs(self._db, {j.job_id for j in all_db_jobs})
+        all_jobs = self._jobs_to_protos(all_db_jobs, task_summaries, autoscaler_pending_hints)
         has_more = limit > 0 and offset + limit < total_count
         return cluster_pb2.Controller.ListJobsResponse(
             jobs=all_jobs,

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -817,8 +817,8 @@ def test_list_jobs_name_filter(service, job_request):
     assert "alpha" in response.jobs[0].name.lower()
 
 
-def test_list_jobs_top_level_only(service, state, job_request):
-    """list_jobs only returns top-level jobs by default."""
+def test_list_jobs_includes_descendants(service, state, job_request):
+    """list_jobs returns top-level jobs plus their descendants for tree display."""
     service.launch_job(job_request("parent-job"), None)
     # Submit child job directly via transitions
     parent_id = JobName.root("test-user", "parent-job")
@@ -835,10 +835,11 @@ def test_list_jobs_top_level_only(service, state, job_request):
     request = cluster_pb2.Controller.ListJobsRequest()
     response = service.list_jobs(request, None)
 
-    # Only the parent should appear
+    # Both parent and child should appear; pagination counts only top-level jobs
     job_ids = [j.job_id for j in response.jobs]
     assert parent_id.to_wire() in job_ids
-    assert child_id.to_wire() not in job_ids
+    assert child_id.to_wire() in job_ids
+    assert response.total_count == 1
 
 
 # =============================================================================


### PR DESCRIPTION
The depth=1 filter added in #3719 excluded child jobs from ListJobs responses,
breaking the dashboard's job tree view — parent jobs no longer showed
expand/collapse arrows and children were invisible.

- Add `_descendants_for_roots()` that fetches all child jobs for the current
  page's root jobs in a single batched SQL query via `root_job_id IN (...)`.
- Include descendants in the ListJobs response alongside their parents.
- Pagination (`total_count`, `has_more`) remains based on top-level jobs only.
- Update test to verify both parent and child appear in the response.

Fixes #3743