### PR TITLE
canary-ferry: move to prod marin cluster, fix diagnostics on timeout

### DIFF
--- a/.github/workflows/marin-canary-ferry.yaml
+++ b/.github/workflows/marin-canary-ferry.yaml
@@ -32,7 +32,7 @@ jobs:
       CANARY_MAX_WALL_CLOCK: "7200"
       WANDB_ENTITY: marin-community
       WANDB_PROJECT: marin
-      IRIS_CONFIG: lib/iris/examples/marin-dev.yaml
+      IRIS_CONFIG: lib/iris/examples/marin.yaml
       IRIS_CONTROLLER_SERVICE_ACCOUNT: iris-controller@hai-gcp-models.iam.gserviceaccount.com
 
     steps:
@@ -79,6 +79,7 @@ jobs:
           JOB_ID=$(.venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
             job run --no-wait \
             --memory=2G --disk=4G --cpu=1 --extra=cpu \
+            --priority production \
             --reserve v5p-8 \
             -e RUN_ID "$RUN_ID" \
             -e CANARY_ACCELERATOR "$CANARY_ACCELERATOR" \
@@ -145,18 +146,74 @@ jobs:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
 
       - name: Capture failure diagnostics
-        if: failure()
+        if: failure() || cancelled()
+        env:
+          JOB_ID: ${{ steps.submit.outputs.job_id }}
+          DIAG_DIR: ${{ github.workspace }}/canary-diagnostics
+          PROJECT: ${{ secrets.GCP_PROJECT_ID }}
+          CONTROLLER_LABEL: iris-marin-controller
         run: |
-          echo "=== Controller logs ==="
+          mkdir -p "$DIAG_DIR"
+
+          echo "=== Controller process logs ==="
           .venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
-            process logs --max-lines=200 || true
-          echo "=== Job list ==="
+            process logs --max-lines=500 > "$DIAG_DIR/controller-process.log" 2>&1 || true
+
+          echo "=== Job tree for $JOB_ID ==="
           .venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
-            job list --json 2>/dev/null | jq '.[0:5]' || true
+            job list --json --prefix "$JOB_ID" > "$DIAG_DIR/job-tree.json" 2>&1 || true
+          jq '.' "$DIAG_DIR/job-tree.json" || true
+
+          # SSH to the controller VM: grab docker logs + SQLite rows for this job.
+          # Matches the approach in iris-cloud-smoke-gcp.yaml.
+          gcloud compute instances list \
+            --project="$PROJECT" \
+            --filter="labels.${CONTROLLER_LABEL}=true" \
+            --format="csv[no-heading](name,zone)" 2>/dev/null \
+          | while IFS=, read -r name zone; do
+              [ -z "$name" ] && continue
+              echo "Fetching host logs from controller $name ($zone)"
+              out="$DIAG_DIR/controller-${name}"
+              gcloud compute ssh "$name" \
+                --project="$PROJECT" --zone="$zone" \
+                --impersonate-service-account="$IRIS_CONTROLLER_SERVICE_ACCOUNT" \
+                --ssh-key-file ~/.ssh/google_compute_engine \
+                --quiet \
+                --command "
+                set +e
+                echo '=== docker ps -a ==='
+                sudo docker ps -a
+                echo '=== docker logs iris-controller (last 5000 lines) ==='
+                sudo docker logs --timestamps --tail 5000 iris-controller 2>&1
+                echo '=== jobs+tasks for $JOB_ID ==='
+                sudo docker exec iris-controller python3 -c \"
+          import sqlite3, json
+          c = sqlite3.connect('/var/cache/iris/controller/db/controller.sqlite3')
+          c.row_factory = sqlite3.Row
+          prefix = '$JOB_ID'
+          rows = list(c.execute('SELECT * FROM jobs WHERE job_id = ? OR parent_job_id LIKE ? OR job_id LIKE ?', (prefix, prefix + '%', prefix + '%')))
+          for r in rows: print('JOB', json.dumps(dict(r), default=str))
+          for r in rows:
+              for t in c.execute('SELECT * FROM tasks WHERE job_id = ?', (r['job_id'],)):
+                  print('TASK', json.dumps(dict(t), default=str))
+                  for a in c.execute('SELECT * FROM task_attempts WHERE task_id = ?', (t['task_id'],)):
+                      print('ATTEMPT', json.dumps(dict(a), default=str))
+          \"
+              " > \"\${out}.log\" 2>&1 || echo \"ssh to \$name failed (see \${out}.log)\"
+            done
+
+      - name: Upload diagnostics
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: canary-diagnostics
+          path: canary-diagnostics/
+          retention-days: 14
+          if-no-files-found: ignore
 
       - name: Claude triage
         id: claude_triage
-        if: failure() && github.event_name == 'schedule'
+        if: (failure() || cancelled()) && github.event_name == 'schedule'
         uses: anthropics/claude-code-action@v1
         timeout-minutes: 30
         with:
@@ -178,7 +235,7 @@ jobs:
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Notify Slack on failure
-        if: failure() && github.event_name == 'schedule'
+        if: (failure() || cancelled()) && github.event_name == 'schedule'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           FALLBACK_TEXT: ":red_circle: *TPU Canary failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## Summary
- Switch canary ferry to the production `marin` cluster (`lib/iris/examples/marin.yaml`) and pass `--priority production` to `iris job run`.
- Gate `Capture failure diagnostics`, `Claude triage`, and `Notify Slack on failure` on `failure() || cancelled()` so GHA-timeout cancels still produce evidence.
- Expand diagnostics to SSH the controller VM (label `iris-marin-controller=true`), capture `docker logs iris-controller`, and dump `jobs` / `tasks` / `task_attempts` rows for the canary's `JOB_ID` directly out of `/var/cache/iris/controller/db/controller.sqlite3`. Upload the bundle as the `canary-diagnostics` artifact. Mirrors the pattern in `.github/workflows/iris-cloud-smoke-gcp.yaml`.

## Why
Run [24332480667](https://github.com/marin-community/marin/actions/runs/24332480667) looked like CI "hung," but the controller SQLite showed the runner job `/runner/iris-run-job-20260413-080356` submitted at 08:03:58 UTC, was granted its v5p-8 reservation at **14:09:21** UTC (~6h 5m queue wait in marin-dev), and finished `SUCCEEDED` at 16:16:11. GHA's `timeout-minutes: 240` killed the job during the reservation wait at 12:03. Because the step ended `cancelled` rather than `failure`, the diagnostics / triage / Slack steps were all skipped and there was nothing to look at.

Prod cluster + `--priority production` should keep canary reservation latency inside the 4h budget; the `cancelled()` gate + expanded diagnostics ensure we still get controller logs the next time it does overrun.

## Test plan
- [ ] Trigger `workflow_dispatch` against this branch and confirm the canary submits against `marin` (not `marin-dev`) and completes within the timeout.
- [ ] Force-fail a run (e.g. pass a tiny `target_tokens`) to confirm diagnostics artifacts upload.