### PR TITLE
Remove RayConfig and port visualize to fray v2

### DIFF
--- a/lib/levanter/config/dpo_tiny_gpt2.yaml
+++ b/lib/levanter/config/dpo_tiny_gpt2.yaml
@@ -35,8 +35,6 @@ trainer:
   num_train_steps: 20
   steps_per_eval: 1
   model_averaging: null
-  ray:
-    auto_start_cluster: false
   require_accelerator: false
   checkpointer:
     save_interval: 1m

--- a/lib/levanter/config/gpt2_small_fast_public.yaml
+++ b/lib/levanter/config/gpt2_small_fast_public.yaml
@@ -30,8 +30,6 @@ trainer:
   per_device_parallelism: -1
   train_batch_size: 256
   num_train_steps: 10000
-  ray:
-    auto_start_cluster: false
 optimizer:
   learning_rate: 1E-3
   weight_decay: 0.1

--- a/lib/levanter/config/harness/eval_llama3.yaml
+++ b/lib/levanter/config/harness/eval_llama3.yaml
@@ -14,5 +14,3 @@ trainer:
     enabled: true
   per_device_parallelism: -1
   train_batch_size: 512
-  ray:
-    auto_start_cluster: false

--- a/lib/levanter/config/harness/harness_llama3.yaml
+++ b/lib/levanter/config/harness/harness_llama3.yaml
@@ -9,8 +9,6 @@ checkpoint_path: meta-llama/Meta-Llama-3-8B
 checkpoint_is_hf: true
 trainer:
   mp: p=bfloat16,c=bfloat16
-  ray:
-    auto_start_cluster: false
   mesh:
     axes:
       model: 4

--- a/lib/levanter/config/harness/harness_llama3_instruct.yaml
+++ b/lib/levanter/config/harness/harness_llama3_instruct.yaml
@@ -16,8 +16,6 @@ checkpoint_path: meta-llama/Meta-Llama-3.1-8B-Instruct
 checkpoint_is_hf: true
 trainer:
   mp: p=bfloat16,c=bfloat16
-  ray:
-    auto_start_cluster: false
   mesh:
     axes:
       model: 4

--- a/lib/levanter/config/llama2_7b.yaml
+++ b/lib/levanter/config/llama2_7b.yaml
@@ -79,10 +79,6 @@ trainer:
     num_steps: 100
     perfetto_link: false
     start_step: 5
-  ray:
-    address: null
-    auto_start_cluster: false
-    start_workers: false
   require_accelerator: true
   seed: 0
   shutdown_at_exit: false

--- a/lib/levanter/config/sampler/sample_llama8b.yaml
+++ b/lib/levanter/config/sampler/sample_llama8b.yaml
@@ -6,8 +6,6 @@ trainer:
   tracker:
     type: wandb
     project: levanter-inference-bench
-  ray:
-    auto_start_cluster: false
   mp: p=bfloat16,c=bfloat16
   mesh:
     axes:

--- a/lib/levanter/config/sampler/sample_nano.yaml
+++ b/lib/levanter/config/sampler/sample_nano.yaml
@@ -1,8 +1,6 @@
 hf_checkpoint: meta-llama/Llama-3.2-1B
 tokenizer: meta-llama/Llama-3.2-1B
 trainer:
-  ray:
-    auto_start_cluster: false
   mp: p=bfloat16,c=bfloat16
 prompts:
 - Four score and seven years ago, our

--- a/lib/levanter/docs/Getting-Started-GPU.md
+++ b/lib/levanter/docs/Getting-Started-GPU.md
@@ -217,7 +217,6 @@ We use [JAX Distributed](https://jax.readthedocs.io/en/latest/multi_process.html
 ```bash
 NCCL_DEBUG=INFO python src/levanter/main/train_lm.py \
   --config_path config/gpt2_7b.yaml \
-  --trainer.ray.auto_start_cluster false \
   --trainer.per_device_parallelism -1 \
   --trainer.distributed.num_processes 4 \
   --trainer.distributed.local_device_ids "[0,1,2,3,4,5,6,7]" \
@@ -251,7 +250,7 @@ Here is an updated Slurm script example where we've added `#SBATCH --nodes=2`.
 export PATH=$(echo $PATH | sed 's|:/usr/local/cuda/bin||')
 
 CONTAINER_PATH="ghcr.io/nvidia/jax:levanter"
-TRAINING_COMMAND="python -m levanter.main.train_lm --config_path config/gpt2_7b.yaml --trainer.ray.auto_start_cluster false --trainer.per_device_parallelism -1"
+TRAINING_COMMAND="python -m levanter.main.train_lm --config_path config/gpt2_7b.yaml --trainer.per_device_parallelism -1"
 
 srun docker run --gpus=all --shm-size=16g --rm $CONTAINER_PATH $TRAINING_COMMAND
 ```

--- a/lib/levanter/docs/reference/Configuration.md
+++ b/lib/levanter/docs/reference/Configuration.md
@@ -463,11 +463,9 @@ trainer:
 
 
 
-### Distributed and Ray
+### Distributed
 
 ::: levanter.distributed.DistributedConfig
-
-::: levanter.distributed.RayConfig
 
 ### Model Averaging
 

--- a/lib/levanter/src/levanter/distributed.py
+++ b/lib/levanter/src/levanter/distributed.py
@@ -1,20 +1,15 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import atexit
 import itertools
 import logging
 import os
 import re
-import socket
 from dataclasses import dataclass
 from typing import List, Optional, Union
 
 import jax
-import ray
-from jax._src import clusters, distributed
-
-from levanter.utils.py_utils import logical_cpu_core_count
+from jax._src import clusters
 
 
 logger = logging.getLogger(__name__)
@@ -193,133 +188,6 @@ def _choose_port(id):
     return port
 
 
-_already_initialized = False
-
-
-def _setup_logger():
-    logging.basicConfig(level=logging.INFO)
-
-
-def auto_ray_cluster(
-    address: Optional[str] = None,
-    namespace: Optional[str] = "levanter",
-    start_workers: bool = True,
-    fail_if_cluster_already_initialized: bool = False,
-    **kwargs,
-):
-    """Initializes ray, automatically discovering the address if it is not provided.
-    Currently supports slurm and TPU.
-
-    NB that Ray has Slurm support: https://docs.ray.io/en/latest/cluster/vms/user-guides/community/slurm.html
-
-    We don't use that because it's more geared towards submitting jobs to a ray cluster that is backed by slurm.
-    Instead, we have our machines already.
-    """
-    global _already_initialized
-
-    if _already_initialized:
-        logger.warning("auto_ray_cluster has already been called. Ignoring subsequent calls.")
-        return
-
-    def _munge_address_port(address: str):
-        # the coordinator address typically includes a port that jax wants to use. we want to use our own port
-        # we add a deterministic number to the chosen port and then cycle through the ephemeral range
-        # this is a hack, but it works
-        host, port_str = address.split(":")
-        port = int(port_str)
-        return host, port
-
-    if address is None:
-        # Ray automatically looks at RAY_ADDRESS. We don't want to use our defaulting logic if that is set
-        if os.getenv("RAY_ADDRESS") is not None:
-            address = os.getenv("RAY_ADDRESS")
-            logger.info("Auto-discovered ray address using RAY_ADDRESS: %s", address)
-        else:
-            coord_address = getattr(distributed.global_state, "coordinator_address", None)
-
-            if coord_address is None:
-                logger.info("No auto-discovered ray address found. Using ray.init('local').")
-                address = "local"
-            else:
-                logger.info(f"Auto-discovered ray address using JAX coordinator address: {coord_address}")
-                host, port = _munge_address_port(coord_address)
-
-                ray_port = _choose_port(port + 240)
-                address = f"{host}:{ray_port}"
-
-                # Explicitly setting the number of CPUs on ray init stops init errors
-                num_cpus = logical_cpu_core_count()
-
-                if _is_local_leader():
-                    # it used to be that if we were coordinator, we were also process 0
-                    # this is no longer the case, so instead we need to check if we are the coordinator
-                    # and if so, start the head
-                    if _is_this_machine(host):
-                        logger.info(f"Starting ray head on port {ray_port}. We are process the coordinator {host}.")
-                        logger.info(f"Starting ray head with num_cpus set to {num_cpus}.")
-                        ret = os.system(
-                            f"ray start --head --port {ray_port} --num-cpus {num_cpus} --dashboard-host=0.0.0.0"
-                        )
-                        if ret != 0:
-                            if not fail_if_cluster_already_initialized:
-                                # see if we can connect to the head
-                                logger.warning(
-                                    f"Failed to start ray head with exit code {ret}. Checking if we can connect to"
-                                    " the head..."
-                                )
-                                ret = os.system("ray status")
-                                if ret != 0:
-                                    raise RuntimeError(f"Failed to start ray head with exit code {ret}")
-                                else:
-                                    logger.info(f"Ray head already running on port {ray_port}. Connecting to it.")
-                            else:
-                                raise RuntimeError(f"Failed to start ray head with exit code {ret}")
-                        else:
-                            logger.info(f"Successfully started ray head on port {ray_port}.")
-
-                        # install an atexit handler to kill the head when we exit
-                        def kill_ray():
-                            # silence spam from ray stop
-                            os.system("bash -c 'ray stop -g 10 --force &> /dev/null'")
-
-                        atexit.register(kill_ray)
-                    elif start_workers:
-                        logger.info(
-                            f"Starting ray worker and connecting to {address}. We are process {jax.process_index()}."
-                        )
-                        logger.info(f"Starting ray worker with num_cpus set to {num_cpus}.")
-                        ret = os.system(f"ray start --address {address} --num-cpus {num_cpus}")
-                        if ret != 0:
-                            raise RuntimeError(f"Failed to start ray head with exit code {ret}")
-                        else:
-                            logger.info(f"Successfully started ray worker and connected to {address}.")
-
-    logger.info(f"ray.init(address={repr(address)}, namespace={repr(namespace)}, **{repr(kwargs)})")
-    # Ray has retry logic, but it doesn't seem to work super well, so we retry manually
-    for i in range(0, 5):
-        try:
-            ray.init(
-                address=address,
-                namespace=namespace,
-                runtime_env={"worker_process_setup_hook": _setup_logger},
-                **kwargs,
-            )
-            break
-        except Exception as e:
-            if i == 4:
-                raise e
-            else:
-                logger.warning(f"Failed to initialize ray with address {address}. Retrying...")
-                continue
-
-    def do_shutdown():
-        logger.info("Shutting down ray...")
-        ray.shutdown()
-
-    atexit.register(do_shutdown)
-    _already_initialized = True
-
-
 @dataclass(frozen=True)
 class DistributedConfig:
     coordinator_address: Optional[str] = None  # if None, we'll use the default coordinator address (for TPU or GPU)
@@ -392,77 +260,3 @@ class DistributedConfig:
                 "Not initializing jax.distributed because no distributed config "
                 "was provided, and no cluster was detected."
             )
-
-
-@dataclass(frozen=True)
-class RayConfig:
-    address: Optional[str] = None
-    start_workers: bool = True
-    auto_start_cluster: bool = False
-
-    def initialize(self):
-        if self.auto_start_cluster:
-            auto_ray_cluster(address=self.address, start_workers=self.start_workers)
-
-
-def _is_this_machine(host):
-    """
-    Checks if the given host identifies this machine.
-    """
-    if host == "localhost" or host == "0.0.0.0":
-        return True
-
-    try:
-        # Get IP addresses of all interfaces
-        machine_ips = [addr[4][0] for addr in socket.getaddrinfo(socket.gethostname(), None)]
-
-        # Get the IP address of the host
-        host_ip = socket.gethostbyname(host)
-    except socket.gaierror:
-        # Host or interface could not be resolved
-        return False
-
-    # Check if the host IP matches any of the machine IPs
-    return any(host_ip == machine_ip for machine_ip in machine_ips)
-
-
-def _remove_if_possible(path):
-    try:
-        os.remove(path)
-    except OSError:
-        pass
-
-
-def _touch(file_path):
-    with open(file_path, "a"):
-        os.utime(file_path, None)
-
-
-def _is_local_leader():
-    import atexit
-
-    import filelock
-    from jax.experimental.multihost_utils import broadcast_one_to_all
-
-    if jax.process_count() == 1:
-        return True
-
-    import random
-
-    random_id = random.randint(0, 1000000)
-    random_id = broadcast_one_to_all(random_id)
-
-    lock = filelock.FileLock(f"/tmp/levanter_local_process_zero_lock.{random_id}")
-    action_performed_file = f"/tmp/levanter_local_process_zero_action_performed.{random_id}"
-
-    try:
-        with lock.acquire(timeout=0.1):
-            atexit.register(_remove_if_possible, lock.lock_file)
-            atexit.register(_remove_if_possible, action_performed_file)
-            if not os.path.exists(action_performed_file):
-                _touch(action_performed_file)
-                return True  # Action needs to be performed
-            else:
-                return False  # Action already performed
-    except filelock.Timeout:
-        return False

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -59,7 +59,7 @@ from levanter.checkpoint import CheckpointerConfig, is_checkpoint_path, load_che
 from levanter.config import JsonAtom
 from levanter.data import AsyncDataset, DataLoader
 from levanter.data.loader import _round_to_nearest_multiple
-from levanter.distributed import DistributedConfig, RayConfig
+from levanter.distributed import DistributedConfig
 from levanter.grad_accum import microbatched
 from levanter.metrics import Metric, auto_metric_from_name, unwrap_metrics
 from levanter.optim.model_averaging import ModelAveragingConfig
@@ -866,7 +866,6 @@ class TrainerConfig:
     jax_compilation_cache_dir: Optional[str] = None
 
     distributed: DistributedConfig = DistributedConfig()
-    ray: RayConfig = field(default_factory=RayConfig)
 
     # whether or not to require an accelerator (e.g. TPU or GPU).
     # default depends on the platform: on macos False, else True
@@ -918,8 +917,6 @@ class TrainerConfig:
         id = self._maybe_set_id()
         levanter.utils.logging.init_logging(self.log_dir, f"{id}.log")
         _initialize_global_tracker(self.tracker, id)
-
-        self.ray.initialize()
 
         if self.require_accelerator is None:
             self.require_accelerator = not sys.platform.startswith("darwin")

--- a/lib/levanter/tests/test_eval_lm.py
+++ b/lib/levanter/tests/test_eval_lm.py
@@ -12,7 +12,7 @@ import haliax
 import levanter.main.eval_lm as eval_lm
 import tiny_test_corpus
 from levanter.checkpoint import save_checkpoint
-from levanter.distributed import DistributedConfig, RayConfig
+from levanter.distributed import DistributedConfig
 from levanter.models.llama import LlamaConfig, LlamaLMHeadModel
 from levanter.tracker import NoopConfig
 from levanter.trainer_state import TrainerState
@@ -51,7 +51,6 @@ def test_eval_lm():
                     tracker=NoopConfig(),
                     require_accelerator=False,
                     distributed=DistributedConfig(initialize_jax_distributed=False),
-                    ray=RayConfig(auto_start_cluster=False),
                 ),
                 checkpoint_path=f"{f}/ckpt",
             )
@@ -96,7 +95,6 @@ def test_eval_lm_from_hf():
                     tracker=NoopConfig(),
                     require_accelerator=False,
                     distributed=DistributedConfig(initialize_jax_distributed=False),
-                    ray=RayConfig(auto_start_cluster=False),
                 ),
                 checkpoint_path=f"{f}/ckpt",
             )

--- a/lib/levanter/tests/test_train_asr.py
+++ b/lib/levanter/tests/test_train_asr.py
@@ -9,7 +9,6 @@ import pytest
 
 import levanter.main.train_asr as train_asr
 import tiny_test_corpus
-from levanter.distributed import RayConfig
 from levanter.tracker import NoopConfig
 from test_utils import skip_if_no_soundlibs
 
@@ -33,7 +32,6 @@ def test_train_asr():
                     max_eval_batches=1,
                     tracker=NoopConfig(),
                     require_accelerator=False,
-                    ray=RayConfig(auto_start_cluster=False),
                 ),
                 hf_save_path=f"{tmpdir}/hf_asr_output",
             )

--- a/lib/levanter/tests/test_train_lm.py
+++ b/lib/levanter/tests/test_train_lm.py
@@ -14,7 +14,7 @@ import levanter.main.train_lm as train_lm
 import tiny_test_corpus
 from levanter.data.dataset import ListAsyncDataset
 from levanter.data.text import DirectDatasetComponent, GrugLmExample, LmDataConfig
-from levanter.distributed import DistributedConfig, RayConfig
+from levanter.distributed import DistributedConfig
 from levanter.tracker import NoopConfig
 
 
@@ -41,7 +41,6 @@ def test_train_lm():
                     tracker=NoopConfig(),
                     require_accelerator=False,
                     distributed=DistributedConfig(initialize_jax_distributed=False),
-                    ray=RayConfig(auto_start_cluster=False),
                 ),
             )
             train_lm.main(config)
@@ -76,7 +75,6 @@ def test_train_lm_fp8():
                     tracker=NoopConfig(),
                     require_accelerator=False,
                     distributed=DistributedConfig(initialize_jax_distributed=False),
-                    ray=RayConfig(auto_start_cluster=False),
                 ),
             )
             train_lm.main(config)
@@ -121,7 +119,6 @@ def test_train_lm_direct_dataset():
                     tracker=NoopConfig(),
                     require_accelerator=False,
                     distributed=DistributedConfig(initialize_jax_distributed=False),
-                    ray=RayConfig(auto_start_cluster=False),
                 ),
             )
             train_lm.main(config)

--- a/lib/levanter/tests/test_viz_lm.py
+++ b/lib/levanter/tests/test_viz_lm.py
@@ -12,7 +12,7 @@ import haliax
 import levanter.main.viz_logprobs as viz_logprobs
 import tiny_test_corpus
 from levanter.checkpoint import save_checkpoint
-from levanter.distributed import DistributedConfig, RayConfig
+from levanter.distributed import DistributedConfig
 from levanter.models.llama import LlamaConfig, LlamaLMHeadModel
 from levanter.tracker import NoopConfig
 
@@ -47,7 +47,6 @@ def test_viz_lm():
                     tracker=NoopConfig(),
                     require_accelerator=False,
                     distributed=DistributedConfig(initialize_jax_distributed=False),
-                    ray=RayConfig(auto_start_cluster=False),
                 ),
                 checkpoint_path=f"{f}/ckpt",
                 num_docs=len(jax.devices()),

--- a/lib/marin/src/marin/evaluation/evaluators/levanter_lm_eval_evaluator.py
+++ b/lib/marin/src/marin/evaluation/evaluators/levanter_lm_eval_evaluator.py
@@ -11,7 +11,6 @@ from rigging.filesystem import filesystem as marin_filesystem
 import levanter
 import levanter.eval_harness as eval_harness
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
-from levanter.distributed import RayConfig
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
 
@@ -73,7 +72,6 @@ class LevanterLmEvalEvaluator(LevanterTpuEvaluator):
                 tracker=WandbConfig(project="marin", tags=wandb_tags, name=name),
                 mp=jmp.get_policy("p=f32,c=bfloat16"),
                 per_device_eval_parallelism=1,
-                ray=RayConfig(auto_start_cluster=False),
             )
             logger.debug("after trainer config")
 

--- a/lib/marin/src/marin/evaluation/log_probs.py
+++ b/lib/marin/src/marin/evaluation/log_probs.py
@@ -13,7 +13,6 @@ from fray.v2 import current_client
 from fray.v2.types import Entrypoint, JobRequest, ResourceConfig, TpuConfig, create_environment
 from levanter.compat.hf_checkpoints import RepoRef
 from levanter.data.text import LMMixtureDatasetConfig
-from levanter.distributed import RayConfig
 from levanter.main.eval_lm import EvalLmConfig as LevanterEvalLmConfig
 from levanter.main.eval_lm import main as eval_lm_main
 from levanter.models.lm_model import LmConfig
@@ -133,7 +132,6 @@ def evaluate_lm_log_probs(config: EvalLmConfig) -> None:
                 WandbConfig(project="marin", tags=wandb_tags, name=name),
                 JsonFileTrackerConfig(output_path=config.output_path),
             ),
-            ray=RayConfig(auto_start_cluster=False),
             per_device_eval_parallelism=config.per_device_batch_size,
             max_eval_batches=max_eval_batches,
         ),

--- a/lib/marin/src/marin/evaluation/save_logprobs.py
+++ b/lib/marin/src/marin/evaluation/save_logprobs.py
@@ -34,7 +34,6 @@ from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, RepoRef
 from levanter.data import DataLoader
 from levanter.data.text import DatasetComponent, LmDataConfig, LMMixtureDatasetConfig
-from levanter.distributed import RayConfig
 from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.models.loss import next_token_loss
@@ -255,7 +254,6 @@ def default_save_logprobs(
                 data=data,
                 trainer=TrainerConfig(
                     tracker=NoopConfig(),
-                    ray=RayConfig(auto_start_cluster=False),
                     per_device_eval_parallelism=per_device_batch_size,
                     mp=jmp.get_policy("c=bf16"),
                 ),

--- a/lib/marin/src/marin/evaluation/visualize.py
+++ b/lib/marin/src/marin/evaluation/visualize.py
@@ -7,74 +7,19 @@ Uses Levanter's viz_lm functionality to visualize log probabilities of a languag
 
 import dataclasses
 import logging
-import multiprocessing
-import sys
 from dataclasses import dataclass
-from queue import Empty
 
-import tblib
-from fray.v1.cluster import Entrypoint, EnvironmentConfig, JobRequest, ResourceConfig, current_cluster
+from fray.v2 import current_client
+from fray.v2.types import Entrypoint, JobRequest, ResourceConfig, TpuConfig, create_environment
 from levanter.data.text import LMMixtureDatasetConfig
-from levanter.distributed import RayConfig
 from levanter.main.viz_logprobs import VizLmConfig as LevanterVizLmConfig
 from levanter.main.viz_logprobs import main as viz_lm_main
 from levanter.models.lm_model import LmConfig
 from levanter.trainer import TrainerConfig
 
 from marin.execution.executor import this_output_path
-from marin.utils import remove_tpu_lockfile_on_exit
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class ExceptionInfo:
-    ex: BaseException | None
-    tb: tblib.Traceback
-
-    def restore(self):
-        if self.ex is not None:
-            exc_value = self.ex.with_traceback(self.tb.as_traceback())
-            return (self.ex.__class__, exc_value, self.tb.as_traceback())
-        else:
-            return (Exception, Exception("Process failed with no exception"), self.tb.as_traceback())
-
-    def reraise(self):
-        if self.ex is not None:
-            raise self.ex.with_traceback(self.tb.as_traceback())
-        else:
-            raise Exception("Process failed with no exception").with_traceback(self.tb.as_traceback())
-
-
-def execute_in_subprocess(underlying_function, args, kwargs):
-    def target_fn(queue, args, kwargs):
-        try:
-            # Call the original function
-            result = underlying_function(*args, **kwargs)
-            queue.put((True, result))  # Success, put the result
-        except Exception as e:
-            # Capture and return the full traceback in case of an exception
-            exc_info = sys.exc_info()
-            exception_info = ExceptionInfo(ex=e, tb=tblib.Traceback(exc_info[2]))
-            queue.put((False, exception_info))
-
-    queue = multiprocessing.Queue()
-    process = multiprocessing.Process(target=target_fn, args=(queue, args, kwargs))
-    process.start()
-    process.join()
-
-    # Retrieve the result or error from the queue
-    logger.info("Process finished")
-    try:
-        success, value = queue.get(timeout=1)
-    except Empty:
-        logger.error("Process timed out")
-        process.terminate()
-        raise TimeoutError("Process timed out") from None
-
-    if not success:
-        value.reraise()
-    return value
 
 
 @dataclass
@@ -98,24 +43,12 @@ class VizLmConfig:
 
 
 def do_viz_lm(config: LevanterVizLmConfig) -> None:
-    """
-    Visualizes log probabilities of a language model.
-
-    Args:
-        config (VizLmConfig): The configuration for visualizing log probabilities.
-    """
     # Levanter can read `gs://` checkpoints directly via fsspec/tensorstore, and HF
     # checkpoints via fsspec as well. Avoid staging large directories locally.
-    execute_in_subprocess(viz_lm_main, (config,), {})
+    viz_lm_main(config)
 
 
 def visualize_lm_log_probs(config: VizLmConfig) -> None:
-    """
-    Visualizes log probabilities of a language model.
-
-    Args:
-        config (VizLmConfig): The configuration for visualizing log probabilities.
-    """
     levanter_config = LevanterVizLmConfig(
         checkpoint_path=config.checkpoint_path,
         checkpoint_is_hf=config.checkpoint_is_hf,
@@ -123,24 +56,19 @@ def visualize_lm_log_probs(config: VizLmConfig) -> None:
         num_docs=config.num_docs_per_dataset,
         path=config.output_path,
         data=config.datasets,
-        trainer=TrainerConfig(
-            ray=RayConfig(auto_start_cluster=False), per_device_eval_parallelism=config.per_device_batch_size
-        ),
+        trainer=TrainerConfig(per_device_eval_parallelism=config.per_device_batch_size),
         comparison_model_path=config.comparison_model_path,
         comparison_is_hf=config.comparison_is_hf,
     )
 
-    def _run_viz():
-        with remove_tpu_lockfile_on_exit():
-            do_viz_lm(levanter_config)
+    assert isinstance(config.resource_config.device, TpuConfig), "visualize_lm_log_probs requires TPU resource config"
 
     job_request = JobRequest(
         name="viz-lm-log-probs",
-        entrypoint=Entrypoint.from_callable(_run_viz),
         resources=config.resource_config,
-        environment=EnvironmentConfig.create(),
+        entrypoint=Entrypoint.from_callable(do_viz_lm, args=[levanter_config]),
+        environment=create_environment(extras=["tpu"]),
     )
-
-    cluster = current_cluster()
-    job_id = cluster.launch(job_request)
-    cluster.wait(job_id, raise_on_failure=True)
+    client = current_client()
+    job = client.submit(job_request)
+    job.wait(raise_on_failure=True)

--- a/lib/marin/src/marin/rl/rl_experiment_utils.py
+++ b/lib/marin/src/marin/rl/rl_experiment_utils.py
@@ -13,7 +13,6 @@ from fray.v2.types import ResourceConfig
 from levanter.checkpoint import CheckpointDebugConfig, CheckpointerConfig
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
 from levanter.layers.attention import AttentionBackend
-from levanter.distributed import RayConfig
 from levanter.optim import AdamConfig
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
@@ -245,7 +244,6 @@ def _build_rl_job_config(
             axes={"context": 1, "model": 1},
             shared_mapping={"mlp": "model", "heads": "model", "position": "context"},
         ),
-        ray=RayConfig(auto_start_cluster=False),
     )
 
     opt_config = AdamConfig(

--- a/lib/marin/src/marin/rl/scripts/evaluate_environment.py
+++ b/lib/marin/src/marin/rl/scripts/evaluate_environment.py
@@ -116,7 +116,6 @@ def _run_evaluation(config: EnvironmentEvalConfig) -> None:
     # Initialize Levanter with minimal trainer config
     trainer_config = TrainerConfig(
         mp=jmp.get_policy("p=f32,c=bfloat16"),
-        ray=levanter.distributed.RayConfig(auto_start_cluster=False),
         mesh=MeshConfig(axes={"model": model_axis_size}),
     )
 

--- a/lib/marin/src/marin/training/training.py
+++ b/lib/marin/src/marin/training/training.py
@@ -120,28 +120,6 @@ def _update_config_to_use_out_path(pod_config: TrainOnPodConfigT) -> TrainOnPodC
     return replace(pod_config, train_config=config)
 
 
-def _suppress_ray_config(config: TrainConfigT) -> TrainConfigT:
-    """
-    Levanter wants to auto-start the Ray cluster, but we're already in a Ray cluster. Disable that.
-    """
-    if config.trainer.ray.auto_start_cluster:
-        logger.info("Ray cluster is set to auto-start, but that's not what we want for Marin. Disabling.")
-        return replace(
-            config,
-            trainer=replace(
-                config.trainer,
-                ray=replace(config.trainer.ray, auto_start_cluster=False, start_workers=False),
-            ),
-        )
-    elif config.trainer.ray.start_workers:
-        logger.info("Ray cluster is set to start workers, but that's not what we want for Marin. Disabling.")
-        return replace(
-            config,
-            trainer=replace(config.trainer, ray=replace(config.trainer.ray, start_workers=False)),
-        )
-    return config
-
-
 def _maybe_override_auto_build_caches(config: TrainConfigT, auto_build: bool) -> TrainConfigT:
     data = config.data
     if data.auto_build_caches != auto_build:
@@ -254,7 +232,6 @@ def _prepare_training_run(
     logger.info(f"Using run ID: {config.train_config.trainer.id}")
 
     train_config = config.train_config
-    train_config = _suppress_ray_config(train_config)
     train_config = _maybe_override_auto_build_caches(train_config, config.auto_build_caches)
 
     # disable accelerator requirement when running without GPU/TPU resources

--- a/tests/rl/integration/config.py
+++ b/tests/rl/integration/config.py
@@ -23,7 +23,6 @@ import jax.random as jrandom
 import jmp
 import numpy as np
 from levanter.checkpoint import CheckpointerConfig
-from levanter.distributed import RayConfig
 from levanter.inference.engine import InferenceEngine, InferenceEngineConfig, Request
 from levanter.inference.jit_scheduler import SeqDecodingParams
 from levanter.inference.openai import InferenceServerConfig
@@ -220,7 +219,6 @@ def create_nano_trainer_config(output_dir: str | Path) -> TrainerConfig:
             base_path=Path(output_dir) / "checkpoints",
             save_interval=datetime.timedelta(seconds=10),
         ),
-        ray=RayConfig(auto_start_cluster=False),
     )
 
 

--- a/tests/rl/integration/test_llama_math_integration.py
+++ b/tests/rl/integration/test_llama_math_integration.py
@@ -12,7 +12,6 @@ import jmp
 from levanter.utils.mesh import MeshConfig
 import pytest
 from levanter.checkpoint import CheckpointerConfig
-from levanter.distributed import RayConfig
 from levanter.models.llama import LlamaConfig
 from levanter.optim import AdamConfig
 from levanter.tracker.json_logger import JsonLoggerConfig
@@ -107,7 +106,6 @@ def test_llama_math_integration(tmp_path):
             save_interval=datetime.timedelta(seconds=600),
         ),
         mesh=MeshConfig(axes={"model": 2}),
-        ray=RayConfig(auto_start_cluster=False),
     )
 
     # Create optimizer config

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -30,7 +30,7 @@ from levanter.checkpoint import CheckpointerConfig
 from levanter.data.dataset import ListAsyncDataset
 from levanter.data.text import DirectDatasetComponent, LmDataConfig
 from levanter.data.text.examples import GrugLmExample
-from levanter.distributed import DistributedConfig, RayConfig
+from levanter.distributed import DistributedConfig
 from levanter.grug.attention import AttentionMask as GrugAttentionMask
 from levanter.tracker.json_logger import JsonLoggerConfig
 from levanter.trainer import TrainerConfig
@@ -218,7 +218,6 @@ def test_grug_base_run_emits_expected_metrics_with_json_tracker(tmp_path: Path):
             require_accelerator=False,
             use_explicit_mesh_axes=True,
             distributed=DistributedConfig(initialize_jax_distributed=False),
-            ray=RayConfig(auto_start_cluster=False),
             log_dir=variant_tmp / "logs",
             checkpointer=CheckpointerConfig(base_path=str(variant_tmp / "checkpoints")),
         )

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 import pytest
 from fray.v2 import ResourceConfig
 from levanter.checkpoint import CheckpointerConfig
-from levanter.distributed import RayConfig
 from levanter.main import train_lm
 from levanter.trainer import TrainerConfig
 
@@ -24,7 +23,6 @@ def trainer_config():
     return TrainerConfig(
         id="test-run",
         checkpointer=CheckpointerConfig(),
-        ray=RayConfig(),
     )
 
 


### PR DESCRIPTION
## Summary
- Remove `RayConfig` from `levanter.distributed` and the `ray` field from `TrainerConfig`; drop the hard `import ray` from `levanter/distributed.py`. All call sites already passed `auto_start_cluster=False` (see #3108 / #3099), so the field was inert at runtime.
- Port `marin/evaluation/visualize.py` from fray v1 to fray v2 (`current_client().submit(JobRequest(...))`), deleting the subprocess/`ExceptionInfo` wrapper that the v1 flow needed. Complements the prior logprob migration in #4398.
- Update all call sites across `lib/levanter`, `lib/marin`, and `tests/` to drop `ray=RayConfig(...)` kwargs and related imports. Delete `_suppress_ray_config` in `marin/training/training.py`, which referenced the now-removed `trainer.ray` attribute.

Closes #4640. Closes #4639. Part of #4453.

## Test plan
- [x] `./infra/pre-commit.py --all-files --fix` clean
- [x] `uvx pyrefly check` — net -2 errors, no new errors introduced
- [x] `lib/levanter/tests/test_{eval_lm,train_lm,viz_lm,train_asr}.py` pass
- [x] `tests/test_training.py`, `tests/test_grug_variant_contracts.py`, `tests/rl/test_rl_experiment_utils.py`, `tests/rl/test_curriculum.py`, `tests/test_evaluator_utils.py` pass
- [x] Manual smoke test of `visualize_lm_log_probs` on v5p-8 via Iris (`/romain/iris-run-job-20260416-014508`): child TPU job submitted via fray v2, scheduled, loaded all dataset caches, discovered and began loading 8b checkpoint successfully. Job killed before completion to avoid cross-region transfer costs (data in us-central2, TPU in us-central1), but all code paths introduced by this PR were already exercised.

<details>
<summary>Smoke test script (not committed)</summary>

```python
# experiments/tootsie/exp4640_viz_smoke.py
from fray.v2 import ResourceConfig
from experiments.defaults import default_validation_sets
from experiments.tootsie.exp600_tootsie import llama3_tokenizer, llama_8b
from marin.evaluation.visualize import VizLmConfig, visualize_lm_log_probs
from marin.execution.executor import ExecutorStep, executor_main, versioned
from marin.processing.tokenize.data_configs import mixture_for_evaluation

CHECKPOINT = "gs://marin-us-central2/checkpoints/llama-8b-tootsie-phase2/checkpoints/step-730000/"

eval_set_mixture = mixture_for_evaluation(default_validation_sets(tokenizer=versioned(llama3_tokenizer)))

smoke_step = ExecutorStep(
    name="analysis/viz/issue-4640-smoke",
    fn=visualize_lm_log_probs,
    config=VizLmConfig(
        checkpoint_path=CHECKPOINT,
        model=llama_8b,
        datasets=eval_set_mixture,
        num_docs_per_dataset=2,
        resource_config=ResourceConfig.with_tpu("v5p-8", regions=["us-central1"]),
    ),
)

if __name__ == "__main__":
    executor_main([smoke_step], description="Smoke test fray v2 port of visualize_lm_log_probs")
```

Run: `.venv/bin/iris --config=lib/iris/examples/marin.yaml job run --no-wait --memory=2G --disk=4G --cpu=1 --extra=cpu --priority interactive -e WANDB_MODE disabled -- python -m experiments.tootsie.exp4640_viz_smoke`
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)