### PR TITLE
fix(canary): lower GPU canary batch size to 16 to fix OOM

### DIFF
--- a/.github/workflows/marin-canary-ferry-cw.yaml
+++ b/.github/workflows/marin-canary-ferry-cw.yaml
@@ -30,7 +30,7 @@ jobs:
     env:
       RUN_ID: canary-gpu-${{ github.run_id }}-${{ github.run_attempt }}
       CANARY_ACCELERATOR: gpu
-      CANARY_BATCH_SIZE: "32"
+      CANARY_BATCH_SIZE: "16"
       CANARY_TARGET_TOKENS: "6553600"
       CANARY_MIN_STEPS: "40"
       CANARY_MAX_LOSS: "8.0"


### PR DESCRIPTION
## Summary
- Lower `CANARY_BATCH_SIZE` from 32 to 16 in the CW GPU canary workflow
- PR #4084 increased the MoE model size (8→64 experts, 512→1024 hidden_dim, 6→11 layers) without adjusting the GPU canary batch size, causing OOM on 8xH100

## Smoke test results (CI H100 cluster)

| Batch Size | Peak Memory | Utilization | Status |
|------------|-------------|-------------|--------|
| 8 | 20.2 GB | 31.7% | PASS |
| **16** | **34.5 GB** | **54.1%** | **PASS** |
| 24 | 48.8 GB | 76.6% | PASS (tight) |
| 32 | >64 GB | OOM | FAIL |

batch_size=16 leaves ~29GB headroom for optimizer states and checkpointing.

## Test results

Ran `workflow_dispatch` on this branch with `target_tokens=524288` (8 steps):
- [Run 23654378044](https://github.com/marin-community/marin/actions/runs/23654378044)
- **Training completed all 8/8 steps with no OOM** (loss=8.62, 5.4s/step after compilation)
- Run cancelled after confirming success — the job was retrying due to a pre-existing profiler shutdown bug (`RuntimeError: No profile started`) unrelated to this change, triggered only by the very small step count

## Test plan
- [x] Trigger `workflow_dispatch` on this branch with small `target_tokens` to verify no OOM
- [ ] Verify nightly scheduled run passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)