### PR TITLE
[levanter] Fix eval harness resource partitioning

### DIFF
--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -347,7 +347,10 @@ class _LmEvalHarnessWorker:
     def _receive_payload(self):
         payload = broadcast_shard(
             self._dummy_batch,
-            hax.partitioning.infer_resource_partitions(self._dummy_batch),
+            hax.partitioning.infer_resource_partitions(
+                self._dummy_batch,
+                resource_mapping=self.axis_resources,
+            ),
         )
         return payload
 
@@ -358,7 +361,13 @@ class _LmEvalHarnessWorker:
 
     def _send_payload(self, payload):
         assert jax.process_index() == 0
-        out = broadcast_shard(payload, hax.partitioning.infer_resource_partitions(payload))
+        out = broadcast_shard(
+            payload,
+            hax.partitioning.infer_resource_partitions(
+                payload,
+                resource_mapping=self.axis_resources,
+            ),
+        )
         return out
 
     def process_loglikelihood(self, packed_request):


### PR DESCRIPTION
## Summary
- Cherry-picks commit 5175dc6e3 to pass `resource_mapping` to `infer_resource_partitions` in `broadcast_shard` calls in `lib/levanter/src/levanter/eval_harness.py`.
- Needed to avoid `ValueError: No resource mapping found` errors during lm-eval harness runs.

## Context
- Discord thread: https://discord.com/channels/1354881461060243556/1364827114670657616/1492883817378222221
- Source commit: https://github.com/marin-community/marin/commit/5175dc6e3

🤖 Generated with [Claude Code](https://claude.com/claude-code)