### PR TITLE
[infra] Cap remaining Ray TPU pools with tiered max_workers rule

### DIFF
--- a/infra/marin-eu-west4-a.yaml
+++ b/infra/marin-eu-west4-a.yaml
@@ -133,7 +133,7 @@ available_node_types:
             # Set Source Image =>> Ubuntu 22.04 Base VM
             sourceImage: projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts
   tpu_worker:
-    max_workers: 1024
+    max_workers: 4
     min_workers: 0
     node_config:
       acceleratorType: v6e-4
@@ -145,7 +145,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v6e_8:
-    max_workers: 1024
+    max_workers: 4
     min_workers: 0
     node_config:
       acceleratorType: v6e-8
@@ -157,7 +157,7 @@ available_node_types:
       TPU: 8
 
   tpu_slice_v6e_16:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v6e-16
@@ -169,7 +169,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v6e_32:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v6e-32
@@ -181,7 +181,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v6e_64:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v6e-64
@@ -205,7 +205,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v6e_256:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v6e-256

--- a/infra/marin-eu-west4-vllm.yaml
+++ b/infra/marin-eu-west4-vllm.yaml
@@ -140,7 +140,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5e_8:
-    max_workers: 1024
+    max_workers: 4
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-8
@@ -152,7 +152,7 @@ available_node_types:
       TPU: 8
 
   tpu_slice_v5e_16:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-16
@@ -164,7 +164,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5e_32:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-32
@@ -176,7 +176,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5e_64:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-64
@@ -188,7 +188,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5e_128:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-128
@@ -200,7 +200,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5e_256:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-256

--- a/infra/marin-eu-west4.yaml
+++ b/infra/marin-eu-west4.yaml
@@ -145,7 +145,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5e_8:
-    max_workers: 1024
+    max_workers: 4
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-8
@@ -157,7 +157,7 @@ available_node_types:
       TPU: 8
 
   tpu_slice_v5e_16:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-16
@@ -169,7 +169,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5e_32:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-32
@@ -181,7 +181,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5e_64:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-64
@@ -193,7 +193,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5e_128:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-128
@@ -205,7 +205,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5e_256:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-256

--- a/infra/marin-us-central1-vllm.yaml
+++ b/infra/marin-us-central1-vllm.yaml
@@ -128,7 +128,7 @@ available_node_types:
             # Set Source Image =>> Ubuntu 22.04 Base VM
             sourceImage: projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts
   tpu_worker:
-    max_workers: 1024
+    max_workers: 4
     min_workers: 0
     node_config:
       acceleratorType: v5p-8
@@ -152,7 +152,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_16:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5p-16
@@ -164,7 +164,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_32:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5p-32
@@ -176,7 +176,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_64:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5p-64
@@ -188,7 +188,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_128:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-128
@@ -200,7 +200,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_256:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-256
@@ -212,7 +212,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_512:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-512
@@ -224,7 +224,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_1024:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-1024
@@ -236,7 +236,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_2048:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-2048

--- a/infra/marin-us-central1.yaml
+++ b/infra/marin-us-central1.yaml
@@ -157,7 +157,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_16:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5p-16
@@ -169,7 +169,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_32:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5p-32
@@ -193,7 +193,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_128:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-128
@@ -205,7 +205,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_256:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-256
@@ -217,7 +217,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_512:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-512
@@ -229,7 +229,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_1024:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-1024
@@ -241,7 +241,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_2048:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-2048

--- a/infra/marin-us-central2-staging.yaml
+++ b/infra/marin-us-central2-staging.yaml
@@ -145,7 +145,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_16:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v4-16
@@ -157,7 +157,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_32:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v4-32
@@ -169,7 +169,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_64:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v4-64
@@ -181,7 +181,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_128:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v4-128
@@ -193,7 +193,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_256:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v4-256
@@ -205,7 +205,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_512:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v4-512
@@ -217,7 +217,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_1024:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v4-1024
@@ -229,7 +229,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_2048:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v4-2048
@@ -241,7 +241,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_4096:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v4-4096

--- a/infra/marin-us-central2-vllm.yaml
+++ b/infra/marin-us-central2-vllm.yaml
@@ -140,7 +140,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_16:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v4-16
@@ -152,7 +152,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_32:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v4-32
@@ -164,7 +164,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_64:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v4-64
@@ -176,7 +176,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_128:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v4-128
@@ -188,7 +188,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_256:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v4-256
@@ -200,7 +200,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_512:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v4-512
@@ -212,7 +212,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_1024:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v4-1024
@@ -224,7 +224,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_2048:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v4-2048
@@ -236,7 +236,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_4096:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v4-4096

--- a/infra/marin-us-central2.yaml
+++ b/infra/marin-us-central2.yaml
@@ -145,7 +145,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_16:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v4-16
@@ -157,7 +157,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_32:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v4-32
@@ -169,7 +169,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_64:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v4-64
@@ -181,7 +181,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_128:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v4-128
@@ -193,7 +193,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_256:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v4-256
@@ -205,7 +205,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_512:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v4-512
@@ -217,7 +217,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_1024:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v4-1024
@@ -229,7 +229,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_2048:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v4-2048
@@ -241,7 +241,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v4_4096:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v4-4096

--- a/infra/marin-us-east1.yaml
+++ b/infra/marin-us-east1.yaml
@@ -133,7 +133,7 @@ available_node_types:
             # Set Source Image =>> Ubuntu 22.04 Base VM
             sourceImage: projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts
   tpu_worker:
-    max_workers: 1024
+    max_workers: 4
     min_workers: 0
     node_config:
       acceleratorType: v6e-4
@@ -145,7 +145,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v6e_8:
-    max_workers: 1024
+    max_workers: 4
     min_workers: 0
     node_config:
       acceleratorType: v6e-8
@@ -157,7 +157,7 @@ available_node_types:
       TPU: 8
 
   tpu_slice_v6e_16:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v6e-16
@@ -169,7 +169,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v6e_32:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v6e-32
@@ -181,7 +181,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v6e_64:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v6e-64
@@ -193,7 +193,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v6e_128:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v6e-128
@@ -205,7 +205,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v6e_256:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v6e-256

--- a/infra/marin-us-east5-a-vllm.yaml
+++ b/infra/marin-us-east5-a-vllm.yaml
@@ -128,7 +128,7 @@ available_node_types:
             # Set Source Image =>> Ubuntu 22.04 Base VM
             sourceImage: projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts
   tpu_worker:
-    max_workers: 1024
+    max_workers: 4
     min_workers: 0
     node_config:
       acceleratorType: v5p-8
@@ -152,7 +152,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_16:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5p-16
@@ -164,7 +164,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_32:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5p-32
@@ -176,7 +176,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_64:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5p-64
@@ -188,7 +188,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_128:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-128
@@ -200,7 +200,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_256:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-256
@@ -212,7 +212,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_512:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-512
@@ -224,7 +224,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_1024:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-1024
@@ -236,7 +236,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_2048:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-2048

--- a/infra/marin-us-east5-a.yaml
+++ b/infra/marin-us-east5-a.yaml
@@ -157,7 +157,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_16:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5p-16
@@ -169,7 +169,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_32:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5p-32
@@ -181,7 +181,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_64:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5p-64
@@ -193,7 +193,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_128:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-128
@@ -205,7 +205,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_256:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-256
@@ -217,7 +217,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_512:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-512
@@ -229,7 +229,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_1024:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-1024
@@ -241,7 +241,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5p_2048:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5p-2048

--- a/infra/marin-us-east5.yaml
+++ b/infra/marin-us-east5.yaml
@@ -133,7 +133,7 @@ available_node_types:
             # Set Source Image =>> Ubuntu 22.04 Base VM
             sourceImage: projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts
   tpu_worker:
-    max_workers: 1024
+    max_workers: 4
     min_workers: 0
     node_config:
       acceleratorType: v6e-4
@@ -145,7 +145,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v6e_8:
-    max_workers: 1024
+    max_workers: 4
     min_workers: 0
     node_config:
       acceleratorType: v6e-8
@@ -157,7 +157,7 @@ available_node_types:
       TPU: 8
 
   tpu_slice_v6e_16:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v6e-16
@@ -169,7 +169,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v6e_32:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v6e-32
@@ -181,7 +181,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v6e_64:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v6e-64
@@ -193,7 +193,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v6e_128:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v6e-128
@@ -205,7 +205,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v6e_256:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v6e-256

--- a/infra/marin-us-west4.yaml
+++ b/infra/marin-us-west4.yaml
@@ -133,7 +133,7 @@ available_node_types:
             # Set Source Image =>> Ubuntu 22.04 Base VM
             sourceImage: projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts
   tpu_worker:
-    max_workers: 1024
+    max_workers: 4
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-4
@@ -145,7 +145,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5e_8:
-    max_workers: 1024
+    max_workers: 4
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-8
@@ -157,7 +157,7 @@ available_node_types:
       TPU: 8
 
   tpu_slice_v5e_16:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-16
@@ -169,7 +169,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5e_32:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-32
@@ -181,7 +181,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5e_64:
-    max_workers: 1024
+    max_workers: 2
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-64
@@ -193,7 +193,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5e_128:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-128
@@ -205,7 +205,7 @@ available_node_types:
       TPU: 4
 
   tpu_slice_v5e_256:
-    max_workers: 1024
+    max_workers: 1
     min_workers: 0
     node_config:
       acceleratorType: v5litepod-256


### PR DESCRIPTION
Caps all remaining max_workers: 1024 TPU pools in Ray cluster configs
using a tiered rule based on accelerator size:

  size 4/8   (single-host):      max_workers: 4
  size 16/32/64 (small multi-host): max_workers: 2
  size 128+  (large multi-host):  max_workers: 1

99 pools capped across 13 files. This closes the gap left by #4604,
which only capped pools with observed activity or nonzero min_workers.
Also fixes the two Codex P1 loopholes from #4604 (uncapped tpu_worker
v5p-8 pools in us-central1-vllm and us-east5-a-vllm).

Excludes marin-big-run.yaml (non-standard naming, separate review).

Follow-up to #4604.
