### PR TITLE
[levanter] Fix fused CE autotune crash from shard_map manual sharding assertion

### DIFF
--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
@@ -12,7 +12,6 @@ import warnings
 import jax
 from jax import core as jax_core
 import jax.numpy as jnp
-from jax.sharding import NamedSharding
 from jaxtyping import Array, Float, Int
 
 from levanter.kernels.pallas import autotune_cache_utils
@@ -112,59 +111,6 @@ def _warn_pallas_fallback_once(exc: Exception) -> None:
 def _is_tpu_vmem_compile_error(exc: Exception) -> bool:
     message = str(exc).lower()
     return "resource_exhausted" in message and "vmem" in message
-
-
-def _sharding_of(value: jax.Array):
-    sharding = None
-    try:
-        sharding = value.sharding  # type: ignore[attr-defined]
-    except Exception:
-        sharding = None
-    if sharding is not None:
-        return sharding
-
-    aval = getattr(value, "aval", None)
-    if aval is None:
-        return None
-    return getattr(aval, "sharding", None)
-
-
-def _named_sharding_of(value: jax.Array) -> NamedSharding | None:
-    sharding = _sharding_of(value)
-    if isinstance(sharding, NamedSharding):
-        return sharding
-    return None
-
-
-def _shape_dtype_struct_with_sharding(value: jax.Array) -> jax.ShapeDtypeStruct:
-    sharding = _sharding_of(value)
-    if sharding is None:
-        return jax.ShapeDtypeStruct(value.shape, value.dtype)
-    return jax.ShapeDtypeStruct(value.shape, value.dtype, sharding=sharding)
-
-
-def _maybe_wrap_loss_in_shard_map_for_benchmark(
-    fn: Callable[[jax.Array, jax.Array, jax.Array], jax.Array],
-    *,
-    x: jax.Array,
-    labels: jax.Array,
-    w: jax.Array,
-) -> Callable[[jax.Array, jax.Array, jax.Array], jax.Array]:
-    x_sharding = _named_sharding_of(x)
-    labels_sharding = _named_sharding_of(labels)
-    w_sharding = _named_sharding_of(w)
-    if x_sharding is None or labels_sharding is None or w_sharding is None:
-        return fn
-    if x_sharding.mesh != labels_sharding.mesh or x_sharding.mesh != w_sharding.mesh:
-        return fn
-
-    return jax.shard_map(
-        fn,
-        mesh=x_sharding.mesh,
-        in_specs=(x_sharding.spec, labels_sharding.spec, w_sharding.spec),
-        out_specs=labels_sharding.spec,
-        check_vma=False,
-    )
 
 
 def _warn_vmem_compile_fallback_once(exc: Exception, *, impl_name: str) -> None:
@@ -410,18 +356,12 @@ def _benchmark_block_sizes_candidate(
         out = fn(x_value, labels_value, w_value, **kwargs)
         return out[0]
 
-    benchmark_fn = _maybe_wrap_loss_in_shard_map_for_benchmark(
-        _loss_only,
-        x=x,
-        labels=labels,
-        w=w,
-    )
-    jitted = jax.jit(benchmark_fn)
+    jitted = jax.jit(_loss_only)
 
     abstract_args = (
-        _shape_dtype_struct_with_sharding(x),
-        _shape_dtype_struct_with_sharding(labels),
-        _shape_dtype_struct_with_sharding(w),
+        jax.ShapeDtypeStruct(x.shape, x.dtype),
+        jax.ShapeDtypeStruct(labels.shape, labels.dtype),
+        jax.ShapeDtypeStruct(w.shape, w.dtype),
     )
     start = time.perf_counter()
     lowered = jitted.lower(*abstract_args)

--- a/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
+++ b/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
@@ -974,49 +974,6 @@ def test_pallas_autotune_skipped_when_tuned_match_exists(monkeypatch: pytest.Mon
     assert seen_block_sizes == [inferred]
 
 
-def test_autotune_benchmark_wraps_in_shard_map_when_named_sharding_present(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    x = jnp.ones((4, 8), dtype=jnp.float32)
-    w = jnp.ones((8, 16), dtype=jnp.float32)
-    y = jnp.zeros((4,), dtype=jnp.int32)
-
-    mesh = object()
-    x_sharding = type("FakeNamedSharding", (), {"mesh": mesh, "spec": ("data", None)})()
-    y_sharding = type("FakeNamedSharding", (), {"mesh": mesh, "spec": ("data",)})()
-    w_sharding = type("FakeNamedSharding", (), {"mesh": mesh, "spec": (None, "model")})()
-
-    def fake_named_sharding_of(value):
-        if value is x:
-            return x_sharding
-        if value is y:
-            return y_sharding
-        if value is w:
-            return w_sharding
-        return None
-
-    calls: list[tuple[object, tuple[object, ...], object, bool]] = []
-
-    def fake_shard_map(fn, *, mesh, in_specs, out_specs, check_vma):
-        calls.append((mesh, in_specs, out_specs, check_vma))
-        return fn
-
-    monkeypatch.setattr(fused_api.jax, "default_backend", lambda: "gpu")
-    monkeypatch.setattr(fused_api, "_named_sharding_of", fake_named_sharding_of)
-    monkeypatch.setattr(fused_api.jax, "shard_map", fake_shard_map)
-
-    wrapped = fused_api._maybe_wrap_loss_in_shard_map_for_benchmark(
-        lambda x_value, labels_value, w_value: x_value[:, 0] + labels_value.astype(x_value.dtype) + w_value[0, 0],
-        x=x,
-        labels=y,
-        w=w,
-    )
-
-    out = wrapped(x, y, w)
-    assert out.shape == (4,)
-    assert calls == [(mesh, (x_sharding.spec, y_sharding.spec, w_sharding.spec), y_sharding.spec, False)]
-
-
 def test_pallas_tpu_vmem_compile_error_falls_back_to_xla_when_requested(monkeypatch: pytest.MonkeyPatch):
     x = jnp.ones((4, 8), dtype=jnp.float32)
     w = jnp.ones((8, 16), dtype=jnp.float32)


### PR DESCRIPTION
Remove shard_map wrapping and sharding-aware ShapeDtypeStruct from the
fused cross-entropy autotune benchmark path. The shard_map wrapper added
in #3669 causes JAX 0.8's get_num_ways_dim_sharded to hit
assert not hlo_sharding.is_manual() during autotune lowering, killing all
TPU canary runs since Mar 15 (last success: Mar 14, grug-train-canary-tpu
job 23283565012).

Block-size autotuning only needs shape/dtype/device to select the fastest
candidate; sharding context is irrelevant. Reverts the benchmark to plain
ShapeDtypeStruct(shape, dtype) and jax.jit (pre-#3669 behavior). Deletes
_sharding_of, _named_sharding_of, _shape_dtype_struct_with_sharding,
_maybe_wrap_loss_in_shard_map_for_benchmark, and the associated test.

All 61 fused CE tests pass (12 skipped, TPU-only).

Part of #3504