### PR TITLE
[iris] Propagate derived region/zone to worker configs

### DIFF
--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -23,7 +23,7 @@ import logging
 from collections import deque
 from collections.abc import Sequence
 
-from iris.cluster.constraints import Constraint
+from iris.cluster.constraints import Constraint, WellKnownAttribute
 from iris.cluster.providers.protocols import WorkerInfraProvider
 from iris.cluster.providers.types import (
     CloudSliceState,
@@ -378,6 +378,14 @@ class Autoscaler:
         if group.config.HasField("worker"):
             for k, v in group.config.worker.attributes.items():
                 wc.worker_attributes[k] = v
+
+        region = group.region
+        if region and not wc.worker_attributes.get(WellKnownAttribute.REGION):
+            wc.worker_attributes[WellKnownAttribute.REGION] = region
+
+        zone = group.zone
+        if zone and not wc.worker_attributes.get(WellKnownAttribute.ZONE):
+            wc.worker_attributes[WellKnownAttribute.ZONE] = zone
 
         if group.config.name:
             wc.worker_attributes["scale-group"] = group.config.name

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -29,7 +29,7 @@ from tests.cluster.providers.conftest import (
     make_mock_slice_handle,
     make_mock_worker_handle,
 )
-from iris.cluster.constraints import DeviceType
+from iris.cluster.constraints import DeviceType, WellKnownAttribute
 from iris.cluster.types import WorkerStatus
 from iris.rpc import config_pb2, vm_pb2
 from iris.time_proto import duration_to_proto
@@ -1186,6 +1186,24 @@ class TestPerGroupWorkerConfig:
 
         assert wc is not None
         assert wc.worker_attributes["team"] == "euw4"
+
+    def test_derives_region_and_zone_from_scale_group_when_missing(self):
+        """Derived region and zone are injected when worker attrs omit them."""
+        base_wc = config_pb2.WorkerConfig(
+            docker_image="ghcr.io/marin-community/iris-worker:latest",
+            port=10001,
+            controller_address="controller:10000",
+        )
+        sg_config = make_scale_group_config(name="east-group", max_slices=5, zones=["us-east5-a"])
+
+        group = ScalingGroup(sg_config, make_mock_platform())
+        autoscaler = make_autoscaler({"east-group": group}, base_worker_config=base_wc)
+
+        wc = autoscaler._per_group_worker_config(group)
+
+        assert wc is not None
+        assert wc.worker_attributes[WellKnownAttribute.REGION] == "us-east5"
+        assert wc.worker_attributes[WellKnownAttribute.ZONE] == "us-east5-a"
 
 
 class TestGpuScaleGroupBugs:


### PR DESCRIPTION
🤖 _PR description written by Claude Code._

## Summary

Finishes the region/zone refactor started in #4681. That PR collapsed region/zone to a single source of truth (`slice_template.gcp.zone`) on the control side, but left `Autoscaler._per_group_worker_config` reading the now-empty `group.config.worker.attributes` dict. New workers stopped publishing a `region` attribute at registration, which silently locked every job with a hard `region` constraint out of fresh capacity.

## Background

#4679 reported jobs sitting forever in PENDING when no scaling group matched their routing constraints. #4681 fixed that at submit time (`check_routing_feasibility` / `job_feasibility`) and, as a secondary cleanup, removed the explicit `worker.attributes.region`/`zone` entries from `_expand_tpu_pools` and `_expand_multi_zone_groups`, moving `ScalingGroup.region`/`.zone` to derive purely from `slice_template.gcp.zone`. The validator in `config.py` now even rejects YAML that sets these attributes explicitly.

That refactor was correct on the control side: submit-time routing, feasibility checks, and autoscaler demand planning all derive from the slice template. The part that got missed is the *data* side: `runtime.py:_per_group_worker_config` still builds each new worker's `WorkerConfig.worker_attributes` by copying from `group.config.worker.attributes`, which is now empty for region/zone. The worker boots, `build_worker_metadata` merges its (empty) `extra_attributes`, and `register_or_refresh_worker` writes zero `region` rows into the `worker_attributes` table.

## Symptom on marin cluster

Eczech's `bolinas_scaling_sweep` child `train_lm` tasks sat pending with:

```
Scheduler: Insufficient TPUs (need 4, available 0) - 2 worker(s)
(with constraints=['device-type', 'device-variant', 'region', 'reservation-job'])
Autoscaler: tier_blocked: 1 matching group(s) blocked by quota-pool tier monotonicity
```

There were 74 BATCH v5p-8 tasks (michaelryan's extracts) on us-east5-a workers sitting at lower priority — all marked `preemptible_by INTERACTIVE` — but preemption never fired. `_run_preemption_pass` only considers victim tasks whose worker passes the preemptor's constraint filter (`controller.py:546`), and none of the BATCH workers carried a `region` attribute, so they never entered the candidate set.

Cluster-wide join of `workers.md_git_hash` × `worker_attributes` at the time:

| md_git_hash | total | with `region` |
|---|---:|---:|
| `91aade6de` (pre-#4681 build) | 375 | 375 |
| `b2ece3448` (post-#4681 build) | 381 | 0 |
| `4657a5aa2` | 40 | 0 |
| `d042e4872` | 9 | 0 |

Last worker with `region=us-east5`: `marin-tpu-v5p-preemptible-8-us-east5-a-20260413-2127-0fa6c413-worker-0` (~21:27 UTC 2026-04-13). First without: `…20260414-0032-9ff96f3d-worker-0`. That gap lines up with the controller redeploy a few hours after #4681 merged.

~38 pending tasks across 7 users (eczech, larry, calvinxu, moojink, konwoo, ahmed, rohith) all carried a hard `region` constraint and were affected. Jobs using soft region constraints (`mode=CONSTRAINT_MODE_PREFERRED`, e.g. michaelryan's extract launchers) were unaffected — soft constraints only influence ranking, not the candidate filter.