### PR TITLE
[nightshift] Align prompt PR guidance with repo workflow

### DIFF
--- a/infra/scripts/nightshift_cleanup.py
+++ b/infra/scripts/nightshift_cleanup.py
@@ -4,17 +4,12 @@
 """Nightshift cleanup: single agent picks a subproject, finds something meaty, opens a PR."""
 
 import datetime
-import secrets
 import subprocess
 
 SUBPROJECTS = ["lib/marin/src/marin", "lib/iris/src/iris", "lib/zephyr/src/zephyr", "lib/levanter/src/levanter"]
 
 CLEANUP_PROMPT = """\
 You are the Nightshift Cleanup Agent.
-
-Your random seed is: {haiku_seed}
-Use this seed to compose a haiku about code maintenance. Include it
-as the epigraph of your PR description.
 
 ## Your Mission
 
@@ -35,6 +30,7 @@ lint, not renaming, but a genuine code quality win. Look for things like:
   internal functions
 
 Read `AGENTS.md` for project conventions.
+Read `.agents/skills/pull-request/SKILL.md` before opening any PR.
 
 ## Rules of Engagement
 
@@ -45,13 +41,16 @@ Read `AGENTS.md` for project conventions.
   that test modules you changed.
 - If you find issues but the fix is non-trivial, file a GitHub issue instead
   of making a risky change.
+- If you open a PR, follow `.agents/skills/pull-request/SKILL.md`: plain-text
+  commit-style title/body, reference an issue with `Fixes #NNNN` or
+  `Part of #NNNN`, and add the `agent-generated` and `nightshift` labels.
 - Keep the PR focused: one coherent improvement.
 
 ## Output
 
 Create a branch named `nightshift/cleanup-{date}` and open a PR with:
-- Title: `[nightshift] <concise description>`
-- Body: your haiku, then a summary of what was cleaned and why
+- A concise `[nightshift] ...` title that matches the pull-request skill
+- A plain-text body that follows the pull-request skill and links the issue
 - Labels: `agent-generated`, `nightshift`
 
 If you find nothing worth changing, exit cleanly — no branch, no PR.
@@ -61,7 +60,6 @@ If you find nothing worth changing, exit cleanly — no branch, no PR.
 def main() -> None:
     date = datetime.date.today().strftime("%Y%m%d")
     prompt = CLEANUP_PROMPT.format(
-        haiku_seed=secrets.token_hex(4),
         subprojects=", ".join(SUBPROJECTS),
         date=date,
     )

--- a/infra/scripts/nightshift_doc_drift.py
+++ b/infra/scripts/nightshift_doc_drift.py
@@ -9,13 +9,6 @@ import subprocess
 DOC_DRIFT_PROMPT = """\
 You are the Nightshift Doc Drift detector.
 
-## Ritual
-
-Your random seed is: {run_id}-{run_attempt}
-Before you begin, use this seed to inspire a haiku about
-documentation drift. Keep the haiku — you will include it as an epigraph
-in any PR or issue you create.
-
 ## Scope
 
 Sample a single subfolder of `docs/` to focus on. Use your random seed
@@ -23,6 +16,7 @@ to pick one at random. If the chosen subfolder has fewer than 3 markdown
 files, expand to its parent.
 
 Read `AGENTS.md` for project conventions.
+Read `.agents/skills/pull-request/SKILL.md` before opening any PR.
 
 ## Mission
 
@@ -56,10 +50,12 @@ is found, exit cleanly with a brief summary of what you checked.
 If meaningful drift is found:
 - Fix straightforward issues (broken links, wrong imports in examples).
 - For larger issues, file a GitHub issue with labels `documentation`,
-  `agent-generated`, and `nightshift`. Begin the body with your haiku.
+  `agent-generated`, and `nightshift`. Keep the issue title/body terse and
+  explain the observed drift plus the concrete follow-up needed.
 - If you made fixes, open a PR titled `[nightshift] fix documentation drift`
-  with labels `agent-generated` and `nightshift`. Begin the PR body with
-  your haiku.
+  with labels `agent-generated` and `nightshift`. Follow
+  `.agents/skills/pull-request/SKILL.md`: use a plain-text commit-style body
+  and reference the issue with `Fixes #NNNN` or `Part of #NNNN`.
 
 If nothing is found, exit cleanly.
 """


### PR DESCRIPTION
[nightshift] Align prompt PR guidance with repo workflow

Update the nightshift cleanup and doc-drift prompts to point at the canonical pull-request skill and stop asking agents for haiku-style PR bodies. This keeps scheduled agent output aligned with the repo’s plain-text PR format and issue-linking rules.

Fixes #3782
