### PR TITLE
[iris] Raise ConnectError(NOT_FOUND) from IrisClient.job_state

### DIFF
--- a/lib/iris/src/iris/client/client.py
+++ b/lib/iris/src/iris/client/client.py
@@ -710,7 +710,7 @@ class IrisClient:
         states = self._cluster_client.get_job_states([job_id])
         wire_id = job_id.to_wire()
         if wire_id not in states:
-            raise KeyError(f"Job {wire_id} not found")
+            raise ConnectError(Code.NOT_FOUND, f"Job {wire_id} not found")
         return cast(job_pb2.JobState, states[wire_id])
 
     def terminate(self, job_id: JobName) -> None:


### PR DESCRIPTION
Restore the pre-#5021 public API: Job.state / state_only() now surface ConnectError(Code.NOT_FOUND) when the job is missing, matching RemoteClusterClient._poll_job_state. The bare KeyError introduced by the lightweight polling path was a regression for callers that rely on ConnectError semantics.

Follow-up to #5021.