### PR TITLE
[iris] Fix iris process profile default target for controller

### DIFF
--- a/lib/iris/src/iris/cli/process_status.py
+++ b/lib/iris/src/iris/cli/process_status.py
@@ -13,6 +13,7 @@ import click
 import humanfriendly
 
 from iris.cli.main import require_controller_url, rpc_client
+from iris.cluster.runtime.profile import SYSTEM_PROCESS_TARGET
 from iris.rpc import logging_pb2
 from iris.rpc import job_pb2
 from iris.rpc.logging_connect import LogServiceClientSync
@@ -146,7 +147,7 @@ def profile(
     /system/worker/<id> for a worker, /alice/job/0 for a task container.
     """
     url = require_controller_url(ctx)
-    rpc_target = target or ""
+    rpc_target = target or SYSTEM_PROCESS_TARGET
     label = target or "Controller"
 
     if profiler == "threads":


### PR DESCRIPTION
The CLI sent target="" for the default (no --target) case, which fell through is_system_target() in the controller service and hit TaskAttempt.from_wire("") raising "TaskAttempt wire format must not be empty". Send /system/process explicitly so the controller profiles its own process.