### PR TITLE
[iris] Skip SA impersonation in metadata SSH auth mode

### DIFF
--- a/lib/iris/src/iris/cluster/providers/gcp/ssh.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/ssh.py
@@ -102,6 +102,10 @@ def ssh_impersonate_service_account(
 ) -> str | None:
     if ssh_config and ssh_config.impersonate_service_account:
         return ssh_config.impersonate_service_account
+    # In metadata auth mode, SSH keys are managed via project/instance metadata
+    # and don't require service account impersonation.
+    if ssh_config and ssh_config.auth_mode == config_pb2.SshConfig.SSH_AUTH_MODE_METADATA:
+        return None
     if service_account:
         return service_account
     return None


### PR DESCRIPTION
## Summary
- `ssh_impersonate_service_account()` was unconditionally falling through to the controller's service account, even in `SSH_AUTH_MODE_METADATA` where keys are managed via project/instance metadata and impersonation is unnecessary.
- This caused local CLI commands like `iris cluster dashboard` to impersonate `iris-controller@hai-gcp-models.iam.gserviceaccount.com` when they shouldn't need to.

## Test plan
- [ ] Run `uv run iris --config lib/iris/examples/marin.yaml cluster dashboard` and verify no `--impersonate-service-account` flag on gcloud commands
- [ ] Verify OS Login mode still impersonates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)