### PR TITLE
[iris] Return raw memray .bin traces and enable native tracking

### DIFF
--- a/lib/iris/dashboard/src/components/controller/JobDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/JobDetail.vue
@@ -404,7 +404,7 @@ const filteredTasks = computed(() => {
 
 function buildProfileType(profilerType: string, format: string | null): Record<string, unknown> {
   if (profilerType === 'cpu') return { cpu: { format: format ?? 'SPEEDSCOPE' } }
-  if (profilerType === 'memory') return { memory: { format: format ?? 'FLAMEGRAPH' } }
+  if (profilerType === 'memory') return { memory: { format: format ?? 'RAW' } }
   return { threads: {} }
 }
 
@@ -428,7 +428,8 @@ async function handleProfile(taskId: string, profilerType: string, format: strin
       const a = document.createElement('a')
       a.href = url
       const ts = new Date().toISOString().replace(/[T]/g, '_').replace(/:/g, '-').replace(/\.\d+Z$/, '')
-      a.download = `${ts}_profile-${taskId.replace(/\//g, '_')}.out`
+      const ext = profilerType === 'memory' ? 'bin' : 'out'
+      a.download = `${ts}_profile-${taskId.replace(/\//g, '_')}.${ext}`
       a.click()
       URL.revokeObjectURL(url)
     }
@@ -785,7 +786,7 @@ async function handleProfile(taskId: string, profilerType: string, format: strin
                   <button
                     class="px-2 py-0.5 text-[11px] font-semibold rounded bg-status-success text-white hover:opacity-80 disabled:opacity-50"
                     :disabled="profilingTaskId === task.taskId"
-                    @click="handleProfile(task.taskId, 'memory', 'FLAMEGRAPH')"
+                    @click="handleProfile(task.taskId, 'memory', 'RAW')"
                   >
                     {{ profilingTaskId === task.taskId ? '⏳' : 'MEM' }}
                   </button>

--- a/lib/iris/dashboard/src/composables/useProfileAction.ts
+++ b/lib/iris/dashboard/src/composables/useProfileAction.ts
@@ -12,7 +12,7 @@ export type ProfilerType = 'cpu' | 'memory' | 'threads'
 
 function buildProfileType(profilerType: ProfilerType): Record<string, unknown> {
   if (profilerType === 'cpu') return { cpu: { format: 'SPEEDSCOPE' } }
-  if (profilerType === 'memory') return { memory: { format: 'FLAMEGRAPH' } }
+  if (profilerType === 'memory') return { memory: { format: 'RAW' } }
   return { threads: {} }
 }
 
@@ -33,7 +33,8 @@ function handleProfileResult(decoded: string, profilerType: ProfilerType, label:
     const a = document.createElement('a')
     a.href = url
     const ts = new Date().toISOString().replace(/[T]/g, '_').replace(/:/g, '-').replace(/\.\d+Z$/, '')
-    a.download = `${ts}_profile-${label.replace(/\//g, '_')}.out`
+    const ext = profilerType === 'memory' ? 'bin' : 'out'
+    a.download = `${ts}_profile-${label.replace(/\//g, '_')}.${ext}`
     a.click()
     URL.revokeObjectURL(url)
   }

--- a/lib/iris/src/iris/cluster/providers/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/tasks.py
@@ -1094,6 +1094,11 @@ class K8sTaskProvider:
         attach_cmd = shlex.join(build_memray_attach_cmd(spec, memray_bin="memray", trace_path=trace_path))
         self._kubectl_exec_shell(pod_name, attach_cmd, timeout=duration + 30)
 
+        if spec.is_raw:
+            data = self.kubectl.read_file(pod_name, trace_path, container="task")
+            self.kubectl.rm_files(pod_name, [trace_path], container="task")
+            return cluster_pb2.ProfileTaskResponse(profile_data=data)
+
         transform_cmd = shlex.join(
             build_memray_transform_cmd(spec, memray_bin="memray", trace_path=trace_path, output_path=output_path)
         )

--- a/lib/iris/src/iris/cluster/runtime/docker.py
+++ b/lib/iris/src/iris/cluster/runtime/docker.py
@@ -383,7 +383,7 @@ class DockerContainerHandle:
 
             if status.exit_code != 0:
                 log_text = "\n".join(f"[{entry.source}] {entry.data}" for entry in build_logs[-50:])
-                raise RuntimeError(f"Build failed with exit_code={status.exit_code}\n" f"Last 50 log lines:\n{log_text}")
+                raise RuntimeError(f"Build failed with exit_code={status.exit_code}\nLast 50 log lines:\n{log_text}")
 
             logger.info("Build phase completed successfully for task %s", self.config.task_id)
             return build_logs
@@ -551,7 +551,6 @@ exec {quoted_cmd}
         output_path = f"/tmp/memray-output-{profile_id}.{spec.ext}"
 
         attach_cmd = build_memray_attach_cmd(spec, memray_bin, trace_path)
-        transform_cmd = build_memray_transform_cmd(spec, memray_bin, trace_path, output_path)
 
         logger.info(
             "Memory profiling container %s for %ds (format=%s, leaks=%s)",
@@ -567,6 +566,10 @@ exec {quoted_cmd}
             if result.returncode != 0:
                 raise RuntimeError(f"memray attach failed: {result.stderr}")
 
+            if spec.is_raw:
+                return self._docker_read_file(container_id, trace_path)
+
+            transform_cmd = build_memray_transform_cmd(spec, memray_bin, trace_path, output_path)
             result = self._docker_exec(container_id, transform_cmd, capture_output=True, text=True, timeout=30)
             if result.returncode != 0:
                 raise RuntimeError(f"memray {spec.reporter} failed: {result.stderr}")

--- a/lib/iris/src/iris/cluster/runtime/process.py
+++ b/lib/iris/src/iris/cluster/runtime/process.py
@@ -357,6 +357,8 @@ def _memory_profile_stub(memory_format: int) -> bytes:
         )
     elif memory_format == cluster_pb2.MemoryProfile.TABLE:
         return b"memray unavailable in local mode\n"
+    elif memory_format == cluster_pb2.MemoryProfile.RAW:
+        return b""
     else:  # STATS
         return b'{"error": "memray unavailable in local mode"}'
 
@@ -584,6 +586,9 @@ class ProcessContainerHandle:
             result = subprocess.run(attach_cmd, capture_output=True, text=True, timeout=duration_seconds + 10)
             if result.returncode != 0:
                 raise RuntimeError(f"memray attach failed: {result.stderr}")
+
+            if spec.is_raw:
+                return Path(trace_path).read_bytes()
 
             if spec.output_is_file:
                 with tempfile.NamedTemporaryFile(suffix=f".{spec.ext}", delete=False) as f:

--- a/lib/iris/src/iris/cluster/runtime/profile.py
+++ b/lib/iris/src/iris/cluster/runtime/profile.py
@@ -40,6 +40,7 @@ MEMORY_FORMAT_MAP: dict[int, tuple[str, str]] = {
     cluster_pb2.MemoryProfile.FLAMEGRAPH: ("flamegraph", "html"),
     cluster_pb2.MemoryProfile.TABLE: ("table", "txt"),
     cluster_pb2.MemoryProfile.STATS: ("stats", "json"),
+    cluster_pb2.MemoryProfile.RAW: ("raw", "bin"),
 }
 
 
@@ -60,6 +61,11 @@ class MemoryProfileSpec:
     duration_seconds: int
     pid: str
     leaks: bool
+
+    @property
+    def is_raw(self) -> bool:
+        """Raw mode returns the .bin trace directly, skipping transform."""
+        return self.reporter == "raw"
 
     @property
     def output_is_file(self) -> bool:
@@ -112,7 +118,7 @@ def build_pyspy_cmd(spec: CpuProfileSpec, py_spy_bin: str, output_path: str) -> 
 
 
 def build_memray_attach_cmd(spec: MemoryProfileSpec, memray_bin: str, trace_path: str) -> list[str]:
-    cmd = [memray_bin, "attach", spec.pid, "--duration", str(spec.duration_seconds), "--output", trace_path]
+    cmd = [memray_bin, "attach", "--native", spec.pid, "--duration", str(spec.duration_seconds), "--output", trace_path]
     if spec.leaks:
         cmd.append("--aggregate")
     return cmd
@@ -215,8 +221,12 @@ def _run_memray_profile(pid: str, duration_seconds: int, memory_config: cluster_
         os.unlink(trace_path)
 
         # Track allocations in-process for the requested duration.
-        with memray.Tracker(trace_path, file_format=file_format):
+        with memray.Tracker(trace_path, native_traces=True, file_format=file_format):
             time.sleep(duration_seconds)
+
+        # Raw mode: return the .bin trace directly, no transform needed.
+        if spec.is_raw:
+            return Path(trace_path).read_bytes()
 
         if spec.output_is_file:
             with tempfile.NamedTemporaryFile(suffix=f".{spec.ext}", delete=False) as f:

--- a/lib/iris/src/iris/rpc/cluster.proto
+++ b/lib/iris/src/iris/rpc/cluster.proto
@@ -105,6 +105,7 @@ message MemoryProfile {
     FLAMEGRAPH = 1;     // HTML flamegraph with memory timeline
     TABLE = 2;          // Text summary table
     STATS = 3;          // JSON statistics
+    RAW = 4;            // Raw .bin trace file (use with memray CLI locally)
   }
   Format format = 1;
   bool leaks = 2;       // Focus on potential memory leaks

--- a/lib/iris/tests/cluster/runtime/test_profile.py
+++ b/lib/iris/tests/cluster/runtime/test_profile.py
@@ -66,6 +66,7 @@ def test_resolve_cpu_spec_preserves_nonzero_rate_hz():
         (cluster_pb2.MemoryProfile.FLAMEGRAPH, "flamegraph", "html", True),
         (cluster_pb2.MemoryProfile.TABLE, "table", "txt", False),
         (cluster_pb2.MemoryProfile.STATS, "stats", "json", True),
+        (cluster_pb2.MemoryProfile.RAW, "raw", "bin", False),
     ],
 )
 def test_resolve_memory_spec_maps_format(proto_format, expected_reporter, expected_ext, expected_is_file):
@@ -98,6 +99,7 @@ def test_memray_attach_includes_aggregate_when_leaks_enabled():
     spec = resolve_memory_spec(cfg, duration_seconds=10, pid="5")
     cmd = build_memray_attach_cmd(spec, memray_bin="memray", trace_path="/tmp/trace.bin")
     assert "--aggregate" in cmd
+    assert "--native" in cmd
 
 
 def test_memray_attach_excludes_aggregate_when_leaks_disabled():
@@ -105,6 +107,7 @@ def test_memray_attach_excludes_aggregate_when_leaks_disabled():
     spec = resolve_memory_spec(cfg, duration_seconds=5, pid="1")
     cmd = build_memray_attach_cmd(spec, memray_bin="memray", trace_path="/tmp/trace.bin")
     assert "--aggregate" not in cmd
+    assert "--native" in cmd
 
 
 # ---------------------------------------------------------------------------
@@ -165,12 +168,25 @@ def _allocate_during(duration_seconds: int) -> list:
     return results
 
 
+def test_resolve_memory_spec_raw_is_raw():
+    cfg = cluster_pb2.MemoryProfile(format=cluster_pb2.MemoryProfile.RAW)
+    spec = resolve_memory_spec(cfg, duration_seconds=5, pid="1")
+    assert spec.is_raw is True
+
+
+def test_resolve_memory_spec_flamegraph_is_not_raw():
+    cfg = cluster_pb2.MemoryProfile(format=cluster_pb2.MemoryProfile.FLAMEGRAPH)
+    spec = resolve_memory_spec(cfg, duration_seconds=5, pid="1")
+    assert spec.is_raw is False
+
+
 @pytest.mark.parametrize(
     "proto_format",
     [
         cluster_pb2.MemoryProfile.FLAMEGRAPH,
         cluster_pb2.MemoryProfile.TABLE,
         cluster_pb2.MemoryProfile.STATS,
+        cluster_pb2.MemoryProfile.RAW,
     ],
 )
 def test_run_memray_profile_returns_nonempty_output(proto_format):


### PR DESCRIPTION
Add RAW format to MemoryProfile that returns the .bin trace file directly,
skipping the server-side transform step. Users run any memray reporter
locally (flamegraph, tree, stats, speedscope). Dashboard MEM button now
downloads .bin by default. Also enables --native on all memray attach
calls so C/Rust allocations (e.g. HuggingFace tokenizers) are visible.