### PR TITLE
fix(zephyr): don't SHUTDOWN idle workers while shards are in-flight

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -529,7 +529,7 @@ class ZephyrCoordinator:
                 return None
 
             if not self._task_queue:
-                if self._is_last_stage:
+                if self._is_last_stage and not self._in_flight:
                     self._worker_states[worker_id] = WorkerState.DEAD
                     return "SHUTDOWN"
                 return None

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -606,9 +606,43 @@ def test_pull_task_returns_shutdown_on_last_stage_empty_queue(actor_context, tmp
     _task, attempt, _config = pulled
     coord.report_result("worker-A", 0, attempt, TaskResult(shard=ListShard(refs=[])))
 
-    # Queue empty on last stage -> SHUTDOWN
+    # Queue empty on last stage, nothing in-flight -> SHUTDOWN
     result = coord.pull_task("worker-A")
     assert result == "SHUTDOWN"
+
+
+def test_last_shard_requeued_after_worker_crash(actor_context, tmp_path):
+    """Surviving workers pick up requeued shards after a crash on the last stage. #4200."""
+    from zephyr.execution import ListShard, ShardTask, TaskResult, ZephyrCoordinator
+
+    coord = ZephyrCoordinator()
+    coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
+
+    tasks = [
+        ShardTask(shard_idx=i, total_shards=2, shard=ListShard(refs=[]), operations=[], stage_name="test")
+        for i in range(2)
+    ]
+    coord.start_stage("last-stage", tasks, is_last_stage=True)
+
+    coord.heartbeat("worker-A")
+    coord.heartbeat("worker-B")
+    pulled_a = coord.pull_task("worker-A")
+    coord.pull_task("worker-B")  # put shard 1 in-flight
+
+    # Worker A finishes
+    _task_a, attempt_a, _ = pulled_a
+    coord.report_result("worker-A", _task_a.shard_idx, attempt_a, TaskResult(shard=ListShard(refs=[])))
+
+    # Worker B crashes. Freshen worker-A, expire worker-B.
+    coord.heartbeat("worker-A")
+    coord.check_heartbeats(timeout=0)
+
+    # Worker A picks up the requeued shard and completes the pipeline.
+    pulled = coord.pull_task("worker-A")
+    assert pulled not in (None, "SHUTDOWN")
+    _task, attempt, _ = pulled
+    coord.report_result("worker-A", _task.shard_idx, attempt, TaskResult(shard=ListShard(refs=[])))
+    assert coord.pull_task("worker-A") == "SHUTDOWN"
 
 
 def test_coordinator_loop_crash_aborts_pipeline(actor_context, tmp_path):


### PR DESCRIPTION
## Summary

- Fix coordinator stall when the last in-flight worker dies or hangs on the final pipeline stage (#4200)
- `pull_task()` now only sends SHUTDOWN when both the queue **and** `_in_flight` are empty, so idle workers stay alive to pick up requeued shards
- One-line fix in `execution.py:532`: `if self._is_last_stage` → `if self._is_last_stage and not self._in_flight`

## Context

Observed in production during Nemotron CC data prep (128 workers, 6 nodes): consolidation stages got stuck at N-1/N shards for hours because all idle workers were SHUTDOWN'd while the last shard was still in-flight. Three failure modes — worker hang, worker OOM/crash, and race between finish-and-shutdown — are all fixed by the same guard.

## Test plan

- [x] `test_last_shard_requeued_after_worker_crash` — worker B crashes on last stage, worker A picks up the requeued shard and completes the pipeline
- [x] `test_pull_task_returns_shutdown_on_last_stage_empty_queue` — existing test still passes (SHUTDOWN when nothing in-flight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)