### PR TITLE
[levanter] Disable xdist in TPU pytest entrypoints

### DIFF
--- a/.github/workflows/levanter-tests.yaml
+++ b/.github/workflows/levanter-tests.yaml
@@ -207,6 +207,7 @@ jobs:
           chmod 777 /tmp/uv-cache
 
           # Run Levanter tests with specific JAX version
+          # TPU collection imports call jax.devices(), so keep pytest single-process here.
           docker run --rm \
             --device /dev/vfio:/dev/vfio \
             --shm-size=100g \
@@ -239,7 +240,7 @@ jobs:
               cp -a /workspace-src/. /workspace/ && cd /workspace && \
               timeout --kill-after=5 --signal=TERM 890 \
               uv run --package levanter --frozen --group test --with 'jax[tpu]==$JAX_VERSION' \
-              pytest lib/levanter/tests \
+              pytest -n 0 lib/levanter/tests \
               -m 'not entry and not ray and not slow and not torch' \
               --ignore=lib/levanter/tests/test_audio.py \
               --ignore=lib/levanter/tests/test_new_cache.py \

--- a/infra/tpu-ci/vm_manager.py
+++ b/infra/tpu-ci/vm_manager.py
@@ -770,7 +770,8 @@ def debug_tpu(name: str, test_path: str, pytest_args: str, timeout: int, env_var
     for env_var in env_vars:
         env_var_flags += f"  -e {env_var} \\\n"
 
-    # Use the same script structure as GitHub Actions workflow
+    # Match the GitHub Actions TPU path and keep pytest single-process because
+    # some levanter tests call jax.devices() during collection.
     test_script = f"""
 sudo rm -f /tmp/libtpu_lockfile || true
 sudo lsof -t /dev/vfio/* 2>/dev/null | xargs -r sudo kill -9 || true
@@ -791,7 +792,7 @@ sudo docker run --rm \\
   --tmpfs /workspace/.pytest_cache:rw \\
   -w /workspace \\
   ghcr.io/{config.GITHUB_REPOSITORY}/{config.DOCKER_IMAGE_NAME}:{config.DOCKER_IMAGE_TAG} \\
-  timeout --kill-after=5 --signal=TERM {timeout} uv run pytest {test_path} {pytest_args}
+  timeout --kill-after=5 --signal=TERM {timeout} uv run pytest -n 0 {test_path} {pytest_args}
 """
 
     ssh_cmd = [


### PR DESCRIPTION
## Summary

Force single-process pytest execution for TPU-specific levanter entrypoints.

Global `addopts = "-n auto"` in `lib/levanter/pyproject.toml` enables xdist by
default, which causes TPU pytest workers to initialize JAX/libtpu concurrently
during collection. This change keeps global xdist behavior intact while adding
`-n 0` to the TPU GitHub Actions workflow and the TPU debug helper.

Fixes #4495.

## Testing

- `env PYTHONPATH=lib/levanter/tests:lib/levanter/src:. uv run --package levanter --frozen --group test --with 'jax[cpu]==0.8.0' pytest -n 0 lib/levanter/tests/test_new_loader.py -k loader_rejects_empty_finite_dataset -vv`