### PR TITLE
[zephyr] Count partitions skipped on existing output

### DIFF
--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -748,6 +748,7 @@ def run_stage(
 
     configure_logging(level=logging.INFO)
 
+    from zephyr import counters
     from zephyr.writers import write_binary_file, write_jsonl_file, write_levanter_cache, write_parquet_file
 
     stream: Iterator = iter(ctx.shard)
@@ -774,6 +775,7 @@ def run_stage(
 
                 if fs.exists(test_path):
                     logger.info(f"Skipping write, output exists: {output_path}")
+                    counters.increment("zephyr/partitions_skipped")
                     yield output_path
                     return
 


### PR DESCRIPTION
## Summary
- Add `zephyr/partitions_skipped` internal counter incremented in `run_stage` when a `Write` op's output already exists and is skipped via `skip_existing`
- Mirrors the existing `zephyr/records_in` / `zephyr/records_out` counters so resume behavior is observable through the standard counters surface

## Test plan
- [ ] Run a pipeline with `skip_existing=True` where some partitions exist; verify `zephyr/partitions_skipped` shows up in `get_counters()` / coordinator counter aggregation