### PR TITLE
[iris] Fix VFIO device passthrough for v5p/v6e TPUs

### DIFF
--- a/lib/iris/src/iris/cluster/runtime/docker.py
+++ b/lib/iris/src/iris/cluster/runtime/docker.py
@@ -114,7 +114,9 @@ def _discover_tpu_device_mappings() -> list[str]:
 
     vfio_path = Path("/dev/vfio")
     if vfio_path.exists():
-        mappings.append("/dev/vfio:/dev/vfio")
+        for entry in sorted(vfio_path.iterdir()):
+            if entry.is_char_device():
+                mappings.append(f"{entry}:{entry}")
 
     accel_devices: list[Path] = []
     for device_path in Path("/dev").glob("accel[0-9]*"):


### PR DESCRIPTION
Enumerate individual char devices under /dev/vfio/ instead of mounting
the directory. Docker --device only passes through device nodes, not
directories, so the previous /dev/vfio:/dev/vfio mount silently exposed
nothing. This broke when commit 1e3fd03 removed --privileged mode and
replaced it with explicit device discovery — the /dev/accel* path for v4
was correct, but the VFIO path for v5p/v6e was not.

Matches the existing /dev/accel* enumeration pattern for v4.