### PR TITLE
[Evals] Wire up RULER for exp2062

### DIFF
--- a/experiments/evals/evals.py
+++ b/experiments/evals/evals.py
@@ -37,6 +37,8 @@ from experiments.evals.task_configs import (
     MMLU_PRO_5_SHOT,
     OPEN_LM_LEADERBOARD_GEN,
     OPEN_LM_LEADERBOARD_MCQ,
+    RULER_MAX_GENERATION_TOKENS,
+    ruler_tasks_for_lengths,
 )
 
 logger = logging.getLogger(__name__)
@@ -52,6 +54,8 @@ def evaluate_lm_evaluation_harness(
     apply_chat_template: bool = False,
     wandb_tags: list[str] | None = None,
     discover_latest_checkpoint: bool = True,
+    task_metadata: dict | None = None,
+    evaluation_name: str | None = None,
 ) -> ExecutorStep:
     """
     Create an ExecutorStep to evaluate the model using LM Evaluation Harness.
@@ -61,8 +65,9 @@ def evaluate_lm_evaluation_harness(
         model_path (str): Path to the model.
         evals (list[EvalTaskConfig]): List of evaluations to run with LM Evaluation Harness.
     """
+    step_name = evaluation_name or model_name
     return ExecutorStep(
-        name=f"evaluation/lm_evaluation_harness/{model_name}",
+        name=f"evaluation/lm_evaluation_harness/{step_name}",
         fn=evaluate,
         config=EvaluationConfig(
             evaluator="lm_evaluation_harness",
@@ -77,6 +82,7 @@ def evaluate_lm_evaluation_harness(
             resource_config=resource_config,
             apply_chat_template=apply_chat_template,
             wandb_tags=wandb_tags,
+            task_metadata=task_metadata,
         ),
     )
 
@@ -330,6 +336,80 @@ def default_sft_eval(
             )
             eval_jobs.append(olmo_generation)
     return eval_jobs
+
+
+def _required_ruler_max_model_len(lengths: Sequence[int], *, apply_chat_template: bool) -> int:
+    selected_lengths = tuple(lengths)
+    if not selected_lengths:
+        raise ValueError("At least one RULER context length is required.")
+
+    chat_template_buffer = 256 if apply_chat_template else 0
+    return max(selected_lengths) + chat_template_buffer
+
+
+def default_ruler_eval(
+    step: ExecutorStep | InputName | str,
+    *,
+    lengths: Sequence[int] = (4096,),
+    task_names: Sequence[str] | None = None,
+    evals: Sequence[EvalTaskConfig] | None = None,
+    resource_config: ResourceConfig = ResourceConfig.with_tpu("v5p-8"),
+    max_eval_instances: int | None = None,
+    engine_kwargs: dict | None = None,
+    tokenizer: str | None = None,
+    apply_chat_template: bool = False,
+    discover_latest_checkpoint: bool = False,
+    wandb_tags: list[str] | None = None,
+) -> ExecutorStep:
+    """Create a vLLM-backed lm-eval RULER evaluation step."""
+    selected_lengths = tuple(lengths)
+    if evals is None:
+        if task_names is None:
+            evals = ruler_tasks_for_lengths(selected_lengths)
+        else:
+            evals = ruler_tasks_for_lengths(selected_lengths, task_names=task_names)
+
+    required_max_model_len = _required_ruler_max_model_len(selected_lengths, apply_chat_template=apply_chat_template)
+    resolved_engine_kwargs = dict(engine_kwargs or {})
+    if tokenizer is not None:
+        existing_tokenizer = resolved_engine_kwargs.get("tokenizer")
+        if existing_tokenizer is not None and existing_tokenizer != tokenizer:
+            raise ValueError(f"Conflicting RULER tokenizer values: {existing_tokenizer!r} and {tokenizer!r}")
+        resolved_engine_kwargs["tokenizer"] = tokenizer
+
+    resolved_engine_kwargs.setdefault("max_model_len", required_max_model_len)
+    if int(resolved_engine_kwargs["max_model_len"]) < required_max_model_len:
+        raise ValueError(
+            f"RULER max_model_len={resolved_engine_kwargs['max_model_len']} is smaller than "
+            f"the required length {required_max_model_len}."
+        )
+
+    resolved_engine_kwargs.setdefault("max_length", resolved_engine_kwargs["max_model_len"])
+    if int(resolved_engine_kwargs["max_length"]) < required_max_model_len:
+        raise ValueError(
+            f"RULER max_length={resolved_engine_kwargs['max_length']} is smaller than "
+            f"the required length {required_max_model_len}."
+        )
+
+    resolved_engine_kwargs.setdefault("max_gen_toks", RULER_MAX_GENERATION_TOKENS)
+
+    name, model_step_path = extract_model_name_and_path(step)
+    length_label = "_".join(f"{length // 1024}k" for length in selected_lengths)
+    task_metadata = {"max_seq_lengths": selected_lengths}
+
+    return evaluate_lm_evaluation_harness(
+        name,
+        model_step_path,
+        list(evals),
+        max_eval_instances=max_eval_instances,
+        engine_kwargs=resolved_engine_kwargs,
+        resource_config=resource_config,
+        apply_chat_template=apply_chat_template,
+        wandb_tags=wandb_tags or ["ruler", "long-context"],
+        discover_latest_checkpoint=discover_latest_checkpoint,
+        task_metadata=task_metadata,
+        evaluation_name=f"{name}/ruler_{length_label}",
+    )
 
 
 def default_key_evals(

--- a/experiments/evals/exp2062_ruler_eval.py
+++ b/experiments/evals/exp2062_ruler_eval.py
@@ -1,0 +1,68 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""RULER/NIAH evaluations for the exp2062 8B long-context checkpoints.
+
+These checkpoints are base models, so RULER prompts are sent as plain completions
+without chat-template wrapping. Use ``apply_chat_template=True`` only for
+instruction-tuned checkpoints whose tokenizer chat template matches training.
+"""
+
+from dataclasses import dataclass
+
+from fray.cluster import ResourceConfig
+
+from experiments.evals.evals import default_ruler_eval
+from experiments.tootsie.exp2062_long_context_8b import (
+    STARLING_WARMSTART_STEP,
+    phase1_final_checkpoint,
+    phase2_final_checkpoint,
+    phase3_final_checkpoint,
+)
+from experiments.tootsie.exp600_tootsie import tootsie_8b_sensible_starling
+from marin.execution.executor import InputName, executor_main
+
+RULER_RESOURCES = ResourceConfig.with_tpu("v5p-8")
+RULER_TOKENIZER = "stanford-crfm/marin-tokenizer"
+
+
+@dataclass(frozen=True)
+class RulerCheckpointSpec:
+    checkpoint: InputName
+    lengths: tuple[int, ...]
+
+
+CHECKPOINTS = (
+    RulerCheckpointSpec(
+        checkpoint=tootsie_8b_sensible_starling.cd(f"hf/step-{STARLING_WARMSTART_STEP}").nonblocking(),
+        lengths=(4096,),
+    ),
+    RulerCheckpointSpec(
+        checkpoint=phase1_final_checkpoint.nonblocking(),
+        lengths=(4096,),
+    ),
+    RulerCheckpointSpec(
+        checkpoint=phase2_final_checkpoint.nonblocking(),
+        lengths=(4096, 8192, 16384, 32768),
+    ),
+    RulerCheckpointSpec(
+        checkpoint=phase3_final_checkpoint.nonblocking(),
+        lengths=(4096, 8192, 16384, 32768, 65536),
+    ),
+)
+
+
+if __name__ == "__main__":
+    executor_main(
+        steps=[
+            default_ruler_eval(
+                checkpoint.checkpoint,
+                lengths=checkpoint.lengths,
+                tokenizer=RULER_TOKENIZER,
+                resource_config=RULER_RESOURCES,
+                apply_chat_template=False,
+                discover_latest_checkpoint=False,
+            )
+            for checkpoint in CHECKPOINTS
+        ]
+    )

--- a/experiments/evals/task_configs.py
+++ b/experiments/evals/task_configs.py
@@ -81,6 +81,62 @@ BASE_GENERATION_TASKS = (
     EvalTaskConfig(name="triviaqa", num_fewshot=0, task_alias="triviaqa"),
 )
 
+RULER_CONTEXT_LENGTHS = (4096, 8192, 16384, 32768, 65536)
+RULER_MAX_GENERATION_TOKENS = 128
+RULER_TASK_NAMES = (
+    "niah_single_1",
+    "niah_single_2",
+    "niah_single_3",
+    "niah_multikey_1",
+    "niah_multikey_2",
+    "niah_multikey_3",
+    "niah_multiquery",
+    "niah_multivalue",
+    "ruler_vt",
+    "ruler_cwe",
+    "ruler_fwe",
+    "ruler_qa_squad",
+    "ruler_qa_hotpot",
+)
+RULER_NIAH_TASK_NAMES = RULER_TASK_NAMES[:8]
+
+
+def _validate_ruler_lengths(lengths: Sequence[int]) -> tuple[int, ...]:
+    selected_lengths = tuple(lengths)
+    if not selected_lengths:
+        raise ValueError("At least one RULER context length is required.")
+
+    unsupported_lengths = sorted(set(selected_lengths) - set(RULER_CONTEXT_LENGTHS))
+    if unsupported_lengths:
+        raise ValueError(
+            f"Unsupported RULER context lengths: {unsupported_lengths}. "
+            f"Supported lengths: {list(RULER_CONTEXT_LENGTHS)}."
+        )
+
+    return selected_lengths
+
+
+def ruler_tasks_for_lengths(
+    lengths: Sequence[int] = (4096,),
+    *,
+    task_names: Sequence[str] = RULER_TASK_NAMES,
+) -> tuple[EvalTaskConfig, ...]:
+    """Build explicit lm-eval RULER task configs for the requested context lengths."""
+    selected_lengths = _validate_ruler_lengths(lengths)
+    return tuple(
+        EvalTaskConfig(
+            name=task_name,
+            num_fewshot=0,
+            task_alias=task_name,
+            task_kwargs={"max_seq_lengths": selected_lengths},
+        )
+        for task_name in task_names
+    )
+
+
+RULER_TASKS = ruler_tasks_for_lengths((4096,))
+RULER_NIAH_TASKS = ruler_tasks_for_lengths((4096,), task_names=RULER_NIAH_TASK_NAMES)
+
 # Settings are chosen to compare to Olmo2
 KEY_GENERATION_TASKS = (
     EvalTaskConfig(name="ifeval", num_fewshot=0),

--- a/lib/fray/tests/test_v2_iris.py
+++ b/lib/fray/tests/test_v2_iris.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from iris.cluster.constraints import Constraint, ConstraintOp
 from fray.v2.iris_backend import (
     FrayIrisClient,
     IrisActorHandle,
@@ -23,6 +24,10 @@ from fray.v2.types import (
     ResourceConfig,
     TpuConfig,
 )
+
+
+def constraint_values(constraint: Constraint) -> tuple[str | int | float, ...]:
+    return tuple(value.value for value in constraint.values)
 
 
 class TestConvertConstraints:
@@ -37,7 +42,7 @@ class TestConvertConstraints:
         assert len(constraints) == 1
         c = constraints[0]
         assert c.key == "preemptible"
-        assert c.values[0].value == "false"
+        assert constraint_values(c) == ("false",)
 
     def test_single_region_produces_eq_constraint(self):
         resources = ResourceConfig(regions=["us-central1"])
@@ -45,10 +50,9 @@ class TestConvertConstraints:
         region_constraints = [c for c in constraints if c.key == "region"]
         assert len(region_constraints) == 1
         c = region_constraints[0]
-        from iris.cluster.constraints import ConstraintOp
 
         assert c.op == ConstraintOp.EQ
-        assert c.values[0].value == "us-central1"
+        assert constraint_values(c) == ("us-central1",)
 
     def test_multiple_regions_produce_in_constraint(self):
         resources = ResourceConfig(regions=["us-central1", "us-central2"])
@@ -56,10 +60,9 @@ class TestConvertConstraints:
         region_constraints = [c for c in constraints if c.key == "region"]
         assert len(region_constraints) == 1
         c = region_constraints[0]
-        from iris.cluster.constraints import ConstraintOp
 
         assert c.op == ConstraintOp.IN
-        assert tuple(v.value for v in c.values) == ("us-central1", "us-central2")
+        assert constraint_values(c) == ("us-central1", "us-central2")
 
     def test_zone_produces_eq_constraint(self):
         resources = ResourceConfig(zone="us-east1-d")
@@ -67,10 +70,9 @@ class TestConvertConstraints:
         zone_constraints = [c for c in constraints if c.key == "zone"]
         assert len(zone_constraints) == 1
         c = zone_constraints[0]
-        from iris.cluster.constraints import ConstraintOp
 
         assert c.op == ConstraintOp.EQ
-        assert c.values[0].value == "us-east1-d"
+        assert constraint_values(c) == ("us-east1-d",)
 
 
 class TestConvertConstraintsDeviceAlternatives:
@@ -86,10 +88,9 @@ class TestConvertConstraintsDeviceAlternatives:
         device_constraints = [c for c in constraints if c.key == "device-variant"]
         assert len(device_constraints) == 1
         c = device_constraints[0]
-        from iris.cluster.constraints import ConstraintOp
 
         assert c.op == ConstraintOp.IN
-        assert {v.value for v in c.values} == {"v4-8", "v5p-8"}
+        assert set(constraint_values(c)) == {"v4-8", "v5p-8"}
 
 
 class TestIrisActorHandlePickle:

--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -60,16 +60,11 @@ from levanter.tokenizers import MarinTokenizer
 from levanter.utils.py_utils import set_global_rng_seeds
 
 try:
-    from lm_eval import evaluator
     from lm_eval.api.instance import Instance
     from lm_eval.api.model import TemplateLM
-    from lm_eval.models.utils import handle_stop_sequences, postprocess_generated_text
 except ImportError:
     TemplateLM = object
     Instance = object
-    evaluator = object
-    handle_stop_sequences = None
-    postprocess_generated_text = None
 
 import haliax as hax
 from haliax.partitioning import ResourceMapping, round_axis_for_partitioning
@@ -89,6 +84,36 @@ from levanter.utils.tree_utils import inference_mode
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+
+def _lm_eval_evaluator_module():
+    try:
+        from lm_eval import evaluator
+    except Exception as e:
+        raise ImportError(
+            "lm-eval's evaluator module could not be imported. Install the evaluation dependencies, including torch."
+        ) from e
+    return evaluator
+
+
+def _handle_stop_sequences(until: Optional[List[str]], eos: str):
+    try:
+        from lm_eval.models.utils import handle_stop_sequences
+    except Exception as e:
+        raise ImportError(
+            "lm-eval generation utilities could not be imported. Install the evaluation dependencies, including torch."
+        ) from e
+    return handle_stop_sequences(until, eos=eos)
+
+
+def _postprocess_generated_text(text: str, until: Optional[List[str]], think_end_token: str | None):
+    try:
+        from lm_eval.models.utils import postprocess_generated_text
+    except Exception as e:
+        raise ImportError(
+            "lm-eval generation utilities could not be imported. Install the evaluation dependencies, including torch."
+        ) from e
+    return postprocess_generated_text(text, until, think_end_token)
 
 
 def _call_with_retry(
@@ -722,7 +747,7 @@ class LevanterHarnessLM(TemplateLM):
             return None
 
         # Process stop sequences to ensure EOS is included
-        processed_until = handle_stop_sequences(until, eos=eos)
+        processed_until = _handle_stop_sequences(until, eos=eos)
 
         if not processed_until:
             return None
@@ -909,7 +934,7 @@ class LevanterHarnessLM(TemplateLM):
                 text = self.tokenizer.decode(full_tokens, skip_special_tokens=True)
 
                 # Post-process the generated text using the imported utility function
-                text = postprocess_generated_text(
+                text = _postprocess_generated_text(
                     text, gen_kwargs.get("until"), None  # think_end_token - could be made configurable if needed
                 )
                 outputs.append(text)
@@ -1337,6 +1362,7 @@ def _actually_run_eval_harness(
         harness.clear_sample_outputs()
 
         with set_global_rng_seeds(0):
+            evaluator = _lm_eval_evaluator_module()
             outputs = evaluator.evaluate(
                 harness,
                 tasks_to_run,

--- a/lib/marin/pyproject.toml
+++ b/lib/marin/pyproject.toml
@@ -145,6 +145,8 @@ rl = [
 
 eval = [
     "lm-eval[math,api]@git+https://github.com/stanford-crfm/lm-evaluation-harness@d5e3391f22cde186c827674d5c3ec7c5f4fe0cab",
+    "nltk>=3.9.1",
+    "wonderwords",
 ]
 
 # Evalchemy for reasoning-focused LLM evaluations (AIME, MATH500, HumanEval+, etc.)

--- a/lib/marin/src/marin/evaluation/evaluation_config.py
+++ b/lib/marin/src/marin/evaluation/evaluation_config.py
@@ -6,7 +6,6 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 
 from fray.cluster import ResourceConfig
-from levanter.eval_harness import TaskConfig
 
 # Wandb project name for evaluations. Controlled via WANDB_PROJECT env var.
 WANDB_PROJECT = os.environ.get("WANDB_PROJECT", "marin")
@@ -105,9 +104,14 @@ class EvaluationConfig:
     """Custom base name for wandb runs. If set, wandb runs will be named
     evalchemy-{base_eval_run_name}[-step{N}]-{task}-seed{S}."""
 
+    task_metadata: dict | None = None
+    """Additional metadata passed to evaluator task loaders."""
 
-def convert_to_levanter_task_config(tasks: Sequence[EvalTaskConfig]) -> list[TaskConfig]:
+
+def convert_to_levanter_task_config(tasks: Sequence[EvalTaskConfig]) -> list:
     """Convert a list of EvalTaskConfig to a list of TaskConfig that Levanter's eval_harness expects."""
+    from levanter.eval_harness import TaskConfig
+
     return [
         TaskConfig(
             task=task.name,

--- a/lib/marin/src/marin/evaluation/evaluators/evaluator.py
+++ b/lib/marin/src/marin/evaluation/evaluators/evaluator.py
@@ -55,6 +55,9 @@ class ModelConfig:
     base_eval_run_name: str | None = None
     """Custom base name for wandb runs."""
 
+    task_metadata: dict[str, Any] | None = None
+    """Additional metadata passed to evaluator task loaders."""
+
 
 class Evaluator(ABC):
     @abstractmethod

--- a/lib/marin/src/marin/evaluation/evaluators/levanter_lm_eval_evaluator.py
+++ b/lib/marin/src/marin/evaluation/evaluators/levanter_lm_eval_evaluator.py
@@ -9,7 +9,6 @@ import os
 import jmp
 from rigging.filesystem import filesystem as marin_filesystem
 import levanter
-import levanter.eval_harness as eval_harness
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.distributed import RayConfig
 from levanter.tracker.wandb import WandbConfig
@@ -60,6 +59,7 @@ class LevanterLmEvalEvaluator(LevanterTpuEvaluator):
         """
         # Eval Harness code: https://github.com/stanford-crfm/levanter/blob/main/src/levanter/eval_harness.py
         # Run the harness with the model and the specified evals
+        import levanter.eval_harness as eval_harness
 
         try:
             model_name_or_path: str = self.model_name_or_path(model)
@@ -130,10 +130,6 @@ class LevanterLmEvalEvaluator(LevanterTpuEvaluator):
         except Exception as e:
             logger.error(f"Error running eval harness: {e}")
             raise e
-
-        finally:
-            # Clean up resources
-            self.cleanup(model)
 
 
 def _json_default(value):

--- a/lib/marin/src/marin/evaluation/evaluators/lm_evaluation_harness_evaluator.py
+++ b/lib/marin/src/marin/evaluation/evaluators/lm_evaluation_harness_evaluator.py
@@ -8,6 +8,7 @@ import tempfile
 import traceback
 from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import Any
 
 from fray.v1.cluster import ResourceConfig
 from fray.v1.cluster.ray.deps import build_runtime_env_for_packages
@@ -20,6 +21,47 @@ from marin.evaluation.utils import is_remote_path, upload_to_gcs
 from marin.inference.vllm_server import VLLM_NATIVE_PIP_PACKAGES, VllmEnvironment, resolve_vllm_mode
 
 logger = logging.getLogger(__name__)
+
+
+def _model_args_for_lm_eval(
+    *,
+    model: ModelConfig,
+    model_id: str,
+    server_url: str,
+    tokenizer: str,
+    apply_chat_template: bool,
+) -> str:
+    endpoint = "chat/completions" if apply_chat_template else "completions"
+    args = (
+        f"model={model_id},"
+        f"base_url={server_url}/{endpoint},"
+        "tokenizer_backend=huggingface,"
+        "tokenized_requests=False,"
+        f"tokenizer={tokenizer}"
+    )
+    for key, value in model.engine_kwargs.items():
+        if key == "tokenizer":
+            continue
+        args += f",{key}={value}"
+    return args
+
+
+def _lm_eval_metadata(model: ModelConfig, eval_task: EvalTaskConfig, *, tokenizer: str) -> dict[str, Any]:
+    metadata = dict(model.task_metadata or {})
+    if eval_task.task_kwargs:
+        metadata.update(eval_task.task_kwargs)
+    metadata["tokenizer"] = tokenizer
+    metadata.setdefault("pretrained", tokenizer)
+    return metadata
+
+
+def _env_vars_from_keys(keys: tuple[str, ...]) -> dict[str, str]:
+    env_vars: dict[str, str] = {}
+    for key in keys:
+        value = os.environ.get(key)
+        if value:
+            env_vars[key] = value
+    return env_vars
 
 
 # TODO: Multiple choice tasks currently don't work on TPUs: https://github.com/vllm-project/vllm/issues/8499
@@ -88,6 +130,18 @@ class LMEvaluationHarnessEvaluator(Evaluator):
 
         mode_str = resolve_vllm_mode(None)
         pip_packages = VLLM_NATIVE_PIP_PACKAGES if mode_str == "native" else ()
+        env_vars = _env_vars_from_keys(
+            (
+                "HF_TOKEN",
+                "WANDB_API_KEY",
+                "MARIN_PREFIX",
+                "MARIN_VLLM_MODE",
+                "VLLM_TPU_DISABLE_TOPK_TOPP_OPTIMIZATION",
+                "VLLM_TPU_SKIP_PRECOMPILE",
+            )
+        )
+        env_vars["HF_ALLOW_CODE_EVAL"] = "1"
+        env_vars.setdefault("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "1")
         launch_evaluate_with_ray(
             evaluator=self,
             job_name="lm-eval",
@@ -99,7 +153,7 @@ class LMEvaluationHarnessEvaluator(Evaluator):
             wandb_tags=wandb_tags,
             extras=("eval", "tpu"),
             pip_packages=pip_packages,
-            env_vars={"HF_ALLOW_CODE_EVAL": "1"},
+            env_vars=env_vars,
         )
 
     def evaluate(
@@ -127,12 +181,13 @@ class LMEvaluationHarnessEvaluator(Evaluator):
             with VllmEnvironment(model) as env:
                 resolved_model = env.model
 
-                def _run_lm_eval(lm_eval_model_local: str, pretrained_args_local: str) -> None:
+                def _run_lm_eval(lm_eval_model_local: str, pretrained_args_local: str, tokenizer: str) -> None:
                     from lm_eval.evaluator import simple_evaluate
                     from lm_eval.loggers import EvaluationTracker, WandbLogger
                     from lm_eval.utils import simple_parse_args_string
 
                     for eval_task in evals:
+                        metadata = _lm_eval_metadata(resolved_model, eval_task, tokenizer=tokenizer)
                         result_filepath = os.path.join(
                             self.RESULTS_PATH, f"{eval_task.name}_{eval_task.num_fewshot}shot"
                         )
@@ -164,6 +219,7 @@ class LMEvaluationHarnessEvaluator(Evaluator):
                             limit=max_eval_instances if max_eval_instances is not None else None,
                             evaluation_tracker=evaluation_tracker,
                             log_samples=True,
+                            metadata=metadata,
                         )
                         if results is not None:
                             samples = results.pop("samples")
@@ -185,32 +241,20 @@ class LMEvaluationHarnessEvaluator(Evaluator):
                 if env.model_id is None:
                     raise RuntimeError("vLLM server did not report a model id.")
 
-                def _run_with_tokenizer(tokenizer: str | None) -> None:
+                def _run_with_tokenizer(tokenizer: str) -> None:
                     if resolved_model.apply_chat_template:
                         lm_eval_model_local = "local-chat-completions"
-                        pretrained_args_local = (
-                            f"model={env.model_id},"
-                            f"base_url={env.server_url}/chat/completions,"
-                            "tokenizer_backend=huggingface,"
-                            "tokenized_requests=False"
-                        )
                     else:
                         lm_eval_model_local = "local-completions"
-                        pretrained_args_local = (
-                            f"model={env.model_id},"
-                            f"base_url={env.server_url}/completions,"
-                            "tokenizer_backend=huggingface,"
-                            "tokenized_requests=False"
-                        )
-                    if tokenizer is not None:
-                        pretrained_args_local += f",tokenizer={tokenizer}"
-                    if resolved_model.engine_kwargs:
-                        for key, value in resolved_model.engine_kwargs.items():
-                            if key == "tokenizer":
-                                continue
-                            pretrained_args_local += f",{key}={value}"
 
-                    _run_lm_eval(lm_eval_model_local, pretrained_args_local)
+                    pretrained_args_local = _model_args_for_lm_eval(
+                        model=resolved_model,
+                        model_id=env.model_id,
+                        server_url=env.server_url,
+                        tokenizer=tokenizer,
+                        apply_chat_template=resolved_model.apply_chat_template,
+                    )
+                    _run_lm_eval(lm_eval_model_local, pretrained_args_local, tokenizer)
 
                 if isinstance(resolved_model.engine_kwargs.get("tokenizer"), str):
                     _run_with_tokenizer(resolved_model.engine_kwargs.get("tokenizer"))
@@ -226,7 +270,7 @@ class LMEvaluationHarnessEvaluator(Evaluator):
                             )
                         _run_with_tokenizer(staged_tokenizer_dir)
                 else:
-                    _run_with_tokenizer(None)
+                    _run_with_tokenizer(env.model_name_or_path)
 
                 return
 

--- a/lib/marin/src/marin/evaluation/run.py
+++ b/lib/marin/src/marin/evaluation/run.py
@@ -165,6 +165,7 @@ def _impute_model_config(config):
         generation_params=generation_params,
         apply_chat_template=config.apply_chat_template,
         base_eval_run_name=config.base_eval_run_name,
+        task_metadata=config.task_metadata,
     )
 
 

--- a/tests/evals/test_ruler_eval.py
+++ b/tests/evals/test_ruler_eval.py
@@ -1,0 +1,99 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from fray.cluster import ResourceConfig
+
+from experiments.evals.evals import default_ruler_eval
+from experiments.evals.task_configs import RULER_MAX_GENERATION_TOKENS, ruler_tasks_for_lengths
+from marin.evaluation.evaluation_config import EvalTaskConfig
+from marin.evaluation.evaluators.evaluator import ModelConfig
+from marin.evaluation.evaluators.lm_evaluation_harness_evaluator import (
+    _lm_eval_metadata,
+    _model_args_for_lm_eval,
+)
+
+
+def test_ruler_tasks_for_lengths_sets_task_metadata():
+    tasks = ruler_tasks_for_lengths((4096, 32768), task_names=("niah_single_1", "ruler_vt"))
+
+    assert tasks == (
+        EvalTaskConfig(
+            name="niah_single_1",
+            num_fewshot=0,
+            task_alias="niah_single_1",
+            task_kwargs={"max_seq_lengths": (4096, 32768)},
+        ),
+        EvalTaskConfig(
+            name="ruler_vt",
+            num_fewshot=0,
+            task_alias="ruler_vt",
+            task_kwargs={"max_seq_lengths": (4096, 32768)},
+        ),
+    )
+
+
+def test_default_ruler_eval_sets_long_context_model_args():
+    step = default_ruler_eval(
+        "gs://marin-us-central2/checkpoints/tootsie-8b-giraffe-32k/hf/step-2999",
+        lengths=(4096, 32768),
+        task_names=("niah_single_1",),
+        tokenizer="stanford-crfm/marin-tokenizer",
+        resource_config=ResourceConfig.with_cpu(cpu=1),
+        apply_chat_template=True,
+        discover_latest_checkpoint=False,
+    )
+
+    config = step.config
+
+    assert config.evaluator == "lm_evaluation_harness"
+    assert config.apply_chat_template is True
+    assert config.discover_latest_checkpoint is False
+    assert config.task_metadata == {"max_seq_lengths": (4096, 32768)}
+    assert config.engine_kwargs["tokenizer"] == "stanford-crfm/marin-tokenizer"
+    assert config.engine_kwargs["max_model_len"] > 32768
+    assert config.engine_kwargs["max_length"] == config.engine_kwargs["max_model_len"]
+    assert config.engine_kwargs["max_gen_toks"] == RULER_MAX_GENERATION_TOKENS
+
+
+def test_lm_eval_metadata_merges_tokenizer_and_task_kwargs():
+    model = ModelConfig(
+        name="test-model",
+        path=None,
+        engine_kwargs={},
+        task_metadata={"max_seq_lengths": (4096,)},
+    )
+    task = EvalTaskConfig(
+        name="niah_single_1",
+        num_fewshot=0,
+        task_kwargs={"max_seq_lengths": (4096, 8192)},
+    )
+
+    metadata = _lm_eval_metadata(model, task, tokenizer="/tmp/tokenizer")
+
+    assert metadata == {
+        "max_seq_lengths": (4096, 8192),
+        "pretrained": "/tmp/tokenizer",
+        "tokenizer": "/tmp/tokenizer",
+    }
+
+
+def test_lm_eval_model_args_include_length_and_tokenizer():
+    model = ModelConfig(
+        name="test-model",
+        path=None,
+        engine_kwargs={"max_length": 32768, "max_model_len": 32768, "tokenizer": "ignored"},
+    )
+
+    args = _model_args_for_lm_eval(
+        model=model,
+        model_id="served-model",
+        server_url="http://127.0.0.1:8000/v1",
+        tokenizer="/tmp/tokenizer",
+        apply_chat_template=False,
+    )
+
+    assert args.startswith("model=served-model,base_url=http://127.0.0.1:8000/v1/completions")
+    assert "tokenizer=/tmp/tokenizer" in args
+    assert "max_length=32768" in args
+    assert "max_model_len=32768" in args
+    assert "tokenized_requests=False" in args

--- a/uv.lock
+++ b/uv.lock
@@ -4649,6 +4649,8 @@ dedup = [
 ]
 eval = [
     { name = "lm-eval", extra = ["api", "math"] },
+    { name = "nltk" },
+    { name = "wonderwords" },
 ]
 evalchemy = [
     { name = "antlr4-python3-runtime" },
@@ -4801,6 +4803,7 @@ requires-dist = [
     { name = "marin-zephyr", editable = "lib/zephyr" },
     { name = "markdownify", specifier = "==0.12.1" },
     { name = "multiprocess", specifier = "==0.70.16" },
+    { name = "nltk", marker = "extra == 'eval'", specifier = ">=3.9.1" },
     { name = "numpy" },
     { name = "openai" },
     { name = "pandas", specifier = ">=2.0" },
@@ -4834,6 +4837,7 @@ requires-dist = [
     { name = "vllm-tpu", marker = "extra == 'vllm'", specifier = "==0.13.2.post6" },
     { name = "wandb" },
     { name = "warcio" },
+    { name = "wonderwords", marker = "extra == 'eval'" },
 ]
 provides-extras = ["gpu", "tpu", "cpu", "rl", "eval", "evalchemy", "vizier", "vllm", "harbor", "dedup", "math"]
 
@@ -12193,6 +12197,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
+]
+
+[[package]]
+name = "wonderwords"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/23/e144fc3dfabb845dc1d94c45315d97b308cf75a664e3db3a89aeb1cb505d/wonderwords-3.0.1.tar.gz", hash = "sha256:5ee43ab6f13823a857a7c3d58c7b4db6a1350bd3aa5f914ed379ad49042a1c36", size = 73339, upload-time = "2025-10-30T17:30:44.231Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/75/855c2062d28b8e9247939f8262fb2f4ff3b12a49e4bab9fd1ba16cc5df82/wonderwords-3.0.1-py3-none-any.whl", hash = "sha256:4dd66deb6a76ca9e0b0422d1d3e111f9b910d7c16922d42de733ee8def98f8d0", size = 51658, upload-time = "2025-10-30T17:30:42.785Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add explicit RULER/NIAH task configs, pass RULER metadata and tokenizer settings through the vLLM lm-eval path, and add an exp2062 runner for the warmstart and phase checkpoints. Also lazy-load optional Levanter lm-eval runtime imports and update the Fray Iris constraint test for the current Constraint values API.

Fixes #2064