### PR TITLE
[iris] Drop fragile upper-bound timing assertions in test_utils

### DIFF
--- a/lib/iris/tests/test_utils.py
+++ b/lib/iris/tests/test_utils.py
@@ -54,7 +54,7 @@ def test_sentinel_file_concurrent_creation(tmp_path: Path) -> None:
     sentinel.wait(timeout=Duration.from_seconds(1.0))
     elapsed = time.monotonic() - start
 
-    assert 0.04 < elapsed < 0.2
+    assert elapsed > 0.04
     assert sentinel.is_set()
 
     thread.join()
@@ -109,6 +109,6 @@ def test_wait_for_condition_becomes_true() -> None:
     wait_for_condition(lambda: flag.is_set(), timeout=Duration.from_seconds(1.0))
     elapsed = time.monotonic() - start
 
-    assert 0.04 < elapsed < 0.2
+    assert elapsed > 0.04
 
     thread.join()


### PR DESCRIPTION
Remove the < 0.2s upper-bound checks from test_sentinel_file_concurrent_creation and test_wait_for_condition_becomes_true. In CI, thread scheduling delays pushed elapsed past 200ms, failing the assertion. The lower bound (> 0.04s) proves the function waited for the condition; the 1.0s function timeout catches hangs. The wall-clock ceiling adds no correctness value.