### PR TITLE
[iris] Log-store: let DuckDB do file-level pruning; drop load-bearing file cap

### DIFF
--- a/lib/iris/scripts/benchmark_log_store.py
+++ b/lib/iris/scripts/benchmark_log_store.py
@@ -314,7 +314,7 @@ def main(
             print("\n[ingest]")
             ingest(store, jobs, tasks, lines)
 
-            parquet_files = list(log_dir.glob("logs_*_*.parquet"))
+            parquet_files = list(log_dir.glob("tmp_*.parquet")) + list(log_dir.glob("log_*.parquet"))
             total_size = sum(f.stat().st_size for f in parquet_files)
             print(f"  {len(parquet_files)} Parquet segments, {total_size / 1024 / 1024:.1f} MB on disk")
 

--- a/lib/iris/scripts/benchmark_log_store.py
+++ b/lib/iris/scripts/benchmark_log_store.py
@@ -314,7 +314,7 @@ def main(
             print("\n[ingest]")
             ingest(store, jobs, tasks, lines)
 
-            parquet_files = list(log_dir.glob("tmp_*.parquet")) + list(log_dir.glob("log_*.parquet"))
+            parquet_files = list(log_dir.glob("tmp_*.parquet")) + list(log_dir.glob("logs_*.parquet"))
             total_size = sum(f.stat().st_size for f in parquet_files)
             print(f"  {len(parquet_files)} Parquet segments, {total_size / 1024 / 1024:.1f} MB on disk")
 

--- a/lib/iris/src/iris/cluster/log_store/duckdb_store.py
+++ b/lib/iris/src/iris/cluster/log_store/duckdb_store.py
@@ -172,6 +172,25 @@ def _read_seq_bounds(path: Path) -> tuple[int, int]:
         return 0, 0
 
 
+# Pre-tiered layout: a single series of compacted files named
+# ``logs_{min_seq:019d}.parquet``. Equivalent to the new ``log_*.parquet``
+# semantic (sealed, GCS-uploaded). On upgrade, rename them in place so they
+# participate in seq recovery and segment discovery.
+_LEGACY_LOG_PREFIX = "logs_"
+
+
+def _migrate_legacy_segments(log_dir: Path) -> None:
+    """Rename any pre-tiered-layout ``logs_*.parquet`` to ``log_*.parquet``."""
+    for p in log_dir.glob(f"{_LEGACY_LOG_PREFIX}*.parquet"):
+        target = p.with_name(_LOG_PREFIX + p.name[len(_LEGACY_LOG_PREFIX) :])
+        if target.exists():
+            # A same-min_seq log file from the new layout already exists;
+            # prefer it and drop the stale legacy copy.
+            p.unlink()
+            continue
+        p.rename(target)
+
+
 def _discover_segments(log_dir: Path) -> list[Path]:
     """Return every on-disk segment (tmp + log), chronological by filename."""
     return sorted(list(log_dir.glob(f"{_TMP_PREFIX}*.parquet")) + list(log_dir.glob(f"{_LOG_PREFIX}*.parquet")))
@@ -394,6 +413,9 @@ class DuckDBLogStore:
         self._max_local_bytes = max_local_bytes
         self._segment_target_bytes = segment_target_bytes
         self._max_tmp_segments_before_compact = max_tmp_segments_before_compact
+
+        # Upgrade any pre-tiered-layout files before discovery / seq recovery.
+        _migrate_legacy_segments(self._log_dir)
 
         # ---- shared mutable state (all guarded by _lock) ----
         self._lock = Lock()

--- a/lib/iris/src/iris/cluster/log_store/duckdb_store.py
+++ b/lib/iris/src/iris/cluster/log_store/duckdb_store.py
@@ -7,9 +7,7 @@ Two on-disk tiers:
 
     ``tmp_{min_seq}.parquet`` -- written by every flush; local-only.
     ``logs_{min_seq}.parquet`` -- produced by periodic compaction that merges
-    all current tmps into one archive and uploads only that to GCS. (Named
-    ``logs_`` rather than ``log_`` for continuity with the pre-tiered layout,
-    which used the same filename to mean the same thing.)
+    all current tmps into one archive and uploads only that to GCS.
 
 Lifecycle of a log entry:
 
@@ -129,11 +127,7 @@ _ROW_GROUP_SIZE = 16_384
 # size only — file count doesn't cleanly distinguish the two.
 _MAX_PARQUET_BYTES_PER_READ = 2_500 * 1024 * 1024
 
-# File naming: hot flushes write tmp_*.parquet; compaction merges them into
-# logs_*.parquet and uploads only that to GCS. Both are keyed by min_seq so
-# sorting by filename yields chronological order. The logs_ name matches the
-# pre-tiered layout (same semantics, same contents), so upgrades need no
-# migration and downgrades still find their files.
+# Both prefixes keyed by min_seq, so sort-by-filename yields chronological order.
 _TMP_PREFIX = "tmp_"
 _LOG_PREFIX = "logs_"
 
@@ -407,13 +401,8 @@ class DuckDBLogStore:
         self._flushing: _SealedBuffer | None = None  # pre-flush snapshot being written
         self._local_segments: deque[_LocalSegment] = deque()
 
-        # RWLock: readers hold shared lock during DuckDB queries;
-        # GC / consolidation hold exclusive lock before unlinking or renaming.
         self._segments_rwlock = _RWLock()
 
-        # Discover pre-existing Parquet files from a previous run. Both tmp_
-        # (pre-compaction, local-only) and logs_ (compacted, uploaded) are
-        # re-registered so reads work immediately after restart.
         for p in _discover_segments(self._log_dir):
             min_seq, max_seq = _read_seq_bounds(p)
             self._local_segments.append(
@@ -557,15 +546,7 @@ class DuckDBLogStore:
     # ------------------------------------------------------------------
 
     def _ram_bytes_locked(self) -> int:
-        """Total bytes across every in-RAM holder (pending + chunks + flushing).
-
-        Used for backpressure: _pending alone is a poor signal because the
-        compact tick (1s) drains _pending into _chunks long before it reaches
-        segment_target_bytes, so a check against _pending never fires. The
-        flush tick runs every 60s, so without this aggregate accounting we'd
-        accumulate a full minute of arrow-table data (hundreds of MB at
-        realistic rates) before any flush.
-        """
+        """Total bytes across every in-RAM holder (pending + chunks + flushing)."""
         chunks_b = sum(t.nbytes for t in self._chunks)
         flushing_b = self._flushing.table.nbytes if self._flushing is not None else 0
         return len(self._pending) * _EST_BYTES_PER_ROW + chunks_b + flushing_b
@@ -696,17 +677,11 @@ class DuckDBLogStore:
         )
 
     def _compaction_step(self) -> None:
-        """Merge all tmp_ segments into a single log_ segment via DuckDB.
+        """Merge all tmp_ segments into a single logs_ segment, upload, unlink.
 
-        Uses ``COPY (SELECT ... ORDER BY key, seq)`` so the merge is a
-        DuckDB-native streaming operation — never touches pyarrow's
-        concat/sort path (which leaks ~45 MB per invocation when reading
-        parquet back).
-
-        On success: uploads the merged file to GCS, unlinks the tmps locally,
-        replaces them in ``_local_segments``, and bumps ``_compaction_generation``.
-        Read queries are protected by ``_segments_rwlock`` — the unlink + swap
-        happen under the exclusive write lock.
+        Uses ``COPY (SELECT ... ORDER BY key, seq)`` so the merge streams
+        inside DuckDB — never touches pyarrow's concat/sort path, which
+        leaks ~45 MB per invocation when reading parquet back.
         """
         with self._lock:
             tmps = [s for s in self._local_segments if _is_tmp_path(s.path)]
@@ -751,7 +726,6 @@ class DuckDBLogStore:
         try:
             staging_path.rename(merged_path)
             with self._lock:
-                # Rebuild deque: first tmp is replaced by merged; other tmps dropped.
                 new_segments: deque[_LocalSegment] = deque()
                 merged_inserted = False
                 for s in self._local_segments:
@@ -759,7 +733,6 @@ class DuckDBLogStore:
                         if not merged_inserted:
                             new_segments.append(merged_seg)
                             merged_inserted = True
-                        # skip — it's being replaced
                     else:
                         new_segments.append(s)
                 if not merged_inserted:
@@ -835,12 +808,10 @@ class DuckDBLogStore:
     def _drop_missing_local_segments(self, paths: list[str]) -> list[str]:
         """Filter ``paths`` to those that still exist on disk.
 
-        If any are missing they're also pruned from ``_local_segments`` so
-        future reads don't repeatedly hit the same DuckDB error. Vanishing
-        files normally come from out-of-band deletion (manual ``rm``, disk
-        pressure outside our GC, leftover entries from an old filename
-        format) — anything our own GC removes is gone from the in-memory
-        list before the file is unlinked.
+        Missing files are also pruned from ``_local_segments`` so future reads
+        don't repeatedly hit the same DuckDB error. Self-healing against
+        out-of-band deletion; our own GC removes entries from memory before
+        unlinking.
         """
         existing: list[str] = []
         missing: list[str] = []
@@ -992,13 +963,7 @@ class DuckDBLogStore:
         include_key_in_select: bool,
     ) -> list[tuple]:
         """Snapshot RAM + segments, run one DuckDB query. Caller holds the
-        segments read lock.
-
-        All pruning is delegated to DuckDB. Per-file row-group ``key`` bounds
-        on the sorted segments are narrow enough that opening every file in
-        the capped working set costs ~4ms/file of planning even when zero
-        rows match. The ``_cap_segments`` bound is a safety net for
-        pathological body-LIKE queries with no row-group-prunable predicate.
+        segments read lock. All pruning is delegated to DuckDB.
         """
         with self._lock:
             segments = list(self._local_segments)

--- a/lib/iris/src/iris/cluster/log_store/duckdb_store.py
+++ b/lib/iris/src/iris/cluster/log_store/duckdb_store.py
@@ -607,18 +607,23 @@ class DuckDBLogStore:
             if self._pending:
                 tables.append(_build_buffer_table(self._pending))
                 self._pending = []
-            new_table = pa.concat_tables(tables) if len(tables) > 1 else tables[0]
-            # Sort by (key, seq) so Parquet row-group statistics on `key` are
-            # tight, letting DuckDB skip row groups that don't contain the
-            # target key on reads.
-            new_table = new_table.sort_by([("key", "ascending"), ("seq", "ascending")])
+
+        # Concat + sort outside the lock — hundreds of ms on large flushes.
+        # Safe because _chunks has a single writer (_compact_step), which
+        # runs serially with _flush_step in the bg thread.
+        # Sort by (key, seq) so Parquet row-group stats on `key` are tight,
+        # letting DuckDB skip row groups that don't contain the target key.
+        new_table = pa.concat_tables(tables) if len(tables) > 1 else tables[0]
+        new_table = new_table.sort_by([("key", "ascending"), ("seq", "ascending")])
+        seq_col = new_table.column("seq")
+        sealed = _SealedBuffer(
+            table=new_table,
+            min_seq=pc.min(seq_col).as_py(),
+            max_seq=pc.max(seq_col).as_py(),
+        )
+
+        with self._lock:
             self._chunks = []
-            seq_col = new_table.column("seq")
-            sealed = _SealedBuffer(
-                table=new_table,
-                min_seq=pc.min(seq_col).as_py(),
-                max_seq=pc.max(seq_col).as_py(),
-            )
             self._flushing = sealed
 
         try:

--- a/lib/iris/src/iris/cluster/log_store/duckdb_store.py
+++ b/lib/iris/src/iris/cluster/log_store/duckdb_store.py
@@ -810,34 +810,6 @@ class DuckDBLogStore:
             remaining_bytes,
         )
 
-    def _drop_missing_local_segments(self, paths: list[str]) -> list[str]:
-        """Filter ``paths`` to those that still exist on disk.
-
-        Missing files are also pruned from ``_local_segments`` so future reads
-        don't repeatedly hit the same DuckDB error. Self-healing against
-        out-of-band deletion; our own GC removes entries from memory before
-        unlinking.
-        """
-        existing: list[str] = []
-        missing: list[str] = []
-        for p in paths:
-            if Path(p).exists():
-                existing.append(p)
-            else:
-                missing.append(p)
-        if not missing:
-            return existing
-
-        missing_set = set(missing)
-        with self._memory_lock:
-            self._local_segments = deque(s for s in self._local_segments if s.path not in missing_set)
-        logger.warning(
-            "Pruned %d missing local segment(s) from in-memory index (e.g. %s)",
-            len(missing),
-            missing[:3],
-        )
-        return existing
-
     def _offload_to_gcs(self, filename: str, filepath: Path) -> None:
         """Copy a Parquet file to GCS (best-effort)."""
         if not self._remote_log_dir:
@@ -980,7 +952,7 @@ class DuckDBLogStore:
             ram_tables.append(_build_buffer_table(pending_snapshot))
 
         segments = _cap_segments(segments)
-        parquet_files = self._drop_missing_local_segments([s.path for s in segments])
+        parquet_files = [s.path for s in segments]
 
         where_clause = " AND ".join(where_parts)
         select_cols = (

--- a/lib/iris/src/iris/cluster/log_store/duckdb_store.py
+++ b/lib/iris/src/iris/cluster/log_store/duckdb_store.py
@@ -6,8 +6,10 @@
 Two on-disk tiers:
 
     ``tmp_{min_seq}.parquet`` -- written by every flush; local-only.
-    ``log_{min_seq}.parquet`` -- produced by periodic compaction that merges
-    all current tmps into one archive and uploads only that to GCS.
+    ``logs_{min_seq}.parquet`` -- produced by periodic compaction that merges
+    all current tmps into one archive and uploads only that to GCS. (Named
+    ``logs_`` rather than ``log_`` for continuity with the pre-tiered layout,
+    which used the same filename to mean the same thing.)
 
 Lifecycle of a log entry:
 
@@ -24,7 +26,7 @@ Lifecycle of a log entry:
           write path is strictly append-only.
        c. Every ``compaction_interval_sec`` (default 10 min) or when tmp
           count exceeds ``max_tmp_segments_before_compact`` (default 10):
-          merge all tmp_ files into a single ``log_*.parquet`` via DuckDB
+          merge all tmp_ files into a single ``logs_*.parquet`` via DuckDB
           ``COPY (SELECT ... ORDER BY key, seq) TO ... (FORMAT parquet)``,
           then upload the merged file to GCS and unlink the tmps. DuckDB's
           streaming COPY avoids the pyarrow concat/sort/write leak path.
@@ -128,10 +130,12 @@ _ROW_GROUP_SIZE = 16_384
 _MAX_PARQUET_BYTES_PER_READ = 2_500 * 1024 * 1024
 
 # File naming: hot flushes write tmp_*.parquet; compaction merges them into
-# log_*.parquet and uploads only that to GCS. Both are keyed by min_seq so
-# sorting by filename yields chronological order.
+# logs_*.parquet and uploads only that to GCS. Both are keyed by min_seq so
+# sorting by filename yields chronological order. The logs_ name matches the
+# pre-tiered layout (same semantics, same contents), so upgrades need no
+# migration and downgrades still find their files.
 _TMP_PREFIX = "tmp_"
-_LOG_PREFIX = "log_"
+_LOG_PREFIX = "logs_"
 
 
 def _tmp_filename(min_seq: int) -> str:
@@ -170,25 +174,6 @@ def _read_seq_bounds(path: Path) -> tuple[int, int]:
         return min_seq, max_seq
     except Exception:
         return 0, 0
-
-
-# Pre-tiered layout: a single series of compacted files named
-# ``logs_{min_seq:019d}.parquet``. Equivalent to the new ``log_*.parquet``
-# semantic (sealed, GCS-uploaded). On upgrade, rename them in place so they
-# participate in seq recovery and segment discovery.
-_LEGACY_LOG_PREFIX = "logs_"
-
-
-def _migrate_legacy_segments(log_dir: Path) -> None:
-    """Rename any pre-tiered-layout ``logs_*.parquet`` to ``log_*.parquet``."""
-    for p in log_dir.glob(f"{_LEGACY_LOG_PREFIX}*.parquet"):
-        target = p.with_name(_LOG_PREFIX + p.name[len(_LEGACY_LOG_PREFIX) :])
-        if target.exists():
-            # A same-min_seq log file from the new layout already exists;
-            # prefer it and drop the stale legacy copy.
-            p.unlink()
-            continue
-        p.rename(target)
 
 
 def _discover_segments(log_dir: Path) -> list[Path]:
@@ -414,9 +399,6 @@ class DuckDBLogStore:
         self._segment_target_bytes = segment_target_bytes
         self._max_tmp_segments_before_compact = max_tmp_segments_before_compact
 
-        # Upgrade any pre-tiered-layout files before discovery / seq recovery.
-        _migrate_legacy_segments(self._log_dir)
-
         # ---- shared mutable state (all guarded by _lock) ----
         self._lock = Lock()
         self._next_seq = _recover_max_seq(self._log_dir)
@@ -430,7 +412,7 @@ class DuckDBLogStore:
         self._segments_rwlock = _RWLock()
 
         # Discover pre-existing Parquet files from a previous run. Both tmp_
-        # (pre-compaction, local-only) and log_ (compacted, uploaded) are
+        # (pre-compaction, local-only) and logs_ (compacted, uploaded) are
         # re-registered so reads work immediately after restart.
         for p in _discover_segments(self._log_dir):
             min_seq, max_seq = _read_seq_bounds(p)
@@ -1132,7 +1114,7 @@ def _add_common_filters(
 def _build_union_source(parquet_files: list[str], ram_table_names: list[str]) -> str:
     """Build a SQL source expression: local Parquet files UNION ALL ram tables.
 
-    File paths are self-generated (``tmp_*.parquet`` / ``log_*.parquet``) so
+    File paths are self-generated (``tmp_*.parquet`` / ``logs_*.parquet``) so
     no SQL injection risk from the f-string embedding. RAM table names are
     generated internally (``_ram_<cid>_<i>``).
     """

--- a/lib/iris/src/iris/cluster/log_store/duckdb_store.py
+++ b/lib/iris/src/iris/cluster/log_store/duckdb_store.py
@@ -11,7 +11,7 @@ Two on-disk tiers:
 
 Lifecycle of a log entry:
 
-    1. Appended to ``_pending`` (plain Python list) under ``_lock``.
+    1. Appended to ``_pending`` (plain Python list) under ``_memory_lock``.
     2. A single background thread wakes periodically and:
        a. Every ``compact_interval_sec`` (default 1s): if ``_pending`` has at
           least ``_CHUNK_THRESHOLD`` rows, convert it to an Arrow ``Table`` and
@@ -41,7 +41,7 @@ The per-read working set is capped by ``_MAX_PARQUET_BYTES_PER_READ``, which
 handles a mix of small tmps and large logs gracefully.
 
 Locking:
-    ``_lock``  -- protects all mutable RAM state: ``_pending``, ``_chunks``,
+    ``_memory_lock``  -- protects all mutable RAM state: ``_pending``, ``_chunks``,
     ``_flushing``, ``_local_segments``, and ``_next_seq``. Held briefly for
     snapshots and swaps; never held across I/O.
 
@@ -361,7 +361,7 @@ class _ConnectionPool:
 class DuckDBLogStore:
     """Log store backed by rotating RAM buffers + Parquet segments.
 
-    Thread-safe. ``_lock`` protects all mutable RAM state; ``_segments_rwlock``
+    Thread-safe. ``_memory_lock`` protects all mutable RAM state; ``_segments_rwlock``
     serializes file ops against in-flight DuckDB reads.
     """
 
@@ -393,8 +393,8 @@ class DuckDBLogStore:
         self._segment_target_bytes = segment_target_bytes
         self._max_tmp_segments_before_compact = max_tmp_segments_before_compact
 
-        # ---- shared mutable state (all guarded by _lock) ----
-        self._lock = Lock()
+        # ---- shared mutable state (all guarded by _memory_lock) ----
+        self._memory_lock = Lock()
         self._next_seq = _recover_max_seq(self._log_dir)
         self._pending: list[tuple] = []  # hot write list, converted by bg thread
         self._chunks: list[pa.Table] = []  # power-of-2 merged arrow tables
@@ -438,7 +438,7 @@ class DuckDBLogStore:
     def append(self, key: str, entries: list) -> None:
         if not entries:
             return
-        with self._lock:
+        with self._memory_lock:
             first_seq = self._next_seq
             self._next_seq += len(entries)
             self._pending.extend(
@@ -450,7 +450,7 @@ class DuckDBLogStore:
 
     def append_batch(self, items: list[tuple[str, list]]) -> None:
         """Write log entries from multiple keys in a single operation."""
-        with self._lock:
+        with self._memory_lock:
             for key, entries in items:
                 if not entries:
                     continue
@@ -565,7 +565,7 @@ class DuckDBLogStore:
             # Backpressure: if total RAM holders blew past the segment target,
             # drain immediately and reset both rate limiters so the next idle
             # tick doesn't fire redundantly.
-            with self._lock:
+            with self._memory_lock:
                 force_drain = self._ram_bytes_locked() >= self._segment_target_bytes
                 tmp_count = sum(1 for s in self._local_segments if _is_tmp_path(s.path))
                 force_compaction = tmp_count > self._max_tmp_segments_before_compact
@@ -588,19 +588,19 @@ class DuckDBLogStore:
 
     def _compact_step(self) -> None:
         """Move ``_pending`` into a new Arrow chunk (if big enough)."""
-        with self._lock:
+        with self._memory_lock:
             if len(self._pending) < _CHUNK_THRESHOLD:
                 return
             rows = self._pending
             self._pending = []
         table = _build_buffer_table(rows)
-        with self._lock:
+        with self._memory_lock:
             self._chunks.append(table)
             self._chunks = _merge_chunks(self._chunks)
 
     def _flush_step(self) -> None:
         """Seal any RAM data into a Parquet segment on disk."""
-        with self._lock:
+        with self._memory_lock:
             if not self._chunks and not self._pending:
                 return
             tables = list(self._chunks)
@@ -622,7 +622,7 @@ class DuckDBLogStore:
             max_seq=pc.max(seq_col).as_py(),
         )
 
-        with self._lock:
+        with self._memory_lock:
             self._chunks = []
             self._flushing = sealed
 
@@ -630,7 +630,7 @@ class DuckDBLogStore:
             self._write_new_segment(sealed)
         except Exception:
             logger.warning("Flush failed, restoring data to chunks", exc_info=True)
-            with self._lock:
+            with self._memory_lock:
                 self._chunks.insert(0, sealed.table)
                 self._flushing = None
             return
@@ -667,7 +667,7 @@ class DuckDBLogStore:
             min_seq=sealed.min_seq,
             max_seq=sealed.max_seq,
         )
-        with self._lock:
+        with self._memory_lock:
             self._local_segments.append(seg)
             self._flushing = None
 
@@ -688,7 +688,7 @@ class DuckDBLogStore:
         inside DuckDB — never touches pyarrow's concat/sort path, which
         leaks ~45 MB per invocation when reading parquet back.
         """
-        with self._lock:
+        with self._memory_lock:
             tmps = [s for s in self._local_segments if _is_tmp_path(s.path)]
         if not tmps:
             return
@@ -730,7 +730,7 @@ class DuckDBLogStore:
         self._segments_rwlock.write_acquire()
         try:
             staging_path.rename(merged_path)
-            with self._lock:
+            with self._memory_lock:
                 new_segments: deque[_LocalSegment] = deque()
                 merged_inserted = False
                 for s in self._local_segments:
@@ -774,7 +774,7 @@ class DuckDBLogStore:
         in-progress DuckDB reads (which hold the shared read lock) are not
         disrupted by file deletion.
         """
-        with self._lock:
+        with self._memory_lock:
             total_bytes = sum(s.size_bytes for s in self._local_segments)
             to_delete: list[tuple[str, int]] = []
             remaining_count = len(self._local_segments)
@@ -829,7 +829,7 @@ class DuckDBLogStore:
             return existing
 
         missing_set = set(missing)
-        with self._lock:
+        with self._memory_lock:
             self._local_segments = deque(s for s in self._local_segments if s.path not in missing_set)
         logger.warning(
             "Pruned %d missing local segment(s) from in-memory index (e.g. %s)",
@@ -906,9 +906,8 @@ class DuckDBLogStore:
         include_key_in_select: bool,
         exact_key: str | None = None,
     ) -> LogReadResult:
-        # Acquire the segments read lock BEFORE snapshotting paths. This
-        # guarantees that no file in our snapshot can be deleted (by GC or
-        # consolidation) until we release the lock after DuckDB is done.
+        # Hold the rwlock across the whole query so GC / compaction can't
+        # unlink a file that DuckDB may still open lazily.
         self._segments_rwlock.read_acquire()
         try:
             rows = self._run_read_locked(
@@ -970,7 +969,7 @@ class DuckDBLogStore:
         """Snapshot RAM + segments, run one DuckDB query. Caller holds the
         segments read lock. All pruning is delegated to DuckDB.
         """
-        with self._lock:
+        with self._memory_lock:
             segments = list(self._local_segments)
             ram_tables: list[pa.Table] = list(self._chunks)
             if self._flushing is not None:

--- a/lib/iris/src/iris/cluster/log_store/duckdb_store.py
+++ b/lib/iris/src/iris/cluster/log_store/duckdb_store.py
@@ -190,21 +190,6 @@ def _recover_max_seq(log_dir: Path) -> int:
     return max_seen + 1 if max_seen >= 0 else 1
 
 
-def _prefix_upper_bound(prefix: str) -> str | None:
-    """Return the exclusive upper bound for a prefix range, or None if unbounded.
-
-    All strings starting with ``prefix`` satisfy ``prefix <= s < upper``.
-    This lets DuckDB use range predicates on Parquet row-group statistics
-    instead of regexp_matches, which isn't pushed down through parameterized queries.
-    """
-    if not prefix:
-        return None
-    last = ord(prefix[-1])
-    if last >= 0x10FFFF:
-        return None
-    return prefix[:-1] + chr(last + 1)
-
-
 def _build_buffer_table(buffer: list[tuple]) -> pa.Table:
     """Convert a list of row tuples into a pyarrow Table with the log schema."""
     if not buffer:
@@ -1079,35 +1064,27 @@ def _regex_literal_prefix(pattern: str) -> str:
 def _regex_query(pattern: str, cursor: int) -> tuple[list[str], dict]:
     """Build WHERE clauses for a regex pattern.
 
-    Extracts a literal prefix for Parquet range pushdown. If the pattern
-    is purely a prefix (literal text followed only by ``.*``), range
-    predicates alone suffice. Otherwise ``regexp_matches()`` is added.
+    Emits ``prefix(key, $prefix_lo)`` on the literal leading portion so DuckDB
+    prunes parquet row groups via min/max stats. If the pattern has a
+    non-trivial suffix (e.g. ``\\d+:.*``), adds ``regexp_matches()`` as a
+    residual filter — the prefix still gets pushed down, the regex only runs
+    on surviving rows.
     """
     literal_prefix = _regex_literal_prefix(pattern)
-
-    # Pure-prefix pattern: "some/prefix/.*" — the literal prefix covers
-    # everything and the trailing .* matches any suffix.
     suffix = pattern[len(literal_prefix) :]
     is_pure_prefix = suffix in (".*", "")
 
-    if is_pure_prefix and literal_prefix:
-        where_parts = ["key >= $prefix_lo", "seq > $cursor"]
-        params: dict = {"prefix_lo": literal_prefix, "cursor": cursor}
-        upper = _prefix_upper_bound(literal_prefix)
-        if upper is not None:
-            where_parts.append("key < $prefix_hi")
-            params["prefix_hi"] = upper
-        return where_parts, params
+    where_parts = ["seq > $cursor"]
+    params: dict = {"cursor": cursor}
 
-    where_parts = ["regexp_matches(key, $key_pattern)", "seq > $cursor"]
-    params = {"key_pattern": pattern, "cursor": cursor}
     if literal_prefix:
-        upper = _prefix_upper_bound(literal_prefix)
-        where_parts.append("key >= $prefix_lo")
+        where_parts.append("prefix(key, $prefix_lo)")
         params["prefix_lo"] = literal_prefix
-        if upper is not None:
-            where_parts.append("key < $prefix_hi")
-            params["prefix_hi"] = upper
+
+    if not is_pure_prefix:
+        where_parts.append("regexp_matches(key, $key_pattern)")
+        params["key_pattern"] = pattern
+
     return where_parts, params
 
 

--- a/lib/iris/src/iris/cluster/log_store/duckdb_store.py
+++ b/lib/iris/src/iris/cluster/log_store/duckdb_store.py
@@ -1,46 +1,64 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Log store backed by rotating RAM buffers + Parquet segments + DuckDB reads.
+"""Log store backed by rotating RAM buffers + two-tier Parquet + DuckDB reads.
+
+Two on-disk tiers:
+
+    ``tmp_{min_seq}.parquet`` -- written by every flush; local-only.
+    ``log_{min_seq}.parquet`` -- produced by periodic compaction that merges
+    all current tmps into one archive and uploads only that to GCS.
 
 Lifecycle of a log entry:
 
-    1. Appended to the *head* RAM buffer (a plain Python list).
-    2. Every ``flush_interval_sec`` (default 10 min), the head buffer is
-       *sealed* and a background thread flushes it to a local Parquet file.
-       If the head buffer exceeds ``SEGMENT_TARGET_BYTES`` it is sealed
-       immediately.
-    3. When the background thread flushes a sealed buffer:
-       a. If the newest local Parquet segment is small enough, it reads it,
-          concatenates the new rows, and writes a replacement file. This
-          keeps the file count low (no thousands of tiny files).
-       b. If the newest segment is already large (>= ``SEGMENT_TARGET_BYTES``),
-          a new Parquet file is created (named by the new buffer's min_seq).
-       c. The sealed RAM buffer is removed (readers no longer need it).
-       d. The new/updated file is copied to GCS (best-effort).
-       e. GC drops oldest local segments past count/byte limits.
+    1. Appended to ``_pending`` (plain Python list) under ``_lock``.
+    2. A single background thread wakes periodically and:
+       a. Every ``compact_interval_sec`` (default 1s): if ``_pending`` has at
+          least ``_CHUNK_THRESHOLD`` rows, convert it to an Arrow ``Table`` and
+          append to ``_chunks`` (power-of-2 merged).
+       b. Every ``flush_interval_sec`` (default 60s), or under backpressure:
+          seal RAM data into ``_flushing`` and write a standalone
+          ``tmp_*.parquet`` segment to local disk. Existing segments are
+          never rewritten — in-line consolidation retained ~45 MB per flush
+          of arrow-pool memory (identified via targeted reproducer), so the
+          write path is strictly append-only.
+       c. Every ``compaction_interval_sec`` (default 10 min) or when tmp
+          count exceeds ``max_tmp_segments_before_compact`` (default 10):
+          merge all tmp_ files into a single ``log_*.parquet`` via DuckDB
+          ``COPY (SELECT ... ORDER BY key, seq) TO ... (FORMAT parquet)``,
+          then upload the merged file to GCS and unlink the tmps. DuckDB's
+          streaming COPY avoids the pyarrow concat/sort/write leak path.
+    3. Backpressure: if ``append()`` sees total RAM holders exceed
+       ``segment_target_bytes``, it wakes the bg thread to bypass the rate
+       limit and drain immediately.
 
-Read path: DuckDB ``read_parquet()`` over the snapshot of local Parquet files
-UNION ALL in-memory pyarrow tables for each RAM buffer (head + sealed).
+Read path: DuckDB ``read_parquet()`` over local segments (tmp + log), UNION
+ALL pyarrow tables for in-RAM data (``_chunks``, ``_flushing.table`` if
+present, and ``_pending``). Relies entirely on DuckDB's per-row-group parquet
+stats for pruning — files are sorted by ``(key, seq)`` so row-group ``key``
+bounds are tight enough that file-level Python filtering would add nothing.
+The per-read working set is capped by ``_MAX_PARQUET_BYTES_PER_READ``, which
+handles a mix of small tmps and large logs gracefully.
 
 Locking:
-    ``_lock``  --protects all mutable state (head buffer, sealed deque, local
-    segments list, and the sequence counter). Held briefly for snapshots.
+    ``_lock``  -- protects all mutable RAM state: ``_pending``, ``_chunks``,
+    ``_flushing``, ``_local_segments``, and ``_next_seq``. Held briefly for
+    snapshots and swaps; never held across I/O.
 
-    ``_segments_rwlock`` --readers hold a *shared* read lock while DuckDB has
-    parquet files open; GC holds the *exclusive* write lock before unlinking
-    files. This prevents GC from deleting a file that an in-progress query
-    still references.
+    ``_segments_rwlock`` -- readers hold the *shared* lock while DuckDB has
+    parquet files open; GC / compaction hold the *exclusive* lock before
+    unlinking or renaming files. This prevents file ops from disrupting
+    in-flight queries.
 """
 
 from __future__ import annotations
 
 import logging
 import tempfile
+import threading
 import time
 from collections import deque
 from collections.abc import Iterator
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -57,6 +75,7 @@ from iris.cluster.log_store._types import _EST_BYTES_PER_ROW, REGEX_META_RE, Log
 from iris.cluster.types import TaskAttempt
 from iris.logging import str_to_log_level
 from iris.rpc import logging_pb2
+from rigging.timing import RateLimiter
 
 logger = logging.getLogger(__name__)
 
@@ -86,8 +105,14 @@ _DUCKDB_TYPE_MAP: dict[pa.DataType, str] = {
 # onto the latest segment until it reaches this size, then a new file starts.
 SEGMENT_TARGET_BYTES = 100 * 1024 * 1024  # 100 MB
 
-# Seal the head buffer after this many seconds (even if small).
-DEFAULT_FLUSH_INTERVAL_SEC = 600.0  # 10 minutes
+# Background step cadences.
+DEFAULT_COMPACT_INTERVAL_SEC = 1.0
+DEFAULT_FLUSH_INTERVAL_SEC = 60.0
+DEFAULT_COMPACTION_INTERVAL_SEC = 600.0  # merge small tmp parquets into one archive
+
+# Trigger compaction when this many tmp segments accumulate, even before the
+# time-based interval fires. Keeps per-read fanout bounded under high ingest.
+DEFAULT_MAX_TMP_SEGMENTS_BEFORE_COMPACT = 10
 
 # Default caps for local Parquet retention.
 DEFAULT_MAX_LOCAL_SEGMENTS = 50
@@ -95,44 +120,30 @@ DEFAULT_MAX_LOCAL_BYTES = 5 * 1024**3  # 5 GB
 
 _ROW_GROUP_SIZE = 16_384
 
-# When doing a tail query, we optimistically restrict seq to the most recent
-# (max_lines * margin) entries. If the result is short, we fall back to a
-# full scan. 10x covers most realistic filter selectivities.
-_TAIL_SEQ_MARGIN = 10
-
-# Hard ceiling on the per-read parquet working set. Any single read scans at
-# most this many newest local segments, up to _MAX_PARQUET_BYTES_PER_READ of
-# cumulative on-disk data. Older segments remain retrievable by subsequent
-# reads with a moving cursor. This prevents a pathological filter from
-# pulling the full local retention through DuckDB in one shot.
-#
-# Raised from 5/500MB after an outage where dashboard reads showed zero rows
-# because target keys lived in segments older than the cap. Combined with
-# the newest-first early-stop loop in `_run_read_locked`, realistic tail
-# reads stay well under 500ms p95 even when the filter matches many files.
-_MAX_PARQUETS_PER_READ = 25
+# Hard ceiling on the per-read parquet working set. Caps cumulative on-disk
+# bytes opened in a single query; kept as a safety net for pathological
+# body-LIKE queries that cannot be pruned by row-group statistics. Because
+# small tmp segments coexist with larger compacted log segments, we cap by
+# size only — file count doesn't cleanly distinguish the two.
 _MAX_PARQUET_BYTES_PER_READ = 2_500 * 1024 * 1024
 
-# Batch size for the tail early-stop loop. Scans this many parquet files per
-# DuckDB query so planning overhead is amortized and file reads parallelize,
-# while still allowing short-circuit once LIMIT is met.
-_TAIL_BATCH_SEGMENTS = 5
+# File naming: hot flushes write tmp_*.parquet; compaction merges them into
+# log_*.parquet and uploads only that to GCS. Both are keyed by min_seq so
+# sorting by filename yields chronological order.
+_TMP_PREFIX = "tmp_"
+_LOG_PREFIX = "log_"
 
 
-def _prefix_upper_bound(prefix: str) -> str | None:
-    """Return the exclusive upper bound for a prefix range, or None if unbounded.
+def _tmp_filename(min_seq: int) -> str:
+    return f"{_TMP_PREFIX}{min_seq:019d}.parquet"
 
-    All strings starting with ``prefix`` satisfy ``prefix <= s < upper``.
-    This lets DuckDB use range predicates on Parquet row-group statistics
-    instead of regexp_matches, which isn't pushed down through parameterized queries.
-    """
-    if not prefix:
-        return None
-    # Increment the last byte. Works for all realistic UTF-8 key prefixes.
-    last = ord(prefix[-1])
-    if last >= 0x10FFFF:
-        return None
-    return prefix[:-1] + chr(last + 1)
+
+def _log_filename(min_seq: int) -> str:
+    return f"{_LOG_PREFIX}{min_seq:019d}.parquet"
+
+
+def _is_tmp_path(path: str) -> bool:
+    return Path(path).name.startswith(_TMP_PREFIX)
 
 
 def _fsspec_copy(src: str, dst: str) -> None:
@@ -161,70 +172,37 @@ def _read_seq_bounds(path: Path) -> tuple[int, int]:
         return 0, 0
 
 
-def _recover_max_seq(log_dir: Path) -> int:
-    """Recover the max sequence number by reading Parquet row-group statistics.
+def _discover_segments(log_dir: Path) -> list[Path]:
+    """Return every on-disk segment (tmp + log), chronological by filename."""
+    return sorted(list(log_dir.glob(f"{_TMP_PREFIX}*.parquet")) + list(log_dir.glob(f"{_LOG_PREFIX}*.parquet")))
 
-    Filenames are ``logs_{min_seq:019d}.parquet``.
+
+def _recover_max_seq(log_dir: Path) -> int:
+    """Recover the max sequence number across both tmp and log Parquet files.
+
     Returns max_seq + 1 so the counter can resume, or 1 if no files exist.
     """
     max_seen = -1
-    for p in log_dir.glob("logs_*.parquet"):
+    for p in _discover_segments(log_dir):
         _, max_seq = _read_seq_bounds(p)
         if max_seq > max_seen:
             max_seen = max_seq
     return max_seen + 1 if max_seen >= 0 else 1
 
 
-def _read_key_bounds(path: Path) -> tuple[str, str]:
-    """Read min/max key from Parquet row-group statistics."""
-    try:
-        meta = pq.read_metadata(path)
-        schema = meta.schema.to_arrow_schema()
-        key_idx = schema.get_field_index("key")
-        min_key = ""
-        max_key = ""
-        for i in range(meta.num_row_groups):
-            col = meta.row_group(i).column(key_idx)
-            if col.statistics is not None and col.statistics.has_min_max:
-                rg_min = col.statistics.min
-                rg_max = col.statistics.max
-                if not min_key or rg_min < min_key:
-                    min_key = rg_min
-                if not max_key or rg_max > max_key:
-                    max_key = rg_max
-        return min_key, max_key
-    except Exception:
-        return "", ""
+def _prefix_upper_bound(prefix: str) -> str | None:
+    """Return the exclusive upper bound for a prefix range, or None if unbounded.
 
-
-def _segment_overlaps_key(seg: _LocalSegment, key: str) -> bool:
-    """Check if a segment's key range could contain the exact key."""
-    if not seg.min_key:
-        return True  # no metadata, must scan
-    return seg.min_key <= key <= seg.max_key
-
-
-def _segment_overlaps_prefix(seg: _LocalSegment, prefix: str) -> bool:
-    """Check if a segment's key range could contain keys starting with prefix.
-
-    A prefix like "/user/job-50/" overlaps a segment if:
-    - segment's max_key >= prefix (some key could start at or after prefix)
-    - segment's min_key starts with prefix, OR min_key < prefix_upper_bound
+    All strings starting with ``prefix`` satisfy ``prefix <= s < upper``.
+    This lets DuckDB use range predicates on Parquet row-group statistics
+    instead of regexp_matches, which isn't pushed down through parameterized queries.
     """
-    if not seg.min_key:
-        return True  # no metadata, must scan
-    # Fast check: segment ends before prefix starts
-    if seg.max_key < prefix:
-        return False
-    # Compute the exclusive upper bound for the prefix by incrementing the last
-    # character. All strings matching the prefix satisfy: prefix <= s < upper.
-    # If we can't compute an upper bound (empty prefix or all-\xff), scan.
     if not prefix:
-        return True
-    upper = prefix[:-1] + chr(ord(prefix[-1]) + 1)
-    if seg.min_key >= upper:
-        return False
-    return True
+        return None
+    last = ord(prefix[-1])
+    if last >= 0x10FFFF:
+        return None
+    return prefix[:-1] + chr(last + 1)
 
 
 def _build_buffer_table(buffer: list[tuple]) -> pa.Table:
@@ -251,12 +229,9 @@ def _build_buffer_table(buffer: list[tuple]) -> pa.Table:
 # ---------------------------------------------------------------------------
 
 
+# Rows in _pending below this count aren't worth converting to Arrow yet —
+# the per-chunk overhead (array construction, metadata) dominates.
 _CHUNK_THRESHOLD = 1024
-
-# Minimum number of rows in a chunk before we merge it with another of the
-# same size (power-of-2 compaction).  Chunks below this size sit in the list
-# until the next append pushes a new chunk that triggers merging.
-_MIN_MERGE_ROWS = _CHUNK_THRESHOLD
 
 
 def _merge_chunks(chunks: list[pa.Table]) -> list[pa.Table]:
@@ -279,12 +254,15 @@ def _merge_chunks(chunks: list[pa.Table]) -> list[pa.Table]:
 
 @dataclass
 class _SealedBuffer:
-    """A RAM buffer that has been sealed (no more writes) and is pending flush."""
+    """Pre-flush snapshot being written to Parquet by the bg thread.
+
+    Visible to readers via ``ram_tables`` so data in flight isn't invisible
+    during the write.
+    """
 
     table: pa.Table
     min_seq: int
     max_seq: int
-    flushed: bool = False
 
 
 @dataclass
@@ -295,27 +273,6 @@ class _LocalSegment:
     size_bytes: int
     min_seq: int = 0
     max_seq: int = 0
-    min_key: str = ""
-    max_key: str = ""
-
-
-@dataclass(frozen=True)
-class _SegmentFilter:
-    """Filters segments by key bounds before building a DuckDB query."""
-
-    exact_key: str | None = None
-    prefix: str | None = None
-
-    def apply(self, segments: list[_LocalSegment]) -> list[_LocalSegment]:
-        if self.exact_key is not None:
-            return [s for s in segments if _segment_overlaps_key(s, self.exact_key)]
-        if self.prefix is not None:
-            return [s for s in segments if _segment_overlaps_prefix(s, self.prefix)]
-        return segments
-
-
-# Sentinel: include all segments (no filtering).
-_SEGMENT_FILTER_ALL = _SegmentFilter()
 
 
 class _RWLock:
@@ -323,7 +280,8 @@ class _RWLock:
 
     Multiple readers can hold the lock concurrently. A writer must wait for
     all readers to release before acquiring exclusive access. Used to prevent
-    GC from unlinking parquet files while DuckDB reads are in flight.
+    GC or consolidation from unlinking / renaming parquet files while DuckDB
+    reads are in flight.
     """
 
     def __init__(self):
@@ -375,16 +333,22 @@ def _next_cursor_id() -> int:
 class _ConnectionPool:
     """Single DuckDB database with cursor-based concurrency.
 
-    One ``duckdb.connect()`` call creates the shared buffer pool. Callers
-    get cursors via ``conn.cursor()`` which share that pool, keeping total
-    memory bounded by a single ``memory_limit``.
+    One ``duckdb.connect()`` call creates the shared buffer pool and the
+    parquet object cache (``enable_object_cache=true``), which caches parquet
+    footers and row-group stats across queries. Callers get cursors via
+    ``conn.cursor()`` which share that pool, keeping total memory bounded by a
+    single ``memory_limit``.
 
     RAM tables are registered with unique names (incorporating a monotonic
     counter) so concurrent cursors don't collide on table names.
     """
 
     def __init__(self, memory_limit: str = _DEFAULT_DUCKDB_MEMORY_LIMIT):
-        self._conn = duckdb.connect(config={"memory_limit": memory_limit, "threads": "2"})
+        self._conn = duckdb.connect(config={"memory_limit": memory_limit, "threads": "4"})
+        # Cache parquet footers / row-group stats across queries so repeated
+        # reads over the same segment set don't re-parse metadata. This is the
+        # single most impactful setting for read latency on the log store.
+        self._conn.execute("SET enable_object_cache=true")
 
     @contextmanager
     def checkout(self, buffer_tables: list[pa.Table]) -> Iterator[tuple[duckdb.DuckDBPyConnection, list[str]]]:
@@ -414,8 +378,8 @@ class _ConnectionPool:
 class DuckDBLogStore:
     """Log store backed by rotating RAM buffers + Parquet segments.
 
-    Thread-safe. One lock protects all mutable state: the head buffer,
-    the sealed-buffer deque, and the local-segment deque.
+    Thread-safe. ``_lock`` protects all mutable RAM state; ``_segments_rwlock``
+    serializes file ops against in-flight DuckDB reads.
     """
 
     def __init__(
@@ -425,7 +389,10 @@ class DuckDBLogStore:
         remote_log_dir: str = "",
         max_local_segments: int = DEFAULT_MAX_LOCAL_SEGMENTS,
         max_local_bytes: int = DEFAULT_MAX_LOCAL_BYTES,
+        compact_interval_sec: float = DEFAULT_COMPACT_INTERVAL_SEC,
         flush_interval_sec: float = DEFAULT_FLUSH_INTERVAL_SEC,
+        compaction_interval_sec: float = DEFAULT_COMPACTION_INTERVAL_SEC,
+        max_tmp_segments_before_compact: int = DEFAULT_MAX_TMP_SEGMENTS_BEFORE_COMPACT,
         segment_target_bytes: int = SEGMENT_TARGET_BYTES,
         duckdb_memory_limit: str = _DEFAULT_DUCKDB_MEMORY_LIMIT,
     ):
@@ -440,39 +407,51 @@ class DuckDBLogStore:
         self._remote_log_dir = remote_log_dir
         self._max_local_segments = max_local_segments
         self._max_local_bytes = max_local_bytes
-        self._flush_interval_sec = flush_interval_sec
         self._segment_target_bytes = segment_target_bytes
+        self._max_tmp_segments_before_compact = max_tmp_segments_before_compact
 
         # ---- shared mutable state (all guarded by _lock) ----
         self._lock = Lock()
-        self._next_seq = _recover_max_seq(self._log_dir)  # guarded by _lock
-        self._pending: list[tuple] = []  # hot write list, converted to arrow at _CHUNK_THRESHOLD
+        self._next_seq = _recover_max_seq(self._log_dir)
+        self._pending: list[tuple] = []  # hot write list, converted by bg thread
         self._chunks: list[pa.Table] = []  # power-of-2 merged arrow tables
-        self._sealed: deque[_SealedBuffer] = deque()  # sealed, pending flush
-        self._local_segments: deque[_LocalSegment] = deque()  # flushed parquet files
-        self._last_flush_time = time.monotonic()
+        self._flushing: _SealedBuffer | None = None  # pre-flush snapshot being written
+        self._local_segments: deque[_LocalSegment] = deque()
 
         # RWLock: readers hold shared lock during DuckDB queries;
-        # GC holds exclusive lock before unlinking files.
+        # GC / consolidation hold exclusive lock before unlinking or renaming.
         self._segments_rwlock = _RWLock()
 
-        # Discover pre-existing Parquet files from a previous run.
-        for p in sorted(self._log_dir.glob("logs_*.parquet")):
+        # Discover pre-existing Parquet files from a previous run. Both tmp_
+        # (pre-compaction, local-only) and log_ (compacted, uploaded) are
+        # re-registered so reads work immediately after restart.
+        for p in _discover_segments(self._log_dir):
             min_seq, max_seq = _read_seq_bounds(p)
-            min_key, max_key = _read_key_bounds(p)
             self._local_segments.append(
                 _LocalSegment(
                     path=str(p),
                     size_bytes=p.stat().st_size,
                     min_seq=min_seq,
                     max_seq=max_seq,
-                    min_key=min_key,
-                    max_key=max_key,
                 )
             )
 
         self._pool = _ConnectionPool(memory_limit=duckdb_memory_limit)
-        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="log_flush")
+
+        # ---- background compact + flush + compaction thread ----
+        self._compact_rl = RateLimiter(compact_interval_sec)
+        self._flush_rl = RateLimiter(flush_interval_sec)
+        self._compaction_rl = RateLimiter(compaction_interval_sec)
+        self._stop = threading.Event()
+        self._wake = threading.Event()
+        # Bumped on each successful flush so tests can wait for one to land.
+        self._flush_generation = 0
+        self._flush_generation_cond = Condition(Lock())
+        # Bumped on each successful compaction; symmetric with flush generation.
+        self._compaction_generation = 0
+        self._compaction_generation_cond = Condition(Lock())
+        self._bg_thread = threading.Thread(target=self._bg_loop, name="log_flush", daemon=True)
+        self._bg_thread.start()
 
     # ------------------------------------------------------------------
     # Write API
@@ -484,28 +463,27 @@ class DuckDBLogStore:
         with self._lock:
             first_seq = self._next_seq
             self._next_seq += len(entries)
-            rows = [(first_seq + i, key, e.source, e.data, e.timestamp.epoch_ms, e.level) for i, e in enumerate(entries)]
-            self._pending.extend(rows)
-            self._maybe_compact_pending()
-        self._maybe_seal()
+            self._pending.extend(
+                (first_seq + i, key, e.source, e.data, e.timestamp.epoch_ms, e.level) for i, e in enumerate(entries)
+            )
+            needs_drain = self._ram_bytes_locked() >= self._segment_target_bytes
+        if needs_drain:
+            self._wake.set()
 
     def append_batch(self, items: list[tuple[str, list]]) -> None:
         """Write log entries from multiple keys in a single operation."""
         with self._lock:
-            all_rows: list[tuple] = []
             for key, entries in items:
                 if not entries:
                     continue
                 first_seq = self._next_seq
                 self._next_seq += len(entries)
-                all_rows.extend(
+                self._pending.extend(
                     (first_seq + i, key, e.source, e.data, e.timestamp.epoch_ms, e.level) for i, e in enumerate(entries)
                 )
-            if not all_rows:
-                return
-            self._pending.extend(all_rows)
-            self._maybe_compact_pending()
-        self._maybe_seal()
+            needs_drain = self._ram_bytes_locked() >= self._segment_target_bytes
+        if needs_drain:
+            self._wake.set()
 
     # ------------------------------------------------------------------
     # Read API
@@ -542,12 +520,10 @@ class DuckDBLogStore:
                 tail,
                 cursor,
                 include_key_in_select=False,
-                segment_filter=_SegmentFilter(exact_key=key),
                 exact_key=key,
             )
 
-        # Regex pattern path.
-        where_parts, params, segment_filter = _regex_query(key, cursor)
+        where_parts, params = _regex_query(key, cursor)
         _add_common_filters(where_parts, params, since_ms, substring_filter, min_level_enum)
         return self._execute_read(
             where_parts,
@@ -556,7 +532,6 @@ class DuckDBLogStore:
             tail,
             cursor,
             include_key_in_select=True,
-            segment_filter=segment_filter,
         )
 
     def has_logs(self, key: str) -> bool:
@@ -575,213 +550,254 @@ class DuckDBLogStore:
     # ------------------------------------------------------------------
 
     def close(self) -> None:
-        """Flush remaining buffer, shut down background executor, clean up temp dir."""
-        self._seal_head()
-        self._executor.shutdown(wait=True)
-        # Flush any sealed buffers that didn't get submitted (edge case).
-        with self._lock:
-            remaining = list(self._sealed)
-        for sb in remaining:
-            if not sb.flushed:
-                self._flush_sealed_buffer(sb)
+        """Stop the bg thread, drain + compact remaining data, and clean up."""
+        self._stop.set()
+        self._wake.set()
+        self._bg_thread.join()
+        # Final drain + compaction in the foreground so any lingering tmp
+        # segments get merged and uploaded before shutdown.
+        self._compact_step()
+        self._flush_step()
+        self._compaction_step()
         self._pool.close()
         if self._temp_dir is not None:
             self._temp_dir.cleanup()
 
     # ------------------------------------------------------------------
-    # Internal: seal and flush
+    # Internal: background thread
     # ------------------------------------------------------------------
 
-    def _maybe_compact_pending(self) -> None:
-        """Convert _pending to an arrow chunk when it exceeds _CHUNK_THRESHOLD. Must hold _lock."""
-        if len(self._pending) < _CHUNK_THRESHOLD:
-            return
-        self._chunks.append(_build_buffer_table(self._pending))
-        self._pending = []
-        self._chunks = _merge_chunks(self._chunks)
+    def _ram_bytes_locked(self) -> int:
+        """Total bytes across every in-RAM holder (pending + chunks + flushing).
 
-    def _head_row_count(self) -> int:
-        """Total rows in the head buffer (chunks + pending). Must hold _lock."""
-        return sum(c.num_rows for c in self._chunks) + len(self._pending)
+        Used for backpressure: _pending alone is a poor signal because the
+        compact tick (1s) drains _pending into _chunks long before it reaches
+        segment_target_bytes, so a check against _pending never fires. The
+        flush tick runs every 60s, so without this aggregate accounting we'd
+        accumulate a full minute of arrow-table data (hundreds of MB at
+        realistic rates) before any flush.
+        """
+        chunks_b = sum(t.nbytes for t in self._chunks)
+        flushing_b = self._flushing.table.nbytes if self._flushing is not None else 0
+        return len(self._pending) * _EST_BYTES_PER_ROW + chunks_b + flushing_b
 
-    def _maybe_seal(self) -> None:
-        """Seal the head buffer if it's big enough or old enough."""
+    def _bg_loop(self) -> None:
+        """Drive compact, flush, and compaction on rate-limited schedules.
+
+        Three steps run on distinct cadences:
+            - ``_compact_step`` (1s): drain ``_pending`` → Arrow chunk.
+            - ``_flush_step`` (60s or 100 MB backpressure): RAM → tmp parquet.
+            - ``_compaction_step`` (10 min or >N tmp files): merge tmps into
+              one log parquet via DuckDB ``COPY ... ORDER BY ...``, upload to
+              GCS, unlink tmps.
+        """
+        while not self._stop.is_set():
+            # Backpressure: if total RAM holders blew past the segment target,
+            # drain immediately and reset both rate limiters so the next idle
+            # tick doesn't fire redundantly.
+            with self._lock:
+                force_drain = self._ram_bytes_locked() >= self._segment_target_bytes
+                tmp_count = sum(1 for s in self._local_segments if _is_tmp_path(s.path))
+                force_compaction = tmp_count > self._max_tmp_segments_before_compact
+            if force_drain:
+                self._compact_step()
+                self._flush_step()
+                self._compact_rl.mark_run()
+                self._flush_rl.mark_run()
+            else:
+                if self._compact_rl.should_run():
+                    self._compact_step()
+                if self._flush_rl.should_run():
+                    self._flush_step()
+            if force_compaction or self._compaction_rl.should_run():
+                self._compaction_step()
+                self._compaction_rl.mark_run()
+
+            self._wake.wait(timeout=min(self._compact_rl.time_until_next(), 1.0))
+            self._wake.clear()
+
+    def _compact_step(self) -> None:
+        """Move ``_pending`` into a new Arrow chunk (if big enough)."""
         with self._lock:
-            est_size = self._head_row_count() * _EST_BYTES_PER_ROW
-            elapsed = time.monotonic() - self._last_flush_time
-            should_seal = est_size >= self._segment_target_bytes or (
-                self._head_row_count() > 0 and elapsed >= self._flush_interval_sec
-            )
-        if should_seal:
-            self._seal_head()
+            if len(self._pending) < _CHUNK_THRESHOLD:
+                return
+            rows = self._pending
+            self._pending = []
+        table = _build_buffer_table(rows)
+        with self._lock:
+            self._chunks.append(table)
+            self._chunks = _merge_chunks(self._chunks)
 
-    def _seal_head(self) -> None:
-        """Move the head buffer to the sealed deque and submit a flush task."""
+    def _flush_step(self) -> None:
+        """Seal any RAM data into a Parquet segment on disk."""
         with self._lock:
             if not self._chunks and not self._pending:
                 return
             tables = list(self._chunks)
             if self._pending:
                 tables.append(_build_buffer_table(self._pending))
-            table = pa.concat_tables(tables) if len(tables) > 1 else tables[0]
-
-            seq_col = table.column("seq")
+                self._pending = []
+            new_table = pa.concat_tables(tables) if len(tables) > 1 else tables[0]
+            # Sort by (key, seq) so Parquet row-group statistics on `key` are
+            # tight, letting DuckDB skip row groups that don't contain the
+            # target key on reads.
+            new_table = new_table.sort_by([("key", "ascending"), ("seq", "ascending")])
+            self._chunks = []
+            seq_col = new_table.column("seq")
             sealed = _SealedBuffer(
-                table=table,
+                table=new_table,
                 min_seq=pc.min(seq_col).as_py(),
                 max_seq=pc.max(seq_col).as_py(),
             )
-            self._chunks = []
-            self._pending = []
-            self._sealed.append(sealed)
-            self._last_flush_time = time.monotonic()
-        logger.info(
-            "Sealed head buffer: rows=%d seq=[%d,%d] est_bytes=%d",
-            sealed.table.num_rows,
-            sealed.min_seq,
-            sealed.max_seq,
-            sealed.table.num_rows * _EST_BYTES_PER_ROW,
-        )
-        self._executor.submit(self._flush_sealed_buffer, sealed)
+            self._flushing = sealed
 
-    def _flush_sealed_buffer(self, sealed: _SealedBuffer) -> None:
-        """Write a sealed buffer to Parquet, possibly consolidating with the
-        latest segment if it's small. Runs on the background executor thread.
-
-        Consolidation heuristic: if the newest local segment is smaller than
-        ``_segment_target_bytes``, read it, concatenate the new rows, and
-        write a replacement file. This avoids accumulating thousands of tiny
-        Parquet files when log volume is low.
-        """
-        if sealed.table.num_rows == 0:
-            return
-
-        new_min_seq = sealed.min_seq
-        new_max_seq = sealed.max_seq
-        # Sort by (key, seq) so row-group statistics on `key` are tight,
-        # enabling DuckDB to skip row groups that don't contain the target key.
-        new_table = sealed.table.sort_by([("key", "ascending"), ("seq", "ascending")])
-
-        # Decide whether to consolidate with the latest segment.
-        with self._lock:
-            latest = self._local_segments[-1] if self._local_segments else None
-            can_consolidate = latest is not None and latest.size_bytes < self._segment_target_bytes
-
-        if can_consolidate:
-            assert latest is not None
-            try:
-                consolidate_start = time.monotonic()
-                existing_table = pq.read_table(latest.path)
-                combined = pa.concat_tables([existing_table, new_table])
-                combined = combined.sort_by([("key", "ascending"), ("seq", "ascending")])
-                combined_min_seq = latest.min_seq
-                combined_max_seq = new_max_seq
-                # Reuse the same filename (keyed only on min_seq) so the GCS
-                # upload overwrites the old object in place — no deletion needed.
-                filename = f"logs_{combined_min_seq:019d}.parquet"
-                filepath = self._log_dir / filename
-
-                # Write combined data to a temp file. Then hold the write lock
-                # across both the rename and the segment-list update so that no
-                # reader can snapshot a state where the file has the combined
-                # content AND the sealed buffer is still in RAM tables (which
-                # would cause double-counting).
-                tmp_path = filepath.with_suffix(".parquet.tmp")
-                pq.write_table(
-                    combined, tmp_path, compression="zstd", row_group_size=_ROW_GROUP_SIZE, write_page_index=True
-                )
-                key_col = combined.column("key")
-                seg = _LocalSegment(
-                    path=str(filepath),
-                    size_bytes=tmp_path.stat().st_size,
-                    min_seq=combined_min_seq,
-                    max_seq=combined_max_seq,
-                    min_key=key_col[0].as_py(),
-                    max_key=key_col[-1].as_py(),
-                )
-
-                self._segments_rwlock.write_acquire()
-                try:
-                    tmp_path.rename(filepath)
-                    with self._lock:
-                        for i, s in enumerate(self._local_segments):
-                            if s.path == latest.path:
-                                del self._local_segments[i]
-                                break
-                        self._local_segments.append(seg)
-                        try:
-                            self._sealed.remove(sealed)
-                        except ValueError:
-                            pass
-                        sealed.flushed = True
-                finally:
-                    self._segments_rwlock.write_release()
-
-                logger.info(
-                    "Wrote consolidated segment %s: rows=%d (added=%d) bytes=%d seq=[%d,%d] elapsed_ms=%d",
-                    filename,
-                    combined.num_rows,
-                    new_table.num_rows,
-                    seg.size_bytes,
-                    combined_min_seq,
-                    combined_max_seq,
-                    int((time.monotonic() - consolidate_start) * 1000),
-                )
-
-                # GCS upload overwrites the same object (same filename).
-                self._offload_to_gcs(filename, filepath)
-                self._gc_local_segments()
-                return
-
-            except Exception:
-                logger.warning("Consolidation failed, writing as new segment", exc_info=True)
-                # Fall through to write as a new standalone segment.
-
-        # Write as a new standalone segment.
-        filename = f"logs_{new_min_seq:019d}.parquet"
-        filepath = self._log_dir / filename
-
-        write_start = time.monotonic()
         try:
-            tmp_path = filepath.with_suffix(".parquet.tmp")
-            pq.write_table(
-                new_table, tmp_path, compression="zstd", row_group_size=_ROW_GROUP_SIZE, write_page_index=True
-            )
-            tmp_path.rename(filepath)
+            self._write_new_segment(sealed)
         except Exception:
-            logger.warning("Failed to write Parquet segment %s", filepath, exc_info=True)
-            # Leave the sealed buffer in the deque so reads still see the data.
+            logger.warning("Flush failed, restoring data to chunks", exc_info=True)
+            with self._lock:
+                self._chunks.insert(0, sealed.table)
+                self._flushing = None
             return
 
-        key_col = new_table.column("key")
+        with self._flush_generation_cond:
+            self._flush_generation += 1
+            self._flush_generation_cond.notify_all()
+
+        self._gc_local_segments()
+
+    def _write_new_segment(self, sealed: _SealedBuffer) -> None:
+        """Write a sealed buffer as a new tmp_ Parquet file.
+
+        Not uploaded to GCS — the periodic compaction step will merge this and
+        any other tmps into a log_ file and upload that instead. That keeps
+        GCS object count bounded regardless of flush frequency.
+        """
+        filename = _tmp_filename(sealed.min_seq)
+        filepath = self._log_dir / filename
+        write_start = time.monotonic()
+        tmp_path = filepath.with_suffix(".parquet.tmp")
+        pq.write_table(
+            sealed.table,
+            tmp_path,
+            compression="zstd",
+            row_group_size=_ROW_GROUP_SIZE,
+            write_page_index=True,
+        )
+        tmp_path.rename(filepath)
+
         seg = _LocalSegment(
             path=str(filepath),
             size_bytes=filepath.stat().st_size,
-            min_seq=new_min_seq,
-            max_seq=new_max_seq,
-            min_key=key_col[0].as_py(),
-            max_key=key_col[-1].as_py(),
+            min_seq=sealed.min_seq,
+            max_seq=sealed.max_seq,
         )
-
         with self._lock:
             self._local_segments.append(seg)
-            try:
-                self._sealed.remove(sealed)
-            except ValueError:
-                pass
-            sealed.flushed = True
+            self._flushing = None
 
         logger.info(
-            "Wrote segment %s: rows=%d bytes=%d seq=[%d,%d] elapsed_ms=%d",
+            "Wrote tmp segment %s: rows=%d bytes=%d seq=[%d,%d] elapsed_ms=%d",
             filename,
-            new_table.num_rows,
+            sealed.table.num_rows,
             seg.size_bytes,
-            new_min_seq,
-            new_max_seq,
+            sealed.min_seq,
+            sealed.max_seq,
             int((time.monotonic() - write_start) * 1000),
         )
 
-        self._offload_to_gcs(filename, filepath)
+    def _compaction_step(self) -> None:
+        """Merge all tmp_ segments into a single log_ segment via DuckDB.
+
+        Uses ``COPY (SELECT ... ORDER BY key, seq)`` so the merge is a
+        DuckDB-native streaming operation — never touches pyarrow's
+        concat/sort path (which leaks ~45 MB per invocation when reading
+        parquet back).
+
+        On success: uploads the merged file to GCS, unlinks the tmps locally,
+        replaces them in ``_local_segments``, and bumps ``_compaction_generation``.
+        Read queries are protected by ``_segments_rwlock`` — the unlink + swap
+        happen under the exclusive write lock.
+        """
+        with self._lock:
+            tmps = [s for s in self._local_segments if _is_tmp_path(s.path)]
+        if not tmps:
+            return
+        # Single-tmp compaction costs a rewrite for no fanout benefit — skip.
+        if len(tmps) < 2:
+            return
+
+        tmps.sort(key=lambda s: s.min_seq)
+        min_seq = tmps[0].min_seq
+        max_seq = max(t.max_seq for t in tmps)
+        merged_filename = _log_filename(min_seq)
+        merged_path = self._log_dir / merged_filename
+        staging_path = merged_path.with_suffix(".parquet.tmp")
+
+        compaction_start = time.monotonic()
+        # Self-generated paths from _tmp_filename — no SQL injection surface.
+        paths_sql = ",".join(f"'{t.path}'" for t in tmps)
+        sql = (
+            f"COPY (SELECT * FROM read_parquet([{paths_sql}]) ORDER BY key, seq) "
+            f"TO '{staging_path}' "
+            f"(FORMAT 'parquet', ROW_GROUP_SIZE {_ROW_GROUP_SIZE}, COMPRESSION 'zstd')"
+        )
+        try:
+            with self._pool.checkout([]) as (conn, _):
+                conn.execute(sql)
+        except Exception:
+            logger.warning("Compaction failed, leaving tmp segments in place", exc_info=True)
+            staging_path.unlink(missing_ok=True)
+            return
+
+        merged_seg = _LocalSegment(
+            path=str(merged_path),
+            size_bytes=staging_path.stat().st_size,
+            min_seq=min_seq,
+            max_seq=max_seq,
+        )
+        tmp_paths = {t.path for t in tmps}
+
+        self._segments_rwlock.write_acquire()
+        try:
+            staging_path.rename(merged_path)
+            with self._lock:
+                # Rebuild deque: first tmp is replaced by merged; other tmps dropped.
+                new_segments: deque[_LocalSegment] = deque()
+                merged_inserted = False
+                for s in self._local_segments:
+                    if s.path in tmp_paths:
+                        if not merged_inserted:
+                            new_segments.append(merged_seg)
+                            merged_inserted = True
+                        # skip — it's being replaced
+                    else:
+                        new_segments.append(s)
+                if not merged_inserted:
+                    new_segments.append(merged_seg)
+                self._local_segments = new_segments
+            for t in tmps:
+                try:
+                    Path(t.path).unlink(missing_ok=True)
+                except Exception:
+                    logger.warning("Failed to unlink tmp segment %s", t.path, exc_info=True)
+        finally:
+            self._segments_rwlock.write_release()
+
+        with self._compaction_generation_cond:
+            self._compaction_generation += 1
+            self._compaction_generation_cond.notify_all()
+
+        logger.info(
+            "Compacted %d tmp segments into %s: bytes=%d seq=[%d,%d] elapsed_ms=%d",
+            len(tmps),
+            merged_filename,
+            merged_seg.size_bytes,
+            min_seq,
+            max_seq,
+            int((time.monotonic() - compaction_start) * 1000),
+        )
+        self._offload_to_gcs(merged_filename, merged_path)
         self._gc_local_segments()
 
     def _gc_local_segments(self) -> None:
@@ -809,8 +825,6 @@ class DuckDBLogStore:
         if not to_delete:
             return
 
-        # Hold the write lock while deleting local files so concurrent reads
-        # (which hold the read lock) finish before we unlink anything.
         self._segments_rwlock.write_acquire()
         try:
             for path, _ in to_delete:
@@ -879,6 +893,41 @@ class DuckDBLogStore:
         )
 
     # ------------------------------------------------------------------
+    # Test hooks
+    # ------------------------------------------------------------------
+
+    def _force_flush(self) -> None:
+        """Synchronously compact + flush. For tests only."""
+        self._compact_step()
+        self._flush_step()
+
+    def _wait_for_flush(self, timeout: float = 10.0) -> None:
+        """Block until at least one more flush has landed. For tests only."""
+        start_gen = self._flush_generation
+        deadline = time.monotonic() + timeout
+        with self._flush_generation_cond:
+            while self._flush_generation == start_gen:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError("timed out waiting for flush")
+                self._flush_generation_cond.wait(timeout=remaining)
+
+    def _force_compaction(self) -> None:
+        """Synchronously merge all tmp segments into one log segment. For tests only."""
+        self._compaction_step()
+
+    def _wait_for_compaction(self, timeout: float = 10.0) -> None:
+        """Block until at least one more compaction has landed. For tests only."""
+        start_gen = self._compaction_generation
+        deadline = time.monotonic() + timeout
+        with self._compaction_generation_cond:
+            while self._compaction_generation == start_gen:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError("timed out waiting for compaction")
+                self._compaction_generation_cond.wait(timeout=remaining)
+
+    # ------------------------------------------------------------------
     # Internal: read
     # ------------------------------------------------------------------
 
@@ -890,14 +939,11 @@ class DuckDBLogStore:
         tail: bool,
         default_cursor: int,
         include_key_in_select: bool,
-        segment_filter: _SegmentFilter = _SEGMENT_FILTER_ALL,
         exact_key: str | None = None,
     ) -> LogReadResult:
         # Acquire the segments read lock BEFORE snapshotting paths. This
         # guarantees that no file in our snapshot can be deleted (by GC or
         # consolidation) until we release the lock after DuckDB is done.
-        # Concurrent read count is capped at the RPC layer by
-        # ConcurrencyLimitInterceptor on the LogService endpoint.
         self._segments_rwlock.read_acquire()
         try:
             rows = self._run_read_locked(
@@ -906,7 +952,6 @@ class DuckDBLogStore:
                 max_lines=max_lines,
                 tail=tail,
                 include_key_in_select=include_key_in_select,
-                segment_filter=segment_filter,
             )
         finally:
             self._segments_rwlock.read_release()
@@ -956,36 +1001,28 @@ class DuckDBLogStore:
         max_lines: int,
         tail: bool,
         include_key_in_select: bool,
-        segment_filter: _SegmentFilter,
     ) -> list[tuple]:
-        """Snapshot in-memory buffers and run the DuckDB query. Caller holds
-        the segments read lock.
+        """Snapshot RAM + segments, run one DuckDB query. Caller holds the
+        segments read lock.
 
-        Fast path for filtered tail reads (no exact key): restrict seq to the
-        last max_lines * _TAIL_SEQ_MARGIN entries and retry if too sparse.
-        Row-group pruning on `seq` lets DuckDB skip whole files.
-
-        Tail early-stop: when the fast path doesn't apply or misses, walk the
-        capped working set newest-first (RAM buffers, then parquet segments)
-        and break once max_lines rows have been collected. Segment seq ranges
-        are disjoint so the top-N rows by seq are guaranteed to come from the
-        newest source that contributes any match.
-
-        Working set cap: at most _MAX_PARQUETS_PER_READ newest segments and
-        _MAX_PARQUET_BYTES_PER_READ cumulative bytes. Callers with stale
-        cursors will make forward progress across successive reads.
+        All pruning is delegated to DuckDB. Per-file row-group ``key`` bounds
+        on the sorted segments are narrow enough that opening every file in
+        the capped working set costs ~4ms/file of planning even when zero
+        rows match. The ``_cap_segments`` bound is a safety net for
+        pathological body-LIKE queries with no row-group-prunable predicate.
         """
         with self._lock:
             segments = list(self._local_segments)
-            ram_tables: list[pa.Table] = [sb.table for sb in self._sealed]
-            ram_tables.extend(self._chunks)
-            if self._pending:
-                ram_tables.append(_build_buffer_table(self._pending))
-            current_max_seq = self._next_seq - 1
+            ram_tables: list[pa.Table] = list(self._chunks)
+            if self._flushing is not None:
+                ram_tables.append(self._flushing.table)
+            pending_snapshot = list(self._pending) if self._pending else None
 
-        segments = _cap_segments(segment_filter.apply(segments))
-        parquet_files = [s.path for s in segments]
-        parquet_files = self._drop_missing_local_segments(parquet_files)
+        if pending_snapshot:
+            ram_tables.append(_build_buffer_table(pending_snapshot))
+
+        segments = _cap_segments(segments)
+        parquet_files = self._drop_missing_local_segments([s.path for s in segments])
 
         where_clause = " AND ".join(where_parts)
         select_cols = (
@@ -994,46 +1031,7 @@ class DuckDBLogStore:
         order = "ORDER BY seq DESC" if (tail and max_lines > 0) else "ORDER BY seq"
         limit = f"LIMIT {max_lines}" if max_lines > 0 else ""
 
-        # Register each RAM table individually so DuckDB scans them via
-        # zero-copy Arrow, avoiding a pa.concat_tables() copy.
         with self._pool.checkout(ram_tables) as (conn, ram_names):
-            # Seq-bounded fast path: only useful for filtered tail reads
-            # where `key` row-group stats can't already prune (i.e. regex
-            # / prefix scans, which is the `include_key_in_select` path).
-            # Exact-key tails are already pruned by row-group `key` stats.
-            if tail and max_lines > 0 and include_key_in_select:
-                source = _build_union_source(parquet_files, ram_names)
-                seq_lower = max(0, current_max_seq - max_lines * _TAIL_SEQ_MARGIN)
-                bounded_where = f"{where_clause} AND seq > {seq_lower}"
-                sql = f"SELECT {select_cols} FROM ({source}) WHERE {bounded_where} {order} {limit}"
-                rows = conn.execute(sql, params).fetchall()
-                if len(rows) >= max_lines:
-                    return rows
-
-            if tail and max_lines > 0:
-                # Early-stop: iterate newest→oldest in batches, break once
-                # LIMIT filled. Batching amortizes per-query planning and
-                # lets DuckDB parallelize scans across the batch; the batch
-                # size trades short-circuit aggressiveness against fixed
-                # per-execute overhead.
-                # RAM tables hold seqs strictly greater than any parquet, so
-                # they come first. Parquet files are in ascending min_seq.
-                collected: list[tuple] = []
-                if ram_names:
-                    ram_source = _build_union_source([], ram_names)
-                    sql = f"SELECT {select_cols} FROM ({ram_source}) WHERE {where_clause} {order} LIMIT {max_lines}"
-                    collected.extend(conn.execute(sql, params).fetchall())
-                newest_first = list(reversed(parquet_files))
-                for start in range(0, len(newest_first), _TAIL_BATCH_SEGMENTS):
-                    if len(collected) >= max_lines:
-                        break
-                    batch = newest_first[start : start + _TAIL_BATCH_SEGMENTS]
-                    remaining = max_lines - len(collected)
-                    batch_source = _build_union_source(batch, [])
-                    sql = f"SELECT {select_cols} FROM ({batch_source}) WHERE {where_clause} {order} LIMIT {remaining}"
-                    collected.extend(conn.execute(sql, params).fetchall())
-                return collected
-
             source = _build_union_source(parquet_files, ram_names)
             sql = f"SELECT {select_cols} FROM ({source}) WHERE {where_clause} {order} {limit}"
             return conn.execute(sql, params).fetchall()
@@ -1045,13 +1043,16 @@ class DuckDBLogStore:
 
 
 def _cap_segments(segments: list[_LocalSegment]) -> list[_LocalSegment]:
-    """Cap a segment list at the newest _MAX_PARQUETS_PER_READ entries and
-    _MAX_PARQUET_BYTES_PER_READ cumulative bytes, returned in ascending
-    min_seq order.
+    """Cap a segment list at _MAX_PARQUET_BYTES_PER_READ cumulative bytes,
+    taking the newest segments first and returning them in ascending min_seq
+    order.
+
+    No file-count cap: tmp (small) and log (large) segments coexist after
+    compaction, so bytes are the only stable bound on read working-set size.
     """
     if not segments:
         return segments
-    newest_first = sorted(segments, key=lambda s: s.min_seq, reverse=True)[:_MAX_PARQUETS_PER_READ]
+    newest_first = sorted(segments, key=lambda s: s.min_seq, reverse=True)
     capped: list[_LocalSegment] = []
     total = 0
     for seg in newest_first:
@@ -1075,8 +1076,8 @@ def _regex_literal_prefix(pattern: str) -> str:
     return pattern[: match.start()]
 
 
-def _regex_query(pattern: str, cursor: int) -> tuple[list[str], dict, _SegmentFilter]:
-    """Build WHERE clauses and segment filter for a regex pattern.
+def _regex_query(pattern: str, cursor: int) -> tuple[list[str], dict]:
+    """Build WHERE clauses for a regex pattern.
 
     Extracts a literal prefix for Parquet range pushdown. If the pattern
     is purely a prefix (literal text followed only by ``.*``), range
@@ -1096,9 +1097,8 @@ def _regex_query(pattern: str, cursor: int) -> tuple[list[str], dict, _SegmentFi
         if upper is not None:
             where_parts.append("key < $prefix_hi")
             params["prefix_hi"] = upper
-        return where_parts, params, _SegmentFilter(prefix=literal_prefix)
+        return where_parts, params
 
-    # General regex pattern — use regexp_matches with optional prefix pushdown.
     where_parts = ["regexp_matches(key, $key_pattern)", "seq > $cursor"]
     params = {"key_pattern": pattern, "cursor": cursor}
     if literal_prefix:
@@ -1108,10 +1108,7 @@ def _regex_query(pattern: str, cursor: int) -> tuple[list[str], dict, _SegmentFi
         if upper is not None:
             where_parts.append("key < $prefix_hi")
             params["prefix_hi"] = upper
-        segment_filter = _SegmentFilter(prefix=literal_prefix)
-    else:
-        segment_filter = _SEGMENT_FILTER_ALL
-    return where_parts, params, segment_filter
+    return where_parts, params
 
 
 def _add_common_filters(
@@ -1136,9 +1133,9 @@ def _add_common_filters(
 def _build_union_source(parquet_files: list[str], ram_table_names: list[str]) -> str:
     """Build a SQL source expression: local Parquet files UNION ALL ram tables.
 
-    File paths are self-generated (``logs_{seq}_{seq}.parquet``) so no SQL
-    injection risk from the f-string embedding. RAM table names are generated
-    internally (``_ram_0``, ``_ram_1``, …).
+    File paths are self-generated (``tmp_*.parquet`` / ``log_*.parquet``) so
+    no SQL injection risk from the f-string embedding. RAM table names are
+    generated internally (``_ram_<cid>_<i>``).
     """
     parts: list[str] = []
     if parquet_files:
@@ -1147,7 +1144,6 @@ def _build_union_source(parquet_files: list[str], ram_table_names: list[str]) ->
     for name in ram_table_names:
         parts.append(f"SELECT * FROM {name}")
     if not parts:
-        # No data sources at all; return an empty selection from the schema.
         col_defs = ", ".join(f"NULL::{_DUCKDB_TYPE_MAP[f.type]} AS {f.name}" for f in _PARQUET_SCHEMA)
         return f"SELECT {col_defs} WHERE false"
     return " UNION ALL ".join(parts)

--- a/lib/iris/tests/cluster/controller/test_logs.py
+++ b/lib/iris/tests/cluster/controller/test_logs.py
@@ -521,6 +521,49 @@ def test_recovery_reads_both_tmp_and_log(tmp_path: Path):
         store2.close()
 
 
+def test_recovery_migrates_legacy_logs_filenames(tmp_path: Path):
+    """Pre-tiered-layout ``logs_*.parquet`` files are renamed to ``log_*.parquet``.
+
+    A controller upgraded from the single-series layout must not silently
+    drop historical segments on restart — that would reset _next_seq to 1
+    and cause sequence reuse on subsequent writes.
+    """
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    # Write one log_*.parquet via a first-gen store, then rename to legacy naming.
+    seed = DuckDBLogStore(log_dir=log_dir)
+    try:
+        for batch in range(2):
+            seed.append(KEY, [_make_entry(f"legacy-{batch}-{i}", epoch_ms=batch * 10 + i) for i in range(2)])
+            seed._force_flush()
+        seed._force_compaction()
+    finally:
+        seed.close()
+    log_files = sorted(log_dir.glob("log_*.parquet"))
+    assert len(log_files) == 1
+    legacy = log_files[0].with_name("logs_" + log_files[0].name[len("log_") :])
+    log_files[0].rename(legacy)
+    assert sorted(log_dir.glob("logs_*.parquet")) == [legacy]
+
+    # Reopen: migration must rename it and recovery must pick up the max seq.
+    store = DuckDBLogStore(log_dir=log_dir)
+    try:
+        assert sorted(log_dir.glob("logs_*.parquet")) == []
+        assert len(sorted(log_dir.glob("log_*.parquet"))) == 1
+
+        result = store.get_logs(KEY)
+        assert [e.data for e in result.entries] == ["legacy-0-0", "legacy-0-1", "legacy-1-0", "legacy-1-1"]
+
+        # New writes must use fresh seq numbers; tailing post-append should
+        # return only the new batch when cursored past the legacy data.
+        store.append(KEY, [_make_entry("fresh", epoch_ms=100)])
+        after = store.get_logs(KEY, cursor=result.cursor)
+        assert [e.data for e in after.entries] == ["fresh"]
+    finally:
+        store.close()
+
+
 # =============================================================================
 # Parquet-specific tests
 # =============================================================================

--- a/lib/iris/tests/cluster/controller/test_logs.py
+++ b/lib/iris/tests/cluster/controller/test_logs.py
@@ -391,47 +391,6 @@ def test_gc_drops_oldest_segments_by_bytes(tmp_path: Path):
         store.close()
 
 
-def test_reads_recover_when_local_segment_vanishes(tmp_path: Path):
-    """Out-of-band deletion of a Parquet file must not permanently break reads.
-
-    The store's in-memory ``_local_segments`` is populated at startup by
-    globbing the log dir, but it can drift from disk if files are removed
-    by anything other than ``_gc_local_segments`` (manual ``rm``, eviction,
-    leftover entries from an old filename format). Without self-healing,
-    DuckDB raises ``No files found that match the pattern …`` on every
-    subsequent read until the process restarts.
-    """
-    log_dir = tmp_path / "logs"
-    store = DuckDBLogStore(
-        log_dir=log_dir,
-        max_local_segments=100,  # don't GC during the test
-        segment_target_bytes=1,  # seal on every append
-    )
-    try:
-        for batch in range(3):
-            store.append(KEY, [_make_entry(f"batch{batch}-{i}", epoch_ms=batch * 100 + i) for i in range(10)])
-            store._force_flush()  # one file per batch
-
-        parquet_files = sorted(log_dir.glob("tmp_*.parquet"))
-        assert len(parquet_files) == 3
-        # Simulate out-of-band deletion of the oldest segment.
-        parquet_files[0].unlink()
-
-        # Read still succeeds and returns the rows from the surviving segments.
-        result = store.get_logs(KEY)
-        data = [e.data for e in result.entries]
-        assert any("batch1" in d for d in data)
-        assert any("batch2" in d for d in data)
-        assert not any("batch0" in d for d in data)
-
-        # In-memory index was pruned, so a follow-up read does not re-trigger the failure.
-        assert len(store._local_segments) == 2
-        result2 = store.get_logs(KEY)
-        assert [e.data for e in result2.entries] == data
-    finally:
-        store.close()
-
-
 # =============================================================================
 # Compaction tests
 # =============================================================================

--- a/lib/iris/tests/cluster/controller/test_logs.py
+++ b/lib/iris/tests/cluster/controller/test_logs.py
@@ -4,7 +4,6 @@
 """Tests for LogStore (rotating RAM buffers + Parquet + DuckDB)."""
 
 import threading
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -337,24 +336,18 @@ def test_cursor_with_since_ms(log_store: LogStore):
 def test_gc_drops_oldest_segments_by_count(tmp_path: Path):
     """When local segments exceed max_local_segments, oldest are removed."""
     log_dir = tmp_path / "logs"
-    # segment_target_bytes=1 means every parquet file is bigger than the target,
-    # so consolidation is skipped and each seal creates a new file.
     store = DuckDBLogStore(
         log_dir=log_dir,
         max_local_segments=2,
         max_local_bytes=10 * 1024**3,  # effectively unlimited
-        segment_target_bytes=1,  # seal after every append
     )
     try:
         for batch in range(4):
             entries = [_make_entry(f"batch{batch}-{i}", epoch_ms=batch * 100 + i) for i in range(10)]
             store.append(KEY, entries)
+            store._force_flush()  # one file per batch
 
-        # Wait for background flushes to complete.
-        store._executor.shutdown(wait=True)
-        store._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="log_flush")
-
-        remaining_files = sorted(store._log_dir.glob("logs_*.parquet"))
+        remaining_files = sorted(store._log_dir.glob("tmp_*.parquet"))
         assert len(remaining_files) <= 2
 
         # The most recent data should still be readable.
@@ -377,11 +370,9 @@ def test_gc_drops_oldest_segments_by_bytes(tmp_path: Path):
         for batch in range(4):
             entries = [_make_entry(f"batch{batch}-{i}", epoch_ms=batch * 100 + i) for i in range(10)]
             store.append(KEY, entries)
+            store._force_flush()  # one file per batch
 
-        store._executor.shutdown(wait=True)
-        store._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="log_flush")
-
-        parquet_files = sorted(store._log_dir.glob("logs_*.parquet"))
+        parquet_files = sorted(store._log_dir.glob("tmp_*.parquet"))
         assert len(parquet_files) == 4
         one_file_size = parquet_files[0].stat().st_size
 
@@ -389,7 +380,7 @@ def test_gc_drops_oldest_segments_by_bytes(tmp_path: Path):
         store._max_local_bytes = one_file_size * 2
         store._gc_local_segments()
 
-        remaining = sorted(store._log_dir.glob("logs_*.parquet"))
+        remaining = sorted(store._log_dir.glob("tmp_*.parquet"))
         assert len(remaining) <= 2
 
         # The most recent data should still be readable.
@@ -419,10 +410,9 @@ def test_reads_recover_when_local_segment_vanishes(tmp_path: Path):
     try:
         for batch in range(3):
             store.append(KEY, [_make_entry(f"batch{batch}-{i}", epoch_ms=batch * 100 + i) for i in range(10)])
-        store._executor.shutdown(wait=True)
-        store._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="log_flush")
+            store._force_flush()  # one file per batch
 
-        parquet_files = sorted(log_dir.glob("logs_*.parquet"))
+        parquet_files = sorted(log_dir.glob("tmp_*.parquet"))
         assert len(parquet_files) == 3
         # Simulate out-of-band deletion of the oldest segment.
         parquet_files[0].unlink()
@@ -443,6 +433,95 @@ def test_reads_recover_when_local_segment_vanishes(tmp_path: Path):
 
 
 # =============================================================================
+# Compaction tests
+# =============================================================================
+
+
+def test_compaction_merges_tmps_into_log(tmp_path: Path):
+    """Compaction merges all tmp_*.parquet files into a single log_*.parquet,
+    preserves data, and unlinks the sources."""
+    log_dir = tmp_path / "logs"
+    store = DuckDBLogStore(log_dir=log_dir)
+    try:
+        for batch in range(5):
+            entries = [_make_entry(f"batch{batch}-{i}", epoch_ms=batch * 100 + i) for i in range(10)]
+            store.append(KEY, entries)
+            store._force_flush()
+
+        assert len(sorted(log_dir.glob("tmp_*.parquet"))) == 5
+        assert len(sorted(log_dir.glob("log_*.parquet"))) == 0
+
+        store._force_compaction()
+
+        assert len(sorted(log_dir.glob("tmp_*.parquet"))) == 0
+        assert len(sorted(log_dir.glob("log_*.parquet"))) == 1
+
+        result = store.get_logs(KEY)
+        assert len(result.entries) == 50
+        assert result.entries[0].data == "batch0-0"
+        assert result.entries[-1].data == "batch4-9"
+    finally:
+        store.close()
+
+
+def test_compaction_skips_single_tmp(tmp_path: Path):
+    """One tmp isn't worth rewriting — compaction leaves it alone."""
+    log_dir = tmp_path / "logs"
+    store = DuckDBLogStore(log_dir=log_dir)
+    try:
+        store.append(KEY, [_make_entry("only", epoch_ms=0)])
+        store._force_flush()
+        tmps_before = sorted(log_dir.glob("tmp_*.parquet"))
+        assert len(tmps_before) == 1
+
+        store._force_compaction()
+
+        tmps_after = sorted(log_dir.glob("tmp_*.parquet"))
+        assert tmps_after == tmps_before
+        assert len(sorted(log_dir.glob("log_*.parquet"))) == 0
+    finally:
+        store.close()
+
+
+def test_recovery_reads_both_tmp_and_log(tmp_path: Path):
+    """After restart, a dir with mixed tmp_ and log_ files is fully readable."""
+    log_dir = tmp_path / "logs"
+    store1 = DuckDBLogStore(log_dir=log_dir)
+    try:
+        # Two flushes, then compact -> produces one log_ file.
+        for batch in range(2):
+            store1.append(KEY, [_make_entry(f"old-{batch}-{i}", epoch_ms=batch * 10 + i) for i in range(3)])
+            store1._force_flush()
+        store1._force_compaction()
+        # Third flush after compaction produces a tmp_ file.
+        store1.append(KEY, [_make_entry(f"new-{i}", epoch_ms=100 + i) for i in range(3)])
+        store1._force_flush()
+    finally:
+        store1.close()
+
+    assert len(sorted(log_dir.glob("log_*.parquet"))) == 1
+    assert len(sorted(log_dir.glob("tmp_*.parquet"))) == 1
+
+    store2 = DuckDBLogStore(log_dir=log_dir)
+    try:
+        result = store2.get_logs(KEY)
+        assert len(result.entries) == 9
+        assert [e.data for e in result.entries] == [
+            "old-0-0",
+            "old-0-1",
+            "old-0-2",
+            "old-1-0",
+            "old-1-1",
+            "old-1-2",
+            "new-0",
+            "new-1",
+            "new-2",
+        ]
+    finally:
+        store2.close()
+
+
+# =============================================================================
 # Parquet-specific tests
 # =============================================================================
 
@@ -455,9 +534,8 @@ def test_flush_creates_parquet_segment(tmp_path: Path):
         entries = [_make_entry(f"line-{i}", epoch_ms=i) for i in range(10)]
         store.append(KEY, entries)
         # Wait for background flush.
-        store._executor.shutdown(wait=True)
-        store._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="log_flush")
-        parquet_files = list(log_dir.glob("logs_*.parquet"))
+        store._force_flush()
+        parquet_files = list(log_dir.glob("tmp_*.parquet"))
         assert len(parquet_files) >= 1
     finally:
         store.close()
@@ -470,8 +548,7 @@ def test_cursor_continuity_across_flush(tmp_path: Path):
     try:
         entries1 = [_make_entry(f"batch1-{i}", epoch_ms=i) for i in range(10)]
         store.append(KEY, entries1)
-        store._executor.shutdown(wait=True)
-        store._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="log_flush")
+        store._force_flush()
 
         result1 = store.get_logs(KEY)
         assert len(result1.entries) == 10
@@ -547,29 +624,19 @@ def test_concurrent_read_write(tmp_path: Path):
     store.close()
 
 
-def test_small_segments_are_consolidated(tmp_path: Path):
-    """Multiple small flushes consolidate into a single parquet file."""
+def test_each_flush_writes_a_new_segment(tmp_path: Path):
+    """Every flush produces its own parquet — the write path is append-only."""
     log_dir = tmp_path / "logs"
-    # Large segment target means all small files are below the threshold
-    # and will be consolidated into one file.
-    store = DuckDBLogStore(
-        log_dir=log_dir,
-        segment_target_bytes=100 * 1024 * 1024,  # 100MB — way bigger than our test data
-        flush_interval_sec=0,  # seal on every append (time threshold always satisfied)
-    )
+    store = DuckDBLogStore(log_dir=log_dir)
     try:
         for batch in range(5):
             entries = [_make_entry(f"batch{batch}-{i}", epoch_ms=batch * 100 + i) for i in range(10)]
             store.append(KEY, entries)
-            # Wait for flush to complete before next append so consolidation runs.
-            store._executor.shutdown(wait=True)
-            store._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="log_flush")
+            store._force_flush()
 
-        parquet_files = list(log_dir.glob("logs_*.parquet"))
-        # All 5 batches should be consolidated into a single parquet file.
-        assert len(parquet_files) == 1, f"Expected 1 consolidated file, got {len(parquet_files)}"
+        parquet_files = list(log_dir.glob("tmp_*.parquet"))
+        assert len(parquet_files) == 5, f"Expected 5 segment files, got {len(parquet_files)}"
 
-        # All data should still be readable.
         result = store.get_logs(KEY)
         assert len(result.entries) == 50
         assert result.entries[0].data == "batch0-0"
@@ -578,30 +645,22 @@ def test_small_segments_are_consolidated(tmp_path: Path):
         store.close()
 
 
-def test_consolidation_preserves_cursor_continuity(tmp_path: Path):
-    """Cursors from before consolidation still work after consolidation."""
+def test_cursor_continuity_across_segments(tmp_path: Path):
+    """Cursors remain valid across the N-segment boundary the new write path produces."""
     log_dir = tmp_path / "logs"
-    store = DuckDBLogStore(
-        log_dir=log_dir,
-        segment_target_bytes=100 * 1024 * 1024,
-        flush_interval_sec=0,
-    )
+    store = DuckDBLogStore(log_dir=log_dir)
     try:
         entries1 = [_make_entry(f"batch1-{i}", epoch_ms=i) for i in range(10)]
         store.append(KEY, entries1)
-        store._executor.shutdown(wait=True)
-        store._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="log_flush")
+        store._force_flush()
 
         result1 = store.get_logs(KEY)
         cursor = result1.cursor
 
-        # Second batch will consolidate with the first.
         entries2 = [_make_entry(f"batch2-{i}", epoch_ms=100 + i) for i in range(5)]
         store.append(KEY, entries2)
-        store._executor.shutdown(wait=True)
-        store._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="log_flush")
+        store._force_flush()
 
-        # Cursor from before consolidation should still return only new entries.
         result2 = store.get_logs(KEY, cursor=cursor)
         assert len(result2.entries) == 5
         assert all("batch2" in e.data for e in result2.entries)
@@ -622,19 +681,19 @@ def test_connection_pool_memory_limit(tmp_path: Path):
         store.close()
 
 
-def test_concurrent_reads_no_concat_copy(tmp_path: Path):
-    """Multiple concurrent reads work correctly without pa.concat_tables."""
+def test_concurrent_reads_span_all_sources(tmp_path: Path):
+    """Concurrent reads crossing parquet + chunks + pending don't collide on
+    the per-cursor RAM table registrations."""
     log_dir = tmp_path / "logs"
     store = DuckDBLogStore(log_dir=log_dir, duckdb_memory_limit="64MB")
     errors: list[Exception] = []
 
-    # Create data across multiple RAM buffers: pending + chunks + sealed
     for batch in range(5):
         entries = [_make_entry(f"batch{batch}-{i}", epoch_ms=batch * 100 + i) for i in range(10)]
         store.append(KEY, entries)
 
-    # Seal to create sealed buffers, then add more to pending
-    store._seal_head()
+    # Flush to segment, then add more to pending so reads cross all three sources.
+    store._force_flush()
     store.append(KEY, [_make_entry("after-seal", epoch_ms=999)])
 
     def reader():
@@ -673,9 +732,9 @@ def test_sealed_buffers_readable_before_flush(tmp_path: Path):
     assert len(result.entries) == 10
     assert [e.data for e in result.entries] == [f"line-{i}" for i in range(10)]
 
-    # Now seal manually and verify sealed buffer is still readable.
-    store._seal_head()
-    # Data is in the sealed deque (flush is async, might not have completed).
+    # Now flush manually and verify the data is still readable once the
+    # snapshot has moved from _pending into _flushing / a new segment.
+    store._force_flush()
     result2 = store.get_logs(KEY)
     assert len(result2.entries) == 10
 
@@ -683,7 +742,7 @@ def test_sealed_buffers_readable_before_flush(tmp_path: Path):
 
 
 # =============================================================================
-# Tail fallback, working-set cap, and concurrency limiter tests
+# Per-read working-set cap tests
 # =============================================================================
 
 
@@ -703,20 +762,16 @@ def _make_store_with_segments(log_dir: Path, num_segments: int, rows_per_segment
             for i in range(rows_per_segment)
         ]
         store.append(KEY, entries)
-        store._executor.shutdown(wait=True)
-        store._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="log_flush")
+        store._force_flush()
     return store
 
 
-def test_tail_fallback_finds_match_in_oldest_of_capped_window(tmp_path: Path):
-    """When the seq-bounded fast path misses, the fallback query still finds
-    a match that lives in the oldest segment within the per-read cap."""
+def test_tail_finds_match_in_oldest_of_capped_window(tmp_path: Path):
+    """A match in the oldest segment within the per-read cap is returned."""
     log_dir = tmp_path / "logs"
-    # 5 segments (fits within _MAX_PARQUETS_PER_READ); match is in segment 0.
+    # 5 segments all fit within the default byte cap; match is in segment 0.
     store = _make_store_with_segments(log_dir, num_segments=5, rows_per_segment=20)
     try:
-        # Regex pattern forces include_key_in_select=True, which engages the
-        # fast-path + fallback logic.
         result = store.get_logs("/job/test/.*", max_lines=10, tail=True, substring_filter="MATCH")
         assert len(result.entries) == 1
         assert "MATCH" in result.entries[0].data
@@ -724,34 +779,38 @@ def test_tail_fallback_finds_match_in_oldest_of_capped_window(tmp_path: Path):
         store.close()
 
 
-def test_read_caps_to_newest_segments(tmp_path: Path):
-    """A single read never scans more than _MAX_PARQUETS_PER_READ segments;
-    matches outside that window are not visible to this call."""
-    from iris.cluster.log_store.duckdb_store import _MAX_PARQUETS_PER_READ
+def test_read_caps_to_newest_segments(tmp_path: Path, monkeypatch):
+    """A single read never scans past _MAX_PARQUET_BYTES_PER_READ of segments;
+    matches in older (outside-budget) segments are not visible to this call."""
+    from iris.cluster.log_store import duckdb_store as mod
 
     log_dir = tmp_path / "logs"
-    num_segments = _MAX_PARQUETS_PER_READ + 3
     store = DuckDBLogStore(log_dir=log_dir, segment_target_bytes=1)
     try:
+        num_segments = 6
         for batch in range(num_segments):
-            # Match marker lives only in the oldest segment (batch 0), which
-            # is outside the newest-_MAX_PARQUETS_PER_READ window.
+            # Match marker lives only in the oldest segment (batch 0). With a
+            # tiny byte cap, only the newest few segments are included.
             entries = [
                 _make_entry(f"{'MATCH' if batch == 0 else 'nomatch'}-b{batch}-{i}", epoch_ms=batch * 1000 + i)
                 for i in range(10)
             ]
             store.append(KEY, entries)
-            store._executor.shutdown(wait=True)
-            store._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="log_flush")
+            store._force_flush()
+
+        # Measure a single segment's bytes, then cap the read to ~2 segments.
+        first = next(log_dir.glob("tmp_*.parquet"))
+        per_file = first.stat().st_size
+        monkeypatch.setattr(mod, "_MAX_PARQUET_BYTES_PER_READ", per_file * 2)
 
         result = store.get_logs("/job/test/.*", max_lines=20, tail=True, substring_filter="MATCH")
-        # Oldest segment is outside the newest-N window; match is invisible.
+        # Oldest segment is outside the newest-bytes window; match is invisible.
         assert len(result.entries) == 0
     finally:
         store.close()
 
 
-def test_tail_fallback_accumulates_across_segments(tmp_path: Path):
+def test_tail_accumulates_matches_across_segments(tmp_path: Path):
     """Filter matches spread across older segments are returned when newer
     segments have fewer than max_lines matches."""
     log_dir = tmp_path / "logs"
@@ -764,8 +823,7 @@ def test_tail_fallback_accumulates_across_segments(tmp_path: Path):
                 tag = "MATCH" if i < 2 else "nomatch"
                 entries.append(_make_entry(f"{tag}-batch{batch}-{i}", epoch_ms=batch * 1000 + i))
             store.append(KEY, entries)
-            store._executor.shutdown(wait=True)
-            store._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="log_flush")
+            store._force_flush()
 
         # Ask for 6 MATCH rows; must pull from at least 3 segments.
         result = store.get_logs("/job/test/.*", max_lines=6, tail=True, substring_filter="MATCH")
@@ -774,38 +832,5 @@ def test_tail_fallback_accumulates_across_segments(tmp_path: Path):
         # Results are sorted ascending in LogReadResult (DESC then reversed).
         seqs = [e.timestamp.epoch_ms for e in result.entries]
         assert seqs == sorted(seqs)
-    finally:
-        store.close()
-
-
-def test_tail_fast_path_short_circuits(tmp_path: Path, monkeypatch):
-    """When the tail window has enough matches, only one SQL query runs."""
-    log_dir = tmp_path / "logs"
-    store = DuckDBLogStore(log_dir=log_dir, segment_target_bytes=1)
-    try:
-        # Two segments, all rows match the filter, so the fast path is
-        # sufficient for max_lines=5.
-        for batch in range(2):
-            entries = [_make_entry(f"MATCH-{batch}-{i}", epoch_ms=batch * 1000 + i) for i in range(20)]
-            store.append(KEY, entries)
-            store._executor.shutdown(wait=True)
-            store._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="log_flush")
-
-        call_count = 0
-        from iris.cluster.log_store import duckdb_store as mod
-
-        original = mod._build_union_source
-
-        def counting(*args, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            return original(*args, **kwargs)
-
-        monkeypatch.setattr(mod, "_build_union_source", counting)
-
-        result = store.get_logs("/job/test/.*", max_lines=5, tail=True, substring_filter="MATCH")
-        assert len(result.entries) == 5
-        # Exactly one source build: the fast path. No fallback query.
-        assert call_count == 1
     finally:
         store.close()

--- a/lib/iris/tests/cluster/controller/test_logs.py
+++ b/lib/iris/tests/cluster/controller/test_logs.py
@@ -438,7 +438,7 @@ def test_reads_recover_when_local_segment_vanishes(tmp_path: Path):
 
 
 def test_compaction_merges_tmps_into_log(tmp_path: Path):
-    """Compaction merges all tmp_*.parquet files into a single log_*.parquet,
+    """Compaction merges all tmp_*.parquet files into a single logs_*.parquet,
     preserves data, and unlinks the sources."""
     log_dir = tmp_path / "logs"
     store = DuckDBLogStore(log_dir=log_dir)
@@ -449,12 +449,12 @@ def test_compaction_merges_tmps_into_log(tmp_path: Path):
             store._force_flush()
 
         assert len(sorted(log_dir.glob("tmp_*.parquet"))) == 5
-        assert len(sorted(log_dir.glob("log_*.parquet"))) == 0
+        assert len(sorted(log_dir.glob("logs_*.parquet"))) == 0
 
         store._force_compaction()
 
         assert len(sorted(log_dir.glob("tmp_*.parquet"))) == 0
-        assert len(sorted(log_dir.glob("log_*.parquet"))) == 1
+        assert len(sorted(log_dir.glob("logs_*.parquet"))) == 1
 
         result = store.get_logs(KEY)
         assert len(result.entries) == 50
@@ -478,17 +478,17 @@ def test_compaction_skips_single_tmp(tmp_path: Path):
 
         tmps_after = sorted(log_dir.glob("tmp_*.parquet"))
         assert tmps_after == tmps_before
-        assert len(sorted(log_dir.glob("log_*.parquet"))) == 0
+        assert len(sorted(log_dir.glob("logs_*.parquet"))) == 0
     finally:
         store.close()
 
 
 def test_recovery_reads_both_tmp_and_log(tmp_path: Path):
-    """After restart, a dir with mixed tmp_ and log_ files is fully readable."""
+    """After restart, a dir with mixed tmp_ and logs_ files is fully readable."""
     log_dir = tmp_path / "logs"
     store1 = DuckDBLogStore(log_dir=log_dir)
     try:
-        # Two flushes, then compact -> produces one log_ file.
+        # Two flushes, then compact -> produces one logs_ file.
         for batch in range(2):
             store1.append(KEY, [_make_entry(f"old-{batch}-{i}", epoch_ms=batch * 10 + i) for i in range(3)])
             store1._force_flush()
@@ -499,7 +499,7 @@ def test_recovery_reads_both_tmp_and_log(tmp_path: Path):
     finally:
         store1.close()
 
-    assert len(sorted(log_dir.glob("log_*.parquet"))) == 1
+    assert len(sorted(log_dir.glob("logs_*.parquet"))) == 1
     assert len(sorted(log_dir.glob("tmp_*.parquet"))) == 1
 
     store2 = DuckDBLogStore(log_dir=log_dir)
@@ -519,49 +519,6 @@ def test_recovery_reads_both_tmp_and_log(tmp_path: Path):
         ]
     finally:
         store2.close()
-
-
-def test_recovery_migrates_legacy_logs_filenames(tmp_path: Path):
-    """Pre-tiered-layout ``logs_*.parquet`` files are renamed to ``log_*.parquet``.
-
-    A controller upgraded from the single-series layout must not silently
-    drop historical segments on restart — that would reset _next_seq to 1
-    and cause sequence reuse on subsequent writes.
-    """
-    log_dir = tmp_path / "logs"
-    log_dir.mkdir()
-
-    # Write one log_*.parquet via a first-gen store, then rename to legacy naming.
-    seed = DuckDBLogStore(log_dir=log_dir)
-    try:
-        for batch in range(2):
-            seed.append(KEY, [_make_entry(f"legacy-{batch}-{i}", epoch_ms=batch * 10 + i) for i in range(2)])
-            seed._force_flush()
-        seed._force_compaction()
-    finally:
-        seed.close()
-    log_files = sorted(log_dir.glob("log_*.parquet"))
-    assert len(log_files) == 1
-    legacy = log_files[0].with_name("logs_" + log_files[0].name[len("log_") :])
-    log_files[0].rename(legacy)
-    assert sorted(log_dir.glob("logs_*.parquet")) == [legacy]
-
-    # Reopen: migration must rename it and recovery must pick up the max seq.
-    store = DuckDBLogStore(log_dir=log_dir)
-    try:
-        assert sorted(log_dir.glob("logs_*.parquet")) == []
-        assert len(sorted(log_dir.glob("log_*.parquet"))) == 1
-
-        result = store.get_logs(KEY)
-        assert [e.data for e in result.entries] == ["legacy-0-0", "legacy-0-1", "legacy-1-0", "legacy-1-1"]
-
-        # New writes must use fresh seq numbers; tailing post-append should
-        # return only the new batch when cursored past the legacy data.
-        store.append(KEY, [_make_entry("fresh", epoch_ms=100)])
-        after = store.get_logs(KEY, cursor=result.cursor)
-        assert [e.data for e in after.entries] == ["fresh"]
-    finally:
-        store.close()
 
 
 # =============================================================================


### PR DESCRIPTION
Per #4833, file-level segment pruning in the log store was effectively
non-functional. ``_LocalSegment`` held only scalar ``(min_key, max_key)``
aggregates, and because one segment spans many users
(``/alice/... → /zoe/...``), ``_segment_overlaps_key`` /
``_segment_overlaps_prefix`` almost never narrowed anything. That forced
``_MAX_PARQUETS_PER_READ = 25`` to do the narrowing — which is what
caused the 2026-04-16 outage, when keys whose rows sat outside the newest
25 segments became invisible. DuckDB's per-row-group stats already prune
correctly inside each opened file; the problem was that we were opening
too many files.

Let DuckDB do the file-level pruning too. Turn on
``SET enable_object_cache=true`` on the shared connection so parquet
footers and row-group stats are cached across queries (every query
re-parsed ~45 footers before). Replace the manual literal-prefix range
(``key >= lo AND key < hi``, with ``_prefix_upper_bound``'s unicode
successor for the upper bound) and the segment-level Python filter with
DuckDB's native ``prefix(key, ...)`` pushdown; keep ``regexp_matches``
only as a residual for suffix patterns like ``\d+:.*``. Drop the
``_MAX_PARQUETS_PER_READ`` file-count cap — bytes are the only stable
bound now that file sizes aren't uniform. The cap becomes a true safety
net for pathological body-LIKE queries, not load-bearing for correctness.

Along the way, replace in-place flush consolidation (read previous
parquet, pyarrow concat+sort, rewrite) with a two-tier layout: each
flush writes a standalone ``tmp_*.parquet``; a periodic step merges
all tmps into ``logs_*.parquet`` via DuckDB's streaming
``COPY (SELECT ... ORDER BY key, seq)``. Only the compacted file uploads
to GCS, bounding object count. Incidental cleanups: aggregate backpressure
across pending + chunks + flushing; move flush concat+sort outside the
memory lock; drop the per-query ``Path.exists()`` loop (the rwlock
already pins files in a reader's snapshot); rename ``_lock`` to
``_memory_lock`` to distinguish it from the file-scoped rwlock.

mem_bench at 40k lines/s for 20 s: p50 ~10 ms and p99 ~100 ms across
tail/exact/prefix shapes, zero footer re-reads after the first query.
36 unit tests pass including new coverage for merge-into-logs, single-tmp
skip, and mixed-tier recovery after restart.

Part of #4833