### PR TITLE
[Iris] Stamp finished_at_ms on retried task attempts

### DIFF
--- a/lib/iris/src/iris/cluster/controller/migrations/0032_backfill_attempt_finished_at.py
+++ b/lib/iris/src/iris/cluster/controller/migrations/0032_backfill_attempt_finished_at.py
@@ -1,0 +1,52 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backfill ``task_attempts.finished_at_ms`` on terminal rows that were left NULL.
+
+Prior to the fix in ``transitions.py``, a terminal attempt (e.g. FAILED) whose
+parent task was rolled back to PENDING for retry had its ``finished_at_ms``
+dropped to NULL alongside the task. This left orphaned dead attempts in the DB
+with no completion timestamp, which in turn confused UI rendering that treats
+``finished_at_ms IS NULL`` as "not done yet".
+
+Best-effort backfill: use the ``created_at_ms`` of the next attempt on the same
+task as the completion time, since the controller created the next attempt in
+the same transaction that wrote the (dropped) terminal_ms. If there is no
+next attempt, fall back to ``started_at_ms`` and then ``created_at_ms``.
+
+Terminal states (see ``iris.cluster.types.TERMINAL_TASK_STATES``):
+  4 SUCCEEDED, 5 FAILED, 6 KILLED, 7 WORKER_FAILED, 8 UNSCHEDULABLE, 10 PREEMPTED
+"""
+
+import sqlite3
+
+_TERMINAL_STATES = (4, 5, 6, 7, 8, 10)
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    placeholders = ",".join("?" for _ in _TERMINAL_STATES)
+    conn.execute(
+        f"""
+        WITH next_attempt AS (
+            SELECT
+                task_id,
+                attempt_id,
+                LEAD(created_at_ms) OVER (
+                    PARTITION BY task_id ORDER BY attempt_id
+                ) AS next_created_at_ms
+            FROM task_attempts
+        )
+        UPDATE task_attempts
+        SET finished_at_ms = COALESCE(
+            (SELECT n.next_created_at_ms
+             FROM next_attempt n
+             WHERE n.task_id = task_attempts.task_id
+               AND n.attempt_id = task_attempts.attempt_id),
+            task_attempts.started_at_ms,
+            task_attempts.created_at_ms
+        )
+        WHERE finished_at_ms IS NULL
+          AND state IN ({placeholders})
+        """,
+        _TERMINAL_STATES,
+    )

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -1784,6 +1784,11 @@ class ControllerTransitions:
                     task_state = job_pb2.TASK_STATE_PENDING
                     terminal_ms = None
 
+            # An attempt is terminal whenever the update itself is terminal, even
+            # if the TASK rolls back to PENDING for a retry. terminal_ms above
+            # tracks the task's finished_at_ms; the attempt needs its own stamp.
+            attempt_terminal_ms = now_ms if int(update.new_state) in TERMINAL_TASK_STATES else None
+
             cur.execute(
                 "UPDATE task_attempts SET state = ?, started_at_ms = COALESCE(started_at_ms, ?), "
                 "finished_at_ms = COALESCE(finished_at_ms, ?), exit_code = COALESCE(?, exit_code), "
@@ -1791,7 +1796,7 @@ class ControllerTransitions:
                 (
                     int(update.new_state),
                     started_ms,
-                    terminal_ms,
+                    attempt_terminal_ms,
                     task_exit,
                     update.error,
                     update.task_id.to_wire(),
@@ -3393,6 +3398,10 @@ class ControllerTransitions:
                         task_state = job_pb2.TASK_STATE_PENDING
                         terminal_ms = None
 
+                # An attempt is terminal whenever the update itself is terminal, even
+                # if the TASK rolls back to PENDING for a retry.
+                attempt_terminal_ms = now_ms if int(update.new_state) in TERMINAL_TASK_STATES else None
+
                 cur.execute(
                     "UPDATE task_attempts SET state = ?, started_at_ms = COALESCE(started_at_ms, ?), "
                     "finished_at_ms = COALESCE(finished_at_ms, ?), exit_code = COALESCE(?, exit_code), "
@@ -3400,7 +3409,7 @@ class ControllerTransitions:
                     (
                         int(update.new_state),
                         started_ms,
-                        terminal_ms,
+                        attempt_terminal_ms,
                         task_exit,
                         update.error,
                         update.task_id.to_wire(),

--- a/lib/iris/tests/cluster/controller/test_db.py
+++ b/lib/iris/tests/cluster/controller/test_db.py
@@ -371,3 +371,80 @@ def test_wal_checkpoint_truncate_runs_incremental_vacuum(tmp_path: Path) -> None
         assert size_after < size_full, f"expected shrink: before={size_full} after={size_after}"
     finally:
         db.close()
+
+
+def test_backfill_attempt_finished_at_migration(tmp_path: Path) -> None:
+    """0032 backfills finished_at_ms for orphaned terminal attempts.
+
+    Reproduces the historical bug where a FAILED/WORKER_FAILED attempt whose
+    task was retried kept finished_at_ms=NULL. The migration should populate
+    it using the next attempt's created_at_ms (and fall back to started_at_ms
+    or created_at_ms when no next attempt exists).
+
+    Exercises the migration SQL directly against a minimal schema so it
+    doesn't need to negotiate controller triggers / FKs.
+    """
+    import importlib
+
+    conn = sqlite3.connect(str(tmp_path / "c.sqlite3"))
+    conn.execute(
+        """
+        CREATE TABLE task_attempts (
+            task_id TEXT NOT NULL,
+            attempt_id INTEGER NOT NULL,
+            worker_id TEXT,
+            state INTEGER NOT NULL,
+            created_at_ms INTEGER NOT NULL,
+            started_at_ms INTEGER,
+            finished_at_ms INTEGER,
+            exit_code INTEGER,
+            error TEXT,
+            PRIMARY KEY (task_id, attempt_id)
+        )
+        """
+    )
+    rows = [
+        # task A: FAILED attempt followed by another FAILED attempt.
+        # Backfill must use next.created_at_ms (2000), not this row's started_at_ms.
+        ("/u/A", 0, 5, 1000, 1100, None),
+        ("/u/A", 1, 5, 2000, 2100, 2500),
+        # task B: FAILED orphan followed by a still-RUNNING retry.
+        # Next exists (created at 4000), so that's the bound — even though the
+        # next attempt isn't itself terminal.
+        ("/u/B", 0, 5, 3000, 3100, None),
+        ("/u/B", 1, 3, 4000, 4100, None),
+        # task C: FAILED orphan with no next attempt at all — fall back to
+        # started_at_ms (5100).
+        ("/u/C", 0, 5, 5000, 5100, None),
+        # task D: FAILED orphan, no next attempt, no started_at_ms — fall back
+        # to created_at_ms (6000).
+        ("/u/D", 0, 5, 6000, None, None),
+        # task E: control cases. Already-stamped row must not be rewritten; a
+        # non-terminal row must never be touched.
+        ("/u/E", 0, 4, 7000, 7100, 7200),
+        ("/u/E", 1, 3, 8000, 8100, None),
+    ]
+    conn.executemany(
+        "INSERT INTO task_attempts(task_id, attempt_id, state, created_at_ms, "
+        "started_at_ms, finished_at_ms) VALUES (?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+
+    mod = importlib.import_module("iris.cluster.controller.migrations.0032_backfill_attempt_finished_at")
+    mod.migrate(conn)
+    conn.commit()
+
+    out = {
+        (r[0], r[1]): r[2]
+        for r in conn.execute("SELECT task_id, attempt_id, finished_at_ms FROM task_attempts").fetchall()
+    }
+    assert out[("/u/A", 0)] == 2000
+    assert out[("/u/A", 1)] == 2500
+    assert out[("/u/B", 0)] == 4000
+    assert out[("/u/B", 1)] is None
+    assert out[("/u/C", 0)] == 5100
+    assert out[("/u/D", 0)] == 6000
+    assert out[("/u/E", 0)] == 7200
+    assert out[("/u/E", 1)] is None
+    conn.close()

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -3466,6 +3466,17 @@ def test_apply_failed_with_retry(state):
     # Task should be PENDING again (1 failure <= 1 max_retries_failure).
     assert _task_state_direct(state, task_id) == job_pb2.TASK_STATE_PENDING
 
+    # The dead attempt 0 must have finished_at_ms stamped even though the task
+    # itself rolled back to PENDING. Otherwise the row is indistinguishable from
+    # a still-assigned attempt. Regression guard for the terminal_ms conflation.
+    with state._db.snapshot() as q:
+        attempts = ATTEMPT_PROJECTION.decode(
+            q.fetchall("SELECT * FROM task_attempts WHERE task_id = ?", (task_id.to_wire(),))
+        )
+    assert len(attempts) == 1
+    assert attempts[0].state == job_pb2.TASK_STATE_FAILED
+    assert attempts[0].finished_at is not None
+
     # Draining again should promote it for a second attempt.
     batch = state.drain_for_direct_provider()
     assert len(batch.tasks_to_run) == 1


### PR DESCRIPTION
When a task attempt reported FAILED/WORKER_FAILED but the parent task rolled back to PENDING for retry, the attempt's finished_at_ms was dropped to NULL alongside the task's. This orphaned ~19.8k terminal attempt rows in the production controller DB and made the dashboard render retried attempts as permanently ASSIGNED. Splits the timestamp so an attempt always stamps its own completion. Migration 0032 backfills orphaned rows using the next attempt's created_at. Adds regression tests.