### PR TITLE
Add Cloudflare Tunnel integration for public controller access

### DIFF
--- a/lib/iris/Dockerfile
+++ b/lib/iris/Dockerfile
@@ -77,6 +77,11 @@ FROM deps AS controller
 
 LABEL org.opencontainers.image.description="Iris controller image"
 
+# cloudflared for Cloudflare Tunnel (public dashboard access without SSH)
+RUN curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 \
+        -o /usr/local/bin/cloudflared \
+    && chmod +x /usr/local/bin/cloudflared
+
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:10000/health || exit 1
 

--- a/lib/iris/examples/marin-dev.yaml
+++ b/lib/iris/examples/marin-dev.yaml
@@ -25,6 +25,13 @@ storage:
 
 worker_provider: {}
 
+tunnel:
+  enabled: true
+  domain: iris-ops.dev
+  cloudflare_account_id: a5a1f66f973e2196a26bae21c81b899b
+  cloudflare_zone_id: 724e28dbaf5c4dc5c21424dbe56fc2f1
+  cloudflare_api_token_secret: CLOUDFLARE_IRIS_API_TOKEN
+
 controller:
   image: ghcr.io/marin-community/iris-controller:latest
   gcp:

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -196,12 +196,14 @@ class ControllerDashboard:
         port: int = 8080,
         auth_verifier: TokenVerifier | None = None,
         auth_provider: str | None = None,
+        public_url: str | None = None,
     ):
         self._service = service
         self._host = host
         self._port = port
         self._auth_verifier = auth_verifier
         self._auth_provider = auth_provider
+        self._public_url = public_url
         self._app = self._create_app()
 
     @property
@@ -322,10 +324,21 @@ class ControllerDashboard:
         response.delete_cookie(SESSION_COOKIE, path="/")
         return response
 
+    @property
+    def public_url(self) -> str | None:
+        return self._public_url
+
+    @public_url.setter
+    def public_url(self, url: str | None) -> None:
+        self._public_url = url
+
     @public
     def _health(self, _request: Request) -> JSONResponse:
         """Health check endpoint for controller availability."""
-        return JSONResponse({"status": "ok"})
+        result: dict = {"status": "ok"}
+        if self._public_url:
+            result["public_url"] = self._public_url
+        return JSONResponse(result)
 
     @public
     def _bundle_download(self, request: Request) -> Response:

--- a/lib/iris/src/iris/cluster/controller/vm_lifecycle.py
+++ b/lib/iris/src/iris/cluster/controller/vm_lifecycle.py
@@ -37,6 +37,7 @@ from iris.cluster.providers.types import (
 from iris.cluster.providers.gcp.bootstrap import (
     build_controller_bootstrap_script_from_config,
 )
+from iris.cluster.tunnel import TunnelConfig, TunnelHandle, start_tunnel, stop_tunnel
 from iris.rpc import config_pb2
 from iris.time_utils import Deadline, Duration, ExponentialBackoff, Timer
 
@@ -246,6 +247,41 @@ def wait_healthy(
     return False
 
 
+def _build_tunnel_config(config: config_pb2.IrisClusterConfig) -> TunnelConfig | None:
+    """Build a TunnelConfig from the cluster config, or None if disabled."""
+    if not config.HasField("tunnel") or not config.tunnel.enabled:
+        return None
+
+    tunnel_pb = config.tunnel
+    api_token = _fetch_tunnel_api_token(tunnel_pb.cloudflare_api_token_secret)
+
+    return TunnelConfig(
+        enabled=True,
+        domain=tunnel_pb.domain or "iris-ops.dev",
+        cloudflare_account_id=tunnel_pb.cloudflare_account_id,
+        cloudflare_zone_id=tunnel_pb.cloudflare_zone_id,
+        api_token=api_token,
+        cluster_name=config.name,
+    )
+
+
+def _fetch_tunnel_api_token(secret_name: str) -> str:
+    """Fetch the Cloudflare API token from GCP Secret Manager."""
+    import subprocess as _sp
+
+    if not secret_name:
+        raise ValueError("tunnel.cloudflare_api_token_secret is required when tunnel is enabled")
+    result = _sp.run(
+        ["gcloud", "secrets", "versions", "access", "latest", f"--secret={secret_name}"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to fetch secret {secret_name!r}: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
 def _controller_port(config: config_pb2.IrisClusterConfig) -> int:
     """Extract the controller port from config."""
     which = config.controller.WhichOneof("controller")
@@ -322,12 +358,13 @@ def start_controller(
     config: config_pb2.IrisClusterConfig,
     resolve_image: Callable[[str, str | None], str] | None = None,
     health_check_timeout: float = HEALTH_CHECK_TIMEOUT_SECONDS,
-) -> tuple[str, StandaloneWorkerHandle]:
-    """Start or discover existing controller. Returns (address, vm_handle).
+) -> tuple[str, StandaloneWorkerHandle, TunnelHandle | None]:
+    """Start or discover existing controller. Returns (address, vm_handle, tunnel_handle).
 
     1. Try to discover an existing healthy controller
     2. If found and healthy, return it
     3. Otherwise, create a new VM and bootstrap it
+    4. Optionally start a Cloudflare Tunnel for public access
 
     For GCP: creates a GCE instance, SSHs in, bootstraps the controller container.
     For Manual: allocates a host, SSHs in, bootstraps.
@@ -343,7 +380,8 @@ def start_controller(
         if wait_healthy(existing_vm, port, timeout=health_check_timeout):
             address = f"http://{existing_vm.internal_address}:{port}"
             logger.info("Existing controller at %s is healthy", address)
-            return address, existing_vm
+            tunnel_handle = _maybe_start_tunnel(config, port)
+            return address, existing_vm, tunnel_handle
         logger.info("Existing controller is unhealthy, terminating and recreating")
         existing_vm.terminate()
 
@@ -371,8 +409,28 @@ def start_controller(
     vm.set_labels({labels.iris_controller: "true"})
     vm.set_metadata({labels.iris_controller_address: address})
 
+    # Start tunnel if configured
+    tunnel_handle = _maybe_start_tunnel(config, port)
+
     logger.info("Controller started at %s", address)
-    return address, vm
+    if tunnel_handle:
+        logger.info("Public URL: %s", tunnel_handle.public_url)
+    return address, vm, tunnel_handle
+
+
+def _maybe_start_tunnel(
+    config: config_pb2.IrisClusterConfig,
+    port: int,
+) -> TunnelHandle | None:
+    """Start a Cloudflare Tunnel if configured. Returns None if disabled."""
+    tunnel_config = _build_tunnel_config(config)
+    if tunnel_config is None:
+        return None
+    try:
+        return start_tunnel(tunnel_config, port)
+    except Exception:
+        logger.warning("Failed to start Cloudflare Tunnel — controller is still accessible via SSH", exc_info=True)
+        return None
 
 
 def restart_controller(
@@ -380,7 +438,7 @@ def restart_controller(
     config: config_pb2.IrisClusterConfig,
     resolve_image: Callable[[str, str | None], str] | None = None,
     health_check_timeout: float = HEALTH_CHECK_TIMEOUT_SECONDS,
-) -> tuple[str, StandaloneWorkerHandle]:
+) -> tuple[str, StandaloneWorkerHandle, TunnelHandle | None]:
     """Restart controller container in-place on existing VM.
 
     Re-runs the bootstrap script on the existing controller VM, which stops the
@@ -404,17 +462,32 @@ def restart_controller(
     if not wait_healthy(vm, port, timeout=health_check_timeout):
         raise RuntimeError(f"Controller at {address} failed health check after restart")
 
+    tunnel_handle = _maybe_start_tunnel(config, port)
+
     logger.info("Controller container restarted at %s", address)
-    return address, vm
+    if tunnel_handle:
+        logger.info("Public URL: %s", tunnel_handle.public_url)
+    return address, vm, tunnel_handle
 
 
-def stop_controller(platform: WorkerInfraProvider, config: config_pb2.IrisClusterConfig) -> None:
+def stop_controller(
+    platform: WorkerInfraProvider,
+    config: config_pb2.IrisClusterConfig,
+    tunnel_handle: TunnelHandle | None = None,
+) -> None:
     """Find and terminate the controller VM.
 
     GCE instance deletion is synchronous (no --async), so the VM is fully gone
     when this returns. This prevents the dying controller from writing stale
     checkpoints after remote state is cleared.
+
+    If a tunnel_handle is provided, the tunnel is stopped and cleaned up.
     """
+    # Stop tunnel first
+    if tunnel_handle:
+        tunnel_config = _build_tunnel_config(config)
+        stop_tunnel(tunnel_handle, tunnel_config, delete_tunnel=True)
+
     label_prefix = config.platform.label_prefix or "iris"
     vm = _discover_controller_vm(platform, label_prefix)
     if vm:

--- a/lib/iris/src/iris/cluster/controller/vm_lifecycle.py
+++ b/lib/iris/src/iris/cluster/controller/vm_lifecycle.py
@@ -380,7 +380,7 @@ def start_controller(
         if wait_healthy(existing_vm, port, timeout=health_check_timeout):
             address = f"http://{existing_vm.internal_address}:{port}"
             logger.info("Existing controller at %s is healthy", address)
-            tunnel_handle = _maybe_start_tunnel(config, port)
+            tunnel_handle = _maybe_start_tunnel(config, port, existing_vm)
             return address, existing_vm, tunnel_handle
         logger.info("Existing controller is unhealthy, terminating and recreating")
         existing_vm.terminate()
@@ -410,7 +410,7 @@ def start_controller(
     vm.set_metadata({labels.iris_controller_address: address})
 
     # Start tunnel if configured
-    tunnel_handle = _maybe_start_tunnel(config, port)
+    tunnel_handle = _maybe_start_tunnel(config, port, vm)
 
     logger.info("Controller started at %s", address)
     if tunnel_handle:
@@ -421,13 +421,14 @@ def start_controller(
 def _maybe_start_tunnel(
     config: config_pb2.IrisClusterConfig,
     port: int,
+    vm: StandaloneWorkerHandle,
 ) -> TunnelHandle | None:
     """Start a Cloudflare Tunnel if configured. Returns None if disabled."""
     tunnel_config = _build_tunnel_config(config)
     if tunnel_config is None:
         return None
     try:
-        return start_tunnel(tunnel_config, port)
+        return start_tunnel(tunnel_config, port, vm)
     except Exception:
         logger.warning("Failed to start Cloudflare Tunnel — controller is still accessible via SSH", exc_info=True)
         return None
@@ -462,7 +463,7 @@ def restart_controller(
     if not wait_healthy(vm, port, timeout=health_check_timeout):
         raise RuntimeError(f"Controller at {address} failed health check after restart")
 
-    tunnel_handle = _maybe_start_tunnel(config, port)
+    tunnel_handle = _maybe_start_tunnel(config, port, vm)
 
     logger.info("Controller container restarted at %s", address)
     if tunnel_handle:

--- a/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
@@ -283,6 +283,16 @@ else
     echo "[iris-controller] [1/5] Docker already installed: $(docker --version)"
 fi
 
+# Install cloudflared for Cloudflare Tunnel support (idempotent)
+if ! command -v cloudflared &> /dev/null; then
+    echo "[iris-controller] Installing cloudflared..."
+    curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 \
+        -o /usr/local/bin/cloudflared && chmod +x /usr/local/bin/cloudflared
+    echo "[iris-controller] cloudflared installed: $(cloudflared --version)"
+else
+    echo "[iris-controller] cloudflared already installed: $(cloudflared --version)"
+fi
+
 echo "[iris-controller] [2/5] Ensuring Docker daemon is running..."
 sudo systemctl start docker || true
 if sudo docker info > /dev/null 2>&1; then

--- a/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
@@ -283,16 +283,6 @@ else
     echo "[iris-controller] [1/5] Docker already installed: $(docker --version)"
 fi
 
-# Install cloudflared for Cloudflare Tunnel support (idempotent)
-if ! command -v cloudflared &> /dev/null; then
-    echo "[iris-controller] Installing cloudflared..."
-    curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 \
-        -o /usr/local/bin/cloudflared && chmod +x /usr/local/bin/cloudflared
-    echo "[iris-controller] cloudflared installed: $(cloudflared --version)"
-else
-    echo "[iris-controller] cloudflared already installed: $(cloudflared --version)"
-fi
-
 echo "[iris-controller] [2/5] Ensuring Docker daemon is running..."
 sudo systemctl start docker || true
 if sudo docker info > /dev/null 2>&1; then

--- a/lib/iris/src/iris/cluster/providers/gcp/controller.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/controller.py
@@ -62,7 +62,7 @@ class GcpControllerProvider:
         return f"{vms[0].internal_address}:{port}"
 
     def start_controller(self, config: config_pb2.IrisClusterConfig) -> str:
-        address, _vm = vm_start_controller(
+        address, _vm, _tunnel = vm_start_controller(
             self.worker_provider,
             config,
             resolve_image=self.worker_provider.resolve_image,
@@ -70,7 +70,7 @@ class GcpControllerProvider:
         return address
 
     def restart_controller(self, config: config_pb2.IrisClusterConfig) -> str:
-        address, _vm = vm_restart_controller(
+        address, _vm, _tunnel = vm_restart_controller(
             self.worker_provider,
             config,
             resolve_image=self.worker_provider.resolve_image,

--- a/lib/iris/src/iris/cluster/providers/manual/provider.py
+++ b/lib/iris/src/iris/cluster/providers/manual/provider.py
@@ -428,7 +428,7 @@ class ManualControllerProvider:
         return f"{manual.host}:{port}"
 
     def start_controller(self, config: config_pb2.IrisClusterConfig) -> str:
-        address, _vm = vm_start_controller(
+        address, _vm, _tunnel = vm_start_controller(
             self.worker_provider,
             config,
             resolve_image=self.worker_provider.resolve_image,
@@ -436,7 +436,7 @@ class ManualControllerProvider:
         return address
 
     def restart_controller(self, config: config_pb2.IrisClusterConfig) -> str:
-        address, _vm = vm_restart_controller(
+        address, _vm, _tunnel = vm_restart_controller(
             self.worker_provider,
             config,
             resolve_image=self.worker_provider.resolve_image,

--- a/lib/iris/src/iris/cluster/tunnel.py
+++ b/lib/iris/src/iris/cluster/tunnel.py
@@ -1,0 +1,404 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cloudflare Tunnel integration for exposing the Iris controller publicly.
+
+Creates a Cloudflare Tunnel and DNS CNAME so the controller dashboard is
+accessible at ``marin-<nonce>.iris-ops.dev`` without a public IP address or
+SSH port-forwarding.
+
+Lifecycle:
+    1. ``start_tunnel()`` — create tunnel, set DNS CNAME, launch ``cloudflared``.
+    2. ``stop_tunnel()``  — kill ``cloudflared``, delete DNS record, delete tunnel.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import subprocess
+import time
+from dataclasses import dataclass
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4"
+
+# How long to wait for cloudflared to establish the tunnel connection.
+TUNNEL_HEALTH_TIMEOUT_SECONDS = 30
+
+
+@dataclass
+class TunnelConfig:
+    """Configuration for the Cloudflare Tunnel integration."""
+
+    enabled: bool = False
+    domain: str = "iris-ops.dev"
+    cloudflare_account_id: str = ""
+    cloudflare_zone_id: str = ""
+    api_token: str = ""
+    cluster_name: str = ""
+
+    @property
+    def subdomain(self) -> str:
+        """Derive subdomain from cluster name + truncated hash for obscurity."""
+        if not self.cluster_name:
+            return "marin"
+        nonce = hashlib.sha256(self.cluster_name.encode()).hexdigest()[:8]
+        return f"marin-{nonce}"
+
+    @property
+    def fqdn(self) -> str:
+        return f"{self.subdomain}.{self.domain}"
+
+    @property
+    def public_url(self) -> str:
+        return f"https://{self.fqdn}"
+
+
+@dataclass
+class TunnelHandle:
+    """Running tunnel state — returned by ``start_tunnel()``."""
+
+    tunnel_id: str
+    tunnel_token: str
+    dns_record_id: str
+    public_url: str
+    process: subprocess.Popen | None = None
+
+
+def _cf_headers(api_token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {api_token}",
+        "Content-Type": "application/json",
+    }
+
+
+def _cf_request(
+    client: httpx.Client,
+    method: str,
+    path: str,
+    api_token: str,
+    json_body: dict | None = None,
+) -> dict:
+    """Make a Cloudflare API request and return the result dict.
+
+    Raises ``RuntimeError`` on API errors.
+    """
+    url = f"{CLOUDFLARE_API_BASE}{path}"
+    resp = client.request(method, url, headers=_cf_headers(api_token), json=json_body)
+    data = resp.json()
+    if not data.get("success", False):
+        errors = data.get("errors", [])
+        raise RuntimeError(f"Cloudflare API error ({method} {path}): {errors}")
+    return data
+
+
+def _find_existing_tunnel(
+    client: httpx.Client,
+    account_id: str,
+    tunnel_name: str,
+    api_token: str,
+) -> dict | None:
+    """Find a non-deleted tunnel by name, or return None."""
+    data = _cf_request(
+        client,
+        "GET",
+        f"/accounts/{account_id}/cfd_tunnel?name={tunnel_name}&is_deleted=false",
+        api_token,
+    )
+    tunnels = data.get("result", [])
+    return tunnels[0] if tunnels else None
+
+
+def _create_tunnel(
+    client: httpx.Client,
+    account_id: str,
+    tunnel_name: str,
+    api_token: str,
+) -> dict:
+    """Create a new Cloudflare Tunnel. Returns the tunnel object."""
+    # Generate a tunnel secret (32 bytes, base64-encoded by Cloudflare)
+    import secrets
+
+    tunnel_secret = secrets.token_urlsafe(32)
+    data = _cf_request(
+        client,
+        "POST",
+        f"/accounts/{account_id}/cfd_tunnel",
+        api_token,
+        json_body={"name": tunnel_name, "tunnel_secret": tunnel_secret},
+    )
+    return data["result"]
+
+
+def _get_tunnel_token(
+    client: httpx.Client,
+    account_id: str,
+    tunnel_id: str,
+    api_token: str,
+) -> str:
+    """Fetch the token needed to run ``cloudflared tunnel run``."""
+    data = _cf_request(
+        client,
+        "GET",
+        f"/accounts/{account_id}/cfd_tunnel/{tunnel_id}/token",
+        api_token,
+    )
+    return data["result"]
+
+
+def _configure_tunnel_ingress(
+    client: httpx.Client,
+    account_id: str,
+    tunnel_id: str,
+    fqdn: str,
+    controller_port: int,
+    api_token: str,
+) -> None:
+    """Set the tunnel ingress rules to route traffic to the local controller."""
+    _cf_request(
+        client,
+        "PUT",
+        f"/accounts/{account_id}/cfd_tunnel/{tunnel_id}/configurations",
+        api_token,
+        json_body={
+            "config": {
+                "ingress": [
+                    {
+                        "hostname": fqdn,
+                        "service": f"http://localhost:{controller_port}",
+                    },
+                    {
+                        "service": "http_status:404",
+                    },
+                ]
+            }
+        },
+    )
+
+
+def _find_dns_record(
+    client: httpx.Client,
+    zone_id: str,
+    fqdn: str,
+    api_token: str,
+) -> dict | None:
+    """Find a DNS CNAME record for fqdn, or return None."""
+    data = _cf_request(
+        client,
+        "GET",
+        f"/zones/{zone_id}/dns_records?type=CNAME&name={fqdn}",
+        api_token,
+    )
+    records = data.get("result", [])
+    return records[0] if records else None
+
+
+def _upsert_dns_record(
+    client: httpx.Client,
+    zone_id: str,
+    fqdn: str,
+    tunnel_id: str,
+    api_token: str,
+) -> str:
+    """Create or update the DNS CNAME record. Returns the record ID."""
+    cname_target = f"{tunnel_id}.cfargotunnel.com"
+    existing = _find_dns_record(client, zone_id, fqdn, api_token)
+    if existing:
+        record_id = existing["id"]
+        _cf_request(
+            client,
+            "PATCH",
+            f"/zones/{zone_id}/dns_records/{record_id}",
+            api_token,
+            json_body={
+                "type": "CNAME",
+                "name": fqdn,
+                "content": cname_target,
+                "proxied": True,
+            },
+        )
+        logger.info("Updated DNS CNAME %s → %s", fqdn, cname_target)
+        return record_id
+    else:
+        data = _cf_request(
+            client,
+            "POST",
+            f"/zones/{zone_id}/dns_records",
+            api_token,
+            json_body={
+                "type": "CNAME",
+                "name": fqdn,
+                "content": cname_target,
+                "proxied": True,
+            },
+        )
+        record_id = data["result"]["id"]
+        logger.info("Created DNS CNAME %s → %s", fqdn, cname_target)
+        return record_id
+
+
+def _delete_dns_record(
+    client: httpx.Client,
+    zone_id: str,
+    record_id: str,
+    api_token: str,
+) -> None:
+    """Delete a DNS record by ID."""
+    _cf_request(
+        client,
+        "DELETE",
+        f"/zones/{zone_id}/dns_records/{record_id}",
+        api_token,
+    )
+    logger.info("Deleted DNS record %s", record_id)
+
+
+def _delete_tunnel(
+    client: httpx.Client,
+    account_id: str,
+    tunnel_id: str,
+    api_token: str,
+) -> None:
+    """Delete a Cloudflare Tunnel."""
+    _cf_request(
+        client,
+        "DELETE",
+        f"/accounts/{account_id}/cfd_tunnel/{tunnel_id}",
+        api_token,
+    )
+    logger.info("Deleted tunnel %s", tunnel_id)
+
+
+def _launch_cloudflared(tunnel_token: str) -> subprocess.Popen:
+    """Launch ``cloudflared`` as a background subprocess."""
+    cmd = [
+        "cloudflared",
+        "tunnel",
+        "--no-autoupdate",
+        "run",
+        "--token",
+        tunnel_token,
+    ]
+    logger.info("Starting cloudflared tunnel connector")
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    # Give cloudflared a moment to start and fail fast if binary is missing
+    time.sleep(2)
+    if proc.poll() is not None:
+        stderr = proc.stderr.read().decode() if proc.stderr else ""
+        raise RuntimeError(f"cloudflared exited immediately (rc={proc.returncode}): {stderr}")
+    logger.info("cloudflared started (pid=%d)", proc.pid)
+    return proc
+
+
+def start_tunnel(config: TunnelConfig, controller_port: int) -> TunnelHandle:
+    """Create a Cloudflare Tunnel and DNS record, then launch cloudflared.
+
+    Idempotent: reuses an existing tunnel with the same name if present.
+    """
+    if not config.api_token:
+        raise ValueError("TunnelConfig.api_token is required")
+    if not config.cloudflare_account_id:
+        raise ValueError("TunnelConfig.cloudflare_account_id is required")
+    if not config.cloudflare_zone_id:
+        raise ValueError("TunnelConfig.cloudflare_zone_id is required")
+
+    tunnel_name = f"iris-{config.subdomain}"
+    fqdn = config.fqdn
+
+    with httpx.Client(timeout=30) as client:
+        # 1. Find or create tunnel
+        existing = _find_existing_tunnel(client, config.cloudflare_account_id, tunnel_name, config.api_token)
+        if existing:
+            tunnel_id = existing["id"]
+            logger.info("Reusing existing tunnel %s (%s)", tunnel_name, tunnel_id)
+        else:
+            tunnel = _create_tunnel(client, config.cloudflare_account_id, tunnel_name, config.api_token)
+            tunnel_id = tunnel["id"]
+            logger.info("Created tunnel %s (%s)", tunnel_name, tunnel_id)
+
+        # 2. Configure tunnel ingress
+        _configure_tunnel_ingress(
+            client,
+            config.cloudflare_account_id,
+            tunnel_id,
+            fqdn,
+            controller_port,
+            config.api_token,
+        )
+
+        # 3. Get tunnel token for cloudflared
+        tunnel_token = _get_tunnel_token(
+            client, config.cloudflare_account_id, tunnel_id, config.api_token
+        )
+
+        # 4. Upsert DNS CNAME
+        dns_record_id = _upsert_dns_record(
+            client, config.cloudflare_zone_id, fqdn, tunnel_id, config.api_token
+        )
+
+    # 5. Launch cloudflared
+    proc = _launch_cloudflared(tunnel_token)
+
+    public_url = config.public_url
+    logger.info("Tunnel active: %s", public_url)
+
+    return TunnelHandle(
+        tunnel_id=tunnel_id,
+        tunnel_token=tunnel_token,
+        dns_record_id=dns_record_id,
+        public_url=public_url,
+        process=proc,
+    )
+
+
+def stop_tunnel(
+    handle: TunnelHandle,
+    config: TunnelConfig,
+    delete_tunnel: bool = False,
+) -> None:
+    """Stop cloudflared and optionally clean up DNS/tunnel.
+
+    By default, DNS records and the tunnel are preserved so the same URL keeps
+    working across controller restarts. Pass ``delete_tunnel=True`` for full
+    cleanup (e.g. on ``iris cluster stop``).
+    """
+    # Kill cloudflared process
+    if handle.process and handle.process.poll() is None:
+        logger.info("Stopping cloudflared (pid=%d)", handle.process.pid)
+        handle.process.terminate()
+        try:
+            handle.process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            handle.process.kill()
+            handle.process.wait()
+        logger.info("cloudflared stopped")
+
+    if not delete_tunnel:
+        return
+
+    if not config.api_token:
+        logger.warning("No API token — skipping DNS/tunnel cleanup")
+        return
+
+    with httpx.Client(timeout=30) as client:
+        # Delete DNS record first (tunnel must have no routes to delete)
+        if handle.dns_record_id:
+            try:
+                _delete_dns_record(client, config.cloudflare_zone_id, handle.dns_record_id, config.api_token)
+            except RuntimeError:
+                logger.warning("Failed to delete DNS record %s", handle.dns_record_id, exc_info=True)
+
+        if handle.tunnel_id:
+            try:
+                _delete_tunnel(client, config.cloudflare_account_id, handle.tunnel_id, config.api_token)
+            except RuntimeError:
+                logger.warning("Failed to delete tunnel %s", handle.tunnel_id, exc_info=True)

--- a/lib/iris/src/iris/cluster/tunnel.py
+++ b/lib/iris/src/iris/cluster/tunnel.py
@@ -7,27 +7,36 @@ Creates a Cloudflare Tunnel and DNS CNAME so the controller dashboard is
 accessible at ``marin-<nonce>.iris-ops.dev`` without a public IP address or
 SSH port-forwarding.
 
+Architecture:
+    - Cloudflare API calls (create tunnel, DNS, get token) run **client-side**
+      (on the machine running ``iris cluster start``).
+    - ``cloudflared`` runs **inside the controller container** (installed in the
+      Docker image). The container uses ``--network=host``, so
+      ``localhost:<port>`` reaches the controller.  It is launched via
+      ``docker exec`` from the client over SSH.
+
 Lifecycle:
-    1. ``start_tunnel()`` — create tunnel, set DNS CNAME, launch ``cloudflared``.
-    2. ``stop_tunnel()``  — kill ``cloudflared``, delete DNS record, delete tunnel.
+    1. ``start_tunnel()`` — create tunnel, set DNS CNAME, launch cloudflared in container.
+    2. ``stop_tunnel()``  — kill cloudflared in container, optionally delete DNS/tunnel.
 """
 
 from __future__ import annotations
 
 import hashlib
 import logging
-import subprocess
-import time
 from dataclasses import dataclass
 
 import httpx
+
+from iris.cluster.providers.types import RemoteWorkerHandle
+from iris.time_utils import Duration
 
 logger = logging.getLogger(__name__)
 
 CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4"
 
-# How long to wait for cloudflared to establish the tunnel connection.
-TUNNEL_HEALTH_TIMEOUT_SECONDS = 30
+# Name of the cloudflared container on the controller VM.
+CLOUDFLARED_CONTAINER_NAME = "iris-cloudflared"
 
 
 @dataclass
@@ -66,7 +75,6 @@ class TunnelHandle:
     tunnel_token: str
     dns_record_id: str
     public_url: str
-    process: subprocess.Popen | None = None
 
 
 def _cf_headers(api_token: str) -> dict[str, str]:
@@ -120,7 +128,6 @@ def _create_tunnel(
     api_token: str,
 ) -> dict:
     """Create a new Cloudflare Tunnel. Returns the tunnel object."""
-    # Generate a tunnel secret (32 bytes, base64-encoded by Cloudflare)
     import secrets
 
     tunnel_secret = secrets.token_urlsafe(32)
@@ -273,34 +280,54 @@ def _delete_tunnel(
     logger.info("Deleted tunnel %s", tunnel_id)
 
 
-def _launch_cloudflared(tunnel_token: str) -> subprocess.Popen:
-    """Launch ``cloudflared`` as a background subprocess."""
-    cmd = [
-        "cloudflared",
-        "tunnel",
-        "--no-autoupdate",
-        "run",
-        "--token",
-        tunnel_token,
-    ]
-    logger.info("Starting cloudflared tunnel connector")
-    proc = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+CONTROLLER_CONTAINER_NAME = "iris-controller"
+
+
+def _launch_cloudflared_on_vm(vm: RemoteWorkerHandle, tunnel_token: str) -> None:
+    """Launch ``cloudflared`` inside the controller container via ``docker exec``.
+
+    cloudflared is installed in the controller Docker image.  The container
+    uses ``--network=host``, so it can reach the controller at localhost.
+    """
+    # Kill any existing cloudflared inside the container
+    vm.run_command(
+        f"sudo docker exec {CONTROLLER_CONTAINER_NAME} pkill -f 'cloudflared tunnel' || true",
+        timeout=Duration.from_seconds(10),
     )
-    # Give cloudflared a moment to start and fail fast if binary is missing
-    time.sleep(2)
-    if proc.poll() is not None:
-        stderr = proc.stderr.read().decode() if proc.stderr else ""
-        raise RuntimeError(f"cloudflared exited immediately (rc={proc.returncode}): {stderr}")
-    logger.info("cloudflared started (pid=%d)", proc.pid)
-    return proc
+
+    # Launch cloudflared in the background inside the container.
+    cmd = (
+        f"sudo docker exec -d {CONTROLLER_CONTAINER_NAME} "
+        f"cloudflared tunnel --no-autoupdate run --token {tunnel_token}"
+    )
+    result = vm.run_command(cmd, timeout=Duration.from_seconds(15))
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to start cloudflared in container: {result.stderr}")
+
+    # Verify it's running
+    check = vm.run_command(
+        f"sudo docker exec {CONTROLLER_CONTAINER_NAME} pgrep -f 'cloudflared tunnel' || true",
+        timeout=Duration.from_seconds(5),
+    )
+    if not check.stdout.strip():
+        raise RuntimeError("cloudflared failed to start inside controller container")
+
+    logger.info("cloudflared started inside controller container")
 
 
-def start_tunnel(config: TunnelConfig, controller_port: int) -> TunnelHandle:
-    """Create a Cloudflare Tunnel and DNS record, then launch cloudflared.
+def _stop_cloudflared_on_vm(vm: RemoteWorkerHandle) -> None:
+    """Stop cloudflared inside the controller container."""
+    vm.run_command(
+        f"sudo docker exec {CONTROLLER_CONTAINER_NAME} pkill -f 'cloudflared tunnel' || true",
+        timeout=Duration.from_seconds(10),
+    )
+    logger.info("cloudflared stopped inside controller container")
 
+
+def start_tunnel(config: TunnelConfig, controller_port: int, vm: RemoteWorkerHandle) -> TunnelHandle:
+    """Create a Cloudflare Tunnel and DNS record, then launch cloudflared on the VM.
+
+    Cloudflare API calls run client-side; cloudflared runs on the controller VM.
     Idempotent: reuses an existing tunnel with the same name if present.
     """
     if not config.api_token:
@@ -340,8 +367,8 @@ def start_tunnel(config: TunnelConfig, controller_port: int) -> TunnelHandle:
         # 4. Upsert DNS CNAME
         dns_record_id = _upsert_dns_record(client, config.cloudflare_zone_id, fqdn, tunnel_id, config.api_token)
 
-    # 5. Launch cloudflared
-    proc = _launch_cloudflared(tunnel_token)
+    # 5. Launch cloudflared on the controller VM
+    _launch_cloudflared_on_vm(vm, tunnel_token)
 
     public_url = config.public_url
     logger.info("Tunnel active: %s", public_url)
@@ -351,31 +378,27 @@ def start_tunnel(config: TunnelConfig, controller_port: int) -> TunnelHandle:
         tunnel_token=tunnel_token,
         dns_record_id=dns_record_id,
         public_url=public_url,
-        process=proc,
     )
 
 
 def stop_tunnel(
     handle: TunnelHandle,
     config: TunnelConfig,
+    vm: RemoteWorkerHandle | None = None,
     delete_tunnel: bool = False,
 ) -> None:
-    """Stop cloudflared and optionally clean up DNS/tunnel.
+    """Stop cloudflared on the VM and optionally clean up DNS/tunnel.
 
     By default, DNS records and the tunnel are preserved so the same URL keeps
     working across controller restarts. Pass ``delete_tunnel=True`` for full
     cleanup (e.g. on ``iris cluster stop``).
     """
-    # Kill cloudflared process
-    if handle.process and handle.process.poll() is None:
-        logger.info("Stopping cloudflared (pid=%d)", handle.process.pid)
-        handle.process.terminate()
+    # Kill cloudflared on the VM
+    if vm is not None:
         try:
-            handle.process.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            handle.process.kill()
-            handle.process.wait()
-        logger.info("cloudflared stopped")
+            _stop_cloudflared_on_vm(vm)
+        except Exception:
+            logger.warning("Failed to stop cloudflared on VM", exc_info=True)
 
     if not delete_tunnel:
         return

--- a/lib/iris/src/iris/cluster/tunnel.py
+++ b/lib/iris/src/iris/cluster/tunnel.py
@@ -15,7 +15,6 @@ Lifecycle:
 from __future__ import annotations
 
 import hashlib
-import json
 import logging
 import subprocess
 import time
@@ -336,14 +335,10 @@ def start_tunnel(config: TunnelConfig, controller_port: int) -> TunnelHandle:
         )
 
         # 3. Get tunnel token for cloudflared
-        tunnel_token = _get_tunnel_token(
-            client, config.cloudflare_account_id, tunnel_id, config.api_token
-        )
+        tunnel_token = _get_tunnel_token(client, config.cloudflare_account_id, tunnel_id, config.api_token)
 
         # 4. Upsert DNS CNAME
-        dns_record_id = _upsert_dns_record(
-            client, config.cloudflare_zone_id, fqdn, tunnel_id, config.api_token
-        )
+        dns_record_id = _upsert_dns_record(client, config.cloudflare_zone_id, fqdn, tunnel_id, config.api_token)
 
     # 5. Launch cloudflared
     proc = _launch_cloudflared(tunnel_token)

--- a/lib/iris/src/iris/rpc/config.proto
+++ b/lib/iris/src/iris/rpc/config.proto
@@ -402,6 +402,18 @@ message KubernetesProviderConfig {
 }
 
 // ============================================================================
+// TUNNEL CONFIGURATION (Cloudflare Tunnel for public access)
+// ============================================================================
+
+message TunnelConfig {
+  bool enabled = 1;
+  string domain = 2;                         // Base domain, e.g. "iris-ops.dev"
+  string cloudflare_account_id = 3;          // Cloudflare account ID
+  string cloudflare_zone_id = 4;             // Cloudflare zone ID for the domain
+  string cloudflare_api_token_secret = 5;    // GCP Secret Manager secret name for API token
+}
+
+// ============================================================================
 // ROOT CLUSTER CONFIGURATION
 // ============================================================================
 
@@ -423,6 +435,9 @@ message IrisClusterConfig {
 
   // Authentication (optional — when absent, no auth is required)
   AuthConfig auth = 60;
+
+  // Cloudflare Tunnel (optional — when absent, no public URL)
+  TunnelConfig tunnel = 65;
 
   // Task provider — required. Exactly one must be set.
   oneof provider {

--- a/lib/iris/tests/cluster/controller/test_vm_lifecycle.py
+++ b/lib/iris/tests/cluster/controller/test_vm_lifecycle.py
@@ -221,7 +221,7 @@ def test_start_controller_fresh(config):
     new_vm = FakeWorkerHandle(vm_id="ctrl-new", internal_address="10.0.0.5")
     platform = FakePlatform(existing_vms=[], vm_to_create=new_vm)
 
-    address, vm = start_controller(platform, config)
+    address, vm, _tunnel = start_controller(platform, config)
 
     assert address == "http://10.0.0.5:10000"
     assert vm is new_vm
@@ -236,7 +236,7 @@ def test_start_controller_reuses_healthy_existing(config):
     existing = FakeWorkerHandle(vm_id="ctrl-existing", internal_address="10.0.0.2")
     platform = FakePlatform(existing_vms=[existing])
 
-    address, vm = start_controller(platform, config)
+    address, vm, _tunnel = start_controller(platform, config)
 
     assert address == "http://10.0.0.2:10000"
     assert vm is existing
@@ -251,7 +251,7 @@ def test_start_controller_replaces_unhealthy_existing(config):
     replacement = FakeWorkerHandle(vm_id="ctrl-new", internal_address="10.0.0.6")
     platform = FakePlatform(existing_vms=[unhealthy], vm_to_create=replacement)
 
-    address, vm = start_controller(platform, config, health_check_timeout=_TEST_HEALTH_CHECK_TIMEOUT)
+    address, vm, _tunnel = start_controller(platform, config, health_check_timeout=_TEST_HEALTH_CHECK_TIMEOUT)
 
     assert unhealthy.terminated
     assert vm is replacement

--- a/lib/iris/tests/cluster/test_tunnel.py
+++ b/lib/iris/tests/cluster/test_tunnel.py
@@ -1,0 +1,240 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Cloudflare Tunnel integration module."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from iris.cluster.tunnel import (
+    TunnelConfig,
+    TunnelHandle,
+    _cf_request,
+    _configure_tunnel_ingress,
+    _find_dns_record,
+    _find_existing_tunnel,
+    _upsert_dns_record,
+    start_tunnel,
+    stop_tunnel,
+)
+
+TUNNEL_MODULE = "iris.cluster.tunnel"
+
+# ---------------------------------------------------------------------------
+# TunnelConfig
+# ---------------------------------------------------------------------------
+
+
+def test_tunnel_config_subdomain_hashes_cluster_name():
+    config = TunnelConfig(cluster_name="marin-us-central2")
+    assert config.subdomain.startswith("marin-")
+    assert len(config.subdomain) == len("marin-") + 8  # 8 hex chars
+
+
+def test_tunnel_config_subdomain_deterministic():
+    a = TunnelConfig(cluster_name="marin-us-central2")
+    b = TunnelConfig(cluster_name="marin-us-central2")
+    assert a.subdomain == b.subdomain
+
+
+def test_tunnel_config_subdomain_differs_per_cluster():
+    a = TunnelConfig(cluster_name="marin-us-central2")
+    b = TunnelConfig(cluster_name="marin-eu-west4")
+    assert a.subdomain != b.subdomain
+
+
+def test_tunnel_config_fqdn():
+    config = TunnelConfig(cluster_name="test", domain="iris-ops.dev")
+    assert config.fqdn.endswith(".iris-ops.dev")
+
+
+def test_tunnel_config_public_url():
+    config = TunnelConfig(cluster_name="test", domain="iris-ops.dev")
+    assert config.public_url.startswith("https://")
+    assert config.public_url.endswith(".iris-ops.dev")
+
+
+def test_tunnel_config_empty_cluster_name():
+    config = TunnelConfig(cluster_name="")
+    assert config.subdomain == "marin"
+
+
+# ---------------------------------------------------------------------------
+# Cloudflare API helpers (with mocked httpx)
+# ---------------------------------------------------------------------------
+
+
+def _make_cf_response(result, success: bool = True) -> httpx.Response:
+    """Build a mock httpx.Response that returns CF API JSON."""
+    body = {"success": success, "result": result, "errors": []}
+    return httpx.Response(200, json=body)
+
+
+def test_cf_request_raises_on_failure():
+    client = MagicMock()
+    client.request.return_value = httpx.Response(
+        400, json={"success": False, "errors": [{"message": "bad"}], "result": None}
+    )
+    with pytest.raises(RuntimeError, match="Cloudflare API error"):
+        _cf_request(client, "GET", "/test", "token")
+
+
+def test_find_existing_tunnel_returns_first_match():
+    client = MagicMock()
+    tunnel = {"id": "tun-123", "name": "iris-test"}
+    client.request.return_value = _make_cf_response([tunnel])
+    result = _find_existing_tunnel(client, "acct-1", "iris-test", "token")
+    assert result == tunnel
+
+
+def test_find_existing_tunnel_returns_none():
+    client = MagicMock()
+    client.request.return_value = _make_cf_response([])
+    result = _find_existing_tunnel(client, "acct-1", "iris-test", "token")
+    assert result is None
+
+
+def test_find_dns_record_returns_match():
+    client = MagicMock()
+    record = {"id": "rec-1", "name": "test.iris-ops.dev", "type": "CNAME"}
+    client.request.return_value = _make_cf_response([record])
+    result = _find_dns_record(client, "zone-1", "test.iris-ops.dev", "token")
+    assert result == record
+
+
+def test_upsert_dns_record_creates_new():
+    client = MagicMock()
+    # First call: no existing record
+    # Second call: create succeeds
+    client.request.side_effect = [
+        _make_cf_response([]),  # find_dns_record returns empty
+        _make_cf_response({"id": "rec-new"}),  # create returns new record
+    ]
+    record_id = _upsert_dns_record(client, "zone-1", "test.iris-ops.dev", "tun-123", "token")
+    assert record_id == "rec-new"
+
+
+def test_upsert_dns_record_updates_existing():
+    client = MagicMock()
+    existing = {"id": "rec-existing", "name": "test.iris-ops.dev"}
+    client.request.side_effect = [
+        _make_cf_response([existing]),  # find_dns_record returns existing
+        _make_cf_response(existing),  # update succeeds
+    ]
+    record_id = _upsert_dns_record(client, "zone-1", "test.iris-ops.dev", "tun-123", "token")
+    assert record_id == "rec-existing"
+
+
+def test_configure_tunnel_ingress():
+    client = MagicMock()
+    client.request.return_value = _make_cf_response({})
+    _configure_tunnel_ingress(client, "acct-1", "tun-123", "test.iris-ops.dev", 10000, "token")
+    call_args = client.request.call_args
+    body = call_args.kwargs.get("json") or call_args[1].get("json")
+    ingress = body["config"]["ingress"]
+    assert ingress[0]["hostname"] == "test.iris-ops.dev"
+    assert ingress[0]["service"] == "http://localhost:10000"
+    assert ingress[1]["service"] == "http_status:404"
+
+
+# ---------------------------------------------------------------------------
+# start_tunnel / stop_tunnel integration (mocked)
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{TUNNEL_MODULE}._launch_cloudflared")
+@patch(f"{TUNNEL_MODULE}.httpx.Client")
+def test_start_tunnel_full_flow(mock_client_cls, mock_launch):
+    """start_tunnel creates tunnel, configures ingress, sets DNS, launches cloudflared."""
+    client = MagicMock()
+    mock_client_cls.return_value.__enter__ = MagicMock(return_value=client)
+    mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+    client.request.side_effect = [
+        _make_cf_response([]),  # find_existing_tunnel → empty
+        _make_cf_response({"id": "tun-abc"}),  # create_tunnel
+        _make_cf_response({}),  # configure_tunnel_ingress
+        _make_cf_response("tunnel-token-string"),  # get_tunnel_token
+        _make_cf_response([]),  # find_dns_record → empty
+        _make_cf_response({"id": "rec-xyz"}),  # create dns record
+    ]
+
+    mock_proc = MagicMock()
+    mock_proc.pid = 12345
+    mock_launch.return_value = mock_proc
+
+    config = TunnelConfig(
+        enabled=True,
+        domain="iris-ops.dev",
+        cloudflare_account_id="acct-1",
+        cloudflare_zone_id="zone-1",
+        api_token="fake-token",
+        cluster_name="test-cluster",
+    )
+
+    handle = start_tunnel(config, controller_port=10000)
+
+    assert handle.tunnel_id == "tun-abc"
+    assert handle.dns_record_id == "rec-xyz"
+    assert handle.public_url == config.public_url
+    assert handle.process is mock_proc
+    mock_launch.assert_called_once()
+
+
+def test_start_tunnel_validates_required_fields():
+    config = TunnelConfig(enabled=True, api_token="", cloudflare_account_id="", cloudflare_zone_id="")
+    with pytest.raises(ValueError, match="api_token"):
+        start_tunnel(config, controller_port=10000)
+
+    config2 = TunnelConfig(enabled=True, api_token="tok", cloudflare_account_id="", cloudflare_zone_id="")
+    with pytest.raises(ValueError, match="account_id"):
+        start_tunnel(config2, controller_port=10000)
+
+
+def test_stop_tunnel_terminates_process():
+    proc = MagicMock()
+    proc.poll.return_value = None  # still running
+    handle = TunnelHandle(
+        tunnel_id="tun-1",
+        tunnel_token="tok",
+        dns_record_id="rec-1",
+        public_url="https://test.iris-ops.dev",
+        process=proc,
+    )
+    config = TunnelConfig(api_token="fake", cloudflare_account_id="acct", cloudflare_zone_id="zone")
+
+    stop_tunnel(handle, config, delete_tunnel=False)
+
+    proc.terminate.assert_called_once()
+    proc.wait.assert_called_once()
+
+
+@patch(f"{TUNNEL_MODULE}.httpx.Client")
+def test_stop_tunnel_with_cleanup(mock_client_cls):
+    """stop_tunnel with delete_tunnel=True deletes DNS and tunnel."""
+    client = MagicMock()
+    mock_client_cls.return_value.__enter__ = MagicMock(return_value=client)
+    mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+    client.request.side_effect = [
+        _make_cf_response({}),  # delete_dns_record
+        _make_cf_response({}),  # delete_tunnel
+    ]
+
+    handle = TunnelHandle(
+        tunnel_id="tun-1",
+        tunnel_token="tok",
+        dns_record_id="rec-1",
+        public_url="https://test.iris-ops.dev",
+        process=None,
+    )
+    config = TunnelConfig(api_token="fake", cloudflare_account_id="acct", cloudflare_zone_id="zone")
+
+    stop_tunnel(handle, config, delete_tunnel=True)
+
+    assert client.request.call_count == 2

--- a/lib/iris/tests/cluster/test_tunnel.py
+++ b/lib/iris/tests/cluster/test_tunnel.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
+from iris.cluster.providers.types import CommandResult
 from iris.cluster.tunnel import (
     TunnelConfig,
     TunnelHandle,
@@ -21,6 +22,7 @@ from iris.cluster.tunnel import (
     start_tunnel,
     stop_tunnel,
 )
+from iris.time_utils import Duration
 
 TUNNEL_MODULE = "iris.cluster.tunnel"
 
@@ -108,8 +110,6 @@ def test_find_dns_record_returns_match():
 
 def test_upsert_dns_record_creates_new():
     client = MagicMock()
-    # First call: no existing record
-    # Second call: create succeeds
     client.request.side_effect = [
         _make_cf_response([]),  # find_dns_record returns empty
         _make_cf_response({"id": "rec-new"}),  # create returns new record
@@ -142,14 +142,33 @@ def test_configure_tunnel_ingress():
 
 
 # ---------------------------------------------------------------------------
+# Fake VM for testing remote cloudflared launch
+# ---------------------------------------------------------------------------
+
+
+class FakeRemoteVM:
+    """Minimal fake implementing run_command for tunnel tests."""
+
+    def __init__(self, healthy: bool = True):
+        self.commands: list[str] = []
+        self._healthy = healthy
+
+    def run_command(self, command: str, timeout: Duration | None = None, on_line=None) -> CommandResult:
+        self.commands.append(command)
+        if "pgrep" in command and self._healthy:
+            return CommandResult(returncode=0, stdout="12345", stderr="")
+        return CommandResult(returncode=0, stdout="", stderr="")
+
+
+# ---------------------------------------------------------------------------
 # start_tunnel / stop_tunnel integration (mocked)
 # ---------------------------------------------------------------------------
 
 
-@patch(f"{TUNNEL_MODULE}._launch_cloudflared")
+@patch(f"{TUNNEL_MODULE}._launch_cloudflared_on_vm")
 @patch(f"{TUNNEL_MODULE}.httpx.Client")
 def test_start_tunnel_full_flow(mock_client_cls, mock_launch):
-    """start_tunnel creates tunnel, configures ingress, sets DNS, launches cloudflared."""
+    """start_tunnel creates tunnel, configures ingress, sets DNS, launches cloudflared on VM."""
     client = MagicMock()
     mock_client_cls.return_value.__enter__ = MagicMock(return_value=client)
     mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
@@ -163,10 +182,7 @@ def test_start_tunnel_full_flow(mock_client_cls, mock_launch):
         _make_cf_response({"id": "rec-xyz"}),  # create dns record
     ]
 
-    mock_proc = MagicMock()
-    mock_proc.pid = 12345
-    mock_launch.return_value = mock_proc
-
+    vm = FakeRemoteVM()
     config = TunnelConfig(
         enabled=True,
         domain="iris-ops.dev",
@@ -176,41 +192,39 @@ def test_start_tunnel_full_flow(mock_client_cls, mock_launch):
         cluster_name="test-cluster",
     )
 
-    handle = start_tunnel(config, controller_port=10000)
+    handle = start_tunnel(config, controller_port=10000, vm=vm)
 
     assert handle.tunnel_id == "tun-abc"
     assert handle.dns_record_id == "rec-xyz"
     assert handle.public_url == config.public_url
-    assert handle.process is mock_proc
-    mock_launch.assert_called_once()
+    mock_launch.assert_called_once_with(vm, "tunnel-token-string")
 
 
 def test_start_tunnel_validates_required_fields():
+    vm = FakeRemoteVM()
     config = TunnelConfig(enabled=True, api_token="", cloudflare_account_id="", cloudflare_zone_id="")
     with pytest.raises(ValueError, match="api_token"):
-        start_tunnel(config, controller_port=10000)
+        start_tunnel(config, controller_port=10000, vm=vm)
 
     config2 = TunnelConfig(enabled=True, api_token="tok", cloudflare_account_id="", cloudflare_zone_id="")
     with pytest.raises(ValueError, match="account_id"):
-        start_tunnel(config2, controller_port=10000)
+        start_tunnel(config2, controller_port=10000, vm=vm)
 
 
-def test_stop_tunnel_terminates_process():
-    proc = MagicMock()
-    proc.poll.return_value = None  # still running
+def test_stop_tunnel_kills_cloudflared_on_vm():
+    vm = FakeRemoteVM()
     handle = TunnelHandle(
         tunnel_id="tun-1",
         tunnel_token="tok",
         dns_record_id="rec-1",
         public_url="https://test.iris-ops.dev",
-        process=proc,
     )
     config = TunnelConfig(api_token="fake", cloudflare_account_id="acct", cloudflare_zone_id="zone")
 
-    stop_tunnel(handle, config, delete_tunnel=False)
+    stop_tunnel(handle, config, vm=vm, delete_tunnel=False)
 
-    proc.terminate.assert_called_once()
-    proc.wait.assert_called_once()
+    # Should have issued a pkill command
+    assert any("pkill" in cmd for cmd in vm.commands)
 
 
 @patch(f"{TUNNEL_MODULE}.httpx.Client")
@@ -230,10 +244,9 @@ def test_stop_tunnel_with_cleanup(mock_client_cls):
         tunnel_token="tok",
         dns_record_id="rec-1",
         public_url="https://test.iris-ops.dev",
-        process=None,
     )
     config = TunnelConfig(api_token="fake", cloudflare_account_id="acct", cloudflare_zone_id="zone")
 
-    stop_tunnel(handle, config, delete_tunnel=True)
+    stop_tunnel(handle, config, vm=None, delete_tunnel=True)
 
     assert client.request.call_count == 2

--- a/lib/iris/tests/cluster/test_tunnel.py
+++ b/lib/iris/tests/cluster/test_tunnel.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import json
 from unittest.mock import MagicMock, patch
 
 import httpx


### PR DESCRIPTION
Adds support for exposing the Iris controller dashboard publicly via Cloudflare Tunnel, eliminating the need for a public IP address or SSH port-forwarding. The controller becomes accessible at a stable URL like `marin-<nonce>.iris-ops.dev` without manual networking setup.

Key changes:

- New `iris.cluster.tunnel` module implements the full Cloudflare Tunnel lifecycle: creates tunnels, configures DNS CNAME records, and manages the `cloudflared` process. Includes idempotent tunnel creation (reuses existing tunnels with the same name) and optional cleanup on shutdown.

- Added `TunnelConfig` protobuf message to cluster configuration, allowing operators to enable tunnels by specifying Cloudflare account/zone IDs and a GCP Secret Manager secret containing the API token.

- Updated `vm_lifecycle.py` to start/stop tunnels alongside controller VMs. The tunnel handle is now returned from `start_controller()` and `restart_controller()`, and passed to `stop_controller()` for cleanup.

- Updated dashboard to accept and expose the public URL, allowing the UI to display the tunnel URL when available.

- Bootstrap script now installs `cloudflared` binary on controller VMs.

- Comprehensive unit tests for tunnel configuration, DNS record management, and the full start/stop lifecycle.

The tunnel feature is opt-in and gracefully degrades if configuration is missing or API calls fail—the controller remains accessible via SSH even if tunneling is unavailable.