### PR TITLE
[RL] Refactor trainer onto objective runtime and neutral data plane

### DIFF
--- a/lib/marin/src/marin/rl/environments/__init__.py
+++ b/lib/marin/src/marin/rl/environments/__init__.py
@@ -2,5 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .base import EnvConfig, MarinEnv, load_environment_from_spec
+from .spec import EnvironmentIdentity, EnvironmentSample, EnvironmentSpec
 
-__all__ = ["EnvConfig", "MarinEnv", "load_environment_from_spec"]
+__all__ = [
+    "EnvConfig",
+    "EnvironmentIdentity",
+    "EnvironmentSample",
+    "EnvironmentSpec",
+    "MarinEnv",
+    "load_environment_from_spec",
+]

--- a/lib/marin/src/marin/rl/environments/base.py
+++ b/lib/marin/src/marin/rl/environments/base.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 
 from marin.rl.decoding import DecodingConfig
 from marin.rl.environments.inference_ctx.base import BaseInferenceContext
-from marin.rl.types import RolloutGroup
+from marin.rl.environments.spec import EnvironmentIdentity, EnvironmentSample
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ class MarinEnv(ABC):
         prng_key,
         mode: str = "train",
         system_prompt: str | None = None,
-    ) -> tuple[list[RolloutGroup], dict[str, float]]:
+    ) -> EnvironmentSample:
         """Sample examples, generate responses, and create rollouts.
 
         Args:
@@ -42,9 +42,14 @@ class MarinEnv(ABC):
             system_prompt: Optional system prompt to use for generation
 
         Returns:
-            Tuple of (rollout_groups, metrics)
+            EnvironmentSample with rollout groups, metrics, and prompt-level traces
         """
         ...
+
+    def environment_identity(self) -> EnvironmentIdentity:
+        """Return stable task and verifier identity for this environment."""
+
+        return EnvironmentIdentity(task_name=f"{self.__class__.__module__}.{self.__class__.__name__}")
 
 
 @dataclass

--- a/lib/marin/src/marin/rl/environments/math_env.py
+++ b/lib/marin/src/marin/rl/environments/math_env.py
@@ -10,6 +10,7 @@ import jax
 import numpy as np
 from marin.rl.decoding import DecodingConfig
 from marin.rl.environments.inference_ctx.base import BaseInferenceContext
+from marin.rl.environments.spec import EnvironmentIdentity, EnvironmentSample
 from marin.rl.environments.tinker_environments.math_env import (
     MathEnv as TinkerMathEnvBase,
 )
@@ -19,6 +20,7 @@ from marin.rl.environments.tinker_environments.math_env import (
 )
 from marin.rl.environments.tinker_environments.math_grading import extract_boxed, grade_answer, normalize_answer
 from marin.rl.math_utils import last_boxed_only_string
+from marin.rl.traces import EpisodeResponseTrace, EpisodeTrace
 from marin.rl.types import Rollout, RolloutGroup
 
 from .base import MarinEnv
@@ -122,6 +124,14 @@ class MathEnv(MarinEnv):
             return False
         return grade_answer(answer, ground_truth)
 
+    def environment_identity(self) -> EnvironmentIdentity:
+        return EnvironmentIdentity(
+            task_name="math",
+            task_version="tinker_v1",
+            verifier_name="math.tinker_grader",
+            verifier_version="v1",
+        )
+
     def sample(
         self,
         inference_ctx: BaseInferenceContext,
@@ -131,7 +141,7 @@ class MathEnv(MarinEnv):
         prng_key,
         mode: str = "train",
         system_prompt: str | None = None,
-    ) -> tuple[list[RolloutGroup], dict[str, float]]:
+    ) -> EnvironmentSample:
         """Sample prompts, evaluate responses, and create rollouts."""
 
         if mode not in ("train", "eval"):
@@ -161,7 +171,9 @@ class MathEnv(MarinEnv):
             system_prompt=None,  # No system prompt - use few-shot examples instead
         )
 
+        identity = self.environment_identity()
         rollout_groups: list[RolloutGroup] = []
+        traces: list[EpisodeTrace] = []
         total_choices = 0
         reward_sum = 0.0
         format_sum = 0.0
@@ -171,6 +183,7 @@ class MathEnv(MarinEnv):
 
         for example, completion in zip(sampled_examples, completions, strict=True):
             group_rollouts: list[Rollout] = []
+            response_traces: list[EpisodeResponseTrace] = []
 
             for choice in completion.choices:
                 reward, fmt_score, correct_score = self._score_choice(
@@ -201,8 +214,30 @@ class MathEnv(MarinEnv):
                 if choice.finish_reason == "length":
                     truncated_count += 1
 
+                response_traces.append(
+                    EpisodeResponseTrace(
+                        response_text=choice.message.content,
+                        reward=reward,
+                        correctness_reward=correct_score,
+                        is_truncated=choice.finish_reason == "length",
+                        metadata={"format_score": fmt_score},
+                    )
+                )
+
             if group_rollouts:
                 rollout_groups.append(RolloutGroup(rollouts=group_rollouts))
+                traces.append(
+                    EpisodeTrace(
+                        env_name="math",
+                        env_example_id=example.example_id,
+                        prompt=example.processed_prompt,
+                        responses=tuple(response_traces),
+                        task_name=identity.task_name,
+                        task_version=identity.task_version,
+                        verifier_name=identity.verifier_name,
+                        verifier_version=identity.verifier_version,
+                    )
+                )
 
         if total_choices == 0:
             raise RuntimeError("Inference context returned no choices; cannot compute metrics")
@@ -218,7 +253,7 @@ class MathEnv(MarinEnv):
             f"{prefix}_truncated_percentage": float(truncated_count) / total_choices,
         }
 
-        return rollout_groups, metrics
+        return EnvironmentSample(rollout_groups=rollout_groups, metrics=metrics, traces=traces, identity=identity)
 
     def _score_choice(
         self, example: DataExample, response_text: str, finish_reason: str, tokenizer

--- a/lib/marin/src/marin/rl/environments/mock_env.py
+++ b/lib/marin/src/marin/rl/environments/mock_env.py
@@ -13,6 +13,8 @@ import numpy as np
 from levanter.tokenizers import MarinTokenizer
 from marin.rl.decoding import DecodingConfig
 from marin.rl.environments.inference_ctx.base import BaseInferenceContext
+from marin.rl.environments.spec import EnvironmentIdentity, EnvironmentSample
+from marin.rl.traces import EpisodeResponseTrace, EpisodeTrace
 from marin.rl.types import RolloutGroup
 
 from .base import MarinEnv
@@ -271,6 +273,14 @@ class MockEnv(MarinEnv):
             f"{len(self.train_examples)} train examples and {len(self.eval_examples)} eval examples."
         )
 
+    def environment_identity(self) -> EnvironmentIdentity:
+        return EnvironmentIdentity(
+            task_name=f"mock_env:{self.task_type}",
+            task_version="v1",
+            verifier_name="mock_env.reward",
+            verifier_version="v1",
+        )
+
     def sample(
         self,
         inference_ctx: BaseInferenceContext,
@@ -280,7 +290,7 @@ class MockEnv(MarinEnv):
         prng_key,
         mode: str = "train",
         system_prompt: str | None = None,
-    ) -> tuple[list[RolloutGroup], dict[str, float]]:
+    ) -> EnvironmentSample:
         """Sample examples, generate responses, and create rollouts."""
         # Select dataset
         if mode == "train":
@@ -309,10 +319,14 @@ class MockEnv(MarinEnv):
         )
 
         # Evaluate and create rollouts
+        identity = self.environment_identity()
         rollout_groups = []
+        traces = []
 
         for prompt, completion in zip(prompts, completions, strict=True):
             group = []
+            response_traces = []
+            env_example_id = str(hash(prompt))
 
             for choice in completion.choices:
                 true_answer = sampled_examples[prompt]
@@ -322,15 +336,34 @@ class MockEnv(MarinEnv):
                     prompt,
                     choice,
                     env_name=f"mock_env:{self.task_type}",
-                    env_example_id=hash(prompt),
+                    env_example_id=env_example_id,
                     reward=reward,
                     decoding=decoding,
                 )
 
                 group.append(rollout)
+                response_traces.append(
+                    EpisodeResponseTrace(
+                        response_text=choice.message.content,
+                        reward=reward,
+                        is_truncated=choice.finish_reason == "length",
+                    )
+                )
             rollout_groups.append(RolloutGroup(rollouts=group))
+            traces.append(
+                EpisodeTrace(
+                    env_name=f"mock_env:{self.task_type}",
+                    env_example_id=env_example_id,
+                    prompt=prompt,
+                    responses=tuple(response_traces),
+                    task_name=identity.task_name,
+                    task_version=identity.task_version,
+                    verifier_name=identity.verifier_name,
+                    verifier_version=identity.verifier_version,
+                )
+            )
 
-        return rollout_groups, {}
+        return EnvironmentSample(rollout_groups=rollout_groups, metrics={}, traces=traces, identity=identity)
 
     def training_data(self) -> Iterator[MockEnvExample]:
         """Stream training data."""

--- a/lib/marin/src/marin/rl/environments/prime_intellect_env.py
+++ b/lib/marin/src/marin/rl/environments/prime_intellect_env.py
@@ -13,8 +13,10 @@ import jax.numpy as jnp
 import numpy as np
 from marin.rl.decoding import DecodingConfig, DecodingStrategy, stop_strings_for_decoding
 from marin.rl.environments import MarinEnv
-from marin.rl.environments.inference_ctx import BaseInferenceContext
 from marin.rl.environments.process_vllm_results import process_vllm_chat_results
+from marin.rl.environments.spec import EnvironmentIdentity, EnvironmentSample
+from marin.rl.environments.inference_ctx import BaseInferenceContext
+from marin.rl.traces import EpisodeResponseTrace, EpisodeTrace
 from marin.rl.types import Rollout, RolloutGroup
 
 logger = logging.getLogger(__name__)
@@ -71,6 +73,14 @@ class PrimeIntellectEnv(MarinEnv):
 
         return self.ENVS[env_id]
 
+    def environment_identity(self) -> EnvironmentIdentity:
+        return EnvironmentIdentity(
+            task_name=f"prime_intellect:{self.env_id}",
+            task_version="v1",
+            verifier_name=f"verifiers:{self.env_id}",
+            verifier_version="v1",
+        )
+
     def sample(
         self,
         inference_ctx: BaseInferenceContext,
@@ -80,7 +90,7 @@ class PrimeIntellectEnv(MarinEnv):
         prng_key,
         mode: str = "train",
         system_prompt: str | None = None,
-    ) -> tuple[list[RolloutGroup], dict[str, float]]:
+    ) -> EnvironmentSample:
         """Sample problems and generate responses using the model."""
         del prng_key, system_prompt
         decoding = inference_ctx.resolve_decoding(decoding)
@@ -148,9 +158,12 @@ class PrimeIntellectEnv(MarinEnv):
         )
 
         # Convert to RolloutGroups
+        identity = self.environment_identity()
         rollout_groups = []
+        traces = []
         for prompt_idx in range(len(processed_outputs.prompt_ids)):
             rollouts = []
+            response_traces = []
             for gen_idx in range(n_generations):
                 overall_idx = prompt_idx * n_generations + gen_idx
                 if overall_idx >= len(processed_outputs.completion_ids):
@@ -177,9 +190,29 @@ class PrimeIntellectEnv(MarinEnv):
                     is_truncated=False,  # prime intellect doesn't seem to report this easily
                 )
                 rollouts.append(rollout)
+                response_text = result.completion[overall_idx] if overall_idx < len(result.completion) else ""
+                response_traces.append(
+                    EpisodeResponseTrace(
+                        response_text=response_text,
+                        reward=float(reward),
+                    )
+                )
 
             if rollouts:
                 rollout_groups.append(RolloutGroup(rollouts=rollouts))
+                prompt_text = result.prompt[prompt_idx * n_generations] if result.prompt else ""
+                traces.append(
+                    EpisodeTrace(
+                        env_name=f"prime_intellect:{self.env_id}",
+                        env_example_id=f"{self.env_id}_example_{prompt_idx}",
+                        prompt=prompt_text,
+                        responses=tuple(response_traces),
+                        task_name=identity.task_name,
+                        task_version=identity.task_version,
+                        verifier_name=identity.verifier_name,
+                        verifier_version=identity.verifier_version,
+                    )
+                )
 
         # Extract metrics
         metrics = {}
@@ -191,4 +224,4 @@ class PrimeIntellectEnv(MarinEnv):
             metrics[f"{self.env_id}.total_rollouts"] = len(result.reward)
 
         logger.info(f"Generated {len(rollout_groups)} rollout groups")
-        return rollout_groups, metrics
+        return EnvironmentSample(rollout_groups=rollout_groups, metrics=metrics, traces=traces, identity=identity)

--- a/lib/marin/src/marin/rl/environments/prime_intellect_env.py
+++ b/lib/marin/src/marin/rl/environments/prime_intellect_env.py
@@ -13,9 +13,9 @@ import jax.numpy as jnp
 import numpy as np
 from marin.rl.decoding import DecodingConfig, DecodingStrategy, stop_strings_for_decoding
 from marin.rl.environments import MarinEnv
+from marin.rl.environments.inference_ctx import BaseInferenceContext
 from marin.rl.environments.process_vllm_results import process_vllm_chat_results
 from marin.rl.environments.spec import EnvironmentIdentity, EnvironmentSample
-from marin.rl.environments.inference_ctx import BaseInferenceContext
 from marin.rl.traces import EpisodeResponseTrace, EpisodeTrace
 from marin.rl.types import Rollout, RolloutGroup
 

--- a/lib/marin/src/marin/rl/environments/spec.py
+++ b/lib/marin/src/marin/rl/environments/spec.py
@@ -1,0 +1,61 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Environment contracts for trace-aware rollout generation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from marin.rl.decoding import DecodingConfig
+from marin.rl.traces import EpisodeTrace
+from marin.rl.types import RolloutGroup
+
+
+@dataclass(frozen=True)
+class EnvironmentIdentity:
+    """Stable task and verifier identity for an environment."""
+
+    task_name: str
+    task_version: str = "v1"
+    verifier_name: str | None = None
+    verifier_version: str | None = None
+
+
+@dataclass(frozen=True)
+class EnvironmentSample:
+    """Rollout output plus cold-path trace metadata."""
+
+    rollout_groups: list[RolloutGroup]
+    metrics: dict[str, float | int] = field(default_factory=dict)
+    traces: list[EpisodeTrace] = field(default_factory=list)
+    identity: EnvironmentIdentity = field(default_factory=lambda: EnvironmentIdentity(task_name=""))
+
+
+class EnvironmentSpec(Protocol):
+    """Protocol for trace-aware Marin environments."""
+
+    def environment_identity(self) -> EnvironmentIdentity:
+        """Return stable task and verifier identity."""
+        ...
+
+    def sample(
+        self,
+        inference_ctx,
+        n_examples: int,
+        n_generations: int,
+        decoding: DecodingConfig,
+        prng_key,
+        mode: str = "train",
+        system_prompt: str | None = None,
+    ) -> EnvironmentSample:
+        """Sample prompts, run generation, and return rollout groups plus traces."""
+        ...
+
+
+def environment_metrics(sample: EnvironmentSample) -> Mapping[str, float | int]:
+    """Return environment metrics from a sample."""
+
+    return sample.metrics

--- a/lib/marin/src/marin/rl/job_config.py
+++ b/lib/marin/src/marin/rl/job_config.py
@@ -28,8 +28,8 @@ from marin.rl.environments.inference_ctx import (
     LevanterInferenceContextConfig,
     vLLMInferenceContextConfig,
 )
+from marin.rl.objectives import ObjectiveSpec
 from marin.rl.replay_buffer import ReplayBufferConfig
-from marin.rl.rl_losses import RLLossModule
 from marin.rl.rollout_storage import RolloutStorageConfig, StorageType
 from marin.rl.rollout_worker import RolloutTrackerConfig, RolloutWorkerConfig
 from marin.rl.train_worker import TrainWorkerConfig
@@ -79,7 +79,8 @@ class TrainParams:
     """RL-specific training configuration parameters."""
 
     optimizer: OptimizerConfig
-    rl_loss: "RLLossModule"
+    objective: ObjectiveSpec
+    scorer_vocab_tile_size: int | None = None
     replay_buffer: ReplayBufferConfig = field(
         default_factory=lambda: ReplayBufferConfig(
             capacity=4096,
@@ -262,7 +263,8 @@ def build_worker_configs(config: RLJobConfig) -> tuple[TrainWorkerConfig, Rollou
         model=config.model,
         trainer=config.trainer,
         optimizer=config.train_params.optimizer,
-        loss=config.train_params.rl_loss,
+        objective=config.train_params.objective,
+        scorer_vocab_tile_size=config.train_params.scorer_vocab_tile_size,
         tokenizer=tokenizer,
         replay_buffer=config.train_params.replay_buffer,
         initial_checkpoint=config.initial_checkpoint,

--- a/lib/marin/src/marin/rl/objectives/__init__.py
+++ b/lib/marin/src/marin/rl/objectives/__init__.py
@@ -11,9 +11,9 @@ from .spec import (
     NoRewardSignalConfig,
     ObjectiveSpec,
     PolicyGradientTermConfig,
-    RLOOSignalConfig,
     ReductionConfig,
     ReductionKind,
     ReferenceKLTermConfig,
+    RLOOSignalConfig,
     TruncationPolicy,
 )

--- a/lib/marin/src/marin/rl/objectives/__init__.py
+++ b/lib/marin/src/marin/rl/objectives/__init__.py
@@ -1,0 +1,19 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Composable objective runtime for RL/post-training."""
+
+from .recipes import make_rloo_objective
+from .runtime import ObjectiveBatch, ObjectiveRuntime, ObjectiveRuntimeConfig, build_objective_runtime
+from .signals import PreparedSignals
+from .spec import (
+    BatchView,
+    NoRewardSignalConfig,
+    ObjectiveSpec,
+    PolicyGradientTermConfig,
+    RLOOSignalConfig,
+    ReductionConfig,
+    ReductionKind,
+    ReferenceKLTermConfig,
+    TruncationPolicy,
+)

--- a/lib/marin/src/marin/rl/objectives/recipes.py
+++ b/lib/marin/src/marin/rl/objectives/recipes.py
@@ -7,10 +7,10 @@ from .spec import (
     BatchView,
     ObjectiveSpec,
     PolicyGradientTermConfig,
-    RLOOSignalConfig,
     ReductionConfig,
     ReductionKind,
     ReferenceKLTermConfig,
+    RLOOSignalConfig,
     TruncationPolicy,
 )
 

--- a/lib/marin/src/marin/rl/objectives/recipes.py
+++ b/lib/marin/src/marin/rl/objectives/recipes.py
@@ -1,0 +1,52 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Named objective recipes built on the compositional objective surface."""
+
+from .spec import (
+    BatchView,
+    ObjectiveSpec,
+    PolicyGradientTermConfig,
+    RLOOSignalConfig,
+    ReductionConfig,
+    ReductionKind,
+    ReferenceKLTermConfig,
+    TruncationPolicy,
+)
+
+
+def make_rloo_objective(
+    *,
+    kl_coef: float = 0.1,
+    clip_epsilon_low: float = 0.2,
+    clip_epsilon_high: float = 0.2,
+    tis_importance_sampling_ratio_max: float = 2.0,
+    synchronous: bool = False,
+    do_trainer_inference_mismatch_importance_sampling: bool = False,
+    do_overlong_filtering: bool = False,
+    reduction_kind: ReductionKind = ReductionKind.DAPO,
+) -> ObjectiveSpec:
+    """Return the current RLOO recipe on the new objective surface."""
+    terms = [
+        PolicyGradientTermConfig(
+            clip_epsilon_low=clip_epsilon_low,
+            clip_epsilon_high=clip_epsilon_high,
+            tis_importance_sampling_ratio_max=tis_importance_sampling_ratio_max,
+            do_trainer_inference_mismatch_importance_sampling=do_trainer_inference_mismatch_importance_sampling,
+            synchronous=synchronous,
+        )
+    ]
+    if kl_coef > 0:
+        terms.append(ReferenceKLTermConfig(kl_coef=kl_coef))
+
+    truncation_policy = TruncationPolicy.KEEP
+    if do_overlong_filtering:
+        truncation_policy = TruncationPolicy.FILTER_ENTIRE_RESPONSE
+
+    return ObjectiveSpec(
+        batch_view=BatchView.SEQUENCE,
+        signal_builder=RLOOSignalConfig(),
+        terms=tuple(terms),
+        reduction=ReductionConfig(kind=reduction_kind),
+        truncation_policy=truncation_policy,
+    )

--- a/lib/marin/src/marin/rl/objectives/recipes.py
+++ b/lib/marin/src/marin/rl/objectives/recipes.py
@@ -3,6 +3,8 @@
 
 """Named objective recipes built on the compositional objective surface."""
 
+from marin.rl.kl_regularization import KLConfig
+
 from .spec import (
     BatchView,
     ObjectiveSpec,
@@ -17,13 +19,14 @@ from .spec import (
 
 def make_rloo_objective(
     *,
-    kl_coef: float = 0.1,
+    kl: KLConfig,
     clip_epsilon_low: float = 0.2,
     clip_epsilon_high: float = 0.2,
     tis_importance_sampling_ratio_max: float = 2.0,
     synchronous: bool = False,
     do_trainer_inference_mismatch_importance_sampling: bool = False,
     do_overlong_filtering: bool = False,
+    log_policy_entropy: bool = False,
     reduction_kind: ReductionKind = ReductionKind.DAPO,
 ) -> ObjectiveSpec:
     """Return the current RLOO recipe on the new objective surface."""
@@ -34,10 +37,11 @@ def make_rloo_objective(
             tis_importance_sampling_ratio_max=tis_importance_sampling_ratio_max,
             do_trainer_inference_mismatch_importance_sampling=do_trainer_inference_mismatch_importance_sampling,
             synchronous=synchronous,
+            log_policy_entropy=log_policy_entropy,
         )
     ]
-    if kl_coef > 0:
-        terms.append(ReferenceKLTermConfig(kl_coef=kl_coef))
+    if kl.enabled():
+        terms.append(ReferenceKLTermConfig(kl=kl))
 
     truncation_policy = TruncationPolicy.KEEP
     if do_overlong_filtering:

--- a/lib/marin/src/marin/rl/objectives/reductions.py
+++ b/lib/marin/src/marin/rl/objectives/reductions.py
@@ -1,0 +1,52 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reduction helpers for token-level objective terms."""
+
+import jax
+import jax.numpy as jnp
+
+from .spec import ReductionConfig, ReductionKind
+
+
+def compute_ppo_loss(
+    loss_objective: jax.Array,
+    loss_masks: jax.Array,
+) -> jax.Array:
+    """Compute PPO-style loss with per-sequence normalization."""
+    return -1 * jnp.mean(jnp.sum(loss_objective * loss_masks, axis=1) / jnp.sum(loss_masks, axis=1))
+
+
+def compute_dapo_loss(
+    loss_objective: jax.Array,
+    loss_masks: jax.Array,
+) -> jax.Array:
+    """Compute DAPO-style loss with global token normalization."""
+    return -1 * jnp.mean(jnp.sum(loss_objective * loss_masks, axis=1) / jnp.sum(loss_masks))
+
+
+def compute_grpo_loss(
+    loss_objective: jax.Array,
+    loss_masks: jax.Array,
+    max_output_tokens: int,
+) -> jax.Array:
+    """Compute GRPO-style loss with fixed response-budget normalization."""
+    return -1 * jnp.mean(jnp.sum(loss_objective * loss_masks, axis=1) / max_output_tokens)
+
+
+def reduce_loss_objective(
+    loss_objective: jax.Array,
+    loss_masks: jax.Array,
+    reduction: ReductionConfig,
+    *,
+    max_output_tokens: int,
+) -> jax.Array:
+    """Reduce a token-level objective into a scalar loss."""
+    if reduction.kind == ReductionKind.PPO:
+        return compute_ppo_loss(loss_objective, loss_masks)
+    if reduction.kind == ReductionKind.DAPO:
+        return compute_dapo_loss(loss_objective, loss_masks)
+    if reduction.kind == ReductionKind.GRPO:
+        return compute_grpo_loss(loss_objective, loss_masks, max_output_tokens=max_output_tokens)
+
+    raise ValueError(f"Unsupported reduction kind: {reduction.kind}")

--- a/lib/marin/src/marin/rl/objectives/runtime.py
+++ b/lib/marin/src/marin/rl/objectives/runtime.py
@@ -10,7 +10,6 @@ import jax
 import jax.numpy as jnp
 from levanter.metrics import Metric, ReductionType
 from levanter.models.lm_model import LmHeadModel
-
 from marin.rl.scoring import LocalScoreSource, ModelRoles, ScoreRequirements, ScoreSource
 from marin.rl.types import BatchInfo, SequenceBatch
 

--- a/lib/marin/src/marin/rl/objectives/runtime.py
+++ b/lib/marin/src/marin/rl/objectives/runtime.py
@@ -1,0 +1,174 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Objective runtime for neutral RL/post-training batches."""
+
+from dataclasses import dataclass
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from levanter.metrics import Metric, ReductionType
+from levanter.models.lm_model import LmHeadModel
+
+from marin.rl.scoring import LocalScoreSource, ModelRoles, ScoreRequirements, ScoreSource
+from marin.rl.types import BatchInfo, SequenceBatch
+
+from .signals import PreparedSignals, SignalBuilder, build_signal_builder
+from .spec import BatchView, ObjectiveSpec
+from .terms import LossTerm, build_loss_terms
+
+
+class ObjectiveBatch(eqx.Module):
+    """Prepared device-ready batch for an objective runtime."""
+
+    sequence_batch: SequenceBatch
+    signals: PreparedSignals
+
+
+@dataclass(frozen=True)
+class ObjectiveRuntimeConfig:
+    """Runtime configuration for compiling one objective recipe."""
+
+    objective: ObjectiveSpec
+    metric_namespace: str = ""
+    vocab_tile_size: int | None = None
+
+
+@dataclass(frozen=True)
+class ObjectiveRuntime:
+    """Compiled runtime for a concrete objective recipe."""
+
+    config: ObjectiveRuntimeConfig
+    score_source: ScoreSource
+    signal_builder: SignalBuilder
+    terms: tuple[LossTerm, ...]
+    score_requirements: ScoreRequirements
+
+    def prepare_batch(self, batch: SequenceBatch, info: BatchInfo) -> ObjectiveBatch:
+        """Prepare one neutral batch for device execution."""
+        if self.config.objective.batch_view is not BatchView.SEQUENCE:
+            raise NotImplementedError(f"Batch view {self.config.objective.batch_view!r} is not implemented yet")
+
+        return ObjectiveBatch(
+            sequence_batch=batch,
+            signals=self.signal_builder.build(batch, info),
+        )
+
+    def create_loss_fn(
+        self,
+        *,
+        reference_model: LmHeadModel | None = None,
+        teacher_model: LmHeadModel | None = None,
+    ):
+        """Create the objective loss function used by the trainer."""
+
+        def loss_fn(model: LmHeadModel, batch: ObjectiveBatch, key: jax.Array | None):
+            score_bundle = self.score_source.score(
+                batch.sequence_batch,
+                info=None,
+                roles=ModelRoles(student=model, reference=reference_model, teacher=teacher_model),
+                key=key,
+            )
+
+            total_loss = jnp.asarray(0.0, dtype=jnp.float32)
+            metrics: dict[str, Metric] = {}
+            for term in self.terms:
+                result = term.compute(batch.sequence_batch, batch.signals, score_bundle)
+                total_loss = total_loss + result.loss
+                metrics.update(result.metrics)
+
+            metrics.update(
+                {
+                    "scoring/student_pass_count": Metric.from_value(
+                        jnp.asarray(score_bundle.student_pass_count, dtype=jnp.float32),
+                        ReductionType.MEAN,
+                    ),
+                    "scoring/reference_pass_count": Metric.from_value(
+                        jnp.asarray(score_bundle.reference_pass_count, dtype=jnp.float32),
+                        ReductionType.MEAN,
+                    ),
+                    "scoring/teacher_pass_count": Metric.from_value(
+                        jnp.asarray(score_bundle.teacher_pass_count, dtype=jnp.float32),
+                        ReductionType.MEAN,
+                    ),
+                }
+            )
+
+            if self.config.metric_namespace:
+                metrics = {f"{self.config.metric_namespace}/{name}": metric for name, metric in metrics.items()}
+
+            return total_loss, metrics
+
+        return loss_fn
+
+
+def _merge_score_requirements(requirements: tuple[ScoreRequirements, ...]) -> ScoreRequirements:
+    teacher_topk_support: int | None = None
+    for requirement in requirements:
+        if requirement.teacher_topk_support is None:
+            continue
+        if teacher_topk_support is None:
+            teacher_topk_support = requirement.teacher_topk_support
+        else:
+            teacher_topk_support = max(teacher_topk_support, requirement.teacher_topk_support)
+
+    return ScoreRequirements(
+        student_logprobs=any(requirement.student_logprobs for requirement in requirements),
+        behavior_logprobs=any(requirement.behavior_logprobs for requirement in requirements),
+        reference_logprobs=any(requirement.reference_logprobs for requirement in requirements),
+        teacher_token_logprobs=any(requirement.teacher_token_logprobs for requirement in requirements),
+        teacher_entropy=any(requirement.teacher_entropy for requirement in requirements),
+        teacher_topk_support=teacher_topk_support,
+    )
+
+
+def _validate_score_source_requirements(provided: ScoreRequirements, required: ScoreRequirements) -> None:
+    missing: list[str] = []
+    if required.student_logprobs and not provided.student_logprobs:
+        missing.append("student_logprobs")
+    if required.behavior_logprobs and not provided.behavior_logprobs:
+        missing.append("behavior_logprobs")
+    if required.reference_logprobs and not provided.reference_logprobs:
+        missing.append("reference_logprobs")
+    if required.teacher_token_logprobs and not provided.teacher_token_logprobs:
+        missing.append("teacher_token_logprobs")
+    if required.teacher_entropy and not provided.teacher_entropy:
+        missing.append("teacher_entropy")
+    if required.teacher_topk_support is not None:
+        if provided.teacher_topk_support is None or provided.teacher_topk_support < required.teacher_topk_support:
+            missing.append(f"teacher_topk_support>={required.teacher_topk_support}")
+
+    if missing:
+        raise ValueError(f"score source is missing required scores: {', '.join(missing)}")
+
+
+def build_objective_runtime(
+    config: ObjectiveRuntimeConfig,
+    *,
+    score_source: ScoreSource | None = None,
+) -> ObjectiveRuntime:
+    """Build a compiled objective runtime from the public objective spec."""
+    signal_builder = build_signal_builder(config.objective.signal_builder)
+    terms = build_loss_terms(
+        config.objective.terms,
+        reduction=config.objective.reduction,
+        truncation_policy=config.objective.truncation_policy,
+    )
+    score_requirements = _merge_score_requirements(tuple(term.score_requirements() for term in terms))
+
+    resolved_score_source = score_source
+    if resolved_score_source is None:
+        resolved_score_source = LocalScoreSource(
+            score_requirements=score_requirements,
+            vocab_tile_size=config.vocab_tile_size,
+        )
+    _validate_score_source_requirements(resolved_score_source.requirements(), score_requirements)
+
+    return ObjectiveRuntime(
+        config=config,
+        score_source=resolved_score_source,
+        signal_builder=signal_builder,
+        terms=terms,
+        score_requirements=score_requirements,
+    )

--- a/lib/marin/src/marin/rl/objectives/runtime.py
+++ b/lib/marin/src/marin/rl/objectives/runtime.py
@@ -143,12 +143,22 @@ def _validate_score_source_requirements(provided: ScoreRequirements, required: S
         raise ValueError(f"score source is missing required scores: {', '.join(missing)}")
 
 
+def _validate_runtime_config(config: ObjectiveRuntimeConfig) -> None:
+    """Reject objective shapes the active runtime cannot execute yet."""
+    if config.objective.batch_view is not BatchView.SEQUENCE:
+        raise NotImplementedError(
+            "The active objective runtime currently supports only sequence batches; "
+            f"got batch_view={config.objective.batch_view.value!r}"
+        )
+
+
 def build_objective_runtime(
     config: ObjectiveRuntimeConfig,
     *,
     score_source: ScoreSource | None = None,
 ) -> ObjectiveRuntime:
     """Build a compiled objective runtime from the public objective spec."""
+    _validate_runtime_config(config)
     signal_builder = build_signal_builder(config.objective.signal_builder)
     terms = build_loss_terms(
         config.objective.terms,

--- a/lib/marin/src/marin/rl/objectives/runtime.py
+++ b/lib/marin/src/marin/rl/objectives/runtime.py
@@ -114,6 +114,7 @@ def _merge_score_requirements(requirements: tuple[ScoreRequirements, ...]) -> Sc
 
     return ScoreRequirements(
         student_logprobs=any(requirement.student_logprobs for requirement in requirements),
+        student_entropy=any(requirement.student_entropy for requirement in requirements),
         behavior_logprobs=any(requirement.behavior_logprobs for requirement in requirements),
         reference_logprobs=any(requirement.reference_logprobs for requirement in requirements),
         teacher_token_logprobs=any(requirement.teacher_token_logprobs for requirement in requirements),
@@ -126,6 +127,8 @@ def _validate_score_source_requirements(provided: ScoreRequirements, required: S
     missing: list[str] = []
     if required.student_logprobs and not provided.student_logprobs:
         missing.append("student_logprobs")
+    if required.student_entropy and not provided.student_entropy:
+        missing.append("student_entropy")
     if required.behavior_logprobs and not provided.behavior_logprobs:
         missing.append("behavior_logprobs")
     if required.reference_logprobs and not provided.reference_logprobs:

--- a/lib/marin/src/marin/rl/objectives/signals.py
+++ b/lib/marin/src/marin/rl/objectives/signals.py
@@ -12,7 +12,6 @@ import haliax.haxtyping as ht
 import jax.numpy as jnp
 import numpy as np
 from haliax import NamedArray
-
 from marin.rl.types import BatchInfo, SequenceBatch
 
 from .spec import NoRewardSignalConfig, RLOOSignalConfig, SignalConfig

--- a/lib/marin/src/marin/rl/objectives/signals.py
+++ b/lib/marin/src/marin/rl/objectives/signals.py
@@ -1,0 +1,113 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Signal builders that turn neutral batch metadata into training signals."""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import equinox as eqx
+import haliax as hax
+import haliax.haxtyping as ht
+import jax.numpy as jnp
+import numpy as np
+from haliax import NamedArray
+
+from marin.rl.types import BatchInfo, SequenceBatch
+
+from .spec import NoRewardSignalConfig, RLOOSignalConfig, SignalConfig
+
+
+def compute_rloo_advantages_from_rewards(rewards: np.ndarray) -> np.ndarray:
+    """Compute reward leave-one-out advantages from a reward vector."""
+    rewards = np.asarray(rewards, dtype=np.float32)
+    if len(rewards) <= 1:
+        return np.zeros_like(rewards)
+
+    total = rewards.sum()
+    leave_one_out_baselines = (total - rewards) / (len(rewards) - 1)
+    return rewards - leave_one_out_baselines
+
+
+def _group_indices(group_ids: tuple[str, ...]) -> dict[str, list[int]]:
+    indices: dict[str, list[int]] = {}
+    for idx, group_id in enumerate(group_ids):
+        indices.setdefault(group_id, []).append(idx)
+    return indices
+
+
+class PreparedSignals(eqx.Module):
+    """Device-ready signals derived from objective-neutral batch metadata."""
+
+    sequence_advantages: ht.Float[NamedArray, "batch"]  # noqa: F821
+    token_weights: ht.Float[NamedArray, "batch position"]
+    loss_mask: ht.Float[NamedArray, "batch position"]
+    group_size: ht.Int[NamedArray, "batch"]  # noqa: F821
+
+
+class SignalBuilder(Protocol):
+    """Build device-ready objective signals from neutral batch metadata."""
+
+    def build(self, batch: SequenceBatch, info: BatchInfo) -> PreparedSignals:
+        """Build prepared signals for one sequence batch."""
+        ...
+
+
+@dataclass(frozen=True)
+class RLOOSignalBuilder:
+    """Build per-sequence RLOO advantages and token weights."""
+
+    config: RLOOSignalConfig
+
+    def build(self, batch: SequenceBatch, info: BatchInfo) -> PreparedSignals:
+        rewards = np.asarray(info.episode_reward.array, dtype=np.float32)
+        group_indices = _group_indices(info.group_id)
+        advantages = np.zeros(len(info), dtype=np.float32)
+        group_sizes = np.zeros(len(info), dtype=np.int32)
+
+        for indices in group_indices.values():
+            index_array = np.asarray(indices, dtype=np.int32)
+            advantages[index_array] = compute_rloo_advantages_from_rewards(rewards[index_array])
+            group_sizes[index_array] = len(indices)
+
+        sequence_advantages = jnp.asarray(advantages, dtype=jnp.float32)
+        token_weights = batch.response_mask.array * sequence_advantages[:, None]
+        return PreparedSignals(
+            sequence_advantages=hax.named(sequence_advantages, ["batch"]),
+            token_weights=hax.named(token_weights, ["batch", "position"]),
+            loss_mask=batch.response_mask,
+            group_size=hax.named(jnp.asarray(group_sizes, dtype=jnp.int32), ["batch"]),
+        )
+
+
+@dataclass(frozen=True)
+class NoRewardSignalBuilder:
+    """Build zero-valued sequence signals for reward-free objectives."""
+
+    config: NoRewardSignalConfig
+
+    def build(self, batch: SequenceBatch, info: BatchInfo) -> PreparedSignals:
+        group_indices = _group_indices(info.group_id)
+        group_sizes = np.zeros(len(info), dtype=np.int32)
+        for indices in group_indices.values():
+            index_array = np.asarray(indices, dtype=np.int32)
+            group_sizes[index_array] = len(indices)
+
+        sequence_advantages = jnp.zeros((len(info),), dtype=jnp.float32)
+        token_weights = jnp.zeros_like(batch.response_mask.array)
+        return PreparedSignals(
+            sequence_advantages=hax.named(sequence_advantages, ["batch"]),
+            token_weights=hax.named(token_weights, ["batch", "position"]),
+            loss_mask=batch.response_mask,
+            group_size=hax.named(jnp.asarray(group_sizes, dtype=jnp.int32), ["batch"]),
+        )
+
+
+def build_signal_builder(config: SignalConfig) -> SignalBuilder:
+    """Instantiate a concrete signal builder from the public config."""
+    if isinstance(config, RLOOSignalConfig):
+        return RLOOSignalBuilder(config)
+    if isinstance(config, NoRewardSignalConfig):
+        return NoRewardSignalBuilder(config)
+
+    raise TypeError(f"Unsupported signal config: {type(config)!r}")

--- a/lib/marin/src/marin/rl/objectives/spec.py
+++ b/lib/marin/src/marin/rl/objectives/spec.py
@@ -1,0 +1,86 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stable public objective specification for RL/post-training."""
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TypeAlias
+
+
+class BatchView(StrEnum):
+    """Batch view consumed by an objective runtime."""
+
+    SEQUENCE = "sequence"
+    GROUP = "group"
+
+
+class ReductionKind(StrEnum):
+    """Supported token-objective reduction semantics."""
+
+    PPO = "ppo"
+    DAPO = "dapo"
+    GRPO = "grpo"
+
+
+class TruncationPolicy(StrEnum):
+    """Policy for handling truncated responses inside objective terms."""
+
+    KEEP = "keep"
+    FILTER_ENTIRE_RESPONSE = "filter_entire_response"
+
+
+@dataclass(frozen=True)
+class RLOOSignalConfig:
+    """Reward leave-one-out sequence-advantage signal."""
+
+    name: str = "rloo"
+
+
+@dataclass(frozen=True)
+class NoRewardSignalConfig:
+    """Signal with zero advantages, used by reward-free objectives."""
+
+    name: str = "none"
+
+
+SignalConfig: TypeAlias = RLOOSignalConfig | NoRewardSignalConfig
+
+
+@dataclass(frozen=True)
+class PolicyGradientTermConfig:
+    """Policy-gradient term with clipping and optional mismatch correction."""
+
+    clip_epsilon_low: float
+    clip_epsilon_high: float
+    tis_importance_sampling_ratio_max: float
+    do_trainer_inference_mismatch_importance_sampling: bool = False
+    synchronous: bool = False
+
+
+@dataclass(frozen=True)
+class ReferenceKLTermConfig:
+    """Reference-model KL penalty."""
+
+    kl_coef: float
+
+
+LossTermConfig: TypeAlias = PolicyGradientTermConfig | ReferenceKLTermConfig
+
+
+@dataclass(frozen=True)
+class ReductionConfig:
+    """How token-level objectives are normalized into a scalar loss."""
+
+    kind: ReductionKind
+
+
+@dataclass(frozen=True)
+class ObjectiveSpec:
+    """Stable public surface for configuring RL/post-training objectives."""
+
+    batch_view: BatchView
+    signal_builder: SignalConfig
+    terms: tuple[LossTermConfig, ...]
+    reduction: ReductionConfig
+    truncation_policy: TruncationPolicy = TruncationPolicy.KEEP

--- a/lib/marin/src/marin/rl/objectives/spec.py
+++ b/lib/marin/src/marin/rl/objectives/spec.py
@@ -5,7 +5,6 @@
 
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TypeAlias
 
 from marin.rl.kl_regularization import KLConfig
 
@@ -46,7 +45,7 @@ class NoRewardSignalConfig:
     name: str = "none"
 
 
-SignalConfig: TypeAlias = RLOOSignalConfig | NoRewardSignalConfig
+type SignalConfig = RLOOSignalConfig | NoRewardSignalConfig
 
 
 @dataclass(frozen=True)
@@ -68,7 +67,7 @@ class ReferenceKLTermConfig:
     kl: KLConfig
 
 
-LossTermConfig: TypeAlias = PolicyGradientTermConfig | ReferenceKLTermConfig
+type LossTermConfig = PolicyGradientTermConfig | ReferenceKLTermConfig
 
 
 @dataclass(frozen=True)

--- a/lib/marin/src/marin/rl/objectives/spec.py
+++ b/lib/marin/src/marin/rl/objectives/spec.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import TypeAlias
 
+from marin.rl.kl_regularization import KLConfig
+
 
 class BatchView(StrEnum):
     """Batch view consumed by an objective runtime."""
@@ -56,13 +58,14 @@ class PolicyGradientTermConfig:
     tis_importance_sampling_ratio_max: float
     do_trainer_inference_mismatch_importance_sampling: bool = False
     synchronous: bool = False
+    log_policy_entropy: bool = False
 
 
 @dataclass(frozen=True)
 class ReferenceKLTermConfig:
     """Reference-model KL penalty."""
 
-    kl_coef: float
+    kl: KLConfig
 
 
 LossTermConfig: TypeAlias = PolicyGradientTermConfig | ReferenceKLTermConfig

--- a/lib/marin/src/marin/rl/objectives/terms.py
+++ b/lib/marin/src/marin/rl/objectives/terms.py
@@ -1,0 +1,289 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Composable loss terms for RL/post-training objectives."""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import jax
+import jax.numpy as jnp
+from levanter.metrics import Metric, ReductionType
+
+from marin.rl.scoring import ScoreBundle, ScoreRequirements
+from marin.rl.types import SequenceBatch
+
+from .reductions import reduce_loss_objective
+from .signals import PreparedSignals
+from .spec import PolicyGradientTermConfig, ReductionConfig, ReferenceKLTermConfig, TruncationPolicy
+
+
+@dataclass(frozen=True)
+class LossTermResult:
+    """Scalar loss contribution plus observability metrics."""
+
+    loss: jax.Array
+    metrics: dict[str, Metric]
+
+
+class LossTerm(Protocol):
+    """Composable scalar loss term."""
+
+    def score_requirements(self) -> ScoreRequirements:
+        """Return the score requirements for this term."""
+        ...
+
+    def compute(self, batch: SequenceBatch, signals: PreparedSignals, scores: ScoreBundle) -> LossTermResult:
+        """Compute the scalar loss contribution for one prepared batch."""
+        ...
+
+
+def importance_sampling_ratio(
+    current_logprobs: jax.Array,
+    policy_logprobs_array: jax.Array,
+    loss_masks_array: jax.Array,
+    *,
+    stop_current_logprob_gradient: bool = False,
+    stop_policy_logprob_gradient: bool = True,
+) -> jax.Array:
+    """Compute per-token policy-ratio weights."""
+    if stop_current_logprob_gradient:
+        current_logprobs = jax.lax.stop_gradient(current_logprobs)
+
+    if stop_policy_logprob_gradient:
+        policy_logprobs_array = jax.lax.stop_gradient(policy_logprobs_array)
+
+    return jnp.exp(current_logprobs - policy_logprobs_array) * loss_masks_array
+
+
+def compute_metadata_metrics(
+    current_logprobs: jax.Array,
+    policy_logprobs_array: jax.Array,
+    loss_weights_array: jax.Array,
+    loss_masks_array: jax.Array,
+) -> dict[str, Metric]:
+    """Compute legacy RLOO metadata metrics from token-level tensors."""
+    batch_size, _ = policy_logprobs_array.shape
+
+    mean_ratio_difference = jnp.sum(
+        (jnp.abs(jnp.exp(current_logprobs) - jnp.exp(policy_logprobs_array))) * loss_masks_array, axis=1
+    ) / jnp.sum(loss_masks_array, axis=1)
+    mean_ratio_difference = jnp.mean(mean_ratio_difference)
+
+    flattened_current_logprobs = current_logprobs.reshape(-1)
+    flattened_policy_logprobs = policy_logprobs_array.reshape(-1)
+    flattened_loss_masks = loss_masks_array.reshape(-1)
+
+    policy_entropy = -jnp.sum(flattened_policy_logprobs * flattened_loss_masks) / jnp.sum(flattened_loss_masks)
+    current_entropy = -jnp.sum(flattened_current_logprobs * flattened_loss_masks) / jnp.sum(flattened_loss_masks)
+
+    mean_advantages = jnp.sum(loss_weights_array * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1)
+    mean_advantages = jnp.mean(mean_advantages)
+
+    max_ratio_diff = jnp.max(jnp.abs(jnp.exp(current_logprobs) - jnp.exp(policy_logprobs_array)) * loss_masks_array)
+
+    return {
+        "trainer_sampler_prob_diff_max": Metric.from_value(max_ratio_diff.astype(jnp.float32), ReductionType.MAX),
+        "trainer_sampler_prob_diff_mean": Metric.from_value(
+            mean_ratio_difference.astype(jnp.float32), ReductionType.MEAN
+        ),
+        "current_entropy": Metric.from_value(current_entropy.astype(jnp.float32), ReductionType.MEAN),
+        "max_advantages": Metric.from_value(jnp.max(loss_weights_array).astype(jnp.float32), ReductionType.MAX),
+        "mean_advantages": Metric.from_value(mean_advantages.astype(jnp.float32), ReductionType.MEAN),
+        "policy_entropy": Metric.from_value(policy_entropy.astype(jnp.float32), ReductionType.MEAN),
+        "response_tokens_length": Metric.from_value(
+            (jnp.sum(loss_masks_array) / batch_size).astype(jnp.float32), ReductionType.MEAN
+        ),
+    }
+
+
+@dataclass(frozen=True)
+class PolicyGradientTerm:
+    """Clipped policy-gradient term over token-level sequence signals."""
+
+    config: PolicyGradientTermConfig
+    reduction: ReductionConfig
+    truncation_policy: TruncationPolicy
+
+    def score_requirements(self) -> ScoreRequirements:
+        return ScoreRequirements(
+            student_logprobs=True,
+            behavior_logprobs=True,
+        )
+
+    def compute(self, batch: SequenceBatch, signals: PreparedSignals, scores: ScoreBundle) -> LossTermResult:
+        if scores.student_logprobs is None:
+            raise ValueError("student logprobs are required for PolicyGradientTerm")
+        if scores.behavior_logprobs is None:
+            raise ValueError("behavior logprobs are required for PolicyGradientTerm")
+
+        current_logprobs = scores.student_logprobs * signals.loss_mask.array
+        behavior_logprobs = scores.behavior_logprobs
+        loss_weights_array = signals.token_weights.array
+        loss_masks_array = signals.loss_mask.array
+
+        if self.config.synchronous:
+            policy_logprobs_for_ratio = current_logprobs
+        else:
+            policy_logprobs_for_ratio = behavior_logprobs
+
+        ratio = importance_sampling_ratio(
+            current_logprobs,
+            policy_logprobs_for_ratio,
+            loss_masks_array,
+            stop_current_logprob_gradient=False,
+            stop_policy_logprob_gradient=True,
+        )
+        clipped_ratio = jnp.clip(
+            ratio,
+            min=1.0 - self.config.clip_epsilon_low,
+            max=1.0 + self.config.clip_epsilon_high,
+        )
+
+        is_clipped = jnp.logical_or(
+            ratio > 1.0 + self.config.clip_epsilon_high,
+            ratio < 1.0 - self.config.clip_epsilon_low,
+        )
+        clip_fraction = jnp.mean(jnp.sum(is_clipped * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1))
+
+        if self.config.do_trainer_inference_mismatch_importance_sampling:
+            trainer_inference_ratio = importance_sampling_ratio(
+                current_logprobs,
+                behavior_logprobs,
+                loss_masks_array,
+                stop_current_logprob_gradient=True,
+                stop_policy_logprob_gradient=True,
+            )
+            trainer_inference_ratio = jnp.minimum(
+                trainer_inference_ratio,
+                self.config.tis_importance_sampling_ratio_max,
+            )
+        else:
+            trainer_inference_ratio = jnp.ones_like(current_logprobs)
+
+        non_clipped_objective = ratio * loss_weights_array * loss_masks_array
+        clipped_objective = clipped_ratio * loss_weights_array * loss_masks_array
+        loss_objective = jnp.minimum(non_clipped_objective, clipped_objective)
+        loss_objective = trainer_inference_ratio * loss_objective
+
+        if self.truncation_policy is TruncationPolicy.FILTER_ENTIRE_RESPONSE:
+            batch_size, _ = loss_objective.shape
+            loss_objective = loss_objective * (1 - batch.truncated.reshape(batch_size, 1))
+
+        reinforce_loss = reduce_loss_objective(
+            loss_objective,
+            loss_masks_array,
+            self.reduction,
+            max_output_tokens=batch.max_output_tokens,
+        )
+
+        per_batch_loss = jnp.sum(loss_objective * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1)
+        trainer_inference_ratio_mean = jnp.mean(
+            jnp.sum(trainer_inference_ratio * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1)
+        )
+        ratio_mean_over_responses_only = jnp.mean(jnp.sum(ratio, axis=1) / jnp.sum(loss_masks_array, axis=1))
+        clipped_ratio_mean_over_responses_only = jnp.mean(
+            jnp.sum(clipped_ratio * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1)
+        )
+
+        metrics = {
+            "ratio_mean": Metric.from_value(ratio_mean_over_responses_only.astype(jnp.float32), ReductionType.MEAN),
+            "clipped_ratio_mean": Metric.from_value(
+                clipped_ratio_mean_over_responses_only.astype(jnp.float32),
+                ReductionType.MEAN,
+            ),
+            "clip_fraction": Metric.from_value(clip_fraction.astype(jnp.float32), ReductionType.MEAN),
+            "reinforce_loss": Metric.from_value(reinforce_loss.astype(jnp.float32), ReductionType.MEAN),
+            "trainer_inference_importance_sampling_ratio_mean": Metric.from_value(
+                trainer_inference_ratio_mean.astype(jnp.float32),
+                ReductionType.MEAN,
+            ),
+            "temperature": Metric.from_value(
+                jnp.mean(batch.sampling_temperature.array).astype(jnp.float32),
+                ReductionType.MEAN,
+            ),
+            "top_k": Metric.from_value(jnp.mean(batch.sampling_top_k.array).astype(jnp.float32), ReductionType.MEAN),
+            "loss_max_over_batch": Metric.from_value((-jnp.max(per_batch_loss)).astype(jnp.float32), ReductionType.MAX),
+            "loss_std_over_batch": Metric.from_value(jnp.std(per_batch_loss).astype(jnp.float32), ReductionType.MEAN),
+            **compute_metadata_metrics(current_logprobs, behavior_logprobs, loss_weights_array, loss_masks_array),
+        }
+        return LossTermResult(loss=reinforce_loss, metrics=metrics)
+
+
+@dataclass(frozen=True)
+class ReferenceKLTerm:
+    """Reference-model KL regularizer."""
+
+    config: ReferenceKLTermConfig
+
+    def score_requirements(self) -> ScoreRequirements:
+        return ScoreRequirements(
+            student_logprobs=self.config.kl_coef > 0,
+            reference_logprobs=self.config.kl_coef > 0,
+        )
+
+    def compute(self, batch: SequenceBatch, signals: PreparedSignals, scores: ScoreBundle) -> LossTermResult:
+        del batch
+
+        if self.config.kl_coef <= 0:
+            zero = jnp.asarray(0.0, dtype=jnp.float32)
+            return LossTermResult(
+                loss=zero,
+                metrics={
+                    "kl_loss": Metric.from_value(zero, ReductionType.MEAN),
+                    "kl_penalty": Metric.from_value(zero, ReductionType.MEAN),
+                },
+            )
+
+        if scores.student_logprobs is None:
+            raise ValueError("student logprobs are required for ReferenceKLTerm")
+        if scores.reference_logprobs is None:
+            raise ValueError("reference logprobs are required for ReferenceKLTerm")
+
+        loss_masks_array = signals.loss_mask.array
+        current_logprobs = scores.student_logprobs * loss_masks_array
+        reference_logprobs = scores.reference_logprobs * loss_masks_array
+
+        kl_penalty = jnp.exp(reference_logprobs - current_logprobs) - (reference_logprobs - current_logprobs) - 1
+        kl_loss = jnp.mean(jnp.sum(kl_penalty * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1))
+        kl_loss = self.config.kl_coef * kl_loss
+
+        kl_penalty_over_responses_only = jnp.mean(
+            jnp.sum(kl_penalty * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1)
+        )
+        return LossTermResult(
+            loss=kl_loss,
+            metrics={
+                "kl_loss": Metric.from_value(jnp.asarray(kl_loss, dtype=jnp.float32), ReductionType.MEAN),
+                "kl_penalty": Metric.from_value(
+                    jnp.asarray(kl_penalty_over_responses_only, dtype=jnp.float32),
+                    ReductionType.MEAN,
+                ),
+            },
+        )
+
+
+def build_loss_terms(
+    term_configs: tuple[PolicyGradientTermConfig | ReferenceKLTermConfig, ...],
+    *,
+    reduction: ReductionConfig,
+    truncation_policy: TruncationPolicy,
+) -> tuple[LossTerm, ...]:
+    """Instantiate concrete loss terms from the public objective spec."""
+    terms: list[LossTerm] = []
+    for config in term_configs:
+        if isinstance(config, PolicyGradientTermConfig):
+            terms.append(
+                PolicyGradientTerm(
+                    config=config,
+                    reduction=reduction,
+                    truncation_policy=truncation_policy,
+                )
+            )
+            continue
+        if isinstance(config, ReferenceKLTermConfig):
+            terms.append(ReferenceKLTerm(config=config))
+            continue
+
+        raise TypeError(f"Unsupported loss term config: {type(config)!r}")
+    return tuple(terms)

--- a/lib/marin/src/marin/rl/objectives/terms.py
+++ b/lib/marin/src/marin/rl/objectives/terms.py
@@ -9,7 +9,6 @@ from typing import Protocol
 import jax
 import jax.numpy as jnp
 from levanter.metrics import Metric, ReductionType
-
 from marin.rl.scoring import ScoreBundle, ScoreRequirements
 from marin.rl.types import SequenceBatch
 

--- a/lib/marin/src/marin/rl/objectives/terms.py
+++ b/lib/marin/src/marin/rl/objectives/terms.py
@@ -9,6 +9,12 @@ from typing import Protocol
 import jax
 import jax.numpy as jnp
 from levanter.metrics import Metric, ReductionType
+from marin.rl.kl_regularization import (
+    kl_penalty_from_log_ratio,
+    kl_statistics_from_log_ratio,
+    masked_response_mean,
+    token_log_ratio,
+)
 from marin.rl.scoring import ScoreBundle, ScoreRequirements
 from marin.rl.types import SequenceBatch
 
@@ -107,6 +113,7 @@ class PolicyGradientTerm:
     def score_requirements(self) -> ScoreRequirements:
         return ScoreRequirements(
             student_logprobs=True,
+            student_entropy=self.config.log_policy_entropy,
             behavior_logprobs=True,
         )
 
@@ -206,6 +213,15 @@ class PolicyGradientTerm:
             "loss_std_over_batch": Metric.from_value(jnp.std(per_batch_loss).astype(jnp.float32), ReductionType.MEAN),
             **compute_metadata_metrics(current_logprobs, behavior_logprobs, loss_weights_array, loss_masks_array),
         }
+        if self.config.log_policy_entropy:
+            if scores.student_entropy is None:
+                raise ValueError("student entropy is required when log_policy_entropy=True")
+            policy_entropy = masked_response_mean(scores.student_entropy, loss_masks_array)
+            metrics["current_policy_entropy"] = Metric.from_value(
+                jax.lax.stop_gradient(policy_entropy).astype(jnp.float32),
+                ReductionType.MEAN,
+            )
+
         return LossTermResult(loss=reinforce_loss, metrics=metrics)
 
 
@@ -217,19 +233,25 @@ class ReferenceKLTerm:
 
     def score_requirements(self) -> ScoreRequirements:
         return ScoreRequirements(
-            student_logprobs=self.config.kl_coef > 0,
-            reference_logprobs=self.config.kl_coef > 0,
+            student_logprobs=self.config.kl.enabled(),
+            reference_logprobs=self.config.kl.enabled(),
         )
 
     def compute(self, batch: SequenceBatch, signals: PreparedSignals, scores: ScoreBundle) -> LossTermResult:
         del batch
 
-        if self.config.kl_coef <= 0:
+        if not self.config.kl.enabled():
             zero = jnp.asarray(0.0, dtype=jnp.float32)
             return LossTermResult(
                 loss=zero,
                 metrics={
                     "kl_loss": Metric.from_value(zero, ReductionType.MEAN),
+                    "kl_beta": Metric.from_value(
+                        jnp.asarray(self.config.kl.beta, dtype=jnp.float32), ReductionType.MEAN
+                    ),
+                    "kl_k1_mean": Metric.from_value(zero, ReductionType.MEAN),
+                    "kl_k2_mean": Metric.from_value(zero, ReductionType.MEAN),
+                    "kl_k3_mean": Metric.from_value(zero, ReductionType.MEAN),
                     "kl_penalty": Metric.from_value(zero, ReductionType.MEAN),
                 },
             )
@@ -243,17 +265,26 @@ class ReferenceKLTerm:
         current_logprobs = scores.student_logprobs * loss_masks_array
         reference_logprobs = scores.reference_logprobs * loss_masks_array
 
-        kl_penalty = jnp.exp(reference_logprobs - current_logprobs) - (reference_logprobs - current_logprobs) - 1
-        kl_loss = jnp.mean(jnp.sum(kl_penalty * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1))
-        kl_loss = self.config.kl_coef * kl_loss
+        log_ratio = token_log_ratio(current_logprobs, reference_logprobs)
+        kl_penalty = kl_penalty_from_log_ratio(log_ratio, self.config.kl.mode)
+        kl_statistics = kl_statistics_from_log_ratio(log_ratio, loss_masks_array)
+        kl_loss = self.config.kl.beta * masked_response_mean(kl_penalty, loss_masks_array)
 
-        kl_penalty_over_responses_only = jnp.mean(
-            jnp.sum(kl_penalty * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1)
-        )
+        kl_penalty_over_responses_only = masked_response_mean(kl_penalty, loss_masks_array)
         return LossTermResult(
             loss=kl_loss,
             metrics={
                 "kl_loss": Metric.from_value(jnp.asarray(kl_loss, dtype=jnp.float32), ReductionType.MEAN),
+                "kl_beta": Metric.from_value(jnp.asarray(self.config.kl.beta, dtype=jnp.float32), ReductionType.MEAN),
+                "kl_k1_mean": Metric.from_value(
+                    jnp.asarray(kl_statistics.k1_mean, dtype=jnp.float32), ReductionType.MEAN
+                ),
+                "kl_k2_mean": Metric.from_value(
+                    jnp.asarray(kl_statistics.k2_mean, dtype=jnp.float32), ReductionType.MEAN
+                ),
+                "kl_k3_mean": Metric.from_value(
+                    jnp.asarray(kl_statistics.k3_mean, dtype=jnp.float32), ReductionType.MEAN
+                ),
                 "kl_penalty": Metric.from_value(
                     jnp.asarray(kl_penalty_over_responses_only, dtype=jnp.float32),
                     ReductionType.MEAN,

--- a/lib/marin/src/marin/rl/replay_buffer.py
+++ b/lib/marin/src/marin/rl/replay_buffer.py
@@ -4,8 +4,9 @@
 """
 Replay buffer for RL training data.
 
-This module provides a replay buffer that manages rollout data for training,
-with balanced sampling across environments and configurable prioritization.
+Replay is responsible for storing, filtering, and sampling neutral trajectory
+records. It intentionally does not compute objective-specific signals such as
+advantages.
 """
 
 import dataclasses
@@ -16,14 +17,16 @@ from collections import defaultdict
 from dataclasses import dataclass
 
 import numpy as np
-from marin.rl.rl_losses import RLLossModule
 
 from .rollout_storage import RolloutReader
-from .types import RolloutBatch, RolloutWithAdvantage
+from .train_batch import rollout_group_to_trajectory_group_record
+from .types import RolloutBatch, TrajectoryGroupRecord, TrajectoryRecord
 
 logger = logging.getLogger(__name__)
 
-# TODO(power) - move advantage calculation and separate it from count
+
+def _trajectory_key(trajectory: TrajectoryRecord) -> tuple[str, str, str]:
+    return (trajectory.group_id, trajectory.env_example_id, trajectory.trace_id)
 
 
 @dataclass
@@ -31,7 +34,7 @@ class ReplayBufferConfig:
     """Configuration for the replay buffer."""
 
     capacity: int
-    """Maximum number of examples per environment in the buffer."""
+    """Maximum number of active trajectories per environment in the buffer."""
 
     alpha: float
     """Recency bias for sampling, higher values favor newer examples."""
@@ -50,21 +53,33 @@ class ReplayBufferConfig:
 
 
 @dataclass
-class RolloutWithCount(RolloutWithAdvantage):
-    """Single rollout with precomputed RLOO advantage & usage count tracking."""
+class StoredTrajectory:
+    """Neutral replay entry for one trajectory with retained group context."""
 
+    trajectory: TrajectoryRecord
+    group: TrajectoryGroupRecord
     usage_count: int = 0
-    weight_step: int = 0
+
+    @property
+    def env_name(self) -> str:
+        return self.trajectory.env_name
+
+    @property
+    def group_id(self) -> str:
+        return self.trajectory.group_id
+
+    @property
+    def weight_step(self) -> int:
+        return self.trajectory.rollout_metadata.weight_step
+
+    @property
+    def timestamp(self) -> float:
+        return self.trajectory.rollout_metadata.timestamp
 
 
 @dataclass
 class ReplayBuffer:
-    """The replay buffer manages incoming rollout data and produces training batches.
-
-    It attempts to prioritize recent data while balancing the number of samples from
-    each environment. As rollout examples appear, they are folded into a shared
-    rollout array which is sampled from to produce training batches.
-    """
+    """Store and sample neutral trajectories for trainer-side objective runtimes."""
 
     capacity: int
     local_batch_size: int
@@ -74,7 +89,6 @@ class ReplayBuffer:
     max_rollout_step_delay: int
     max_rollout_timestamp_delay: float
     filter_out_groups_with_no_variance: bool
-    loss_module: RLLossModule
     seed: int
 
     _total_batches_added: int = 0
@@ -82,7 +96,9 @@ class ReplayBuffer:
     _lock: threading.Lock = dataclasses.field(default_factory=threading.Lock)
     _current_step: int = 0
     _rng: np.random.Generator = dataclasses.field(init=False)
-    rollout_storage: dict[str, list[RolloutWithCount]] = dataclasses.field(default_factory=dict)
+    rollout_storage: dict[str, list[StoredTrajectory]] = dataclasses.field(default_factory=dict)
+    _group_records: dict[str, TrajectoryGroupRecord] = dataclasses.field(default_factory=dict)
+    _group_active_counts: dict[str, int] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
         self._rng = np.random.default_rng(seed=self.seed)
@@ -93,21 +109,9 @@ class ReplayBuffer:
         config: ReplayBufferConfig,
         local_batch_size: int,
         total_processes: int,
-        loss_module: RLLossModule,
         seed: int,
     ) -> "ReplayBuffer":
-        """Create ReplayBuffer from configuration.
-
-        Args:
-            config: Replay buffer configuration.
-            local_batch_size: Batch size for sampling.
-            total_processes: Total number of processes.
-            loss_module: Loss module for computing advantages.
-            seed: Random seed for sampling.
-
-        Returns:
-            Configured ReplayBuffer instance.
-        """
+        """Create ReplayBuffer from configuration."""
         return cls(
             capacity=config.capacity,
             local_batch_size=local_batch_size,
@@ -117,7 +121,6 @@ class ReplayBuffer:
             max_rollout_step_delay=config.max_rollout_step_delay,
             max_rollout_timestamp_delay=config.max_rollout_timestamp_delay,
             filter_out_groups_with_no_variance=config.filter_out_groups_with_no_variance,
-            loss_module=loss_module,
             seed=seed,
         )
 
@@ -135,12 +138,87 @@ class ReplayBuffer:
         if rollout_step < min_step or rollout_step > max_step:
             return False
 
-        # Check timestamp
         min_time = current_time - self.max_rollout_timestamp_delay
         if rollout_timestamp <= min_time:
             return False
 
         return True
+
+    def _refresh_group_records(self, group_ids: set[str]) -> None:
+        for group_id in group_ids:
+            group_record = self._group_records.get(group_id)
+            if group_record is None:
+                continue
+
+            active_members: list[StoredTrajectory] = []
+            for rollouts in self.rollout_storage.values():
+                for stored_trajectory in rollouts:
+                    if stored_trajectory.group_id == group_id:
+                        active_members.append(stored_trajectory)
+
+            if not active_members:
+                self._group_active_counts.pop(group_id, None)
+                self._group_records.pop(group_id, None)
+                continue
+
+            active_members_by_key = {
+                _trajectory_key(stored_trajectory.trajectory): stored_trajectory for stored_trajectory in active_members
+            }
+            active_trajectories = tuple(
+                stored_trajectory.trajectory
+                for trajectory in group_record.trajectories
+                if (stored_trajectory := active_members_by_key.get(_trajectory_key(trajectory))) is not None
+            )
+            refreshed_group = dataclasses.replace(group_record, trajectories=active_trajectories)
+            self._group_records[group_id] = refreshed_group
+            self._group_active_counts[group_id] = len(active_trajectories)
+            for stored_trajectory in active_members:
+                stored_trajectory.group = refreshed_group
+
+    def _evict_over_capacity(self, env_name: str) -> None:
+        rollouts = self.rollout_storage[env_name]
+        overflow = len(rollouts) - self.capacity
+        if overflow <= 0:
+            return
+
+        removed = rollouts[:overflow]
+        self.rollout_storage[env_name] = rollouts[overflow:]
+        self._refresh_group_records({stored_trajectory.group_id for stored_trajectory in removed})
+
+    def _retire_overused_trajectories(self) -> None:
+        """Remove trajectories that exceeded max_samples usage."""
+        if self.max_samples < 0:
+            return
+
+        affected_group_ids: set[str] = set()
+        for env_name, rollouts in self.rollout_storage.items():
+            kept_rollouts = []
+            for stored_trajectory in rollouts:
+                if stored_trajectory.usage_count < self.max_samples:
+                    kept_rollouts.append(stored_trajectory)
+                    continue
+                affected_group_ids.add(stored_trajectory.group_id)
+            self.rollout_storage[env_name] = kept_rollouts
+        self._refresh_group_records(affected_group_ids)
+
+    def _ordered_full_group_ids_for_env(self, env_name: str) -> list[str]:
+        latest_index: dict[str, int] = {}
+        for index, stored_trajectory in enumerate(self.rollout_storage.get(env_name, [])):
+            group_id = stored_trajectory.group_id
+            group_record = self._group_records.get(group_id)
+            if group_record is None:
+                continue
+            if self._group_active_counts.get(group_id) != len(group_record.trajectories):
+                continue
+            latest_index[group_id] = index
+
+        return [group_id for group_id, _ in sorted(latest_index.items(), key=lambda item: item[1])]
+
+    def _increment_group_usage(self, group_id: str) -> None:
+        for rollouts in self.rollout_storage.values():
+            for stored_trajectory in rollouts:
+                if stored_trajectory.group_id == group_id:
+                    stored_trajectory.usage_count += 1
 
     def set_current_step(self, step: int) -> None:
         """Set current training step and filter stale rollouts."""
@@ -149,155 +227,191 @@ class ReplayBuffer:
 
         with self._lock:
             total_removed = 0
-            for env_name in self.rollout_storage:
-                rollouts = self.rollout_storage[env_name]
-                before = len(rollouts)
-                self.rollout_storage[env_name] = [
-                    r
-                    for r in rollouts
+            affected_group_ids: set[str] = set()
+            for env_name, rollouts in self.rollout_storage.items():
+                kept_rollouts = []
+                for stored_trajectory in rollouts:
                     if self._is_rollout_fresh(
-                        r.rollout.metadata.weight_step, r.rollout.metadata.timestamp, step, current_time
-                    )
-                ]
-                total_removed += before - len(self.rollout_storage[env_name])
+                        stored_trajectory.weight_step,
+                        stored_trajectory.timestamp,
+                        step,
+                        current_time,
+                    ):
+                        kept_rollouts.append(stored_trajectory)
+                        continue
+
+                    total_removed += 1
+                    affected_group_ids.add(stored_trajectory.group_id)
+
+                self.rollout_storage[env_name] = kept_rollouts
+
+            self._refresh_group_records(affected_group_ids)
 
             total_remaining = sum(len(rollouts) for rollouts in self.rollout_storage.values())
-
             if total_removed > 0:
-                logger.info(f"Filtered {total_removed} stale rollouts {total_remaining} remaining")
-
-    def _retire_overused_rollouts(self):
-        """Remove rollouts that exceeded max_samples usage."""
-        if self.max_samples < 0:
-            return
-
-        for env_name in self.rollout_storage:
-            rollouts = self.rollout_storage[env_name]
-            # Keep only rollouts under usage limit
-            self.rollout_storage[env_name] = [r for r in rollouts if r.usage_count < self.max_samples]
+                logger.info("Filtered %d stale rollouts %d remaining", total_removed, total_remaining)
 
     def add_batches(self, new_batches: list[RolloutBatch]) -> None:
-        """Add new rollout batches into the replay buffer.
-
-        Computes RLOO advantages at ingestion and stores individual rollouts
-        with their precomputed advantages and usage tracking.
-        """
-        env_examples: dict[str, list[RolloutWithCount]] = defaultdict(list)
+        """Add new rollout batches into the replay buffer without computing objectives."""
+        env_examples: dict[str, list[StoredTrajectory]] = defaultdict(list)
+        group_records_to_store: dict[str, TrajectoryGroupRecord] = {}
+        group_active_increments: dict[str, int] = defaultdict(int)
+        reward_arrays: list[np.ndarray] = []
         current_time = time.time()
 
         for batch in new_batches:
-            # R[num_groups, num_rollouts_per_group]
-            batch_rewards = np.zeros((len(batch.groups), len(batch.groups[0].rollouts)), dtype=np.float32)
-
-            if not batch.groups or not batch.groups[0].rollouts:
-                continue
-
-            # Read weight_step from first rollout's metadata
-            first_rollout = batch.groups[0].rollouts[0]
-            rollout_step = first_rollout.metadata.weight_step
-            rollout_timestamp = first_rollout.metadata.timestamp
-
-            if not self._is_rollout_fresh(rollout_step, rollout_timestamp, self._current_step, current_time):
-                logger.info(
-                    f"Skipping stale rollout batch (rollout_step={rollout_step}, current_step={self._current_step})"
-                )
-                continue
-
-            self._total_batches_added += 1
-
+            accepted_any_group = False
             for group_idx, group in enumerate(batch.groups):
-                # Compute RLOO advantages for the group
-                advantages = self.loss_module.compute_advantages(group.rollouts)
-                maybe_used_rollouts = []
-                for rollout_idx, (rollout, advantage) in enumerate(zip(group.rollouts, advantages, strict=True)):
-                    individual = RolloutWithCount(
-                        rollout=rollout, advantage=advantage, usage_count=0, weight_step=rollout_step
+                if not group.rollouts:
+                    continue
+
+                group_record = rollout_group_to_trajectory_group_record(group)
+                first_trajectory = group_record.trajectories[0]
+                rollout_step = first_trajectory.rollout_metadata.weight_step
+                rollout_timestamp = first_trajectory.rollout_metadata.timestamp
+
+                if not self._is_rollout_fresh(rollout_step, rollout_timestamp, self._current_step, current_time):
+                    logger.info(
+                        "Skipping stale rollout group (rollout_step=%d, current_step=%d)",
+                        rollout_step,
+                        self._current_step,
                     )
-                    maybe_used_rollouts.append(individual)
-                    batch_rewards[group_idx, rollout_idx] = rollout.episode_reward
+                    continue
 
-                if np.std(batch_rewards[group_idx]) > 0.0:
-                    env_examples[rollout.env_name].extend(maybe_used_rollouts)
-                else:  # group has no variance in rewards
-                    if not self.filter_out_groups_with_no_variance:
-                        env_examples[rollout.env_name].extend(maybe_used_rollouts)
+                rewards = np.asarray(
+                    [trajectory.episode_reward for trajectory in group_record.trajectories],
+                    dtype=np.float32,
+                )
+                if rewards.size == 0:
+                    continue
 
-                    logger.info(f"Group {group_idx} has no variance in rewards")
+                if np.std(rewards) == 0.0:
+                    logger.info("Group %d has no variance in rewards", group_idx)
+                    if self.filter_out_groups_with_no_variance:
+                        continue
 
-            logger.info(f"Reward mean across all groups: {batch_rewards.mean()}")
-            logger.info(f"Reward std across all groups: {batch_rewards.std(axis=1).mean()}")
+                env_name = first_trajectory.env_name
+                env_examples[env_name].extend(
+                    StoredTrajectory(trajectory=trajectory, group=group_record)
+                    for trajectory in group_record.trajectories
+                )
+                group_records_to_store[group_record.group_id] = group_record
+                group_active_increments[group_record.group_id] += len(group_record.trajectories)
+                reward_arrays.append(rewards)
+                accepted_any_group = True
+
+            if accepted_any_group:
+                self._total_batches_added += 1
 
         with self._lock:
+            for group_id, group_record in group_records_to_store.items():
+                self._group_records[group_id] = group_record
+                self._group_active_counts[group_id] = (
+                    self._group_active_counts.get(group_id, 0) + group_active_increments[group_id]
+                )
+
             for env_name, examples in env_examples.items():
                 if env_name in self.rollout_storage:
                     self.rollout_storage[env_name].extend(examples)
                 else:
-                    self.rollout_storage[env_name] = examples
+                    self.rollout_storage[env_name] = list(examples)
+                self._evict_over_capacity(env_name)
 
-                if len(self.rollout_storage[env_name]) > self.capacity:
-                    self.rollout_storage[env_name] = self.rollout_storage[env_name][-self.capacity :]
+        if reward_arrays:
+            all_rewards = np.concatenate(reward_arrays)
+            per_group_std = np.asarray([rewards.std() for rewards in reward_arrays], dtype=np.float32)
+            logger.info("Reward mean across all groups: %s", float(all_rewards.mean()))
+            logger.info("Reward std across all groups: %s", float(per_group_std.mean()))
 
-    def sample_rollouts(self) -> list[RolloutWithCount] | None:
-        """Sample individual rollouts with balanced environment sampling.
-
-        If no samples are available, returns None.
-
-        Returns:
-            List of IndividualRollout objects up to local_batch_size.
-        """
+    def sample_sequences(self) -> list[StoredTrajectory] | None:
+        """Sample neutral trajectories with balanced environment sampling."""
         with self._lock:
-            # Get all environments with rollouts
             env_names = [name for name, rollouts in self.rollout_storage.items() if rollouts]
             if not env_names:
                 return None
 
-            # sample environments N times without replacement
-            # we fill the array with the number of rollouts in each env
             total_count = 0
             env_choices = []
             for env_name in env_names:
                 env_choices.extend([env_name] * len(self.rollout_storage[env_name]))
                 total_count += len(self.rollout_storage[env_name])
 
-            # not enough samples to fill a batch
             if total_count < self.local_batch_size:
                 return None
 
-            env_choices = np.array(env_choices)
-            env_indices = self._rng.choice(
-                env_choices,
-                size=self.local_batch_size,
-                replace=False,
-            )
+            env_choices = np.asarray(env_choices)
+            env_indices = self._rng.choice(env_choices, size=self.local_batch_size, replace=False)
 
-            # count the number of times each env is chosen
             env_count = defaultdict(int)
             for env_name in env_indices:
-                env_count[env_name] += 1
+                env_count[str(env_name)] += 1
 
-            # now sample from each env according to recency weights & number of times chosen
-            sampled: list[RolloutWithCount] = []
+            sampled: list[StoredTrajectory] = []
             for env_name, count in env_count.items():
                 rollouts = self.rollout_storage[env_name]
                 weights = np.arange(len(rollouts)) + 1
                 weights = weights**self.alpha
                 weights = weights / weights.sum()
+                indices = self._rng.choice(len(rollouts), p=weights, size=count, replace=False)
+                for index in indices:
+                    sampled.append(rollouts[index])
+                    rollouts[index].usage_count += 1
 
-                # Sample rollout index
-                idx = self._rng.choice(len(rollouts), p=weights, size=count, replace=False)
-                for i in idx:
-                    sampled.append(rollouts[i])
-                    rollouts[i].usage_count += 1
-
-            # Retire overused rollouts
-            self._retire_overused_rollouts()
-
-            # Update stats
+            self._retire_overused_trajectories()
             self._total_batches_sampled += 1
             return sampled
 
+    def sample_groups(self, min_trajectories: int | None = None) -> list[TrajectoryGroupRecord] | None:
+        """Sample full trajectory groups, preserving prompt grouping."""
+        target_trajectories = self.local_batch_size if min_trajectories is None else min_trajectories
+        with self._lock:
+            ordered_full_group_ids_for_env = self._ordered_full_group_ids_for_env
+            available_groups_by_env = {
+                env_name: ordered_full_group_ids_for_env(env_name) for env_name in self.rollout_storage
+            }
+            total_available = sum(
+                len(self._group_records[group_id].trajectories)
+                for group_ids in available_groups_by_env.values()
+                for group_id in group_ids
+            )
+            if total_available < target_trajectories:
+                return None
+
+            sampled_groups: list[TrajectoryGroupRecord] = []
+            sampled_trajectories = 0
+
+            while sampled_trajectories < target_trajectories:
+                available_envs = [env_name for env_name, group_ids in available_groups_by_env.items() if group_ids]
+                if not available_envs:
+                    return None
+
+                env_choices = []
+                for env_name in available_envs:
+                    for group_id in available_groups_by_env[env_name]:
+                        env_choices.extend([env_name] * len(self._group_records[group_id].trajectories))
+
+                chosen_env = str(self._rng.choice(np.asarray(env_choices)))
+                group_ids = available_groups_by_env[chosen_env]
+                weights = np.arange(len(group_ids)) + 1
+                weights = weights**self.alpha
+                weights = weights / weights.sum()
+                group_index = int(self._rng.choice(len(group_ids), p=weights))
+                group_id = group_ids.pop(group_index)
+                group_record = self._group_records[group_id]
+                sampled_groups.append(group_record)
+                sampled_trajectories += len(group_record.trajectories)
+                self._increment_group_usage(group_id)
+
+            self._retire_overused_trajectories()
+            self._total_batches_sampled += 1
+            return sampled_groups
+
+    def sample_rollouts(self) -> list[StoredTrajectory] | None:
+        """Compatibility alias for the old replay API name."""
+        return self.sample_sequences()
+
     def size(self) -> int:
-        """Get total number of rollouts across all environments."""
+        """Get total number of active trajectories across all environments."""
         with self._lock:
             return sum(len(rollouts) for rollouts in self.rollout_storage.values())
 
@@ -309,13 +423,14 @@ class ReplayBuffer:
                 "total_size": sum(env_sizes.values()),
                 "env_sizes": env_sizes,
                 "num_environments": len(self.rollout_storage),
+                "num_active_groups": len(self._group_records),
                 "total_batches_added": self._total_batches_added,
                 "total_batches_sampled": self._total_batches_sampled,
             }
 
 
 class ReplayDataLoader:
-    """Loads data from rollout reader into replay buffer and provides training batches."""
+    """Loads data from rollout reader into replay buffer and provides neutral samples."""
 
     def __init__(
         self,
@@ -323,13 +438,7 @@ class ReplayDataLoader:
         replay_buffer: ReplayBuffer,
         rollout_fetch_interval: float = 1.0,
     ):
-        """Initialize replay data loader.
-
-        Args:
-            rollout_reader: Reader to get rollout data from.
-            replay_buffer: Buffer to store rollout data.
-            batch_interval: Interval in seconds between data collection iterations.
-        """
+        """Initialize replay data loader."""
         self.rollout_reader = rollout_reader
         self.replay_buffer = replay_buffer
         self.rollout_fetch_interval = rollout_fetch_interval
@@ -355,30 +464,37 @@ class ReplayDataLoader:
             self._thread = None
             logger.info("Stopped ReplayDataLoader background thread")
 
-    def get_rollouts(self, timeout: float = 5.0) -> list[RolloutWithCount] | None:
-        """Get next batch of rollouts from replay buffer.
-
-        Args:
-            timeout: Maximum time to wait for rollouts in seconds.
-
-        Returns:
-            List of IndividualRollout if available, None if timeout or no data.
-        """
+    def get_trajectories(self, timeout: float = 5.0) -> list[StoredTrajectory] | None:
+        """Get the next sampled neutral trajectories from replay."""
         start_time = time.time()
         while time.time() - start_time < timeout:
-            rollouts = self.replay_buffer.sample_rollouts()
-            if rollouts is not None:
-                return rollouts
+            trajectories = self.replay_buffer.sample_sequences()
+            if trajectories is not None:
+                return trajectories
             time.sleep(0.1)
         return None
+
+    def get_groups(self, timeout: float = 5.0) -> list[TrajectoryGroupRecord] | None:
+        """Get the next sampled full trajectory groups from replay."""
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            groups = self.replay_buffer.sample_groups()
+            if groups is not None:
+                return groups
+            time.sleep(0.1)
+        return None
+
+    def get_rollouts(self, timeout: float = 5.0) -> list[StoredTrajectory] | None:
+        """Compatibility alias for the old loader API name."""
+        return self.get_trajectories(timeout=timeout)
 
     def _worker_loop(self) -> None:
         """Main worker loop for background data loading."""
         while not self._stop_event.is_set():
             try:
                 self._collect_rollouts()
-            except Exception as e:
-                logger.error(f"Error in ReplayDataLoader worker loop: {e}", exc_info=True)
+            except Exception as exc:
+                logger.error("Error in ReplayDataLoader worker loop: %s", exc, exc_info=True)
 
             # Sleep via the stop event so shutdown is responsive instead of blocking the full interval.
             self._stop_event.wait(self.rollout_fetch_interval)
@@ -386,14 +502,13 @@ class ReplayDataLoader:
     def _collect_rollouts(self) -> None:
         """Collect available rollouts from reader and add to buffer."""
         batches = self.rollout_reader.read_all_available()
-
         if not batches:
             return
 
         start_time = time.time()
         self.replay_buffer.add_batches(batches)
         elapsed = time.time() - start_time
-        logger.info(f"Collected {len(batches)} rollout batches, updated replay buffer in {elapsed:.3f}s")
+        logger.info("Collected %d rollout batches, updated replay buffer in %s", len(batches), elapsed)
 
     def __enter__(self):
         self.start()

--- a/lib/marin/src/marin/rl/rl_experiment_utils.py
+++ b/lib/marin/src/marin/rl/rl_experiment_utils.py
@@ -28,10 +28,10 @@ from marin.rl.environments.inference_ctx import (
     VLLMFallbackSamplingConfig,
     vLLMInferenceContextConfig,
 )
+from marin.rl.objectives import ObjectiveSpec
 from marin.rl.placement import resolve_launcher_region, singleton_region_list
 from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_job import RLJob, RLJobConfig, RunConfig, TrainParams
-from marin.rl.rl_losses import RLLossModule
 from marin.rl.rollout_storage import RolloutStorageConfig, StorageType
 from marin.rl.rollout_worker import RolloutTrackerConfig
 from marin.rl.weight_transfer import WeightTransferConfig, WeightTransferMode
@@ -75,7 +75,8 @@ class RLExperimentConfig:
     """Shared configuration for RL experiments."""
 
     model_config: ModelConfig
-    rl_loss: RLLossModule
+    objective: ObjectiveSpec
+    scorer_vocab_tile_size: int | None
     experiment_name_suffix: str
 
     # trainer params
@@ -308,7 +309,8 @@ def _build_rl_job_config(
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=opt_config,
-            rl_loss=config.rl_loss,
+            objective=config.objective,
+            scorer_vocab_tile_size=config.scorer_vocab_tile_size,
             replay_buffer=ReplayBufferConfig(
                 capacity=config.replay_buffer_capacity,
                 alpha=config.replay_buffer_alpha,

--- a/lib/marin/src/marin/rl/rl_losses.py
+++ b/lib/marin/src/marin/rl/rl_losses.py
@@ -3,23 +3,21 @@
 
 """RL loss functions."""
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-import logging
 from typing import Protocol
 
 import equinox as eqx
-import haliax as hax
 import jax
 import jax.numpy as jnp
 import numpy as np
-
+from levanter.metrics import Metric, ReductionType
+from levanter.models.lm_model import LmHeadModel
 from marin.rl.objectives.reductions import compute_dapo_loss
 from marin.rl.objectives.signals import compute_rloo_advantages_from_rewards
 from marin.rl.objectives.terms import compute_metadata_metrics, importance_sampling_ratio
 from marin.rl.scoring import LocalScoreSource, ModelRoles, ScoreRequirements, ScoreSource
-from levanter.metrics import Metric, ReductionType
-from levanter.models.lm_model import LmHeadModel
 from marin.rl.types import Rollout, TrainingBatch
 
 logger = logging.getLogger(__name__)

--- a/lib/marin/src/marin/rl/rl_losses.py
+++ b/lib/marin/src/marin/rl/rl_losses.py
@@ -14,6 +14,9 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from marin.rl.objectives.reductions import compute_dapo_loss
+from marin.rl.objectives.signals import compute_rloo_advantages_from_rewards
+from marin.rl.objectives.terms import compute_metadata_metrics, importance_sampling_ratio
 from marin.rl.scoring import LocalScoreSource, ModelRoles, ScoreRequirements, ScoreSource
 from levanter.metrics import Metric, ReductionType
 from levanter.models.lm_model import LmHeadModel
@@ -40,49 +43,6 @@ class RLLossModule(Protocol):
     def create_loss_fn(self, reference_model: eqx.Module | None, train_model: eqx.Module) -> Callable:
         """Create the loss function for training."""
         ...
-
-
-def compute_metadata_metrics(
-    current_logprobs: jax.Array,
-    policy_logprobs_array: jax.Array,
-    loss_weights_array: jax.Array,
-    loss_masks_array: jax.Array,
-) -> dict[str, Metric]:
-    """Compute metadata metrics for the loss function."""
-    batch_size, _ = policy_logprobs_array.shape
-
-    mean_ratio_difference = jnp.sum(
-        (jnp.abs(jnp.exp(current_logprobs) - jnp.exp(policy_logprobs_array))) * loss_masks_array, axis=1
-    ) / jnp.sum(loss_masks_array, axis=1)
-    mean_ratio_difference = jnp.mean(mean_ratio_difference)
-
-    flattened_current_logprobs = current_logprobs.reshape(-1)
-    flattened_policy_logprobs = policy_logprobs_array.reshape(-1)
-    flattened_loss_masks = loss_masks_array.reshape(-1)
-
-    policy_entropy = -jnp.sum(flattened_policy_logprobs * flattened_loss_masks) / jnp.sum(flattened_loss_masks)
-    current_entropy = -jnp.sum(flattened_current_logprobs * flattened_loss_masks) / jnp.sum(flattened_loss_masks)
-
-    mean_advantages = jnp.sum(loss_weights_array * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1)
-    mean_advantages = jnp.mean(mean_advantages)
-
-    max_ratio_diff = jnp.max(jnp.abs(jnp.exp(current_logprobs) - jnp.exp(policy_logprobs_array)) * loss_masks_array)
-
-    metrics = {
-        "trainer_sampler_prob_diff_max": Metric.from_value(max_ratio_diff.astype(jnp.float32), ReductionType.MAX),
-        "trainer_sampler_prob_diff_mean": Metric.from_value(
-            mean_ratio_difference.astype(jnp.float32), ReductionType.MEAN
-        ),
-        "current_entropy": Metric.from_value(current_entropy.astype(jnp.float32), ReductionType.MEAN),
-        "max_advantages": Metric.from_value(jnp.max(loss_weights_array).astype(jnp.float32), ReductionType.MAX),
-        "mean_advantages": Metric.from_value(mean_advantages.astype(jnp.float32), ReductionType.MEAN),
-        "policy_entropy": Metric.from_value(policy_entropy.astype(jnp.float32), ReductionType.MEAN),
-        "response_tokens_length": Metric.from_value(
-            (jnp.sum(loss_masks_array) / batch_size).astype(jnp.float32), ReductionType.MEAN
-        ),
-    }
-
-    return metrics
 
 
 def compute_ppo_loss_objective(
@@ -120,35 +80,6 @@ def compute_ppo_loss_objective(
         "loss_std_over_batch": Metric.from_value(jnp.std(per_batch_loss).astype(jnp.float32), ReductionType.MEAN),
     }
     return loss, metadata
-
-
-def compute_dapo_loss(
-    loss_objective: jax.Array,
-    loss_masks: jax.Array,
-) -> jax.Array:
-    """Compute DAPO-like loss (global token normalization).
-
-    Divides by total tokens across all examples in the batch, not per-example.
-    """
-    return -1 * jnp.mean(jnp.sum(loss_objective * loss_masks, axis=1) / jnp.sum(loss_masks))
-
-
-def importance_sampling_ratio(
-    current_logprobs: jax.Array,
-    policy_logprobs_array: jax.Array,
-    loss_masks_array: jax.Array,
-    *,
-    stop_current_logprob_gradient: bool = False,
-    stop_policy_logprob_gradient: bool = True,
-) -> jax.Array:
-    if stop_current_logprob_gradient:
-        current_logprobs = jax.lax.stop_gradient(current_logprobs)
-
-    if stop_policy_logprob_gradient:
-        policy_logprobs_array = jax.lax.stop_gradient(policy_logprobs_array)
-
-    prob_difference = jnp.exp(current_logprobs - policy_logprobs_array) * loss_masks_array
-    return prob_difference
 
 
 def rloo_loss_with_importance_sampling(
@@ -312,16 +243,8 @@ def rloo_loss_with_importance_sampling(
 
 def compute_rloo_advantages(rollouts: list[Rollout]) -> np.ndarray:
     """Compute RLOO (Reward Leave-One-Out) advantages for a group of rollouts."""
-    rewards = np.array([r.episode_reward for r in rollouts])
-
-    n = len(rewards)
-    if n <= 1:
-        return np.zeros_like(rewards)
-
-    total = rewards.sum()
-    leave_one_out_baselines = (total - rewards) / (n - 1)
-    advantages = rewards - leave_one_out_baselines
-    return advantages
+    rewards = np.array([r.episode_reward for r in rollouts], dtype=np.float32)
+    return compute_rloo_advantages_from_rewards(rewards)
 
 
 @dataclass

--- a/lib/marin/src/marin/rl/rl_losses.py
+++ b/lib/marin/src/marin/rl/rl_losses.py
@@ -14,6 +14,13 @@ import jax.numpy as jnp
 import numpy as np
 from levanter.metrics import Metric, ReductionType
 from levanter.models.lm_model import LmHeadModel
+from marin.rl.kl_regularization import (
+    KLConfig,
+    kl_penalty_from_log_ratio,
+    kl_statistics_from_log_ratio,
+    masked_response_mean,
+    token_log_ratio,
+)
 from marin.rl.objectives.reductions import compute_dapo_loss
 from marin.rl.objectives.signals import compute_rloo_advantages_from_rewards
 from marin.rl.objectives.terms import compute_metadata_metrics, importance_sampling_ratio
@@ -87,13 +94,14 @@ def rloo_loss_with_importance_sampling(
     score_source: ScoreSource,
     *,
     key: jax.Array | None,
-    kl_coef: float,
+    kl: KLConfig,
     clip_epsilon_low: float,
     clip_epsilon_high: float,
     tis_importance_sampling_ratio_max: float,
     do_trainer_inference_mismatch_importance_sampling: bool = False,
     synchronous: bool = False,
     do_overlong_filtering: bool = False,
+    log_policy_entropy: bool = False,
 ) -> tuple[jax.Array, dict[str, Metric]]:
     """Compute RLOO (Reward Leave-One-Out) loss with importance sampling for off-policy data.
 
@@ -101,9 +109,10 @@ def rloo_loss_with_importance_sampling(
         model: The language model
         batch: dict containing rollout data with RLOO advantages
         key: JAX random key for dropout
-        kl_coef: Coefficient for KL regularization
+        kl: KL regularization configuration
         clip_epsilon_low: Lower clipping epsilon for importance sampling ratio
         clip_epsilon_high: Upper clipping epsilon for importance sampling ratio
+        log_policy_entropy: Whether to log exact full-vocabulary policy entropy
     Returns:
         Tuple of (loss, aux_metrics)
     """
@@ -175,22 +184,21 @@ def rloo_loss_with_importance_sampling(
     # weighted_loss = -clipped_ratio * loss_weights_array * loss_masks_array
     # KL regularization
 
-    if kl_coef > 0:
+    log_ratio = jnp.zeros_like(current_logprobs)
+    kl_penalty = jnp.zeros_like(current_logprobs)
+    kl_loss = jnp.asarray(0.0, dtype=current_logprobs.dtype)
+    kl_statistics = kl_statistics_from_log_ratio(log_ratio, loss_masks_array)
+    if kl.enabled():
         if reference_model is None:
-            raise ValueError("reference_model is required when kl_coef > 0")
+            raise ValueError("reference_model is required when KL regularization is enabled")
         if score_bundle.reference_logprobs is None:
             raise ValueError("score source did not produce reference logprobs")
         reference_logprobs = score_bundle.reference_logprobs
         reference_logprobs = reference_logprobs * loss_masks_array
-        # log_ratio = (current_logprobs - reference_logprobs_array) * loss_masks_array
-        kl_penalty = jnp.exp(reference_logprobs - current_logprobs) - (reference_logprobs - current_logprobs) - 1
-        # https://github.com/openai/lm-human-preferences/blob/cbfd210bb8b08f6bc5c26878c10984b90f516c66/lm_human_preferences/train_policy.py#L151
-        # kl_penalty = jnp.abs(log_ratio)
-        kl_loss = jnp.mean(jnp.sum(kl_penalty * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1))
-        kl_loss = kl_coef * kl_loss
-    else:
-        kl_penalty = 0
-        kl_loss = 0
+        log_ratio = token_log_ratio(current_logprobs, reference_logprobs)
+        kl_penalty = kl_penalty_from_log_ratio(log_ratio, kl.mode)
+        kl_statistics = kl_statistics_from_log_ratio(log_ratio, loss_masks_array)
+        kl_loss = kl.beta * masked_response_mean(kl_penalty, loss_masks_array)
 
     loss = reinforce_loss + kl_loss
 
@@ -202,11 +210,9 @@ def rloo_loss_with_importance_sampling(
     clipped_ratio_mean_over_responses_only = jnp.mean(
         jnp.sum(clipped_ratio * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1)
     )
-    kl_penalty_over_responses_only = jnp.mean(
-        jnp.sum(kl_penalty * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1)
-    )
+    kl_penalty_over_responses_only = masked_response_mean(kl_penalty, loss_masks_array)
 
-    return loss, {
+    metrics = {
         "ratio_mean": Metric.from_value(ratio_mean_over_responses_only.astype(jnp.float32), ReductionType.MEAN),
         "clipped_ratio_mean": Metric.from_value(
             clipped_ratio_mean_over_responses_only.astype(jnp.float32), ReductionType.MEAN
@@ -214,6 +220,10 @@ def rloo_loss_with_importance_sampling(
         "clip_fraction": Metric.from_value(clip_fraction.astype(jnp.float32), ReductionType.MEAN),
         "reinforce_loss": Metric.from_value(reinforce_loss.astype(jnp.float32), ReductionType.MEAN),
         "kl_loss": Metric.from_value(jnp.asarray(kl_loss, dtype=jnp.float32), ReductionType.MEAN),
+        "kl_beta": Metric.from_value(jnp.asarray(kl.beta, dtype=jnp.float32), ReductionType.MEAN),
+        "kl_k1_mean": Metric.from_value(jnp.asarray(kl_statistics.k1_mean, dtype=jnp.float32), ReductionType.MEAN),
+        "kl_k2_mean": Metric.from_value(jnp.asarray(kl_statistics.k2_mean, dtype=jnp.float32), ReductionType.MEAN),
+        "kl_k3_mean": Metric.from_value(jnp.asarray(kl_statistics.k3_mean, dtype=jnp.float32), ReductionType.MEAN),
         "kl_penalty": Metric.from_value(
             jnp.asarray(kl_penalty_over_responses_only, dtype=jnp.float32), ReductionType.MEAN
         ),
@@ -237,6 +247,16 @@ def rloo_loss_with_importance_sampling(
         **compute_metadata_metrics(current_logprobs, policy_logprobs_array, loss_weights_array, loss_masks_array),
         **metadata,
     }
+    if log_policy_entropy:
+        if score_bundle.student_entropy is None:
+            raise ValueError("score source must produce student entropy when log_policy_entropy=True")
+        policy_entropy = masked_response_mean(score_bundle.student_entropy, loss_masks_array)
+        metrics["current_policy_entropy"] = Metric.from_value(
+            jax.lax.stop_gradient(policy_entropy).astype(jnp.float32),
+            ReductionType.MEAN,
+        )
+
+    return loss, metrics
 
 
 def compute_rloo_advantages(rollouts: list[Rollout]) -> np.ndarray:
@@ -249,7 +269,7 @@ def compute_rloo_advantages(rollouts: list[Rollout]) -> np.ndarray:
 class RLOOLoss(RLLossModule):
     """RLOO loss with importance sampling."""
 
-    kl_coef: float = 0.1
+    kl: KLConfig
     clip_epsilon_low: float = 0.2
     clip_epsilon_high: float = 0.2
     tis_importance_sampling_ratio_max: float = 2.0
@@ -257,6 +277,7 @@ class RLOOLoss(RLLossModule):
     do_trainer_inference_mismatch_importance_sampling: bool = False
     do_overlong_filtering: bool = False
     vocab_tile_size: int | None = None
+    log_policy_entropy: bool = False
 
     def build(self, reference_model: eqx.Module) -> RLLossModule:
         """Initialize any learned components (e.g., value heads)."""
@@ -268,16 +289,19 @@ class RLOOLoss(RLLossModule):
 
     def needs_reference_model(self) -> bool:
         """Return whether KL regularization requires a reference model."""
-        return self.kl_coef > 0
+        return self.kl.enabled()
 
     def create_loss_fn(self, reference_model: eqx.Module | None, train_model: eqx.Module) -> Callable:
         """Create the loss function for training."""
         if self.needs_reference_model() and reference_model is None:
-            raise ValueError("reference_model is required when kl_coef > 0")
+            raise ValueError("reference_model is required when KL regularization is enabled")
+        if self.log_policy_entropy and self.vocab_tile_size is not None:
+            raise ValueError("Exact policy entropy is not supported with vocab_tile_size yet")
 
         score_source = LocalScoreSource(
             score_requirements=ScoreRequirements(
                 student_logprobs=True,
+                student_entropy=self.log_policy_entropy,
                 behavior_logprobs=True,
                 reference_logprobs=self.needs_reference_model(),
             ),
@@ -297,13 +321,14 @@ class RLOOLoss(RLLossModule):
                 batch,
                 score_source,
                 key=key,
-                kl_coef=self.kl_coef,
+                kl=self.kl,
                 clip_epsilon_low=self.clip_epsilon_low,
                 clip_epsilon_high=self.clip_epsilon_high,
                 tis_importance_sampling_ratio_max=self.tis_importance_sampling_ratio_max,
                 synchronous=self.synchronous,
                 do_trainer_inference_mismatch_importance_sampling=self.do_trainer_inference_mismatch_importance_sampling,
                 do_overlong_filtering=self.do_overlong_filtering,
+                log_policy_entropy=self.log_policy_entropy,
             )
 
         return loss_fn

--- a/lib/marin/src/marin/rl/rl_losses.py
+++ b/lib/marin/src/marin/rl/rl_losses.py
@@ -5,6 +5,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+import logging
 from typing import Protocol
 
 import equinox as eqx
@@ -12,21 +13,13 @@ import haliax as hax
 import jax
 import jax.numpy as jnp
 import numpy as np
-from levanter.layers.attention import AttentionMask
+
+from marin.rl.scoring import LocalScoreSource, ModelRoles, ScoreRequirements, ScoreSource
 from levanter.metrics import Metric, ReductionType
 from levanter.models.lm_model import LmHeadModel
-from levanter.models.loss import fused_cross_entropy_loss_and_logsumexp_penalty
-from marin.rl.kl_regularization import (
-    KLConfig,
-    kl_penalty_from_log_ratio,
-    kl_statistics_from_log_ratio,
-    masked_response_mean,
-    token_log_ratio,
-)
 from marin.rl.types import Rollout, TrainingBatch
 
-# TODO(power) - these should be refactored to accept the precomputed logits instead
-# of computing outputs themselves.
+logger = logging.getLogger(__name__)
 
 
 class RLLossModule(Protocol):
@@ -90,132 +83,6 @@ def compute_metadata_metrics(
     }
 
     return metrics
-
-
-def compute_logprobs_and_entropy(
-    model: LmHeadModel,
-    batch: TrainingBatch,
-    key: jax.Array | None,
-    *,
-    compute_entropy: bool,
-) -> tuple[jax.Array, jax.Array | None]:
-    """Compute selected-token logprobs and, optionally, full-vocabulary entropy.
-
-    Args:
-        model: The language model
-        batch: Training batch containing input_ids, position_ids, temperature
-        key: JAX random key for dropout
-        compute_entropy: Whether to compute full-vocabulary entropy for each predicted token
-    Returns:
-        Tuple of selected-token logprobs and optional entropy arrays, each shaped [batch, seq_len].
-    """
-    batch_size, _seq_len = batch.input_ids.array.shape
-
-    model_output = model(
-        input_ids=batch.input_ids,
-        attn_mask=AttentionMask.causal(),
-        pos_ids=batch.position_ids,
-        key=key,
-    )
-
-    # logits[i] predicts token at position i+1
-    # We want logprob[j] = P(token[j] | tokens[0:j])
-    # This comes from logits[j-1] indexed by token[j]
-    logits_array = model_output.array.astype(jnp.float32)[:, :-1, :]  # Drop last position [batch, seq_len-1, vocab]
-    target_ids_array = batch.input_ids.array[:, 1:]  # Drop first position [batch, seq_len-1]
-
-    safe_temperature = jnp.where(batch.temperature.array == 0, 1.0, batch.temperature.array).reshape(batch_size, 1, 1)
-    logits_array = logits_array / safe_temperature.astype(jnp.float32)
-
-    log_probs = jax.nn.log_softmax(logits_array, axis=-1)
-    logprobs_shifted = jnp.take_along_axis(log_probs, target_ids_array[..., None], axis=-1).squeeze(
-        -1
-    )  # [batch, seq_len-1]
-
-    logprobs = jnp.concatenate(
-        [jnp.zeros((logprobs_shifted.shape[0], 1), dtype=logprobs_shifted.dtype), logprobs_shifted], axis=1
-    )  # [batch, seq_len]
-
-    if not compute_entropy:
-        return logprobs, None
-
-    probs = jax.nn.softmax(logits_array, axis=-1)
-    entropy_shifted = jax.nn.logsumexp(logits_array, axis=-1) - jnp.sum(probs * logits_array, axis=-1)
-    entropy = jnp.concatenate(
-        [jnp.zeros((entropy_shifted.shape[0], 1), dtype=entropy_shifted.dtype), entropy_shifted],
-        axis=1,
-    )
-
-    return logprobs, entropy
-
-
-def compute_logprobs(
-    model: LmHeadModel,
-    batch: TrainingBatch,
-    key: jax.Array | None,
-) -> jax.Array:
-    """Compute log probabilities of target tokens.
-
-    Args:
-        model: The language model
-        batch: Training batch containing input_ids, position_ids, temperature
-        key: JAX random key for dropout
-    Returns:
-        logprobs array of shape [batch, seq_len]
-    """
-    logprobs, _entropy = compute_logprobs_and_entropy(model, batch, key, compute_entropy=False)
-    return logprobs
-
-
-def chunked_compute_logprobs(
-    model: LmHeadModel,
-    batch: TrainingBatch,
-    key: jax.Array | None,
-    block_size: int,
-) -> jax.Array:
-    """Compute log probabilities of target tokens in a chunked manner to save memory.
-
-    This avoids materializing the full [batch, seq, vocab] logits tensor by using
-    the fused cross-entropy kernel with blockwise processing.
-    """
-    # Get activations
-    activations = model.activations(
-        input_ids=batch.input_ids,
-        attn_mask=AttentionMask.causal(),
-        pos_ids=batch.position_ids,
-        key=key,
-    )
-    if isinstance(activations, tuple):
-        activations, _aux = activations
-
-    pred_embeddings = activations.astype(jnp.float32)
-    pred_lm_head = model.get_lm_head().astype(jnp.float32)
-
-    safe_temperature = hax.where(batch.temperature == 0, 1.0, batch.temperature).astype(jnp.float32)
-    pred_embeddings = pred_embeddings / safe_temperature
-
-    pos_axis = batch.input_ids.resolve_axis("position")
-    target_y = hax.roll(batch.input_ids, -1, pos_axis)
-
-    loss = fused_cross_entropy_loss_and_logsumexp_penalty(
-        pred_embeddings,
-        pred_lm_head,
-        Contract=model.Embed,
-        Label=model.Vocab,
-        target_y=target_y,
-        reduction=None,
-        logsumexp_weight=0.0,
-        block_size=block_size,
-        dtype=jnp.float32,
-    )
-
-    logprobs_shifted = -loss.array[:, :-1]
-    logprobs = jnp.concatenate(
-        [jnp.zeros((logprobs_shifted.shape[0], 1), dtype=logprobs_shifted.dtype), logprobs_shifted],
-        axis=1,
-    )
-
-    return logprobs
 
 
 def compute_ppo_loss_objective(
@@ -288,41 +155,45 @@ def rloo_loss_with_importance_sampling(
     model: LmHeadModel,
     reference_model: LmHeadModel | None,
     batch: TrainingBatch,
+    score_source: ScoreSource,
     *,
     key: jax.Array | None,
-    kl: KLConfig,
+    kl_coef: float,
     clip_epsilon_low: float,
     clip_epsilon_high: float,
     tis_importance_sampling_ratio_max: float,
     do_trainer_inference_mismatch_importance_sampling: bool = False,
     synchronous: bool = False,
     do_overlong_filtering: bool = False,
-    log_policy_entropy: bool = False,
-    compute_policy_stats_fn: Callable = compute_logprobs_and_entropy,
 ) -> tuple[jax.Array, dict[str, Metric]]:
     """Compute RLOO (Reward Leave-One-Out) loss with importance sampling for off-policy data.
 
     Args:
         model: The language model
-        batch: Training batch containing rollout data with RLOO advantages
+        batch: dict containing rollout data with RLOO advantages
         key: JAX random key for dropout
-        kl: KL regularization configuration
+        kl_coef: Coefficient for KL regularization
         clip_epsilon_low: Lower clipping epsilon for importance sampling ratio
         clip_epsilon_high: Upper clipping epsilon for importance sampling ratio
-        log_policy_entropy: Whether to log exact full-vocabulary policy entropy
-        compute_policy_stats_fn: Function to compute logprobs and optional entropy
-
     Returns:
         Tuple of (loss, aux_metrics)
     """
-    policy_logprobs_array = batch.policy_logprobs.array
+    score_bundle = score_source.score(
+        batch,
+        info=None,
+        roles=ModelRoles(student=model, reference=reference_model),
+        key=key,
+    )
+    if score_bundle.student_logprobs is None:
+        raise ValueError("score source did not produce student logprobs")
+    if score_bundle.behavior_logprobs is None:
+        raise ValueError("score source did not produce behavior logprobs")
+
+    policy_logprobs_array = score_bundle.behavior_logprobs
     loss_weights_array = batch.loss_weights.array
     loss_masks_array = batch.loss_masks.array
 
-    # Get logits from current policy
-    current_logprobs, current_policy_entropy = compute_policy_stats_fn(
-        model, batch, key, compute_entropy=log_policy_entropy
-    )
+    current_logprobs = score_bundle.student_logprobs
     current_logprobs = current_logprobs * loss_masks_array
 
     if synchronous:
@@ -375,21 +246,22 @@ def rloo_loss_with_importance_sampling(
     # weighted_loss = -clipped_ratio * loss_weights_array * loss_masks_array
     # KL regularization
 
-    log_ratio = jnp.zeros_like(current_logprobs)
-    kl_penalty = jnp.zeros_like(current_logprobs)
-    kl_loss = jnp.asarray(0.0, dtype=current_logprobs.dtype)
-    kl_statistics = kl_statistics_from_log_ratio(log_ratio, loss_masks_array)
-    if kl.enabled():
+    if kl_coef > 0:
         if reference_model is None:
-            raise ValueError("reference_model is required when KL regularization is enabled")
-        reference_logprobs, _reference_entropy = compute_policy_stats_fn(
-            reference_model, batch, key, compute_entropy=False
-        )
+            raise ValueError("reference_model is required when kl_coef > 0")
+        if score_bundle.reference_logprobs is None:
+            raise ValueError("score source did not produce reference logprobs")
+        reference_logprobs = score_bundle.reference_logprobs
         reference_logprobs = reference_logprobs * loss_masks_array
-        log_ratio = token_log_ratio(current_logprobs, reference_logprobs)
-        kl_penalty = kl_penalty_from_log_ratio(log_ratio, kl.mode)
-        kl_statistics = kl_statistics_from_log_ratio(log_ratio, loss_masks_array)
-        kl_loss = kl.beta * masked_response_mean(kl_penalty, loss_masks_array)
+        # log_ratio = (current_logprobs - reference_logprobs_array) * loss_masks_array
+        kl_penalty = jnp.exp(reference_logprobs - current_logprobs) - (reference_logprobs - current_logprobs) - 1
+        # https://github.com/openai/lm-human-preferences/blob/cbfd210bb8b08f6bc5c26878c10984b90f516c66/lm_human_preferences/train_policy.py#L151
+        # kl_penalty = jnp.abs(log_ratio)
+        kl_loss = jnp.mean(jnp.sum(kl_penalty * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1))
+        kl_loss = kl_coef * kl_loss
+    else:
+        kl_penalty = 0
+        kl_loss = 0
 
     loss = reinforce_loss + kl_loss
 
@@ -401,8 +273,11 @@ def rloo_loss_with_importance_sampling(
     clipped_ratio_mean_over_responses_only = jnp.mean(
         jnp.sum(clipped_ratio * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1)
     )
+    kl_penalty_over_responses_only = jnp.mean(
+        jnp.sum(kl_penalty * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1)
+    )
 
-    metrics = {
+    return loss, {
         "ratio_mean": Metric.from_value(ratio_mean_over_responses_only.astype(jnp.float32), ReductionType.MEAN),
         "clipped_ratio_mean": Metric.from_value(
             clipped_ratio_mean_over_responses_only.astype(jnp.float32), ReductionType.MEAN
@@ -410,28 +285,29 @@ def rloo_loss_with_importance_sampling(
         "clip_fraction": Metric.from_value(clip_fraction.astype(jnp.float32), ReductionType.MEAN),
         "reinforce_loss": Metric.from_value(reinforce_loss.astype(jnp.float32), ReductionType.MEAN),
         "kl_loss": Metric.from_value(jnp.asarray(kl_loss, dtype=jnp.float32), ReductionType.MEAN),
-        "kl_beta": Metric.from_value(jnp.asarray(kl.beta, dtype=jnp.float32), ReductionType.MEAN),
-        "kl_k1_mean": Metric.from_value(jnp.asarray(kl_statistics.k1_mean, dtype=jnp.float32), ReductionType.MEAN),
-        "kl_k2_mean": Metric.from_value(jnp.asarray(kl_statistics.k2_mean, dtype=jnp.float32), ReductionType.MEAN),
-        "kl_k3_mean": Metric.from_value(jnp.asarray(kl_statistics.k3_mean, dtype=jnp.float32), ReductionType.MEAN),
+        "kl_penalty": Metric.from_value(
+            jnp.asarray(kl_penalty_over_responses_only, dtype=jnp.float32), ReductionType.MEAN
+        ),
         "trainer_inference_importance_sampling_ratio_mean": Metric.from_value(
             trainer_inference_importance_sampling_ratio_mean.astype(jnp.float32), ReductionType.MEAN
         ),
         "temperature": Metric.from_value(jnp.mean(batch.temperature.array).astype(jnp.float32), ReductionType.MEAN),
         "top_k": Metric.from_value(jnp.mean(batch.top_k.array).astype(jnp.float32), ReductionType.MEAN),
+        "scoring/student_pass_count": Metric.from_value(
+            jnp.asarray(score_bundle.student_pass_count, dtype=jnp.float32),
+            ReductionType.MEAN,
+        ),
+        "scoring/reference_pass_count": Metric.from_value(
+            jnp.asarray(score_bundle.reference_pass_count, dtype=jnp.float32),
+            ReductionType.MEAN,
+        ),
+        "scoring/teacher_pass_count": Metric.from_value(
+            jnp.asarray(score_bundle.teacher_pass_count, dtype=jnp.float32),
+            ReductionType.MEAN,
+        ),
         **compute_metadata_metrics(current_logprobs, policy_logprobs_array, loss_weights_array, loss_masks_array),
         **metadata,
     }
-
-    if log_policy_entropy:
-        if current_policy_entropy is None:
-            raise ValueError("compute_policy_stats_fn must return entropy when log_policy_entropy=True")
-        policy_entropy = masked_response_mean(current_policy_entropy, loss_masks_array)
-        metrics["current_policy_entropy"] = Metric.from_value(
-            jax.lax.stop_gradient(policy_entropy).astype(jnp.float32), ReductionType.MEAN
-        )
-
-    return loss, metrics
 
 
 def compute_rloo_advantages(rollouts: list[Rollout]) -> np.ndarray:
@@ -452,7 +328,7 @@ def compute_rloo_advantages(rollouts: list[Rollout]) -> np.ndarray:
 class RLOOLoss(RLLossModule):
     """RLOO loss with importance sampling."""
 
-    kl: KLConfig
+    kl_coef: float = 0.1
     clip_epsilon_low: float = 0.2
     clip_epsilon_high: float = 0.2
     tis_importance_sampling_ratio_max: float = 2.0
@@ -460,7 +336,6 @@ class RLOOLoss(RLLossModule):
     do_trainer_inference_mismatch_importance_sampling: bool = False
     do_overlong_filtering: bool = False
     vocab_tile_size: int | None = None
-    log_policy_entropy: bool = False
 
     def build(self, reference_model: eqx.Module) -> RLLossModule:
         """Initialize any learned components (e.g., value heads)."""
@@ -472,43 +347,42 @@ class RLOOLoss(RLLossModule):
 
     def needs_reference_model(self) -> bool:
         """Return whether KL regularization requires a reference model."""
-        return self.kl.enabled()
+        return self.kl_coef > 0
 
     def create_loss_fn(self, reference_model: eqx.Module | None, train_model: eqx.Module) -> Callable:
         """Create the loss function for training."""
         if self.needs_reference_model() and reference_model is None:
-            raise ValueError("reference_model is required when KL regularization is enabled")
-        if self.log_policy_entropy and self.vocab_tile_size is not None:
-            raise ValueError(
-                "Exact policy entropy is not supported with vocab_tile_size yet. "
-                "Set vocab_tile_size=None or implement chunked entropy first."
-            )
+            raise ValueError("reference_model is required when kl_coef > 0")
+
+        score_source = LocalScoreSource(
+            score_requirements=ScoreRequirements(
+                student_logprobs=True,
+                behavior_logprobs=True,
+                reference_logprobs=self.needs_reference_model(),
+            ),
+            vocab_tile_size=self.vocab_tile_size,
+        )
+        logger.info(
+            "Using score source backend=%s requirements=%s vocab_tile_size=%s",
+            score_source.backend_name,
+            score_source.requirements(),
+            self.vocab_tile_size,
+        )
 
         def loss_fn(model, batch, key):
-            if self.vocab_tile_size is not None:
-
-                def compute_policy_stats_fn(m, b, k, *, compute_entropy: bool):
-                    if compute_entropy:
-                        raise ValueError("Exact policy entropy is not supported with vocab_tile_size yet")
-                    return chunked_compute_logprobs(m, b, k, self.vocab_tile_size), None
-
-            else:
-                compute_policy_stats_fn = compute_logprobs_and_entropy
-
             return rloo_loss_with_importance_sampling(
                 model,
                 reference_model,
                 batch,
+                score_source,
                 key=key,
-                kl=self.kl,
+                kl_coef=self.kl_coef,
                 clip_epsilon_low=self.clip_epsilon_low,
                 clip_epsilon_high=self.clip_epsilon_high,
                 tis_importance_sampling_ratio_max=self.tis_importance_sampling_ratio_max,
                 synchronous=self.synchronous,
                 do_trainer_inference_mismatch_importance_sampling=self.do_trainer_inference_mismatch_importance_sampling,
                 do_overlong_filtering=self.do_overlong_filtering,
-                log_policy_entropy=self.log_policy_entropy,
-                compute_policy_stats_fn=compute_policy_stats_fn,
             )
 
         return loss_fn

--- a/lib/marin/src/marin/rl/rollout_storage.py
+++ b/lib/marin/src/marin/rl/rollout_storage.py
@@ -4,22 +4,8 @@
 """
 Queues for communicating rollout information between inference and training workers.
 
-A rollout is a set of ndarrays containing all of the information required for training a model.
-This includes:
-
-* input_ids: The input token IDs.
-* attention_mask: The attention mask for the input.
-* position_ids: The position IDs for the input.
-* target_ids: The target token IDs for computing loss.
-* loss_weights: Weights for each token in the loss computation.
-* loss_masks: Masks indicating which tokens contribute to the loss.
-
-A RolloutBatch consists of the model information in addition to:
-
-* Environment name
-* Worker ID
-* Creation timestamp
-* Rollout ID
+A RolloutBatch stores grouped prompt/response trajectories plus rollout
+provenance. Training-ready batches are derived later by `train_batch.py`.
 
 During training, rollout batches are read from the file queue and compacted into
 training batches continously. Training data prioritizes recent rollouts and an

--- a/lib/marin/src/marin/rl/rollout_worker.py
+++ b/lib/marin/src/marin/rl/rollout_worker.py
@@ -447,6 +447,7 @@ class RolloutWorker:
         self._current_train_step: int = -1
         self._last_transfer_counters = RolloutTransferCounterSnapshot()
         self._last_eval_train_step: int | None = None
+        self._sample_batch_index: int = 0
 
         self._tokenizer = config.tokenizer
 
@@ -554,6 +555,8 @@ class RolloutWorker:
         )
 
         # Attach metadata to each rollout in each group
+        sample_batch_index = getattr(self, "_sample_batch_index", 0)
+        self._sample_batch_index = sample_batch_index + 1
         rollout_groups_with_metadata = []
         for group_index, group in enumerate(rollout_groups):
             trace = sample.traces[group_index] if sample.traces else None
@@ -565,6 +568,7 @@ class RolloutWorker:
                     lesson_id,
                     self._current_weight_step,
                     batch_metadata.worker_id,
+                    sample_batch_index,
                     group_index,
                 )
             )
@@ -576,6 +580,7 @@ class RolloutWorker:
                     lesson_id,
                     self._current_weight_step,
                     batch_metadata.worker_id,
+                    sample_batch_index,
                     group_index,
                 )
             )

--- a/lib/marin/src/marin/rl/rollout_worker.py
+++ b/lib/marin/src/marin/rl/rollout_worker.py
@@ -56,9 +56,11 @@ from marin.rl.run_state import RolloutTransferCounters
 from marin.rl.runtime import RLRuntimeHandles
 
 from .rollout_storage import RolloutStorageConfig, RolloutWriter
+from .traces import make_group_id, make_trace_id
 from .types import (
     RolloutBatch,
     RolloutGroup,
+    RolloutGroupMetadata,
     RolloutMetadata,
     RolloutStats,
 )
@@ -510,7 +512,7 @@ class RolloutWorker:
         lesson_config = self.config.curriculum_config.lessons[lesson_id]
         decoding = resolve_decoding_for_mode(lesson_config.sampling_params, mode)
 
-        rollout_groups, metrics = env.sample(
+        sample = env.sample(
             inference_ctx=self._policy_ctx,
             n_examples=n_examples,
             n_generations=n_generations,
@@ -519,10 +521,17 @@ class RolloutWorker:
             mode=mode,
             system_prompt=self.config.system_prompt,
         )
+        rollout_groups = sample.rollout_groups
+        metrics = sample.metrics
 
         if len(rollout_groups) == 0:
             logger.warning("No valid rollouts generated in this batch...")
             return None, None
+
+        if sample.traces and len(sample.traces) != len(rollout_groups):
+            raise ValueError(
+                f"Environment returned {len(sample.traces)} traces for {len(rollout_groups)} rollout groups"
+            )
 
         logger.info(
             "Generated rollout with %d groups from lesson %s at step %d",
@@ -536,18 +545,68 @@ class RolloutWorker:
             worker_id=f"{socket.gethostname()}_{os.getpid()}",
             timestamp=time.time(),
             weight_step=self._current_weight_step,
+            run_id=self.config.run_id,
+            lesson_id=lesson_id,
+            task_name=sample.identity.task_name,
+            task_version=sample.identity.task_version,
+            verifier_name=sample.identity.verifier_name,
+            verifier_version=sample.identity.verifier_version,
         )
 
         # Attach metadata to each rollout in each group
         rollout_groups_with_metadata = []
-        for group in rollout_groups:
+        for group_index, group in enumerate(rollout_groups):
+            trace = sample.traces[group_index] if sample.traces else None
+            group_id = (
+                trace.group_id
+                if trace and trace.group_id
+                else make_group_id(
+                    self.config.run_id,
+                    lesson_id,
+                    self._current_weight_step,
+                    batch_metadata.worker_id,
+                    group_index,
+                )
+            )
+            trace_id = (
+                trace.trace_id
+                if trace and trace.trace_id
+                else make_trace_id(
+                    self.config.run_id,
+                    lesson_id,
+                    self._current_weight_step,
+                    batch_metadata.worker_id,
+                    group_index,
+                )
+            )
+            trace_ref = trace.trace_ref if trace is not None else None
+            group_metadata = RolloutGroupMetadata(
+                group_id=group_id,
+                lesson_id=lesson_id,
+                trace_id=trace_id,
+                task_name=sample.identity.task_name,
+                task_version=sample.identity.task_version,
+                verifier_name=sample.identity.verifier_name,
+                verifier_version=sample.identity.verifier_version,
+                trace_ref=trace_ref,
+            )
+
             rollouts_with_metadata = []
             for rollout in group.rollouts:
                 # Create new rollout with metadata attached
-                rollout_with_meta = eqx.tree_at(lambda r: r.metadata, rollout, batch_metadata)
+                rollout_with_meta = eqx.tree_at(
+                    lambda r: r.metadata,
+                    rollout,
+                    dataclasses.replace(
+                        batch_metadata,
+                        group_id=group_id,
+                        trace_id=trace_id,
+                        trace_ref=trace_ref,
+                    ),
+                )
                 rollouts_with_metadata.append(rollout_with_meta)
 
-            rollout_groups_with_metadata.append(RolloutGroup(rollouts=rollouts_with_metadata))
+            rollout_groups_with_metadata.append(RolloutGroup(rollouts=rollouts_with_metadata, metadata=group_metadata))
 
         rollout_batch = RolloutBatch(
             groups=rollout_groups_with_metadata,

--- a/lib/marin/src/marin/rl/scoring.py
+++ b/lib/marin/src/marin/rl/scoring.py
@@ -1,0 +1,268 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared scoring runtime for RL/post-training objectives."""
+
+from dataclasses import dataclass
+from typing import Protocol, TypeAlias
+
+import haliax as hax
+import jax
+import jax.numpy as jnp
+from haliax import NamedArray
+from levanter.layers.attention import AttentionMask
+from levanter.models.lm_model import LmHeadModel
+from levanter.models.loss import fused_cross_entropy_loss_and_logsumexp_penalty
+
+from .types import BatchInfo, SequenceBatch, TrainingBatch
+
+ScoredBatch: TypeAlias = SequenceBatch | TrainingBatch
+
+
+@dataclass(frozen=True)
+class TokenScoreInputs:
+    """Canonical token-scoring inputs shared by sequence and training batches."""
+
+    input_ids: NamedArray
+    position_ids: NamedArray
+    sampling_temperature: NamedArray
+
+
+@dataclass(frozen=True)
+class ScoreRequirements:
+    """Scores required by an objective runtime."""
+
+    student_logprobs: bool = True
+    behavior_logprobs: bool = False
+    reference_logprobs: bool = False
+    teacher_token_logprobs: bool = False
+    teacher_entropy: bool = False
+    teacher_topk_support: int | None = None
+
+
+@dataclass
+class ScoreBundle:
+    """Resolved scores plus compact execution metadata."""
+
+    student_logprobs: jax.Array | None = None
+    behavior_logprobs: jax.Array | None = None
+    reference_logprobs: jax.Array | None = None
+    teacher_logprobs: jax.Array | None = None
+    teacher_entropy: jax.Array | None = None
+    teacher_topk_ids: jax.Array | None = None
+    teacher_topk_logprobs: jax.Array | None = None
+    student_pass_count: int = 0
+    reference_pass_count: int = 0
+    teacher_pass_count: int = 0
+
+
+@dataclass(frozen=True)
+class ModelRoles:
+    """Concrete model handles used by a score source."""
+
+    student: LmHeadModel
+    reference: LmHeadModel | None = None
+    teacher: LmHeadModel | None = None
+
+
+class ScoreSource(Protocol):
+    """Backend protocol for scoring model-dependent quantities."""
+
+    @property
+    def backend_name(self) -> str:
+        """Return a stable scorer backend identifier."""
+        ...
+
+    def requirements(self) -> ScoreRequirements:
+        """Return the score requests handled by this source."""
+        ...
+
+    def score(
+        self,
+        batch: ScoredBatch,
+        info: BatchInfo | None,
+        roles: ModelRoles,
+        *,
+        key: jax.Array | None,
+    ) -> ScoreBundle:
+        """Compute requested scores for the provided batch."""
+        ...
+
+
+def token_score_inputs_from_batch(batch: ScoredBatch) -> TokenScoreInputs:
+    """Project a batch into the canonical token-scoring view."""
+    if isinstance(batch, SequenceBatch):
+        return TokenScoreInputs(
+            input_ids=batch.input_ids,
+            position_ids=batch.position_ids,
+            sampling_temperature=batch.sampling_temperature,
+        )
+    if isinstance(batch, TrainingBatch):
+        return TokenScoreInputs(
+            input_ids=batch.input_ids,
+            position_ids=batch.position_ids,
+            sampling_temperature=batch.temperature,
+        )
+    raise TypeError(f"Unsupported batch type for scoring: {type(batch)!r}")
+
+
+def behavior_logprobs_from_batch(batch: ScoredBatch) -> jax.Array:
+    """Extract the behavior-policy logprobs from the current batch view."""
+    if isinstance(batch, SequenceBatch):
+        return batch.behavior_logprobs.array
+    if isinstance(batch, TrainingBatch):
+        return batch.policy_logprobs.array
+    raise TypeError(f"Unsupported batch type for scoring: {type(batch)!r}")
+
+
+def compute_logprobs(
+    model: LmHeadModel,
+    batch: TokenScoreInputs,
+    key: jax.Array | None,
+) -> jax.Array:
+    """Compute token log probabilities for the observed next-token targets."""
+    batch_size, _seq_len = batch.input_ids.array.shape
+
+    model_output = model(
+        input_ids=batch.input_ids,
+        attn_mask=AttentionMask.causal(),
+        pos_ids=batch.position_ids,
+        key=key,
+    )
+
+    logits_array = model_output.array.astype(jnp.float32)[:, :-1, :]
+    target_ids_array = batch.input_ids.array[:, 1:]
+    safe_temperature = jnp.where(batch.sampling_temperature.array == 0, 1.0, batch.sampling_temperature.array).reshape(
+        batch_size, 1, 1
+    )
+    logits_array = logits_array / safe_temperature.astype(jnp.float32)
+
+    log_probs = jax.nn.log_softmax(logits_array, axis=-1)
+    logprobs_shifted = jnp.take_along_axis(log_probs, target_ids_array[..., None], axis=-1).squeeze(-1)
+    return jnp.concatenate(
+        [jnp.zeros((logprobs_shifted.shape[0], 1), dtype=logprobs_shifted.dtype), logprobs_shifted],
+        axis=1,
+    )
+
+
+def chunked_compute_logprobs(
+    model: LmHeadModel,
+    batch: TokenScoreInputs,
+    key: jax.Array | None,
+    block_size: int,
+) -> jax.Array:
+    """Compute token log probabilities with blockwise vocab processing."""
+    activations = model.activations(
+        input_ids=batch.input_ids,
+        attn_mask=AttentionMask.causal(),
+        pos_ids=batch.position_ids,
+        key=key,
+    )
+    if isinstance(activations, tuple):
+        activations, _aux = activations
+
+    pred_embeddings = activations.astype(jnp.float32)
+    pred_lm_head = model.get_lm_head().astype(jnp.float32)
+
+    safe_temperature = hax.where(batch.sampling_temperature == 0, 1.0, batch.sampling_temperature).astype(jnp.float32)
+    pred_embeddings = pred_embeddings / safe_temperature
+
+    pos_axis = batch.input_ids.resolve_axis("position")
+    target_y = hax.roll(batch.input_ids, -1, pos_axis)
+
+    loss = fused_cross_entropy_loss_and_logsumexp_penalty(
+        pred_embeddings,
+        pred_lm_head,
+        Contract=model.Embed,
+        Label=model.Vocab,
+        target_y=target_y,
+        reduction=None,
+        logsumexp_weight=0.0,
+        block_size=block_size,
+        dtype=jnp.float32,
+    )
+
+    logprobs_shifted = -loss.array[:, :-1]
+    return jnp.concatenate(
+        [jnp.zeros((logprobs_shifted.shape[0], 1), dtype=logprobs_shifted.dtype), logprobs_shifted],
+        axis=1,
+    )
+
+
+def compute_model_logprobs(
+    model: LmHeadModel,
+    batch: ScoredBatch,
+    key: jax.Array | None,
+    *,
+    vocab_tile_size: int | None = None,
+) -> jax.Array:
+    """Compute logprobs using either the eager or chunked backend."""
+    score_inputs = token_score_inputs_from_batch(batch)
+    if vocab_tile_size is None:
+        return compute_logprobs(model, score_inputs, key)
+    return chunked_compute_logprobs(model, score_inputs, key, vocab_tile_size)
+
+
+@dataclass(frozen=True)
+class LocalScoreSource:
+    """Local Levanter-backed scorer for student, reference, and teacher models."""
+
+    score_requirements: ScoreRequirements
+    vocab_tile_size: int | None = None
+    backend_name: str = "levanter-local"
+
+    def requirements(self) -> ScoreRequirements:
+        return self.score_requirements
+
+    def score(
+        self,
+        batch: ScoredBatch,
+        info: BatchInfo | None,
+        roles: ModelRoles,
+        *,
+        key: jax.Array | None,
+    ) -> ScoreBundle:
+        del info
+
+        requirements = self.score_requirements
+        if requirements.teacher_entropy:
+            raise NotImplementedError("Teacher entropy scoring is not implemented yet")
+        if requirements.teacher_topk_support is not None:
+            raise NotImplementedError("Teacher top-k scoring is not implemented yet")
+
+        score_bundle = ScoreBundle()
+        if requirements.behavior_logprobs:
+            score_bundle.behavior_logprobs = behavior_logprobs_from_batch(batch)
+
+        if requirements.student_logprobs:
+            score_bundle.student_logprobs = compute_model_logprobs(
+                roles.student,
+                batch,
+                key,
+                vocab_tile_size=self.vocab_tile_size,
+            )
+            score_bundle.student_pass_count = 1
+
+        if requirements.reference_logprobs:
+            if roles.reference is None:
+                raise ValueError("reference model is required to score reference logprobs")
+            score_bundle.reference_logprobs = compute_model_logprobs(
+                roles.reference,
+                batch,
+                key,
+                vocab_tile_size=self.vocab_tile_size,
+            )
+            score_bundle.reference_pass_count = 1
+
+        if requirements.teacher_token_logprobs:
+            if roles.teacher is None:
+                raise ValueError("teacher model is required to score teacher logprobs")
+            score_bundle.teacher_logprobs = compute_model_logprobs(
+                roles.teacher,
+                batch,
+                key,
+                vocab_tile_size=self.vocab_tile_size,
+            )
+            score_bundle.teacher_pass_count = 1
+
+        return score_bundle

--- a/lib/marin/src/marin/rl/scoring.py
+++ b/lib/marin/src/marin/rl/scoring.py
@@ -33,6 +33,7 @@ class ScoreRequirements:
     """Scores required by an objective runtime."""
 
     student_logprobs: bool = True
+    student_entropy: bool = False
     behavior_logprobs: bool = False
     reference_logprobs: bool = False
     teacher_token_logprobs: bool = False
@@ -45,6 +46,7 @@ class ScoreBundle:
     """Resolved scores plus compact execution metadata."""
 
     student_logprobs: jax.Array | None = None
+    student_entropy: jax.Array | None = None
     behavior_logprobs: jax.Array | None = None
     reference_logprobs: jax.Array | None = None
     teacher_logprobs: jax.Array | None = None
@@ -121,6 +123,18 @@ def compute_logprobs(
     key: jax.Array | None,
 ) -> jax.Array:
     """Compute token log probabilities for the observed next-token targets."""
+    logprobs, _entropy = compute_logprobs_and_entropy(model, batch, key, compute_entropy=False)
+    return logprobs
+
+
+def compute_logprobs_and_entropy(
+    model: LmHeadModel,
+    batch: TokenScoreInputs,
+    key: jax.Array | None,
+    *,
+    compute_entropy: bool,
+) -> tuple[jax.Array, jax.Array | None]:
+    """Compute selected-token logprobs and optional full-vocabulary policy entropy."""
     batch_size, _seq_len = batch.input_ids.array.shape
 
     model_output = model(
@@ -139,10 +153,20 @@ def compute_logprobs(
 
     log_probs = jax.nn.log_softmax(logits_array, axis=-1)
     logprobs_shifted = jnp.take_along_axis(log_probs, target_ids_array[..., None], axis=-1).squeeze(-1)
-    return jnp.concatenate(
+    logprobs = jnp.concatenate(
         [jnp.zeros((logprobs_shifted.shape[0], 1), dtype=logprobs_shifted.dtype), logprobs_shifted],
         axis=1,
     )
+    if not compute_entropy:
+        return logprobs, None
+
+    probs = jax.nn.softmax(logits_array, axis=-1)
+    entropy_shifted = jax.nn.logsumexp(logits_array, axis=-1) - jnp.sum(probs * logits_array, axis=-1)
+    entropy = jnp.concatenate(
+        [jnp.zeros((entropy_shifted.shape[0], 1), dtype=entropy_shifted.dtype), entropy_shifted],
+        axis=1,
+    )
+    return logprobs, entropy
 
 
 def chunked_compute_logprobs(
@@ -197,10 +221,32 @@ def compute_model_logprobs(
     vocab_tile_size: int | None = None,
 ) -> jax.Array:
     """Compute logprobs using either the eager or chunked backend."""
+    logprobs, _entropy = compute_model_logprobs_and_entropy(
+        model,
+        batch,
+        key,
+        vocab_tile_size=vocab_tile_size,
+        compute_entropy=False,
+    )
+    return logprobs
+
+
+def compute_model_logprobs_and_entropy(
+    model: LmHeadModel,
+    batch: ScoredBatch,
+    key: jax.Array | None,
+    *,
+    vocab_tile_size: int | None = None,
+    compute_entropy: bool = False,
+) -> tuple[jax.Array, jax.Array | None]:
+    """Compute model token logprobs and optional exact entropy for scored batches."""
     score_inputs = token_score_inputs_from_batch(batch)
+    if compute_entropy and vocab_tile_size is not None:
+        raise ValueError("Exact policy entropy is not supported with vocab_tile_size yet")
+
     if vocab_tile_size is None:
-        return compute_logprobs(model, score_inputs, key)
-    return chunked_compute_logprobs(model, score_inputs, key, vocab_tile_size)
+        return compute_logprobs_and_entropy(model, score_inputs, key, compute_entropy=compute_entropy)
+    return chunked_compute_logprobs(model, score_inputs, key, vocab_tile_size), None
 
 
 @dataclass(frozen=True)
@@ -234,13 +280,16 @@ class LocalScoreSource:
         if requirements.behavior_logprobs:
             score_bundle.behavior_logprobs = behavior_logprobs_from_batch(batch)
 
-        if requirements.student_logprobs:
-            score_bundle.student_logprobs = compute_model_logprobs(
+        if requirements.student_logprobs or requirements.student_entropy:
+            student_logprobs, student_entropy = compute_model_logprobs_and_entropy(
                 roles.student,
                 batch,
                 key,
                 vocab_tile_size=self.vocab_tile_size,
+                compute_entropy=requirements.student_entropy,
             )
+            score_bundle.student_logprobs = student_logprobs
+            score_bundle.student_entropy = student_entropy
             score_bundle.student_pass_count = 1
 
         if requirements.reference_logprobs:

--- a/lib/marin/src/marin/rl/scoring.py
+++ b/lib/marin/src/marin/rl/scoring.py
@@ -4,7 +4,7 @@
 """Shared scoring runtime for RL/post-training objectives."""
 
 from dataclasses import dataclass
-from typing import Protocol, TypeAlias
+from typing import Protocol
 
 import haliax as hax
 import jax
@@ -16,7 +16,7 @@ from levanter.models.loss import fused_cross_entropy_loss_and_logsumexp_penalty
 
 from .types import BatchInfo, SequenceBatch, TrainingBatch
 
-ScoredBatch: TypeAlias = SequenceBatch | TrainingBatch
+type ScoredBatch = SequenceBatch | TrainingBatch
 
 
 @dataclass(frozen=True)

--- a/lib/marin/src/marin/rl/traces.py
+++ b/lib/marin/src/marin/rl/traces.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field, replace
 import uuid
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 

--- a/lib/marin/src/marin/rl/traces.py
+++ b/lib/marin/src/marin/rl/traces.py
@@ -1,0 +1,77 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Trace contracts for RL/post-training environments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+import uuid
+from typing import Any
+
+
+@dataclass(frozen=True)
+class EpisodeResponseTrace:
+    """Cold-path trace data for one sampled response."""
+
+    response_text: str
+    reward: float | None = None
+    correctness_reward: float | None = None
+    is_truncated: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class EpisodeTrace:
+    """Prompt-level trace data for one rollout group."""
+
+    env_name: str
+    env_example_id: str
+    prompt: str | list[dict[str, str]]
+    responses: tuple[EpisodeResponseTrace, ...]
+    task_name: str = ""
+    task_version: str = "v1"
+    verifier_name: str | None = None
+    verifier_version: str | None = None
+    lesson_id: str = ""
+    group_id: str = ""
+    trace_id: str = ""
+    trace_ref: str | None = None
+
+    def with_runtime_metadata(
+        self,
+        *,
+        lesson_id: str,
+        group_id: str,
+        trace_id: str,
+        task_name: str,
+        task_version: str,
+        verifier_name: str | None,
+        verifier_version: str | None,
+    ) -> EpisodeTrace:
+        """Return a copy with rollout-runtime metadata attached."""
+
+        return replace(
+            self,
+            lesson_id=lesson_id,
+            group_id=group_id,
+            trace_id=trace_id,
+            task_name=task_name,
+            task_version=task_version,
+            verifier_name=verifier_name,
+            verifier_version=verifier_version,
+        )
+
+
+def make_group_id(run_id: str, lesson_id: str, weight_step: int, worker_id: str, group_index: int) -> str:
+    """Build a stable group identifier for a rollout group."""
+
+    seed = f"group:{run_id}:{lesson_id}:{weight_step}:{worker_id}:{group_index}"
+    return f"group-{uuid.uuid5(uuid.NAMESPACE_URL, seed)}"
+
+
+def make_trace_id(run_id: str, lesson_id: str, weight_step: int, worker_id: str, group_index: int) -> str:
+    """Build a stable trace identifier for a rollout group."""
+
+    seed = f"trace:{run_id}:{lesson_id}:{weight_step}:{worker_id}:{group_index}"
+    return f"trace-{uuid.uuid5(uuid.NAMESPACE_URL, seed)}"

--- a/lib/marin/src/marin/rl/traces.py
+++ b/lib/marin/src/marin/rl/traces.py
@@ -63,15 +63,29 @@ class EpisodeTrace:
         )
 
 
-def make_group_id(run_id: str, lesson_id: str, weight_step: int, worker_id: str, group_index: int) -> str:
+def make_group_id(
+    run_id: str,
+    lesson_id: str,
+    weight_step: int,
+    worker_id: str,
+    sample_batch_index: int,
+    group_index: int,
+) -> str:
     """Build a stable group identifier for a rollout group."""
 
-    seed = f"group:{run_id}:{lesson_id}:{weight_step}:{worker_id}:{group_index}"
+    seed = f"group:{run_id}:{lesson_id}:{weight_step}:{worker_id}:{sample_batch_index}:{group_index}"
     return f"group-{uuid.uuid5(uuid.NAMESPACE_URL, seed)}"
 
 
-def make_trace_id(run_id: str, lesson_id: str, weight_step: int, worker_id: str, group_index: int) -> str:
+def make_trace_id(
+    run_id: str,
+    lesson_id: str,
+    weight_step: int,
+    worker_id: str,
+    sample_batch_index: int,
+    group_index: int,
+) -> str:
     """Build a stable trace identifier for a rollout group."""
 
-    seed = f"trace:{run_id}:{lesson_id}:{weight_step}:{worker_id}:{group_index}"
+    seed = f"trace:{run_id}:{lesson_id}:{weight_step}:{worker_id}:{sample_batch_index}:{group_index}"
     return f"trace-{uuid.uuid5(uuid.NAMESPACE_URL, seed)}"

--- a/lib/marin/src/marin/rl/train_batch.py
+++ b/lib/marin/src/marin/rl/train_batch.py
@@ -61,6 +61,24 @@ def rollout_to_trajectory_record(rollout: Rollout) -> TrajectoryRecord:
     )
 
 
+def trajectory_record_to_rollout(trajectory: TrajectoryRecord) -> Rollout:
+    """Reconstruct a rollout from the neutral trajectory record."""
+    return Rollout(
+        env_name=trajectory.env_name,
+        env_example_id=trajectory.env_example_id,
+        prompt_tokens=trajectory.prompt_tokens,
+        response_tokens=trajectory.response_tokens,
+        response_logprobs=trajectory.behavior_logprobs,
+        token_rewards=trajectory.token_rewards,
+        episode_reward=trajectory.episode_reward,
+        temperature=trajectory.sampling_temperature,
+        top_k=trajectory.sampling_top_k,
+        is_truncated=trajectory.is_truncated,
+        metadata=trajectory.rollout_metadata,
+        correctness_reward=trajectory.correctness_reward,
+    )
+
+
 def rollout_group_to_trajectory_group_record(group: RolloutGroup) -> TrajectoryGroupRecord:
     """Convert a rollout group into a prompt-level grouped record."""
     if not group.rollouts:

--- a/lib/marin/src/marin/rl/train_batch.py
+++ b/lib/marin/src/marin/rl/train_batch.py
@@ -5,8 +5,8 @@
 Training batch creation utilities for RL training.
 
 This module owns the neutral trajectory-to-batch transform used by the RL
-training stack. The current TrainingBatch remains available as a compatibility
-adapter until replay and objective runtime refactors land.
+training stack. TrainingBatch remains available only as a legacy compatibility
+adapter for parity tests and old helper paths.
 """
 
 import logging

--- a/lib/marin/src/marin/rl/train_batch.py
+++ b/lib/marin/src/marin/rl/train_batch.py
@@ -4,19 +4,90 @@
 """
 Training batch creation utilities for RL training.
 
-This module provides functions to convert rollout data into training-ready
-batches with proper padding, masking, and advantage weighting.
+This module owns the neutral trajectory-to-batch transform used by the RL
+training stack. The current TrainingBatch remains available as a compatibility
+adapter until replay and objective runtime refactors land.
 """
 
 import logging
+from typing import Any
 
 import haliax as hax
 import jax.numpy as jnp
 import numpy as np
 
-from .types import Rollout, RolloutWithAdvantage, TrainingBatch
+from .types import (
+    BatchInfo,
+    Rollout,
+    RolloutGroup,
+    RolloutWithAdvantage,
+    SequenceBatch,
+    TrainingBatch,
+    TrajectoryGroupRecord,
+    TrajectoryRecord,
+)
 
 logger = logging.getLogger(__name__)
+
+TOP_K_NONE_SENTINEL = -1
+UNKNOWN_TRAIN_STEP = -1
+UNKNOWN_CORRECTNESS_REWARD = np.nan
+
+
+def rollout_to_trajectory_record(rollout: Rollout) -> TrajectoryRecord:
+    """Convert a rollout into the canonical neutral training record."""
+    metadata = rollout.metadata
+    return TrajectoryRecord(
+        trace_id=metadata.trace_id,
+        env_name=rollout.env_name,
+        task_name=metadata.task_name,
+        task_version=metadata.task_version,
+        lesson_id=metadata.lesson_id,
+        env_example_id=rollout.env_example_id,
+        group_id=metadata.group_id,
+        verifier_name=metadata.verifier_name,
+        verifier_version=metadata.verifier_version,
+        prompt_tokens=rollout.prompt_tokens,
+        response_tokens=rollout.response_tokens,
+        behavior_logprobs=rollout.response_logprobs,
+        token_rewards=rollout.token_rewards,
+        episode_reward=rollout.episode_reward,
+        correctness_reward=rollout.correctness_reward,
+        is_truncated=rollout.is_truncated,
+        sampling_temperature=rollout.decoding.temperature,
+        sampling_top_k=rollout.decoding.top_k,
+        rollout_metadata=metadata,
+        trace_ref=metadata.trace_ref,
+    )
+
+
+def rollout_group_to_trajectory_group_record(group: RolloutGroup) -> TrajectoryGroupRecord:
+    """Convert a rollout group into a prompt-level grouped record."""
+    if not group.rollouts:
+        raise ValueError("Cannot convert an empty rollout group")
+
+    prompt_tokens = group.rollouts[0].prompt_tokens
+    for rollout in group.rollouts[1:]:
+        if not np.array_equal(rollout.prompt_tokens, prompt_tokens):
+            raise ValueError("All rollouts in a group must share the same prompt tokens")
+
+    trajectories = tuple(rollout_to_trajectory_record(rollout) for rollout in group.rollouts)
+    metadata = group.metadata
+    first_trajectory = trajectories[0]
+    return TrajectoryGroupRecord(
+        group_id=metadata.group_id or first_trajectory.group_id,
+        lesson_id=metadata.lesson_id or first_trajectory.lesson_id,
+        trace_id=metadata.trace_id or first_trajectory.trace_id,
+        task_name=metadata.task_name or first_trajectory.task_name,
+        task_version=metadata.task_version or first_trajectory.task_version,
+        verifier_name=metadata.verifier_name if metadata.verifier_name is not None else first_trajectory.verifier_name,
+        verifier_version=(
+            metadata.verifier_version if metadata.verifier_version is not None else first_trajectory.verifier_version
+        ),
+        prompt_tokens=prompt_tokens,
+        trajectories=trajectories,
+        trace_ref=metadata.trace_ref if metadata.trace_ref is not None else first_trajectory.trace_ref,
+    )
 
 
 def trim_and_pad(ary: np.ndarray, max_seq_len: int, pad_to: int, padding_value: int | float) -> np.ndarray:
@@ -28,66 +99,243 @@ def trim_and_pad(ary: np.ndarray, max_seq_len: int, pad_to: int, padding_value: 
     return ary
 
 
+def convert_trajectory_to_sequence_format(
+    trajectory: TrajectoryRecord,
+    max_tokens: int,
+    pad_to: int,
+    pad_token_id: int,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Convert a trajectory into neutral sequence tensors and metadata."""
+    input_tokens = np.concatenate([trajectory.prompt_tokens, trajectory.response_tokens])
+    position_ids = np.arange(len(input_tokens), dtype=np.int32)
+
+    prompt_mask = np.concatenate(
+        [
+            np.ones(len(trajectory.prompt_tokens), dtype=np.float32),
+            np.zeros(len(trajectory.response_tokens), dtype=np.float32),
+        ]
+    )
+    response_mask = np.concatenate(
+        [
+            np.zeros(len(trajectory.prompt_tokens), dtype=np.float32),
+            np.ones(len(trajectory.response_tokens), dtype=np.float32),
+        ]
+    )
+    behavior_logprobs = np.concatenate(
+        [
+            np.zeros(len(trajectory.prompt_tokens), dtype=np.float32),
+            trajectory.behavior_logprobs.astype(np.float32),
+        ]
+    )
+    token_rewards = np.concatenate(
+        [
+            np.zeros(len(trajectory.prompt_tokens), dtype=np.float32),
+            trajectory.token_rewards.astype(np.float32),
+        ]
+    )
+
+    input_ids = trim_and_pad(input_tokens, max_tokens, pad_to, padding_value=pad_token_id)
+    position_ids = trim_and_pad(position_ids, max_tokens, pad_to, padding_value=0)
+    prompt_mask = trim_and_pad(prompt_mask, max_tokens, pad_to, padding_value=0)
+    response_mask = trim_and_pad(response_mask, max_tokens, pad_to, padding_value=0)
+    behavior_logprobs = trim_and_pad(behavior_logprobs, max_tokens, pad_to, padding_value=0)
+    token_rewards = trim_and_pad(token_rewards, max_tokens, pad_to, padding_value=0)
+
+    metadata = trajectory.rollout_metadata
+    sequence_example = {
+        "input_ids": input_ids,
+        "position_ids": position_ids,
+        "prompt_mask": prompt_mask,
+        "response_mask": response_mask,
+        "behavior_logprobs": behavior_logprobs,
+        "sampling_temperature": trajectory.sampling_temperature,
+        "sampling_top_k": trajectory.sampling_top_k if trajectory.sampling_top_k is not None else TOP_K_NONE_SENTINEL,
+        "truncated": trajectory.is_truncated,
+    }
+    info_example = {
+        "group_id": trajectory.group_id,
+        "lesson_id": trajectory.lesson_id,
+        "env_name": trajectory.env_name,
+        "env_example_id": trajectory.env_example_id,
+        "task_name": trajectory.task_name,
+        "task_version": trajectory.task_version,
+        "verifier_name": trajectory.verifier_name,
+        "verifier_version": trajectory.verifier_version,
+        "worker_id": metadata.worker_id,
+        "run_id": metadata.run_id,
+        "trace_id": trajectory.trace_id,
+        "trace_ref": trajectory.trace_ref,
+        "prompt_length": int(prompt_mask.sum()),
+        "response_length": int(response_mask.sum()),
+        "episode_reward": trajectory.episode_reward,
+        "token_rewards": token_rewards,
+        "correctness_reward": (
+            UNKNOWN_CORRECTNESS_REWARD
+            if trajectory.correctness_reward is None
+            else np.float32(trajectory.correctness_reward)
+        ),
+        "weight_step": metadata.weight_step,
+        "train_step": UNKNOWN_TRAIN_STEP,
+        "timestamp": metadata.timestamp,
+    }
+    return sequence_example, info_example
+
+
 def convert_rollout_to_training_format(
     rollout: Rollout,
     advantage: float,
     max_tokens: int,
     pad_to: int,
     pad_token_id: int,
-) -> dict:
-    """Convert a single rollout to training format with advantage.
-
-    Args:
-        rollout: The rollout data to convert
-        advantage: Precomputed advantage value for this rollout
-        max_tokens: Maximum sequence length for truncation
-        pad_to: Target length to pad to after truncation
-        pad_token_id: Token ID to use for padding
-
-    Returns:
-        Dictionary containing training-ready arrays for the rollout
-    """
-    input_tokens = np.concatenate([rollout.prompt_tokens, rollout.response_tokens])
-    position_ids = np.arange(len(input_tokens), dtype=np.int32)
-
-    # Loss mask (only on response tokens)
-    loss_mask = np.concatenate(
-        [
-            np.zeros(len(rollout.prompt_tokens), dtype=np.float32),
-            np.ones(len(rollout.response_tokens), dtype=np.float32),
-        ]
+) -> dict[str, Any]:
+    """Compatibility wrapper that materializes the legacy training example."""
+    sequence_example, _ = convert_trajectory_to_sequence_format(
+        rollout_to_trajectory_record(rollout),
+        max_tokens=max_tokens,
+        pad_to=pad_to,
+        pad_token_id=pad_token_id,
     )
-
-    # Loss weights (advantage for all response tokens)
-    loss_weight = np.concatenate(
-        [
-            np.zeros(len(rollout.prompt_tokens), dtype=np.float32),
-            np.full(len(rollout.response_tokens), advantage, dtype=np.float32),
-        ]
-    )
-
-    policy_logprob = np.concatenate(
-        [np.zeros(len(rollout.prompt_tokens), dtype=np.float32), rollout.response_logprobs.astype(np.float32)]
-    )
-
-    max_seq_len = max_tokens
-
-    input_ids = trim_and_pad(input_tokens, max_seq_len, pad_to, padding_value=pad_token_id)
-    position_ids = trim_and_pad(position_ids, max_seq_len, pad_to, padding_value=0)
-    loss_weight = trim_and_pad(loss_weight, max_seq_len, pad_to, padding_value=0)
-    loss_mask = trim_and_pad(loss_mask, max_seq_len, pad_to, padding_value=0)
-    policy_logprob = trim_and_pad(policy_logprob, max_seq_len, pad_to, padding_value=0)
-
     return {
-        "input_ids": input_ids,
-        "position_ids": position_ids,
-        "loss_weights": loss_weight,
-        "loss_masks": loss_mask,
-        "policy_logprobs": policy_logprob,
-        "temperature": rollout.decoding.temperature,
-        "top_k": rollout.decoding.top_k if rollout.decoding.top_k is not None else -1,
-        "truncated": rollout.is_truncated,
+        "input_ids": sequence_example["input_ids"],
+        "position_ids": sequence_example["position_ids"],
+        "loss_weights": sequence_example["response_mask"] * np.float32(advantage),
+        "loss_masks": sequence_example["response_mask"],
+        "policy_logprobs": sequence_example["behavior_logprobs"],
+        "temperature": sequence_example["sampling_temperature"],
+        "top_k": sequence_example["sampling_top_k"],
+        "truncated": sequence_example["truncated"],
     }
+
+
+def _compute_pad_to(sequence_lengths: list[int], max_tokens: int, pad_to_multiple: int | None) -> int:
+    batch_max_len = max(min(sequence_length, max_tokens) for sequence_length in sequence_lengths)
+    pad_to = batch_max_len
+    if pad_to_multiple is not None and pad_to_multiple > 0:
+        pad_to = ((batch_max_len + pad_to_multiple - 1) // pad_to_multiple) * pad_to_multiple
+        if pad_to > max_tokens:
+            raise ValueError(
+                "Rounded batch padding length exceeds max_tokens. "
+                f"batch_max_len={batch_max_len}, pad_to_multiple={pad_to_multiple}, max_tokens={max_tokens}. "
+                "Increase max_seq_len or reduce flash_attention_block_size."
+            )
+    return pad_to
+
+
+def create_sequence_batch_from_trajectories(
+    trajectories: list[TrajectoryRecord],
+    max_tokens: int,
+    pad_token_id: int,
+    pad_to_multiple: int | None = None,
+) -> tuple[SequenceBatch, BatchInfo]:
+    """Create a neutral sequence batch and sidecar metadata from trajectories."""
+    if not trajectories:
+        raise ValueError("Cannot create batch from empty trajectory list")
+
+    pad_to = _compute_pad_to(
+        [len(trajectory.prompt_tokens) + len(trajectory.response_tokens) for trajectory in trajectories],
+        max_tokens=max_tokens,
+        pad_to_multiple=pad_to_multiple,
+    )
+
+    sequence_examples = []
+    info_examples = []
+    for trajectory in trajectories:
+        sequence_example, info_example = convert_trajectory_to_sequence_format(
+            trajectory,
+            max_tokens=max_tokens,
+            pad_to=pad_to,
+            pad_token_id=pad_token_id,
+        )
+        sequence_examples.append(sequence_example)
+        info_examples.append(info_example)
+
+    sequence_tensors = {
+        "input_ids": jnp.stack([example["input_ids"] for example in sequence_examples], axis=0),
+        "position_ids": jnp.stack([example["position_ids"] for example in sequence_examples], axis=0),
+        "prompt_mask": jnp.stack([example["prompt_mask"] for example in sequence_examples], axis=0),
+        "response_mask": jnp.stack([example["response_mask"] for example in sequence_examples], axis=0),
+        "behavior_logprobs": jnp.stack([example["behavior_logprobs"] for example in sequence_examples], axis=0),
+        "sampling_temperature": jnp.asarray(
+            [example["sampling_temperature"] for example in sequence_examples],
+            dtype=np.float32,
+        ),
+        "sampling_top_k": jnp.asarray(
+            [example["sampling_top_k"] for example in sequence_examples],
+            dtype=np.int32,
+        ),
+        "truncated": jnp.asarray([example["truncated"] for example in sequence_examples], dtype=np.bool_),
+    }
+    info_tensors = {
+        "prompt_length": jnp.asarray([example["prompt_length"] for example in info_examples], dtype=np.int32),
+        "response_length": jnp.asarray([example["response_length"] for example in info_examples], dtype=np.int32),
+        "episode_reward": jnp.asarray([example["episode_reward"] for example in info_examples], dtype=np.float32),
+        "token_rewards": jnp.stack([example["token_rewards"] for example in info_examples], axis=0),
+        "correctness_reward": jnp.asarray(
+            [example["correctness_reward"] for example in info_examples],
+            dtype=np.float32,
+        ),
+        "weight_step": jnp.asarray([example["weight_step"] for example in info_examples], dtype=np.int32),
+        "train_step": jnp.asarray([example["train_step"] for example in info_examples], dtype=np.int32),
+    }
+
+    per_row_mask_sum = sequence_tensors["response_mask"].sum(axis=1)
+    zero_mask_rows = int((per_row_mask_sum == 0).sum())
+    assert zero_mask_rows == 0, (
+        f"Found {zero_mask_rows} rollouts with all-zero response masks. "
+        "This happens when prompt_tokens >= max_seq_len, leaving no room for response tokens. "
+        "Increase max_seq_len in CurriculumConfig."
+    )
+
+    sequence_batch = SequenceBatch(
+        input_ids=hax.named(sequence_tensors["input_ids"], ["batch", "position"]),
+        position_ids=hax.named(sequence_tensors["position_ids"], ["batch", "position"]),
+        prompt_mask=hax.named(sequence_tensors["prompt_mask"], ["batch", "position"]),
+        response_mask=hax.named(sequence_tensors["response_mask"], ["batch", "position"]),
+        behavior_logprobs=hax.named(sequence_tensors["behavior_logprobs"], ["batch", "position"]),
+        sampling_temperature=hax.named(sequence_tensors["sampling_temperature"], ["batch"]),
+        sampling_top_k=hax.named(sequence_tensors["sampling_top_k"], ["batch"]),
+        truncated=sequence_tensors["truncated"],
+        max_output_tokens=max_tokens,
+    )
+    batch_info = BatchInfo(
+        group_id=tuple(example["group_id"] for example in info_examples),
+        lesson_id=tuple(example["lesson_id"] for example in info_examples),
+        env_name=tuple(example["env_name"] for example in info_examples),
+        env_example_id=tuple(example["env_example_id"] for example in info_examples),
+        task_name=tuple(example["task_name"] for example in info_examples),
+        task_version=tuple(example["task_version"] for example in info_examples),
+        verifier_name=tuple(example["verifier_name"] for example in info_examples),
+        verifier_version=tuple(example["verifier_version"] for example in info_examples),
+        worker_id=tuple(example["worker_id"] for example in info_examples),
+        run_id=tuple(example["run_id"] for example in info_examples),
+        trace_id=tuple(example["trace_id"] for example in info_examples),
+        trace_ref=tuple(example["trace_ref"] for example in info_examples),
+        prompt_length=hax.named(info_tensors["prompt_length"], ["batch"]),
+        response_length=hax.named(info_tensors["response_length"], ["batch"]),
+        episode_reward=hax.named(info_tensors["episode_reward"], ["batch"]),
+        token_rewards=hax.named(info_tensors["token_rewards"], ["batch", "position"]),
+        correctness_reward=hax.named(info_tensors["correctness_reward"], ["batch"]),
+        weight_step=hax.named(info_tensors["weight_step"], ["batch"]),
+        train_step=hax.named(info_tensors["train_step"], ["batch"]),
+        timestamp=tuple(example["timestamp"] for example in info_examples),
+    )
+    return sequence_batch, batch_info
+
+
+def create_sequence_batch_from_rollouts(
+    rollouts: list[Rollout],
+    max_tokens: int,
+    pad_token_id: int,
+    pad_to_multiple: int | None = None,
+) -> tuple[SequenceBatch, BatchInfo]:
+    """Create a neutral batch directly from rollout objects."""
+    trajectories = [rollout_to_trajectory_record(rollout) for rollout in rollouts]
+    return create_sequence_batch_from_trajectories(
+        trajectories,
+        max_tokens=max_tokens,
+        pad_token_id=pad_token_id,
+        pad_to_multiple=pad_to_multiple,
+    )
 
 
 def create_training_batch_from_rollouts(
@@ -96,73 +344,27 @@ def create_training_batch_from_rollouts(
     pad_token_id: int,
     pad_to_multiple: int | None = None,
 ) -> TrainingBatch:
-    """Create a training batch from a list of individual rollouts.
-
-    Args:
-        individual_rollouts: List of RolloutWithAdvantage objects with precomputed advantages
-        max_tokens: Maximum sequence length for truncation
-        pad_token_id: Token ID to use for padding
-        pad_to_multiple: Optional multiple to pad sequence length to for FlashAttention
-
-    Returns:
-        TrainingBatch ready for training
-    """
+    """Create the legacy TrainingBatch from the neutral sequence batch path."""
     if not individual_rollouts:
         raise ValueError("Cannot create batch from empty rollout list")
 
-    max_seq_len = max_tokens
-    batch_max_len = max(
-        min(len(individual.rollout.prompt_tokens) + len(individual.rollout.response_tokens), max_seq_len)
-        for individual in individual_rollouts
+    sequence_batch, _ = create_sequence_batch_from_rollouts(
+        [individual.rollout for individual in individual_rollouts],
+        max_tokens=max_tokens,
+        pad_token_id=pad_token_id,
+        pad_to_multiple=pad_to_multiple,
     )
-    pad_to = batch_max_len
-    if pad_to_multiple is not None and pad_to_multiple > 0:
-        pad_to = ((batch_max_len + pad_to_multiple - 1) // pad_to_multiple) * pad_to_multiple
-        if pad_to > max_seq_len:
-            raise ValueError(
-                "Rounded batch padding length exceeds max_tokens. "
-                f"batch_max_len={batch_max_len}, pad_to_multiple={pad_to_multiple}, max_tokens={max_seq_len}. "
-                "Increase max_seq_len or reduce flash_attention_block_size."
-            )
+    advantages = jnp.asarray([individual.advantage for individual in individual_rollouts], dtype=np.float32)
+    loss_weights = sequence_batch.response_mask.array * advantages[:, None]
 
-    training_examples = []
-    for individual in individual_rollouts:
-        training_example = convert_rollout_to_training_format(
-            individual.rollout,
-            individual.advantage,
-            max_tokens,
-            pad_to,
-            pad_token_id,
-        )
-        training_examples.append(training_example)
-
-    # Stack the examples into a single batch with proper 2D arrays
-    stacked = {}
-    for key in training_examples[0].keys():
-        if isinstance(training_examples[0][key], float):
-            stacked[key] = jnp.array([ex[key] for ex in training_examples], dtype=np.float32)
-        else:
-            stacked[key] = jnp.stack([ex[key] for ex in training_examples], axis=0)
-
-    # Ensure each row has at least one non-zero loss mask (otherwise division by zero -> NaN)
-    per_row_mask_sum = stacked["loss_masks"].sum(axis=1)
-    zero_mask_rows = int((per_row_mask_sum == 0).sum())
-    assert zero_mask_rows == 0, (
-        f"Found {zero_mask_rows} rollouts with all-zero loss masks. "
-        "This happens when prompt_tokens >= max_seq_len, leaving no room for response tokens. "
-        "Increase max_seq_len in CurriculumConfig."
+    return TrainingBatch(
+        input_ids=sequence_batch.input_ids,
+        position_ids=sequence_batch.position_ids,
+        loss_weights=hax.named(loss_weights, ["batch", "position"]),
+        loss_masks=sequence_batch.response_mask,
+        policy_logprobs=sequence_batch.behavior_logprobs,
+        temperature=sequence_batch.sampling_temperature,
+        top_k=sequence_batch.sampling_top_k,
+        truncated=sequence_batch.truncated,
+        max_output_tokens=sequence_batch.max_output_tokens,
     )
-
-    batch = TrainingBatch(
-        input_ids=hax.named(stacked["input_ids"], ["batch", "position"]),
-        position_ids=hax.named(stacked["position_ids"], ["batch", "position"]),
-        loss_weights=hax.named(stacked["loss_weights"], ["batch", "position"]),
-        loss_masks=hax.named(stacked["loss_masks"], ["batch", "position"]),
-        policy_logprobs=hax.named(stacked["policy_logprobs"], ["batch", "position"]),
-        temperature=hax.named(stacked["temperature"], ["batch"]),
-        top_k=hax.named(stacked["top_k"], ["batch"]),
-        truncated=stacked["truncated"],
-        max_output_tokens=max_tokens,
-    )
-
-    return batch

--- a/lib/marin/src/marin/rl/train_batch.py
+++ b/lib/marin/src/marin/rl/train_batch.py
@@ -15,6 +15,7 @@ from typing import Any
 import haliax as hax
 import jax.numpy as jnp
 import numpy as np
+from marin.rl.decoding import DecodingConfig
 
 from .types import (
     BatchInfo,
@@ -63,6 +64,7 @@ def rollout_to_trajectory_record(rollout: Rollout) -> TrajectoryRecord:
 
 def trajectory_record_to_rollout(trajectory: TrajectoryRecord) -> Rollout:
     """Reconstruct a rollout from the neutral trajectory record."""
+    sampling_top_k = None if trajectory.sampling_top_k == TOP_K_NONE_SENTINEL else trajectory.sampling_top_k
     return Rollout(
         env_name=trajectory.env_name,
         env_example_id=trajectory.env_example_id,
@@ -71,8 +73,11 @@ def trajectory_record_to_rollout(trajectory: TrajectoryRecord) -> Rollout:
         response_logprobs=trajectory.behavior_logprobs,
         token_rewards=trajectory.token_rewards,
         episode_reward=trajectory.episode_reward,
-        temperature=trajectory.sampling_temperature,
-        top_k=trajectory.sampling_top_k,
+        decoding=DecodingConfig(
+            temperature=trajectory.sampling_temperature,
+            top_k=sampling_top_k,
+            max_output_tokens=max(1, len(trajectory.response_tokens)),
+        ).as_trace(),
         is_truncated=trajectory.is_truncated,
         metadata=trajectory.rollout_metadata,
         correctness_reward=trajectory.correctness_reward,

--- a/lib/marin/src/marin/rl/train_worker.py
+++ b/lib/marin/src/marin/rl/train_worker.py
@@ -38,14 +38,13 @@ from levanter.trainer import Trainer, TrainerConfig
 from marin.rl import weight_transfer
 from marin.rl.curriculum import CurriculumConfig
 from marin.rl.model_utils import load_model_from_checkpoint
+from marin.rl.objectives import ObjectiveRuntime, ObjectiveRuntimeConfig, ObjectiveSpec, build_objective_runtime
 from marin.rl.runtime import RLRuntimeHandles
 from marin.rl.weight_transfer import WeightTransferConfig
 
 from .replay_buffer import ReplayBuffer, ReplayBufferConfig, ReplayDataLoader, StoredTrajectory
-from .rl_losses import RLLossModule
 from .rollout_storage import RolloutStorageConfig
-from .train_batch import create_training_batch_from_rollouts, trajectory_record_to_rollout
-from .types import RolloutWithAdvantage, TrajectoryRecord
+from .train_batch import create_sequence_batch_from_trajectories
 
 logger = logging.getLogger(__name__)
 
@@ -133,41 +132,6 @@ def _training_step_timing_metrics(step_duration: float, batch_prep_timing: Batch
     }
 
 
-def _trajectory_key(trajectory: TrajectoryRecord) -> tuple[str, str, str]:
-    return (trajectory.group_id, trajectory.env_example_id, trajectory.trace_id)
-
-
-def build_rollouts_with_advantages(
-    sampled_trajectories: list[StoredTrajectory],
-    loss_module: RLLossModule,
-) -> list[RolloutWithAdvantage]:
-    """Build the current trainer-compatible rollout view from neutral replay samples."""
-    advantages_by_key: dict[tuple[str, str, str], float] = {}
-    grouped_records: dict[str, list[TrajectoryRecord]] = {}
-    for stored_trajectory in sampled_trajectories:
-        group_id = stored_trajectory.group_id
-        if group_id in grouped_records:
-            continue
-        grouped_records[group_id] = list(stored_trajectory.group.trajectories)
-
-    for group_trajectories in grouped_records.values():
-        group_rollouts = [trajectory_record_to_rollout(trajectory) for trajectory in group_trajectories]
-        advantages = loss_module.compute_advantages(group_rollouts)
-        for trajectory, advantage in zip(group_trajectories, advantages, strict=True):
-            advantages_by_key[_trajectory_key(trajectory)] = float(advantage)
-
-    rollouts = []
-    for stored_trajectory in sampled_trajectories:
-        trajectory = stored_trajectory.trajectory
-        rollouts.append(
-            RolloutWithAdvantage(
-                rollout=trajectory_record_to_rollout(trajectory),
-                advantage=advantages_by_key[_trajectory_key(trajectory)],
-            )
-        )
-    return rollouts
-
-
 @dataclass
 class TrainWorkerConfig:
     """Configuration for Levanter-based RL training worker."""
@@ -179,7 +143,8 @@ class TrainWorkerConfig:
     replay_buffer: ReplayBufferConfig
     weight_transfer: WeightTransferConfig
     curriculum_config: CurriculumConfig
-    loss: RLLossModule
+    objective: ObjectiveSpec
+    scorer_vocab_tile_size: int | None
     tokenizer: MarinTokenizer
     run_id: str
 
@@ -208,6 +173,7 @@ class StreamingRolloutLoader:
         self,
         data_loader: ReplayDataLoader,
         config: TrainWorkerConfig,
+        objective_runtime: ObjectiveRuntime,
     ):
         """Initialize the streaming rollout loader.
 
@@ -217,6 +183,7 @@ class StreamingRolloutLoader:
         """
         self.data_loader = data_loader
         self.config = config
+        self.objective_runtime = objective_runtime
         self.timeout = 60.0
 
         # Get max_seq_len from curriculum (total sequence length for prompt + response)
@@ -236,7 +203,6 @@ class StreamingRolloutLoader:
 
         # Track batch preparation timing for RL throughput diagnostics.
         self._last_batch_prep_timing = BatchPrepTiming()
-        self._last_rollouts: list[RolloutWithAdvantage] | None = None
         self._last_trajectories: list[StoredTrajectory] | None = None
 
     def __iter__(self):
@@ -262,14 +228,16 @@ class StreamingRolloutLoader:
                 continue
 
             cumulative_wait = 0.0
-            rollouts = build_rollouts_with_advantages(trajectories, self.config.loss)
-            self._last_rollouts = rollouts
 
             # Measure batch creation time
             batch_start = time.time()
-            batch = create_training_batch_from_rollouts(
-                rollouts, self.max_tokens, self.pad_token_id, self.pad_to_multiple
+            sequence_batch, batch_info = create_sequence_batch_from_trajectories(
+                [trajectory.trajectory for trajectory in trajectories],
+                self.max_tokens,
+                self.pad_token_id,
+                self.pad_to_multiple,
             )
+            batch = self.objective_runtime.prepare_batch(sequence_batch, batch_info)
             batch_time = time.time() - batch_start
 
             # Measure sharding time
@@ -281,7 +249,7 @@ class StreamingRolloutLoader:
             timing = BatchPrepTiming(fetch_time=fetch_time, batch_time=batch_time, shard_time=shard_time)
             self._last_batch_prep_timing = timing
             logger.info(
-                "Batch prep: fetch=%.3fs, create=%.3fs, shard=%.3fs, total=%.3fs, rollouts=%d",
+                "Batch prep: fetch=%.3fs, create=%.3fs, shard=%.3fs, total=%.3fs, trajectories=%d",
                 fetch_time,
                 batch_time,
                 shard_time,
@@ -306,7 +274,7 @@ class TrainWorker:
     replay_loader: ReplayDataLoader
     transfer_server: weight_transfer.WeightTransferServer
     tokenizer: MarinTokenizer
-    loss_module: RLLossModule
+    objective_runtime: ObjectiveRuntime
     initial_model: LmHeadModel | None
     reference_model: LmHeadModel | None
 
@@ -332,7 +300,18 @@ class TrainWorker:
         self._runtime = runtime
         self._should_stop = False
         self.tokenizer = config.tokenizer
-        self.loss_module = config.loss
+        self.objective_runtime = build_objective_runtime(
+            ObjectiveRuntimeConfig(
+                objective=config.objective,
+                vocab_tile_size=config.scorer_vocab_tile_size,
+            )
+        )
+        logger.info(
+            "Using objective runtime backend=%s requirements=%s scorer_vocab_tile_size=%s",
+            self.objective_runtime.score_source.backend_name,
+            self.objective_runtime.score_requirements,
+            config.scorer_vocab_tile_size,
+        )
 
         self.rollout_reader = config.rollout_storage.create_reader()
 
@@ -352,6 +331,7 @@ class TrainWorker:
         self.data_loader = StreamingRolloutLoader(
             self.replay_loader,
             config,
+            self.objective_runtime,
         )
 
         self.transfer_server = weight_transfer.create_weight_transfer_server(
@@ -404,8 +384,12 @@ class TrainWorker:
     def _drop_bootstrap_model_references(self) -> None:
         """Release one-shot bootstrap model references once trainer state exists."""
         self.initial_model = None
-        if not self.loss_module.needs_reference_model():
+        if not self._needs_reference_model():
             self.reference_model = None
+
+    def _needs_reference_model(self) -> bool:
+        """Return whether the active objective runtime needs a fixed reference model."""
+        return self.objective_runtime.score_requirements.reference_logprobs
 
     def _seed_initial_rollout_state(self, rollout_state: InitialRolloutState) -> None:
         """Seed replay/run state before replay ingestion starts."""
@@ -476,7 +460,7 @@ class TrainWorker:
         debug_weight_transfer = self.config.weight_transfer.debug_weight_transfer
         if (debug_checkpointer or debug_weight_transfer) and hasattr(signal, "SIGUSR2"):
             faulthandler.register(signal.SIGUSR2, file=sys.stderr, all_threads=True)
-        logger.info("Starting RLOO training with Levanter...")
+        logger.info("Starting objective-driven RL training with Levanter...")
 
         checkpoint_debug_provider_name = f"{self.config.run_id}-checkpoint-debug"
         if debug_checkpointer:
@@ -488,7 +472,7 @@ class TrainWorker:
         try:
             config = self.config
             optimizer = config.optimizer.build(config.trainer.num_train_steps)
-            loss_fn = self.loss_module.create_loss_fn(self.reference_model, None)
+            loss_fn = self.objective_runtime.create_loss_fn(reference_model=self.reference_model)
 
             @jax.jit
             def _loss_function(model, batch, key):
@@ -585,9 +569,9 @@ class TrainWorker:
         trainer.add_hook(_log_step_timing, every=1)
 
         def _log_samples_hook(info: levanter.callbacks.StepInfo):
-            rollouts = self.data_loader._last_rollouts
-            if rollouts is not None:
-                self._log_samples(trainer, info.step, rollouts)
+            trajectories = self.data_loader._last_trajectories
+            if trajectories is not None:
+                self._log_samples(trainer, info.step, trajectories)
 
         trainer.add_hook(_log_samples_hook, every=1)
 
@@ -653,16 +637,16 @@ class TrainWorker:
         trainer.tracker.log(metrics, step=step)
         logger.info("Successfully transferred weights with ID %d (transfer_time=%.2fs)", step, transfer_time)
 
-    def _log_samples(self, trainer, step, rollouts):
+    def _log_samples(self, trainer, step, trajectories: list[StoredTrajectory]):
         """Log trainer samples for the first 5 prompts to wandb table."""
         # group by prompt
         prompts = {}
-        for r_adv in rollouts:
-            r = r_adv.rollout
-            pid = r.env_example_id
+        for stored_trajectory in trajectories:
+            trajectory = stored_trajectory.trajectory
+            pid = trajectory.env_example_id
             if pid not in prompts:
                 prompts[pid] = []
-            prompts[pid].append(r)
+            prompts[pid].append(trajectory)
 
         # take first 5 prompts
         first_5_pids = list(prompts.keys())[:5]
@@ -670,11 +654,11 @@ class TrainWorker:
         columns = ["step", "prompt_id", "prompt", "response", "reward"]
         data = []
         for pid in first_5_pids:
-            prompt_rs = prompts[pid]
-            prompt_text = self.tokenizer.decode(prompt_rs[0].prompt_tokens, skip_special_tokens=False)
-            for r in prompt_rs:
-                response_text = self.tokenizer.decode(r.response_tokens, skip_special_tokens=False)
-                data.append([step, pid, prompt_text, response_text, float(r.episode_reward)])
+            prompt_trajectories = prompts[pid]
+            prompt_text = self.tokenizer.decode(prompt_trajectories[0].prompt_tokens, skip_special_tokens=False)
+            for trajectory in prompt_trajectories:
+                response_text = self.tokenizer.decode(trajectory.response_tokens, skip_special_tokens=False)
+                data.append([step, pid, prompt_text, response_text, float(trajectory.episode_reward)])
 
         table = wandb.Table(columns=columns, data=data)
         trainer.tracker.log({"train/samples": table}, step=step)

--- a/lib/marin/src/marin/rl/train_worker.py
+++ b/lib/marin/src/marin/rl/train_worker.py
@@ -41,10 +41,11 @@ from marin.rl.model_utils import load_model_from_checkpoint
 from marin.rl.runtime import RLRuntimeHandles
 from marin.rl.weight_transfer import WeightTransferConfig
 
-from .replay_buffer import ReplayBuffer, ReplayBufferConfig, ReplayDataLoader, RolloutWithCount
+from .replay_buffer import ReplayBuffer, ReplayBufferConfig, ReplayDataLoader, StoredTrajectory
 from .rl_losses import RLLossModule
 from .rollout_storage import RolloutStorageConfig
-from .train_batch import create_training_batch_from_rollouts
+from .train_batch import create_training_batch_from_rollouts, trajectory_record_to_rollout
+from .types import RolloutWithAdvantage, TrajectoryRecord
 
 logger = logging.getLogger(__name__)
 
@@ -132,6 +133,41 @@ def _training_step_timing_metrics(step_duration: float, batch_prep_timing: Batch
     }
 
 
+def _trajectory_key(trajectory: TrajectoryRecord) -> tuple[str, str, str]:
+    return (trajectory.group_id, trajectory.env_example_id, trajectory.trace_id)
+
+
+def build_rollouts_with_advantages(
+    sampled_trajectories: list[StoredTrajectory],
+    loss_module: RLLossModule,
+) -> list[RolloutWithAdvantage]:
+    """Build the current trainer-compatible rollout view from neutral replay samples."""
+    advantages_by_key: dict[tuple[str, str, str], float] = {}
+    grouped_records: dict[str, list[TrajectoryRecord]] = {}
+    for stored_trajectory in sampled_trajectories:
+        group_id = stored_trajectory.group_id
+        if group_id in grouped_records:
+            continue
+        grouped_records[group_id] = list(stored_trajectory.group.trajectories)
+
+    for group_trajectories in grouped_records.values():
+        group_rollouts = [trajectory_record_to_rollout(trajectory) for trajectory in group_trajectories]
+        advantages = loss_module.compute_advantages(group_rollouts)
+        for trajectory, advantage in zip(group_trajectories, advantages, strict=True):
+            advantages_by_key[_trajectory_key(trajectory)] = float(advantage)
+
+    rollouts = []
+    for stored_trajectory in sampled_trajectories:
+        trajectory = stored_trajectory.trajectory
+        rollouts.append(
+            RolloutWithAdvantage(
+                rollout=trajectory_record_to_rollout(trajectory),
+                advantage=advantages_by_key[_trajectory_key(trajectory)],
+            )
+        )
+    return rollouts
+
+
 @dataclass
 class TrainWorkerConfig:
     """Configuration for Levanter-based RL training worker."""
@@ -200,7 +236,8 @@ class StreamingRolloutLoader:
 
         # Track batch preparation timing for RL throughput diagnostics.
         self._last_batch_prep_timing = BatchPrepTiming()
-        self._last_rollouts: list[RolloutWithCount] | None = None
+        self._last_rollouts: list[RolloutWithAdvantage] | None = None
+        self._last_trajectories: list[StoredTrajectory] | None = None
 
     def __iter__(self):
         """Yield batches continuously from the replay buffer."""
@@ -209,12 +246,12 @@ class StreamingRolloutLoader:
 
         while True:
             fetch_start = time.time()
-            rollouts = self.data_loader.get_rollouts(timeout=self.timeout)
+            trajectories = self.data_loader.get_trajectories(timeout=self.timeout)
             fetch_time = time.time() - fetch_start
 
-            self._last_rollouts = rollouts
+            self._last_trajectories = trajectories
 
-            if not rollouts:
+            if not trajectories:
                 cumulative_wait += fetch_time
                 if cumulative_wait >= max_cumulative_wait:
                     raise TimeoutError(f"No rollouts received after {cumulative_wait:.0f}s total wait")
@@ -225,6 +262,8 @@ class StreamingRolloutLoader:
                 continue
 
             cumulative_wait = 0.0
+            rollouts = build_rollouts_with_advantages(trajectories, self.config.loss)
+            self._last_rollouts = rollouts
 
             # Measure batch creation time
             batch_start = time.time()
@@ -247,7 +286,7 @@ class StreamingRolloutLoader:
                 batch_time,
                 shard_time,
                 timing.total_time,
-                len(rollouts),
+                len(trajectories),
             )
 
             yield sharded_batch
@@ -301,7 +340,6 @@ class TrainWorker:
             config=config.replay_buffer,
             local_batch_size=config.trainer.train_batch_size,
             total_processes=jax.process_count(),
-            loss_module=self.loss_module,
             seed=config.seed,
         )
 

--- a/lib/marin/src/marin/rl/train_worker.py
+++ b/lib/marin/src/marin/rl/train_worker.py
@@ -42,9 +42,10 @@ from marin.rl.objectives import ObjectiveRuntime, ObjectiveRuntimeConfig, Object
 from marin.rl.runtime import RLRuntimeHandles
 from marin.rl.weight_transfer import WeightTransferConfig
 
-from .replay_buffer import ReplayBuffer, ReplayBufferConfig, ReplayDataLoader, StoredTrajectory
+from .replay_buffer import ReplayBuffer, ReplayBufferConfig, ReplayDataLoader
 from .rollout_storage import RolloutStorageConfig
 from .train_batch import create_sequence_batch_from_trajectories
+from .types import TrajectoryRecord
 
 logger = logging.getLogger(__name__)
 
@@ -203,7 +204,7 @@ class StreamingRolloutLoader:
 
         # Track batch preparation timing for RL throughput diagnostics.
         self._last_batch_prep_timing = BatchPrepTiming()
-        self._last_trajectories: list[StoredTrajectory] | None = None
+        self._last_trajectories: list[TrajectoryRecord] | None = None
 
     def __iter__(self):
         """Yield batches continuously from the replay buffer."""
@@ -212,27 +213,28 @@ class StreamingRolloutLoader:
 
         while True:
             fetch_start = time.time()
-            trajectories = self.data_loader.get_trajectories(timeout=self.timeout)
+            groups = self.data_loader.get_groups(timeout=self.timeout)
             fetch_time = time.time() - fetch_start
 
-            self._last_trajectories = trajectories
-
-            if not trajectories:
+            if not groups:
                 cumulative_wait += fetch_time
                 if cumulative_wait >= max_cumulative_wait:
                     raise TimeoutError(f"No rollouts received after {cumulative_wait:.0f}s total wait")
                 logger.warning(
-                    "No rollouts received from data loader within timeout (cumulative_wait=%.0fs), retrying...",
+                    "No full rollout groups received from data loader within timeout "
+                    "(cumulative_wait=%.0fs), retrying...",
                     cumulative_wait,
                 )
                 continue
 
             cumulative_wait = 0.0
+            trajectories = [trajectory for group in groups for trajectory in group.trajectories]
+            self._last_trajectories = trajectories
 
             # Measure batch creation time
             batch_start = time.time()
             sequence_batch, batch_info = create_sequence_batch_from_trajectories(
-                [trajectory.trajectory for trajectory in trajectories],
+                trajectories,
                 self.max_tokens,
                 self.pad_token_id,
                 self.pad_to_multiple,
@@ -249,11 +251,12 @@ class StreamingRolloutLoader:
             timing = BatchPrepTiming(fetch_time=fetch_time, batch_time=batch_time, shard_time=shard_time)
             self._last_batch_prep_timing = timing
             logger.info(
-                "Batch prep: fetch=%.3fs, create=%.3fs, shard=%.3fs, total=%.3fs, trajectories=%d",
+                "Batch prep: fetch=%.3fs, create=%.3fs, shard=%.3fs, total=%.3fs, groups=%d, trajectories=%d",
                 fetch_time,
                 batch_time,
                 shard_time,
                 timing.total_time,
+                len(groups),
                 len(trajectories),
             )
 
@@ -637,12 +640,11 @@ class TrainWorker:
         trainer.tracker.log(metrics, step=step)
         logger.info("Successfully transferred weights with ID %d (transfer_time=%.2fs)", step, transfer_time)
 
-    def _log_samples(self, trainer, step, trajectories: list[StoredTrajectory]):
+    def _log_samples(self, trainer, step, trajectories: list[TrajectoryRecord]):
         """Log trainer samples for the first 5 prompts to wandb table."""
         # group by prompt
         prompts = {}
-        for stored_trajectory in trajectories:
-            trajectory = stored_trajectory.trajectory
+        for trajectory in trajectories:
             pid = trajectory.env_example_id
             if pid not in prompts:
                 prompts[pid] = []

--- a/lib/marin/src/marin/rl/types.py
+++ b/lib/marin/src/marin/rl/types.py
@@ -4,9 +4,11 @@
 """
 Type definitions for RL/post-training.
 
-This module contains training-focused type definitions:
-- Rollout types (Rollout, RolloutGroup, RolloutBatch, etc.)
-- Training types (TrainingBatch, RolloutWithAdvantage)
+This module contains the shared RL data plane:
+- rollout types (Rollout, RolloutGroup, RolloutBatch)
+- neutral trajectory and batch types (TrajectoryRecord, SequenceBatch, BatchInfo)
+- compatibility types still used by the current trainer path
+  (TrainingBatch, RolloutWithAdvantage)
 
 For inference-related types, see marin.rl.inference_ctx
 """
@@ -137,16 +139,105 @@ class RolloutBatch(eqx.Module):
     metadata: RolloutMetadata
 
 
+@dataclass(frozen=True)
+class TrajectoryRecord:
+    """Objective-neutral per-response training record."""
+
+    trace_id: str
+    env_name: str
+    task_name: str
+    task_version: str
+    lesson_id: str
+    env_example_id: str
+    group_id: str
+    verifier_name: str | None
+    verifier_version: str | None
+    prompt_tokens: np.ndarray
+    response_tokens: np.ndarray
+    behavior_logprobs: np.ndarray
+    token_rewards: np.ndarray
+    episode_reward: float
+    correctness_reward: float | None
+    is_truncated: bool
+    sampling_temperature: float
+    sampling_top_k: int | None
+    rollout_metadata: RolloutMetadata
+    trace_ref: str | None = None
+
+
+@dataclass(frozen=True)
+class TrajectoryGroupRecord:
+    """Prompt-level grouped trajectory record."""
+
+    group_id: str
+    lesson_id: str
+    trace_id: str
+    task_name: str
+    task_version: str
+    verifier_name: str | None
+    verifier_version: str | None
+    prompt_tokens: np.ndarray
+    trajectories: tuple[TrajectoryRecord, ...]
+    trace_ref: str | None = None
+
+
+@dataclass(frozen=True)
+class BatchInfo:
+    """Sidecar metadata carried alongside a SequenceBatch."""
+
+    group_id: tuple[str, ...]
+    lesson_id: tuple[str, ...]
+    env_name: tuple[str, ...]
+    env_example_id: tuple[str, ...]
+    task_name: tuple[str, ...]
+    task_version: tuple[str, ...]
+    verifier_name: tuple[str | None, ...]
+    verifier_version: tuple[str | None, ...]
+    worker_id: tuple[str, ...]
+    run_id: tuple[str, ...]
+    trace_id: tuple[str, ...]
+    trace_ref: tuple[str | None, ...]
+    prompt_length: ht.Int[NamedArray, "batch"]  # noqa: F821
+    response_length: ht.Int[NamedArray, "batch"]  # noqa: F821
+    episode_reward: ht.Float[NamedArray, "batch"]  # noqa: F821
+    token_rewards: ht.Float[NamedArray, "batch position"]
+    correctness_reward: ht.Float[NamedArray, "batch"]  # noqa: F821
+    weight_step: ht.Int[NamedArray, "batch"]  # noqa: F821
+    train_step: ht.Int[NamedArray, "batch"]  # noqa: F821
+    timestamp: tuple[float, ...]
+    """Wall-clock timestamps in seconds, kept host-side to avoid float32 quantization."""
+
+    def __len__(self) -> int:
+        return self.prompt_length.axis_size("batch")
+
+
+class SequenceBatch(eqx.Module):
+    """Objective-neutral batch with only scoring-time tensors."""
+
+    input_ids: ht.Int[NamedArray, "batch position"]
+    position_ids: ht.Int[NamedArray, "batch position"]
+    prompt_mask: ht.Float[NamedArray, "batch position"]
+    response_mask: ht.Float[NamedArray, "batch position"]
+    behavior_logprobs: ht.Float[NamedArray, "batch position"]
+    sampling_temperature: ht.Float[NamedArray, "batch"]  # noqa: F821
+    sampling_top_k: ht.Int[NamedArray, "batch"]  # noqa: F821
+    truncated: jax.Array  # [batch]
+    max_output_tokens: int
+
+    def __len__(self) -> int:
+        return self.input_ids.axis_size("batch")
+
+
 @dataclass
 class RolloutWithAdvantage:
-    """A rollout paired with its computed advantage."""
+    """Compatibility wrapper for the current trainer path."""
 
     rollout: Rollout
     advantage: float
 
 
 class TrainingBatch(eqx.Module):
-    """A batch ready for training with Haliax named arrays."""
+    """Compatibility batch still consumed by the current loss implementation."""
 
     input_ids: ht.Int[NamedArray, "batch position"]
     position_ids: ht.Int[NamedArray, "batch position"]

--- a/lib/marin/src/marin/rl/types.py
+++ b/lib/marin/src/marin/rl/types.py
@@ -44,6 +44,47 @@ class RolloutMetadata:
     weight_step: int = -1
     """The step at which the model weights were used to generate this rollout."""
 
+    run_id: str = ""
+    """Stable run identifier for the rollout job."""
+
+    lesson_id: str = ""
+    """Lesson identifier associated with this rollout."""
+
+    group_id: str = ""
+    """Stable identifier for the rollout group that owns this rollout."""
+
+    trace_id: str = ""
+    """Stable identifier for the prompt-level trace that owns this rollout."""
+
+    task_name: str = ""
+    """Stable task identifier for this rollout."""
+
+    task_version: str = ""
+    """Version for the task contract used to generate this rollout."""
+
+    verifier_name: str | None = None
+    """Verifier name associated with this rollout, if any."""
+
+    verifier_version: str | None = None
+    """Verifier version associated with this rollout, if any."""
+
+    trace_ref: str | None = None
+    """Optional sidecar reference to richer cold-path trace data."""
+
+
+@dataclass(frozen=True)
+class RolloutGroupMetadata:
+    """Prompt-level metadata shared across all rollouts in a group."""
+
+    group_id: str = ""
+    lesson_id: str = ""
+    trace_id: str = ""
+    task_name: str = ""
+    task_version: str = ""
+    verifier_name: str | None = None
+    verifier_version: str | None = None
+    trace_ref: str | None = None
+
 
 class Rollout(eqx.Module):
     """A single rollout: one prompt + one generated response + rewards."""
@@ -86,6 +127,7 @@ class RolloutGroup(eqx.Module):
     """Multiple rollouts for the same prompt (e.g., n_generations samples)."""
 
     rollouts: list[Rollout]
+    metadata: RolloutGroupMetadata = RolloutGroupMetadata()
 
 
 class RolloutBatch(eqx.Module):

--- a/lib/marin/src/marin/rl/types.py
+++ b/lib/marin/src/marin/rl/types.py
@@ -7,7 +7,7 @@ Type definitions for RL/post-training.
 This module contains the shared RL data plane:
 - rollout types (Rollout, RolloutGroup, RolloutBatch)
 - neutral trajectory and batch types (TrajectoryRecord, SequenceBatch, BatchInfo)
-- compatibility types still used by the current trainer path
+- legacy compatibility types retained for parity checks and helper adapters
   (TrainingBatch, RolloutWithAdvantage)
 
 For inference-related types, see marin.rl.inference_ctx
@@ -230,14 +230,14 @@ class SequenceBatch(eqx.Module):
 
 @dataclass
 class RolloutWithAdvantage:
-    """Compatibility wrapper for the current trainer path."""
+    """Legacy compatibility wrapper retained for parity checks."""
 
     rollout: Rollout
     advantage: float
 
 
 class TrainingBatch(eqx.Module):
-    """Compatibility batch still consumed by the current loss implementation."""
+    """Legacy compatibility batch retained for the old loss implementation."""
 
     input_ids: ht.Int[NamedArray, "batch position"]
     position_ids: ht.Int[NamedArray, "batch position"]

--- a/lib/marin/src/marin/rl/verification.py
+++ b/lib/marin/src/marin/rl/verification.py
@@ -1,0 +1,57 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verifier contracts for RL/post-training environments."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Protocol
+
+import numpy as np
+
+from marin.rl.traces import EpisodeTrace
+
+
+@dataclass(frozen=True)
+class VerifierResult:
+    """Structured verifier output for one trace."""
+
+    reward: float
+    token_rewards: np.ndarray | None = None
+    correctness_reward: float | None = None
+    passed: bool | None = None
+    metrics: dict[str, float] = field(default_factory=dict)
+
+
+class VerifierSpec(Protocol):
+    """Protocol for reusable verifier implementations."""
+
+    @property
+    def name(self) -> str:
+        """Stable verifier identifier."""
+        ...
+
+    @property
+    def version(self) -> str:
+        """Stable verifier version."""
+        ...
+
+    def verify(self, trace: EpisodeTrace) -> VerifierResult:
+        """Verify a prompt-level episode trace."""
+        ...
+
+
+@dataclass(frozen=True)
+class VerifierMetadata:
+    """Stable verifier identity for provenance."""
+
+    name: str
+    version: str = "v1"
+
+
+def verifier_metrics(result: VerifierResult) -> Mapping[str, float]:
+    """Return verifier metrics for logging or sidecar storage."""
+
+    return result.metrics

--- a/lib/marin/src/marin/rl/verification.py
+++ b/lib/marin/src/marin/rl/verification.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass, field
 from typing import Protocol
 
 import numpy as np
-
 from marin.rl.traces import EpisodeTrace
 
 

--- a/tests/rl/environments/test_load_environment.py
+++ b/tests/rl/environments/test_load_environment.py
@@ -18,6 +18,7 @@ def test_load_mock_environment():
     assert env.task_type == "cats"
     assert len(env.train_examples) > 0
     assert len(env.eval_examples) > 0
+    assert env.environment_identity().task_name == "mock_env:cats"
 
 
 def test_load_math_environment():
@@ -36,3 +37,4 @@ def test_load_math_environment():
     assert isinstance(env, MathEnv)
     assert len(env.train_examples) > 0
     assert len(env.eval_examples) > 0
+    assert env.environment_identity().task_name == "math"

--- a/tests/rl/environments/test_load_environment.py
+++ b/tests/rl/environments/test_load_environment.py
@@ -18,7 +18,6 @@ def test_load_mock_environment():
     assert env.task_type == "cats"
     assert len(env.train_examples) > 0
     assert len(env.eval_examples) > 0
-    assert env.environment_identity().task_name == "mock_env:cats"
 
 
 def test_load_math_environment():
@@ -37,4 +36,3 @@ def test_load_math_environment():
     assert isinstance(env, MathEnv)
     assert len(env.train_examples) > 0
     assert len(env.eval_examples) > 0
-    assert env.environment_identity().task_name == "math"

--- a/tests/rl/environments/test_math_env.py
+++ b/tests/rl/environments/test_math_env.py
@@ -71,7 +71,7 @@ def test_math_env_reward_calculation(gpt2_tokenizer):
     env = MathEnv(train_dataset=train_data, eval_dataset=[], max_train_examples=1)
 
     prng_key = jax.random.PRNGKey(42)
-    rollout_groups, metrics = env.sample(
+    sample = env.sample(
         inference_ctx=inference_ctx,
         n_examples=1,
         n_generations=1,
@@ -79,6 +79,8 @@ def test_math_env_reward_calculation(gpt2_tokenizer):
         prng_key=prng_key,
         mode="train",
     )
+    rollout_groups = sample.rollout_groups
+    metrics = sample.metrics
 
     # Verify structure
     assert len(rollout_groups) == 1
@@ -100,3 +102,8 @@ def test_math_env_reward_calculation(gpt2_tokenizer):
     # With format_coef=0.1, format_valid=1.0, correct_answer=1.0: reward = 0.1 * 0 + 1.0 = 1.0
     np.testing.assert_allclose(rollout.token_rewards, 1.0), (rollout, metrics)
     assert rollout.episode_reward == pytest.approx(1.0), (rollout, metrics)
+
+    assert sample.identity.task_name == "math"
+    assert sample.identity.verifier_name == "math.tinker_grader"
+    assert len(sample.traces) == 1
+    assert sample.traces[0].env_example_id == rollout.env_example_id

--- a/tests/rl/environments/test_math_env.py
+++ b/tests/rl/environments/test_math_env.py
@@ -106,4 +106,14 @@ def test_math_env_reward_calculation(gpt2_tokenizer):
     assert sample.identity.task_name == "math"
     assert sample.identity.verifier_name == "math.tinker_grader"
     assert len(sample.traces) == 1
-    assert sample.traces[0].env_example_id == rollout.env_example_id
+    trace = sample.traces[0]
+    assert trace.env_name == rollout.env_name
+    assert trace.env_example_id == rollout.env_example_id
+    assert "What is 2+2?" in trace.prompt
+    assert trace.task_name == sample.identity.task_name
+    assert trace.verifier_name == sample.identity.verifier_name
+    assert len(trace.responses) == 1
+    assert trace.responses[0].response_text == "\\boxed{4}"
+    assert trace.responses[0].reward == pytest.approx(rollout.episode_reward)
+    assert trace.responses[0].correctness_reward == pytest.approx(1.0)
+    assert trace.responses[0].metadata["format_score"] == pytest.approx(1.0)

--- a/tests/rl/environments/test_prime_intellect_env.py
+++ b/tests/rl/environments/test_prime_intellect_env.py
@@ -84,7 +84,7 @@ def test_prime_intellect_env_sample(tokenizer, inference_ctx, vf_env):
     # Patch only external dependencies
     with patch.object(env, "load_prime_intellect_env", return_value=vf_env), patch("subprocess.run"):
         prng_key = jax.random.PRNGKey(0)
-        rollout_groups, metrics = env.sample(
+        sample = env.sample(
             inference_ctx=inference_ctx,
             n_examples=2,
             n_generations=2,
@@ -92,6 +92,8 @@ def test_prime_intellect_env_sample(tokenizer, inference_ctx, vf_env):
             prng_key=prng_key,
             mode="train",
         )
+    rollout_groups = sample.rollout_groups
+    metrics = sample.metrics
 
     # Verify rollout groups structure
     assert len(rollout_groups) == 2, "Should have 2 rollout groups (one per prompt)"
@@ -115,6 +117,9 @@ def test_prime_intellect_env_sample(tokenizer, inference_ctx, vf_env):
     # Verify metrics exist
     assert "primeintellect/gsm8k.mean_reward" in metrics
     assert "primeintellect/gsm8k.total_rollouts" in metrics
+    assert sample.identity.task_name == "prime_intellect:primeintellect/gsm8k"
+    assert sample.identity.verifier_name == "verifiers:primeintellect/gsm8k"
+    assert len(sample.traces) == 2
 
 
 def test_prime_intellect_env_openai_client_called(tokenizer, inference_ctx, vf_env):
@@ -123,7 +128,7 @@ def test_prime_intellect_env_openai_client_called(tokenizer, inference_ctx, vf_e
 
     with patch.object(env, "load_prime_intellect_env", return_value=vf_env), patch("subprocess.run"):
         prng_key = jax.random.PRNGKey(42)
-        rollout_groups, _ = env.sample(
+        sample = env.sample(
             inference_ctx=inference_ctx,
             n_examples=1,
             n_generations=1,
@@ -132,7 +137,7 @@ def test_prime_intellect_env_openai_client_called(tokenizer, inference_ctx, vf_e
         )
 
     # Verify we got rollout groups (which means generate() was called successfully)
-    assert len(rollout_groups) >= 0
+    assert len(sample.rollout_groups) >= 0
 
 
 def test_prime_intellect_env_records_resolved_decoding_trace(tokenizer, inference_ctx, vf_env):
@@ -158,13 +163,14 @@ def test_prime_intellect_env_tokenization(tokenizer, inference_ctx, vf_env):
 
     with patch.object(env, "load_prime_intellect_env", return_value=vf_env), patch("subprocess.run"):
         prng_key = jax.random.PRNGKey(123)
-        rollout_groups, _ = env.sample(
+        sample = env.sample(
             inference_ctx=inference_ctx,
             n_examples=2,
             n_generations=2,
             decoding=DecodingConfig(temperature=0.8),
             prng_key=prng_key,
         )
+    rollout_groups = sample.rollout_groups
 
     # Verify tokenization and chat template application
     for group in rollout_groups:

--- a/tests/rl/environments/test_prime_intellect_env.py
+++ b/tests/rl/environments/test_prime_intellect_env.py
@@ -59,9 +59,11 @@ def inference_ctx(tokenizer):
             self.tokenizer = tokenizer
             self._stop_tokens = None
             self.max_tokens = 1024
+            self.openai_client_calls = 0
 
         def openai_client(self):
             """Return a mock AsyncOpenAI client that returns proper ChatCompletion objects."""
+            self.openai_client_calls += 1
             mock_client = AsyncMock()
             # Configure the mock to return a proper ChatCompletion
             mock_client.chat.completions.create = AsyncMock(return_value=create_mock_chat_completion())
@@ -119,7 +121,17 @@ def test_prime_intellect_env_sample(tokenizer, inference_ctx, vf_env):
     assert "primeintellect/gsm8k.total_rollouts" in metrics
     assert sample.identity.task_name == "prime_intellect:primeintellect/gsm8k"
     assert sample.identity.verifier_name == "verifiers:primeintellect/gsm8k"
-    assert len(sample.traces) == 2
+    assert len(sample.traces) == len(rollout_groups)
+    for trace, group in zip(sample.traces, rollout_groups, strict=True):
+        assert trace.env_name == group.rollouts[0].env_name
+        assert trace.env_example_id == group.rollouts[0].env_example_id
+        assert trace.task_name == sample.identity.task_name
+        assert trace.verifier_name == sample.identity.verifier_name
+        assert len(trace.responses) == len(group.rollouts)
+        np.testing.assert_allclose(
+            [response.reward for response in trace.responses],
+            [rollout.episode_reward for rollout in group.rollouts],
+        )
 
 
 def test_prime_intellect_env_openai_client_called(tokenizer, inference_ctx, vf_env):
@@ -136,8 +148,11 @@ def test_prime_intellect_env_openai_client_called(tokenizer, inference_ctx, vf_e
             prng_key=prng_key,
         )
 
-    # Verify we got rollout groups (which means generate() was called successfully)
-    assert len(sample.rollout_groups) >= 0
+    assert inference_ctx.openai_client_calls == 1
+    assert len(sample.rollout_groups) == 1
+    assert len(sample.rollout_groups[0].rollouts) == 1
+    assert len(sample.traces) == 1
+    assert sample.traces[0].responses[0].reward == pytest.approx(sample.rollout_groups[0].rollouts[0].episode_reward)
 
 
 def test_prime_intellect_env_records_resolved_decoding_trace(tokenizer, inference_ctx, vf_env):

--- a/tests/rl/integration/config.py
+++ b/tests/rl/integration/config.py
@@ -42,9 +42,8 @@ from marin.rl.environments.inference_ctx import (
     VLLMFallbackSamplingConfig,
     vLLMInferenceContextConfig,
 )
-from marin.rl.kl_regularization import KLConfig, KLMode
+from marin.rl.objectives import make_rloo_objective
 from marin.rl.replay_buffer import ReplayBufferConfig
-from marin.rl.rl_losses import RLOOLoss
 from marin.rl.rollout_storage import RolloutStorageConfig, StorageType
 from marin.rl.rollout_worker import RolloutWorker, find_open_port
 from marin.rl.run_state import RLRunState
@@ -316,11 +315,8 @@ def create_nano_train_worker_config(rollout_storage: RolloutStorageConfig, outpu
             max_samples=1,
             max_rollout_step_delay=0,
         ),
-        loss=RLOOLoss(
-            kl=KLConfig(mode=KLMode.NONE, beta=0.0),
-            clip_epsilon_low=5.0,
-            clip_epsilon_high=5.0,
-        ),
+        objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=5.0, clip_epsilon_high=5.0),
+        scorer_vocab_tile_size=None,
         initial_checkpoint=None,
     )
 

--- a/tests/rl/integration/config.py
+++ b/tests/rl/integration/config.py
@@ -42,6 +42,7 @@ from marin.rl.environments.inference_ctx import (
     VLLMFallbackSamplingConfig,
     vLLMInferenceContextConfig,
 )
+from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.objectives import make_rloo_objective
 from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rollout_storage import RolloutStorageConfig, StorageType
@@ -315,7 +316,11 @@ def create_nano_train_worker_config(rollout_storage: RolloutStorageConfig, outpu
             max_samples=1,
             max_rollout_step_delay=0,
         ),
-        objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=5.0, clip_epsilon_high=5.0),
+        objective=make_rloo_objective(
+            kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+            clip_epsilon_low=5.0,
+            clip_epsilon_high=5.0,
+        ),
         scorer_vocab_tile_size=None,
         initial_checkpoint=None,
     )

--- a/tests/rl/integration/config.py
+++ b/tests/rl/integration/config.py
@@ -204,6 +204,7 @@ def create_nano_llama_config() -> LlamaConfig:
         num_kv_heads=8,
         num_layers=4,
         tokenizer=DummyTokenizer(),
+        flash_attention_block_size=16,
     )
 
 
@@ -710,6 +711,7 @@ class RolloutBatchFeeder:
     def __post_init__(self):
         self.thread = None
         self.stop_flag = threading.Event()
+        self.batch_index = 0
 
     def _run(self):
         """Thread target - continuously generate batches until runner completes."""
@@ -730,11 +732,15 @@ class RolloutBatchFeeder:
                 if self.runner.trained_model:
                     model = self.runner.trained_model
 
+                rollout_step = self.runner.all_steps_seen[-1] if self.runner.all_steps_seen else -1
+                batch_index = self.batch_index
+                self.batch_index += 1
                 batch = self.batch_generator(
                     policy_model=model,
                     batch_size=batch_size,
                     tokenizer=self.tokenizer,
-                    step=self.runner.steps_completed,
+                    step=rollout_step,
+                    batch_index=batch_index,
                 )
                 self.queue_writer.write_batch(batch)
         except Exception:

--- a/tests/rl/integration/tasks.py
+++ b/tests/rl/integration/tasks.py
@@ -7,7 +7,7 @@ import time
 
 import numpy as np
 from marin.rl.decoding import DecodingConfig
-from marin.rl.types import Rollout, RolloutBatch, RolloutGroup, RolloutMetadata
+from marin.rl.types import Rollout, RolloutBatch, RolloutGroup, RolloutGroupMetadata, RolloutMetadata
 
 from tests.rl.integration.config import (
     DummyTokenizer,
@@ -15,6 +15,17 @@ from tests.rl.integration.config import (
     encode_prompt_and_response,
     run_inference_with_engine,
 )
+
+SYNTHETIC_ROLLOUT_TEMPERATURE = 1.0
+SYNTHETIC_ROLLOUT_TOP_K = None
+SYNTHETIC_ROLLOUTS_PER_GROUP = 4
+SYNTHETIC_TASK_VERSION = "integration-v1"
+
+
+def _is_response_truncated(response_text: str, tokenizer: DummyTokenizer, max_output_length: int) -> bool:
+    response_token_count = len(tokenizer.encode(response_text, add_special_tokens=False))
+    return response_token_count > max_output_length
+
 
 # ============================================================================
 # Cats Task
@@ -37,6 +48,7 @@ def create_cats_rollout_batch(
     max_output_length: int = 16,
     pad_token_id: int = 0,
     worker_id: str = "test_worker",
+    batch_index: int = 0,
 ) -> RolloutBatch:
     """Create a rollout batch with cat-themed examples using real model logprob computation."""
     if tokenizer is None:
@@ -55,17 +67,19 @@ def create_cats_rollout_batch(
     examples = []
     rng = np.random.default_rng(42)
 
-    for _ in range(batch_size):
-        prompt = rng.choice(prompts)
-        if rng.random() < 0.5:
-            response = " ".join(rng.choice(positive_words, size=rng.integers(1, 8)))
-        else:
-            response = " ".join(rng.choice(negative_words, size=rng.integers(1, 8)))
-        examples.append((prompt, response))
+    for group_idx, group_start in enumerate(range(0, batch_size, SYNTHETIC_ROLLOUTS_PER_GROUP)):
+        prompt = prompts[group_idx % len(prompts)]
+        group_size = min(SYNTHETIC_ROLLOUTS_PER_GROUP, batch_size - group_start)
+        for sample_idx in range(group_size):
+            if sample_idx % 2 == 0:
+                response = " ".join(rng.choice(positive_words, size=rng.integers(1, 8)))
+            else:
+                response = " ".join(rng.choice(negative_words, size=rng.integers(1, 8)))
+            examples.append((group_idx, prompt, response))
 
     # Encode examples
     encoded_examples = []
-    for prompt_text, response_text in examples:
+    for _, prompt_text, response_text in examples:
         encoded = encode_prompt_and_response(
             prompt_text,
             response_text,
@@ -82,52 +96,76 @@ def create_cats_rollout_batch(
     response_tokens = np.stack([ex["response_tokens"] for ex in encoded_examples])
     response_masks = np.stack([ex["response_attention_mask"] for ex in encoded_examples])
 
-    policy_logprobs = compute_model_logprobs(
-        policy_model,
-        prompt_tokens,
-        prompt_masks,
-        response_tokens,
-        response_masks,
+    policy_logprobs = np.asarray(
+        compute_model_logprobs(
+            policy_model,
+            prompt_tokens,
+            prompt_masks,
+            response_tokens,
+            response_masks,
+        )
     )
 
-    # Create individual rollouts
-    rollouts = []
+    num_groups = (batch_size + SYNTHETIC_ROLLOUTS_PER_GROUP - 1) // SYNTHETIC_ROLLOUTS_PER_GROUP
+    grouped_rollouts: list[list[Rollout]] = [[] for _ in range(num_groups)]
     for i in range(len(examples)):
-        prompt_text, response_text = examples[i]
+        group_idx, prompt_text, response_text = examples[i]
         encoded_ex = encoded_examples[i]
         episode_reward = compute_cats_reward(response_text)
 
         # Extract individual arrays (remove batch dimension)
+        response_mask = response_masks[i].astype(bool)
         individual_prompt = encoded_ex["prompt_tokens"][prompt_masks[i] == 1]
-        individual_response = encoded_ex["response_tokens"][response_masks[i] == 1]
-        individual_logprobs = policy_logprobs[i][response_masks[i] == 1]
+        individual_response = encoded_ex["response_tokens"][response_mask]
+        individual_logprobs = policy_logprobs[i][response_mask]
 
         # Token rewards (simple: use episode reward for all response tokens)
         token_rewards = np.full(len(individual_response), episode_reward, dtype=np.float32)
 
+        group_id = f"{worker_id}:cats:{step}:batch-{batch_index}:group-{group_idx}"
+        trace_id = f"{worker_id}:cats:{step}:batch-{batch_index}:trace-{group_idx}"
         rollout = Rollout(
             env_name="mock:cats",
-            env_example_id=f"cats_example_{i}",
+            env_example_id=f"cats_example_{group_idx}_{len(grouped_rollouts[group_idx])}",
             prompt_tokens=individual_prompt,
             response_tokens=individual_response,
             response_logprobs=individual_logprobs,
             token_rewards=token_rewards,
             episode_reward=episode_reward,
-            decoding=DecodingConfig(temperature=1.0).as_trace(),
+            decoding=DecodingConfig(
+                temperature=SYNTHETIC_ROLLOUT_TEMPERATURE,
+                top_k=SYNTHETIC_ROLLOUT_TOP_K,
+                max_output_tokens=max_output_length,
+            ).as_trace(),
+            is_truncated=_is_response_truncated(response_text, tokenizer, max_output_length),
             metadata=RolloutMetadata(
                 worker_id=worker_id,
                 timestamp=time.time(),
                 weight_step=step,
+                group_id=group_id,
+                trace_id=trace_id,
+                task_name="mock:cats",
+                task_version=SYNTHETIC_TASK_VERSION,
             ),
         )
-        rollouts.append(rollout)
+        grouped_rollouts[group_idx].append(rollout)
 
-    # Group rollouts
-    group = RolloutGroup(rollouts=rollouts)
+    groups = [
+        RolloutGroup(
+            rollouts=rollouts,
+            metadata=RolloutGroupMetadata(
+                group_id=rollouts[0].metadata.group_id,
+                trace_id=rollouts[0].metadata.trace_id,
+                task_name="mock:cats",
+                task_version=SYNTHETIC_TASK_VERSION,
+            ),
+        )
+        for rollouts in grouped_rollouts
+        if rollouts
+    ]
 
-    # Use a fixed large step number to ensure these batches are never discarded
-    metadata = RolloutMetadata(worker_id=worker_id, timestamp=time.time(), weight_step=10000)
-    return RolloutBatch(groups=[group], metadata=metadata)
+    metadata = RolloutMetadata(worker_id=worker_id, timestamp=time.time(), weight_step=step)
+    return RolloutBatch(groups=groups, metadata=metadata)
 
 
 def validate_cats_model(model, tokenizer) -> dict[str, str]:
@@ -230,6 +268,7 @@ def create_sequential_digits_rollout_batch(
     max_output_length: int = 16,
     pad_token_id: int = 0,
     worker_id: str = "test_worker",
+    batch_index: int = 0,
 ) -> RolloutBatch:
     """Create a rollout batch with sequential digit examples."""
     if tokenizer is None:
@@ -243,20 +282,21 @@ def create_sequential_digits_rollout_batch(
         "i like cats",
     ]
 
-    for _ in range(batch_size):
+    for group_idx, group_start in enumerate(range(0, batch_size, SYNTHETIC_ROLLOUTS_PER_GROUP)):
         start_idx = rng.integers(0, 5)
         end_idx = start_idx + rng.integers(start_idx, 9)
         prompt = f"{start_idx} to {end_idx}:"
-        # 60% chance of positive (sequential) response
-        if rng.random() < 0.6:
-            response = "".join(str(i) for i in range(start_idx, end_idx))
-        else:
-            response = rng.choice(bad_responses)
-        examples.append((prompt, response))
+        group_size = min(SYNTHETIC_ROLLOUTS_PER_GROUP, batch_size - group_start)
+        for sample_idx in range(group_size):
+            if sample_idx % 2 == 0:
+                response = "".join(str(i) for i in range(start_idx, end_idx))
+            else:
+                response = rng.choice(bad_responses)
+            examples.append((group_idx, prompt, response))
 
     # Encode examples
     encoded_examples = []
-    for prompt_text, response_text in examples:
+    for _, prompt_text, response_text in examples:
         encoded = encode_prompt_and_response(
             prompt_text,
             response_text,
@@ -273,52 +313,77 @@ def create_sequential_digits_rollout_batch(
     response_tokens = np.stack([ex["response_tokens"] for ex in encoded_examples])
     response_masks = np.stack([ex["response_attention_mask"] for ex in encoded_examples])
 
-    policy_logprobs = compute_model_logprobs(
-        policy_model,
-        prompt_tokens,
-        prompt_masks,
-        response_tokens,
-        response_masks,
+    policy_logprobs = np.asarray(
+        compute_model_logprobs(
+            policy_model,
+            prompt_tokens,
+            prompt_masks,
+            response_tokens,
+            response_masks,
+        )
     )
 
     # Create individual rollouts
-    rollouts = []
+    num_groups = (batch_size + SYNTHETIC_ROLLOUTS_PER_GROUP - 1) // SYNTHETIC_ROLLOUTS_PER_GROUP
+    grouped_rollouts: list[list[Rollout]] = [[] for _ in range(num_groups)]
     for i in range(len(examples)):
-        prompt_text, response_text = examples[i]
+        group_idx, prompt_text, response_text = examples[i]
         encoded_ex = encoded_examples[i]
         episode_reward = compute_sequential_digits_reward(response_text)
 
         # Extract individual arrays (remove batch dimension)
+        response_mask = response_masks[i].astype(bool)
         individual_prompt = encoded_ex["prompt_tokens"][prompt_masks[i] == 1]
-        individual_response = encoded_ex["response_tokens"][response_masks[i] == 1]
-        individual_logprobs = policy_logprobs[i][response_masks[i] == 1]
+        individual_response = encoded_ex["response_tokens"][response_mask]
+        individual_logprobs = policy_logprobs[i][response_mask]
 
         # Token rewards (use episode reward for all response tokens)
         token_rewards = np.full(len(individual_response), episode_reward, dtype=np.float32)
 
+        group_id = f"{worker_id}:sequential_digits:{step}:batch-{batch_index}:group-{group_idx}"
+        trace_id = f"{worker_id}:sequential_digits:{step}:batch-{batch_index}:trace-{group_idx}"
         rollout = Rollout(
             env_name="mock:sequential_digits",
-            env_example_id=f"seq_digits_example_{i}",
+            env_example_id=f"seq_digits_example_{group_idx}_{len(grouped_rollouts[group_idx])}",
             prompt_tokens=individual_prompt,
             response_tokens=individual_response,
             response_logprobs=individual_logprobs,
             token_rewards=token_rewards,
             episode_reward=episode_reward,
-            decoding=DecodingConfig(temperature=1.0).as_trace(),
+            decoding=DecodingConfig(
+                temperature=SYNTHETIC_ROLLOUT_TEMPERATURE,
+                top_k=SYNTHETIC_ROLLOUT_TOP_K,
+                max_output_tokens=max_output_length,
+            ).as_trace(),
+            is_truncated=_is_response_truncated(response_text, tokenizer, max_output_length),
             metadata=RolloutMetadata(
                 worker_id=worker_id,
                 timestamp=time.time(),
                 weight_step=step,
+                group_id=group_id,
+                trace_id=trace_id,
+                task_name="mock:sequential_digits",
+                task_version=SYNTHETIC_TASK_VERSION,
             ),
         )
-        rollouts.append(rollout)
+        grouped_rollouts[group_idx].append(rollout)
 
-    # Group rollouts
-    group = RolloutGroup(rollouts=rollouts)
+    groups = [
+        RolloutGroup(
+            rollouts=rollouts,
+            metadata=RolloutGroupMetadata(
+                group_id=rollouts[0].metadata.group_id,
+                trace_id=rollouts[0].metadata.trace_id,
+                task_name="mock:sequential_digits",
+                task_version=SYNTHETIC_TASK_VERSION,
+            ),
+        )
+        for rollouts in grouped_rollouts
+        if rollouts
+    ]
 
-    # Use fixed large step number to ensure batches are never discarded
-    metadata = RolloutMetadata(worker_id=worker_id, timestamp=time.time(), weight_step=10000)
-    return RolloutBatch(groups=[group], metadata=metadata)
+    metadata = RolloutMetadata(worker_id=worker_id, timestamp=time.time(), weight_step=step)
+    return RolloutBatch(groups=groups, metadata=metadata)
 
 
 def validate_sequential_digits_model(model, tokenizer) -> dict[str, str]:

--- a/tests/rl/integration/test_cats_integration.py
+++ b/tests/rl/integration/test_cats_integration.py
@@ -13,6 +13,7 @@ import pytest
 from marin.rl.objectives import make_rloo_objective
 from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
+
 from tests.rl.integration.config import (
     DummyTokenizer,
     RolloutBatchFeeder,

--- a/tests/rl/integration/test_cats_integration.py
+++ b/tests/rl/integration/test_cats_integration.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.objectives import make_rloo_objective
 from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
@@ -57,7 +58,7 @@ def test_train_worker_with_manual_cats_rollout(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            objective=make_rloo_objective(kl_coef=0.0),
+            objective=make_rloo_objective(kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
             replay_buffer=ReplayBufferConfig(
                 capacity=2048,
                 alpha=3.0,
@@ -116,7 +117,11 @@ def test_full_integration_moar_cats(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=0.2, clip_epsilon_high=0.2),
+            objective=make_rloo_objective(
+                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+                clip_epsilon_low=0.2,
+                clip_epsilon_high=0.2,
+            ),
             replay_buffer=ReplayBufferConfig(
                 capacity=4096,
                 alpha=3.0,
@@ -172,7 +177,11 @@ def test_full_integration_moar_cats_vllm(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=0.2, clip_epsilon_high=0.2),
+            objective=make_rloo_objective(
+                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+                clip_epsilon_low=0.2,
+                clip_epsilon_high=0.2,
+            ),
             replay_buffer=ReplayBufferConfig(
                 capacity=4096,
                 alpha=3.0,

--- a/tests/rl/integration/test_cats_integration.py
+++ b/tests/rl/integration/test_cats_integration.py
@@ -10,11 +10,9 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from marin.rl.kl_regularization import KLConfig, KLMode
+from marin.rl.objectives import make_rloo_objective
 from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
-from marin.rl.rl_losses import RLOOLoss
-
 from tests.rl.integration.config import (
     DummyTokenizer,
     RolloutBatchFeeder,
@@ -58,7 +56,7 @@ def test_train_worker_with_manual_cats_rollout(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            rl_loss=RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
+            objective=make_rloo_objective(kl_coef=0.0),
             replay_buffer=ReplayBufferConfig(
                 capacity=2048,
                 alpha=3.0,
@@ -117,11 +115,7 @@ def test_full_integration_moar_cats(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            rl_loss=RLOOLoss(
-                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
-                clip_epsilon_low=0.2,
-                clip_epsilon_high=0.2,
-            ),
+            objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=0.2, clip_epsilon_high=0.2),
             replay_buffer=ReplayBufferConfig(
                 capacity=4096,
                 alpha=3.0,
@@ -177,11 +171,7 @@ def test_full_integration_moar_cats_vllm(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            rl_loss=RLOOLoss(
-                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
-                clip_epsilon_low=0.2,
-                clip_epsilon_high=0.2,
-            ),
+            objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=0.2, clip_epsilon_high=0.2),
             replay_buffer=ReplayBufferConfig(
                 capacity=4096,
                 alpha=3.0,

--- a/tests/rl/integration/test_checkpoint_restart.py
+++ b/tests/rl/integration/test_checkpoint_restart.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 from marin.rl.objectives import make_rloo_objective
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
+
 from tests.rl.integration.config import (
     DummyTokenizer,
     TrainWorkerRunner,

--- a/tests/rl/integration/test_checkpoint_restart.py
+++ b/tests/rl/integration/test_checkpoint_restart.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from pathlib import Path
 
 import pytest
+from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.objectives import make_rloo_objective
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
 
@@ -44,7 +45,11 @@ def test_train_worker_checkpoint_restart(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=0.2, clip_epsilon_high=0.2),
+            objective=make_rloo_objective(
+                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+                clip_epsilon_low=0.2,
+                clip_epsilon_high=0.2,
+            ),
         ),
         curriculum=create_test_curriculum_config(),
         tokenizer=DummyTokenizer(),
@@ -96,7 +101,11 @@ def test_train_worker_checkpoint_restart(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=0.2, clip_epsilon_high=0.2),
+            objective=make_rloo_objective(
+                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+                clip_epsilon_low=0.2,
+                clip_epsilon_high=0.2,
+            ),
         ),
         curriculum=create_test_curriculum_config(),
         tokenizer=DummyTokenizer(),

--- a/tests/rl/integration/test_checkpoint_restart.py
+++ b/tests/rl/integration/test_checkpoint_restart.py
@@ -9,10 +9,8 @@ from datetime import timedelta
 from pathlib import Path
 
 import pytest
-from marin.rl.kl_regularization import KLConfig, KLMode
+from marin.rl.objectives import make_rloo_objective
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
-from marin.rl.rl_losses import RLOOLoss
-
 from tests.rl.integration.config import (
     DummyTokenizer,
     TrainWorkerRunner,
@@ -45,11 +43,7 @@ def test_train_worker_checkpoint_restart(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            rl_loss=RLOOLoss(
-                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
-                clip_epsilon_low=0.2,
-                clip_epsilon_high=0.2,
-            ),
+            objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=0.2, clip_epsilon_high=0.2),
         ),
         curriculum=create_test_curriculum_config(),
         tokenizer=DummyTokenizer(),
@@ -101,11 +95,7 @@ def test_train_worker_checkpoint_restart(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            rl_loss=RLOOLoss(
-                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
-                clip_epsilon_low=0.2,
-                clip_epsilon_high=0.2,
-            ),
+            objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=0.2, clip_epsilon_high=0.2),
         ),
         curriculum=create_test_curriculum_config(),
         tokenizer=DummyTokenizer(),

--- a/tests/rl/integration/test_llama_math_integration.py
+++ b/tests/rl/integration/test_llama_math_integration.py
@@ -20,10 +20,9 @@ from levanter.utils.mesh import MeshConfig
 from marin.rl.curriculum import CurriculumConfig, LessonConfig, SamplingParams
 from marin.rl.decoding import DecodingConfig
 from marin.rl.environments import EnvConfig
-from marin.rl.kl_regularization import KLConfig, KLMode
+from marin.rl.objectives import make_rloo_objective
 from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
-from marin.rl.rl_losses import RLOOLoss
 from marin.rl.weight_transfer import WeightTransferConfig, WeightTransferMode
 from transformers import AutoConfig
 
@@ -136,11 +135,7 @@ def test_llama_math_integration(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=opt_config,
-            rl_loss=RLOOLoss(
-                kl=KLConfig(mode=KLMode.K3_LOSS, beta=0.01),
-                clip_epsilon_low=0.2,
-                clip_epsilon_high=0.2,
-            ),
+            objective=make_rloo_objective(kl_coef=0.01, clip_epsilon_low=0.2, clip_epsilon_high=0.2),
             replay_buffer=ReplayBufferConfig(
                 capacity=2048,
                 alpha=3.0,

--- a/tests/rl/integration/test_llama_math_integration.py
+++ b/tests/rl/integration/test_llama_math_integration.py
@@ -20,6 +20,7 @@ from levanter.utils.mesh import MeshConfig
 from marin.rl.curriculum import CurriculumConfig, LessonConfig, SamplingParams
 from marin.rl.decoding import DecodingConfig
 from marin.rl.environments import EnvConfig
+from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.objectives import make_rloo_objective
 from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
@@ -135,7 +136,11 @@ def test_llama_math_integration(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=opt_config,
-            objective=make_rloo_objective(kl_coef=0.01, clip_epsilon_low=0.2, clip_epsilon_high=0.2),
+            objective=make_rloo_objective(
+                kl=KLConfig(mode=KLMode.K3_LOSS, beta=0.01),
+                clip_epsilon_low=0.2,
+                clip_epsilon_high=0.2,
+            ),
             replay_buffer=ReplayBufferConfig(
                 capacity=2048,
                 alpha=3.0,

--- a/tests/rl/integration/test_rollout_worker.py
+++ b/tests/rl/integration/test_rollout_worker.py
@@ -9,6 +9,7 @@ import time
 import pytest
 from marin.rl.objectives import make_rloo_objective
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
+
 from tests.rl.integration.config import (
     DummyTokenizer,
     RolloutWorkerRunner,

--- a/tests/rl/integration/test_rollout_worker.py
+++ b/tests/rl/integration/test_rollout_worker.py
@@ -7,6 +7,7 @@ import os
 import time
 
 import pytest
+from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.objectives import make_rloo_objective
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
 
@@ -38,7 +39,11 @@ def test_rollout_worker(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=0.2, clip_epsilon_high=0.2),
+            objective=make_rloo_objective(
+                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+                clip_epsilon_low=0.2,
+                clip_epsilon_high=0.2,
+            ),
         ),
         curriculum=create_test_curriculum_config(),
         tokenizer=DummyTokenizer(),

--- a/tests/rl/integration/test_rollout_worker.py
+++ b/tests/rl/integration/test_rollout_worker.py
@@ -7,10 +7,8 @@ import os
 import time
 
 import pytest
-from marin.rl.kl_regularization import KLConfig, KLMode
+from marin.rl.objectives import make_rloo_objective
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
-from marin.rl.rl_losses import RLOOLoss
-
 from tests.rl.integration.config import (
     DummyTokenizer,
     RolloutWorkerRunner,
@@ -39,11 +37,7 @@ def test_rollout_worker(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            rl_loss=RLOOLoss(
-                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
-                clip_epsilon_low=0.2,
-                clip_epsilon_high=0.2,
-            ),
+            objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=0.2, clip_epsilon_high=0.2),
         ),
         curriculum=create_test_curriculum_config(),
         tokenizer=DummyTokenizer(),

--- a/tests/rl/integration/test_sequential_digits_integration.py
+++ b/tests/rl/integration/test_sequential_digits_integration.py
@@ -12,6 +12,7 @@ import pytest
 from marin.rl.curriculum import CurriculumConfig, LessonConfig, SamplingParams
 from marin.rl.decoding import DecodingConfig
 from marin.rl.environments import EnvConfig
+from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.objectives import make_rloo_objective
 from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
@@ -75,7 +76,11 @@ def test_train_worker_with_sequential_digits(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=0.2, clip_epsilon_high=0.2),
+            objective=make_rloo_objective(
+                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+                clip_epsilon_low=0.2,
+                clip_epsilon_high=0.2,
+            ),
             replay_buffer=ReplayBufferConfig(
                 capacity=2048,
                 alpha=3.0,
@@ -153,7 +158,11 @@ def test_full_integration_sequential_digits(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=1.0, clip_epsilon_high=1.0),
+            objective=make_rloo_objective(
+                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+                clip_epsilon_low=1.0,
+                clip_epsilon_high=1.0,
+            ),
             replay_buffer=ReplayBufferConfig(
                 capacity=4096,
                 alpha=3.0,

--- a/tests/rl/integration/test_sequential_digits_integration.py
+++ b/tests/rl/integration/test_sequential_digits_integration.py
@@ -12,10 +12,9 @@ import pytest
 from marin.rl.curriculum import CurriculumConfig, LessonConfig, SamplingParams
 from marin.rl.decoding import DecodingConfig
 from marin.rl.environments import EnvConfig
-from marin.rl.kl_regularization import KLConfig, KLMode
+from marin.rl.objectives import make_rloo_objective
 from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
-from marin.rl.rl_losses import RLOOLoss
 
 from tests.rl.integration.config import (
     DummyTokenizer,
@@ -76,11 +75,7 @@ def test_train_worker_with_sequential_digits(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            rl_loss=RLOOLoss(
-                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
-                clip_epsilon_low=0.2,
-                clip_epsilon_high=0.2,
-            ),
+            objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=0.2, clip_epsilon_high=0.2),
             replay_buffer=ReplayBufferConfig(
                 capacity=2048,
                 alpha=3.0,
@@ -158,11 +153,7 @@ def test_full_integration_sequential_digits(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            rl_loss=RLOOLoss(
-                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
-                clip_epsilon_low=1.0,
-                clip_epsilon_high=1.0,
-            ),
+            objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=1.0, clip_epsilon_high=1.0),
             replay_buffer=ReplayBufferConfig(
                 capacity=4096,
                 alpha=3.0,

--- a/tests/rl/integration/test_train_worker.py
+++ b/tests/rl/integration/test_train_worker.py
@@ -8,6 +8,7 @@ import os
 import pytest
 from marin.rl.objectives import make_rloo_objective
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
+
 from tests.rl.integration.config import (
     DummyTokenizer,
     RolloutBatchFeeder,

--- a/tests/rl/integration/test_train_worker.py
+++ b/tests/rl/integration/test_train_worker.py
@@ -6,10 +6,8 @@
 import os
 
 import pytest
-from marin.rl.kl_regularization import KLConfig, KLMode
+from marin.rl.objectives import make_rloo_objective
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
-from marin.rl.rl_losses import RLOOLoss
-
 from tests.rl.integration.config import (
     DummyTokenizer,
     RolloutBatchFeeder,
@@ -39,11 +37,7 @@ def test_train_worker(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            rl_loss=RLOOLoss(
-                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
-                clip_epsilon_low=0.2,
-                clip_epsilon_high=0.2,
-            ),
+            objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=0.2, clip_epsilon_high=0.2),
         ),
         curriculum=create_test_curriculum_config(),
         tokenizer=DummyTokenizer(),

--- a/tests/rl/integration/test_train_worker.py
+++ b/tests/rl/integration/test_train_worker.py
@@ -6,6 +6,7 @@
 import os
 
 import pytest
+from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.objectives import make_rloo_objective
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
 
@@ -38,7 +39,11 @@ def test_train_worker(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=0.2, clip_epsilon_high=0.2),
+            objective=make_rloo_objective(
+                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+                clip_epsilon_low=0.2,
+                clip_epsilon_high=0.2,
+            ),
         ),
         curriculum=create_test_curriculum_config(),
         tokenizer=DummyTokenizer(),

--- a/tests/rl/integration/test_weight_sync.py
+++ b/tests/rl/integration/test_weight_sync.py
@@ -9,6 +9,7 @@ import time
 import pytest
 from marin.rl.objectives import make_rloo_objective
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
+
 from tests.rl.integration.config import (
     DummyTokenizer,
     RolloutWorkerRunner,

--- a/tests/rl/integration/test_weight_sync.py
+++ b/tests/rl/integration/test_weight_sync.py
@@ -7,6 +7,7 @@ import os
 import time
 
 import pytest
+from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.objectives import make_rloo_objective
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
 
@@ -38,7 +39,11 @@ def test_rollout_and_train_workers(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=0.2, clip_epsilon_high=0.2),
+            objective=make_rloo_objective(
+                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+                clip_epsilon_low=0.2,
+                clip_epsilon_high=0.2,
+            ),
         ),
         curriculum=create_test_curriculum_config(),
         tokenizer=DummyTokenizer(),

--- a/tests/rl/integration/test_weight_sync.py
+++ b/tests/rl/integration/test_weight_sync.py
@@ -7,10 +7,8 @@ import os
 import time
 
 import pytest
-from marin.rl.kl_regularization import KLConfig, KLMode
+from marin.rl.objectives import make_rloo_objective
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
-from marin.rl.rl_losses import RLOOLoss
-
 from tests.rl.integration.config import (
     DummyTokenizer,
     RolloutWorkerRunner,
@@ -39,11 +37,7 @@ def test_rollout_and_train_workers(tmp_path):
         trainer=trainer_config,
         train_params=TrainParams(
             optimizer=create_nano_optimizer_config(),
-            rl_loss=RLOOLoss(
-                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
-                clip_epsilon_low=0.2,
-                clip_epsilon_high=0.2,
-            ),
+            objective=make_rloo_objective(kl_coef=0.0, clip_epsilon_low=0.2, clip_epsilon_high=0.2),
         ),
         curriculum=create_test_curriculum_config(),
         tokenizer=DummyTokenizer(),

--- a/tests/rl/test_compute_logprobs.py
+++ b/tests/rl/test_compute_logprobs.py
@@ -5,7 +5,6 @@ import haliax as hax
 import jax
 import jax.numpy as jnp
 import pytest
-
 from marin.rl.rl_losses import importance_sampling_ratio
 from marin.rl.scoring import (
     LocalScoreSource,

--- a/tests/rl/test_compute_logprobs.py
+++ b/tests/rl/test_compute_logprobs.py
@@ -1,12 +1,20 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from types import SimpleNamespace
-
+import haliax as hax
 import jax
 import jax.numpy as jnp
 import pytest
-from marin.rl.rl_losses import compute_logprobs, compute_logprobs_and_entropy, importance_sampling_ratio
+
+from marin.rl.rl_losses import importance_sampling_ratio
+from marin.rl.scoring import (
+    LocalScoreSource,
+    ModelRoles,
+    ScoreRequirements,
+    TokenScoreInputs,
+    compute_logprobs,
+)
+from marin.rl.types import SequenceBatch, TrainingBatch
 
 
 class DummyNamedArray:
@@ -27,14 +35,46 @@ class DummyModel:
         return DummyModelOutput(self._logits)
 
 
+def _named(array, axes):
+    return hax.named(jnp.asarray(array), axes)
+
+
+def _make_training_batch() -> TrainingBatch:
+    return TrainingBatch(
+        input_ids=_named([[0, 1]], ["batch", "position"]),
+        position_ids=_named([[0, 1]], ["batch", "position"]),
+        loss_weights=_named([[0.0, 1.0]], ["batch", "position"]),
+        loss_masks=_named([[0.0, 1.0]], ["batch", "position"]),
+        policy_logprobs=_named([[0.0, -0.75]], ["batch", "position"]),
+        temperature=_named([1.0], ["batch"]),
+        top_k=_named([-1], ["batch"]),
+        truncated=jnp.asarray([False]),
+        max_output_tokens=2,
+    )
+
+
+def _make_sequence_batch() -> SequenceBatch:
+    return SequenceBatch(
+        input_ids=_named([[0, 1]], ["batch", "position"]),
+        position_ids=_named([[0, 1]], ["batch", "position"]),
+        prompt_mask=_named([[1.0, 0.0]], ["batch", "position"]),
+        response_mask=_named([[0.0, 1.0]], ["batch", "position"]),
+        behavior_logprobs=_named([[0.0, -0.25]], ["batch", "position"]),
+        sampling_temperature=_named([1.0], ["batch"]),
+        sampling_top_k=_named([-1], ["batch"]),
+        truncated=jnp.asarray([False]),
+        max_output_tokens=2,
+    )
+
+
 def test_compute_logprobs_one_hot_next_token():
     logits = jnp.zeros((1, 2, 10), dtype=jnp.float32)
     logits = logits.at[0, 0, 1].set(1.0)
 
-    batch = SimpleNamespace(
+    batch = TokenScoreInputs(
         input_ids=DummyNamedArray(jnp.array([[0, 1]], dtype=jnp.int32)),
         position_ids=DummyNamedArray(jnp.array([[0, 1]], dtype=jnp.int32)),
-        temperature=DummyNamedArray(jnp.array([1.0], dtype=jnp.float32)),
+        sampling_temperature=DummyNamedArray(jnp.array([1.0], dtype=jnp.float32)),
     )
     model = DummyModel(logits)
 
@@ -47,102 +87,89 @@ def test_compute_logprobs_one_hot_next_token():
     assert logprobs[0, 1] == pytest.approx(float(expected_next_logprob))
 
 
-def test_compute_logprobs_and_entropy_can_skip_entropy():
-    logits = jnp.zeros((1, 2, 10), dtype=jnp.float32)
-    logits = logits.at[0, 0, 1].set(1.0)
-
-    batch = SimpleNamespace(
-        input_ids=DummyNamedArray(jnp.array([[0, 1]], dtype=jnp.int32)),
-        position_ids=DummyNamedArray(jnp.array([[0, 1]], dtype=jnp.int32)),
-        temperature=DummyNamedArray(jnp.array([1.0], dtype=jnp.float32)),
-    )
-    model = DummyModel(logits)
-
-    logprobs, entropy = compute_logprobs_and_entropy(model, batch, key=None, compute_entropy=False)
-
-    expected_next_logprob = jax.nn.log_softmax(logits[:, :-1, :], axis=-1)[0, 0, 1]
-
-    assert entropy is None
-    assert logprobs.shape == (1, 2)
-    assert logprobs[0, 0] == pytest.approx(0.0)
-    assert logprobs[0, 1] == pytest.approx(float(expected_next_logprob))
-
-
-def test_compute_logprobs_and_entropy_uniform_logits():
-    vocab_size = 5
-    logits = jnp.zeros((1, 3, vocab_size), dtype=jnp.float32)
-
-    batch = SimpleNamespace(
-        input_ids=DummyNamedArray(jnp.array([[0, 1, 2]], dtype=jnp.int32)),
-        position_ids=DummyNamedArray(jnp.array([[0, 1, 2]], dtype=jnp.int32)),
-        temperature=DummyNamedArray(jnp.array([1.0], dtype=jnp.float32)),
-    )
-    model = DummyModel(logits)
-
-    logprobs, entropy = compute_logprobs_and_entropy(model, batch, key=None, compute_entropy=True)
-
-    assert entropy is not None
-    assert logprobs.shape == (1, 3)
-    assert entropy.shape == (1, 3)
-    assert entropy[0, 0] == pytest.approx(0.0)
-    assert entropy[0, 1] == pytest.approx(float(jnp.log(vocab_size)))
-    assert entropy[0, 2] == pytest.approx(float(jnp.log(vocab_size)))
-
-
-def test_compute_logprobs_and_entropy_peaked_logits_have_lower_entropy():
-    uniform_logits = jnp.zeros((1, 2, 4), dtype=jnp.float32)
-    peaked_logits = uniform_logits.at[0, 0, 0].set(8.0)
-
-    batch = SimpleNamespace(
-        input_ids=DummyNamedArray(jnp.array([[0, 1]], dtype=jnp.int32)),
-        position_ids=DummyNamedArray(jnp.array([[0, 1]], dtype=jnp.int32)),
-        temperature=DummyNamedArray(jnp.array([1.0], dtype=jnp.float32)),
+def test_local_score_source_scores_training_batch_student_behavior_and_reference():
+    student_logits = jnp.zeros((1, 2, 10), dtype=jnp.float32).at[0, 0, 1].set(1.0)
+    reference_logits = jnp.zeros((1, 2, 10), dtype=jnp.float32).at[0, 0, 1].set(2.0)
+    batch = _make_training_batch()
+    score_source = LocalScoreSource(
+        score_requirements=ScoreRequirements(
+            student_logprobs=True,
+            behavior_logprobs=True,
+            reference_logprobs=True,
+        )
     )
 
-    _uniform_logprobs, uniform_entropy = compute_logprobs_and_entropy(
-        DummyModel(uniform_logits), batch, key=None, compute_entropy=True
+    score_bundle = score_source.score(
+        batch,
+        info=None,
+        roles=ModelRoles(student=DummyModel(student_logits), reference=DummyModel(reference_logits)),
+        key=None,
     )
-    _peaked_logprobs, peaked_entropy = compute_logprobs_and_entropy(
-        DummyModel(peaked_logits), batch, key=None, compute_entropy=True
+
+    expected_student = compute_logprobs(
+        DummyModel(student_logits),
+        TokenScoreInputs(
+            input_ids=batch.input_ids,
+            position_ids=batch.position_ids,
+            sampling_temperature=batch.temperature,
+        ),
+        key=None,
+    )
+    expected_reference = compute_logprobs(
+        DummyModel(reference_logits),
+        TokenScoreInputs(
+            input_ids=batch.input_ids,
+            position_ids=batch.position_ids,
+            sampling_temperature=batch.temperature,
+        ),
+        key=None,
     )
 
-    assert uniform_entropy is not None
-    assert peaked_entropy is not None
-    assert peaked_entropy[0, 1] < uniform_entropy[0, 1]
+    assert score_bundle.behavior_logprobs is not None
+    assert score_bundle.student_logprobs is not None
+    assert score_bundle.reference_logprobs is not None
+    assert score_bundle.student_pass_count == 1
+    assert score_bundle.reference_pass_count == 1
+    assert score_bundle.teacher_pass_count == 0
+    assert jnp.array_equal(score_bundle.behavior_logprobs, batch.policy_logprobs.array)
+    assert jnp.allclose(score_bundle.student_logprobs, expected_student)
+    assert jnp.allclose(score_bundle.reference_logprobs, expected_reference)
 
 
-def test_compute_logprobs_and_entropy_temperature_scales_entropy():
-    logits = jnp.zeros((2, 2, 4), dtype=jnp.float32)
-    logits = logits.at[:, 0, 0].set(8.0)
-
-    batch = SimpleNamespace(
-        input_ids=DummyNamedArray(jnp.array([[0, 1], [0, 1]], dtype=jnp.int32)),
-        position_ids=DummyNamedArray(jnp.array([[0, 1], [0, 1]], dtype=jnp.int32)),
-        temperature=DummyNamedArray(jnp.array([0.5, 2.0], dtype=jnp.float32)),
+def test_local_score_source_uses_sequence_batch_behavior_logprobs():
+    logits = jnp.zeros((1, 2, 10), dtype=jnp.float32).at[0, 0, 1].set(1.0)
+    batch = _make_sequence_batch()
+    score_source = LocalScoreSource(
+        score_requirements=ScoreRequirements(
+            student_logprobs=True,
+            behavior_logprobs=True,
+        )
     )
-    model = DummyModel(logits)
 
-    _logprobs, entropy = compute_logprobs_and_entropy(model, batch, key=None, compute_entropy=True)
-
-    assert entropy is not None
-    assert entropy[1, 1] > entropy[0, 1]
-
-
-def test_compute_logprobs_and_entropy_extreme_logits_are_finite():
-    logits = jnp.array([[[1000.0, -1000.0, -1000.0], [0.0, 0.0, 0.0]]], dtype=jnp.float32)
-
-    batch = SimpleNamespace(
-        input_ids=DummyNamedArray(jnp.array([[0, 1]], dtype=jnp.int32)),
-        position_ids=DummyNamedArray(jnp.array([[0, 1]], dtype=jnp.int32)),
-        temperature=DummyNamedArray(jnp.array([1.0], dtype=jnp.float32)),
+    score_bundle = score_source.score(
+        batch,
+        info=None,
+        roles=ModelRoles(student=DummyModel(logits)),
+        key=None,
     )
-    model = DummyModel(logits)
 
-    _logprobs, entropy = compute_logprobs_and_entropy(model, batch, key=None, compute_entropy=True)
+    assert score_bundle.behavior_logprobs is not None
+    assert score_bundle.student_logprobs is not None
+    assert score_bundle.reference_logprobs is None
+    assert score_bundle.student_pass_count == 1
+    assert jnp.array_equal(score_bundle.behavior_logprobs, batch.behavior_logprobs.array)
 
-    assert entropy is not None
-    assert jnp.isfinite(entropy[0, 1])
-    assert entropy[0, 1] == pytest.approx(0.0)
+
+def test_local_score_source_requires_reference_model_when_requested():
+    score_source = LocalScoreSource(score_requirements=ScoreRequirements(reference_logprobs=True))
+
+    with pytest.raises(ValueError, match="reference model is required"):
+        score_source.score(
+            _make_training_batch(),
+            info=None,
+            roles=ModelRoles(student=DummyModel(jnp.zeros((1, 2, 10), dtype=jnp.float32))),
+            key=None,
+        )
 
 
 def test_current_and_policy_importance_sampling_ratio_equals_one_when_equal():

--- a/tests/rl/test_compute_logprobs.py
+++ b/tests/rl/test_compute_logprobs.py
@@ -12,6 +12,7 @@ from marin.rl.scoring import (
     ScoreRequirements,
     TokenScoreInputs,
     compute_logprobs,
+    compute_logprobs_and_entropy,
 )
 from marin.rl.types import SequenceBatch, TrainingBatch
 
@@ -86,6 +87,104 @@ def test_compute_logprobs_one_hot_next_token():
     assert logprobs[0, 1] == pytest.approx(float(expected_next_logprob))
 
 
+def test_compute_logprobs_and_entropy_can_skip_entropy():
+    logits = jnp.zeros((1, 2, 10), dtype=jnp.float32)
+    logits = logits.at[0, 0, 1].set(1.0)
+
+    batch = TokenScoreInputs(
+        input_ids=DummyNamedArray(jnp.array([[0, 1]], dtype=jnp.int32)),
+        position_ids=DummyNamedArray(jnp.array([[0, 1]], dtype=jnp.int32)),
+        sampling_temperature=DummyNamedArray(jnp.array([1.0], dtype=jnp.float32)),
+    )
+    model = DummyModel(logits)
+
+    logprobs, entropy = compute_logprobs_and_entropy(model, batch, key=None, compute_entropy=False)
+
+    expected_next_logprob = jax.nn.log_softmax(logits[:, :-1, :], axis=-1)[0, 0, 1]
+
+    assert entropy is None
+    assert logprobs.shape == (1, 2)
+    assert logprobs[0, 0] == pytest.approx(0.0)
+    assert logprobs[0, 1] == pytest.approx(float(expected_next_logprob))
+
+
+def test_compute_logprobs_and_entropy_uniform_logits():
+    vocab_size = 5
+    logits = jnp.zeros((1, 3, vocab_size), dtype=jnp.float32)
+
+    batch = TokenScoreInputs(
+        input_ids=DummyNamedArray(jnp.array([[0, 1, 2]], dtype=jnp.int32)),
+        position_ids=DummyNamedArray(jnp.array([[0, 1, 2]], dtype=jnp.int32)),
+        sampling_temperature=DummyNamedArray(jnp.array([1.0], dtype=jnp.float32)),
+    )
+    model = DummyModel(logits)
+
+    logprobs, entropy = compute_logprobs_and_entropy(model, batch, key=None, compute_entropy=True)
+
+    assert entropy is not None
+    assert logprobs.shape == (1, 3)
+    assert entropy.shape == (1, 3)
+    assert entropy[0, 0] == pytest.approx(0.0)
+    assert entropy[0, 1] == pytest.approx(float(jnp.log(vocab_size)))
+    assert entropy[0, 2] == pytest.approx(float(jnp.log(vocab_size)))
+
+
+def test_compute_logprobs_and_entropy_peaked_logits_have_lower_entropy():
+    uniform_logits = jnp.zeros((1, 2, 4), dtype=jnp.float32)
+    peaked_logits = uniform_logits.at[0, 0, 0].set(8.0)
+
+    batch = TokenScoreInputs(
+        input_ids=DummyNamedArray(jnp.array([[0, 1]], dtype=jnp.int32)),
+        position_ids=DummyNamedArray(jnp.array([[0, 1]], dtype=jnp.int32)),
+        sampling_temperature=DummyNamedArray(jnp.array([1.0], dtype=jnp.float32)),
+    )
+
+    _uniform_logprobs, uniform_entropy = compute_logprobs_and_entropy(
+        DummyModel(uniform_logits), batch, key=None, compute_entropy=True
+    )
+    _peaked_logprobs, peaked_entropy = compute_logprobs_and_entropy(
+        DummyModel(peaked_logits), batch, key=None, compute_entropy=True
+    )
+
+    assert uniform_entropy is not None
+    assert peaked_entropy is not None
+    assert peaked_entropy[0, 1] < uniform_entropy[0, 1]
+
+
+def test_compute_logprobs_and_entropy_temperature_scales_entropy():
+    logits = jnp.zeros((2, 2, 4), dtype=jnp.float32)
+    logits = logits.at[:, 0, 0].set(8.0)
+
+    batch = TokenScoreInputs(
+        input_ids=DummyNamedArray(jnp.array([[0, 1], [0, 1]], dtype=jnp.int32)),
+        position_ids=DummyNamedArray(jnp.array([[0, 1], [0, 1]], dtype=jnp.int32)),
+        sampling_temperature=DummyNamedArray(jnp.array([0.5, 2.0], dtype=jnp.float32)),
+    )
+    model = DummyModel(logits)
+
+    _logprobs, entropy = compute_logprobs_and_entropy(model, batch, key=None, compute_entropy=True)
+
+    assert entropy is not None
+    assert entropy[1, 1] > entropy[0, 1]
+
+
+def test_compute_logprobs_and_entropy_extreme_logits_are_finite():
+    logits = jnp.array([[[1000.0, -1000.0, -1000.0], [0.0, 0.0, 0.0]]], dtype=jnp.float32)
+
+    batch = TokenScoreInputs(
+        input_ids=DummyNamedArray(jnp.array([[0, 1]], dtype=jnp.int32)),
+        position_ids=DummyNamedArray(jnp.array([[0, 1]], dtype=jnp.int32)),
+        sampling_temperature=DummyNamedArray(jnp.array([1.0], dtype=jnp.float32)),
+    )
+    model = DummyModel(logits)
+
+    _logprobs, entropy = compute_logprobs_and_entropy(model, batch, key=None, compute_entropy=True)
+
+    assert entropy is not None
+    assert jnp.isfinite(entropy[0, 1])
+    assert entropy[0, 1] == pytest.approx(0.0)
+
+
 def test_local_score_source_scores_training_batch_student_behavior_and_reference():
     student_logits = jnp.zeros((1, 2, 10), dtype=jnp.float32).at[0, 0, 1].set(1.0)
     reference_logits = jnp.zeros((1, 2, 10), dtype=jnp.float32).at[0, 0, 1].set(2.0)
@@ -133,6 +232,46 @@ def test_local_score_source_scores_training_batch_student_behavior_and_reference
     assert jnp.array_equal(score_bundle.behavior_logprobs, batch.policy_logprobs.array)
     assert jnp.allclose(score_bundle.student_logprobs, expected_student)
     assert jnp.allclose(score_bundle.reference_logprobs, expected_reference)
+
+
+def test_local_score_source_can_request_student_entropy():
+    vocab_size = 5
+    logits = jnp.zeros((1, 2, vocab_size), dtype=jnp.float32)
+    batch = _make_training_batch()
+    score_source = LocalScoreSource(
+        score_requirements=ScoreRequirements(
+            student_logprobs=True,
+            student_entropy=True,
+        )
+    )
+
+    score_bundle = score_source.score(
+        batch,
+        info=None,
+        roles=ModelRoles(student=DummyModel(logits)),
+        key=None,
+    )
+
+    assert score_bundle.student_logprobs is not None
+    assert score_bundle.student_entropy is not None
+    assert score_bundle.student_entropy.shape == (1, 2)
+    assert score_bundle.student_entropy[0, 0] == pytest.approx(0.0)
+    assert score_bundle.student_entropy[0, 1] == pytest.approx(float(jnp.log(vocab_size)))
+
+
+def test_local_score_source_rejects_entropy_with_vocab_tiling():
+    score_source = LocalScoreSource(
+        score_requirements=ScoreRequirements(student_entropy=True),
+        vocab_tile_size=1024,
+    )
+
+    with pytest.raises(ValueError, match="not supported with vocab_tile_size"):
+        score_source.score(
+            _make_training_batch(),
+            info=None,
+            roles=ModelRoles(student=DummyModel(jnp.zeros((1, 2, 10), dtype=jnp.float32))),
+            key=None,
+        )
 
 
 def test_local_score_source_uses_sequence_batch_behavior_logprobs():

--- a/tests/rl/test_loss.py
+++ b/tests/rl/test_loss.py
@@ -21,12 +21,47 @@ from marin.rl.rl_losses import (
     compute_rloo_advantages,
     rloo_loss_with_importance_sampling,
 )
+from marin.rl.scoring import ScoreBundle, ScoreRequirements
 from marin.rl.types import Rollout
 
 
 class DummyNamedArray:
     def __init__(self, array):
         self.array = jnp.asarray(array)
+
+
+class StaticScoreSource:
+    backend_name = "static"
+
+    def __init__(
+        self,
+        *,
+        student_logprobs,
+        student_entropy=None,
+        reference_logprobs=None,
+    ):
+        self.student_logprobs = student_logprobs
+        self.student_entropy = student_entropy
+        self.reference_logprobs = reference_logprobs
+
+    def requirements(self) -> ScoreRequirements:
+        return ScoreRequirements(
+            student_logprobs=True,
+            student_entropy=self.student_entropy is not None,
+            behavior_logprobs=True,
+            reference_logprobs=self.reference_logprobs is not None,
+        )
+
+    def score(self, batch, info, roles, *, key):
+        del info, roles, key
+        return ScoreBundle(
+            student_logprobs=self.student_logprobs,
+            student_entropy=self.student_entropy,
+            behavior_logprobs=batch.policy_logprobs.array,
+            reference_logprobs=self.reference_logprobs,
+            student_pass_count=1,
+            reference_pass_count=1 if self.reference_logprobs is not None else 0,
+        )
 
 
 def create_test_rollout(
@@ -258,24 +293,16 @@ def test_rloo_loss_reports_selected_kl_loss(mode: KLMode, expected_kl_loss: floa
         max_output_tokens=2,
     )
 
-    def compute_policy_stats_fn(model, _batch, _key, *, compute_entropy: bool):
-        assert not compute_entropy
-        if model is current_model:
-            return current_logprobs, None
-        if model is reference_model:
-            return reference_logprobs, None
-        raise AssertionError("unexpected model passed to compute_policy_stats_fn")
-
     loss, metrics = rloo_loss_with_importance_sampling(
         current_model,
         reference_model,
         batch,
+        StaticScoreSource(student_logprobs=current_logprobs, reference_logprobs=reference_logprobs),
         key=None,
         kl=KLConfig(mode=mode, beta=0.25),
         clip_epsilon_low=0.2,
         clip_epsilon_high=0.2,
         tis_importance_sampling_ratio_max=2.0,
-        compute_policy_stats_fn=compute_policy_stats_fn,
     )
 
     assert set(("kl_beta", "kl_k1_mean", "kl_k2_mean", "kl_k3_mean", "kl_loss")) <= metrics.keys()
@@ -300,21 +327,17 @@ def test_rloo_loss_policy_entropy_metric_is_opt_in_and_loss_neutral():
     current_logprobs = jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32)
     current_policy_entropy = jnp.array([[100.0, 0.25, 0.75]], dtype=jnp.float32)
 
-    def compute_policy_stats_fn(_model, _batch, _key, *, compute_entropy: bool):
-        assert compute_entropy
-        return current_logprobs, current_policy_entropy
-
     loss, metrics = rloo_loss_with_importance_sampling(
         model=None,
         reference_model=None,
         batch=batch,
+        score_source=StaticScoreSource(student_logprobs=current_logprobs, student_entropy=current_policy_entropy),
         key=None,
         kl=KLConfig(mode=KLMode.NONE, beta=0.0),
         clip_epsilon_low=0.2,
         clip_epsilon_high=0.2,
         tis_importance_sampling_ratio_max=2.0,
         log_policy_entropy=True,
-        compute_policy_stats_fn=compute_policy_stats_fn,
     )
 
     assert loss == pytest.approx(-1.0)
@@ -328,21 +351,17 @@ def test_rloo_loss_skips_policy_entropy_when_metric_disabled():
     batch = create_test_training_batch()
     current_logprobs = jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32)
 
-    def compute_policy_stats_fn(_model, _batch, _key, *, compute_entropy: bool):
-        assert not compute_entropy
-        return current_logprobs, None
-
     loss, metrics = rloo_loss_with_importance_sampling(
         model=None,
         reference_model=None,
         batch=batch,
+        score_source=StaticScoreSource(student_logprobs=current_logprobs),
         key=None,
         kl=KLConfig(mode=KLMode.NONE, beta=0.0),
         clip_epsilon_low=0.2,
         clip_epsilon_high=0.2,
         tis_importance_sampling_ratio_max=2.0,
         log_policy_entropy=False,
-        compute_policy_stats_fn=compute_policy_stats_fn,
     )
 
     assert loss == pytest.approx(-1.0)
@@ -351,61 +370,50 @@ def test_rloo_loss_skips_policy_entropy_when_metric_disabled():
     assert "policy_entropy" in metrics
 
 
-def test_rloo_loss_policy_entropy_does_not_request_reference_entropy():
+def test_rloo_loss_policy_entropy_uses_student_entropy_with_reference_kl():
     batch = create_test_training_batch()
     current_model = object()
     reference_model = object()
     current_logprobs = jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32)
     current_policy_entropy = jnp.array([[100.0, 0.25, 0.75]], dtype=jnp.float32)
-    calls = []
-
-    def compute_policy_stats_fn(model, _batch, _key, *, compute_entropy: bool):
-        calls.append((model, compute_entropy))
-        if model is reference_model:
-            assert not compute_entropy
-            return current_logprobs, None
-        assert model is current_model
-        assert compute_entropy
-        return current_logprobs, current_policy_entropy
 
     loss, metrics = rloo_loss_with_importance_sampling(
         model=current_model,
         reference_model=reference_model,
         batch=batch,
+        score_source=StaticScoreSource(
+            student_logprobs=current_logprobs,
+            student_entropy=current_policy_entropy,
+            reference_logprobs=current_logprobs,
+        ),
         key=None,
         kl=KLConfig(mode=KLMode.K3_LOSS, beta=0.1),
         clip_epsilon_low=0.2,
         clip_epsilon_high=0.2,
         tis_importance_sampling_ratio_max=2.0,
         log_policy_entropy=True,
-        compute_policy_stats_fn=compute_policy_stats_fn,
     )
 
     assert loss == pytest.approx(-1.0)
     assert metrics["current_policy_entropy"].value() == pytest.approx(0.5)
     assert metrics["kl_loss"].value() == pytest.approx(0.0)
-    assert calls == [(current_model, True), (reference_model, False)]
 
 
 def test_rloo_loss_rejects_missing_policy_entropy_when_metric_enabled():
     batch = create_test_training_batch()
 
-    def compute_policy_stats_fn(_model, _batch, _key, *, compute_entropy: bool):
-        assert compute_entropy
-        return jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32), None
-
-    with pytest.raises(ValueError, match="must return entropy"):
+    with pytest.raises(ValueError, match="must produce student entropy"):
         rloo_loss_with_importance_sampling(
             model=None,
             reference_model=None,
             batch=batch,
+            score_source=StaticScoreSource(student_logprobs=jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32)),
             key=None,
             kl=KLConfig(mode=KLMode.NONE, beta=0.0),
             clip_epsilon_low=0.2,
             clip_epsilon_high=0.2,
             tis_importance_sampling_ratio_max=2.0,
             log_policy_entropy=True,
-            compute_policy_stats_fn=compute_policy_stats_fn,
         )
 
 

--- a/tests/rl/test_loss.py
+++ b/tests/rl/test_loss.py
@@ -397,6 +397,8 @@ def test_rloo_loss_policy_entropy_uses_student_entropy_with_reference_kl():
     assert loss == pytest.approx(-1.0)
     assert metrics["current_policy_entropy"].value() == pytest.approx(0.5)
     assert metrics["kl_loss"].value() == pytest.approx(0.0)
+    assert metrics["scoring/student_pass_count"].value() == pytest.approx(1.0)
+    assert metrics["scoring/reference_pass_count"].value() == pytest.approx(1.0)
 
 
 def test_rloo_loss_rejects_missing_policy_entropy_when_metric_enabled():

--- a/tests/rl/test_objective_runtime.py
+++ b/tests/rl/test_objective_runtime.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass, replace
 import jax
 import numpy as np
 import pytest
-
 from marin.rl.objectives.recipes import make_rloo_objective
 from marin.rl.objectives.runtime import ObjectiveRuntimeConfig, build_objective_runtime
 from marin.rl.objectives.signals import compute_rloo_advantages_from_rewards

--- a/tests/rl/test_objective_runtime.py
+++ b/tests/rl/test_objective_runtime.py
@@ -1,14 +1,16 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import jax
 import numpy as np
+import pytest
 
 from marin.rl.objectives.recipes import make_rloo_objective
 from marin.rl.objectives.runtime import ObjectiveRuntimeConfig, build_objective_runtime
 from marin.rl.objectives.signals import compute_rloo_advantages_from_rewards
+from marin.rl.objectives.spec import BatchView
 from marin.rl.rl_losses import rloo_loss_with_importance_sampling
 from marin.rl.scoring import ScoreBundle, ScoreRequirements
 from marin.rl.train_batch import create_sequence_batch_from_rollouts, create_training_batch_from_rollouts
@@ -118,6 +120,13 @@ def test_build_objective_runtime_requires_reference_scores_for_kl_recipe():
         assert "reference_logprobs" in str(exc)
     else:
         raise AssertionError("expected build_objective_runtime to reject missing reference scores")
+
+
+def test_build_objective_runtime_rejects_group_batch_view_up_front():
+    objective = replace(make_rloo_objective(kl_coef=0.0), batch_view=BatchView.GROUP)
+
+    with pytest.raises(NotImplementedError, match="supports only sequence batches"):
+        build_objective_runtime(ObjectiveRuntimeConfig(objective=objective))
 
 
 def test_rloo_objective_runtime_matches_current_rloo_loss_path():

--- a/tests/rl/test_objective_runtime.py
+++ b/tests/rl/test_objective_runtime.py
@@ -1,0 +1,198 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+
+import jax
+import numpy as np
+
+from marin.rl.objectives.recipes import make_rloo_objective
+from marin.rl.objectives.runtime import ObjectiveRuntimeConfig, build_objective_runtime
+from marin.rl.objectives.signals import compute_rloo_advantages_from_rewards
+from marin.rl.rl_losses import rloo_loss_with_importance_sampling
+from marin.rl.scoring import ScoreBundle, ScoreRequirements
+from marin.rl.train_batch import create_sequence_batch_from_rollouts, create_training_batch_from_rollouts
+from marin.rl.types import Rollout, RolloutMetadata, RolloutWithAdvantage
+
+
+def create_test_rollout(
+    *,
+    group_id: str,
+    trace_id: str,
+    unique_id: int,
+    episode_reward: float,
+    is_truncated: bool = False,
+) -> Rollout:
+    prompt_tokens = np.full(3, unique_id, dtype=np.int32)
+    response_tokens = np.array([1000 + unique_id, 1001 + unique_id], dtype=np.int32)
+    response_logprobs = np.array([-0.7, -0.4], dtype=np.float32)
+    token_rewards = np.array([0.1, 0.2], dtype=np.float32)
+
+    return Rollout(
+        env_name="test_env",
+        env_example_id=f"example-{unique_id}",
+        prompt_tokens=prompt_tokens,
+        response_tokens=response_tokens,
+        response_logprobs=response_logprobs,
+        token_rewards=token_rewards,
+        episode_reward=episode_reward,
+        temperature=1.0,
+        top_k=16,
+        is_truncated=is_truncated,
+        metadata=RolloutMetadata(
+            worker_id="worker-1",
+            timestamp=111.0 + unique_id,
+            weight_step=9,
+            run_id="run-1",
+            lesson_id="lesson-a",
+            group_id=group_id,
+            trace_id=trace_id,
+            task_name="math",
+            task_version="v1",
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class StaticScoreSource:
+    score_requirements: ScoreRequirements
+    student_logprobs: jax.Array
+    behavior_logprobs: jax.Array | None = None
+    reference_logprobs: jax.Array | None = None
+    backend_name: str = "static"
+
+    def requirements(self) -> ScoreRequirements:
+        return self.score_requirements
+
+    def score(self, batch, info, roles, *, key):
+        del batch, info, roles, key
+        return ScoreBundle(
+            student_logprobs=self.student_logprobs,
+            behavior_logprobs=self.behavior_logprobs,
+            reference_logprobs=self.reference_logprobs,
+            student_pass_count=1 if self.student_logprobs is not None else 0,
+            reference_pass_count=1 if self.reference_logprobs is not None else 0,
+        )
+
+
+def _metric_values(metrics: dict[str, object], keys: tuple[str, ...]) -> dict[str, float]:
+    return {key: float(metrics[key]) for key in keys}
+
+
+def test_rloo_signal_builder_computes_groupwise_advantages_and_group_sizes():
+    rollouts = [
+        create_test_rollout(group_id="group-a", trace_id="trace-a", unique_id=1, episode_reward=0.0),
+        create_test_rollout(group_id="group-a", trace_id="trace-a", unique_id=2, episode_reward=1.0),
+        create_test_rollout(group_id="group-b", trace_id="trace-b", unique_id=3, episode_reward=0.5),
+    ]
+    sequence_batch, batch_info = create_sequence_batch_from_rollouts(rollouts, max_tokens=12, pad_token_id=0)
+
+    runtime = build_objective_runtime(
+        ObjectiveRuntimeConfig(
+            objective=make_rloo_objective(kl_coef=0.0),
+        )
+    )
+    prepared_batch = runtime.prepare_batch(sequence_batch, batch_info)
+
+    np.testing.assert_allclose(prepared_batch.signals.sequence_advantages.array[:2], np.array([-1.0, 1.0]))
+    np.testing.assert_allclose(prepared_batch.signals.sequence_advantages.array[2:], np.array([0.0]))
+    np.testing.assert_array_equal(prepared_batch.signals.group_size.array, np.array([2, 2, 1], dtype=np.int32))
+    np.testing.assert_allclose(
+        prepared_batch.signals.token_weights.array,
+        prepared_batch.sequence_batch.response_mask.array * prepared_batch.signals.sequence_advantages.array[:, None],
+    )
+
+
+def test_build_objective_runtime_requires_reference_scores_for_kl_recipe():
+    objective = make_rloo_objective(kl_coef=0.2)
+    sequence_runtime_config = ObjectiveRuntimeConfig(objective=objective)
+    bad_score_source = StaticScoreSource(
+        score_requirements=ScoreRequirements(student_logprobs=True, behavior_logprobs=True),
+        student_logprobs=jax.numpy.zeros((1, 1), dtype=jax.numpy.float32),
+        behavior_logprobs=jax.numpy.zeros((1, 1), dtype=jax.numpy.float32),
+    )
+
+    try:
+        build_objective_runtime(sequence_runtime_config, score_source=bad_score_source)
+    except ValueError as exc:
+        assert "reference_logprobs" in str(exc)
+    else:
+        raise AssertionError("expected build_objective_runtime to reject missing reference scores")
+
+
+def test_rloo_objective_runtime_matches_current_rloo_loss_path():
+    rollouts = [
+        create_test_rollout(group_id="group-a", trace_id="trace-a", unique_id=1, episode_reward=0.0),
+        create_test_rollout(group_id="group-a", trace_id="trace-a", unique_id=2, episode_reward=1.0),
+    ]
+    sequence_batch, batch_info = create_sequence_batch_from_rollouts(rollouts, max_tokens=12, pad_token_id=0)
+    advantages = compute_rloo_advantages_from_rewards(np.array([rollout.episode_reward for rollout in rollouts]))
+    training_batch = create_training_batch_from_rollouts(
+        [
+            RolloutWithAdvantage(rollout=rollout, advantage=float(advantage))
+            for rollout, advantage in zip(rollouts, advantages, strict=True)
+        ],
+        max_tokens=12,
+        pad_token_id=0,
+    )
+
+    behavior_logprobs = sequence_batch.behavior_logprobs.array
+    response_mask = sequence_batch.response_mask.array
+    student_logprobs = behavior_logprobs + 0.1 * response_mask
+    reference_logprobs = behavior_logprobs - 0.05 * response_mask
+    score_source = StaticScoreSource(
+        score_requirements=ScoreRequirements(
+            student_logprobs=True,
+            behavior_logprobs=True,
+            reference_logprobs=True,
+        ),
+        student_logprobs=student_logprobs,
+        behavior_logprobs=behavior_logprobs,
+        reference_logprobs=reference_logprobs,
+    )
+
+    runtime = build_objective_runtime(
+        ObjectiveRuntimeConfig(
+            objective=make_rloo_objective(kl_coef=0.2, do_trainer_inference_mismatch_importance_sampling=True)
+        ),
+        score_source=score_source,
+    )
+    prepared_batch = runtime.prepare_batch(sequence_batch, batch_info)
+    new_loss_fn = runtime.create_loss_fn(reference_model=object())
+    new_loss, new_metrics = new_loss_fn(object(), prepared_batch, key=None)
+
+    old_loss, old_metrics = rloo_loss_with_importance_sampling(
+        object(),
+        object(),
+        training_batch,
+        score_source,
+        key=None,
+        kl_coef=0.2,
+        clip_epsilon_low=0.2,
+        clip_epsilon_high=0.2,
+        tis_importance_sampling_ratio_max=2.0,
+        do_trainer_inference_mismatch_importance_sampling=True,
+        synchronous=False,
+        do_overlong_filtering=False,
+    )
+
+    np.testing.assert_allclose(new_loss, old_loss, atol=1e-6)
+    metric_keys = (
+        "ratio_mean",
+        "clipped_ratio_mean",
+        "clip_fraction",
+        "reinforce_loss",
+        "kl_loss",
+        "kl_penalty",
+        "trainer_inference_importance_sampling_ratio_mean",
+        "mean_advantages",
+        "current_entropy",
+        "policy_entropy",
+        "scoring/student_pass_count",
+        "scoring/reference_pass_count",
+    )
+    np.testing.assert_allclose(
+        list(_metric_values(new_metrics, metric_keys).values()),
+        list(_metric_values(old_metrics, metric_keys).values()),
+        atol=1e-6,
+    )

--- a/tests/rl/test_objective_runtime.py
+++ b/tests/rl/test_objective_runtime.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, replace
 import jax
 import numpy as np
 import pytest
+from marin.rl.decoding import DecodingConfig
 from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.objectives.recipes import make_rloo_objective
 from marin.rl.objectives.runtime import ObjectiveRuntimeConfig, build_objective_runtime
@@ -38,8 +39,7 @@ def create_test_rollout(
         response_logprobs=response_logprobs,
         token_rewards=token_rewards,
         episode_reward=episode_reward,
-        temperature=1.0,
-        top_k=16,
+        decoding=DecodingConfig(temperature=1.0, top_k=16).as_trace(),
         is_truncated=is_truncated,
         metadata=RolloutMetadata(
             worker_id="worker-1",

--- a/tests/rl/test_objective_runtime.py
+++ b/tests/rl/test_objective_runtime.py
@@ -116,12 +116,8 @@ def test_build_objective_runtime_requires_reference_scores_for_kl_recipe():
         behavior_logprobs=jax.numpy.zeros((1, 1), dtype=jax.numpy.float32),
     )
 
-    try:
+    with pytest.raises(ValueError, match="reference_logprobs"):
         build_objective_runtime(sequence_runtime_config, score_source=bad_score_source)
-    except ValueError as exc:
-        assert "reference_logprobs" in str(exc)
-    else:
-        raise AssertionError("expected build_objective_runtime to reject missing reference scores")
 
 
 def test_build_objective_runtime_rejects_group_batch_view_up_front():

--- a/tests/rl/test_objective_runtime.py
+++ b/tests/rl/test_objective_runtime.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, replace
 import jax
 import numpy as np
 import pytest
+from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.objectives.recipes import make_rloo_objective
 from marin.rl.objectives.runtime import ObjectiveRuntimeConfig, build_objective_runtime
 from marin.rl.objectives.signals import compute_rloo_advantages_from_rewards
@@ -58,6 +59,7 @@ def create_test_rollout(
 class StaticScoreSource:
     score_requirements: ScoreRequirements
     student_logprobs: jax.Array
+    student_entropy: jax.Array | None = None
     behavior_logprobs: jax.Array | None = None
     reference_logprobs: jax.Array | None = None
     backend_name: str = "static"
@@ -69,6 +71,7 @@ class StaticScoreSource:
         del batch, info, roles, key
         return ScoreBundle(
             student_logprobs=self.student_logprobs,
+            student_entropy=self.student_entropy,
             behavior_logprobs=self.behavior_logprobs,
             reference_logprobs=self.reference_logprobs,
             student_pass_count=1 if self.student_logprobs is not None else 0,
@@ -90,7 +93,7 @@ def test_rloo_signal_builder_computes_groupwise_advantages_and_group_sizes():
 
     runtime = build_objective_runtime(
         ObjectiveRuntimeConfig(
-            objective=make_rloo_objective(kl_coef=0.0),
+            objective=make_rloo_objective(kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
         )
     )
     prepared_batch = runtime.prepare_batch(sequence_batch, batch_info)
@@ -105,7 +108,7 @@ def test_rloo_signal_builder_computes_groupwise_advantages_and_group_sizes():
 
 
 def test_build_objective_runtime_requires_reference_scores_for_kl_recipe():
-    objective = make_rloo_objective(kl_coef=0.2)
+    objective = make_rloo_objective(kl=KLConfig(mode=KLMode.K3_LOSS, beta=0.2))
     sequence_runtime_config = ObjectiveRuntimeConfig(objective=objective)
     bad_score_source = StaticScoreSource(
         score_requirements=ScoreRequirements(student_logprobs=True, behavior_logprobs=True),
@@ -122,7 +125,7 @@ def test_build_objective_runtime_requires_reference_scores_for_kl_recipe():
 
 
 def test_build_objective_runtime_rejects_group_batch_view_up_front():
-    objective = replace(make_rloo_objective(kl_coef=0.0), batch_view=BatchView.GROUP)
+    objective = replace(make_rloo_objective(kl=KLConfig(mode=KLMode.NONE, beta=0.0)), batch_view=BatchView.GROUP)
 
     with pytest.raises(NotImplementedError, match="supports only sequence batches"):
         build_objective_runtime(ObjectiveRuntimeConfig(objective=objective))
@@ -161,7 +164,10 @@ def test_rloo_objective_runtime_matches_current_rloo_loss_path():
 
     runtime = build_objective_runtime(
         ObjectiveRuntimeConfig(
-            objective=make_rloo_objective(kl_coef=0.2, do_trainer_inference_mismatch_importance_sampling=True)
+            objective=make_rloo_objective(
+                kl=KLConfig(mode=KLMode.K3_LOSS, beta=0.2),
+                do_trainer_inference_mismatch_importance_sampling=True,
+            )
         ),
         score_source=score_source,
     )
@@ -175,7 +181,7 @@ def test_rloo_objective_runtime_matches_current_rloo_loss_path():
         training_batch,
         score_source,
         key=None,
-        kl_coef=0.2,
+        kl=KLConfig(mode=KLMode.K3_LOSS, beta=0.2),
         clip_epsilon_low=0.2,
         clip_epsilon_high=0.2,
         tis_importance_sampling_ratio_max=2.0,
@@ -191,6 +197,10 @@ def test_rloo_objective_runtime_matches_current_rloo_loss_path():
         "clip_fraction",
         "reinforce_loss",
         "kl_loss",
+        "kl_beta",
+        "kl_k1_mean",
+        "kl_k2_mean",
+        "kl_k3_mean",
         "kl_penalty",
         "trainer_inference_importance_sampling_ratio_mean",
         "mean_advantages",

--- a/tests/rl/test_replay_buffer.py
+++ b/tests/rl/test_replay_buffer.py
@@ -11,25 +11,46 @@ import pytest
 try:
     from marin.rl import train_batch
     from marin.rl.decoding import DecodingConfig
-    from marin.rl.kl_regularization import KLConfig, KLMode
-    from marin.rl.replay_buffer import ReplayBuffer, ReplayDataLoader
+    from marin.rl.replay_buffer import ReplayBuffer, ReplayDataLoader, StoredTrajectory
     from marin.rl.rl_losses import RLOOLoss
 except ImportError:
     pytest.skip("Post training imports unavailable", allow_module_level=True)
-from marin.rl.rollout_storage import (
-    InMemoryRolloutQueue,
-)
-from marin.rl.types import (
-    Rollout,
-    RolloutBatch,
-    RolloutGroup,
-    RolloutMetadata,
-)
+from marin.rl.rollout_storage import InMemoryRolloutQueue
+from marin.rl.types import Rollout, RolloutBatch, RolloutGroup, RolloutMetadata, RolloutWithAdvantage, TrajectoryRecord
 
 
-def rollouts_to_training_batch(rollouts, max_tokens=32, pad_token_id=0):
-    """Helper function to convert rollouts to training batch for testing."""
-    return train_batch.create_training_batch_from_rollouts(rollouts, max_tokens, pad_token_id)
+def _trajectory_key(trajectory: TrajectoryRecord) -> tuple[str, str, str]:
+    return (trajectory.group_id, trajectory.env_example_id, trajectory.trace_id)
+
+
+def sampled_trajectories_to_training_batch(
+    sampled_trajectories: list[StoredTrajectory],
+    max_tokens: int = 32,
+    pad_token_id: int = 0,
+) -> object:
+    """Build the current trainer-compatible batch from neutral replay samples."""
+    loss_module = RLOOLoss()
+    advantages_by_key: dict[tuple[str, str, str], float] = {}
+
+    seen_groups: set[str] = set()
+    for stored_trajectory in sampled_trajectories:
+        if stored_trajectory.group.group_id in seen_groups:
+            continue
+        seen_groups.add(stored_trajectory.group.group_id)
+        group_trajectories = stored_trajectory.group.trajectories
+        group_rollouts = [train_batch.trajectory_record_to_rollout(trajectory) for trajectory in group_trajectories]
+        advantages = loss_module.compute_advantages(group_rollouts)
+        for trajectory, advantage in zip(group_trajectories, advantages, strict=True):
+            advantages_by_key[_trajectory_key(trajectory)] = float(advantage)
+
+    rollouts_with_advantage = [
+        RolloutWithAdvantage(
+            rollout=train_batch.trajectory_record_to_rollout(stored_trajectory.trajectory),
+            advantage=advantages_by_key[_trajectory_key(stored_trajectory.trajectory)],
+        )
+        for stored_trajectory in sampled_trajectories
+    ]
+    return train_batch.create_training_batch_from_rollouts(rollouts_with_advantage, max_tokens, pad_token_id)
 
 
 def create_test_batch(
@@ -39,6 +60,7 @@ def create_test_batch(
     env_name: str | None = None,
     weight_step: int = 0,
     timestamp: float | None = None,
+    episode_rewards: list[float] | None = None,
 ) -> RolloutBatch:
     """Helper to create test batches with identifiable tokens for testing."""
     rng = np.random.default_rng(42 + idx)
@@ -47,30 +69,36 @@ def create_test_batch(
     if timestamp is None:
         timestamp = time.time()
 
-    # Create batch metadata
-    batch_metadata = RolloutMetadata(worker_id="test_worker", timestamp=timestamp, weight_step=weight_step)
+    batch_metadata = RolloutMetadata(
+        worker_id="test_worker",
+        timestamp=timestamp,
+        weight_step=weight_step,
+        lesson_id=f"lesson_{idx}",
+        group_id=f"group_{idx}",
+        trace_id=f"trace_{idx}",
+        task_name="test_task",
+        task_version="v1",
+    )
 
-    # Create individual rollouts with identifiable tokens
     rollouts = []
+    prompt_group_id = idx * 1000
+    prompt_len = max_seq_len // 2
+    response_len = max_seq_len - prompt_len
+    shared_prompt_tokens = np.full(prompt_len, prompt_group_id, dtype=np.int32)
+    shared_prompt_tokens[1:] = rng.integers(0, 1000, size=prompt_len - 1, dtype=np.int32)
     for i in range(batch_size):
-        # Split sequence into prompt and response
-        prompt_len = max_seq_len // 2
-        response_len = max_seq_len - prompt_len
-
-        # Create identifiable tokens - first token identifies the rollout
-        unique_id = idx * 1000 + i
-        prompt_tokens = np.full(prompt_len, unique_id, dtype=np.int32)
-        prompt_tokens[1:] = rng.integers(0, 1000, size=prompt_len - 1, dtype=np.int32)
-
         response_tokens = rng.integers(0, 1000, size=response_len, dtype=np.int32)
         response_logprobs = rng.standard_normal(response_len).astype(np.float32)
         token_rewards = rng.standard_normal(response_len).astype(np.float32)
-        episode_reward = float(rng.standard_normal())
+        if episode_rewards is None:
+            episode_reward = float(rng.standard_normal())
+        else:
+            episode_reward = episode_rewards[i]
 
         rollout = Rollout(
             env_name=env_name,
             env_example_id=f"example_{idx}_{i}",
-            prompt_tokens=prompt_tokens,
+            prompt_tokens=shared_prompt_tokens.copy(),
             response_tokens=response_tokens,
             response_logprobs=response_logprobs,
             token_rewards=token_rewards,
@@ -81,10 +109,7 @@ def create_test_batch(
         )
         rollouts.append(rollout)
 
-    # Group rollouts
     group = RolloutGroup(rollouts=rollouts)
-
-    # Create batch
     return RolloutBatch(groups=[group], metadata=batch_metadata)
 
 
@@ -94,7 +119,6 @@ def test_replay_buffer():
     writer = queue.writer()
     reader = queue.reader()
 
-    # Write batches with different environments
     for env in ["env1", "env2"]:
         for i in range(5):
             batch = create_test_batch(i, batch_size=2, max_seq_len=16, env_name=env)
@@ -109,45 +133,68 @@ def test_replay_buffer():
         max_rollout_step_delay=1000,
         max_rollout_timestamp_delay=3600.0,
         filter_out_groups_with_no_variance=False,
-        loss_module=RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
         seed=42,
     )
 
-    # Add batches to replay buffer
     batches = reader.read_all_available()
     replay_buffer.add_batches(batches)
 
-    # Test sampling
-    sampled_rollouts = replay_buffer.sample_rollouts()
-    assert sampled_rollouts is not None
-    assert len(sampled_rollouts) == 4
+    sampled_trajectories = replay_buffer.sample_sequences()
+    assert sampled_trajectories is not None
+    assert len(sampled_trajectories) == 4
+    assert not hasattr(sampled_trajectories[0], "advantage")
 
-    # Convert to training batch to verify format
-    training_batch = rollouts_to_training_batch(sampled_rollouts)
+    training_batch = sampled_trajectories_to_training_batch(sampled_trajectories)
     assert training_batch is not None
     assert training_batch.input_ids.shape == {"batch": 4, "position": 16}
 
-    # Test data loader
     data_loader = ReplayDataLoader(rollout_reader=reader, replay_buffer=replay_buffer, rollout_fetch_interval=0.1)
 
-    # Write more batches for data loader to collect
     for i in range(5, 10):
         batch = create_test_batch(i, batch_size=2, max_seq_len=16, env_name="env1")
         writer.write_batch(batch)
 
     with data_loader:
+        time.sleep(0.2)
+        trajectories = data_loader.get_trajectories(timeout=1.0)
+        assert trajectories is not None
+        assert len(trajectories) == 4
 
-        time.sleep(0.2)  # Let it collect some batches
-        rollouts = data_loader.get_rollouts(timeout=1.0)
-        assert rollouts is not None
+
+def test_replay_buffer_sample_groups_preserves_full_group_context():
+    replay_buffer = ReplayBuffer(
+        capacity=100,
+        local_batch_size=4,
+        alpha=2.0,
+        total_processes=1,
+        max_samples=-1,
+        max_rollout_step_delay=1000,
+        max_rollout_timestamp_delay=3600.0,
+        filter_out_groups_with_no_variance=False,
+        seed=42,
+    )
+
+    replay_buffer.add_batches(
+        [
+            create_test_batch(0, batch_size=2, max_seq_len=16, env_name="env1"),
+            create_test_batch(1, batch_size=2, max_seq_len=16, env_name="env1"),
+            create_test_batch(2, batch_size=2, max_seq_len=16, env_name="env2"),
+        ]
+    )
+
+    groups = replay_buffer.sample_groups()
+    assert groups is not None
+    assert sum(len(group.trajectories) for group in groups) >= 4
+    assert all(len(group.trajectories) == 2 for group in groups)
+    assert all(group.group_id for group in groups)
+    assert all(group.lesson_id.startswith("lesson_") for group in groups)
 
 
 def test_replay_buffer_recency_bias():
     """Test that high recency bias strongly favors recent (higher index) samples."""
-    # Create a batch with 100 rollouts across multiple groups for better testing
     batches = []
     rollouts_per_batch = 10
-    for batch_idx in range(10):  # 10 batches * 10 rollouts each = 100 total
+    for batch_idx in range(10):
         batch = create_test_batch(batch_idx, batch_size=rollouts_per_batch, max_seq_len=16, env_name="test_env")
         batches.append(batch)
 
@@ -160,26 +207,19 @@ def test_replay_buffer_recency_bias():
         max_rollout_step_delay=1000,
         max_rollout_timestamp_delay=3600.0,
         filter_out_groups_with_no_variance=False,
-        loss_module=RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
         seed=42,
     )
     replay_buffer.add_batches(batches)
 
-    # Sample many times to see distribution
     all_samples = []
     for _ in range(100):
-        sample = replay_buffer.sample_rollouts()
+        sample = replay_buffer.sample_sequences()
         if sample is not None:
-            # Extract the identifiable tokens from the first prompt token of each rollout
-            batch_indices = [int(rollout.rollout.prompt_tokens[0]) // 1000 for rollout in sample]
+            batch_indices = [int(stored.trajectory.prompt_tokens[0]) // 1000 for stored in sample]
             all_samples.extend(batch_indices)
 
-    # With strong recency bias, we should heavily favor high batch indices (later batches)
-    # Split indices into low (0-4) and high (5-9) batch ranges
     low_indices = [idx for idx in all_samples if idx < 5]
     high_indices = [idx for idx in all_samples if idx >= 5]
-
-    # High indices should be much more frequent than low indices
     assert len(high_indices) > len(
         low_indices
     ), f"Expected high indices to be more frequent, got {len(high_indices)} high vs {len(low_indices)} low"
@@ -196,21 +236,52 @@ def test_replay_buffer_capacity_eviction():
         max_rollout_step_delay=1000,
         max_rollout_timestamp_delay=3600.0,
         filter_out_groups_with_no_variance=False,
-        loss_module=RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
         seed=42,
     )
 
     for i in range(5):
-        batch = create_test_batch(i, batch_size=2, max_seq_len=16, env_name="test_env")
-        replay_buffer.add_batches([batch])
+        replay_buffer.add_batches([create_test_batch(i, batch_size=2, max_seq_len=16, env_name="test_env")])
 
     stats = replay_buffer.get_stats()
-    assert stats["total_size"] == 3  # Should be capped at capacity
+    assert stats["total_size"] == 3
     assert stats["env_sizes"]["test_env"] == 3
     assert stats["total_batches_added"] == 5
 
-    # Verify most recent data is kept (batches 2, 3, 4 should remain)
-    # This is hard to test directly without exposing internals, but capacity enforcement is verified
+
+def test_replay_buffer_capacity_eviction_removes_evicted_group_members_from_advantages():
+    replay_buffer = ReplayBuffer(
+        capacity=3,
+        local_batch_size=1,
+        alpha=1.0,
+        total_processes=1,
+        max_samples=-1,
+        max_rollout_step_delay=1000,
+        max_rollout_timestamp_delay=3600.0,
+        filter_out_groups_with_no_variance=False,
+        seed=42,
+    )
+
+    replay_buffer.add_batches(
+        [
+            create_test_batch(0, batch_size=2, max_seq_len=16, env_name="test_env", episode_rewards=[1.0, 3.0]),
+            create_test_batch(1, batch_size=2, max_seq_len=16, env_name="test_env", episode_rewards=[0.0, 0.0]),
+        ]
+    )
+
+    surviving_group_zero = [
+        stored_trajectory
+        for stored_trajectory in replay_buffer.rollout_storage["test_env"]
+        if stored_trajectory.group_id == "group_0"
+    ]
+    assert len(surviving_group_zero) == 1
+
+    training_batch = sampled_trajectories_to_training_batch(surviving_group_zero, max_tokens=16, pad_token_id=0)
+
+    assert len(surviving_group_zero[0].group.trajectories) == 1
+    np.testing.assert_array_equal(
+        training_batch.loss_weights.array[0],
+        np.zeros_like(training_batch.loss_weights.array[0]),
+    )
 
 
 def test_replay_buffer_max_resamples():
@@ -224,32 +295,23 @@ def test_replay_buffer_max_resamples():
         max_rollout_step_delay=1000,
         max_rollout_timestamp_delay=3600.0,
         filter_out_groups_with_no_variance=False,
-        loss_module=RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
         seed=42,
     )
 
-    # Create batch with identifiable examples (already has identifiable tokens)
-    batch = create_test_batch(0, batch_size=4, max_seq_len=16, env_name="test_env")
+    replay_buffer.add_batches([create_test_batch(0, batch_size=4, max_seq_len=16, env_name="test_env")])
 
-    replay_buffer.add_batches([batch])
-
-    # Initial size should be 4
     assert replay_buffer.size() == 4
 
-    # Sample multiple times - with batch size 2, we expect examples to be used multiple times
     samples_taken = 0
-    max_iterations = 20
-
-    for _ in range(max_iterations):
-        sample = replay_buffer.sample_rollouts()
+    for _ in range(20):
+        sample = replay_buffer.sample_sequences()
         if sample is None:
             break
         samples_taken += 1
 
-    # Should have retired all examples due to max_resamples
     final_size = replay_buffer.size()
     assert final_size == 0, f"Expected buffer to shrink due to max_resamples, but size remained {final_size}"
-    assert samples_taken > 4, "Should have been able to sample multiple times before retirement"
+    assert samples_taken > 4
 
 
 def test_replay_buffer_max_resamples_disabled():
@@ -263,28 +325,18 @@ def test_replay_buffer_max_resamples_disabled():
         max_rollout_step_delay=1000,
         max_rollout_timestamp_delay=3600.0,
         filter_out_groups_with_no_variance=False,
-        loss_module=RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
         seed=42,
     )
 
-    # Add small batch
-    batch = create_test_batch(0, batch_size=3, max_seq_len=16, env_name="test_env")
-    replay_buffer.add_batches([batch])
-
+    replay_buffer.add_batches([create_test_batch(0, batch_size=3, max_seq_len=16, env_name="test_env")])
     initial_size = replay_buffer.size()
     assert initial_size == 3
 
-    # Sample many times - examples should never be retired
     for _ in range(50):
-        sample = replay_buffer.sample_rollouts()
+        sample = replay_buffer.sample_sequences()
         assert sample is not None
-        assert len(sample) == 2  # batch_size
-
-        # Size should remain constant
-        current_size = replay_buffer.size()
-        assert (
-            current_size == initial_size
-        ), f"Buffer size changed from {initial_size} to {current_size} with disabled max_resamples"
+        assert len(sample) == 2
+        assert replay_buffer.size() == initial_size
 
 
 def test_replay_buffer_max_resamples_multiple_envs():
@@ -298,35 +350,27 @@ def test_replay_buffer_max_resamples_multiple_envs():
         max_rollout_step_delay=1000,
         max_rollout_timestamp_delay=3600.0,
         filter_out_groups_with_no_variance=False,
-        loss_module=RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
         seed=42,
     )
 
-    # Add batches from different environments (identifiable tokens already set)
     for env_id in range(2):
         env_name = f"env_{env_id}"
-        batch = create_test_batch(env_id, batch_size=3, max_seq_len=16, env_name=env_name)
-        replay_buffer.add_batches([batch])
+        replay_buffer.add_batches([create_test_batch(env_id, batch_size=3, max_seq_len=16, env_name=env_name)])
 
     initial_stats = replay_buffer.get_stats()
     assert initial_stats["total_size"] == 6
     assert initial_stats["num_environments"] == 2
 
-    # Sample multiple times
     for _ in range(15):
-        sample = replay_buffer.sample_rollouts()
+        sample = replay_buffer.sample_sequences()
         if sample is None:
             break
 
-    # Both environments should still exist but may have fewer examples
     final_stats = replay_buffer.get_stats()
     assert final_stats["num_environments"] == 2
-    assert final_stats["total_size"] < 6, "Expected some examples to be retired"
-
-    # Each environment should have at least some examples remaining
+    assert final_stats["total_size"] < 6
     for env_name in ["env_0", "env_1"]:
         assert env_name in final_stats["env_sizes"]
-        # Due to balanced sampling, both environments should have some data
 
 
 def test_replay_buffer_weight_step_filtering():
@@ -339,54 +383,39 @@ def test_replay_buffer_weight_step_filtering():
         max_rollout_step_delay=30,
         max_rollout_timestamp_delay=3600.0,
         filter_out_groups_with_no_variance=False,
-        loss_module=RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
         seed=42,
     )
 
-    # Create batches with weight_steps 50, 100, 150
     for weight_step in [50, 100, 150]:
-        batch = create_test_batch(
-            weight_step, batch_size=4, max_seq_len=16, env_name="test_env", weight_step=weight_step
+        replay_buffer.add_batches(
+            [create_test_batch(weight_step, batch_size=4, max_seq_len=16, env_name="test_env", weight_step=weight_step)]
         )
-        replay_buffer.add_batches([batch])
 
-    # All batches rejected at ingestion since current_step=0, acceptable range [-30, 0]
-    # Future rollouts (50, 100, 150 > 0) are rejected
     assert replay_buffer.size() == 0
 
-    # Set current step to 100, acceptable range [70, 100]
-    # Add batches again - only weight_step=100 should be accepted at ingestion
     replay_buffer.set_current_step(100)
     for weight_step in [50, 100, 150]:
-        batch = create_test_batch(
-            weight_step, batch_size=4, max_seq_len=16, env_name="test_env", weight_step=weight_step
+        replay_buffer.add_batches(
+            [create_test_batch(weight_step, batch_size=4, max_seq_len=16, env_name="test_env", weight_step=weight_step)]
         )
-        replay_buffer.add_batches([batch])
 
-    assert replay_buffer.size() == 4  # Only weight_step=100
+    assert replay_buffer.size() == 4
 
-    # Add batch with weight_step=95 (within range [70, 100])
     batch_95 = create_test_batch(95, batch_size=3, max_seq_len=16, env_name="test_env", weight_step=95)
     replay_buffer.add_batches([batch_95])
     assert replay_buffer.size() == 7
 
-    # Set current step to 150, acceptable range [120, 150]
-    # Should filter out weight_step=100 and weight_step=95 (too old)
     replay_buffer.set_current_step(150)
     assert replay_buffer.size() == 0
 
-    # Add new batch with weight_step=150 (at upper bound)
     new_batch = create_test_batch(150, batch_size=2, max_seq_len=16, env_name="test_env", weight_step=150)
     replay_buffer.add_batches([new_batch])
     assert replay_buffer.size() == 2
 
-    # Add batch with weight_step=130 (within range [120, 150])
     batch_130 = create_test_batch(130, batch_size=3, max_seq_len=16, env_name="test_env", weight_step=130)
     replay_buffer.add_batches([batch_130])
     assert replay_buffer.size() == 5
 
-    # Set current step to 160, acceptable range [130, 160]
-    # Should filter out nothing (both 130 and 150 are within range)
     replay_buffer.set_current_step(160)
     assert replay_buffer.size() == 5
 
@@ -402,42 +431,32 @@ def test_replay_buffer_rollout_delay_progressive():
         max_rollout_step_delay=10,
         max_rollout_timestamp_delay=3600.0,
         filter_out_groups_with_no_variance=False,
-        loss_module=RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
         seed=42,
     )
 
-    # Set current step to 15, acceptable range [5, 15]
     replay_buffer.set_current_step(15)
 
-    # Add batches at steps 5, 10, 15 (all within acceptable range)
     for step in [5, 10, 15]:
-        batch = create_test_batch(step, batch_size=2, max_seq_len=16, env_name="test_env", weight_step=step)
-        replay_buffer.add_batches([batch])
+        replay_buffer.add_batches(
+            [create_test_batch(step, batch_size=2, max_seq_len=16, env_name="test_env", weight_step=step)]
+        )
 
     assert replay_buffer.size() == 6
 
-    # Try to add a stale batch (step 3 < min_step=5), should be rejected
-    stale_batch = create_test_batch(3, batch_size=2, max_seq_len=16, env_name="test_env", weight_step=3)
-    replay_buffer.add_batches([stale_batch])
-    assert replay_buffer.size() == 6  # Size unchanged
+    replay_buffer.add_batches([create_test_batch(3, batch_size=2, max_seq_len=16, env_name="test_env", weight_step=3)])
+    assert replay_buffer.size() == 6
 
-    # Try to add a future batch (step 20 > current_step=15), should be rejected
-    future_batch = create_test_batch(20, batch_size=2, max_seq_len=16, env_name="test_env", weight_step=20)
-    replay_buffer.add_batches([future_batch])
-    assert replay_buffer.size() == 6  # Size unchanged
+    replay_buffer.add_batches([create_test_batch(20, batch_size=2, max_seq_len=16, env_name="test_env", weight_step=20)])
+    assert replay_buffer.size() == 6
 
-    # Add a fresh batch (step 14 in range [5, 15]), should be accepted
     fresh_batch = create_test_batch(14, batch_size=3, max_seq_len=16, env_name="test_env", weight_step=14)
     replay_buffer.add_batches([fresh_batch])
     assert replay_buffer.size() == 9
 
-    # Advance to step 20, acceptable range [10, 20]
-    # Should filter out step 5 (too old), keep steps 10, 14, 15
     replay_buffer.set_current_step(20)
     assert replay_buffer.size() == 7
 
-    # Verify we can still sample from remaining data
-    sample = replay_buffer.sample_rollouts()
+    sample = replay_buffer.sample_sequences()
     assert sample is not None
     assert len(sample) == 2
 
@@ -453,25 +472,20 @@ def test_is_rollout_fresh():
         max_rollout_step_delay=10,
         max_rollout_timestamp_delay=100.0,
         filter_out_groups_with_no_variance=False,
-        loss_module=RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
         seed=42,
     )
 
     current_step = 100
     current_time = time.time()
 
-    # Fresh rollout: within step window [90, 100] and timestamp limits
     assert replay_buffer._is_rollout_fresh(90, current_time - 50, current_step, current_time)
     assert replay_buffer._is_rollout_fresh(95, current_time - 50, current_step, current_time)
     assert replay_buffer._is_rollout_fresh(100, current_time - 50, current_step, current_time)
 
-    # Too old: weight_step < min_step (100 - 10 = 90)
     assert not replay_buffer._is_rollout_fresh(89, current_time - 50, current_step, current_time)
 
-    # Future rollout: weight_step > current_step
     assert not replay_buffer._is_rollout_fresh(101, current_time - 50, current_step, current_time)
     assert not replay_buffer._is_rollout_fresh(105, current_time - 50, current_step, current_time)
     assert not replay_buffer._is_rollout_fresh(111, current_time - 50, current_step, current_time)
 
-    # Stale timestamp
     assert not replay_buffer._is_rollout_fresh(95, current_time - 200, current_step, current_time)

--- a/tests/rl/test_replay_buffer.py
+++ b/tests/rl/test_replay_buffer.py
@@ -187,8 +187,14 @@ def test_replay_buffer_sample_groups_preserves_full_group_context():
     assert groups is not None
     assert sum(len(group.trajectories) for group in groups) >= 4
     assert all(len(group.trajectories) == 2 for group in groups)
-    assert all(group.group_id for group in groups)
-    assert all(group.lesson_id.startswith("lesson_") for group in groups)
+    assert {group.group_id for group in groups} <= {"group_0", "group_1", "group_2"}
+    for group in groups:
+        assert group.lesson_id == group.group_id.replace("group_", "lesson_")
+        assert {trajectory.group_id for trajectory in group.trajectories} == {group.group_id}
+        assert {trajectory.rollout_metadata.group_id for trajectory in group.trajectories} == {group.group_id}
+        assert {trajectory.rollout_metadata.trace_id for trajectory in group.trajectories} == {
+            group.group_id.replace("group_", "trace_")
+        }
 
 
 def test_replay_buffer_recency_bias():

--- a/tests/rl/test_replay_buffer.py
+++ b/tests/rl/test_replay_buffer.py
@@ -11,6 +11,7 @@ import pytest
 try:
     from marin.rl import train_batch
     from marin.rl.decoding import DecodingConfig
+    from marin.rl.kl_regularization import KLConfig, KLMode
     from marin.rl.replay_buffer import ReplayBuffer, ReplayDataLoader, StoredTrajectory
     from marin.rl.rl_losses import RLOOLoss
 except ImportError:
@@ -29,7 +30,7 @@ def sampled_trajectories_to_training_batch(
     pad_token_id: int = 0,
 ) -> object:
     """Build the current trainer-compatible batch from neutral replay samples."""
-    loss_module = RLOOLoss()
+    loss_module = RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0))
     advantages_by_key: dict[tuple[str, str, str], float] = {}
 
     seen_groups: set[str] = set()

--- a/tests/rl/test_rl_experiment_utils.py
+++ b/tests/rl/test_rl_experiment_utils.py
@@ -9,8 +9,8 @@ from levanter.models.llama import LlamaConfig
 from marin.execution.artifact import Artifact
 from marin.execution.lazy import ArtifactStep, materialized_config
 from marin.rl.curriculum import CurriculumConfig
-from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.model_utils import is_hf_checkpoint
+from marin.rl.objectives import make_rloo_objective
 from marin.rl.rl_experiment_utils import (
     ModelConfig,
     RLExperimentConfig,
@@ -22,7 +22,6 @@ from marin.rl.rl_experiment_utils import (
     launcher_region_for_rl_experiment,
     make_rl_step,
 )
-from marin.rl.rl_losses import RLOOLoss
 from marin.training.training import LevanterCheckpoint
 
 MODEL_NAME = "meta-llama/Llama-3.1-8B-Instruct"
@@ -65,16 +64,16 @@ def _test_config(
             artifact=MODEL_NAME,
             config_class_path=config_class_path(LlamaConfig),
         ),
-        rl_loss=RLOOLoss(
-            kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+        objective=make_rloo_objective(
+            kl_coef=0.0,
             clip_epsilon_low=0.2,
             clip_epsilon_high=0.28,
             synchronous=True,
             do_trainer_inference_mismatch_importance_sampling=True,
             tis_importance_sampling_ratio_max=2.0,
             do_overlong_filtering=True,
-            vocab_tile_size=32064,
         ),
+        scorer_vocab_tile_size=32064,
         experiment_name_suffix="test",
         train_tpu_type=train_tpu_type,
         inference_tpu_type=inference_tpu_type,

--- a/tests/rl/test_rl_experiment_utils.py
+++ b/tests/rl/test_rl_experiment_utils.py
@@ -9,6 +9,7 @@ from levanter.models.llama import LlamaConfig
 from marin.execution.artifact import Artifact
 from marin.execution.lazy import ArtifactStep, materialized_config
 from marin.rl.curriculum import CurriculumConfig
+from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.model_utils import is_hf_checkpoint
 from marin.rl.objectives import make_rloo_objective
 from marin.rl.rl_experiment_utils import (
@@ -65,7 +66,7 @@ def _test_config(
             config_class_path=config_class_path(LlamaConfig),
         ),
         objective=make_rloo_objective(
-            kl_coef=0.0,
+            kl=KLConfig(mode=KLMode.NONE, beta=0.0),
             clip_epsilon_low=0.2,
             clip_epsilon_high=0.28,
             synchronous=True,

--- a/tests/rl/test_rollout_storage.py
+++ b/tests/rl/test_rollout_storage.py
@@ -68,6 +68,7 @@ def create_test_rollout_group(key: str, n_rollouts: int, start_idx: int = 0) -> 
             task_version="v1",
             verifier_name="test_verifier",
             verifier_version="v1",
+            trace_ref=f"trace://{key}",
         ),
     )
 
@@ -82,6 +83,10 @@ def create_test_rollout_batch(idx: int, n_groups: int = 2, rollouts_per_group: i
 
     metadata = RolloutMetadata(worker_id=f"worker_{idx}", timestamp=time.time(), weight_step=0)
     return RolloutBatch(groups=groups, metadata=metadata)
+
+
+def assert_group_metadata_round_trips(read_back: RolloutGroup, original: RolloutGroup) -> None:
+    assert read_back.metadata == original.metadata
 
 
 @pytest.fixture(params=["memory", "file"])
@@ -115,10 +120,11 @@ def test_storage_operations(storage_config):
     assert len(read_batches) == 3
 
     # Verify content
-    for original, read_back in zip(test_batches, read_batches, strict=False):
+    for original, read_back in zip(test_batches, read_batches, strict=True):
         assert len(read_back.groups) == len(original.groups)
         assert read_back.metadata.worker_id == original.metadata.worker_id
-        assert read_back.groups[0].metadata.group_id == original.groups[0].metadata.group_id
+        for read_group, original_group in zip(read_back.groups, original.groups, strict=True):
+            assert_group_metadata_round_trips(read_group, original_group)
 
         # Check first rollout of first group
         orig_rollout = original.groups[0].rollouts[0]
@@ -174,4 +180,5 @@ def test_large_rollout_batch():
     assert read_batch is not None
     assert len(read_batch.groups) == 10
     assert len(read_batch.groups[0].rollouts) == 20
-    assert read_batch.groups[0].metadata.group_id == batch.groups[0].metadata.group_id
+    for read_group, original_group in zip(read_batch.groups, batch.groups, strict=True):
+        assert_group_metadata_round_trips(read_group, original_group)

--- a/tests/rl/test_rollout_storage.py
+++ b/tests/rl/test_rollout_storage.py
@@ -18,6 +18,7 @@ from marin.rl.types import (
     Rollout,
     RolloutBatch,
     RolloutGroup,
+    RolloutGroupMetadata,
     RolloutMetadata,
 )
 
@@ -57,7 +58,18 @@ def create_test_rollout(idx: int) -> Rollout:
 def create_test_rollout_group(key: str, n_rollouts: int, start_idx: int = 0) -> RolloutGroup:
     """Create a test rollout group."""
     rollouts = [create_test_rollout(start_idx + i) for i in range(n_rollouts)]
-    return RolloutGroup(rollouts=rollouts)
+    return RolloutGroup(
+        rollouts=rollouts,
+        metadata=RolloutGroupMetadata(
+            group_id=key,
+            lesson_id="lesson",
+            trace_id=f"trace-{key}",
+            task_name="test_task",
+            task_version="v1",
+            verifier_name="test_verifier",
+            verifier_version="v1",
+        ),
+    )
 
 
 def create_test_rollout_batch(idx: int, n_groups: int = 2, rollouts_per_group: int = 3) -> RolloutBatch:
@@ -106,6 +118,7 @@ def test_storage_operations(storage_config):
     for original, read_back in zip(test_batches, read_batches, strict=False):
         assert len(read_back.groups) == len(original.groups)
         assert read_back.metadata.worker_id == original.metadata.worker_id
+        assert read_back.groups[0].metadata.group_id == original.groups[0].metadata.group_id
 
         # Check first rollout of first group
         orig_rollout = original.groups[0].rollouts[0]
@@ -161,3 +174,4 @@ def test_large_rollout_batch():
     assert read_batch is not None
     assert len(read_batch.groups) == 10
     assert len(read_batch.groups[0].rollouts) == 20
+    assert read_batch.groups[0].metadata.group_id == batch.groups[0].metadata.group_id

--- a/tests/rl/test_rollout_worker.py
+++ b/tests/rl/test_rollout_worker.py
@@ -5,13 +5,16 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import fsspec
+import numpy as np
 import pytest
+from marin.rl.decoding import DecodingConfig, SamplingParams
 from marin.rl.environments.inference_ctx.staging import stage_vllm_metadata_locally
 from marin.rl.environments.inference_ctx.vllm import (
     VLLMEngineConfig,
     VLLMFallbackSamplingConfig,
     vLLMInferenceContextConfig,
 )
+from marin.rl.environments.spec import EnvironmentIdentity, EnvironmentSample
 from marin.rl.rollout_worker import (
     RolloutTracker,
     RolloutTrackerConfig,
@@ -22,6 +25,8 @@ from marin.rl.rollout_worker import (
     create_inference_context,
 )
 from marin.rl.run_state import RolloutTransferCounters
+from marin.rl.traces import EpisodeResponseTrace, EpisodeTrace
+from marin.rl.types import Rollout, RolloutGroup
 
 
 def test_rollout_tracker_uses_explicit_name_when_provided(monkeypatch):
@@ -192,6 +197,83 @@ def test_log_lesson_eval_uses_wandb_default_step_and_context_metrics():
             None,
         )
     ]
+
+
+def test_sample_batch_attaches_trace_and_verifier_metadata():
+    rollout = Rollout(
+        env_name="mock_env:cats",
+        env_example_id="example-1",
+        prompt_tokens=np.array([1, 2, 3], dtype=np.int32),
+        response_tokens=np.array([4, 5], dtype=np.int32),
+        response_logprobs=np.array([-0.1, -0.2], dtype=np.float32),
+        token_rewards=np.array([1.0, 1.0], dtype=np.float32),
+        episode_reward=1.0,
+        decoding=DecodingConfig(temperature=0.7, top_k=5, max_output_tokens=32).as_trace(),
+        is_truncated=False,
+    )
+    sample = EnvironmentSample(
+        rollout_groups=[RolloutGroup(rollouts=[rollout])],
+        traces=[
+            EpisodeTrace(
+                env_name="mock_env:cats",
+                env_example_id="example-1",
+                prompt="prompt",
+                responses=(EpisodeResponseTrace(response_text="response", reward=1.0),),
+                task_name="mock_env:cats",
+                task_version="v1",
+                verifier_name="mock_env.reward",
+                verifier_version="v1",
+            )
+        ],
+        identity=EnvironmentIdentity(
+            task_name="mock_env:cats",
+            task_version="v1",
+            verifier_name="mock_env.reward",
+            verifier_version="v1",
+        ),
+    )
+
+    class _FakeEnv:
+        def sample(self, **_kwargs):
+            return sample
+
+    worker = object.__new__(RolloutWorker)
+    worker._load_environment = lambda _lesson_id: _FakeEnv()
+    worker._policy_ctx = object()
+    worker._current_weight_step = 42
+    worker.config = SimpleNamespace(
+        run_id="run-123",
+        system_prompt=None,
+        curriculum_config=SimpleNamespace(
+            lessons={
+                "lesson-a": SimpleNamespace(
+                    sampling_params=SamplingParams(
+                        train_decoding=DecodingConfig(
+                            temperature=0.7,
+                            top_k=5,
+                            max_output_tokens=32,
+                        )
+                    )
+                )
+            }
+        ),
+    )
+
+    batch, metrics = worker._sample_batch("lesson-a", 1, 1, "train", rng=None)
+
+    assert batch is not None
+    assert metrics == {}
+    assert batch.metadata.run_id == "run-123"
+    assert batch.metadata.lesson_id == "lesson-a"
+    assert batch.metadata.task_name == "mock_env:cats"
+    assert batch.metadata.verifier_name == "mock_env.reward"
+    assert batch.groups[0].metadata.lesson_id == "lesson-a"
+    assert batch.groups[0].metadata.group_id
+    assert batch.groups[0].metadata.trace_id
+    assert batch.groups[0].rollouts[0].metadata.group_id == batch.groups[0].metadata.group_id
+    assert batch.groups[0].rollouts[0].metadata.trace_id == batch.groups[0].metadata.trace_id
+    assert batch.groups[0].rollouts[0].metadata.task_name == "mock_env:cats"
+    assert batch.groups[0].rollouts[0].metadata.verifier_name == "mock_env.reward"
 
 
 def test_stage_vllm_metadata_locally_copies_hf_metadata(tmp_path, monkeypatch):

--- a/tests/rl/test_rollout_worker.py
+++ b/tests/rl/test_rollout_worker.py
@@ -223,6 +223,9 @@ def test_sample_batch_attaches_trace_and_verifier_metadata():
                 task_version="v1",
                 verifier_name="mock_env.reward",
                 verifier_version="v1",
+                group_id="trace-group-1",
+                trace_id="trace-id-1",
+                trace_ref="trace://mock-env/example-1",
             )
         ],
         identity=EnvironmentIdentity(
@@ -231,6 +234,7 @@ def test_sample_batch_attaches_trace_and_verifier_metadata():
             verifier_name="mock_env.reward",
             verifier_version="v1",
         ),
+        metrics={"mock_env/rollouts": 1},
     )
 
     class _FakeEnv:
@@ -262,16 +266,18 @@ def test_sample_batch_attaches_trace_and_verifier_metadata():
     batch, metrics = worker._sample_batch("lesson-a", 1, 1, "train", rng=None)
 
     assert batch is not None
-    assert metrics == {}
+    assert metrics == {"mock_env/rollouts": 1}
     assert batch.metadata.run_id == "run-123"
     assert batch.metadata.lesson_id == "lesson-a"
     assert batch.metadata.task_name == "mock_env:cats"
     assert batch.metadata.verifier_name == "mock_env.reward"
     assert batch.groups[0].metadata.lesson_id == "lesson-a"
-    assert batch.groups[0].metadata.group_id
-    assert batch.groups[0].metadata.trace_id
+    assert batch.groups[0].metadata.group_id == "trace-group-1"
+    assert batch.groups[0].metadata.trace_id == "trace-id-1"
+    assert batch.groups[0].metadata.trace_ref == "trace://mock-env/example-1"
     assert batch.groups[0].rollouts[0].metadata.group_id == batch.groups[0].metadata.group_id
     assert batch.groups[0].rollouts[0].metadata.trace_id == batch.groups[0].metadata.trace_id
+    assert batch.groups[0].rollouts[0].metadata.trace_ref == batch.groups[0].metadata.trace_ref
     assert batch.groups[0].rollouts[0].metadata.task_name == "mock_env:cats"
     assert batch.groups[0].rollouts[0].metadata.verifier_name == "mock_env.reward"
 

--- a/tests/rl/test_rollout_worker.py
+++ b/tests/rl/test_rollout_worker.py
@@ -291,8 +291,7 @@ def test_sample_batch_generates_unique_fallback_group_ids_across_calls():
         response_logprobs=np.array([-0.1, -0.2], dtype=np.float32),
         token_rewards=np.array([1.0, 1.0], dtype=np.float32),
         episode_reward=1.0,
-        temperature=0.7,
-        top_k=5,
+        decoding=DecodingConfig(temperature=0.7, top_k=5, max_output_tokens=32).as_trace(),
         is_truncated=False,
     )
     sample = EnvironmentSample(
@@ -327,11 +326,12 @@ def test_sample_batch_generates_unique_fallback_group_ids_across_calls():
         curriculum_config=SimpleNamespace(
             lessons={
                 "lesson-a": SimpleNamespace(
-                    sampling_params=SimpleNamespace(
-                        temperature=0.7,
-                        top_k=5,
-                        stop_tokens=None,
-                        max_output_tokens=32,
+                    sampling_params=SamplingParams(
+                        train_decoding=DecodingConfig(
+                            temperature=0.7,
+                            top_k=5,
+                            max_output_tokens=32,
+                        )
                     )
                 )
             }

--- a/tests/rl/test_rollout_worker.py
+++ b/tests/rl/test_rollout_worker.py
@@ -282,6 +282,73 @@ def test_sample_batch_attaches_trace_and_verifier_metadata():
     assert batch.groups[0].rollouts[0].metadata.verifier_name == "mock_env.reward"
 
 
+def test_sample_batch_generates_unique_fallback_group_ids_across_calls():
+    rollout = Rollout(
+        env_name="mock_env:cats",
+        env_example_id="example-1",
+        prompt_tokens=np.array([1, 2, 3], dtype=np.int32),
+        response_tokens=np.array([4, 5], dtype=np.int32),
+        response_logprobs=np.array([-0.1, -0.2], dtype=np.float32),
+        token_rewards=np.array([1.0, 1.0], dtype=np.float32),
+        episode_reward=1.0,
+        temperature=0.7,
+        top_k=5,
+        is_truncated=False,
+    )
+    sample = EnvironmentSample(
+        rollout_groups=[RolloutGroup(rollouts=[rollout])],
+        traces=[
+            EpisodeTrace(
+                env_name="mock_env:cats",
+                env_example_id="example-1",
+                prompt="prompt",
+                responses=(EpisodeResponseTrace(response_text="response", reward=1.0),),
+            )
+        ],
+        identity=EnvironmentIdentity(
+            task_name="mock_env:cats",
+            task_version="v1",
+            verifier_name="mock_env.reward",
+            verifier_version="v1",
+        ),
+    )
+
+    class _FakeEnv:
+        def sample(self, **_kwargs):
+            return sample
+
+    worker = object.__new__(RolloutWorker)
+    worker._load_environment = lambda _lesson_id: _FakeEnv()
+    worker._policy_ctx = object()
+    worker._current_weight_step = 42
+    worker.config = SimpleNamespace(
+        run_id="run-123",
+        system_prompt=None,
+        curriculum_config=SimpleNamespace(
+            lessons={
+                "lesson-a": SimpleNamespace(
+                    sampling_params=SimpleNamespace(
+                        temperature=0.7,
+                        top_k=5,
+                        stop_tokens=None,
+                        max_output_tokens=32,
+                    )
+                )
+            }
+        ),
+    )
+
+    first_batch, _ = worker._sample_batch("lesson-a", 1, 1, "train", rng=None)
+    second_batch, _ = worker._sample_batch("lesson-a", 1, 1, "train", rng=None)
+
+    assert first_batch is not None
+    assert second_batch is not None
+    assert first_batch.groups[0].metadata.group_id != second_batch.groups[0].metadata.group_id
+    assert first_batch.groups[0].metadata.trace_id != second_batch.groups[0].metadata.trace_id
+    assert first_batch.groups[0].rollouts[0].metadata.group_id == first_batch.groups[0].metadata.group_id
+    assert second_batch.groups[0].rollouts[0].metadata.group_id == second_batch.groups[0].metadata.group_id
+
+
 def test_stage_vllm_metadata_locally_copies_hf_metadata(tmp_path, monkeypatch):
     remote_dir = tmp_path / "remote-model"
     remote_dir.mkdir()

--- a/tests/rl/test_train_batch.py
+++ b/tests/rl/test_train_batch.py
@@ -3,6 +3,8 @@
 
 """Test training batch creation utilities."""
 
+from dataclasses import replace
+
 import numpy as np
 import pytest
 from marin.rl import train_batch
@@ -236,6 +238,7 @@ def test_rollout_to_trajectory_record_preserves_trace_and_verifier_metadata():
     rollout = create_test_rollout(metadata=metadata, correctness_reward=0.75)
 
     record = train_batch.rollout_to_trajectory_record(rollout)
+    roundtripped = train_batch.trajectory_record_to_rollout(record)
 
     assert record.trace_id == "trace-9"
     assert record.group_id == "group-3"
@@ -247,6 +250,10 @@ def test_rollout_to_trajectory_record_preserves_trace_and_verifier_metadata():
     assert record.trace_ref == "gs://trace.json"
     assert record.rollout_metadata.run_id == "run-1"
     assert record.correctness_reward == 0.75
+    assert roundtripped.metadata == metadata
+    assert roundtripped.correctness_reward == 0.75
+    np.testing.assert_array_equal(roundtripped.prompt_tokens, rollout.prompt_tokens)
+    np.testing.assert_array_equal(roundtripped.response_tokens, rollout.response_tokens)
 
 
 def test_create_sequence_batch_from_rollouts_produces_neutral_masks_and_info():
@@ -352,7 +359,13 @@ def test_rollout_group_to_trajectory_group_record_uses_group_metadata():
         trace_ref="trace://shared",
     )
     rollout_a = create_test_rollout(prompt_len=3, response_len=2, unique_id=88, metadata=metadata)
-    rollout_b = create_test_rollout(prompt_len=3, response_len=2, unique_id=88, metadata=metadata)
+    rollout_b_metadata = replace(
+        metadata,
+        trace_id="trace-shared-b",
+        verifier_version="v3",
+        trace_ref="trace://shared-b",
+    )
+    rollout_b = create_test_rollout(prompt_len=3, response_len=2, unique_id=88, metadata=rollout_b_metadata)
     group = RolloutGroup(
         rollouts=[rollout_a, rollout_b],
         metadata=RolloutGroupMetadata(
@@ -378,6 +391,9 @@ def test_rollout_group_to_trajectory_group_record_uses_group_metadata():
     assert record.verifier_version == "v2"
     assert record.trace_ref == "trace://override"
     assert len(record.trajectories) == 2
+    assert [trajectory.trace_id for trajectory in record.trajectories] == ["trace-shared", "trace-shared-b"]
+    assert [trajectory.trace_ref for trajectory in record.trajectories] == ["trace://shared", "trace://shared-b"]
+    assert {trajectory.group_id for trajectory in record.trajectories} == {"group-shared"}
 
 
 def test_rollout_group_to_trajectory_group_record_rejects_mismatched_prompts():

--- a/tests/rl/test_train_batch.py
+++ b/tests/rl/test_train_batch.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from marin.rl import train_batch
 from marin.rl.decoding import DecodingConfig
-from marin.rl.types import Rollout, RolloutWithAdvantage
+from marin.rl.types import Rollout, RolloutGroup, RolloutGroupMetadata, RolloutMetadata, RolloutWithAdvantage
 
 
 def create_test_rollout(
@@ -16,6 +16,8 @@ def create_test_rollout(
     env_name: str = "test_env",
     episode_reward: float = 1.0,
     unique_id: int = 12345,
+    metadata: RolloutMetadata | None = None,
+    correctness_reward: float | None = None,
 ) -> Rollout:
     """Create a test rollout with predictable token values."""
     prompt_tokens = np.full(prompt_len, unique_id, dtype=np.int32)
@@ -33,6 +35,8 @@ def create_test_rollout(
         episode_reward=episode_reward,
         decoding=DecodingConfig(temperature=1.0).as_trace(),
         is_truncated=False,
+        metadata=RolloutMetadata() if metadata is None else metadata,
+        correctness_reward=correctness_reward,
     )
 
 
@@ -212,3 +216,174 @@ def test_batch_dtypes():
     assert batch.loss_weights.array.dtype == np.float32
     assert batch.loss_masks.array.dtype == np.float32
     assert batch.policy_logprobs.array.dtype == np.float32
+
+
+def test_rollout_to_trajectory_record_preserves_trace_and_verifier_metadata():
+    metadata = RolloutMetadata(
+        worker_id="worker-7",
+        timestamp=12.5,
+        weight_step=42,
+        run_id="run-1",
+        lesson_id="lesson-a",
+        group_id="group-3",
+        trace_id="trace-9",
+        task_name="math",
+        task_version="v2",
+        verifier_name="grader",
+        verifier_version="2026-04-14",
+        trace_ref="gs://trace.json",
+    )
+    rollout = create_test_rollout(metadata=metadata, correctness_reward=0.75)
+
+    record = train_batch.rollout_to_trajectory_record(rollout)
+
+    assert record.trace_id == "trace-9"
+    assert record.group_id == "group-3"
+    assert record.lesson_id == "lesson-a"
+    assert record.task_name == "math"
+    assert record.task_version == "v2"
+    assert record.verifier_name == "grader"
+    assert record.verifier_version == "2026-04-14"
+    assert record.trace_ref == "gs://trace.json"
+    assert record.rollout_metadata.run_id == "run-1"
+    assert record.correctness_reward == 0.75
+
+
+def test_create_sequence_batch_from_rollouts_produces_neutral_masks_and_info():
+    rollout_a = create_test_rollout(
+        prompt_len=3,
+        response_len=2,
+        unique_id=10,
+        episode_reward=1.5,
+        metadata=RolloutMetadata(
+            worker_id="worker-a",
+            timestamp=5.0,
+            weight_step=11,
+            run_id="run-a",
+            lesson_id="lesson-1",
+            group_id="group-1",
+            trace_id="trace-1",
+            task_name="task-a",
+            task_version="v1",
+            verifier_name="verifier-a",
+            verifier_version="1.0",
+            trace_ref="trace://1",
+        ),
+        correctness_reward=0.25,
+    )
+    rollout_b = create_test_rollout(
+        prompt_len=2,
+        response_len=4,
+        unique_id=20,
+        episode_reward=2.5,
+        metadata=RolloutMetadata(
+            worker_id="worker-b",
+            timestamp=7.5,
+            weight_step=13,
+            run_id="run-b",
+            lesson_id="lesson-2",
+            group_id="group-2",
+            trace_id="trace-2",
+            task_name="task-b",
+            task_version="v3",
+        ),
+    )
+
+    batch, info = train_batch.create_sequence_batch_from_rollouts([rollout_a, rollout_b], max_tokens=16, pad_token_id=0)
+
+    assert len(batch) == 2
+    assert batch.input_ids.axis_size("position") == 6
+    np.testing.assert_array_equal(batch.prompt_mask.array[0], np.array([1, 1, 1, 0, 0, 0], dtype=np.float32))
+    np.testing.assert_array_equal(batch.response_mask.array[0], np.array([0, 0, 0, 1, 1, 0], dtype=np.float32))
+    np.testing.assert_array_equal(
+        info.token_rewards.array[0],
+        np.array([0.0, 0.0, 0.0, 0.1, 0.1, 0.0], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(info.prompt_length.array, np.array([3, 2], dtype=np.int32))
+    np.testing.assert_array_equal(info.response_length.array, np.array([2, 4], dtype=np.int32))
+    np.testing.assert_allclose(info.episode_reward.array, np.array([1.5, 2.5], dtype=np.float32))
+    np.testing.assert_allclose(info.correctness_reward.array[0], 0.25)
+    assert np.isnan(info.correctness_reward.array[1])
+    assert info.group_id == ("group-1", "group-2")
+    assert info.lesson_id == ("lesson-1", "lesson-2")
+    assert info.task_name == ("task-a", "task-b")
+    assert info.verifier_name == ("verifier-a", None)
+    assert info.trace_id == ("trace-1", "trace-2")
+    assert info.trace_ref == ("trace://1", None)
+    assert info.timestamp == (5.0, 7.5)
+
+
+def test_sequence_batch_lengths_reflect_truncation():
+    rollout = create_test_rollout(prompt_len=5, response_len=4, unique_id=33)
+
+    batch, info = train_batch.create_sequence_batch_from_rollouts([rollout], max_tokens=7, pad_token_id=0)
+
+    np.testing.assert_array_equal(batch.prompt_mask.array[0], np.array([1, 1, 1, 1, 1, 0, 0], dtype=np.float32))
+    np.testing.assert_array_equal(batch.response_mask.array[0], np.array([0, 0, 0, 0, 0, 1, 1], dtype=np.float32))
+    np.testing.assert_array_equal(info.prompt_length.array, np.array([5], dtype=np.int32))
+    np.testing.assert_array_equal(info.response_length.array, np.array([2], dtype=np.int32))
+
+
+def test_batch_info_preserves_timestamp_precision_at_unix_scale():
+    base_timestamp = 1_710_000_000.0
+    rollout_a = create_test_rollout(
+        unique_id=41,
+        metadata=RolloutMetadata(timestamp=base_timestamp, weight_step=1),
+    )
+    rollout_b = create_test_rollout(
+        unique_id=42,
+        metadata=RolloutMetadata(timestamp=base_timestamp + 1.0, weight_step=2),
+    )
+
+    _, info = train_batch.create_sequence_batch_from_rollouts([rollout_a, rollout_b], max_tokens=16, pad_token_id=0)
+
+    assert info.timestamp == (base_timestamp, base_timestamp + 1.0)
+
+
+def test_rollout_group_to_trajectory_group_record_uses_group_metadata():
+    metadata = RolloutMetadata(
+        lesson_id="lesson-shared",
+        group_id="group-shared",
+        trace_id="trace-shared",
+        task_name="task-shared",
+        task_version="v9",
+        verifier_name="verifier-shared",
+        verifier_version="v1",
+        trace_ref="trace://shared",
+    )
+    rollout_a = create_test_rollout(prompt_len=3, response_len=2, unique_id=88, metadata=metadata)
+    rollout_b = create_test_rollout(prompt_len=3, response_len=2, unique_id=88, metadata=metadata)
+    group = RolloutGroup(
+        rollouts=[rollout_a, rollout_b],
+        metadata=RolloutGroupMetadata(
+            group_id="group-override",
+            lesson_id="lesson-override",
+            trace_id="trace-override",
+            task_name="task-override",
+            task_version="v10",
+            verifier_name="verifier-override",
+            verifier_version="v2",
+            trace_ref="trace://override",
+        ),
+    )
+
+    record = train_batch.rollout_group_to_trajectory_group_record(group)
+
+    assert record.group_id == "group-override"
+    assert record.lesson_id == "lesson-override"
+    assert record.trace_id == "trace-override"
+    assert record.task_name == "task-override"
+    assert record.task_version == "v10"
+    assert record.verifier_name == "verifier-override"
+    assert record.verifier_version == "v2"
+    assert record.trace_ref == "trace://override"
+    assert len(record.trajectories) == 2
+
+
+def test_rollout_group_to_trajectory_group_record_rejects_mismatched_prompts():
+    rollout_a = create_test_rollout(prompt_len=3, response_len=2, unique_id=1)
+    rollout_b = create_test_rollout(prompt_len=3, response_len=2, unique_id=2)
+    group = RolloutGroup(rollouts=[rollout_a, rollout_b], metadata=RolloutGroupMetadata())
+
+    with pytest.raises(ValueError, match="share the same prompt tokens"):
+        train_batch.rollout_group_to_trajectory_group_record(group)

--- a/tests/rl/test_train_worker.py
+++ b/tests/rl/test_train_worker.py
@@ -3,9 +3,7 @@
 
 from types import SimpleNamespace
 
-import pytest
-from marin.rl.kl_regularization import KLConfig, KLMode
-from marin.rl.rl_losses import RLOOLoss
+from marin.rl.scoring import ScoreRequirements
 from marin.rl.train_worker import (
     BatchPrepTiming,
     InitialRolloutState,
@@ -20,7 +18,7 @@ from marin.rl.weight_transfer.base import WeightTransferServerMetrics
 def test_drop_bootstrap_model_references_clears_reference_model_when_kl_disabled():
     worker = TrainWorker.__new__(TrainWorker)
     model = object()
-    worker.loss_module = RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0))
+    worker.objective_runtime = SimpleNamespace(score_requirements=ScoreRequirements(reference_logprobs=False))
     worker.initial_model = model
     worker.reference_model = model
 
@@ -30,11 +28,10 @@ def test_drop_bootstrap_model_references_clears_reference_model_when_kl_disabled
     assert worker.reference_model is None
 
 
-@pytest.mark.parametrize("mode", [KLMode.K1_LOSS, KLMode.K2_LOSS, KLMode.K3_LOSS])
-def test_drop_bootstrap_model_references_preserves_reference_model_when_kl_enabled(mode: KLMode):
+def test_drop_bootstrap_model_references_preserves_reference_model_when_kl_enabled():
     worker = TrainWorker.__new__(TrainWorker)
     model = object()
-    worker.loss_module = RLOOLoss(kl=KLConfig(mode=mode, beta=0.01))
+    worker.objective_runtime = SimpleNamespace(score_requirements=ScoreRequirements(reference_logprobs=True))
     worker.initial_model = model
     worker.reference_model = model
 
@@ -166,7 +163,10 @@ def test_train_bootstraps_fresh_run_with_step_minus_one(monkeypatch):
         optimizer=SimpleNamespace(build=lambda num_steps: object()),
         weight_transfer=SimpleNamespace(debug_weight_transfer=False, sync_interval_steps=1),
     )
-    worker.loss_module = SimpleNamespace(create_loss_fn=lambda reference_model, _: lambda model, batch, key: 0.0)
+    worker.objective_runtime = SimpleNamespace(
+        create_loss_fn=lambda *, reference_model=None, teacher_model=None: lambda model, batch, key: 0.0,
+        score_requirements=ScoreRequirements(reference_logprobs=False),
+    )
     worker.reference_model = object()
     worker.initial_model = object()
     worker.replay_buffer = SimpleNamespace(set_current_step=replay_steps.append)
@@ -244,7 +244,10 @@ def test_train_reuses_recovered_step_on_resume(monkeypatch):
         optimizer=SimpleNamespace(build=lambda num_steps: object()),
         weight_transfer=SimpleNamespace(debug_weight_transfer=False, sync_interval_steps=1),
     )
-    worker.loss_module = SimpleNamespace(create_loss_fn=lambda reference_model, _: lambda model, batch, key: 0.0)
+    worker.objective_runtime = SimpleNamespace(
+        create_loss_fn=lambda *, reference_model=None, teacher_model=None: lambda model, batch, key: 0.0,
+        score_requirements=ScoreRequirements(reference_logprobs=True),
+    )
     worker.reference_model = object()
     worker.initial_model = object()
     worker.replay_buffer = SimpleNamespace(set_current_step=replay_steps.append)

--- a/tests/rl/test_train_worker.py
+++ b/tests/rl/test_train_worker.py
@@ -1,18 +1,56 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import contextlib
 from types import SimpleNamespace
 
+import numpy as np
 from marin.rl.scoring import ScoreRequirements
 from marin.rl.train_worker import (
     BatchPrepTiming,
     InitialRolloutState,
+    StreamingRolloutLoader,
     TrainWorker,
     _initial_rollout_state,
     _resume_safe_weight_transfer_metrics,
     _training_step_timing_metrics,
 )
+from marin.rl.types import RolloutMetadata, TrajectoryGroupRecord, TrajectoryRecord
 from marin.rl.weight_transfer.base import WeightTransferServerMetrics
+
+
+def create_test_trajectory(group_id: str, trace_id: str, reward: float) -> TrajectoryRecord:
+    return TrajectoryRecord(
+        trace_id=trace_id,
+        env_name="test_env",
+        task_name="math",
+        task_version="v1",
+        lesson_id="lesson-a",
+        env_example_id="example-a",
+        group_id=group_id,
+        verifier_name="verifier",
+        verifier_version="v1",
+        prompt_tokens=np.array([1, 2, 3], dtype=np.int32),
+        response_tokens=np.array([4, 5], dtype=np.int32),
+        behavior_logprobs=np.array([-0.1, -0.2], dtype=np.float32),
+        token_rewards=np.array([reward, reward], dtype=np.float32),
+        episode_reward=reward,
+        correctness_reward=None,
+        is_truncated=False,
+        sampling_temperature=1.0,
+        sampling_top_k=None,
+        rollout_metadata=RolloutMetadata(
+            worker_id="worker-a",
+            timestamp=123.0,
+            weight_step=7,
+            run_id="run-a",
+            lesson_id="lesson-a",
+            group_id=group_id,
+            trace_id=trace_id,
+            task_name="math",
+            task_version="v1",
+        ),
+    )
 
 
 def test_drop_bootstrap_model_references_clears_reference_model_when_kl_disabled():
@@ -104,6 +142,70 @@ def test_seed_initial_rollout_state_publishes_resumed_step():
     worker._seed_initial_rollout_state(InitialRolloutState(weight_step=68, published_train_step=68))
 
     assert recorded_steps == [68, 68]
+
+
+def test_streaming_rollout_loader_preserves_full_groups(monkeypatch):
+    trajectories = (
+        create_test_trajectory(group_id="group-a", trace_id="trace-a-0", reward=0.0),
+        create_test_trajectory(group_id="group-a", trace_id="trace-a-1", reward=1.0),
+    )
+    group = TrajectoryGroupRecord(
+        group_id="group-a",
+        lesson_id="lesson-a",
+        trace_id="trace-a",
+        task_name="math",
+        task_version="v1",
+        verifier_name="verifier",
+        verifier_version="v1",
+        prompt_tokens=trajectories[0].prompt_tokens,
+        trajectories=trajectories,
+    )
+
+    class _FakeReplayLoader:
+        get_groups_calls = 0
+
+        def get_trajectories(self, *, timeout):
+            del timeout
+            raise AssertionError("trainer data path must sample full groups, not individual trajectories")
+
+        def get_groups(self, *, timeout):
+            del timeout
+            self.get_groups_calls += 1
+            return [group]
+
+    class _FakeObjectiveRuntime:
+        prepared_group_ids: tuple[str, ...] | None = None
+        prepared_rewards: list[float] | None = None
+
+        def prepare_batch(self, sequence_batch, batch_info):
+            del sequence_batch
+            self.prepared_group_ids = batch_info.group_id
+            self.prepared_rewards = [float(value) for value in batch_info.episode_reward.array]
+            return batch_info
+
+    monkeypatch.setattr("marin.rl.train_worker.hax.set_mesh", lambda _mesh: contextlib.nullcontext())
+    monkeypatch.setattr("marin.rl.train_worker.hax.shard", lambda batch, _axis_mapping: batch)
+
+    replay_loader = _FakeReplayLoader()
+    objective_runtime = _FakeObjectiveRuntime()
+    loader = StreamingRolloutLoader(
+        data_loader=replay_loader,
+        config=SimpleNamespace(
+            curriculum_config=SimpleNamespace(max_seq_len=8),
+            model=SimpleNamespace(attn_backend=None, flash_attention_block_size=1),
+            tokenizer=SimpleNamespace(pad_token_id=0, eos_token_id=0),
+            trainer=SimpleNamespace(device_mesh=None, compute_axis_mapping={}),
+        ),
+        objective_runtime=objective_runtime,
+    )
+
+    prepared_batch = next(iter(loader))
+
+    assert replay_loader.get_groups_calls == 1
+    assert objective_runtime.prepared_group_ids == ("group-a", "group-a")
+    assert objective_runtime.prepared_rewards == [0.0, 1.0]
+    assert prepared_batch.group_id == ("group-a", "group-a")
+    assert loader._last_trajectories == list(trajectories)
 
 
 def test_train_bootstraps_fresh_run_with_step_minus_one(monkeypatch):


### PR DESCRIPTION
Introduce trace and verifier contracts, neutral trajectory and replay batches, shared scoring, and the compositional objective runtime for RL training. Switch the active trainer path from RLOOLoss to ObjectiveSpec while preserving current RLOO behavior and failing fast on unsupported objective shapes. Adds parity and integration coverage across replay, environments, and trainer wiring.