### PR TITLE
fix: upgrade triage workflow to opus, bias toward PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -82,7 +82,7 @@ jobs:
        github.event.issue.author_association == 'COLLABORATOR') &&
       !contains(github.event.issue.body, '@claude') &&
       !contains(github.event.issue.title, '@claude')
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -125,27 +125,54 @@ jobs:
 
             ## Step 2: Scope Assessment
             Investigate the codebase to understand the issue. Determine whether the fix is
-            small and self-contained (e.g. a bug fix, adding a small feature, changing styles,
-            config tweaks) or whether it requires broader design work.
+            small and self-contained or whether it requires broader design work.
 
-            ## Step 3a: Small Fix
-            If the change is small and self-contained, follow the fix-issue skill workflow
-            (already loaded above). Post a brief comment on the issue summarizing your fix
-            and linking the PR when done.
+            A fix is "small" if it meets ALL of these:
+            - Touches ≤3 files (excluding tests)
+            - The issue describes the problem clearly enough that the fix is unambiguous
+            - No new public API surface or architectural decisions needed
 
-            ## Step 3b: Research Report
-            If the change is larger or needs design input:
-            - Analyze the codebase: identify affected files, modules, and interfaces
-            - Use web search if the issue involves external libraries or standards
-            - Post a comment (prefixed "🤖 Research Report:") covering:
-              * Affected files and modules
-              * Viable design directions with trade-offs
-              * Your recommended approach
-            - Do not attempt implementation
+            Examples of small fixes: changing a default value, adjusting a timeout/retry
+            parameter, fixing a typo, adding a missing import, fixing an off-by-one error,
+            adding a flag to an existing function, renaming a variable.
+
+            If in doubt, treat it as small and submit a PR. A reviewable PR is always more
+            useful than a research comment.
+
+            ## Step 3a: Small Fix (DEFAULT — use this unless the issue clearly requires design work)
+            Follow the full fix-issue skill workflow end-to-end:
+            1. Research the codebase and identify the fix
+            2. Create a branch, write tests, implement the fix
+            3. Run pre-commit and pytest
+            4. Open a PR and verify CI
+            5. Post a brief comment on the issue linking the PR
+
+            ## Step 3b: Research Report (ONLY for issues requiring multi-module design changes)
+            Use this path ONLY when the fix requires architectural decisions, touches >3 modules,
+            or needs human input on design trade-offs.
+
+            Post a single comment with this exact format:
+
+            🤖 ## Research
+            <2-3 sentences: root cause, not symptoms>
+
+            **Relevant code**
+            - [`file.py#L123`](permalink) - short annotation
+            - (max 5 links)
+
+            ## Proposed Fix
+            <1-2 sentences describing the recommended approach>
+            <code snippet if non-obvious>
+
+            Rules for research comments:
+            - Never post partial or "test" comments. Write the full comment, review it, then post once.
+            - Follow the exact format above. No deviations, no extra sections, no filler.
+            - If you cannot complete the research, post nothing rather than a partial comment.
           claude_args: |
-            --model claude-sonnet-4-6
-            --max-turns 100
-            --allowedTools "Bash(git:*),Bash(./infra/pre-commit.py:*),Bash(uv:*),Bash(pytest:*),Bash(gh:*),Bash(python:*),Bash(cat:*)"
+            --model opus
+            --max-turns 250
+            --allowedTools "Bash(git:*),Bash(./infra/pre-commit.py:*),Bash(uv:*),Bash(pytest:*),Bash(gh:*),Bash(python:*)"
+            --system-prompt "Always read and follow the guidelines in AGENTS.md before starting work. You always have the ability to commit and push your changes. Use your MCP tools if available, falling back to git and gh (which you have authorization for) if needed. Before submitting any changes: 1) Run ./infra/pre-commit.py --all-files --fix and fix any issues. 2) Run uv run pytest on tests relevant to your changes. Report on the test status when you provide an update. Always commit and push changes, even if you couldn't get the tests to pass. Never post partial, placeholder, or test comments. Every comment must be complete and follow the format specified in the prompt."
 
   autofix:
     if: |


### PR DESCRIPTION
- Switches triage from Sonnet to Opus — the current Sonnet-based triage produces garbage comments ("test" comments, badly formatted research reports)
- Biases toward submitting PRs for trivial issues instead of writing research comments. Issues like #3741 (change a default value) should get a PR, not a research report
- Adds system prompt, strict comment format, and ban on partial/test comments
- Bumps timeout (15→30min) and max-turns (100→250) to accommodate the full fix-issue workflow

## Changes
- **Model**: `claude-sonnet-4-6` → `opus`
- **Default path**: Small fix with PR (Step 3a) is now the default; research reports (Step 3b) are explicitly gated to multi-module design changes only
- **Small fix criteria**: ≤3 files, unambiguous fix, no new API surface. Concrete examples provided (timeout changes, defaults, typos, imports, etc.)
- **Comment quality**: Strict format template for research comments, explicit ban on partial/test comments
- **System prompt**: Added matching the `@claude` job's guidelines