### PR TITLE
Remove CW interruptable toleration from GPU worker pods

### DIFF
--- a/lib/iris/src/iris/cluster/providers/k8s/constants.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/constants.py
@@ -3,14 +3,6 @@
 
 """Shared Kubernetes constants for Iris cluster components."""
 
-# CoreWeave GPU nodes carry this taint. All pods targeting GPU nodes must
-# tolerate it or they will remain Pending / be evicted.
-CW_INTERRUPTABLE_TOLERATION: dict = {
-    "key": "qos.coreweave.cloud/interruptable",
-    "operator": "Exists",
-    "effect": "NoExecute",
-}
-
 # NVIDIA GPU nodes commonly carry this taint. Pods requesting GPUs must
 # tolerate it or they will remain Pending.
 NVIDIA_GPU_TOLERATION: dict = {

--- a/lib/iris/src/iris/cluster/providers/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/tasks.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from iris.cluster.controller.transitions import ClusterCapacity, DirectProviderSyncResult, SchedulingEvent
 from iris.cluster.controller.transitions import DirectProviderBatch, RunningTaskEntry, TaskUpdate
 from iris.cluster.log_store._types import LogStoreProtocol, TaskAttempt, task_log_key
-from iris.cluster.providers.k8s.constants import CW_INTERRUPTABLE_TOLERATION, NVIDIA_GPU_TOLERATION
+from iris.cluster.providers.k8s.constants import NVIDIA_GPU_TOLERATION
 from iris.cluster.providers.k8s.service import K8sService
 from iris.cluster.providers.k8s.types import KubectlError, KubectlLogLine, parse_k8s_quantity
 from iris.cluster.runtime.env import build_common_iris_env, normalize_workdir_relative_path
@@ -430,12 +430,7 @@ def _build_pod_manifest(
         spec["nodeSelector"] = node_selector
 
     if gpu_count > 0:
-        spec.setdefault("tolerations", []).extend(
-            [
-                CW_INTERRUPTABLE_TOLERATION,
-                NVIDIA_GPU_TOLERATION,
-            ]
-        )
+        spec.setdefault("tolerations", []).append(NVIDIA_GPU_TOLERATION)
 
     if service_account:
         spec["serviceAccountName"] = service_account

--- a/lib/iris/tests/cluster/providers/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_pod_manifest.py
@@ -313,7 +313,7 @@ def test_build_pod_manifest_no_gpu_no_toleration():
 
 
 def test_nvidia_gpu_toleration_added():
-    """GPU pods get both CW interruptable and NVIDIA GPU tolerations."""
+    """GPU pods get NVIDIA GPU toleration."""
     req = make_run_req("/my-job/task-0")
     req.resources.device.gpu.CopyFrom(cluster_pb2.GpuDevice(variant="A100", count=4))
 
@@ -321,7 +321,7 @@ def test_nvidia_gpu_toleration_added():
     tolerations = manifest["spec"].get("tolerations", [])
     toleration_keys = {t.get("key") for t in tolerations}
     assert "nvidia.com/gpu" in toleration_keys
-    assert "qos.coreweave.cloud/interruptable" in toleration_keys
+    assert "qos.coreweave.cloud/interruptable" not in toleration_keys
 
 
 def test_coreweave_constraints_end_to_end():
@@ -336,7 +336,7 @@ def test_coreweave_constraints_end_to_end():
 
     assert spec["nodeSelector"]["iris.pool"] == "h100-8x"
     assert spec["nodeSelector"]["iris.region"] == "US-WEST-04A"
-    assert any(t.get("key") == "qos.coreweave.cloud/interruptable" for t in spec["tolerations"])
+    assert not any(t.get("key") == "qos.coreweave.cloud/interruptable" for t in spec["tolerations"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/iris/test_kind_gpu_canary.py
+++ b/tests/integration/iris/test_kind_gpu_canary.py
@@ -156,7 +156,6 @@ def _make_coreweave_harness(tmp_path: Path) -> ServiceTestHarness:
         labels={"iris.pool": "h100-8x"},
         taints=[
             {"key": "nvidia.com/gpu", "effect": "NoSchedule", "operator": "Exists"},
-            {"key": "qos.coreweave.cloud/interruptable", "effect": "NoExecute", "operator": "Exists"},
         ],
         resources=FakeNodeResources(
             cpu_millicores=128_000,
@@ -362,7 +361,7 @@ def test_gpu_pod_attributes_with_in_memory_k8s(tmp_path: Path) -> None:
         assert gpu_limits["nvidia.com/gpu"] == "8"
         assert gpu_limits["rdma/ib"] == "8"
         assert "nvidia.com/gpu" in gpu_toleration_keys
-        assert "qos.coreweave.cloud/interruptable" in gpu_toleration_keys
+        assert "qos.coreweave.cloud/interruptable" not in gpu_toleration_keys
         assert "h100-8x" in gpu_pods[0]["spec"].get("nodeName", "")
         assert "cpu-erapids" in cpu_pods[0]["spec"].get("nodeName", "")
     finally:
@@ -430,5 +429,5 @@ def test_gpu_pod_attributes_with_kind(tmp_path: Path, kind_cluster) -> None:
 
         assert gpu_limits["nvidia.com/gpu"] == "8"
         assert "nvidia.com/gpu" in gpu_toleration_keys
-        assert "qos.coreweave.cloud/interruptable" in gpu_toleration_keys
+        assert "qos.coreweave.cloud/interruptable" not in gpu_toleration_keys
         assert "nvidia.com/gpu" not in cpu_toleration_keys


### PR DESCRIPTION
## Summary
- Remove `CW_INTERRUPTABLE_TOLERATION` from GPU worker pod manifests
- Marin uses on-demand CW nodes (`preemptible: false`) which do not carry this taint
- Follows up on #4322 which removed the same toleration from the controller