### PR TITLE
datakit: optional exact dedup in normalize

### DIFF
--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -177,6 +177,7 @@ def _build_pipeline(
     num_shards: int,
     text_field: str,
     id_field: str | None,
+    exact_dedup: bool,
 ) -> Dataset:
     """Build a single Zephyr pipeline for one subdirectory."""
     normalize_record = _make_normalize_fn(text_field, id_field)
@@ -189,6 +190,10 @@ def _build_pipeline(
             if rid != prev_id:
                 prev_id = rid
                 yield record
+
+    def passthrough(_key: int, items: Iterator[dict[str, Any]]) -> Iterator[dict[str, Any]]:
+        """Yield items unchanged; used when exact dedup is disabled."""
+        yield from items
 
     def has_text(record: dict[str, Any]) -> bool:
         text = record.get(text_field)
@@ -204,7 +209,7 @@ def _build_pipeline(
         .map(normalize_record)
         .group_by(
             key=lambda r: int(r["id"], 16) % num_shards,
-            reducer=dedup_and_sort,
+            reducer=dedup_and_sort if exact_dedup else passthrough,
             sort_by=lambda r: r["id"],
             num_output_shards=num_shards,
         )
@@ -224,14 +229,15 @@ def normalize_to_parquet(
     target_partition_bytes: int = 256 * 1024 * 1024,
     worker_resources: ResourceConfig | None = None,
     file_extensions: tuple[str, ...] | None = None,
+    exact_dedup: bool = True,
 ) -> NormalizeResult:
     """Normalize raw downloaded data to the datakit standard Parquet format.
 
     Discovers all data files under *input_path*, groups them by subdirectory,
     and launches one Zephyr pipeline per subdirectory concurrently.  Each
     pipeline normalizes records (``id``, ``text``, preserves all other columns),
-    deduplicates by content, sorts by ``id``, and writes Parquet partitions
-    sized by *target_partition_bytes*.
+    optionally exact-deduplicates by content, sorts by ``id``, and writes
+    Parquet partitions sized by *target_partition_bytes*.
 
     Args:
         input_path: Root directory containing raw downloaded data.
@@ -249,6 +255,9 @@ def normalize_to_parquet(
         file_extensions: Tuple of file extensions to include (e.g.
             ``(".parquet",)``).  Defaults to all extensions supported by
             ``zephyr.readers.load_file``.
+        exact_dedup: If True (the default), drop records with duplicate ``id``
+            values (i.e. exact text duplicates) within each output shard.  Set
+            to False to skip the dedup pass and preserve all input records.
 
     Returns:
         A :class:`NormalizeResult` describing the output files and zephyr
@@ -276,7 +285,7 @@ def normalize_to_parquet(
             num_shards,
         )
 
-        pipeline = _build_pipeline(files, output_dir, num_shards, text_field, id_field)
+        pipeline = _build_pipeline(files, output_dir, num_shards, text_field, id_field, exact_dedup)
         ctx = ZephyrContext(
             name=f"normalize-{subdir.replace('/', '-') if subdir else 'all'}",
             resources=resources,
@@ -323,6 +332,7 @@ def normalize_step(
     override_output_path: str | None = None,
     input_path: str | None = None,
     file_extensions: tuple[str, ...] | None = None,
+    exact_dedup: bool = True,
 ) -> StepSpec:
     """Create a StepSpec that normalizes downloaded data to Parquet.
 
@@ -340,6 +350,8 @@ def normalize_step(
         file_extensions: Tuple of file extensions to include (e.g.
             ``(".parquet",)``).  Defaults to all extensions supported by
             ``zephyr.readers.load_file``.
+        exact_dedup: If True (the default), drop records with duplicate ``id``
+            values (i.e. exact text duplicates) within each output shard.
     """
     resolved_input = input_path or download.output_path
 
@@ -353,6 +365,7 @@ def normalize_step(
             target_partition_bytes=target_partition_bytes,
             worker_resources=worker_resources,
             file_extensions=file_extensions,
+            exact_dedup=exact_dedup,
         ),
         deps=[download],
         hash_attrs={
@@ -361,6 +374,7 @@ def normalize_step(
             "target_partition_bytes": target_partition_bytes,
             "input_path": resolved_input,
             "file_extensions": file_extensions,
+            "exact_dedup": exact_dedup,
         },
         override_output_path=override_output_path,
     )

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -19,6 +19,7 @@ import os
 from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import Any
 
 import dupekit
@@ -30,6 +31,17 @@ from zephyr import Dataset, ZephyrContext
 from zephyr.readers import SUPPORTED_EXTENSIONS, load_file
 
 logger = logging.getLogger(__name__)
+
+
+class DedupMode(StrEnum):
+    """How aggressively to deduplicate records during normalization.
+
+    ``EXACT`` drops records with duplicate ``id`` (i.e. byte-identical text)
+    within each output shard.  ``NONE`` skips the dedup pass entirely.
+    """
+
+    NONE = "none"
+    EXACT = "exact"
 
 
 @dataclass
@@ -177,7 +189,7 @@ def _build_pipeline(
     num_shards: int,
     text_field: str,
     id_field: str | None,
-    exact_dedup: bool,
+    dedup_mode: DedupMode,
 ) -> Dataset:
     """Build a single Zephyr pipeline for one subdirectory."""
     normalize_record = _make_normalize_fn(text_field, id_field)
@@ -192,7 +204,7 @@ def _build_pipeline(
                 yield record
 
     def passthrough(_key: int, items: Iterator[dict[str, Any]]) -> Iterator[dict[str, Any]]:
-        """Yield items unchanged; used when exact dedup is disabled."""
+        """Yield items unchanged; used when dedup is disabled."""
         yield from items
 
     def has_text(record: dict[str, Any]) -> bool:
@@ -202,6 +214,8 @@ def _build_pipeline(
             return False
         return True
 
+    reducers: dict[DedupMode, Callable] = {DedupMode.EXACT: dedup, DedupMode.NONE: passthrough}
+
     return (
         Dataset.from_list(files)
         .flat_map(load_file)
@@ -209,7 +223,7 @@ def _build_pipeline(
         .map(normalize_record)
         .group_by(
             key=lambda r: int(r["id"], 16) % num_shards,
-            reducer=dedup if exact_dedup else passthrough,
+            reducer=reducers[dedup_mode],
             sort_by=lambda r: r["id"],
             num_output_shards=num_shards,
         )
@@ -229,15 +243,15 @@ def normalize_to_parquet(
     target_partition_bytes: int = 256 * 1024 * 1024,
     worker_resources: ResourceConfig | None = None,
     file_extensions: tuple[str, ...] | None = None,
-    exact_dedup: bool = True,
+    dedup_mode: DedupMode = DedupMode.EXACT,
 ) -> NormalizeResult:
     """Normalize raw downloaded data to the datakit standard Parquet format.
 
     Discovers all data files under *input_path*, groups them by subdirectory,
     and launches one Zephyr pipeline per subdirectory concurrently.  Each
     pipeline normalizes records (``id``, ``text``, preserves all other columns),
-    optionally exact-deduplicates by content, sorts by ``id``, and writes
-    Parquet partitions sized by *target_partition_bytes*.
+    optionally deduplicates by content per *dedup_mode*, sorts by ``id``, and
+    writes Parquet partitions sized by *target_partition_bytes*.
 
     Args:
         input_path: Root directory containing raw downloaded data.
@@ -255,9 +269,10 @@ def normalize_to_parquet(
         file_extensions: Tuple of file extensions to include (e.g.
             ``(".parquet",)``).  Defaults to all extensions supported by
             ``zephyr.readers.load_file``.
-        exact_dedup: If True (the default), drop records with duplicate ``id``
-            values (i.e. exact text duplicates) within each output shard.  Set
-            to False to skip the dedup pass and preserve all input records.
+        dedup_mode: How to deduplicate records within each output shard.
+            ``EXACT`` (the default) drops records with duplicate ``id`` values
+            (i.e. byte-identical text).  ``NONE`` skips dedup and preserves
+            all input records.
 
     Returns:
         A :class:`NormalizeResult` describing the output files and zephyr
@@ -285,7 +300,7 @@ def normalize_to_parquet(
             num_shards,
         )
 
-        pipeline = _build_pipeline(files, output_dir, num_shards, text_field, id_field, exact_dedup)
+        pipeline = _build_pipeline(files, output_dir, num_shards, text_field, id_field, dedup_mode)
         ctx = ZephyrContext(
             name=f"normalize-{subdir.replace('/', '-') if subdir else 'all'}",
             resources=resources,
@@ -332,7 +347,7 @@ def normalize_step(
     override_output_path: str | None = None,
     input_path: str | None = None,
     file_extensions: tuple[str, ...] | None = None,
-    exact_dedup: bool = True,
+    dedup_mode: DedupMode = DedupMode.EXACT,
 ) -> StepSpec:
     """Create a StepSpec that normalizes downloaded data to Parquet.
 
@@ -350,8 +365,8 @@ def normalize_step(
         file_extensions: Tuple of file extensions to include (e.g.
             ``(".parquet",)``).  Defaults to all extensions supported by
             ``zephyr.readers.load_file``.
-        exact_dedup: If True (the default), drop records with duplicate ``id``
-            values (i.e. exact text duplicates) within each output shard.
+        dedup_mode: How to deduplicate records within each output shard.
+            Defaults to ``DedupMode.EXACT``; use ``DedupMode.NONE`` to skip.
     """
     resolved_input = input_path or download.output_path
 
@@ -365,7 +380,7 @@ def normalize_step(
             target_partition_bytes=target_partition_bytes,
             worker_resources=worker_resources,
             file_extensions=file_extensions,
-            exact_dedup=exact_dedup,
+            dedup_mode=dedup_mode,
         ),
         deps=[download],
         hash_attrs={
@@ -374,7 +389,7 @@ def normalize_step(
             "target_partition_bytes": target_partition_bytes,
             "input_path": resolved_input,
             "file_extensions": file_extensions,
-            "exact_dedup": exact_dedup,
+            "dedup_mode": dedup_mode,
         },
         override_output_path=override_output_path,
     )

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -182,8 +182,8 @@ def _build_pipeline(
     """Build a single Zephyr pipeline for one subdirectory."""
     normalize_record = _make_normalize_fn(text_field, id_field)
 
-    def dedup_and_sort(_key: int, items: Iterator[dict[str, Any]]) -> Iterator[dict[str, Any]]:
-        """Deduplicate by id. Items arrive sorted by id via sort_by."""
+    def dedup(_key: int, items: Iterator[dict[str, Any]]) -> Iterator[dict[str, Any]]:
+        """Drop adjacent duplicate ids. Items arrive sorted by id via sort_by."""
         prev_id: str | None = None
         for record in items:
             rid = record["id"]
@@ -209,7 +209,7 @@ def _build_pipeline(
         .map(normalize_record)
         .group_by(
             key=lambda r: int(r["id"], 16) % num_shards,
-            reducer=dedup_and_sort if exact_dedup else passthrough,
+            reducer=dedup if exact_dedup else passthrough,
             sort_by=lambda r: r["id"],
             num_output_shards=num_shards,
         )


### PR DESCRIPTION
* add `dedup_mode: DedupMode` to `normalize_to_parquet` and `normalize_step` so the per-shard id-dedup pass can be skipped
* `DedupMode` is a `StrEnum` with `EXACT` (current behavior, default) and `NONE` (skip dedup) — leaves room for future modes (e.g. minhash) [^1]
* when `DedupMode.NONE`, the `group_by` reducer becomes a passthrough — records are still sharded and id-sorted, just not de-duplicated
* `dedup_mode` is included in `hash_attrs` so cached step outputs distinguish runs by mode

[^1]: default is `EXACT`, so existing call sites keep current behavior with no changes.