### PR TITLE
[CI] Fix required checks hanging + rename to project-scoped names

### DIFF
--- a/.github/workflows/fray-unit-tests.yaml
+++ b/.github/workflows/fray-unit-tests.yaml
@@ -28,22 +28,19 @@ jobs:
               - 'uv.lock'
               - '.github/workflows/fray-unit-tests.yaml'
 
-  cpu-test:
+  fray-tests:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      matrix:
-        python-version: ["3.12"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -55,7 +52,7 @@ jobs:
           # NOTE: do not use frozen here because it makes ray sad when it sets up venvs with uv
           cd lib/fray && uv run --group=fray-test pytest --durations=5 --tb=short -m 'not slow and not tpu_ci' -v -s tests/
 
-  tpu-test:
+  fray-tpu-tests:
     needs: changes
     runs-on: [tpu-ci]
     timeout-minutes: 10

--- a/.github/workflows/haliax-run_tests.yaml
+++ b/.github/workflows/haliax-run_tests.yaml
@@ -29,16 +29,11 @@ jobs:
               - 'uv.lock'
               - '.github/workflows/haliax-*.yaml'
 
-  cpu-test:
+  haliax-tests:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
 
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        python-version: ["3.11"]
-        jax-version: ["0.8.0"]
 
     defaults:
       run:
@@ -46,15 +41,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install uv
           uv sync --package haliax --dev
-      - name: Test with pytest (JAX ${{ matrix.jax-version }})
+      - name: Test with pytest (JAX 0.8.0)
         run: |
           # Test with specific JAX version
-          JAX_NUM_CPU_DEVICES=8 PYTHONPATH=tests:src:. uv run --package haliax --with "jax[cpu]==${{ matrix.jax-version }}" pytest -c pyproject.toml tests
+          JAX_NUM_CPU_DEVICES=8 PYTHONPATH=tests:src:. uv run --package haliax --with "jax[cpu]==0.8.0" pytest -c pyproject.toml tests

--- a/.github/workflows/iris-unit-tests.yaml
+++ b/.github/workflows/iris-unit-tests.yaml
@@ -31,22 +31,19 @@ jobs:
               - 'uv.lock'
               - '.github/workflows/iris-unit-tests.yaml'
 
-  cpu-test:
+  iris-tests:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      matrix:
-        python-version: ["3.12"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -65,22 +62,19 @@ jobs:
         run: |
           cd lib/iris && uv run --group dev python -m pytest -n1 --durations=5 --tb=short -m 'not slow and not docker and not e2e' tests/
 
-  e2e-smoke-test:
+  iris-e2e-smoke:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    strategy:
-      matrix:
-        python-version: ["3.12"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/levanter-tests.yaml
+++ b/.github/workflows/levanter-tests.yaml
@@ -30,14 +30,10 @@ jobs:
               - 'uv.lock'
               - '.github/workflows/levanter-tests.yaml'
 
-  cpu-unit-tests:
+  levanter-tests:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11"]
-        jax-version: ["0.8.0"]
     defaults:
       run:
         working-directory: lib/levanter
@@ -48,7 +44,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           version: "0.7.20"
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           enable-cache: true
           working-directory: lib/levanter
       - name: Set up Node.js
@@ -62,15 +58,12 @@ jobs:
       - name: Test with pytest
         run: |
           # Test with specific JAX version, excluding TPU tests
-          PYTHONPATH=tests:src:. uv run --package levanter --frozen --with "jax[cpu]==${{ matrix.jax-version }}" pytest tests -m "not entry and not slow and not ray and not tpu" --durations=20
+          PYTHONPATH=tests:src:. uv run --package levanter --frozen --with "jax[cpu]==0.8.0" pytest tests -m "not entry and not slow and not ray and not tpu" --durations=20
 
-  cpu-ray-tests:
+  levanter-ray-tests:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11"]
     defaults:
       run:
         working-directory: lib/levanter
@@ -81,7 +74,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           version: "0.7.20"
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           enable-cache: true
           working-directory: lib/levanter
       - name: Set up Node.js
@@ -96,13 +89,10 @@ jobs:
         run: |
           PYTHONPATH=tests:src:. uv run --package levanter --frozen pytest tests -m "ray" --durations=20
 
-  cpu-entry-tests:
+  levanter-entry-tests:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11"]
     defaults:
       run:
         working-directory: lib/levanter
@@ -113,7 +103,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           version: "0.7.20"
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           enable-cache: true
           working-directory: lib/levanter
       - name: Set up Node.js
@@ -128,14 +118,11 @@ jobs:
         run: |
           PYTHONPATH=tests:src:. uv run --package levanter --frozen pytest tests -m "entry" --durations=20
 
-  cpu-torch-tests:
+  levanter-torch-tests:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    strategy:
-      matrix:
-        python-version: ["3.11"]
     defaults:
       run:
         working-directory: lib/levanter
@@ -146,7 +133,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           version: "0.7.20"
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           enable-cache: true
           working-directory: lib/levanter
       - name: Set up Node.js
@@ -193,15 +180,11 @@ jobs:
           CUDA_VISIBLE_DEVICES="" PYTHONPATH=tests:src:. ../../.venv/bin/python -m pytest tests -m "torch" --durations=20
 #          CUDA_VISIBLE_DEVICES="" PYTHONPATH=tests:src:. uv run --package levanter --frozen --extra torch_test pytest tests -m "torch" --durations=20
 
-  tpu-tests:
+  levanter-tpu-tests:
     needs: changes
     if: needs.changes.outputs.should_run == 'true' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [tpu-ci]
     timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        jax_version: ["0.8.0"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -212,7 +195,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
-          JAX_VERSION: ${{ matrix.jax_version }}
+          JAX_VERSION: "0.8.0"
         run: |
           bash infra/tpu-ci/clean-tpu.sh
 

--- a/.github/workflows/marin-itest.yaml
+++ b/.github/workflows/marin-itest.yaml
@@ -9,7 +9,7 @@ on:
 
 
 jobs:
-  itest:
+  marin-itest:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     # uv has to resolve + download large binary wheels (jax/torch). 10 minutes wasn't
@@ -19,17 +19,13 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
 
-    strategy:
-      matrix:
-        python-version: [ "3.12" ]
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/marin-unit-tests.yaml
+++ b/.github/workflows/marin-unit-tests.yaml
@@ -31,23 +31,19 @@ jobs:
               - 'pyproject.toml'
               - '.github/workflows/marin-unit-tests.yaml'
 
-  cpu-unit-test:
+  marin-tests:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    strategy:
-      matrix:
-        python-version: ["3.12"]
-        node-version: ["20.10.0"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      
-      - name: Set up Python ${{ matrix.python-version }}
+
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
@@ -60,10 +56,10 @@ jobs:
           python -m pip install --upgrade pip
           uv sync --package marin --extra cpu --extra dedup --group test --frozen
 
-      - name: Set up Node.js ${{ matrix.node-version }}
+      - name: Set up Node.js 20.10.0
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "20.10.0"
       
       - name: Test with pytest
         env:

--- a/.github/workflows/zephyr-unit-tests.yaml
+++ b/.github/workflows/zephyr-unit-tests.yaml
@@ -30,22 +30,19 @@ jobs:
               - 'uv.lock'
               - '.github/workflows/zephyr-unit-tests.yaml'
 
-  cpu-unit-test:
+  zephyr-tests:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    strategy:
-      matrix:
-        python-version: ["3.12"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Remove single-element strategy.matrix from all CI workflow jobs and
rename job IDs from generic cpu-test/cpu-unit-test to {project}-tests.
Update branch protection required checks to match.

When a matrix job is skipped via if: condition, GitHub Actions never
expands the matrix, so parameterized check names like
cpu-unit-tests (3.11, 0.8.0) are never created and branch protection
waits forever. Inlining the values and dropping the matrix fixes this.

New required checks: levanter-tests, levanter-ray-tests,
levanter-entry-tests, levanter-torch-tests, marin-tests, zephyr-tests,
haliax-tests, iris-tests, fray-tests, marin-itest, build-docs,
lint-and-format.

Follows up on #3986. Fixes #3985.