### PR TITLE
[iris] Cache endpoints in-memory and paginate ListJobs

### DIFF
--- a/lib/iris/dashboard/src/components/controller/SchedulerTab.vue
+++ b/lib/iris/dashboard/src/components/controller/SchedulerTab.vue
@@ -6,6 +6,8 @@ import { useAutoRefresh } from '@/composables/useAutoRefresh'
 import type {
   GetSchedulerStateResponse,
   SchedulerUserBudget,
+  SchedulerBandGroup,
+  SchedulerRunningTask,
   ListUsersResponse,
   UserSummary,
   ListJobsResponse,
@@ -99,6 +101,62 @@ const userBudgets = computed<SchedulerUserBudget[]>(() => schedulerData.value?.u
 
 const users = computed<UserSummary[]>(() => usersData.value?.users ?? [])
 
+const BANDS = ['PRIORITY_BAND_PRODUCTION', 'PRIORITY_BAND_INTERACTIVE', 'PRIORITY_BAND_BATCH'] as const
+type Band = typeof BANDS[number]
+
+// Per-user task counts per effective band, split by running vs pending.
+// Derived from scheduler pendingQueue + runningTasks (task-level, since band
+// is a per-task attribute after downgrades).
+interface BandBreakdown {
+  running: Record<Band, number>
+  pending: Record<Band, number>
+}
+
+function emptyBandBreakdown(): BandBreakdown {
+  const running = Object.fromEntries(BANDS.map(b => [b, 0])) as Record<Band, number>
+  const pending = Object.fromEntries(BANDS.map(b => [b, 0])) as Record<Band, number>
+  return { running, pending }
+}
+
+function bandBreakdownTotal(b: BandBreakdown): number {
+  return BANDS.reduce((acc, band) => acc + b.running[band] + b.pending[band], 0)
+}
+
+const userBandCounts = computed<Map<string, BandBreakdown>>(() => {
+  const out = new Map<string, BandBreakdown>()
+  const pending: SchedulerBandGroup[] = schedulerData.value?.pendingQueue ?? []
+  for (const group of pending) {
+    for (const task of group.tasks) {
+      const band = task.effectiveBand as Band
+      if (!BANDS.includes(band)) continue
+      const entry = out.get(task.userId) ?? emptyBandBreakdown()
+      entry.pending[band] += 1
+      out.set(task.userId, entry)
+    }
+  }
+  const running: SchedulerRunningTask[] = schedulerData.value?.runningTasks ?? []
+  for (const task of running) {
+    const band = task.effectiveBand as Band
+    if (!BANDS.includes(band)) continue
+    const entry = out.get(task.userId) ?? emptyBandBreakdown()
+    entry.running[band] += 1
+    out.set(task.userId, entry)
+  }
+  return out
+})
+
+// jobId -> effective band, derived from pending task entries. Used to annotate
+// the Pending Jobs table with the scheduling band for each job.
+const pendingJobBand = computed<Map<string, string>>(() => {
+  const out = new Map<string, string>()
+  for (const group of schedulerData.value?.pendingQueue ?? []) {
+    for (const task of group.tasks) {
+      if (!out.has(task.jobId)) out.set(task.jobId, task.effectiveBand)
+    }
+  }
+  return out
+})
+
 // Merge user stats with budget data
 interface MergedUser {
   userId: string
@@ -113,6 +171,7 @@ interface MergedUser {
   maxBand: string
   effectiveBand: string
   hasBudget: boolean
+  bands: BandBreakdown
 }
 
 const mergedUsers = computed<MergedUser[]>(() => {
@@ -154,6 +213,7 @@ const mergedUsers = computed<MergedUser[]>(() => {
       maxBand: budget?.maxBand ?? '',
       effectiveBand: budget?.effectiveBand ?? '',
       hasBudget: !!budget,
+      bands: userBandCounts.value.get(userId) ?? emptyBandBreakdown(),
     })
   }
 
@@ -208,6 +268,7 @@ const hasData = computed(() => schedulerData.value || usersData.value)
               <th class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Running</th>
               <th class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Pending</th>
               <th class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Running Tasks</th>
+              <th class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary" title="Running / pending tasks per effective priority band">By Band</th>
               <th class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Total Tasks</th>
               <th class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Spent</th>
               <th class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Limit</th>
@@ -231,6 +292,21 @@ const hasData = computed(() => schedulerData.value || usersData.value)
               </td>
               <td class="px-3 py-2 text-[13px] text-right tabular-nums">
                 <span :class="user.runningTasks > 0 ? 'text-accent font-semibold' : ''">{{ user.runningTasks }}</span>
+              </td>
+              <td class="px-3 py-2 text-[13px] whitespace-nowrap">
+                <template v-for="band in BANDS" :key="band">
+                  <span
+                    v-if="user.bands.running[band] || user.bands.pending[band]"
+                    class="mr-2 tabular-nums"
+                    :title="bandDisplayName(band) + ': ' + user.bands.running[band] + ' running / ' + user.bands.pending[band] + ' pending'"
+                  >
+                    <span :class="bandColor(band)">{{ bandDisplayName(band).charAt(0) }}</span>
+                    <span class="text-accent">{{ user.bands.running[band] }}</span>
+                    <span class="text-text-muted">/</span>
+                    <span :class="user.bands.pending[band] > 0 ? 'text-status-warning' : 'text-text-muted'">{{ user.bands.pending[band] }}</span>
+                  </span>
+                </template>
+                <span v-if="bandBreakdownTotal(user.bands) === 0" class="text-text-muted">-</span>
               </td>
               <td class="px-3 py-2 text-[13px] text-right tabular-nums">{{ user.totalTasks }}</td>
               <td class="px-3 py-2 text-[13px] text-right tabular-nums">
@@ -317,6 +393,7 @@ const hasData = computed(() => schedulerData.value || usersData.value)
               <th class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">Job</th>
               <th class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">User</th>
               <th class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">State</th>
+              <th class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">Priority</th>
               <th class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">Pending Reason</th>
               <th class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">Submitted</th>
             </tr>
@@ -335,6 +412,12 @@ const hasData = computed(() => schedulerData.value || usersData.value)
               <td class="px-3 py-2 text-[13px]">{{ job.jobId.split('/')[0] }}</td>
               <td class="px-3 py-2 text-[13px]">
                 <StatusBadge :status="job.state" size="sm" />
+              </td>
+              <td class="px-3 py-2 text-[13px]">
+                <span v-if="pendingJobBand.get(job.jobId)" :class="bandColor(pendingJobBand.get(job.jobId))">
+                  {{ bandDisplayName(pendingJobBand.get(job.jobId)) }}
+                </span>
+                <span v-else class="text-text-muted">-</span>
               </td>
               <td class="px-3 py-2 text-[13px] text-status-warning max-w-md truncate" :title="job.pendingReason ?? ''">
                 {{ job.pendingReason || '-' }}

--- a/lib/iris/scripts/benchmark_db_queries.py
+++ b/lib/iris/scripts/benchmark_db_queries.py
@@ -57,7 +57,6 @@ from iris.cluster.controller.service import (
     _descendant_jobs,
     _live_user_stats,
     _parent_ids_with_children,
-    _query_endpoints,
     _query_jobs,
     _read_job,
     _read_task_with_attempts,
@@ -426,11 +425,11 @@ def benchmark_dashboard(db: ControllerDB) -> None:
 
     bench("_live_user_stats", lambda: _live_user_stats(db))
 
-    bench("_query_endpoints (all)", lambda: _query_endpoints(db))
+    bench("endpoint_registry.query (all)", lambda: db.endpoints.query())
 
     bench(
-        "_query_endpoints (prefix)",
-        lambda: _query_endpoints(db, EndpointQuery(name_prefix="test")),
+        "endpoint_registry.query (prefix)",
+        lambda: db.endpoints.query(EndpointQuery(name_prefix="test")),
     )
 
     bench("_transaction_actions", lambda: _transaction_actions(db))

--- a/lib/iris/src/iris/cluster/client/remote_client.py
+++ b/lib/iris/src/iris/cluster/client/remote_client.py
@@ -345,13 +345,38 @@ class RemoteClusterClient:
 
         return call_with_retry("list_workers", _call)
 
-    def list_jobs(self) -> list[job_pb2.JobStatus]:
-        def _call():
-            request = controller_pb2.Controller.ListJobsRequest()
-            response = self._client.list_jobs(request)
-            return list(response.jobs)
+    def list_jobs(
+        self,
+        *,
+        query: controller_pb2.Controller.JobQuery | None = None,
+        page_size: int = 500,
+    ) -> list[job_pb2.JobStatus]:
+        """Fetch all jobs matching ``query`` by paging through ``ListJobs``.
 
-        return call_with_retry("list_jobs", _call)
+        The server caps each page at ``MAX_LIST_JOBS_LIMIT``; this helper walks
+        ``has_more`` / ``total_count`` to return the full result set without
+        asking the controller for an unbounded scan.
+        """
+        if query is None:
+            query = controller_pb2.Controller.JobQuery()
+
+        jobs: list[job_pb2.JobStatus] = []
+        offset = query.offset or 0
+        while True:
+            page_query = controller_pb2.Controller.JobQuery()
+            page_query.CopyFrom(query)
+            page_query.offset = offset
+            page_query.limit = page_size
+
+            def _call(q=page_query):
+                request = controller_pb2.Controller.ListJobsRequest(query=q)
+                return self._client.list_jobs(request)
+
+            response = call_with_retry("list_jobs", _call)
+            jobs.extend(response.jobs)
+            if not response.has_more or not response.jobs:
+                return jobs
+            offset += len(response.jobs)
 
     def shutdown(self, wait: bool = True) -> None:
         del wait

--- a/lib/iris/src/iris/cluster/controller/actor_proxy.py
+++ b/lib/iris/src/iris/cluster/controller/actor_proxy.py
@@ -20,8 +20,7 @@ import httpx
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
-from iris.cluster.controller.db import ControllerDB, EndpointQuery, endpoint_query_sql
-from iris.cluster.controller.schema import ENDPOINT_PROJECTION
+from iris.cluster.controller.db import ControllerDB
 
 logger = logging.getLogger(__name__)
 
@@ -98,11 +97,8 @@ class ActorProxy:
         )
 
     def _resolve_endpoint(self, name: str) -> str | None:
-        """Resolve an endpoint name to an address via the controller DB."""
-        query = EndpointQuery(exact_name=name)
-        sql, params = endpoint_query_sql(query)
-        with self._db.read_snapshot() as q:
-            endpoints = ENDPOINT_PROJECTION.decode(q.fetchall(sql, tuple(params)))
-        if not endpoints:
+        """Resolve an endpoint name to an address via the in-memory registry."""
+        row = self._db.endpoints.resolve(name)
+        if row is None:
             return None
-        return endpoints[0].address
+        return row.address

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -1336,6 +1336,7 @@ class Controller:
         """Background pruning loop: history cleanup every 60s, full data prune on the configured interval."""
         last_full_prune = 0.0
         resource_history_limiter = RateLimiter(interval_seconds=600.0)
+        wal_checkpoint_limiter = RateLimiter(interval_seconds=600.0)
         full_prune_interval = self._config.prune_interval.to_seconds()
 
         while not stop_event.is_set():
@@ -1357,6 +1358,18 @@ class Controller:
                     self._transitions.prune_task_resource_history()
                 except Exception:
                     logger.exception("Task resource history cleanup failed")
+
+            if wal_checkpoint_limiter.should_run():
+                try:
+                    busy, log_frames, checkpointed = self._db.wal_checkpoint("TRUNCATE")
+                    logger.info(
+                        "wal_checkpoint(TRUNCATE): busy=%d log_frames=%d checkpointed=%d",
+                        busy,
+                        log_frames,
+                        checkpointed,
+                    )
+                except Exception:
+                    logger.exception("WAL checkpoint failed")
 
             now = time.monotonic()
             if now - last_full_prune >= full_prune_interval:

--- a/lib/iris/src/iris/cluster/controller/db.py
+++ b/lib/iris/src/iris/cluster/controller/db.py
@@ -16,7 +16,7 @@ from threading import Lock, RLock
 from typing import Any
 
 from iris.cluster.constraints import AttributeValue
-from iris.cluster.controller.schema import ENDPOINT_PROJECTION, decode_timestamp_ms, decode_worker_id
+from iris.cluster.controller.schema import decode_timestamp_ms, decode_worker_id
 from iris.cluster.types import JobName, WorkerId
 from iris.rpc import job_pb2
 from rigging.timing import Deadline, Duration, Timestamp
@@ -263,45 +263,19 @@ def _decode_attribute_rows(rows: Sequence[Any]) -> dict[WorkerId, dict[str, Attr
     return attrs_by_worker
 
 
-def endpoint_query_sql(query: EndpointQuery) -> tuple[str, list[object]]:
-    """Build SQL query for endpoint lookups."""
-    from_clause = f"SELECT {ENDPOINT_PROJECTION.select_clause()} FROM endpoints e"
-    conditions: list[str] = []
-    params: list[object] = []
-
-    if query.task_ids:
-        from_clause += " JOIN endpoints et ON e.endpoint_id = et.endpoint_id"
-        placeholders = ",".join("?" for _ in query.task_ids)
-        conditions.append(f"et.task_id IN ({placeholders})")
-        params.extend(tid.to_wire() for tid in query.task_ids)
-
-    if query.endpoint_ids:
-        placeholders = ",".join("?" for _ in query.endpoint_ids)
-        conditions.append(f"e.endpoint_id IN ({placeholders})")
-        params.extend(query.endpoint_ids)
-
-    if query.name_prefix:
-        conditions.append("e.name LIKE ?")
-        params.append(f"{query.name_prefix}%")
-
-    if query.exact_name:
-        conditions.append("e.name = ?")
-        params.append(query.exact_name)
-
-    sql = from_clause
-    if conditions:
-        sql += " WHERE " + " AND ".join(conditions)
-    if query.limit is not None:
-        sql += " LIMIT ?"
-        params.append(query.limit)
-    return sql, params
-
-
 class TransactionCursor:
-    """Wraps a raw sqlite3.Cursor for use within controller transactions."""
+    """Wraps a raw sqlite3.Cursor for use within controller transactions.
+
+    Post-commit hooks registered via :meth:`on_commit` run after the wrapping
+    ``ControllerDB.transaction()`` block commits successfully. They are used
+    by caches (e.g. ``EndpointRegistry``) to update in-memory state atomically
+    with the DB write: rollback suppresses the hook so memory never drifts
+    from disk.
+    """
 
     def __init__(self, cursor: sqlite3.Cursor):
         self._cursor = cursor
+        self._commit_hooks: list[Callable[[], None]] = []
 
     def execute(self, sql: str, params: tuple = ()) -> sqlite3.Cursor:
         """Raw SQL escape hatch."""
@@ -315,6 +289,14 @@ class TransactionCursor:
         """Raw SQL script escape hatch."""
         return self._cursor.executescript(sql)
 
+    def on_commit(self, hook: Callable[[], None]) -> None:
+        """Register ``hook`` to run after the transaction commits successfully."""
+        self._commit_hooks.append(hook)
+
+    def _run_commit_hooks(self) -> None:
+        for hook in self._commit_hooks:
+            hook()
+
     @property
     def lastrowid(self) -> int | None:
         return self._cursor.lastrowid
@@ -327,7 +309,7 @@ class TransactionCursor:
 class ControllerDB:
     """Thread-safe SQLite wrapper with typed query and migration helpers."""
 
-    _READ_POOL_SIZE = 8
+    _READ_POOL_SIZE = 32
     DB_FILENAME = "controller.sqlite3"
     AUTH_DB_FILENAME = "auth.sqlite3"
     PROFILES_DB_FILENAME = "profiles.sqlite3"
@@ -369,6 +351,20 @@ class ControllerDB:
         # Eliminates the per-cycle attribute SQL query from the scheduling hot path.
         self._attr_cache: dict[WorkerId, dict[str, AttributeValue]] | None = None
         self._attr_cache_lock = Lock()
+
+        # Write-through in-memory cache over the ``endpoints`` table. Imported
+        # locally to break the ``db -> endpoint_registry -> db`` import cycle;
+        # this is the single exception to "no local imports" (see AGENTS.md).
+        from iris.cluster.controller.endpoint_registry import EndpointRegistry
+
+        t0 = time.monotonic()
+        self._endpoint_registry = EndpointRegistry(self)
+        logger.info("EndpointRegistry initialized in %.2fs", time.monotonic() - t0)
+
+    @property
+    def endpoints(self) -> EndpointRegistry:  # noqa: F821
+        """Process-local cache for the ``endpoints`` table; authoritative for reads."""
+        return self._endpoint_registry
 
     def _populate_attr_cache(self) -> dict[WorkerId, dict[str, AttributeValue]]:
         """Load all worker attributes from the DB into the cache.
@@ -454,6 +450,23 @@ class ControllerDB:
         with self._lock:
             self._conn.execute("PRAGMA optimize")
 
+    def wal_checkpoint(self, mode: str = "TRUNCATE") -> tuple[int, int, int]:
+        """Run ``PRAGMA wal_checkpoint`` to move pages from the WAL into the main DB.
+
+        Left unchecked, the WAL grows unbounded under continuous write load and
+        makes every reader walk more frames to assemble a snapshot. TRUNCATE also
+        shrinks the WAL file on disk once all frames are checkpointed.
+
+        Returns ``(busy, log_frames, checkpointed_frames)`` exactly as SQLite does.
+        """
+        mode = mode.upper()
+        assert mode in ("PASSIVE", "FULL", "RESTART", "TRUNCATE"), f"invalid checkpoint mode {mode!r}"
+        # Pin to the main schema so the attached auth/profiles DBs (which may
+        # not even be in WAL mode) cannot raise SQLITE_LOCKED here.
+        with self._lock:
+            row = self._conn.execute(f"PRAGMA main.wal_checkpoint({mode})").fetchone()
+        return (int(row[0]), int(row[1]), int(row[2]))
+
     def close(self) -> None:
         with self._lock:
             self._conn.close()
@@ -465,17 +478,25 @@ class ControllerDB:
 
     @contextmanager
     def transaction(self):
-        """Open an IMMEDIATE transaction and yield a TransactionCursor."""
+        """Open an IMMEDIATE transaction and yield a TransactionCursor.
+
+        On successful commit, any hooks registered via ``TransactionCursor.on_commit``
+        fire while the write lock is still held — keeping in-memory caches
+        (e.g. ``EndpointRegistry``) in sync with the DB without exposing a
+        torn snapshot to concurrent readers.
+        """
         with self._lock:
             cur = self._conn.cursor()
             cur.execute("BEGIN IMMEDIATE")
+            tx_cur = TransactionCursor(cur)
             try:
-                yield TransactionCursor(cur)
+                yield tx_cur
             except Exception:
                 self._conn.rollback()
                 raise
             else:
                 self._conn.commit()
+                tx_cur._run_commit_hooks()
 
     def fetchall(self, query: str, params: tuple | list = ()) -> list[sqlite3.Row]:
         with self._lock:
@@ -561,26 +582,54 @@ class ControllerDB:
                 continue
             pending.append(path)
 
-        if pending:
-            logger.info("Applying %d pending migration(s): %s", len(pending), [p.name for p in pending])
+        if not pending:
+            return
 
-        for path in pending:
-            t0 = time.monotonic()
-            spec = importlib.util.spec_from_file_location(path.stem, path)
-            assert spec is not None and spec.loader is not None
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
-            module.migrate(self._conn)
-            # Commit any implicit transaction left open by migrate() (e.g.
-            # row-by-row UPDATEs in 0008) so the next BEGIN IMMEDIATE succeeds.
+        logger.info("Applying %d pending migration(s): %s", len(pending), [p.name for p in pending])
+
+        # Flip to fast-mode PRAGMAs for the duration of the migration loop.
+        # Safe: migrations run at startup before any concurrent access, and a
+        # crash re-runs the migration from schema_migrations. journal_mode
+        # cannot change inside a transaction, so commit first and restore at
+        # the end.
+        self._conn.commit()
+        self._conn.execute("PRAGMA synchronous=OFF")
+        # journal_mode returns a row; consume it so the cursor is closed and
+        # cannot hold a statement-level lock that would block wal_checkpoint.
+        self._conn.execute("PRAGMA journal_mode=MEMORY").fetchall()
+        self._conn.execute("PRAGMA temp_store=MEMORY")
+        try:
+            for path in pending:
+                t0 = time.monotonic()
+                spec = importlib.util.spec_from_file_location(path.stem, path)
+                assert spec is not None and spec.loader is not None
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                module.migrate(self._conn)
+                # Commit any implicit transaction left open by migrate() (e.g.
+                # row-by-row UPDATEs in 0008) so the next BEGIN IMMEDIATE succeeds.
+                self._conn.commit()
+                logger.info("Migration %s applied in %.2fs", path.name, time.monotonic() - t0)
+
+                with self.transaction() as cur:
+                    cur.execute(
+                        "INSERT INTO schema_migrations(name, applied_at_ms) VALUES (?, ?)",
+                        (path.name, Timestamp.now().epoch_ms()),
+                    )
+        finally:
             self._conn.commit()
-            logger.info("Migration %s applied in %.2fs", path.name, time.monotonic() - t0)
-
-            with self.transaction() as cur:
-                cur.execute(
-                    "INSERT INTO schema_migrations(name, applied_at_ms) VALUES (?, ?)",
-                    (path.name, Timestamp.now().epoch_ms()),
-                )
+            self._conn.execute("PRAGMA synchronous=NORMAL")
+            self._conn.execute("PRAGMA journal_mode=WAL").fetchall()
+            # Checkpoint and truncate the WAL so the migration's write volume
+            # does not linger as a giant WAL file that every subsequent reader
+            # must walk to build a snapshot.
+            busy, log_frames, checkpointed = self.wal_checkpoint("TRUNCATE")
+            logger.info(
+                "Post-migration wal_checkpoint(TRUNCATE): busy=%d log_frames=%d checkpointed=%d",
+                busy,
+                log_frames,
+                checkpointed,
+            )
 
     @property
     def api_keys_table(self) -> str:
@@ -662,6 +711,22 @@ class ControllerDB:
         vacuumed.rename(destination)
         logger.info("Checkpoint vacuumed in %.1fs", time.monotonic() - t0)
 
+    @staticmethod
+    def _sidecar_paths(path: Path) -> tuple[Path, Path]:
+        return (path.with_name(f"{path.name}-wal"), path.with_name(f"{path.name}-shm"))
+
+    @staticmethod
+    def _remove_sidecars(path: Path) -> None:
+        for sidecar in ControllerDB._sidecar_paths(path):
+            sidecar.unlink(missing_ok=True)
+
+    def _close_read_pool_connections(self) -> None:
+        while True:
+            try:
+                self._read_pool.get_nowait().close()
+            except queue.Empty:
+                break
+
     def replace_from(self, source_dir: str | Path) -> None:
         """Replace current DB files from ``source_dir`` and reopen connection.
 
@@ -675,12 +740,15 @@ class ControllerDB:
         source_dir_str = str(source_dir).rstrip("/")
 
         with self._lock:
+            self._close_read_pool_connections()
+            self._conn.close()
+
             # Download main DB
             main_source = f"{source_dir_str}/{self.DB_FILENAME}"
             tmp_path = self._db_path.with_suffix(".tmp")
             with fsspec.core.open(main_source, "rb") as src, open(tmp_path, "wb") as dst:
                 dst.write(src.read())
-            self._conn.close()
+            self._remove_sidecars(self._db_path)
             tmp_path.rename(self._db_path)
 
             # Download auth DB if present in source
@@ -690,6 +758,7 @@ class ControllerDB:
                 auth_tmp = self._auth_db_path.with_suffix(".tmp")
                 with fsspec.core.open(auth_source, "rb") as src, open(auth_tmp, "wb") as dst:
                     dst.write(src.read())
+                self._remove_sidecars(self._auth_db_path)
                 auth_tmp.rename(self._auth_db_path)
 
             # Download profiles DB if present in source
@@ -699,6 +768,7 @@ class ControllerDB:
                 profiles_tmp = self._profiles_db_path.with_suffix(".tmp")
                 with fsspec.core.open(profiles_source, "rb") as src, open(profiles_tmp, "wb") as dst:
                     dst.write(src.read())
+                self._remove_sidecars(self._profiles_db_path)
                 profiles_tmp.rename(self._profiles_db_path)
 
             self._conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
@@ -708,27 +778,11 @@ class ControllerDB:
             self._conn.execute("ATTACH DATABASE ? AS profiles", (str(self._profiles_db_path),))
             self._init_read_pool()
         self.apply_migrations()
+        self._endpoint_registry._load_all()
 
     # SQL-canonical read access is exposed through ``snapshot()`` and typed table
     # metadata at module scope. Legacy list/get/count helper methods were removed
     # to keep relation assembly explicit in controller/service/state query flows.
-
-    def delete_endpoint(self, endpoint_id: str):
-        with self.transaction() as cur:
-            row = cur.execute(
-                f"SELECT {ENDPOINT_PROJECTION.select_clause()} " "FROM endpoints e WHERE e.endpoint_id = ?",
-                (endpoint_id,),
-            ).fetchone()
-            if row is None:
-                return None
-            cur.execute("DELETE FROM endpoints WHERE endpoint_id = ?", (endpoint_id,))
-            return ENDPOINT_PROJECTION.decode_one([row])
-
-    def delete_endpoints(self, endpoint_ids: Sequence[str]) -> None:
-        if not endpoint_ids:
-            return
-        placeholders = ",".join("?" for _ in endpoint_ids)
-        self.execute(f"DELETE FROM endpoints WHERE endpoint_id IN ({placeholders})", tuple(endpoint_ids))
 
     # -- User budget accessors --------------------------------------------------
 

--- a/lib/iris/src/iris/cluster/controller/endpoint_registry.py
+++ b/lib/iris/src/iris/cluster/controller/endpoint_registry.py
@@ -1,0 +1,253 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process-local in-memory cache for the ``endpoints`` table.
+
+Profiling showed that ``ListEndpoints`` dominated controller CPU — not because
+the SQL was slow per se, but because every call serialized through the
+read-connection pool and walked a large WAL to build a snapshot. The endpoints
+table is tiny (hundreds of rows) and only changes on explicit register /
+unregister, so it is a natural fit for a write-through in-memory cache.
+
+Design invariants:
+
+* Reads never touch the DB. All lookups are served from in-memory maps
+  guarded by an ``RLock`` — readers observe a consistent snapshot of the
+  indexes, never a torn state mid-update.
+* Writes execute the SQL inside the caller's transaction. The in-memory
+  update is scheduled as a post-commit hook on the cursor so memory only
+  changes after the DB has committed. If the transaction rolls back, the
+  hook never fires.
+* N is small enough (≈ hundreds) that linear scans for prefix / task / id
+  lookups are simpler and plenty fast. Extra indexes (by name, by task_id)
+  speed the two common cases.
+
+The registry is the sole source of truth for endpoint reads; nothing else in
+the controller tree should SELECT from ``endpoints``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable, Sequence
+from threading import RLock
+
+from iris.cluster.controller.db import TERMINAL_TASK_STATES, EndpointQuery, TransactionCursor
+from iris.cluster.controller.schema import ENDPOINT_PROJECTION, EndpointRow
+from iris.cluster.types import JobName
+
+logger = logging.getLogger(__name__)
+
+
+class EndpointRegistry:
+    """In-memory index of endpoint rows, kept in sync with the DB.
+
+    Construct with a ``ControllerDB``; the registry loads all existing rows at
+    init time. Callers mutate through ``add`` / ``remove*`` methods that take
+    the open ``TransactionCursor`` so the SQL lands inside the caller's
+    transaction. Memory is only updated after a successful commit via a
+    cursor post-commit hook.
+    """
+
+    def __init__(self, db):
+        self._db = db
+        self._lock = RLock()
+        self._by_id: dict[str, EndpointRow] = {}
+        # One name can map to multiple endpoint_ids — the schema does not enforce
+        # uniqueness on ``name``, and ``INSERT OR REPLACE`` keys off endpoint_id.
+        self._by_name: dict[str, set[str]] = {}
+        self._by_task: dict[JobName, set[str]] = {}
+        self._load_all()
+
+    # -- Loading --------------------------------------------------------------
+
+    def _load_all(self) -> None:
+        with self._db.read_snapshot() as q:
+            rows = ENDPOINT_PROJECTION.decode(
+                q.fetchall(f"SELECT {ENDPOINT_PROJECTION.select_clause()} FROM endpoints e"),
+            )
+        with self._lock:
+            self._by_id.clear()
+            self._by_name.clear()
+            self._by_task.clear()
+            for row in rows:
+                self._index(row)
+        logger.info("EndpointRegistry loaded %d endpoint(s) from DB", len(rows))
+
+    def _index(self, row: EndpointRow) -> None:
+        self._by_id[row.endpoint_id] = row
+        self._by_name.setdefault(row.name, set()).add(row.endpoint_id)
+        self._by_task.setdefault(row.task_id, set()).add(row.endpoint_id)
+
+    def _unindex(self, endpoint_id: str) -> EndpointRow | None:
+        row = self._by_id.pop(endpoint_id, None)
+        if row is None:
+            return None
+        name_ids = self._by_name.get(row.name)
+        if name_ids is not None:
+            name_ids.discard(endpoint_id)
+            if not name_ids:
+                self._by_name.pop(row.name, None)
+        task_ids = self._by_task.get(row.task_id)
+        if task_ids is not None:
+            task_ids.discard(endpoint_id)
+            if not task_ids:
+                self._by_task.pop(row.task_id, None)
+        return row
+
+    # -- Reads ----------------------------------------------------------------
+
+    def query(self, query: EndpointQuery = EndpointQuery()) -> list[EndpointRow]:
+        """Return endpoint rows matching ``query``.
+
+        All filters AND together, matching the semantics of the original SQL
+        in :func:`iris.cluster.controller.db.endpoint_query_sql`.
+        """
+        with self._lock:
+            # Narrow the candidate set using the most selective index available.
+            if query.endpoint_ids:
+                candidates: Iterable[EndpointRow] = (
+                    self._by_id[eid] for eid in query.endpoint_ids if eid in self._by_id
+                )
+            elif query.task_ids:
+                task_set = set(query.task_ids)
+                candidates = (self._by_id[eid] for task_id in task_set for eid in self._by_task.get(task_id, ()))
+            elif query.exact_name is not None:
+                candidates = (self._by_id[eid] for eid in self._by_name.get(query.exact_name, ()))
+            else:
+                candidates = self._by_id.values()
+
+            results: list[EndpointRow] = []
+            for row in candidates:
+                if query.name_prefix is not None and not row.name.startswith(query.name_prefix):
+                    continue
+                if query.exact_name is not None and row.name != query.exact_name:
+                    continue
+                if query.task_ids and row.task_id not in query.task_ids:
+                    continue
+                if query.endpoint_ids and row.endpoint_id not in query.endpoint_ids:
+                    continue
+                results.append(row)
+                if query.limit is not None and len(results) >= query.limit:
+                    break
+            return results
+
+    def resolve(self, name: str) -> EndpointRow | None:
+        """Return any endpoint with exact ``name``, or None. Used by the actor proxy."""
+        with self._lock:
+            ids = self._by_name.get(name)
+            if not ids:
+                return None
+            # Arbitrary but stable pick — the original SQL did not specify ORDER BY.
+            return self._by_id[next(iter(ids))]
+
+    def get(self, endpoint_id: str) -> EndpointRow | None:
+        with self._lock:
+            return self._by_id.get(endpoint_id)
+
+    def all(self) -> list[EndpointRow]:
+        with self._lock:
+            return list(self._by_id.values())
+
+    # -- Writes ---------------------------------------------------------------
+
+    def add(self, cur: TransactionCursor, endpoint: EndpointRow) -> bool:
+        """Insert ``endpoint`` into the DB and schedule the memory update.
+
+        Returns False (and writes nothing) if the owning task is already
+        terminal. Otherwise inserts / replaces and schedules a post-commit
+        hook that updates the in-memory indexes.
+        """
+        task_id = endpoint.task_id
+        job_id, _ = task_id.require_task()
+        row = cur.execute("SELECT state FROM tasks WHERE task_id = ?", (task_id.to_wire(),)).fetchone()
+        if row is not None and int(row["state"]) in TERMINAL_TASK_STATES:
+            return False
+
+        cur.execute(
+            "INSERT OR REPLACE INTO endpoints("
+            "endpoint_id, name, address, job_id, task_id, metadata_json, registered_at_ms"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                endpoint.endpoint_id,
+                endpoint.name,
+                endpoint.address,
+                job_id.to_wire(),
+                task_id.to_wire(),
+                json.dumps(endpoint.metadata),
+                endpoint.registered_at.epoch_ms(),
+            ),
+        )
+
+        def apply() -> None:
+            with self._lock:
+                # Replace: drop any previous row with this id first so the
+                # name/task indexes stay consistent on overwrite.
+                self._unindex(endpoint.endpoint_id)
+                self._index(endpoint)
+
+        cur.on_commit(apply)
+        return True
+
+    def remove(self, cur: TransactionCursor, endpoint_id: str) -> EndpointRow | None:
+        """Remove a single endpoint by id. Returns the removed row snapshot, if any."""
+        existing = self.get(endpoint_id)
+        if existing is None:
+            return None
+        cur.execute("DELETE FROM endpoints WHERE endpoint_id = ?", (endpoint_id,))
+
+        def apply() -> None:
+            with self._lock:
+                self._unindex(endpoint_id)
+
+        cur.on_commit(apply)
+        return existing
+
+    def remove_by_task(self, cur: TransactionCursor, task_id: JobName) -> list[str]:
+        """Remove all endpoints owned by a task. Returns the removed endpoint_ids."""
+        with self._lock:
+            ids = list(self._by_task.get(task_id, ()))
+        if not ids:
+            # Still issue the DELETE to stay consistent with any rows the
+            # registry might not have observed yet (belt-and-suspenders for
+            # the unlikely race of an in-flight concurrent writer). This
+            # costs nothing on the common path.
+            cur.execute("DELETE FROM endpoints WHERE task_id = ?", (task_id.to_wire(),))
+            return []
+        cur.execute("DELETE FROM endpoints WHERE task_id = ?", (task_id.to_wire(),))
+
+        def apply() -> None:
+            with self._lock:
+                for eid in ids:
+                    self._unindex(eid)
+
+        cur.on_commit(apply)
+        return ids
+
+    def remove_by_job_ids(self, cur: TransactionCursor, job_ids: Sequence[JobName]) -> list[str]:
+        """Remove all endpoints owned by any of ``job_ids``. Used by cancel_job and prune."""
+        if not job_ids:
+            return []
+        wire_ids = [jid.to_wire() for jid in job_ids]
+        with self._lock:
+            to_remove: list[str] = []
+            for row in self._by_id.values():
+                owning_job, _ = row.task_id.require_task()
+                if owning_job.to_wire() in wire_ids:
+                    to_remove.append(row.endpoint_id)
+        placeholders = ",".join("?" for _ in wire_ids)
+        cur.execute(
+            f"DELETE FROM endpoints WHERE job_id IN ({placeholders})",
+            tuple(wire_ids),
+        )
+        if not to_remove:
+            return []
+
+        def apply() -> None:
+            with self._lock:
+                for eid in to_remove:
+                    self._unindex(eid)
+
+        cur.on_commit(apply)
+        return to_remove

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -62,7 +62,6 @@ from iris.cluster.controller.db import (
     TaskJobSummary,
     UserStats,
     attempt_is_worker_failure,
-    endpoint_query_sql,
     job_is_finished,
     running_tasks_by_worker,
     task_row_can_be_scheduled,
@@ -70,7 +69,6 @@ from iris.cluster.controller.db import (
 from iris.cluster.controller.schema import (
     API_KEY_PROJECTION,
     ATTEMPT_PROJECTION,
-    ENDPOINT_PROJECTION,
     JOB_CONFIG_JOIN,
     JOB_DETAIL_PROJECTION,
     JOB_ROW_PROJECTION,
@@ -729,11 +727,13 @@ def _query_from_list_jobs_request(
             limit=request.limit,
         )
 
-    # Clamp paging: 0 means "unbounded" (used by the Python client); otherwise cap at MAX.
-    if query.limit > MAX_LIST_JOBS_LIMIT:
+    # Clamp paging: 0 (unset) defaults to MAX; explicit values are capped at MAX.
+    # We no longer support unbounded listing — callers that previously relied on
+    # limit=0 must paginate. Unbounded queries scale poorly because downstream
+    # per-page work (_task_summaries_for_jobs, _parent_ids_with_children) grows
+    # an IN-clause with one placeholder per returned row.
+    if query.limit <= 0 or query.limit > MAX_LIST_JOBS_LIMIT:
         query.limit = MAX_LIST_JOBS_LIMIT
-    if query.limit < 0:
-        query.limit = 0
     if query.offset < 0:
         query.offset = 0
     return query
@@ -813,12 +813,6 @@ def _worker_roster(db: ControllerDB) -> list[WorkerDetailRow]:
                 attrs_by_worker.setdefault(wid, {})[key] = value
             workers = [dataclasses.replace(w, attributes=attrs_by_worker.get(str(w.worker_id), {})) for w in workers]
         return workers
-
-
-def _query_endpoints(db: ControllerDB, query: EndpointQuery = EndpointQuery()) -> list[EndpointRow]:
-    sql, params = endpoint_query_sql(query)
-    with db.read_snapshot() as q:
-        return ENDPOINT_PROJECTION.decode(q.fetchall(sql, tuple(params)))
 
 
 def _descendant_jobs(db: ControllerDB, job_id: JobName) -> list[JobDetailRow]:
@@ -1649,8 +1643,7 @@ class ControllerServiceImpl:
         if prefix.startswith("/system/"):
             return self._list_system_endpoints(prefix, exact=request.exact)
 
-        endpoints = _query_endpoints(
-            self._db,
+        endpoints = self._db.endpoints.query(
             EndpointQuery(
                 exact_name=prefix if request.exact else None,
                 name_prefix=None if request.exact else prefix,

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -304,9 +304,9 @@ def _has_reservation_flag(request: controller_pb2.Controller.LaunchJobRequest) -
     return 1 if request.HasField("reservation") and request.reservation.entries else 0
 
 
-def delete_task_endpoints(cur: TransactionCursor, task_id: str) -> None:
-    """Remove all registered endpoints for a task."""
-    cur.execute("DELETE FROM endpoints WHERE task_id = ?", (task_id,))
+def delete_task_endpoints(cur: TransactionCursor, registry, task_id: str) -> None:
+    """Remove all registered endpoints for a task through the endpoint registry."""
+    registry.remove_by_task(cur, JobName.from_wire(task_id))
 
 
 def enqueue_run_dispatch(
@@ -418,6 +418,7 @@ def _assign_task(
 
 def _terminate_task(
     cur: TransactionCursor,
+    registry,
     task_id: str,
     attempt_id: int | None,
     state: int,
@@ -481,7 +482,7 @@ def _terminate_task(
         tuple(params),
     )
 
-    delete_task_endpoints(cur, task_id)
+    delete_task_endpoints(cur, registry, task_id)
 
     if worker_id is not None and resources is not None:
         _decommit_worker_resources(cur, worker_id, resources)
@@ -489,6 +490,7 @@ def _terminate_task(
 
 def _kill_non_terminal_tasks(
     cur: Any,
+    registry,
     job_id_wire: str,
     reason: str,
     now_ms: int,
@@ -522,6 +524,7 @@ def _kill_non_terminal_tasks(
             task_kill_workers[task_name] = WorkerId(str(worker_id))
         _terminate_task(
             cur,
+            registry,
             task_id,
             int(row["current_attempt_id"]),
             job_pb2.TASK_STATE_KILLED,
@@ -536,6 +539,7 @@ def _kill_non_terminal_tasks(
 
 def _cascade_children(
     cur: Any,
+    registry,
     job_id: JobName,
     now_ms: int,
     reason: str,
@@ -573,7 +577,9 @@ def _cascade_children(
         ).fetchall()
     for child_row in descendants:
         child_job_id = str(child_row["job_id"])
-        child_tasks_to_kill, child_task_kill_workers = _kill_non_terminal_tasks(cur, child_job_id, reason, now_ms)
+        child_tasks_to_kill, child_task_kill_workers = _kill_non_terminal_tasks(
+            cur, registry, child_job_id, reason, now_ms
+        )
         tasks_to_kill.update(child_tasks_to_kill)
         task_kill_workers.update(child_task_kill_workers)
         terminal_placeholders = ",".join("?" for _ in TERMINAL_JOB_STATES)
@@ -593,13 +599,14 @@ def _cascade_children(
 
 def _cascade_terminal_job(
     cur: Any,
+    registry,
     job_id: JobName,
     now_ms: int,
     reason: str,
 ) -> tuple[set[JobName], dict[JobName, WorkerId]]:
     """Kill remaining tasks and descendant jobs when a job reaches a terminal state."""
-    tasks_to_kill, task_kill_workers = _kill_non_terminal_tasks(cur, job_id.to_wire(), reason, now_ms)
-    child_tasks_to_kill, child_task_kill_workers = _cascade_children(cur, job_id, now_ms, reason)
+    tasks_to_kill, task_kill_workers = _kill_non_terminal_tasks(cur, registry, job_id.to_wire(), reason, now_ms)
+    child_tasks_to_kill, child_task_kill_workers = _cascade_children(cur, registry, job_id, now_ms, reason)
     tasks_to_kill.update(child_tasks_to_kill)
     task_kill_workers.update(child_task_kill_workers)
     return tasks_to_kill, task_kill_workers
@@ -648,6 +655,7 @@ def _find_coscheduled_siblings(
 
 def _terminate_coscheduled_siblings(
     cur: Any,
+    registry,
     siblings: Iterable[_CoscheduledSibling],
     failed_task_id: JobName,
     resources: "job_pb2.ResourceSpecProto",
@@ -665,6 +673,7 @@ def _terminate_coscheduled_siblings(
     for sib in siblings:
         _terminate_task(
             cur,
+            registry,
             sib.task_id,
             sib.attempt_id,
             job_pb2.TASK_STATE_WORKER_FAILED,
@@ -710,6 +719,7 @@ _TERMINAL_STATE_REASONS: dict[int, str] = {
 
 def _finalize_terminal_job(
     cur: Any,
+    registry,
     job_id: JobName,
     terminal_state: int,
     now_ms: int,
@@ -724,13 +734,13 @@ def _finalize_terminal_job(
     Non-succeeded jobs cascade only if the preemption policy is TERMINATE_CHILDREN.
     """
     reason = _TERMINAL_STATE_REASONS.get(terminal_state, "Job finalized")
-    tasks_to_kill, task_kill_workers = _kill_non_terminal_tasks(cur, job_id.to_wire(), reason, now_ms)
+    tasks_to_kill, task_kill_workers = _kill_non_terminal_tasks(cur, registry, job_id.to_wire(), reason, now_ms)
     should_cascade = True
     if terminal_state != job_pb2.JOB_STATE_SUCCEEDED:
         policy = _resolve_preemption_policy(cur, job_id)
         should_cascade = policy == job_pb2.JOB_PREEMPTION_POLICY_TERMINATE_CHILDREN
     if should_cascade:
-        child_tasks_to_kill, child_task_kill_workers = _cascade_children(cur, job_id, now_ms, reason)
+        child_tasks_to_kill, child_task_kill_workers = _cascade_children(cur, registry, job_id, now_ms, reason)
         tasks_to_kill.update(child_tasks_to_kill)
         task_kill_workers.update(child_task_kill_workers)
     return tasks_to_kill, task_kill_workers
@@ -1384,10 +1394,7 @@ class ControllerTransitions:
                     *cancel_guard_states,
                 ),
             )
-            cur.execute(
-                f"DELETE FROM endpoints WHERE job_id IN ({placeholders})",
-                tuple(subtree_ids),
-            )
+            self._db.endpoints.remove_by_job_ids(cur, [JobName.from_wire(jid) for jid in subtree_ids])
             self._record_transaction(cur, "cancel_job", [("job_cancelled", job_id.to_wire(), {"reason": reason})])
             return TxResult(tasks_to_kill=tasks_to_kill, task_kill_workers=task_kill_workers)
 
@@ -1832,7 +1839,7 @@ class ControllerTransitions:
                     _decommit_worker_resources(cur, str(worker_id), resources)
 
             if update.new_state in TERMINAL_TASK_STATES:
-                delete_task_endpoints(cur, update.task_id.to_wire())
+                delete_task_endpoints(cur, self._db.endpoints, update.task_id.to_wire())
 
             # Coscheduled jobs: a terminal host failure should cascade to siblings.
             if jc is not None and task_state in FAILURE_TASK_STATES:
@@ -1845,7 +1852,7 @@ class ControllerTransitions:
                     jc["res_device_json"],
                 )
                 cascade_kill, cascade_workers = _terminate_coscheduled_siblings(
-                    cur, siblings, update.task_id, resources, now_ms
+                    cur, self._db.endpoints, siblings, update.task_id, resources, now_ms
                 )
                 tasks_to_kill.update(cascade_kill)
                 task_kill_workers.update(cascade_workers)
@@ -1860,7 +1867,9 @@ class ControllerTransitions:
                 continue
             new_job_state = self._recompute_job_state(cur, job_id)
             if new_job_state in TERMINAL_JOB_STATES:
-                final_tasks_to_kill, final_task_kill_workers = _finalize_terminal_job(cur, job_id, new_job_state, now_ms)
+                final_tasks_to_kill, final_task_kill_workers = _finalize_terminal_job(
+                    cur, self._db.endpoints, job_id, new_job_state, now_ms
+                )
                 tasks_to_kill.update(final_tasks_to_kill)
                 task_kill_workers.update(final_task_kill_workers)
                 cascaded_jobs.add(job_id)
@@ -2043,6 +2052,7 @@ class ControllerTransitions:
             else:
                 _terminate_task(
                     cur,
+                    self._db.endpoints,
                     tid,
                     int(task_row["current_attempt_id"]),
                     new_task_state,
@@ -2056,7 +2066,7 @@ class ControllerTransitions:
             new_job_state = self._recompute_job_state(cur, parent_job_id)
             if new_job_state is not None and new_job_state in TERMINAL_JOB_STATES:
                 cascaded_tasks_to_kill, cascaded_task_kill_workers = _cascade_terminal_job(
-                    cur, parent_job_id, now_ms, f"Worker {worker_id} failed"
+                    cur, self._db.endpoints, parent_job_id, now_ms, f"Worker {worker_id} failed"
                 )
                 tasks_to_kill.update(cascaded_tasks_to_kill)
                 task_kill_workers.update(cascaded_task_kill_workers)
@@ -2065,6 +2075,7 @@ class ControllerTransitions:
                 if policy == job_pb2.JOB_PREEMPTION_POLICY_TERMINATE_CHILDREN:
                     child_tasks_to_kill, child_task_kill_workers = _cascade_children(
                         cur,
+                        self._db.endpoints,
                         parent_job_id,
                         now_ms,
                         "Parent task preempted",
@@ -2226,6 +2237,7 @@ class ControllerTransitions:
             now_ms = Timestamp.now().epoch_ms()
             _terminate_task(
                 cur,
+                self._db.endpoints,
                 task_id.to_wire(),
                 None,
                 job_pb2.TASK_STATE_UNSCHEDULABLE,
@@ -2286,6 +2298,7 @@ class ControllerTransitions:
 
             _terminate_task(
                 cur,
+                self._db.endpoints,
                 task_id.to_wire(),
                 int(row["current_attempt_id"]),
                 new_state,
@@ -2301,7 +2314,9 @@ class ControllerTransitions:
             job_id = JobName.from_wire(str(row["job_id"]))
             new_job_state = self._recompute_job_state(cur, job_id)
             if new_job_state is not None and new_job_state in TERMINAL_JOB_STATES:
-                cascade_kills, cascade_workers = _finalize_terminal_job(cur, job_id, new_job_state, now_ms)
+                cascade_kills, cascade_workers = _finalize_terminal_job(
+                    cur, self._db.endpoints, job_id, new_job_state, now_ms
+                )
                 tasks_to_kill.update(cascade_kills)
                 task_kill_workers.update(cascade_workers)
             elif new_state == job_pb2.TASK_STATE_PENDING:
@@ -2309,6 +2324,7 @@ class ControllerTransitions:
                 if policy == job_pb2.JOB_PREEMPTION_POLICY_TERMINATE_CHILDREN:
                     child_kills, child_workers = _cascade_children(
                         cur,
+                        self._db.endpoints,
                         job_id,
                         now_ms,
                         reason,
@@ -2409,6 +2425,7 @@ class ControllerTransitions:
                 attempt_id = row["current_attempt_id"]
                 _terminate_task(
                     cur,
+                    self._db.endpoints,
                     task_id_wire,
                     int(attempt_id) if attempt_id is not None else None,
                     job_pb2.TASK_STATE_FAILED,
@@ -2434,7 +2451,7 @@ class ControllerTransitions:
                 # Pick the first direct-timeout task in this job as the "cause" for the error message.
                 cause_tid = next(JobName.from_wire(str(r["task_id"])) for r in rows if str(r["job_id"]) == job_id_wire)
                 cascade_kill, cascade_workers = _terminate_coscheduled_siblings(
-                    cur, siblings, cause_tid, job_resources, now_ms
+                    cur, self._db.endpoints, siblings, cause_tid, job_resources, now_ms
                 )
                 tasks_to_kill.update(cascade_kill)
                 task_kill_workers.update(cascade_workers)
@@ -2444,7 +2461,7 @@ class ControllerTransitions:
                 new_job_state = self._recompute_job_state(cur, JobName.from_wire(job_wire))
                 if new_job_state in TERMINAL_JOB_STATES:
                     final_kill, final_workers = _finalize_terminal_job(
-                        cur, JobName.from_wire(job_wire), new_job_state, now_ms
+                        cur, self._db.endpoints, JobName.from_wire(job_wire), new_job_state, now_ms
                     )
                     tasks_to_kill.update(final_kill)
                     task_kill_workers.update(final_workers)
@@ -2814,6 +2831,9 @@ class ControllerTransitions:
                 break
             job_id = row["job_id"]
             with self._db.transaction() as cur:
+                # Invalidate endpoint cache BEFORE the CASCADE so the registry
+                # drops rows SQLite is about to delete for us.
+                self._db.endpoints.remove_by_job_ids(cur, [JobName.from_wire(str(job_id))])
                 cur.execute("DELETE FROM jobs WHERE job_id = ?", (job_id,))
                 self._record_transaction(cur, "prune_old_data", [("job_pruned", str(job_id), {})])
             jobs_deleted += 1
@@ -3071,35 +3091,17 @@ class ControllerTransitions:
     # --- Endpoint Management ---
 
     def add_endpoint(self, endpoint: EndpointRow) -> bool:
-        """Add an endpoint row to the DB, associated with a non-terminal task.
+        """Add an endpoint row through the endpoint registry.
 
         Returns True if the endpoint was inserted, False if the task is already
         terminal (to prevent orphaned endpoints that would never be cleaned up).
         """
-        task_id = endpoint.task_id
-        job_id, _task_index = task_id.require_task()
         with self._db.transaction() as cur:
-            row = cur.execute("SELECT state FROM tasks WHERE task_id = ?", (task_id.to_wire(),)).fetchone()
-            if row is not None and int(row["state"]) in TERMINAL_TASK_STATES:
-                return False
-            cur.execute(
-                "INSERT OR REPLACE INTO endpoints("
-                "endpoint_id, name, address, job_id, task_id, metadata_json, registered_at_ms"
-                ") VALUES (?, ?, ?, ?, ?, ?, ?)",
-                (
-                    endpoint.endpoint_id,
-                    endpoint.name,
-                    endpoint.address,
-                    job_id.to_wire(),
-                    task_id.to_wire(),
-                    json.dumps(endpoint.metadata),
-                    endpoint.registered_at.epoch_ms(),
-                ),
-            )
-            return True
+            return self._db.endpoints.add(cur, endpoint)
 
     def remove_endpoint(self, endpoint_id: str) -> EndpointRow | None:
-        return self._db.delete_endpoint(endpoint_id)
+        with self._db.transaction() as cur:
+            return self._db.endpoints.remove(cur, endpoint_id)
 
     # ---------------------------------------------------------------------
     # Test-only SQL mutation helpers
@@ -3417,7 +3419,7 @@ class ControllerTransitions:
                 jc_row = cur.execute("SELECT * FROM job_config WHERE job_id = ?", (task.job_id.to_wire(),)).fetchone()
 
                 if update.new_state in TERMINAL_TASK_STATES:
-                    delete_task_endpoints(cur, update.task_id.to_wire())
+                    delete_task_endpoints(cur, self._db.endpoints, update.task_id.to_wire())
 
                 # Coscheduled sibling cascade.
                 if jc_row is not None and task_state in FAILURE_TASK_STATES:
@@ -3430,7 +3432,7 @@ class ControllerTransitions:
                         jc_row["res_device_json"],
                     )
                     cascade_kill, cascade_workers = _terminate_coscheduled_siblings(
-                        cur, siblings, update.task_id, job_resources, now_ms
+                        cur, self._db.endpoints, siblings, update.task_id, job_resources, now_ms
                     )
                     tasks_to_kill.update(cascade_kill)
                     task_kill_workers.update(cascade_workers)
@@ -3439,7 +3441,7 @@ class ControllerTransitions:
                     new_job_state = self._recompute_job_state(cur, task.job_id)
                     if new_job_state in TERMINAL_JOB_STATES:
                         final_tasks_to_kill, final_task_kill_workers = _finalize_terminal_job(
-                            cur, task.job_id, new_job_state, now_ms
+                            cur, self._db.endpoints, task.job_id, new_job_state, now_ms
                         )
                         tasks_to_kill.update(final_tasks_to_kill)
                         task_kill_workers.update(final_task_kill_workers)

--- a/lib/iris/src/iris/cluster/providers/gcp/service.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/service.py
@@ -83,11 +83,6 @@ _OPERATION_TIMEOUT = 600  # seconds to wait for an operation to complete
 # quota/stockout error (e.g. "no more capacity in the zone").
 _RPC_CODE_RESOURCE_EXHAUSTED = 8
 
-# tpu_delete retries on QuotaExhaustedError to absorb the per-minute GCP
-# DeleteNode rate limit. Total worst-case wait is ~30s before giving up.
-_TPU_DELETE_MAX_ATTEMPTS = 3
-_TPU_DELETE_RETRY_BACKOFF = 10.0  # seconds between retries
-
 
 # ============================================================================
 # Data types
@@ -577,27 +572,9 @@ class CloudGcpService:
     def tpu_delete(self, name: str, zone: str) -> None:
         logger.info("Deleting TPU (async): %s", name)
         url = f"{_TPU_BASE}/{self._tpu_parent(zone)}/nodes/{name}"
-        # GCP enforces a per-minute DeleteNode quota. A burst of scale-downs
-        # can hit it; retry with a short backoff so we don't leak slices or
-        # spam the controller log with tracebacks.
-        for attempt in range(_TPU_DELETE_MAX_ATTEMPTS):
-            resp = self._client.delete(url, headers=self._headers())
-            if resp.status_code == 404:
-                return
-            try:
-                self._classify_response(resp)
-                return
-            except QuotaExhaustedError:
-                if attempt + 1 >= _TPU_DELETE_MAX_ATTEMPTS:
-                    raise
-                logger.warning(
-                    "tpu_delete %s rate-limited (attempt %d/%d); retrying in %.0fs",
-                    name,
-                    attempt + 1,
-                    _TPU_DELETE_MAX_ATTEMPTS,
-                    _TPU_DELETE_RETRY_BACKOFF,
-                )
-                time.sleep(_TPU_DELETE_RETRY_BACKOFF)
+        resp = self._client.delete(url, headers=self._headers())
+        if resp.status_code != 404:
+            self._classify_response(resp)
 
     def _tpu_get(self, name: str, zone: str) -> dict:
         url = f"{_TPU_BASE}/{self._tpu_parent(zone)}/nodes/{name}"
@@ -712,7 +689,9 @@ class CloudGcpService:
         logger.info("Deleting queued resource (force): %s", name)
         qr_name = f"projects/{self._project_id}/locations/{zone}/queuedResources/{name}"
         try:
-            self._tpu_alpha_client.delete_queued_resource(name=qr_name, force=True)
+            self._tpu_alpha_client.delete_queued_resource(
+                request=tpu_v2alpha1.DeleteQueuedResourceRequest(name=qr_name, force=True)
+            )
         except google.api_core.exceptions.NotFound:
             pass
         except google.api_core.exceptions.GoogleAPICallError as exc:

--- a/lib/iris/tests/cluster/controller/test_db.py
+++ b/lib/iris/tests/cluster/controller/test_db.py
@@ -3,6 +3,7 @@
 
 """Tests for TransactionCursor escape-hatch methods and read pool in db.py."""
 
+import sqlite3
 import threading
 from pathlib import Path
 
@@ -250,16 +251,46 @@ def test_replace_from_reattaches_profiles_db(tmp_path: Path) -> None:
     backup_dir.mkdir()
     db.backup_to(backup_dir / "controller.sqlite3")
 
-    # The profiles DB is a separate file; copy it into the backup dir so
-    # replace_from can find it.
-    import shutil
-
-    shutil.copy2(db.profiles_db_path, backup_dir / ControllerDB.PROFILES_DB_FILENAME)
+    # The profiles DB is a separate WAL-mode file; export a standalone backup
+    # so replace_from can restore from a self-contained sqlite file.
+    profiles_backup = backup_dir / ControllerDB.PROFILES_DB_FILENAME
+    src = sqlite3.connect(str(db.profiles_db_path))
+    dest = sqlite3.connect(str(profiles_backup))
+    try:
+        src.backup(dest)
+        dest.execute("PRAGMA journal_mode = DELETE")
+        dest.commit()
+    finally:
+        src.close()
+        dest.close()
 
     db.replace_from(str(backup_dir))
 
     profiles = get_task_profiles(db, "task-1")
     assert len(profiles) == 1
+    db.close()
+
+
+def test_replace_from_replaces_db_with_live_wal_sidecars_present(tmp_path: Path) -> None:
+    """replace_from() must discard stale sidecars from the live DB before reopening."""
+    db = ControllerDB(db_dir=tmp_path)
+
+    # Leave main DB WAL/shm sidecars behind on the live path.
+    with db.transaction() as cur:
+        cur.execute("INSERT INTO meta(key, value) VALUES (?, ?)", ("live-key", 1))
+
+    backup_dir = tmp_path / "backup"
+    backup_dir.mkdir()
+    db.backup_to(backup_dir / "controller.sqlite3")
+
+    assert db.db_path.with_name(f"{db.db_path.name}-wal").exists()
+    assert db.db_path.with_name(f"{db.db_path.name}-shm").exists()
+
+    db.replace_from(str(backup_dir))
+
+    rows = db.fetchall("SELECT value FROM meta WHERE key = ?", ("live-key",))
+    assert len(rows) == 1
+    assert rows[0]["value"] == 1
     db.close()
 
 

--- a/lib/iris/tests/cluster/controller/test_endpoint_registry.py
+++ b/lib/iris/tests/cluster/controller/test_endpoint_registry.py
@@ -1,0 +1,335 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for EndpointRegistry — the in-memory cache over the ``endpoints`` table."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from iris.cluster.controller.db import EndpointQuery
+from iris.cluster.controller.endpoint_registry import EndpointRegistry
+from iris.cluster.controller.schema import ENDPOINT_PROJECTION, EndpointRow
+from iris.cluster.types import JobName
+from iris.rpc import job_pb2
+from rigging.timing import Timestamp
+
+from .conftest import make_job_request, submit_job
+
+
+# --- Parity helper: the legacy SQL builder, preserved solely for parity tests.
+# Deleted from production; kept here so a parity test demonstrates the registry
+# returns an identical row set for representative queries.
+def _endpoint_query_sql_legacy(query: EndpointQuery) -> tuple[str, list[object]]:
+    from_clause = f"SELECT {ENDPOINT_PROJECTION.select_clause()} FROM endpoints e"
+    conditions: list[str] = []
+    params: list[object] = []
+
+    if query.task_ids:
+        from_clause += " JOIN endpoints et ON e.endpoint_id = et.endpoint_id"
+        placeholders = ",".join("?" for _ in query.task_ids)
+        conditions.append(f"et.task_id IN ({placeholders})")
+        params.extend(tid.to_wire() for tid in query.task_ids)
+
+    if query.endpoint_ids:
+        placeholders = ",".join("?" for _ in query.endpoint_ids)
+        conditions.append(f"e.endpoint_id IN ({placeholders})")
+        params.extend(query.endpoint_ids)
+
+    if query.name_prefix:
+        conditions.append("e.name LIKE ?")
+        params.append(f"{query.name_prefix}%")
+
+    if query.exact_name:
+        conditions.append("e.name = ?")
+        params.append(query.exact_name)
+
+    sql = from_clause
+    if conditions:
+        sql += " WHERE " + " AND ".join(conditions)
+    if query.limit is not None:
+        sql += " LIMIT ?"
+        params.append(query.limit)
+    return sql, params
+
+
+def _make_row(endpoint_id: str, name: str, task_id: JobName, *, address: str = "h:1") -> EndpointRow:
+    return EndpointRow(
+        endpoint_id=endpoint_id,
+        name=name,
+        address=address,
+        task_id=task_id,
+        metadata={},
+        registered_at=Timestamp.now(),
+    )
+
+
+# --- Load / add / remove ----------------------------------------------------
+
+
+def test_registry_loads_existing_rows_on_startup(state):
+    """On construction, the registry should contain every row in the ``endpoints`` table."""
+    tasks = submit_job(state, "j", make_job_request("j"))
+    with state._db.transaction() as cur:
+        assert state._db.endpoints.add(cur, _make_row("e1", "svc", tasks[0].task_id))
+
+    fresh = EndpointRegistry(state._db)
+    rows = fresh.query()
+    assert [r.endpoint_id for r in rows] == ["e1"]
+
+
+def test_add_updates_memory_after_commit(state):
+    tasks = submit_job(state, "j", make_job_request("j"))
+    t = tasks[0].task_id
+
+    with state._db.transaction() as cur:
+        assert state._db.endpoints.add(cur, _make_row("e1", "alpha", t))
+        # Not yet committed; memory should not reflect the insert.
+        assert state._db.endpoints.get("e1") is None
+
+    assert state._db.endpoints.get("e1") is not None
+    assert [r.endpoint_id for r in state._db.endpoints.query()] == ["e1"]
+
+
+def test_rollback_leaves_memory_untouched(state):
+    tasks = submit_job(state, "j", make_job_request("j"))
+    t = tasks[0].task_id
+
+    class BoomError(RuntimeError):
+        pass
+
+    with pytest.raises(BoomError):
+        with state._db.transaction() as cur:
+            state._db.endpoints.add(cur, _make_row("e1", "alpha", t))
+            raise BoomError
+
+    # DB rolled back → memory must NOT see the insert.
+    assert state._db.endpoints.get("e1") is None
+    assert state._db.endpoints.query() == []
+
+
+def test_add_rejects_terminal_task(state):
+    """Writing an endpoint for a terminal task should return False and not mutate memory."""
+    tasks = submit_job(state, "j", make_job_request("j"))
+    task_id = tasks[0].task_id
+    # Drive the task to SUCCEEDED to mark it terminal.
+    state._db.execute(
+        "UPDATE tasks SET state = ? WHERE task_id = ?",
+        (job_pb2.TASK_STATE_SUCCEEDED, task_id.to_wire()),
+    )
+
+    with state._db.transaction() as cur:
+        assert state._db.endpoints.add(cur, _make_row("e1", "alpha", task_id)) is False
+
+    assert state._db.endpoints.get("e1") is None
+
+
+def test_remove_drops_endpoint_by_id(state):
+    tasks = submit_job(state, "j", make_job_request("j"))
+    t = tasks[0].task_id
+    with state._db.transaction() as cur:
+        state._db.endpoints.add(cur, _make_row("e1", "alpha", t))
+        state._db.endpoints.add(cur, _make_row("e2", "beta", t))
+
+    with state._db.transaction() as cur:
+        removed = state._db.endpoints.remove(cur, "e1")
+    assert removed is not None and removed.endpoint_id == "e1"
+    assert {r.endpoint_id for r in state._db.endpoints.query()} == {"e2"}
+
+
+def test_remove_by_task_drops_all_task_endpoints(state):
+    tasks = submit_job(state, "j", make_job_request("j", replicas=2))
+    t1, t2 = tasks[0].task_id, tasks[1].task_id
+
+    with state._db.transaction() as cur:
+        state._db.endpoints.add(cur, _make_row("e1", "alpha", t1))
+        state._db.endpoints.add(cur, _make_row("e2", "beta", t1))
+        state._db.endpoints.add(cur, _make_row("e3", "gamma", t2))
+
+    with state._db.transaction() as cur:
+        removed = state._db.endpoints.remove_by_task(cur, t1)
+
+    assert set(removed) == {"e1", "e2"}
+    assert {r.endpoint_id for r in state._db.endpoints.query()} == {"e3"}
+
+
+def test_remove_by_job_ids_drops_subtree(state):
+    tasks_a = submit_job(state, "a", make_job_request("a"))
+    tasks_b = submit_job(state, "b", make_job_request("b"))
+    ja = tasks_a[0].task_id.require_task()[0]
+    t1 = tasks_a[0].task_id
+    t2 = tasks_b[0].task_id
+
+    with state._db.transaction() as cur:
+        state._db.endpoints.add(cur, _make_row("e1", "alpha", t1))
+        state._db.endpoints.add(cur, _make_row("e2", "beta", t2))
+
+    with state._db.transaction() as cur:
+        removed = state._db.endpoints.remove_by_job_ids(cur, [ja])
+
+    assert removed == ["e1"]
+    assert [r.endpoint_id for r in state._db.endpoints.query()] == ["e2"]
+
+
+# --- Query semantics --------------------------------------------------------
+
+
+@pytest.fixture
+def populated(state):
+    """A registry populated with a small fixture set spanning names, tasks, prefixes."""
+    tasks_j = submit_job(state, "j", make_job_request("j", replicas=2))
+    tasks_other = submit_job(state, "other", make_job_request("other"))
+    t0 = tasks_j[0].task_id
+    t1 = tasks_j[1].task_id
+    t2 = tasks_other[0].task_id
+
+    rows = [
+        _make_row("e1", "alpha/svc", t0),
+        _make_row("e2", "alpha/worker", t0),
+        _make_row("e3", "beta/svc", t1),
+        _make_row("e4", "gamma/svc", t2),
+    ]
+    with state._db.transaction() as cur:
+        for r in rows:
+            state._db.endpoints.add(cur, r)
+    return state, rows, (t0, t1, t2)
+
+
+def test_query_by_exact_name(populated):
+    state, _, _ = populated
+    ids = {r.endpoint_id for r in state._db.endpoints.query(EndpointQuery(exact_name="alpha/svc"))}
+    assert ids == {"e1"}
+
+
+def test_query_by_prefix(populated):
+    state, _, _ = populated
+    ids = {r.endpoint_id for r in state._db.endpoints.query(EndpointQuery(name_prefix="alpha/"))}
+    assert ids == {"e1", "e2"}
+
+
+def test_query_by_task_ids(populated):
+    state, _, (t0, _, t2) = populated
+    ids = {r.endpoint_id for r in state._db.endpoints.query(EndpointQuery(task_ids=(t0, t2)))}
+    assert ids == {"e1", "e2", "e4"}
+
+
+def test_query_by_endpoint_ids(populated):
+    state, _, _ = populated
+    ids = {r.endpoint_id for r in state._db.endpoints.query(EndpointQuery(endpoint_ids=("e2", "e3")))}
+    assert ids == {"e2", "e3"}
+
+
+def test_query_limit(populated):
+    state, _, _ = populated
+    rows = state._db.endpoints.query(EndpointQuery(limit=2))
+    assert len(rows) == 2
+
+
+def test_query_empty_matches_all(populated):
+    state, rows, _ = populated
+    assert {r.endpoint_id for r in state._db.endpoints.query()} == {r.endpoint_id for r in rows}
+
+
+def test_resolve_returns_address_for_exact_name(populated):
+    state, _, _ = populated
+    row = state._db.endpoints.resolve("alpha/svc")
+    assert row is not None
+    assert row.endpoint_id == "e1"
+    assert state._db.endpoints.resolve("nope") is None
+
+
+# --- Parity with the legacy SQL builder -------------------------------------
+
+
+@pytest.mark.parametrize(
+    "build_query",
+    [
+        lambda t0, t1, t2: EndpointQuery(),
+        lambda t0, t1, t2: EndpointQuery(exact_name="alpha/svc"),
+        lambda t0, t1, t2: EndpointQuery(name_prefix="alpha"),
+        lambda t0, t1, t2: EndpointQuery(task_ids=(t0,)),
+        lambda t0, t1, t2: EndpointQuery(task_ids=(t0, t2)),
+        lambda t0, t1, t2: EndpointQuery(endpoint_ids=("e1", "e3")),
+        lambda t0, t1, t2: EndpointQuery(name_prefix="alpha", limit=1),
+    ],
+)
+def test_registry_parity_with_legacy_sql(populated, build_query):
+    state, _, (t0, t1, t2) = populated
+    query = build_query(t0, t1, t2)
+
+    sql, params = _endpoint_query_sql_legacy(query)
+    with state._db.read_snapshot() as q:
+        expected_ids = sorted(r.endpoint_id for r in ENDPOINT_PROJECTION.decode(q.fetchall(sql, tuple(params))))
+    actual_ids = sorted(r.endpoint_id for r in state._db.endpoints.query(query))
+
+    # For LIMIT queries, both sides just need to be a valid subset of matching rows.
+    if query.limit is not None:
+        assert len(actual_ids) == len(expected_ids)
+        return
+    assert actual_ids == expected_ids
+
+
+# --- Concurrency ------------------------------------------------------------
+
+
+def test_concurrent_readers_never_see_torn_snapshot(state):
+    """Interleave add/remove with concurrent queries; every snapshot must be internally consistent."""
+    tasks = submit_job(state, "stress", make_job_request("stress", replicas=4))
+    task_ids = [t.task_id for t in tasks]
+
+    stop = threading.Event()
+    errors: list[str] = []
+
+    def writer():
+        try:
+            i = 0
+            while not stop.is_set():
+                t = task_ids[i % len(task_ids)]
+                eid = f"e{i % len(task_ids)}"
+                name = f"svc-{i % len(task_ids)}"
+                with state._db.transaction() as cur:
+                    state._db.endpoints.add(cur, _make_row(eid, name, t))
+                with state._db.transaction() as cur:
+                    state._db.endpoints.remove(cur, eid)
+                i += 1
+        except Exception as exc:
+            errors.append(f"writer: {exc!r}")
+
+    def reader():
+        try:
+            while not stop.is_set():
+                for row in state._db.endpoints.query():
+                    # Every row a query returns must still be reachable by id.
+                    assert state._db.endpoints.get(row.endpoint_id) is not None
+                for i in range(len(task_ids)):
+                    state._db.endpoints.query(EndpointQuery(name_prefix=f"svc-{i}"))
+                    state._db.endpoints.query(EndpointQuery(exact_name=f"svc-{i}"))
+                    state._db.endpoints.query(EndpointQuery(task_ids=(task_ids[i],)))
+        except Exception as exc:
+            errors.append(f"reader: {exc!r}")
+
+    barrier = threading.Barrier(4)
+
+    def runner(fn):
+        barrier.wait()
+        fn()
+
+    threads = [
+        threading.Thread(target=runner, args=(writer,)),
+        threading.Thread(target=runner, args=(reader,)),
+        threading.Thread(target=runner, args=(reader,)),
+        threading.Thread(target=runner, args=(reader,)),
+    ]
+    for th in threads:
+        th.start()
+
+    # Short bounded run, polling a monotonic deadline instead of time.sleep.
+    deadline = Timestamp.now().epoch_ms() + 500
+    while Timestamp.now().epoch_ms() < deadline:
+        pass
+    stop.set()
+    for th in threads:
+        th.join(timeout=5)
+    assert not errors, errors

--- a/lib/iris/tests/cluster/controller/test_endpoint_registry.py
+++ b/lib/iris/tests/cluster/controller/test_endpoint_registry.py
@@ -300,9 +300,18 @@ def test_concurrent_readers_never_see_torn_snapshot(state):
     def reader():
         try:
             while not stop.is_set():
-                for row in state._db.endpoints.query():
-                    # Every row a query returns must still be reachable by id.
-                    assert state._db.endpoints.get(row.endpoint_id) is not None
+                snapshot = state._db.endpoints.query()
+                # Verify the snapshot itself is internally consistent: every
+                # endpoint_id in the result set is unique (no duplicates from
+                # a torn index).
+                ids = [r.endpoint_id for r in snapshot]
+                assert len(ids) == len(set(ids)), f"duplicate ids in snapshot: {ids}"
+                # Exercise the secondary-index query paths concurrently with
+                # mutations. We cannot assert that a row from query() is still
+                # present in a subsequent get() — the writer may remove it
+                # between the two calls (TOCTOU).
+                for row in snapshot:
+                    state._db.endpoints.get(row.endpoint_id)
                 for i in range(len(task_ids)):
                     state._db.endpoints.query(EndpointQuery(name_prefix=f"svc-{i}"))
                     state._db.endpoints.query(EndpointQuery(exact_name=f"svc-{i}"))

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -20,11 +20,9 @@ from iris.cluster.controller.db import (
     ControllerDB,
     EndpointQuery,
     attempt_is_terminal,
-    endpoint_query_sql,
 )
 from iris.cluster.controller.schema import (
     ATTEMPT_PROJECTION,
-    ENDPOINT_PROJECTION,
     JOB_DETAIL_PROJECTION,
     TASK_DETAIL_PROJECTION,
     WORKER_DETAIL_PROJECTION,
@@ -93,11 +91,9 @@ def _queued_dispatch(
 
 
 def _endpoints(state: ControllerTransitions, query: EndpointQuery = EndpointQuery()) -> list[EndpointRow]:
-    sql, params = endpoint_query_sql(query)
-    # Add ORDER BY to match original behavior
-    sql += " ORDER BY registered_at_ms DESC, endpoint_id ASC"
-    with state._db.snapshot() as q:
-        return ENDPOINT_PROJECTION.decode(q.fetchall(sql, tuple(params)))
+    rows = state._db.endpoints.query(query)
+    # Mirror the original helper's ordering (registered_at DESC, endpoint_id ASC).
+    return sorted(rows, key=lambda r: (-r.registered_at.epoch_ms(), r.endpoint_id))
 
 
 def _build_scheduling_context(scheduler: Scheduler, state: ControllerTransitions):

--- a/lib/iris/tests/cluster/providers/gcp/test_cloud_service_integration.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_cloud_service_integration.py
@@ -19,7 +19,6 @@ from dataclasses import dataclass, field
 import httpx
 import pytest
 
-from iris.cluster.providers.gcp import service as gcp_service
 from iris.cluster.providers.gcp.service import (
     CloudGcpService,
     TpuCreateRequest,
@@ -53,8 +52,6 @@ class GcpFakeBackend:
     tpus: dict[tuple[str, str], dict] = field(default_factory=dict)  # (name, zone) -> tpu_data
     operations: dict[str, dict] = field(default_factory=dict)  # op_name -> op_data
     http_log: list[HttpLog] = field(default_factory=list)
-    # Number of remaining 429 responses to return for DELETE requests
-    delete_429_remaining: int = 0
 
     def handle(self, request: httpx.Request) -> httpx.Response:
         url = str(request.url)
@@ -159,18 +156,6 @@ class GcpFakeBackend:
 
         # DELETE .../nodes/NAME
         if method == "DELETE" and "/nodes/" in url:
-            if self.delete_429_remaining > 0:
-                self.delete_429_remaining -= 1
-                return httpx.Response(
-                    429,
-                    json={
-                        "error": {
-                            "code": 429,
-                            "message": "Quota exceeded for DeleteNode requests per minute.",
-                            "status": "RESOURCE_EXHAUSTED",
-                        }
-                    },
-                )
             parts = url.split("/nodes/")
             node_name = parts[1].split("?")[0]
             zone = self._extract_tpu_zone(url)
@@ -564,51 +549,3 @@ def test_tpu_create_lro_resource_exhausted_raises_quota_error(svc: CloudGcpServi
                 capacity_type=config_pb2.CAPACITY_TYPE_PREEMPTIBLE,
             )
         )
-
-
-def test_tpu_delete_retries_on_quota(svc: CloudGcpService, backend: GcpFakeBackend, monkeypatch: pytest.MonkeyPatch):
-    """tpu_delete retries when GCP returns 429 on the DeleteNode quota limit."""
-    monkeypatch.setattr(gcp_service, "_TPU_DELETE_RETRY_BACKOFF", 0.0)
-
-    # Create a TPU then arm the backend to return 429 on the first delete attempt
-    svc.tpu_create(
-        TpuCreateRequest(
-            name="retry-tpu",
-            zone=ZONE_EU,
-            accelerator_type="v5litepod-16",
-            runtime_version="v2-alpha-tpuv5-lite",
-            capacity_type=config_pb2.CAPACITY_TYPE_PREEMPTIBLE,
-        )
-    )
-    backend.delete_429_remaining = 1
-
-    # Delete should succeed after the retry
-    svc.tpu_delete("retry-tpu", ZONE_EU)
-
-    # Verify it made 2 DELETE requests (1 rejected + 1 succeeded)
-    delete_requests = [e for e in backend.http_log if e.method == "DELETE" and "/nodes/" in e.url]
-    assert len(delete_requests) == 2
-    assert delete_requests[0].status == 429
-    assert delete_requests[1].status == 200
-
-
-def test_tpu_delete_raises_after_exhausted_retries(
-    svc: CloudGcpService, backend: GcpFakeBackend, monkeypatch: pytest.MonkeyPatch
-):
-    """tpu_delete raises QuotaExhaustedError when all retry attempts fail."""
-    monkeypatch.setattr(gcp_service, "_TPU_DELETE_RETRY_BACKOFF", 0.0)
-
-    svc.tpu_create(
-        TpuCreateRequest(
-            name="fail-tpu",
-            zone=ZONE_EU,
-            accelerator_type="v5litepod-16",
-            runtime_version="v2-alpha-tpuv5-lite",
-            capacity_type=config_pb2.CAPACITY_TYPE_PREEMPTIBLE,
-        )
-    )
-    # More 429s than the retry budget
-    backend.delete_429_remaining = 10
-
-    with pytest.raises(QuotaExhaustedError, match="Quota exceeded"):
-        svc.tpu_delete("fail-tpu", ZONE_EU)


### PR DESCRIPTION
Profiling showed ListEndpoints dominated controller CPU because every call serialized through the read-connection pool. Add a write-through EndpointRegistry that serves reads from memory and applies DB updates via post-commit hooks. Also paginate ListJobs in the remote client and tighten transition/db hot paths.