### PR TITLE
[iris] Tighten RPC stats histogram, redact previews, redesign dashboard panel

### DIFF
--- a/lib/iris/dashboard/src/components/controller/RpcStatsPanel.vue
+++ b/lib/iris/dashboard/src/components/controller/RpcStatsPanel.vue
@@ -4,17 +4,17 @@ import { useStatsRpc } from '@/composables/useRpc'
 import { useAutoRefresh, DEFAULT_REFRESH_MS } from '@/composables/useAutoRefresh'
 import { formatRelativeTime, timestampMs } from '@/utils/formatting'
 import InfoCard from '@/components/shared/InfoCard.vue'
-import DataTable, { type Column } from '@/components/shared/DataTable.vue'
 import type { GetRpcStatsResponse, RpcCallSample, RpcMethodStats } from '@/types/rpc'
 
 const { data, loading, error, refresh } = useStatsRpc<GetRpcStatsResponse>('GetRpcStats')
-
 useAutoRefresh(refresh, DEFAULT_REFRESH_MS)
 onMounted(refresh)
 
 type SortKey = 'method' | 'count' | 'errorCount' | 'p50' | 'p95' | 'p99' | 'max' | 'last'
 const sortKey = ref<SortKey>('p95')
 const sortDir = ref<'asc' | 'desc'>('desc')
+const expanded = ref<Set<string>>(new Set())
+const sampleTab = ref<Record<string, 'recent' | 'slow'>>({})
 
 function toNum(value: string | number | undefined): number {
   if (typeof value === 'number') return value
@@ -31,6 +31,9 @@ interface MethodRow {
   p99: number
   max: number
   last: number
+  buckets: number[]
+  bounds: number[]
+  totalDurationMs: number
 }
 
 function toRow(m: RpcMethodStats): MethodRow {
@@ -43,48 +46,78 @@ function toRow(m: RpcMethodStats): MethodRow {
     p99: m.p99Ms ?? 0,
     max: m.maxDurationMs ?? 0,
     last: timestampMs(m.lastCall),
+    buckets: (m.bucketCounts ?? []).map(toNum),
+    bounds: (m.bucketUpperBoundsMs ?? []).map(toNum),
+    totalDurationMs: m.totalDurationMs ?? 0,
   }
 }
 
-const methodRows = computed<MethodRow[]>(() => {
-  const rows = (data.value?.methods ?? []).map(toRow)
+const rows = computed<MethodRow[]>(() => {
+  const list = (data.value?.methods ?? []).map(toRow)
   const dir = sortDir.value === 'asc' ? 1 : -1
   const key = sortKey.value
-  return [...rows].sort((a, b) => {
+  return [...list].sort((a, b) => {
     if (key === 'method') return a.method.localeCompare(b.method) * dir
     return (a[key] - b[key]) * dir
   })
 })
 
-function onSort(key: string, dir: 'asc' | 'desc') {
-  sortKey.value = key as SortKey
-  sortDir.value = dir
+const slowByMethod = computed<Record<string, RpcCallSample[]>>(() => {
+  const out: Record<string, RpcCallSample[]> = {}
+  for (const s of data.value?.slowSamples ?? []) {
+    (out[s.method] ||= []).push(s)
+  }
+  for (const k of Object.keys(out)) out[k].reverse()
+  return out
+})
+
+const discoveryByMethod = computed<Record<string, RpcCallSample[]>>(() => {
+  const out: Record<string, RpcCallSample[]> = {}
+  for (const s of data.value?.discoverySamples ?? []) {
+    (out[s.method] ||= []).push(s)
+  }
+  for (const k of Object.keys(out)) out[k].reverse()
+  return out
+})
+
+const totalCount = computed(() => rows.value.reduce((a, r) => a + r.count, 0))
+const totalErrors = computed(() => rows.value.reduce((a, r) => a + r.errorCount, 0))
+const collectorStartedAt = computed(() => timestampMs(data.value?.collectorStartedAt))
+
+function toggleExpand(method: string) {
+  const next = new Set(expanded.value)
+  if (next.has(method)) next.delete(method)
+  else next.add(method)
+  expanded.value = next
+  if (!sampleTab.value[method]) sampleTab.value[method] = 'recent'
 }
 
-const columns: Column[] = [
-  { key: 'method', label: 'Method', sortable: true, mono: true },
-  { key: 'count', label: 'Count', sortable: true, align: 'right', mono: true },
-  { key: 'errorCount', label: 'Errors', sortable: true, align: 'right', mono: true },
-  { key: 'p50', label: 'p50 (ms)', sortable: true, align: 'right', mono: true },
-  { key: 'p95', label: 'p95 (ms)', sortable: true, align: 'right', mono: true },
-  { key: 'p99', label: 'p99 (ms)', sortable: true, align: 'right', mono: true },
-  { key: 'max', label: 'Max (ms)', sortable: true, align: 'right', mono: true },
-  { key: 'last', label: 'Last', sortable: true, align: 'right' },
-]
+function setSort(key: SortKey) {
+  if (sortKey.value === key) {
+    sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    sortDir.value = key === 'method' ? 'asc' : 'desc'
+  }
+}
 
 function fmtMs(value: number): string {
-  if (!value) return '-'
+  if (!value) return '—'
   if (value < 10) return value.toFixed(1)
-  return Math.round(value).toString()
+  if (value < 1000) return Math.round(value).toString()
+  return (value / 1000).toFixed(value < 10000 ? 2 : 1) + 's'
+}
+
+function fmtBound(ms: number): string {
+  if (!ms) return '+∞'
+  if (ms < 1000) return `${ms}ms`
+  return `${(ms / 1000).toFixed(ms % 1000 === 0 ? 0 : 1)}s`
 }
 
 function fmtSince(epochMs: number): string {
-  if (!epochMs) return '-'
+  if (!epochMs) return '—'
   return formatRelativeTime(epochMs)
 }
-
-const slowSamples = computed<RpcCallSample[]>(() => [...(data.value?.slowSamples ?? [])].reverse())
-const discoverySamples = computed<RpcCallSample[]>(() => [...(data.value?.discoverySamples ?? [])].reverse())
 
 function prettyPreview(raw: string | undefined): string {
   if (!raw) return ''
@@ -94,95 +127,349 @@ function prettyPreview(raw: string | undefined): string {
     return raw
   }
 }
+
+function methodLabel(method: string): string {
+  const slash = method.lastIndexOf('/')
+  return slash >= 0 ? method.slice(slash + 1) : method
+}
+
+function methodService(method: string): string {
+  const slash = method.lastIndexOf('/')
+  return slash >= 0 ? method.slice(0, slash) : ''
+}
+
+function sortIndicator(key: SortKey): string {
+  if (sortKey.value !== key) return ''
+  return sortDir.value === 'asc' ? '▲' : '▼'
+}
+
+interface Sparkbar {
+  height: number
+  count: number
+  upper: number
+  isInf: boolean
+}
+
+// Log-shade very small counts so a single tail sample remains visible
+// against a large mode bucket; pure linear scaling renders p99 tails as
+// invisible slivers.
+function sparkBars(row: MethodRow): Sparkbar[] {
+  const max = Math.max(...row.buckets, 1)
+  return row.buckets.map((c, i) => ({
+    height: c === 0 ? 0 : Math.max(6, Math.round((Math.log1p(c) / Math.log1p(max)) * 100)),
+    count: c,
+    upper: row.bounds[i] ?? 0,
+    isInf: (row.bounds[i] ?? 0) === 0,
+  }))
+}
+
+// Locate the bucket whose right edge first crosses `pct` ms, so we can
+// draw a p50/p95/p99 tick over the histogram.
+function percentileBucket(row: MethodRow, pct: number): number | null {
+  if (!pct) return null
+  for (let i = 0; i < row.bounds.length; i++) {
+    const upper = row.bounds[i]
+    if (upper === 0) return i
+    if (upper >= pct) return i
+  }
+  return row.bounds.length - 1
+}
+
+function markerLeft(row: MethodRow, pct: number): string | null {
+  const idx = percentileBucket(row, pct)
+  if (idx === null || !row.buckets.length) return null
+  return `${((idx + 0.5) / row.buckets.length) * 100}%`
+}
+
+function errorRate(row: MethodRow): string {
+  if (!row.count) return '0%'
+  const pct = (row.errorCount / row.count) * 100
+  if (pct === 0) return '0%'
+  if (pct < 0.1) return '<0.1%'
+  return pct.toFixed(pct < 10 ? 1 : 0) + '%'
+}
+
+function avgMs(row: MethodRow): number {
+  return row.count ? row.totalDurationMs / row.count : 0
+}
+
+function currentSamples(method: string, tab: 'recent' | 'slow'): RpcCallSample[] {
+  return tab === 'recent' ? (discoveryByMethod.value[method] ?? []) : (slowByMethod.value[method] ?? [])
+}
 </script>
 
 <template>
   <div class="space-y-4">
-    <div v-if="error" class="px-4 py-3 text-sm text-status-danger bg-status-danger-bg rounded-lg border border-status-danger-border">
+    <div
+      v-if="error"
+      class="px-4 py-3 text-sm text-status-danger bg-status-danger-bg rounded-lg border border-status-danger-border"
+    >
       {{ error }}
+    </div>
+
+    <!-- Summary strip -->
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-2">
+      <div class="rounded-lg border border-surface-border bg-surface px-3 py-2">
+        <div class="text-[10px] uppercase tracking-wider text-text-muted">Methods</div>
+        <div class="font-mono text-lg text-text">{{ rows.length }}</div>
+      </div>
+      <div class="rounded-lg border border-surface-border bg-surface px-3 py-2">
+        <div class="text-[10px] uppercase tracking-wider text-text-muted">Calls</div>
+        <div class="font-mono text-lg text-text">{{ totalCount.toLocaleString() }}</div>
+      </div>
+      <div class="rounded-lg border border-surface-border bg-surface px-3 py-2">
+        <div class="text-[10px] uppercase tracking-wider text-text-muted">Errors</div>
+        <div
+          class="font-mono text-lg"
+          :class="totalErrors > 0 ? 'text-status-danger' : 'text-text'"
+        >
+          {{ totalErrors.toLocaleString() }}
+        </div>
+      </div>
+      <div class="rounded-lg border border-surface-border bg-surface px-3 py-2">
+        <div class="text-[10px] uppercase tracking-wider text-text-muted">Since</div>
+        <div class="font-mono text-sm text-text pt-1">{{ fmtSince(collectorStartedAt) }}</div>
+      </div>
     </div>
 
     <InfoCard title="RPC Methods">
       <p class="text-xs text-text-muted mb-3">
-        Aggregate counters and latency percentiles per ControllerService RPC, since controller start.
-        Histogram buckets are coarse (1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000 ms, +inf).
+        Per-method counters, latency percentiles, and an inline histogram on a log scale
+        (3 buckets per octave, ≈1 ms → 60 s). Click a row to expand samples.
+        Request previews are redacted server-side for keys matching
+        <code class="font-mono">KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL</code>.
       </p>
-      <DataTable
-        :columns="columns"
-        :rows="methodRows"
-        :loading="loading && !data"
-        :sort-key="sortKey"
-        :sort-dir="sortDir"
-        :page-size="50"
-        empty-message="No RPCs recorded yet"
-        @sort="onSort"
+
+      <!-- Header -->
+      <div
+        class="grid items-center gap-x-3 px-2 py-1.5 text-[10px] uppercase tracking-wider text-text-muted border-b border-surface-border"
+        style="grid-template-columns: minmax(0,1fr) 72px 90px 64px 64px 64px 200px 72px"
       >
-        <template #cell-p50="{ row }">{{ fmtMs((row as MethodRow).p50) }}</template>
-        <template #cell-p95="{ row }">{{ fmtMs((row as MethodRow).p95) }}</template>
-        <template #cell-p99="{ row }">{{ fmtMs((row as MethodRow).p99) }}</template>
-        <template #cell-max="{ row }">{{ fmtMs((row as MethodRow).max) }}</template>
-        <template #cell-last="{ row }">{{ fmtSince((row as MethodRow).last) }}</template>
-      </DataTable>
-    </InfoCard>
+        <button class="text-left cursor-pointer hover:text-text" @click="setSort('method')">
+          Method <span class="text-accent">{{ sortIndicator('method') }}</span>
+        </button>
+        <button class="text-right cursor-pointer hover:text-text" @click="setSort('count')">
+          Count <span class="text-accent">{{ sortIndicator('count') }}</span>
+        </button>
+        <button class="text-right cursor-pointer hover:text-text" @click="setSort('errorCount')">
+          Err <span class="text-accent">{{ sortIndicator('errorCount') }}</span>
+        </button>
+        <button class="text-right cursor-pointer hover:text-text" @click="setSort('p50')">
+          p50 <span class="text-accent">{{ sortIndicator('p50') }}</span>
+        </button>
+        <button class="text-right cursor-pointer hover:text-text" @click="setSort('p95')">
+          p95 <span class="text-accent">{{ sortIndicator('p95') }}</span>
+        </button>
+        <button class="text-right cursor-pointer hover:text-text" @click="setSort('p99')">
+          p99 <span class="text-accent">{{ sortIndicator('p99') }}</span>
+        </button>
+        <div class="text-center">Distribution</div>
+        <button class="text-right cursor-pointer hover:text-text" @click="setSort('last')">
+          Last <span class="text-accent">{{ sortIndicator('last') }}</span>
+        </button>
+      </div>
 
-    <InfoCard title="Slow RPC samples">
-      <p class="text-xs text-text-muted mb-3">
-        Most recent calls slower than the 1000ms threshold (or any failure). Newest first.
-      </p>
-      <div v-if="!slowSamples.length" class="text-sm text-text-muted py-4">No slow calls recorded.</div>
-      <ul v-else class="space-y-3">
-        <li
-          v-for="(s, i) in slowSamples"
-          :key="i"
-          class="border border-surface-border rounded-md p-3 text-xs"
-        >
-          <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-            <span class="font-mono font-semibold">{{ s.method }}</span>
-            <span class="font-mono text-status-warning">{{ fmtMs(s.durationMs ?? 0) }}ms</span>
-            <span v-if="s.errorCode" class="font-mono text-status-danger">{{ s.errorCode }}</span>
-            <span class="text-text-muted">{{ fmtSince(timestampMs(s.timestamp)) }}</span>
-          </div>
-          <div class="text-text-muted mt-1 flex flex-wrap gap-x-3 gap-y-0.5">
-            <span v-if="s.caller"><strong>caller:</strong> <span class="font-mono">{{ s.caller }}</span></span>
-            <span v-if="s.peer"><strong>peer:</strong> <span class="font-mono">{{ s.peer }}</span></span>
-            <span v-if="s.userAgent"><strong>ua:</strong> <span class="font-mono">{{ s.userAgent }}</span></span>
-          </div>
-          <div v-if="s.errorMessage" class="mt-1 text-status-danger font-mono">{{ s.errorMessage }}</div>
-          <details v-if="s.requestPreview" class="mt-2">
-            <summary class="cursor-pointer text-text-muted">request preview</summary>
-            <pre class="mt-1 font-mono text-[11px] whitespace-pre-wrap break-all bg-surface-muted rounded p-2">{{ prettyPreview(s.requestPreview) }}</pre>
-          </details>
-        </li>
-      </ul>
-    </InfoCard>
+      <div v-if="loading && !data" class="text-sm text-text-muted py-4 text-center">Loading…</div>
+      <div v-else-if="!rows.length" class="text-sm text-text-muted py-4 text-center">
+        No RPCs recorded yet.
+      </div>
 
-    <InfoCard title="Sampled calls (discovery)">
-      <p class="text-xs text-text-muted mb-3">
-        One sample per method captured at most every 30 seconds regardless of latency, so you can see what a typical call looks like. Newest first.
-      </p>
-      <div v-if="!discoverySamples.length" class="text-sm text-text-muted py-4">No samples recorded yet.</div>
-      <ul v-else class="space-y-3">
-        <li
-          v-for="(s, i) in discoverySamples"
-          :key="i"
-          class="border border-surface-border rounded-md p-3 text-xs"
-        >
-          <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-            <span class="font-mono font-semibold">{{ s.method }}</span>
-            <span class="font-mono">{{ fmtMs(s.durationMs ?? 0) }}ms</span>
-            <span class="text-text-muted">{{ fmtSince(timestampMs(s.timestamp)) }}</span>
+      <div v-else class="divide-y divide-surface-border">
+        <div v-for="row in rows" :key="row.method">
+          <button
+            class="w-full grid items-center gap-x-3 px-2 py-2 text-sm text-left hover:bg-surface-raised transition-colors cursor-pointer"
+            style="grid-template-columns: minmax(0,1fr) 72px 90px 64px 64px 64px 200px 72px"
+            @click="toggleExpand(row.method)"
+          >
+            <div class="flex items-center gap-1.5 min-w-0">
+              <span
+                class="text-text-muted text-xs transition-transform inline-block w-3"
+                :class="{ 'rotate-90': expanded.has(row.method) }"
+              >▶</span>
+              <div class="min-w-0 truncate">
+                <span class="font-mono text-text">{{ methodLabel(row.method) }}</span>
+                <span
+                  v-if="methodService(row.method)"
+                  class="font-mono text-[10px] text-text-muted ml-1.5"
+                >{{ methodService(row.method) }}</span>
+              </div>
+            </div>
+            <div class="text-right font-mono text-text">{{ row.count.toLocaleString() }}</div>
+            <div
+              class="text-right font-mono"
+              :class="row.errorCount > 0 ? 'text-status-danger' : 'text-text-muted'"
+            >
+              <template v-if="row.errorCount > 0">{{ row.errorCount }} · {{ errorRate(row) }}</template>
+              <template v-else>—</template>
+            </div>
+            <div class="text-right font-mono text-text-secondary">{{ fmtMs(row.p50) }}</div>
+            <div class="text-right font-mono text-text">{{ fmtMs(row.p95) }}</div>
+            <div
+              class="text-right font-mono"
+              :class="row.p99 > 1000 ? 'text-status-warning' : 'text-text-secondary'"
+            >{{ fmtMs(row.p99) }}</div>
+            <div class="flex items-end h-8 gap-px bg-surface-sunken rounded px-0.5 relative overflow-hidden">
+              <div
+                v-for="(bar, i) in sparkBars(row)"
+                :key="i"
+                class="flex-1 min-w-[2px]"
+                :style="{ height: bar.height + '%' }"
+                :class="bar.count === 0
+                  ? 'bg-transparent'
+                  : (bar.isInf ? 'bg-status-danger' : 'bg-accent')"
+                :title="`≤ ${fmtBound(bar.upper)}: ${bar.count}`"
+              ></div>
+              <div
+                v-if="markerLeft(row, row.p50)"
+                class="absolute top-0 bottom-0 w-px bg-text-muted/60 pointer-events-none"
+                :style="{ left: markerLeft(row, row.p50)! }"
+                title="p50"
+              ></div>
+              <div
+                v-if="markerLeft(row, row.p95)"
+                class="absolute top-0 bottom-0 w-px bg-status-warning/80 pointer-events-none"
+                :style="{ left: markerLeft(row, row.p95)! }"
+                title="p95"
+              ></div>
+              <div
+                v-if="markerLeft(row, row.p99)"
+                class="absolute top-0 bottom-0 w-px bg-status-danger/80 pointer-events-none"
+                :style="{ left: markerLeft(row, row.p99)! }"
+                title="p99"
+              ></div>
+            </div>
+            <div class="text-right font-mono text-text-muted text-xs">{{ fmtSince(row.last) }}</div>
+          </button>
+
+          <div
+            v-if="expanded.has(row.method)"
+            class="px-4 py-3 bg-surface-sunken/60 border-t border-surface-border space-y-4"
+          >
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs">
+              <div class="border border-surface-border-subtle rounded px-2 py-1.5 bg-surface">
+                <div class="text-[10px] uppercase text-text-muted tracking-wider">avg</div>
+                <div class="font-mono">{{ fmtMs(avgMs(row)) }}</div>
+              </div>
+              <div class="border border-surface-border-subtle rounded px-2 py-1.5 bg-surface">
+                <div class="text-[10px] uppercase text-text-muted tracking-wider">max</div>
+                <div class="font-mono">{{ fmtMs(row.max) }}</div>
+              </div>
+              <div class="border border-surface-border-subtle rounded px-2 py-1.5 bg-surface">
+                <div class="text-[10px] uppercase text-text-muted tracking-wider">total time</div>
+                <div class="font-mono">{{ fmtMs(row.totalDurationMs) }}</div>
+              </div>
+              <div class="border border-surface-border-subtle rounded px-2 py-1.5 bg-surface">
+                <div class="text-[10px] uppercase text-text-muted tracking-wider">error rate</div>
+                <div
+                  class="font-mono"
+                  :class="row.errorCount > 0 ? 'text-status-danger' : ''"
+                >{{ errorRate(row) }}</div>
+              </div>
+            </div>
+
+            <div>
+              <div class="text-[10px] uppercase tracking-wider text-text-muted mb-1">
+                Latency histogram · counts per bucket upper bound
+              </div>
+              <div class="flex items-end h-24 gap-px bg-surface rounded border border-surface-border-subtle p-1 relative">
+                <div
+                  v-for="(bar, i) in sparkBars(row)"
+                  :key="i"
+                  class="flex-1 min-w-[3px] relative group/bar"
+                  :style="{ height: bar.height + '%' }"
+                  :class="bar.count === 0
+                    ? 'bg-transparent border-b border-surface-border-subtle/40'
+                    : (bar.isInf ? 'bg-status-danger' : 'bg-accent')"
+                >
+                  <span
+                    v-if="bar.count > 0"
+                    class="absolute left-1/2 -translate-x-1/2 -top-6 text-[10px] font-mono bg-surface border border-surface-border rounded px-1 py-0.5 opacity-0 group-hover/bar:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-10"
+                  >≤ {{ fmtBound(bar.upper) }} · {{ bar.count }}</span>
+                </div>
+              </div>
+              <div class="flex justify-between text-[9px] font-mono text-text-muted mt-1 px-1">
+                <span>{{ fmtBound(row.bounds[0] ?? 0) }}</span>
+                <span>{{ fmtBound(row.bounds[Math.floor(row.bounds.length / 2)] ?? 0) }}</span>
+                <span>+∞</span>
+              </div>
+              <div class="flex flex-wrap gap-3 text-[10px] font-mono text-text-muted mt-2">
+                <span class="flex items-center gap-1"><span class="inline-block w-2 h-2 bg-accent"></span>count</span>
+                <span class="flex items-center gap-1"><span class="inline-block w-2 h-2 bg-status-danger"></span>+∞ overflow</span>
+                <span class="flex items-center gap-1"><span class="inline-block w-px h-3 bg-text-muted/60"></span>p50</span>
+                <span class="flex items-center gap-1"><span class="inline-block w-px h-3 bg-status-warning/80"></span>p95</span>
+                <span class="flex items-center gap-1"><span class="inline-block w-px h-3 bg-status-danger/80"></span>p99</span>
+              </div>
+            </div>
+
+            <div>
+              <div class="flex items-center gap-1 mb-2 text-xs">
+                <button
+                  class="px-2 py-1 border-b-2 font-mono uppercase text-[10px] tracking-wider cursor-pointer"
+                  :class="(sampleTab[row.method] ?? 'recent') === 'recent'
+                    ? 'border-accent text-text'
+                    : 'border-transparent text-text-muted hover:text-text'"
+                  @click="sampleTab[row.method] = 'recent'"
+                >Recent · {{ (discoveryByMethod[row.method] ?? []).length }}</button>
+                <button
+                  class="px-2 py-1 border-b-2 font-mono uppercase text-[10px] tracking-wider cursor-pointer"
+                  :class="sampleTab[row.method] === 'slow'
+                    ? 'border-accent text-text'
+                    : 'border-transparent text-text-muted hover:text-text'"
+                  @click="sampleTab[row.method] = 'slow'"
+                >Slow &amp; errors · {{ (slowByMethod[row.method] ?? []).length }}</button>
+              </div>
+
+              <div
+                v-if="!currentSamples(row.method, sampleTab[row.method] ?? 'recent').length"
+                class="text-xs text-text-muted italic py-2"
+              >
+                {{ (sampleTab[row.method] ?? 'recent') === 'slow'
+                  ? 'No slow calls or errors captured for this method.'
+                  : 'No samples captured yet.' }}
+              </div>
+              <ul v-else class="space-y-1.5">
+                <li
+                  v-for="(s, i) in currentSamples(row.method, sampleTab[row.method] ?? 'recent')"
+                  :key="i"
+                  class="border border-surface-border-subtle rounded text-xs bg-surface"
+                >
+                  <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1 px-2 py-1.5">
+                    <span
+                      class="font-mono"
+                      :class="s.errorCode
+                        ? 'text-status-danger'
+                        : ((s.durationMs ?? 0) > 1000 ? 'text-status-warning' : 'text-text')"
+                    >{{ fmtMs(s.durationMs ?? 0) }}</span>
+                    <span v-if="s.errorCode" class="font-mono text-status-danger text-[10px] uppercase">{{ s.errorCode }}</span>
+                    <span class="text-text-muted">{{ fmtSince(timestampMs(s.timestamp)) }}</span>
+                    <span v-if="s.caller" class="text-text-muted">
+                      <span class="text-[10px] uppercase tracking-wider">caller</span>
+                      <span class="font-mono ml-1">{{ s.caller }}</span>
+                    </span>
+                    <span v-if="s.peer" class="text-text-muted">
+                      <span class="text-[10px] uppercase tracking-wider">peer</span>
+                      <span class="font-mono ml-1">{{ s.peer }}</span>
+                    </span>
+                  </div>
+                  <div v-if="s.errorMessage" class="px-2 pb-1.5 font-mono text-status-danger break-all">
+                    {{ s.errorMessage }}
+                  </div>
+                  <details v-if="s.requestPreview" class="px-2 pb-1.5">
+                    <summary class="cursor-pointer text-text-muted text-[10px] uppercase tracking-wider hover:text-text">
+                      request · <span class="normal-case tracking-normal">redacted preview</span>
+                    </summary>
+                    <pre class="mt-1 font-mono text-[11px] whitespace-pre-wrap break-all bg-surface-sunken rounded p-2 border border-surface-border-subtle">{{ prettyPreview(s.requestPreview) }}</pre>
+                    <div v-if="s.userAgent" class="mt-1 text-[10px] text-text-muted">
+                      <span class="uppercase tracking-wider">ua</span>
+                      <span class="font-mono ml-1">{{ s.userAgent }}</span>
+                    </div>
+                  </details>
+                </li>
+              </ul>
+            </div>
           </div>
-          <div class="text-text-muted mt-1 flex flex-wrap gap-x-3 gap-y-0.5">
-            <span v-if="s.caller"><strong>caller:</strong> <span class="font-mono">{{ s.caller }}</span></span>
-            <span v-if="s.peer"><strong>peer:</strong> <span class="font-mono">{{ s.peer }}</span></span>
-            <span v-if="s.userAgent"><strong>ua:</strong> <span class="font-mono">{{ s.userAgent }}</span></span>
-          </div>
-          <details v-if="s.requestPreview" class="mt-2">
-            <summary class="cursor-pointer text-text-muted">request preview</summary>
-            <pre class="mt-1 font-mono text-[11px] whitespace-pre-wrap break-all bg-surface-muted rounded p-2">{{ prettyPreview(s.requestPreview) }}</pre>
-          </details>
-        </li>
-      </ul>
+        </div>
+      </div>
     </InfoCard>
   </div>
 </template>

--- a/lib/iris/src/iris/cluster/redaction.py
+++ b/lib/iris/src/iris/cluster/redaction.py
@@ -7,9 +7,13 @@ Used on both the client (before capturing argv for bookkeeping) and the
 controller (when returning job requests via RPC).
 """
 
+import json
+import logging
 import re
 
 from iris.rpc import controller_pb2
+
+logger = logging.getLogger(__name__)
 
 SENSITIVE_ENV_KEY_RE = re.compile(r"KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL", re.IGNORECASE)
 REDACTED_VALUE = "**REDACTED**"
@@ -58,6 +62,35 @@ def redact_request_env_vars(
         if is_sensitive_env_key(key):
             env_vars[key] = REDACTED_VALUE
     return redacted
+
+
+def _redact_tree(node):
+    """Walk a parsed-JSON tree, redacting values under sensitive-looking keys."""
+    if isinstance(node, dict):
+        return {k: REDACTED_VALUE if is_sensitive_env_key(k) else _redact_tree(v) for k, v in node.items()}
+    if isinstance(node, list):
+        return [_redact_tree(v) for v in node]
+    return node
+
+
+def redact_json_preview(rendered: str) -> str:
+    """Return *rendered* with values under sensitive-looking keys replaced.
+
+    The input is arbitrary JSON (typically a protobuf rendered via
+    ``MessageToJson``). Any key matching :data:`SENSITIVE_ENV_KEY_RE` at
+    any depth has its value replaced with :data:`REDACTED_VALUE`; this also
+    covers map<string,string> fields like ``env_vars`` where secrets tend
+    to live. Unparseable input is returned unchanged so callers never lose
+    the preview entirely.
+    """
+    if not rendered:
+        return rendered
+    try:
+        tree = json.loads(rendered)
+    except ValueError:
+        logger.debug("redact_json_preview: input was not valid JSON, returning as-is")
+        return rendered
+    return json.dumps(_redact_tree(tree), separators=(",", ":"))
 
 
 def redact_submit_argv(argv: list[str]) -> list[str]:

--- a/lib/iris/src/iris/rpc/stats.py
+++ b/lib/iris/src/iris/rpc/stats.py
@@ -26,15 +26,36 @@ from connectrpc.request import RequestContext
 from google.protobuf.json_format import MessageToJson
 from google.protobuf.message import Message
 
+from iris.cluster.redaction import redact_json_preview
 from iris.rpc import stats_pb2, time_pb2
 from iris.rpc.auth import get_verified_identity
 
 logger = logging.getLogger(__name__)
 
-# Bucket upper bounds in milliseconds. A trailing 0 sentinel means "+inf".
-# Kept static so the dashboard can render consistent histograms across
-# restarts without needing to read them back.
-BUCKET_UPPER_BOUNDS_MS: tuple[int, ...] = (1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 0)
+
+def _make_bucket_bounds() -> tuple[int, ...]:
+    """Log-scale bucket upper bounds in ms with a +inf sentinel (trailing 0).
+
+    Buckets sit at 2**(k/3) — three buckets per octave, base ≈ 1.26 — from
+    1 ms up to ~60 s. That is an order of magnitude tighter than the legacy
+    1/2/5/10/... scale, so percentile estimates stay tight without bloating
+    storage (roughly 30 finite buckets). Rounded to integers and deduped.
+    """
+    bounds: list[int] = []
+    for k in range(0, 50):
+        b = round(2.0 ** (k / 3.0))
+        if b > 60000:
+            break
+        if not bounds or b > bounds[-1]:
+            bounds.append(b)
+    bounds.append(0)  # +inf sentinel
+    return tuple(bounds)
+
+
+# A trailing 0 sentinel in the tuple means "+inf". Kept static so the
+# dashboard can render consistent histograms across restarts without
+# needing to read them back.
+BUCKET_UPPER_BOUNDS_MS: tuple[int, ...] = _make_bucket_bounds()
 
 # Default sample ring sizes. Tuned so the whole structure stays <1 MB even
 # with many methods; request previews are capped separately below.
@@ -241,6 +262,7 @@ def _render_preview(request: Message | None, max_bytes: int) -> str:
     except Exception:
         logger.debug("Failed to render request preview for %s", type(request).__name__, exc_info=True)
         return ""
+    rendered = redact_json_preview(rendered)
     return _truncate(rendered, max_bytes)
 
 

--- a/lib/iris/tests/cluster/test_redaction.py
+++ b/lib/iris/tests/cluster/test_redaction.py
@@ -3,11 +3,35 @@
 
 """Tests for iris.cluster.redaction."""
 
+import json
+
 from iris.cluster.redaction import (
     REDACTED_VALUE,
     is_sensitive_env_key,
+    redact_json_preview,
     redact_submit_argv,
 )
+
+
+def test_redact_json_preview_redacts_nested_sensitive_keys():
+    raw = json.dumps(
+        {
+            "name": "train-job",
+            "environment": {"env_vars": {"HF_TOKEN": "hf_xyz", "LOG_LEVEL": "info"}},
+            "metadata": [{"api_key": "sk-abc"}, {"benign": "ok"}],
+        }
+    )
+    out = json.loads(redact_json_preview(raw))
+    assert out["environment"]["env_vars"]["HF_TOKEN"] == REDACTED_VALUE
+    assert out["environment"]["env_vars"]["LOG_LEVEL"] == "info"
+    assert out["metadata"][0]["api_key"] == REDACTED_VALUE
+    assert out["metadata"][1]["benign"] == "ok"
+    assert out["name"] == "train-job"
+
+
+def test_redact_json_preview_passes_through_invalid_json():
+    assert redact_json_preview("not json{{{") == "not json{{{"
+    assert redact_json_preview("") == ""
 
 
 def test_is_sensitive_env_key_matches_common_secret_names():

--- a/lib/iris/tests/rpc/test_stats.py
+++ b/lib/iris/tests/rpc/test_stats.py
@@ -31,7 +31,7 @@ def _ctx() -> Mock:
 def test_collector_records_counts_and_histogram():
     collector = RpcStatsCollector(slow_threshold_ms=1000)
 
-    for d in (0.5, 3, 12, 70, 900, 1500, 20000):
+    for d in (0.5, 3, 12, 70, 900, 1500, 200000):
         collector.record(method="ListJobs", duration_ms=d, request=_request(), ctx=_ctx())
 
     snap = collector.snapshot_proto()
@@ -43,12 +43,13 @@ def test_collector_records_counts_and_histogram():
     # Buckets echoed for the UI and sum to count.
     assert list(m.bucket_upper_bounds_ms) == list(BUCKET_UPPER_BOUNDS_MS)
     assert sum(m.bucket_counts) == 7
-    # Bucket placements: 0.5 → ≤1, 3 → ≤5, 12 → ≤20, 70 → ≤100, 900 → ≤1000, 1500 → ≤2000, 20000 → +inf.
-    assert m.bucket_counts[0] == 1  # ≤1
-    assert m.bucket_counts[-1] == 1  # +inf
+    # 0.5ms lands in the first bucket (≤1ms); 200000ms is above the largest
+    # finite bound (~52s) and falls into the +inf sentinel bucket.
+    assert m.bucket_counts[0] == 1
+    assert m.bucket_counts[-1] == 1
     # p99 picks up the large tail; p50 stays small.
     assert m.p99_ms >= m.p95_ms >= m.p50_ms
-    assert m.max_duration_ms == 20000
+    assert m.max_duration_ms == 200000
 
 
 def test_collector_captures_slow_samples_and_respects_bound():


### PR DESCRIPTION
Replace coarse 1/2/5/10/... histogram buckets with a log-scale schedule at 3 buckets per octave (base ~1.26) from 1ms to ~60s so percentile estimates stay tight across the full range. Sanitize request previews server-side via the existing env-var redaction regex. Redesign RpcStatsPanel.vue with inline per-method sparkline histograms (p50/p95/p99 ticks), expandable rows that scope samples to one method, and a Recent / Slow-&-errors tab so sample lists stop piling up.