### PR TITLE
[iris] Decode constraints to native Constraint at load time

### DIFF
--- a/lib/iris/src/iris/cluster/constraints.py
+++ b/lib/iris/src/iris/cluster/constraints.py
@@ -161,6 +161,13 @@ class ConstraintOp(IntEnum):
         return mapping[self]
 
 
+def _normalize_value(v: str | int | float) -> str | int | float:
+    """Strip and lowercase string values so constraint evaluation is case-insensitive."""
+    if isinstance(v, str):
+        return v.strip().lower()
+    return v
+
+
 @dataclass(frozen=True)
 class Constraint:
     """Worker constraint for job scheduling.
@@ -203,14 +210,18 @@ class Constraint:
 
     @staticmethod
     def from_proto(proto: job_pb2.Constraint) -> Constraint:
-        """Convert from protobuf representation."""
+        """Convert from protobuf representation.
+
+        String values are stripped and lowercased at ingestion so that
+        downstream constraint evaluation never needs case-normalization.
+        """
         op = ConstraintOp(proto.op)
         value: str | int | float | None = None
         if proto.HasField("value"):
-            value = AttributeValue.from_proto(proto.value).value
+            value = _normalize_value(AttributeValue.from_proto(proto.value).value)
         values: tuple[str | int | float, ...] | None = None
         if proto.values:
-            values = tuple(AttributeValue.from_proto(v).value for v in proto.values)
+            values = tuple(_normalize_value(AttributeValue.from_proto(v).value) for v in proto.values)
         return Constraint(key=proto.key, op=op, value=value, values=values, mode=proto.mode)
 
 
@@ -411,16 +422,13 @@ def _extract_device_type(constraints: list[Constraint]) -> DeviceType | None:
         raise ValueError(f"unknown device type: {raw}") from e
 
 
-def extract_placement_requirements(constraints: Sequence[job_pb2.Constraint]) -> PlacementRequirements:
-    """Extract canonical placement requirements from protobuf constraints.
+def extract_placement_requirements(constraints: Sequence[Constraint]) -> PlacementRequirements:
+    """Extract canonical placement requirements from constraints.
 
-    Parses proto constraints once, groups by key, then extracts each field
-    using shared helpers.
+    Groups constraints by key, then extracts each field using shared helpers.
     """
-    parsed = [Constraint.from_proto(c) for c in constraints]
-
     by_key: dict[str, list[Constraint]] = {}
-    for c in parsed:
+    for c in constraints:
         by_key.setdefault(c.key, []).append(c)
 
     return PlacementRequirements(
@@ -494,26 +502,6 @@ class ConstraintDescriptor:
     allowed_ops: frozenset[int]
     canonical: bool
     routing: bool
-    extract: Callable[..., Any] | None
-
-
-# --- Extract functions ---
-
-
-def _extract_string(constraint: job_pb2.Constraint) -> str:
-    return constraint.value.string_value.strip()
-
-
-def _extract_string_lower(constraint: job_pb2.Constraint) -> str:
-    return constraint.value.string_value.strip().lower()
-
-
-def _extract_bool_string(constraint: job_pb2.Constraint) -> str:
-    return constraint.value.string_value.strip().lower()
-
-
-def _extract_int(constraint: job_pb2.Constraint) -> int:
-    return constraint.value.int_value
 
 
 _EQ_IN = frozenset({job_pb2.CONSTRAINT_OP_EQ, job_pb2.CONSTRAINT_OP_IN})
@@ -543,68 +531,32 @@ def _register(desc: ConstraintDescriptor) -> ConstraintDescriptor:
 
 _register(
     ConstraintDescriptor(
-        key="device-type",
-        kind=ConstraintKind.TAG,
-        python_type=str,
-        allowed_ops=_EQ_IN,
-        canonical=True,
-        routing=True,
-        extract=_extract_string_lower,
+        key="device-type", kind=ConstraintKind.TAG, python_type=str, allowed_ops=_EQ_IN, canonical=True, routing=True
     )
 )
 _register(
     ConstraintDescriptor(
-        key="device-variant",
-        kind=ConstraintKind.TAG,
-        python_type=str,
-        allowed_ops=_EQ_IN,
-        canonical=True,
-        routing=True,
-        extract=_extract_string,
+        key="device-variant", kind=ConstraintKind.TAG, python_type=str, allowed_ops=_EQ_IN, canonical=True, routing=True
     )
 )
 _register(
     ConstraintDescriptor(
-        key="preemptible",
-        kind=ConstraintKind.TAG,
-        python_type=bool,
-        allowed_ops=_EQ_ONLY,
-        canonical=True,
-        routing=True,
-        extract=_extract_bool_string,
+        key="preemptible", kind=ConstraintKind.TAG, python_type=bool, allowed_ops=_EQ_ONLY, canonical=True, routing=True
     )
 )
 _register(
     ConstraintDescriptor(
-        key="region",
-        kind=ConstraintKind.TAG,
-        python_type=str,
-        allowed_ops=_EQ_IN,
-        canonical=True,
-        routing=True,
-        extract=_extract_string,
+        key="region", kind=ConstraintKind.TAG, python_type=str, allowed_ops=_EQ_IN, canonical=True, routing=True
     )
 )
 _register(
     ConstraintDescriptor(
-        key="zone",
-        kind=ConstraintKind.TAG,
-        python_type=str,
-        allowed_ops=_EQ_IN,
-        canonical=True,
-        routing=True,
-        extract=_extract_string,
+        key="zone", kind=ConstraintKind.TAG, python_type=str, allowed_ops=_EQ_IN, canonical=True, routing=True
     )
 )
 _register(
     ConstraintDescriptor(
-        key="tpu-name",
-        kind=ConstraintKind.TAG,
-        python_type=str,
-        allowed_ops=_ALL_OPS,
-        canonical=False,
-        routing=False,
-        extract=_extract_string,
+        key="tpu-name", kind=ConstraintKind.TAG, python_type=str, allowed_ops=_ALL_OPS, canonical=False, routing=False
     )
 )
 _register(
@@ -615,7 +567,6 @@ _register(
         allowed_ops=_ALL_OPS,
         canonical=False,
         routing=False,
-        extract=_extract_int,
     )
 )
 _register(
@@ -626,7 +577,6 @@ _register(
         allowed_ops=_ALL_OPS,
         canonical=False,
         routing=False,
-        extract=_extract_string,
     )
 )
 _register(
@@ -637,18 +587,11 @@ _register(
         allowed_ops=_ALL_OPS,
         canonical=False,
         routing=False,
-        extract=_extract_int,
     )
 )
 _register(
     ConstraintDescriptor(
-        key="gpu-variant",
-        kind=ConstraintKind.TAG,
-        python_type=str,
-        allowed_ops=_ALL_OPS,
-        canonical=False,
-        routing=False,
-        extract=_extract_string,
+        key="gpu-variant", kind=ConstraintKind.TAG, python_type=str, allowed_ops=_ALL_OPS, canonical=False, routing=False
     )
 )
 _register(
@@ -659,7 +602,6 @@ _register(
         allowed_ops=_ALL_OPS,
         canonical=False,
         routing=False,
-        extract=_extract_int,
     )
 )
 
@@ -818,67 +760,52 @@ def _compare_ordered(
 
 def evaluate_constraint(
     attr: AttributeValue | None,
-    constraint: job_pb2.Constraint,
+    constraint: Constraint,
 ) -> bool:
     """Evaluate a single constraint against an entity's attribute.
 
     Works for any entity (worker, scaling group, etc.) that has typed attributes.
-
-    Args:
-        attr: Attribute value (None if attribute doesn't exist on the entity)
-        constraint: Constraint to evaluate
-
-    Returns:
-        True if constraint is satisfied, False otherwise
+    Constraint values are already normalized (stripped, lowercased) at ingestion.
     """
     op = constraint.op
 
-    # EXISTS/NOT_EXISTS don't need a value comparison
-    if op == job_pb2.CONSTRAINT_OP_EXISTS:
+    if op == ConstraintOp.EXISTS:
         return attr is not None
-    if op == job_pb2.CONSTRAINT_OP_NOT_EXISTS:
+    if op == ConstraintOp.NOT_EXISTS:
         return attr is None
 
-    # All other operators require the attribute to exist
     if attr is None:
         return False
 
-    target = AttributeValue.from_proto(constraint.value)
-
     match op:
-        case job_pb2.CONSTRAINT_OP_EQ:
-            return attr.value == target.value
-        case job_pb2.CONSTRAINT_OP_NE:
-            return attr.value != target.value
-        case job_pb2.CONSTRAINT_OP_GT:
-            return _compare_ordered(attr.value, target.value, "gt")
-        case job_pb2.CONSTRAINT_OP_GE:
-            return _compare_ordered(attr.value, target.value, "ge")
-        case job_pb2.CONSTRAINT_OP_LT:
-            return _compare_ordered(attr.value, target.value, "lt")
-        case job_pb2.CONSTRAINT_OP_LE:
-            return _compare_ordered(attr.value, target.value, "le")
-        case job_pb2.CONSTRAINT_OP_IN:
-            target_values = {AttributeValue.from_proto(v).value for v in constraint.values}
-            return attr.value in target_values
+        case ConstraintOp.EQ:
+            return attr.value == constraint.value
+        case ConstraintOp.NE:
+            return attr.value != constraint.value
+        case ConstraintOp.GT:
+            return _compare_ordered(attr.value, constraint.value, "gt")
+        case ConstraintOp.GE:
+            return _compare_ordered(attr.value, constraint.value, "ge")
+        case ConstraintOp.LT:
+            return _compare_ordered(attr.value, constraint.value, "lt")
+        case ConstraintOp.LE:
+            return _compare_ordered(attr.value, constraint.value, "le")
+        case ConstraintOp.IN:
+            return attr.value in constraint.values if constraint.values else False
         case _:
             return False
 
 
-def is_cpu_device_type_constraint(c: job_pb2.Constraint) -> bool:
+def is_cpu_device_type_constraint(c: Constraint) -> bool:
     """True if this constraint is device-type=cpu.
 
     CPU jobs match any scaling group, so this constraint is stripped
-    before routing evaluation.
+    before routing evaluation. Values are already normalized at ingestion.
     """
-    return (
-        c.key == WellKnownAttribute.DEVICE_TYPE
-        and c.op == job_pb2.CONSTRAINT_OP_EQ
-        and c.value.string_value.strip().lower() == "cpu"
-    )
+    return c.key == WellKnownAttribute.DEVICE_TYPE and c.op == ConstraintOp.EQ and c.value == "cpu"
 
 
-def routing_constraints(constraints: Sequence[job_pb2.Constraint]) -> list[job_pb2.Constraint]:
+def routing_constraints(constraints: Sequence[Constraint]) -> list[Constraint]:
     """Filter to routing-only constraints, stripping CPU device-type.
 
     Non-routing constraints (tpu-name, tpu-worker-id, etc.) and unknown
@@ -897,16 +824,16 @@ def routing_constraints(constraints: Sequence[job_pb2.Constraint]) -> list[job_p
 
 
 def split_hard_soft(
-    constraints: Sequence[job_pb2.Constraint],
-) -> tuple[list[job_pb2.Constraint], list[job_pb2.Constraint]]:
-    """Split proto constraints into (hard, soft) lists based on mode.
+    constraints: Sequence[Constraint],
+) -> tuple[list[Constraint], list[Constraint]]:
+    """Split constraints into (hard, soft) lists based on mode.
 
     Hard constraints filter candidates; soft constraints only influence ranking.
     """
-    hard: list[job_pb2.Constraint] = []
-    soft: list[job_pb2.Constraint] = []
+    hard: list[Constraint] = []
+    soft: list[Constraint] = []
     for c in constraints:
-        if c.mode == job_pb2.CONSTRAINT_MODE_PREFERRED:
+        if c.is_soft:
             soft.append(c)
         else:
             hard.append(c)
@@ -915,7 +842,7 @@ def split_hard_soft(
 
 def soft_constraint_score(
     entity_attrs: dict[str, AttributeValue],
-    soft_constraints: Sequence[job_pb2.Constraint],
+    soft_constraints: Sequence[Constraint],
 ) -> int:
     """Count how many soft constraints an entity satisfies.
 
@@ -966,7 +893,7 @@ class ConstraintIndex:
             _entity_attributes=dict(entities),
         )
 
-    def matching_entities(self, constraints: Sequence[job_pb2.Constraint]) -> set[str]:
+    def matching_entities(self, constraints: Sequence[Constraint]) -> set[str]:
         """Get entity IDs matching ALL constraints."""
         if not constraints:
             return set(self._all_ids)
@@ -981,16 +908,15 @@ class ConstraintIndex:
                 return set()
         return result or set()
 
-    def _evaluate_constraint_set(self, constraint: job_pb2.Constraint) -> set[str]:
+    def _evaluate_constraint_set(self, constraint: Constraint) -> set[str]:
         """Evaluate a single constraint, returning matching entity IDs."""
         key = constraint.key
         op = constraint.op
 
-        if op == job_pb2.CONSTRAINT_OP_EQ and key in self._discrete_lists:
-            target = AttributeValue.from_proto(constraint.value).value
-            return self._discrete_lists[key].get(target, set())
+        if op == ConstraintOp.EQ and key in self._discrete_lists:
+            return self._discrete_lists[key].get(constraint.value, set())
 
-        if op == job_pb2.CONSTRAINT_OP_EXISTS:
+        if op == ConstraintOp.EXISTS:
             if key in self._discrete_lists:
                 result: set[str] = set()
                 for entities in self._discrete_lists[key].values():
@@ -998,7 +924,7 @@ class ConstraintIndex:
                 return result
             return set()
 
-        if op == job_pb2.CONSTRAINT_OP_NOT_EXISTS:
+        if op == ConstraintOp.NOT_EXISTS:
             if key in self._discrete_lists:
                 has_attr: set[str] = set()
                 for entities in self._discrete_lists[key].values():
@@ -1006,11 +932,10 @@ class ConstraintIndex:
                 return set(self._all_ids) - has_attr
             return set(self._all_ids)
 
-        if op == job_pb2.CONSTRAINT_OP_IN and key in self._discrete_lists:
+        if op == ConstraintOp.IN and key in self._discrete_lists and constraint.values:
             in_result: set[str] = set()
-            for av in constraint.values:
-                target_val = AttributeValue.from_proto(av).value
-                in_result |= self._discrete_lists[key].get(target_val, set())
+            for val in constraint.values:
+                in_result |= self._discrete_lists[key].get(val, set())
             return in_result
 
         # Slow path for NE, GT, GE, LT, LE, or non-indexed attributes

--- a/lib/iris/src/iris/cluster/constraints.py
+++ b/lib/iris/src/iris/cluster/constraints.py
@@ -92,9 +92,19 @@ class AttributeValue:
 
     Used for coscheduling and constraint-based worker filtering.
     Values can be strings, integers, or floats.
+
+    String values are stripped and lowercased at construction so that
+    constraint comparisons are case-insensitive by construction — there is
+    no way to hold a non-normalized string in this type. Worker attributes
+    and constraint literals share this type and therefore share the
+    normalization invariant.
     """
 
     value: str | int | float
+
+    def __post_init__(self) -> None:
+        if isinstance(self.value, str):
+            object.__setattr__(self, "value", self.value.strip().lower())
 
     def to_proto(self) -> job_pb2.AttributeValue:
         """Convert to protobuf representation."""
@@ -128,11 +138,11 @@ class ConstraintOp(IntEnum):
 
     Example:
         >>> # Match workers where region equals "us-central1"
-        >>> Constraint(key="region", op=ConstraintOp.EQ, value="us-central1")
+        >>> Constraint.create(key="region", op=ConstraintOp.EQ, value="us-central1")
         >>> # Match workers with memory > 32GB
-        >>> Constraint(key="memory_gb", op=ConstraintOp.GT, value=32)
+        >>> Constraint.create(key="memory_gb", op=ConstraintOp.GT, value=32)
         >>> # Match workers that have the "gpu" attribute set
-        >>> Constraint(key="gpu", op=ConstraintOp.EXISTS)
+        >>> Constraint.create(key="gpu", op=ConstraintOp.EXISTS)
     """
 
     EQ = 0
@@ -161,11 +171,19 @@ class ConstraintOp(IntEnum):
         return mapping[self]
 
 
-def _normalize_value(v: str | int | float) -> str | int | float:
-    """Strip and lowercase string values so constraint evaluation is case-insensitive."""
-    if isinstance(v, str):
-        return v.strip().lower()
-    return v
+# Per-op arity bounds (lo, hi) for Constraint.values. hi=None means unbounded.
+# Enforced in Constraint.__post_init__ so invalid constraints cannot be constructed.
+_CONSTRAINT_ARITY: dict[ConstraintOp, tuple[int, int | None]] = {
+    ConstraintOp.EXISTS: (0, 0),
+    ConstraintOp.NOT_EXISTS: (0, 0),
+    ConstraintOp.EQ: (1, 1),
+    ConstraintOp.NE: (1, 1),
+    ConstraintOp.GT: (1, 1),
+    ConstraintOp.GE: (1, 1),
+    ConstraintOp.LT: (1, 1),
+    ConstraintOp.LE: (1, 1),
+    ConstraintOp.IN: (1, None),
+}
 
 
 @dataclass(frozen=True)
@@ -175,54 +193,107 @@ class Constraint:
     Constraints filter which workers are eligible to run a job based on
     worker attributes. Workers must satisfy all constraints to be considered.
 
+    `values` is a tuple of `AttributeValue` — a single type for both worker-side
+    and constraint-side scalars. The arity of `values` is determined by `op`
+    and validated at construction; downstream code can always index into
+    `values` without None checks.
+
+    Prefer ``Constraint.create(...)`` in call sites — it accepts raw
+    ``value=``/``values=`` scalars and wraps them in ``AttributeValue``
+    automatically. The primary constructor is used by ``from_proto`` and
+    tests of the invariant itself.
+
     Example:
         >>> # Require a specific TPU pod
-        >>> Constraint(key="tpu-name", op=ConstraintOp.EQ, value="my-tpu-pod")
-        >>> # Require workers in a specific zone
-        >>> Constraint(key="zone", op=ConstraintOp.EQ, value="us-central1-a")
+        >>> Constraint.create(key="tpu-name", op=ConstraintOp.EQ, value="my-tpu-pod")
         >>> # Require workers with at least 64GB memory
-        >>> Constraint(key="memory_gb", op=ConstraintOp.GE, value=64)
+        >>> Constraint.create(key="memory_gb", op=ConstraintOp.GE, value=64)
         >>> # Require workers that have a GPU
-        >>> Constraint(key="gpu", op=ConstraintOp.EXISTS)
+        >>> Constraint.create(key="gpu", op=ConstraintOp.EXISTS)
         >>> # Require workers in one of several regions
-        >>> Constraint(key="region", op=ConstraintOp.IN, values=("us-central1", "us-central2"))
+        >>> Constraint.create(key="region", op=ConstraintOp.IN,
+        ...                   values=["us-central1", "us-central2"])
     """
 
     key: str
     op: ConstraintOp
-    value: str | int | float | None = None
-    values: tuple[str | int | float, ...] | None = None
+    values: tuple[AttributeValue, ...] = ()
     mode: int = job_pb2.CONSTRAINT_MODE_REQUIRED
+
+    def __post_init__(self) -> None:
+        lo, hi = _CONSTRAINT_ARITY[self.op]
+        n = len(self.values)
+        if n < lo or (hi is not None and n > hi):
+            bound = str(hi) if hi is not None else "∞"
+            raise ValueError(f"Constraint op {self.op.name} requires {lo}..{bound} values, got {n}")
 
     @property
     def is_soft(self) -> bool:
         return self.mode == job_pb2.CONSTRAINT_MODE_PREFERRED
 
     def to_proto(self) -> job_pb2.Constraint:
-        """Convert to protobuf representation."""
+        """Convert to protobuf representation.
+
+        Singular ops (EQ/NE/GT/GE/LT/LE) write `proto.value`; IN writes
+        `proto.values`; EXISTS/NOT_EXISTS write neither.
+        """
         proto = job_pb2.Constraint(key=self.key, op=self.op.to_proto(), mode=self.mode)
-        if self.value is not None:
-            proto.value.CopyFrom(AttributeValue(self.value).to_proto())
-        if self.values is not None:
+        if self.op == ConstraintOp.IN:
             for v in self.values:
-                proto.values.append(AttributeValue(v).to_proto())
+                proto.values.append(v.to_proto())
+        elif self.values:
+            proto.value.CopyFrom(self.values[0].to_proto())
         return proto
 
     @staticmethod
     def from_proto(proto: job_pb2.Constraint) -> Constraint:
         """Convert from protobuf representation.
 
-        String values are stripped and lowercased at ingestion so that
-        downstream constraint evaluation never needs case-normalization.
+        Normalization (strip/lowercase for strings) happens inside
+        AttributeValue.__post_init__, so constraint evaluation never needs
+        to re-normalize.
         """
         op = ConstraintOp(proto.op)
-        value: str | int | float | None = None
-        if proto.HasField("value"):
-            value = _normalize_value(AttributeValue.from_proto(proto.value).value)
-        values: tuple[str | int | float, ...] | None = None
-        if proto.values:
-            values = tuple(_normalize_value(AttributeValue.from_proto(v).value) for v in proto.values)
-        return Constraint(key=proto.key, op=op, value=value, values=values, mode=proto.mode)
+        if op in (ConstraintOp.EXISTS, ConstraintOp.NOT_EXISTS):
+            values: tuple[AttributeValue, ...] = ()
+        elif op == ConstraintOp.IN:
+            values = tuple(AttributeValue.from_proto(v) for v in proto.values)
+        else:
+            values = (AttributeValue.from_proto(proto.value),)
+        return Constraint(key=proto.key, op=op, values=values, mode=proto.mode)
+
+    @classmethod
+    def create(
+        cls,
+        key: str,
+        op: ConstraintOp,
+        *,
+        value: str | int | float | None = None,
+        values: Sequence[str | int | float] | None = None,
+        mode: int = job_pb2.CONSTRAINT_MODE_REQUIRED,
+    ) -> Constraint:
+        """Ergonomic factory: wraps raw scalars in AttributeValue automatically.
+
+        - Singular ops (EQ/NE/GT/GE/LT/LE): pass ``value=``.
+        - IN: pass ``values=``.
+        - EXISTS/NOT_EXISTS: pass neither.
+
+        Raw strings are normalized (stripped + lowercased) via
+        AttributeValue.__post_init__.
+        """
+        if op in (ConstraintOp.EXISTS, ConstraintOp.NOT_EXISTS):
+            if value is not None or values is not None:
+                raise ValueError(f"op={op.name} takes no value/values")
+            tup: tuple[AttributeValue, ...] = ()
+        elif op == ConstraintOp.IN:
+            if value is not None or values is None:
+                raise ValueError("op=IN requires values=, not value=")
+            tup = tuple(AttributeValue(v) for v in values)
+        else:
+            if value is None or values is not None:
+                raise ValueError(f"op={op.name} requires value=, not values=")
+            tup = (AttributeValue(value),)
+        return cls(key=key, op=op, values=tup, mode=mode)
 
 
 # ---------------------------------------------------------------------------
@@ -248,14 +319,14 @@ def preemptible_constraint(preemptible: bool = True, soft: bool | None = None) -
         # preemptible=True is a preference (soft), preemptible=False is a requirement (hard)
         soft = preemptible
     mode = job_pb2.CONSTRAINT_MODE_PREFERRED if soft else job_pb2.CONSTRAINT_MODE_REQUIRED
-    return Constraint(key=WellKnownAttribute.PREEMPTIBLE, op=ConstraintOp.EQ, value=str(preemptible).lower(), mode=mode)
+    return Constraint.create(key=WellKnownAttribute.PREEMPTIBLE, op=ConstraintOp.EQ, value=str(preemptible), mode=mode)
 
 
 def zone_constraint(zone: str) -> Constraint:
     """Constraint requiring workers to be in a given zone."""
     if not zone:
         raise ValueError("zone must be non-empty")
-    return Constraint(key=WellKnownAttribute.ZONE, op=ConstraintOp.EQ, value=zone)
+    return Constraint.create(key=WellKnownAttribute.ZONE, op=ConstraintOp.EQ, value=zone)
 
 
 def region_constraint(regions: list[str]) -> Constraint:
@@ -279,8 +350,8 @@ def region_constraint(regions: list[str]) -> Constraint:
         if not r:
             raise ValueError("region must be non-empty")
     if len(regions) == 1:
-        return Constraint(key=WellKnownAttribute.REGION, op=ConstraintOp.EQ, value=regions[0])
-    return Constraint(key=WellKnownAttribute.REGION, op=ConstraintOp.IN, values=tuple(regions))
+        return Constraint.create(key=WellKnownAttribute.REGION, op=ConstraintOp.EQ, value=regions[0])
+    return Constraint.create(key=WellKnownAttribute.REGION, op=ConstraintOp.IN, values=regions)
 
 
 def device_variant_constraint(variants: Sequence[str]) -> Constraint:
@@ -303,10 +374,8 @@ def device_variant_constraint(variants: Sequence[str]) -> Constraint:
         if not v:
             raise ValueError("variant must be non-empty")
     if len(variants) == 1:
-        return Constraint(key=WellKnownAttribute.DEVICE_VARIANT, op=ConstraintOp.EQ, value=variants[0].lower())
-    return Constraint(
-        key=WellKnownAttribute.DEVICE_VARIANT, op=ConstraintOp.IN, values=tuple(v.lower() for v in variants)
-    )
+        return Constraint.create(key=WellKnownAttribute.DEVICE_VARIANT, op=ConstraintOp.EQ, value=variants[0])
+    return Constraint.create(key=WellKnownAttribute.DEVICE_VARIANT, op=ConstraintOp.IN, values=list(variants))
 
 
 @dataclass(frozen=True)
@@ -350,17 +419,17 @@ def _collect_values(
     *,
     allow_in: bool = True,
 ) -> list[str | int | float]:
-    """Flatten a Constraint's value(s) into a list. EQ → [value], IN → list(values)."""
+    """Flatten a Constraint's value(s) into a list of raw scalars.
+
+    EQ → [values[0].value], IN → [v.value for v in values]. Arity is already
+    enforced by Constraint.__post_init__ so no None checks are needed here.
+    """
     if constraint.op == ConstraintOp.EQ:
-        if constraint.value is None:
-            raise ValueError(f"{constraint.key} constraint requires a value")
-        return [constraint.value]
+        return [constraint.values[0].value]
     if constraint.op == ConstraintOp.IN:
         if not allow_in:
             raise ValueError(f"{constraint.key} constraint must use EQ")
-        if not constraint.values:
-            raise ValueError(f"IN {constraint.key} constraint requires at least one value")
-        return list(constraint.values)
+        return [v.value for v in constraint.values]
     raise ValueError(f"{constraint.key} constraint must use EQ or IN, got {constraint.op}")
 
 
@@ -640,23 +709,11 @@ def constraints_from_resources(resources: job_pb2.ResourceSpecProto) -> list[Con
 
     device_type = get_device_type(resources.device)
     if device_type != "cpu":
-        constraints.append(
-            Constraint(
-                key=WellKnownAttribute.DEVICE_TYPE,
-                op=ConstraintOp.EQ,
-                value=device_type,
-            )
-        )
+        constraints.append(Constraint.create(key=WellKnownAttribute.DEVICE_TYPE, op=ConstraintOp.EQ, value=device_type))
 
     variant = get_device_variant(resources.device)
     if variant and variant != "auto":
-        constraints.append(
-            Constraint(
-                key=WellKnownAttribute.DEVICE_VARIANT,
-                op=ConstraintOp.EQ,
-                value=variant.lower(),
-            )
-        )
+        constraints.append(Constraint.create(key=WellKnownAttribute.DEVICE_VARIANT, op=ConstraintOp.EQ, value=variant))
 
     return constraints
 
@@ -779,19 +836,19 @@ def evaluate_constraint(
 
     match op:
         case ConstraintOp.EQ:
-            return attr.value == constraint.value
+            return attr.value == constraint.values[0].value
         case ConstraintOp.NE:
-            return attr.value != constraint.value
+            return attr.value != constraint.values[0].value
         case ConstraintOp.GT:
-            return _compare_ordered(attr.value, constraint.value, "gt")
+            return _compare_ordered(attr.value, constraint.values[0].value, "gt")
         case ConstraintOp.GE:
-            return _compare_ordered(attr.value, constraint.value, "ge")
+            return _compare_ordered(attr.value, constraint.values[0].value, "ge")
         case ConstraintOp.LT:
-            return _compare_ordered(attr.value, constraint.value, "lt")
+            return _compare_ordered(attr.value, constraint.values[0].value, "lt")
         case ConstraintOp.LE:
-            return _compare_ordered(attr.value, constraint.value, "le")
+            return _compare_ordered(attr.value, constraint.values[0].value, "le")
         case ConstraintOp.IN:
-            return attr.value in constraint.values if constraint.values else False
+            return any(attr.value == v.value for v in constraint.values)
         case _:
             return False
 
@@ -802,7 +859,7 @@ def is_cpu_device_type_constraint(c: Constraint) -> bool:
     CPU jobs match any scaling group, so this constraint is stripped
     before routing evaluation. Values are already normalized at ingestion.
     """
-    return c.key == WellKnownAttribute.DEVICE_TYPE and c.op == ConstraintOp.EQ and c.value == "cpu"
+    return c.key == WellKnownAttribute.DEVICE_TYPE and c.op == ConstraintOp.EQ and c.values[0].value == "cpu"
 
 
 def routing_constraints(constraints: Sequence[Constraint]) -> list[Constraint]:
@@ -914,7 +971,7 @@ class ConstraintIndex:
         op = constraint.op
 
         if op == ConstraintOp.EQ and key in self._discrete_lists:
-            return self._discrete_lists[key].get(constraint.value, set())
+            return self._discrete_lists[key].get(constraint.values[0].value, set())
 
         if op == ConstraintOp.EXISTS:
             if key in self._discrete_lists:
@@ -932,10 +989,10 @@ class ConstraintIndex:
                 return set(self._all_ids) - has_attr
             return set(self._all_ids)
 
-        if op == ConstraintOp.IN and key in self._discrete_lists and constraint.values:
+        if op == ConstraintOp.IN and key in self._discrete_lists:
             in_result: set[str] = set()
             for val in constraint.values:
-                in_result |= self._discrete_lists[key].get(val, set())
+                in_result |= self._discrete_lists[key].get(val.value, set())
             return in_result
 
         # Slow path for NE, GT, GE, LT, LE, or non-indexed attributes

--- a/lib/iris/src/iris/cluster/controller/autoscaler/models.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/models.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 
-from iris.cluster.constraints import PlacementRequirements
+from iris.cluster.constraints import Constraint, PlacementRequirements
 from iris.rpc import job_pb2
 
 
@@ -35,7 +35,7 @@ class DemandEntry:
     task_ids: list[str]
     coschedule_group_id: str | None
     normalized: PlacementRequirements
-    constraints: list[job_pb2.Constraint]
+    constraints: list[Constraint]
     resources: job_pb2.ResourceSpecProto
     invalid_reason: str | None = None
 

--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -30,7 +30,7 @@ from iris.cluster.providers.types import (
     RemoteWorkerHandle,
     SliceHandle,
 )
-from iris.cluster.constraints import ConstraintIndex, routing_constraints
+from iris.cluster.constraints import Constraint, ConstraintIndex, routing_constraints
 from iris.cluster.controller.autoscaler.models import (
     DemandEntry,
     ScalingAction,
@@ -53,7 +53,6 @@ from iris.cluster.controller.db import ControllerDB
 from iris.cluster.types import WorkerStatusMap
 from iris.managed_thread import ThreadContainer, get_thread_container
 from iris.rpc import config_pb2, vm_pb2
-from iris.rpc import job_pb2
 from iris.time_proto import duration_from_proto, timestamp_to_proto
 from rigging.timing import Duration, Timestamp
 
@@ -533,7 +532,7 @@ class Autoscaler:
     def check_coscheduling_feasibility(
         self,
         replicas: int,
-        constraints: list[job_pb2.Constraint],
+        constraints: list[Constraint],
     ) -> str | None:
         """Check if a coscheduled job with the given replicas can ever be scheduled.
 

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -24,6 +24,7 @@ from iris.cluster.providers.types import Labels, SliceHandle
 from iris.cluster.constraints import (
     AttributeValue,
     CONSTRAINT_REGISTRY,
+    Constraint,
     DeviceType,
     ResourceCapacity,
     WellKnownAttribute,
@@ -958,8 +959,8 @@ class ScalingGroup:
             attrs[WellKnownAttribute.ZONE] = AttributeValue(zone)
         return attrs
 
-    def matches_constraints(self, constraints: Sequence[job_pb2.Constraint]) -> bool:
-        """Check if this group satisfies the given proto constraints.
+    def matches_constraints(self, constraints: Sequence[Constraint]) -> bool:
+        """Check if this group satisfies the given constraints.
 
         Only evaluates routing constraints (device-type, device-variant,
         preemptible, region, zone). Non-routing constraints (tpu-name, etc.)

--- a/lib/iris/src/iris/cluster/controller/codec.py
+++ b/lib/iris/src/iris/cluster/controller/codec.py
@@ -14,6 +14,7 @@ from collections.abc import Iterable
 
 from google.protobuf import json_format
 
+from iris.cluster.constraints import Constraint
 from iris.rpc import controller_pb2, job_pb2
 
 # Shared kwargs for MessageToDict so every call site is consistent.
@@ -54,11 +55,18 @@ def constraints_to_json(constraints: Iterable[job_pb2.Constraint]) -> str | None
     return json.dumps(items) if items else None
 
 
-def constraints_from_json(constraints_json: str | None) -> list[job_pb2.Constraint]:
-    """Deserialize a JSON array of constraints back to proto objects."""
+def constraints_from_json(constraints_json: str | None) -> list[Constraint]:
+    """Deserialize a JSON array of constraints to native Constraint objects.
+
+    Goes through proto for JSON parsing, then normalizes via Constraint.from_proto
+    (which strips/lowercases string values for case-insensitive comparison).
+    Native Constraint is the canonical hot-path type — protos only at serialization.
+    """
     if not constraints_json:
         return []
-    return [json_format.ParseDict(item, job_pb2.Constraint()) for item in json.loads(constraints_json)]
+    return [
+        Constraint.from_proto(json_format.ParseDict(item, job_pb2.Constraint())) for item in json.loads(constraints_json)
+    ]
 
 
 def reservation_to_json(request: controller_pb2.Controller.LaunchJobRequest) -> str | None:

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -21,12 +21,14 @@ from iris.cluster.bundle import BundleStore
 from iris.cluster.constraints import (
     AttributeValue,
     Constraint,
+    ConstraintOp,
     PlacementRequirements,
     WellKnownAttribute,
     constraints_from_resources,
     evaluate_constraint,
     extract_placement_requirements,
     merge_constraints,
+    region_constraint as make_region_constraint,
 )
 from iris.cluster.controller.autoscaler import Autoscaler
 from iris.cluster.controller.codec import (
@@ -673,8 +675,7 @@ def _worker_matches_reservation_entry(
     explicit = [Constraint.from_proto(c) for c in res_entry.constraints]
     merged = merge_constraints(auto, explicit)
 
-    merged_protos = [c.to_proto() for c in merged]
-    for constraint in merged_protos:
+    for constraint in merged:
         attr = worker.attributes.get(constraint.key)
         if not evaluate_constraint(attr, constraint):
             return False
@@ -732,18 +733,15 @@ def _inject_taint_constraints(
     if has_direct_reservation is None:
         has_direct_reservation = set()
 
-    taint_constraint = job_pb2.Constraint(
-        key=RESERVATION_TAINT_KEY,
-        op=job_pb2.CONSTRAINT_OP_NOT_EXISTS,
-    )
+    taint_constraint = Constraint(key=RESERVATION_TAINT_KEY, op=ConstraintOp.NOT_EXISTS)
 
     modified: dict[JobName, JobRequirements] = {}
     for job_id, req in jobs.items():
         if job_id in has_direct_reservation:
-            eq_constraint = job_pb2.Constraint(
+            eq_constraint = Constraint(
                 key=RESERVATION_TAINT_KEY,
-                op=job_pb2.CONSTRAINT_OP_EQ,
-                value=job_pb2.AttributeValue(string_value=job_id.to_wire()),
+                op=ConstraintOp.EQ,
+                value=job_id.to_wire(),
             )
             modified[job_id] = replace(
                 req,
@@ -782,8 +780,8 @@ def _reservation_region_constraints(
     job_id_wire: str,
     claims: dict[WorkerId, ReservationClaim],
     queries: ControllerDB,
-    existing_constraints: list[job_pb2.Constraint],
-) -> list[job_pb2.Constraint]:
+    existing_constraints: list[Constraint],
+) -> list[Constraint]:
     """Derive region constraints from claimed reservation workers.
 
     When a reservation job has no explicit region constraint, this function
@@ -812,21 +810,7 @@ def _reservation_region_constraints(
     if not regions:
         return existing_constraints
 
-    region_list = sorted(regions)
-    if len(region_list) == 1:
-        region_constraint = job_pb2.Constraint(
-            key=WellKnownAttribute.REGION,
-            op=job_pb2.CONSTRAINT_OP_EQ,
-            value=job_pb2.AttributeValue(string_value=region_list[0]),
-        )
-    else:
-        region_constraint = job_pb2.Constraint(
-            key=WellKnownAttribute.REGION,
-            op=job_pb2.CONSTRAINT_OP_IN,
-            values=[job_pb2.AttributeValue(string_value=r) for r in region_list],
-        )
-
-    return [*existing_constraints, region_constraint]
+    return [*existing_constraints, make_region_constraint(sorted(regions))]
 
 
 def _preference_pass(

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -738,7 +738,7 @@ def _inject_taint_constraints(
     modified: dict[JobName, JobRequirements] = {}
     for job_id, req in jobs.items():
         if job_id in has_direct_reservation:
-            eq_constraint = Constraint(
+            eq_constraint = Constraint.create(
                 key=RESERVATION_TAINT_KEY,
                 op=ConstraintOp.EQ,
                 value=job_id.to_wire(),

--- a/lib/iris/src/iris/cluster/controller/scheduler.py
+++ b/lib/iris/src/iris/cluster/controller/scheduler.py
@@ -23,6 +23,7 @@ from typing import Any, Protocol
 
 from iris.cluster.constraints import (
     AttributeValue,
+    Constraint,
     ConstraintIndex,
     ResourceCapacity,
     WellKnownAttribute,
@@ -124,13 +125,10 @@ class RejectionReason:
 
 @dataclass
 class JobRequirements:
-    """What a job needs from a worker. Scheduler's input type.
-
-    Protos are readonly -- shared by reference, no copy needed.
-    """
+    """What a job needs from a worker. Scheduler's input type."""
 
     resources: job_pb2.ResourceSpecProto
-    constraints: list[job_pb2.Constraint]
+    constraints: list[Constraint]
     is_coscheduled: bool
     coscheduling_group_by: str | None
 
@@ -260,7 +258,7 @@ class WorkerCapacity:
         # Increment building count since new tasks start in BUILDING state
         self.building_task_count += 1
 
-    def matches_constraints(self, constraints: Sequence[job_pb2.Constraint]) -> bool:
+    def matches_constraints(self, constraints: Sequence[Constraint]) -> bool:
         """Check if this worker matches all given constraints."""
         for constraint in constraints:
             attr = self.attributes.get(constraint.key)
@@ -363,7 +361,7 @@ class SchedulingContext:
             max_assignments_per_worker=max_assignments_per_worker,
         )
 
-    def matching_workers(self, constraints: Sequence[job_pb2.Constraint]) -> set[WorkerId]:
+    def matching_workers(self, constraints: Sequence[Constraint]) -> set[WorkerId]:
         """Get workers matching ALL constraints.
 
         Uses posting lists for fast EQ/EXISTS/NOT_EXISTS lookups.
@@ -421,7 +419,7 @@ class SchedulingResult:
 
 def _rank_by_soft_score(
     candidate_ids: set[WorkerId],
-    soft_constraints: list[job_pb2.Constraint],
+    soft_constraints: list[Constraint],
     context: SchedulingContext,
 ) -> list[WorkerId]:
     """Sort candidate workers by soft-constraint satisfaction (descending).

--- a/lib/iris/src/iris/cluster/controller/schema.py
+++ b/lib/iris/src/iris/cluster/controller/schema.py
@@ -18,7 +18,6 @@ from threading import Lock
 from typing import Any, Generic, TypeVar
 
 from iris.cluster.types import JobName, WorkerId
-from iris.rpc import job_pb2
 from rigging.timing import Timestamp
 
 T = TypeVar("T")
@@ -110,14 +109,6 @@ def proto_decoder(proto_factory: Callable[[], T]) -> Callable[[Any], T]:
         return proto
 
     return decode
-
-
-def _constraint_list_decoder(blob: bytes | None) -> list[job_pb2.Constraint]:
-    if blob is None:
-        return []
-    cl = job_pb2.ConstraintList()
-    cl.ParseFromString(blob)
-    return list(cl.constraints)
 
 
 # Sentinel for "no default" -- distinct from dataclasses.MISSING so we can use

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -404,7 +404,7 @@ def _reconstruct_launch_job_request(job: JobDetailRow) -> controller_pb2.Control
     )
 
     for c in constraints_from_json(job.constraints_json):
-        req.constraints.append(c)
+        req.constraints.append(c.to_proto())
     for port in json.loads(job.ports_json):
         req.ports.append(port)
 
@@ -925,7 +925,7 @@ class AutoscalerProtocol(Protocol):
     def check_coscheduling_feasibility(
         self,
         replicas: int,
-        constraints: list[job_pb2.Constraint],
+        constraints: list[Constraint],
     ) -> str | None:
         """Check if a coscheduled job can be scheduled. Returns error message or None."""
         ...
@@ -1162,7 +1162,7 @@ class ControllerServiceImpl:
             if autoscaler is not None:
                 error = autoscaler.check_coscheduling_feasibility(
                     replicas=request.replicas,
-                    constraints=list(request.constraints),
+                    constraints=[Constraint.from_proto(c) for c in request.constraints],
                 )
                 if error:
                     raise ConnectError(

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -1611,7 +1611,7 @@ class ControllerTransitions:
                         resources=resources,
                         ports=json.loads(job.ports_json),
                         attempt_id=attempt_id,
-                        constraints=constraints_from_json(job.constraints_json),
+                        constraints=[c.to_proto() for c in constraints_from_json(job.constraints_json)],
                         task_image=job.task_image,
                     )
                     enqueue_run_dispatch(cur, str(assignment.worker_id), run_request.SerializeToString(), now_ms)
@@ -3202,7 +3202,7 @@ class ControllerTransitions:
                     resources=resources,
                     ports=json.loads(str(row["ports_json"])),
                     attempt_id=attempt_id,
-                    constraints=constraints_from_json(row["constraints_json"]),
+                    constraints=[c.to_proto() for c in constraints_from_json(row["constraints_json"])],
                     task_image=str(row["task_image"]),
                 )
                 # Propagate timeout for K8s activeDeadlineSeconds (Kubernetes-native enforcement).

--- a/lib/iris/src/iris/cluster/types.py
+++ b/lib/iris/src/iris/cluster/types.py
@@ -343,7 +343,8 @@ class ReservationEntry:
 
     Example:
         >>> ReservationEntry(resources=ResourceSpec(cpu=2, memory="8g"))
-        >>> ReservationEntry(resources=ResourceSpec(cpu=2), constraints=[Constraint("region", value="us-central1")])
+        >>> ReservationEntry(resources=ResourceSpec(cpu=2),
+        ...                  constraints=[Constraint.create(key="region", op=ConstraintOp.EQ, value="us-central1")])
     """
 
     resources: "ResourceSpec"

--- a/lib/iris/tests/cli/test_job.py
+++ b/lib/iris/tests/cli/test_job.py
@@ -94,7 +94,7 @@ def test_executor_heuristic_small_cpu_job_gets_non_preemptible():
     preemptible = infer_preemptible_constraint(resources_proto, replicas, constraints)
     assert preemptible is not None
     assert preemptible.key == WellKnownAttribute.PREEMPTIBLE
-    assert preemptible.value == "false"
+    assert preemptible.values[0].value == "false"
 
 
 def test_executor_heuristic_skipped_for_gpu_job():
@@ -135,7 +135,7 @@ def test_executor_heuristic_with_region_constraint():
 
     preemptible = infer_preemptible_constraint(resources_proto, replicas, constraints)
     assert preemptible is not None
-    assert preemptible.value == "false"
+    assert preemptible.values[0].value == "false"
 
 
 # --tpu multi-variant parsing

--- a/lib/iris/tests/cluster/conftest.py
+++ b/lib/iris/tests/cluster/conftest.py
@@ -16,7 +16,7 @@ from unittest.mock import Mock
 import pytest
 
 from iris.cluster.bundle import BundleStore
-from iris.cluster.constraints import WellKnownAttribute
+from iris.cluster.constraints import Constraint, ConstraintOp, WellKnownAttribute
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.schema import (
     TASK_DETAIL_PROJECTION,
@@ -43,20 +43,14 @@ from rigging.timing import Timestamp
 # ---------------------------------------------------------------------------
 
 
-def eq_constraint(key: str, value: str) -> job_pb2.Constraint:
-    """Build an EQ constraint proto for the given key and string value."""
-    c = job_pb2.Constraint(key=key, op=job_pb2.CONSTRAINT_OP_EQ)
-    c.value.string_value = value
-    return c
+def eq_constraint(key: str, value: str) -> Constraint:
+    """Build an EQ constraint for the given key and string value."""
+    return Constraint(key=key, op=ConstraintOp.EQ, value=value.strip().lower())
 
 
-def in_constraint(key: str, values: list[str]) -> job_pb2.Constraint:
-    """Build an IN constraint proto for the given key and string values."""
-    c = job_pb2.Constraint(key=key, op=job_pb2.CONSTRAINT_OP_IN)
-    for v in values:
-        av = c.values.add()
-        av.string_value = v
-    return c
+def in_constraint(key: str, values: list[str]) -> Constraint:
+    """Build an IN constraint for the given key and string values."""
+    return Constraint(key=key, op=ConstraintOp.IN, values=tuple(v.strip().lower() for v in values))
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/conftest.py
+++ b/lib/iris/tests/cluster/conftest.py
@@ -45,12 +45,12 @@ from rigging.timing import Timestamp
 
 def eq_constraint(key: str, value: str) -> Constraint:
     """Build an EQ constraint for the given key and string value."""
-    return Constraint(key=key, op=ConstraintOp.EQ, value=value.strip().lower())
+    return Constraint.create(key=key, op=ConstraintOp.EQ, value=value)
 
 
 def in_constraint(key: str, values: list[str]) -> Constraint:
     """Build an IN constraint for the given key and string values."""
-    return Constraint(key=key, op=ConstraintOp.IN, values=tuple(v.strip().lower() for v in values))
+    return Constraint.create(key=key, op=ConstraintOp.IN, values=values)
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/controller/conftest.py
+++ b/lib/iris/tests/cluster/controller/conftest.py
@@ -743,14 +743,12 @@ def make_demand_entries(
     if required_zones:
         for z in sorted(required_zones):
             constraint_list.append(zone_constraint(z))
-    proto_constraints = [c.to_proto() for c in constraint_list]
-
     return [
         DemandEntry(
             task_ids=[f"{task_prefix}-{i}"],
             coschedule_group_id=None,
             normalized=normalized,
-            constraints=proto_constraints,
+            constraints=constraint_list,
             resources=resources,
         )
         for i in range(count)

--- a/lib/iris/tests/cluster/controller/conftest.py
+++ b/lib/iris/tests/cluster/controller/conftest.py
@@ -732,7 +732,7 @@ def make_demand_entries(
     constraint_list: list[Constraint] = []
     if device_type is not None:
         constraint_list.append(
-            Constraint(key=WellKnownAttribute.DEVICE_TYPE, op=ConstraintOp.EQ, value=device_type.value)
+            Constraint.create(key=WellKnownAttribute.DEVICE_TYPE, op=ConstraintOp.EQ, value=device_type.value)
         )
     if effective_variants:
         constraint_list.append(device_variant_constraint(sorted(effective_variants)))

--- a/lib/iris/tests/cluster/controller/test_reservation.py
+++ b/lib/iris/tests/cluster/controller/test_reservation.py
@@ -667,7 +667,7 @@ def test_taint_constraint_not_added_to_reservation_jobs():
     eq = [c for c in constraints if c.key == RESERVATION_TAINT_KEY]
     assert len(eq) == 1
     assert eq[0].op == ConstraintOp.EQ
-    assert eq[0].value == res_job.to_wire()
+    assert eq[0].values[0].value == res_job.to_wire()
 
 
 def test_taint_constraint_mixed_jobs():
@@ -689,7 +689,7 @@ def test_taint_constraint_mixed_jobs():
     res_constraints = [c for c in result[res_job].constraints if c.key == RESERVATION_TAINT_KEY]
     assert len(res_constraints) == 1
     assert res_constraints[0].op == ConstraintOp.EQ
-    assert res_constraints[0].value == res_job.to_wire()
+    assert res_constraints[0].values[0].value == res_job.to_wire()
 
     # Descendant: no taint constraint
     desc_constraints = [c for c in result[descendant_job].constraints if c.key == RESERVATION_TAINT_KEY]
@@ -703,11 +703,7 @@ def test_taint_constraint_mixed_jobs():
 
 def test_taint_constraint_preserves_existing_constraints():
     """Existing constraints are preserved when the taint constraint is added."""
-    existing = Constraint(
-        key=WellKnownAttribute.REGION,
-        op=ConstraintOp.EQ,
-        value="us-central1",
-    )
+    existing = Constraint.create(key=WellKnownAttribute.REGION, op=ConstraintOp.EQ, value="us-central1")
     jobs = {
         JobName.root("test-user", "regular"): JobRequirements(
             resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
@@ -923,7 +919,7 @@ def test_region_constraint_injected_from_claimed_workers():
     assert len(result) == 1
     assert result[0].key == WellKnownAttribute.REGION
     assert result[0].op == ConstraintOp.EQ
-    assert result[0].value == "us-central1"
+    assert result[0].values[0].value == "us-central1"
 
 
 def test_region_constraint_not_injected_when_already_present():
@@ -936,11 +932,7 @@ def test_region_constraint_not_injected_when_already_present():
     jid = _submit_job(ctrl.state, "j1", req)
     ctrl._claim_workers_for_reservations()
 
-    existing = Constraint(
-        key=WellKnownAttribute.REGION,
-        op=ConstraintOp.EQ,
-        value="us-east1",
-    )
+    existing = Constraint.create(key=WellKnownAttribute.REGION, op=ConstraintOp.EQ, value="us-east1")
     result = _reservation_region_constraints(
         jid.to_wire(),
         ctrl.reservation_claims,
@@ -995,7 +987,7 @@ def test_region_constraint_multiple_regions():
     assert len(result) == 1
     assert result[0].key == WellKnownAttribute.REGION
     assert result[0].op == ConstraintOp.IN
-    assert set(result[0].values) == {"us-central1", "us-east1"}
+    assert {v.value for v in result[0].values} == {"us-central1", "us-east1"}
 
 
 def test_no_injection_for_non_reservation_job():
@@ -1577,7 +1569,7 @@ def _tpu_metadata(variant: str = "v5p-64", region: str | None = None) -> job_pb2
 
 def _region_constraint(region: str) -> job_pb2.Constraint:
     """Create a region=<value> constraint proto."""
-    return Constraint(key="region", op=ConstraintOp.EQ, value=region).to_proto()
+    return Constraint.create(key="region", op=ConstraintOp.EQ, value=region).to_proto()
 
 
 def test_holder_task_gets_device_constraints_from_tpu_entry(state):

--- a/lib/iris/tests/cluster/controller/test_reservation.py
+++ b/lib/iris/tests/cluster/controller/test_reservation.py
@@ -649,7 +649,7 @@ def test_taint_constraint_added_to_non_reservation_jobs():
     constraints = result[JobName.root("test-user", "regular")].constraints
     not_exists = [c for c in constraints if c.key == RESERVATION_TAINT_KEY]
     assert len(not_exists) == 1
-    assert not_exists[0].op == job_pb2.CONSTRAINT_OP_NOT_EXISTS
+    assert not_exists[0].op == ConstraintOp.NOT_EXISTS
 
 
 def test_taint_constraint_not_added_to_reservation_jobs():
@@ -666,8 +666,8 @@ def test_taint_constraint_not_added_to_reservation_jobs():
     constraints = result[res_job].constraints
     eq = [c for c in constraints if c.key == RESERVATION_TAINT_KEY]
     assert len(eq) == 1
-    assert eq[0].op == job_pb2.CONSTRAINT_OP_EQ
-    assert eq[0].value.string_value == res_job.to_wire()
+    assert eq[0].op == ConstraintOp.EQ
+    assert eq[0].value == res_job.to_wire()
 
 
 def test_taint_constraint_mixed_jobs():
@@ -688,8 +688,8 @@ def test_taint_constraint_mixed_jobs():
     # Direct reservation job: EQ constraint
     res_constraints = [c for c in result[res_job].constraints if c.key == RESERVATION_TAINT_KEY]
     assert len(res_constraints) == 1
-    assert res_constraints[0].op == job_pb2.CONSTRAINT_OP_EQ
-    assert res_constraints[0].value.string_value == res_job.to_wire()
+    assert res_constraints[0].op == ConstraintOp.EQ
+    assert res_constraints[0].value == res_job.to_wire()
 
     # Descendant: no taint constraint
     desc_constraints = [c for c in result[descendant_job].constraints if c.key == RESERVATION_TAINT_KEY]
@@ -698,15 +698,15 @@ def test_taint_constraint_mixed_jobs():
     # Regular job: NOT_EXISTS constraint
     reg_constraints = [c for c in result[reg_job].constraints if c.key == RESERVATION_TAINT_KEY]
     assert len(reg_constraints) == 1
-    assert reg_constraints[0].op == job_pb2.CONSTRAINT_OP_NOT_EXISTS
+    assert reg_constraints[0].op == ConstraintOp.NOT_EXISTS
 
 
 def test_taint_constraint_preserves_existing_constraints():
     """Existing constraints are preserved when the taint constraint is added."""
-    existing = job_pb2.Constraint(
+    existing = Constraint(
         key=WellKnownAttribute.REGION,
-        op=job_pb2.CONSTRAINT_OP_EQ,
-        value=job_pb2.AttributeValue(string_value="us-central1"),
+        op=ConstraintOp.EQ,
+        value="us-central1",
     )
     jobs = {
         JobName.root("test-user", "regular"): JobRequirements(
@@ -922,8 +922,8 @@ def test_region_constraint_injected_from_claimed_workers():
 
     assert len(result) == 1
     assert result[0].key == WellKnownAttribute.REGION
-    assert result[0].op == job_pb2.CONSTRAINT_OP_EQ
-    assert result[0].value.string_value == "us-central1"
+    assert result[0].op == ConstraintOp.EQ
+    assert result[0].value == "us-central1"
 
 
 def test_region_constraint_not_injected_when_already_present():
@@ -936,10 +936,10 @@ def test_region_constraint_not_injected_when_already_present():
     jid = _submit_job(ctrl.state, "j1", req)
     ctrl._claim_workers_for_reservations()
 
-    existing = job_pb2.Constraint(
+    existing = Constraint(
         key=WellKnownAttribute.REGION,
-        op=job_pb2.CONSTRAINT_OP_EQ,
-        value=job_pb2.AttributeValue(string_value="us-east1"),
+        op=ConstraintOp.EQ,
+        value="us-east1",
     )
     result = _reservation_region_constraints(
         jid.to_wire(),
@@ -994,9 +994,8 @@ def test_region_constraint_multiple_regions():
 
     assert len(result) == 1
     assert result[0].key == WellKnownAttribute.REGION
-    assert result[0].op == job_pb2.CONSTRAINT_OP_IN
-    regions = {v.string_value for v in result[0].values}
-    assert regions == {"us-central1", "us-east1"}
+    assert result[0].op == ConstraintOp.IN
+    assert set(result[0].values) == {"us-central1", "us-east1"}
 
 
 def test_no_injection_for_non_reservation_job():

--- a/lib/iris/tests/cluster/controller/test_scheduler.py
+++ b/lib/iris/tests/cluster/controller/test_scheduler.py
@@ -419,7 +419,7 @@ def test_constraint_filters_workers_by_attribute(scheduler, state):
 
     # Job with constraint requiring tpu-name = "tpu-a"
     req = make_job_request()
-    req.constraints.append(eq_constraint(WellKnownAttribute.TPU_NAME, "tpu-a"))
+    req.constraints.append(eq_constraint(WellKnownAttribute.TPU_NAME, "tpu-a").to_proto())
     tasks = submit_job(state, "j1", req)
 
     context = _build_context(scheduler, state)
@@ -602,7 +602,7 @@ def test_constraint_in_operator_matches_any_value(scheduler, state):
 
     # Job with IN constraint: region IN (us-central1, us-central2)
     req = make_job_request()
-    req.constraints.append(in_constraint(WellKnownAttribute.REGION, ["us-central1", "us-central2"]))
+    req.constraints.append(in_constraint(WellKnownAttribute.REGION, ["us-central1", "us-central2"]).to_proto())
 
     submit_job(state, "j1", req)
 
@@ -621,7 +621,7 @@ def test_constraint_in_operator_no_match(scheduler, state):
     register_worker(state, "w1", "addr1", meta)
 
     req = make_job_request()
-    req.constraints.append(in_constraint(WellKnownAttribute.REGION, ["us-central1", "us-central2"]))
+    req.constraints.append(in_constraint(WellKnownAttribute.REGION, ["us-central1", "us-central2"]).to_proto())
     submit_job(state, "j1", req)
 
     context = _build_context(scheduler, state)
@@ -652,7 +652,7 @@ def test_multiple_constraints_all_must_match(scheduler, state):
 
     # Job requiring tpu-name=tpu-a AND tpu-worker-id=0
     req = make_job_request()
-    req.constraints.append(eq_constraint(WellKnownAttribute.TPU_NAME, "tpu-a"))
+    req.constraints.append(eq_constraint(WellKnownAttribute.TPU_NAME, "tpu-a").to_proto())
     c2 = req.constraints.add()
     c2.key = WellKnownAttribute.TPU_WORKER_ID
     c2.op = job_pb2.CONSTRAINT_OP_EQ
@@ -675,7 +675,7 @@ def test_constraint_with_missing_attribute_fails(scheduler, state):
 
     # Job requiring tpu-name = "tpu-a"
     req = make_job_request()
-    req.constraints.append(eq_constraint(WellKnownAttribute.TPU_NAME, "tpu-a"))
+    req.constraints.append(eq_constraint(WellKnownAttribute.TPU_NAME, "tpu-a").to_proto())
     submit_job(state, "j1", req)
 
     context = _build_context(scheduler, state)
@@ -896,7 +896,7 @@ def test_coscheduled_job_with_constraints(scheduler, state):
         environment=job_pb2.EnvironmentConfig(),
     )
     req.coscheduling.group_by = WellKnownAttribute.TPU_NAME
-    req.constraints.append(eq_constraint(WellKnownAttribute.REGION, "us-east"))
+    req.constraints.append(eq_constraint(WellKnownAttribute.REGION, "us-east").to_proto())
     submit_job(state, "j1", req)
 
     context = _build_context(scheduler, state)
@@ -1153,7 +1153,7 @@ def test_preemptible_constraint_routes_to_matching_worker(scheduler, state):
 
     # Job requiring non-preemptible worker
     req = make_job_request()
-    req.constraints.append(eq_constraint(WellKnownAttribute.PREEMPTIBLE, "false"))
+    req.constraints.append(eq_constraint(WellKnownAttribute.PREEMPTIBLE, "false").to_proto())
     tasks = submit_job(state, "j1", req)
 
     context = _build_context(scheduler, state)
@@ -2027,7 +2027,7 @@ def test_device_variant_in_constraint_matches_probed_workers(scheduler, state):
     _register_worker_with_probed_attributes(state, "w3", "addr3", meta3)
 
     req = make_job_request()
-    req.constraints.append(in_constraint(WellKnownAttribute.DEVICE_VARIANT, ["v5litepod-8", "v4-8"]))
+    req.constraints.append(in_constraint(WellKnownAttribute.DEVICE_VARIANT, ["v5litepod-8", "v4-8"]).to_proto())
 
     submit_job(state, "flex-job", req)
     result = schedule_until_done(scheduler, state)

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -959,9 +959,9 @@ def test_launch_job_injects_device_constraints_from_tpu_resource(service, state)
     assert WellKnownAttribute.DEVICE_VARIANT in keys
 
     dt = next(c for c in stored_constraints if c.key == WellKnownAttribute.DEVICE_TYPE)
-    assert dt.value == "tpu"
+    assert dt.values[0].value == "tpu"
     dv = next(c for c in stored_constraints if c.key == WellKnownAttribute.DEVICE_VARIANT)
-    assert dv.value == "v5litepod-16"
+    assert dv.values[0].value == "v5litepod-16"
 
 
 def test_launch_job_user_constraints_override_auto(service, state):
@@ -990,7 +990,7 @@ def test_launch_job_user_constraints_override_auto(service, state):
     # device-type should still be auto-injected
     dt_constraints = [c for c in stored_constraints if c.key == WellKnownAttribute.DEVICE_TYPE]
     assert len(dt_constraints) == 1
-    assert dt_constraints[0].value == "tpu"
+    assert dt_constraints[0].values[0].value == "tpu"
 
 
 def test_launch_job_cpu_resource_no_constraints_injected(service, state):

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -11,7 +11,7 @@ import pytest
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 
-from iris.cluster.constraints import WellKnownAttribute, device_variant_constraint
+from iris.cluster.constraints import ConstraintOp, WellKnownAttribute, device_variant_constraint
 from iris.cluster.controller.service import ControllerServiceImpl
 from iris.log_server.server import LogServiceImpl
 from iris.cluster.controller.codec import constraints_from_json
@@ -959,9 +959,9 @@ def test_launch_job_injects_device_constraints_from_tpu_resource(service, state)
     assert WellKnownAttribute.DEVICE_VARIANT in keys
 
     dt = next(c for c in stored_constraints if c.key == WellKnownAttribute.DEVICE_TYPE)
-    assert dt.value.string_value == "tpu"
+    assert dt.value == "tpu"
     dv = next(c for c in stored_constraints if c.key == WellKnownAttribute.DEVICE_VARIANT)
-    assert dv.value.string_value == "v5litepod-16"
+    assert dv.value == "v5litepod-16"
 
 
 def test_launch_job_user_constraints_override_auto(service, state):
@@ -985,12 +985,12 @@ def test_launch_job_user_constraints_override_auto(service, state):
     # device-variant should be the user's IN constraint, not the auto EQ
     dv_constraints = [c for c in stored_constraints if c.key == WellKnownAttribute.DEVICE_VARIANT]
     assert len(dv_constraints) == 1
-    assert dv_constraints[0].op == job_pb2.CONSTRAINT_OP_IN
+    assert dv_constraints[0].op == ConstraintOp.IN
 
     # device-type should still be auto-injected
     dt_constraints = [c for c in stored_constraints if c.key == WellKnownAttribute.DEVICE_TYPE]
     assert len(dt_constraints) == 1
-    assert dt_constraints[0].value.string_value == "tpu"
+    assert dt_constraints[0].value == "tpu"
 
 
 def test_launch_job_cpu_resource_no_constraints_injected(service, state):

--- a/lib/iris/tests/cluster/test_constraints.py
+++ b/lib/iris/tests/cluster/test_constraints.py
@@ -8,6 +8,7 @@ import pytest
 from iris.cluster.constraints import (
     AttributeValue,
     Constraint,
+    ConstraintIndex,
     ConstraintOp,
     DeviceType,
     INHERITED_CONSTRAINT_KEYS,
@@ -120,16 +121,16 @@ def test_extract_placement_requirements_parameterized(constraints, expected):
 
 
 def test_merge_canonical_key_child_overrides_parent():
-    parent = [Constraint(key="device-type", op=ConstraintOp.EQ, value="gpu")]
-    child = [Constraint(key="device-type", op=ConstraintOp.EQ, value="tpu")]
+    parent = [Constraint.create(key="device-type", op=ConstraintOp.EQ, value="gpu")]
+    child = [Constraint.create(key="device-type", op=ConstraintOp.EQ, value="tpu")]
     merged = merge_constraints(parent, child)
     assert len(merged) == 1
-    assert merged[0].value == "tpu"
+    assert merged[0].values[0].value == "tpu"
 
 
 def test_merge_non_canonical_key_appends():
-    parent = [Constraint(key="tpu-name", op=ConstraintOp.EQ, value="pod-a")]
-    child = [Constraint(key="tpu-name", op=ConstraintOp.EQ, value="pod-b")]
+    parent = [Constraint.create(key="tpu-name", op=ConstraintOp.EQ, value="pod-a")]
+    child = [Constraint.create(key="tpu-name", op=ConstraintOp.EQ, value="pod-b")]
     merged = merge_constraints(parent, child)
     assert len(merged) == 2
 
@@ -213,7 +214,7 @@ def test_infer_preemptible_constraint_adds_non_preemptible():
     result = infer_preemptible_constraint(resources, replicas=1, existing_constraints=[])
     assert result is not None
     assert result.key == WellKnownAttribute.PREEMPTIBLE
-    assert result.value == "false"
+    assert result.values[0].value == "false"
 
 
 def test_infer_preemptible_constraint_noop_when_explicit():
@@ -236,11 +237,11 @@ def test_preemptible_constraint_soft_default_logic():
     """preemptible=True defaults to soft, preemptible=False defaults to hard."""
     c_true = preemptible_constraint(True)
     assert c_true.mode == job_pb2.CONSTRAINT_MODE_PREFERRED
-    assert c_true.value == "true"
+    assert c_true.values[0].value == "true"
 
     c_false = preemptible_constraint(False)
     assert c_false.mode == job_pb2.CONSTRAINT_MODE_REQUIRED
-    assert c_false.value == "false"
+    assert c_false.values[0].value == "false"
 
 
 def test_preemptible_constraint_soft_override():
@@ -254,7 +255,7 @@ def test_preemptible_constraint_soft_override():
 
 def test_split_hard_soft():
     hard = eq_constraint("region", "us-central1")
-    soft = Constraint(
+    soft = Constraint.create(
         key="preemptible",
         op=ConstraintOp.EQ,
         value="true",
@@ -276,7 +277,7 @@ def test_split_hard_soft_all_required():
 
 
 def _soft_eq(key: str, value: str) -> Constraint:
-    return Constraint(key=key, op=ConstraintOp.EQ, value=value.lower(), mode=job_pb2.CONSTRAINT_MODE_PREFERRED)
+    return Constraint.create(key=key, op=ConstraintOp.EQ, value=value, mode=job_pb2.CONSTRAINT_MODE_PREFERRED)
 
 
 def test_soft_constraint_score_counts_matches():
@@ -297,3 +298,44 @@ def test_soft_constraint_score_zero_when_no_match():
     attrs = {"preemptible": AttributeValue("false")}
     soft = _soft_eq("preemptible", "true")
     assert soft_constraint_score(attrs, [soft]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Regression: case-insensitive matching for custom user attributes.
+# Worker attributes and constraint literals share AttributeValue, which
+# normalizes strings at construction — so "NLP" on either side matches "nlp".
+# ---------------------------------------------------------------------------
+
+
+def test_custom_attribute_case_insensitive_match_evaluator():
+    attrs = {"team": AttributeValue("NLP")}
+    proto = job_pb2.Constraint(key="team", op=job_pb2.CONSTRAINT_OP_EQ)
+    proto.value.string_value = "NLP"
+    c = Constraint.from_proto(proto)
+    assert evaluate_constraint(attrs["team"], c)
+
+
+def test_custom_attribute_case_insensitive_match_index():
+    entities = {"w1": {"team": AttributeValue("NLP")}}
+    index = ConstraintIndex.build(entities)
+    proto = job_pb2.Constraint(key="team", op=job_pb2.CONSTRAINT_OP_EQ)
+    proto.value.string_value = "NLP"
+    c = Constraint.from_proto(proto)
+    assert index.matching_entities([c]) == {"w1"}
+
+
+def test_attribute_value_normalizes_at_construction():
+    av = AttributeValue("  My-Region  ")
+    assert av.value == "my-region"
+    # Integers and floats pass through untouched.
+    assert AttributeValue(64).value == 64
+    assert AttributeValue(1.5).value == 1.5
+
+
+def test_constraint_rejects_invalid_arity():
+    with pytest.raises(ValueError, match="EQ requires"):
+        Constraint(key="region", op=ConstraintOp.EQ, values=())
+    with pytest.raises(ValueError, match="IN requires"):
+        Constraint(key="region", op=ConstraintOp.IN, values=())
+    with pytest.raises(ValueError, match="EXISTS"):
+        Constraint.create(key="gpu", op=ConstraintOp.EXISTS, value="x")

--- a/lib/iris/tests/cluster/test_constraints.py
+++ b/lib/iris/tests/cluster/test_constraints.py
@@ -254,12 +254,12 @@ def test_preemptible_constraint_soft_override():
 
 def test_split_hard_soft():
     hard = eq_constraint("region", "us-central1")
-    soft = job_pb2.Constraint(
+    soft = Constraint(
         key="preemptible",
-        op=job_pb2.CONSTRAINT_OP_EQ,
+        op=ConstraintOp.EQ,
+        value="true",
         mode=job_pb2.CONSTRAINT_MODE_PREFERRED,
     )
-    soft.value.string_value = "true"
     hard_list, soft_list = split_hard_soft([hard, soft])
     assert len(hard_list) == 1
     assert hard_list[0].key == "region"
@@ -275,25 +275,25 @@ def test_split_hard_soft_all_required():
     assert len(soft_list) == 0
 
 
+def _soft_eq(key: str, value: str) -> Constraint:
+    return Constraint(key=key, op=ConstraintOp.EQ, value=value.lower(), mode=job_pb2.CONSTRAINT_MODE_PREFERRED)
+
+
 def test_soft_constraint_score_counts_matches():
     attrs = {
         "preemptible": AttributeValue("true"),
         "region": AttributeValue("us-central1"),
     }
-    soft1 = eq_constraint("preemptible", "true")
-    soft1.mode = job_pb2.CONSTRAINT_MODE_PREFERRED
-    soft2 = eq_constraint("region", "eu-west1")
-    soft2.mode = job_pb2.CONSTRAINT_MODE_PREFERRED
+    soft1 = _soft_eq("preemptible", "true")
+    soft2 = _soft_eq("region", "eu-west1")
     # Only preemptible matches
     assert soft_constraint_score(attrs, [soft1, soft2]) == 1
     # Both match
-    soft2_match = eq_constraint("region", "us-central1")
-    soft2_match.mode = job_pb2.CONSTRAINT_MODE_PREFERRED
+    soft2_match = _soft_eq("region", "us-central1")
     assert soft_constraint_score(attrs, [soft1, soft2_match]) == 2
 
 
 def test_soft_constraint_score_zero_when_no_match():
     attrs = {"preemptible": AttributeValue("false")}
-    soft = eq_constraint("preemptible", "true")
-    soft.mode = job_pb2.CONSTRAINT_MODE_PREFERRED
+    soft = _soft_eq("preemptible", "true")
     assert soft_constraint_score(attrs, [soft]) == 0

--- a/lib/iris/tests/cluster/test_env_propagation.py
+++ b/lib/iris/tests/cluster/test_env_propagation.py
@@ -135,8 +135,8 @@ def test_child_job_inherits_parent_constraints(capturing_client, parent_context)
     entrypoint = Entrypoint.from_callable(dummy_entrypoint)
     resources = ResourceSpec(cpu=1, memory="1g")
     parent_constraints = [
-        Constraint(key=WellKnownAttribute.REGION, op=ConstraintOp.EQ, value="us-west4"),
-        Constraint(key=WellKnownAttribute.PREEMPTIBLE, op=ConstraintOp.EQ, value="true"),
+        Constraint.create(key=WellKnownAttribute.REGION, op=ConstraintOp.EQ, value="us-west4"),
+        Constraint.create(key=WellKnownAttribute.PREEMPTIBLE, op=ConstraintOp.EQ, value="true"),
     ]
 
     with (
@@ -157,8 +157,8 @@ def test_child_explicit_constraints_override_parent(capturing_client, parent_con
     client, stub = capturing_client
     entrypoint = Entrypoint.from_callable(dummy_entrypoint)
     resources = ResourceSpec(cpu=1, memory="1g")
-    parent_constraints = [Constraint(key=WellKnownAttribute.REGION, op=ConstraintOp.EQ, value="us-west4")]
-    child_constraints = [Constraint(key=WellKnownAttribute.REGION, op=ConstraintOp.EQ, value="europe-west4")]
+    parent_constraints = [Constraint.create(key=WellKnownAttribute.REGION, op=ConstraintOp.EQ, value="us-west4")]
+    child_constraints = [Constraint.create(key=WellKnownAttribute.REGION, op=ConstraintOp.EQ, value="europe-west4")]
 
     with (
         iris_ctx_scope(parent_context),
@@ -201,7 +201,7 @@ def test_child_explicit_region_not_overridden_by_worker_region(capturing_client,
     client, stub = capturing_client
     entrypoint = Entrypoint.from_callable(dummy_entrypoint)
     resources = ResourceSpec(cpu=1, memory="1g")
-    child_constraints = [Constraint(key=WellKnownAttribute.REGION, op=ConstraintOp.EQ, value="europe-west4")]
+    child_constraints = [Constraint.create(key=WellKnownAttribute.REGION, op=ConstraintOp.EQ, value="europe-west4")]
 
     with (
         iris_ctx_scope(parent_context),
@@ -226,7 +226,7 @@ def test_parent_region_constraint_not_overridden_by_worker_region(capturing_clie
     client, stub = capturing_client
     entrypoint = Entrypoint.from_callable(dummy_entrypoint)
     resources = ResourceSpec(cpu=1, memory="1g")
-    parent_constraints = [Constraint(key=WellKnownAttribute.REGION, op=ConstraintOp.EQ, value="us-west4")]
+    parent_constraints = [Constraint.create(key=WellKnownAttribute.REGION, op=ConstraintOp.EQ, value="us-west4")]
 
     with (
         iris_ctx_scope(parent_context),

--- a/lib/iris/tests/cluster/test_types.py
+++ b/lib/iris/tests/cluster/test_types.py
@@ -201,7 +201,7 @@ def test_task_name_attempt_zero():
 
 def _proto_constraint(key: str, string_value: str, op: int = job_pb2.CONSTRAINT_OP_EQ) -> Constraint:
     """Build a native Constraint with a string value (normalized at construction)."""
-    return Constraint(key=key, op=ConstraintOp(op), value=string_value.strip().lower())
+    return Constraint.create(key=key, op=ConstraintOp(op), value=string_value)
 
 
 # ---------------------------------------------------------------------------
@@ -213,15 +213,14 @@ def test_region_constraint_single_region_produces_eq():
     c = region_constraint(["us-west4"])
     assert c.key == WellKnownAttribute.REGION
     assert c.op == ConstraintOp.EQ
-    assert c.value == "us-west4"
+    assert c.values[0].value == "us-west4"
 
 
 def test_region_constraint_multiple_regions_produces_in():
     c = region_constraint(["us-central1", "us-central2"])
     assert c.key == WellKnownAttribute.REGION
     assert c.op == ConstraintOp.IN
-    assert c.values == ("us-central1", "us-central2")
-    assert c.value is None
+    assert tuple(v.value for v in c.values) == ("us-central1", "us-central2")
 
 
 def test_region_constraint_empty_list_raises():
@@ -366,7 +365,7 @@ def test_merge_child_overrides_region():
     result = merge_constraints(parent, child)
     regions = [c for c in result if c.key == WellKnownAttribute.REGION]
     assert len(regions) == 1
-    assert regions[0].value == "eu-west4"
+    assert regions[0].values[0].value == "eu-west4"
 
 
 def test_merge_child_overrides_preemptible():
@@ -375,32 +374,32 @@ def test_merge_child_overrides_preemptible():
     result = merge_constraints(parent, child)
     preemptibles = [c for c in result if c.key == WellKnownAttribute.PREEMPTIBLE]
     assert len(preemptibles) == 1
-    assert preemptibles[0].value == "false"
+    assert preemptibles[0].values[0].value == "false"
 
 
 def test_merge_child_overrides_zone():
     """Child zone constraint replaces parent's (zone is canonical)."""
-    parent = [Constraint(key=WellKnownAttribute.ZONE, op=ConstraintOp.EQ, value="a")]
-    child = [Constraint(key=WellKnownAttribute.ZONE, op=ConstraintOp.EQ, value="b")]
+    parent = [Constraint.create(key=WellKnownAttribute.ZONE, op=ConstraintOp.EQ, value="a")]
+    child = [Constraint.create(key=WellKnownAttribute.ZONE, op=ConstraintOp.EQ, value="b")]
     result = merge_constraints(parent, child)
     zone_constraints = [c for c in result if c.key == WellKnownAttribute.ZONE]
     assert len(zone_constraints) == 1
-    assert zone_constraints[0].value == "b"
+    assert zone_constraints[0].values[0].value == "b"
 
 
 def test_merge_non_canonical_key_both_present():
     """Non-canonical keys from parent and child are both kept."""
-    parent = [Constraint(key=WellKnownAttribute.TPU_NAME, op=ConstraintOp.EQ, value="a")]
-    child = [Constraint(key=WellKnownAttribute.TPU_NAME, op=ConstraintOp.EQ, value="b")]
+    parent = [Constraint.create(key=WellKnownAttribute.TPU_NAME, op=ConstraintOp.EQ, value="a")]
+    child = [Constraint.create(key=WellKnownAttribute.TPU_NAME, op=ConstraintOp.EQ, value="b")]
     result = merge_constraints(parent, child)
     tpu_constraints = [c for c in result if c.key == WellKnownAttribute.TPU_NAME]
     assert len(tpu_constraints) == 2
-    assert {c.value for c in tpu_constraints} == {"a", "b"}
+    assert {c.values[0].value for c in tpu_constraints} == {"a", "b"}
 
 
 def test_merge_non_canonical_key_dedup():
     """Duplicate non-canonical constraints are deduplicated."""
-    shared = Constraint(key=WellKnownAttribute.TPU_NAME, op=ConstraintOp.EQ, value="a")
+    shared = Constraint.create(key=WellKnownAttribute.TPU_NAME, op=ConstraintOp.EQ, value="a")
     result = merge_constraints([shared], [shared])
     tpu_constraints = [c for c in result if c.key == WellKnownAttribute.TPU_NAME]
     assert len(tpu_constraints) == 1
@@ -414,11 +413,11 @@ def test_merge_multiple_canonical_keys_partial_override():
 
     regions = [c for c in result if c.key == WellKnownAttribute.REGION]
     assert len(regions) == 1
-    assert regions[0].value == "eu-west4"
+    assert regions[0].values[0].value == "eu-west4"
 
     preemptibles = [c for c in result if c.key == WellKnownAttribute.PREEMPTIBLE]
     assert len(preemptibles) == 1
-    assert preemptibles[0].value == "true"
+    assert preemptibles[0].values[0].value == "true"
 
 
 def test_region_constraint_empty_string_in_multi_raises():
@@ -433,7 +432,7 @@ def test_region_constraint_empty_string_in_multi_raises():
 
 def test_constraint_in_proto_roundtrip():
     """IN constraint survives a proto round-trip."""
-    original = Constraint(key=WellKnownAttribute.REGION, op=ConstraintOp.IN, values=("us-central1", "eu-west4"))
+    original = Constraint.create(key=WellKnownAttribute.REGION, op=ConstraintOp.IN, values=["us-central1", "eu-west4"])
     proto = original.to_proto()
     assert proto.op == job_pb2.CONSTRAINT_OP_IN
     assert len(proto.values) == 2
@@ -448,7 +447,7 @@ def test_constraint_in_proto_roundtrip():
 
 def _proto_in_constraint(key: str, string_values: list[str]) -> Constraint:
     """Build a native IN Constraint with multiple string values."""
-    return Constraint(key=key, op=ConstraintOp.IN, values=tuple(v.strip().lower() for v in string_values))
+    return Constraint.create(key=key, op=ConstraintOp.IN, values=list(string_values))
 
 
 def test_required_regions_in_multiple():
@@ -464,10 +463,9 @@ def test_required_regions_in_single():
 
 
 def test_required_regions_in_empty_values_raises():
-    """IN constraint with no values is invalid."""
-    c = Constraint(key=WellKnownAttribute.REGION, op=ConstraintOp.IN, values=())
-    with pytest.raises(ValueError, match="at least one value"):
-        extract_placement_requirements([c])
+    """IN constraint with no values is invalid — rejected at construction."""
+    with pytest.raises(ValueError, match="IN requires"):
+        Constraint(key=WellKnownAttribute.REGION, op=ConstraintOp.IN, values=())
 
 
 def test_extract_placement_requirements_with_in_region():
@@ -497,9 +495,9 @@ def test_constraints_from_resources_tpu():
     assert WellKnownAttribute.DEVICE_TYPE in keys
     assert WellKnownAttribute.DEVICE_VARIANT in keys
     type_c = next(c for c in result if c.key == WellKnownAttribute.DEVICE_TYPE)
-    assert type_c.value == "tpu"
+    assert type_c.values[0].value == "tpu"
     variant_c = next(c for c in result if c.key == WellKnownAttribute.DEVICE_VARIANT)
-    assert variant_c.value == "v5litepod-16"
+    assert variant_c.values[0].value == "v5litepod-16"
 
 
 def test_constraints_from_resources_gpu():
@@ -507,9 +505,9 @@ def test_constraints_from_resources_gpu():
     resources.device.CopyFrom(gpu_device("H100", count=8))
     result = constraints_from_resources(resources)
     type_c = next(c for c in result if c.key == WellKnownAttribute.DEVICE_TYPE)
-    assert type_c.value == "gpu"
+    assert type_c.values[0].value == "gpu"
     variant_c = next(c for c in result if c.key == WellKnownAttribute.DEVICE_VARIANT)
-    assert variant_c.value == "h100"
+    assert variant_c.values[0].value == "h100"
 
 
 def test_constraints_from_resources_cpu_produces_nothing():
@@ -543,12 +541,12 @@ def test_constraints_from_resources_auto_variant_skipped():
 
 def test_merge_child_overrides_device_type():
     """Child device-type constraint replaces parent's."""
-    parent = [Constraint(key=WellKnownAttribute.DEVICE_TYPE, op=ConstraintOp.EQ, value="tpu")]
-    child = [Constraint(key=WellKnownAttribute.DEVICE_TYPE, op=ConstraintOp.EQ, value="gpu")]
+    parent = [Constraint.create(key=WellKnownAttribute.DEVICE_TYPE, op=ConstraintOp.EQ, value="tpu")]
+    child = [Constraint.create(key=WellKnownAttribute.DEVICE_TYPE, op=ConstraintOp.EQ, value="gpu")]
     result = merge_constraints(parent, child)
     dt = [c for c in result if c.key == WellKnownAttribute.DEVICE_TYPE]
     assert len(dt) == 1
-    assert dt[0].value == "gpu"
+    assert dt[0].values[0].value == "gpu"
 
 
 # ---------------------------------------------------------------------------
@@ -593,10 +591,10 @@ def test_merge_auto_constraints_with_user_variant_override():
     # device-type from auto should be kept
     dt = [c for c in merged if c.key == WellKnownAttribute.DEVICE_TYPE]
     assert len(dt) == 1
-    assert dt[0].value == "tpu"
+    assert dt[0].values[0].value == "tpu"
 
     # device-variant should be the user's IN constraint, not auto's EQ
     dv = [c for c in merged if c.key == WellKnownAttribute.DEVICE_VARIANT]
     assert len(dv) == 1
     assert dv[0].op == ConstraintOp.IN
-    assert dv[0].values == ("v5litepod-16", "v6e-16")
+    assert tuple(v.value for v in dv[0].values) == ("v5litepod-16", "v6e-16")

--- a/lib/iris/tests/cluster/test_types.py
+++ b/lib/iris/tests/cluster/test_types.py
@@ -199,13 +199,9 @@ def test_task_name_attempt_zero():
 # ---------------------------------------------------------------------------
 
 
-def _proto_constraint(key: str, string_value: str, op: int = job_pb2.CONSTRAINT_OP_EQ) -> job_pb2.Constraint:
-    """Build a proto Constraint with a string value."""
-    return job_pb2.Constraint(
-        key=key,
-        op=op,
-        value=job_pb2.AttributeValue(string_value=string_value),
-    )
+def _proto_constraint(key: str, string_value: str, op: int = job_pb2.CONSTRAINT_OP_EQ) -> Constraint:
+    """Build a native Constraint with a string value (normalized at construction)."""
+    return Constraint(key=key, op=ConstraintOp(op), value=string_value.strip().lower())
 
 
 # ---------------------------------------------------------------------------
@@ -450,12 +446,9 @@ def test_constraint_in_proto_roundtrip():
 # ---------------------------------------------------------------------------
 
 
-def _proto_in_constraint(key: str, string_values: list[str]) -> job_pb2.Constraint:
-    """Build a proto Constraint with IN op and multiple string values."""
-    c = job_pb2.Constraint(key=key, op=job_pb2.CONSTRAINT_OP_IN)
-    for sv in string_values:
-        c.values.append(job_pb2.AttributeValue(string_value=sv))
-    return c
+def _proto_in_constraint(key: str, string_values: list[str]) -> Constraint:
+    """Build a native IN Constraint with multiple string values."""
+    return Constraint(key=key, op=ConstraintOp.IN, values=tuple(v.strip().lower() for v in string_values))
 
 
 def test_required_regions_in_multiple():
@@ -472,7 +465,7 @@ def test_required_regions_in_single():
 
 def test_required_regions_in_empty_values_raises():
     """IN constraint with no values is invalid."""
-    c = job_pb2.Constraint(key=WellKnownAttribute.REGION, op=job_pb2.CONSTRAINT_OP_IN)
+    c = Constraint(key=WellKnownAttribute.REGION, op=ConstraintOp.IN, values=())
     with pytest.raises(ValueError, match="at least one value"):
         extract_placement_requirements([c])
 

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -367,9 +367,9 @@ def test_dashboard_task_logs(smoke_cluster, verbose_job, smoke_page, smoke_scree
 def test_dashboard_constraints(smoke_cluster, smoke_page, smoke_screenshot):
     """Constraint chips rendered on job detail."""
     constraints = [
-        Constraint(key="region", op=ConstraintOp.EQ, value="local"),
-        Constraint(key="env-tag", op=ConstraintOp.EXISTS),
-        Constraint(key="device-variant", op=ConstraintOp.IN, values=("v5p-8", "v6e-4")),
+        Constraint.create(key="region", op=ConstraintOp.EQ, value="local"),
+        Constraint.create(key="env-tag", op=ConstraintOp.EXISTS),
+        Constraint.create(key="device-variant", op=ConstraintOp.IN, values=["v5p-8", "v6e-4"]),
     ]
     with smoke_cluster.launched_job(TestJobs.quick, "smoke-constraints", constraints=constraints) as job:
         time.sleep(3)

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -11,27 +11,21 @@ has workers across CPU, TPU coscheduling, and multi-region scale groups.
 import logging
 import os
 import re
-import subprocess
 import time
 import uuid
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 from connectrpc.errors import ConnectError
 from iris.client.client import IrisClient
 from iris.cluster.config import connect_cluster, load_config, make_local_config
 from iris.cluster.constraints import Constraint, ConstraintOp, WellKnownAttribute, region_constraint
-from iris.cluster.runtime.process import ProcessRuntime
 from iris.cluster.types import (
     Entrypoint,
     ReservationEntry,
     ResourceSpec,
     gpu_device,
 )
-from iris.cluster.worker.env_probe import DefaultEnvironmentProvider
-from iris.cluster.worker.worker import Worker, WorkerConfig
-from iris.managed_thread import ThreadContainer
 from iris.rpc import config_pb2, logging_pb2
 from iris.rpc import job_pb2
 from iris.rpc import controller_pb2
@@ -887,10 +881,8 @@ def test_stress_50_tasks(smoke_cluster):
 
 
 # ============================================================================
-# GPU metadata (local-only, creates standalone cluster with mocked nvidia-smi)
+# Standalone cluster helpers
 # ============================================================================
-
-_NVIDIA_SMI_H100_8X = "\n".join(["NVIDIA H100 80GB HBM3, 81559"] * 8)
 
 
 def _make_controller_only_config() -> config_pb2.IrisClusterConfig:
@@ -911,77 +903,7 @@ def _make_controller_only_config() -> config_pb2.IrisClusterConfig:
     return make_local_config(config)
 
 
-def test_gpu_worker_metadata(tmp_path):
-    """Mocked nvidia-smi registers GPU metadata on worker.
-
-    Creates a standalone local cluster (not the shared smoke_cluster) with a
-    manually started worker using mocked nvidia-smi output. This test only
-    works in local mode — it doesn't run against real GPU/TPU clusters.
-    """
-    config = _make_controller_only_config()
-
-    with connect_cluster(config) as url:
-        original_run = subprocess.run
-        with patch(
-            "iris.cluster.worker.env_probe.subprocess.run",
-            side_effect=lambda cmd, *a, **kw: (
-                subprocess.CompletedProcess(args=cmd, returncode=0, stdout=_NVIDIA_SMI_H100_8X, stderr="")
-                if isinstance(cmd, list) and cmd and cmd[0] == "nvidia-smi"
-                else original_run(cmd, *a, **kw)
-            ),
-        ):
-            env_provider = DefaultEnvironmentProvider()
-            threads = ThreadContainer(name="test-gpu-worker")
-            cache_dir = tmp_path / "cache"
-            cache_dir.mkdir()
-
-            worker_config = WorkerConfig(
-                host="127.0.0.1",
-                port=0,
-                cache_dir=cache_dir,
-                controller_address=url,
-                worker_id=f"test-gpu-worker-{uuid.uuid4().hex[:8]}",
-                poll_interval=Duration.from_seconds(0.1),
-            )
-            worker = Worker(
-                worker_config,
-                container_runtime=ProcessRuntime(cache_dir=cache_dir),
-                environment_provider=env_provider,
-                threads=threads,
-            )
-            worker.start()
-
-            try:
-                controller_client = ControllerServiceClientSync(address=url, timeout_ms=10000)
-                deadline = time.monotonic() + 15.0
-                workers = []
-                while time.monotonic() < deadline:
-                    request = controller_pb2.Controller.ListWorkersRequest()
-                    response = controller_client.list_workers(request)
-                    workers = [w for w in response.workers if w.healthy]
-                    if workers:
-                        break
-                    time.sleep(0.5)
-
-                assert workers, "Worker did not register within timeout"
-                w = workers[0]
-                meta = w.metadata
-                assert meta.gpu_count == 8
-                assert "H100" in meta.gpu_name
-                assert meta.gpu_memory_mb == 81559
-                assert meta.device.gpu.count == 8
-                assert "H100" in meta.device.gpu.variant
-
-                attrs = meta.attributes
-                assert WellKnownAttribute.GPU_VARIANT in attrs
-                assert "H100" in attrs[WellKnownAttribute.GPU_VARIANT].string_value
-                assert WellKnownAttribute.GPU_COUNT in attrs
-                assert attrs[WellKnownAttribute.GPU_COUNT].int_value == 8
-
-                controller_client.close()
-            finally:
-                worker.stop()
-                threads.stop(timeout=Duration.from_seconds(5.0))
+# GPU metadata test lives in tests/test_gpu_metadata.py
 
 
 # ============================================================================

--- a/lib/iris/tests/test_gpu_metadata.py
+++ b/lib/iris/tests/test_gpu_metadata.py
@@ -83,7 +83,7 @@ def test_gpu_worker_metadata(tmp_path):
 
                 attrs = meta.attributes
                 assert WellKnownAttribute.GPU_VARIANT in attrs
-                assert "H100" in attrs[WellKnownAttribute.GPU_VARIANT].string_value
+                assert "h100" in attrs[WellKnownAttribute.GPU_VARIANT].string_value
                 assert WellKnownAttribute.GPU_COUNT in attrs
                 assert attrs[WellKnownAttribute.GPU_COUNT].int_value == 8
 

--- a/lib/iris/tests/test_iris_run.py
+++ b/lib/iris/tests/test_iris_run.py
@@ -145,7 +145,7 @@ def test_run_iris_job_adds_zone_constraint(monkeypatch):
     zone_constraints = [c for c in constraints if c.key == WellKnownAttribute.ZONE]
     assert len(zone_constraints) == 1
     assert zone_constraints[0].op == ConstraintOp.EQ
-    assert zone_constraints[0].value == "us-central2-b"
+    assert zone_constraints[0].values[0].value == "us-central2-b"
 
 
 def test_run_iris_job_passes_reservation(monkeypatch):
@@ -201,12 +201,12 @@ def test_run_iris_job_adds_region_and_zone_constraints(monkeypatch):
     region_constraints = [c for c in constraints if c.key == WellKnownAttribute.REGION]
     assert len(region_constraints) == 1
     assert region_constraints[0].op == ConstraintOp.EQ
-    assert region_constraints[0].value == "us-central2"
+    assert region_constraints[0].values[0].value == "us-central2"
 
     zone_constraints = [c for c in constraints if c.key == WellKnownAttribute.ZONE]
     assert len(zone_constraints) == 1
     assert zone_constraints[0].op == ConstraintOp.EQ
-    assert zone_constraints[0].value == "us-central2-b"
+    assert zone_constraints[0].values[0].value == "us-central2-b"
 
 
 def test_run_iris_job_passes_priority_band(monkeypatch):


### PR DESCRIPTION
Constraints were stored as proto job_pb2.Constraint and only converted to native Constraint inside the inner constraint-evaluation loop, where AttributeValue.from_proto() ran O(tasks * candidates * constraints) per autoscaler tick. Decode once when reading from the DB and propagate native Constraint through the scheduler, autoscaler routing, and ConstraintIndex. String values are stripped/lowercased at ingestion so case-insensitive comparisons no longer re-normalize on every evaluation.