### PR TITLE
fix(zephyr): add lifecycle logging to coordinator thread

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -870,7 +870,7 @@ class ZephyrCoordinator:
 
             # Checked after completion so a clean shutdown racing the final
             # task can never false-positive — only true crashes reach here.
-            if not self._coordinator_thread.is_alive():
+            if self._coordinator_thread is not None and not self._coordinator_thread.is_alive():
                 raise ZephyrWorkerError(
                     "Coordinator thread is no longer alive. "
                     "Check logs for 'Coordinator loop crashed' for the root cause."

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -619,18 +619,25 @@ class ZephyrCoordinator:
 
     def _coordinator_loop(self) -> None:
         """Background loop for heartbeat checking and worker job monitoring."""
+        logger.info("Coordinator loop started (thread=%s)", threading.current_thread().name)
         last_log_time = 0.0
 
-        while not self._shutdown_event.is_set():
-            self.check_heartbeats()
-            self._check_worker_group()
+        try:
+            while not self._shutdown_event.is_set():
+                self.check_heartbeats()
+                self._check_worker_group()
 
-            now = time.monotonic()
-            if self._has_active_execution() and now - last_log_time > 5.0:
-                self._log_status()
-                last_log_time = now
+                now = time.monotonic()
+                if self._has_active_execution() and now - last_log_time > 5.0:
+                    self._log_status()
+                    last_log_time = now
 
-            self._shutdown_event.wait(timeout=0.5)
+                self._shutdown_event.wait(timeout=0.5)
+
+            logger.info("Coordinator loop exiting: shutdown event set")
+        except Exception:
+            logger.error("Coordinator loop crashed with unhandled exception", exc_info=True)
+            self._fatal_error = "Coordinator thread crashed — see logs for traceback"
 
     def _check_worker_group(self) -> None:
         """Abort the pipeline if the worker job has permanently terminated."""
@@ -860,6 +867,14 @@ class ZephyrCoordinator:
                 else:
                     # Workers are alive — reset the dead timer
                     all_dead_since = None
+
+            # Checked after completion so a clean shutdown racing the final
+            # task can never false-positive — only true crashes reach here.
+            if not self._coordinator_thread.is_alive():
+                raise ZephyrWorkerError(
+                    "Coordinator thread is no longer alive. "
+                    "Check logs for 'Coordinator loop crashed' for the root cause."
+                )
 
             if completed != last_log_completed:
                 logger.info("[%s] %d/%d tasks completed", self._stage_name, completed, total)


### PR DESCRIPTION
## Summary

Fixes #4004 — the coordinator thread (`_coordinator_loop`) had no lifecycle logging, making production hangs undiagnosable.

### Changes

- **Start/exit logging**: `_coordinator_loop` now logs on entry and on clean exit
- **Crash handling**: Wrapped the loop body in `try/except`; unhandled exceptions are logged at ERROR with full traceback (`exc_info=True`) and propagated to the main thread via `_fatal_error`
- **Dead-thread detection**: `_wait_for_stage` checks `_coordinator_thread.is_alive()` after the completion check each poll iteration and raises `ZephyrWorkerError` immediately if the thread is gone, instead of spinning forever

### What this would have changed in the #3996 incident

| Before | After |
|---|---|
| No log when coordinator thread died | `ERROR Coordinator loop crashed with unhandled exception` + traceback |
| `_wait_for_stage` spun forever at N-1/N | Immediate `ZephyrWorkerError: Coordinator thread is no longer alive` |
| Required `kubectl exec` + `threading.enumerate()` to diagnose | Root cause visible in pod logs |

## Test plan

- [x] Manual smoke test: verified start log, exit log, crash log + traceback, and dead-thread detection all produce expected output
- [ ] CI green


🤖 Generated with [Claude Code](https://claude.com/claude-code)