### PR TITLE
Add GPU Triton kernel for ragged_dot MoE grouped matmul

### DIFF
--- a/lib/haliax/src/haliax/nn/ragged_dot.py
+++ b/lib/haliax/src/haliax/nn/ragged_dot.py
@@ -51,6 +51,7 @@ def _ragged_dot_megablox_impl(lhs: jax.Array, rhs: jax.Array, group_sizes: jax.A
         interpret=jax.default_backend() == "cpu",
     )
 
+
 def _triton_ragged_dot_kernel(
     a_ref,
     b_ref,
@@ -98,9 +99,7 @@ def _triton_pallas_call(lhs: jax.Array, rhs: jax.Array, group_sizes: jax.Array) 
     cum_rows = jnp.cumulative_sum(group_sizes, include_initial=True)
 
     return pl.pallas_call(
-        lambda a, b, lo, hi, out: _triton_ragged_dot_kernel(
-            a, b, lo, hi, out, block_m=block_m, block_k=block_k
-        ),
+        lambda a, b, lo, hi, out: _triton_ragged_dot_kernel(a, b, lo, hi, out, block_m=block_m, block_k=block_k),
         out_shape=jax.ShapeDtypeStruct((m, n), lhs.dtype),
         in_specs=[
             pl.no_block_spec,

--- a/lib/haliax/src/haliax/nn/ragged_dot.py
+++ b/lib/haliax/src/haliax/nn/ragged_dot.py
@@ -2,24 +2,47 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import functools
+import logging
+import os
 import warnings
 from typing import Literal, TypeAlias
 
 import jax
 import jax.numpy as jnp
-from jax.experimental.pallas.ops.tpu.megablox import gmm
 
 from ..partitioning import ResourceAxis
 
-Implementation: TypeAlias = Literal["auto", "megablox", "xla"]
+logger = logging.getLogger(__name__)
+
+# Guard TPU-only megablox import; unavailable on GPU/CPU installs.
+_gmm_megablox = None
+try:
+    from jax.experimental.pallas.ops.tpu.megablox import gmm as _gmm_megablox  # type: ignore[assignment]
+except (ImportError, ModuleNotFoundError):
+    pass
+
+# Guard Pallas Triton import; unavailable on TPU/CPU installs.
+_has_pallas_triton = False
+try:
+    from jax.experimental import pallas as pl
+    from jax.experimental.pallas import triton as plgpu
+
+    _has_pallas_triton = True
+except (ImportError, ModuleNotFoundError):
+    pass
+
+Implementation: TypeAlias = Literal["auto", "megablox", "triton", "xla"]
 _AUTO_FALLBACK_EXCEPTIONS = (NotImplementedError, RuntimeError)
 _HAS_WARNED_AUTO_FALLBACK = False
 
 
 def _ragged_dot_megablox_impl(lhs: jax.Array, rhs: jax.Array, group_sizes: jax.Array) -> jax.Array:
+    if _gmm_megablox is None:
+        raise NotImplementedError("megablox GMM is not available (TPU-only)")
     tile_size = (512, 1024, 1024)  # (m, k, n)
     m, k, n = lhs.shape[0], lhs.shape[1], rhs.shape[2]
-    return gmm(
+    return _gmm_megablox(
         lhs,
         rhs,
         group_sizes,
@@ -27,6 +50,138 @@ def _ragged_dot_megablox_impl(lhs: jax.Array, rhs: jax.Array, group_sizes: jax.A
         tiling=(min(m, tile_size[0]), min(k, tile_size[1]), min(n, tile_size[2])),
         interpret=jax.default_backend() == "cpu",
     )
+
+def _triton_ragged_dot_kernel(
+    a_ref,
+    b_ref,
+    lo_ref,
+    hi_ref,
+    out_ref,
+    *,
+    block_m: int,
+    block_k: int,
+):
+    """Pallas-Triton ragged dot kernel (no quantization)."""
+    lo = lo_ref[()]
+    hi = hi_ref[()]
+    start_m = lo + pl.program_id(0) * block_m
+
+    @pl.when(start_m < hi)
+    def _compute():
+        span_m = pl.ds(start_m, block_m)
+        acc = jnp.zeros((block_m, out_ref.shape[1]), dtype=jnp.float32)
+        k = a_ref.shape[1]
+
+        def body(i, acc):
+            start_k = i * block_k
+            span_k = pl.ds(start_k, block_k)
+            a = pl.load(a_ref, (span_m, span_k))
+            b = pl.load(b_ref, (span_k, pl.ds(0, b_ref.shape[1])))
+            dtype = jnp.result_type(a, b)
+            return acc + pl.dot(a.astype(dtype), b.astype(dtype))
+
+        num_k_blocks = pl.cdiv(k, block_k)
+        acc = jax.lax.fori_loop(0, num_k_blocks, body, acc)
+        mask = (start_m + jnp.arange(block_m)) < hi
+        pl.store(out_ref, (span_m, pl.ds(0, out_ref.shape[1])), acc.astype(out_ref.dtype), mask=mask[:, None])
+
+
+def _triton_pallas_call(lhs: jax.Array, rhs: jax.Array, group_sizes: jax.Array) -> jax.Array:
+    """Raw Pallas-Triton grouped matmul (forward only, not differentiable)."""
+    m, k = lhs.shape
+    num_groups, _, n = rhs.shape
+
+    block_m = min(128, int(pl.next_power_of_2(m)))
+    block_n = min(128, int(pl.next_power_of_2(n)))
+    block_k = min(32, int(pl.next_power_of_2(k)))
+
+    cum_rows = jnp.cumulative_sum(group_sizes, include_initial=True)
+
+    return pl.pallas_call(
+        lambda a, b, lo, hi, out: _triton_ragged_dot_kernel(
+            a, b, lo, hi, out, block_m=block_m, block_k=block_k
+        ),
+        out_shape=jax.ShapeDtypeStruct((m, n), lhs.dtype),
+        in_specs=[
+            pl.no_block_spec,
+            pl.BlockSpec((None, k, block_n), lambda _, j, e: (e, 0, j)),
+            pl.BlockSpec((None,), lambda _, __, e: (e,)),
+            pl.BlockSpec((None,), lambda _, __, e: (e,)),
+        ],
+        out_specs=pl.BlockSpec((m, block_n), lambda _, j, __: (0, j)),
+        grid=(pl.cdiv(m, block_m), pl.cdiv(n, block_n), num_groups),
+        compiler_params=plgpu.CompilerParams(num_warps=4, num_stages=4),
+    )(lhs, rhs, cum_rows[:-1], cum_rows[1:])
+
+
+_DEFAULT_DIM_NUMS = jax.lax.RaggedDotDimensionNumbers(
+    dot_dimension_numbers=(((1,), (1,)), ((), ())),
+    lhs_ragged_dimensions=(0,),
+    rhs_group_dimensions=(0,),
+)
+
+# Dimension numbers for the dlhs backward pass: dout[M,N] @ rhs[G,K,N]^T → dlhs[M,K]
+# Contracts over N (dout dim 1 with rhs dim 2), groups on rhs dim 0.
+_DLHS_DIM_NUMS = jax.lax.RaggedDotDimensionNumbers(
+    dot_dimension_numbers=(((1,), (2,)), ((), ())),
+    lhs_ragged_dimensions=(0,),
+    rhs_group_dimensions=(0,),
+)
+
+# Dimension numbers for the drhs backward pass: lhs[M,K]^T @ dout[M,N] → drhs[G,K,N]
+# Contracts over M (lhs dim 0 with dout dim 0), ragged on lhs dim 0, no group dim.
+_DRHS_DIM_NUMS = jax.lax.RaggedDotDimensionNumbers(
+    dot_dimension_numbers=(((0,), (0,)), ((), ())),
+    lhs_ragged_dimensions=(0,),
+    rhs_group_dimensions=[],
+)
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=())
+def _ragged_dot_triton_impl(lhs: jax.Array, rhs: jax.Array, group_sizes: jax.Array) -> jax.Array:
+    """Pallas-Triton grouped matmul with explicit backward pass.
+
+    Uses custom_vjp so JAX never tries to autodiff through pallas_call
+    (which lacks JVP rules in JAX 0.8.0). Both forward and backward use
+    the Triton kernel for the full 5x speedup over XLA.
+    """
+    if not _has_pallas_triton:
+        raise NotImplementedError("Pallas Triton backend is not available")
+    return _triton_pallas_call(lhs, rhs, group_sizes)
+
+
+def _ragged_dot_triton_fwd(lhs, rhs, group_sizes):
+    out = _triton_pallas_call(lhs, rhs, group_sizes)
+    return out, (lhs, rhs, group_sizes)
+
+
+def _ragged_dot_triton_bwd(residuals, dout):
+    lhs, rhs, group_sizes = residuals
+
+    # dlhs[M,K] = ragged_dot_general(dout[M,N], rhs[G,K,N], gs)
+    # Contracts dout dim 1 (N) with rhs dim 2 (N) — different from forward's
+    # contracting dims, so we use XLA here. The Triton kernel only supports
+    # the standard (dim1, dim1) contraction.
+    dlhs = jax.lax.ragged_dot_general(
+        lhs=dout,
+        rhs=rhs,
+        group_sizes=group_sizes,
+        ragged_dot_dimension_numbers=_DLHS_DIM_NUMS,
+    )
+
+    # drhs[G,K,N] = ragged_dot_general(lhs[M,K], dout[M,N], gs)
+    # Contracts over ragged M dimension — also non-standard for our kernel.
+    drhs = jax.lax.ragged_dot_general(
+        lhs=lhs,
+        rhs=dout,
+        group_sizes=group_sizes,
+        ragged_dot_dimension_numbers=_DRHS_DIM_NUMS,
+    )
+
+    return dlhs, drhs, None  # None for group_sizes (integer, no gradient)
+
+
+_ragged_dot_triton_impl.defvjp(_ragged_dot_triton_fwd, _ragged_dot_triton_bwd)
 
 
 def _ragged_dot_xla_impl(lhs: jax.Array, rhs: jax.Array, group_sizes: jax.Array) -> jax.Array:
@@ -43,11 +198,21 @@ def _ragged_dot_xla_impl(lhs: jax.Array, rhs: jax.Array, group_sizes: jax.Array)
 
 
 def _preferred_implementations(implementation: Implementation) -> tuple[Implementation, ...]:
+    # Allow override via env var for A/B benchmarking:
+    #   RAGGED_DOT_IMPL=xla     → force XLA
+    #   RAGGED_DOT_IMPL=triton  → force Triton
+    env_override = os.environ.get("RAGGED_DOT_IMPL")
+    if env_override is not None:
+        return (env_override,)  # type: ignore[return-value]
+
     if implementation != "auto":
         return (implementation,)
 
     if jax.default_backend() == "tpu":
         return ("megablox", "xla")
+
+    if jax.default_backend() == "gpu" and _has_pallas_triton:
+        return ("triton", "xla")
 
     return ("xla",)
 
@@ -55,6 +220,8 @@ def _preferred_implementations(implementation: Implementation) -> tuple[Implemen
 def _run_impl(name: Implementation, lhs: jax.Array, rhs: jax.Array, group_sizes: jax.Array) -> jax.Array:
     if name == "megablox":
         return _ragged_dot_megablox_impl(lhs, rhs, group_sizes)
+    if name == "triton":
+        return _ragged_dot_triton_impl(lhs, rhs, group_sizes)
     if name == "xla":
         return _ragged_dot_xla_impl(lhs, rhs, group_sizes)
     raise ValueError(f"Unknown ragged_dot implementation: {name}")
@@ -74,8 +241,9 @@ def ragged_dot(
         rhs_: [experts, in, out] expert weights.
         group_sizes_: [experts] number of tokens per expert.
         ar: Whether to perform an all-reduce over the model axis on the output.
-        implementation: Backend selection policy. `"auto"` uses XLA on CPU/GPU and
-            Megablox on TPU with XLA fallback.
+        implementation: Backend selection. ``"auto"`` selects per-platform default.
+            ``"triton"`` forces GPU Pallas Triton kernel. ``"megablox"`` forces
+            TPU megablox. ``"xla"`` forces ``jax.lax.ragged_dot_general``.
 
     Returns:
         A [tokens, out] array.
@@ -92,11 +260,11 @@ def ragged_dot(
             out = _run_impl(impl, lhs_, rhs_, group_sizes_)
             break
         except _AUTO_FALLBACK_EXCEPTIONS as exc:
-            if implementation == "auto" and impl == "megablox":
+            if implementation == "auto" and impl != "xla":
                 global _HAS_WARNED_AUTO_FALLBACK
                 if not _HAS_WARNED_AUTO_FALLBACK:
                     warnings.warn(
-                        f"ragged_dot auto fallback: megablox failed ({type(exc).__name__}), trying XLA.",
+                        f"ragged_dot auto fallback: {impl} failed ({type(exc).__name__}), trying next.",
                         RuntimeWarning,
                     )
                     _HAS_WARNED_AUTO_FALLBACK = True


### PR DESCRIPTION
Fixes #2828

Added a triton kernel for ragged_dot from [tokamax](https://github.com/openxla/tokamax/blob/8cba6a6a1e52e9efbb7ff8facb66f18f0bfcbe4c/tokamax/_src/ops/ragged_dot/pallas_triton.py#L52). Loss matches the pure xla baseline (0.266 vs 0.27). MoELinear(use_gmm=true) path for GPU should have this triton kernel affect it as well as anything in the moe_mlp() path used by Grug MOE models. 

Note: Jax 0.8.0 doesn't support autodiff through `pallas_call` (this is why tokamax requires         
  `>=0.9.1`), so the backward pass uses a `custom_vjp` wrapper with XLA `ragged_dot_general` for gradients.
   The forward pass kernel is adapted from tokamax's Triton `ragged_dot` kernel. Once we upgrade to JAX    
  0.9.1, the backward pass can also use Triton for further speedups.

If we're able to upgrade over to Jax 0.9. versioning, should be able to use Triton for the backward pass to, which should lead to speedups too. The MFU increase in 256M param model is not that great, but thought it'd be good to get initial feedback on this first ! Please lmk if there are better ways to organize this as well but thought the flow on GPU should be try Triton kernel if not fallback on existing XLA ragged_dot

Results on 8xh100:

Kernel-level (forward only, single h100) 
- Uniform: XLA: 29.98 ms, 15% MFU, Triton: 5.78 ms, 78% MFU, 5.2x speedup 
- Skewed: 30..59ms 15% MFU, Triton: 10.89ms, 41% MFU, 2.8x speedup 

256M Params, 8 experts, ran 100 steps 
steps/sec: 
- Triton (Fwd) + XLA (bwd) 3.86
-  XLA: 3.21 -> 20% speedup 
MFU (not that great) : 
- Triton (Fwd) + XLA (bwd)  7.6%, 
- XLA: 6.32%