### PR TITLE
fix(iris): add Docker Buildx setup to GPU canary workflow

### DIFF
--- a/.github/workflows/marin-canary-ferry-cw.yaml
+++ b/.github/workflows/marin-canary-ferry-cw.yaml
@@ -64,6 +64,9 @@ jobs:
           echo "${{ secrets.CW_KUBECONFIG }}" > ~/.kube/coreweave-iris
           chmod 600 ~/.kube/coreweave-iris
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary
- add `docker/setup-buildx-action@v3` to the CoreWeave GPU canary workflow before `iris cluster start`
- align the canary workflow with the Buildx requirement introduced by `#4139`

## Testing
- not run (workflow-only change)