### PR TITLE
[Iris] Remove controller interruptable toleration

### DIFF
--- a/lib/iris/tests/cluster/providers/k8s/test_coreweave.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_coreweave.py
@@ -159,7 +159,6 @@ def test_start_controller_creates_all_resources():
     deploy_spec = dep["spec"]
     node_selector = deploy_spec["template"]["spec"]["nodeSelector"]
     assert node_selector == {iris_labels.iris_scale_group: "cpu-erapids"}
-    assert "tolerations" not in deploy_spec["template"]["spec"]
 
     # Verify controller uses S3 env vars (no GCS credentials)
     container = deploy_spec["template"]["spec"]["containers"][0]


### PR DESCRIPTION
Stop adding the CoreWeave interruptable toleration to the K8s controller Deployment. The controller runs on the cpu-erapids scale group, and a regression test now checks that its manifest does not opt into interruptable-tainted nodes.