### PR TITLE
[iris] Use npx for Playwright system deps on CI cache hit

### DIFF
--- a/.github/workflows/iris-cloud-smoke-gcp.yaml
+++ b/.github/workflows/iris-cloud-smoke-gcp.yaml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Install Playwright system deps
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
+        run: npx --yes playwright@1.57.0 install-deps chromium
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/.github/workflows/iris-unit-tests.yaml
+++ b/.github/workflows/iris-unit-tests.yaml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Install Playwright system deps
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
+        run: npx --yes playwright@1.57.0 install-deps chromium
 
       - name: Run E2E smoke tests
         env:


### PR DESCRIPTION
On Playwright browser cache hit, uv run playwright install-deps rebuilds the entire Python venv (~5 min) just to run apt-get for system libraries. Switch to npx playwright install-deps which only needs Node.js (already set up in both workflows) and takes seconds.