### PR TITLE
docs: clarify supported Python versions in setup guides

### DIFF
--- a/docs/dev-guide/building-docs.md
+++ b/docs/dev-guide/building-docs.md
@@ -6,7 +6,7 @@ This guide explains how to build, test, and maintain the Marin documentation.
 
 Before you begin, ensure you have the following installed:
 
-- Python 3.11 or higher
+- Python 3.11 or 3.12
 - uv (Python package manager)
 - Git
 

--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -6,7 +6,7 @@ In this tutorial, you will install Marin on your local machine.
 
 Before you begin, ensure you have the following installed:
 
-- Python 3.11 or higher
+- Python 3.11 or 3.12
 - uv (Python package manager)
 - Git
 - Rust toolchain via [rustup](https://rustup.rs) (needed for `lib/dupekit`, which is built with Maturin;


### PR DESCRIPTION
docs: clarify supported Python versions in setup guides

Tighten the installation and docs build guides to match Marins current Python support in lib/marin/pyproject.toml. The docs previously said "Python 3.11 or higher" even though Marin currently supports Python 3.11 and 3.12 only.

Fixes #3780
