### PR TITLE
[infra] Use acceptEdits for Claude triage

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -149,7 +149,7 @@ jobs:
           claude_args: |
             --model opus
             --max-turns 250
-            --dangerously-skip-permissions
+            --permission-mode acceptEdits
             --allowedTools "Bash(git:*),Bash(./infra/pre-commit.py:*),Bash(uv:*),Bash(pytest:*),Bash(gh:*),Bash(python:*)"
             --system-prompt "Always read and follow the guidelines in AGENTS.md before starting work. You always have the ability to commit and push your changes. Use your MCP tools if available, falling back to git and gh (which you have authorization for) if needed. Before submitting any changes: 1) Run ./infra/pre-commit.py --all-files --fix and fix any issues. 2) Run uv run pytest on tests relevant to your changes. Report on the test status when you provide an update. Always commit and push changes, even if you couldn't get the tests to pass. Never post partial, placeholder, or test comments. Every comment must be complete and follow the format specified in the prompt. To update the task list comment, use `gh issue comment <number> --edit-last --body '...'` to edit your last comment in place."
 


### PR DESCRIPTION
Set the triage Claude invocation to use permission mode acceptEdits so the issues-triggered path matches the successful manual @claude flow. The failed triage run for issue #3801 had GitHub write scopes and git auth, but still hit Claude edit denials until it bailed out.

Fixes #3801