### PR TITLE
[nightshift] Increase agent turn limits and timeouts 10x

### DIFF
--- a/.github/workflows/nightshift-cleanup.yml
+++ b/.github/workflows/nightshift-cleanup.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 240
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/nightshift-doc-drift.yml
+++ b/.github/workflows/nightshift-doc-drift.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   doc-drift:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 240
     permissions:
       contents: write
       pull-requests: write

--- a/infra/scripts/nightshift_cleanup.py
+++ b/infra/scripts/nightshift_cleanup.py
@@ -74,7 +74,7 @@ def main() -> None:
             "--dangerously-skip-permissions",
             "--tools=Read,Write,Edit,Glob,Grep,Bash",
             "--max-turns",
-            "80",
+            "800",
             "--",
             prompt,
         ],

--- a/infra/scripts/nightshift_doc_drift.py
+++ b/infra/scripts/nightshift_doc_drift.py
@@ -84,7 +84,7 @@ def main() -> None:
             "--dangerously-skip-permissions",
             "--tools=Read,Write,Edit,Glob,Grep,Bash",
             "--max-turns",
-            "60",
+            "600",
             "--",
             prompt,
         ],


### PR DESCRIPTION
Cleanup agent was hitting the 80-turn limit and terminating before finishing work. Bump both nightshift agents to ~10x their previous limits: cleanup 80 to 800 turns (45 to 240 min timeout), doc-drift 60 to 600 turns (30 to 240 min timeout).