### PR TITLE
zephyr: xxh3 hash + pre-sharded int passthrough for scatter routing

### DIFF
--- a/lib/zephyr/pyproject.toml
+++ b/lib/zephyr/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "zstandard>=0.18.0",
     "tqdm-loggable>=0.2",
     "vortex-data>=0.61.0",
+    "xxhash>=3.4",
 ]
 
 [dependency-groups]

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -14,7 +14,6 @@ import heapq
 import inspect
 import logging
 import os
-import zlib
 from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass, field
 from enum import StrEnum, auto
@@ -22,6 +21,7 @@ from itertools import groupby, islice
 from typing import Any, Protocol
 
 import msgspec
+import xxhash
 from iris.env_resources import TaskResources as _TaskResources
 from rigging.filesystem import url_to_fs
 
@@ -564,7 +564,7 @@ def compute_plan(dataset: Dataset) -> PhysicalPlan:
 def deterministic_hash(obj: object) -> int:
     """Compute a deterministic hash for an object."""
     s = msgspec.msgpack.encode(obj, order="deterministic")
-    return zlib.adler32(s)
+    return xxhash.xxh3_64_intdigest(s)
 
 
 def make_windows(

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -96,13 +96,13 @@ def test_max_chunk_rows_per_shard(tmp_path):
 
     scatter_paths = _build_shard(tmp_path, items, num_output_shards=num_shards)
 
-    shard0 = ScatterReader.from_sidecars(scatter_paths, 0)
-    shard1 = ScatterReader.from_sidecars(scatter_paths, 1)
+    big_shard = ScatterReader.from_sidecars(scatter_paths, _target(3, num_shards))
+    small_shard = ScatterReader.from_sidecars(scatter_paths, _target(0, num_shards))
 
-    assert shard0.max_chunk_rows == 500
-    assert shard1.max_chunk_rows == 2, (
-        f"shard1 max_chunk_rows={shard1.max_chunk_rows}, expected 2; "
-        "contamination from shard0's large chunk would show 500"
+    assert big_shard.max_chunk_rows == 500
+    assert small_shard.max_chunk_rows == 2, (
+        f"small_shard max_chunk_rows={small_shard.max_chunk_rows}, expected 2; "
+        "contamination from the large chunk would show 500"
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -5449,6 +5449,7 @@ dependencies = [
     { name = "tqdm-loggable" },
     { name = "typing-extensions" },
     { name = "vortex-data" },
+    { name = "xxhash" },
     { name = "zstandard" },
 ]
 
@@ -5481,6 +5482,7 @@ requires-dist = [
     { name = "tqdm-loggable", specifier = ">=0.2" },
     { name = "typing-extensions", specifier = ">=4.0" },
     { name = "vortex-data", specifier = ">=0.61.0" },
+    { name = "xxhash", specifier = ">=3.4" },
     { name = "zstandard", specifier = ">=0.18.0" },
 ]
 


### PR DESCRIPTION
* fix scatter double-hash that left ~11% of output shards empty on a 6307-way `normalize` run
* route keys via new `shard_for_key(key, N)` — int keys in `[0, N)` pass through for perfect distribution; others go through `deterministic_hash(key) % N`
  * bounds check matters: bare int passthrough would send structured keys like `[0, N, 2N, ...]` all to shard 0
* switch `deterministic_hash` from `adler32` [^1] to `xxh3_64` for uniform distribution of non-passthrough keys
* `marin/datakit/normalize.py` now uses the natural hex `id` string as the `group_by` key instead of pre-hashing to int
* regression tests: pre-sharded ints cover all buckets, structured ints distribute via hash, negative ints don't passthrough
* caveat: in-flight pipelines resuming across this commit will route inconsistently between old/new mapper outputs — land during a quiet window for scatter-based jobs

[^1]: with adler32 and N=6307, ~11% empty — accidentally less bad than a uniform hash would give (`N/e ≈ 37%`). the fix addresses both the birthday problem (via passthrough) and the weak checksum (via xxh3).