### PR TITLE
datakit: fix smoke ferry validator for new normalize/fuzzy_dups layout

### DIFF
--- a/scripts/datakit/validate_ferry_outputs.py
+++ b/scripts/datakit/validate_ferry_outputs.py
@@ -9,9 +9,9 @@ Run after the iris job for the datakit smoke ferry has completed.
 
 Checks the full pipeline chain:
   download (14 files, ~9.7M rows)
-  → normalize (106 files, ~9.3M rows, some rows filtered)
-  → dedup (106 attribute files, ~286K flagged dups)
-  → consolidate (106 files, normalize - dedup rows)
+  → normalize (106 files under outputs/main, ~9.3M rows)
+  → fuzzy_dups (106 cluster-member attr files per source)
+  → consolidate (106 files, normalize - non_canonical rows)
   → tokenize (cache ledger rows == consolidate rows)
 """
 
@@ -19,8 +19,12 @@ import logging
 import os
 import sys
 
+import pyarrow.compute as pc
 import pyarrow.parquet as pq
 from levanter.store.cache import CacheLedger
+from marin.datakit.normalize import NormalizedData
+from marin.execution.artifact import Artifact
+from marin.processing.classification.deduplication.fuzzy_dups import FuzzyDupsAttrData
 from marin.utils import fsspec_glob
 from rigging.filesystem import url_to_fs
 from rigging.log_setup import configure_logging
@@ -36,13 +40,15 @@ NORMALIZE_EXPECTED_FILES = 106
 NORMALIZE_MIN_ROWS = 8_000_000  # observed: 9,268,156
 NORMALIZE_REQUIRED_COLUMNS = {"id", "text", "url", "source_id", "token_count"}
 
-# --- Dedup: one attribute file per normalize shard ---
-DEDUP_EXPECTED_FILES = 106
-DEDUP_REQUIRED_COLUMNS = {"id", "attributes"}
-# Dedup should flag a non-trivial fraction but not everything.
-# Observed: 286,263 / 9,268,156 = 3.1%.
-DEDUP_MIN_FRACTION = 0.005  # at least 0.5% flagged
-DEDUP_MAX_FRACTION = 0.50  # at most 50% flagged
+# --- Fuzzy dups: one cluster-member attr file per normalize shard per source ---
+# The smoke ferry runs fuzzy dedup over a single source (fineweb-edu sample/10BT).
+FUZZY_DUPS_EXPECTED_SOURCES = 1
+FUZZY_DUPS_EXPECTED_FILES_PER_SOURCE = 106
+FUZZY_DUPS_REQUIRED_COLUMNS = {"id", "attributes"}
+# Non-canonicals are the rows consolidate will drop. Should be a non-trivial
+# but bounded fraction. Reference (old exact-dedup pipeline): 286,263 / 9,268,156 = 3.1%.
+FUZZY_DUPS_DROP_MIN_FRACTION = 0.005  # at least 0.5% dropped
+FUZZY_DUPS_DROP_MAX_FRACTION = 0.50  # at most 50% dropped
 
 # --- Consolidate: same file count, strictly fewer rows than normalize ---
 CONSOLIDATE_REQUIRED_COLUMNS = NORMALIZE_REQUIRED_COLUMNS
@@ -94,7 +100,11 @@ def _validate_download(base: str) -> int:
 
 
 def _validate_normalize(base: str, download_rows: int) -> int:
-    files = _list_parquet(f"{base}/normalize")
+    # Normalize writes main records to {base}/normalize/outputs/main and duplicates
+    # (when exact dedup is enabled) to {base}/normalize/outputs/dups. We load the
+    # artifact to resolve the paths rather than hard-coding the layout.
+    normalized = Artifact.load(f"{base}/normalize", NormalizedData)
+    files = _list_parquet(normalized.main_output_dir)
     if len(files) != NORMALIZE_EXPECTED_FILES:
         raise SystemExit(f"Normalize: expected {NORMALIZE_EXPECTED_FILES} files, got {len(files)}")
 
@@ -113,38 +123,73 @@ def _validate_normalize(base: str, download_rows: int) -> int:
     return rows
 
 
-def _validate_dedup(base: str, normalize_rows: int) -> int:
-    files = _list_parquet(f"{base}/dedup/data")
-    if len(files) != DEDUP_EXPECTED_FILES:
-        raise SystemExit(f"Dedup: expected {DEDUP_EXPECTED_FILES} files, got {len(files)}")
+def _count_canonicals(files: list[str]) -> int:
+    """Sum is_cluster_canonical=True rows across fuzzy-dups attr files."""
+    fs, _ = url_to_fs(files[0])
+    total = 0
+    for path in files:
+        with fs.open(path, "rb") as f:
+            tbl = pq.ParquetFile(f).read(columns=["attributes"])
+        if tbl.num_rows == 0:
+            continue
+        canonical = tbl.column("attributes").combine_chunks().field("is_cluster_canonical")
+        total += int(pc.sum(canonical).as_py() or 0)
+    return total
 
-    _check_schema(files[0], DEDUP_REQUIRED_COLUMNS)
 
-    flagged = _count_parquet_rows(files)
-    fraction = flagged / normalize_rows if normalize_rows > 0 else 0
+def _validate_fuzzy_dups(base: str, normalize_rows: int) -> int:
+    """Validate the fuzzy-dups step and return the number of rows consolidate will drop.
 
-    if fraction < DEDUP_MIN_FRACTION:
+    Fuzzy dedup writes one cluster-member parquet per normalize shard, per source,
+    under ``<attr_dir>/*.parquet`` with schema ``{id, attributes: {dup_cluster_id,
+    is_cluster_canonical}}``. Singletons are omitted, and exactly one cluster
+    member is flagged ``is_cluster_canonical=True``. Consolidate's default policy
+    keeps canonicals and singletons, so non-canonicals == rows dropped.
+    """
+    dedup = Artifact.load(f"{base}/fuzzy_dups", FuzzyDupsAttrData)
+    if len(dedup.sources) != FUZZY_DUPS_EXPECTED_SOURCES:
+        raise SystemExit(f"Fuzzy dups: expected exactly {FUZZY_DUPS_EXPECTED_SOURCES} source, got {len(dedup.sources)}")
+    (per_source,) = dedup.sources.values()
+    files = _list_parquet(per_source.attr_dir)
+    if len(files) != FUZZY_DUPS_EXPECTED_FILES_PER_SOURCE:
+        raise SystemExit(f"Fuzzy dups: expected {FUZZY_DUPS_EXPECTED_FILES_PER_SOURCE} files, got {len(files)}")
+
+    _check_schema(files[0], FUZZY_DUPS_REQUIRED_COLUMNS)
+
+    cluster_members = _count_parquet_rows(files)
+    canonicals = _count_canonicals(files)
+    if canonicals > cluster_members:
         raise SystemExit(
-            f"Dedup: only {flagged} dups flagged ({fraction:.1%} of {normalize_rows}) — "
-            f"expected >= {DEDUP_MIN_FRACTION:.1%}"
+            f"Fuzzy dups: {canonicals} canonicals > {cluster_members} cluster members — "
+            "at most one canonical per cluster must hold"
         )
-    if fraction > DEDUP_MAX_FRACTION:
+    dropped = cluster_members - canonicals
+    fraction = dropped / normalize_rows if normalize_rows > 0 else 0
+
+    if fraction < FUZZY_DUPS_DROP_MIN_FRACTION:
         raise SystemExit(
-            f"Dedup: {flagged} dups flagged ({fraction:.1%} of {normalize_rows}) — "
-            f"expected <= {DEDUP_MAX_FRACTION:.0%}, something is wrong"
+            f"Fuzzy dups: only {dropped} non-canonicals ({fraction:.1%} of {normalize_rows}) — "
+            f"expected >= {FUZZY_DUPS_DROP_MIN_FRACTION:.1%}"
+        )
+    if fraction > FUZZY_DUPS_DROP_MAX_FRACTION:
+        raise SystemExit(
+            f"Fuzzy dups: {dropped} non-canonicals ({fraction:.1%} of {normalize_rows}) — "
+            f"expected <= {FUZZY_DUPS_DROP_MAX_FRACTION:.0%}, something is wrong"
         )
 
     logger.info(
-        "Dedup OK: %d files, %d flagged duplicates (%.1f%% of %d docs)",
+        "Fuzzy dups OK: %d files, %d cluster members, %d canonicals → %d non-canonicals (%.1f%% of %d docs)",
         len(files),
-        flagged,
+        cluster_members,
+        canonicals,
+        dropped,
         100 * fraction,
         normalize_rows,
     )
-    return flagged
+    return dropped
 
 
-def _validate_consolidate(base: str, normalize_rows: int, dedup_rows: int) -> int:
+def _validate_consolidate(base: str, normalize_rows: int, dropped_rows: int) -> int:
     files = _list_parquet(f"{base}/consolidate")
 
     _check_schema(files[0], CONSOLIDATE_REQUIRED_COLUMNS)
@@ -154,24 +199,24 @@ def _validate_consolidate(base: str, normalize_rows: int, dedup_rows: int) -> in
     # Core invariant: consolidate must have strictly fewer rows than normalize
     if rows >= normalize_rows:
         raise SystemExit(
-            f"Consolidate: {rows} rows >= normalize {normalize_rows} rows — " "dedup removal did not reduce row count"
+            f"Consolidate: {rows} rows >= normalize {normalize_rows} rows — dedup removal did not reduce row count"
         )
 
-    # The expected count is exactly normalize - dedup
-    expected = normalize_rows - dedup_rows
+    # Exact expected count: consolidate drops non-canonical cluster members; all
+    # other normalize rows (canonicals + singletons) pass through.
+    expected = normalize_rows - dropped_rows
     if rows != expected:
         raise SystemExit(
             f"Consolidate: {rows} rows, expected exactly {expected} "
-            f"(normalize {normalize_rows} - dedup {dedup_rows})"
+            f"(normalize {normalize_rows} - non_canonicals {dropped_rows})"
         )
 
-    removed = normalize_rows - rows
     logger.info(
         "Consolidate OK: %d files, %d rows (removed %d, %.1f%%)",
         len(files),
         rows,
-        removed,
-        100 * removed / normalize_rows,
+        dropped_rows,
+        100 * dropped_rows / normalize_rows,
     )
     return rows
 
@@ -206,15 +251,15 @@ def main() -> None:
 
     download_rows = _validate_download(base)
     normalize_rows = _validate_normalize(base, download_rows)
-    dedup_rows = _validate_dedup(base, normalize_rows)
-    consolidate_rows = _validate_consolidate(base, normalize_rows, dedup_rows)
+    dropped_rows = _validate_fuzzy_dups(base, normalize_rows)
+    consolidate_rows = _validate_consolidate(base, normalize_rows, dropped_rows)
     token_rows = _validate_tokens(base, consolidate_rows)
 
     logger.info(
-        "All checks passed: download=%d → normalize=%d → dedup_flagged=%d → consolidate=%d → tokens=%d",
+        "All checks passed: download=%d → normalize=%d → non_canonicals=%d → consolidate=%d → tokens=%d",
         download_rows,
         normalize_rows,
-        dedup_rows,
+        dropped_rows,
         consolidate_rows,
         token_rows,
     )


### PR DESCRIPTION
## Summary

Fixes #4908. The `datakit-smoke` canary failed because `scripts/datakit/validate_ferry_outputs.py` globbed stale paths:

- **Normalize** moved to `outputs/main/` + `outputs/dups/` in #4886 — the validator still globbed `normalize/*.parquet` and found zero files (the actual failure).
- **Dedup** was split into `minhash` + `fuzzy_dups` steps in #4893 (merged after the failed run); the validator still expected `dedup/data/*.parquet`, so the very next run would have failed for a different reason.

Replace both hard-coded path patterns with `Artifact.load(..., NormalizedData)` and `Artifact.load(..., FuzzyDupsAttrData)`, matching what `experiments/ferries/datakit_ferry.py` already does. This makes the validator follow layout changes automatically.

The consolidate exact-row invariant is also updated: instead of `normalize − flagged_dups`, it's now `normalize − non_canonical_cluster_members`, which is what consolidate's default `keep is_cluster_canonical` filter actually drops.

## Test plan

- [x] Ran the updated `_validate_download` + `_validate_normalize` against the existing failed-run GCS prefix (`gs://marin-tmp-us-central2/ttl=1d/datakit-smoke/datakit-smoke-24624194038-1`) — both pass: 14 download files / 9,672,101 rows → 106 normalize files / 9,268,156 rows.
- [ ] Full end-to-end verification of `_validate_fuzzy_dups` + `_validate_consolidate` will happen on the next scheduled canary run (no existing ferry output uses the new `fuzzy_dups` layout yet).
- [x] `./infra/pre-commit.py --fix` ok, `uv run pyrefly` ok.