### PR TITLE
[iris] Restore PushLogs proxy on controller; fix legacy parent_job_id filter

### DIFF
--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -265,13 +265,12 @@ class ControllerDashboard:
             interceptors.insert(0, NullAuthInterceptor(verifier=self._auth_verifier))
         rpc_wsgi_app = ControllerServiceWSGIApplication(service=self._service, interceptors=interceptors)
 
+        # PushLogs is kept on the controller as a forwarding proxy: older workers
+        # cached /system/log-server -> controller URL, so we must accept their
+        # pushes and forward them to the real log server. Forwarding happens
+        # transparently because self._log_service is a LogServiceProxy whose
+        # push_logs() calls the remote LogService over RPC.
         log_wsgi_app = LogServiceWSGIApplication(service=self._log_service, interceptors=interceptors)
-
-        # Workers push directly to the log server; remove PushLogs from the
-        # controller so there is no stale proxy path.
-        _LOG_PUSH_ENDPOINT = "/iris.logging.LogService/PushLogs"
-        log_wsgi_app._endpoints.pop(_LOG_PUSH_ENDPOINT, None)
-
         log_app = WSGIMiddleware(log_wsgi_app)
 
         # Backward-compat: old clients call ControllerService/FetchLogs (removed

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -716,8 +716,16 @@ def _query_from_list_jobs_request(
         query = controller_pb2.Controller.JobQuery()
         query.CopyFrom(request.query)
     else:
+        # Legacy parent_job_id is only honored under SCOPE_CHILDREN; without
+        # this mapping the filter is silently dropped and all jobs are
+        # returned. See https://github.com/marin-community/marin/issues/4705.
+        scope = (
+            controller_pb2.Controller.JOB_QUERY_SCOPE_CHILDREN
+            if request.parent_job_id
+            else controller_pb2.Controller.JOB_QUERY_SCOPE_ALL
+        )
         query = controller_pb2.Controller.JobQuery(
-            scope=controller_pb2.Controller.JOB_QUERY_SCOPE_ALL,
+            scope=scope,
             parent_job_id=request.parent_job_id,
             name_filter=request.name_filter,
             state_filter=request.state_filter,

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -829,6 +829,14 @@ def test_list_jobs_job_query_roots_and_children(service, state):
     )
     assert [job.job_id for job in children_response.jobs] == [child_id.to_wire()]
 
+    # Legacy flat parent_job_id field (no JobQuery sub-message) must also
+    # filter to children only — see issue #4705.
+    legacy_children_response = service.list_jobs(
+        controller_pb2.Controller.ListJobsRequest(parent_job_id=parent_id.to_wire()),
+        None,
+    )
+    assert [job.job_id for job in legacy_children_response.jobs] == [child_id.to_wire()]
+
 
 # =============================================================================
 # SQL Aggregation Tests


### PR DESCRIPTION
## Summary

- **Restore PushLogs forwarding on the controller.** After PR #4682 moved `LogServiceImpl` into a subprocess on `port+1`, the dashboard explicitly removed the `PushLogs` route from the controller. Older workers still cache `/system/log-server -> http://controller:10000` and so silently fail to push task logs (observed: `Resolved /system/log-server -> http://10.128.0.3:10000 from the workers`). Re-register the PushLogs handler — `self._log_service` is already a `LogServiceProxy` whose `push_logs` forwards to the real log server, so the controller becomes a transparent proxy for legacy workers while new workers continue to push direct.
- **Fix #4705: legacy `parent_job_id` on `ListJobsRequest` is silently ignored.** `_query_jobs` only adds the `j.parent_job_id = ?` filter under `JOB_QUERY_SCOPE_CHILDREN`, but `_query_from_list_jobs_request` hard-coded `SCOPE_ALL` on the legacy path. Map a non-empty `parent_job_id` to `SCOPE_CHILDREN` so flat-field clients filter correctly.
- (`name_filter` on the legacy path was also called out in the issue but is in fact honored unconditionally in `_query_jobs`; existing test `test_list_jobs_name_filter` exercises it.)

Fixes #4705.

## Test plan

- [x] `uv run pytest lib/iris/tests/cluster/controller/test_service.py -k list_jobs` — 7 passed, including new legacy-`parent_job_id` regression assertion.
- [ ] After deploy: confirm task logs reappear on the marin controller from older workers and that `/system/log-server` resolution continues to work for new workers pointing at port 10001.