### PR TITLE
[storage] Fix duplicate rows in scan output and harden report generator

### DIFF
--- a/scripts/storage/distributed_scan.py
+++ b/scripts/storage/distributed_scan.py
@@ -128,6 +128,25 @@ def _write_parquet_to_gcs(table: pa.Table, staging_dir: str) -> str:
     return path
 
 
+def _truncate_staging_dir(staging_dir: str) -> None:
+    """Delete all `objects_*.parquet` segments under staging_dir before a run.
+
+    Segments are written under fresh UUIDs so reruns cannot overwrite prior
+    files — without this, every re-run strictly appends and the consumer
+    sees N-way duplicated (bucket, name) rows.
+    """
+    import fsspec
+
+    fs, _ = fsspec.core.url_to_fs(staging_dir)
+    pattern = f"{staging_dir.rstrip('/')}/objects_*.parquet"
+    existing = fs.glob(pattern)
+    if not existing:
+        return
+    print(f"Truncating {len(existing)} stale segments under {staging_dir}")
+    for path in existing:
+        fs.rm(path)
+
+
 # ---------------------------------------------------------------------------
 # Coordinator actor
 # ---------------------------------------------------------------------------
@@ -556,6 +575,8 @@ def run_distributed(
 
     ctx = iris_ctx()
     client = ctx.client
+
+    _truncate_staging_dir(staging_dir)
 
     # Start coordinator actor
     coordinator = ScanCoordinatorActor(staging_dir)

--- a/scripts/storage/report.py
+++ b/scripts/storage/report.py
@@ -4,8 +4,16 @@
 
 """Storage usage report generator.
 
-Loads object-listing parquet files into an in-memory DuckDB, runs analysis
-queries, and produces a markdown report with size, cost, and trend breakdowns.
+Builds a bounded directory-level rollup (`dir_summary`) from raw parquet
+object listings in a single streaming pass, then computes every report
+section from the rollup. Produces a markdown report with size, cost, and
+trend breakdowns.
+
+The rollup groups objects by `(bucket, storage_class_id, dir_prefix)` for
+the dir summary and `(bucket, storage_class_id, created_month, age_bucket)`
+for the time summary. `dir_prefix` is the first DIR_DEPTH path components.
+This keeps the working set in the low millions of rows regardless of how
+many billions of objects the scan produced.
 
 Usage (standalone):
     uv run scripts/storage/report.py [PARQUET_DIR]
@@ -15,18 +23,19 @@ The default parquet directory is scripts/storage/purge/objects_parquet/.
 
 from __future__ import annotations
 
+import hashlib
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
 import click
 import duckdb
-
 from scripts.storage.constants import (
     BUCKET_LOCATIONS,
     DISCOUNT_FACTOR,
     STORAGE_CLASS_PRICING,
 )
+from tqdm import tqdm
 
 
 def _download_gcs_parquet(gcs_dir: str, local_dir: Path) -> Path:
@@ -39,9 +48,15 @@ def _download_gcs_parquet(gcs_dir: str, local_dir: Path) -> Path:
     local_dir.mkdir(parents=True, exist_ok=True)
     src = gcs_dir.rstrip("/") + "/*.parquet"
     print(f"Downloading {src} -> {local_dir} ...")
-    # rsync-style: only copies new files
     result = subprocess.run(
-        ["gcloud", "storage", "rsync", "--recursive", gcs_dir.rstrip("/"), str(local_dir)],
+        [
+            "gcloud",
+            "storage",
+            "rsync",
+            "--recursive",
+            gcs_dir.rstrip("/"),
+            str(local_dir),
+        ],
         capture_output=True,
         text=True,
         check=False,
@@ -71,8 +86,152 @@ def _init_storage_classes(conn: duckdb.DuckDBPyConnection) -> None:
         )
 
 
+# Depth at which we roll up directory paths. First DIR_DEPTH components
+# of each object name form the `dir_prefix` key; deeper structure is discarded.
+DIR_DEPTH = 3
+
+
+def _dir_agg_sql(source: str) -> str:
+    return f"""
+    SELECT
+        bucket,
+        storage_class_id,
+        array_to_string(list_slice(string_split(name, '/'), 1, {DIR_DEPTH}), '/') AS dir_prefix,
+        COUNT(*) AS object_count,
+        SUM(size_bytes) AS total_bytes
+    FROM {source}
+    GROUP BY 1, 2, 3
+    """
+
+
+def _time_agg_sql(source: str) -> str:
+    return f"""
+    SELECT
+        bucket,
+        storage_class_id,
+        date_trunc('month', created) AS created_month,
+        CASE
+            WHEN created >= CURRENT_TIMESTAMP - INTERVAL  '7 days'  THEN '<7d'
+            WHEN created >= CURRENT_TIMESTAMP - INTERVAL '30 days'  THEN '7-30d'
+            WHEN created >= CURRENT_TIMESTAMP - INTERVAL '90 days'  THEN '30-90d'
+            WHEN created >= CURRENT_TIMESTAMP - INTERVAL '365 days' THEN '90-365d'
+            WHEN created IS NULL                                    THEN NULL
+            ELSE '>365d'
+        END AS age_bucket,
+        COUNT(*) AS object_count,
+        SUM(size_bytes) AS total_bytes
+    FROM {source}
+    GROUP BY 1, 2, 3, 4
+    """
+
+
+def _batch_key(batch: list[str], depth: int) -> str:
+    """Stable content-addressed key for a batch — invariant to run ordering.
+
+    Changing DIR_DEPTH or the files in a batch invalidates the cache."""
+    h = hashlib.sha1()
+    for p in sorted(batch):
+        h.update(p.encode())
+        h.update(b"\0")
+    h.update(f"d{depth}".encode())
+    return h.hexdigest()[:16]
+
+
+def _build_summaries(
+    conn: duckdb.DuckDBPyConnection,
+    parquet_files: list[str],
+    summary_cache: Path,
+) -> None:
+    """Map step: per-batch aggregates written to cached parquets.
+
+    Per-batch parquets are written to `summary_cache` with content-addressed
+    names, so reruns skip already-computed batches. `dir_summary` and
+    `time_summary` are then registered as views over the leaf parquets —
+    the full-cardinality reduce is skipped because every report query
+    except `top_dir3` has tiny group cardinality, and `top_dir3` prunes
+    via hierarchical top-K.
+    """
+    batch_size = 32
+    batches = [parquet_files[i : i + batch_size] for i in range(0, len(parquet_files), batch_size)]
+
+    leaf_root = summary_cache / f"d{DIR_DEPTH}"
+    dir_leaves = leaf_root / "dir"
+    time_leaves = leaf_root / "time"
+    for d in (dir_leaves, time_leaves):
+        d.mkdir(parents=True, exist_ok=True)
+
+    total_objects = 0
+    total_bytes = 0
+    pbar = tqdm(batches, desc="map (per-batch agg)", unit="batch", dynamic_ncols=True)
+    cache_hits = 0
+    for batch in pbar:
+        key = _batch_key(batch, DIR_DEPTH)
+        dir_out = dir_leaves / f"{key}.parquet"
+        time_out = time_leaves / f"{key}.parquet"
+
+        if dir_out.exists() and time_out.exists():
+            cache_hits += 1
+        else:
+            path_list = ", ".join(f"'{p}'" for p in batch)
+            source = f"read_parquet([{path_list}], union_by_name=true)"
+            conn.execute(f"CREATE TEMP VIEW _batch AS SELECT * FROM {source}")
+            # Write to a .tmp then rename so partial files don't poison the cache.
+            dir_tmp = dir_out.with_suffix(".parquet.tmp")
+            time_tmp = time_out.with_suffix(".parquet.tmp")
+            conn.execute(f"COPY ({_dir_agg_sql('_batch')}) TO '{dir_tmp}' (FORMAT parquet)")
+            conn.execute(f"COPY ({_time_agg_sql('_batch')}) TO '{time_tmp}' (FORMAT parquet)")
+            conn.execute("DROP VIEW _batch")
+            dir_tmp.rename(dir_out)
+            time_tmp.rename(time_out)
+
+        oc, tb = conn.execute(f"SELECT SUM(object_count), SUM(total_bytes) FROM read_parquet('{dir_out}')").fetchone()
+        total_objects += oc or 0
+        total_bytes += tb or 0
+        pbar.set_postfix(
+            cached=cache_hits,
+            objects=f"{total_objects/1e6:.1f}M",
+            size=f"{total_bytes/1e12:.2f}TB",
+            refresh=False,
+        )
+
+    print(f"map done: {cache_hits}/{len(batches)} batches from cache", file=sys.stderr)
+
+    # Skip the reduce step: report queries with small group cardinality
+    # (by_bucket, by_class, top_dir1, top_dir2, age, monthly) run happily
+    # against the per-batch leaf parquets directly. The only query that
+    # would need a full (bucket, dir_prefix) reduce is top_dir3, which is
+    # handled via hierarchical top-K in `_query_top_dir_prefix`.
+    dir_files = sorted(dir_leaves.glob("*.parquet"))
+    time_files = sorted(time_leaves.glob("*.parquet"))
+    dir_list = ", ".join(f"'{p}'" for p in dir_files)
+    time_list = ", ".join(f"'{p}'" for p in time_files)
+    conn.execute(f"CREATE VIEW dir_summary AS SELECT * FROM read_parquet([{dir_list}])")
+    conn.execute(f"CREATE VIEW time_summary AS SELECT * FROM read_parquet([{time_list}])")
+    print(
+        f"views registered: dir_summary over {len(dir_files)} leaves, " f"time_summary over {len(time_files)} leaves",
+        file=sys.stderr,
+    )
+
+
+def _tune_duckdb(conn: duckdb.DuckDBPyConnection, scratch: Path) -> None:
+    """Cap working set and give DuckDB a big temp dir on the main disk.
+
+    /tmp on macOS is tiny; DuckDB otherwise auto-caps its spill based on
+    /tmp's free space and bails at ~2GiB mid-reduce. Pointing it at the
+    same scratch we use for summary cache avoids that.
+    """
+    scratch.mkdir(parents=True, exist_ok=True)
+    spill = scratch / "duckdb_tmp"
+    spill.mkdir(parents=True, exist_ok=True)
+    conn.execute("SET threads=2")
+    conn.execute("SET memory_limit='8GB'")
+    conn.execute("SET preserve_insertion_order=false")
+    conn.execute(f"SET temp_directory='{spill}'")
+    conn.execute("SET max_temp_directory_size='100GiB'")
+
+
 def load_parquet_db(parquet_dir: Path | str, local_cache: Path | None = None) -> duckdb.DuckDBPyConnection:
-    """Create an in-memory DuckDB with objects view over a parquet directory.
+    """Build an in-memory DuckDB with a pre-aggregated `dir_summary` table.
 
     For gs:// paths, downloads files to local_cache (or a temp dir) first so
     DuckDB reads from local disk — avoids the GCS auth maze.
@@ -80,7 +239,6 @@ def load_parquet_db(parquet_dir: Path | str, local_cache: Path | None = None) ->
     dir_str = str(parquet_dir)
     if dir_str.startswith("gs://"):
         if local_cache is None:
-            # Default cache: /tmp/storage-scan-cache/<bucket-path>
             cache_root = Path("/tmp/storage-scan-cache")
             subpath = dir_str.removeprefix("gs://").replace("/", "_")
             local_cache = cache_root / subpath
@@ -89,30 +247,26 @@ def load_parquet_db(parquet_dir: Path | str, local_cache: Path | None = None) ->
         local_dir = Path(dir_str)
 
     conn = duckdb.connect(":memory:")
-    conn.execute("SET threads=8")
-    glob_pattern = str(local_dir / "*.parquet")
-    conn.execute(
-        f"""
-        CREATE VIEW objects AS
-        SELECT * FROM read_parquet('{glob_pattern}', union_by_name=true)
-    """
-    )
+    files = sorted(str(p) for p in local_dir.glob("*.parquet"))
+    if not files:
+        raise RuntimeError(f"no parquet files found under {local_dir}")
+    summary_cache = local_dir.parent / (local_dir.name + "_summaries")
+    _tune_duckdb(conn, summary_cache)
+    _build_summaries(conn, files, summary_cache)
     _init_storage_classes(conn)
     return conn
 
 
-def load_parquet_db_from_paths(paths: list[str]) -> duckdb.DuckDBPyConnection:
-    """Create an in-memory DuckDB with objects view over explicit parquet paths (local or GCS)."""
+def load_parquet_db_from_paths(paths: list[str], summary_cache: Path | None = None) -> duckdb.DuckDBPyConnection:
+    """Build an in-memory DuckDB from explicit parquet paths (local or GCS)."""
     conn = duckdb.connect(":memory:")
-    conn.execute("SET threads=8")
-
-    path_list = ", ".join(f"'{p}'" for p in paths)
-    conn.execute(
-        f"""
-        CREATE VIEW objects AS
-        SELECT * FROM read_parquet([{path_list}], union_by_name=true)
-    """
-    )
+    if summary_cache is None:
+        h = hashlib.sha1()
+        for p in sorted(paths):
+            h.update(p.encode() + b"\0")
+        summary_cache = Path("/tmp/storage-scan-cache/_from_paths_summaries") / h.hexdigest()[:16]
+    _tune_duckdb(conn, summary_cache)
+    _build_summaries(conn, list(paths), summary_cache)
     _init_storage_classes(conn)
     return conn
 
@@ -121,17 +275,19 @@ def load_parquet_db_from_paths(paths: list[str]) -> duckdb.DuckDBPyConnection:
 # Cost SQL fragment (reused across queries)
 # ---------------------------------------------------------------------------
 
-# Per-row cost expression (use inside SUM(...) or as a column)
+# Per-summary-row cost expression (use inside SUM(...) or as a column).
+# Works on any summary table aliased `s` joined to `storage_classes sc`,
+# as long as `s` exposes `bucket` and `total_bytes`.
 _ROW_COST = f"""
-    o.size_bytes / (1024.0 * 1024.0 * 1024.0)
-        * CASE WHEN o.bucket LIKE '%eu%' THEN sc.price_per_gib_month_eu
+    s.total_bytes / (1024.0 * 1024.0 * 1024.0)
+        * CASE WHEN s.bucket LIKE '%eu%' THEN sc.price_per_gib_month_eu
                ELSE sc.price_per_gib_month_us END
         * {DISCOUNT_FACTOR}
 """
 
 
 # ---------------------------------------------------------------------------
-# Query functions
+# Query functions (all read from dir_summary)
 # ---------------------------------------------------------------------------
 
 
@@ -139,12 +295,12 @@ def _query_overview(conn: duckdb.DuckDBPyConnection) -> dict:
     row = conn.execute(
         f"""
         SELECT
-            COUNT(*) as total_objects,
-            SUM(o.size_bytes) as total_bytes,
-            SUM({_ROW_COST}) as monthly_cost
-        FROM objects o
-        JOIN storage_classes sc ON o.storage_class_id = sc.id
-    """
+            SUM(s.object_count),
+            SUM(s.total_bytes),
+            SUM({_ROW_COST})
+        FROM dir_summary s
+        JOIN storage_classes sc ON s.storage_class_id = sc.id
+        """
     ).fetchone()
     return {"total_objects": row[0], "total_bytes": row[1], "monthly_cost": row[2]}
 
@@ -153,15 +309,15 @@ def _query_by_bucket(conn: duckdb.DuckDBPyConnection) -> list[dict]:
     rows = conn.execute(
         f"""
         SELECT
-            o.bucket,
-            COUNT(*) as object_count,
-            SUM(o.size_bytes) as total_bytes,
-            SUM({_ROW_COST}) as monthly_cost
-        FROM objects o
-        JOIN storage_classes sc ON o.storage_class_id = sc.id
-        GROUP BY o.bucket
+            s.bucket,
+            SUM(s.object_count) AS object_count,
+            SUM(s.total_bytes) AS total_bytes,
+            SUM({_ROW_COST}) AS monthly_cost
+        FROM dir_summary s
+        JOIN storage_classes sc ON s.storage_class_id = sc.id
+        GROUP BY s.bucket
         ORDER BY monthly_cost DESC
-    """
+        """
     ).fetchall()
     return [
         {
@@ -180,14 +336,14 @@ def _query_by_storage_class(conn: duckdb.DuckDBPyConnection) -> list[dict]:
         f"""
         SELECT
             sc.name,
-            COUNT(*) as object_count,
-            SUM(o.size_bytes) as total_bytes,
-            SUM({_ROW_COST}) as monthly_cost
-        FROM objects o
-        JOIN storage_classes sc ON o.storage_class_id = sc.id
+            SUM(s.object_count) AS object_count,
+            SUM(s.total_bytes) AS total_bytes,
+            SUM({_ROW_COST}) AS monthly_cost
+        FROM dir_summary s
+        JOIN storage_classes sc ON s.storage_class_id = sc.id
         GROUP BY sc.name
         ORDER BY monthly_cost DESC
-    """
+        """
     ).fetchall()
     grand_total = sum(r[2] for r in rows) or 1
     return [
@@ -206,21 +362,27 @@ def _query_top_dir1(conn: duckdb.DuckDBPyConnection, limit: int = 30) -> list[di
     rows = conn.execute(
         f"""
         SELECT
-            o.bucket,
-            split_part(o.name, '/', 1) as dir1,
-            COUNT(*) as object_count,
-            SUM(o.size_bytes) as total_bytes,
-            SUM({_ROW_COST}) as monthly_cost
-        FROM objects o
-        JOIN storage_classes sc ON o.storage_class_id = sc.id
-        WHERE o.name LIKE '%/%'
-        GROUP BY o.bucket, dir1
+            s.bucket,
+            split_part(s.dir_prefix, '/', 1) AS dir1,
+            SUM(s.object_count) AS object_count,
+            SUM(s.total_bytes) AS total_bytes,
+            SUM({_ROW_COST}) AS monthly_cost
+        FROM dir_summary s
+        JOIN storage_classes sc ON s.storage_class_id = sc.id
+        WHERE s.dir_prefix LIKE '%/%'
+        GROUP BY s.bucket, dir1
         ORDER BY monthly_cost DESC
         LIMIT {limit}
-    """
+        """
     ).fetchall()
     return [
-        {"bucket": r[0], "prefix": r[1] + "/", "object_count": r[2], "total_bytes": r[3], "monthly_cost": r[4]}
+        {
+            "bucket": r[0],
+            "prefix": r[1] + "/",
+            "object_count": r[2],
+            "total_bytes": r[3],
+            "monthly_cost": r[4],
+        }
         for r in rows
     ]
 
@@ -229,42 +391,82 @@ def _query_top_dir2(conn: duckdb.DuckDBPyConnection, limit: int = 30) -> list[di
     rows = conn.execute(
         f"""
         SELECT
-            o.bucket,
-            split_part(o.name, '/', 1) || '/' || split_part(o.name, '/', 2) as prefix2,
-            COUNT(*) as object_count,
-            SUM(o.size_bytes) as total_bytes,
-            SUM({_ROW_COST}) as monthly_cost
-        FROM objects o
-        JOIN storage_classes sc ON o.storage_class_id = sc.id
-        WHERE o.name LIKE '%/%/%'
-        GROUP BY o.bucket, prefix2
+            s.bucket,
+            split_part(s.dir_prefix, '/', 1) || '/' || split_part(s.dir_prefix, '/', 2) AS prefix2,
+            SUM(s.object_count) AS object_count,
+            SUM(s.total_bytes) AS total_bytes,
+            SUM({_ROW_COST}) AS monthly_cost
+        FROM dir_summary s
+        JOIN storage_classes sc ON s.storage_class_id = sc.id
+        WHERE s.dir_prefix LIKE '%/%/%'
+        GROUP BY s.bucket, prefix2
         ORDER BY monthly_cost DESC
         LIMIT {limit}
-    """
+        """
     ).fetchall()
     return [
-        {"bucket": r[0], "prefix": r[1], "object_count": r[2], "total_bytes": r[3], "monthly_cost": r[4]} for r in rows
+        {
+            "bucket": r[0],
+            "prefix": r[1],
+            "object_count": r[2],
+            "total_bytes": r[3],
+            "monthly_cost": r[4],
+        }
+        for r in rows
     ]
 
 
-def _query_top_prefix50(conn: duckdb.DuckDBPyConnection, limit: int = 30) -> list[dict]:
+# Safety margin for hierarchical top-K: true top-`limit` dir3 prefixes are
+# guaranteed to live under dir2 parents whose total cost ≥ the cost of the
+# top-`limit`-th dir3. We don't know that cost up front, so we include the
+# top-N dir2s with N >> limit. N=200 x ~few-thousand dir3 children per dir2
+# keeps the second-pass hash table in the hundreds of thousands of keys.
+_TOP_DIR3_CANDIDATE_DIR2S = 200
+
+
+def _query_top_dir_prefix(conn: duckdb.DuckDBPyConnection, limit: int = 30) -> list[dict]:
+    # Two-pass: restrict the (bucket, dir_prefix) GROUP BY to dir3 rows whose
+    # (bucket, dir1/dir2) parent is in the top-N dir2s by cost. This bounds
+    # the hash table instead of materializing ~20M global dir_prefix groups.
     rows = conn.execute(
         f"""
+        WITH top_dir2 AS (
+            SELECT
+                s.bucket,
+                split_part(s.dir_prefix, '/', 1) || '/' || split_part(s.dir_prefix, '/', 2) AS dir2,
+                SUM({_ROW_COST}) AS c
+            FROM dir_summary s
+            JOIN storage_classes sc ON s.storage_class_id = sc.id
+            WHERE s.dir_prefix LIKE '%/%/%'
+            GROUP BY s.bucket, dir2
+            ORDER BY c DESC
+            LIMIT {_TOP_DIR3_CANDIDATE_DIR2S}
+        )
         SELECT
-            o.bucket,
-            left(o.name, 50) as prefix50,
-            COUNT(*) as object_count,
-            SUM(o.size_bytes) as total_bytes,
-            SUM({_ROW_COST}) as monthly_cost
-        FROM objects o
-        JOIN storage_classes sc ON o.storage_class_id = sc.id
-        GROUP BY o.bucket, prefix50
+            s.bucket,
+            s.dir_prefix AS prefix,
+            SUM(s.object_count) AS object_count,
+            SUM(s.total_bytes) AS total_bytes,
+            SUM({_ROW_COST}) AS monthly_cost
+        FROM dir_summary s
+        JOIN storage_classes sc ON s.storage_class_id = sc.id
+        JOIN top_dir2 t
+          ON t.bucket = s.bucket
+         AND t.dir2 = split_part(s.dir_prefix, '/', 1) || '/' || split_part(s.dir_prefix, '/', 2)
+        GROUP BY s.bucket, s.dir_prefix
         ORDER BY monthly_cost DESC
         LIMIT {limit}
-    """
+        """
     ).fetchall()
     return [
-        {"bucket": r[0], "prefix": r[1], "object_count": r[2], "total_bytes": r[3], "monthly_cost": r[4]} for r in rows
+        {
+            "bucket": r[0],
+            "prefix": r[1],
+            "object_count": r[2],
+            "total_bytes": r[3],
+            "monthly_cost": r[4],
+        }
+        for r in rows
     ]
 
 
@@ -272,45 +474,47 @@ def _query_age_distribution(conn: duckdb.DuckDBPyConnection) -> list[dict]:
     rows = conn.execute(
         f"""
         SELECT
-            CASE
-                WHEN created >= CURRENT_TIMESTAMP - INTERVAL '7 days' THEN '<7d'
-                WHEN created >= CURRENT_TIMESTAMP - INTERVAL '30 days' THEN '7-30d'
-                WHEN created >= CURRENT_TIMESTAMP - INTERVAL '90 days' THEN '30-90d'
-                WHEN created >= CURRENT_TIMESTAMP - INTERVAL '365 days' THEN '90-365d'
-                ELSE '>365d'
-            END as age_bucket,
-            COUNT(*) as object_count,
-            SUM(o.size_bytes) as total_bytes,
-            SUM({_ROW_COST}) as monthly_cost
-        FROM objects o
-        JOIN storage_classes sc ON o.storage_class_id = sc.id
-        WHERE created IS NOT NULL
-        GROUP BY age_bucket
-        ORDER BY CASE age_bucket
+            s.age_bucket,
+            SUM(s.object_count) AS object_count,
+            SUM(s.total_bytes) AS total_bytes,
+            SUM({_ROW_COST}) AS monthly_cost
+        FROM time_summary s
+        JOIN storage_classes sc ON s.storage_class_id = sc.id
+        WHERE s.age_bucket IS NOT NULL
+        GROUP BY s.age_bucket
+        ORDER BY CASE s.age_bucket
             WHEN '<7d' THEN 1
             WHEN '7-30d' THEN 2
             WHEN '30-90d' THEN 3
             WHEN '90-365d' THEN 4
             ELSE 5
         END
-    """
+        """
     ).fetchall()
-    return [{"age_bucket": r[0], "object_count": r[1], "total_bytes": r[2], "monthly_cost": r[3]} for r in rows]
+    return [
+        {
+            "age_bucket": r[0],
+            "object_count": r[1],
+            "total_bytes": r[2],
+            "monthly_cost": r[3],
+        }
+        for r in rows
+    ]
 
 
 def _query_monthly_growth(conn: duckdb.DuckDBPyConnection, months: int = 12) -> list[dict]:
     rows = conn.execute(
         f"""
         SELECT
-            strftime(created, '%Y-%m') as month,
-            COUNT(*) as object_count,
-            SUM(size_bytes) as total_bytes
-        FROM objects
-        WHERE created IS NOT NULL
-          AND created >= CURRENT_TIMESTAMP - INTERVAL '{months} months'
+            strftime(created_month, '%Y-%m') AS month,
+            SUM(object_count) AS object_count,
+            SUM(total_bytes) AS total_bytes
+        FROM time_summary
+        WHERE created_month IS NOT NULL
+          AND created_month >= date_trunc('month', CURRENT_TIMESTAMP) - INTERVAL '{months} months'
         GROUP BY month
         ORDER BY month DESC
-    """
+        """
     ).fetchall()
     return [{"month": r[0], "object_count": r[1], "total_bytes": r[2]} for r in rows]
 
@@ -365,7 +569,7 @@ def generate_report(conn: duckdb.DuckDBPyConnection) -> str:
     by_class = _query_by_storage_class(conn)
     top_dir1 = _query_top_dir1(conn)
     top_dir2 = _query_top_dir2(conn)
-    top_p50 = _query_top_prefix50(conn)
+    top_prefix = _query_top_dir_prefix(conn)
     age_dist = _query_age_distribution(conn)
     monthly = _query_monthly_growth(conn)
 
@@ -374,7 +578,6 @@ def generate_report(conn: duckdb.DuckDBPyConnection) -> str:
     ts = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     parts.append(f"# GCS Storage Report\n\nGenerated: {ts}\n")
 
-    # Overview
     parts.append("## Overview\n")
     parts.append(
         _md_table(
@@ -389,7 +592,6 @@ def generate_report(conn: duckdb.DuckDBPyConnection) -> str:
         )
     )
 
-    # By Bucket
     parts.append("## By Bucket\n")
     parts.append(
         _md_table(
@@ -408,7 +610,6 @@ def generate_report(conn: duckdb.DuckDBPyConnection) -> str:
         )
     )
 
-    # By Storage Class
     parts.append("## By Storage Class\n")
     parts.append(
         _md_table(
@@ -427,7 +628,6 @@ def generate_report(conn: duckdb.DuckDBPyConnection) -> str:
         )
     )
 
-    # Top First-Level Directories
     parts.append("## Top First-Level Directories\n")
     parts.append(
         _md_table(
@@ -446,7 +646,6 @@ def generate_report(conn: duckdb.DuckDBPyConnection) -> str:
         )
     )
 
-    # Top Two-Level Prefixes
     parts.append("## Top Two-Level Prefixes\n")
     parts.append(
         _md_table(
@@ -465,8 +664,7 @@ def generate_report(conn: duckdb.DuckDBPyConnection) -> str:
         )
     )
 
-    # Top 50-char Prefixes
-    parts.append("## Top Prefixes (50-char grouping)\n")
+    parts.append(f"## Top {DIR_DEPTH}-Level Prefixes\n")
     parts.append(
         _md_table(
             ["Bucket", "Prefix", "Objects", "Size (TB)", "Monthly Cost"],
@@ -478,26 +676,29 @@ def generate_report(conn: duckdb.DuckDBPyConnection) -> str:
                     _fmt_tb(r["total_bytes"]),
                     _fmt_cost(r["monthly_cost"]),
                 ]
-                for r in top_p50
+                for r in top_prefix
             ],
             align=["l", "l", "r", "r", "r"],
         )
     )
 
-    # Age Distribution
     parts.append("## Age Distribution\n")
     parts.append(
         _md_table(
             ["Age", "Objects", "Size (TB)", "Monthly Cost"],
             [
-                [r["age_bucket"], _fmt_count(r["object_count"]), _fmt_tb(r["total_bytes"]), _fmt_cost(r["monthly_cost"])]
+                [
+                    r["age_bucket"],
+                    _fmt_count(r["object_count"]),
+                    _fmt_tb(r["total_bytes"]),
+                    _fmt_cost(r["monthly_cost"]),
+                ]
                 for r in age_dist
             ],
             align=["l", "r", "r", "r"],
         )
     )
 
-    # Monthly Creation Trend
     parts.append("## Monthly Creation Trend\n")
     parts.append(
         _md_table(
@@ -517,7 +718,12 @@ def generate_report(conn: duckdb.DuckDBPyConnection) -> str:
 
 @click.command()
 @click.argument("parquet_dir")
-@click.option("--output", "-o", type=click.Path(), help="Write markdown report to file (default: stdout).")
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(),
+    help="Write markdown report to file (default: stdout).",
+)
 def main(parquet_dir: str, output: str | None) -> None:
     """Generate a storage usage report from parquet output of a scan.
 


### PR DESCRIPTION
distributed_scan writes each segment under a fresh UUID but never cleaned staging_dir between runs, so re-runs appended instead of overwriting. Report consumers saw 3-8x duplicate (bucket, name) rows, inflating reported cost and size by ~3x over the billing dashboard. Truncate objects_*.parquet at run start.

report.py now builds a per-batch dir/age rollup cache and runs report queries directly off the leaves. Top-3-level prefixes uses hierarchical top-K so the final hash aggregate does not materialize the ~20M global (bucket, dir_prefix) key space that was OOMing on the old single-pass reduce.