### PR TITLE
[iris] Fix test_iris_run_cli timeout from #3899 preemptible constraint mismatch

### DIFF
--- a/lib/iris/examples/test.yaml
+++ b/lib/iris/examples/test.yaml
@@ -90,6 +90,27 @@ scale_groups:
         zone: europe-west4-b
         runtime_version: v2-alpha-tpuv6e
 
+  # Non-preemptible CPU group for executor-heuristic jobs (iris run).
+  # The executor heuristic auto-tags small CPU jobs with preemptible=false,
+  # so at least one non-preemptible worker must exist for scheduling to succeed.
+  cpu_non_preemptible:
+    num_vms: 1
+    resources:
+      cpu: 2
+      ram: 4GB
+      disk: 10GB
+      device_type: cpu
+      device_count: 0
+      preemptible: false
+    min_slices: 1
+    max_slices: 1
+    slice_template:
+      num_vms: 1
+      gcp:
+        mode: GCP_SLICE_MODE_VM
+        zone: europe-west4-b
+        machine_type: e2-standard-2
+
   # Disabled group - min and max both zero
   gpu_disabled:
     num_vms: 1

--- a/lib/iris/tests/test_iris_run.py
+++ b/lib/iris/tests/test_iris_run.py
@@ -171,17 +171,13 @@ def local_cluster_and_config(tmp_path):
 
 
 @pytest.mark.slow
-def test_iris_run_cli_simple_job(local_cluster_and_config, tmp_path):
+def test_iris_run_cli_simple_job(local_cluster_and_config):
     """Test iris job submission runs a simple job successfully."""
     _test_config, url, _client = local_cluster_and_config
 
-    # Create test script that prints and exits
-    test_script = tmp_path / "test.py"
-    test_script.write_text('print("SUCCESS"); exit(0)')
-
     exit_code = run_iris_job(
         controller_url=url,
-        command=[sys.executable, str(test_script)],
+        command=[sys.executable, "-c", 'print("SUCCESS")'],
         env_vars={},
         wait=True,
     )
@@ -190,27 +186,19 @@ def test_iris_run_cli_simple_job(local_cluster_and_config, tmp_path):
 
 
 @pytest.mark.slow
-def test_iris_run_cli_env_vars_propagate(local_cluster_and_config, tmp_path):
+def test_iris_run_cli_env_vars_propagate(local_cluster_and_config):
     """Test environment variables reach the job."""
     _test_config, url, _client = local_cluster_and_config
-
-    # Create script that checks env var
-    test_script = tmp_path / "check_env.py"
-    test_script.write_text(
-        """
-import os
-import sys
-val = os.environ.get("TEST_VAR", "MISSING")
-print(f"TEST_VAR={val}")
-sys.exit(0 if val == "test_value" else 1)
-"""
-    )
 
     env_vars = load_env_vars([["TEST_VAR", "test_value"]])
 
     exit_code = run_iris_job(
         controller_url=url,
-        command=[sys.executable, str(test_script)],
+        command=[
+            sys.executable,
+            "-c",
+            "import os, sys; val = os.environ.get('TEST_VAR', 'MISSING');" " sys.exit(0 if val == 'test_value' else 1)",
+        ],
         env_vars=env_vars,
         wait=True,
     )
@@ -219,16 +207,13 @@ sys.exit(0 if val == "test_value" else 1)
 
 
 @pytest.mark.slow
-def test_iris_run_cli_job_failure(local_cluster_and_config, tmp_path):
+def test_iris_run_cli_job_failure(local_cluster_and_config):
     """Test job submission returns non-zero on job failure."""
     _test_config, url, _client = local_cluster_and_config
 
-    test_script = tmp_path / "fail.py"
-    test_script.write_text("exit(1)")
-
     exit_code = run_iris_job(
         controller_url=url,
-        command=[sys.executable, str(test_script)],
+        command=[sys.executable, "-c", "exit(1)"],
         env_vars={},
         wait=True,
     )


### PR DESCRIPTION
## Summary

Fixes #3932.

- **Add `cpu_non_preemptible` scale group to `test.yaml`**: #3899 added an executor heuristic that auto-tags small CPU-only jobs with a hard `preemptible=false` constraint. The local test cluster only had `preemptible=true` TPU workers, so the constraint never matched and the task hung until the 30s timeout.
- **Switch test commands to inline `python -c`**: The three `test_iris_run_cli_*` tests wrote scripts to pytest's `tmp_path`, but the worker runs from its own cache directory and can't resolve those paths. Using `-c` with inline code avoids the path issue entirely.

## Test plan

- [x] `test_iris_run_cli_simple_job` — passes (was timing out)
- [x] `test_iris_run_cli_env_vars_propagate` — passes (was timing out)
- [x] `test_iris_run_cli_job_failure` — passes (was timing out)
- [x] Full `test_iris_run.py` suite — 25/25 pass
- [x] Full `test_config.py` suite — 73/73 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
