### PR TITLE
marin: port inference/vllm_smoke_test.py to fray v2

### DIFF
--- a/lib/marin/src/marin/inference/vllm_smoke_test.py
+++ b/lib/marin/src/marin/inference/vllm_smoke_test.py
@@ -10,7 +10,8 @@ from typing import Literal
 from urllib.parse import urlparse
 
 import requests
-from fray.v1.cluster import Entrypoint, EnvironmentConfig, JobRequest, ResourceConfig, current_cluster
+from fray.v2 import current_client
+from fray.v2.types import Entrypoint, JobRequest, ResourceConfig, create_environment
 
 from marin.evaluation.evaluators.evaluator import ModelConfig
 from marin.inference.vllm_server import VLLM_NATIVE_PIP_PACKAGES, VllmEnvironment, resolve_vllm_mode
@@ -225,20 +226,20 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"[run {i + 1}/{args.repeat}] {elapsed:.1f}s")
                 print(output)
 
-    cluster = current_cluster()
+    client = current_client()
     resources = ResourceConfig.with_tpu(args.tpu_type)
     job_request = JobRequest(
         name=f"vllm-smoke:{args.tpu_type}",
         entrypoint=Entrypoint.from_callable(_run),
         resources=resources,
-        environment=EnvironmentConfig.create(
+        environment=create_environment(
             extras=["eval", "tpu"],
             pip_packages=VLLM_NATIVE_PIP_PACKAGES if mode_str == "native" else (),
             env_vars=env_vars or None,
         ),
     )
-    job_id = cluster.launch(job_request)
-    cluster.wait(job_id, raise_on_failure=True)
+    job = client.submit(job_request)
+    job.wait(raise_on_failure=True)
     return 0
 
 


### PR DESCRIPTION
🤖

## Summary

Ports `lib/marin/src/marin/inference/vllm_smoke_test.py` from `fray.v1.cluster.*` to `fray.v2`, mirroring the pattern landed in [#4980](https://github.com/marin-community/marin/pull/4980) (`export/levanter_checkpoint.py` port). CLI surface is unchanged; only the cluster-submission internals move.

This is Bucket 2 PR-C in the Ray-removal roadmap. Part of [#4453](https://github.com/marin-community/marin/issues/4453).

## What this file does

Developer-facing CLI smoke test for the vLLM TPU sidecar. Has a `--local` flag (in-process, untouched by this PR) and a cluster-submission mode. Zero code importers; manually invoked.

## Test plan

- [x] `./infra/pre-commit.py --all-files --fix` — green.
- [x] `uv run pyrefly` — no new errors vs `origin/main` baseline.
- [x] `uv run python -m marin.inference.vllm_smoke_test --help` — argparse prints cleanly, exit 0.
- [x] No `fray.v1` references remain in the file.
- [ ] Real TPU smoke-test run — **out of scope** for this PR (requires cluster + live HF model). Manual check after merge if desired.