### PR TITLE
marin: fix unmet-deps error in StepRunner

### DIFF
--- a/lib/marin/src/marin/execution/step_runner.py
+++ b/lib/marin/src/marin/execution/step_runner.py
@@ -218,7 +218,7 @@ class StepRunner:
                     missing = []
                     for s in waiting:
                         unmet = [
-                            _display_name(d)
+                            _display_name(d.output_path)
                             for d in s.deps
                             if d.output_path not in completed and d.output_path not in failed
                         ]

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -372,6 +372,31 @@ def test_runner_max_concurrent(tmp_path: Path):
     assert train_artifact.tokens_seen > 0
 
 
+def test_runner_raises_clear_error_for_unmet_deps(tmp_path: Path):
+    """When the iterable omits a dependency, the runner must name the offending step and
+    its unmet dep paths — not crash with ``TypeError: unhashable type: 'list'``."""
+
+    dep = StepSpec(
+        name="missing_upstream",
+        override_output_path=(tmp_path / "missing_upstream").as_posix(),
+        fn=lambda output_path: PathMetadata(path=output_path),
+    )
+    downstream = StepSpec(
+        name="downstream",
+        override_output_path=(tmp_path / "downstream").as_posix(),
+        deps=[dep],
+        fn=lambda output_path: PathMetadata(path=output_path),
+    )
+
+    runner = StepRunner()
+    with pytest.raises(RuntimeError, match=r"Iterable exhausted .* unsatisfied dependencies") as exc_info:
+        runner.run([downstream])
+
+    message = str(exc_info.value)
+    assert downstream.name_with_hash in message
+    assert dep.output_path in message
+
+
 def test_runner_preserves_underlying_step_exception(tmp_path: Path):
     """The top-level runner error should retain the original failing exception as a cause."""
 


### PR DESCRIPTION
* fixes https://github.com/marin-community/marin/issues/4991
* `StepRunner.run` unmet-deps listcomp passed whole `StepSpec` to `_display_name`, which `dict.get`'s the key and hashes the `StepSpec`[^1] — crashed with `TypeError: unhashable type: 'list'` instead of the intended `RuntimeError` naming the step and its unmet dep paths
* fix: pass `d.output_path` (`str`) instead of `d` (`StepSpec`)
* regression test in `tests/execution/test_step_runner.py` asserts the `RuntimeError` names the waiting step and its unmet dep paths

[^1]: `StepSpec` is a frozen dataclass, so `__hash__` is synthesized and walks the `deps: list[StepSpec]` field — lists aren't hashable.