### PR TITLE
iris-iap-proxy: auto-deploy to cloud run on merge to main

### DIFF
--- a/.github/workflows/iris-iap-proxy.yaml
+++ b/.github/workflows/iris-iap-proxy.yaml
@@ -3,7 +3,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'infra/iris-iap-proxy/**'
+      - '.github/workflows/iris-iap-proxy.yaml'
   pull_request:
+    paths:
+      - 'infra/iris-iap-proxy/**'
+      - '.github/workflows/iris-iap-proxy.yaml'
 
 
 concurrency:
@@ -11,26 +17,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      should_run: ${{ steps.filter.outputs.relevant }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            relevant:
-              - 'infra/iris-iap-proxy/**'
-              - '.github/workflows/iris-iap-proxy.yaml'
-
   build:
-    needs: changes
-    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -49,8 +36,8 @@ jobs:
           cache-to: type=gha,mode=max
 
   deploy:
-    needs: [changes, build]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.should_run == 'true'
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:

--- a/.github/workflows/iris-iap-proxy.yaml
+++ b/.github/workflows/iris-iap-proxy.yaml
@@ -7,8 +7,8 @@ on:
 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   changes:

--- a/.github/workflows/iris-iap-proxy.yaml
+++ b/.github/workflows/iris-iap-proxy.yaml
@@ -1,4 +1,4 @@
-name: Iris - IAP Proxy Deploy
+name: Iris - IAP Proxy
 on:
   push:
     branches:

--- a/.github/workflows/iris-iap-proxy.yaml
+++ b/.github/workflows/iris-iap-proxy.yaml
@@ -28,8 +28,28 @@ jobs:
               - 'infra/iris-iap-proxy/**'
               - '.github/workflows/iris-iap-proxy.yaml'
 
-  deploy:
+  build:
     needs: changes
+    if: needs.changes.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build container image
+        uses: docker/build-push-action@v6
+        with:
+          context: infra/iris-iap-proxy
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: [changes, build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/iris-iap-proxy.yaml
+++ b/.github/workflows/iris-iap-proxy.yaml
@@ -1,0 +1,59 @@
+name: Iris - IAP Proxy Deploy
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'infra/iris-iap-proxy/**'
+              - '.github/workflows/iris-iap-proxy.yaml'
+
+  deploy:
+    needs: changes
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        cluster: [marin, marin-dev]
+    concurrency:
+      group: iris-iap-proxy-deploy-${{ matrix.cluster }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.MARIN_CD_CLOUD_RUN_SA_KEY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          install_components: beta
+
+      - name: Deploy to Cloud Run
+        run: ./infra/iris-iap-proxy/deploy.sh ${{ matrix.cluster }}

--- a/.github/workflows/marin-infra-dashboard.yaml
+++ b/.github/workflows/marin-infra-dashboard.yaml
@@ -7,8 +7,8 @@ on:
 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   changes:

--- a/.github/workflows/marin-infra-dashboard.yaml
+++ b/.github/workflows/marin-infra-dashboard.yaml
@@ -3,7 +3,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'infra/status-page/**'
+      - '.github/workflows/marin-infra-dashboard.yaml'
   pull_request:
+    paths:
+      - 'infra/status-page/**'
+      - '.github/workflows/marin-infra-dashboard.yaml'
 
 
 concurrency:
@@ -11,26 +17,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      should_run: ${{ steps.filter.outputs.relevant }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            relevant:
-              - 'infra/status-page/**'
-              - '.github/workflows/marin-infra-dashboard.yaml'
-
   build:
-    needs: changes
-    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
@@ -60,8 +47,8 @@ jobs:
         run: npm run build
 
   deploy:
-    needs: [changes, build]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.should_run == 'true'
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     concurrency:

--- a/infra/iris-iap-proxy/deploy.sh
+++ b/infra/iris-iap-proxy/deploy.sh
@@ -112,7 +112,7 @@ gcloud beta run deploy "${SERVICE}" \
   --vpc-egress=private-ranges-only \
   --set-env-vars="GCP_PROJECT=${PROJECT},CONTROLLER_ZONE=${ZONE},CONTROLLER_LABEL=${CONTROLLER_LABEL},CONTROLLER_PORT=10000" \
   --timeout=300 \
-  --memory=512Mi \
+  --memory=1Gi \
   --cpu=1 \
   --min-instances=1 \
   --max-instances=1 \

--- a/infra/status-page/deploy.sh
+++ b/infra/status-page/deploy.sh
@@ -111,7 +111,7 @@ gcloud beta run deploy "${SERVICE}" \
   --set-env-vars="GCP_PROJECT=${PROJECT},CONTROLLER_ZONE=${ZONE},CONTROLLER_LABEL=${CONTROLLER_LABEL},CONTROLLER_PORT=${CONTROLLER_PORT},CLUSTER_NAME=marin" \
   --set-secrets="GITHUB_TOKEN=${GITHUB_TOKEN_SECRET}:latest" \
   --timeout=60 \
-  --memory=512Mi \
+  --memory=1Gi \
   --cpu=1 \
   --min-instances=1 \
   --max-instances=1 \


### PR DESCRIPTION
* new `.github/workflows/iris-iap-proxy.yaml` workflow
  * `changes` job — `dorny/paths-filter` on `infra/iris-iap-proxy/**` and the workflow file itself
  * `build` job — `docker build` of `infra/iris-iap-proxy/Dockerfile` with gha cache, runs on PRs too so regressions are caught pre-merge
  * `deploy` job — runs only on push to `main` after `build` passes
    * matrix over `marin` and `marin-dev`, one concurrency group per cluster, `cancel-in-progress: false`
    * shells out to `infra/iris-iap-proxy/deploy.sh <cluster>` (source-based `gcloud beta run deploy`)
    * reuses the `MARIN_CD_CLOUD_RUN_SA_KEY` secret introduced by #4745
    * `install_components: beta` per #4748