### PR TITLE
[iris] Allow capacity_type in resources with stale compiled protos

### DIFF
--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -952,9 +952,10 @@ def _normalize_scale_group_resources(data: dict) -> None:
             raise ValueError(f"scale_groups.{name}.resources must be a mapping")
 
         # Proto field names derived from the ScaleGroupResources descriptor,
-        # plus user-friendly YAML aliases that get normalized below.
-        _YAML_ALIASES = {"cpu", "ram", "disk"}
-        allowed_keys = set(config_pb2.ScaleGroupResources.DESCRIPTOR.fields_by_name.keys()) | _YAML_ALIASES
+        # plus fields handled explicitly by normalization code below (may not
+        # yet appear in stale compiled protos).
+        _NORMALIZED_KEYS = {"cpu", "ram", "disk", "capacity_type"}
+        allowed_keys = set(config_pb2.ScaleGroupResources.DESCRIPTOR.fields_by_name.keys()) | _NORMALIZED_KEYS
         unknown_keys = set(resources.keys()) - allowed_keys
         if unknown_keys:
             unknown = ", ".join(sorted(unknown_keys))


### PR DESCRIPTION
The unknown-keys check in _normalize_scale_group_resources derived allowed
keys solely from the compiled proto descriptor. When the installed proto
bindings are stale (capacity_type not yet in DESCRIPTOR.fields_by_name),
the check raises ValueError before the normalization code can handle it.

Add capacity_type to _NORMALIZED_KEYS (renamed from _YAML_ALIASES to
reflect its actual purpose: fields explicitly handled by normalization,
which may not yet appear in stale compiled protos).