### PR TITLE
Fix TensorStore handle leak in cache-copy (~14 MiB/shard)

### DIFF
--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -4,6 +4,7 @@
 import asyncio
 import copy
 import dataclasses
+import gc
 import logging as pylogging
 import operator
 import os
@@ -34,7 +35,7 @@ from ..data._preprocessor import BatchProcessor, BatchResult, dict_from_record_b
 from ..data.sharded_datasource import ShardedDataSource
 from ..utils.fsspec_utils import exists as fsspec_exists
 from ..utils.fsspec_utils import remove as fsspec_remove
-from .jagged_array import JaggedArrayStore
+from .jagged_array import JaggedArrayStore, _no_cache_read_context
 from .tree_store import TreeStore
 
 T = TypeVar("T")
@@ -574,19 +575,22 @@ async def _extend_cache_with_other_cache(
 ) -> int:
     try:
         logger.info(f"Copying data from {source_path} to {dest_path}.")
-        dest = TreeStore.open(exemplar, dest_path, mode="a", cache_metadata=False)
-        source = TreeStore.open(exemplar, source_path, mode="r", cache_metadata=True)
+        with _no_cache_read_context():
+            dest = TreeStore.open(exemplar, dest_path, mode="a", cache_metadata=False)
+            source = TreeStore.open(exemplar, source_path, mode="r", cache_metadata=True)
 
-        source_num_rows = await source.async_len()
+            source_num_rows = await source.async_len()
 
-        async def _copy_one_array(dest_array: JaggedArrayStore, source_array: JaggedArrayStore, data_offset: int):
-            data_size = source_array.data_size
-            data = source_array.data
-            MAX_ELEMS = 1024 * 1024 * 1024
-            await _copy_in_batches(dest_array.data, data_offset, data, data_size, MAX_ELEMS)
+            async def _copy_one_array(dest_array: JaggedArrayStore, source_array: JaggedArrayStore, data_offset: int):
+                data_size = source_array.data_size
+                data = source_array.data
+                MAX_ELEMS = 64 * 1024 * 1024
+                await _copy_in_batches(dest_array.data, data_offset, data, data_size, MAX_ELEMS)
 
-        futures = jax.tree.map(_copy_one_array, dest.tree, source.tree, data_offset_tree)
-        await asyncio.gather(*jax.tree.leaves(futures))
+            futures = jax.tree.map(_copy_one_array, dest.tree, source.tree, data_offset_tree)
+            await asyncio.gather(*jax.tree.leaves(futures))
+            del dest, source
+        gc.collect()
         logger.info(f"Finished copying data from {source_path} to {dest_path}.")
         return source_num_rows
     except Exception as e:  # noqa: BLE001
@@ -595,23 +599,21 @@ async def _extend_cache_with_other_cache(
 
 
 async def _copy_in_batches(dest_array, dest_offset, src_array, src_len, elems_per_batch):
-    last_future: ts.Future | None = None
     start = 0
     out_start = dest_offset
     while start < src_len:
-        if last_future is not None:
-            await last_future
-        async with ts.Transaction() as txn:
-            num_to_copy = min(elems_per_batch, src_len - start)
-            end = start + num_to_copy
-            out_end = out_start + num_to_copy
+        num_to_copy = min(elems_per_batch, src_len - start)
+        end = start + num_to_copy
+        out_end = out_start + num_to_copy
 
-            last_future = dest_array.with_transaction(txn)[out_start:out_end].write(src_array[start:end])
-            start += num_to_copy
-            out_start += num_to_copy
+        # Materialize into numpy to avoid holding TensorStore internal references
+        # across iterations. Direct ts-to-ts copy leaks ~14 MiB/shard (#4196).
+        chunk = await src_array[start:end].read()
+        await dest_array[out_start:out_end].write(chunk)
+        del chunk
 
-    if last_future is not None:
-        await last_future
+        start += num_to_copy
+        out_start += num_to_copy
 
 
 async def _consolidate_metadata(dest_path: str, exemplar: dict, shard_infos: list[dict]) -> None:

--- a/lib/levanter/src/levanter/store/jagged_array.py
+++ b/lib/levanter/src/levanter/store/jagged_array.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import contextlib
 import os
 import threading
 from dataclasses import dataclass
@@ -53,6 +54,20 @@ def _read_context() -> ts.Context:
             # TensorStore only shares cache_pool entries across stores that share a Context.
             _READ_CONTEXT = ts.Context({"cache_pool": _READ_CACHE_SETTINGS})
     return _READ_CONTEXT
+
+
+@contextlib.contextmanager
+def _no_cache_read_context():
+    """Use a disposable, zero-byte-cache read context for the duration of the block."""
+    global _READ_CONTEXT
+    with _READ_CONTEXT_LOCK:
+        prev = _READ_CONTEXT
+        _READ_CONTEXT = ts.Context({"cache_pool": {"total_bytes_limit": 0}})
+    try:
+        yield
+    finally:
+        with _READ_CONTEXT_LOCK:
+            _READ_CONTEXT = prev
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Fixes the ~14 MiB/shard memory leak in `_extend_cache_with_other_cache` that OOMKilled 19% of cache-copy pods in our Nemotron CC data prep run.

- **No-cache read context for copy ops**: each shard has a unique path so the shared 1 GiB `cache_pool` entries are never reused — they just accumulate. A new `_no_cache_read_context()` context manager swaps in a zero-byte-limit `ts.Context` for the duration of the copy, then restores the original.
- **Materialize reads into numpy**: the old `_copy_in_batches` did direct TensorStore-to-TensorStore copy via `ts.Transaction`, which kept C++ internal references alive. Reading into numpy first breaks that reference chain.
- **Explicit `del` + `gc.collect()`**: ensures handles are freed promptly rather than waiting for GC pressure.

## Repro

See the [repro script in #4196](https://github.com/marin-community/marin/issues/4196). Three variants over 50 shards:

| Variant | RSS/shard | Behavior |
|---------|-----------|----------|
| LEAKY (old code) | +13.8 MiB | linear growth, OOMKill at ~44 shards |
| PATCHED (this PR) | +0.6 MiB | plateaus at ~28 MiB |
| FIXED (standalone PoC) | +0.2 MiB | plateaus at ~12 MiB |

## Test plan

- [x] Repro script shows LEAKY at +14.2 MiB/iter, PATCHED at +0.6 MiB/iter (plateaus)
- [x] Existing cache/tokenization tests pass (53 passed)
- [x] CW smoke cluster: 50-shard cache-copy job, +2.6 MiB/shard (plateaus at ~127 MiB), PASS

Closes #4196

🤖 Generated with [Claude Code](https://claude.com/claude-code)