### PR TITLE
Add rollout data pipelines for 6 datasets

### DIFF
--- a/experiments/rollout_data/__init__.py
+++ b/experiments/rollout_data/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/experiments/rollout_data/coderforge.py
+++ b/experiments/rollout_data/coderforge.py
@@ -1,0 +1,38 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""togethercomputer/CoderForge-Preview rollout dataset.
+
+Usage:
+    uv run lib/marin/src/marin/run/ray_run.py -- python experiments/rollout_data/coderforge.py
+"""
+
+from marin.datakit.download.coderforge import download_coderforge_step
+from marin.execution.step_runner import StepRunner
+from marin.execution.step_spec import StepSpec
+from marin.processing.tokenize import TokenizeConfig, tokenize
+from experiments.marin_models import marin_tokenizer
+
+
+def build_steps() -> list[StepSpec]:
+    processed = download_coderforge_step()
+
+    tokenized = StepSpec(
+        name="tokenized/coderforge-preview",
+        deps=[processed],
+        fn=lambda output_path: tokenize(
+            TokenizeConfig(
+                train_paths=[processed.output_path],
+                validation_paths=[],
+                cache_path=output_path,
+                tokenizer=marin_tokenizer,
+            )
+        ),
+        hash_attrs={"tokenizer": marin_tokenizer},
+    )
+
+    return [*processed.deps, processed, tokenized]
+
+
+if __name__ == "__main__":
+    StepRunner().run(build_steps())

--- a/experiments/rollout_data/gpt_oss_rollouts.py
+++ b/experiments/rollout_data/gpt_oss_rollouts.py
@@ -1,0 +1,38 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""andyrdt/gpt-oss-20b-rollouts rollout dataset (non-benchmark subsets).
+
+Usage:
+    uv run lib/marin/src/marin/run/ray_run.py -- python experiments/rollout_data/gpt_oss_rollouts.py
+"""
+
+from marin.datakit.download.gpt_oss_rollouts import download_gpt_oss_rollouts_step
+from marin.execution.step_runner import StepRunner
+from marin.execution.step_spec import StepSpec
+from marin.processing.tokenize import TokenizeConfig, tokenize
+from experiments.marin_models import marin_tokenizer
+
+
+def build_steps() -> list[StepSpec]:
+    processed = download_gpt_oss_rollouts_step()
+
+    tokenized = StepSpec(
+        name="tokenized/gpt-oss-20b-rollouts",
+        deps=[processed],
+        fn=lambda output_path: tokenize(
+            TokenizeConfig(
+                train_paths=[processed.output_path],
+                validation_paths=[],
+                cache_path=output_path,
+                tokenizer=marin_tokenizer,
+            )
+        ),
+        hash_attrs={"tokenizer": marin_tokenizer},
+    )
+
+    return [*processed.deps, processed, tokenized]
+
+
+if __name__ == "__main__":
+    StepRunner().run(build_steps())

--- a/experiments/rollout_data/nemotron_terminal.py
+++ b/experiments/rollout_data/nemotron_terminal.py
@@ -1,0 +1,41 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""nvidia/Nemotron-Terminal-Corpus rollout dataset.
+
+Usage:
+    uv run lib/marin/src/marin/run/ray_run.py -- python experiments/rollout_data/nemotron_terminal.py
+"""
+
+from fray.v2 import ResourceConfig
+from marin.datakit.download.nemotron_terminal import download_nemotron_terminal_step
+from marin.execution.step_runner import StepRunner
+from marin.execution.step_spec import StepSpec
+from marin.processing.tokenize import TokenizeConfig, tokenize
+from experiments.marin_models import marin_tokenizer
+
+
+def build_steps() -> list[StepSpec]:
+    processed = download_nemotron_terminal_step()
+
+    tokenized = StepSpec(
+        name="tokenized/nemotron-terminal-corpus",
+        deps=[processed],
+        fn=lambda output_path: tokenize(
+            TokenizeConfig(
+                train_paths=[processed.output_path],
+                validation_paths=[],
+                cache_path=output_path,
+                tokenizer=marin_tokenizer,
+                num_shards=64,
+                worker_resources=ResourceConfig(ram="48g", disk="5g"),
+            )
+        ),
+        hash_attrs={"tokenizer": marin_tokenizer},
+    )
+
+    return [*processed.deps, processed, tokenized]
+
+
+if __name__ == "__main__":
+    StepRunner().run(build_steps())

--- a/experiments/rollout_data/principia.py
+++ b/experiments/rollout_data/principia.py
@@ -1,0 +1,38 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""facebook/principia-collection rollout dataset.
+
+Usage:
+    uv run lib/marin/src/marin/run/ray_run.py -- python experiments/rollout_data/principia.py
+"""
+
+from marin.datakit.download.principia import download_principia_step
+from marin.execution.step_runner import StepRunner
+from marin.execution.step_spec import StepSpec
+from marin.processing.tokenize import TokenizeConfig, tokenize
+from experiments.marin_models import marin_tokenizer
+
+
+def build_steps() -> list[StepSpec]:
+    processed = download_principia_step()
+
+    tokenized = StepSpec(
+        name="tokenized/principia-collection",
+        deps=[processed],
+        fn=lambda output_path: tokenize(
+            TokenizeConfig(
+                train_paths=[processed.output_path],
+                validation_paths=[],
+                cache_path=output_path,
+                tokenizer=marin_tokenizer,
+            )
+        ),
+        hash_attrs={"tokenizer": marin_tokenizer},
+    )
+
+    return [*processed.deps, processed, tokenized]
+
+
+if __name__ == "__main__":
+    StepRunner().run(build_steps())

--- a/experiments/rollout_data/superior_reasoning.py
+++ b/experiments/rollout_data/superior_reasoning.py
@@ -1,0 +1,40 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Alibaba-Apsara/Superior-Reasoning-SFT-gpt-oss-120b rollout dataset.
+
+Usage:
+    uv run lib/marin/src/marin/run/ray_run.py -- python experiments/rollout_data/superior_reasoning.py
+"""
+
+from fray.v2 import ResourceConfig
+from marin.datakit.download.superior_reasoning import download_superior_reasoning_step
+from marin.execution.step_runner import StepRunner
+from marin.execution.step_spec import StepSpec
+from marin.processing.tokenize import TokenizeConfig, tokenize
+from experiments.marin_models import marin_tokenizer
+
+
+def build_steps() -> list[StepSpec]:
+    processed = download_superior_reasoning_step()
+
+    tokenized = StepSpec(
+        name="tokenized/superior-reasoning-sft",
+        deps=[processed],
+        fn=lambda output_path: tokenize(
+            TokenizeConfig(
+                train_paths=[processed.output_path],
+                validation_paths=[],
+                cache_path=output_path,
+                tokenizer=marin_tokenizer,
+                worker_resources=ResourceConfig(ram="80g", disk="5g"),
+            )
+        ),
+        hash_attrs={"tokenizer": marin_tokenizer},
+    )
+
+    return [*processed.deps, processed, tokenized]
+
+
+if __name__ == "__main__":
+    StepRunner().run(build_steps())

--- a/experiments/rollout_data/swe_rebench_openhands.py
+++ b/experiments/rollout_data/swe_rebench_openhands.py
@@ -1,0 +1,40 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""nebius/SWE-rebench-openhands-trajectories rollout dataset.
+
+Usage:
+    uv run lib/marin/src/marin/run/ray_run.py -- python experiments/rollout_data/swe_rebench_openhands.py
+"""
+
+from fray.v2 import ResourceConfig
+from marin.datakit.download.swe_rebench_openhands import download_swe_rebench_openhands_step
+from marin.execution.step_runner import StepRunner
+from marin.execution.step_spec import StepSpec
+from marin.processing.tokenize import TokenizeConfig, tokenize
+from experiments.marin_models import marin_tokenizer
+
+
+def build_steps() -> list[StepSpec]:
+    processed = download_swe_rebench_openhands_step()
+
+    tokenized = StepSpec(
+        name="tokenized/swe-rebench-openhands-trajectories",
+        deps=[processed],
+        fn=lambda output_path: tokenize(
+            TokenizeConfig(
+                train_paths=[processed.output_path],
+                validation_paths=[],
+                cache_path=output_path,
+                tokenizer=marin_tokenizer,
+                worker_resources=ResourceConfig(ram="48g", disk="5g"),
+            )
+        ),
+        hash_attrs={"tokenizer": marin_tokenizer},
+    )
+
+    return [*processed.deps, processed, tokenized]
+
+
+if __name__ == "__main__":
+    StepRunner().run(build_steps())

--- a/experiments/rollout_data/synthetic1.py
+++ b/experiments/rollout_data/synthetic1.py
@@ -1,0 +1,38 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""PrimeIntellect/SYNTHETIC-1 pretraining dataset.
+
+Usage:
+    uv run lib/marin/src/marin/run/ray_run.py -- python experiments/synthetic1.py
+"""
+
+from marin.datakit.download.synthetic1 import download_synthetic1_step
+from marin.execution.step_runner import StepRunner
+from marin.execution.step_spec import StepSpec
+from marin.processing.tokenize import TokenizeConfig, tokenize
+from experiments.marin_models import marin_tokenizer
+
+
+def build_steps() -> list[StepSpec]:
+    processed = download_synthetic1_step()
+
+    tokenized = StepSpec(
+        name="tokenized/synthetic-1",
+        deps=[processed],
+        fn=lambda output_path: tokenize(
+            TokenizeConfig(
+                train_paths=[processed.output_path],
+                validation_paths=[],
+                cache_path=output_path,
+                tokenizer=marin_tokenizer,
+            )
+        ),
+        hash_attrs={"tokenizer": marin_tokenizer},
+    )
+
+    return [*processed.deps, processed, tokenized]
+
+
+if __name__ == "__main__":
+    StepRunner().run(build_steps())

--- a/experiments/rollout_data/synthetic1.py
+++ b/experiments/rollout_data/synthetic1.py
@@ -4,7 +4,7 @@
 """PrimeIntellect/SYNTHETIC-1 pretraining dataset.
 
 Usage:
-    uv run lib/marin/src/marin/run/ray_run.py -- python experiments/synthetic1.py
+    uv run lib/marin/src/marin/run/ray_run.py -- python experiments/rollout_data/synthetic1.py
 """
 
 from marin.datakit.download.synthetic1 import download_synthetic1_step

--- a/experiments/synthetic1.py
+++ b/experiments/synthetic1.py
@@ -1,0 +1,116 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""PrimeIntellect/SYNTHETIC-1 pretraining dataset.
+
+Each row has a prompt, an LLM chain-of-thought rollout, and a real-valued score.
+We concat prompt + score tag + rollout into a single document so the model learns
+to distinguish correct and incorrect reasoning traces.
+
+Usage:
+    uv run lib/marin/src/marin/run/ray_run.py -- python experiments/synthetic1.py
+"""
+
+import hashlib
+
+from fray.v2 import ResourceConfig
+from zephyr import Dataset, ZephyrContext, load_parquet
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.execution.step_runner import StepRunner
+from marin.execution.step_spec import StepSpec
+from marin.processing.tokenize import TokenizeConfig, tokenize
+from experiments.marin_models import marin_tokenizer
+
+HF_DATASET_ID = "PrimeIntellect/SYNTHETIC-1"
+HF_REVISION = "f08fe8c"
+
+SCORE_TAGS = [
+    (0.8, "This is a mostly correct solution."),
+    (0.5, "This is a partially correct solution."),
+    (0.2, "This is a mostly incorrect solution."),
+    (0.0, "This is an incorrect solution."),
+]
+
+
+def score_to_tag(score: float | None) -> str:
+    if score is None:
+        return "This is an unscored solution."
+    if score >= 1.0:
+        return "This is a correct solution."
+    for threshold, tag in SCORE_TAGS:
+        if score >= threshold:
+            return tag
+    return "This is an incorrect solution."
+
+
+def strip_think_tags(text: str) -> str:
+    return text.replace("<think>", "").replace("</think>", "").strip()
+
+
+def row_to_doc(row: dict) -> dict | None:
+    prompt = row.get("prompt", "")
+    response = row.get("llm_response", "")
+    if not prompt or not response:
+        return None
+
+    response = strip_think_tags(response)
+    if not response.strip():
+        return None
+
+    tag = score_to_tag(row.get("score"))
+    text = f"{prompt}\n\n{tag}\n\n{response}"
+
+    return {
+        "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        "text": text,
+        "source": "PrimeIntellect/SYNTHETIC-1",
+    }
+
+
+def transform(input_path: str, output_path: str) -> None:
+    pipeline = (
+        Dataset.from_files(f"{input_path}/**/*.parquet")
+        .flat_map(load_parquet)
+        .map(row_to_doc)
+        .filter(lambda r: r is not None)
+        .write_jsonl(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz", skip_existing=True)
+    )
+    ctx = ZephyrContext(name="synthetic1-transform", resources=ResourceConfig(cpu=1, ram="4g"))
+    list(ctx.execute(pipeline))
+
+
+def build_steps() -> list[StepSpec]:
+    dl = download_hf_step(
+        "raw/synthetic-1",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+    )
+
+    transformed = StepSpec(
+        name="processed/synthetic-1",
+        deps=[dl],
+        fn=lambda output_path: transform(
+            input_path=dl.output_path,
+            output_path=output_path,
+        ),
+        hash_attrs={"version": "v1"},
+    )
+
+    tokenized = StepSpec(
+        name="tokenized/synthetic-1",
+        deps=[transformed],
+        fn=lambda output_path: tokenize(TokenizeConfig(
+            train_paths=[transformed.output_path],
+            validation_paths=[],
+            cache_path=output_path,
+            tokenizer=marin_tokenizer,
+        )),
+        hash_attrs={"tokenizer": marin_tokenizer},
+    )
+
+    return [dl, transformed, tokenized]
+
+
+if __name__ == "__main__":
+    StepRunner().run(build_steps())

--- a/lib/marin/src/marin/datakit/download/coderforge.py
+++ b/lib/marin/src/marin/datakit/download/coderforge.py
@@ -13,7 +13,7 @@ import hashlib
 import json
 
 from fray.v2 import ResourceConfig
-from zephyr import Dataset, ZephyrContext, load_parquet
+from zephyr import Dataset, ZephyrContext, counters, load_parquet
 
 from marin.datakit.download.huggingface import download_hf_step
 from marin.execution.step_spec import StepSpec
@@ -60,24 +60,29 @@ def render_message(msg: dict) -> str:
     return "\n".join(parts)
 
 
-def row_to_doc(row: dict) -> dict | None:
+def row_to_doc(row: dict) -> list[dict]:
     messages_raw = row.get("messages", "")
     if not messages_raw:
-        return None
+        counters.increment("coderforge/dropped")
+        return []
 
     messages = json.loads(messages_raw) if isinstance(messages_raw, str) else messages_raw
     if not messages:
-        return None
+        counters.increment("coderforge/dropped")
+        return []
 
     tag = reward_to_tag(row.get("reward"))
     rendered = "\n\n".join(render_message(m) for m in messages)
     text = f"{tag}\n\n{rendered}"
 
-    return {
-        "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
-        "text": text,
-        "source": "togethercomputer/CoderForge-Preview",
-    }
+    counters.increment("coderforge/kept")
+    return [
+        {
+            "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "text": text,
+            "source": "togethercomputer/CoderForge-Preview",
+        }
+    ]
 
 
 def transform(input_path: str, output_path: str) -> None:
@@ -85,9 +90,8 @@ def transform(input_path: str, output_path: str) -> None:
     pipeline = (
         Dataset.from_files(f"{input_path}/**/*.parquet")
         .flat_map(load_parquet)
-        .map(row_to_doc)
-        .filter(lambda r: r is not None)
-        .write_jsonl(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz", skip_existing=True)
+        .flat_map(row_to_doc)
+        .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
     )
     ctx = ZephyrContext(name="coderforge-transform", resources=ResourceConfig(cpu=1, ram="8g"))
     list(ctx.execute(pipeline))

--- a/lib/marin/src/marin/datakit/download/coderforge.py
+++ b/lib/marin/src/marin/datakit/download/coderforge.py
@@ -1,0 +1,113 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""togethercomputer/CoderForge-Preview dataset download and transform.
+
+Downloads raw parquet files from HuggingFace, then transforms each trajectory
+into a single document by rendering the chat messages as readable text with a
+reward tag prefix so the model learns to distinguish successful and failed
+rollouts.
+"""
+
+import hashlib
+import json
+
+from fray.v2 import ResourceConfig
+from zephyr import Dataset, ZephyrContext, load_parquet
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "togethercomputer/CoderForge-Preview"
+HF_REVISION = "060fca9"
+
+SPLITS = ["SWE_Rebench", "SWE_Smith", "R2E_Gym"]
+
+
+def reward_to_tag(reward: float | None) -> str:
+    if reward is None:
+        return "This trajectory has an unknown outcome."
+    if reward >= 1.0:
+        return "This trajectory solved the task successfully."
+    return "This trajectory failed to solve the task."
+
+
+def render_tool_call(tc: dict) -> str:
+    func = tc.get("function", {})
+    name = func.get("name", "unknown")
+    args = func.get("arguments", {})
+    if isinstance(args, str):
+        args = json.loads(args)
+    parts = [f"<tool_call:{name}>"]
+    for k, v in args.items():
+        parts.append(f"  {k}: {v}")
+    parts.append(f"</tool_call:{name}>")
+    return "\n".join(parts)
+
+
+def render_message(msg: dict) -> str:
+    role = msg.get("role", "unknown")
+    content = msg.get("content") or ""
+    tool_calls = msg.get("tool_calls")
+
+    parts = [f"<{role}>"]
+    if content:
+        parts.append(content)
+    if tool_calls:
+        for tc in tool_calls:
+            parts.append(render_tool_call(tc))
+    parts.append(f"</{role}>")
+    return "\n".join(parts)
+
+
+def row_to_doc(row: dict) -> dict | None:
+    messages_raw = row.get("messages", "")
+    if not messages_raw:
+        return None
+
+    messages = json.loads(messages_raw) if isinstance(messages_raw, str) else messages_raw
+    if not messages:
+        return None
+
+    tag = reward_to_tag(row.get("reward"))
+    rendered = "\n\n".join(render_message(m) for m in messages)
+    text = f"{tag}\n\n{rendered}"
+
+    return {
+        "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        "text": text,
+        "source": "togethercomputer/CoderForge-Preview",
+    }
+
+
+def transform(input_path: str, output_path: str) -> None:
+    # The download already filters to only the splits we want via hf_urls_glob
+    pipeline = (
+        Dataset.from_files(f"{input_path}/**/*.parquet")
+        .flat_map(load_parquet)
+        .map(row_to_doc)
+        .filter(lambda r: r is not None)
+        .write_jsonl(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz", skip_existing=True)
+    )
+    ctx = ZephyrContext(name="coderforge-transform", resources=ResourceConfig(cpu=1, ram="8g"))
+    list(ctx.execute(pipeline))
+
+
+def download_coderforge_step() -> StepSpec:
+    """Download and transform CoderForge-Preview into JSONL documents."""
+    dl = download_hf_step(
+        "raw/coderforge-preview",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=[f"trajectories/{split}-*.parquet" for split in SPLITS],
+    )
+
+    return StepSpec(
+        name="processed/coderforge-preview",
+        deps=[dl],
+        fn=lambda output_path: transform(
+            input_path=dl.output_path,
+            output_path=output_path,
+        ),
+        hash_attrs={"version": "v1"},
+    )

--- a/lib/marin/src/marin/datakit/download/gpt_oss_rollouts.py
+++ b/lib/marin/src/marin/datakit/download/gpt_oss_rollouts.py
@@ -1,0 +1,87 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""andyrdt/gpt-oss-20b-rollouts dataset download and transform.
+
+GPT-OSS-20B rollouts with parsed reasoning chains. We include only the
+non-benchmark subsets: NuminaMath-CoT, WildChat-1M, and ultrachat_200k.
+
+Each row has a user prompt, the model's internal thinking, and the final
+assistant response. We render these into a single document.
+"""
+
+import hashlib
+
+from fray.v2 import ResourceConfig
+from zephyr import Dataset, ZephyrContext
+from zephyr.readers import load_jsonl
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "andyrdt/gpt-oss-20b-rollouts"
+HF_REVISION = "f47b4a2"
+
+SUBSETS = {
+    "NuminaMath-CoT": "train",
+    "WildChat-1M": "train",
+    "ultrachat_200k": "train_sft",
+}
+
+
+def row_to_doc(row: dict) -> dict | None:
+    user = row.get("user_content") or ""
+    thinking = row.get("assistant_thinking") or ""
+    response = row.get("assistant_content") or ""
+    if not user or not response:
+        return None
+
+    parts = [f"<user>\n{user}\n</user>"]
+    if thinking:
+        parts.append(f"<thinking>\n{thinking}\n</thinking>")
+    parts.append(f"<assistant>\n{response}\n</assistant>")
+
+    text = "\n\n".join(parts)
+
+    return {
+        "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        "text": text,
+        "source": "andyrdt/gpt-oss-20b-rollouts",
+    }
+
+
+def transform(input_path: str, output_path: str) -> None:
+    input_files = [f"{input_path}/{subset}/{split}.jsonl" for subset, split in SUBSETS.items()]
+    pipeline = (
+        Dataset.from_list(input_files)
+        .flat_map(load_jsonl)
+        .map(row_to_doc)
+        .filter(lambda r: r is not None)
+        .write_jsonl(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz", skip_existing=True)
+    )
+    ctx = ZephyrContext(name="gpt-oss-rollouts-transform", resources=ResourceConfig(cpu=1, ram="8g"))
+    list(ctx.execute(pipeline))
+
+
+def download_gpt_oss_rollouts_step() -> StepSpec:
+    """Download and transform non-benchmark GPT-OSS-20B rollouts into JSONL documents."""
+    hf_urls_glob = []
+    for subset, split in SUBSETS.items():
+        hf_urls_glob.append(f"{subset}/{split}.jsonl")
+
+    dl = download_hf_step(
+        "raw/gpt-oss-20b-rollouts",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=hf_urls_glob,
+    )
+
+    return StepSpec(
+        name="processed/gpt-oss-20b-rollouts",
+        deps=[dl],
+        fn=lambda output_path: transform(
+            input_path=dl.output_path,
+            output_path=output_path,
+        ),
+        hash_attrs={"version": "v2"},
+    )

--- a/lib/marin/src/marin/datakit/download/gpt_oss_rollouts.py
+++ b/lib/marin/src/marin/datakit/download/gpt_oss_rollouts.py
@@ -13,7 +13,7 @@ assistant response. We render these into a single document.
 import hashlib
 
 from fray.v2 import ResourceConfig
-from zephyr import Dataset, ZephyrContext
+from zephyr import Dataset, ZephyrContext, counters
 from zephyr.readers import load_jsonl
 
 from marin.datakit.download.huggingface import download_hf_step
@@ -29,12 +29,13 @@ SUBSETS = {
 }
 
 
-def row_to_doc(row: dict) -> dict | None:
+def row_to_doc(row: dict) -> list[dict]:
     user = row.get("user_content") or ""
     thinking = row.get("assistant_thinking") or ""
     response = row.get("assistant_content") or ""
     if not user or not response:
-        return None
+        counters.increment("gpt_oss_rollouts/dropped")
+        return []
 
     parts = [f"<user>\n{user}\n</user>"]
     if thinking:
@@ -43,11 +44,14 @@ def row_to_doc(row: dict) -> dict | None:
 
     text = "\n\n".join(parts)
 
-    return {
-        "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
-        "text": text,
-        "source": "andyrdt/gpt-oss-20b-rollouts",
-    }
+    counters.increment("gpt_oss_rollouts/kept")
+    return [
+        {
+            "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "text": text,
+            "source": "andyrdt/gpt-oss-20b-rollouts",
+        }
+    ]
 
 
 def transform(input_path: str, output_path: str) -> None:
@@ -55,9 +59,8 @@ def transform(input_path: str, output_path: str) -> None:
     pipeline = (
         Dataset.from_list(input_files)
         .flat_map(load_jsonl)
-        .map(row_to_doc)
-        .filter(lambda r: r is not None)
-        .write_jsonl(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz", skip_existing=True)
+        .flat_map(row_to_doc)
+        .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
     )
     ctx = ZephyrContext(name="gpt-oss-rollouts-transform", resources=ResourceConfig(cpu=1, ram="8g"))
     list(ctx.execute(pipeline))

--- a/lib/marin/src/marin/datakit/download/nemotron_terminal.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_terminal.py
@@ -34,8 +34,7 @@ def row_to_doc(row: dict) -> dict | None:
     if not conversations:
         return None
 
-    rendered = "\n\n".join(render_message(m) for m in conversations)
-    text = rendered
+    text = "\n\n".join(render_message(m) for m in conversations)
 
     return {
         "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),

--- a/lib/marin/src/marin/datakit/download/nemotron_terminal.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_terminal.py
@@ -9,14 +9,12 @@ CLI tasks, with thinking traces.
 """
 
 import hashlib
-from collections.abc import Iterator
 
-import pyarrow.parquet as pq
 from fray.v2 import ResourceConfig
-from rigging.filesystem import open_url
-from zephyr import Dataset, ZephyrContext
+from zephyr import Dataset, ZephyrContext, counters
 
 from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.download.rollout_transforms import load_parquet_batched
 from marin.execution.step_spec import StepSpec
 
 HF_DATASET_ID = "nvidia/Nemotron-Terminal-Corpus"
@@ -29,39 +27,31 @@ def render_message(msg: dict) -> str:
     return f"<{role}>\n{content}\n</{role}>"
 
 
-def row_to_doc(row: dict) -> dict | None:
+def row_to_doc(row: dict) -> list[dict]:
     conversations = row.get("conversations")
     if not conversations:
-        return None
+        counters.increment("nemotron_terminal/dropped")
+        return []
 
     text = "\n\n".join(render_message(m) for m in conversations)
 
-    return {
-        "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
-        "text": text,
-        "source": "nvidia/Nemotron-Terminal-Corpus",
-    }
-
-
-def load_parquet_batched(path: str) -> Iterator[dict]:
-    """Read parquet via iter_batches — works around older pyarrow failing on nested list<struct> columns."""
-    with open_url(path, "rb") as f:
-        pf = pq.ParquetFile(f)
-        for batch in pf.iter_batches(batch_size=16):
-            rows = batch.to_pydict()
-            n = len(next(iter(rows.values())))
-            for i in range(n):
-                yield {k: rows[k][i] for k in rows}
+    counters.increment("nemotron_terminal/kept")
+    return [
+        {
+            "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "text": text,
+            "source": "nvidia/Nemotron-Terminal-Corpus",
+        }
+    ]
 
 
 def transform(input_path: str, output_path: str) -> None:
     pipeline = (
         Dataset.from_files(f"{input_path}/**/*.parquet")
         .flat_map(load_parquet_batched)
-        .map(row_to_doc)
-        .filter(lambda r: r is not None)
+        .flat_map(row_to_doc)
         .reshard(64)
-        .write_jsonl(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz", skip_existing=True)
+        .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
     )
     ctx = ZephyrContext(name="nemotron-terminal-transform", resources=ResourceConfig(cpu=1, ram="32g"))
     list(ctx.execute(pipeline))

--- a/lib/marin/src/marin/datakit/download/nemotron_terminal.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_terminal.py
@@ -1,0 +1,87 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""nvidia/Nemotron-Terminal-Corpus dataset download and transform.
+
+Terminal agent rollouts (command-line task solving). Each row contains a
+multi-turn conversation between a user and an AI assistant solving Linux
+CLI tasks, with thinking traces.
+"""
+
+import hashlib
+from collections.abc import Iterator
+
+import pyarrow.parquet as pq
+from fray.v2 import ResourceConfig
+from rigging.filesystem import open_url
+from zephyr import Dataset, ZephyrContext
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "nvidia/Nemotron-Terminal-Corpus"
+HF_REVISION = "a1667c4"
+
+
+def render_message(msg: dict) -> str:
+    role = msg.get("role", "unknown")
+    content = msg.get("content", "")
+    return f"<{role}>\n{content}\n</{role}>"
+
+
+def row_to_doc(row: dict) -> dict | None:
+    conversations = row.get("conversations")
+    if not conversations:
+        return None
+
+    rendered = "\n\n".join(render_message(m) for m in conversations)
+    text = rendered
+
+    return {
+        "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        "text": text,
+        "source": "nvidia/Nemotron-Terminal-Corpus",
+    }
+
+
+def load_parquet_batched(path: str) -> Iterator[dict]:
+    """Read parquet via iter_batches — works around older pyarrow failing on nested list<struct> columns."""
+    with open_url(path, "rb") as f:
+        pf = pq.ParquetFile(f)
+        for batch in pf.iter_batches(batch_size=16):
+            rows = batch.to_pydict()
+            n = len(next(iter(rows.values())))
+            for i in range(n):
+                yield {k: rows[k][i] for k in rows}
+
+
+def transform(input_path: str, output_path: str) -> None:
+    pipeline = (
+        Dataset.from_files(f"{input_path}/**/*.parquet")
+        .flat_map(load_parquet_batched)
+        .map(row_to_doc)
+        .filter(lambda r: r is not None)
+        .reshard(64)
+        .write_jsonl(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz", skip_existing=True)
+    )
+    ctx = ZephyrContext(name="nemotron-terminal-transform", resources=ResourceConfig(cpu=1, ram="32g"))
+    list(ctx.execute(pipeline))
+
+
+def download_nemotron_terminal_step() -> StepSpec:
+    """Download and transform Nemotron-Terminal-Corpus into JSONL documents."""
+    dl = download_hf_step(
+        "raw/nemotron-terminal-corpus",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+    )
+
+    return StepSpec(
+        name="processed/nemotron-terminal-corpus",
+        deps=[dl],
+        fn=lambda output_path: transform(
+            input_path=dl.output_path,
+            output_path=output_path,
+        ),
+        hash_attrs={"version": "v2"},
+    )

--- a/lib/marin/src/marin/datakit/download/principia.py
+++ b/lib/marin/src/marin/datakit/download/principia.py
@@ -10,7 +10,7 @@ answer, topic, and answer type. We render these into a single document.
 import hashlib
 
 from fray.v2 import ResourceConfig
-from zephyr import Dataset, ZephyrContext, load_parquet
+from zephyr import Dataset, ZephyrContext, counters, load_parquet
 
 from marin.datakit.download.huggingface import download_hf_step
 from marin.execution.step_spec import StepSpec
@@ -19,11 +19,12 @@ HF_DATASET_ID = "facebook/principia-collection"
 HF_REVISION = "f4413ee"
 
 
-def row_to_doc(row: dict) -> dict | None:
+def row_to_doc(row: dict) -> list[dict]:
     problem = row.get("problem_statement", "")
     answer = row.get("answer", "")
     if not problem or not answer:
-        return None
+        counters.increment("principia/dropped")
+        return []
 
     topic = row.get("topic", "")
     answer_type = row.get("answer_type", "")
@@ -39,20 +40,22 @@ def row_to_doc(row: dict) -> dict | None:
 
     text = "\n\n".join(parts)
 
-    return {
-        "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
-        "text": text,
-        "source": "facebook/principia-collection",
-    }
+    counters.increment("principia/kept")
+    return [
+        {
+            "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "text": text,
+            "source": "facebook/principia-collection",
+        }
+    ]
 
 
 def transform(input_path: str, output_path: str) -> None:
     pipeline = (
         Dataset.from_files(f"{input_path}/**/*.parquet")
         .flat_map(load_parquet)
-        .map(row_to_doc)
-        .filter(lambda r: r is not None)
-        .write_jsonl(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz", skip_existing=True)
+        .flat_map(row_to_doc)
+        .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
     )
     ctx = ZephyrContext(name="principia-transform", resources=ResourceConfig(cpu=1, ram="4g"))
     list(ctx.execute(pipeline))

--- a/lib/marin/src/marin/datakit/download/principia.py
+++ b/lib/marin/src/marin/datakit/download/principia.py
@@ -1,0 +1,77 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""facebook/principia-collection dataset download and transform.
+
+GPT-OSS-generated math problems with answers. Each row has a problem statement,
+answer, topic, and answer type. We render these into a single document.
+"""
+
+import hashlib
+
+from fray.v2 import ResourceConfig
+from zephyr import Dataset, ZephyrContext, load_parquet
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "facebook/principia-collection"
+HF_REVISION = "f4413ee"
+
+
+def row_to_doc(row: dict) -> dict | None:
+    problem = row.get("problem_statement", "")
+    answer = row.get("answer", "")
+    if not problem or not answer:
+        return None
+
+    topic = row.get("topic", "")
+    answer_type = row.get("answer_type", "")
+
+    parts = []
+    if topic:
+        parts.append(f"Topic: {topic}")
+    parts.append(problem)
+    if answer_type:
+        parts.append(f"Answer ({answer_type}): {answer}")
+    else:
+        parts.append(f"Answer: {answer}")
+
+    text = "\n\n".join(parts)
+
+    return {
+        "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        "text": text,
+        "source": "facebook/principia-collection",
+    }
+
+
+def transform(input_path: str, output_path: str) -> None:
+    pipeline = (
+        Dataset.from_files(f"{input_path}/**/*.parquet")
+        .flat_map(load_parquet)
+        .map(row_to_doc)
+        .filter(lambda r: r is not None)
+        .write_jsonl(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz", skip_existing=True)
+    )
+    ctx = ZephyrContext(name="principia-transform", resources=ResourceConfig(cpu=1, ram="4g"))
+    list(ctx.execute(pipeline))
+
+
+def download_principia_step() -> StepSpec:
+    """Download and transform facebook/principia-collection into JSONL documents."""
+    dl = download_hf_step(
+        "raw/principia-collection",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+    )
+
+    return StepSpec(
+        name="processed/principia-collection",
+        deps=[dl],
+        fn=lambda output_path: transform(
+            input_path=dl.output_path,
+            output_path=output_path,
+        ),
+        hash_attrs={"version": "v1"},
+    )

--- a/lib/marin/src/marin/datakit/download/rollout_transforms.py
+++ b/lib/marin/src/marin/datakit/download/rollout_transforms.py
@@ -1,0 +1,24 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared transform helpers for rollout dataset pipelines."""
+
+from collections.abc import Iterator
+
+import pyarrow.parquet as pq
+from rigging.filesystem import open_url
+
+
+def load_parquet_batched(path: str) -> Iterator[dict]:
+    """Read parquet via iter_batches to avoid OOM on large nested-struct columns."""
+    with open_url(path, "rb") as f:
+        pf = pq.ParquetFile(f)
+        for batch in pf.iter_batches(batch_size=16):
+            rows = batch.to_pydict()
+            n = len(next(iter(rows.values())))
+            for i in range(n):
+                yield {k: rows[k][i] for k in rows}
+
+
+def strip_think_tags(text: str) -> str:
+    return text.replace("<think>", "").replace("</think>", "").strip()

--- a/lib/marin/src/marin/datakit/download/superior_reasoning.py
+++ b/lib/marin/src/marin/datakit/download/superior_reasoning.py
@@ -1,0 +1,81 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Alibaba-Apsara/Superior-Reasoning-SFT-gpt-oss-120b dataset download and transform.
+
+GPT-OSS-120B reasoning rollouts with chain-of-thought in <think> tags.
+Each row has a math prompt and a model response with reasoning traces.
+"""
+
+import hashlib
+
+from fray.v2 import ResourceConfig
+from zephyr import Dataset, ZephyrContext
+from zephyr.readers import load_jsonl
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "Alibaba-Apsara/Superior-Reasoning-SFT-gpt-oss-120b"
+HF_REVISION = "21b55a6"
+
+STAGES = [
+    "Superior-Reasoning-SFT-gpt-oss-120b-stage1-train-data.jsonl",
+    "Superior-Reasoning-SFT-gpt-oss-120b-stage2-train-data.jsonl",
+]
+
+
+def strip_think_tags(text: str) -> str:
+    return text.replace("<think>", "").replace("</think>", "").strip()
+
+
+def row_to_doc(row: dict) -> dict | None:
+    prompt = row.get("input") or ""
+    response = row.get("output") or ""
+    if not prompt or not response:
+        return None
+
+    response = strip_think_tags(response)
+    if not response:
+        return None
+
+    text = f"<user>\n{prompt}\n</user>\n\n<assistant>\n{response}\n</assistant>"
+
+    return {
+        "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        "text": text,
+        "source": "Alibaba-Apsara/Superior-Reasoning-SFT-gpt-oss-120b",
+    }
+
+
+def transform(input_path: str, output_path: str) -> None:
+    input_files = [f"{input_path}/{stage}" for stage in STAGES]
+    pipeline = (
+        Dataset.from_list(input_files)
+        .flat_map(load_jsonl)
+        .map(row_to_doc)
+        .filter(lambda r: r is not None)
+        .write_jsonl(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz", skip_existing=True)
+    )
+    ctx = ZephyrContext(name="superior-reasoning-transform", resources=ResourceConfig(cpu=1, ram="8g"))
+    list(ctx.execute(pipeline))
+
+
+def download_superior_reasoning_step() -> StepSpec:
+    """Download and transform Superior-Reasoning-SFT-gpt-oss-120b into JSONL documents."""
+    dl = download_hf_step(
+        "raw/superior-reasoning-sft",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=[stage for stage in STAGES],
+    )
+
+    return StepSpec(
+        name="processed/superior-reasoning-sft",
+        deps=[dl],
+        fn=lambda output_path: transform(
+            input_path=dl.output_path,
+            output_path=output_path,
+        ),
+        hash_attrs={"version": "v1"},
+    )

--- a/lib/marin/src/marin/datakit/download/superior_reasoning.py
+++ b/lib/marin/src/marin/datakit/download/superior_reasoning.py
@@ -67,7 +67,7 @@ def download_superior_reasoning_step() -> StepSpec:
         "raw/superior-reasoning-sft",
         hf_dataset_id=HF_DATASET_ID,
         revision=HF_REVISION,
-        hf_urls_glob=[stage for stage in STAGES],
+        hf_urls_glob=STAGES,
     )
 
     return StepSpec(

--- a/lib/marin/src/marin/datakit/download/superior_reasoning.py
+++ b/lib/marin/src/marin/datakit/download/superior_reasoning.py
@@ -10,10 +10,11 @@ Each row has a math prompt and a model response with reasoning traces.
 import hashlib
 
 from fray.v2 import ResourceConfig
-from zephyr import Dataset, ZephyrContext
+from zephyr import Dataset, ZephyrContext, counters
 from zephyr.readers import load_jsonl
 
 from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.download.rollout_transforms import strip_think_tags
 from marin.execution.step_spec import StepSpec
 
 HF_DATASET_ID = "Alibaba-Apsara/Superior-Reasoning-SFT-gpt-oss-120b"
@@ -25,27 +26,28 @@ STAGES = [
 ]
 
 
-def strip_think_tags(text: str) -> str:
-    return text.replace("<think>", "").replace("</think>", "").strip()
-
-
-def row_to_doc(row: dict) -> dict | None:
+def row_to_doc(row: dict) -> list[dict]:
     prompt = row.get("input") or ""
     response = row.get("output") or ""
     if not prompt or not response:
-        return None
+        counters.increment("superior_reasoning/dropped")
+        return []
 
     response = strip_think_tags(response)
     if not response:
-        return None
+        counters.increment("superior_reasoning/dropped")
+        return []
 
     text = f"<user>\n{prompt}\n</user>\n\n<assistant>\n{response}\n</assistant>"
 
-    return {
-        "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
-        "text": text,
-        "source": "Alibaba-Apsara/Superior-Reasoning-SFT-gpt-oss-120b",
-    }
+    counters.increment("superior_reasoning/kept")
+    return [
+        {
+            "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "text": text,
+            "source": "Alibaba-Apsara/Superior-Reasoning-SFT-gpt-oss-120b",
+        }
+    ]
 
 
 def transform(input_path: str, output_path: str) -> None:
@@ -53,9 +55,8 @@ def transform(input_path: str, output_path: str) -> None:
     pipeline = (
         Dataset.from_list(input_files)
         .flat_map(load_jsonl)
-        .map(row_to_doc)
-        .filter(lambda r: r is not None)
-        .write_jsonl(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz", skip_existing=True)
+        .flat_map(row_to_doc)
+        .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
     )
     ctx = ZephyrContext(name="superior-reasoning-transform", resources=ResourceConfig(cpu=1, ram="8g"))
     list(ctx.execute(pipeline))

--- a/lib/marin/src/marin/datakit/download/swe_rebench_openhands.py
+++ b/lib/marin/src/marin/datakit/download/swe_rebench_openhands.py
@@ -1,0 +1,95 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""nebius/SWE-rebench-openhands-trajectories dataset download and transform.
+
+OpenHands agent trajectories on SWE-rebench tasks. Each row contains a
+multi-turn conversation (system, assistant, user, tool roles) along with
+a resolved flag indicating whether the trajectory solved the issue.
+"""
+
+import hashlib
+from collections.abc import Iterator
+
+import pyarrow.parquet as pq
+from fray.v2 import ResourceConfig
+from rigging.filesystem import open_url
+from zephyr import Dataset, ZephyrContext
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "nebius/SWE-rebench-openhands-trajectories"
+HF_REVISION = "3545538"
+
+
+def resolved_to_tag(resolved: int | None) -> str | None:
+    if resolved is None:
+        return None
+    if resolved >= 1:
+        return "This trajectory solved the task successfully."
+    return "This trajectory failed to solve the task."
+
+
+def render_message(msg: dict) -> str:
+    role = msg.get("role", "unknown")
+    content = msg.get("content") or ""
+    return f"<{role}>\n{content}\n</{role}>"
+
+
+def row_to_doc(row: dict) -> dict | None:
+    trajectory = row.get("trajectory")
+    if not trajectory:
+        return None
+
+    tag = resolved_to_tag(row.get("resolved"))
+    rendered = "\n\n".join(render_message(m) for m in trajectory)
+    text = f"{tag}\n\n{rendered}" if tag else rendered
+
+    return {
+        "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        "text": text,
+        "source": "nebius/SWE-rebench-openhands-trajectories",
+    }
+
+
+def load_parquet_batched(path: str) -> Iterator[dict]:
+    """Read parquet via iter_batches to avoid OOM on large nested-struct columns."""
+    with open_url(path, "rb") as f:
+        pf = pq.ParquetFile(f)
+        for batch in pf.iter_batches(batch_size=16):
+            rows = batch.to_pydict()
+            n = len(next(iter(rows.values())))
+            for i in range(n):
+                yield {k: rows[k][i] for k in rows}
+
+
+def transform(input_path: str, output_path: str) -> None:
+    pipeline = (
+        Dataset.from_files(f"{input_path}/**/*.parquet")
+        .flat_map(load_parquet_batched)
+        .map(row_to_doc)
+        .filter(lambda r: r is not None)
+        .write_jsonl(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz", skip_existing=True)
+    )
+    ctx = ZephyrContext(name="swe-rebench-openhands-transform", resources=ResourceConfig(cpu=1, ram="32g"))
+    list(ctx.execute(pipeline))
+
+
+def download_swe_rebench_openhands_step() -> StepSpec:
+    """Download and transform SWE-rebench-openhands-trajectories into JSONL documents."""
+    dl = download_hf_step(
+        "raw/swe-rebench-openhands-trajectories",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+    )
+
+    return StepSpec(
+        name="processed/swe-rebench-openhands-trajectories",
+        deps=[dl],
+        fn=lambda output_path: transform(
+            input_path=dl.output_path,
+            output_path=output_path,
+        ),
+        hash_attrs={"version": "v2"},
+    )

--- a/lib/marin/src/marin/datakit/download/swe_rebench_openhands.py
+++ b/lib/marin/src/marin/datakit/download/swe_rebench_openhands.py
@@ -9,14 +9,12 @@ a resolved flag indicating whether the trajectory solved the issue.
 """
 
 import hashlib
-from collections.abc import Iterator
 
-import pyarrow.parquet as pq
 from fray.v2 import ResourceConfig
-from rigging.filesystem import open_url
-from zephyr import Dataset, ZephyrContext
+from zephyr import Dataset, ZephyrContext, counters
 
 from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.download.rollout_transforms import load_parquet_batched
 from marin.execution.step_spec import StepSpec
 
 HF_DATASET_ID = "nebius/SWE-rebench-openhands-trajectories"
@@ -37,40 +35,32 @@ def render_message(msg: dict) -> str:
     return f"<{role}>\n{content}\n</{role}>"
 
 
-def row_to_doc(row: dict) -> dict | None:
+def row_to_doc(row: dict) -> list[dict]:
     trajectory = row.get("trajectory")
     if not trajectory:
-        return None
+        counters.increment("swe_rebench_openhands/dropped")
+        return []
 
     tag = resolved_to_tag(row.get("resolved"))
     rendered = "\n\n".join(render_message(m) for m in trajectory)
     text = f"{tag}\n\n{rendered}" if tag else rendered
 
-    return {
-        "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
-        "text": text,
-        "source": "nebius/SWE-rebench-openhands-trajectories",
-    }
-
-
-def load_parquet_batched(path: str) -> Iterator[dict]:
-    """Read parquet via iter_batches to avoid OOM on large nested-struct columns."""
-    with open_url(path, "rb") as f:
-        pf = pq.ParquetFile(f)
-        for batch in pf.iter_batches(batch_size=16):
-            rows = batch.to_pydict()
-            n = len(next(iter(rows.values())))
-            for i in range(n):
-                yield {k: rows[k][i] for k in rows}
+    counters.increment("swe_rebench_openhands/kept")
+    return [
+        {
+            "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "text": text,
+            "source": "nebius/SWE-rebench-openhands-trajectories",
+        }
+    ]
 
 
 def transform(input_path: str, output_path: str) -> None:
     pipeline = (
         Dataset.from_files(f"{input_path}/**/*.parquet")
         .flat_map(load_parquet_batched)
-        .map(row_to_doc)
-        .filter(lambda r: r is not None)
-        .write_jsonl(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz", skip_existing=True)
+        .flat_map(row_to_doc)
+        .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
     )
     ctx = ZephyrContext(name="swe-rebench-openhands-transform", resources=ResourceConfig(cpu=1, ram="32g"))
     list(ctx.execute(pipeline))

--- a/lib/marin/src/marin/datakit/download/synthetic1.py
+++ b/lib/marin/src/marin/datakit/download/synthetic1.py
@@ -10,9 +10,10 @@ single document by concatenating prompt + score tag + response.
 import hashlib
 
 from fray.v2 import ResourceConfig
-from zephyr import Dataset, ZephyrContext, load_parquet
+from zephyr import Dataset, ZephyrContext, counters, load_parquet
 
 from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.download.rollout_transforms import strip_think_tags
 from marin.execution.step_spec import StepSpec
 
 HF_DATASET_ID = "PrimeIntellect/SYNTHETIC-1"
@@ -37,37 +38,37 @@ def score_to_tag(score: float | None) -> str:
     return "This is an incorrect solution."
 
 
-def strip_think_tags(text: str) -> str:
-    return text.replace("<think>", "").replace("</think>", "").strip()
-
-
-def row_to_doc(row: dict) -> dict | None:
+def row_to_doc(row: dict) -> list[dict]:
     prompt = row.get("prompt", "")
     response = row.get("llm_response", "")
     if not prompt or not response:
-        return None
+        counters.increment("synthetic1/dropped")
+        return []
 
     response = strip_think_tags(response)
     if not response.strip():
-        return None
+        counters.increment("synthetic1/dropped")
+        return []
 
     tag = score_to_tag(row.get("score"))
     text = f"{prompt}\n\n{tag}\n\n{response}"
 
-    return {
-        "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
-        "text": text,
-        "source": "PrimeIntellect/SYNTHETIC-1",
-    }
+    counters.increment("synthetic1/kept")
+    return [
+        {
+            "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "text": text,
+            "source": "PrimeIntellect/SYNTHETIC-1",
+        }
+    ]
 
 
 def transform(input_path: str, output_path: str) -> None:
     pipeline = (
         Dataset.from_files(f"{input_path}/**/*.parquet")
         .flat_map(load_parquet)
-        .map(row_to_doc)
-        .filter(lambda r: r is not None)
-        .write_jsonl(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz", skip_existing=True)
+        .flat_map(row_to_doc)
+        .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
     )
     ctx = ZephyrContext(name="synthetic1-transform", resources=ResourceConfig(cpu=1, ram="4g"))
     list(ctx.execute(pipeline))

--- a/lib/marin/src/marin/datakit/download/synthetic1.py
+++ b/lib/marin/src/marin/datakit/download/synthetic1.py
@@ -1,14 +1,10 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""PrimeIntellect/SYNTHETIC-1 pretraining dataset.
+"""PrimeIntellect/SYNTHETIC-1 dataset download and transform.
 
-Each row has a prompt, an LLM chain-of-thought rollout, and a real-valued score.
-We concat prompt + score tag + rollout into a single document so the model learns
-to distinguish correct and incorrect reasoning traces.
-
-Usage:
-    uv run lib/marin/src/marin/run/ray_run.py -- python experiments/synthetic1.py
+Downloads raw parquet files from HuggingFace, then transforms each row into a
+single document by concatenating prompt + score tag + response.
 """
 
 import hashlib
@@ -17,10 +13,7 @@ from fray.v2 import ResourceConfig
 from zephyr import Dataset, ZephyrContext, load_parquet
 
 from marin.datakit.download.huggingface import download_hf_step
-from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
-from marin.processing.tokenize import TokenizeConfig, tokenize
-from experiments.marin_models import marin_tokenizer
 
 HF_DATASET_ID = "PrimeIntellect/SYNTHETIC-1"
 HF_REVISION = "f08fe8c"
@@ -80,14 +73,15 @@ def transform(input_path: str, output_path: str) -> None:
     list(ctx.execute(pipeline))
 
 
-def build_steps() -> list[StepSpec]:
+def download_synthetic1_step() -> StepSpec:
+    """Download and transform PrimeIntellect/SYNTHETIC-1 into JSONL documents."""
     dl = download_hf_step(
         "raw/synthetic-1",
         hf_dataset_id=HF_DATASET_ID,
         revision=HF_REVISION,
     )
 
-    transformed = StepSpec(
+    return StepSpec(
         name="processed/synthetic-1",
         deps=[dl],
         fn=lambda output_path: transform(
@@ -96,21 +90,3 @@ def build_steps() -> list[StepSpec]:
         ),
         hash_attrs={"version": "v1"},
     )
-
-    tokenized = StepSpec(
-        name="tokenized/synthetic-1",
-        deps=[transformed],
-        fn=lambda output_path: tokenize(TokenizeConfig(
-            train_paths=[transformed.output_path],
-            validation_paths=[],
-            cache_path=output_path,
-            tokenizer=marin_tokenizer,
-        )),
-        hash_attrs={"tokenizer": marin_tokenizer},
-    )
-
-    return [dl, transformed, tokenized]
-
-
-if __name__ == "__main__":
-    StepRunner().run(build_steps())


### PR DESCRIPTION
## Summary

🤖 *PR text generated by Claude Code*

- Adds download-and-transform pipelines for 6 HuggingFace rollout/reasoning datasets:
  - **CoderForge-Preview** (togethercomputer) — coding agent trajectories with reward tags
  - **GPT-OSS-20B rollouts** (andyrdt) — reasoning chains from non-benchmark subsets
  - **Nemotron-Terminal-Corpus** (nvidia) — terminal agent CLI rollouts
  - **Principia-Collection** (facebook) — GPT-OSS math problems with answers
  - **Superior-Reasoning-SFT** (Alibaba-Apsara) — GPT-OSS-120B reasoning rollouts
  - **SYNTHETIC-1** (PrimeIntellect) — scored reasoning rollouts
- Each dataset gets a download module (`lib/marin/src/marin/datakit/download/`) and an experiment script (`experiments/rollout_data/`)
- All HF revisions are pinned for reproducibility

## Test plan

- [ ] Run each experiment script in dry-run mode to verify step graph construction
- [ ] Spot-check one dataset end-to-end (download → transform → tokenize)
- [ ] Verify tokenized output loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)