### PR TITLE
fix: regenerate uv.lock in dupekit wheels workflow

### DIFF
--- a/.github/workflows/dupekit-wheels.yaml
+++ b/.github/workflows/dupekit-wheels.yaml
@@ -138,7 +138,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Update pyproject.toml with pinned dupekit release
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Update pyproject.toml and uv.lock with pinned dupekit release
         run: |
           set -euo pipefail
 
@@ -154,6 +156,9 @@ jobs:
 
           # Update dupekit version pin in dependencies
           sed -i 's|^\(\s*\)"dupekit[^"]*"|    "dupekit >= '"${VERSION}"'"|' pyproject.toml
+
+          # Regenerate uv.lock so devs don't get dirty lockfile diffs
+          uv lock
 
       - uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
The update-pyproject job in dupekit-wheels.yaml edits pyproject.toml (find-links URL and version pin) but never ran uv lock, so every dev who pulled the resulting auto-PR got a dirty uv.lock diff on their next sync.

Adds astral-sh/setup-uv@v7 and a uv lock step after the sed edits so the lockfile stays in sync with the pyproject.toml changes.