### PR TITLE
fix(iris): reap workers with stale heartbeats on controller restart

### DIFF
--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -62,6 +62,7 @@ from iris.cluster.controller.auth import ControllerAuth
 from iris.cluster.controller.service import ControllerServiceImpl
 from iris.cluster.controller.transitions import (
     HEARTBEAT_FAILURE_THRESHOLD,
+    HEARTBEAT_STALENESS_THRESHOLD,
     RESERVATION_HOLDER_JOB_NAME,
     Assignment,
     ControllerTransitions,
@@ -1385,6 +1386,37 @@ class Controller:
         if any_buffered:
             self._heartbeat_event.set()
 
+    def _reap_stale_workers(self) -> None:
+        """Fail workers whose last heartbeat exceeds the staleness threshold.
+
+        On controller restart from checkpoint, workers carry their old
+        last_heartbeat_ms but consecutive_failures=0 and healthy=1.  If the
+        backing VMs were preempted during the outage, we'd otherwise wait for
+        10 RPC timeouts per worker before marking them dead.  This check
+        short-circuits that by failing any worker that hasn't heartbeated in
+        HEARTBEAT_STALENESS_THRESHOLD (15 minutes).
+        """
+        threshold_ms = HEARTBEAT_STALENESS_THRESHOLD.to_ms()
+        workers = healthy_active_workers_with_attributes(self._db)
+        stale = [w for w in workers if w.last_heartbeat.age_ms() > threshold_ms]
+        if not stale:
+            return
+
+        logger.warning(
+            "Failing %d workers with stale heartbeats (threshold=%ds): %s",
+            len(stale),
+            HEARTBEAT_STALENESS_THRESHOLD.to_seconds(),
+            [str(w.worker_id) for w in stale[:10]],
+        )
+        removed = self._transitions.fail_workers_by_ids(
+            [str(w.worker_id) for w in stale],
+            reason=f"heartbeat stale (>{int(HEARTBEAT_STALENESS_THRESHOLD.to_seconds())}s since last heartbeat)",
+        )
+        for wid, addr in removed:
+            self.stub_factory.evict(addr)
+            if self._autoscaler:
+                self._autoscaler.notify_worker_failed(str(wid))
+
     def _heartbeat_all_workers(self) -> None:
         """Send heartbeats to all registered workers.
 
@@ -1403,6 +1435,12 @@ class Controller:
 
     def _heartbeat_all_workers_inner(self) -> None:
         round_timer = Timer()
+
+        # Phase 0: fail workers whose last heartbeat exceeds the staleness
+        # threshold.  This catches workers restored from a checkpoint whose
+        # backing VMs no longer exist — without it they'd sit "healthy" until
+        # 10 consecutive RPC failures accumulate.
+        self._reap_stale_workers()
 
         # Phase 1: create snapshots for all healthy workers (lock-acquiring).
         with slow_log(logger, "heartbeat phase 1 (snapshot)", threshold_ms=100):

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -65,6 +65,13 @@ accidental collision with normal job names."""
 HEARTBEAT_FAILURE_THRESHOLD = 10
 """Consecutive heartbeat failures before marking worker as failed."""
 
+HEARTBEAT_STALENESS_THRESHOLD = Duration.from_seconds(900)
+"""If a worker's last successful heartbeat is older than this, it is failed
+immediately. Catches workers restored from a checkpoint whose backing VMs
+no longer exist — without this, the controller would need 10 consecutive
+RPC failures (50s) per worker to notice, during which they appear healthy
+in the dashboard and block scheduling capacity."""
+
 WORKER_TASK_HISTORY_RETENTION = 500
 """Maximum worker_task_history rows retained per worker."""
 

--- a/lib/iris/tests/cluster/controller/test_heartbeat.py
+++ b/lib/iris/tests/cluster/controller/test_heartbeat.py
@@ -6,11 +6,13 @@
 import time
 
 import pytest
+from iris.cluster.controller.controller import Controller, ControllerConfig
 from iris.cluster.controller.db import TASKS, WORKERS, ControllerDB
 from iris.cluster.log_store import LogStore
 from iris.cluster.controller.transitions import (
     Assignment,
     ControllerTransitions,
+    HEARTBEAT_STALENESS_THRESHOLD,
     HeartbeatAction,
     HeartbeatApplyRequest,
     DispatchBatch,
@@ -215,3 +217,76 @@ def test_unhealthy_worker_cascades_to_tasks(tmp_path):
         task = q.one(TASKS, where=TASKS.c.task_id == task_id.to_wire())
     assert task is not None
     assert task.state == cluster_pb2.TASK_STATE_WORKER_FAILED
+
+
+class _FakeStubFactory:
+    def get_stub(self, address: str):
+        raise NotImplementedError
+
+    def evict(self, address: str) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def test_reap_stale_workers_removes_old_heartbeat(tmp_path, worker_metadata):
+    """Workers restored from checkpoint with heartbeat older than the staleness
+    threshold are failed immediately by the heartbeat loop's reap pass."""
+    db = ControllerDB(db_path=tmp_path / "controller.sqlite3")
+    log_store = LogStore(db_path=tmp_path / "controller.sqlite3")
+    config = ControllerConfig(remote_state_dir="file:///tmp/iris-test-state", local_state_dir=tmp_path)
+    controller = Controller(config=config, worker_stub_factory=_FakeStubFactory(), db=db)
+    state = controller.state
+
+    # Register a worker with a timestamp well beyond the staleness threshold.
+    stale_ts = Timestamp.from_ms(Timestamp.now().epoch_ms() - HEARTBEAT_STALENESS_THRESHOLD.to_ms() - 60_000)
+    state.register_or_refresh_worker(
+        worker_id=WorkerId("stale-worker"),
+        address="10.0.0.1:10001",
+        metadata=worker_metadata,
+        ts=stale_ts,
+    )
+    # Register a fresh worker that should survive.
+    state.register_or_refresh_worker(
+        worker_id=WorkerId("fresh-worker"),
+        address="10.0.0.2:10001",
+        metadata=worker_metadata,
+        ts=Timestamp.now(),
+    )
+
+    with db.snapshot() as q:
+        assert q.exists(WORKERS, where=WORKERS.c.worker_id == "stale-worker")
+        assert q.exists(WORKERS, where=WORKERS.c.worker_id == "fresh-worker")
+
+    controller._reap_stale_workers()
+
+    with db.snapshot() as q:
+        assert not q.exists(WORKERS, where=WORKERS.c.worker_id == "stale-worker")
+        assert q.exists(WORKERS, where=WORKERS.c.worker_id == "fresh-worker")
+
+    log_store.close()
+    db.close()
+
+
+def test_reap_stale_workers_no_op_when_all_fresh(tmp_path, worker_metadata):
+    """When all workers have recent heartbeats, no workers are reaped."""
+    db = ControllerDB(db_path=tmp_path / "controller.sqlite3")
+    log_store = LogStore(db_path=tmp_path / "controller.sqlite3")
+    config = ControllerConfig(remote_state_dir="file:///tmp/iris-test-state", local_state_dir=tmp_path)
+    controller = Controller(config=config, worker_stub_factory=_FakeStubFactory(), db=db)
+
+    controller.state.register_or_refresh_worker(
+        worker_id=WorkerId("worker1"),
+        address="10.0.0.1:10001",
+        metadata=worker_metadata,
+        ts=Timestamp.now(),
+    )
+
+    controller._reap_stale_workers()
+
+    with db.snapshot() as q:
+        assert q.exists(WORKERS, where=WORKERS.c.worker_id == "worker1")
+
+    log_store.close()
+    db.close()


### PR DESCRIPTION
On controller restart from checkpoint, workers carry old last_heartbeat_ms
but consecutive_failures=0 and healthy=1. The heartbeat loop only marks
workers unhealthy after 10 consecutive RPC failures, so stale workers sit
"healthy" in the dashboard and block scheduling capacity while failures
accumulate.

Add HEARTBEAT_STALENESS_THRESHOLD (15 min) check at the start of each
heartbeat round. Workers exceeding it are immediately failed via
fail_workers_by_ids, the same path used for slice reaping.