### PR TITLE
[iris] Increase GCP smoke test shell poll timeout

### DIFF
--- a/.github/workflows/iris-cloud-smoke-gcp.yaml
+++ b/.github/workflows/iris-cloud-smoke-gcp.yaml
@@ -130,7 +130,7 @@ jobs:
             --worker-timeout 600 &
           START_PID=$!
           echo "START_PID=$START_PID" >> "$GITHUB_ENV"
-          for i in $(seq 1 360); do
+          for i in $(seq 1 900); do
             if [ -f /tmp/iris-controller-url ]; then
               echo "Cluster ready!"
               echo "IRIS_CONTROLLER_URL=$(cat /tmp/iris-controller-url)" >> "$GITHUB_ENV"


### PR DESCRIPTION
The shell loop waiting for the controller URL file had a 720s budget
(seq 1 360 * 2s) shared between image build/push and worker startup.
When Docker push was slow in CI (~10min), workers had <90s to register
before the shell killed the process. Observed in run 23498489452 where
the tunnel came up at 15:56:54 but the shell timed out at 15:58:22.

Increase to seq 1 900 (1800s) so the Python-side --worker-timeout 600
becomes the effective deadline for worker readiness.

Reproduced locally: cluster came up in 376s with the fix.