### PR TITLE
[iris] Log-store: compact single tmp on close, drop crash-leftover tmps on startup

### DIFF
--- a/lib/iris/src/iris/cluster/log_store/duckdb_store.py
+++ b/lib/iris/src/iris/cluster/log_store/duckdb_store.py
@@ -403,9 +403,15 @@ class DuckDBLogStore:
 
         self._segments_rwlock = _RWLock()
 
+        # Seq numbers are monotonic across the controller's lifetime and each
+        # flush assigns a unique range, so any tmp whose [min, max] is fully
+        # contained in a logs_ segment's range is a leftover from a prior
+        # compaction that crashed between rename and unlink. Drop it on
+        # startup so restart reads don't double-count those rows.
+        discovered = []
         for p in _discover_segments(self._log_dir):
             min_seq, max_seq = _read_seq_bounds(p)
-            self._local_segments.append(
+            discovered.append(
                 _LocalSegment(
                     path=str(p),
                     size_bytes=p.stat().st_size,
@@ -413,6 +419,16 @@ class DuckDBLogStore:
                     max_seq=max_seq,
                 )
             )
+        log_ranges = [(s.min_seq, s.max_seq) for s in discovered if not _is_tmp_path(s.path)]
+        for s in discovered:
+            if _is_tmp_path(s.path) and any(lo <= s.min_seq and s.max_seq <= hi for lo, hi in log_ranges):
+                logger.info("Dropping stale tmp segment %s covered by compacted logs_ range", s.path)
+                try:
+                    Path(s.path).unlink()
+                except Exception:
+                    logger.warning("Failed to unlink stale tmp segment %s", s.path, exc_info=True)
+                continue
+            self._local_segments.append(s)
 
         self._pool = _ConnectionPool(memory_limit=duckdb_memory_limit)
 
@@ -533,10 +549,13 @@ class DuckDBLogStore:
         self._wake.set()
         self._bg_thread.join()
         # Final drain + compaction in the foreground so any lingering tmp
-        # segments get merged and uploaded before shutdown.
+        # segments get merged and uploaded before shutdown. ``compact_single``
+        # ensures the last tmp is rewritten to a logs_ segment and offloaded
+        # to GCS even when only one exists — otherwise a low-volume shutdown
+        # leaves only local tmp_*.parquet and loses data on fresh restart.
         self._compact_step()
         self._flush_step()
-        self._compaction_step()
+        self._compaction_step(compact_single=True)
         self._pool.close()
         if self._temp_dir is not None:
             self._temp_dir.cleanup()
@@ -681,19 +700,22 @@ class DuckDBLogStore:
             int((time.monotonic() - write_start) * 1000),
         )
 
-    def _compaction_step(self) -> None:
+    def _compaction_step(self, *, compact_single: bool = False) -> None:
         """Merge all tmp_ segments into a single logs_ segment, upload, unlink.
 
         Uses ``COPY (SELECT ... ORDER BY key, seq)`` so the merge streams
         inside DuckDB — never touches pyarrow's concat/sort path, which
         leaks ~45 MB per invocation when reading parquet back.
+
+        By default, a single tmp is left alone — rewriting it buys nothing at
+        steady state. ``close()`` passes ``compact_single=True`` so the final
+        tmp on shutdown still becomes a logs_ segment and reaches GCS.
         """
         with self._memory_lock:
             tmps = [s for s in self._local_segments if _is_tmp_path(s.path)]
         if not tmps:
             return
-        # Single-tmp compaction costs a rewrite for no fanout benefit — skip.
-        if len(tmps) < 2:
+        if len(tmps) < 2 and not compact_single:
             return
 
         tmps.sort(key=lambda s: s.min_seq)

--- a/lib/iris/tests/cluster/controller/test_logs.py
+++ b/lib/iris/tests/cluster/controller/test_logs.py
@@ -442,8 +442,82 @@ def test_compaction_skips_single_tmp(tmp_path: Path):
         store.close()
 
 
+def test_close_compacts_and_offloads_single_tmp(tmp_path: Path):
+    """close() with exactly one tmp must still produce a logs_ segment and
+    offload it to remote storage. Regression: the < 2 tmp skip in the
+    steady-state compaction path was inherited by close(), so a low-volume
+    shutdown left data only in local tmp_*.parquet and lost it on a fresh
+    restart with empty local storage."""
+    log_dir = tmp_path / "logs"
+    remote_dir = tmp_path / "remote"
+    remote_dir.mkdir()
+    store = DuckDBLogStore(log_dir=log_dir, remote_log_dir=str(remote_dir))
+    store.append(KEY, [_make_entry("only", epoch_ms=0)])
+    store._force_flush()
+    assert len(sorted(log_dir.glob("tmp_*.parquet"))) == 1
+    assert len(sorted(log_dir.glob("logs_*.parquet"))) == 0
+
+    store.close()
+
+    assert sorted(log_dir.glob("tmp_*.parquet")) == []
+    local_logs = sorted(log_dir.glob("logs_*.parquet"))
+    assert len(local_logs) == 1
+    remote_logs = sorted(remote_dir.glob("logs_*.parquet"))
+    assert len(remote_logs) == 1
+    assert remote_logs[0].name == local_logs[0].name
+
+
+def test_startup_drops_tmps_covered_by_log(tmp_path: Path):
+    """A compaction crash between ``rename(logs_)`` and ``unlink(tmp_)``
+    leaves both on disk with overlapping ranges. Restart must drop the
+    now-redundant tmps or reads double-count those rows."""
+    log_dir = tmp_path / "logs"
+    store1 = DuckDBLogStore(log_dir=log_dir)
+    for batch in range(3):
+        store1.append(KEY, [_make_entry(f"b{batch}-{i}", epoch_ms=batch * 10 + i) for i in range(3)])
+        store1._force_flush()
+
+    # Snapshot the tmp bytes before compaction destroys them.
+    tmps_before_compact = sorted(log_dir.glob("tmp_*.parquet"))
+    assert len(tmps_before_compact) == 3
+    saved_tmps = {p.name: p.read_bytes() for p in tmps_before_compact}
+
+    store1._force_compaction()
+    store1.close()
+    assert len(sorted(log_dir.glob("logs_*.parquet"))) == 1
+    assert sorted(log_dir.glob("tmp_*.parquet")) == []
+
+    # Simulate a mid-compaction crash: rename landed, unlink didn't.
+    for name, data in saved_tmps.items():
+        (log_dir / name).write_bytes(data)
+    assert len(sorted(log_dir.glob("tmp_*.parquet"))) == 3
+    assert len(sorted(log_dir.glob("logs_*.parquet"))) == 1
+
+    store2 = DuckDBLogStore(log_dir=log_dir)
+    try:
+        assert sorted(log_dir.glob("tmp_*.parquet")) == []
+        assert len(sorted(log_dir.glob("logs_*.parquet"))) == 1
+        result = store2.get_logs(KEY)
+        assert len(result.entries) == 9
+        assert [e.data for e in result.entries] == [
+            "b0-0",
+            "b0-1",
+            "b0-2",
+            "b1-0",
+            "b1-1",
+            "b1-2",
+            "b2-0",
+            "b2-1",
+            "b2-2",
+        ]
+    finally:
+        store2.close()
+
+
 def test_recovery_reads_both_tmp_and_log(tmp_path: Path):
-    """After restart, a dir with mixed tmp_ and logs_ files is fully readable."""
+    """After a non-graceful exit, a dir with mixed tmp_ and logs_ files is
+    fully readable. Emulates a crash by halting the bg thread without going
+    through close() (which would compact the trailing tmp into a logs_)."""
     log_dir = tmp_path / "logs"
     store1 = DuckDBLogStore(log_dir=log_dir)
     try:
@@ -456,7 +530,12 @@ def test_recovery_reads_both_tmp_and_log(tmp_path: Path):
         store1.append(KEY, [_make_entry(f"new-{i}", epoch_ms=100 + i) for i in range(3)])
         store1._force_flush()
     finally:
-        store1.close()
+        # Simulate crash: stop bg thread and release DuckDB without the
+        # shutdown-compaction path close() runs.
+        store1._stop.set()
+        store1._wake.set()
+        store1._bg_thread.join()
+        store1._pool.close()
 
     assert len(sorted(log_dir.glob("logs_*.parquet"))) == 1
     assert len(sorted(log_dir.glob("tmp_*.parquet"))) == 1


### PR DESCRIPTION
## Summary

Follow-up to #4881. Review on that PR flagged two durability regressions that landed with the merge ([review comment on single-tmp skip](https://github.com/marin-community/marin/pull/4881#discussion_r3104360876), [review comment on rename/unlink crash window](https://github.com/marin-community/marin/pull/4881#discussion_r3104360873)):

- **`close()` with exactly one tmp never uploads.** The steady-state compaction step skips when `len(tmps) < 2` (rewriting one tmp buys no fanout benefit). `close()` inherited that skip, so a low-volume shutdown left data only in local `tmp_*.parquet` and lost it on a fresh restart with empty local storage.
- **Crash between compaction's `rename` and `unlink` double-counts rows.** The rename lands first; a crash before the tmps are unlinked leaves the merged `logs_` and its source tmps on disk. Startup loads both, `get_logs()` returns the overlapping range twice.

## Fixes

- `_compaction_step` takes `compact_single: bool` (default `False` to preserve the steady-state skip). `close()` passes `compact_single=True` so the final tmp on shutdown becomes a `logs_` segment and reaches GCS. Costs one extra rewrite on shutdown.
- On startup, after discovering segments, drop any tmp whose seq range is fully contained in a `logs_` range. Seq numbers are monotonic per controller and each flush assigns a unique range, so a contained tmp can only be a crashed-compaction leftover — its rows are already in the `logs_`.

## Test plan

- [x] `test_close_compacts_and_offloads_single_tmp` — close() with one tmp produces a local `logs_` and copies it to `remote_log_dir`.
- [x] `test_startup_drops_tmps_covered_by_log` — save tmp bytes, compact to `logs_`, restore tmp bytes (simulating the crash), reopen. Assert reconciler unlinks the tmps and `get_logs()` returns a single copy.
- [x] Existing `test_recovery_reads_both_tmp_and_log` updated: it previously relied on `close()` leaving a trailing tmp, which no longer happens. Now emulates a crash by halting the bg thread without the shutdown-compaction path.
- [x] Full `tests/cluster/controller/test_logs.py` suite — 38 passed.
- [x] `./infra/pre-commit.py --fix` clean on changed files.