### PR TITLE
[zephyr] Use local temp + put for S3 atomic writes

### DIFF
--- a/lib/zephyr/src/zephyr/writers.py
+++ b/lib/zephyr/src/zephyr/writers.py
@@ -72,7 +72,12 @@ def atomic_rename(output_path: str) -> Iterable[str]:
         with tempfile.TemporaryDirectory() as local_tmp_dir:
             local_path = os.path.join(local_tmp_dir, "output")
             yield local_path
-            fs.put(local_path, resolved_path, recursive=True)
+            if os.path.isdir(local_path):
+                # Trailing slash prevents fsspec from nesting under an extra
+                # "output/" level when the destination already exists.
+                fs.put(local_path + "/", resolved_path, recursive=True)
+            else:
+                fs.put(local_path, resolved_path)
         return
 
     temp_path = unique_temp_path(output_path)

--- a/lib/zephyr/tests/test_writers.py
+++ b/lib/zephyr/tests/test_writers.py
@@ -3,6 +3,7 @@
 
 """Tests for writers module."""
 
+import os
 import tempfile
 from pathlib import Path
 
@@ -184,6 +185,49 @@ def test_write_levanter_cache_end_to_end():
         assert len(store) == len(records)
         assert store[0]["input_ids"].tolist() == records[0]["input_ids"]
         assert store[len(records) - 1]["input_ids"].tolist() == records[len(records) - 1]["input_ids"]
+
+
+def test_atomic_rename_s3_directory_preserves_layout(tmp_path):
+    """S3 atomic_rename must not add extra nesting for directory outputs.
+
+    When the yielded path is used as a directory (e.g. by write_levanter_cache),
+    fs.put must place contents directly at the destination — not under an extra
+    ``output/`` subdirectory.  fsspec nests when the source has no trailing
+    slash and the destination already exists, so atomic_rename must account for
+    that.
+    """
+    from unittest.mock import patch
+    from fsspec.implementations.local import LocalFileSystem
+
+    dest = tmp_path / "dest"
+    dest.mkdir()  # pre-create so fsspec considers it "existing"
+    local_fs = LocalFileSystem()
+
+    with patch("zephyr.writers.url_to_fs", return_value=(local_fs, str(dest))):
+        with atomic_rename("s3://bucket/dest") as local_path:
+            os.makedirs(local_path)
+            (Path(local_path) / "shard_0.bin").write_bytes(b"data0")
+            (Path(local_path) / "shard_1.bin").write_bytes(b"data1")
+
+    assert (dest / "shard_0.bin").exists(), "shard_0.bin should be directly under dest"
+    assert (dest / "shard_1.bin").exists(), "shard_1.bin should be directly under dest"
+    assert not (dest / "output").exists(), "should not have extra 'output' nesting"
+
+
+def test_atomic_rename_s3_single_file(tmp_path):
+    """S3 atomic_rename works correctly for single-file outputs."""
+    from unittest.mock import patch
+    from fsspec.implementations.local import LocalFileSystem
+
+    dest = tmp_path / "output.jsonl"
+    local_fs = LocalFileSystem()
+
+    with patch("zephyr.writers.url_to_fs", return_value=(local_fs, str(dest))):
+        with atomic_rename("s3://bucket/output.jsonl") as local_path:
+            Path(local_path).write_text("line1\nline2\n")
+
+    assert dest.exists()
+    assert dest.read_text() == "line1\nline2\n"
 
 
 def test_infer_arrow_schema_basic():


### PR DESCRIPTION
## Summary
- Adds S3-compatible path to `atomic_rename` in zephyr writers
- Writes to a local temp directory first, then uploads via `fs.put()` to avoid unreliable server-side multipart copy on providers like Cloudflare R2

## Test plan
- [ ] Verify writes to S3/R2 complete without multipart copy errors
- [ ] Verify GCS and local paths still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)