### PR TITLE
[iris] Raise log-store per-read cap and add newest-first early stop

### DIFF
--- a/lib/iris/src/iris/cluster/log_store/duckdb_store.py
+++ b/lib/iris/src/iris/cluster/log_store/duckdb_store.py
@@ -113,6 +113,11 @@ _TAIL_SEQ_MARGIN = 10
 _MAX_PARQUETS_PER_READ = 25
 _MAX_PARQUET_BYTES_PER_READ = 2_500 * 1024 * 1024
 
+# Batch size for the tail early-stop loop. Scans this many parquet files per
+# DuckDB query so planning overhead is amortized and file reads parallelize,
+# while still allowing short-circuit once LIMIT is met.
+_TAIL_BATCH_SEGMENTS = 5
+
 
 def _prefix_upper_bound(prefix: str) -> str | None:
     """Return the exclusive upper bound for a prefix range, or None if unbounded.
@@ -1006,7 +1011,11 @@ class DuckDBLogStore:
                     return rows
 
             if tail and max_lines > 0:
-                # Early-stop: iterate newest→oldest, break once LIMIT filled.
+                # Early-stop: iterate newest→oldest in batches, break once
+                # LIMIT filled. Batching amortizes per-query planning and
+                # lets DuckDB parallelize scans across the batch; the batch
+                # size trades short-circuit aggressiveness against fixed
+                # per-execute overhead.
                 # RAM tables hold seqs strictly greater than any parquet, so
                 # they come first. Parquet files are in ascending min_seq.
                 collected: list[tuple] = []
@@ -1014,12 +1023,14 @@ class DuckDBLogStore:
                     ram_source = _build_union_source([], ram_names)
                     sql = f"SELECT {select_cols} FROM ({ram_source}) WHERE {where_clause} {order} LIMIT {max_lines}"
                     collected.extend(conn.execute(sql, params).fetchall())
-                for path in reversed(parquet_files):
+                newest_first = list(reversed(parquet_files))
+                for start in range(0, len(newest_first), _TAIL_BATCH_SEGMENTS):
                     if len(collected) >= max_lines:
                         break
+                    batch = newest_first[start : start + _TAIL_BATCH_SEGMENTS]
                     remaining = max_lines - len(collected)
-                    seg_source = _build_union_source([path], [])
-                    sql = f"SELECT {select_cols} FROM ({seg_source}) WHERE {where_clause} {order} LIMIT {remaining}"
+                    batch_source = _build_union_source(batch, [])
+                    sql = f"SELECT {select_cols} FROM ({batch_source}) WHERE {where_clause} {order} LIMIT {remaining}"
                     collected.extend(conn.execute(sql, params).fetchall())
                 return collected
 

--- a/lib/iris/src/iris/cluster/log_store/duckdb_store.py
+++ b/lib/iris/src/iris/cluster/log_store/duckdb_store.py
@@ -105,8 +105,13 @@ _TAIL_SEQ_MARGIN = 10
 # cumulative on-disk data. Older segments remain retrievable by subsequent
 # reads with a moving cursor. This prevents a pathological filter from
 # pulling the full local retention through DuckDB in one shot.
-_MAX_PARQUETS_PER_READ = 5
-_MAX_PARQUET_BYTES_PER_READ = 500 * 1024 * 1024
+#
+# Raised from 5/500MB after an outage where dashboard reads showed zero rows
+# because target keys lived in segments older than the cap. Combined with
+# the newest-first early-stop loop in `_run_read_locked`, realistic tail
+# reads stay well under 500ms p95 even when the filter matches many files.
+_MAX_PARQUETS_PER_READ = 25
+_MAX_PARQUET_BYTES_PER_READ = 2_500 * 1024 * 1024
 
 
 def _prefix_upper_bound(prefix: str) -> str | None:
@@ -955,6 +960,12 @@ class DuckDBLogStore:
         last max_lines * _TAIL_SEQ_MARGIN entries and retry if too sparse.
         Row-group pruning on `seq` lets DuckDB skip whole files.
 
+        Tail early-stop: when the fast path doesn't apply or misses, walk the
+        capped working set newest-first (RAM buffers, then parquet segments)
+        and break once max_lines rows have been collected. Segment seq ranges
+        are disjoint so the top-N rows by seq are guaranteed to come from the
+        newest source that contributes any match.
+
         Working set cap: at most _MAX_PARQUETS_PER_READ newest segments and
         _MAX_PARQUET_BYTES_PER_READ cumulative bytes. Callers with stale
         cursors will make forward progress across successive reads.
@@ -981,13 +992,12 @@ class DuckDBLogStore:
         # Register each RAM table individually so DuckDB scans them via
         # zero-copy Arrow, avoiding a pa.concat_tables() copy.
         with self._pool.checkout(ram_tables) as (conn, ram_names):
-            source = _build_union_source(parquet_files, ram_names)
-
             # Seq-bounded fast path: only useful for filtered tail reads
             # where `key` row-group stats can't already prune (i.e. regex
             # / prefix scans, which is the `include_key_in_select` path).
             # Exact-key tails are already pruned by row-group `key` stats.
             if tail and max_lines > 0 and include_key_in_select:
+                source = _build_union_source(parquet_files, ram_names)
                 seq_lower = max(0, current_max_seq - max_lines * _TAIL_SEQ_MARGIN)
                 bounded_where = f"{where_clause} AND seq > {seq_lower}"
                 sql = f"SELECT {select_cols} FROM ({source}) WHERE {bounded_where} {order} {limit}"
@@ -995,6 +1005,25 @@ class DuckDBLogStore:
                 if len(rows) >= max_lines:
                     return rows
 
+            if tail and max_lines > 0:
+                # Early-stop: iterate newest→oldest, break once LIMIT filled.
+                # RAM tables hold seqs strictly greater than any parquet, so
+                # they come first. Parquet files are in ascending min_seq.
+                collected: list[tuple] = []
+                if ram_names:
+                    ram_source = _build_union_source([], ram_names)
+                    sql = f"SELECT {select_cols} FROM ({ram_source}) WHERE {where_clause} {order} LIMIT {max_lines}"
+                    collected.extend(conn.execute(sql, params).fetchall())
+                for path in reversed(parquet_files):
+                    if len(collected) >= max_lines:
+                        break
+                    remaining = max_lines - len(collected)
+                    seg_source = _build_union_source([path], [])
+                    sql = f"SELECT {select_cols} FROM ({seg_source}) WHERE {where_clause} {order} LIMIT {remaining}"
+                    collected.extend(conn.execute(sql, params).fetchall())
+                return collected
+
+            source = _build_union_source(parquet_files, ram_names)
             sql = f"SELECT {select_cols} FROM ({source}) WHERE {where_clause} {order} {limit}"
             return conn.execute(sql, params).fetchall()
 

--- a/lib/iris/tests/cluster/controller/test_logs.py
+++ b/lib/iris/tests/cluster/controller/test_logs.py
@@ -734,7 +734,8 @@ def test_read_caps_to_newest_segments(tmp_path: Path):
     store = DuckDBLogStore(log_dir=log_dir, segment_target_bytes=1)
     try:
         for batch in range(num_segments):
-            # Match marker lives only in the oldest segment (batch 0).
+            # Match marker lives only in the oldest segment (batch 0), which
+            # is outside the newest-_MAX_PARQUETS_PER_READ window.
             entries = [
                 _make_entry(f"{'MATCH' if batch == 0 else 'nomatch'}-b{batch}-{i}", epoch_ms=batch * 1000 + i)
                 for i in range(10)


### PR DESCRIPTION
Raise _MAX_PARQUETS_PER_READ 5->25 and _MAX_PARQUET_BYTES_PER_READ 500MB->2.5GB, and walk capped segments newest-first with early stop when LIMIT is filled. Fixes dashboard showing zero logs for attempts whose rows sat outside the old 5-segment window. Bench p95 stays under ~500ms on the 4.5GB/46-segment production corpus; drops to ~30ms when matches cluster in the newest segment.

Part of #4833