### PR TITLE
[ci] Reduce canary ferry entrypoint memory from 16G to 2G

### DIFF
--- a/.github/workflows/marin-canary-ferry-cw.yaml
+++ b/.github/workflows/marin-canary-ferry-cw.yaml
@@ -89,7 +89,7 @@ jobs:
         run: |
           JOB_ID=$(.venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
             job run --no-wait \
-            --memory=2G --disk=16G --cpu=1 --extra=cpu \
+            --memory=2G --disk=4G --cpu=1 --extra=cpu \
             -e MARIN_PREFIX s3://marin-na/marin/ \
             -e RUN_ID "$RUN_ID" \
             -e CANARY_ACCELERATOR "$CANARY_ACCELERATOR" \

--- a/.github/workflows/marin-canary-ferry-cw.yaml
+++ b/.github/workflows/marin-canary-ferry-cw.yaml
@@ -89,7 +89,7 @@ jobs:
         run: |
           JOB_ID=$(.venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
             job run --no-wait \
-            --memory=16G --disk=16G --cpu=1 --extra=cpu \
+            --memory=2G --disk=16G --cpu=1 --extra=cpu \
             -e MARIN_PREFIX s3://marin-na/marin/ \
             -e RUN_ID "$RUN_ID" \
             -e CANARY_ACCELERATOR "$CANARY_ACCELERATOR" \

--- a/.github/workflows/marin-canary-ferry.yaml
+++ b/.github/workflows/marin-canary-ferry.yaml
@@ -78,7 +78,7 @@ jobs:
         run: |
           JOB_ID=$(.venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
             job run --no-wait \
-            --memory=2G --disk=16G --cpu=1 --extra=cpu \
+            --memory=2G --disk=4G --cpu=1 --extra=cpu \
             --reserve v5p-8 \
             -e RUN_ID "$RUN_ID" \
             -e CANARY_ACCELERATOR "$CANARY_ACCELERATOR" \

--- a/.github/workflows/marin-canary-ferry.yaml
+++ b/.github/workflows/marin-canary-ferry.yaml
@@ -78,7 +78,7 @@ jobs:
         run: |
           JOB_ID=$(.venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
             job run --no-wait \
-            --memory=16G --disk=16G --cpu=1 --extra=cpu \
+            --memory=2G --disk=16G --cpu=1 --extra=cpu \
             --reserve v5p-8 \
             -e RUN_ID "$RUN_ID" \
             -e CANARY_ACCELERATOR "$CANARY_ACCELERATOR" \


### PR DESCRIPTION
The coordinator entrypoint job only needs modest resources to schedule and dispatch work. 16G triggers the --enable-extra-resources guard, breaking both TPU and CoreWeave canary ferries.