### PR TITLE
[iris] Enforce heartbeat timeout for dead worker detection

### DIFF
--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -94,7 +94,6 @@ from iris.cluster.controller.auth import ControllerAuth
 from iris.cluster.controller.service import ControllerServiceImpl
 from iris.cluster.controller.transitions import (
     HEARTBEAT_FAILURE_THRESHOLD,
-    HEARTBEAT_STALENESS_THRESHOLD,
     RESERVATION_HOLDER_JOB_NAME,
     Assignment,
     ClusterCapacity,
@@ -2119,28 +2118,37 @@ class Controller:
         last_heartbeat_ms but consecutive_failures=0 and healthy=1.  If the
         backing VMs were preempted during the outage, we'd otherwise wait for
         10 RPC timeouts per worker before marking them dead.  This check
-        short-circuits that by failing any worker that hasn't heartbeated in
-        HEARTBEAT_STALENESS_THRESHOLD (15 minutes).
+        short-circuits that by failing any worker that hasn't heartbeated
+        within the computed staleness window.
+
+        The threshold is derived from heartbeat_interval * heartbeat_failure_threshold * 2
+        (default: 5s * 10 * 2 = 100s), which gives a reasonable safety margin over the
+        expected failure detection time while catching dead workers far sooner than the
+        previous hardcoded 15-minute constant.
         """
         if isinstance(self._provider, K8sTaskProvider):
             return
         if self._config.dry_run:
             return
-        threshold_ms = HEARTBEAT_STALENESS_THRESHOLD.to_ms()
+        staleness_threshold = Duration.from_seconds(
+            self._config.heartbeat_interval.to_seconds() * self._config.heartbeat_failure_threshold * 2,
+        )
+        threshold_ms = staleness_threshold.to_ms()
         workers = healthy_active_workers_with_attributes(self._db)
         stale = [w for w in workers if w.last_heartbeat.age_ms() > threshold_ms]
         if not stale:
             return
 
+        threshold_seconds = int(staleness_threshold.to_seconds())
         logger.warning(
             "Failing %d workers with stale heartbeats (threshold=%ds): %s",
             len(stale),
-            HEARTBEAT_STALENESS_THRESHOLD.to_seconds(),
+            threshold_seconds,
             [str(w.worker_id) for w in stale[:10]],
         )
         failure_result = self._transitions.fail_workers_batch(
             [str(w.worker_id) for w in stale],
-            reason=f"heartbeat stale (>{int(HEARTBEAT_STALENESS_THRESHOLD.to_seconds())}s since last heartbeat)",
+            reason=f"heartbeat stale (>{threshold_seconds}s since last heartbeat)",
         )
         for wid, addr in failure_result.removed_workers:
             self._provider.on_worker_failed(wid, addr)

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -89,13 +89,6 @@ accidental collision with normal job names."""
 HEARTBEAT_FAILURE_THRESHOLD = 10
 """Consecutive heartbeat failures before marking worker as failed."""
 
-HEARTBEAT_STALENESS_THRESHOLD = Duration.from_seconds(900)
-"""If a worker's last successful heartbeat is older than this, it is failed
-immediately. Catches workers restored from a checkpoint whose backing VMs
-no longer exist — without this, the controller would need 10 consecutive
-RPC failures (50s) per worker to notice, during which they appear healthy
-in the dashboard and block scheduling capacity."""
-
 WORKER_TASK_HISTORY_RETENTION = 500
 """Maximum worker_task_history rows retained per worker."""
 

--- a/lib/iris/tests/cluster/controller/test_heartbeat.py
+++ b/lib/iris/tests/cluster/controller/test_heartbeat.py
@@ -16,7 +16,6 @@ from tests.cluster.controller.conftest import FakeProvider
 from iris.cluster.controller.transitions import (
     Assignment,
     ControllerTransitions,
-    HEARTBEAT_STALENESS_THRESHOLD,
     HeartbeatAction,
     HeartbeatApplyRequest,
     DispatchBatch,
@@ -236,8 +235,12 @@ def test_reap_stale_workers_removes_old_heartbeat(tmp_path, worker_metadata):
     controller = Controller(config=config, provider=FakeProvider(), db=db)
     state = controller.state
 
-    # Register a worker with a timestamp well beyond the staleness threshold.
-    stale_ts = Timestamp.from_ms(Timestamp.now().epoch_ms() - HEARTBEAT_STALENESS_THRESHOLD.to_ms() - 60_000)
+    # Register a worker with a timestamp well beyond the config-derived staleness
+    # threshold (heartbeat_interval * heartbeat_failure_threshold * 2).
+    staleness_ms = int(
+        config.heartbeat_interval.to_seconds() * config.heartbeat_failure_threshold * 2 * 1000,
+    )
+    stale_ts = Timestamp.from_ms(Timestamp.now().epoch_ms() - staleness_ms - 60_000)
     state.register_or_refresh_worker(
         worker_id=WorkerId("stale-worker"),
         address="10.0.0.1:10001",


### PR DESCRIPTION
🤖 Replace the hardcoded 900-second (15-minute) HEARTBEAT_STALENESS_THRESHOLD with a value derived from the controller config: heartbeat_interval * heartbeat_failure_threshold * 2 (default: 5s * 10 * 2 = 100s). This catches preempted workers whose tasks were stuck in "running" state for 6+ hours because the 15-minute constant was far too lenient for the actual heartbeat cadence.

The constant is removed from transitions.py since it is now computed inline in the controller. The test is updated to derive the stale timestamp from the config the same way.

Fixes #4712