### PR TITLE
[zephyr] Return counters alongside results from ctx.execute()

### DIFF
--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -328,7 +328,7 @@ def build_cache(
         max_workers=min(128, len(shard_jobs)),
         name="levanter-cache-build",
     )
-    shard_results = ctx.execute(Dataset.from_list(shard_jobs).map(process_shard), verbose=False)
+    shard_results = ctx.execute(Dataset.from_list(shard_jobs).map(process_shard), verbose=False).results
     shard_results = sorted(shard_results, key=lambda r: r["index"])
 
     shard_cache_paths = [s["path"] for s in shard_results]
@@ -449,11 +449,9 @@ def consolidate_shard_caches(
         max_workers=min(CONSOLIDATE_DATA_SIZE_WORKERS, len(shard_cache_paths)),
         name="levanter-cache-probe",
     )
-    probe_results = list(
-        probe_ctx.execute(
-            Dataset.from_list(shard_cache_paths).map(_probe_shard),
-        )
-    )
+    probe_results = probe_ctx.execute(
+        Dataset.from_list(shard_cache_paths).map(_probe_shard),
+    ).results
     per_shard_sizes = [r[0] for r in probe_results]
     shard_ledgers = [r[1] for r in probe_results]
 

--- a/lib/marin/src/marin/datakit/download/uncheatable_eval.py
+++ b/lib/marin/src/marin/datakit/download/uncheatable_eval.py
@@ -327,7 +327,7 @@ def download_latest_uncheatable_eval(cfg: UncheatableEvalDownloadConfig) -> dict
         .write_jsonl(f"{cfg.output_path}/.metrics/part-{{shard:05d}}.jsonl", skip_existing=True)
     )
     ctx = ZephyrContext(name="download-uncheatable-eval")
-    output_paths = ctx.execute(pipeline)
+    output_paths = ctx.execute(pipeline).results
 
     for dataset, metadata_file in zip(filtered_datasets, output_paths, strict=True):
         with open_url(metadata_file, "r", encoding="utf-8") as meta_file:

--- a/lib/marin/src/marin/datakit/download/wikipedia.py
+++ b/lib/marin/src/marin/datakit/download/wikipedia.py
@@ -86,18 +86,18 @@ def download_wikipedia(input_urls: list[str], revision: str, output_path: str) -
         Dataset.from_list(input_urls)
         .map(lambda url: download_tar(url, output_base))
         .write_jsonl(f"{output_base}/.metrics/download-{{shard:05d}}.jsonl", skip_existing=True),
-    )
+    ).results
 
     # load all of the output filenames to process
-    downloads = ctx.execute(Dataset.from_list(download_metrics).flat_map(load_jsonl))
+    downloads = ctx.execute(Dataset.from_list(download_metrics).flat_map(load_jsonl)).results
 
     extracted = ctx.execute(
         Dataset.from_list(downloads)
         .flat_map(lambda file: process_file(file, output_base))
         .write_jsonl(f"{output_base}/.metrics/process-{{shard:05d}}.jsonl", skip_existing=True),
-    )
+    ).results
 
-    logger.info("Wikipedia dump transfer complete, wrote: %s", list(extracted))
+    logger.info("Wikipedia dump transfer complete, wrote: %s", extracted)
 
 
 def download_wikipedia_step(

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -18,6 +18,7 @@ import logging
 import os
 from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
 from typing import Any
 
 import dupekit
@@ -28,6 +29,34 @@ from zephyr import Dataset, ZephyrContext
 from zephyr.readers import SUPPORTED_EXTENSIONS, load_file
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class NormalizeSubdirResult:
+    """Per-subdirectory outcome of :func:`normalize_to_parquet`.
+
+    Attributes:
+        subdir: Relative subdirectory under the input root (``""`` for root).
+        output_files: Absolute paths of the Parquet partitions written.
+        counters: Aggregated zephyr counters from the subdirectory's pipeline
+            run (builtin ``zephyr/records_in``/``records_out`` plus any user
+            counters).
+    """
+
+    subdir: str
+    output_files: list[str]
+    counters: dict[str, int]
+
+
+@dataclass
+class NormalizeResult:
+    """Full outcome of :func:`normalize_to_parquet`, one entry per subdir.
+
+    Persisted as the step's ``.artifact`` so counters and output paths are
+    available to downstream consumers without re-running the pipeline.
+    """
+
+    subdirs: list[NormalizeSubdirResult] = field(default_factory=list)
 
 
 def generate_id(text: str) -> str:
@@ -186,7 +215,7 @@ def normalize_to_parquet(
     target_partition_bytes: int = 256 * 1024 * 1024,
     worker_resources: ResourceConfig | None = None,
     file_extensions: tuple[str, ...] | None = None,
-) -> None:
+) -> NormalizeResult:
     """Normalize raw downloaded data to the datakit standard Parquet format.
 
     Discovers all data files under *input_path*, groups them by subdirectory,
@@ -211,6 +240,10 @@ def normalize_to_parquet(
         file_extensions: Tuple of file extensions to include (e.g.
             ``(".parquet",)``).  Defaults to all extensions supported by
             ``zephyr.readers.load_file``.
+
+    Returns:
+        A :class:`NormalizeResult` describing the output files and zephyr
+        counters for each subdirectory that was processed.
     """
     resources = worker_resources or ResourceConfig(cpu=2, ram="16g", disk="10g")
 
@@ -220,7 +253,7 @@ def normalize_to_parquet(
 
     logger.info("Discovered %d subdirectories under %s", len(file_groups), input_path)
 
-    def _run_subdir(subdir: str, files: list[str]) -> None:
+    def _run_subdir(subdir: str, files: list[str]) -> NormalizeSubdirResult:
         total_bytes = _compute_total_bytes(files)
         num_shards = max(1, total_bytes // target_partition_bytes)
         output_dir = os.path.join(output_path, subdir) if subdir else output_path
@@ -239,15 +272,25 @@ def normalize_to_parquet(
             name=f"normalize-{subdir.replace('/', '-') if subdir else 'all'}",
             resources=resources,
         )
-        ctx.execute(pipeline)
+        outcome = ctx.execute(pipeline)
+        return NormalizeSubdirResult(
+            subdir=subdir,
+            output_files=list(outcome.results),
+            counters=dict(outcome.counters),
+        )
 
     # Launch all subdirectory pipelines concurrently
+    subdir_results: list[NormalizeSubdirResult] = []
     with ThreadPoolExecutor(max_workers=len(file_groups)) as pool:
         futures = {pool.submit(_run_subdir, subdir, files): subdir for subdir, files in file_groups.items()}
         for future in as_completed(futures):
             subdir = futures[future]
-            future.result()  # Propagate exceptions
+            subdir_results.append(future.result())  # Propagate exceptions
             logger.info("Completed normalization for %s", os.path.join(output_path, subdir) if subdir else output_path)
+
+    # Sort for deterministic output so re-runs produce stable .artifact contents
+    subdir_results.sort(key=lambda r: r.subdir)
+    return NormalizeResult(subdirs=subdir_results)
 
 
 def normalize_step(

--- a/lib/marin/src/marin/processing/classification/consolidate.py
+++ b/lib/marin/src/marin/processing/classification/consolidate.py
@@ -200,7 +200,7 @@ def _compute_percentile_threshold(
         .load_file()
         .select("attributes")
         .reduce(local_reducer=local_reducer, global_reducer=global_reducer)
-    )
+    ).results
 
     combined_sketch = next(iter(result))
     threshold = combined_sketch.get_quantile_value(1 - keep_fraction)
@@ -347,6 +347,6 @@ def consolidate(config: ConsolidateConfig):
             )
         )
         .write_parquet(output_pattern)
-    )
+    ).results
 
     logger.info(f"Consolidation complete. Wrote {len(results)} output files")

--- a/lib/marin/src/marin/processing/classification/decon.py
+++ b/lib/marin/src/marin/processing/classification/decon.py
@@ -167,7 +167,7 @@ def build_filter(
         .select(config.text_field)
         .map_shard(build_shard_bloom)
         .write_binary(f"{bloom_path}-{{shard:05d}}-of-{{total:05d}}.bin", skip_existing=True),
-    )
+    ).results
 
     if len(shard_blooms_data) == 1:
         return shard_blooms_data[0]
@@ -178,7 +178,7 @@ def build_filter(
         .reshard(num_shards=1)
         .map_shard(_merge_bloom)
         .write_binary(bloom_path, skip_existing=True),
-    )
+    ).results
 
     return merged_bloom[0]
 
@@ -249,24 +249,21 @@ def mark_duplicates_bloom(
 
     # Use write_jsonl with callable output pattern
     zephyr_ctx = ZephyrContext(name="decon-mark")
-    result = list(
-        zephyr_ctx.execute(
-            Dataset.from_iterable(all_files)
-            .flat_map(load_file)
-            .map_shard(process_shard_with_bloom)
-            .write_jsonl(
-                output_pattern=lambda shard_idx, total: rebase_file_path(
-                    base_path,
-                    all_files[shard_idx],
-                    output_path,
-                    new_extension=_get_extension(all_files[shard_idx]),
-                    old_extension=_get_extension(all_files[shard_idx]),
-                ),
-                skip_existing=True,
+    return zephyr_ctx.execute(
+        Dataset.from_iterable(all_files)
+        .flat_map(load_file)
+        .map_shard(process_shard_with_bloom)
+        .write_jsonl(
+            output_pattern=lambda shard_idx, total: rebase_file_path(
+                base_path,
+                all_files[shard_idx],
+                output_path,
+                new_extension=_get_extension(all_files[shard_idx]),
+                old_extension=_get_extension(all_files[shard_idx]),
             ),
-        )
-    )
-    return result
+            skip_existing=True,
+        ),
+    ).results
 
 
 def _run_decontamination(config: DeconConfig):

--- a/lib/marin/src/marin/processing/classification/deduplication/connected_components.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/connected_components.py
@@ -142,7 +142,7 @@ def connected_components(
             num_output_shards=num_reduce_shards,
         ).write_parquet(f"{output_dir}/it_0/part-{{shard:05d}}.parquet"),
         verbose=True,
-    )
+    ).results
 
     def _get_write_shard_and_count_fn(iteration: int):
         # NOTE: this function exists to make the iteration number closure capture explicit
@@ -170,17 +170,15 @@ def connected_components(
     for i in range(1, max_iterations + 1):  # type: ignore[bad-assignment]
         logger.info(f"Connected components iteration {i}...")
 
-        shard_results = list(
-            ctx.execute(
-                Dataset.from_list(curr_it)
-                .load_parquet()
-                .map(lambda record: CCNode(**record))
-                .flat_map(_emit_messages)
-                .group_by(key=lambda x: x["key"], reducer=_reduce_node_step, num_output_shards=num_reduce_shards)
-                .map_shard(_get_write_shard_and_count_fn(i)),
-                verbose=True,
-            )
-        )
+        shard_results = ctx.execute(
+            Dataset.from_list(curr_it)
+            .load_parquet()
+            .map(lambda record: CCNode(**record))
+            .flat_map(_emit_messages)
+            .group_by(key=lambda x: x["key"], reducer=_reduce_node_step, num_output_shards=num_reduce_shards)
+            .map_shard(_get_write_shard_and_count_fn(i)),
+            verbose=True,
+        ).results
 
         curr_it = [r["path"] for r in shard_results]
         num_changes = sum(r["num_changes"] for r in shard_results)

--- a/lib/marin/src/marin/processing/classification/deduplication/exact.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/exact.py
@@ -161,24 +161,22 @@ def dedup_exact_paragraph(
                     yield {"file_idx": path_to_idx[path], "id": hash_record.pop("doc_id"), **hash_record}
 
     file_groups = group_files(input_files, max_parallelism)
-    shard_results = list(
-        ctx.execute(
-            Dataset.from_list(file_groups)
-            .flat_map(_flat_map_paragraph_hashes)
-            .group_by(
-                lambda record: record["hash"],
-                # NOTE: selecting the canonical record is deterministic via this sort
-                sort_by=lambda record: record["id"],
-                reducer=annotate_dups,
-            )
-            .group_by(
-                lambda r: r["file_idx"],
-                sort_by=lambda r: r["id"],
-                reducer=aggregate_and_write_to_corresponding_files,
-            ),
-            verbose=True,
+    shard_results = ctx.execute(
+        Dataset.from_list(file_groups)
+        .flat_map(_flat_map_paragraph_hashes)
+        .group_by(
+            lambda record: record["hash"],
+            # NOTE: selecting the canonical record is deterministic via this sort
+            sort_by=lambda record: record["id"],
+            reducer=annotate_dups,
+        )
+        .group_by(
+            lambda r: r["file_idx"],
+            sort_by=lambda r: r["id"],
+            reducer=aggregate_and_write_to_corresponding_files,
         ),
-    )
+        verbose=True,
+    ).results
 
     return finalize_dedup(shard_results, DedupMode.EXACT_PARAGRAPH, method="exact", level="paragraph")
 
@@ -247,19 +245,17 @@ def dedup_exact_document(
                     yield {"file_idx": path_to_idx[path], **hash_record}
 
     file_groups = group_files(input_files, max_parallelism)
-    shard_results = list(
-        ctx.execute(
-            Dataset.from_list(file_groups)
-            .flat_map(_flat_map_document_hashes)
-            .group_by(
-                lambda record: record["hash"],
-                # NOTE: selecting the canonical record is deterministic via this sort
-                sort_by=lambda record: record["id"],
-                reducer=annotate_dups,
-            )
-            .group_by(lambda r: r["file_idx"], sort_by=lambda r: r["id"], reducer=aggregate_and_write),
-            verbose=True,
-        ),
-    )
+    shard_results = ctx.execute(
+        Dataset.from_list(file_groups)
+        .flat_map(_flat_map_document_hashes)
+        .group_by(
+            lambda record: record["hash"],
+            # NOTE: selecting the canonical record is deterministic via this sort
+            sort_by=lambda record: record["id"],
+            reducer=annotate_dups,
+        )
+        .group_by(lambda r: r["file_idx"], sort_by=lambda r: r["id"], reducer=aggregate_and_write),
+        verbose=True,
+    ).results
 
     return finalize_dedup(shard_results, DedupMode.EXACT_DOCUMENT, method="exact", level="document")

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy.py
@@ -130,24 +130,22 @@ def dedup_fuzzy_document(
         counter_prefix="dedup/fuzzy/document",
     )
 
-    shard_results = list(
-        ctx.execute(
-            Dataset.from_list(cc_files)
-            .load_parquet()
-            .map(
-                lambda r: {
-                    "id": r["record_id"],
-                    "is_dup": r["component_id"] != r["id_norm"],
-                    "file_idx": r["file_idx"],
-                }
-            )
-            .group_by(
-                lambda r: r["file_idx"],
-                sort_by=lambda r: r["id"],
-                reducer=aggregate_and_write,
-            ),
-            verbose=True,
+    shard_results = ctx.execute(
+        Dataset.from_list(cc_files)
+        .load_parquet()
+        .map(
+            lambda r: {
+                "id": r["record_id"],
+                "is_dup": r["component_id"] != r["id_norm"],
+                "file_idx": r["file_idx"],
+            }
+        )
+        .group_by(
+            lambda r: r["file_idx"],
+            sort_by=lambda r: r["id"],
+            reducer=aggregate_and_write,
         ),
-    )
+        verbose=True,
+    ).results
 
     return finalize_dedup(shard_results, DedupMode.FUZZY_DOCUMENT, method="fuzzy", level="document")

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -352,14 +352,12 @@ def tokenize(config: TokenizeConfigBase):
             resources=ResourceConfig(cpu=1, ram="1g"),
             name="tokenize-filescan",
         )
-        file_stats = list(
-            scan_ctx.execute(
-                Dataset.from_list(batched_paths).flat_map(
-                    lambda batch: [{"filename": p, "size": fsspec_size(p)} for p in batch]
-                ),
-                verbose=False,
-            )
-        )
+        file_stats = scan_ctx.execute(
+            Dataset.from_list(batched_paths).flat_map(
+                lambda batch: [{"filename": p, "size": fsspec_size(p)} for p in batch]
+            ),
+            verbose=False,
+        ).results
         total_input_bytes = sum(f["size"] for f in file_stats)
         if config.num_shards is not None:
             target_group_bytes = _compute_target_group_bytes(total_input_bytes, config.num_shards)
@@ -412,7 +410,7 @@ def tokenize(config: TokenizeConfigBase):
         ctx.put("tokenizer_backend", config.tokenizer_backend)
 
         tokenize_start = time.monotonic()
-        shard_paths = ctx.execute(temp_shards)
+        shard_paths = ctx.execute(temp_shards).results
         tokenize_elapsed = time.monotonic() - tokenize_start
 
         logger.info("Computing exemplar for cache consolidation")
@@ -422,7 +420,7 @@ def tokenize(config: TokenizeConfigBase):
             .take_per_shard(1)
             .map_shard(lambda example, _: _tokenize_batches(config=config, batches=[example])),
             verbose=False,
-        )[0]
+        ).results[0]
 
         consolidate_start = time.monotonic()
         logger.info(f"Consolidating {len(shard_paths)} shards into {prefix}")

--- a/lib/marin/src/marin/transform/conversation/transform_conversation.py
+++ b/lib/marin/src/marin/transform/conversation/transform_conversation.py
@@ -398,7 +398,7 @@ def transform_hf_dataset(cfg: TransformSFTDatasetConfig):
         .write_jsonl(f"{metrics_path}/{{shard:05d}}-transform.jsonl", skip_existing=True)
     )
     ctx = ZephyrContext(name="transform-conversation")
-    metric_files = ctx.execute(pipeline)
+    metric_files = ctx.execute(pipeline).results
 
     # Log summary by subset/split
     by_subset_split = defaultdict(list)

--- a/lib/marin/src/marin/transform/conversation/transform_preference_data.py
+++ b/lib/marin/src/marin/transform/conversation/transform_preference_data.py
@@ -288,7 +288,7 @@ def transform_hf_preference_dataset(cfg: TransformPreferenceDatasetConfig):
     # Process all tasks in parallel
     pipeline = Dataset.from_list(tasks).map(process_split_task)
     ctx = ZephyrContext(name="transform-preference")
-    results = ctx.execute(pipeline)
+    results = ctx.execute(pipeline).results
 
     # Log summary
     for result in results:

--- a/lib/marin/src/marin/transform/lingoly/to_dolma.py
+++ b/lib/marin/src/marin/transform/lingoly/to_dolma.py
@@ -78,7 +78,7 @@ def convert_lingoly_to_dolma(config: ConvertLingolyToDolmaConfig) -> None:
         .write_jsonl(f"{config.output_path}/{{shard:05d}}.jsonl")
     )
     ctx = ZephyrContext(name="lingoly-to-dolma")
-    list(ctx.execute(pipeline))
+    ctx.execute(pipeline)
 
 
 @draccus.wrap()

--- a/lib/marin/src/marin/transform/medical/lavita_to_dolma.py
+++ b/lib/marin/src/marin/transform/medical/lavita_to_dolma.py
@@ -140,7 +140,7 @@ def convert_lavita_split_to_dolma(cfg: LavitaToDolmaConfig) -> None:
         .write_parquet(f"{cfg.output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet")
     )
     ctx = ZephyrContext(name="lavita-to-dolma")
-    list(ctx.execute(pipeline))
+    ctx.execute(pipeline)
 
 
 if __name__ == "__main__":

--- a/lib/marin/src/marin/transform/simple_html_to_md/process.py
+++ b/lib/marin/src/marin/transform/simple_html_to_md/process.py
@@ -82,4 +82,4 @@ def html_to_md(cfg: SimpleHtmlToMdConfig):
         .write_jsonl(f"{cfg.output_path}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz")
     )
     ctx = ZephyrContext(name="html-to-md")
-    list(ctx.execute(pipeline))
+    ctx.execute(pipeline)

--- a/lib/marin/src/marin/transform/wikipedia/transform_wikipedia.py
+++ b/lib/marin/src/marin/transform/wikipedia/transform_wikipedia.py
@@ -300,4 +300,4 @@ def process_wiki_dump(cfg: WikiExtractionConfig) -> None:
         .write_jsonl(f"{output_base}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz", skip_existing=True)
     )
     ctx = ZephyrContext(name="transform-wikipedia")
-    list(ctx.execute(pipeline))
+    ctx.execute(pipeline)

--- a/lib/marin/src/marin/validate/validate.py
+++ b/lib/marin/src/marin/validate/validate.py
@@ -155,7 +155,7 @@ def main(cfg: ValidationConfig) -> None:
     )
 
     ctx = ZephyrContext(name="validate")
-    result = list(ctx.execute(pipeline))
+    result = ctx.execute(pipeline).results
     print(f"Validation complete: {result[0]}")
 
 

--- a/lib/zephyr/README.md
+++ b/lib/zephyr/README.md
@@ -16,7 +16,7 @@ pipeline = (
     .map(lambda x: transform_record(x))
     .write_jsonl("gs://output/data-{shard:05d}-of-{total:05d}.jsonl.gz")
 )
-list(ctx.execute(pipeline))
+ctx.execute(pipeline)
 ```
 
 ## Key Patterns
@@ -44,7 +44,7 @@ list(ctx.execute(pipeline))
 **Execution (`ZephyrContext`):**
 - `ZephyrContext(max_workers=N)` — auto-detects backend (Ray, Iris, or local) via `fray.v2.current_client()`
 - `ZephyrContext(client=LocalClient())` — explicit local backend (testing)
-- `list(ctx.execute(pipeline))` — runs the pipeline and returns results
+- `ctx.execute(pipeline)` — runs the pipeline; returns a `ZephyrExecutionResult(results, counters)`
 
 ## Real Usage
 
@@ -60,7 +60,7 @@ pipeline = (
     .filter(lambda x: x is not None)
     .write_jsonl(f"{output}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz")
 )
-list(ctx.execute(pipeline))
+ctx.execute(pipeline)
 ```
 
 **Dataset Sampling:**
@@ -73,7 +73,7 @@ pipeline = (
     .map(lambda path: sample_file(path, weights))
     .write_jsonl(f"{output}/sampled-{{shard:05d}}.jsonl.gz")
 )
-list(ctx.execute(pipeline))
+ctx.execute(pipeline)
 ```
 
 **Parallel Downloads:**
@@ -83,7 +83,7 @@ from zephyr import Dataset, ZephyrContext
 tasks = [(config, fs, src, dst) for src, dst in file_pairs]
 ctx = ZephyrContext(max_workers=32)
 pipeline = Dataset.from_list(tasks).map(lambda t: download(*t))
-list(ctx.execute(pipeline))
+ctx.execute(pipeline)
 ```
 
 ## Installation

--- a/lib/zephyr/src/zephyr/__init__.py
+++ b/lib/zephyr/src/zephyr/__init__.py
@@ -7,7 +7,13 @@ import logging
 
 from zephyr import counters
 from zephyr.dataset import Dataset, ShardInfo
-from zephyr.execution import CounterSnapshot, WorkerContext, ZephyrContext, zephyr_worker_ctx
+from zephyr.execution import (
+    CounterSnapshot,
+    WorkerContext,
+    ZephyrContext,
+    ZephyrExecutionResult,
+    zephyr_worker_ctx,
+)
 from zephyr.expr import Expr, col, lit
 from zephyr.plan import compute_plan
 from zephyr.readers import InputFileSpec, load_file, load_jsonl, load_parquet, load_vortex, load_zip_members
@@ -23,6 +29,7 @@ __all__ = [
     "ShardInfo",
     "WorkerContext",
     "ZephyrContext",
+    "ZephyrExecutionResult",
     "atomic_rename",
     "col",
     "compute_plan",

--- a/lib/zephyr/src/zephyr/dataset.py
+++ b/lib/zephyr/src/zephyr/dataset.py
@@ -310,7 +310,7 @@ class Dataset(Generic[T]):
         ...     .filter(lambda x: x % 2 == 0)
         ...     .map(lambda x: x * 2)
         ... )
-        >>> results = ctx.execute(ds)
+        >>> results = ctx.execute(ds).results
         [4, 8]
     """
 
@@ -360,7 +360,7 @@ class Dataset(Generic[T]):
             ...     .map(lambda path: process_file(path))
             ...     .write_jsonl("/output/data-{shard:05d}.jsonl.gz")
             ... )
-            >>> output_files = ctx.execute(ds)
+            >>> output_files = ctx.execute(ds).results
         """
         # Normalize double slashes while preserving protocol (e.g., gs://, s3://, http://)
         pattern = re.sub(r"(?<!:)//+", "/", pattern)
@@ -527,7 +527,7 @@ class Dataset(Generic[T]):
             ...     .filter(lambda r: r["score"] > 0.5)
             ...     .write_jsonl("/output/filtered-{shard:05d}.jsonl.gz")
             ... )
-            >>> output_files = ctx.execute(ds)
+            >>> output_files = ctx.execute(ds).results
         """
         return Dataset(self.source, [*self.operations, FlatMapOp(fn)])
 
@@ -547,7 +547,7 @@ class Dataset(Generic[T]):
             ...     .filter(lambda r: r["score"] > 0.5)
             ...     .write_jsonl("/output/filtered-{shard:05d}.jsonl.gz")
             ... )
-            >>> output_files = ctx.execute(ds)
+            >>> output_files = ctx.execute(ds).results
         """
         return Dataset(self.source, [*self.operations, LoadFileOp("auto", columns)])
 
@@ -598,7 +598,7 @@ class Dataset(Generic[T]):
             ...     .map_shard(deduplicate_shard)
             ...     .write_jsonl("output/deduped-{shard:05d}.jsonl.gz")
             ... )
-            >>> output_files = ctx.execute(ds)
+            >>> output_files = ctx.execute(ds).results
         """
         return Dataset(self.source, [*self.operations, MapShardOp(fn)])
 
@@ -625,7 +625,7 @@ class Dataset(Generic[T]):
             ...     .reshard(num_shards=20)              # Redistribute to 20 shards
             ...     .map(expensive_transform)            # Now uses up to 20 workers
             ... )
-            >>> output_files = ctx.execute(ds)
+            >>> output_files = ctx.execute(ds).results
         """
         if num_shards is not None and num_shards <= 0:
             raise ValueError(f"num_shards must be positive, got {num_shards}")
@@ -880,7 +880,7 @@ class Dataset(Generic[T]):
 
         Example:
             >>> ds = Dataset.from_list(range(100)).reduce(sum)
-            >>> result = list(ctx.execute(ds))[0]
+            >>> result = ctx.execute(ds).results[0]
             4950
         """
         if global_reducer is None:
@@ -896,7 +896,7 @@ class Dataset(Generic[T]):
 
         Example:
             >>> ds = Dataset.from_list(range(100)).filter(lambda x: x % 2 == 0)
-            >>> count = list(ctx.execute(ds.count()))[0]
+            >>> count = ctx.execute(ds.count()).results[0]
             50
         """
         return self.reduce(

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -27,7 +27,7 @@ import time
 import uuid
 from collections import defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor
-from collections.abc import Callable, Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator
 from contextlib import suppress
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -1340,6 +1340,25 @@ def _regroup_result_refs(
 
 
 @dataclass(frozen=True)
+class ZephyrExecutionResult:
+    """Result of running a Zephyr pipeline.
+
+    This is also the wire format pickled by ``_run_coordinator_job`` into the
+    result file, so callers of ``ZephyrContext.execute`` receive it as-is.
+
+    Attributes:
+        results: Flat list of items produced by the terminal stage of the
+            pipeline (e.g. output file paths for write stages).
+        counters: Aggregated counter values from the run, including built-in
+            zephyr counters (e.g. ``zephyr/records_in``) and any user counters
+            recorded via ``zephyr.counters.increment``.
+    """
+
+    results: list
+    counters: dict[str, int]
+
+
+@dataclass(frozen=True)
 class _CoordinatorJobConfig:
     """Serializable config for the coordinator job entrypoint."""
 
@@ -1421,10 +1440,12 @@ def _run_coordinator_job(config_path: str, result_path: str) -> None:
 
     try:
         results = coordinator.run_pipeline.submit(config.plan, config.execution_id).result()
+        counters = coordinator.get_counters.remote().result(timeout=10.0) or {}
+        payload = ZephyrExecutionResult(results=results, counters=counters)
 
         ensure_parent_dir(result_path)
         with open_url(result_path, "wb") as f:
-            f.write(cloudpickle.dumps(results))
+            f.write(cloudpickle.dumps(payload))
     except Exception as e:
         # Persist the exception so the caller can recover the original type
         # (important for non-retryable error detection).
@@ -1572,7 +1593,7 @@ class ZephyrContext:
         dataset: Dataset,
         verbose: bool = False,
         dry_run: bool = False,
-    ) -> Sequence:
+    ) -> ZephyrExecutionResult:
         """Execute a dataset pipeline.
 
         Submits a coordinator *job* that creates coordinator and worker
@@ -1580,12 +1601,19 @@ class ZephyrContext:
         disk. If the coordinator job dies (e.g., VM preemption), the
         pipeline is retried up to ``max_execution_retries`` times.
         Application errors (``ZephyrWorkerError``) are never retried.
+
+        Returns:
+            A ``ZephyrExecutionResult`` containing the flat list of results
+            produced by the terminal stage and the aggregated counters from
+            the run. Callers that only care about the results should access
+            ``.results``; counters are exposed for callers that want to
+            persist or surface them.
         """
         plan = compute_plan(dataset)
         if verbose or dry_run:
             _print_plan(dataset.operations, plan)
         if dry_run:
-            return []
+            return ZephyrExecutionResult(results=[], counters={})
 
         # NOTE: pipeline ID incremented on clean completion only
         self._pipeline_id += 1
@@ -1645,10 +1673,10 @@ class ZephyrContext:
 
                 # Read results written by the coordinator job.
                 # This must succeed — the job completed successfully.
-                result = _read_coordinator_result(result_path)
-                if isinstance(result, Exception):
-                    raise result
-                return result
+                payload = _read_coordinator_result(result_path)
+                if isinstance(payload, Exception):
+                    raise payload
+                return payload
 
             except _NON_RETRYABLE_ERRORS:
                 raise

--- a/lib/zephyr/src/zephyr/readers.py
+++ b/lib/zephyr/src/zephyr/readers.py
@@ -205,12 +205,12 @@ def load_jsonl(source: str | InputFileSpec) -> Iterator[dict]:
         ...     .filter(lambda r: r["score"] > 0.5)
         ...     .write_jsonl("/output/filtered-{shard:05d}.jsonl.gz")
         ... )
-        >>> output_files = list(ctx.execute(ds))
+        >>> output_files = ctx.execute(ds).results
         >>>
         >>> # Load from HuggingFace Hub (requires HF_TOKEN env var)
         >>> hf_url = "hf://datasets/username/dataset@main/data/train.jsonl.gz"
         >>> ds = Dataset.from_list([hf_url]).flat_map(load_jsonl)
-        >>> records = list(ctx.execute(ds))
+        >>> records = ctx.execute(ds).results
     """
     spec = _as_spec(source)
     decoder = msgspec.json.Decoder()
@@ -245,7 +245,7 @@ def load_parquet(source: str | InputFileSpec) -> Iterator[dict]:
         ...     .map(lambda r: transform_record(r))
         ...     .write_jsonl("/output/data-{shard:05d}.jsonl.gz")
         ... )
-        >>> output_files = list(ctx.execute(ds))
+        >>> output_files = ctx.execute(ds).results
     """
     spec = _as_spec(source)
     logger.info("Loading: %s", spec.path)
@@ -302,7 +302,7 @@ def load_vortex(source: str | InputFileSpec) -> Iterator[dict]:
         ...     .filter(lambda r: r["score"] > 0.5)
         ...     .write_jsonl("/output/filtered-{shard:05d}.jsonl.gz")
         ... )
-        >>> output_files = list(ctx.execute(ds))
+        >>> output_files = ctx.execute(ds).results
     """
     import vortex
 
@@ -375,7 +375,7 @@ def load_file(source: str | InputFileSpec) -> Iterator[dict]:
         ...     .filter(lambda r: r["score"] > 0.5)
         ...     .write_jsonl("/output/data-{shard:05d}.jsonl.gz")
         ... )
-        >>> output_files = list(ctx.execute(ds))
+        >>> output_files = ctx.execute(ds).results
     """
     spec = _as_spec(source)
     logger.info("Loading file: %s", spec.path)
@@ -418,7 +418,7 @@ def load_zip_members(source: str | InputFileSpec, pattern: str = "*") -> Iterato
         ...     .flat_map(lambda p: load_zip_members(p, pattern="test.jsonl"))
         ...     .map(lambda m: process_file(m["filename"], m["content"]))
         ... )
-        >>> output_files = list(ctx.execute(ds))
+        >>> output_files = ctx.execute(ds).results
     """
     spec = _as_spec(source)
     with open_url(spec.path, "rb") as f:

--- a/lib/zephyr/tests/benchmark_dedup_pipeline.py
+++ b/lib/zephyr/tests/benchmark_dedup_pipeline.py
@@ -136,7 +136,7 @@ def run_benchmark(
         mem_before = process.memory_info().rss
         exec_start = time.time()
         ctx = ZephyrContext(name="benchmark")
-        results = list(ctx.execute(pipeline))
+        results = ctx.execute(pipeline).results
         exec_time = time.time() - exec_start
         mem_after = process.memory_info().rss
 

--- a/lib/zephyr/tests/test_counters.py
+++ b/lib/zephyr/tests/test_counters.py
@@ -4,7 +4,7 @@
 """Tests for Zephyr user-defined counters: worker API and heartbeat plumbing."""
 
 from zephyr import counters
-from zephyr.execution import CounterSnapshot, _worker_ctx_var
+from zephyr.execution import CounterSnapshot, ZephyrExecutionResult, _worker_ctx_var
 
 
 class FakeWorker:
@@ -48,3 +48,17 @@ def test_counters_noop_outside_worker():
         assert counters.get_counters() == {}
     finally:
         _worker_ctx_var.reset(token)
+
+
+def test_zephyr_execution_result_fields():
+    """ZephyrExecutionResult exposes both results and counters."""
+    result = ZephyrExecutionResult(results=["a.jsonl", "b.jsonl"], counters={"docs": 7})
+    assert result.results == ["a.jsonl", "b.jsonl"]
+    assert result.counters == {"docs": 7}
+
+
+def test_zephyr_execution_result_empty():
+    """ZephyrExecutionResult handles empty results and counters (e.g. dry_run)."""
+    result = ZephyrExecutionResult(results=[], counters={})
+    assert result.results == []
+    assert result.counters == {}

--- a/lib/zephyr/tests/test_dataset.py
+++ b/lib/zephyr/tests/test_dataset.py
@@ -27,7 +27,7 @@ def sample_data():
 def test_from_list(sample_data, zephyr_ctx):
     """Test creating dataset from list."""
     ds = Dataset.from_list(sample_data)
-    assert list(zephyr_ctx.execute(ds)) == sample_data
+    assert zephyr_ctx.execute(ds).results == sample_data
 
 
 def test_dataclass_round_trip_preserves_type(zephyr_ctx):
@@ -35,34 +35,34 @@ def test_dataclass_round_trip_preserves_type(zephyr_ctx):
     items = [SampleDataclass("alpha", 1), SampleDataclass("beta", 2)]
 
     ds = Dataset.from_list(items)
-    result = list(zephyr_ctx.execute(ds))
+    result = zephyr_ctx.execute(ds).results
 
     assert [item.name for item in result] == ["alpha", "beta"]
     assert all(isinstance(item, SampleDataclass) for item in result)
 
     doubled = Dataset.from_list(items).map(lambda x: x.value * 2)
-    assert list(zephyr_ctx.execute(doubled)) == [2, 4]
+    assert zephyr_ctx.execute(doubled).results == [2, 4]
 
 
 def test_from_iterable(zephyr_ctx):
     """Test creating dataset from iterable."""
     ds = Dataset.from_iterable(range(5))
-    assert list(zephyr_ctx.execute(ds)) == [0, 1, 2, 3, 4]
+    assert zephyr_ctx.execute(ds).results == [0, 1, 2, 3, 4]
 
 
 def test_filter(sample_data, zephyr_ctx):
     """Test filtering dataset."""
     ds = Dataset.from_list(sample_data).filter(lambda x: x % 2 == 0)
-    assert list(zephyr_ctx.execute(ds)) == [2, 4, 6, 8, 10]
+    assert zephyr_ctx.execute(ds).results == [2, 4, 6, 8, 10]
 
 
 def test_take_per_shard(zephyr_ctx):
     ds = Dataset.from_list([list(range(10))]).flat_map(lambda x: x).take_per_shard(5)
-    result = list(zephyr_ctx.execute(ds))
+    result = zephyr_ctx.execute(ds).results
     assert result == [0, 1, 2, 3, 4]
 
     ds = Dataset.from_list([list(range(10))]).flat_map(lambda x: x).take_per_shard(0)
-    result = list(zephyr_ctx.execute(ds))
+    result = zephyr_ctx.execute(ds).results
     assert result == []
 
     # Create 3 shards with 5 items each
@@ -72,7 +72,7 @@ def test_take_per_shard(zephyr_ctx):
         .take_per_shard(2)
     )
 
-    result = sorted(list(zephyr_ctx.execute(ds)))
+    result = sorted(zephyr_ctx.execute(ds).results)
     # Each of 3 shards contributes 2 items = 6 total
     # Shard 0: [0, 1], Shard 1: [5, 6], Shard 2: [10, 11]
     assert result == [0, 1, 5, 6, 10, 11]
@@ -87,14 +87,14 @@ def test_take_with_filter_and_map(zephyr_ctx):
         .take_per_shard(5)  # [0, 2, 4, 6, 8]
         .map(lambda x: x * 2)  # [0, 4, 8, 12, 16]
     )
-    result = list(zephyr_ctx.execute(ds))
+    result = zephyr_ctx.execute(ds).results
     assert result == [0, 4, 8, 12, 16]
 
 
 def test_window(zephyr_ctx):
     """Test window operation (same as batch)."""
     ds = Dataset.from_list([[1, 2, 3, 4, 5]]).flat_map(lambda x: x).window(2)
-    windows = list(zephyr_ctx.execute(ds))
+    windows = zephyr_ctx.execute(ds).results
     assert windows == [[1, 2], [3, 4], [5]]
 
 
@@ -117,7 +117,7 @@ def test_window_by_size_based(zephyr_ctx):
         )
     )
 
-    windows = list(zephyr_ctx.execute(ds))
+    windows = zephyr_ctx.execute(ds).results
     # Window 1: [id=1 (5GB)] - total 5GB
     # Window 2: [id=2 (6GB), id=3 (3GB)] - total 9GB
     # Window 3: [id=4 (8GB)] - total 8GB
@@ -146,7 +146,7 @@ def test_window_by_count_based(zephyr_ctx):
         )
     )
 
-    windows = list(zephyr_ctx.execute(ds))
+    windows = zephyr_ctx.execute(ds).results
     # Window 1: [1, 2, 3] - sum = 6
     # Window 2: [4, 5] - sum = 9
     # Window 3: [6] - sum = 6
@@ -160,7 +160,7 @@ def test_window_by_count_based(zephyr_ctx):
 def test_map(zephyr_ctx):
     """Test map operation with all backends."""
     ds = Dataset.from_list([1, 2, 3, 4, 5]).map(lambda x: x * 2)
-    result = list(zephyr_ctx.execute(ds))
+    result = zephyr_ctx.execute(ds).results
     assert sorted(result) == [2, 4, 6, 8, 10]
 
 
@@ -177,7 +177,7 @@ def test_chaining_operations(zephyr_ctx):
         .window(2)  # [[4, 8], [12, 16], [20]]
     )
 
-    result = list(zephyr_ctx.execute(ds))
+    result = zephyr_ctx.execute(ds).results
 
     # Flatten and sort for comparison since some backends may reorder
     flattened = [item for batch in result for item in batch]
@@ -199,10 +199,10 @@ def test_lazy_evaluation():
 def test_empty_dataset(zephyr_ctx):
     """Test operations on empty dataset."""
     ds = Dataset.from_list([])
-    assert list(zephyr_ctx.execute(ds)) == []
-    assert list(zephyr_ctx.execute(ds.filter(lambda x: True))) == []
-    assert list(zephyr_ctx.execute(ds.map(lambda x: x * 2))) == []
-    assert list(zephyr_ctx.execute(ds.window(10))) == []
+    assert zephyr_ctx.execute(ds).results == []
+    assert zephyr_ctx.execute(ds.filter(lambda x: True)).results == []
+    assert zephyr_ctx.execute(ds.map(lambda x: x * 2)).results == []
+    assert zephyr_ctx.execute(ds.window(10)).results == []
 
 
 def test_reshard(zephyr_ctx):
@@ -214,17 +214,17 @@ def test_reshard(zephyr_ctx):
         .reshard(5)  # Redistribute to 5 shards
         .map(lambda x: x * 2)
     )
-    result = sorted(zephyr_ctx.execute(ds))
+    result = sorted(zephyr_ctx.execute(ds).results)
     assert result == [x * 2 for x in range(50)]
 
     # Test 2: Start with many items, reshard to fewer
     ds = Dataset.from_list(range(50)).reshard(5).map(lambda x: x + 100)  # 50 shards  # Consolidate to 5 shards
-    result = sorted(zephyr_ctx.execute(ds))
+    result = sorted(zephyr_ctx.execute(ds).results)
     assert result == [x + 100 for x in range(50)]
 
     # Test 3: Reshard preserves order when materializing all shards
     ds = Dataset.from_list(range(10)).reshard(3)
-    result = list(zephyr_ctx.execute(ds))
+    result = zephyr_ctx.execute(ds).results
     assert sorted(result) == list(range(10))
 
 
@@ -235,10 +235,10 @@ def test_reshard_noop(zephyr_ctx):
         yield from [1]
 
     ds = Dataset.from_list(range(10)).reshard(None).map_shard(yield_1)
-    assert sum(list(zephyr_ctx.execute(ds))) == 10
+    assert sum(zephyr_ctx.execute(ds).results) == 10
 
     ds = Dataset.from_list(range(10)).reshard(2).map_shard(yield_1)
-    assert sum(list(zephyr_ctx.execute(ds))) == 2
+    assert sum(zephyr_ctx.execute(ds).results) == 2
 
     with pytest.raises(ValueError, match="num_shards must be positive"):
         Dataset.from_list(range(10)).reshard(-5)
@@ -256,7 +256,7 @@ def test_complex_pipeline(zephyr_ctx):
         .filter(lambda item: item["label"] == "even")  # Even items only
     )
 
-    result = list(zephyr_ctx.execute(ds))
+    result = zephyr_ctx.execute(ds).results
     assert len(result) == 8  # 6, 8, 10, 12, 14, 16, 18, 20
     assert all(item["label"] == "even" for item in result)
     assert all(item["value"] % 2 == 0 for item in result)
@@ -367,7 +367,7 @@ def test_from_files_with_map(tmp_path, zephyr_ctx):
         .write_jsonl(str(output_dir / "output-{shard:05d}.jsonl"))
     )
 
-    result = list(zephyr_ctx.execute(ds))
+    result = zephyr_ctx.execute(ds).results
 
     # Verify output files were created
     assert len(result) == 3
@@ -392,7 +392,7 @@ def test_write_and_read_parquet(tmp_path, zephyr_ctx):
     # Write to parquet
     ds = Dataset.from_list(sample_data).write_parquet(str(output_dir / "data-{shard:05d}.parquet"))
 
-    output_files = list(zephyr_ctx.execute(ds))
+    output_files = zephyr_ctx.execute(ds).results
 
     # Verify output files were created
     assert len(output_files) > 0
@@ -402,7 +402,7 @@ def test_write_and_read_parquet(tmp_path, zephyr_ctx):
     # Read back from parquet
     ds_read = Dataset.from_files(f"{output_dir}/*.parquet").flat_map(load_parquet)
 
-    records = list(zephyr_ctx.execute(ds_read))
+    records = zephyr_ctx.execute(ds_read).results
 
     # Verify data integrity
     assert len(records) == len(sample_data)
@@ -433,7 +433,7 @@ def test_write_and_read_parquet_nested(tmp_path, zephyr_ctx):
     # Write to parquet
     ds = Dataset.from_list(sample_data).write_parquet(str(output_dir / "nested-{shard:05d}.parquet"))
 
-    output_files = list(zephyr_ctx.execute(ds))
+    output_files = zephyr_ctx.execute(ds).results
 
     # Verify output files were created
     assert len(output_files) > 0
@@ -442,7 +442,7 @@ def test_write_and_read_parquet_nested(tmp_path, zephyr_ctx):
     # Read back from parquet
     ds_read = Dataset.from_files(f"{output_dir}/*.parquet").flat_map(load_parquet)
 
-    records = list(zephyr_ctx.execute(ds_read))
+    records = zephyr_ctx.execute(ds_read).results
 
     # Verify data integrity
     assert len(records) == len(sample_data)
@@ -475,14 +475,14 @@ def test_write_dataclass(tmp_path, zephyr_ctx, output_format: str):
     else:
         ds = Dataset.from_list(sample_data).write_parquet(str(output_dir / "dataclass-{shard:05d}.parquet"))
 
-    output_files = list(zephyr_ctx.execute(ds))
+    output_files = zephyr_ctx.execute(ds).results
 
     # Verify output files were created
     assert len(output_files) > 0
 
     ds_read = Dataset.from_files(f"{output_dir}/*.{output_format}").flat_map(load_file)
 
-    records = list(zephyr_ctx.execute(ds_read))
+    records = zephyr_ctx.execute(ds_read).results
 
     # Verify data integrity
     assert len(records) == len(sample_data)
@@ -510,11 +510,11 @@ def test_load_file_parquet(tmp_path, zephyr_ctx):
 
     # Write to parquet with shard pattern
     ds = Dataset.from_list(sample_data).write_parquet(str(output_dir / "test-{shard:05d}.parquet"))
-    _ = list(zephyr_ctx.execute(ds))
+    _ = zephyr_ctx.execute(ds).results
 
     # Load using load_file
     ds_read = Dataset.from_files(f"{output_dir}/*.parquet").flat_map(load_file)
-    records = list(zephyr_ctx.execute(ds_read))
+    records = zephyr_ctx.execute(ds_read).results
 
     # Verify data
     assert len(records) == len(sample_data)
@@ -550,11 +550,11 @@ def test_load_file_mixed_directory(tmp_path, zephyr_ctx):
     ]
 
     ds = Dataset.from_list(parquet_data).write_parquet(str(input_dir / "data-{shard:05d}.parquet"))
-    list(zephyr_ctx.execute(ds))
+    zephyr_ctx.execute(ds)
 
     # Load all files using load_file
     ds_read = Dataset.from_files(f"{input_dir}/*").flat_map(load_file)
-    records = list(zephyr_ctx.execute(ds_read))
+    records = zephyr_ctx.execute(ds_read).results
 
     # Verify we got data from both files
     assert len(records) == 4
@@ -580,7 +580,7 @@ def test_load_file_unsupported_extension(tmp_path, zephyr_ctx):
     from zephyr.execution import ZephyrWorkerError
 
     with pytest.raises(ZephyrWorkerError, match="Unsupported"):
-        list(zephyr_ctx.execute(ds))
+        zephyr_ctx.execute(ds)
 
 
 def test_write_without_shard_pattern_multiple_shards(tmp_path, zephyr_ctx):
@@ -598,7 +598,7 @@ def test_write_without_shard_pattern_multiple_shards(tmp_path, zephyr_ctx):
     from zephyr.execution import ZephyrWorkerError
 
     with pytest.raises(ZephyrWorkerError, match="Output pattern must"):
-        list(zephyr_ctx.execute(ds))
+        zephyr_ctx.execute(ds)
 
 
 def test_write_without_shard_pattern_single_shard(tmp_path, zephyr_ctx):
@@ -613,7 +613,7 @@ def test_write_without_shard_pattern_single_shard(tmp_path, zephyr_ctx):
     ds = Dataset.from_list(sample_data).write_jsonl(str(output_dir / "output.jsonl"))
 
     # Should succeed since there's only one shard
-    output_files = list(zephyr_ctx.execute(ds))
+    output_files = zephyr_ctx.execute(ds).results
     assert len(output_files) == 1
     assert Path(output_files[0]).exists()
 
@@ -621,7 +621,7 @@ def test_write_without_shard_pattern_single_shard(tmp_path, zephyr_ctx):
 def test_reduce_sum(zephyr_ctx):
     """Test basic sum reduction."""
     ds = Dataset.from_list(range(100)).reduce(sum)
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 1
     assert results[0] == sum(range(100))
 
@@ -632,7 +632,7 @@ def test_reduce_count(zephyr_ctx):
         local_reducer=lambda items: sum(1 for _ in items),
         global_reducer=sum,
     )
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 1
     assert results[0] == 50
 
@@ -665,7 +665,7 @@ def test_reduce_complex_aggregation(zephyr_ctx):
         global_reducer=global_stats,
     )
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 1
     assert results[0]["sum"] == sum(range(1, 101))
     assert results[0]["count"] == 100
@@ -676,7 +676,7 @@ def test_reduce_complex_aggregation(zephyr_ctx):
 def test_reduce_empty(zephyr_ctx):
     """Test reduce on empty dataset."""
     ds = Dataset.from_list([]).reduce(sum)
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 0
 
 
@@ -684,7 +684,7 @@ def test_reduce_with_pipeline(zephyr_ctx):
     """Test reduce integrated with other operations."""
     ds = Dataset.from_list(range(1, 21)).filter(lambda x: x % 2 == 0).map(lambda x: x * 2).reduce(sum)
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 1
     expected = sum(x * 2 for x in range(1, 21) if x % 2 == 0)
     assert results[0] == expected
@@ -693,7 +693,7 @@ def test_reduce_with_pipeline(zephyr_ctx):
 def test_count_basic(zephyr_ctx):
     """Test basic count operation."""
     ds = Dataset.from_list(range(100)).count()
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 1
     assert results[0] == 100
 
@@ -701,14 +701,14 @@ def test_count_basic(zephyr_ctx):
 def test_count_empty(zephyr_ctx):
     """Test count on empty dataset."""
     ds = Dataset.from_list([]).count()
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 0
 
 
 def test_count_with_filter(zephyr_ctx):
     """Test count with filter operation."""
     ds = Dataset.from_list(range(100)).filter(lambda x: x % 2 == 0).count()
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 1
     assert results[0] == 50
 
@@ -725,7 +725,7 @@ def test_sorted_merge_join_inner_basic(zephyr_ctx):
 
     joined = left.sorted_merge_join(right, left_key=lambda x: x["id"], right_key=lambda x: x["id"], how="inner")
 
-    results = sorted(list(zephyr_ctx.execute(joined)), key=lambda x: x["id"])
+    results = sorted(zephyr_ctx.execute(joined).results, key=lambda x: x["id"])
     assert len(results) == 2
     assert results[0] == {"id": 1, "text": "hello", "score": 0.9}
     assert results[1] == {"id": 2, "text": "world", "score": 0.3}
@@ -749,7 +749,7 @@ def test_sorted_merge_join_left(zephyr_ctx):
         how="left",
     )
 
-    results = sorted(list(zephyr_ctx.execute(joined)), key=lambda x: x["id"])
+    results = sorted(zephyr_ctx.execute(joined).results, key=lambda x: x["id"])
     assert len(results) == 2
     assert results[0] == {"id": 1, "text": "hello", "score": 0.9}
     assert results[1] == {"id": 2, "text": "world", "score": 0.0}
@@ -771,7 +771,7 @@ def test_sorted_merge_join_duplicate_keys(zephyr_ctx):
 
     joined = left.sorted_merge_join(right, left_key=lambda x: x["id"], right_key=lambda x: x["id"], how="inner")
 
-    results = sorted(list(zephyr_ctx.execute(joined)), key=lambda x: (x["text"], x["score"]))
+    results = sorted(zephyr_ctx.execute(joined).results, key=lambda x: (x["text"], x["score"]))
     assert len(results) == 4
     assert results[0] == {"id": 1, "text": "a", "score": 0.3}
     assert results[1] == {"id": 1, "text": "a", "score": 0.9}
@@ -805,7 +805,7 @@ def test_sorted_merge_join_after_group_by(zephyr_ctx):
 
     joined = docs.sorted_merge_join(attrs, left_key=lambda x: x["id"], right_key=lambda x: x["id"], how="inner")
 
-    results = sorted(list(zephyr_ctx.execute(joined)), key=lambda x: x["id"])
+    results = sorted(zephyr_ctx.execute(joined).results, key=lambda x: x["id"])
     assert len(results) == 3
     assert results[0] == {"id": 1, "text": "hello updated", "version": 2, "quality": 0.9}
     assert results[1] == {"id": 2, "text": "world", "version": 1, "quality": 0.3}
@@ -828,7 +828,7 @@ def test_sorted_merge_join_shard_mismatch(zephyr_ctx):
     joined = left.sorted_merge_join(right, left_key=lambda x: x["id"], right_key=lambda x: x["id"], how="inner")
 
     with pytest.raises(ValueError, match="Sorted merge join requires equal shard counts"):
-        list(zephyr_ctx.execute(joined))
+        zephyr_ctx.execute(joined)
 
 
 def test_sorted_merge_join_empty_datasets(zephyr_ctx):
@@ -842,7 +842,7 @@ def test_sorted_merge_join_empty_datasets(zephyr_ctx):
     )
 
     joined = left.sorted_merge_join(right, left_key=lambda x: x["id"], right_key=lambda x: x["id"], how="inner")
-    assert list(zephyr_ctx.execute(joined)) == []
+    assert zephyr_ctx.execute(joined).results == []
 
     # Empty right dataset
     left = Dataset.from_list([{"id": 1, "text": "hello"}]).group_by(
@@ -853,7 +853,7 @@ def test_sorted_merge_join_empty_datasets(zephyr_ctx):
     )
 
     joined = left.sorted_merge_join(right, left_key=lambda x: x["id"], right_key=lambda x: x["id"], how="inner")
-    assert list(zephyr_ctx.execute(joined)) == []
+    assert zephyr_ctx.execute(joined).results == []
 
 
 def test_map_shard_stateful_deduplication(zephyr_ctx):
@@ -876,7 +876,7 @@ def test_map_shard_stateful_deduplication(zephyr_ctx):
     ]
 
     ds = Dataset.from_list([data]).flat_map(lambda x: x).map_shard(deduplicate_shard)
-    result = sorted(list(zephyr_ctx.execute(ds)), key=lambda x: x["id"])
+    result = sorted(zephyr_ctx.execute(ds).results, key=lambda x: x["id"])
 
     # Should keep first occurrence of each id
     assert len(result) == 3
@@ -894,7 +894,7 @@ def test_map_shard_empty_result(zephyr_ctx):
         return iter([])  # Return empty iterator
 
     ds = Dataset.from_list([list(range(1, 6))]).flat_map(lambda x: x).map_shard(filter_all)
-    result = list(zephyr_ctx.execute(ds))
+    result = zephyr_ctx.execute(ds).results
     assert result == []
 
 
@@ -912,7 +912,7 @@ def test_map_shard_error_propagation(zephyr_ctx):
     from zephyr.execution import ZephyrWorkerError
 
     with pytest.raises(ZephyrWorkerError, match="Test error"):
-        list(zephyr_ctx.execute(ds))
+        zephyr_ctx.execute(ds)
 
 
 def test_map_shard_with_shard_info(zephyr_ctx):
@@ -924,7 +924,7 @@ def test_map_shard_with_shard_info(zephyr_ctx):
 
     data = [{"id": i} for i in range(10)]
     ds = Dataset.from_list([data]).flat_map(lambda x: x).map_shard(tag_with_shard_info)
-    result = list(zephyr_ctx.execute(ds))
+    result = zephyr_ctx.execute(ds).results
 
     assert len(result) == 10
     # All items should have shard info injected
@@ -946,7 +946,7 @@ def test_map_shard_with_shard_info_classmethod(zephyr_ctx):
 
     data = [{"id": i} for i in range(10)]
     ds = Dataset.from_list([data]).flat_map(lambda x: x).map_shard(ShardTagger.tag)
-    result = list(zephyr_ctx.execute(ds))
+    result = zephyr_ctx.execute(ds).results
 
     assert len(result) == 10
     for item in result:
@@ -982,7 +982,7 @@ def test_skip_existing_clean_run(tmp_path, sample_input_files):
     )
 
     try:
-        result = list(ctx.execute(ds))
+        result = ctx.execute(ds).results
         assert len(result) == 3
         assert all(Path(p).exists() for p in result)
         for p in result:
@@ -1011,7 +1011,7 @@ def test_skip_existing_one_file_exists(tmp_path, sample_input_files):
     )
 
     try:
-        result = list(ctx.execute(ds))
+        result = ctx.execute(ds).results
         assert len(result) == 3
         assert all(Path(p).exists() for p in result)
         # Shard 1 was skipped — its file still has the pre-existing content
@@ -1041,7 +1041,7 @@ def test_skip_existing_all_files_exist(tmp_path, sample_input_files):
 
     try:
         # First run: create all output files
-        result = list(ctx.execute(ds))
+        result = ctx.execute(ds).results
         assert len(result) == 3
         assert all(Path(p).exists() for p in result)
         for p in result:
@@ -1059,7 +1059,7 @@ def test_skip_existing_all_files_exist(tmp_path, sample_input_files):
             .write_jsonl(str(output_dir / "output-{shard:05d}.jsonl"), skip_existing=True)
         )
 
-        result2 = list(ctx.execute(ds2))
+        result2 = ctx.execute(ds2).results
         assert len(result2) == 3
         # Files should be untouched — still have "processed", not "rerun"
         for p in result2:
@@ -1097,7 +1097,7 @@ def test_filter_with_expression(zephyr_ctx):
         ]
     ).filter(col("score") > 70)
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 2
     assert all(r["score"] > 70 for r in results)
 
@@ -1114,7 +1114,7 @@ def test_filter_expression_equality(zephyr_ctx):
         ]
     ).filter(col("category") == "A")
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 2
     assert all(r["category"] == "A" for r in results)
 
@@ -1132,7 +1132,7 @@ def test_filter_expression_logical_and(zephyr_ctx):
         ]
     ).filter((col("a") > 0) & (col("b") > 0))
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 1
     assert results[0] == {"a": 1, "b": 2}
 
@@ -1150,7 +1150,7 @@ def test_filter_expression_logical_or(zephyr_ctx):
         ]
     ).filter((col("a") > 0) | (col("b") > 0))
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 3
 
 
@@ -1166,7 +1166,7 @@ def test_filter_nested_field(zephyr_ctx):
         ]
     ).filter(col("meta")["score"] > 0.5)
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 2
     assert all(r["meta"]["score"] > 0.5 for r in results)
 
@@ -1180,7 +1180,7 @@ def test_select_columns(zephyr_ctx):
         ]
     ).select("id", "name")
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 2
     assert results[0] == {"id": 1, "name": "alice"}
     assert results[1] == {"id": 2, "name": "bob"}
@@ -1195,7 +1195,7 @@ def test_select_partial_columns(zephyr_ctx):
         ]
     ).select("id", "score")
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 2
     assert results[0] == {"id": 1}
     assert results[1] == {"id": 2, "score": 60}
@@ -1217,7 +1217,7 @@ def test_filter_and_select_combined(zephyr_ctx):
         .select("id", "name")
     )
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 2
     assert all(set(r.keys()) == {"id", "name"} for r in results)
 
@@ -1246,7 +1246,7 @@ def test_filter_and_select(tmp_path, zephyr_ctx, output_format: str):
 
     ds = Dataset.from_files(str(output_path)).load_file().filter(col("score") > 70).select("id", "name")
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 2
     assert all(set(r.keys()) == {"id", "name"} for r in results)
     names = {r["name"] for r in results}
@@ -1281,7 +1281,7 @@ def test_mixed_filter_expression_and_lambda(zephyr_ctx):
         .filter(lambda r: r["b"] == "x")
     )
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 1
     assert results[0] == {"a": 3, "b": "x"}
 
@@ -1342,15 +1342,15 @@ def test_input_file_spec_with_columns_and_row_range(tmp_path):
 
 def test_reshard_integration(integration_ctx):
     ds = Dataset.from_list([list(range(50))]).flat_map(lambda x: x).reshard(5).map(lambda x: x * 2)
-    result = sorted(integration_ctx.execute(ds))
+    result = sorted(integration_ctx.execute(ds).results)
     assert result == [x * 2 for x in range(50)]
 
     ds = Dataset.from_list(range(50)).reshard(5).map(lambda x: x + 100)
-    result = sorted(integration_ctx.execute(ds))
+    result = sorted(integration_ctx.execute(ds).results)
     assert result == [x + 100 for x in range(50)]
 
     ds = Dataset.from_list(range(10)).reshard(3)
-    result = list(integration_ctx.execute(ds))
+    result = integration_ctx.execute(ds).results
     assert sorted(result) == list(range(10))
 
 
@@ -1364,7 +1364,7 @@ def test_sorted_merge_join_inner_basic_integration(integration_ctx):
 
     joined = left.sorted_merge_join(right, left_key=lambda x: x["id"], right_key=lambda x: x["id"], how="inner")
 
-    results = sorted(list(integration_ctx.execute(joined)), key=lambda x: x["id"])
+    results = sorted(integration_ctx.execute(joined).results, key=lambda x: x["id"])
     assert len(results) == 2
     assert results[0] == {"id": 1, "text": "hello", "score": 0.9}
     assert results[1] == {"id": 2, "text": "world", "score": 0.3}
@@ -1386,7 +1386,7 @@ def test_sorted_merge_join_left_integration(integration_ctx):
         how="left",
     )
 
-    results = sorted(list(integration_ctx.execute(joined)), key=lambda x: x["id"])
+    results = sorted(integration_ctx.execute(joined).results, key=lambda x: x["id"])
     assert len(results) == 2
     assert results[0] == {"id": 1, "text": "hello", "score": 0.9}
     assert results[1] == {"id": 2, "text": "world", "score": 0.0}
@@ -1416,7 +1416,7 @@ def test_sorted_merge_join_after_group_by_integration(integration_ctx):
 
     joined = docs.sorted_merge_join(attrs, left_key=lambda x: x["id"], right_key=lambda x: x["id"], how="inner")
 
-    results = sorted(list(integration_ctx.execute(joined)), key=lambda x: x["id"])
+    results = sorted(integration_ctx.execute(joined).results, key=lambda x: x["id"])
     assert len(results) == 3
     assert results[0] == {"id": 1, "text": "hello updated", "version": 2, "quality": 0.9}
     assert results[1] == {"id": 2, "text": "world", "version": 1, "quality": 0.3}

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -20,14 +20,14 @@ from zephyr.execution import CounterSnapshot, ZephyrContext, zephyr_worker_ctx
 def test_simple_map(zephyr_ctx):
     """Map pipeline produces correct results."""
     ds = Dataset.from_list([1, 2, 3]).map(lambda x: x * 2)
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert sorted(results) == [2, 4, 6]
 
 
 def test_filter(zephyr_ctx):
     """Filter pipeline produces correct results."""
     ds = Dataset.from_list([1, 2, 3, 4, 5]).filter(lambda x: x > 3)
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert sorted(results) == [4, 5]
 
 
@@ -65,7 +65,7 @@ def test_subprocess_propagates_user_counters(zephyr_ctx):
     target_logger.setLevel(logging.INFO)
     try:
         ds = Dataset.from_list([1, 2, 3, 4, 5]).map(increment_per_item)
-        results = list(zephyr_ctx.execute(ds))
+        results = zephyr_ctx.execute(ds).results
     finally:
         target_logger.removeHandler(handler)
         target_logger.setLevel(prior_level)
@@ -104,7 +104,7 @@ def test_subprocess_exception_includes_subprocess_traceback(zephyr_ctx):
     ds = Dataset.from_list([0]).map(buggy_index_lookup)
 
     with pytest.raises(ZephyrWorkerError) as exc_info:
-        list(zephyr_ctx.execute(ds))
+        zephyr_ctx.execute(ds)
 
     rendered = str(exc_info.value) + "".join(getattr(exc_info.value, "__notes__", []))
     # The wrapping ZephyrWorkerError should chain through the parent's
@@ -140,7 +140,7 @@ def test_shared_data(integration_client, tmp_path):
     )
     zctx.put("multiplier", 10)
     ds = Dataset.from_list([1, 2, 3]).map(use_shared)
-    results = list(zctx.execute(ds))
+    results = zctx.execute(ds).results
     assert sorted(results) == [10, 20, 30]
     zctx.shutdown()
 
@@ -148,7 +148,7 @@ def test_shared_data(integration_client, tmp_path):
 def test_multi_stage(zephyr_ctx):
     """Multi-stage pipeline (map + filter) works."""
     ds = Dataset.from_list([1, 2, 3, 4, 5]).map(lambda x: x * 2).filter(lambda x: x > 5)
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert sorted(results) == [6, 8, 10]
 
 
@@ -161,7 +161,7 @@ def test_context_manager(local_client):
         name=f"test-execution-{uuid.uuid4().hex[:8]}",
     )
     ds = Dataset.from_list([1, 2, 3]).map(lambda x: x + 1)
-    results = list(zctx.execute(ds))
+    results = zctx.execute(ds).results
     assert sorted(results) == [2, 3, 4]
 
 
@@ -169,7 +169,7 @@ def test_write_jsonl(tmp_path, zephyr_ctx):
     """Pipeline writing to jsonl file."""
     output = str(tmp_path / "out-{shard}.jsonl")
     ds = Dataset.from_list([{"a": 1}, {"a": 2}, {"a": 3}]).write_jsonl(output)
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 3
     # Verify all files were written and contain correct data
     all_records = []
@@ -184,21 +184,21 @@ def test_write_jsonl(tmp_path, zephyr_ctx):
 def test_dry_run(zephyr_ctx):
     """Dry run shows plan without executing."""
     ds = Dataset.from_list([1, 2, 3]).map(lambda x: x * 2)
-    results = list(zephyr_ctx.execute(ds, dry_run=True))
+    results = zephyr_ctx.execute(ds, dry_run=True).results
     assert results == []
 
 
 def test_flat_map(zephyr_ctx):
     """FlatMap pipeline produces correct results."""
     ds = Dataset.from_list([1, 2, 3]).flat_map(lambda x: [x, x * 10])
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert sorted(results) == [1, 2, 3, 10, 20, 30]
 
 
 def test_empty_dataset(zephyr_ctx):
     """Empty dataset produces empty results."""
     ds = Dataset.from_list([])
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert results == []
 
 
@@ -214,7 +214,7 @@ def test_chunk_cleanup(local_client, tmp_path):
     )
 
     ds = Dataset.from_list([1, 2, 3]).map(lambda x: x * 2)
-    results = list(ctx.execute(ds))
+    results = ctx.execute(ds).results
 
     assert sorted(results) == [2, 4, 6]
 
@@ -633,7 +633,7 @@ def test_fresh_actors_per_execute(integration_client, tmp_path):
         name=f"test-execution-{uuid.uuid4().hex[:8]}",
     )
     ds = Dataset.from_list([1, 2, 3]).map(lambda x: x + 1)
-    results = list(zctx.execute(ds))
+    results = zctx.execute(ds).results
     assert sorted(results) == [2, 3, 4]
 
     # After execute(): coordinator job is torn down
@@ -642,7 +642,7 @@ def test_fresh_actors_per_execute(integration_client, tmp_path):
 
     # Can execute again (creates fresh coordinator job)
     ds2 = Dataset.from_list([10, 20]).map(lambda x: x * 2)
-    results2 = list(zctx.execute(ds2))
+    results2 = zctx.execute(ds2).results
     assert sorted(results2) == [20, 40]
 
     assert zctx._coordinator_job is None
@@ -669,7 +669,7 @@ def test_fatal_errors_fail_fast(local_client, tmp_path):
 
     start = time.monotonic()
     with pytest.raises(ZephyrWorkerError, match="ValueError"):
-        list(zctx.execute(ds))
+        zctx.execute(ds)
     elapsed = time.monotonic() - start
 
     # Should fail fast — well under the 30s heartbeat timeout
@@ -698,7 +698,7 @@ def test_chunk_storage_with_join(integration_client, tmp_path):
         combiner=lambda left, right: {**left, **right},
     )
 
-    results = sorted(list(ctx.execute(joined)), key=lambda x: x["id"])
+    results = sorted(ctx.execute(joined).results, key=lambda x: x["id"])
     assert len(results) == 2
     assert results[0] == {"id": 1, "a": "x", "b": "p"}
     assert results[1] == {"id": 2, "a": "y", "b": "q"}
@@ -714,7 +714,7 @@ def test_workers_capped_to_shard_count(local_client, tmp_path):
         chunk_storage_prefix=str(tmp_path / "chunks"),
         name=f"test-execution-{uuid.uuid4().hex[:8]}",
     )
-    results = list(ctx.execute(ds.map(lambda x: x * 2)))
+    results = ctx.execute(ds.map(lambda x: x * 2)).results
     assert sorted(results) == [2, 4, 6]
     # Everything torn down after execute; correct results prove workers
     # were created and sized properly (min(10, 3) = 3)
@@ -925,7 +925,7 @@ def test_execute_stops_coordinator_thread(local_client, tmp_path):
         name=f"test-execution-{uuid.uuid4().hex[:8]}",
     )
 
-    results = list(ctx.execute(Dataset.from_list([1, 2, 3]).map(lambda x: x + 1)))
+    results = ctx.execute(Dataset.from_list([1, 2, 3]).map(lambda x: x + 1)).results
     assert sorted(results) == [2, 3, 4]
 
     deadline = time.monotonic() + 2.0
@@ -962,7 +962,7 @@ def test_execute_retries_on_coordinator_death(tmp_path):
     )
 
     # First execute() succeeds normally
-    results = list(ctx.execute(Dataset.from_list([1, 2, 3]).map(lambda x: x * 2)))
+    results = ctx.execute(Dataset.from_list([1, 2, 3]).map(lambda x: x * 2)).results
     assert sorted(results) == [2, 4, 6]
 
     # Patch submit to fail on the first coordinator job, then succeed on retry.
@@ -980,7 +980,7 @@ def test_execute_retries_on_coordinator_death(tmp_path):
 
     # Next execute() should: fail on attempt 0 (submit raises),
     # then succeed on attempt 1 with a fresh coordinator job.
-    results = list(ctx.execute(Dataset.from_list([10, 20]).map(lambda x: x + 1)))
+    results = ctx.execute(Dataset.from_list([10, 20]).map(lambda x: x + 1)).results
     assert sorted(results) == [11, 21]
     assert submit_count[0] >= 2, "Expected at least 2 submit attempts (1 failed + 1 succeeded)"
 
@@ -1009,7 +1009,7 @@ def test_execute_does_not_retry_worker_errors(local_client, tmp_path):
 
     start = time.monotonic()
     with pytest.raises(ZephyrWorkerError, match="ValueError"):
-        list(ctx.execute(ds))
+        ctx.execute(ds)
     elapsed = time.monotonic() - start
 
     # Should fail fast — no retries for application errors
@@ -1021,9 +1021,9 @@ def test_execute_does_not_retry_worker_errors(local_client, tmp_path):
 
 def test_simple_map_integration(integration_ctx):
     ds = Dataset.from_list([1, 2, 3]).map(lambda x: x * 2)
-    assert sorted(integration_ctx.execute(ds)) == [2, 4, 6]
+    assert sorted(integration_ctx.execute(ds).results) == [2, 4, 6]
 
 
 def test_multi_stage_integration(integration_ctx):
     ds = Dataset.from_list([1, 2, 3, 4, 5]).map(lambda x: x * 2).filter(lambda x: x > 5)
-    assert sorted(integration_ctx.execute(ds)) == [6, 8, 10]
+    assert sorted(integration_ctx.execute(ds).results) == [6, 8, 10]

--- a/lib/zephyr/tests/test_groupby.py
+++ b/lib/zephyr/tests/test_groupby.py
@@ -39,7 +39,7 @@ def test_deduplicate_basic(zephyr_ctx):
 
     ds = Dataset.from_list(data).deduplicate(key=lambda x: x["id"])
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
 
     # Should have exactly 3 unique items (ids 1, 2, 3)
     assert len(results) == 3
@@ -52,7 +52,7 @@ def test_deduplicate_basic(zephyr_ctx):
 def test_deduplicate_empty(zephyr_ctx):
     """Test deduplication on empty dataset."""
     ds = Dataset.from_list([]).deduplicate(key=lambda x: x["id"])
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert results == []
 
 
@@ -62,7 +62,7 @@ def test_deduplicate_all_unique(zephyr_ctx):
 
     ds = Dataset.from_list(data).deduplicate(key=lambda x: x["id"])
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 10
 
 
@@ -72,7 +72,7 @@ def test_deduplicate_all_duplicates(zephyr_ctx):
 
     ds = Dataset.from_list(data).deduplicate(key=lambda x: x["id"])
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert len(results) == 1
     assert results[0]["id"] == 1
 
@@ -92,7 +92,7 @@ def test_group_by_count(zephyr_ctx):
         key=lambda x: x["cat"], reducer=lambda key, items: {"cat": key, "count": sum(1 for _ in items)}
     )
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
 
     # Should have 3 groups
     assert len(results) == 3
@@ -119,7 +119,7 @@ def test_group_by_sum(zephyr_ctx):
         key=lambda x: x["cat"], reducer=lambda key, items: {"cat": key, "sum": sum(item["val"] for item in items)}
     )
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     results = sorted(results, key=lambda x: x["cat"])
 
     assert results[0] == {"cat": "A", "sum": 4}  # 1 + 3
@@ -139,7 +139,7 @@ def test_group_by_list(zephyr_ctx):
         key=lambda x: x["cat"], reducer=lambda key, items: {"cat": key, "vals": [item["val"] for item in items]}
     )
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     results = sorted(results, key=lambda x: x["cat"])
 
     assert results[0]["cat"] == "A"
@@ -155,7 +155,7 @@ def test_group_by_empty(zephyr_ctx):
         key=lambda x: x["cat"], reducer=lambda key, items: {"cat": key, "count": sum(1 for _ in items)}
     )
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     assert results == []
 
 
@@ -165,7 +165,7 @@ def test_deduplicate_with_num_output_shards(zephyr_ctx):
 
     ds = Dataset.from_list(data).deduplicate(key=lambda x: x["id"], num_output_shards=5)
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
 
     # Should have exactly 3 unique items (ids 0, 1, 2)
     assert len(results) == 3
@@ -197,7 +197,7 @@ def test_group_by_with_hash_key_large(zephyr_ctx, large_document_dataset):
         .group_by(key=lambda doc: doc["hash"], reducer=count_and_extract)
     )
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
 
     # Should have exactly 100 groups (one per unique content)
     assert len(results) == 100
@@ -230,7 +230,7 @@ def test_group_by_generator_reducer(zephyr_ctx):
         reducer=explode_reducer,
     )
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
 
     # Generator reducer should flatten: 4 items total (2 from A, 2 from B)
     assert len(results) == 4
@@ -259,7 +259,7 @@ def test_group_by_secondary_sort(zephyr_ctx):
         sort_by=lambda x: x["ts"],
     )
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     results = sorted(results, key=lambda x: x["user"])
 
     # Items within each group should be sorted by timestamp
@@ -286,7 +286,7 @@ def test_group_by_secondary_sort_with_generator_reducer(zephyr_ctx):
         sort_by=lambda x: x["rank"],
     )
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     results = sorted(results, key=lambda x: (x["cat"], x["rank"]))
 
     # Items should arrive at reducer sorted by rank
@@ -322,7 +322,7 @@ def test_group_by_with_none_and_filter(zephyr_ctx):
         .filter(lambda x: x is not None)  # Filter out None values
     )
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
 
     # Should only have duplicate keys: "a" and "foo"
     assert len(results) == 2
@@ -354,7 +354,7 @@ def test_group_by_non_vortex_serializable(zephyr_ctx):
         reducer=lambda key, items: {"key": key, "value": frozenset().union(*(item["values"] for item in items))},
     )
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     results = sorted(results, key=lambda x: x["key"])
     assert len(results) == 2
     assert results[0] == {"key": "a", "value": frozenset([1, 2, 3, 4])}
@@ -401,7 +401,7 @@ def test_group_by_schema_evolution(zephyr_ctx):
         reducer=lambda key, items: {"cat": key, "count": sum(1 for _ in items)},
     )
 
-    results = list(zephyr_ctx.execute(ds))
+    results = zephyr_ctx.execute(ds).results
     results = sorted(results, key=lambda x: x["cat"])
 
     assert len(results) == 5
@@ -443,7 +443,7 @@ def test_group_by_combiner(zephyr_ctx):
         combiner=dedup_combiner,
     )
 
-    results = sorted(zephyr_ctx.execute(ds), key=lambda x: x["key"])
+    results = sorted(zephyr_ctx.execute(ds).results, key=lambda x: x["key"])
     assert results == [
         {"key": "a", "ids": [1, 2]},
         {"key": "b", "ids": [3, 4]},
@@ -470,7 +470,7 @@ def test_group_by_combiner_sum(zephyr_ctx):
         combiner=sum_combiner,
     )
 
-    results = sorted(zephyr_ctx.execute(ds), key=lambda x: x["cat"])
+    results = sorted(zephyr_ctx.execute(ds).results, key=lambda x: x["cat"])
     assert results == [
         {"cat": "x", "total": 6},
         {"cat": "y", "total": 30},
@@ -491,7 +491,7 @@ def test_deduplicate_basic_integration(integration_ctx):
 
     ds = Dataset.from_list(data).deduplicate(key=lambda x: x["id"])
 
-    results = list(integration_ctx.execute(ds))
+    results = integration_ctx.execute(ds).results
     assert len(results) == 3
     ids = sorted([r["id"] for r in results])
     assert ids == [1, 2, 3]
@@ -530,7 +530,7 @@ def test_group_by_combiner_integration(integration_ctx):
         combiner=dedup_combiner,
     )
 
-    results = sorted(integration_ctx.execute(ds), key=lambda x: x["key"])
+    results = sorted(integration_ctx.execute(ds).results, key=lambda x: x["key"])
     assert results == [
         {"key": "a", "ids": [1, 2]},
         {"key": "b", "ids": [3, 4]},

--- a/lib/zephyr/tests/test_optimization.py
+++ b/lib/zephyr/tests/test_optimization.py
@@ -98,7 +98,7 @@ def test_fused_execution_with_batch():
     )
 
     ctx = ZephyrContext(name="test_fusion")
-    result = list(ctx.execute(ds))
+    result = ctx.execute(ds).results
     assert result == [[6, 8], [10, 12]]
 
 

--- a/lib/zephyr/tests/test_vortex.py
+++ b/lib/zephyr/tests/test_vortex.py
@@ -119,7 +119,7 @@ class TestVortexPipeline:
             .write_vortex(output_pattern)
         )
 
-        results = list(sync_ctx.execute(ds))
+        results = sync_ctx.execute(ds).results
         assert len(results) == 1
 
         # Verify output
@@ -133,7 +133,7 @@ class TestVortexPipeline:
 
         ds = Dataset.from_files(str(vortex_file)).load_file().filter(lambda r: r["id"] < 10).write_jsonl(output_pattern)
 
-        results = list(sync_ctx.execute(ds))
+        results = sync_ctx.execute(ds).results
         assert len(results) == 1
 
     def test_vortex_to_parquet_conversion(self, sync_ctx, vortex_file, tmp_path):
@@ -142,7 +142,7 @@ class TestVortexPipeline:
 
         ds = Dataset.from_files(str(vortex_file)).load_vortex().write_parquet(output_pattern)
 
-        results = list(sync_ctx.execute(ds))
+        results = sync_ctx.execute(ds).results
         assert len(results) == 1
 
         # Verify parquet output
@@ -164,7 +164,7 @@ class TestVortexPipeline:
 
         ds = Dataset.from_files(str(parquet_path)).load_parquet().write_vortex(output_pattern)
 
-        results = list(sync_ctx.execute(ds))
+        results = sync_ctx.execute(ds).results
         assert len(results) == 1
 
         # Verify vortex output
@@ -179,7 +179,7 @@ class TestVortexFilterPushdown:
         """Test filter pushdown with expression."""
         ds = Dataset.from_files(str(vortex_file)).load_vortex().filter(col("score") > 500)
 
-        results = list(sync_ctx.execute(ds))
+        results = sync_ctx.execute(ds).results
         assert len(results) == 49  # scores 510, 520, ..., 990
         assert all(r["score"] > 500 for r in results)
 
@@ -187,6 +187,6 @@ class TestVortexFilterPushdown:
         """Test column selection pushdown."""
         ds = Dataset.from_files(str(vortex_file)).load_vortex().select("id", "score")
 
-        results = list(sync_ctx.execute(ds))
+        results = sync_ctx.execute(ds).results
         assert len(results) == 100
         assert set(results[0].keys()) == {"id", "score"}

--- a/tests/processing/classification/deduplication/test_connected_components.py
+++ b/tests/processing/classification/deduplication/test_connected_components.py
@@ -21,7 +21,7 @@ def test_connected_components_happy_path(tmp_path):
     ctx = ZephyrContext(name="test-cc")
     converged, output_path = connected_components(ds, ctx, output_dir=tmp_path.as_posix(), max_iterations=5)
     assert converged
-    results = ctx.execute(Dataset.from_list(output_path).load_parquet())
+    results = ctx.execute(Dataset.from_list(output_path).load_parquet()).results
     assert len(results) == len(set(r["id"] for r in input_data))
 
     components = defaultdict(list)
@@ -43,6 +43,6 @@ def test_connected_components_already_converged(tmp_path):
     converged, output_path = connected_components(ds, ctx, output_dir=tmp_path.as_posix(), max_iterations=5)
     assert converged
 
-    results = ctx.execute(Dataset.from_list(output_path).load_parquet())
+    results = ctx.execute(Dataset.from_list(output_path).load_parquet()).results
     assert len(results) == 1
     assert results[0]["record_id"] == "doc_1"


### PR DESCRIPTION
ctx.execute() now returns a ZephyrExecutionResult(results, counters)
dataclass instead of a bare list. Aggregated counters (builtin plus any
zephyr.counters.increment values) are exposed alongside the pipeline
results so callers can inspect or persist them as they see fit. Zephyr
writes no counter artifacts — persistence is the caller's call. A
caller that wants counters in its step's .artifact can simply include
result.counters in its return value.

Internal coordinator-job wire format now pickles a _CoordinatorResult
instead of a bare list. All marin call sites that use the result list
are updated to append .results; discarded-return sites are unchanged.