### PR TITLE
fix(ci): add Docker Buildx setup to iris-dev-restart workflow

### DIFF
--- a/.github/workflows/iris-dev-restart.yaml
+++ b/.github/workflows/iris-dev-restart.yaml
@@ -43,6 +43,9 @@ jobs:
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Add missing docker/setup-buildx-action@v3 step to iris-dev-restart.yaml. The workflow has been failing daily with "Cache export is not supported for the docker driver" because the default docker driver doesn't support cache export. Same fix previously applied to the smoke test workflows in 6a58bfe3d.