### PR TITLE
Migrate DNABatchTokenizer and DNALmDatasetFormat to MarinTokenizer

### DIFF
--- a/experiments/dna/defaults.py
+++ b/experiments/dna/defaults.py
@@ -12,7 +12,7 @@ from collections.abc import Sequence
 
 from fray.cluster import ResourceConfig
 from levanter.data.text import DNABatchTokenizer, DNALmDatasetFormat, TextLmDatasetFormat
-from transformers import AutoTokenizer
+from levanter.tokenizers import load_tokenizer
 
 from experiments.defaults import default_tokenize, default_train
 from experiments.simple_train_config import SimpleTrainConfig
@@ -95,7 +95,7 @@ def dna_effective_seq_len(base_seq_len: int, tokenizer_name: str) -> int:
     ``max_seq_len`` stays in sync automatically. Uses ``DNABatchTokenizer`` as the
     single source of truth for special-token detection.
     """
-    tok = AutoTokenizer.from_pretrained(tokenizer_name)
+    tok = load_tokenizer(tokenizer_name)
     bt = DNABatchTokenizer(tok)
     return base_seq_len + bt.num_special_tokens
 

--- a/lib/levanter/src/levanter/data/text/_batch_tokenizer.py
+++ b/lib/levanter/src/levanter/data/text/_batch_tokenizer.py
@@ -9,7 +9,6 @@ import regex
 
 from levanter.data import BatchProcessor
 from levanter.tokenizers import MarinTokenizer
-from levanter.utils.hf_utils import HfTokenizer
 from levanter.utils.py_utils import logical_cpu_core_count
 
 LONG_STRING_WORKAROUND = 10_000
@@ -223,7 +222,7 @@ class DNABatchTokenizer(BatchProcessor[dict, dict]):
 
     def __init__(
         self,
-        tokenizer: HfTokenizer,
+        tokenizer: MarinTokenizer,
         text_field: str = "seq",
         uppercase_weight: float = 1.0,
         lowercase_weight: float = 1.0,
@@ -231,6 +230,7 @@ class DNABatchTokenizer(BatchProcessor[dict, dict]):
         override_resources=None,
     ):
         self.tokenizer = tokenizer
+        self._hf_tokenizer = tokenizer.as_hf_tokenizer()
         self.text_field = text_field
         self.override_resources = override_resources
         self.uppercase_weight = uppercase_weight
@@ -247,7 +247,7 @@ class DNABatchTokenizer(BatchProcessor[dict, dict]):
 
         assert len(set(len(t) for t in texts)) == 1, "All sequences must have the same length"
 
-        encodings = self.tokenizer(
+        encodings = self._hf_tokenizer(
             texts,
             # important so input ids are aligned with loss weights
             add_special_tokens=False,
@@ -304,7 +304,7 @@ class DNABatchTokenizer(BatchProcessor[dict, dict]):
     def metadata(self) -> dict[str, Any]:
         return {
             "tokenizer": self.tokenizer.name_or_path,
-            "vocab_size": len(self.tokenizer),
+            "vocab_size": self.tokenizer.vocab_size,
             "uppercase_weight": self.uppercase_weight,
             "lowercase_weight": self.lowercase_weight,
             "has_bos": self._has_bos,

--- a/lib/levanter/src/levanter/data/text/formats.py
+++ b/lib/levanter/src/levanter/data/text/formats.py
@@ -11,7 +11,6 @@ from draccus import ChoiceRegistry
 
 from levanter.data._preprocessor import BatchProcessor
 from levanter.tokenizers import MarinTokenizer
-from levanter.utils.hf_utils import HfTokenizer
 
 from ._batch_tokenizer import BatchTokenizer, DNABatchTokenizer
 
@@ -120,7 +119,7 @@ class DNALmDatasetFormat(LmDatasetFormatBase):
     lowercase_weight: float = 1.0
 
     def build_preprocessor(
-        self, tokenizer: HfTokenizer, *, enforce_eos: bool = True, enforce_bos: bool = True
+        self, tokenizer: MarinTokenizer, *, enforce_eos: bool = True, enforce_bos: bool = True
     ) -> BatchProcessor[dict, dict]:
         del enforce_eos, enforce_bos
         return DNABatchTokenizer(

--- a/lib/levanter/tests/test_dna_batch_tokenizer.py
+++ b/lib/levanter/tests/test_dna_batch_tokenizer.py
@@ -4,17 +4,19 @@
 # Copyright 2025 The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
+
 import numpy as np
 import pytest
-from transformers import AutoTokenizer
 
 from levanter.data.text import DNABatchTokenizer
+from levanter.tokenizers import load_tokenizer
 
 
 def _skip_if_tokenizer_unavailable(tokenizer_name: str):
     def try_load(name):
         try:
-            AutoTokenizer.from_pretrained(name)
+            load_tokenizer(name)
         except Exception:
             return False
         return True
@@ -29,7 +31,7 @@ BOS_EOS_TOKENIZER = "bolinas-dna/tokenizer-char"
 @_skip_if_tokenizer_unavailable(NO_BOS_EOS_TOKENIZER)
 def test_no_special_tokens():
     """With a tokenizer that has no BOS/EOS, output matches input length."""
-    tokenizer = AutoTokenizer.from_pretrained(NO_BOS_EOS_TOKENIZER)
+    tokenizer = load_tokenizer(NO_BOS_EOS_TOKENIZER)
     bt = DNABatchTokenizer(tokenizer, lowercase_weight=0.01)
 
     assert bt.num_special_tokens == 0
@@ -48,7 +50,7 @@ def test_no_special_tokens():
 @_skip_if_tokenizer_unavailable(NO_BOS_EOS_TOKENIZER)
 def test_weights_target_aligned_no_special_tokens():
     """Weights are target-aligned: loss_weight[i] reflects the case of input_ids[i+1]."""
-    tokenizer = AutoTokenizer.from_pretrained(NO_BOS_EOS_TOKENIZER)
+    tokenizer = load_tokenizer(NO_BOS_EOS_TOKENIZER)
     bt = DNABatchTokenizer(tokenizer, lowercase_weight=0.1)
 
     # Sequence: A  C  g  t
@@ -63,7 +65,7 @@ def test_weights_target_aligned_no_special_tokens():
 @_skip_if_tokenizer_unavailable(BOS_EOS_TOKENIZER)
 def test_bos_eos_tokens_added():
     """With a tokenizer that has BOS/EOS, they are prepended/appended."""
-    tokenizer = AutoTokenizer.from_pretrained(BOS_EOS_TOKENIZER)
+    tokenizer = load_tokenizer(BOS_EOS_TOKENIZER)
     bt = DNABatchTokenizer(tokenizer, lowercase_weight=0.01)
 
     assert bt.num_special_tokens == 2
@@ -79,14 +81,14 @@ def test_bos_eos_tokens_added():
     assert result["input_ids"][-1] == tokenizer.eos_token_id
 
     # Interior tokens should match tokenizing without special tokens
-    plain_ids = tokenizer(seq, add_special_tokens=False)["input_ids"]
+    plain_ids = tokenizer.encode(seq, add_special_tokens=False)
     np.testing.assert_array_equal(result["input_ids"][1:-1], plain_ids)
 
 
 @_skip_if_tokenizer_unavailable(BOS_EOS_TOKENIZER)
 def test_loss_weights_with_bos_eos():
     """Weights are target-aligned with BOS/EOS."""
-    tokenizer = AutoTokenizer.from_pretrained(BOS_EOS_TOKENIZER)
+    tokenizer = load_tokenizer(BOS_EOS_TOKENIZER)
     bt = DNABatchTokenizer(tokenizer, lowercase_weight=0.1)
 
     batch = [{"seq": "ACgt"}]
@@ -102,7 +104,7 @@ def test_loss_weights_with_bos_eos():
 @_skip_if_tokenizer_unavailable(BOS_EOS_TOKENIZER)
 def test_batch_consistency_with_bos_eos():
     """All sequences in a batch get BOS/EOS and have the same length."""
-    tokenizer = AutoTokenizer.from_pretrained(BOS_EOS_TOKENIZER)
+    tokenizer = load_tokenizer(BOS_EOS_TOKENIZER)
     bt = DNABatchTokenizer(tokenizer, lowercase_weight=0.01)
 
     batch = [{"seq": "AAAA"}, {"seq": "CCCC"}, {"seq": "TTTT"}]
@@ -115,7 +117,7 @@ def test_batch_consistency_with_bos_eos():
 
 @_skip_if_tokenizer_unavailable(NO_BOS_EOS_TOKENIZER)
 def test_metadata_no_special_tokens():
-    tokenizer = AutoTokenizer.from_pretrained(NO_BOS_EOS_TOKENIZER)
+    tokenizer = load_tokenizer(NO_BOS_EOS_TOKENIZER)
     bt = DNABatchTokenizer(tokenizer, lowercase_weight=0.5)
     meta = bt.metadata
 
@@ -127,7 +129,7 @@ def test_metadata_no_special_tokens():
 
 @_skip_if_tokenizer_unavailable(BOS_EOS_TOKENIZER)
 def test_metadata_with_special_tokens():
-    tokenizer = AutoTokenizer.from_pretrained(BOS_EOS_TOKENIZER)
+    tokenizer = load_tokenizer(BOS_EOS_TOKENIZER)
     bt = DNABatchTokenizer(tokenizer, lowercase_weight=0.01)
     meta = bt.metadata
 
@@ -138,9 +140,9 @@ def test_metadata_with_special_tokens():
 @_skip_if_tokenizer_unavailable(BOS_EOS_TOKENIZER)
 def test_bos_only():
     """When only BOS is defined, only BOS is prepended (no EOS)."""
-    tokenizer = AutoTokenizer.from_pretrained(BOS_EOS_TOKENIZER)
+    tokenizer = load_tokenizer(BOS_EOS_TOKENIZER)
     # Patch out EOS so only BOS is active
-    tokenizer.eos_token_id = None
+    tokenizer = dataclasses.replace(tokenizer, _eos_id=None)
     bt = DNABatchTokenizer(tokenizer, lowercase_weight=0.1)
 
     assert bt.num_special_tokens == 1
@@ -157,7 +159,7 @@ def test_bos_only():
 @_skip_if_tokenizer_unavailable(NO_BOS_EOS_TOKENIZER)
 def test_uppercase_weight_zero():
     """Setting uppercase_weight=0 zeroes out loss for predicting uppercase targets."""
-    tokenizer = AutoTokenizer.from_pretrained(NO_BOS_EOS_TOKENIZER)
+    tokenizer = load_tokenizer(NO_BOS_EOS_TOKENIZER)
     bt = DNABatchTokenizer(tokenizer, uppercase_weight=0.0, lowercase_weight=1.0)
 
     # Sequence: A    C    g    t
@@ -172,10 +174,10 @@ def test_uppercase_weight_zero():
 @_skip_if_tokenizer_unavailable(BOS_EOS_TOKENIZER)
 def test_eos_only():
     """When only EOS is defined, only EOS is appended (no BOS)."""
-    tokenizer = AutoTokenizer.from_pretrained(BOS_EOS_TOKENIZER)
+    tokenizer = load_tokenizer(BOS_EOS_TOKENIZER)
     eos_id = tokenizer.eos_token_id
     # Patch out BOS so only EOS is active
-    tokenizer.bos_token_id = None
+    tokenizer = dataclasses.replace(tokenizer, _bos_id=None)
     bt = DNABatchTokenizer(tokenizer, lowercase_weight=0.1)
 
     assert bt.num_special_tokens == 1


### PR DESCRIPTION
## Summary
- Update `DNABatchTokenizer` and `DNALmDatasetFormat` to accept `MarinTokenizer` instead of `HfTokenizer`
- Replace `AutoTokenizer.from_pretrained` with `load_tokenizer` across experiments and tests
- Use `MarinTokenizer.as_hf_tokenizer()` internally where HF tokenizer calls are still needed
- Use `dataclasses.replace` for tokenizer patching in tests instead of mutating HF tokenizer attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)