### PR TITLE
docs: align docs build guide install command with CI

### DIFF
--- a/docs/dev-guide/building-docs.md
+++ b/docs/dev-guide/building-docs.md
@@ -14,8 +14,10 @@ Before you begin, ensure you have the following installed:
 
 1. Install the documentation dependencies:
    ```bash
-   uv sync --package marin --group docs
+   uv sync --package marin --group dev
    ```
+   Marin's `dev` group includes the docs tooling, and this is the same install
+   command used by the docs CI workflow and the general contributor setup.
 
 ## Building Documentation
 


### PR DESCRIPTION
docs: align docs build guide install command with CI

Update docs/dev-guide/building-docs.md to use `uv sync --package marin --group dev`, which matches the docs CI workflow and contributor setup. This keeps the local docs build instructions aligned with the supported dependency install path.

Fixes #3815
