### PR TITLE
[levanter] Cap homogeneous-run length when calling Rust BPE tokenizers

### DIFF
--- a/lib/levanter/src/levanter/tokenizers.py
+++ b/lib/levanter/src/levanter/tokenizers.py
@@ -37,6 +37,50 @@ from tokenizers import Tokenizer as HfBaseTokenizer
 logger = logging.getLogger(__name__)
 
 
+# Borrowed from meta-llama/llama3 tokenizer.py: bound the size of any single
+# string passed into the underlying tokenizer to avoid pathological inputs
+# (e.g. multi-MB runs of whitespace from broken HTML→text extraction) blowing
+# up Rust tokenizer working memory. We split on whitespace/non-whitespace
+# transitions and cap each homogeneous run.
+_MAX_ENCODE_CHARS = 400_000
+_MAX_HOMOGENEOUS_RUN_CHARS = 25_000
+
+
+def _split_homogeneous_runs(s: str, max_run: int):
+    """Split ``s`` so each substring has at most ``max_run`` consecutive
+    whitespace OR consecutive non-whitespace characters."""
+    if not s:
+        return
+    current_len = 0
+    current_is_space = s[0].isspace()
+    slice_start = 0
+    for i, ch in enumerate(s):
+        is_space = ch.isspace()
+        if current_is_space ^ is_space:
+            current_len = 1
+            current_is_space = is_space
+        else:
+            current_len += 1
+            if current_len > max_run:
+                yield s[slice_start:i]
+                slice_start = i
+                current_len = 1
+    yield s[slice_start:]
+
+
+def _safe_split_for_tokenizer(text: str) -> list[str]:
+    """Split ``text`` into substrings safe to feed to a Rust BPE tokenizer.
+
+    Each substring is at most ``_MAX_ENCODE_CHARS`` long and contains no run
+    of more than ``_MAX_HOMOGENEOUS_RUN_CHARS`` consecutive whitespace or
+    non-whitespace characters.
+    """
+    parts: list[str] = []
+    for i in range(0, len(text), _MAX_ENCODE_CHARS):
+        parts.extend(_split_homogeneous_runs(text[i : i + _MAX_ENCODE_CHARS], _MAX_HOMOGENEOUS_RUN_CHARS))
+    return parts
+
+
 @runtime_checkable
 class MarinTokenizer(Protocol):
     @property
@@ -270,7 +314,18 @@ class HfMarinTokenizer:
         return self._vocab_size
 
     def encode(self, text: str, *, add_special_tokens: bool = False) -> list[int]:
-        return self._tokenizer.encode(text, add_special_tokens=add_special_tokens).ids
+        parts = _safe_split_for_tokenizer(text)
+        if len(parts) <= 1:
+            return self._tokenizer.encode(text, add_special_tokens=add_special_tokens).ids
+        # Multi-chunk path: only the first chunk gets BOS/EOS-style specials so
+        # the joined ids match a single-call encode for normal-sized inputs.
+        ids: list[int] = []
+        encodings = self._tokenizer.encode_batch(parts, add_special_tokens=False)
+        for enc in encodings:
+            ids.extend(enc.ids)
+        if add_special_tokens and self._bos_id is not None:
+            ids = [self._bos_id] + ids
+        return ids
 
     def decode(self, ids: list[int], *, skip_special_tokens: bool = False) -> str:
         return self._tokenizer.decode(ids, skip_special_tokens=skip_special_tokens)
@@ -279,8 +334,7 @@ class HfMarinTokenizer:
         # Copy strings to release references to potentially large source buffers,
         # mitigating memory retention from sliced strings.
         texts = ["".join(s) for s in texts]
-        encodings = self._tokenizer.encode_batch(texts, add_special_tokens=add_special_tokens)
-        return [enc.ids for enc in encodings]
+        return [self.encode(t, add_special_tokens=add_special_tokens) for t in texts]
 
     def get_vocab(self) -> dict[str, int]:
         return self._vocab
@@ -403,7 +457,13 @@ class KitokenMarinTokenizer:
         # encode_specials=True tells kitoken to recognize special token strings
         # (e.g. "<|end_of_text|>") in the input, matching HF's default behavior.
         # This is orthogonal to add_special_tokens which controls BOS/EOS wrapping.
-        ids = self._tokenizer.encode(text, True)
+        parts = _safe_split_for_tokenizer(text)
+        if len(parts) <= 1:
+            ids = self._tokenizer.encode(text, True)
+        else:
+            ids = []
+            for chunk_ids in self._tokenizer.encode_all(parts, True):
+                ids.extend(chunk_ids)
         if add_special_tokens and self._prepend_bos and self._bos_id is not None:
             ids = [self._bos_id] + ids
         return ids
@@ -416,10 +476,7 @@ class KitokenMarinTokenizer:
 
     def encode_batch(self, texts: list[str], *, add_special_tokens: bool = False) -> list[list[int]]:
         texts = ["".join(s) for s in texts]
-        results = self._tokenizer.encode_all(texts, True)
-        if add_special_tokens and self._prepend_bos and self._bos_id is not None:
-            return [[self._bos_id] + ids for ids in results]
-        return results
+        return [self.encode(t, add_special_tokens=add_special_tokens) for t in texts]
 
     def get_vocab(self) -> dict[str, int]:
         return self._vocab

--- a/lib/levanter/src/levanter/tokenizers.py
+++ b/lib/levanter/src/levanter/tokenizers.py
@@ -46,26 +46,10 @@ _MAX_ENCODE_CHARS = 400_000
 _MAX_HOMOGENEOUS_RUN_CHARS = 25_000
 
 
-def _split_homogeneous_runs(s: str, max_run: int) -> Iterator[str]:
-    """Split ``s`` so each substring has at most ``max_run`` consecutive
-    whitespace OR consecutive non-whitespace characters."""
-    if not s:
-        return
-    current_len = 0
-    current_is_space = s[0].isspace()
-    slice_start = 0
-    for i, ch in enumerate(s):
-        is_space = ch.isspace()
-        if current_is_space ^ is_space:
-            current_len = 1
-            current_is_space = is_space
-        else:
-            current_len += 1
-            if current_len > max_run:
-                yield s[slice_start:i]
-                slice_start = i
-                current_len = 1
-    yield s[slice_start:]
+# \s matches any whitespace, \S matches any non-whitespace.
+# {1, N} matches a run of at least 1 and at most N chars.
+# The | (alternation) ensures we split at whitespace/non-whitespace transitions.
+_SAFE_CHUNK_RE = re.compile(rf"\s{{1,{_MAX_HOMOGENEOUS_RUN_CHARS}}}|\S{{1,{_MAX_HOMOGENEOUS_RUN_CHARS}}}")
 
 
 def _safe_split_for_tokenizer(text: str) -> list[str]:
@@ -77,7 +61,7 @@ def _safe_split_for_tokenizer(text: str) -> list[str]:
     """
     parts: list[str] = []
     for i in range(0, len(text), _MAX_ENCODE_CHARS):
-        parts.extend(_split_homogeneous_runs(text[i : i + _MAX_ENCODE_CHARS], _MAX_HOMOGENEOUS_RUN_CHARS))
+        parts.extend(_SAFE_CHUNK_RE.findall(text[i : i + _MAX_ENCODE_CHARS]))
     return parts
 
 

--- a/lib/levanter/src/levanter/tokenizers.py
+++ b/lib/levanter/src/levanter/tokenizers.py
@@ -46,23 +46,37 @@ _MAX_ENCODE_CHARS = 400_000
 _MAX_HOMOGENEOUS_RUN_CHARS = 25_000
 
 
-# \s matches any whitespace, \S matches any non-whitespace.
-# {1, N} matches a run of at least 1 and at most N chars.
-# The | (alternation) ensures we split at whitespace/non-whitespace transitions.
-_SAFE_CHUNK_RE = re.compile(rf"\s{{1,{_MAX_HOMOGENEOUS_RUN_CHARS}}}|\S{{1,{_MAX_HOMOGENEOUS_RUN_CHARS}}}")
+# Match runs of N+ whitespace OR N+ non-whitespace chars. These are the only
+# points where the input MUST be split to keep each substring's longest
+# homogeneous run bounded; everything else passes through untouched so that
+# BPE merges (e.g. " world" leading-space tokens) on normal text are
+# preserved exactly as the underlying tokenizer would produce them.
+_OVERLONG_RUN_RE = re.compile(rf"\s{{{_MAX_HOMOGENEOUS_RUN_CHARS},}}|\S{{{_MAX_HOMOGENEOUS_RUN_CHARS},}}")
 
 
 def _safe_split_for_tokenizer(text: str) -> list[str]:
     """Split ``text`` into substrings safe to feed to a Rust BPE tokenizer.
 
-    Each substring is at most ``_MAX_ENCODE_CHARS`` long and contains no run
-    of more than ``_MAX_HOMOGENEOUS_RUN_CHARS`` consecutive whitespace or
-    non-whitespace characters.
+    Each substring contains no more than ``_MAX_HOMOGENEOUS_RUN_CHARS``
+    consecutive whitespace or non-whitespace characters. Inputs whose runs
+    are all within the cap are returned unchanged as a single-element list,
+    so normal text round-trips byte-identically through the tokenizer.
     """
+    if len(text) <= _MAX_HOMOGENEOUS_RUN_CHARS:
+        return [text]
+
     parts: list[str] = []
-    for i in range(0, len(text), _MAX_ENCODE_CHARS):
-        parts.extend(_SAFE_CHUNK_RE.findall(text[i : i + _MAX_ENCODE_CHARS]))
-    return parts
+    last = 0
+    for m in _OVERLONG_RUN_RE.finditer(text):
+        if m.start() > last:
+            parts.append(text[last : m.start()])
+        run = m.group()
+        for i in range(0, len(run), _MAX_HOMOGENEOUS_RUN_CHARS):
+            parts.append(run[i : i + _MAX_HOMOGENEOUS_RUN_CHARS])
+        last = m.end()
+    if last < len(text):
+        parts.append(text[last:])
+    return parts or [text]
 
 
 @runtime_checkable

--- a/lib/levanter/src/levanter/tokenizers.py
+++ b/lib/levanter/src/levanter/tokenizers.py
@@ -46,7 +46,7 @@ _MAX_ENCODE_CHARS = 400_000
 _MAX_HOMOGENEOUS_RUN_CHARS = 25_000
 
 
-def _split_homogeneous_runs(s: str, max_run: int):
+def _split_homogeneous_runs(s: str, max_run: int) -> Iterator[str]:
     """Split ``s`` so each substring has at most ``max_run`` consecutive
     whitespace OR consecutive non-whitespace characters."""
     if not s:
@@ -317,14 +317,17 @@ class HfMarinTokenizer:
         parts = _safe_split_for_tokenizer(text)
         if len(parts) <= 1:
             return self._tokenizer.encode(text, add_special_tokens=add_special_tokens).ids
-        # Multi-chunk path: only the first chunk gets BOS/EOS-style specials so
-        # the joined ids match a single-call encode for normal-sized inputs.
+        # Multi-chunk path: encode each chunk without specials and prepend BOS
+        # at the end. We don't append EOS — Llama-style BPE tokenizers used
+        # here don't add EOS via the post-processor, matching the llama3
+        # reference. If a future tokenizer's post-processor appends EOS, the
+        # multi-chunk path would silently drop it.
         ids: list[int] = []
         encodings = self._tokenizer.encode_batch(parts, add_special_tokens=False)
         for enc in encodings:
             ids.extend(enc.ids)
         if add_special_tokens and self._bos_id is not None:
-            ids = [self._bos_id] + ids
+            ids = [self._bos_id, *ids]
         return ids
 
     def decode(self, ids: list[int], *, skip_special_tokens: bool = False) -> str:
@@ -334,7 +337,27 @@ class HfMarinTokenizer:
         # Copy strings to release references to potentially large source buffers,
         # mitigating memory retention from sliced strings.
         texts = ["".join(s) for s in texts]
-        return [self.encode(t, add_special_tokens=add_special_tokens) for t in texts]
+
+        # Flatten all parts across all texts into one batch so the underlying
+        # Rust encoder can parallelize across them via rayon. ``origin[i]``
+        # tracks which original text part ``i`` belongs to so we can scatter
+        # the encoded ids back into per-text lists.
+        flat_parts: list[str] = []
+        origin: list[int] = []
+        for orig_idx, text in enumerate(texts):
+            for part in _safe_split_for_tokenizer(text):
+                flat_parts.append(part)
+                origin.append(orig_idx)
+
+        encodings = self._tokenizer.encode_batch(flat_parts, add_special_tokens=False)
+
+        results: list[list[int]] = [[] for _ in texts]
+        for orig_idx, enc in zip(origin, encodings, strict=True):
+            results[orig_idx].extend(enc.ids)
+
+        if add_special_tokens and self._bos_id is not None:
+            results = [[self._bos_id, *r] for r in results]
+        return results
 
     def get_vocab(self) -> dict[str, int]:
         return self._vocab
@@ -476,7 +499,26 @@ class KitokenMarinTokenizer:
 
     def encode_batch(self, texts: list[str], *, add_special_tokens: bool = False) -> list[list[int]]:
         texts = ["".join(s) for s in texts]
-        return [self.encode(t, add_special_tokens=add_special_tokens) for t in texts]
+
+        # Flatten all parts across all texts so kitoken's batch encoder
+        # parallelizes across them. ``origin[i]`` maps each part back to its
+        # original text index for the scatter step.
+        flat_parts: list[str] = []
+        origin: list[int] = []
+        for orig_idx, text in enumerate(texts):
+            for part in _safe_split_for_tokenizer(text):
+                flat_parts.append(part)
+                origin.append(orig_idx)
+
+        encodings = self._tokenizer.encode_all(flat_parts, True)
+
+        results: list[list[int]] = [[] for _ in texts]
+        for orig_idx, chunk_ids in zip(origin, encodings, strict=True):
+            results[orig_idx].extend(chunk_ids)
+
+        if add_special_tokens and self._prepend_bos and self._bos_id is not None:
+            results = [[self._bos_id, *r] for r in results]
+        return results
 
     def get_vocab(self) -> dict[str, int]:
         return self._vocab

--- a/lib/levanter/tests/test_tokenizers.py
+++ b/lib/levanter/tests/test_tokenizers.py
@@ -686,7 +686,7 @@ def test_multi_chunk_path_preserves_bos(backend_tokenizer, monkeypatch):
 
     # Force the multi-chunk path by capping homogeneous runs at 100 chars.
     monkeypatch.setattr(tk, "_MAX_HOMOGENEOUS_RUN_CHARS", 100)
-    monkeypatch.setattr(tk, "_SAFE_CHUNK_RE", re.compile(r"\s{1,100}|\S{1,100}"))
+    monkeypatch.setattr(tk, "_OVERLONG_RUN_RE", re.compile(r"\s{100,}|\S{100,}"))
     parts = tk._safe_split_for_tokenizer(text)
     assert len(parts) > 1, "Expected multi-chunk path to activate"
     assert "".join(parts) == text
@@ -750,7 +750,7 @@ def test_encode_batch_scatters_parts_back_to_originals(backend_tokenizer, monkey
     import levanter.tokenizers as tk
 
     monkeypatch.setattr(tk, "_MAX_HOMOGENEOUS_RUN_CHARS", 100)
-    monkeypatch.setattr(tk, "_SAFE_CHUNK_RE", re.compile(r"\s{1,100}|\S{1,100}"))
+    monkeypatch.setattr(tk, "_OVERLONG_RUN_RE", re.compile(r"\s{100,}|\S{100,}"))
 
     short = "The quick brown fox."
     pathological = "start" + (" " * 500) + "end"

--- a/lib/levanter/tests/test_tokenizers.py
+++ b/lib/levanter/tests/test_tokenizers.py
@@ -714,6 +714,36 @@ def test_multi_chunk_path_preserves_bos(backend_tokenizer, monkeypatch):
 
 
 @requires_model
+def test_normal_text_unchanged_by_splitter(backend_tokenizer):
+    """For text where no homogeneous run exceeds the cap, the splitter must
+    not change tokenization at all. ``encode(text)`` should return exactly
+    what a single direct call to the underlying Rust tokenizer would.
+
+    A regex like ``\\s{1,N}|\\S{1,N}`` splits at every whitespace transition,
+    which severs leading-space-prefix BPE merges (e.g. " world" → 1 token vs
+    " " + "world" → 2 different tokens) and roughly doubles the token count
+    on normal English text. This test guards against that regression.
+    """
+    text = "The quick brown fox jumps over the lazy dog."
+
+    via_split = backend_tokenizer.encode(text, add_special_tokens=False)
+
+    # Bypass our splitter and call the underlying Rust tokenizer directly.
+    inner = backend_tokenizer._tokenizer
+    if hasattr(inner, "encode_batch"):
+        # HF tokenizers backend
+        direct = inner.encode(text, add_special_tokens=False).ids
+    else:
+        # kitoken backend: encode(text, encode_specials=True)
+        direct = inner.encode(text, True)
+
+    assert via_split == direct, (
+        f"splitter changed tokenization on normal text: "
+        f"{len(via_split)} tokens via splitter vs {len(direct)} direct"
+    )
+
+
+@requires_model
 def test_encode_batch_scatters_parts_back_to_originals(backend_tokenizer, monkeypatch):
     """encode_batch must reassemble per-text token sequences correctly when
     some texts are split into multiple parts and others aren't."""

--- a/lib/levanter/tests/test_tokenizers.py
+++ b/lib/levanter/tests/test_tokenizers.py
@@ -711,6 +711,40 @@ def test_multi_chunk_path_preserves_bos(backend_tokenizer, monkeypatch):
     assert backend_tokenizer.decode(multi_special, skip_special_tokens=True) == text
 
 
+@requires_model
+def test_encode_batch_scatters_parts_back_to_originals(backend_tokenizer, monkeypatch):
+    """encode_batch must reassemble per-text token sequences correctly when
+    some texts are split into multiple parts and others aren't."""
+    import levanter.tokenizers as tk
+
+    monkeypatch.setattr(tk, "_MAX_HOMOGENEOUS_RUN_CHARS", 100)
+
+    short = "The quick brown fox."
+    pathological = "start" + (" " * 500) + "end"
+    texts = [short, pathological, short, pathological, short]
+
+    # Sanity: with the patched cap, the pathological text gets split.
+    assert len(tk._safe_split_for_tokenizer(pathological)) > 1
+    assert len(tk._safe_split_for_tokenizer(short)) == 1
+
+    batch_ids = backend_tokenizer.encode_batch(texts, add_special_tokens=False)
+    assert len(batch_ids) == len(texts)
+
+    # Each row must equal the per-text encode result (ground truth).
+    for got, original in zip(batch_ids, texts, strict=True):
+        expected = backend_tokenizer.encode(original, add_special_tokens=False)
+        assert got == expected
+        # And every row must round-trip losslessly.
+        assert backend_tokenizer.decode(got) == original
+
+    # add_special_tokens=True must prepend BOS to every row exactly once.
+    if backend_tokenizer.bos_token_id is not None:
+        batch_special = backend_tokenizer.encode_batch(texts, add_special_tokens=True)
+        for row in batch_special:
+            assert row[0] == backend_tokenizer.bos_token_id
+            assert row.count(backend_tokenizer.bos_token_id) == 1
+
+
 def test_safe_split_caps_runs_and_roundtrips(monkeypatch):
     """The splitter must cap homogeneous runs within each part and round-trip
     losslessly on a pathological all-whitespace input."""

--- a/lib/levanter/tests/test_tokenizers.py
+++ b/lib/levanter/tests/test_tokenizers.py
@@ -641,6 +641,102 @@ def test_add_special_tokens_false_no_bos(backend_tokenizer):
         assert ids[0] != backend_tokenizer.bos_token_id
 
 
+def _longest_homogeneous_run(s: str) -> int:
+    """Return the length of the longest run of consecutive whitespace OR
+    consecutive non-whitespace characters in ``s``."""
+    if not s:
+        return 0
+    longest = 1
+    current = 1
+    is_space = s[0].isspace()
+    for ch in s[1:]:
+        ch_is_space = ch.isspace()
+        if ch_is_space == is_space:
+            current += 1
+            if current > longest:
+                longest = current
+        else:
+            current = 1
+            is_space = ch_is_space
+    return longest
+
+
+@requires_model
+def test_multi_chunk_path_preserves_bos(backend_tokenizer, monkeypatch):
+    """When the safe-split path activates, BOS handling must still match the
+    single-chunk path (BOS prepended exactly once when add_special_tokens=True,
+    absent otherwise) and the decoded text must round-trip.
+
+    Forces the multi-chunk path by feeding text with a long run of whitespace
+    and capping the homogeneous-run limit so the splitter cuts it up.
+    """
+    import levanter.tokenizers as tk
+
+    if backend_tokenizer.bos_token_id is None:
+        pytest.skip("Backend has no BOS token to verify against")
+
+    # Pathological-ish: real text bracketing a 1k-space run. With the default
+    # 25k cap this stays one part; with the patched 100-char cap below it
+    # gets split into ~10 parts.
+    text = "The quick brown fox jumps. " + (" " * 1_000) + "And then the lazy dog naps."
+
+    # Sanity: this text should NOT trigger the split path with default limits.
+    assert len(tk._safe_split_for_tokenizer(text)) == 1
+
+    # Force the multi-chunk path by capping homogeneous runs at 100 chars.
+    monkeypatch.setattr(tk, "_MAX_HOMOGENEOUS_RUN_CHARS", 100)
+    parts = tk._safe_split_for_tokenizer(text)
+    assert len(parts) > 1, "Expected multi-chunk path to activate"
+    assert "".join(parts) == text
+    # Each part respects the run cap (the cap is on max consecutive run length
+    # within a part, not on part length itself).
+    for p in parts:
+        assert _longest_homogeneous_run(p) <= 100
+
+    multi_plain = backend_tokenizer.encode(text, add_special_tokens=False)
+    multi_special = backend_tokenizer.encode(text, add_special_tokens=True)
+
+    # BOS handling: present iff add_special_tokens=True, exactly once at the front.
+    assert multi_plain[0] != backend_tokenizer.bos_token_id
+    assert multi_special[0] == backend_tokenizer.bos_token_id
+    assert multi_special.count(backend_tokenizer.bos_token_id) == 1
+    assert backend_tokenizer.bos_token_id not in multi_plain
+
+    # The multi-chunk add_special_tokens=True path must equal the
+    # add_special_tokens=False path with a single BOS prepended.
+    assert multi_special == [backend_tokenizer.bos_token_id] + multi_plain
+
+    # Decoded text must round-trip losslessly even with broken BPE merges.
+    assert backend_tokenizer.decode(multi_plain) == text
+    assert backend_tokenizer.decode(multi_special, skip_special_tokens=True) == text
+
+
+def test_safe_split_caps_runs_and_roundtrips(monkeypatch):
+    """The splitter must cap homogeneous runs within each part and round-trip
+    losslessly on a pathological all-whitespace input."""
+    import levanter.tokenizers as tk
+
+    # 1 MB of spaces with two real words at the ends — the realistic shape of
+    # the FDLP/lps47065 OOM document.
+    text = "hello" + (" " * 1_000_000) + "world"
+
+    parts = tk._safe_split_for_tokenizer(text)
+    assert "".join(parts) == text
+    assert len(parts) > 1
+    for p in parts:
+        run = _longest_homogeneous_run(p)
+        assert run <= tk._MAX_HOMOGENEOUS_RUN_CHARS, f"run {run} exceeds cap {tk._MAX_HOMOGENEOUS_RUN_CHARS}"
+
+    # Also confirm the outer 400k chunking is respected when the input has no
+    # long homogeneous runs (so only the outer cap fires).
+    no_runs = "abcde" * 200_000  # 1M chars, longest run = 1
+    parts2 = tk._safe_split_for_tokenizer(no_runs)
+    assert "".join(parts2) == no_runs
+    assert len(parts2) > 1
+    for p in parts2:
+        assert len(p) <= tk._MAX_ENCODE_CHARS
+
+
 @requires_model
 def test_decode_skip_special_tokens(backend_tokenizer):
     text = "hello"

--- a/lib/levanter/tests/test_tokenizers.py
+++ b/lib/levanter/tests/test_tokenizers.py
@@ -11,6 +11,7 @@ which requires HF authentication (tests skip if auth is missing).
 import json
 import os
 import pathlib
+import re
 import shutil
 from unittest.mock import patch
 
@@ -685,6 +686,7 @@ def test_multi_chunk_path_preserves_bos(backend_tokenizer, monkeypatch):
 
     # Force the multi-chunk path by capping homogeneous runs at 100 chars.
     monkeypatch.setattr(tk, "_MAX_HOMOGENEOUS_RUN_CHARS", 100)
+    monkeypatch.setattr(tk, "_SAFE_CHUNK_RE", re.compile(r"\s{1,100}|\S{1,100}"))
     parts = tk._safe_split_for_tokenizer(text)
     assert len(parts) > 1, "Expected multi-chunk path to activate"
     assert "".join(parts) == text
@@ -718,6 +720,7 @@ def test_encode_batch_scatters_parts_back_to_originals(backend_tokenizer, monkey
     import levanter.tokenizers as tk
 
     monkeypatch.setattr(tk, "_MAX_HOMOGENEOUS_RUN_CHARS", 100)
+    monkeypatch.setattr(tk, "_SAFE_CHUNK_RE", re.compile(r"\s{1,100}|\S{1,100}"))
 
     short = "The quick brown fox."
     pathological = "start" + (" " * 500) + "end"


### PR DESCRIPTION
Borrows the splitter from meta-llama/llama3 tokenizer.py: bound any string passed to HfMarinTokenizer or KitokenMarinTokenizer at 400k chars and 25k consecutive whitespace/non-whitespace chars. Prevents OOM from pathological inputs (e.g. multi-MB whitespace runs from broken HTML→text extraction). Multi-chunk encode preserves single BOS handling. Adds tests covering BOS preservation across the multi-chunk path and lossless round-trip on a 1MB-whitespace input.

Fixes the core complaint at #4588