### PR TITLE
[tokenize] Add cache copy worker cap

### DIFF
--- a/experiments/ferries/canary_ferry.py
+++ b/experiments/ferries/canary_ferry.py
@@ -9,6 +9,7 @@ to the Iris container. workflow_dispatch inputs override CANARY_TARGET_TOKENS.
 
     CANARY_ACCELERATOR   tpu | gpu
     CANARY_BATCH_SIZE    per-device batch size
+    CANARY_CACHE_COPY_MAX_WORKERS gpu-only cache-copy worker cap
     CANARY_TARGET_TOKENS total training tokens
     RUN_ID               unique run identifier
 """
@@ -81,6 +82,7 @@ def _build_step_from_env() -> ExecutorStep:
     else:
         multi_host = os.environ.get("CANARY_MULTI_HOST", "").lower() in ("1", "true")
         batch_size = _env_int("CANARY_BATCH_SIZE", 32)
+        cache_copy_max_workers = _env_int("CANARY_CACHE_COPY_MAX_WORKERS", 12)
         target_tokens = _env_int("CANARY_TARGET_TOKENS", batch_size * GRUG_MOE_TRIAL_MODEL.max_seq_len * 50)
         # SlimPajama-6B with block-shuffle — small dataset, re-tokenized on first run.
         tokenize_step = default_tokenize(
@@ -95,6 +97,7 @@ def _build_step_from_env() -> ExecutorStep:
                 tokenize_step.config,
                 # SlimPajama-6B tokenization OOMs at the default 10g worker_resources.
                 worker_resources=ResourceConfig(ram="64g", disk="64g"),
+                cache_copy_max_workers=cache_copy_max_workers,
             ),
         )
         data = lm_data_config(

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -398,6 +398,7 @@ def consolidate_shard_caches(
     output_path: str,
     exemplar,
     metadata: CacheMetadata | None = None,
+    copy_max_workers: int = 128,
 ) -> CacheLedger:
     """
     Consolidate multiple shard caches into a single cache directory.
@@ -407,9 +408,12 @@ def consolidate_shard_caches(
         output_path: Destination cache directory.
         exemplar: Output exemplar structure.
         metadata: CacheMetadata to use for the final ledger.
+        copy_max_workers: Maximum Zephyr fanout for the cache copy phase.
     """
     if metadata is None:
         metadata = CacheMetadata.empty()
+    if copy_max_workers < 1:
+        raise ValueError(f"copy_max_workers must be positive, got {copy_max_workers}")
 
     if not shard_cache_paths:
         ledger = CacheLedger(
@@ -467,7 +471,7 @@ def consolidate_shard_caches(
 
     ctx = ZephyrContext(
         resources=ResourceConfig(ram="32g", disk="16g"),
-        max_workers=min(128, len(shard_info)),
+        max_workers=min(copy_max_workers, len(shard_info)),
         name="levanter-cache-copy",
     )
     ctx.execute(

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -65,6 +65,7 @@ class TokenizeConfigBase(abc.ABC):
     """Base class for tokenize configs."""
 
     max_workers: int = 4096
+    cache_copy_max_workers: int = 128
     worker_resources: ResourceConfig = dataclasses.field(default_factory=lambda: ResourceConfig(ram="10g", disk="5g"))
 
     num_shards: int | None = None
@@ -402,7 +403,12 @@ def tokenize(config: TokenizeConfigBase):
 
         consolidate_start = time.monotonic()
         logger.info(f"Consolidating {len(shard_paths)} shards into {prefix}")
-        ledger = consolidate_shard_caches(shard_cache_paths=shard_paths, output_path=prefix, exemplar=exemplar)
+        ledger = consolidate_shard_caches(
+            shard_cache_paths=shard_paths,
+            output_path=prefix,
+            exemplar=exemplar,
+            copy_max_workers=config.cache_copy_max_workers,
+        )
         consolidate_elapsed = time.monotonic() - consolidate_start
 
         total_elements = ledger.total_num_rows

--- a/tests/test_consolidate_metadata.py
+++ b/tests/test_consolidate_metadata.py
@@ -141,7 +141,7 @@ def test_consolidate_shard_caches_end_to_end():
             shard_paths.append(shard_path)
 
         dest_path = os.path.join(tmpdir, "merged")
-        ledger = consolidate_shard_caches(shard_paths, dest_path, EXEMPLAR_FLAT)
+        ledger = consolidate_shard_caches(shard_paths, dest_path, EXEMPLAR_FLAT, copy_max_workers=1)
 
         assert ledger.total_num_rows == NUM_SHARDS * ROWS_PER_SHARD
         assert ledger.is_finished


### PR DESCRIPTION
Thread a cache-copy worker cap through tokenization into Levanter cache consolidation. Surface the knob in the CoreWeave canary ferry so GPU runs can lower consolidation fanout on smaller CPU clusters.


<details>
<summary>Why surface <code>CANARY_CACHE_COPY_MAX_WORKERS</code>?</summary>

The underlying issue is not the main tokenize fanout. It is the later `levanter-cache-copy` consolidation phase, which currently defaults to a 128-worker CPU Zephyr pool.

On the recent CoreWeave GPU canary investigation, that phase ran on a much smaller eligible CPU pool than 128. In practice we only had capacity for roughly a dozen to a few dozen workers, so the copy phase spent most of its tasks pending and eventually failed in a way that looked like a cache-copy fanout mismatch rather than a bad shard.

Surfacing the knob in the CoreWeave canary path does two things:

- It keeps the library default at 128 for higher-capacity environments.
- It gives the CW canary an explicit, reviewable override for the smaller CPU cluster it actually runs on.

So the goal is not to make cache copy generally configurable for its own sake. The goal is to let the same tokenization code run with a smaller consolidation fanout on CW without forcing that lower value onto GCP or other larger-capacity runs.
</details>