### PR TITLE
[docs] Fix executor API reference paths

### DIFF
--- a/docs/references/executor-api.md
+++ b/docs/references/executor-api.md
@@ -4,27 +4,27 @@ This is the API documentation for the executor framework.
 
 ## Executor Entrypoint
 
-::: marin.execution.executor_main
-::: marin.execution.ExecutorMainConfig
+::: marin.execution.executor.executor_main
+::: marin.execution.executor.ExecutorMainConfig
 
 ## Executor and Steps
 
-::: marin.execution.Executor
-::: marin.execution.ExecutorStep
+::: marin.execution.executor.Executor
+::: marin.execution.executor.ExecutorStep
 
 ## Inputs and Outputs
 
-::: marin.execution.InputName
-::: marin.execution.output_path_of
-::: marin.execution.this_output_path
-::: marin.execution.OutputName
-::: marin.execution.THIS_OUTPUT_PATH
+::: marin.execution.executor.InputName
+::: marin.execution.executor.output_path_of
+::: marin.execution.executor.this_output_path
+::: marin.execution.executor.OutputName
+::: marin.execution.executor.THIS_OUTPUT_PATH
 
 
 ## Versioning
 
-::: marin.execution.VersionedValue
-::: marin.execution.versioned
-::: marin.execution.ensure_versioned
-::: marin.execution.unwrap_versioned_value
-::: marin.execution.get_executor_step
+::: marin.execution.executor.VersionedValue
+::: marin.execution.executor.versioned
+::: marin.execution.executor.ensure_versioned
+::: marin.execution.executor.unwrap_versioned_value
+::: marin.execution.executor.get_executor_step


### PR DESCRIPTION
[docs] Fix executor API reference paths

Point the executor API reference page at the real `marin.execution.executor` symbols so mkdocstrings renders the current implementation instead of nonexistent object paths. Validated with `uv run mkdocs build --strict` and `uv run python infra/check_docs_source_links.py`.

Fixes #3759
