### PR TITLE
[iris] Consolidate ping-loop DB writes; fix dropped resource_snapshot_proto column

### DIFF
--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -104,6 +104,7 @@ from iris.cluster.controller.transitions import (
     ReservationClaim,
     SchedulingEvent,
     TaskUpdate,
+    WorkerPing,
 )
 from iris.cluster.log_store import CONTROLLER_LOG_KEY
 from iris.cluster.providers.types import find_free_port, resolve_external_host
@@ -2280,7 +2281,7 @@ class Controller:
                 cycle += 1
 
                 dead_workers: list[str] = []
-                liveness_ids: list[WorkerId] = []
+                pings: list[WorkerPing] = []
                 for result in results:
                     wid_str = str(result.worker_id)
                     if result.error is not None:
@@ -2294,13 +2295,10 @@ class Controller:
                             )
                     else:
                         ping_failures.pop(wid_str, None)
-                        if update_resources and result.resource_snapshot:
-                            self._transitions.update_worker_ping_success(result.worker_id, result.resource_snapshot)
-                        else:
-                            liveness_ids.append(result.worker_id)
+                        snapshot = result.resource_snapshot if update_resources else None
+                        pings.append(WorkerPing(worker_id=result.worker_id, snapshot=snapshot))
 
-                if liveness_ids:
-                    self._transitions.touch_worker_liveness(liveness_ids)
+                self._transitions.update_worker_pings(pings)
 
                 if dead_workers:
                     failure_result = self._transitions.fail_workers_batch(

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -104,7 +104,6 @@ from iris.cluster.controller.transitions import (
     ReservationClaim,
     SchedulingEvent,
     TaskUpdate,
-    WorkerPing,
 )
 from iris.cluster.log_store import CONTROLLER_LOG_KEY
 from iris.cluster.providers.types import find_free_port, resolve_external_host
@@ -2281,7 +2280,7 @@ class Controller:
                 cycle += 1
 
                 dead_workers: list[str] = []
-                pings: list[WorkerPing] = []
+                ping_snapshots: dict[WorkerId, job_pb2.WorkerResourceSnapshot | None] = {}
                 for result in results:
                     wid_str = str(result.worker_id)
                     if result.error is not None:
@@ -2295,10 +2294,9 @@ class Controller:
                             )
                     else:
                         ping_failures.pop(wid_str, None)
-                        snapshot = result.resource_snapshot if update_resources else None
-                        pings.append(WorkerPing(worker_id=result.worker_id, snapshot=snapshot))
+                        ping_snapshots[result.worker_id] = result.resource_snapshot if update_resources else None
 
-                self._transitions.update_worker_pings(pings)
+                self._transitions.update_worker_pings(ping_snapshots)
 
                 if dead_workers:
                     failure_result = self._transitions.fail_workers_batch(

--- a/lib/iris/src/iris/cluster/controller/db.py
+++ b/lib/iris/src/iris/cluster/controller/db.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 import queue
 import sqlite3
-from collections.abc import Callable, Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace as dc_replace
 from pathlib import Path
@@ -250,7 +250,7 @@ class TransactionCursor:
         """Raw SQL escape hatch."""
         return self._cursor.execute(sql, params)
 
-    def executemany(self, sql: str, params: Iterable[tuple]) -> sqlite3.Cursor:
+    def executemany(self, sql: str, params: Iterable[tuple | Mapping[str, object]]) -> sqlite3.Cursor:
         """Raw SQL batch escape hatch."""
         return self._cursor.executemany(sql, params)
 

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 import json
 import logging
 from dataclasses import dataclass, field
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, NamedTuple
 
 from iris.cluster.constraints import AttributeValue, Constraint, constraints_from_resources, merge_constraints
@@ -277,19 +277,6 @@ class WorkerFailureBatchResult(TxResult):
 
     removed_workers: list[tuple[WorkerId, str | None]] = field(default_factory=list)
     results: list[HeartbeatFailureResult] = field(default_factory=list)
-
-
-@dataclass(frozen=True)
-class WorkerPing:
-    """Result of a Ping RPC for a single worker.
-
-    A snapshot of None means liveness-only: bump last_heartbeat without
-    rewriting resource columns. The ping loop emits these on the cycles
-    where it skips the (more expensive) resource refresh.
-    """
-
-    worker_id: WorkerId
-    snapshot: job_pb2.WorkerResourceSnapshot | None
 
 
 class RunningTaskEntry(NamedTuple):
@@ -921,7 +908,7 @@ def _batch_worker_health(
     ).fetchall()
     existing = {str(r["worker_id"]) for r in rows}
 
-    liveness_params: list[tuple] = []
+    liveness_params: list[tuple[int, str]] = []
     snapshot_writes: list[tuple[str, job_pb2.WorkerResourceSnapshot]] = []
     for req in requests:
         wid = str(req.worker_id)
@@ -3092,26 +3079,31 @@ class ControllerTransitions:
     # Split Heartbeat Helpers
     # =========================================================================
 
-    def update_worker_pings(self, pings: Sequence[WorkerPing]) -> None:
+    def update_worker_pings(
+        self,
+        snapshots: Mapping[WorkerId, job_pb2.WorkerResourceSnapshot | None],
+    ) -> None:
         """Apply a batch of Ping RPC results in a single transaction.
 
-        For each ping, bumps last_heartbeat_ms; if a snapshot is attached,
+        For each entry, bumps last_heartbeat_ms; if the value is a snapshot,
         also rewrites the worker's snapshot_* columns and appends a row to
-        worker_resource_history. Does not touch healthy/active/
-        consecutive_failures — the ping loop tracks failures in-memory and
-        uses fail_workers_batch to remove workers past threshold.
+        worker_resource_history. A None value means liveness-only — the ping
+        loop emits these on cycles where it skips the resource refresh.
+        Does not touch healthy/active/consecutive_failures — the ping loop
+        tracks failures in-memory and uses fail_workers_batch to remove
+        workers past threshold.
         """
-        if not pings:
+        if not snapshots:
             return
         now_ms = Timestamp.now().epoch_ms()
-        liveness_params: list[tuple] = []
+        liveness_params: list[tuple[int, str]] = []
         snapshot_writes: list[tuple[str, job_pb2.WorkerResourceSnapshot]] = []
-        for ping in pings:
-            wid = str(ping.worker_id)
-            if ping.snapshot is None:
+        for worker_id, snap in snapshots.items():
+            wid = str(worker_id)
+            if snap is None:
                 liveness_params.append((now_ms, wid))
             else:
-                snapshot_writes.append((wid, ping.snapshot))
+                snapshot_writes.append((wid, snap))
 
         with self._db.transaction() as cur:
             if liveness_params:

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -279,6 +279,19 @@ class WorkerFailureBatchResult(TxResult):
     results: list[HeartbeatFailureResult] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class WorkerPing:
+    """Result of a Ping RPC for a single worker.
+
+    A snapshot of None means liveness-only: bump last_heartbeat without
+    rewriting resource columns. The ping loop emits these on the cycles
+    where it skips the (more expensive) resource refresh.
+    """
+
+    worker_id: WorkerId
+    snapshot: job_pb2.WorkerResourceSnapshot | None
+
+
 class RunningTaskEntry(NamedTuple):
     """Task ID and attempt ID pair captured at snapshot time."""
 
@@ -822,6 +835,67 @@ def _resolve_task_failure_state(
 
 
 # =============================================================================
+# Worker resource snapshot writers
+# =============================================================================
+
+
+def _snapshot_fields(snap: job_pb2.WorkerResourceSnapshot) -> tuple[int, ...]:
+    """Pack the 9 scalar columns we persist from a WorkerResourceSnapshot."""
+    return (
+        snap.host_cpu_percent,
+        snap.memory_used_bytes,
+        snap.memory_total_bytes,
+        snap.disk_used_bytes,
+        snap.disk_total_bytes,
+        snap.running_task_count,
+        snap.total_process_count,
+        snap.net_recv_bps,
+        snap.net_sent_bps,
+    )
+
+
+def _write_worker_snapshots(
+    cur: TransactionCursor,
+    items: Sequence[tuple[str, job_pb2.WorkerResourceSnapshot]],
+    now_ms: int,
+    *,
+    reset_health: bool,
+) -> None:
+    """Update worker snapshot columns and append history rows.
+
+    Heartbeat path passes ``reset_health=True`` because a successful heartbeat
+    means the worker has recovered. Ping path passes False — the ping loop
+    tracks failures in-memory and removes workers via ``fail_workers_batch``.
+    """
+    if not items:
+        return
+
+    rows = [(wid, _snapshot_fields(snap)) for wid, snap in items]
+    update_params = [(now_ms, *fields, wid) for wid, fields in rows]
+    history_params = [(wid, *fields, now_ms) for wid, fields in rows]
+
+    health_prefix = "healthy = 1, active = 1, consecutive_failures = 0, " if reset_health else ""
+    cur.executemany(
+        f"UPDATE workers SET {health_prefix}last_heartbeat_ms = ?, "
+        "snapshot_host_cpu_percent = ?, snapshot_memory_used_bytes = ?, "
+        "snapshot_memory_total_bytes = ?, snapshot_disk_used_bytes = ?, "
+        "snapshot_disk_total_bytes = ?, snapshot_running_task_count = ?, "
+        "snapshot_total_process_count = ?, snapshot_net_recv_bps = ?, "
+        "snapshot_net_sent_bps = ? WHERE worker_id = ?",
+        update_params,
+    )
+    cur.executemany(
+        "INSERT INTO worker_resource_history("
+        "worker_id, snapshot_host_cpu_percent, snapshot_memory_used_bytes, "
+        "snapshot_memory_total_bytes, snapshot_disk_used_bytes, snapshot_disk_total_bytes, "
+        "snapshot_running_task_count, snapshot_total_process_count, "
+        "snapshot_net_recv_bps, snapshot_net_sent_bps, timestamp_ms"
+        ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        history_params,
+    )
+
+
+# =============================================================================
 # Batch helpers for apply_heartbeats_batch
 # =============================================================================
 
@@ -847,58 +921,24 @@ def _batch_worker_health(
     ).fetchall()
     existing = {str(r["worker_id"]) for r in rows}
 
-    health_params_no_snap = []
-    health_params_with_snap = []
-    history_params = []
+    liveness_params: list[tuple] = []
+    snapshot_writes: list[tuple[str, job_pb2.WorkerResourceSnapshot]] = []
     for req in requests:
         wid = str(req.worker_id)
         if wid not in existing:
             continue
-        snap = req.worker_resource_snapshot
-        if snap is not None:
-            snap_fields = (
-                snap.host_cpu_percent,
-                snap.memory_used_bytes,
-                snap.memory_total_bytes,
-                snap.disk_used_bytes,
-                snap.disk_total_bytes,
-                snap.running_task_count,
-                snap.total_process_count,
-                snap.net_recv_bps,
-                snap.net_sent_bps,
-            )
-            health_params_with_snap.append((now_ms, *snap_fields, wid))
-            history_params.append((wid, *snap_fields, now_ms))
+        if req.worker_resource_snapshot is None:
+            liveness_params.append((now_ms, wid))
         else:
-            health_params_no_snap.append((now_ms, wid))
+            snapshot_writes.append((wid, req.worker_resource_snapshot))
 
-    if health_params_no_snap:
+    if liveness_params:
         cur.executemany(
             "UPDATE workers SET healthy = 1, active = 1, consecutive_failures = 0, "
             "last_heartbeat_ms = ? WHERE worker_id = ?",
-            health_params_no_snap,
+            liveness_params,
         )
-    if health_params_with_snap:
-        cur.executemany(
-            "UPDATE workers SET healthy = 1, active = 1, consecutive_failures = 0, "
-            "last_heartbeat_ms = ?, "
-            "snapshot_host_cpu_percent = ?, snapshot_memory_used_bytes = ?, "
-            "snapshot_memory_total_bytes = ?, snapshot_disk_used_bytes = ?, "
-            "snapshot_disk_total_bytes = ?, snapshot_running_task_count = ?, "
-            "snapshot_total_process_count = ?, snapshot_net_recv_bps = ?, "
-            "snapshot_net_sent_bps = ? WHERE worker_id = ?",
-            health_params_with_snap,
-        )
-    if history_params:
-        cur.executemany(
-            "INSERT INTO worker_resource_history("
-            "worker_id, snapshot_host_cpu_percent, snapshot_memory_used_bytes, "
-            "snapshot_memory_total_bytes, snapshot_disk_used_bytes, snapshot_disk_total_bytes, "
-            "snapshot_running_task_count, snapshot_total_process_count, "
-            "snapshot_net_recv_bps, snapshot_net_sent_bps, timestamp_ms"
-            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            history_params,
-        )
+    _write_worker_snapshots(cur, snapshot_writes, now_ms, reset_health=True)
     return existing
 
 
@@ -3052,53 +3092,34 @@ class ControllerTransitions:
     # Split Heartbeat Helpers
     # =========================================================================
 
-    def touch_worker_liveness(self, worker_ids: Sequence[WorkerId]) -> None:
-        """Cheap liveness bump: update last_heartbeat_ms without rewriting resources."""
-        if not worker_ids:
+    def update_worker_pings(self, pings: Sequence[WorkerPing]) -> None:
+        """Apply a batch of Ping RPC results in a single transaction.
+
+        For each ping, bumps last_heartbeat_ms; if a snapshot is attached,
+        also rewrites the worker's snapshot_* columns and appends a row to
+        worker_resource_history. Does not touch healthy/active/
+        consecutive_failures — the ping loop tracks failures in-memory and
+        uses fail_workers_batch to remove workers past threshold.
+        """
+        if not pings:
             return
         now_ms = Timestamp.now().epoch_ms()
-        with self._db.transaction() as cur:
-            cur.executemany(
-                "UPDATE workers SET last_heartbeat_ms = ? WHERE worker_id = ?",
-                [(now_ms, str(wid)) for wid in worker_ids],
-            )
+        liveness_params: list[tuple] = []
+        snapshot_writes: list[tuple[str, job_pb2.WorkerResourceSnapshot]] = []
+        for ping in pings:
+            wid = str(ping.worker_id)
+            if ping.snapshot is None:
+                liveness_params.append((now_ms, wid))
+            else:
+                snapshot_writes.append((wid, ping.snapshot))
 
-    def update_worker_ping_success(self, worker_id: WorkerId, resource_snapshot: job_pb2.WorkerResourceSnapshot) -> None:
-        """Update worker timestamp and resource snapshot from a successful ping.
-
-        Does not reset consecutive_failures — the ping loop tracks failures in-memory.
-        """
-        snap_fields = (
-            resource_snapshot.host_cpu_percent,
-            resource_snapshot.memory_used_bytes,
-            resource_snapshot.memory_total_bytes,
-            resource_snapshot.disk_used_bytes,
-            resource_snapshot.disk_total_bytes,
-            resource_snapshot.running_task_count,
-            resource_snapshot.total_process_count,
-            resource_snapshot.net_recv_bps,
-            resource_snapshot.net_sent_bps,
-        )
-        now_ms = Timestamp.now().epoch_ms()
         with self._db.transaction() as cur:
-            cur.execute(
-                "UPDATE workers SET last_heartbeat_ms = ?, "
-                "snapshot_host_cpu_percent = ?, snapshot_memory_used_bytes = ?, "
-                "snapshot_memory_total_bytes = ?, snapshot_disk_used_bytes = ?, "
-                "snapshot_disk_total_bytes = ?, snapshot_running_task_count = ?, "
-                "snapshot_total_process_count = ?, snapshot_net_recv_bps = ?, "
-                "snapshot_net_sent_bps = ? WHERE worker_id = ?",
-                (now_ms, *snap_fields, str(worker_id)),
-            )
-            cur.execute(
-                "INSERT INTO worker_resource_history("
-                "worker_id, snapshot_host_cpu_percent, snapshot_memory_used_bytes, "
-                "snapshot_memory_total_bytes, snapshot_disk_used_bytes, snapshot_disk_total_bytes, "
-                "snapshot_running_task_count, snapshot_total_process_count, "
-                "snapshot_net_recv_bps, snapshot_net_sent_bps, timestamp_ms"
-                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (str(worker_id), *snap_fields, now_ms),
-            )
+            if liveness_params:
+                cur.executemany(
+                    "UPDATE workers SET last_heartbeat_ms = ? WHERE worker_id = ?",
+                    liveness_params,
+                )
+            _write_worker_snapshots(cur, snapshot_writes, now_ms, reset_health=False)
 
     def get_running_tasks_for_poll(
         self,

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -3068,16 +3068,36 @@ class ControllerTransitions:
 
         Does not reset consecutive_failures — the ping loop tracks failures in-memory.
         """
-        snapshot_bytes = resource_snapshot.SerializeToString()
+        snap_fields = (
+            resource_snapshot.host_cpu_percent,
+            resource_snapshot.memory_used_bytes,
+            resource_snapshot.memory_total_bytes,
+            resource_snapshot.disk_used_bytes,
+            resource_snapshot.disk_total_bytes,
+            resource_snapshot.running_task_count,
+            resource_snapshot.total_process_count,
+            resource_snapshot.net_recv_bps,
+            resource_snapshot.net_sent_bps,
+        )
         now_ms = Timestamp.now().epoch_ms()
         with self._db.transaction() as cur:
             cur.execute(
-                "UPDATE workers SET last_heartbeat_ms = ?, resource_snapshot_proto = ? WHERE worker_id = ?",
-                (now_ms, snapshot_bytes, str(worker_id)),
+                "UPDATE workers SET last_heartbeat_ms = ?, "
+                "snapshot_host_cpu_percent = ?, snapshot_memory_used_bytes = ?, "
+                "snapshot_memory_total_bytes = ?, snapshot_disk_used_bytes = ?, "
+                "snapshot_disk_total_bytes = ?, snapshot_running_task_count = ?, "
+                "snapshot_total_process_count = ?, snapshot_net_recv_bps = ?, "
+                "snapshot_net_sent_bps = ? WHERE worker_id = ?",
+                (now_ms, *snap_fields, str(worker_id)),
             )
             cur.execute(
-                "INSERT INTO worker_resource_history(worker_id, snapshot_proto, timestamp_ms) VALUES (?, ?, ?)",
-                (str(worker_id), snapshot_bytes, now_ms),
+                "INSERT INTO worker_resource_history("
+                "worker_id, snapshot_host_cpu_percent, snapshot_memory_used_bytes, "
+                "snapshot_memory_total_bytes, snapshot_disk_used_bytes, snapshot_disk_total_bytes, "
+                "snapshot_running_task_count, snapshot_total_process_count, "
+                "snapshot_net_recv_bps, snapshot_net_sent_bps, timestamp_ms"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (str(worker_id), *snap_fields, now_ms),
             )
 
     def get_running_tasks_for_poll(

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -826,21 +826,6 @@ def _resolve_task_failure_state(
 # =============================================================================
 
 
-def _snapshot_fields(snap: job_pb2.WorkerResourceSnapshot) -> tuple[int, ...]:
-    """Pack the 9 scalar columns we persist from a WorkerResourceSnapshot."""
-    return (
-        snap.host_cpu_percent,
-        snap.memory_used_bytes,
-        snap.memory_total_bytes,
-        snap.disk_used_bytes,
-        snap.disk_total_bytes,
-        snap.running_task_count,
-        snap.total_process_count,
-        snap.net_recv_bps,
-        snap.net_sent_bps,
-    )
-
-
 def _write_worker_snapshots(
     cur: TransactionCursor,
     items: Sequence[tuple[str, job_pb2.WorkerResourceSnapshot]],
@@ -857,28 +842,50 @@ def _write_worker_snapshots(
     if not items:
         return
 
-    rows = [(wid, _snapshot_fields(snap)) for wid, snap in items]
-    update_params = [(now_ms, *fields, wid) for wid, fields in rows]
-    history_params = [(wid, *fields, now_ms) for wid, fields in rows]
-
+    binds = [
+        {
+            "worker_id": wid,
+            "now_ms": now_ms,
+            "host_cpu_percent": snap.host_cpu_percent,
+            "memory_used_bytes": snap.memory_used_bytes,
+            "memory_total_bytes": snap.memory_total_bytes,
+            "disk_used_bytes": snap.disk_used_bytes,
+            "disk_total_bytes": snap.disk_total_bytes,
+            "running_task_count": snap.running_task_count,
+            "total_process_count": snap.total_process_count,
+            "net_recv_bps": snap.net_recv_bps,
+            "net_sent_bps": snap.net_sent_bps,
+        }
+        for wid, snap in items
+    ]
     health_prefix = "healthy = 1, active = 1, consecutive_failures = 0, " if reset_health else ""
     cur.executemany(
-        f"UPDATE workers SET {health_prefix}last_heartbeat_ms = ?, "
-        "snapshot_host_cpu_percent = ?, snapshot_memory_used_bytes = ?, "
-        "snapshot_memory_total_bytes = ?, snapshot_disk_used_bytes = ?, "
-        "snapshot_disk_total_bytes = ?, snapshot_running_task_count = ?, "
-        "snapshot_total_process_count = ?, snapshot_net_recv_bps = ?, "
-        "snapshot_net_sent_bps = ? WHERE worker_id = ?",
-        update_params,
+        f"UPDATE workers SET {health_prefix}last_heartbeat_ms = :now_ms, "
+        "snapshot_host_cpu_percent = :host_cpu_percent, "
+        "snapshot_memory_used_bytes = :memory_used_bytes, "
+        "snapshot_memory_total_bytes = :memory_total_bytes, "
+        "snapshot_disk_used_bytes = :disk_used_bytes, "
+        "snapshot_disk_total_bytes = :disk_total_bytes, "
+        "snapshot_running_task_count = :running_task_count, "
+        "snapshot_total_process_count = :total_process_count, "
+        "snapshot_net_recv_bps = :net_recv_bps, "
+        "snapshot_net_sent_bps = :net_sent_bps "
+        "WHERE worker_id = :worker_id",
+        binds,
     )
     cur.executemany(
-        "INSERT INTO worker_resource_history("
+        "INSERT INTO worker_resource_history ("
         "worker_id, snapshot_host_cpu_percent, snapshot_memory_used_bytes, "
         "snapshot_memory_total_bytes, snapshot_disk_used_bytes, snapshot_disk_total_bytes, "
         "snapshot_running_task_count, snapshot_total_process_count, "
         "snapshot_net_recv_bps, snapshot_net_sent_bps, timestamp_ms"
-        ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        history_params,
+        ") VALUES ("
+        ":worker_id, :host_cpu_percent, :memory_used_bytes, "
+        ":memory_total_bytes, :disk_used_bytes, :disk_total_bytes, "
+        ":running_task_count, :total_process_count, "
+        ":net_recv_bps, :net_sent_bps, :now_ms"
+        ")",
+        binds,
     )
 
 

--- a/lib/iris/tests/cluster/controller/test_heartbeat.py
+++ b/lib/iris/tests/cluster/controller/test_heartbeat.py
@@ -24,6 +24,7 @@ from iris.cluster.controller.transitions import (
     HeartbeatApplyRequest,
     RunningTaskEntry,
     TaskUpdate,
+    WorkerPing,
 )
 from iris.cluster.controller.worker_provider import RpcWorkerStubFactory, WorkerProvider
 from iris.cluster.types import JobName, WorkerId
@@ -111,9 +112,16 @@ def test_complete_heartbeat_success(state, worker_metadata):
     assert worker.healthy
 
 
-def test_update_worker_ping_success_writes_snapshot_columns(state, worker_metadata):
-    """Ping-loop success path writes scalar snapshot columns and history row."""
+def test_update_worker_pings_writes_snapshot_and_liveness(state, worker_metadata):
+    """Bulk ping update writes scalar snapshot columns + history for snapshot
+    pings, and bumps last_heartbeat for liveness-only pings, in one call."""
     _register_worker(state, "worker1", worker_metadata)
+    _register_worker(state, "worker2", worker_metadata, address="host:8081")
+
+    # Force liveness-only worker's heartbeat backwards so we can detect the bump.
+    with state._db.transaction() as cur:
+        cur.execute("UPDATE workers SET last_heartbeat_ms = 0 WHERE worker_id = ?", ("worker2",))
+
     snap = job_pb2.WorkerResourceSnapshot(
         host_cpu_percent=42,
         memory_used_bytes=1_000,
@@ -126,17 +134,22 @@ def test_update_worker_ping_success_writes_snapshot_columns(state, worker_metada
         net_sent_bps=8,
     )
 
-    state.update_worker_ping_success(WorkerId("worker1"), snap)
+    state.update_worker_pings(
+        [
+            WorkerPing(worker_id=WorkerId("worker1"), snapshot=snap),
+            WorkerPing(worker_id=WorkerId("worker2"), snapshot=None),
+        ]
+    )
 
     with state._db.snapshot() as q:
-        row = q.fetchone(
+        row1 = q.fetchone(
             "SELECT snapshot_host_cpu_percent, snapshot_memory_used_bytes, snapshot_net_sent_bps "
             "FROM workers WHERE worker_id = ?",
             ("worker1",),
         )
-        assert row["snapshot_host_cpu_percent"] == 42
-        assert row["snapshot_memory_used_bytes"] == 1_000
-        assert row["snapshot_net_sent_bps"] == 8
+        assert row1["snapshot_host_cpu_percent"] == 42
+        assert row1["snapshot_memory_used_bytes"] == 1_000
+        assert row1["snapshot_net_sent_bps"] == 8
 
         hist = q.fetchall(
             "SELECT snapshot_host_cpu_percent FROM worker_resource_history WHERE worker_id = ?",
@@ -144,6 +157,19 @@ def test_update_worker_ping_success_writes_snapshot_columns(state, worker_metada
         )
         assert len(hist) == 1
         assert hist[0]["snapshot_host_cpu_percent"] == 42
+
+        # Liveness-only ping bumps last_heartbeat without inserting history.
+        row2 = q.fetchone(
+            "SELECT last_heartbeat_ms, snapshot_host_cpu_percent FROM workers WHERE worker_id = ?",
+            ("worker2",),
+        )
+        assert row2["last_heartbeat_ms"] > 0
+        assert row2["snapshot_host_cpu_percent"] is None
+        assert q.fetchall("SELECT 1 FROM worker_resource_history WHERE worker_id = ?", ("worker2",)) == []
+
+
+def test_update_worker_pings_empty_is_noop(state):
+    state.update_worker_pings([])
 
 
 def test_fail_heartbeat_below_threshold(state, worker_metadata):

--- a/lib/iris/tests/cluster/controller/test_heartbeat.py
+++ b/lib/iris/tests/cluster/controller/test_heartbeat.py
@@ -24,7 +24,6 @@ from iris.cluster.controller.transitions import (
     HeartbeatApplyRequest,
     RunningTaskEntry,
     TaskUpdate,
-    WorkerPing,
 )
 from iris.cluster.controller.worker_provider import RpcWorkerStubFactory, WorkerProvider
 from iris.cluster.types import JobName, WorkerId
@@ -134,12 +133,7 @@ def test_update_worker_pings_writes_snapshot_and_liveness(state, worker_metadata
         net_sent_bps=8,
     )
 
-    state.update_worker_pings(
-        [
-            WorkerPing(worker_id=WorkerId("worker1"), snapshot=snap),
-            WorkerPing(worker_id=WorkerId("worker2"), snapshot=None),
-        ]
-    )
+    state.update_worker_pings({WorkerId("worker1"): snap, WorkerId("worker2"): None})
 
     with state._db.snapshot() as q:
         row1 = q.fetchone(
@@ -169,7 +163,7 @@ def test_update_worker_pings_writes_snapshot_and_liveness(state, worker_metadata
 
 
 def test_update_worker_pings_empty_is_noop(state):
-    state.update_worker_pings([])
+    state.update_worker_pings({})
 
 
 def test_fail_heartbeat_below_threshold(state, worker_metadata):

--- a/lib/iris/tests/cluster/controller/test_heartbeat.py
+++ b/lib/iris/tests/cluster/controller/test_heartbeat.py
@@ -111,61 +111,6 @@ def test_complete_heartbeat_success(state, worker_metadata):
     assert worker.healthy
 
 
-def test_update_worker_pings_writes_snapshot_and_liveness(state, worker_metadata):
-    """Bulk ping update writes scalar snapshot columns + history for snapshot
-    pings, and bumps last_heartbeat for liveness-only pings, in one call."""
-    _register_worker(state, "worker1", worker_metadata)
-    _register_worker(state, "worker2", worker_metadata, address="host:8081")
-
-    # Force liveness-only worker's heartbeat backwards so we can detect the bump.
-    with state._db.transaction() as cur:
-        cur.execute("UPDATE workers SET last_heartbeat_ms = 0 WHERE worker_id = ?", ("worker2",))
-
-    snap = job_pb2.WorkerResourceSnapshot(
-        host_cpu_percent=42,
-        memory_used_bytes=1_000,
-        memory_total_bytes=2_000,
-        disk_used_bytes=3_000,
-        disk_total_bytes=4_000,
-        running_task_count=5,
-        total_process_count=6,
-        net_recv_bps=7,
-        net_sent_bps=8,
-    )
-
-    state.update_worker_pings({WorkerId("worker1"): snap, WorkerId("worker2"): None})
-
-    with state._db.snapshot() as q:
-        row1 = q.fetchone(
-            "SELECT snapshot_host_cpu_percent, snapshot_memory_used_bytes, snapshot_net_sent_bps "
-            "FROM workers WHERE worker_id = ?",
-            ("worker1",),
-        )
-        assert row1["snapshot_host_cpu_percent"] == 42
-        assert row1["snapshot_memory_used_bytes"] == 1_000
-        assert row1["snapshot_net_sent_bps"] == 8
-
-        hist = q.fetchall(
-            "SELECT snapshot_host_cpu_percent FROM worker_resource_history WHERE worker_id = ?",
-            ("worker1",),
-        )
-        assert len(hist) == 1
-        assert hist[0]["snapshot_host_cpu_percent"] == 42
-
-        # Liveness-only ping bumps last_heartbeat without inserting history.
-        row2 = q.fetchone(
-            "SELECT last_heartbeat_ms, snapshot_host_cpu_percent FROM workers WHERE worker_id = ?",
-            ("worker2",),
-        )
-        assert row2["last_heartbeat_ms"] > 0
-        assert row2["snapshot_host_cpu_percent"] is None
-        assert q.fetchall("SELECT 1 FROM worker_resource_history WHERE worker_id = ?", ("worker2",)) == []
-
-
-def test_update_worker_pings_empty_is_noop(state):
-    state.update_worker_pings({})
-
-
 def test_fail_heartbeat_below_threshold(state, worker_metadata):
     """RPC failure below threshold returns TRANSIENT_FAILURE, worker stays alive."""
     _register_worker(state, "worker1", worker_metadata)

--- a/lib/iris/tests/cluster/controller/test_heartbeat.py
+++ b/lib/iris/tests/cluster/controller/test_heartbeat.py
@@ -111,6 +111,41 @@ def test_complete_heartbeat_success(state, worker_metadata):
     assert worker.healthy
 
 
+def test_update_worker_ping_success_writes_snapshot_columns(state, worker_metadata):
+    """Ping-loop success path writes scalar snapshot columns and history row."""
+    _register_worker(state, "worker1", worker_metadata)
+    snap = job_pb2.WorkerResourceSnapshot(
+        host_cpu_percent=42,
+        memory_used_bytes=1_000,
+        memory_total_bytes=2_000,
+        disk_used_bytes=3_000,
+        disk_total_bytes=4_000,
+        running_task_count=5,
+        total_process_count=6,
+        net_recv_bps=7,
+        net_sent_bps=8,
+    )
+
+    state.update_worker_ping_success(WorkerId("worker1"), snap)
+
+    with state._db.snapshot() as q:
+        row = q.fetchone(
+            "SELECT snapshot_host_cpu_percent, snapshot_memory_used_bytes, snapshot_net_sent_bps "
+            "FROM workers WHERE worker_id = ?",
+            ("worker1",),
+        )
+        assert row["snapshot_host_cpu_percent"] == 42
+        assert row["snapshot_memory_used_bytes"] == 1_000
+        assert row["snapshot_net_sent_bps"] == 8
+
+        hist = q.fetchall(
+            "SELECT snapshot_host_cpu_percent FROM worker_resource_history WHERE worker_id = ?",
+            ("worker1",),
+        )
+        assert len(hist) == 1
+        assert hist[0]["snapshot_host_cpu_percent"] == 42
+
+
 def test_fail_heartbeat_below_threshold(state, worker_metadata):
     """RPC failure below threshold returns TRANSIENT_FAILURE, worker stays alive."""
     _register_worker(state, "worker1", worker_metadata)


### PR DESCRIPTION
Migration 0025 dropped the resource_snapshot_proto/snapshot_proto BLOB columns in favor of scalar snapshot_* columns, but the split-heartbeat ping success path still wrote to the old columns and crashed every ping loop iteration in production. Consolidate touch_worker_liveness + update_worker_ping_success into a single bulk update_worker_pings(Sequence[WorkerPing]) — one transaction per cycle instead of one per healthy worker — and extract _write_worker_snapshots so the heartbeat and ping paths share the snapshot UPDATE and history INSERT. Adds regression tests.