### PR TITLE
[iris] Raise worker heartbeat RPC timeout

### DIFF
--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -2131,12 +2131,20 @@ class Controller:
         stale = [w for w in workers if w.last_heartbeat.age_ms() > threshold_ms]
         if not stale:
             return
+        stale_samples = [
+            {
+                "worker_id": str(w.worker_id),
+                "age_s": int(w.last_heartbeat.age_ms() / 1000),
+                "address": w.address,
+            }
+            for w in stale[:10]
+        ]
 
         logger.warning(
             "Failing %d workers with stale heartbeats (threshold=%ds): %s",
             len(stale),
             HEARTBEAT_STALENESS_THRESHOLD.to_seconds(),
-            [str(w.worker_id) for w in stale[:10]],
+            stale_samples,
         )
         failure_result = self._transitions.fail_workers_batch(
             [str(w.worker_id) for w in stale],
@@ -2231,7 +2239,25 @@ class Controller:
 
         primary_failed_workers: list[str] = []
         for (batch, error), result in zip(failure_entries, failure_result.results, strict=False):
-            logger.debug("Sync error for %s: %s", batch.worker_id, error)
+            last_success_age_s = (
+                "unknown" if result.last_heartbeat_age_ms is None else f"{result.last_heartbeat_age_ms / 1000.0:.1f}"
+            )
+            log_level = logging.ERROR if result.action == HeartbeatAction.WORKER_FAILED else logging.WARNING
+            logger.log(
+                log_level,
+                "Heartbeat RPC failure: worker=%s address=%s action=%s failures=%d/%d last_success_age_s=%s "
+                "expected=%d run=%d kill=%d error=%s",
+                batch.worker_id,
+                batch.worker_address or "<missing>",
+                result.action.value,
+                result.consecutive_failures,
+                result.failure_threshold,
+                last_success_age_s,
+                len(batch.running_tasks),
+                len(batch.tasks_to_run),
+                len(batch.tasks_to_kill),
+                error,
+            )
             if result.action == HeartbeatAction.WORKER_FAILED:
                 acc.fail_count += 1
                 acc.failed_workers.append(batch.worker_id)

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -81,7 +81,6 @@ from iris.cluster.controller.budget import (
 from iris.cluster.controller.dashboard import ControllerDashboard
 from iris.cluster.providers.k8s.tasks import K8sTaskProvider
 from iris.cluster.controller.provider import TaskProvider
-from iris.cluster.controller.worker_provider import WorkerProvider
 from iris.cluster.controller.scheduler import (
     JobRequirements,
     Scheduler,
@@ -1058,10 +1057,10 @@ class Controller:
         log_client_interceptors = _log_client_interceptors(config)
         self._remote_log_service = LogServiceProxy(self._log_service_address, interceptors=log_client_interceptors)
 
-        # Providers push directly to the log server via RPC.
-        provider_log_pusher = LogPusher(self._log_service_address, interceptors=log_client_interceptors)
-        if isinstance(self._provider, (K8sTaskProvider, WorkerProvider)):
-            self._provider.log_pusher = provider_log_pusher
+        # Providers that collect logs outside the worker process push directly
+        # to the log server via RPC.
+        if isinstance(self._provider, K8sTaskProvider):
+            self._provider.log_pusher = LogPusher(self._log_service_address, interceptors=log_client_interceptors)
 
         # Controller process logs ship to the log server via RemoteLogHandler.
         self._log_pusher = LogPusher(self._log_service_address, interceptors=log_client_interceptors)

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -226,6 +226,9 @@ class HeartbeatApplyResult(TxResult):
 class HeartbeatFailureResult(TxResult):
     worker_removed: bool = False
     action: HeartbeatAction = HeartbeatAction.TRANSIENT_FAILURE
+    consecutive_failures: int = 0
+    failure_threshold: int = HEARTBEAT_FAILURE_THRESHOLD
+    last_heartbeat_age_ms: int | None = None
 
 
 @dataclass(frozen=True)
@@ -2121,12 +2124,19 @@ class ControllerTransitions:
         tasks_to_kill: set[JobName] = set()
         task_kill_workers: dict[JobName, WorkerId] = {}
         row = cur.execute(
-            "SELECT consecutive_failures FROM workers WHERE worker_id = ? AND active = 1",
+            "SELECT consecutive_failures, last_heartbeat_ms FROM workers WHERE worker_id = ? AND active = 1",
             (str(worker_id),),
         ).fetchone()
         if row is None:
-            return HeartbeatFailureResult(worker_removed=True, action=HeartbeatAction.WORKER_FAILED)
+            return HeartbeatFailureResult(
+                worker_removed=True,
+                action=HeartbeatAction.WORKER_FAILED,
+                failure_threshold=self._heartbeat_failure_threshold,
+            )
 
+        now_ms = now_ms or Timestamp.now().epoch_ms()
+        last_heartbeat_ms = row["last_heartbeat_ms"]
+        last_heartbeat_age_ms = None if last_heartbeat_ms is None else max(0, now_ms - int(last_heartbeat_ms))
         failures = int(row["consecutive_failures"]) + 1
         cur.execute(
             "UPDATE workers SET consecutive_failures = ?, healthy = CASE WHEN ? >= ? THEN 0 ELSE healthy END "
@@ -2134,7 +2144,6 @@ class ControllerTransitions:
             (failures, failures, self._heartbeat_failure_threshold, str(worker_id)),
         )
         should_remove = force_remove or failures >= self._heartbeat_failure_threshold
-        now_ms = now_ms or Timestamp.now().epoch_ms()
         if should_remove:
             removal = self._remove_failed_worker(cur, worker_id, error, now_ms=now_ms)
             tasks_to_kill.update(removal.tasks_to_kill)
@@ -2150,6 +2159,9 @@ class ControllerTransitions:
             task_kill_workers=task_kill_workers,
             worker_removed=should_remove,
             action=action,
+            consecutive_failures=failures,
+            failure_threshold=self._heartbeat_failure_threshold,
+            last_heartbeat_age_ms=last_heartbeat_age_ms,
         )
 
     def record_heartbeat_failure(

--- a/lib/iris/src/iris/cluster/controller/worker_provider.py
+++ b/lib/iris/src/iris/cluster/controller/worker_provider.py
@@ -17,7 +17,6 @@ from iris.cluster.controller.transitions import (
     HeartbeatApplyRequest,
     TaskUpdate,
 )
-from iris.cluster.log_store._types import LogPusherProtocol, TaskAttempt, task_log_key
 from iris.cluster.types import JobName, WorkerId
 from iris.rpc import job_pb2
 from iris.rpc import worker_pb2
@@ -126,7 +125,6 @@ class WorkerProvider:
     """
 
     stub_factory: WorkerStubFactory
-    log_pusher: LogPusherProtocol | None = None
     parallelism: int = 32
     _pool: ThreadPoolExecutor = field(init=False)
 
@@ -185,16 +183,6 @@ class WorkerProvider:
             if not response.worker_healthy:
                 health_error = response.health_error or "worker reported unhealthy"
                 raise ProviderError(f"worker {batch.worker_id} reported unhealthy: {health_error}")
-
-            # Forward log entries from old workers that still piggyback logs on
-            # heartbeat responses.  New workers push logs directly via LogPusher.
-            if self.log_pusher:
-                for entry in response.tasks:
-                    if entry.log_entries:
-                        key = task_log_key(
-                            TaskAttempt(task_id=JobName.from_wire(entry.task_id), attempt_id=entry.attempt_id)
-                        )
-                        self.log_pusher.push(key, list(entry.log_entries))
 
             elapsed_ms = int((monotonic() - started) * 1000)
             if elapsed_ms >= _SLOW_HEARTBEAT_RPC_LOG_THRESHOLD_MS:

--- a/lib/iris/src/iris/cluster/controller/worker_provider.py
+++ b/lib/iris/src/iris/cluster/controller/worker_provider.py
@@ -7,7 +7,7 @@ import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from time import sleep
+from time import monotonic, sleep
 from typing import Protocol
 
 from iris.chaos import chaos
@@ -26,6 +26,23 @@ from rigging.timing import Duration
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_WORKER_RPC_TIMEOUT = Duration.from_seconds(30.0)
+_SLOW_HEARTBEAT_RPC_LOG_THRESHOLD_MS = 10_000
+
+
+def _heartbeat_rpc_context(
+    batch: DispatchBatch,
+    *,
+    elapsed_ms: int,
+    timeout_ms: int | None,
+) -> str:
+    timeout_fragment = f" timeout_ms={timeout_ms}" if timeout_ms is not None else ""
+    return (
+        f"worker={batch.worker_id} address={batch.worker_address or '<missing>'}"
+        f" elapsed_ms={elapsed_ms}{timeout_fragment}"
+        f" expected={len(batch.running_tasks)} run={len(batch.tasks_to_run)} kill={len(batch.tasks_to_kill)}"
+    )
+
 
 class WorkerStubFactory(Protocol):
     """Factory for getting cached worker RPC stubs."""
@@ -39,10 +56,14 @@ class RpcWorkerStubFactory:
     """Caches WorkerServiceClientSync stubs by address so each worker gets
     one persistent httpx.Client instead of a new one per RPC."""
 
-    def __init__(self, timeout: Duration = Duration.from_seconds(5.0)) -> None:
+    def __init__(self, timeout: Duration = DEFAULT_WORKER_RPC_TIMEOUT) -> None:
         self._timeout = timeout
         self._stubs: dict[str, WorkerServiceClientSync] = {}
         self._lock = threading.Lock()
+
+    @property
+    def timeout_ms(self) -> int:
+        return self._timeout.to_ms()
 
     def get_stub(self, address: str) -> WorkerServiceClientSync:
         with self._lock:
@@ -131,6 +152,9 @@ class WorkerProvider:
 
     def _heartbeat_one(self, batch: DispatchBatch) -> HeartbeatApplyRequest:
         """Send heartbeat RPC to one worker and return the apply request."""
+        started = monotonic()
+        timeout_ms = getattr(self.stub_factory, "timeout_ms", None)
+
         if rule := chaos("controller.heartbeat"):
             sleep(rule.delay_seconds)
             raise ProviderError("chaos: heartbeat unavailable")
@@ -155,23 +179,36 @@ class WorkerProvider:
             tasks_to_kill=batch.tasks_to_kill,
             expected_tasks=expected_tasks,
         )
-        response = stub.heartbeat(request)
+        try:
+            response = stub.heartbeat(request)
 
-        if not response.worker_healthy:
-            health_error = response.health_error or "worker reported unhealthy"
-            raise ProviderError(f"worker {batch.worker_id} reported unhealthy: {health_error}")
+            if not response.worker_healthy:
+                health_error = response.health_error or "worker reported unhealthy"
+                raise ProviderError(f"worker {batch.worker_id} reported unhealthy: {health_error}")
 
-        # Forward log entries from old workers that still piggyback logs on
-        # heartbeat responses.  New workers push logs directly via LogPusher.
-        if self.log_pusher:
-            for entry in response.tasks:
-                if entry.log_entries:
-                    key = task_log_key(
-                        TaskAttempt(task_id=JobName.from_wire(entry.task_id), attempt_id=entry.attempt_id)
-                    )
-                    self.log_pusher.push(key, list(entry.log_entries))
+            # Forward log entries from old workers that still piggyback logs on
+            # heartbeat responses.  New workers push logs directly via LogPusher.
+            if self.log_pusher:
+                for entry in response.tasks:
+                    if entry.log_entries:
+                        key = task_log_key(
+                            TaskAttempt(task_id=JobName.from_wire(entry.task_id), attempt_id=entry.attempt_id)
+                        )
+                        self.log_pusher.push(key, list(entry.log_entries))
 
-        return _apply_request_from_response(batch.worker_id, response)
+            elapsed_ms = int((monotonic() - started) * 1000)
+            if elapsed_ms >= _SLOW_HEARTBEAT_RPC_LOG_THRESHOLD_MS:
+                logger.warning(
+                    "Slow heartbeat RPC succeeded: %s",
+                    _heartbeat_rpc_context(batch, elapsed_ms=elapsed_ms, timeout_ms=timeout_ms),
+                )
+            return _apply_request_from_response(batch.worker_id, response)
+        except Exception as e:
+            elapsed_ms = int((monotonic() - started) * 1000)
+            context = _heartbeat_rpc_context(batch, elapsed_ms=elapsed_ms, timeout_ms=timeout_ms)
+            if isinstance(e, ProviderError):
+                raise ProviderError(f"{e}; {context}") from e
+            raise ProviderError(f"heartbeat RPC failed: {context}; error={e}") from e
 
     def get_process_status(
         self,

--- a/lib/iris/tests/cluster/controller/test_heartbeat.py
+++ b/lib/iris/tests/cluster/controller/test_heartbeat.py
@@ -3,10 +3,12 @@
 
 """Tests for worker heartbeat timeout handling, health checks, and unified heartbeat path."""
 
+import logging
 import time
 
+import iris.cluster.controller.worker_provider as worker_provider_module
 import pytest
-from iris.cluster.controller.controller import Controller, ControllerConfig
+from iris.cluster.controller.controller import Controller, ControllerConfig, _SyncFailureAccumulator
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.schema import (
     TASK_DETAIL_PROJECTION,
@@ -23,7 +25,7 @@ from iris.cluster.controller.transitions import (
     RunningTaskEntry,
     TaskUpdate,
 )
-from iris.cluster.controller.worker_provider import WorkerProvider
+from iris.cluster.controller.worker_provider import RpcWorkerStubFactory, WorkerProvider
 from iris.cluster.log_store._types import TaskAttempt, task_log_key
 from iris.cluster.types import JobName, WorkerId
 from iris.log_server.server import LogServiceImpl
@@ -228,7 +230,7 @@ def test_unhealthy_worker_cascades_to_tasks(tmp_path):
     assert task.state == job_pb2.TASK_STATE_WORKER_FAILED
 
 
-def test_reap_stale_workers_removes_old_heartbeat(tmp_path, worker_metadata):
+def test_reap_stale_workers_removes_old_heartbeat(tmp_path, worker_metadata, caplog):
     """Workers restored from checkpoint with heartbeat older than the staleness
     threshold are failed immediately by the heartbeat loop's reap pass."""
     db = ControllerDB(db_dir=tmp_path)
@@ -256,11 +258,15 @@ def test_reap_stale_workers_removes_old_heartbeat(tmp_path, worker_metadata):
         assert q.fetchone("SELECT 1 FROM workers WHERE worker_id = ?", ("stale-worker",)) is not None
         assert q.fetchone("SELECT 1 FROM workers WHERE worker_id = ?", ("fresh-worker",)) is not None
 
-    controller._reap_stale_workers()
+    with caplog.at_level(logging.WARNING):
+        controller._reap_stale_workers()
 
     with db.snapshot() as q:
         assert q.fetchone("SELECT 1 FROM workers WHERE worker_id = ?", ("stale-worker",)) is None
         assert q.fetchone("SELECT 1 FROM workers WHERE worker_id = ?", ("fresh-worker",)) is not None
+    assert "stale-worker" in caplog.text
+    assert "age_s" in caplog.text
+    assert "10.0.0.1:10001" in caplog.text
 
     controller.stop()
 
@@ -296,6 +302,14 @@ class _FakeStub:
         return self._response
 
 
+class _RaisingStub:
+    def __init__(self, exc: Exception):
+        self._exc = exc
+
+    def heartbeat(self, request: job_pb2.HeartbeatRequest) -> job_pb2.HeartbeatResponse:
+        raise self._exc
+
+
 class _FakeStubFactory:
     def __init__(self, stub: _FakeStub):
         self._stub = stub
@@ -305,6 +319,90 @@ class _FakeStubFactory:
 
     def evict(self, address: str) -> None:
         pass
+
+    def close(self) -> None:
+        pass
+
+
+def test_handle_failed_heartbeats_logs_diagnostics(tmp_path, worker_metadata, caplog):
+    db = ControllerDB(db_dir=tmp_path)
+    config = ControllerConfig(remote_state_dir="file:///tmp/iris-test-state", local_state_dir=tmp_path)
+    controller = Controller(config=config, provider=FakeProvider(), db=db)
+    state = controller.state
+    _register_worker(state, "worker1", worker_metadata, address="10.0.0.1:10001")
+
+    batch = DispatchBatch(
+        worker_id=WorkerId("worker1"),
+        worker_address="10.0.0.1:10001",
+        running_tasks=[RunningTaskEntry(JobName.from_wire("/user/test-job/0"), 0)],
+        tasks_to_run=[],
+        tasks_to_kill=[],
+    )
+    acc = _SyncFailureAccumulator()
+    with caplog.at_level(logging.WARNING):
+        primary_failed_workers = controller._handle_failed_heartbeats(
+            [(batch, "deadline exceeded after 12000ms")],
+            acc,
+        )
+
+    assert primary_failed_workers == []
+    assert acc.fail_count == 1
+    assert "worker=worker1" in caplog.text
+    assert "address=10.0.0.1:10001" in caplog.text
+    assert "action=transient_failure" in caplog.text
+    assert "failures=1/10" in caplog.text
+    assert "last_success_age_s=" in caplog.text
+    assert "deadline exceeded after 12000ms" in caplog.text
+
+    controller.stop()
+
+
+def test_rpc_worker_stub_factory_uses_longer_default_timeout(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class _RecordingClient:
+        def __init__(self, address: str, timeout_ms: int):
+            captured["address"] = address
+            captured["timeout_ms"] = timeout_ms
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(worker_provider_module, "WorkerServiceClientSync", _RecordingClient)
+
+    factory = RpcWorkerStubFactory()
+    factory.get_stub("host:8080")
+
+    assert captured["address"] == "http://host:8080"
+    assert captured["timeout_ms"] == 30_000
+
+    factory.close()
+
+
+def test_heartbeat_failure_error_includes_rpc_context():
+    provider = WorkerProvider(
+        stub_factory=_FakeStubFactory(_RaisingStub(RuntimeError("deadline exceeded"))),
+    )
+    batch = DispatchBatch(
+        worker_id=WorkerId("w1"),
+        worker_address="host:8080",
+        running_tasks=[RunningTaskEntry(JobName.from_wire("/user/test-job/0"), 0)],
+        tasks_to_run=[],
+        tasks_to_kill=[],
+    )
+
+    results = provider.sync([batch])
+
+    assert len(results) == 1
+    _, apply_req, error = results[0]
+    assert apply_req is None
+    assert error is not None
+    assert "heartbeat RPC failed:" in error
+    assert "worker=w1" in error
+    assert "address=host:8080" in error
+    assert "expected=1" in error
+
+    provider.close()
 
 
 def test_heartbeat_forwards_old_worker_log_entries(tmp_path):

--- a/lib/iris/tests/cluster/controller/test_heartbeat.py
+++ b/lib/iris/tests/cluster/controller/test_heartbeat.py
@@ -18,21 +18,17 @@ from tests.cluster.controller.conftest import FakeProvider
 from iris.cluster.controller.transitions import (
     Assignment,
     ControllerTransitions,
+    DispatchBatch,
     HEARTBEAT_STALENESS_THRESHOLD,
     HeartbeatAction,
     HeartbeatApplyRequest,
-    DispatchBatch,
     RunningTaskEntry,
     TaskUpdate,
 )
 from iris.cluster.controller.worker_provider import RpcWorkerStubFactory, WorkerProvider
-from iris.cluster.log_store._types import TaskAttempt, task_log_key
 from iris.cluster.types import JobName, WorkerId
-from iris.log_server.server import LogServiceImpl
-from iris.rpc import logging_pb2
-from tests.cluster.providers.k8s.conftest import InProcessLogPusher
-from iris.rpc import job_pb2
 from iris.rpc import controller_pb2
+from iris.rpc import job_pb2
 from rigging.timing import Duration, Timestamp
 
 
@@ -403,153 +399,3 @@ def test_heartbeat_failure_error_includes_rpc_context():
     assert "expected=1" in error
 
     provider.close()
-
-
-def test_heartbeat_forwards_old_worker_log_entries(tmp_path):
-    """Old workers that piggyback log_entries on heartbeat responses have their
-    logs forwarded to LogService by the WorkerProvider."""
-    log_service = LogServiceImpl(log_dir=tmp_path / "logs")
-
-    task_id = JobName.from_wire("/user/test-job/0")
-    attempt_id = 0
-    log_key = task_log_key(TaskAttempt(task_id=task_id, attempt_id=attempt_id))
-
-    log_entry = logging_pb2.LogEntry(source="stdout", data="old-worker log line")
-    log_entry.timestamp.epoch_ms = 42000
-
-    response = job_pb2.HeartbeatResponse(
-        worker_healthy=True,
-        tasks=[
-            job_pb2.WorkerTaskStatus(
-                task_id=task_id.to_wire(),
-                attempt_id=attempt_id,
-                state=job_pb2.TASK_STATE_RUNNING,
-                log_entries=[log_entry],
-            )
-        ],
-    )
-
-    provider = WorkerProvider(
-        stub_factory=_FakeStubFactory(_FakeStub(response)),
-        log_pusher=InProcessLogPusher(log_service),
-    )
-
-    batch = DispatchBatch(
-        worker_id=WorkerId("w1"),
-        worker_address="host:8080",
-        running_tasks=[RunningTaskEntry(task_id, attempt_id)],
-        tasks_to_run=[],
-        tasks_to_kill=[],
-    )
-    results = provider.sync([batch])
-    assert len(results) == 1
-    _, apply_req, error = results[0]
-    assert error is None
-    assert apply_req is not None
-
-    fetch_resp = log_service.fetch_logs(logging_pb2.FetchLogsRequest(source=log_key), ctx=None)
-    assert len(fetch_resp.entries) == 1
-    assert fetch_resp.entries[0].data == "old-worker log line"
-    assert fetch_resp.entries[0].timestamp.epoch_ms == 42000
-
-    log_service.close()
-
-
-def test_heartbeat_no_log_entries_no_push(tmp_path):
-    """When heartbeat response has no log_entries, no logs are pushed."""
-    log_service = LogServiceImpl(log_dir=tmp_path / "logs")
-
-    task_id = JobName.from_wire("/user/test-job/0")
-    attempt_id = 0
-    log_key = task_log_key(TaskAttempt(task_id=task_id, attempt_id=attempt_id))
-
-    response = job_pb2.HeartbeatResponse(
-        worker_healthy=True,
-        tasks=[
-            job_pb2.WorkerTaskStatus(
-                task_id=task_id.to_wire(),
-                attempt_id=attempt_id,
-                state=job_pb2.TASK_STATE_RUNNING,
-            )
-        ],
-    )
-
-    provider = WorkerProvider(
-        stub_factory=_FakeStubFactory(_FakeStub(response)),
-        log_pusher=InProcessLogPusher(log_service),
-    )
-
-    batch = DispatchBatch(
-        worker_id=WorkerId("w1"),
-        worker_address="host:8080",
-        running_tasks=[RunningTaskEntry(task_id, attempt_id)],
-        tasks_to_run=[],
-        tasks_to_kill=[],
-    )
-    provider.sync([batch])
-
-    fetch_resp = log_service.fetch_logs(logging_pb2.FetchLogsRequest(source=log_key), ctx=None)
-    assert len(fetch_resp.entries) == 0
-
-    log_service.close()
-
-
-def test_heartbeat_forwards_logs_for_multiple_tasks(tmp_path):
-    """Log entries from multiple tasks in a single heartbeat are each forwarded."""
-    log_service = LogServiceImpl(log_dir=tmp_path / "logs")
-
-    task_id_0 = JobName.from_wire("/user/test-job/0")
-    task_id_1 = JobName.from_wire("/user/test-job/1")
-
-    entry_0 = logging_pb2.LogEntry(source="stdout", data="task-0 output")
-    entry_0.timestamp.epoch_ms = 1000
-    entry_1 = logging_pb2.LogEntry(source="stderr", data="task-1 error")
-    entry_1.timestamp.epoch_ms = 2000
-
-    response = job_pb2.HeartbeatResponse(
-        worker_healthy=True,
-        tasks=[
-            job_pb2.WorkerTaskStatus(
-                task_id=task_id_0.to_wire(),
-                attempt_id=0,
-                state=job_pb2.TASK_STATE_RUNNING,
-                log_entries=[entry_0],
-            ),
-            job_pb2.WorkerTaskStatus(
-                task_id=task_id_1.to_wire(),
-                attempt_id=0,
-                state=job_pb2.TASK_STATE_RUNNING,
-                log_entries=[entry_1],
-            ),
-        ],
-    )
-
-    provider = WorkerProvider(
-        stub_factory=_FakeStubFactory(_FakeStub(response)),
-        log_pusher=InProcessLogPusher(log_service),
-    )
-
-    batch = DispatchBatch(
-        worker_id=WorkerId("w1"),
-        worker_address="host:8080",
-        running_tasks=[
-            RunningTaskEntry(task_id_0, 0),
-            RunningTaskEntry(task_id_1, 0),
-        ],
-        tasks_to_run=[],
-        tasks_to_kill=[],
-    )
-    provider.sync([batch])
-
-    key_0 = task_log_key(TaskAttempt(task_id=task_id_0, attempt_id=0))
-    key_1 = task_log_key(TaskAttempt(task_id=task_id_1, attempt_id=0))
-
-    resp_0 = log_service.fetch_logs(logging_pb2.FetchLogsRequest(source=key_0), ctx=None)
-    resp_1 = log_service.fetch_logs(logging_pb2.FetchLogsRequest(source=key_1), ctx=None)
-
-    assert len(resp_0.entries) == 1
-    assert resp_0.entries[0].data == "task-0 output"
-    assert len(resp_1.entries) == 1
-    assert resp_1.entries[0].data == "task-1 error"
-
-    log_service.close()


### PR DESCRIPTION
Raise the controller-to-worker heartbeat RPC timeout and log failure counts, stale ages, and worker addresses when heartbeats fail or stale workers are reaped. This covers the registered-but-never-advanced path from base issue #4697.

Part of #4746