### PR TITLE
Clean up agent skills: concise PR descriptions, remove redundant index

### DIFF
--- a/.agents/skills/ferries/SKILL.md
+++ b/.agents/skills/ferries/SKILL.md
@@ -183,7 +183,7 @@ Recommendation / victory decision: <next action>
 
 #### 7) Seal and open log-only PR
 - Create and push a sealing tag for the exact launch commit (the commit containing the `experiments/ferries/daily.py` used for the run).
-- Open a PR that updates only `docs/experiments/daily-ferry-log.md`.
+- Open a PR that updates only `docs/experiments/daily-ferry-log.md`, following `.agents/skills/pull-request/SKILL.md` for description format.
 - Keep all detailed launch/retry/debug narrative in the run issue, not in the PR.
 - Apply canonical labels on the run-closure PR: `ferry`, `ferry-daily`, `ferry-log-only`, `ferry-sealed`.
 

--- a/.agents/skills/fix-issue/SKILL.md
+++ b/.agents/skills/fix-issue/SKILL.md
@@ -108,8 +108,8 @@ beginning work. Your tests will be minimal and refrain from using mocks.
 ## Uploading
 
 When all tests pass, you may proceed to upload your branch.
-You will then open a pull request for the branch.
-You will attach it to the Github issue with a comment summarizing the fix.
+Open a pull request following `.agents/skills/pull-request/SKILL.md`.
+Attach it to the Github issue with a comment summarizing the fix.
 
 ## Verify CI Status
 

--- a/.agents/skills/handle-gh-scrub/SKILL.md
+++ b/.agents/skills/handle-gh-scrub/SKILL.md
@@ -15,7 +15,7 @@ Use this skill for scheduled scrub turns.
 3. If useful work exists, implement and validate it.
 4. Publish outcomes before ending the run:
    - commit/push to a branch
-   - open/update a PR when code or docs changed
+   - open/update a PR when code or docs changed (follow `.agents/skills/pull-request/SKILL.md`)
 5. If publish is blocked (token/permissions/infra), keep the run open and schedule follow-up.
 6. If no-op is correct, explicitly report inspected scope and why no change was justified.
 

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -10,23 +10,23 @@ human and agent authors.
 
 ## PR Descriptions
 
-The PR description doubles as the squash-merge commit message. Write it
-accordingly: no markdown formatting beyond plain text paragraphs and bullets,
-concise, and self-contained.
+The PR description doubles as the squash-merge commit message. Write it like
+a git commit message: plain text, no markdown, no ceremony.
 
-**Required elements:**
+**Format:**
 
 1. **Title** -- short imperative sentence, optionally prefixed with a scope tag
    in brackets (e.g. `[RL] Fix loss normalization`).
-2. **Body** -- one paragraph stating what changed and why. Follow with a few
-   bullets for specific changes if needed. Link the issue with `Fixes #NNNN`.
+2. **Body** -- plain text. State what changed and why in 1-3 sentences. Link the
+   issue with `Fixes #NNNN` or `Part of #NNNN`. That's it.
 
 **Style rules:**
 
-- No markdown headers, tables, or images in the body.
+- No markdown headers, tables, images, or bullet sections.
+- No `## Summary`, `## Test plan`, or other section headers.
 - No filler ("This PR...", "I noticed..."). State the change directly.
-- Keep it under ~150 words. A reviewer should absorb it in 30 seconds.
-- Include example output or metrics when the change is substantial.
+- Plain text links only (no `[text](url)` markdown links).
+- Keep it under ~80 words. A reviewer should absorb it in 10 seconds.
 
 ### Example
 
@@ -34,14 +34,10 @@ concise, and self-contained.
 Title: [RL] Fix loss: use global token normalization instead of per-example
 
 Body:
-Fixes a regression in the DAPO loss computation by switching from per-example
-normalization (/ n_i) back to global token normalization (/ N). Per-example
-normalization gives shorter responses disproportionately more gradient weight,
-which hurts math reasoning tasks where correct answers often require detailed,
-longer derivations.
-
-- Switch normalization in `compute_dapo_loss()` from per-example to global.
-- Add regression test in `tests/test_dapo_loss.py`.
+Switch DAPO loss from per-example normalization (/ n_i) to global token
+normalization (/ N). Per-example normalization over-weights short responses,
+hurting math reasoning where correct answers need longer derivations.
+Adds regression test.
 
 Fixes #1234
 ```

--- a/.agents/skills/scrub-docs-code-parity/SKILL.md
+++ b/.agents/skills/scrub-docs-code-parity/SKILL.md
@@ -25,7 +25,7 @@ Use this skill on scheduled scrub turns for docs/code parity in `marin-community
 ## Output
 
 - Keep the final scrub response concise and action-focused.
-- Treat local-only edits as incomplete work. If you modify files, publish the result (commit/push and open or update a PR) before finishing this scrub run.
+- Treat local-only edits as incomplete work. If you modify files, publish the result (commit/push and open or update a PR per `.agents/skills/pull-request/SKILL.md`) before finishing this scrub run.
 - If publish is blocked (auth, permissions, CI infra, etc.), report the blocker and set a future `needs_followup_at` instead of ending the run.
 - If no material drift is found, explicitly report inspected scope and why no change was needed.
 - Always end with the required `HARNESS_SCRUB_LOOP` footer (provided by the base scrub contract).

--- a/.agents/skills/scrub-reflection-self-improvement/SKILL.md
+++ b/.agents/skills/scrub-reflection-self-improvement/SKILL.md
@@ -48,7 +48,7 @@ turning ad-hoc scrub judgment into explicit repeatable guidance).
 
 - Keep rationale explicit: observed gap, change made (or plan), and expected impact.
 - Prefer durable artifacts over transient notes: land guidance updates in `AGENTS.md` and/or recipe docs when that is the primary improvement.
-- Treat local-only edits as incomplete work. If you modify files, publish the result (commit/push and open or update a PR) before finishing this scrub run.
+- Treat local-only edits as incomplete work. If you modify files, publish the result (commit/push and open or update a PR per `.agents/skills/pull-request/SKILL.md`) before finishing this scrub run.
 - If publish is blocked (auth, permissions, CI infra, etc.), report the blocker and set a future `needs_followup_at` instead of ending the run.
 - If you choose no-op, include explicit inspected signals and why no justified improvement exists now.
 - Always end with the required `HARNESS_SCRUB_LOOP` footer (provided by the base scrub contract).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,25 +8,7 @@ Start with the shared practices below. Consult subproject manuals for directory-
 
 ## Workflow Playbooks
 
-Agent-friendly skills live in `.agents/skills/` (also accessible as `.claude/skills/`). Load a skill by reading its `SKILL.md`. Key ones:
-
-- [pull-request](.agents/skills/pull-request/SKILL.md) — PR descriptions, testing, review workflow
-- [fix-issue](.agents/skills/fix-issue/SKILL.md) — issue triage and fix protocol
-- [file-issue](.agents/skills/file-issue/SKILL.md) — file a GitHub issue from conversation context
-- [add-dataset](.agents/skills/add-dataset/SKILL.md) — dataset addition (start with schema inspection)
-- [organize-experiments](.agents/skills/organize-experiments/SKILL.md) — experiment organization
-- [agent-research](.agents/skills/agent-research/SKILL.md) — long-running benchmark/research threads
-- [ferries](.agents/skills/ferries/SKILL.md) — canary/daily ferry workflow
-- [change-grug](.agents/skills/change-grug/SKILL.md) — Grug/Grugformer changes
-- [agent-profiling](.agents/skills/agent-profiling/SKILL.md) — profiling and optimization
-- [github-pr-review](.agents/skills/github-pr-review/SKILL.md) — PR review prompt
-- [debugger](.agents/skills/debugger/SKILL.md) — structured debugging workflow
-- [design-doc](.agents/skills/design-doc/SKILL.md) — writing design documents
-- [multi-stage](.agents/skills/multi-stage/SKILL.md) — coordinator/sub-agent orchestration
-- [add-pallas-kernel](.agents/skills/add-pallas-kernel/SKILL.md) — TPU Pallas kernel development
-- [archive-experiments](.agents/skills/archive-experiments/SKILL.md) — retiring legacy experiments
-- [architecture](.agents/skills/architecture/SKILL.md) — codebase architecture reference
-- [iris-controller-debug](.agents/skills/iris-controller-debug/SKILL.md) — debug Iris controller via live SQLite DB
+Agent-friendly skills live in `.agents/skills/` (also accessible as `.claude/skills/`). Load a skill by reading its `SKILL.md`.
 
 ## Development
 


### PR DESCRIPTION
Remove the redundant skill description list from AGENTS.md -- agents already discover skills from .agents/skills/. Tighten PR description format to plain-text commit-message style (~80 words, no markdown headers/sections). Add PR skill cross-references to fix-issue, ferries, handle-gh-scrub, and the scrub workflows so agents use consistent PR formatting.