### PR TITLE
marin: add version field to NormalizeResult

### DIFF
--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -81,6 +81,7 @@ class NormalizeResult(BaseModel):
     via ``Artifact.load(step, NormalizeResult)``.
     """
 
+    version: str = "v1"
     subdirs: list[NormalizeSubdirResult] = []
 
     @property


### PR DESCRIPTION
* Stamp the persisted artifact with a schema version ("v1") so downstream consumers can guard against future format changes.
* This will be used in near future