### PR TITLE
Fix tokenizer loading for lm-eval on HF checkpoints

### DIFF
--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -42,7 +42,7 @@ from haliax import NamedArray
 from jax.sharding import PartitionSpec
 
 import levanter.tracker
-from levanter.compat.hf_checkpoints import HFCheckpointConverter, load_tokenizer
+from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.data.packing import (
     PromptCompletion,
     greedy_pack_prompt_completions,
@@ -56,7 +56,7 @@ from levanter.inference.utils import INVALID
 from levanter.models.gpt2 import Gpt2Config
 from levanter.models.loss import fused_cross_entropy_loss_and_logsumexp_penalty
 from levanter.utils.background_iterable import BackgroundIterator
-from levanter.tokenizers import MarinTokenizer
+from levanter.tokenizers import MarinTokenizer, load_tokenizer
 from levanter.utils.py_utils import set_global_rng_seeds
 
 try:

--- a/lib/levanter/tests/test_eval_harness.py
+++ b/lib/levanter/tests/test_eval_harness.py
@@ -183,3 +183,16 @@ def test_task_config():
     q = config.to_task_dict()
 
     assert len(q) == 3
+
+
+def test_eval_harness_config_loads_marin_tokenizer():
+    """Verify EvalHarnessMainConfig.the_tokenizer returns a MarinTokenizer."""
+    from levanter.eval_harness import EvalHarnessMainConfig, LmEvalHarnessConfig
+    from levanter.tokenizers import MarinTokenizer
+
+    config = EvalHarnessMainConfig(
+        eval_harness=LmEvalHarnessConfig(task_spec=["hellaswag"]),
+        tokenizer="stanford-crfm/marin-tokenizer",
+        checkpoint_path="/nonexistent",
+    )
+    assert isinstance(config.the_tokenizer, MarinTokenizer)


### PR DESCRIPTION
I ran into an issue where configuring an eval like this:

```python
eval_harness.EvalHarnessMainConfig(
  ...
  tokenizer="stanford-crfm/marin-tokenizer",
  checkpoint_path=CHECKPOINT_PATH,
  checkpoint_is_hf=True,
)
```
results in later calls to MarinTokenizer methods like `tokenizer.encode_batch(combined_batch)` here: https://github.com/marin-community/marin/blob/f8d48894ef38822773ea890ef2b119ee2607545f/lib/levanter/src/levanter/eval_harness.py#L1668

That doesn't exist on HF tokenizers so a script run this way fails with:

```
AttributeError: PreTrainedTokenizerFast has no attribute encode_batch
```

I think this should be failing on existing tests in [lib/levanter/tests/test_eval_harness.py](https://github.com/marin-community/marin/blob/main/lib/levanter/tests/test_eval_harness.py), but they're currently skipped in CI (e.g. see [here](https://github.com/marin-community/marin/actions/runs/24305559700/job/70966104227)):

```
lib/levanter/tests/test_eval_harness.py::test_iterate_tokenized_requests_with_chat_template SKIPPED [ 40%]
lib/levanter/tests/test_eval_harness.py::test_iterate_tokenized_requests SKIPPED [ 40%]
```

Are these tests being skipped intentionally due to no lm_eval install?  Is there some CI workflow in which they should be running?

Regardless, this PR replaces the tokenizer loading with `levanter.tokenizers.load_tokenizer` instead of `levanter.compat.hf_checkpoints.load_tokenizer`, which has worked for me.  I'm not sure where to go next with adding better test coverage on it, of it that's worth it.  This may not be the approach we want vs sticking to HF tokenizers in eval_harness.py.