### PR TITLE
Log final counters on coordinator shutdown

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -853,6 +853,11 @@ class ZephyrCoordinator:
     def shutdown(self) -> None:
         """Signal workers to exit. Worker group is managed by ZephyrContext."""
         logger.info("[coordinator.shutdown] Starting shutdown")
+
+        counters = self.get_counters()
+        if counters:
+            logger.info("[coordinator.shutdown] Final counters: %s", counters)
+
         self._shutdown_event.set()
 
         # Wait for coordinator thread to exit


### PR DESCRIPTION
Add logging of final counters when the coordinator shuts down. This provides visibility into the final state of execution metrics at shutdown time, which is useful for debugging and monitoring coordinator lifecycle.

The change retrieves counters before signaling the shutdown event and logs them if any counters exist.