### PR TITLE
[zephyr] Replace Parquet shuffle with zstd-chunk format

### DIFF
--- a/lib/zephyr/AGENTS.md
+++ b/lib/zephyr/AGENTS.md
@@ -15,7 +15,7 @@ Lazy dataset processing library. Start with the shared instructions in `/AGENTS.
 - `src/zephyr/plan.py` — `compute_plan`, `PhysicalPlan`, operation fusion
 - `src/zephyr/readers.py` — `load_jsonl`, `load_parquet`, `load_vortex`, `InputFileSpec`
 - `src/zephyr/writers.py` — `write_jsonl_file`, `write_parquet_file`, `write_vortex_file`, Levanter cache writer
-- `src/zephyr/shuffle.py` — scatter pipeline internals (`ScatterParquetIterator`, `ScatterShard`, hash-routing, combiner, Parquet envelope)
+- `src/zephyr/shuffle.py` — scatter pipeline internals (`ScatterFileIterator`, `ScatterShard`, hash-routing, combiner, zstd-chunk file format with byte-range sidecar)
 - `src/zephyr/expr.py` — `Expr`, `col`, `lit` for filter expressions
 - `src/zephyr/external_sort.py` — `external_sort_merge` k-way merge of sorted runs
 - `src/zephyr/counters.py` — `increment` / `get_counters` per-worker counter API (`CounterSnapshot` lives in `execution.py`)

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -35,7 +35,6 @@ from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 import cloudpickle
-import pyarrow as pa
 from rigging.filesystem import open_url, url_to_fs
 from fray.v2 import ActorConfig, ActorFuture, ActorHandle, Client, ResourceConfig
 from fray.v2.client import JobHandle
@@ -114,8 +113,7 @@ from zephyr.shuffle import (  # noqa: E402
     MemChunk,
     ScatterShard,  # noqa: F401 — re-exported for plan.py and external callers
     _build_scatter_shard_from_manifest,  # noqa: F401 — re-exported for plan.py
-    _make_envelope,
-    _write_parquet_scatter,
+    _write_scatter,
     _write_scatter_manifest,
     _SCATTER_MANIFEST_NAME,
 )
@@ -232,36 +230,22 @@ def _write_stage_output(
     TaskResult with a ListShard.
     """
     if scatter_op is not None:
-        # Peek first item to test Arrow serializability
         first_item = next(stage_gen, None)
         if first_item is None:
             return TaskResult(shard=ListShard(refs=[]))
 
         full_gen = itertools.chain([first_item], stage_gen)
 
-        use_pickle_envelope = False
-        try:
-            test_envelope = _make_envelope([first_item], 0, 0)
-            pa.RecordBatch.from_pylist(test_envelope)
-            logger.info("Using Parquet for scatter serialization for shard %d", source_shard)
-        except Exception:
-            use_pickle_envelope = True
-            logger.info(
-                "Using Parquet with pickle envelope for scatter serialization for shard %d",
-                source_shard,
-            )
-
         num_output_shards = scatter_op.num_output_shards if scatter_op.num_output_shards > 0 else total_shards
-        parquet_path = f"{stage_dir}/shard-{shard_idx:04d}.parquet"
-        shard = _write_parquet_scatter(
+        data_path = f"{stage_dir}/shard-{shard_idx:04d}.shuffle"
+        shard = _write_scatter(
             full_gen,
             source_shard,
-            parquet_path,
+            data_path,
             key_fn=scatter_op.key_fn,
             num_output_shards=num_output_shards,
             sort_fn=scatter_op.sort_fn,
             combiner_fn=scatter_op.combiner_fn,
-            pickled=use_pickle_envelope,
         )
         return TaskResult(shard=shard)
 

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -111,7 +111,9 @@ class PickleDiskChunk:
 from zephyr.shuffle import (  # noqa: E402
     ListShard,
     MemChunk,
-    ScatterShard,  # noqa: F401 — re-exported for plan.py and external callers
+    ScatterReader,  # noqa: F401 — re-exported for plan.py and external callers
+    ScatterShard,  # noqa: F401 — backward-compat alias for ScatterReader
+    ScatterWriter,  # noqa: F401 — re-exported for external callers
     _build_scatter_shard_from_manifest,  # noqa: F401 — re-exported for plan.py
     _write_scatter,
     _write_scatter_manifest,

--- a/lib/zephyr/src/zephyr/external_sort.py
+++ b/lib/zephyr/src/zephyr/external_sort.py
@@ -7,9 +7,11 @@ Used by the reduce stage when the number of sorted chunk iterators exceeds
 ``EXTERNAL_SORT_FAN_IN``, to avoid opening O(k) scanners simultaneously and
 exhausting worker memory.
 
-Pass 1: batch the k iterators into groups of EXTERNAL_SORT_FAN_IN, merge each
-group with heapq.merge, and spill items to a run file under
-``{external_sort_dir}/run-{i:04d}.spill`` via :class:`SpillWriter`.
+Pass 1: batch the k iterators into groups of ``fan_in`` (defaulting to
+``EXTERNAL_SORT_FAN_IN`` but typically lowered via :func:`compute_fan_in` to
+fit the worker's memory budget), merge each group with ``heapq.merge``, and
+spill items to a run file under ``{external_sort_dir}/run-{i:04d}.spill`` via
+:class:`SpillWriter`.
 
 Pass 2: heapq.merge over the (much smaller) set of run file iterators.  Each
 iterator streams chunks from its spill file via :class:`SpillReader`; the read
@@ -31,18 +33,62 @@ from zephyr.spill import SpillReader, SpillWriter
 
 logger = logging.getLogger(__name__)
 
-# Maximum simultaneous chunk iterators per pass-1 batch.
+# Hard cap on simultaneous chunk iterators per pass-1 batch. Used as the
+# default when the caller cannot estimate per-iterator memory; otherwise
+# ``compute_fan_in`` lowers it to fit within the worker's memory budget.
 EXTERNAL_SORT_FAN_IN = 500
 
-# Items buffered before handing to the SpillWriter. Larger values amortize
-# per-chunk overhead in the spill format.
+# Fraction of worker memory budgeted for the open chunk iterators during a
+# pass-1 merge batch.
+_FAN_IN_MEMORY_FRACTION = 0.5
+
+# Floor on fan-in. Below 2, pass-1 just rewrites each chunk to its own run
+# file with no merging — pass-2 still produces correct output but the extra
+# round-trip is wasteful, so we keep at least a small merge fan-in.
+_FAN_IN_FLOOR = 4
+
+# Default item count per write into the SpillWriter in pass-1. Large enough
+# for good compression + low per-call overhead. For large items (e.g. 1 MB
+# each) the caller should pass a smaller ``write_batch_size`` via
+# :func:`compute_write_batch_size` so the in-memory ``pending`` buffer stays
+# bounded by bytes rather than count.
 _WRITE_BATCH_SIZE = 10_000
+
+# Target bytes for the in-memory pass-1 spill buffer.
+_WRITE_BATCH_TARGET_BYTES = 64 * 1024 * 1024
 
 # Target bytes per spill chunk in pass-1 runs.
 _ROW_GROUP_BYTES = 8 * 1024 * 1024
 
 # Fraction of container memory budgeted for pass-2 read buffers.
 _READ_MEMORY_FRACTION = 0.25
+
+
+def compute_fan_in(per_iterator_bytes: int, memory_limit: int) -> int:
+    """Pick a pass-1 fan-in that fits within the memory budget.
+
+    ``per_iterator_bytes`` is the caller's estimate of memory held per open
+    chunk iterator (typically compressed chunk bytes plus a small decoded
+    buffer). Returns at least ``_FAN_IN_FLOOR`` and at most
+    ``EXTERNAL_SORT_FAN_IN``.
+    """
+    if per_iterator_bytes <= 0 or memory_limit <= 0:
+        return EXTERNAL_SORT_FAN_IN
+    budget = int(memory_limit * _FAN_IN_MEMORY_FRACTION)
+    fan_in = budget // per_iterator_bytes
+    fan_in = max(_FAN_IN_FLOOR, fan_in)
+    return min(fan_in, EXTERNAL_SORT_FAN_IN)
+
+
+def compute_write_batch_size(avg_item_bytes: float) -> int:
+    """Pick a pass-1 pending-buffer size sized to a byte budget.
+
+    Caps at the ``_WRITE_BATCH_SIZE`` default when items are small.
+    """
+    if avg_item_bytes <= 0:
+        return _WRITE_BATCH_SIZE
+    by_bytes = int(_WRITE_BATCH_TARGET_BYTES // avg_item_bytes)
+    return max(1, min(by_bytes, _WRITE_BATCH_SIZE))
 
 
 def _safe_read_batch_size(n_runs: int, sample_run_path: str) -> int:
@@ -87,16 +133,25 @@ def external_sort_merge(
     chunk_iterators_gen: Iterator[Iterator],  # lazy — consumed in batches
     merge_key: Callable,
     external_sort_dir: str,
+    fan_in: int = EXTERNAL_SORT_FAN_IN,
+    write_batch_size: int = _WRITE_BATCH_SIZE,
 ) -> Iterator:
     """Merge ``chunk_iterators_gen`` via a two-pass external sort.
 
     Args:
         chunk_iterators_gen: Lazy iterator of sorted iterators (one per scatter chunk).
-            Consumed in batches of EXTERNAL_SORT_FAN_IN to avoid opening all file
+            Consumed in batches of ``fan_in`` to avoid opening all file
             handles simultaneously.
         merge_key: Key function passed to heapq.merge.
         external_sort_dir: GCS prefix for spill files, e.g.
             ``gs://bucket/.../stage1-external-sort/shard-0042``.
+        fan_in: Maximum number of chunk iterators to merge in one pass-1
+            batch. Defaults to ``EXTERNAL_SORT_FAN_IN``; callers should pass
+            a value computed by :func:`compute_fan_in` to bound memory.
+        write_batch_size: Item count threshold for the pass-1 ``pending``
+            buffer. Callers should pass a value from
+            :func:`compute_write_batch_size` to keep the buffer bounded by
+            bytes rather than item count.
 
     Yields:
         Items in merged sort order.
@@ -109,8 +164,10 @@ def external_sort_merge(
     spill_fs, spill_dir = url_to_fs(external_sort_dir)
     spill_fs.makedirs(spill_dir, exist_ok=True)
 
+    logger.info("External sort: pass-1 fan_in=%d, write_batch_size=%d", fan_in, write_batch_size)
+
     while True:
-        batch = list(islice(chunk_iterators_gen, EXTERNAL_SORT_FAN_IN))
+        batch = list(islice(chunk_iterators_gen, fan_in))
         if not batch:
             break
         run_path = f"{external_sort_dir}/run-{batch_idx:04d}.spill"
@@ -119,7 +176,7 @@ def external_sort_merge(
         with SpillWriter(run_path, row_group_bytes=_ROW_GROUP_BYTES) as writer:
             for item in heapq.merge(*batch, key=merge_key):
                 pending.append(item)
-                if len(pending) >= _WRITE_BATCH_SIZE:
+                if len(pending) >= write_batch_size:
                     writer.write(pending)
                     item_count += len(pending)
                     pending = []

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -644,18 +644,31 @@ def _merge_sorted_chunks(
     )
 
     if use_external:
+        from zephyr.external_sort import compute_fan_in
+
+        memory_limit = _TaskResources.from_environment().memory_bytes
+        # Per-iterator memory ~= compressed bytes for one chunk held by
+        # cat_file. Use uncompressed (max_chunk_rows * avg_item_bytes) as a
+        # conservative upper bound — scatter writes ASCII-ish data with
+        # mediocre zstd ratio.
+        per_iter_bytes = int(shard.max_chunk_rows * shard.avg_item_bytes)
+        fan_in = compute_fan_in(per_iter_bytes, memory_limit)
         logger.info(
-            "External sort triggered for shard with %d iterators, spilling to %s",
+            "External sort triggered for shard with %d iterators, fan_in=%d (per_iter≈%dKB), spilling to %s",
             sum(it.chunk_count for it in shard.iterators),
+            fan_in,
+            per_iter_bytes // 1024,
             external_sort_dir,
         )
         # Pass lazy generator — external_sort_merge consumes in batches without opening all files
-        merged_stream = external_sort_merge(shard.get_iterators(), merge_key, external_sort_dir)
+        merged_stream = external_sort_merge(
+            shard.get_iterators(), merge_key, external_sort_dir, fan_in=fan_in
+        )
     else:
         chunk_iterators = list(shard.get_iterators())
         logger.info(f"Merging {len(chunk_iterators):,} sorted chunk iterators")
         if external_sort_dir is not None and len(chunk_iterators) > EXTERNAL_SORT_FAN_IN:
-            # Fallback: stats unavailable, use fan_in threshold
+            # Fallback: stats unavailable, use the hard-cap fan-in.
             merged_stream = external_sort_merge(iter(chunk_iterators), merge_key, external_sort_dir)
         else:
             merged_stream = heapq.merge(*chunk_iterators, key=merge_key)

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -644,7 +644,7 @@ def _merge_sorted_chunks(
     )
 
     if use_external:
-        from zephyr.external_sort import compute_fan_in
+        from zephyr.external_sort import compute_fan_in, compute_write_batch_size
 
         memory_limit = _TaskResources.from_environment().memory_bytes
         # Per-iterator memory ~= compressed bytes for one chunk held by
@@ -653,16 +653,23 @@ def _merge_sorted_chunks(
         # mediocre zstd ratio.
         per_iter_bytes = int(shard.max_chunk_rows * shard.avg_item_bytes)
         fan_in = compute_fan_in(per_iter_bytes, memory_limit)
+        write_batch_size = compute_write_batch_size(shard.avg_item_bytes)
         logger.info(
-            "External sort triggered for shard with %d iterators, fan_in=%d (per_iter≈%dKB), spilling to %s",
+            "External sort triggered for shard with %d iterators, "
+            "fan_in=%d (per_iter≈%dKB), write_batch_size=%d, spilling to %s",
             sum(it.chunk_count for it in shard.iterators),
             fan_in,
             per_iter_bytes // 1024,
+            write_batch_size,
             external_sort_dir,
         )
         # Pass lazy generator — external_sort_merge consumes in batches without opening all files
         merged_stream = external_sort_merge(
-            shard.get_iterators(), merge_key, external_sort_dir, fan_in=fan_in
+            shard.get_iterators(),
+            merge_key,
+            external_sort_dir,
+            fan_in=fan_in,
+            write_batch_size=write_batch_size,
         )
     else:
         chunk_iterators = list(shard.get_iterators())

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -25,7 +25,7 @@ import msgspec
 from iris.env_resources import TaskResources as _TaskResources
 from rigging.filesystem import url_to_fs
 
-from zephyr.external_sort import EXTERNAL_SORT_FAN_IN, external_sort_merge
+from zephyr.external_sort import external_sort_merge
 
 from zephyr.dataset import (
     Dataset,
@@ -635,7 +635,7 @@ def _merge_sorted_chunks(
 
     # Check if external sort is needed BEFORE materializing all iterators.
     # ScatterShard can decide using manifest stats (no file opens needed).
-    from zephyr.shuffle import ScatterShard
+    from zephyr.shuffle import ScatterShard  # ScatterShard is an alias for ScatterReader
 
     use_external = (
         external_sort_dir is not None
@@ -648,10 +648,8 @@ def _merge_sorted_chunks(
 
         memory_limit = _TaskResources.from_environment().memory_bytes
         # Per-iterator memory ~= compressed bytes for one chunk held by
-        # cat_file. Use uncompressed (max_chunk_rows * avg_item_bytes) as a
-        # conservative upper bound — scatter writes ASCII-ish data with
-        # mediocre zstd ratio.
-        per_iter_bytes = int(shard.max_chunk_rows * shard.avg_item_bytes)
+        # cat_file. Use the actual max compressed chunk size from the sidecar.
+        per_iter_bytes = shard.max_compressed_chunk_bytes
         fan_in = compute_fan_in(per_iter_bytes, memory_limit)
         write_batch_size = compute_write_batch_size(shard.avg_item_bytes)
         logger.info(
@@ -674,11 +672,7 @@ def _merge_sorted_chunks(
     else:
         chunk_iterators = list(shard.get_iterators())
         logger.info(f"Merging {len(chunk_iterators):,} sorted chunk iterators")
-        if external_sort_dir is not None and len(chunk_iterators) > EXTERNAL_SORT_FAN_IN:
-            # Fallback: stats unavailable, use the hard-cap fan-in.
-            merged_stream = external_sort_merge(iter(chunk_iterators), merge_key, external_sort_dir)
-        else:
-            merged_stream = heapq.merge(*chunk_iterators, key=merge_key)
+        merged_stream = heapq.merge(*chunk_iterators, key=merge_key)
     yield from groupby(merged_stream, key=key_fn)
 
 

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -64,7 +64,7 @@ class Shard(Protocol):
 
     Implementations:
     - ListShard: backed by iterable references (source data, non-scatter)
-    - ScatterShard: backed by scatter Parquet files with predicate pushdown
+    - ScatterShard: backed by scatter zstd-chunk files with byte-range sidecar
     """
 
     def __iter__(self) -> Iterator: ...

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -1,19 +1,29 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Scatter/shuffle Parquet support for Zephyr pipelines.
+"""Scatter/shuffle support for Zephyr pipelines.
 
-Handles the full scatter pipeline: hash-routing items to target shards,
-buffering per-shard, applying an optional combiner, sorting each buffer, and
-writing sorted chunks as Parquet row groups with envelope wrapping.
+Each source-shard's scatter output is a single binary file containing a
+sequence of zstd-compressed frames. Each frame holds the items of one sorted
+chunk for one target shard, written as repeated ``pickle.dump`` calls into a
+single zstd stream so individual items can be unpickled without materialising
+the full chunk.
 
-Also provides ScatterShard, which reads back scatter data for the reduce stage.
+A JSON sidecar (``.scatter_meta``) maps ``target_shard -> [(offset, length)]``
+byte ranges into the data file, plus per-shard ``max_chunk_rows`` and a global
+``avg_item_bytes`` estimate. Sidecars from all source shards are aggregated
+into a single ``scatter_metadata`` manifest at the end of the scatter stage,
+which reducers consume to build :class:`ScatterShard` instances.
+
+Compared to the previous Parquet-based layout this drops the Arrow dependency
+on the data plane, removes schema-evolution segment splits, and replaces
+row-group statistics with explicit byte ranges.
 """
 
 from __future__ import annotations
 
 import concurrent.futures
-import functools
+import io
 import json
 import logging
 import os
@@ -23,10 +33,7 @@ from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from typing import Any
 
-import cloudpickle
-import fsspec
-import pyarrow as pa
-import pyarrow.parquet as pq
+import zstandard as zstd
 from iris.env_resources import TaskResources as _TaskResources
 from rigging.filesystem import open_url, url_to_fs
 from rigging.timing import log_time
@@ -68,271 +75,73 @@ class ListShard:
 
 
 # ---------------------------------------------------------------------------
-# Column names and constants
+# Constants
 # ---------------------------------------------------------------------------
 
-_ZEPHYR_SHUFFLE_SHARD_IDX_COL = "shard_idx"
-_ZEPHYR_SHUFFLE_CHUNK_IDX_COL = "chunk_idx"
-_ZEPHYR_SHUFFLE_ITEM_COL = "item"
-_ZEPHYR_SHUFFLE_PICKLED_COL = "pickled"
 _SCATTER_META_SUFFIX = ".scatter_meta"
 _SCATTER_MANIFEST_NAME = "scatter_metadata"
+_SCATTER_DATA_SUFFIX = ".shuffle"
 
 _SCATTER_META_READ_CONCURRENCY = 256
-# Number of items sampled from the first flush to estimate avg_item_bytes at scatter-write time
+# Number of items sampled from the first flush to estimate avg_item_bytes.
 _SCATTER_SAMPLE_SIZE = 100
-# Fraction of total memory limit to budget for scatter read buffers
+# Fraction of total memory budgeted for read-side decompression buffers.
 _SCATTER_READ_BUFFER_FRACTION = 0.25
 
-
-# ---------------------------------------------------------------------------
-# Filesystem helpers
-# ---------------------------------------------------------------------------
-
-
-@functools.cache
-def _get_scatter_read_fs(num_files: int, sample_path: str, memory_fraction: float = 0.05) -> pa.fs.FileSystem:
-    """Return a pyarrow filesystem with per-file block_size budgeted from available memory.
-
-    Caps total fsspec buffer memory at ``memory_fraction`` of the worker's RAM,
-    split evenly across ``num_files``.  Falls back to a default fsspec-backed
-    filesystem when the budget is large enough or ``block_size`` is not supported.
-    """
-    fs, _ = fsspec.core.url_to_fs(sample_path)
-    default_fs = pa.fs.PyFileSystem(pa.fs.FSSpecHandler(fs))
-
-    if num_files <= 0:
-        return default_fs
-
-    total_mem = _TaskResources.from_environment().memory_bytes
-    budget = int(total_mem * memory_fraction)
-    per_file = max(budget // num_files, 64 * 1024)  # floor at 64 KB
-
-    # Only override when we would meaningfully reduce the default (~5 MB).
-    if per_file >= 5 * 1024 * 1024:
-        return default_fs
-
-    if not hasattr(fs, "blocksize"):
-        return default_fs
-
-    # Recreate the filesystem with the budgeted block_size.
-    fsspec_fs = type(fs)(block_size=per_file, **{k: v for k, v in fs.storage_options.items() if k != "block_size"})
-    logger.info(
-        "Scatter read: %d files, per-file block_size=%d KB (total budget=%.1f GB)",
-        num_files,
-        per_file // 1024,
-        budget / 1024**3,
-    )
-    return pa.fs.PyFileSystem(pa.fs.FSSpecHandler(fsspec_fs))
+_ZSTD_COMPRESS_LEVEL = 3
+# fsspec block_size for read-side file handles (one per open chunk during
+# k-way merge). Kept small so N concurrent handles do not blow the budget.
+_READ_BLOCK_SIZE = 64 * 1024
 
 
 # ---------------------------------------------------------------------------
-# ScatterParquetIterator
+# Sidecar / manifest helpers
 # ---------------------------------------------------------------------------
 
 
-@dataclass(frozen=True)
-class ScatterParquetIterator:
-    """Reference to sorted chunks for one target shard in one Parquet file.
-
-    Opens the file via ``pq.ParquetFile`` and uses Parquet row-group
-    statistics on ``(shard_idx, chunk_idx)`` for predicate pushdown,
-    avoiding the ``pyarrow.dataset`` memory leak (apache/arrow#39808).
-    """
-
-    path: str
-    shard_idx: int
-    chunk_count: int
-    is_pickled: bool
-    filesystem: pa.fs.FileSystem
-
-    def __iter__(self) -> Iterator:
-        for chunk_iter in self.get_chunk_iterators():
-            yield from chunk_iter
-
-    def get_chunk_iterators(self, batch_size: int = 1024) -> Iterator[Iterator]:
-        """Yield one lazy iterator per sorted chunk.
-
-        Opens the file once via ``pq.ParquetFile`` and uses row-group
-        statistics to skip non-matching row groups (equivalent to dataset
-        Scanner predicate pushdown for the scatter envelope columns).
-        """
-
-        _, fs_path = url_to_fs(self.path)
-        pf = pq.ParquetFile(self.filesystem.open_input_file(fs_path))
-        col = _ZEPHYR_SHUFFLE_PICKLED_COL if self.is_pickled else _ZEPHYR_SHUFFLE_ITEM_COL
-
-        for chunk_idx in range(self.chunk_count):
-            yield self._iter_chunk(pf, col, chunk_idx)
-
-    def _iter_chunk(self, pf: pq.ParquetFile, col: str, chunk_idx: int) -> Iterator:
-        from zephyr.readers import iter_parquet_row_groups
-
-        # The scatter writer writes one (shard_idx, chunk_idx) per row group,
-        # so equality_predicates on min/max statistics skip non-matching row
-        # groups without reading data — equivalent to dataset predicate pushdown.
-        for table in iter_parquet_row_groups(
-            pf,
-            columns=[col],
-            equality_predicates={
-                _ZEPHYR_SHUFFLE_SHARD_IDX_COL: self.shard_idx,
-                _ZEPHYR_SHUFFLE_CHUNK_IDX_COL: chunk_idx,
-            },
-        ):
-            items = table.column(col).to_pylist()
-            if self.is_pickled:
-                yield from (pickle.loads(b) for b in items)
-            else:
-                yield from items
-
-
-# ---------------------------------------------------------------------------
-# ScatterShard
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class ScatterShard:
-    """Shard backed by scatter Parquet files for one target shard.
-
-    Each ``iterator`` is a ScatterParquetIterator pointing to sorted chunks
-    in a single Parquet file. ``get_iterators`` yields per-sorted-chunk
-    iterators across all files for the k-way merge in Reduce.
-    """
-
-    iterators: list[ScatterParquetIterator]
-    max_row_group_rows: int = 100_000  # conservative default = chunk_size
-    avg_item_bytes: float = 0.0  # 0.0 = unknown, will probe on demand
-
-    def __iter__(self) -> Iterator:
-        for it in self.iterators:
-            yield from it
-
-    def get_iterators(self) -> Iterator[Iterator]:
-        batch_size = self._compute_batch_size()
-        for it in self.iterators:
-            yield from it.get_chunk_iterators(batch_size=batch_size)
-
-    def needs_external_sort(self, memory_limit: int, memory_fraction: float = 0.5) -> bool:
-        """Return True if opening all chunk iterators simultaneously would exceed memory_fraction of memory_limit."""
-        total_chunks = sum(it.chunk_count for it in self.iterators)
-        if total_chunks == 0:
-            return False
-        if self.avg_item_bytes <= 0:
-            raise ValueError(
-                "avg_item_bytes not available in scatter manifest. "
-                "Re-run the scatter stage with a version that records avg_item_bytes."
-            )
-        estimated = total_chunks * self.max_row_group_rows * self.avg_item_bytes
-        return estimated > memory_limit * memory_fraction
-
-    def _compute_batch_size(self) -> int:
-        """Compute a safe batch_size that keeps scatter read buffers within budget.
-
-        With N total chunk iterators in the k-way merge, each holding one
-        batch of batch_size deserialized items in memory simultaneously,
-        the total buffer footprint is N * batch_size * bytes_per_item.
-        We cap this at _SCATTER_READ_BUFFER_FRACTION of the worker's memory limit.
-        """
-        total_chunks = sum(it.chunk_count for it in self.iterators)
-        if total_chunks == 0:
-            return 1024
-        if self.avg_item_bytes <= 0:
-            raise ValueError(
-                "avg_item_bytes not available in scatter manifest. "
-                "Re-run the scatter stage with a version that records avg_item_bytes."
-            )
-        bytes_per_item = self.avg_item_bytes
-        memory_limit = _TaskResources.from_environment().memory_bytes
-        buffer_budget = int(memory_limit * _SCATTER_READ_BUFFER_FRACTION)
-        safe = max(1, int(buffer_budget // (total_chunks * bytes_per_item)))
-        safe = min(safe, 8192)
-        logger.info(
-            "ScatterShard batch_size=%d (total_chunks=%d, bytes_per_item=%.0f, buffer_budget=%dMB, memory_limit=%dMB)",
-            safe,
-            total_chunks,
-            bytes_per_item,
-            buffer_budget // (1024 * 1024),
-            memory_limit // (1024 * 1024),
-        )
-        return safe
-
-
-# ---------------------------------------------------------------------------
-# Scatter write helpers
-# ---------------------------------------------------------------------------
-
-
-def _scatter_meta_path(parquet_path: str) -> str:
-    """Return the sidecar metadata path for a scatter Parquet file.
-
-    Replaces the ``.parquet`` extension: ``shard-0000-seg0000.parquet`` →
-    ``shard-0000-seg0000.scatter_meta``.
-    """
-    stem, _ = os.path.splitext(parquet_path)
+def _scatter_meta_path(data_path: str) -> str:
+    """``shard-0000.shuffle`` -> ``shard-0000.scatter_meta``."""
+    stem, _ = os.path.splitext(data_path)
     return stem + _SCATTER_META_SUFFIX
 
 
-def _write_scatter_meta(
-    parquet_path: str,
-    chunk_counts: dict[int, int],
-    is_pickled: bool,
-    max_chunk_rows: dict[int, int] | None = None,
-    avg_item_bytes: float = 0.0,
-) -> None:
-    """Write a ``.scatter_meta`` sidecar alongside a scatter Parquet file."""
-    meta_path = _scatter_meta_path(parquet_path)
-    payload_dict: dict = {
-        "chunk_counts": {str(k): v for k, v in chunk_counts.items()},
-    }
-    if is_pickled:
-        payload_dict["is_pickled"] = True
-    if max_chunk_rows:
-        payload_dict["max_chunk_rows"] = {str(k): v for k, v in max_chunk_rows.items() if v > 0}
-    if avg_item_bytes > 0:
-        payload_dict["avg_item_bytes"] = round(avg_item_bytes, 1)
-    payload = json.dumps(payload_dict)
-    with log_time(f"Writing scatter meta for {parquet_path} to {meta_path}", level=logging.DEBUG):
+def _write_scatter_meta(data_path: str, sidecar: dict) -> None:
+    meta_path = _scatter_meta_path(data_path)
+    payload = json.dumps(sidecar)
+    with log_time(f"Writing scatter meta for {data_path} to {meta_path}", level=logging.DEBUG):
         with open_url(meta_path, "w") as f:
             f.write(payload)
 
 
-# Per-worker cache for scatter sidecar metadata (populated on first read, shared across tasks)
+# Per-worker caches for sidecar + manifest reads.
 _scatter_meta_cache: dict[str, dict] = {}
+_scatter_manifest_cache: dict[str, list[dict]] = {}
 
 
-def _read_scatter_meta(parquet_path: str) -> dict:
-    """Read a ``.scatter_meta`` sidecar, cached per-worker."""
-    meta_path = _scatter_meta_path(parquet_path)
+def _read_scatter_meta(data_path: str) -> dict:
+    meta_path = _scatter_meta_path(data_path)
     if meta_path not in _scatter_meta_cache:
         with open_url(meta_path, "r") as f:
             _scatter_meta_cache[meta_path] = json.loads(f.read())
     return _scatter_meta_cache[meta_path]
 
 
+def _read_scatter_manifest(manifest_path: str) -> list[dict]:
+    if manifest_path not in _scatter_manifest_cache:
+        with open_url(manifest_path, "r") as f:
+            _scatter_manifest_cache[manifest_path] = json.loads(f.read())
+    return _scatter_manifest_cache[manifest_path]
+
+
 def _write_scatter_manifest(scatter_paths: list[str], output_path: str) -> None:
-    """Write a consolidated scatter manifest combining all sidecar metadata.
+    """Aggregate ``.scatter_meta`` sidecars into a single manifest.
 
-    The manifest is a JSON array of objects, each containing a scatter file
-    path alongside its chunk_counts, chunk_offsets, and is_pickled metadata.
-    Reducers read this single file instead of N individual sidecars.
-
-    Sidecar reads are parallelised via a thread pool since each is an
-    independent GCS fetch (I/O bound, O(N) sequential latency otherwise).
+    Sidecar reads run in parallel since each is an independent GCS GET.
     """
 
     def _read_entry(path: str) -> tuple[str, dict]:
         meta = _read_scatter_meta(path)
-        entry: dict = {
-            "path": path,
-            "chunk_counts": meta["chunk_counts"],
-            "is_pickled": meta.get("is_pickled", False),
-        }
-        if "max_chunk_rows" in meta:
-            entry["max_chunk_rows"] = meta["max_chunk_rows"]
-        if "avg_item_bytes" in meta:
-            entry["avg_item_bytes"] = meta["avg_item_bytes"]
-        return path, entry
+        return path, {"path": path, **meta}
 
     results: dict[str, dict] = {}
     with concurrent.futures.ThreadPoolExecutor(max_workers=_SCATTER_META_READ_CONCURRENCY) as pool:
@@ -348,108 +157,161 @@ def _write_scatter_manifest(scatter_paths: list[str], output_path: str) -> None:
             f.write(payload)
 
 
-# Per-worker cache for scatter manifests (populated on first read, shared across tasks)
-_scatter_manifest_cache: dict[str, list[dict]] = {}
+# ---------------------------------------------------------------------------
+# Reader: one source-file's chunks for one target shard
+# ---------------------------------------------------------------------------
 
 
-def _read_scatter_manifest(manifest_path: str) -> list[dict]:
-    """Read a consolidated scatter manifest, cached per-worker."""
-    if manifest_path not in _scatter_manifest_cache:
-        with open_url(manifest_path, "r") as f:
-            _scatter_manifest_cache[manifest_path] = json.loads(f.read())
-    return _scatter_manifest_cache[manifest_path]
+@dataclass(frozen=True)
+class ScatterFileIterator:
+    """Reads chunks for one target shard from one scatter file.
+
+    ``chunks`` is a tuple of ``(offset, length)`` byte ranges. Each range
+    holds one zstd frame whose decompressed bytes are a sequence of
+    ``pickle.dump`` items. Reads stream item-by-item so each open iterator
+    holds only one decoded item plus the zstd decompressor state.
+    """
+
+    path: str
+    chunks: tuple[tuple[int, int], ...]
+
+    @property
+    def chunk_count(self) -> int:
+        return len(self.chunks)
+
+    def __iter__(self) -> Iterator:
+        for chunk_iter in self.get_chunk_iterators():
+            yield from chunk_iter
+
+    def get_chunk_iterators(self) -> Iterator[Iterator]:
+        """Yield one lazy iterator per chunk, in write order."""
+        for offset, length in self.chunks:
+            yield self._iter_chunk(offset, length)
+
+    def _iter_chunk(self, offset: int, length: int) -> Iterator:
+        fs, fs_path = url_to_fs(self.path)
+        # Open one file handle per chunk so concurrent iterators in a
+        # k-way merge do not interleave seeks. block_size is small so
+        # the per-handle buffer stays bounded for many concurrent chunks.
+        f = fs.open(fs_path, "rb", block_size=_READ_BLOCK_SIZE)
+        try:
+            f.seek(offset)
+            # zstd's stream_reader does not honour zstd frame boundaries —
+            # it consumes the underlying source until EOF. Wrap with a
+            # length-bounded reader so we stop at this chunk's frame.
+            bounded = _BoundedReader(f, length)
+            with zstd.ZstdDecompressor().stream_reader(bounded, read_size=_READ_BLOCK_SIZE) as reader:
+                while True:
+                    try:
+                        yield pickle.load(reader)
+                    except EOFError:
+                        return
+        finally:
+            f.close()
+
+
+class _BoundedReader:
+    """File-like wrapper that exposes only the next ``limit`` bytes of ``source``."""
+
+    __slots__ = ("_source", "_left")
+
+    def __init__(self, source, limit: int) -> None:
+        self._source = source
+        self._left = limit
+
+    def read(self, n: int = -1) -> bytes:
+        if self._left <= 0:
+            return b""
+        if n < 0 or n > self._left:
+            n = self._left
+        data = self._source.read(n)
+        self._left -= len(data)
+        return data
+
+
+# ---------------------------------------------------------------------------
+# ScatterShard: built from manifest, fed to Reduce
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ScatterShard:
+    """All scatter chunks for one target shard, across all source files."""
+
+    iterators: list[ScatterFileIterator]
+    max_chunk_rows: int = 100_000
+    avg_item_bytes: float = 0.0
+
+    def __iter__(self) -> Iterator:
+        for it in self.iterators:
+            yield from it
+
+    def get_iterators(self) -> Iterator[Iterator]:
+        for it in self.iterators:
+            yield from it.get_chunk_iterators()
+
+    def needs_external_sort(self, memory_limit: int, memory_fraction: float = 0.5) -> bool:
+        """Return True if opening all chunks at once would blow the budget."""
+        total_chunks = sum(it.chunk_count for it in self.iterators)
+        if total_chunks == 0:
+            return False
+        if self.avg_item_bytes <= 0:
+            raise ValueError(
+                "avg_item_bytes not available in scatter manifest. "
+                "Re-run the scatter stage with a version that records avg_item_bytes."
+            )
+        # Heuristic: assume each open chunk could hold up to max_chunk_rows
+        # items in the worst case (e.g. if downstream materialises chunks).
+        estimated = total_chunks * self.max_chunk_rows * self.avg_item_bytes
+        return estimated > memory_limit * memory_fraction
 
 
 def _build_scatter_shard_from_manifest(manifest_path: str, target_shard: int) -> ScatterShard:
-    """Build a ScatterShard for one target shard from a consolidated scatter manifest."""
+    """Build a ScatterShard for one target shard from the consolidated manifest."""
     entries = _read_scatter_manifest(manifest_path)
-    iterators: list[ScatterParquetIterator] = []
+    iterators: list[ScatterFileIterator] = []
+    shard_key = str(target_shard)
+    max_rows = 0
+    weighted_bytes = 0.0
+    total_chunks_for_avg = 0
+
     with log_time(f"Building ScatterShard for target shard {target_shard} from manifest ({len(entries)} files)"):
-        # Filter to entries that have data for this shard
-        shard_key = str(target_shard)
-        file_entries = []
         for entry in entries:
-            count = entry["chunk_counts"].get(shard_key, 0)
-            if count > 0:
-                file_entries.append((entry, count))
+            shards = entry.get("shards", {})
+            ranges = shards.get(shard_key)
+            if not ranges:
+                continue
 
-        sample_path = file_entries[0][0]["path"] if file_entries else ""
-        filesystem = _get_scatter_read_fs(len(file_entries), sample_path)
-
-        # Single pass: build iterators and aggregate stats
-        max_rg_rows = 0
-        total_chunks_for_avg = 0
-        weighted_bytes = 0.0
-        for entry, count in file_entries:
             iterators.append(
-                ScatterParquetIterator(
+                ScatterFileIterator(
                     path=entry["path"],
-                    shard_idx=target_shard,
-                    chunk_count=count,
-                    is_pickled=entry.get("is_pickled", False),
-                    filesystem=filesystem,
+                    chunks=tuple((int(off), int(length)) for off, length in ranges),
                 )
             )
 
-            # max_chunk_rows is a per-shard dict; fall back to old scalar max_row_group_rows
-            per_shard = entry.get("max_chunk_rows", {})
-            if per_shard:
-                max_rg_rows = max(max_rg_rows, per_shard.get(shard_key, 0))
-            else:
-                max_rg_rows = max(max_rg_rows, entry.get("max_row_group_rows", 0))
+            per_shard_max = entry.get("max_chunk_rows", {})
+            max_rows = max(max_rows, per_shard_max.get(shard_key, 0))
 
-            # Weighted avg item bytes (weight by chunk_count for this shard)
             ab = entry.get("avg_item_bytes", 0.0)
             if ab > 0:
+                count = len(ranges)
                 weighted_bytes += ab * count
                 total_chunks_for_avg += count
 
-        if max_rg_rows == 0:
-            max_rg_rows = 100_000  # fallback for old manifests without stats
-        avg_item_bytes = weighted_bytes / total_chunks_for_avg if total_chunks_for_avg > 0 else 0.0
+    if max_rows == 0:
+        max_rows = 100_000
+    avg_item_bytes = weighted_bytes / total_chunks_for_avg if total_chunks_for_avg > 0 else 0.0
 
-    return ScatterShard(iterators=iterators, max_row_group_rows=max_rg_rows, avg_item_bytes=avg_item_bytes)
+    return ScatterShard(iterators=iterators, max_chunk_rows=max_rows, avg_item_bytes=avg_item_bytes)
 
 
 # ---------------------------------------------------------------------------
-# Envelope helpers
+# Combiner / sort helper
 # ---------------------------------------------------------------------------
-
-
-def _make_envelope(items: list, target_shard: int, chunk_idx: int) -> list[dict]:
-    return [
-        {
-            _ZEPHYR_SHUFFLE_SHARD_IDX_COL: target_shard,
-            _ZEPHYR_SHUFFLE_CHUNK_IDX_COL: chunk_idx,
-            _ZEPHYR_SHUFFLE_ITEM_COL: item,
-        }
-        for item in items
-    ]
-
-
-def _make_pickle_envelope(items: list, target_shard: int, chunk_idx: int) -> list[dict]:
-    """Wrap items as pickle-serialized bytes for Arrow-incompatible types."""
-    return [
-        {
-            _ZEPHYR_SHUFFLE_SHARD_IDX_COL: target_shard,
-            _ZEPHYR_SHUFFLE_CHUNK_IDX_COL: chunk_idx,
-            _ZEPHYR_SHUFFLE_PICKLED_COL: cloudpickle.dumps(item),
-        }
-        for item in items
-    ]
-
-
-def _segment_path(base_path: str, seg_idx: int) -> str:
-    """Return the file path for a given segment index.
-
-    ``shard-0000.parquet`` → ``shard-0000-seg0000.parquet``
-    """
-    stem, ext = os.path.splitext(base_path)
-    return f"{stem}-seg{seg_idx:04d}{ext}"
 
 
 def _apply_combiner(buffer: list, key_fn: Callable, combiner_fn: Callable) -> list:
-    """Apply combiner to a buffer, grouping by key and reducing locally."""
+    """Group buffer by key and reduce locally."""
     by_key: dict[object, list] = defaultdict(list)
     with log_time(f"Applying combiner to buffer of size {len(buffer)}", level=logging.DEBUG):
         for item in buffer:
@@ -460,26 +322,37 @@ def _apply_combiner(buffer: list, key_fn: Callable, combiner_fn: Callable) -> li
     return combined
 
 
-def _write_parquet_scatter(
+# ---------------------------------------------------------------------------
+# Scatter writer
+# ---------------------------------------------------------------------------
+
+
+def _write_chunk_frame(items: list) -> bytes:
+    """Encode a list of items as one zstd frame of streamed pickled items."""
+    raw = io.BytesIO()
+    cctx = zstd.ZstdCompressor(level=_ZSTD_COMPRESS_LEVEL)
+    with cctx.stream_writer(raw, closefd=False) as zf:
+        for item in items:
+            pickle.dump(item, zf, protocol=pickle.HIGHEST_PROTOCOL)
+    return raw.getvalue()
+
+
+def _write_scatter(
     items: Iterator,
     source_shard: int,
-    parquet_path: str,
+    data_path: str,
     key_fn: Callable,
     num_output_shards: int,
     sort_fn: Callable | None = None,
     combiner_fn: Callable | None = None,
-    pickled: bool = False,
 ) -> ListShard:
-    """Route items to target shards, buffer, sort, and write as Parquet row groups.
+    """Route items to target shards, buffer, sort, and append zstd chunks.
 
-    Handles the full scatter pipeline: hash-routing each item to a target shard,
-    buffering per-shard, applying an optional combiner, sorting each buffer, and
-    writing sorted chunks as Parquet row groups with envelope wrapping.
-
-    Writes ``.scatter_meta`` sidecar files alongside each Parquet segment.
+    Writes one binary data file plus one ``.scatter_meta`` sidecar.
 
     Returns:
-        A ListShard containing the segment file paths.
+        A ListShard wrapping the data file path (as the existing scatter
+        plumbing expects a list of paths).
     """
     if sort_fn is not None:
         captured_sort_fn = sort_fn
@@ -492,134 +365,72 @@ def _write_parquet_scatter(
 
     chunk_size = INTERMEDIATE_CHUNK_SIZE
 
-    # Per-segment per-shard chunk counts
-    seg_shard_counts: dict[int, dict[int, int]] = defaultdict(lambda: defaultdict(int))
-    per_shard_chunk_cnt: dict[int, int] = defaultdict(int)
     buffers: dict[int, list] = defaultdict(list)
-    n_chunks_flushed = 0
-    seg_idx = 0
-    seg_paths: list[str] = []
-    schema: pa.Schema | None = None
-    writer: pq.ParquetWriter | None = None
-    seg_file = ""
-
-    pending_chunk: pa.RecordBatch | None = None
-    pending_target: int = -1
-    pending_cnt: int = 0
-
+    # Per-shard list of (offset, length, n_items) for the sidecar.
+    shard_ranges: dict[int, list[tuple[int, int]]] = defaultdict(list)
     per_shard_max_rows: dict[int, int] = defaultdict(int)
+
     avg_item_bytes: float = 0.0
-    _sampled_avg = False
+    sampled_avg = False
+    n_chunks_written = 0
 
-    def _flush_pending():
-        nonlocal n_chunks_flushed, pending_chunk
-        if pending_chunk is None:
-            return
-        writer.write_batch(pending_chunk)
-        seg_shard_counts[seg_idx][pending_target] = seg_shard_counts[seg_idx].get(pending_target, 0) + 1
-        n_chunks_flushed += 1
-        pending_chunk = None
-        if n_chunks_flushed % 10 == 0:
-            logger.info(
-                "[shard %d segment %d] Wrote %d parquet chunks so far (latest chunk size: %d items)",
-                source_shard,
-                seg_idx,
-                n_chunks_flushed,
-                pending_cnt,
-            )
+    ensure_parent_dir(data_path)
+    fs, fs_path = url_to_fs(data_path)
 
-    def _prepare_batch(target_shard: int, buf: list) -> list[dict]:
-        """Apply combiner, sort, envelope a buffer. Returns enveloped rows."""
+    def _flush(target: int, buf: list) -> None:
+        nonlocal avg_item_bytes, sampled_avg, n_chunks_written
+
         if combiner_fn is not None:
             buf = _apply_combiner(buf, key_fn, combiner_fn)
         buf.sort(key=_sort_key)
-        shard_chunk_idx = per_shard_chunk_cnt[target_shard]
-        per_shard_chunk_cnt[target_shard] += 1
-        envelope_fn = _make_pickle_envelope if pickled else _make_envelope
-        return envelope_fn(buf, target_shard, shard_chunk_idx)
 
-    def _ensure_writer(chunk_schema: pa.Schema) -> pa.Schema:
-        """Ensure Parquet writer is open and compatible. Returns the active write schema."""
-        nonlocal schema, writer, seg_file, seg_idx, per_shard_chunk_cnt
-        if schema is None:
-            schema = chunk_schema
-            seg_file = _segment_path(parquet_path, seg_idx)
-            seg_paths.append(seg_file)
-            ensure_parent_dir(seg_file)
-            writer = pq.ParquetWriter(seg_file, schema)
-        elif chunk_schema != schema:
-            _flush_pending()
-            writer.close()
-            schema = pa.unify_schemas([schema, chunk_schema])
-            seg_idx += 1
-            per_shard_chunk_cnt = defaultdict(int)  # chunk_idx restarts at 0 in new segment
-            seg_file = _segment_path(parquet_path, seg_idx)
-            seg_paths.append(seg_file)
-            ensure_parent_dir(seg_file)
-            writer = pq.ParquetWriter(seg_file, schema)
+        if not sampled_avg and buf:
+            sample = buf[: min(len(buf), _SCATTER_SAMPLE_SIZE)]
+            total_bytes = sum(len(pickle.dumps(item, protocol=pickle.HIGHEST_PROTOCOL)) for item in sample)
+            avg_item_bytes = total_bytes / len(sample)
+            sampled_avg = True
+
+        frame = _write_chunk_frame(buf)
+        offset = out.tell()
+        out.write(frame)
+        shard_ranges[target].append((offset, len(frame)))
+        per_shard_max_rows[target] = max(per_shard_max_rows[target], len(buf))
+
+        n_chunks_written += 1
+        if n_chunks_written % 10 == 0:
             logger.info(
-                "[shard %d] Schema evolved after %d chunks; starting segment %d",
+                "[shard %d] Wrote %d scatter chunks so far (latest chunk size: %d items, %d bytes)",
                 source_shard,
-                n_chunks_flushed,
-                seg_idx,
+                n_chunks_written,
+                len(buf),
+                len(frame),
             )
-        else:
-            _flush_pending()
-        return schema
 
-    def _write_buffer(target_shard: int, buf: list) -> None:
-        """Sort a buffer and write it as a Parquet row group."""
-        nonlocal pending_chunk, pending_target, pending_cnt, avg_item_bytes, _sampled_avg
-        enveloped = _prepare_batch(target_shard, buf)
-        chunk_arrow = pa.RecordBatch.from_pylist(enveloped)
-        write_schema = _ensure_writer(chunk_arrow.schema)
-        if chunk_arrow.schema != write_schema:
-            chunk_arrow = chunk_arrow.cast(write_schema)
-        pending_chunk = chunk_arrow
-        pending_target = target_shard
-        pending_cnt = len(buf)
-        per_shard_max_rows[target_shard] = max(per_shard_max_rows[target_shard], len(buf))
+    with fs.open(fs_path, "wb") as out:
+        # Route items, flush per-shard buffers when they hit chunk_size.
+        for item in items:
+            key = key_fn(item)
+            target = deterministic_hash(key) % num_output_shards
+            buffers[target].append(item)
+            if chunk_size > 0 and len(buffers[target]) >= chunk_size:
+                _flush(target, buffers[target])
+                buffers[target] = []
 
-        # Sample avg_item_bytes once on first flush
-        if not _sampled_avg and len(enveloped) > 0:
-            sample_size = min(len(enveloped), _SCATTER_SAMPLE_SIZE)
-            sample_rows = enveloped[:sample_size]
-            if pickled:
-                total_bytes = sum(len(row[_ZEPHYR_SHUFFLE_PICKLED_COL]) for row in sample_rows)
-            else:
-                total_bytes = sum(len(pickle.dumps(row[_ZEPHYR_SHUFFLE_ITEM_COL])) for row in sample_rows)
-            avg_item_bytes = total_bytes / len(sample_rows)
-            _sampled_avg = True
+        # Flush remaining per-shard buffers in shard order so the file
+        # has a stable layout.
+        with log_time(f"Flushing remaining buffers for {data_path}"):
+            for target, buf in sorted(buffers.items()):
+                if buf:
+                    _flush(target, buf)
 
-    # Route items to target shards, flush buffers at chunk_size
-    for item in items:
-        key = key_fn(item)
-        target = deterministic_hash(key) % num_output_shards
-        buffers[target].append(item)
-        if chunk_size > 0 and len(buffers[target]) >= chunk_size:
-            _write_buffer(target, buffers[target])
-            buffers[target] = []
+    sidecar: dict = {
+        "shards": {str(k): v for k, v in shard_ranges.items()},
+        "max_chunk_rows": {str(k): v for k, v in per_shard_max_rows.items() if v > 0},
+    }
+    if avg_item_bytes > 0:
+        sidecar["avg_item_bytes"] = round(avg_item_bytes, 1)
 
-    # Flush remaining buffers — write each shard as its own row group so PyArrow
-    # can use min/max statistics on shard_idx to skip non-matching row groups on read.
-    with log_time(f"Flushing remaining buffers for {parquet_path}"):
-        _flush_pending()
-        for target, buf in sorted(buffers.items()):
-            if not buf:
-                continue
-            _write_buffer(target, buf)
-        _flush_pending()
+    with log_time(f"Writing scatter meta for {data_path}"):
+        _write_scatter_meta(data_path, sidecar)
 
-    if writer is not None:
-        writer.close()
-
-    # Write sidecar metadata for each segment.
-    # chunk_offsets track where each segment's chunks start in the global
-    # chunk_idx space (cumulative across segments from this source shard).
-    with log_time(f"Writing scatter meta for {parquet_path}"):
-        for i, path in enumerate(seg_paths):
-            counts = dict(seg_shard_counts.get(i, {}))
-            seg_max_rows = {shard: per_shard_max_rows[shard] for shard in counts if per_shard_max_rows[shard] > 0}
-            _write_scatter_meta(path, counts, pickled, seg_max_rows, avg_item_bytes)
-
-    return ListShard(refs=[MemChunk(items=seg_paths)])
+    return ListShard(refs=[MemChunk(items=[data_path])])

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -4,10 +4,9 @@
 """Scatter/shuffle support for Zephyr pipelines.
 
 Each source-shard's scatter output is a single binary file containing a
-sequence of zstd-compressed frames. Each frame holds the items of one sorted
-chunk for one target shard, written as repeated ``pickle.dump`` calls into a
-single zstd stream so individual items can be unpickled without materialising
-the full chunk.
+sequence of zstd-compressed frames. Each frame is ``zstd(pickle(items))`` —
+the entire sorted chunk for one target shard is pickled as a single list,
+then compressed as one zstd frame.
 
 A JSON sidecar (``.scatter_meta``) maps ``target_shard -> [(offset, length)]``
 byte ranges into the data file, plus per-shard ``max_chunk_rows`` and a global
@@ -15,15 +14,20 @@ byte ranges into the data file, plus per-shard ``max_chunk_rows`` and a global
 into a single ``scatter_metadata`` manifest at the end of the scatter stage,
 which reducers consume to build :class:`ScatterShard` instances.
 
-Compared to the previous Parquet-based layout this drops the Arrow dependency
-on the data plane, removes schema-evolution segment splits, and replaces
+On read, each :class:`ScatterFileIterator` issues *one* coalesced range GET
+per (source file, target shard) covering all of that shard's chunks, then
+hands per-chunk byte slices to the merge. This avoids one fsspec file open
+per chunk — the dominant cost when target shards are sharded across many
+source files.
+
+Compared to the previous Parquet-based layout this drops Arrow from the
+shuffle data plane, removes schema-evolution segment splits, and replaces
 row-group statistics with explicit byte ranges.
 """
 
 from __future__ import annotations
 
 import concurrent.futures
-import io
 import json
 import logging
 import os
@@ -89,9 +93,6 @@ _SCATTER_SAMPLE_SIZE = 100
 _SCATTER_READ_BUFFER_FRACTION = 0.25
 
 _ZSTD_COMPRESS_LEVEL = 3
-# fsspec block_size for read-side file handles (one per open chunk during
-# k-way merge). Kept small so N concurrent handles do not blow the budget.
-_READ_BLOCK_SIZE = 64 * 1024
 
 
 # ---------------------------------------------------------------------------
@@ -166,10 +167,10 @@ def _write_scatter_manifest(scatter_paths: list[str], output_path: str) -> None:
 class ScatterFileIterator:
     """Reads chunks for one target shard from one scatter file.
 
-    ``chunks`` is a tuple of ``(offset, length)`` byte ranges. Each range
-    holds one zstd frame whose decompressed bytes are a sequence of
-    ``pickle.dump`` items. Reads stream item-by-item so each open iterator
-    holds only one decoded item plus the zstd decompressor state.
+    ``chunks`` is a tuple of ``(offset, length)`` byte ranges. The constructor
+    fetches the smallest contiguous byte range covering all chunks in a
+    single GCS GET on first iteration, then yields per-chunk iterators that
+    decode lazily from the in-memory blob.
     """
 
     path: str
@@ -184,49 +185,29 @@ class ScatterFileIterator:
             yield from chunk_iter
 
     def get_chunk_iterators(self) -> Iterator[Iterator]:
-        """Yield one lazy iterator per chunk, in write order."""
-        for offset, length in self.chunks:
-            yield self._iter_chunk(offset, length)
+        """Yield one lazy iterator per chunk, in write order.
 
-    def _iter_chunk(self, offset: int, length: int) -> Iterator:
+        Issues a single coalesced ``cat_file`` covering all chunks for this
+        (source file, target shard) pair. The compressed bytes for this
+        shard are typically ~total_data / num_shards per file.
+        """
+        if not self.chunks:
+            return
+
+        start = min(off for off, _ in self.chunks)
+        end = max(off + length for off, length in self.chunks)
         fs, fs_path = url_to_fs(self.path)
-        # Open one file handle per chunk so concurrent iterators in a
-        # k-way merge do not interleave seeks. block_size is small so
-        # the per-handle buffer stays bounded for many concurrent chunks.
-        f = fs.open(fs_path, "rb", block_size=_READ_BLOCK_SIZE)
-        try:
-            f.seek(offset)
-            # zstd's stream_reader does not honour zstd frame boundaries —
-            # it consumes the underlying source until EOF. Wrap with a
-            # length-bounded reader so we stop at this chunk's frame.
-            bounded = _BoundedReader(f, length)
-            with zstd.ZstdDecompressor().stream_reader(bounded, read_size=_READ_BLOCK_SIZE) as reader:
-                while True:
-                    try:
-                        yield pickle.load(reader)
-                    except EOFError:
-                        return
-        finally:
-            f.close()
+        blob = fs.cat_file(fs_path, start=start, end=end)
+
+        for offset, length in self.chunks:
+            rel = offset - start
+            yield _decode_chunk(blob, rel, length)
 
 
-class _BoundedReader:
-    """File-like wrapper that exposes only the next ``limit`` bytes of ``source``."""
-
-    __slots__ = ("_source", "_left")
-
-    def __init__(self, source, limit: int) -> None:
-        self._source = source
-        self._left = limit
-
-    def read(self, n: int = -1) -> bytes:
-        if self._left <= 0:
-            return b""
-        if n < 0 or n > self._left:
-            n = self._left
-        data = self._source.read(n)
-        self._left -= len(data)
-        return data
+def _decode_chunk(blob: bytes, offset: int, length: int) -> Iterator:
+    """Decompress and unpickle a single chunk frame, yielding its items."""
+    items = pickle.loads(zstd.ZstdDecompressor().decompress(blob[offset : offset + length]))
+    yield from items
 
 
 # ---------------------------------------------------------------------------
@@ -328,13 +309,9 @@ def _apply_combiner(buffer: list, key_fn: Callable, combiner_fn: Callable) -> li
 
 
 def _write_chunk_frame(items: list) -> bytes:
-    """Encode a list of items as one zstd frame of streamed pickled items."""
-    raw = io.BytesIO()
-    cctx = zstd.ZstdCompressor(level=_ZSTD_COMPRESS_LEVEL)
-    with cctx.stream_writer(raw, closefd=False) as zf:
-        for item in items:
-            pickle.dump(item, zf, protocol=pickle.HIGHEST_PROTOCOL)
-    return raw.getvalue()
+    """Encode a list of items as one zstd frame: ``zstd(pickle(items))``."""
+    raw = pickle.dumps(items, protocol=pickle.HIGHEST_PROTOCOL)
+    return zstd.ZstdCompressor(level=_ZSTD_COMPRESS_LEVEL).compress(raw)
 
 
 def _write_scatter(

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -14,7 +14,7 @@ A JSON sidecar (``.scatter_meta``) maps ``target_shard -> [(offset, length)]``
 byte ranges into the data file, plus per-shard ``max_chunk_rows`` and a global
 ``avg_item_bytes`` estimate. Sidecars from all source shards are aggregated
 into a single ``scatter_metadata`` manifest at the end of the scatter stage,
-which reducers consume to build :class:`ScatterShard` instances.
+which reducers consume to build :class:`ScatterReader` instances.
 
 On read, each chunk is fetched with a single ``cat_file`` range GET (one
 HTTP request, no per-chunk file handle), then streamed via
@@ -38,6 +38,7 @@ from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from typing import Any
 
+import cloudpickle
 import zstandard as zstd
 from rigging.filesystem import open_url, url_to_fs
 from rigging.timing import log_time
@@ -178,6 +179,14 @@ class ScatterFileIterator:
 
     path: str
     chunks: tuple[tuple[int, int], ...]
+    _fs: Any = None
+    _fs_path: str = ""
+
+    def __post_init__(self) -> None:
+        if self._fs is None:
+            fs, fs_path = url_to_fs(self.path)
+            object.__setattr__(self, "_fs", fs)
+            object.__setattr__(self, "_fs_path", fs_path)
 
     @property
     def chunk_count(self) -> int:
@@ -190,10 +199,10 @@ class ScatterFileIterator:
     def get_chunk_iterators(self) -> Iterator[Iterator]:
         """Yield one lazy iterator per chunk, in write order."""
         for offset, length in self.chunks:
-            yield _iter_chunk(self.path, offset, length)
+            yield _iter_chunk(self._fs, self._fs_path, offset, length)
 
 
-def _iter_chunk(path: str, offset: int, length: int) -> Iterator:
+def _iter_chunk(fs: Any, fs_path: str, offset: int, length: int) -> Iterator:
     """Fetch one chunk's compressed bytes via cat_file and stream items.
 
     Each chunk is a zstd frame containing a sequence of pickled sub-batches
@@ -201,7 +210,6 @@ def _iter_chunk(path: str, offset: int, length: int) -> Iterator:
     sub-batch at a time, so per-iterator memory is bounded by the
     sub-batch size plus the chunk's compressed bytes.
     """
-    fs, fs_path = url_to_fs(path)
     blob = fs.cat_file(fs_path, start=offset, end=offset + length)
     with zstd.ZstdDecompressor().stream_reader(io.BytesIO(blob)) as reader:
         while True:
@@ -213,17 +221,69 @@ def _iter_chunk(path: str, offset: int, length: int) -> Iterator:
 
 
 # ---------------------------------------------------------------------------
-# ScatterShard: built from manifest, fed to Reduce
+# ScatterReader: built from manifest, fed to Reduce
 # ---------------------------------------------------------------------------
 
 
-@dataclass
-class ScatterShard:
-    """All scatter chunks for one target shard, across all source files."""
+class ScatterReader:
+    """All scatter chunks for one target shard, across all source files.
 
-    iterators: list[ScatterFileIterator]
-    max_chunk_rows: int = 100_000
-    avg_item_bytes: float = 0.0
+    Replaces the former ScatterShard dataclass + ScatterFileIterator assembly
+    + ``_build_scatter_shard_from_manifest`` builder function.
+
+    Construct via :meth:`from_manifest` for production use, or pass fields
+    directly for testing.
+    """
+
+    def __init__(
+        self,
+        iterators: list[ScatterFileIterator] | None = None,
+        max_chunk_rows: int = 100_000,
+        avg_item_bytes: float = 0.0,
+    ) -> None:
+        self.iterators: list[ScatterFileIterator] = iterators if iterators is not None else []
+        self.max_chunk_rows: int = max_chunk_rows
+        self.avg_item_bytes: float = avg_item_bytes
+
+    @classmethod
+    def from_manifest(cls, manifest_path: str, target_shard: int) -> ScatterReader:
+        """Build a ScatterReader for one target shard from the consolidated manifest."""
+        entries = _read_scatter_manifest(manifest_path)
+        shard_key = str(target_shard)
+
+        iterators: list[ScatterFileIterator] = []
+        max_rows = 0
+        weighted_bytes = 0.0
+        total_chunks_for_avg = 0
+
+        with log_time(f"Building ScatterReader for target shard {target_shard} from manifest ({len(entries)} files)"):
+            for entry in entries:
+                shards = entry.get("shards", {})
+                ranges = shards.get(shard_key)
+                if not ranges:
+                    continue
+
+                iterators.append(
+                    ScatterFileIterator(
+                        path=entry["path"],
+                        chunks=tuple((int(off), int(length)) for off, length in ranges),
+                    )
+                )
+
+                per_shard_max = entry.get("max_chunk_rows", {})
+                max_rows = max(max_rows, per_shard_max.get(shard_key, 0))
+
+                ab = entry.get("avg_item_bytes", 0.0)
+                if ab > 0:
+                    count = len(ranges)
+                    weighted_bytes += ab * count
+                    total_chunks_for_avg += count
+
+        if max_rows == 0:
+            max_rows = 100_000
+        avg_item_bytes = weighted_bytes / total_chunks_for_avg if total_chunks_for_avg > 0 else 0.0
+
+        return cls(iterators=iterators, max_chunk_rows=max_rows, avg_item_bytes=avg_item_bytes)
 
     def __iter__(self) -> Iterator:
         for it in self.iterators:
@@ -233,9 +293,20 @@ class ScatterShard:
         for it in self.iterators:
             yield from it.get_chunk_iterators()
 
+    @property
+    def total_chunks(self) -> int:
+        return sum(it.chunk_count for it in self.iterators)
+
+    @property
+    def max_compressed_chunk_bytes(self) -> int:
+        """Return the largest compressed chunk length across all files."""
+        if not self.iterators:
+            return 0
+        return max(length for file_iter in self.iterators for _, length in file_iter.chunks)
+
     def needs_external_sort(self, memory_limit: int, memory_fraction: float = 0.5) -> bool:
         """Return True if opening all chunks at once would blow the budget."""
-        total_chunks = sum(it.chunk_count for it in self.iterators)
+        total_chunks = self.total_chunks
         if total_chunks == 0:
             return False
         if self.avg_item_bytes <= 0:
@@ -249,43 +320,13 @@ class ScatterShard:
         return estimated > memory_limit * memory_fraction
 
 
-def _build_scatter_shard_from_manifest(manifest_path: str, target_shard: int) -> ScatterShard:
-    """Build a ScatterShard for one target shard from the consolidated manifest."""
-    entries = _read_scatter_manifest(manifest_path)
-    iterators: list[ScatterFileIterator] = []
-    shard_key = str(target_shard)
-    max_rows = 0
-    weighted_bytes = 0.0
-    total_chunks_for_avg = 0
+# Backward-compatible alias so plan.py isinstance checks still work.
+ScatterShard = ScatterReader
 
-    with log_time(f"Building ScatterShard for target shard {target_shard} from manifest ({len(entries)} files)"):
-        for entry in entries:
-            shards = entry.get("shards", {})
-            ranges = shards.get(shard_key)
-            if not ranges:
-                continue
 
-            iterators.append(
-                ScatterFileIterator(
-                    path=entry["path"],
-                    chunks=tuple((int(off), int(length)) for off, length in ranges),
-                )
-            )
-
-            per_shard_max = entry.get("max_chunk_rows", {})
-            max_rows = max(max_rows, per_shard_max.get(shard_key, 0))
-
-            ab = entry.get("avg_item_bytes", 0.0)
-            if ab > 0:
-                count = len(ranges)
-                weighted_bytes += ab * count
-                total_chunks_for_avg += count
-
-    if max_rows == 0:
-        max_rows = 100_000
-    avg_item_bytes = weighted_bytes / total_chunks_for_avg if total_chunks_for_avg > 0 else 0.0
-
-    return ScatterShard(iterators=iterators, max_chunk_rows=max_rows, avg_item_bytes=avg_item_bytes)
+def _build_scatter_shard_from_manifest(manifest_path: str, target_shard: int) -> ScatterReader:
+    """Build a ScatterReader for one target shard from the consolidated manifest."""
+    return ScatterReader.from_manifest(manifest_path, target_shard)
 
 
 # ---------------------------------------------------------------------------
@@ -314,7 +355,7 @@ def _write_chunk_frame(items: list) -> bytes:
     """Encode a list of items as one zstd frame of pickled sub-batches.
 
     Items are split into sub-batches of ``_SUB_BATCH_SIZE`` and each
-    sub-batch is written as a single ``pickle.dump(sublist)`` into the
+    sub-batch is written as a single ``cloudpickle.dump(sublist)`` into the
     same zstd stream. This batches per-call dispatch overhead while
     keeping per-iterator read memory bounded by the sub-batch size.
     """
@@ -322,8 +363,116 @@ def _write_chunk_frame(items: list) -> bytes:
     cctx = zstd.ZstdCompressor(level=_ZSTD_COMPRESS_LEVEL)
     with cctx.stream_writer(raw, closefd=False) as zf:
         for i in range(0, len(items), _SUB_BATCH_SIZE):
-            pickle.dump(items[i : i + _SUB_BATCH_SIZE], zf, protocol=pickle.HIGHEST_PROTOCOL)
+            cloudpickle.dump(items[i : i + _SUB_BATCH_SIZE], zf, protocol=pickle.HIGHEST_PROTOCOL)
     return raw.getvalue()
+
+
+class ScatterWriter:
+    """Writes items to a scatter data file with zstd-compressed chunks.
+
+    Items are routed to target shards by ``key_fn``, buffered, optionally
+    combined and sorted, then flushed as zstd frames. A JSON sidecar is
+    written on close.
+    """
+
+    def __init__(
+        self,
+        data_path: str,
+        key_fn: Callable,
+        num_output_shards: int,
+        source_shard: int = 0,
+        sort_fn: Callable | None = None,
+        combiner_fn: Callable | None = None,
+    ) -> None:
+        self._data_path = data_path
+        self._key_fn = key_fn
+        self._num_output_shards = num_output_shards
+        self._source_shard = source_shard
+        self._combiner_fn = combiner_fn
+        self._chunk_size = INTERMEDIATE_CHUNK_SIZE
+
+        if sort_fn is not None:
+            captured_sort_fn = sort_fn
+
+            def _sort_key(item: Any) -> Any:
+                return (key_fn(item), captured_sort_fn(item))
+
+            self._sort_key = _sort_key
+        else:
+            self._sort_key = key_fn
+
+        self._buffers: dict[int, list] = defaultdict(list)
+        self._shard_ranges: dict[int, list[tuple[int, int]]] = defaultdict(list)
+        self._per_shard_max_rows: dict[int, int] = defaultdict(int)
+        self._avg_item_bytes: float = 0.0
+        self._sampled_avg = False
+        self._n_chunks_written = 0
+
+        ensure_parent_dir(data_path)
+        fs, fs_path = url_to_fs(data_path)
+        self._out = fs.open(fs_path, "wb")
+
+    def _flush(self, target: int, buf: list) -> None:
+        if self._combiner_fn is not None:
+            buf = _apply_combiner(buf, self._key_fn, self._combiner_fn)
+        buf.sort(key=self._sort_key)
+
+        if not self._sampled_avg and buf:
+            sample = buf[: min(len(buf), _SCATTER_SAMPLE_SIZE)]
+            total_bytes = sum(len(pickle.dumps(item, protocol=pickle.HIGHEST_PROTOCOL)) for item in sample)
+            self._avg_item_bytes = total_bytes / len(sample)
+            self._sampled_avg = True
+
+        frame = _write_chunk_frame(buf)
+        offset = self._out.tell()
+        self._out.write(frame)
+        self._shard_ranges[target].append((offset, len(frame)))
+        self._per_shard_max_rows[target] = max(self._per_shard_max_rows[target], len(buf))
+
+        self._n_chunks_written += 1
+        if self._n_chunks_written % 10 == 0:
+            logger.info(
+                "[shard %d] Wrote %d scatter chunks so far (latest chunk size: %d items, %d bytes)",
+                self._source_shard,
+                self._n_chunks_written,
+                len(buf),
+                len(frame),
+            )
+
+    def write(self, item: Any) -> None:
+        """Route a single item to its target shard buffer, flushing when full."""
+        key = self._key_fn(item)
+        target = deterministic_hash(key) % self._num_output_shards
+        self._buffers[target].append(item)
+        if self._chunk_size > 0 and len(self._buffers[target]) >= self._chunk_size:
+            self._flush(target, self._buffers[target])
+            self._buffers[target] = []
+
+    def close(self) -> ListShard:
+        """Flush remaining buffers, write sidecar, return ListShard."""
+        with log_time(f"Flushing remaining buffers for {self._data_path}"):
+            for target, buf in sorted(self._buffers.items()):
+                if buf:
+                    self._flush(target, buf)
+        self._out.close()
+
+        sidecar: dict = {
+            "shards": {str(k): v for k, v in self._shard_ranges.items()},
+            "max_chunk_rows": {str(k): v for k, v in self._per_shard_max_rows.items() if v > 0},
+        }
+        if self._avg_item_bytes > 0:
+            sidecar["avg_item_bytes"] = round(self._avg_item_bytes, 1)
+
+        with log_time(f"Writing scatter meta for {self._data_path}"):
+            _write_scatter_meta(self._data_path, sidecar)
+
+        return ListShard(refs=[MemChunk(items=[self._data_path])])
+
+    def __enter__(self) -> ScatterWriter:
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
 
 
 def _write_scatter(
@@ -343,83 +492,14 @@ def _write_scatter(
         A ListShard wrapping the data file path (as the existing scatter
         plumbing expects a list of paths).
     """
-    if sort_fn is not None:
-        captured_sort_fn = sort_fn
-
-        def _sort_key(item):
-            return (key_fn(item), captured_sort_fn(item))
-
-    else:
-        _sort_key = key_fn
-
-    chunk_size = INTERMEDIATE_CHUNK_SIZE
-
-    buffers: dict[int, list] = defaultdict(list)
-    # Per-shard list of (offset, length, n_items) for the sidecar.
-    shard_ranges: dict[int, list[tuple[int, int]]] = defaultdict(list)
-    per_shard_max_rows: dict[int, int] = defaultdict(int)
-
-    avg_item_bytes: float = 0.0
-    sampled_avg = False
-    n_chunks_written = 0
-
-    ensure_parent_dir(data_path)
-    fs, fs_path = url_to_fs(data_path)
-
-    def _flush(target: int, buf: list) -> None:
-        nonlocal avg_item_bytes, sampled_avg, n_chunks_written
-
-        if combiner_fn is not None:
-            buf = _apply_combiner(buf, key_fn, combiner_fn)
-        buf.sort(key=_sort_key)
-
-        if not sampled_avg and buf:
-            sample = buf[: min(len(buf), _SCATTER_SAMPLE_SIZE)]
-            total_bytes = sum(len(pickle.dumps(item, protocol=pickle.HIGHEST_PROTOCOL)) for item in sample)
-            avg_item_bytes = total_bytes / len(sample)
-            sampled_avg = True
-
-        frame = _write_chunk_frame(buf)
-        offset = out.tell()
-        out.write(frame)
-        shard_ranges[target].append((offset, len(frame)))
-        per_shard_max_rows[target] = max(per_shard_max_rows[target], len(buf))
-
-        n_chunks_written += 1
-        if n_chunks_written % 10 == 0:
-            logger.info(
-                "[shard %d] Wrote %d scatter chunks so far (latest chunk size: %d items, %d bytes)",
-                source_shard,
-                n_chunks_written,
-                len(buf),
-                len(frame),
-            )
-
-    with fs.open(fs_path, "wb") as out:
-        # Route items, flush per-shard buffers when they hit chunk_size.
-        for item in items:
-            key = key_fn(item)
-            target = deterministic_hash(key) % num_output_shards
-            buffers[target].append(item)
-            if chunk_size > 0 and len(buffers[target]) >= chunk_size:
-                _flush(target, buffers[target])
-                buffers[target] = []
-
-        # Flush remaining per-shard buffers in shard order so the file
-        # has a stable layout.
-        with log_time(f"Flushing remaining buffers for {data_path}"):
-            for target, buf in sorted(buffers.items()):
-                if buf:
-                    _flush(target, buf)
-
-    sidecar: dict = {
-        "shards": {str(k): v for k, v in shard_ranges.items()},
-        "max_chunk_rows": {str(k): v for k, v in per_shard_max_rows.items() if v > 0},
-    }
-    if avg_item_bytes > 0:
-        sidecar["avg_item_bytes"] = round(avg_item_bytes, 1)
-
-    with log_time(f"Writing scatter meta for {data_path}"):
-        _write_scatter_meta(data_path, sidecar)
-
-    return ListShard(refs=[MemChunk(items=[data_path])])
+    writer = ScatterWriter(
+        data_path=data_path,
+        key_fn=key_fn,
+        num_output_shards=num_output_shards,
+        source_shard=source_shard,
+        sort_fn=sort_fn,
+        combiner_fn=combiner_fn,
+    )
+    for item in items:
+        writer.write(item)
+    return writer.close()

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -43,7 +43,6 @@ from dataclasses import dataclass
 from typing import Any
 
 import zstandard as zstd
-from iris.env_resources import TaskResources as _TaskResources
 from rigging.filesystem import open_url, url_to_fs
 from rigging.timing import log_time
 

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -4,9 +4,11 @@
 """Scatter/shuffle support for Zephyr pipelines.
 
 Each source-shard's scatter output is a single binary file containing a
-sequence of zstd-compressed frames. Each frame is ``zstd(pickle(items))`` —
-the entire sorted chunk for one target shard is pickled as a single list,
-then compressed as one zstd frame.
+sequence of zstd-compressed frames. Within one chunk's zstd frame, items
+are written in sub-batches of ``_SUB_BATCH_SIZE`` — each sub-batch is a
+single ``pickle.dump(list_of_items)`` into the zstd stream. This amortises
+per-item pickle/zstd dispatch over a sub-batch while still letting the
+reader stream sub-batches lazily without materialising the full chunk.
 
 A JSON sidecar (``.scatter_meta``) maps ``target_shard -> [(offset, length)]``
 byte ranges into the data file, plus per-shard ``max_chunk_rows`` and a global
@@ -14,11 +16,13 @@ byte ranges into the data file, plus per-shard ``max_chunk_rows`` and a global
 into a single ``scatter_metadata`` manifest at the end of the scatter stage,
 which reducers consume to build :class:`ScatterShard` instances.
 
-On read, each :class:`ScatterFileIterator` issues *one* coalesced range GET
-per (source file, target shard) covering all of that shard's chunks, then
-hands per-chunk byte slices to the merge. This avoids one fsspec file open
-per chunk — the dominant cost when target shards are sharded across many
-source files.
+On read, each chunk is fetched with a single ``cat_file`` range GET (one
+HTTP request, no per-chunk file handle), then streamed via
+``pickle.load`` on a length-bounded zstd reader. Per-iterator memory stays
+near-constant: one buffered item plus the zstd decoder state plus the
+chunk's compressed bytes (typically a few MB). This bound is essential for
+skewed shuffles where one reducer pulls disproportionate data and the
+external-sort fan-in opens hundreds of chunk iterators at once.
 
 Compared to the previous Parquet-based layout this drops Arrow from the
 shuffle data plane, removes schema-evolution segment splits, and replaces
@@ -28,6 +32,7 @@ row-group statistics with explicit byte ranges.
 from __future__ import annotations
 
 import concurrent.futures
+import io
 import json
 import logging
 import os
@@ -93,6 +98,9 @@ _SCATTER_SAMPLE_SIZE = 100
 _SCATTER_READ_BUFFER_FRACTION = 0.25
 
 _ZSTD_COMPRESS_LEVEL = 3
+# Items per pickle.dump call within a chunk. Larger = faster (less per-call
+# dispatch overhead), smaller = lower per-iterator read memory.
+_SUB_BATCH_SIZE = 1024
 
 
 # ---------------------------------------------------------------------------
@@ -167,10 +175,10 @@ def _write_scatter_manifest(scatter_paths: list[str], output_path: str) -> None:
 class ScatterFileIterator:
     """Reads chunks for one target shard from one scatter file.
 
-    ``chunks`` is a tuple of ``(offset, length)`` byte ranges. The constructor
-    fetches the smallest contiguous byte range covering all chunks in a
-    single GCS GET on first iteration, then yields per-chunk iterators that
-    decode lazily from the in-memory blob.
+    ``chunks`` is a tuple of ``(offset, length)`` byte ranges. Each chunk is
+    fetched on demand via a single ``cat_file`` and streamed item-by-item.
+    Per-iterator memory is bounded by the chunk's compressed size (typically
+    a few MB) plus tiny zstd/pickle state.
     """
 
     path: str
@@ -185,29 +193,28 @@ class ScatterFileIterator:
             yield from chunk_iter
 
     def get_chunk_iterators(self) -> Iterator[Iterator]:
-        """Yield one lazy iterator per chunk, in write order.
-
-        Issues a single coalesced ``cat_file`` covering all chunks for this
-        (source file, target shard) pair. The compressed bytes for this
-        shard are typically ~total_data / num_shards per file.
-        """
-        if not self.chunks:
-            return
-
-        start = min(off for off, _ in self.chunks)
-        end = max(off + length for off, length in self.chunks)
-        fs, fs_path = url_to_fs(self.path)
-        blob = fs.cat_file(fs_path, start=start, end=end)
-
+        """Yield one lazy iterator per chunk, in write order."""
         for offset, length in self.chunks:
-            rel = offset - start
-            yield _decode_chunk(blob, rel, length)
+            yield _iter_chunk(self.path, offset, length)
 
 
-def _decode_chunk(blob: bytes, offset: int, length: int) -> Iterator:
-    """Decompress and unpickle a single chunk frame, yielding its items."""
-    items = pickle.loads(zstd.ZstdDecompressor().decompress(blob[offset : offset + length]))
-    yield from items
+def _iter_chunk(path: str, offset: int, length: int) -> Iterator:
+    """Fetch one chunk's compressed bytes via cat_file and stream items.
+
+    Each chunk is a zstd frame containing a sequence of pickled sub-batches
+    (lists of up to ``_SUB_BATCH_SIZE`` items). The reader streams one
+    sub-batch at a time, so per-iterator memory is bounded by the
+    sub-batch size plus the chunk's compressed bytes.
+    """
+    fs, fs_path = url_to_fs(path)
+    blob = fs.cat_file(fs_path, start=offset, end=offset + length)
+    with zstd.ZstdDecompressor().stream_reader(io.BytesIO(blob)) as reader:
+        while True:
+            try:
+                sub_batch = pickle.load(reader)
+            except EOFError:
+                return
+            yield from sub_batch
 
 
 # ---------------------------------------------------------------------------
@@ -309,9 +316,19 @@ def _apply_combiner(buffer: list, key_fn: Callable, combiner_fn: Callable) -> li
 
 
 def _write_chunk_frame(items: list) -> bytes:
-    """Encode a list of items as one zstd frame: ``zstd(pickle(items))``."""
-    raw = pickle.dumps(items, protocol=pickle.HIGHEST_PROTOCOL)
-    return zstd.ZstdCompressor(level=_ZSTD_COMPRESS_LEVEL).compress(raw)
+    """Encode a list of items as one zstd frame of pickled sub-batches.
+
+    Items are split into sub-batches of ``_SUB_BATCH_SIZE`` and each
+    sub-batch is written as a single ``pickle.dump(sublist)`` into the
+    same zstd stream. This batches per-call dispatch overhead while
+    keeping per-iterator read memory bounded by the sub-batch size.
+    """
+    raw = io.BytesIO()
+    cctx = zstd.ZstdCompressor(level=_ZSTD_COMPRESS_LEVEL)
+    with cctx.stream_writer(raw, closefd=False) as zf:
+        for i in range(0, len(items), _SUB_BATCH_SIZE):
+            pickle.dump(items[i : i + _SUB_BATCH_SIZE], zf, protocol=pickle.HIGHEST_PROTOCOL)
+    return raw.getvalue()
 
 
 def _write_scatter(

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -23,10 +23,6 @@ near-constant: one buffered item plus the zstd decoder state plus the
 chunk's compressed bytes (typically a few MB). This bound is essential for
 skewed shuffles where one reducer pulls disproportionate data and the
 external-sort fan-in opens hundreds of chunk iterators at once.
-
-Compared to the previous Parquet-based layout this drops Arrow from the
-shuffle data plane, removes schema-evolution segment splits, and replaces
-row-group statistics with explicit byte ranges.
 """
 
 from __future__ import annotations

--- a/lib/zephyr/src/zephyr/writers.py
+++ b/lib/zephyr/src/zephyr/writers.py
@@ -40,7 +40,7 @@ _MICRO_BATCH_SIZE = 8
 _LEVANTER_BATCH_SIZE = 16384
 
 # Number of items per intermediate chunk for pickle and scatter writes.
-# Used by both _write_pickle_chunks (execution.py) and _write_parquet_scatter (shuffle.py).
+# Used by both _write_pickle_chunks (execution.py) and _write_scatter (shuffle.py).
 INTERMEDIATE_CHUNK_SIZE = 100_000
 
 

--- a/lib/zephyr/tests/test_groupby.py
+++ b/lib/zephyr/tests/test_groupby.py
@@ -361,26 +361,18 @@ def test_group_by_non_vortex_serializable(zephyr_ctx):
     assert results[1] == {"key": "b", "value": frozenset([2])}
 
 
-def test_scatter_parquet_iterator_pickle_roundtrip(tmp_path):
-    """ScatterParquetIterator with is_pickled=True round-trips non-Arrow-serializable items."""
-    import pyarrow.parquet as pq
-
-    from zephyr.shuffle import ScatterParquetIterator, _make_pickle_envelope
+def test_scatter_file_iterator_pickle_roundtrip(tmp_path):
+    """ScatterFileIterator round-trips non-Arrow-serializable items (e.g. frozenset)."""
+    from zephyr.shuffle import ScatterFileIterator, _write_chunk_frame
 
     items = [frozenset([1, 2]), frozenset([3, 4, 5])]
-    envelope = _make_pickle_envelope(items, target_shard=0, chunk_idx=0)
-    batch = pa.RecordBatch.from_pylist(envelope)
+    frame = _write_chunk_frame(items)
 
-    path = str(tmp_path / "test.parquet")
-    pq.write_table(pa.Table.from_batches([batch]), path)
+    path = str(tmp_path / "test.shuffle")
+    with open(path, "wb") as f:
+        f.write(frame)
 
-    it = ScatterParquetIterator(
-        path=path,
-        shard_idx=0,
-        chunk_count=1,
-        is_pickled=True,
-        filesystem=pa.fs.LocalFileSystem(),
-    )
+    it = ScatterFileIterator(path=path, chunks=((0, len(frame)),))
     chunks = [list(chunk_iter) for chunk_iter in it.get_chunk_iterators()]
     assert len(chunks) == 1
     assert chunks[0] == items

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -3,26 +3,19 @@
 
 """Unit tests for zephyr/shuffle.py.
 
-Tests the scatter write/read roundtrip, per-shard stats, needs_external_sort,
-and multi-segment schema evolution — all without spinning up a full coordinator.
+Covers the scatter write/read roundtrip, per-shard stats, and external sort —
+without spinning up a full coordinator.
 """
-
-import pyarrow as pa
-import pyarrow.parquet as pq
 
 from zephyr.plan import deterministic_hash
 from zephyr.shuffle import (
-    ScatterParquetIterator,
+    ScatterFileIterator,
     ScatterShard,
     _build_scatter_shard_from_manifest,
-    _make_pickle_envelope,
-    _write_parquet_scatter,
+    _write_chunk_frame,
+    _write_scatter,
     _write_scatter_manifest,
 )
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 
 def _key(item):
@@ -34,19 +27,19 @@ def _target(key, num_shards):
 
 
 def _build_shard(tmp_path, items, num_output_shards=4, source_shard=0):
-    """Write a scatter file and manifest; return (manifest_path, seg_paths)."""
-    parquet_path = str(tmp_path / f"shard-{source_shard:04d}.parquet")
-    list_shard = _write_parquet_scatter(
+    """Write a scatter file and manifest; return (manifest_path, data_paths)."""
+    data_path = str(tmp_path / f"shard-{source_shard:04d}.shuffle")
+    list_shard = _write_scatter(
         iter(items),
         source_shard=source_shard,
-        parquet_path=parquet_path,
+        data_path=data_path,
         key_fn=_key,
         num_output_shards=num_output_shards,
     )
-    seg_paths = list(list_shard)
+    data_paths = list(list_shard)
     manifest_path = str(tmp_path / "scatter_metadata")
-    _write_scatter_manifest(seg_paths, manifest_path)
-    return manifest_path, seg_paths
+    _write_scatter_manifest(data_paths, manifest_path)
+    return manifest_path, data_paths
 
 
 # ---------------------------------------------------------------------------
@@ -60,7 +53,6 @@ def test_scatter_roundtrip(tmp_path):
     items = [{"k": i % 4, "v": i} for i in range(40)]
     manifest_path, _ = _build_shard(tmp_path, items, num_output_shards=num_shards)
 
-    # Collect all items across all shards
     recovered = []
     for shard_idx in range(num_shards):
         shard = _build_scatter_shard_from_manifest(manifest_path, shard_idx)
@@ -96,31 +88,25 @@ def test_scatter_roundtrip_sorted_chunks(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Per-shard max_chunk_rows — no cross-shard contamination
+# Per-shard stats — no cross-shard contamination
 # ---------------------------------------------------------------------------
 
 
 def test_max_chunk_rows_per_shard(tmp_path):
-    """max_row_group_rows reflects only the target shard's row groups, not a global max.
-
-    We create a skewed distribution: one key has many items (large row group),
-    another has few (small row group). Verify each shard's stat is accurate.
-    """
+    """max_chunk_rows reflects only the target shard's chunks, not a global max."""
     num_shards = 4
-    # k=3 → shard 0 (deterministic_hash(3) % 4 == 0): send 500 items
-    # k=0 → shard 1 (deterministic_hash(0) % 4 == 1): send 2 items
     items = [{"k": 3, "v": i} for i in range(500)]
     items += [{"k": 0, "v": i + 1000} for i in range(2)]
 
     manifest_path, _ = _build_shard(tmp_path, items, num_output_shards=num_shards)
 
-    shard0 = _build_scatter_shard_from_manifest(manifest_path, 0)  # k=3, 500 items
-    shard1 = _build_scatter_shard_from_manifest(manifest_path, 1)  # k=0, 2 items
+    shard0 = _build_scatter_shard_from_manifest(manifest_path, 0)
+    shard1 = _build_scatter_shard_from_manifest(manifest_path, 1)
 
-    assert shard0.max_row_group_rows == 500
-    assert shard1.max_row_group_rows == 2, (
-        f"shard1 max_chunk_rows={shard1.max_row_group_rows}, expected 2; "
-        "contamination from shard0's large row group would show 500"
+    assert shard0.max_chunk_rows == 500
+    assert shard1.max_chunk_rows == 2, (
+        f"shard1 max_chunk_rows={shard1.max_chunk_rows}, expected 2; "
+        "contamination from shard0's large chunk would show 500"
     )
 
 
@@ -129,19 +115,10 @@ def test_max_chunk_rows_per_shard(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_needs_external_sort_triggers(tmp_path):
-    """needs_external_sort returns True when estimated memory exceeds the budget."""
+def test_needs_external_sort_triggers():
     shard = ScatterShard(
-        iterators=[
-            ScatterParquetIterator(
-                path="gs://fake/path.parquet",
-                shard_idx=0,
-                chunk_count=1000,
-                is_pickled=False,
-                filesystem=pa.fs.LocalFileSystem(),
-            )
-        ],
-        max_row_group_rows=1000,
+        iterators=[ScatterFileIterator(path="gs://fake/path.shuffle", chunks=tuple((i, 1) for i in range(1000)))],
+        max_chunk_rows=1000,
         avg_item_bytes=1000.0,
     )
     # 1000 chunks * 1000 rows * 1000 bytes = 1 GB > 0.5 * 1 GB
@@ -149,98 +126,76 @@ def test_needs_external_sort_triggers(tmp_path):
 
 
 def test_needs_external_sort_below_threshold(tmp_path):
-    """needs_external_sort returns False for a small shard well within budget."""
     items = [{"k": 0, "v": i} for i in range(5)]
     manifest_path, _ = _build_shard(tmp_path, items, num_output_shards=1)
-    # k=0 → deterministic_hash(0) % 1 = 0
     shard = _build_scatter_shard_from_manifest(manifest_path, 0)
     assert not shard.needs_external_sort(memory_limit=32 * 1024**3)
 
 
 def test_needs_external_sort_empty_shard():
-    """needs_external_sort returns False for a shard with no chunks."""
-    shard = ScatterShard(iterators=[], max_row_group_rows=100_000, avg_item_bytes=200.0)
+    shard = ScatterShard(iterators=[], max_chunk_rows=100_000, avg_item_bytes=200.0)
     assert not shard.needs_external_sort(memory_limit=32 * 1024**3)
 
 
 # ---------------------------------------------------------------------------
-# Schema evolution (multi-segment)
+# avg_item_bytes
 # ---------------------------------------------------------------------------
 
 
-def test_schema_evolution_multi_segment(tmp_path):
-    """Items with evolving schemas across shards create multiple segments.
+def test_avg_item_bytes_written(tmp_path):
+    items = [{"k": 0, "v": i} for i in range(20)]
+    manifest_path, _ = _build_shard(tmp_path, items, num_output_shards=1)
+    shard = _build_scatter_shard_from_manifest(manifest_path, 0)
+    assert shard.avg_item_bytes > 0
 
-    k=1 → shard 0 (hash(1)%2=0): score is int  — written first (shard 0)
-    k=0 → shard 1 (hash(0)%2=1): score is None — written second (shard 1)
 
-    int64 != null triggers schema evolution and a second segment.
-    All items are still recovered correctly.
-    """
-    # k=1 items → shard 0, score is int (non-null)
-    items = [{"k": 1, "v": i, "score": i} for i in range(5)]
-    # k=0 items → shard 1, score is None
-    items += [{"k": 0, "v": i + 100, "score": None} for i in range(5)]
+# ---------------------------------------------------------------------------
+# Mixed-type values (dropped Parquet's schema constraint)
+# ---------------------------------------------------------------------------
 
-    parquet_path = str(tmp_path / "shard-0000.parquet")
-    list_shard = _write_parquet_scatter(
-        iter(items),
-        source_shard=0,
-        parquet_path=parquet_path,
-        key_fn=_key,
-        num_output_shards=2,
-    )
-    seg_paths = list(list_shard)
-    assert len(seg_paths) >= 2, "expected multiple segments from schema evolution"
 
-    manifest_path = str(tmp_path / "scatter_metadata")
-    _write_scatter_manifest(seg_paths, manifest_path)
+def test_scatter_handles_arbitrary_python_objects(tmp_path):
+    """Values that are not Arrow-friendly (frozenset, mixed None/int) round-trip."""
+    items = [
+        {"k": 0, "v": frozenset([1, 2, 3])},
+        {"k": 0, "v": frozenset([4, 5])},
+        {"k": 1, "v": None},
+        {"k": 1, "v": frozenset([6])},
+    ]
+    manifest_path, _ = _build_shard(tmp_path, items, num_output_shards=2)
 
     recovered = []
     for shard_idx in range(2):
         shard = _build_scatter_shard_from_manifest(manifest_path, shard_idx)
         recovered.extend(list(shard))
 
-    assert sorted(recovered, key=lambda x: x["v"]) == sorted(items, key=lambda x: x["v"])
+    def _ord(x):
+        return (x["k"], repr(x["v"]))
+
+    assert sorted(recovered, key=_ord) == sorted(items, key=_ord)
 
 
 # ---------------------------------------------------------------------------
-# avg_item_bytes stat
+# ScatterFileIterator low-level
 # ---------------------------------------------------------------------------
 
 
-def test_avg_item_bytes_written(tmp_path):
-    """avg_item_bytes is written to the manifest and recovered in ScatterShard."""
-    items = [{"k": 0, "v": i} for i in range(20)]
-    manifest_path, _ = _build_shard(tmp_path, items, num_output_shards=1)
-    shard = _build_scatter_shard_from_manifest(manifest_path, 0)
-    assert shard.avg_item_bytes > 0, "avg_item_bytes should be populated from manifest"
+def test_scatter_file_iterator_multiple_chunks(tmp_path):
+    """Multiple frames in one file are read in declared order."""
+    chunk_a = [{"i": i} for i in range(5)]
+    chunk_b = [{"i": i} for i in range(100, 103)]
 
+    frame_a = _write_chunk_frame(chunk_a)
+    frame_b = _write_chunk_frame(chunk_b)
 
-# ---------------------------------------------------------------------------
-# Pickle roundtrip
-# ---------------------------------------------------------------------------
+    path = str(tmp_path / "two-chunks.shuffle")
+    with open(path, "wb") as f:
+        f.write(frame_a)
+        f.write(frame_b)
 
-
-def test_scatter_parquet_iterator_pickle_roundtrip(tmp_path):
-    """ScatterParquetIterator with is_pickled=True round-trips non-Arrow-serializable items."""
-    items = [frozenset([1, 2]), frozenset([3, 4, 5])]
-    envelope = _make_pickle_envelope(items, target_shard=0, chunk_idx=0)
-    batch = pa.RecordBatch.from_pylist(envelope)
-
-    path = str(tmp_path / "test.parquet")
-    pq.write_table(pa.Table.from_batches([batch]), path)
-
-    it = ScatterParquetIterator(
-        path=path,
-        shard_idx=0,
-        chunk_count=1,
-        is_pickled=True,
-        filesystem=pa.fs.LocalFileSystem(),
-    )
-    chunks = [list(chunk_iter) for chunk_iter in it.get_chunk_iterators()]
-    assert len(chunks) == 1
-    assert chunks[0] == items
+    it = ScatterFileIterator(path=path, chunks=((0, len(frame_a)), (len(frame_a), len(frame_b))))
+    chunks = [list(c) for c in it.get_chunk_iterators()]
+    assert chunks == [chunk_a, chunk_b]
 
 
 # ---------------------------------------------------------------------------
@@ -249,18 +204,14 @@ def test_scatter_parquet_iterator_pickle_roundtrip(tmp_path):
 
 
 def test_external_sort_merge_streaming(tmp_path):
-    """external_sort_merge streams items to disk; output is fully sorted."""
     from zephyr.external_sort import external_sort_merge
 
-    # Build 3 sorted iterators, more than would fit in one batch if fan-in were 2
     iters = [iter([1, 4, 7]), iter([2, 5, 8]), iter([3, 6, 9])]
-
     result = list(external_sort_merge(iter(iters), merge_key=lambda x: x, external_sort_dir=str(tmp_path)))
     assert result == list(range(1, 10))
 
 
 def test_external_sort_merge_single_batch(tmp_path):
-    """Works correctly when all iterators fit in a single pass-1 batch."""
     from zephyr.external_sort import external_sort_merge
 
     iters = [iter([i]) for i in range(10)]
@@ -269,10 +220,8 @@ def test_external_sort_merge_single_batch(tmp_path):
 
 
 def test_external_sort_merge_cleans_up(tmp_path):
-    """Run files are deleted after the merge completes."""
-    from zephyr.external_sort import external_sort_merge, EXTERNAL_SORT_FAN_IN
+    from zephyr.external_sort import EXTERNAL_SORT_FAN_IN, external_sort_merge
 
-    # Force multiple batches by making more iterators than EXTERNAL_SORT_FAN_IN
     iters = [iter([i]) for i in range(EXTERNAL_SORT_FAN_IN + 1)]
     list(external_sort_merge(iter(iters), merge_key=lambda x: x, external_sort_dir=str(tmp_path)))
     assert list(tmp_path.iterdir()) == [], "run files should be deleted after merge"


### PR DESCRIPTION
## Summary
- Replaces Parquet-based scatter/reduce shuffle with flat zstd frames + byte-range sidecar. Drops Arrow from the shuffle data plane.
- Adds memory-bounded external-sort fan-in and byte-budgeted pass-1 spill batch so skewed and large-item shuffles don't OOM the worker.
- Net **−165 lines** across `shuffle.py` / `external_sort.py` / `plan.py` / `execution.py`.

## Format

Each scatter source writes a single binary file: a concatenation of zstd frames. Each frame is one sorted chunk, containing repeated `pickle.dump(sub_batch)` calls into a single zstd stream (sub-batch size = 1024 items by default). A JSON `.scatter_meta` sidecar maps `target_shard → [(offset, length)]`. Sidecars aggregate into one `scatter_metadata` manifest per stage (wire format unchanged from before).

On read, `ScatterFileIterator` fetches each chunk via one `cat_file` range GET and streams sub-batches with `pickle.load`. Per-iterator memory is bounded by `sub_batch_size * avg_item_bytes + chunk_compressed_bytes` — independent of chunk row count.

Gone:
- Segment-rotation for schema evolution (`_ensure_writer`, `seg_idx`, `pa.unify_schemas`)
- Arrow-vs-pickle envelope peek (`use_pickle_envelope`, `pa.RecordBatch.from_pylist`)
- Row-group statistics + predicate pushdown (`equality_predicates`, `iter_parquet_row_groups`)
- PyArrow dataset memory-leak workaround (`_get_scatter_read_fs`, block-size budgeting)
- `pyarrow` on the shuffle data plane

## External-sort scaling

Two knobs now scale with the workload instead of being hardcoded:

- `compute_fan_in(per_iter_bytes, mem_limit)` — pass-1 fan-in floored at 4, capped at `EXTERNAL_SORT_FAN_IN=500`, otherwise sized to fit 50% of worker memory given `max_chunk_rows * avg_item_bytes` per open chunk.
- `compute_write_batch_size(avg_item_bytes)` — pass-1 `pending` buffer sized to ~64 MB of items (capped at 10k). Prior fixed `_WRITE_BATCH_SIZE=10_000` could OOM at 10 GB on 1 MB items.

`_merge_sorted_chunks` reads `shard.max_chunk_rows` and `shard.avg_item_bytes` from the manifest and passes both values through `external_sort_merge`.

## Benchmarks on marin-dev (4 workers × 8 GB RAM)

| Workload | Baseline (Parquet) | New | Hot-worker peak mem |
|---|---|---|---|
| Uniform 10 GB, 250 B items | 736 s | **392 s** | 551 MB |
| Uniform 10 GB, 1 MB items | — | **352 s** | 621 MB |
| Skew 90% 10 GB, 250 B items | **OOM** | 800 s | 3.09 GB |
| Skew 90% 10 GB, 1 MB items | **OOM** | 1349 s | 7.18 GB |
| Skew 90% 50 GB, 250 B items | **OOM** | 7796 s* | 3.58 GB |
| Skew 90% 50 GB, 1 MB items | **OOM** | 2996 s | 7.33 GB |

*Includes ~35 min lost to a mid-run coordinator preemption + automatic pipeline retry.

Uniform throughput 1.88× faster than Parquet at 10 GB small. Every skewed case baseline OOMs on now completes with memory bounded below the worker limit.

## Tests

- `lib/zephyr/tests/test_shuffle.py` rewritten for the new API (13 tests).
- `lib/zephyr/tests/test_groupby.py` pickle-roundtrip test updated.
- `lib/zephyr/tests/benchmark_shuffle.py` new — synthetic 10-50 GB shuffle with `--hot-shard-frac`/`--hot-key-pool`.
- `test_shuffle.py` (13), `test_groupby.py` (23), `test_execution.py` (40) all pass locally.

## Test plan

- [x] Unit tests pass locally
- [x] Uniform shuffle (10 GB, small + large items) on marin-dev
- [x] Skewed shuffle (10 GB + 50 GB, small + large items) on marin-dev
- [ ] Datakit ferry on marin — deferred (not necessary given direct shuffle benchmarks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)