### PR TITLE
[levanter] Pass explicit AWS credentials to silence CRT log spam

### DIFF
--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -50,6 +50,13 @@ def build_kvstore_spec(path: str) -> dict:
             # Custom endpoint with no explicit region: use a placeholder to prevent
             # tensorstore from trying (and failing) to discover the region via HEAD bucket.
             spec["aws_region"] = "us-east-1"
+
+        # Supplying credentials explicitly reduces noisy AWS CRT logs in containers.
+        access_key = os.environ.get("AWS_ACCESS_KEY_ID")
+        secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+        if access_key and secret_key:
+            spec["aws_credentials"] = {"access_key": access_key, "secret_key": secret_key}
+
         return spec
     elif parsed.scheme == "gs":
         return {"driver": "gcs", "bucket": parsed.netloc, "path": parsed.path.lstrip("/")}


### PR DESCRIPTION
## Summary
- Pass `aws_credentials` explicitly in the tensorstore S3 kvstore spec when `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` env vars are set
- This skips the default AWS credential chain, eliminating noisy CRT log spam (`Failed to open file`, `Profile credentials parser could not load`) in containers without `~/.aws/config`
- Primarily affects levanter-cache-copy/build workers on iris-task using R2 via env-var auth

Closes #4384

## Test plan
- [ ] Verify on a linux container with `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` set and no `~/.aws/` directory that the CRT log noise is gone
- [ ] Verify S3/R2 reads and writes still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
