### PR TITLE
[iris] Fix FetchLogs compat shim for old clients using proto binary encoding

### DIFF
--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -30,7 +30,6 @@ from http.cookies import SimpleCookie
 from urllib.parse import urlparse
 
 import httpx
-from google.protobuf.json_format import MessageToDict, ParseDict
 from starlette.applications import Starlette
 from starlette.middleware.wsgi import WSGIMiddleware
 from starlette.requests import Request
@@ -42,7 +41,6 @@ from iris.cluster.controller.actor_proxy import PROXY_ROUTE, ActorProxy
 from iris.cluster.controller.service import ControllerServiceImpl
 from iris.cluster.dashboard_common import html_shell, on_shutdown, static_files_mount
 from iris.log_server.server import LogServiceImpl
-from iris.rpc import logging_pb2
 from iris.rpc.auth import SESSION_COOKIE, NullAuthInterceptor, TokenVerifier, extract_bearer_token, resolve_auth
 from iris.rpc.cluster_connect import ControllerServiceWSGIApplication
 from iris.rpc.interceptors import RequestTimingInterceptor
@@ -265,24 +263,25 @@ class ControllerDashboard:
             # when present but treat everything as anonymous/admin.
             interceptors.insert(0, NullAuthInterceptor(verifier=self._auth_verifier))
         rpc_wsgi_app = ControllerServiceWSGIApplication(service=self._service, interceptors=interceptors)
-        rpc_app = WSGIMiddleware(rpc_wsgi_app)
 
         log_wsgi_app = LogServiceWSGIApplication(service=self._log_service, interceptors=interceptors)
         log_app = WSGIMiddleware(log_wsgi_app)
+
+        # Backward-compat: old clients call ControllerService/FetchLogs (removed
+        # from the proto in the LogService migration).  Register the already-
+        # intercepted LogService FetchLogs endpoint under the old path so the
+        # Connect protocol handles encoding, compression, and auth correctly.
+        _LOG_FETCH_ENDPOINT = "/iris.logging.LogService/FetchLogs"
+        _COMPAT_FETCH_ENDPOINT = "/iris.cluster.ControllerService/FetchLogs"
+        rpc_wsgi_app._endpoints[_COMPAT_FETCH_ENDPOINT] = log_wsgi_app._endpoints[_LOG_FETCH_ENDPOINT]
+
+        rpc_app = WSGIMiddleware(rpc_wsgi_app)
 
         self._actor_proxy = ActorProxy(self._service._db)
 
         @requires_auth
         async def _proxy_actor_rpc(request: Request) -> Response:
             return await self._actor_proxy.handle(request)
-
-        @requires_auth
-        async def _fetch_logs_compat(request: Request) -> JSONResponse:
-            """Backward-compat proxy: old clients POST to ControllerService/FetchLogs."""
-            body = await request.json()
-            req = ParseDict(body, logging_pb2.FetchLogsRequest())
-            resp = self._log_service.fetch_logs(req, None)
-            return JSONResponse(MessageToDict(resp, preserving_proto_field_name=True))
 
         routes = [
             Route("/", self._dashboard),
@@ -296,7 +295,6 @@ class ControllerDashboard:
             Route("/blobs/{blob_id:str}", self._blob_download),
             Route("/health", self._health),
             Route(PROXY_ROUTE, _proxy_actor_rpc, methods=["POST"]),
-            Route("/iris.cluster.ControllerService/FetchLogs", _fetch_logs_compat, methods=["POST"]),
             Mount(log_wsgi_app.path, app=log_app),
             Mount(rpc_wsgi_app.path, app=rpc_app),
             static_files_mount(),

--- a/lib/iris/tests/cluster/controller/test_dashboard.py
+++ b/lib/iris/tests/cluster/controller/test_dashboard.py
@@ -822,6 +822,23 @@ def test_fetch_logs_backward_compat_proxy(client):
     assert data.get("entries", []) == []
 
 
+def test_fetch_logs_backward_compat_proxy_proto_binary(client):
+    """Old clients using default Connect proto encoding hit the compat endpoint."""
+    from iris.rpc import logging_pb2
+
+    task_id = JobName.root("test-user", "nonexistent").task(0).to_wire()
+    req = logging_pb2.FetchLogsRequest(source=re.escape(task_id) + ":.*")
+    resp = client.post(
+        "/iris.cluster.ControllerService/FetchLogs",
+        content=req.SerializeToString(),
+        headers={"Content-Type": "application/proto"},
+    )
+    assert resp.status_code == 200
+    parsed = logging_pb2.FetchLogsResponse()
+    parsed.ParseFromString(resp.content)
+    assert list(parsed.entries) == []
+
+
 # =============================================================================
 # Coscheduling Diagnostic Tests
 # =============================================================================


### PR DESCRIPTION
The backward-compat handler for ControllerService/FetchLogs (added in #4274)
assumed JSON encoding via request.json(), but Connect protocol clients default
to protobuf binary. Old clients hitting the updated controller got 500 Internal
Server Error because json.loads() cannot parse binary protobuf data.

Replace the hand-rolled Starlette route with an endpoint alias: register the
LogService FetchLogs endpoint under the old ControllerService path in the
ConnectWSGIApplication so the Connect infrastructure handles encoding,
compression, and auth natively. Adds a proto-binary regression test.