### PR TITLE
[iris] Chunk terminal-task history eviction across transactions

### DIFF
--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -185,7 +185,8 @@ class _SyncFailureAccumulator:
     """Mutable accumulator for tracking failures during provider sync."""
 
     fail_count: int = 0
-    failed_workers: list[str] = field(default_factory=list)
+    transient_failed_workers: list[str] = field(default_factory=list)
+    terminal_failed_workers: list[str] = field(default_factory=list)
     all_tasks_to_kill: set[JobName] = field(default_factory=set)
     all_task_kill_workers: dict[JobName, WorkerId] = field(default_factory=dict)
 
@@ -2188,7 +2189,8 @@ class Controller:
         self._log_sync_health_summary(
             batch_count=len(batches),
             fail_count=acc.fail_count,
-            failed_workers=acc.failed_workers,
+            transient_failed_workers=acc.transient_failed_workers,
+            terminal_failed_workers=acc.terminal_failed_workers,
             elapsed_ms=round_timer.elapsed_ms(),
         )
 
@@ -2252,12 +2254,12 @@ class Controller:
             )
             if result.action == HeartbeatAction.WORKER_FAILED:
                 acc.fail_count += 1
-                acc.failed_workers.append(batch.worker_id)
+                acc.terminal_failed_workers.append(batch.worker_id)
                 self._provider.on_worker_failed(batch.worker_id, batch.worker_address)
                 primary_failed_workers.append(str(batch.worker_id))
             elif result.action == HeartbeatAction.TRANSIENT_FAILURE:
                 acc.fail_count += 1
-                acc.failed_workers.append(batch.worker_id)
+                acc.transient_failed_workers.append(batch.worker_id)
         return primary_failed_workers
 
     def _handle_sibling_worker_failures(
@@ -2282,7 +2284,7 @@ class Controller:
             self._provider.on_worker_failed(wid, addr)
         if sibling_failures.removed_workers:
             acc.fail_count += len(sibling_failures.removed_workers)
-            acc.failed_workers.extend(wid for wid, _ in sibling_failures.removed_workers)
+            acc.terminal_failed_workers.extend(wid for wid, _ in sibling_failures.removed_workers)
             logger.info(
                 "Failed %d sibling workers from slices: %s",
                 len(sibling_failures.removed_workers),
@@ -2293,17 +2295,34 @@ class Controller:
         self,
         batch_count: int,
         fail_count: int,
-        failed_workers: list[str],
+        transient_failed_workers: list[str],
+        terminal_failed_workers: list[str],
         elapsed_ms: int,
     ) -> None:
         """Log provider sync timing and periodic cluster health summary."""
         level = logging.WARNING if elapsed_ms > _SLOW_HEARTBEAT_MS else logging.DEBUG
-        fmt = "Provider sync: %d workers, %d failed, %dms"
-        args: list[object] = [batch_count, fail_count, elapsed_ms]
-        if failed_workers:
-            fmt += " failed=[%s]"
-            args.append(", ".join(failed_workers))
-        logger.log(level, fmt, *args)
+        logger.log(
+            level,
+            "Provider sync: %d workers, %d failed (%d transient, %d terminal), %dms",
+            batch_count,
+            fail_count,
+            len(transient_failed_workers),
+            len(terminal_failed_workers),
+            elapsed_ms,
+        )
+        if transient_failed_workers:
+            logger.log(
+                level,
+                "Provider sync transient failures (%d): [%s]",
+                len(transient_failed_workers),
+                ", ".join(transient_failed_workers),
+            )
+        if terminal_failed_workers:
+            logger.warning(
+                "Provider sync terminal failures (%d): [%s]",
+                len(terminal_failed_workers),
+                ", ".join(terminal_failed_workers),
+            )
 
         self._heartbeat_iteration += 1
         if _HEALTH_SUMMARY_INTERVAL.should_run():

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -120,9 +120,13 @@ memory from tasks.peak_memory_mb once a task is done; retaining per-sample
 rows forever bloats the DB (~85% of task_resource_history on prod is for
 terminal tasks) and amplifies writer contention during heartbeat batches."""
 
-TASK_RESOURCE_HISTORY_DELETE_CHUNK = 5000
-"""Maximum ids per DELETE in prune_task_resource_history — bounds how long
-the writer lock is held per chunk so other RPCs can interleave."""
+TASK_RESOURCE_HISTORY_DELETE_CHUNK = 1000
+"""Maximum task_ids per DELETE in prune_task_resource_history. Each chunk
+is its own write transaction so the writer lock releases between chunks.
+Sweep on a 1M-row prod checkpoint: chunk=1000 gives p95 ~400ms / max 1.3s
+writer hold; chunk=5000 gives p95 1.6s / max 1.7s. The background loop
+runs every 10 min so total wall-time is irrelevant — bounding worst-case
+writer hold is what matters for concurrent RPCs."""
 
 DIRECT_PROVIDER_PROMOTION_RATE = 128
 """Token bucket capacity for task promotion (pods per minute).
@@ -2806,20 +2810,22 @@ class ControllerTransitions:
         ttl_cutoff_ms = now_ms - TASK_RESOURCE_HISTORY_TERMINAL_TTL.to_ms()
         terminal_placeholders = ",".join("?" for _ in TERMINAL_TASK_STATES)
 
-        evicted_terminal = 0
-        with self._db.transaction() as cur:
+        with self._db.read_snapshot() as snap:
             terminal_ids = [
                 str(r["task_id"])
-                for r in cur.execute(
+                for r in snap.fetchall(
                     f"SELECT task_id FROM tasks "
                     f"WHERE state IN ({terminal_placeholders}) "
                     f"AND finished_at_ms IS NOT NULL AND finished_at_ms < ?",
                     (*TERMINAL_TASK_STATES, ttl_cutoff_ms),
-                ).fetchall()
+                )
             ]
-            for chunk_start in range(0, len(terminal_ids), TASK_RESOURCE_HISTORY_DELETE_CHUNK):
-                chunk = terminal_ids[chunk_start : chunk_start + TASK_RESOURCE_HISTORY_DELETE_CHUNK]
-                ph = ",".join("?" * len(chunk))
+
+        evicted_terminal = 0
+        for chunk_start in range(0, len(terminal_ids), TASK_RESOURCE_HISTORY_DELETE_CHUNK):
+            chunk = terminal_ids[chunk_start : chunk_start + TASK_RESOURCE_HISTORY_DELETE_CHUNK]
+            ph = ",".join("?" * len(chunk))
+            with self._db.transaction() as cur:
                 cur.execute(f"DELETE FROM task_resource_history WHERE task_id IN ({ph})", tuple(chunk))
                 evicted_terminal += cur.rowcount
 


### PR DESCRIPTION
Move the SELECT of expired task_ids to read_snapshot (no writer held) and give each DELETE chunk its own write transaction, mirroring fail_heartbeats_batch. Drop chunk size from 5000 to 1000: sweep on a 1M-row prod checkpoint shows chunk=1000 holds the writer for p95 ~400ms / max 1.3s per chunk vs 5000's 1.6s / 1.7s. Total wall is ~15% longer but the prune loop runs every 10 min — bounding worst-case writer hold is what matters for concurrent RPCs.

Also split provider-sync failure logs into transient vs terminal buckets so terminal failures surface at WARNING while transient blips stay at DEBUG.