### PR TITLE
[Levanter] Fix ragged all-to-all sender offsets

### DIFF
--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -211,7 +211,12 @@ def _shard_a2a_params(
     send_sizes = row
 
     recv_sizes = shard_counts[:, shard_id]
-    output_offsets = jnp.cumsum(jnp.concatenate((jnp.array([0], dtype=recv_sizes.dtype), recv_sizes[:-1])))
+    # `ragged_all_to_all` expects sender-side output offsets: for each
+    # destination shard, where this sender's slice should land in the remote
+    # receiver buffer. JAX computes the local receive offsets by transposing
+    # these offsets with an internal all_to_all.
+    sender_output_offsets = jnp.cumsum(shard_counts, axis=0, dtype=shard_counts.dtype) - shard_counts
+    output_offsets = sender_output_offsets[shard_id]
     return input_offsets, send_sizes, output_offsets, recv_sizes
 
 

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -193,7 +193,7 @@ def test_moe_ep_path_lowers_on_abstract_mesh(implementation: MoeImplementation):
         assert lowered is not None
 
 
-def test_shard_a2a_params_uses_receive_axis_for_output_offsets():
+def test_shard_a2a_params_uses_sender_side_output_offsets():
     shard_counts = jnp.array(
         [
             [1, 7, 2],
@@ -210,7 +210,65 @@ def test_shard_a2a_params_uses_receive_axis_for_output_offsets():
     np.testing.assert_array_equal(np.asarray(send_sizes), np.array([3, 5, 4], dtype=np.int32))
     np.testing.assert_array_equal(np.asarray(input_offsets), np.array([0, 3, 8], dtype=np.int32))
     np.testing.assert_array_equal(np.asarray(recv_sizes), np.array([7, 5, 8], dtype=np.int32))
-    np.testing.assert_array_equal(np.asarray(output_offsets), np.array([0, 7, 12], dtype=np.int32))
+    np.testing.assert_array_equal(np.asarray(output_offsets), np.array([1, 7, 2], dtype=np.int32))
+
+
+def test_moe_mlp_ragged_matches_ring_with_ep_axis_when_available():
+    mesh = _make_ep_mesh_or_none()
+    if mesh is None:
+        pytest.skip("requires an even number of >=2 devices")
+    if jax.devices()[0].platform == "cpu":
+        pytest.skip("ragged_all_to_all is not implemented on XLA:CPU")
+
+    tokens = len(jax.devices()) * 8
+    hidden_dim = 16
+    intermediate_dim = 24
+    num_experts = 4
+    topk = 2
+
+    with jax.set_mesh(mesh):
+        x, selected_experts, combine_weights, w_up_gate, w_down = _make_inputs(
+            key=jax.random.key(23),
+            tokens=tokens,
+            hidden_dim=hidden_dim,
+            intermediate_dim=intermediate_dim,
+            num_experts=num_experts,
+            topk=topk,
+        )
+
+        batch_sharding = NamedSharding(mesh, P(("data", "expert"), None))
+        expert_sharding = NamedSharding(mesh, P("expert", None, None))
+        x = jax.sharding.reshard(x, batch_sharding)
+        selected_experts = jax.sharding.reshard(selected_experts, batch_sharding)
+        combine_weights = jax.sharding.reshard(combine_weights, batch_sharding)
+        w_up_gate = jax.sharding.reshard(w_up_gate, expert_sharding)
+        w_down = jax.sharding.reshard(w_down, expert_sharding)
+
+        ring_out, ring_dropped = moe_mlp(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            implementation="ring",
+            mesh=None,
+            report_capacity_overflow=True,
+            capacity_factor=1.0,
+        )
+        ragged_out, ragged_dropped = moe_mlp(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            implementation="ragged_all_to_all",
+            mesh=None,
+            report_capacity_overflow=True,
+            capacity_factor=1.0,
+        )
+
+    np.testing.assert_allclose(np.asarray(ragged_out), np.asarray(ring_out), rtol=1e-5, atol=1e-5)
+    assert int(ragged_dropped) == int(ring_dropped)
 
 
 def test_moe_mlp_runs_with_ep_axis_when_available():


### PR DESCRIPTION
Compute sender-side output offsets for `_shard_a2a_params` so `jax.lax.ragged_all_to_all` places returned slices in the correct remote slots. Adds a regression for the offset calculation and a ring-vs-ragged EP parity test.

Part of #4697