### PR TITLE
Fix ResourceConfig serialization and remove asia-northeast1 buckets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test:
 	RAY_ADDRESS= PYTHONPATH=tests:. pytest tests --durations=0 -n 4 --tb=no -v
 
 # Define regions and tags for the Docker images
-CLUSTER_REPOS = us-central2 us-central1 europe-west4 us-west4 asia-northeast1 us-east5 us-east1
+CLUSTER_REPOS = us-central2 us-central1 europe-west4 us-west4 us-east5 us-east1
 TAG_DATE = $(shell date -u +"%Y%m%d")
 TAG_VERSIONS = latest $(shell git rev-parse --short HEAD) $(TAG_DATE)
 

--- a/infra/configure_temp_buckets.py
+++ b/infra/configure_temp_buckets.py
@@ -26,7 +26,6 @@ logger = logging.getLogger(__name__)
 
 # Dedicated tmp buckets, one per region.
 BUCKETS: dict[str, str] = {
-    "marin-tmp-asia-northeast-1": "asia-northeast1",
     "marin-tmp-us-central1": "us-central1",
     "marin-tmp-us-central2": "us-central2",
     "marin-tmp-eu-west4": "europe-west4",

--- a/lib/iris/src/iris/marin_fs.py
+++ b/lib/iris/src/iris/marin_fs.py
@@ -52,7 +52,6 @@ _DEFAULT_LOCAL_PREFIX = "/tmp/marin"
 # Canonical mapping from GCP region to marin-tmp bucket name.
 # Must stay in sync with infra/configure_temp_buckets.py BUCKETS dict.
 REGION_TO_TMP_BUCKET: dict[str, str] = {
-    "asia-northeast1": "marin-tmp-asia-northeast-1",
     "us-central1": "marin-tmp-us-central1",
     "us-central2": "marin-tmp-us-central2",
     "europe-west4": "marin-tmp-eu-west4",
@@ -77,7 +76,6 @@ REGION_TO_DATA_BUCKET: dict[str, str] = {
     "us-east5": "marin-us-east5",
     "us-west4": "marin-us-west4",
     "europe-west4": "marin-eu-west4",
-    "asia-northeast1": "marin-asia-northeast1",
 }
 
 # Reverse lookup: bucket name → canonical GCP region.

--- a/lib/marin/src/marin/utilities/json_encoder.py
+++ b/lib/marin/src/marin/utilities/json_encoder.py
@@ -1,6 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
 import json
 import logging
 from datetime import timedelta
@@ -20,6 +21,8 @@ class CustomJsonEncoder(json.JSONEncoder):
             return str(obj)
         if obj in (float32, bfloat16):
             return str(obj)
+        if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+            return dataclasses.asdict(obj)
         try:
             return super().default(obj)
         except TypeError:


### PR DESCRIPTION
- **Fix `ResourceConfig` serialization**: `CustomJsonEncoder` now handles dataclass instances via `dataclasses.asdict()`, eliminating the "Could not serialize object of type ResourceConfig" warning during version computation.
- **Remove non-existent `asia-northeast1` buckets**: The `mirror://` filesystem was scanning `gs://marin-asia-northeast1` which doesn't exist, causing `Forbidden` errors. Removed from `REGION_TO_DATA_BUCKET`, `REGION_TO_TMP_BUCKET`, `configure_temp_buckets.py`, and `Makefile` CLUSTER_REPOS.