### PR TITLE
ferries: weekly datakit nemotron ferry

### DIFF
--- a/.github/workflows/marin-datakit-nemotron-ferry.yaml
+++ b/.github/workflows/marin-datakit-nemotron-ferry.yaml
@@ -68,7 +68,7 @@ jobs:
           JOB_ID=$(.venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
             job run --no-wait \
             --region=europe-west4 \
-            --memory=3G --disk=4G --cpu=1 --extra=cpu \
+            --memory=3G --disk=5G --cpu=1 --extra=cpu \
             --priority production \
             -e SMOKE_RUN_ID "$SMOKE_RUN_ID" \
             -e FERRY_STATUS_PATH "$FERRY_STATUS_PATH" \

--- a/.github/workflows/marin-datakit-nemotron-ferry.yaml
+++ b/.github/workflows/marin-datakit-nemotron-ferry.yaml
@@ -68,7 +68,7 @@ jobs:
           JOB_ID=$(.venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
             job run --no-wait \
             --region=europe-west4 \
-            --memory=2G --disk=4G --cpu=1 --extra=cpu \
+            --memory=3G --disk=4G --cpu=1 --extra=cpu \
             --priority production \
             -e SMOKE_RUN_ID "$SMOKE_RUN_ID" \
             -e FERRY_STATUS_PATH "$FERRY_STATUS_PATH" \

--- a/.github/workflows/marin-datakit-nemotron-ferry.yaml
+++ b/.github/workflows/marin-datakit-nemotron-ferry.yaml
@@ -1,4 +1,4 @@
-name: Marin - Datakit Nemotron Smoke
+name: Marin - Datakit Nemotron Ferry
 
 on:
   schedule:
@@ -9,15 +9,15 @@ permissions:
   contents: read
 
 jobs:
-  datakit-nemotron-smoke:
+  datakit-nemotron-ferry:
     runs-on: ubuntu-latest
     timeout-minutes: 1440  # 24h — nemotron medium is ~3.4 TiB
     concurrency:
-      group: datakit-nemotron-smoke
+      group: datakit-nemotron-ferry
       cancel-in-progress: true
     env:
-      SMOKE_RUN_ID: datakit-nemotron-smoke-${{ github.run_id }}-${{ github.run_attempt }}
-      FERRY_STATUS_PATH: gs://marin-tmp-eu-west4/ttl=1d/ci/datakit-nemotron-smoke-${{ github.run_id }}-${{ github.run_attempt }}/ferry_run_status.json
+      SMOKE_RUN_ID: datakit-nemotron-ferry-${{ github.run_id }}-${{ github.run_attempt }}
+      FERRY_STATUS_PATH: gs://marin-tmp-eu-west4/ttl=1d/ci/datakit-nemotron-ferry-${{ github.run_id }}-${{ github.run_attempt }}/ferry_run_status.json
       WANDB_ENTITY: marin-community
       WANDB_PROJECT: marin
       IRIS_CONFIG: lib/iris/examples/marin.yaml
@@ -61,7 +61,7 @@ jobs:
           chmod 600 ~/.ssh/google_compute_engine
           chmod 644 ~/.ssh/google_compute_engine.pub
 
-      - name: Submit datakit nemotron smoke ferry
+      - name: Submit datakit nemotron ferry
         id: submit
         shell: bash -l {0}
         run: |
@@ -83,7 +83,7 @@ jobs:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
-      - name: Wait for datakit nemotron smoke ferry
+      - name: Wait for datakit nemotron ferry
         shell: bash -l {0}
         run: |
           JOB_ID="${{ steps.submit.outputs.job_id }}"
@@ -128,14 +128,14 @@ jobs:
   # Separate job so Slack always fires, even if the main job is force-killed
   # after its grace window. See the datakit-smoke workflow for rationale.
   notify-slack:
-    needs: datakit-nemotron-smoke
-    if: always() && (needs.datakit-nemotron-smoke.result == 'failure' || needs.datakit-nemotron-smoke.result == 'cancelled') && github.event_name == 'schedule'
+    needs: datakit-nemotron-ferry
+    if: always() && (needs.datakit-nemotron-ferry.result == 'failure' || needs.datakit-nemotron-ferry.result == 'cancelled') && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          TEXT: ":red_circle: *Datakit Nemotron Smoke failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          TEXT: ":red_circle: *Datakit Nemotron Ferry failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         run: |
           PAYLOAD=$(python3 -c "import sys,json; print(json.dumps({'text': sys.stdin.read()}))" <<< "$TEXT")
           curl -sf -X POST -H 'Content-Type: application/json' -d "$PAYLOAD" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/marin-datakit-nemotron-smoke.yaml
+++ b/.github/workflows/marin-datakit-nemotron-smoke.yaml
@@ -1,0 +1,188 @@
+name: Marin - Datakit Nemotron Smoke
+
+on:
+  schedule:
+    - cron: '0 1 * * 1'  # Weekly, Monday 01:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write    # claude triage files issues
+  id-token: write  # claude-code-action OIDC
+
+jobs:
+  datakit-nemotron-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1440  # 24h — nemotron medium is ~3.4 TiB
+    concurrency:
+      group: datakit-nemotron-smoke
+      cancel-in-progress: true
+    env:
+      SMOKE_RUN_ID: datakit-nemotron-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+      FERRY_STATUS_PATH: gs://marin-tmp-eu-west4/ttl=1d/ci/datakit-nemotron-smoke-${{ github.run_id }}-${{ github.run_attempt }}/ferry_run_status.json
+      WANDB_ENTITY: marin-community
+      WANDB_PROJECT: marin
+      IRIS_CONFIG: lib/iris/examples/marin.yaml
+      IRIS_CONTROLLER_SERVICE_ACCOUNT: iris-controller@hai-gcp-models.iam.gserviceaccount.com
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-packages --extra=cpu --no-default-groups
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Install SSH key
+        env:
+          SSH_KEY: ${{ secrets.IRIS_CI_GCP_SSH_KEY }}
+          SSH_KEY_PUB: ${{ secrets.IRIS_CI_GCP_SSH_KEY_PUB }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/google_compute_engine
+          printf '%s\n' "$SSH_KEY_PUB" > ~/.ssh/google_compute_engine.pub
+          chmod 600 ~/.ssh/google_compute_engine
+          chmod 644 ~/.ssh/google_compute_engine.pub
+
+      - name: Submit datakit nemotron smoke ferry
+        id: submit
+        shell: bash -l {0}
+        run: |
+          JOB_ID=$(.venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
+            job run --no-wait \
+            --region=europe-west4 \
+            --memory=2G --disk=4G --cpu=1 --extra=cpu \
+            --priority production \
+            -e SMOKE_RUN_ID "$SMOKE_RUN_ID" \
+            -e FERRY_STATUS_PATH "$FERRY_STATUS_PATH" \
+            -e WANDB_ENTITY "$WANDB_ENTITY" \
+            -e WANDB_PROJECT "$WANDB_PROJECT" \
+            -e WANDB_API_KEY "$WANDB_API_KEY" \
+            -e HF_TOKEN "$HF_TOKEN" \
+            -- python -m experiments.ferries.datakit_nemotron_ferry)
+          echo "job_id=$JOB_ID" >> "$GITHUB_OUTPUT"
+          echo "Submitted job: $JOB_ID"
+        env:
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+      - name: Wait for datakit nemotron smoke ferry
+        shell: bash -l {0}
+        run: |
+          JOB_ID="${{ steps.submit.outputs.job_id }}"
+          echo "Polling job status: $JOB_ID"
+          while true; do
+            STATE=$(.venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
+              job list --json --prefix "$JOB_ID" \
+              | jq -r --arg id "$JOB_ID" '[.[] | select(.job_id == $id)][0].state // empty')
+            case "$STATE" in
+              JOB_STATE_SUCCEEDED)
+                echo "Job succeeded"
+                exit 0
+                ;;
+              JOB_STATE_PENDING|JOB_STATE_BUILDING|JOB_STATE_RUNNING)
+                echo "$(date -u +%H:%M:%S) Job state: $STATE"
+                sleep 30
+                ;;
+              "")
+                echo "Job not found: $JOB_ID"
+                exit 1
+                ;;
+              *)
+                echo "Job finished with state: $STATE"
+                .venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
+                  job list --json --prefix "$JOB_ID" \
+                  | jq --arg id "$JOB_ID" '.[] | {job_id, state, error}' || true
+                exit 1
+                ;;
+            esac
+          done
+
+      - name: Capture failure diagnostics
+        if: failure() || cancelled()
+        run: |
+          echo "=== Controller logs ==="
+          .venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
+            process logs --max-lines=200 || true
+          echo "=== Job list ==="
+          .venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
+            job list --json 2>/dev/null | jq '.[0:5]' || true
+
+      # The canary-triage skill handles multiple lanes; CANARY_LANE selects
+      # datakit-nemotron-smoke vs datakit-smoke vs tpu.
+      - name: Claude triage
+        id: claude_triage
+        if: (failure() || cancelled()) && github.event_name == 'schedule'
+        uses: anthropics/claude-code-action@v1
+        timeout-minutes: 30
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
+          prompt: |
+            Read .agents/skills/canary-triage/SKILL.md and follow it.
+          claude_args: |
+            --model opus
+            --max-turns 500
+            --allowedTools "Bash(gh:*),Bash(.venv/bin/iris:*),Bash(.venv/bin/python:*),Bash(cat:*),Bash(jq:*),Bash(head:*),Bash(tail:*),Bash(grep:*)"
+        env:
+          CANARY_LANE: datakit-nemotron-smoke
+          CANARY_JOB_ID: ${{ steps.submit.outputs.job_id }}
+          CANARY_RUN_ID: ${{ env.SMOKE_RUN_ID }}
+          IRIS_CONFIG: ${{ env.IRIS_CONFIG }}
+          WANDB_ENTITY: ${{ env.WANDB_ENTITY }}
+          WANDB_PROJECT: ${{ env.WANDB_PROJECT }}
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Upload Slack message
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: slack-message
+          path: slack_message.md
+          retention-days: 1
+          if-no-files-found: ignore
+
+  # Separate job so Slack always fires, even if the main job is force-killed
+  # after its grace window. See the datakit-smoke workflow for rationale.
+  notify-slack:
+    needs: datakit-nemotron-smoke
+    if: always() && (needs.datakit-nemotron-smoke.result == 'failure' || needs.datakit-nemotron-smoke.result == 'cancelled') && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Slack message
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: slack-message
+
+      - name: Notify Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          FALLBACK_TEXT: ":red_circle: *Datakit Nemotron Smoke failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: |
+          if [ -f slack_message.md ]; then
+            TEXT=$(cat slack_message.md)
+          else
+            TEXT="$FALLBACK_TEXT"
+          fi
+          PAYLOAD=$(python3 -c "import sys,json; print(json.dumps({'text': sys.stdin.read()}))" <<< "$TEXT")
+          curl -sf -X POST -H 'Content-Type: application/json' -d "$PAYLOAD" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/marin-datakit-nemotron-smoke.yaml
+++ b/.github/workflows/marin-datakit-nemotron-smoke.yaml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  issues: write    # claude triage files issues
-  id-token: write  # claude-code-action OIDC
 
 jobs:
   datakit-nemotron-smoke:
@@ -127,40 +125,6 @@ jobs:
           .venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
             job list --json 2>/dev/null | jq '.[0:5]' || true
 
-      # The canary-triage skill handles multiple lanes; CANARY_LANE selects
-      # datakit-nemotron-smoke vs datakit-smoke vs tpu.
-      - name: Claude triage
-        id: claude_triage
-        if: (failure() || cancelled()) && github.event_name == 'schedule'
-        uses: anthropics/claude-code-action@v1
-        timeout-minutes: 30
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
-          prompt: |
-            Read .agents/skills/canary-triage/SKILL.md and follow it.
-          claude_args: |
-            --model opus
-            --max-turns 500
-            --allowedTools "Bash(gh:*),Bash(.venv/bin/iris:*),Bash(.venv/bin/python:*),Bash(cat:*),Bash(jq:*),Bash(head:*),Bash(tail:*),Bash(grep:*)"
-        env:
-          CANARY_LANE: datakit-nemotron-smoke
-          CANARY_JOB_ID: ${{ steps.submit.outputs.job_id }}
-          CANARY_RUN_ID: ${{ env.SMOKE_RUN_ID }}
-          IRIS_CONFIG: ${{ env.IRIS_CONFIG }}
-          WANDB_ENTITY: ${{ env.WANDB_ENTITY }}
-          WANDB_PROJECT: ${{ env.WANDB_PROJECT }}
-          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
-          GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-      - name: Upload Slack message
-        if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
-        with:
-          name: slack-message
-          path: slack_message.md
-          retention-days: 1
-          if-no-files-found: ignore
-
   # Separate job so Slack always fires, even if the main job is force-killed
   # after its grace window. See the datakit-smoke workflow for rationale.
   notify-slack:
@@ -168,21 +132,10 @@ jobs:
     if: always() && (needs.datakit-nemotron-smoke.result == 'failure' || needs.datakit-nemotron-smoke.result == 'cancelled') && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - name: Download Slack message
-        uses: actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          name: slack-message
-
       - name: Notify Slack
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          FALLBACK_TEXT: ":red_circle: *Datakit Nemotron Smoke failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          TEXT: ":red_circle: *Datakit Nemotron Smoke failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         run: |
-          if [ -f slack_message.md ]; then
-            TEXT=$(cat slack_message.md)
-          else
-            TEXT="$FALLBACK_TEXT"
-          fi
           PAYLOAD=$(python3 -c "import sys,json; print(json.dumps({'text': sys.stdin.read()}))" <<< "$TEXT")
           curl -sf -X POST -H 'Content-Type: application/json' -d "$PAYLOAD" "$SLACK_WEBHOOK_URL"

--- a/experiments/ferries/datakit_nemotron_ferry.py
+++ b/experiments/ferries/datakit_nemotron_ferry.py
@@ -123,7 +123,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
             output_path=output_path,
             max_parallelism=512,
             cc_max_iterations=3,
-            worker_resources=ResourceConfig(cpu=1, ram="32g", disk="10g"),
+            worker_resources=ResourceConfig(cpu=1, ram="16g", disk="10g"),
         ),
         override_output_path=f"{base}/fuzzy_dups",
     )
@@ -163,6 +163,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
                 cache_path=output_path,
                 tokenizer="gpt2",
                 max_workers=512,
+                worker_resources=ResourceConfig(ram="16g", disk="5g"),
             )
         ),
         override_output_path=f"{base}/tokens",

--- a/experiments/ferries/datakit_nemotron_ferry.py
+++ b/experiments/ferries/datakit_nemotron_ferry.py
@@ -97,7 +97,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
         text_field="text",
         id_field="id",
         input_path=medium_input,
-        worker_resources=ResourceConfig(cpu=2, ram="16g", disk="20g"),
+        worker_resources=ResourceConfig(cpu=2, ram="16g", disk="5g"),
         max_workers=512,
         override_output_path=f"{base}/normalize",
     )
@@ -108,7 +108,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
         fn=lambda output_path: compute_minhash_attrs(
             source=Artifact.load(normalized, NormalizedData),
             output_path=output_path,
-            worker_resources=ResourceConfig(cpu=5, ram="16g", disk="10g"),
+            worker_resources=ResourceConfig(cpu=5, ram="16g", disk="5g"),
             max_workers=512,
         ),
         override_output_path=f"{base}/minhash",
@@ -123,7 +123,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
             output_path=output_path,
             max_parallelism=512,
             cc_max_iterations=3,
-            worker_resources=ResourceConfig(cpu=1, ram="16g", disk="10g"),
+            worker_resources=ResourceConfig(cpu=1, ram="16g", disk="5g"),
         ),
         override_output_path=f"{base}/fuzzy_dups",
     )
@@ -146,7 +146,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
                     keep_if_missing=True,
                 ),
             ],
-            worker_resources=ResourceConfig(cpu=1, ram="16g"),
+            worker_resources=ResourceConfig(cpu=1, ram="16g", disk="5g"),
             max_workers=512,
         ),
         override_output_path=f"{base}/consolidate",

--- a/experiments/ferries/datakit_nemotron_ferry.py
+++ b/experiments/ferries/datakit_nemotron_ferry.py
@@ -1,0 +1,207 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Datakit nemotron ferry: weekly full-pipeline run on the Nemotron-CC medium split.
+
+Pipeline: verify raw dump → normalize → minhash → fuzzy_dups → consolidate →
+tokenize. The first step is verification-only: it confirms the ``quality=medium``
+subtree of the Nemotron-CC dump is already staged at ``NEMOTRON_RAW_PATH`` and
+refuses to initiate a Common Crawl download.
+
+Pipeline outputs land under ``$MARIN_PREFIX/datakit-nemotron-smoke/$SMOKE_RUN_ID/...``;
+``MARIN_PREFIX`` defaults to a region-local temp bucket with 1-day TTL.
+"""
+
+import json
+import logging
+import os
+
+from rigging.filesystem import (
+    check_path_in_region,
+    marin_temp_bucket,
+    region_from_metadata,
+    url_to_fs,
+)
+from rigging.log_setup import configure_logging
+from rigging.timing import log_time
+
+from fray import ResourceConfig
+from marin.datakit.normalize import NormalizedData, normalize_step
+from marin.execution.artifact import Artifact
+from marin.execution.step_runner import StepRunner
+from marin.execution.step_spec import StepSpec
+from marin.processing.classification.consolidate import (
+    FilterConfig,
+    FilterType,
+    consolidate,
+)
+from marin.processing.classification.deduplication.fuzzy_dups import (
+    FuzzyDupsAttrData,
+    compute_fuzzy_dups_attrs,
+)
+from marin.processing.classification.deduplication.fuzzy_minhash import (
+    MinHashAttrData,
+    compute_minhash_attrs,
+)
+from marin.processing.tokenize.tokenize import TokenizeConfig, tokenize
+
+logger = logging.getLogger(__name__)
+
+# Canonical, region-pinned location of the staged Nemotron-CC raw dump. The
+# dump was populated by a one-off download into marin-eu-west4; the ferry only
+# reads from it and will fail-fast if it isn't there. Matches the path used in
+# ``experiments/dedup/poc_nemotron.py``.
+NEMOTRON_RAW_PATH = "gs://marin-eu-west4/raw/nemotro-cc-eeb783"
+NEMOTRON_DATA_SUBDIR = "contrib/Nemotron/Nemotron-CC/data-jsonl"
+NEMOTRON_MEDIUM_DIR = "quality=medium"
+
+
+def _verify_nemotron_medium_present(output_path: str) -> None:
+    """Confirm the medium split is staged at ``output_path``; never downloads.
+
+    Invoked by StepRunner only on a cache miss. Raises with a clear message so
+    that an accidental cache eviction can never trigger a multi-TB Common Crawl
+    re-download.
+    """
+    medium_dir = f"{output_path}/{NEMOTRON_DATA_SUBDIR}/{NEMOTRON_MEDIUM_DIR}"
+    fs, _ = url_to_fs(medium_dir)
+    if not fs.exists(medium_dir):
+        raise RuntimeError(
+            f"Nemotron-CC medium split not found at {medium_dir}. "
+            "The nemotron ferry refuses to download Common Crawl — stage the raw dump externally first."
+        )
+    sample = fs.glob(f"{medium_dir}/**/*.jsonl.*", maxdepth=4)
+    if not sample:
+        raise RuntimeError(f"Nemotron-CC medium split at {medium_dir} contains no .jsonl.* files.")
+    logger.info("Nemotron-CC medium split confirmed at %s (e.g. %s)", medium_dir, sample[0])
+
+
+def build_steps(run_id: str) -> list[StepSpec]:
+    base = f"datakit-nemotron-smoke/{run_id}"
+
+    # Verify-only raw step. Uses an absolute override so it points at the
+    # pre-staged dump regardless of MARIN_PREFIX.
+    download = StepSpec(
+        name="datakit-nemotron-smoke/download",
+        fn=_verify_nemotron_medium_present,
+        override_output_path=NEMOTRON_RAW_PATH,
+    )
+
+    medium_input = f"{download.output_path}/{NEMOTRON_DATA_SUBDIR}/{NEMOTRON_MEDIUM_DIR}"
+
+    # Sizes mirror validate_normalize_phase1.py, which ran successfully on
+    # nemotron_v1 in eu-west4. 512 workers across all fan-out stages.
+    normalized = normalize_step(
+        name="datakit-nemotron-smoke/normalize",
+        download=download,
+        text_field="text",
+        id_field="id",
+        input_path=medium_input,
+        worker_resources=ResourceConfig(cpu=2, ram="16g", disk="20g"),
+        max_workers=512,
+        override_output_path=f"{base}/normalize",
+    )
+
+    minhash = StepSpec(
+        name="datakit-nemotron-smoke/minhash",
+        deps=[normalized],
+        fn=lambda output_path: compute_minhash_attrs(
+            source=Artifact.load(normalized, NormalizedData),
+            output_path=output_path,
+            worker_resources=ResourceConfig(cpu=5, ram="16g", disk="10g"),
+            max_workers=512,
+        ),
+        override_output_path=f"{base}/minhash",
+    )
+
+    deduped = StepSpec(
+        name="datakit-nemotron-smoke/fuzzy_dups",
+        deps=[minhash],
+        hash_attrs={"cc_max_iterations": 3},
+        fn=lambda output_path: compute_fuzzy_dups_attrs(
+            inputs=[Artifact.load(minhash, MinHashAttrData)],
+            output_path=output_path,
+            max_parallelism=512,
+            cc_max_iterations=3,
+            worker_resources=ResourceConfig(cpu=1, ram="32g", disk="10g"),
+        ),
+        override_output_path=f"{base}/fuzzy_dups",
+    )
+
+    consolidated = StepSpec(
+        name="datakit-nemotron-smoke/consolidate",
+        deps=[normalized, deduped],
+        fn=lambda output_path: consolidate(
+            input_path=Artifact.load(normalized, NormalizedData).main_output_dir,
+            output_path=output_path,
+            filetype="parquet",
+            filters=[
+                FilterConfig(
+                    type=FilterType.KEEP_DOC,
+                    attribute_path=Artifact.load(deduped, FuzzyDupsAttrData)
+                    .sources[Artifact.load(normalized, NormalizedData).main_output_dir]
+                    .attr_dir,
+                    name="is_cluster_canonical",
+                    attribute_filetype="parquet",
+                    keep_if_missing=True,
+                ),
+            ],
+            worker_resources=ResourceConfig(cpu=1, ram="16g"),
+            max_workers=512,
+        ),
+        override_output_path=f"{base}/consolidate",
+    )
+
+    tokenized = StepSpec(
+        name="datakit-nemotron-smoke/tokenize",
+        deps=[consolidated],
+        hash_attrs={"tokenizer": "gpt2"},
+        fn=lambda output_path: tokenize(
+            TokenizeConfig(
+                train_paths=[consolidated.output_path],
+                validation_paths=[],
+                cache_path=output_path,
+                tokenizer="gpt2",
+                max_workers=512,
+            )
+        ),
+        override_output_path=f"{base}/tokens",
+    )
+
+    return [download, normalized, minhash, deduped, consolidated, tokenized]
+
+
+def _write_status(status: str, marin_prefix: str) -> None:
+    """Write ferry run status to FERRY_STATUS_PATH if set."""
+    status_path = os.environ.get("FERRY_STATUS_PATH")
+    if not status_path:
+        return
+    payload = json.dumps({"status": status, "marin_prefix": marin_prefix})
+    fs, _ = url_to_fs(status_path)
+    with fs.open(status_path, "w") as f:
+        f.write(payload)
+    logger.info("Wrote ferry status to %s", status_path)
+
+
+def main() -> None:
+    configure_logging()
+    if not os.environ.get("MARIN_PREFIX"):
+        os.environ["MARIN_PREFIX"] = marin_temp_bucket(ttl_days=1)
+
+    marin_prefix = os.environ["MARIN_PREFIX"]
+    logger.info("MARIN_PREFIX defaulted to %s", marin_prefix)
+    run_id = os.environ["SMOKE_RUN_ID"]
+
+    # Guard against accidental cross-region reads of the multi-TB raw dump.
+    region = region_from_metadata()
+    if region:
+        check_path_in_region("nemotron_raw", NEMOTRON_RAW_PATH, region)
+
+    _write_status("running", marin_prefix)
+    with log_time("Datakit nemotron ferry total wall time"):
+        StepRunner().run(build_steps(run_id))
+    _write_status("succeeded", marin_prefix)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* new `experiments/ferries/datakit_nemotron_ferry.py` — full datakit pipeline (normalize → minhash → fuzzy_dups → consolidate → tokenize) on the Nemotron-CC `quality=medium` split
* download step is verify-only via `_verify_nemotron_medium_present` — asserts the pre-staged dump at `gs://marin-eu-west4/raw/nemotro-cc-eeb783` exists and has `.jsonl.*` files, raises otherwise [^1]
  * reuses the canonical `override_output_path` so `StepRunner`'s cache check short-circuits on the existing `STATUS_SUCCESS`, and `check_path_in_region` guards against cross-region reads
* 512 workers across fan-out stages, resources mirror `scripts/validate_normalize_phase1.py`
* per-run outputs under `$MARIN_PREFIX/datakit-nemotron-smoke/$SMOKE_RUN_ID/...`, `MARIN_PREFIX` defaults to the region-local 1-day TTL temp bucket
* new `.github/workflows/marin-datakit-nemotron-ferry.yaml` — cron `0 1 * * 1` (Monday 01:00 UTC), `--region=europe-west4`, 24h timeout
  * on scheduled failure, fires a minimal Slack notify with a link to the GHA run; no Claude triage
  * drops the fineweb-specific `validate_ferry_outputs.py` step — pipeline success is the only signal

[^1]: the invariant is "the download MUST never happen": an accidental cache eviction triggers the verify fn instead of a multi-TB Common Crawl refetch.