### PR TITLE
Remove consolidate from tokenize

### DIFF
--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -77,7 +77,7 @@ class TokenSeqDataset(AsyncDataset[np.ndarray]):
 
     async def async_len(self) -> int:
         token_arrays = await self._await_token_cache()
-        return token_arrays.data_size // self.seq_len
+        return await token_arrays.data_size_async() // self.seq_len
 
     async def _await_token_cache(self) -> JaggedArrayStore:
         if self._store is None:

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -30,6 +30,7 @@ from zephyr.writers import write_levanter_cache
 
 from levanter.data.dataset import AsyncDataset
 from levanter.utils.jax_utils import broadcast_one_to_all
+from levanter.utils.thread_utils import blocking_wait
 
 from ..data._preprocessor import BatchProcessor, BatchResult, dict_from_record_batch
 from ..data.sharded_datasource import ShardedDataSource
@@ -160,6 +161,219 @@ class TreeCache(AsyncDataset[T_co]):
         return True
 
 
+class _VirtualRead:
+    def __init__(self, read_async):
+        self._read_async = read_async
+
+    def read(self):
+        return self
+
+    def __await__(self):
+        return self._read_async().__await__()
+
+    def result(self):
+        return blocking_wait(self._read_async())
+
+
+class _ShardedArray:
+    def __init__(self, arrays, sizes: list[int]):
+        self._arrays = arrays
+        self._sizes = sizes
+        self._boundaries = _cumulative_offsets(sizes)
+
+    def __getitem__(self, item):
+        return _VirtualRead(lambda: self._read(item))
+
+    async def _read(self, item):
+        if isinstance(item, slice):
+            start, stop, step = item.indices(self._boundaries[-1])
+            if step != 1:
+                values = await self._read(slice(start, stop))
+                return values[::step]
+            pieces = []
+            for shard_index, local_slice in _split_slice_by_boundaries(start, stop, self._boundaries):
+                pieces.append(await self._arrays[shard_index][local_slice].read())
+            return _concatenate_or_empty(pieces)
+
+        index = item
+        if index < 0:
+            index += self._boundaries[-1]
+        if index < 0 or index >= self._boundaries[-1]:
+            raise IndexError("Index out of bounds")
+        shard_index = bisect.bisect_right(self._boundaries, index) - 1
+        local_index = index - self._boundaries[shard_index]
+        return await self._arrays[shard_index][local_index].read()
+
+
+class _ShardedOffsets:
+    def __init__(self, stores: list[JaggedArrayStore]):
+        self._stores = stores
+        self._num_rows = sum(store.num_rows for store in stores)
+        self._data_sizes = [store.data_size for store in stores]
+
+    def __getitem__(self, item):
+        return _VirtualRead(lambda: self._read(item))
+
+    async def _read(self, item):
+        offsets = await self._full_offsets()
+        return offsets[item]
+
+    async def _full_offsets(self):
+        offset_reads = [store.offsets[0 : store.num_rows + 1].read() for store in self._stores]
+        per_shard_offsets = await asyncio.gather(*offset_reads)
+        adjusted_offsets = [np.asarray([self._num_rows], dtype=np.int64)]
+        data_base = 0
+        for offsets, data_size in zip(per_shard_offsets, self._data_sizes):
+            offsets = np.asarray(offsets, dtype=np.int64)
+            offsets[0] = 0
+            adjusted_offsets.append(offsets[1:] + data_base)
+            data_base += data_size
+        return np.concatenate(adjusted_offsets)
+
+
+class _ShardedShapes:
+    def __init__(self, stores: list[JaggedArrayStore]):
+        self._stores = stores
+        self._sizes = [store.num_rows for store in stores]
+        self._boundaries = _cumulative_offsets(self._sizes)
+
+    def __getitem__(self, item):
+        return _VirtualRead(lambda: self._read(item))
+
+    async def _read(self, item):
+        if isinstance(item, slice):
+            start, stop, step = item.indices(self._boundaries[-1])
+            if step != 1:
+                values = await self._read(slice(start, stop))
+                return values[::step]
+            pieces = []
+            for shard_index, local_slice in _split_slice_by_boundaries(start, stop, self._boundaries):
+                shapes = self._stores[shard_index].shapes
+                assert shapes is not None
+                pieces.append(await shapes[local_slice].read())
+            return _concatenate_or_empty(pieces)
+
+        index = item
+        if index < 0:
+            index += self._boundaries[-1]
+        if index < 0 or index >= self._boundaries[-1]:
+            raise IndexError("Index out of bounds")
+        shard_index = bisect.bisect_right(self._boundaries, index) - 1
+        local_index = index - self._boundaries[shard_index]
+        shapes = self._stores[shard_index].shapes
+        assert shapes is not None
+        return await shapes[local_index].read()
+
+
+class ShardedJaggedArrayStore:
+    """Virtual JaggedArrayStore backed by multiple shard-local stores."""
+
+    def __init__(self, stores: list[JaggedArrayStore]):
+        if not stores:
+            raise ValueError("ShardedJaggedArrayStore requires at least one store")
+        self._stores = stores
+        self.item_rank = stores[0].item_rank
+        self.offsets = _ShardedOffsets(stores)
+        self.data = _ShardedArray([store.data for store in stores], [store.data_size for store in stores])
+        self.shapes = _ShardedShapes(stores) if stores[0].shapes is not None else None
+
+    @property
+    def num_rows(self):
+        return sum(store.num_rows for store in self._stores)
+
+    async def num_rows_async(self):
+        return self.num_rows
+
+    @property
+    def data_size(self):
+        return sum(store.data_size for store in self._stores)
+
+    async def data_size_async(self):
+        return self.data_size
+
+    def __len__(self):
+        return self.num_rows
+
+    def __getitem__(self, item):
+        if isinstance(item, slice):
+            start, stop, step = item.indices(len(self))
+            return self.get_batch_sync(list(range(start, stop, step)))
+        shard_index, local_index = self._resolve_row(item)
+        return self._stores[shard_index][local_index]
+
+    async def get_batch(self, indices: Sequence[int]) -> Sequence[np.ndarray]:
+        shard_groups = _group_indices_by_shard(indices, self._row_boundaries())
+
+        results: list[None | np.ndarray] = [None] * len(indices)
+
+        async def fetch_shard(shard_index: int, items: list[tuple[int, int]]):
+            local_indices = [local_index for _, local_index in items]
+            batch = await self._stores[shard_index].get_batch(local_indices)
+            for (position, _), value in zip(items, batch):
+                results[position] = value
+
+        await asyncio.gather(*[fetch_shard(shard_index, items) for shard_index, items in shard_groups.items()])
+        return results
+
+    def get_batch_sync(self, indices: Sequence[int]) -> Sequence[np.ndarray]:
+        shard_groups = _group_indices_by_shard(indices, self._row_boundaries())
+        results: list[None | np.ndarray] = [None] * len(indices)
+        for shard_index, items in shard_groups.items():
+            local_indices = [local_index for _, local_index in items]
+            batch = self._stores[shard_index].get_batch_sync(local_indices)
+            for (position, _), value in zip(items, batch):
+                results[position] = value
+        return results
+
+    def _resolve_row(self, index: int) -> tuple[int, int]:
+        boundaries = self._row_boundaries()
+        if index < 0:
+            index += boundaries[-1]
+        if index < 0 or index >= boundaries[-1]:
+            raise IndexError("Index out of bounds")
+        shard_index = bisect.bisect_right(boundaries, index) - 1
+        return shard_index, index - boundaries[shard_index]
+
+    def _row_boundaries(self):
+        return _cumulative_offsets([store.num_rows for store in self._stores])
+
+
+class ShardedTreeStore:
+    """Virtual TreeStore backed by multiple shard-local TreeStores."""
+
+    def __init__(self, stores: list[TreeStore]):
+        if not stores:
+            raise ValueError("ShardedTreeStore requires at least one store")
+        self.path = stores[0].path
+        self.mode = "r"
+        self._stores = stores
+        self.tree = jax.tree.map(
+            lambda *leaves: ShardedJaggedArrayStore(list(leaves)), *[store.tree for store in stores]
+        )
+
+    def __len__(self):
+        return len(jax.tree.leaves(self.tree)[0])
+
+    async def async_len(self):
+        return len(self)
+
+    def __getitem__(self, item):
+        if isinstance(item, slice):
+            start, stop, step = item.indices(len(self))
+            return self.get_batch_sync(list(range(start, stop, step)))
+        return jax.tree.map(lambda reader: reader[item], self.tree)
+
+    async def get_batch(self, indices) -> List[T_co]:
+        grouped = jax.tree.map(lambda reader: reader.get_batch(indices), self.tree)
+        leaves, structure = jax.tree.flatten(grouped)
+        awaited_leaves = await asyncio.gather(*leaves)
+        return [jax.tree.unflatten(structure, [leaf[i] for leaf in awaited_leaves]) for i in range(len(indices))]
+
+    def get_batch_sync(self, indices) -> List[T_co]:
+        grouped = jax.tree.map(lambda reader: reader.get_batch_sync(indices), self.tree)
+        return [jax.tree.map(lambda _, leaf: leaf[i], self.tree, grouped) for i in range(len(indices))]
+
+
 class ShardedTreeCache(AsyncDataset[T_co]):
     """Reads across multiple shard caches without requiring a consolidation step.
 
@@ -181,6 +395,11 @@ class ShardedTreeCache(AsyncDataset[T_co]):
             rows = ledger.shard_rows.get(shard_name, 0)
             self._cum_rows.append(self._cum_rows[-1] + rows)
             self._stores.append(TreeStore.open(exemplar, path, mode="r", cache_metadata=False))
+        self._store = ShardedTreeStore(self._stores)
+
+    @property
+    def store(self) -> ShardedTreeStore:
+        return self._store
 
     def _resolve_index(self, global_idx: int) -> tuple[int, int]:
         """Return (shard_index, local_row) for a global row index."""
@@ -203,7 +422,10 @@ class ShardedTreeCache(AsyncDataset[T_co]):
         shard_idx, local_idx = self._resolve_index(item)
         return self._stores[shard_idx][local_idx]
 
-    async def get_batch(self, indices: Sequence[int]) -> Sequence:
+    async def get_batch(self, indices: Sequence[int] | slice) -> Sequence:
+        if isinstance(indices, slice):
+            indices = range(indices.start or 0, indices.stop or len(self), indices.step or 1)
+
         # Group indices by shard, preserving original order
         shard_groups: dict[int, list[tuple[int, int]]] = {}  # shard_idx -> [(position_in_output, local_idx)]
         for pos, global_idx in enumerate(indices):
@@ -246,6 +468,51 @@ class ShardedTreeCache(AsyncDataset[T_co]):
     @property
     def is_finished(self):
         return True
+
+
+def _cumulative_offsets(sizes: Sequence[int]) -> list[int]:
+    offsets = [0]
+    for size in sizes:
+        offsets.append(offsets[-1] + size)
+    return offsets
+
+
+def _split_slice_by_boundaries(start: int, stop: int, boundaries: Sequence[int]) -> list[tuple[int, slice]]:
+    if start >= stop:
+        return []
+    pieces = []
+    shard_index = bisect.bisect_right(boundaries, start) - 1
+    while shard_index < len(boundaries) - 1 and start < stop:
+        shard_start = boundaries[shard_index]
+        shard_stop = boundaries[shard_index + 1]
+        piece_stop = min(stop, shard_stop)
+        if start < piece_stop:
+            pieces.append((shard_index, slice(start - shard_start, piece_stop - shard_start)))
+        start = piece_stop
+        shard_index += 1
+    return pieces
+
+
+def _concatenate_or_empty(pieces: Sequence[np.ndarray]) -> np.ndarray:
+    if not pieces:
+        return np.asarray([])
+    if len(pieces) == 1:
+        return np.asarray(pieces[0])
+    return np.concatenate(pieces)
+
+
+def _group_indices_by_shard(indices: Sequence[int], boundaries: Sequence[int]) -> dict[int, list[tuple[int, int]]]:
+    shard_groups: dict[int, list[tuple[int, int]]] = {}
+    total_rows = boundaries[-1]
+    for position, index in enumerate(indices):
+        if index < 0:
+            index += total_rows
+        if index < 0 or index >= total_rows:
+            raise IndexError("Index out of bounds")
+        shard_index = bisect.bisect_right(boundaries, index) - 1
+        local_index = index - boundaries[shard_index]
+        shard_groups.setdefault(shard_index, []).append((position, local_index))
+    return shard_groups
 
 
 @dataclass_json

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -190,9 +190,11 @@ class _ShardedArray:
             if step != 1:
                 values = await self._read(slice(start, stop))
                 return values[::step]
-            pieces = []
-            for shard_index, local_slice in _split_slice_by_boundaries(start, stop, self._boundaries):
-                pieces.append(await self._arrays[shard_index][local_slice].read())
+            reads = [
+                self._arrays[shard_index][local_slice].read()
+                for shard_index, local_slice in _split_slice_by_boundaries(start, stop, self._boundaries)
+            ]
+            pieces = await asyncio.gather(*reads)
             return _concatenate_or_empty(pieces)
 
         index = item

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -212,6 +212,7 @@ class _ShardedOffsets:
         self._stores = stores
         self._num_rows = sum(store.num_rows for store in stores)
         self._data_sizes = [store.data_size for store in stores]
+        self._offsets: np.ndarray | None = None
 
     def __getitem__(self, item):
         return _VirtualRead(lambda: self._read(item))
@@ -221,6 +222,11 @@ class _ShardedOffsets:
         return offsets[item]
 
     async def _full_offsets(self):
+        if self._offsets is None:
+            self._offsets = await self._compute_full_offsets()
+        return self._offsets
+
+    async def _compute_full_offsets(self):
         offset_reads = [store.offsets[0 : store.num_rows + 1].read() for store in self._stores]
         per_shard_offsets = await asyncio.gather(*offset_reads)
         adjusted_offsets = [np.asarray([self._num_rows], dtype=np.int64)]

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -255,11 +255,12 @@ class _ShardedShapes:
             if step != 1:
                 values = await self._read(slice(start, stop))
                 return values[::step]
-            pieces = []
+            reads = []
             for shard_index, local_slice in _split_slice_by_boundaries(start, stop, self._boundaries):
                 shapes = self._stores[shard_index].shapes
                 assert shapes is not None
-                pieces.append(await shapes[local_slice].read())
+                reads.append(shapes[local_slice].read())
+            pieces = await asyncio.gather(*reads)
             return _concatenate_or_empty(pieces)
 
         index = item

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -12,7 +12,7 @@ import os
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Sequence, TypeVar, Union
+from typing import Any, Awaitable, Callable, Dict, Generator, Generic, List, Optional, Sequence, TypeVar, Union
 
 import deepdiff
 import jax
@@ -161,17 +161,17 @@ class TreeCache(AsyncDataset[T_co]):
         return True
 
 
-class _VirtualRead:
-    def __init__(self, read_async):
+class _VirtualRead(Generic[T]):
+    def __init__(self, read_async: Callable[[], Awaitable[T]]):
         self._read_async = read_async
 
-    def read(self):
+    def read(self) -> "_VirtualRead[T]":
         return self
 
-    def __await__(self):
+    def __await__(self) -> Generator[Any, None, T]:
         return self._read_async().__await__()
 
-    def result(self):
+    def result(self) -> T:
         return blocking_wait(self._read_async())
 
 

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import bisect
 import copy
 import dataclasses
 import gc
@@ -139,6 +140,8 @@ class TreeCache(AsyncDataset[T_co]):
 
         if not ledger.is_finished:
             raise FileNotFoundError(f"Cache at {cache_dir} is not finished. Use build_or_load to build it.")
+        if ledger.shard_paths is not None:
+            return ShardedTreeCache(ledger.shard_paths, exemplar, ledger)  # type: ignore[return-value]
         return TreeCache(cache_dir, exemplar, ledger)
 
     @staticmethod
@@ -157,6 +160,94 @@ class TreeCache(AsyncDataset[T_co]):
         return True
 
 
+class ShardedTreeCache(AsyncDataset[T_co]):
+    """Reads across multiple shard caches without requiring a consolidation step.
+
+    Each shard is an independent TreeStore directory. This class maintains a
+    cumulative row index to translate global indices into (shard, local_index).
+    """
+
+    def __init__(self, shard_paths: list[str], exemplar: T_co, ledger: "CacheLedger"):
+        super().__init__()
+        self._exemplar = exemplar
+        self.ledger = ledger
+        self._shard_paths = shard_paths
+
+        # Build cumulative row boundaries: [0, rows_shard0, rows_shard0+rows_shard1, ...]
+        self._cum_rows: list[int] = [0]
+        self._stores: list[TreeStore] = []
+        for path in shard_paths:
+            shard_name = os.path.basename(path)
+            rows = ledger.shard_rows.get(shard_name, 0)
+            self._cum_rows.append(self._cum_rows[-1] + rows)
+            self._stores.append(TreeStore.open(exemplar, path, mode="r", cache_metadata=False))
+
+    def _resolve_index(self, global_idx: int) -> tuple[int, int]:
+        """Return (shard_index, local_row) for a global row index."""
+        if global_idx < 0 or global_idx >= self._cum_rows[-1]:
+            raise IndexError(f"Index {global_idx} out of range [0, {self._cum_rows[-1]})")
+        shard_idx = bisect.bisect_right(self._cum_rows, global_idx) - 1
+        local_idx = global_idx - self._cum_rows[shard_idx]
+        return shard_idx, local_idx
+
+    def __len__(self):
+        return self._cum_rows[-1]
+
+    async def async_len(self) -> int:
+        return len(self)
+
+    def is_finite(self) -> bool:
+        return True
+
+    def __getitem__(self, item):
+        shard_idx, local_idx = self._resolve_index(item)
+        return self._stores[shard_idx][local_idx]
+
+    async def get_batch(self, indices: Sequence[int]) -> Sequence:
+        # Group indices by shard, preserving original order
+        shard_groups: dict[int, list[tuple[int, int]]] = {}  # shard_idx -> [(position_in_output, local_idx)]
+        for pos, global_idx in enumerate(indices):
+            shard_idx, local_idx = self._resolve_index(global_idx)
+            shard_groups.setdefault(shard_idx, []).append((pos, local_idx))
+
+        # Fetch per-shard batches concurrently
+        results: list[None | Any] = [None] * len(indices)
+
+        async def _fetch_shard(shard_idx: int, items: list[tuple[int, int]]):
+            local_indices = [local_idx for _, local_idx in items]
+            batch = await self._stores[shard_idx].get_batch(local_indices)
+            for (pos, _), value in zip(items, batch):
+                results[pos] = value
+
+        await asyncio.gather(*[_fetch_shard(si, items) for si, items in shard_groups.items()])
+        return results
+
+    def get_batch_sync(self, indices_or_slice, *, timeout: Optional[float] = None):
+        if isinstance(indices_or_slice, slice):
+            indices_or_slice = range(
+                indices_or_slice.start or 0,
+                indices_or_slice.stop or len(self),
+                indices_or_slice.step or 1,
+            )
+        # Group by shard, fetch per-shard, reassemble
+        shard_groups: dict[int, list[tuple[int, int]]] = {}
+        for pos, global_idx in enumerate(indices_or_slice):
+            shard_idx, local_idx = self._resolve_index(global_idx)
+            shard_groups.setdefault(shard_idx, []).append((pos, local_idx))
+
+        results: list[None | Any] = [None] * len(indices_or_slice)
+        for shard_idx, items in shard_groups.items():
+            local_indices = [local_idx for _, local_idx in items]
+            batch = self._stores[shard_idx].get_batch_sync(local_indices)
+            for (pos, _), value in zip(items, batch):
+                results[pos] = value
+        return results
+
+    @property
+    def is_finished(self):
+        return True
+
+
 @dataclass_json
 @dataclass
 class CacheLedger:
@@ -166,6 +257,7 @@ class CacheLedger:
     finished_shards: List[str] = dataclasses.field(default_factory=list)
     field_counts: Dict[str, int] = dataclasses.field(default_factory=dict)
     metadata: "CacheMetadata" = dataclasses.field(default_factory=lambda: CacheMetadata({}))
+    shard_paths: Optional[List[str]] = None
 
     @staticmethod
     def load_or_initialize(cache_dir: str, source: ShardedDataSource, processor: BatchProcessor):
@@ -332,13 +424,11 @@ def build_cache(
     shard_results = sorted(shard_results, key=lambda r: r["index"])
 
     shard_cache_paths = [s["path"] for s in shard_results]
-    ledger = consolidate_shard_caches(
-        shard_cache_paths=shard_cache_paths,
-        output_path=cache_dir,
-        exemplar=processor.output_exemplar,
-        metadata=metadata,
-    )
-    _safe_remove(temp_root)
+    shard_ledgers = [s["ledger"] for s in shard_results]
+    ledger = _merge_ledgers(cache_dir, shard_cache_paths, shard_ledgers, metadata)
+    # Store shard paths so the reader can find them without consolidation
+    ledger.shard_paths = shard_cache_paths
+    ledger._serialize_and_commit(cache_dir)
     return ledger
 
 
@@ -715,6 +805,7 @@ def _try_load(path, metadata):
 
 __all__ = [
     "TreeCache",
+    "ShardedTreeCache",
     "build_or_load_cache",
     "SerialCacheWriter",
     "CacheLedger",

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -419,6 +419,8 @@ class ShardedTreeCache(AsyncDataset[T_co]):
         return True
 
     def __getitem__(self, item):
+        if isinstance(item, slice):
+            return self.get_batch_sync(item)
         shard_idx, local_idx = self._resolve_index(item)
         return self._stores[shard_idx][local_idx]
 

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -709,10 +709,7 @@ def build_cache(
 
     shard_cache_paths = [s["path"] for s in shard_results]
     shard_ledgers = [s["ledger"] for s in shard_results]
-    ledger = _merge_ledgers(cache_dir, shard_cache_paths, shard_ledgers, metadata)
-    # Store shard paths so the reader can find them without consolidation
-    ledger.shard_paths = shard_cache_paths
-    ledger._serialize_and_commit(cache_dir)
+    ledger = _merge_ledgers(cache_dir, shard_cache_paths, shard_ledgers, metadata, shard_paths=shard_cache_paths)
     return ledger
 
 
@@ -873,7 +870,12 @@ def consolidate_shard_caches(
 
 
 def _merge_ledgers(
-    output_path: str, shard_cache_paths: list[str], shard_ledgers: list[CacheLedger], metadata: CacheMetadata
+    output_path: str,
+    shard_cache_paths: list[str],
+    shard_ledgers: list[CacheLedger],
+    metadata: CacheMetadata,
+    *,
+    shard_paths: list[str] | None = None,
 ) -> CacheLedger:
     final_ledger = CacheLedger(
         total_num_rows=0,
@@ -881,8 +883,9 @@ def _merge_ledgers(
         finished_shards=[],
         field_counts={},
         metadata=metadata,
+        shard_paths=shard_paths,
     )
-    for shard_path, ledger in zip(shard_cache_paths, shard_ledgers):
+    for shard_path, ledger in zip(shard_cache_paths, shard_ledgers, strict=True):
         shard_name = os.path.basename(shard_path)
         final_ledger.shard_rows[shard_name] = ledger.total_num_rows
         final_ledger.finished_shards.append(shard_name)

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -142,7 +142,8 @@ class TreeCache(AsyncDataset[T_co]):
         if not ledger.is_finished:
             raise FileNotFoundError(f"Cache at {cache_dir} is not finished. Use build_or_load to build it.")
         if ledger.shard_paths is not None:
-            return ShardedTreeCache(ledger.shard_paths, exemplar, ledger)  # type: ignore[return-value]
+            shard_paths = [_resolve_shard_path(cache_dir, path) for path in ledger.shard_paths]
+            return ShardedTreeCache(shard_paths, exemplar, ledger)  # type: ignore[return-value]
         return TreeCache(cache_dir, exemplar, ledger)
 
     @staticmethod
@@ -523,6 +524,12 @@ def _group_indices_by_shard(indices: Sequence[int], boundaries: Sequence[int]) -
         local_index = index - boundaries[shard_index]
         shard_groups.setdefault(shard_index, []).append((position, local_index))
     return shard_groups
+
+
+def _resolve_shard_path(cache_dir: str, shard_path: str) -> str:
+    if "://" in shard_path or os.path.isabs(shard_path):
+        return shard_path
+    return os.path.join(cache_dir, shard_path)
 
 
 @dataclass_json

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -38,7 +38,7 @@ from ..data.sharded_datasource import ShardedDataSource
 from ..utils.fsspec_utils import exists as fsspec_exists
 from ..utils.fsspec_utils import remove as fsspec_remove
 from .jagged_array import JaggedArrayStore, _no_cache_read_context
-from .tree_store import TreeStore, _render_path_elem
+from .tree_store import TreeStore, _render_path_elem, heuristic_is_leaf
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -433,7 +433,7 @@ class ShardedTreeStore:
         self.mode = "r"
         self._shard_paths = list(shard_paths)
         self._shard_rows = list(shard_rows)
-        self.tree = jtu.tree_map_with_path(self._open_lazy_leaf, exemplar)
+        self.tree = jtu.tree_map_with_path(self._open_lazy_leaf, exemplar, is_leaf=heuristic_is_leaf)
 
     def _open_lazy_leaf(self, tree_path, item):
         item = np.asarray(item)

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import bisect
+import concurrent.futures
 import copy
 import dataclasses
 import gc
@@ -46,7 +47,7 @@ T_co = TypeVar("T_co", covariant=True)
 logger = pylogging.getLogger(__name__)
 
 LEDGER_FILE_NAME = "shard_ledger.json"
-CONSOLIDATE_DATA_SIZE_WORKERS = 32
+CACHE_WORKERS = 32
 
 DEFAULT_LOG_LEVEL = pylogging.INFO
 LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
@@ -398,18 +399,29 @@ class ShardedTreeCache(AsyncDataset[T_co]):
         self._shard_paths = shard_paths
 
         # Build cumulative row boundaries: [0, rows_shard0, rows_shard0+rows_shard1, ...]
-        self._cum_rows: list[int] = [0]
-        self._stores: list[TreeStore] = []
-        for path in shard_paths:
-            shard_name = os.path.basename(path)
-            rows = ledger.shard_rows.get(shard_name, 0)
-            self._cum_rows.append(self._cum_rows[-1] + rows)
-            self._stores.append(TreeStore.open(exemplar, path, mode="r", cache_metadata=False))
+        self._cum_rows = _cumulative_offsets(
+            [ledger.shard_rows.get(os.path.basename(path), 0) for path in shard_paths]
+        )
+        self._stores = self._open_stores(exemplar, shard_paths)
         self._store = ShardedTreeStore(self._stores)
 
     @property
     def store(self) -> ShardedTreeStore:
         return self._store
+
+    def _open_stores(self, exemplar: Any, shard_paths: Sequence[str]) -> list[TreeStore]:
+        if not shard_paths:
+            return []
+
+        max_workers = min(len(shard_paths), CACHE_WORKERS)
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix="sharded_tree_cache_open",
+        ) as executor:
+            futures = [
+                executor.submit(TreeStore.open, exemplar, path, mode="r", cache_metadata=False) for path in shard_paths
+            ]
+            return [future.result() for future in futures]
 
     def _resolve_index(self, global_idx: int) -> tuple[int, int]:
         """Return (shard_index, local_row) for a global row index."""
@@ -818,7 +830,7 @@ def consolidate_shard_caches(
 
     probe_ctx = ZephyrContext(
         resources=ResourceConfig(ram="5g", cpu=2),
-        max_workers=min(CONSOLIDATE_DATA_SIZE_WORKERS, len(shard_cache_paths)),
+        max_workers=min(CACHE_WORKERS, len(shard_cache_paths)),
         name="levanter-cache-probe",
     )
     probe_results = probe_ctx.execute(

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -110,7 +110,7 @@ class TreeCache(AsyncDataset[T_co]):
         return self._store
 
     async def async_len(self) -> int:
-        return len(self.store)
+        return await self.store.async_len()
 
     def __len__(self):
         return len(self.store)
@@ -123,7 +123,8 @@ class TreeCache(AsyncDataset[T_co]):
 
     async def get_batch(self, indices: Sequence[int] | slice):
         if isinstance(indices, slice):
-            indices = range(indices.start or 0, indices.stop or len(self), indices.step or 1)
+            stop = indices.stop if indices.stop is not None else await self.async_len()
+            indices = range(indices.start or 0, stop, indices.step or 1)
         return await self.store.get_batch(indices)
 
     def get_batch_sync(self, indices_or_slice, *, timeout: Optional[float] = None):

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -3,7 +3,6 @@
 
 import asyncio
 import bisect
-import concurrent.futures
 import copy
 import dataclasses
 import gc
@@ -17,6 +16,7 @@ from typing import Any, Awaitable, Callable, Dict, Generator, Generic, List, Opt
 
 import deepdiff
 import jax
+import jax.tree_util as jtu
 from rigging.filesystem import open_url, url_to_fs
 import numpy as np
 import pyarrow as pa
@@ -38,7 +38,7 @@ from ..data.sharded_datasource import ShardedDataSource
 from ..utils.fsspec_utils import exists as fsspec_exists
 from ..utils.fsspec_utils import remove as fsspec_remove
 from .jagged_array import JaggedArrayStore, _no_cache_read_context
-from .tree_store import TreeStore
+from .tree_store import TreeStore, _render_path_elem
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -177,43 +177,112 @@ class _VirtualRead(Generic[T]):
         return blocking_wait(self._read_async())
 
 
+class _LazyJaggedArrayStore:
+    def __init__(self, path: str, item_rank: int, dtype: np.dtype, num_rows: int):
+        self.path = path
+        self.item_rank = item_rank
+        self.dtype = dtype
+        self._num_rows = num_rows
+        self._store: JaggedArrayStore | None = None
+        self._lock = threading.Lock()
+
+    def _open(self) -> JaggedArrayStore:
+        store = self._store
+        if store is not None:
+            return store
+
+        with self._lock:
+            if self._store is None:
+                self._store = JaggedArrayStore.open(
+                    self.path,
+                    mode="r",
+                    item_rank=self.item_rank,
+                    dtype=self.dtype,
+                    cache_metadata=False,
+                )
+            return self._store
+
+    @property
+    def offsets(self):
+        return self._open().offsets
+
+    @property
+    def data(self):
+        return self._open().data
+
+    @property
+    def shapes(self):
+        return self._open().shapes
+
+    @property
+    def num_rows(self):
+        return self._num_rows
+
+    async def num_rows_async(self):
+        return self.num_rows
+
+    @property
+    def data_size(self):
+        return self._open().data_size
+
+    async def data_size_async(self):
+        return await self._open().data_size_async()
+
+    def __len__(self):
+        return self.num_rows
+
+    def __getitem__(self, item):
+        return self._open()[item]
+
+    async def get_batch(self, indices: Sequence[int]) -> Sequence[np.ndarray]:
+        return await self._open().get_batch(indices)
+
+    def get_batch_sync(self, indices: Sequence[int]) -> Sequence[np.ndarray]:
+        return self._open().get_batch_sync(indices)
+
+
 class _ShardedArray:
-    def __init__(self, arrays, sizes: list[int]):
-        self._arrays = arrays
-        self._sizes = sizes
-        self._boundaries = _cumulative_offsets(sizes)
+    def __init__(self, stores: Sequence[_LazyJaggedArrayStore]):
+        self._stores = stores
+        self._boundaries: list[int] | None = None
+
+    async def _data_boundaries(self):
+        if self._boundaries is None:
+            data_sizes = await asyncio.gather(*[store.data_size_async() for store in self._stores])
+            self._boundaries = _cumulative_offsets(data_sizes)
+        return self._boundaries
 
     def __getitem__(self, item):
         return _VirtualRead(lambda: self._read(item))
 
     async def _read(self, item):
+        boundaries = await self._data_boundaries()
         if isinstance(item, slice):
-            start, stop, step = item.indices(self._boundaries[-1])
+            start, stop, step = item.indices(boundaries[-1])
             if step != 1:
                 values = await self._read(slice(start, stop))
                 return values[::step]
             reads = [
-                self._arrays[shard_index][local_slice].read()
-                for shard_index, local_slice in _split_slice_by_boundaries(start, stop, self._boundaries)
+                self._stores[shard_index].data[local_slice].read()
+                for shard_index, local_slice in _split_slice_by_boundaries(start, stop, boundaries)
             ]
             pieces = await asyncio.gather(*reads)
             return _concatenate_or_empty(pieces)
 
         index = item
         if index < 0:
-            index += self._boundaries[-1]
-        if index < 0 or index >= self._boundaries[-1]:
+            index += boundaries[-1]
+        if index < 0 or index >= boundaries[-1]:
             raise IndexError("Index out of bounds")
-        shard_index = bisect.bisect_right(self._boundaries, index) - 1
-        local_index = index - self._boundaries[shard_index]
-        return await self._arrays[shard_index][local_index].read()
+        shard_index = bisect.bisect_right(boundaries, index) - 1
+        local_index = index - boundaries[shard_index]
+        return await self._stores[shard_index].data[local_index].read()
 
 
 class _ShardedOffsets:
-    def __init__(self, stores: list[JaggedArrayStore]):
+    def __init__(self, stores: Sequence[_LazyJaggedArrayStore]):
         self._stores = stores
         self._num_rows = sum(store.num_rows for store in stores)
-        self._data_sizes = [store.data_size for store in stores]
         self._offsets: np.ndarray | None = None
 
     def __getitem__(self, item):
@@ -230,10 +299,13 @@ class _ShardedOffsets:
 
     async def _compute_full_offsets(self):
         offset_reads = [store.offsets[0 : store.num_rows + 1].read() for store in self._stores]
-        per_shard_offsets = await asyncio.gather(*offset_reads)
+        per_shard_offsets, data_sizes = await asyncio.gather(
+            asyncio.gather(*offset_reads),
+            asyncio.gather(*[store.data_size_async() for store in self._stores]),
+        )
         adjusted_offsets = [np.asarray([self._num_rows], dtype=np.int64)]
         data_base = 0
-        for offsets, data_size in zip(per_shard_offsets, self._data_sizes):
+        for offsets, data_size in zip(per_shard_offsets, data_sizes):
             offsets = np.asarray(offsets, dtype=np.int64)
             offsets[0] = 0
             adjusted_offsets.append(offsets[1:] + data_base)
@@ -242,7 +314,7 @@ class _ShardedOffsets:
 
 
 class _ShardedShapes:
-    def __init__(self, stores: list[JaggedArrayStore]):
+    def __init__(self, stores: Sequence[_LazyJaggedArrayStore]):
         self._stores = stores
         self._sizes = [store.num_rows for store in stores]
         self._boundaries = _cumulative_offsets(self._sizes)
@@ -279,14 +351,14 @@ class _ShardedShapes:
 class ShardedJaggedArrayStore:
     """Virtual JaggedArrayStore backed by multiple shard-local stores."""
 
-    def __init__(self, stores: list[JaggedArrayStore]):
+    def __init__(self, stores: Sequence[_LazyJaggedArrayStore]):
         if not stores:
             raise ValueError("ShardedJaggedArrayStore requires at least one store")
-        self._stores = stores
+        self._stores = list(stores)
         self.item_rank = stores[0].item_rank
         self.offsets = _ShardedOffsets(stores)
-        self.data = _ShardedArray([store.data for store in stores], [store.data_size for store in stores])
-        self.shapes = _ShardedShapes(stores) if stores[0].shapes is not None else None
+        self.data = _ShardedArray(stores)
+        self.shapes = _ShardedShapes(stores) if self.item_rank > 1 else None
 
     @property
     def num_rows(self):
@@ -297,10 +369,10 @@ class ShardedJaggedArrayStore:
 
     @property
     def data_size(self):
-        return sum(store.data_size for store in self._stores)
+        return blocking_wait(self.data_size_async())
 
     async def data_size_async(self):
-        return self.data_size
+        return sum(await asyncio.gather(*[store.data_size_async() for store in self._stores]))
 
     def __len__(self):
         return self.num_rows
@@ -352,15 +424,27 @@ class ShardedJaggedArrayStore:
 class ShardedTreeStore:
     """Virtual TreeStore backed by multiple shard-local TreeStores."""
 
-    def __init__(self, stores: list[TreeStore]):
-        if not stores:
+    def __init__(self, shard_paths: Sequence[str], exemplar: T_co, shard_rows: Sequence[int]):
+        if not shard_paths:
             raise ValueError("ShardedTreeStore requires at least one store")
-        self.path = stores[0].path
+        if len(shard_paths) != len(shard_rows):
+            raise ValueError("shard_paths and shard_rows must have the same length")
+        self.path = shard_paths[0]
         self.mode = "r"
-        self._stores = stores
-        self.tree = jax.tree.map(
-            lambda *leaves: ShardedJaggedArrayStore(list(leaves)), *[store.tree for store in stores]
-        )
+        self._shard_paths = list(shard_paths)
+        self._shard_rows = list(shard_rows)
+        self.tree = jtu.tree_map_with_path(self._open_lazy_leaf, exemplar)
+
+    def _open_lazy_leaf(self, tree_path, item):
+        item = np.asarray(item)
+        rank = item.ndim
+        dtype = item.dtype
+        rendered_path = "/".join(_render_path_elem(x) for x in tree_path)
+        stores = [
+            _LazyJaggedArrayStore(os.path.join(shard_path, rendered_path), rank, dtype, rows)
+            for shard_path, rows in zip(self._shard_paths, self._shard_rows, strict=True)
+        ]
+        return ShardedJaggedArrayStore(stores)
 
     def __len__(self):
         return len(jax.tree.leaves(self.tree)[0])
@@ -399,29 +483,13 @@ class ShardedTreeCache(AsyncDataset[T_co]):
         self._shard_paths = shard_paths
 
         # Build cumulative row boundaries: [0, rows_shard0, rows_shard0+rows_shard1, ...]
-        self._cum_rows = _cumulative_offsets(
-            [ledger.shard_rows.get(os.path.basename(path), 0) for path in shard_paths]
-        )
-        self._stores = self._open_stores(exemplar, shard_paths)
-        self._store = ShardedTreeStore(self._stores)
+        self._shard_rows = [ledger.shard_rows.get(os.path.basename(path), 0) for path in shard_paths]
+        self._cum_rows = _cumulative_offsets(self._shard_rows)
+        self._store = ShardedTreeStore(shard_paths, exemplar, self._shard_rows)
 
     @property
     def store(self) -> ShardedTreeStore:
         return self._store
-
-    def _open_stores(self, exemplar: Any, shard_paths: Sequence[str]) -> list[TreeStore]:
-        if not shard_paths:
-            return []
-
-        max_workers = min(len(shard_paths), CACHE_WORKERS)
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=max_workers,
-            thread_name_prefix="sharded_tree_cache_open",
-        ) as executor:
-            futures = [
-                executor.submit(TreeStore.open, exemplar, path, mode="r", cache_metadata=False) for path in shard_paths
-            ]
-            return [future.result() for future in futures]
 
     def _resolve_index(self, global_idx: int) -> tuple[int, int]:
         """Return (shard_index, local_row) for a global row index."""
@@ -441,32 +509,13 @@ class ShardedTreeCache(AsyncDataset[T_co]):
         return True
 
     def __getitem__(self, item):
-        if isinstance(item, slice):
-            return self.get_batch_sync(item)
-        shard_idx, local_idx = self._resolve_index(item)
-        return self._stores[shard_idx][local_idx]
+        return self._store[item]
 
     async def get_batch(self, indices: Sequence[int] | slice) -> Sequence:
         if isinstance(indices, slice):
             indices = range(indices.start or 0, indices.stop or len(self), indices.step or 1)
 
-        # Group indices by shard, preserving original order
-        shard_groups: dict[int, list[tuple[int, int]]] = {}  # shard_idx -> [(position_in_output, local_idx)]
-        for pos, global_idx in enumerate(indices):
-            shard_idx, local_idx = self._resolve_index(global_idx)
-            shard_groups.setdefault(shard_idx, []).append((pos, local_idx))
-
-        # Fetch per-shard batches concurrently
-        results: list[None | Any] = [None] * len(indices)
-
-        async def _fetch_shard(shard_idx: int, items: list[tuple[int, int]]):
-            local_indices = [local_idx for _, local_idx in items]
-            batch = await self._stores[shard_idx].get_batch(local_indices)
-            for (pos, _), value in zip(items, batch):
-                results[pos] = value
-
-        await asyncio.gather(*[_fetch_shard(si, items) for si, items in shard_groups.items()])
-        return results
+        return await self._store.get_batch(indices)
 
     def get_batch_sync(self, indices_or_slice, *, timeout: Optional[float] = None):
         if isinstance(indices_or_slice, slice):
@@ -475,19 +524,7 @@ class ShardedTreeCache(AsyncDataset[T_co]):
                 indices_or_slice.stop or len(self),
                 indices_or_slice.step or 1,
             )
-        # Group by shard, fetch per-shard, reassemble
-        shard_groups: dict[int, list[tuple[int, int]]] = {}
-        for pos, global_idx in enumerate(indices_or_slice):
-            shard_idx, local_idx = self._resolve_index(global_idx)
-            shard_groups.setdefault(shard_idx, []).append((pos, local_idx))
-
-        results: list[None | Any] = [None] * len(indices_or_slice)
-        for shard_idx, items in shard_groups.items():
-            local_indices = [local_idx for _, local_idx in items]
-            batch = self._stores[shard_idx].get_batch_sync(local_indices)
-            for (pos, _), value in zip(items, batch):
-                results[pos] = value
-        return results
+        return self._store.get_batch_sync(indices_or_slice)
 
     @property
     def is_finished(self):

--- a/lib/levanter/src/levanter/store/jagged_array.py
+++ b/lib/levanter/src/levanter/store/jagged_array.py
@@ -220,7 +220,8 @@ class JaggedArrayStore:
     async def data_size_async(self):
         if self._cached_data_size is not None:
             return self._cached_data_size
-        result = int(await self.offsets[self.num_rows].read())
+        num_rows = await self.num_rows_async()
+        result = int(await self.offsets[num_rows].read())
         if self._cache_metadata:
             self._cached_data_size = result
         return result
@@ -235,11 +236,11 @@ class JaggedArrayStore:
         """
         Trims so we have exactly `size` rows in the jagged array.
         """
-        if size >= len(self):
+        current_num_rows = await self.num_rows_async()
+        if size >= current_num_rows:
             return
 
-        current_data_size = self.data_size
-        current_num_rows = await self.num_rows_async()
+        current_data_size = await self.data_size_async()
 
         offsets_fut = self.offsets[size + 1 : current_num_rows + 1].write(0)
 
@@ -313,7 +314,7 @@ class JaggedArrayStore:
 
         num_rows = await self.num_rows_async()
         num_added = len(new_offsets)
-        current_data_size = self.data_size
+        current_data_size = await self.data_size_async()
 
         new_offsets = new_offsets + current_data_size
 
@@ -415,7 +416,7 @@ class JaggedArrayStore:
                 data = await self.data[start:stop].read()
 
                 if self.shapes is not None:
-                    shapes = np.array(self.shapes[item])
+                    shapes = await self.shapes[item].read()
                     data = data.reshape(*shapes, -1)
                 return data
             except ValueError as e:

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -19,6 +19,7 @@ from levanter.store.cache import (
     SerialCacheWriter,
     _ShardedArray,
     _ShardedOffsets,
+    _ShardedShapes,
     ShardedTreeCache,
     TreeStore,
     build_or_load_cache,
@@ -413,6 +414,47 @@ async def test_sharded_array_reads_slice_shards_concurrently():
     values = await asyncio.wait_for(sharded[2:6], timeout=1)
 
     np.testing.assert_array_equal(values, np.asarray([2, 3, 4, 5]))
+
+
+@pytest.mark.asyncio
+async def test_sharded_shapes_reads_slice_shards_concurrently():
+    started = 0
+    both_started = asyncio.Event()
+
+    class FakeRead:
+        def __init__(self, values: np.ndarray):
+            self._values = values
+
+        async def read(self):
+            nonlocal started
+            started += 1
+            if started == 2:
+                both_started.set()
+            await both_started.wait()
+            return self._values
+
+    class FakeShapes:
+        def __init__(self, values: np.ndarray):
+            self._values = values
+
+        def __getitem__(self, item):
+            return FakeRead(self._values[item])
+
+    class FakeStore:
+        def __init__(self, shapes: np.ndarray):
+            self.num_rows = len(shapes)
+            self.shapes = FakeShapes(shapes)
+
+    sharded = _ShardedShapes(
+        [
+            FakeStore(np.asarray([[0], [1], [2], [3]])),
+            FakeStore(np.asarray([[4], [5], [6], [7]])),
+        ]
+    )
+
+    values = await asyncio.wait_for(sharded[2:6], timeout=1)
+
+    np.testing.assert_array_equal(values, np.asarray([[2], [3], [4], [5]]))
 
 
 @pytest.mark.asyncio

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -18,6 +18,7 @@ from levanter.store.cache import (
     CacheMetadata,
     SerialCacheWriter,
     _ShardedArray,
+    _ShardedOffsets,
     ShardedTreeCache,
     TreeStore,
     build_or_load_cache,
@@ -412,6 +413,44 @@ async def test_sharded_array_reads_slice_shards_concurrently():
     values = await asyncio.wait_for(sharded[2:6], timeout=1)
 
     np.testing.assert_array_equal(values, np.asarray([2, 3, 4, 5]))
+
+
+@pytest.mark.asyncio
+async def test_sharded_offsets_cache_full_offsets():
+    read_count = 0
+
+    class FakeRead:
+        def __init__(self, values: np.ndarray):
+            self._values = values
+
+        async def read(self):
+            nonlocal read_count
+            read_count += 1
+            return self._values
+
+    class FakeOffsets:
+        def __init__(self, values: np.ndarray):
+            self._values = values
+
+        def __getitem__(self, item):
+            return FakeRead(self._values[item])
+
+    class FakeStore:
+        def __init__(self, offsets: np.ndarray, data_size: int):
+            self.num_rows = len(offsets) - 1
+            self.data_size = data_size
+            self.offsets = FakeOffsets(offsets)
+
+    offsets = _ShardedOffsets(
+        [
+            FakeStore(np.asarray([2, 10, 20]), data_size=20),
+            FakeStore(np.asarray([2, 5, 15]), data_size=15),
+        ]
+    )
+
+    np.testing.assert_array_equal(await offsets[0:3], np.asarray([4, 10, 20]))
+    np.testing.assert_array_equal(await offsets[2:5], np.asarray([20, 25, 35]))
+    assert read_count == 2
 
 
 def test_sharded_tree_cache_via_load():

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -10,6 +10,7 @@ import pytest
 from zephyr.execution import ZephyrWorkerError
 
 from levanter.data import BatchProcessor, ShardedDataSource, batched
+from levanter.data.packing import GreedyPrepackedDataset
 from levanter.data.sharded_datasource import TextUrlDataSource
 from levanter.store.cache import (
     CacheLedger,
@@ -334,6 +335,28 @@ def test_sharded_tree_cache_reads_across_shards():
         cache = ShardedTreeCache(shard_paths, exemplar, ledger)
 
         assert len(cache) == 40
+        assert cache.store.tree["data"].num_rows == 40
+        assert cache.store.tree["data"].data_size == 400
+        np.testing.assert_array_equal(
+            cache.store.tree["data"].offsets[0:5].read().result(),
+            np.asarray([40, 10, 20, 30, 40]),
+        )
+        np.testing.assert_array_equal(
+            cache.store.tree["data"].data[95:105].read().result(),
+            np.asarray([9, 9, 9, 9, 9, 10, 10, 10, 10, 10]),
+        )
+        packed = GreedyPrepackedDataset(
+            cache.store.tree,
+            max_length=25,
+            max_segments_per_example=3,
+            slice_strategy="raise",
+        )
+        packed_batch = packed.as_sync_dataset().get_batch([0])
+        assert packed_batch[0][0]["data"].shape == (25,)
+        np.testing.assert_array_equal(
+            packed_batch[0][0]["data"],
+            np.asarray([0] * 10 + [1] * 10 + [0] * 5),
+        )
 
         # Sequential read
         for i in range(40):

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -461,12 +461,14 @@ def test_sharded_tree_cache_via_load():
 
     with tempfile.TemporaryDirectory() as tmpdir:
         shard_paths = []
+        relative_shard_paths = []
         for shard_idx, shard_name in enumerate(source.shard_names):
             shard_path = os.path.join(tmpdir, f"shard_{shard_idx}")
             with SerialCacheWriter(shard_path, exemplar, shard_name=shard_name) as writer:
                 for batch in batched(source.open_shard(shard_name), 32):
                     writer.write_batch(processor(batch))
             shard_paths.append(shard_path)
+            relative_shard_paths.append(os.path.basename(shard_path))
 
         shard_rows = {}
         for path in shard_paths:
@@ -480,7 +482,7 @@ def test_sharded_tree_cache_via_load():
             finished_shards=list(shard_rows.keys()),
             field_counts={},
             metadata=CacheMetadata.empty(),
-            shard_paths=shard_paths,
+            shard_paths=relative_shard_paths,
         )
         ledger._serialize_and_commit(tmpdir)
 

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -1,6 +1,7 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import os
 import tempfile
 from typing import Any, Dict, Iterator, Sequence
@@ -16,6 +17,7 @@ from levanter.store.cache import (
     CacheLedger,
     CacheMetadata,
     SerialCacheWriter,
+    _ShardedArray,
     ShardedTreeCache,
     TreeStore,
     build_or_load_cache,
@@ -373,6 +375,43 @@ def test_sharded_tree_cache_reads_across_shards():
         batch = cache.get_batch_sync(cross_indices)
         for idx, b in zip(cross_indices, batch):
             np.testing.assert_array_equal(b["data"], all_expected[idx]["data"])
+
+
+@pytest.mark.asyncio
+async def test_sharded_array_reads_slice_shards_concurrently():
+    started = 0
+    both_started = asyncio.Event()
+
+    class FakeRead:
+        def __init__(self, values: np.ndarray):
+            self._values = values
+
+        async def read(self):
+            nonlocal started
+            started += 1
+            if started == 2:
+                both_started.set()
+            await both_started.wait()
+            return self._values
+
+    class FakeArray:
+        def __init__(self, values: np.ndarray):
+            self._values = values
+
+        def __getitem__(self, item):
+            return FakeRead(self._values[item])
+
+    sharded = _ShardedArray(
+        [
+            FakeArray(np.asarray([0, 1, 2, 3])),
+            FakeArray(np.asarray([4, 5, 6, 7])),
+        ],
+        [4, 4],
+    )
+
+    values = await asyncio.wait_for(sharded[2:6], timeout=1)
+
+    np.testing.assert_array_equal(values, np.asarray([2, 3, 4, 5]))
 
 
 def test_sharded_tree_cache_via_load():

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -1,6 +1,7 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import tempfile
 from typing import Any, Dict, Iterator, Sequence
 
@@ -10,7 +11,14 @@ from zephyr.execution import ZephyrWorkerError
 
 from levanter.data import BatchProcessor, ShardedDataSource, batched
 from levanter.data.sharded_datasource import TextUrlDataSource
-from levanter.store.cache import SerialCacheWriter, TreeStore, build_or_load_cache
+from levanter.store.cache import (
+    CacheLedger,
+    CacheMetadata,
+    SerialCacheWriter,
+    ShardedTreeCache,
+    TreeStore,
+    build_or_load_cache,
+)
 
 
 class TestProcessor(BatchProcessor[Sequence[int], dict[str, np.ndarray]]):
@@ -286,3 +294,98 @@ def test_shard_cache_fails_gracefully_with_unknown_file_type():
 
         with pytest.raises(ZephyrWorkerError):
             build_or_load_cache(tmpdir, dataset, TestProcessor())
+
+
+def test_sharded_tree_cache_reads_across_shards():
+    """Write independent shard caches, then read them via ShardedTreeCache."""
+    source = SimpleShardSource(num_shards=4, rows_per_shard=10)
+    processor = SimpleProcessor()
+    exemplar = processor.output_exemplar
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        shard_paths = []
+        all_expected = []
+
+        for shard_idx, shard_name in enumerate(source.shard_names):
+            shard_path = os.path.join(tmpdir, f"shard_{shard_idx}")
+            with SerialCacheWriter(shard_path, exemplar, shard_name=shard_name) as writer:
+                for batch in batched(source.open_shard(shard_name), 32):
+                    processed = processor(batch)
+                    writer.write_batch(processed)
+                    all_expected.extend(processed)
+            shard_paths.append(shard_path)
+
+        # Build a ledger that references the shard paths
+        shard_rows = {}
+        for path in shard_paths:
+            shard_ledger = CacheLedger.load(path)
+            shard_rows[os.path.basename(path)] = shard_ledger.total_num_rows
+
+        ledger = CacheLedger(
+            total_num_rows=sum(shard_rows.values()),
+            shard_rows=shard_rows,
+            is_finished=True,
+            finished_shards=list(shard_rows.keys()),
+            field_counts={},
+            metadata=CacheMetadata.empty(),
+            shard_paths=shard_paths,
+        )
+
+        cache = ShardedTreeCache(shard_paths, exemplar, ledger)
+
+        assert len(cache) == 40
+
+        # Sequential read
+        for i in range(40):
+            row = cache[i]
+            np.testing.assert_array_equal(row["data"], all_expected[i]["data"])
+
+        # Batch read (sync)
+        batch = cache.get_batch_sync(list(range(0, 40, 3)))
+        for idx, b in zip(range(0, 40, 3), batch):
+            np.testing.assert_array_equal(b["data"], all_expected[idx]["data"])
+
+        # Cross-shard batch (indices spanning multiple shards)
+        cross_indices = [0, 10, 20, 30, 5, 15, 25, 35]
+        batch = cache.get_batch_sync(cross_indices)
+        for idx, b in zip(cross_indices, batch):
+            np.testing.assert_array_equal(b["data"], all_expected[idx]["data"])
+
+
+def test_sharded_tree_cache_via_load():
+    """TreeCache.load returns ShardedTreeCache when ledger has shard_paths."""
+    source = SimpleShardSource(num_shards=3, rows_per_shard=5)
+    processor = SimpleProcessor()
+    exemplar = processor.output_exemplar
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        shard_paths = []
+        for shard_idx, shard_name in enumerate(source.shard_names):
+            shard_path = os.path.join(tmpdir, f"shard_{shard_idx}")
+            with SerialCacheWriter(shard_path, exemplar, shard_name=shard_name) as writer:
+                for batch in batched(source.open_shard(shard_name), 32):
+                    writer.write_batch(processor(batch))
+            shard_paths.append(shard_path)
+
+        shard_rows = {}
+        for path in shard_paths:
+            shard_ledger = CacheLedger.load(path)
+            shard_rows[os.path.basename(path)] = shard_ledger.total_num_rows
+
+        ledger = CacheLedger(
+            total_num_rows=sum(shard_rows.values()),
+            shard_rows=shard_rows,
+            is_finished=True,
+            finished_shards=list(shard_rows.keys()),
+            field_counts={},
+            metadata=CacheMetadata.empty(),
+            shard_paths=shard_paths,
+        )
+        ledger._serialize_and_commit(tmpdir)
+
+        # Load via TreeCache.load — should return ShardedTreeCache
+        from levanter.store.cache import TreeCache
+
+        loaded = TreeCache.load(tmpdir, exemplar)
+        assert isinstance(loaded, ShardedTreeCache)
+        assert len(loaded) == 15

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -4,12 +4,14 @@
 import asyncio
 import os
 import tempfile
+import threading
 from typing import Any, Dict, Iterator, Sequence
 
 import numpy as np
 import pytest
 from zephyr.execution import ZephyrWorkerError
 
+import levanter.store.cache as cache_module
 from levanter.data import BatchProcessor, ShardedDataSource, batched
 from levanter.data.packing import GreedyPrepackedDataset
 from levanter.data.sharded_datasource import TextUrlDataSource
@@ -377,6 +379,49 @@ def test_sharded_tree_cache_reads_across_shards():
         batch = cache.get_batch_sync(cross_indices)
         for idx, b in zip(cross_indices, batch):
             np.testing.assert_array_equal(b["data"], all_expected[idx]["data"])
+
+
+def test_sharded_tree_cache_opens_shards_concurrently(monkeypatch):
+    shard_paths = [f"/tmp/shard_{idx}" for idx in range(3)]
+    ledger = CacheLedger(
+        total_num_rows=len(shard_paths),
+        shard_rows={os.path.basename(path): 1 for path in shard_paths},
+        is_finished=True,
+        finished_shards=[os.path.basename(path) for path in shard_paths],
+        field_counts={},
+        metadata=CacheMetadata.empty(),
+        shard_paths=shard_paths,
+    )
+    first_open_started = threading.Event()
+    second_open_started = threading.Event()
+    release_first_open = threading.Event()
+
+    class FakeShardedTreeStore:
+        def __init__(self, stores):
+            self.stores = stores
+
+    def open_store(exemplar, path, *, mode, cache_metadata):
+        assert exemplar == {}
+        assert mode == "r"
+        assert cache_metadata is False
+
+        if path == shard_paths[0]:
+            first_open_started.set()
+            assert second_open_started.wait(timeout=2)
+            release_first_open.set()
+        elif path == shard_paths[1]:
+            assert first_open_started.wait(timeout=2)
+            second_open_started.set()
+            assert release_first_open.wait(timeout=2)
+
+        return path
+
+    monkeypatch.setattr(cache_module.TreeStore, "open", open_store)
+    monkeypatch.setattr(cache_module, "ShardedTreeStore", FakeShardedTreeStore)
+
+    cache = ShardedTreeCache(shard_paths, {}, ledger)
+
+    assert cache.store.stores == shard_paths
 
 
 @pytest.mark.asyncio

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -4,7 +4,6 @@
 import asyncio
 import os
 import tempfile
-import threading
 from typing import Any, Dict, Iterator, Sequence
 
 import numpy as np
@@ -381,7 +380,7 @@ def test_sharded_tree_cache_reads_across_shards():
             np.testing.assert_array_equal(b["data"], all_expected[idx]["data"])
 
 
-def test_sharded_tree_cache_opens_shards_concurrently(monkeypatch):
+def test_sharded_tree_cache_opens_shards_lazily(monkeypatch):
     shard_paths = [f"/tmp/shard_{idx}" for idx in range(3)]
     ledger = CacheLedger(
         total_num_rows=len(shard_paths),
@@ -392,36 +391,33 @@ def test_sharded_tree_cache_opens_shards_concurrently(monkeypatch):
         metadata=CacheMetadata.empty(),
         shard_paths=shard_paths,
     )
-    first_open_started = threading.Event()
-    second_open_started = threading.Event()
-    release_first_open = threading.Event()
+    opened_paths = []
 
-    class FakeShardedTreeStore:
-        def __init__(self, stores):
-            self.stores = stores
+    class FakeJaggedArrayStore:
+        def __init__(self, path):
+            self.path = path
 
-    def open_store(exemplar, path, *, mode, cache_metadata):
-        assert exemplar == {}
+        def __getitem__(self, item):
+            return np.asarray([item])
+
+    def open_store(path, *, mode, item_rank, dtype, cache_metadata):
         assert mode == "r"
+        assert item_rank == 1
+        assert dtype == np.dtype(np.int64)
         assert cache_metadata is False
+        opened_paths.append(path)
+        return FakeJaggedArrayStore(path)
 
-        if path == shard_paths[0]:
-            first_open_started.set()
-            assert second_open_started.wait(timeout=2)
-            release_first_open.set()
-        elif path == shard_paths[1]:
-            assert first_open_started.wait(timeout=2)
-            second_open_started.set()
-            assert release_first_open.wait(timeout=2)
+    monkeypatch.setattr(cache_module.JaggedArrayStore, "open", open_store)
 
-        return path
+    cache = ShardedTreeCache(shard_paths, {"data": np.asarray([0], dtype=np.int64)}, ledger)
 
-    monkeypatch.setattr(cache_module.TreeStore, "open", open_store)
-    monkeypatch.setattr(cache_module, "ShardedTreeStore", FakeShardedTreeStore)
+    assert opened_paths == []
+    assert cache.store.tree["data"].num_rows == len(shard_paths)
+    assert opened_paths == []
 
-    cache = ShardedTreeCache(shard_paths, {}, ledger)
-
-    assert cache.store.stores == shard_paths
+    np.testing.assert_array_equal(cache[0]["data"], np.asarray([0]))
+    assert opened_paths == [os.path.join(shard_paths[0], "data")]
 
 
 @pytest.mark.asyncio

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -420,6 +420,41 @@ def test_sharded_tree_cache_opens_shards_lazily(monkeypatch):
     assert opened_paths == [os.path.join(shard_paths[0], "data")]
 
 
+def test_sharded_tree_cache_treats_scalar_lists_as_leaves(monkeypatch):
+    shard_paths = ["/tmp/shard_0"]
+    ledger = CacheLedger(
+        total_num_rows=1,
+        shard_rows={os.path.basename(shard_paths[0]): 1},
+        is_finished=True,
+        finished_shards=[os.path.basename(shard_paths[0])],
+        field_counts={},
+        metadata=CacheMetadata.empty(),
+        shard_paths=shard_paths,
+    )
+    opened_paths = []
+
+    class FakeJaggedArrayStore:
+        data_size = 1024
+
+        async def data_size_async(self):
+            return self.data_size
+
+    def open_store(path, *, mode, item_rank, dtype, cache_metadata):
+        assert item_rank == 1
+        assert dtype == np.dtype(np.int64)
+        opened_paths.append(path)
+        return FakeJaggedArrayStore()
+
+    monkeypatch.setattr(cache_module.JaggedArrayStore, "open", open_store)
+
+    cache = ShardedTreeCache(shard_paths, {"input_ids": [0]}, ledger)
+
+    token_arrays = cache.store.tree["input_ids"]
+    assert token_arrays.num_rows == 1
+    assert token_arrays.data_size == 1024
+    assert opened_paths == [os.path.join(shard_paths[0], "input_ids")]
+
+
 @pytest.mark.asyncio
 async def test_sharded_array_reads_slice_shards_concurrently():
     started = 0

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -15,6 +15,7 @@ import os
 import re
 import time
 from collections.abc import Iterator, Sequence
+from concurrent.futures import ThreadPoolExecutor
 
 import braceexpand
 import draccus
@@ -49,6 +50,7 @@ MIN_GROUP_BYTES = 100_000_000  # 100 MB floor to avoid degenerate tiny shards
 # Empirical upper bound on the zephyr window size (see
 # https://github.com/marin-community/marin/issues/2829#issuecomment-3963661943).
 _MAX_WINDOW_SIZE = 64
+_LOCAL_METADATA_MAX_WORKERS = 32
 
 
 def _avg_parquet_row_group_rows(path: str) -> int | None:
@@ -70,6 +72,10 @@ def _compute_target_group_bytes(total_input_bytes: int, max_workers: int) -> int
     Applies a floor of MIN_GROUP_BYTES to avoid degenerate tiny shards.
     """
     return max(total_input_bytes // max_workers, MIN_GROUP_BYTES)
+
+
+def _local_metadata_workers(num_items: int) -> int:
+    return max(1, min(_LOCAL_METADATA_MAX_WORKERS, num_items))
 
 
 @dataclasses.dataclass(frozen=True)
@@ -471,7 +477,10 @@ def tokenize(config: TokenizeConfigBase):
         tokenize_elapsed = time.monotonic() - tokenize_start
 
         # Build sharded ledger — each shard is directly readable, no consolidation needed.
-        shard_ledgers = [CacheLedger.load(p) for p in shard_paths]
+        # Loading per-shard ledgers is remote metadata I/O, so keep bounded
+        # parallelism in the local driver.
+        with ThreadPoolExecutor(max_workers=_local_metadata_workers(len(shard_paths))) as pool:
+            shard_ledgers = list(pool.map(CacheLedger.load, shard_paths))
         shard_rows = {}
         total_elements = 0
         field_counts: dict[str, int] = {}

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -502,13 +502,18 @@ def tokenize(config: TokenizeConfigBase):
         )
         ledger._serialize_and_commit(prefix)
 
-        # Sum token counts across shards
         exemplar = {"input_ids": np.zeros(0, dtype=np.int32)}
-        total_tokens = 0
-        for path in shard_paths:
+
+        def input_id_data_size(path: str) -> int:
             store = TreeStore.open(exemplar, path, mode="r", cache_metadata=True)
             if "input_ids" in store.tree:
-                total_tokens += store.tree["input_ids"].data_size
+                return store.tree["input_ids"].data_size
+            return 0
+
+        # Sum token counts across shards. TreeStore.open and data_size are
+        # remote metadata I/O, so parallelize with the same local cap.
+        with ThreadPoolExecutor(max_workers=_local_metadata_workers(len(shard_paths))) as pool:
+            total_tokens = sum(pool.map(input_id_data_size, shard_paths))
 
         stats_path = os.path.join(prefix, ".stats.json")
         with open_url(stats_path, "w") as f:

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -19,6 +19,7 @@ from collections.abc import Iterator, Sequence
 import braceexpand
 import draccus
 import fsspec
+import numpy as np
 import pyarrow.parquet as pq
 from datasets import load_dataset_builder
 from fray import ResourceConfig
@@ -30,7 +31,7 @@ from levanter.data.text import (
     UrlDatasetSourceConfig,
     preprocessor_for_format,
 )
-from levanter.store.cache import consolidate_shard_caches
+from levanter.store.cache import CacheLedger, CacheMetadata
 from levanter.store.tree_store import TreeStore
 from levanter.tokenizers import MarinTokenizer, TokenizerBackend, load_tokenizer
 from rigging.filesystem import open_url, url_to_fs
@@ -469,28 +470,36 @@ def tokenize(config: TokenizeConfigBase):
         shard_paths = ctx.execute(temp_shards).results
         tokenize_elapsed = time.monotonic() - tokenize_start
 
-        logger.info("Computing exemplar for cache consolidation")
-        exemplar = ctx.execute(
-            Dataset.from_list(file_groups[0][0:1])
-            .flat_map(load_file)
-            .take_per_shard(1)
-            .map_shard(lambda example, _: _tokenize_batches(config=config, batches=[example])),
-            verbose=False,
-        ).results[0]
+        # Build sharded ledger — each shard is directly readable, no consolidation needed.
+        shard_ledgers = [CacheLedger.load(p) for p in shard_paths]
+        shard_rows = {}
+        total_elements = 0
+        field_counts: dict[str, int] = {}
+        for path, sl in zip(shard_paths, shard_ledgers, strict=True):
+            shard_name = os.path.basename(path)
+            shard_rows[shard_name] = sl.total_num_rows
+            total_elements += sl.total_num_rows
+            for field, count in sl.field_counts.items():
+                field_counts[field] = field_counts.get(field, 0) + count
 
-        consolidate_start = time.monotonic()
-        logger.info(f"Consolidating {len(shard_paths)} shards into {prefix}")
-        ledger = consolidate_shard_caches(
-            shard_cache_paths=shard_paths,
-            output_path=prefix,
-            exemplar=exemplar,
-            copy_max_workers=config.cache_copy_max_workers,
+        ledger = CacheLedger(
+            total_num_rows=total_elements,
+            shard_rows=shard_rows,
+            is_finished=True,
+            finished_shards=list(shard_rows.keys()),
+            field_counts=field_counts,
+            metadata=CacheMetadata.empty(),
+            shard_paths=shard_paths,
         )
-        consolidate_elapsed = time.monotonic() - consolidate_start
+        ledger._serialize_and_commit(prefix)
 
-        total_elements = ledger.total_num_rows
-        store = TreeStore.open(exemplar, prefix, mode="r", cache_metadata=True)
-        total_tokens = store.tree["input_ids"].data_size if "input_ids" in store.tree else 0
+        # Sum token counts across shards
+        exemplar = {"input_ids": np.zeros(0, dtype=np.int32)}
+        total_tokens = 0
+        for path in shard_paths:
+            store = TreeStore.open(exemplar, path, mode="r", cache_metadata=True)
+            if "input_ids" in store.tree:
+                total_tokens += store.tree["input_ids"].data_size
 
         stats_path = os.path.join(prefix, ".stats.json")
         with open_url(stats_path, "w") as f:
@@ -502,7 +511,7 @@ def tokenize(config: TokenizeConfigBase):
         logger.info(
             f"{split_name} pipeline complete: {total_elements:,} docs, {total_tokens:,} tokens "
             f"in {pipeline_elapsed:.1f}s (tokenize: {tokenize_elapsed:.1f}s at {overall_tok_per_sec:,.0f} tokens/s "
-            f"{overall_doc_per_sec:,.1f} docs/s, consolidate: {consolidate_elapsed:.1f}s). "
+            f"{overall_doc_per_sec:,.1f} docs/s). "
             f"Wrote stats to {stats_path}"
         )
 

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -32,7 +32,7 @@ from levanter.data.text import (
     UrlDatasetSourceConfig,
     preprocessor_for_format,
 )
-from levanter.store.cache import CacheLedger, CacheMetadata
+from levanter.store.cache import CacheLedger, CacheMetadata, _merge_ledgers
 from levanter.store.tree_store import TreeStore
 from levanter.tokenizers import MarinTokenizer, TokenizerBackend, load_tokenizer
 from rigging.filesystem import open_url, url_to_fs
@@ -486,26 +486,14 @@ def tokenize(config: TokenizeConfigBase):
         # parallelism in the local driver.
         with ThreadPoolExecutor(max_workers=_local_metadata_workers(len(shard_paths))) as pool:
             shard_ledgers = list(pool.map(CacheLedger.load, shard_paths))
-        shard_rows = {}
-        total_elements = 0
-        field_counts: dict[str, int] = {}
-        for path, sl in zip(shard_paths, shard_ledgers, strict=True):
-            shard_name = os.path.basename(path)
-            shard_rows[shard_name] = sl.total_num_rows
-            total_elements += sl.total_num_rows
-            for field, count in sl.field_counts.items():
-                field_counts[field] = field_counts.get(field, 0) + count
-
-        ledger = CacheLedger(
-            total_num_rows=total_elements,
-            shard_rows=shard_rows,
-            is_finished=True,
-            finished_shards=list(shard_rows.keys()),
-            field_counts=field_counts,
-            metadata=CacheMetadata.empty(),
+        ledger = _merge_ledgers(
+            prefix,
+            shard_paths,
+            shard_ledgers,
+            CacheMetadata.empty(),
             shard_paths=_shard_paths_for_ledger(prefix, shard_paths),
         )
-        ledger._serialize_and_commit(prefix)
+        total_elements = ledger.total_num_rows
 
         exemplar = {"input_ids": np.zeros(0, dtype=np.int32)}
 

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -78,6 +78,11 @@ def _local_metadata_workers(num_items: int) -> int:
     return max(1, min(_LOCAL_METADATA_MAX_WORKERS, num_items))
 
 
+def _shard_paths_for_ledger(cache_path: str, shard_paths: Sequence[str]) -> list[str]:
+    prefix = cache_path.rstrip("/") + "/"
+    return [path.removeprefix(prefix) if path.startswith(prefix) else path for path in shard_paths]
+
+
 @dataclasses.dataclass(frozen=True)
 class HfDatasetSpec:
     """Specification for a HuggingFace dataset and optional subset name."""
@@ -498,7 +503,7 @@ def tokenize(config: TokenizeConfigBase):
             finished_shards=list(shard_rows.keys()),
             field_counts=field_counts,
             metadata=CacheMetadata.empty(),
-            shard_paths=shard_paths,
+            shard_paths=_shard_paths_for_ledger(prefix, shard_paths),
         )
         ledger._serialize_and_commit(prefix)
 

--- a/tests/processing/tokenize/test_tokenize.py
+++ b/tests/processing/tokenize/test_tokenize.py
@@ -16,6 +16,7 @@ from marin.processing.tokenize.tokenize import (
     TokenizeConfig,
     _bundle_files_by_size,
     _compute_target_group_bytes,
+    _shard_paths_for_ledger,
     tokenize,
 )
 from zephyr.dataset import FileEntry
@@ -172,6 +173,23 @@ def test_bundle_files_single_large_file():
     groups = list(_bundle_files_by_size(files, target))
     assert groups[0] == ["big.jsonl"]
     assert groups[1] == ["small1.jsonl", "small2.jsonl"]
+
+
+def test_shard_paths_for_ledger_makes_child_paths_relative():
+    cache_path = "gs://bucket/cache/train"
+
+    assert _shard_paths_for_ledger(
+        cache_path,
+        [
+            "gs://bucket/cache/train/part-00000-of-00002",
+            "gs://bucket/cache/train/nested/part-00001-of-00002",
+            "gs://other-bucket/cache/train/part-00000-of-00001",
+        ],
+    ) == [
+        "part-00000-of-00002",
+        "nested/part-00001-of-00002",
+        "gs://other-bucket/cache/train/part-00000-of-00001",
+    ]
 
 
 @pytest.mark.slow


### PR DESCRIPTION
- **[claude] remove consolidate**
- **[codex] add in-memory virtual tree for sharded caches**

Related to #4445

Remove consolidate from tokenize. Instead create a virtual `ShardedTreeCache` for downstream readers.