### PR TITLE
[marin] Expose max_workers on normalize and consolidate

### DIFF
--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -322,6 +322,7 @@ def normalize_to_parquet(
     target_partition_bytes: int = 256 * 1024 * 1024,
     max_whitespace_run_chars: int = DEFAULT_MAX_WHITESPACE_RUN_CHARS,
     worker_resources: ResourceConfig | None = None,
+    max_workers: int | None = None,
     file_extensions: tuple[str, ...] | None = None,
     dedup_mode: DedupMode = DedupMode.EXACT,
 ) -> NormalizedData:
@@ -354,6 +355,8 @@ def normalize_to_parquet(
             Defaults to 2 CPU / 16GB RAM / 10GB disk, sized for
             ``target_partition_bytes`` of 256MB.  Scale up when increasing
             partition size.
+        max_workers: Maximum number of Zephyr workers per subdirectory pipeline.
+            Defaults to Zephyr's own default (128 for distributed backends).
         file_extensions: Tuple of file extensions to include (e.g.
             ``(".parquet",)``).  Defaults to all extensions supported by
             ``zephyr.readers.load_file``.
@@ -422,6 +425,7 @@ def normalize_step(
     target_partition_bytes: int = 256 * 1024 * 1024,
     max_whitespace_run_chars: int = DEFAULT_MAX_WHITESPACE_RUN_CHARS,
     worker_resources: ResourceConfig | None = None,
+    max_workers: int | None = None,
     override_output_path: str | None = None,
     input_path: str | None = None,
     file_extensions: tuple[str, ...] | None = None,
@@ -437,6 +441,8 @@ def normalize_step(
         target_partition_bytes: Target size per output partition.
         worker_resources: Per-worker resource request for the Zephyr pipeline.
             See :func:`normalize_to_parquet` for the default.
+        max_workers: Maximum number of Zephyr workers. Defaults to Zephyr's
+            own default (128 for distributed backends).
         override_output_path: Override the computed output path.
         input_path: Override the input path. Defaults to ``download.output_path``.
             Useful when normalizing a subdirectory of the download output.
@@ -458,6 +464,7 @@ def normalize_step(
             target_partition_bytes=target_partition_bytes,
             max_whitespace_run_chars=max_whitespace_run_chars,
             worker_resources=worker_resources,
+            max_workers=max_workers,
             file_extensions=file_extensions,
             dedup_mode=dedup_mode,
         ),

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -355,7 +355,7 @@ def normalize_to_parquet(
             Defaults to 2 CPU / 16GB RAM / 10GB disk, sized for
             ``target_partition_bytes`` of 256MB.  Scale up when increasing
             partition size.
-        max_workers: Maximum number of Zephyr workers per subdirectory pipeline.
+        max_workers: Maximum number of Zephyr workers for the pipeline.
             Defaults to Zephyr's own default (128 for distributed backends).
         file_extensions: Tuple of file extensions to include (e.g.
             ``(".parquet",)``).  Defaults to all extensions supported by
@@ -396,7 +396,10 @@ def normalize_to_parquet(
         dedup_mode,
         max_whitespace_run_chars,
     )
-    ctx = ZephyrContext(name="normalize", resources=resources)
+    ctx_kwargs: dict = {"name": "normalize", "resources": resources}
+    if max_workers is not None:
+        ctx_kwargs["max_workers"] = max_workers
+    ctx = ZephyrContext(**ctx_kwargs)
     outcome = ctx.execute(pipeline)
     counters_dict = dict(outcome.counters)
 

--- a/lib/marin/src/marin/processing/classification/consolidate.py
+++ b/lib/marin/src/marin/processing/classification/consolidate.py
@@ -143,6 +143,7 @@ def consolidate(
     filters: list[FilterConfig],
     filetype: str = "jsonl.gz",
     worker_resources: ResourceConfig | None = None,
+    max_workers: int | None = None,
 ) -> ZephyrExecutionResult:
     """Consolidate documents by applying filters based on attributes.
 
@@ -156,6 +157,7 @@ def consolidate(
         filters: List of filters to apply (see :class:`FilterConfig`).
         filetype: Extension of the input documents (default: ``"jsonl.gz"``).
         worker_resources: Optional Zephyr worker resource config (defaults to Zephyr defaults).
+        max_workers: Maximum number of Zephyr workers (defaults to Zephyr's default).
     """
     input_paths = sorted(fsspec_glob(os.path.join(input_path, f"**/*.{filetype}")))
     if not input_paths:
@@ -180,8 +182,10 @@ def consolidate(
         # Drop rejected docs before the next join so its key extractor never sees None.
         ds = ds.filter(lambda r: r is not None)
 
-    ctx = ZephyrContext(
-        name="consolidate-filter",
-        **({"resources": worker_resources} if worker_resources else {}),
-    )
+    ctx_kwargs: dict = {"name": "consolidate-filter"}
+    if worker_resources is not None:
+        ctx_kwargs["resources"] = worker_resources
+    if max_workers is not None:
+        ctx_kwargs["max_workers"] = max_workers
+    ctx = ZephyrContext(**ctx_kwargs)
     return ctx.execute(ds.write_parquet(f"{output_path}/part-{{shard:05d}}-of-{{total:05d}}.parquet"))


### PR DESCRIPTION
Replace the unused coordinator_resources parameter on datakit normalize with max_workers, plumb it into ZephyrContext, and add the same parameter to processing.classification.consolidate. Lets callers cap Zephyr worker count per pipeline instead of relying on the default of 128.