### PR TITLE
[experiments] Add PleIAs/common_corpus dataset (English open-access subset)

### DIFF
--- a/experiments/pretraining_datasets/__init__.py
+++ b/experiments/pretraining_datasets/__init__.py
@@ -48,6 +48,10 @@ from experiments.pretraining_datasets.nemotron_v2 import (
     downloads as nemotron_v2_downloads,
     tokenize_nemotron_v2_family,
 )
+from experiments.pretraining_datasets.common_corpus import (
+    common_corpus_download,
+    tokenize_common_corpus,
+)
 from experiments.pretraining_datasets.nsf_awards import (
     nsf_awards_download,
     nsf_awards_tokenized,
@@ -116,6 +120,11 @@ DATASETS = {
         "subsets": ["all"],
         "download": dolmino_downloads["dolmino"],
         "tokenize_fn": lambda: {"dolmino_math/all": tokenize_dolmino_math()},
+    },
+    "common_corpus": {
+        "subsets": ["all"],
+        "download": common_corpus_download,
+        "tokenize_fn": lambda: {"common_corpus/all": tokenize_common_corpus()},
     },
     "nsf_awards": {
         "subsets": ["all"],

--- a/experiments/pretraining_datasets/common_corpus.py
+++ b/experiments/pretraining_datasets/common_corpus.py
@@ -1,0 +1,34 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Common Corpus dataset definitions and tokenization."""
+
+from fray.v2 import ResourceConfig
+
+from marin.datakit.download.common_corpus import download_common_corpus_raw_step, filter_common_corpus_step
+from marin.execution.executor import ExecutorStep, this_output_path, versioned
+from marin.processing.tokenize import TokenizeConfig, tokenize
+from marin.processing.tokenize.data_configs import TokenizerStep
+
+_raw_download = download_common_corpus_raw_step()
+common_corpus_download = filter_common_corpus_step(_raw_download).as_executor_step()
+
+
+def tokenize_common_corpus(*, tokenizer: str | None = None) -> TokenizerStep:
+    """Tokenize the filtered Common Corpus (English, open types)."""
+    if tokenizer is None:
+        from experiments.marin_models import marin_tokenizer
+
+        tokenizer = marin_tokenizer
+
+    return ExecutorStep(
+        name="tokenized/common_corpus_english",
+        fn=tokenize,
+        config=TokenizeConfig(
+            train_paths=[common_corpus_download.as_input_name() / "**/*.parquet"],
+            validation_paths=versioned([]),
+            cache_path=this_output_path(),
+            tokenizer=versioned(tokenizer),
+            worker_resources=ResourceConfig(ram="40g", disk="5g"),
+        ),
+    )

--- a/experiments/pretraining_datasets/common_corpus.py
+++ b/experiments/pretraining_datasets/common_corpus.py
@@ -5,13 +5,18 @@
 
 from fray.v2 import ResourceConfig
 
-from marin.datakit.download.common_corpus import download_common_corpus_raw_step, filter_common_corpus_step
+from marin.datakit.download.common_corpus import (
+    download_common_corpus_raw_step,
+    filter_common_corpus_step,
+    normalize_common_corpus_step,
+)
 from marin.execution.executor import ExecutorStep, this_output_path, versioned
 from marin.processing.tokenize import TokenizeConfig, tokenize
 from marin.processing.tokenize.data_configs import TokenizerStep
 
-_raw_download = download_common_corpus_raw_step()
-common_corpus_download = filter_common_corpus_step(_raw_download).as_executor_step()
+common_corpus_download = normalize_common_corpus_step(
+    filter_common_corpus_step(download_common_corpus_raw_step())
+).as_executor_step()
 
 
 def tokenize_common_corpus(*, tokenizer: str | None = None) -> TokenizerStep:

--- a/lib/marin/src/marin/datakit/download/common_corpus.py
+++ b/lib/marin/src/marin/datakit/download/common_corpus.py
@@ -1,19 +1,43 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Download and filter PleIAs/common_corpus from HuggingFace."""
+"""Download, filter, and normalize PleIAs/common_corpus from HuggingFace."""
 
 import os
 
 from fray.v2 import ResourceConfig
 
 from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.normalize import normalize_step
 from marin.execution.step_spec import StepSpec
-from zephyr import Dataset, ZephyrContext
-from zephyr.expr import col
+from zephyr import Dataset, ZephyrContext, counters
 
 HF_DATASET_ID = "PleIAs/common_corpus"
 OPEN_TYPES = ["Open Science", "Open Government", "Open Culture"]
+
+
+def _count_total(record: dict) -> dict:
+    counters.increment("common_corpus/total")
+    return record
+
+
+def _language_is_english(record: dict) -> bool:
+    if record.get("language") != "English":
+        counters.increment("common_corpus/dropped_non_english")
+        return False
+    return True
+
+
+def _open_type_allowed(record: dict) -> bool:
+    if record.get("open_type") not in OPEN_TYPES:
+        counters.increment("common_corpus/dropped_wrong_open_type")
+        return False
+    return True
+
+
+def _count_kept(record: dict) -> dict:
+    counters.increment("common_corpus/kept")
+    return record
 
 
 def download_common_corpus_raw_step() -> StepSpec:
@@ -31,12 +55,10 @@ def filter_common_corpus(input_path: str, output_path: str) -> None:
     pipeline = (
         Dataset.from_files(os.path.join(input_path, "**/*.parquet"))
         .load_parquet()
-        .filter(col("language") == "English")
-        .filter(
-            (col("open_type") == "Open Science")
-            | (col("open_type") == "Open Government")
-            | (col("open_type") == "Open Culture")
-        )
+        .map(_count_total)
+        .filter(_language_is_english)
+        .filter(_open_type_allowed)
+        .map(_count_kept)
         .write_parquet(
             os.path.join(output_path, "data-{shard:05d}-of-{total:05d}.parquet"),
             skip_existing=True,
@@ -49,7 +71,16 @@ def filter_common_corpus(input_path: str, output_path: str) -> None:
 
 def filter_common_corpus_step(raw_step: StepSpec) -> StepSpec:
     return StepSpec(
-        name="raw/common_corpus_english",
+        name="raw/common_corpus_english_filtered",
         fn=lambda output_path: filter_common_corpus(raw_step.output_path, output_path),
         deps=[raw_step],
+    )
+
+
+def normalize_common_corpus_step(filtered_step: StepSpec) -> StepSpec:
+    """Normalize filtered common_corpus: generate content-hash IDs, dedup, sort."""
+    return normalize_step(
+        name="normalized/common_corpus_english_filtered",
+        download=filtered_step,
+        id_field="identifier",
     )

--- a/lib/marin/src/marin/datakit/download/common_corpus.py
+++ b/lib/marin/src/marin/datakit/download/common_corpus.py
@@ -1,0 +1,55 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Download and filter PleIAs/common_corpus from HuggingFace."""
+
+import os
+
+from fray.v2 import ResourceConfig
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.execution.step_spec import StepSpec
+from zephyr import Dataset, ZephyrContext
+from zephyr.expr import col
+
+HF_DATASET_ID = "PleIAs/common_corpus"
+OPEN_TYPES = ["Open Science", "Open Government", "Open Culture"]
+
+
+def download_common_corpus_raw_step() -> StepSpec:
+    """Download the raw PleIAs/common_corpus parquet files to GCS."""
+    return download_hf_step(
+        "raw/common_corpus",
+        hf_dataset_id=HF_DATASET_ID,
+        revision="b78a5c1",
+        hf_urls_glob=["common_corpus_*/*.parquet"],
+    )
+
+
+def filter_common_corpus(input_path: str, output_path: str) -> None:
+    """Filter common_corpus to English + open types, writing parquet."""
+    pipeline = (
+        Dataset.from_files(os.path.join(input_path, "**/*.parquet"))
+        .load_parquet()
+        .filter(col("language") == "English")
+        .filter(
+            (col("open_type") == "Open Science")
+            | (col("open_type") == "Open Government")
+            | (col("open_type") == "Open Culture")
+        )
+        .write_parquet(
+            os.path.join(output_path, "data-{shard:05d}-of-{total:05d}.parquet"),
+            skip_existing=True,
+        )
+    )
+
+    ctx = ZephyrContext(name="filter-common-corpus", resources=ResourceConfig(cpu=1, ram="8g"))
+    ctx.execute(pipeline)
+
+
+def filter_common_corpus_step(raw_step: StepSpec) -> StepSpec:
+    return StepSpec(
+        name="raw/common_corpus_english",
+        fn=lambda output_path: filter_common_corpus(raw_step.output_path, output_path),
+        deps=[raw_step],
+    )


### PR DESCRIPTION
Adds a download → filter → tokenize pipeline for PleIAs/common_corpus. The download mirrors the raw parquet files from HF (revision b78a5c1); a Zephyr filter step keeps only English documents whose open_type is Open Science, Open Government, or Open Culture and writes the result back as parquet; the tokenize step uses the marin tokenizer over those parquet files. Registered under "common_corpus" in the pretraining datasets registry.