### PR TITLE
[iris] Offload large workdir files to blob store in launch_job

### DIFF
--- a/lib/iris/src/iris/cluster/bundle.py
+++ b/lib/iris/src/iris/cluster/bundle.py
@@ -30,6 +30,11 @@ def bundle_id_for_zip(blob: bytes) -> str:
     return hashlib.sha256(blob).hexdigest()
 
 
+def blob_id_for_bytes(data: bytes) -> str:
+    """Return canonical blob id (SHA-256 hex digest) for arbitrary bytes."""
+    return hashlib.sha256(data).hexdigest()
+
+
 class BundleStore:
     """Bundle store with fsspec persistence and in-memory LRU cache.
 
@@ -64,6 +69,9 @@ class BundleStore:
 
     def _bundle_fs_path(self, bundle_id: str) -> str:
         return f"{self._fs_path}/{bundle_id}.zip"
+
+    def _blob_fs_path(self, blob_id: str) -> str:
+        return f"{self._fs_path}/blobs/{blob_id}"
 
     def _exists_in_storage(self, bundle_id: str) -> bool:
         return self._fs.exists(self._bundle_fs_path(bundle_id))
@@ -154,6 +162,65 @@ class BundleStore:
             logger.info("Content %s not in local cache, fetching from controller", content_id)
             self._fetch_from_controller(content_id, url_path)
             return self.get_zip(content_id)
+
+    def write_blob(self, data: bytes) -> str:
+        """Store a blob by content hash, return blob_id."""
+        blob_id = blob_id_for_bytes(data)
+        with self._lock:
+            if blob_id in self._cache:
+                self._cache.move_to_end(blob_id)
+                return blob_id
+
+            blob_path = self._blob_fs_path(blob_id)
+            if not self._fs.exists(blob_path):
+                self._fs.mkdirs(f"{self._fs_path}/blobs", exist_ok=True)
+                with self._fs.open(blob_path, "wb") as f:
+                    f.write(data)
+            self._cache_put(blob_id, data)
+        return blob_id
+
+    def get_blob(self, blob_id: str) -> bytes:
+        """Retrieve a blob by ID. Cache, then fsspec, then controller HTTP fallback."""
+        with self._lock:
+            if blob_id in self._cache:
+                self._cache.move_to_end(blob_id)
+                return self._cache[blob_id]
+
+            blob_path = self._blob_fs_path(blob_id)
+            if self._fs.exists(blob_path):
+                with self._fs.open(blob_path, "rb") as f:
+                    data = f.read()
+                self._cache_put(blob_id, data)
+                return data
+
+        # Outside lock: fetch from controller, which calls write_blob to populate cache/storage.
+        self._fetch_blob_from_controller(blob_id)
+        return self.get_blob(blob_id)
+
+    def _fetch_blob_from_controller(self, blob_id: str) -> None:
+        """Fetch a blob from the controller HTTP endpoint and store it locally.
+
+        Retries up to 3 times with exponential backoff. Verifies the SHA-256
+        hash of the downloaded data matches ``blob_id``.
+        """
+        if not self._controller_address:
+            raise RuntimeError(f"Blob {blob_id} is not cached and controller address is not configured")
+
+        url = f"{self._controller_address}/blobs/{blob_id}"
+        for attempt in range(3):
+            try:
+                with urlopen(url, timeout=120) as resp:
+                    data = resp.read()
+                break
+            except Exception as e:
+                if attempt == 2:
+                    raise RuntimeError(f"Failed to fetch blob {blob_id}: {e}") from e
+                time.sleep(0.25 * (2**attempt))
+
+        actual = blob_id_for_bytes(data)
+        if actual != blob_id:
+            raise ValueError(f"Blob hash mismatch while fetching {blob_id}: got {actual}")
+        self.write_blob(data)
 
     def extract_bundle_to(self, bundle_id: str, dest: Path) -> None:
         """Extract a bundle zip into ``dest`` with zip-slip protection.

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -851,7 +851,7 @@ class ControllerServiceImpl:
         return self._bundle_store.get_zip(bundle_id)
 
     def blob_data(self, blob_id: str) -> bytes:
-        return self._bundle_store.get_zip(blob_id)
+        return self._bundle_store.get_blob(blob_id)
 
     def _get_autoscaler_pending_hints(self) -> dict[str, PendingHint]:
         """Build autoscaler-based pending hints keyed by job id."""

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -981,7 +981,7 @@ class ControllerServiceImpl:
             if len(data) > WORKDIR_FILE_OFFLOAD_THRESHOLD
         }
         if large_files:
-            new_request = cluster_pb2.Controller.LaunchJobRequest()
+            new_request = controller_pb2.Controller.LaunchJobRequest()
             new_request.CopyFrom(request)
             for name, data in large_files.items():
                 blob_id = self._bundle_store.write_blob(data)

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -128,6 +128,7 @@ DEFAULT_MAX_TOTAL_LINES = 100000
 
 # Maximum bundle size in bytes (25 MB) - matches client-side limit
 MAX_BUNDLE_SIZE_BYTES = 25 * 1024 * 1024
+WORKDIR_FILE_OFFLOAD_THRESHOLD = 100 * 1024  # 100KB — externalize large workdir files to blob store
 
 USER_TASK_STATES = (
     job_pb2.TASK_STATE_PENDING,
@@ -970,6 +971,23 @@ class ControllerServiceImpl:
             new_request.CopyFrom(request)
             new_request.ClearField("bundle_blob")
             new_request.bundle_id = bundle_id
+            request = new_request
+
+        # Externalize large workdir files to the blob store so request_proto
+        # (and every RunTaskRequest dispatch) stays small.
+        large_files = {
+            name: data
+            for name, data in request.entrypoint.workdir_files.items()
+            if len(data) > WORKDIR_FILE_OFFLOAD_THRESHOLD
+        }
+        if large_files:
+            new_request = cluster_pb2.Controller.LaunchJobRequest()
+            new_request.CopyFrom(request)
+            for name, data in large_files.items():
+                blob_id = self._bundle_store.write_blob(data)
+                del new_request.entrypoint.workdir_files[name]
+                new_request.entrypoint.workdir_file_refs[name] = blob_id
+                logger.info("Externalized workdir file %s (%d bytes) as blob %s", name, len(data), blob_id[:12])
             request = new_request
 
         # Auto-inject device constraints from the resource spec.

--- a/lib/iris/src/iris/cluster/providers/k8s/bundle_fetch.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/bundle_fetch.py
@@ -4,11 +4,13 @@
 """Standalone bundle fetch script for Kubernetes init containers.
 
 Downloads and extracts a bundle zip from the Iris controller, with
-retry logic and zip-slip protection. Uses only stdlib so the init
-container needs no extra dependencies.
+retry logic and zip-slip protection. Also fetches externalized workdir
+files (blob refs) from the controller's blob endpoint. Uses only stdlib
+so the init container needs no extra dependencies.
 """
 
 import hashlib
+import json
 import os
 import shutil
 import sys
@@ -55,6 +57,32 @@ def fetch_bundle(controller_url: str, bundle_id: str, workdir: str) -> None:
     os.remove(zip_path)
 
 
+def fetch_workdir_blob_refs(controller_url: str, blob_refs_json: str, workdir: str) -> None:
+    """Download externalized workdir files from the controller's blob endpoint."""
+    refs = json.loads(blob_refs_json)
+    for name, blob_id in refs.items():
+        url = f"{controller_url}/blobs/{blob_id}"
+        rel_path = os.path.normpath(name)
+        dst_path = os.path.join(workdir, rel_path)
+        os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+
+        for attempt in range(3):
+            try:
+                req = urllib.request.Request(url)
+                with urllib.request.urlopen(req, timeout=300) as resp:
+                    data = resp.read()
+                with open(dst_path, "wb") as f:
+                    f.write(data)
+                print(f"Fetched blob ref {name} ({len(data)} bytes) from {blob_id[:12]}")
+                break
+            except Exception as e:
+                if attempt == 2:
+                    raise
+                wait = 2**attempt
+                print(f"Blob fetch {name} attempt {attempt + 1} failed: {e}; retrying in {wait}s", file=sys.stderr)
+                time.sleep(wait)
+
+
 def copy_workdir_files(src_dir: str, workdir: str) -> None:
     """Copy staged workdir files from ConfigMap mount into workdir."""
     if not os.path.isdir(src_dir):
@@ -80,5 +108,9 @@ if __name__ == "__main__":
     src_dir = os.environ.get("IRIS_WORKDIR_FILES_SRC", "")
     if src_dir:
         copy_workdir_files(src_dir, workdir)
+
+    blob_refs_json = os.environ.get("IRIS_WORKDIR_BLOB_REFS", "")
+    if blob_refs_json and controller_url:
+        fetch_workdir_blob_refs(controller_url, blob_refs_json, workdir)
 
     print("Workdir staging complete.")

--- a/lib/iris/src/iris/cluster/providers/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/tasks.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import base64
 import concurrent.futures
 import hashlib
+import json
 import logging
 import re
 import shlex
@@ -255,7 +256,9 @@ def _build_init_container_spec(
     """
     has_bundle = bool(run_req.bundle_id) and bool(controller_address)
     workdir_files = dict(run_req.entrypoint.workdir_files)
-    if not has_bundle and not workdir_files:
+    workdir_file_refs = dict(run_req.entrypoint.workdir_file_refs)
+    has_blob_refs = bool(workdir_file_refs) and bool(controller_address)
+    if not has_bundle and not workdir_files and not has_blob_refs:
         return [], [], None
 
     script_path = Path(__file__).parent / "bundle_fetch.py"
@@ -266,13 +269,14 @@ def _build_init_container_spec(
     extra_volumes: list[dict] = []
     configmap_name: str | None = None
 
+    if has_bundle or has_blob_refs:
+        init_env.append({"name": "IRIS_CONTROLLER_URL", "value": controller_address})
+
     if has_bundle:
-        init_env.extend(
-            [
-                {"name": "IRIS_BUNDLE_ID", "value": run_req.bundle_id},
-                {"name": "IRIS_CONTROLLER_URL", "value": controller_address},
-            ]
-        )
+        init_env.append({"name": "IRIS_BUNDLE_ID", "value": run_req.bundle_id})
+
+    if has_blob_refs:
+        init_env.append({"name": "IRIS_WORKDIR_BLOB_REFS", "value": json.dumps(workdir_file_refs)})
 
     if workdir_files:
         configmap_name = f"{pod_name}-wf"

--- a/lib/iris/src/iris/cluster/runtime/entrypoint.py
+++ b/lib/iris/src/iris/cluster/runtime/entrypoint.py
@@ -106,6 +106,8 @@ def build_runtime_entrypoint(
     rt.run_command.argv[:] = entrypoint.command
     for k, v in entrypoint.workdir_files.items():
         rt.workdir_files[k] = v
+    for k, v in entrypoint.workdir_file_refs.items():
+        rt.workdir_file_refs[k] = v
     return rt
 
 

--- a/lib/iris/src/iris/cluster/types.py
+++ b/lib/iris/src/iris/cluster/types.py
@@ -764,11 +764,13 @@ class Entrypoint:
         *,
         command: list[str],
         workdir_files: dict[str, bytes] | None = None,
+        workdir_file_refs: dict[str, str] | None = None,
     ):
         if not command:
             raise ValueError("Command must have at least one argument")
         self.command = command
         self.workdir_files: dict[str, bytes] = workdir_files or {}
+        self.workdir_file_refs: dict[str, str] = workdir_file_refs or {}
 
     def resolve(self) -> tuple[Callable[..., Any], tuple, dict[str, Any]]:
         """Deserialize the callable, args, kwargs from pickle bytes.
@@ -826,6 +828,8 @@ class Entrypoint:
         proto.run_command.argv[:] = self.command
         for name, data in self.workdir_files.items():
             proto.workdir_files[name] = data
+        for name, blob_id in self.workdir_file_refs.items():
+            proto.workdir_file_refs[name] = blob_id
         return proto
 
     @classmethod
@@ -833,4 +837,5 @@ class Entrypoint:
         """Create from protobuf representation."""
         command = list(proto.run_command.argv)
         workdir_files = dict(proto.workdir_files) if proto.workdir_files else None
-        return cls(command=command, workdir_files=workdir_files)
+        workdir_file_refs = dict(proto.workdir_file_refs) if proto.workdir_file_refs else None
+        return cls(command=command, workdir_files=workdir_files, workdir_file_refs=workdir_file_refs)

--- a/lib/iris/src/iris/cluster/worker/task_attempt.py
+++ b/lib/iris/src/iris/cluster/worker/task_attempt.py
@@ -629,7 +629,7 @@ class TaskAttempt:
         assert self.workdir is not None
         workdir_files = dict(self.request.entrypoint.workdir_files)
         for name, blob_id in self.request.entrypoint.workdir_file_refs.items():
-            workdir_files[name] = self._bundle_store.get_or_fetch(blob_id, f"blobs/{blob_id}")
+            workdir_files[name] = self._bundle_store.get_blob(blob_id)
         self._runtime.stage_bundle(
             bundle_id=self.request.bundle_id,
             workdir=self.workdir,

--- a/lib/iris/tests/cluster/controller/test_bundle_store.py
+++ b/lib/iris/tests/cluster/controller/test_bundle_store.py
@@ -59,3 +59,72 @@ def test_get_or_fetch_missing_no_controller_raises_not_found(store):
     """get_or_fetch raises FileNotFoundError when content is absent and no controller is configured."""
     with pytest.raises(FileNotFoundError):
         store.get_or_fetch("b" * 64, "blobs/" + "b" * 64)
+
+
+def test_write_zip_skips_upload_when_already_in_storage(tmp_path):
+    """write_zip should not re-upload if bundle exists in storage but was evicted from cache."""
+    storage_dir = str(tmp_path / "bundles")
+    store = BundleStore(storage_dir=storage_dir, max_cache_items=1)
+
+    blob_a = b"bundle A"
+    blob_b = b"bundle B"
+    id_a = store.write_zip(blob_a)
+    store.write_zip(blob_b)  # evicts blob_a from in-memory cache
+
+    # blob_a should still be in storage; re-submitting should not call _write_to_storage
+    original_write = store._write_to_storage
+    write_calls = []
+
+    def tracking_write(bundle_id, blob):
+        write_calls.append(bundle_id)
+        return original_write(bundle_id, blob)
+
+    store._write_to_storage = tracking_write
+    id_a2 = store.write_zip(blob_a)
+    assert id_a2 == id_a
+    assert write_calls == [], "write_zip should not re-upload when bundle exists in storage"
+
+
+def test_write_blob_returns_content_hash(store):
+    data = b"large pickle payload"
+
+    blob_id = store.write_blob(data)
+    assert blob_id == hashlib.sha256(data).hexdigest()
+    assert store.get_blob(blob_id) == data
+
+
+def test_write_blob_is_idempotent(store):
+    data = b"same blob bytes"
+
+    id1 = store.write_blob(data)
+    id2 = store.write_blob(data)
+    assert id1 == id2
+
+
+def test_get_blob_missing_raises(store):
+    with pytest.raises(RuntimeError, match="not cached and controller address is not configured"):
+        store.get_blob("b" * 64)
+
+
+def test_blob_survives_restart(tmp_path):
+    storage_dir = str(tmp_path / "bundles")
+    store = BundleStore(storage_dir=storage_dir)
+    data = b"persist this blob"
+    blob_id = store.write_blob(data)
+    store.close()
+
+    store2 = BundleStore(storage_dir=storage_dir)
+    assert store2.get_blob(blob_id) == data
+
+
+def test_blob_and_bundle_namespaces_independent(store):
+    """Blobs and bundles with identical content get separate storage paths."""
+    data = b"shared content"
+
+    bundle_id = store.write_zip(data)
+    blob_id = store.write_blob(data)
+    # Same hash since content is identical
+    assert bundle_id == blob_id
+    # Both retrievable via their respective methods
+    assert store.get_zip(bundle_id) == data
+    assert store.get_blob(blob_id) == data

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -119,6 +119,35 @@ def test_launch_job_bundle_blob_rewrites_to_controller_bundle_id(service, state)
     assert len(job.request.bundle_id) == 64
 
 
+def test_launch_job_externalizes_large_workdir_files(service, state):
+    request = make_job_request("big-pickle-job")
+    small_file = b"tiny"
+    large_file = b"x" * (200 * 1024)  # 200KB, above 100KB threshold
+    request.entrypoint.workdir_files["small.txt"] = small_file
+    request.entrypoint.workdir_files["_callable.pkl"] = large_file
+    service.launch_job(request, None)
+
+    job = _query_job(state, JobName.root("test-user", "big-pickle-job"))
+    assert job is not None
+    # Small file stays inline
+    assert job.request.entrypoint.workdir_files["small.txt"] == small_file
+    # Large file externalized to blob ref
+    assert "_callable.pkl" not in job.request.entrypoint.workdir_files
+    assert len(job.request.entrypoint.workdir_file_refs["_callable.pkl"]) == 64
+
+
+def test_launch_job_keeps_small_workdir_files_inline(service, state):
+    request = make_job_request("small-pickle-job")
+    small_file = b"x" * 1024  # 1KB
+    request.entrypoint.workdir_files["_callable.pkl"] = small_file
+    service.launch_job(request, None)
+
+    job = _query_job(state, JobName.root("test-user", "small-pickle-job"))
+    assert job is not None
+    assert job.request.entrypoint.workdir_files["_callable.pkl"] == small_file
+    assert "_callable.pkl" not in job.request.entrypoint.workdir_file_refs
+
+
 def test_launch_job_rejects_duplicate_name(service):
     """Verify launch_job rejects duplicate job names for running jobs."""
     request = make_job_request("duplicate-job")

--- a/lib/iris/tests/cluster/providers/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_pod_manifest.py
@@ -781,6 +781,68 @@ def test_init_container_bundle_and_workdir_files():
     assert len(extra_volumes) == 1
 
 
+def test_init_container_for_workdir_file_refs():
+    """Blob refs produce an init container with IRIS_WORKDIR_BLOB_REFS env var."""
+    req = make_run_req("/my-job/task-0")
+    req.entrypoint.workdir_file_refs["_callable.pkl"] = "abcd1234" * 8
+
+    init_containers, _extra_volumes, configmap_name = _build_init_container_spec(
+        req,
+        "iris-pod-name",
+        "myrepo/iris:latest",
+        "http://ctrl:8080",
+    )
+
+    assert len(init_containers) == 1
+    ic = init_containers[0]
+    env_by_name = {e["name"]: e["value"] for e in ic["env"]}
+    assert env_by_name["IRIS_CONTROLLER_URL"] == "http://ctrl:8080"
+    assert "IRIS_WORKDIR_BLOB_REFS" in env_by_name
+
+    import json
+
+    refs = json.loads(env_by_name["IRIS_WORKDIR_BLOB_REFS"])
+    assert refs == {"_callable.pkl": "abcd1234" * 8}
+    assert configmap_name is None
+
+
+def test_no_init_container_for_blob_refs_without_controller():
+    """Blob refs without controller_address are ignored (no way to fetch)."""
+    req = make_run_req("/my-job/task-0")
+    req.entrypoint.workdir_file_refs["_callable.pkl"] = "abcd1234" * 8
+
+    init_containers, _extra_volumes, configmap_name = _build_init_container_spec(
+        req,
+        "iris-pod-name",
+        "myrepo/iris:latest",
+        None,
+    )
+
+    assert init_containers == []
+    assert configmap_name is None
+
+
+def test_init_container_workdir_files_and_blob_refs():
+    """Both inline files and blob refs produce ConfigMap + blob ref env var."""
+    req = make_run_req("/my-job/task-0")
+    req.entrypoint.workdir_files["small.txt"] = b"tiny"
+    req.entrypoint.workdir_file_refs["big.pkl"] = "deadbeef" * 8
+
+    init_containers, _extra_volumes, configmap_name = _build_init_container_spec(
+        req,
+        "iris-pod-name",
+        "myrepo/iris:latest",
+        "http://ctrl:8080",
+    )
+
+    assert len(init_containers) == 1
+    ic = init_containers[0]
+    env_by_name = {e["name"]: e["value"] for e in ic["env"]}
+    assert "IRIS_WORKDIR_FILES_SRC" in env_by_name
+    assert "IRIS_WORKDIR_BLOB_REFS" in env_by_name
+    assert configmap_name is not None
+
+
 # ---------------------------------------------------------------------------
 # Coordinator detection and PDB manifest
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/runtime/test_entrypoint.py
+++ b/lib/iris/tests/cluster/runtime/test_entrypoint.py
@@ -86,6 +86,16 @@ def test_runtime_entrypoint_to_bash_script_structure():
     assert "exec python train.py --lr 0.001" in script
 
 
+def test_build_runtime_entrypoint_propagates_workdir_file_refs():
+    refs = {"_callable.pkl": "sha256abc", "weights.bin": "sha256def"}
+    ep = Entrypoint(command=["python", "run.py"], workdir_files={"small.txt": b"hi"}, workdir_file_refs=refs)
+    env = _make_env_config()
+    rt = build_runtime_entrypoint(ep, env)
+
+    assert dict(rt.workdir_files) == {"small.txt": b"hi"}
+    assert dict(rt.workdir_file_refs) == refs
+
+
 @pytest.mark.parametrize(
     "extras,expected_fragments",
     [

--- a/lib/iris/tests/cluster/test_types.py
+++ b/lib/iris/tests/cluster/test_types.py
@@ -50,6 +50,19 @@ def test_entrypoint_proto_roundtrip_preserves_bytes():
     assert fn(*args, **kwargs) == 3
 
 
+def test_entrypoint_proto_roundtrip_preserves_workdir_file_refs():
+    """workdir_file_refs survive to_proto -> from_proto."""
+    refs = {"_callable.pkl": "abc123", "model.bin": "def456"}
+    ep = Entrypoint(command=["python", "run.py"], workdir_files={"small.txt": b"hi"}, workdir_file_refs=refs)
+
+    proto = ep.to_proto()
+    ep2 = Entrypoint.from_proto(proto)
+
+    assert ep2.workdir_file_refs == refs
+    assert ep2.workdir_files == {"small.txt": b"hi"}
+    assert ep2.command == ["python", "run.py"]
+
+
 def test_entrypoint_command():
     ep = Entrypoint.from_command("echo", "hello")
     assert not ep.workdir_files

--- a/lib/iris/tests/cluster/worker/test_bundle_store.py
+++ b/lib/iris/tests/cluster/worker/test_bundle_store.py
@@ -98,7 +98,6 @@ def test_lru_eviction_by_item_count(store):
     assert store.get_zip(bundles[2][0]) == bundles[2][1]
 
 
-
 def test_get_or_fetch_fetches_blob_on_demand(monkeypatch, store):
     """get_or_fetch should fetch from controller on cache miss using the provided URL path."""
     data = b"large pickle data"

--- a/lib/iris/tests/cluster/worker/test_bundle_store.py
+++ b/lib/iris/tests/cluster/worker/test_bundle_store.py
@@ -98,6 +98,7 @@ def test_lru_eviction_by_item_count(store):
     assert store.get_zip(bundles[2][0]) == bundles[2][1]
 
 
+
 def test_get_or_fetch_fetches_blob_on_demand(monkeypatch, store):
     """get_or_fetch should fetch from controller on cache miss using the provided URL path."""
     data = b"large pickle data"
@@ -131,3 +132,39 @@ def test_get_or_fetch_hash_verification_failure(monkeypatch, store):
     monkeypatch.setattr("iris.cluster.bundle.urlopen", fake_urlopen)
     with pytest.raises(ValueError, match="Hash mismatch"):
         store.get_or_fetch(wrong_id, f"blobs/{wrong_id}")
+
+
+def test_get_blob_fetches_on_demand(monkeypatch, store):
+    """get_blob should fetch from controller on cache miss."""
+    data = b"large pickle data"
+    blob_id = hashlib.sha256(data).hexdigest()
+
+    def fake_urlopen(url: str, timeout: int):
+        assert url == f"http://controller.internal/blobs/{blob_id}"
+        return _FakeResponse(data)
+
+    monkeypatch.setattr("iris.cluster.bundle.urlopen", fake_urlopen)
+
+    result = store.get_blob(blob_id)
+    assert result == data
+
+
+def test_get_blob_uses_cache_on_hit(store):
+    """get_blob should return cached data without hitting the network."""
+    data = b"cached blob"
+    store.write_blob(data)
+    blob_id = hashlib.sha256(data).hexdigest()
+    assert store.get_blob(blob_id) == data
+
+
+def test_get_blob_hash_verification_failure(monkeypatch, store):
+    bad_data = b"wrong content"
+    wrong_id = "c" * 64
+
+    def fake_urlopen(url: str, timeout: int):
+        assert url == f"http://controller.internal/blobs/{wrong_id}"
+        return _FakeResponse(bad_data)
+
+    monkeypatch.setattr("iris.cluster.bundle.urlopen", fake_urlopen)
+    with pytest.raises(ValueError, match="Blob hash mismatch"):
+        store.get_blob(wrong_id)

--- a/lib/iris/tests/e2e/helpers.py
+++ b/lib/iris/tests/e2e/helpers.py
@@ -135,6 +135,20 @@ class TestJobs:
         assert info.ports["grpc"] > 0
 
     @staticmethod
+    def verify_workdir_file(filename: str, expected_size: int):
+        """Verify a workdir file exists with the expected size."""
+        import os
+
+        workdir = os.environ.get("IRIS_WORKDIR", "/app")
+        path = os.path.join(workdir, filename)
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"Workdir file {filename} not found at {path}")
+        actual_size = os.path.getsize(path)
+        if actual_size != expected_size:
+            raise ValueError(f"Expected {expected_size} bytes, got {actual_size}")
+        return actual_size
+
+    @staticmethod
     def validate_job_context():
         """Validate job context via get_job_info() in a coscheduled job."""
         import logging

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -910,6 +910,26 @@ def test_stress_50_tasks(smoke_cluster):
 
 
 # ============================================================================
+# Workdir file offload (large files externalized to blob store)
+# ============================================================================
+
+OFFLOAD_FILE_SIZE = 200 * 1024  # 200KB — exceeds the 100KB offload threshold
+
+
+def test_workdir_file_offload(smoke_cluster):
+    """A job with a >100KB workdir file succeeds after blob-store offloading."""
+    entrypoint = Entrypoint.from_callable(TestJobs.verify_workdir_file, "large_payload.bin", OFFLOAD_FILE_SIZE)
+    entrypoint.workdir_files["large_payload.bin"] = b"\xab" * OFFLOAD_FILE_SIZE
+    job = smoke_cluster.client.submit(
+        entrypoint=entrypoint,
+        name=f"smoke-offload-{uuid.uuid4().hex[:8]}",
+        resources=ResourceSpec(cpu=1, memory="1g"),
+    )
+    status = smoke_cluster.wait(job, timeout=smoke_cluster.job_timeout)
+    assert status.state == job_pb2.JOB_STATE_SUCCEEDED
+
+
+# ============================================================================
 # GPU metadata (local-only, creates standalone cluster with mocked nvidia-smi)
 # ============================================================================
 


### PR DESCRIPTION
Controller-side offload logic for large workdir files. During launch_job,
any workdir_file exceeding 100KB is written to the blob store and replaced
with a SHA-256 reference in workdir_file_refs. This keeps request_proto
and gRPC dispatch messages small.

Stacked on #4245 which adds the blob infrastructure, dashboard endpoint,
and worker-side resolution. Deploy workers with #4245 first, then merge
this to enable offloading.