### PR TITLE
[iris] Expand v4-reserved pool to match v4-preemptible sizes (32-4096)

### DIFF
--- a/lib/iris/examples/marin-dev.yaml
+++ b/lib/iris/examples/marin-dev.yaml
@@ -102,7 +102,11 @@ tpu_pools:
         service_account: iris-worker@hai-gcp-models.iam.gserviceaccount.com
         runtime_version: tpu-ubuntu2204-base
     sizes:
-      32: { buffer_slices: 0, max_slices: 1 }
+      32:  { buffer_slices: 0, max_slices: 1 }
+      64:  { buffer_slices: 0, max_slices: 1 }
+      128: { buffer_slices: 0, max_slices: 1 }
+      256: { buffer_slices: 0, max_slices: 1 }
+      512: { buffer_slices: 0, max_slices: 1 }
 
 scale_groups:
   cpu_vm_e2_highmem_2_ondemand:

--- a/lib/iris/examples/marin-dev.yaml
+++ b/lib/iris/examples/marin-dev.yaml
@@ -102,11 +102,14 @@ tpu_pools:
         service_account: iris-worker@hai-gcp-models.iam.gserviceaccount.com
         runtime_version: tpu-ubuntu2204-base
     sizes:
-      32:  { buffer_slices: 0, max_slices: 1 }
-      64:  { buffer_slices: 0, max_slices: 1 }
-      128: { buffer_slices: 0, max_slices: 1 }
-      256: { buffer_slices: 0, max_slices: 1 }
-      512: { buffer_slices: 0, max_slices: 1 }
+      32:   { buffer_slices: 0, max_slices: 1 }
+      64:   { buffer_slices: 0, max_slices: 1 }
+      128:  { buffer_slices: 0, max_slices: 1 }
+      256:  { buffer_slices: 0, max_slices: 1 }
+      512:  { buffer_slices: 0, max_slices: 1 }
+      1024: { buffer_slices: 0, max_slices: 1 }
+      2048: { buffer_slices: 0, max_slices: 1 }
+      4096: { buffer_slices: 0, max_slices: 1 }
 
 scale_groups:
   cpu_vm_e2_highmem_2_ondemand:

--- a/lib/iris/examples/marin.yaml
+++ b/lib/iris/examples/marin.yaml
@@ -148,11 +148,14 @@ tpu_pools:
         service_account: iris-worker@hai-gcp-models.iam.gserviceaccount.com
         runtime_version: tpu-ubuntu2204-base
     sizes:
-      32:  { buffer_slices: 0, max_slices: 4 }
-      64:  { buffer_slices: 0, max_slices: 4 }
-      128: { buffer_slices: 0, max_slices: 4 }
-      256: { buffer_slices: 0, max_slices: 4 }
-      512: { buffer_slices: 0, max_slices: 4 }
+      32:   { buffer_slices: 0, max_slices: 4 }
+      64:   { buffer_slices: 0, max_slices: 4 }
+      128:  { buffer_slices: 0, max_slices: 4 }
+      256:  { buffer_slices: 0, max_slices: 4 }
+      512:  { buffer_slices: 0, max_slices: 4 }
+      1024: { buffer_slices: 0, max_slices: 4 }
+      2048: { buffer_slices: 0, max_slices: 4 }
+      4096: { buffer_slices: 0, max_slices: 4 }
 
 # ---------------------------------------------------------------------------
 # Non-TPU scale groups (not part of tpu_pools)

--- a/lib/iris/examples/marin.yaml
+++ b/lib/iris/examples/marin.yaml
@@ -148,7 +148,11 @@ tpu_pools:
         service_account: iris-worker@hai-gcp-models.iam.gserviceaccount.com
         runtime_version: tpu-ubuntu2204-base
     sizes:
-      32: { buffer_slices: 0, max_slices: 4 }
+      32:  { buffer_slices: 0, max_slices: 4 }
+      64:  { buffer_slices: 0, max_slices: 4 }
+      128: { buffer_slices: 0, max_slices: 4 }
+      256: { buffer_slices: 0, max_slices: 4 }
+      512: { buffer_slices: 0, max_slices: 4 }
 
 # ---------------------------------------------------------------------------
 # Non-TPU scale groups (not part of tpu_pools)


### PR DESCRIPTION
## Summary

- Extend the `v4-reserved` TPU pool (us-central2-b) to register the full range of topology sizes that `v4-preemptible` already supports: **32, 64, 128, 256, 512, 1024, 2048, 4096**
- Applies to both `lib/iris/examples/marin.yaml` (prod) and `lib/iris/examples/marin-dev.yaml` (dev)
- No changes to `base_priority` (stays 1000), `capacity_type` (stays reserved), or `resources` per slice

## Motivation

The `v4-reserved` pool was originally added in #4528 for queued-resource debugging, scoped to just v4-32. This PR generalizes it so any existing v4 training recipe can route to reserved capacity when preemptible is backed off — not just for exp4307's 32B SFT, but for all cluster v4 users.

Observed failure mode driving this (from #4307): the `v4-preemptible_256` pool entered `tier_blocked: 1 matching group(s) blocked by quota-pool tier monotonicity`, and no alternative reserved pool existed at size 256+. Having reserved-tier alternatives at every preemptible size lets production jobs route to guaranteed capacity instead of being stuck.

Existing large-job use cases that need the larger sizes:
- `exp1994_32b_sft` already runs 32B SFT on **v4-2048** with batch=2048

## What's added

| Size | max_slices (prod) | max_slices (dev) |
|------|---:|---:|
| 32 (existing) | 4 | 1 |
| 64 (new) | 4 | 1 |
| 128 (new) | 4 | 1 |
| 256 (new) | 4 | 1 |
| 512 (new) | 4 | 1 |
| 1024 (new) | 4 | 1 |
| 2048 (new) | 4 | 1 |
| 4096 (new) | 4 | 1 |

This matches `v4-preemptible` size coverage exactly. `buffer_slices` stays 0 for all entries so no capacity is reserved upfront — scale groups are only registered, actual slice acquisition still depends on GCP reservation quota and on-demand allocation via the queued resources API.

## Test plan

- [x] `./infra/pre-commit.py --fix lib/iris/examples/marin.yaml lib/iris/examples/marin-dev.yaml` — passes
- [x] `IrisConfig.load(...)` for both files — registers 8 v4-reserved groups each (`tpu_v4-reserved_{32,64,128,256,512,1024,2048,4096}-us-central2-b`)
- [ ] Controller config reload to make the new groups live
- [ ] Submit a v4-reserved_256 job and verify scheduling (tracked in #4307)

🤖 Generated with [Claude Code](https://claude.com/claude-code)