### PR TITLE
Support hf://buckets paths in default_download and default_tokenize

### DIFF
--- a/experiments/defaults.py
+++ b/experiments/defaults.py
@@ -78,6 +78,20 @@ from marin.training.training import (
 logger = logging.getLogger(__name__)
 
 
+HF_BUCKET_URI_PREFIX = "hf://buckets/"
+HF_BUCKET_PATH_PREFIX = "buckets/"
+
+
+def _is_hf_bucket_path(path: str) -> bool:
+    return path.startswith(HF_BUCKET_URI_PREFIX) or path.startswith(HF_BUCKET_PATH_PREFIX)
+
+
+def _normalize_hf_bucket_path(path: str) -> str:
+    if path.startswith(HF_BUCKET_URI_PREFIX):
+        return path.removeprefix("hf://")
+    return path
+
+
 DEFAULT_NEW_RUN_DATA_SHUFFLE = BlockShuffleConfig(
     io_block_size=256,
     window_blocks=512,
@@ -125,7 +139,7 @@ def _validate_train_length(train_seq_len: int | None, model_config: LmConfig) ->
 def default_download(
     name: str,
     hf_dataset_id: str,
-    revision: str,
+    revision: str | None = None,
     override_output_path: str | None = None,
     **kwargs: Any,
 ) -> InputName:
@@ -135,25 +149,41 @@ def default_download(
     Args:
         name: The name of the Download step. It forms the basis of the output path
             unless override_output_path is explicitly specified.
-        hf_dataset_id: The HuggingFace dataset ID to download. As `$ORG/$DATASET` on HF Hub
-        revision: The revision of the dataset to download.
-            Short Commit Hash from HF Dataset Repo (7 characters)
+        hf_dataset_id: Hugging Face source. Either `$ORG/$DATASET` on HF Hub or `hf://buckets/...`.
+        revision: The revision of the dataset to download for Hub datasets.
+            Optional for bucket paths.
         override_output_path: Optional. The output path for the dataset.
         **kwargs: Additional keyword arguments that are passed to the download config.
 
     The final output data will reside in '{output_path}/{revision}'.
     """
 
+    download_kwargs = dict(kwargs)
+    hf_repo_type_prefix = download_kwargs.pop("hf_repo_type_prefix", None)
+    if _is_hf_bucket_path(hf_dataset_id):
+        normalized_dataset_id = _normalize_hf_bucket_path(hf_dataset_id)
+        description = f"Download {hf_dataset_id}"
+        resolved_hf_repo_type_prefix = "" if hf_repo_type_prefix is None else hf_repo_type_prefix
+        resolved_revision = "main" if revision is None else revision
+    else:
+        if revision is None:
+            raise ValueError("revision is required for non-bucket Hugging Face dataset downloads.")
+        normalized_dataset_id = hf_dataset_id
+        description = f"Download {hf_dataset_id} revision {revision}"
+        resolved_hf_repo_type_prefix = "datasets" if hf_repo_type_prefix is None else hf_repo_type_prefix
+        resolved_revision = revision
+
     step = ExecutorStep(
         name=name,
-        description=f"Download {hf_dataset_id} revision {revision}",
+        description=description,
         fn=download_hf,
         config=DownloadConfig(
-            hf_dataset_id=hf_dataset_id,
-            revision=revision,
+            hf_dataset_id=normalized_dataset_id,
+            revision=resolved_revision,
             gcs_output_path=this_output_path(),
             wait_for_completion=True,
-            **kwargs,
+            hf_repo_type_prefix=resolved_hf_repo_type_prefix,
+            **download_kwargs,
         ),
         override_output_path=override_output_path,
     )
@@ -201,7 +231,12 @@ def default_tokenize(
             format=format,
             sample_count=ensure_versioned(sample_count) if sample_count is not None else None,
         )
-    elif isinstance(dataset, str) and dataset.count("/") == 1 and not fsspec_utils.exists(dataset):
+    elif (
+        isinstance(dataset, str)
+        and not _is_hf_bucket_path(dataset)
+        and dataset.count("/") == 1
+        and not fsspec_utils.exists(dataset)
+    ):
         config = HfTokenizeConfig(
             id=dataset,
             cache_path=this_output_path(),

--- a/lib/marin/src/marin/download/huggingface/download_hf.py
+++ b/lib/marin/src/marin/download/huggingface/download_hf.py
@@ -15,9 +15,11 @@ import time
 from dataclasses import dataclass, field
 
 import draccus
+import huggingface_hub
 from huggingface_hub import HfFileSystem
 from iris.marin_fs import open_url, url_to_fs
 from huggingface_hub.errors import HfHubHTTPError
+from packaging.version import Version
 from marin.execution.executor import THIS_OUTPUT_PATH
 from marin.utilities.validation_utils import write_provenance_json
 from zephyr import Dataset, ZephyrContext
@@ -25,6 +27,9 @@ from zephyr.writers import atomic_rename
 from iris.logging import configure_logging
 
 logger = logging.getLogger(__name__)
+
+HF_PROTOCOL_PREFIX = "hf://"
+HF_BUCKET_PATH_PREFIX = "buckets/"
 
 
 @dataclass(frozen=True)
@@ -67,6 +72,56 @@ class DownloadConfig:
 
     read_chunk_size_mib: int = 8
     """Chunk size for each streaming read from HF."""
+
+
+def _strip_hf_protocol(path: str) -> str:
+    return path.removeprefix(HF_PROTOCOL_PREFIX).lstrip("/")
+
+
+def _resolve_hf_source_path(cfg: DownloadConfig) -> str:
+    source_path = (
+        os.path.join(cfg.hf_repo_type_prefix, cfg.hf_dataset_id) if cfg.hf_repo_type_prefix else cfg.hf_dataset_id
+    )
+    return _strip_hf_protocol(source_path)
+
+
+def _assert_bucket_support_available(source_path: str) -> None:
+    if not source_path.startswith(HF_BUCKET_PATH_PREFIX):
+        return
+
+    if Version(huggingface_hub.__version__) < Version("1.6.0"):
+        raise RuntimeError(
+            f"Bucket paths require huggingface_hub>=1.6.0, found {huggingface_hub.__version__}. "
+            "Upgrade the runtime environment to a buckets-capable huggingface_hub version."
+        )
+
+
+def _relative_path_in_source(file_path: str, source_path: str) -> str:
+    normalized_file = _strip_hf_protocol(file_path)
+    normalized_source = _strip_hf_protocol(source_path).rstrip("/")
+
+    source_prefix = f"{normalized_source}/"
+    if normalized_file.startswith(source_prefix):
+        return normalized_file.removeprefix(source_prefix)
+
+    source_parts = [segment for segment in normalized_source.split("/") if segment]
+    file_parts = [segment for segment in normalized_file.split("/") if segment]
+
+    if len(file_parts) >= len(source_parts):
+        matches_source = True
+        for source_segment, file_segment in zip(source_parts, file_parts, strict=False):
+            if source_segment == file_segment:
+                continue
+            if file_segment.split("@", 1)[0] == source_segment:
+                continue
+            matches_source = False
+            break
+
+        if matches_source:
+            return "/".join(file_parts[len(source_parts) :])
+
+    # Backwards-compatible fallback for historical dataset path layout.
+    return normalized_file.split("/", 3)[-1]
 
 
 def ensure_fsspec_path_writable(output_path: str) -> None:
@@ -215,16 +270,17 @@ def download_hf(cfg: DownloadConfig) -> None:
     # Initialize Hugging Face filesystem
     logger.info("Identifying files to download from HuggingFace...")
     hf_fs = HfFileSystem(token=os.environ.get("HF_TOKEN", False))
-    hf_repo_name_with_prefix = os.path.join(cfg.hf_repo_type_prefix, cfg.hf_dataset_id)
+    hf_source_path = _resolve_hf_source_path(cfg)
+    _assert_bucket_support_available(hf_source_path)
 
     if not cfg.hf_urls_glob:
         # We get all the files using find
-        files = hf_fs.find(hf_repo_name_with_prefix, revision=cfg.revision)
+        files = hf_fs.find(hf_source_path, revision=cfg.revision)
     else:
         # Get list of files directly from HfFileSystem matching the pattern
         files = []
         for hf_url_glob in cfg.hf_urls_glob:
-            pattern = os.path.join(hf_repo_name_with_prefix, hf_url_glob)
+            pattern = os.path.join(hf_source_path, hf_url_glob)
             files += hf_fs.glob(pattern, revision=cfg.revision)
 
     if not files:
@@ -245,8 +301,10 @@ def download_hf(cfg: DownloadConfig) -> None:
 
     for file in files:
         try:
-            fsspec_file_path = os.path.join(output_path, file.split("/", 3)[-1])  # Strip the dataset prefix
-            # Hf file paths are always of format : hf://[<repo_type_prefix>]<repo_id>[@<revision>]/<path/in/repo>
+            relative_file_path = _relative_path_in_source(file, hf_source_path)
+            if relative_file_path.startswith(".."):
+                raise ValueError(f"Computed path escapes source root: source={hf_source_path}, file={file}")
+            fsspec_file_path = os.path.join(output_path, relative_file_path)
             expected_size = file_sizes.get(file)
             download_tasks.append(
                 (

--- a/tests/download/test_huggingface.py
+++ b/tests/download/test_huggingface.py
@@ -10,7 +10,12 @@ from unittest.mock import MagicMock, Mock, patch
 import pandas as pd
 import pytest
 
-from marin.download.huggingface.download_hf import DownloadConfig, download_hf, stream_file_to_fsspec
+from marin.download.huggingface.download_hf import (
+    DownloadConfig,
+    _relative_path_in_source,
+    download_hf,
+    stream_file_to_fsspec,
+)
 from marin.download.huggingface.stream_remove_columns import (
     DatasetConfig,
     prune_hf_dataset,
@@ -124,6 +129,30 @@ def test_download_hf_appends_sha_when_configured(mock_hf_fs, tmp_path):
     target_output = base_output_path / revision
     assert (target_output / "data" / "file1.txt").exists()
     assert (target_output / "provenance.json").exists()
+
+
+def test_relative_path_in_source_supports_bucket_paths():
+    file_path = "hf://buckets/demo-user/demo-bucket/data/train/file1.txt"
+    source_path = "hf://buckets/demo-user/demo-bucket/data"
+    assert _relative_path_in_source(file_path, source_path) == "train/file1.txt"
+
+
+def test_relative_path_in_source_supports_revision_qualified_bucket_paths():
+    file_path = "hf://buckets/demo-user/demo-bucket/data@main/train/file1.txt"
+    source_path = "hf://buckets/demo-user/demo-bucket/data"
+    assert _relative_path_in_source(file_path, source_path) == "train/file1.txt"
+
+
+def test_download_hf_bucket_requires_newer_huggingface_hub(tmp_path):
+    cfg = DownloadConfig(
+        hf_dataset_id="buckets/demo-user/demo-bucket/data",
+        revision="main",
+        gcs_output_path=str(tmp_path),
+        hf_repo_type_prefix="",
+    )
+
+    with pytest.raises(RuntimeError, match=r"huggingface_hub>=1\.6\.0"):
+        download_hf(cfg)
 
 
 def test_prune_hf_dataset(tmp_path):

--- a/tests/test_hfdataset_spec.py
+++ b/tests/test_hfdataset_spec.py
@@ -1,9 +1,10 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from experiments.defaults import default_tokenize
+from experiments.defaults import default_download, default_tokenize
+from marin.download.huggingface.download_hf import DownloadConfig
 from marin.processing.tokenize import HfDatasetSpec
-from marin.processing.tokenize.tokenize import HfTokenizeConfig
+from marin.processing.tokenize.tokenize import HfTokenizeConfig, TokenizeConfig
 
 
 def test_default_tokenize_with_dataset_name():
@@ -15,3 +16,40 @@ def test_default_tokenize_with_dataset_name():
     assert isinstance(step.config, HfTokenizeConfig)
     assert step.config.id == "cnn_dailymail"
     assert step.config.name == "3.0.0"
+
+
+def test_default_tokenize_with_hf_bucket_path_uses_filesystem_tokenize_config():
+    bucket_path = "hf://buckets/demo-user/demo-bucket/data/train.jsonl"
+    step = default_tokenize(
+        name="dummy",
+        dataset=bucket_path,
+        tokenizer="gpt2",
+    )
+
+    assert isinstance(step.config, TokenizeConfig)
+    assert step.config.train_paths == [bucket_path]
+
+
+def test_default_download_with_hf_bucket_path_uses_bucket_prefix():
+    bucket_path = "hf://buckets/demo-user/demo-bucket/data"
+    step_input = default_download(
+        name="dummy-bucket-download",
+        hf_dataset_id=bucket_path,
+    )
+
+    assert step_input.step is not None
+    assert isinstance(step_input.step.config, DownloadConfig)
+    assert step_input.step.config.hf_repo_type_prefix == ""
+    assert step_input.step.config.hf_dataset_id == "buckets/demo-user/demo-bucket/data"
+
+
+def test_default_download_requires_revision_for_hub_dataset_ids():
+    try:
+        default_download(
+            name="dummy-hf-download",
+            hf_dataset_id="allenai/c4",
+        )
+    except ValueError as error:
+        assert "revision is required" in str(error)
+    else:
+        raise AssertionError("expected ValueError when revision is missing for non-bucket dataset IDs")


### PR DESCRIPTION
## Summary
- add bucket-path support to `default_download` for `hf://buckets/...` (and normalized `buckets/...`)
- add explicit bucket-path handling in `default_tokenize` so bucket URIs route through filesystem tokenization (`TokenizeConfig`) instead of HF dataset-id sniffing
- update HF download path handling to compute relative output paths from the resolved source root for both dataset and bucket sources
- add a clear runtime guard error when bucket sources are used with `huggingface_hub<1.6.0`

## Details
- `default_download` now:
  - normalizes bucket URIs to `buckets/...`
  - uses empty `hf_repo_type_prefix` for bucket sources
  - allows omitted `revision` for bucket sources (defaults to `main`)
  - still requires explicit `revision` for non-bucket HF dataset IDs
- `download_hf` now resolves source roots generically and preserves relative paths into output for bucket and dataset sources.

## Tests
- `uv run --package marin --group test pytest tests/test_hfdataset_spec.py tests/download/test_huggingface.py -q` (10 passed)
- `./infra/pre-commit.py --all-files --fix` (passed)
- attempted: `uv run --package marin --extra dedup --group test pytest -m 'not slow'` (hits unrelated timeout in `tests/evals/test_lm_eval.py`)

## Live bucket verification
- uploaded `gettysburg_5x.jsonl` to `hf://buckets/dlwh/marin-demo/unit-test/` and `hf://buckets/dlwh/marin-demo/smoke/`
- verified live download via `download_hf` from bucket path
- verified live tokenization path from `default_tokenize` on `hf://buckets/.../*.jsonl`

Closes #3788
