### PR TITLE
Remove guidelines-internal.md from CLAUDE.md context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,1 @@
-@docs/dev-guide/guidelines-internal.md
 @AGENTS.md


### PR DESCRIPTION
## Summary

- Drop `@docs/dev-guide/guidelines-internal.md` from `CLAUDE.md`, saving ~1.5k tokens per agent conversation
- `guidelines-internal.md` is a human onboarding doc (GCP auth, SSH tunneling, Ray dashboard setup) — none of it is agent-actionable
- Its only overlap with `AGENTS.md` is the precommit command, which `AGENTS.md` already covers more completely

## Test plan

- [ ] Verify `CLAUDE.md` still includes `@AGENTS.md`
- [ ] Confirm no agent-relevant information was lost (Ray job submission is covered by agent skills; precommit is in `AGENTS.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)