### PR TITLE
iris: apply state filter only to top-level jobs

### DIFF
--- a/lib/iris/dashboard/src/components/controller/JobsTab.vue
+++ b/lib/iris/dashboard/src/components/controller/JobsTab.vue
@@ -125,7 +125,6 @@ async function loadChildJobs(parentJobId: string) {
         parentJobId,
         sortField: SORT_FIELD_MAP[sortField.value],
         sortDirection: sortDir.value === 'asc' ? 'SORT_DIRECTION_ASC' : 'SORT_DIRECTION_DESC',
-        stateFilter: stateFilter.value || undefined,
       } satisfies JobQuery,
     })
     const nextChildren = new Map(childJobsByParent.value)


### PR DESCRIPTION
* state filter on the controller Jobs tab now only scopes the top-level (root) job list
* previously `stateFilter` was also forwarded to the `JOB_QUERY_SCOPE_CHILDREN` RPC in `loadChildJobs`, so expanding a parent hid any children that weren't in the selected state
* drop `stateFilter` from the children query so an expanded parent always shows all of its children