### PR TITLE
Enable split heartbeat for prod Marin cluster

### DIFF
--- a/lib/iris/examples/marin.yaml
+++ b/lib/iris/examples/marin.yaml
@@ -28,7 +28,7 @@ worker_provider: {}
 
 controller:
   image: ghcr.io/marin-community/iris-controller:latest
-  use_split_heartbeat: false  # Stay on legacy heartbeat path until split mode burns in elsewhere.
+  use_split_heartbeat: true
   gcp:
     service_account: iris-controller@hai-gcp-models.iam.gserviceaccount.com
     zone: us-central1-a


### PR DESCRIPTION
Enable use_split_heartbeat in lib/iris/examples/marin.yaml now that the split heartbeat path has burned in on other clusters.