### PR TITLE
fix(iris): remove --nonblocking from py-spy to fix native CPU profiles

### DIFF
--- a/lib/iris/src/iris/cluster/runtime/profile.py
+++ b/lib/iris/src/iris/cluster/runtime/profile.py
@@ -107,7 +107,6 @@ def build_pyspy_cmd(spec: CpuProfileSpec, py_spy_bin: str, output_path: str) -> 
         "--output",
         output_path,
         "--subprocesses",
-        "--nonblocking",
         *(["--native"] if spec.native else []),
     ]
 

--- a/lib/iris/src/iris/rpc/cluster.proto
+++ b/lib/iris/src/iris/rpc/cluster.proto
@@ -94,7 +94,7 @@ message CpuProfile {
     RAW = 3;            // Text output
   }
   Format format = 1;
-  int32 rate_hz = 2;    // Sample rate (default: 100)
+  int32 rate_hz = 2;    // Sample rate (default: 20)
   bool native = 3;  // Collect native (C/C++) frames via py-spy --native; default true when unset
 }
 


### PR DESCRIPTION
--native is incompatible with --nonblocking in py-spy, which broke CPU
profiles after we added --native. Drop --nonblocking since native frames
are essential for ML profiling (JAX/XLA) and the blocking overhead at
20 Hz is negligible (~20 us/s). Also fixes the rate_hz proto comment
to match the actual default of 20 Hz.