### PR TITLE
[iris] Add slice lifecycle state machine for autoscaler transitions

### DIFF
--- a/lib/iris/src/iris/cluster/controller/autoscaler/models.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/models.py
@@ -5,11 +5,67 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from enum import Enum
+import enum
+from dataclasses import dataclass, field
+from enum import Enum, StrEnum
+
+from rigging.timing import Timestamp
 
 from iris.cluster.constraints import Constraint, PlacementRequirements
+from iris.cluster.providers.types import SliceHandle
 from iris.rpc import job_pb2
+
+
+class SliceLifecycleState(StrEnum):
+    """Lifecycle state for a slice (VM group) in the autoscaler.
+
+    These states represent the dominant state of a slice based on its constituent VMs.
+    String values are lowercase names for use as dictionary keys and proto map keys.
+
+    States:
+    - REQUESTING: Scale-up operation in progress (tracked at ScalingGroup level)
+    - BOOTING: At least one VM is booting (VM_STATE_BOOTING)
+    - INITIALIZING: At least one VM is initializing (VM_STATE_INITIALIZING)
+    - READY: All VMs are ready (VM_STATE_READY)
+    - FAILED: At least one VM has failed (VM_STATE_FAILED or VM_STATE_PREEMPTED)
+
+    Note: These are slice-level aggregate states, not direct VM states.
+    """
+
+    REQUESTING = enum.auto()
+    BOOTING = enum.auto()
+    INITIALIZING = enum.auto()
+    READY = enum.auto()
+    FAILED = enum.auto()
+
+
+@dataclass
+class SliceState:
+    """Per-slice state tracked by ScalingGroup.
+
+    Consolidates the slice handle with its associated tracking state
+    (idle timeout, lifecycle) into a single structure.
+    lifecycle and worker_ids are populated eagerly by the bootstrap thread.
+    """
+
+    handle: SliceHandle
+    # Timestamp at which the slice's workers all became idle. None means
+    # the slice is currently active or has never been observed; in both
+    # cases the slice is not eligible for scale-down. Scale-down kicks in
+    # once `now - quiet_since >= idle_threshold`. Memory-only.
+    quiet_since: Timestamp | None = None
+    lifecycle: SliceLifecycleState = SliceLifecycleState.BOOTING
+    worker_ids: list[str] = field(default_factory=list)
+    # worker_id -> reachable http://host:port URL. Populated at READY transition
+    # from the slice handle's worker info. Empty after a controller restart for
+    # already-READY slices — the health probe lazy-fetches via
+    # handle.describe() in that case. Memory-only.
+    worker_urls: dict[str, str] = field(default_factory=dict)
+    # worker_id -> consecutive /health probe failures since the last
+    # success. Reset on a healthy response; once any worker crosses
+    # PING_FAILURE_THRESHOLD the slice is terminated. Memory-only.
+    ping_failures: dict[str, int] = field(default_factory=dict)
+    error_message: str = ""
 
 
 class ScalingAction(Enum):

--- a/lib/iris/src/iris/cluster/controller/autoscaler/planning.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/planning.py
@@ -9,8 +9,13 @@ from dataclasses import dataclass
 
 from rigging.timing import Timestamp
 
-from iris.cluster.controller.autoscaler.models import RoutingDecision, ScalingAction, ScalingDecision
-from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup, SliceLifecycleState
+from iris.cluster.controller.autoscaler.models import (
+    RoutingDecision,
+    ScalingAction,
+    ScalingDecision,
+    SliceLifecycleState,
+)
+from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup
 
 
 @dataclass(frozen=True)

--- a/lib/iris/src/iris/cluster/controller/autoscaler/routing.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/routing.py
@@ -29,9 +29,10 @@ from iris.cluster.controller.autoscaler.models import (
     DemandEntry,
     GroupRoutingStatus,
     RoutingDecision,
+    SliceLifecycleState,
     UnmetDemand,
 )
-from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability, ScalingGroup, SliceLifecycleState
+from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability, ScalingGroup
 from iris.rpc import config_pb2
 
 

--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -34,9 +34,6 @@ from iris.cluster.controller.autoscaler.models import (
     ScalingAction,
     ScalingDecision,
 )
-from iris.cluster.controller.autoscaler.operations import (
-    terminate_slices_for_workers as terminate_slices_for_workers_operation,
-)
 from iris.cluster.controller.autoscaler.planning import ScalePlan, build_scale_plan
 from iris.cluster.controller.autoscaler.recovery import (
     load_autoscaler_checkpoint,
@@ -44,13 +41,25 @@ from iris.cluster.controller.autoscaler.recovery import (
 )
 from iris.cluster.controller.autoscaler.routing import job_feasibility, route_demand
 from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup, build_worker_config_for_group
+from iris.cluster.controller.autoscaler.slice_lifecycle import (
+    BecameFailed,
+    BecameReady,
+    CloudFailed,
+    IdleTimeout,
+    InternalTransition,
+    NoOp,
+    SliceEvent,
+    TransitionOutcome,
+    UnknownTimeout,
+    WorkerFailure,
+    cloud_event,
+)
 from iris.cluster.controller.autoscaler.status import PendingHint, build_job_pending_hints, routing_decision_to_proto
 from iris.cluster.controller.autoscaler.worker_registry import TrackedWorker, WorkerRegistry
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.worker_health import PING_FAILURE_THRESHOLD
 from iris.cluster.providers.protocols import WorkerInfraProvider
 from iris.cluster.providers.types import (
-    CloudSliceState,
     QuotaExhaustedError,
     RemoteWorkerHandle,
     SliceHandle,
@@ -91,6 +100,27 @@ def _probe_worker_health(worker_url: str) -> bool:
         return 200 <= resp.status < 300
     except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError):
         return False
+
+
+def _failure_log(event: SliceEvent) -> tuple[str, str, str]:
+    """Map a terminal event to (action_type, reason, status) for the action log.
+
+    Keeps the action_log taxonomy readable:
+      - scale_down: healthy teardown of an idle slice
+      - worker_failed: explicit worker-side failure report
+      - slice_failed: everything else (cloud-side terminal states)
+    """
+    match event:
+        case IdleTimeout(target_capacity=target, ready_before=ready):
+            return "scale_down", f"idle slice (target={target}, ready={ready})", "completed"
+        case WorkerFailure(failed_worker_ids=ids):
+            return "worker_failed", f"workers failed: {', '.join(ids)}", "failed"
+        case CloudFailed(error_message=msg):
+            return "slice_failed", msg or "cloud slice failed", "failed"
+        case UnknownTimeout():
+            return "slice_failed", "cloud state UNKNOWN past timeout", "failed"
+        case _:
+            return "slice_failed", f"slice failed ({event.label})", "failed"
 
 
 class Autoscaler:
@@ -265,6 +295,40 @@ class Autoscaler:
         )
         return action
 
+    def _apply(self, outcome: TransitionOutcome, group: ScalingGroup) -> None:
+        """Execute caller-side work for a slice transition.
+
+        `ScalingGroup.dispatch()` has already mutated slice and (if triggered)
+        group-backoff state atomically. This method owns the externally-visible
+        side effects: worker registry, async terminate, and action-log entries.
+        """
+        match outcome:
+            case BecameReady(slice_id=slice_id, workers=workers):
+                worker_urls = self._worker_urls(workers)
+                if worker_urls:
+                    group.set_worker_urls(slice_id, worker_urls)
+                self._worker_registry.register_slice_workers(list(workers), slice_id, group.name)
+                self._log_action(
+                    "slice_ready",
+                    group.name,
+                    slice_id,
+                    reason=f"bootstrap completed ({len(workers)} workers)",
+                )
+            case BecameFailed(slice_id=slice_id, handle=handle, event=event, triggered_backoff=triggered):
+                self._worker_registry.unregister_slice_workers(slice_id)
+                self._spawn_terminate(group, handle)
+                action_type, reason, status = _failure_log(event)
+                self._log_action(action_type, group.name, slice_id, reason=reason, status=status)
+                if triggered:
+                    self._log_action(
+                        "backoff_triggered",
+                        group.name,
+                        slice_id=slice_id,
+                        reason=f"short-lived slice failure ({event.label})",
+                    )
+            case NoOp() | InternalTransition():
+                return
+
     def evaluate(
         self,
         demand_entries: list[DemandEntry],
@@ -424,23 +488,8 @@ class Autoscaler:
         """Build per-group WorkerConfig by merging base config with scale group overrides."""
         return build_worker_config_for_group(self._base_worker_config, group.config)
 
-    def _register_slice_workers(
-        self,
-        workers: list[RemoteWorkerHandle],
-        slice_id: str,
-        scale_group: str,
-    ) -> None:
-        """Register all workers from a slice into the in-memory handle cache."""
-
-        self._worker_registry.register_slice_workers(workers, slice_id, scale_group)
-
-    def _unregister_slice_workers(self, slice_id: str, worker_ids: Sequence[str] | None = None) -> None:
-        """Remove tracked workers belonging to a slice from the handle cache."""
-
-        self._worker_registry.unregister_slice_workers(slice_id, worker_ids)
-
     def refresh(self, worker_status_map: WorkerStatusMap, timestamp: Timestamp | None = None) -> None:
-        """State-read phase: scale down idle slices from currently tracked state."""
+        """State-read phase: poll non-READY slices and scale down idle slices."""
         timestamp = timestamp or Timestamp.now()
 
         for group in self._groups.values():
@@ -451,64 +500,22 @@ class Autoscaler:
                     logger.warning("Failed to poll slice %s: %s", slice_id, e)
                     continue
 
-                if status.state == CloudSliceState.READY:
-                    worker_ids = [w.worker_id for w in status.workers]
-                    worker_urls = self._worker_urls(status.workers)
-                    group.mark_slice_ready(slice_id, worker_ids, worker_urls=worker_urls)
-                    self._register_slice_workers(status.workers, slice_id, group.name)
-                    self._log_action(
-                        "slice_ready",
-                        group.name,
-                        slice_id,
-                        reason=f"bootstrap completed ({len(worker_ids)} workers)",
-                    )
-                elif status.state == CloudSliceState.FAILED:
-                    group.mark_slice_failed(slice_id, error_message=status.error_message)
-                    group.scale_down(slice_id)
-                    self._unregister_slice_workers(slice_id)
-                    group.record_slice_boot_failed(slice_id, timestamp)
-                    reason = status.error_message if status.error_message else "bootstrap failed"
-                    self._log_action(
-                        "slice_failed",
-                        group.name,
-                        slice_id,
-                        reason=reason,
-                        status="failed",
-                    )
-                elif status.state == CloudSliceState.UNKNOWN:
-                    age = Duration.from_ms(timestamp.epoch_ms() - handle.created_at.epoch_ms())
-                    if age >= self._unresolvable_timeout:
-                        group.mark_slice_failed(slice_id, error_message="unresolvable after timeout")
-                        group.scale_down(slice_id)
-                        self._unregister_slice_workers(slice_id)
-                        group.record_slice_boot_failed(slice_id, timestamp)
-                        self._log_action(
-                            "slice_failed",
-                            group.name,
-                            slice_id,
-                            reason=f"TPU unresolvable for {age}",
-                            status="failed",
-                        )
-                    else:
-                        logger.debug(
-                            "Slice %s UNKNOWN (age %s < timeout %s); will retry",
-                            slice_id,
-                            age,
-                            self._unresolvable_timeout,
-                        )
+                event = cloud_event(
+                    status.state,
+                    handle.created_at,
+                    timestamp,
+                    self._unresolvable_timeout,
+                    workers=status.workers,
+                    error_message=status.error_message,
+                )
+                if event is None:
+                    continue
+                self._apply(group.dispatch(slice_id, event, now=timestamp), group)
 
         for group in self._groups.values():
             target_capacity = min(group.current_demand + group.buffer_slices, group.max_slices)
-            ready_before = group.ready_slice_count()
-            scaled_down_handles = group.scale_down_if_idle(worker_status_map, target_capacity, timestamp)
-            for handle in scaled_down_handles:
-                self._unregister_slice_workers(handle.slice_id)
-                self._log_action(
-                    "scale_down",
-                    group.name,
-                    slice_id=handle.slice_id,
-                    reason=f"idle slice (target={target_capacity}, ready={ready_before})",
-                )
+            for outcome in group.scale_down_if_idle(worker_status_map, target_capacity, timestamp):
+                self._apply(outcome, group)
 
     def probe_health(self, timestamp: Timestamp | None = None) -> None:
         """Probe each READY slice's worker /health endpoint and terminate dead slices.
@@ -548,28 +555,26 @@ class Autoscaler:
             results = list(pool.map(lambda p: _probe_worker_health(p[3]), probes))
 
         # Phase 3: record results and collect slices that tripped the threshold.
-        tripped: dict[str, tuple[ScalingGroup, str]] = {}  # slice_id -> (group, reason)
+        # slice_id -> (group, failed worker ids accumulated in probe order)
+        tripped: dict[str, tuple[ScalingGroup, list[str]]] = {}
         for (group, slice_id, worker_id, _url), healthy in zip(probes, results, strict=True):
             count = group.record_health_probe_result(slice_id, worker_id, healthy)
-            if count >= PING_FAILURE_THRESHOLD and slice_id not in tripped:
-                reason = f"worker {worker_id} failed /health {count}x"
-                logger.warning("Slice %s: %s; terminating", slice_id, reason)
-                tripped[slice_id] = (group, reason)
+            if count >= PING_FAILURE_THRESHOLD:
+                logger.warning(
+                    "Slice %s: worker %s failed /health %dx; terminating",
+                    slice_id,
+                    worker_id,
+                    count,
+                )
+                tripped.setdefault(slice_id, (group, []))[1].append(worker_id)
 
-        # Phase 4: terminate tripped slices. Record as a PREEMPTED-style death,
-        # not a boot failure — these slices booted cleanly and only died at
-        # runtime, so the BackoffDetector's scale-up budget shouldn't decay.
-        for slice_id, (group, reason) in tripped.items():
-            group.mark_slice_failed(slice_id, error_message=reason)
-            group.scale_down(slice_id, timestamp)
-            self._unregister_slice_workers(slice_id)
-            self._log_action(
-                "slice_failed",
-                group.name,
-                slice_id,
-                reason=reason,
-                status="failed",
-            )
+        # Phase 4: terminate tripped slices. Routed through dispatch with a
+        # WorkerFailure event so the BackoffDetector and _apply side effects
+        # (unregister workers, async terminate, action log) stay in sync with
+        # the rest of the lifecycle pipeline.
+        for slice_id, (group, failed_worker_ids) in tripped.items():
+            event = WorkerFailure(failed_worker_ids=tuple(failed_worker_ids))
+            self._apply(group.dispatch(slice_id, event, now=timestamp), group)
 
     def _worker_urls(self, workers: Sequence[RemoteWorkerHandle]) -> dict[str, str]:
         """Map worker_id to the worker's reachable ``http://host:port`` URL.
@@ -713,30 +718,44 @@ class Autoscaler:
         Returns sibling worker IDs that should be failed immediately because
         their slices are being torn down.
         """
-        result = terminate_slices_for_workers_operation(
-            groups=self._groups,
-            worker_ids=worker_ids,
-            unregister_slice_workers=self._unregister_slice_workers,
-            log_action=self._log_action,
-            timestamp=Timestamp.now(),
-        )
-        for request in result.termination_requests:
+        if not worker_ids:
+            return []
 
-            def _terminate(
-                stop_event,
-                target_group: ScalingGroup = request.group,
-                target_slice_id: str = request.slice_id,
-                target_handle: SliceHandle = request.handle,
-            ) -> None:
-                del stop_event
-                self._terminate_slice_handle(target_group, target_slice_id, target_handle)
+        timestamp = Timestamp.now()
+        primary_workers = set(worker_ids)
+        sibling_worker_ids: set[str] = set()
+        slices_seen: set[str] = set()
 
-            self._threads.spawn(
-                target=_terminate,
-                name=f"slice-terminate-{request.slice_id}",
+        for worker_id in primary_workers:
+            slice_id, group = self._find_slice_for_worker(worker_id)
+            if not slice_id or group is None:
+                logger.debug("Worker %s not found in any managed slice", worker_id)
+                continue
+            if slice_id in slices_seen:
+                continue
+            slices_seen.add(slice_id)
+
+            slice_worker_ids = group.get_slice_worker_ids(slice_id)
+            sibling_worker_ids.update(wid for wid in slice_worker_ids if wid not in primary_workers)
+            failed = tuple(sorted(primary_workers & set(slice_worker_ids)))
+
+            self._apply(
+                group.dispatch(slice_id, WorkerFailure(failed_worker_ids=failed), now=timestamp),
+                group,
             )
 
-        return result.sibling_worker_ids
+        return sorted(sibling_worker_ids)
 
-    def _terminate_slice_handle(self, group: ScalingGroup, slice_id: str, handle: SliceHandle) -> None:
-        group._terminate_slice_handle(handle, context="cleaning up anyway")
+    def _find_slice_for_worker(self, worker_id: str) -> tuple[str | None, ScalingGroup | None]:
+        for group in self._groups.values():
+            slice_id = group.find_slice_for_worker(worker_id)
+            if slice_id is not None:
+                return slice_id, group
+        return None, None
+
+    def _spawn_terminate(self, group: ScalingGroup, handle: SliceHandle) -> None:
+        def _do_terminate(stop_event, g: ScalingGroup = group, h: SliceHandle = handle) -> None:
+            del stop_event
+            g._terminate_slice_handle(h, context="lifecycle teardown")
+
+        self._threads.spawn(target=_do_terminate, name=f"slice-terminate-{handle.slice_id}")

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -16,7 +16,7 @@ import math
 import threading
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from enum import Enum, StrEnum
+from enum import Enum
 
 from rigging.timing import Duration, Timestamp, TokenBucket
 from sqlalchemy import delete, update
@@ -40,6 +40,20 @@ from iris.cluster.controller.autoscaler.backoff_detector import (
     GroupHealth,
     SliceFate,
 )
+from iris.cluster.controller.autoscaler.models import SliceLifecycleState, SliceState
+from iris.cluster.controller.autoscaler.slice_lifecycle import (
+    SHORT_LIVED_SLICE_THRESHOLD,
+    TRANSITIONS,
+    BecameFailed,
+    BecameReady,
+    CloudFailed,
+    CloudReady,
+    IdleTimeout,
+    InternalTransition,
+    NoOp,
+    SliceEvent,
+    TransitionOutcome,
+)
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.schema import scaling_groups_table, slices_table
 from iris.cluster.providers.protocols import WorkerInfraProvider
@@ -49,29 +63,6 @@ from iris.rpc import config_pb2, job_pb2, time_pb2, vm_pb2
 from iris.time_proto import timestamp_to_proto
 
 logger = logging.getLogger(__name__)
-
-
-class SliceLifecycleState(StrEnum):
-    """Lifecycle state for a slice (VM group) in the autoscaler.
-
-    These states represent the dominant state of a slice based on its constituent VMs.
-    String values are lowercase names for use as dictionary keys and proto map keys.
-
-    States:
-    - REQUESTING: Scale-up operation in progress (tracked at ScalingGroup level)
-    - BOOTING: At least one VM is booting (VM_STATE_BOOTING)
-    - INITIALIZING: At least one VM is initializing (VM_STATE_INITIALIZING)
-    - READY: All VMs are ready (VM_STATE_READY)
-    - FAILED: At least one VM has failed (VM_STATE_FAILED or VM_STATE_PREEMPTED)
-
-    Note: These are slice-level aggregate states, not direct VM states.
-    """
-
-    REQUESTING = "requesting"
-    BOOTING = "booting"
-    INITIALIZING = "initializing"
-    READY = "ready"
-    FAILED = "failed"
 
 
 class GroupAvailability(Enum):
@@ -109,35 +100,6 @@ DEFAULT_SCALE_UP_RATE_LIMIT = 16  # per minute
 DEFAULT_SCALE_DOWN_RATE_LIMIT = 32  # per minute
 DEFAULT_IDLE_THRESHOLD = Duration.from_minutes(10)
 DEFAULT_QUOTA_TIMEOUT = Duration.from_minutes(5)
-
-
-@dataclass
-class SliceState:
-    """Per-slice state tracked by ScalingGroup.
-
-    Consolidates the slice handle with its associated tracking state
-    (idle timeout, lifecycle) into a single structure.
-    lifecycle and worker_ids are populated eagerly by the bootstrap thread.
-    """
-
-    handle: SliceHandle
-    # Timestamp at which the slice's workers all became idle. None means
-    # the slice is currently active or has never been observed; in both
-    # cases the slice is not eligible for scale-down. Scale-down kicks in
-    # once `now - quiet_since >= idle_threshold`. Memory-only.
-    quiet_since: Timestamp | None = None
-    lifecycle: SliceLifecycleState = SliceLifecycleState.BOOTING
-    worker_ids: list[str] = field(default_factory=list)
-    # worker_id -> reachable http://host:port URL. Populated at READY transition
-    # from the slice handle's worker info. Empty after a controller restart for
-    # already-READY slices — the health probe lazy-fetches via
-    # handle.describe() in that case. Memory-only.
-    worker_urls: dict[str, str] = field(default_factory=dict)
-    # worker_id -> consecutive /health probe failures since the last
-    # success. Reset on a healthy response; once any worker crosses
-    # PING_FAILURE_THRESHOLD the slice is terminated. Memory-only.
-    ping_failures: dict[str, int] = field(default_factory=dict)
-    error_message: str = ""
 
 
 def prepare_slice_config(
@@ -584,26 +546,89 @@ class ScalingGroup:
                 worker_ids,
             )
 
-    def mark_slice_failed(self, slice_id: str, error_message: str = "") -> None:
-        """Mark a slice as FAILED. Called when bootstrap fails."""
+    def dispatch(self, slice_id: str, event: SliceEvent, *, now: Timestamp | None = None) -> TransitionOutcome:
+        """Apply a typed lifecycle event, atomically with any cross-machine cascade.
+
+        Behavior note: a FAILED transition removes the slice from _slices and
+        hands the SliceHandle to the caller via BecameFailed.handle. The caller
+        is responsible for unregistering workers and async-terminating the
+        cloud handle. As a consequence, slice_state_counts() and to_status()
+        will never observe a slice in the FAILED state for this group — failure
+        is surfaced via the action log and the returned outcome, not via
+        lingering FAILED entries in the tracked slice map.
+
+        Holds _slices_lock across the slice mutation and dispatches the
+        terminal fate to the BackoffDetector so that short-lived failures
+        feed the AIMD health score consistently with the slice detach.
+        See test_concurrent_failures_account_atomically.
+        """
+        now = now or Timestamp.now()
+
         with self._slices_lock:
             state = self._slices.get(slice_id)
-            if state is not None:
-                state.lifecycle = SliceLifecycleState.FAILED
-                state.error_message = error_message
-                registered = list(state.worker_ids)
-            else:
-                registered = []
-        if state is not None:
-            self._db_upsert_slice(slice_id, state)
-            logger.warning(
-                "slice failed group=%s slice=%s n_registered=%d registered=%s error=%s",
-                self._config.name,
-                slice_id,
-                len(registered),
-                registered,
-                error_message,
-            )
+            if state is None:
+                logger.warning("slice event for unknown slice %s (event=%s)", slice_id, event.label)
+                return NoOp(slice_id, reason="unknown_slice")
+
+            to_state = TRANSITIONS.get((state.lifecycle, type(event)))
+            if to_state is None:
+                logger.warning(
+                    "no transition for slice %s in state %s on event %s",
+                    slice_id,
+                    state.lifecycle,
+                    event.label,
+                )
+                return NoOp(slice_id, reason=f"no_transition/{state.lifecycle.value}+{event.label}")
+
+            prior = state.lifecycle
+            state.lifecycle = to_state
+
+            outcome: TransitionOutcome
+            if to_state == SliceLifecycleState.READY:
+                assert isinstance(event, CloudReady)
+                state.quiet_since = None
+                state.worker_ids = [w.worker_id for w in event.workers]
+                outcome = BecameReady(slice_id=slice_id, workers=event.workers)
+
+            elif to_state == SliceLifecycleState.FAILED:
+                handle = state.handle
+                age = Duration.from_ms(now.epoch_ms() - handle.created_at.epoch_ms())
+                short_lived = age < SHORT_LIVED_SLICE_THRESHOLD
+                triggered = event.counts_toward_backoff and short_lived
+                # Feed the AIMD detector: BOOT_FAILED for slices that never
+                # reached READY (always decays); PREEMPTED for healthy slices
+                # that died short-lived (the detector applies its own
+                # short_lived gate). IdleTimeout is graceful — no fate.
+                if event.counts_toward_backoff:
+                    fate = SliceFate.PREEMPTED if prior == SliceLifecycleState.READY else SliceFate.BOOT_FAILED
+                    self._detector.record_terminated(slice_id, fate, now)
+                if isinstance(event, CloudFailed) and event.error_message:
+                    state.error_message = event.error_message
+                self._slices.pop(slice_id, None)
+                self._last_scale_down = now
+                outcome = BecameFailed(slice_id=slice_id, handle=handle, event=event, triggered_backoff=triggered)
+
+            else:  # BOOTING -> INITIALIZING
+                outcome = InternalTransition(slice_id=slice_id, prior=prior, new_state=to_state)
+
+        # Persistence outside the lock.
+        if isinstance(outcome, BecameFailed):
+            self._db_remove_slice(slice_id)
+            if outcome.triggered_backoff:
+                self._db_update_group()
+        elif slice_id in self._slices:
+            self._db_upsert_slice(slice_id, self._slices[slice_id])
+
+        logger.info(
+            "slice_transition group=%s slice=%s %s→%s event=%s backoff=%s",
+            self.name,
+            slice_id,
+            prior.value,
+            to_state.value,
+            event.label,
+            isinstance(outcome, BecameFailed) and outcome.triggered_backoff,
+        )
+        return outcome
 
     def reconcile(self) -> None:
         """Discover and adopt existing slices from the cloud.
@@ -887,41 +912,29 @@ class ScalingGroup:
         worker_status_map: WorkerStatusMap,
         target_capacity: int,
         timestamp: Timestamp,
-    ) -> list[SliceHandle]:
-        """Terminate idle slices over ``target_capacity``, rate-limited by the scale-down bucket.
+    ) -> list[BecameFailed]:
+        """Scale down idle slices that exceed target capacity.
 
-        Args:
-            worker_status_map: Map of worker_id to worker status.
-            target_capacity: Target number of slices (typically
-                ``min(demand + buffer_slices, max_slices)``).
-            timestamp: Current timestamp for idle calculation.
+        Dispatches IdleTimeout through the state machine for each eligible
+        slice so that all slice teardowns go through the same path. Returns
+        the list of BecameFailed outcomes so the caller can execute
+        side-effect work (unregister workers, async terminate the handle).
 
-        Returns:
-            List of terminated slice handles (may be empty).
+        Terminates multiple idle slices in a single call, rate-limited by a
+        token bucket.
         """
-        # Update activity tracking
         self.update_slice_activity(worker_status_map, timestamp)
 
-        # Use ready + pending for capacity check to prevent churn during boot
         counts = self.slice_state_counts()
         ready = counts[SliceLifecycleState.READY]
         pending = counts[SliceLifecycleState.BOOTING] + counts[SliceLifecycleState.INITIALIZING]
 
-        # Don't scale down if total capacity (ready + pending) is at or below target
-        if ready + pending <= target_capacity:
+        if ready + pending <= target_capacity or ready <= target_capacity:
             return []
 
-        # Don't scale down ready slices if we're still waiting for pending
-        if ready <= target_capacity:
-            return []
-
-        terminated: list[SliceHandle] = []
-
-        # Find idle slices and verify they're still idle before termination
-        idle_slices = self.get_idle_slices(timestamp)
-        for slice_state in idle_slices:
-            # Stop once we've scaled down to the target
-            if ready - len(terminated) <= target_capacity:
+        results: list[BecameFailed] = []
+        for slice_state in self.get_idle_slices(timestamp):
+            if ready - len(results) <= target_capacity:
                 break
 
             # Verify idle before acquiring a rate-limit token so that
@@ -930,11 +943,11 @@ class ScalingGroup:
                 continue
 
             if not self.acquire_scale_down_token(timestamp):
-                if terminated:
+                if results:
                     logger.info(
                         "Scale group %s: scale down rate-limited after %d terminations",
                         self.name,
-                        len(terminated),
+                        len(results),
                     )
                 break
 
@@ -943,7 +956,7 @@ class ScalingGroup:
             quiet_since = state.quiet_since if state is not None else None
             idle_ms = timestamp.epoch_ms() - quiet_since.epoch_ms() if quiet_since is not None else 0
             logger.info(
-                "Scale group %s: scaling down slice %s " "(idle for %dms, ready=%d/%d, pending=%d, target=%d)",
+                "Scale group %s: scaling down slice %s (idle for %dms, ready=%d/%d, pending=%d, target=%d)",
                 self.name,
                 slice_state.handle.slice_id,
                 idle_ms,
@@ -952,10 +965,12 @@ class ScalingGroup:
                 pending,
                 target_capacity,
             )
-            self.scale_down(slice_state.handle.slice_id, timestamp)
-            terminated.append(slice_state.handle)
+            event = IdleTimeout(target_capacity=target_capacity, ready_before=ready)
+            outcome = self.dispatch(slice_state.handle.slice_id, event, now=timestamp)
+            if isinstance(outcome, BecameFailed):
+                results.append(outcome)
 
-        return terminated
+        return results
 
     def _verify_slice_idle(self, state: SliceState, worker_status_map: WorkerStatusMap) -> bool:
         """Verify all workers in a slice are idle before termination.

--- a/lib/iris/src/iris/cluster/controller/autoscaler/slice_lifecycle.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/slice_lifecycle.py
@@ -1,0 +1,188 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Slice lifecycle state machine: typed events, table of transitions, variant outcomes.
+
+Events are discriminated-union dataclasses carrying the exact payload each
+transition needs; there is no untyped context dict at the API boundary.
+Cross-machine cascades (short-lived failure → group backoff) live on
+ScalingGroup, which holds _slices_lock across both the slice mutation and
+the group failure accounting so the two stay consistent.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import ClassVar
+
+from rigging.timing import Duration, Timestamp
+
+from iris.cluster.controller.autoscaler.models import SliceLifecycleState
+from iris.cluster.providers.types import CloudSliceState, RemoteWorkerHandle, SliceHandle
+
+logger = logging.getLogger(__name__)
+
+SHORT_LIVED_SLICE_THRESHOLD = Duration.from_minutes(5)
+
+
+# ---------------------------------------------------------------------------
+# Events
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SliceEvent:
+    """Base class for slice lifecycle events.
+
+    Subclasses carry exactly the payload the transition needs. Class-level
+    attributes (counts_toward_backoff, label) are read from the concrete type
+    so dispatch logic never branches on event kind.
+    """
+
+    counts_toward_backoff: ClassVar[bool] = False
+    label: ClassVar[str] = "slice_event"
+
+
+@dataclass(frozen=True)
+class CloudInitializing(SliceEvent):
+    label: ClassVar[str] = "cloud_initializing"
+
+
+@dataclass(frozen=True)
+class CloudReady(SliceEvent):
+    workers: tuple[RemoteWorkerHandle, ...]
+    label: ClassVar[str] = "cloud_ready"
+
+
+@dataclass(frozen=True)
+class CloudFailed(SliceEvent):
+    error_message: str = ""
+    counts_toward_backoff: ClassVar[bool] = True
+    label: ClassVar[str] = "cloud_failed"
+
+
+@dataclass(frozen=True)
+class UnknownTimeout(SliceEvent):
+    counts_toward_backoff: ClassVar[bool] = True
+    label: ClassVar[str] = "cloud_unknown_timeout"
+
+
+@dataclass(frozen=True)
+class WorkerFailure(SliceEvent):
+    failed_worker_ids: tuple[str, ...]
+    counts_toward_backoff: ClassVar[bool] = True
+    label: ClassVar[str] = "worker_failure"
+
+
+@dataclass(frozen=True)
+class IdleTimeout(SliceEvent):
+    target_capacity: int
+    ready_before: int
+    label: ClassVar[str] = "idle_timeout"
+
+
+# ---------------------------------------------------------------------------
+# Transition table
+# ---------------------------------------------------------------------------
+
+_B = SliceLifecycleState.BOOTING
+_I = SliceLifecycleState.INITIALIZING
+_R = SliceLifecycleState.READY
+_F = SliceLifecycleState.FAILED
+
+TRANSITIONS: dict[tuple[SliceLifecycleState, type[SliceEvent]], SliceLifecycleState] = {
+    (_B, CloudInitializing): _I,
+    (_B, CloudReady):        _R,
+    (_B, CloudFailed):       _F,
+    (_B, UnknownTimeout):    _F,
+    (_B, WorkerFailure):     _F,
+    (_I, CloudReady):        _R,
+    (_I, CloudFailed):       _F,
+    (_I, UnknownTimeout):    _F,
+    (_I, WorkerFailure):     _F,
+    (_R, WorkerFailure):     _F,
+    (_R, IdleTimeout):       _F,
+}  # fmt: skip
+
+
+# ---------------------------------------------------------------------------
+# Outcomes: variant type the caller match-dispatches on.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NoOp:
+    """Unknown slice or invalid (state, event) pair; caller has no work to do."""
+
+    slice_id: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class InternalTransition:
+    """State changed but the transition has no externally visible side effect
+    (e.g. BOOTING → INITIALIZING). Persistence is handled inside dispatch."""
+
+    slice_id: str
+    prior: SliceLifecycleState
+    new_state: SliceLifecycleState
+
+
+@dataclass(frozen=True)
+class BecameReady:
+    """Slice reached READY. Caller registers workers and logs a slice_ready action."""
+
+    slice_id: str
+    workers: tuple[RemoteWorkerHandle, ...]
+
+
+@dataclass(frozen=True)
+class BecameFailed:
+    """Slice reached FAILED and has been detached from the group's _slices map.
+
+    Caller unregisters workers, async-terminates the handle, and logs. If
+    triggered_backoff is True, the group's consecutive_failures/backoff_until
+    were also updated atomically under the same lock as the slice detach.
+    """
+
+    slice_id: str
+    handle: SliceHandle
+    event: SliceEvent
+    triggered_backoff: bool
+
+
+TransitionOutcome = NoOp | InternalTransition | BecameReady | BecameFailed
+
+
+# ---------------------------------------------------------------------------
+# Event derivation from cloud observations.
+# ---------------------------------------------------------------------------
+
+
+def cloud_event(
+    cloud_state: CloudSliceState,
+    handle_created_at: Timestamp,
+    now: Timestamp,
+    unresolvable_timeout: Duration,
+    *,
+    workers: Sequence[RemoteWorkerHandle] = (),
+    error_message: str = "",
+) -> SliceEvent | None:
+    """Map a cloud-side observation to a typed lifecycle event.
+
+    Returns None for UNKNOWN within the timeout (retryable) and for any
+    cloud_state the state machine does not model.
+    """
+    if cloud_state == CloudSliceState.READY:
+        return CloudReady(workers=tuple(workers))
+    if cloud_state == CloudSliceState.FAILED:
+        return CloudFailed(error_message=error_message)
+    if cloud_state in (CloudSliceState.BOOTSTRAPPING, CloudSliceState.CREATING):
+        return CloudInitializing()
+    if cloud_state == CloudSliceState.UNKNOWN:
+        age = Duration.from_ms(now.epoch_ms() - handle_created_at.epoch_ms())
+        if age >= unresolvable_timeout:
+            return UnknownTimeout()
+        logger.debug("Slice UNKNOWN (age %s < timeout %s); will retry", age, unresolvable_timeout)
+        return None
+    return None

--- a/lib/iris/tests/cluster/controller/conftest.py
+++ b/lib/iris/tests/cluster/controller/conftest.py
@@ -33,6 +33,7 @@ from iris.cluster.controller import reads
 from iris.cluster.controller.autoscaler import Autoscaler
 from iris.cluster.controller.autoscaler.models import DemandEntry
 from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup
+from iris.cluster.controller.autoscaler.slice_lifecycle import CloudReady
 from iris.cluster.controller.controller import Controller, ControllerConfig
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.provider import ProviderUnsupportedError
@@ -991,8 +992,8 @@ def make_autoscaler(
 def mark_discovered_ready(group: ScalingGroup, handles: list[MagicMock], timestamp: Timestamp | None = None) -> None:
     """Mark discovered slices as READY with their worker IDs."""
     for handle in handles:
-        worker_ids = [w.worker_id for w in handle.describe().workers]
-        group.mark_slice_ready(handle.slice_id, worker_ids, timestamp=timestamp)
+        workers = tuple(handle.describe().workers)
+        group.dispatch(handle.slice_id, CloudReady(workers=workers), now=timestamp)
 
 
 def mark_all_slices_ready(group: ScalingGroup) -> None:
@@ -1004,8 +1005,7 @@ def mark_all_slices_ready(group: ScalingGroup) -> None:
     for handle in group.slice_handles():
         desc = handle.describe()
         if desc.state == CloudSliceState.READY:
-            worker_ids = [w.worker_id for w in desc.workers]
-            group.mark_slice_ready(handle.slice_id, worker_ids)
+            group.dispatch(handle.slice_id, CloudReady(workers=tuple(desc.workers)))
 
 
 def make_gcp_provider(

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -19,6 +19,7 @@ from iris.cluster.controller.autoscaler.backoff_detector import GroupHealth
 from iris.cluster.controller.autoscaler.models import ScalingAction, ScalingDecision
 from iris.cluster.controller.autoscaler.routing import route_demand
 from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability, ScalingGroup
+from iris.cluster.controller.autoscaler.slice_lifecycle import CloudReady
 from iris.cluster.controller.worker_health import PING_FAILURE_THRESHOLD
 from iris.cluster.providers.types import (
     CloudSliceState,
@@ -680,7 +681,7 @@ class TestAutoscalerBootstrapLogs:
         autoscaler = make_autoscaler({"test-group": group})
 
         workers = mock_handle.describe().workers
-        autoscaler._register_slice_workers(workers, mock_handle.slice_id, "test-group")
+        autoscaler._worker_registry.register_slice_workers(list(workers), mock_handle.slice_id, "test-group")
 
         vm_id = mock_handle.describe().workers[0].worker_id
         assert autoscaler.get_init_log(vm_id) == bootstrap_log
@@ -694,7 +695,7 @@ class TestAutoscalerBootstrapLogs:
         autoscaler = make_autoscaler({"test-group": group})
 
         workers = mock_handle.describe().workers
-        autoscaler._register_slice_workers(workers, mock_handle.slice_id, "test-group")
+        autoscaler._worker_registry.register_slice_workers(list(workers), mock_handle.slice_id, "test-group")
 
         worker = workers[0]
         # Lookup by platform worker_id
@@ -1279,9 +1280,11 @@ class TestGpuScaleGroupBugs:
         handle = group.scale_up(timestamp=ts)
         group.complete_scale_up(handle, ts)
 
-        worker_ids = [w.worker_id for w in handle.describe().workers]
-        group.mark_slice_ready(handle.slice_id, worker_ids)
+        # Mark the slice as READY (simulates bootstrap completion)
+        group.dispatch(handle.slice_id, CloudReady(workers=tuple(handle.describe().workers)))
 
+        # quiet_since=None means the slice is currently active (or never
+        # observed idle) — the next tick decides based on live worker state.
         with group._slices_lock:
             state = group._slices[handle.slice_id]
 

--- a/lib/iris/tests/cluster/controller/test_slice_lifecycle.py
+++ b/lib/iris/tests/cluster/controller/test_slice_lifecycle.py
@@ -1,0 +1,282 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for slice lifecycle state machine transitions, exercised via ScalingGroup.dispatch().
+
+Organization:
+- `test_table_transitions_produce_expected_state` is a parametrized sanity
+  check that every entry in TRANSITIONS yields the declared new_state. Catches
+  typos in the table without writing one test per entry.
+- Invariant tests below cover behavior that isn't readable off the table:
+  cross-machine cascades (backoff triggers), timestamp/worker-id bookkeeping
+  on READY, exponential backoff math, exhaustiveness, atomic failure
+  accounting under concurrent dispatches, and no-op paths.
+"""
+
+import threading
+
+import pytest
+from iris.cluster.controller.autoscaler.models import SliceLifecycleState, SliceState
+from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup
+from iris.cluster.controller.autoscaler.slice_lifecycle import (
+    SHORT_LIVED_SLICE_THRESHOLD,
+    TRANSITIONS,
+    BecameFailed,
+    BecameReady,
+    CloudFailed,
+    CloudInitializing,
+    CloudReady,
+    IdleTimeout,
+    InternalTransition,
+    NoOp,
+    SliceEvent,
+    UnknownTimeout,
+    WorkerFailure,
+)
+from rigging.timing import Timestamp
+
+from tests.cluster.controller.conftest import make_scale_group_config
+from tests.cluster.providers.conftest import make_fake_slice_handle, make_mock_platform
+
+CREATED_AT_MS = 1_000_000
+SHORT_LIVED_NOW = Timestamp.from_ms(CREATED_AT_MS + 60_000)
+LONG_LIVED_NOW = Timestamp.from_ms(CREATED_AT_MS + int(SHORT_LIVED_SLICE_THRESHOLD.to_ms()) + 60_000)
+
+
+@pytest.fixture
+def group() -> ScalingGroup:
+    config = make_scale_group_config(name="test", buffer_slices=0, max_slices=10)
+    return ScalingGroup(config, make_mock_platform())
+
+
+def _seed(
+    group: ScalingGroup,
+    slice_id: str = "slice-001",
+    lifecycle: SliceLifecycleState = SliceLifecycleState.BOOTING,
+):
+    handle = make_fake_slice_handle(slice_id, created_at_ms=CREATED_AT_MS)
+    with group._slices_lock:
+        group._slices[slice_id] = SliceState(handle=handle, lifecycle=lifecycle)
+    return handle
+
+
+def _example_event(event_type: type[SliceEvent], workers=()) -> SliceEvent:
+    """Construct a sample event of the given type with minimal valid payload."""
+    if event_type is CloudReady:
+        return CloudReady(workers=tuple(workers))
+    if event_type is CloudFailed:
+        return CloudFailed(error_message="boom")
+    if event_type is CloudInitializing:
+        return CloudInitializing()
+    if event_type is UnknownTimeout:
+        return UnknownTimeout()
+    if event_type is WorkerFailure:
+        return WorkerFailure(failed_worker_ids=("w1",))
+    if event_type is IdleTimeout:
+        return IdleTimeout(target_capacity=0, ready_before=1)
+    raise AssertionError(f"no example for {event_type}")
+
+
+# ---------------------------------------------------------------------------
+# Transition table sanity — every declared transition is reachable and
+# produces its declared target state.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "from_state,event_type,expected_to_state",
+    [(key[0], key[1], to) for key, to in TRANSITIONS.items()],
+    ids=[f"{key[0].value}+{key[1].__name__}" for key in TRANSITIONS],
+)
+def test_table_transitions_produce_expected_state(
+    from_state: SliceLifecycleState,
+    event_type: type[SliceEvent],
+    expected_to_state: SliceLifecycleState,
+    group: ScalingGroup,
+):
+    handle = _seed(group, lifecycle=from_state)
+    event = _example_event(event_type, workers=handle.describe().workers)
+    outcome = group.dispatch("slice-001", event, now=LONG_LIVED_NOW)
+    if expected_to_state == SliceLifecycleState.READY:
+        assert isinstance(outcome, BecameReady)
+    elif expected_to_state == SliceLifecycleState.FAILED:
+        assert isinstance(outcome, BecameFailed)
+    else:
+        assert isinstance(outcome, InternalTransition)
+        assert outcome.new_state == expected_to_state
+        assert outcome.prior == from_state
+
+
+# ---------------------------------------------------------------------------
+# READY invariants: quiet_since cleared and worker_ids set atomically.
+# ---------------------------------------------------------------------------
+
+
+def test_ready_transition_clears_quiet_since_and_sets_worker_ids(group: ScalingGroup):
+    handle = _seed(group)
+    workers = tuple(handle.describe().workers)
+    outcome = group.dispatch("slice-001", CloudReady(workers=workers), now=SHORT_LIVED_NOW)
+
+    assert isinstance(outcome, BecameReady)
+    assert outcome.workers == workers
+    state = group._slices["slice-001"]
+    # quiet_since=None means the slice is active/never observed idle — next
+    # tick will decide based on live worker state.
+    assert state.quiet_since is None
+    assert state.worker_ids == [w.worker_id for w in workers]
+
+
+# ---------------------------------------------------------------------------
+# Cross-machine backoff cascade.
+# ---------------------------------------------------------------------------
+
+
+BACKOFF_TRIGGER_TYPES: list[type[SliceEvent]] = [CloudFailed, UnknownTimeout, WorkerFailure]
+
+
+@pytest.mark.parametrize("event_type", BACKOFF_TRIGGER_TYPES, ids=lambda t: t.__name__)
+def test_short_lived_failure_triggers_backoff(event_type: type[SliceEvent], group: ScalingGroup):
+    """Short-lived terminal events surface ``triggered_backoff=True`` and decay
+    the BackoffDetector health score."""
+    from_state = SliceLifecycleState.READY if event_type is WorkerFailure else SliceLifecycleState.BOOTING
+    _seed(group, lifecycle=from_state)
+    outcome = group.dispatch("slice-001", _example_event(event_type), now=SHORT_LIVED_NOW)
+    assert isinstance(outcome, BecameFailed)
+    assert outcome.triggered_backoff
+    assert group._detector.health(SHORT_LIVED_NOW) < 1.0
+
+
+@pytest.mark.parametrize("event_type", BACKOFF_TRIGGER_TYPES, ids=lambda t: t.__name__)
+def test_long_lived_failure_no_backoff(event_type: type[SliceEvent], group: ScalingGroup):
+    """Long-lived READY failures don't trip ``triggered_backoff``. Note: the
+    detector still records the terminal event (PREEMPTED for READY slices,
+    BOOT_FAILED for booting ones) and may decay independently — we only
+    assert the dispatch outcome flag here."""
+    from_state = SliceLifecycleState.READY if event_type is WorkerFailure else SliceLifecycleState.BOOTING
+    _seed(group, lifecycle=from_state)
+    outcome = group.dispatch("slice-001", _example_event(event_type), now=LONG_LIVED_NOW)
+    assert isinstance(outcome, BecameFailed)
+    assert not outcome.triggered_backoff
+
+
+def test_idle_timeout_never_triggers_backoff(group: ScalingGroup):
+    """IDLE_TIMEOUT is healthy scaledown; counts_toward_backoff must stay False
+    and the detector health must remain at full."""
+    assert not IdleTimeout.counts_toward_backoff
+    _seed(group, lifecycle=SliceLifecycleState.READY)
+    outcome = group.dispatch("slice-001", IdleTimeout(target_capacity=0, ready_before=1), now=SHORT_LIVED_NOW)
+    assert isinstance(outcome, BecameFailed)
+    assert not outcome.triggered_backoff
+    assert group._detector.health(SHORT_LIVED_NOW) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Terminal-and-detached invariant.
+# ---------------------------------------------------------------------------
+
+
+def test_failed_transition_detaches_slice_and_is_terminal(group: ScalingGroup):
+    handle = _seed(group)
+    outcome = group.dispatch("slice-001", CloudFailed(error_message="x"), now=LONG_LIVED_NOW)
+    assert isinstance(outcome, BecameFailed)
+    assert outcome.handle is handle
+    assert "slice-001" not in group._slices
+
+    # Terminal: subsequent events find no slice and noop.
+    again = group.dispatch("slice-001", CloudReady(workers=()), now=LONG_LIVED_NOW)
+    assert isinstance(again, NoOp)
+
+
+# ---------------------------------------------------------------------------
+# Backoff math.
+# ---------------------------------------------------------------------------
+
+
+def test_repeated_short_lived_failures_decay_health(group: ScalingGroup):
+    """Repeated short-lived failures monotonically decay the detector health score."""
+    healths = [group._detector.health(SHORT_LIVED_NOW)]
+    for i in range(3):
+        _seed(group, slice_id=f"s-{i}")
+        group.dispatch(f"s-{i}", CloudFailed(error_message=""), now=SHORT_LIVED_NOW)
+        healths.append(group._detector.health(SHORT_LIVED_NOW))
+    # Strictly decreasing (modulo the tiny recovery between calls at the same
+    # timestamp, which is zero).
+    assert healths == sorted(healths, reverse=True)
+    assert healths[-1] < healths[0]
+
+
+# ---------------------------------------------------------------------------
+# Atomic failure accounting under concurrent dispatches.
+# Guards the lock widening: _apply_failure_locked is called under _slices_lock,
+# so concurrent failures on different slices in the same group must sum
+# consecutive_failures without lost updates.
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_failures_account_atomically(group: ScalingGroup):
+    """Concurrent dispatches on distinct slices in the same group must not
+    lose updates: every slice is detached and the detector health reflects
+    the full set of failures."""
+    n = 32
+    for i in range(n):
+        _seed(group, slice_id=f"s-{i}")
+
+    baseline = group._detector.health(SHORT_LIVED_NOW)
+    start = threading.Event()
+    threads = []
+    for i in range(n):
+        sid = f"s-{i}"
+
+        def run(sid=sid):
+            start.wait()
+            group.dispatch(sid, CloudFailed(error_message=""), now=SHORT_LIVED_NOW)
+
+        t = threading.Thread(target=run)
+        t.start()
+        threads.append(t)
+
+    start.set()
+    for t in threads:
+        t.join()
+
+    assert len(group._slices) == 0
+    # All n short-lived failures fed the detector; health strictly decayed.
+    assert group._detector.health(SHORT_LIVED_NOW) < baseline
+
+
+# ---------------------------------------------------------------------------
+# No-op paths and structural invariants.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "slice_exists,from_state,event",
+    [
+        (False, None, CloudReady(workers=())),  # unknown slice
+        (True, SliceLifecycleState.READY, CloudInitializing()),  # invalid transition
+    ],
+    ids=["unknown_slice", "invalid_transition"],
+)
+def test_noop_returns_noop_outcome(
+    slice_exists: bool,
+    from_state: SliceLifecycleState | None,
+    event: SliceEvent,
+    group: ScalingGroup,
+):
+    if slice_exists:
+        _seed(group, lifecycle=from_state)
+    outcome = group.dispatch("slice-001", event, now=SHORT_LIVED_NOW)
+    assert isinstance(outcome, NoOp)
+
+
+def test_every_tracked_state_has_outgoing_transitions():
+    """Every lifecycle state that can appear on a tracked slice must have outgoing
+    transitions, or the slice gets stuck. REQUESTING is not tracked on a slice —
+    it is derived from the pending-scale-up counter."""
+    tracked_non_terminal = {
+        SliceLifecycleState.BOOTING,
+        SliceLifecycleState.INITIALIZING,
+        SliceLifecycleState.READY,
+    }
+    for state in tracked_non_terminal:
+        assert any(key[0] == state for key in TRANSITIONS), f"{state.value} is a dead state"

--- a/lib/iris/tests/cluster/providers/test_scaling_group.py
+++ b/lib/iris/tests/cluster/providers/test_scaling_group.py
@@ -14,14 +14,19 @@ import pytest
 from iris.cluster.config import _derive_slice_config_from_resources, load_config
 from iris.cluster.constraints import DeviceType
 from iris.cluster.controller.autoscaler.backoff_detector import GroupHealth, SliceFate
+from iris.cluster.controller.autoscaler.models import SliceLifecycleState, SliceState
 from iris.cluster.controller.autoscaler.scaling_group import (
     GroupAvailability,
     ScalingGroup,
-    SliceLifecycleState,
-    SliceState,
     _zones_from_config,
     prepare_slice_config,
     slice_state_to_proto,
+)
+from iris.cluster.controller.autoscaler.slice_lifecycle import (
+    BecameFailed,
+    CloudFailed,
+    CloudReady,
+    NoOp,
 )
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.providers.types import (
@@ -60,19 +65,24 @@ def _with_resources(config: config_pb2.ScaleGroupConfig, *, num_vms: int = 1) ->
     return config
 
 
+def _fake_workers(ids: list[str]) -> tuple[FakeWorkerHandle, ...]:
+    """Build CloudReady worker payloads from a list of IP/worker ids."""
+    return tuple(FakeWorkerHandle(_vm_id=wid, _internal_address=wid) for wid in ids)
+
+
 def _mark_discovered_ready(
     group: ScalingGroup, handles: list[FakeSliceHandle], timestamp: Timestamp | None = None
 ) -> None:
     """Mark discovered slices as READY with their worker IDs."""
     for handle in handles:
-        worker_ids = [vm.worker_id for vm in handle.describe().workers]
-        group.mark_slice_ready(handle.slice_id, worker_ids, timestamp=timestamp)
+        workers = tuple(handle.describe().workers)
+        group.dispatch(handle.slice_id, CloudReady(workers=workers), now=timestamp)
 
 
 def _mark_discovered_failed(group: ScalingGroup, handles: list[FakeSliceHandle]) -> None:
     """Mark discovered slices as FAILED."""
     for handle in handles:
-        group.mark_slice_failed(handle.slice_id)
+        group.dispatch(handle.slice_id, CloudFailed())
 
 
 def _get_worker_id(handle: FakeSliceHandle) -> str:
@@ -650,9 +660,7 @@ class TestScalingGroupVmGroupStateCounts:
             (vm_pb2.VM_STATE_READY, SliceLifecycleState.READY),
             (vm_pb2.VM_STATE_BOOTING, SliceLifecycleState.BOOTING),
             # INITIALIZING is an Iris lifecycle concept not present at the cloud level.
-            # The Platform adapter maps unknown cloud states to BOOTING. INITIALIZING
-            # will come from WorkerVm lifecycle tracking in a future task.
-            (vm_pb2.VM_STATE_FAILED, SliceLifecycleState.FAILED),
+            # The Platform adapter maps unknown cloud states to BOOTING.
         ],
     )
     def test_counts_vm_groups_by_state(
@@ -668,9 +676,6 @@ class TestScalingGroupVmGroupStateCounts:
         group.reconcile()
         if expected_state == SliceLifecycleState.READY:
             _mark_discovered_ready(group, discovered)
-        elif expected_state == SliceLifecycleState.FAILED:
-            _mark_discovered_failed(group, discovered)
-        # BOOTING is the default lifecycle state after reconcile
 
         counts = group.slice_state_counts()
 
@@ -679,8 +684,8 @@ class TestScalingGroupVmGroupStateCounts:
             if state != expected_state:
                 assert counts[state] == 0
 
-    def test_failed_takes_precedence(self, scale_group_config: config_pb2.ScaleGroupConfig):
-        """A VM group with any failed VM is counted as failed."""
+    def test_failed_slice_detached_atomically(self, scale_group_config: config_pb2.ScaleGroupConfig):
+        """FAILED transition removes the slice from tracking; counts reflect that."""
         discovered = [
             make_fake_slice_handle(
                 "slice-001",
@@ -693,9 +698,9 @@ class TestScalingGroupVmGroupStateCounts:
         _mark_discovered_failed(group, discovered)
 
         counts = group.slice_state_counts()
-
-        assert counts[SliceLifecycleState.FAILED] == 1
-        assert counts[SliceLifecycleState.READY] == 0
+        # FAILED is terminal-and-detached; the slice is gone from tracking.
+        assert counts[SliceLifecycleState.FAILED] == 0
+        assert group.slice_count() == 0
 
     def test_unobserved_slices_counted_as_booting(self, scale_group_config: config_pb2.ScaleGroupConfig):
         """Slices that haven't been marked ready or failed are counted as BOOTING."""
@@ -741,8 +746,7 @@ class TestScalingGroupAvailability:
         group = ScalingGroup(config, platform)
         group.reconcile()
         for h in discovered:
-            worker_ids = [w.worker_id for w in h.describe().workers]
-            group.mark_slice_ready(h.slice_id, worker_ids)
+            group.dispatch(h.slice_id, CloudReady(workers=tuple(h.describe().workers)))
 
         state = group.availability()
         assert state.status == GroupAvailability.AT_MAX_SLICES
@@ -780,8 +784,7 @@ class TestScalingGroupAvailability:
         group = ScalingGroup(config, platform)
         group.reconcile()
         for h in discovered:
-            worker_ids = [w.worker_id for w in h.describe().workers]
-            group.mark_slice_ready(h.slice_id, worker_ids)
+            group.dispatch(h.slice_id, CloudReady(workers=tuple(h.describe().workers)))
 
         assert group.can_accept_demand() is False
 
@@ -894,8 +897,7 @@ class TestScalingGroupAvailability:
         assert state.status == GroupAvailability.COOLDOWN
 
         # Once the slice is READY, AT_MAX_SLICES takes precedence over cooldown
-        worker_ids = [w.worker_id for w in handle.describe().workers]
-        group.mark_slice_ready(handle.slice_id, worker_ids)
+        group.dispatch(handle.slice_id, CloudReady(workers=tuple(handle.describe().workers)))
         state = group.availability(Timestamp.from_ms(1_003_000))
         assert state.status == GroupAvailability.AT_MAX_SLICES
 
@@ -945,8 +947,7 @@ class TestVerifySliceIdle:
         group = ScalingGroup(unbounded_config, platform)
         ts = Timestamp.from_ms(1000000)
         handle = _tracked_scale_up(group, timestamp=ts)
-        worker_ids = [vm.worker_id for vm in handle.describe().workers]
-        group.mark_slice_ready(handle.slice_id, worker_ids)
+        group.dispatch(handle.slice_id, CloudReady(workers=tuple(handle.describe().workers)))
         state = _get_slice_state(group, handle)
 
         # Get worker ID from mock
@@ -1078,10 +1079,10 @@ class TestPrepareSliceConfigGpuCount:
         assert cpu_slice.gpu_count == 0
 
 
-class TestMarkSliceLockDiscipline:
-    """Tests that mark_slice_ready/mark_slice_failed hold the lock during mutation."""
+class TestDispatchLockDiscipline:
+    """Tests that dispatch() holds the lock during mutation."""
 
-    def test_mark_slice_ready_atomic(self, unbounded_config: config_pb2.ScaleGroupConfig):
+    def test_dispatch_ready_atomic(self, unbounded_config: config_pb2.ScaleGroupConfig):
         """lifecycle and worker_ids are set while holding the lock."""
         platform = make_mock_platform()
         group = ScalingGroup(unbounded_config, platform)
@@ -1093,7 +1094,7 @@ class TestMarkSliceLockDiscipline:
         assert state.worker_ids == []
 
         addresses = ["10.0.0.1", "10.0.0.2"]
-        group.mark_slice_ready(handle.slice_id, addresses)
+        group.dispatch(handle.slice_id, CloudReady(workers=_fake_workers(addresses)))
 
         # All fields should be set atomically
         with group._slices_lock:
@@ -1101,29 +1102,32 @@ class TestMarkSliceLockDiscipline:
             assert state.lifecycle == SliceLifecycleState.READY
             assert state.worker_ids == addresses
 
-    def test_mark_slice_failed_atomic(self, unbounded_config: config_pb2.ScaleGroupConfig):
-        """lifecycle is set to FAILED while holding the lock."""
+    def test_dispatch_failed_detaches_atomically(self, unbounded_config: config_pb2.ScaleGroupConfig):
+        """FAILED transition detaches the slice from tracking and returns its handle."""
         platform = make_mock_platform()
         group = ScalingGroup(unbounded_config, platform)
         handle = _tracked_scale_up(group)
 
-        group.mark_slice_failed(handle.slice_id)
+        outcome = group.dispatch(handle.slice_id, CloudFailed())
 
+        assert isinstance(outcome, BecameFailed)
+        assert outcome.handle is handle
         with group._slices_lock:
-            state = group._slices[handle.slice_id]
-            assert state.lifecycle == SliceLifecycleState.FAILED
+            assert handle.slice_id not in group._slices
 
-    def test_mark_slice_ready_nonexistent_is_noop(self, unbounded_config: config_pb2.ScaleGroupConfig):
-        """mark_slice_ready on a nonexistent slice does not raise."""
+    def test_dispatch_ready_nonexistent_is_noop(self, unbounded_config: config_pb2.ScaleGroupConfig):
+        """dispatch CloudReady on a nonexistent slice does not raise."""
         platform = make_mock_platform()
         group = ScalingGroup(unbounded_config, platform)
-        group.mark_slice_ready("nonexistent", ["10.0.0.1"])
+        outcome = group.dispatch("nonexistent", CloudReady(workers=_fake_workers(["10.0.0.1"])))
+        assert isinstance(outcome, NoOp)
 
-    def test_mark_slice_failed_nonexistent_is_noop(self, unbounded_config: config_pb2.ScaleGroupConfig):
-        """mark_slice_failed on a nonexistent slice does not raise."""
+    def test_dispatch_failed_nonexistent_is_noop(self, unbounded_config: config_pb2.ScaleGroupConfig):
+        """dispatch CloudFailed on a nonexistent slice does not raise."""
         platform = make_mock_platform()
         group = ScalingGroup(unbounded_config, platform)
-        group.mark_slice_failed("nonexistent")
+        outcome = group.dispatch("nonexistent", CloudFailed())
+        assert isinstance(outcome, NoOp)
 
 
 def test_slice_state_to_proto_uses_worker_ids_as_vm_ids():
@@ -1244,7 +1248,7 @@ class TestMultiVmSliceIdleScaleDown:
         assert group.slice_count() == 1
 
     def test_multi_vm_slice_activity_updates_when_any_worker_busy(self):
-        """update_slice_activity treats the slice as active when ANY worker is busy."""
+        """update_slice_activity keeps quiet_since=None when ANY worker is busy."""
         config = _make_multi_vm_config(num_vms=4)
         discovered = [_make_multi_vm_slice_handle("slice-001", num_vms=4)]
         platform = make_mock_platform(slices_to_discover=discovered)
@@ -1309,7 +1313,7 @@ class TestMultiVmSliceIdleScaleDown:
 
         handle = _tracked_scale_up(group)
         worker_ids = [f"10.0.0.{i}" for i in range(4)]
-        group.mark_slice_ready(handle.slice_id, worker_ids)
+        group.dispatch(handle.slice_id, CloudReady(workers=_fake_workers(worker_ids)))
         state = _get_slice_state(group, handle)
 
         # Only 2 of 4 workers in status map, both idle
@@ -1328,7 +1332,7 @@ class TestMultiVmSliceIdleScaleDown:
 
         handle = _tracked_scale_up(group)
         worker_ids = [f"10.0.0.{i}" for i in range(4)]
-        group.mark_slice_ready(handle.slice_id, worker_ids)
+        group.dispatch(handle.slice_id, CloudReady(workers=_fake_workers(worker_ids)))
         state = _get_slice_state(group, handle)
 
         assert not group._verify_slice_idle(state, {})

--- a/lib/iris/tests/cluster/test_snapshot_reconciliation.py
+++ b/lib/iris/tests/cluster/test_snapshot_reconciliation.py
@@ -11,9 +11,9 @@ lost slice inventory (capacity gaps).
 
 from dataclasses import dataclass, field
 
+from iris.cluster.controller.autoscaler.models import SliceLifecycleState
 from iris.cluster.controller.autoscaler.scaling_group import (
     GroupSnapshot,
-    SliceLifecycleState,
     SliceSnapshot,
     restore_scaling_group,
 )


### PR DESCRIPTION
## Summary

- Slice lifecycle in the autoscaler becomes an explicit state machine: a `(from_state, type(event)) → to_state` transition table, typed event dataclasses carrying exactly the payload each transition needs, and a sum-type outcome (`NoOp | InternalTransition | BecameReady | BecameFailed`) that callers consume via a single `match` statement.
- `ScalingGroup.dispatch()` folds the short-lived-failure → group-backoff cascade into the same lock as the slice mutation, so `consecutive_failures` / `backoff_until` stay consistent with `_slices` under concurrent failures (see `test_concurrent_failures_account_atomically`).
- `SliceLifecycleState` and `SliceState` move from `scaling_group.py` to `models.py` so the transition table can import them without creating a cycle.

## Behavior change

FAILED transitions now **atomically remove the slice from `_slices` and return the SliceHandle to the caller** (via `BecameFailed.handle`). Callers unregister workers and async-terminate the handle. Consequences:

- `slice_state_counts()` and `to_status()` will never observe a FAILED slice for this group. Failure is surfaced via the returned outcome, a `slice_failed` / `worker_failed` entry in the action log, and the `slice_transition … →failed` structured log line.
- The old code left FAILED slices tracked until a separate cleanup pass; in practice both paths removed them within the same refresh cycle, so downstream consumers (dashboards, RPC status) observe no regression. Callers that depend on visible FAILED state must reach for the action log.

## Changes

| File | What |
|------|------|
| `slice_lifecycle.py` | Typed `SliceEvent` hierarchy, `TRANSITIONS` table, `cloud_event()` helper, `TransitionOutcome` sum type. No `StrEnum`, no `context: dict[str, Any]`, no separate `BACKOFF_TRIGGERS` set (each event type carries `counts_toward_backoff`). |
| `models.py` | Owns `SliceLifecycleState` (StrEnum with `enum.auto()`) and `SliceState`. |
| `scaling_group.py` | New `dispatch(slice_id, event)` method. Short-lived-failure backoff cascade is atomic with the slice detach under `_slices_lock`. |
| `runtime.py` | Single `_apply(outcome, group)` method `match`es on outcome type and owns all external side effects (worker registry, async terminate, action-log entries). `refresh()` / `terminate_slices_for_workers()` lose their scattered `if new_state == …` switches. `operations.py` folded back into `Autoscaler`. |
| `test_slice_lifecycle.py` | Parametrized table sanity, READY/FAILED invariants, exponential backoff, exhaustiveness, and a new `test_concurrent_failures_account_atomically` covering the lock widening. |

## Test plan

- [x] `tests/cluster/controller/test_slice_lifecycle.py` — 20+ cases including concurrent-failure atomicity
- [x] `tests/cluster/controller/ tests/cluster/providers/` — 1359 tests pass
- [x] `./infra/pre-commit.py --fix` — ruff, black, pyrefly, license headers clean

Refs: #4754