### PR TITLE
[iris] Drop implicit SA fallback from SSH impersonation

### DIFF
--- a/lib/iris/src/iris/cluster/providers/gcp/controller.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/controller.py
@@ -117,7 +117,6 @@ class GcpControllerProvider:
             project=self.worker_provider.project_id,
             label_prefix=self.worker_provider.label_prefix,
             ssh_config=self.worker_provider.ssh_config,
-            service_account=self.controller_service_account,
             local_port=local_port,
         )
 
@@ -228,7 +227,6 @@ def _gcp_tunnel(
     project: str,
     label_prefix: str,
     ssh_config: config_pb2.SshConfig | None,
-    service_account: str | None = None,
     local_port: int | None = None,
     timeout: float = 60.0,
 ) -> Iterator[str]:
@@ -238,7 +236,7 @@ def _gcp_tunnel(
     that may be listening on the same port on a different address family (IPv6).
     Picks a free port automatically if none is specified.
     """
-    effective_service_account = ssh_impersonate_service_account(ssh_config, service_account)
+    effective_service_account = ssh_impersonate_service_account(ssh_config)
     key_file = ssh_key_file(ssh_config, effective_service_account)
     _check_gcloud_ssh_key(key_file)
 

--- a/lib/iris/src/iris/cluster/providers/gcp/handles.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/handles.py
@@ -65,15 +65,12 @@ _GCE_VM_SLICE_SSH_USER = "iris"
 
 def _os_login_user(
     ssh_config: config_pb2.SshConfig | None,
-    service_account: str | None = None,
 ) -> str:
     if ssh_config and ssh_config.os_login_user:
         return ssh_config.os_login_user
     if ssh_config and ssh_config.user and ssh_config.user != "root":
         return ssh_config.user
-    return resolve_current_os_login_user(
-        impersonate_service_account=ssh_impersonate_service_account(ssh_config, service_account)
-    )
+    return resolve_current_os_login_user(impersonate_service_account=ssh_impersonate_service_account(ssh_config))
 
 
 def _vm_slice_metadata_user(ssh_config: config_pb2.SshConfig | None) -> str:
@@ -319,10 +316,10 @@ class GcpSliceHandle:
                 direct_host = external_ip or internal_ip
                 remote_exec = DirectSshRemoteExec(
                     host=direct_host,
-                    user=_os_login_user(self._ssh_config, self._service_account),
+                    user=_os_login_user(self._ssh_config),
                     key_file=ssh_key_file(
                         self._ssh_config,
-                        ssh_impersonate_service_account(self._ssh_config, self._service_account),
+                        ssh_impersonate_service_account(self._ssh_config),
                     ),
                     connect_timeout=(
                         duration_from_proto(self._ssh_config.connect_timeout)
@@ -339,12 +336,9 @@ class GcpSliceHandle:
                     ssh_user=_vm_slice_metadata_user(self._ssh_config),
                     ssh_key_file=ssh_key_file(
                         self._ssh_config,
-                        ssh_impersonate_service_account(self._ssh_config, self._service_account),
+                        ssh_impersonate_service_account(self._ssh_config),
                     ),
-                    impersonate_service_account=ssh_impersonate_service_account(
-                        self._ssh_config,
-                        self._service_account,
-                    ),
+                    impersonate_service_account=ssh_impersonate_service_account(self._ssh_config),
                     _address=internal_ip,
                 )
             workers.append(
@@ -449,12 +443,9 @@ class GcpVmSliceHandle:
             ssh_user=None if uses_os_login(self._ssh_config) else _vm_slice_metadata_user(self._ssh_config),
             ssh_key_file=ssh_key_file(
                 self._ssh_config,
-                ssh_impersonate_service_account(self._ssh_config, self._service_account),
+                ssh_impersonate_service_account(self._ssh_config),
             ),
-            impersonate_service_account=ssh_impersonate_service_account(
-                self._ssh_config,
-                self._service_account,
-            ),
+            impersonate_service_account=ssh_impersonate_service_account(self._ssh_config),
         )
         worker = GcpStandaloneWorkerHandle(
             _vm_id=f"{self._slice_id}-worker-0",

--- a/lib/iris/src/iris/cluster/providers/gcp/ssh.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/ssh.py
@@ -98,14 +98,8 @@ def ssh_key_file(
 
 def ssh_impersonate_service_account(
     ssh_config: config_pb2.SshConfig | None,
-    service_account: str | None = None,
 ) -> str | None:
+    """Return the explicit impersonation SA from ssh_config, or None."""
     if ssh_config and ssh_config.impersonate_service_account:
         return ssh_config.impersonate_service_account
-    # In metadata auth mode, SSH keys are managed via project/instance metadata
-    # and don't require service account impersonation.
-    if ssh_config and ssh_config.auth_mode == config_pb2.SshConfig.SSH_AUTH_MODE_METADATA:
-        return None
-    if service_account:
-        return service_account
     return None

--- a/lib/iris/src/iris/cluster/providers/gcp/workers.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/workers.py
@@ -236,7 +236,7 @@ class GcpWorkerProvider:
             zone=zone,
             vm_name=config.name,
             ssh_key_file=ssh_key_file(self._ssh_config),
-            impersonate_service_account=ssh_impersonate_service_account(self._ssh_config, request.service_account),
+            impersonate_service_account=ssh_impersonate_service_account(self._ssh_config),
         )
 
         return GcpStandaloneWorkerHandle(
@@ -536,7 +536,7 @@ class GcpWorkerProvider:
                 zone=vm.zone,
                 vm_name=vm.name,
                 ssh_key_file=ssh_key_file(self._ssh_config),
-                impersonate_service_account=ssh_impersonate_service_account(self._ssh_config, vm.service_account),
+                impersonate_service_account=ssh_impersonate_service_account(self._ssh_config),
             )
             handles.append(
                 GcpStandaloneWorkerHandle(

--- a/lib/iris/tests/cluster/providers/gcp/test_platform.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_platform.py
@@ -475,7 +475,7 @@ def test_gcp_vm_slice_os_login_uses_service_account_impersonation():
 
     handle = platform.create_slice(cfg)
     status = handle.describe()
-    assert status.workers[0]._remote_exec.impersonate_service_account == cfg.gcp.service_account
+    assert status.workers[0]._remote_exec.impersonate_service_account is None
 
 
 def test_gcp_vm_slice_os_login_prefers_explicit_ssh_impersonation_account():
@@ -857,7 +857,7 @@ def test_gcp_tpu_slice_os_login_resolves_user_from_service_account():
         handle = platform.create_slice(cfg)
         status = handle.describe()
 
-    resolve_user.assert_called_with(impersonate_service_account=cfg.gcp.service_account)
+    resolve_user.assert_called_with(impersonate_service_account=None)
     assert status.workers[0]._remote_exec.user == "svc-user"
 
 


### PR DESCRIPTION
Remove the service_account parameter from ssh_impersonate_service_account()
so impersonation only happens when explicitly configured in SshConfig. Previously
the function fell back to the worker/controller service_account, which caused
metadata-mode SSH commands to include --impersonate-service-account unnecessarily,
requiring the controller SA to hold iam.serviceAccountUser on every worker SA.
Now metadata mode uses the VM's ambient identity and OS Login setups must set
ssh.impersonate_service_account explicitly.