### PR TITLE
[zephyr] Fix logging crash in coordinator daemon thread during shutdown

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -19,6 +19,7 @@ import logging
 import os
 import pickle
 import re
+import sys
 from datetime import datetime, timezone
 import threading
 import time
@@ -452,6 +453,8 @@ class ZephyrCoordinator:
         last_log_time = 0.0
 
         while not self._shutdown_event.is_set():
+            if sys.is_finalizing():
+                return
             try:
                 self.check_heartbeats()
                 self._check_worker_group()
@@ -461,6 +464,8 @@ class ZephyrCoordinator:
                     self._log_status()
                     last_log_time = now
             except Exception:
+                if sys.is_finalizing():
+                    return
                 logger.exception("Coordinator loop crashed, aborting pipeline")
                 self.abort("Coordinator loop crashed unexpectedly")
                 return


### PR DESCRIPTION
During process teardown in levanter CI tests, wandb's atexit handler closes its stderr capture before daemon coordinator threads exit. The threads' logging calls then deadlock on the stderr buffer lock, causing 'Fatal Python error: _enter_buffered_busy'.

The root cause is that ZephyrContext._terminate_coordinator_job() cancels the future but does not wait for _run_coordinator_job's finally block to run coordinator.shutdown(), so the coordinator daemon thread keeps spinning. The thread must stay daemon since it can outlive the process when killed before the shutdown RPC arrives.

Fix by checking sys.is_finalizing() in the coordinator loop, exiting before any I/O during interpreter teardown.