### PR TITLE
[iris] Classify OOMKilled as application failure, not infrastructure

### DIFF
--- a/lib/iris/src/iris/cluster/providers/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/tasks.py
@@ -69,11 +69,12 @@ _K8S_LABEL_MAX_LEN = 63
 _POD_NOT_FOUND_GRACE_CYCLES = 3
 
 # Kubernetes terminated reasons that indicate infrastructure failure (not application error).
-# OOMKilled: container exceeded memory limits or node ran out of memory.
 # Evicted: kubelet evicted the pod due to resource pressure.
 # DeadlineExceeded: pod's activeDeadlineSeconds expired.
 # Preempting: scheduler preempted the pod for a higher-priority workload.
-_INFRASTRUCTURE_FAILURE_REASONS = frozenset({"OOMKilled", "Evicted", "DeadlineExceeded", "Preempting"})
+# NOTE: OOMKilled is intentionally excluded — it indicates a misconfigured job
+# (requesting too little memory), not transient infrastructure failure.
+_INFRASTRUCTURE_FAILURE_REASONS = frozenset({"Evicted", "DeadlineExceeded", "Preempting"})
 
 
 def _constraints_to_node_selector(
@@ -500,8 +501,8 @@ def _is_infrastructure_failure(pod: dict) -> bool:
 def _task_update_from_pod(entry: RunningTaskEntry, pod: dict) -> TaskUpdate:
     """Build a TaskUpdate from a Kubernetes Pod dict.
 
-    Infrastructure failures (OOMKilled, eviction) are reported as WORKER_FAILED
-    so they count against max_retries_preemption (default: 100).
+    Infrastructure failures (eviction, preemption) are reported as WORKER_FAILED
+    so they count against max_retries_preemption.
     Application failures (non-zero exit code) are reported as FAILED so they
     count against max_retries_failure (default: 0, no retries).
     """

--- a/lib/iris/tests/cluster/providers/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_pod_manifest.py
@@ -177,11 +177,20 @@ def test_task_update_failed_has_exit_code():
 
 @pytest.mark.parametrize("reason", sorted(_INFRASTRUCTURE_FAILURE_REASONS))
 def test_task_update_infrastructure_failure_is_worker_failed(reason):
-    """OOMKilled, Evicted, etc. should be WORKER_FAILED, not FAILED."""
+    """Evicted, Preempting, etc. should be WORKER_FAILED, not FAILED."""
     entry = RunningTaskEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0)
     pod = make_pod("iris-job-0-0", "Failed", exit_code=137, reason=reason)
     update = _task_update_from_pod(entry, pod)
     assert update.new_state == cluster_pb2.TASK_STATE_WORKER_FAILED
+    assert update.exit_code == 137
+
+
+def test_task_update_oom_killed_is_application_failure():
+    """OOMKilled is a misconfiguration, not infrastructure — should be FAILED."""
+    entry = RunningTaskEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0)
+    pod = make_pod("iris-job-0-0", "Failed", exit_code=137, reason="OOMKilled")
+    update = _task_update_from_pod(entry, pod)
+    assert update.new_state == cluster_pb2.TASK_STATE_FAILED
     assert update.exit_code == 137
 
 
@@ -201,11 +210,6 @@ def test_is_infrastructure_failure_with_pod_level_reason():
         "status": {"phase": "Failed", "reason": "Evicted", "containerStatuses": []},
     }
     assert _is_infrastructure_failure(pod)
-
-
-def test_is_infrastructure_failure_false_for_application_error():
-    pod = make_pod("test", "Failed", exit_code=1, reason="Error")
-    assert not _is_infrastructure_failure(pod)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
OOMKilled was grouped with Evicted/Preempting in _INFRASTRUCTURE_FAILURE_REASONS,
so OOM pods retried against max_retries_preemption (default 10000) instead of
max_retries_failure (default 0). A memory-misconfigured job would loop thousands
of times before surfacing as failed. Moves OOMKilled out of the infra set so it
is classified as TASK_STATE_FAILED and fails immediately by default.