### PR TITLE
[RL] Add telemetry event shards and provenance substrate

### DIFF
--- a/lib/marin/src/marin/rl/job_config.py
+++ b/lib/marin/src/marin/rl/job_config.py
@@ -155,6 +155,15 @@ class RLJobConfig:
     rollout_tracker: RolloutTrackerConfig | None = None
     """Tracker configuration for rollout workers. Uses a standalone tracker to avoid JAX deadlocks."""
 
+    eval_tracker: RolloutTrackerConfig | None = None
+    """Dedicated tracker configuration for eval and micro-eval streams."""
+
+    eval_owner_worker_index: int = 0
+    """Worker index that owns the eval tracker stream."""
+
+    metadata_path: str | None = None
+    """Base path for durable RL telemetry artifacts and event shards."""
+
     pip_dependency_groups: list[str] = field(default_factory=list)
     """Extra pip dependency groups to include for all workers."""
 
@@ -268,8 +277,11 @@ def build_worker_configs(config: RLJobConfig) -> tuple[TrainWorkerConfig, Rollou
         initial_checkpoint=config.initial_checkpoint,
         vocab_size=config.vocab_size,
         run_id=config.run_id,
+        root_run_id=config.run_id,
         curriculum_config=config.curriculum,
         seed=config.seed,
+        metadata_path=config.metadata_path,
+        instance_id=config.resolved_instance_id,
     )
 
     # Create rollout worker config
@@ -285,12 +297,17 @@ def build_worker_configs(config: RLJobConfig) -> tuple[TrainWorkerConfig, Rollou
         weight_transfer=weight_transfer_config,
         rollout_storage=config.rollout_storage,
         run_id=config.run_id,
+        root_run_id=config.run_id,
         seed=config.seed + 1000,
         inference_type=config.inference_type,
         inference_config=inference_config,
         system_prompt=config.system_prompt,
         inflight_weight_updates=config.inflight_weight_updates,
         tracker_config=config.rollout_tracker,
+        eval_tracker_config=config.eval_tracker,
+        eval_owner_worker_index=config.eval_owner_worker_index,
+        metadata_path=config.metadata_path,
+        instance_id=config.resolved_instance_id,
     )
 
     return train_worker_config, rollout_worker_config

--- a/lib/marin/src/marin/rl/rl_experiment_utils.py
+++ b/lib/marin/src/marin/rl/rl_experiment_utils.py
@@ -254,6 +254,7 @@ def _build_rl_job_config(
     tags = [*config.tags, config.model_config.name.split("/")[-1]]
     checkpoints_path = join_path(output_path, "checkpoints")
     rollout_storage_path = join_path(output_path, "rollouts")
+    metadata_path = join_path(output_path, "metadata")
 
     trainer_config = TrainerConfig(
         tracker=WandbConfig(
@@ -347,6 +348,12 @@ def _build_rl_job_config(
             name=f"{name}-rollout",
             tags=[*config.tags, "rollout", config.model_config.name.split("/")[-1]],
         ),
+        eval_tracker=RolloutTrackerConfig(
+            project=config.project_name,
+            name=f"{name}-eval",
+            tags=[*config.tags, "eval", config.model_config.name.split("/")[-1]],
+        ),
+        metadata_path=metadata_path,
         pip_dependency_groups=(
             config.model_config.pip_dependency_groups if config.model_config.pip_dependency_groups else ["vllm", "math"]
         ),

--- a/lib/marin/src/marin/rl/rollout_worker.py
+++ b/lib/marin/src/marin/rl/rollout_worker.py
@@ -54,6 +54,7 @@ from marin.rl.metrics import pass_at_k_estimator
 from marin.rl.model_utils import load_model_from_checkpoint
 from marin.rl.run_state import RolloutTransferCounters
 from marin.rl.runtime import RLRuntimeHandles
+from marin.rl.telemetry import EventShardWriter, StepProvenance, TelemetryEvent, TrackerRunRef, TrackerStream
 
 from .rollout_storage import RolloutStorageConfig, RolloutWriter
 from .types import (
@@ -147,6 +148,35 @@ class _NoOpTracker:
     def log(self, metrics, step=None):
         pass
 
+    def log_summary(self, metrics):
+        pass
+
+    def log_artifact(self, artifact_path, *, name=None, artifact_type=None):
+        pass
+
+    @property
+    def run_id(self) -> str | None:
+        return None
+
+    @property
+    def run_name(self) -> str | None:
+        return None
+
+    @property
+    def run_url(self) -> str | None:
+        return None
+
+    @property
+    def entity(self) -> str | None:
+        return None
+
+    @property
+    def project(self) -> str | None:
+        return None
+
+    def as_tracker_ref(self, *, stream: TrackerStream, worker_index: int | None = None) -> TrackerRunRef | None:
+        return None
+
     def finish(self):
         pass
 
@@ -183,6 +213,7 @@ class RolloutTracker:
     """
 
     def __init__(self, config: RolloutTrackerConfig, run_id: str):
+        self._config = config
         run_name = config.name or run_id
         self._run = wandb.init(
             entity=config.entity,
@@ -199,6 +230,46 @@ class RolloutTracker:
             self._run.log(metrics)
             return
         self._run.log(metrics, step=step)
+
+    def log_summary(self, metrics: Mapping[str, Any]) -> None:
+        self._run.summary.update(metrics)
+
+    def log_artifact(self, artifact_path, *, name: str | None = None, artifact_type: str | None = None):
+        self._run.log_artifact(artifact_path, name=name, type=artifact_type)
+
+    @property
+    def run_id(self) -> str | None:
+        return getattr(self._run, "id", None)
+
+    @property
+    def run_name(self) -> str | None:
+        return getattr(self._run, "name", None)
+
+    @property
+    def run_url(self) -> str | None:
+        return getattr(self._run, "url", None)
+
+    @property
+    def entity(self) -> str | None:
+        return getattr(self._run, "entity", None) or self._config.entity
+
+    @property
+    def project(self) -> str | None:
+        return getattr(self._run, "project", None) or self._config.project
+
+    def as_tracker_ref(self, *, stream: TrackerStream, worker_index: int | None = None) -> TrackerRunRef:
+        tracker_run_id = self.run_id
+        if tracker_run_id is None:
+            raise RuntimeError("Tracker run ID is unavailable")
+        return TrackerRunRef(
+            stream=stream,
+            tracker_run_id=tracker_run_id,
+            project=self.project,
+            entity=self.entity,
+            run_name=self.run_name,
+            run_url=self.run_url,
+            worker_index=worker_index,
+        )
 
     def finish(self):
         self._run.finish()
@@ -221,8 +292,14 @@ class RolloutWorkerConfig:
     inference_config: LevanterInferenceContextConfig | vLLMInferenceContextConfig
     """Configuration for inference context."""
 
+    root_run_id: str | None = None
+    """Stable RL job run id used for shared telemetry and artifact paths."""
+
     tracker_config: RolloutTrackerConfig | None = None
     """Configuration for the rollout worker's tracker. If None, tracking is disabled."""
+
+    eval_tracker_config: RolloutTrackerConfig | None = None
+    """Configuration for the dedicated eval tracker."""
 
     seed: int = 0
     """Random seed to use for sampling."""
@@ -246,6 +323,15 @@ class RolloutWorkerConfig:
 
     worker_index: int = 0
     """Index of this worker among all rollout workers."""
+
+    eval_owner_worker_index: int = 0
+    """Worker index responsible for owning the eval tracker stream."""
+
+    metadata_path: str | None = None
+    """Base metadata path for local RL telemetry artifacts."""
+
+    instance_id: str | None = None
+    """Coordinator invocation identifier used for per-attempt artifact naming."""
 
 
 def find_open_port() -> int:
@@ -413,6 +499,8 @@ class RolloutWorker:
     _tokenizer: MarinTokenizer
     _environments: dict[str, MarinEnv]
     tracker: Any  # levanter.Tracker or RolloutTracker
+    _event_writer: EventShardWriter | None
+    _eval_event_writer: EventShardWriter | None
 
     def __init__(self, config: RolloutWorkerConfig, runtime: RLRuntimeHandles):
         config.trainer.id = f"{config.run_id}-rollout"
@@ -445,12 +533,15 @@ class RolloutWorker:
         self._current_train_step: int = -1
         self._last_transfer_counters = RolloutTransferCounterSnapshot()
         self._last_eval_train_step: int | None = None
+        self._event_writer = None
+        self._eval_event_writer = None
 
         self._tokenizer = config.tokenizer
 
         # Event to signal that the first weight transfer has completed.
         # For inflight weight updates, we block inference until initial weights are received.
         self._first_weights_received = threading.Event()
+        self._initialize_telemetry()
 
         logger.info("Starting rollout policy context with weight transfer config %s", self.config.weight_transfer)
 
@@ -486,6 +577,70 @@ class RolloutWorker:
                 daemon=True,
             )
             self.weight_transfer_thread.start()
+
+    def _initialize_telemetry(self) -> None:
+        metadata_path = self.config.metadata_path
+        instance_id = self.config.instance_id
+        if metadata_path is None or instance_id is None:
+            return
+
+        telemetry_run_id = self.config.root_run_id or self.config.run_id
+
+        self._event_writer = EventShardWriter(
+            metadata_path=metadata_path,
+            run_id=telemetry_run_id,
+            stream=TrackerStream.ROLLOUT,
+            instance_id=instance_id,
+            worker_index=self.config.worker_index,
+        )
+        self._event_writer.append(
+            TelemetryEvent(
+                run_id=telemetry_run_id,
+                stream=TrackerStream.ROLLOUT,
+                event_type="worker_started",
+                provenance=StepProvenance(
+                    instance_id=instance_id,
+                    worker_index=self.config.worker_index,
+                ),
+                payload={"worker_role": "rollout"},
+            )
+        )
+        self._register_artifact_ref(self._event_writer.artifact_ref())
+
+        tracker_ref_fn = getattr(self.tracker, "as_tracker_ref", None)
+        register_tracker = getattr(self._runtime.run_state, "register_tracker_ref", None)
+        if tracker_ref_fn is not None and register_tracker is not None:
+            tracker_ref = tracker_ref_fn(stream=TrackerStream.ROLLOUT, worker_index=self.config.worker_index)
+            if tracker_ref is not None:
+                register_tracker.remote(tracker_ref).result()
+
+        if self.config.worker_index != self.config.eval_owner_worker_index:
+            return
+
+        self._eval_event_writer = EventShardWriter(
+            metadata_path=metadata_path,
+            run_id=telemetry_run_id,
+            stream=TrackerStream.EVAL,
+            instance_id=instance_id,
+        )
+        self._eval_event_writer.append(
+            TelemetryEvent(
+                run_id=telemetry_run_id,
+                stream=TrackerStream.EVAL,
+                event_type="stream_initialized",
+                provenance=StepProvenance(
+                    instance_id=instance_id,
+                    worker_index=self.config.worker_index,
+                ),
+                payload={"worker_role": "eval_owner"},
+            )
+        )
+        self._register_artifact_ref(self._eval_event_writer.artifact_ref())
+
+    def _register_artifact_ref(self, artifact_ref) -> None:
+        register_artifact = getattr(self._runtime.run_state, "register_artifact_ref", None)
+        if register_artifact is not None:
+            register_artifact.remote(artifact_ref).result()
 
     def _load_environment(self, lesson_id: str) -> MarinEnv:
         """Load environment from lesson ID."""

--- a/lib/marin/src/marin/rl/run_state.py
+++ b/lib/marin/src/marin/rl/run_state.py
@@ -14,6 +14,8 @@ import logging
 from dataclasses import dataclass
 from enum import StrEnum
 
+from marin.rl.telemetry import ArtifactRef, TrackerRunRef, TrackerStream
+
 logger = logging.getLogger(__name__)
 
 
@@ -51,7 +53,10 @@ class RLRunState:
         self._status: RunStatus = RunStatus.RUNNING
         self._failure_message: str | None = None
         self._train_step: int = -1
+        self._next_eval_sequence: int = 0
         self._rollout_transfer_counters: dict[int, RolloutTransferCounters] = {}
+        self._tracker_refs: dict[tuple[str, int | None], TrackerRunRef] = {}
+        self._artifact_refs: dict[str, ArtifactRef] = {}
 
     def get_status(self) -> str:
         return self._status.value
@@ -72,6 +77,11 @@ class RLRunState:
 
     def get_train_step(self) -> int:
         return self._train_step
+
+    def next_eval_sequence(self) -> int:
+        sequence = self._next_eval_sequence
+        self._next_eval_sequence += 1
+        return sequence
 
     def get_rollout_transfer_counters(self, worker_index: int) -> RolloutTransferCounters:
         return self._rollout_transfer_counters.get(worker_index, RolloutTransferCounters())
@@ -95,6 +105,27 @@ class RLRunState:
         )
         self._rollout_transfer_counters[worker_index] = updated
         return updated
+
+    def register_tracker_ref(self, tracker_ref: TrackerRunRef) -> TrackerRunRef:
+        key = (tracker_ref.stream.value, tracker_ref.worker_index)
+        self._tracker_refs[key] = tracker_ref
+        return tracker_ref
+
+    def get_tracker_ref(self, stream: TrackerStream, worker_index: int | None = None) -> TrackerRunRef | None:
+        return self._tracker_refs.get((stream.value, worker_index))
+
+    def list_tracker_refs(self) -> list[TrackerRunRef]:
+        return list(self._tracker_refs.values())
+
+    def register_artifact_ref(self, artifact_ref: ArtifactRef) -> ArtifactRef:
+        self._artifact_refs[artifact_ref.name] = artifact_ref
+        return artifact_ref
+
+    def get_artifact_ref(self, name: str) -> ArtifactRef | None:
+        return self._artifact_refs.get(name)
+
+    def list_artifact_refs(self) -> list[ArtifactRef]:
+        return list(self._artifact_refs.values())
 
     def mark_completed(self) -> None:
         if self._status == RunStatus.RUNNING:

--- a/lib/marin/src/marin/rl/telemetry.py
+++ b/lib/marin/src/marin/rl/telemetry.py
@@ -20,9 +20,8 @@ from enum import StrEnum
 from typing import Any
 
 from levanter.utils.fsspec_utils import join_path
-from rigging.filesystem import url_to_fs
-
 from marin.utilities.json_encoder import CustomJsonEncoder
+from rigging.filesystem import url_to_fs
 
 TELEMETRY_EVENT_SCHEMA_VERSION = "telemetry_event.v1"
 TRACKER_RUN_REF_SCHEMA_VERSION = "rl_tracker_run_ref.v1"

--- a/lib/marin/src/marin/rl/telemetry.py
+++ b/lib/marin/src/marin/rl/telemetry.py
@@ -1,0 +1,235 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Telemetry primitives for RL observability.
+
+This module defines the durable event and reference schemas used by the RL
+observability roadmap. The first implementation wave keeps the API small:
+event records, step provenance, tracker/artifact references, and per-writer
+event shards.
+"""
+
+import dataclasses
+import datetime
+import json
+import os
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from levanter.utils.fsspec_utils import join_path
+from rigging.filesystem import url_to_fs
+
+from marin.utilities.json_encoder import CustomJsonEncoder
+
+TELEMETRY_EVENT_SCHEMA_VERSION = "telemetry_event.v1"
+TRACKER_RUN_REF_SCHEMA_VERSION = "rl_tracker_run_ref.v1"
+ARTIFACT_REF_SCHEMA_VERSION = "rl_artifact_ref.v1"
+
+
+class TrackerStream(StrEnum):
+    """Named RL telemetry streams."""
+
+    TRAINER = "trainer"
+    ROLLOUT = "rollout"
+    EVAL = "eval"
+
+
+def _utc_now_iso() -> str:
+    return datetime.datetime.now(datetime.UTC).isoformat()
+
+
+def _fresh_event_id() -> str:
+    return uuid.uuid4().hex
+
+
+@dataclass(frozen=True)
+class StepProvenance:
+    """Provenance for one telemetry record."""
+
+    train_step: int | None = None
+    rollout_step: int | None = None
+    weight_step: int | None = None
+    eval_sequence: int | None = None
+    worker_index: int | None = None
+    instance_id: str | None = None
+
+    def as_dict(self, *, prefix: str | None = None) -> dict[str, int | str]:
+        items: dict[str, int | str] = {}
+        for field_name, value in dataclasses.asdict(self).items():
+            if value is None:
+                continue
+            key = field_name if prefix is None else f"{prefix}.{field_name}"
+            items[key] = value
+        return items
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "StepProvenance":
+        return cls(
+            train_step=data.get("train_step"),
+            rollout_step=data.get("rollout_step"),
+            weight_step=data.get("weight_step"),
+            eval_sequence=data.get("eval_sequence"),
+            worker_index=data.get("worker_index"),
+            instance_id=data.get("instance_id"),
+        )
+
+
+@dataclass(frozen=True)
+class TelemetryEvent:
+    """One durable RL telemetry event."""
+
+    stream: TrackerStream
+    event_type: str
+    provenance: StepProvenance
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    run_id: str | None = None
+    event_id: str = field(default_factory=_fresh_event_id)
+    created_at: str = field(default_factory=_utc_now_iso)
+    schema_version: str = TELEMETRY_EVENT_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "event_id": self.event_id,
+            "created_at": self.created_at,
+            "run_id": self.run_id,
+            "stream": self.stream.value,
+            "event_type": self.event_type,
+            "provenance": dataclasses.asdict(self.provenance),
+            "payload": dict(self.payload),
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True, cls=CustomJsonEncoder)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "TelemetryEvent":
+        return cls(
+            schema_version=str(data["schema_version"]),
+            event_id=str(data["event_id"]),
+            created_at=str(data["created_at"]),
+            run_id=data.get("run_id"),
+            stream=TrackerStream(data["stream"]),
+            event_type=str(data["event_type"]),
+            provenance=StepProvenance.from_dict(data.get("provenance", {})),
+            payload=dict(data.get("payload", {})),
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> "TelemetryEvent":
+        return cls.from_dict(json.loads(payload))
+
+
+@dataclass(frozen=True)
+class TrackerRunRef:
+    """Durable reference to an external tracker run."""
+
+    stream: TrackerStream
+    tracker_run_id: str
+    project: str | None = None
+    entity: str | None = None
+    run_name: str | None = None
+    run_url: str | None = None
+    worker_index: int | None = None
+    schema_version: str = TRACKER_RUN_REF_SCHEMA_VERSION
+
+
+@dataclass(frozen=True)
+class ArtifactRef:
+    """Durable reference to a file or artifact emitted by the RL run."""
+
+    name: str
+    path: str
+    artifact_type: str
+    stream: TrackerStream | None = None
+    worker_index: int | None = None
+    schema_version: str = ARTIFACT_REF_SCHEMA_VERSION
+
+
+def event_shard_directory(metadata_path: str, run_id: str) -> str:
+    return join_path(join_path(metadata_path, run_id), "events")
+
+
+def event_shard_filename(
+    stream: TrackerStream,
+    *,
+    instance_id: str,
+    worker_index: int | None = None,
+) -> str:
+    if stream == TrackerStream.TRAINER:
+        return f"train-{instance_id}.jsonl"
+    if stream == TrackerStream.EVAL:
+        return f"eval-{instance_id}.jsonl"
+    if stream == TrackerStream.ROLLOUT:
+        if worker_index is None:
+            raise ValueError("worker_index is required for rollout event shards")
+        return f"rollout-{worker_index}-{instance_id}.jsonl"
+    raise ValueError(f"Unsupported tracker stream: {stream}")
+
+
+def event_shard_path(
+    metadata_path: str,
+    run_id: str,
+    stream: TrackerStream,
+    *,
+    instance_id: str,
+    worker_index: int | None = None,
+) -> str:
+    return join_path(
+        event_shard_directory(metadata_path, run_id),
+        event_shard_filename(stream, instance_id=instance_id, worker_index=worker_index),
+    )
+
+
+class EventShardWriter:
+    """Append-only writer for one RL telemetry shard.
+
+    Each process owns exactly one shard. This avoids multi-process append
+    contention while still keeping the event record line-oriented and easy to
+    mirror into external trackers later.
+    """
+
+    def __init__(
+        self,
+        *,
+        metadata_path: str,
+        run_id: str,
+        stream: TrackerStream,
+        instance_id: str,
+        worker_index: int | None = None,
+    ):
+        self.metadata_path = metadata_path
+        self.run_id = run_id
+        self.stream = stream
+        self.instance_id = instance_id
+        self.worker_index = worker_index
+        self.directory = event_shard_directory(metadata_path, run_id)
+        self.path = event_shard_path(
+            metadata_path,
+            run_id,
+            stream,
+            instance_id=instance_id,
+            worker_index=worker_index,
+        )
+
+    def artifact_ref(self) -> ArtifactRef:
+        return ArtifactRef(
+            name=os.path.basename(self.path),
+            path=self.path,
+            artifact_type="event_shard",
+            stream=self.stream,
+            worker_index=self.worker_index,
+        )
+
+    def append(self, event: TelemetryEvent) -> None:
+        if event.stream != self.stream:
+            raise ValueError(f"event stream {event.stream} does not match shard stream {self.stream}")
+
+        fs = url_to_fs(self.path)[0]
+        fs.makedirs(self.directory, exist_ok=True)
+        with fs.open(self.path, "a") as handle:
+            handle.write(event.to_json())
+            handle.write("\n")

--- a/lib/marin/src/marin/rl/train_worker.py
+++ b/lib/marin/src/marin/rl/train_worker.py
@@ -38,6 +38,7 @@ from marin.rl import weight_transfer
 from marin.rl.curriculum import CurriculumConfig
 from marin.rl.model_utils import load_model_from_checkpoint
 from marin.rl.runtime import RLRuntimeHandles
+from marin.rl.telemetry import EventShardWriter, StepProvenance, TelemetryEvent, TrackerStream
 from marin.rl.weight_transfer import WeightTransferConfig
 
 from .replay_buffer import ReplayBuffer, ReplayBufferConfig, ReplayDataLoader, RolloutWithCount
@@ -145,6 +146,8 @@ class TrainWorkerConfig:
     loss: RLLossModule
     tokenizer: MarinTokenizer
     run_id: str
+    root_run_id: str | None = None
+    """Stable RL job run id used for shared telemetry and artifact paths."""
 
     initial_checkpoint: str | None = None
     """Initial checkpoint for the reference model (auto-detects HF repo vs local path)."""
@@ -155,6 +158,12 @@ class TrainWorkerConfig:
 
     seed: int = 0
     """Random seed for replay buffer sampling and model construction."""
+
+    metadata_path: str | None = None
+    """Base metadata path for local RL telemetry artifacts."""
+
+    instance_id: str | None = None
+    """Coordinator invocation identifier used for per-attempt artifact naming."""
 
 
 class StreamingRolloutLoader:
@@ -269,6 +278,7 @@ class TrainWorker:
     loss_module: RLLossModule
     initial_model: LmHeadModel | None
     reference_model: LmHeadModel | None
+    _event_writer: EventShardWriter | None
 
     def __init__(
         self,
@@ -293,6 +303,9 @@ class TrainWorker:
         self._should_stop = False
         self.tokenizer = config.tokenizer
         self.loss_module = config.loss
+        self._event_writer = None
+
+        self._initialize_telemetry()
 
         self.rollout_reader = config.rollout_storage.create_reader()
 
@@ -332,6 +345,34 @@ class TrainWorker:
         logger.info("Connected to curriculum actor: %s", config.curriculum_config.actor_name)
 
         self._build_models()
+
+    def _initialize_telemetry(self) -> None:
+        metadata_path = self.config.metadata_path
+        instance_id = self.config.instance_id
+        if metadata_path is None or instance_id is None:
+            return
+
+        telemetry_run_id = self.config.root_run_id or self.config.run_id
+
+        writer = EventShardWriter(
+            metadata_path=metadata_path,
+            run_id=telemetry_run_id,
+            stream=TrackerStream.TRAINER,
+            instance_id=instance_id,
+        )
+        writer.append(
+            TelemetryEvent(
+                run_id=telemetry_run_id,
+                stream=TrackerStream.TRAINER,
+                event_type="worker_started",
+                provenance=StepProvenance(instance_id=instance_id),
+                payload={"worker_role": "trainer"},
+            )
+        )
+        register_artifact = getattr(self._runtime.run_state, "register_artifact_ref", None)
+        if register_artifact is not None:
+            register_artifact.remote(writer.artifact_ref()).result()
+        self._event_writer = writer
 
     def _build_models(self):
         """Build the initial policy model and optional retained reference model."""

--- a/tests/rl/test_rl_experiment_utils.py
+++ b/tests/rl/test_rl_experiment_utils.py
@@ -53,6 +53,14 @@ def _default_launcher_region(monkeypatch):
     monkeypatch.setenv("MARIN_PREFIX", "gs://marin-us-central1")
 
 
+@pytest.fixture(autouse=True)
+def _stub_tpu_region_lookup(monkeypatch):
+    monkeypatch.setattr(
+        "marin.rl.placement.infer_tpu_variant_regions_from_iris",
+        lambda _variants: ["us-central1", "us-east5", "europe-west4"],
+    )
+
+
 def _test_config(
     *,
     train_tpu_type: str,
@@ -181,8 +189,12 @@ def test_build_rl_job_config_resolves_runtime_output_paths(monkeypatch):
 
     assert job_config.trainer.checkpointer.base_path == "gs://marin-us-central1/rl_testing/rl-test/checkpoints"
     assert job_config.rollout_storage.path == "gs://marin-us-central1/rl_testing/rl-test/rollouts"
+    assert job_config.metadata_path == "gs://marin-us-central1/rl_testing/rl-test/metadata"
     assert job_config.inference_config.engine.load_format == "runai_streamer"
     assert job_config.inference_config.engine.canonical_model_name == MODEL_NAME
+    assert job_config.eval_tracker is not None
+    assert job_config.eval_tracker.name == "rl-test-eval"
+    assert job_config.eval_owner_worker_index == 0
 
 
 def test_build_rl_job_config_keeps_rollout_policy_out_of_vllm_fallback_sampling(monkeypatch):

--- a/tests/rl/test_rollout_worker.py
+++ b/tests/rl/test_rollout_worker.py
@@ -22,14 +22,34 @@ from marin.rl.rollout_worker import (
     create_inference_context,
 )
 from marin.rl.run_state import RolloutTransferCounters
+from marin.rl.telemetry import TelemetryEvent, TrackerRunRef, TrackerStream
 
 
 def test_rollout_tracker_uses_explicit_name_when_provided(monkeypatch):
     captured = {}
+    summary_updates = []
+    artifact_logs = []
 
     class _FakeRun:
         def log(self, _metrics, step=None):
             pass
+
+        def log_artifact(self, artifact_path, name=None, artifact_type=None):
+            artifact_logs.append((artifact_path, name, artifact_type))
+
+        @property
+        def summary(self):
+            class _Summary:
+                def update(self_inner, metrics):
+                    summary_updates.append(metrics)
+
+            return _Summary()
+
+        id = "wandb-rollout-123"
+        name = "iris-rl-e4ms2-500-rollout-0"
+        url = "https://wandb.ai/example/run"
+        entity = "marin"
+        project = "marin_iris_rl_debug"
 
         def finish(self):
             pass
@@ -39,7 +59,7 @@ def test_rollout_tracker_uses_explicit_name_when_provided(monkeypatch):
         lambda **kwargs: captured.update(kwargs) or _FakeRun(),
     )
 
-    RolloutTracker(
+    tracker = RolloutTracker(
         RolloutTrackerConfig(project="marin_iris_rl_debug", name="iris-rl-e4ms2-500-rollout-0"),
         run_id="iris-rl-e4ms2-500-rollout-0",
     )
@@ -47,6 +67,11 @@ def test_rollout_tracker_uses_explicit_name_when_provided(monkeypatch):
     assert captured["name"] == "iris-rl-e4ms2-500-rollout-0"
     assert captured["id"] == "iris-rl-e4ms2-500-rollout-0"
     assert captured["resume"] == "allow"
+    tracker.log_summary({"metric": 1})
+    tracker.log_artifact("/tmp/trace.json", name="trace", artifact_type="trace")
+    assert summary_updates == [{"metric": 1}]
+    assert artifact_logs == [("/tmp/trace.json", "trace", "trace")]
+    assert tracker.as_tracker_ref(stream=TrackerStream.ROLLOUT, worker_index=0).tracker_run_id == "wandb-rollout-123"
 
 
 def test_resume_safe_transfer_metrics_logs_attempt_and_cumulative_values_after_counter_reset():
@@ -192,6 +217,68 @@ def test_log_lesson_eval_uses_wandb_default_step_and_context_metrics():
             None,
         )
     ]
+
+
+def test_initialize_telemetry_writes_rollout_and_eval_shards_and_registers_refs(tmp_path):
+    registered_artifacts = []
+    registered_trackers = []
+
+    class _FakeRemoteMethod:
+        def __init__(self, sink):
+            self._sink = sink
+
+        def remote(self, value):
+            self._sink.append(value)
+            return SimpleNamespace(result=lambda: None)
+
+    worker = object.__new__(RolloutWorker)
+    worker.config = SimpleNamespace(
+        metadata_path=str(tmp_path / "metadata"),
+        run_id="rl-test-rollout-0",
+        root_run_id="rl-test",
+        instance_id="attempt-abc",
+        worker_index=0,
+        eval_owner_worker_index=0,
+    )
+    worker._runtime = SimpleNamespace(
+        run_state=SimpleNamespace(
+            register_artifact_ref=_FakeRemoteMethod(registered_artifacts),
+            register_tracker_ref=_FakeRemoteMethod(registered_trackers),
+        )
+    )
+    worker.tracker = SimpleNamespace(
+        as_tracker_ref=lambda *, stream, worker_index=None: TrackerRunRef(
+            stream=stream,
+            tracker_run_id="wandb-rollout-123",
+            project="marin_post_training",
+            run_name="rl-test-rollout-0",
+            worker_index=worker_index,
+        )
+    )
+    worker._event_writer = None
+    worker._eval_event_writer = None
+
+    worker._initialize_telemetry()
+
+    assert worker._event_writer is not None
+    assert worker._eval_event_writer is not None
+    assert len(registered_artifacts) == 2
+    assert len(registered_trackers) == 1
+
+    fs = fsspec.filesystem("file")
+    with fs.open(worker._event_writer.path) as handle:
+        rollout_events = [TelemetryEvent.from_json(line) for line in handle.read().splitlines() if line]
+    with fs.open(worker._eval_event_writer.path) as handle:
+        eval_events = [TelemetryEvent.from_json(line) for line in handle.read().splitlines() if line]
+
+    assert "/rl-test/events/" in worker._event_writer.path
+    assert "/rl-test/events/" in worker._eval_event_writer.path
+    assert [event.stream for event in rollout_events] == [TrackerStream.ROLLOUT]
+    assert [event.event_type for event in rollout_events] == ["worker_started"]
+    assert [event.run_id for event in rollout_events] == ["rl-test"]
+    assert [event.stream for event in eval_events] == [TrackerStream.EVAL]
+    assert [event.event_type for event in eval_events] == ["stream_initialized"]
+    assert [event.run_id for event in eval_events] == ["rl-test"]
 
 
 def test_stage_vllm_metadata_locally_copies_hf_metadata(tmp_path, monkeypatch):

--- a/tests/rl/test_rollout_worker.py
+++ b/tests/rl/test_rollout_worker.py
@@ -62,7 +62,7 @@ def test_rollout_tracker_uses_explicit_name_when_provided(monkeypatch):
         @property
         def summary(self):
             class _Summary:
-                def update(self_inner, metrics):
+                def update(self, metrics):
                     summary_updates.append(metrics)
 
             return _Summary()

--- a/tests/rl/test_rollout_worker.py
+++ b/tests/rl/test_rollout_worker.py
@@ -22,7 +22,16 @@ from marin.rl.rollout_worker import (
     create_inference_context,
 )
 from marin.rl.run_state import RolloutTransferCounters
-from marin.rl.telemetry import TelemetryEvent, TrackerRunRef, TrackerStream
+from marin.rl.telemetry import ArtifactRef, TelemetryEvent, TrackerRunRef, TrackerStream
+
+
+class _RemoteRecorder:
+    def __init__(self):
+        self.values = []
+
+    def remote(self, value):
+        self.values.append(value)
+        return SimpleNamespace(result=lambda: None)
 
 
 def test_rollout_tracker_uses_explicit_name_when_provided(monkeypatch):
@@ -34,9 +43,8 @@ def test_rollout_tracker_uses_explicit_name_when_provided(monkeypatch):
         def log(self, _metrics, step=None):
             pass
 
-        def log_artifact(self, artifact_path, name=None, artifact_type=None, **kwargs):
-            logged_artifact_type = artifact_type if artifact_type is not None else kwargs.get("type")
-            artifact_logs.append((artifact_path, name, logged_artifact_type))
+        def log_artifact(self, artifact_path, name=None, **kwargs):
+            artifact_logs.append((artifact_path, name, kwargs))
 
         @property
         def summary(self):
@@ -71,8 +79,16 @@ def test_rollout_tracker_uses_explicit_name_when_provided(monkeypatch):
     tracker.log_summary({"metric": 1})
     tracker.log_artifact("/tmp/trace.json", name="trace", artifact_type="trace")
     assert summary_updates == [{"metric": 1}]
-    assert artifact_logs == [("/tmp/trace.json", "trace", "trace")]
-    assert tracker.as_tracker_ref(stream=TrackerStream.ROLLOUT, worker_index=0).tracker_run_id == "wandb-rollout-123"
+    assert artifact_logs == [("/tmp/trace.json", "trace", {"type": "trace"})]
+    assert tracker.as_tracker_ref(stream=TrackerStream.ROLLOUT, worker_index=0) == TrackerRunRef(
+        stream=TrackerStream.ROLLOUT,
+        tracker_run_id="wandb-rollout-123",
+        project="marin_iris_rl_debug",
+        entity="marin",
+        run_name="iris-rl-e4ms2-500-rollout-0",
+        run_url="https://wandb.ai/example/run",
+        worker_index=0,
+    )
 
 
 def test_resume_safe_transfer_metrics_logs_attempt_and_cumulative_values_after_counter_reset():
@@ -221,16 +237,8 @@ def test_log_lesson_eval_uses_wandb_default_step_and_context_metrics():
 
 
 def test_initialize_telemetry_writes_rollout_and_eval_shards_and_registers_refs(tmp_path):
-    registered_artifacts = []
-    registered_trackers = []
-
-    class _FakeRemoteMethod:
-        def __init__(self, sink):
-            self._sink = sink
-
-        def remote(self, value):
-            self._sink.append(value)
-            return SimpleNamespace(result=lambda: None)
+    artifact_recorder = _RemoteRecorder()
+    tracker_recorder = _RemoteRecorder()
 
     worker = object.__new__(RolloutWorker)
     worker.config = SimpleNamespace(
@@ -243,8 +251,8 @@ def test_initialize_telemetry_writes_rollout_and_eval_shards_and_registers_refs(
     )
     worker._runtime = SimpleNamespace(
         run_state=SimpleNamespace(
-            register_artifact_ref=_FakeRemoteMethod(registered_artifacts),
-            register_tracker_ref=_FakeRemoteMethod(registered_trackers),
+            register_artifact_ref=artifact_recorder,
+            register_tracker_ref=tracker_recorder,
         )
     )
     worker.tracker = SimpleNamespace(
@@ -263,8 +271,30 @@ def test_initialize_telemetry_writes_rollout_and_eval_shards_and_registers_refs(
 
     assert worker._event_writer is not None
     assert worker._eval_event_writer is not None
-    assert len(registered_artifacts) == 2
-    assert len(registered_trackers) == 1
+    assert artifact_recorder.values == [
+        ArtifactRef(
+            name="rollout-0-attempt-abc.jsonl",
+            path=worker._event_writer.path,
+            artifact_type="event_shard",
+            stream=TrackerStream.ROLLOUT,
+            worker_index=0,
+        ),
+        ArtifactRef(
+            name="eval-attempt-abc.jsonl",
+            path=worker._eval_event_writer.path,
+            artifact_type="event_shard",
+            stream=TrackerStream.EVAL,
+        ),
+    ]
+    assert tracker_recorder.values == [
+        TrackerRunRef(
+            stream=TrackerStream.ROLLOUT,
+            tracker_run_id="wandb-rollout-123",
+            project="marin_post_training",
+            run_name="rl-test-rollout-0",
+            worker_index=0,
+        )
+    ]
 
     fs = fsspec.filesystem("file")
     with fs.open(worker._event_writer.path) as handle:
@@ -277,9 +307,66 @@ def test_initialize_telemetry_writes_rollout_and_eval_shards_and_registers_refs(
     assert [event.stream for event in rollout_events] == [TrackerStream.ROLLOUT]
     assert [event.event_type for event in rollout_events] == ["worker_started"]
     assert [event.run_id for event in rollout_events] == ["rl-test"]
+    assert [event.provenance.worker_index for event in rollout_events] == [0]
+    assert [event.provenance.instance_id for event in rollout_events] == ["attempt-abc"]
+    assert [event.payload for event in rollout_events] == [{"worker_role": "rollout"}]
     assert [event.stream for event in eval_events] == [TrackerStream.EVAL]
     assert [event.event_type for event in eval_events] == ["stream_initialized"]
     assert [event.run_id for event in eval_events] == ["rl-test"]
+    assert [event.provenance.worker_index for event in eval_events] == [0]
+    assert [event.provenance.instance_id for event in eval_events] == ["attempt-abc"]
+    assert [event.payload for event in eval_events] == [{"worker_role": "eval_owner"}]
+
+
+def test_initialize_telemetry_does_not_create_eval_shard_for_non_owner(tmp_path):
+    artifact_recorder = _RemoteRecorder()
+    tracker_recorder = _RemoteRecorder()
+
+    worker = object.__new__(RolloutWorker)
+    worker.config = SimpleNamespace(
+        metadata_path=str(tmp_path / "metadata"),
+        run_id="rl-test-rollout-1",
+        root_run_id="rl-test",
+        instance_id="attempt-abc",
+        worker_index=1,
+        eval_owner_worker_index=0,
+    )
+    worker._runtime = SimpleNamespace(
+        run_state=SimpleNamespace(
+            register_artifact_ref=artifact_recorder,
+            register_tracker_ref=tracker_recorder,
+        )
+    )
+    worker.tracker = SimpleNamespace(
+        as_tracker_ref=lambda *, stream, worker_index=None: TrackerRunRef(
+            stream=stream,
+            tracker_run_id="wandb-rollout-456",
+            worker_index=worker_index,
+        )
+    )
+    worker._event_writer = None
+    worker._eval_event_writer = None
+
+    worker._initialize_telemetry()
+
+    assert worker._event_writer is not None
+    assert worker._eval_event_writer is None
+    assert artifact_recorder.values == [
+        ArtifactRef(
+            name="rollout-1-attempt-abc.jsonl",
+            path=worker._event_writer.path,
+            artifact_type="event_shard",
+            stream=TrackerStream.ROLLOUT,
+            worker_index=1,
+        )
+    ]
+    assert tracker_recorder.values == [
+        TrackerRunRef(
+            stream=TrackerStream.ROLLOUT,
+            tracker_run_id="wandb-rollout-456",
+            worker_index=1,
+        )
+    ]
 
 
 def test_stage_vllm_metadata_locally_copies_hf_metadata(tmp_path, monkeypatch):

--- a/tests/rl/test_rollout_worker.py
+++ b/tests/rl/test_rollout_worker.py
@@ -21,17 +21,30 @@ from marin.rl.rollout_worker import (
     _should_run_micro_eval,
     create_inference_context,
 )
-from marin.rl.run_state import RolloutTransferCounters
+from marin.rl.run_state import RLRunState, RolloutTransferCounters
 from marin.rl.telemetry import ArtifactRef, TelemetryEvent, TrackerRunRef, TrackerStream
 
 
-class _RemoteRecorder:
-    def __init__(self):
-        self.values = []
+class _RemoteResult:
+    def __init__(self, value):
+        self._value = value
 
-    def remote(self, value):
-        self.values.append(value)
-        return SimpleNamespace(result=lambda: None)
+    def result(self):
+        return self._value
+
+
+class _RemoteMethod:
+    def __init__(self, fn):
+        self._fn = fn
+
+    def remote(self, *args, **kwargs):
+        return _RemoteResult(self._fn(*args, **kwargs))
+
+
+class _RunStateHandle:
+    def __init__(self, run_state: RLRunState):
+        self.register_artifact_ref = _RemoteMethod(run_state.register_artifact_ref)
+        self.register_tracker_ref = _RemoteMethod(run_state.register_tracker_ref)
 
 
 def test_rollout_tracker_uses_explicit_name_when_provided(monkeypatch):
@@ -237,8 +250,7 @@ def test_log_lesson_eval_uses_wandb_default_step_and_context_metrics():
 
 
 def test_initialize_telemetry_writes_rollout_and_eval_shards_and_registers_refs(tmp_path):
-    artifact_recorder = _RemoteRecorder()
-    tracker_recorder = _RemoteRecorder()
+    run_state = RLRunState()
 
     worker = object.__new__(RolloutWorker)
     worker.config = SimpleNamespace(
@@ -249,12 +261,7 @@ def test_initialize_telemetry_writes_rollout_and_eval_shards_and_registers_refs(
         worker_index=0,
         eval_owner_worker_index=0,
     )
-    worker._runtime = SimpleNamespace(
-        run_state=SimpleNamespace(
-            register_artifact_ref=artifact_recorder,
-            register_tracker_ref=tracker_recorder,
-        )
-    )
+    worker._runtime = SimpleNamespace(run_state=_RunStateHandle(run_state))
     worker.tracker = SimpleNamespace(
         as_tracker_ref=lambda *, stream, worker_index=None: TrackerRunRef(
             stream=stream,
@@ -271,7 +278,7 @@ def test_initialize_telemetry_writes_rollout_and_eval_shards_and_registers_refs(
 
     assert worker._event_writer is not None
     assert worker._eval_event_writer is not None
-    assert artifact_recorder.values == [
+    assert run_state.list_artifact_refs() == [
         ArtifactRef(
             name="rollout-0-attempt-abc.jsonl",
             path=worker._event_writer.path,
@@ -286,7 +293,7 @@ def test_initialize_telemetry_writes_rollout_and_eval_shards_and_registers_refs(
             stream=TrackerStream.EVAL,
         ),
     ]
-    assert tracker_recorder.values == [
+    assert run_state.list_tracker_refs() == [
         TrackerRunRef(
             stream=TrackerStream.ROLLOUT,
             tracker_run_id="wandb-rollout-123",
@@ -319,8 +326,7 @@ def test_initialize_telemetry_writes_rollout_and_eval_shards_and_registers_refs(
 
 
 def test_initialize_telemetry_does_not_create_eval_shard_for_non_owner(tmp_path):
-    artifact_recorder = _RemoteRecorder()
-    tracker_recorder = _RemoteRecorder()
+    run_state = RLRunState()
 
     worker = object.__new__(RolloutWorker)
     worker.config = SimpleNamespace(
@@ -331,12 +337,7 @@ def test_initialize_telemetry_does_not_create_eval_shard_for_non_owner(tmp_path)
         worker_index=1,
         eval_owner_worker_index=0,
     )
-    worker._runtime = SimpleNamespace(
-        run_state=SimpleNamespace(
-            register_artifact_ref=artifact_recorder,
-            register_tracker_ref=tracker_recorder,
-        )
-    )
+    worker._runtime = SimpleNamespace(run_state=_RunStateHandle(run_state))
     worker.tracker = SimpleNamespace(
         as_tracker_ref=lambda *, stream, worker_index=None: TrackerRunRef(
             stream=stream,
@@ -351,7 +352,7 @@ def test_initialize_telemetry_does_not_create_eval_shard_for_non_owner(tmp_path)
 
     assert worker._event_writer is not None
     assert worker._eval_event_writer is None
-    assert artifact_recorder.values == [
+    assert run_state.list_artifact_refs() == [
         ArtifactRef(
             name="rollout-1-attempt-abc.jsonl",
             path=worker._event_writer.path,
@@ -360,7 +361,7 @@ def test_initialize_telemetry_does_not_create_eval_shard_for_non_owner(tmp_path)
             worker_index=1,
         )
     ]
-    assert tracker_recorder.values == [
+    assert run_state.list_tracker_refs() == [
         TrackerRunRef(
             stream=TrackerStream.ROLLOUT,
             tracker_run_id="wandb-rollout-456",

--- a/tests/rl/test_rollout_worker.py
+++ b/tests/rl/test_rollout_worker.py
@@ -34,8 +34,9 @@ def test_rollout_tracker_uses_explicit_name_when_provided(monkeypatch):
         def log(self, _metrics, step=None):
             pass
 
-        def log_artifact(self, artifact_path, name=None, artifact_type=None):
-            artifact_logs.append((artifact_path, name, artifact_type))
+        def log_artifact(self, artifact_path, name=None, artifact_type=None, **kwargs):
+            logged_artifact_type = artifact_type if artifact_type is not None else kwargs.get("type")
+            artifact_logs.append((artifact_path, name, logged_artifact_type))
 
         @property
         def summary(self):

--- a/tests/rl/test_run_state.py
+++ b/tests/rl/test_run_state.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from marin.rl.run_state import RLRunState, RolloutTransferCounters, RunStatus
+from marin.rl.telemetry import ArtifactRef, TrackerRunRef, TrackerStream
 
 
 def test_run_state_snapshot_tracks_latest_completed_train_step():
@@ -50,3 +51,37 @@ def test_run_state_accumulates_rollout_transfer_counters_per_worker():
     assert updated == RolloutTransferCounters(total_polls=7, successful_receives=5, failed_receives=1)
 
     assert run_state.get_rollout_transfer_counters(worker_index=0) == RolloutTransferCounters()
+
+
+def test_run_state_allocates_monotonic_eval_sequences():
+    run_state = RLRunState()
+
+    assert run_state.next_eval_sequence() == 0
+    assert run_state.next_eval_sequence() == 1
+    assert run_state.next_eval_sequence() == 2
+
+
+def test_run_state_registers_tracker_and_artifact_refs():
+    run_state = RLRunState()
+    tracker_ref = TrackerRunRef(
+        stream=TrackerStream.ROLLOUT,
+        tracker_run_id="wandb-rollout-123",
+        project="marin_post_training",
+        run_name="rl-test-rollout-0",
+        run_url="https://wandb.ai/example/run",
+        worker_index=0,
+    )
+    artifact_ref = ArtifactRef(
+        name="train-events",
+        path="gs://bucket/metadata/rl-test/events/train-attempt-abc.jsonl",
+        artifact_type="event_shard",
+        stream=TrackerStream.TRAINER,
+    )
+
+    run_state.register_tracker_ref(tracker_ref)
+    run_state.register_artifact_ref(artifact_ref)
+
+    assert run_state.get_tracker_ref(TrackerStream.ROLLOUT, worker_index=0) == tracker_ref
+    assert run_state.list_tracker_refs() == [tracker_ref]
+    assert run_state.get_artifact_ref("train-events") == artifact_ref
+    assert run_state.list_artifact_refs() == [artifact_ref]

--- a/tests/rl/test_telemetry.py
+++ b/tests/rl/test_telemetry.py
@@ -1,0 +1,111 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import fsspec
+import pytest
+
+from marin.rl.telemetry import (
+    EventShardWriter,
+    StepProvenance,
+    TelemetryEvent,
+    TrackerStream,
+    event_shard_path,
+)
+
+
+def test_telemetry_event_round_trips_through_json():
+    event = TelemetryEvent(
+        run_id="rl-test",
+        stream=TrackerStream.ROLLOUT,
+        event_type="rollout_batch_written",
+        provenance=StepProvenance(
+            rollout_step=12,
+            weight_step=10,
+            train_step=8,
+            worker_index=2,
+            instance_id="attempt-abc",
+        ),
+        payload={"avg_reward": 0.5, "lesson_id": "math"},
+    )
+
+    restored = TelemetryEvent.from_json(event.to_json())
+
+    assert restored == event
+    assert restored.schema_version == "telemetry_event.v1"
+    assert restored.event_id
+
+
+def test_event_shard_path_uses_per_writer_names():
+    metadata_path = "gs://bucket/runs/metadata"
+
+    assert (
+        event_shard_path(
+            metadata_path,
+            "rl-test",
+            TrackerStream.TRAINER,
+            instance_id="attempt-abc",
+        )
+        == "gs://bucket/runs/metadata/rl-test/events/train-attempt-abc.jsonl"
+    )
+    assert (
+        event_shard_path(
+            metadata_path,
+            "rl-test",
+            TrackerStream.EVAL,
+            instance_id="attempt-abc",
+        )
+        == "gs://bucket/runs/metadata/rl-test/events/eval-attempt-abc.jsonl"
+    )
+    assert (
+        event_shard_path(
+            metadata_path,
+            "rl-test",
+            TrackerStream.ROLLOUT,
+            instance_id="attempt-abc",
+            worker_index=3,
+        )
+        == "gs://bucket/runs/metadata/rl-test/events/rollout-3-attempt-abc.jsonl"
+    )
+
+
+def test_rollout_event_shard_path_requires_worker_index():
+    with pytest.raises(ValueError, match="worker_index is required"):
+        event_shard_path("/tmp/metadata", "rl-test", TrackerStream.ROLLOUT, instance_id="attempt-abc")
+
+
+def test_event_shard_writer_appends_jsonl_records(tmp_path: Path):
+    writer = EventShardWriter(
+        metadata_path=str(tmp_path / "metadata"),
+        run_id="rl-test",
+        stream=TrackerStream.TRAINER,
+        instance_id="attempt-abc",
+    )
+
+    first_event = TelemetryEvent(
+        run_id="rl-test",
+        stream=TrackerStream.TRAINER,
+        event_type="worker_started",
+        provenance=StepProvenance(instance_id="attempt-abc"),
+        payload={"message": "trainer online"},
+    )
+    second_event = TelemetryEvent(
+        run_id="rl-test",
+        stream=TrackerStream.TRAINER,
+        event_type="checkpoint_written",
+        provenance=StepProvenance(instance_id="attempt-abc", train_step=5),
+        payload={"checkpoint_step": 5},
+    )
+
+    writer.append(first_event)
+    writer.append(second_event)
+
+    fs = fsspec.filesystem("file")
+    assert fs.exists(writer.path)
+    with fs.open(writer.path) as handle:
+        lines = [line for line in handle.read().splitlines() if line]
+
+    restored = [TelemetryEvent.from_json(line) for line in lines]
+    assert restored == [first_event, second_event]
+    assert writer.artifact_ref().schema_version == "rl_artifact_ref.v1"

--- a/tests/rl/test_telemetry.py
+++ b/tests/rl/test_telemetry.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import fsspec
 import pytest
-
 from marin.rl.telemetry import (
     EventShardWriter,
     StepProvenance,

--- a/tests/rl/test_telemetry.py
+++ b/tests/rl/test_telemetry.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import fsspec
 import pytest
 from marin.rl.telemetry import (
+    ArtifactRef,
     EventShardWriter,
     StepProvenance,
     TelemetryEvent,
@@ -107,4 +108,28 @@ def test_event_shard_writer_appends_jsonl_records(tmp_path: Path):
 
     restored = [TelemetryEvent.from_json(line) for line in lines]
     assert restored == [first_event, second_event]
-    assert writer.artifact_ref().schema_version == "rl_artifact_ref.v1"
+    assert writer.artifact_ref() == ArtifactRef(
+        name="train-attempt-abc.jsonl",
+        path=writer.path,
+        artifact_type="event_shard",
+        stream=TrackerStream.TRAINER,
+    )
+
+
+def test_event_shard_writer_rejects_events_for_other_streams(tmp_path: Path):
+    writer = EventShardWriter(
+        metadata_path=str(tmp_path / "metadata"),
+        run_id="rl-test",
+        stream=TrackerStream.TRAINER,
+        instance_id="attempt-abc",
+    )
+
+    with pytest.raises(ValueError, match="does not match shard stream"):
+        writer.append(
+            TelemetryEvent(
+                run_id="rl-test",
+                stream=TrackerStream.ROLLOUT,
+                event_type="worker_started",
+                provenance=StepProvenance(instance_id="attempt-abc", worker_index=0),
+            )
+        )

--- a/tests/rl/test_train_worker.py
+++ b/tests/rl/test_train_worker.py
@@ -7,7 +7,7 @@ import fsspec
 import pytest
 from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.rl_losses import RLOOLoss
-from marin.rl.telemetry import TelemetryEvent, TrackerStream
+from marin.rl.telemetry import ArtifactRef, StepProvenance, TelemetryEvent, TrackerStream
 from marin.rl.train_worker import (
     BatchPrepTiming,
     InitialRolloutState,
@@ -86,18 +86,31 @@ def test_initialize_telemetry_writes_trainer_event_shard_and_registers_artifact(
     worker._initialize_telemetry()
 
     assert worker._event_writer is not None
-    assert len(registered_artifacts) == 1
+    assert registered_artifacts == [
+        ArtifactRef(
+            name="train-attempt-abc.jsonl",
+            path=worker._event_writer.path,
+            artifact_type="event_shard",
+            stream=TrackerStream.TRAINER,
+        )
+    ]
 
     fs = fsspec.filesystem("file")
     assert fs.exists(worker._event_writer.path)
     with fs.open(worker._event_writer.path) as handle:
         events = [TelemetryEvent.from_json(line) for line in handle.read().splitlines() if line]
 
-    assert len(events) == 1
-    assert events[0].stream == TrackerStream.TRAINER
-    assert events[0].event_type == "worker_started"
-    assert events[0].run_id == "rl-test"
-    assert events[0].payload == {"worker_role": "trainer"}
+    assert events == [
+        TelemetryEvent(
+            run_id="rl-test",
+            stream=TrackerStream.TRAINER,
+            event_type="worker_started",
+            provenance=StepProvenance(instance_id="attempt-abc"),
+            payload={"worker_role": "trainer"},
+            event_id=events[0].event_id,
+            created_at=events[0].created_at,
+        )
+    ]
 
 
 def test_initial_rollout_state_uses_bootstrap_weights_for_fresh_run():

--- a/tests/rl/test_train_worker.py
+++ b/tests/rl/test_train_worker.py
@@ -3,9 +3,11 @@
 
 from types import SimpleNamespace
 
+import fsspec
 import pytest
 from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.rl_losses import RLOOLoss
+from marin.rl.telemetry import TelemetryEvent, TrackerStream
 from marin.rl.train_worker import (
     BatchPrepTiming,
     InitialRolloutState,
@@ -61,6 +63,41 @@ def test_record_train_step_updates_replay_buffer_and_shared_run_state():
     worker._record_train_step(7)
 
     assert recorded_steps == [7, 7]
+
+
+def test_initialize_telemetry_writes_trainer_event_shard_and_registers_artifact(tmp_path):
+    registered_artifacts = []
+
+    class _FakeRemoteMethod:
+        def remote(self, artifact_ref):
+            registered_artifacts.append(artifact_ref)
+            return SimpleNamespace(result=lambda: None)
+
+    worker = TrainWorker.__new__(TrainWorker)
+    worker.config = SimpleNamespace(
+        metadata_path=str(tmp_path / "metadata"),
+        run_id="rl-test",
+        root_run_id="rl-test",
+        instance_id="attempt-abc",
+    )
+    worker._runtime = SimpleNamespace(run_state=SimpleNamespace(register_artifact_ref=_FakeRemoteMethod()))
+    worker._event_writer = None
+
+    worker._initialize_telemetry()
+
+    assert worker._event_writer is not None
+    assert len(registered_artifacts) == 1
+
+    fs = fsspec.filesystem("file")
+    assert fs.exists(worker._event_writer.path)
+    with fs.open(worker._event_writer.path) as handle:
+        events = [TelemetryEvent.from_json(line) for line in handle.read().splitlines() if line]
+
+    assert len(events) == 1
+    assert events[0].stream == TrackerStream.TRAINER
+    assert events[0].event_type == "worker_started"
+    assert events[0].run_id == "rl-test"
+    assert events[0].payload == {"worker_role": "trainer"}
 
 
 def test_initial_rollout_state_uses_bootstrap_weights_for_fresh_run():

--- a/tests/rl/test_train_worker.py
+++ b/tests/rl/test_train_worker.py
@@ -7,6 +7,7 @@ import fsspec
 import pytest
 from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.rl_losses import RLOOLoss
+from marin.rl.run_state import RLRunState
 from marin.rl.telemetry import ArtifactRef, StepProvenance, TelemetryEvent, TrackerStream
 from marin.rl.train_worker import (
     BatchPrepTiming,
@@ -17,6 +18,27 @@ from marin.rl.train_worker import (
     _training_step_timing_metrics,
 )
 from marin.rl.weight_transfer.base import WeightTransferServerMetrics
+
+
+class _RemoteResult:
+    def __init__(self, value):
+        self._value = value
+
+    def result(self):
+        return self._value
+
+
+class _RemoteMethod:
+    def __init__(self, fn):
+        self._fn = fn
+
+    def remote(self, *args, **kwargs):
+        return _RemoteResult(self._fn(*args, **kwargs))
+
+
+class _RunStateHandle:
+    def __init__(self, run_state: RLRunState):
+        self.register_artifact_ref = _RemoteMethod(run_state.register_artifact_ref)
 
 
 def test_drop_bootstrap_model_references_clears_reference_model_when_kl_disabled():
@@ -66,12 +88,7 @@ def test_record_train_step_updates_replay_buffer_and_shared_run_state():
 
 
 def test_initialize_telemetry_writes_trainer_event_shard_and_registers_artifact(tmp_path):
-    registered_artifacts = []
-
-    class _FakeRemoteMethod:
-        def remote(self, artifact_ref):
-            registered_artifacts.append(artifact_ref)
-            return SimpleNamespace(result=lambda: None)
+    run_state = RLRunState()
 
     worker = TrainWorker.__new__(TrainWorker)
     worker.config = SimpleNamespace(
@@ -80,13 +97,13 @@ def test_initialize_telemetry_writes_trainer_event_shard_and_registers_artifact(
         root_run_id="rl-test",
         instance_id="attempt-abc",
     )
-    worker._runtime = SimpleNamespace(run_state=SimpleNamespace(register_artifact_ref=_FakeRemoteMethod()))
+    worker._runtime = SimpleNamespace(run_state=_RunStateHandle(run_state))
     worker._event_writer = None
 
     worker._initialize_telemetry()
 
     assert worker._event_writer is not None
-    assert registered_artifacts == [
+    assert run_state.list_artifact_refs() == [
         ArtifactRef(
             name="train-attempt-abc.jsonl",
             path=worker._event_writer.path,


### PR DESCRIPTION
Add the PR1 RL telemetry substrate with durable event shards, tracker and artifact refs, and metadata-path plumbing for trainer, rollout, and eval startup. This makes provenance and stream ownership explicit before the later metrics cutover and adds coverage for event encoding, run-state registration, and worker initialization. Spec: .agents/projects/rl-logging-observability-implementation-plan-2026-04-09.md