### PR TITLE
[iris/dashboard] Task page thread dump: use dedicated page

### DIFF
--- a/lib/iris/dashboard/src/components/controller/TaskDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/TaskDetail.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
-import { RouterLink } from 'vue-router'
+import { RouterLink, useRouter } from 'vue-router'
 import { useControllerRpc } from '@/composables/useRpc'
 import { useAutoRefresh } from '@/composables/useAutoRefresh'
 import { stateToName } from '@/types/status'
@@ -126,7 +126,16 @@ onMounted(async () => {
   if (isActive.value) startRefresh()
 })
 
+const router = useRouter()
 const { profiling, profile } = useProfileAction(controllerRpcCall, () => props.taskId)
+
+function handleProfile(type: 'cpu' | 'memory' | 'threads') {
+  if (type === 'threads') {
+    router.push(`/job/${encodeURIComponent(props.jobId)}/task/${encodeURIComponent(props.taskId)}/threads`)
+  } else {
+    profile(type)
+  }
+}
 
 const logViewerRef = ref<{ selectedAttemptId: number } | null>(null)
 
@@ -207,7 +216,7 @@ watch(() => props.taskId, async () => {
             <span class="text-status-warning">{{ task.pendingReason }}</span>
           </InfoRow>
           <div v-if="isActive" class="mt-3 pt-3 border-t border-surface-border">
-            <ProfileButtons :profiling="profiling" @profile="profile" />
+            <ProfileButtons :profiling="profiling" @profile="handleProfile" />
           </div>
         </InfoCard>
 


### PR DESCRIPTION
## Summary
- The Thread Dump button on the Task detail page opened a raw `window.open()` popup with just a `<pre>` tag — no refresh, no controls
- The same action in the Job view navigated to the dedicated `ThreadDump.vue` page with refresh button, "include locals" toggle, and proper styling
- Aligned the Task page to use the same route-based navigation as the Job view

## Test plan
- [ ] Open a running task's detail page, click "Thread Dump" — should navigate to `/job/.../task/.../threads` (the dedicated page with refresh + locals toggle)
- [ ] CPU Profile and Memory Profile buttons still work as before (file download)
- [ ] Thread dump from Job view task table ("THR" button) still works identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)