### PR TITLE
[iris] Use buildx --push for atomic build+push+cache-write

### DIFF
--- a/lib/iris/src/iris/cli/build.py
+++ b/lib/iris/src/iris/cli/build.py
@@ -207,6 +207,10 @@ def build_image(
     Always tags the image with both the git SHA and "latest" so that
     deployments can pin to a specific version while local workflows
     continue to use "latest".
+
+    When ``push=True``, images are pushed directly via ``docker buildx build --push``
+    and the registry cache is updated in the same operation. The images are NOT
+    loaded into the local Docker daemon (buildx cannot do both simultaneously).
     """
     # Controller and worker images COPY dashboard/dist — ensure it exists.
     if image_type in ("controller", "worker"):
@@ -227,7 +231,18 @@ def build_image(
 
     click.echo(f"Using Dockerfile: {dockerfile_path}")
 
-    all_tags = dict.fromkeys([tag, sha_tag, latest_tag])
+    if push:
+        # Fully-qualified GHCR tags for the registry push
+        all_tags = dict.fromkeys(
+            [
+                f"ghcr.io/{ghcr_org}/{tag}",
+                f"ghcr.io/{ghcr_org}/{sha_tag}",
+                f"ghcr.io/{ghcr_org}/{latest_tag}",
+            ]
+        )
+    else:
+        all_tags = dict.fromkeys([tag, sha_tag, latest_tag])
+
     cmd = ["docker", "buildx", "build", "--platform", platform]
     cmd.extend(["--target", image_type])
     cmd.extend(["--build-arg", f"IRIS_GIT_HASH={git_sha}"])
@@ -235,12 +250,16 @@ def build_image(
         cmd.extend(["-t", t])
     cmd.extend(["-f", str(dockerfile_path)])
 
-    # Use the weekly GHCR image as a build cache source so that cold builds
-    # (new runner, branch switch) only rebuild layers that actually changed.
-    cache_ref = f"ghcr.io/{ghcr_org}/iris-{image_type}:latest"
+    cache_ref = f"ghcr.io/{ghcr_org}/iris-cache:{image_type}"
     cmd.extend(["--cache-from", f"type=registry,ref={cache_ref}"])
 
-    cmd.extend(["--output", f"type=docker,compression=zstd,compression-level=1,name={tag}"])
+    if push:
+        cmd.extend(["--cache-to", f"type=registry,ref={cache_ref},mode=max"])
+        cmd.extend(["--output", "type=image,compression=zstd,compression-level=3,push=true"])
+        cmd.append("--provenance=false")
+    else:
+        cmd.extend(["--output", f"type=docker,compression=zstd,compression-level=1,name={tag}"])
+
     cmd.append(str(context_path))
 
     extra = [t for t in all_tags if t != tag]
@@ -248,6 +267,8 @@ def build_image(
     click.echo(f"Building image: {tag}{extra_msg}")
     click.echo(f"Platform: {platform}")
     click.echo(f"Context: {context_path}")
+    if push:
+        click.echo("Push: enabled (images will be pushed to registry)")
     click.echo()
 
     if verbose:
@@ -263,16 +284,16 @@ def build_image(
                 click.echo(result.stderr, err=True)
         raise SystemExit(1)
 
-    # buildx --output=docker only loads one name; tag the rest manually
-    for t in extra:
-        subprocess.run(["docker", "tag", tag, t], check=True)
+    if not push:
+        # buildx --output=docker only loads one name; tag the rest manually
+        for t in extra:
+            subprocess.run(["docker", "tag", tag, t], check=True)
 
     click.echo("Build successful!")
-    click.echo(f"Image available locally as: {', '.join(all_tags)}")
-
     if push:
-        push_to_ghcr(sha_tag, ghcr_org=ghcr_org, verbose=verbose)
-        push_to_ghcr(latest_tag, ghcr_org=ghcr_org, verbose=verbose)
+        click.echo(f"Images pushed to: {', '.join(all_tags)}")
+    else:
+        click.echo(f"Image available locally as: {', '.join(all_tags)}")
 
 
 def _build_all(

--- a/lib/iris/src/iris/cli/cluster.py
+++ b/lib/iris/src/iris/cli/cluster.py
@@ -19,7 +19,6 @@ from iris.cli.build import (
     build_image,
     find_marin_root,
     get_git_sha,
-    push_to_ghcr,
 )
 from iris.cli.main import require_controller_url
 from iris.cluster.config import IrisConfig, clear_remote_state, make_local_config
@@ -98,14 +97,12 @@ def _build_and_push_for_tag(image_tag: str, image_type: str, verbose: bool = Fal
     build_image(
         image_type=image_type,
         tag=local_tag,
-        push=False,
+        push=True,
         context=None,
         platform="linux/amd64",
         ghcr_org=org,
         verbose=verbose,
     )
-    click.echo()
-    push_to_ghcr(local_tag, ghcr_org=org, image_name=image_name, version=version, verbose=verbose)
     click.echo()
 
 
@@ -129,14 +126,12 @@ def _build_and_push_task_image(task_tag: str, verbose: bool = False) -> None:
     build_image(
         image_type="task",
         tag=local_tag,
-        push=False,
+        push=True,
         context=marin_root,
         platform="linux/amd64",
         ghcr_org=org,
         verbose=verbose,
     )
-    click.echo()
-    push_to_ghcr(local_tag, ghcr_org=org, image_name=image_name, version=version, verbose=verbose)
     click.echo()
 
 


### PR DESCRIPTION
Push images directly via buildx --output=type=image,push=true instead
of building locally then running docker push separately. This lets
--cache-to write the registry cache in the same operation, so every
CI and cluster build keeps the cache fresh (not just the weekly job).
Previously only the weekly docker-images.yaml wrote cache; smoke tests
and cluster deploys rebuilt from scratch every time.