### PR TITLE
[zephyr] Split tests into functional (local-only) and integration (all backends)

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -549,7 +549,7 @@ class ZephyrCoordinator:
         self._worker_handles: dict[str, ActorHandle] = {}
         self._worker_group: Any = None  # ActorGroup, set via set_worker_group()
         self._coordinator_thread: threading.Thread | None = None
-        self._shutdown: bool = False
+        self._shutdown_event = threading.Event()
         self._is_last_stage: bool = False
         self._initialized: bool = False
         self._pipeline_running: bool = False
@@ -621,7 +621,7 @@ class ZephyrCoordinator:
         """Background loop for heartbeat checking and worker job monitoring."""
         last_log_time = 0.0
 
-        while not self._shutdown:
+        while not self._shutdown_event.is_set():
             self.check_heartbeats()
             self._check_worker_group()
 
@@ -630,7 +630,7 @@ class ZephyrCoordinator:
                 self._log_status()
                 last_log_time = now
 
-            time.sleep(0.5)
+            self._shutdown_event.wait(timeout=0.5)
 
     def _check_worker_group(self) -> None:
         """Abort the pipeline if the worker job has permanently terminated."""
@@ -695,7 +695,7 @@ class ZephyrCoordinator:
             self._last_seen[worker_id] = time.monotonic()
             self._worker_states[worker_id] = WorkerState.READY
 
-            if self._shutdown:
+            if self._shutdown_event.is_set():
                 self._worker_states[worker_id] = WorkerState.DEAD
                 return "SHUTDOWN"
 
@@ -775,7 +775,7 @@ class ZephyrCoordinator:
                 retries=self._retries,
                 in_flight=len(self._in_flight),
                 queue_depth=len(self._task_queue),
-                done=self._shutdown,
+                done=self._shutdown_event.is_set(),
                 fatal_error=self._fatal_error,
                 workers={
                     wid: {
@@ -817,11 +817,12 @@ class ZephyrCoordinator:
 
     def _wait_for_stage(self) -> None:
         """Block until current stage completes or error occurs."""
-        backoff = ExponentialBackoff(initial=0.05, maximum=1.0)
+        backoff = ExponentialBackoff(initial=0.1, maximum=1.0)
         last_log_completed = -1
         start_time = time.monotonic()
         all_dead_since: float | None = None
         no_workers_timeout = self._no_workers_timeout
+        stage_done = threading.Event()
 
         while True:
             with self._lock:
@@ -865,7 +866,7 @@ class ZephyrCoordinator:
                 last_log_completed = completed
                 backoff.reset()
 
-            time.sleep(backoff.next_interval())
+            stage_done.wait(timeout=backoff.next_interval())
 
     def _collect_results(self) -> dict[int, TaskResult]:
         """Return results for the completed stage."""
@@ -985,7 +986,7 @@ class ZephyrCoordinator:
     def shutdown(self) -> None:
         """Signal workers to exit. Worker group is managed by ZephyrContext."""
         logger.info("[coordinator.shutdown] Starting shutdown")
-        self._shutdown = True
+        self._shutdown_event.set()
 
         # Wait for coordinator thread to exit
         if self._coordinator_thread is not None:
@@ -1022,7 +1023,7 @@ class ZephyrCoordinator:
 
     def signal_done(self) -> None:
         """Signal workers that no more stages will be submitted (legacy compat)."""
-        self._shutdown = True
+        self._shutdown_event.set()
 
 
 # ---------------------------------------------------------------------------
@@ -1141,7 +1142,7 @@ class ZephyrWorker:
     def _poll_loop(self, coordinator: ActorHandle) -> None:
         """Pure polling loop. Exits on SHUTDOWN signal, coordinator death, or shutdown event."""
         task_count = 0
-        backoff = ExponentialBackoff(initial=0.05, maximum=1.0)
+        backoff = ExponentialBackoff(initial=0.1, maximum=1.0)
 
         future: ActorFuture | None = None
         future_start = 0.0

--- a/lib/zephyr/tests/conftest.py
+++ b/lib/zephyr/tests/conftest.py
@@ -14,6 +14,8 @@ import traceback
 import warnings
 from pathlib import Path
 
+from iris.time_utils import ExponentialBackoff
+
 # Disable Ray's automatic UV runtime env propagation BEFORE importing ray.
 # This prevents Ray from packaging the entire working directory (~38MB) for actors.
 os.environ["RAY_ENABLE_UV_RUN_RUNTIME_ENV"] = "0"
@@ -63,10 +65,38 @@ def ray_cluster():
     # Don't shutdown - Ray will be reused across test sessions
 
 
-@pytest.fixture(params=["local", "iris", "ray"], scope="module")
-def fray_client(request):
+# --- Local-only fixtures (functional tests) ---
+
+
+@pytest.fixture(scope="session")
+def local_client():
+    client = LocalClient()
+    yield client
+    client.shutdown(wait=True)
+
+
+@pytest.fixture(scope="session")
+def zephyr_ctx(local_client, tmp_path_factory):
+    """Local-only ZephyrContext for functional tests."""
+    tmp_path = tmp_path_factory.mktemp("zephyr")
+    ctx = ZephyrContext(
+        client=local_client,
+        max_workers=2,
+        resources=ResourceConfig(cpu=1, ram="512m"),
+        chunk_storage_prefix=str(tmp_path / "chunks"),
+        name="test-ctx",
+    )
+    yield ctx
+
+
+# --- Multi-backend fixtures (integration tests) ---
+
+
+@pytest.fixture(params=["local", "iris", "ray"], scope="session")
+def integration_client(request):
     """Parametrized fixture providing Local, Iris, and Ray clients.
 
+    Session-scoped to reuse clusters across all test modules.
     Fixtures are requested lazily to avoid initializing Ray when running
     Iris tests (and vice-versa), since ray.is_initialized() being true
     causes current_client() auto-detection to pick Ray.
@@ -83,7 +113,6 @@ def fray_client(request):
         iris_client = IrisClient.remote(iris_cluster, workspace=ZEPHYR_ROOT)
         client = FrayIrisClient.from_iris_client(iris_client)
 
-        # Set up IrisContext so actor handles can resolve
         ctx = IrisContext(job_id=JobName.root("test-user", "test"), client=iris_client)
         with iris_ctx_scope(ctx):
             yield client
@@ -95,6 +124,20 @@ def fray_client(request):
         client.shutdown(wait=True)
     else:
         raise ValueError(f"Unknown backend: {request.param}")
+
+
+@pytest.fixture(scope="session")
+def integration_ctx(integration_client, tmp_path_factory):
+    """ZephyrContext on all backends for integration tests."""
+    tmp_path = tmp_path_factory.mktemp("zephyr-integration")
+    ctx = ZephyrContext(
+        client=integration_client,
+        max_workers=2,
+        resources=ResourceConfig(cpu=1, ram="512m"),
+        chunk_storage_prefix=str(tmp_path / "chunks"),
+        name="test-integration",
+    )
+    yield ctx
 
 
 @pytest.fixture
@@ -113,24 +156,6 @@ def actor_context():
 def sample_data():
     """Sample data for testing."""
     return list(range(1, 11))  # [1, 2, 3, ..., 10]
-
-
-@pytest.fixture(scope="module")
-def zephyr_ctx(fray_client, tmp_path_factory):
-    """ZephyrContext running on all backends with temp chunk storage.
-
-    Module-scoped to reuse coordinator/workers across tests in the same file.
-    """
-    tmp_path = tmp_path_factory.mktemp("zephyr")
-    chunk_prefix = str(tmp_path / "chunks")
-    ctx = ZephyrContext(
-        client=fray_client,
-        max_workers=2,
-        resources=ResourceConfig(cpu=1, ram="512m"),
-        chunk_storage_prefix=chunk_prefix,
-        name="test-ctx",
-    )
-    yield ctx
 
 
 class CallCounter:
@@ -169,6 +194,20 @@ def _configure_marin_prefix():
         del os.environ["MARIN_PREFIX"]
 
 
+# Thread name prefixes for infrastructure threads managed by session-scoped
+# clusters (iris, ray, fray). These persist across tests and are not leaks.
+_INFRA_THREAD_PREFIXES = (
+    "worker-server",
+    "worker-lifecycle",
+    "AnyIO worker thread",
+    "ThreadPoolExecutor",
+    "asyncio_",
+    "ray::",
+    "grpc_",
+    "monitoring",
+)
+
+
 @pytest.fixture(autouse=True)
 def _thread_cleanup():
     """Ensure no new non-daemon threads leak from each test.
@@ -176,20 +215,29 @@ def _thread_cleanup():
     Takes a snapshot of threads before the test and checks that no new
     non-daemon threads remain after teardown. Waits briefly for threads
     that are in the process of shutting down.
+
+    Infrastructure threads from session-scoped clusters (iris, ray) are
+    excluded — they persist for the session and are not leaks.
     """
     before = {t.ident for t in threading.enumerate()}
     yield
 
-    deadline = time.monotonic() + 5.0
+    def _is_leaked(t: threading.Thread) -> bool:
+        if not t.is_alive() or t.daemon or t.name == "MainThread":
+            return False
+        if t.ident in before:
+            return False
+        if any(t.name.startswith(prefix) for prefix in _INFRA_THREAD_PREFIXES):
+            return False
+        return True
+
+    backoff = ExponentialBackoff(initial=0.1, maximum=1.0)
+    deadline = time.monotonic() + 2.0
     while time.monotonic() < deadline:
-        leaked = [
-            t
-            for t in threading.enumerate()
-            if t.is_alive() and not t.daemon and t.name != "MainThread" and t.ident not in before
-        ]
+        leaked = [t for t in threading.enumerate() if _is_leaked(t)]
         if not leaked:
             return
-        time.sleep(0.1)
+        time.sleep(backoff.next_interval())
 
     thread_info = [f"{t.name} (daemon={t.daemon}, ident={t.ident})" for t in leaked]
     warnings.warn(

--- a/lib/zephyr/tests/test_dataset.py
+++ b/lib/zephyr/tests/test_dataset.py
@@ -1349,3 +1349,89 @@ def test_input_file_spec_with_columns_and_row_range(tmp_path):
     assert set(records[0].keys()) == {"id", "value"}
     assert records[0]["id"] == 5
     assert records[-1]["id"] == 9
+
+
+# --- Integration tests (all backends) ---
+
+
+def test_reshard_integration(integration_ctx):
+    ds = Dataset.from_list([list(range(50))]).flat_map(lambda x: x).reshard(5).map(lambda x: x * 2)
+    result = sorted(integration_ctx.execute(ds))
+    assert result == [x * 2 for x in range(50)]
+
+    ds = Dataset.from_list(range(50)).reshard(5).map(lambda x: x + 100)
+    result = sorted(integration_ctx.execute(ds))
+    assert result == [x + 100 for x in range(50)]
+
+    ds = Dataset.from_list(range(10)).reshard(3)
+    result = list(integration_ctx.execute(ds))
+    assert sorted(result) == list(range(10))
+
+
+def test_sorted_merge_join_inner_basic_integration(integration_ctx):
+    left = Dataset.from_list(
+        [{"id": 1, "text": "hello"}, {"id": 2, "text": "world"}, {"id": 3, "text": "foo"}]
+    ).group_by(key=lambda x: x["id"], reducer=lambda k, items: next(iter(items)), num_output_shards=5)
+    right = Dataset.from_list([{"id": 1, "score": 0.9}, {"id": 2, "score": 0.3}]).group_by(
+        key=lambda x: x["id"], reducer=lambda k, items: next(iter(items)), num_output_shards=5
+    )
+
+    joined = left.sorted_merge_join(right, left_key=lambda x: x["id"], right_key=lambda x: x["id"], how="inner")
+
+    results = sorted(list(integration_ctx.execute(joined)), key=lambda x: x["id"])
+    assert len(results) == 2
+    assert results[0] == {"id": 1, "text": "hello", "score": 0.9}
+    assert results[1] == {"id": 2, "text": "world", "score": 0.3}
+
+
+def test_sorted_merge_join_left_integration(integration_ctx):
+    left = Dataset.from_list([{"id": 1, "text": "hello"}, {"id": 2, "text": "world"}]).group_by(
+        key=lambda x: x["id"], reducer=lambda k, items: next(iter(items)), num_output_shards=5
+    )
+    right = Dataset.from_list([{"id": 1, "score": 0.9}]).group_by(
+        key=lambda x: x["id"], reducer=lambda k, items: next(iter(items)), num_output_shards=5
+    )
+
+    joined = left.sorted_merge_join(
+        right,
+        left_key=lambda x: x["id"],
+        right_key=lambda x: x["id"],
+        combiner=lambda left, right: {**left, "score": right["score"] if right else 0.0},
+        how="left",
+    )
+
+    results = sorted(list(integration_ctx.execute(joined)), key=lambda x: x["id"])
+    assert len(results) == 2
+    assert results[0] == {"id": 1, "text": "hello", "score": 0.9}
+    assert results[1] == {"id": 2, "text": "world", "score": 0.0}
+
+
+def test_sorted_merge_join_after_group_by_integration(integration_ctx):
+    docs = Dataset.from_list(
+        [
+            {"id": 1, "text": "hello", "version": 1},
+            {"id": 1, "text": "hello updated", "version": 2},
+            {"id": 2, "text": "world", "version": 1},
+            {"id": 3, "text": "foo", "version": 1},
+        ]
+    ).group_by(
+        key=lambda x: x["id"],
+        reducer=lambda k, items: max(items, key=lambda x: x["version"]),
+        num_output_shards=10,
+    )
+
+    attrs = Dataset.from_list(
+        [
+            {"id": 1, "quality": 0.9},
+            {"id": 2, "quality": 0.3},
+            {"id": 3, "quality": 0.8},
+        ]
+    ).group_by(key=lambda x: x["id"], reducer=lambda k, items: next(iter(items)), num_output_shards=10)
+
+    joined = docs.sorted_merge_join(attrs, left_key=lambda x: x["id"], right_key=lambda x: x["id"], how="inner")
+
+    results = sorted(list(integration_ctx.execute(joined)), key=lambda x: x["id"])
+    assert len(results) == 3
+    assert results[0] == {"id": 1, "text": "hello updated", "version": 2, "quality": 0.9}
+    assert results[1] == {"id": 2, "text": "world", "version": 1, "quality": 0.3}
+    assert results[2] == {"id": 3, "text": "foo", "version": 1, "quality": 0.8}

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -30,7 +30,7 @@ def test_filter(zephyr_ctx):
     assert sorted(results) == [4, 5]
 
 
-def test_shared_data(fray_client, tmp_path):
+def test_shared_data(integration_client, tmp_path):
     """Workers can access shared data via zephyr_worker_ctx().
 
     Shared data is serialized to disk by put() and loaded lazily by workers.
@@ -41,7 +41,7 @@ def test_shared_data(fray_client, tmp_path):
         return x * multiplier
 
     zctx = ZephyrContext(
-        client=fray_client,
+        client=integration_client,
         max_workers=1,
         resources=ResourceConfig(cpu=1, ram="512m"),
         chunk_storage_prefix=str(tmp_path / "chunks"),
@@ -61,10 +61,10 @@ def test_multi_stage(zephyr_ctx):
     assert sorted(results) == [6, 8, 10]
 
 
-def test_context_manager(fray_client):
+def test_context_manager(local_client):
     """ZephyrContext works without context manager."""
     zctx = ZephyrContext(
-        client=fray_client,
+        client=local_client,
         max_workers=1,
         resources=ResourceConfig(cpu=1, ram="512m"),
         name=f"test-execution-{uuid.uuid4().hex[:8]}",
@@ -111,11 +111,11 @@ def test_empty_dataset(zephyr_ctx):
     assert results == []
 
 
-def test_chunk_cleanup(fray_client, tmp_path):
+def test_chunk_cleanup(local_client, tmp_path):
     """Verify chunks are cleaned up after execution."""
     chunk_prefix = str(tmp_path / "chunks")
     ctx = ZephyrContext(
-        client=fray_client,
+        client=local_client,
         max_workers=2,
         resources=ResourceConfig(cpu=1, ram="512m"),
         chunk_storage_prefix=chunk_prefix,
@@ -209,7 +209,7 @@ def test_status_reports_alive_workers_not_total(actor_context, tmp_path):
     assert len(coord._task_queue) == 1  # task was requeued
 
 
-def test_no_duplicate_results_on_heartbeat_timeout(actor_context, fray_client, tmp_path):
+def test_no_duplicate_results_on_heartbeat_timeout(actor_context, tmp_path):
     """When a task is requeued after heartbeat timeout, the original worker's
     stale result (from a previous attempt) is rejected by the coordinator."""
     from zephyr.execution import Shard, ShardTask, TaskResult, ZephyrCoordinator
@@ -437,7 +437,7 @@ def test_wait_for_stage_resets_dead_timer_on_recovery(actor_context, tmp_path):
     # In a background thread, re-register the worker and complete the task
     # after a short delay (simulating recovery before timeout expires)
     def recover_and_complete():
-        time.sleep(0.3)
+        time.sleep(0.1)
         coord.register_worker("worker-0", MagicMock())
         pulled = coord.pull_task("worker-0")
         assert pulled is not None and pulled != "SHUTDOWN"
@@ -454,12 +454,12 @@ def test_wait_for_stage_resets_dead_timer_on_recovery(actor_context, tmp_path):
     assert coord._completed_shards == 1
 
 
-def test_fresh_actors_per_execute(fray_client, tmp_path):
+def test_fresh_actors_per_execute(integration_client, tmp_path):
     """Each execute() creates and tears down its own coordinator and workers."""
     chunk_prefix = str(tmp_path / "chunks")
 
     zctx = ZephyrContext(
-        client=fray_client,
+        client=integration_client,
         max_workers=2,
         resources=ResourceConfig(cpu=1, ram="512m"),
         chunk_storage_prefix=chunk_prefix,
@@ -482,7 +482,7 @@ def test_fresh_actors_per_execute(fray_client, tmp_path):
     assert zctx._pipeline_id == 1
 
 
-def test_fatal_errors_fail_fast(fray_client, tmp_path):
+def test_fatal_errors_fail_fast(local_client, tmp_path):
     """Application errors (e.g. ValueError) cause immediate failure, no retries."""
     from zephyr.execution import ZephyrWorkerError
 
@@ -492,7 +492,7 @@ def test_fatal_errors_fail_fast(fray_client, tmp_path):
         raise ValueError(f"bad value: {x}")
 
     zctx = ZephyrContext(
-        client=fray_client,
+        client=local_client,
         max_workers=1,
         resources=ResourceConfig(cpu=1, ram="512m"),
         chunk_storage_prefix=chunk_prefix,
@@ -509,11 +509,11 @@ def test_fatal_errors_fail_fast(fray_client, tmp_path):
     assert elapsed < 15.0, f"Took {elapsed:.1f}s, expected fast failure"
 
 
-def test_chunk_storage_with_join(fray_client, tmp_path):
+def test_chunk_storage_with_join(integration_client, tmp_path):
     """Verify chunk storage works with join operations."""
     chunk_prefix = str(tmp_path / "chunks")
     ctx = ZephyrContext(
-        client=fray_client,
+        client=integration_client,
         max_workers=2,
         resources=ResourceConfig(cpu=1, ram="512m"),
         chunk_storage_prefix=chunk_prefix,
@@ -537,11 +537,11 @@ def test_chunk_storage_with_join(fray_client, tmp_path):
     assert results[1] == {"id": 2, "a": "y", "b": "q"}
 
 
-def test_workers_capped_to_shard_count(fray_client, tmp_path):
+def test_workers_capped_to_shard_count(local_client, tmp_path):
     """When max_workers > num_shards, only num_shards workers are created."""
     ds = Dataset.from_list([1, 2, 3])  # 3 shards
     ctx = ZephyrContext(
-        client=fray_client,
+        client=local_client,
         max_workers=10,
         resources=ResourceConfig(cpu=1, ram="512m"),
         chunk_storage_prefix=str(tmp_path / "chunks"),
@@ -554,10 +554,10 @@ def test_workers_capped_to_shard_count(fray_client, tmp_path):
     assert ctx._pipeline_id == 0
 
 
-def test_pipeline_id_increments(fray_client, tmp_path):
+def test_pipeline_id_increments(local_client, tmp_path):
     """Pipeline ID increments after each execute(), ensuring unique actor names."""
     ctx = ZephyrContext(
-        client=fray_client,
+        client=local_client,
         max_workers=10,
         resources=ResourceConfig(cpu=1, ram="512m"),
         chunk_storage_prefix=str(tmp_path / "chunks"),
@@ -641,7 +641,7 @@ def test_run_pipeline_rejects_concurrent_calls(actor_context, tmp_path):
 
     def blocking_wait():
         first_entered.set()
-        time.sleep(0.5)
+        time.sleep(0.1)
         coord._fatal_error = "test: forced exit"
         try:
             original_wait()
@@ -709,7 +709,7 @@ def test_execute_retries_on_coordinator_death(tmp_path):
     client.shutdown(wait=True)
 
 
-def test_execute_does_not_retry_worker_errors(fray_client, tmp_path):
+def test_execute_does_not_retry_worker_errors(local_client, tmp_path):
     """ZephyrWorkerError (application errors) are never retried."""
     from zephyr.execution import ZephyrWorkerError
 
@@ -719,7 +719,7 @@ def test_execute_does_not_retry_worker_errors(fray_client, tmp_path):
         raise ValueError(f"bad value: {x}")
 
     ctx = ZephyrContext(
-        client=fray_client,
+        client=local_client,
         max_workers=1,
         resources=ResourceConfig(cpu=1, ram="512m"),
         chunk_storage_prefix=chunk_prefix,
@@ -735,3 +735,16 @@ def test_execute_does_not_retry_worker_errors(fray_client, tmp_path):
 
     # Should fail fast — no retries for application errors
     assert elapsed < 15.0, f"Took {elapsed:.1f}s, expected fast failure (no retries)"
+
+
+# --- Integration tests (all backends) ---
+
+
+def test_simple_map_integration(integration_ctx):
+    ds = Dataset.from_list([1, 2, 3]).map(lambda x: x * 2)
+    assert sorted(integration_ctx.execute(ds)) == [2, 4, 6]
+
+
+def test_multi_stage_integration(integration_ctx):
+    ds = Dataset.from_list([1, 2, 3, 4, 5]).map(lambda x: x * 2).filter(lambda x: x > 5)
+    assert sorted(integration_ctx.execute(ds)) == [6, 8, 10]

--- a/lib/zephyr/tests/test_groupby.py
+++ b/lib/zephyr/tests/test_groupby.py
@@ -471,3 +471,63 @@ def test_group_by_combiner_sum(zephyr_ctx):
         {"cat": "x", "total": 6},
         {"cat": "y", "total": 30},
     ]
+
+
+# --- Integration tests (all backends) ---
+
+
+def test_deduplicate_basic_integration(integration_ctx):
+    data = [
+        {"id": 1, "val": "a"},
+        {"id": 2, "val": "b"},
+        {"id": 1, "val": "c"},
+        {"id": 3, "val": "d"},
+        {"id": 2, "val": "e"},
+    ]
+
+    ds = Dataset.from_list(data).deduplicate(key=lambda x: x["id"])
+
+    results = list(integration_ctx.execute(ds))
+    assert len(results) == 3
+    ids = sorted([r["id"] for r in results])
+    assert ids == [1, 2, 3]
+
+
+def test_group_by_combiner_integration(integration_ctx):
+    data = [
+        {"key": "a", "id": 1},
+        {"key": "a", "id": 1},
+        {"key": "a", "id": 2},
+        {"key": "b", "id": 3},
+        {"key": "b", "id": 3},
+        {"key": "b", "id": 3},
+        {"key": "b", "id": 4},
+    ]
+
+    def dedup_combiner(key, items):
+        seen = set()
+        for item in items:
+            if item["id"] not in seen:
+                seen.add(item["id"])
+                yield item
+
+    def dedup_reducer(key, items):
+        seen = set()
+        ids = []
+        for item in items:
+            if item["id"] not in seen:
+                seen.add(item["id"])
+                ids.append(item["id"])
+        return {"key": key, "ids": sorted(ids)}
+
+    ds = Dataset.from_list(data).group_by(
+        key=lambda x: x["key"],
+        reducer=dedup_reducer,
+        combiner=dedup_combiner,
+    )
+
+    results = sorted(integration_ctx.execute(ds), key=lambda x: x["key"])
+    assert results == [
+        {"key": "a", "ids": [1, 2]},
+        {"key": "b", "ids": [3, 4]},
+    ]


### PR DESCRIPTION
Most zephyr tests exercise dataset/pipeline logic, not backend behavior.
Running all 386 tests across local/iris/ray wasted ~8 minutes on redundant
iris subprocess spawning. Now functional tests run on local only (~36s),
with 8 representative integration tests covering all 3 backends.

Changes:
- conftest.py: local_client/zephyr_ctx (local-only) + integration_client/integration_ctx (all backends)
- execution.py: coordinator uses threading.Event for instant shutdown, backoff starts at 0.1s
- Thread cleanup excludes infrastructure threads (5s -> 2s teardown deadline)
- test_dataset/test_execution/test_groupby: most tests local-only, small integration subset added

Before: 386 tests, iris/ray = 172 tests
After: 236 tests, iris/ray = 22 tests