### PR TITLE
fix(iris): strip trailing slash from MirrorFileSystem prefix

### DIFF
--- a/lib/iris/src/iris/marin_fs.py
+++ b/lib/iris/src/iris/marin_fs.py
@@ -718,7 +718,7 @@ class MirrorFileSystem(fsspec.AbstractFileSystem):
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
-        self._local_prefix = marin_prefix()
+        self._local_prefix = marin_prefix().rstrip("/")
         self._remote_prefixes = [p for p in _all_data_bucket_prefixes() if not self._local_prefix.startswith(p)]
         self._budget = budget if budget is not None else _global_transfer_budget
         self._worker_id = default_worker_id()


### PR DESCRIPTION
## Summary
- Strip trailing slash from `MirrorFileSystem._local_prefix` to prevent double-slash paths (`s3://bucket/prefix//path`)
- Fixes GPU canary validation failing with `FileNotFoundError` / GCS 401 when `MARIN_PREFIX` ends with `/`

## Test plan
- [x] Local repro: validation fails before fix, passes after with `MARIN_PREFIX=s3://marin-na/marin/`
- [ ] GPU canary `workflow_dispatch` with validation step passing end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)