### PR TITLE
[levanter] Move chex from test group into main dependencies

### DIFF
--- a/lib/levanter/pyproject.toml
+++ b/lib/levanter/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "datasets>=3.1.0,<5.0",
     "gcsfs>=2024.2,<2026",
     "braceexpand>=0.1.7",
+    "chex>=0.1.86",
     "jmp>=0.0.3",
     "fsspec[http]>=2024.2,<2026",
     "tensorstore>=0.1.73",


### PR DESCRIPTION
levanter.optim.adam_mini imports chex unconditionally, so any import of levanter (e.g. via levanter.callbacks) requires chex. Listing it only in the test dependency group breaks downstream consumers that install levanter without dev/test groups.