### PR TITLE
Add normalization and tokenization for starcoder2-extras

### DIFF
--- a/experiments/defaults.py
+++ b/experiments/defaults.py
@@ -207,6 +207,8 @@ def default_tokenize(
     sample_count: int | VersionedValue[int] | None = None,
     is_validation: bool = False,
     levanter_batch_size: int | None = None,
+    resources: ResourceConfig | None = None,
+    worker_resources: ResourceConfig | None = None,
 ) -> ExecutorStep:
     """
     Tokenizes a dataset using the specified tokenizer and Levanter's tokenization infrastructure.
@@ -229,6 +231,11 @@ def default_tokenize(
         An ExecutorStep that represents the tokenized dataset.
     """
 
+    # Common kwargs for config constructors
+    extra_kwargs: dict = {}
+    if worker_resources is not None:
+        extra_kwargs["worker_resources"] = worker_resources
+
     # sniff out if it's a HuggingFace dataset
     if isinstance(dataset, HfDatasetSpec):
         config = HfTokenizeConfig(
@@ -239,6 +246,7 @@ def default_tokenize(
             format=format,
             sample_count=ensure_versioned(sample_count) if sample_count is not None else None,
             levanter_batch_size=levanter_batch_size,
+            **extra_kwargs,
         )
     elif (
         isinstance(dataset, str)
@@ -253,6 +261,7 @@ def default_tokenize(
             format=format,
             sample_count=ensure_versioned(sample_count) if sample_count is not None else None,
             levanter_batch_size=levanter_batch_size,
+            **extra_kwargs,
         )
     else:
         config = TokenizeConfig(
@@ -263,6 +272,7 @@ def default_tokenize(
             format=format,
             sample_count=ensure_versioned(sample_count) if sample_count is not None else None,
             levanter_batch_size=levanter_batch_size,
+            **extra_kwargs,
         )
 
     return ExecutorStep(
@@ -270,7 +280,7 @@ def default_tokenize(
         description=f"Tokenize raw text using the {tokenizer} tokenizer.",
         fn=remote(
             tokenize,
-            resources=ResourceConfig.with_cpu(cpu=4, ram="16g", disk="10g"),
+            resources=resources or ResourceConfig.with_cpu(cpu=4, ram="16g", disk="10g"),
             pip_dependency_groups=["cpu"],
             env_vars={
                 "TRANSFORMERS_NO_TORCH": "1",

--- a/experiments/defaults.py
+++ b/experiments/defaults.py
@@ -206,6 +206,7 @@ def default_tokenize(
     *,
     sample_count: int | VersionedValue[int] | None = None,
     is_validation: bool = False,
+    levanter_batch_size: int | None = None,
 ) -> ExecutorStep:
     """
     Tokenizes a dataset using the specified tokenizer and Levanter's tokenization infrastructure.
@@ -237,6 +238,7 @@ def default_tokenize(
             tokenizer=ensure_versioned(tokenizer),
             format=format,
             sample_count=ensure_versioned(sample_count) if sample_count is not None else None,
+            levanter_batch_size=levanter_batch_size,
         )
     elif (
         isinstance(dataset, str)
@@ -250,6 +252,7 @@ def default_tokenize(
             tokenizer=ensure_versioned(tokenizer),
             format=format,
             sample_count=ensure_versioned(sample_count) if sample_count is not None else None,
+            levanter_batch_size=levanter_batch_size,
         )
     else:
         config = TokenizeConfig(
@@ -259,6 +262,7 @@ def default_tokenize(
             tokenizer=ensure_versioned(tokenizer),
             format=format,
             sample_count=ensure_versioned(sample_count) if sample_count is not None else None,
+            levanter_batch_size=levanter_batch_size,
         )
 
     return ExecutorStep(

--- a/experiments/pretraining_datasets/starcoder2_extras.py
+++ b/experiments/pretraining_datasets/starcoder2_extras.py
@@ -25,9 +25,6 @@ def tokenize_starcoder2_extras(*, tokenizer: str = marin_tokenizer) -> list[Toke
             download=download,
             text_field="content",
             file_extensions=(".parquet",),
-            # documentation contains very large records (e.g. full OpenJDK docs at 64MB);
-            # split them to avoid OOM during tokenization
-            max_record_size=10_000_000 if subset == "documentation" else None,
         )
         steps.append(
             default_tokenize(

--- a/experiments/pretraining_datasets/starcoder2_extras.py
+++ b/experiments/pretraining_datasets/starcoder2_extras.py
@@ -5,6 +5,7 @@
 
 from experiments.defaults import default_tokenize
 from experiments.marin_models import marin_tokenizer
+from fray.v2 import ResourceConfig
 from levanter.data.text.formats import TextLmDatasetFormat
 from marin.datakit.download.starcoder2_extras import (
     SUBSETS,
@@ -26,6 +27,12 @@ def tokenize_starcoder2_extras(*, tokenizer: str = marin_tokenizer) -> list[Toke
             text_field="content",
             file_extensions=(".parquet",),
         )
+        # documentation contains a single 64MB OpenJDK record that peaks at ~9GB RSS
+        # during tokenization; bump worker memory to 32GB for that subset
+        if subset == "documentation":
+            doc_resources = ResourceConfig(ram="32g", disk="10g")
+        else:
+            doc_resources = None
         steps.append(
             default_tokenize(
                 name=f"starcoder2_extras/{subset}",
@@ -33,6 +40,8 @@ def tokenize_starcoder2_extras(*, tokenizer: str = marin_tokenizer) -> list[Toke
                 tokenizer=tokenizer,
                 format=TextLmDatasetFormat(text_key="text"),
                 levanter_batch_size=128,
+                resources=ResourceConfig.with_cpu(cpu=4, ram="32g", disk="10g") if subset == "documentation" else None,
+                worker_resources=doc_resources,
             )
         )
     return steps

--- a/experiments/pretraining_datasets/starcoder2_extras.py
+++ b/experiments/pretraining_datasets/starcoder2_extras.py
@@ -28,11 +28,8 @@ def tokenize_starcoder2_extras(*, tokenizer: str = marin_tokenizer) -> list[Toke
             file_extensions=(".parquet",),
         )
         # documentation contains a single 64MB OpenJDK record that peaks at ~9GB RSS
-        # during tokenization; bump worker memory to 32GB for that subset
-        if subset == "documentation":
-            doc_resources = ResourceConfig(ram="32g", disk="10g")
-        else:
-            doc_resources = None
+        # during tokenization; bump memory to 32GB for that subset
+        doc_resources = ResourceConfig(ram="32g", disk="10g") if subset == "documentation" else None
         steps.append(
             default_tokenize(
                 name=f"starcoder2_extras/{subset}",
@@ -40,7 +37,6 @@ def tokenize_starcoder2_extras(*, tokenizer: str = marin_tokenizer) -> list[Toke
                 tokenizer=tokenizer,
                 format=TextLmDatasetFormat(text_key="text"),
                 levanter_batch_size=128,
-                resources=ResourceConfig.with_cpu(cpu=4, ram="32g", disk="10g") if subset == "documentation" else None,
                 worker_resources=doc_resources,
             )
         )

--- a/experiments/pretraining_datasets/starcoder2_extras.py
+++ b/experiments/pretraining_datasets/starcoder2_extras.py
@@ -5,37 +5,37 @@
 
 from experiments.defaults import default_tokenize
 from experiments.marin_models import marin_tokenizer
-from fray.v2 import ResourceConfig
 from levanter.data.text.formats import TextLmDatasetFormat
 from marin.datakit.download.starcoder2_extras import (
     SUBSETS,
     download_starcoder2_extras_step,
-    reshard_starcoder2_extras_step,
 )
+from marin.datakit.normalize import normalize_step
 from marin.execution.executor import executor_main
 from marin.processing.tokenize.data_configs import TokenizerStep
 
-WORKER_RAM = {"ir_low_resource": "80g"}
-DEFAULT_WORKER_RAM = "40g"
-
 
 def tokenize_starcoder2_extras(*, tokenizer: str = marin_tokenizer) -> list[TokenizerStep]:
-    """Download and tokenize all selected starcoder2data-extras subsets."""
+    """Download, normalize, and tokenize all selected starcoder2data-extras subsets."""
     steps = []
-    RESHARD_SUBSETS = {"ir_low_resource"}
     for subset in SUBSETS:
-        if subset in RESHARD_SUBSETS:
-            download = reshard_starcoder2_extras_step(subset)
-        else:
-            download = download_starcoder2_extras_step(subset)
-        ram = WORKER_RAM.get(subset, DEFAULT_WORKER_RAM)
+        download = download_starcoder2_extras_step(subset)
+        normalized = normalize_step(
+            name=f"normalized/starcoder2_extras/{subset}",
+            download=download,
+            text_field="content",
+            file_extensions=(".parquet",),
+            # documentation contains very large records (e.g. full OpenJDK docs at 64MB);
+            # split them to avoid OOM during tokenization
+            max_record_size=10_000_000 if subset == "documentation" else None,
+        )
         steps.append(
             default_tokenize(
                 name=f"starcoder2_extras/{subset}",
-                dataset=download.as_executor_step(),
+                dataset=normalized.as_executor_step(),
                 tokenizer=tokenizer,
-                format=TextLmDatasetFormat(text_key="content"),
-                worker_resources=ResourceConfig(ram=ram, disk="10g"),
+                format=TextLmDatasetFormat(text_key="text"),
+                levanter_batch_size=128,
             )
         )
     return steps

--- a/experiments/pretraining_datasets/starcoder2_extras.py
+++ b/experiments/pretraining_datasets/starcoder2_extras.py
@@ -1,0 +1,45 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""StarCoder2 data extras: download and tokenize ir_cpp, ir_python, ir_rust, ir_low_resource, documentation."""
+
+from experiments.defaults import default_tokenize
+from experiments.marin_models import marin_tokenizer
+from fray.v2 import ResourceConfig
+from levanter.data.text.formats import TextLmDatasetFormat
+from marin.datakit.download.starcoder2_extras import (
+    SUBSETS,
+    download_starcoder2_extras_step,
+    reshard_starcoder2_extras_step,
+)
+from marin.execution.executor import executor_main
+from marin.processing.tokenize.data_configs import TokenizerStep
+
+WORKER_RAM = {"ir_low_resource": "80g"}
+DEFAULT_WORKER_RAM = "40g"
+
+
+def tokenize_starcoder2_extras(*, tokenizer: str = marin_tokenizer) -> list[TokenizerStep]:
+    """Download and tokenize all selected starcoder2data-extras subsets."""
+    steps = []
+    RESHARD_SUBSETS = {"ir_low_resource"}
+    for subset in SUBSETS:
+        if subset in RESHARD_SUBSETS:
+            download = reshard_starcoder2_extras_step(subset)
+        else:
+            download = download_starcoder2_extras_step(subset)
+        ram = WORKER_RAM.get(subset, DEFAULT_WORKER_RAM)
+        steps.append(
+            default_tokenize(
+                name=f"starcoder2_extras/{subset}",
+                dataset=download.as_executor_step(),
+                tokenizer=tokenizer,
+                format=TextLmDatasetFormat(text_key="content"),
+                worker_resources=ResourceConfig(ram=ram, disk="10g"),
+            )
+        )
+    return steps
+
+
+if __name__ == "__main__":
+    executor_main(steps=tokenize_starcoder2_extras())

--- a/lib/marin/src/marin/datakit/download/starcoder2_extras.py
+++ b/lib/marin/src/marin/datakit/download/starcoder2_extras.py
@@ -1,0 +1,84 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Download subsets of the bigcode/starcoder2data-extras dataset from HuggingFace.
+
+Subsets: ir_cpp, ir_python, ir_rust, ir_low_resource, documentation, kaggle.
+"""
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "bigcode/starcoder2data-extras"
+HF_REVISION = "1ba0d4f"
+
+SUBSETS = ["ir_cpp", "ir_python", "ir_rust", "ir_low_resource", "documentation", "kaggle"]
+
+
+def download_starcoder2_extras_step(subset: str) -> StepSpec:
+    """Download a single subset of the starcoder2data-extras dataset."""
+    return download_hf_step(
+        f"raw/starcoder2_extras/{subset}",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=[f"{subset}/*.parquet"],
+        override_output_path=f"raw/starcoder2_extras-{HF_REVISION}/{subset}",
+    )
+
+
+def reshard_starcoder2_extras_step(subset: str, target_shard_mb: int = 200) -> StepSpec:
+    """Reshard a downloaded subset into more evenly-sized parquet files."""
+    raw = download_starcoder2_extras_step(subset)
+    raw_output_path = raw.output_path
+
+    def _run(output_path: str) -> None:
+        import logging
+
+        import pyarrow.parquet as pq
+        from rigging.filesystem import url_to_fs
+
+        logger = logging.getLogger(__name__)
+        input_path = raw_output_path
+        fs, _ = url_to_fs(input_path)
+        files = sorted(f"gs://{f}" for f in fs.glob(f"{input_path}/**/*.parquet") if not f.endswith("/.parquet"))
+
+        # Read all files, split into evenly-sized output shards
+        target_bytes = target_shard_mb * 1024 * 1024
+        shard_idx = 0
+        for file_path in files:
+            meta = pq.read_metadata(file_path)
+            if meta.serialized_size <= target_bytes:
+                # Small file — copy as-is
+                out = f"{output_path}/shard-{shard_idx:05d}.parquet"
+                table = pq.read_table(file_path)
+                pq.write_table(table, out)
+                logger.info(f"Copied {file_path} -> {out} ({table.num_rows} rows)")
+                shard_idx += 1
+            else:
+                # Big file — split by row groups or by row count
+                table = pq.read_table(file_path)
+                rows_per_shard = max(1, (table.num_rows * target_bytes) // meta.serialized_size)
+                offset = 0
+                while offset < table.num_rows:
+                    chunk = table.slice(offset, min(rows_per_shard, table.num_rows - offset))
+                    out = f"{output_path}/shard-{shard_idx:05d}.parquet"
+                    pq.write_table(chunk, out)
+                    logger.info(
+                        f"Split {file_path}[{offset}:{offset + chunk.num_rows}] -> {out} ({chunk.num_rows} rows)"
+                    )
+                    shard_idx += 1
+                    offset += chunk.num_rows
+                del table
+
+        logger.info(f"Resharded {len(files)} files into {shard_idx} shards")
+
+    return StepSpec(
+        name=f"resharded/starcoder2_extras/{subset}",
+        fn=_run,
+        deps=[raw],
+    )
+
+
+def download_all_starcoder2_extras_steps() -> list[StepSpec]:
+    """Download all selected subsets of starcoder2data-extras."""
+    return [download_starcoder2_extras_step(subset) for subset in SUBSETS]

--- a/lib/marin/src/marin/datakit/download/starcoder2_extras.py
+++ b/lib/marin/src/marin/datakit/download/starcoder2_extras.py
@@ -26,59 +26,6 @@ def download_starcoder2_extras_step(subset: str) -> StepSpec:
     )
 
 
-def reshard_starcoder2_extras_step(subset: str, target_shard_mb: int = 200) -> StepSpec:
-    """Reshard a downloaded subset into more evenly-sized parquet files."""
-    raw = download_starcoder2_extras_step(subset)
-    raw_output_path = raw.output_path
-
-    def _run(output_path: str) -> None:
-        import logging
-
-        import pyarrow.parquet as pq
-        from rigging.filesystem import url_to_fs
-
-        logger = logging.getLogger(__name__)
-        input_path = raw_output_path
-        fs, _ = url_to_fs(input_path)
-        files = sorted(f"gs://{f}" for f in fs.glob(f"{input_path}/**/*.parquet") if not f.endswith("/.parquet"))
-
-        # Read all files, split into evenly-sized output shards
-        target_bytes = target_shard_mb * 1024 * 1024
-        shard_idx = 0
-        for file_path in files:
-            meta = pq.read_metadata(file_path)
-            if meta.serialized_size <= target_bytes:
-                # Small file — copy as-is
-                out = f"{output_path}/shard-{shard_idx:05d}.parquet"
-                table = pq.read_table(file_path)
-                pq.write_table(table, out)
-                logger.info(f"Copied {file_path} -> {out} ({table.num_rows} rows)")
-                shard_idx += 1
-            else:
-                # Big file — split by row groups or by row count
-                table = pq.read_table(file_path)
-                rows_per_shard = max(1, (table.num_rows * target_bytes) // meta.serialized_size)
-                offset = 0
-                while offset < table.num_rows:
-                    chunk = table.slice(offset, min(rows_per_shard, table.num_rows - offset))
-                    out = f"{output_path}/shard-{shard_idx:05d}.parquet"
-                    pq.write_table(chunk, out)
-                    logger.info(
-                        f"Split {file_path}[{offset}:{offset + chunk.num_rows}] -> {out} ({chunk.num_rows} rows)"
-                    )
-                    shard_idx += 1
-                    offset += chunk.num_rows
-                del table
-
-        logger.info(f"Resharded {len(files)} files into {shard_idx} shards")
-
-    return StepSpec(
-        name=f"resharded/starcoder2_extras/{subset}",
-        fn=_run,
-        deps=[raw],
-    )
-
-
 def download_all_starcoder2_extras_steps() -> list[StepSpec]:
     """Download all selected subsets of starcoder2data-extras."""
     return [download_starcoder2_extras_step(subset) for subset in SUBSETS]

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -42,57 +42,68 @@ def generate_id(text: str) -> str:
 def _make_normalize_fn(
     text_field: str,
     id_field: str,
-) -> Callable[[dict[str, Any]], dict[str, Any]]:
-    """Return a record-level transform function.
+    max_record_size: int | None = None,
+) -> Callable[[dict[str, Any]], Iterator[dict[str, Any]]]:
+    """Return a record-level transform that yields one or more normalized records.
 
     The returned function:
     1. Extracts ``text`` from *text_field* (raises on missing/empty).
-    2. Generates a deterministic ``id`` via xxh3_128.
-    3. If *id_field* exists in the record, preserves it as ``source_id``.
-    4. Keeps all other columns.
+    2. If *max_record_size* is set and the text exceeds that size, splits
+       the text into chunks and yields one record per chunk.
+    3. Generates a deterministic ``id`` via xxh3_128.
+    4. If *id_field* exists in the record, preserves it as ``source_id``.
+    5. Keeps all other columns.
     """
 
-    def normalize_record(record: dict[str, Any]) -> dict[str, Any]:
-        # --- text ---
-        text = record.get(text_field)
-        if text is None or not str(text).strip():
-            raise ValueError(f"Record missing or empty text in field {text_field!r}: {record!r:.200}")
-        text = str(text)
-
-        # --- source_id (skip silently if id_field absent) ---
-        source_id = record.get(id_field)
-
-        # --- build output ---
+    def _build_record(text: str, record: dict[str, Any], source_id: Any) -> dict[str, Any]:
         out: dict[str, Any] = {}
-
-        # Copy all original columns except the ones we're replacing
         for k, v in record.items():
             if k == id_field:
                 continue
             if k == text_field and text_field != "text":
                 continue
             out[k] = v
-
         out["id"] = generate_id(text)
         out["text"] = text
         if source_id is not None:
             out["source_id"] = source_id
-
         return out
+
+    def normalize_record(record: dict[str, Any]) -> Iterator[dict[str, Any]]:
+        text = record.get(text_field)
+        if text is None or not str(text).strip():
+            raise ValueError(f"Record missing or empty text in field {text_field!r}: {record!r:.200}")
+        text = str(text)
+        source_id = record.get(id_field)
+
+        if max_record_size is None or len(text) <= max_record_size:
+            yield _build_record(text, record, source_id)
+        else:
+            for offset in range(0, len(text), max_record_size):
+                chunk = text[offset : offset + max_record_size]
+                if chunk.strip():
+                    yield _build_record(chunk, record, source_id)
 
     return normalize_record
 
 
 def _discover_file_groups(
     input_path: str,
+    file_extensions: tuple[str, ...] | None = None,
 ) -> dict[str, list[str]]:
     """Walk *input_path* and group data files by their subdirectory.
 
     Returns a mapping from relative subdirectory (``""`` for root) to a sorted
-    list of file paths.  Only files with extensions supported by
-    ``zephyr.readers.load_file`` are included; dotfiles and ``.metrics``
-    directories are skipped.
+    list of file paths.  Only files with matching extensions are included;
+    dotfiles and ``.metrics`` directories are skipped.
+
+    Args:
+        input_path: Root directory to walk.
+        file_extensions: Tuple of file extensions to include (e.g.
+            ``(".parquet",)``).  Defaults to all extensions supported by
+            ``zephyr.readers.load_file``.
     """
+    extensions = file_extensions or SUPPORTED_EXTENSIONS
     fs, resolved = url_to_fs(input_path)
     protocol = input_path.split("://")[0] if "://" in input_path else ""
 
@@ -113,7 +124,7 @@ def _discover_file_groups(
         for fname in sorted(files):
             if fname.startswith("."):
                 continue
-            if not fname.endswith(SUPPORTED_EXTENSIONS):
+            if not fname.endswith(extensions):
                 continue
             full = _full_path(os.path.join(root, fname))
             groups.setdefault(rel_root, []).append(full)
@@ -140,9 +151,10 @@ def _build_pipeline(
     num_shards: int,
     text_field: str,
     id_field: str | None,
+    max_record_size: int | None = None,
 ) -> Dataset:
     """Build a single Zephyr pipeline for one subdirectory."""
-    normalize_record = _make_normalize_fn(text_field, id_field)
+    normalize_record = _make_normalize_fn(text_field, id_field, max_record_size=max_record_size)
 
     def dedup_and_sort(_key: int, items: Iterator[dict[str, Any]]) -> Iterator[dict[str, Any]]:
         """Deduplicate by id. Items arrive sorted by id via sort_by."""
@@ -156,7 +168,7 @@ def _build_pipeline(
     return (
         Dataset.from_list(files)
         .flat_map(load_file)
-        .map(normalize_record)
+        .flat_map(normalize_record)
         .group_by(
             key=lambda r: int(r["id"], 16) % num_shards,
             reducer=dedup_and_sort,
@@ -178,6 +190,8 @@ def normalize_to_parquet(
     id_field: str = "id",
     target_partition_bytes: int = 256 * 1024 * 1024,
     worker_resources: ResourceConfig | None = None,
+    file_extensions: tuple[str, ...] | None = None,
+    max_record_size: int | None = None,
 ) -> None:
     """Normalize raw downloaded data to the datakit standard Parquet format.
 
@@ -200,10 +214,16 @@ def normalize_to_parquet(
             Defaults to 2 CPU / 16GB RAM / 10GB disk, sized for
             ``target_partition_bytes`` of 256MB.  Scale up when increasing
             partition size.
+        file_extensions: Tuple of file extensions to include (e.g.
+            ``(".parquet",)``).  Defaults to all extensions supported by
+            ``zephyr.readers.load_file``.
+        max_record_size: Maximum text size in bytes per record. Records
+            exceeding this size are split into chunks. ``None`` disables
+            splitting.
     """
     resources = worker_resources or ResourceConfig(cpu=2, ram="16g", disk="10g")
 
-    file_groups = _discover_file_groups(input_path)
+    file_groups = _discover_file_groups(input_path, file_extensions=file_extensions)
     if not file_groups:
         raise FileNotFoundError(f"No data files found under {input_path}")
 
@@ -223,7 +243,7 @@ def normalize_to_parquet(
             num_shards,
         )
 
-        pipeline = _build_pipeline(files, output_dir, num_shards, text_field, id_field)
+        pipeline = _build_pipeline(files, output_dir, num_shards, text_field, id_field, max_record_size=max_record_size)
         ctx = ZephyrContext(
             name=f"normalize-{subdir.replace('/', '-') if subdir else 'all'}",
             resources=resources,
@@ -249,6 +269,8 @@ def normalize_step(
     worker_resources: ResourceConfig | None = None,
     override_output_path: str | None = None,
     input_path: str | None = None,
+    file_extensions: tuple[str, ...] | None = None,
+    max_record_size: int | None = None,
 ) -> StepSpec:
     """Create a StepSpec that normalizes downloaded data to Parquet.
 
@@ -263,6 +285,12 @@ def normalize_step(
         override_output_path: Override the computed output path.
         input_path: Override the input path. Defaults to ``download.output_path``.
             Useful when normalizing a subdirectory of the download output.
+        file_extensions: Tuple of file extensions to include (e.g.
+            ``(".parquet",)``).  Defaults to all extensions supported by
+            ``zephyr.readers.load_file``.
+        max_record_size: Maximum text size in bytes per record. Records
+            exceeding this size are split into chunks. ``None`` disables
+            splitting.
     """
     resolved_input = input_path or download.output_path
 
@@ -275,6 +303,8 @@ def normalize_step(
             id_field=id_field,
             target_partition_bytes=target_partition_bytes,
             worker_resources=worker_resources,
+            file_extensions=file_extensions,
+            max_record_size=max_record_size,
         ),
         deps=[download],
         hash_attrs={
@@ -282,6 +312,8 @@ def normalize_step(
             "id_field": id_field,
             "target_partition_bytes": target_partition_bytes,
             "input_path": resolved_input,
+            "file_extensions": file_extensions,
+            "max_record_size": max_record_size,
         },
         override_output_path=override_output_path,
     )

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -42,47 +42,43 @@ def generate_id(text: str) -> str:
 def _make_normalize_fn(
     text_field: str,
     id_field: str,
-    max_record_size: int | None = None,
-) -> Callable[[dict[str, Any]], Iterator[dict[str, Any]]]:
-    """Return a record-level transform that yields one or more normalized records.
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Return a record-level transform function.
 
     The returned function:
     1. Extracts ``text`` from *text_field* (raises on missing/empty).
-    2. If *max_record_size* is set and the text exceeds that size, splits
-       the text into chunks and yields one record per chunk.
-    3. Generates a deterministic ``id`` via xxh3_128.
-    4. If *id_field* exists in the record, preserves it as ``source_id``.
-    5. Keeps all other columns.
+    2. Generates a deterministic ``id`` via xxh3_128.
+    3. If *id_field* exists in the record, preserves it as ``source_id``.
+    4. Keeps all other columns.
     """
 
-    def _build_record(text: str, record: dict[str, Any], source_id: Any) -> dict[str, Any]:
+    def normalize_record(record: dict[str, Any]) -> dict[str, Any]:
+        # --- text ---
+        text = record.get(text_field)
+        if text is None or not str(text).strip():
+            raise ValueError(f"Record missing or empty text in field {text_field!r}: {record!r:.200}")
+        text = str(text)
+
+        # --- source_id (skip silently if id_field absent) ---
+        source_id = record.get(id_field)
+
+        # --- build output ---
         out: dict[str, Any] = {}
+
+        # Copy all original columns except the ones we're replacing
         for k, v in record.items():
             if k == id_field:
                 continue
             if k == text_field and text_field != "text":
                 continue
             out[k] = v
+
         out["id"] = generate_id(text)
         out["text"] = text
         if source_id is not None:
             out["source_id"] = source_id
+
         return out
-
-    def normalize_record(record: dict[str, Any]) -> Iterator[dict[str, Any]]:
-        text = record.get(text_field)
-        if text is None or not str(text).strip():
-            raise ValueError(f"Record missing or empty text in field {text_field!r}: {record!r:.200}")
-        text = str(text)
-        source_id = record.get(id_field)
-
-        if max_record_size is None or len(text) <= max_record_size:
-            yield _build_record(text, record, source_id)
-        else:
-            for offset in range(0, len(text), max_record_size):
-                chunk = text[offset : offset + max_record_size]
-                if chunk.strip():
-                    yield _build_record(chunk, record, source_id)
 
     return normalize_record
 
@@ -151,10 +147,9 @@ def _build_pipeline(
     num_shards: int,
     text_field: str,
     id_field: str | None,
-    max_record_size: int | None = None,
 ) -> Dataset:
     """Build a single Zephyr pipeline for one subdirectory."""
-    normalize_record = _make_normalize_fn(text_field, id_field, max_record_size=max_record_size)
+    normalize_record = _make_normalize_fn(text_field, id_field)
 
     def dedup_and_sort(_key: int, items: Iterator[dict[str, Any]]) -> Iterator[dict[str, Any]]:
         """Deduplicate by id. Items arrive sorted by id via sort_by."""
@@ -168,7 +163,7 @@ def _build_pipeline(
     return (
         Dataset.from_list(files)
         .flat_map(load_file)
-        .flat_map(normalize_record)
+        .map(normalize_record)
         .group_by(
             key=lambda r: int(r["id"], 16) % num_shards,
             reducer=dedup_and_sort,
@@ -191,7 +186,6 @@ def normalize_to_parquet(
     target_partition_bytes: int = 256 * 1024 * 1024,
     worker_resources: ResourceConfig | None = None,
     file_extensions: tuple[str, ...] | None = None,
-    max_record_size: int | None = None,
 ) -> None:
     """Normalize raw downloaded data to the datakit standard Parquet format.
 
@@ -217,9 +211,6 @@ def normalize_to_parquet(
         file_extensions: Tuple of file extensions to include (e.g.
             ``(".parquet",)``).  Defaults to all extensions supported by
             ``zephyr.readers.load_file``.
-        max_record_size: Maximum text size in bytes per record. Records
-            exceeding this size are split into chunks. ``None`` disables
-            splitting.
     """
     resources = worker_resources or ResourceConfig(cpu=2, ram="16g", disk="10g")
 
@@ -243,7 +234,7 @@ def normalize_to_parquet(
             num_shards,
         )
 
-        pipeline = _build_pipeline(files, output_dir, num_shards, text_field, id_field, max_record_size=max_record_size)
+        pipeline = _build_pipeline(files, output_dir, num_shards, text_field, id_field)
         ctx = ZephyrContext(
             name=f"normalize-{subdir.replace('/', '-') if subdir else 'all'}",
             resources=resources,
@@ -270,7 +261,6 @@ def normalize_step(
     override_output_path: str | None = None,
     input_path: str | None = None,
     file_extensions: tuple[str, ...] | None = None,
-    max_record_size: int | None = None,
 ) -> StepSpec:
     """Create a StepSpec that normalizes downloaded data to Parquet.
 
@@ -288,9 +278,6 @@ def normalize_step(
         file_extensions: Tuple of file extensions to include (e.g.
             ``(".parquet",)``).  Defaults to all extensions supported by
             ``zephyr.readers.load_file``.
-        max_record_size: Maximum text size in bytes per record. Records
-            exceeding this size are split into chunks. ``None`` disables
-            splitting.
     """
     resolved_input = input_path or download.output_path
 
@@ -304,7 +291,6 @@ def normalize_step(
             target_partition_bytes=target_partition_bytes,
             worker_resources=worker_resources,
             file_extensions=file_extensions,
-            max_record_size=max_record_size,
         ),
         deps=[download],
         hash_attrs={
@@ -313,7 +299,6 @@ def normalize_step(
             "target_partition_bytes": target_partition_bytes,
             "input_path": resolved_input,
             "file_extensions": file_extensions,
-            "max_record_size": max_record_size,
         },
         override_output_path=override_output_path,
     )

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -76,6 +76,10 @@ class TokenizeConfigBase(abc.ABC):
     this many shards instead of deriving the count from max_workers. This can be useful if you want
     more shards than max_workers, for example to mitigate the cost of retrying a single shard."""
 
+    levanter_batch_size: int | None = None
+    """Number of tokenized records to accumulate before flushing to disk. Defaults to 16384.
+    Lower values reduce peak memory for datasets with large documents."""
+
     @abc.abstractmethod
     def as_lm_dataset_source_config(
         self, actual_output_path: str | InputName | None, *, include_raw_paths=True
@@ -398,6 +402,7 @@ def tokenize(config: TokenizeConfigBase):
                 f"{prefix}/part-{{shard:05d}}-of-{{total:05d}}",
                 metadata={},
                 skip_existing=True,
+                batch_size=config.levanter_batch_size,
             )
         )
 

--- a/lib/zephyr/src/zephyr/dataset.py
+++ b/lib/zephyr/src/zephyr/dataset.py
@@ -161,6 +161,7 @@ class WriteOp:
 
     # Format-specific parameters (only used by relevant writer)
     levanter_metadata: dict[str, Any] | None = None
+    levanter_batch_size: int | None = None
     schema: object | None = None  # For parquet (pyarrow.Schema)
     skip_existing: bool = False  # Skip writing if output file already exists
 
@@ -727,6 +728,7 @@ class Dataset(Generic[T]):
         output_pattern: str | Callable[[int, int], str],
         metadata: dict[str, Any],
         skip_existing: bool = False,
+        batch_size: int | None = None,
     ) -> Dataset[str]:
         """Write tokenized records to Levanter cache format.
 
@@ -734,6 +736,10 @@ class Dataset(Generic[T]):
         in training. Each shard creates a separate cache directory.
         The output pattern supports substitutions: {shard:05d}, {total:05d}, {basename}
         or can be a callable that takes (shard_idx, total_shards) and returns the output path.
+
+        Args:
+            batch_size: Number of records to accumulate before flushing to disk.
+                Defaults to 16384. Lower values reduce peak memory for large documents.
         """
         return Dataset(
             self.source,
@@ -743,6 +749,7 @@ class Dataset(Generic[T]):
                     _normalize_output_pattern(output_pattern),
                     writer_type="levanter_cache",
                     levanter_metadata=metadata,
+                    levanter_batch_size=batch_size,
                     skip_existing=skip_existing,
                 ),
             ],

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -106,6 +106,7 @@ class Write:
     skip_existing: bool = False
     # Writer-specific parameters
     levanter_metadata: dict | None = None
+    levanter_batch_size: int | None = None
     schema: Any = None  # For parquet
 
 
@@ -421,6 +422,7 @@ def _fuse_operations(operations: list) -> list[PhysicalStage]:
                     writer_type=op.writer_type,
                     skip_existing=op.skip_existing,
                     levanter_metadata=op.levanter_metadata,
+                    levanter_batch_size=op.levanter_batch_size,
                     schema=op.schema,
                 )
             )
@@ -782,7 +784,10 @@ def run_stage(
                 result = write_parquet_file(stream, output_path, schema=op.schema)["path"]
             elif op.writer_type == "levanter_cache":
                 metadata = op.levanter_metadata if op.levanter_metadata is not None else {}
-                result = write_levanter_cache(stream, output_path, metadata=metadata)["path"]
+                kwargs: dict[str, Any] = {"metadata": metadata}
+                if op.levanter_batch_size is not None:
+                    kwargs["batch_size"] = op.levanter_batch_size
+                result = write_levanter_cache(stream, output_path, **kwargs)["path"]
             elif op.writer_type == "binary":
                 result = write_binary_file(stream, output_path)["path"]
             elif op.writer_type == "vortex":

--- a/lib/zephyr/src/zephyr/writers.py
+++ b/lib/zephyr/src/zephyr/writers.py
@@ -381,7 +381,11 @@ def write_levanter_cache(
         records: Tokenized records (iterable of dicts with array values)
         output_path: Path to output cache directory
         metadata: Metadata for the cache
+        batch_size: Number of records to accumulate before flushing to disk.
     """
+    if batch_size < 1:
+        raise ValueError(f"batch_size must be >= 1, got {batch_size}")
+
     from levanter.store.cache import CacheMetadata, SerialCacheWriter
 
     ensure_parent_dir(output_path)

--- a/lib/zephyr/src/zephyr/writers.py
+++ b/lib/zephyr/src/zephyr/writers.py
@@ -373,6 +373,7 @@ def write_levanter_cache(
     output_path: str,
     *,
     metadata: dict[str, Any],
+    batch_size: int = _LEVANTER_BATCH_SIZE,
 ) -> dict:
     """Write tokenized records to Levanter cache format.
 
@@ -392,7 +393,7 @@ def write_levanter_cache(
         return {"path": output_path, "count": 0}
 
     count = 0
-    logger.info("write_levanter_cache: starting write to %s (batch_size=%d)", output_path, _LEVANTER_BATCH_SIZE)
+    logger.info("write_levanter_cache: starting write to %s (batch_size=%d)", output_path, batch_size)
 
     with atomic_rename(output_path) as tmp_path:
         with SerialCacheWriter(tmp_path, exemplar, shard_name=output_path, metadata=CacheMetadata(metadata)) as writer:
@@ -405,7 +406,7 @@ def write_levanter_cache(
                 threaded.submit([exemplar])
                 count += 1
                 counters.increment("zephyr/records_out")
-                for batch in batchify(record_iter, n=_LEVANTER_BATCH_SIZE):
+                for batch in batchify(record_iter, n=batch_size):
                     threaded.submit(batch)
                     count += len(batch)
                     counters.increment("zephyr/records_out", len(batch))


### PR DESCRIPTION
## Summary

- Add download, normalize, and tokenize pipeline for all 6 starcoder2data-extras subsets (ir_cpp, ir_python, ir_rust, ir_low_resource, documentation, kaggle)
- Add `file_extensions` filter to normalize's file discovery to skip non-data files (e.g. `provenance.json`)
- Expose `levanter_batch_size` through the full write pipeline (writers → plan → Dataset → TokenizeConfig → default_tokenize) to control memory for large-document datasets
- Expose `resources` and `worker_resources` on `default_tokenize` for per-subset memory tuning
- Remove `reshard_starcoder2_extras_step` (superseded by normalize)
- Documentation subset gets 32GB worker memory — contains a single 64MB OpenJDK record that peaks at ~9GB RSS during tokenization

## Test plan

- [x] All 6 subsets normalize and tokenize successfully on Iris in europe-west4
- [x] Benchmarked tokenization of 64MB doc: whole (8.8GB peak), paragraph-split (1.1GB peak)
- [x] Verified `levanter_batch_size=128` prevents OOM on large-document shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)