### PR TITLE
ferries: run datakit smoke on marin cluster at production priority

### DIFF
--- a/.github/workflows/marin-datakit-smoke.yaml
+++ b/.github/workflows/marin-datakit-smoke.yaml
@@ -22,7 +22,7 @@ jobs:
       FERRY_STATUS_PATH: gs://marin-tmp-us-central1/ttl=1d/ci/datakit-smoke-${{ github.run_id }}-${{ github.run_attempt }}/ferry_run_status.json
       WANDB_ENTITY: marin-community
       WANDB_PROJECT: marin
-      IRIS_CONFIG: lib/iris/examples/marin-dev.yaml
+      IRIS_CONFIG: lib/iris/examples/marin.yaml
       IRIS_CONTROLLER_SERVICE_ACCOUNT: iris-controller@hai-gcp-models.iam.gserviceaccount.com
 
     steps:

--- a/.github/workflows/marin-datakit-smoke.yaml
+++ b/.github/workflows/marin-datakit-smoke.yaml
@@ -69,6 +69,7 @@ jobs:
           JOB_ID=$(.venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
             job run --no-wait \
             --memory=2G --disk=4G --cpu=1 --extra=cpu \
+            --priority production \
             -e SMOKE_RUN_ID "$SMOKE_RUN_ID" \
             -e FERRY_STATUS_PATH "$FERRY_STATUS_PATH" \
             -e WANDB_ENTITY "$WANDB_ENTITY" \


### PR DESCRIPTION
* point datakit smoke at the prod cluster and submit at production band
* `IRIS_CONFIG`: `lib/iris/examples/marin-dev.yaml` → `lib/iris/examples/marin.yaml`
* add `--priority production` to the `iris job run` invocation, matching `marin-canary-ferry.yaml` [^1]

[^1]: production band is admin-only and preempts running INTERACTIVE/BATCH tasks — see `lib/iris/docs/priority-bands.md`.