### PR TITLE
[iris] Add --fresh flag to skip checkpoint restore on controller start

### DIFF
--- a/.github/workflows/iris-coreweave-ci.yaml
+++ b/.github/workflows/iris-coreweave-ci.yaml
@@ -104,7 +104,7 @@ jobs:
         run: |
           cd lib/iris && uv run --group dev iris -v \
             --config=examples/coreweave-ci.yaml \
-            cluster start
+            cluster start --fresh
 
       - name: Run integration tests
         env:

--- a/lib/iris/src/iris/cli/cluster.py
+++ b/lib/iris/src/iris/cli/cluster.py
@@ -225,8 +225,11 @@ def cluster_list():
 
 @cluster.command("start")
 @click.option("--local", is_flag=True, help="Create a local cluster for testing that mimics the original config")
+@click.option(
+    "--fresh", is_flag=True, default=False, help="Start with an empty database, ignoring any remote checkpoint"
+)
 @click.pass_context
-def cluster_start(ctx, local: bool):
+def cluster_start(ctx, local: bool, fresh: bool):
     """Start controller and wait for health.
 
     Each platform handles its own controller lifecycle:
@@ -272,7 +275,7 @@ def cluster_start(ctx, local: bool):
         else:
             iris_config = IrisConfig(config)
             bundle = iris_config.provider_bundle()
-            address = bundle.controller.start_controller(config)
+            address = bundle.controller.start_controller(config, fresh=fresh)
             click.echo(f"Controller started at {address}")
             click.echo("\nController is running with integrated autoscaler.")
             click.echo("Use 'iris --config=... cluster status' to check cluster state.")
@@ -604,8 +607,14 @@ def controller(ctx):
     default=False,
     help="Start in dry-run mode: compute scheduling but suppress all side effects",
 )
+@click.option(
+    "--fresh",
+    is_flag=True,
+    default=False,
+    help="Start with an empty database, ignoring any remote checkpoint",
+)
 @click.pass_context
-def controller_serve(ctx, host, port, checkpoint_path, checkpoint_interval, dry_run):
+def controller_serve(ctx, host, port, checkpoint_path, checkpoint_interval, dry_run, fresh):
     """Start a local controller process.
 
     Loads the cluster config, restores from checkpoint, and runs the full
@@ -631,6 +640,7 @@ def controller_serve(ctx, host, port, checkpoint_path, checkpoint_interval, dry_
         checkpoint_path=checkpoint_path,
         checkpoint_interval=checkpoint_interval,
         dry_run=dry_run,
+        fresh=fresh,
     )
 
 

--- a/lib/iris/src/iris/cluster/controller/main.py
+++ b/lib/iris/src/iris/cluster/controller/main.py
@@ -39,6 +39,7 @@ def run_controller_serve(
     checkpoint_path: str | None = None,
     checkpoint_interval: float | None = None,
     dry_run: bool = False,
+    fresh: bool = False,
 ) -> None:
     """Start the Iris controller, block until SIGTERM/SIGINT.
 
@@ -78,7 +79,10 @@ def run_controller_serve(
     db_dir = local_state_dir / "db"
     db_path = db_dir / ControllerDB.DB_FILENAME
     auth_db_path = db_dir / ControllerDB.AUTH_DB_FILENAME
-    if db_path.exists() and auth_db_path.exists():
+    if fresh:
+        logger.info("--fresh: starting with empty database, skipping checkpoint restore")
+        db_dir.mkdir(parents=True, exist_ok=True)
+    elif db_path.exists() and auth_db_path.exists():
         logger.info("Local DB exists at %s, skipping remote restore", db_dir)
     else:
         if db_path.exists() and not auth_db_path.exists():
@@ -244,6 +248,12 @@ def cli():
     default=False,
     help="Start in dry-run mode: compute scheduling but suppress all side effects",
 )
+@click.option(
+    "--fresh",
+    is_flag=True,
+    default=False,
+    help="Start with an empty database, ignoring any remote checkpoint",
+)
 def serve(
     host: str,
     port: int,
@@ -252,6 +262,7 @@ def serve(
     checkpoint_path: str | None,
     checkpoint_interval: float | None,
     dry_run: bool,
+    fresh: bool,
 ):
     """Start the Iris controller service."""
     from iris.cluster.config import load_config
@@ -269,6 +280,7 @@ def serve(
         checkpoint_path=checkpoint_path,
         checkpoint_interval=checkpoint_interval,
         dry_run=dry_run,
+        fresh=fresh,
     )
 
 

--- a/lib/iris/src/iris/cluster/controller/main.py
+++ b/lib/iris/src/iris/cluster/controller/main.py
@@ -11,6 +11,7 @@ serve`` subcommand in the main CLI.
 
 import logging
 import os
+import shutil
 import signal
 import tempfile
 import threading
@@ -80,6 +81,12 @@ def run_controller_serve(
     db_path = db_dir / ControllerDB.DB_FILENAME
     auth_db_path = db_dir / ControllerDB.AUTH_DB_FILENAME
     if fresh:
+        # Wipe any pre-existing db_dir so we're guaranteed to start with an
+        # empty database. Otherwise a stale or corrupt local SQLite file would
+        # be silently reused, defeating the purpose of --fresh.
+        if db_dir.exists():
+            logger.info("--fresh: removing existing db_dir %s", db_dir)
+            shutil.rmtree(db_dir)
         logger.info("--fresh: starting with empty database, skipping checkpoint restore")
         db_dir.mkdir(parents=True, exist_ok=True)
     elif db_path.exists() and auth_db_path.exists():

--- a/lib/iris/src/iris/cluster/controller/vm_lifecycle.py
+++ b/lib/iris/src/iris/cluster/controller/vm_lifecycle.py
@@ -327,15 +327,21 @@ def start_controller(
     config: config_pb2.IrisClusterConfig,
     resolve_image: Callable[[str, str | None], str] | None = None,
     health_check_timeout: float = HEALTH_CHECK_TIMEOUT_SECONDS,
+    fresh: bool = False,
 ) -> tuple[str, StandaloneWorkerHandle]:
     """Start or discover existing controller. Returns (address, vm_handle).
 
     1. Try to discover an existing healthy controller
-    2. If found and healthy, return it
+    2. If found and healthy, return it (unless ``fresh`` is set)
     3. Otherwise, create a new VM and bootstrap it
 
     For GCP: creates a GCE instance, SSHs in, bootstraps the controller container.
     For Manual: allocates a host, SSHs in, bootstraps.
+
+    If ``fresh`` is True, any existing controller VM is terminated and
+    recreated so the new container starts from an empty database. The
+    ``--fresh`` flag is also threaded into the bootstrap script so the
+    controller skips the remote checkpoint restore on startup.
     """
     _resolve_image = resolve_image or _identity_resolve_image
     label_prefix = config.platform.label_prefix or "iris"
@@ -344,13 +350,20 @@ def start_controller(
     # Check for existing controller
     existing_vm = _discover_controller_vm(platform, label_prefix)
     if existing_vm:
-        logger.info("Found existing controller VM %s, checking health...", existing_vm.vm_id)
-        if wait_healthy(existing_vm, port, timeout=health_check_timeout):
-            address = f"http://{existing_vm.internal_address}:{port}"
-            logger.info("Existing controller at %s is healthy", address)
-            return address, existing_vm
-        logger.info("Existing controller is unhealthy, terminating and recreating")
-        existing_vm.terminate(wait=True)
+        if fresh:
+            logger.info(
+                "Found existing controller VM %s, terminating for --fresh start",
+                existing_vm.vm_id,
+            )
+            existing_vm.terminate(wait=True)
+        else:
+            logger.info("Found existing controller VM %s, checking health...", existing_vm.vm_id)
+            if wait_healthy(existing_vm, port, timeout=health_check_timeout):
+                address = f"http://{existing_vm.internal_address}:{port}"
+                logger.info("Existing controller at %s is healthy", address)
+                return address, existing_vm
+            logger.info("Existing controller is unhealthy, terminating and recreating")
+            existing_vm.terminate(wait=True)
 
     # Create new controller VM
     vm_config = _build_controller_vm_config(config)
@@ -363,7 +376,11 @@ def start_controller(
         raise RuntimeError(f"Controller VM {vm_config.name} did not become reachable within 300s")
 
     # Bootstrap
-    bootstrap_script = build_controller_bootstrap_script_from_config(config, resolve_image=_resolve_image)
+    bootstrap_script = build_controller_bootstrap_script_from_config(
+        config,
+        resolve_image=_resolve_image,
+        fresh=fresh,
+    )
     vm.bootstrap(bootstrap_script)
 
     # Health check

--- a/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
@@ -343,7 +343,7 @@ sudo docker run -d --name {{ container_name }} \\
     {{ config_volume }} \\
     {{ docker_image }} \\
     .venv/bin/python -m iris.cluster.controller.main serve \\
-        --host 0.0.0.0 --port {{ port }} {{ config_flag }}
+        --host 0.0.0.0 --port {{ port }} {{ config_flag }} {{ fresh_flag }}
 
 echo "[iris-controller] [5/5] Controller container started"
 
@@ -413,6 +413,7 @@ def build_controller_bootstrap_script(
     docker_image: str,
     port: int,
     config_yaml: str = "",
+    fresh: bool = False,
 ) -> str:
     """Build bootstrap script for controller VM.
 
@@ -420,6 +421,8 @@ def build_controller_bootstrap_script(
         docker_image: Docker image to run
         port: Controller port
         config_yaml: Optional YAML config to write to /etc/iris/config.yaml
+        fresh: When True, pass ``--fresh`` to the controller serve command so
+            it starts with an empty local database and skips checkpoint restore.
     """
     if config_yaml:
         config_setup = _build_config_setup(config_yaml, log_prefix="[iris-controller]")
@@ -438,18 +441,22 @@ def build_controller_bootstrap_script(
         config_setup=config_setup,
         config_volume=config_volume,
         config_flag=config_flag,
+        fresh_flag="--fresh" if fresh else "",
     )
 
 
 def build_controller_bootstrap_script_from_config(
     config: config_pb2.IrisClusterConfig,
     resolve_image: Callable[[str, str | None], str],
+    fresh: bool = False,
 ) -> str:
     """Build controller bootstrap script from the full cluster config.
 
     Args:
         config: Full cluster configuration.
         resolve_image: Resolves a container image tag for the target registry.
+        fresh: When True, pass ``--fresh`` to the controller serve command so
+            it starts with an empty local database and skips checkpoint restore.
     """
     # Local import to avoid circular dependency (config.py imports from bootstrap)
     from iris.cluster.config import config_to_dict
@@ -465,4 +472,4 @@ def build_controller_bootstrap_script_from_config(
 
     image = resolve_image(image, zone)
 
-    return build_controller_bootstrap_script(image, port, config_yaml)
+    return build_controller_bootstrap_script(image, port, config_yaml, fresh=fresh)

--- a/lib/iris/src/iris/cluster/providers/gcp/controller.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/controller.py
@@ -78,6 +78,7 @@ class GcpControllerProvider:
             self.worker_provider,
             config,
             resolve_image=self.worker_provider.resolve_image,
+            fresh=fresh,
         )
         return address
 

--- a/lib/iris/src/iris/cluster/providers/gcp/controller.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/controller.py
@@ -73,7 +73,7 @@ class GcpControllerProvider:
             )
         return f"{vms[0].internal_address}:{port}"
 
-    def start_controller(self, config: config_pb2.IrisClusterConfig) -> str:
+    def start_controller(self, config: config_pb2.IrisClusterConfig, *, fresh: bool = False) -> str:
         address, _vm = vm_start_controller(
             self.worker_provider,
             config,

--- a/lib/iris/src/iris/cluster/providers/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/controller.py
@@ -135,6 +135,7 @@ def _build_controller_deployment(
     port: int,
     node_selector: dict[str, str],
     s3_env_vars: list[dict],
+    fresh: bool = False,
 ) -> dict:
     """Build the controller Deployment manifest as a dict."""
     # Reserve controller CPU/memory so Kubernetes doesn't classify this Pod
@@ -172,6 +173,7 @@ def _build_controller_deployment(
                                 "--host=0.0.0.0",
                                 f"--port={port}",
                                 "--config=/etc/iris/config.json",
+                                *(["--fresh"] if fresh else []),
                             ],
                             "ports": [{"containerPort": port}],
                             "env": s3_env_vars,
@@ -266,7 +268,7 @@ class K8sControllerProvider:
         port = cw.port or 10000
         return f"{service_name}.{self._namespace}.svc.cluster.local:{port}"
 
-    def start_controller(self, config: config_pb2.IrisClusterConfig) -> str:
+    def start_controller(self, config: config_pb2.IrisClusterConfig, *, fresh: bool = False) -> str:
         """Start the controller, reconciling all resources. Returns address (host:port).
 
         Fully idempotent: always applies ConfigMap, Deployment, and Service
@@ -309,6 +311,7 @@ class K8sControllerProvider:
             port=port,
             node_selector={self._iris_labels.iris_scale_group: cw.scale_group},
             s3_env_vars=s3_env,
+            fresh=fresh,
         )
         self._kubectl.apply_json(deploy_manifest)
         self._kubectl.rollout_restart(K8sResource.DEPLOYMENTS, "iris-controller")

--- a/lib/iris/src/iris/cluster/providers/manual/provider.py
+++ b/lib/iris/src/iris/cluster/providers/manual/provider.py
@@ -433,6 +433,7 @@ class ManualControllerProvider:
             self.worker_provider,
             config,
             resolve_image=self.worker_provider.resolve_image,
+            fresh=fresh,
         )
         return address
 

--- a/lib/iris/src/iris/cluster/providers/manual/provider.py
+++ b/lib/iris/src/iris/cluster/providers/manual/provider.py
@@ -428,7 +428,7 @@ class ManualControllerProvider:
         port = manual.port or 10000
         return f"{manual.host}:{port}"
 
-    def start_controller(self, config: config_pb2.IrisClusterConfig) -> str:
+    def start_controller(self, config: config_pb2.IrisClusterConfig, *, fresh: bool = False) -> str:
         address, _vm = vm_start_controller(
             self.worker_provider,
             config,

--- a/lib/iris/src/iris/cluster/providers/protocols.py
+++ b/lib/iris/src/iris/cluster/providers/protocols.py
@@ -35,8 +35,12 @@ class ControllerProvider(Protocol):
         """
         ...
 
-    def start_controller(self, config: config_pb2.IrisClusterConfig) -> str:
-        """Start or discover existing controller. Returns address (host:port)."""
+    def start_controller(self, config: config_pb2.IrisClusterConfig, *, fresh: bool = False) -> str:
+        """Start or discover existing controller. Returns address (host:port).
+
+        If fresh=True, the controller starts with an empty database instead
+        of restoring from a remote checkpoint.
+        """
         ...
 
     def restart_controller(self, config: config_pb2.IrisClusterConfig) -> str:

--- a/lib/iris/tests/cluster/controller/test_vm_lifecycle.py
+++ b/lib/iris/tests/cluster/controller/test_vm_lifecycle.py
@@ -259,6 +259,43 @@ def test_start_controller_replaces_unhealthy_existing(config):
     assert len(replacement.bootstrap_calls) == 1
 
 
+def test_start_controller_fresh_terminates_existing_and_bootstraps_with_flag(config):
+    """fresh=True -- existing healthy VM is terminated, new VM gets --fresh in bootstrap."""
+    existing = FakeWorkerHandle(vm_id="ctrl-existing", internal_address="10.0.0.2")
+    replacement = FakeWorkerHandle(vm_id="ctrl-new", internal_address="10.0.0.7")
+    platform = FakePlatform(existing_vms=[existing], vm_to_create=replacement)
+
+    address, vm = start_controller(platform, config, fresh=True)
+
+    assert existing.terminated
+    assert vm is replacement
+    assert address == "http://10.0.0.7:10000"
+    assert len(replacement.bootstrap_calls) == 1
+    assert "--fresh" in replacement.bootstrap_calls[0]
+
+
+def test_start_controller_fresh_new_vm_bootstrap_contains_flag(config):
+    """fresh=True with no existing VM still threads --fresh into the bootstrap script."""
+    new_vm = FakeWorkerHandle(vm_id="ctrl-new", internal_address="10.0.0.8")
+    platform = FakePlatform(existing_vms=[], vm_to_create=new_vm)
+
+    start_controller(platform, config, fresh=True)
+
+    assert len(new_vm.bootstrap_calls) == 1
+    assert "--fresh" in new_vm.bootstrap_calls[0]
+
+
+def test_start_controller_without_fresh_omits_flag(config):
+    """fresh=False (default) must not inject --fresh into the bootstrap script."""
+    new_vm = FakeWorkerHandle(vm_id="ctrl-new", internal_address="10.0.0.9")
+    platform = FakePlatform(existing_vms=[], vm_to_create=new_vm)
+
+    start_controller(platform, config)
+
+    assert len(new_vm.bootstrap_calls) == 1
+    assert "--fresh" not in new_vm.bootstrap_calls[0]
+
+
 def test_start_controller_connection_timeout_terminates_vm(config):
     """VM created but wait_for_connection fails -- terminates the VM and raises."""
     unreachable = FakeWorkerHandle(


### PR DESCRIPTION
The CoreWeave CI controller restores its SQLite DB from an S3 checkpoint on
every start. A corrupt checkpoint (migration 0024 recorded in schema_migrations
but the actual task_resource_history table missing) caused GetJobStatus to fail
with "no such column: trh.cpu_millicores" across all CI runs.

Adds --fresh flag to iris cluster start and controller serve that skips
checkpoint restore and starts with an empty DB. The CW CI workflow now uses
--fresh since tests don't need prior controller state.