### PR TITLE
Remove dead alpaca evaluator references

### DIFF
--- a/docs/explanations/evaluation.md
+++ b/docs/explanations/evaluation.md
@@ -34,7 +34,7 @@ Task sets are configured in [`task_configs.py`](https://github.com/marin-communi
 !!! note
 
     See [`levanter_lm_eval_evaluator.py`](https://github.com/marin-community/marin/blob/main/lib/marin/src/marin/evaluation/evaluators/levanter_lm_eval_evaluator.py) for the default evaluator implementation.
-    Additional evaluators (including HELM, Alpaca, and other backends) live in [`lib/marin/src/marin/evaluation/evaluators`](https://github.com/marin-community/marin/tree/main/lib/marin/src/marin/evaluation/evaluators).
+    Additional evaluators live in [`lib/marin/src/marin/evaluation/evaluators`](https://github.com/marin-community/marin/tree/main/lib/marin/src/marin/evaluation/evaluators).
 
 ### Reported metrics
 

--- a/docs/tutorials/run-lm-evals.md
+++ b/docs/tutorials/run-lm-evals.md
@@ -100,8 +100,6 @@ At the time of writing, `KEY_GENERATION_TASKS` includes:
 - `mmlu` 5-shot
 - `truthfulqa_mc2`
 
-There is no longer an in-repo `evaluate_alpaca_eval` helper, so Alpaca-specific guidance has been removed from this tutorial.
-
 ## 3. Build a Custom Eval Step
 
 Use the lower-level helpers when you want a custom task list or evaluator:

--- a/tests/evals/test_lm_eval.py
+++ b/tests/evals/test_lm_eval.py
@@ -63,26 +63,3 @@ def test_lm_eval_harness(current_date_time, model_config):
         engine_kwargs=model_config.engine_kwargs,
     )
     evaluate(config=config)
-
-
-@pytest.mark.tpu_ci
-def test_alpaca_eval(current_date_time, model_config):
-    config = EvaluationConfig(
-        evaluator="alpaca",
-        model_name=model_config.name,
-        model_path=model_config.path,
-        evaluation_path=f"gs://marin-us-east5/evaluation/alpaca_eval/{model_config.name}-{current_date_time}",
-        max_eval_instances=1,
-        launch_with_ray=True,
-        resource_config=ResourceConfig.with_cpu(cpu=1),
-        engine_kwargs={
-            "temperature": 0.7,
-            "presence_penalty": 0.0,
-            "frequency_penalty": 0.0,
-            "repetition_penalty": 1.0,
-            "top_p": 1.0,
-            "top_k": -1,
-            **model_config.engine_kwargs,
-        },
-    )
-    evaluate(config=config)


### PR DESCRIPTION
The alpaca evaluator was removed from the registry previously, but the tpu_ci test test_alpaca_eval and two doc mentions were left behind. Delete the test and drop stale Alpaca (and HELM, also gone) mentions from the explanation and tutorial docs.