### PR TITLE
[agent-research] Leave issue refs plain for autolinks

### DIFF
--- a/.agents/skills/agent-research/SKILL.md
+++ b/.agents/skills/agent-research/SKILL.md
@@ -147,6 +147,7 @@ Issue comment style:
 - Mostly append-only.
 - Do not rewrite historical comments.
 - It is fine (and preferred) to edit a comment to fix formatting/escaping/errors.
+- In issue bodies and comments, leave GitHub issue references like #1234 as plain text; do not wrap them in backticks, so GitHub cross-links them.
 - Keep claims scoped and falsifiable.
 
 ### 3) Maintain the Issue Body


### PR DESCRIPTION
Prevent `agent-research` from wrapping GitHub issue references like #1234 in backticks when writing issue bodies and comments. Bare issue references autolink on GitHub; backticked ones do not, and recent experiment issues used the wrong format.

- Add an explicit `agent-research` rule covering both issue bodies and comments.
- Verification: `./infra/pre-commit.py --all-files --fix` (fails on existing `pyrefly` import error in `lib/iris/src/iris/rpc/__init__.py:9`, unrelated to this change).
