### PR TITLE
[iris] Target python child PID for in-container profiling

### DIFF
--- a/lib/iris/Dockerfile
+++ b/lib/iris/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openssh-client \
     git \
     lldb \
+    procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Google Cloud SDK (controller needs it for TPU management, worker for discovery)
@@ -144,6 +145,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     build-essential \
     lldb \
+    procps \
     libibverbs1 \
     ibverbs-providers \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \

--- a/lib/iris/src/iris/cluster/providers/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/tasks.py
@@ -1199,17 +1199,17 @@ class K8sTaskProvider:
 
     def _profile_threads(self, pod_name: str, threads_config: job_pb2.ThreadsProfile) -> job_pb2.ProfileTaskResponse:
         """Get thread stacks via py-spy dump."""
-        from iris.cluster.runtime.profile import build_pyspy_dump_cmd
+        from iris.cluster.runtime.profile import PYTHON_PID_EXPR, build_pyspy_dump_cmd
 
-        cmd = shlex.join(build_pyspy_dump_cmd("1", include_locals=threads_config.locals))
+        cmd = shlex.join(build_pyspy_dump_cmd(PYTHON_PID_EXPR, include_locals=threads_config.locals))
         stdout = self._kubectl_exec_shell(pod_name, cmd, timeout=30)
         return job_pb2.ProfileTaskResponse(profile_data=stdout.encode("utf-8"))
 
     def _profile_cpu(self, pod_name: str, cpu_config: job_pb2.CpuProfile, duration: int) -> job_pb2.ProfileTaskResponse:
         """Record CPU profile via py-spy."""
-        from iris.cluster.runtime.profile import build_pyspy_cmd, resolve_cpu_spec
+        from iris.cluster.runtime.profile import PYTHON_PID_EXPR, build_pyspy_cmd, resolve_cpu_spec
 
-        spec = resolve_cpu_spec(cpu_config, duration, pid="1")
+        spec = resolve_cpu_spec(cpu_config, duration, pid=PYTHON_PID_EXPR)
         output_path = f"/tmp/iris-profile.{spec.ext}"
         cmd = shlex.join(build_pyspy_cmd(spec, py_spy_bin="py-spy", output_path=output_path))
         self._kubectl_exec_shell(pod_name, cmd, timeout=duration + 30)
@@ -1222,12 +1222,13 @@ class K8sTaskProvider:
     ) -> job_pb2.ProfileTaskResponse:
         """Record memory profile via memray."""
         from iris.cluster.runtime.profile import (
+            PYTHON_PID_EXPR,
             build_memray_attach_cmd,
             build_memray_transform_cmd,
             resolve_memory_spec,
         )
 
-        spec = resolve_memory_spec(memory_config, duration, pid="1")
+        spec = resolve_memory_spec(memory_config, duration, pid=PYTHON_PID_EXPR)
         trace_path = "/tmp/iris-memray.bin"
         output_path = f"/tmp/iris-memray.{spec.ext}"
 

--- a/lib/iris/src/iris/cluster/runtime/docker.py
+++ b/lib/iris/src/iris/cluster/runtime/docker.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from iris.cluster.bundle import BundleStore
 from iris.cluster.runtime.env import write_workdir_files
 from iris.cluster.runtime.profile import (
+    PYTHON_PID_EXPR,
     build_memray_attach_cmd,
     build_memray_transform_cmd,
     build_pyspy_cmd,
@@ -510,14 +511,20 @@ exec {quoted_cmd}
 
     def _profile_threads(self, container_id: str, *, include_locals: bool = False) -> bytes:
         """Collect thread stacks from the container using py-spy dump."""
-        cmd = build_pyspy_dump_cmd(pid="1", py_spy_bin="/app/.venv/bin/py-spy", include_locals=include_locals)
-        result = self._docker_exec(container_id, cmd, capture_output=True, text=True, timeout=30)
+        cmd = build_pyspy_dump_cmd(
+            pid=PYTHON_PID_EXPR, py_spy_bin="/app/.venv/bin/py-spy", include_locals=include_locals
+        )
+        result = self._docker_exec_shell(container_id, cmd, capture_output=True, text=True, timeout=30)
         if result.returncode != 0:
             raise RuntimeError(f"py-spy dump failed: {result.stderr}")
         return result.stdout.encode("utf-8")
 
     def _docker_exec(self, container_id: str, cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
         return subprocess.run(["docker", "exec", container_id, *cmd], **kwargs)
+
+    def _docker_exec_shell(self, container_id: str, cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+        """Run cmd through `sh -c` so shell expansions like `$(pgrep ...)` apply."""
+        return self._docker_exec(container_id, ["sh", "-c", shlex.join(cmd)], **kwargs)
 
     def _docker_read_file(self, container_id: str, path: str) -> bytes:
         result = self._docker_exec(container_id, ["cat", path], capture_output=True, timeout=5)
@@ -532,7 +539,7 @@ exec {quoted_cmd}
         self, container_id: str, duration_seconds: int, cpu_config: "job_pb2.CpuProfile", profile_id: str
     ) -> bytes:
         """Profile CPU using py-spy."""
-        spec = resolve_cpu_spec(cpu_config, duration_seconds, pid="1")
+        spec = resolve_cpu_spec(cpu_config, duration_seconds, pid=PYTHON_PID_EXPR)
         output_path = f"/tmp/profile-cpu-{profile_id}.{spec.ext}"
         cmd = build_pyspy_cmd(spec, py_spy_bin="/app/.venv/bin/py-spy", output_path=output_path)
 
@@ -545,7 +552,9 @@ exec {quoted_cmd}
         )
         try:
             # py-spy needs extra headroom beyond the sample duration for writing output
-            result = self._docker_exec(container_id, cmd, capture_output=True, text=True, timeout=duration_seconds + 30)
+            result = self._docker_exec_shell(
+                container_id, cmd, capture_output=True, text=True, timeout=duration_seconds + 30
+            )
             if result.returncode != 0:
                 raise RuntimeError(f"py-spy failed: {result.stderr}")
             return self._docker_read_file(container_id, output_path)
@@ -556,7 +565,7 @@ exec {quoted_cmd}
         self, container_id: str, duration_seconds: int, memory_config: "job_pb2.MemoryProfile", profile_id: str
     ) -> bytes:
         """Profile memory using memray."""
-        spec = resolve_memory_spec(memory_config, duration_seconds, pid="1")
+        spec = resolve_memory_spec(memory_config, duration_seconds, pid=PYTHON_PID_EXPR)
         memray_bin = "/app/.venv/bin/memray"
         trace_path = f"/tmp/memray-trace-{profile_id}.bin"
         output_path = f"/tmp/memray-output-{profile_id}.{spec.ext}"
@@ -571,7 +580,7 @@ exec {quoted_cmd}
             spec.leaks,
         )
         try:
-            result = self._docker_exec(
+            result = self._docker_exec_shell(
                 container_id, attach_cmd, capture_output=True, text=True, timeout=duration_seconds + 10
             )
             if result.returncode != 0:

--- a/lib/iris/src/iris/cluster/runtime/profile.py
+++ b/lib/iris/src/iris/cluster/runtime/profile.py
@@ -30,6 +30,15 @@ logger = logging.getLogger(__name__)
 # Target sentinel for profiling the local worker/controller process itself.
 SYSTEM_PROCESS_TARGET = "/system/process"
 
+# Shell expression that resolves to the oldest python PID inside a task
+# container, falling back to PID 1 if none is found. Task entrypoints are
+# typically `uv run python ...`, so PID 1 is the `uv` Rust binary and py-spy
+# cannot fingerprint it as CPython. The user's actual interpreter is a child
+# of uv; `pgrep -o python` selects the oldest matching process (the main
+# interpreter), and py-spy's --subprocesses then walks any further children.
+# The expression must be evaluated inside a shell on the target container.
+PYTHON_PID_EXPR = "$(pgrep -o python || echo 1)"
+
 CPU_FORMAT_MAP: dict[int, tuple[str, str]] = {
     job_pb2.CpuProfile.FLAMEGRAPH: ("flamegraph", "svg"),
     job_pb2.CpuProfile.SPEEDSCOPE: ("speedscope", "json"),


### PR DESCRIPTION
Task entrypoints are typically `uv run python ...`, so PID 1 inside the container is the `uv` Rust binary and py-spy/memray fail to attach with "Failed to find python version from target process". Resolve the oldest python PID via `$(pgrep -o python || echo 1)` inside the container for thread, CPU, and memory profiling, and add `procps` to the controller and task images so `pgrep` is available.