### PR TITLE
zephyr: row-level filtering in iter_parquet_row_groups

### DIFF
--- a/lib/zephyr/src/zephyr/readers.py
+++ b/lib/zephyr/src/zephyr/readers.py
@@ -71,12 +71,23 @@ def iter_parquet_row_groups(
         columns: Columns to read (``None`` for all).
         row_start: First row to include (inclusive, before filtering).
         row_end: Last row to include (exclusive, before filtering).
-        equality_predicates: Column-value pairs for statistics-based row group
-            skipping.  Row groups whose min/max statistics exclude the target
-            value are not read at all.
+        equality_predicates: Column-value pairs for row group skipping and
+            row-level filtering.  Row groups whose min/max statistics exclude
+            the target value are not read at all, and within matching groups
+            only rows where every predicate column equals its target are kept.
     """
     pf = pq.ParquetFile(source) if isinstance(source, str) else source
     has_row_range = row_start is not None and row_end is not None
+
+    # If caller requests specific columns, ensure predicate columns are
+    # also read so row-level filtering works; drop them before yielding.
+    read_columns = columns
+    drop_columns: list[str] = []
+    if columns is not None and equality_predicates:
+        extra = [c for c in equality_predicates if c not in columns]
+        if extra:
+            read_columns = list(columns) + extra
+            drop_columns = extra
 
     cumulative_rows = 0
 
@@ -97,7 +108,7 @@ def iter_parquet_row_groups(
             if rg_start >= row_end:
                 return
 
-        table = pf.read_row_group(i, columns=columns)
+        table = pf.read_row_group(i, columns=read_columns)
 
         if has_row_range:
             assert row_start is not None and row_end is not None
@@ -106,6 +117,13 @@ def iter_parquet_row_groups(
                 local_start = max(0, row_start - rg_start)
                 local_end = min(rg_num_rows, row_end - rg_start)
                 table = table.slice(local_start, local_end - local_start)
+
+        if equality_predicates:
+            for col_name, value in equality_predicates.items():
+                mask = pa.compute.equal(table.column(col_name), value)
+                table = table.filter(mask)
+            if drop_columns:
+                table = table.drop(drop_columns)
 
         if len(table) > 0:
             yield table

--- a/lib/zephyr/tests/test_readers.py
+++ b/lib/zephyr/tests/test_readers.py
@@ -151,6 +151,30 @@ def test_iter_parquet_row_groups_skips_all_non_matching(tmp_path):
     assert tables == []
 
 
+def test_iter_parquet_row_groups_filters_within_row_group(tmp_path):
+    """Row-level filtering when a row group contains multiple predicate values."""
+    path = str(tmp_path / "mixed.parquet")
+    # Single row group with mixed shard values
+    rows = [{"shard": s, "val": f"s{s}-{i}"} for s in range(3) for i in range(2)]
+    pq.write_table(pa.Table.from_pylist(rows), path, row_group_size=100)
+
+    tables = list(iter_parquet_row_groups(path, equality_predicates={"shard": 1}))
+    assert len(tables) == 1
+    assert tables[0].column("val").to_pylist() == ["s1-0", "s1-1"]
+
+
+def test_iter_parquet_row_groups_predicate_columns_dropped(tmp_path):
+    """Predicate columns not in requested columns are read for filtering then dropped."""
+    path = str(tmp_path / "drop.parquet")
+    rows = [{"shard": s, "data": f"d{s}"} for s in range(3)]
+    pq.write_table(pa.Table.from_pylist(rows), path, row_group_size=100)
+
+    tables = list(iter_parquet_row_groups(path, columns=["data"], equality_predicates={"shard": 2}))
+    assert len(tables) == 1
+    assert tables[0].column_names == ["data"]
+    assert tables[0].column("data").to_pylist() == ["d2"]
+
+
 def test_load_parquet_no_dataset_api(tmp_path, monkeypatch):
     """Verify that load_parquet does NOT import pyarrow.dataset."""
     import sys


### PR DESCRIPTION
* `equality_predicates` in `iter_parquet_row_groups` now filter at the row level, not just skip row groups via min/max stats
* matching groups used to return all their rows, forcing callers to post-filter — now rows where any predicate column doesn't match are dropped in-reader
* predicate columns not present in the caller's `columns` list are read temporarily for filtering, then dropped before yielding[^1]

[^1]: so passing `columns=["data"]` with `equality_predicates={"shard": 2}` still yields a table with only the `data` column.