### PR TITLE
[iris] Pin networkConfig.network=default on TPU create

### DIFF
--- a/lib/iris/src/iris/cluster/providers/gcp/workers.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/workers.py
@@ -415,6 +415,7 @@ class GcpWorkerProvider:
             labels=dict(config.labels),
             metadata=metadata,
             service_account=gcp.service_account or None,
+            network="default",
         )
 
         logger.info("Creating TPU slice: %s (type=%s, zone=%s)", slice_id, config.accelerator_variant, gcp.zone)
@@ -475,6 +476,7 @@ class GcpWorkerProvider:
             labels=labels,
             metadata=metadata,
             service_account=gcp.service_account or None,
+            network="default",
         )
 
         logger.info(


### PR DESCRIPTION
Set networkConfig.network=default in both preemptible and reserved TPU create paths. Manually-created QueuedResources in this project set the field explicitly; iris was leaving it blank. Pin it so iris requests match in case GCP-side placement treats the unset vs explicit-default cases differently.