### PR TITLE
[iris] Fix LogCollector starvation under slow kubectl

### DIFF
--- a/lib/iris/src/iris/cluster/providers/k8s/service.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/service.py
@@ -349,7 +349,7 @@ class CloudK8sService:
             args.extend(["-c", container])
         if since_time is not None:
             args.append(f"--since-time={since_time.strftime('%Y-%m-%dT%H:%M:%S.%f')}Z")
-        result = self._run(args, namespaced=True)
+        result = self._run(args, namespaced=True, timeout=15.0)
         if result.returncode != 0:
             return KubectlLogResult(lines=[], last_timestamp=since_time)
 

--- a/lib/iris/src/iris/cluster/providers/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/tasks.py
@@ -711,7 +711,7 @@ class LogCollector:
                 self._log_pusher.push(key, entries)
             pod.last_timestamp = result.last_timestamp
         except Exception as e:
-            logger.debug("LogCollector: failed for pod %s: %s", pod.pod_name, e)
+            logger.warning("LogCollector: fetch failed for pod %s: %s", pod.pod_name, e)
 
     def close(self) -> None:
         self._stop.set()
@@ -816,7 +816,7 @@ class K8sTaskProvider:
     managed_label: str = ""
     task_env: dict[str, str] = field(default_factory=dict)
     log_pusher: LogPusherProtocol | None = None
-    poll_concurrency: int = 8
+    poll_concurrency: int = 32
     _pod_not_found_counts: dict[str, int] = field(default_factory=dict, init=False, repr=False)
     _log_collector: LogCollector | None = field(default=None, init=False, repr=False)
     _resource_collector: ResourceCollector | None = field(default=None, init=False, repr=False)


### PR DESCRIPTION
Reduce stream_logs timeout from 60s to 15s, increase collector thread pool
from 8 to 32, and escalate fetch failures from DEBUG to WARNING so they
appear in controller logs. With 125+ pods and the old 60s timeout, a few
slow kubectl calls could saturate the 8-thread pool and starve all log
collection for minutes. The 1h recovery Rav observed matches API server
warm-up stabilizing the slow calls.

Fixes #4414