### PR TITLE
Fix Ray host_actor() leaking coordinator actors

### DIFF
--- a/lib/fray/src/fray/v2/ray_backend/backend.py
+++ b/lib/fray/src/fray/v2/ray_backend/backend.py
@@ -365,9 +365,10 @@ class RayClient:
         actor_config: ActorConfig = ActorConfig(),
         **kwargs: Any,
     ) -> HostedActor:
-        """Ray cannot host actors in-process; falls back to create_actor."""
-        handle = self.create_actor(actor_class, *args, name=name, actor_config=actor_config, **kwargs)
-        return HostedActor(handle)
+        """Ray cannot host actors in-process; falls back to a single-actor group."""
+        group = self.create_actor_group(actor_class, *args, name=name, count=1, actor_config=actor_config, **kwargs)
+        handle = group.wait_ready()[0]
+        return HostedActor(handle, stop=group.shutdown)
 
     def create_actor(
         self,


### PR DESCRIPTION
## Summary

- Fix `RayClient.host_actor()` leaking coordinator actors on Ray by returning a `HostedActor` with a real shutdown callback (`group.shutdown`) instead of `None`
- Root cause: `#3861` switched Zephyr to `host_actor()` + `hosted.shutdown()` for coordinator lifecycle, but on Ray the fallback created a bare actor with no cleanup hook — leaked coordinators consumed all CPUs, starving worker scheduling

Fixes #3877

## Test plan

- [x] Reproduced the hang on unpatched `main`: integration test stalls at `0/0 workers alive` on the second Zephyr pipeline
- [x] Applied fix and re-ran integration test end-to-end: completes successfully with no stall
- [x] Fray v2 unit tests pass (54/54)
- [x] Zephyr execution/backend tests pass (34/34 before interrupted — all green, rerunning)
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)