### PR TITLE
[ci] Open nightshift PRs with a GitHub App token so CI runs

### DIFF
--- a/.github/workflows/nightshift-cleanup.yml
+++ b/.github/workflows/nightshift-cleanup.yml
@@ -20,10 +20,18 @@ jobs:
       id-token: write
       actions: read
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.NIGHTSHIFT_APP_ID }}
+          private-key: ${{ secrets.NIGHTSHIFT_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -39,5 +47,5 @@ jobs:
       - name: Run cleanup agent
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: python infra/scripts/nightshift_cleanup.py

--- a/.github/workflows/nightshift-doc-drift.yml
+++ b/.github/workflows/nightshift-doc-drift.yml
@@ -20,10 +20,18 @@ jobs:
       id-token: write
       actions: read
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.NIGHTSHIFT_APP_ID }}
+          private-key: ${{ secrets.NIGHTSHIFT_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -39,5 +47,5 @@ jobs:
       - name: Detect documentation drift
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: python infra/scripts/nightshift_doc_drift.py --run-id ${{ github.run_id }} --run-attempt ${{ github.run_attempt }}


### PR DESCRIPTION
PRs opened with the default GITHUB_TOKEN don't trigger workflow runs, so nightshift PRs merge with no checks. Swap both nightshift workflows to mint a claude-nightshift GitHub App token via actions/create-github-app-token, use it for checkout and gh pr create. New PRs will be authored by claude-nightshift[bot] and trigger pull_request workflows normally. Requires NIGHTSHIFT_APP_ID and NIGHTSHIFT_APP_PRIVATE_KEY secrets (already set).