### PR TITLE
nemotron: set 4GB worker memory for CC download

### DIFF
--- a/lib/marin/src/marin/datakit/download/nemotron_v1.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_v1.py
@@ -13,6 +13,7 @@ import zstandard
 from rigging.filesystem import open_url
 from marin.execution.step_spec import StepSpec
 from marin.utils import fsspec_exists
+from fray.cluster import ResourceConfig
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 from zephyr import Dataset, ZephyrContext
@@ -102,7 +103,9 @@ def download_nemotron_cc(output_path: str) -> None:
         .write_jsonl(os.path.join(output_path, ".metrics/download-{shard:05d}.jsonl"), skip_existing=True)
     )
 
-    ctx = ZephyrContext(name="download-nemotron-cc")
+    # Each worker downloads a ~350MB zstd file and decompresses to ~1.5-2GB in memory.
+    # Default ZephyrContext resources (1GB) causes OOMKill; 4GB gives sufficient headroom.
+    ctx = ZephyrContext(name="download-nemotron-cc", resources=ResourceConfig(cpu=1, ram="4g"))
     ctx.execute(pipeline)
 
     logger.info(f"Downloaded Nemotron CC files to {output_path}")


### PR DESCRIPTION
Each Nemotron CC download worker decompresses a ~350MB zstd file to ~1.5-2GB in memory. The default ZephyrContext resources (1GB) caused OOMKill when workers exceeded their memory limit. Set 4GB to give sufficient headroom.
