### PR TITLE
[grug] Add configurable MoE implementation

### DIFF
--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -28,7 +28,7 @@ except ModuleNotFoundError:
 from jaxtyping import Array, Float, Int, PRNGKeyArray
 
 from levanter.grug.attention import AttentionMask, RotaryConfig, align_kv_heads, apply_rotary_embedding, attention
-from levanter.grug.grug_moe import MoeActivation, moe_mlp
+from levanter.grug.grug_moe import MoeActivation, MoeImplementation, moe_mlp
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
 from levanter.grug.sharding import Pembed_vocab, Plm_head, unshard
 from levanter.tracker.histogram import Histogram
@@ -72,6 +72,7 @@ class GrugModelConfig:
     initializer_std: float = 0.02
     qk_mult: float = 1.0
     router_z_loss_coef: float = 0.001
+    moe_implementation: MoeImplementation | None = None
     rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
 
     def __post_init__(self) -> None:
@@ -397,6 +398,7 @@ class MoEMLP(eqx.Module):
             self.w_gate_up,
             self.w_down,
             activation=ActivationFunctionEnum.silu,
+            implementation=self.cfg.moe_implementation,
             mesh=get_abstract_mesh(),
             capacity_factor=_DEFAULT_EP_CAPACITY_FACTOR,
         )

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -146,6 +146,42 @@ def test_grug_variant_one_step_contract_lowers_with_default_ctor(variant: str):
     assert out_watch_shape is None
 
 
+def test_grug_moe_variant_threads_moe_implementation_to_kernel():
+    train_module = importlib.import_module("experiments.grug.moe.train")
+    model_module = importlib.import_module("experiments.grug.moe.model")
+    make_train_step = train_module._make_train_step
+    initial_state = train_module.initial_state
+    mesh_fn = getattr(model_module, "debug_mesh_and_token_pspec", None)
+    if mesh_fn is None:
+        raise AssertionError("experiments.grug.moe.model must define debug_mesh_and_token_pspec")
+
+    cfg = _small_model_config(model_module.GrugModelConfig, vocab_size=1024, seq_len=4)
+    cfg = dataclasses.replace(cfg, moe_implementation="ragged_all_to_all")
+    optimizer = optax.adam(1e-2)
+    mp = jmp.get_policy("f32")
+    train_step = make_train_step(optimizer, mp, z_loss_weight=0.0, ema_beta=None)
+    mesh, token_pspec = mesh_fn(num_devices=4)
+    batch = GrugLmExample(
+        tokens=jnp.zeros((8, 4), dtype=jnp.int32),
+        loss_weight=jnp.ones((8, 4), dtype=jnp.float32),
+        attn_mask=GrugAttentionMask.causal(),
+    )
+
+    def one_step():
+        sharded_batch = dataclasses.replace(
+            batch,
+            tokens=jax.sharding.reshard(batch.tokens, token_pspec),
+            loss_weight=jax.sharding.reshard(batch.loss_weight, token_pspec),
+        )
+        state = initial_state(cfg, optimizer=optimizer, mp=mp, key=jax.random.PRNGKey(0), ema_beta=None)
+        return train_step(state, sharded_batch, compute_watch=False)
+
+    with _reset_abstract_mesh(), use_abstract_mesh(mesh):
+        closed_jaxpr, _, _ = eqx.filter_make_jaxpr(one_step)()
+
+    assert "ragged_all_to_all" in str(closed_jaxpr)
+
+
 @pytest.mark.parametrize(
     "variant",
     _discover_grug_variants_with_model_and_train(),


### PR DESCRIPTION
Thread the grug MoE config through to `moe_mlp` so experiment code can explicitly choose ring or ragged dispatch. Adds a contract test that lowers the MoE variant with ragged dispatch and checks the `ragged_all_to_all` path is selected.

Part of #4697