### PR TITLE
ci: pass ferry output prefix via status file to validation step

### DIFF
--- a/.github/workflows/marin-datakit-smoke.yaml
+++ b/.github/workflows/marin-datakit-smoke.yaml
@@ -19,7 +19,7 @@ jobs:
       cancel-in-progress: true
     env:
       SMOKE_RUN_ID: datakit-smoke-${{ github.run_id }}-${{ github.run_attempt }}
-      # MARIN_PREFIX is defaulted by the ferry entrypoint to marin_temp_bucket(ttl_days=1).
+      FERRY_STATUS_PATH: gs://marin-tmp-us-central1/ttl=1d/ci/datakit-smoke-${{ github.run_id }}-${{ github.run_attempt }}/ferry_run_status.json
       WANDB_ENTITY: marin-community
       WANDB_PROJECT: marin
       IRIS_CONFIG: lib/iris/examples/marin-dev.yaml
@@ -70,6 +70,7 @@ jobs:
             job run --no-wait \
             --memory=2G --disk=4G --cpu=1 --extra=cpu \
             -e SMOKE_RUN_ID "$SMOKE_RUN_ID" \
+            -e FERRY_STATUS_PATH "$FERRY_STATUS_PATH" \
             -e WANDB_ENTITY "$WANDB_ENTITY" \
             -e WANDB_PROJECT "$WANDB_PROJECT" \
             -e WANDB_API_KEY "$WANDB_API_KEY" \
@@ -113,12 +114,24 @@ jobs:
             esac
           done
 
+      - name: Read ferry status
+        id: ferry_status
+        shell: bash -l {0}
+        run: |
+          PREFIX=$(.venv/bin/python -c "
+          import json
+          from rigging.filesystem import url_to_fs
+          fs, _ = url_to_fs('$FERRY_STATUS_PATH')
+          with fs.open('$FERRY_STATUS_PATH') as f:
+              print(json.load(f)['marin_prefix'])
+          ")
+          echo "marin_prefix=$PREFIX" >> "$GITHUB_OUTPUT"
+          echo "Ferry output prefix: $PREFIX"
+
       - name: Validate datakit smoke outputs
         shell: bash -l {0}
         env:
-          SMOKE_RUN_ID: ${{ env.SMOKE_RUN_ID }}
-          # MARIN_PREFIX intentionally unset — validate script defaults via marin_temp_bucket,
-          # matching the ferry entrypoint default.
+          MARIN_PREFIX: ${{ steps.ferry_status.outputs.marin_prefix }}
         run: .venv/bin/python scripts/datakit/validate_ferry_outputs.py
 
       - name: Capture failure diagnostics

--- a/experiments/ferries/datakit_ferry.py
+++ b/experiments/ferries/datakit_ferry.py
@@ -7,10 +7,11 @@ Runs against the FineWeb-Edu ``sample/10BT`` subset using the StepSpec DAG runne
 Output paths are placed under ``$MARIN_PREFIX/datakit-smoke/$SMOKE_RUN_ID/...``.
 """
 
+import json
 import logging
 import os
 
-from rigging.filesystem import marin_temp_bucket
+from rigging.filesystem import marin_temp_bucket, url_to_fs
 from rigging.log_setup import configure_logging
 
 from fray import ResourceConfig
@@ -109,14 +110,30 @@ def build_steps(run_id: str) -> list[StepSpec]:
     return [downloaded, normalized, deduped, consolidated, tokenized]
 
 
+def _write_status(status: str, marin_prefix: str) -> None:
+    """Write ferry run status to FERRY_STATUS_PATH if set."""
+    status_path = os.environ.get("FERRY_STATUS_PATH")
+    if not status_path:
+        return
+    payload = json.dumps({"status": status, "marin_prefix": marin_prefix})
+    fs, _ = url_to_fs(status_path)
+    with fs.open(status_path, "w") as f:
+        f.write(payload)
+    logger.info("Wrote ferry status to %s", status_path)
+
+
 def main() -> None:
     configure_logging()
     if not os.environ.get("MARIN_PREFIX"):
         os.environ["MARIN_PREFIX"] = marin_temp_bucket(ttl_days=1)
 
-    logger.info("MARIN_PREFIX defaulted to %s", os.environ["MARIN_PREFIX"])
+    marin_prefix = os.environ["MARIN_PREFIX"]
+    logger.info("MARIN_PREFIX defaulted to %s", marin_prefix)
     run_id = os.environ["SMOKE_RUN_ID"]
+
+    _write_status("running", marin_prefix)
     StepRunner().run(build_steps(run_id))
+    _write_status("succeeded", marin_prefix)
 
 
 if __name__ == "__main__":

--- a/scripts/datakit/validate_ferry_outputs.py
+++ b/scripts/datakit/validate_ferry_outputs.py
@@ -3,10 +3,9 @@
 
 """Validate datakit smoke ferry outputs.
 
-Run after the iris job for the datakit smoke ferry has completed. Resolves
-the output prefix via ``MARIN_PREFIX`` (falling back to
-``marin_temp_bucket(ttl_days=1, prefix="datakit-smoke")`` — same default as
-the ferry entrypoint).
+Run after the iris job for the datakit smoke ferry has completed.
+``MARIN_PREFIX`` must be set to the GCS prefix the ferry wrote to
+(read from ``ferry_run_status.json`` by the workflow).
 
 Checks the full pipeline chain:
   download (14 files, ~9.7M rows)
@@ -23,7 +22,7 @@ import sys
 import pyarrow.parquet as pq
 from levanter.store.cache import CacheLedger
 from marin.utils import fsspec_glob
-from rigging.filesystem import marin_temp_bucket, url_to_fs
+from rigging.filesystem import url_to_fs
 from rigging.log_setup import configure_logging
 
 logger = logging.getLogger(__name__)
@@ -198,9 +197,11 @@ def _validate_tokens(base: str, consolidate_rows: int) -> int:
 
 def main() -> None:
     configure_logging()
-    prefix = os.environ.get("MARIN_PREFIX") or marin_temp_bucket(ttl_days=1)
-    prefix = prefix.rstrip("/")
+    prefix = os.environ.get("MARIN_PREFIX")
+    if not prefix:
+        raise SystemExit("MARIN_PREFIX must be set to the GCS prefix the ferry wrote to")
     run_id = os.environ["SMOKE_RUN_ID"]
+    prefix = prefix.rstrip("/")
     base = f"{prefix}/datakit-smoke/{run_id}"
 
     download_rows = _validate_download(base)


### PR DESCRIPTION
* `validate_ferry_outputs.py` failed — `marin_temp_bucket()` falls back to `file:///tmp/marin/tmp/` on the GHA runner (no GCP metadata), while the Iris worker resolves to `gs://marin-tmp-{region}/ttl=1d`
* fix: ferry writes `ferry_run_status.json` (with resolved `marin_prefix`) to a `FERRY_STATUS_PATH` provided by the workflow, then the GHA "Read ferry status" step reads it back and passes `MARIN_PREFIX` to the validation step
* add `_write_status()` in `datakit_ferry.py` — writes `{"status": ..., "marin_prefix": ...}` to `FERRY_STATUS_PATH` at start and end of the run
* `validate_ferry_outputs.py` now requires `MARIN_PREFIX` to be set explicitly, removed `marin_temp_bucket` fallback
* no hardcoded data regions — the ferry auto-detects its region on the worker and communicates it back via the status file

### test plan
- [x] ran `validate_ferry_outputs.py` with correct `MARIN_PREFIX` against today's ferry output — all checks pass
- [ ] re-run the `Marin - Datakit Smoke` workflow to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)