### PR TITLE
[marin] dedup output: use parquet instead of vortex

### DIFF
--- a/lib/marin/src/marin/processing/classification/deduplication/dedup_commons.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/dedup_commons.py
@@ -12,7 +12,7 @@ import wandb
 from fray.v2 import ResourceConfig
 from marin.utilities.wandb_utils import init_wandb
 from marin.utils import fsspec_glob, rebase_file_path
-from zephyr import counters, write_vortex_file
+from zephyr import counters, write_parquet_file
 from zephyr.readers import SUPPORTED_EXTENSIONS, open_file
 
 logger = logging.getLogger(__name__)
@@ -155,10 +155,10 @@ def make_document_dedup_aggregator(
     output_path: str,
     counter_prefix: str,
 ) -> Callable[[int, Iterator[dict]], dict]:
-    """Return a group_by reducer that counts dedup stats and writes vortex output.
+    """Return a group_by reducer that counts dedup stats and writes parquet output.
 
     The returned callable maps ``(file_idx, records) -> dict`` with keys
-    ``total``, ``dups``, ``unique`` plus whatever ``write_vortex_file`` returns.
+    ``total``, ``dups``, ``unique`` plus whatever ``write_parquet_file`` returns.
 
     Used identically by both exact-document and fuzzy-document dedup.
     """
@@ -170,7 +170,7 @@ def make_document_dedup_aggregator(
             input_path,
             f"{output_path}/data/",
             old_extension=_get_extension(input_path),
-            new_extension=".vortex",
+            new_extension=".parquet",
         )
 
         total = 0
@@ -194,7 +194,7 @@ def make_document_dedup_aggregator(
                 if record["is_dup"]:
                     yield {"id": record["id"], "attributes": {"dup_doc": True}}
 
-        result = write_vortex_file(only_dups(counting_iter()), output_file)
+        result = write_parquet_file(only_dups(counting_iter()), output_file)
         return {**result, "total": total, "dups": dups, "unique": total - dups}
 
     return aggregate

--- a/lib/marin/src/marin/processing/classification/deduplication/exact.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/exact.py
@@ -22,7 +22,7 @@ from marin.utils import rebase_file_path
 import pyarrow as pa
 import logging
 from fray.v2 import ResourceConfig
-from zephyr import ZephyrContext, counters, write_vortex_file
+from zephyr import ZephyrContext, counters, write_parquet_file
 from zephyr.dataset import Dataset
 
 logger = logging.getLogger(__name__)
@@ -92,7 +92,7 @@ def dedup_exact_paragraph(
             input_path,
             f"{output_path}/data/",
             old_extension=_get_extension(input_path),
-            new_extension=".vortex",
+            new_extension=".parquet",
         )
 
         total = 0
@@ -134,7 +134,7 @@ def dedup_exact_paragraph(
             if doc_level_record and doc_level_record["attributes"]["dup_spans"]:
                 yield doc_level_record
 
-        result = write_vortex_file(group_by_doc_id(counting_iter()), output_file)
+        result = write_parquet_file(group_by_doc_id(counting_iter()), output_file)
         return {**result, "total": total, "dups": dups, "unique": total - dups}
 
     def annotate_dups(key_hash: str, records: Iterator[dict[str, Any]]) -> Iterator[dict[str, Any]]:

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -112,7 +112,7 @@ def create_steps(prefix: str, synth_data: str) -> list[ExecutorStep]:
                     type=FilterType.REMOVE_SPANS,
                     attribute_path=dedup_exact_paragraph_step.cd("data"),
                     name="dup_spans",
-                    attribute_filetype="vortex",
+                    attribute_filetype="parquet",
                     keep_if_missing=True,
                 ),
             ],

--- a/tests/processing/classification/deduplication/conftest.py
+++ b/tests/processing/classification/deduplication/conftest.py
@@ -1,11 +1,9 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
-from zephyr import load_vortex
-
 from pathlib import Path
 
 import pytest
-from zephyr.readers import load_jsonl
+from zephyr.readers import load_jsonl, load_parquet
 
 
 @pytest.fixture(scope="module")
@@ -33,14 +31,14 @@ def load_dedup_outputs(output_dir: str) -> dict[str, dict]:
     return {r["id"]: r for r in results}
 
 
-def load_dedup_vortex_outputs(output_dir: str) -> dict[str, list[dict]]:
-    """Load all dedup vortex output files keyed by output filename stem.
+def load_dedup_parquet_outputs(output_dir: str) -> dict[str, list[dict]]:
+    """Load all dedup parquet output files keyed by output filename stem.
 
     Returns:
         Dictionary mapping output file stem (e.g. "test_shard_0") to list of records.
     """
-    output_files = sorted(Path(output_dir).glob("**/*.vortex"))
+    output_files = sorted(Path(output_dir).glob("**/*.parquet"))
     by_file: dict[str, list[dict]] = {}
     for output_file in output_files:
-        by_file[output_file.stem] = list(load_vortex(str(output_file)))
+        by_file[output_file.stem] = list(load_parquet(str(output_file)))
     return by_file

--- a/tests/processing/classification/deduplication/test_exact.py
+++ b/tests/processing/classification/deduplication/test_exact.py
@@ -3,7 +3,7 @@
 
 from marin.processing.classification.deduplication.dedup_commons import DedupMode
 from marin.processing.classification.deduplication.exact import dedup_exact_paragraph, dedup_exact_document
-from tests.processing.classification.deduplication.conftest import load_dedup_vortex_outputs
+from tests.processing.classification.deduplication.conftest import load_dedup_parquet_outputs
 
 
 def test_exact_paragraph_deduplication(fox_corpus):
@@ -22,7 +22,7 @@ def test_exact_paragraph_deduplication(fox_corpus):
     assert result["dedup/exact/paragraph/unique"] == 11
 
     # Load outputs keyed by output file stem (mirrors input shard names)
-    by_file = load_dedup_vortex_outputs(fox_corpus["output_dir"])
+    by_file = load_dedup_parquet_outputs(fox_corpus["output_dir"])
 
     # Output files should mirror the input shard structure
     assert "test_shard_0" in by_file
@@ -67,7 +67,7 @@ def test_exact_document_deduplication(fox_corpus):
     assert result["dedup/exact/document/dups"] == 2
     assert result["dedup/exact/document/unique"] == 9
 
-    by_file = load_dedup_vortex_outputs(fox_corpus["output_dir"])
+    by_file = load_dedup_parquet_outputs(fox_corpus["output_dir"])
 
     # Output files should mirror input shard structure
     assert "test_shard_0" in by_file

--- a/tests/processing/classification/deduplication/test_fuzzy.py
+++ b/tests/processing/classification/deduplication/test_fuzzy.py
@@ -3,7 +3,7 @@
 
 from marin.processing.classification.deduplication.dedup_commons import DedupMode
 from marin.processing.classification.deduplication.fuzzy import dedup_fuzzy_document
-from tests.processing.classification.deduplication.conftest import load_dedup_vortex_outputs
+from tests.processing.classification.deduplication.conftest import load_dedup_parquet_outputs
 
 
 def test_fuzzy_document_deduplication(fox_corpus):
@@ -24,7 +24,7 @@ def test_fuzzy_document_deduplication(fox_corpus):
     # At least 2 gray dups + 1 fuzzy dup (contaminated/high_overlap cluster)
     assert dups >= 3
 
-    by_file = load_dedup_vortex_outputs(fox_corpus["output_dir"] + "/data")
+    by_file = load_dedup_parquet_outputs(fox_corpus["output_dir"] + "/data")
 
     all_records = [r for records in by_file.values() for r in records]
     by_doc = {r["id"]: r for r in all_records}

--- a/tests/processing/classification/test_consolidate.py
+++ b/tests/processing/classification/test_consolidate.py
@@ -157,7 +157,7 @@ def test_dedupe_consolidate_integration(fox_corpus):
     assert result["mode"] == DedupMode.EXACT_PARAGRAPH
 
     # Verify dedupe output exists and has same structure as input
-    dedupe_output_files = list(Path(dedupe_output_dir).glob("data/*.vortex"))
+    dedupe_output_files = list(Path(dedupe_output_dir).glob("data/*.parquet"))
     assert len(dedupe_output_files) > 0
 
     # Now run consolidate using the dedupe attributes
@@ -171,7 +171,7 @@ def test_dedupe_consolidate_integration(fox_corpus):
                 type=FilterType.REMOVE_SPANS,
                 attribute_path=f"{dedupe_output_dir}/data",
                 name="dup_spans",
-                attribute_filetype="vortex",
+                attribute_filetype="parquet",
                 keep_if_missing=True,
             )
         ],


### PR DESCRIPTION
## Summary
- Switch final dedup output (exact paragraph, exact document, fuzzy document) from vortex to parquet, completing the vortex-to-parquet migration started in #4596.

## Test plan
- [x] `uv run pytest tests/processing/classification/deduplication/test_exact.py tests/processing/classification/deduplication/test_fuzzy.py` — all 3 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)