### PR TITLE
[iris] Make checkpoint fully concurrent; trim task_resource_history retention

### DIFF
--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -2369,17 +2369,20 @@ class Controller:
         return result
 
     def begin_checkpoint(self) -> tuple[str, CheckpointResult]:
-        """Pause loops and write a consistent SQLite checkpoint copy."""
+        """Write a consistent SQLite checkpoint copy.
+
+        The backup runs through a dedicated read-only source connection
+        (see ``ControllerDB.backup_to``), so writers proceed concurrently
+        under WAL semantics. Heartbeat rounds apply their updates as
+        atomic batches, so each SQLite snapshot already captures a
+        consistent state without needing the heartbeat lock.
+        """
         if self._config.dry_run:
             logger.info("[DRY-RUN] Skipping checkpoint write")
             return ("dry-run", CheckpointResult(created_at=Timestamp.now(), job_count=0, task_count=0, worker_count=0))
         self._checkpoint_paused.set()
         try:
-            # Hold the heartbeat lock only for the SQLite backup (consistent
-            # snapshot). Compression and GCS upload run outside the lock so
-            # heartbeat processing is not blocked for 5-30s.
-            with self._heartbeat_lock:
-                backup = backup_databases(self._db)
+            backup = backup_databases(self._db)
             try:
                 path, result = upload_checkpoint(self._db, backup, self._config.remote_state_dir)
             finally:

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -1124,15 +1124,12 @@ class Controller:
         # are only valid before the controller loops begin (e.g. LoadCheckpoint).
         self._started = False
 
-        # Checkpoint coordination: when set, scheduling and autoscaler loops
-        # skip their work so the snapshot captures a quiescent state.
-        # threading.Event (not a bare bool) for cross-thread memory ordering.
-        self._checkpoint_paused = threading.Event()
         self._atexit_registered = False
 
-        # Serializes heartbeat rounds against checkpoint snapshots so that
-        # begin_checkpoint cannot fire while dispatches from begin_heartbeat()
-        # are in flight (but not yet applied by complete_heartbeat).
+        # Serializes provider sync rounds so only one heartbeat round mutates
+        # DB state at a time. Checkpointing no longer takes this lock: the
+        # backup reads via a dedicated RO connection and each heartbeat round
+        # commits as an atomic batch, so snapshots are always consistent.
         self._heartbeat_lock = threading.Lock()
 
         # Rate-limits periodic (best-effort) checkpoint writes.
@@ -1319,9 +1316,6 @@ class Controller:
             if stop_event.is_set():
                 break
 
-            if self._checkpoint_paused.is_set():
-                continue
-
             if woken:
                 backoff.reset()
 
@@ -1392,8 +1386,6 @@ class Controller:
         while not stop_event.is_set():
             if not limiter.wait(cancel=stop_event):
                 break
-            if self._checkpoint_paused.is_set():
-                continue
             try:
                 self._run_autoscaler_once()
             except Exception:
@@ -1415,8 +1407,6 @@ class Controller:
             limiter.mark_run()
             if stop_event.is_set():
                 break
-            if self._checkpoint_paused.is_set():
-                continue
             try:
                 with self._heartbeat_lock:
                     self._sync_all_execution_units()
@@ -1432,8 +1422,6 @@ class Controller:
             limiter.mark_run()
             if stop_event.is_set():
                 break
-            if self._checkpoint_paused.is_set():
-                continue
             try:
                 self._sync_direct_provider()
             except Exception:
@@ -1473,8 +1461,6 @@ class Controller:
             if stop_event.is_set():
                 break
             limiter.mark_run()
-            if self._checkpoint_paused.is_set():
-                continue
             try:
                 self._profile_all_running_tasks()
             except Exception:
@@ -2380,23 +2366,19 @@ class Controller:
         if self._config.dry_run:
             logger.info("[DRY-RUN] Skipping checkpoint write")
             return ("dry-run", CheckpointResult(created_at=Timestamp.now(), job_count=0, task_count=0, worker_count=0))
-        self._checkpoint_paused.set()
+        backup = backup_databases(self._db)
         try:
-            backup = backup_databases(self._db)
-            try:
-                path, result = upload_checkpoint(self._db, backup, self._config.remote_state_dir)
-            finally:
-                backup.cleanup()
-            logger.info(
-                "Checkpoint written: %s (jobs=%d tasks=%d workers=%d)",
-                path,
-                result.job_count,
-                result.task_count,
-                result.worker_count,
-            )
-            return path, result
+            path, result = upload_checkpoint(self._db, backup, self._config.remote_state_dir)
         finally:
-            self._checkpoint_paused.clear()
+            backup.cleanup()
+        logger.info(
+            "Checkpoint written: %s (jobs=%d tasks=%d workers=%d)",
+            path,
+            result.job_count,
+            result.task_count,
+            result.worker_count,
+        )
+        return path, result
 
     def launch_job(
         self,

--- a/lib/iris/src/iris/cluster/controller/db.py
+++ b/lib/iris/src/iris/cluster/controller/db.py
@@ -660,23 +660,29 @@ class ControllerDB:
         VACUUM at boot.  This is a single-pass operation against the
         already-written backup file -- no redundant copy is required.
 
-        Only the page-copy step acquires ``self._lock``; the destination-side
-        PRAGMAs operate on the freshly-written backup file and do not need
-        the source write lock.  Keeping those PRAGMAs inside the lock would
-        stall the mainloop for the duration of ``incremental_vacuum`` on a
-        multi-GB file.
+        The backup runs through a dedicated read-only source connection,
+        so writers on ``self._conn`` proceed concurrently under SQLite's
+        WAL semantics -- no controller-level lock is held for the
+        duration of the copy.  Batched page copying (``pages=500``)
+        yields between steps so a sustained write stream cannot starve
+        the backup.
         """
         destination.parent.mkdir(parents=True, exist_ok=True)
-        dest = sqlite3.connect(str(destination))
+        src = sqlite3.connect(str(self._db_path), check_same_thread=False)
         try:
-            with self._lock:
-                self._conn.backup(dest)
-            dest.execute("PRAGMA journal_mode = DELETE")
-            dest.execute("PRAGMA auto_vacuum = INCREMENTAL")
-            dest.execute("PRAGMA incremental_vacuum")
-            dest.commit()
+            self._configure(src)
+            src.execute("PRAGMA query_only = ON")
+            dest = sqlite3.connect(str(destination))
+            try:
+                src.backup(dest, pages=500, sleep=0)
+                dest.execute("PRAGMA journal_mode = DELETE")
+                dest.execute("PRAGMA auto_vacuum = INCREMENTAL")
+                dest.execute("PRAGMA incremental_vacuum")
+                dest.commit()
+            finally:
+                dest.close()
         finally:
-            dest.close()
+            src.close()
 
     @staticmethod
     def _sidecar_paths(path: Path) -> tuple[Path, Path]:

--- a/lib/iris/src/iris/cluster/controller/db.py
+++ b/lib/iris/src/iris/cluster/controller/db.py
@@ -659,18 +659,24 @@ class ControllerDB:
         checkpoint start in incremental mode without needing a full
         VACUUM at boot.  This is a single-pass operation against the
         already-written backup file -- no redundant copy is required.
+
+        Only the page-copy step acquires ``self._lock``; the destination-side
+        PRAGMAs operate on the freshly-written backup file and do not need
+        the source write lock.  Keeping those PRAGMAs inside the lock would
+        stall the mainloop for the duration of ``incremental_vacuum`` on a
+        multi-GB file.
         """
         destination.parent.mkdir(parents=True, exist_ok=True)
-        with self._lock:
-            dest = sqlite3.connect(str(destination))
-            try:
+        dest = sqlite3.connect(str(destination))
+        try:
+            with self._lock:
                 self._conn.backup(dest)
-                dest.execute("PRAGMA journal_mode = DELETE")
-                dest.execute("PRAGMA auto_vacuum = INCREMENTAL")
-                dest.execute("PRAGMA incremental_vacuum")
-                dest.commit()
-            finally:
-                dest.close()
+            dest.execute("PRAGMA journal_mode = DELETE")
+            dest.execute("PRAGMA auto_vacuum = INCREMENTAL")
+            dest.execute("PRAGMA incremental_vacuum")
+            dest.commit()
+        finally:
+            dest.close()
 
     @staticmethod
     def _sidecar_paths(path: Path) -> tuple[Path, Path]:

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -102,7 +102,7 @@ WORKER_TASK_HISTORY_RETENTION = 500
 WORKER_RESOURCE_HISTORY_RETENTION = 500
 """Maximum worker_resource_history rows retained per worker."""
 
-TASK_RESOURCE_HISTORY_RETENTION = 200
+TASK_RESOURCE_HISTORY_RETENTION = 50
 """Maximum task_resource_history rows retained per (task_id, attempt_id).
 Logarithmic downsampling triggers at 2x this value."""
 
@@ -2768,7 +2768,7 @@ class ControllerTransitions:
             for row in overflows:
                 tid, aid = row["task_id"], row["attempt_id"]
                 # Load all IDs into Python for index-based thinning.
-                # Bounded by 2*N + heartbeats-per-prune-cycle (~460 rows max at N=200).
+                # Bounded by 2*N + heartbeats-per-prune-cycle (~160 rows max at N=50).
                 all_ids = [
                     r["id"]
                     for r in cur.execute(

--- a/lib/iris/tests/cluster/controller/test_db.py
+++ b/lib/iris/tests/cluster/controller/test_db.py
@@ -213,6 +213,52 @@ def test_read_snapshot_pool_returns_connections(db: ControllerDB) -> None:
     assert db._read_pool.qsize() == pool_size
 
 
+def test_backup_to_does_not_block_concurrent_writes(tmp_path: Path) -> None:
+    """backup_to uses a separate read-only source connection, so writers on
+    self._conn must proceed under WAL semantics while the backup runs."""
+    db = ControllerDB(db_dir=tmp_path)
+    _create_simple_table(db)
+
+    # Seed enough rows that the backup takes at least a few page-copy steps,
+    # giving the writer thread a real chance to interleave.
+    with db.transaction() as cur:
+        for i in range(2000):
+            cur.execute("INSERT INTO kv (key, value) VALUES (?, ?)", (f"seed-{i}", "x" * 256))
+
+    backup_dir = tmp_path / "backup"
+    backup_dir.mkdir()
+
+    writes_completed = 0
+    writer_exc: BaseException | None = None
+    stop = threading.Event()
+
+    def writer() -> None:
+        nonlocal writes_completed, writer_exc
+        try:
+            i = 0
+            while not stop.is_set():
+                with db.transaction() as cur:
+                    cur.execute("INSERT INTO kv (key, value) VALUES (?, ?)", (f"live-{i}", "y"))
+                writes_completed += 1
+                i += 1
+        except BaseException as e:
+            writer_exc = e
+
+    t = threading.Thread(target=writer, daemon=True)
+    t.start()
+    try:
+        db.backup_to(backup_dir / "controller.sqlite3")
+    finally:
+        stop.set()
+        t.join(timeout=5)
+
+    assert writer_exc is None, f"writer crashed: {writer_exc!r}"
+    # The writer must have made forward progress during the backup; if the
+    # backup path had re-acquired self._lock we'd expect zero writes here.
+    assert writes_completed > 0
+    db.close()
+
+
 def test_replace_from_reattaches_auth_db(tmp_path: Path) -> None:
     """replace_from() must re-attach the auth DB so auth tables remain accessible."""
     db = ControllerDB(db_dir=tmp_path)


### PR DESCRIPTION
Run ControllerDB.backup_to through a dedicated read-only source connection so the SQLite page-copy runs entirely under WAL semantics with no Python-level lock held. Drop the self._heartbeat_lock wrapper around backup_databases in begin_checkpoint, and remove the _checkpoint_paused event so scheduling, autoscaler, provider, direct-provider, and profile loops keep making progress during the checkpoint; heartbeat rounds already commit as atomic batches, so snapshots are always consistent. Cut TASK_RESOURCE_HISTORY_RETENTION from 200 to 50, the dominant contributor to controller DB size (observed 2M rows in a 1.8GB checkpoint that stalled the mainloop for 9 minutes during a production incident). Adds a regression test that concurrent writes make forward progress during a backup.