### PR TITLE
[zephyr] Clean up coordinators after failed pipelines

### DIFF
--- a/lib/fray/src/fray/v2/actor.py
+++ b/lib/fray/src/fray/v2/actor.py
@@ -10,8 +10,9 @@ holds a set of actor handles with lifecycle tied to underlying jobs.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 
@@ -33,6 +34,13 @@ class ActorContext:
 
     group_name: str
     """The name of the actor group this actor belongs to."""
+
+    _terminate: Callable[[], None] = field(default=lambda: None, repr=False, compare=False)
+    """Backend-owned termination hook."""
+
+    def terminate(self) -> None:
+        """Request that the backend terminate this actor host."""
+        self._terminate()
 
 
 _current_actor_ctx: ContextVar[ActorContext | None] = ContextVar("actor_context", default=None)

--- a/lib/fray/src/fray/v2/iris_backend.py
+++ b/lib/fray/src/fray/v2/iris_backend.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
 
@@ -53,6 +54,33 @@ from fray.v2.types import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class _ActorContextProxy:
+    """Wrap actor methods so current_actor() is available during method calls."""
+
+    def __init__(self, instance: Any, actor_ctx: ActorContext, on_terminate: Callable[[], None]):
+        self._instance = instance
+        self._actor_ctx = actor_ctx
+        self._on_terminate = on_terminate
+
+    def __dir__(self) -> list[str]:
+        return dir(self._instance)
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._instance, name)
+        if name.startswith("_") or not callable(attr):
+            return attr
+
+        def _wrapped(*args: Any, **kwargs: Any) -> Any:
+            token = _set_current_actor(self._actor_ctx)
+            try:
+                return attr(*args, **kwargs)
+            finally:
+                _reset_current_actor(token)
+                self._on_terminate()
+
+        return _wrapped
 
 
 def _convert_device(device: DeviceConfig) -> cluster_pb2.DeviceConfig | None:
@@ -202,12 +230,40 @@ def _host_actor(actor_class: type, args: tuple, kwargs: dict, name_prefix: str) 
 
     # Create handle BEFORE instance so actor can access it during __init__
     handle = IrisActorHandle(actor_name)
-    actor_ctx = ActorContext(handle=handle, index=job_info.task_index, group_name=name_prefix)
+    assert ctx.client is not None
+    terminate_requested = threading.Event()
+
+    def _terminate_job_if_requested() -> None:
+        if not terminate_requested.is_set():
+            return
+        terminate_requested.clear()
+
+        def _terminate_job() -> None:
+            time.sleep(2.0)
+            try:
+                ctx.client.terminate(ctx.job_id)
+            except Exception:
+                logger.warning("Failed to terminate actor job %s", ctx.job_id, exc_info=True)
+
+        thread = threading.Thread(
+            target=_terminate_job,
+            daemon=True,
+            name=f"terminate-{name_prefix}-{job_info.task_index}",
+        )
+        thread.start()
+
+    actor_ctx = ActorContext(
+        handle=handle,
+        index=job_info.task_index,
+        group_name=name_prefix,
+        _terminate=terminate_requested.set,
+    )
     token = _set_current_actor(actor_ctx)
     try:
         instance = actor_class(*args, **kwargs)
     finally:
         _reset_current_actor(token)
+    instance = _ActorContextProxy(instance, actor_ctx, on_terminate=_terminate_job_if_requested)
 
     server = ActorServer(host="0.0.0.0", port=ctx.get_port("actor"))
     server.register(actor_name, instance)

--- a/lib/fray/src/fray/v2/local_backend.py
+++ b/lib/fray/src/fray/v2/local_backend.py
@@ -160,14 +160,19 @@ class LocalClient:
             # Create endpoint-based handle BEFORE instance so actor can access it
             endpoint = f"local/{name}-{i}"
             handle = LocalActorHandle(endpoint)
+            terminate_requested = threading.Event()
 
             # Set actor context with handle so actor can pass it to other actors
-            ctx = ActorContext(handle=handle, index=i, group_name=name)
+            ctx = ActorContext(handle=handle, index=i, group_name=name, _terminate=terminate_requested.set)
             token = _set_current_actor(ctx)
             try:
                 instance = actor_class(*args, **kwargs)
             finally:
                 _reset_current_actor(token)
+
+            instance._fray_actor_ctx = ctx
+            instance._fray_actor_endpoint = endpoint
+            instance._fray_terminate_requested = terminate_requested
 
             # Register instance so handle can resolve it
             _local_actor_registry[endpoint] = instance
@@ -236,6 +241,30 @@ class LocalActorMethod:
     def __init__(self, method: Any):
         self._method = method
 
+    def _invoke(self, *args: Any, **kwargs: Any) -> Any:
+        instance = getattr(self._method, "__self__", None)
+        actor_ctx = getattr(instance, "_fray_actor_ctx", None)
+        token = _set_current_actor(actor_ctx) if actor_ctx is not None else None
+
+        try:
+            return self._method(*args, **kwargs)
+        finally:
+            if actor_ctx is not None:
+                _reset_current_actor(token)
+
+            if instance is not None:
+                terminate_requested = getattr(instance, "_fray_terminate_requested", None)
+                if terminate_requested is not None and terminate_requested.is_set():
+                    terminate_requested.clear()
+                    try:
+                        instance.shutdown()
+                    except Exception as e:
+                        logger.warning("Error shutting down actor %s: %s", type(instance).__name__, e)
+
+                    endpoint = getattr(instance, "_fray_actor_endpoint", None)
+                    if endpoint is not None and _local_actor_registry.get(endpoint) is instance:
+                        _local_actor_registry.pop(endpoint, None)
+
     def remote(self, *args: Any, **kwargs: Any) -> ActorFuture:
         """Spawn a dedicated thread for this call, returning a future.
 
@@ -247,7 +276,7 @@ class LocalActorMethod:
 
         def run():
             try:
-                result = self._method(*args, **kwargs)
+                result = self._invoke(*args, **kwargs)
                 future.set_result(result)
             except Exception as e:
                 logger.warning("Actor method %r failed: %s", method_name, e, exc_info=True)
@@ -259,7 +288,7 @@ class LocalActorMethod:
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         """Call method synchronously."""
-        return self._method(*args, **kwargs)
+        return self._invoke(*args, **kwargs)
 
 
 class LocalActorGroup:

--- a/lib/fray/src/fray/v2/ray_backend/backend.py
+++ b/lib/fray/src/fray/v2/ray_backend/backend.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 import time
 import uuid
 from typing import Any, cast
@@ -32,6 +33,15 @@ from fray.v2.types import (
 from iris.logging import configure_logging
 
 logger = logging.getLogger(__name__)
+
+
+@ray.remote(enable_task_events=False)
+def _kill_named_actor(actor_name: str) -> None:
+    try:
+        actor = ray.get_actor(actor_name)
+    except ValueError:
+        return
+    ray.kill(actor)
 
 
 def _convert_ray_status(ray_status: RayJobStatus) -> JobStatus:
@@ -463,8 +473,15 @@ class _RayActorHostBase:
 
         # Create handle by name - will resolve via ray.get_actor() when used
         handle = RayActorHandle(actor_name)
-        ctx = ActorContext(handle=handle, index=actor_index, group_name=group_name)
-        token = _set_current_actor(ctx)
+        self._actor_name = actor_name
+        self._terminate_requested = threading.Event()
+        self._actor_ctx = ActorContext(
+            handle=handle,
+            index=actor_index,
+            group_name=group_name,
+            _terminate=self._terminate_requested.set,
+        )
+        token = _set_current_actor(self._actor_ctx)
         try:
             self._instance = actor_class(*args, **kwargs)
         finally:
@@ -472,7 +489,14 @@ class _RayActorHostBase:
 
     def _proxy_call(self, method_name: str, args: tuple, kwargs: dict) -> Any:
         """Proxy method calls to the wrapped actor instance."""
-        return getattr(self._instance, method_name)(*args, **kwargs)
+        token = _set_current_actor(self._actor_ctx)
+        try:
+            return getattr(self._instance, method_name)(*args, **kwargs)
+        finally:
+            _reset_current_actor(token)
+            if self._terminate_requested.is_set():
+                self._terminate_requested.clear()
+                _kill_named_actor.remote(self._actor_name)
 
 
 _named_actor_host_cache: dict[str, type] = {}

--- a/lib/fray/tests/test_v2_actor.py
+++ b/lib/fray/tests/test_v2_actor.py
@@ -7,7 +7,7 @@ import threading
 
 import pytest
 
-from fray.v2 import LocalClient
+from fray.v2 import LocalClient, current_actor
 
 
 class Counter:
@@ -25,6 +25,16 @@ class Counter:
 class Adder:
     def add(self, a: int, b: int) -> int:
         return a + b
+
+
+class SelfAwareActor:
+    def actor_identity(self) -> tuple[int, str]:
+        ctx = current_actor()
+        return (ctx.index, ctx.group_name)
+
+    def terminate(self) -> str:
+        current_actor().terminate()
+        return "terminating"
 
 
 @pytest.fixture
@@ -107,3 +117,15 @@ def test_actor_method_with_kwargs(client: LocalClient):
     actor = client.create_actor(Adder, name="adder")
     assert actor.add.remote(a=3, b=4).result() == 7
     assert actor.add(a=10, b=20) == 30
+
+
+def test_actor_methods_run_with_current_actor_context(client: LocalClient):
+    actor = client.create_actor(SelfAwareActor, name="self-aware")
+    assert actor.actor_identity.remote().result() == (0, "self-aware")
+
+
+def test_actor_can_request_backend_termination(client: LocalClient):
+    actor = client.create_actor(SelfAwareActor, name="self-aware")
+    assert actor.terminate.remote().result() == "terminating"
+    with pytest.raises(RuntimeError, match="Actor not found"):
+        actor.actor_identity.remote()

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -34,7 +34,7 @@ import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.parquet as pq
 from iris.marin_fs import open_url, url_to_fs
-from fray.v2 import ActorConfig, ActorFuture, ActorHandle, Client, ResourceConfig
+from fray.v2 import ActorConfig, ActorFuture, ActorHandle, Client, ResourceConfig, current_actor
 from iris.marin_fs import marin_temp_bucket
 from iris.time_utils import ExponentialBackoff
 
@@ -864,6 +864,7 @@ class ZephyrCoordinator:
         hints: ExecutionHint,
     ) -> list:
         """Run complete pipeline, blocking until done. Returns flattened results."""
+        failed = False
         with self._lock:
             if self._pipeline_running:
                 self._fatal_error = "run_pipeline called while another pipeline is already running"
@@ -914,10 +915,15 @@ class ZephyrCoordinator:
                     flat_result.extend(list(chunk))
 
             return flat_result
+        except Exception:
+            failed = True
+            raise
         finally:
             try:
                 self.shutdown()
             finally:
+                if failed:
+                    current_actor().terminate()
                 with self._lock:
                     self._pipeline_running = False
 

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -913,13 +913,13 @@ class ZephyrCoordinator:
                 for chunk in shard.chunks:
                     flat_result.extend(list(chunk))
 
-            # Signal workers to shut down now that all stages are complete.
-            self.shutdown()
-
             return flat_result
         finally:
-            with self._lock:
-                self._pipeline_running = False
+            try:
+                self.shutdown()
+            finally:
+                with self._lock:
+                    self._pipeline_running = False
 
     def _compute_join_aux(
         self,

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -6,14 +6,16 @@
 from __future__ import annotations
 
 import json
+import threading
 import time
 import uuid
 from pathlib import Path
 
 import pytest
-from fray.v2 import ResourceConfig
+from fray.v2 import ActorConfig, ResourceConfig
+from fray.v2.local_backend import LocalClient, _local_actor_registry
 from zephyr.dataset import Dataset
-from zephyr.execution import ZephyrContext, zephyr_worker_ctx
+from zephyr.execution import ZephyrContext, ZephyrCoordinator, ZephyrWorkerError, zephyr_worker_ctx
 
 
 def test_simple_map(zephyr_ctx):
@@ -712,6 +714,82 @@ def test_execute_retries_on_coordinator_death(tmp_path):
 
     ctx.shutdown()
     client.shutdown(wait=True)
+
+
+def test_execute_cleans_up_original_coordinator_after_same_endpoint_replacement(tmp_path):
+    """Replacing a coordinator at the same endpoint must not leak the original coordinator."""
+    client = LocalClient()
+    chunk_prefix = str(tmp_path / "chunks")
+
+    task_started = threading.Event()
+    release_task = threading.Event()
+    execution_error: list[Exception] = []
+    old_coordinator = None
+    replacement_group = None
+
+    def blocking_map(x):
+        task_started.set()
+        if not release_task.wait(timeout=5.0):
+            raise RuntimeError("release timed out")
+        return x + 1
+
+    ctx = ZephyrContext(
+        client=client,
+        max_workers=1,
+        resources=ResourceConfig(cpu=1, ram="512m"),
+        chunk_storage_prefix=chunk_prefix,
+        no_workers_timeout=0.2,
+        max_execution_retries=0,
+        name=f"test-execution-{uuid.uuid4().hex[:8]}",
+    )
+
+    def run_failing_execute():
+        try:
+            list(ctx.execute(Dataset.from_list([1]).map(blocking_map)))
+        except Exception as exc:
+            execution_error.append(exc)
+
+    execution_thread = threading.Thread(target=run_failing_execute, daemon=True)
+
+    try:
+        execution_thread.start()
+        assert task_started.wait(timeout=5.0)
+        assert ctx._coordinator is not None
+
+        endpoint = ctx._coordinator._endpoint
+        old_coordinator = _local_actor_registry[endpoint]
+        assert old_coordinator._coordinator_thread is not None
+        assert old_coordinator._coordinator_thread.is_alive()
+
+        replacement_group = client.create_actor_group(
+            ZephyrCoordinator,
+            name=f"zephyr-{ctx.name}-p{ctx._pipeline_id}-a0-coord",
+            count=1,
+            resources=ResourceConfig(cpu=1, ram="5g"),
+            actor_config=ActorConfig(max_concurrency=100),
+        )
+        replacement_group.wait_ready()
+        assert _local_actor_registry[endpoint] is not old_coordinator
+
+        old_coordinator.check_heartbeats(timeout=0.0)
+        release_task.set()
+
+        execution_thread.join(timeout=10.0)
+        assert not execution_thread.is_alive()
+        assert len(execution_error) == 1
+        assert isinstance(execution_error[0], ZephyrWorkerError)
+
+        results = list(ctx.execute(Dataset.from_list([10]).map(lambda x: x + 1)))
+        assert results == [11]
+        assert not old_coordinator._coordinator_thread.is_alive()
+    finally:
+        release_task.set()
+        execution_thread.join(timeout=10.0)
+        if old_coordinator is not None:
+            old_coordinator.shutdown()
+        if replacement_group is not None:
+            replacement_group.shutdown()
+        client.shutdown(wait=True)
 
 
 def test_execute_does_not_retry_worker_errors(fray_client, tmp_path):

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -738,7 +738,6 @@ def test_execute_cleans_up_original_coordinator_after_same_endpoint_replacement(
         max_workers=1,
         resources=ResourceConfig(cpu=1, ram="512m"),
         chunk_storage_prefix=chunk_prefix,
-        no_workers_timeout=0.2,
         max_execution_retries=0,
         name=f"test-execution-{uuid.uuid4().hex[:8]}",
     )
@@ -771,7 +770,7 @@ def test_execute_cleans_up_original_coordinator_after_same_endpoint_replacement(
         replacement_group.wait_ready()
         assert _local_actor_registry[endpoint] is not old_coordinator
 
-        old_coordinator.check_heartbeats(timeout=0.0)
+        old_coordinator.abort("test: replaced coordinator")
         release_task.set()
 
         execution_thread.join(timeout=10.0)


### PR DESCRIPTION
[zephyr] Clean up coordinators after failed pipelines

Shut Zephyr coordinators down from `run_pipeline()`'s `finally` block so failed executions do not leave idle coordinator jobs behind after retries or actor replacement. Adds a regression test that forces same-endpoint coordinator replacement and verifies the original coordinator is gone before a later execution runs.

Fixes #3705