### PR TITLE
Make memray import optional in profile tests

### DIFF
--- a/lib/iris/tests/cluster/runtime/test_profile.py
+++ b/lib/iris/tests/cluster/runtime/test_profile.py
@@ -11,6 +11,8 @@ import os
 
 import pytest
 
+memray = pytest.importorskip("memray")
+
 from iris.cluster.runtime.profile import (
     _run_memray_profile,
     build_memray_attach_cmd,


### PR DESCRIPTION
Make the memray dependency optional in the profile test module by using pytest.importorskip. This allows the test module to be imported and other tests to run even when memray is not installed, rather than failing at import time.

The change moves the memray import to use pytest.importorskip before the module imports that depend on it, ensuring tests requiring memray are skipped gracefully when the package is unavailable.
