### PR TITLE
Switch SQLite backups from WAL to DELETE journal mode

### DIFF
--- a/lib/iris/src/iris/cluster/controller/checkpoint.py
+++ b/lib/iris/src/iris/cluster/controller/checkpoint.py
@@ -88,11 +88,18 @@ def _fsspec_copy(src: str, dst: str) -> None:
 
 
 def _backup_sqlite_file(source: Path, dest: Path) -> None:
-    """Hot-backup a standalone SQLite file using the backup API."""
+    """Hot-backup a standalone SQLite file using the backup API.
+
+    After the backup, the destination is switched from WAL to DELETE
+    journal mode so the result is a single self-contained file without
+    -wal/-shm sidecars.  This prevents corruption when the file is
+    later compressed and uploaded without its WAL/SHM companions.
+    """
     src_conn = sqlite3.connect(str(source))
     dst_conn = sqlite3.connect(str(dest))
     try:
         src_conn.backup(dst_conn)
+        dst_conn.execute("PRAGMA journal_mode = DELETE")
         dst_conn.commit()
     finally:
         dst_conn.close()

--- a/lib/iris/src/iris/cluster/controller/db.py
+++ b/lib/iris/src/iris/cluster/controller/db.py
@@ -1240,12 +1240,20 @@ class ControllerDB:
         return value
 
     def backup_to(self, destination: Path) -> None:
-        """Create a hot backup to ``destination`` using SQLite backup API."""
+        """Create a hot backup to ``destination`` using SQLite backup API.
+
+        The source DB uses WAL journal mode, but the backup API copies
+        the WAL flag into the destination header.  We switch the
+        destination to DELETE mode so the result is a single
+        self-contained file (no -wal/-shm sidecars) that survives
+        compression and remote upload without corruption.
+        """
         destination.parent.mkdir(parents=True, exist_ok=True)
         with self._lock:
             dest = sqlite3.connect(str(destination))
             try:
                 self._conn.backup(dest)
+                dest.execute("PRAGMA journal_mode = DELETE")
                 dest.commit()
             finally:
                 dest.close()


### PR DESCRIPTION
Switch the destination database to DELETE journal mode after creating
SQLite backups using the backup API. The source databases use WAL
(write-ahead logging) mode, and the backup API copies the WAL flag into
the destination header. However, this creates a multi-file database with
-wal and -shm sidecars that can become corrupted when compressed and
uploaded without their companions.

By switching to DELETE mode after the backup completes, the destination
becomes a single self-contained file that survives compression and
remote upload without corruption.

Changes:
- db.py: Switch destination to DELETE journal mode in backup_to()
- checkpoint.py: Switch destination to DELETE journal mode in _backup_sqlite_file()
- Updated docstrings to explain the journal mode conversion

https://claude.ai/code/session_01VNKEn22RJeieNmPLQxn9L6