### PR TITLE
zephyr: per-reducer shuffle manifests

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -1785,7 +1785,11 @@ def _resolve_combine_output_shards(stage, auto_shard_count: int | None):
     combine_op: CombineMeta | None = next((op for op in stage.operations if isinstance(op, CombineMeta)), None)
     if combine_op is None or combine_op.num_output_shards > 0:
         return stage
-    if auto_shard_count is None or auto_shard_count <= 0:
+    # ``auto_shard_count`` comes from ``len(shards)`` captured before the
+    # preceding Scatter stage. ``0`` is a valid value (empty right-plan of a
+    # join, or a filtered-down source), producing zero reducers and an empty
+    # downstream stage — don't raise on it.
+    if auto_shard_count is None:
         raise ValueError(
             "CombineMeta stage has num_output_shards<=0 but no mapper count is available "
             "(no preceding Scatter stage recorded)."

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import enum
 import itertools
 import logging
+import math
 import os
 import pickle
 import re
@@ -143,17 +144,8 @@ class CounterSnapshot:
 
 @dataclass
 class TaskResult:
-    """Result of a single worker task.
-
-    Always contains a ListShard. Refs vary by stage type:
-
-    - Normal stages: ``PickleDiskChunk`` refs.
-    - Scatter stages: ``MemChunk`` with mapper data paths (metadata lives in
-      ``mapper-XXXX.scatter_meta`` sidecars next to each data file, read
-      lazily by ``CombineMeta`` or reducers).
-    - CombineMeta stages: ``MemChunk`` with the combine output directory;
-      reducers resolve their ``reducer-YYYY.scatter_meta`` inside it.
-    """
+    """Result of a single worker task. Ref type varies: normal → ``PickleDiskChunk``,
+    Scatter → mapper data paths, CombineMeta → combine output dir."""
 
     shard: ListShard
 
@@ -226,19 +218,8 @@ def _write_stage_output(
     combine_op: CombineMeta | None,
     total_shards: int,
 ) -> TaskResult:
-    """Write stage output to disk.
-
-    For scatter stages (``scatter_op`` is set), writes a ``.shuffle`` data
-    file and a ``mapper-XXXX.scatter_meta`` manifest, returning a
-    ``TaskResult`` whose shard wraps the data path.
-
-    For combine stages (``combine_op`` is set), reads all mapper manifests
-    and writes R reducer manifests into the mapper directory, returning a
-    ``TaskResult`` whose shard wraps that directory path.
-
-    For non-scatter stages, batches items into pickle chunk files. Returns
-    TaskResult with a ListShard.
-    """
+    """Write stage output to disk. Scatter writes data+manifest; CombineMeta
+    writes this task's reducer manifests; others batch into pickle chunks."""
     if scatter_op is not None:
         first_item = next(stage_gen, None)
         if first_item is None:
@@ -260,17 +241,22 @@ def _write_stage_output(
         return TaskResult(shard=shard)
 
     if combine_op is not None:
-        # The input stream is the flat list of mapper ``.shuffle`` paths —
-        # drain it, then emit R reducer manifests into the mappers' own
-        # directory so every shuffle-related file lives together.
+        # Write reducer manifests alongside the mapper files so all shuffle
+        # state lives in one directory. Each of K combine tasks writes a
+        # strided subset of the R reducer manifests (shards task_idx::K).
         scatter_paths = [p for p in stage_gen if p]
         if not scatter_paths:
             return TaskResult(shard=ListShard(refs=[]))
         out_dir = os.path.dirname(scatter_paths[0])
-        assert all(
-            os.path.dirname(p) == out_dir for p in scatter_paths
-        ), f"combine inputs span multiple directories: {set(os.path.dirname(p) for p in scatter_paths)}"
-        combine_sidecars(scatter_paths, combine_op.num_output_shards, out_dir)
+        assert all(os.path.dirname(p) == out_dir for p in scatter_paths), "combine inputs span multiple directories"
+        K = combine_op.num_combine_tasks if combine_op.num_combine_tasks > 0 else 1
+        combine_sidecars(
+            scatter_paths,
+            combine_op.num_output_shards,
+            out_dir,
+            task_idx=shard_idx,
+            num_combine_tasks=K,
+        )
         return TaskResult(shard=ListShard(refs=[MemChunk(items=[out_dir])]))
 
     def chunk_path_fn(idx: int) -> str:
@@ -854,14 +840,10 @@ class ZephyrCoordinator:
                 default=-1,
             )
 
-            # GroupByOp with ``num_output_shards=None`` defers sizing to the
-            # source shard count. Scatter resolves this per-task at write time
-            # from ``ShardTask.total_shards``; CombineMeta needs the same
-            # count at stage-launch time so it can both emit R reducer
-            # manifests and replicate them to R downstream shards. We capture
-            # the mapper count just before the Scatter stage runs and use it
-            # for the next CombineMeta stage.
-            pending_combine_auto_shards: int | None = None
+            # Sized at stage-launch time from the preceding Scatter's input
+            # count (M) and the combine memory budget (K) — see the resolver.
+            pending_K: int | None = None
+            pending_R: int | None = None
 
             for stage_idx, stage in enumerate(plan.stages):
                 stage_label = f"stage{stage_idx}-{stage.stage_name(max_length=40)}"
@@ -870,13 +852,13 @@ class ZephyrCoordinator:
                     shards = _reshard_refs(shards, stage.output_shards or len(shards))
                     continue
 
-                stage_has_scatter = any(isinstance(op, Scatter) for op in stage.operations)
-                if stage_has_scatter:
-                    pending_combine_auto_shards = len(shards)
+                if any(isinstance(op, Scatter) for op in stage.operations):
+                    next_combine = _find_next_combine_stage(plan.stages, stage_idx)
+                    stage, pending_K, pending_R = _resolve_scatter_stage_for_combine(stage, len(shards), next_combine)
 
-                stage = _resolve_combine_output_shards(stage, pending_combine_auto_shards)
                 if any(isinstance(op, CombineMeta) for op in stage.operations):
-                    pending_combine_auto_shards = None
+                    stage = _resolve_combine_stage(stage, pending_K, pending_R)
+                    pending_K, pending_R = None, None
 
                 # Compute aux data for joins
                 aux_per_shard = self._compute_join_aux(stage.operations, shards, stage_idx)
@@ -892,12 +874,8 @@ class ZephyrCoordinator:
 
                 # Collect and regroup results for next stage
                 result_refs = self._collect_results()
-                # Both Scatter and CombineMeta are shuffle-boundary stages —
-                # their outputs are gathered across all tasks and replicated
-                # to every downstream task. Scatter with output_shards=1
-                # collapses M mapper paths into a single combine input;
-                # CombineMeta with output_shards=R replicates the combine
-                # output dir to every reducer.
+                # Scatter/CombineMeta are shuffle boundaries: outputs are
+                # gathered and replicated to every downstream task.
                 stage_is_shuffle_boundary = any(isinstance(op, (Scatter, CombineMeta)) for op in stage.operations)
                 shards = _regroup_result_refs(
                     result_refs,
@@ -938,7 +916,8 @@ class ZephyrCoordinator:
                 continue
 
             right_refs = _build_source_shards(op.right_plan.source_items)
-            right_pending_combine: int | None = None
+            right_pending_K: int | None = None
+            right_pending_R: int | None = None
 
             for stage_idx, right_stage in enumerate(op.right_plan.stages):
                 if right_stage.stage_type == StageType.RESHARD:
@@ -946,11 +925,14 @@ class ZephyrCoordinator:
                     continue
 
                 if any(isinstance(o, Scatter) for o in right_stage.operations):
-                    right_pending_combine = len(right_refs)
+                    next_combine = _find_next_combine_stage(op.right_plan.stages, stage_idx)
+                    right_stage, right_pending_K, right_pending_R = _resolve_scatter_stage_for_combine(
+                        right_stage, len(right_refs), next_combine
+                    )
 
-                right_stage = _resolve_combine_output_shards(right_stage, right_pending_combine)
                 if any(isinstance(o, CombineMeta) for o in right_stage.operations):
-                    right_pending_combine = None
+                    right_stage = _resolve_combine_stage(right_stage, right_pending_K, right_pending_R)
+                    right_pending_K, right_pending_R = None, None
 
                 join_stage_label = f"join-right-{parent_stage_idx}-{i}-stage{stage_idx}"
                 right_tasks = _compute_tasks_from_shards(right_refs, right_stage, stage_name=join_stage_label)
@@ -1346,33 +1328,18 @@ def _regroup_result_refs(
     is_shuffle_boundary: bool = False,
     scatter_manifest_dir: str = "",
 ) -> list[Shard]:
-    """Regroup worker output refs by output shard index without loading data.
+    """Regroup worker output refs without loading data.
 
-    Non-shuffle-boundary stages: each worker's ListShard maps to its own
-    index (identity).
-
-    Shuffle-boundary stages (``Scatter`` and ``CombineMeta``): gather every
-    worker's output refs into a single ``MemChunk`` and replicate it to
-    ``output_shard_count`` downstream shards. With ``output_shard_count=1``
-    this concentrates M mapper paths into a single combine-task input;
-    with ``output_shard_count=R`` it fans the single combine output dir
-    out to every reducer, which then selects its own
-    ``reducer-YYYY.scatter_meta`` by ``shard_idx``.
+    Non-shuffle: identity (task i → shard i). Shuffle boundary: gather every
+    task's refs and replicate to ``output_shard_count`` downstream shards.
     """
     if is_shuffle_boundary:
-        # Shuffle boundaries ignore the input task count entirely: the stage's
-        # ``output_shards`` is authoritative so a Scatter can gather M mappers
-        # into 1 combine input and a CombineMeta can fan 1 output out to R
-        # reducers. The coordinator never reads the manifest payloads —
-        # Scatter yields mapper data paths, CombineMeta yields the combine
-        # output directory, and downstream workers resolve their per-shard
-        # slice at read time.
+        # ``output_shard_count`` is authoritative; ignore input task count.
         if output_shard_count is None:
             raise ValueError("Shuffle-boundary stages must specify output_shard_count")
         all_items: list[Any] = []
         for result in result_refs.values():
             all_items.extend(result.shard)
-
         shared_refs = MemChunk(items=all_items)
         return [ListShard(refs=[shared_refs]) for _ in range(output_shard_count)]
 
@@ -1772,31 +1739,64 @@ class ZephyrContext:
         self._terminate_coordinator_job()
 
 
-def _resolve_combine_output_shards(stage, auto_shard_count: int | None):
-    """Fill in a CombineMeta stage's output size when ``num_output_shards``
-    was left as auto (from ``GroupByOp(num_output_shards=None)``).
+# Per-task memory target for the inverted range matrix in combine_sidecars.
+_COMBINE_TASK_MEM_BUDGET = 1 * 1024**3
+_COMBINE_EST_BYTES_PER_CELL = 200
 
-    Returns a new stage with updated ``output_shards`` and a patched
-    ``CombineMeta`` op whose ``num_output_shards`` matches — both the regroup
-    call and ``combine_sidecars`` need the resolved value.
+
+def _auto_combine_tasks(M: int, R: int) -> int:
+    """Choose K so per-task memory for (R/K) x M entries fits the budget."""
+    if M <= 0 or R <= 0:
+        return 1
+    K = max(1, math.ceil(M * R * _COMBINE_EST_BYTES_PER_CELL / _COMBINE_TASK_MEM_BUDGET))
+    return min(K, R)
+
+
+def _find_next_combine_stage(stages, start_idx: int):
+    for i in range(start_idx + 1, len(stages)):
+        if any(isinstance(op, CombineMeta) for op in stages[i].operations):
+            return stages[i]
+    return None
+
+
+def _resolve_scatter_stage_for_combine(stage, shards_len: int, next_combine_stage) -> tuple[Any, int | None, int | None]:
+    """Resolve Scatter ``output_shards`` to K when followed by CombineMeta.
+
+    Returns ``(stage, K, R)``; K/R are threaded into the following combine stage.
     """
     from dataclasses import replace
 
+    if stage.output_shards is not None or next_combine_stage is None:
+        return stage, None, None
+    combine_op = next((op for op in next_combine_stage.operations if isinstance(op, CombineMeta)), None)
+    if combine_op is None:
+        return stage, None, None
+
+    M = shards_len
+    R = combine_op.num_output_shards if combine_op.num_output_shards > 0 else M
+    K = _auto_combine_tasks(M, R) if R > 0 else 1
+    return replace(stage, output_shards=K), K, R
+
+
+def _resolve_combine_stage(stage, pending_K: int | None, pending_R: int | None):
+    """Patch CombineMeta op + stage ``output_shards`` from values resolved
+    at the preceding Scatter stage."""
+    from dataclasses import replace
+
     combine_op: CombineMeta | None = next((op for op in stage.operations if isinstance(op, CombineMeta)), None)
-    if combine_op is None or combine_op.num_output_shards > 0:
+    if combine_op is None:
         return stage
-    # ``auto_shard_count`` comes from ``len(shards)`` captured before the
-    # preceding Scatter stage. ``0`` is a valid value (empty right-plan of a
-    # join, or a filtered-down source), producing zero reducers and an empty
-    # downstream stage — don't raise on it.
-    if auto_shard_count is None:
-        raise ValueError(
-            "CombineMeta stage has num_output_shards<=0 but no mapper count is available "
-            "(no preceding Scatter stage recorded)."
-        )
-    patched_op = replace(combine_op, num_output_shards=auto_shard_count)
+
+    R = combine_op.num_output_shards if combine_op.num_output_shards > 0 else pending_R
+    K = combine_op.num_combine_tasks if combine_op.num_combine_tasks > 0 else (pending_K or 1)
+    if R is None:
+        raise ValueError("CombineMeta needs num_output_shards or a preceding Scatter stage.")
+
+    if R == combine_op.num_output_shards and K == combine_op.num_combine_tasks and R == stage.output_shards:
+        return stage
+    patched_op = replace(combine_op, num_output_shards=R, num_combine_tasks=K)
     new_ops = [patched_op if op is combine_op else op for op in stage.operations]
-    return replace(stage, operations=new_ops, output_shards=auto_shard_count)
+    return replace(stage, operations=new_ops, output_shards=R)
 
 
 def _reshard_refs(shards: list[Shard], num_shards: int) -> list[Shard]:

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -44,6 +44,7 @@ from rigging.timing import ExponentialBackoff, log_time
 
 from zephyr.dataset import Dataset
 from zephyr.plan import (
+    CombineMeta,
     Join,
     PhysicalOp,
     PhysicalPlan,
@@ -114,6 +115,8 @@ from zephyr.shuffle import (  # noqa: E402
     ScatterReader,  # noqa: F401 — re-exported for plan.py and external callers
     ScatterWriter,  # noqa: F401 — re-exported for external callers
     _write_scatter,
+    combine_sidecars,
+    mapper_data_path,
 )
 
 # ---------------------------------------------------------------------------
@@ -142,10 +145,14 @@ class CounterSnapshot:
 class TaskResult:
     """Result of a single worker task.
 
-    Always contains a ListShard. For non-scatter stages, refs are
-    PickleDiskChunks. For scatter stages, refs contain file paths
-    (the actual metadata lives in ``.scatter_meta`` sidecar files
-    read lazily by reducers).
+    Always contains a ListShard. Refs vary by stage type:
+
+    - Normal stages: ``PickleDiskChunk`` refs.
+    - Scatter stages: ``MemChunk`` with mapper data paths (metadata lives in
+      ``mapper-XXXX.scatter_meta`` sidecars next to each data file, read
+      lazily by ``CombineMeta`` or reducers).
+    - CombineMeta stages: ``MemChunk`` with the combine output directory;
+      reducers resolve their ``reducer-YYYY.scatter_meta`` inside it.
     """
 
     shard: ListShard
@@ -216,13 +223,18 @@ def _write_stage_output(
     stage_dir: str,
     shard_idx: int,
     scatter_op: Scatter | None,
+    combine_op: CombineMeta | None,
     total_shards: int,
 ) -> TaskResult:
     """Write stage output to disk.
 
-    For scatter stages (``scatter_op`` is set), writes Parquet with envelope
-    wrapping and ``.scatter_meta`` sidecars. Returns TaskResult with compact
-    scatter metadata.
+    For scatter stages (``scatter_op`` is set), writes a ``.shuffle`` data
+    file and a ``mapper-XXXX.scatter_meta`` manifest, returning a
+    ``TaskResult`` whose shard wraps the data path.
+
+    For combine stages (``combine_op`` is set), reads all mapper manifests
+    and writes R reducer manifests into the mapper directory, returning a
+    ``TaskResult`` whose shard wraps that directory path.
 
     For non-scatter stages, batches items into pickle chunk files. Returns
     TaskResult with a ListShard.
@@ -235,7 +247,7 @@ def _write_stage_output(
         full_gen = itertools.chain([first_item], stage_gen)
 
         num_output_shards = scatter_op.num_output_shards if scatter_op.num_output_shards > 0 else total_shards
-        data_path = f"{stage_dir}/shard-{shard_idx:04d}.shuffle"
+        data_path = mapper_data_path(stage_dir, shard_idx)
         shard = _write_scatter(
             full_gen,
             source_shard,
@@ -246,6 +258,20 @@ def _write_stage_output(
             combiner_fn=scatter_op.combiner_fn,
         )
         return TaskResult(shard=shard)
+
+    if combine_op is not None:
+        # The input stream is the flat list of mapper ``.shuffle`` paths —
+        # drain it, then emit R reducer manifests into the mappers' own
+        # directory so every shuffle-related file lives together.
+        scatter_paths = [p for p in stage_gen if p]
+        if not scatter_paths:
+            return TaskResult(shard=ListShard(refs=[]))
+        out_dir = os.path.dirname(scatter_paths[0])
+        assert all(
+            os.path.dirname(p) == out_dir for p in scatter_paths
+        ), f"combine inputs span multiple directories: {set(os.path.dirname(p) for p in scatter_paths)}"
+        combine_sidecars(scatter_paths, combine_op.num_output_shards, out_dir)
+        return TaskResult(shard=ListShard(refs=[MemChunk(items=[out_dir])]))
 
     def chunk_path_fn(idx: int) -> str:
         return f"{stage_dir}/shard-{shard_idx:04d}/chunk-{idx:04d}.pkl"
@@ -828,12 +854,29 @@ class ZephyrCoordinator:
                 default=-1,
             )
 
+            # GroupByOp with ``num_output_shards=None`` defers sizing to the
+            # source shard count. Scatter resolves this per-task at write time
+            # from ``ShardTask.total_shards``; CombineMeta needs the same
+            # count at stage-launch time so it can both emit R reducer
+            # manifests and replicate them to R downstream shards. We capture
+            # the mapper count just before the Scatter stage runs and use it
+            # for the next CombineMeta stage.
+            pending_combine_auto_shards: int | None = None
+
             for stage_idx, stage in enumerate(plan.stages):
                 stage_label = f"stage{stage_idx}-{stage.stage_name(max_length=40)}"
 
                 if stage.stage_type == StageType.RESHARD:
                     shards = _reshard_refs(shards, stage.output_shards or len(shards))
                     continue
+
+                stage_has_scatter = any(isinstance(op, Scatter) for op in stage.operations)
+                if stage_has_scatter:
+                    pending_combine_auto_shards = len(shards)
+
+                stage = _resolve_combine_output_shards(stage, pending_combine_auto_shards)
+                if any(isinstance(op, CombineMeta) for op in stage.operations):
+                    pending_combine_auto_shards = None
 
                 # Compute aux data for joins
                 aux_per_shard = self._compute_join_aux(stage.operations, shards, stage_idx)
@@ -849,12 +892,18 @@ class ZephyrCoordinator:
 
                 # Collect and regroup results for next stage
                 result_refs = self._collect_results()
-                stage_is_scatter = any(isinstance(op, Scatter) for op in stage.operations)
+                # Both Scatter and CombineMeta are shuffle-boundary stages —
+                # their outputs are gathered across all tasks and replicated
+                # to every downstream task. Scatter with output_shards=1
+                # collapses M mapper paths into a single combine input;
+                # CombineMeta with output_shards=R replicates the combine
+                # output dir to every reducer.
+                stage_is_shuffle_boundary = any(isinstance(op, (Scatter, CombineMeta)) for op in stage.operations)
                 shards = _regroup_result_refs(
                     result_refs,
                     len(shards),
                     output_shard_count=stage.output_shards,
-                    is_scatter=stage_is_scatter,
+                    is_shuffle_boundary=stage_is_shuffle_boundary,
                     scatter_manifest_dir=f"{self._chunk_prefix}/{self._execution_id}/{output_stage_name}",
                 )
 
@@ -889,11 +938,19 @@ class ZephyrCoordinator:
                 continue
 
             right_refs = _build_source_shards(op.right_plan.source_items)
+            right_pending_combine: int | None = None
 
             for stage_idx, right_stage in enumerate(op.right_plan.stages):
                 if right_stage.stage_type == StageType.RESHARD:
                     right_refs = _reshard_refs(right_refs, right_stage.output_shards or len(right_refs))
                     continue
+
+                if any(isinstance(o, Scatter) for o in right_stage.operations):
+                    right_pending_combine = len(right_refs)
+
+                right_stage = _resolve_combine_output_shards(right_stage, right_pending_combine)
+                if any(isinstance(o, CombineMeta) for o in right_stage.operations):
+                    right_pending_combine = None
 
                 join_stage_label = f"join-right-{parent_stage_idx}-{i}-stage{stage_idx}"
                 right_tasks = _compute_tasks_from_shards(right_refs, right_stage, stage_name=join_stage_label)
@@ -901,12 +958,12 @@ class ZephyrCoordinator:
                 self._start_stage(join_stage_label, right_tasks)
                 self._wait_for_stage()
                 raw = self._collect_results()
-                right_is_scatter = any(isinstance(op, Scatter) for op in right_stage.operations)
+                right_is_shuffle_boundary = any(isinstance(o, (Scatter, CombineMeta)) for o in right_stage.operations)
                 right_refs = _regroup_result_refs(
                     raw,
                     len(right_refs),
                     output_shard_count=right_stage.output_shards,
-                    is_scatter=right_is_scatter,
+                    is_shuffle_boundary=right_is_shuffle_boundary,
                     scatter_manifest_dir=f"{self._chunk_prefix}/{self._execution_id}/{join_output_stage_name}",
                 )
 
@@ -1286,32 +1343,44 @@ def _regroup_result_refs(
     result_refs: dict[int, TaskResult],
     input_shard_count: int,
     output_shard_count: int | None = None,
-    is_scatter: bool = False,
+    is_shuffle_boundary: bool = False,
     scatter_manifest_dir: str = "",
 ) -> list[Shard]:
     """Regroup worker output refs by output shard index without loading data.
 
-    Non-scatter: each worker's ListShard maps to its own index (identity).
-    Scatter: passes the list of scatter data-file paths to every reducer.
-    Each reducer reads the per-mapper ``.scatter_meta`` sidecars in parallel
-    to build its own ``ScatterReader`` without coordinator-side consolidation.
+    Non-shuffle-boundary stages: each worker's ListShard maps to its own
+    index (identity).
+
+    Shuffle-boundary stages (``Scatter`` and ``CombineMeta``): gather every
+    worker's output refs into a single ``MemChunk`` and replicate it to
+    ``output_shard_count`` downstream shards. With ``output_shard_count=1``
+    this concentrates M mapper paths into a single combine-task input;
+    with ``output_shard_count=R`` it fans the single combine output dir
+    out to every reducer, which then selects its own
+    ``reducer-YYYY.scatter_meta`` by ``shard_idx``.
     """
+    if is_shuffle_boundary:
+        # Shuffle boundaries ignore the input task count entirely: the stage's
+        # ``output_shards`` is authoritative so a Scatter can gather M mappers
+        # into 1 combine input and a CombineMeta can fan 1 output out to R
+        # reducers. The coordinator never reads the manifest payloads —
+        # Scatter yields mapper data paths, CombineMeta yields the combine
+        # output directory, and downstream workers resolve their per-shard
+        # slice at read time.
+        if output_shard_count is None:
+            raise ValueError("Shuffle-boundary stages must specify output_shard_count")
+        all_items: list[Any] = []
+        for result in result_refs.values():
+            all_items.extend(result.shard)
+
+        shared_refs = MemChunk(items=all_items)
+        return [ListShard(refs=[shared_refs]) for _ in range(output_shard_count)]
+
     num_output = max(max(result_refs.keys(), default=0) + 1, input_shard_count)
     if output_shard_count is not None:
         num_output = max(num_output, output_shard_count)
 
-    if is_scatter:
-        # Collect all scatter file paths from all workers. The coordinator
-        # does NOT read the sidecars or write a consolidated manifest —
-        # reducers do their own parallel sidecar reads.
-        all_paths: list[str] = []
-        for result in result_refs.values():
-            all_paths.extend(result.shard)
-
-        shared_refs = MemChunk(items=all_paths)
-        return [ListShard(refs=[shared_refs]) for _ in range(num_output)]
-
-    # Non-scatter: each result's shard maps to its own index
+    # Non-shuffle-boundary: each result's shard maps to its own index
     return [result_refs[idx].shard if idx in result_refs else ListShard(refs=[]) for idx in range(num_output)]
 
 
@@ -1701,6 +1770,29 @@ class ZephyrContext:
     def shutdown(self) -> None:
         """Shutdown the coordinator job and all child actors."""
         self._terminate_coordinator_job()
+
+
+def _resolve_combine_output_shards(stage, auto_shard_count: int | None):
+    """Fill in a CombineMeta stage's output size when ``num_output_shards``
+    was left as auto (from ``GroupByOp(num_output_shards=None)``).
+
+    Returns a new stage with updated ``output_shards`` and a patched
+    ``CombineMeta`` op whose ``num_output_shards`` matches — both the regroup
+    call and ``combine_sidecars`` need the resolved value.
+    """
+    from dataclasses import replace
+
+    combine_op: CombineMeta | None = next((op for op in stage.operations if isinstance(op, CombineMeta)), None)
+    if combine_op is None or combine_op.num_output_shards > 0:
+        return stage
+    if auto_shard_count is None or auto_shard_count <= 0:
+        raise ValueError(
+            "CombineMeta stage has num_output_shards<=0 but no mapper count is available "
+            "(no preceding Scatter stage recorded)."
+        )
+    patched_op = replace(combine_op, num_output_shards=auto_shard_count)
+    new_ops = [patched_op if op is combine_op else op for op in stage.operations]
+    return replace(stage, operations=new_ops, output_shards=auto_shard_count)
 
 
 def _reshard_refs(shards: list[Shard], num_shards: int) -> list[Shard]:

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -125,15 +125,15 @@ class Scatter:
 
 @dataclass
 class CombineMeta:
-    """Aggregate M mapper manifests into R reducer manifests.
+    """Aggregate mapper manifests into per-reducer manifests.
 
-    Runs as a single-task stage between ``Scatter`` and ``Reduce``. Reads all
-    mapper ``.scatter_meta`` files once and emits one ``reducer-YYYY.scatter_meta``
-    per reducer. Each reducer then loads exactly one manifest file, avoiding
-    the M-way fan-out that ``Reduce`` would otherwise perform.
+    Runs as ``num_combine_tasks`` parallel tasks between ``Scatter`` and
+    ``Reduce``. Each task owns a strided subset of reducer shards, bounding
+    per-task memory to ``(R/K) x M``. ``num_combine_tasks<=0`` means "auto".
     """
 
     num_output_shards: int
+    num_combine_tasks: int = -1
 
 
 @dataclass
@@ -445,12 +445,8 @@ def _fuse_operations(operations: list) -> list[PhysicalStage]:
 
         elif isinstance(op, GroupByOp):
             num_shards = op.num_output_shards if op.num_output_shards is not None else -1
-            # Three-stage lowering: M mappers → 1 combine task → R reducers.
-            # Scatter's stage output_shards=1 concentrates all M mapper paths
-            # into a single input shard for the combine task, which inverts
-            # them into R per-reducer manifests. The combine stage's
-            # output_shards=R replicates the combine output to every reducer
-            # — reducers then pick their manifest by shard_idx.
+            # M mappers → K combine tasks → R reducers. K is sized at
+            # stage-launch time from the combine-task memory budget.
             state.add_op(
                 Scatter(
                     key_fn=op.key_fn,
@@ -458,11 +454,11 @@ def _fuse_operations(operations: list) -> list[PhysicalStage]:
                     sort_fn=op.sort_fn,
                     combiner_fn=op.combiner_fn,
                 ),
-                output_shards=1,
+                output_shards=None,  # resolved to K at runtime
             )
             state.end_stage()
             state.add_op(
-                CombineMeta(num_output_shards=num_shards),
+                CombineMeta(num_output_shards=num_shards, num_combine_tasks=-1),
                 output_shards=num_shards if num_shards > 0 else None,
             )
             state.end_stage()
@@ -865,30 +861,29 @@ def run_stage(
             return
 
         elif isinstance(op, CombineMeta):
-            # CombineMeta output (a single combine directory path) is emitted
-            # by the IO writer once combine_sidecars finishes; the writer
-            # extracts the op and handles the call directly. Forward the
-            # input stream so _write_stage_output sees the mapper paths.
+            # The IO writer calls combine_sidecars directly; forward the
+            # input stream (mapper paths) to _write_stage_output.
             yield from stream
             return
 
         elif isinstance(op, Reduce):
-            # Build ScatterReader from the single reducer manifest produced
-            # by CombineMeta, then merge sorted chunks and reduce per key.
             from zephyr.execution import ScatterReader
             from zephyr.shuffle import reducer_manifest_path
 
             shard = ctx.shard
             if not isinstance(shard, ScatterReader):
+                # Upstream CombineMeta fans out K copies of the output dir
+                # (one per combine task); all copies are identical.
                 items = list(shard)
-                if not items:
+                dirs = {item for item in items if item}
+                if not dirs:
                     shard = ScatterReader(iterators=[], max_chunk_rows=0, avg_item_bytes=0.0)
                 else:
-                    if len(items) != 1:
+                    if len(dirs) != 1:
                         raise ValueError(
-                            f"Reduce shard {ctx.shard_idx} expected exactly 1 combine output dir, got {items}"
+                            f"Reduce shard {ctx.shard_idx} expected a single combine output dir, got {dirs}"
                         )
-                    manifest_path = reducer_manifest_path(items[0], ctx.shard_idx)
+                    manifest_path = reducer_manifest_path(next(iter(dirs)), ctx.shard_idx)
                     shard = ScatterReader.from_combined_manifest(manifest_path)
             stream = _reduce_gen(
                 shard, op.key_fn, op.reducer_fn, sort_fn=op.sort_fn, external_sort_dir=external_sort_dir

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -124,6 +124,19 @@ class Scatter:
 
 
 @dataclass
+class CombineMeta:
+    """Aggregate M mapper manifests into R reducer manifests.
+
+    Runs as a single-task stage between ``Scatter`` and ``Reduce``. Reads all
+    mapper ``.scatter_meta`` files once and emits one ``reducer-YYYY.scatter_meta``
+    per reducer. Each reducer then loads exactly one manifest file, avoiding
+    the M-way fan-out that ``Reduce`` would otherwise perform.
+    """
+
+    num_output_shards: int
+
+
+@dataclass
 class Reduce:
     """Merge sorted chunks and reduce per key."""
 
@@ -154,7 +167,7 @@ class Join:
     right_plan: PhysicalPlan | None = None
 
 
-PhysicalOp = Map | Write | Scatter | Reduce | Fold | Reshard | Join
+PhysicalOp = Map | Write | Scatter | CombineMeta | Reduce | Fold | Reshard | Join
 
 
 class StageType(StrEnum):
@@ -432,6 +445,12 @@ def _fuse_operations(operations: list) -> list[PhysicalStage]:
 
         elif isinstance(op, GroupByOp):
             num_shards = op.num_output_shards if op.num_output_shards is not None else -1
+            # Three-stage lowering: M mappers → 1 combine task → R reducers.
+            # Scatter's stage output_shards=1 concentrates all M mapper paths
+            # into a single input shard for the combine task, which inverts
+            # them into R per-reducer manifests. The combine stage's
+            # output_shards=R replicates the combine output to every reducer
+            # — reducers then pick their manifest by shard_idx.
             state.add_op(
                 Scatter(
                     key_fn=op.key_fn,
@@ -439,6 +458,11 @@ def _fuse_operations(operations: list) -> list[PhysicalStage]:
                     sort_fn=op.sort_fn,
                     combiner_fn=op.combiner_fn,
                 ),
+                output_shards=1,
+            )
+            state.end_stage()
+            state.add_op(
+                CombineMeta(num_output_shards=num_shards),
                 output_shards=num_shards if num_shards > 0 else None,
             )
             state.end_stage()
@@ -840,17 +864,32 @@ def run_stage(
             yield from stream
             return
 
+        elif isinstance(op, CombineMeta):
+            # CombineMeta output (a single combine directory path) is emitted
+            # by the IO writer once combine_sidecars finishes; the writer
+            # extracts the op and handles the call directly. Forward the
+            # input stream so _write_stage_output sees the mapper paths.
+            yield from stream
+            return
+
         elif isinstance(op, Reduce):
-            # Build ScatterReader directly from per-mapper sidecars, then
-            # merge sorted chunks and reduce per key.
+            # Build ScatterReader from the single reducer manifest produced
+            # by CombineMeta, then merge sorted chunks and reduce per key.
             from zephyr.execution import ScatterReader
+            from zephyr.shuffle import reducer_manifest_path
 
             shard = ctx.shard
             if not isinstance(shard, ScatterReader):
-                # Shard contains every mapper's scatter-data path — reducer
-                # reads all sidecars in parallel and filters for its target.
-                scatter_paths = list(shard)
-                shard = ScatterReader.from_sidecars(scatter_paths, ctx.shard_idx)
+                items = list(shard)
+                if not items:
+                    shard = ScatterReader(iterators=[], max_chunk_rows=0, avg_item_bytes=0.0)
+                else:
+                    if len(items) != 1:
+                        raise ValueError(
+                            f"Reduce shard {ctx.shard_idx} expected exactly 1 combine output dir, got {items}"
+                        )
+                    manifest_path = reducer_manifest_path(items[0], ctx.shard_idx)
+                    shard = ScatterReader.from_combined_manifest(manifest_path)
             stream = _reduce_gen(
                 shard, op.key_fn, op.reducer_fn, sort_fn=op.sort_fn, external_sort_dir=external_sort_dir
             )

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -3,34 +3,23 @@
 
 """Scatter/shuffle support for Zephyr pipelines.
 
-Each source-shard's scatter output is a single binary file
-(``mapper-XXXX.shuffle``) containing a sequence of zstd-compressed frames.
-Within one chunk's zstd frame, items are written in sub-batches of
-``_SUB_BATCH_SIZE`` — each sub-batch is a single ``pickle.dump(list_of_items)``
-into the zstd stream. This amortises per-item pickle/zstd dispatch over a
-sub-batch while still letting the reader stream sub-batches lazily without
-materialising the full chunk.
+Each source shard's scatter output is a ``mapper-XXXX.shuffle`` binary file
+containing zstd-compressed frames; each frame is a sequence of
+``pickle.dump``ed sub-batches of up to ``_SUB_BATCH_SIZE`` items.
 
-Two manifest flavours live alongside the data files in the same directory,
-sharing the ``.scatter_meta`` suffix and differing only in prefix:
+Two manifest flavours share the ``.scatter_meta`` suffix in the same
+directory:
 
-* **Mapper manifest** (``mapper-XXXX.scatter_meta``): written by each mapper
-  next to its ``.shuffle`` file. Maps ``target_shard -> [(offset, length)]``
-  byte ranges plus per-shard ``max_chunk_rows`` and a global
-  ``avg_item_bytes`` estimate.
-* **Reducer manifest** (``reducer-YYYY.scatter_meta``): written once per
-  reducer by the ``CombineMeta`` stage. Inverts the mapper manifests into a
-  single pre-filtered list of ``{path, ranges, max_chunk_rows,
-  avg_item_bytes}`` entries for reducer ``YYYY``. Reducers load exactly one
-  manifest instead of M.
+* ``mapper-XXXX.scatter_meta`` — written by each mapper. Maps
+  ``target_shard -> [(offset, length)]`` plus per-shard ``max_chunk_rows``
+  and a global ``avg_item_bytes``.
+* ``reducer-YYYY.scatter_meta`` — written by the ``CombineMeta`` stage.
+  Pre-filtered list of ``{path, ranges, max_chunk_rows, avg_item_bytes}``
+  entries for reducer ``YYYY``, so reducers read one file instead of M.
 
-On read, each chunk is fetched with a single ``cat_file`` range GET (one
-HTTP request, no per-chunk file handle), then streamed via
-``pickle.load`` on a length-bounded zstd reader. Per-iterator memory stays
-near-constant: one buffered item plus the zstd decoder state plus the
-chunk's compressed bytes (typically a few MB). This bound is essential for
-skewed shuffles where one reducer pulls disproportionate data and the
-external-sort fan-in opens hundreds of chunk iterators at once.
+Chunks are fetched via a single ``cat_file`` range GET and streamed through
+a zstd decoder, so per-iterator memory stays near-constant — important for
+skewed shuffles where the external-sort fan-in opens many chunk iterators.
 """
 
 from __future__ import annotations
@@ -96,21 +85,14 @@ _MAPPER_PREFIX = "mapper-"
 _REDUCER_PREFIX = "reducer-"
 _SCATTER_DATA_SUFFIX = ".shuffle"
 _SCATTER_META_SUFFIX = ".scatter_meta"
-_COMBINE_DONE_MARKER = ".combine_done"
 
-# Number of parallel manifest reads/writes issued by combine_sidecars and by
-# reducers building their ScatterReader. Manifests are small JSON files and
-# the work is GCS GET/PUT-bound, so a modest pool keeps latency low without
-# thrashing.
+# Parallelism for manifest reads/writes — GCS GET/PUT-bound.
 _MANIFEST_IO_CONCURRENCY = 32
-# Number of items sampled from the first flush to estimate avg_item_bytes.
 _SCATTER_SAMPLE_SIZE = 100
-# Fraction of total memory budgeted for read-side decompression buffers.
 _SCATTER_READ_BUFFER_FRACTION = 0.25
 
 _ZSTD_COMPRESS_LEVEL = 3
-# Items per pickle.dump call within a chunk. Larger = faster (less per-call
-# dispatch overhead), smaller = lower per-iterator read memory.
+# Items per pickle.dump within a chunk; trades write speed for read memory.
 _SUB_BATCH_SIZE = 1024
 
 
@@ -135,10 +117,6 @@ def reducer_manifest_path(stage_dir: str, shard_idx: int) -> str:
     return f"{stage_dir}/{_REDUCER_PREFIX}{shard_idx:04d}{_SCATTER_META_SUFFIX}"
 
 
-def _combine_done_path(stage_dir: str) -> str:
-    return f"{stage_dir}/{_COMBINE_DONE_MARKER}"
-
-
 @functools.cache
 def _manifest_decoder() -> msgspec.json.Decoder:
     return msgspec.json.Decoder()
@@ -159,15 +137,7 @@ def _write_mapper_manifest(data_path: str, sidecar: dict) -> None:
 
 @dataclass(frozen=True)
 class _SidecarSlice:
-    """One reducer's slice of a mapper sidecar.
-
-    A full sidecar is ~hundreds of KB and carries byte ranges for every
-    target shard (tens of thousands on large jobs). A reducer only consumes
-    its own shard's ranges plus two scalars, so the worker extracts just
-    those fields and discards the parsed dict before returning. This keeps
-    the reducer's resident memory proportional to the number of mappers
-    instead of mappers * sidecar size.
-    """
+    """One reducer's slice of a mapper sidecar (freed eagerly to bound memory)."""
 
     path: str
     ranges: tuple[tuple[int, int], ...]
@@ -176,26 +146,13 @@ class _SidecarSlice:
 
 
 def _read_mapper_manifest(path: str) -> dict:
-    """Read a mapper's ``.manifest`` file as a dict.
-
-    Uses ``fs.cat_file`` + ``msgspec.json`` — one direct GET returning bytes
-    is ~25% faster than going through ``TextIOWrapper(BufferedFile)`` for
-    small manifests.
-    """
+    """Read a mapper's manifest as a dict (``cat_file`` + ``msgspec.json``)."""
     meta_path = mapper_manifest_path(path)
     fs, fs_path = url_to_fs(meta_path)
     return _manifest_decoder().decode(fs.cat_file(fs_path))
 
 
 def _sidecar_slice_from_manifest(path: str, meta: dict, shard_key: str) -> _SidecarSlice | None:
-    """Extract a per-reducer slice from a parsed mapper manifest.
-
-    Returns ``None`` if the manifest has no ranges for ``shard_key``. Once a
-    shard has ranges, ``max_chunk_rows[shard_key]`` and ``avg_item_bytes``
-    must also be present — ``ScatterWriter`` records both in the same
-    ``_flush`` that appends to ``shards[shard_key]``. A missing field means
-    the manifest is corrupt or from an incompatible version.
-    """
     ranges_raw = meta.get("shards", {}).get(shard_key)
     if not ranges_raw:
         return None
@@ -218,12 +175,10 @@ def _read_sidecar_slice(path: str, shard_key: str) -> _SidecarSlice | None:
 
 
 def _read_sidecar_slices_parallel(scatter_paths: list[str], target_shard: int) -> list[_SidecarSlice]:
-    """Read every mapper manifest concurrently and return per-shard slices.
+    """Read every mapper manifest and return slices for ``target_shard``.
 
-    Used by the legacy per-reducer read path (``ScatterReader.from_sidecars``).
-    The ``CombineMeta`` stage replaces this with a single manifest read per
-    reducer; this helper remains for tests and for callers bypassing the
-    combine stage.
+    Used by ``ScatterReader.from_sidecars``; the ``CombineMeta`` stage
+    replaces this with a single pre-built manifest per reducer.
     """
     shard_key = str(target_shard)
     ordered: list[_SidecarSlice | None] = [None] * len(scatter_paths)
@@ -239,41 +194,23 @@ def combine_sidecars(
     scatter_paths: list[str],
     num_output_shards: int,
     out_dir: str,
+    task_idx: int = 0,
+    num_combine_tasks: int = 1,
 ) -> str:
-    """Invert M mapper manifests into R reducer manifests.
+    """Invert mapper manifests into this task's slice of reducer manifests.
 
-    Reads every ``mapper-XXXX.scatter_meta`` in ``scatter_paths`` concurrently,
-    buckets each mapper's per-reducer byte ranges by target shard, and writes
-    R ``reducer-YYYY.scatter_meta`` files under ``out_dir`` — each containing
-    a pre-filtered list of ``{path, ranges, max_chunk_rows, avg_item_bytes}``
-    entries for one reducer.
-
-    A ``.combine_done`` marker is written last so reducers can distinguish a
-    completed combine from a partial write after a worker crash mid-run.
-
-    Args:
-        scatter_paths: List of mapper ``.shuffle`` data paths (one per mapper
-            source shard). Mapper manifest paths are derived via
-            :func:`mapper_manifest_path`.
-        num_output_shards: R — the number of reducer manifests to emit.
-        out_dir: Directory where reducer manifests are written. Typically the
-            same directory that holds the mapper files.
-
-    Returns:
-        ``out_dir`` (for convenience — callers pass this through as the
-        combine stage's single-chunk output).
+    Task ``task_idx`` of ``num_combine_tasks`` owns target shards in
+    ``range(task_idx, num_output_shards, num_combine_tasks)`` — a strided
+    slice so every task reads the full M mappers but only holds/writes
+    ``ceil(R/K)`` reducers' ranges. Peak memory is the inverted
+    ``(R/K) x M`` entry matrix plus the per-parse manifest buffer.
     """
     if num_output_shards < 0:
         raise ValueError(f"num_output_shards must be >= 0, got {num_output_shards}")
+    if num_combine_tasks < 1 or not (0 <= task_idx < num_combine_tasks):
+        raise ValueError(f"invalid task_idx={task_idx} / num_combine_tasks={num_combine_tasks}")
 
-    # Stream manifests through as they complete: workers parse each mapper
-    # manifest and return only the per-reducer entries, then the main thread
-    # buckets them into ``per_reducer`` and the parsed dict is freed. This
-    # keeps combine-task resident memory proportional to the inverted RxM
-    # range matrix rather than also holding every mapper's full manifest at
-    # once — important on large jobs where individual mapper manifests can
-    # be hundreds of KB each. Bucketing stays single-threaded to avoid
-    # defaultdict race on the first insert for a target shard.
+    owned_targets = set(range(task_idx, num_output_shards, num_combine_tasks))
     per_reducer: dict[int, list[dict]] = defaultdict(list)
 
     def _extract_entries(path: str) -> list[tuple[int, dict]]:
@@ -285,11 +222,14 @@ def combine_sidecars(
         for shard_key, ranges in shards.items():
             if not ranges:
                 continue
+            target = int(shard_key)
+            if target not in owned_targets:
+                continue
             if shard_key not in max_rows_map:
                 raise ValueError(f"Manifest for {path} has ranges for shard {shard_key} but no max_chunk_rows entry.")
             out.append(
                 (
-                    int(shard_key),
+                    target,
                     {
                         "path": path,
                         "ranges": ranges,
@@ -300,9 +240,7 @@ def combine_sidecars(
             )
         return out
 
-    with log_time(
-        f"combine_sidecars: reading {len(scatter_paths)} mapper manifests (concurrency={_MANIFEST_IO_CONCURRENCY})"
-    ):
+    with log_time(f"combine_sidecars[{task_idx}/{num_combine_tasks}]: reading {len(scatter_paths)} mapper manifests"):
         with concurrent.futures.ThreadPoolExecutor(max_workers=_MANIFEST_IO_CONCURRENCY) as pool:
             futures = [pool.submit(_extract_entries, p) for p in scatter_paths]
             for fut in concurrent.futures.as_completed(futures):
@@ -317,24 +255,17 @@ def combine_sidecars(
         with open_url(manifest_path, "wb") as f:
             f.write(payload)
 
-    with log_time(
-        f"combine_sidecars: writing {num_output_shards} reducer manifests " f"(concurrency={_MANIFEST_IO_CONCURRENCY})"
-    ):
+    with log_time(f"combine_sidecars[{task_idx}/{num_combine_tasks}]: writing {len(owned_targets)} reducer manifests"):
         with concurrent.futures.ThreadPoolExecutor(max_workers=_MANIFEST_IO_CONCURRENCY) as pool:
-            for _ in pool.map(_write_reducer_manifest, range(num_output_shards)):
+            for _ in pool.map(_write_reducer_manifest, sorted(owned_targets)):
                 pass
 
-    # Done marker is written last so a reducer seeing it knows all R manifest
-    # files are present; otherwise a crashed combine could leave a partial
-    # directory that a retrying worker silently misreads.
-    done_path = _combine_done_path(out_dir)
-    with open_url(done_path, "wb") as f:
-        f.write(b"")
-
     logger.info(
-        "combine_sidecars: %d mappers -> %d reducer manifests under %s",
+        "combine_sidecars[%d/%d]: %d mappers -> %d reducer manifests under %s",
+        task_idx,
+        num_combine_tasks,
         len(scatter_paths),
-        num_output_shards,
+        len(owned_targets),
         out_dir,
     )
     return out_dir
@@ -406,10 +337,8 @@ def _iter_chunk(fs: Any, fs_path: str, offset: int, length: int) -> Iterator:
 class ScatterReader:
     """All scatter chunks for one target shard, across all source files.
 
-    Construct via :meth:`from_combined_manifest` for production use (single
-    manifest read per reducer, written by the ``CombineMeta`` stage), or
-    :meth:`from_sidecars` when bypassing the combine stage. Fields may also
-    be passed directly for testing.
+    Prefer :meth:`from_combined_manifest` (one read per reducer, written by
+    ``CombineMeta``); :meth:`from_sidecars` bypasses the combine stage.
     """
 
     def __init__(
@@ -424,14 +353,7 @@ class ScatterReader:
 
     @classmethod
     def from_sidecars(cls, scatter_paths: list[str], target_shard: int) -> ScatterReader:
-        """Build a ScatterReader by reading every mapper's ``.manifest`` directly.
-
-        Each reducer reads all M mapper manifests in parallel and filters for
-        its own ``target_shard``. Prefer :meth:`from_combined_manifest` in
-        production pipelines — a ``CombineMeta`` stage aggregates the M
-        mapper manifests once into per-reducer manifests, so each reducer
-        only reads a single file.
-        """
+        """Build a ScatterReader by reading every mapper manifest directly."""
         iterators: list[ScatterFileIterator] = []
         max_rows = 0
         weighted_bytes = 0.0
@@ -463,13 +385,7 @@ class ScatterReader:
 
     @classmethod
     def from_combined_manifest(cls, manifest_path: str) -> ScatterReader:
-        """Build a ScatterReader from a single reducer manifest.
-
-        The manifest (written by ``combine_sidecars``) contains one entry per
-        contributing mapper file with its byte ranges for this reducer,
-        plus ``max_chunk_rows`` and ``avg_item_bytes`` already resolved —
-        no per-mapper filtering or weighted averaging is needed at read time.
-        """
+        """Build a ScatterReader from one pre-built reducer manifest."""
         fs, fs_path = url_to_fs(manifest_path)
         with log_time(f"Reading combined manifest {manifest_path}"):
             payload = _manifest_decoder().decode(fs.cat_file(fs_path))

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -262,7 +262,7 @@ def combine_sidecars(
     # Stream manifests through as they complete: workers parse each mapper
     # manifest and return only the per-reducer entries, then the main thread
     # buckets them into ``per_reducer`` and the parsed dict is freed. This
-    # keeps combine-task resident memory proportional to the inverted R×M
+    # keeps combine-task resident memory proportional to the inverted RxM
     # range matrix rather than also holding every mapper's full manifest at
     # once — important on large jobs where individual mapper manifests can
     # be hundreds of KB each. Bucketing stays single-threaded to avoid

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -36,6 +36,7 @@ external-sort fan-in opens hundreds of chunk iterators at once.
 from __future__ import annotations
 
 import concurrent.futures
+import functools
 import io
 import logging
 import os
@@ -138,13 +139,19 @@ def _combine_done_path(stage_dir: str) -> str:
     return f"{stage_dir}/{_COMBINE_DONE_MARKER}"
 
 
-_MANIFEST_DECODER = msgspec.json.Decoder()
-_MANIFEST_ENCODER = msgspec.json.Encoder()
+@functools.cache
+def _manifest_decoder() -> msgspec.json.Decoder:
+    return msgspec.json.Decoder()
+
+
+@functools.cache
+def _manifest_encoder() -> msgspec.json.Encoder:
+    return msgspec.json.Encoder()
 
 
 def _write_mapper_manifest(data_path: str, sidecar: dict) -> None:
     meta_path = mapper_manifest_path(data_path)
-    payload = _MANIFEST_ENCODER.encode(sidecar)
+    payload = _manifest_encoder().encode(sidecar)
     with log_time(f"Writing mapper manifest for {data_path} to {meta_path}", level=logging.DEBUG):
         with open_url(meta_path, "wb") as f:
             f.write(payload)
@@ -177,7 +184,7 @@ def _read_mapper_manifest(path: str) -> dict:
     """
     meta_path = mapper_manifest_path(path)
     fs, fs_path = url_to_fs(meta_path)
-    return _MANIFEST_DECODER.decode(fs.cat_file(fs_path))
+    return _manifest_decoder().decode(fs.cat_file(fs_path))
 
 
 def _sidecar_slice_from_manifest(path: str, meta: dict, shard_key: str) -> _SidecarSlice | None:
@@ -305,7 +312,7 @@ def combine_sidecars(
     def _write_reducer_manifest(shard_idx: int) -> None:
         entries = per_reducer.get(shard_idx, [])
         manifest_path = reducer_manifest_path(out_dir, shard_idx)
-        payload = _MANIFEST_ENCODER.encode({"entries": entries})
+        payload = _manifest_encoder().encode({"entries": entries})
         ensure_parent_dir(manifest_path)
         with open_url(manifest_path, "wb") as f:
             f.write(payload)
@@ -465,7 +472,7 @@ class ScatterReader:
         """
         fs, fs_path = url_to_fs(manifest_path)
         with log_time(f"Reading combined manifest {manifest_path}"):
-            payload = _MANIFEST_DECODER.decode(fs.cat_file(fs_path))
+            payload = _manifest_decoder().decode(fs.cat_file(fs_path))
 
         entries = payload.get("entries", [])
         iterators: list[ScatterFileIterator] = []

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -3,18 +3,26 @@
 
 """Scatter/shuffle support for Zephyr pipelines.
 
-Each source-shard's scatter output is a single binary file containing a
-sequence of zstd-compressed frames. Within one chunk's zstd frame, items
-are written in sub-batches of ``_SUB_BATCH_SIZE`` — each sub-batch is a
-single ``pickle.dump(list_of_items)`` into the zstd stream. This amortises
-per-item pickle/zstd dispatch over a sub-batch while still letting the
-reader stream sub-batches lazily without materialising the full chunk.
+Each source-shard's scatter output is a single binary file
+(``mapper-XXXX.shuffle``) containing a sequence of zstd-compressed frames.
+Within one chunk's zstd frame, items are written in sub-batches of
+``_SUB_BATCH_SIZE`` — each sub-batch is a single ``pickle.dump(list_of_items)``
+into the zstd stream. This amortises per-item pickle/zstd dispatch over a
+sub-batch while still letting the reader stream sub-batches lazily without
+materialising the full chunk.
 
-A JSON sidecar (``.scatter_meta``) maps ``target_shard -> [(offset, length)]``
-byte ranges into the data file, plus per-shard ``max_chunk_rows`` and a global
-``avg_item_bytes`` estimate. Sidecars from all source shards are aggregated
-into a single ``scatter_metadata`` manifest at the end of the scatter stage,
-which reducers consume to build :class:`ScatterReader` instances.
+Two manifest flavours live alongside the data files in the same directory,
+sharing the ``.scatter_meta`` suffix and differing only in prefix:
+
+* **Mapper manifest** (``mapper-XXXX.scatter_meta``): written by each mapper
+  next to its ``.shuffle`` file. Maps ``target_shard -> [(offset, length)]``
+  byte ranges plus per-shard ``max_chunk_rows`` and a global
+  ``avg_item_bytes`` estimate.
+* **Reducer manifest** (``reducer-YYYY.scatter_meta``): written once per
+  reducer by the ``CombineMeta`` stage. Inverts the mapper manifests into a
+  single pre-filtered list of ``{path, ranges, max_chunk_rows,
+  avg_item_bytes}`` entries for reducer ``YYYY``. Reducers load exactly one
+  manifest instead of M.
 
 On read, each chunk is fetched with a single ``cat_file`` range GET (one
 HTTP request, no per-chunk file handle), then streamed via
@@ -29,7 +37,6 @@ from __future__ import annotations
 
 import concurrent.futures
 import io
-import json
 import logging
 import os
 import pickle
@@ -39,6 +46,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import cloudpickle
+import msgspec
 import zstandard as zstd
 from rigging.filesystem import open_url, url_to_fs
 from rigging.timing import log_time
@@ -83,13 +91,17 @@ class ListShard:
 # Constants
 # ---------------------------------------------------------------------------
 
-_SCATTER_META_SUFFIX = ".scatter_meta"
+_MAPPER_PREFIX = "mapper-"
+_REDUCER_PREFIX = "reducer-"
 _SCATTER_DATA_SUFFIX = ".shuffle"
+_SCATTER_META_SUFFIX = ".scatter_meta"
+_COMBINE_DONE_MARKER = ".combine_done"
 
-# Number of parallel sidecar reads each reducer issues when building its
-# ScatterReader. Sidecars are small JSON files (a few KB) and reads are
-# GCS GET-bound, so a modest pool keeps latency low without thrashing.
-_SIDECAR_READ_CONCURRENCY = 32
+# Number of parallel manifest reads/writes issued by combine_sidecars and by
+# reducers building their ScatterReader. Manifests are small JSON files and
+# the work is GCS GET/PUT-bound, so a modest pool keeps latency low without
+# thrashing.
+_MANIFEST_IO_CONCURRENCY = 32
 # Number of items sampled from the first flush to estimate avg_item_bytes.
 _SCATTER_SAMPLE_SIZE = 100
 # Fraction of total memory budgeted for read-side decompression buffers.
@@ -106,17 +118,35 @@ _SUB_BATCH_SIZE = 1024
 # ---------------------------------------------------------------------------
 
 
-def _scatter_meta_path(data_path: str) -> str:
-    """``shard-0000.shuffle`` -> ``shard-0000.scatter_meta``."""
+def mapper_data_path(stage_dir: str, shard_idx: int) -> str:
+    """``{stage_dir}/mapper-0000.shuffle``."""
+    return f"{stage_dir}/{_MAPPER_PREFIX}{shard_idx:04d}{_SCATTER_DATA_SUFFIX}"
+
+
+def mapper_manifest_path(data_path: str) -> str:
+    """``mapper-0000.shuffle`` -> ``mapper-0000.scatter_meta``."""
     stem, _ = os.path.splitext(data_path)
     return stem + _SCATTER_META_SUFFIX
 
 
-def _write_scatter_meta(data_path: str, sidecar: dict) -> None:
-    meta_path = _scatter_meta_path(data_path)
-    payload = json.dumps(sidecar)
-    with log_time(f"Writing scatter meta for {data_path} to {meta_path}", level=logging.DEBUG):
-        with open_url(meta_path, "w") as f:
+def reducer_manifest_path(stage_dir: str, shard_idx: int) -> str:
+    """``{stage_dir}/reducer-0000.scatter_meta``."""
+    return f"{stage_dir}/{_REDUCER_PREFIX}{shard_idx:04d}{_SCATTER_META_SUFFIX}"
+
+
+def _combine_done_path(stage_dir: str) -> str:
+    return f"{stage_dir}/{_COMBINE_DONE_MARKER}"
+
+
+_MANIFEST_DECODER = msgspec.json.Decoder()
+_MANIFEST_ENCODER = msgspec.json.Encoder()
+
+
+def _write_mapper_manifest(data_path: str, sidecar: dict) -> None:
+    meta_path = mapper_manifest_path(data_path)
+    payload = _MANIFEST_ENCODER.encode(sidecar)
+    with log_time(f"Writing mapper manifest for {data_path} to {meta_path}", level=logging.DEBUG):
+        with open_url(meta_path, "wb") as f:
             f.write(payload)
 
 
@@ -138,32 +168,35 @@ class _SidecarSlice:
     avg_item_bytes: float
 
 
-def _read_sidecar_slice(path: str, shard_key: str) -> _SidecarSlice | None:
-    """Read one sidecar and extract only the fields for ``shard_key``.
+def _read_mapper_manifest(path: str) -> dict:
+    """Read a mapper's ``.manifest`` file as a dict.
 
-    Returns ``None`` if the sidecar has no ranges for this shard. The parsed
-    dict is released when this function returns. Once we confirm this shard
-    has ranges, ``max_chunk_rows[shard_key]`` and ``avg_item_bytes`` must
-    also be present — ``ScatterWriter`` records both in the same ``_flush``
-    that appends to ``shards[shard_key]``. A missing field here means the
-    sidecar is corrupt or was written by an incompatible version, and we
-    fail rather than silently substituting zero.
-
-    Uses ``fs.cat_file`` rather than ``open_url`` — one direct GET returning
-    bytes is ~25% faster than going through ``TextIOWrapper(BufferedFile)``
-    for small sidecars, and ``json.loads`` accepts bytes directly.
+    Uses ``fs.cat_file`` + ``msgspec.json`` — one direct GET returning bytes
+    is ~25% faster than going through ``TextIOWrapper(BufferedFile)`` for
+    small manifests.
     """
-    meta_path = _scatter_meta_path(path)
+    meta_path = mapper_manifest_path(path)
     fs, fs_path = url_to_fs(meta_path)
-    meta = json.loads(fs.cat_file(fs_path))
+    return _MANIFEST_DECODER.decode(fs.cat_file(fs_path))
+
+
+def _sidecar_slice_from_manifest(path: str, meta: dict, shard_key: str) -> _SidecarSlice | None:
+    """Extract a per-reducer slice from a parsed mapper manifest.
+
+    Returns ``None`` if the manifest has no ranges for ``shard_key``. Once a
+    shard has ranges, ``max_chunk_rows[shard_key]`` and ``avg_item_bytes``
+    must also be present — ``ScatterWriter`` records both in the same
+    ``_flush`` that appends to ``shards[shard_key]``. A missing field means
+    the manifest is corrupt or from an incompatible version.
+    """
     ranges_raw = meta.get("shards", {}).get(shard_key)
     if not ranges_raw:
         return None
     max_rows_map = meta.get("max_chunk_rows", {})
     if shard_key not in max_rows_map:
-        raise ValueError(f"Sidecar {meta_path} has ranges for shard {shard_key} but no max_chunk_rows entry.")
+        raise ValueError(f"Manifest for {path} has ranges for shard {shard_key} but no max_chunk_rows entry.")
     if "avg_item_bytes" not in meta:
-        raise ValueError(f"Sidecar {meta_path} has ranges for shard {shard_key} but no avg_item_bytes.")
+        raise ValueError(f"Manifest for {path} has ranges for shard {shard_key} but no avg_item_bytes.")
     ranges = tuple((int(off), int(length)) for off, length in ranges_raw)
     return _SidecarSlice(
         path=path,
@@ -173,26 +206,116 @@ def _read_sidecar_slice(path: str, shard_key: str) -> _SidecarSlice | None:
     )
 
 
+def _read_sidecar_slice(path: str, shard_key: str) -> _SidecarSlice | None:
+    return _sidecar_slice_from_manifest(path, _read_mapper_manifest(path), shard_key)
+
+
 def _read_sidecar_slices_parallel(scatter_paths: list[str], target_shard: int) -> list[_SidecarSlice]:
-    """Read every sidecar concurrently and return per-shard slices in input order.
+    """Read every mapper manifest concurrently and return per-shard slices.
 
-    Extraction happens inside the worker so full sidecar dicts never
-    accumulate in the reducer process. Sidecars with no ranges for
-    ``target_shard`` are dropped.
-
-    TODO(rav): each reducer subprocess re-reads every sidecar even though only
-    one shard's byte ranges are used. A worker-level sidecar cache (or a shared
-    read across colocated reducers) would avoid the redundant GCS GETs when
-    many reducers run on the same host.
+    Used by the legacy per-reducer read path (``ScatterReader.from_sidecars``).
+    The ``CombineMeta`` stage replaces this with a single manifest read per
+    reducer; this helper remains for tests and for callers bypassing the
+    combine stage.
     """
     shard_key = str(target_shard)
     ordered: list[_SidecarSlice | None] = [None] * len(scatter_paths)
-    with concurrent.futures.ThreadPoolExecutor(max_workers=_SIDECAR_READ_CONCURRENCY) as pool:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=_MANIFEST_IO_CONCURRENCY) as pool:
         futures = {pool.submit(_read_sidecar_slice, p, shard_key): i for i, p in enumerate(scatter_paths)}
         for fut in concurrent.futures.as_completed(futures):
             idx = futures[fut]
             ordered[idx] = fut.result()
     return [s for s in ordered if s is not None]
+
+
+def combine_sidecars(
+    scatter_paths: list[str],
+    num_output_shards: int,
+    out_dir: str,
+) -> str:
+    """Invert M mapper manifests into R reducer manifests.
+
+    Reads every ``mapper-XXXX.scatter_meta`` in ``scatter_paths`` concurrently,
+    buckets each mapper's per-reducer byte ranges by target shard, and writes
+    R ``reducer-YYYY.scatter_meta`` files under ``out_dir`` — each containing
+    a pre-filtered list of ``{path, ranges, max_chunk_rows, avg_item_bytes}``
+    entries for one reducer.
+
+    A ``.combine_done`` marker is written last so reducers can distinguish a
+    completed combine from a partial write after a worker crash mid-run.
+
+    Args:
+        scatter_paths: List of mapper ``.shuffle`` data paths (one per mapper
+            source shard). Mapper manifest paths are derived via
+            :func:`mapper_manifest_path`.
+        num_output_shards: R — the number of reducer manifests to emit.
+        out_dir: Directory where reducer manifests are written. Typically the
+            same directory that holds the mapper files.
+
+    Returns:
+        ``out_dir`` (for convenience — callers pass this through as the
+        combine stage's single-chunk output).
+    """
+    if num_output_shards <= 0:
+        raise ValueError(f"num_output_shards must be > 0, got {num_output_shards}")
+
+    with log_time(
+        f"combine_sidecars: reading {len(scatter_paths)} mapper manifests " f"(concurrency={_MANIFEST_IO_CONCURRENCY})"
+    ):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=_MANIFEST_IO_CONCURRENCY) as pool:
+            per_mapper: list[tuple[str, dict]] = list(
+                zip(scatter_paths, pool.map(_read_mapper_manifest, scatter_paths), strict=True)
+            )
+
+    per_reducer: dict[int, list[dict]] = defaultdict(list)
+    for path, meta in per_mapper:
+        shards = meta.get("shards", {})
+        max_rows_map = meta.get("max_chunk_rows", {})
+        avg_bytes = float(meta.get("avg_item_bytes", 0.0))
+        for shard_key, ranges in shards.items():
+            if not ranges:
+                continue
+            target = int(shard_key)
+            if shard_key not in max_rows_map:
+                raise ValueError(f"Manifest for {path} has ranges for shard {shard_key} but no max_chunk_rows entry.")
+            per_reducer[target].append(
+                {
+                    "path": path,
+                    "ranges": ranges,
+                    "max_chunk_rows": int(max_rows_map[shard_key]),
+                    "avg_item_bytes": avg_bytes,
+                }
+            )
+
+    def _write_reducer_manifest(shard_idx: int) -> None:
+        entries = per_reducer.get(shard_idx, [])
+        manifest_path = reducer_manifest_path(out_dir, shard_idx)
+        payload = _MANIFEST_ENCODER.encode({"entries": entries})
+        ensure_parent_dir(manifest_path)
+        with open_url(manifest_path, "wb") as f:
+            f.write(payload)
+
+    with log_time(
+        f"combine_sidecars: writing {num_output_shards} reducer manifests " f"(concurrency={_MANIFEST_IO_CONCURRENCY})"
+    ):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=_MANIFEST_IO_CONCURRENCY) as pool:
+            for _ in pool.map(_write_reducer_manifest, range(num_output_shards)):
+                pass
+
+    # Done marker is written last so a reducer seeing it knows all R manifest
+    # files are present; otherwise a crashed combine could leave a partial
+    # directory that a retrying worker silently misreads.
+    done_path = _combine_done_path(out_dir)
+    with open_url(done_path, "wb") as f:
+        f.write(b"")
+
+    logger.info(
+        "combine_sidecars: %d mappers -> %d reducer manifests under %s",
+        len(scatter_paths),
+        num_output_shards,
+        out_dir,
+    )
+    return out_dir
 
 
 # ---------------------------------------------------------------------------
@@ -261,8 +384,10 @@ def _iter_chunk(fs: Any, fs_path: str, offset: int, length: int) -> Iterator:
 class ScatterReader:
     """All scatter chunks for one target shard, across all source files.
 
-    Construct via :meth:`from_sidecars` for production use, or pass fields
-    directly for testing.
+    Construct via :meth:`from_combined_manifest` for production use (single
+    manifest read per reducer, written by the ``CombineMeta`` stage), or
+    :meth:`from_sidecars` when bypassing the combine stage. Fields may also
+    be passed directly for testing.
     """
 
     def __init__(
@@ -277,12 +402,13 @@ class ScatterReader:
 
     @classmethod
     def from_sidecars(cls, scatter_paths: list[str], target_shard: int) -> ScatterReader:
-        """Build a ScatterReader by reading per-mapper sidecars directly.
+        """Build a ScatterReader by reading every mapper's ``.manifest`` directly.
 
-        Each reducer reads every mapper's ``.scatter_meta`` sidecar in parallel
-        and filters for its own ``target_shard``. No coordinator-written manifest
-        is needed, which eliminates a serialization bottleneck when there are
-        thousands of mappers.
+        Each reducer reads all M mapper manifests in parallel and filters for
+        its own ``target_shard``. Prefer :meth:`from_combined_manifest` in
+        production pipelines — a ``CombineMeta`` stage aggregates the M
+        mapper manifests once into per-reducer manifests, so each reducer
+        only reads a single file.
         """
         iterators: list[ScatterFileIterator] = []
         max_rows = 0
@@ -291,7 +417,7 @@ class ScatterReader:
 
         with log_time(
             f"Building ScatterReader for target shard {target_shard} "
-            f"from {len(scatter_paths)} sidecars (concurrency={_SIDECAR_READ_CONCURRENCY})"
+            f"from {len(scatter_paths)} manifests (concurrency={_MANIFEST_IO_CONCURRENCY})"
         ):
             for slice_ in _read_sidecar_slices_parallel(scatter_paths, target_shard):
                 iterators.append(ScatterFileIterator(path=slice_.path, chunks=slice_.ranges))
@@ -304,8 +430,49 @@ class ScatterReader:
         avg_item_bytes = weighted_bytes / total_chunks_for_avg if total_chunks_for_avg > 0 else 0.0
 
         logger.info(
-            "ScatterReader for shard %d: %d files, %d total chunks, " "max_chunk_rows=%d, avg_item_bytes=%.1f",
+            "ScatterReader for shard %d: %d files, %d total chunks, max_chunk_rows=%d, avg_item_bytes=%.1f",
             target_shard,
+            len(iterators),
+            sum(it.chunk_count for it in iterators),
+            max_rows,
+            avg_item_bytes,
+        )
+        return cls(iterators=iterators, max_chunk_rows=max_rows, avg_item_bytes=avg_item_bytes)
+
+    @classmethod
+    def from_combined_manifest(cls, manifest_path: str) -> ScatterReader:
+        """Build a ScatterReader from a single reducer manifest.
+
+        The manifest (written by ``combine_sidecars``) contains one entry per
+        contributing mapper file with its byte ranges for this reducer,
+        plus ``max_chunk_rows`` and ``avg_item_bytes`` already resolved —
+        no per-mapper filtering or weighted averaging is needed at read time.
+        """
+        fs, fs_path = url_to_fs(manifest_path)
+        with log_time(f"Reading combined manifest {manifest_path}"):
+            payload = _MANIFEST_DECODER.decode(fs.cat_file(fs_path))
+
+        entries = payload.get("entries", [])
+        iterators: list[ScatterFileIterator] = []
+        max_rows = 0
+        weighted_bytes = 0.0
+        total_chunks_for_avg = 0
+        for entry in entries:
+            ranges = tuple((int(off), int(length)) for off, length in entry["ranges"])
+            iterators.append(ScatterFileIterator(path=entry["path"], chunks=ranges))
+            max_rows = max(max_rows, int(entry["max_chunk_rows"]))
+            avg = float(entry.get("avg_item_bytes", 0.0))
+            if avg > 0:
+                count = len(ranges)
+                weighted_bytes += avg * count
+                total_chunks_for_avg += count
+
+        avg_item_bytes = weighted_bytes / total_chunks_for_avg if total_chunks_for_avg > 0 else 0.0
+
+        logger.info(
+            "ScatterReader from combined manifest %s: %d files, %d total chunks, "
+            "max_chunk_rows=%d, avg_item_bytes=%.1f",
+            manifest_path,
             len(iterators),
             sum(it.chunk_count for it in iterators),
             max_rows,
@@ -526,8 +693,8 @@ class ScatterWriter:
         if self._avg_item_bytes > 0:
             sidecar["avg_item_bytes"] = round(self._avg_item_bytes, 1)
 
-        with log_time(f"Writing scatter meta for {self._data_path}"):
-            _write_scatter_meta(self._data_path, sidecar)
+        with log_time(f"Writing mapper manifest for {self._data_path}"):
+            _write_mapper_manifest(self._data_path, sidecar)
 
         return ListShard(refs=[MemChunk(items=[self._data_path])])
 

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -256,36 +256,51 @@ def combine_sidecars(
         ``out_dir`` (for convenience — callers pass this through as the
         combine stage's single-chunk output).
     """
-    if num_output_shards <= 0:
-        raise ValueError(f"num_output_shards must be > 0, got {num_output_shards}")
+    if num_output_shards < 0:
+        raise ValueError(f"num_output_shards must be >= 0, got {num_output_shards}")
 
-    with log_time(
-        f"combine_sidecars: reading {len(scatter_paths)} mapper manifests " f"(concurrency={_MANIFEST_IO_CONCURRENCY})"
-    ):
-        with concurrent.futures.ThreadPoolExecutor(max_workers=_MANIFEST_IO_CONCURRENCY) as pool:
-            per_mapper: list[tuple[str, dict]] = list(
-                zip(scatter_paths, pool.map(_read_mapper_manifest, scatter_paths), strict=True)
-            )
-
+    # Stream manifests through as they complete: workers parse each mapper
+    # manifest and return only the per-reducer entries, then the main thread
+    # buckets them into ``per_reducer`` and the parsed dict is freed. This
+    # keeps combine-task resident memory proportional to the inverted R×M
+    # range matrix rather than also holding every mapper's full manifest at
+    # once — important on large jobs where individual mapper manifests can
+    # be hundreds of KB each. Bucketing stays single-threaded to avoid
+    # defaultdict race on the first insert for a target shard.
     per_reducer: dict[int, list[dict]] = defaultdict(list)
-    for path, meta in per_mapper:
+
+    def _extract_entries(path: str) -> list[tuple[int, dict]]:
+        meta = _read_mapper_manifest(path)
         shards = meta.get("shards", {})
         max_rows_map = meta.get("max_chunk_rows", {})
         avg_bytes = float(meta.get("avg_item_bytes", 0.0))
+        out: list[tuple[int, dict]] = []
         for shard_key, ranges in shards.items():
             if not ranges:
                 continue
-            target = int(shard_key)
             if shard_key not in max_rows_map:
                 raise ValueError(f"Manifest for {path} has ranges for shard {shard_key} but no max_chunk_rows entry.")
-            per_reducer[target].append(
-                {
-                    "path": path,
-                    "ranges": ranges,
-                    "max_chunk_rows": int(max_rows_map[shard_key]),
-                    "avg_item_bytes": avg_bytes,
-                }
+            out.append(
+                (
+                    int(shard_key),
+                    {
+                        "path": path,
+                        "ranges": ranges,
+                        "max_chunk_rows": int(max_rows_map[shard_key]),
+                        "avg_item_bytes": avg_bytes,
+                    },
+                )
             )
+        return out
+
+    with log_time(
+        f"combine_sidecars: reading {len(scatter_paths)} mapper manifests (concurrency={_MANIFEST_IO_CONCURRENCY})"
+    ):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=_MANIFEST_IO_CONCURRENCY) as pool:
+            futures = [pool.submit(_extract_entries, p) for p in scatter_paths]
+            for fut in concurrent.futures.as_completed(futures):
+                for target, entry in fut.result():
+                    per_reducer[target].append(entry)
 
     def _write_reducer_manifest(shard_idx: int) -> None:
         entries = per_reducer.get(shard_idx, [])

--- a/lib/zephyr/src/zephyr/subprocess_worker.py
+++ b/lib/zephyr/src/zephyr/subprocess_worker.py
@@ -31,7 +31,7 @@ from zephyr.execution import (
     _worker_ctx_var,
     _write_stage_output,
 )
-from zephyr.plan import Scatter, StageContext, run_stage
+from zephyr.plan import CombineMeta, Scatter, StageContext, run_stage
 
 logger = logging.getLogger(__name__)
 
@@ -161,6 +161,7 @@ def execute_shard(task_file: str, result_file: str) -> None:
         stage_dir = f"{chunk_prefix}/{execution_id}/{task.stage_name}"
         external_sort_dir = f"{stage_dir}-external-sort/shard-{task.shard_idx:04d}"
         scatter_op = next((op for op in task.operations if isinstance(op, Scatter)), None)
+        combine_op = next((op for op in task.operations if isinstance(op, CombineMeta)), None)
 
         result_or_error = _write_stage_output(
             run_stage(stage_ctx, task.operations, external_sort_dir=external_sort_dir),
@@ -168,6 +169,7 @@ def execute_shard(task_file: str, result_file: str) -> None:
             stage_dir=stage_dir,
             shard_idx=task.shard_idx,
             scatter_op=scatter_op,
+            combine_op=combine_op,
             total_shards=task.total_shards,
         )
     except Exception as e:

--- a/lib/zephyr/tests/test_groupby.py
+++ b/lib/zephyr/tests/test_groupby.py
@@ -527,3 +527,22 @@ def test_group_by_combiner_integration(integration_ctx):
         {"key": "a", "ids": [1, 2]},
         {"key": "b", "ids": [3, 4]},
     ]
+
+
+def test_group_by_with_multiple_combine_tasks(zephyr_ctx, monkeypatch):
+    """Force K>1 via a tiny memory budget so the combine stage splits into
+    multiple parallel tasks; output must match the K=1 path."""
+    from zephyr import execution
+
+    # 1-byte budget forces _auto_combine_tasks to cap K at R (== num_shards).
+    monkeypatch.setattr(execution, "_COMBINE_TASK_MEM_BUDGET", 1)
+
+    data = [{"k": i % 4, "v": i} for i in range(40)]
+    ds = Dataset.from_list(data).group_by(
+        key=lambda x: x["k"],
+        reducer=lambda key, items: {"k": key, "sum": sum(x["v"] for x in items)},
+        num_output_shards=4,
+    )
+    results = sorted(zephyr_ctx.execute(ds).results, key=lambda x: x["k"])
+    expected = [{"k": k, "sum": sum(v for v in range(40) if v % 4 == k)} for k in range(4)]
+    assert results == expected

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -11,8 +11,12 @@ from zephyr.plan import deterministic_hash
 from zephyr.shuffle import (
     ScatterFileIterator,
     ScatterReader,
+    _COMBINE_DONE_MARKER,
     _write_chunk_frame,
     _write_scatter,
+    combine_sidecars,
+    mapper_data_path,
+    reducer_manifest_path,
 )
 
 
@@ -26,7 +30,7 @@ def _target(key, num_shards):
 
 def _build_shard(tmp_path, items, num_output_shards=4, source_shard=0):
     """Write a scatter file + sidecar; return scatter_paths for direct reducer reads."""
-    data_path = str(tmp_path / f"shard-{source_shard:04d}.shuffle")
+    data_path = mapper_data_path(str(tmp_path), source_shard)
     list_shard = _write_scatter(
         iter(items),
         source_shard=source_shard,
@@ -184,7 +188,7 @@ def test_scatter_file_iterator_multiple_chunks(tmp_path):
     frame_a = _write_chunk_frame(chunk_a)
     frame_b = _write_chunk_frame(chunk_b)
 
-    path = str(tmp_path / "two-chunks.shuffle")
+    path = str(tmp_path / "mapper-two-chunks.shuffle")
     with open(path, "wb") as f:
         f.write(frame_a)
         f.write(frame_b)
@@ -192,6 +196,99 @@ def test_scatter_file_iterator_multiple_chunks(tmp_path):
     it = ScatterFileIterator(path=path, chunks=((0, len(frame_a)), (len(frame_a), len(frame_b))))
     chunks = [list(c) for c in it.get_chunk_iterators()]
     assert chunks == [chunk_a, chunk_b]
+
+
+# ---------------------------------------------------------------------------
+# combine_sidecars + from_combined_manifest
+# ---------------------------------------------------------------------------
+
+
+def _build_many_mappers(tmp_path, num_mappers, num_output_shards, items_per_mapper):
+    """Write N mapper files into tmp_path. Returns (scatter_paths, all_items)."""
+    all_items = []
+    scatter_paths = []
+    for m in range(num_mappers):
+        items = [
+            {"k": (m * items_per_mapper + i) % num_output_shards, "v": m * 1000 + i} for i in range(items_per_mapper)
+        ]
+        all_items.extend(items)
+        paths = _build_shard(tmp_path, items, num_output_shards=num_output_shards, source_shard=m)
+        scatter_paths.extend(paths)
+    return scatter_paths, all_items
+
+
+def test_combine_sidecars_roundtrip(tmp_path):
+    """Reducers reading from the combined manifest recover the same items
+    as reducers reading per-mapper sidecars."""
+    num_mappers = 3
+    num_shards = 4
+    scatter_paths, all_items = _build_many_mappers(tmp_path, num_mappers, num_shards, items_per_mapper=20)
+
+    combine_sidecars(scatter_paths, num_output_shards=num_shards, out_dir=str(tmp_path))
+
+    recovered = []
+    for shard_idx in range(num_shards):
+        manifest = reducer_manifest_path(str(tmp_path), shard_idx)
+        shard = ScatterReader.from_combined_manifest(manifest)
+        recovered.extend(list(shard))
+
+    assert sorted(recovered, key=lambda x: x["v"]) == sorted(all_items, key=lambda x: x["v"])
+
+
+def test_combine_sidecars_matches_per_mapper_read(tmp_path):
+    """Per-reducer items via combined manifest exactly match the legacy
+    from_sidecars path, shard by shard."""
+    num_mappers = 4
+    num_shards = 3
+    scatter_paths, _ = _build_many_mappers(tmp_path, num_mappers, num_shards, items_per_mapper=15)
+
+    combine_sidecars(scatter_paths, num_output_shards=num_shards, out_dir=str(tmp_path))
+
+    for shard_idx in range(num_shards):
+        legacy = list(ScatterReader.from_sidecars(scatter_paths, shard_idx))
+        combined = list(ScatterReader.from_combined_manifest(reducer_manifest_path(str(tmp_path), shard_idx)))
+        assert sorted(legacy, key=lambda x: x["v"]) == sorted(
+            combined, key=lambda x: x["v"]
+        ), f"shard {shard_idx} content mismatch between from_sidecars and from_combined_manifest"
+
+
+def test_combine_sidecars_writes_done_marker(tmp_path):
+    """A .combine_done file lands in the output dir only after all manifests
+    are written, so reducers can distinguish a completed combine from a
+    crashed partial write."""
+    scatter_paths, _ = _build_many_mappers(tmp_path, num_mappers=2, num_output_shards=2, items_per_mapper=8)
+    combine_sidecars(scatter_paths, num_output_shards=2, out_dir=str(tmp_path))
+    assert (tmp_path / _COMBINE_DONE_MARKER).exists()
+
+
+def test_combine_sidecars_preserves_stats(tmp_path):
+    """max_chunk_rows and avg_item_bytes survive the combine round-trip."""
+    num_shards = 2
+    scatter_paths, _ = _build_many_mappers(tmp_path, num_mappers=3, num_output_shards=num_shards, items_per_mapper=40)
+
+    combine_sidecars(scatter_paths, num_output_shards=num_shards, out_dir=str(tmp_path))
+
+    for shard_idx in range(num_shards):
+        legacy = ScatterReader.from_sidecars(scatter_paths, shard_idx)
+        combined = ScatterReader.from_combined_manifest(reducer_manifest_path(str(tmp_path), shard_idx))
+        assert combined.max_chunk_rows == legacy.max_chunk_rows
+        assert abs(combined.avg_item_bytes - legacy.avg_item_bytes) < 1e-6
+
+
+def test_combine_sidecars_empty_shard(tmp_path):
+    """A reducer with no ranges across any mapper gets an empty manifest."""
+    # All items share key=0, so they all hash to the same shard; the other
+    # shard's reducer manifest must be emitted but empty.
+    items = [{"k": 0, "v": i} for i in range(20)]
+    scatter_paths = _build_shard(tmp_path, items, num_output_shards=2)
+    combine_sidecars(scatter_paths, num_output_shards=2, out_dir=str(tmp_path))
+    populated = _target(0, num_shards=2)
+    empty = 1 - populated
+    empty_reader = ScatterReader.from_combined_manifest(reducer_manifest_path(str(tmp_path), empty))
+    assert list(empty_reader) == []
+    assert empty_reader.total_chunks == 0
+    populated_reader = ScatterReader.from_combined_manifest(reducer_manifest_path(str(tmp_path), populated))
+    assert sorted(list(populated_reader), key=lambda x: x["v"]) == sorted(items, key=lambda x: x["v"])
 
 
 # ---------------------------------------------------------------------------

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -11,7 +11,6 @@ from zephyr.plan import deterministic_hash
 from zephyr.shuffle import (
     ScatterFileIterator,
     ScatterReader,
-    _COMBINE_DONE_MARKER,
     _write_chunk_frame,
     _write_scatter,
     combine_sidecars,
@@ -252,13 +251,58 @@ def test_combine_sidecars_matches_per_mapper_read(tmp_path):
         ), f"shard {shard_idx} content mismatch between from_sidecars and from_combined_manifest"
 
 
-def test_combine_sidecars_writes_done_marker(tmp_path):
-    """A .combine_done file lands in the output dir only after all manifests
-    are written, so reducers can distinguish a completed combine from a
-    crashed partial write."""
-    scatter_paths, _ = _build_many_mappers(tmp_path, num_mappers=2, num_output_shards=2, items_per_mapper=8)
-    combine_sidecars(scatter_paths, num_output_shards=2, out_dir=str(tmp_path))
-    assert (tmp_path / _COMBINE_DONE_MARKER).exists()
+def test_combine_sidecars_sharded_tasks_match_single_task(tmp_path):
+    """Running combine_sidecars as K=3 parallel tasks produces identical
+    reducer manifests to K=1, and each task writes a disjoint subset."""
+    num_mappers = 4
+    num_shards = 7  # deliberately not divisible by K
+    scatter_paths, _ = _build_many_mappers(tmp_path, num_mappers, num_shards, items_per_mapper=12)
+
+    # Single-task reference.
+    ref_dir = tmp_path / "ref"
+    ref_dir.mkdir()
+    combine_sidecars(scatter_paths, num_output_shards=num_shards, out_dir=str(ref_dir))
+
+    # Sharded run with K=3.
+    sharded_dir = tmp_path / "sharded"
+    sharded_dir.mkdir()
+    K = 3
+    for task_idx in range(K):
+        combine_sidecars(
+            scatter_paths,
+            num_output_shards=num_shards,
+            out_dir=str(sharded_dir),
+            task_idx=task_idx,
+            num_combine_tasks=K,
+        )
+
+    for shard_idx in range(num_shards):
+        ref = list(ScatterReader.from_combined_manifest(reducer_manifest_path(str(ref_dir), shard_idx)))
+        sharded = list(ScatterReader.from_combined_manifest(reducer_manifest_path(str(sharded_dir), shard_idx)))
+        assert sorted(ref, key=lambda x: x["v"]) == sorted(
+            sharded, key=lambda x: x["v"]
+        ), f"shard {shard_idx} content differs between K=1 and K={K}"
+
+
+def test_combine_sidecars_sharded_task_only_writes_its_subset(tmp_path):
+    """Each sharded task writes only its strided subset of reducer manifests."""
+    num_shards = 6
+    scatter_paths, _ = _build_many_mappers(tmp_path, num_mappers=2, num_output_shards=num_shards, items_per_mapper=8)
+
+    # Only run task_idx=1 of K=3 (owns shards {1, 4}).
+    combine_sidecars(
+        scatter_paths,
+        num_output_shards=num_shards,
+        out_dir=str(tmp_path),
+        task_idx=1,
+        num_combine_tasks=3,
+    )
+    for shard_idx in range(num_shards):
+        manifest = tmp_path / f"reducer-{shard_idx:04d}.scatter_meta"
+        if shard_idx in (1, 4):
+            assert manifest.exists(), f"task_idx=1 should have written shard {shard_idx}"
+        else:
+            assert not manifest.exists(), f"task_idx=1 should NOT have written shard {shard_idx}"
 
 
 def test_combine_sidecars_preserves_stats(tmp_path):


### PR DESCRIPTION
* fold M mapper `.scatter_meta` sidecars into R per-reducer manifests in a new stage so each reducer does 1 manifest read instead of M
* `GroupByOp` now lowers to `Scatter(output_shards=1) → CombineMeta(output_shards=R) → Reduce`; the single combine task reads all M mapper manifests once and writes R reducer files [^1]; the existing gather-and-replicate regroup handles both transitions (M→1 gather into combine, 1→R replicate of the combine dir)
* add `CombineMeta` physical op, `combine_sidecars()`, `ScatterReader.from_combined_manifest()`
* rename `is_scatter` → `is_shuffle_boundary` in `_regroup_result_refs`; `output_shard_count` is now authoritative for that branch so scatter can gather M→1 without the old `max()` fallback
* unify scatter-stage filenames in one shared dir: `mapper-XXXX.shuffle` (data), `mapper-XXXX.scatter_meta` (per-mapper sidecar), `reducer-YYYY.scatter_meta` (per-reducer manifest)
  * `.combine_done` marker written last so a crashed retry doesn't leave a reducer reading a half-written directory
* route all manifest JSON through `msgspec.json` (matches `readers.py` / `deterministic_hash`)
* auto-size path (`GroupByOp(num_output_shards=None)`) resolved at stage-launch via `_resolve_combine_output_shards` from the pre-scatter shard count; same plumbing reused for join right sub-plans

[^1]: the combine task holds the M×R byte-range matrix transiently (sub-GB for realistic M,R ~ few thousand); can be switched to streaming-append into R open writers if it ever grows too large