### PR TITLE
ci: alert on cancellation for canary workflows, run Slack notify in a separate job

### DIFF
--- a/.github/workflows/marin-canary-ferry-cw.yaml
+++ b/.github/workflows/marin-canary-ferry-cw.yaml
@@ -292,14 +292,42 @@ jobs:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
+      # Upload Claude's Slack message (if it was written) so the separate
+      # notify-slack job can pick it up. We run Slack notify in a separate
+      # job because a job-level timeout can force-kill this runner before
+      # in-job steps after Claude triage ever execute — see
+      # https://github.com/marin-community/marin/actions/runs/24498461666.
+      - name: Upload Slack message
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: slack-message
+          path: slack_message.md
+          retention-days: 1
+          if-no-files-found: ignore
+
       - name: Stop port-forward
         if: always()
         run: |
           [ -n "$PF_PID" ] && kill "$PF_PID" 2>/dev/null || true
           pkill -f "kubectl port-forward.*$IRIS_NAMESPACE" 2>/dev/null || true
 
-      - name: Notify Slack on failure
-        if: (failure() || cancelled()) && github.event_name == 'schedule'
+  # Separate job so Slack always fires, even if the main job is force-killed
+  # after its grace window. `needs.canary-ferry-cw.result` reflects the main
+  # job outcome; failure()/cancelled() context functions only see this job's
+  # steps.
+  notify-slack:
+    needs: canary-ferry-cw
+    if: always() && (needs.canary-ferry-cw.result == 'failure' || needs.canary-ferry-cw.result == 'cancelled') && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Slack message
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: slack-message
+
+      - name: Notify Slack
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           FALLBACK_TEXT: ":red_circle: *GPU Canary failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/marin-canary-ferry.yaml
+++ b/.github/workflows/marin-canary-ferry.yaml
@@ -234,8 +234,42 @@ jobs:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-      - name: Notify Slack on failure
-        if: (failure() || cancelled()) && github.event_name == 'schedule'
+      # Upload Claude's Slack message (if it was written) so the separate
+      # notify-slack job can pick it up. We run Slack notify in a separate
+      # job because a job-level timeout can force-kill this runner before
+      # in-job steps after Claude triage ever execute — see
+      # https://github.com/marin-community/marin/actions/runs/24498461666.
+      - name: Upload Slack message
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: slack-message
+          path: slack_message.md
+          retention-days: 1
+          if-no-files-found: ignore
+
+      - name: Remove OS Login SSH key
+        if: always()
+        run: |
+          gcloud compute os-login ssh-keys remove \
+            --impersonate-service-account="$IRIS_CONTROLLER_SERVICE_ACCOUNT" \
+            --key-file ~/.ssh/google_compute_engine.pub || true
+
+  # Separate job so Slack always fires, even if the main job is force-killed
+  # after its grace window. `needs.canary-ferry.result` reflects the main job
+  # outcome; failure()/cancelled() context functions only see this job's steps.
+  notify-slack:
+    needs: canary-ferry
+    if: always() && (needs.canary-ferry.result == 'failure' || needs.canary-ferry.result == 'cancelled') && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Slack message
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: slack-message
+
+      - name: Notify Slack
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           FALLBACK_TEXT: ":red_circle: *TPU Canary failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -247,10 +281,3 @@ jobs:
           fi
           PAYLOAD=$(python3 -c "import sys,json; print(json.dumps({'text': sys.stdin.read()}))" <<< "$TEXT")
           curl -sf -X POST -H 'Content-Type: application/json' -d "$PAYLOAD" "$SLACK_WEBHOOK_URL"
-
-      - name: Remove OS Login SSH key
-        if: always()
-        run: |
-          gcloud compute os-login ssh-keys remove \
-            --impersonate-service-account="$IRIS_CONTROLLER_SERVICE_ACCOUNT" \
-            --key-file ~/.ssh/google_compute_engine.pub || true

--- a/.github/workflows/marin-datakit-smoke.yaml
+++ b/.github/workflows/marin-datakit-smoke.yaml
@@ -136,7 +136,7 @@ jobs:
         run: .venv/bin/python scripts/datakit/validate_ferry_outputs.py
 
       - name: Capture failure diagnostics
-        if: failure()
+        if: failure() || cancelled()
         run: |
           echo "=== Controller logs ==="
           .venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
@@ -148,7 +148,7 @@ jobs:
       # The canary-triage skill handles both lanes; CANARY_LANE selects datakit-smoke vs tpu.
       - name: Claude triage
         id: claude_triage
-        if: failure() && github.event_name == 'schedule'
+        if: (failure() || cancelled()) && github.event_name == 'schedule'
         uses: anthropics/claude-code-action@v1
         timeout-minutes: 30
         with:
@@ -169,8 +169,43 @@ jobs:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-      - name: Notify Slack on failure
-        if: failure() && github.event_name == 'schedule'
+      # Upload Claude's Slack message (if it was written) so the separate
+      # notify-slack job can pick it up. We run Slack notify in a separate
+      # job because a job-level timeout can force-kill this runner before
+      # in-job steps after Claude triage ever execute — see
+      # https://github.com/marin-community/marin/actions/runs/24498461666.
+      - name: Upload Slack message
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: slack-message
+          path: slack_message.md
+          retention-days: 1
+          if-no-files-found: ignore
+
+      - name: Remove OS Login SSH key
+        if: always()
+        run: |
+          gcloud compute os-login ssh-keys remove \
+            --impersonate-service-account="$IRIS_CONTROLLER_SERVICE_ACCOUNT" \
+            --key-file ~/.ssh/google_compute_engine.pub || true
+
+  # Separate job so Slack always fires, even if the main job is force-killed
+  # after its grace window. `needs.datakit-smoke.result` reflects the main
+  # job outcome; failure()/cancelled() context functions only see this job's
+  # steps.
+  notify-slack:
+    needs: datakit-smoke
+    if: always() && (needs.datakit-smoke.result == 'failure' || needs.datakit-smoke.result == 'cancelled') && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Slack message
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: slack-message
+
+      - name: Notify Slack
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           FALLBACK_TEXT: ":red_circle: *Datakit Smoke failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -182,10 +217,3 @@ jobs:
           fi
           PAYLOAD=$(python3 -c "import sys,json; print(json.dumps({'text': sys.stdin.read()}))" <<< "$TEXT")
           curl -sf -X POST -H 'Content-Type: application/json' -d "$PAYLOAD" "$SLACK_WEBHOOK_URL"
-
-      - name: Remove OS Login SSH key
-        if: always()
-        run: |
-          gcloud compute os-login ssh-keys remove \
-            --impersonate-service-account="$IRIS_CONTROLLER_SERVICE_ACCOUNT" \
-            --key-file ~/.ssh/google_compute_engine.pub || true

--- a/.github/workflows/zephyr-shuffle-itest.yaml
+++ b/.github/workflows/zephyr-shuffle-itest.yaml
@@ -159,7 +159,7 @@ jobs:
             | grep "RESULT:" || echo "No RESULT lines found"
 
       - name: Capture failure diagnostics
-        if: failure()
+        if: failure() || cancelled()
         shell: bash -l {0}
         run: |
           JOB_ID="${{ steps.submit.outputs.job_id }}"


### PR DESCRIPTION
## Summary

- Canary / smoke workflows only alerted on `failure()`, not `cancelled()`. A GHA job timeout surfaces as cancellation, so hung runs disappeared silently.
- Run [24498461666](https://github.com/marin-community/marin/actions/runs/24498461666) is the concrete motivator: the 240-min job timeout fired, `Capture failure diagnostics` and `Upload diagnostics` ran in the post-cancel grace window, but `Claude triage` then consumed the rest of that window and `Notify Slack on failure` never got a turn before the runner was force-killed.
- Fix: `failure() || cancelled()` on diagnostics/triage gates, and split Slack notify into its own `notify-slack` job. A separate job = fresh runner + fresh timeout budget, so Slack always posts regardless of what happened to the main job. Claude's optional `slack_message.md` is handed off via an upload-artifact step; if it was never written (e.g. Claude was killed mid-triage), the notify job uses `FALLBACK_TEXT`.
- `zephyr-shuffle-itest.yaml` has no Slack step, so only its diagnostics `if:` changed.

Applied to `marin-canary-ferry.yaml`, `marin-canary-ferry-cw.yaml`, `marin-datakit-smoke.yaml`, and `zephyr-shuffle-itest.yaml`.

## Test plan

- [ ] `workflow_dispatch` each of the three canary/smoke workflows and confirm both `main` and `notify-slack` jobs render in the Actions UI (notify-slack will be skipped on success — expected)
- [ ] Artificially induce a failure (e.g. bad `IRIS_CONFIG`) in one workflow and verify Slack posts the fallback text from the separate job
- [ ] Confirm a success run doesn't page — `notify-slack` should be skipped via `needs.<main>.result`

🤖 Generated with [Claude Code](https://claude.com/claude-code)