### PR TITLE
fix(iris): hash workdir tokens to prevent ENAMETOOLONG for nested jobs

### DIFF
--- a/lib/iris/src/iris/cluster/types.py
+++ b/lib/iris/src/iris/cluster/types.py
@@ -12,6 +12,7 @@ This module provides Python types for the Iris cluster API:
 Wire-format types (ResourceSpecProto, JobStatus, etc.) are defined in cluster.proto.
 """
 
+import hashlib
 import os
 import sys
 from collections.abc import Callable, Sequence
@@ -165,8 +166,14 @@ class JobName:
         return other._parts[: len(self._parts)] == self._parts
 
     def to_safe_token(self) -> str:
-        """Return a filesystem/tag-safe token derived from this name."""
-        return "job__" + "__".join(self._parts)
+        """Return a filesystem/tag-safe token derived from this name.
+
+        Uses ``<user>-<sha256-hex>`` so the token stays short even for deeply
+        nested job hierarchies (avoids ``ENAMETOOLONG`` on workdir creation).
+        The full canonical name is hashed to preserve uniqueness.
+        """
+        digest = hashlib.sha256(str(self).encode()).hexdigest()
+        return f"{self.user}-{digest}"
 
     def require_task(self) -> tuple["JobName", int]:
         """Return (parent_job, task_index) for task names.

--- a/lib/iris/tests/cluster/test_types.py
+++ b/lib/iris/tests/cluster/test_types.py
@@ -101,9 +101,22 @@ def test_job_name_require_task_errors_on_non_task():
 
 
 def test_job_name_to_safe_token_and_deep_nesting():
+    import hashlib
+
     job = JobName.from_string("/test-user/a/b/c/d/e/0")
-    assert job.to_safe_token() == "job__test-user__a__b__c__d__e__0"
+    expected_hash = hashlib.sha256(str(job).encode()).hexdigest()
+    assert job.to_safe_token() == f"test-user-{expected_hash}"
     assert job.require_task()[1] == 0
+
+    # Deeply nested names still produce short tokens (no ENAMETOOLONG).
+    deep = JobName.from_string("/alice/" + "/".join(f"layer-{i}" for i in range(20)) + "/0")
+    token = deep.to_safe_token()
+    assert token.startswith("alice-")
+    assert len(token) < 128  # well under the 255-byte filesystem limit
+
+    # Different names produce different tokens.
+    job2 = JobName.from_string("/test-user/a/b/c/d/e/1")
+    assert job.to_safe_token() != job2.to_safe_token()
 
 
 def test_job_name_depth():


### PR DESCRIPTION
Deeply nested Iris job names could produce workdir path components exceeding the 255-byte filesystem limit, crashing worker setup with `ENAMETOOLONG`.

Changes `JobName.to_safe_token()` to return `<user>-<sha256>` instead of the full flattened name, keeping the token short and unique.

Fixes #4103