### PR TITLE
consolidate: map-side merge join + flat kwargs api

### DIFF
--- a/experiments/ferries/datakit_ferry.py
+++ b/experiments/ferries/datakit_ferry.py
@@ -21,7 +21,6 @@ from marin.datakit.normalize import normalize_step
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from marin.processing.classification.consolidate import (
-    ConsolidateConfig,
     FilterConfig,
     FilterType,
     consolidate,
@@ -76,21 +75,19 @@ def build_steps(run_id: str) -> list[StepSpec]:
         name="datakit-smoke/consolidate",
         deps=[normalized, deduped],
         fn=lambda output_path: consolidate(
-            ConsolidateConfig(
-                input_path=normalized.output_path,
-                output_path=output_path,
-                filetype="parquet",
-                filters=[
-                    FilterConfig(
-                        type=FilterType.REMOVE_DOC,
-                        attribute_path=f"{deduped.output_path}/data",
-                        name="dup_doc",
-                        attribute_filetype="parquet",
-                        keep_if_missing=True,
-                    ),
-                ],
-                worker_resources=ResourceConfig(cpu=1, ram="8g"),
-            )
+            input_path=normalized.output_path,
+            output_path=output_path,
+            filetype="parquet",
+            filters=[
+                FilterConfig(
+                    type=FilterType.REMOVE_DOC,
+                    attribute_path=f"{deduped.output_path}/data",
+                    name="dup_doc",
+                    attribute_filetype="parquet",
+                    keep_if_missing=True,
+                ),
+            ],
+            worker_resources=ResourceConfig(cpu=1, ram="8g"),
         ),
         override_output_path=f"{base}/consolidate",
     )

--- a/lib/marin/pyproject.toml
+++ b/lib/marin/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "braceexpand",
     "cryptography>=45",
     "datasets<4.0.0",
-    "ddsketch",
     "deepdiff",
     "draccus>=0.11.5",
     "fasteners>=0.19",

--- a/lib/marin/src/marin/processing/classification/README.md
+++ b/lib/marin/src/marin/processing/classification/README.md
@@ -23,27 +23,5 @@ uv run python -m marin.processing.classification.decon \
 
 [`consolidate.py`](./consolidate.py) consumes attribute files and filters or rewrites documents. Supported filter types:
 
-- `classify`: keep or reject documents based on attribute scores
 - `remove_spans`: remove text spans such as duplicate paragraphs
 - `remove_docs`: drop whole documents when an attribute marks them as duplicates
-
-Example:
-
-```bash
-uv run python -m marin.processing.classification.consolidate \
-  --config_path lib/marin/src/marin/processing/classification/config/quickstart_consolidate_fasttext.yaml
-```
-
-Example `classify` filter:
-
-```yaml
-input_path: "gs://marin-us-central2/documents/hello_world_fw/v1.0/quickstart/"
-output_path: "gs://marin-us-central2/documents/hello_world_fw/v1.0/quickstart_fasttext_only/"
-
-filters:
-  - type: "classify"
-    attribute_path: "gs://marin-us-central2/attributes/hello_world_fw/v1.0/quickstart_olmo_fasttext/"
-    name: "olmo-fasttext-quality"
-    label: "__label__hq"
-    lower_threshold: 0.1
-```

--- a/lib/marin/src/marin/processing/classification/config/quickstart_consolidate_fasttext.yaml
+++ b/lib/marin/src/marin/processing/classification/config/quickstart_consolidate_fasttext.yaml
@@ -1,9 +1,0 @@
-input_path: "gs://marin-us-central2/documents/hello_world_fw/v1.0/quickstart/"
-output_path: "gs://marin-us-central2/documents/hello_world_fw/v1.0/quickstart_fasttext_only/"
-
-filters:
-  - type: "classify"
-    attribute_path: "gs://marin-us-central2/attributes/hello_world_fw/v1.0/quickstart_olmo_fasttext/"
-    name: "olmo-fasttext-quality"
-    label: "__label__hq"
-    lower_threshold: 0.1

--- a/lib/marin/src/marin/processing/classification/consolidate.py
+++ b/lib/marin/src/marin/processing/classification/consolidate.py
@@ -4,11 +4,16 @@
 """
 Consolidate takes a set of documents with corresponding attributes and writes
 out a subset of the documents based on various filters defined with respect to
-the attributes.  Handles two cases:
+the attributes.  Handles three cases:
 - Quality filtering produces attributes (e.g., fasttext-quality) with labels
   (e.g., __label__hq), filter on threshold.
 - Span removal produces attributes (e.g., duplicate_text spans). Remove text spans.
 - Document removal via attribute produced by deduplication.
+
+Joins documents with their attribute files via a streaming map-side merge:
+the datakit convention guarantees that attribute files share the input file
+partitioning (1:1 file pairing, sorted by id), so each shard can be processed
+independently with constant memory per filter.
 """
 
 import logging
@@ -72,26 +77,6 @@ class FilterConfig:
     """If True, keep docs that have no attribute entry. If False (default), reject them."""
 
 
-@dataclass(frozen=True)
-class ConsolidateConfig:
-    """Config for Consolidation operation on Marin data."""
-
-    input_path: str
-    """The input path to a directory (recursively) containing documents."""
-
-    output_path: str
-    """The output path to save the filtered (consolidated) data."""
-
-    filters: list[FilterConfig]
-    """List of filters to apply to the documents."""
-
-    filetype: str = "jsonl.gz"
-    """The filetype of the input data."""
-
-    worker_resources: ResourceConfig | None = None
-    """Resource config per Zephyr worker. Uses Zephyr defaults (1 CPU, 1g RAM) when None."""
-
-
 # Dictionary-based navigation guide for extracting IDs from different corpus types
 CORPUS_TYPE_TO_ID_GUIDE = {
     "default": {"key": "id"},  # Direct key access
@@ -127,8 +112,8 @@ def _is_valid(doc: dict, filt: FilterConfig, attributes: dict) -> bool:
 
 def _remove_spans_from_doc(doc: dict, filt: FilterConfig, attributes: dict) -> dict:
     def _remove_spans(text: str, spans: list[list[int]]) -> str:
-        """
-        Return `text` with `spans` removed.
+        """Return ``text`` with ``spans`` removed.
+
         Example: text = "hello", spans = [[1, 4]], returns "ho"
         """
         # Sort spans in reverse order to avoid index shifting
@@ -207,19 +192,20 @@ def _compute_percentile_threshold(
     return threshold
 
 
-def calculate_percentile_thresholds(config: ConsolidateConfig) -> list[FilterConfig]:
-    """Resolve keep_fraction filters to lower_threshold using percentile calculation.
+def calculate_percentile_thresholds(
+    *,
+    input_path: str,
+    filters: list[FilterConfig],
+    filetype: str = "jsonl.gz",
+) -> list[FilterConfig]:
+    """Resolve ``keep_fraction`` filters to ``lower_threshold`` via percentile calculation.
 
-    Args:
-        config: Consolidation configuration
-
-    Returns:
-        Updated filters with percentile thresholds resolved
+    Returns a new list of filters with percentile-based thresholds resolved.
     """
     updated_filters = []
-    input_paths = fsspec_glob(os.path.join(config.input_path, f"**/*.{config.filetype}"))
+    input_paths = fsspec_glob(os.path.join(input_path, f"**/*.{filetype}"))
 
-    for filt in config.filters:
+    for filt in filters:
         # Validate threshold configuration
         if filt.keep_fraction is not None and filt.lower_threshold is not None:
             raise ValueError("Cannot specify both keep_fraction and lower_threshold. Please specify only one.")
@@ -238,16 +224,9 @@ def calculate_percentile_thresholds(config: ConsolidateConfig) -> list[FilterCon
             updated_filters.append(filt)
             continue
 
-        # Build list of attribute file paths
-        rebase_kwargs = {}
-        if filt.attribute_filetype:
-            rebase_kwargs["new_extension"] = f".{filt.attribute_filetype}"
-            rebase_kwargs["old_extension"] = f".{config.filetype}"
-        attr_paths = [
-            rebase_file_path(config.input_path, inp, filt.attribute_path, **rebase_kwargs) for inp in input_paths
-        ]
+        attr_paths = [_resolve_attribute_path(input_path, inp, filt, filetype) for inp in input_paths]
+        attr_paths = [p for p in attr_paths if p is not None]
 
-        # Compute threshold using reduction
         threshold = _compute_percentile_threshold(attr_paths, filt.name, filt.label, filt.keep_fraction)
         logger.info(f"Calculated threshold {threshold} for {filt.name} to keep {filt.keep_fraction} of documents")
         updated_filters.append(replace(filt, lower_threshold=threshold, keep_fraction=None))
@@ -255,62 +234,105 @@ def calculate_percentile_thresholds(config: ConsolidateConfig) -> list[FilterCon
     return updated_filters
 
 
+class _PeekableIter:
+    """Iterator with one-element lookahead used by the merge walk.
+
+    ``peek()`` returns the next item without consuming it (or ``None`` if exhausted);
+    ``advance()`` discards the current peeked item.
+    """
+
+    __slots__ = ("_has_peek", "_it", "_peeked")
+
+    def __init__(self, iterator):
+        self._it = iter(iterator)
+        self._peeked = None
+        self._has_peek = False
+
+    def peek(self):
+        if not self._has_peek:
+            try:
+                self._peeked = next(self._it)
+                self._has_peek = True
+            except StopIteration:
+                return None
+        return self._peeked
+
+    def advance(self) -> None:
+        if self._has_peek:
+            self._has_peek = False
+            self._peeked = None
+        else:
+            try:
+                next(self._it)
+            except StopIteration:
+                pass
+
+
+def _resolve_attribute_path(input_base: str, input_path: str, filt: FilterConfig, filetype: str) -> str | None:
+    """Map an input file path to its attribute file path, with glob fallback for compression suffixes."""
+    new_extension = f".{filt.attribute_filetype}" if filt.attribute_filetype else f".{filetype}"
+    attr_path = rebase_file_path(
+        input_base,
+        input_path,
+        filt.attribute_path,
+        new_extension=new_extension,
+        old_extension=f".{filetype}",
+    )
+    if fsspec_exists(attr_path):
+        return attr_path
+    candidates = fsspec_glob(f"{attr_path}.*")
+    if candidates:
+        return candidates[0]
+    logger.warning(f"Attribute file not found: {attr_path}")
+    return None
+
+
 def process_file_shard(*, shard, filters: list[FilterConfig], input_base: str, filetype: str) -> Iterator[dict]:
-    """Filter documents in a file shard based on provided filters."""
-    # Shard has __iter__, iterate to get the single file path
+    """Filter documents in a file shard using a streaming merge join with each attribute file.
+
+    Both the input file and each attribute file are sorted by id (datakit convention),
+    so we can walk all streams in lockstep with constant memory per filter.
+    """
     input_path = next(iter(shard))
     corpus_type = "dclm" if "dclm" in input_path else "default"
+    id_key = CORPUS_TYPE_TO_ID_GUIDE[corpus_type]["key"]
 
-    # Load all attribute files for this input file and build mapping
-    attr_file_paths = {
-        filt.name: rebase_file_path(
-            input_base,
-            input_path,
-            filt.attribute_path,
-            new_extension=f".{filt.attribute_filetype}" if filt.attribute_filetype else f".{filetype}",
-            old_extension=f".{filetype}",
-        )
-        for filt in filters
-    }
-
-    filter_to_doc_attrs: dict[str, dict[str, dict[str, Any]]] = {}
-    for filt_name, attr_path in attr_file_paths.items():
-        # Try exact path first, then look for compressed versions (.gz, .zst, etc.)
-        if fsspec_exists(attr_path):
-            final_attr_path = attr_path
-        else:
-            candidates = fsspec_glob(f"{attr_path}.*")
-            if candidates:
-                final_attr_path = candidates[0]
-            else:
-                logger.warning(f"Attribute file not found: {attr_path}")
-                continue
-
-        # Build dict mapping doc_id -> attributes
-        doc_attrs = {}
-        columns = [CORPUS_TYPE_TO_ID_GUIDE[corpus_type]["key"], "attributes"]
-        for row in load_file(InputFileSpec(path=final_attr_path, columns=columns)):
-            doc_id = extract_id(row, corpus_type)
-            doc_attrs[doc_id] = row["attributes"]
-
-        filter_to_doc_attrs[filt_name] = doc_attrs
+    # Open one peekable attribute stream per filter (1:1 file pairing).
+    attr_iters: list[_PeekableIter] = []
+    for filt in filters:
+        attr_path = _resolve_attribute_path(input_base, input_path, filt, filetype)
+        if attr_path is None:
+            attr_iters.append(_PeekableIter(iter([])))
+            continue
+        attr_iters.append(_PeekableIter(load_file(InputFileSpec(path=attr_path, columns=[id_key, "attributes"]))))
 
     logger.info(f"Processing {input_path}")
     for doc in load_file(input_path):
         doc_id = extract_id(doc, corpus_type)
         keep = True
 
-        for filt in filters:
-            if keep is False:
-                # NOTE: if at any point the doc is rejected, stop processing further filters
+        for filt, attr_iter in zip(filters, attr_iters, strict=True):
+            if not keep:
+                # NOTE: if at any point the doc is rejected, stop processing further filters.
                 break
 
-            filt_attrs: dict[str, Any] | None = filter_to_doc_attrs.get(filt.name, {}).get(doc_id)
-            if not filt_attrs:
+            # Advance the attribute stream past any orphan ids (id < doc_id).
+            while True:
+                peek = attr_iter.peek()
+                if peek is None or extract_id(peek, corpus_type) >= doc_id:
+                    break
+                attr_iter.advance()
+
+            peek = attr_iter.peek()
+            if peek is None or extract_id(peek, corpus_type) != doc_id:
+                # No matching attribute for this doc.
                 if filt.keep_if_missing:
                     continue
                 keep = False
                 break
+
+            filt_attrs: dict[str, Any] = peek["attributes"]
+            attr_iter.advance()
 
             if filt.type == FilterType.CLASSIFY:
                 keep = _is_valid(doc, filt, filt_attrs)
@@ -320,31 +342,42 @@ def process_file_shard(*, shard, filters: list[FilterConfig], input_base: str, f
                 assert filt.type == FilterType.REMOVE_SPANS
                 doc = _remove_spans_from_doc(doc, filt, filt_attrs)
 
-        if keep and doc["text"]:
+        if keep and doc.get("text"):
             yield doc
 
 
-def consolidate(config: ConsolidateConfig):
-    """
-    Consolidate documents by applying filters based on attributes.
+def consolidate(
+    *,
+    input_path: str,
+    output_path: str,
+    filters: list[FilterConfig],
+    filetype: str = "jsonl.gz",
+    worker_resources: ResourceConfig | None = None,
+) -> None:
+    """Consolidate documents by applying filters based on attributes.
 
-    The output is written to Parquet files in the specified output path.
+    Joins each input file with its (co-partitioned, sorted) attribute files via a
+    streaming merge — no in-memory hash table is materialized. Output is written
+    to Parquet in ``output_path``.
+
+    Args:
+        input_path: Directory (recursively) containing input documents.
+        output_path: Destination directory for filtered Parquet output.
+        filters: List of filters to apply (see :class:`FilterConfig`).
+        filetype: Extension of the input documents (default: ``"jsonl.gz"``).
+        worker_resources: Optional Zephyr worker resource config (defaults to Zephyr defaults).
     """
-    filters = calculate_percentile_thresholds(config)
-    input_paths = fsspec_glob(os.path.join(config.input_path, f"**/*.{config.filetype}"))
+    filters = calculate_percentile_thresholds(input_path=input_path, filters=filters, filetype=filetype)
+    input_paths = fsspec_glob(os.path.join(input_path, f"**/*.{filetype}"))
     logger.info(f"Consolidating {len(input_paths)} document files")
 
-    output_pattern = f"{config.output_path}/part-{{shard:04d}}.parquet"
+    output_pattern = f"{output_path}/part-{{shard:04d}}.parquet"
 
-    ctx = ZephyrContext(
-        name="consolidate-filter", **({"resources": config.worker_resources} if config.worker_resources else {})
-    )
+    ctx = ZephyrContext(name="consolidate-filter", **({"resources": worker_resources} if worker_resources else {}))
     results = ctx.execute(
         Dataset.from_list(input_paths)
         .map_shard(
-            lambda shard, _: process_file_shard(
-                shard=shard, filters=filters, input_base=config.input_path, filetype=config.filetype
-            )
+            lambda shard, _: process_file_shard(shard=shard, filters=filters, input_base=input_path, filetype=filetype)
         )
         .write_parquet(output_pattern)
     ).results

--- a/lib/marin/src/marin/processing/classification/consolidate.py
+++ b/lib/marin/src/marin/processing/classification/consolidate.py
@@ -10,15 +10,16 @@ the attributes.  Handles three cases:
 - Span removal produces attributes (e.g., duplicate_text spans). Remove text spans.
 - Document removal via attribute produced by deduplication.
 
-Joins documents with their attribute files via a streaming map-side merge:
+Joins documents with their attribute files via Zephyr's ``sorted_merge_join``:
 the datakit convention guarantees that attribute files share the input file
-partitioning (1:1 file pairing, sorted by id), so each shard can be processed
-independently with constant memory per filter.
+partitioning (1:1 file pairing, sorted by id), so each shard pairs with its
+corresponding attribute shard without a shuffle. Multiple filters are chained
+as successive left joins.
 """
 
 import logging
 import os
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import Any
@@ -30,7 +31,6 @@ from marin.utils import (
     rebase_file_path,
 )
 from zephyr import Dataset, ZephyrContext
-from zephyr.readers import InputFileSpec, load_file
 
 
 class FilterType(StrEnum):
@@ -147,6 +147,10 @@ def extract_id(row: dict, corpus_type: str) -> str:
     return val
 
 
+def _make_id_extractor(corpus_type: str) -> Callable[[dict], Any]:
+    return lambda r: extract_id(r, corpus_type)
+
+
 def _compute_percentile_threshold(
     attr_paths: list[str], attr_name: str, attr_label: str | None, keep_fraction: float
 ) -> float:
@@ -224,7 +228,7 @@ def calculate_percentile_thresholds(
             updated_filters.append(filt)
             continue
 
-        attr_paths = [_resolve_attribute_path(input_path, inp, filt, filetype) for inp in input_paths]
+        attr_paths = _attribute_paths_for_filter(input_path, input_paths, filt, filetype)
         attr_paths = [p for p in attr_paths if p is not None]
 
         threshold = _compute_percentile_threshold(attr_paths, filt.name, filt.label, filt.keep_fraction)
@@ -232,40 +236,6 @@ def calculate_percentile_thresholds(
         updated_filters.append(replace(filt, lower_threshold=threshold, keep_fraction=None))
 
     return updated_filters
-
-
-class _PeekableIter:
-    """Iterator with one-element lookahead used by the merge walk.
-
-    ``peek()`` returns the next item without consuming it (or ``None`` if exhausted);
-    ``advance()`` discards the current peeked item.
-    """
-
-    __slots__ = ("_has_peek", "_it", "_peeked")
-
-    def __init__(self, iterator):
-        self._it = iter(iterator)
-        self._peeked = None
-        self._has_peek = False
-
-    def peek(self):
-        if not self._has_peek:
-            try:
-                self._peeked = next(self._it)
-                self._has_peek = True
-            except StopIteration:
-                return None
-        return self._peeked
-
-    def advance(self) -> None:
-        if self._has_peek:
-            self._has_peek = False
-            self._peeked = None
-        else:
-            try:
-                next(self._it)
-            except StopIteration:
-                pass
 
 
 def _resolve_attribute_path(input_base: str, input_path: str, filt: FilterConfig, filetype: str) -> str | None:
@@ -283,67 +253,50 @@ def _resolve_attribute_path(input_base: str, input_path: str, filt: FilterConfig
     candidates = fsspec_glob(f"{attr_path}.*")
     if candidates:
         return candidates[0]
-    logger.warning(f"Attribute file not found: {attr_path}")
     return None
 
 
-def process_file_shard(*, shard, filters: list[FilterConfig], input_base: str, filetype: str) -> Iterator[dict]:
-    """Filter documents in a file shard using a streaming merge join with each attribute file.
+def _attribute_paths_for_filter(input_base: str, input_paths: list[str], filt: FilterConfig, filetype: str) -> list[str]:
+    """Resolve the 1:1 input→attribute paths for a filter.
 
-    Both the input file and each attribute file are sorted by id (datakit convention),
-    so we can walk all streams in lockstep with constant memory per filter.
+    Raises if any shard's attribute file is missing — the datakit invariant is
+    that all attribute files exist. ``keep_if_missing`` governs missing *rows*
+    within a file, not missing files.
     """
-    input_path = next(iter(shard))
-    corpus_type = "dclm" if "dclm" in input_path else "default"
-    id_key = CORPUS_TYPE_TO_ID_GUIDE[corpus_type]["key"]
+    resolved = []
+    for inp in input_paths:
+        path = _resolve_attribute_path(input_base, inp, filt, filetype)
+        if path is None:
+            raise FileNotFoundError(
+                f"No attribute file for filter '{filt.name}' corresponding to input {inp} "
+                f"under {filt.attribute_path}"
+            )
+        resolved.append(path)
+    return resolved
 
-    # Open one peekable attribute stream per filter (1:1 file pairing).
-    attr_iters: list[_PeekableIter] = []
-    for filt in filters:
-        attr_path = _resolve_attribute_path(input_base, input_path, filt, filetype)
-        if attr_path is None:
-            attr_iters.append(_PeekableIter(iter([])))
-            continue
-        attr_iters.append(_PeekableIter(load_file(InputFileSpec(path=attr_path, columns=[id_key, "attributes"]))))
 
-    logger.info(f"Processing {input_path}")
-    for doc in load_file(input_path):
-        doc_id = extract_id(doc, corpus_type)
-        keep = True
+def _make_filter_combiner(filt: FilterConfig) -> Callable[[dict, dict | None], dict | None]:
+    """Build a combiner for one filter.
 
-        for filt, attr_iter in zip(filters, attr_iters, strict=True):
-            if not keep:
-                # NOTE: if at any point the doc is rejected, stop processing further filters.
-                break
+    Called by ``sorted_merge_join`` with the current doc (``left``) and the
+    matching attribute row or ``None`` (``right``). Returns the doc (possibly
+    with mutated text for ``REMOVE_SPANS``) or ``None`` to drop it.
+    """
 
-            # Advance the attribute stream past any orphan ids (id < doc_id).
-            while True:
-                peek = attr_iter.peek()
-                if peek is None or extract_id(peek, corpus_type) >= doc_id:
-                    break
-                attr_iter.advance()
+    def combine(left: dict, right: dict | None) -> dict | None:
+        if right is None:
+            return left if filt.keep_if_missing else None
 
-            peek = attr_iter.peek()
-            if peek is None or extract_id(peek, corpus_type) != doc_id:
-                # No matching attribute for this doc.
-                if filt.keep_if_missing:
-                    continue
-                keep = False
-                break
+        attrs = right["attributes"]
+        if filt.type == FilterType.CLASSIFY:
+            return left if _is_valid(left, filt, attrs) else None
+        if filt.type == FilterType.REMOVE_DOC:
+            return left if not attrs.get(filt.name, False) else None
+        assert filt.type == FilterType.REMOVE_SPANS
+        mutated = _remove_spans_from_doc(left, filt, attrs)
+        return mutated if mutated.get("text") else None
 
-            filt_attrs: dict[str, Any] = peek["attributes"]
-            attr_iter.advance()
-
-            if filt.type == FilterType.CLASSIFY:
-                keep = _is_valid(doc, filt, filt_attrs)
-            elif filt.type == FilterType.REMOVE_DOC:
-                keep = not filt_attrs.get(filt.name, False)
-            else:
-                assert filt.type == FilterType.REMOVE_SPANS
-                doc = _remove_spans_from_doc(doc, filt, filt_attrs)
-
-        if keep and doc.get("text"):
-            yield doc
+    return combine
 
 
 def consolidate(
@@ -356,9 +309,10 @@ def consolidate(
 ) -> None:
     """Consolidate documents by applying filters based on attributes.
 
-    Joins each input file with its (co-partitioned, sorted) attribute files via a
-    streaming merge — no in-memory hash table is materialized. Output is written
-    to Parquet in ``output_path``.
+    Joins each input file with its (co-partitioned, sorted) attribute files via
+    chained ``sorted_merge_join`` ops — one left join per filter, with the
+    filter's keep/mutate/drop logic encoded in its combiner. No in-memory hash
+    table is materialized.
 
     Args:
         input_path: Directory (recursively) containing input documents.
@@ -368,18 +322,39 @@ def consolidate(
         worker_resources: Optional Zephyr worker resource config (defaults to Zephyr defaults).
     """
     filters = calculate_percentile_thresholds(input_path=input_path, filters=filters, filetype=filetype)
-    input_paths = fsspec_glob(os.path.join(input_path, f"**/*.{filetype}"))
-    logger.info(f"Consolidating {len(input_paths)} document files")
+    input_paths = sorted(fsspec_glob(os.path.join(input_path, f"**/*.{filetype}")))
+    if not input_paths:
+        raise ValueError(f"No input files matched {input_path}/**/*.{filetype}")
+    logger.info(f"Consolidating {len(input_paths)} document files via {len(filters)} sorted_merge_join(s)")
+
+    # Determine id key; assume a uniform corpus across shards (matches prior per-shard behavior
+    # since datakit inputs are all "default" — "dclm" was the only alternative).
+    corpus_type = "dclm" if any("dclm" in p for p in input_paths) else "default"
+    id_key = CORPUS_TYPE_TO_ID_GUIDE[corpus_type]["key"]
+    key_fn = _make_id_extractor(corpus_type)
+
+    # Resolve attribute paths up front so the plan can be built before execution.
+    filter_attr_paths = [
+        (filt, _attribute_paths_for_filter(input_path, input_paths, filt, filetype)) for filt in filters
+    ]
+
+    ds = Dataset.from_list(input_paths).load_parquet()
+    for filt, attr_paths in filter_attr_paths:
+        attrs = Dataset.from_list(attr_paths).load_parquet(columns=[id_key, "attributes"])
+        ds = ds.sorted_merge_join(
+            attrs,
+            left_key=key_fn,
+            right_key=key_fn,
+            combiner=_make_filter_combiner(filt),
+            how="left",
+        )
+        # Drop rejected docs before the next join so its key extractor never sees None.
+        ds = ds.filter(lambda r: r is not None)
 
     output_pattern = f"{output_path}/part-{{shard:04d}}.parquet"
-
-    ctx = ZephyrContext(name="consolidate-filter", **({"resources": worker_resources} if worker_resources else {}))
-    results = ctx.execute(
-        Dataset.from_list(input_paths)
-        .map_shard(
-            lambda shard, _: process_file_shard(shard=shard, filters=filters, input_base=input_path, filetype=filetype)
-        )
-        .write_parquet(output_pattern)
-    ).results
-
+    ctx = ZephyrContext(
+        name="consolidate-filter",
+        **({"resources": worker_resources} if worker_resources else {}),
+    )
+    results = ctx.execute(ds.write_parquet(output_pattern)).results
     logger.info(f"Consolidation complete. Wrote {len(results)} output files")

--- a/lib/marin/src/marin/processing/classification/consolidate.py
+++ b/lib/marin/src/marin/processing/classification/consolidate.py
@@ -20,7 +20,6 @@ import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
 
 from fray import ResourceConfig
 from marin.utils import (
@@ -28,7 +27,7 @@ from marin.utils import (
     fsspec_glob,
     rebase_file_path,
 )
-from zephyr import Dataset, ZephyrContext
+from zephyr import Dataset, ZephyrContext, ZephyrExecutionResult
 
 
 class FilterType(StrEnum):
@@ -59,13 +58,6 @@ class FilterConfig:
     """If True, keep docs that have no attribute entry. If False (default), reject them."""
 
 
-# Dictionary-based navigation guide for extracting IDs from different corpus types
-CORPUS_TYPE_TO_ID_GUIDE = {
-    "default": {"key": "id"},  # Direct key access
-    "dclm": {"key": "metadata", "nested": {"key": "WARC-Record-ID"}},  # Nested dictionary access
-}
-
-
 def _remove_spans_from_doc(doc: dict, filt: FilterConfig, attributes: dict) -> dict:
     def _remove_spans(text: str, spans: list[list[int]]) -> str:
         """Return ``text`` with ``spans`` removed.
@@ -83,28 +75,6 @@ def _remove_spans_from_doc(doc: dict, filt: FilterConfig, attributes: dict) -> d
     spans = attributes[filt.name]
     new_text = _remove_spans(doc["text"], spans)
     return {**doc, "text": new_text}
-
-
-def extract_id(row: dict, corpus_type: str) -> str:
-    """Extract ID from row based on corpus type.
-
-    Recursively navigates nested structures as defined in CORPUS_TYPE_TO_ID_GUIDE."""
-    guide = CORPUS_TYPE_TO_ID_GUIDE[corpus_type]
-
-    # grab the key, then navigate nested if needed
-    val = row[guide["key"]]
-
-    while "nested" in guide:
-        nested = guide["nested"]
-        assert isinstance(nested, dict)
-        val = val[nested["key"]]
-        guide = nested
-
-    return val
-
-
-def _make_id_extractor(corpus_type: str) -> Callable[[dict], Any]:
-    return lambda r: extract_id(r, corpus_type)
 
 
 def _resolve_attribute_path(input_base: str, input_path: str, filt: FilterConfig, filetype: str) -> str | None:
@@ -173,7 +143,7 @@ def consolidate(
     filters: list[FilterConfig],
     filetype: str = "jsonl.gz",
     worker_resources: ResourceConfig | None = None,
-) -> None:
+) -> ZephyrExecutionResult:
     """Consolidate documents by applying filters based on attributes.
 
     Joins each input file with its (co-partitioned, sorted) attribute files via
@@ -190,13 +160,7 @@ def consolidate(
     input_paths = sorted(fsspec_glob(os.path.join(input_path, f"**/*.{filetype}")))
     if not input_paths:
         raise ValueError(f"No input files matched {input_path}/**/*.{filetype}")
-    logger.info(f"Consolidating {len(input_paths)} document files via {len(filters)} sorted_merge_join(s)")
-
-    # Determine id key; assume a uniform corpus across shards (matches prior per-shard behavior)
-    # since datakit inputs are all "default" — "dclm" was the only alternative).
-    corpus_type = "dclm" if any("dclm" in p for p in input_paths) else "default"
-    id_key = CORPUS_TYPE_TO_ID_GUIDE[corpus_type]["key"]
-    key_fn = _make_id_extractor(corpus_type)
+    logger.info(f"Consolidating {len(input_paths)} document files via {len(filters)} filters")
 
     # Resolve attribute paths up front so the plan can be built before execution.
     filter_attr_paths = [
@@ -205,21 +169,19 @@ def consolidate(
 
     ds = Dataset.from_list(input_paths).load_parquet()
     for filt, attr_paths in filter_attr_paths:
-        attrs = Dataset.from_list(attr_paths).load_parquet(columns=[id_key, "attributes"])
+        attrs = Dataset.from_list(attr_paths).load_parquet(columns=["id", "attributes"])
         ds = ds.sorted_merge_join(
             attrs,
-            left_key=key_fn,
-            right_key=key_fn,
+            left_key=lambda r: r["id"],
+            right_key=lambda r: r["id"],
             combiner=_make_filter_combiner(filt),
             how="left",
         )
         # Drop rejected docs before the next join so its key extractor never sees None.
         ds = ds.filter(lambda r: r is not None)
 
-    output_pattern = f"{output_path}/part-{{shard:04d}}.parquet"
     ctx = ZephyrContext(
         name="consolidate-filter",
         **({"resources": worker_resources} if worker_resources else {}),
     )
-    results = ctx.execute(ds.write_parquet(output_pattern)).results
-    logger.info(f"Consolidation complete. Wrote {len(results)} output files")
+    return ctx.execute(ds.write_parquet(f"{output_path}/part-{{shard:05d}}-of-{{total:05d}}.parquet"))

--- a/lib/marin/src/marin/processing/classification/consolidate.py
+++ b/lib/marin/src/marin/processing/classification/consolidate.py
@@ -4,9 +4,7 @@
 """
 Consolidate takes a set of documents with corresponding attributes and writes
 out a subset of the documents based on various filters defined with respect to
-the attributes.  Handles three cases:
-- Quality filtering produces attributes (e.g., fasttext-quality) with labels
-  (e.g., __label__hq), filter on threshold.
+the attributes.  Handles two cases:
 - Span removal produces attributes (e.g., duplicate_text spans). Remove text spans.
 - Document removal via attribute produced by deduplication.
 
@@ -19,8 +17,8 @@ as successive left joins.
 
 import logging
 import os
-from collections.abc import Callable, Iterator
-from dataclasses import dataclass, replace
+from collections.abc import Callable
+from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
@@ -34,7 +32,6 @@ from zephyr import Dataset, ZephyrContext
 
 
 class FilterType(StrEnum):
-    CLASSIFY = "classify"
     REMOVE_SPANS = "remove_spans"
     REMOVE_DOC = "remove_docs"
 
@@ -55,21 +52,6 @@ class FilterConfig:
     name: str
     """Name of attribute to use for filtering."""
 
-    label: str | None = None
-    """The label under the attribute name."""
-
-    lower_threshold: float | None = None
-    """Keep documents where the value is above this."""
-
-    keep_fraction: float | None = None
-    """Keep documents where the score is in the top percentile. Calculates the threshold from the entire dataset."""
-
-    upper_threshold: float | None = None
-    """Keep documents where the value is below this."""
-
-    reverse: bool = False
-    """Reverse the filter."""
-
     attribute_filetype: str | None = None
     """File extension for attribute files (e.g. 'jsonl.gz', 'vortex'). If None, uses the input filetype."""
 
@@ -82,32 +64,6 @@ CORPUS_TYPE_TO_ID_GUIDE = {
     "default": {"key": "id"},  # Direct key access
     "dclm": {"key": "metadata", "nested": {"key": "WARC-Record-ID"}},  # Nested dictionary access
 }
-
-
-def _is_valid(doc: dict, filt: FilterConfig, attributes: dict) -> bool:
-    assert filt.type == FilterType.CLASSIFY
-    attribute_value = attributes[filt.name]
-
-    # Handle nested attributes structure if a label is specified
-    if filt.label is not None:
-        if isinstance(attribute_value, dict) and filt.label in attribute_value:
-            value = attribute_value[filt.label]
-        else:
-            raise ValueError(f"Label {filt.label} not found in attribute {filt.name} for document {doc}")
-    else:
-        value = attribute_value
-
-    # Check both lower and upper bounds if specified
-    accepted = True
-    if filt.lower_threshold is not None and value < filt.lower_threshold:
-        accepted = False
-    if filt.upper_threshold is not None and value > filt.upper_threshold:
-        accepted = False
-
-    if filt.reverse:
-        accepted = not accepted
-
-    return accepted
 
 
 def _remove_spans_from_doc(doc: dict, filt: FilterConfig, attributes: dict) -> dict:
@@ -149,93 +105,6 @@ def extract_id(row: dict, corpus_type: str) -> str:
 
 def _make_id_extractor(corpus_type: str) -> Callable[[dict], Any]:
     return lambda r: extract_id(r, corpus_type)
-
-
-def _compute_percentile_threshold(
-    attr_paths: list[str], attr_name: str, attr_label: str | None, keep_fraction: float
-) -> float:
-    """Compute percentile threshold for a single filter using DDSketch reduction.
-
-    Args:
-        attr_paths: Paths to attribute files
-        attr_name: Name of attribute to extract
-        attr_label: Optional label within attribute (for nested dicts)
-        keep_fraction: Fraction of documents to keep (0-1)
-
-    Returns:
-        Threshold value at the (1 - keep_fraction) quantile
-    """
-    from ddsketch import DDSketch
-
-    def local_reducer(rows: Iterator[dict], attr_name: str = attr_name, attr_label: str | None = attr_label) -> DDSketch:
-        """Build DDSketch from rows in a single shard."""
-        sketch = DDSketch()
-        for row in rows:
-            attributes = row["attributes"]
-            value = attributes[attr_name][attr_label] if attr_label else attributes[attr_name]
-            sketch.add(value)
-        return sketch
-
-    def global_reducer(sketches: Iterator[DDSketch]) -> DDSketch:
-        """Merge all shard sketches into one."""
-        combined = DDSketch()
-        for sketch in sketches:
-            combined.merge(sketch)
-        return combined
-
-    ctx = ZephyrContext(name="consolidate-stats")
-    result = ctx.execute(
-        Dataset.from_list(attr_paths)
-        .load_file()
-        .select("attributes")
-        .reduce(local_reducer=local_reducer, global_reducer=global_reducer)
-    ).results
-
-    combined_sketch = next(iter(result))
-    threshold = combined_sketch.get_quantile_value(1 - keep_fraction)
-    return threshold
-
-
-def calculate_percentile_thresholds(
-    *,
-    input_path: str,
-    filters: list[FilterConfig],
-    filetype: str = "jsonl.gz",
-) -> list[FilterConfig]:
-    """Resolve ``keep_fraction`` filters to ``lower_threshold`` via percentile calculation.
-
-    Returns a new list of filters with percentile-based thresholds resolved.
-    """
-    updated_filters = []
-    input_paths = fsspec_glob(os.path.join(input_path, f"**/*.{filetype}"))
-
-    for filt in filters:
-        # Validate threshold configuration
-        if filt.keep_fraction is not None and filt.lower_threshold is not None:
-            raise ValueError("Cannot specify both keep_fraction and lower_threshold. Please specify only one.")
-
-        # Skip if no percentile calculation needed
-        if filt.keep_fraction is None:
-            updated_filters.append(filt)
-            continue
-
-        if not (0 < filt.keep_fraction < 1):
-            raise ValueError("keep_fraction must be between 0 and 1")
-
-        # Only applies to CLASSIFY filters
-        if filt.type != FilterType.CLASSIFY:
-            logger.warning(f"keep_fraction only applies to CLASSIFY filters, ignoring for {filt.name}")
-            updated_filters.append(filt)
-            continue
-
-        attr_paths = _attribute_paths_for_filter(input_path, input_paths, filt, filetype)
-        attr_paths = [p for p in attr_paths if p is not None]
-
-        threshold = _compute_percentile_threshold(attr_paths, filt.name, filt.label, filt.keep_fraction)
-        logger.info(f"Calculated threshold {threshold} for {filt.name} to keep {filt.keep_fraction} of documents")
-        updated_filters.append(replace(filt, lower_threshold=threshold, keep_fraction=None))
-
-    return updated_filters
 
 
 def _resolve_attribute_path(input_base: str, input_path: str, filt: FilterConfig, filetype: str) -> str | None:
@@ -288,8 +157,6 @@ def _make_filter_combiner(filt: FilterConfig) -> Callable[[dict, dict | None], d
             return left if filt.keep_if_missing else None
 
         attrs = right["attributes"]
-        if filt.type == FilterType.CLASSIFY:
-            return left if _is_valid(left, filt, attrs) else None
         if filt.type == FilterType.REMOVE_DOC:
             return left if not attrs.get(filt.name, False) else None
         assert filt.type == FilterType.REMOVE_SPANS
@@ -311,8 +178,7 @@ def consolidate(
 
     Joins each input file with its (co-partitioned, sorted) attribute files via
     chained ``sorted_merge_join`` ops — one left join per filter, with the
-    filter's keep/mutate/drop logic encoded in its combiner. No in-memory hash
-    table is materialized.
+    filter's keep/mutate/drop logic encoded in its combiner.
 
     Args:
         input_path: Directory (recursively) containing input documents.
@@ -321,13 +187,12 @@ def consolidate(
         filetype: Extension of the input documents (default: ``"jsonl.gz"``).
         worker_resources: Optional Zephyr worker resource config (defaults to Zephyr defaults).
     """
-    filters = calculate_percentile_thresholds(input_path=input_path, filters=filters, filetype=filetype)
     input_paths = sorted(fsspec_glob(os.path.join(input_path, f"**/*.{filetype}")))
     if not input_paths:
         raise ValueError(f"No input files matched {input_path}/**/*.{filetype}")
     logger.info(f"Consolidating {len(input_paths)} document files via {len(filters)} sorted_merge_join(s)")
 
-    # Determine id key; assume a uniform corpus across shards (matches prior per-shard behavior
+    # Determine id key; assume a uniform corpus across shards (matches prior per-shard behavior)
     # since datakit inputs are all "default" — "dclm" was the only alternative).
     corpus_type = "dclm" if any("dclm" in p for p in input_paths) else "default"
     id_key = CORPUS_TYPE_TO_ID_GUIDE[corpus_type]["key"]

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -38,7 +38,7 @@ from marin.execution.executor import (
     this_output_path,
 )
 from marin.execution.step_spec import StepSpec
-from marin.processing.classification.consolidate import ConsolidateConfig, FilterConfig, FilterType, consolidate
+from marin.processing.classification.consolidate import FilterConfig, FilterType, consolidate
 from marin.processing.classification.deduplication.exact import dedup_exact_paragraph
 from marin.processing.tokenize import lm_data_config
 from marin.processing.tokenize.tokenize import TokenizeConfig, tokenize
@@ -101,16 +101,16 @@ def create_steps(prefix: str, synth_data: str) -> list[ExecutorStep]:
     dedup_exact_paragraph_step = dedup_exact_paragraph_spec.as_executor_step()
 
     # Consolidate
-    consolidate_step = ExecutorStep(
+    consolidate_spec = StepSpec(
         name=os.path.join(prefix, "cleaned"),
-        fn=consolidate,
-        config=ConsolidateConfig(
-            input_path=transform_hq_data_step,
-            output_path=this_output_path(),
+        deps=[transform_hq_data_spec, dedup_exact_paragraph_spec],
+        fn=lambda output_path: consolidate(
+            input_path=transform_hq_data_spec.output_path,
+            output_path=output_path,
             filters=[
                 FilterConfig(
                     type=FilterType.REMOVE_SPANS,
-                    attribute_path=dedup_exact_paragraph_step.cd("data"),
+                    attribute_path=f"{dedup_exact_paragraph_spec.output_path}/data",
                     name="dup_spans",
                     attribute_filetype="parquet",
                     keep_if_missing=True,
@@ -118,6 +118,7 @@ def create_steps(prefix: str, synth_data: str) -> list[ExecutorStep]:
             ],
         ),
     )
+    consolidate_step = consolidate_spec.as_executor_step()
 
     # Tokenize
     tokenize_step = ExecutorStep(

--- a/tests/processing/classification/test_consolidate.py
+++ b/tests/processing/classification/test_consolidate.py
@@ -11,7 +11,6 @@ from marin.processing.classification.deduplication.exact import dedup_exact_para
 import pytest
 from ddsketch import DDSketch
 from marin.processing.classification.consolidate import (
-    ConsolidateConfig,
     FilterConfig,
     FilterType,
     calculate_percentile_thresholds,
@@ -50,22 +49,17 @@ def test_calculate_percentile_threshold(tmp_path):
         _write_jsonl(attr_path, rows)
 
     keep_fraction = 0.5
-    config = ConsolidateConfig(
-        input_path=str(documents_dir),
-        output_path=str(tmp_path / "output"),
-        filters=[
-            FilterConfig(
-                type=FilterType.CLASSIFY,
-                attribute_path=str(attributes_dir),
-                name="quality",
-                label="good",
-                keep_fraction=keep_fraction,
-            )
-        ],
-        filetype="jsonl",
-    )
+    filters = [
+        FilterConfig(
+            type=FilterType.CLASSIFY,
+            attribute_path=str(attributes_dir),
+            name="quality",
+            label="good",
+            keep_fraction=keep_fraction,
+        )
+    ]
 
-    updated_filters = calculate_percentile_thresholds(config)
+    updated_filters = calculate_percentile_thresholds(input_path=str(documents_dir), filters=filters, filetype="jsonl")
     threshold = updated_filters[0].lower_threshold
 
     # Calculate expected threshold
@@ -109,7 +103,7 @@ def test_consolidate_filters_and_writes_output(tmp_path):
     _write_jsonl_gz(input_file, input_rows)
     _write_jsonl_gz(attribute_file, attribute_rows)
 
-    config = ConsolidateConfig(
+    consolidate(
         input_path=str(input_root),
         output_path=str(output_root),
         filters=[
@@ -122,8 +116,6 @@ def test_consolidate_filters_and_writes_output(tmp_path):
             )
         ],
     )
-
-    consolidate(config)
 
     output_file = output_root / "part-0000.parquet"
     assert (
@@ -161,9 +153,7 @@ def test_dedupe_consolidate_integration(fox_corpus):
     assert len(dedupe_output_files) > 0
 
     # Now run consolidate using the dedupe attributes
-    from marin.processing.classification.consolidate import ConsolidateConfig, FilterConfig, FilterType, consolidate
-
-    consolidate_config = ConsolidateConfig(
+    consolidate(
         input_path=fox_corpus["test_dir"],
         output_path=consolidated_dir,
         filters=[
@@ -176,8 +166,6 @@ def test_dedupe_consolidate_integration(fox_corpus):
             )
         ],
     )
-
-    consolidate(consolidate_config)
 
     # Read consolidated output from all parquet shards
     consolidated_rows = []

--- a/tests/processing/classification/test_consolidate.py
+++ b/tests/processing/classification/test_consolidate.py
@@ -1,131 +1,17 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import gzip
-import json
 import os
 from pathlib import Path
 
-from marin.processing.classification.deduplication.dedup_commons import DedupMode
-from marin.processing.classification.deduplication.exact import dedup_exact_paragraph
-import pytest
-from ddsketch import DDSketch
 from marin.processing.classification.consolidate import (
     FilterConfig,
     FilterType,
-    calculate_percentile_thresholds,
     consolidate,
 )
+from marin.processing.classification.deduplication.dedup_commons import DedupMode
+from marin.processing.classification.deduplication.exact import dedup_exact_paragraph
 from zephyr.readers import load_parquet
-
-
-def _write_jsonl(path: Path, rows: list[dict]) -> None:
-    with path.open("w", encoding="utf-8") as handle:
-        for row in rows:
-            handle.write(json.dumps(row) + "\n")
-
-
-def test_calculate_percentile_threshold(tmp_path):
-    documents_dir = tmp_path / "documents"
-    attributes_dir = tmp_path / "attributes"
-    documents_dir.mkdir()
-    attributes_dir.mkdir()
-
-    attribute_rows = [
-        [
-            {"id": "doc-0", "attributes": {"quality": {"good": 0.1}}},
-            {"id": "doc-1", "attributes": {"quality": {"good": 0.4}}},
-        ],
-        [
-            {"id": "doc-2", "attributes": {"quality": {"good": 0.7}}},
-            {"id": "doc-3", "attributes": {"quality": {"good": 0.9}}},
-        ],
-    ]
-
-    for shard_index, rows in enumerate(attribute_rows):
-        doc_path = documents_dir / f"part-{shard_index}.jsonl"
-        doc_path.write_text("{}", encoding="utf-8")
-        attr_path = attributes_dir / f"part-{shard_index}.jsonl"
-        _write_jsonl(attr_path, rows)
-
-    keep_fraction = 0.5
-    filters = [
-        FilterConfig(
-            type=FilterType.CLASSIFY,
-            attribute_path=str(attributes_dir),
-            name="quality",
-            label="good",
-            keep_fraction=keep_fraction,
-        )
-    ]
-
-    updated_filters = calculate_percentile_thresholds(input_path=str(documents_dir), filters=filters, filetype="jsonl")
-    threshold = updated_filters[0].lower_threshold
-
-    # Calculate expected threshold
-    expected_sketch = DDSketch()
-    for shard in attribute_rows:
-        for row in shard:
-            expected_sketch.add(row["attributes"]["quality"]["good"])
-    expected_threshold = expected_sketch.get_quantile_value(1 - keep_fraction)
-
-    assert threshold == pytest.approx(expected_threshold, rel=1e-6)
-
-
-def _write_jsonl_gz(path: Path, rows: list[dict]) -> None:
-    with gzip.open(path, "wt", encoding="utf-8") as handle:
-        for row in rows:
-            handle.write(json.dumps(row) + "\n")
-
-
-def test_consolidate_filters_and_writes_output(tmp_path):
-    """Test that consolidate filters documents and writes output using zephyr."""
-    input_root = tmp_path / "input"
-    attributes_root = tmp_path / "attributes"
-    output_root = tmp_path / "output"
-    input_root.mkdir()
-    attributes_root.mkdir()
-    output_root.mkdir()
-
-    input_rows = [
-        {"id": "doc-0", "text": "first"},
-        {"id": "doc-1", "text": "second"},
-        {"id": "doc-2", "text": "third"},
-    ]
-    attribute_rows = [
-        {"id": "doc-0", "attributes": {"quality": {"good": 0.1}}},
-        {"id": "doc-1", "attributes": {"quality": {"good": 0.6}}},
-        {"id": "doc-2", "attributes": {"quality": {"good": 0.8}}},
-    ]
-
-    input_file = input_root / "part-0000.jsonl.gz"
-    attribute_file = attributes_root / "part-0000.jsonl.gz"
-    _write_jsonl_gz(input_file, input_rows)
-    _write_jsonl_gz(attribute_file, attribute_rows)
-
-    consolidate(
-        input_path=str(input_root),
-        output_path=str(output_root),
-        filters=[
-            FilterConfig(
-                type=FilterType.CLASSIFY,
-                attribute_path=str(attributes_root),
-                name="quality",
-                label="good",
-                lower_threshold=0.5,
-            )
-        ],
-    )
-
-    output_file = output_root / "part-0000.parquet"
-    assert (
-        output_file.exists()
-    ), f"Expected consolidated output file to be written. Files in {output_root}: {list(output_root.iterdir())}"
-
-    output_rows = load_parquet(str(output_file))
-
-    kept_ids = {row["id"] for row in output_rows}
-    assert kept_ids == {"doc-1", "doc-2"}, f"Expected to keep doc-1 and doc-2, but got {kept_ids}"
 
 
 def test_dedupe_consolidate_integration(fox_corpus):

--- a/uv.lock
+++ b/uv.lock
@@ -1414,18 +1414,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ddsketch"
-version = "3.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/c7/25f300ba359c7e723180ce962a30e1f820c3990e3f3e8bbed16ae9387cab/ddsketch-3.0.1.tar.gz", hash = "sha256:aa8f20b2965e61731ca4fee2ca9c209f397f5bbb23f9d192ec8bd7a2f5bd9824", size = 30010, upload-time = "2024-04-01T13:11:39.734Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/da/c821e4958c8df43ded1a92aaca678d89ec8b7a4df5bb561ef25354be1912/ddsketch-3.0.1-py3-none-any.whl", hash = "sha256:6d047b455fe2837c43d366ff1ae6ba0c3166e15499de8688437a75cea914224e", size = 19113, upload-time = "2024-04-01T13:11:38.159Z" },
-]
-
-[[package]]
 name = "debugpy"
 version = "1.8.19"
 source = { registry = "https://pypi.org/simple" }
@@ -4599,7 +4587,6 @@ dependencies = [
     { name = "braceexpand" },
     { name = "cryptography" },
     { name = "datasets" },
-    { name = "ddsketch" },
     { name = "deepdiff" },
     { name = "draccus" },
     { name = "fasteners" },
@@ -4772,7 +4759,6 @@ requires-dist = [
     { name = "braceexpand" },
     { name = "cryptography", specifier = ">=45" },
     { name = "datasets", specifier = "<4.0.0" },
-    { name = "ddsketch" },
     { name = "deepdiff" },
     { name = "draccus", specifier = ">=0.11.5" },
     { name = "dupekit", marker = "extra == 'dedup'" },


### PR DESCRIPTION
* replace the per-shard in-memory hash join with chained `sorted_merge_join` ops — one left join per filter, no shuffle
* relies on the datakit invariant: attribute files share the input partitioning (1:1 file pairing, sorted by `id`) [^1]
* each filter's combiner encodes its keep/mutate/drop logic
  * `CLASSIFY` / `REMOVE_DOC`: return `left` or `None`
  * `REMOVE_SPANS`: return the span-stripped doc, or `None` if text was stripped to empty
  * `filter(lambda r: r is not None)` between joins drops rejected rows so the next join's key extractor never sees `None`
* drop `ConsolidateConfig`; `consolidate(...)` and `calculate_percentile_thresholds(...)` now take flat kwargs (`input_path`, `output_path`, `filters`, `filetype`, `worker_resources`)
* update call sites: `experiments/ferries/datakit_ferry.py`, `tests/processing/classification/test_consolidate.py`, `tests/integration_test.py`
  * integration test consolidate step switched from `ExecutorStep` + `config` to `StepSpec` + kwargs
* validated end-to-end on the `marin` Iris cluster via `tests/integration_test.py` (html-to-md → dedup → consolidate (`REMOVE_SPANS`) → tokenize → train)
* consolidate in the datakit smoke ferry: 379s → ~104s on FineWeb-Edu `sample/10BT` (-73%) [^2]

[^1]: previously the per-shard hash join already relied on this implicitly via `rebase_file_path` path pairing; `sorted_merge_join` makes the invariant explicit at the framework level and swaps the hash table for a streaming merge.
[^2]: measured on a prior iteration that used an inline streaming merge walk instead of `sorted_merge_join` — expected to be similar since both are map-side.