### PR TITLE
fix(iris): add Docker Buildx setup to smoke test workflows

### DIFF
--- a/.github/workflows/iris-cloud-smoke-cw.yaml
+++ b/.github/workflows/iris-cloud-smoke-cw.yaml
@@ -77,6 +77,9 @@ jobs:
           echo "${{ secrets.CW_KUBECONFIG }}" > ~/.kube/coreweave-iris
           chmod 600 ~/.kube/coreweave-iris
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/iris-cloud-smoke-gcp.yaml
+++ b/.github/workflows/iris-cloud-smoke-gcp.yaml
@@ -109,6 +109,9 @@ jobs:
           echo "${{ secrets.MARIN_SSH_KEY }}" > ~/.ssh/marin_ray_cluster.pem
           chmod 600 ~/.ssh/marin_ray_cluster.pem
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Smoke test workflows (GCP and CoreWeave) were missing the
docker/setup-buildx-action step. After b140fd2 switched iris build to use
buildx --push with registry cache, the default docker driver fails with
"Cache export is not supported for the docker driver." Adding the buildx
setup creates the docker-container driver that supports cache export.