### PR TITLE
Add lib/rigging/src to Ray PYTHONPATH and pyrefly search paths

### DIFF
--- a/infra/pre-commit.py
+++ b/infra/pre-commit.py
@@ -655,6 +655,7 @@ PRECOMMIT_CONFIGS = [
             "lib/haliax/src/**/*.py",
             "lib/fray/src/**/*.py",
             "lib/iris/src/**/*.py",
+            "lib/rigging/src/**/*.py",
             "lib/zephyr/src/**/*.py",
         ],
         checks=[

--- a/lib/fray/src/fray/v1/cluster/ray/deps.py
+++ b/lib/fray/src/fray/v1/cluster/ray/deps.py
@@ -128,6 +128,7 @@ def build_python_path(submodules_dir: str = "submodules") -> list[str]:
         "lib/iris/src",
         "lib/levanter/src",
         "lib/marin/src",
+        "lib/rigging/src",
         "lib/zephyr/src",
     ]
 

--- a/lib/fray/src/fray/v2/ray_backend/deps.py
+++ b/lib/fray/src/fray/v2/ray_backend/deps.py
@@ -128,6 +128,7 @@ def build_python_path(submodules_dir: str = "submodules") -> list[str]:
         "lib/iris/src",
         "lib/levanter/src",
         "lib/marin/src",
+        "lib/rigging/src",
         "lib/zephyr/src",
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ project-includes = [
     "lib/haliax/src/**/*.py",
     "lib/fray/src/**/*.py",
     "lib/iris/src/**/*.py",
+    "lib/rigging/src/**/*.py",
     "lib/zephyr/src/**/*.py",
 ]
 
@@ -115,6 +116,7 @@ search-path = [
     "lib/marin/src",
     "lib/levanter/src",
     "lib/haliax/src",
+    "lib/rigging/src",
     "lib/zephyr/src",
     "lib/fray/src",
     "lib/iris/src",


### PR DESCRIPTION
rigging was missing from the workspace paths injected into Ray job environments (both fray v1 and v2), causing ImportError when client code imports from rigging. Also add rigging to pyrefly project-includes and pre-commit type-check patterns for consistency with other workspace members.