### PR TITLE
fray: trivial v1 → v2 swaps (device_flops + test fixtures)

### DIFF
--- a/lib/levanter/src/levanter/callbacks/_metrics.py
+++ b/lib/levanter/src/levanter/callbacks/_metrics.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 from typing import Optional
 
 import jax
-from fray.v1.cluster.device_flops import device_flops_for_jax_device
+from fray.v2.device_flops import device_flops_for_jax_device
 from tqdm_loggable.auto import tqdm
 from tqdm_loggable.tqdm_logging import tqdm_logging
 

--- a/tests/datakit/test_normalize.py
+++ b/tests/datakit/test_normalize.py
@@ -9,14 +9,14 @@ from pathlib import Path
 
 import pyarrow.parquet as pq
 import pytest
-from fray.v1.job import create_job_ctx, fray_default_job_ctx
+from fray.v2 import LocalClient, set_current_client
 
 from marin.datakit.normalize import generate_id, normalize_to_parquet
 
 
 @pytest.fixture(autouse=True)
 def flow_backend_ctx():
-    with fray_default_job_ctx(create_job_ctx("sync")):
+    with set_current_client(LocalClient()):
         yield
 
 

--- a/tests/processing/classification/deduplication/test_fuzzy.py
+++ b/tests/processing/classification/deduplication/test_fuzzy.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pyarrow.parquet as pq
 import pytest
-from fray.v1.job import create_job_ctx, fray_default_job_ctx
+from fray.v2 import LocalClient, set_current_client
 
 from marin.datakit.normalize import NormalizedData, generate_id, normalize_to_parquet
 from marin.processing.classification.deduplication.fuzzy_dups import compute_fuzzy_dups_attrs
@@ -17,7 +17,7 @@ from marin.processing.classification.deduplication.fuzzy_minhash import (
 
 @pytest.fixture(autouse=True)
 def flow_backend_ctx():
-    with fray_default_job_ctx(create_job_ctx("sync")):
+    with set_current_client(LocalClient()):
         yield
 
 


### PR DESCRIPTION
🤖

## Summary

Bucket 1 of [#4453](https://github.com/marin-community/marin/issues/4453) — three trivial in-place swaps from `fray.v1` to `fray.v2`. One commit per file so each can be reverted individually.

- `lib/levanter/src/levanter/callbacks/_metrics.py` — `fray.v1.cluster.device_flops` → `fray.v2.device_flops` (v2 implementation is byte-for-byte identical to v1).
- `tests/datakit/test_normalize.py` — `fray.v1.job.create_job_ctx(...)` → `set_current_client(LocalClient())`.
- `tests/processing/classification/deduplication/test_fuzzy.py` — same swap as above.

## Not included here

`lib/marin/src/marin/rl/weight_transfer/jax.py` was initially planned as a 4th trivial swap but turned out to have a semantic gap: v1's `create_actor(..., get_if_exists=True)` has no direct v2 equivalent (`adopt_existing` is only on `Client.submit()` for jobs, not on `create_actor`). Moved to Bucket 2 as a standalone non-trivial port.

## Test plan

- [x] \`./infra/pre-commit.py --all-files --fix\` green (ruff, black, pyrefly, license headers).
- [x] \`uv run pyrefly\` — no new errors vs \`origin/main\` baseline.
- [x] \`pytest tests/datakit/test_normalize.py tests/processing/classification/deduplication/test_fuzzy.py\` — 19/19 passed.