### PR TITLE
[Eval] Add long-context evaluation lane for exp2062

### DIFF
--- a/experiments/evals/evals.py
+++ b/experiments/evals/evals.py
@@ -6,10 +6,12 @@ Canonical set of evals.
 """
 
 import logging
+import os
 import re
 from collections.abc import Sequence
 
 from fray.cluster import ResourceConfig
+from iris.marin_fs import marin_prefix
 from marin.evaluation.evaluation_config import EvalTaskConfig, EvaluationConfig
 from marin.evaluation.evaluators.harbor_evaluator import HARBOR_EVAL_ENV_KEYS, env_vars_from_keys
 from marin.evaluation.run import evaluate
@@ -34,11 +36,13 @@ from experiments.evals.task_configs import (
     CORE_TASKS_PLUS_LEADERBOARD,
     KEY_GENERATION_TASKS,
     KEY_MULTIPLE_CHOICE_TASKS,
+    LONG_CONTEXT_TASKS_BY_LENGTH,
     MMLU_0_SHOT,
     MMLU_5_SHOT,
     MMLU_PRO_5_SHOT,
     OPEN_LM_LEADERBOARD_GEN,
     OPEN_LM_LEADERBOARD_MCQ,
+    long_context_tasks_for_lengths,
 )
 
 EVAL_DEPENDENCY_GROUPS = ["eval", "vllm", "tpu"]
@@ -105,7 +109,11 @@ def _infer_model_name_for_path(model_path: str) -> str:
     if model_path.endswith("/"):
         model_path = model_path[:-1]
 
-    return "_".join(model_path.split("/")[-2:])
+    path_parts = model_path.split("/")
+    if len(path_parts) >= 3 and path_parts[-2] == "hf" and path_parts[-1].startswith("step-"):
+        return f"{path_parts[-3]}_{path_parts[-1]}"
+
+    return "_".join(path_parts[-2:])
 
 
 def extract_model_name_and_path(step: ExecutorStep | InputName | str) -> tuple[str, InputName | str]:
@@ -123,7 +131,10 @@ def extract_model_name_and_path(step: ExecutorStep | InputName | str) -> tuple[s
         if step.step is None:
             if step.name is None:
                 raise ValueError("Invalid InputName: both `step` and `name` are None.")
-            model_step_path = step.name
+            if "://" in step.name or os.path.isabs(step.name):
+                model_step_path = step.name
+            else:
+                model_step_path = os.path.join(marin_prefix(), step.name)
             name = _infer_model_name_for_path(step.name)
         else:
             # If `name` is already set, the InputName refers to a specific subpath under the step's output.
@@ -345,6 +356,94 @@ def default_sft_eval(
             )
             eval_jobs.append(olmo_generation)
     return eval_jobs
+
+
+def _required_long_context_max_model_len(evals: Sequence[EvalTaskConfig]) -> int:
+    max_context_len = 0
+    max_gen_toks = 0
+    for eval_task in evals:
+        task_kwargs = dict(eval_task.task_kwargs or {})
+        max_context_len = max(max_context_len, int(task_kwargs.get("context_len", 0)))
+        max_gen_toks = max(max_gen_toks, int(task_kwargs.get("max_gen_toks", 32)))
+    return max_context_len + max_gen_toks + 256
+
+
+def evaluate_long_context(
+    model_name: str,
+    model_path: str,
+    evals: Sequence[EvalTaskConfig],
+    *,
+    max_eval_instances: int | None = None,
+    engine_kwargs: dict | None = None,
+    generation_params: dict | None = None,
+    resource_config: ResourceConfig | None = None,
+    apply_chat_template: bool = False,
+    wandb_tags: list[str] | None = None,
+    discover_latest_checkpoint: bool = False,
+) -> ExecutorStep:
+    task_names = "_".join(sorted(eval_task.name for eval_task in evals))
+    return ExecutorStep(
+        name=f"evaluation/long_context/{model_name}/{task_names}",
+        fn=evaluate,
+        config=EvaluationConfig(
+            evaluator="long_context",
+            model_name=model_name,
+            model_path=model_path,
+            evaluation_path=this_output_path(),
+            evals=versioned(list(evals)),
+            max_eval_instances=max_eval_instances,
+            launch_with_ray=True,
+            discover_latest_checkpoint=discover_latest_checkpoint,
+            engine_kwargs=engine_kwargs,
+            generation_params=generation_params,
+            resource_config=resource_config,
+            apply_chat_template=apply_chat_template,
+            wandb_tags=wandb_tags,
+        ),
+    )
+
+
+def default_long_context_eval(
+    step: ExecutorStep | InputName | str,
+    *,
+    lengths: Sequence[int] | None = None,
+    finepdf_manifest_path: str | None = None,
+    evals: Sequence[EvalTaskConfig] | None = None,
+    resource_config: ResourceConfig = ResourceConfig.with_tpu("v5p-8"),
+    max_eval_instances: int | None = None,
+    engine_kwargs: dict | None = None,
+    generation_params: dict | None = None,
+    apply_chat_template: bool = False,
+    discover_latest_checkpoint: bool = False,
+) -> ExecutorStep:
+    name, model_step_path = extract_model_name_and_path(step)
+
+    if evals is None:
+        selected_lengths = tuple(lengths) if lengths is not None else tuple(sorted(LONG_CONTEXT_TASKS_BY_LENGTH))
+        evals = long_context_tasks_for_lengths(
+            selected_lengths,
+            finepdf_manifest_path=finepdf_manifest_path,
+        )
+
+    resolved_engine_kwargs = dict(engine_kwargs or {})
+    resolved_engine_kwargs.setdefault("tensor_parallel_size", 4)
+    resolved_engine_kwargs.setdefault("max_model_len", _required_long_context_max_model_len(evals))
+
+    resolved_generation_params = dict(generation_params or {})
+    resolved_generation_params.setdefault("temperature", 0.0)
+
+    return evaluate_long_context(
+        name,
+        model_step_path,
+        evals,
+        max_eval_instances=max_eval_instances,
+        engine_kwargs=resolved_engine_kwargs,
+        generation_params=resolved_generation_params,
+        resource_config=resource_config,
+        apply_chat_template=apply_chat_template,
+        wandb_tags=["long_context"],
+        discover_latest_checkpoint=discover_latest_checkpoint,
+    )
 
 
 def default_key_evals(

--- a/experiments/evals/evals.py
+++ b/experiments/evals/evals.py
@@ -11,7 +11,6 @@ import re
 from collections.abc import Sequence
 
 from fray.cluster import ResourceConfig
-from iris.marin_fs import marin_prefix
 from marin.evaluation.evaluation_config import EvalTaskConfig, EvaluationConfig
 from marin.evaluation.evaluators.harbor_evaluator import HARBOR_EVAL_ENV_KEYS, env_vars_from_keys
 from marin.evaluation.run import evaluate
@@ -26,6 +25,7 @@ from marin.execution.executor import (
 )
 from marin.execution.remote import remote
 from marin.inference.vllm_server import validate_vllm_mode_env
+from rigging.filesystem import marin_prefix
 
 from experiments.evals.engine_configs import DEFAULT_LM_EVAL_MODEL_KWARGS
 from experiments.evals.evalchemy_results_compiler import compile_evalchemy_results_fn
@@ -368,6 +368,14 @@ def _required_long_context_max_model_len(evals: Sequence[EvalTaskConfig]) -> int
     return max_context_len + max_gen_toks + 256
 
 
+def _default_long_context_tensor_parallel_size(resource_config: ResourceConfig | None) -> int | None:
+    if resource_config is None:
+        return None
+
+    chip_count = resource_config.chip_count()
+    return chip_count if chip_count > 0 else None
+
+
 def evaluate_long_context(
     model_name: str,
     model_path: str,
@@ -384,7 +392,12 @@ def evaluate_long_context(
     task_names = "_".join(sorted(eval_task.name for eval_task in evals))
     return ExecutorStep(
         name=f"evaluation/long_context/{model_name}/{task_names}",
-        fn=evaluate,
+        fn=remote(
+            evaluate,
+            resources=resource_config,
+            env_vars=env_vars_from_keys(HARBOR_EVAL_ENV_KEYS),
+            pip_dependency_groups=EVAL_DEPENDENCY_GROUPS,
+        ),
         config=EvaluationConfig(
             evaluator="long_context",
             model_name=model_name,
@@ -392,7 +405,6 @@ def evaluate_long_context(
             evaluation_path=this_output_path(),
             evals=versioned(list(evals)),
             max_eval_instances=max_eval_instances,
-            launch_with_ray=True,
             discover_latest_checkpoint=discover_latest_checkpoint,
             engine_kwargs=engine_kwargs,
             generation_params=generation_params,
@@ -407,7 +419,6 @@ def default_long_context_eval(
     step: ExecutorStep | InputName | str,
     *,
     lengths: Sequence[int] | None = None,
-    finepdf_manifest_path: str | None = None,
     evals: Sequence[EvalTaskConfig] | None = None,
     resource_config: ResourceConfig = ResourceConfig.with_tpu("v5p-8"),
     max_eval_instances: int | None = None,
@@ -420,13 +431,12 @@ def default_long_context_eval(
 
     if evals is None:
         selected_lengths = tuple(lengths) if lengths is not None else tuple(sorted(LONG_CONTEXT_TASKS_BY_LENGTH))
-        evals = long_context_tasks_for_lengths(
-            selected_lengths,
-            finepdf_manifest_path=finepdf_manifest_path,
-        )
+        evals = long_context_tasks_for_lengths(selected_lengths)
 
     resolved_engine_kwargs = dict(engine_kwargs or {})
-    resolved_engine_kwargs.setdefault("tensor_parallel_size", 4)
+    default_tensor_parallel_size = _default_long_context_tensor_parallel_size(resource_config)
+    if default_tensor_parallel_size is not None:
+        resolved_engine_kwargs.setdefault("tensor_parallel_size", default_tensor_parallel_size)
     resolved_engine_kwargs.setdefault("max_model_len", _required_long_context_max_model_len(evals))
 
     resolved_generation_params = dict(generation_params or {})

--- a/experiments/evals/exp2062_long_context_eval.py
+++ b/experiments/evals/exp2062_long_context_eval.py
@@ -1,0 +1,78 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+
+from fray.cluster import ResourceConfig
+
+from experiments.evals.evals import default_base_eval, default_long_context_eval
+from experiments.tootsie.exp2062_long_context_8b import (
+    STARLING_WARMSTART_STEP,
+    phase1_final_checkpoint,
+    phase2_final_checkpoint,
+    phase3_final_checkpoint,
+)
+from marin.execution.executor import InputName, executor_main
+
+BASE_EVAL_RESOURCES = ResourceConfig.with_tpu("v6e-8")
+LONG_CONTEXT_RESOURCES = ResourceConfig.with_tpu("v5p-8")
+
+# Fill this in once the frozen natural long-context manifest is ready.
+# When left as None, the runner evaluates only the synthetic long-context tasks.
+FINEPDF_MANIFEST_PATH: str | None = None
+
+
+@dataclass(frozen=True)
+class CheckpointEvalSpec:
+    name: str
+    checkpoint: InputName
+    lengths: tuple[int, ...]
+
+
+CHECKPOINTS = (
+    CheckpointEvalSpec(
+        name="starling_warmstart",
+        checkpoint=InputName.hardcoded(
+            f"checkpoints/tootsie-8b-sensible-starling/hf/step-{STARLING_WARMSTART_STEP}"
+        ),
+        lengths=(4096,),
+    ),
+    CheckpointEvalSpec(
+        name="giraffe_phase1_end",
+        checkpoint=phase1_final_checkpoint,
+        lengths=(4096,),
+    ),
+    CheckpointEvalSpec(
+        name="giraffe_phase2_end",
+        checkpoint=phase2_final_checkpoint,
+        lengths=(4096, 16384, 32768),
+    ),
+    CheckpointEvalSpec(
+        name="giraffe_phase3_end",
+        checkpoint=phase3_final_checkpoint,
+        lengths=(4096, 16384, 32768, 65536),
+    ),
+)
+
+
+if __name__ == "__main__":
+    eval_steps = []
+    for checkpoint in CHECKPOINTS:
+        eval_steps.extend(
+            default_base_eval(
+                checkpoint.checkpoint,
+                resource_config=BASE_EVAL_RESOURCES,
+                discover_latest_checkpoint=False,
+            )
+        )
+        eval_steps.append(
+            default_long_context_eval(
+                checkpoint.checkpoint,
+                lengths=checkpoint.lengths,
+                finepdf_manifest_path=FINEPDF_MANIFEST_PATH,
+                resource_config=LONG_CONTEXT_RESOURCES,
+                discover_latest_checkpoint=False,
+            )
+        )
+
+    executor_main(steps=eval_steps)

--- a/experiments/evals/exp2062_long_context_eval.py
+++ b/experiments/evals/exp2062_long_context_eval.py
@@ -31,19 +31,19 @@ class CheckpointEvalSpec:
 
 CHECKPOINTS = (
     CheckpointEvalSpec(
-        checkpoint=tootsie_8b_sensible_starling.cd(f"hf/step-{STARLING_WARMSTART_STEP}"),
+        checkpoint=tootsie_8b_sensible_starling.cd(f"hf/step-{STARLING_WARMSTART_STEP}").nonblocking(),
         lengths=(4096,),
     ),
     CheckpointEvalSpec(
-        checkpoint=phase1_final_checkpoint,
+        checkpoint=phase1_final_checkpoint.nonblocking(),
         lengths=(4096,),
     ),
     CheckpointEvalSpec(
-        checkpoint=phase2_final_checkpoint,
+        checkpoint=phase2_final_checkpoint.nonblocking(),
         lengths=(4096, 16384, 32768),
     ),
     CheckpointEvalSpec(
-        checkpoint=phase3_final_checkpoint,
+        checkpoint=phase3_final_checkpoint.nonblocking(),
         lengths=(4096, 16384, 32768, 65536),
     ),
 )

--- a/experiments/evals/exp2062_long_context_eval.py
+++ b/experiments/evals/exp2062_long_context_eval.py
@@ -12,6 +12,7 @@ from experiments.tootsie.exp2062_long_context_8b import (
     phase2_final_checkpoint,
     phase3_final_checkpoint,
 )
+from experiments.tootsie.exp600_tootsie import tootsie_8b_sensible_starling
 from marin.execution.executor import InputName, executor_main
 
 BASE_EVAL_RESOURCES = ResourceConfig.with_tpu("v6e-8")
@@ -24,31 +25,24 @@ FINEPDF_MANIFEST_PATH: str | None = None
 
 @dataclass(frozen=True)
 class CheckpointEvalSpec:
-    name: str
     checkpoint: InputName
     lengths: tuple[int, ...]
 
 
 CHECKPOINTS = (
     CheckpointEvalSpec(
-        name="starling_warmstart",
-        checkpoint=InputName.hardcoded(
-            f"checkpoints/tootsie-8b-sensible-starling/hf/step-{STARLING_WARMSTART_STEP}"
-        ),
+        checkpoint=tootsie_8b_sensible_starling.cd(f"hf/step-{STARLING_WARMSTART_STEP}"),
         lengths=(4096,),
     ),
     CheckpointEvalSpec(
-        name="giraffe_phase1_end",
         checkpoint=phase1_final_checkpoint,
         lengths=(4096,),
     ),
     CheckpointEvalSpec(
-        name="giraffe_phase2_end",
         checkpoint=phase2_final_checkpoint,
         lengths=(4096, 16384, 32768),
     ),
     CheckpointEvalSpec(
-        name="giraffe_phase3_end",
         checkpoint=phase3_final_checkpoint,
         lengths=(4096, 16384, 32768, 65536),
     ),

--- a/experiments/evals/exp2062_long_context_eval.py
+++ b/experiments/evals/exp2062_long_context_eval.py
@@ -4,23 +4,19 @@
 from dataclasses import dataclass
 
 from fray.cluster import ResourceConfig
+from marin.execution.executor import InputName, executor_main
 
 from experiments.evals.evals import default_base_eval, default_long_context_eval
+from experiments.tootsie.exp600_tootsie import tootsie_8b_sensible_starling
 from experiments.tootsie.exp2062_long_context_8b import (
     STARLING_WARMSTART_STEP,
     phase1_final_checkpoint,
     phase2_final_checkpoint,
     phase3_final_checkpoint,
 )
-from experiments.tootsie.exp600_tootsie import tootsie_8b_sensible_starling
-from marin.execution.executor import InputName, executor_main
 
 BASE_EVAL_RESOURCES = ResourceConfig.with_tpu("v6e-8")
 LONG_CONTEXT_RESOURCES = ResourceConfig.with_tpu("v5p-8")
-
-# Fill this in once the frozen natural long-context manifest is ready.
-# When left as None, the runner evaluates only the synthetic long-context tasks.
-FINEPDF_MANIFEST_PATH: str | None = None
 
 
 @dataclass(frozen=True)
@@ -63,7 +59,6 @@ if __name__ == "__main__":
             default_long_context_eval(
                 checkpoint.checkpoint,
                 lengths=checkpoint.lengths,
-                finepdf_manifest_path=FINEPDF_MANIFEST_PATH,
                 resource_config=LONG_CONTEXT_RESOURCES,
                 discover_latest_checkpoint=False,
             )

--- a/experiments/evals/task_configs.py
+++ b/experiments/evals/task_configs.py
@@ -81,6 +81,89 @@ BASE_GENERATION_TASKS = (
     EvalTaskConfig(name="triviaqa", num_fewshot=0, task_alias="triviaqa"),
 )
 
+
+def finepdf_extractive_qa_task(*, context_len: int, manifest_path: str, max_gen_toks: int = 64) -> EvalTaskConfig:
+    context_len_k = context_len // 1024
+    return EvalTaskConfig(
+        name=f"finepdf_extractive_qa_{context_len_k}k",
+        num_fewshot=0,
+        task_kwargs={
+            "family": "finepdf_qa",
+            "context_len": context_len,
+            "manifest_path": manifest_path,
+            "max_gen_toks": max_gen_toks,
+        },
+    )
+
+
+LONG_CONTEXT_TASKS_BY_LENGTH = {
+    4096: (
+        EvalTaskConfig(
+            name="passkey_4k",
+            num_fewshot=0,
+            task_kwargs={"family": "passkey", "context_len": 4096, "num_examples": 128, "seed": 0, "max_gen_toks": 16},
+        ),
+        EvalTaskConfig(
+            name="kv_retrieval_4k",
+            num_fewshot=0,
+            task_kwargs={"family": "kv", "context_len": 4096, "num_examples": 128, "seed": 0, "max_gen_toks": 16},
+        ),
+    ),
+    16384: (
+        EvalTaskConfig(
+            name="passkey_16k",
+            num_fewshot=0,
+            task_kwargs={"family": "passkey", "context_len": 16384, "num_examples": 128, "seed": 0, "max_gen_toks": 16},
+        ),
+        EvalTaskConfig(
+            name="kv_retrieval_16k",
+            num_fewshot=0,
+            task_kwargs={"family": "kv", "context_len": 16384, "num_examples": 128, "seed": 0, "max_gen_toks": 16},
+        ),
+    ),
+    32768: (
+        EvalTaskConfig(
+            name="passkey_32k",
+            num_fewshot=0,
+            task_kwargs={"family": "passkey", "context_len": 32768, "num_examples": 128, "seed": 0, "max_gen_toks": 16},
+        ),
+        EvalTaskConfig(
+            name="kv_retrieval_32k",
+            num_fewshot=0,
+            task_kwargs={"family": "kv", "context_len": 32768, "num_examples": 128, "seed": 0, "max_gen_toks": 16},
+        ),
+    ),
+    65536: (
+        EvalTaskConfig(
+            name="passkey_64k",
+            num_fewshot=0,
+            task_kwargs={"family": "passkey", "context_len": 65536, "num_examples": 128, "seed": 0, "max_gen_toks": 16},
+        ),
+        EvalTaskConfig(
+            name="kv_retrieval_64k",
+            num_fewshot=0,
+            task_kwargs={"family": "kv", "context_len": 65536, "num_examples": 128, "seed": 0, "max_gen_toks": 16},
+        ),
+    ),
+}
+
+
+def long_context_tasks_for_lengths(
+    lengths: Sequence[int],
+    *,
+    finepdf_manifest_path: str | None = None,
+) -> tuple[EvalTaskConfig, ...]:
+    tasks: list[EvalTaskConfig] = []
+    for length in lengths:
+        if length not in LONG_CONTEXT_TASKS_BY_LENGTH:
+            raise KeyError(f"Unsupported long-context length: {length}")
+        tasks.extend(LONG_CONTEXT_TASKS_BY_LENGTH[length])
+        if finepdf_manifest_path is not None:
+            tasks.append(finepdf_extractive_qa_task(context_len=length, manifest_path=finepdf_manifest_path))
+
+    return tuple(tasks)
+
+
 # Settings are chosen to compare to Olmo2
 KEY_GENERATION_TASKS = (
     EvalTaskConfig(name="ifeval", num_fewshot=0),

--- a/experiments/evals/task_configs.py
+++ b/experiments/evals/task_configs.py
@@ -82,20 +82,6 @@ BASE_GENERATION_TASKS = (
 )
 
 
-def finepdf_extractive_qa_task(*, context_len: int, manifest_path: str, max_gen_toks: int = 64) -> EvalTaskConfig:
-    context_len_k = context_len // 1024
-    return EvalTaskConfig(
-        name=f"finepdf_extractive_qa_{context_len_k}k",
-        num_fewshot=0,
-        task_kwargs={
-            "family": "finepdf_qa",
-            "context_len": context_len,
-            "manifest_path": manifest_path,
-            "max_gen_toks": max_gen_toks,
-        },
-    )
-
-
 LONG_CONTEXT_TASKS_BY_LENGTH = {
     4096: (
         EvalTaskConfig(
@@ -148,18 +134,12 @@ LONG_CONTEXT_TASKS_BY_LENGTH = {
 }
 
 
-def long_context_tasks_for_lengths(
-    lengths: Sequence[int],
-    *,
-    finepdf_manifest_path: str | None = None,
-) -> tuple[EvalTaskConfig, ...]:
+def long_context_tasks_for_lengths(lengths: Sequence[int]) -> tuple[EvalTaskConfig, ...]:
     tasks: list[EvalTaskConfig] = []
     for length in lengths:
         if length not in LONG_CONTEXT_TASKS_BY_LENGTH:
             raise KeyError(f"Unsupported long-context length: {length}")
         tasks.extend(LONG_CONTEXT_TASKS_BY_LENGTH[length])
-        if finepdf_manifest_path is not None:
-            tasks.append(finepdf_extractive_qa_task(context_len=length, manifest_path=finepdf_manifest_path))
 
     return tuple(tasks)
 

--- a/lib/marin/src/marin/evaluation/benchmarks/__init__.py
+++ b/lib/marin/src/marin/evaluation/benchmarks/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/lib/marin/src/marin/evaluation/benchmarks/long_context.py
+++ b/lib/marin/src/marin/evaluation/benchmarks/long_context.py
@@ -1,10 +1,19 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+"""Synthetic long-context sanity checks for Marin eval runs.
+
+These bespoke tasks are intentionally small and deterministic. `passkey`
+places one generated identifier inside filler text and asks the model to copy
+it back. `kv` builds a generated key-value registry and asks for one value.
+They are useful for catching obvious context-extension failures, but they are
+not a replacement for external long-context suites such as lm-eval tasks,
+RULER, or NIAH.
+"""
+
 import json
 import random
 import re
-from collections import Counter
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -33,7 +42,6 @@ _FILLER_VOCAB = (
 class LongContextFamily(StrEnum):
     PASSKEY = "passkey"
     KV = "kv"
-    FINEPDF_QA = "finepdf_qa"
 
 
 @dataclass(frozen=True)
@@ -70,9 +78,6 @@ def build_long_context_task(
     elif family is LongContextFamily.KV:
         examples = _build_kv_examples(context_len=context_len, task_kwargs=task_kwargs)
         metric_names = ("exact_match",)
-    elif family is LongContextFamily.FINEPDF_QA:
-        examples = _load_finepdf_examples(task_kwargs=task_kwargs)
-        metric_names = ("exact_match", "token_f1")
     else:
         raise ValueError(f"Unsupported long-context family: {family}")
 
@@ -127,7 +132,6 @@ def write_long_context_results(output_dir: str | Path, results: Sequence[dict[st
 
 def score_long_context_task(task: LongContextTask, predictions: Sequence[str]) -> dict[str, Any]:
     exact_total = 0.0
-    f1_total = 0.0
     example_results: list[dict[str, Any]] = []
 
     for example, prediction in zip(task.examples, predictions, strict=True):
@@ -140,12 +144,6 @@ def score_long_context_task(task: LongContextTask, predictions: Sequence[str]) -
             "correct": bool(exact_match),
             "metadata": example.metadata,
         }
-
-        if task.family is LongContextFamily.FINEPDF_QA:
-            token_f1 = _token_f1(prediction, example.gold_answer)
-            f1_total += token_f1
-            example_result["token_f1"] = token_f1
-
         example_results.append(example_result)
 
     num_examples = len(task.examples)
@@ -153,8 +151,6 @@ def score_long_context_task(task: LongContextTask, predictions: Sequence[str]) -
         raise ValueError(f"Long-context task {task.task_name!r} produced zero examples")
 
     metrics: dict[str, float] = {"exact_match": exact_total / num_examples}
-    if task.family is LongContextFamily.FINEPDF_QA:
-        metrics["token_f1"] = f1_total / num_examples
 
     return {
         "task_name": task.task_name,
@@ -232,70 +228,6 @@ def _build_kv_examples(*, context_len: int, task_kwargs: dict[str, Any]) -> list
     return examples
 
 
-def _load_finepdf_examples(*, task_kwargs: dict[str, Any]) -> list[LongContextExample]:
-    manifest_path = task_kwargs.get("manifest_path")
-    if not isinstance(manifest_path, str) or not manifest_path:
-        raise ValueError("finepdf_qa tasks require a non-empty task_kwargs['manifest_path']")
-
-    requested_context_len = int(task_kwargs["context_len"])
-    examples: list[LongContextExample] = []
-    with _open_manifest(manifest_path) as manifest_file:
-        for line_num, line in enumerate(manifest_file, start=1):
-            line = line.strip()
-            if not line:
-                continue
-            record = json.loads(line)
-            if "context_len" not in record:
-                raise ValueError(
-                    f"finepdf_qa manifest {manifest_path!r} record on line {line_num} is missing required "
-                    "'context_len'"
-                )
-
-            record_context_len = int(record["context_len"])
-            if record_context_len != requested_context_len:
-                continue
-
-            example_id = str(record["id"])
-            gold_answer = str(record["answer"])
-            metadata = dict(record.get("metadata", {}))
-            metadata["context_len"] = record_context_len
-            if "prompt" in record:
-                prompt = str(record["prompt"])
-            else:
-                context = str(record["context"])
-                question = str(record["question"])
-                prompt = (
-                    "Read the following document excerpt and answer the question.\n\n"
-                    f"Document:\n{context}\n\n"
-                    f"Question: {question}\n"
-                    "Answer with a short extract from the document."
-                )
-            examples.append(
-                LongContextExample(
-                    example_id=example_id,
-                    prompt=prompt,
-                    gold_answer=gold_answer,
-                    metadata=metadata,
-                )
-            )
-
-    if not examples:
-        raise ValueError(
-            f"finepdf_qa manifest {manifest_path!r} did not contain any examples for context_len={requested_context_len}"
-        )
-
-    return examples
-
-
-def _open_manifest(manifest_path: str):
-    if "://" not in manifest_path:
-        return open(manifest_path, "r")
-
-    import fsspec
-
-    return fsspec.open(manifest_path, "r").open()
-
-
 def _build_filler(*, target_units: int, rng: random.Random) -> str:
     fragments: list[str] = []
     num_units = 0
@@ -309,22 +241,3 @@ def _build_filler(*, target_units: int, rng: random.Random) -> str:
 def _normalize_text(text: str) -> str:
     normalized = _NON_WORD_RE.sub(" ", text.lower()).strip()
     return re.sub(r"\s+", " ", normalized)
-
-
-def _token_f1(prediction: str, gold_answer: str) -> float:
-    pred_tokens = _normalize_text(prediction).split()
-    gold_tokens = _normalize_text(gold_answer).split()
-    if not pred_tokens and not gold_tokens:
-        return 1.0
-    if not pred_tokens or not gold_tokens:
-        return 0.0
-
-    pred_counts = Counter(pred_tokens)
-    gold_counts = Counter(gold_tokens)
-    overlap = sum((pred_counts & gold_counts).values())
-    if overlap == 0:
-        return 0.0
-
-    precision = overlap / len(pred_tokens)
-    recall = overlap / len(gold_tokens)
-    return 2 * precision * recall / (precision + recall)

--- a/lib/marin/src/marin/evaluation/benchmarks/long_context.py
+++ b/lib/marin/src/marin/evaluation/benchmarks/long_context.py
@@ -1,0 +1,312 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import random
+import re
+from collections import Counter
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from marin.evaluation.evaluation_config import EvalTaskConfig
+
+_NON_WORD_RE = re.compile(r"[^a-z0-9]+")
+
+
+class LongContextFamily(StrEnum):
+    PASSKEY = "passkey"
+    KV = "kv"
+    FINEPDF_QA = "finepdf_qa"
+
+
+@dataclass(frozen=True)
+class LongContextExample:
+    example_id: str
+    prompt: str
+    gold_answer: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class LongContextTask:
+    task_name: str
+    family: LongContextFamily
+    context_len: int
+    max_gen_toks: int
+    metric_names: tuple[str, ...]
+    examples: tuple[LongContextExample, ...]
+
+
+def build_long_context_task(
+    eval_task: EvalTaskConfig,
+    *,
+    max_eval_instances: int | None = None,
+) -> LongContextTask:
+    task_kwargs = dict(eval_task.task_kwargs or {})
+    family = LongContextFamily(task_kwargs["family"])
+    context_len = int(task_kwargs["context_len"])
+    max_gen_toks = int(task_kwargs.get("max_gen_toks", 32))
+
+    if family is LongContextFamily.PASSKEY:
+        examples = _build_passkey_examples(context_len=context_len, task_kwargs=task_kwargs)
+        metric_names = ("exact_match",)
+    elif family is LongContextFamily.KV:
+        examples = _build_kv_examples(context_len=context_len, task_kwargs=task_kwargs)
+        metric_names = ("exact_match",)
+    elif family is LongContextFamily.FINEPDF_QA:
+        examples = _load_finepdf_examples(task_kwargs=task_kwargs)
+        metric_names = ("exact_match", "token_f1")
+    else:
+        raise ValueError(f"Unsupported long-context family: {family}")
+
+    if max_eval_instances is not None:
+        examples = examples[:max_eval_instances]
+
+    return LongContextTask(
+        task_name=eval_task.name,
+        family=family,
+        context_len=context_len,
+        max_gen_toks=max_gen_toks,
+        metric_names=metric_names,
+        examples=tuple(examples),
+    )
+
+
+def evaluate_long_context_tasks(
+    evals: Sequence[EvalTaskConfig],
+    *,
+    completion_fn: Callable[[list[str], int], list[str]],
+    max_eval_instances: int | None = None,
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for eval_task in evals:
+        task = build_long_context_task(eval_task, max_eval_instances=max_eval_instances)
+        prompts = [example.prompt for example in task.examples]
+        predictions = completion_fn(prompts, task.max_gen_toks)
+        if len(predictions) != len(prompts):
+            raise ValueError(
+                f"Completion function returned {len(predictions)} predictions for {len(prompts)} prompts "
+                f"on task {task.task_name!r}"
+            )
+        results.append(score_long_context_task(task, predictions))
+
+    return results
+
+
+def write_long_context_results(output_dir: str | Path, results: Sequence[dict[str, Any]]) -> None:
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    summary_tasks = []
+    for result in results:
+        task_name = result["task_name"]
+        task_summary = {key: value for key, value in result.items() if key != "examples"}
+        summary_tasks.append(task_summary)
+        (output_path / f"{task_name}.json").write_text(json.dumps(result, indent=2, sort_keys=True))
+
+    summary_payload = {"tasks": summary_tasks}
+    (output_path / "results.json").write_text(json.dumps(summary_payload, indent=2, sort_keys=True))
+
+
+def score_long_context_task(task: LongContextTask, predictions: Sequence[str]) -> dict[str, Any]:
+    exact_total = 0.0
+    f1_total = 0.0
+    example_results: list[dict[str, Any]] = []
+
+    for example, prediction in zip(task.examples, predictions, strict=True):
+        exact_match = float(_normalize_text(prediction) == _normalize_text(example.gold_answer))
+        exact_total += exact_match
+        example_result: dict[str, Any] = {
+            "example_id": example.example_id,
+            "prediction": prediction,
+            "gold_answer": example.gold_answer,
+            "correct": bool(exact_match),
+            "metadata": example.metadata,
+        }
+
+        if task.family is LongContextFamily.FINEPDF_QA:
+            token_f1 = _token_f1(prediction, example.gold_answer)
+            f1_total += token_f1
+            example_result["token_f1"] = token_f1
+
+        example_results.append(example_result)
+
+    num_examples = len(task.examples)
+    if num_examples == 0:
+        raise ValueError(f"Long-context task {task.task_name!r} produced zero examples")
+
+    metrics: dict[str, float] = {"exact_match": exact_total / num_examples}
+    if task.family is LongContextFamily.FINEPDF_QA:
+        metrics["token_f1"] = f1_total / num_examples
+
+    return {
+        "task_name": task.task_name,
+        "family": task.family.value,
+        "context_len": task.context_len,
+        "max_gen_toks": task.max_gen_toks,
+        "num_examples": num_examples,
+        "metrics": metrics,
+        "examples": example_results,
+    }
+
+
+def _build_passkey_examples(*, context_len: int, task_kwargs: dict[str, Any]) -> list[LongContextExample]:
+    num_examples = int(task_kwargs.get("num_examples", 128))
+    seed = int(task_kwargs.get("seed", 0))
+    rng = random.Random(seed)
+
+    examples: list[LongContextExample] = []
+    for index in range(num_examples):
+        passkey = f"key-{rng.randrange(10**12):012d}"
+        filler_prefix = _build_filler(target_units=max(context_len // 2, 32), rng=rng)
+        filler_suffix = _build_filler(target_units=max(context_len // 2, 32), rng=rng)
+        prompt = (
+            "Read the following long context carefully.\n\n"
+            f"{filler_prefix}\n\n"
+            f"Embedded passkey: {passkey}\n\n"
+            f"{filler_suffix}\n\n"
+            "Question: What is the embedded passkey?\n"
+            "Answer with only the passkey."
+        )
+        examples.append(
+            LongContextExample(
+                example_id=f"passkey-{index}",
+                prompt=prompt,
+                gold_answer=passkey,
+                metadata={"family": LongContextFamily.PASSKEY.value, "context_len": context_len},
+            )
+        )
+
+    return examples
+
+
+def _build_kv_examples(*, context_len: int, task_kwargs: dict[str, Any]) -> list[LongContextExample]:
+    num_examples = int(task_kwargs.get("num_examples", 128))
+    seed = int(task_kwargs.get("seed", 0))
+    num_pairs = int(task_kwargs.get("num_pairs", max(8, context_len // 16)))
+    rng = random.Random(seed)
+
+    examples: list[LongContextExample] = []
+    for index in range(num_examples):
+        pairs = [(f"item_{pair_index:04d}", f"value_{rng.randrange(10**8):08d}") for pair_index in range(num_pairs)]
+        target_key, target_value = rng.choice(pairs)
+        serialized_pairs = "\n".join(f"{key}: {value}" for key, value in pairs)
+        filler = _build_filler(target_units=max(context_len // 4, 16), rng=rng)
+        prompt = (
+            "You are given a long registry of key-value pairs.\n\n"
+            f"{serialized_pairs}\n\n"
+            f"{filler}\n\n"
+            f"Question: What is the value for {target_key}?\n"
+            "Answer with only the value."
+        )
+        examples.append(
+            LongContextExample(
+                example_id=f"kv-{index}",
+                prompt=prompt,
+                gold_answer=target_value,
+                metadata={
+                    "family": LongContextFamily.KV.value,
+                    "context_len": context_len,
+                    "target_key": target_key,
+                },
+            )
+        )
+
+    return examples
+
+
+def _load_finepdf_examples(*, task_kwargs: dict[str, Any]) -> list[LongContextExample]:
+    manifest_path = task_kwargs.get("manifest_path")
+    if not isinstance(manifest_path, str) or not manifest_path:
+        raise ValueError("finepdf_qa tasks require a non-empty task_kwargs['manifest_path']")
+
+    requested_context_len = int(task_kwargs["context_len"])
+    examples: list[LongContextExample] = []
+    with _open_manifest(manifest_path) as manifest_file:
+        for line in manifest_file:
+            line = line.strip()
+            if not line:
+                continue
+            record = json.loads(line)
+            record_context_len = int(record.get("context_len", requested_context_len))
+            if record_context_len != requested_context_len:
+                continue
+
+            example_id = str(record["id"])
+            gold_answer = str(record["answer"])
+            metadata = dict(record.get("metadata", {}))
+            metadata["context_len"] = record_context_len
+            if "prompt" in record:
+                prompt = str(record["prompt"])
+            else:
+                context = str(record["context"])
+                question = str(record["question"])
+                prompt = (
+                    "Read the following document excerpt and answer the question.\n\n"
+                    f"Document:\n{context}\n\n"
+                    f"Question: {question}\n"
+                    "Answer with a short extract from the document."
+                )
+            examples.append(
+                LongContextExample(
+                    example_id=example_id,
+                    prompt=prompt,
+                    gold_answer=gold_answer,
+                    metadata=metadata,
+                )
+            )
+
+    if not examples:
+        raise ValueError(
+            f"finepdf_qa manifest {manifest_path!r} did not contain any examples for context_len={requested_context_len}"
+        )
+
+    return examples
+
+
+def _open_manifest(manifest_path: str):
+    if "://" not in manifest_path:
+        return open(manifest_path, "r")
+
+    import fsspec
+
+    return fsspec.open(manifest_path, "r").open()
+
+
+def _build_filler(*, target_units: int, rng: random.Random) -> str:
+    fragments: list[str] = []
+    while len(" ".join(fragments).split()) < target_units:
+        fragments.append(
+            "archive entry "
+            f"{rng.randrange(1000, 9999)} "
+            f"notes signal {rng.randrange(1000, 9999)} "
+            f"catalog marker {rng.randrange(1000, 9999)}."
+        )
+    return " ".join(fragments)
+
+
+def _normalize_text(text: str) -> str:
+    normalized = _NON_WORD_RE.sub(" ", text.lower()).strip()
+    return re.sub(r"\s+", " ", normalized)
+
+
+def _token_f1(prediction: str, gold_answer: str) -> float:
+    pred_tokens = _normalize_text(prediction).split()
+    gold_tokens = _normalize_text(gold_answer).split()
+    if not pred_tokens and not gold_tokens:
+        return 1.0
+    if not pred_tokens or not gold_tokens:
+        return 0.0
+
+    pred_counts = Counter(pred_tokens)
+    gold_counts = Counter(gold_tokens)
+    overlap = sum((pred_counts & gold_counts).values())
+    if overlap == 0:
+        return 0.0
+
+    precision = overlap / len(pred_tokens)
+    recall = overlap / len(gold_tokens)
+    return 2 * precision * recall / (precision + recall)

--- a/lib/marin/src/marin/evaluation/benchmarks/long_context.py
+++ b/lib/marin/src/marin/evaluation/benchmarks/long_context.py
@@ -14,6 +14,20 @@ from typing import Any
 from marin.evaluation.evaluation_config import EvalTaskConfig
 
 _NON_WORD_RE = re.compile(r"[^a-z0-9]+")
+_FILLER_VOCAB = (
+    "amber",
+    "cedar",
+    "delta",
+    "elm",
+    "flint",
+    "grove",
+    "harbor",
+    "island",
+    "juniper",
+    "keystone",
+    "lumen",
+    "meadow",
+)
 
 
 class LongContextFamily(StrEnum):
@@ -278,13 +292,11 @@ def _open_manifest(manifest_path: str):
 
 def _build_filler(*, target_units: int, rng: random.Random) -> str:
     fragments: list[str] = []
-    while len(" ".join(fragments).split()) < target_units:
-        fragments.append(
-            "archive entry "
-            f"{rng.randrange(1000, 9999)} "
-            f"notes signal {rng.randrange(1000, 9999)} "
-            f"catalog marker {rng.randrange(1000, 9999)}."
-        )
+    num_units = 0
+    while num_units < target_units:
+        fragment_words = [rng.choice(_FILLER_VOCAB) for _ in range(min(16, target_units - num_units))]
+        fragments.append(" ".join(fragment_words))
+        num_units += len(fragment_words)
     return " ".join(fragments)
 
 

--- a/lib/marin/src/marin/evaluation/benchmarks/long_context.py
+++ b/lib/marin/src/marin/evaluation/benchmarks/long_context.py
@@ -240,12 +240,18 @@ def _load_finepdf_examples(*, task_kwargs: dict[str, Any]) -> list[LongContextEx
     requested_context_len = int(task_kwargs["context_len"])
     examples: list[LongContextExample] = []
     with _open_manifest(manifest_path) as manifest_file:
-        for line in manifest_file:
+        for line_num, line in enumerate(manifest_file, start=1):
             line = line.strip()
             if not line:
                 continue
             record = json.loads(line)
-            record_context_len = int(record.get("context_len", requested_context_len))
+            if "context_len" not in record:
+                raise ValueError(
+                    f"finepdf_qa manifest {manifest_path!r} record on line {line_num} is missing required "
+                    "'context_len'"
+                )
+
+            record_context_len = int(record["context_len"])
             if record_context_len != requested_context_len:
                 continue
 

--- a/lib/marin/src/marin/evaluation/evaluators/long_context_evaluator.py
+++ b/lib/marin/src/marin/evaluation/evaluators/long_context_evaluator.py
@@ -122,38 +122,43 @@ class LongContextEvaluator(Evaluator):
         temperature = float(generation_params.get("temperature", 0.0))
         top_p = float(generation_params.get("top_p", 1.0))
         timeout = int(generation_params.get("timeout", 1800))
+        request_batch_size = int(generation_params.get("request_batch_size", 8))
 
         predictions: list[str] = []
-        for prompt in prompts:
+        for batch_start in range(0, len(prompts), request_batch_size):
+            prompt_batch = prompts[batch_start : batch_start + request_batch_size]
             if model.apply_chat_template:
-                response = requests.post(
-                    f"{env.server_url}/chat/completions",
-                    json={
-                        "model": env.model_id,
-                        "messages": [{"role": "user", "content": prompt}],
-                        "temperature": temperature,
-                        "top_p": top_p,
-                        "max_tokens": max_gen_toks,
-                    },
-                    timeout=timeout,
-                )
-                response.raise_for_status()
-                payload = response.json()
-                predictions.append(payload["choices"][0]["message"]["content"])
-            else:
-                response = requests.post(
-                    f"{env.server_url}/completions",
-                    json={
-                        "model": env.model_id,
-                        "prompt": prompt,
-                        "temperature": temperature,
-                        "top_p": top_p,
-                        "max_tokens": max_gen_toks,
-                    },
-                    timeout=timeout,
-                )
-                response.raise_for_status()
-                payload = response.json()
-                predictions.append(payload["choices"][0]["text"])
+                for prompt in prompt_batch:
+                    response = requests.post(
+                        f"{env.server_url}/chat/completions",
+                        json={
+                            "model": env.model_id,
+                            "messages": [{"role": "user", "content": prompt}],
+                            "temperature": temperature,
+                            "top_p": top_p,
+                            "max_tokens": max_gen_toks,
+                        },
+                        timeout=timeout,
+                    )
+                    response.raise_for_status()
+                    payload = response.json()
+                    predictions.append(payload["choices"][0]["message"]["content"])
+                continue
+
+            response = requests.post(
+                f"{env.server_url}/completions",
+                json={
+                    "model": env.model_id,
+                    "prompt": prompt_batch,
+                    "temperature": temperature,
+                    "top_p": top_p,
+                    "max_tokens": max_gen_toks,
+                },
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            choices = sorted(payload["choices"], key=lambda choice: choice["index"])
+            predictions.extend(choice["text"] for choice in choices)
 
         return predictions

--- a/lib/marin/src/marin/evaluation/evaluators/long_context_evaluator.py
+++ b/lib/marin/src/marin/evaluation/evaluators/long_context_evaluator.py
@@ -6,69 +6,19 @@ import logging
 import os
 import shutil
 import tempfile
-from collections.abc import Sequence
 
 import requests
-from fray.v1.cluster import ResourceConfig
 
 from marin.evaluation.benchmarks.long_context import evaluate_long_context_tasks, write_long_context_results
 from marin.evaluation.evaluation_config import EvalTaskConfig
-from marin.evaluation.evaluators.evaluator import Evaluator, ModelConfig, launch_evaluate_with_ray
+from marin.evaluation.evaluators.evaluator import Evaluator, ModelConfig
 from marin.evaluation.utils import is_remote_path, upload_to_gcs
-from marin.inference.vllm_server import VLLM_NATIVE_PIP_PACKAGES, VllmEnvironment, resolve_vllm_mode
+from marin.inference.vllm_server import VllmEnvironment
 
 logger = logging.getLogger(__name__)
 
 
-def _env_vars_from_keys(keys: Sequence[str]) -> dict[str, str]:
-    env_vars: dict[str, str] = {}
-    for key in keys:
-        value = os.environ.get(key)
-        if value:
-            env_vars[key] = value
-    return env_vars
-
-
 class LongContextEvaluator(Evaluator):
-    def launch_evaluate_with_ray(
-        self,
-        model: ModelConfig,
-        evals: list[EvalTaskConfig],
-        output_path: str,
-        resource_config: ResourceConfig,
-        max_eval_instances: int | None = None,
-        wandb_tags: list[str] | None = None,
-    ) -> None:
-        mode_str = resolve_vllm_mode(None)
-        pip_packages = VLLM_NATIVE_PIP_PACKAGES if mode_str == "native" else ()
-        env_vars = _env_vars_from_keys(
-            [
-                "HF_TOKEN",
-                "MARIN_PREFIX",
-                "MARIN_VLLM_MODE",
-                "VLLM_ALLOW_LONG_MAX_MODEL_LEN",
-                "VLLM_TPU_DISABLE_TOPK_TOPP_OPTIMIZATION",
-                "VLLM_TPU_SKIP_PRECOMPILE",
-            ]
-        )
-        env_vars.setdefault("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "1")
-        env_vars.setdefault("VLLM_TPU_DISABLE_TOPK_TOPP_OPTIMIZATION", "1")
-        env_vars.setdefault("VLLM_TPU_SKIP_PRECOMPILE", "1")
-
-        launch_evaluate_with_ray(
-            evaluator=self,
-            job_name="long-context-eval",
-            model=model,
-            evals=evals,
-            output_path=output_path,
-            resource_config=resource_config,
-            max_eval_instances=max_eval_instances,
-            wandb_tags=wandb_tags,
-            extras=("eval", "tpu"),
-            pip_packages=pip_packages,
-            env_vars=env_vars,
-        )
-
     def evaluate(
         self,
         model: ModelConfig,

--- a/lib/marin/src/marin/evaluation/evaluators/long_context_evaluator.py
+++ b/lib/marin/src/marin/evaluation/evaluators/long_context_evaluator.py
@@ -1,0 +1,159 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import logging
+import os
+import shutil
+import tempfile
+from collections.abc import Sequence
+
+import requests
+from fray.v1.cluster import ResourceConfig
+
+from marin.evaluation.benchmarks.long_context import evaluate_long_context_tasks, write_long_context_results
+from marin.evaluation.evaluation_config import EvalTaskConfig
+from marin.evaluation.evaluators.evaluator import Evaluator, ModelConfig, launch_evaluate_with_ray
+from marin.evaluation.utils import is_remote_path, upload_to_gcs
+from marin.inference.vllm_server import VLLM_NATIVE_PIP_PACKAGES, VllmEnvironment, resolve_vllm_mode
+
+logger = logging.getLogger(__name__)
+
+
+def _env_vars_from_keys(keys: Sequence[str]) -> dict[str, str]:
+    env_vars: dict[str, str] = {}
+    for key in keys:
+        value = os.environ.get(key)
+        if value:
+            env_vars[key] = value
+    return env_vars
+
+
+class LongContextEvaluator(Evaluator):
+    def launch_evaluate_with_ray(
+        self,
+        model: ModelConfig,
+        evals: list[EvalTaskConfig],
+        output_path: str,
+        resource_config: ResourceConfig,
+        max_eval_instances: int | None = None,
+        wandb_tags: list[str] | None = None,
+    ) -> None:
+        mode_str = resolve_vllm_mode(None)
+        pip_packages = VLLM_NATIVE_PIP_PACKAGES if mode_str == "native" else ()
+        env_vars = _env_vars_from_keys(
+            [
+                "HF_TOKEN",
+                "MARIN_PREFIX",
+                "MARIN_VLLM_MODE",
+                "VLLM_ALLOW_LONG_MAX_MODEL_LEN",
+                "VLLM_TPU_DISABLE_TOPK_TOPP_OPTIMIZATION",
+                "VLLM_TPU_SKIP_PRECOMPILE",
+            ]
+        )
+        env_vars.setdefault("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "1")
+        env_vars.setdefault("VLLM_TPU_DISABLE_TOPK_TOPP_OPTIMIZATION", "1")
+        env_vars.setdefault("VLLM_TPU_SKIP_PRECOMPILE", "1")
+
+        launch_evaluate_with_ray(
+            evaluator=self,
+            job_name="long-context-eval",
+            model=model,
+            evals=evals,
+            output_path=output_path,
+            resource_config=resource_config,
+            max_eval_instances=max_eval_instances,
+            wandb_tags=wandb_tags,
+            extras=("eval", "tpu"),
+            pip_packages=pip_packages,
+            env_vars=env_vars,
+        )
+
+    def evaluate(
+        self,
+        model: ModelConfig,
+        evals: list[EvalTaskConfig],
+        output_path: str,
+        max_eval_instances: int | None = None,
+        wandb_tags: list[str] | None = None,
+    ) -> None:
+        os.environ.setdefault("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "1")
+        os.environ.setdefault("VLLM_TPU_DISABLE_TOPK_TOPP_OPTIMIZATION", "1")
+        os.environ.setdefault("VLLM_TPU_SKIP_PRECOMPILE", "1")
+
+        with tempfile.TemporaryDirectory(prefix="marin-long-context-") as local_output_dir:
+            with VllmEnvironment(model) as env:
+                if env.model_id is None:
+                    raise RuntimeError("Expected vLLM server to expose a model id.")
+
+                results = evaluate_long_context_tasks(
+                    evals,
+                    completion_fn=lambda prompts, max_gen_toks: self._generate_predictions(
+                        env=env,
+                        model=model,
+                        prompts=prompts,
+                        max_gen_toks=max_gen_toks,
+                    ),
+                    max_eval_instances=max_eval_instances,
+                )
+                payload = {
+                    "model_name": model.name,
+                    "model_path": model.path,
+                    "tasks": results,
+                }
+                write_long_context_results(local_output_dir, results)
+                with open(os.path.join(local_output_dir, "metadata.json"), "w") as f:
+                    json.dump(payload, f, indent=2, sort_keys=True)
+
+            if is_remote_path(output_path):
+                upload_to_gcs(local_output_dir, output_path)
+            else:
+                shutil.copytree(local_output_dir, output_path, dirs_exist_ok=True)
+
+    def _generate_predictions(
+        self,
+        *,
+        env: VllmEnvironment,
+        model: ModelConfig,
+        prompts: list[str],
+        max_gen_toks: int,
+    ) -> list[str]:
+        generation_params = dict(model.generation_params or {})
+        temperature = float(generation_params.get("temperature", 0.0))
+        top_p = float(generation_params.get("top_p", 1.0))
+        timeout = int(generation_params.get("timeout", 1800))
+
+        predictions: list[str] = []
+        for prompt in prompts:
+            if model.apply_chat_template:
+                response = requests.post(
+                    f"{env.server_url}/chat/completions",
+                    json={
+                        "model": env.model_id,
+                        "messages": [{"role": "user", "content": prompt}],
+                        "temperature": temperature,
+                        "top_p": top_p,
+                        "max_tokens": max_gen_toks,
+                    },
+                    timeout=timeout,
+                )
+                response.raise_for_status()
+                payload = response.json()
+                predictions.append(payload["choices"][0]["message"]["content"])
+            else:
+                response = requests.post(
+                    f"{env.server_url}/completions",
+                    json={
+                        "model": env.model_id,
+                        "prompt": prompt,
+                        "temperature": temperature,
+                        "top_p": top_p,
+                        "max_tokens": max_gen_toks,
+                    },
+                    timeout=timeout,
+                )
+                response.raise_for_status()
+                payload = response.json()
+                predictions.append(payload["choices"][0]["text"])
+
+        return predictions

--- a/lib/marin/src/marin/evaluation/run.py
+++ b/lib/marin/src/marin/evaluation/run.py
@@ -21,6 +21,7 @@ from marin.evaluation.evaluators.evalchemy_evaluator import EvalchemyEvaluator
 from marin.evaluation.evaluators.evaluator import Evaluator, ModelConfig
 from marin.evaluation.evaluators.harbor_evaluator import HarborEvaluator
 from marin.evaluation.evaluators.levanter_lm_eval_evaluator import LevanterLmEvalEvaluator
+from marin.evaluation.evaluators.long_context_evaluator import LongContextEvaluator
 from marin.evaluation.evaluators.lm_evaluation_harness_evaluator import LMEvaluationHarnessEvaluator
 from marin.evaluation.evaluators.simple_evaluator import SimpleEvaluator
 from marin.evaluation.utils import discover_hf_checkpoints
@@ -32,6 +33,7 @@ EVALUATORS = {
     "lm_evaluation_harness": LMEvaluationHarnessEvaluator,
     "levanter_lm_evaluation_harness": LevanterLmEvalEvaluator,
     "evalchemy": EvalchemyEvaluator,
+    "long_context": LongContextEvaluator,
     "debug": SimpleEvaluator,
     "harbor": HarborEvaluator,
 }

--- a/lib/marin/src/marin/evaluation/run.py
+++ b/lib/marin/src/marin/evaluation/run.py
@@ -21,8 +21,8 @@ from marin.evaluation.evaluators.evalchemy_evaluator import EvalchemyEvaluator
 from marin.evaluation.evaluators.evaluator import Evaluator, ModelConfig
 from marin.evaluation.evaluators.harbor_evaluator import HarborEvaluator
 from marin.evaluation.evaluators.levanter_lm_eval_evaluator import LevanterLmEvalEvaluator
-from marin.evaluation.evaluators.long_context_evaluator import LongContextEvaluator
 from marin.evaluation.evaluators.lm_evaluation_harness_evaluator import LMEvaluationHarnessEvaluator
+from marin.evaluation.evaluators.long_context_evaluator import LongContextEvaluator
 from marin.evaluation.evaluators.simple_evaluator import SimpleEvaluator
 from marin.evaluation.utils import discover_hf_checkpoints
 from marin.utils import fsspec_exists

--- a/tests/evals/test_long_context.py
+++ b/tests/evals/test_long_context.py
@@ -3,6 +3,8 @@
 
 import json
 
+import pytest
+
 from marin.evaluation.evaluation_config import EvalTaskConfig
 
 from marin.evaluation.benchmarks.long_context import (
@@ -74,6 +76,33 @@ def test_finepdf_task_loads_manifest_and_honors_limit(tmp_path):
     assert len(task.examples) == 1
     assert task.examples[0].example_id == "doc-1"
     assert task.metric_names == ("exact_match", "token_f1")
+
+
+def test_finepdf_task_requires_explicit_context_len(tmp_path):
+    manifest_path = tmp_path / "finepdf_manifest_missing_context_len.jsonl"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "id": "doc-1",
+                "context": "Alpha section. The answer is orion.",
+                "question": "What is the answer?",
+                "answer": "orion",
+            }
+        )
+    )
+
+    config = EvalTaskConfig(
+        name="finepdf_extractive_qa_4k",
+        num_fewshot=0,
+        task_kwargs={
+            "family": "finepdf_qa",
+            "context_len": 4096,
+            "manifest_path": str(manifest_path),
+        },
+    )
+
+    with pytest.raises(ValueError, match="missing required 'context_len'"):
+        build_long_context_task(config)
 
 
 def test_evaluate_and_write_long_context_results(tmp_path):

--- a/tests/evals/test_long_context.py
+++ b/tests/evals/test_long_context.py
@@ -1,0 +1,107 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+from marin.evaluation.evaluation_config import EvalTaskConfig
+
+from marin.evaluation.benchmarks.long_context import (
+    build_long_context_task,
+    evaluate_long_context_tasks,
+    write_long_context_results,
+)
+
+
+def test_passkey_task_is_deterministic():
+    config = EvalTaskConfig(
+        name="passkey_4k",
+        num_fewshot=0,
+        task_kwargs={
+            "family": "passkey",
+            "context_len": 128,
+            "num_examples": 2,
+            "seed": 7,
+        },
+    )
+
+    first = build_long_context_task(config)
+    second = build_long_context_task(config)
+
+    assert [example.prompt for example in first.examples] == [example.prompt for example in second.examples]
+    assert [example.gold_answer for example in first.examples] == [example.gold_answer for example in second.examples]
+    assert first.metric_names == ("exact_match",)
+
+
+def test_finepdf_task_loads_manifest_and_honors_limit(tmp_path):
+    manifest_path = tmp_path / "finepdf_manifest.jsonl"
+    manifest_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "id": "doc-1",
+                        "context_len": 4096,
+                        "context": "Alpha section. The answer is orion.",
+                        "question": "What is the answer?",
+                        "answer": "orion",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "id": "doc-2",
+                        "context_len": 4096,
+                        "context": "Beta section. The answer is vega.",
+                        "question": "What is the answer?",
+                        "answer": "vega",
+                    }
+                ),
+            ]
+        )
+    )
+
+    config = EvalTaskConfig(
+        name="finepdf_extractive_qa_4k",
+        num_fewshot=0,
+        task_kwargs={
+            "family": "finepdf_qa",
+            "context_len": 4096,
+            "manifest_path": str(manifest_path),
+        },
+    )
+
+    task = build_long_context_task(config, max_eval_instances=1)
+
+    assert len(task.examples) == 1
+    assert task.examples[0].example_id == "doc-1"
+    assert task.metric_names == ("exact_match", "token_f1")
+
+
+def test_evaluate_and_write_long_context_results(tmp_path):
+    config = EvalTaskConfig(
+        name="kv_retrieval_4k",
+        num_fewshot=0,
+        task_kwargs={
+            "family": "kv",
+            "context_len": 128,
+            "num_examples": 2,
+            "seed": 3,
+        },
+    )
+
+    task = build_long_context_task(config)
+    gold_by_prompt = {example.prompt: example.gold_answer for example in task.examples}
+
+    results = evaluate_long_context_tasks(
+        [config],
+        completion_fn=lambda prompts, max_gen_toks: [gold_by_prompt[prompt] for prompt in prompts],
+    )
+
+    output_dir = tmp_path / "results"
+    write_long_context_results(output_dir, results)
+
+    summary = json.loads((output_dir / "results.json").read_text())
+    task_result = json.loads((output_dir / "kv_retrieval_4k.json").read_text())
+
+    assert summary["tasks"][0]["task_name"] == "kv_retrieval_4k"
+    assert task_result["metrics"]["exact_match"] == 1.0
+    assert all(example["correct"] for example in task_result["examples"])

--- a/tests/evals/test_long_context.py
+++ b/tests/evals/test_long_context.py
@@ -1,17 +1,11 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import json
-
-import pytest
-
-from marin.evaluation.evaluation_config import EvalTaskConfig
-
 from marin.evaluation.benchmarks.long_context import (
     build_long_context_task,
     evaluate_long_context_tasks,
-    write_long_context_results,
 )
+from marin.evaluation.evaluation_config import EvalTaskConfig
 
 
 def test_passkey_task_is_deterministic():
@@ -34,78 +28,7 @@ def test_passkey_task_is_deterministic():
     assert first.metric_names == ("exact_match",)
 
 
-def test_finepdf_task_loads_manifest_and_honors_limit(tmp_path):
-    manifest_path = tmp_path / "finepdf_manifest.jsonl"
-    manifest_path.write_text(
-        "\n".join(
-            [
-                json.dumps(
-                    {
-                        "id": "doc-1",
-                        "context_len": 4096,
-                        "context": "Alpha section. The answer is orion.",
-                        "question": "What is the answer?",
-                        "answer": "orion",
-                    }
-                ),
-                json.dumps(
-                    {
-                        "id": "doc-2",
-                        "context_len": 4096,
-                        "context": "Beta section. The answer is vega.",
-                        "question": "What is the answer?",
-                        "answer": "vega",
-                    }
-                ),
-            ]
-        )
-    )
-
-    config = EvalTaskConfig(
-        name="finepdf_extractive_qa_4k",
-        num_fewshot=0,
-        task_kwargs={
-            "family": "finepdf_qa",
-            "context_len": 4096,
-            "manifest_path": str(manifest_path),
-        },
-    )
-
-    task = build_long_context_task(config, max_eval_instances=1)
-
-    assert len(task.examples) == 1
-    assert task.examples[0].example_id == "doc-1"
-    assert task.metric_names == ("exact_match", "token_f1")
-
-
-def test_finepdf_task_requires_explicit_context_len(tmp_path):
-    manifest_path = tmp_path / "finepdf_manifest_missing_context_len.jsonl"
-    manifest_path.write_text(
-        json.dumps(
-            {
-                "id": "doc-1",
-                "context": "Alpha section. The answer is orion.",
-                "question": "What is the answer?",
-                "answer": "orion",
-            }
-        )
-    )
-
-    config = EvalTaskConfig(
-        name="finepdf_extractive_qa_4k",
-        num_fewshot=0,
-        task_kwargs={
-            "family": "finepdf_qa",
-            "context_len": 4096,
-            "manifest_path": str(manifest_path),
-        },
-    )
-
-    with pytest.raises(ValueError, match="missing required 'context_len'"):
-        build_long_context_task(config)
-
-
-def test_evaluate_and_write_long_context_results(tmp_path):
+def test_evaluate_long_context_scores_exact_match_per_example():
     config = EvalTaskConfig(
         name="kv_retrieval_4k",
         num_fewshot=0,
@@ -118,19 +41,16 @@ def test_evaluate_and_write_long_context_results(tmp_path):
     )
 
     task = build_long_context_task(config)
-    gold_by_prompt = {example.prompt: example.gold_answer for example in task.examples}
+    predictions_by_prompt = {
+        task.examples[0].prompt: task.examples[0].gold_answer,
+        task.examples[1].prompt: "wrong-value",
+    }
 
     results = evaluate_long_context_tasks(
         [config],
-        completion_fn=lambda prompts, max_gen_toks: [gold_by_prompt[prompt] for prompt in prompts],
+        completion_fn=lambda prompts, max_gen_toks: [predictions_by_prompt[prompt] for prompt in prompts],
     )
+    task_result = results[0]
 
-    output_dir = tmp_path / "results"
-    write_long_context_results(output_dir, results)
-
-    summary = json.loads((output_dir / "results.json").read_text())
-    task_result = json.loads((output_dir / "kv_retrieval_4k.json").read_text())
-
-    assert summary["tasks"][0]["task_name"] == "kv_retrieval_4k"
-    assert task_result["metrics"]["exact_match"] == 1.0
-    assert all(example["correct"] for example in task_result["examples"])
+    assert task_result["metrics"]["exact_match"] == 0.5
+    assert [example["correct"] for example in task_result["examples"]] == [True, False]


### PR DESCRIPTION
Add a narrow synthetic long-context sanity-check lane for exp2062 with passkey and key-value retrieval tasks plus an issue-specific checkpoint runner. This compares the existing 4k, 32k, and 64k checkpoints without retraining while leaving lm-eval long-context benchmarks and natural-document QA for follow-up.

Part of #2062