### PR TITLE
[docs] Fix stale evaluation tutorial links

### DIFF
--- a/docs/explanations/evaluation.md
+++ b/docs/explanations/evaluation.md
@@ -3,8 +3,7 @@
 This document explains how Marin evaluates models and where to find runnable workflows.
 
 For step-by-step usage, start with:
-- [Running LM Evaluations](../tutorials/run-lm-evals.md) for multiple-choice and key eval suites.
-- [Running Alpaca Eval](../tutorials/run-alpaca-eval.md) for generation-focused Alpaca evaluation.
+- [Running Evaluations with Marin](../tutorials/run-lm-evals.md) for multiple-choice, generation, and key eval suites.
 - [Harbor Framework Integration](../harbor-integration.md) for Harbor-backed agent and benchmark evaluation.
 
 ## Evaluation modes
@@ -53,7 +52,7 @@ Generation tasks (for example AlpacaEval, HumanEval, GSM8K, and MATH) use a fast
 
 - Task and suite definitions are in [`task_configs.py`](https://github.com/marin-community/marin/blob/main/experiments/evals/task_configs.py).
 - A common entrypoint is [`run_key_evals.py`](https://github.com/marin-community/marin/blob/main/experiments/evals/run_key_evals.py).
-- Alpaca-specific setup is documented in [Running Alpaca Eval](../tutorials/run-alpaca-eval.md).
+- Current generation-eval setup is documented in [Running Evaluations with Marin](../tutorials/run-lm-evals.md).
 
 In current Marin workflows, generation evals are commonly run with `Dockerfile.vllm` or on a dedicated vLLM Ray cluster (for example [`marin-us-east5-b-vllm.yaml`](https://github.com/marin-community/marin/blob/main/infra/marin-us-east5-b-vllm.yaml)).
 
@@ -67,8 +66,7 @@ Harbor tasks use [`evaluate_harbor`](https://github.com/marin-community/marin/bl
 
 ## Where to go next
 
-- [Running LM Evaluations](../tutorials/run-lm-evals.md)
-- [Running Alpaca Eval](../tutorials/run-alpaca-eval.md)
+- [Running Evaluations with Marin](../tutorials/run-lm-evals.md)
 - [Harbor Framework Integration](../harbor-integration.md)
 - [`experiments/evals/evals.py`](https://github.com/marin-community/marin/blob/main/experiments/evals/evals.py)
 - [`experiments/evals/task_configs.py`](https://github.com/marin-community/marin/blob/main/experiments/evals/task_configs.py)


### PR DESCRIPTION
Replace dead run-alpaca-eval.md links in the evaluation overview with the current run-lm-evals.md tutorial so mkdocs strict builds stop failing on missing-doc warnings.

Fixes #3864