### PR TITLE
[levanter] Improve Grug Muon MoE orthogonalization

### DIFF
--- a/lib/levanter/src/levanter/optim/grugmuon.py
+++ b/lib/levanter/src/levanter/optim/grugmuon.py
@@ -9,18 +9,96 @@ All 2D arrays are routed to Muon, except those whose path contains
 'embed', 'lm_head', or 'output' (case-insensitive), which use AdamW.
 """
 
+import math
 from dataclasses import dataclass
 from functools import partial
 
 import jax
 import jax.numpy as jnp
 import optax
+from jax.sharding import PartitionSpec
 from optax import tree_utils as otu
 
 from levanter.optim.config import OptimizerConfig
 from levanter.optim.muon import MuonConfig, ScaleByMuonState
 from levanter.optim.util import NEWTON_SCHULZ_COEFFICIENTS, CoefficientType
 from levanter.utils.jax_utils import leaf_key_paths
+
+VMAP_REPLICATED = "vmap_replicated"
+STACK_BATCH_SHARDED = "stack_batch_sharded"
+ORTHOGONALIZATION_LAYOUTS = (VMAP_REPLICATED, STACK_BATCH_SHARDED)
+
+
+def _target_sharding(array) -> jax.sharding.Sharding | None:
+    if array is None or not hasattr(array, "shape"):
+        return None
+
+    sharding = getattr(array, "sharding", None)
+    if sharding is not None:
+        return sharding
+
+    aval = jax.typeof(array)
+    return getattr(aval, "sharding", None)
+
+
+def _partition_spec(array) -> PartitionSpec | None:
+    sharding = _target_sharding(array)
+    if sharding is None:
+        return None
+    return getattr(sharding, "spec", None)
+
+
+def _clear_mesh_axes(partition, axes_to_clear: frozenset[str]):
+    if partition is None:
+        return None
+    if isinstance(partition, tuple):
+        kept_axes = tuple(axis for axis in partition if axis not in axes_to_clear)
+        if not kept_axes:
+            return None
+        if len(kept_axes) == 1:
+            return kept_axes[0]
+        return kept_axes
+    if partition in axes_to_clear:
+        return None
+    return partition
+
+
+def _orthogonalization_target_pspec(
+    array,
+    *,
+    axes_to_clear: frozenset[str] = frozenset({"data", "model"}),
+    drop_leading_dims: int = 0,
+) -> PartitionSpec | None:
+    pspec = _partition_spec(array)
+    if pspec is None:
+        return None
+
+    partitions = tuple(pspec)
+    if drop_leading_dims:
+        partitions = partitions[drop_leading_dims:]
+    return PartitionSpec(*(_clear_mesh_axes(partition, axes_to_clear) for partition in partitions))
+
+
+def _batch_sharded_stack_target_pspec(array) -> PartitionSpec | None:
+    if array is None or not hasattr(array, "shape") or array.ndim != 3:
+        return None
+
+    mesh = jax.sharding.get_abstract_mesh()
+    if mesh.empty:
+        return None
+
+    mesh_shape = tuple((axis_name, axis_size) for axis_name, axis_size in mesh.shape.items() if axis_size > 1)
+    if not mesh_shape:
+        return None
+
+    batch_axis = tuple(axis_name for axis_name, _ in mesh_shape)
+    batch_shards = math.prod(axis_size for _, axis_size in mesh_shape)
+    if array.shape[0] % batch_shards != 0:
+        return None
+
+    if len(batch_axis) == 1:
+        return PartitionSpec(batch_axis[0], None, None)
+    return PartitionSpec(batch_axis, None, None)
 
 
 @OptimizerConfig.register_subclass("grug_muon")
@@ -54,6 +132,7 @@ class GrugMuonConfig(MuonConfig):
                 if self.weight_decay > 0:
                     components.append(optax.add_decayed_weights(self.weight_decay, self.build_weight_decay_mask()))
                 components.append(optax.scale(-learning_rate))
+                components.append(_match_update_sharding())
                 return optax.chain(*components)
 
             def adamw_transform():
@@ -88,6 +167,8 @@ class GrugMuonConfig(MuonConfig):
                 return "adamw"
             elif hasattr(param, "ndim") and param.ndim == 2:
                 return "muon"
+            elif hasattr(param, "ndim") and param.ndim == 3 and ("w_up_gate" in path_lower or "w_down" in path_lower):
+                return "muon"
             else:
                 return "adamw"
 
@@ -95,10 +176,21 @@ class GrugMuonConfig(MuonConfig):
 
 
 def _grug_scale_with_muon(
-    momentum=0.95, nesterov=True, steps=5, muon_eps=1e-8, use_kimi_scaling=False, coefficient_type="quintic"
+    momentum=0.95,
+    nesterov=True,
+    steps=5,
+    muon_eps=1e-8,
+    use_kimi_scaling=False,
+    coefficient_type="quintic",
+    orthogonalization_layout: str = STACK_BATCH_SHARDED,
 ):
-    """Muon gradient transformation for raw 2D JAX arrays in (fan_in, fan_out) layout."""
+    """Muon gradient transformation for raw arrays with matrix-shaped trailing dimensions."""
     steps = int(steps)
+    if orthogonalization_layout not in ORTHOGONALIZATION_LAYOUTS:
+        raise ValueError(
+            f"Unknown orthogonalization_layout={orthogonalization_layout!r}. "
+            f"Expected one of {ORTHOGONALIZATION_LAYOUTS!r}."
+        )
 
     def init_fn(params):
         momentum_buffer = otu.tree_zeros_like(params)
@@ -122,12 +214,50 @@ def _grug_scale_with_muon(
         else:
             updates = buf
 
-        def transform_array(x):
-            if not hasattr(x, "ndim") or x.ndim != 2:
+        def transform_array(x, param):
+            if not hasattr(x, "ndim") or x.ndim not in (2, 3):
                 return x
-            updated = _zeropower_via_newtonschulz(x, steps=steps, eps=muon_eps, coefficient_type=coefficient_type)
-            # Layout is (fan_in, fan_out)
-            fan_in, fan_out = updated.shape
+            if x.ndim == 2:
+                updated = _zeropower_via_newtonschulz_replicated(
+                    x,
+                    steps,
+                    muon_eps,
+                    coefficient_type,
+                    None,
+                )
+            else:
+                if orthogonalization_layout == VMAP_REPLICATED:
+                    updated = jax.vmap(
+                        lambda matrix: _zeropower_via_newtonschulz_replicated(
+                            matrix,
+                            steps,
+                            muon_eps,
+                            coefficient_type,
+                            None,
+                        )
+                    )(x)
+                else:
+                    stack_target_pspec = _batch_sharded_stack_target_pspec(param)
+                    if stack_target_pspec is None:
+                        updated = jax.vmap(
+                            lambda matrix: _zeropower_via_newtonschulz_replicated(
+                                matrix,
+                                steps,
+                                muon_eps,
+                                coefficient_type,
+                                None,
+                            )
+                        )(x)
+                    else:
+                        updated = _zeropower_via_newtonschulz_batched_stack_sharded(
+                            x,
+                            steps,
+                            muon_eps,
+                            coefficient_type,
+                            stack_target_pspec,
+                        )
+
+            fan_in, fan_out = updated.shape[-2:]
             if not use_kimi_scaling:
                 scale = jnp.sqrt(jnp.maximum(1, fan_out / fan_in))
             else:
@@ -135,29 +265,109 @@ def _grug_scale_with_muon(
             updated *= scale
             return updated
 
-        updates = jax.tree.map(transform_array, updates)
+        if params is None:
+            updates = jax.tree.map(lambda x: transform_array(x, None), updates)
+        else:
+            updates = jax.tree.map(transform_array, updates, params)
 
         return updates, ScaleByMuonState(momentum_buffer=buf)
 
     return optax.GradientTransformation(init_fn, update_fn)
 
 
-def _zeropower_via_newtonschulz(X, steps: int = 5, eps: float = 1e-7, coefficient_type: CoefficientType = "quintic"):
-    """Newton-Schulz iteration to orthogonalize X.
+def _match_update_sharding():
+    """Ensure updates inherit the parameter sharding expected by apply_updates."""
+
+    def init_fn(params):
+        del params
+        return optax.EmptyState()
+
+    def update_fn(updates, state, params=None):
+        if params is None:
+            return updates, state
+
+        def match_sharding(update, param):
+            if update is None:
+                return None
+            target_sharding = _target_sharding(param)
+            if target_sharding is None:
+                return update
+            return jax.sharding.reshard(update, target_sharding)
+
+        updates = jax.tree.map(match_sharding, updates, params, is_leaf=lambda x: x is None)
+        return updates, state
+
+    return optax.GradientTransformation(init_fn, update_fn)
+
+
+def _zeropower_via_newtonschulz_preserve_sharding(
+    X: jax.Array,
+    steps: int = 5,
+    eps: float = 1e-7,
+    coefficient_type: CoefficientType = "quintic",
+    target_pspec: PartitionSpec | None = None,
+) -> jax.Array:
+    """Orthogonalize X without fully replicating it first.
+
+    The legacy Grug Muon path resharded each 2D update to ``P(None, None)``
+    before Newton-Schulz, which can introduce a full all-gather per matrix on
+    sharded TPU runs. Instead, reshard only to the contraction-friendly layout
+    used by the iteration and let the caller restore the final parameter layout.
+    """
+    from jax.sharding import PartitionSpec as P, reshard
+
+    coeffs = NEWTON_SCHULZ_COEFFICIENTS[coefficient_type]
+    has_mesh = not jax.sharding.get_abstract_mesh().empty
+    X = X / (jnp.linalg.norm(X) + eps)
+
+    transpose = False
+    if X.shape[0] > X.shape[1]:
+        X = X.T
+        transpose = True
+
+    if target_pspec is None:
+        target_pspec = _orthogonalization_target_pspec(X)
+
+    if has_mesh and target_pspec is not None:
+        X = reshard(X, target_pspec)
+
+    gram_out_sharding = P(None, None) if has_mesh else None
+    X_out_sharding = target_pspec if (has_mesh and target_pspec is not None) else gram_out_sharding
+    for i in range(steps):
+        a, b, c = coeffs[i % len(coeffs)]
+        A = jnp.einsum("ik,jk->ij", X, X, out_sharding=gram_out_sharding)
+        B = b * A + c * jnp.einsum("ik,kj->ij", A, A, out_sharding=gram_out_sharding)
+        X = a * X + jnp.einsum("ik,kj->ij", B, X, out_sharding=X_out_sharding)
+
+    if transpose:
+        X = X.T
+
+    return X
+
+
+def _zeropower_via_newtonschulz_replicated(
+    X: jax.Array,
+    steps: int = 5,
+    eps: float = 1e-7,
+    coefficient_type: CoefficientType = "quintic",
+    target_pspec: PartitionSpec | None = None,
+) -> jax.Array:
+    """Legacy Grug Muon orthogonalization that fully replicates each matrix.
 
     Replicates the array across devices before iterating to avoid sharding
-    ambiguities in the X @ X.T contractions, then reshards back to the
-    original sharding.
+    ambiguities in the X @ X.T contractions. The caller is responsible for
+    restoring the final parameter layout. Kept for A/B benchmarking.
     """
     from jax.sharding import PartitionSpec as P, reshard
 
     assert X.ndim == 2
-
-    orig_sharding = X.sharding if hasattr(X, "sharding") else None
-    X = reshard(X, P(None, None))
+    del target_pspec
 
     coeffs = NEWTON_SCHULZ_COEFFICIENTS[coefficient_type]
-    X /= jnp.linalg.norm(X) + eps
+    has_mesh = not jax.sharding.get_abstract_mesh().empty
+    if has_mesh:
+        X = reshard(X, P(None, None))
+    X = X / (jnp.linalg.norm(X) + eps)
 
     transpose = False
     if X.shape[0] > X.shape[1]:
@@ -166,14 +376,52 @@ def _zeropower_via_newtonschulz(X, steps: int = 5, eps: float = 1e-7, coefficien
 
     for i in range(steps):
         a, b, c = coeffs[i % len(coeffs)]
-        A = X @ X.T
-        B = b * A + c * A @ A
-        X = a * X + B @ X
+        out_sharding = P(None, None) if has_mesh else None
+        A = jnp.einsum("ik,jk->ij", X, X, out_sharding=out_sharding)
+        B = b * A + c * jnp.einsum("ik,kj->ij", A, A, out_sharding=out_sharding)
+        X = a * X + jnp.einsum("ik,kj->ij", B, X, out_sharding=out_sharding)
 
     if transpose:
         X = X.T
 
-    if orig_sharding is not None:
-        X = reshard(X, orig_sharding)
+    return X
+
+
+def _zeropower_via_newtonschulz_batched_stack_sharded(
+    X: jax.Array,
+    steps: int = 5,
+    eps: float = 1e-7,
+    coefficient_type: CoefficientType = "quintic",
+    target_pspec: PartitionSpec | None = None,
+) -> jax.Array:
+    """Run Newton-Schulz on a stacked batch of matrices with only the batch axis sharded."""
+    from jax.sharding import reshard
+
+    assert X.ndim == 3
+
+    coeffs = NEWTON_SCHULZ_COEFFICIENTS[coefficient_type]
+    has_mesh = not jax.sharding.get_abstract_mesh().empty
+    X = X / (jnp.linalg.norm(X, axis=(-2, -1), keepdims=True) + eps)
+
+    transpose = False
+    if X.shape[-2] > X.shape[-1]:
+        X = jnp.swapaxes(X, -1, -2)
+        transpose = True
+
+    if target_pspec is None:
+        target_pspec = _batch_sharded_stack_target_pspec(X)
+
+    if has_mesh and target_pspec is not None:
+        X = reshard(X, target_pspec)
+
+    X_out_sharding = target_pspec if (has_mesh and target_pspec is not None) else None
+    for i in range(steps):
+        a, b, c = coeffs[i % len(coeffs)]
+        A = jnp.einsum("...ik,...jk->...ij", X, X, out_sharding=X_out_sharding)
+        B = b * A + c * jnp.einsum("...ik,...kj->...ij", A, A, out_sharding=X_out_sharding)
+        X = a * X + jnp.einsum("...ik,...kj->...ij", B, X, out_sharding=X_out_sharding)
+
+    if transpose:
+        X = jnp.swapaxes(X, -1, -2)
 
     return X

--- a/lib/levanter/tests/test_grugmuon.py
+++ b/lib/levanter/tests/test_grugmuon.py
@@ -1,0 +1,87 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+
+from levanter.optim.grugmuon import (
+    GrugMuonConfig,
+    STACK_BATCH_SHARDED,
+    VMAP_REPLICATED,
+    _grug_scale_with_muon,
+    _zeropower_via_newtonschulz_batched_stack_sharded,
+    _zeropower_via_newtonschulz_replicated,
+)
+
+
+def test_grug_scale_with_muon_orthogonalizes_matrix_trailing_dims():
+    updates = {
+        "matrix": jnp.ones((2, 3), dtype=jnp.float32),
+        "moe_tensor": jnp.ones((2, 2, 2), dtype=jnp.float32),
+        "vector": jnp.ones((3,), dtype=jnp.float32),
+    }
+    transform = _grug_scale_with_muon(
+        momentum=0.0,
+        nesterov=False,
+        use_kimi_scaling=False,
+        orthogonalization_layout=VMAP_REPLICATED,
+    )
+
+    new_updates, _ = transform.update(updates, transform.init(updates))
+
+    assert new_updates["matrix"].shape == updates["matrix"].shape
+    assert new_updates["moe_tensor"].shape == updates["moe_tensor"].shape
+    assert not jnp.array_equal(new_updates["matrix"], updates["matrix"])
+    assert not jnp.array_equal(new_updates["moe_tensor"], updates["moe_tensor"])
+    assert jnp.array_equal(new_updates["vector"], updates["vector"])
+
+
+def test_grug_muon_mask_routes_stacked_expert_weights_to_muon():
+    params = {
+        "embed": jnp.ones((16, 8), dtype=jnp.float32),
+        "router": jnp.ones((8, 4), dtype=jnp.float32),
+        "moe": {
+            "w_up_gate": jnp.ones((4, 8, 16), dtype=jnp.float32),
+            "w_down": jnp.ones((4, 16, 8), dtype=jnp.float32),
+        },
+        "vector": jnp.ones((8,), dtype=jnp.float32),
+    }
+
+    mask = GrugMuonConfig().create_mask(params)
+
+    assert mask["embed"] == "adamw"
+    assert mask["router"] == "muon"
+    assert mask["moe"]["w_up_gate"] == "muon"
+    assert mask["moe"]["w_down"] == "muon"
+    assert mask["vector"] == "adamw"
+
+
+def test_batched_stack_sharded_matches_vmap_replicated_without_mesh():
+    x = jnp.arange(2 * 3 * 4, dtype=jnp.float32).reshape(2, 3, 4)
+
+    expected = jax.vmap(
+        lambda matrix: _zeropower_via_newtonschulz_replicated(matrix, steps=2, eps=1e-7, coefficient_type="quintic")
+    )(x)
+    actual = _zeropower_via_newtonschulz_batched_stack_sharded(
+        x,
+        steps=2,
+        eps=1e-7,
+        coefficient_type="quintic",
+    )
+
+    assert jnp.allclose(actual, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_grug_scale_with_muon_stack_batch_sharded_handles_stacked_expert_tensor():
+    updates = {"moe_tensor": jnp.arange(2 * 3 * 4, dtype=jnp.float32).reshape(2, 3, 4)}
+    transform = _grug_scale_with_muon(
+        momentum=0.0,
+        nesterov=False,
+        use_kimi_scaling=False,
+        orthogonalization_layout=STACK_BATCH_SHARDED,
+    )
+
+    new_updates, _ = transform.update(updates, transform.init(updates))
+
+    assert new_updates["moe_tensor"].shape == updates["moe_tensor"].shape
+    assert not jnp.array_equal(new_updates["moe_tensor"], updates["moe_tensor"])


### PR DESCRIPTION
Improve Grug Muon to cover stacked MoE expert weights, batch Newton-Schulz over expert stacks, and restore update sharding exactly once at the optimizer boundary. Adds focused regression tests for the new MoE update path.

Part of #3469