### PR TITLE
[evaluation] Remove dead self.cleanup(model) call in LevanterLmEvalEvaluator

### DIFF
--- a/lib/marin/src/marin/evaluation/evaluators/levanter_lm_eval_evaluator.py
+++ b/lib/marin/src/marin/evaluation/evaluators/levanter_lm_eval_evaluator.py
@@ -129,10 +129,6 @@ class LevanterLmEvalEvaluator(LevanterTpuEvaluator):
             logger.error(f"Error running eval harness: {e}")
             raise e
 
-        finally:
-            # Clean up resources
-            self.cleanup(model)
-
 
 def _json_default(value):
     """


### PR DESCRIPTION
Delete a finally-block call to self.cleanup(model) that raised AttributeError on every invocation, masking real failures. The cleanup staticmethod was removed from LevanterTpuEvaluator in #2320 when checkpoint staging was replaced with direct GCS reads, but the caller was missed. Validated with pre-commit and pyrefly; no regression test added because exercising evaluate() meaningfully requires TPU + vLLM.

Fixes #4937