### PR TITLE
[Agents] Prefer main repo branches for PRs

### DIFF
--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -85,6 +85,11 @@ A specification contains:
 
 ## Creating the PR
 
+Unless the user says otherwise, and when permissions allow, push directly to a
+branch on the main repository and open the PR from that branch. Do not default
+to pushing to a fork. Use a fork only when direct push to the main repository
+is not available or the user explicitly asks for it.
+
 Use `gh pr create` with these flags:
 
 ```bash


### PR DESCRIPTION
Update the pull-request skill to prefer pushing directly to a branch on the main repository when permissions allow. Fall back to a fork only when direct push is unavailable or the user explicitly asks for it.