### PR TITLE
[iris] Label always-on CoreWeave nodes as system-critical

### DIFF
--- a/lib/iris/src/iris/cluster/platform/coreweave.py
+++ b/lib/iris/src/iris/cluster/platform/coreweave.py
@@ -384,6 +384,9 @@ class CoreweavePlatform:
                 "nodeLabels": {
                     self._iris_labels.iris_managed: "true",
                     self._iris_labels.iris_scale_group: scale_group_name,
+                    # Pin Konnectivity agents and monitoring pods to always-on nodes
+                    # so GPU NodePools can safely scale to zero.
+                    **({"cks.coreweave.cloud/system-critical": "true"} if min_nodes > 0 else {}),
                 },
             },
         }


### PR DESCRIPTION
Add cks.coreweave.cloud/system-critical label to NodePools with min_nodes > 0.
This pins Konnectivity agents and monitoring pods to always-on CPU nodes so
GPU NodePools can safely scale to zero without losing cluster connectivity.