### PR TITLE
[iris] Preserve reservation holders during preemption retry cascade

### DIFF
--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -524,19 +524,38 @@ def _cascade_children(
     job_id: JobName,
     now_ms: int,
     reason: str,
+    exclude_reservation_holders: bool = False,
 ) -> tuple[set[JobName], dict[JobName, WorkerId]]:
-    """Kill descendant jobs (not the job itself) when a parent reaches terminal state or is preempted."""
+    """Kill descendant jobs (not the job itself) when a parent reaches terminal state or is preempted.
+
+    When exclude_reservation_holders is True, reservation holder jobs and their
+    descendants are left alive. This is used during preemption retry: the parent
+    goes back to PENDING and needs its reservation to survive so the scheduler
+    can re-satisfy it.
+    """
     tasks_to_kill: set[JobName] = set()
     task_kill_workers: dict[JobName, WorkerId] = {}
 
-    descendants = cur.execute(
-        "WITH RECURSIVE subtree(job_id) AS ("
-        "  SELECT job_id FROM jobs WHERE parent_job_id = ? "
-        "  UNION ALL "
-        "  SELECT j.job_id FROM jobs j JOIN subtree s ON j.parent_job_id = s.job_id"
-        ") SELECT job_id FROM subtree",
-        (job_id.to_wire(),),
-    ).fetchall()
+    if exclude_reservation_holders:
+        # Skip reservation holder jobs and anything below them.
+        descendants = cur.execute(
+            "WITH RECURSIVE subtree(job_id) AS ("
+            "  SELECT job_id FROM jobs WHERE parent_job_id = ? AND is_reservation_holder = 0 "
+            "  UNION ALL "
+            "  SELECT j.job_id FROM jobs j JOIN subtree s ON j.parent_job_id = s.job_id"
+            "   WHERE j.is_reservation_holder = 0"
+            ") SELECT job_id FROM subtree",
+            (job_id.to_wire(),),
+        ).fetchall()
+    else:
+        descendants = cur.execute(
+            "WITH RECURSIVE subtree(job_id) AS ("
+            "  SELECT job_id FROM jobs WHERE parent_job_id = ? "
+            "  UNION ALL "
+            "  SELECT j.job_id FROM jobs j JOIN subtree s ON j.parent_job_id = s.job_id"
+            ") SELECT job_id FROM subtree",
+            (job_id.to_wire(),),
+        ).fetchall()
     for child_row in descendants:
         child_job_id = str(child_row["job_id"])
         child_tasks_to_kill, child_task_kill_workers = _kill_non_terminal_tasks(cur, child_job_id, reason, now_ms)
@@ -1847,7 +1866,11 @@ class ControllerTransitions:
                 policy = _resolve_preemption_policy(cur, parent_job_id)
                 if policy == job_pb2.JOB_PREEMPTION_POLICY_TERMINATE_CHILDREN:
                     child_tasks_to_kill, child_task_kill_workers = _cascade_children(
-                        cur, parent_job_id, now_ms, "Parent task preempted"
+                        cur,
+                        parent_job_id,
+                        now_ms,
+                        "Parent task preempted",
+                        exclude_reservation_holders=True,
                     )
                     tasks_to_kill.update(child_tasks_to_kill)
                     task_kill_workers.update(child_task_kill_workers)
@@ -2082,7 +2105,13 @@ class ControllerTransitions:
             elif new_state == job_pb2.TASK_STATE_PENDING:
                 policy = _resolve_preemption_policy(cur, job_id)
                 if policy == job_pb2.JOB_PREEMPTION_POLICY_TERMINATE_CHILDREN:
-                    child_kills, child_workers = _cascade_children(cur, job_id, now_ms, reason)
+                    child_kills, child_workers = _cascade_children(
+                        cur,
+                        job_id,
+                        now_ms,
+                        reason,
+                        exclude_reservation_holders=True,
+                    )
                     tasks_to_kill.update(child_kills)
                     task_kill_workers.update(child_workers)
 

--- a/lib/iris/tests/cluster/controller/test_preemption.py
+++ b/lib/iris/tests/cluster/controller/test_preemption.py
@@ -4,7 +4,7 @@
 """Tests for the preemption loop — higher-priority tasks evict lower-priority running tasks."""
 
 from iris.cluster.controller.budget import compute_effective_band
-from iris.cluster.controller.transitions import _resolve_task_failure_state
+from iris.cluster.controller.transitions import RESERVATION_HOLDER_JOB_NAME, _resolve_task_failure_state
 from iris.cluster.controller.controller import (
     PreemptionCandidate,
     RunningTaskInfo,
@@ -25,7 +25,9 @@ from .conftest import (
     make_test_entrypoint,
     make_worker_metadata,
     query_attempt,
+    query_job,
     query_task,
+    query_tasks_for_job,
     register_worker,
     submit_job,
 )
@@ -796,3 +798,104 @@ def test_preempt_task_cascades_coscheduled_siblings():
         all_kills = result0.tasks_to_kill | result1.tasks_to_kill
         assert tasks[0].task_id in all_kills
         assert tasks[1].task_id in all_kills
+
+
+# ---------------------------------------------------------------------------
+# Reservation holder survival during preemption retry
+# ---------------------------------------------------------------------------
+
+
+def test_preemption_retry_preserves_reservation_holder():
+    """When a parent with a reservation retries after preemption, the :reservation: child is NOT killed.
+
+    Non-reservation children (e.g. train_lm) must still be killed by the cascade.
+    This prevents a deadlock where the killed reservation can never be re-satisfied,
+    leaving the parent stuck PENDING forever.
+    """
+
+    with make_controller_state() as state:
+        harness = ControllerTestHarness(state)
+        w1 = harness.add_worker("w1", cpu=4)
+        w2 = harness.add_worker("w2", cpu=4)
+
+        # Submit parent job with a reservation (has_reservation=1)
+        parent_job_id = JobName.root("test-user", "res-parent")
+        parent_req = controller_pb2.Controller.LaunchJobRequest(
+            name=parent_job_id.to_wire(),
+            entrypoint=make_test_entrypoint(),
+            resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
+            environment=job_pb2.EnvironmentConfig(),
+            replicas=1,
+            max_retries_preemption=5,
+        )
+        parent_req.reservation.entries.append(
+            job_pb2.ReservationEntry(
+                resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
+            )
+        )
+        submit_job(state, parent_job_id.to_wire(), parent_req)
+
+        holder_job_id = parent_job_id.child(RESERVATION_HOLDER_JOB_NAME)
+
+        # Verify the reservation holder child was created
+        holder_tasks = [t for t in query_tasks_for_job(state, holder_job_id)]
+        assert len(holder_tasks) == 1, "reservation holder job should have 1 task"
+
+        # Submit a non-reservation child job under the parent (simulating train_lm)
+        child_job_id = parent_job_id.child("train_lm")
+        child_req = controller_pb2.Controller.LaunchJobRequest(
+            name=child_job_id.to_wire(),
+            entrypoint=make_test_entrypoint(),
+            resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
+            environment=job_pb2.EnvironmentConfig(),
+            replicas=1,
+            max_retries_preemption=0,
+        )
+        submit_job(state, child_job_id.to_wire(), child_req)
+        child_tasks = query_tasks_for_job(state, child_job_id)
+        assert len(child_tasks) == 1
+
+        # Dispatch parent task and advance to RUNNING
+        parent_tasks = query_tasks_for_job(state, parent_job_id)
+        assert len(parent_tasks) == 1
+        parent_task = parent_tasks[0]
+        dispatch_task(state, parent_task, w1)
+        assert query_task(state, parent_task.task_id).state == job_pb2.TASK_STATE_RUNNING
+
+        # Dispatch reservation holder task to w2
+        dispatch_task(state, holder_tasks[0], w2)
+
+        # Dispatch child task to w2
+        dispatch_task(state, child_tasks[0], w2)
+
+        # Preempt the parent task — it should retry (go PENDING)
+        state.preempt_task(parent_task.task_id, reason="Preempted by higher priority")
+
+        # Parent task should be PENDING (retry)
+        updated_parent = query_task(state, parent_task.task_id)
+        assert updated_parent.state == job_pb2.TASK_STATE_PENDING
+        assert updated_parent.preemption_count == 1
+
+        # Reservation holder job should NOT be killed
+        holder_job = query_job(state, holder_job_id)
+        assert (
+            holder_job.state != job_pb2.JOB_STATE_KILLED
+        ), "reservation holder job must survive parent preemption retry"
+
+        # Reservation holder task should NOT be killed
+        holder_task_updated = query_task(state, holder_tasks[0].task_id)
+        assert (
+            holder_task_updated.state != job_pb2.TASK_STATE_KILLED
+        ), "reservation holder task must survive parent preemption retry"
+
+        # Non-reservation child job SHOULD be killed
+        child_job = query_job(state, child_job_id)
+        assert (
+            child_job.state == job_pb2.JOB_STATE_KILLED
+        ), "non-reservation child job must be killed on parent preemption retry"
+
+        # Non-reservation child task SHOULD be killed
+        child_task_updated = query_task(state, child_tasks[0].task_id)
+        assert (
+            child_task_updated.state == job_pb2.TASK_STATE_KILLED
+        ), "non-reservation child task must be killed on parent preemption retry"


### PR DESCRIPTION
Exclude is_reservation_holder jobs from _cascade_children when a parent
task retries after preemption or worker failure. Previously the cascade
killed the :reservation: child along with everything else, leaving it in
terminal KILLED state. Since the scheduler gates real tasks on reservation
satisfaction, the parent stayed PENDING forever in a deadlock. The fix
filters reservation holders out of the recursive CTE at both preemption
retry call sites while leaving terminal cascade paths unchanged.