### PR TITLE
[infra] Revert pull_request_target to pull_request and restore id-token: write

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,7 +1,7 @@
 name: Claude PR Review
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, ready_for_review, reopened]
   issue_comment:
     # NOTE: there's no PR comment specific event, so instead we need to check all comments and filter in the job.
@@ -16,7 +16,7 @@ jobs:
   review:
     if: >-
       (
-        github.event_name == 'pull_request_target' &&
+        github.event_name == 'pull_request' &&
         (
           github.event.pull_request.author_association == 'OWNER' ||
           github.event.pull_request.author_association == 'MEMBER' ||
@@ -39,6 +39,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -49,7 +50,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
-          track_progress: ${{ github.event_name == 'pull_request_target' }}
+          track_progress: ${{ github.event_name == 'pull_request' }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,6 +40,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
       actions: read
     steps:
       - name: Checkout repository
@@ -87,7 +88,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-
+      id-token: write
       actions: read
     steps:
       - name: Checkout repository
@@ -173,7 +174,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-
+      id-token: write
       actions: read
     steps:
       - name: Checkout PR branch

--- a/.github/workflows/nightshift-cleanup.yml
+++ b/.github/workflows/nightshift-cleanup.yml
@@ -17,6 +17,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
       actions: read
     steps:
       - name: Checkout repository

--- a/.github/workflows/nightshift-doc-drift.yml
+++ b/.github/workflows/nightshift-doc-drift.yml
@@ -17,6 +17,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
       actions: read
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Revert claude-review.yml from pull_request_target back to pull_request. pull_request_target does not provide OIDC environment variables (ACTIONS_ID_TOKEN_REQUEST_URL) for fork PRs, which causes claude-code-action to fail with "Could not fetch an OIDC token". Also restores id-token: write permissions across all Claude workflows, removed in acc004137.