### PR TITLE
[iris] Fix unpooled CPU VM groups rendering under last TPU pool

### DIFF
--- a/lib/iris/dashboard/src/components/controller/AutoscalerTab.vue
+++ b/lib/iris/dashboard/src/components/controller/AutoscalerTab.vue
@@ -285,7 +285,7 @@ const poolSections = computed<PoolSection[]>(() => {
   }
 
   if (unpooled.length > 0) {
-    sections.push({ pool: '', groups: unpooled, blockedAtTier: null })
+    sections.push({ pool: '__unpooled', groups: unpooled, blockedAtTier: null })
   }
 
   return sections
@@ -548,14 +548,14 @@ function idleThresholdMs(groupName: string): number {
           <tbody>
             <template v-for="section in poolSections" :key="section.pool || '__unpooled'">
               <!-- Pool header row -->
-              <tr v-if="section.pool" class="bg-surface border-b border-surface-border cursor-pointer hover:bg-surface-raised" @click="togglePool(section.pool)">
+              <tr class="bg-surface border-b border-surface-border cursor-pointer hover:bg-surface-raised" @click="togglePool(section.pool)">
                 <td colspan="8" class="px-3 py-1.5">
                   <div class="flex items-center gap-2">
                     <span class="text-[10px] text-text-muted">
                       {{ collapsedPools.has(section.pool) ? '▶' : '▼' }}
                     </span>
                     <span class="text-xs font-semibold uppercase tracking-wider text-text-secondary">
-                      Pool: {{ section.pool }}
+                      {{ section.pool === '__unpooled' ? 'Unpooled' : `Pool: ${section.pool}` }}
                     </span>
                     <span
                       v-if="section.blockedAtTier"
@@ -564,8 +564,8 @@ function idleThresholdMs(groupName: string): number {
                     >
                       blocked at tier {{ section.blockedAtTier }}+
                     </span>
-                    <!-- Tier chain visualization -->
-                    <span class="flex items-center gap-0.5 text-xs text-text-muted ml-2">
+                    <!-- Tier chain visualization (not shown for unpooled groups) -->
+                    <span v-if="section.pool !== '__unpooled'" class="flex items-center gap-0.5 text-xs text-text-muted ml-2">
                       <template v-for="(gs, idx) in section.groups" :key="gs.group">
                         <span v-if="idx > 0" class="text-text-muted mx-0.5">&rarr;</span>
                         <span
@@ -591,7 +591,7 @@ function idleThresholdMs(groupName: string): number {
             <template v-for="gs in section.groups" :key="gs.group">
               <!-- Main row -->
               <tr
-                v-if="!section.pool || !collapsedPools.has(section.pool)"
+                v-if="!collapsedPools.has(section.pool)"
                 :class="[
                   'border-b border-surface-border-subtle hover:bg-surface-raised transition-colors',
                   isInactiveRow(gs) ? 'opacity-50' : '',
@@ -703,7 +703,7 @@ function idleThresholdMs(groupName: string): number {
               </tr>
 
               <!-- Slice detail (expanded) -->
-              <tr v-if="expandedSlices.has(gs.group) && groupHasSlices(gs.group) && (!section.pool || !collapsedPools.has(section.pool))" class="bg-surface-sunken">
+              <tr v-if="expandedSlices.has(gs.group) && groupHasSlices(gs.group) && (!collapsedPools.has(section.pool))" class="bg-surface-sunken">
                 <td colspan="8" class="px-6 py-3">
                   <div class="space-y-1.5">
                     <div
@@ -742,7 +742,7 @@ function idleThresholdMs(groupName: string): number {
               </tr>
 
               <!-- Demand detail (expanded) -->
-              <tr v-if="expandedDemand.has(gs.group) && groupDemand(gs.group) > 0 && (!section.pool || !collapsedPools.has(section.pool))" class="bg-surface-sunken">
+              <tr v-if="expandedDemand.has(gs.group) && groupDemand(gs.group) > 0 && (!collapsedPools.has(section.pool))" class="bg-surface-sunken">
                 <td colspan="8" class="px-6 py-3">
                   <div class="space-y-1">
                     <div


### PR DESCRIPTION
## Summary
- Groups without a `quota_pool` (e.g. CPU VMs from `marin-dev.yaml`) were rendered without a section header, causing them to visually merge with the preceding TPU pool section
- Give the unpooled section a `'__unpooled'` sentinel key so it gets its own collapsible "Unpooled" header row
- Remove the special-case `!section.pool` bypass so unpooled groups participate in collapse/expand like pooled groups
- Hide the tier chain visualization for unpooled groups (tiers don't apply to CPU VMs)

## Test plan
- [ ] Load the Iris controller dashboard with a config that includes both TPU pools and unpooled CPU VM groups
- [ ] Verify CPU VM groups appear under their own "Unpooled" section header, not under the last TPU pool
- [ ] Verify the "Unpooled" section is collapsible via click
- [ ] Verify TPU pool sections still render correctly with tier chains and blocked-at-tier badges