### PR TITLE
[zephyr] Add records_in / records_out counters to readers and writers

### DIFF
--- a/lib/zephyr/src/zephyr/readers.py
+++ b/lib/zephyr/src/zephyr/readers.py
@@ -32,9 +32,6 @@ _READ_BLOCK_SIZE = 16_000_000
 _READ_CACHE_TYPE = "background"
 _READ_MAX_BLOCKS = 2
 
-# How often per-record counters are flushed (to avoid lock-per-record).
-_COUNTER_FLUSH_INTERVAL = 1024
-
 
 @dataclass
 class InputFileSpec:
@@ -133,19 +130,13 @@ def load_jsonl(source: str | InputFileSpec) -> Iterator[dict]:
     """
     spec = _as_spec(source)
     decoder = msgspec.json.Decoder()
-    pending_counter = 0
 
     with open_file(spec.path, "rt") as f:
         for line in f:
             line = line.strip()
             if line:
-                pending_counter += 1
-                if pending_counter >= _COUNTER_FLUSH_INTERVAL:
-                    counters.increment("zephyr/records_in", pending_counter)
-                    pending_counter = 0
+                counters.increment("zephyr/records_in")
                 yield decoder.decode(line)
-
-    counters.increment("zephyr/records_in", pending_counter)
 
 
 def load_parquet(source: str | InputFileSpec) -> Iterator[dict]:
@@ -378,19 +369,13 @@ def load_zip_members(source: str | InputFileSpec, pattern: str = "*") -> Iterato
         >>> output_files = list(ctx.execute(ds))
     """
     spec = _as_spec(source)
-    pending_counter = 0
     with open_url(spec.path, "rb") as f:
         with zipfile.ZipFile(f) as zf:
             for member_name in zf.namelist():
                 if not member_name.endswith("/") and fnmatch.fnmatch(member_name, pattern):
                     with zf.open(member_name, "r") as member_file:
-                        pending_counter += 1
-                        if pending_counter >= _COUNTER_FLUSH_INTERVAL:
-                            counters.increment("zephyr/records_in", pending_counter)
-                            pending_counter = 0
+                        counters.increment("zephyr/records_in")
                         yield {
                             "filename": member_name,
                             "content": member_file.read(),
                         }
-
-    counters.increment("zephyr/records_in", pending_counter)

--- a/lib/zephyr/src/zephyr/writers.py
+++ b/lib/zephyr/src/zephyr/writers.py
@@ -40,9 +40,6 @@ _MICRO_BATCH_SIZE = 8
 # Fixed batch size for Levanter cache writes (2^14).
 _LEVANTER_BATCH_SIZE = 16384
 
-# How often per-record counters are flushed (to avoid lock-per-record).
-_COUNTER_FLUSH_INTERVAL = 1024
-
 
 def unique_temp_path(output_path: str) -> str:
     """Return a unique temporary path derived from ``output_path``.
@@ -102,8 +99,6 @@ def write_jsonl_file(records: Iterable, output_path: str) -> dict:
     count = 0
     encoder = msgspec.json.Encoder()
 
-    pending_counter = 0
-
     with atomic_rename(output_path) as temp_path:
         fs, resolved_temp = url_to_fs(temp_path)
         if output_path.endswith(".zst"):
@@ -115,30 +110,19 @@ def write_jsonl_file(records: Iterable, output_path: str) -> dict:
                     for record in records:
                         f.write(encoder.encode(record) + b"\n")
                         count += 1
-                        pending_counter += 1
-                        if pending_counter >= _COUNTER_FLUSH_INTERVAL:
-                            counters.increment("zephyr/records_out", pending_counter)
-                            pending_counter = 0
+                        counters.increment("zephyr/records_out")
         elif output_path.endswith(".gz"):
             with fs.open(resolved_temp, "wb", block_size=_WRITE_BLOCK_SIZE, compression="gzip") as f:
                 for record in records:
                     f.write(encoder.encode(record) + b"\n")
                     count += 1
-                    pending_counter += 1
-                    if pending_counter >= _COUNTER_FLUSH_INTERVAL:
-                        counters.increment("zephyr/records_out", pending_counter)
-                        pending_counter = 0
+                    counters.increment("zephyr/records_out")
         else:
             with fs.open(resolved_temp, "wb", block_size=_WRITE_BLOCK_SIZE) as f:
                 for record in records:
                     f.write(encoder.encode(record) + b"\n")
                     count += 1
-                    pending_counter += 1
-                    if pending_counter >= _COUNTER_FLUSH_INTERVAL:
-                        counters.increment("zephyr/records_out", pending_counter)
-                        pending_counter = 0
-
-    counters.increment("zephyr/records_out", pending_counter)
+                    counters.increment("zephyr/records_out")
 
     return {"path": output_path, "count": count}
 
@@ -430,18 +414,12 @@ def write_binary_file(records: Iterable[bytes], output_path: str) -> dict:
     ensure_parent_dir(output_path)
 
     count = 0
-    pending_counter = 0
     with atomic_rename(output_path) as temp_path:
         fs, resolved_temp = url_to_fs(temp_path)
         with fs.open(resolved_temp, "wb", block_size=_WRITE_BLOCK_SIZE) as f:
             for record in records:
                 f.write(record)
                 count += 1
-                pending_counter += 1
-                if pending_counter >= _COUNTER_FLUSH_INTERVAL:
-                    counters.increment("zephyr/records_out", pending_counter)
-                    pending_counter = 0
-
-    counters.increment("zephyr/records_out", pending_counter)
+                counters.increment("zephyr/records_out")
 
     return {"path": output_path, "count": count}


### PR DESCRIPTION
- Add zephyr/records_in counter to all readers (jsonl, parquet, vortex, zip_members)
- Add zephyr/records_out counter to all writers (jsonl, parquet, vortex, levanter_cache, binary)