### PR TITLE
[iris] Fix dev_tpu.py to use provider_bundle API

### DIFF
--- a/scripts/iris/dev_tpu.py
+++ b/scripts/iris/dev_tpu.py
@@ -169,11 +169,12 @@ def find_workspace_root(start: Path) -> Path | None:
 def controller_client(config_file: str) -> Iterable[IrisClient]:
     iris_config = IrisConfig.load(config_file)
     controller_address = iris_config.controller_address()
-    platform = iris_config.platform()
+    providers = iris_config.provider_bundle()
+    controller = providers.controller
     workspace = find_workspace_root(Path.cwd())
     if not controller_address:
-        controller_address = platform.discover_controller(iris_config.proto.controller)
-    with platform.tunnel(address=controller_address) as tunneled:
+        controller_address = controller.discover_controller(iris_config.proto.controller)
+    with controller.tunnel(address=controller_address) as tunneled:
         client = IrisClient.remote(tunneled, workspace=workspace)
         try:
             yield client


### PR DESCRIPTION
## Summary

- `scripts/iris/dev_tpu.py` still called `IrisConfig.platform()`, which was removed in #3900
- Replace with `provider_bundle().controller` to match the current `IrisConfig` API

Fixes #4394

## Test plan

- [x] `uv run python scripts/iris/dev_tpu.py --help` — CLI loads without import errors
- [x] `uv run pytest lib/iris/tests/test_dev_tpu.py` — 4/4 pass
- [x] `uv run python scripts/iris/dev_tpu.py --config lib/iris/examples/marin.yaml --tpu-name test-dev-tpu allocate --tpu-type v6e-8` — tunnel established, job submitted to live cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)