### PR TITLE
zephyr: exempt preemption requeues from MAX_SHARD_FAILURES

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -545,13 +545,15 @@ class ZephyrCoordinator:
                 errors = self._shard_errors.get(shard_idx, [])
                 error_detail = f"\nLast error:\n{errors[-1]}" if errors else ""
                 logger.error(
-                    "Shard %d has failed %d times (max %d), aborting pipeline.",
+                    "Shard %d has failed %d times (max %d), last failure on worker %s, aborting pipeline.",
                     shard_idx,
                     error_attempts,
                     MAX_SHARD_FAILURES,
+                    worker_id,
                 )
                 self._fatal_error = (
-                    f"Shard {shard_idx} failed {error_attempts} times " f"(max {MAX_SHARD_FAILURES}).{error_detail}"
+                    f"Shard {shard_idx} failed {error_attempts} times "
+                    f"(max {MAX_SHARD_FAILURES}), last failure on worker {worker_id}.{error_detail}"
                 )
                 return True
 

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -57,10 +57,17 @@ from zephyr.writers import INTERMEDIATE_CHUNK_SIZE, ensure_parent_dir
 
 logger = logging.getLogger(__name__)
 
-# Maximum number of times a single shard can fail before aborting the pipeline.
-# Covers both explicit task errors (report_error) and implicit worker deaths
-# (heartbeat timeout / OOM).
+# Max explicit task errors (report_error) per shard before aborting. Preemption
+# requeues (re-registration, heartbeat timeout) do not count — they retry
+# unbounded. `_check_worker_group` backstops if workers fully exhaust Iris retries.
 MAX_SHARD_FAILURES = 3
+
+
+class ShardFailureKind(enum.Enum):
+    """TASK failures count toward MAX_SHARD_FAILURES; INFRA failures (preemption) do not."""
+
+    TASK = "task"
+    INFRA = "infra"
 
 
 @dataclass(frozen=True)
@@ -347,7 +354,10 @@ class ZephyrCoordinator:
         self._completed_shards: int = 0
         self._retries: int = 0
         self._in_flight: dict[str, tuple[ShardTask, int]] = {}
+        # _task_attempts: monotonic generation for stale-result rejection (bumps on every
+        # requeue). _task_error_attempts: TASK-only counter, bounded by MAX_SHARD_FAILURES.
         self._task_attempts: dict[int, int] = {}
+        self._task_error_attempts: dict[int, int] = {}
         self._fatal_error: str | None = None
         self._shard_errors: dict[int, list[str]] = {}
         self._chunk_prefix: str = ""
@@ -498,15 +508,15 @@ class ZephyrCoordinator:
             attempts_histogram = dict(sorted(Counter(retried.values()).items()))
             logger.warning("[%s] Shards retried (attempts: shard count): %s", self._execution_id, attempts_histogram)
 
-    def _record_shard_failure(self, worker_id: str, error_info: str | None = None) -> bool:
-        """Record a failure for the worker's in-flight shard. Must be called with lock held.
+    def _record_shard_failure(
+        self,
+        worker_id: str,
+        kind: ShardFailureKind,
+        error_info: str | None = None,
+    ) -> bool:
+        """Requeue the worker's in-flight shard; abort only if TASK errors hit MAX_SHARD_FAILURES.
 
-        Pops the task from _in_flight, zeros the worker's counter snapshot,
-        records the error, increments the attempt counter, and either re-queues
-        the task or sets _fatal_error when MAX_SHARD_FAILURES is reached.
-
-        Returns True if the shard was aborted (fatal), False otherwise
-        (including when there was no in-flight task).
+        Must be called with lock held. Returns True if the pipeline was aborted.
         """
         task_and_attempt = self._in_flight.pop(worker_id, None)
 
@@ -525,38 +535,51 @@ class ZephyrCoordinator:
         if error_info is not None:
             self._shard_errors.setdefault(shard_idx, []).append(error_info)
 
+        # Bump generation regardless of kind so report_result rejects stale attempts.
         self._task_attempts[shard_idx] += 1
-        attempts = self._task_attempts[shard_idx]
 
-        if attempts >= MAX_SHARD_FAILURES:
-            errors = self._shard_errors.get(shard_idx, [])
-            error_detail = f"\nLast error:\n{errors[-1]}" if errors else ""
-            logger.error(
-                "Shard %d has failed %d times (max %d), aborting pipeline.",
+        if kind is ShardFailureKind.TASK:
+            self._task_error_attempts[shard_idx] += 1
+            error_attempts = self._task_error_attempts[shard_idx]
+            if error_attempts >= MAX_SHARD_FAILURES:
+                errors = self._shard_errors.get(shard_idx, [])
+                error_detail = f"\nLast error:\n{errors[-1]}" if errors else ""
+                logger.error(
+                    "Shard %d has failed %d times (max %d), aborting pipeline.",
+                    shard_idx,
+                    error_attempts,
+                    MAX_SHARD_FAILURES,
+                )
+                self._fatal_error = (
+                    f"Shard {shard_idx} failed {error_attempts} times " f"(max {MAX_SHARD_FAILURES}).{error_detail}"
+                )
+                return True
+
+            logger.warning(
+                "Shard %d failed on worker %s (task error %d/%d), re-queuing.",
                 shard_idx,
-                attempts,
+                worker_id,
+                error_attempts,
                 MAX_SHARD_FAILURES,
             )
-            self._fatal_error = (
-                f"Shard {shard_idx} failed {attempts} times " f"(max {MAX_SHARD_FAILURES}).{error_detail}"
+        else:
+            logger.warning(
+                "Shard %d requeued from worker %s due to infra failure (preemption/heartbeat); "
+                "infra retries are unbounded. Total generation: %d, task errors so far: %d/%d.",
+                shard_idx,
+                worker_id,
+                self._task_attempts[shard_idx],
+                self._task_error_attempts[shard_idx],
+                MAX_SHARD_FAILURES,
             )
-            return True
 
-        logger.warning(
-            "Shard %d failed on worker %s (attempt %d/%d), re-queuing.",
-            shard_idx,
-            worker_id,
-            attempts,
-            MAX_SHARD_FAILURES,
-        )
         self._task_queue.append(task)
         self._retries += 1
         return False
 
     def _maybe_requeue_worker_task(self, worker_id: str) -> None:
-        """If the worker has a task in-flight, re-queue it unless the shard has
-        exceeded MAX_SHARD_FAILURES, in which case abort the pipeline."""
-        self._record_shard_failure(worker_id)
+        """Requeue the worker's in-flight task as an INFRA failure (preemption/heartbeat)."""
+        self._record_shard_failure(worker_id, ShardFailureKind.INFRA)
 
     def _check_worker_heartbeats(self, timeout: float = 120.0) -> None:
         """Internal heartbeat check (called with lock held)."""
@@ -657,7 +680,7 @@ class ZephyrCoordinator:
         with self._lock:
             self._last_seen[worker_id] = time.monotonic()
             self._assert_in_flight_consistent(worker_id, shard_idx)
-            aborted = self._record_shard_failure(worker_id, error_info)
+            aborted = self._record_shard_failure(worker_id, ShardFailureKind.TASK, error_info)
             self._worker_states[worker_id] = WorkerState.DEAD if aborted else WorkerState.READY
 
     def heartbeat(self, worker_id: str, counter_snapshot: CounterSnapshot | None = None) -> None:
@@ -736,6 +759,7 @@ class ZephyrCoordinator:
             self._retries = 0
             self._in_flight = {}
             self._task_attempts = {task.shard_idx: 0 for task in tasks}
+            self._task_error_attempts = {task.shard_idx: 0 for task in tasks}
             self._shard_errors = {}
             self._fatal_error = None
             self._is_last_stage = is_last_stage

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -63,11 +63,11 @@ logger = logging.getLogger(__name__)
 MAX_SHARD_FAILURES = 3
 
 
-class ShardFailureKind(enum.Enum):
+class ShardFailureKind(enum.StrEnum):
     """TASK failures count toward MAX_SHARD_FAILURES; INFRA failures (preemption) do not."""
 
-    TASK = "task"
-    INFRA = "infra"
+    TASK = enum.auto()
+    INFRA = enum.auto()
 
 
 @dataclass(frozen=True)

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -6,15 +6,33 @@
 from __future__ import annotations
 
 import json
+import logging
+import os
 import threading
 import time
 import uuid
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from fray.v2 import ResourceConfig
+from fray.v2.local_backend import LocalClient
+from zephyr import counters
 from zephyr.dataset import Dataset
-from zephyr.execution import CounterSnapshot, ZephyrContext, zephyr_worker_ctx
+from zephyr.execution import (
+    MAX_SHARD_FAILURES,
+    CounterSnapshot,
+    ListShard,
+    PickleDiskChunk,
+    ShardTask,
+    TaskResult,
+    WorkerState,
+    ZephyrContext,
+    ZephyrCoordinator,
+    ZephyrWorkerError,
+    zephyr_worker_ctx,
+)
+from zephyr.plan import compute_plan
 
 
 def test_simple_map(zephyr_ctx):
@@ -43,9 +61,6 @@ def test_subprocess_propagates_user_counters(zephyr_ctx):
     Uses a direct logging handler attachment (rather than ``caplog``) so the
     test works whether or not pytest's logging plugin is enabled.
     """
-    import logging
-
-    from zephyr import counters
 
     def increment_per_item(x: int) -> int:
         counters.increment("docs", 1)
@@ -92,7 +107,6 @@ def test_subprocess_exception_includes_subprocess_traceback(zephyr_ctx):
     original exception type AND a snippet from the user-code frame survive
     the round-trip.
     """
-    from zephyr.execution import ZephyrWorkerError
 
     def buggy_index_lookup(x: int) -> int:
         # Force a non-trivial subprocess-side exception with a recognizable
@@ -219,8 +233,6 @@ def test_chunk_cleanup(local_client, tmp_path):
     assert sorted(results) == [2, 4, 6]
 
     # Verify chunks directory is cleaned up
-    import os
-
     if os.path.exists(chunk_prefix):
         # Should be empty or not exist
         files = list(Path(chunk_prefix).rglob("*"))
@@ -234,10 +246,6 @@ def test_status_reports_alive_workers_not_total(actor_context, tmp_path):
     Also verifies that re-registering a worker that had an in-flight task
     requeues that task so it is not silently lost.
     """
-    from unittest.mock import MagicMock
-
-    from zephyr.execution import ListShard, ShardTask, ZephyrCoordinator
-
     coord = ZephyrCoordinator()
     coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
 
@@ -302,8 +310,6 @@ def test_status_reports_alive_workers_not_total(actor_context, tmp_path):
 def test_no_duplicate_results_on_heartbeat_timeout(actor_context, tmp_path):
     """When a task is requeued after heartbeat timeout, the original worker's
     stale result (from a previous attempt) is rejected by the coordinator."""
-    from zephyr.execution import ListShard, ShardTask, TaskResult, ZephyrCoordinator
-
     coord = ZephyrCoordinator()
     coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
 
@@ -348,8 +354,6 @@ def test_no_duplicate_results_on_heartbeat_timeout(actor_context, tmp_path):
 
 def test_disk_chunk_write_uses_unique_paths(tmp_path):
     """Each PickleDiskChunk.write() writes to a unique location, avoiding collisions."""
-    from zephyr.execution import PickleDiskChunk
-
     base_path = str(tmp_path / "chunk.pkl")
     refs = [PickleDiskChunk.write(base_path, [i]) for i in range(3)]
 
@@ -370,8 +374,6 @@ def test_coordinator_accepts_winner_ignores_stale(actor_context, tmp_path):
 
     Stale chunk files are left for context-dir cleanup (no per-chunk deletion).
     """
-    from zephyr.execution import ListShard, PickleDiskChunk, ShardTask, TaskResult, ZephyrCoordinator
-
     coord = ZephyrCoordinator()
     coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
 
@@ -433,8 +435,6 @@ def test_shard_streaming_low_memory(tmp_path):
 
     Verifies get_iterators yields data lazily and flat iteration works.
     """
-    from zephyr.execution import ListShard, PickleDiskChunk
-
     # Write 3 refs to disk (directly readable, no finalize needed)
     refs = []
     for i in range(3):
@@ -459,16 +459,6 @@ def test_shard_streaming_low_memory(tmp_path):
 
 def test_report_error_requeues_until_max_shard_failures(actor_context, tmp_path):
     """report_error re-queues a task until MAX_SHARD_FAILURES, then aborts."""
-    from unittest.mock import MagicMock
-
-    from zephyr.execution import (
-        MAX_SHARD_FAILURES,
-        ListShard,
-        ShardTask,
-        WorkerState,
-        ZephyrCoordinator,
-    )
-
     coord = ZephyrCoordinator()
     coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
 
@@ -502,17 +492,6 @@ def test_report_error_requeues_until_max_shard_failures(actor_context, tmp_path)
 
 def test_heartbeat_timeouts_do_not_count_toward_shard_failures(actor_context, tmp_path):
     """Heartbeat-timeout requeues (preemption) must not consume MAX_SHARD_FAILURES."""
-    from unittest.mock import MagicMock
-
-    from zephyr.execution import (
-        MAX_SHARD_FAILURES,
-        CounterSnapshot,
-        ListShard,
-        ShardTask,
-        TaskResult,
-        ZephyrCoordinator,
-    )
-
     coord = ZephyrCoordinator()
     coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
 
@@ -546,15 +525,6 @@ def test_heartbeat_timeouts_do_not_count_toward_shard_failures(actor_context, tm
 
 def test_worker_reregistration_does_not_count_toward_shard_failures(actor_context, tmp_path):
     """Preemption-driven worker re-registration requeues without burning MAX_SHARD_FAILURES."""
-    from unittest.mock import MagicMock
-
-    from zephyr.execution import (
-        MAX_SHARD_FAILURES,
-        ListShard,
-        ShardTask,
-        ZephyrCoordinator,
-    )
-
     coord = ZephyrCoordinator()
     coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
 
@@ -582,15 +552,6 @@ def test_worker_reregistration_does_not_count_toward_shard_failures(actor_contex
 
 def test_report_error_still_aborts_at_max_shard_failures_after_preemptions(actor_context, tmp_path):
     """Task errors still abort at MAX_SHARD_FAILURES even after many survived preemptions."""
-    from unittest.mock import MagicMock
-
-    from zephyr.execution import (
-        MAX_SHARD_FAILURES,
-        ListShard,
-        ShardTask,
-        ZephyrCoordinator,
-    )
-
     coord = ZephyrCoordinator()
     coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
 
@@ -626,10 +587,6 @@ def test_report_error_still_aborts_at_max_shard_failures_after_preemptions(actor
 def test_wait_for_stage_fails_when_all_workers_die(actor_context, tmp_path):
     """When all registered workers become dead/failed, _wait_for_stage raises
     after the no_workers_timeout instead of waiting forever."""
-    from unittest.mock import MagicMock
-
-    from zephyr.execution import ListShard, ShardTask, WorkerState, ZephyrCoordinator, ZephyrWorkerError
-
     coord = ZephyrCoordinator()
     coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
     coord._no_workers_timeout = 0.5  # short timeout for test
@@ -663,12 +620,6 @@ def test_wait_for_stage_fails_when_all_workers_die(actor_context, tmp_path):
 def test_wait_for_stage_resets_dead_timer_on_recovery(actor_context, tmp_path):
     """When a worker recovers (re-registers) after all workers died,
     the dead timer resets and execution can continue."""
-    import threading
-
-    from unittest.mock import MagicMock
-
-    from zephyr.execution import ListShard, ShardTask, TaskResult, WorkerState, ZephyrCoordinator
-
     coord = ZephyrCoordinator()
     coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
     coord._no_workers_timeout = 2.0
@@ -738,8 +689,6 @@ def test_fresh_actors_per_execute(integration_client, tmp_path):
 
 def test_fatal_errors_fail_fast(local_client, tmp_path):
     """Application errors (e.g. ValueError) cause immediate failure, no retries."""
-    from zephyr.execution import ZephyrWorkerError
-
     chunk_prefix = str(tmp_path / "chunks")
 
     def exploding_map(x):
@@ -826,8 +775,6 @@ def test_pipeline_id_increments(local_client, tmp_path):
 
 def test_pull_task_returns_shutdown_on_last_stage_empty_queue(actor_context, tmp_path):
     """When the last stage's tasks are all in-flight or done, pull_task returns SHUTDOWN."""
-    from zephyr.execution import ListShard, ShardTask, TaskResult, ZephyrCoordinator
-
     coord = ZephyrCoordinator()
     coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
 
@@ -884,10 +831,6 @@ def test_pull_task_returns_shutdown_on_last_stage_empty_queue(actor_context, tmp
 
 def test_last_stage_deadlock_detected_when_worker_job_dies(actor_context, tmp_path):
     """Coordinator aborts if the worker job dies while last-stage work is outstanding."""
-    from unittest.mock import MagicMock
-
-    from zephyr.execution import ListShard, ShardTask, TaskResult, ZephyrCoordinator
-
     coord = ZephyrCoordinator()
     coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
 
@@ -935,8 +878,6 @@ def test_last_stage_deadlock_detected_when_worker_job_dies(actor_context, tmp_pa
 
 def test_coordinator_loop_crash_aborts_pipeline(actor_context, tmp_path):
     """Coordinator loop crash sets _fatal_error instead of dying silently. #3996."""
-    from zephyr.execution import ZephyrCoordinator
-
     coord = ZephyrCoordinator()
     coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
 
@@ -960,11 +901,6 @@ def test_coordinator_loop_crash_aborts_pipeline(actor_context, tmp_path):
 
 def test_run_pipeline_rejects_concurrent_calls(actor_context, tmp_path):
     """Calling run_pipeline while another is already running raises RuntimeError."""
-    from unittest.mock import MagicMock
-
-    from zephyr.execution import ZephyrCoordinator
-    from zephyr.plan import compute_plan
-
     coord = ZephyrCoordinator()
     coord.initialize(str(tmp_path / "chunks"), MagicMock())
 
@@ -1034,8 +970,6 @@ def test_execute_retries_on_coordinator_death(tmp_path):
     Patches client.submit so the first coordinator job submission raises,
     then the retry submits a real job that succeeds.
     """
-    from fray.v2.local_backend import LocalClient
-
     client = LocalClient()
     chunk_prefix = str(tmp_path / "chunks")
 
@@ -1077,8 +1011,6 @@ def test_execute_retries_on_coordinator_death(tmp_path):
 
 def test_execute_does_not_retry_worker_errors(local_client, tmp_path):
     """ZephyrWorkerError (application errors) are never retried."""
-    from zephyr.execution import ZephyrWorkerError
-
     chunk_prefix = str(tmp_path / "chunks")
 
     def exploding_map(x):

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -500,9 +500,52 @@ def test_report_error_requeues_until_max_shard_failures(actor_context, tmp_path)
     assert "final-error" in coord._fatal_error
 
 
-def test_heartbeat_death_aborts_at_max_shard_failures(actor_context, tmp_path):
-    """When a shard's worker keeps dying (heartbeat timeout), abort after
-    MAX_SHARD_FAILURES re-queues instead of retrying forever."""
+def test_heartbeat_timeouts_do_not_count_toward_shard_failures(actor_context, tmp_path):
+    """Heartbeat-timeout requeues (preemption) must not consume MAX_SHARD_FAILURES."""
+    from unittest.mock import MagicMock
+
+    from zephyr.execution import (
+        MAX_SHARD_FAILURES,
+        CounterSnapshot,
+        ListShard,
+        ShardTask,
+        TaskResult,
+        ZephyrCoordinator,
+    )
+
+    coord = ZephyrCoordinator()
+    coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
+
+    task = ShardTask(
+        shard_idx=0,
+        total_shards=1,
+        shard=ListShard(refs=[]),
+        operations=[],
+        stage_name="test",
+    )
+    coord.start_stage("test", [task])
+    coord.register_worker("worker-0", MagicMock())
+
+    # Far more heartbeat timeouts than MAX_SHARD_FAILURES — must not abort.
+    for _ in range(MAX_SHARD_FAILURES * 5):
+        pulled = coord.pull_task("worker-0")
+        assert pulled is not None and pulled != "SHUTDOWN"
+        coord._last_seen["worker-0"] = 0.0
+        coord.check_heartbeats(timeout=0.0)
+        assert coord._fatal_error is None
+
+    # Task-error budget is untouched; a successful completion closes the shard.
+    assert coord._task_error_attempts[0] == 0
+    pulled = coord.pull_task("worker-0")
+    assert pulled is not None and pulled != "SHUTDOWN"
+    _task, attempt, _config = pulled
+    coord.report_result("worker-0", 0, attempt, TaskResult(shard=ListShard(refs=[])), CounterSnapshot.empty())
+    assert coord._completed_shards == 1
+    assert coord._fatal_error is None
+
+
+def test_worker_reregistration_does_not_count_toward_shard_failures(actor_context, tmp_path):
+    """Preemption-driven worker re-registration requeues without burning MAX_SHARD_FAILURES."""
     from unittest.mock import MagicMock
 
     from zephyr.execution import (
@@ -525,12 +568,56 @@ def test_heartbeat_death_aborts_at_max_shard_failures(actor_context, tmp_path):
     coord.start_stage("test", [task])
     coord.register_worker("worker-0", MagicMock())
 
-    for _i in range(MAX_SHARD_FAILURES):
+    for _ in range(MAX_SHARD_FAILURES * 5):
         pulled = coord.pull_task("worker-0")
         assert pulled is not None and pulled != "SHUTDOWN"
-        # Simulate worker death via heartbeat timeout
+        # Simulate preemption + Iris reconstruction: worker re-registers while
+        # a task is still recorded as in-flight on the old handle.
+        coord.register_worker("worker-0", MagicMock())
+        assert "worker-0" not in coord._in_flight
+        assert coord._fatal_error is None
+
+    assert coord._task_error_attempts[0] == 0
+
+
+def test_report_error_still_aborts_at_max_shard_failures_after_preemptions(actor_context, tmp_path):
+    """Task errors still abort at MAX_SHARD_FAILURES even after many survived preemptions."""
+    from unittest.mock import MagicMock
+
+    from zephyr.execution import (
+        MAX_SHARD_FAILURES,
+        ListShard,
+        ShardTask,
+        ZephyrCoordinator,
+    )
+
+    coord = ZephyrCoordinator()
+    coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
+
+    task = ShardTask(
+        shard_idx=0,
+        total_shards=1,
+        shard=ListShard(refs=[]),
+        operations=[],
+        stage_name="test",
+    )
+    coord.start_stage("test", [task])
+    coord.register_worker("worker-0", MagicMock())
+
+    # Several preemption cycles first — these must not count.
+    for _ in range(5):
+        pulled = coord.pull_task("worker-0")
+        assert pulled is not None and pulled != "SHUTDOWN"
         coord._last_seen["worker-0"] = 0.0
         coord.check_heartbeats(timeout=0.0)
+
+    assert coord._fatal_error is None
+
+    # Now MAX_SHARD_FAILURES explicit task errors should abort.
+    for i in range(MAX_SHARD_FAILURES):
+        pulled = coord.pull_task("worker-0")
+        assert pulled is not None and pulled != "SHUTDOWN"
+        coord.report_error("worker-0", 0, f"boom-{i}")
 
     assert coord._fatal_error is not None
     assert "Shard 0" in coord._fatal_error


### PR DESCRIPTION
* preemption-driven requeues (`register_worker`, heartbeat timeout) no longer consume the 3-attempt `MAX_SHARD_FAILURES` budget — previously three clean preemptions aborted the pipeline
* split `_task_attempts` into two counters: generation (bumps on every requeue, drives stale-result rejection in `report_result`) and `_task_error_attempts` (`TASK`-only, still capped at `MAX_SHARD_FAILURES=3`)
* add `ShardFailureKind.{TASK,INFRA}`; `report_error` → `TASK`, `_maybe_requeue_worker_task` → `INFRA`
* `INFRA` requeues retry unbounded [^1]
* tests
  * replace `test_heartbeat_death_aborts_at_max_shard_failures` (codified the bug) with `test_heartbeat_timeouts_do_not_count_toward_shard_failures` — 15 timeouts + final success
  * add `test_worker_reregistration_does_not_count_toward_shard_failures`
  * add `test_report_error_still_aborts_at_max_shard_failures_after_preemptions` — pins that real task errors still abort at 3 even after prior preemptions

[^1]: `_check_worker_group` already aborts if the worker job permanently exhausts Iris' own retry budget, so unbounded infra retries cannot loop forever