### PR TITLE
[fray] Split actor RPC into remote() (direct) and submit() (long-poll)

### DIFF
--- a/lib/fray/src/fray/v2/actor.py
+++ b/lib/fray/src/fray/v2/actor.py
@@ -100,6 +100,18 @@ class ActorMethod(Protocol):
         """Invoke the method remotely. Returns a future."""
         ...
 
+    def submit(self, *args: Any, **kwargs: Any) -> ActorFuture:
+        """Invoke via long-running operation with polling.
+
+        Use for methods that run for minutes/hours where holding an HTTP
+        connection open is fragile. The backend uses a durable polling
+        mechanism (e.g. StartOperation + GetOperation RPCs) so that
+        transient connection drops don't kill the call.
+
+        For local and Ray backends this is identical to remote().
+        """
+        ...
+
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         """Invoke the method synchronously (blocking)."""
         ...

--- a/lib/fray/src/fray/v2/iris_backend.py
+++ b/lib/fray/src/fray/v2/iris_backend.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from concurrent.futures import Future
 from pathlib import Path
 from typing import Any, cast
 
@@ -328,14 +329,40 @@ class OperationFuture:
             time.sleep(self._poll_interval)
 
 
+class _ThreadFuture:
+    """Future backed by a daemon thread running a direct Call RPC.
+
+    Unlike OperationFuture, this holds a single HTTP connection for the
+    call duration and does not poll. Suitable for short RPCs where the
+    overhead of StartOperation + GetOperation polling is unnecessary.
+    """
+
+    def __init__(self, fn: Any, args: tuple, kwargs: dict):
+        self._future: Future[Any] = Future()
+
+        def run() -> None:
+            try:
+                self._future.set_result(fn(*args, **kwargs))
+            except Exception as e:
+                self._future.set_exception(e)
+
+        threading.Thread(target=run, daemon=True).start()
+
+    def result(self, timeout: float | None = None) -> Any:
+        return self._future.result(timeout=timeout)
+
+
 class _IrisActorMethod:
     """Wraps a method on an Iris actor.
 
-    ``remote()`` uses long-running operations: a fast ``StartOperation`` RPC
-    returns an operation ID, and ``OperationFuture.result()`` polls via
-    ``GetOperation``. No client-side thread pool is needed.
+    ``remote()`` spawns a thread running a direct ``Call`` RPC — fast
+    (single RPC) and suitable for short-lived methods.
 
-    ``__call__()`` uses the existing blocking ``Call`` RPC for simplicity.
+    ``submit()`` uses long-running operations: a fast ``StartOperation``
+    RPC returns an operation ID, and ``OperationFuture.result()`` polls
+    via ``GetOperation``. Use for methods that run for minutes/hours.
+
+    ``__call__()`` uses the blocking ``Call`` RPC synchronously.
     """
 
     def __init__(self, handle: IrisActorHandle, method_name: str):
@@ -343,6 +370,11 @@ class _IrisActorMethod:
         self._method = method_name
 
     def remote(self, *args: Any, **kwargs: Any) -> ActorFuture:
+        client = self._handle._resolve()
+        method = getattr(client, self._method)
+        return _ThreadFuture(method, args, kwargs)
+
+    def submit(self, *args: Any, **kwargs: Any) -> ActorFuture:
         client = self._handle._resolve()
         op_id = client.start_operation(self._method, *args, **kwargs)
         return OperationFuture(client, op_id)

--- a/lib/fray/src/fray/v2/local_backend.py
+++ b/lib/fray/src/fray/v2/local_backend.py
@@ -291,6 +291,10 @@ class LocalActorMethod:
         thread.start()
         return future
 
+    def submit(self, *args: Any, **kwargs: Any) -> ActorFuture:
+        """Long-running operation path. Same as remote() for local backend."""
+        return self.remote(*args, **kwargs)
+
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         """Call method synchronously."""
         return self._method(*args, **kwargs)

--- a/lib/fray/src/fray/v2/ray_backend/backend.py
+++ b/lib/fray/src/fray/v2/ray_backend/backend.py
@@ -598,6 +598,10 @@ class RayProxyMethod:
         object_ref = self._ray_handle._proxy_call.remote(self._method_name, args, kwargs)
         return RayActorFuture(object_ref)
 
+    def submit(self, *args: Any, **kwargs: Any) -> ActorFuture:
+        """Long-running operation path. Same as remote() for Ray backend."""
+        return self.remote(*args, **kwargs)
+
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         object_ref = self._ray_handle._proxy_call.remote(self._method_name, args, kwargs)
         return ray.get(object_ref)

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -1351,7 +1351,7 @@ def _run_coordinator_job(config_path: str, result_path: str) -> None:
         coordinator.set_worker_group.remote(worker_group).result()
 
     try:
-        results = coordinator.run_pipeline.remote(config.plan, config.execution_id).result()
+        results = coordinator.run_pipeline.submit(config.plan, config.execution_id).result()
 
         ensure_parent_dir(result_path)
         with open_url(result_path, "wb") as f:


### PR DESCRIPTION
remote() now uses a thread + direct Call RPC (single RPC) for short-lived
methods like heartbeat, register_worker, pull_task, and report_result.
submit() uses StartOperation + GetOperation polling for methods that run
for minutes/hours (e.g. run_pipeline). Previously remote() always used the
operation path, costing 2+ RPCs per call even for trivial RPCs. Also fixes
a bad interaction where pull_task's 0.5s timeout triggered server-side
operation cancellation via OperationFuture.