### PR TITLE
Skip tokenizer tests that require HuggingFace downloads in CI

### DIFF
--- a/tests/test_data_configs.py
+++ b/tests/test_data_configs.py
@@ -1,9 +1,13 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import pytest
 
 from marin.processing.tokenize.data_configs import _are_tokenizers_equivalent
+
+pytestmark = pytest.mark.skipif("CI" in os.environ, reason="Requires HF tokenizer download")
 
 
 def test_are_tokenizers_equivalent():

--- a/tests/test_marin_chat_template.py
+++ b/tests/test_marin_chat_template.py
@@ -1,6 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from collections.abc import Sequence
 
 import pytest
@@ -12,22 +13,19 @@ from experiments.create_marin_tokenizer import (
 )
 from levanter.data.text import ChatProcessor
 
+pytestmark = pytest.mark.skipif("CI" in os.environ, reason="Requires HF tokenizer download")
 
-@pytest.fixture()
-def fresh_marin_tokenizer():
-    try:
-        base = load_llama3_tokenizer()
-    except Exception as exc:
-        pytest.skip(f"Could not load llama3 tokenizer: {exc}", allow_module_level=True)
-    return create_marin_tokenizer(base)
+
+def _load_marin_tokenizer():
+    return create_marin_tokenizer(load_llama3_tokenizer())
 
 
 def decode_sequence(tokenizer, tensor: Sequence[int]) -> str:
     return tokenizer.decode(list(tensor), skip_special_tokens=False)
 
 
-def test_marin_chat_template_handles_tool_calls(fresh_marin_tokenizer):
-    tokenizer = fresh_marin_tokenizer
+def test_marin_chat_template_handles_tool_calls():
+    tokenizer = _load_marin_tokenizer()
     processor = ChatProcessor(tokenizer, mask_user_turns=True)
 
     batch = [
@@ -63,13 +61,13 @@ def test_marin_chat_template_handles_tool_calls(fresh_marin_tokenizer):
     assert result[0]["assistant_masks"].sum() > 0
 
 
-def test_marin_tokenizer_integration_checks(fresh_marin_tokenizer):
-    tokenizer = fresh_marin_tokenizer
+def test_marin_tokenizer_integration_checks():
+    tokenizer = _load_marin_tokenizer()
     run_all_tests(tokenizer)
 
 
-def test_marin_chat_template_ipython_output(fresh_marin_tokenizer):
-    tokenizer = fresh_marin_tokenizer
+def test_marin_chat_template_ipython_output():
+    tokenizer = _load_marin_tokenizer()
     processor = ChatProcessor(tokenizer, mask_user_turns=True)
 
     batch = [

--- a/tests/test_marin_tokenizer.py
+++ b/tests/test_marin_tokenizer.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 
 import pytest
-from transformers import AutoTokenizer, PreTrainedTokenizer
+from transformers import AutoTokenizer
 
 from experiments.create_marin_tokenizer import (
     create_marin_tokenizer,
@@ -13,26 +13,15 @@ from experiments.create_marin_tokenizer import (
     special_tokens_injection_check,
 )
 
+pytestmark = pytest.mark.skipif("CI" in os.environ, reason="Requires HF tokenizer download")
 
-@pytest.fixture
-def marin_tokenizer():
-    """Fixture that provides a configured marin tokenizer for testing."""
-    try:
-        llama3_tokenizer = load_llama3_tokenizer()
-    except Exception as e:
-        if os.getenv("CI", False) in ["true", "1"]:
-            pytest.skip("Llama 3 tokenizer repository is gated")
-        raise e
-    tokenizer = create_marin_tokenizer(llama3_tokenizer)
 
-    # Roundtrip write-read to ensure consistency
+def test_special_tokens_injection():
+    """Test that special tokens are correctly replaced after a save/load roundtrip."""
+    tokenizer = create_marin_tokenizer(load_llama3_tokenizer())
+
     with tempfile.TemporaryDirectory() as temp_path:
         tokenizer.save_pretrained(temp_path)
         tokenizer = AutoTokenizer.from_pretrained(temp_path, local_files_only=True)
 
-    return tokenizer
-
-
-def test_special_tokens_injection(marin_tokenizer: PreTrainedTokenizer):
-    """Test that special tokens are correctly replaced."""
-    special_tokens_injection_check(marin_tokenizer)
+    special_tokens_injection_check(tokenizer)


### PR DESCRIPTION
- Add `pytestmark` skip decorators to test modules that download tokenizers from HuggingFace
- Tests in `test_data_configs.py`, `test_marin_chat_template.py`, and `test_marin_tokenizer.py` are now skipped when `CI` environment variable is set
- Simplify test fixtures by converting `fresh_marin_tokenizer` fixture to `_load_marin_tokenizer()` helper function
- Remove unnecessary try-catch logic in favor of pytest skip markers
- Clean up unused imports