### PR TITLE
[Zephyr] Fix bug where counter flushing thread was given dummy context

### DIFF
--- a/lib/zephyr/src/zephyr/subprocess_worker.py
+++ b/lib/zephyr/src/zephyr/subprocess_worker.py
@@ -132,16 +132,11 @@ def execute_shard(task_file: str, result_file: str) -> None:
     # a Python traceback on stderr instead of a bare ``returncode < 0``.
     configure_logging(level=logging.INFO)
 
-    ctx = _SubprocessWorkerContext("", "")
     counter_file = f"{result_file}.counters"
     stop_event = threading.Event()
-    flusher = threading.Thread(
-        target=_periodic_counter_writer,
-        args=(stop_event, ctx, counter_file, SUBPROCESS_COUNTER_FLUSH_INTERVAL),
-        daemon=True,
-        name="zephyr-subprocess-counter-flusher",
-    )
+    flusher: threading.Thread | None = None
     result_or_error: Any
+    ctx: _SubprocessWorkerContext | None = None
     try:
         with open(task_file, "rb") as f:
             task, chunk_prefix, execution_id = cloudpickle.load(f)
@@ -149,6 +144,12 @@ def execute_shard(task_file: str, result_file: str) -> None:
         ctx = _SubprocessWorkerContext(chunk_prefix, execution_id)
         _worker_ctx_var.set(ctx)
 
+        flusher = threading.Thread(
+            target=_periodic_counter_writer,
+            args=(stop_event, ctx, counter_file, SUBPROCESS_COUNTER_FLUSH_INTERVAL),
+            daemon=True,
+            name="zephyr-subprocess-counter-flusher",
+        )
         flusher.start()
 
         stage_ctx = StageContext(
@@ -176,18 +177,17 @@ def execute_shard(task_file: str, result_file: str) -> None:
         # at the subprocess origin. Attach the formatted traceback as a note
         # — ``__notes__`` survives pickling and Python prints it inline when
         # the exception eventually propagates.
-        import traceback
-
         logger.exception("Subprocess shard execution failed")
         e.add_note(f"--- subprocess traceback ---\n{traceback.format_exc().rstrip()}")
         result_or_error = e
     finally:
         stop_event.set()
-        if flusher.is_alive():
+        if flusher is not None and flusher.is_alive():
             flusher.join(timeout=2.0)
 
     with open(result_file, "wb") as f:
-        cloudpickle.dump((result_or_error, dict(ctx._counters)), f)
+        counters_out = dict(ctx._counters) if ctx is not None else {}
+        cloudpickle.dump((result_or_error, counters_out), f)
 
 
 def main() -> None:

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -17,6 +17,57 @@ from zephyr.dataset import Dataset
 from zephyr.execution import CounterSnapshot, ZephyrContext, zephyr_worker_ctx
 
 
+def test_counter_flusher(tmp_path):
+    """Counter file flushed during shard execution reflects actual counter increments."""
+    import cloudpickle
+    import zephyr.subprocess_worker as sw
+
+    from zephyr import counters
+    from zephyr.execution import ListShard, ShardTask
+    from zephyr.plan import Map
+    from zephyr.shuffle import MemChunk
+
+    original_interval = sw.SUBPROCESS_COUNTER_FLUSH_INTERVAL
+    sw.SUBPROCESS_COUNTER_FLUSH_INTERVAL = 0.01  # flush aggressively during the test
+
+    try:
+
+        def counting_map(stream):
+            for item in stream:
+                counters.increment("items", 1)
+                time.sleep(0.05)  # longer than flush interval — guarantees ≥1 flush
+                yield item
+
+        chunk_prefix = str(tmp_path / "chunks")
+        execution_id = "test-exec"
+        task = ShardTask(
+            shard_idx=0,
+            total_shards=1,
+            shard=ListShard(refs=[MemChunk([1, 2, 3])]),
+            operations=[Map(fn=counting_map)],
+            stage_name="test",
+        )
+
+        task_file = str(tmp_path / "task.pkl")
+        result_file = str(tmp_path / "result.pkl")
+        counter_file = f"{result_file}.counters"
+
+        with open(task_file, "wb") as f:
+            cloudpickle.dump((task, chunk_prefix, execution_id), f)
+
+        sw.execute_shard(task_file, result_file)
+
+        assert Path(counter_file).exists(), "counter file was never written — flusher did not run"
+        with open(counter_file, "rb") as f:
+            flushed = cloudpickle.load(f)
+        assert flushed.get("items", 0) > 0, (
+            f"counter file is empty ({flushed!r}); flusher likely held a dummy context "
+            "instead of the real one created from the task file"
+        )
+    finally:
+        sw.SUBPROCESS_COUNTER_FLUSH_INTERVAL = original_interval
+
+
 def test_simple_map(zephyr_ctx):
     """Map pipeline produces correct results."""
     ds = Dataset.from_list([1, 2, 3]).map(lambda x: x * 2)


### PR DESCRIPTION
The thread that flushed the Zephyr worker context to disk was being given a dummy context, different from the one the worker was actually given. This meant the counters that were flushed to disk were always empty, since they were being incremented on a different object.