### PR TITLE
[zephyr] On-demand single-task workers with per-stage resources

### DIFF
--- a/lib/fray/src/fray/v2/local_backend.py
+++ b/lib/fray/src/fray/v2/local_backend.py
@@ -275,13 +275,20 @@ class LocalActorMethod:
 
         Uses a dedicated thread per call instead of a thread pool to avoid
         backpressure when many actors make concurrent remote calls.
+
+        Copies the caller's contextvars into the worker thread so that
+        callees see the same context (e.g. ``set_current_client``) as the
+        in-process caller. ``LocalClient.submit`` does the same; without
+        this, an actor method that calls ``current_client()`` would fall
+        back to auto-detection and pick up an unrelated backend.
         """
         future: Future[Any] = Future()
         method_name = getattr(self._method, "__name__", repr(self._method))
+        ctx = contextvars.copy_context()
 
         def run():
             try:
-                result = self._method(*args, **kwargs)
+                result = ctx.run(self._method, *args, **kwargs)
                 future.set_result(result)
             except Exception as e:
                 logger.warning("Actor method %r failed: %s", method_name, e, exc_info=True)

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -396,6 +396,11 @@ class ZephyrCoordinator:
         self._worker_batch_counter: int = 0
         """Counts the number of batches spawned so far, used for unique worker
         group naming when spawning on-demand batches."""
+        self._pending_worker_count: int = 0
+        """Workers requested from the backend that have not yet called
+        register_worker. The spawn loop counts these as in-flight so it
+        does not over-provision while a slow backend is still bringing up
+        the previous batch."""
 
         # Lock for accessing coordinator state from background thread
         self._lock = threading.Lock()
@@ -480,6 +485,10 @@ class ZephyrCoordinator:
             self._worker_handles[worker_id] = worker_handle
             self._worker_states[worker_id] = WorkerState.READY
             self._last_seen[worker_id] = time.monotonic()
+            # A pending spawn has materialized — drop it from the in-flight
+            # request count so the spawn loop can decide based on real state.
+            if self._pending_worker_count > 0:
+                self._pending_worker_count -= 1
 
             logger.info("Worker %s registered, total: %d", worker_id, len(self._worker_handles))
 
@@ -746,12 +755,17 @@ class ZephyrCoordinator:
             self._in_flight = {}
             self._task_attempts = {task.shard_idx: 0 for task in tasks}
             self._fatal_error = None
+            # Pending worker requests are per-stage: each stage starts with no
+            # outstanding spawns. A leftover counter from a prior stage would
+            # block the new stage from spawning its first batch.
+            self._pending_worker_count = 0
             # Only reset in-flight worker snapshots; completed snapshots
             # accumulate across stages for full pipeline visibility.
             self._worker_counters = {}
 
     def _wait_for_stage(
         self,
+        # TODO: when would spawn_fn be None?
         spawn_fn: Callable[[int], None] | None = None,
     ) -> None:
         """Block until current stage completes or error occurs.
@@ -786,8 +800,15 @@ class ZephyrCoordinator:
                 alive_workers = sum(
                     1 for s in self._worker_states.values() if s in {WorkerState.READY, WorkerState.BUSY}
                 )
+                # Count workers we have asked the backend to spawn but that
+                # have not yet called register_worker. Without this, a slow
+                # backend (e.g. Iris waiting on scheduler capacity) makes the
+                # spawn loop think there is no in-flight work and over-spawn.
+                pending_workers = self._pending_worker_count
 
-            if alive_workers == 0:
+            in_flight_workers = alive_workers + pending_workers
+
+            if in_flight_workers == 0:
                 if queue_depth > 0 and spawn_fn is not None:
                     # Tasks waiting but no workers — spawn a batch
                     spawn_fn(queue_depth)
@@ -847,14 +868,21 @@ class ZephyrCoordinator:
         self._worker_batch_counter += 1
         name = f"zephyr-{self._pipeline_name}-p{self._pipeline_id}-a{self._attempt_id}-b{batch_id}"
         logger.info("Creating worker batch %s: %d workers, resources=%s", name, count, resources)
-        group = self._client.create_actor_group(
-            ZephyrWorker,
-            self._self_handle,
-            name=name,
-            count=count,
-            resources=resources,
-            actor_config=ActorConfig(max_task_retries=10),
-        )
+        with self._lock:
+            self._pending_worker_count += count
+        try:
+            group = self._client.create_actor_group(
+                ZephyrWorker,
+                self._self_handle,
+                name=name,
+                count=count,
+                resources=resources,
+                actor_config=ActorConfig(max_task_retries=10),
+            )
+        except Exception:
+            with self._lock:
+                self._pending_worker_count = max(0, self._pending_worker_count - count)
+            raise
         group.wait_ready(count=1)
         self._await_first_registration(name, timeout=3600.0)
         return group

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -394,6 +394,8 @@ class ZephyrCoordinator:
         self._pipeline_id: int = 0
         self._attempt_id: int = 0
         self._worker_batch_counter: int = 0
+        """Counts the number of batches spawned so far, used for unique worker
+        group naming when spawning on-demand batches."""
 
         # Lock for accessing coordinator state from background thread
         self._lock = threading.Lock()

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -771,9 +771,10 @@ class ZephyrCoordinator:
         """Block until current stage completes or error occurs.
 
         Args:
-            spawn_fn: If provided, called with queue_depth when workers need to
-                be spawned (tasks are queued but no workers are alive). Used for
-                on-demand worker creation.
+            spawn_fn: If provided, called with the desired number of additional
+                workers when the in-flight count is below
+                ``min(max_workers, queue_depth)``. Used for on-demand worker
+                creation.
         """
         backoff = ExponentialBackoff(initial=0.1, maximum=1.0)
         last_log_completed = -1
@@ -808,14 +809,29 @@ class ZephyrCoordinator:
 
             in_flight_workers = alive_workers + pending_workers
 
-            if in_flight_workers == 0:
-                if queue_depth > 0 and spawn_fn is not None:
-                    # Tasks waiting but no workers — spawn a batch
-                    spawn_fn(queue_depth)
-                    all_dead_since = None
-                    backoff.reset()
-                    continue
+            # In single-task mode, alive workers in BUSY state are processing
+            # an already-pulled task and will not pull more from the queue.
+            # Demand for new workers is therefore `queue_depth - pending` —
+            # the queued tasks that have not been promised to a worker yet.
+            # The budget is `max_workers - in_flight`, the slots remaining
+            # within the user's concurrency limit. Spawn the deficit.
+            queue_demand = max(0, queue_depth - pending_workers)
+            slot_budget = max(0, self._max_workers - in_flight_workers)
+            needed = min(queue_demand, slot_budget)
 
+            if needed > 0 and spawn_fn is not None:
+                spawn_fn(needed)
+                all_dead_since = None
+                backoff.reset()
+                continue
+
+            if in_flight_workers > 0:
+                # Workers are alive or pending — reset the dead timer.
+                all_dead_since = None
+            else:
+                # Nothing in flight and we don't need to spawn (queue is
+                # empty but the stage isn't done — tasks are stuck in the
+                # `_in_flight` map waiting for heartbeat to requeue them).
                 now = time.monotonic()
                 elapsed = now - start_time
 
@@ -831,9 +847,6 @@ class ZephyrCoordinator:
                         f"All {len(self._worker_handles)} registered workers are dead/failed. "
                         "Check cluster resources and worker group configuration."
                     )
-            else:
-                # Workers are alive — reset the dead timer
-                all_dead_since = None
 
             if completed != last_log_completed:
                 logger.info("[%s] %d/%d tasks completed", self._stage_name, completed, total)
@@ -925,9 +938,10 @@ class ZephyrCoordinator:
     ) -> None:
         """Load tasks, spawn workers on-demand, and wait until all tasks complete.
 
-        Workers are created in batches. Each worker executes a single task and
-        exits. When all workers in a batch finish and tasks remain (from the
-        initial queue or from failure requeues), a new batch is spawned.
+        Workers are created in batches. ``_wait_for_stage`` calls ``spawn_fn``
+        with the desired number of additional workers whenever the in-flight
+        count is below ``min(max_workers, queue_depth)``. Each worker executes
+        a single task and exits.
         """
         self._start_stage(stage_label, tasks)
         if not tasks:
@@ -935,9 +949,8 @@ class ZephyrCoordinator:
 
         worker_groups: list = []
 
-        def spawn_fn(queue_depth: int) -> None:
-            batch_size = min(self._max_workers, queue_depth)
-            group = self.spawn_worker_batch(batch_size, resources)
+        def spawn_fn(count: int) -> None:
+            group = self.spawn_worker_batch(count, resources)
             worker_groups.append(group)
 
         try:

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -417,7 +417,7 @@ class ZephyrCoordinator:
         """Initialize coordinator for push-based worker registration.
 
         Workers register themselves by calling register_worker() when they start.
-        Workers are created on-demand per stage via _spawn_worker_batch().
+        Workers are created on-demand per stage via spawn_worker_batch().
 
         Args:
             chunk_prefix: Storage prefix for intermediate chunks
@@ -827,7 +827,7 @@ class ZephyrCoordinator:
         with self._lock:
             return dict(self._results)
 
-    def _spawn_worker_batch(self, count: int, resources: ResourceConfig) -> Any:
+    def spawn_worker_batch(self, count: int, resources: ResourceConfig) -> Any:
         """Create a batch of single-task workers.
 
         Each worker pulls one task, executes it, reports the result, and exits.
@@ -875,7 +875,7 @@ class ZephyrCoordinator:
 
         def spawn_fn(queue_depth: int) -> None:
             batch_size = min(self._max_workers, queue_depth)
-            group = self._spawn_worker_batch(batch_size, resources)
+            group = self.spawn_worker_batch(batch_size, resources)
             worker_groups.append(group)
 
         try:

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -831,6 +831,17 @@ class ZephyrCoordinator:
 
         Each worker pulls one task, executes it, reports the result, and exits.
         Returns the ActorGroup for lifecycle management.
+
+        Blocks until at least one worker from the batch has called
+        ``register_worker``. ``ActorGroup.wait_ready`` is the backend's
+        notion of "the actor object exists" — on Local and Ray it returns
+        immediately; on Iris it waits for the actor to be discoverable
+        and fails fast if the underlying job died. None of the backends
+        wait for the actor's ``__init__`` to finish, so we follow up with
+        ``_await_first_registration`` which polls the coordinator's own
+        worker map. Without this, ``_wait_for_stage`` would see
+        ``alive_workers == 0`` right after spawning and immediately call
+        ``spawn_fn`` again, producing a tight spawn-storm.
         """
         batch_id = self._worker_batch_counter
         self._worker_batch_counter += 1
@@ -844,8 +855,33 @@ class ZephyrCoordinator:
             resources=resources,
             actor_config=ActorConfig(max_task_retries=10),
         )
-        group.wait_ready(count=1, timeout=3600.0)
+        group.wait_ready(count=1)
+        self._await_first_registration(name, timeout=3600.0)
         return group
+
+    def _await_first_registration(self, batch_name: str, timeout: float) -> None:
+        """Block until at least one worker whose id starts with ``batch_name`` has registered.
+
+        Workers register themselves from ``ZephyrWorker.__init__``, but on
+        Ray that runs asynchronously after ``wait_ready`` returns. Polling
+        ``_worker_handles`` here keeps the spawn loop in sync with actual
+        worker startup. Checks presence rather than state because a fast
+        single-task worker may already have run its task and transitioned
+        to DEAD by the time we observe it — that still counts as a
+        successful registration for spawn-decision purposes.
+        """
+        prefix = f"{batch_name}-"
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with self._lock:
+                for worker_id in self._worker_handles:
+                    if worker_id.startswith(prefix):
+                        return
+            time.sleep(0.05)
+        raise ZephyrWorkerError(
+            f"No worker from batch {batch_name} registered within {timeout:.0f}s. "
+            "Check cluster resources and worker startup logs."
+        )
 
     def _stage_resources(self, stage: Any) -> ResourceConfig:
         """Return the resource config for a stage."""

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -386,6 +386,16 @@ class ZephyrCoordinator:
         self._initialized: bool = False
         self._pipeline_running: bool = False
 
+        # On-demand worker lifecycle management (set via initialize)
+        self._client: Any = None
+        self._max_workers: int = 128
+        self._worker_resources: ResourceConfig = ResourceConfig(cpu=1, ram="1g")
+        self._reducer_resources: ResourceConfig | None = None
+        self._pipeline_name: str = ""
+        self._pipeline_id: int = 0
+        self._attempt_id: int = 0
+        self._batch_counter: int = 0
+
         # Lock for accessing coordinator state from background thread
         self._lock = threading.Lock()
 
@@ -397,20 +407,43 @@ class ZephyrCoordinator:
         chunk_prefix: str,
         coordinator_handle: ActorHandle,
         no_workers_timeout: float = 60.0,
+        max_workers: int = 128,
+        worker_resources: ResourceConfig | None = None,
+        reducer_resources: ResourceConfig | None = None,
+        pipeline_name: str = "",
+        pipeline_id: int = 0,
+        attempt_id: int = 0,
     ) -> None:
         """Initialize coordinator for push-based worker registration.
 
         Workers register themselves by calling register_worker() when they start.
-        This eliminates polling overhead and log spam from discover_new() calls.
+        Workers are created on-demand per stage via _spawn_worker_batch().
 
         Args:
             chunk_prefix: Storage prefix for intermediate chunks
             coordinator_handle: Handle to this coordinator actor (passed from context)
             no_workers_timeout: Seconds to wait for at least one worker before failing.
+            max_workers: Upper bound on concurrent workers per batch.
+            worker_resources: Default (mapper) resource config per worker.
+            reducer_resources: Resource config for reduce stages. Falls back to
+                worker_resources when None.
+            pipeline_name: Name for worker group naming.
+            pipeline_id: Pipeline ID for worker group naming.
+            attempt_id: Attempt ID for worker group naming.
         """
+        from fray.v2.client import current_client
+
         self._chunk_prefix = chunk_prefix
         self._self_handle = coordinator_handle
         self._no_workers_timeout = no_workers_timeout
+        self._max_workers = max_workers
+        if worker_resources is not None:
+            self._worker_resources = worker_resources
+        self._reducer_resources = reducer_resources
+        self._pipeline_name = pipeline_name
+        self._pipeline_id = pipeline_id
+        self._attempt_id = attempt_id
+        self._client = current_client()
 
         logger.info("Coordinator initialized")
 
@@ -448,6 +481,12 @@ class ZephyrCoordinator:
             self._last_seen[worker_id] = time.monotonic()
 
             logger.info("Worker %s registered, total: %d", worker_id, len(self._worker_handles))
+
+    def deregister_worker(self, worker_id: str) -> None:
+        """Called by a worker when it has finished its task and is exiting."""
+        with self._lock:
+            self._worker_states[worker_id] = WorkerState.DEAD
+            self._last_seen[worker_id] = time.monotonic()
 
     def _coordinator_loop(self) -> None:
         """Background loop for heartbeat checking and worker job monitoring."""
@@ -712,8 +751,17 @@ class ZephyrCoordinator:
             # accumulate across stages for full pipeline visibility.
             self._worker_counters = {}
 
-    def _wait_for_stage(self) -> None:
-        """Block until current stage completes or error occurs."""
+    def _wait_for_stage(
+        self,
+        spawn_fn: Callable[[int], None] | None = None,
+    ) -> None:
+        """Block until current stage completes or error occurs.
+
+        Args:
+            spawn_fn: If provided, called with queue_depth when workers need to
+                be spawned (tasks are queued but no workers are alive). Used for
+                on-demand worker creation.
+        """
         backoff = ExponentialBackoff(initial=0.1, maximum=1.0)
         last_log_completed = -1
         start_time = time.monotonic()
@@ -732,31 +780,40 @@ class ZephyrCoordinator:
                 if completed >= total:
                     return
 
+                queue_depth = len(self._task_queue)
+
                 # Count alive workers (READY or BUSY), not just total registered.
                 # Dead/failed workers stay in _worker_handles but can't make progress.
                 alive_workers = sum(
                     1 for s in self._worker_states.values() if s in {WorkerState.READY, WorkerState.BUSY}
                 )
 
-                if alive_workers == 0:
-                    now = time.monotonic()
-                    elapsed = now - start_time
-
-                    if all_dead_since is None:
-                        all_dead_since = now
-                        logger.warning("All workers are dead/failed. Waiting for workers to recover...")
-
-                    dead_duration = now - all_dead_since
-                    if dead_duration > no_workers_timeout:
-                        raise ZephyrWorkerError(
-                            f"No alive workers for {dead_duration:.1f}s "
-                            f"(total elapsed {elapsed:.1f}s). "
-                            f"All {len(self._worker_handles)} registered workers are dead/failed. "
-                            "Check cluster resources and worker group configuration."
-                        )
-                else:
-                    # Workers are alive — reset the dead timer
+            if alive_workers == 0:
+                if queue_depth > 0 and spawn_fn is not None:
+                    # Tasks waiting but no workers — spawn a batch
+                    spawn_fn(queue_depth)
                     all_dead_since = None
+                    backoff.reset()
+                    continue
+
+                now = time.monotonic()
+                elapsed = now - start_time
+
+                if all_dead_since is None:
+                    all_dead_since = now
+                    logger.warning("All workers are dead/failed. Waiting for workers to recover...")
+
+                dead_duration = now - all_dead_since
+                if dead_duration > no_workers_timeout:
+                    raise ZephyrWorkerError(
+                        f"No alive workers for {dead_duration:.1f}s "
+                        f"(total elapsed {elapsed:.1f}s). "
+                        f"All {len(self._worker_handles)} registered workers are dead/failed. "
+                        "Check cluster resources and worker group configuration."
+                    )
+            else:
+                # Workers are alive — reset the dead timer
+                all_dead_since = None
 
             if completed != last_log_completed:
                 logger.info("[%s] %d/%d tasks completed", self._stage_name, completed, total)
@@ -769,6 +826,64 @@ class ZephyrCoordinator:
         """Return results for the completed stage."""
         with self._lock:
             return dict(self._results)
+
+    def _spawn_worker_batch(self, count: int, resources: ResourceConfig) -> Any:
+        """Create a batch of single-task workers.
+
+        Each worker pulls one task, executes it, reports the result, and exits.
+        Returns the ActorGroup for lifecycle management.
+        """
+        batch_id = self._batch_counter
+        self._batch_counter += 1
+        name = f"zephyr-{self._pipeline_name}-p{self._pipeline_id}-a{self._attempt_id}-b{batch_id}"
+        logger.info("Creating worker batch %s: %d workers, resources=%s", name, count, resources)
+        group = self._client.create_actor_group(
+            ZephyrWorker,
+            self._self_handle,
+            name=name,
+            count=count,
+            resources=resources,
+            actor_config=ActorConfig(max_task_retries=10),
+        )
+        group.wait_ready(count=1, timeout=3600.0)
+        return group
+
+    def _stage_resources(self, stage: Any) -> ResourceConfig:
+        """Return the resource config for a stage."""
+        if stage.is_reduce_stage and self._reducer_resources is not None:
+            return self._reducer_resources
+        return self._worker_resources
+
+    def _run_stage_with_workers(
+        self,
+        stage_label: str,
+        tasks: list[ShardTask],
+        resources: ResourceConfig,
+        is_last_stage: bool,
+    ) -> None:
+        """Load tasks, spawn workers on-demand, and wait until all tasks complete.
+
+        Workers are created in batches. Each worker executes a single task and
+        exits. When all workers in a batch finish and tasks remain (from the
+        initial queue or from failure requeues), a new batch is spawned.
+        """
+        self._start_stage(stage_label, tasks, is_last_stage=is_last_stage)
+        if not tasks:
+            return
+
+        worker_groups: list = []
+
+        def spawn_fn(queue_depth: int) -> None:
+            batch_size = min(self._max_workers, queue_depth)
+            group = self._spawn_worker_batch(batch_size, resources)
+            worker_groups.append(group)
+
+        try:
+            self._wait_for_stage(spawn_fn=spawn_fn)
+        finally:
+            for group in worker_groups:
+                with suppress(Exception):
+                    group.shutdown()
 
     def run_pipeline(
         self,
@@ -811,10 +926,15 @@ class ZephyrCoordinator:
                 tasks = _compute_tasks_from_shards(shards, stage, aux_per_shard, stage_name=stage_label)
                 output_stage_name = tasks[0].stage_name if tasks else stage_label
                 logger.info("[%s] Starting stage %s with %d tasks", self._execution_id, stage_label, len(tasks))
-                self._start_stage(stage_label, tasks, is_last_stage=(stage_idx == last_worker_stage_idx))
 
-                # Wait for stage completion
-                self._wait_for_stage()
+                # Create workers on-demand for this stage with appropriate resources
+                stage_resources = self._stage_resources(stage)
+                self._run_stage_with_workers(
+                    stage_label,
+                    tasks,
+                    stage_resources,
+                    is_last_stage=(stage_idx == last_worker_stage_idx),
+                )
 
                 # Collect and regroup results for next stage
                 result_refs = self._collect_results()
@@ -870,8 +990,13 @@ class ZephyrCoordinator:
                 join_stage_label = f"join-right-{parent_stage_idx}-{i}-stage{stage_idx}"
                 right_tasks = _compute_tasks_from_shards(right_refs, right_stage, stage_name=join_stage_label)
                 join_output_stage_name = right_tasks[0].stage_name if right_tasks else join_stage_label
-                self._start_stage(join_stage_label, right_tasks)
-                self._wait_for_stage()
+                join_resources = self._stage_resources(right_stage)
+                self._run_stage_with_workers(
+                    join_stage_label,
+                    right_tasks,
+                    join_resources,
+                    is_last_stage=False,
+                )
                 raw = self._collect_results()
                 right_is_scatter = any(isinstance(op, Scatter) for op in right_stage.operations)
                 right_refs = _regroup_result_refs(
@@ -1096,24 +1221,24 @@ class ZephyrWorker:
         logger.debug("[%s] Heartbeat loop exiting after %d beats", self._worker_id, heartbeat_count)
 
     def _poll_loop(self, coordinator: ActorHandle) -> None:
-        """Pure polling loop. Exits on SHUTDOWN signal, coordinator death, or shutdown event."""
-        task_count = 0
-        backoff = ExponentialBackoff(initial=0.1, maximum=1.0)
+        """Pull a single task, execute it, and exit.
+
+        Each worker is a single-task actor: it pulls one task from the
+        coordinator, executes it, reports the result, deregisters, and exits.
+        The coordinator spawns new worker batches as needed.
+        """
+        import traceback as tb_mod
 
         future: ActorFuture | None = None
         future_start = 0.0
         warned = False
 
         while not self._shutdown_event.is_set():
-            # Create a pull_task future if we don't have one in flight
             if future is None:
                 future = coordinator.pull_task.remote(self._worker_id)
                 future_start = time.monotonic()
                 warned = False
 
-            # Poll with a short timeout so we stay responsive to shutdown
-            # without killing the worker (and its heartbeat thread) on slow
-            # deserialization.
             try:
                 response = future.result(timeout=0.5)
             except TimeoutError:
@@ -1126,21 +1251,17 @@ class ZephyrWorker:
                 logger.info("[%s] pull_task failed (coordinator may be dead): %s", self._worker_id, e)
                 break
 
-            future = None  # consumed; next iteration will create a new one
+            future = None
 
-            # SHUTDOWN signal - exit cleanly
             if response == "SHUTDOWN":
                 logger.info("[%s] Received SHUTDOWN", self._worker_id)
                 break
 
-            # No task available - backoff and retry
+            # No task available — exit (coordinator will spawn more workers if needed)
             if response is None:
-                time.sleep(backoff.next_interval())
-                continue
+                logger.info("[%s] No task available, exiting", self._worker_id)
+                break
 
-            backoff.reset()
-
-            # Unpack task and config
             task, attempt, config = response
 
             logger.info("[%s] Executing task for shard %d (attempt %d)", self._worker_id, task.shard_idx, attempt)
@@ -1153,10 +1274,6 @@ class ZephyrWorker:
                     task.shard_idx,
                     time.monotonic() - t_0,
                 )
-                # Block until coordinator records the result. This ensures
-                # report_result is fully processed before the next pull_task,
-                # preventing _in_flight tracking races.  Send the final counter
-                # snapshot so no increments are lost between heartbeats.
                 coordinator.report_result.remote(
                     self._worker_id,
                     task.shard_idx,
@@ -1164,16 +1281,18 @@ class ZephyrWorker:
                     result,
                     self.get_counter_snapshot(),
                 ).result()
-                task_count += 1
             except Exception as e:
                 logger.error("Worker %s error on shard %d: %s", self._worker_id, task.shard_idx, e)
-                import traceback
-
                 coordinator.report_error.remote(
                     self._worker_id,
                     task.shard_idx,
-                    "".join(traceback.format_exc()),
+                    "".join(tb_mod.format_exc()),
                 ).result()
+
+            # Single-task worker: deregister and exit after one task
+            with suppress(Exception):
+                coordinator.deregister_worker.remote(self._worker_id).result(timeout=5.0)
+            break
 
     def _execute_shard(self, task: ShardTask, config: dict) -> TaskResult:
         """Execute a stage's operations on a single shard.
@@ -1280,6 +1399,7 @@ class _CoordinatorJobConfig:
     no_workers_timeout: float
     max_workers: int
     worker_resources: ResourceConfig
+    reducer_resources: ResourceConfig | None
     name: str
     pipeline_id: int
 
@@ -1287,10 +1407,9 @@ class _CoordinatorJobConfig:
 def _run_coordinator_job(config_path: str, result_path: str) -> None:
     """Entrypoint for the coordinator job.
 
-    Hosts the coordinator actor in-process via host_actor(), creates
-    worker actors as child jobs, runs the pipeline, and writes results
-    to disk. The coordinator monitors worker job health directly in its
-    maintenance loop (no separate watchdog thread).
+    Hosts the coordinator actor in-process via host_actor(). Workers are
+    created on-demand by the coordinator during run_pipeline(), not upfront.
+    Each worker executes a single task and exits.
     """
     from fray.v2.client import current_client
     from iris.cluster.client.job_info import get_job_info
@@ -1324,31 +1443,15 @@ def _run_coordinator_job(config_path: str, result_path: str) -> None:
         config.chunk_storage_prefix,
         coordinator,
         config.no_workers_timeout,
+        max_workers=config.max_workers,
+        worker_resources=config.worker_resources,
+        reducer_resources=config.reducer_resources,
+        pipeline_name=config.name,
+        pipeline_id=config.pipeline_id,
+        attempt_id=attempt_id,
     ).result()
 
-    # Create workers (child jobs)
-    num_shards = config.plan.num_shards
-    actual_workers = min(config.max_workers, num_shards) if num_shards > 0 else 0
-    worker_group = None
-
-    if actual_workers > 0:
-        # Worker name includes attempt ID so that if a stale coordinator
-        # process from a previous attempt is still running, its shutdown
-        # targets the old name and cannot kill this attempt's workers.
-        worker_name = f"zephyr-{config.name}-p{config.pipeline_id}-workers-a{attempt_id}"
-        logger.info("Starting %d workers (max=%d, shards=%d)", actual_workers, config.max_workers, num_shards)
-        worker_group = client.create_actor_group(
-            ZephyrWorker,
-            coordinator,
-            name=worker_name,
-            count=actual_workers,
-            resources=config.worker_resources,
-            actor_config=ActorConfig(max_task_retries=10),
-        )
-        worker_group.wait_ready(count=1, timeout=3600.0)
-
-        # Let the coordinator poll worker job health in its maintenance loop
-        coordinator.set_worker_group.remote(worker_group).result()
+    # Workers are created on-demand by the coordinator during run_pipeline()
 
     try:
         results = coordinator.run_pipeline.submit(config.plan, config.execution_id).result()
@@ -1365,14 +1468,8 @@ def _run_coordinator_job(config_path: str, result_path: str) -> None:
                 f.write(cloudpickle.dumps(e))
         raise
     finally:
-        # Signal coordinator shutdown first so workers receive SHUTDOWN from
-        # pull_task and self-terminate via shutdown_event → exit_actor()
-        # before worker_group.shutdown() sends __ray_terminate__.
         with suppress(Exception):
             coordinator.shutdown.remote().result(timeout=10.0)
-        if worker_group is not None:
-            with suppress(Exception):
-                worker_group.shutdown()
         with suppress(Exception):
             hosted.shutdown()
 
@@ -1410,7 +1507,9 @@ class ZephyrContext:
         max_workers: Upper bound on worker count. The actual count is
             min(max_workers, num_shards), computed at first execute(). If None,
             defaults to os.cpu_count() for LocalClient, or 128 for distributed clients.
-        resources: Resource config per worker.
+        resources: Resource config per worker (used for mapper/non-reduce stages).
+        reducer_resources: Resource config for reduce stages (group_by, reduce).
+            When None, all stages use ``resources``.
         coordinator_resources: Resource config for the coordinator job. The coordinator
             accumulates scatter manifests for all shards in memory; increase ram for
             large pipelines (many shards). Defaults to 5 GB.
@@ -1428,6 +1527,7 @@ class ZephyrContext:
     client: Client | None = None
     max_workers: int | None = None
     resources: ResourceConfig = field(default_factory=lambda: ResourceConfig(cpu=1, ram="1g"))
+    reducer_resources: ResourceConfig | None = None
     coordinator_resources: ResourceConfig = field(default_factory=lambda: ResourceConfig(cpu=1, ram="5g"))
     chunk_storage_prefix: str | None = None
     name: str = ""
@@ -1543,6 +1643,7 @@ class ZephyrContext:
                     no_workers_timeout=self.no_workers_timeout,
                     max_workers=self.max_workers,
                     worker_resources=self.resources,
+                    reducer_resources=self.reducer_resources,
                     name=self.name,
                     pipeline_id=self._pipeline_id,
                 )

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -349,8 +349,8 @@ class ZephyrCoordinator:
 
     The coordinator creates workers via current_client(), runs a background
     loop for discovery and heartbeat checking, and manages all pipeline
-    execution internally. Workers poll the coordinator for tasks until
-    receiving a SHUTDOWN signal.
+    execution internally. Each worker pulls a single task, executes it,
+    reports the result, and exits.
     """
 
     def __init__(self):
@@ -382,7 +382,6 @@ class ZephyrCoordinator:
         self._worker_group: Any = None  # ActorGroup, set via set_worker_group()
         self._coordinator_thread: threading.Thread | None = None
         self._shutdown_event = threading.Event()
-        self._is_last_stage: bool = False
         self._initialized: bool = False
         self._pipeline_running: bool = False
 
@@ -394,7 +393,7 @@ class ZephyrCoordinator:
         self._pipeline_name: str = ""
         self._pipeline_id: int = 0
         self._attempt_id: int = 0
-        self._batch_counter: int = 0
+        self._worker_batch_counter: int = 0
 
         # Lock for accessing coordinator state from background thread
         self._lock = threading.Lock()
@@ -516,8 +515,8 @@ class ZephyrCoordinator:
         """Abort the pipeline if the worker job has permanently terminated."""
         if self._worker_group is None or self._fatal_error is not None:
             return
-        # After the last stage completes, workers exit cleanly via SHUTDOWN.
-        # The worker job finishing at that point is expected, not a crash.
+        # Single-task workers exit cleanly after each task. The worker job
+        # finishing once all shards are done is expected, not a crash.
         with self._lock:
             if self._total_shards > 0 and self._completed_shards >= self._total_shards:
                 return
@@ -581,7 +580,9 @@ class ZephyrCoordinator:
         Returns:
             - (task, attempt, config) tuple if task available
             - "SHUTDOWN" string if coordinator is shutting down
-            - None if no task available (worker should backoff and retry)
+            - None if no task is currently available; single-task workers
+              treat this as a signal to exit (the coordinator will spawn
+              another batch if more tasks need running)
         """
         with self._lock:
             self._last_seen[worker_id] = time.monotonic()
@@ -595,9 +596,6 @@ class ZephyrCoordinator:
                 return None
 
             if not self._task_queue:
-                if self._is_last_stage and not self._in_flight:
-                    self._worker_states[worker_id] = WorkerState.DEAD
-                    return "SHUTDOWN"
                 return None
 
             task = self._task_queue.popleft()
@@ -734,7 +732,7 @@ class ZephyrCoordinator:
                 logger.error("Coordinator aborted: %s", reason)
                 self._fatal_error = reason
 
-    def _start_stage(self, stage_name: str, tasks: list[ShardTask], is_last_stage: bool = False) -> None:
+    def _start_stage(self, stage_name: str, tasks: list[ShardTask]) -> None:
         """Load a new stage's tasks into the queue."""
         with self._lock:
             self._task_queue = deque(tasks)
@@ -746,7 +744,6 @@ class ZephyrCoordinator:
             self._in_flight = {}
             self._task_attempts = {task.shard_idx: 0 for task in tasks}
             self._fatal_error = None
-            self._is_last_stage = is_last_stage
             # Only reset in-flight worker snapshots; completed snapshots
             # accumulate across stages for full pipeline visibility.
             self._worker_counters = {}
@@ -833,8 +830,8 @@ class ZephyrCoordinator:
         Each worker pulls one task, executes it, reports the result, and exits.
         Returns the ActorGroup for lifecycle management.
         """
-        batch_id = self._batch_counter
-        self._batch_counter += 1
+        batch_id = self._worker_batch_counter
+        self._worker_batch_counter += 1
         name = f"zephyr-{self._pipeline_name}-p{self._pipeline_id}-a{self._attempt_id}-b{batch_id}"
         logger.info("Creating worker batch %s: %d workers, resources=%s", name, count, resources)
         group = self._client.create_actor_group(
@@ -859,7 +856,6 @@ class ZephyrCoordinator:
         stage_label: str,
         tasks: list[ShardTask],
         resources: ResourceConfig,
-        is_last_stage: bool,
     ) -> None:
         """Load tasks, spawn workers on-demand, and wait until all tasks complete.
 
@@ -867,7 +863,7 @@ class ZephyrCoordinator:
         exits. When all workers in a batch finish and tasks remain (from the
         initial queue or from failure requeues), a new batch is spawned.
         """
-        self._start_stage(stage_label, tasks, is_last_stage=is_last_stage)
+        self._start_stage(stage_label, tasks)
         if not tasks:
             return
 
@@ -903,15 +899,6 @@ class ZephyrCoordinator:
             if not shards:
                 return []
 
-            # Identify the last stage that dispatches work to workers (non-RESHARD).
-            # On that stage, idle workers receive SHUTDOWN once all tasks are
-            # in-flight, so they exit eagerly instead of polling until
-            # coordinator.shutdown().
-            last_worker_stage_idx = max(
-                (i for i, s in enumerate(plan.stages) if s.stage_type != StageType.RESHARD),
-                default=-1,
-            )
-
             for stage_idx, stage in enumerate(plan.stages):
                 stage_label = f"stage{stage_idx}-{stage.stage_name(max_length=40)}"
 
@@ -933,7 +920,6 @@ class ZephyrCoordinator:
                     stage_label,
                     tasks,
                     stage_resources,
-                    is_last_stage=(stage_idx == last_worker_stage_idx),
                 )
 
                 # Collect and regroup results for next stage
@@ -995,7 +981,6 @@ class ZephyrCoordinator:
                     join_stage_label,
                     right_tasks,
                     join_resources,
-                    is_last_stage=False,
                 )
                 raw = self._collect_results()
                 right_is_scatter = any(isinstance(op, Scatter) for op in right_stage.operations)
@@ -1055,9 +1040,9 @@ class ZephyrCoordinator:
                 "execution_id": self._execution_id,
             }
 
-    def start_stage(self, stage_name: str, tasks: list[ShardTask], is_last_stage: bool = False) -> None:
+    def start_stage(self, stage_name: str, tasks: list[ShardTask]) -> None:
         """Load a new stage's tasks into the queue (legacy compat)."""
-        self._start_stage(stage_name, tasks, is_last_stage=is_last_stage)
+        self._start_stage(stage_name, tasks)
 
     def check_heartbeats(self, timeout: float = 120.0) -> None:
         """Marks stale workers as FAILED, re-queues their in-flight tasks."""

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -1220,66 +1220,75 @@ class ZephyrWorker:
         future_start = 0.0
         warned = False
 
-        while not self._shutdown_event.is_set():
-            if future is None:
-                future = coordinator.pull_task.remote(self._worker_id)
-                future_start = time.monotonic()
-                warned = False
+        try:
+            while not self._shutdown_event.is_set():
+                if future is None:
+                    future = coordinator.pull_task.remote(self._worker_id)
+                    future_start = time.monotonic()
+                    warned = False
 
-            try:
-                response = future.result(timeout=0.5)
-            except TimeoutError:
-                elapsed = time.monotonic() - future_start
-                if elapsed > 30 and not warned:
-                    logger.warning("[%s] Waiting for coordinator pull_task response (%.0fs)", self._worker_id, elapsed)
-                    warned = True
-                continue
-            except Exception as e:
-                logger.info("[%s] pull_task failed (coordinator may be dead): %s", self._worker_id, e)
-                break
+                try:
+                    response = future.result(timeout=0.5)
+                except TimeoutError:
+                    elapsed = time.monotonic() - future_start
+                    if elapsed > 30 and not warned:
+                        logger.warning(
+                            "[%s] Waiting for coordinator pull_task response (%.0fs)", self._worker_id, elapsed
+                        )
+                        warned = True
+                    continue
+                except Exception as e:
+                    logger.info("[%s] pull_task failed (coordinator may be dead): %s", self._worker_id, e)
+                    return
 
-            future = None
+                future = None
 
-            if response == "SHUTDOWN":
-                logger.info("[%s] Received SHUTDOWN", self._worker_id)
-                break
+                if response == "SHUTDOWN":
+                    logger.info("[%s] Received SHUTDOWN", self._worker_id)
+                    return
 
-            # No task available — exit (coordinator will spawn more workers if needed)
-            if response is None:
-                logger.info("[%s] No task available, exiting", self._worker_id)
-                break
+                # No task available — exit (coordinator will spawn more workers if needed)
+                if response is None:
+                    logger.info("[%s] No task available, exiting", self._worker_id)
+                    return
 
-            task, attempt, config = response
+                task, attempt, config = response
 
-            logger.info("[%s] Executing task for shard %d (attempt %d)", self._worker_id, task.shard_idx, attempt)
-            try:
-                t_0 = time.monotonic()
-                result = self._execute_shard(task, config)
-                logger.info(
-                    "[%s] Task for shard %d completed in %.2f seconds",
-                    self._worker_id,
-                    task.shard_idx,
-                    time.monotonic() - t_0,
-                )
-                coordinator.report_result.remote(
-                    self._worker_id,
-                    task.shard_idx,
-                    attempt,
-                    result,
-                    self.get_counter_snapshot(),
-                ).result()
-            except Exception as e:
-                logger.error("Worker %s error on shard %d: %s", self._worker_id, task.shard_idx, e)
-                coordinator.report_error.remote(
-                    self._worker_id,
-                    task.shard_idx,
-                    "".join(tb_mod.format_exc()),
-                ).result()
+                logger.info("[%s] Executing task for shard %d (attempt %d)", self._worker_id, task.shard_idx, attempt)
+                try:
+                    t_0 = time.monotonic()
+                    result = self._execute_shard(task, config)
+                    logger.info(
+                        "[%s] Task for shard %d completed in %.2f seconds",
+                        self._worker_id,
+                        task.shard_idx,
+                        time.monotonic() - t_0,
+                    )
+                    coordinator.report_result.remote(
+                        self._worker_id,
+                        task.shard_idx,
+                        attempt,
+                        result,
+                        self.get_counter_snapshot(),
+                    ).result()
+                except Exception as e:
+                    logger.error("Worker %s error on shard %d: %s", self._worker_id, task.shard_idx, e)
+                    coordinator.report_error.remote(
+                        self._worker_id,
+                        task.shard_idx,
+                        "".join(tb_mod.format_exc()),
+                    ).result()
 
-            # Single-task worker: deregister and exit after one task
+                return
+        finally:
+            # Always deregister before exiting so the coordinator drops the
+            # worker from its alive-count bookkeeping. Without this, exit
+            # paths other than the task-executed one (SHUTDOWN, empty queue,
+            # RPC failure) leave a stale READY entry in _worker_states, and
+            # the next stage can stall until check_heartbeats reclassifies
+            # the phantom worker as FAILED.
             with suppress(Exception):
                 coordinator.deregister_worker.remote(self._worker_id).result(timeout=5.0)
-            break
 
     def _execute_shard(self, task: ShardTask, config: dict) -> TaskResult:
         """Execute a stage's operations on a single shard.

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -279,6 +279,7 @@ class PhysicalStage:
     operations: list[PhysicalOp] = field(default_factory=list)
     stage_type: StageType = StageType.WORKER
     output_shards: int | None = None
+    is_reduce_stage: bool = False
 
     def stage_name(self, max_length: int | None = None) -> str:
         """Generate a descriptive name from operations.
@@ -374,11 +375,13 @@ class FusionState:
         """Flush pending ops and close current stage."""
         self.flush_pending()
         if self.current_ops:
+            is_reduce = any(isinstance(op, (Reduce, Fold)) for op in self.current_ops)
             self.stages.append(
                 PhysicalStage(
                     operations=self.current_ops[:],
                     stage_type=self.stage_type,
                     output_shards=self.output_shards,
+                    is_reduce_stage=is_reduce,
                 )
             )
             self.current_ops = []

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -568,8 +568,8 @@ def test_pipeline_id_increments(local_client, tmp_path):
     assert ctx._pipeline_id == 1
 
 
-def test_pull_task_returns_shutdown_on_last_stage_empty_queue(actor_context, tmp_path):
-    """When the last stage's tasks are all in-flight or done, pull_task returns SHUTDOWN."""
+def test_pull_task_returns_none_on_empty_queue(actor_context, tmp_path):
+    """Empty queue returns None; single-task workers treat that as exit."""
     from zephyr.execution import ListShard, ShardTask, TaskResult, ZephyrCoordinator
 
     coord = ZephyrCoordinator()
@@ -583,34 +583,18 @@ def test_pull_task_returns_shutdown_on_last_stage_empty_queue(actor_context, tmp
         stage_name="test",
     )
 
-    # Non-last stage: empty queue returns None
-    coord.start_stage("stage-0", [task], is_last_stage=False)
+    coord.start_stage("stage-0", [task])
     pulled = coord.pull_task("worker-A")
     assert pulled is not None and pulled != "SHUTDOWN"
     _task, attempt, _config = pulled
     coord.report_result("worker-A", 0, attempt, TaskResult(shard=ListShard(refs=[])), CounterSnapshot.empty())
 
-    # Queue empty, but not last stage -> None
-    result = coord.pull_task("worker-A")
-    assert result is None
+    # Queue drained -> None (worker exits, coordinator may spawn another batch)
+    assert coord.pull_task("worker-A") is None
 
-    # Last stage: empty queue returns SHUTDOWN
-    task2 = ShardTask(
-        shard_idx=0,
-        total_shards=1,
-        shard=ListShard(refs=[]),
-        operations=[],
-        stage_name="test-last",
-    )
-    coord.start_stage("stage-1", [task2], is_last_stage=True)
-    pulled = coord.pull_task("worker-A")
-    assert pulled is not None and pulled != "SHUTDOWN"
-    _task, attempt, _config = pulled
-    coord.report_result("worker-A", 0, attempt, TaskResult(shard=ListShard(refs=[])), CounterSnapshot.empty())
-
-    # Queue empty on last stage, nothing in-flight -> SHUTDOWN
-    result = coord.pull_task("worker-A")
-    assert result == "SHUTDOWN"
+    # Coordinator shutdown takes precedence and returns SHUTDOWN.
+    coord.shutdown()
+    assert coord.pull_task("worker-A") == "SHUTDOWN"
 
 
 def test_last_shard_requeued_after_worker_crash(actor_context, tmp_path):
@@ -624,7 +608,7 @@ def test_last_shard_requeued_after_worker_crash(actor_context, tmp_path):
         ShardTask(shard_idx=i, total_shards=2, shard=ListShard(refs=[]), operations=[], stage_name="test")
         for i in range(2)
     ]
-    coord.start_stage("last-stage", tasks, is_last_stage=True)
+    coord.start_stage("last-stage", tasks)
 
     coord.heartbeat("worker-A")
     coord.heartbeat("worker-B")
@@ -648,7 +632,8 @@ def test_last_shard_requeued_after_worker_crash(actor_context, tmp_path):
     coord.report_result(
         "worker-A", _task.shard_idx, attempt, TaskResult(shard=ListShard(refs=[])), CounterSnapshot.empty()
     )
-    assert coord.pull_task("worker-A") == "SHUTDOWN"
+    # Stage drained — empty queue returns None (worker exits).
+    assert coord.pull_task("worker-A") is None
 
 
 def test_coordinator_loop_crash_aborts_pipeline(actor_context, tmp_path):

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -694,12 +694,12 @@ def test_run_pipeline_rejects_concurrent_calls(actor_context, tmp_path):
     first_entered = threading.Event()
     original_wait = coord._wait_for_stage
 
-    def blocking_wait():
+    def blocking_wait(**kwargs):
         first_entered.set()
         time.sleep(0.1)
         coord._fatal_error = "test: forced exit"
         try:
-            original_wait()
+            original_wait(**kwargs)
         except Exception:
             pass
 
@@ -832,3 +832,98 @@ def test_simple_map_integration(integration_ctx):
 def test_multi_stage_integration(integration_ctx):
     ds = Dataset.from_list([1, 2, 3, 4, 5]).map(lambda x: x * 2).filter(lambda x: x > 5)
     assert sorted(integration_ctx.execute(ds)) == [6, 8, 10]
+
+
+# --- On-demand worker tests ---
+
+
+def test_deregister_worker(actor_context, tmp_path):
+    """Workers deregister after completing their task, marking themselves DEAD."""
+    from unittest.mock import MagicMock
+
+    from zephyr.execution import ListShard, ShardTask, TaskResult, WorkerState, ZephyrCoordinator
+
+    coord = ZephyrCoordinator()
+    coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
+
+    task = ShardTask(shard_idx=0, total_shards=1, shard=ListShard(refs=[]), operations=[], stage_name="test")
+    coord.start_stage("test", [task])
+
+    coord.register_worker("worker-0", MagicMock())
+    assert coord._worker_states["worker-0"] == WorkerState.READY
+
+    pulled = coord.pull_task("worker-0")
+    assert pulled is not None and pulled != "SHUTDOWN"
+    _task, attempt, _ = pulled
+    assert coord._worker_states["worker-0"] == WorkerState.BUSY
+
+    coord.report_result("worker-0", 0, attempt, TaskResult(shard=ListShard(refs=[])), CounterSnapshot.empty())
+    assert coord._worker_states["worker-0"] == WorkerState.READY
+
+    coord.deregister_worker("worker-0")
+    assert coord._worker_states["worker-0"] == WorkerState.DEAD
+
+
+def test_reduce_stage_detection():
+    """PhysicalStage.is_reduce_stage is set for stages containing Reduce/Fold ops."""
+    from zephyr.dataset import GroupByOp, MapOp
+    from zephyr.plan import StageType, _fuse_operations
+
+    # GroupByOp produces: Scatter stage (mapper) + Reduce stage (reducer)
+    operations = [
+        MapOp(fn=lambda x: x),
+        GroupByOp(
+            key_fn=lambda x: x["key"],
+            reducer_fn=lambda k, items: {"key": k, "total": sum(i["val"] for i in items)},
+            num_output_shards=2,
+        ),
+    ]
+    stages = _fuse_operations(operations)
+    worker_stages = [s for s in stages if s.stage_type == StageType.WORKER]
+    assert len(worker_stages) == 2
+    # First worker stage: Map + Scatter (mapper) — not a reduce stage
+    assert not worker_stages[0].is_reduce_stage
+    # Second worker stage: Reduce (reducer) — is a reduce stage
+    assert worker_stages[1].is_reduce_stage
+
+
+def test_more_tasks_than_workers(local_client, tmp_path):
+    """On-demand batching handles more tasks than max_workers correctly."""
+    ctx = ZephyrContext(
+        client=local_client,
+        max_workers=2,
+        resources=ResourceConfig(cpu=1, ram="512m"),
+        chunk_storage_prefix=str(tmp_path / "chunks"),
+        name=f"test-batch-{uuid.uuid4().hex[:8]}",
+    )
+    # 6 tasks with max_workers=2: needs multiple worker batches
+    ds = Dataset.from_list([1, 2, 3, 4, 5, 6]).map(lambda x: x * 3)
+    results = sorted(list(ctx.execute(ds)))
+    assert results == [3, 6, 9, 12, 15, 18]
+
+
+def test_on_demand_workers_with_reducer_resources(local_client, tmp_path):
+    """Pipeline with group_by uses reducer_resources for reduce stages."""
+    ctx = ZephyrContext(
+        client=local_client,
+        max_workers=2,
+        resources=ResourceConfig(cpu=1, ram="512m"),
+        reducer_resources=ResourceConfig(cpu=1, ram="1g"),
+        chunk_storage_prefix=str(tmp_path / "chunks"),
+        name=f"test-reducer-res-{uuid.uuid4().hex[:8]}",
+    )
+    ds = Dataset.from_list(
+        [
+            {"key": "a", "val": 1},
+            {"key": "b", "val": 2},
+            {"key": "a", "val": 3},
+        ]
+    ).group_by(
+        lambda x: x["key"],
+        reducer=lambda key, items: {"key": key, "total": sum(i["val"] for i in items)},
+        num_output_shards=2,
+    )
+    results = sorted(list(ctx.execute(ds)), key=lambda x: x["key"])
+    assert len(results) == 2
+    assert results[0] == {"key": "a", "total": 4}
+    assert results[1] == {"key": "b", "total": 2}

--- a/lib/zephyr/tests/test_worker_group_race.py
+++ b/lib/zephyr/tests/test_worker_group_race.py
@@ -4,7 +4,7 @@
 """Regression tests for issue #4117: _check_worker_group false abort.
 
 The race (before fix):
-1. Last stage completes — all shards done, workers get SHUTDOWN, exit
+1. A stage's last shard completes — single-task workers exit cleanly
 2. Main thread is in _collect_results / _regroup_result_refs (between
    _wait_for_stage returning and self.shutdown())
 3. Background coordinator loop calls _check_worker_group
@@ -39,7 +39,7 @@ def test_check_worker_group_skips_after_completed_stage(coordinator):
     coordinator.set_worker_group(mock_group)
 
     task = ShardTask(shard_idx=0, total_shards=1, shard=ListShard(refs=[]), operations=[], stage_name="test")
-    coordinator.start_stage("last-stage", [task], is_last_stage=True)
+    coordinator.start_stage("last-stage", [task])
     coordinator.report_result("worker-0", 0, 0, TaskResult(shard=ListShard(refs=[])), CounterSnapshot.empty())
 
     assert coordinator._completed_shards >= coordinator._total_shards
@@ -56,7 +56,7 @@ def test_check_worker_group_still_aborts_mid_stage(coordinator):
     coordinator.set_worker_group(mock_group)
 
     task = ShardTask(shard_idx=0, total_shards=2, shard=ListShard(refs=[]), operations=[], stage_name="test")
-    coordinator.start_stage("mid-stage", [task, task], is_last_stage=False)
+    coordinator.start_stage("mid-stage", [task, task])
     # Only 1 of 2 shards completed
     coordinator.report_result("worker-0", 0, 0, TaskResult(shard=ListShard(refs=[])), CounterSnapshot.empty())
 
@@ -80,7 +80,7 @@ def test_coordinator_loop_no_abort_during_result_collection(coordinator):
     coordinator.set_worker_group(mock_group)
 
     task = ShardTask(shard_idx=0, total_shards=1, shard=ListShard(refs=[]), operations=[], stage_name="test")
-    coordinator.start_stage("last-stage", [task], is_last_stage=True)
+    coordinator.start_stage("last-stage", [task])
     coordinator.report_result("worker-0", 0, 0, TaskResult(shard=ListShard(refs=[])), CounterSnapshot.empty())
 
     t = threading.Thread(target=coordinator._coordinator_loop, daemon=True)


### PR DESCRIPTION
* fixes https://github.com/marin-community/marin/issues/4003
* replace the fixed-size worker pool with on-demand single-task workers, spawned per stage
* each worker pulls one task, executes it, reports the result, deregisters, and exits — the coordinator spawns a fresh batch whenever tasks remain in the queue but no workers are alive
* add `ZephyrContext.reducer_resources` so reduce stages can request a different `ResourceConfig` than mapper stages [^1]
  * `PhysicalStage.is_reduce_stage` is set during plan fusion for stages containing `Reduce`/`Fold` ops
* expose `ZephyrCoordinator.spawn_worker_batch` as a public method
* remove the vestigial `is_last_stage` flag — single-task workers exit on both `SHUTDOWN` and an empty-queue `None` from `pull_task`, so the eager-shutdown branch was a no-op
* `_poll_loop` now always calls `deregister_worker` in a `finally` block, not just on the task-completed path
  * fixes a stale `READY` race [^2] where a worker that exited via `SHUTDOWN`, empty queue, or RPC failure would block the next stage's spawn decision until heartbeat timeout reclassified it
* `spawn_worker_batch` now blocks on `_await_first_registration` before returning
  * `ActorGroup.wait_ready()` returns the actor handles immediately on Ray and Local — without this wait, `_wait_for_stage` saw `alive_workers == 0` right after spawning and called `spawn_fn` again in a tight loop, producing a spawn-storm of dozens of unregistered workers in <1s
  * polls `_worker_handles` for presence rather than `READY`/`BUSY` state, since a fast single-task worker may already be `DEAD` by the time we observe it
* fray: `LocalActorMethod.remote` now propagates `contextvars` into the worker thread, mirroring `LocalClient.submit`
  * without it, an actor method that calls `current_client()` from the spawned thread loses `set_current_client(...)` and falls back to auto-detection — picking up an unrelated backend if e.g. ray is initialized in the same process for an earlier test [^3]

[^1]: previously all stages shared `ZephyrContext.resources`, which forced reducers (typically larger memory, fewer parallel tasks) onto the same shape as mappers
[^2]: flagged on https://github.com/marin-community/marin/pull/4375#discussion_r3030878915
[^3]: surfaced by `test_multi_stage` hanging when run after `test_multi_stage_integration[ray]` in the same session — `current_client()` returned a `RayClient` instead of the local one and the spawned workers couldn't reach the local-hosted coordinator
