### PR TITLE
marin: use natural string key in normalize group_by

### DIFF
--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -228,7 +228,7 @@ def _build_pipeline(
     """Build a single Zephyr pipeline for one subdirectory."""
     normalize_record = _make_normalize_fn(text_field, id_field)
 
-    def dedup(_key: int, items: Iterator[dict[str, Any]]) -> Iterator[dict[str, Any]]:
+    def dedup(_key: str, items: Iterator[dict[str, Any]]) -> Iterator[dict[str, Any]]:
         """Drop adjacent duplicate ids. Items arrive sorted by id via sort_by."""
         prev_id: str | None = None
         for record in items:
@@ -237,7 +237,7 @@ def _build_pipeline(
                 prev_id = rid
                 yield record
 
-    def passthrough(_key: int, items: Iterator[dict[str, Any]]) -> Iterator[dict[str, Any]]:
+    def passthrough(_key: str, items: Iterator[dict[str, Any]]) -> Iterator[dict[str, Any]]:
         """Yield items unchanged; used when dedup is disabled."""
         yield from items
 
@@ -257,7 +257,7 @@ def _build_pipeline(
         .map(normalize_record)
         .map(_make_whitespace_compactor(max_whitespace_run_chars))
         .group_by(
-            key=lambda r: int(r["id"], 16) % num_shards,
+            key=lambda r: r["id"],
             reducer=reducers[dedup_mode],
             sort_by=lambda r: r["id"],
             num_output_shards=num_shards,


### PR DESCRIPTION
* fix double-hash in normalize `group_by` that pre-hashed document ids to ints and triggered birthday collisions in scatter, leaving ~11% of output shards empty on a 6307-way run
* pass the hex `id` string directly as the `group_by` key instead of `int(r["id"], 16) % num_shards`; scatter handles routing via its standard hash
* with 1.24B unique ids the hash distribution is effectively uniform without any pre-sharding
* standalone fix — no zephyr changes required [^1]

[^1]: zephyr's scatter routing weakness is addressed separately in https://github.com/marin-community/marin/pull/4818.