### PR TITLE
status-page: install gcloud beta component in deploy job

### DIFF
--- a/.github/workflows/marin-infra-dashboard.yaml
+++ b/.github/workflows/marin-infra-dashboard.yaml
@@ -80,6 +80,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
+          install_components: beta
 
       - name: Deploy to Cloud Run
         run: ./infra/status-page/deploy.sh


### PR DESCRIPTION
* follow-up to #4745
* deploy job fails with `ERROR: (gcloud) The component [beta] requires the latest version of gcloud.` because `deploy.sh` runs `gcloud beta run deploy --iap`
* pass `install_components: beta` to `google-github-actions/setup-gcloud` so the beta surface is present before `deploy.sh` runs