### PR TITLE
[CI] Fix required checks hanging due to workflow path filters

### DIFF
--- a/.github/workflows/dupekit-unit-tests.yaml
+++ b/.github/workflows/dupekit-unit-tests.yaml
@@ -13,6 +13,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       should_run: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/dupekit-wheels.yaml
+++ b/.github/workflows/dupekit-wheels.yaml
@@ -20,6 +20,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       should_run: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/fray-unit-tests.yaml
+++ b/.github/workflows/fray-unit-tests.yaml
@@ -13,6 +13,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       should_run: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/grug-variant-diff.yaml
+++ b/.github/workflows/grug-variant-diff.yaml
@@ -15,6 +15,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       should_run: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/haliax-run_tests.yaml
+++ b/.github/workflows/haliax-run_tests.yaml
@@ -14,6 +14,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       should_run: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/iris-unit-tests.yaml
+++ b/.github/workflows/iris-unit-tests.yaml
@@ -16,6 +16,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       should_run: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/levanter-tests.yaml
+++ b/.github/workflows/levanter-tests.yaml
@@ -14,6 +14,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       should_run: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/marin-docs.yaml
+++ b/.github/workflows/marin-docs.yaml
@@ -14,6 +14,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       should_run: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/marin-unit-tests.yaml
+++ b/.github/workflows/marin-unit-tests.yaml
@@ -14,6 +14,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       should_run: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/zephyr-unit-tests.yaml
+++ b/.github/workflows/zephyr-unit-tests.yaml
@@ -13,6 +13,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       should_run: ${{ steps.filter.outputs.relevant }}


### PR DESCRIPTION
Replace workflow-level path filters with job-level conditional execution
using dorny/paths-filter. Workflows always trigger so GitHub reports a
status, but test jobs skip when no relevant files changed. Skipped jobs
satisfy required checks. Affects iris, zephyr, levanter, haliax, fray.

Fixes #3985