### PR TITLE
Fix Zephyr resource starvation regression from #3861

### DIFF
--- a/lib/fray/src/fray/v2/ray_backend/backend.py
+++ b/lib/fray/src/fray/v2/ray_backend/backend.py
@@ -318,8 +318,15 @@ class RayClient:
         else:
             num_gpus = 0
 
+        options: dict[str, Any] = {
+            "runtime_env": runtime_env,
+            "num_cpus": request.resources.cpu,
+        }
+        if request.resources.ram:
+            options["memory"] = humanfriendly.parse_size(request.resources.ram, binary=True)
+
         remote_fn = ray.remote(num_gpus=num_gpus, max_retries=compute_ray_retry_count(request))(entrypoint.callable)
-        ref = remote_fn.options(runtime_env=runtime_env).remote(*entrypoint.args, **entrypoint.kwargs)
+        ref = remote_fn.options(**options).remote(*entrypoint.args, **entrypoint.kwargs)
         job_id = f"ray-callable-{request.name}-{uuid.uuid4().hex[:8]}"
         return RayJobHandle(job_id, ref=ref)
 

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -1552,7 +1552,7 @@ class ZephyrContext:
                             _run_coordinator_job,
                             args=(config, result_path),
                         ),
-                        resources=ResourceConfig(cpu=1, ram="1g"),
+                        resources=ResourceConfig(cpu=0, ram="256m"),
                     )
                 )
 


### PR DESCRIPTION
## Summary

#3861 introduced a coordinator-as-job pattern where `_run_coordinator_job` runs as a Ray remote task that blocks waiting for child actors. This caused resource starvation on clusters with limited CPUs (including CI):

- **`_launch_callable_job` ignored `JobRequest.resources`** — it always used Ray's default of 1 CPU per task, regardless of what the caller requested.
- **The coordinator wrapper job requested `cpu=1`** despite doing no computation — it just blocks on `job.wait()`.

With 3+ concurrent Zephyr pipelines, the wrapper tasks consumed all available CPUs, preventing worker actors from being scheduled. Pipelines hung indefinitely with "0/0 workers alive".

<details>
<summary>Fixes</summary>

1. `_launch_callable_job` now passes `num_cpus` and `memory` from `request.resources` to `ray.remote().options()`.
2. The coordinator wrapper job requests `cpu=0, ram=256m` since it only blocks waiting for children.

</details>

## Test plan

- [ ] Integration test (`tests/integration_test.py`) no longer hangs on concurrent Zephyr pipelines
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)