### PR TITLE
Fix get_caller_path returning <frozen runpy> under python -m

### DIFF
--- a/lib/marin/src/marin/execution/executor.py
+++ b/lib/marin/src/marin/execution/executor.py
@@ -85,6 +85,7 @@ import logging
 import os
 import re
 import subprocess
+import sys
 import time
 import urllib.parse
 from collections.abc import Callable, Sequence
@@ -1577,8 +1578,17 @@ def get_git_commit() -> str | None:
 
 
 def get_caller_path() -> str:
-    """Return the path of the file that called this function."""
-    return inspect.stack()[-1].filename
+    """Return the path of the file that called this function.
+
+    Walks the stack from the outermost frame inward, returning the first
+    frame that corresponds to a real file (skips ``<frozen runpy>`` and
+    similar synthetic frames produced by ``python -m`` invocation).
+    """
+    for frame_info in reversed(inspect.stack()):
+        if not frame_info.filename.startswith("<"):
+            return frame_info.filename
+    # All frames are synthetic (shouldn't happen in practice) — fall back to argv.
+    return sys.argv[0]
 
 
 def get_user() -> str | None:


### PR DESCRIPTION
## Summary

- Fix `get_caller_path()` producing `<frozen runpy>` as the experiment name when scripts are invoked via `python -m` (e.g. `python -m experiments.protein.train_protein_1b`)
- In Python 3.11+, `runpy` is a frozen stdlib module, so `inspect.stack()[-1].filename` returns the string `<frozen runpy>` instead of a real file path
- This caused executor info to be written to paths like `gs://marin-us-west4/experiments/<frozen runpy>-ee7bce.json`

## Root cause

`get_caller_path()` used `inspect.stack()[-1].filename` to find the outermost stack frame. When a script is launched via `python -m`, the outermost frame belongs to the frozen `runpy` bootstrap, not the user's script.

Observed in `/tim/iris-run-job-20260407-181022` on `marin-dev` — confirmed via controller state checkpoint that the entrypoint was `['python', '-m', 'experiments.protein.train_protein_1b']`.

## Fix

Walk the stack from the outermost frame inward, skipping frames with synthetic filenames (those starting with `<`), and return the first real file. Falls back to `sys.argv[0]` if all frames are synthetic.

## Test plan

Manual red/green with `python -m`. Save this as `test_caller_path_manual.py` at the repo root:

```python
"""Manual red/green test: run via `python -m test_caller_path_manual`."""
import os
from marin.execution.executor import get_caller_path

caller = get_caller_path()
name = os.path.basename(caller).replace(".py", "")
print(f"caller_path = {caller!r}")
print(f"experiment name = {name!r}")
assert "<" not in name, f"FAIL: experiment name contains angle bracket: {name!r}"
print("PASS")
```

```
# red (before fix)
$ python -m test_caller_path_manual
caller_path = '<frozen runpy>'
experiment name = '<frozen runpy>'
AssertionError: FAIL: experiment name contains angle bracket: '<frozen runpy>'

# green (after fix)
$ python -m test_caller_path_manual
caller_path = '.../test_caller_path_manual.py'
experiment name = 'test_caller_path_manual'
PASS
```

No unit test — the fix is 4 lines, the failure mode only manifests under `python -m`, and a synthetic unit test that mocks `inspect.stack` doesn't add real confidence beyond code review.

- [x] Pre-commit passes
- [ ] Verify on a real `python -m` Iris job that the experiment path no longer contains `<frozen runpy>`

Fixes #4504

🤖 Generated with [Claude Code](https://claude.com/claude-code)