### PR TITLE
[Iris] Touch resolver docstring for smoke repro

### DIFF
--- a/lib/iris/src/iris/client/resolver.py
+++ b/lib/iris/src/iris/client/resolver.py
@@ -1,7 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Namespace-aware resolver for actor discovery via cluster controller."""
+"""Namespace-aware resolver for actor discovery through the cluster controller."""
 
 import os
 


### PR DESCRIPTION
Touch a docstring in iris.client.resolver without changing behavior so we can observe PR smoke behavior on a minimal Iris source diff.