### PR TITLE
Use hardcoded path for nemotron download to stabilize version hash

### DIFF
--- a/experiments/pretraining_datasets/nemotron.py
+++ b/experiments/pretraining_datasets/nemotron.py
@@ -9,7 +9,7 @@ import os.path
 from experiments.defaults import DEFAULT_NEW_RUN_DATA_SHUFFLE
 from experiments.pretraining_datasets.dclm import dclm_components_llama3
 from marin.datakit.download.nemotron_v1 import download_nemotron_v1_step
-from marin.execution.executor import ExecutorStep, output_path_of, this_output_path, versioned
+from marin.execution.executor import ExecutorStep, InputName, this_output_path, versioned
 from marin.processing.tokenize import TokenizeConfig, lm_mixture_data_config, tokenize
 from marin.processing.tokenize.data_configs import TokenizerStep
 
@@ -18,18 +18,14 @@ def nemotron_cc_download() -> ExecutorStep:
     return download_nemotron_v1_step().as_executor_step()
 
 
-# These globs use .jsonl.gz (not .jsonl.*) to preserve the version hash that
-# NEMOTRON_LLAMA3_OVERRIDES were computed against. The tokenize steps never
-# re-execute because with_output_path() pins them to existing outputs.
-# If retokenizing, update these to .jsonl.zst (current download format).
 NEMOTRON_DATASETS = {
-    "hq_actual": ["quality=high/kind=actual/**/*.jsonl.gz"],
-    "hq_synth": ["quality=high/kind=synthetic/**/*.jsonl.gz"],
-    "medium_high": ["quality=medium-high/**/*.jsonl.gz"],
-    "medium": ["quality=medium/**/*.jsonl.gz"],
-    "medium_low": ["quality=medium-low/**/*.jsonl.gz"],
-    "low_actual": ["quality=low/kind=actual/**/*.jsonl.gz"],
-    "low_synth": ["quality=low/kind=synthetic/**/*.jsonl.gz"],
+    "hq_actual": ["quality=high/kind=actual/**/*.jsonl.*"],
+    "hq_synth": ["quality=high/kind=synthetic/**/*.jsonl.*"],
+    "medium_high": ["quality=medium-high/**/*.jsonl.*"],
+    "medium": ["quality=medium/**/*.jsonl.*"],
+    "medium_low": ["quality=medium-low/**/*.jsonl.*"],
+    "low_actual": ["quality=low/kind=actual/**/*.jsonl.*"],
+    "low_synth": ["quality=low/kind=synthetic/**/*.jsonl.*"],
 }
 
 # Weights for each split based on their size in TiB
@@ -55,10 +51,14 @@ NEMOTRON_LLAMA3_OVERRIDES = {
 }
 
 
+# Hardcoded path to the nemotron download output so that glob or download
+# step changes don't alter the tokenize step's version hash.
+_NEMOTRON_CC_DATA_PATH = InputName.hardcoded("raw/nemotro-cc-eeb783/contrib/Nemotron/Nemotron-CC/data-jsonl/")
+
+
 def _get_nemotron_split_paths(split: str):
     """Helper to get file paths for a nemotron split."""
-    base = output_path_of(nemotron_cc_download(), "contrib/Nemotron/Nemotron-CC/data-jsonl/")
-    return [base / pattern for pattern in NEMOTRON_DATASETS[split]]
+    return [_NEMOTRON_CC_DATA_PATH / pattern for pattern in NEMOTRON_DATASETS[split]]
 
 
 def tokenize_nemotron(


### PR DESCRIPTION
## Summary

Fixes #4204

- Replace `output_path_of(nemotron_cc_download(), ...)` with `InputName.hardcoded("raw/nemotro-cc-eeb783/...")` in `_get_nemotron_split_paths`
- This decouples the tokenize step's version hash from the download step, so changes to glob patterns (`.jsonl.gz` → `.jsonl.*`) no longer cascade to downstream training steps
- The hardcoded path resolves to the same GCS location at runtime (`gs://marin-us-central2/raw/nemotro-cc-eeb783/contrib/Nemotron/Nemotron-CC/data-jsonl/`)
- Validated that all `NEMOTRON_LLAMA3_OVERRIDES` paths exist on GCS

**Root cause**: `InputName.name` (which includes the glob pattern) is always included in the version hash via `collect_dependencies_and_version`. When the glob changed from `.jsonl.gz` to `.jsonl.*`, the tokenize step's version dict changed and propagated to all downstream steps through `_dep_version`.

**Why hardcoded**: With `InputName.hardcoded()` (step=None), the version entry is just the path string itself, not `dep_N/<path>`. This means future changes to the download step don't affect the tokenize step's hash. The `NEMOTRON_LLAMA3_OVERRIDES` + `with_output_path()` continue to pin the tokenize output paths.
