### PR TITLE
zephyr: non-preemptible coordinator defaults, 2g RAM

### DIFF
--- a/lib/marin/src/marin/processing/classification/deduplication/dedup_commons.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/dedup_commons.py
@@ -9,7 +9,6 @@ import pyarrow as pa
 import pyarrow.json as pa_json
 import wandb
 
-from fray.v2 import ResourceConfig
 from marin.utilities.wandb_utils import init_wandb
 from marin.utils import fsspec_glob, rebase_file_path
 from zephyr import counters, write_parquet_file
@@ -18,7 +17,6 @@ from zephyr.readers import SUPPORTED_EXTENSIONS, open_file
 logger = logging.getLogger(__name__)
 
 DEFAULT_FILETYPES: list[str] = ["jsonl", "jsonl.gz", "jsonl.zst", "parquet"]
-DEFAULT_COORDINATOR_RESOURCES: ResourceConfig = ResourceConfig(cpu=1, ram="5g")
 
 
 class DedupMode(StrEnum):

--- a/lib/marin/src/marin/processing/classification/deduplication/exact.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/exact.py
@@ -5,7 +5,6 @@ from typing import Any, TypeVar
 
 from collections.abc import Iterator
 from marin.processing.classification.deduplication.dedup_commons import (
-    DEFAULT_COORDINATOR_RESOURCES,
     DEFAULT_FILETYPES,
     DedupMode,
     _collect_input_files,
@@ -76,12 +75,14 @@ def dedup_exact_paragraph(
         ]
         return dupekit.transform(batch, pipeline)
 
-    ctx = ZephyrContext(
-        name="exact-para-dedup",
-        max_workers=max_parallelism,
-        resources=worker_resources or ResourceConfig(cpu=1, ram="32g", disk="5g"),
-        coordinator_resources=coordinator_resources or DEFAULT_COORDINATOR_RESOURCES,
-    )
+    ctx_kwargs: dict = {
+        "name": "exact-para-dedup",
+        "max_workers": max_parallelism,
+        "resources": worker_resources or ResourceConfig(cpu=1, ram="32g", disk="5g"),
+    }
+    if coordinator_resources is not None:
+        ctx_kwargs["coordinator_resources"] = coordinator_resources
+    ctx = ZephyrContext(**ctx_kwargs)
 
     def aggregate_and_write_to_corresponding_files(file_idx: int, records: Iterator[dict]) -> dict:
         # NOTE: all records belong to the specific file and are sorted by doc_id
@@ -208,12 +209,14 @@ def dedup_exact_document(
         ]
         return dupekit.transform(batch, pipeline)
 
-    ctx = ZephyrContext(
-        name="exact-doc-dedup",
-        max_workers=max_parallelism,
-        resources=worker_resources or ResourceConfig(cpu=1, ram="32g", disk="5g"),
-        coordinator_resources=coordinator_resources or DEFAULT_COORDINATOR_RESOURCES,
-    )
+    ctx_kwargs: dict = {
+        "name": "exact-doc-dedup",
+        "max_workers": max_parallelism,
+        "resources": worker_resources or ResourceConfig(cpu=1, ram="32g", disk="5g"),
+    }
+    if coordinator_resources is not None:
+        ctx_kwargs["coordinator_resources"] = coordinator_resources
+    ctx = ZephyrContext(**ctx_kwargs)
 
     aggregate_and_write = make_document_dedup_aggregator(
         idx_to_path=idx_to_path,

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
@@ -45,10 +45,7 @@ from zephyr import Dataset, ZephyrContext, counters, write_parquet_file
 from marin.execution.artifact import Artifact
 from marin.execution.step_spec import StepSpec
 from marin.processing.classification.deduplication.connected_components import connected_components
-from marin.processing.classification.deduplication.dedup_commons import (
-    DEFAULT_COORDINATOR_RESOURCES,
-    _load_batches,
-)
+from marin.processing.classification.deduplication.dedup_commons import _load_batches
 from marin.processing.classification.deduplication.fuzzy_minhash import MinHashAttrData, MinHashParams
 from marin.utils import fsspec_glob
 
@@ -283,12 +280,14 @@ def compute_fuzzy_dups_attrs(
         params,
     )
 
-    ctx = ZephyrContext(
-        name="fuzzy-dups",
-        max_workers=max_parallelism,
-        resources=worker_resources or ResourceConfig(cpu=1, ram="32g", disk="5g"),
-        coordinator_resources=coordinator_resources or DEFAULT_COORDINATOR_RESOURCES,
-    )
+    ctx_kwargs: dict = {
+        "name": "fuzzy-dups",
+        "max_workers": max_parallelism,
+        "resources": worker_resources or ResourceConfig(cpu=1, ram="32g", disk="5g"),
+    }
+    if coordinator_resources is not None:
+        ctx_kwargs["coordinator_resources"] = coordinator_resources
+    ctx = ZephyrContext(**ctx_kwargs)
 
     # Cap shard count at max_parallelism. Each group reads its attr files
     # sequentially and emits bucket records; file_idx is preserved on the entry

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -1482,9 +1482,7 @@ class ZephyrContext:
             min(max_workers, num_shards), computed at first execute(). If None,
             defaults to os.cpu_count() for LocalClient, or 128 for distributed clients.
         resources: Resource config per worker.
-        coordinator_resources: Resource config for the coordinator job. The coordinator
-            accumulates scatter manifests for all shards in memory; increase ram for
-            large pipelines (many shards). Defaults to 5 GB.
+        coordinator_resources: Resource config for the coordinator job. Defaults to 2 GB.
         chunk_storage_prefix: Storage prefix for intermediate chunks. If None, defaults
             to MARIN_PREFIX/tmp/zephyr or /tmp/zephyr.
         name: Descriptive name for this context, used in actor group names for debugging.
@@ -1500,7 +1498,7 @@ class ZephyrContext:
     max_workers: int | None = None
     resources: ResourceConfig = field(default_factory=lambda: ResourceConfig(cpu=1, ram="1g"))
     coordinator_resources: ResourceConfig = field(
-        default_factory=lambda: ResourceConfig(cpu=1, ram="5g", preemptible=False)
+        default_factory=lambda: ResourceConfig(cpu=1, ram="2g", preemptible=False)
     )
     chunk_storage_prefix: str | None = None
     name: str = ""

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -1499,7 +1499,9 @@ class ZephyrContext:
     client: Client | None = None
     max_workers: int | None = None
     resources: ResourceConfig = field(default_factory=lambda: ResourceConfig(cpu=1, ram="1g"))
-    coordinator_resources: ResourceConfig = field(default_factory=lambda: ResourceConfig(cpu=1, ram="5g"))
+    coordinator_resources: ResourceConfig = field(
+        default_factory=lambda: ResourceConfig(cpu=1, ram="5g", preemptible=False)
+    )
     chunk_storage_prefix: str | None = None
     name: str = ""
     no_workers_timeout: float | None = None


### PR DESCRIPTION
* default coordinator to `preemptible=False` so the long-lived orchestrator survives spot reclamation
* lower default coordinator RAM from 5g to 2g — sidecar-direct-read removed in-memory scatter manifest consolidation[^1]
* remove `DEFAULT_COORDINATOR_RESOURCES` from `exact.py` and `fuzzy_dups.py`; zephyr default now fits dedup
  * callers can still pass `coordinator_resources` explicitly

[^1]: `ResourceConfig.preemptible=False` is already plumbed through fray's `convert_constraints()` to iris scheduling.