### PR TITLE
[SFT] Add FineProofs-SFT raw and proof-only instruction datasets

### DIFF
--- a/experiments/posttrain/instruction_datasets.py
+++ b/experiments/posttrain/instruction_datasets.py
@@ -35,6 +35,8 @@ Current datasets:
 20. nvidia/Nemotron-Post-Training-Dataset-v2
 21. HuggingFaceH4/no_robots
 22. open-thoughts/OpenThoughts3-1.2M  # Original OT3 dataset; smoltalk2 uses a slightly different version
+23. lm-provers/FineProofs-SFT
+24. lm-provers/FineProofs-SFT/proof-only
 """
 
 import dataclasses
@@ -245,6 +247,15 @@ class ReasoningToChatKwargs:
 
 reasoning_to_chat_kwargs = ReasoningToChatKwargs()
 
+FINEPROOFS_SFT_REVISION = "73661e6"
+FINEPROOFS_SFT_METADATA_COLUMNS = [
+    "category",
+    "competition",
+    "gemini-3-pro-grade",
+    "qwen3-4b-thinking-reward@128",
+    "source",
+]
+
 
 INSTRUCTION_DATASET_NAME_TO_CONFIG = {
     "meta-math/MetaMathQA": InstructionDatasetConfig(
@@ -387,6 +398,27 @@ INSTRUCTION_DATASET_NAME_TO_CONFIG = {
         ),
         metadata_columns=["source", "task_type", "problem_id"],
         name="PrimeIntellect/verifiable-math-problems",
+    ),
+    "lm-provers/FineProofs-SFT": InstructionDatasetConfig(
+        hf_dataset_id="lm-provers/FineProofs-SFT",
+        revision=FINEPROOFS_SFT_REVISION,
+        adapter=multi_turn_adapter(),
+        metadata_columns=FINEPROOFS_SFT_METADATA_COLUMNS,
+        name="lm-provers/FineProofs-SFT",
+        subsets=["default"],
+        splits=["train"],
+    ),
+    "lm-provers/FineProofs-SFT/proof-only": InstructionDatasetConfig(
+        hf_dataset_id="lm-provers/FineProofs-SFT",
+        revision=FINEPROOFS_SFT_REVISION,
+        adapter=instruction_response_adapter(
+            instruction_column="problem",
+            response_column="proof",
+        ),
+        metadata_columns=FINEPROOFS_SFT_METADATA_COLUMNS,
+        name="lm-provers/FineProofs-SFT/proof-only",
+        subsets=["default"],
+        splits=["train"],
     ),
     "sherryy/tulu-3-sft-personas-instruction-following-expanded": InstructionDatasetConfig(
         hf_dataset_id="sherryy/tulu-3-sft-personas-instruction-following-expanded",

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -1,0 +1,56 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from experiments.posttrain.instruction_datasets import (
+    FINEPROOFS_SFT_METADATA_COLUMNS,
+    FINEPROOFS_SFT_REVISION,
+    INSTRUCTION_DATASET_NAME_TO_CONFIG,
+    get_instruction_dataset,
+)
+from marin.execution.executor import unwrap_versioned_value
+from marin.transform.conversation.adapters import InputDatasetFormat
+
+
+def test_fineproofs_sft_datasets_are_registered():
+    raw_dataset = INSTRUCTION_DATASET_NAME_TO_CONFIG["lm-provers/FineProofs-SFT"]
+    proof_only_dataset = INSTRUCTION_DATASET_NAME_TO_CONFIG["lm-provers/FineProofs-SFT/proof-only"]
+
+    assert raw_dataset.hf_dataset_id == "lm-provers/FineProofs-SFT"
+    assert raw_dataset.revision == FINEPROOFS_SFT_REVISION
+    assert raw_dataset.subsets == ["default"]
+    assert raw_dataset.splits == ["train"]
+    assert raw_dataset.metadata_columns == FINEPROOFS_SFT_METADATA_COLUMNS
+    assert raw_dataset.adapter.dataset_format == InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN
+
+    assert proof_only_dataset.hf_dataset_id == "lm-provers/FineProofs-SFT"
+    assert proof_only_dataset.revision == FINEPROOFS_SFT_REVISION
+    assert proof_only_dataset.subsets == ["default"]
+    assert proof_only_dataset.splits == ["train"]
+    assert proof_only_dataset.metadata_columns == FINEPROOFS_SFT_METADATA_COLUMNS
+    assert proof_only_dataset.adapter.dataset_format == InputDatasetFormat.INSTRUCTION_RESPONSE
+    assert proof_only_dataset.adapter.instruction_column == "problem"
+    assert proof_only_dataset.adapter.response_column == "proof"
+
+
+def test_get_instruction_dataset_preserves_fineproofs_config():
+    raw_step = get_instruction_dataset("lm-provers/FineProofs-SFT")
+    raw_cfg = raw_step.config
+
+    assert unwrap_versioned_value(raw_cfg.source) == "lm-provers/FineProofs-SFT"
+    assert unwrap_versioned_value(raw_cfg.revision) == FINEPROOFS_SFT_REVISION
+    assert unwrap_versioned_value(raw_cfg.subsets) == ["default"]
+    assert unwrap_versioned_value(raw_cfg.splits) == ["train"]
+    assert unwrap_versioned_value(raw_cfg.metadata_columns) == FINEPROOFS_SFT_METADATA_COLUMNS
+    assert unwrap_versioned_value(raw_cfg.adapter).dataset_format == InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN
+    assert raw_step.name == "documents/lm-provers/FineProofs-SFT"
+
+    proof_only_step = get_instruction_dataset("lm-provers/FineProofs-SFT/proof-only")
+    proof_only_cfg = proof_only_step.config
+
+    assert unwrap_versioned_value(proof_only_cfg.source) == "lm-provers/FineProofs-SFT"
+    assert unwrap_versioned_value(proof_only_cfg.revision) == FINEPROOFS_SFT_REVISION
+    assert unwrap_versioned_value(proof_only_cfg.subsets) == ["default"]
+    assert unwrap_versioned_value(proof_only_cfg.splits) == ["train"]
+    assert unwrap_versioned_value(proof_only_cfg.metadata_columns) == FINEPROOFS_SFT_METADATA_COLUMNS
+    assert unwrap_versioned_value(proof_only_cfg.adapter).dataset_format == InputDatasetFormat.INSTRUCTION_RESPONSE
+    assert proof_only_step.name == "documents/lm-provers/FineProofs-SFT/proof-only"

--- a/tests/transform/test_conversation.py
+++ b/tests/transform/test_conversation.py
@@ -48,6 +48,36 @@ PREFERENCE_DATA_SAMPLE = {
     "metadata_field": "pref_test",
 }
 
+FINEPROOFS_MESSAGES_SAMPLE = {
+    "messages": [
+        {"role": "user", "content": "Prove that 1 + 1 = 2."},
+        {"role": "assistant", "content": "<think>Use Peano arithmetic.</think>\nHere is the proof."},
+    ],
+    "category": "number_theory",
+    "competition": "imo",
+    "gemini-3-pro-grade": 7,
+    "qwen3-4b-thinking-reward@128": 0.93,
+    "source": "olympiads",
+}
+
+FINEPROOFS_PROOF_ONLY_SAMPLE = {
+    "problem": "Show that the sum of two even integers is even.",
+    "proof": "Let the integers be 2a and 2b. Their sum is 2(a + b), so it is even.",
+    "category": "algebra",
+    "competition": "aops",
+    "gemini-3-pro-grade": 6,
+    "qwen3-4b-thinking-reward@128": 0.75,
+    "source": "aops",
+}
+
+FINEPROOFS_METADATA_COLUMNS = [
+    "category",
+    "competition",
+    "gemini-3-pro-grade",
+    "qwen3-4b-thinking-reward@128",
+    "source",
+]
+
 
 class TestTransformAdapters:
     """Test the different adapter formats."""
@@ -126,6 +156,68 @@ class TestTransformRow:
         assert "<|start_think|>" in response_message.content
         assert "<|end_think|>" in response_message.content
         assert "<think>" not in response_message.content
+
+    def test_fineproofs_multi_turn_row_preserves_metadata_and_rewrites_think_tags(self):
+        """Test FineProofs-like multi-turn rows."""
+        adapter = TransformAdapter(
+            dataset_format=InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN,
+            conversation_column="messages",
+            role_key="role",
+            content_key="content",
+            user_value="user",
+            assistant_value="assistant",
+            system_value="system",
+        )
+        cfg = TransformSFTDatasetConfig(
+            source="lm-provers/FineProofs-SFT",
+            revision="73661e6",
+            output_path="/tmp/output",
+            metadata_columns=FINEPROOFS_METADATA_COLUMNS,
+            adapter=adapter,
+        )
+
+        result = transform_row(FINEPROOFS_MESSAGES_SAMPLE, cfg, adapter)
+
+        assert result is not None
+        assert result.source == "lm-provers/FineProofs-SFT"
+        assert result.metadata == {
+            "category": "number_theory",
+            "competition": "imo",
+            "gemini-3-pro-grade": 7,
+            "qwen3-4b-thinking-reward@128": 0.93,
+            "source": "olympiads",
+        }
+        assert result.messages[0].content == "Prove that 1 + 1 = 2."
+        assert result.messages[1].content == "<|start_think|>Use Peano arithmetic.<|end_think|>\nHere is the proof."
+
+    def test_fineproofs_proof_only_row_builds_instruction_response_chat(self):
+        """Test FineProofs proof-only row conversion."""
+        adapter = TransformAdapter(
+            dataset_format=InputDatasetFormat.INSTRUCTION_RESPONSE,
+            instruction_column="problem",
+            response_column="proof",
+        )
+        cfg = TransformSFTDatasetConfig(
+            source="lm-provers/FineProofs-SFT",
+            revision="73661e6",
+            output_path="/tmp/output",
+            metadata_columns=FINEPROOFS_METADATA_COLUMNS,
+            adapter=adapter,
+        )
+
+        result = transform_row(FINEPROOFS_PROOF_ONLY_SAMPLE, cfg, adapter)
+
+        assert result is not None
+        assert [message.role for message in result.messages] == ["user", "assistant"]
+        assert result.messages[0].content == FINEPROOFS_PROOF_ONLY_SAMPLE["problem"]
+        assert result.messages[1].content == FINEPROOFS_PROOF_ONLY_SAMPLE["proof"]
+        assert result.metadata == {
+            "category": "algebra",
+            "competition": "aops",
+            "gemini-3-pro-grade": 6,
+            "qwen3-4b-thinking-reward@128": 0.75,
+            "source": "aops",
+        }
 
 
 class TestPreferenceDataTransform:


### PR DESCRIPTION
Register FineProofs-SFT as both a raw messages dataset and a proof-only view so Marin can use it for long-context reasoning runs and standard SFT baselines. Add regression tests covering think-tag rewriting, metadata preservation, and get_instruction_dataset wiring.