### PR TITLE
[iris] Make controller restart idempotent

### DIFF
--- a/lib/iris/src/iris/cli/cluster.py
+++ b/lib/iris/src/iris/cli/cluster.py
@@ -633,7 +633,29 @@ def controller_restart(ctx):
             "Stop and restart the 'iris cluster start --local' process instead."
         )
 
-    controller_url = require_controller_url(ctx)
+    iris_config = IrisConfig(config)
+    platform = iris_config.platform()
+
+    # Try to discover existing controller for checkpoint + restart.
+    # If none exists, fall back to a fresh start (idempotent).
+    try:
+        controller_url = require_controller_url(ctx)
+    except (RuntimeError, click.ClickException):
+        click.echo("No existing controller found. Starting fresh...")
+        _pin_latest_images(config)
+        verbose = ctx.obj.get("verbose", False)
+        built = _build_cluster_images(config, verbose=verbose)
+        if built:
+            click.echo("Built image tags:")
+            for name, tag in built.items():
+                click.echo(f"  {name}: {tag}")
+        try:
+            address = platform.start_controller(config)
+        except Exception as e:
+            click.echo(f"Failed to start controller: {e}", err=True)
+            raise SystemExit(1) from e
+        click.echo(f"Controller started at {address}")
+        return
 
     # Checkpoint
     client = cluster_connect.ControllerServiceClientSync(controller_url)
@@ -655,9 +677,6 @@ def controller_restart(ctx):
         for name, tag in built.items():
             click.echo(f"  {name}: {tag}")
 
-    # Restart controller in-place (re-runs bootstrap on existing VM)
-    iris_config = IrisConfig(config)
-    platform = iris_config.platform()
     try:
         address = platform.restart_controller(config)
     except Exception as e:


### PR DESCRIPTION
When no controller VM exists, controller restart crashes with a RuntimeError
from discover_controller. Now it catches the error and falls back to
start_controller(), so the command works whether or not a controller is
already running.