### PR TITLE
Use iris bundle for Ray working_dir to include pb2 files

### DIFF
--- a/lib/fray/src/fray/v1/cluster/ray/cluster.py
+++ b/lib/fray/src/fray/v1/cluster/ray/cluster.py
@@ -276,13 +276,13 @@ class RayCluster(Cluster):
                 pip_packages=list(environment.pip_packages),
                 env_vars=env_vars,
             )
-            from iris.cluster.client.bundle import create_workspace_zip  # lazy: avoid PyPI iris conflict on workers
+            import re
 
-            runtime_env["working_dir"] = create_workspace_zip(
+            from iris.cluster.client.bundle import create_workspace_dir  # lazy: avoid PyPI iris conflict on workers
+
+            runtime_env["working_dir"] = create_workspace_dir(
                 environment.workspace,
-                exclude_dirs={"tests", "docs"},
-                exclude_extensions={".pack"},
-                max_size_bytes=None,
+                exclude=re.compile(r"^(tests|docs)(/|$)|\.pack$"),
             )
             runtime_env["config"] = {"setup_timeout_seconds": 1800}
         else:

--- a/lib/fray/src/fray/v2/ray_backend/backend.py
+++ b/lib/fray/src/fray/v2/ray_backend/backend.py
@@ -208,13 +208,13 @@ def build_runtime_env(request: JobRequest) -> dict:
             pip_packages=list(environment.pip_packages),
             env_vars=env_vars,
         )
-        from iris.cluster.client.bundle import create_workspace_zip  # lazy: avoid PyPI iris conflict on workers
+        import re
 
-        runtime_env["working_dir"] = create_workspace_zip(
+        from iris.cluster.client.bundle import create_workspace_dir  # lazy: avoid PyPI iris conflict on workers
+
+        runtime_env["working_dir"] = create_workspace_dir(
             environment.workspace,
-            exclude_dirs={"tests", "docs"},
-            exclude_extensions={".pack"},
-            max_size_bytes=None,
+            exclude=re.compile(r"^(tests|docs)(/|$)|\.pack$"),
         )
         runtime_env["config"] = {"setup_timeout_seconds": 1800}
     else:

--- a/lib/iris/src/iris/cluster/client/bundle.py
+++ b/lib/iris/src/iris/cluster/client/bundle.py
@@ -6,6 +6,8 @@
 import atexit
 import logging
 import os
+import re
+import shutil
 import subprocess
 import tempfile
 import zipfile
@@ -16,26 +18,29 @@ logger = logging.getLogger(__name__)
 # Maximum bundle size in bytes (25 MB)
 MAX_BUNDLE_SIZE_BYTES = 25 * 1024 * 1024
 
-EXCLUDE_EXTENSIONS = {".mov", ".pyc"}
-
-EXCLUDE_DIRS = {
-    "__pycache__",
-    ".git",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".ruff_cache",
-    ".venv",
-    "node_modules",
-    "venv",
-}
-
-EXCLUDE_SUBPATHS = {
-    "docs/figures",
-    "docs/images",
-    "docs/reports",
-    "docs/static",
-    "tests/snapshot",
-}
+# Default exclude pattern applied to all bundles.  Matches against the
+# *relative* path (forward-slash separated, no leading slash).
+DEFAULT_EXCLUDE = re.compile(
+    r"""
+      \.mov$                        # video files
+    | \.pyc$                        # bytecode
+    | \.egg-info(/|$)               # egg metadata
+    | (^|/)__pycache__(/|$)         # pycache at any depth
+    | (^|/)\.git(/|$)               # .git at any depth
+    | (^|/)\.mypy_cache(/|$)
+    | (^|/)\.pytest_cache(/|$)
+    | (^|/)\.ruff_cache(/|$)
+    | (^|/)\.venv(/|$)
+    | (^|/)node_modules(/|$)
+    | (^|/)venv(/|$)
+    | ^docs/figures(/|$)
+    | ^docs/images(/|$)
+    | ^docs/reports(/|$)
+    | ^docs/static(/|$)
+    | ^tests/snapshot(/|$)
+    """,
+    re.VERBOSE,
+)
 
 # Glob patterns for generated files that are gitignored but required at runtime.
 # These are produced by build hooks (e.g. hatch_build.py protobuf generation)
@@ -51,43 +56,109 @@ GENERATED_ARTIFACT_GLOBS = [
 ]
 
 
-def _should_exclude(
-    relative: Path,
-    extra_dirs: set[str] | None = None,
-    extra_extensions: set[str] | None = None,
-    extra_subpaths: set[str] | None = None,
-) -> bool:
-    """Check whether a relative path should be excluded from the bundle.
-
-    Default EXCLUDE_DIRS (e.g. __pycache__, .git) are matched at any depth.
-    Caller-supplied extra_dirs are matched only against the top-level directory
-    component, mirroring Ray's excludes behavior (e.g. "tests/" excludes only
-    the top-level tests directory, not lib/foo/tests/).
-    """
-    all_extensions = EXCLUDE_EXTENSIONS | (extra_extensions or set())
-    all_subpaths = EXCLUDE_SUBPATHS | (extra_subpaths or set())
-
-    if relative.suffix in all_extensions:
-        return True
-    # e.g. foo.egg-info
-    if any(part.endswith(".egg-info") for part in relative.parts):
-        return True
-    # Default dirs excluded at any depth
-    if any(part in EXCLUDE_DIRS for part in relative.parts):
-        return True
-    # Caller-supplied dirs excluded only at the top level
-    if extra_dirs and relative.parts and relative.parts[0] in extra_dirs:
-        return True
-    rel_str = str(relative)
-    return any(subpath in rel_str for subpath in all_subpaths)
+def _should_exclude(relative: str, exclude: re.Pattern[str]) -> bool:
+    return bool(exclude.search(relative))
 
 
-def get_git_non_ignored_files(
-    workspace: Path,
+def _merge_exclude(extra: re.Pattern[str] | None) -> re.Pattern[str]:
+    if extra is None:
+        return DEFAULT_EXCLUDE
+    return re.compile(f"(?:{DEFAULT_EXCLUDE.pattern})|(?:{extra.pattern})", re.VERBOSE)
+
+
+def collect_workspace_files(
+    workspace: str | Path,
     *,
-    exclude_dirs: set[str] | None = None,
-    exclude_extensions: set[str] | None = None,
-    exclude_subpaths: set[str] | None = None,
+    exclude: re.Pattern[str] | None = None,
+) -> list[Path]:
+    """Collect the list of files to include in a workspace bundle.
+
+    Uses git ls-files when available (respecting .gitignore), then adds back
+    generated protobuf artifacts that are gitignored but needed at runtime.
+    Falls back to pattern-based exclusion when git is unavailable.
+
+    Args:
+        workspace: Root directory to bundle.
+        exclude: Extra regex to exclude (merged with DEFAULT_EXCLUDE).
+
+    Returns:
+        Sorted list of absolute paths.
+    """
+    workspace = Path(workspace)
+    merged = _merge_exclude(exclude)
+
+    git_files = _get_git_non_ignored_files(workspace, merged)
+    if git_files is not None:
+        _include_generated_build_artifacts(workspace, git_files, merged)
+        return sorted(f for f in git_files if f.is_file())
+
+    return sorted(
+        f for f in workspace.rglob("*") if f.is_file() and not _should_exclude(str(f.relative_to(workspace)), merged)
+    )
+
+
+def create_workspace_zip(
+    workspace: str | Path,
+    *,
+    exclude: re.Pattern[str] | None = None,
+    max_size_bytes: int | None = MAX_BUNDLE_SIZE_BYTES,
+) -> bytes:
+    """Create a zip of the workspace and return the raw bytes.
+
+    Suitable for Iris bundle uploads where the caller sends bytes directly.
+    """
+    workspace = Path(workspace)
+    files = collect_workspace_files(workspace, exclude=exclude)
+
+    fd, tmp_path = tempfile.mkstemp(suffix=".zip", prefix="workspace_")
+    os.close(fd)
+    try:
+        with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for file in files:
+                zf.write(file, file.relative_to(workspace))
+        buf = Path(tmp_path).read_bytes()
+    finally:
+        os.unlink(tmp_path)
+
+    if max_size_bytes is not None and len(buf) > max_size_bytes:
+        size_mb = len(buf) / (1024 * 1024)
+        max_mb = max_size_bytes / (1024 * 1024)
+        raise ValueError(
+            f"Bundle size {size_mb:.1f}MB exceeds maximum {max_mb:.0f}MB. "
+            "Consider excluding large files or using .gitignore."
+        )
+
+    return buf
+
+
+def create_workspace_dir(
+    workspace: str | Path,
+    *,
+    exclude: re.Pattern[str] | None = None,
+) -> str:
+    """Copy workspace files into a temporary directory for Ray's working_dir.
+
+    Ray's JobSubmissionClient expects a directory path: it zips and uploads it
+    internally. The temp directory is cleaned up at process exit via atexit.
+    """
+    workspace = Path(workspace)
+    files = collect_workspace_files(workspace, exclude=exclude)
+
+    tmp_dir = tempfile.mkdtemp(prefix="workspace_")
+    atexit.register(lambda d=tmp_dir: shutil.rmtree(d, ignore_errors=True))
+
+    for file in files:
+        rel = file.relative_to(workspace)
+        dest = Path(tmp_dir) / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(file, dest)
+
+    return tmp_dir
+
+
+def _get_git_non_ignored_files(
+    workspace: Path,
+    exclude: re.Pattern[str],
 ) -> set[Path] | None:
     """Get files that are not ignored by git.
 
@@ -101,120 +172,31 @@ def get_git_non_ignored_files(
             text=True,
             check=True,
         )
-        files = [Path(f) for f in result.stdout.splitlines() if f]
-        files = [f for f in files if not _should_exclude(f, exclude_dirs, exclude_extensions, exclude_subpaths)]
+        files = [f for f in result.stdout.splitlines() if f and not _should_exclude(f, exclude)]
         return {workspace / f for f in files}
     except (subprocess.CalledProcessError, FileNotFoundError) as e:
         logger.debug("Git not available, using pattern-based exclusion: %s", e)
         return None
 
 
-def include_generated_build_artifacts(
+def _include_generated_build_artifacts(
     workspace: Path,
     files: set[Path],
-    *,
-    exclude_dirs: set[str] | None = None,
-    exclude_extensions: set[str] | None = None,
-    exclude_subpaths: set[str] | None = None,
+    exclude: re.Pattern[str],
 ) -> None:
     """Add generated build artifacts that exist on disk but are gitignored."""
     added = 0
     for pattern in GENERATED_ARTIFACT_GLOBS:
         for path in workspace.glob(pattern):
-            if (
-                path.is_file()
-                and path not in files
-                and not _should_exclude(path.relative_to(workspace), exclude_dirs, exclude_extensions, exclude_subpaths)
-            ):
+            if path.is_file() and path not in files and not _should_exclude(str(path.relative_to(workspace)), exclude):
                 files.add(path)
                 added += 1
     if added:
         logger.debug("Included %d generated build artifact(s) in bundle", added)
 
 
-def create_workspace_zip(
-    workspace: str | Path,
-    *,
-    exclude_dirs: set[str] | None = None,
-    exclude_extensions: set[str] | None = None,
-    exclude_subpaths: set[str] | None = None,
-    max_size_bytes: int | None = MAX_BUNDLE_SIZE_BYTES,
-) -> str:
-    """Create a zip of the workspace suitable for Ray's working_dir or Iris bundles.
-
-    Uses git ls-files to determine which files to include (respecting .gitignore),
-    then adds back generated protobuf artifacts that are gitignored but needed at
-    runtime. When git is unavailable, falls back to pattern-based exclusion.
-
-    Args:
-        workspace: Root directory to bundle.
-        exclude_dirs: Additional directory names to exclude (merged with defaults).
-        exclude_extensions: Additional file extensions to exclude (merged with defaults).
-        exclude_subpaths: Additional subpath strings to exclude (merged with defaults).
-        max_size_bytes: Maximum allowed zip size. Pass None to disable the check.
-
-    Returns:
-        Path to the created zip file.  The file is cleaned up automatically
-        at process exit via atexit.  Ray accepts zip file paths directly as
-        working_dir, so no intermediate directory is needed.
-    """
-    workspace = Path(workspace)
-
-    git_files = get_git_non_ignored_files(
-        workspace,
-        exclude_dirs=exclude_dirs,
-        exclude_extensions=exclude_extensions,
-        exclude_subpaths=exclude_subpaths,
-    )
-    if git_files is not None:
-        include_generated_build_artifacts(
-            workspace,
-            git_files,
-            exclude_dirs=exclude_dirs,
-            exclude_extensions=exclude_extensions,
-            exclude_subpaths=exclude_subpaths,
-        )
-
-    # Create a temp *file* (not directory) so Ray can use the path directly as
-    # working_dir.  Register cleanup on process exit.
-    fd, zip_path_str = tempfile.mkstemp(suffix=".zip", prefix="workspace_")
-    os.close(fd)
-    zip_path = Path(zip_path_str)
-    atexit.register(lambda p=zip_path_str: os.unlink(p) if os.path.exists(p) else None)
-
-    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-        if git_files is not None:
-            for file in git_files:
-                if file.is_file():
-                    zf.write(file, file.relative_to(workspace))
-        else:
-            for file in workspace.rglob("*"):
-                rel = file.relative_to(workspace)
-                if file.is_file() and not _should_exclude(rel, exclude_dirs, exclude_extensions, exclude_subpaths):
-                    zf.write(file, rel)
-
-    if max_size_bytes is not None:
-        zip_size = zip_path.stat().st_size
-        if zip_size > max_size_bytes:
-            zip_size_mb = zip_size / (1024 * 1024)
-            max_size_mb = max_size_bytes / (1024 * 1024)
-            raise ValueError(
-                f"Bundle size {zip_size_mb:.1f}MB exceeds maximum {max_size_mb:.0f}MB. "
-                "Consider excluding large files or using .gitignore."
-            )
-
-    return str(zip_path)
-
-
 class BundleCreator:
-    """Helper for creating workspace bundles for Iris job submission.
-
-    Bundles a user's workspace directory (containing pyproject.toml, uv.lock,
-    and source code) into a zip file for job execution.
-
-    The workspace must already have iris as a dependency in pyproject.toml.
-    If uv.lock doesn't exist, it will be generated.
-    """
+    """Helper for creating workspace bundles for Iris job submission."""
 
     def __init__(self, workspace: Path):
         self._workspace = workspace
@@ -228,5 +210,4 @@ class BundleCreator:
         Raises:
             ValueError: If bundle size exceeds MAX_BUNDLE_SIZE_BYTES
         """
-        zip_path = create_workspace_zip(self._workspace, max_size_bytes=MAX_BUNDLE_SIZE_BYTES)
-        return Path(zip_path).read_bytes()
+        return create_workspace_zip(self._workspace, max_size_bytes=MAX_BUNDLE_SIZE_BYTES)

--- a/lib/iris/tests/cluster/client/test_bundle.py
+++ b/lib/iris/tests/cluster/client/test_bundle.py
@@ -1,22 +1,19 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for BundleCreator and create_workspace_zip."""
+"""Tests for workspace bundling."""
 
-import io
 import os
-import zipfile
-from pathlib import Path
+import re
 from unittest.mock import patch
 
 import pytest
 
-from iris.cluster.client.bundle import MAX_BUNDLE_SIZE_BYTES, BundleCreator, create_workspace_zip
+from iris.cluster.client.bundle import MAX_BUNDLE_SIZE_BYTES, collect_workspace_files, create_workspace_zip
 
 
 @pytest.fixture
 def workspace(tmp_path):
-    """Create a test workspace."""
     (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'\n")
     (tmp_path / "src").mkdir()
     (tmp_path / "src" / "main.py").write_text("print('hello')")
@@ -25,62 +22,54 @@ def workspace(tmp_path):
     return tmp_path
 
 
-def test_bundle_creator_uses_fallback_when_git_unavailable(workspace):
-    with patch("iris.cluster.client.bundle.get_git_non_ignored_files", return_value=None):
-        creator = BundleCreator(workspace)
-        bundle_bytes = creator.create_bundle()
-
-    with zipfile.ZipFile(io.BytesIO(bundle_bytes)) as zf:
-        names = zf.namelist()
-        assert "pyproject.toml" in names
-        assert "src/main.py" in names
-        assert not any("__pycache__" in n for n in names)
+def _mock_git_none():
+    return patch("iris.cluster.client.bundle._get_git_non_ignored_files", return_value=None)
 
 
-def test_bundle_creator_uses_git_files_when_available(workspace):
-    git_files = {workspace / "pyproject.toml", workspace / "src" / "main.py"}
-    with patch("iris.cluster.client.bundle.get_git_non_ignored_files", return_value=git_files):
-        creator = BundleCreator(workspace)
-        bundle_bytes = creator.create_bundle()
-
-    with zipfile.ZipFile(io.BytesIO(bundle_bytes)) as zf:
-        names = zf.namelist()
-        assert "pyproject.toml" in names
-        assert "src/main.py" in names
-        assert not any("__pycache__" in n for n in names)
+def _mock_git_files(workspace, *rel_paths):
+    files = {workspace / p for p in rel_paths}
+    return patch("iris.cluster.client.bundle._get_git_non_ignored_files", return_value=files)
 
 
-def test_bundle_includes_generated_proto_files(workspace):
-    """Generated protobuf files (gitignored) are included in the bundle."""
+def test_collect_falls_back_when_git_unavailable(workspace):
+    with _mock_git_none():
+        files = collect_workspace_files(workspace)
+    rel = {str(f.relative_to(workspace)) for f in files}
+    assert "pyproject.toml" in rel
+    assert "src/main.py" in rel
+    assert not any("__pycache__" in r for r in rel)
+
+
+def test_collect_includes_generated_proto_files(workspace):
     rpc_dir = workspace / "src" / "iris" / "rpc"
     rpc_dir.mkdir(parents=True)
     (rpc_dir / "cluster_pb2.py").write_text("# generated")
     (rpc_dir / "cluster_pb2.pyi").write_text("# generated")
     (rpc_dir / "cluster_connect.py").write_text("# generated")
 
-    # Simulate git ls-files returning only tracked files (not the generated ones)
-    git_files = {workspace / "pyproject.toml", workspace / "src" / "main.py"}
-    with patch("iris.cluster.client.bundle.get_git_non_ignored_files") as mock_git:
-        # Call the real function's logic but with controlled git output,
-        # then verify generated files are added via include_generated_build_artifacts.
-        mock_git.return_value = git_files
-        creator = BundleCreator(workspace)
-        bundle_bytes = creator.create_bundle()
-
-    with zipfile.ZipFile(io.BytesIO(bundle_bytes)) as zf:
-        names = zf.namelist()
-        assert "src/iris/rpc/cluster_pb2.py" in names
-        assert "src/iris/rpc/cluster_pb2.pyi" in names
-        assert "src/iris/rpc/cluster_connect.py" in names
+    with _mock_git_files(workspace, "pyproject.toml", "src/main.py"):
+        files = collect_workspace_files(workspace)
+    rel = {str(f.relative_to(workspace)) for f in files}
+    assert "src/iris/rpc/cluster_pb2.py" in rel
+    assert "src/iris/rpc/cluster_pb2.pyi" in rel
+    assert "src/iris/rpc/cluster_connect.py" in rel
 
 
-def test_bundle_creator_rejects_oversized_bundles(workspace):
-    """Test that bundles exceeding MAX_BUNDLE_SIZE_BYTES are rejected."""
+def test_collect_respects_extra_exclude(workspace):
+    (workspace / "data").mkdir()
+    (workspace / "data" / "big.csv").write_text("1,2,3")
+
+    with _mock_git_none():
+        files = collect_workspace_files(workspace, exclude=re.compile(r"^data(/|$)"))
+    rel = {str(f.relative_to(workspace)) for f in files}
+    assert "data/big.csv" not in rel
+    assert "pyproject.toml" in rel
+
+
+def test_zip_rejects_oversized_bundles(workspace):
     large_file = workspace / "large_file.bin"
-    # Use urandom to create incompressible data
     large_file.write_bytes(os.urandom(MAX_BUNDLE_SIZE_BYTES + 1024 * 1024))
 
-    with patch("iris.cluster.client.bundle.get_git_non_ignored_files", return_value=None):
-        creator = BundleCreator(workspace)
+    with _mock_git_none():
         with pytest.raises(ValueError, match=r"Bundle size .* exceeds maximum"):
-            creator.create_bundle()
+            create_workspace_zip(workspace)

--- a/lib/marin/src/marin/run/ray_run.py
+++ b/lib/marin/src/marin/run/ray_run.py
@@ -29,7 +29,9 @@ from ray.job_submission import JobSubmissionClient
 from marin.cluster.config import find_config_by_region
 from fray.v1.cluster.ray import DashboardConfig, ray_dashboard
 from fray.v1.cluster.ray.deps import build_runtime_env_for_packages, accelerator_type_from_extra, AcceleratorType
-from iris.cluster.client.bundle import create_workspace_zip
+from iris.cluster.client.bundle import create_workspace_dir
+
+RAY_RUN_EXCLUDE = re.compile(r"^docs(/|$)|\.pack$|^lib/levanter/docs(/|$)")
 from iris.logging import configure_logging
 
 logger = logging.getLogger(__name__)
@@ -157,13 +159,7 @@ async def submit_and_track_job(
     logger.info(f"env_vars: {json.dumps(env_vars, indent=4)}")
 
     runtime_dict = {
-        "working_dir": create_workspace_zip(
-            current_dir,
-            exclude_dirs={"docs"},
-            exclude_extensions={".pack"},
-            exclude_subpaths={"lib/levanter/docs"},
-            max_size_bytes=None,
-        ),
+        "working_dir": create_workspace_dir(current_dir, exclude=RAY_RUN_EXCLUDE),
         "config": {"setup_timeout_seconds": 1800},
     }
 


### PR DESCRIPTION
Extract create_workspace_zip() from BundleCreator as a reusable function
that produces a zip including gitignored protobuf artifacts (pb2 files).
Wire it into fray v1/v2 ray backends and ray_run.py as the working_dir
source, replacing Ray's native directory bundling which skips gitignored
files. This fixes jobs failing because generated pb2 files were missing
from the uploaded workspace.