### PR TITLE
[ci] Fetch host-level logs when iris cloud tests fail

### DIFF
--- a/.github/workflows/iris-cloud-smoke-gcp.yaml
+++ b/.github/workflows/iris-cloud-smoke-gcp.yaml
@@ -171,10 +171,49 @@ jobs:
         if: failure()
         env:
           LOG_DIR: ${{ github.workspace }}/iris-cloud-logs
+          LABEL_PREFIX: ${{ steps.label.outputs.prefix }}
+          PROJECT: ${{ secrets.GCP_PROJECT_ID }}
         run: |
           mkdir -p "$LOG_DIR"
+          MANAGED_LABEL="iris-${LABEL_PREFIX}-managed"
+          CONTROLLER_LABEL="iris-${LABEL_PREFIX}-controller"
+
+          # Always try to grab docker/host logs directly from every VM we
+          # spun up. This works even when the controller never became
+          # reachable (e.g. tunnel never opened, controller crashed during
+          # boot), which is exactly the case where these logs matter most.
+          gcloud compute instances list \
+            --project="$PROJECT" \
+            --filter="labels.${MANAGED_LABEL}=true OR labels.${CONTROLLER_LABEL}=true" \
+            --format="csv[no-heading](name,zone,labels.list())" 2>/dev/null \
+          | while IFS=, read -r name zone labels; do
+              [ -z "$name" ] && continue
+              role=worker
+              case "$labels" in *"$CONTROLLER_LABEL"*) role=controller ;; esac
+              echo "Fetching host logs from $role $name ($zone)"
+              out="$LOG_DIR/${role}-${name}"
+              gcloud compute ssh "$name" \
+                --project="$PROJECT" --zone="$zone" \
+                --impersonate-service-account="$IRIS_CONTROLLER_SERVICE_ACCOUNT" \
+                --ssh-key-file ~/.ssh/google_compute_engine \
+                --quiet \
+                --command '
+                set +e
+                echo "=== docker ps -a ==="
+                sudo docker ps -a
+                for cid in $(sudo docker ps -aq); do
+                  echo "=== docker logs $cid ==="
+                  sudo docker logs --timestamps --tail 5000 "$cid" 2>&1
+                done
+                echo "=== startup script ==="
+                sudo journalctl -u google-startup-scripts.service --no-pager 2>&1 | tail -n 2000
+                echo "=== kernel/cloud-init ==="
+                sudo journalctl -u cloud-final.service --no-pager 2>&1 | tail -n 500
+              ' > "${out}.log" 2>&1 || echo "ssh to $name failed (see ${out}.log)"
+            done
+
           if [ -z "$IRIS_CONTROLLER_URL" ]; then
-            echo "No controller URL, skipping log collection"
+            echo "No controller URL, skipping RPC-based log collection"
             exit 0
           fi
           cd lib/iris

--- a/.github/workflows/iris-coreweave-ci.yaml
+++ b/.github/workflows/iris-coreweave-ci.yaml
@@ -185,9 +185,14 @@ jobs:
 
       - name: Capture failure diagnostics
         if: failure()
+        env:
+          LOG_DIR: ${{ github.workspace }}/iris-cw-logs
         run: |
           export KUBECONFIG=~/.kube/coreweave-iris
-          echo "=== Controller logs ==="
+          mkdir -p "$LOG_DIR"
+
+          # Stream to the GH Actions log for quick triage…
+          echo "=== Controller logs (tail) ==="
           kubectl -n "$IRIS_NAMESPACE" logs -l app=iris-controller --tail=500 || true
           echo "=== Controller pod describe ==="
           kubectl -n "$IRIS_NAMESPACE" describe pod -l app=iris-controller || true
@@ -195,6 +200,36 @@ jobs:
           kubectl -n "$IRIS_NAMESPACE" get pods -l "$IRIS_MANAGED_LABEL=true" || true
           echo "=== Warning events ==="
           kubectl -n "$IRIS_NAMESPACE" get events --sort-by='.lastTimestamp' --field-selector type!=Normal || true
+
+          # …and also persist per-pod logs + describe so failures in worker
+          # containers are recoverable from the uploaded artifact, not just
+          # the controller's view.
+          kubectl -n "$IRIS_NAMESPACE" logs -l app=iris-controller --tail=-1 --all-containers \
+            > "$LOG_DIR/controller.log" 2>&1 || true
+          kubectl -n "$IRIS_NAMESPACE" logs -l app=iris-controller --tail=-1 --all-containers --previous \
+            > "$LOG_DIR/controller-previous.log" 2>&1 || true
+          kubectl -n "$IRIS_NAMESPACE" describe pod -l app=iris-controller \
+            > "$LOG_DIR/controller-describe.txt" 2>&1 || true
+
+          for pod in $(kubectl -n "$IRIS_NAMESPACE" get pods -l "$IRIS_MANAGED_LABEL=true" -o name 2>/dev/null); do
+            safe=$(echo "$pod" | tr '/' '-')
+            kubectl -n "$IRIS_NAMESPACE" logs "$pod" --tail=-1 --all-containers \
+              > "$LOG_DIR/${safe}.log" 2>&1 || true
+            kubectl -n "$IRIS_NAMESPACE" describe "$pod" \
+              > "$LOG_DIR/${safe}-describe.txt" 2>&1 || true
+          done
+
+          kubectl -n "$IRIS_NAMESPACE" get events --sort-by='.lastTimestamp' \
+            > "$LOG_DIR/events.txt" 2>&1 || true
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: iris-cw-ci-logs
+          path: iris-cw-logs/
+          retention-days: 14
+          if-no-files-found: ignore
 
       - name: Set commit status to result
         if: always() && github.event_name == 'issue_comment'


### PR DESCRIPTION
The GCP smoke log-collection step used to bail whenever IRIS_CONTROLLER_URL was unset, which is exactly when the controller host's docker logs are most useful. It now ssh's into every managed/controller VM by label and captures docker ps, per-container docker logs, and startup journals. The CoreWeave CI equivalent now persists per-pod kubectl logs (current and --previous) plus describe output as an uploaded artifact instead of only streaming the controller tail to the GH Actions console.