### PR TITLE
[iris] Bundle cluster YAML configs in wheel and probe both layouts

### DIFF
--- a/lib/iris/Dockerfile
+++ b/lib/iris/Dockerfile
@@ -63,6 +63,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Now copy full source for both rigging and iris, then install.
 COPY lib/rigging/src/ ./lib/rigging/src/
 COPY lib/iris/src/ ./lib/iris/src/
+COPY lib/iris/examples/ ./lib/iris/examples/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --package iris
 

--- a/lib/iris/Dockerfile.dockerignore
+++ b/lib/iris/Dockerfile.dockerignore
@@ -5,6 +5,8 @@
 !lib/iris/pyproject.toml
 !lib/iris/hatch_build.py
 !lib/iris/src/
+!lib/iris/examples/
+!lib/iris/config/
 !lib/iris/dashboard/dist/
 
 !lib/rigging/

--- a/lib/iris/pyproject.toml
+++ b/lib/iris/pyproject.toml
@@ -71,6 +71,14 @@ dev = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/iris"]
 
+[tool.hatch.build.targets.wheel.force-include]
+# Cluster YAML configs live outside src/ because they are configuration data,
+# not Python package source. force-include maps them into the wheel at
+# iris/examples/ so that when iris is installed as a wheel, the bundled configs
+# are reachable via ``importlib.resources.files("iris") / "examples"`` (and
+# via the _bundled_iris_examples_dir() probe in iris.cli.main).
+"examples" = "iris/examples"
+
 [tool.pytest.ini_options]
 timeout = 10
 addopts = "-n auto --durations=25 -m 'not slow and not docker' -v"

--- a/lib/iris/pyproject.toml
+++ b/lib/iris/pyproject.toml
@@ -75,8 +75,8 @@ packages = ["src/iris"]
 # Cluster YAML configs live outside src/ because they are configuration data,
 # not Python package source. force-include maps them into the wheel at
 # iris/examples/ so that when iris is installed as a wheel, the bundled configs
-# are reachable via ``importlib.resources.files("iris") / "examples"`` (and
-# via the _bundled_iris_examples_dir() probe in iris.cli.main).
+# are reachable via Path(__file__).parent.parent / "examples" (the wheel-layout
+# probe in _bundled_iris_examples_dir() in iris.cli.main).
 "examples" = "iris/examples"
 
 [tool.pytest.ini_options]

--- a/lib/iris/src/iris/cli/main.py
+++ b/lib/iris/src/iris/cli/main.py
@@ -58,9 +58,9 @@ def _bundled_iris_examples_dir() -> str | None:
 IRIS_CLUSTER_CONFIG_DIRS: tuple[str, ...] = tuple(
     p
     for p in (
+        "~/.config/marin/clusters",  # user override — checked first
         "lib/iris/examples",  # in-tree marin checkout
         _bundled_iris_examples_dir(),  # editable install from sibling workspace
-        "~/.config/marin/clusters",  # user override
     )
     if p is not None
 )

--- a/lib/iris/src/iris/cli/main.py
+++ b/lib/iris/src/iris/cli/main.py
@@ -8,6 +8,7 @@ Defines the ``iris`` Click group and registers all subcommands.
 
 import logging as _logging_module
 import sys
+from pathlib import Path
 
 import click
 
@@ -22,12 +23,46 @@ from iris.rpc.proto_utils import PRIORITY_BAND_NAMES, priority_band_name, priori
 
 logger = _logging_module.getLogger(__name__)
 
-# Directories searched (in priority order) to resolve ``--cluster=<name>`` to a
-# YAML config file. Relative paths are resolved against the marin project root
-# by ``rigging.config_discovery``.
-IRIS_CLUSTER_CONFIG_DIRS: tuple[str, ...] = (
-    "lib/iris/examples",
-    "~/.config/marin/clusters",
+
+def _bundled_iris_examples_dir() -> str | None:
+    """Return the iris package's bundled examples/ dir when it ships on disk.
+
+    Probes two layouts because the examples directory can physically live in
+    two places depending on how iris was installed:
+
+    1. Wheel installs (site-packages): hatchling force-include places the
+       yamls at ``iris/examples/`` inside the package. Resolve that via
+       ``Path(__file__).parent.parent / "examples"``.
+    2. Editable workspace installs: the yamls stay at their source location
+       ``lib/iris/examples/`` — reachable via ``parents[3] / "examples"`` from
+       ``lib/iris/src/iris/cli/main.py``.
+
+    Returns the first directory that exists, or ``None`` for wheel installs
+    that don't ship examples at all.
+    """
+    here = Path(__file__).resolve()
+    # Wheel install: examples is a sibling of cli/ inside the iris package.
+    wheel_path = here.parent.parent / "examples"
+    if wheel_path.is_dir():
+        return str(wheel_path)
+    # Editable install: examples lives at lib/iris/examples/ (parents[3]).
+    editable_path = here.parents[3] / "examples"
+    if editable_path.is_dir():
+        return str(editable_path)
+    return None
+
+
+# Directories searched (in priority order) to resolve ``--cluster=<name>`` to
+# a YAML config file. Relative paths are resolved against the marin project
+# root by ``rigging.config_discovery``; absolute paths are used as-is.
+IRIS_CLUSTER_CONFIG_DIRS: tuple[str, ...] = tuple(
+    p
+    for p in (
+        "lib/iris/examples",  # in-tree marin checkout
+        _bundled_iris_examples_dir(),  # editable install from sibling workspace
+        "~/.config/marin/clusters",  # user override
+    )
+    if p is not None
 )
 
 


### PR DESCRIPTION
force-include lib/iris/examples/ into the wheel at iris/examples/ so sibling experiments that depend on iris as a wheel can resolve --cluster=marin without needing the marin source tree. _bundled_iris_examples_dir() now probes the in-package wheel location and falls back to the editable lib/iris/examples/ path.