### PR TITLE
[datakit] Filter empty text in normalize pipeline

### DIFF
--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -299,6 +299,16 @@ def normalize_to_parquet(
 
     # Sort for deterministic output so re-runs produce stable .artifact contents
     subdir_results.sort(key=lambda r: r.subdir)
+
+    total_in = sum(r.counters.get("zephyr/records_in", 0) for r in subdir_results)
+    total_filtered = sum(r.counters.get("normalize/empty_text_filtered", 0) for r in subdir_results)
+    if total_in > 0 and total_filtered == total_in:
+        raise ValueError(
+            f"All {total_in} records were filtered out due to missing/empty text. "
+            f"Your data is either invalid or you have selected the wrong column, "
+            f"current column: {text_field!r}"
+        )
+
     return NormalizeResult(subdirs=subdir_results)
 
 

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import dupekit
 from rigging.filesystem import url_to_fs
+from zephyr import counters
 from marin.execution.step_spec import StepSpec
 from fray.v2 import ResourceConfig
 from zephyr import Dataset, ZephyrContext
@@ -75,18 +76,18 @@ def _make_normalize_fn(
     """Return a record-level transform function.
 
     The returned function:
-    1. Extracts ``text`` from *text_field* (raises on missing/empty).
+    1. Extracts ``text`` from *text_field*.
     2. Generates a deterministic ``id`` via xxh3_128.
     3. If *id_field* exists in the record, preserves it as ``source_id``.
     4. Keeps all other columns.
+
+    Records with missing or blank text must be filtered out before calling
+    the returned function.
     """
 
     def normalize_record(record: dict[str, Any]) -> dict[str, Any]:
         # --- text ---
-        text = record.get(text_field)
-        if text is None or not str(text).strip():
-            raise ValueError(f"Record missing or empty text in field {text_field!r}: {record!r:.200}")
-        text = str(text)
+        text = str(record[text_field])
 
         # --- source_id (skip silently if id_field absent) ---
         source_id = record.get(id_field)
@@ -189,9 +190,17 @@ def _build_pipeline(
                 prev_id = rid
                 yield record
 
+    def has_text(record: dict[str, Any]) -> bool:
+        text = record.get(text_field)
+        if text is None or str(text).strip() == "":
+            counters.increment("normalize/empty_text_filtered")
+            return False
+        return True
+
     return (
         Dataset.from_list(files)
         .flat_map(load_file)
+        .filter(has_text)
         .map(normalize_record)
         .group_by(
             key=lambda r: int(r["id"], 16) % num_shards,

--- a/tests/datakit/test_normalize.py
+++ b/tests/datakit/test_normalize.py
@@ -148,7 +148,7 @@ def test_all_records_empty_text_raises(tmp_path: Path, write_jsonl_gz):
 
     write_jsonl_gz(input_dir / "data.jsonl.gz", [{"text": "   "}, {"text": ""}, {"text": None}])
 
-    with pytest.raises(ValueError, match="All 3 records were filtered out.*wrong column"):
+    with pytest.raises(ValueError, match=r"All 3 records were filtered out.*wrong column"):
         normalize_to_parquet(input_path=str(input_dir), output_path=str(output_dir))
 
 

--- a/tests/datakit/test_normalize.py
+++ b/tests/datakit/test_normalize.py
@@ -141,6 +141,17 @@ def test_missing_or_empty_text_filtered(tmp_path: Path, write_jsonl_gz, record):
     assert total_empty >= 1
 
 
+def test_all_records_empty_text_raises(tmp_path: Path, write_jsonl_gz):
+    """Pipeline fails when every record has missing/empty text."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+
+    write_jsonl_gz(input_dir / "data.jsonl.gz", [{"text": "   "}, {"text": ""}, {"text": None}])
+
+    with pytest.raises(ValueError, match="All 3 records were filtered out.*wrong column"):
+        normalize_to_parquet(input_path=str(input_dir), output_path=str(output_dir))
+
+
 def test_directory_structure_preserved(tmp_path: Path, write_jsonl_gz):
     """Each input subdirectory gets its own parquet output under the same relative path."""
     input_dir = tmp_path / "input"

--- a/tests/datakit/test_normalize.py
+++ b/tests/datakit/test_normalize.py
@@ -118,17 +118,27 @@ def test_missing_id_field_silently_skipped(tmp_path: Path, write_jsonl_gz):
     [
         {"other": "no text here"},  # missing text field
         {"text": "   "},  # whitespace-only text
+        {"text": "\xa0\xa0\xa0\n\n\xa0\xa0\xa0"},  # non-breaking spaces + newlines
+        {"text": ""},  # empty string
+        {"text": None},  # explicit None
     ],
-    ids=["missing", "whitespace"],
+    ids=["missing", "whitespace", "nbsp", "empty", "none"],
 )
-def test_missing_or_empty_text_raises(tmp_path: Path, write_jsonl_gz, record):
+def test_missing_or_empty_text_filtered(tmp_path: Path, write_jsonl_gz, record):
+    """Records with missing or blank text are silently filtered out."""
     input_dir = tmp_path / "input"
     output_dir = tmp_path / "output"
 
-    write_jsonl_gz(input_dir / "data.jsonl.gz", [record])
+    write_jsonl_gz(input_dir / "data.jsonl.gz", [{"text": "valid"}, record])
 
-    with pytest.raises(Exception, match="text"):
-        normalize_to_parquet(input_path=str(input_dir), output_path=str(output_dir))
+    result = normalize_to_parquet(input_path=str(input_dir), output_path=str(output_dir))
+
+    results = _read_all_parquet(output_dir)
+    assert len(results) == 1
+    assert results[0]["text"] == "valid"
+
+    total_empty = sum(s.counters.get("normalize/empty_text_filtered", 0) for s in result.subdirs)
+    assert total_empty >= 1
 
 
 def test_directory_structure_preserved(tmp_path: Path, write_jsonl_gz):


### PR DESCRIPTION
## Summary
- Records with missing, empty, or whitespace-only text (including `\xa0` non-breaking spaces) are now silently filtered out instead of crashing the normalize pipeline with `ValueError`
- Adds a `normalize/empty_text_filtered` zephyr counter to track how many records are dropped
- Extends test coverage with `nbsp`, `empty`, and `none` cases and asserts the counter is incremented

## Test plan
- [x] All 13 tests in `tests/datakit/test_normalize.py` pass
- [x] New parametrized cases cover `\xa0`, empty string, and `None` text
- [x] Counter assertion validates `normalize/empty_text_filtered` is reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)