### PR TITLE
Fix kwargs in sync Iris actor RPCs

### DIFF
--- a/lib/iris/src/iris/actor/server.py
+++ b/lib/iris/src/iris/actor/server.py
@@ -10,6 +10,7 @@ Example:
 """
 
 import asyncio
+import functools
 import inspect
 import logging
 import socket
@@ -150,7 +151,7 @@ class ActorServer:
             # We use our own executor instead of asyncio.to_thread() to avoid issues
             # when asyncio's default executor is shut down during process cleanup.
             loop = asyncio.get_running_loop()
-            result = await loop.run_in_executor(self._executor, method, *args, **kwargs)
+            result = await loop.run_in_executor(self._executor, functools.partial(method, *args, **kwargs))
 
             return actor_pb2.ActorResponse(serialized_value=cloudpickle.dumps(result))
 

--- a/lib/iris/tests/actor/test_actor_e2e.py
+++ b/lib/iris/tests/actor/test_actor_e2e.py
@@ -21,6 +21,9 @@ class Calculator:
     def divide(self, a: int, b: int) -> float:
         return a / b  # May raise ZeroDivisionError
 
+    def increment(self, value: int, *, amount: int = 1) -> int:
+        return value + amount
+
 
 def test_basic_actor_call():
     """Test basic actor method calls work correctly."""
@@ -33,6 +36,20 @@ def test_basic_actor_call():
         client = ActorClient(resolver, "calc")
         assert client.add(2, 3) == 5
         assert client.multiply(4, 5) == 20
+    finally:
+        server.stop()
+
+
+def test_actor_call_with_kwargs():
+    """Test actor method calls preserve keyword arguments."""
+    server = ActorServer(host="127.0.0.1")
+    server.register("calc", Calculator())
+    port = server.serve_background()
+
+    try:
+        resolver = FixedResolver({"calc": f"http://127.0.0.1:{port}"})
+        client = ActorClient(resolver, "calc")
+        assert client.increment(2, amount=3) == 5
     finally:
         server.stop()
 


### PR DESCRIPTION
## Summary

Fix sync Iris actor RPCs when kwargs are used.

`ActorServer.call()` was passing `**kwargs` directly to `asyncio.run_in_executor()`, which only accepts positional arguments. That caused sync actor RPCs to fail before the target method ran.

## Changes

- wrap sync actor calls with `functools.partial(method, *args, **kwargs)` before passing them to `run_in_executor()`
- add a regression test covering sync actor RPCs with keyword arguments

## Validation

### Red before fix

```bash
PYTHONPATH="$PWD/lib/fray/src:$PWD/lib/iris/src:$PWD/lib/haliax/src:$PWD/lib/levanter/src:$PWD/lib/marin/src:$PWD/lib/zephyr/src" \
/home/ubuntu/dev/marin/.venv/bin/python -m pytest \
tests/rl/integration/test_iris_integration.py::test_curriculum_via_iris_under_ray \
-o "addopts=" -vv -s
```

Failed with:

```text
TypeError: run_in_executor() got an unexpected keyword argument 'seed'
```

### Green after fix

Same command passed: `1 passed, 1 warning in 28.60s`

### Regression coverage

```bash
PYTHONPATH="$PWD/lib/fray/src:$PWD/lib/iris/src:$PWD/lib/haliax/src:$PWD/lib/levanter/src:$PWD/lib/marin/src:$PWD/lib/zephyr/src" \
/home/ubuntu/dev/marin/.venv/bin/python -m pytest lib/iris/tests/actor -o "addopts=" -vv
```

Passed: `15 passed in 5.51s`
