### PR TITLE
Add DFS stitching pipeline for Common Pile Stack v2

### DIFF
--- a/experiments/common_pile/stitch_stackv2.py
+++ b/experiments/common_pile/stitch_stackv2.py
@@ -1,0 +1,210 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stitch Common Pile's ``common-pile/stackv2`` file-level records into whole-repo documents.
+
+The base ``common-pile/stackv2`` dataset (the SWH-keyed variant) ships ``metadata.url`` of
+the form ``https://raw.githubusercontent.com/<owner>/<repo>/<commit>/<path>`` and a matching
+``metadata.path``. We group on ``<owner>/<repo>@<commit>`` and concatenate each repo's files
+in depth-first traversal order — siblings stay adjacent, and descendants of a directory
+appear before later siblings of its parent. The result is a single document per repo
+(optionally split into chunks for very large repos) intended for long-context training.
+
+The filtered variants (``stackv2_edu_filtered``, ``stackv2_html_filtered``) strip ``url``/
+``path`` and are **not** supported by this transform — recovering repo identity there would
+require an out-of-band Software Heritage lookup.
+"""
+
+import logging
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from zephyr import Dataset, ZephyrContext, load_jsonl
+
+from experiments.common_pile.tokenize_common_pile import stackv2
+from experiments.defaults import default_tokenize
+from experiments.llama import llama3_tokenizer
+from marin.execution.executor import ExecutorStep, executor_main, this_output_path
+
+logger = logging.getLogger(__name__)
+
+# ``raw.githubusercontent.com`` paths look like ``/<owner>/<repo>/<commit>/<path>`` after the
+# hostname is stripped, so splitting on ``/`` yields: ["", owner, repo, commit, *path_parts].
+_URL_OWNER_IDX = 1
+_URL_REPO_IDX = 2
+_URL_COMMIT_IDX = 3
+_URL_PATH_START = 4
+
+
+@dataclass(frozen=True)
+class StitchStackV2Config:
+    """Configuration for DFS-stitching Stack v2 file-level records into repo documents.
+
+    Attributes:
+        input_path: Directory of ``common-pile/stackv2`` JSONL shards.
+        output_path: Destination directory for stitched JSONL shards.
+        input_glob: Glob (relative to ``input_path``) selecting input shards.
+        separator: String inserted between adjacent file bodies in the stitched document.
+        file_header: ``str.format`` template (with ``{path}``) prepended before each file body.
+        max_chars_per_repo: When set, a repo that accumulates more than this many characters
+            is split into multiple chunked records (still in DFS order). ``None`` emits one
+            record per repo regardless of size.
+        min_files_per_repo: Repos (or chunks) with fewer than this many files are dropped.
+    """
+
+    input_path: str
+    output_path: str
+    input_glob: str = "*.json*"
+    separator: str = "\n\n"
+    file_header: str = "# === {path} ===\n"
+    max_chars_per_repo: int | None = None
+    min_files_per_repo: int = 1
+
+
+def _repo_key(record: dict) -> str | None:
+    """Return ``<owner>/<repo>@<commit>`` for the record, or ``None`` if unparseable.
+
+    The commit hash is included in the key so that multiple snapshots of the same repo
+    (if present) don't collapse into one stitched document with interleaved histories.
+    """
+    metadata = record.get("metadata") or {}
+    url = metadata.get("url")
+    if not isinstance(url, str) or not url:
+        return None
+    parts = urlparse(url).path.split("/")
+    if len(parts) <= _URL_COMMIT_IDX:
+        return None
+    owner, repo, commit = parts[_URL_OWNER_IDX], parts[_URL_REPO_IDX], parts[_URL_COMMIT_IDX]
+    if not (owner and repo and commit):
+        return None
+    return f"{owner}/{repo}@{commit}"
+
+
+def _file_path(record: dict) -> str | None:
+    """Return the in-repo file path for the record, falling back to the url tail."""
+    metadata = record.get("metadata") or {}
+    path = metadata.get("path")
+    if isinstance(path, str) and path:
+        return path.lstrip("/")
+    url = metadata.get("url")
+    if isinstance(url, str) and url:
+        parts = urlparse(url).path.split("/")
+        if len(parts) > _URL_PATH_START:
+            return "/".join(parts[_URL_PATH_START:])
+    return None
+
+
+def _dfs_sort_key(record: dict) -> tuple[str, ...]:
+    """Sort key that yields depth-first traversal when applied across a repo's files.
+
+    Python's tuple comparison is lexicographic on components, so files sharing a directory
+    prefix stay contiguous and the deepest descendants of each directory are emitted before
+    moving on to the next sibling at the parent level.
+    """
+    path = _file_path(record) or ""
+    return tuple(path.split("/"))
+
+
+def _make_stitch_reducer(
+    config: StitchStackV2Config,
+) -> Callable[[str, Iterator[dict]], Iterator[dict]]:
+    """Build the (repo_key, files) -> records reducer used by ``group_by``."""
+
+    separator = config.separator
+    header_tpl = config.file_header
+    max_chars = config.max_chars_per_repo
+    min_files = config.min_files_per_repo
+
+    def reducer(repo: str, files: Iterator[dict]) -> Iterator[dict]:
+        buf: list[str] = []
+        paths: list[str] = []
+        running_chars = 0
+        chunk_idx = 0
+
+        def emit() -> dict | None:
+            if len(paths) < min_files:
+                return None
+            doc_id = f"{repo}#{chunk_idx}" if max_chars is not None else repo
+            return {
+                "id": doc_id,
+                "text": separator.join(buf),
+                "metadata": {
+                    "repo": repo,
+                    "chunk_idx": chunk_idx,
+                    "n_files": len(paths),
+                    "paths": list(paths),
+                },
+            }
+
+        for record in files:  # delivered in DFS order thanks to sort_by
+            path = _file_path(record)
+            text = record.get("text")
+            if path is None or not isinstance(text, str):
+                continue
+            piece = header_tpl.format(path=path) + text
+            # Length cost of appending ``piece`` to a non-empty buffer: piece + one separator.
+            incremental = len(piece) + (len(separator) if buf else 0)
+            if max_chars is not None and buf and running_chars + incremental > max_chars:
+                out = emit()
+                if out is not None:
+                    yield out
+                    chunk_idx += 1
+                buf, paths, running_chars = [], [], 0
+                incremental = len(piece)  # first piece in a fresh chunk has no separator
+            buf.append(piece)
+            paths.append(path)
+            running_chars += incremental
+
+        out = emit()
+        if out is not None:
+            yield out
+
+    return reducer
+
+
+def stitch_stackv2_repos(config: StitchStackV2Config) -> None:
+    """Group Stack v2 records by repo and emit DFS-stitched documents."""
+    logger.info(
+        "Stitching Stack v2 records from %s into repo-level documents at %s",
+        config.input_path,
+        config.output_path,
+    )
+
+    pipeline = (
+        Dataset.from_files(f"{config.input_path}/{config.input_glob}")
+        .flat_map(load_jsonl)
+        .filter(lambda record: _repo_key(record) is not None and _file_path(record) is not None)
+        .group_by(
+            key=_repo_key,
+            sort_by=_dfs_sort_key,
+            reducer=_make_stitch_reducer(config),
+        )
+        .write_jsonl(f"{config.output_path}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz")
+    )
+    ctx = ZephyrContext(name="stitch-stackv2-repos")
+    ctx.execute(pipeline)
+
+
+# Executor wiring: take ``common-pile/stackv2`` (the SWH-keyed variant downloaded in
+# tokenize_common_pile.py), stitch into repo-level documents, and tokenize with the llama3
+# tokenizer for long-context training.
+stackv2_stitched = ExecutorStep(
+    name="documents/common_pile/stackv2_stitched",
+    fn=stitch_stackv2_repos,
+    config=StitchStackV2Config(
+        input_path=stackv2,
+        output_path=this_output_path(),
+    ),
+)
+
+
+stackv2_stitched_tokenized = default_tokenize(
+    name="common_pile_stackv2_stitched",
+    dataset=stackv2_stitched,
+    tokenizer=llama3_tokenizer,
+)
+
+
+if __name__ == "__main__":
+    executor_main(steps=[stackv2_stitched, stackv2_stitched_tokenized])

--- a/tests/transform/common_pile/test_stitch_stackv2.py
+++ b/tests/transform/common_pile/test_stitch_stackv2.py
@@ -189,9 +189,7 @@ def test_stitch_splits_mega_repo_when_max_chars_set(
     body = "x" * 50
     write_jsonl_gz(
         input_dir / "stack-0000.jsonl.gz",
-        [
-            _record(REPO_A_URL, f"dir/file_{i}.py", body) for i in range(3)
-        ],
+        [_record(REPO_A_URL, f"dir/file_{i}.py", body) for i in range(3)],
     )
 
     stitch_stackv2_repos(

--- a/tests/transform/common_pile/test_stitch_stackv2.py
+++ b/tests/transform/common_pile/test_stitch_stackv2.py
@@ -1,0 +1,258 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from experiments.common_pile.stitch_stackv2 import (
+    StitchStackV2Config,
+    _dfs_sort_key,
+    _file_path,
+    _repo_key,
+    stitch_stackv2_repos,
+)
+
+REPO_A_URL = "https://raw.githubusercontent.com/alice/repo_a/abc123"
+REPO_A_ALT_COMMIT_URL = "https://raw.githubusercontent.com/alice/repo_a/deadbee"
+REPO_B_URL = "https://raw.githubusercontent.com/bob/repo_b/ffffff"
+
+
+def _record(url_prefix: str, path: str, text: str) -> dict:
+    """Build a minimal Stack v2 record with the ``metadata.url`` and ``metadata.path`` fields."""
+    return {
+        "id": f"{url_prefix}/{path}",
+        "text": text,
+        "metadata": {"url": f"{url_prefix}/{path}", "path": path},
+    }
+
+
+def test_repo_key_extracts_owner_repo_commit() -> None:
+    record = _record(REPO_A_URL, "src/main.py", "print('hi')")
+    assert _repo_key(record) == "alice/repo_a@abc123"
+
+
+def test_repo_key_returns_none_when_url_missing_or_malformed() -> None:
+    assert _repo_key({"metadata": {}}) is None
+    assert _repo_key({"metadata": {"url": ""}}) is None
+    # Path too short: no commit segment.
+    assert _repo_key({"metadata": {"url": "https://raw.githubusercontent.com/alice/repo_a"}}) is None
+
+
+def test_file_path_falls_back_to_url_tail_when_path_absent() -> None:
+    record = {"metadata": {"url": f"{REPO_A_URL}/src/deep/main.py"}}
+    assert _file_path(record) == "src/deep/main.py"
+
+
+def test_dfs_sort_key_orders_files_depth_first() -> None:
+    # Mix of top-level files, nested subdirs, and adjacent siblings — exercise the
+    # tuple-comparison rules that power DFS ordering.
+    paths = [
+        "z/e.py",
+        "a.py",
+        "sub/nested/d.py",
+        "sub/b.py",
+        "sub/c.py",
+    ]
+    records = [_record(REPO_A_URL, p, "") for p in paths]
+    records.sort(key=_dfs_sort_key)
+    assert [r["metadata"]["path"] for r in records] == [
+        "a.py",
+        "sub/b.py",
+        "sub/c.py",
+        "sub/nested/d.py",
+        "z/e.py",
+    ]
+
+
+def test_dfs_sort_key_enters_subdirectory_before_sibling_file() -> None:
+    # A directory ``a/`` precedes a sibling file ``a.py`` because the tuple ('a', 'c.py')
+    # compares less than ('a.py',) — matches how a DFS keyed on sorted directory entries
+    # would visit the tree.
+    records = [_record(REPO_A_URL, p, "") for p in ["a.py", "a/c.py"]]
+    records.sort(key=_dfs_sort_key)
+    assert [r["metadata"]["path"] for r in records] == ["a/c.py", "a.py"]
+
+
+def test_stitch_emits_one_record_per_repo_in_dfs_order(
+    tmp_path: Path,
+    write_jsonl_gz,
+    read_all_jsonl_gz,
+) -> None:
+    """End-to-end: two repos split across shards; verify DFS stitching and metadata."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+
+    # Shard the same repo across two input files to confirm group_by collapses across shards.
+    write_jsonl_gz(
+        input_dir / "stack-0000.jsonl.gz",
+        [
+            _record(REPO_A_URL, "z/late.py", "Z_LATE"),
+            _record(REPO_A_URL, "sub/b.py", "SUB_B"),
+            _record(REPO_B_URL, "only.py", "ONLY"),
+            # Unparseable URL — should be dropped rather than crash the pipeline.
+            {"id": "garbage", "text": "ignored", "metadata": {"url": "not-a-url"}},
+        ],
+    )
+    write_jsonl_gz(
+        input_dir / "stack-0001.jsonl.gz",
+        [
+            _record(REPO_A_URL, "a.py", "A"),
+            _record(REPO_A_URL, "sub/nested/d.py", "SUB_NESTED_D"),
+            _record(REPO_A_URL, "sub/c.py", "SUB_C"),
+        ],
+    )
+
+    stitch_stackv2_repos(
+        StitchStackV2Config(
+            input_path=str(input_dir),
+            output_path=str(output_dir),
+            input_glob="*.jsonl.gz",
+            file_header="### {path}\n",
+            separator="\n---\n",
+        )
+    )
+
+    stitched = read_all_jsonl_gz(output_dir)
+    by_repo = {r["metadata"]["repo"]: r for r in stitched}
+    assert set(by_repo) == {"alice/repo_a@abc123", "bob/repo_b@ffffff"}
+
+    repo_a = by_repo["alice/repo_a@abc123"]
+    assert repo_a["id"] == "alice/repo_a@abc123"
+    assert repo_a["metadata"]["n_files"] == 5
+    assert repo_a["metadata"]["paths"] == [
+        "a.py",
+        "sub/b.py",
+        "sub/c.py",
+        "sub/nested/d.py",
+        "z/late.py",
+    ]
+    # Bodies are concatenated in DFS order with per-file headers between them.
+    assert repo_a["text"] == (
+        "### a.py\nA"
+        "\n---\n"
+        "### sub/b.py\nSUB_B"
+        "\n---\n"
+        "### sub/c.py\nSUB_C"
+        "\n---\n"
+        "### sub/nested/d.py\nSUB_NESTED_D"
+        "\n---\n"
+        "### z/late.py\nZ_LATE"
+    )
+
+    repo_b = by_repo["bob/repo_b@ffffff"]
+    assert repo_b["metadata"]["n_files"] == 1
+    assert repo_b["metadata"]["paths"] == ["only.py"]
+
+
+def test_stitch_commit_pinning_splits_same_repo_across_commits(
+    tmp_path: Path,
+    write_jsonl_gz,
+    read_all_jsonl_gz,
+) -> None:
+    """Different commits of the same ``owner/repo`` must produce separate stitched docs."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    write_jsonl_gz(
+        input_dir / "stack-0000.jsonl.gz",
+        [
+            _record(REPO_A_URL, "main.py", "OLD"),
+            _record(REPO_A_ALT_COMMIT_URL, "main.py", "NEW"),
+        ],
+    )
+
+    stitch_stackv2_repos(
+        StitchStackV2Config(
+            input_path=str(input_dir),
+            output_path=str(output_dir),
+            input_glob="*.jsonl.gz",
+        )
+    )
+
+    stitched = read_all_jsonl_gz(output_dir)
+    repos = {r["metadata"]["repo"] for r in stitched}
+    assert repos == {"alice/repo_a@abc123", "alice/repo_a@deadbee"}
+
+
+def test_stitch_splits_mega_repo_when_max_chars_set(
+    tmp_path: Path,
+    write_jsonl_gz,
+    read_all_jsonl_gz,
+) -> None:
+    """With ``max_chars_per_repo`` set, a single repo is split into chunked records."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    # Each file body is 50 chars. Headers add ~15. With max_chars=80, each file should
+    # end up in its own chunk (second file triggers a flush).
+    body = "x" * 50
+    write_jsonl_gz(
+        input_dir / "stack-0000.jsonl.gz",
+        [
+            _record(REPO_A_URL, f"dir/file_{i}.py", body) for i in range(3)
+        ],
+    )
+
+    stitch_stackv2_repos(
+        StitchStackV2Config(
+            input_path=str(input_dir),
+            output_path=str(output_dir),
+            input_glob="*.jsonl.gz",
+            max_chars_per_repo=80,
+        )
+    )
+
+    stitched = sorted(read_all_jsonl_gz(output_dir), key=lambda r: r["metadata"]["chunk_idx"])
+    assert len(stitched) == 3
+    assert [r["metadata"]["chunk_idx"] for r in stitched] == [0, 1, 2]
+    # IDs are decorated with ``#<chunk_idx>`` when splitting is active.
+    assert [r["id"] for r in stitched] == [
+        "alice/repo_a@abc123#0",
+        "alice/repo_a@abc123#1",
+        "alice/repo_a@abc123#2",
+    ]
+    # Each chunk retains the repo key and records exactly the file(s) it contains.
+    assert all(r["metadata"]["repo"] == "alice/repo_a@abc123" for r in stitched)
+    assert [r["metadata"]["paths"] for r in stitched] == [
+        ["dir/file_0.py"],
+        ["dir/file_1.py"],
+        ["dir/file_2.py"],
+    ]
+
+
+@pytest.mark.parametrize(
+    "bad_record",
+    [
+        {"id": "no_metadata", "text": "body"},
+        {"id": "empty_url", "text": "body", "metadata": {"url": ""}},
+        {"id": "path_missing_url_too_short", "text": "body", "metadata": {"url": "https://host/only"}},
+    ],
+)
+def test_stitch_drops_records_without_parseable_repo(
+    bad_record: dict,
+    tmp_path: Path,
+    write_jsonl_gz,
+    read_all_jsonl_gz,
+) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    write_jsonl_gz(
+        input_dir / "stack-0000.jsonl.gz",
+        [
+            _record(REPO_A_URL, "main.py", "GOOD"),
+            bad_record,
+        ],
+    )
+
+    stitch_stackv2_repos(
+        StitchStackV2Config(
+            input_path=str(input_dir),
+            output_path=str(output_dir),
+            input_glob="*.jsonl.gz",
+        )
+    )
+
+    stitched = read_all_jsonl_gz(output_dir)
+    assert len(stitched) == 1
+    assert stitched[0]["metadata"]["repo"] == "alice/repo_a@abc123"


### PR DESCRIPTION
Groups `common-pile/stackv2` file-level records by `owner/repo@commit` (parsed from `metadata.url`) and concatenates each repo's files in depth-first path order, producing one (or, with `max_chars_per_repo`, chunked) document per repo. Targets long-context code pretraining; the filtered variants (`stackv2_edu`/`_html`) strip the url/path fields needed for grouping and are not supported here.

Lives entirely in `experiments/common_pile/` per issue discussion.

Closes #4978

Generated with [Claude Code](https://claude.ai/code)