### PR TITLE
zephyr: bound reducer memory when reading scatter sidecars

### DIFF
--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -142,7 +142,12 @@ def _read_sidecar_slice(path: str, shard_key: str) -> _SidecarSlice | None:
     """Read one sidecar and extract only the fields for ``shard_key``.
 
     Returns ``None`` if the sidecar has no ranges for this shard. The parsed
-    dict is released when this function returns.
+    dict is released when this function returns. Once we confirm this shard
+    has ranges, ``max_chunk_rows[shard_key]`` and ``avg_item_bytes`` must
+    also be present — ``ScatterWriter`` records both in the same ``_flush``
+    that appends to ``shards[shard_key]``. A missing field here means the
+    sidecar is corrupt or was written by an incompatible version, and we
+    fail rather than silently substituting zero.
     """
     meta_path = _scatter_meta_path(path)
     with open_url(meta_path, "r") as f:
@@ -150,10 +155,18 @@ def _read_sidecar_slice(path: str, shard_key: str) -> _SidecarSlice | None:
     ranges_raw = meta.get("shards", {}).get(shard_key)
     if not ranges_raw:
         return None
+    max_rows_map = meta.get("max_chunk_rows", {})
+    if shard_key not in max_rows_map:
+        raise ValueError(f"Sidecar {meta_path} has ranges for shard {shard_key} but no max_chunk_rows entry.")
+    if "avg_item_bytes" not in meta:
+        raise ValueError(f"Sidecar {meta_path} has ranges for shard {shard_key} but no avg_item_bytes.")
     ranges = tuple((int(off), int(length)) for off, length in ranges_raw)
-    max_rows = int(meta.get("max_chunk_rows", {}).get(shard_key, 0))
-    avg = float(meta.get("avg_item_bytes", 0.0))
-    return _SidecarSlice(path=path, ranges=ranges, max_chunk_rows=max_rows, avg_item_bytes=avg)
+    return _SidecarSlice(
+        path=path,
+        ranges=ranges,
+        max_chunk_rows=int(max_rows_map[shard_key]),
+        avg_item_bytes=float(meta["avg_item_bytes"]),
+    )
 
 
 def _read_sidecar_slices_parallel(scatter_paths: list[str], target_shard: int) -> list[_SidecarSlice]:

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -120,29 +120,62 @@ def _write_scatter_meta(data_path: str, sidecar: dict) -> None:
             f.write(payload)
 
 
-def _read_sidecars_parallel(scatter_paths: list[str]) -> list[tuple[str, dict]]:
-    """Read every ``.scatter_meta`` sidecar concurrently, preserving input order.
+@dataclass(frozen=True)
+class _SidecarSlice:
+    """One reducer's slice of a mapper sidecar.
 
-    Each reducer calls this to build its ``ScatterReader`` directly from the
-    per-mapper sidecars, without going through a coordinator-written manifest.
+    A full sidecar is ~hundreds of KB and carries byte ranges for every
+    target shard (tens of thousands on large jobs). A reducer only consumes
+    its own shard's ranges plus two scalars, so the worker extracts just
+    those fields and discards the parsed dict before returning. This keeps
+    the reducer's resident memory proportional to the number of mappers
+    instead of mappers * sidecar size.
+    """
+
+    path: str
+    ranges: tuple[tuple[int, int], ...]
+    max_chunk_rows: int
+    avg_item_bytes: float
+
+
+def _read_sidecar_slice(path: str, shard_key: str) -> _SidecarSlice | None:
+    """Read one sidecar and extract only the fields for ``shard_key``.
+
+    Returns ``None`` if the sidecar has no ranges for this shard. The parsed
+    dict is released when this function returns.
+    """
+    meta_path = _scatter_meta_path(path)
+    with open_url(meta_path, "r") as f:
+        meta = json.loads(f.read())
+    ranges_raw = meta.get("shards", {}).get(shard_key)
+    if not ranges_raw:
+        return None
+    ranges = tuple((int(off), int(length)) for off, length in ranges_raw)
+    max_rows = int(meta.get("max_chunk_rows", {}).get(shard_key, 0))
+    avg = float(meta.get("avg_item_bytes", 0.0))
+    return _SidecarSlice(path=path, ranges=ranges, max_chunk_rows=max_rows, avg_item_bytes=avg)
+
+
+def _read_sidecar_slices_parallel(scatter_paths: list[str], target_shard: int) -> list[_SidecarSlice]:
+    """Read every sidecar concurrently and return per-shard slices in input order.
+
+    Extraction happens inside the worker so full sidecar dicts never
+    accumulate in the reducer process. Sidecars with no ranges for
+    ``target_shard`` are dropped.
 
     TODO(rav): each reducer subprocess re-reads every sidecar even though only
     one shard's byte ranges are used. A worker-level sidecar cache (or a shared
     read across colocated reducers) would avoid the redundant GCS GETs when
     many reducers run on the same host.
     """
-
-    def _read_entry(path: str) -> tuple[str, dict]:
-        meta_path = _scatter_meta_path(path)
-        with open_url(meta_path, "r") as f:
-            return path, json.loads(f.read())
-
-    results: dict[str, dict] = {}
+    shard_key = str(target_shard)
+    ordered: list[_SidecarSlice | None] = [None] * len(scatter_paths)
     with concurrent.futures.ThreadPoolExecutor(max_workers=_SIDECAR_READ_CONCURRENCY) as pool:
-        for path, meta in pool.map(_read_entry, scatter_paths):
-            results[path] = meta
-
-    return [(path, results[path]) for path in scatter_paths]
+        futures = {pool.submit(_read_sidecar_slice, p, shard_key): i for i, p in enumerate(scatter_paths)}
+        for fut in concurrent.futures.as_completed(futures):
+            idx = futures[fut]
+            ordered[idx] = fut.result()
+    return [s for s in ordered if s is not None]
 
 
 # ---------------------------------------------------------------------------
@@ -234,8 +267,6 @@ class ScatterReader:
         is needed, which eliminates a serialization bottleneck when there are
         thousands of mappers.
         """
-        shard_key = str(target_shard)
-
         iterators: list[ScatterFileIterator] = []
         max_rows = 0
         weighted_bytes = 0.0
@@ -245,26 +276,12 @@ class ScatterReader:
             f"Building ScatterReader for target shard {target_shard} "
             f"from {len(scatter_paths)} sidecars (concurrency={_SIDECAR_READ_CONCURRENCY})"
         ):
-            for path, meta in _read_sidecars_parallel(scatter_paths):
-                shards = meta.get("shards", {})
-                ranges = shards.get(shard_key)
-                if not ranges:
-                    continue
-
-                iterators.append(
-                    ScatterFileIterator(
-                        path=path,
-                        chunks=tuple((int(off), int(length)) for off, length in ranges),
-                    )
-                )
-
-                per_shard_max = meta.get("max_chunk_rows", {})
-                max_rows = max(max_rows, per_shard_max.get(shard_key, 0))
-
-                ab = meta.get("avg_item_bytes", 0.0)
-                if ab > 0:
-                    count = len(ranges)
-                    weighted_bytes += ab * count
+            for slice_ in _read_sidecar_slices_parallel(scatter_paths, target_shard):
+                iterators.append(ScatterFileIterator(path=slice_.path, chunks=slice_.ranges))
+                max_rows = max(max_rows, slice_.max_chunk_rows)
+                if slice_.avg_item_bytes > 0:
+                    count = len(slice_.ranges)
+                    weighted_bytes += slice_.avg_item_bytes * count
                     total_chunks_for_avg += count
 
         if max_rows == 0:

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -148,10 +148,14 @@ def _read_sidecar_slice(path: str, shard_key: str) -> _SidecarSlice | None:
     that appends to ``shards[shard_key]``. A missing field here means the
     sidecar is corrupt or was written by an incompatible version, and we
     fail rather than silently substituting zero.
+
+    Uses ``fs.cat_file`` rather than ``open_url`` — one direct GET returning
+    bytes is ~25% faster than going through ``TextIOWrapper(BufferedFile)``
+    for small sidecars, and ``json.loads`` accepts bytes directly.
     """
     meta_path = _scatter_meta_path(path)
-    with open_url(meta_path, "r") as f:
-        meta = json.loads(f.read())
+    fs, fs_path = url_to_fs(meta_path)
+    meta = json.loads(fs.cat_file(fs_path))
     ranges_raw = meta.get("shards", {}).get(shard_key)
     if not ranges_raw:
         return None


### PR DESCRIPTION
* reducers OOM'd reading scatter sidecars — on a ~10k mapper / ~14k shard job each reducer held ~16 GB of parsed sidecar dicts before picking out one shard's fields
* extract per-shard slice inside the sidecar worker thread and discard the full parsed dict before returning — peak RSS drops from ~16 GB to ~200 MB on the same input [^1]
* new `_SidecarSlice` dataclass holds just `(path, ranges, max_chunk_rows, avg_item_bytes)` — the only fields `ScatterReader.from_sidecars` consumes
* switch collector from `pool.map` to `as_completed` with an index-tracked output list, preserving input order without buffering full dicts

[^1]: benchmarked locally over a 9678-sidecar snapshot, same input to both paths