### PR TITLE
[iris] Fix AT_MAX_SLICES demand waterfall causing multi-zone cascade

### DIFF
--- a/lib/iris/src/iris/cluster/controller/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/scaling_group.py
@@ -1035,6 +1035,10 @@ class ScalingGroup:
         with self._slices_lock:
             pending = self._pending_scale_ups
             count = len(self._slices) + pending
+            has_inflight = pending > 0 or any(
+                s.lifecycle in (SliceLifecycleState.BOOTING, SliceLifecycleState.INITIALIZING)
+                for s in self._slices.values()
+            )
         if pending > 0:
             return AvailabilityState(
                 GroupAvailability.REQUESTING,
@@ -1042,6 +1046,11 @@ class ScalingGroup:
             )
 
         if count >= self._config.max_slices:
+            # When all slice slots are filled but some are still booting/initializing,
+            # accept demand so it doesn't waterfall to other groups. The routing budget
+            # already accounts for in-flight capacity via max_vms.
+            if has_inflight:
+                return AvailabilityState(GroupAvailability.COOLDOWN, "at max_slices with in-flight capacity")
             return AvailabilityState(GroupAvailability.AT_MAX_SLICES)
 
         cooldown_end = self._last_scale_up.add(self._scale_up_cooldown)

--- a/lib/iris/tests/cluster/controller/test_autoscaler_integration.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler_integration.py
@@ -124,12 +124,12 @@ class TestAutoscalerWaterfallEndToEnd:
         autoscaler.shutdown()
 
     def test_full_group_cascades_to_fallback(self):
-        """When primary group hits max_slices, demand cascades to fallback."""
+        """When primary group hits max_slices with all slices READY, demand cascades to fallback."""
 
         config_primary = make_scale_group_config(name="primary", max_slices=1, priority=10, zones=["us-central1-a"])
         config_fallback = make_scale_group_config(name="fallback", max_slices=5, priority=20, zones=["us-central1-a"])
 
-        platform_primary, _ = make_gcp_provider(config_primary)
+        platform_primary, service_primary = make_gcp_provider(config_primary)
         platform_fallback, _ = make_gcp_provider(config_fallback)
 
         group_primary = ScalingGroup(config_primary, platform_primary, scale_up_cooldown=Duration.from_ms(0))
@@ -146,6 +146,10 @@ class TestAutoscalerWaterfallEndToEnd:
         autoscaler.run_once(demand, {})
         autoscaler._wait_for_inflight()
         assert group_primary.slice_count() == 1
+
+        # Mark the primary slice as READY so it enters AT_MAX_SLICES (rejecting)
+        advance_all_tpus(service_primary, "READY")
+        _mark_all_slices_ready(group_primary)
 
         demand = make_demand_entries(2, device_type=DeviceType.CPU, device_variant=None)
         autoscaler.run_once(demand, {})

--- a/lib/iris/tests/cluster/controller/test_demand_routing.py
+++ b/lib/iris/tests/cluster/controller/test_demand_routing.py
@@ -291,6 +291,7 @@ class TestWaterfallRouting:
         discovered = [make_mock_slice_handle(f"slice-{i}", all_ready=True) for i in range(2)]
         group_high = ScalingGroup(config_high, make_mock_platform(slices_to_discover=discovered))
         group_high.reconcile()
+        _mark_discovered_ready(group_high, discovered)
 
         group_low = ScalingGroup(config_low, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
 
@@ -476,6 +477,7 @@ class TestWaterfallRouting:
         discovered = [make_mock_slice_handle("slice-0", all_ready=True)]
         group_a = ScalingGroup(config_a, make_mock_platform(slices_to_discover=discovered))
         group_a.reconcile()
+        _mark_discovered_ready(group_a, discovered)
         assert group_a.availability().status == GroupAvailability.AT_MAX_SLICES
 
         group_b = ScalingGroup(
@@ -489,6 +491,63 @@ class TestWaterfallRouting:
 
         # 2 tiny CPU entries pack into 1 slice
         assert len(result.routed_entries.get("group-b", [])) == 2
+
+    def test_booting_slice_at_max_does_not_cascade_across_zones(self):
+        """A single pending task must not waterfall across zones when the first zone
+        has a booting (in-flight) slice at max_slices.
+
+        Regression test: with max_slices=1 per zone and N zones, a single CPU task
+        caused all N zones to scale up because once a slice moved from REQUESTING to
+        BOOTING, the group returned AT_MAX_SLICES (rejecting), and demand waterfalled
+        to the next zone on every autoscaler cycle.
+        """
+
+        # Simulate 3 zones, each with max_slices=1 (mirrors production CPU VM config)
+        configs = [
+            make_scale_group_config(
+                name=f"cpu-zone-{i}",
+                max_slices=1,
+                priority=1000,
+                accelerator_type=config_pb2.ACCELERATOR_TYPE_CPU,
+                accelerator_variant="",
+            )
+            for i in range(3)
+        ]
+
+        ts = Timestamp.from_ms(1_000_000)
+
+        # Zone 0: has 1 booting slice (scale-up happened, slice created but not ready)
+        handle_0 = make_mock_slice_handle("slice-zone-0", all_ready=False)
+        group_0 = ScalingGroup(configs[0], make_mock_platform(), scale_up_cooldown=Duration.from_ms(60_000))
+        group_0.begin_scale_up(timestamp=ts)
+        group_0.complete_scale_up(handle_0, timestamp=ts)
+        # Slice is BOOTING, not READY. Group is at max_slices.
+        assert group_0.slice_count() == 1
+
+        # Zone 1 and 2: empty, ready to accept
+        group_1 = ScalingGroup(configs[1], make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        group_2 = ScalingGroup(configs[2], make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+
+        groups = [group_0, group_1, group_2]
+        demand = make_demand_entries(1, device_type=DeviceType.CPU, device_variant=None)
+
+        eval_ts = Timestamp.from_ms(1_030_000)
+        result = route_demand(groups, demand, eval_ts)
+
+        # The task should route to zone 0 (which already has a booting slice)
+        # and NOT cascade to zone 1 or zone 2.
+        routed_groups = [name for name, entries in result.routed_entries.items() if entries]
+        assert len(routed_groups) == 1, (
+            f"Expected demand routed to exactly 1 group, but routed to {routed_groups}. "
+            f"launch={result.group_to_launch}"
+        )
+        assert routed_groups[0] == "cpu-zone-0", (
+            f"Expected demand routed to cpu-zone-0 (has booting slice), " f"but routed to {routed_groups[0]}"
+        )
+        # No new slices should be launched — zone 0 already has capacity incoming
+        assert result.group_to_launch.get("cpu-zone-0", 0) == 0
+        assert result.group_to_launch.get("cpu-zone-1", 0) == 0
+        assert result.group_to_launch.get("cpu-zone-2", 0) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/providers/test_scaling_group.py
+++ b/lib/iris/tests/cluster/providers/test_scaling_group.py
@@ -738,7 +738,7 @@ class TestScalingGroupAvailability:
         assert state.status == GroupAvailability.AVAILABLE
 
     def test_at_max_slices_when_at_max_slices(self):
-        """Group is AT_MAX_SLICES when at max_slices."""
+        """Group is AT_MAX_SLICES when at max_slices with all slices READY."""
         from iris.cluster.controller.scaling_group import GroupAvailability
 
         config = _with_resources(
@@ -748,10 +748,13 @@ class TestScalingGroupAvailability:
                 max_slices=2,
             ),
         )
-        discovered = [make_fake_slice_handle(f"slice-{i}") for i in range(2)]
+        discovered = [make_fake_slice_handle(f"slice-{i}", all_ready=True) for i in range(2)]
         platform = make_mock_platform(slices_to_discover=discovered)
         group = ScalingGroup(config, platform)
         group.reconcile()
+        for h in discovered:
+            worker_ids = [w.worker_id for w in h.describe().workers]
+            group.mark_slice_ready(h.slice_id, worker_ids)
 
         state = group.availability()
         assert state.status == GroupAvailability.AT_MAX_SLICES
@@ -785,10 +788,13 @@ class TestScalingGroupAvailability:
                 max_slices=1,
             ),
         )
-        discovered = [make_fake_slice_handle("slice-0")]
+        discovered = [make_fake_slice_handle("slice-0", all_ready=True)]
         platform = make_mock_platform(slices_to_discover=discovered)
         group = ScalingGroup(config, platform)
         group.reconcile()
+        for h in discovered:
+            worker_ids = [w.worker_id for w in h.describe().workers]
+            group.mark_slice_ready(h.slice_id, worker_ids)
 
         assert group.can_accept_demand() is False
 
@@ -917,7 +923,8 @@ class TestScalingGroupAvailability:
         assert group.can_accept_demand(Timestamp.from_ms(1_003_000)) is True
 
     def test_at_max_slices_takes_precedence_over_cooldown(self):
-        """When both at max_slices and in cooldown, AT_MAX_SLICES takes precedence."""
+        """When both at max_slices and in cooldown, AT_MAX_SLICES takes precedence
+        (once all slices are READY)."""
         from iris.cluster.controller.scaling_group import GroupAvailability
 
         config = _with_resources(
@@ -936,7 +943,13 @@ class TestScalingGroupAvailability:
         handle = group.scale_up(timestamp=ts)
         group.complete_scale_up(handle, ts)
 
-        # At max_slices (1) AND in cooldown — AT_MAX_SLICES should win
+        # While slice is BOOTING, group accepts demand (in-flight capacity)
+        state = group.availability(Timestamp.from_ms(1_003_000))
+        assert state.status == GroupAvailability.COOLDOWN
+
+        # Once the slice is READY, AT_MAX_SLICES takes precedence over cooldown
+        worker_ids = [w.worker_id for w in handle.describe().workers]
+        group.mark_slice_ready(handle.slice_id, worker_ids)
         state = group.availability(Timestamp.from_ms(1_003_000))
         assert state.status == GroupAvailability.AT_MAX_SLICES
 


### PR DESCRIPTION
## Summary
- When a scaling group had a booting/initializing slice at `max_slices`, `availability()` returned `AT_MAX_SLICES` (rejecting), causing demand to waterfall to the next zone on every autoscaler cycle
- With `max_slices: 1` per zone and N zones (e.g. 10 CPU VM zones in marin-dev.yaml), a single pending CPU task would cascade across all N zones, spinning up N VMs
- Fix: when at `max_slices` but with in-flight (BOOTING/INITIALIZING) slices, return `COOLDOWN` (accepting) instead of `AT_MAX_SLICES`, so demand sticks to the group that's already provisioning capacity

## Test plan
- [x] Added regression test `test_booting_slice_at_max_does_not_cascade_across_zones` that verifies a single CPU task routes to the group with a booting slice and doesn't cascade
- [x] Updated existing tests to properly mark slices READY before asserting `AT_MAX_SLICES` behavior
- [x] All 775 controller + scaling_group tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)