### PR TITLE
[iris] Add dev cluster config with daily automated restart

### DIFF
--- a/.github/workflows/iris-dev-restart.yaml
+++ b/.github/workflows/iris-dev-restart.yaml
@@ -1,0 +1,54 @@
+name: Iris - Dev Cluster Daily Restart
+
+on:
+  schedule:
+    # Daily at 06:00 UTC
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: iris-dev-restart
+  cancel-in-progress: false
+
+jobs:
+  restart:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "lib/iris/pyproject.toml"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Write SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.MARIN_SSH_KEY }}" > ~/.ssh/marin_ray_cluster.pem
+          chmod 600 ~/.ssh/marin_ray_cluster.pem
+
+      - name: Restart dev controller
+        run: |
+          uv run python lib/iris/scripts/migrations/controller_restart.py \
+            --config lib/iris/examples/marin-dev.yaml

--- a/lib/iris/examples/marin-dev.yaml
+++ b/lib/iris/examples/marin-dev.yaml
@@ -1,0 +1,155 @@
+# Iris development cluster configuration
+# Mirrors production marin.yaml with isolated state and smaller scale caps.
+# Usage: uv run iris cluster --config=examples/marin-dev.yaml start
+
+platform:
+  label_prefix: marin-dev
+  gcp:
+    project_id: hai-gcp-models
+
+defaults:
+  autoscaler:
+    evaluation_interval:
+      milliseconds: 10000
+    scale_up_delay:
+      milliseconds: 60000
+    scale_down_delay:
+      milliseconds: 300000
+  worker:
+    docker_image: ghcr.io/marin-community/iris-worker:latest
+    default_task_image: ghcr.io/marin-community/iris-task:latest
+    port: 10001
+
+storage:
+  remote_state_dir: gs://marin-us-central2/iris/marin-dev/state
+
+worker_provider: {}
+
+controller:
+  image: ghcr.io/marin-community/iris-controller:latest
+  gcp:
+    zone: us-central1-a
+    machine_type: e2-standard-4
+    boot_disk_size_gb: 100
+    port: 10000
+
+scale_groups:
+  cpu_vm_e2_highmem_2_ondemand:
+    zones: [us-central1-a, us-east1-b, us-west1-a, europe-west4-a]
+    num_vms: 1
+    priority: 1000
+    resources: { cpu: 2, ram: 16GB, disk: 100GB, device_type: cpu, preemptible: false }
+    min_slices: 0
+    max_slices: 1
+    slice_template:
+      gcp:
+        mode: GCP_SLICE_MODE_VM
+        machine_type: e2-highmem-2
+
+  # v5e (v5litepod) — capped at 4 slices per group
+  tpu_v5e_4:
+    zones: [europe-west4-b, us-west4-a]
+    num_vms: 1
+    priority: 10
+    resources: { cpu: 112, ram: 192GB, disk: 100GB, device_type: tpu, device_variant: v5litepod-4, device_count: 4, preemptible: true }
+    min_slices: 0
+    max_slices: 4
+    slice_template:
+      gcp:
+        runtime_version: v2-alpha-tpuv5-lite
+  tpu_v5e_8:
+    zones: [europe-west4-b, us-west4-a]
+    num_vms: 1
+    priority: 20
+    resources: { cpu: 112, ram: 192GB, disk: 100GB, device_type: tpu, device_variant: v5litepod-8, device_count: 8, preemptible: true }
+    min_slices: 0
+    max_slices: 4
+    slice_template:
+      gcp:
+        runtime_version: v2-alpha-tpuv5-lite
+  tpu_v5e_16:
+    zones: [europe-west4-b, us-west4-a]
+    num_vms: 4
+    priority: 30
+    resources: { cpu: 112, ram: 192GB, disk: 100GB, device_type: tpu, device_variant: v5litepod-16, device_count: 4, preemptible: true }
+    min_slices: 0
+    max_slices: 4
+    slice_template:
+      gcp:
+        runtime_version: v2-alpha-tpuv5-lite
+
+  # v6e — capped at 4 slices per group
+  tpu_v6e_4:
+    zones: [europe-west4-a, us-east1-d, us-east5-b]
+    num_vms: 1
+    priority: 10
+    resources: { cpu: 180, ram: 720GB, disk: 100GB, device_type: tpu, device_variant: v6e-4, device_count: 4, preemptible: true }
+    min_slices: 0
+    max_slices: 4
+    slice_template:
+      gcp:
+        runtime_version: v2-alpha-tpuv6e
+  tpu_v6e_8:
+    zones: [europe-west4-a, us-east1-d, us-east5-b]
+    num_vms: 1
+    priority: 20
+    resources: { cpu: 180, ram: 720GB, disk: 100GB, device_type: tpu, device_variant: v6e-8, device_count: 8, preemptible: true }
+    min_slices: 0
+    max_slices: 4
+    slice_template:
+      gcp:
+        runtime_version: v2-alpha-tpuv6e
+  tpu_v6e_16:
+    zones: [europe-west4-a, us-east1-d, us-east5-b]
+    num_vms: 4
+    priority: 30
+    resources: { cpu: 180, ram: 720GB, disk: 100GB, device_type: tpu, device_variant: v6e-16, device_count: 4, preemptible: true }
+    min_slices: 0
+    max_slices: 4
+    slice_template:
+      gcp:
+        runtime_version: v2-alpha-tpuv6e
+
+  # v5p — capped at 4 slices per group
+  tpu_v5p_8:
+    zones: [us-central1-a, us-east5-a]
+    num_vms: 1
+    priority: 20
+    resources: { cpu: 208, ram: 448GB, disk: 100GB, device_type: tpu, device_variant: v5p-8, device_count: 4, preemptible: true }
+    min_slices: 0
+    max_slices: 4
+    slice_template:
+      gcp:
+        runtime_version: v2-alpha-tpuv5
+  tpu_v5p_16:
+    zones: [us-central1-a, us-east5-a]
+    num_vms: 2
+    priority: 30
+    resources: { cpu: 208, ram: 448GB, disk: 100GB, device_type: tpu, device_variant: v5p-16, device_count: 4, preemptible: true }
+    min_slices: 0
+    max_slices: 4
+    slice_template:
+      gcp:
+        runtime_version: v2-alpha-tpuv5
+
+  # v4 — capped at 4 slices per group
+  tpu_v4_8:
+    zones: [us-central2-b]
+    num_vms: 1
+    priority: 20
+    resources: { cpu: 240, ram: 400GB, disk: 100GB, device_type: tpu, device_variant: v4-8, device_count: 4, preemptible: true }
+    min_slices: 0
+    max_slices: 4
+    slice_template:
+      gcp:
+        runtime_version: tpu-ubuntu2204-base
+  tpu_v4_16:
+    zones: [us-central2-b]
+    num_vms: 2
+    priority: 30
+    resources: { cpu: 240, ram: 400GB, disk: 100GB, device_type: tpu, device_variant: v4-16, device_count: 4, preemptible: true }
+    min_slices: 0
+    max_slices: 4
+    slice_template:
+      gcp:
+        runtime_version: tpu-ubuntu2204-base

--- a/lib/iris/tests/cluster/platform/test_config.py
+++ b/lib/iris/tests/cluster/platform/test_config.py
@@ -681,6 +681,7 @@ scale_groups:
         iris_root = Path(__file__).parent.parent.parent.parent
         example_configs = [
             iris_root / "examples" / "marin.yaml",
+            iris_root / "examples" / "marin-dev.yaml",
             iris_root / "examples" / "test.yaml",
         ]
 


### PR DESCRIPTION
Add marin-dev.yaml cluster config with isolated state directory and capped max_slices (4 per TPU group). Add iris-dev-restart.yaml GitHub Actions cron workflow that runs controller_restart.py daily at 06:00 UTC using existing CI secrets.

Fixes #3969