### PR TITLE
fix: expose GH_TOKEN to nightshift workflows

### DIFF
--- a/.github/workflows/nightshift-cleanup.yml
+++ b/.github/workflows/nightshift-cleanup.yml
@@ -39,4 +39,5 @@ jobs:
       - name: Run cleanup agent
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: python infra/scripts/nightshift_cleanup.py

--- a/.github/workflows/nightshift-doc-drift.yml
+++ b/.github/workflows/nightshift-doc-drift.yml
@@ -39,4 +39,5 @@ jobs:
       - name: Detect documentation drift
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: python infra/scripts/nightshift_doc_drift.py --run-id ${{ github.run_id }} --run-attempt ${{ github.run_attempt }}


### PR DESCRIPTION
The nightshift cleanup and doc-drift agents push branches successfully
but fail to create PRs because the gh CLI has no GitHub token available.
Pass github.token via GH_TOKEN so gh pr create works.

Confirmed from today's run log: "No GitHub token is available in this
environment. The branch has been pushed, but I can't create the PR
via gh."