### PR TITLE
[Iris] Touch resolver docstring for second smoke repro

### DIFF
--- a/lib/iris/src/iris/client/resolver.py
+++ b/lib/iris/src/iris/client/resolver.py
@@ -1,7 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Namespace-aware resolver for actor discovery via cluster controller."""
+"""Namespace-aware endpoint resolver for actor discovery via cluster controller."""
 
 import os
 


### PR DESCRIPTION
Touch another docstring in iris.client.resolver without changing behavior so we can re-run Iris cloud smoke against main. This is a control PR to check whether the restart smoke failure reproduces independently of #4764.