### PR TITLE
[training] Set max_retries_failure=0 for training job submissions

### DIFF
--- a/lib/marin/src/marin/training/training.py
+++ b/lib/marin/src/marin/training/training.py
@@ -292,7 +292,7 @@ def _submit_training_job(
         entrypoint=Entrypoint.from_callable(main_fn, args=[train_config]),
         resources=resources,
         environment=create_environment(env_vars=env, extras=extras),
-        max_retries_failure=10,
+        max_retries_failure=0,
     )
     job = client.submit(job_request)
     job.wait(raise_on_failure=True)


### PR DESCRIPTION
Removes the hardcoded max_retries_failure=10 in _submit_training_job. Retrying on deterministic failures (e.g. ModuleNotFoundError) wastes resources and delays surfacing real errors. Preemptions are handled separately via max_retries_preemption (default 100).