### PR TITLE
[marin] Add RL LoRA training and export support

### DIFF
--- a/lib/levanter/src/levanter/adaptor/lora.py
+++ b/lib/levanter/src/levanter/adaptor/lora.py
@@ -48,6 +48,7 @@ import json
 import logging
 import os
 import re
+import urllib.parse
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Literal, Optional, Tuple, TypeVar, Union
 
@@ -497,7 +498,8 @@ def save_peft_pretrained(
             as a repo name + branch
         upload_kwargs: kwargs to pass to the upload function
     """
-    os.makedirs(path, exist_ok=True)
+    if urllib.parse.urlparse(path).scheme == "":
+        os.makedirs(path, exist_ok=True)
     base_ref = str(base_model_name_or_path) if base_model_name_or_path is not None else None
     if prefix is None:
         prefix = _default_peft_state_dict_prefix(lora_model)

--- a/lib/levanter/tests/test_lora.py
+++ b/lib/levanter/tests/test_lora.py
@@ -5,6 +5,7 @@ import json
 import tempfile
 
 import equinox as eqx
+import fsspec
 import haliax as hax
 import haliax.nn as hnn
 import jax
@@ -148,6 +149,28 @@ def test_merge_lora():
     input = hax.random.normal(k0, (In,))
     # light tolerances for TPU
     assert_trees_all_close(merged.fold(input), loraized.fold(input), rtol=1e-3, atol=3e-3)
+
+
+def test_save_peft_pretrained_supports_url_like_paths():
+    class Module(eqx.Module):
+        first: hnn.Linear
+
+        def __call__(self, x):
+            return self.first(x)
+
+    module = Module(first=hnn.Linear.init(In, Out, key=jax.random.PRNGKey(0)))
+    loraized = loraize(module, LoraConfig(r=4, target_modules=["first"]), key=jax.random.PRNGKey(1))
+    export_path = "memory://levanter-test-lora-export"
+
+    save_peft_pretrained(loraized, LoraConfig(r=4, target_modules=["first"]), "hf://toy/base", export_path)
+
+    with fsspec.open(f"{export_path}/adapter_config.json", "rt") as f:
+        config = json.load(f)
+
+    assert config["base_model_name_or_path"] == "hf://toy/base"
+    assert config["peft_type"] == "LORA"
+    with fsspec.open(f"{export_path}/adapter_model.safetensors", "rb") as f:
+        assert f.read()
 
 
 @skip_if_module_missing("peft")

--- a/lib/marin/src/marin/rl/environments/inference_ctx/vllm.py
+++ b/lib/marin/src/marin/rl/environments/inference_ctx/vllm.py
@@ -351,6 +351,9 @@ class vLLMInferenceContext(BaseInferenceContext):
         )
 
     def reload_model(self, model: LmHeadModel | None, state_dict: dict) -> LmHeadModel | None:
+        if state_dict is None:
+            raise ValueError("vLLM weight reload requires a full state_dict payload")
+
         t0 = time.time()
         logger.info("reload_model: starting prefix cache reset")
         # Reset prefix cache before syncing weights to free up memory

--- a/lib/marin/src/marin/rl/job_config.py
+++ b/lib/marin/src/marin/rl/job_config.py
@@ -19,15 +19,18 @@ from typing import Literal
 
 from levanter.inference.engine import InferenceEngineConfig
 from levanter.inference.openai import InferenceServerConfig
+from levanter.adaptor.lora import LoraConfig
 from levanter.models.lm_model import LmConfig
 from levanter.optim import OptimizerConfig
 from levanter.tokenizers import MarinTokenizer, load_tokenizer
 from levanter.trainer import TrainerConfig
+from levanter.utils.fsspec_utils import join_path
 from marin.rl.curriculum import CurriculumConfig
 from marin.rl.environments.inference_ctx import (
     LevanterInferenceContextConfig,
     vLLMInferenceContextConfig,
 )
+from marin.rl.lora_manifest import RUN_MANIFEST_FILENAME, RolloutPolicyFormat
 from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_losses import RLLossModule
 from marin.rl.rollout_storage import RolloutStorageConfig, StorageType
@@ -37,6 +40,8 @@ from marin.rl.weight_transfer import WeightTransferConfig
 from marin.utilities.json_encoder import CustomJsonEncoder
 
 logger = logging.getLogger(__name__)
+
+ROLLOUT_POLICY_FORMAT: RolloutPolicyFormat = "merged"
 
 
 @dataclass
@@ -80,6 +85,7 @@ class TrainParams:
 
     optimizer: OptimizerConfig
     rl_loss: "RLLossModule"
+    lora: LoraConfig | None = None
     replay_buffer: ReplayBufferConfig = field(
         default_factory=lambda: ReplayBufferConfig(
             capacity=4096,
@@ -108,6 +114,7 @@ class RLJobConfig:
     tokenizer: str | MarinTokenizer
 
     inference_type: Literal["levanter", "vllm"]
+    rollout_policy_format: RolloutPolicyFormat = ROLLOUT_POLICY_FORMAT
 
     seed: int = 42
 
@@ -126,6 +133,9 @@ class RLJobConfig:
         )
     )
     weight_transfer: WeightTransferConfig = field(default_factory=WeightTransferConfig)
+    run_manifest_path: str | None = None
+    adapter_artifacts_path: str | None = None
+    merged_hf_export_path: str | None = None
 
     # Deployment configuration
     run_config: RunConfig | None = None
@@ -204,6 +214,12 @@ def build_worker_configs(config: RLJobConfig) -> tuple[TrainWorkerConfig, Rollou
     can call it without importing :class:`~marin.rl.rl_job.RLJob`, which would
     re-introduce the rl_job <-> orchestration import cycle.
     """
+    if config.rollout_policy_format != "merged":
+        raise ValueError(
+            "rollout_policy_format='adapter' is not implemented yet; "
+            "use rollout_policy_format='merged' for the current RL runtime"
+        )
+
     # Create tokenizer
     tokenizer = make_tokenizer(config.tokenizer)
 
@@ -263,12 +279,22 @@ def build_worker_configs(config: RLJobConfig) -> tuple[TrainWorkerConfig, Rollou
         trainer=config.trainer,
         optimizer=config.train_params.optimizer,
         loss=config.train_params.rl_loss,
+        lora=config.train_params.lora,
         tokenizer=tokenizer,
         replay_buffer=config.train_params.replay_buffer,
         initial_checkpoint=config.initial_checkpoint,
         vocab_size=config.vocab_size,
         run_id=config.run_id,
+        run_manifest_path=(
+            config.run_manifest_path
+            if config.run_manifest_path is not None
+            else join_path(config.trainer.checkpointer.expanded_path(f"{config.run_id}-train"), RUN_MANIFEST_FILENAME)
+        ),
+        adapter_artifacts_path=config.adapter_artifacts_path,
+        merged_hf_export_path=config.merged_hf_export_path,
         curriculum_config=config.curriculum,
+        inference_type=config.inference_type,
+        rollout_policy_format=config.rollout_policy_format,
         seed=config.seed,
     )
 
@@ -291,6 +317,7 @@ def build_worker_configs(config: RLJobConfig) -> tuple[TrainWorkerConfig, Rollou
         system_prompt=config.system_prompt,
         inflight_weight_updates=config.inflight_weight_updates,
         tracker_config=config.rollout_tracker,
+        rollout_policy_format=config.rollout_policy_format,
     )
 
     return train_worker_config, rollout_worker_config

--- a/lib/marin/src/marin/rl/job_config.py
+++ b/lib/marin/src/marin/rl/job_config.py
@@ -17,9 +17,9 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Literal
 
+from levanter.adaptor.lora import LoraConfig
 from levanter.inference.engine import InferenceEngineConfig
 from levanter.inference.openai import InferenceServerConfig
-from levanter.adaptor.lora import LoraConfig
 from levanter.models.lm_model import LmConfig
 from levanter.optim import OptimizerConfig
 from levanter.tokenizers import MarinTokenizer, load_tokenizer

--- a/lib/marin/src/marin/rl/lora_manifest.py
+++ b/lib/marin/src/marin/rl/lora_manifest.py
@@ -16,6 +16,7 @@ from marin.utils import fsspec_mkdirs
 
 RolloutPolicyFormat = Literal["merged", "adapter"]
 ReferenceMode = Literal["base"]
+MANIFEST_VERSION = 1
 RUN_MANIFEST_FILENAME = "rl_run_manifest.json"
 
 
@@ -50,7 +51,7 @@ def build_rl_run_manifest(
 ) -> RLRunManifest:
     """Build the run manifest recorded alongside LoRA RL training artifacts."""
     return RLRunManifest(
-        manifest_version=1,
+        manifest_version=MANIFEST_VERSION,
         initial_checkpoint=initial_checkpoint,
         model_config_type=f"{type(model_config).__module__}.{type(model_config).__qualname__}",
         model_config_fingerprint=config_fingerprint(model_config),
@@ -67,3 +68,15 @@ def write_rl_run_manifest(path: str, manifest: RLRunManifest) -> None:
     fsspec_mkdirs(os.path.dirname(path), exist_ok=True)
     with fsspec.open(path, "wt") as f:
         json.dump(dataclasses.asdict(manifest), f, indent=2, sort_keys=True, cls=CustomJsonEncoder)
+
+
+def read_rl_run_manifest(path: str) -> RLRunManifest:
+    """Read a manifest file describing the LoRA RL run configuration."""
+    with fsspec.open(path, "rt") as f:
+        data = json.load(f)
+
+    lora_config = data.get("lora_config")
+    if lora_config is not None:
+        data["lora_config"] = LoraConfig(**lora_config)
+
+    return RLRunManifest(**data)

--- a/lib/marin/src/marin/rl/lora_manifest.py
+++ b/lib/marin/src/marin/rl/lora_manifest.py
@@ -10,7 +10,6 @@ from typing import Literal
 
 import fsspec
 from levanter.adaptor.lora import LoraConfig
-
 from marin.utilities.json_encoder import CustomJsonEncoder
 from marin.utils import fsspec_mkdirs
 

--- a/lib/marin/src/marin/rl/lora_manifest.py
+++ b/lib/marin/src/marin/rl/lora_manifest.py
@@ -1,0 +1,69 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from typing import Literal
+
+import fsspec
+from levanter.adaptor.lora import LoraConfig
+
+from marin.utilities.json_encoder import CustomJsonEncoder
+from marin.utils import fsspec_mkdirs
+
+RolloutPolicyFormat = Literal["merged", "adapter"]
+ReferenceMode = Literal["base"]
+RUN_MANIFEST_FILENAME = "rl_run_manifest.json"
+
+
+@dataclass(frozen=True)
+class RLRunManifest:
+    """Trainer-side manifest for LoRA RL configuration and artifacts."""
+
+    manifest_version: int
+    initial_checkpoint: str | None
+    model_config_type: str
+    model_config_fingerprint: str
+    lora_config: LoraConfig | None
+    lora_config_fingerprint: str | None
+    rollout_policy_format: RolloutPolicyFormat
+    reference_mode: ReferenceMode
+    inference_type: Literal["levanter", "vllm"]
+
+
+def config_fingerprint(config: object) -> str:
+    """Return a stable fingerprint for a serializable config object."""
+    serialized = json.dumps(config, sort_keys=True, cls=CustomJsonEncoder)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
+
+
+def build_rl_run_manifest(
+    *,
+    initial_checkpoint: str | None,
+    model_config: object,
+    lora_config: LoraConfig | None,
+    rollout_policy_format: RolloutPolicyFormat,
+    inference_type: Literal["levanter", "vllm"],
+) -> RLRunManifest:
+    """Build the run manifest recorded alongside LoRA RL training artifacts."""
+    return RLRunManifest(
+        manifest_version=1,
+        initial_checkpoint=initial_checkpoint,
+        model_config_type=f"{type(model_config).__module__}.{type(model_config).__qualname__}",
+        model_config_fingerprint=config_fingerprint(model_config),
+        lora_config=lora_config,
+        lora_config_fingerprint=None if lora_config is None else config_fingerprint(lora_config),
+        rollout_policy_format=rollout_policy_format,
+        reference_mode="base",
+        inference_type=inference_type,
+    )
+
+
+def write_rl_run_manifest(path: str, manifest: RLRunManifest) -> None:
+    """Write a manifest file describing the LoRA RL run configuration."""
+    fsspec_mkdirs(os.path.dirname(path), exist_ok=True)
+    with fsspec.open(path, "wt") as f:
+        json.dump(dataclasses.asdict(manifest), f, indent=2, sort_keys=True, cls=CustomJsonEncoder)

--- a/lib/marin/src/marin/rl/rl_experiment_utils.py
+++ b/lib/marin/src/marin/rl/rl_experiment_utils.py
@@ -31,6 +31,7 @@ from marin.rl.environments.inference_ctx import (
     vLLMInferenceContextConfig,
 )
 from marin.rl.lora_manifest import RUN_MANIFEST_FILENAME, RolloutPolicyFormat
+from marin.rl.model_utils import is_hf_checkpoint
 from marin.rl.placement import marin_prefix_for_region, resolve_launcher_region, singleton_region_list
 from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_job import RLJob, RLJobConfig, RunConfig, TrainParams
@@ -42,6 +43,9 @@ from marin.rl.weight_transfer import WeightTransferConfig, WeightTransferMode
 logger = logging.getLogger(__name__)
 
 RL_EXECUTOR_STEP_RESOURCES = ResourceConfig.with_cpu(cpu=0.5, ram="4g", disk="30g")
+ADAPTER_ARTIFACTS_DIR = "adapter_artifacts"
+EXPORTS_DIR = "exports"
+MERGED_EXPORT_DIR = "merged"
 
 
 ModelArtifact = ExecutorStep | InputName | str
@@ -80,6 +84,8 @@ class RLExperimentConfig:
     experiment_name_suffix: str
     lora: LoraConfig | None = None
     rollout_policy_format: RolloutPolicyFormat = "merged"
+    adapter_artifacts_path: str | None = None
+    merged_hf_export_path: str | None = None
 
     # trainer params
     train_batch_size: int = 1024
@@ -261,6 +267,13 @@ def _build_rl_job_config(
     checkpoints_path = join_path(output_path, "checkpoints")
     rollout_storage_path = join_path(output_path, "rollouts")
     run_manifest_path = join_path(output_path, RUN_MANIFEST_FILENAME)
+    adapter_artifacts_path = config.adapter_artifacts_path
+    if adapter_artifacts_path is None and config.lora is not None and is_hf_checkpoint(model_path):
+        adapter_artifacts_path = join_path(output_path, ADAPTER_ARTIFACTS_DIR)
+
+    merged_hf_export_path = config.merged_hf_export_path
+    if merged_hf_export_path is None and config.lora is not None:
+        merged_hf_export_path = join_path(join_path(output_path, EXPORTS_DIR), MERGED_EXPORT_DIR)
 
     trainer_config = TrainerConfig(
         tracker=WandbConfig(
@@ -338,6 +351,8 @@ def _build_rl_job_config(
         rollout_storage=rollout_storage,
         weight_transfer=weight_transfer,
         run_manifest_path=run_manifest_path,
+        adapter_artifacts_path=adapter_artifacts_path,
+        merged_hf_export_path=merged_hf_export_path,
         run_id=name,
         log_freq=1,
         run_config=RunConfig(

--- a/lib/marin/src/marin/rl/rl_experiment_utils.py
+++ b/lib/marin/src/marin/rl/rl_experiment_utils.py
@@ -12,6 +12,7 @@ import jmp
 from fray.types import ResourceConfig
 from levanter.checkpoint import CheckpointDebugConfig, CheckpointerConfig
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
+from levanter.adaptor.lora import LoraConfig
 from levanter.layers.attention import AttentionBackend
 from levanter.optim import AdamConfig
 from levanter.tracker.wandb import WandbConfig
@@ -29,6 +30,7 @@ from marin.rl.environments.inference_ctx import (
     VLLMFallbackSamplingConfig,
     vLLMInferenceContextConfig,
 )
+from marin.rl.lora_manifest import RUN_MANIFEST_FILENAME, RolloutPolicyFormat
 from marin.rl.placement import marin_prefix_for_region, resolve_launcher_region, singleton_region_list
 from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_job import RLJob, RLJobConfig, RunConfig, TrainParams
@@ -76,6 +78,8 @@ class RLExperimentConfig:
     model_config: ModelConfig
     rl_loss: RLLossModule
     experiment_name_suffix: str
+    lora: LoraConfig | None = None
+    rollout_policy_format: RolloutPolicyFormat = "merged"
 
     # trainer params
     train_batch_size: int = 1024
@@ -256,6 +260,7 @@ def _build_rl_job_config(
     tags = [*config.tags, config.model_config.name.split("/")[-1]]
     checkpoints_path = join_path(output_path, "checkpoints")
     rollout_storage_path = join_path(output_path, "rollouts")
+    run_manifest_path = join_path(output_path, RUN_MANIFEST_FILENAME)
 
     trainer_config = TrainerConfig(
         tracker=WandbConfig(
@@ -313,6 +318,7 @@ def _build_rl_job_config(
         train_params=TrainParams(
             optimizer=opt_config,
             rl_loss=config.rl_loss,
+            lora=config.lora,
             replay_buffer=ReplayBufferConfig(
                 capacity=config.replay_buffer_capacity,
                 alpha=config.replay_buffer_alpha,
@@ -323,6 +329,7 @@ def _build_rl_job_config(
         curriculum=curriculum_config,
         tokenizer=model_path,
         inference_type="vllm",
+        rollout_policy_format=config.rollout_policy_format,
         inference_config=vLLMInferenceContextConfig(
             engine=_build_vllm_engine_config(config, model_path),
             fallback_sampling=_build_vllm_fallback_sampling_config(config),
@@ -330,6 +337,7 @@ def _build_rl_job_config(
         initial_checkpoint=model_path,
         rollout_storage=rollout_storage,
         weight_transfer=weight_transfer,
+        run_manifest_path=run_manifest_path,
         run_id=name,
         log_freq=1,
         run_config=RunConfig(

--- a/lib/marin/src/marin/rl/rl_experiment_utils.py
+++ b/lib/marin/src/marin/rl/rl_experiment_utils.py
@@ -10,9 +10,9 @@ from urllib.parse import urlparse
 
 import jmp
 from fray.types import ResourceConfig
+from levanter.adaptor.lora import LoraConfig
 from levanter.checkpoint import CheckpointDebugConfig, CheckpointerConfig
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
-from levanter.adaptor.lora import LoraConfig
 from levanter.layers.attention import AttentionBackend
 from levanter.optim import AdamConfig
 from levanter.tracker.wandb import WandbConfig

--- a/lib/marin/src/marin/rl/rollout_worker.py
+++ b/lib/marin/src/marin/rl/rollout_worker.py
@@ -50,6 +50,7 @@ from marin.rl.environments.inference_ctx import (
 from marin.rl.environments.inference_ctx.staging import (
     prepare_vllm_inference_config_for_inflight,
 )
+from marin.rl.lora_manifest import RolloutPolicyFormat
 from marin.rl.metrics import pass_at_k_estimator
 from marin.rl.model_utils import load_model_from_checkpoint
 from marin.rl.run_state import RolloutTransferCounters
@@ -246,6 +247,9 @@ class RolloutWorkerConfig:
 
     worker_index: int = 0
     """Index of this worker among all rollout workers."""
+
+    rollout_policy_format: RolloutPolicyFormat = "merged"
+    """Expected trainer-to-rollout policy payload format."""
 
 
 def find_open_port() -> int:

--- a/lib/marin/src/marin/rl/train_worker.py
+++ b/lib/marin/src/marin/rl/train_worker.py
@@ -26,10 +26,12 @@ import wandb
 from levanter import callbacks
 from levanter.callbacks.tensorstore_callbacks import install_tensorstore_metrics_hook
 from levanter.checkpoint import (
+    discover_latest_checkpoint,
+    is_checkpoint_path,
     register_debug_checkpointer_state_provider,
     unregister_debug_checkpointer_state_provider,
 )
-from levanter.adaptor.lora import LoraConfig, lora_trainable_params_filter, loraize
+from levanter.adaptor.lora import LoraConfig, lora_trainable_params_filter, loraize, merge_lora_modules
 from levanter.kernels.pallas.splash_attention import DEFAULT_SPLASH_BLOCK_SIZE
 from levanter.layers.attention import AttentionBackend
 from levanter.models.flash_attention import BLOCK_SIZE as DEFAULT_FLASH_BLOCK_SIZE
@@ -40,7 +42,7 @@ from levanter.trainer import Trainer, TrainerConfig
 from levanter.utils.jax_utils import parameter_count
 from marin.rl import weight_transfer
 from marin.rl.curriculum import CurriculumConfig
-from marin.rl.lora_manifest import build_rl_run_manifest, write_rl_run_manifest
+from marin.rl.lora_manifest import RLRunManifest, build_rl_run_manifest, read_rl_run_manifest, write_rl_run_manifest
 from marin.rl.model_utils import load_model_from_checkpoint
 from marin.rl.runtime import RLRuntimeHandles
 from marin.rl.weight_transfer import WeightTransferConfig
@@ -267,6 +269,17 @@ class StopTrainerException(Exception):
     pass
 
 
+def _resume_checkpoint_path_for_validation(trainer: Trainer) -> str | None:
+    """Return the checkpoint path that a LoRA resume would load, if any."""
+    if trainer.config.load_checkpoint is False:
+        initialize_from = trainer.config.initialize_from
+        if initialize_from is None or not is_checkpoint_path(initialize_from):
+            return None
+        return initialize_from
+
+    return discover_latest_checkpoint(trainer.checkpoint_path)
+
+
 class TrainWorker:
     """Training worker that reads rollout data from a queue and trains the model using Levanter."""
 
@@ -387,14 +400,67 @@ class TrainWorker:
 
     def _write_run_manifest(self) -> None:
         """Persist LoRA run metadata needed for checkpoint validation and future exports."""
-        manifest = build_rl_run_manifest(
+        manifest = self._expected_run_manifest()
+        write_rl_run_manifest(self.config.run_manifest_path, manifest)
+
+    def _expected_run_manifest(self) -> RLRunManifest:
+        """Build the manifest expected for the current RL training configuration."""
+        return build_rl_run_manifest(
             initial_checkpoint=self.config.initial_checkpoint,
             model_config=self.config.model,
             lora_config=self.config.lora,
-            rollout_policy_format=self.config.rollout_policy_format,
+            rollout_policy_format=self._rollout_policy_format(),
             inference_type=self.config.inference_type,
         )
-        write_rl_run_manifest(self.config.run_manifest_path, manifest)
+
+    def _validate_run_manifest_for_resume(self, trainer: Trainer) -> None:
+        """Fail fast when a LoRA resume request does not match the saved run manifest."""
+        resume_checkpoint = _resume_checkpoint_path_for_validation(trainer)
+        if resume_checkpoint is None:
+            return
+
+        try:
+            manifest = read_rl_run_manifest(self.config.run_manifest_path)
+        except FileNotFoundError as exc:
+            raise ValueError(
+                f"LoRA resume from {resume_checkpoint!r} requires run manifest {self.config.run_manifest_path!r}"
+            ) from exc
+
+        expected = self._expected_run_manifest()
+        mismatches = {
+            "manifest_version": (expected.manifest_version, manifest.manifest_version),
+            "initial_checkpoint": (expected.initial_checkpoint, manifest.initial_checkpoint),
+            "model_config_type": (expected.model_config_type, manifest.model_config_type),
+            "model_config_fingerprint": (expected.model_config_fingerprint, manifest.model_config_fingerprint),
+            "lora_config_fingerprint": (expected.lora_config_fingerprint, manifest.lora_config_fingerprint),
+            "inference_type": (expected.inference_type, manifest.inference_type),
+            "rollout_policy_format": (expected.rollout_policy_format, manifest.rollout_policy_format),
+            "reference_mode": (expected.reference_mode, manifest.reference_mode),
+        }
+
+        for field_name, (expected_value, actual_value) in mismatches.items():
+            if expected_value != actual_value:
+                raise ValueError(
+                    f"LoRA resume manifest mismatch for {field_name}: "
+                    f"expected {expected_value!r}, found {actual_value!r}"
+                )
+
+    def _rollout_transfer_model(self, model: LmHeadModel) -> LmHeadModel:
+        """Return the plain rollout-serving model for the current trainer state."""
+        if self._rollout_policy_format() != "merged":
+            raise ValueError(
+                "rollout_policy_format='adapter' is not implemented yet; "
+                "rollout workers still require merged full-model transfers"
+            )
+
+        if getattr(self.config, "lora", None) is None:
+            return model
+
+        return merge_lora_modules(model)
+
+    def _rollout_policy_format(self) -> Literal["merged", "adapter"]:
+        """Return the rollout-serving format, defaulting to the v1 merged contract."""
+        return getattr(self.config, "rollout_policy_format", "merged")
 
     def _log_lora_parameter_metrics(self, state) -> None:
         """Log total and trainable parameter counts for LoRA runs."""
@@ -413,6 +479,20 @@ class TrainWorker:
         logger.info("Total parameter count: %d", all_param_count)
         logger.info("Trainable parameter count: %d", trainable_param_count)
         logger.info("Fraction of parameters that are trainable: %.3e", fraction_trainable)
+
+    def _log_rollout_policy_metadata(self) -> None:
+        """Record rollout-serving semantics for the current RL run."""
+        levanter.tracker.log_summary(
+            {
+                "rollout_policy_format": self._rollout_policy_format(),
+                "reference_mode": "base",
+            }
+        )
+        logger.info(
+            "Rollout serving configured with rollout_policy_format=%s reference_mode=%s",
+            self._rollout_policy_format(),
+            "base",
+        )
 
     def _drop_bootstrap_model_references(self) -> None:
         """Release one-shot bootstrap model references once trainer state exists."""
@@ -515,10 +595,12 @@ class TrainWorker:
             with Trainer(config=config.trainer, optimizer=optimizer, loss_fn=_loss_function) as trainer:
                 if debug_checkpointer:
                     install_tensorstore_metrics_hook(trainer, every=1)
+                self._log_rollout_policy_metadata()
                 _, training_key = jrandom.split(jrandom.PRNGKey(config.trainer.seed), 2)
                 if config.lora is None:
                     state = trainer.initial_state(training_key, model=self.initial_model)
                 else:
+                    self._validate_run_manifest_for_resume(trainer)
                     if jax.process_index() == 0:
                         self._write_run_manifest()
                     state = trainer.initial_state(
@@ -547,7 +629,8 @@ class TrainWorker:
 
                 with self.replay_loader:
                     # Always transfer startup weights to rollout workers before we attempt to train.
-                    self.transfer_server.serve_weights(startup_rollout_state.weight_step, state.model)
+                    startup_rollout_model = self._rollout_transfer_model(state.model)
+                    self.transfer_server.serve_weights(startup_rollout_state.weight_step, startup_rollout_model)
 
                     # Wait for startup rollouts so both fresh runs and resumed runs begin with
                     # rollouts that match the currently served weights.
@@ -653,12 +736,13 @@ class TrainWorker:
         state = info.state
 
         logger.info(
-            "Transferring weights at step %d, loss=%s",
+            "Transferring weights at step %d, loss=%s, rollout_policy_format=%s",
             step,
             info.loss,
+            self._rollout_policy_format(),
         )
 
-        model_params = state.model
+        model_params = self._rollout_transfer_model(state.model)
 
         # Measure weight transfer time
         transfer_start = time.time()

--- a/lib/marin/src/marin/rl/train_worker.py
+++ b/lib/marin/src/marin/rl/train_worker.py
@@ -24,13 +24,6 @@ import jax.random as jrandom
 import levanter
 import wandb
 from levanter import callbacks
-from levanter.callbacks.tensorstore_callbacks import install_tensorstore_metrics_hook
-from levanter.checkpoint import (
-    discover_latest_checkpoint,
-    is_checkpoint_path,
-    register_debug_checkpointer_state_provider,
-    unregister_debug_checkpointer_state_provider,
-)
 from levanter.adaptor.lora import (
     LoraConfig,
     lora_trainable_params_filter,
@@ -38,6 +31,13 @@ from levanter.adaptor.lora import (
     merge_lora_modules,
     save_merged_hf_model,
     save_peft_pretrained,
+)
+from levanter.callbacks.tensorstore_callbacks import install_tensorstore_metrics_hook
+from levanter.checkpoint import (
+    discover_latest_checkpoint,
+    is_checkpoint_path,
+    register_debug_checkpointer_state_provider,
+    unregister_debug_checkpointer_state_provider,
 )
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.kernels.pallas.splash_attention import DEFAULT_SPLASH_BLOCK_SIZE

--- a/lib/marin/src/marin/rl/train_worker.py
+++ b/lib/marin/src/marin/rl/train_worker.py
@@ -16,6 +16,7 @@ import signal
 import sys
 import time
 from dataclasses import dataclass
+from typing import Literal
 
 import haliax as hax
 import jax
@@ -28,6 +29,7 @@ from levanter.checkpoint import (
     register_debug_checkpointer_state_provider,
     unregister_debug_checkpointer_state_provider,
 )
+from levanter.adaptor.lora import LoraConfig, lora_trainable_params_filter, loraize
 from levanter.kernels.pallas.splash_attention import DEFAULT_SPLASH_BLOCK_SIZE
 from levanter.layers.attention import AttentionBackend
 from levanter.models.flash_attention import BLOCK_SIZE as DEFAULT_FLASH_BLOCK_SIZE
@@ -35,8 +37,10 @@ from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.optim import OptimizerConfig
 from levanter.tokenizers import MarinTokenizer
 from levanter.trainer import Trainer, TrainerConfig
+from levanter.utils.jax_utils import parameter_count
 from marin.rl import weight_transfer
 from marin.rl.curriculum import CurriculumConfig
+from marin.rl.lora_manifest import build_rl_run_manifest, write_rl_run_manifest
 from marin.rl.model_utils import load_model_from_checkpoint
 from marin.rl.runtime import RLRuntimeHandles
 from marin.rl.weight_transfer import WeightTransferConfig
@@ -144,8 +148,12 @@ class TrainWorkerConfig:
     weight_transfer: WeightTransferConfig
     curriculum_config: CurriculumConfig
     loss: RLLossModule
+    lora: LoraConfig | None
     tokenizer: MarinTokenizer
     run_id: str
+    run_manifest_path: str
+    inference_type: Literal["levanter", "vllm"]
+    rollout_policy_format: Literal["merged", "adapter"] = "merged"
 
     initial_checkpoint: str | None = None
     """Initial checkpoint for the reference model (auto-detects HF repo vs local path)."""
@@ -270,6 +278,7 @@ class TrainWorker:
     loss_module: RLLossModule
     initial_model: LmHeadModel | None
     reference_model: LmHeadModel | None
+    trainable_model_filter: object
 
     def __init__(
         self,
@@ -337,7 +346,7 @@ class TrainWorker:
     def _build_models(self):
         """Build the initial policy model and optional retained reference model."""
         config = self.config
-        model_key = jrandom.PRNGKey(config.seed)
+        model_key, lora_key = jrandom.split(jrandom.PRNGKey(config.seed))
         vocab_size = config.vocab_size if config.vocab_size is not None else self.tokenizer.vocab_size
         Vocab = hax.Axis("vocab", vocab_size)
 
@@ -358,10 +367,52 @@ class TrainWorker:
                 key=model_key,
             )
 
-        self.initial_model = _load_model()
+        base_model = _load_model()
+        self.trainable_model_filter = True
+
+        if config.lora is None:
+            self.initial_model = base_model
+        else:
+
+            @hax.named_jit(axis_resources=config.trainer.parameter_axis_mapping)
+            def _loraize_model(model: LmHeadModel) -> LmHeadModel:
+                return loraize(model, config.lora, key=lora_key)
+
+            self.initial_model = _loraize_model(base_model)
+            self.trainable_model_filter = lora_trainable_params_filter(self.initial_model)
+
         # Keep compatibility for callers that inspect the worker immediately after construction.
         # The zero-KL path clears this alias once trainer state has been materialized.
-        self.reference_model = self.initial_model
+        self.reference_model = base_model
+
+    def _write_run_manifest(self) -> None:
+        """Persist LoRA run metadata needed for checkpoint validation and future exports."""
+        manifest = build_rl_run_manifest(
+            initial_checkpoint=self.config.initial_checkpoint,
+            model_config=self.config.model,
+            lora_config=self.config.lora,
+            rollout_policy_format=self.config.rollout_policy_format,
+            inference_type=self.config.inference_type,
+        )
+        write_rl_run_manifest(self.config.run_manifest_path, manifest)
+
+    def _log_lora_parameter_metrics(self, state) -> None:
+        """Log total and trainable parameter counts for LoRA runs."""
+        all_param_count = parameter_count(state.model)
+        trainable_param_count = parameter_count(state.trainable_model)
+        fraction_trainable = trainable_param_count / all_param_count
+
+        levanter.tracker.log_summary(
+            {
+                "parameter_count": all_param_count,
+                "trainable_parameter_count": trainable_param_count,
+                "fraction_trainable": fraction_trainable,
+            }
+        )
+
+        logger.info("Total parameter count: %d", all_param_count)
+        logger.info("Trainable parameter count: %d", trainable_param_count)
+        logger.info("Fraction of parameters that are trainable: %.3e", fraction_trainable)
 
     def _drop_bootstrap_model_references(self) -> None:
         """Release one-shot bootstrap model references once trainer state exists."""
@@ -465,7 +516,17 @@ class TrainWorker:
                 if debug_checkpointer:
                     install_tensorstore_metrics_hook(trainer, every=1)
                 _, training_key = jrandom.split(jrandom.PRNGKey(config.trainer.seed), 2)
-                state = trainer.initial_state(training_key, model=self.initial_model)
+                if config.lora is None:
+                    state = trainer.initial_state(training_key, model=self.initial_model)
+                else:
+                    if jax.process_index() == 0:
+                        self._write_run_manifest()
+                    state = trainer.initial_state(
+                        training_key,
+                        model=self.initial_model,
+                        is_trainable=self.trainable_model_filter,
+                    )
+                    self._log_lora_parameter_metrics(state)
                 self._drop_bootstrap_model_references()
                 startup_rollout_state = _initial_rollout_state(int(state.step))
                 logger.info(

--- a/lib/marin/src/marin/rl/train_worker.py
+++ b/lib/marin/src/marin/rl/train_worker.py
@@ -31,7 +31,15 @@ from levanter.checkpoint import (
     register_debug_checkpointer_state_provider,
     unregister_debug_checkpointer_state_provider,
 )
-from levanter.adaptor.lora import LoraConfig, lora_trainable_params_filter, loraize, merge_lora_modules
+from levanter.adaptor.lora import (
+    LoraConfig,
+    lora_trainable_params_filter,
+    loraize,
+    merge_lora_modules,
+    save_merged_hf_model,
+    save_peft_pretrained,
+)
+from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.kernels.pallas.splash_attention import DEFAULT_SPLASH_BLOCK_SIZE
 from levanter.layers.attention import AttentionBackend
 from levanter.models.flash_attention import BLOCK_SIZE as DEFAULT_FLASH_BLOCK_SIZE
@@ -39,11 +47,12 @@ from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.optim import OptimizerConfig
 from levanter.tokenizers import MarinTokenizer
 from levanter.trainer import Trainer, TrainerConfig
+from levanter.utils.fsspec_utils import join_path
 from levanter.utils.jax_utils import parameter_count
 from marin.rl import weight_transfer
 from marin.rl.curriculum import CurriculumConfig
 from marin.rl.lora_manifest import RLRunManifest, build_rl_run_manifest, read_rl_run_manifest, write_rl_run_manifest
-from marin.rl.model_utils import load_model_from_checkpoint
+from marin.rl.model_utils import is_hf_checkpoint, load_model_from_checkpoint
 from marin.rl.runtime import RLRuntimeHandles
 from marin.rl.weight_transfer import WeightTransferConfig
 
@@ -53,6 +62,7 @@ from .rollout_storage import RolloutStorageConfig
 from .train_batch import create_training_batch_from_rollouts
 
 logger = logging.getLogger(__name__)
+FINAL_EXPORT_DIR = "final"
 
 
 @dataclass(frozen=True)
@@ -156,6 +166,8 @@ class TrainWorkerConfig:
     run_manifest_path: str
     inference_type: Literal["levanter", "vllm"]
     rollout_policy_format: Literal["merged", "adapter"] = "merged"
+    adapter_artifacts_path: str | None = None
+    merged_hf_export_path: str | None = None
 
     initial_checkpoint: str | None = None
     """Initial checkpoint for the reference model (auto-detects HF repo vs local path)."""
@@ -494,6 +506,73 @@ class TrainWorker:
             "base",
         )
 
+    def _adapter_artifacts_path(self) -> str | None:
+        """Return the adapter export root, if configured."""
+        return getattr(self.config, "adapter_artifacts_path", None)
+
+    def _merged_hf_export_path(self) -> str | None:
+        """Return the merged-HF export root, if configured."""
+        return getattr(self.config, "merged_hf_export_path", None)
+
+    def _final_export_path(self, base_path: str) -> str:
+        """Return the final export directory under an artifact root."""
+        return join_path(base_path, FINAL_EXPORT_DIR)
+
+    def _adapter_base_model_name_or_path(self) -> str | None:
+        """Return the base checkpoint identifier used by PEFT adapter exports."""
+        if self.config.initial_checkpoint is not None:
+            return self.config.initial_checkpoint
+
+        reference_checkpoint = getattr(self.config.model, "reference_checkpoint", None)
+        if reference_checkpoint is None:
+            return None
+
+        return str(reference_checkpoint)
+
+    def _hf_export_converter(self) -> HFCheckpointConverter:
+        """Build an HF converter for merged full-model exports."""
+        if not hasattr(self.config.model, "hf_checkpoint_converter"):
+            raise ValueError("Merged HF export requires an HF-compatible model config")
+
+        converter = self.config.model.hf_checkpoint_converter(self.config.initial_checkpoint)
+        return converter.replaced(tokenizer=self.tokenizer)
+
+    def _export_lora_artifacts(self, model: LmHeadModel) -> None:
+        """Export adapter and merged artifacts for LoRA runs."""
+        if self.config.lora is None:
+            return
+
+        exported_paths: dict[str, str] = {}
+
+        adapter_artifacts_path = self._adapter_artifacts_path()
+        if adapter_artifacts_path is not None:
+            base_model_name_or_path = self._adapter_base_model_name_or_path()
+            if base_model_name_or_path is None or not is_hf_checkpoint(base_model_name_or_path):
+                raise ValueError(
+                    "PEFT adapter export requires an HF-compatible base checkpoint, " f"got {base_model_name_or_path!r}"
+                )
+
+            adapter_export_path = self._final_export_path(adapter_artifacts_path)
+            logger.info("Exporting LoRA adapter artifacts to %s", adapter_export_path)
+            save_peft_pretrained(
+                model,
+                self.config.lora,
+                base_model_name_or_path,
+                adapter_export_path,
+                tokenizer=self.tokenizer,
+            )
+            exported_paths["adapter_artifacts_path"] = adapter_export_path
+
+        merged_hf_export_path = self._merged_hf_export_path()
+        if merged_hf_export_path is not None:
+            merged_export_path = self._final_export_path(merged_hf_export_path)
+            logger.info("Exporting merged HF model to %s", merged_export_path)
+            save_merged_hf_model(model, self._hf_export_converter(), merged_export_path)
+            exported_paths["merged_hf_export_path"] = merged_export_path
+
+        if exported_paths:
+            levanter.tracker.log_summary(exported_paths)
+
     def _drop_bootstrap_model_references(self) -> None:
         """Release one-shot bootstrap model references once trainer state exists."""
         self.initial_model = None
@@ -639,7 +718,8 @@ class TrainWorker:
 
                     self._configure_training_hooks(trainer)
                     try:
-                        trainer.train(state, self.data_loader)
+                        final_info = trainer.train(state, self.data_loader)
+                        self._export_lora_artifacts(final_info.eval_model)
                     except StopTrainerException:
                         pass
         except StopTrainerException:

--- a/lib/marin/src/marin/rl/train_worker.py
+++ b/lib/marin/src/marin/rl/train_worker.py
@@ -283,13 +283,20 @@ class StopTrainerException(Exception):
 
 def _resume_checkpoint_path_for_validation(trainer: Trainer) -> str | None:
     """Return the checkpoint path that a LoRA resume would load, if any."""
-    if trainer.config.load_checkpoint is False:
-        initialize_from = trainer.config.initialize_from
-        if initialize_from is None or not is_checkpoint_path(initialize_from):
-            return None
-        return initialize_from
+    load_checkpoint = trainer.config.load_checkpoint
+    if load_checkpoint is not False:
+        latest_checkpoint = discover_latest_checkpoint(*trainer.checkpoint_search_paths)
+        if latest_checkpoint is not None:
+            return latest_checkpoint
 
-    return discover_latest_checkpoint(trainer.checkpoint_path)
+        if load_checkpoint is True:
+            return None
+
+    initialize_from = trainer.config.initialize_from
+    if initialize_from is None or not is_checkpoint_path(initialize_from):
+        return None
+
+    return initialize_from
 
 
 class TrainWorker:

--- a/tests/rl/integration/config.py
+++ b/tests/rl/integration/config.py
@@ -309,7 +309,10 @@ def create_nano_train_worker_config(rollout_storage: RolloutStorageConfig, outpu
         optimizer=create_nano_optimizer_config(),
         weight_transfer=create_weight_transfer_config(),
         curriculum_config=create_test_curriculum_config(),
+        lora=None,
         tokenizer=DummyTokenizer(),
+        run_manifest_path=str(Path(output_dir) / "rl_run_manifest.json"),
+        inference_type="vllm",
         replay_buffer=ReplayBufferConfig(
             capacity=2048,
             alpha=3.0,

--- a/tests/rl/integration/test_checkpoint_restart.py
+++ b/tests/rl/integration/test_checkpoint_restart.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from pathlib import Path
 
 import pytest
+from levanter.adaptor.lora import LoraConfig
 from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
 from marin.rl.rl_losses import RLOOLoss
@@ -148,3 +149,90 @@ def test_train_worker_checkpoint_restart(tmp_path):
     assert (
         max_step_second_run > max_step_first_run
     ), f"Second run should progress beyond first run: first max={max_step_first_run}, second max={max_step_second_run}"
+
+
+@pytest.mark.slow("Integration test with checkpoint restart")
+def test_lora_resume_manifest_mismatch_fails_fast(tmp_path):
+    """Test that LoRA resume fails before training starts when manifest fields change."""
+    rollout_storage_config = create_test_rollout_storage_config()
+    queue_writer = rollout_storage_config.create_writer()
+
+    trainer_config = create_nano_trainer_config(tmp_path)
+    trainer_config.num_train_steps = 3
+    trainer_config.checkpointer.save_interval = timedelta(milliseconds=100)
+    run_id = "test-lora"
+
+    initial_job_config = RLJobConfig(
+        model=create_nano_llama_config(),
+        trainer=trainer_config,
+        train_params=TrainParams(
+            optimizer=create_nano_optimizer_config(),
+            rl_loss=RLOOLoss(
+                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+                clip_epsilon_low=0.2,
+                clip_epsilon_high=0.2,
+            ),
+            lora=LoraConfig(r=4, alpha=8.0),
+        ),
+        curriculum=create_test_curriculum_config(),
+        tokenizer=DummyTokenizer(),
+        rollout_storage=rollout_storage_config,
+        run_id=run_id,
+        inference_type="levanter",
+    )
+
+    initial_job = RLJob(initial_job_config)
+
+    with TrainWorkerRunner.from_job(initial_job) as runner:
+        tokenizer = DummyTokenizer()
+        batch_size = runner.training_worker_config.trainer.train_batch_size
+
+        while not runner.worker:
+            time.sleep(0.1)
+
+        for _ in range(5):
+            batch = create_cats_rollout_batch(
+                policy_model=runner.reference_model,
+                batch_size=batch_size,
+                tokenizer=tokenizer,
+            )
+            queue_writer.write_batch(batch)
+
+        result = runner.wait_for_result(timeout=30)
+        assert result == WaitResult.SUCCESS, "Initial LoRA training timed out after 30s"
+
+        manifest_path = Path(runner.training_worker_config.run_manifest_path)
+        assert manifest_path.exists(), f"Expected run manifest at {manifest_path}"
+
+    mismatched_job_config = RLJobConfig(
+        model=create_nano_llama_config(),
+        trainer=trainer_config,
+        train_params=TrainParams(
+            optimizer=create_nano_optimizer_config(),
+            rl_loss=RLOOLoss(
+                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+                clip_epsilon_low=0.2,
+                clip_epsilon_high=0.2,
+            ),
+            lora=LoraConfig(r=2, alpha=8.0),
+        ),
+        curriculum=create_test_curriculum_config(),
+        tokenizer=DummyTokenizer(),
+        rollout_storage=rollout_storage_config,
+        run_id=run_id,
+        inference_type="levanter",
+    )
+
+    mismatched_job = RLJob(mismatched_job_config)
+    runner = TrainWorkerRunner.from_job(mismatched_job)
+    runner.start()
+
+    try:
+        with pytest.raises(RuntimeError, match="TrainWorkerRunner failed") as exc_info:
+            runner.wait_for_result(timeout=30)
+
+        assert exc_info.value.__cause__ is not None
+        assert "lora_config_fingerprint" in str(exc_info.value.__cause__)
+    finally:
+        runner.stop()
+        runner.join(timeout=5)

--- a/tests/rl/integration/test_weight_sync.py
+++ b/tests/rl/integration/test_weight_sync.py
@@ -7,6 +7,7 @@ import os
 import time
 
 import pytest
+from levanter.adaptor.lora import LoraConfig
 from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
 from marin.rl.rl_losses import RLOOLoss
@@ -75,4 +76,48 @@ def test_rollout_and_train_workers(tmp_path):
 
     print(f"Weight transfers detected: {rollout_runner.weight_transfers}")
     assert rollout_runner.weight_transfers >= 1, "Expected at least 1 weight transfer"
+    assert rollout_runner.rollouts_generated > 0, "Should have generated at least one rollout"
+
+
+@pytest.mark.slow("Integration test.")
+def test_rollout_and_train_workers_with_lora(tmp_path):
+    """Test LoRA training with merged rollout weight serving."""
+    rollout_storage_config = create_test_rollout_storage_config()
+
+    trainer_config = create_nano_trainer_config(tmp_path)
+    trainer_config.num_train_steps = 100
+
+    job_config = RLJobConfig(
+        model=create_nano_llama_config(),
+        trainer=trainer_config,
+        train_params=TrainParams(
+            optimizer=create_nano_optimizer_config(),
+            rl_loss=RLOOLoss(
+                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+                clip_epsilon_low=0.2,
+                clip_epsilon_high=0.2,
+            ),
+            lora=LoraConfig(r=4, alpha=8.0),
+        ),
+        curriculum=create_test_curriculum_config(),
+        tokenizer=DummyTokenizer(),
+        rollout_storage=rollout_storage_config,
+        inference_type="levanter",
+    )
+
+    job = RLJob(job_config)
+
+    training_runner = TrainWorkerRunner.from_job(job)
+    rollout_runner = RolloutWorkerRunner.from_job(job)
+
+    rollout_runner.rollout_worker_config.weight_transfer.sync_interval_steps = 1
+    rollout_runner.rollout_worker_config.max_rollouts = 100
+
+    with training_runner:
+        time.sleep(1)
+        with rollout_runner:
+            result = training_runner.wait_for_result(timeout=60)
+            assert result == WaitResult.SUCCESS, "Training timed out after 60s"
+
+    assert rollout_runner.weight_transfers >= 1, "Expected at least 1 merged weight transfer"
     assert rollout_runner.rollouts_generated > 0, "Should have generated at least one rollout"

--- a/tests/rl/test_inference_ctx.py
+++ b/tests/rl/test_inference_ctx.py
@@ -735,35 +735,8 @@ def test_vllm_reload_model_resets_prefix_cache_and_syncs_weights(monkeypatch):
     assert call["reshard_fn"] is None
 
 
-def test_vllm_reload_model_requires_state_dict(monkeypatch):
-    fake_llm = SimpleNamespace(
-        llm_engine=SimpleNamespace(
-            reset_prefix_cache=lambda: None,
-            model_executor=SimpleNamespace(driver_worker=SimpleNamespace(sync_weights=lambda **kwargs: None)),
-        )
-    )
-
-    monkeypatch.setattr(vLLMInferenceContext, "_get_llm_engine", staticmethod(lambda _config: fake_llm))
-    monkeypatch.setattr(
-        "marin.rl.environments.inference_ctx.vllm.load_tokenizer",
-        lambda _path: SimpleNamespace(get_vocab=lambda: {}),
-    )
-    monkeypatch.setattr(
-        vLLMInferenceContext,
-        "_get_renderer",
-        staticmethod(lambda model_name, _tokenizer: model_name),
-    )
-
-    ctx = vLLMInferenceContext(
-        vLLMInferenceContextConfig(
-            model_name="Qwen/Qwen3-0.6B",
-            canonical_model_name="Qwen/Qwen3-0.6B",
-            max_model_len=1024,
-            tensor_parallel_size=1,
-            gpu_memory_utilization=0.9,
-            sampling_params=VLLMSamplingConfig(),
-        )
-    )
+def test_vllm_reload_model_requires_state_dict():
+    ctx = vLLMInferenceContext.__new__(vLLMInferenceContext)
 
     with pytest.raises(ValueError, match="requires a full state_dict payload"):
         ctx.reload_model(model=None, state_dict=None)

--- a/tests/rl/test_inference_ctx.py
+++ b/tests/rl/test_inference_ctx.py
@@ -651,6 +651,124 @@ def test_vllm_async_engine_receives_engine_seed(monkeypatch):
     assert calls["seed"] == 1234
 
 
+def test_levanter_reload_model_reloads_plain_model(monkeypatch):
+    reloaded_models: list[object] = []
+    model = object()
+
+    ctx = LevanterInferenceContext(
+        LevanterInferenceContextConfig(
+            inference_server_config=None,
+            tokenizer=SimpleNamespace(),
+            stop_tokens=None,
+            max_tokens=16,
+            mesh=None,
+            axis_mapping={},
+        )
+    )
+    ctx._inference_server = SimpleNamespace(reload=lambda loader: reloaded_models.append(loader(None)))
+
+    returned_model = ctx.reload_model(model, state_dict=None)
+
+    assert returned_model is model
+    assert reloaded_models == [model]
+
+
+def test_vllm_reload_model_resets_prefix_cache_and_syncs_weights(monkeypatch):
+    reset_calls: list[str] = []
+    sync_calls: list[dict[str, object]] = []
+
+    class _FakeDriverWorker:
+        def sync_weights(self, nnx_state, *, mappings, transpose_keys, reshard_fn):
+            sync_calls.append(
+                {
+                    "nnx_state": nnx_state,
+                    "mappings": mappings,
+                    "transpose_keys": transpose_keys,
+                    "reshard_fn": reshard_fn,
+                }
+            )
+
+    class _FakeLLMEngine:
+        def reset_prefix_cache(self):
+            reset_calls.append("reset")
+
+        model_executor = SimpleNamespace(driver_worker=_FakeDriverWorker())
+
+    fake_llm = SimpleNamespace(llm_engine=_FakeLLMEngine())
+
+    monkeypatch.setattr(vLLMInferenceContext, "_get_llm_engine", staticmethod(lambda _config: fake_llm))
+    monkeypatch.setattr(
+        "marin.rl.environments.inference_ctx.vllm.load_tokenizer",
+        lambda _path: SimpleNamespace(get_vocab=lambda: {}),
+    )
+    monkeypatch.setattr(
+        vLLMInferenceContext,
+        "_get_renderer",
+        staticmethod(lambda model_name, _tokenizer: model_name),
+    )
+    monkeypatch.setattr(
+        "marin.rl.environments.inference_ctx.vllm.levanter_state_dict_to_nnx_state_on_cpu",
+        lambda state_dict: {"converted": state_dict},
+    )
+
+    ctx = vLLMInferenceContext(
+        vLLMInferenceContextConfig(
+            engine=VLLMEngineConfig(
+                model_name="Qwen/Qwen3-0.6B",
+                canonical_model_name="Qwen/Qwen3-0.6B",
+                max_model_len=1024,
+                tensor_parallel_size=1,
+                gpu_memory_utilization=0.9,
+            ),
+        )
+    )
+
+    returned_model = ctx.reload_model(model=None, state_dict={"weight": np.array([1.0], dtype=np.float32)})
+
+    assert returned_model is None
+    assert reset_calls == ["reset", "reset"]
+    assert len(sync_calls) == 1
+    call = sync_calls[0]
+    np.testing.assert_array_equal(call["nnx_state"]["converted"]["weight"], np.array([1.0], dtype=np.float32))
+    assert call["mappings"] == MODEL_MAPPINGS["Qwen/Qwen3-0.6B"]
+    assert call["transpose_keys"] == MODEL_TRANSPOSE_KEYS["Qwen/Qwen3-0.6B"]
+    assert call["reshard_fn"] is None
+
+
+def test_vllm_reload_model_requires_state_dict(monkeypatch):
+    fake_llm = SimpleNamespace(
+        llm_engine=SimpleNamespace(
+            reset_prefix_cache=lambda: None,
+            model_executor=SimpleNamespace(driver_worker=SimpleNamespace(sync_weights=lambda **kwargs: None)),
+        )
+    )
+
+    monkeypatch.setattr(vLLMInferenceContext, "_get_llm_engine", staticmethod(lambda _config: fake_llm))
+    monkeypatch.setattr(
+        "marin.rl.environments.inference_ctx.vllm.load_tokenizer",
+        lambda _path: SimpleNamespace(get_vocab=lambda: {}),
+    )
+    monkeypatch.setattr(
+        vLLMInferenceContext,
+        "_get_renderer",
+        staticmethod(lambda model_name, _tokenizer: model_name),
+    )
+
+    ctx = vLLMInferenceContext(
+        vLLMInferenceContextConfig(
+            model_name="Qwen/Qwen3-0.6B",
+            canonical_model_name="Qwen/Qwen3-0.6B",
+            max_model_len=1024,
+            tensor_parallel_size=1,
+            gpu_memory_utilization=0.9,
+            sampling_params=VLLMSamplingConfig(),
+        )
+    )
+
+    with pytest.raises(ValueError, match="requires a full state_dict payload"):
+        ctx.reload_model(model=None, state_dict=None)
+
+
 def test_worker_extension_uses_public_sync_weights():
     calls = {}
 

--- a/tests/rl/test_rl_experiment_utils.py
+++ b/tests/rl/test_rl_experiment_utils.py
@@ -311,35 +311,6 @@ def test_build_rl_job_config_propagates_checkpoint_controls_and_instance_id(monk
     assert job_config.trainer.checkpointer.debug.dump_stacks_after == 45.0
 
 
-def test_build_rl_job_config_propagates_lora_and_rollout_policy_format(monkeypatch):
-    class _FakeConverter:
-        def __init__(self, *args, **kwargs):
-            self.default_hf_config = SimpleNamespace(vocab_size=32000)
-
-    monkeypatch.setattr("marin.rl.rl_experiment_utils._resolve_config_class", lambda _path: _FakeRuntimeLmConfig)
-    monkeypatch.setattr("marin.rl.rl_experiment_utils.HFCheckpointConverter", _FakeConverter)
-    monkeypatch.setattr("marin.rl.rl_experiment_utils.is_hf_checkpoint", lambda _path: True)
-
-    lora_config = LoraConfig(r=16, alpha=32.0, target_modules=["q_proj", "v_proj"])
-    job_config = _build_rl_job_config(
-        name="rl-test",
-        config=_test_config(
-            train_tpu_type="v5p-8",
-            inference_tpu_type="v5p-8",
-            lora=lora_config,
-            rollout_policy_format="merged",
-        ),
-        curriculum=_test_curriculum(),
-        model_path="gs://marin-us-central1/models/test-model",
-        output_path="gs://marin-us-central1/rl_testing/rl-test",
-    )
-
-    assert job_config.train_params.lora == lora_config
-    assert job_config.rollout_policy_format == "merged"
-    assert job_config.adapter_artifacts_path == "gs://marin-us-central1/rl_testing/rl-test/adapter_artifacts"
-    assert job_config.merged_hf_export_path == "gs://marin-us-central1/rl_testing/rl-test/exports/merged"
-
-
 def test_build_rl_job_config_skips_default_adapter_export_for_non_hf_base(monkeypatch):
     class _FakeConverter:
         def __init__(self, *args, **kwargs):
@@ -365,36 +336,7 @@ def test_build_rl_job_config_skips_default_adapter_export_for_non_hf_base(monkey
     assert job_config.merged_hf_export_path == "gs://marin-us-central1/rl_testing/rl-test/exports/merged"
 
 
-def test_to_worker_configs_threads_manifest_fields_for_non_lora_runs(monkeypatch):
-    class _FakeConverter:
-        def __init__(self, *args, **kwargs):
-            self.default_hf_config = SimpleNamespace(vocab_size=32000)
-
-    monkeypatch.setattr("marin.rl.rl_experiment_utils._resolve_config_class", lambda _path: _FakeRuntimeLmConfig)
-    monkeypatch.setattr("marin.rl.rl_experiment_utils.HFCheckpointConverter", _FakeConverter)
-    monkeypatch.setattr("marin.rl.rl_experiment_utils.is_hf_checkpoint", lambda _path: True)
-    monkeypatch.setattr("marin.rl.job_config.make_tokenizer", lambda _tokenizer: SimpleNamespace(vocab_size=32000))
-
-    job_config = _build_rl_job_config(
-        name="rl-test",
-        config=_test_config(
-            train_tpu_type="v5p-8",
-            inference_tpu_type="v5p-8",
-        ),
-        curriculum=_test_curriculum(),
-        model_path="gs://marin-us-central1/models/test-model",
-        output_path="gs://marin-us-central1/rl_testing/rl-test",
-    )
-
-    train_worker_config, rollout_worker_config = RLJob(job_config).to_worker_configs()
-
-    assert train_worker_config.rollout_policy_format == "merged"
-    assert train_worker_config.run_manifest_path == "gs://marin-us-central1/rl_testing/rl-test/rl_run_manifest.json"
-    assert train_worker_config.inference_type == "vllm"
-    assert rollout_worker_config.rollout_policy_format == "merged"
-
-
-def test_to_worker_configs_threads_lora_fields(monkeypatch):
+def test_lora_job_config_reaches_worker_with_safe_export_paths(monkeypatch):
     class _FakeConverter:
         def __init__(self, *args, **kwargs):
             self.default_hf_config = SimpleNamespace(vocab_size=32000)
@@ -418,39 +360,21 @@ def test_to_worker_configs_threads_lora_fields(monkeypatch):
     )
 
     train_worker_config, rollout_worker_config = RLJob(job_config).to_worker_configs()
+    adapter_artifacts_path = train_worker_config.adapter_artifacts_path
+    merged_hf_export_path = train_worker_config.merged_hf_export_path
+    checkpointer_path = train_worker_config.trainer.checkpointer.base_path
 
     assert train_worker_config.lora == lora_config
     assert train_worker_config.rollout_policy_format == "merged"
     assert train_worker_config.run_manifest_path == "gs://marin-us-central1/rl_testing/rl-test/rl_run_manifest.json"
-    assert train_worker_config.adapter_artifacts_path == "gs://marin-us-central1/rl_testing/rl-test/adapter_artifacts"
-    assert train_worker_config.merged_hf_export_path == "gs://marin-us-central1/rl_testing/rl-test/exports/merged"
+    assert adapter_artifacts_path == "gs://marin-us-central1/rl_testing/rl-test/adapter_artifacts"
+    assert merged_hf_export_path == "gs://marin-us-central1/rl_testing/rl-test/exports/merged"
     assert train_worker_config.inference_type == "vllm"
     assert rollout_worker_config.rollout_policy_format == "merged"
-
-
-def test_export_paths_stay_distinct_from_resume_checkpoints(monkeypatch):
-    class _FakeConverter:
-        def __init__(self, *args, **kwargs):
-            self.default_hf_config = SimpleNamespace(vocab_size=32000)
-
-    monkeypatch.setattr("marin.rl.rl_experiment_utils._resolve_config_class", lambda _path: _FakeRuntimeLmConfig)
-    monkeypatch.setattr("marin.rl.rl_experiment_utils.HFCheckpointConverter", _FakeConverter)
-
-    job_config = _build_rl_job_config(
-        name="rl-test",
-        config=_test_config(
-            train_tpu_type="v5p-8",
-            inference_tpu_type="v5p-8",
-            lora=LoraConfig(r=8, alpha=16.0, target_modules=["q_proj"]),
-        ),
-        curriculum=_test_curriculum(),
-        model_path=MODEL_NAME,
-        output_path="gs://marin-us-central1/rl_testing/rl-test",
-    )
-
-    assert job_config.trainer.checkpointer.base_path == "gs://marin-us-central1/rl_testing/rl-test/checkpoints"
-    assert job_config.adapter_artifacts_path == "gs://marin-us-central1/rl_testing/rl-test/adapter_artifacts"
-    assert job_config.merged_hf_export_path == "gs://marin-us-central1/rl_testing/rl-test/exports/merged"
+    assert adapter_artifacts_path != checkpointer_path
+    assert merged_hf_export_path != checkpointer_path
+    assert not adapter_artifacts_path.startswith(f"{checkpointer_path}/")
+    assert not merged_hf_export_path.startswith(f"{checkpointer_path}/")
 
 
 def test_to_worker_configs_rejects_unimplemented_adapter_rollout_format(monkeypatch):
@@ -476,6 +400,7 @@ def test_to_worker_configs_rejects_unimplemented_adapter_rollout_format(monkeypa
 
     with pytest.raises(ValueError, match="rollout_policy_format='adapter' is not implemented yet"):
         RLJob(job_config).to_worker_configs()
+
 
 def test_run_rl_experiment_step_returns_serializable_path_metadata(monkeypatch):
     calls = {}

--- a/tests/rl/test_rl_experiment_utils.py
+++ b/tests/rl/test_rl_experiment_utils.py
@@ -365,7 +365,7 @@ def test_to_worker_configs_threads_manifest_fields_for_non_lora_runs(monkeypatch
     assert rollout_worker_config.rollout_policy_format == "merged"
 
 
-def test_to_worker_configs_rejects_lora_until_merged_rollout_sync_exists(monkeypatch):
+def test_to_worker_configs_threads_lora_fields(monkeypatch):
     class _FakeConverter:
         def __init__(self, *args, **kwargs):
             self.default_hf_config = SimpleNamespace(vocab_size=32000)
@@ -387,8 +387,13 @@ def test_to_worker_configs_rejects_lora_until_merged_rollout_sync_exists(monkeyp
         output_path="gs://marin-us-central1/rl_testing/rl-test",
     )
 
-    with pytest.raises(ValueError, match="LoRA RL rollout serving is not implemented yet"):
-        RLJob(job_config).to_worker_configs()
+    train_worker_config, rollout_worker_config = RLJob(job_config).to_worker_configs()
+
+    assert train_worker_config.lora == lora_config
+    assert train_worker_config.rollout_policy_format == "merged"
+    assert train_worker_config.run_manifest_path == "gs://marin-us-central1/rl_testing/rl-test/rl_run_manifest.json"
+    assert train_worker_config.inference_type == "vllm"
+    assert rollout_worker_config.rollout_policy_format == "merged"
 
 
 def test_to_worker_configs_rejects_unimplemented_adapter_rollout_format(monkeypatch):

--- a/tests/rl/test_rl_experiment_utils.py
+++ b/tests/rl/test_rl_experiment_utils.py
@@ -318,6 +318,7 @@ def test_build_rl_job_config_propagates_lora_and_rollout_policy_format(monkeypat
 
     monkeypatch.setattr("marin.rl.rl_experiment_utils._resolve_config_class", lambda _path: _FakeRuntimeLmConfig)
     monkeypatch.setattr("marin.rl.rl_experiment_utils.HFCheckpointConverter", _FakeConverter)
+    monkeypatch.setattr("marin.rl.rl_experiment_utils.is_hf_checkpoint", lambda _path: True)
 
     lora_config = LoraConfig(r=16, alpha=32.0, target_modules=["q_proj", "v_proj"])
     job_config = _build_rl_job_config(
@@ -335,6 +336,33 @@ def test_build_rl_job_config_propagates_lora_and_rollout_policy_format(monkeypat
 
     assert job_config.train_params.lora == lora_config
     assert job_config.rollout_policy_format == "merged"
+    assert job_config.adapter_artifacts_path == "gs://marin-us-central1/rl_testing/rl-test/adapter_artifacts"
+    assert job_config.merged_hf_export_path == "gs://marin-us-central1/rl_testing/rl-test/exports/merged"
+
+
+def test_build_rl_job_config_skips_default_adapter_export_for_non_hf_base(monkeypatch):
+    class _FakeConverter:
+        def __init__(self, *args, **kwargs):
+            self.default_hf_config = SimpleNamespace(vocab_size=32000)
+
+    monkeypatch.setattr("marin.rl.rl_experiment_utils._resolve_config_class", lambda _path: _FakeRuntimeLmConfig)
+    monkeypatch.setattr("marin.rl.rl_experiment_utils.HFCheckpointConverter", _FakeConverter)
+    monkeypatch.setattr("marin.rl.rl_experiment_utils.is_hf_checkpoint", lambda _path: False)
+
+    job_config = _build_rl_job_config(
+        name="rl-test",
+        config=_test_config(
+            train_tpu_type="v5p-8",
+            inference_tpu_type="v5p-8",
+            lora=LoraConfig(r=16, alpha=32.0, target_modules=["q_proj"]),
+        ),
+        curriculum=_test_curriculum(),
+        model_path="/tmp/checkpoints/run/step-10",
+        output_path="gs://marin-us-central1/rl_testing/rl-test",
+    )
+
+    assert job_config.adapter_artifacts_path is None
+    assert job_config.merged_hf_export_path == "gs://marin-us-central1/rl_testing/rl-test/exports/merged"
 
 
 def test_to_worker_configs_threads_manifest_fields_for_non_lora_runs(monkeypatch):
@@ -344,6 +372,7 @@ def test_to_worker_configs_threads_manifest_fields_for_non_lora_runs(monkeypatch
 
     monkeypatch.setattr("marin.rl.rl_experiment_utils._resolve_config_class", lambda _path: _FakeRuntimeLmConfig)
     monkeypatch.setattr("marin.rl.rl_experiment_utils.HFCheckpointConverter", _FakeConverter)
+    monkeypatch.setattr("marin.rl.rl_experiment_utils.is_hf_checkpoint", lambda _path: True)
     monkeypatch.setattr("marin.rl.job_config.make_tokenizer", lambda _tokenizer: SimpleNamespace(vocab_size=32000))
 
     job_config = _build_rl_job_config(
@@ -372,6 +401,7 @@ def test_to_worker_configs_threads_lora_fields(monkeypatch):
 
     monkeypatch.setattr("marin.rl.rl_experiment_utils._resolve_config_class", lambda _path: _FakeRuntimeLmConfig)
     monkeypatch.setattr("marin.rl.rl_experiment_utils.HFCheckpointConverter", _FakeConverter)
+    monkeypatch.setattr("marin.rl.rl_experiment_utils.is_hf_checkpoint", lambda _path: True)
     monkeypatch.setattr("marin.rl.job_config.make_tokenizer", lambda _tokenizer: SimpleNamespace(vocab_size=32000))
 
     lora_config = LoraConfig(r=8, alpha=16.0, target_modules=["q_proj"])
@@ -392,8 +422,35 @@ def test_to_worker_configs_threads_lora_fields(monkeypatch):
     assert train_worker_config.lora == lora_config
     assert train_worker_config.rollout_policy_format == "merged"
     assert train_worker_config.run_manifest_path == "gs://marin-us-central1/rl_testing/rl-test/rl_run_manifest.json"
+    assert train_worker_config.adapter_artifacts_path == "gs://marin-us-central1/rl_testing/rl-test/adapter_artifacts"
+    assert train_worker_config.merged_hf_export_path == "gs://marin-us-central1/rl_testing/rl-test/exports/merged"
     assert train_worker_config.inference_type == "vllm"
     assert rollout_worker_config.rollout_policy_format == "merged"
+
+
+def test_export_paths_stay_distinct_from_resume_checkpoints(monkeypatch):
+    class _FakeConverter:
+        def __init__(self, *args, **kwargs):
+            self.default_hf_config = SimpleNamespace(vocab_size=32000)
+
+    monkeypatch.setattr("marin.rl.rl_experiment_utils._resolve_config_class", lambda _path: _FakeRuntimeLmConfig)
+    monkeypatch.setattr("marin.rl.rl_experiment_utils.HFCheckpointConverter", _FakeConverter)
+
+    job_config = _build_rl_job_config(
+        name="rl-test",
+        config=_test_config(
+            train_tpu_type="v5p-8",
+            inference_tpu_type="v5p-8",
+            lora=LoraConfig(r=8, alpha=16.0, target_modules=["q_proj"]),
+        ),
+        curriculum=_test_curriculum(),
+        model_path=MODEL_NAME,
+        output_path="gs://marin-us-central1/rl_testing/rl-test",
+    )
+
+    assert job_config.trainer.checkpointer.base_path == "gs://marin-us-central1/rl_testing/rl-test/checkpoints"
+    assert job_config.adapter_artifacts_path == "gs://marin-us-central1/rl_testing/rl-test/adapter_artifacts"
+    assert job_config.merged_hf_export_path == "gs://marin-us-central1/rl_testing/rl-test/exports/merged"
 
 
 def test_to_worker_configs_rejects_unimplemented_adapter_rollout_format(monkeypatch):

--- a/tests/rl/test_rl_experiment_utils.py
+++ b/tests/rl/test_rl_experiment_utils.py
@@ -377,6 +377,37 @@ def test_lora_job_config_reaches_worker_with_safe_export_paths(monkeypatch):
     assert not merged_hf_export_path.startswith(f"{checkpointer_path}/")
 
 
+def test_default_run_manifest_paths_are_scoped_to_train_run_ids(monkeypatch):
+    class _FakeConverter:
+        def __init__(self, *args, **kwargs):
+            self.default_hf_config = SimpleNamespace(vocab_size=32000)
+
+    monkeypatch.setattr("marin.rl.rl_experiment_utils._resolve_config_class", lambda _path: _FakeRuntimeLmConfig)
+    monkeypatch.setattr("marin.rl.rl_experiment_utils.HFCheckpointConverter", _FakeConverter)
+    monkeypatch.setattr("marin.rl.job_config.make_tokenizer", lambda _tokenizer: SimpleNamespace(vocab_size=32000))
+
+    base_job_config = _build_rl_job_config(
+        name="rl-test",
+        config=_test_config(train_tpu_type="v5p-8", inference_tpu_type="v5p-8"),
+        curriculum=_test_curriculum(),
+        model_path=MODEL_NAME,
+        output_path="gs://marin-us-central1/rl_testing/rl-test",
+    )
+    first_job_config = dataclasses.replace(base_job_config, run_id="first-run", run_manifest_path=None)
+    second_job_config = dataclasses.replace(base_job_config, run_id="second-run", run_manifest_path=None)
+
+    first_train_config, _ = RLJob(first_job_config).to_worker_configs()
+    second_train_config, _ = RLJob(second_job_config).to_worker_configs()
+
+    assert first_train_config.run_manifest_path == (
+        "gs://marin-us-central1/rl_testing/rl-test/checkpoints/first-run-train/rl_run_manifest.json"
+    )
+    assert second_train_config.run_manifest_path == (
+        "gs://marin-us-central1/rl_testing/rl-test/checkpoints/second-run-train/rl_run_manifest.json"
+    )
+    assert first_train_config.run_manifest_path != second_train_config.run_manifest_path
+
+
 def test_to_worker_configs_rejects_unimplemented_adapter_rollout_format(monkeypatch):
     class _FakeConverter:
         def __init__(self, *args, **kwargs):

--- a/tests/rl/test_rl_experiment_utils.py
+++ b/tests/rl/test_rl_experiment_utils.py
@@ -5,6 +5,8 @@ import dataclasses
 from types import SimpleNamespace
 
 import pytest
+from levanter.checkpoint import CheckpointDebugConfig
+from levanter.adaptor.lora import LoraConfig
 from levanter.models.llama import LlamaConfig
 from marin.execution.artifact import PathMetadata
 from marin.execution.types import ExecutorStep, output_path_of
@@ -13,6 +15,7 @@ from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.model_utils import is_hf_checkpoint
 from marin.rl.rl_experiment_utils import (
     ModelConfig,
+    RLJob,
     RLExperimentConfig,
     RLStepConfig,
     _build_rl_job_config,
@@ -57,6 +60,13 @@ def _test_config(
     *,
     train_tpu_type: str,
     inference_tpu_type: str,
+    train_ram: str | None = None,
+    inference_ram: str | None = None,
+    zone: str | None = None,
+    keep_last_temporary_checkpoints: int = 5,
+    checkpoint_debug: CheckpointDebugConfig | None = None,
+    lora: LoraConfig | None = None,
+    rollout_policy_format: str = "merged",
 ) -> RLExperimentConfig:
     return RLExperimentConfig(
         model_config=ModelConfig(
@@ -76,8 +86,15 @@ def _test_config(
             vocab_tile_size=32064,
         ),
         experiment_name_suffix="test",
+        lora=lora,
+        rollout_policy_format=rollout_policy_format,
         train_tpu_type=train_tpu_type,
         inference_tpu_type=inference_tpu_type,
+        train_ram=train_ram,
+        inference_ram=inference_ram,
+        zone=zone,
+        keep_last_temporary_checkpoints=keep_last_temporary_checkpoints,
+        checkpoint_debug=checkpoint_debug or CheckpointDebugConfig(),
     )
 
 
@@ -181,6 +198,7 @@ def test_build_rl_job_config_resolves_runtime_output_paths(monkeypatch):
 
     assert job_config.trainer.checkpointer.base_path == "gs://marin-us-central1/rl_testing/rl-test/checkpoints"
     assert job_config.rollout_storage.path == "gs://marin-us-central1/rl_testing/rl-test/rollouts"
+    assert job_config.run_manifest_path == "gs://marin-us-central1/rl_testing/rl-test/rl_run_manifest.json"
     assert job_config.inference_config.engine.load_format == "runai_streamer"
     assert job_config.inference_config.engine.canonical_model_name == MODEL_NAME
 
@@ -230,6 +248,172 @@ def test_build_rl_job_config_uses_dummy_load_format_for_non_object_store_model_p
     assert job_config.inference_config.engine.load_format == "dummy"
     assert job_config.inference_config.engine.canonical_model_name == MODEL_NAME
 
+
+def test_build_rl_job_config_propagates_ram_overrides(monkeypatch):
+    class _FakeConverter:
+        def __init__(self, *args, **kwargs):
+            self.default_hf_config = SimpleNamespace(vocab_size=32000)
+
+    monkeypatch.setattr("marin.rl.rl_experiment_utils._resolve_config_class", lambda _path: _FakeRuntimeLmConfig)
+    monkeypatch.setattr("marin.rl.rl_experiment_utils.HFCheckpointConverter", _FakeConverter)
+
+    job_config = _build_rl_job_config(
+        name="rl-test",
+        config=_test_config(
+            train_tpu_type="v5p-8",
+            inference_tpu_type="v5p-8",
+            train_ram="300g",
+            inference_ram="300g",
+        ),
+        curriculum=_test_curriculum(),
+        model_path="gs://marin-us-central1/models/test-model",
+        output_path="gs://marin-us-central1/rl_testing/rl-test",
+    )
+
+    assert job_config.run_config.train_ram == "300g"
+    assert job_config.run_config.inference_ram == "300g"
+
+
+def test_build_rl_job_config_propagates_checkpoint_controls_and_instance_id(monkeypatch):
+    class _FakeConverter:
+        def __init__(self, *args, **kwargs):
+            self.default_hf_config = SimpleNamespace(vocab_size=32000)
+
+    monkeypatch.setattr("marin.rl.rl_experiment_utils._resolve_config_class", lambda _path: _FakeRuntimeLmConfig)
+    monkeypatch.setattr("marin.rl.rl_experiment_utils.HFCheckpointConverter", _FakeConverter)
+
+    job_config = _build_rl_job_config(
+        name="rl-test",
+        config=_test_config(
+            train_tpu_type="v5p-8",
+            inference_tpu_type="v5p-8",
+            zone="us-central1-b",
+            keep_last_temporary_checkpoints=0,
+            checkpoint_debug=CheckpointDebugConfig(
+                enabled=True,
+                log_interval=15.0,
+                dump_stacks_after=45.0,
+            ),
+        ),
+        curriculum=_test_curriculum(),
+        model_path="gs://marin-us-central1/models/test-model",
+        output_path="gs://marin-us-central1/rl_testing/rl-test",
+        instance_id="rl-test-instance",
+    )
+
+    assert job_config.instance_id == "rl-test-instance"
+    assert job_config.run_config.zone == "us-central1-b"
+    assert job_config.curriculum.actor_name == "curriculum-rl-test-instance"
+    assert job_config.weight_transfer.coordinator_name == "wt-coord-rl-test-instance"
+    assert job_config.trainer.checkpointer.keep_last_temporary_checkpoints == 0
+    assert job_config.trainer.checkpointer.debug.enabled
+    assert job_config.trainer.checkpointer.debug.log_interval == 15.0
+    assert job_config.trainer.checkpointer.debug.dump_stacks_after == 45.0
+
+
+def test_build_rl_job_config_propagates_lora_and_rollout_policy_format(monkeypatch):
+    class _FakeConverter:
+        def __init__(self, *args, **kwargs):
+            self.default_hf_config = SimpleNamespace(vocab_size=32000)
+
+    monkeypatch.setattr("marin.rl.rl_experiment_utils._resolve_config_class", lambda _path: _FakeRuntimeLmConfig)
+    monkeypatch.setattr("marin.rl.rl_experiment_utils.HFCheckpointConverter", _FakeConverter)
+
+    lora_config = LoraConfig(r=16, alpha=32.0, target_modules=["q_proj", "v_proj"])
+    job_config = _build_rl_job_config(
+        name="rl-test",
+        config=_test_config(
+            train_tpu_type="v5p-8",
+            inference_tpu_type="v5p-8",
+            lora=lora_config,
+            rollout_policy_format="merged",
+        ),
+        curriculum=_test_curriculum(),
+        model_path="gs://marin-us-central1/models/test-model",
+        output_path="gs://marin-us-central1/rl_testing/rl-test",
+    )
+
+    assert job_config.train_params.lora == lora_config
+    assert job_config.rollout_policy_format == "merged"
+
+
+def test_to_worker_configs_threads_manifest_fields_for_non_lora_runs(monkeypatch):
+    class _FakeConverter:
+        def __init__(self, *args, **kwargs):
+            self.default_hf_config = SimpleNamespace(vocab_size=32000)
+
+    monkeypatch.setattr("marin.rl.rl_experiment_utils._resolve_config_class", lambda _path: _FakeRuntimeLmConfig)
+    monkeypatch.setattr("marin.rl.rl_experiment_utils.HFCheckpointConverter", _FakeConverter)
+    monkeypatch.setattr("marin.rl.job_config.make_tokenizer", lambda _tokenizer: SimpleNamespace(vocab_size=32000))
+
+    job_config = _build_rl_job_config(
+        name="rl-test",
+        config=_test_config(
+            train_tpu_type="v5p-8",
+            inference_tpu_type="v5p-8",
+        ),
+        curriculum=_test_curriculum(),
+        model_path="gs://marin-us-central1/models/test-model",
+        output_path="gs://marin-us-central1/rl_testing/rl-test",
+    )
+
+    train_worker_config, rollout_worker_config = RLJob(job_config).to_worker_configs()
+
+    assert train_worker_config.rollout_policy_format == "merged"
+    assert train_worker_config.run_manifest_path == "gs://marin-us-central1/rl_testing/rl-test/rl_run_manifest.json"
+    assert train_worker_config.inference_type == "vllm"
+    assert rollout_worker_config.rollout_policy_format == "merged"
+
+
+def test_to_worker_configs_rejects_lora_until_merged_rollout_sync_exists(monkeypatch):
+    class _FakeConverter:
+        def __init__(self, *args, **kwargs):
+            self.default_hf_config = SimpleNamespace(vocab_size=32000)
+
+    monkeypatch.setattr("marin.rl.rl_experiment_utils._resolve_config_class", lambda _path: _FakeRuntimeLmConfig)
+    monkeypatch.setattr("marin.rl.rl_experiment_utils.HFCheckpointConverter", _FakeConverter)
+    monkeypatch.setattr("marin.rl.job_config.make_tokenizer", lambda _tokenizer: SimpleNamespace(vocab_size=32000))
+
+    lora_config = LoraConfig(r=8, alpha=16.0, target_modules=["q_proj"])
+    job_config = _build_rl_job_config(
+        name="rl-test",
+        config=_test_config(
+            train_tpu_type="v5p-8",
+            inference_tpu_type="v5p-8",
+            lora=lora_config,
+        ),
+        curriculum=_test_curriculum(),
+        model_path="gs://marin-us-central1/models/test-model",
+        output_path="gs://marin-us-central1/rl_testing/rl-test",
+    )
+
+    with pytest.raises(ValueError, match="LoRA RL rollout serving is not implemented yet"):
+        RLJob(job_config).to_worker_configs()
+
+
+def test_to_worker_configs_rejects_unimplemented_adapter_rollout_format(monkeypatch):
+    class _FakeConverter:
+        def __init__(self, *args, **kwargs):
+            self.default_hf_config = SimpleNamespace(vocab_size=32000)
+
+    monkeypatch.setattr("marin.rl.rl_experiment_utils._resolve_config_class", lambda _path: _FakeRuntimeLmConfig)
+    monkeypatch.setattr("marin.rl.rl_experiment_utils.HFCheckpointConverter", _FakeConverter)
+    monkeypatch.setattr("marin.rl.job_config.make_tokenizer", lambda _tokenizer: SimpleNamespace(vocab_size=32000))
+
+    job_config = dataclasses.replace(
+        _build_rl_job_config(
+            name="rl-test",
+            config=_test_config(train_tpu_type="v5p-8", inference_tpu_type="v5p-8"),
+            curriculum=_test_curriculum(),
+            model_path=MODEL_NAME,
+            output_path="gs://marin-us-central1/rl_testing/rl-test",
+        ),
+        tokenizer=SimpleNamespace(vocab_size=32000),
+        rollout_policy_format="adapter",
+    )
+
+    with pytest.raises(ValueError, match="rollout_policy_format='adapter' is not implemented yet"):
+        RLJob(job_config).to_worker_configs()
 
 def test_run_rl_experiment_step_returns_serializable_path_metadata(monkeypatch):
     calls = {}

--- a/tests/rl/test_rl_experiment_utils.py
+++ b/tests/rl/test_rl_experiment_utils.py
@@ -5,8 +5,8 @@ import dataclasses
 from types import SimpleNamespace
 
 import pytest
-from levanter.checkpoint import CheckpointDebugConfig
 from levanter.adaptor.lora import LoraConfig
+from levanter.checkpoint import CheckpointDebugConfig
 from levanter.models.llama import LlamaConfig
 from marin.execution.artifact import PathMetadata
 from marin.execution.types import ExecutorStep, output_path_of
@@ -15,8 +15,8 @@ from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.model_utils import is_hf_checkpoint
 from marin.rl.rl_experiment_utils import (
     ModelConfig,
-    RLJob,
     RLExperimentConfig,
+    RLJob,
     RLStepConfig,
     _build_rl_job_config,
     _run_rl_experiment_step,

--- a/tests/rl/test_train_worker.py
+++ b/tests/rl/test_train_worker.py
@@ -278,8 +278,10 @@ def test_train_uses_trainable_filter_for_lora_runs(monkeypatch):
     manifest_writes: list[bool] = []
     logged_summaries: list[dict[str, float | int]] = []
     served_weights: list[tuple[int, object]] = []
+    exported_models: list[object] = []
     merged_model = object()
     trainable_model = object()
+    eval_model = object()
 
     class _FakeReplayLoader:
         def __enter__(self):
@@ -311,8 +313,8 @@ def test_train_uses_trainable_filter_for_lora_runs(monkeypatch):
             return SimpleNamespace(step=0, model=model, trainable_model=trainable_model)
 
         def train(self, state, data_loader) -> None:
-            del data_loader
-            return SimpleNamespace(eval_model=state.model)
+            del state, data_loader
+            return SimpleNamespace(eval_model=eval_model)
 
     monkeypatch.setattr("marin.rl.train_worker.Trainer", _FakeTrainer)
     monkeypatch.setattr("marin.rl.train_worker.merge_lora_modules", lambda model: merged_model)
@@ -352,6 +354,7 @@ def test_train_uses_trainable_filter_for_lora_runs(monkeypatch):
     worker._wait_for_initial_rollouts = lambda *, weight_step: True
     worker._validate_run_manifest_for_resume = lambda trainer: None
     worker._write_run_manifest = lambda: manifest_writes.append(True)
+    worker._export_lora_artifacts = exported_models.append
     worker.stop = lambda: None
 
     worker.train()
@@ -359,6 +362,7 @@ def test_train_uses_trainable_filter_for_lora_runs(monkeypatch):
     assert manifest_writes == [True]
     assert initial_state_calls == [{"model": worker.initial_model, "is_trainable": "lora-filter"}]
     assert served_weights == [(-1, merged_model)]
+    assert exported_models == [eval_model]
     assert logged_summaries == [
         {"rollout_policy_format": "merged", "reference_mode": "base"},
         {"parameter_count": 12, "trainable_parameter_count": 3, "fraction_trainable": 0.25},
@@ -434,87 +438,6 @@ def test_export_lora_artifacts_requires_hf_compatible_base_for_adapter_export(mo
 
     with pytest.raises(ValueError, match="HF-compatible base checkpoint"):
         worker._export_lora_artifacts(object())
-
-
-def test_train_exports_lora_artifacts_after_training(monkeypatch):
-    exported_models: list[object] = []
-    eval_model = object()
-
-    class _FakeReplayLoader:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-    class _FakeTransferServer:
-        def serve_weights(self, weight_step: int, model: object) -> None:
-            del weight_step, model
-
-        def cleanup(self) -> None:
-            return None
-
-    class _FakeTrainer:
-        def __init__(self, *, config, optimizer, loss_fn):
-            del config, optimizer, loss_fn
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-        def initial_state(self, key, *, model, is_trainable):
-            del key, is_trainable
-            return SimpleNamespace(step=0, model=model, trainable_model=object())
-
-        def train(self, state, data_loader):
-            del state, data_loader
-            return SimpleNamespace(eval_model=eval_model)
-
-    monkeypatch.setattr("marin.rl.train_worker.Trainer", _FakeTrainer)
-    monkeypatch.setattr("marin.rl.train_worker.parameter_count", lambda model: 4 if model is eval_model else 16)
-    monkeypatch.setattr("marin.rl.train_worker.levanter.tracker.log_summary", lambda summary: None)
-
-    worker = TrainWorker.__new__(TrainWorker)
-    worker.config = SimpleNamespace(
-        run_id="lora-export-test",
-        trainer=SimpleNamespace(
-            checkpointer=SimpleNamespace(debug=SimpleNamespace(enabled=False)),
-            num_train_steps=10,
-            seed=0,
-        ),
-        optimizer=SimpleNamespace(build=lambda num_steps: object()),
-        weight_transfer=SimpleNamespace(debug_weight_transfer=False, sync_interval_steps=1),
-        lora=LoraConfig(r=8, alpha=16.0, target_modules=["q_proj"]),
-        rollout_policy_format="merged",
-        initial_checkpoint="hf://meta-llama/Llama-3.1-8B",
-        model={"name": "toy-model"},
-        inference_type="vllm",
-        run_manifest_path="/tmp/rl_run_manifest.json",
-    )
-    worker.loss_module = SimpleNamespace(create_loss_fn=lambda reference_model, _: lambda model, batch, key: 0.0)
-    worker.reference_model = object()
-    worker.initial_model = object()
-    worker.trainable_model_filter = "lora-filter"
-    worker.replay_buffer = SimpleNamespace(set_current_step=lambda step: None)
-    worker.replay_loader = _FakeReplayLoader()
-    worker.transfer_server = _FakeTransferServer()
-    worker.data_loader = object()
-    worker._runtime = SimpleNamespace(
-        run_state=SimpleNamespace(update_train_step=SimpleNamespace(remote=lambda step: None))
-    )
-    worker._drop_bootstrap_model_references = lambda: None
-    worker._configure_training_hooks = lambda trainer: None
-    worker._wait_for_initial_rollouts = lambda *, weight_step: True
-    worker._validate_run_manifest_for_resume = lambda trainer: None
-    worker._write_run_manifest = lambda: None
-    worker._export_lora_artifacts = exported_models.append
-    worker.stop = lambda: None
-
-    worker.train()
-
-    assert exported_models == [eval_model]
 
 
 def test_write_run_manifest_persists_expected_lora_metadata(tmp_path):

--- a/tests/rl/test_train_worker.py
+++ b/tests/rl/test_train_worker.py
@@ -1,9 +1,11 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 from types import SimpleNamespace
 
 import pytest
+from levanter.adaptor.lora import LoraConfig
 from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.rl_losses import RLOOLoss
 from marin.rl.train_worker import (
@@ -165,6 +167,7 @@ def test_train_bootstraps_fresh_run_with_step_minus_one(monkeypatch):
         ),
         optimizer=SimpleNamespace(build=lambda num_steps: object()),
         weight_transfer=SimpleNamespace(debug_weight_transfer=False, sync_interval_steps=1),
+        lora=None,
     )
     worker.loss_module = SimpleNamespace(create_loss_fn=lambda reference_model, _: lambda model, batch, key: 0.0)
     worker.reference_model = object()
@@ -243,6 +246,7 @@ def test_train_reuses_recovered_step_on_resume(monkeypatch):
         ),
         optimizer=SimpleNamespace(build=lambda num_steps: object()),
         weight_transfer=SimpleNamespace(debug_weight_transfer=False, sync_interval_steps=1),
+        lora=None,
     )
     worker.loss_module = SimpleNamespace(create_loss_fn=lambda reference_model, _: lambda model, batch, key: 0.0)
     worker.reference_model = object()
@@ -263,6 +267,111 @@ def test_train_reuses_recovered_step_on_resume(monkeypatch):
     assert published_steps == [68]
     assert served_weight_steps == [68]
     assert waited_weight_steps == [68]
+
+
+def test_train_uses_trainable_filter_for_lora_runs(monkeypatch):
+    initial_state_calls: list[dict[str, object]] = []
+    manifest_writes: list[bool] = []
+    logged_summaries: list[dict[str, float | int]] = []
+    trainable_model = object()
+
+    class _FakeReplayLoader:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    class _FakeTransferServer:
+        def serve_weights(self, weight_step: int, model: object) -> None:
+            del weight_step, model
+
+        def cleanup(self) -> None:
+            return None
+
+    class _FakeTrainer:
+        def __init__(self, *, config, optimizer, loss_fn):
+            del config, optimizer, loss_fn
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def initial_state(self, key, *, model, is_trainable):
+            del key
+            initial_state_calls.append({"model": model, "is_trainable": is_trainable})
+            return SimpleNamespace(step=0, model=model, trainable_model=trainable_model)
+
+        def train(self, state, data_loader) -> None:
+            del state, data_loader
+
+    monkeypatch.setattr("marin.rl.train_worker.Trainer", _FakeTrainer)
+    monkeypatch.setattr("marin.rl.train_worker.parameter_count", lambda model: 3 if model is trainable_model else 12)
+    monkeypatch.setattr("marin.rl.train_worker.levanter.tracker.log_summary", logged_summaries.append)
+
+    worker = TrainWorker.__new__(TrainWorker)
+    worker.config = SimpleNamespace(
+        run_id="lora-test",
+        trainer=SimpleNamespace(
+            checkpointer=SimpleNamespace(debug=SimpleNamespace(enabled=False)),
+            num_train_steps=10,
+            seed=0,
+        ),
+        optimizer=SimpleNamespace(build=lambda num_steps: object()),
+        weight_transfer=SimpleNamespace(debug_weight_transfer=False, sync_interval_steps=1),
+        lora=LoraConfig(r=8, alpha=16.0, target_modules=["q_proj"]),
+    )
+    worker.loss_module = SimpleNamespace(create_loss_fn=lambda reference_model, _: lambda model, batch, key: 0.0)
+    worker.reference_model = object()
+    worker.initial_model = object()
+    worker.trainable_model_filter = "lora-filter"
+    worker.replay_buffer = SimpleNamespace(set_current_step=lambda step: None)
+    worker.replay_loader = _FakeReplayLoader()
+    worker.transfer_server = _FakeTransferServer()
+    worker.data_loader = object()
+    worker._runtime = SimpleNamespace(
+        run_state=SimpleNamespace(update_train_step=SimpleNamespace(remote=lambda step: None))
+    )
+    worker._drop_bootstrap_model_references = lambda: None
+    worker._configure_training_hooks = lambda trainer: None
+    worker._wait_for_initial_rollouts = lambda *, weight_step: True
+    worker._write_run_manifest = lambda: manifest_writes.append(True)
+    worker.stop = lambda: None
+
+    worker.train()
+
+    assert manifest_writes == [True]
+    assert initial_state_calls == [{"model": worker.initial_model, "is_trainable": "lora-filter"}]
+    assert logged_summaries == [{"parameter_count": 12, "trainable_parameter_count": 3, "fraction_trainable": 0.25}]
+
+
+def test_write_run_manifest_persists_expected_lora_metadata(tmp_path):
+    manifest_path = tmp_path / "artifacts" / "rl_run_manifest.json"
+
+    worker = TrainWorker.__new__(TrainWorker)
+    worker.config = SimpleNamespace(
+        initial_checkpoint="hf://meta-llama/Llama-3.1-8B",
+        model={"name": "toy-model", "hidden_dim": 128},
+        lora=LoraConfig(r=8, alpha=16.0, target_modules=["q_proj", "v_proj"]),
+        rollout_policy_format="merged",
+        inference_type="vllm",
+        run_manifest_path=str(manifest_path),
+    )
+
+    worker._write_run_manifest()
+
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["manifest_version"] == 1
+    assert manifest["initial_checkpoint"] == "hf://meta-llama/Llama-3.1-8B"
+    assert manifest["rollout_policy_format"] == "merged"
+    assert manifest["reference_mode"] == "base"
+    assert manifest["inference_type"] == "vllm"
+    assert manifest["lora_config"]["r"] == 8
+    assert manifest["lora_config"]["alpha"] == 16.0
+    assert manifest["lora_config"]["target_modules"] == ["q_proj", "v_proj"]
+    assert manifest["lora_config_fingerprint"] is not None
 
 
 def test_resume_safe_weight_transfer_metrics_counts_bootstrap_and_sync_hooks():

--- a/tests/rl/test_train_worker.py
+++ b/tests/rl/test_train_worker.py
@@ -156,6 +156,7 @@ def test_train_bootstraps_fresh_run_with_step_minus_one(monkeypatch):
 
         def train(self, state, data_loader) -> None:
             del state, data_loader
+            return SimpleNamespace(eval_model=object())
 
     monkeypatch.setattr("marin.rl.train_worker.Trainer", _FakeTrainer)
 
@@ -235,6 +236,7 @@ def test_train_reuses_recovered_step_on_resume(monkeypatch):
 
         def train(self, state, data_loader) -> None:
             del state, data_loader
+            return SimpleNamespace(eval_model=object())
 
     monkeypatch.setattr("marin.rl.train_worker.Trainer", _FakeTrainer)
 
@@ -309,7 +311,8 @@ def test_train_uses_trainable_filter_for_lora_runs(monkeypatch):
             return SimpleNamespace(step=0, model=model, trainable_model=trainable_model)
 
         def train(self, state, data_loader) -> None:
-            del state, data_loader
+            del data_loader
+            return SimpleNamespace(eval_model=state.model)
 
     monkeypatch.setattr("marin.rl.train_worker.Trainer", _FakeTrainer)
     monkeypatch.setattr("marin.rl.train_worker.merge_lora_modules", lambda model: merged_model)
@@ -360,6 +363,158 @@ def test_train_uses_trainable_filter_for_lora_runs(monkeypatch):
         {"rollout_policy_format": "merged", "reference_mode": "base"},
         {"parameter_count": 12, "trainable_parameter_count": 3, "fraction_trainable": 0.25},
     ]
+
+
+def test_export_lora_artifacts_uses_expected_paths_and_helpers(monkeypatch):
+    exported_calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+    logged_summaries: list[dict[str, str]] = []
+
+    def _record_adapter_export(*args, **kwargs):
+        exported_calls.append(("adapter", args, kwargs))
+
+    def _record_merged_export(*args, **kwargs):
+        exported_calls.append(("merged", args, kwargs))
+
+    worker = TrainWorker.__new__(TrainWorker)
+    worker.config = SimpleNamespace(
+        lora=LoraConfig(r=8, alpha=16.0, target_modules=["q_proj"]),
+        initial_checkpoint="hf://meta-llama/Llama-3.1-8B",
+        adapter_artifacts_path="gs://marin-us-central1/rl/adapter_artifacts",
+        merged_hf_export_path="gs://marin-us-central1/rl/exports/merged",
+    )
+    worker.tokenizer = object()
+    worker._hf_export_converter = lambda: "converter"
+
+    monkeypatch.setattr("marin.rl.train_worker.save_peft_pretrained", _record_adapter_export)
+    monkeypatch.setattr("marin.rl.train_worker.save_merged_hf_model", _record_merged_export)
+    monkeypatch.setattr("marin.rl.train_worker.levanter.tracker.log_summary", logged_summaries.append)
+
+    model = object()
+    worker._export_lora_artifacts(model)
+
+    assert exported_calls == [
+        (
+            "adapter",
+            (
+                model,
+                worker.config.lora,
+                "hf://meta-llama/Llama-3.1-8B",
+                "gs://marin-us-central1/rl/adapter_artifacts/final",
+            ),
+            {"tokenizer": worker.tokenizer},
+        ),
+        (
+            "merged",
+            (
+                model,
+                "converter",
+                "gs://marin-us-central1/rl/exports/merged/final",
+            ),
+            {},
+        ),
+    ]
+    assert logged_summaries == [
+        {
+            "adapter_artifacts_path": "gs://marin-us-central1/rl/adapter_artifacts/final",
+            "merged_hf_export_path": "gs://marin-us-central1/rl/exports/merged/final",
+        }
+    ]
+
+
+def test_export_lora_artifacts_requires_hf_compatible_base_for_adapter_export(monkeypatch):
+    worker = TrainWorker.__new__(TrainWorker)
+    worker.config = SimpleNamespace(
+        lora=LoraConfig(r=8, alpha=16.0, target_modules=["q_proj"]),
+        initial_checkpoint="/tmp/checkpoints/run/step-10",
+        adapter_artifacts_path="gs://marin-us-central1/rl/adapter_artifacts",
+        merged_hf_export_path=None,
+    )
+
+    monkeypatch.setattr("marin.rl.train_worker.is_hf_checkpoint", lambda path: False)
+
+    with pytest.raises(ValueError, match="HF-compatible base checkpoint"):
+        worker._export_lora_artifacts(object())
+
+
+def test_train_exports_lora_artifacts_after_training(monkeypatch):
+    exported_models: list[object] = []
+    eval_model = object()
+
+    class _FakeReplayLoader:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    class _FakeTransferServer:
+        def serve_weights(self, weight_step: int, model: object) -> None:
+            del weight_step, model
+
+        def cleanup(self) -> None:
+            return None
+
+    class _FakeTrainer:
+        def __init__(self, *, config, optimizer, loss_fn):
+            del config, optimizer, loss_fn
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def initial_state(self, key, *, model, is_trainable):
+            del key, is_trainable
+            return SimpleNamespace(step=0, model=model, trainable_model=object())
+
+        def train(self, state, data_loader):
+            del state, data_loader
+            return SimpleNamespace(eval_model=eval_model)
+
+    monkeypatch.setattr("marin.rl.train_worker.Trainer", _FakeTrainer)
+    monkeypatch.setattr("marin.rl.train_worker.parameter_count", lambda model: 4 if model is eval_model else 16)
+    monkeypatch.setattr("marin.rl.train_worker.levanter.tracker.log_summary", lambda summary: None)
+
+    worker = TrainWorker.__new__(TrainWorker)
+    worker.config = SimpleNamespace(
+        run_id="lora-export-test",
+        trainer=SimpleNamespace(
+            checkpointer=SimpleNamespace(debug=SimpleNamespace(enabled=False)),
+            num_train_steps=10,
+            seed=0,
+        ),
+        optimizer=SimpleNamespace(build=lambda num_steps: object()),
+        weight_transfer=SimpleNamespace(debug_weight_transfer=False, sync_interval_steps=1),
+        lora=LoraConfig(r=8, alpha=16.0, target_modules=["q_proj"]),
+        rollout_policy_format="merged",
+        initial_checkpoint="hf://meta-llama/Llama-3.1-8B",
+        model={"name": "toy-model"},
+        inference_type="vllm",
+        run_manifest_path="/tmp/rl_run_manifest.json",
+    )
+    worker.loss_module = SimpleNamespace(create_loss_fn=lambda reference_model, _: lambda model, batch, key: 0.0)
+    worker.reference_model = object()
+    worker.initial_model = object()
+    worker.trainable_model_filter = "lora-filter"
+    worker.replay_buffer = SimpleNamespace(set_current_step=lambda step: None)
+    worker.replay_loader = _FakeReplayLoader()
+    worker.transfer_server = _FakeTransferServer()
+    worker.data_loader = object()
+    worker._runtime = SimpleNamespace(
+        run_state=SimpleNamespace(update_train_step=SimpleNamespace(remote=lambda step: None))
+    )
+    worker._drop_bootstrap_model_references = lambda: None
+    worker._configure_training_hooks = lambda trainer: None
+    worker._wait_for_initial_rollouts = lambda *, weight_step: True
+    worker._validate_run_manifest_for_resume = lambda trainer: None
+    worker._write_run_manifest = lambda: None
+    worker._export_lora_artifacts = exported_models.append
+    worker.stop = lambda: None
+
+    worker.train()
+
+    assert exported_models == [eval_model]
 
 
 def test_write_run_manifest_persists_expected_lora_metadata(tmp_path):

--- a/tests/rl/test_train_worker.py
+++ b/tests/rl/test_train_worker.py
@@ -2,13 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
-import json
 from types import SimpleNamespace
 
 import pytest
 from levanter.adaptor.lora import LoraConfig
 from marin.rl.kl_regularization import KLConfig, KLMode
-from marin.rl.lora_manifest import build_rl_run_manifest
+from marin.rl.lora_manifest import build_rl_run_manifest, read_rl_run_manifest
 from marin.rl.rl_losses import RLOOLoss
 from marin.rl.train_worker import (
     BatchPrepTiming,
@@ -455,16 +454,7 @@ def test_write_run_manifest_persists_expected_lora_metadata(tmp_path):
 
     worker._write_run_manifest()
 
-    manifest = json.loads(manifest_path.read_text())
-    assert manifest["manifest_version"] == 1
-    assert manifest["initial_checkpoint"] == "hf://meta-llama/Llama-3.1-8B"
-    assert manifest["rollout_policy_format"] == "merged"
-    assert manifest["reference_mode"] == "base"
-    assert manifest["inference_type"] == "vllm"
-    assert manifest["lora_config"]["r"] == 8
-    assert manifest["lora_config"]["alpha"] == 16.0
-    assert manifest["lora_config"]["target_modules"] == ["q_proj", "v_proj"]
-    assert manifest["lora_config_fingerprint"] is not None
+    assert read_rl_run_manifest(str(manifest_path)) == worker._expected_run_manifest()
 
 
 def test_validate_run_manifest_for_resume_accepts_matching_manifest(monkeypatch):

--- a/tests/rl/test_train_worker.py
+++ b/tests/rl/test_train_worker.py
@@ -1,12 +1,14 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
 import json
 from types import SimpleNamespace
 
 import pytest
 from levanter.adaptor.lora import LoraConfig
 from marin.rl.kl_regularization import KLConfig, KLMode
+from marin.rl.lora_manifest import build_rl_run_manifest
 from marin.rl.rl_losses import RLOOLoss
 from marin.rl.train_worker import (
     BatchPrepTiming,
@@ -273,6 +275,8 @@ def test_train_uses_trainable_filter_for_lora_runs(monkeypatch):
     initial_state_calls: list[dict[str, object]] = []
     manifest_writes: list[bool] = []
     logged_summaries: list[dict[str, float | int]] = []
+    served_weights: list[tuple[int, object]] = []
+    merged_model = object()
     trainable_model = object()
 
     class _FakeReplayLoader:
@@ -284,7 +288,7 @@ def test_train_uses_trainable_filter_for_lora_runs(monkeypatch):
 
     class _FakeTransferServer:
         def serve_weights(self, weight_step: int, model: object) -> None:
-            del weight_step, model
+            served_weights.append((weight_step, model))
 
         def cleanup(self) -> None:
             return None
@@ -308,6 +312,7 @@ def test_train_uses_trainable_filter_for_lora_runs(monkeypatch):
             del state, data_loader
 
     monkeypatch.setattr("marin.rl.train_worker.Trainer", _FakeTrainer)
+    monkeypatch.setattr("marin.rl.train_worker.merge_lora_modules", lambda model: merged_model)
     monkeypatch.setattr("marin.rl.train_worker.parameter_count", lambda model: 3 if model is trainable_model else 12)
     monkeypatch.setattr("marin.rl.train_worker.levanter.tracker.log_summary", logged_summaries.append)
 
@@ -322,6 +327,11 @@ def test_train_uses_trainable_filter_for_lora_runs(monkeypatch):
         optimizer=SimpleNamespace(build=lambda num_steps: object()),
         weight_transfer=SimpleNamespace(debug_weight_transfer=False, sync_interval_steps=1),
         lora=LoraConfig(r=8, alpha=16.0, target_modules=["q_proj"]),
+        rollout_policy_format="merged",
+        initial_checkpoint="hf://meta-llama/Llama-3.1-8B",
+        model={"name": "toy-model"},
+        inference_type="vllm",
+        run_manifest_path="/tmp/rl_run_manifest.json",
     )
     worker.loss_module = SimpleNamespace(create_loss_fn=lambda reference_model, _: lambda model, batch, key: 0.0)
     worker.reference_model = object()
@@ -337,6 +347,7 @@ def test_train_uses_trainable_filter_for_lora_runs(monkeypatch):
     worker._drop_bootstrap_model_references = lambda: None
     worker._configure_training_hooks = lambda trainer: None
     worker._wait_for_initial_rollouts = lambda *, weight_step: True
+    worker._validate_run_manifest_for_resume = lambda trainer: None
     worker._write_run_manifest = lambda: manifest_writes.append(True)
     worker.stop = lambda: None
 
@@ -344,7 +355,11 @@ def test_train_uses_trainable_filter_for_lora_runs(monkeypatch):
 
     assert manifest_writes == [True]
     assert initial_state_calls == [{"model": worker.initial_model, "is_trainable": "lora-filter"}]
-    assert logged_summaries == [{"parameter_count": 12, "trainable_parameter_count": 3, "fraction_trainable": 0.25}]
+    assert served_weights == [(-1, merged_model)]
+    assert logged_summaries == [
+        {"rollout_policy_format": "merged", "reference_mode": "base"},
+        {"parameter_count": 12, "trainable_parameter_count": 3, "fraction_trainable": 0.25},
+    ]
 
 
 def test_write_run_manifest_persists_expected_lora_metadata(tmp_path):
@@ -372,6 +387,100 @@ def test_write_run_manifest_persists_expected_lora_metadata(tmp_path):
     assert manifest["lora_config"]["alpha"] == 16.0
     assert manifest["lora_config"]["target_modules"] == ["q_proj", "v_proj"]
     assert manifest["lora_config_fingerprint"] is not None
+
+
+def test_validate_run_manifest_for_resume_accepts_matching_manifest(monkeypatch):
+    worker = TrainWorker.__new__(TrainWorker)
+    worker.config = SimpleNamespace(
+        initial_checkpoint="hf://meta-llama/Llama-3.1-8B",
+        model={"name": "toy-model", "hidden_dim": 128},
+        lora=LoraConfig(r=8, alpha=16.0, target_modules=["q_proj", "v_proj"]),
+        rollout_policy_format="merged",
+        inference_type="vllm",
+        run_manifest_path="/tmp/rl_run_manifest.json",
+    )
+    trainer = SimpleNamespace(
+        config=SimpleNamespace(load_checkpoint=None, initialize_from=None),
+        checkpoint_path="/tmp/checkpoints/run",
+    )
+    manifest = build_rl_run_manifest(
+        initial_checkpoint=worker.config.initial_checkpoint,
+        model_config=worker.config.model,
+        lora_config=worker.config.lora,
+        rollout_policy_format=worker.config.rollout_policy_format,
+        inference_type=worker.config.inference_type,
+    )
+
+    monkeypatch.setattr("marin.rl.train_worker.discover_latest_checkpoint", lambda path: f"{path}/step_10")
+    monkeypatch.setattr("marin.rl.train_worker.read_rl_run_manifest", lambda path: manifest)
+
+    worker._validate_run_manifest_for_resume(trainer)
+
+
+@pytest.mark.parametrize(
+    ("manifest_overrides", "field_name"),
+    [
+        ({"initial_checkpoint": "hf://meta-llama/Llama-3.1-70B"}, "initial_checkpoint"),
+        ({"model_config_fingerprint": "deadbeefdeadbeef"}, "model_config_fingerprint"),
+        ({"lora_config_fingerprint": "cafebabecafebabe"}, "lora_config_fingerprint"),
+        ({"inference_type": "levanter"}, "inference_type"),
+        ({"rollout_policy_format": "adapter"}, "rollout_policy_format"),
+        ({"reference_mode": "adapter"}, "reference_mode"),
+    ],
+)
+def test_validate_run_manifest_for_resume_rejects_mismatches(monkeypatch, manifest_overrides, field_name):
+    worker = TrainWorker.__new__(TrainWorker)
+    worker.config = SimpleNamespace(
+        initial_checkpoint="hf://meta-llama/Llama-3.1-8B",
+        model={"name": "toy-model", "hidden_dim": 128},
+        lora=LoraConfig(r=8, alpha=16.0, target_modules=["q_proj", "v_proj"]),
+        rollout_policy_format="merged",
+        inference_type="vllm",
+        run_manifest_path="/tmp/rl_run_manifest.json",
+    )
+    trainer = SimpleNamespace(
+        config=SimpleNamespace(load_checkpoint=None, initialize_from=None),
+        checkpoint_path="/tmp/checkpoints/run",
+    )
+    expected_manifest = build_rl_run_manifest(
+        initial_checkpoint=worker.config.initial_checkpoint,
+        model_config=worker.config.model,
+        lora_config=worker.config.lora,
+        rollout_policy_format=worker.config.rollout_policy_format,
+        inference_type=worker.config.inference_type,
+    )
+    manifest = dataclasses.replace(expected_manifest, **manifest_overrides)
+
+    monkeypatch.setattr("marin.rl.train_worker.discover_latest_checkpoint", lambda path: f"{path}/step_10")
+    monkeypatch.setattr("marin.rl.train_worker.read_rl_run_manifest", lambda path: manifest)
+
+    with pytest.raises(ValueError, match=field_name):
+        worker._validate_run_manifest_for_resume(trainer)
+
+
+def test_validate_run_manifest_for_resume_requires_manifest(monkeypatch):
+    worker = TrainWorker.__new__(TrainWorker)
+    worker.config = SimpleNamespace(
+        initial_checkpoint="hf://meta-llama/Llama-3.1-8B",
+        model={"name": "toy-model", "hidden_dim": 128},
+        lora=LoraConfig(r=8, alpha=16.0, target_modules=["q_proj", "v_proj"]),
+        rollout_policy_format="merged",
+        inference_type="vllm",
+        run_manifest_path="/tmp/rl_run_manifest.json",
+    )
+    trainer = SimpleNamespace(
+        config=SimpleNamespace(load_checkpoint=None, initialize_from=None),
+        checkpoint_path="/tmp/checkpoints/run",
+    )
+
+    monkeypatch.setattr("marin.rl.train_worker.discover_latest_checkpoint", lambda path: f"{path}/step_10")
+    monkeypatch.setattr(
+        "marin.rl.train_worker.read_rl_run_manifest",
+        lambda path: (_ for _ in ()).throw(FileNotFoundError(path)),
+    )
+
+    with pytest.raises(ValueError, match="requires run manifest"):
+        worker._validate_run_manifest_for_resume(trainer)
 
 
 def test_resume_safe_weight_transfer_metrics_counts_bootstrap_and_sync_hooks():
@@ -439,6 +548,40 @@ def test_weight_transfer_hook_logs_global_and_attempt_metrics(monkeypatch):
     assert metrics["weight_transfer/total_transfers"] == 69
     assert metrics["weight_transfer/successful_transfers"] == 69
     assert metrics["weight_transfer/serve_time_seconds"] == 0.0
+
+
+def test_weight_transfer_hook_merges_lora_weights_before_serving(monkeypatch):
+    served_weights: list[tuple[int, object]] = []
+    merged_model = object()
+
+    class _FakeTransferServer:
+        def serve_weights(self, weight_id: int, model: object) -> None:
+            served_weights.append((weight_id, model))
+
+        def get_metrics(self) -> WeightTransferServerMetrics:
+            return WeightTransferServerMetrics(total_transfers=8, successful_transfers=8, failed_transfers=0)
+
+    class _FakeTracker:
+        def log(self, metrics: dict[str, float | int], *, step: int) -> None:
+            del metrics, step
+
+    monkeypatch.setattr("marin.rl.train_worker.merge_lora_modules", lambda model: merged_model)
+    monkeypatch.setattr("marin.rl.train_worker.time.time", lambda: 100.0)
+
+    worker = TrainWorker.__new__(TrainWorker)
+    worker.config = SimpleNamespace(
+        lora=LoraConfig(r=8, alpha=16.0, target_modules=["q_proj"]),
+        rollout_policy_format="merged",
+        weight_transfer=SimpleNamespace(sync_interval_steps=1),
+    )
+    worker.transfer_server = _FakeTransferServer()
+
+    trainer = SimpleNamespace(tracker=_FakeTracker())
+    info = SimpleNamespace(step=67, state=SimpleNamespace(model=object()), loss=1.23)
+
+    worker.weight_transfer_hook(trainer, info)
+
+    assert served_weights == [(67, merged_model)]
 
 
 def test_checkpoint_debug_snapshot_includes_replay_buffer_and_transfer_state():

--- a/tests/rl/test_train_worker.py
+++ b/tests/rl/test_train_worker.py
@@ -469,7 +469,7 @@ def test_validate_run_manifest_for_resume_accepts_matching_manifest(monkeypatch)
     )
     trainer = SimpleNamespace(
         config=SimpleNamespace(load_checkpoint=None, initialize_from=None),
-        checkpoint_path="/tmp/checkpoints/run",
+        checkpoint_search_paths=["/tmp/checkpoints/run"],
     )
     manifest = build_rl_run_manifest(
         initial_checkpoint=worker.config.initial_checkpoint,
@@ -479,7 +479,7 @@ def test_validate_run_manifest_for_resume_accepts_matching_manifest(monkeypatch)
         inference_type=worker.config.inference_type,
     )
 
-    monkeypatch.setattr("marin.rl.train_worker.discover_latest_checkpoint", lambda path: f"{path}/step_10")
+    monkeypatch.setattr("marin.rl.train_worker.discover_latest_checkpoint", lambda *paths: f"{paths[0]}/step_10")
     monkeypatch.setattr("marin.rl.train_worker.read_rl_run_manifest", lambda path: manifest)
 
     worker._validate_run_manifest_for_resume(trainer)
@@ -508,7 +508,7 @@ def test_validate_run_manifest_for_resume_rejects_mismatches(monkeypatch, manife
     )
     trainer = SimpleNamespace(
         config=SimpleNamespace(load_checkpoint=None, initialize_from=None),
-        checkpoint_path="/tmp/checkpoints/run",
+        checkpoint_search_paths=["/tmp/checkpoints/run"],
     )
     expected_manifest = build_rl_run_manifest(
         initial_checkpoint=worker.config.initial_checkpoint,
@@ -519,10 +519,41 @@ def test_validate_run_manifest_for_resume_rejects_mismatches(monkeypatch, manife
     )
     manifest = dataclasses.replace(expected_manifest, **manifest_overrides)
 
-    monkeypatch.setattr("marin.rl.train_worker.discover_latest_checkpoint", lambda path: f"{path}/step_10")
+    monkeypatch.setattr("marin.rl.train_worker.discover_latest_checkpoint", lambda *paths: f"{paths[0]}/step_10")
     monkeypatch.setattr("marin.rl.train_worker.read_rl_run_manifest", lambda path: manifest)
 
     with pytest.raises(ValueError, match=field_name):
+        worker._validate_run_manifest_for_resume(trainer)
+
+
+def test_validate_run_manifest_for_resume_checks_initialize_from_when_checkpoint_auto_detects_empty(monkeypatch):
+    worker = TrainWorker.__new__(TrainWorker)
+    worker.config = SimpleNamespace(
+        initial_checkpoint="hf://meta-llama/Llama-3.1-8B",
+        model={"name": "toy-model", "hidden_dim": 128},
+        lora=LoraConfig(r=8, alpha=16.0, target_modules=["q_proj", "v_proj"]),
+        rollout_policy_format="merged",
+        inference_type="vllm",
+        run_manifest_path="/tmp/rl_run_manifest.json",
+    )
+    trainer = SimpleNamespace(
+        config=SimpleNamespace(load_checkpoint=None, initialize_from="/tmp/source-run/step_10"),
+        checkpoint_search_paths=["/tmp/current-run"],
+    )
+    expected_manifest = build_rl_run_manifest(
+        initial_checkpoint=worker.config.initial_checkpoint,
+        model_config=worker.config.model,
+        lora_config=worker.config.lora,
+        rollout_policy_format=worker.config.rollout_policy_format,
+        inference_type=worker.config.inference_type,
+    )
+    manifest = dataclasses.replace(expected_manifest, lora_config_fingerprint="cafebabecafebabe")
+
+    monkeypatch.setattr("marin.rl.train_worker.discover_latest_checkpoint", lambda *paths: None)
+    monkeypatch.setattr("marin.rl.train_worker.is_checkpoint_path", lambda path: path == "/tmp/source-run/step_10")
+    monkeypatch.setattr("marin.rl.train_worker.read_rl_run_manifest", lambda path: manifest)
+
+    with pytest.raises(ValueError, match="lora_config_fingerprint"):
         worker._validate_run_manifest_for_resume(trainer)
 
 
@@ -538,10 +569,10 @@ def test_validate_run_manifest_for_resume_requires_manifest(monkeypatch):
     )
     trainer = SimpleNamespace(
         config=SimpleNamespace(load_checkpoint=None, initialize_from=None),
-        checkpoint_path="/tmp/checkpoints/run",
+        checkpoint_search_paths=["/tmp/checkpoints/run"],
     )
 
-    monkeypatch.setattr("marin.rl.train_worker.discover_latest_checkpoint", lambda path: f"{path}/step_10")
+    monkeypatch.setattr("marin.rl.train_worker.discover_latest_checkpoint", lambda *paths: f"{paths[0]}/step_10")
     monkeypatch.setattr(
         "marin.rl.train_worker.read_rl_run_manifest",
         lambda path: (_ for _ in ()).throw(FileNotFoundError(path)),


### PR DESCRIPTION
Enable zero-preserving Levanter LoRA init, adapter-only RL training, merged rollout weight serving, and final adapter and merged exports. Keep trainer resume checkpoints distinct from user-facing artifacts and validate the full path with RL and Levanter coverage.