### PR TITLE
status-page: add cw ferry, iris.oa.dev links, auto-deploy

### DIFF
--- a/.github/workflows/marin-infra-dashboard.yaml
+++ b/.github/workflows/marin-infra-dashboard.yaml
@@ -58,3 +58,28 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  deploy:
+    needs: [changes, build]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: marin-infra-dashboard-deploy
+      cancel-in-progress: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Deploy to Cloud Run
+        run: ./infra/status-page/deploy.sh

--- a/.github/workflows/marin-infra-dashboard.yaml
+++ b/.github/workflows/marin-infra-dashboard.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
+          credentials_json: ${{ secrets.MARIN_STATUS_PAGE_DEPLOY_SA_KEY }}
 
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/marin-infra-dashboard.yaml
+++ b/.github/workflows/marin-infra-dashboard.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.MARIN_STATUS_PAGE_DEPLOY_SA_KEY }}
+          credentials_json: ${{ secrets.MARIN_CD_CLOUD_RUN_SA_KEY }}
 
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/infra/status-page/deploy.sh
+++ b/infra/status-page/deploy.sh
@@ -70,6 +70,44 @@ echo -n "<paste-github-token>" | gcloud secrets create ${GITHUB_TOKEN_SECRET} \\
 #    infra/iris-iap-proxy/deploy.sh marin --setup. Otherwise see that
 #    script for the one-time project-level steps.
 
+# 3a. Deploy service account (used by the GitHub Actions deploy job).
+#     Separate from the runtime SA above so the CI key's blast radius is
+#     limited to "can deploy this Cloud Run service". Export its key and
+#     store as GitHub Actions secret MARIN_STATUS_PAGE_DEPLOY_SA_KEY.
+DEPLOY_SA=marin-status-page-deploy
+DEPLOY_SA_EMAIL=\${DEPLOY_SA}@${PROJECT}.iam.gserviceaccount.com
+
+gcloud iam service-accounts create \${DEPLOY_SA} \\
+  --project=${PROJECT} \\
+  --display-name="Marin Infra Dashboard CI Deployer"
+
+gcloud projects add-iam-policy-binding ${PROJECT} \\
+  --member="serviceAccount:\${DEPLOY_SA_EMAIL}" \\
+  --role="roles/run.admin"
+
+gcloud projects add-iam-policy-binding ${PROJECT} \\
+  --member="serviceAccount:\${DEPLOY_SA_EMAIL}" \\
+  --role="roles/cloudbuild.builds.editor"
+
+gcloud projects add-iam-policy-binding ${PROJECT} \\
+  --member="serviceAccount:\${DEPLOY_SA_EMAIL}" \\
+  --role="roles/storage.objectAdmin"
+
+# Let the deploy SA act as the runtime SA.
+gcloud iam service-accounts add-iam-policy-binding ${SA_EMAIL} \\
+  --project=${PROJECT} \\
+  --member="serviceAccount:\${DEPLOY_SA_EMAIL}" \\
+  --role="roles/iam.serviceAccountUser"
+
+# Export a JSON key and store as GitHub Actions repo secret
+# MARIN_STATUS_PAGE_DEPLOY_SA_KEY.
+gcloud iam service-accounts keys create /tmp/\${DEPLOY_SA}.json \\
+  --project=${PROJECT} \\
+  --iam-account=\${DEPLOY_SA_EMAIL}
+gh secret set MARIN_STATUS_PAGE_DEPLOY_SA_KEY \\
+  --repo marin-community/marin < /tmp/\${DEPLOY_SA}.json
+rm /tmp/\${DEPLOY_SA}.json
+
 # 4. Deploy (use deploy.sh without --setup)
 
 # 5. Grant the IAP service agent permission to invoke this Cloud Run service.

--- a/infra/status-page/deploy.sh
+++ b/infra/status-page/deploy.sh
@@ -70,44 +70,6 @@ echo -n "<paste-github-token>" | gcloud secrets create ${GITHUB_TOKEN_SECRET} \\
 #    infra/iris-iap-proxy/deploy.sh marin --setup. Otherwise see that
 #    script for the one-time project-level steps.
 
-# 3a. Deploy service account (used by the GitHub Actions deploy job).
-#     Separate from the runtime SA above so the CI key's blast radius is
-#     limited to "can deploy this Cloud Run service". Export its key and
-#     store as GitHub Actions secret MARIN_STATUS_PAGE_DEPLOY_SA_KEY.
-DEPLOY_SA=marin-status-page-deploy
-DEPLOY_SA_EMAIL=\${DEPLOY_SA}@${PROJECT}.iam.gserviceaccount.com
-
-gcloud iam service-accounts create \${DEPLOY_SA} \\
-  --project=${PROJECT} \\
-  --display-name="Marin Infra Dashboard CI Deployer"
-
-gcloud projects add-iam-policy-binding ${PROJECT} \\
-  --member="serviceAccount:\${DEPLOY_SA_EMAIL}" \\
-  --role="roles/run.admin"
-
-gcloud projects add-iam-policy-binding ${PROJECT} \\
-  --member="serviceAccount:\${DEPLOY_SA_EMAIL}" \\
-  --role="roles/cloudbuild.builds.editor"
-
-gcloud projects add-iam-policy-binding ${PROJECT} \\
-  --member="serviceAccount:\${DEPLOY_SA_EMAIL}" \\
-  --role="roles/storage.objectAdmin"
-
-# Let the deploy SA act as the runtime SA.
-gcloud iam service-accounts add-iam-policy-binding ${SA_EMAIL} \\
-  --project=${PROJECT} \\
-  --member="serviceAccount:\${DEPLOY_SA_EMAIL}" \\
-  --role="roles/iam.serviceAccountUser"
-
-# Export a JSON key and store as GitHub Actions repo secret
-# MARIN_STATUS_PAGE_DEPLOY_SA_KEY.
-gcloud iam service-accounts keys create /tmp/\${DEPLOY_SA}.json \\
-  --project=${PROJECT} \\
-  --iam-account=\${DEPLOY_SA_EMAIL}
-gh secret set MARIN_STATUS_PAGE_DEPLOY_SA_KEY \\
-  --repo marin-community/marin < /tmp/\${DEPLOY_SA}.json
-rm /tmp/\${DEPLOY_SA}.json
-
 # 4. Deploy (use deploy.sh without --setup)
 
 # 5. Grant the IAP service agent permission to invoke this Cloud Run service.

--- a/infra/status-page/server/sources/githubActions.ts
+++ b/infra/status-page/server/sources/githubActions.ts
@@ -11,6 +11,7 @@ import { githubAuthHeaders, REPO } from "./github.js";
 
 export const FERRY_WORKFLOWS = [
   { name: "Canary ferry", file: "marin-canary-ferry.yaml" },
+  { name: "CW ferry", file: "marin-canary-ferry-cw.yaml" },
   { name: "Datakit ferry", file: "marin-datakit-smoke.yaml" },
 ] as const;
 

--- a/infra/status-page/web/src/components/IrisPanel.tsx
+++ b/infra/status-page/web/src/components/IrisPanel.tsx
@@ -33,6 +33,14 @@ export function IrisPanel() {
             {data.controllerUrl && (
               <span className="font-mono text-xs text-slate-500">· {data.controllerUrl}</span>
             )}
+            <a
+              href="https://iris.oa.dev"
+              target="_blank"
+              rel="noreferrer"
+              className="text-xs text-slate-500 hover:text-emerald-300"
+            >
+              · iris.oa.dev ↗
+            </a>
           </>
         )}
         <span className="ml-auto text-xs text-slate-500">

--- a/infra/status-page/web/src/components/JobsPanel.tsx
+++ b/infra/status-page/web/src/components/JobsPanel.tsx
@@ -79,10 +79,20 @@ export function JobsPanel() {
 
   return (
     <div>
-      <div className="mb-2 flex items-baseline justify-between">
-        <h3 className="text-sm font-semibold uppercase tracking-wider text-slate-400">
-          Jobs
-        </h3>
+      <div className="mb-2 flex items-baseline justify-between gap-3">
+        <div className="flex items-baseline gap-3">
+          <h3 className="text-sm font-semibold uppercase tracking-wider text-slate-400">
+            Jobs
+          </h3>
+          <a
+            href="https://iris.oa.dev"
+            target="_blank"
+            rel="noreferrer"
+            className="text-xs text-slate-500 hover:text-emerald-300"
+          >
+            iris.oa.dev ↗
+          </a>
+        </div>
         <span className="text-xs text-slate-500">root jobs only</span>
       </div>
       <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">


### PR DESCRIPTION
* add `CW ferry` (`marin-canary-ferry-cw.yaml`) to `FERRY_WORKFLOWS` so the Ferries panel shows a third card next to canary + datakit
* add `iris.oa.dev ↗` link next to the Jobs subsection header
* add `iris.oa.dev ↗` link next to the controller URL in the Iris section header
* new `deploy` job in `.github/workflows/marin-infra-dashboard.yaml`
  * runs only on push to `main` after `build` passes, gated by the existing `dorny/paths-filter` on `infra/status-page/**`
  * own concurrency group, `cancel-in-progress: false` so rapid merges don't kill an in-flight deploy
  * shells out to `infra/status-page/deploy.sh` (source-based `gcloud beta run deploy`)
  * authenticates with dedicated repo secret `MARIN_CD_CLOUD_RUN_SA_KEY`