### PR TITLE
[iris] Fix dev cluster restart ghcr.io auth failure

### DIFF
--- a/.github/workflows/iris-coreweave-dev-restart.yaml
+++ b/.github/workflows/iris-coreweave-dev-restart.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 concurrency:
   group: iris-coreweave-dev-restart
@@ -31,6 +32,13 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "lib/iris/pyproject.toml"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Write kubeconfig
         run: |

--- a/.github/workflows/iris-dev-restart.yaml
+++ b/.github/workflows/iris-dev-restart.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 concurrency:
   group: iris-dev-restart
@@ -41,6 +42,13 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Write SSH key
         run: |


### PR DESCRIPTION
The controller restart command builds Docker images and pushes them to
ghcr.io/marin-community/, but both dev restart workflows were missing
packages:write permission and the docker/login-action step, causing
pushes to fail with "unauthenticated". Adds both to iris-dev-restart.yaml
and iris-coreweave-dev-restart.yaml, matching docker-images.yaml.