### PR TITLE
Skip e2e/integration tests by default and gracefully skip gated tokenizer test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,5 +223,7 @@ markers = [
 ]
 testpaths = ["tests", "experiments"]
 
-# Don't run TPU or slow tests by default
-addopts = "--session-timeout=480 -m 'not tpu_ci and not slow'"
+# Don't run TPU, slow, or integration tests by default. Integration tests
+# require external infrastructure (Iris cluster, GCS, gated HF repos, etc.)
+# and are run from dedicated CI workflows.
+addopts = "--session-timeout=480 -m 'not tpu_ci and not slow and not integration'"

--- a/tests/test_integration_test.py
+++ b/tests/test_integration_test.py
@@ -8,6 +8,7 @@ import tempfile
 import pytest
 
 
+@pytest.mark.integration
 @pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip this test in CI, since we run it as a separate worflow.")
 def test_integration_test_run():
     MARIN_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))

--- a/tests/test_marin_tokenizer.py
+++ b/tests/test_marin_tokenizer.py
@@ -1,7 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import tempfile
 
 import pytest
@@ -16,13 +15,16 @@ from experiments.create_marin_tokenizer import (
 
 @pytest.fixture
 def marin_tokenizer():
-    """Fixture that provides a configured marin tokenizer for testing."""
+    """Fixture that provides a configured marin tokenizer for testing.
+
+    The base llama3 tokenizer lives in a gated Hugging Face repo. When the
+    current environment lacks credentials (or network access), skip rather
+    than fail - this test exercises our tokenizer surgery, not HF auth.
+    """
     try:
         llama3_tokenizer = load_llama3_tokenizer()
     except Exception as e:
-        if os.getenv("CI", False) in ["true", "1"]:
-            pytest.skip("Llama 3 tokenizer repository is gated")
-        raise e
+        pytest.skip(f"Llama 3 tokenizer is unavailable (gated repo or no network): {e}")
     tokenizer = create_marin_tokenizer(llama3_tokenizer)
 
     # Roundtrip write-read to ensure consistency


### PR DESCRIPTION
Fixes #4741.

## Summary
- Add `not integration` to pytest default `addopts` so a plain `uv run pytest` deselects the integration runner.
- Mark `test_integration_test_run` with `@pytest.mark.integration`.
- Always skip `test_marin_tokenizer.py` when the gated llama3 tokenizer cannot be downloaded, not just on CI.