### PR TITLE
[iris] Self-heal log store when local Parquet files vanish; add INFO logs

### DIFF
--- a/lib/iris/src/iris/cluster/log_store/duckdb_store.py
+++ b/lib/iris/src/iris/cluster/log_store/duckdb_store.py
@@ -614,6 +614,13 @@ class DuckDBLogStore:
             self._pending = []
             self._sealed.append(sealed)
             self._last_flush_time = time.monotonic()
+        logger.info(
+            "Sealed head buffer: rows=%d seq=[%d,%d] est_bytes=%d",
+            sealed.table.num_rows,
+            sealed.min_seq,
+            sealed.max_seq,
+            sealed.table.num_rows * _EST_BYTES_PER_ROW,
+        )
         self._executor.submit(self._flush_sealed_buffer, sealed)
 
     def _flush_sealed_buffer(self, sealed: _SealedBuffer) -> None:
@@ -642,6 +649,7 @@ class DuckDBLogStore:
         if can_consolidate:
             assert latest is not None
             try:
+                consolidate_start = time.monotonic()
                 existing_table = pq.read_table(latest.path)
                 combined = pa.concat_tables([existing_table, new_table])
                 combined = combined.sort_by([("key", "ascending"), ("seq", "ascending")])
@@ -688,6 +696,17 @@ class DuckDBLogStore:
                 finally:
                     self._segments_rwlock.write_release()
 
+                logger.info(
+                    "Wrote consolidated segment %s: rows=%d (added=%d) bytes=%d seq=[%d,%d] elapsed_ms=%d",
+                    filename,
+                    combined.num_rows,
+                    new_table.num_rows,
+                    seg.size_bytes,
+                    combined_min_seq,
+                    combined_max_seq,
+                    int((time.monotonic() - consolidate_start) * 1000),
+                )
+
                 # GCS upload overwrites the same object (same filename).
                 self._offload_to_gcs(filename, filepath)
                 self._gc_local_segments()
@@ -701,6 +720,7 @@ class DuckDBLogStore:
         filename = f"logs_{new_min_seq:019d}.parquet"
         filepath = self._log_dir / filename
 
+        write_start = time.monotonic()
         try:
             tmp_path = filepath.with_suffix(".parquet.tmp")
             pq.write_table(
@@ -730,6 +750,16 @@ class DuckDBLogStore:
                 pass
             sealed.flushed = True
 
+        logger.info(
+            "Wrote segment %s: rows=%d bytes=%d seq=[%d,%d] elapsed_ms=%d",
+            filename,
+            new_table.num_rows,
+            seg.size_bytes,
+            new_min_seq,
+            new_max_seq,
+            int((time.monotonic() - write_start) * 1000),
+        )
+
         self._offload_to_gcs(filename, filepath)
         self._gc_local_segments()
 
@@ -742,14 +772,18 @@ class DuckDBLogStore:
         """
         with self._lock:
             total_bytes = sum(s.size_bytes for s in self._local_segments)
-            to_delete: list[str] = []
+            to_delete: list[tuple[str, int]] = []
+            remaining_count = len(self._local_segments)
+            remaining_bytes = total_bytes
 
             while self._local_segments and (
                 len(self._local_segments) > self._max_local_segments or total_bytes > self._max_local_bytes
             ):
                 oldest = self._local_segments.popleft()
                 total_bytes -= oldest.size_bytes
-                to_delete.append(oldest.path)
+                to_delete.append((oldest.path, oldest.size_bytes))
+                remaining_count -= 1
+                remaining_bytes -= oldest.size_bytes
 
         if not to_delete:
             return
@@ -758,7 +792,7 @@ class DuckDBLogStore:
         # (which hold the read lock) finish before we unlink anything.
         self._segments_rwlock.write_acquire()
         try:
-            for path in to_delete:
+            for path, _ in to_delete:
                 try:
                     Path(path).unlink(missing_ok=True)
                 except Exception:
@@ -766,15 +800,62 @@ class DuckDBLogStore:
         finally:
             self._segments_rwlock.write_release()
 
+        logger.info(
+            "GC'd %d local segment(s), freed=%d bytes, remaining=%d segments / %d bytes",
+            len(to_delete),
+            sum(b for _, b in to_delete),
+            remaining_count,
+            remaining_bytes,
+        )
+
+    def _drop_missing_local_segments(self, paths: list[str]) -> list[str]:
+        """Filter ``paths`` to those that still exist on disk.
+
+        If any are missing they're also pruned from ``_local_segments`` so
+        future reads don't repeatedly hit the same DuckDB error. Vanishing
+        files normally come from out-of-band deletion (manual ``rm``, disk
+        pressure outside our GC, leftover entries from an old filename
+        format) — anything our own GC removes is gone from the in-memory
+        list before the file is unlinked.
+        """
+        existing: list[str] = []
+        missing: list[str] = []
+        for p in paths:
+            if Path(p).exists():
+                existing.append(p)
+            else:
+                missing.append(p)
+        if not missing:
+            return existing
+
+        missing_set = set(missing)
+        with self._lock:
+            self._local_segments = deque(s for s in self._local_segments if s.path not in missing_set)
+        logger.warning(
+            "Pruned %d missing local segment(s) from in-memory index (e.g. %s)",
+            len(missing),
+            missing[:3],
+        )
+        return existing
+
     def _offload_to_gcs(self, filename: str, filepath: Path) -> None:
         """Copy a Parquet file to GCS (best-effort)."""
         if not self._remote_log_dir:
             return
         remote_path = f"{self._remote_log_dir.rstrip('/')}/{filename}"
+        upload_start = time.monotonic()
         try:
             _fsspec_copy(str(filepath), remote_path)
         except Exception:
             logger.warning("Failed to offload %s to GCS", filepath, exc_info=True)
+            return
+        logger.info(
+            "Offloaded %s to %s: bytes=%d elapsed_ms=%d",
+            filename,
+            remote_path,
+            filepath.stat().st_size,
+            int((time.monotonic() - upload_start) * 1000),
+        )
 
     # ------------------------------------------------------------------
     # Internal: read
@@ -805,6 +886,7 @@ class DuckDBLogStore:
                 current_max_seq = self._next_seq - 1
 
             parquet_files = [s.path for s in segment_filter.apply(segments)]
+            parquet_files = self._drop_missing_local_segments(parquet_files)
 
             where_clause = " AND ".join(where_parts)
 

--- a/lib/iris/src/iris/log_server/main.py
+++ b/lib/iris/src/iris/log_server/main.py
@@ -30,7 +30,7 @@ from iris.log_server.server import LogServiceImpl
 from iris.rpc.auth import AuthInterceptor, NullAuthInterceptor
 from iris.rpc.logging_connect import LogServiceWSGIApplication
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("iris.log_server")
 
 
 # Env var used by the subprocess entrypoint to receive the controller's JWT

--- a/lib/iris/tests/cluster/controller/test_logs.py
+++ b/lib/iris/tests/cluster/controller/test_logs.py
@@ -400,6 +400,48 @@ def test_gc_drops_oldest_segments_by_bytes(tmp_path: Path):
         store.close()
 
 
+def test_reads_recover_when_local_segment_vanishes(tmp_path: Path):
+    """Out-of-band deletion of a Parquet file must not permanently break reads.
+
+    The store's in-memory ``_local_segments`` is populated at startup by
+    globbing the log dir, but it can drift from disk if files are removed
+    by anything other than ``_gc_local_segments`` (manual ``rm``, eviction,
+    leftover entries from an old filename format). Without self-healing,
+    DuckDB raises ``No files found that match the pattern …`` on every
+    subsequent read until the process restarts.
+    """
+    log_dir = tmp_path / "logs"
+    store = DuckDBLogStore(
+        log_dir=log_dir,
+        max_local_segments=100,  # don't GC during the test
+        segment_target_bytes=1,  # seal on every append
+    )
+    try:
+        for batch in range(3):
+            store.append(KEY, [_make_entry(f"batch{batch}-{i}", epoch_ms=batch * 100 + i) for i in range(10)])
+        store._executor.shutdown(wait=True)
+        store._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="log_flush")
+
+        parquet_files = sorted(log_dir.glob("logs_*.parquet"))
+        assert len(parquet_files) == 3
+        # Simulate out-of-band deletion of the oldest segment.
+        parquet_files[0].unlink()
+
+        # Read still succeeds and returns the rows from the surviving segments.
+        result = store.get_logs(KEY)
+        data = [e.data for e in result.entries]
+        assert any("batch1" in d for d in data)
+        assert any("batch2" in d for d in data)
+        assert not any("batch0" in d for d in data)
+
+        # In-memory index was pruned, so a follow-up read does not re-trigger the failure.
+        assert len(store._local_segments) == 2
+        result2 = store.get_logs(KEY)
+        assert [e.data for e in result2.entries] == data
+    finally:
+        store.close()
+
+
 # =============================================================================
 # Parquet-specific tests
 # =============================================================================


### PR DESCRIPTION
DuckDBLogStore tracked local segments in memory but never reconciled with disk after startup. If a Parquet file was removed out-of-band (manual rm, disk eviction, leftover entries from an older filename format), every read of that segment range failed permanently with "No files found that match the pattern …". Reads now filter to existing files and prune the in-memory index so subsequent reads succeed. Also adds INFO logs around seal/flush/offload/GC and renames the log_server logger from __main__ to iris.log_server so subprocess output is greppable in controller stderr.