### PR TITLE
Add grug activation watch logging

### DIFF
--- a/experiments/grug/base/launch.py
+++ b/experiments/grug/base/launch.py
@@ -14,13 +14,11 @@ from datetime import timedelta
 
 import jmp
 from fray.cluster import ResourceConfig
-from levanter.callbacks.profiler import ProfilerConfig
 from levanter.checkpoint import CheckpointerConfig
 from levanter.data.text import LmDataConfig
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.tracker import TrackerConfig
 from levanter.tracker.wandb import WandbConfig
-from levanter.trainer import TrainerConfig
 from marin.execution.executor import ExecutorStep, executor_main, this_output_path, versioned
 from marin.processing.tokenize import add_validation_sets_to_mixture
 
@@ -57,10 +55,10 @@ GRUG_130M_MODEL = GrugModelConfig(
     hidden_dim=512,
     intermediate_dim=1792,
     num_layers=6,
-    num_heads=8,
-    num_kv_heads=8,
+    num_heads=4,
+    num_kv_heads=4,
     max_seq_len=4096,
-    head_dim=None,
+    head_dim=128,
 )
 
 NEMOTRON_MIX_WITH_DEFAULT_VALIDATION = add_validation_sets_to_mixture(
@@ -86,12 +84,12 @@ def _resolve_tracker(tracker: TrackerConfig, run_id: str) -> TrackerConfig:
 
 def run_grug_base_trial(config: GrugBaseLaunchConfig) -> None:
     # Map template launch knobs onto full Levanter TrainerConfig.
-    trainer = TrainerConfig(
+    trainer = dataclasses.replace(
+        config.grug_trainer.trainer,
         id=config.run_id,
         seed=config.seed,
         train_batch_size=config.batch_size,
         num_train_steps=config.steps,
-        profiler=ProfilerConfig(enabled=False, start_step=5, num_steps=100, perfetto_link=False),
         mp=jmp.get_policy(config.mp),
         tracker=_resolve_tracker(config.tracker, config.run_id),
         use_explicit_mesh_axes=True,

--- a/experiments/grug/base/model.py
+++ b/experiments/grug/base/model.py
@@ -14,9 +14,17 @@ from jax.sharding import PartitionSpec as P
 from jax.sharding import reshard
 from jaxtyping import Array, Float, Int, PRNGKeyArray
 
-from levanter.grug.attention import AttentionMask, RotaryConfig, apply_rotary_embedding, attention
+from levanter.grug.activation_logging import LayerLogging, block_activation_logging, flatten_layer_logging
+from levanter.grug.attention import (
+    AttentionMask,
+    RotaryConfig,
+    apply_rotary_embedding,
+    attention,
+    max_abs_attention_logit,
+)
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
 from levanter.grug.sharding import Pbatch, Pembed_vocab, Plm_head, Plogits, unshard
+from levanter.tracker.histogram import SummaryStats
 
 
 @dataclass(frozen=True)
@@ -75,7 +83,11 @@ class CausalSelfAttention(eqx.Module):
         )
 
     @named_call
-    def __call__(self, x: Float[Array, "B S D"], mask: AttentionMask | jax.Array) -> Float[Array, "B S D"]:
+    def __call__(
+        self,
+        x: Float[Array, "B S D"],
+        mask: AttentionMask | jax.Array,
+    ) -> tuple[Float[Array, "B S D"], jax.Array]:
         head_dim = self.cfg.inferred_head_dim
         seq_len = x.shape[1]
 
@@ -83,9 +95,11 @@ class CausalSelfAttention(eqx.Module):
         k = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_k), "... (m d) -> ... m d", d=head_dim)
         v = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_v), "... (m d) -> ... m d", d=head_dim)
         q, k = apply_rotary_embedding(q, k, seq_len=seq_len, head_dim=head_dim, rope=self.cfg.rope)
+        max_logit = max_abs_attention_logit(q, k)
         attn_out = attention(q, k, v, mask)
         attn_out = rearrange(attn_out, "... n d -> ... (n d)")
-        return jnp.einsum("bsh,hd->bsd", attn_out, self.w_o, out_sharding=Pbatch)
+        output = jnp.einsum("bsh,hd->bsd", attn_out, self.w_o, out_sharding=Pbatch)
+        return output, max_logit
 
 
 class MLP(eqx.Module):
@@ -143,10 +157,25 @@ class Block(eqx.Module):
         )
 
     @named_call
-    def __call__(self, x: Float[Array, "B S D"], mask: AttentionMask | jax.Array) -> Float[Array, "B S D"]:
-        x = x + self.attn(self.rms_attn(x), mask)
-        x = x + self.mlp(self.rms_mlp(x))
-        return x
+    def __call__(
+        self,
+        x: Float[Array, "B S D"],
+        mask: AttentionMask | jax.Array,
+    ) -> tuple[Float[Array, "B S D"], LayerLogging]:
+        attn_in = self.rms_attn(x)
+        attn_out, max_abs_logit = self.attn(attn_in, mask)
+        x = x + attn_out
+        mlp_in = self.rms_mlp(x)
+        mlp_out = self.mlp(mlp_in)
+        x = x + mlp_out
+        return x, block_activation_logging(
+            attn_in=attn_in,
+            attn_out=attn_out,
+            mlp_in=mlp_in,
+            mlp_out=mlp_out,
+            block_out=x,
+            max_abs_attn_logit=max_abs_logit,
+        )
 
 
 class Transformer(eqx.Module):
@@ -178,14 +207,21 @@ class Transformer(eqx.Module):
         self,
         token_ids: Int[Array, "B S"],
         mask: AttentionMask | jax.Array | None = None,
-    ) -> Float[Array, "B S D"]:
+        *,
+        return_activation_metrics: bool = False,
+    ) -> Float[Array, "B S D"] | tuple[Float[Array, "B S D"], dict[str, jax.Array | SummaryStats]]:
         if mask is None:
             mask = AttentionMask.causal()
 
         hidden = self.token_embed.at[token_ids].get(out_sharding=Pbatch)
+        layer_logging: list[LayerLogging] = []
         for block in self.blocks:
-            hidden = eqx.filter_checkpoint(block)(hidden, mask)
-        return self.final_norm(hidden)
+            hidden, block_logging = eqx.filter_checkpoint(block)(hidden, mask)
+            layer_logging.append(block_logging)
+        hidden = self.final_norm(hidden)
+        if return_activation_metrics:
+            return hidden, flatten_layer_logging(layer_logging)
+        return hidden
 
     @named_call
     def logits(
@@ -205,13 +241,14 @@ class Transformer(eqx.Module):
         reduction: str = "mean",
         logsumexp_weight: float | None = None,
         loss_dtype: jnp.dtype = jnp.float32,
-    ) -> jax.Array:
+        return_activation_metrics: bool = False,
+    ) -> jax.Array | tuple[jax.Array, dict[str, jax.Array | SummaryStats]]:
         """Compute next-token cross-entropy loss for a batch."""
-        hidden = self(token_ids, mask=mask)
+        hidden, activation_metrics = self(token_ids, mask=mask, return_activation_metrics=True)
         labels = jnp.concatenate([token_ids[:, 1:], token_ids[:, :1] * 0], axis=1).astype(jnp.int32)
         loss_weight = loss_weight.astype(loss_dtype)
 
-        return fused_linear_softmax_cross_entropy_loss(
+        loss = fused_linear_softmax_cross_entropy_loss(
             hidden,
             self.output_proj,
             labels,
@@ -220,6 +257,9 @@ class Transformer(eqx.Module):
             logsumexp_weight=logsumexp_weight,
             dtype=loss_dtype,
         )
+        if return_activation_metrics:
+            return loss, activation_metrics
+        return loss
 
 
 def _init_weight(key: PRNGKeyArray, shape: tuple[int, ...], std: float) -> Float[Array, "..."]:

--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -274,7 +274,24 @@ def _make_train_step(
                 logsumexp_weight=z_loss,
             )
 
-        loss, grads = jax.value_and_grad(loss_fn)(state.params)
+        def loss_with_activation_metrics_fn(params):
+            compute_params = mp.cast_to_compute(params)
+            return compute_params.next_token_loss(
+                batch.tokens,
+                batch.loss_weight,
+                mask=batch.attn_mask,
+                reduction="mean",
+                logsumexp_weight=z_loss,
+                return_activation_metrics=True,
+            )
+
+        if compute_watch:
+            (loss, activation_metrics), grads = jax.value_and_grad(loss_with_activation_metrics_fn, has_aux=True)(
+                state.params
+            )
+        else:
+            loss, grads = jax.value_and_grad(loss_fn)(state.params)
+            activation_metrics = None
         updates, opt_state = optimizer.update(grads, state.opt_state, state.params)
         params = optax.apply_updates(state.params, updates)
 
@@ -303,6 +320,9 @@ def _make_train_step(
                 opt_state=state.opt_state,
                 model_tree_type=type(state.params),
             )
+            if activation_metrics is None:
+                raise AssertionError("activation_metrics should be populated when compute_watch=True")
+            watch_stats.update(activation_metrics)
 
         next_state = dataclasses.replace(
             state,

--- a/experiments/grug/modular_opt/model.py
+++ b/experiments/grug/modular_opt/model.py
@@ -14,9 +14,17 @@ from jax.sharding import PartitionSpec as P
 from jax.sharding import reshard
 from jaxtyping import Array, Float, Int, PRNGKeyArray
 
-from levanter.grug.attention import AttentionMask, RotaryConfig, apply_rotary_embedding, attention
+from levanter.grug.activation_logging import LayerLogging, block_activation_logging, flatten_layer_logging
+from levanter.grug.attention import (
+    AttentionMask,
+    RotaryConfig,
+    apply_rotary_embedding,
+    attention,
+    max_abs_attention_logit,
+)
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
 from levanter.grug.sharding import Pbatch, Pembed_vocab, Plm_head, Plogits, unshard
+from levanter.tracker.histogram import SummaryStats
 
 
 @dataclass(frozen=True)
@@ -75,7 +83,11 @@ class CausalSelfAttention(eqx.Module):
         )
 
     @named_call
-    def __call__(self, x: Float[Array, "B S D"], mask: AttentionMask | jax.Array) -> Float[Array, "B S D"]:
+    def __call__(
+        self,
+        x: Float[Array, "B S D"],
+        mask: AttentionMask | jax.Array,
+    ) -> tuple[Float[Array, "B S D"], jax.Array]:
         head_dim = self.cfg.inferred_head_dim
         seq_len = x.shape[1]
 
@@ -83,9 +95,11 @@ class CausalSelfAttention(eqx.Module):
         k = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_k), "... (m d) -> ... m d", d=head_dim)
         v = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_v), "... (m d) -> ... m d", d=head_dim)
         q, k = apply_rotary_embedding(q, k, seq_len=seq_len, head_dim=head_dim, rope=self.cfg.rope)
+        max_logit = max_abs_attention_logit(q, k)
         attn_out = attention(q, k, v, mask)
         attn_out = rearrange(attn_out, "... n d -> ... (n d)")
-        return jnp.einsum("bsh,hd->bsd", attn_out, self.w_o, out_sharding=Pbatch)
+        output = jnp.einsum("bsh,hd->bsd", attn_out, self.w_o, out_sharding=Pbatch)
+        return output, max_logit
 
 
 class MLP(eqx.Module):
@@ -143,10 +157,25 @@ class Block(eqx.Module):
         )
 
     @named_call
-    def __call__(self, x: Float[Array, "B S D"], mask: AttentionMask | jax.Array) -> Float[Array, "B S D"]:
-        x = x + self.attn(self.rms_attn(x), mask)
-        x = x + self.mlp(self.rms_mlp(x))
-        return x
+    def __call__(
+        self,
+        x: Float[Array, "B S D"],
+        mask: AttentionMask | jax.Array,
+    ) -> tuple[Float[Array, "B S D"], LayerLogging]:
+        attn_in = self.rms_attn(x)
+        attn_out, max_abs_logit = self.attn(attn_in, mask)
+        x = x + attn_out
+        mlp_in = self.rms_mlp(x)
+        mlp_out = self.mlp(mlp_in)
+        x = x + mlp_out
+        return x, block_activation_logging(
+            attn_in=attn_in,
+            attn_out=attn_out,
+            mlp_in=mlp_in,
+            mlp_out=mlp_out,
+            block_out=x,
+            max_abs_attn_logit=max_abs_logit,
+        )
 
 
 class Transformer(eqx.Module):
@@ -178,14 +207,21 @@ class Transformer(eqx.Module):
         self,
         token_ids: Int[Array, "B S"],
         mask: AttentionMask | jax.Array | None = None,
-    ) -> Float[Array, "B S D"]:
+        *,
+        return_activation_metrics: bool = False,
+    ) -> Float[Array, "B S D"] | tuple[Float[Array, "B S D"], dict[str, jax.Array | SummaryStats]]:
         if mask is None:
             mask = AttentionMask.causal()
 
         hidden = self.token_embed.at[token_ids].get(out_sharding=Pbatch)
+        layer_logging: list[LayerLogging] = []
         for block in self.blocks:
-            hidden = eqx.filter_checkpoint(block)(hidden, mask)
-        return self.final_norm(hidden)
+            hidden, block_logging = eqx.filter_checkpoint(block)(hidden, mask)
+            layer_logging.append(block_logging)
+        hidden = self.final_norm(hidden)
+        if return_activation_metrics:
+            return hidden, flatten_layer_logging(layer_logging)
+        return hidden
 
     @named_call
     def logits(
@@ -205,13 +241,14 @@ class Transformer(eqx.Module):
         reduction: str = "mean",
         logsumexp_weight: float | None = None,
         loss_dtype: jnp.dtype = jnp.float32,
-    ) -> jax.Array:
+        return_activation_metrics: bool = False,
+    ) -> jax.Array | tuple[jax.Array, dict[str, jax.Array | SummaryStats]]:
         """Compute next-token cross-entropy loss for a batch."""
-        hidden = self(token_ids, mask=mask)
+        hidden, activation_metrics = self(token_ids, mask=mask, return_activation_metrics=True)
         labels = jnp.concatenate([token_ids[:, 1:], token_ids[:, :1] * 0], axis=1).astype(jnp.int32)
         loss_weight = loss_weight.astype(loss_dtype)
 
-        return fused_linear_softmax_cross_entropy_loss(
+        loss = fused_linear_softmax_cross_entropy_loss(
             hidden,
             self.output_proj,
             labels,
@@ -220,6 +257,9 @@ class Transformer(eqx.Module):
             logsumexp_weight=logsumexp_weight,
             dtype=loss_dtype,
         )
+        if return_activation_metrics:
+            return loss, activation_metrics
+        return loss
 
 
 def _init_weight(key: PRNGKeyArray, shape: tuple[int, ...], std: float) -> Float[Array, "..."]:

--- a/experiments/grug/modular_opt/train.py
+++ b/experiments/grug/modular_opt/train.py
@@ -274,7 +274,24 @@ def _make_train_step(
                 logsumexp_weight=z_loss,
             )
 
-        loss, grads = jax.value_and_grad(loss_fn)(state.params)
+        def loss_with_activation_metrics_fn(params):
+            compute_params = mp.cast_to_compute(params)
+            return compute_params.next_token_loss(
+                batch.tokens,
+                batch.loss_weight,
+                mask=batch.attn_mask,
+                reduction="mean",
+                logsumexp_weight=z_loss,
+                return_activation_metrics=True,
+            )
+
+        if compute_watch:
+            (loss, activation_metrics), grads = jax.value_and_grad(loss_with_activation_metrics_fn, has_aux=True)(
+                state.params
+            )
+        else:
+            loss, grads = jax.value_and_grad(loss_fn)(state.params)
+            activation_metrics = None
         updates, opt_state = optimizer.update(grads, state.opt_state, state.params)
         params = optax.apply_updates(state.params, updates)
 
@@ -303,6 +320,9 @@ def _make_train_step(
                 opt_state=state.opt_state,
                 model_tree_type=type(state.params),
             )
+            if activation_metrics is None:
+                raise AssertionError("activation_metrics should be populated when compute_watch=True")
+            watch_stats.update(activation_metrics)
 
         next_state = dataclasses.replace(
             state,

--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -28,11 +28,18 @@ except ModuleNotFoundError:
     from jax.experimental.shard_map import shard_map
 from jaxtyping import Array, Float, Int, PRNGKeyArray
 
-from levanter.grug.attention import AttentionMask, RotaryConfig, apply_rotary_embedding, attention
+from levanter.grug.activation_logging import LayerLogging, block_activation_logging, flatten_layer_logging
+from levanter.grug.attention import (
+    AttentionMask,
+    RotaryConfig,
+    apply_rotary_embedding,
+    attention,
+    max_abs_attention_logit,
+)
 from levanter.grug.grug_moe import MoeActivation, moe_mlp
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
 from levanter.grug.sharding import Pembed_vocab, Plm_head, unshard
-from levanter.tracker.histogram import Histogram
+from levanter.tracker.histogram import Histogram, SummaryStats
 from levanter.utils.activation import ActivationFunctionEnum
 
 _DEFAULT_EP_CAPACITY_FACTOR = 1.25
@@ -134,7 +141,11 @@ class CausalSelfAttention(eqx.Module):
         )
 
     @named_call
-    def __call__(self, x: Float[Array, "B S D"], mask: AttentionMask | jax.Array) -> Float[Array, "B S D"]:
+    def __call__(
+        self,
+        x: Float[Array, "B S D"],
+        mask: AttentionMask | jax.Array,
+    ) -> tuple[Float[Array, "B S D"], jax.Array]:
         head_dim = self.cfg.inferred_head_dim
         seq_len = x.shape[1]
         batch_spec = _batch_spec()
@@ -146,6 +157,7 @@ class CausalSelfAttention(eqx.Module):
         k = rms_norm(k)
         q, k = apply_rotary_embedding(q, k, seq_len=seq_len, head_dim=head_dim, rope=self.cfg.rope)
         q = q * self.cfg.qk_mult
+        max_logit = max_abs_attention_logit(q, k)
         attn_out = attention(q, k, v, mask)
         # Exclusive Self Attention: subtract the component of yᵢ parallel to vᵢ.
         # zᵢ = yᵢ - (yᵢᵀvᵢ / ‖vᵢ‖²) vᵢ, per head.
@@ -156,7 +168,8 @@ class CausalSelfAttention(eqx.Module):
         gate = 2 * jax.nn.sigmoid(jnp.einsum("bsd,dn->bsn", x, self.attn_gate))[..., None]
         attn_out = gate * attn_out
         attn_out = rearrange(attn_out, "... n d -> ... (n d)")
-        return jnp.einsum("bsh,hd->bsd", attn_out, self.w_o, out_sharding=batch_spec)
+        output = jnp.einsum("bsh,hd->bsd", attn_out, self.w_o, out_sharding=batch_spec)
+        return output, max_logit
 
 
 class RMSNorm(eqx.Module):
@@ -264,14 +277,14 @@ def _routing_stats(
     }
 
 
-def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str, jax.Array | Histogram]:
+def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str, jax.Array | SummaryStats]:
     routing_entropy = router_metrics["routing_entropy_per_layer"]
     routing_counts = router_metrics["routing_counts_per_layer"]
     load_balancing_loss = router_metrics["load_balancing_loss_per_layer"]
     router_z_loss = router_metrics["router_z_loss_per_layer"]
     num_layers = int(routing_entropy.shape[0])
 
-    out: dict[str, jax.Array | Histogram] = {
+    out: dict[str, jax.Array | SummaryStats] = {
         "train/router/routing_entropy_mean": jnp.mean(routing_entropy),
         "train/router/load_balancing_loss": jnp.mean(load_balancing_loss),
         "train/router/router_z_loss": jnp.mean(router_z_loss),
@@ -286,7 +299,7 @@ def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str,
     return out
 
 
-def _histogram_from_expert_counts(expert_counts: jax.Array) -> Histogram:
+def _histogram_from_expert_counts(expert_counts: jax.Array) -> SummaryStats:
     counts = jnp.asarray(expert_counts, dtype=jnp.float32)
     num_experts = counts.shape[0]
     expert_ids = jnp.arange(num_experts, dtype=jnp.float32)
@@ -299,14 +312,17 @@ def _histogram_from_expert_counts(expert_counts: jax.Array) -> Histogram:
     min_value = jnp.where(num > 0, min_value, 0.0)
     max_value = jnp.where(num > 0, max_value, 0.0)
     bucket_limits = jnp.arange(num_experts + 1, dtype=jnp.float32)
-    return Histogram(
+    return SummaryStats(
         min=min_value,
         max=max_value,
         num=num,
+        nonzero_count=num - counts[0],
         sum=sum_values,
         sum_squares=sum_squares,
-        bucket_limits=bucket_limits,
-        bucket_counts=counts,
+        histogram=Histogram(
+            bucket_limits=bucket_limits,
+            bucket_counts=counts,
+        ),
     )
 
 
@@ -351,8 +367,7 @@ class MoEMLP(eqx.Module):
     ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
         b, s, _ = x.shape
         x_flat = rearrange(x, "b s d -> (b s) d")
-        # Keep the router path in fp32 before top-k, softmax, and QB statistics.
-        router_logits = jnp.einsum("td,de->te", x_flat, reshard(self.router, P(None, None))).astype(jnp.float32)
+        router_logits = jnp.einsum("td,de->te", x_flat, reshard(self.router, P(None, None)))
         biased_logits = router_logits + jax.lax.stop_gradient(self.router_bias)
         router_probs = jax.nn.softmax(router_logits, axis=-1)
         # Select top-(K+1) on biased logits; the (K+1)-th is the QB threshold alpha.
@@ -448,9 +463,10 @@ class Block(eqx.Module):
         self,
         x: Float[Array, "B S D"],
         mask: AttentionMask | jax.Array,
-    ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
+    ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array], LayerLogging]:
         attn_in = self.attn_gated_norm(self.rms_attn(x))
-        x = x + self.attn(attn_in, mask)
+        attn_out, max_abs_logit = self.attn(attn_in, mask)
+        x = x + attn_out
         mlp_in = self.mlp_gated_norm(self.rms_mlp(x))
         if self.dense_mlp is not None:
             mlp_out = self.dense_mlp(mlp_in, activation=ActivationFunctionEnum.silu)
@@ -461,7 +477,18 @@ class Block(eqx.Module):
             if self.shared is not None:
                 mlp_out = mlp_out + self.shared(mlp_in, activation=ActivationFunctionEnum.silu)
         x = x + mlp_out
-        return x, router_stats
+        return (
+            x,
+            router_stats,
+            block_activation_logging(
+                attn_in=attn_in,
+                attn_out=attn_out,
+                mlp_in=mlp_in,
+                mlp_out=mlp_out,
+                block_out=x,
+                max_abs_attn_logit=max_abs_logit,
+            ),
+        )
 
 
 class Transformer(eqx.Module):
@@ -500,7 +527,12 @@ class Transformer(eqx.Module):
         self,
         token_ids: Int[Array, "B S"],
         mask: AttentionMask | jax.Array | None = None,
-    ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
+        *,
+        return_activation_metrics: bool = False,
+    ) -> (
+        tuple[Float[Array, "B S D"], dict[str, jax.Array]]
+        | tuple[Float[Array, "B S D"], dict[str, jax.Array], dict[str, jax.Array | SummaryStats]]
+    ):
         if mask is None:
             mask = AttentionMask.causal()
 
@@ -514,9 +546,11 @@ class Transformer(eqx.Module):
         long_mask = AttentionMask(is_causal=True, sliding_window=cfg.sliding_window, segment_ids=segment_ids)
 
         moe_router_stats: list[dict[str, jax.Array]] = []
+        layer_logging: list[LayerLogging] = []
         for i, block in enumerate(self.blocks):
             layer_mask = long_mask if i % 4 == 3 else short_mask
-            hidden, router_stats = eqx.filter_checkpoint(block)(hidden, layer_mask)
+            hidden, router_stats, block_logging = eqx.filter_checkpoint(block)(hidden, layer_mask)
+            layer_logging.append(block_logging)
             if router_stats:
                 moe_router_stats.append(router_stats)
 
@@ -528,6 +562,8 @@ class Transformer(eqx.Module):
             "qb_beta_per_layer": jnp.stack([s["qb_beta"] for s in moe_router_stats], axis=0),
         }
         hidden = self.final_gated_norm(self.final_norm(hidden))
+        if return_activation_metrics:
+            return hidden, router_metrics, flatten_layer_logging(layer_logging)
         return hidden, router_metrics
 
     @named_call
@@ -550,8 +586,13 @@ class Transformer(eqx.Module):
         logsumexp_weight: float | None = None,
         loss_dtype: jnp.dtype = jnp.float32,
         return_router_metrics: bool = False,
-    ) -> jax.Array | tuple[jax.Array, dict[str, jax.Array | Histogram]]:
-        hidden, router_metrics = self(token_ids, mask=mask)
+        return_activation_metrics: bool = False,
+    ) -> (
+        jax.Array
+        | tuple[jax.Array, dict[str, jax.Array | SummaryStats]]
+        | tuple[jax.Array, tuple[dict[str, jax.Array | SummaryStats], dict[str, jax.Array | SummaryStats]]]
+    ):
+        hidden, router_metrics, activation_metrics = self(token_ids, mask=mask, return_activation_metrics=True)
         labels = jnp.concatenate([token_ids[:, 1:], token_ids[:, :1] * 0], axis=1).astype(jnp.int32)
         loss_weight = loss_weight.astype(loss_dtype)
 
@@ -569,11 +610,19 @@ class Transformer(eqx.Module):
         rzl = jnp.sum(router_metrics["router_z_loss_per_layer"]) / num_moe_layers
         aux_loss = self.config.router_z_loss_coef * rzl
         loss = cross_entropy_loss + aux_loss if reduction != "none" else cross_entropy_loss
+        summarized_metrics = None
         if return_router_metrics:
             summarized_metrics = _summarize_router_metrics(router_metrics)
             summarized_metrics["train/cross_entropy_loss"] = cross_entropy_loss
             summarized_metrics["train/router/aux_loss_weighted"] = aux_loss
+        if return_router_metrics and return_activation_metrics:
+            return loss, (summarized_metrics, activation_metrics)
+        if return_router_metrics:
+            if summarized_metrics is None:
+                raise AssertionError("summarized_metrics should be populated when return_router_metrics=True")
             return loss, summarized_metrics
+        if return_activation_metrics:
+            return loss, activation_metrics
         return loss
 
 

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -299,7 +299,25 @@ def _make_train_step(
                 return_router_metrics=True,
             )
 
-        (loss, summarized_metrics), grads = jax.value_and_grad(loss_fn, has_aux=True)(state.params)
+        def loss_with_watch_metrics_fn(params):
+            compute_params = mp.cast_to_compute(params)
+            return compute_params.next_token_loss(
+                batch.tokens,
+                batch.loss_weight,
+                mask=batch.attn_mask,
+                reduction="mean",
+                logsumexp_weight=z_loss,
+                return_router_metrics=True,
+                return_activation_metrics=True,
+            )
+
+        if compute_watch:
+            (loss, (summarized_metrics, activation_metrics)), grads = jax.value_and_grad(
+                loss_with_watch_metrics_fn, has_aux=True
+            )(state.params)
+        else:
+            (loss, summarized_metrics), grads = jax.value_and_grad(loss_fn, has_aux=True)(state.params)
+            activation_metrics = None
         metrics = {"train/loss": loss, **summarized_metrics}
         updates, opt_state = optimizer.update(grads, state.opt_state, state.params)
         params = optax.apply_updates(state.params, updates)
@@ -329,6 +347,9 @@ def _make_train_step(
                 opt_state=state.opt_state,
                 model_tree_type=type(state.params),
             )
+            if activation_metrics is None:
+                raise AssertionError("activation_metrics should be populated when compute_watch=True")
+            watch_stats.update(activation_metrics)
 
         next_state = dataclasses.replace(
             state,

--- a/lib/levanter/src/levanter/grug/activation_logging.py
+++ b/lib/levanter/src/levanter/grug/activation_logging.py
@@ -1,0 +1,122 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Mapping, Sequence
+from typing import TypeAlias
+
+import jax
+import jax.numpy as jnp
+
+from levanter.tracker.histogram import Histogram, SummaryStats
+
+
+MetricValue: TypeAlias = SummaryStats | jax.Array
+LayerLogging: TypeAlias = dict[str, MetricValue]
+
+_COSINE_EPS = 1e-6
+_HISTOGRAM_NUM_BINS = 31
+
+
+def block_activation_logging(
+    *,
+    attn_in: jax.Array,
+    attn_out: jax.Array,
+    mlp_in: jax.Array,
+    mlp_out: jax.Array,
+    block_out: jax.Array,
+    max_abs_attn_logit: jax.Array,
+) -> LayerLogging:
+    out: LayerLogging = {
+        "attn_in": SummaryStats.from_sharded_array(attn_in, num_bins=_HISTOGRAM_NUM_BINS, include_histogram=False),
+        "attn_out": SummaryStats.from_sharded_array(attn_out, num_bins=_HISTOGRAM_NUM_BINS, include_histogram=False),
+        "mlp_out": SummaryStats.from_sharded_array(mlp_out, num_bins=_HISTOGRAM_NUM_BINS, include_histogram=False),
+        "block_out": SummaryStats.from_sharded_array(block_out, num_bins=_HISTOGRAM_NUM_BINS, include_histogram=False),
+        "attn_out_cosine_with_in": _cosine_similarity_summary(attn_out, attn_in),
+        "mlp_out_cosine_with_in": _cosine_similarity_summary(mlp_out, mlp_in),
+        "max_abs_attn_logit": max_abs_attn_logit.astype(jnp.float32),
+    }
+    return out
+
+
+def flatten_layer_logging(
+    layer_logging: Sequence[Mapping[str, MetricValue]] | Mapping[str, MetricValue],
+    *,
+    prefix: str = "train/activations",
+) -> dict[str, MetricValue]:
+    if isinstance(layer_logging, Mapping):
+        per_layer_logging = unstack_layer_logging(layer_logging)
+    else:
+        per_layer_logging = tuple(dict(layer_metrics) for layer_metrics in layer_logging)
+
+    flattened: dict[str, MetricValue] = {}
+    for layer_index, layer_metrics in enumerate(per_layer_logging):
+        for name, value in layer_metrics.items():
+            flattened[f"{prefix}/layer_{layer_index}/{name}"] = value
+
+    return flattened
+
+
+def unstack_layer_logging(stacked_logging: Mapping[str, MetricValue]) -> tuple[LayerLogging, ...]:
+    if not stacked_logging:
+        return ()
+
+    num_layers = _leading_axis_size(next(iter(stacked_logging.values())))
+    per_layer: list[LayerLogging] = []
+    for layer_index in range(num_layers):
+        per_layer.append({name: _slice_metric(value, layer_index) for name, value in stacked_logging.items()})
+
+    return tuple(per_layer)
+
+
+def _cosine_similarity_summary(lhs: jax.Array, rhs: jax.Array) -> SummaryStats:
+    lhs32 = lhs.astype(jnp.float32)
+    rhs32 = rhs.astype(jnp.float32)
+    lhs_norm = jnp.linalg.norm(lhs32, axis=-1)
+    rhs_norm = jnp.linalg.norm(rhs32, axis=-1)
+    denom = jnp.maximum(lhs_norm * rhs_norm, _COSINE_EPS)
+    cosine = jnp.sum(lhs32 * rhs32, axis=-1) / denom
+    return SummaryStats.from_sharded_array(
+        jnp.clip(cosine, -1.0, 1.0),
+        num_bins=_HISTOGRAM_NUM_BINS,
+        include_histogram=False,
+    )
+
+
+def _leading_axis_size(value: MetricValue) -> int:
+    if isinstance(value, SummaryStats):
+        return _leading_axis_size(value.min)
+    if isinstance(value, Histogram):
+        return int(value.bucket_counts.shape[0])
+    return int(value.shape[0])
+
+
+def _slice_metric(value: MetricValue, index: int) -> MetricValue:
+    if isinstance(value, SummaryStats):
+        histogram = value.histogram
+        if histogram is not None:
+            histogram = _slice_histogram(histogram, index)
+        return SummaryStats(
+            min=value.min[index],
+            max=value.max[index],
+            num=value.num[index],
+            nonzero_count=value.nonzero_count[index],
+            sum=value.sum[index],
+            sum_squares=value.sum_squares[index],
+            histogram=histogram,
+        )
+    if isinstance(value, Histogram):
+        return _slice_histogram(value, index)
+    return value[index]
+
+
+def _slice_histogram(value: Histogram, index: int) -> Histogram:
+    return Histogram(bucket_limits=value.bucket_limits[index], bucket_counts=value.bucket_counts[index])
+
+
+__all__ = [
+    "LayerLogging",
+    "MetricValue",
+    "block_activation_logging",
+    "flatten_layer_logging",
+    "unstack_layer_logging",
+]

--- a/lib/levanter/src/levanter/grug/attention.py
+++ b/lib/levanter/src/levanter/grug/attention.py
@@ -18,6 +18,7 @@ from haliax.partitioning import _get_mesh
 
 _SHARD_MAP_CHECK_KWARG = "check_vma" if "check_vma" in inspect.signature(shard_map).parameters else "check_rep"
 _SHARD_MAP_CHECK_KWARGS = {_SHARD_MAP_CHECK_KWARG: False}
+_MAX_LOGIT_CHUNK_SIZE = 128
 
 
 @dataclass(frozen=True)
@@ -188,6 +189,62 @@ def reference_attention(
     weights = jax.nn.softmax(scores, axis=-1).astype(v.dtype)
     ctx = jnp.einsum("bhqk,bkhd->bqhd", weights, v)
     return ctx.astype(v.dtype)
+
+
+def max_abs_attention_logit(
+    q: Float[Array, "B Q Hq D"],
+    k: Float[Array, "B K Hkv D"],
+) -> jax.Array:
+    head_dim = q.shape[-1]
+    num_q_heads = q.shape[2]
+    num_kv_heads = k.shape[2]
+
+    if num_q_heads != num_kv_heads:
+        if num_q_heads % num_kv_heads != 0:
+            raise ValueError(f"num_heads ({num_q_heads}) must be divisible by num_kv_heads ({num_kv_heads})")
+        kv_repeat = num_q_heads // num_kv_heads
+    else:
+        kv_repeat = 1
+
+    scale = jnp.asarray(1.0 / math.sqrt(head_dim), dtype=jnp.float32)
+    q32 = _pad_attention_sequence(q.astype(jnp.float32) * scale, axis=1, block_size=_MAX_LOGIT_CHUNK_SIZE)
+    k32 = _pad_attention_sequence(k.astype(jnp.float32), axis=1, block_size=_MAX_LOGIT_CHUNK_SIZE)
+    num_q_chunks = q32.shape[1] // _MAX_LOGIT_CHUNK_SIZE
+    num_k_chunks = k32.shape[1] // _MAX_LOGIT_CHUNK_SIZE
+
+    def _q_body(q_index: int, running_max: jax.Array) -> jax.Array:
+        q_chunk = jax.lax.dynamic_slice_in_dim(
+            q32,
+            q_index * _MAX_LOGIT_CHUNK_SIZE,
+            _MAX_LOGIT_CHUNK_SIZE,
+            axis=1,
+        )
+
+        def _k_body(k_index: int, chunk_max: jax.Array) -> jax.Array:
+            k_chunk = jax.lax.dynamic_slice_in_dim(
+                k32,
+                k_index * _MAX_LOGIT_CHUNK_SIZE,
+                _MAX_LOGIT_CHUNK_SIZE,
+                axis=1,
+            )
+            if kv_repeat != 1:
+                k_chunk = jnp.repeat(k_chunk, kv_repeat, axis=2)
+            scores = jnp.einsum("bqhd,bkhd->bhqk", q_chunk, k_chunk)
+            return jnp.maximum(chunk_max, jnp.max(jnp.abs(scores)))
+
+        return jax.lax.fori_loop(0, num_k_chunks, _k_body, running_max)
+
+    return jax.lax.fori_loop(0, num_q_chunks, _q_body, jnp.array(0.0, dtype=jnp.float32))
+
+
+def _pad_attention_sequence(array: jax.Array, *, axis: int, block_size: int) -> jax.Array:
+    pad = (-array.shape[axis]) % block_size
+    if pad == 0:
+        return array
+
+    pad_width = [(0, 0)] * array.ndim
+    pad_width[axis] = (0, pad)
+    return jnp.pad(array, pad_width)
 
 
 def _spec_shard_factor(entry: str | tuple[str, ...] | None, mesh) -> int:
@@ -394,5 +451,6 @@ __all__ = [
     "RotaryConfig",
     "apply_rotary_embedding",
     "attention",
+    "max_abs_attention_logit",
     "reference_attention",
 ]

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -28,6 +28,7 @@ from jax._src import config as jax_config
 from jax.sharding import use_abstract_mesh
 
 from levanter.checkpoint import CheckpointerConfig
+from levanter.callbacks.watch import WatchConfig
 from levanter.data.dataset import ListAsyncDataset
 from levanter.data.text import DirectDatasetComponent, LmDataConfig
 from levanter.data.text.examples import GrugLmExample
@@ -145,6 +146,74 @@ def test_grug_variant_one_step_contract_lowers_with_default_ctor(variant: str):
     assert "train/loss" in out_metrics_shape
     assert out_metrics_shape["train/loss"].shape == ()
     assert out_watch_shape is None
+
+
+@pytest.mark.parametrize(
+    "variant",
+    _discover_grug_variants_with_model_and_train(),
+)
+def test_grug_variant_activation_watch_contract_lowers(variant: str):
+    train_module = importlib.import_module(_variant_module_name(variant, "train"))
+    model_module = importlib.import_module(_variant_module_name(variant, "model"))
+    model_config_cls = model_module.GrugModelConfig
+    make_train_step = train_module._make_train_step
+    initial_state = train_module.initial_state
+    mesh_fn = getattr(model_module, "debug_mesh_and_token_pspec", None)
+    if mesh_fn is None:
+        raise AssertionError(f"{_variant_module_name(variant, 'model')} must define debug_mesh_and_token_pspec")
+
+    optimizer = optax.adam(1e-2)
+    mp = jmp.get_policy("f32")
+    watch_config = WatchConfig(
+        watch_targets=["grads"],
+        include_norms=True,
+        include_per_parameter_norms=False,
+        include_histograms=False,
+        interval=1,
+    )
+    train_step = make_train_step(optimizer, mp, z_loss_weight=0.0, ema_beta=None, watch_config=watch_config)
+    mesh, token_pspec = mesh_fn(num_devices=4)
+    batch = GrugLmExample(
+        tokens=jnp.zeros((8, 4), dtype=jnp.int32),
+        loss_weight=jnp.ones((8, 4), dtype=jnp.float32),
+        attn_mask=GrugAttentionMask.causal(),
+    )
+
+    def one_step():
+        sharded_batch = dataclasses.replace(
+            batch,
+            tokens=jax.sharding.reshard(batch.tokens, token_pspec),
+            loss_weight=jax.sharding.reshard(batch.loss_weight, token_pspec),
+        )
+        cfg = _small_model_config(model_config_cls, vocab_size=1024, seq_len=batch.tokens.shape[1])
+        if variant == "moe":
+            cfg = dataclasses.replace(cfg, num_layers=4)
+        state = initial_state(
+            cfg,
+            optimizer=optimizer,
+            mp=mp,
+            key=jax.random.PRNGKey(0),
+            ema_beta=None,
+        )
+        return train_step(state, sharded_batch, compute_watch=True)
+
+    with _reset_abstract_mesh(), use_abstract_mesh(mesh):
+        _, _, out_watch_shape = eqx.filter_eval_shape(one_step)
+
+    if out_watch_shape is None:
+        raise AssertionError("expected heavy-watch activation metrics")
+
+    required_keys = [
+        "train/activations/layer_0/attn_in",
+        "train/activations/layer_0/attn_out",
+        "train/activations/layer_0/mlp_out",
+        "train/activations/layer_0/block_out",
+        "train/activations/layer_0/attn_out_cosine_with_in",
+        "train/activations/layer_0/mlp_out_cosine_with_in",
+        "train/activations/layer_0/max_abs_attn_logit",
+    ]
+    for key in required_keys:
+        assert key in out_watch_shape
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add activation watch logging for grug variants and thread activation metrics through the model/train paths
- log reduced activation summaries during watch steps to keep the watch path lightweight enough to run on `v4-8`
- expose histogram RMS in the W&B tracker and add contract coverage for activation watch lowering

## Testing
- `./infra/pre-commit.py --all-files --fix`
- `uv run --with pytest python -m pytest -o addopts='' lib/levanter/tests/test_histogram.py`
- `uv run --with pytest python -m pytest -o addopts='' tests/test_grug_variant_contracts.py -k activation_watch_contract_lowers`