### PR TITLE
Add DspyEvaluator improvements and ToonAdapter

### DIFF
--- a/experiments/dspy/adapters/toon.py
+++ b/experiments/dspy/adapters/toon.py
@@ -1,15 +1,204 @@
-import dspy
+"""
+ToonAdapter — Alpaca-style structured output adapter.
 
+Uses "### {Field}:" section markers instead of the JSON-based (BAML) or
+delimiter-based (Chat) formats.  Because the prompt style is fundamentally
+different from the adapters used during training, this adapter is primarily
+useful as an **out-of-distribution (OOD) evaluation target**: we want to
+know whether a model trained on BAML/Chat data can still follow instructions
+when they arrive in TOON format.
+
+Prompt structure
+----------------
+System message:
+    <signature instructions>
+    Output fields and their types.
+
+User message:
+    ### Claim:
+    <value>
+
+    ### Evidence:
+    <value>
+
+    Respond with the following fields:
+    ### Label:
+    ### Reasoning:
+
+Assistant response (expected):
+    ### Label:
+    Supports
+
+    ### Reasoning:
+    <reasoning text>
+"""
+
+import re
 from typing import Any
 
-class ToonAdapter(dspy.Adapter):
-    def call(self, example: dspy.Example) -> dspy.Example:
-        return example
+import dspy
+from dspy import Adapter
+from dspy.signatures.signature import Signature
 
-    def parse(self, signature: type[dspy.Signature], completion: str) -> dict[str, Any]:
-        return {
-            "result": completion
-        }
 
-    def format(self, signature: type[dspy.Signature], inputs: dict[str, Any]) -> str:
-        return f"### User: {inputs['user']}\n### Assistant: {inputs['assistant']}"
+class ToonAdapter(Adapter):
+    """Alpaca-style adapter that formats prompts using '### Field:' markers.
+
+    Extends :class:`dspy.Adapter` and overrides ``format`` / ``parse`` so
+    that the full prompt pipeline (system + user message construction,
+    response parsing) uses TOON-style markers rather than JSON or the
+    ``[[ ## field ## ]]`` delimiters used by ChatAdapter.
+    """
+
+    # ------------------------------------------------------------------
+    # format() — called by dspy.Adapter.__call__ to build the messages
+    # ------------------------------------------------------------------
+
+    def format(
+        self,
+        signature: type[Signature],
+        demos: list[dict[str, Any]],
+        inputs: dict[str, Any],
+    ) -> list[dict[str, str]]:
+        """Return a list of chat messages in TOON format.
+
+        Args:
+            signature: The DSPy signature describing inputs and outputs.
+            inputs: A dict mapping input field names to their values.
+            demos: Few-shot demonstrations (currently ignored).
+
+        Returns:
+            A list of ``{"role": ..., "content": ...}`` dicts.
+        """
+        messages: list[dict[str, str]] = []
+
+        # ---- System message ----
+        system_lines = [signature.instructions.strip(), ""]
+        system_lines.append("Output fields and their expected types:")
+        for name, field in signature.output_fields.items():
+            type_name = getattr(field.annotation, "__name__", str(field.annotation))
+            desc = f"  - {name} ({type_name})"
+            if field.description:
+                desc += f": {field.description}"
+            system_lines.append(desc)
+
+        messages.append({"role": "system", "content": "\n".join(system_lines)})
+
+        # ---- User message ----
+        user_lines: list[str] = []
+        for name, field in signature.input_fields.items():
+            value = inputs.get(name, "")
+            if isinstance(value, list):
+                value = "\n".join(str(v) for v in value)
+            user_lines.append(f"### {name.capitalize()}:")
+            user_lines.append(str(value))
+            user_lines.append("")
+
+        user_lines.append("Respond using the following fields:")
+        for name in signature.output_fields:
+            user_lines.append(f"### {name.capitalize()}:")
+
+        messages.append({"role": "user", "content": "\n".join(user_lines)})
+
+        return messages
+
+    # ------------------------------------------------------------------
+    # parse() — called by dspy.Adapter.__call__ to parse the LM response
+    # ------------------------------------------------------------------
+
+    def parse(
+        self,
+        signature: type[Signature],
+        completion: str,
+    ) -> dict[str, Any]:
+        """Extract output fields from a TOON-formatted completion.
+
+        Looks for ``### FieldName:`` markers and collects the text that
+        follows each one up to the next marker (or end of string).
+
+        Args:
+            signature: The DSPy signature (used to know which fields to
+                extract and what types to coerce them to).
+            completion: The raw text returned by the language model.
+
+        Returns:
+            A dict mapping output field names to their parsed values.
+            Fields that cannot be found are set to ``None``.
+        """
+        output_fields = signature.output_fields
+        result: dict[str, Any] = {name: None for name in output_fields}
+
+        if not completion or not completion.strip():
+            return result
+
+        field_names = list(output_fields.keys())
+
+        # Split on ALL "### Something:" markers so values don't bleed into
+        # the next section even when the next field is not an output field.
+        any_header_pattern = re.compile(r"###\s+(\w+)\s*:[ \t]*", re.IGNORECASE)
+        parts = any_header_pattern.split(completion)
+        # parts layout: [pre_text, name1, value1, name2, value2, ...]
+        i = 1
+        while i + 1 < len(parts):
+            raw_name  = parts[i].strip().lower()
+            raw_value = parts[i + 1].strip()
+            i += 2
+
+            # Keep only known output fields
+            matched_name = next(
+                (n for n in field_names if n.lower() == raw_name), None
+            )
+            if matched_name is None:
+                continue
+
+            field_annotation = output_fields[matched_name].annotation
+            result[matched_name] = self._coerce(raw_value, field_annotation)
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal helper
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _coerce(value: str, annotation: Any) -> Any:
+        """Attempt to coerce *value* to the field's annotated type.
+
+        Falls back to the raw string if coercion is not straightforward.
+        """
+        if annotation is None or annotation is str:
+            return value
+
+        # Handle Enum types (e.g. ClaimVerificationLabel)
+        try:
+            import enum
+            if isinstance(annotation, type) and issubclass(annotation, enum.Enum):
+                # Try matching by value (case-insensitive)
+                value_lower = value.strip().lower()
+                for member in annotation:
+                    if member.value.lower() == value_lower:
+                        return member
+                # Try matching by name
+                for member in annotation:
+                    if member.name.lower() == value_lower:
+                        return member
+        except Exception:
+            pass
+
+        # int / float
+        if annotation is int:
+            try:
+                return int(value)
+            except ValueError:
+                return None
+        if annotation is float:
+            try:
+                return float(value)
+            except ValueError:
+                return None
+
+        # bool
+        if annotation is bool:
+            return value.strip().lower() in ("true", "yes", "1")
+
+        return value

--- a/lib/marin/src/marin/evaluation/evaluators/dspy_evaluator.py
+++ b/lib/marin/src/marin/evaluation/evaluators/dspy_evaluator.py
@@ -1,52 +1,343 @@
+import enum
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
 import dspy
 import requests
-
 from openai import AsyncOpenAI
-from langprobe import EvaluateBench
 
+
+class _EnumSafeEncoder(json.JSONEncoder):
+    """JSON encoder that converts Enum values to their .value string."""
+    def default(self, obj: Any) -> Any:
+        if isinstance(obj, enum.Enum):
+            return obj.value
+        return super().default(obj)
+
+from experiments.dspy.adapters.baml import BAMLAdapter
+from experiments.dspy.adapters.toon import ToonAdapter
+from experiments.dspy.metrics import claim_verification_metric
+from experiments.dspy.programs.claim_verification import ClaimVerification
 from marin.evaluation.evaluators.evaluator import Evaluator, ModelConfig
-from levanter.inference.openai import InferenceServer, InferenceServerConfig
+
+logger = logging.getLogger(__name__)
+
+# --- Supported adapters ---
+ADAPTER_MAP: dict[str, type[dspy.Adapter]] = {
+    "baml": BAMLAdapter,
+    "chat": dspy.ChatAdapter,
+    "toon": ToonAdapter,
+}
+
+# --- Supported tasks ---
+# Each entry has:
+#   "program"   : DSPy module class
+#   "metric"    : callable(example, prediction) -> float
+#   "input_keys": fields used as program inputs
+TASK_MAP = {
+    "hover": {
+        "program": ClaimVerification,
+        "metric": claim_verification_metric,
+        "input_keys": ("claim", "evidence"),
+    },
+}
+
+
+def _load_hover(split: str, max_examples: int | None) -> list[dspy.Example]:
+    """Load HoVer examples from HuggingFace for the requested split.
+
+    HoVer only has a 'train' split on HF, so we partition it deterministically:
+        train : first 80%
+        dev   : next 10%
+        test  : last 10%
+    """
+    from dspy.datasets.dataloader import DataLoader
+
+    dl = DataLoader()
+    full = dl.from_huggingface(
+        "Dzeniks/hover",
+        split="train",
+        input_keys=("claim", "evidence"),
+    )
+
+    n = len(full)
+    boundaries = {
+        "train": (0, int(0.8 * n)),
+        "dev":   (int(0.8 * n), int(0.9 * n)),
+        "test":  (int(0.9 * n), n),
+    }
+    if split not in boundaries:
+        raise ValueError(f"Unknown split '{split}'. Choose from {list(boundaries)}")
+
+    lo, hi = boundaries[split]
+    examples = full[lo:hi]
+
+    if max_examples is not None:
+        examples = examples[:max_examples]
+
+    logger.info(f"Loaded {len(examples)} HoVer examples (split={split})")
+    return examples
+
+
+def _build_bm25s_retriever(examples: list[dspy.Example]):
+    """Build an offline BM25S retriever from HoVer evidence passages.
+
+    Collects all unique passages from the dataset examples, indexes them
+    with BM25S (no server needed), and returns a callable that DSPy can
+    use as dspy.settings.rm.
+    """
+    import bm25s
+
+    # Collect all unique passages from the dataset
+    corpus = []
+    seen = set()
+    for ex in examples:
+        evidence = getattr(ex, "evidence", [])
+        if isinstance(evidence, str):
+            evidence = [evidence]
+        for passage in evidence:
+            if passage not in seen:
+                corpus.append(passage)
+                seen.add(passage)
+
+    if not corpus:
+        raise ValueError("No evidence passages found in dataset to build BM25S index.")
+
+    logger.info(f"Building BM25S index over {len(corpus)} passages...")
+    retriever = bm25s.BM25()
+    retriever.index(bm25s.tokenize(corpus))
+    logger.info("BM25S index ready.")
+
+    def rm(query: str, k: int = 3, **kwargs) -> list[str]:
+        tokens = bm25s.tokenize([query])
+        results, _ = retriever.retrieve(tokens, k=min(k, len(corpus)))
+        return [corpus[i] for i in results[0]]
+
+    return rm
+
+
+def _detect_format_error(pred: dspy.Prediction, task_name: str) -> bool:
+    """Return True if the prediction is missing expected output fields."""
+    if pred is None:
+        return True
+    if task_name == "hover":
+        return getattr(pred, "label", None) is None
+    return False
 
 
 class DspyEvaluator(Evaluator):
+    """Evaluates a DSPy program on a structured task across different adapters.
+
+    Measures accuracy and format-error rate, and saves per-example trajectories
+    to a JSONL file for downstream analysis and SFT data generation.
+
+    Args:
+        model: Model configuration (name, path, engine kwargs).
+        endpoint: URL of a running OpenAI-compatible inference server.
+        output_path: Directory where results and trajectories are saved.
+        adapter_name: DSPy adapter to use. One of 'baml', 'chat', 'toon'.
+        task_name: Task to evaluate. Currently only 'hover' is supported.
+        split: Dataset split. One of 'train', 'dev', 'test'.
+        max_eval_instances: Cap on examples to evaluate (None = full split).
+        wandb_tags: Optional W&B tags (reserved for future use).
+
+    Example usage::
+
+        evaluator = DspyEvaluator(
+            model=ModelConfig(name="Qwen/Qwen2.5-7B-Instruct", path=None, engine_kwargs={}),
+            endpoint="http://localhost:8000",
+            output_path="outputs/hover_baml_test",
+            adapter_name="baml",
+            task_name="hover",
+            split="test",
+            max_eval_instances=100,
+        )
+        results = evaluator.evaluate()
+        print(results)
+    """
+
     def __init__(
         self,
         model: ModelConfig,
         endpoint: str,
         output_path: str,
-        max_eval_instances: int | None = None,
+        adapter_name: str = "baml",
+        task_name: str = "hover",
+        split: str = "test",
+        max_eval_instances: int | None = 1000,
         wandb_tags: list[str] | None = None,
         **kwargs,
     ):
         super().__init__()
 
-        self.endpoint = endpoint
+        if adapter_name not in ADAPTER_MAP:
+            raise ValueError(
+                f"Unknown adapter '{adapter_name}'. Choose from {list(ADAPTER_MAP)}"
+            )
+        if task_name not in TASK_MAP:
+            raise ValueError(
+                f"Unknown task '{task_name}'. Choose from {list(TASK_MAP)}"
+            )
+
+        self.model = model
         self.output_path = output_path
+        self.adapter_name = adapter_name
+        self.task_name = task_name
+        self.split = split
         self.max_eval_instances = max_eval_instances
         self.wandb_tags = wandb_tags
 
-        self.model = model
-        self.endpoint = self._validate_endpoint()
+        self.endpoint = self._validate_endpoint(endpoint)
         self.client = AsyncOpenAI(base_url=self.endpoint, api_key="dspy")
-        # IMPORTANT: pass keyword arguments correctly
-        self.langprobe = EvaluateBench(**kwargs)
 
-    def _validate_endpoint(self) -> str:
-        response = requests.get(self.endpoint + "/health")
-        if response.status_code == 200:
-            return self.endpoint
-        else:
-            return self._run_oai_server()
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _validate_endpoint(self, endpoint: str) -> str:
+        """Return endpoint if healthy, otherwise fall back to localhost."""
+        try:
+            resp = requests.get(endpoint + "/health", timeout=5)
+            if resp.status_code == 200:
+                return endpoint
+        except requests.exceptions.RequestException:
+            pass
+        logger.warning("Endpoint unreachable — falling back to local server.")
+        return self._run_oai_server()
 
     def _run_oai_server(self) -> str:
-        # Run oai server and return the endpoint
         return "http://localhost:8000"
 
-    def evaluate(
-        self,
-        modules: dspy.Module,
-        dataset: list[dspy.Example],
-        optimizer: dspy.Teleprompter,
-        **kwargs,
-    ) -> None:
-        return self.langprobe.evaluate(modules, dataset, optimizer, **kwargs)
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def evaluate(self, **kwargs) -> dict:
+        """Run evaluation and return a summary dict.
+
+        Writes two files to ``output_path``:
+
+        * ``<task>_<adapter>_<split>_trajectories.jsonl``
+          One JSON line per example::
+
+              {
+                  "sample_id": 0,
+                  "input":  {...},
+                  "output": {...},
+                  "score":  1.0,
+                  "parsing_error": false
+              }
+
+        * ``<task>_<adapter>_<split>_results.json``
+          Aggregate metrics (accuracy, format_error_rate, elapsed_seconds, …).
+        """
+        task_cfg = TASK_MAP[self.task_name]
+
+        # Configure DSPy — temperature=0 and cache=False for reproducibility
+        lm = dspy.LM(
+            model=f"openai/{self.model.name}",
+            base_url=self.endpoint,
+            api_key="dspy",
+            temperature=0.0,
+            cache=False,
+        )
+        adapter = ADAPTER_MAP[self.adapter_name]()
+
+        examples = _load_hover(self.split, self.max_eval_instances)
+
+        # BM25S runs fully offline — no server needed.
+        # ColBERT was avoided because it requires a running server and caused
+        # pipeline crashes in earlier experiments.
+        rm = _build_bm25s_retriever(examples)
+        dspy.configure(lm=lm, adapter=adapter, rm=rm)
+        program = task_cfg["program"]()
+        metric  = task_cfg["metric"]
+
+        trajectories: list[dict] = []
+        total_score        = 0.0
+        total_format_errors = 0
+        start_time = time.time()
+
+        for i, example in enumerate(examples):
+            traj: dict = {
+                "sample_id":    i,
+                "input":        example.toDict() if hasattr(example, "toDict") else vars(example),
+                "output":       None,
+                "score":        None,
+                "parsing_error": False,
+            }
+
+            try:
+                pred      = program(**example.inputs())
+                has_error = _detect_format_error(pred, self.task_name)
+                score     = float(metric(example, pred))
+
+                traj["output"]        = pred.toDict() if hasattr(pred, "toDict") else str(pred)
+                traj["score"]         = score
+                traj["parsing_error"] = has_error
+
+                total_score += score
+                if has_error:
+                    total_format_errors += 1
+
+            except Exception as exc:
+                traj["parsing_error"] = True
+                traj["error"]         = str(exc)
+                total_format_errors  += 1
+                logger.warning(f"Example {i} failed: {exc}")
+
+            trajectories.append(traj)
+
+            if (i + 1) % 50 == 0:
+                logger.info(f"Progress: {i + 1}/{len(examples)} ({(i+1)/len(examples):.1%})")
+
+        elapsed = time.time() - start_time
+        n = len(examples)
+
+        results = {
+            "task":              self.task_name,
+            "adapter":           self.adapter_name,
+            "split":             self.split,
+            "model":             self.model.name,
+            "total_examples":    n,
+            "accuracy":          round(total_score / n, 4) if n > 0 else 0.0,
+            "format_error_rate": round(total_format_errors / n, 4) if n > 0 else 0.0,
+            "elapsed_seconds":   round(elapsed, 2),
+        }
+
+        # ---- Persist outputs ----
+        out_dir = Path(self.output_path)
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        traj_file = out_dir / f"{self.task_name}_{self.adapter_name}_{self.split}_trajectories.jsonl"
+        with open(traj_file, "w", encoding="utf-8") as f:
+            for traj in trajectories:
+                f.write(json.dumps(traj, cls=_EnumSafeEncoder, ensure_ascii=False) + "\n")
+
+        results_file = out_dir / f"{self.task_name}_{self.adapter_name}_{self.split}_results.json"
+        with open(results_file, "w", encoding="utf-8") as f:
+            json.dump(results, f, indent=2, ensure_ascii=False)
+
+        # ---- Print summary ----
+        logger.info("=" * 52)
+        logger.info(f"  Task          : {results['task']}")
+        logger.info(f"  Adapter       : {results['adapter']}")
+        logger.info(f"  Split         : {results['split']}")
+        logger.info(f"  Model         : {results['model']}")
+        logger.info(f"  Examples      : {results['total_examples']}")
+        logger.info(f"  Accuracy      : {results['accuracy']:.2%}")
+        logger.info(f"  Format errors : {results['format_error_rate']:.2%}")
+        logger.info(f"  Elapsed       : {results['elapsed_seconds']}s")
+        logger.info("=" * 52)
+        logger.info(f"  Trajectories  -> {traj_file}")
+        logger.info(f"  Results       -> {results_file}")
+
+        return results
+
+    def launch_evaluate_with_ray(self, model, evals, output_path, **kwargs):
+        raise NotImplementedError(
+            "Ray-based evaluation is not supported for DspyEvaluator."
+        )


### PR DESCRIPTION
DspyEvaluator improvements:

Added adapter_name parameter (baml, chat, toon)
Added task_name, split, max_eval_instances parameters
Format error rate tracked per example
Trajectories saved to JSONL with score and parsing_error fields
Aggregate results saved to JSON
Temperature set to 0.0 and cache disabled for reproducibility
HoVer dataset loader with deterministic train/dev/test splits (80/10/10)
Offline BM25S retriever built from dataset evidence passages (no server required)
ToonAdapter:

Full implementation of Alpaca-style ### Field: format
Correct DSPy Adapter interface (format + parse)
Enum coercion for ClaimVerificationLabel
Used as OOD evaluation adapter