### PR TITLE
[rigging] Silence fsspec BlockCache debug log spam

### DIFF
--- a/lib/rigging/src/rigging/log_setup.py
+++ b/lib/rigging/src/rigging/log_setup.py
@@ -241,5 +241,7 @@ def configure_logging(level: int = logging.INFO) -> LogRingBuffer:
 
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("httpcore").setLevel(logging.WARNING)
+    logging.getLogger("fsspec").setLevel(logging.WARNING)
+    logging.getLogger("fsspec.caching").setLevel(logging.WARNING)
 
     return _global_buffer


### PR DESCRIPTION
Suppress fsspec's per-block DEBUG logs ("BlockCache fetching block (async) N" / "waiting for background fetch") by setting the fsspec and fsspec.caching loggers to WARNING in configure_logging, alongside the existing httpx/httpcore suppression.