### PR TITLE
[iris] Chunk fail_heartbeats_batch to release SQLite writer between groups

### DIFF
--- a/lib/iris/scripts/benchmark_db_queries.py
+++ b/lib/iris/scripts/benchmark_db_queries.py
@@ -18,12 +18,15 @@ Usage:
     uv run python lib/iris/scripts/benchmark_db_queries.py --only scheduling
     uv run python lib/iris/scripts/benchmark_db_queries.py --only dashboard
     uv run python lib/iris/scripts/benchmark_db_queries.py --only heartbeat
+    uv run python lib/iris/scripts/benchmark_db_queries.py --only endpoints
 """
 
 import shutil
 import sqlite3
 import tempfile
+import threading
 import time
+import uuid
 from pathlib import Path
 from typing import Any
 from collections.abc import Callable
@@ -41,7 +44,6 @@ from iris.cluster.controller.controller import (
 )
 from iris.cluster.controller.db import (
     ACTIVE_TASK_STATES,
-    TERMINAL_JOB_STATES,
     ControllerDB,
     EndpointQuery,
     healthy_active_workers_with_attributes,
@@ -69,16 +71,19 @@ from iris.cluster.controller.service import (
     _worker_addresses_for_tasks,
     _worker_roster,
 )
+from iris.cluster.controller.schema import EndpointRow
 from iris.cluster.controller.transitions import (
     Assignment,
     ControllerTransitions,
+    DispatchBatch,
     HeartbeatApplyRequest,
     ReservationClaim,
     TaskUpdate,
 )
-from iris.cluster.types import JobName, WorkerId
+from iris.cluster.types import TERMINAL_JOB_STATES, JobName, WorkerId
 from iris.rpc import job_pb2
 from iris.rpc import controller_pb2
+from rigging.timing import Timestamp
 
 _results: list[tuple[str, float, float, int]] = []
 
@@ -94,6 +99,7 @@ _CLONE_TABLES = [
     "dispatch_queue",
     "worker_task_history",
     "worker_resource_history",
+    "task_resource_history",
     "endpoints",
     "reservation_claims",
     "txn_log",
@@ -425,13 +431,6 @@ def benchmark_dashboard(db: ControllerDB) -> None:
 
     bench("_live_user_stats", lambda: _live_user_stats(db))
 
-    bench("endpoint_registry.query (all)", lambda: db.endpoints.query())
-
-    bench(
-        "endpoint_registry.query (prefix)",
-        lambda: db.endpoints.query(EndpointQuery(name_prefix="test")),
-    )
-
     bench("_transaction_actions", lambda: _transaction_actions(db))
 
     bench("_worker_roster", lambda: _worker_roster(db))
@@ -619,6 +618,604 @@ def benchmark_heartbeat(db: ControllerDB) -> None:
         shutil.rmtree(hb_db._db_dir, ignore_errors=True)
 
 
+def _active_task_sample(db: ControllerDB, limit: int) -> list[tuple[JobName, int]]:
+    """Return up to ``limit`` (task_id, current_attempt_id) pairs for non-terminal tasks.
+
+    add_endpoint checks that the task is not TERMINAL, so we pick from
+    ACTIVE_TASK_STATES to exercise the full RegisterEndpoint write path.
+    """
+    active_states = tuple(ACTIVE_TASK_STATES)
+    placeholders = ",".join("?" for _ in active_states)
+    rows = db.fetchall(
+        f"SELECT task_id, current_attempt_id FROM tasks "
+        f"WHERE state IN ({placeholders}) AND current_attempt_id IS NOT NULL LIMIT ?",
+        (*active_states, limit),
+    )
+    return [(JobName.from_wire(str(r["task_id"])), int(r["current_attempt_id"])) for r in rows]
+
+
+def _make_endpoint(task_id: JobName) -> EndpointRow:
+    return EndpointRow(
+        endpoint_id=str(uuid.uuid4()),
+        name=f"/bench/endpoint/{uuid.uuid4().hex[:8]}",
+        address="127.0.0.1:0",
+        task_id=task_id,
+        metadata={"bench": "true"},
+        registered_at=Timestamp.now(),
+    )
+
+
+def _measure_tail_latency(
+    *,
+    name: str,
+    write_db: ControllerDB,
+    write_txns: ControllerTransitions,
+    batch_fn: Callable[[], Any],
+    endpoint_tasks: list[JobName],
+    reset: Callable[[], Any],
+) -> None:
+    """Fire add_endpoint calls on a probe thread while ``batch_fn`` runs on
+    another thread, and report the per-call latency distribution of the
+    probe. This is the metric that matches the production symptom —
+    RegisterEndpoint RPCs stalling for seconds while a large
+    fail_heartbeats_batch holds the SQLite writer — not the batch's own
+    wall time.
+    """
+    print(f"  {name:50s}  ", end="", flush=True)
+
+    def _run() -> tuple[list[float], float]:
+        probe_latencies: list[float] = []
+        errors: list[BaseException] = []
+        stop = threading.Event()
+
+        def _batch() -> None:
+            try:
+                batch_fn()
+            except BaseException as e:
+                errors.append(e)
+            finally:
+                stop.set()
+
+        def _probe() -> None:
+            # Hammer add_endpoint back-to-back; record each call's latency.
+            # Rotate through endpoint_tasks to avoid exhausting the list.
+            i = 0
+            try:
+                while not stop.is_set():
+                    t = endpoint_tasks[i % len(endpoint_tasks)]
+                    start = time.perf_counter()
+                    write_txns.add_endpoint(_make_endpoint(t))
+                    probe_latencies.append((time.perf_counter() - start) * 1000)
+                    i += 1
+            except BaseException as e:
+                errors.append(e)
+
+        t_batch = threading.Thread(target=_batch)
+        t_probe = threading.Thread(target=_probe)
+        wall_start = time.perf_counter()
+        t_batch.start()
+        t_probe.start()
+        t_batch.join()
+        t_probe.join()
+        wall_ms = (time.perf_counter() - wall_start) * 1000
+        if errors:
+            raise errors[0]
+        return probe_latencies, wall_ms
+
+    # Single real run — no warmup; the batch itself is expensive.
+    latencies, wall_ms = _run()
+    reset()
+
+    if not latencies:
+        print("(no probe samples)")
+        return
+
+    latencies.sort()
+    p50 = latencies[len(latencies) // 2]
+    p95 = latencies[int(len(latencies) * 0.95)]
+    max_ms = latencies[-1]
+    _results.append((name, p50, p95, len(latencies)))
+    print(
+        f"probes={len(latencies):4d} p50={p50:7.1f}ms  p95={p95:7.1f}ms  "
+        f"max={max_ms:7.1f}ms  batch_wall={wall_ms:7.0f}ms"
+    )
+
+
+def _measure_drain_tail_latency(
+    *,
+    name: str,
+    write_db: ControllerDB,
+    write_txns: ControllerTransitions,
+    batch_fn: Callable[[], Any],
+    reset: Callable[[], Any],
+) -> None:
+    """Measure drain_dispatch_all latency while ``batch_fn`` holds the writer.
+
+    Same pattern as ``_measure_tail_latency`` but probes drain_dispatch_all
+    (provider-sync phase 1) instead of add_endpoint.
+    """
+    print(f"  {name:50s}  ", end="", flush=True)
+
+    def _run() -> tuple[list[float], float]:
+        drain_latencies: list[float] = []
+        errors: list[BaseException] = []
+        stop = threading.Event()
+
+        def _batch() -> None:
+            try:
+                batch_fn()
+            except BaseException as e:
+                errors.append(e)
+            finally:
+                stop.set()
+
+        def _probe() -> None:
+            try:
+                while not stop.is_set():
+                    start = time.perf_counter()
+                    write_txns.drain_dispatch_all()
+                    drain_latencies.append((time.perf_counter() - start) * 1000)
+            except BaseException as e:
+                errors.append(e)
+
+        t_batch = threading.Thread(target=_batch)
+        t_probe = threading.Thread(target=_probe)
+        wall_start = time.perf_counter()
+        t_batch.start()
+        t_probe.start()
+        t_batch.join()
+        t_probe.join()
+        wall_ms = (time.perf_counter() - wall_start) * 1000
+        if errors:
+            raise errors[0]
+        return drain_latencies, wall_ms
+
+    latencies, wall_ms = _run()
+    reset()
+
+    if not latencies:
+        print("(no probe samples)")
+        return
+
+    latencies.sort()
+    p50 = latencies[len(latencies) // 2]
+    p95 = latencies[int(len(latencies) * 0.95)]
+    max_ms = latencies[-1]
+    _results.append((name, p50, p95, len(latencies)))
+    print(
+        f"probes={len(latencies):4d} p50={p50:7.1f}ms  p95={p95:7.1f}ms  "
+        f"max={max_ms:7.1f}ms  batch_wall={wall_ms:7.0f}ms"
+    )
+
+
+def benchmark_endpoints(db: ControllerDB) -> None:
+    """Benchmark registration RPC hot paths: RegisterEndpoint and Register (worker).
+
+    Covers:
+      - add_endpoint: single write, burst-per-txn, burst-in-one-txn
+      - fail_heartbeats_batch: provider-sync "apply results" failure path
+      - endpoint burst contending with apply_heartbeats_batch on a thread
+      - register_worker: single, burst of 100, and burst under heartbeat
+        contention (matches the production Register p95 of 3-4s)
+    """
+    # Read-path queries run against the source DB (cheap, no clone needed).
+    bench("endpoint_registry.query (all)", lambda: db.endpoints.query())
+    bench(
+        "endpoint_registry.query (prefix)",
+        lambda: db.endpoints.query(EndpointQuery(name_prefix="test")),
+    )
+
+    write_db = clone_db(db)
+    write_txns = ControllerTransitions(write_db)
+
+    try:
+        sample = _active_task_sample(write_db, limit=300)
+        if not sample:
+            print("  (skipped, no active tasks to attach endpoints to)")
+            return
+
+        # Single RegisterEndpoint write: one transaction = one fsync.
+        single_task = sample[0][0]
+
+        def _do_single():
+            write_txns.add_endpoint(_make_endpoint(single_task))
+
+        def _reset_single():
+            write_db.execute("DELETE FROM endpoints WHERE name LIKE '/bench/endpoint/%'")
+            write_db.endpoints._load_all()
+
+        bench("add_endpoint (1 write)", _do_single, reset=_reset_single)
+
+        # Burst: N endpoints each in their own transaction. This is what the
+        # controller does today — every RegisterEndpoint RPC opens its own
+        # write transaction, so N simultaneous callers serialize on the DB
+        # write lock.
+        for burst_n in (50, 200):
+            if len(sample) < burst_n:
+                print(f"  add_endpoint burst x{burst_n} (per-txn)                 (skipped, only {len(sample)} tasks)")
+                continue
+            tasks_for_burst = [t for t, _ in sample[:burst_n]]
+
+            def _do_burst_per_txn(tasks=tasks_for_burst):
+                for t in tasks:
+                    write_txns.add_endpoint(_make_endpoint(t))
+
+            bench(
+                f"add_endpoint burst x{burst_n} (per-txn)",
+                _do_burst_per_txn,
+                reset=_reset_single,
+                min_runs=3,
+                min_time_s=1.0,
+            )
+
+            # Same N inserts, but coalesced into a single transaction — the
+            # upper bound on what a batched RegisterEndpoint would cost.
+            def _do_burst_one_txn(tasks=tasks_for_burst):
+                with write_db.transaction() as cur:
+                    for t in tasks:
+                        write_db.endpoints.add(cur, _make_endpoint(t))
+
+            bench(
+                f"add_endpoint burst x{burst_n} (1 txn)",
+                _do_burst_one_txn,
+                reset=_reset_single,
+                min_runs=3,
+                min_time_s=1.0,
+            )
+
+        # Provider-sync "apply results" failure path: mark ~N workers failed
+        # in one fail_heartbeats_batch call (force_remove=True matches slice
+        # reaping). This is the exact code path the controller log attributes
+        # the 29s "apply results" phase to.
+        # x50 is enough to show the contention pattern (~5s batch, plenty of
+        # headroom to observe starved RPCs). x300 is instructive but 6x longer
+        # and doesn't change the conclusion.
+        for fail_n in (50,):
+            with write_db.read_snapshot() as snap:
+                worker_rows = snap.fetchall(
+                    "SELECT worker_id, address FROM workers WHERE active = 1 LIMIT ?",
+                    (fail_n,),
+                )
+            if len(worker_rows) < fail_n:
+                print(
+                    f"  fail_heartbeats_batch x{fail_n}                      "
+                    f"(skipped, only {len(worker_rows)} active workers)"
+                )
+                continue
+
+            failures = [
+                (
+                    DispatchBatch(
+                        worker_id=WorkerId(str(r["worker_id"])),
+                        worker_address=str(r["address"]) if r["address"] is not None else None,
+                        running_tasks=[],
+                    ),
+                    "benchmark: simulated provider-sync failure",
+                )
+                for r in worker_rows
+            ]
+
+            # Snapshot worker rows so we can restore between runs. force_remove
+            # flips active=0 and clears current_worker_* on tasks, so the reset
+            # has to restore the worker table and re-activate their tasks.
+            target_ids = [str(r["worker_id"]) for r in worker_rows]
+            placeholders_w = ",".join("?" for _ in target_ids)
+            saved_workers = write_db.fetchall(
+                f"SELECT * FROM workers WHERE worker_id IN ({placeholders_w})",
+                tuple(target_ids),
+            )
+            saved_tasks = write_db.fetchall(
+                f"SELECT task_id, state, current_attempt_id, current_worker_id, current_worker_address, "
+                f"started_at_ms FROM tasks WHERE current_worker_id IN ({placeholders_w})",
+                tuple(target_ids),
+            )
+
+            def _reset_fail(saved_w=saved_workers, saved_t=saved_tasks):
+                for r in saved_w:
+                    cols = r.keys()
+                    ph = ",".join("?" for _ in cols)
+                    write_db.execute(
+                        f"INSERT OR REPLACE INTO workers({','.join(cols)}) VALUES ({ph})",
+                        tuple(r),
+                    )
+                for r in saved_t:
+                    write_db.execute(
+                        "UPDATE tasks SET state=?, current_attempt_id=?, current_worker_id=?, "
+                        "current_worker_address=?, started_at_ms=? WHERE task_id=?",
+                        (
+                            r["state"],
+                            r["current_attempt_id"],
+                            r["current_worker_id"],
+                            r["current_worker_address"],
+                            r["started_at_ms"],
+                            r["task_id"],
+                        ),
+                    )
+
+            bench(
+                f"fail_heartbeats_batch x{fail_n} (force_remove)",
+                lambda f=failures: write_txns.fail_heartbeats_batch(f, force_remove=True),
+                reset=_reset_fail,
+                min_runs=3,
+                min_time_s=1.0,
+            )
+
+            # Tail-latency: what does a concurrent RegisterEndpoint see while
+            # fail_heartbeats_batch is running? This is the metric that
+            # matches the production symptom (2-6s RegisterEndpoint RPCs
+            # during a zone-wide worker failure burst), not the batch's own
+            # wall time. One thread runs the failure batch; another thread
+            # fires add_endpoint calls back-to-back and records each one's
+            # latency. Report p50/p95/max of the endpoint adds.
+            endpoint_tasks = [t for t, _ in sample[:200]] if len(sample) >= 200 else None
+            if endpoint_tasks:
+                # A/B: simulate "one giant txn" (pre-fix) vs chunk_size=10
+                # (current default) to show what chunking buys.
+                _measure_tail_latency(
+                    name=f"add_endpoint tail latency during fail x{fail_n} (1 txn)",
+                    write_db=write_db,
+                    write_txns=write_txns,
+                    batch_fn=lambda f=failures, n=fail_n: write_txns.fail_heartbeats_batch(
+                        f, force_remove=True, chunk_size=n
+                    ),
+                    endpoint_tasks=endpoint_tasks,
+                    reset=_reset_fail,
+                )
+                _measure_tail_latency(
+                    name=f"add_endpoint tail latency during fail x{fail_n} (chunk=10)",
+                    write_db=write_db,
+                    write_txns=write_txns,
+                    batch_fn=lambda f=failures: write_txns.fail_heartbeats_batch(f, force_remove=True, chunk_size=10),
+                    endpoint_tasks=endpoint_tasks,
+                    reset=_reset_fail,
+                )
+
+            # Tail-latency for drain_dispatch_all — controller's
+            # "provider sync phase 1 (snapshot)" path. Its phase-2
+            # dispatch_queue drain opens a write transaction; if
+            # fail_heartbeats_batch is holding the writer, phase 1 waits
+            # for the full batch. This is the "81s phase 1" you see in the
+            # log — it's a victim of writer starvation, not slow itself.
+            _measure_drain_tail_latency(
+                name=f"drain_dispatch_all tail latency during fail x{fail_n} (1 txn)",
+                write_db=write_db,
+                write_txns=write_txns,
+                batch_fn=lambda f=failures, n=fail_n: write_txns.fail_heartbeats_batch(
+                    f, force_remove=True, chunk_size=n
+                ),
+                reset=_reset_fail,
+            )
+            _measure_drain_tail_latency(
+                name=f"drain_dispatch_all tail latency during fail x{fail_n} (chunk=10)",
+                write_db=write_db,
+                write_txns=write_txns,
+                batch_fn=lambda f=failures: write_txns.fail_heartbeats_batch(f, force_remove=True, chunk_size=10),
+                reset=_reset_fail,
+            )
+
+        # Contention: run an add_endpoint burst concurrently with an
+        # apply_heartbeats_batch call on two Python threads sharing the clone
+        # DB. SQLite serializes writers, so this measures write-lock wait.
+        workers = healthy_active_workers_with_attributes(write_db)
+        if workers and len(sample) >= 200:
+            active_states = tuple(ACTIVE_TASK_STATES)
+            running_by_worker: dict[str, list[tuple[str, int]]] = {}
+            for w in workers:
+                wid = str(w.worker_id)
+                rows = write_db.fetchall(
+                    "SELECT task_id, current_attempt_id FROM tasks "
+                    "WHERE current_worker_id = ? AND state IN (?, ?, ?)",
+                    (wid, *active_states),
+                )
+                if rows:
+                    running_by_worker[wid] = [(str(r["task_id"]), int(r["current_attempt_id"])) for r in rows]
+
+            snapshot_proto = job_pb2.WorkerResourceSnapshot()
+            resource_usage_proto = job_pb2.ResourceUsage(cpu_millicores=1000, memory_mb=1024)
+            hb_requests: list[HeartbeatApplyRequest] = []
+            for wid, task_list in running_by_worker.items():
+                updates = [
+                    TaskUpdate(
+                        task_id=JobName.from_wire(tid),
+                        attempt_id=aid,
+                        new_state=job_pb2.TASK_STATE_RUNNING,
+                        resource_usage=resource_usage_proto,
+                    )
+                    for tid, aid in task_list
+                ]
+                hb_requests.append(
+                    HeartbeatApplyRequest(
+                        worker_id=WorkerId(wid),
+                        worker_resource_snapshot=snapshot_proto,
+                        updates=updates,
+                    )
+                )
+
+            burst_tasks = [t for t, _ in sample[:200]]
+
+            def _run_contended():
+                errors: list[BaseException] = []
+
+                def _hb():
+                    try:
+                        write_txns.apply_heartbeats_batch(hb_requests)
+                    except BaseException as e:  # surface thread errors
+                        errors.append(e)
+
+                def _reg():
+                    try:
+                        for t in burst_tasks:
+                            write_txns.add_endpoint(_make_endpoint(t))
+                    except BaseException as e:
+                        errors.append(e)
+
+                t1 = threading.Thread(target=_hb)
+                t2 = threading.Thread(target=_reg)
+                t1.start()
+                t2.start()
+                t1.join()
+                t2.join()
+                if errors:
+                    raise errors[0]
+
+            bench(
+                f"contention: add_endpoint x200 || apply_heartbeats_batch ({len(hb_requests)}w)",
+                _run_contended,
+                reset=_reset_single,
+                min_runs=3,
+                min_time_s=1.0,
+            )
+        else:
+            print("  contention (endpoint burst || heartbeats)         (skipped, insufficient workers/tasks)")
+
+        # --- Worker Register RPC benchmarks ---
+        # Production report: Register RPC takes 3-4s under burst. Same
+        # single-writer transaction path as add_endpoint, but register_worker
+        # also writes to worker_attributes and touches the in-memory
+        # attribute cache, so measure it separately.
+        #
+        # NOTE: clone_db() uses CREATE TABLE AS SELECT which drops the UNIQUE
+        # constraint needed by register_worker's UPSERT. Skip when the clone
+        # can't support it.
+        try:
+            _bench_register_worker(write_db, write_txns)
+        except sqlite3.OperationalError as e:
+            print(f"  register_worker benchmarks                        (skipped: {e})")
+    finally:
+        write_db.close()
+        shutil.rmtree(write_db._db_dir, ignore_errors=True)
+
+
+def _build_sample_worker_metadata() -> job_pb2.WorkerMetadata:
+    """Minimal but representative WorkerMetadata for a CPU worker.
+
+    Matches the shape of real worker metadata (device set, a handful of
+    attributes) so the INSERT path hits the same column and attribute count
+    as production.
+    """
+    device = job_pb2.DeviceConfig()
+    device.cpu.CopyFrom(job_pb2.CpuDevice(variant="cpu"))
+    meta = job_pb2.WorkerMetadata(
+        hostname="bench-worker",
+        ip_address="127.0.0.1",
+        cpu_count=64,
+        memory_bytes=256 * 1024**3,
+        disk_bytes=2 * 1024**4,
+        device=device,
+    )
+    meta.attributes["device_type"].string_value = "cpu"
+    meta.attributes["device_variant"].string_value = "cpu"
+    meta.attributes["pool"].string_value = "default"
+    return meta
+
+
+def _bench_register_worker(write_db: ControllerDB, write_txns: ControllerTransitions) -> None:
+    """Benchmark the worker Register RPC hot path.
+
+    Cases:
+      (a) single fresh Register — per-call INSERT cost baseline.
+      (b) sequential burst of 100 fresh Registers — what happens when a slice
+          of 100 workers all come up at once and each hits its own write txn.
+      (c) same 100-burst with apply_heartbeats_batch hammering the same DB on
+          a background thread — exercises SQLite write-lock contention, which
+          is our leading theory for the 3-4s p95 seen in prod.
+    """
+    sample_meta = _build_sample_worker_metadata()
+
+    def _register_one(worker_id: WorkerId) -> None:
+        write_txns.register_worker(
+            worker_id=worker_id,
+            address=f"tcp://{worker_id}:1234",
+            metadata=sample_meta,
+            ts=Timestamp.now(),
+            slice_id="",
+            scale_group="bench",
+        )
+
+    # (a) single Register, fresh worker each iteration.
+    single_counter = {"n": 0}
+
+    def _single():
+        single_counter["n"] += 1
+        _register_one(WorkerId(f"bench-single-{uuid.uuid4().hex[:8]}-{single_counter['n']}"))
+
+    bench("register_worker (1 fresh, WRITE)", _single)
+
+    # (b) burst: 100 sequential fresh Registers per bench iteration.
+    burst_counter = {"n": 0}
+
+    def _burst_100():
+        burst_counter["n"] += 1
+        base = f"bench-burst-{uuid.uuid4().hex[:8]}-{burst_counter['n']}"
+        for i in range(100):
+            _register_one(WorkerId(f"{base}-{i}"))
+
+    bench("register_worker (burst 100, WRITE)", _burst_100, min_runs=3, min_time_s=2.0)
+
+    # (c) burst 100 under concurrent apply_heartbeats_batch contention.
+    active_states = tuple(ACTIVE_TASK_STATES)
+    workers = healthy_active_workers_with_attributes(write_db)
+    running_tasks_per_worker: dict[str, list[tuple[str, int]]] = {}
+    for w in workers:
+        wid = str(w.worker_id)
+        rows = write_db.fetchall(
+            "SELECT task_id, current_attempt_id FROM tasks " "WHERE current_worker_id = ? AND state IN (?, ?, ?)",
+            (wid, *active_states),
+        )
+        if rows:
+            running_tasks_per_worker[wid] = [(str(r["task_id"]), int(r["current_attempt_id"])) for r in rows]
+
+    if not running_tasks_per_worker:
+        print("  register_worker (burst 100 + hb contention)       (skipped, no running tasks)")
+        return
+
+    resource_usage_proto = job_pb2.ResourceUsage(cpu_millicores=1000, memory_mb=1024)
+    snapshot_proto = job_pb2.WorkerResourceSnapshot()
+    heartbeat_requests: list[HeartbeatApplyRequest] = [
+        HeartbeatApplyRequest(
+            worker_id=WorkerId(wid),
+            worker_resource_snapshot=snapshot_proto,
+            updates=[
+                TaskUpdate(
+                    task_id=JobName.from_wire(tid),
+                    attempt_id=aid,
+                    new_state=job_pb2.TASK_STATE_RUNNING,
+                    resource_usage=resource_usage_proto,
+                )
+                for tid, aid in task_list
+            ],
+        )
+        for wid, task_list in running_tasks_per_worker.items()
+    ]
+
+    stop_flag = threading.Event()
+
+    def _heartbeat_loop():
+        while not stop_flag.is_set():
+            write_txns.apply_heartbeats_batch(heartbeat_requests)
+
+    contention_counter = {"n": 0}
+
+    def _burst_100_contended():
+        contention_counter["n"] += 1
+        base = f"bench-contend-{uuid.uuid4().hex[:8]}-{contention_counter['n']}"
+        for i in range(100):
+            _register_one(WorkerId(f"{base}-{i}"))
+
+    hb_thread = threading.Thread(target=_heartbeat_loop, name="bench-heartbeat", daemon=True)
+    hb_thread.start()
+    try:
+        bench(
+            "register_worker (burst 100 + hb contention, WRITE)",
+            _burst_100_contended,
+            min_runs=3,
+            min_time_s=2.0,
+        )
+    finally:
+        stop_flag.set()
+        hb_thread.join(timeout=10.0)
+
+
 def print_summary() -> None:
     print("\n" + "=" * 80)
     print(f"  {'Query':50s}  {'p50':>10s}  {'p95':>10s}  {'n':>5s}")
@@ -666,7 +1263,7 @@ def _ensure_db(db_path: Path | None) -> Path:
 @click.option(
     "--only",
     "only_group",
-    type=click.Choice(["scheduling", "dashboard", "heartbeat"]),
+    type=click.Choice(["scheduling", "dashboard", "heartbeat", "endpoints"]),
     help="Run only this group",
 )
 @click.option("--no-analyze", is_flag=True, help="Skip ANALYZE to test unoptimized query plans")
@@ -707,6 +1304,11 @@ def main(db_path: Path | None, only_group: str | None, no_analyze: bool, fresh: 
     if only_group is None or only_group == "heartbeat":
         print("[heartbeat]")
         benchmark_heartbeat(db)
+        print()
+
+    if only_group is None or only_group == "endpoints":
+        print("[endpoints]")
+        benchmark_endpoints(db)
 
     print_summary()
     db.close()

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -89,6 +89,13 @@ accidental collision with normal job names."""
 HEARTBEAT_FAILURE_THRESHOLD = 10
 """Consecutive heartbeat failures before marking worker as failed."""
 
+FAIL_HEARTBEATS_CHUNK_SIZE = 10
+"""Number of worker failures processed per transaction in
+``fail_heartbeats_batch``. Commits between chunks so the SQLite writer is
+released and other RPCs (RegisterEndpoint, Register, LaunchJob,
+apply_heartbeats_batch) can interleave. Keeps worst-case writer-hold
+below ~1s even when a zone-wide failure removes hundreds of workers."""
+
 HEARTBEAT_STALENESS_THRESHOLD = Duration.from_seconds(900)
 """If a worker's last successful heartbeat is older than this, it is failed
 immediately. Catches workers restored from a checkpoint whose backing VMs
@@ -2220,8 +2227,22 @@ class ControllerTransitions:
         failures: list[tuple[DispatchBatch, str]],
         *,
         force_remove: bool = False,
+        chunk_size: int = FAIL_HEARTBEATS_CHUNK_SIZE,
     ) -> WorkerFailureBatchResult:
-        """Apply a batch of heartbeat RPC failures in one transaction."""
+        """Apply heartbeat RPC failures in chunked transactions.
+
+        Each chunk is its own write transaction so we release the SQLite
+        writer between chunks and other RPCs (RegisterEndpoint, Register,
+        LaunchJob, apply_heartbeats_batch) can interleave instead of
+        stalling for the full batch. A single big transaction would starve
+        them for seconds when a zone-wide failure knocks out hundreds of
+        workers at once.
+
+        Heartbeat failures are idempotent at the semantic level
+        (``_record_heartbeat_failure`` guards on ``active = 1``), so
+        partial progress on crash is safe. Downstream consumers do not
+        rely on cross-worker atomicity.
+        """
         if not failures:
             return WorkerFailureBatchResult()
 
@@ -2229,26 +2250,33 @@ class ControllerTransitions:
         removed_workers: list[tuple[WorkerId, str | None]] = []
         all_tasks_to_kill: set[JobName] = set()
         all_task_kill_workers: dict[JobName, WorkerId] = {}
-        actions: list[tuple[str, str, dict[str, object]]] = []
 
-        with self._db.transaction() as cur:
-            now_ms = Timestamp.now().epoch_ms()
-            for snapshot, error in failures:
-                result = self._record_heartbeat_failure(
+        for chunk_start in range(0, len(failures), chunk_size):
+            chunk = failures[chunk_start : chunk_start + chunk_size]
+            chunk_actions: list[tuple[str, str, dict[str, object]]] = []
+            with self._db.transaction() as cur:
+                now_ms = Timestamp.now().epoch_ms()
+                for snapshot, error in chunk:
+                    result = self._record_heartbeat_failure(
+                        cur,
+                        snapshot.worker_id,
+                        error,
+                        snapshot,
+                        force_remove=force_remove,
+                        now_ms=now_ms,
+                    )
+                    results.append(result)
+                    chunk_actions.append(("worker_heartbeat_failed", str(snapshot.worker_id), {"error": error}))
+                    all_tasks_to_kill.update(result.tasks_to_kill)
+                    all_task_kill_workers.update(result.task_kill_workers)
+                    if result.worker_removed:
+                        removed_workers.append((snapshot.worker_id, snapshot.worker_address))
+                self._record_transaction(
                     cur,
-                    snapshot.worker_id,
-                    error,
-                    snapshot,
-                    force_remove=force_remove,
-                    now_ms=now_ms,
+                    "heartbeat_failures_batch",
+                    chunk_actions,
+                    payload={"count": len(chunk_actions)},
                 )
-                results.append(result)
-                actions.append(("worker_heartbeat_failed", str(snapshot.worker_id), {"error": error}))
-                all_tasks_to_kill.update(result.tasks_to_kill)
-                all_task_kill_workers.update(result.task_kill_workers)
-                if result.worker_removed:
-                    removed_workers.append((snapshot.worker_id, snapshot.worker_address))
-            self._record_transaction(cur, "heartbeat_failures_batch", actions, payload={"count": len(actions)})
 
         for worker_id, _ in removed_workers:
             self._db.remove_worker_from_attr_cache(worker_id)

--- a/lib/iris/src/iris/cluster/worker/worker.py
+++ b/lib/iris/src/iris/cluster/worker/worker.py
@@ -249,7 +249,7 @@ class Worker:
                 interceptors = (AuthTokenInjector(StaticTokenProvider(self._config.auth_token)),)
             self._controller_client = ControllerServiceClientSync(
                 address=self._config.controller_address,
-                timeout_ms=5000,
+                timeout_ms=60_000,
                 interceptors=interceptors,
             )
 


### PR DESCRIPTION
Previously one transaction covered the entire failure batch, holding the SQLite writer for ~30s when a zone-wide failure reaped hundreds of workers and starving RegisterEndpoint, Register, LaunchJob, and apply_heartbeats_batch behind BEGIN IMMEDIATE. Commit per chunk (default 10) so concurrent writers can interleave; heartbeat failures are idempotent so partial progress on crash is safe. Also bumps the worker's controller-client timeout from 5s to 60s so workers ride out residual slow RPCs rather than abandoning them. Benchmark adds tail-latency A/B probes; x50 run shows max add_endpoint latency during a failure batch drop from 5.3s to 2.4s, drain_dispatch_all from 5.4s to 2.9s, batch wall time unchanged.