### PR TITLE
[Datakit] Add NuminaMath TIR source

### DIFF
--- a/lib/marin/src/marin/datakit/download/numinamath_tir.py
+++ b/lib/marin/src/marin/datakit/download/numinamath_tir.py
@@ -1,0 +1,116 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""AI-MO/NuminaMath-TIR dataset download and transform.
+
+NuminaMath-TIR is a math SFT corpus where assistant turns contain
+tool-integrated reasoning traces, including Python snippets and their outputs.
+The Hugging Face rows already expose OpenAI-style ``messages``; this module
+renders those messages into the tagged transcript format used by Marin's
+datakit reasoning sources.
+"""
+
+import hashlib
+from typing import Any
+
+from fray import ResourceConfig
+from zephyr import Dataset, ZephyrContext, counters, load_parquet
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.normalize import normalize_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "AI-MO/NuminaMath-TIR"
+HF_REVISION = "77a91d7"
+TRAIN_PARQUET_GLOB = "data/train-*.parquet"
+VALID_ROLES = frozenset({"assistant", "system", "tool", "user"})
+
+
+def _message_text(message: Any) -> str | None:
+    if not isinstance(message, dict):
+        return None
+
+    role = message.get("role")
+    content = message.get("content")
+    if role not in VALID_ROLES or not isinstance(content, str):
+        return None
+
+    content = content.strip()
+    if not content:
+        return None
+
+    return f"<{role}>\n{content}\n</{role}>"
+
+
+def render_messages(messages: Any) -> str | None:
+    """Render OpenAI-style messages as a tagged datakit transcript."""
+    if not isinstance(messages, list):
+        return None
+
+    parts: list[str] = []
+    for message in messages:
+        text = _message_text(message)
+        if text is None:
+            return None
+        parts.append(text)
+
+    if not parts:
+        return None
+
+    return "\n\n".join(parts)
+
+
+def row_to_doc(row: dict) -> list[dict]:
+    text = render_messages(row.get("messages"))
+    if text is None:
+        counters.increment("numinamath_tir/dropped")
+        return []
+
+    counters.increment("numinamath_tir/kept")
+    return [
+        {
+            "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "text": text,
+            "source": HF_DATASET_ID,
+        }
+    ]
+
+
+def transform(input_path: str, output_path: str) -> None:
+    pipeline = (
+        Dataset.from_files(f"{input_path}/**/*.parquet")
+        .flat_map(load_parquet)
+        .flat_map(row_to_doc)
+        .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
+    )
+    ctx = ZephyrContext(name="numinamath-tir-transform", resources=ResourceConfig(cpu=1, ram="4g"))
+    ctx.execute(pipeline)
+
+
+def download_numinamath_tir_step() -> StepSpec:
+    """Download and transform NuminaMath-TIR train rows into tagged transcript documents."""
+    dl = download_hf_step(
+        "raw/numinamath-tir",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=[TRAIN_PARQUET_GLOB],
+    )
+
+    return StepSpec(
+        name="processed/numinamath-tir",
+        deps=[dl],
+        fn=lambda output_path: transform(
+            input_path=dl.output_path,
+            output_path=output_path,
+        ),
+        hash_attrs={"version": "v1"},
+    )
+
+
+def numinamath_tir_normalize_steps() -> tuple[StepSpec, ...]:
+    """Return the full ``(download+transform, normalize)`` chain for NuminaMath-TIR."""
+    processed = download_numinamath_tir_step()
+    return (
+        processed,
+        normalize_step(name="normalized/numinamath-tir", download=processed),
+    )

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -36,6 +36,7 @@ from marin.datakit.download.molmo2_cap import molmo2_cap_normalize_steps
 from marin.datakit.download.nemotron_terminal import nemotron_terminal_normalize_steps
 from marin.datakit.download.nemotron_v2 import nemotron_v2_normalize_steps
 from marin.datakit.download.nsf_awards import nsf_awards_normalize_steps
+from marin.datakit.download.numinamath_tir import numinamath_tir_normalize_steps
 from marin.datakit.download.numinamath_v1_5 import numinamath_v1_5_normalize_steps
 from marin.datakit.download.starcoder2_extras import starcoder2_extras_normalize_steps
 from marin.datakit.download.superior_reasoning import superior_reasoning_normalize_steps
@@ -156,6 +157,7 @@ def all_sources() -> dict[str, DatakitSource]:
         ("nemotron-terminal", nemotron_terminal_normalize_steps, 6.08),
         ("nsf_awards", nsf_awards_normalize_steps, 0.17),
         ("numinamath-1.5", numinamath_v1_5_normalize_steps, 0.40),
+        ("numinamath-tir", numinamath_tir_normalize_steps, 0.08),
         ("superior-reasoning", superior_reasoning_normalize_steps, 7.08),
         ("svg", svgfind_creativecommons_normalize_steps, 8.95),
         ("swe-rebench-openhands", swe_rebench_openhands_normalize_steps, 2.47),

--- a/tests/datakit/download/test_numinamath_tir.py
+++ b/tests/datakit/download/test_numinamath_tir.py
@@ -9,9 +9,6 @@ import pyarrow.parquet as pq
 import pytest
 from marin.datakit.download.numinamath_tir import (
     HF_DATASET_ID,
-    HF_REVISION,
-    TRAIN_PARQUET_GLOB,
-    numinamath_tir_normalize_steps,
     row_to_doc,
     transform,
 )
@@ -63,41 +60,33 @@ def test_row_to_doc_renders_messages_as_tagged_transcript():
 @pytest.mark.parametrize(
     "row",
     [
-        {},
         {"messages": "not-a-list"},
         {"messages": []},
         {"messages": [{"role": "critic", "content": "Nope."}]},
         {"messages": [{"role": "user", "content": ""}]},
         {"messages": [{"role": "user", "content": None}]},
-        {"messages": [{"role": "user"}]},
-        {"messages": [{"content": "Missing role."}]},
         {"messages": [{"role": "user", "content": "Hi"}, "bad-message"]},
+    ],
+    ids=[
+        "messages-not-list",
+        "empty-transcript",
+        "unsupported-role",
+        "empty-content",
+        "non-string-content",
+        "malformed-message",
     ],
 )
 def test_row_to_doc_drops_invalid_rows(row):
     assert row_to_doc(row) == []
 
 
-def test_numinamath_tir_normalize_steps_use_train_split_and_stable_names():
-    processed, normalized = numinamath_tir_normalize_steps()
-    download = processed.deps[0]
-
-    assert download.name == "raw/numinamath-tir"
-    assert download.hash_attrs["hf_dataset_id"] == HF_DATASET_ID
-    assert download.hash_attrs["revision"] == HF_REVISION
-    assert download.hash_attrs["hf_urls_glob"] == [TRAIN_PARQUET_GLOB]
-    assert processed.name == "processed/numinamath-tir"
-    assert processed.deps == [download]
-    assert normalized.name == "normalized/numinamath-tir"
-    assert normalized.deps == [processed]
-
-
-def test_numinamath_tir_is_registered_as_datakit_source():
+def test_numinamath_tir_is_materializable_from_datakit_registry():
     source = all_sources()["numinamath-tir"]
+    processed, normalized = source.normalize_steps
 
-    assert source.rough_token_count_b == 0.08
-    assert source.normalize_steps[0].name == "processed/numinamath-tir"
-    assert source.normalized.name == "normalized/numinamath-tir"
+    assert source.normalized is normalized
+    assert processed.deps
+    assert normalized.deps == [processed]
 
 
 def test_transform_reads_parquet_and_writes_valid_docs(tmp_path: Path):
@@ -115,8 +104,4 @@ def test_transform_reads_parquet_and_writes_valid_docs(tmp_path: Path):
     transform(str(tmp_path / "raw"), str(output_dir))
 
     rows = [row for path in output_dir.rglob("*.parquet") for row in pq.read_table(path).to_pylist()]
-    assert len(rows) == 1
-    assert rows[0]["source"] == HF_DATASET_ID
-    assert rows[0]["text"].startswith("<user>\nSolve $x + 1 = 3$.\n</user>")
-    assert "```python\nprint(3 - 1)\n```" in rows[0]["text"]
-    assert rows[0]["id"] == hashlib.sha256(rows[0]["text"].encode("utf-8")).hexdigest()
+    assert rows == row_to_doc(_valid_row())

--- a/tests/datakit/download/test_numinamath_tir.py
+++ b/tests/datakit/download/test_numinamath_tir.py
@@ -1,6 +1,11 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import hashlib
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 from marin.datakit.download.numinamath_tir import (
     HF_DATASET_ID,
@@ -8,26 +13,29 @@ from marin.datakit.download.numinamath_tir import (
     TRAIN_PARQUET_GLOB,
     numinamath_tir_normalize_steps,
     row_to_doc,
+    transform,
 )
 from marin.datakit.sources import all_sources
 
 
-def test_row_to_doc_renders_messages_as_tagged_transcript():
+def _valid_row(**overrides) -> dict:
     row = {
+        "problem": "Solve $x + 1 = 3$.",
+        "solution": "We can verify with code.\n```python\nprint(3 - 1)\n```\n```output\n2\n```\nThus x = 2.",
         "messages": [
-            {"role": "user", "content": "Solve $x + 1 = 3$."},
+            {"role": "user", "content": " Solve $x + 1 = 3$. "},
             {
                 "role": "assistant",
-                "content": "We can verify with code.\n```python\nprint(3 - 1)\n```\n```output\n2\n```\nThus x = 2.",
+                "content": " We can verify with code.\n```python\nprint(3 - 1)\n```\n```output\n2\n```\nThus x = 2. ",
             },
-        ]
+        ],
     }
+    row.update(overrides)
+    return row
 
-    [doc] = row_to_doc(row)
 
-    assert doc["source"] == HF_DATASET_ID
-    assert len(doc["id"]) == 64
-    assert doc["text"] == (
+def test_row_to_doc_renders_messages_as_tagged_transcript():
+    expected_text = (
         "<user>\n"
         "Solve $x + 1 = 3$.\n"
         "</user>\n\n"
@@ -43,25 +51,13 @@ def test_row_to_doc_renders_messages_as_tagged_transcript():
         "</assistant>"
     )
 
+    [doc] = row_to_doc(_valid_row())
 
-def test_row_to_doc_preserves_supported_message_order():
-    row = {
-        "messages": [
-            {"role": "system", "content": "You are a math tutor."},
-            {"role": "user", "content": "Compute 2 + 2."},
-            {"role": "tool", "content": "4"},
-            {"role": "assistant", "content": "The answer is 4."},
-        ]
+    assert doc == {
+        "id": hashlib.sha256(expected_text.encode("utf-8")).hexdigest(),
+        "text": expected_text,
+        "source": HF_DATASET_ID,
     }
-
-    [doc] = row_to_doc(row)
-
-    assert doc["text"] == (
-        "<system>\nYou are a math tutor.\n</system>\n\n"
-        "<user>\nCompute 2 + 2.\n</user>\n\n"
-        "<tool>\n4\n</tool>\n\n"
-        "<assistant>\nThe answer is 4.\n</assistant>"
-    )
 
 
 @pytest.mark.parametrize(
@@ -102,3 +98,25 @@ def test_numinamath_tir_is_registered_as_datakit_source():
     assert source.rough_token_count_b == 0.08
     assert source.normalize_steps[0].name == "processed/numinamath-tir"
     assert source.normalized.name == "normalized/numinamath-tir"
+
+
+def test_transform_reads_parquet_and_writes_valid_docs(tmp_path: Path):
+    raw_dir = tmp_path / "raw" / "data"
+    raw_dir.mkdir(parents=True)
+    table = pa.Table.from_pylist(
+        [
+            _valid_row(),
+            _valid_row(messages=[{"role": "critic", "content": "Nope."}]),
+        ]
+    )
+    pq.write_table(table, raw_dir / "train-00000-of-00001.parquet")
+
+    output_dir = tmp_path / "processed"
+    transform(str(tmp_path / "raw"), str(output_dir))
+
+    rows = [row for path in output_dir.rglob("*.parquet") for row in pq.read_table(path).to_pylist()]
+    assert len(rows) == 1
+    assert rows[0]["source"] == HF_DATASET_ID
+    assert rows[0]["text"].startswith("<user>\nSolve $x + 1 = 3$.\n</user>")
+    assert "```python\nprint(3 - 1)\n```" in rows[0]["text"]
+    assert rows[0]["id"] == hashlib.sha256(rows[0]["text"].encode("utf-8")).hexdigest()

--- a/tests/datakit/download/test_numinamath_tir.py
+++ b/tests/datakit/download/test_numinamath_tir.py
@@ -1,0 +1,104 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from marin.datakit.download.numinamath_tir import (
+    HF_DATASET_ID,
+    HF_REVISION,
+    TRAIN_PARQUET_GLOB,
+    numinamath_tir_normalize_steps,
+    row_to_doc,
+)
+from marin.datakit.sources import all_sources
+
+
+def test_row_to_doc_renders_messages_as_tagged_transcript():
+    row = {
+        "messages": [
+            {"role": "user", "content": "Solve $x + 1 = 3$."},
+            {
+                "role": "assistant",
+                "content": "We can verify with code.\n```python\nprint(3 - 1)\n```\n```output\n2\n```\nThus x = 2.",
+            },
+        ]
+    }
+
+    [doc] = row_to_doc(row)
+
+    assert doc["source"] == HF_DATASET_ID
+    assert len(doc["id"]) == 64
+    assert doc["text"] == (
+        "<user>\n"
+        "Solve $x + 1 = 3$.\n"
+        "</user>\n\n"
+        "<assistant>\n"
+        "We can verify with code.\n"
+        "```python\n"
+        "print(3 - 1)\n"
+        "```\n"
+        "```output\n"
+        "2\n"
+        "```\n"
+        "Thus x = 2.\n"
+        "</assistant>"
+    )
+
+
+def test_row_to_doc_preserves_supported_message_order():
+    row = {
+        "messages": [
+            {"role": "system", "content": "You are a math tutor."},
+            {"role": "user", "content": "Compute 2 + 2."},
+            {"role": "tool", "content": "4"},
+            {"role": "assistant", "content": "The answer is 4."},
+        ]
+    }
+
+    [doc] = row_to_doc(row)
+
+    assert doc["text"] == (
+        "<system>\nYou are a math tutor.\n</system>\n\n"
+        "<user>\nCompute 2 + 2.\n</user>\n\n"
+        "<tool>\n4\n</tool>\n\n"
+        "<assistant>\nThe answer is 4.\n</assistant>"
+    )
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        {},
+        {"messages": "not-a-list"},
+        {"messages": []},
+        {"messages": [{"role": "critic", "content": "Nope."}]},
+        {"messages": [{"role": "user", "content": ""}]},
+        {"messages": [{"role": "user", "content": None}]},
+        {"messages": [{"role": "user"}]},
+        {"messages": [{"content": "Missing role."}]},
+        {"messages": [{"role": "user", "content": "Hi"}, "bad-message"]},
+    ],
+)
+def test_row_to_doc_drops_invalid_rows(row):
+    assert row_to_doc(row) == []
+
+
+def test_numinamath_tir_normalize_steps_use_train_split_and_stable_names():
+    processed, normalized = numinamath_tir_normalize_steps()
+    download = processed.deps[0]
+
+    assert download.name == "raw/numinamath-tir"
+    assert download.hash_attrs["hf_dataset_id"] == HF_DATASET_ID
+    assert download.hash_attrs["revision"] == HF_REVISION
+    assert download.hash_attrs["hf_urls_glob"] == [TRAIN_PARQUET_GLOB]
+    assert processed.name == "processed/numinamath-tir"
+    assert processed.deps == [download]
+    assert normalized.name == "normalized/numinamath-tir"
+    assert normalized.deps == [processed]
+
+
+def test_numinamath_tir_is_registered_as_datakit_source():
+    source = all_sources()["numinamath-tir"]
+
+    assert source.rough_token_count_b == 0.08
+    assert source.normalize_steps[0].name == "processed/numinamath-tir"
+    assert source.normalized.name == "normalized/numinamath-tir"

--- a/tests/datakit/download/test_numinamath_tir.py
+++ b/tests/datakit/download/test_numinamath_tir.py
@@ -12,7 +12,6 @@ from marin.datakit.download.numinamath_tir import (
     row_to_doc,
     transform,
 )
-from marin.datakit.sources import all_sources
 
 
 def _valid_row(**overrides) -> dict:
@@ -78,15 +77,6 @@ def test_row_to_doc_renders_messages_as_tagged_transcript():
 )
 def test_row_to_doc_drops_invalid_rows(row):
     assert row_to_doc(row) == []
-
-
-def test_numinamath_tir_is_materializable_from_datakit_registry():
-    source = all_sources()["numinamath-tir"]
-    processed, normalized = source.normalize_steps
-
-    assert source.normalized is normalized
-    assert processed.deps
-    assert normalized.deps == [processed]
 
 
 def test_transform_reads_parquet_and_writes_valid_docs(tmp_path: Path):


### PR DESCRIPTION
Add NuminaMath-TIR through datakit's download, transform, and normalize pipeline. Drop standalone NuminaMath-CoT from this branch to avoid overlap with the existing gpt-oss-rollouts NuminaMath-CoT path. Tests cover the TIR row transform and datakit source wiring.