### PR TITLE
[iris] Revert to --privileged for TPU task containers

### DIFF
--- a/lib/iris/src/iris/cluster/runtime/docker.py
+++ b/lib/iris/src/iris/cluster/runtime/docker.py
@@ -151,6 +151,9 @@ def _build_device_flags(config: ContainerConfig) -> list[str]:
             [
                 "--privileged",
                 "--shm-size=100g",
+                "--cap-add=SYS_RESOURCE",
+                "--ulimit",
+                "memlock=68719476736:68719476736",
             ]
         )
         logger.info("TPU device flags: %s", flags)


### PR DESCRIPTION
The non-privileged device discovery from #3751/#3858 doesn't work because
_discover_tpu_device_mappings() runs inside the iris-worker container,
which has no access to /dev/vfio or /dev/accel*. Discovery finds nothing,
so task containers get zero --device flags and TPU init fails.

Revert to --privileged for TPU run containers (skipping no-new-privileges
and cap-drop ALL for those containers). Non-TPU task containers keep the
hardened defaults.

Proper fix is to bind-mount host device paths into the worker container
so discovery works without --privileged.