### PR TITLE
[iris] LogPusher: background drain thread, self-heal via resolver, never drop on send failures

### DIFF
--- a/lib/iris/src/iris/cluster/worker/worker.py
+++ b/lib/iris/src/iris/cluster/worker/worker.py
@@ -467,7 +467,8 @@ class Worker:
 
     def _resolve_log_service(self, server_url: str) -> str:
         """Look up ``server_url`` on the controller's endpoint registry."""
-        assert self._controller_client is not None, "controller client must exist before log resolution"
+        if self._controller_client is None:
+            raise ConnectionError("worker controller client not yet initialized")
         resp = self._controller_client.list_endpoints(
             controller_pb2.Controller.ListEndpointsRequest(prefix=server_url, exact=True),
         )

--- a/lib/iris/src/iris/cluster/worker/worker.py
+++ b/lib/iris/src/iris/cluster/worker/worker.py
@@ -460,61 +460,57 @@ class Worker:
 
         return None
 
-    def _resolve_log_service(self) -> str | None:
+    def _resolve_log_service(self, _server_url: str) -> str:
         """Resolve the LogService address via the /system/log-server endpoint.
 
-        Called before registration, so the controller may not yet be reachable.
-        Treats RPC errors and missing endpoints the same: log a warning and
-        return None so the caller can skip remote log attachment without
-        crashing the lifecycle thread.
+        Passed to ``LogPusher`` as its resolver. Raises on any failure so the
+        pusher treats the attempt as unresolved and keeps the cached client
+        slot empty; the next push will retry. The ``_server_url`` argument is
+        ignored — it only exists to satisfy the resolver signature — so
+        callers can tag the pusher with any symbolic name.
         """
-        if not self._controller_client:
-            return None
-        try:
-            resp = self._controller_client.list_endpoints(
-                controller_pb2.Controller.ListEndpointsRequest(
-                    prefix="/system/log-server",
-                    exact=True,
-                ),
-            )
-        except Exception as e:
-            logger.warning("Failed to resolve /system/log-server: %s", e)
-            return None
+        assert self._controller_client is not None, "controller client must exist before log resolution"
+        resp = self._controller_client.list_endpoints(
+            controller_pb2.Controller.ListEndpointsRequest(
+                prefix="/system/log-server",
+                exact=True,
+            ),
+        )
         if not resp.endpoints:
-            logger.warning("No /system/log-server endpoint registered on controller")
-            return None
-        addr = resp.endpoints[0].address
-        logger.info("Resolved /system/log-server -> %s", addr)
-        return addr
+            raise ConnectionError("No /system/log-server endpoint registered on controller")
+        return resp.endpoints[0].address
 
     def _attach_log_handler(self) -> None:
-        """Create LogPusher and attach RemoteLogHandler under ``worker_log_key``.
+        """Attach ``RemoteLogHandler`` under ``worker_log_key(self._worker_id)``.
 
-        Always tears down any existing handler first so each lifecycle cycle
-        re-resolves /system/log-server (picking up log-server failover) and
-        rebuilds the LogPusher against the fresh address.
-
-        Skipped when ``self._worker_id`` is not yet known locally — in that
-        (rare) case the controller will assign an id during ``_register`` and
-        the lifecycle loop re-calls this method with the canonical id.
+        Idempotent: if a pusher already exists, just rename the handler's
+        key. ``LogPusher`` self-heals via its resolver across log-server
+        failovers, so there's no teardown-and-rebuild across lifecycle
+        iterations. Skipped when ``self._worker_id`` is not yet known
+        locally — in that case the controller assigns one during
+        ``_register`` and the lifecycle loop re-calls this method.
         """
-        self._detach_log_handler()
         if not self._worker_id:
             return
-        log_addr = self._resolve_log_service()
-        if not log_addr:
-            return
-        log_interceptors = ()
-        if self._config.auth_token:
-            log_interceptors = (AuthTokenInjector(StaticTokenProvider(self._config.auth_token)),)
-        self._log_pusher = LogPusher(log_addr, interceptors=log_interceptors)
-        self._log_handler = RemoteLogHandler(
-            self._log_pusher,
-            key=worker_log_key(self._worker_id),
-        )
-        self._log_handler.setLevel(logging.INFO)
-        self._log_handler.setFormatter(logging.Formatter("%(asctime)s %(name)s %(message)s"))
-        logging.getLogger().addHandler(self._log_handler)
+        key = worker_log_key(self._worker_id)
+
+        if self._log_pusher is None:
+            log_interceptors = ()
+            if self._config.auth_token:
+                log_interceptors = (AuthTokenInjector(StaticTokenProvider(self._config.auth_token)),)
+            self._log_pusher = LogPusher(
+                "iris://system/log-server",
+                interceptors=log_interceptors,
+                resolver=self._resolve_log_service,
+            )
+
+        if self._log_handler is None:
+            self._log_handler = RemoteLogHandler(self._log_pusher, key=key)
+            self._log_handler.setLevel(logging.INFO)
+            self._log_handler.setFormatter(logging.Formatter("%(asctime)s %(name)s %(message)s"))
+            logging.getLogger().addHandler(self._log_handler)
+        else:
+            self._log_handler.key = key
 
     def _detach_log_handler(self) -> None:
         """Remove and close the current RemoteLogHandler and LogPusher if any."""

--- a/lib/iris/src/iris/cluster/worker/worker.py
+++ b/lib/iris/src/iris/cluster/worker/worker.py
@@ -252,6 +252,11 @@ class Worker:
                 timeout_ms=60_000,
                 interceptors=interceptors,
             )
+            self._log_pusher = LogPusher(
+                "/system/log-server",
+                interceptors=interceptors,
+                resolver=self._resolve_log_service,
+            )
 
             # Start lifecycle thread: register + serve + reset loop
             self._threads.spawn(target=self._run_lifecycle, name="worker-lifecycle")
@@ -460,50 +465,21 @@ class Worker:
 
         return None
 
-    def _resolve_log_service(self, _server_url: str) -> str:
-        """Resolve the LogService address via the /system/log-server endpoint.
-
-        Passed to ``LogPusher`` as its resolver. Raises on any failure so the
-        pusher treats the attempt as unresolved and keeps the cached client
-        slot empty; the next push will retry. The ``_server_url`` argument is
-        ignored — it only exists to satisfy the resolver signature — so
-        callers can tag the pusher with any symbolic name.
-        """
+    def _resolve_log_service(self, server_url: str) -> str:
+        """Look up ``server_url`` on the controller's endpoint registry."""
         assert self._controller_client is not None, "controller client must exist before log resolution"
         resp = self._controller_client.list_endpoints(
-            controller_pb2.Controller.ListEndpointsRequest(
-                prefix="/system/log-server",
-                exact=True,
-            ),
+            controller_pb2.Controller.ListEndpointsRequest(prefix=server_url, exact=True),
         )
         if not resp.endpoints:
-            raise ConnectionError("No /system/log-server endpoint registered on controller")
+            raise ConnectionError(f"No {server_url!r} endpoint registered on controller")
         return resp.endpoints[0].address
 
     def _attach_log_handler(self) -> None:
-        """Attach ``RemoteLogHandler`` under ``worker_log_key(self._worker_id)``.
-
-        Idempotent: if a pusher already exists, just rename the handler's
-        key. ``LogPusher`` self-heals via its resolver across log-server
-        failovers, so there's no teardown-and-rebuild across lifecycle
-        iterations. Skipped when ``self._worker_id`` is not yet known
-        locally — in that case the controller assigns one during
-        ``_register`` and the lifecycle loop re-calls this method.
-        """
-        if not self._worker_id:
+        """Attach or rename the remote log handler under ``worker_log_key(self._worker_id)``."""
+        if not self._worker_id or self._log_pusher is None:
             return
         key = worker_log_key(self._worker_id)
-
-        if self._log_pusher is None:
-            log_interceptors = ()
-            if self._config.auth_token:
-                log_interceptors = (AuthTokenInjector(StaticTokenProvider(self._config.auth_token)),)
-            self._log_pusher = LogPusher(
-                "iris://system/log-server",
-                interceptors=log_interceptors,
-                resolver=self._resolve_log_service,
-            )
-
         if self._log_handler is None:
             self._log_handler = RemoteLogHandler(self._log_pusher, key=key)
             self._log_handler.setLevel(logging.INFO)

--- a/lib/iris/src/iris/log_server/client.py
+++ b/lib/iris/src/iris/log_server/client.py
@@ -55,11 +55,16 @@ _BACKOFF_MAX_SEC = 30.0
 
 
 class LogPusher:
-    """Non-blocking buffered client for pushing log entries to a remote LogService.
+    """Buffered client for pushing log entries to a remote LogService.
 
-    ``push`` appends to an in-memory queue; a background thread drains it
-    in per-key batches. Send failures re-buffer and back off exponentially
-    — only the ``MAX_LOG_BUFFER_SIZE`` overflow path drops entries.
+    ``push`` is non-blocking: it appends to an in-memory queue and returns.
+    A background thread drains the queue in per-key batches. Send failures
+    re-buffer and back off exponentially — only the ``MAX_LOG_BUFFER_SIZE``
+    overflow path drops entries.
+
+    ``flush`` blocks until every entry enqueued before the call has been
+    processed (sent or overflow-dropped). Use the ``timeout`` argument to
+    bound the wait — by default ``flush`` waits indefinitely.
 
     ``server_url`` is passed to ``resolver`` (default: identity) to obtain
     the actual http address. Retryable failures invalidate the cached RPC
@@ -87,11 +92,19 @@ class LogPusher:
 
         # All shared state is guarded by _cond. The drain thread is the
         # only owner of _client, so no separate client lock. ``_queue`` is
-        # a single FIFO of (key, entry); the drain thread groups by key
-        # just before sending. Trimming on overflow is one popleft.
+        # a single FIFO of (seq, key, entry); the drain thread groups by
+        # key just before sending. Trimming on overflow is one popleft.
+        # ``seq`` is a monotonic per-entry counter used by blocking flush.
         self._cond = threading.Condition()
-        self._queue: deque[tuple[str, logging_pb2.LogEntry]] = deque()
+        self._queue: deque[tuple[int, str, logging_pb2.LogEntry]] = deque()
         self._closed = False
+
+        # Monotonic counters for blocking flush(). ``_pushed_seq`` advances
+        # on every entry enqueued. ``_processed_seq`` advances when the
+        # drain thread acks an entry as either successfully sent or
+        # overflow-dropped — both terminal states from flush's POV.
+        self._pushed_seq = 0
+        self._processed_seq = 0
 
         # Built lazily by the drain thread on first send; invalidated on
         # any failure so the next attempt re-resolves.
@@ -115,27 +128,53 @@ class LogPusher:
             if self._closed:
                 return
             for e in entries:
-                self._queue.append((key, e))
+                self._pushed_seq += 1
+                self._queue.append((self._pushed_seq, key, e))
             self._trim_oldest_locked()
             if len(self._queue) >= self._batch_size:
-                self._cond.notify()
+                self._cond.notify_all()
 
-    def flush(self) -> None:
-        """Poke the drain thread to send whatever is buffered now.
+    def flush(self, timeout: float | None = None) -> bool:
+        """Block until every entry enqueued before this call has been processed.
 
-        Non-blocking. For draining on shutdown, use ``close``.
+        "Processed" means either successfully sent or overflow-dropped —
+        both terminal states. Returns ``True`` if the drain caught up,
+        ``False`` on timeout. ``timeout=None`` waits indefinitely.
+
+        For shutdown drain, prefer ``close`` (best-effort, won't block on
+        a stuck server).
         """
         with self._cond:
-            if self._queue:
-                self._cond.notify()
+            target = self._pushed_seq
+            if target == 0 or self._processed_seq >= target:
+                return True
+            self._cond.notify_all()
+            deadline = (time.monotonic() + timeout) if timeout is not None else None
+            while self._processed_seq < target:
+                if self._closed:
+                    return self._processed_seq >= target
+                if deadline is None:
+                    # Re-check periodically so a wedged drain still surfaces.
+                    self._cond.wait(timeout=1.0)
+                else:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        return False
+                    self._cond.wait(timeout=remaining)
+            return True
 
     def close(self) -> None:
-        """Stop the drain thread after one best-effort drain, close the RPC client."""
+        """Stop the drain thread after one best-effort drain, close the RPC client.
+
+        Best-effort: if a send is in flight when ``close()`` returns the
+        join timeout, we still close the cached client. Use ``flush()``
+        first if you need to guarantee final delivery.
+        """
         with self._cond:
             if self._closed:
                 return
             self._closed = True
-            self._cond.notify()
+            self._cond.notify_all()
         # Join the drain thread; it will send what it can and exit.
         self._thread.join(timeout=max(self._flush_interval * 2, 10.0))
         if self._client is not None:
@@ -150,10 +189,17 @@ class LogPusher:
     # ------------------------------------------------------------------
 
     def _trim_oldest_locked(self) -> None:
-        """Drop oldest entries until under ``_max_buffer_size``."""
+        """Drop oldest entries until under ``_max_buffer_size``.
+
+        Dropped entries advance ``_processed_seq`` so blocking ``flush``
+        doesn't wait forever on entries that will never reach the server.
+        """
         dropped = 0
+        max_dropped_seq = 0
         while len(self._queue) > self._max_buffer_size:
-            self._queue.popleft()
+            seq, _key, _entry = self._queue.popleft()
+            if seq > max_dropped_seq:
+                max_dropped_seq = seq
             dropped += 1
         if dropped:
             logger.warning(
@@ -161,17 +207,20 @@ class LogPusher:
                 dropped,
                 self._max_buffer_size,
             )
+            if max_dropped_seq > self._processed_seq:
+                self._processed_seq = max_dropped_seq
+                self._cond.notify_all()
 
-    def _take_queue_locked(self) -> list[tuple[str, logging_pb2.LogEntry]]:
+    def _take_queue_locked(self) -> list[tuple[int, str, logging_pb2.LogEntry]]:
         """Drain the entire queue, preserving arrival order."""
         items = list(self._queue)
         self._queue.clear()
         return items
 
-    def _rebuffer_at_head_locked(self, items: list[tuple[str, logging_pb2.LogEntry]]) -> None:
+    def _rebuffer_at_head_locked(self, items: list[tuple[int, str, logging_pb2.LogEntry]]) -> None:
         """Put unsent items back at the head of the queue (original order)."""
-        for pair in reversed(items):
-            self._queue.appendleft(pair)
+        for triple in reversed(items):
+            self._queue.appendleft(triple)
         self._trim_oldest_locked()
 
     # ------------------------------------------------------------------
@@ -194,7 +243,11 @@ class LogPusher:
                     return
                 items = self._take_queue_locked()
 
-            unsent = self._send_items(items)
+            sent_max_seq, unsent = self._send_items(items)
+            with self._cond:
+                if sent_max_seq > self._processed_seq:
+                    self._processed_seq = sent_max_seq
+                    self._cond.notify_all()
             if not unsent:
                 self._backoff.reset()
                 continue
@@ -216,44 +269,50 @@ class LogPusher:
 
     def _send_items(
         self,
-        items: list[tuple[str, logging_pb2.LogEntry]],
-    ) -> list[tuple[str, logging_pb2.LogEntry]]:
+        items: list[tuple[int, str, logging_pb2.LogEntry]],
+    ) -> tuple[int, list[tuple[int, str, logging_pb2.LogEntry]]]:
         """Group ``items`` by key (stable on first occurrence) and push one
-        RPC per key. On any failure, return every item from that key onward
-        so the caller can re-buffer it at the head of the queue.
+        RPC per key. Returns ``(max_sent_seq, unsent_items)``.
 
+        On any failure, every item from that key onward is returned as
+        unsent so the caller can re-buffer it at the head of the queue.
         Every failure mode — resolver error, retryable RPC error, or
         non-retryable RPC error — re-buffers so no log entries are silently
         dropped. Retryable errors additionally invalidate the cached client
         so the next attempt re-resolves the endpoint.
         """
-        groups: dict[str, list[logging_pb2.LogEntry]] = {}
-        for key, entry in items:
-            groups.setdefault(key, []).append(entry)
+        groups: dict[str, list[tuple[int, logging_pb2.LogEntry]]] = {}
+        for seq, key, entry in items:
+            groups.setdefault(key, []).append((seq, entry))
 
         sent_keys: set[str] = set()
-        for key, entries in groups.items():
+        max_sent_seq = 0
+        for key, seq_entries in groups.items():
             try:
                 client = self._get_client()
             except Exception as exc:
                 logger.warning("LogPusher: endpoint resolution failed: %s", exc)
-                return [p for p in items if p[0] not in sent_keys]
+                return max_sent_seq, [p for p in items if p[1] not in sent_keys]
             try:
+                entries = [e for _s, e in seq_entries]
                 client.push_logs(logging_pb2.PushLogsRequest(key=key, entries=entries))
                 sent_keys.add(key)
+                for seq, _e in seq_entries:
+                    if seq > max_sent_seq:
+                        max_sent_seq = seq
             except Exception as exc:
                 retryable = is_retryable_error(exc)
                 logger.warning(
                     "LogPusher: send failure for key=%s (%d entries, retryable=%s): %s",
                     key,
-                    len(entries),
+                    len(seq_entries),
                     retryable,
                     exc,
                 )
                 if retryable:
                     self._invalidate(str(exc))
-                return [p for p in items if p[0] not in sent_keys]
-        return []
+                return max_sent_seq, [p for p in items if p[1] not in sent_keys]
+        return max_sent_seq, []
 
     def _build_client(self, address: str) -> LogServiceClientSync:
         return LogServiceClientSync(

--- a/lib/iris/src/iris/log_server/client.py
+++ b/lib/iris/src/iris/log_server/client.py
@@ -14,10 +14,12 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 from collections import deque
 from collections.abc import Callable, Iterable
 
 from connectrpc.interceptor import Interceptor
+from rigging.timing import ExponentialBackoff
 
 from iris.logging import str_to_log_level
 from iris.rpc import logging_pb2
@@ -31,9 +33,11 @@ MAX_LOG_BUFFER_SIZE = 10_000
 """Global cap on buffered entries across all keys. Older entries are
 dropped first when the cap is exceeded."""
 
-# Backoff after a retryable send failure; keeps us from hot-looping when
-# the log server is unreachable. Independent of ``flush_interval``.
-_SEND_FAILURE_BACKOFF_SEC = 1.0
+# Exponential backoff bounds between send failures. Prevents the drain
+# loop from hot-spinning when the log server is unreachable. Reset after
+# any successful batch send.
+_BACKOFF_INITIAL_SEC = 0.5
+_BACKOFF_MAX_SEC = 30.0
 
 
 class LogPusher:
@@ -95,6 +99,9 @@ class LogPusher:
         self._client: LogServiceClientSync | None = None
         if self._resolver is None:
             self._client = self._build_client(self._server_url)
+
+        # Owned by the drain thread; reset after any successful send.
+        self._backoff = ExponentialBackoff(initial=_BACKOFF_INITIAL_SEC, maximum=_BACKOFF_MAX_SEC, factor=2.0)
 
         self._thread = threading.Thread(target=self._run, name="log-pusher", daemon=True)
         self._thread.start()
@@ -203,6 +210,7 @@ class LogPusher:
 
             failed = self._send_batch(batch)
             if not failed:
+                self._backoff.reset()
                 continue
 
             with self._cond:
@@ -212,7 +220,19 @@ class LogPusher:
                     # unreachable server. Unsent entries are left in the
                     # buffers and lost on process exit.
                     return
-                self._cond.wait(timeout=_SEND_FAILURE_BACKOFF_SEC)
+            # Sleep on the backoff clock. Push-triggered notifies would
+            # re-wake us immediately and defeat the backoff, so we loop
+            # on _cond.wait until the deadline passes — only ``close()``
+            # can (correctly) shortcut by setting ``_closed``.
+            deadline = time.monotonic() + self._backoff.next_interval()
+            with self._cond:
+                while not self._closed:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        break
+                    self._cond.wait(timeout=remaining)
+                if self._closed:
+                    return
 
     def _send_batch(
         self,

--- a/lib/iris/src/iris/log_server/client.py
+++ b/lib/iris/src/iris/log_server/client.py
@@ -87,11 +87,12 @@ class LogPusher:
         self._flush_interval = flush_interval
         self._max_buffer_size = max_buffer_size
 
-        # Buffers and all shared state are guarded by _cond. The drain
-        # thread is the only owner of _client, so no separate client lock.
+        # All shared state is guarded by _cond. The drain thread is the
+        # only owner of _client, so no separate client lock. ``_queue`` is
+        # a single FIFO of (key, entry); the drain thread groups by key
+        # just before sending. Trimming on overflow is one popleft.
         self._cond = threading.Condition()
-        self._buffers: dict[str, deque[logging_pb2.LogEntry]] = {}
-        self._buffered = 0
+        self._queue: deque[tuple[str, logging_pb2.LogEntry]] = deque()
         self._closed = False
 
         # Without a resolver, build the client eagerly so we fail fast on
@@ -111,17 +112,16 @@ class LogPusher:
     # ------------------------------------------------------------------
 
     def push(self, key: str, entries: list[logging_pb2.LogEntry]) -> None:
-        """Append ``entries`` to ``key``'s buffer. Never blocks the caller."""
+        """Append ``entries`` to the outbound queue. Never blocks the caller."""
         if not entries:
             return
         with self._cond:
             if self._closed:
                 return
-            buf = self._buffers.setdefault(key, deque())
-            buf.extend(entries)
-            self._buffered += len(entries)
+            for e in entries:
+                self._queue.append((key, e))
             self._trim_oldest_locked()
-            if self._buffered >= self._batch_size:
+            if len(self._queue) >= self._batch_size:
                 self._cond.notify()
 
     def flush(self) -> None:
@@ -130,7 +130,7 @@ class LogPusher:
         Non-blocking. For draining on shutdown, use ``close``.
         """
         with self._cond:
-            if self._buffered > 0:
+            if self._queue:
                 self._cond.notify()
 
     def close(self) -> None:
@@ -154,18 +154,11 @@ class LogPusher:
     # ------------------------------------------------------------------
 
     def _trim_oldest_locked(self) -> None:
-        """Drop oldest entries across keys until under ``_max_buffer_size``."""
+        """Drop oldest entries until under ``_max_buffer_size``."""
         dropped = 0
-        while self._buffered > self._max_buffer_size:
-            for buf in self._buffers.values():
-                if buf:
-                    buf.popleft()
-                    self._buffered -= 1
-                    dropped += 1
-                    break
-            else:
-                # All buffers empty somehow — nothing left to drop.
-                break
+        while len(self._queue) > self._max_buffer_size:
+            self._queue.popleft()
+            dropped += 1
         if dropped:
             logger.warning(
                 "LogPusher buffer overflow: dropped %d oldest entries (cap=%d)",
@@ -173,24 +166,16 @@ class LogPusher:
                 self._max_buffer_size,
             )
 
-    def _take_batch_locked(self) -> list[tuple[str, list[logging_pb2.LogEntry]]]:
-        """Drain all buffered entries into a (key, entries) list."""
-        batch = [(k, list(v)) for k, v in self._buffers.items() if v]
-        for v in self._buffers.values():
-            v.clear()
-        self._buffered = 0
-        return batch
+    def _take_queue_locked(self) -> list[tuple[str, logging_pb2.LogEntry]]:
+        """Drain the entire queue, preserving arrival order."""
+        items = list(self._queue)
+        self._queue.clear()
+        return items
 
-    def _rebuffer_at_head_locked(
-        self,
-        failed: list[tuple[str, list[logging_pb2.LogEntry]]],
-    ) -> None:
-        """Put unsent entries back at the head of their key's deque."""
-        for key, entries in failed:
-            buf = self._buffers.setdefault(key, deque())
-            for e in reversed(entries):
-                buf.appendleft(e)
-                self._buffered += 1
+    def _rebuffer_at_head_locked(self, items: list[tuple[str, logging_pb2.LogEntry]]) -> None:
+        """Put unsent items back at the head of the queue (original order)."""
+        for pair in reversed(items):
+            self._queue.appendleft(pair)
         self._trim_oldest_locked()
 
     # ------------------------------------------------------------------
@@ -201,24 +186,24 @@ class LogPusher:
         """Drain loop: wait for buffered entries, send them, retry failures with backoff."""
         while True:
             with self._cond:
-                while not self._closed and self._buffered == 0:
+                while not self._closed and not self._queue:
                     self._cond.wait(timeout=self._flush_interval)
-                if self._buffered == 0:
+                if not self._queue:
                     # _closed must be True here; nothing left to flush.
                     return
-                batch = self._take_batch_locked()
+                items = self._take_queue_locked()
 
-            failed = self._send_batch(batch)
-            if not failed:
+            unsent = self._send_items(items)
+            if not unsent:
                 self._backoff.reset()
                 continue
 
             with self._cond:
-                self._rebuffer_at_head_locked(failed)
+                self._rebuffer_at_head_locked(unsent)
                 if self._closed:
                     # Best-effort on close: don't loop forever against an
                     # unreachable server. Unsent entries are left in the
-                    # buffers and lost on process exit.
+                    # queue and lost on process exit.
                     return
             # Sleep on the backoff clock. Push-triggered notifies would
             # re-wake us immediately and defeat the backoff, so we loop
@@ -234,28 +219,33 @@ class LogPusher:
                 if self._closed:
                     return
 
-    def _send_batch(
+    def _send_items(
         self,
-        batch: list[tuple[str, list[logging_pb2.LogEntry]]],
-    ) -> list[tuple[str, list[logging_pb2.LogEntry]]]:
-        """Send each (key, entries); return entries that still need delivery.
+        items: list[tuple[str, logging_pb2.LogEntry]],
+    ) -> list[tuple[str, logging_pb2.LogEntry]]:
+        """Group ``items`` by key (stable on first occurrence) and push one
+        RPC per key. On any failure, return every item from that key onward
+        so the caller can re-buffer it at the head of the queue.
 
-        Every failure — resolver error, retryable RPC error, or
-        non-retryable RPC error — re-buffers the offending batch (and
-        everything after it) so no log entries are silently dropped.
-        Retryable errors additionally invalidate the cached client so the
-        next attempt re-resolves the endpoint; non-retryable errors keep
-        the client but still retry (the caller bounds memory via
-        ``MAX_LOG_BUFFER_SIZE``).
+        Every failure mode — resolver error, retryable RPC error, or
+        non-retryable RPC error — re-buffers so no log entries are silently
+        dropped. Retryable errors additionally invalidate the cached client
+        so the next attempt re-resolves the endpoint.
         """
-        for i, (key, entries) in enumerate(batch):
+        groups: dict[str, list[logging_pb2.LogEntry]] = {}
+        for key, entry in items:
+            groups.setdefault(key, []).append(entry)
+
+        sent_keys: set[str] = set()
+        for key, entries in groups.items():
             try:
                 client = self._get_client()
             except Exception as exc:
                 logger.warning("LogPusher: endpoint resolution failed: %s", exc)
-                return list(batch[i:])
+                return [p for p in items if p[0] not in sent_keys]
             try:
                 client.push_logs(logging_pb2.PushLogsRequest(key=key, entries=entries))
+                sent_keys.add(key)
             except Exception as exc:
                 retryable = is_retryable_error(exc)
                 logger.warning(
@@ -267,7 +257,7 @@ class LogPusher:
                 )
                 if retryable:
                     self._invalidate(str(exc))
-                return list(batch[i:])
+                return [p for p in items if p[0] not in sent_keys]
         return []
 
     def _build_client(self, address: str) -> LogServiceClientSync:

--- a/lib/iris/src/iris/log_server/client.py
+++ b/lib/iris/src/iris/log_server/client.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import threading
+from collections import deque
 from collections.abc import Callable, Iterable
 
 from connectrpc.interceptor import Interceptor
@@ -26,23 +27,41 @@ from iris.rpc.logging_connect import LogServiceClientSync
 logger = logging.getLogger(__name__)
 
 
-class LogPusher:
-    """Buffered client for pushing log entries to a remote LogService.
+MAX_LOG_BUFFER_SIZE = 10_000
+"""Global cap on buffered entries across all keys. Older entries are
+dropped first when the cap is exceeded."""
 
-    Entries are buffered per-key and flushed when either ``batch_size``
-    entries accumulate or ``flush_interval`` seconds elapse.
+# Backoff after a retryable send failure; keeps us from hot-looping when
+# the log server is unreachable. Independent of ``flush_interval``.
+_SEND_FAILURE_BACKOFF_SEC = 1.0
+
+
+class LogPusher:
+    """Buffered non-blocking client for pushing log entries to a remote LogService.
+
+    ``push`` always returns immediately — entries land in an in-memory
+    deque and a dedicated background thread drains them to the LogService
+    in batches. The thread:
+
+    - sleeps on a condition variable, waking whenever ``batch_size``
+      entries accumulate, ``flush()`` is called, or after
+      ``flush_interval`` seconds (whichever fires first);
+    - on any send failure, re-buffers the batch at the head of the key's
+      deque and backs off briefly before retrying. Retryable errors
+      additionally invalidate the cached RPC client so the next attempt
+      re-resolves the endpoint;
+    - when total buffered entries exceed ``MAX_LOG_BUFFER_SIZE``, drops
+      the oldest entries across keys. This is the only path that discards
+      log entries — send failures never drop.
 
     Endpoint resolution:
         If ``resolver`` is None, ``server_url`` is used as a direct http
         address and the RPC client is built eagerly.
 
         If ``resolver`` is set, ``server_url`` is passed to it on each
-        resolution to obtain the actual http address — e.g. the worker
-        passes ``server_url="iris://system/log-server"`` with a resolver
-        that calls the controller's ``list_endpoints``. The underlying
-        client is built lazily on first push. On a retryable RPC error
-        (UNAVAILABLE / INTERNAL / DEADLINE_EXCEEDED) the cached client
-        is invalidated and the next push re-invokes the resolver.
+        resolution to obtain the actual http address. The client is built
+        lazily and invalidated on retryable failures; the next send will
+        re-invoke the resolver.
     """
 
     def __init__(
@@ -54,29 +73,182 @@ class LogPusher:
         interceptors: Iterable[Interceptor] = (),
         *,
         resolver: Callable[[str], str] | None = None,
+        max_buffer_size: int = MAX_LOG_BUFFER_SIZE,
     ) -> None:
         self._server_url = server_url
         self._resolver = resolver
         self._timeout_ms = timeout_ms
         self._interceptors = tuple(interceptors)
-
         self._batch_size = batch_size
         self._flush_interval = flush_interval
-        self._buffers: dict[str, list[logging_pb2.LogEntry]] = {}
-        self._lock = threading.Lock()
-        # Serializes RPC sends so close() can wait for in-flight flushes.
-        self._send_lock = threading.Lock()
+        self._max_buffer_size = max_buffer_size
+
+        # Buffers and all shared state are guarded by _cond. The drain
+        # thread is the only owner of _client, so no separate client lock.
+        self._cond = threading.Condition()
+        self._buffers: dict[str, deque[logging_pb2.LogEntry]] = {}
+        self._buffered = 0
         self._closed = False
 
         # Without a resolver, build the client eagerly so we fail fast on
-        # bad URLs. With a resolver, defer construction until first push —
-        # the controller may not be reachable at construction time.
+        # bad URLs. With a resolver, defer until the drain thread needs it.
         self._client: LogServiceClientSync | None = None
         if self._resolver is None:
             self._client = self._build_client(self._server_url)
 
-        self._flush_timer: threading.Timer | None = None
-        self._schedule_flush()
+        self._thread = threading.Thread(target=self._run, name="log-pusher", daemon=True)
+        self._thread.start()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def push(self, key: str, entries: list[logging_pb2.LogEntry]) -> None:
+        """Append ``entries`` to ``key``'s buffer. Never blocks the caller."""
+        if not entries:
+            return
+        with self._cond:
+            if self._closed:
+                return
+            buf = self._buffers.setdefault(key, deque())
+            buf.extend(entries)
+            self._buffered += len(entries)
+            self._trim_oldest_locked()
+            if self._buffered >= self._batch_size:
+                self._cond.notify()
+
+    def flush(self) -> None:
+        """Poke the drain thread to send whatever is buffered now.
+
+        Non-blocking. For draining on shutdown, use ``close``.
+        """
+        with self._cond:
+            if self._buffered > 0:
+                self._cond.notify()
+
+    def close(self) -> None:
+        """Stop the drain thread after one best-effort drain, close the RPC client."""
+        with self._cond:
+            if self._closed:
+                return
+            self._closed = True
+            self._cond.notify()
+        # Join the drain thread; it will send what it can and exit.
+        self._thread.join(timeout=max(self._flush_interval * 2, 10.0))
+        if self._client is not None:
+            try:
+                self._client.close()
+            except Exception:
+                logger.debug("LogPusher close: cached client close raised", exc_info=True)
+            self._client = None
+
+    # ------------------------------------------------------------------
+    # Internal — buffer management (callers hold ``_cond``)
+    # ------------------------------------------------------------------
+
+    def _trim_oldest_locked(self) -> None:
+        """Drop oldest entries across keys until under ``_max_buffer_size``."""
+        dropped = 0
+        while self._buffered > self._max_buffer_size:
+            for buf in self._buffers.values():
+                if buf:
+                    buf.popleft()
+                    self._buffered -= 1
+                    dropped += 1
+                    break
+            else:
+                # All buffers empty somehow — nothing left to drop.
+                break
+        if dropped:
+            logger.warning(
+                "LogPusher buffer overflow: dropped %d oldest entries (cap=%d)",
+                dropped,
+                self._max_buffer_size,
+            )
+
+    def _take_batch_locked(self) -> list[tuple[str, list[logging_pb2.LogEntry]]]:
+        """Drain all buffered entries into a (key, entries) list."""
+        batch = [(k, list(v)) for k, v in self._buffers.items() if v]
+        for v in self._buffers.values():
+            v.clear()
+        self._buffered = 0
+        return batch
+
+    def _rebuffer_at_head_locked(
+        self,
+        failed: list[tuple[str, list[logging_pb2.LogEntry]]],
+    ) -> None:
+        """Put unsent entries back at the head of their key's deque."""
+        for key, entries in failed:
+            buf = self._buffers.setdefault(key, deque())
+            for e in reversed(entries):
+                buf.appendleft(e)
+                self._buffered += 1
+        self._trim_oldest_locked()
+
+    # ------------------------------------------------------------------
+    # Internal — drain thread
+    # ------------------------------------------------------------------
+
+    def _run(self) -> None:
+        """Drain loop: wait for buffered entries, send them, retry failures with backoff."""
+        while True:
+            with self._cond:
+                while not self._closed and self._buffered == 0:
+                    self._cond.wait(timeout=self._flush_interval)
+                if self._buffered == 0:
+                    # _closed must be True here; nothing left to flush.
+                    return
+                batch = self._take_batch_locked()
+
+            failed = self._send_batch(batch)
+            if not failed:
+                continue
+
+            with self._cond:
+                self._rebuffer_at_head_locked(failed)
+                if self._closed:
+                    # Best-effort on close: don't loop forever against an
+                    # unreachable server. Unsent entries are left in the
+                    # buffers and lost on process exit.
+                    return
+                self._cond.wait(timeout=_SEND_FAILURE_BACKOFF_SEC)
+
+    def _send_batch(
+        self,
+        batch: list[tuple[str, list[logging_pb2.LogEntry]]],
+    ) -> list[tuple[str, list[logging_pb2.LogEntry]]]:
+        """Send each (key, entries); return entries that still need delivery.
+
+        Every failure — resolver error, retryable RPC error, or
+        non-retryable RPC error — re-buffers the offending batch (and
+        everything after it) so no log entries are silently dropped.
+        Retryable errors additionally invalidate the cached client so the
+        next attempt re-resolves the endpoint; non-retryable errors keep
+        the client but still retry (the caller bounds memory via
+        ``MAX_LOG_BUFFER_SIZE``).
+        """
+        for i, (key, entries) in enumerate(batch):
+            try:
+                client = self._get_client()
+            except Exception as exc:
+                logger.warning("LogPusher: endpoint resolution failed: %s", exc)
+                return list(batch[i:])
+            try:
+                client.push_logs(logging_pb2.PushLogsRequest(key=key, entries=entries))
+            except Exception as exc:
+                retryable = is_retryable_error(exc)
+                logger.warning(
+                    "LogPusher: send failure for key=%s (%d entries, retryable=%s): %s",
+                    key,
+                    len(entries),
+                    retryable,
+                    exc,
+                )
+                if retryable:
+                    self._invalidate(str(exc))
+                return list(batch[i:])
+        return []
 
     def _build_client(self, address: str) -> LogServiceClientSync:
         return LogServiceClientSync(
@@ -86,14 +258,10 @@ class LogPusher:
         )
 
     def _get_client(self) -> LogServiceClientSync:
-        """Return the cached RPC client, resolving + constructing on demand.
-
-        Must be called under ``_send_lock`` so invalidation is race-free
-        against other senders.
-        """
+        """Return the cached RPC client, resolving on demand. Drain-thread only."""
         if self._client is not None:
             return self._client
-        assert self._resolver is not None  # cleared only by _invalidate
+        assert self._resolver is not None
         address = self._resolver(self._server_url)
         if not address:
             raise ConnectionError(f"LogPusher resolver returned empty address for {self._server_url!r}")
@@ -102,78 +270,15 @@ class LogPusher:
         return self._client
 
     def _invalidate(self, reason: str) -> None:
-        """Drop the cached RPC client so the next send re-resolves.
-
-        Must be called under ``_send_lock``. No-op when no resolver is
-        configured (a static-URL pusher has nothing to re-resolve to).
-        """
+        """Drop the cached RPC client so the next send re-resolves. Drain-thread only."""
         if self._resolver is None or self._client is None:
             return
-        logger.warning("LogPusher: invalidating cached endpoint for %s (%s)", self._server_url, reason)
+        logger.info("LogPusher: invalidating cached endpoint for %s (%s)", self._server_url, reason)
         try:
             self._client.close()
         except Exception:
             logger.debug("LogPusher _invalidate: cached client close raised", exc_info=True)
         self._client = None
-
-    def _schedule_flush(self) -> None:
-        if self._closed:
-            return
-        self._flush_timer = threading.Timer(self._flush_interval, self._periodic_flush)
-        self._flush_timer.daemon = True
-        self._flush_timer.start()
-
-    def _periodic_flush(self) -> None:
-        self._flush_all()
-        self._schedule_flush()
-
-    def push(self, key: str, entries: list[logging_pb2.LogEntry]) -> None:
-        if not entries:
-            return
-        to_send: list[logging_pb2.LogEntry] | None = None
-        with self._lock:
-            buf = self._buffers.get(key)
-            if buf is None:
-                buf = []
-                self._buffers[key] = buf
-            buf.extend(entries)
-            if len(buf) >= self._batch_size:
-                to_send = self._buffers.pop(key, None)
-        if to_send:
-            self._send(key, to_send)
-
-    def _flush_all(self) -> None:
-        with self._lock:
-            snapshot = self._buffers
-            self._buffers = {}
-        for key, entries in snapshot.items():
-            self._send(key, entries)
-
-    def _send(self, key: str, entries: list[logging_pb2.LogEntry]) -> None:
-        with self._send_lock:
-            if self._closed:
-                return
-            try:
-                client = self._get_client()
-                client.push_logs(logging_pb2.PushLogsRequest(key=key, entries=entries))
-            except Exception as exc:
-                logger.debug("Failed to push %d log entries for key %s", len(entries), key, exc_info=True)
-                if is_retryable_error(exc):
-                    self._invalidate(str(exc))
-
-    def flush(self) -> None:
-        """Force-flush all buffered entries."""
-        self._flush_all()
-
-    def close(self) -> None:
-        if self._flush_timer is not None:
-            self._flush_timer.cancel()
-        self.flush()
-        with self._send_lock:
-            self._closed = True
-            if self._client is not None:
-                self._client.close()
-                self._client = None
 
 
 class LogServiceProxy:

--- a/lib/iris/src/iris/log_server/client.py
+++ b/lib/iris/src/iris/log_server/client.py
@@ -14,12 +14,13 @@ from __future__ import annotations
 
 import logging
 import threading
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 
 from connectrpc.interceptor import Interceptor
 
 from iris.logging import str_to_log_level
 from iris.rpc import logging_pb2
+from iris.rpc.errors import is_retryable_error
 from iris.rpc.logging_connect import LogServiceClientSync
 
 logger = logging.getLogger(__name__)
@@ -30,6 +31,18 @@ class LogPusher:
 
     Entries are buffered per-key and flushed when either ``batch_size``
     entries accumulate or ``flush_interval`` seconds elapse.
+
+    Endpoint resolution:
+        If ``resolver`` is None, ``server_url`` is used as a direct http
+        address and the RPC client is built eagerly.
+
+        If ``resolver`` is set, ``server_url`` is passed to it on each
+        resolution to obtain the actual http address — e.g. the worker
+        passes ``server_url="iris://system/log-server"`` with a resolver
+        that calls the controller's ``list_endpoints``. The underlying
+        client is built lazily on first push. On a retryable RPC error
+        (UNAVAILABLE / INTERNAL / DEADLINE_EXCEEDED) the cached client
+        is invalidated and the next push re-invokes the resolver.
     """
 
     def __init__(
@@ -39,8 +52,14 @@ class LogPusher:
         batch_size: int = 1000,
         flush_interval: float = 5.0,
         interceptors: Iterable[Interceptor] = (),
+        *,
+        resolver: Callable[[str], str] | None = None,
     ) -> None:
-        self._client = LogServiceClientSync(address=server_url, timeout_ms=timeout_ms, interceptors=tuple(interceptors))
+        self._server_url = server_url
+        self._resolver = resolver
+        self._timeout_ms = timeout_ms
+        self._interceptors = tuple(interceptors)
+
         self._batch_size = batch_size
         self._flush_interval = flush_interval
         self._buffers: dict[str, list[logging_pb2.LogEntry]] = {}
@@ -49,8 +68,53 @@ class LogPusher:
         self._send_lock = threading.Lock()
         self._closed = False
 
+        # Without a resolver, build the client eagerly so we fail fast on
+        # bad URLs. With a resolver, defer construction until first push —
+        # the controller may not be reachable at construction time.
+        self._client: LogServiceClientSync | None = None
+        if self._resolver is None:
+            self._client = self._build_client(self._server_url)
+
         self._flush_timer: threading.Timer | None = None
         self._schedule_flush()
+
+    def _build_client(self, address: str) -> LogServiceClientSync:
+        return LogServiceClientSync(
+            address=address,
+            timeout_ms=self._timeout_ms,
+            interceptors=self._interceptors,
+        )
+
+    def _get_client(self) -> LogServiceClientSync:
+        """Return the cached RPC client, resolving + constructing on demand.
+
+        Must be called under ``_send_lock`` so invalidation is race-free
+        against other senders.
+        """
+        if self._client is not None:
+            return self._client
+        assert self._resolver is not None  # cleared only by _invalidate
+        address = self._resolver(self._server_url)
+        if not address:
+            raise ConnectionError(f"LogPusher resolver returned empty address for {self._server_url!r}")
+        self._client = self._build_client(address)
+        logger.info("LogPusher resolved %s -> %s", self._server_url, address)
+        return self._client
+
+    def _invalidate(self, reason: str) -> None:
+        """Drop the cached RPC client so the next send re-resolves.
+
+        Must be called under ``_send_lock``. No-op when no resolver is
+        configured (a static-URL pusher has nothing to re-resolve to).
+        """
+        if self._resolver is None or self._client is None:
+            return
+        logger.warning("LogPusher: invalidating cached endpoint for %s (%s)", self._server_url, reason)
+        try:
+            self._client.close()
+        except Exception:
+            logger.debug("LogPusher _invalidate: cached client close raised", exc_info=True)
+        self._client = None
 
     def _schedule_flush(self) -> None:
         if self._closed:
@@ -90,9 +154,12 @@ class LogPusher:
             if self._closed:
                 return
             try:
-                self._client.push_logs(logging_pb2.PushLogsRequest(key=key, entries=entries))
-            except Exception:
+                client = self._get_client()
+                client.push_logs(logging_pb2.PushLogsRequest(key=key, entries=entries))
+            except Exception as exc:
                 logger.debug("Failed to push %d log entries for key %s", len(entries), key, exc_info=True)
+                if is_retryable_error(exc):
+                    self._invalidate(str(exc))
 
     def flush(self) -> None:
         """Force-flush all buffered entries."""
@@ -104,7 +171,9 @@ class LogPusher:
         self.flush()
         with self._send_lock:
             self._closed = True
-        self._client.close()
+            if self._client is not None:
+                self._client.close()
+                self._client = None
 
 
 class LogServiceProxy:

--- a/lib/iris/src/iris/log_server/client.py
+++ b/lib/iris/src/iris/log_server/client.py
@@ -55,30 +55,15 @@ _BACKOFF_MAX_SEC = 30.0
 
 
 class LogPusher:
-    """Buffered non-blocking client for pushing log entries to a remote LogService.
+    """Non-blocking buffered client for pushing log entries to a remote LogService.
 
-    ``push`` always returns immediately — entries land in an in-memory
-    deque and a dedicated background thread drains them to the LogService
-    in batches. The thread:
+    ``push`` appends to an in-memory queue; a background thread drains it
+    in per-key batches. Send failures re-buffer and back off exponentially
+    — only the ``MAX_LOG_BUFFER_SIZE`` overflow path drops entries.
 
-    - sleeps on a condition variable, waking whenever ``batch_size``
-      entries accumulate, ``flush()`` is called, or after
-      ``flush_interval`` seconds (whichever fires first);
-    - on any send failure, re-buffers the batch at the head of the key's
-      deque and backs off briefly before retrying. Retryable errors
-      additionally invalidate the cached RPC client so the next attempt
-      re-resolves the endpoint;
-    - when total buffered entries exceed ``MAX_LOG_BUFFER_SIZE``, drops
-      the oldest entries across keys. This is the only path that discards
-      log entries — send failures never drop.
-
-    Endpoint resolution:
-        ``server_url`` is passed to ``resolver`` (default: identity) on
-        every resolution to obtain the actual http address. The RPC client
-        is built on first send and invalidated on any failure, so the next
-        send re-invokes the resolver. For static URLs this is a rebuild
-        against the same address, which still heals a stuck TCP
-        connection.
+    ``server_url`` is passed to ``resolver`` (default: identity) to obtain
+    the actual http address. Retryable failures invalidate the cached RPC
+    client so the next send re-resolves.
     """
 
     def __init__(

--- a/lib/iris/src/iris/log_server/client.py
+++ b/lib/iris/src/iris/log_server/client.py
@@ -13,6 +13,7 @@ RemoteLogHandler: Python logging.Handler that formats records and pushes
 from __future__ import annotations
 
 import logging
+import sys
 import threading
 import time
 from collections import deque
@@ -26,7 +27,20 @@ from iris.rpc import logging_pb2
 from iris.rpc.errors import is_retryable_error
 from iris.rpc.logging_connect import LogServiceClientSync
 
+# Detached from the root logger: ``RemoteLogHandler`` lives on the root
+# logger and calls ``LogPusher.push``, so if our own diagnostics reached
+# the root they'd be enqueued right back into the pusher — a re-entrant
+# loop that silently amplifies during failure storms. We send to stderr
+# directly and set ``propagate = False`` so nothing here can feed the
+# handler we serve.
 logger = logging.getLogger(__name__)
+logger.propagate = False
+if not logger.handlers:
+    _stderr_handler = logging.StreamHandler(sys.stderr)
+    _stderr_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+    logger.addHandler(_stderr_handler)
+    if logger.level == logging.NOTSET:
+        logger.setLevel(logging.INFO)
 
 
 MAX_LOG_BUFFER_SIZE = 10_000
@@ -205,7 +219,9 @@ class LogPusher:
             # Sleep on the backoff clock. Push-triggered notifies would
             # re-wake us immediately and defeat the backoff, so we loop
             # on _cond.wait until the deadline passes — only ``close()``
-            # can (correctly) shortcut by setting ``_closed``.
+            # can (correctly) shortcut by setting ``_closed``. If close
+            # wins the race, the next iteration of the outer loop sees
+            # ``_closed`` and returns.
             deadline = time.monotonic() + self._backoff.next_interval()
             with self._cond:
                 while not self._closed:
@@ -213,8 +229,6 @@ class LogPusher:
                     if remaining <= 0:
                         break
                     self._cond.wait(timeout=remaining)
-                if self._closed:
-                    return
 
     def _send_items(
         self,

--- a/lib/iris/src/iris/log_server/client.py
+++ b/lib/iris/src/iris/log_server/client.py
@@ -179,13 +179,18 @@ class LogPusher:
     # ------------------------------------------------------------------
 
     def _run(self) -> None:
-        """Drain loop: wait for buffered entries, send them, retry failures with backoff."""
-        while True:
+        """Drain loop: wait for buffered entries, send them, retry failures with backoff.
+
+        Close semantics: on ``close()`` the drain thread performs exactly
+        one best-effort send pass over whatever is buffered, then exits.
+        A second attempt against a presumably-dead server on close would
+        just delay shutdown by the RPC timeout.
+        """
+        while not self._closed:
             with self._cond:
                 while not self._closed and not self._queue:
                     self._cond.wait(timeout=self._flush_interval)
                 if not self._queue:
-                    # _closed must be True here; nothing left to flush.
                     return
                 items = self._take_queue_locked()
 
@@ -196,17 +201,11 @@ class LogPusher:
 
             with self._cond:
                 self._rebuffer_at_head_locked(unsent)
-                if self._closed:
-                    # Best-effort on close: don't loop forever against an
-                    # unreachable server. Unsent entries are left in the
-                    # queue and lost on process exit.
-                    return
             # Sleep on the backoff clock. Push-triggered notifies would
             # re-wake us immediately and defeat the backoff, so we loop
-            # on _cond.wait until the deadline passes — only ``close()``
-            # can (correctly) shortcut by setting ``_closed``. If close
-            # wins the race, the next iteration of the outer loop sees
-            # ``_closed`` and returns.
+            # on _cond.wait until the deadline passes. ``close()`` breaks
+            # the wait via ``_closed``; the outer ``while not self._closed``
+            # then terminates the drain loop.
             deadline = time.monotonic() + self._backoff.next_interval()
             with self._cond:
                 while not self._closed:

--- a/lib/iris/src/iris/log_server/client.py
+++ b/lib/iris/src/iris/log_server/client.py
@@ -59,13 +59,12 @@ class LogPusher:
       log entries — send failures never drop.
 
     Endpoint resolution:
-        If ``resolver`` is None, ``server_url`` is used as a direct http
-        address and the RPC client is built eagerly.
-
-        If ``resolver`` is set, ``server_url`` is passed to it on each
-        resolution to obtain the actual http address. The client is built
-        lazily and invalidated on retryable failures; the next send will
-        re-invoke the resolver.
+        ``server_url`` is passed to ``resolver`` (default: identity) on
+        every resolution to obtain the actual http address. The RPC client
+        is built on first send and invalidated on any failure, so the next
+        send re-invokes the resolver. For static URLs this is a rebuild
+        against the same address, which still heals a stuck TCP
+        connection.
     """
 
     def __init__(
@@ -80,7 +79,7 @@ class LogPusher:
         max_buffer_size: int = MAX_LOG_BUFFER_SIZE,
     ) -> None:
         self._server_url = server_url
-        self._resolver = resolver
+        self._resolver: Callable[[str], str] = resolver if resolver is not None else (lambda url: url)
         self._timeout_ms = timeout_ms
         self._interceptors = tuple(interceptors)
         self._batch_size = batch_size
@@ -95,11 +94,9 @@ class LogPusher:
         self._queue: deque[tuple[str, logging_pb2.LogEntry]] = deque()
         self._closed = False
 
-        # Without a resolver, build the client eagerly so we fail fast on
-        # bad URLs. With a resolver, defer until the drain thread needs it.
+        # Built lazily by the drain thread on first send; invalidated on
+        # any failure so the next attempt re-resolves.
         self._client: LogServiceClientSync | None = None
-        if self._resolver is None:
-            self._client = self._build_client(self._server_url)
 
         # Owned by the drain thread; reset after any successful send.
         self._backoff = ExponentialBackoff(initial=_BACKOFF_INITIAL_SEC, maximum=_BACKOFF_MAX_SEC, factor=2.0)
@@ -271,7 +268,6 @@ class LogPusher:
         """Return the cached RPC client, resolving on demand. Drain-thread only."""
         if self._client is not None:
             return self._client
-        assert self._resolver is not None
         address = self._resolver(self._server_url)
         if not address:
             raise ConnectionError(f"LogPusher resolver returned empty address for {self._server_url!r}")
@@ -281,7 +277,7 @@ class LogPusher:
 
     def _invalidate(self, reason: str) -> None:
         """Drop the cached RPC client so the next send re-resolves. Drain-thread only."""
-        if self._resolver is None or self._client is None:
+        if self._client is None:
             return
         logger.info("LogPusher: invalidating cached endpoint for %s (%s)", self._server_url, reason)
         try:

--- a/lib/iris/tests/cluster/worker/test_worker.py
+++ b/lib/iris/tests/cluster/worker/test_worker.py
@@ -666,18 +666,22 @@ def test_port_binding_failure(mock_bundle_store, tmp_path):
 # ============================================================================
 
 
-def _log_server_endpoints(address: str):
-    from iris.rpc import controller_pb2
+def _worker_with_mock_pusher(config, mock_bundle_store, mock_runtime):
+    """Build a Worker and attach a fake LogPusher (normally built in start())."""
+    worker = Worker(config, bundle_store=mock_bundle_store, container_runtime=mock_runtime)
 
-    return controller_pb2.Controller.ListEndpointsResponse(
-        endpoints=[
-            controller_pb2.Controller.Endpoint(
-                endpoint_id="/system/log-server",
-                name="/system/log-server",
-                address=address,
-            )
-        ]
-    )
+    class _FakePusher:
+        def push(self, key, entries):
+            pass
+
+        def flush(self):
+            pass
+
+        def close(self):
+            pass
+
+    worker._log_pusher = _FakePusher()
+    return worker
 
 
 def test_attach_log_handler_uses_worker_log_key_before_register(mock_bundle_store, mock_runtime, tmp_path):
@@ -692,8 +696,7 @@ def test_attach_log_handler_uses_worker_log_key_before_register(mock_bundle_stor
         default_task_image="mock-image",
         worker_id="w-1",
     )
-    worker = Worker(config, bundle_store=mock_bundle_store, container_runtime=mock_runtime)
-    worker._controller_client = Mock(list_endpoints=Mock(return_value=_log_server_endpoints("http://log:9000")))
+    worker = _worker_with_mock_pusher(config, mock_bundle_store, mock_runtime)
 
     try:
         worker._attach_log_handler()
@@ -703,36 +706,22 @@ def test_attach_log_handler_uses_worker_log_key_before_register(mock_bundle_stor
         worker._detach_log_handler()
 
 
-def test_attach_log_handler_defers_resolution_to_pusher(mock_bundle_store, mock_runtime, tmp_path):
-    """A ListEndpoints RPC failure at attach time must not crash the lifecycle
-    thread. Resolution happens lazily inside LogPusher on the first push, so
-    the handler is attached even if the controller is not yet reachable."""
+def test_attach_log_handler_noop_without_worker_id(mock_bundle_store, mock_runtime, tmp_path):
+    """Before the worker_id is known, attach is a no-op."""
     config = WorkerConfig(
         port=0,
         port_range=(50000, 50100),
         cache_dir=tmp_path / "cache",
         default_task_image="mock-image",
-        worker_id="w-1",
     )
-    worker = Worker(config, bundle_store=mock_bundle_store, container_runtime=mock_runtime)
-    worker._controller_client = Mock(list_endpoints=Mock(side_effect=ConnectionError("controller down")))
+    worker = _worker_with_mock_pusher(config, mock_bundle_store, mock_runtime)
 
-    try:
-        worker._attach_log_handler()
-        # Handler attached; pusher exists but has no cached RPC client yet.
-        assert worker._log_handler is not None
-        assert worker._log_pusher is not None
-        # The controller mock was NOT called at attach time — resolution
-        # is deferred to the first send.
-        assert worker._controller_client.list_endpoints.call_count == 0
-    finally:
-        worker._detach_log_handler()
+    worker._attach_log_handler()
+    assert worker._log_handler is None
 
 
 def test_attach_log_handler_idempotent_renames_key(mock_bundle_store, mock_runtime, tmp_path):
-    """Re-attach under a new worker_id renames the handler's key in place
-    rather than rebuilding the LogPusher — the pusher owns its own
-    resolve-on-failure loop across lifecycle iterations."""
+    """Re-attach under a new worker_id renames the handler's key in place."""
     from iris.cluster.log_store import worker_log_key
 
     config = WorkerConfig(
@@ -742,26 +731,18 @@ def test_attach_log_handler_idempotent_renames_key(mock_bundle_store, mock_runti
         default_task_image="mock-image",
         worker_id="w-1",
     )
-    worker = Worker(config, bundle_store=mock_bundle_store, container_runtime=mock_runtime)
-    worker._controller_client = Mock(list_endpoints=Mock(return_value=_log_server_endpoints("http://log:9000")))
+    worker = _worker_with_mock_pusher(config, mock_bundle_store, mock_runtime)
 
     try:
         worker._attach_log_handler()
-        first_pusher = worker._log_pusher
         first_handler = worker._log_handler
-        assert first_pusher is not None
         assert first_handler is not None
 
-        # Re-attach with same id → identity preserved.
         worker._attach_log_handler()
-        assert worker._log_pusher is first_pusher
         assert worker._log_handler is first_handler
 
-        # Re-attach under a different worker_id → same pusher, same handler,
-        # renamed key.
         worker._worker_id = "w-2"
         worker._attach_log_handler()
-        assert worker._log_pusher is first_pusher
         assert worker._log_handler is first_handler
         assert first_handler.key == worker_log_key("w-2")
     finally:

--- a/lib/iris/tests/cluster/worker/test_worker.py
+++ b/lib/iris/tests/cluster/worker/test_worker.py
@@ -7,7 +7,6 @@ import hashlib
 import socket
 import time
 import zipfile
-from typing import ClassVar
 from unittest.mock import Mock
 
 import pytest
@@ -681,38 +680,7 @@ def _log_server_endpoints(address: str):
     )
 
 
-class _RecordingPusher:
-    """Records server_url so tests can observe LogPusher re-creation."""
-
-    instances: ClassVar[list["_RecordingPusher"]] = []
-
-    def __init__(self, server_url, **_kwargs):
-        self.server_url = server_url
-        _RecordingPusher.instances.append(self)
-
-    def push(self, key, entries):
-        pass
-
-    def flush(self):
-        pass
-
-    def close(self):
-        pass
-
-
-@pytest.fixture
-def recording_log_pusher(monkeypatch):
-    """Swap iris.log_server.client.LogPusher for a recorder that tracks constructions."""
-    from iris.cluster.worker import worker as worker_module
-
-    _RecordingPusher.instances = []
-    monkeypatch.setattr(worker_module, "LogPusher", _RecordingPusher)
-    yield _RecordingPusher
-
-
-def test_attach_log_handler_uses_worker_log_key_before_register(
-    mock_bundle_store, mock_runtime, tmp_path, recording_log_pusher
-):
+def test_attach_log_handler_uses_worker_log_key_before_register(mock_bundle_store, mock_runtime, tmp_path):
     """Worker known locally (e.g. via slice_id) attaches under worker_log_key
     *before* register so pre-register failures ship remote logs."""
     from iris.cluster.log_store import worker_log_key
@@ -735,8 +703,10 @@ def test_attach_log_handler_uses_worker_log_key_before_register(
         worker._detach_log_handler()
 
 
-def test_attach_log_handler_tolerates_resolve_failure(mock_bundle_store, mock_runtime, tmp_path, recording_log_pusher):
-    """A ListEndpoints RPC failure must not crash the lifecycle thread."""
+def test_attach_log_handler_defers_resolution_to_pusher(mock_bundle_store, mock_runtime, tmp_path):
+    """A ListEndpoints RPC failure at attach time must not crash the lifecycle
+    thread. Resolution happens lazily inside LogPusher on the first push, so
+    the handler is attached even if the controller is not yet reachable."""
     config = WorkerConfig(
         port=0,
         port_range=(50000, 50100),
@@ -747,15 +717,24 @@ def test_attach_log_handler_tolerates_resolve_failure(mock_bundle_store, mock_ru
     worker = Worker(config, bundle_store=mock_bundle_store, container_runtime=mock_runtime)
     worker._controller_client = Mock(list_endpoints=Mock(side_effect=ConnectionError("controller down")))
 
-    worker._attach_log_handler()
-    assert worker._log_handler is None
-    assert worker._log_pusher is None
-    assert recording_log_pusher.instances == []
+    try:
+        worker._attach_log_handler()
+        # Handler attached; pusher exists but has no cached RPC client yet.
+        assert worker._log_handler is not None
+        assert worker._log_pusher is not None
+        # The controller mock was NOT called at attach time — resolution
+        # is deferred to the first send.
+        assert worker._controller_client.list_endpoints.call_count == 0
+    finally:
+        worker._detach_log_handler()
 
 
-def test_attach_log_handler_rebuilds_pusher_on_reattach(mock_bundle_store, mock_runtime, tmp_path, recording_log_pusher):
-    """Repeated attach must tear down the old LogPusher so log-server failover
-    is picked up — protects against the regression Codex flagged."""
+def test_attach_log_handler_idempotent_renames_key(mock_bundle_store, mock_runtime, tmp_path):
+    """Re-attach under a new worker_id renames the handler's key in place
+    rather than rebuilding the LogPusher — the pusher owns its own
+    resolve-on-failure loop across lifecycle iterations."""
+    from iris.cluster.log_store import worker_log_key
+
     config = WorkerConfig(
         port=0,
         port_range=(50000, 50100),
@@ -764,17 +743,27 @@ def test_attach_log_handler_rebuilds_pusher_on_reattach(mock_bundle_store, mock_
         worker_id="w-1",
     )
     worker = Worker(config, bundle_store=mock_bundle_store, container_runtime=mock_runtime)
-    addrs = iter(["http://log-a:9000", "http://log-b:9000"])
-    worker._controller_client = Mock(list_endpoints=Mock(side_effect=lambda _req: _log_server_endpoints(next(addrs))))
+    worker._controller_client = Mock(list_endpoints=Mock(return_value=_log_server_endpoints("http://log:9000")))
 
     try:
         worker._attach_log_handler()
+        first_pusher = worker._log_pusher
+        first_handler = worker._log_handler
+        assert first_pusher is not None
+        assert first_handler is not None
+
+        # Re-attach with same id → identity preserved.
         worker._attach_log_handler()
-        assert [p.server_url for p in recording_log_pusher.instances] == [
-            "http://log-a:9000",
-            "http://log-b:9000",
-        ]
-        assert worker._log_pusher is recording_log_pusher.instances[-1]
+        assert worker._log_pusher is first_pusher
+        assert worker._log_handler is first_handler
+
+        # Re-attach under a different worker_id → same pusher, same handler,
+        # renamed key.
+        worker._worker_id = "w-2"
+        worker._attach_log_handler()
+        assert worker._log_pusher is first_pusher
+        assert worker._log_handler is first_handler
+        assert first_handler.key == worker_log_key("w-2")
     finally:
         worker._detach_log_handler()
 

--- a/lib/iris/tests/test_remote_log_handler.py
+++ b/lib/iris/tests/test_remote_log_handler.py
@@ -7,7 +7,10 @@ import logging
 import threading
 
 import pytest
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
 
+from iris.log_server import client as client_mod
 from iris.log_server.client import LogPusher, RemoteLogHandler
 from iris.rpc import logging_pb2
 
@@ -231,3 +234,157 @@ def test_close_waits_for_inflight_send():
     assert close_done.wait(timeout=5.0), "close() never completed"
     t.join(timeout=1.0)
     assert not client_closed_during_send, "client was destroyed while _send was in flight"
+
+
+# ---------------------------------------------------------------------------
+# Resolver-based LogPusher (self-healing on log-server failover)
+# ---------------------------------------------------------------------------
+
+
+class _FakeLogServiceClient:
+    """Records pushes and can be seeded with errors to raise."""
+
+    def __init__(self, address, **_kwargs):
+        self.address = address
+        self.pushes: list[logging_pb2.PushLogsRequest] = []
+        self.errors: list[Exception] = []
+        self.closed = False
+
+    def push_logs(self, request):
+        if self.errors:
+            raise self.errors.pop(0)
+        self.pushes.append(request)
+        return logging_pb2.PushLogsResponse()
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def tracked_log_service_client(monkeypatch):
+    """Patch LogServiceClientSync to track every constructed instance."""
+    created: list[_FakeLogServiceClient] = []
+
+    def factory(address, timeout_ms=10_000, interceptors=()):
+        c = _FakeLogServiceClient(address, timeout_ms=timeout_ms, interceptors=interceptors)
+        created.append(c)
+        return c
+
+    monkeypatch.setattr(client_mod, "LogServiceClientSync", factory)
+    return created
+
+
+def _entry(data="line"):
+    e = logging_pb2.LogEntry(source="test", data=data, level=logging_pb2.LOG_LEVEL_INFO)
+    e.timestamp.epoch_ms = 1
+    return e
+
+
+def test_resolver_called_lazily_and_cached(tracked_log_service_client):
+    calls = []
+
+    def resolver(url):
+        calls.append(url)
+        return "http://resolved:1"
+
+    pusher = LogPusher("iris://system/log-server", batch_size=1, resolver=resolver)
+    try:
+        # No resolution yet — pusher is deferred.
+        assert calls == []
+        assert tracked_log_service_client == []
+
+        pusher.push("k", [_entry("a")])
+        assert calls == ["iris://system/log-server"]
+        assert len(tracked_log_service_client) == 1
+
+        # Second push reuses cached client.
+        pusher.push("k", [_entry("b")])
+        assert calls == ["iris://system/log-server"]
+        assert len(tracked_log_service_client) == 1
+        assert len(tracked_log_service_client[0].pushes) == 2
+    finally:
+        pusher.close()
+
+
+def test_retryable_error_invalidates_and_reresolves(tracked_log_service_client):
+    addresses = iter(["http://a:1", "http://b:2"])
+
+    def resolver(_url):
+        return next(addresses)
+
+    pusher = LogPusher("iris://system/log-server", batch_size=1, resolver=resolver)
+    try:
+        pusher.push("k", [_entry("a")])
+        assert tracked_log_service_client[0].address == "http://a:1"
+
+        # Next push: UNAVAILABLE on the cached client → invalidate.
+        tracked_log_service_client[0].errors.append(ConnectError(Code.UNAVAILABLE, "gone"))
+        pusher.push("k", [_entry("b")])
+        assert tracked_log_service_client[0].closed is True
+
+        # Next push triggers re-resolve + new client.
+        pusher.push("k", [_entry("c")])
+        assert len(tracked_log_service_client) == 2
+        assert tracked_log_service_client[1].address == "http://b:2"
+        assert len(tracked_log_service_client[1].pushes) == 1
+    finally:
+        pusher.close()
+
+
+def test_non_retryable_error_does_not_invalidate(tracked_log_service_client):
+    pusher = LogPusher("iris://system/log-server", batch_size=1, resolver=lambda _url: "http://a:1")
+    try:
+        pusher.push("k", [_entry("a")])
+        assert len(tracked_log_service_client) == 1
+
+        # NOT_FOUND is not retryable — pusher keeps its cached client.
+        tracked_log_service_client[0].errors.append(ConnectError(Code.NOT_FOUND, "missing"))
+        pusher.push("k", [_entry("b")])
+
+        assert len(tracked_log_service_client) == 1
+        assert tracked_log_service_client[0].closed is False
+    finally:
+        pusher.close()
+
+
+def test_resolver_raising_is_retried_on_next_push(tracked_log_service_client):
+    attempts = []
+
+    def resolver(_url):
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise ConnectionError("controller down")
+        return "http://good:1"
+
+    pusher = LogPusher("iris://system/log-server", batch_size=1, resolver=resolver)
+    try:
+        # First push: resolver raises. Entry is lost (best-effort) but
+        # pusher stays healthy — no cached client to invalidate.
+        pusher.push("k", [_entry("a")])
+        assert len(attempts) == 1
+        assert tracked_log_service_client == []
+
+        # Second push: resolver succeeds this time.
+        pusher.push("k", [_entry("b")])
+        assert len(attempts) == 2
+        assert len(tracked_log_service_client) == 1
+        assert len(tracked_log_service_client[0].pushes) == 1
+    finally:
+        pusher.close()
+
+
+def test_static_url_pusher_unchanged(tracked_log_service_client):
+    """Without a resolver the pusher builds its client eagerly — legacy behavior."""
+    pusher = LogPusher("http://h:1", batch_size=1)
+    try:
+        # Eager construction at __init__ time.
+        assert len(tracked_log_service_client) == 1
+        assert tracked_log_service_client[0].address == "http://h:1"
+
+        # Retryable error does NOT invalidate — there's nothing to re-resolve to.
+        tracked_log_service_client[0].errors.append(ConnectError(Code.UNAVAILABLE, "gone"))
+        pusher.push("k", [_entry("a")])
+        assert tracked_log_service_client[0].closed is False
+        assert len(tracked_log_service_client) == 1
+    finally:
+        pusher.close()

--- a/lib/iris/tests/test_remote_log_handler.py
+++ b/lib/iris/tests/test_remote_log_handler.py
@@ -183,22 +183,23 @@ def test_overflow_drops_oldest(tracked_log_service_client, caplog):
         flush_interval=999.0,
         max_buffer_size=3,
     )
+    # The pusher's own logger is detached from the root (to avoid
+    # re-entry via RemoteLogHandler); attach caplog's handler directly.
+    client_logger = logging.getLogger("iris.log_server.client")
+    client_logger.addHandler(caplog.handler)
+    client_logger.setLevel(logging.WARNING)
     try:
-        with caplog.at_level(logging.WARNING, logger="iris.log_server.client"):
-            entries = [
-                logging_pb2.LogEntry(source="test", data=str(i), level=logging_pb2.LOG_LEVEL_INFO) for i in range(5)
-            ]
-            pusher.push("k", entries)
+        entries = [logging_pb2.LogEntry(source="test", data=str(i), level=logging_pb2.LOG_LEVEL_INFO) for i in range(5)]
+        pusher.push("k", entries)
         pusher.flush()
         pusher.close()
         datas = [e.data for p in tracked_log_service_client[0].pushes for e in p.entries]
         # Oldest 2 dropped; "2","3","4" survive in order.
         assert datas == ["2", "3", "4"]
         assert any("buffer overflow" in r.message for r in caplog.records)
-    except Exception:
-        # Best-effort cleanup for test failures.
+    finally:
+        client_logger.removeHandler(caplog.handler)
         pusher.close()
-        raise
 
 
 def test_retryable_failure_rebuffers_at_head(monkeypatch):

--- a/lib/iris/tests/test_remote_log_handler.py
+++ b/lib/iris/tests/test_remote_log_handler.py
@@ -117,7 +117,11 @@ def _wait_for(predicate, timeout: float = 5.0) -> None:
 
 
 def test_log_pusher_buffers_and_flushes_on_demand(tracked_log_service_client):
-    """Entries buffered below batch_size are drained on flush()."""
+    """Entries buffered below batch_size are drained on flush().
+
+    flush() blocks until every entry enqueued before the call has shipped,
+    so the assertions can run immediately without polling.
+    """
     pusher = LogPusher(
         "http://h:1",
         batch_size=1000,
@@ -127,11 +131,58 @@ def test_log_pusher_buffers_and_flushes_on_demand(tracked_log_service_client):
         entry = logging_pb2.LogEntry(source="test", data="line1")
         pusher.push("key-a", [entry, entry, entry])
         pusher.push("key-b", [entry])
-        pusher.flush()
-        _wait_for(lambda: len(tracked_log_service_client) == 1 and len(tracked_log_service_client[0].pushes) >= 2)
+        assert pusher.flush(timeout=5.0)
 
         totals = {p.key: len(p.entries) for p in tracked_log_service_client[0].pushes}
         assert totals == {"key-a": 3, "key-b": 1}
+    finally:
+        pusher.close()
+
+
+def test_log_pusher_flush_is_blocking(tracked_log_service_client):
+    """flush() returns only after every previously-pushed entry has been sent."""
+    pusher = LogPusher(
+        "http://h:1",
+        batch_size=1000,
+        flush_interval=999.0,
+    )
+    try:
+        entry = logging_pb2.LogEntry(source="test", data="line")
+        pusher.push("k", [entry, entry])
+        # No polling — flush must block until shipped.
+        assert pusher.flush(timeout=5.0) is True
+        assert len(tracked_log_service_client[0].pushes) == 1
+        assert len(tracked_log_service_client[0].pushes[0].entries) == 2
+    finally:
+        pusher.close()
+
+
+def test_log_pusher_flush_timeout_returns_false(monkeypatch):
+    """flush(timeout=...) returns False when the drain can't catch up in time.
+
+    Seeds a non-retryable error so the drain rebuffers and enters the
+    backoff window; flush is given less time than the backoff interval.
+    """
+    created: list[_FakeLogServiceClient] = []
+
+    def factory(address, timeout_ms=10_000, interceptors=()):
+        c = _FakeLogServiceClient(address, timeout_ms=timeout_ms, interceptors=interceptors)
+        created.append(c)
+        return c
+
+    monkeypatch.setattr(client_mod, "LogServiceClientSync", factory)
+
+    pusher = LogPusher("http://h:1", batch_size=1, flush_interval=999.0)
+    try:
+        entry = logging_pb2.LogEntry(source="test", data="primer")
+        pusher.push("k", [entry])
+        # Wait for the cached client to exist, then seed a non-retryable
+        # error so the next send rebuffers and the drain enters backoff.
+        assert pusher.flush(timeout=5.0) is True
+        created[0].errors.append(ConnectError(Code.NOT_FOUND, "missing"))
+        pusher.push("k", [logging_pb2.LogEntry(source="test", data="stuck")])
+        # Backoff is 0.5s; a 0.05s flush cannot catch up.
+        assert pusher.flush(timeout=0.05) is False
     finally:
         pusher.close()
 
@@ -305,8 +356,9 @@ def test_failures_always_deliver_via_retry(monkeypatch, scenario):
         # for resolver_raises, which has no client to seed).
         pusher.push("k", [_entry("a")])
         if scenario != "resolver_raises":
-            _wait_for(lambda: created and created[0].pushes)
-            # Seed the cached client with the scenario-appropriate error.
+            # Block until "a" has shipped, so seeding the next error is
+            # race-free with the drain thread's next iteration.
+            assert pusher.flush(timeout=5.0)
             err = (
                 ConnectError(Code.NOT_FOUND, "missing")
                 if scenario == "non_retryable"
@@ -316,15 +368,19 @@ def test_failures_always_deliver_via_retry(monkeypatch, scenario):
 
         pusher.push("k", [_entry("b")])
 
-        # "b" must eventually land somewhere.
+        # Wait deterministically for "b" to be processed (sent or dropped).
+        assert pusher.flush(timeout=10.0)
+
+        # "b" must have landed somewhere — the buffer-overflow path is not
+        # exercised here, so processed implies delivered.
         def delivered():
             return any(any(e.data == "b" for p in c.pushes for e in p.entries) for c in created)
 
-        _wait_for(delivered, timeout=10.0)
+        assert delivered(), "entry 'b' was never delivered to any client"
 
         if scenario.startswith("retryable"):
             # Retryable RPC failure invalidated the first client; second built.
-            _wait_for(lambda: len(created) >= 2)
+            assert len(created) >= 2
             assert created[0].closed is True
         elif scenario == "resolver_raises":
             # Resolver raised on first call → no client yet. Second call

--- a/lib/iris/tests/test_remote_log_handler.py
+++ b/lib/iris/tests/test_remote_log_handler.py
@@ -128,7 +128,7 @@ def test_log_pusher_buffers_and_flushes_on_demand(tracked_log_service_client):
         pusher.push("key-a", [entry, entry, entry])
         pusher.push("key-b", [entry])
         pusher.flush()
-        _wait_for(lambda: len(tracked_log_service_client[0].pushes) >= 2)
+        _wait_for(lambda: len(tracked_log_service_client) == 1 and len(tracked_log_service_client[0].pushes) >= 2)
 
         totals = {p.key: len(p.entries) for p in tracked_log_service_client[0].pushes}
         assert totals == {"key-a": 3, "key-b": 1}
@@ -147,14 +147,13 @@ def test_log_pusher_flushes_at_batch_size(tracked_log_service_client):
         entry = logging_pb2.LogEntry(source="test", data="line")
         pusher.push("k", [entry])
         # One entry is below batch_size — nothing should ship yet.
-        # Small sleep lets any bogus wake happen (test will still catch).
         import time as _time
 
         _time.sleep(0.05)
-        assert tracked_log_service_client[0].pushes == []
+        assert tracked_log_service_client == [] or tracked_log_service_client[0].pushes == []
 
         pusher.push("k", [entry])
-        _wait_for(lambda: len(tracked_log_service_client[0].pushes) == 1)
+        _wait_for(lambda: len(tracked_log_service_client) == 1 and len(tracked_log_service_client[0].pushes) == 1)
         assert tracked_log_service_client[0].pushes[0].key == "k"
         assert len(tracked_log_service_client[0].pushes[0].entries) == 2
     finally:
@@ -376,23 +375,28 @@ def test_resolver_raising_is_retried(tracked_log_service_client):
         pusher.close()
 
 
-def test_static_url_pusher_retries_without_invalidating(tracked_log_service_client):
-    """Without a resolver, retryable failures re-buffer and retry on the same client."""
+def test_static_url_pusher_reconnects_on_retryable_failure(tracked_log_service_client):
+    """A retryable failure against a static URL invalidates the cached RPC
+    client and rebuilds against the same URL — heals a stuck TCP connection
+    even without a resolver that can point elsewhere."""
     pusher = LogPusher(
         "http://h:1",
         batch_size=1,
         flush_interval=0.1,
     )
     try:
-        assert len(tracked_log_service_client) == 1
+        pusher.push("k", [_entry("a")])
+        _wait_for(lambda: len(tracked_log_service_client) == 1 and tracked_log_service_client[0].pushes)
         assert tracked_log_service_client[0].address == "http://h:1"
 
-        # One UNAVAILABLE, then success on retry.
+        # Seed a retryable failure on the current client.
         tracked_log_service_client[0].errors.append(ConnectError(Code.UNAVAILABLE, "gone"))
-        pusher.push("k", [_entry("a")])
-        _wait_for(lambda: len(tracked_log_service_client[0].pushes) == 1)
-        # Same client — no resolver means no re-resolution.
-        assert tracked_log_service_client[0].closed is False
-        assert len(tracked_log_service_client) == 1
+        pusher.push("k", [_entry("b")])
+
+        # Client invalidated + new client built against the same URL.
+        _wait_for(lambda: len(tracked_log_service_client) == 2)
+        assert tracked_log_service_client[0].closed is True
+        assert tracked_log_service_client[1].address == "http://h:1"
+        _wait_for(lambda: len(tracked_log_service_client[1].pushes) == 1)
     finally:
         pusher.close()

--- a/lib/iris/tests/test_remote_log_handler.py
+++ b/lib/iris/tests/test_remote_log_handler.py
@@ -202,38 +202,6 @@ def test_overflow_drops_oldest(tracked_log_service_client, caplog):
         pusher.close()
 
 
-def test_retryable_failure_rebuffers_at_head(monkeypatch):
-    """On a retryable send failure the batch is re-buffered at the head and
-    drained on the next successful attempt."""
-    created: list[_FakeLogServiceClient] = []
-
-    def factory(address, timeout_ms=10_000, interceptors=()):
-        c = _FakeLogServiceClient(address, timeout_ms=timeout_ms, interceptors=interceptors)
-        if not created:
-            c.errors = [ConnectError(Code.UNAVAILABLE, "gone") for _ in range(3)]
-        created.append(c)
-        return c
-
-    monkeypatch.setattr(client_mod, "LogServiceClientSync", factory)
-
-    addresses = iter(["http://a:1", "http://b:2"])
-    pusher = LogPusher(
-        "/system/log-server",
-        batch_size=1,
-        flush_interval=999.0,
-        resolver=lambda _url: next(addresses),
-    )
-    try:
-        pusher.push("k", [logging_pb2.LogEntry(source="test", data="a", level=logging_pb2.LOG_LEVEL_INFO)])
-        # Wait for the drain thread to fail on client #0 and re-resolve to #1.
-        _wait_for(lambda: len(created) == 2)
-        _wait_for(lambda: len(created[1].pushes) == 1)
-        assert created[0].closed is True
-        assert created[1].pushes[0].entries[0].data == "a"
-    finally:
-        pusher.close()
-
-
 # ---------------------------------------------------------------------------
 # Resolver-based LogPusher (self-healing on log-server failover)
 # ---------------------------------------------------------------------------
@@ -278,126 +246,93 @@ def _entry(data="line"):
     return e
 
 
-def test_resolver_called_lazily_and_cached(tracked_log_service_client):
-    calls = []
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        # Retryable RPC failure, resolver points elsewhere on the retry —
+        # the common log-server failover case.
+        "retryable_with_resolver_failover",
+        # Retryable RPC failure against a fixed URL — rebuilds the RPC
+        # client to heal a stuck TCP connection.
+        "retryable_static_url",
+        # Resolver itself raises on first call — rebuffers, retries, and
+        # the next resolver call succeeds.
+        "resolver_raises",
+        # Non-retryable RPC error — rebuffers (no drops) but does NOT
+        # invalidate the cached client.
+        "non_retryable",
+    ],
+)
+def test_failures_always_deliver_via_retry(monkeypatch, scenario):
+    """No send-failure path drops entries; the retry loop eventually delivers.
 
-    def resolver(url):
-        calls.append(url)
-        return "http://resolved:1"
+    Asserts the delivery guarantee across all failure kinds. Per-scenario
+    extras check the side-effects (invalidate vs keep client, resolver
+    re-invoked or not).
+    """
+    created: list[_FakeLogServiceClient] = []
 
-    pusher = LogPusher("iris://system/log-server", batch_size=1, resolver=resolver)
-    try:
-        # Drain thread hasn't needed a client yet.
-        assert calls == []
-        assert tracked_log_service_client == []
+    def factory(address, timeout_ms=10_000, interceptors=()):
+        c = _FakeLogServiceClient(address, timeout_ms=timeout_ms, interceptors=interceptors)
+        created.append(c)
+        return c
 
-        pusher.push("k", [_entry("a")])
-        _wait_for(lambda: len(tracked_log_service_client) == 1)
-        assert calls == ["iris://system/log-server"]
+    monkeypatch.setattr(client_mod, "LogServiceClientSync", factory)
 
-        pusher.push("k", [_entry("b")])
-        _wait_for(lambda: len(tracked_log_service_client[0].pushes) == 2)
-        assert calls == ["iris://system/log-server"]
-        assert len(tracked_log_service_client) == 1
-    finally:
-        pusher.close()
+    pusher: LogPusher
+    if scenario == "retryable_with_resolver_failover":
+        addrs = iter(["http://a:1", "http://b:2"])
+        pusher = LogPusher("iris://x", batch_size=1, flush_interval=0.1, resolver=lambda _url: next(addrs))
+    elif scenario == "retryable_static_url":
+        pusher = LogPusher("http://h:1", batch_size=1, flush_interval=0.1)
+    elif scenario == "resolver_raises":
+        attempts: list[int] = []
 
-
-def test_retryable_error_invalidates_and_reresolves(tracked_log_service_client):
-    addresses = iter(["http://a:1", "http://b:2"])
-    pusher = LogPusher("iris://system/log-server", batch_size=1, resolver=lambda _url: next(addresses))
-    try:
-        pusher.push("k", [_entry("a")])
-        _wait_for(lambda: len(tracked_log_service_client) == 1 and tracked_log_service_client[0].pushes)
-        assert tracked_log_service_client[0].address == "http://a:1"
-
-        # Seed the cached client with a retryable failure; next send
-        # invalidates, re-resolves to #b, and delivers.
-        tracked_log_service_client[0].errors.append(ConnectError(Code.UNAVAILABLE, "gone"))
-        pusher.push("k", [_entry("b")])
-        _wait_for(lambda: len(tracked_log_service_client) == 2)
-        assert tracked_log_service_client[0].closed is True
-        assert tracked_log_service_client[1].address == "http://b:2"
-        _wait_for(lambda: len(tracked_log_service_client[1].pushes) == 1)
-    finally:
-        pusher.close()
-
-
-def test_non_retryable_error_rebuffers_without_invalidating(tracked_log_service_client):
-    """Non-retryable errors re-buffer the entry (no drops) but keep the cached
-    client — the next attempt retries on the same endpoint."""
-    pusher = LogPusher("iris://system/log-server", batch_size=1, resolver=lambda _url: "http://a:1")
-    try:
-        pusher.push("k", [_entry("a")])
-        _wait_for(lambda: len(tracked_log_service_client) == 1 and tracked_log_service_client[0].pushes)
-
-        # Seed one NOT_FOUND: the entry is re-buffered and then delivered on
-        # the next attempt against the same (not invalidated) client.
-        tracked_log_service_client[0].errors.append(ConnectError(Code.NOT_FOUND, "missing"))
-        pusher.push("k", [_entry("b")])
-        _wait_for(lambda: len(tracked_log_service_client[0].errors) == 0)
-        _wait_for(lambda: len(tracked_log_service_client[0].pushes) == 2)
-
-        assert len(tracked_log_service_client) == 1
-        assert tracked_log_service_client[0].closed is False
-        assert [p.entries[0].data for p in tracked_log_service_client[0].pushes] == ["a", "b"]
-    finally:
-        pusher.close()
-
-
-def test_resolver_raising_is_retried(tracked_log_service_client):
-    """A resolver failure re-buffers the pending entries; the next
-    successful resolution drains them."""
-    attempts = []
-    lock = threading.Lock()
-
-    def resolver(_url):
-        with lock:
+        def resolver(_url):
             attempts.append(1)
-            n = len(attempts)
-        if n == 1:
-            raise ConnectionError("controller down")
-        return "http://good:1"
+            if len(attempts) == 1:
+                raise ConnectionError("controller down")
+            return "http://good:1"
 
-    pusher = LogPusher(
-        "iris://system/log-server",
-        batch_size=1,
-        flush_interval=0.1,
-        resolver=resolver,
-    )
+        pusher = LogPusher("iris://x", batch_size=1, flush_interval=0.1, resolver=resolver)
+    elif scenario == "non_retryable":
+        pusher = LogPusher("iris://x", batch_size=1, flush_interval=0.1, resolver=lambda _url: "http://a:1")
+    else:
+        raise AssertionError(scenario)
+
     try:
+        # First push — forces the drain thread to produce a client (except
+        # for resolver_raises, which has no client to seed).
         pusher.push("k", [_entry("a")])
-        # First attempt raises, backoff, second attempt succeeds.
-        _wait_for(lambda: len(tracked_log_service_client) == 1, timeout=10.0)
-        _wait_for(lambda: len(tracked_log_service_client[0].pushes) == 1)
-        with lock:
-            assert len(attempts) >= 2
-    finally:
-        pusher.close()
+        if scenario != "resolver_raises":
+            _wait_for(lambda: created and created[0].pushes)
+            # Seed the cached client with the scenario-appropriate error.
+            err = (
+                ConnectError(Code.NOT_FOUND, "missing")
+                if scenario == "non_retryable"
+                else ConnectError(Code.UNAVAILABLE, "gone")
+            )
+            created[0].errors.append(err)
 
-
-def test_static_url_pusher_reconnects_on_retryable_failure(tracked_log_service_client):
-    """A retryable failure against a static URL invalidates the cached RPC
-    client and rebuilds against the same URL — heals a stuck TCP connection
-    even without a resolver that can point elsewhere."""
-    pusher = LogPusher(
-        "http://h:1",
-        batch_size=1,
-        flush_interval=0.1,
-    )
-    try:
-        pusher.push("k", [_entry("a")])
-        _wait_for(lambda: len(tracked_log_service_client) == 1 and tracked_log_service_client[0].pushes)
-        assert tracked_log_service_client[0].address == "http://h:1"
-
-        # Seed a retryable failure on the current client.
-        tracked_log_service_client[0].errors.append(ConnectError(Code.UNAVAILABLE, "gone"))
         pusher.push("k", [_entry("b")])
 
-        # Client invalidated + new client built against the same URL.
-        _wait_for(lambda: len(tracked_log_service_client) == 2)
-        assert tracked_log_service_client[0].closed is True
-        assert tracked_log_service_client[1].address == "http://h:1"
-        _wait_for(lambda: len(tracked_log_service_client[1].pushes) == 1)
+        # "b" must eventually land somewhere.
+        def delivered():
+            return any(any(e.data == "b" for p in c.pushes for e in p.entries) for c in created)
+
+        _wait_for(delivered, timeout=10.0)
+
+        if scenario.startswith("retryable"):
+            # Retryable RPC failure invalidated the first client; second built.
+            _wait_for(lambda: len(created) >= 2)
+            assert created[0].closed is True
+        elif scenario == "resolver_raises":
+            # Resolver raised on first call → no client yet. Second call
+            # succeeded → exactly one client created.
+            assert len(created) == 1
+        elif scenario == "non_retryable":
+            # Same client retries; no invalidate, no rebuild.
+            assert len(created) == 1
+            assert created[0].closed is False
     finally:
         pusher.close()

--- a/lib/iris/tests/test_remote_log_handler.py
+++ b/lib/iris/tests/test_remote_log_handler.py
@@ -104,136 +104,134 @@ def test_no_deadlock_on_push_failure():
     assert finished, "RemoteLogHandler deadlocked on push failure"
 
 
-def test_log_pusher_buffers_and_flushes():
-    """LogPusher buffers entries and flushes on flush() call."""
-    sent: list[tuple[str, int]] = []
+def _wait_for(predicate, timeout: float = 5.0) -> None:
+    """Poll ``predicate`` for up to ``timeout`` seconds. Assert on timeout."""
+    import time as _time
 
-    class RecordingPusher(LogPusher):
-        """Override _send to record without RPC."""
-
-        def __init__(self):
-            # Skip real __init__ to avoid RPC client setup.
-            self._batch_size = 1000
-            self._flush_interval = 999.0
-            self._buffers: dict[str, list[logging_pb2.LogEntry]] = {}
-            self._lock = threading.Lock()
-            self._send_lock = threading.Lock()
-            self._closed = False
-            self._flush_timer = None
-
-        def _send(self, key: str, entries: list[logging_pb2.LogEntry]) -> None:
-            sent.append((key, len(entries)))
-
-    pusher = RecordingPusher()
-
-    entry = logging_pb2.LogEntry(source="test", data="line1")
-    pusher.push("key-a", [entry])
-    pusher.push("key-a", [entry, entry])
-    pusher.push("key-b", [entry])
-
-    assert len(sent) == 0  # Still buffered
-
-    pusher.flush()
-
-    assert ("key-a", 3) in sent
-    assert ("key-b", 1) in sent
+    deadline = _time.monotonic() + timeout
+    while _time.monotonic() < deadline:
+        if predicate():
+            return
+        _time.sleep(0.01)
+    raise AssertionError(f"predicate {predicate!r} never became true within {timeout}s")
 
 
-def test_log_pusher_flushes_at_batch_size():
-    """LogPusher flushes automatically when batch_size is reached."""
-    sent: list[tuple[str, int]] = []
+def test_log_pusher_buffers_and_flushes_on_demand(tracked_log_service_client):
+    """Entries buffered below batch_size are drained on flush()."""
+    pusher = LogPusher(
+        "http://h:1",
+        batch_size=1000,
+        flush_interval=999.0,  # don't rely on periodic wake
+    )
+    try:
+        entry = logging_pb2.LogEntry(source="test", data="line1")
+        pusher.push("key-a", [entry, entry, entry])
+        pusher.push("key-b", [entry])
+        pusher.flush()
+        _wait_for(lambda: len(tracked_log_service_client[0].pushes) >= 2)
 
-    class RecordingPusher(LogPusher):
-        def __init__(self):
-            self._batch_size = 2
-            self._flush_interval = 999.0
-            self._buffers: dict[str, list[logging_pb2.LogEntry]] = {}
-            self._lock = threading.Lock()
-            self._send_lock = threading.Lock()
-            self._closed = False
-            self._flush_timer = None
-
-        def _send(self, key: str, entries: list[logging_pb2.LogEntry]) -> None:
-            sent.append((key, len(entries)))
-
-    pusher = RecordingPusher()
-    entry = logging_pb2.LogEntry(source="test", data="line")
-
-    pusher.push("k", [entry])
-    assert len(sent) == 0
-
-    pusher.push("k", [entry])  # Hits batch_size=2
-    assert len(sent) == 1
-    assert sent[0] == ("k", 2)
-
-
-def test_close_waits_for_inflight_send():
-    """close() must not destroy the client while _send() is in flight.
-
-    Simulates a slow RPC by blocking inside _send. close() must wait for it
-    to finish before closing the client. Without the _send_lock this would
-    close the client while the send is still running.
-    """
-    send_entered = threading.Event()
-    send_may_proceed = threading.Event()
-    client_closed_during_send = False
-
-    class SlowPusher(LogPusher):
-        def __init__(self):
-            self._batch_size = 1000
-            self._flush_interval = 0.01  # fast timer to trigger the race
-            self._buffers: dict[str, list[logging_pb2.LogEntry]] = {}
-            self._lock = threading.Lock()
-            self._send_lock = threading.Lock()
-            self._closed = False
-            self._flush_timer = None
-            self._client_alive = True
-            self._schedule_flush()
-
-        def _send(self, key: str, entries: list[logging_pb2.LogEntry]) -> None:
-            nonlocal client_closed_during_send
-            with self._send_lock:
-                if self._closed:
-                    return
-                send_entered.set()
-                send_may_proceed.wait(timeout=5.0)
-                if not self._client_alive:
-                    client_closed_during_send = True
-
-        def close(self) -> None:
-            if self._flush_timer is not None:
-                self._flush_timer.cancel()
-            self.flush()
-            with self._send_lock:
-                self._closed = True
-            self._client_alive = False
-
-    pusher = SlowPusher()
-    entry = logging_pb2.LogEntry(source="test", data="line")
-    pusher.push("k", [entry])
-
-    # Wait for the periodic flush timer to trigger _send
-    assert send_entered.wait(timeout=5.0), "timer-triggered _send never started"
-
-    # Now call close() from another thread — it should block on _send_lock
-    close_done = threading.Event()
-
-    def do_close():
+        totals = {p.key: len(p.entries) for p in tracked_log_service_client[0].pushes}
+        assert totals == {"key-a": 3, "key-b": 1}
+    finally:
         pusher.close()
-        close_done.set()
 
-    t = threading.Thread(target=do_close)
-    t.start()
 
-    # Give close() a moment to potentially race ahead (it shouldn't)
-    assert not close_done.wait(timeout=0.1), "close() returned before send finished"
+def test_log_pusher_flushes_at_batch_size(tracked_log_service_client):
+    """Reaching batch_size wakes the drain thread without waiting for a timer."""
+    pusher = LogPusher(
+        "http://h:1",
+        batch_size=2,
+        flush_interval=999.0,  # isolate the batch-size-triggered send
+    )
+    try:
+        entry = logging_pb2.LogEntry(source="test", data="line")
+        pusher.push("k", [entry])
+        # One entry is below batch_size — nothing should ship yet.
+        # Small sleep lets any bogus wake happen (test will still catch).
+        import time as _time
 
-    # Let the send complete
-    send_may_proceed.set()
+        _time.sleep(0.05)
+        assert tracked_log_service_client[0].pushes == []
 
-    assert close_done.wait(timeout=5.0), "close() never completed"
-    t.join(timeout=1.0)
-    assert not client_closed_during_send, "client was destroyed while _send was in flight"
+        pusher.push("k", [entry])
+        _wait_for(lambda: len(tracked_log_service_client[0].pushes) == 1)
+        assert tracked_log_service_client[0].pushes[0].key == "k"
+        assert len(tracked_log_service_client[0].pushes[0].entries) == 2
+    finally:
+        pusher.close()
+
+
+def test_close_drains_pending_entries(tracked_log_service_client):
+    """close() must drain buffered entries before returning."""
+    pusher = LogPusher(
+        "http://h:1",
+        batch_size=1000,
+        flush_interval=999.0,
+    )
+    entry = logging_pb2.LogEntry(source="test", data="line")
+    pusher.push("k", [entry, entry])
+    pusher.close()
+    # Drain thread must have sent the pending batch before close() returned.
+    assert len(tracked_log_service_client[0].pushes) == 1
+    assert len(tracked_log_service_client[0].pushes[0].entries) == 2
+
+
+def test_overflow_drops_oldest(tracked_log_service_client, caplog):
+    """Exceeding max_buffer_size drops oldest entries across keys."""
+    pusher = LogPusher(
+        "http://h:1",
+        batch_size=1000,  # large — don't ship mid-test
+        flush_interval=999.0,
+        max_buffer_size=3,
+    )
+    try:
+        with caplog.at_level(logging.WARNING, logger="iris.log_server.client"):
+            entries = [
+                logging_pb2.LogEntry(source="test", data=str(i), level=logging_pb2.LOG_LEVEL_INFO) for i in range(5)
+            ]
+            pusher.push("k", entries)
+        pusher.flush()
+        pusher.close()
+        datas = [e.data for p in tracked_log_service_client[0].pushes for e in p.entries]
+        # Oldest 2 dropped; "2","3","4" survive in order.
+        assert datas == ["2", "3", "4"]
+        assert any("buffer overflow" in r.message for r in caplog.records)
+    except Exception:
+        # Best-effort cleanup for test failures.
+        pusher.close()
+        raise
+
+
+def test_retryable_failure_rebuffers_at_head(monkeypatch):
+    """On a retryable send failure the batch is re-buffered at the head and
+    drained on the next successful attempt."""
+    created: list[_FakeLogServiceClient] = []
+
+    def factory(address, timeout_ms=10_000, interceptors=()):
+        c = _FakeLogServiceClient(address, timeout_ms=timeout_ms, interceptors=interceptors)
+        if not created:
+            c.errors = [ConnectError(Code.UNAVAILABLE, "gone") for _ in range(3)]
+        created.append(c)
+        return c
+
+    monkeypatch.setattr(client_mod, "LogServiceClientSync", factory)
+
+    addresses = iter(["http://a:1", "http://b:2"])
+    pusher = LogPusher(
+        "/system/log-server",
+        batch_size=1,
+        flush_interval=999.0,
+        resolver=lambda _url: next(addresses),
+    )
+    try:
+        pusher.push("k", [logging_pb2.LogEntry(source="test", data="a", level=logging_pb2.LOG_LEVEL_INFO)])
+        # Wait for the drain thread to fail on client #0 and re-resolve to #1.
+        _wait_for(lambda: len(created) == 2)
+        _wait_for(lambda: len(created[1].pushes) == 1)
+        assert created[0].closed is True
+        assert created[1].pushes[0].entries[0].data == "a"
+    finally:
+        pusher.close()
 
 
 # ---------------------------------------------------------------------------
@@ -289,101 +287,111 @@ def test_resolver_called_lazily_and_cached(tracked_log_service_client):
 
     pusher = LogPusher("iris://system/log-server", batch_size=1, resolver=resolver)
     try:
-        # No resolution yet — pusher is deferred.
+        # Drain thread hasn't needed a client yet.
         assert calls == []
         assert tracked_log_service_client == []
 
         pusher.push("k", [_entry("a")])
+        _wait_for(lambda: len(tracked_log_service_client) == 1)
         assert calls == ["iris://system/log-server"]
-        assert len(tracked_log_service_client) == 1
 
-        # Second push reuses cached client.
         pusher.push("k", [_entry("b")])
+        _wait_for(lambda: len(tracked_log_service_client[0].pushes) == 2)
         assert calls == ["iris://system/log-server"]
         assert len(tracked_log_service_client) == 1
-        assert len(tracked_log_service_client[0].pushes) == 2
     finally:
         pusher.close()
 
 
 def test_retryable_error_invalidates_and_reresolves(tracked_log_service_client):
     addresses = iter(["http://a:1", "http://b:2"])
-
-    def resolver(_url):
-        return next(addresses)
-
-    pusher = LogPusher("iris://system/log-server", batch_size=1, resolver=resolver)
+    pusher = LogPusher("iris://system/log-server", batch_size=1, resolver=lambda _url: next(addresses))
     try:
         pusher.push("k", [_entry("a")])
+        _wait_for(lambda: len(tracked_log_service_client) == 1 and tracked_log_service_client[0].pushes)
         assert tracked_log_service_client[0].address == "http://a:1"
 
-        # Next push: UNAVAILABLE on the cached client → invalidate.
+        # Seed the cached client with a retryable failure; next send
+        # invalidates, re-resolves to #b, and delivers.
         tracked_log_service_client[0].errors.append(ConnectError(Code.UNAVAILABLE, "gone"))
         pusher.push("k", [_entry("b")])
+        _wait_for(lambda: len(tracked_log_service_client) == 2)
         assert tracked_log_service_client[0].closed is True
-
-        # Next push triggers re-resolve + new client.
-        pusher.push("k", [_entry("c")])
-        assert len(tracked_log_service_client) == 2
         assert tracked_log_service_client[1].address == "http://b:2"
-        assert len(tracked_log_service_client[1].pushes) == 1
+        _wait_for(lambda: len(tracked_log_service_client[1].pushes) == 1)
     finally:
         pusher.close()
 
 
-def test_non_retryable_error_does_not_invalidate(tracked_log_service_client):
+def test_non_retryable_error_rebuffers_without_invalidating(tracked_log_service_client):
+    """Non-retryable errors re-buffer the entry (no drops) but keep the cached
+    client — the next attempt retries on the same endpoint."""
     pusher = LogPusher("iris://system/log-server", batch_size=1, resolver=lambda _url: "http://a:1")
     try:
         pusher.push("k", [_entry("a")])
-        assert len(tracked_log_service_client) == 1
+        _wait_for(lambda: len(tracked_log_service_client) == 1 and tracked_log_service_client[0].pushes)
 
-        # NOT_FOUND is not retryable — pusher keeps its cached client.
+        # Seed one NOT_FOUND: the entry is re-buffered and then delivered on
+        # the next attempt against the same (not invalidated) client.
         tracked_log_service_client[0].errors.append(ConnectError(Code.NOT_FOUND, "missing"))
         pusher.push("k", [_entry("b")])
+        _wait_for(lambda: len(tracked_log_service_client[0].errors) == 0)
+        _wait_for(lambda: len(tracked_log_service_client[0].pushes) == 2)
 
         assert len(tracked_log_service_client) == 1
         assert tracked_log_service_client[0].closed is False
+        assert [p.entries[0].data for p in tracked_log_service_client[0].pushes] == ["a", "b"]
     finally:
         pusher.close()
 
 
-def test_resolver_raising_is_retried_on_next_push(tracked_log_service_client):
+def test_resolver_raising_is_retried(tracked_log_service_client):
+    """A resolver failure re-buffers the pending entries; the next
+    successful resolution drains them."""
     attempts = []
+    lock = threading.Lock()
 
     def resolver(_url):
-        attempts.append(1)
-        if len(attempts) == 1:
+        with lock:
+            attempts.append(1)
+            n = len(attempts)
+        if n == 1:
             raise ConnectionError("controller down")
         return "http://good:1"
 
-    pusher = LogPusher("iris://system/log-server", batch_size=1, resolver=resolver)
+    pusher = LogPusher(
+        "iris://system/log-server",
+        batch_size=1,
+        flush_interval=0.1,
+        resolver=resolver,
+    )
     try:
-        # First push: resolver raises. Entry is lost (best-effort) but
-        # pusher stays healthy — no cached client to invalidate.
         pusher.push("k", [_entry("a")])
-        assert len(attempts) == 1
-        assert tracked_log_service_client == []
-
-        # Second push: resolver succeeds this time.
-        pusher.push("k", [_entry("b")])
-        assert len(attempts) == 2
-        assert len(tracked_log_service_client) == 1
-        assert len(tracked_log_service_client[0].pushes) == 1
+        # First attempt raises, backoff, second attempt succeeds.
+        _wait_for(lambda: len(tracked_log_service_client) == 1, timeout=10.0)
+        _wait_for(lambda: len(tracked_log_service_client[0].pushes) == 1)
+        with lock:
+            assert len(attempts) >= 2
     finally:
         pusher.close()
 
 
-def test_static_url_pusher_unchanged(tracked_log_service_client):
-    """Without a resolver the pusher builds its client eagerly — legacy behavior."""
-    pusher = LogPusher("http://h:1", batch_size=1)
+def test_static_url_pusher_retries_without_invalidating(tracked_log_service_client):
+    """Without a resolver, retryable failures re-buffer and retry on the same client."""
+    pusher = LogPusher(
+        "http://h:1",
+        batch_size=1,
+        flush_interval=0.1,
+    )
     try:
-        # Eager construction at __init__ time.
         assert len(tracked_log_service_client) == 1
         assert tracked_log_service_client[0].address == "http://h:1"
 
-        # Retryable error does NOT invalidate — there's nothing to re-resolve to.
+        # One UNAVAILABLE, then success on retry.
         tracked_log_service_client[0].errors.append(ConnectError(Code.UNAVAILABLE, "gone"))
         pusher.push("k", [_entry("a")])
+        _wait_for(lambda: len(tracked_log_service_client[0].pushes) == 1)
+        # Same client — no resolver means no re-resolution.
         assert tracked_log_service_client[0].closed is False
         assert len(tracked_log_service_client) == 1
     finally:


### PR DESCRIPTION
Rewrite LogPusher with a dedicated drain thread. push() is non-blocking;
the thread wakes on batch_size, flush, close, or flush_interval and sends
what's buffered. Every send failure rebuffers at the head of the key's
deque and backs off — retryable errors additionally invalidate the cached
RPC client so the next attempt re-resolves. Only MAX_LOG_BUFFER_SIZE (10k)
overflow drops entries, oldest-first. Worker builds one pusher in start()
with a resolver that looks up /system/log-server on the controller.

Fixes #4860