### PR TITLE
[infra] Remove OIDC auth from Claude workflows, use OAuth token

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -39,7 +39,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,7 +40,6 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
       actions: read
     steps:
       - name: Checkout repository
@@ -88,7 +87,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
+
       actions: read
     steps:
       - name: Checkout repository
@@ -174,7 +173,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
+
       actions: read
     steps:
       - name: Checkout PR branch

--- a/.github/workflows/nightshift-cleanup.yml
+++ b/.github/workflows/nightshift-cleanup.yml
@@ -18,7 +18,6 @@ jobs:
       pull-requests: write
       issues: write
       actions: read
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/nightshift-doc-drift.yml
+++ b/.github/workflows/nightshift-doc-drift.yml
@@ -18,7 +18,6 @@ jobs:
       pull-requests: write
       issues: write
       actions: read
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Drop id-token: write from all four Claude workflow files (claude-review,
claude, nightshift-cleanup, nightshift-doc-drift). The pull_request_target
event produces an OIDC token whose sub claim differs from pull_request,
which Anthropic's backend rejects during the app token exchange. Without
id-token permission the action skips OIDC and authenticates via the
existing OAuth token secret directly.