### PR TITLE
[iris] Fix py-spy EPERM on TPU containers by always adding SYS_PTRACE

### DIFF
--- a/lib/iris/src/iris/cluster/runtime/docker.py
+++ b/lib/iris/src/iris/cluster/runtime/docker.py
@@ -659,7 +659,9 @@ exec {quoted_cmd}
 
         if not is_tpu_run:
             cmd.extend(["--cap-drop", "ALL"])
-            cmd.extend(["--cap-add", "SYS_PTRACE"])
+        # Always add SYS_PTRACE so py-spy can attach via docker exec regardless of TPU/CPU.
+        # TPU containers use --privileged but docker exec processes don't reliably inherit it.
+        cmd.extend(["--cap-add", "SYS_PTRACE"])
 
         # Device flags (TPU passthrough etc) - only for run container
         if include_devices:


### PR DESCRIPTION
TPU containers run --privileged but docker exec processes don't reliably inherit all capabilities, causing py-spy to fail with EPERM when trying to attach to PID 1 for thread dumps. Move --cap-add SYS_PTRACE outside the non-TPU block so it is always applied. This matches how the K8s provider already handles it: SYS_PTRACE is always added for all containers, and SYS_RESOURCE is added additionally for TPU.