### PR TITLE
Only download the 10BT sample, since that's all that that will be processed

### DIFF
--- a/experiments/dedup/fineweb_10bt_exact.py
+++ b/experiments/dedup/fineweb_10bt_exact.py
@@ -29,6 +29,7 @@ def build_steps() -> list[StepSpec]:
         "raw/fineweb-edu",
         hf_dataset_id="HuggingFaceFW/fineweb-edu",
         revision="87f0914",
+        hf_urls_glob=["sample/10BT/*.parquet"],
     )
 
     dedup_step = StepSpec(

--- a/experiments/dedup/fineweb_10bt_exact.py
+++ b/experiments/dedup/fineweb_10bt_exact.py
@@ -14,7 +14,7 @@ import os
 from rigging.log_setup import configure_logging
 from rigging.filesystem import marin_prefix
 
-from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.canonical import fineweb_edu
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from marin.processing.classification.deduplication.exact import dedup_exact_paragraph
@@ -25,10 +25,7 @@ OUTPUT_PREFIX = os.environ.get("OUTPUT_PREFIX", "exact-para-dedup-fineweb-10bt")
 
 
 def build_steps() -> list[StepSpec]:
-    download = download_hf_step(
-        "raw/fineweb-edu",
-        hf_dataset_id="HuggingFaceFW/fineweb-edu",
-        revision="87f0914",
+    download = fineweb_edu.download(
         hf_urls_glob=["sample/10BT/*.parquet"],
     )
 

--- a/lib/marin/src/marin/datakit/canonical/fineweb_edu.py
+++ b/lib/marin/src/marin/datakit/canonical/fineweb_edu.py
@@ -23,11 +23,13 @@ from marin.execution.step_spec import StepSpec
 def download(
     *,
     revision: str = "87f0914",
+    hf_urls_glob: list[str] | None = None,
 ) -> StepSpec:
     """Download FineWeb-Edu from HuggingFace."""
     return download_hf_step(
         "raw/fineweb-edu",
         hf_dataset_id="HuggingFaceFW/fineweb-edu",
         revision=revision,
+        hf_urls_glob=hf_urls_glob,
         override_output_path=f"raw/fineweb-edu-{revision}",
     )


### PR DESCRIPTION
`experiments/dedup/fineweb_10bt_exact.py` only intends to process `sample/10BT` but was downloading everything. Limit the download to only `sample/10BT`.

