### PR TITLE
fix(fray): pass device default env vars in create_actor_group

### DIFF
--- a/lib/fray/src/fray/v2/iris_backend.py
+++ b/lib/fray/src/fray/v2/iris_backend.py
@@ -641,6 +641,7 @@ class FrayIrisClient:
 
         iris_resources = convert_resources(resources)
         iris_constraints = convert_constraints(resources)
+        iris_environment = convert_environment(None, device=resources.device)
 
         coscheduling = resolve_coscheduling(resources.device, count)
 
@@ -656,6 +657,7 @@ class FrayIrisClient:
             entrypoint=entrypoint,
             name=name,
             resources=iris_resources,
+            environment=iris_environment,
             ports=["actor"],
             constraints=iris_constraints if iris_constraints else None,
             coscheduling=coscheduling,

--- a/lib/fray/tests/test_v2_iris.py
+++ b/lib/fray/tests/test_v2_iris.py
@@ -37,7 +37,7 @@ class TestConvertConstraints:
         assert len(constraints) == 1
         c = constraints[0]
         assert c.key == "preemptible"
-        assert c.value == "false"
+        assert c.values[0].value == "false"
 
     def test_single_region_produces_eq_constraint(self):
         resources = ResourceConfig(regions=["us-central1"])
@@ -48,7 +48,7 @@ class TestConvertConstraints:
         from iris.cluster.constraints import ConstraintOp
 
         assert c.op == ConstraintOp.EQ
-        assert c.value == "us-central1"
+        assert c.values[0].value == "us-central1"
 
     def test_multiple_regions_produce_in_constraint(self):
         resources = ResourceConfig(regions=["us-central1", "us-central2"])
@@ -59,7 +59,7 @@ class TestConvertConstraints:
         from iris.cluster.constraints import ConstraintOp
 
         assert c.op == ConstraintOp.IN
-        assert c.values == ("us-central1", "us-central2")
+        assert tuple(v.value for v in c.values) == ("us-central1", "us-central2")
 
     def test_zone_produces_eq_constraint(self):
         resources = ResourceConfig(zone="us-east1-d")
@@ -70,7 +70,7 @@ class TestConvertConstraints:
         from iris.cluster.constraints import ConstraintOp
 
         assert c.op == ConstraintOp.EQ
-        assert c.value == "us-east1-d"
+        assert c.values[0].value == "us-east1-d"
 
 
 class TestConvertConstraintsDeviceAlternatives:
@@ -89,7 +89,7 @@ class TestConvertConstraintsDeviceAlternatives:
         from iris.cluster.constraints import ConstraintOp
 
         assert c.op == ConstraintOp.IN
-        assert set(c.values) == {"v4-8", "v5p-8"}
+        assert {v.value for v in c.values} == {"v4-8", "v5p-8"}
 
 
 class TestIrisActorHandlePickle:

--- a/lib/fray/tests/test_v2_iris.py
+++ b/lib/fray/tests/test_v2_iris.py
@@ -173,6 +173,62 @@ class TestImagePlumbing:
         assert kwargs["task_image"] == "custom/swetrace:dev"
 
 
+class TestActorGroupEnvironment:
+    """Verify create_actor_group passes device-appropriate env vars to Iris."""
+
+    def test_tpu_actor_gets_tpu_env_vars(self):
+        """TPU actors must receive JAX_PLATFORMS='' and LIBTPU_INIT_ARGS from device defaults."""
+        fake_iris = MagicMock()
+        fake_iris.submit.return_value = MagicMock(job_id="job-tpu")
+        client = FrayIrisClient.from_iris_client(fake_iris)
+
+        class _DummyActor:
+            pass
+
+        resources = ResourceConfig.with_tpu("v5p-8")
+        client.create_actor_group(_DummyActor, name="tpu-actor", count=1, resources=resources)
+
+        kwargs = fake_iris.submit.call_args.kwargs
+        env = kwargs["environment"]
+        assert env is not None
+        assert env.env_vars["JAX_PLATFORMS"] == ""
+        assert "LIBTPU_INIT_ARGS" in env.env_vars
+
+    def test_cpu_actor_gets_cpu_env_vars(self):
+        """CPU actors must receive JAX_PLATFORMS=cpu."""
+        fake_iris = MagicMock()
+        fake_iris.submit.return_value = MagicMock(job_id="job-cpu")
+        client = FrayIrisClient.from_iris_client(fake_iris)
+
+        class _DummyActor:
+            pass
+
+        resources = ResourceConfig(cpu=2, ram="4g")
+        client.create_actor_group(_DummyActor, name="cpu-actor", count=1, resources=resources)
+
+        kwargs = fake_iris.submit.call_args.kwargs
+        env = kwargs["environment"]
+        assert env is not None
+        assert env.env_vars["JAX_PLATFORMS"] == "cpu"
+
+    def test_gpu_actor_gets_gpu_env_vars(self):
+        """GPU actors must receive JAX_PLATFORMS='' from GpuConfig defaults."""
+        fake_iris = MagicMock()
+        fake_iris.submit.return_value = MagicMock(job_id="job-gpu")
+        client = FrayIrisClient.from_iris_client(fake_iris)
+
+        class _DummyActor:
+            pass
+
+        resources = ResourceConfig.with_gpu("a100-80g")
+        client.create_actor_group(_DummyActor, name="gpu-actor", count=1, resources=resources)
+
+        kwargs = fake_iris.submit.call_args.kwargs
+        env = kwargs["environment"]
+        assert env is not None
+        assert env.env_vars["JAX_PLATFORMS"] == ""
+
+
 class TestWithTpuFlexible:
     def test_single_type_returns_standard_config(self):
         rc = ResourceConfig.with_tpu(["v5p-8"])


### PR DESCRIPTION
create_actor_group was calling self._iris.submit() without an environment parameter, so device defaults (e.g. JAX_PLATFORMS="" for TPU) were never set on actor jobs. Combined with Iris's parent→child env inheritance, actors spawned from a coordinator with a different device type (e.g. CPU coordinator → TPU actor) inherited the wrong JAX_PLATFORMS, causing JAX to refuse to initialize the correct backend.

Fix: compute iris_environment via convert_environment(None, device=...) and pass it to self._iris.submit(), matching the existing submit() path.

Closes #4714