### PR TITLE
[iris] Fix bundle exclude patterns for docs and test snapshots

### DIFF
--- a/lib/iris/src/iris/cluster/client/bundle.py
+++ b/lib/iris/src/iris/cluster/client/bundle.py
@@ -33,11 +33,11 @@ DEFAULT_EXCLUDE = re.compile(
     | (^|/)\.venv(/|$)
     | (^|/)node_modules(/|$)
     | (^|/)venv(/|$)
-    | ^docs/figures(/|$)
-    | ^docs/images(/|$)
-    | ^docs/reports(/|$)
-    | ^docs/static(/|$)
-    | ^tests/snapshot(/|$)
+    | (^|/)docs/figures(/|$)
+    | (^|/)docs/images(/|$)
+    | (^|/)docs/reports(/|$)
+    | (^|/)docs/static(/|$)
+    | (^|/)tests/snapshots(/|$)
     """,
     re.VERBOSE,
 )


### PR DESCRIPTION
Fix typo: tests/snapshot -> tests/snapshots (the actual directory name). Remove ^ anchor from docs/* and tests/* excludes so they match at any depth, since sub-library directories like lib/haliax/docs/figures were not being excluded by root-anchored patterns.