### PR TITLE
Preserve root cause on fatal grug train failures

### DIFF
--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -485,7 +485,9 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 if checkpointer is not None:
                     checkpointer.on_step(tree={"train_state": state}, step=int(state.step))
         except BaseException:
-            logger.exception("Fatal error in grug training loop; skipping final callbacks/checkpoint to preserve root cause")
+            logger.exception(
+                "Fatal error in grug training loop; skipping final callbacks/checkpoint to preserve root cause"
+            )
             raise
         else:
             # Mirror classic trainer behavior: force callbacks on the last completed step.

--- a/experiments/grug/modular_opt/train.py
+++ b/experiments/grug/modular_opt/train.py
@@ -485,7 +485,9 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 if checkpointer is not None:
                     checkpointer.on_step(tree={"train_state": state}, step=int(state.step))
         except BaseException:
-            logger.exception("Fatal error in grug training loop; skipping final callbacks/checkpoint to preserve root cause")
+            logger.exception(
+                "Fatal error in grug training loop; skipping final callbacks/checkpoint to preserve root cause"
+            )
             raise
         else:
             # Mirror classic trainer behavior: force callbacks on the last completed step.

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -503,7 +503,9 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 if checkpointer is not None:
                     checkpointer.on_step(tree={"train_state": state}, step=int(state.step))
         except BaseException:
-            logger.exception("Fatal error in grug training loop; skipping final callbacks/checkpoint to preserve root cause")
+            logger.exception(
+                "Fatal error in grug training loop; skipping final callbacks/checkpoint to preserve root cause"
+            )
             raise
         else:
             # Mirror classic trainer behavior: force callbacks on the last completed step.


### PR DESCRIPTION
## Summary

- preserve the original fatal exception in grug train loops by re-raising before final callbacks/checkpointing
- only force final callbacks and checkpoint writes after a clean loop exit
- apply the fix consistently across the `base`, `modular_opt`, and `moe` grug variants

## Validation

- `python3 -m py_compile experiments/grug/moe/train.py experiments/grug/base/train.py experiments/grug/modular_opt/train.py`

Refs #3762
