### PR TITLE
fix: map K8s CACHE mounts under worker cache_dir

### DIFF
--- a/lib/iris/src/iris/cluster/runtime/kubernetes.py
+++ b/lib/iris/src/iris/cluster/runtime/kubernetes.py
@@ -152,6 +152,7 @@ class KubernetesContainerHandle:
 
     config: ContainerConfig
     kubectl: Kubectl
+    cache_dir: Path | None = None
     service_account_name: str = ""
     s3_secret_name: str = ""
     s3_endpoint_url: str = ""
@@ -239,6 +240,10 @@ class KubernetesContainerHandle:
                     }
                 )
             elif mount.kind == MountKind.CACHE:
+                if self.cache_dir is not None:
+                    host_path = str(self.cache_dir / mount.container_path.strip("/").replace("/", "-"))
+                else:
+                    host_path = mount.container_path
                 mounts.append(
                     {
                         "name": volume_name,
@@ -249,7 +254,7 @@ class KubernetesContainerHandle:
                 volumes.append(
                     {
                         "name": volume_name,
-                        "hostPath": {"path": mount.container_path, "type": "DirectoryOrCreate"},
+                        "hostPath": {"path": host_path, "type": "DirectoryOrCreate"},
                     }
                 )
 
@@ -629,6 +634,7 @@ class KubernetesRuntime:
         namespace: str | None = None,
         service_account_name: str | None = None,
         s3_secret_name: str | None = None,
+        cache_dir: Path | None = None,
     ) -> None:
         resolved_namespace = namespace or os.environ.get("IRIS_POD_NAMESPACE") or "iris"
         self._service_account_name = service_account_name or os.environ.get("IRIS_SERVICE_ACCOUNT_NAME") or ""
@@ -641,12 +647,14 @@ class KubernetesRuntime:
         # is deleted. If worker containers crash-loop in-place, task Pods remain.
         # Consider restartPolicy=Never for worker Pods or explicit stale-task cleanup.
         self._kubectl = Kubectl(namespace=resolved_namespace)
+        self._cache_dir = cache_dir
         self._handles: list[KubernetesContainerHandle] = []
 
     def create_container(self, config: ContainerConfig) -> KubernetesContainerHandle:
         handle = KubernetesContainerHandle(
             config=config,
             kubectl=self._kubectl,
+            cache_dir=self._cache_dir,
             service_account_name=self._service_account_name,
             s3_secret_name=self._s3_secret_name,
             s3_endpoint_url=self._s3_endpoint_url,

--- a/lib/iris/src/iris/cluster/worker/main.py
+++ b/lib/iris/src/iris/cluster/worker/main.py
@@ -69,7 +69,7 @@ def serve(worker_config: str):
     config = worker_config_from_proto(wc_proto, resolve_image=resolve_image)
 
     if wc_proto.runtime == "kubernetes":
-        container_runtime = KubernetesRuntime()
+        container_runtime = KubernetesRuntime(cache_dir=config.cache_dir)
     else:
         container_runtime = DockerRuntime(cache_dir=config.cache_dir)
 

--- a/lib/iris/tests/cluster/runtime/test_kubernetes_runtime.py
+++ b/lib/iris/tests/cluster/runtime/test_kubernetes_runtime.py
@@ -439,6 +439,44 @@ def test_disk_bytes_sets_emptydir_sizelimit(monkeypatch):
     assert workdir_vol["emptyDir"]["sizeLimit"] == str(10 * 1024**3)
 
 
+def test_cache_mounts_use_cache_dir_host_path(monkeypatch):
+    """CACHE mounts must map hostPath under worker cache_dir, not use the container path directly."""
+    manifests = _capture_manifest(monkeypatch)
+
+    config = _make_config()
+    config.mounts = [
+        MountSpec(container_path="/uv/cache", kind=MountKind.CACHE),
+        MountSpec(container_path="/root/.cargo/registry", kind=MountKind.CACHE),
+    ]
+    from pathlib import Path
+
+    runtime = KubernetesRuntime(namespace="iris", cache_dir=Path("/mnt/nvme/iris"))
+    handle = runtime.create_container(config)
+    handle.run()
+
+    pod = _pod_manifest(manifests)
+    volumes = pod["spec"]["volumes"]
+    cache_volumes = [v for v in volumes if "hostPath" in v]
+    assert len(cache_volumes) == 2
+    host_paths = sorted(v["hostPath"]["path"] for v in cache_volumes)
+    assert host_paths == ["/mnt/nvme/iris/root-.cargo-registry", "/mnt/nvme/iris/uv-cache"]
+
+
+def test_cache_mounts_fallback_without_cache_dir(monkeypatch):
+    """Without cache_dir, CACHE mounts fall back to container_path as hostPath."""
+    manifests = _capture_manifest(monkeypatch)
+
+    config = _make_config()
+    config.mounts = [MountSpec(container_path="/uv/cache", kind=MountKind.CACHE)]
+    runtime = KubernetesRuntime(namespace="iris")
+    handle = runtime.create_container(config)
+    handle.run()
+
+    pod = _pod_manifest(manifests)
+    cache_vol = next(v for v in pod["spec"]["volumes"] if "hostPath" in v)
+    assert cache_vol["hostPath"]["path"] == "/uv/cache"
+
+
 def test_no_disk_bytes_emptydir_has_no_sizelimit(monkeypatch):
     """When a WORKDIR MountSpec has size_bytes=0, the emptyDir volume should have no sizeLimit."""
     manifests = _capture_manifest(monkeypatch)


### PR DESCRIPTION
CACHE mounts (uv, cargo) were using container_path as the hostPath, pushing caches onto the node root filesystem. On CoreWeave this triggers disk pressure. Now cache_dir is threaded through KubernetesRuntime so CACHE mounts use the configured NVMe cache path.

Fixes regression from #3696.

Generated with [Claude Code](https://claude.ai/code)