### PR TITLE
infra-dashboard: fix /api/workers 504 timeout on Cloud Run

### DIFF
--- a/infra/status-page/server/main.ts
+++ b/infra/status-page/server/main.ts
@@ -48,6 +48,7 @@ const workerHistory = new WorkerHistory(HISTORY_CAPACITY);
 async function sampleWorkers(): Promise<void> {
   const snapshot = await workersCache.get("workers", () => workerSnapshot());
   if (snapshot.error) {
+    console.error("worker sampler: snapshot error:", snapshot.error);
     // Don't pollute history with zeros when the controller is unreachable.
     return;
   }

--- a/infra/status-page/server/sources/controllerQuery.ts
+++ b/infra/status-page/server/sources/controllerQuery.ts
@@ -32,17 +32,26 @@ interface RawQueryWireResponse {
 
 export async function executeRawQuery(sql: string): Promise<RawQueryResult> {
   const base = await getControllerUrl();
-  const res = await fetch(`${base}/iris.cluster.ControllerService/ExecuteRawQuery`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ sql }),
-    signal: AbortSignal.timeout(10_000),
-  });
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`ExecuteRawQuery ${res.status}: ${body.slice(0, 300)}`);
+  // Keep a strong reference to the AbortController so the timer is not
+  // garbage-collected before it fires (observed on Node 20 / undici when
+  // multiple concurrent fetches create inline AbortSignal.timeout objects).
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(new Error("query timed out after 10s")), 10_000);
+  try {
+    const res = await fetch(`${base}/iris.cluster.ControllerService/ExecuteRawQuery`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sql }),
+      signal: ac.signal,
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`ExecuteRawQuery ${res.status}: ${body.slice(0, 300)}`);
+    }
+    const body = (await res.json()) as RawQueryWireResponse;
+    const rows = body.rows.map((r) => JSON.parse(r) as unknown[]);
+    return { columns: body.columns, rows };
+  } finally {
+    clearTimeout(timer);
   }
-  const body = (await res.json()) as RawQueryWireResponse;
-  const rows = body.rows.map((r) => JSON.parse(r) as unknown[]);
-  return { columns: body.columns, rows };
 }

--- a/infra/status-page/server/sources/discovery.ts
+++ b/infra/status-page/server/sources/discovery.ts
@@ -30,11 +30,16 @@ function getClient(): InstancesClient {
 }
 
 async function queryControllerIp(): Promise<string> {
-  const [instances] = await getClient().list({
-    project: GCP_PROJECT,
-    zone: CONTROLLER_ZONE,
-    filter: `labels.${CONTROLLER_LABEL}=true AND status=RUNNING`,
-  });
+  const [instances] = await Promise.race([
+    getClient().list({
+      project: GCP_PROJECT,
+      zone: CONTROLLER_ZONE,
+      filter: `labels.${CONTROLLER_LABEL}=true AND status=RUNNING`,
+    }),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("GCE discovery timed out after 15s")), 15_000),
+    ),
+  ]);
   if (!instances || instances.length === 0) {
     throw new Error(
       `No controller VM found (label=${CONTROLLER_LABEL}=true, ` +

--- a/infra/status-page/server/sources/workers.ts
+++ b/infra/status-page/server/sources/workers.ts
@@ -82,12 +82,19 @@ function emptyResources(): WorkerResourceTotals {
   };
 }
 
+// Hard ceiling so the TTLCache inflight promise can never hang indefinitely.
+// If the inner queries don't settle in 20s (10s per-query timeout + margin),
+// we return an error snapshot instead of blocking all future callers.
+const SNAPSHOT_DEADLINE_MS = 20_000;
+
 export async function workerSnapshot(): Promise<WorkersSnapshot> {
   const fetchedAt = new Date().toISOString();
   try {
-    const [totalsResult, regionsResult] = await Promise.all([
-      executeRawQuery(TOTALS_SQL),
-      executeRawQuery(REGION_SQL),
+    const [totalsResult, regionsResult] = await Promise.race([
+      Promise.all([executeRawQuery(TOTALS_SQL), executeRawQuery(REGION_SQL)]),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("workerSnapshot deadline exceeded")), SNAPSHOT_DEADLINE_MS),
+      ),
     ]);
     const totalsRow = totalsResult.rows[0];
     if (!totalsRow) {


### PR DESCRIPTION
## Summary
- The `/api/workers` endpoint returned 504 on every request because inline `AbortSignal.timeout()` objects were garbage-collected before firing in Node 20 undici, leaving the `TTLCache` inflight promise permanently stuck
- Replaced inline `AbortSignal.timeout` with explicit `AbortController` + `setTimeout` to keep a strong timer reference
- Added a 20s `Promise.race` deadline around the entire `workerSnapshot()` so the cache inflight can never hang indefinitely
- Added a 15s timeout to GCE `InstancesClient.list()` in discovery, which previously had no timeout

## Test plan
- [ ] Redeploy to Cloud Run (`./deploy.sh`)
- [ ] Verify `/api/workers` returns 200 (not 504)
- [ ] Verify worker count panel renders in the dashboard
- [ ] Check Cloud Run stderr logs for any `workerSnapshot deadline exceeded` errors
- [ ] Confirm `/api/iris`, `/api/jobs`, `/api/builds` still return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)