### PR TITLE
[zephyr] Include stage name in worker task-execution log

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -1163,7 +1163,13 @@ class ZephyrWorker:
             # Unpack task and config
             task, attempt, config = response
 
-            logger.info("[%s] Executing task for shard %d (attempt %d)", self._worker_id, task.shard_idx, attempt)
+            logger.info(
+                "[%s] Executing task for stage %s shard %d (attempt %d)",
+                self._worker_id,
+                task.stage_name,
+                task.shard_idx,
+                attempt,
+            )
             try:
                 t_0 = time.monotonic()
                 result, task_counters = self._execute_shard(task, config)


### PR DESCRIPTION
The worker previously logged "Executing task for shard N"; add the stage name so per-shard logs identify which stage the shard belongs to when multiple stages run in the same pipeline.