### PR TITLE
[iris] Fix preemption race in heartbeat task kill

### DIFF
--- a/lib/iris/src/iris/cluster/worker/worker.py
+++ b/lib/iris/src/iris/cluster/worker/worker.py
@@ -699,7 +699,8 @@ class Worker:
 
         Processing order (sequential, not concurrent):
         1. Submit tasks_to_run — registers each task in self._tasks
-        2. Kill tasks_to_kill — async, sets stop flag immediately
+        2. Kill tasks_to_kill — synchronously, blocks until old process is stopped
+           so the controller does not assign new work while old tasks hold resources
         3. Reconcile expected_tasks — for each expected task, report its current
            state. If not found in self._tasks, report WORKER_FAILED ("Task not
            found on worker"). This happens when the worker has reset its state
@@ -713,8 +714,8 @@ class Worker:
         for newly-assigned tasks) will be submitted before reconciliation checks
         for it, so it will be found.
 
-        Kill operations are performed asynchronously in daemon threads to avoid
-        blocking the heartbeat RPC.
+        Reconciliation kills (step 4) remain async to avoid blocking the heartbeat
+        for stale-task cleanup that is not part of a preemption handoff.
         """
         # Reset heartbeat deadline
         self._heartbeat_deadline = Deadline.from_seconds(self._config.heartbeat_timeout.to_seconds())
@@ -729,14 +730,16 @@ class Worker:
                     except Exception as e:
                         logger.warning("Heartbeat: failed to submit task %s: %s", run_req.task_id, e)
 
-            # Kill requested tasks asynchronously so the heartbeat returns immediately
-            with slow_log(logger, "heartbeat kill_tasks", threshold_ms=100):
+            # Kill requested tasks synchronously so the old process is fully stopped
+            # before the heartbeat returns. This prevents the controller from assigning
+            # new work while the old task still holds accelerator resources (TPU/GPU chips).
+            with slow_log(logger, "heartbeat kill_tasks", threshold_ms=5000):
                 for task_id in request.tasks_to_kill:
                     try:
                         current = self._get_current_attempt(task_id)
                         if current:
-                            self._kill_task_attempt(task_id, current.attempt_id, async_kill=True)
-                            logger.info("Heartbeat: initiated async kill for task %s", task_id)
+                            self._kill_task_attempt(task_id, current.attempt_id, async_kill=False)
+                            logger.info("Heartbeat: killed task %s", task_id)
                     except Exception as e:
                         logger.warning("Heartbeat: failed to kill task %s: %s", task_id, e)
 
@@ -830,7 +833,7 @@ class Worker:
         self,
         task_id: str,
         attempt_id: int,
-        term_timeout_ms: int = 5000,
+        term_timeout_ms: int = 2000,
         async_kill: bool = False,
     ) -> bool:
         """Kill a specific task attempt.
@@ -896,7 +899,7 @@ class Worker:
             # Container may have already been removed or stopped
             pass
 
-    def kill_task(self, task_id: str, term_timeout_ms: int = 5000) -> bool:
+    def kill_task(self, task_id: str, term_timeout_ms: int = 2000) -> bool:
         """Kill the current (most recent) attempt of a task."""
         current = self._get_current_attempt(task_id)
         if not current:

--- a/lib/iris/src/iris/cluster/worker/worker.py
+++ b/lib/iris/src/iris/cluster/worker/worker.py
@@ -833,7 +833,7 @@ class Worker:
         self,
         task_id: str,
         attempt_id: int,
-        term_timeout_ms: int = 2000,
+        term_timeout_ms: int = 5000,
         async_kill: bool = False,
     ) -> bool:
         """Kill a specific task attempt.
@@ -899,7 +899,7 @@ class Worker:
             # Container may have already been removed or stopped
             pass
 
-    def kill_task(self, task_id: str, term_timeout_ms: int = 2000) -> bool:
+    def kill_task(self, task_id: str, term_timeout_ms: int = 5000) -> bool:
         """Kill the current (most recent) attempt of a task."""
         current = self._get_current_attempt(task_id)
         if not current:

--- a/lib/iris/tests/cluster/worker/test_worker.py
+++ b/lib/iris/tests/cluster/worker/test_worker.py
@@ -346,12 +346,12 @@ def test_duplicate_attempt_rejected(mock_worker, mock_runtime):
     task.thread.join(timeout=15.0)
 
 
-def test_heartbeat_kill_is_non_blocking(mock_worker, mock_runtime):
-    """Heartbeat returns immediately when killing tasks, without waiting for container shutdown."""
+def test_heartbeat_kill_blocks_until_stopped(mock_worker, mock_runtime):
+    """Heartbeat blocks on tasks_to_kill so the old task releases resources before returning."""
     mock_handle = create_mock_container_handle(status_sequence=[ContainerStatus(phase=ContainerPhase.RUNNING)] * 1000)
 
     def slow_stop(force=False):
-        time.sleep(0.5)
+        time.sleep(0.3)
 
     mock_handle.stop_hook = slow_stop
     mock_runtime.create_container = Mock(return_value=mock_handle)
@@ -376,17 +376,12 @@ def test_heartbeat_kill_is_non_blocking(mock_worker, mock_runtime):
 
     response = mock_worker.handle_heartbeat(heartbeat_req)
 
-    # should_stop is set synchronously by the heartbeat before the async stop() runs
     assert task.should_stop is True
-    # The task is not yet KILLED because slow_stop is async — confirms kill is non-blocking
-    assert task.status != job_pb2.TASK_STATE_KILLED
+    # The task is KILLED by the time handle_heartbeat returns — kill is blocking
+    assert task.status == job_pb2.TASK_STATE_KILLED
 
     # The response should still include the task's current state
     assert len(response.tasks) >= 1
-
-    # Wait for the task to finish
-    task.thread.join(timeout=15.0)
-    assert task.status == job_pb2.TASK_STATE_KILLED
 
 
 def test_heartbeat_reconciliation_kill_is_non_blocking(mock_worker, mock_runtime):


### PR DESCRIPTION
The heartbeat handler processed tasks_to_kill asynchronously (async_kill=True), so the old task kept holding TPU chips while the controller assigned new work on the next heartbeat. This caused two tasks to compete for the same accelerator on single-task workers.

Changed tasks_to_kill to block synchronously (async_kill=False) so the old process is fully stopped before the heartbeat returns. Reconciliation kills (unexpected tasks) remain async since they are not part of a preemption handoff.

Fixes #4689