### PR TITLE
pyrefly: cluster D cleanup (bad-specialization + override)

### DIFF
--- a/.pyrefly-baseline.json
+++ b/.pyrefly-baseline.json
@@ -1105,30 +1105,6 @@
       "severity": "error"
     },
     {
-      "line": 573,
-      "column": 9,
-      "stop_line": 573,
-      "stop_column": 20,
-      "path": "lib/marin/src/marin/rl/weight_transfer/arrow_flight.py",
-      "code": -2,
-      "name": "bad-override",
-      "description": "Class member `ArrowFlightServer.get_metrics` overrides parent class `WeightTransferServer` in an inconsistent manner\n  `ArrowFlightServer.get_metrics` has type `(self: ArrowFlightServer) -> WeightTransferServerMetrics`, which is not assignable to `(self: ArrowFlightServer) -> dict[Unknown, Unknown]`, the type of `WeightTransferServer.get_metrics`\n  Signature mismatch:\n  expected: def get_metrics(self: ArrowFlightServer) -> dict[Unknown, Unknown]: ...\n                                                        ^^^^^^^^^^^^^^^^^^^^^^ return type\n  found:    def get_metrics(self: ArrowFlightServer) -> WeightTransferServerMetrics: ...\n                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ return type",
-      "concise_description": "Class member `ArrowFlightServer.get_metrics` overrides parent class `WeightTransferServer` in an inconsistent manner",
-      "severity": "error"
-    },
-    {
-      "line": 577,
-      "column": 9,
-      "stop_line": 577,
-      "stop_column": 27,
-      "path": "lib/marin/src/marin/rl/weight_transfer/arrow_flight.py",
-      "code": -2,
-      "name": "bad-override",
-      "description": "Class member `ArrowFlightServer.get_debug_snapshot` overrides parent class `WeightTransferServer` in an inconsistent manner\n  `ArrowFlightServer.get_debug_snapshot` has type `(self: ArrowFlightServer) -> Mapping[str, object]`, which is not assignable to `(self: ArrowFlightServer) -> dict[str, object]`, the type of `WeightTransferServer.get_debug_snapshot`\n  Signature mismatch:\n  expected: def get_debug_snapshot(self: ArrowFlightServer) -> dict[str, object]: ...\n                                                               ^^^^ return type\n  found:    def get_debug_snapshot(self: ArrowFlightServer) -> Mapping[str, object]: ...\n                                                               ^^^^^^^ return type",
-      "concise_description": "Class member `ArrowFlightServer.get_debug_snapshot` overrides parent class `WeightTransferServer` in an inconsistent manner",
-      "severity": "error"
-    },
-    {
       "line": 139,
       "column": 21,
       "stop_line": 143,

--- a/lib/marin/src/marin/rl/train_worker.py
+++ b/lib/marin/src/marin/rl/train_worker.py
@@ -9,7 +9,6 @@ rollout workers, and periodically dumps new checkpoints to disk. These
 checkpoints are read by the rollout workers to update their models.
 """
 
-import dataclasses
 import faulthandler
 import logging
 import signal
@@ -605,7 +604,7 @@ class TrainWorker:
         self.transfer_server.serve_weights(step, model_params)
         transfer_time = time.time() - transfer_start
 
-        attempt_metrics = dataclasses.asdict(self.transfer_server.get_metrics())
+        attempt_metrics = self.transfer_server.get_metrics()
         metrics = {f"weight_transfer/attempt_{k}": v for k, v in attempt_metrics.items()}
         metrics.update(
             {

--- a/lib/marin/src/marin/rl/weight_transfer/arrow_flight.py
+++ b/lib/marin/src/marin/rl/weight_transfer/arrow_flight.py
@@ -22,7 +22,6 @@ import os
 import socket
 import threading
 import time
-from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from functools import partial
@@ -570,11 +569,11 @@ class ArrowFlightServer(WeightTransferServer):
             logger.debug(f"Shutting down Arrow Flight server at {flight_server._location}...")
             threading.Thread(target=flight_server.shutdown, daemon=True).start()
 
-    def get_metrics(self) -> WeightTransferServerMetrics:
+    def get_metrics(self) -> dict:
         """Get transfer metrics."""
-        return self.metrics
+        return dataclasses.asdict(self.metrics)
 
-    def get_debug_snapshot(self) -> Mapping[str, object]:
+    def get_debug_snapshot(self) -> dict[str, object]:
         latest_metrics = dataclasses.asdict(self.metrics)
         latest_metrics["transfer_bytes_mib"] = round(self.metrics.transfer_bytes / _BYTES_PER_MIB, 2)
         latest_metrics["largest_param_bytes_mib"] = round(self.metrics.largest_param_bytes / _BYTES_PER_MIB, 2)

--- a/tests/rl/test_train_worker.py
+++ b/tests/rl/test_train_worker.py
@@ -1,6 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
 from types import SimpleNamespace
 
 from marin.rl.rl_losses import RLOOLoss
@@ -298,8 +299,10 @@ def test_weight_transfer_hook_logs_global_and_attempt_metrics(monkeypatch):
         def serve_weights(self, weight_id: int, model: object) -> None:
             served_weights.append((weight_id, model))
 
-        def get_metrics(self) -> WeightTransferServerMetrics:
-            return WeightTransferServerMetrics(total_transfers=8, successful_transfers=8, failed_transfers=0)
+        def get_metrics(self) -> dict:
+            return dataclasses.asdict(
+                WeightTransferServerMetrics(total_transfers=8, successful_transfers=8, failed_transfers=0)
+            )
 
     class _FakeTracker:
         def log(self, metrics: dict[str, float | int], *, step: int) -> None:

--- a/tests/rl/test_weight_transfer.py
+++ b/tests/rl/test_weight_transfer.py
@@ -280,9 +280,9 @@ def test_arrow_flight_exports_and_tracks_bytes(sample_params):
             assert update.weight_id == 1
 
             server_metrics = server.get_metrics()
-            assert server_metrics.transfer_bytes > 0
-            assert server_metrics.param_count > 0
-            assert server_metrics.materialize_time >= 0
+            assert server_metrics["transfer_bytes"] > 0
+            assert server_metrics["param_count"] > 0
+            assert server_metrics["materialize_time"] >= 0
 
             client_metrics = client.get_metrics()
             assert client_metrics["receive_bytes"] > 0


### PR DESCRIPTION
## Summary

Stacked on #4808 (PR-1, cluster C). Clears Cluster D from the pyrefly
tightening plan (`.agents/projects/2026-04-15_pyrefly_tightening.md`).

- Baseline: 100 → 1 diagnostic (1203 → 15 lines). The single remaining
  entry is the haliax einsum Axis widening diagnostic, deferred per
  user decision.
- Clears all 69 `bad-specialization`, 21 `bad-override`, 10
  `inconsistent-overload` sites from Cluster D.

## The `dataclass_replace` helper

`bad-specialization` (69 sites, ~70% of the cluster-D baseline) is
driven by pyrefly 0.61 being unable to specialize
`dataclasses.replace(self, ...)` through `Self` — the typeshed stub
uses a `DataclassInstance`-bounded TypeVar. A thin module-level helper
`dataclass_replace(obj, /, **changes) -> _ReplaceT` in
`levanter/utils/py_utils.py` keeps the caller's concrete type without
the bound. Call sites across:

- `lib/levanter/src/levanter/inference/jit_scheduler.py` (26)
- `lib/levanter/src/levanter/models/*.py` (12 files)
- `lib/levanter/src/levanter/layers/{kv_cache,gated_deltanet}.py`
- `lib/levanter/src/levanter/trainer_state.py`
- `lib/marin/src/marin/training/training.py`
- `lib/marin/src/marin/rl/rl_experiment_utils.py`

migrate to the helper.

I chose the helper-function approach over a mixin because `eqx.Module`
uses a custom dataclass transform and every affected class already
subclasses it — a mixin would force multiple inheritance across ~17
files and risk conflicts with Equinox's `__init_subclass__` machinery.
One module-level helper with a single in-function ignore is less
surface area.

## Non-Self `bad-specialization` sites (2)

- `lib/iris/src/iris/cluster/controller/controller.py:697` — `replace(worker, ...)` where `worker: WorkerSnapshot` is a `Protocol`. `iris` is upstream of `levanter`, so it cannot import the helper — per-site ignore.
- `lib/haliax/src/haliax/nn/linear.py:160` — `dataclasses.replace(self, ...)` in vendored haliax. Same dep-direction constraint — per-site ignore.

## `bad-override` (21) disposition

Real fixes:
- `lib/levanter/src/levanter/models/gemma.py` `Gemma3Config.model_type` — narrows parent's return.
- `lib/marin/src/marin/rl/weight_transfer/arrow_flight.py` `get_metrics` / `get_debug_snapshot` — narrows base-class return types.

Per-site ignores (18, all vendored haliax):
- `NamedArray.__eq__` / `__ne__` (numpy convention: broadcasted mask, not `bool`)
- `Embedding.reparam`, `Linear.reparam` (concrete properties implementing an `AbstractVar`)
- 14 sites in `haliax/nn/mup.py` (concrete properties implementing abstract methods on `AbstractLinearReparam` / `AbstractEmbeddingReparam`)

Per-site ignores keep `bad-override` enabled for our code, which was the goal.

## `inconsistent-overload` (10) disposition

All in vendored haliax (`axis.py`, `core.py`, `nn/scan.py`,
`partitioning.py`). Per-site ignores with rationale "vendored haliax
@overload resolution" — the category stays active for new code.

## `[tool.pyrefly.errors]` changes

None removed. All Cluster D categories were baseline-suppressed, not
globally disabled. Added a one-line comment noting `bad-specialization`
and `inconsistent-overload` are cleared in PR-2.

## Upstream pyrefly issue

To be filed after this PR lands (`Self` / `DataclassInstance` specialization in `replace()`).

## Test plan

- [x] `./infra/pre-commit.py --all-files` passes.
- [x] Baseline strictly smaller (1203 → 15 lines, 100 → 1 diagnostic).
- [x] Pyrefly green with the new baseline.