### PR TITLE
Add --frozen flag to uv sync and optimize PYTHONDONTWRITEBYTECODE

### DIFF
--- a/lib/iris/Dockerfile
+++ b/lib/iris/Dockerfile
@@ -137,7 +137,10 @@ ENV PATH="/root/.cargo/bin:$PATH"
 
 ENV UV_CACHE_DIR=/uv/cache
 ENV CARGO_TARGET_DIR=/root/.cargo/target
-ENV PYTHONDONTWRITEBYTECODE=1
+# Only disable bytecode during build to keep image layers clean.
+# At runtime, bytecode compilation is re-enabled so .pyc files accumulate
+# in the persistent uv cache, speeding up repeated imports across pods.
+ARG PYTHONDONTWRITEBYTECODE=1
 
 ARG IRIS_GIT_HASH=unknown
 ENV IRIS_GIT_HASH=${IRIS_GIT_HASH}

--- a/lib/iris/src/iris/cluster/runtime/entrypoint.py
+++ b/lib/iris/src/iris/cluster/runtime/entrypoint.py
@@ -71,10 +71,13 @@ def build_runtime_entrypoint(
     # avoiding redundant installation. Symlinks work across bind mounts.
     link_mode_flag = "--link-mode symlink"
     setup_commands.append("echo 'syncing deps'")
+    frozen_flag = "--frozen"
     if uv_sync_flags:
-        setup_commands.append(f"uv sync {quiet_flag} {link_mode_flag} {python_flag} {uv_sync_flags}".strip())
+        setup_commands.append(
+            f"uv sync {quiet_flag} {frozen_flag} {link_mode_flag} {python_flag} {uv_sync_flags}".strip()
+        )
     else:
-        setup_commands.append(f"uv sync {quiet_flag} {link_mode_flag} {python_flag}".strip())
+        setup_commands.append(f"uv sync {quiet_flag} {frozen_flag} {link_mode_flag} {python_flag}".strip())
     setup_commands.append("echo 'installing pip deps'")
     if pip_install_args:
         setup_commands.append(f"uv pip install {quiet_flag} {link_mode_flag} {pip_install_args}")


### PR DESCRIPTION
This change improves dependency management and Docker image layer efficiency:

1. Add --frozen flag to all uv sync commands to ensure reproducible builds by preventing any dependency updates during installation. This flag is applied consistently whether or not additional uv_sync_flags are provided.

2. Convert PYTHONDONTWRITEBYTECODE from ENV to ARG in the Dockerfile so it only applies during the build phase. This keeps image layers clean during construction while allowing bytecode compilation at runtime. At runtime, .pyc files accumulate in the persistent uv cache, which speeds up repeated imports across pod restarts.