### PR TITLE
[iris] Fix dashboard log viewer showing child job logs

### DIFF
--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -46,7 +46,7 @@ const taskLogState = props.taskId
         ? `${props.taskId}:${selectedAttemptId.value}`
         : isTask
           ? `${props.taskId}:.*`
-          : `${props.taskId}/.*`,
+          : `${props.taskId}/\\d+:.*`,
       maxLines: tailLines.value || undefined,
       tail: true,
     }))

--- a/lib/iris/tests/cluster/controller/test_logs.py
+++ b/lib/iris/tests/cluster/controller/test_logs.py
@@ -237,6 +237,11 @@ def test_get_logs_regex_pattern_scoping(log_store: LogStore):
     result_all = log_store.get_logs("/job/parent/.*")
     assert len(result_all.entries) == 2
 
+    # Direct-tasks-only pattern: excludes child job entries
+    result_direct = log_store.get_logs(r"/job/parent/\d+:.*")
+    assert len(result_direct.entries) == 1
+    assert result_direct.entries[0].data == "parent-line"
+
 
 def test_get_logs_regex_pattern_tail_returns_last_n(log_store: LogStore):
     """Tail mode with regex pattern returns the last N entries across all matching keys."""


### PR DESCRIPTION
Use \d+:.* pattern instead of .* for job-level log queries in the
dashboard LogViewer, restricting matches to direct task logs and
excluding child job logs. The prefix pattern /job/parent/.* matches
child job keys like /job/parent/child/0:0 because they fall within
the lexicographic range used for Parquet pushdown. The legacy
get_task_logs RPC already uses \d+:.* correctly; this aligns the
dashboard.