### PR TITLE
tests: restore integration-test pytest wrapper

### DIFF
--- a/.github/workflows/iris-coreweave-ci.yaml
+++ b/.github/workflows/iris-coreweave-ci.yaml
@@ -175,9 +175,9 @@ jobs:
           AWS_ENDPOINT_URL: https://74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com
           FSSPEC_S3: '{"endpoint_url": "https://74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com"}'
         run: |
-          IRIS_CONTROLLER_URL="http://localhost:${LOCAL_PORT}"
-          timeout 600 uv run tests/integration_test.py \
-            --controller-url "$IRIS_CONTROLLER_URL"
+          export IRIS_CONTROLLER_URL="http://localhost:${LOCAL_PORT}"
+          timeout 600 uv run pytest tests/test_integration_test.py \
+            -m integration -o "addopts=" --timeout=600 -v -s
 
       - name: Stop port-forward
         if: always()

--- a/.github/workflows/marin-itest.yaml
+++ b/.github/workflows/marin-itest.yaml
@@ -82,8 +82,8 @@ jobs:
 
       - name: Run full marin integration pipeline
         run: |
-          timeout 600 uv run tests/integration_test.py \
-            --controller-url "$IRIS_CONTROLLER_URL"
+          timeout 600 uv run pytest tests/test_integration_test.py \
+            -m integration -o "addopts=" --timeout=600 -v -s
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           WANDB_MODE: disabled

--- a/tests/test_integration_test.py
+++ b/tests/test_integration_test.py
@@ -24,10 +24,6 @@ _CONTROLLER_URL_RE = re.compile(r"Controller started at (\S+)")
 
 
 @pytest.mark.integration
-@pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="Skip in CI; the marin-itest workflow runs the script directly against its own cluster.",
-)
 def test_integration_test_run(tmp_path):
     with _iris_controller_url(tmp_path) as url:
         result = subprocess.run(

--- a/tests/test_integration_test.py
+++ b/tests/test_integration_test.py
@@ -1,24 +1,93 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+"""Pytest wrapper for the end-to-end integration script.
+
+Runs ``tests/integration_test.py`` against an Iris controller. If
+``IRIS_CONTROLLER_URL`` is set the wrapper reuses that cluster; otherwise
+it spawns a local one for the duration of the test and tears it down on
+exit.
+"""
+
 import os
+import re
+import signal
 import subprocess
-import tempfile
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 import pytest
 
+MARIN_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_CONTROLLER_URL_RE = re.compile(r"Controller started at (\S+)")
+
 
 @pytest.mark.integration
-@pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip this test in CI, since we run it as a separate worflow.")
-def test_integration_test_run():
-    MARIN_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    """Test the dry runs of experiment scripts"""
-    # Emulate running tests/integration_test.py on the cmdline
-    # don't name dir `test` because tokenizer gets mad that you're trying to train on test
-    with tempfile.TemporaryDirectory(prefix="executor-integration") as temp_dir:
+@pytest.mark.skipif(
+    os.getenv("CI") == "true",
+    reason="Skip in CI; the marin-itest workflow runs the script directly against its own cluster.",
+)
+def test_integration_test_run(tmp_path):
+    with _iris_controller_url(tmp_path) as url:
         result = subprocess.run(
-            ["python", os.path.join(MARIN_ROOT, "tests/integration_test.py"), "--prefix", temp_dir],
-            capture_output=False,
-            text=True,
+            ["uv", "run", "python", "tests/integration_test.py", "--controller-url", url],
+            cwd=MARIN_ROOT,
         )
-    assert result.returncode == 0, f"Integration test run failed: {result.stderr}"
+        assert result.returncode == 0, f"Integration test returned {result.returncode}"
+
+
+@contextmanager
+def _iris_controller_url(tmp_path) -> Iterator[str]:
+    """Yield a controller URL — either from the env or from a freshly-started local cluster."""
+    env_url = os.environ.get("IRIS_CONTROLLER_URL")
+    if env_url:
+        yield env_url
+        return
+
+    log_file = tmp_path / "iris-cluster.log"
+    with log_file.open("w") as log:
+        cluster = subprocess.Popen(
+            ["uv", "run", "iris", "--config", "lib/iris/examples/test.yaml", "cluster", "start", "--local"],
+            cwd=MARIN_ROOT,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+    try:
+        yield _wait_for_controller_url(log_file, cluster, timeout=180)
+    finally:
+        _kill_process_group(cluster)
+
+
+def _wait_for_controller_url(log_file, cluster: subprocess.Popen, timeout: float) -> str:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if cluster.poll() is not None:
+            raise RuntimeError(
+                f"Cluster exited (code={cluster.returncode}) before printing controller URL; log at {log_file}"
+            )
+        if log_file.exists():
+            for line in log_file.read_text().splitlines():
+                match = _CONTROLLER_URL_RE.search(line)
+                if match:
+                    return match.group(1)
+        time.sleep(1)
+    raise TimeoutError(f"Cluster did not print controller URL within {timeout}s; log at {log_file}")
+
+
+def _kill_process_group(cluster: subprocess.Popen) -> None:
+    try:
+        os.killpg(os.getpgid(cluster.pid), signal.SIGINT)
+    except ProcessLookupError:
+        return
+    try:
+        cluster.wait(timeout=30)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        os.killpg(os.getpgid(cluster.pid), signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    cluster.wait()


### PR DESCRIPTION
* wrapper in `tests/test_integration_test.py` was passing `--prefix` to `integration_test.py`, but #4601 switched that CLI to `--controller-url`[^1]
* rewritten wrapper reuses `IRIS_CONTROLLER_URL` if set, else spawns `iris ... cluster start --local` in its own process group, waits for the controller URL, and tears down on exit
* drop the `skipif(CI == "true")` guard and switch `marin-itest` and `iris-coreweave-ci` to invoke the wrapper via `uv run pytest tests/test_integration_test.py -m integration` so local and CI share one entry point
  * both workflows already export `IRIS_CONTROLLER_URL`, so the env-var branch is taken — no extra cluster spawned
* verified locally: self-start path passes in 97s, env-var path in 99s

[^1]: the break wasn't visible on main because the wrapper was skipped in CI (`skipif(CI == "true")`) and CI invoked `integration_test.py` directly — so only local `pytest -m integration` hit the stale flag