### PR TITLE
[iris] Tune limits for task containers

### DIFF
--- a/lib/iris/src/iris/actor/client.py
+++ b/lib/iris/src/iris/actor/client.py
@@ -59,8 +59,8 @@ class ActorClient:
         resolver: Resolver,
         name: str,
         call_timeout: float | None = None,
-        max_call_attempts: int = 5,
-        backoff: ExponentialBackoff = ExponentialBackoff(initial=0.1, maximum=10.0, factor=2.0, jitter=0.25),
+        max_call_attempts: int = 10,
+        backoff: ExponentialBackoff = ExponentialBackoff(initial=0.5, maximum=10.0, factor=2.0, jitter=0.25),
     ):
         """Initialize the actor client.
 

--- a/lib/iris/src/iris/cluster/controller/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/scaling_group.py
@@ -98,8 +98,8 @@ class AvailabilityState:
     until: Timestamp | None = None
 
 
-DEFAULT_SCALE_UP_RATE_LIMIT = 5  # per minute
-DEFAULT_SCALE_DOWN_RATE_LIMIT = 5  # per minute
+DEFAULT_SCALE_UP_RATE_LIMIT = 32  # per minute
+DEFAULT_SCALE_DOWN_RATE_LIMIT = 32  # per minute
 DEFAULT_SCALE_UP_COOLDOWN = Duration.from_minutes(1)
 DEFAULT_BACKOFF_INITIAL = Duration.from_minutes(5)
 DEFAULT_BACKOFF_MAX = Duration.from_minutes(15)

--- a/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
@@ -136,9 +136,11 @@ fi
 sudo systemctl start docker || true
 
 # Tune network stack for high-connection workloads (#3066).
-# Expands ephemeral port range and allows reuse of TIME_WAIT sockets.
+# Expands ephemeral port range, allows reuse of TIME_WAIT sockets,
+# and raises listen backlog for actor servers handling 1000s of workers.
 sudo sysctl -w net.ipv4.ip_local_port_range="1024 65535"
 sudo sysctl -w net.ipv4.tcp_tw_reuse=1
+sudo sysctl -w net.core.somaxconn=4096
 
 # Create cache directory
 sudo mkdir -p {{ cache_dir }}

--- a/lib/iris/src/iris/cluster/runtime/docker.py
+++ b/lib/iris/src/iris/cluster/runtime/docker.py
@@ -618,6 +618,8 @@ exec {quoted_cmd}
             "create",
             "--ulimit",
             "core=0:0",
+            "--ulimit",
+            "nofile=65536:524288",
             "-w",
             config.workdir,
         ]


### PR DESCRIPTION
Bump scaling group rate limits from 5 to 32/min, increase actor client retries (5->10) and initial backoff (0.1->0.5s), raise somaxconn to 4096 in bootstrap, and add nofile ulimit (65536:524288) to task containers.