### PR TITLE
[iris] Add events permission to CoreWeave RBAC ClusterRole

### DIFF
--- a/lib/iris/src/iris/cluster/platform/coreweave.py
+++ b/lib/iris/src/iris/cluster/platform/coreweave.py
@@ -207,6 +207,11 @@ class CoreweavePlatform:
                 },
                 {
                     "apiGroups": [""],
+                    "resources": ["events"],
+                    "verbs": ["get", "list", "watch"],
+                },
+                {
+                    "apiGroups": [""],
                     "resources": ["configmaps"],
                     "verbs": ["get", "list", "watch", "create", "update", "patch", "delete"],
                 },


### PR DESCRIPTION
Add events (get/list/watch) to the ClusterRole created by ensure_rbac(). The controller queries events in _check_controller_pod_events (fatal mount detection) and _collect_scheduling_events (scheduling diagnostics) but the RBAC rule was missing, causing repeated Forbidden errors that have been breaking the CW GPU canary since Mar 21. Existing clusters need iris cluster start re-run to pick up the new rules.

Part of #3981