### PR TITLE
Add ops-log skill and move logs out of gitignored path

### DIFF
--- a/.agents/ops/2026-04-21-iris-scheduler-freeze.md
+++ b/.agents/ops/2026-04-21-iris-scheduler-freeze.md
@@ -1,0 +1,122 @@
+---
+date: 2026-04-21
+system: iris
+severity: outage
+resolution: fixed
+pr: none
+issue: none
+---
+
+# Iris scheduler thread freeze — "Pending scheduler feedback"
+
+## TL;DR
+
+- Dashboard showed **"Pending scheduler feedback"** on every pending job in the Marin cluster; a user-reported job had been pending 30+ min with no diagnostic text.
+- The scheduling thread had crashed ~21 minutes before the reported job was submitted, with `sqlite3.IntegrityError: UNIQUE constraint failed: task_attempts.task_id, task_attempts.attempt_id` in `_dispatch_assignments_direct → queue_assignments → _assign_task → insert_task_attempt`.
+- `ManagedThread._safe_target` logged the crash and returned — no respawn — so `_scheduling_diagnostics` cache stopped updating and every pending job fell back to the literal `"Pending scheduler feedback"` in `service.py:1224`.
+- Real root cause: `fail_worker`'s reservation-holder branch at `transitions.py:2170-2180` reset `tasks.current_attempt_id = -1` while leaving old `task_attempts` rows (ids 0..N-1) in place. The next assignment computed `attempt_id = -1 + 1 = 0` and collided.
+- Fix: route reservation holders through `_terminate_task` like non-holders, passing `preemption_count=0` to preserve the holder-specific retry-budget semantic. Companion migration `0036_reconcile_reservation_holder_attempt_ids.py` heals any stale row on restart. Regression test added.
+
+## Original problem report
+
+> help me debug why this job on lib/iris/examples/marin.yaml is showing "awaiting scheduler feedback". i think we might have a bug in the controller?
+>
+> https://iris.oa.dev/#/job/%2Fmichaelryan%2Fcuration-fm-157m-dclm-1p8e19-canonical
+
+Job `/michaelryan/curation-fm-157m-dclm-1p8e19-canonical` — 2 CPU / 2 GiB, interactive band, 1 task — submitted 2026-04-22T00:53:34 UTC, pending 90+ minutes at queue_position 271 with pending_reason `"Pending scheduler feedback"`. CPU VM pool (`cpu_vm_e2_highmem_2_ondemand`) had 5 READY idle slices, so capacity was not the issue.
+
+## Investigation path
+
+1. Pulled `job bug-report` and `rpc controller get-scheduler-state`. Job was in `PRIORITY_BAND_INTERACTIVE` pending queue at position 271 with resource_value 12 — nothing exotic. Budget row showed `limit=0, spent=318036` for `michaelryan`; **user explicitly ruled this out** ("budgets aren't the problem").
+2. Traced the fallback string `"Pending scheduler feedback"` to `service.py:1224` — set when `controller.get_job_scheduling_diagnostics()` returns None. Diagnostics only populated by `_cache_scheduling_diagnostics` inside `_run_scheduling` (controller.py:2007).
+3. Dispatched a senior-engineer agent in the background to enumerate code paths that could suppress diagnostics for a long-pending task. Top hypotheses: `task_id.parent is None` (D), `reservation_unsatisfied` gate (A.3), `job_not_found` (A.2).
+4. Downloaded the latest controller checkpoint from `gs://marin-us-central2/iris/marin/state/controller-state/` via `gcloud storage cp` + `zstd -df`. The checkpoint was from 00:41:28 — 12 minutes *before* the job was submitted, so `/michaelryan/...` wasn't in it. Hypotheses D, A.3, A.2 all refuted by live `iris query`: task had `/0` suffix (parent exists), `has_reservation=0`, `job_config` row present.
+5. **User:** "it looks like the scheduling loop crashed, can you look for an exception in the parquet?" — pivoted to searching recent parquet log shards.
+6. Downloaded 9 recent parquet log shards to `/tmp/iris-debug/` and queried with duckdb. **In hindsight this was unnecessary** — `pyarrow.dataset` + `gcsfs` + `duckdb.register` lets duckdb query `gs://...` directly with predicate pushdown; 15-shard searches complete in ~7s with no local storage. See the reference recipe in the OPS.md suggestions below. Found one hit on pattern `Traceback` in the controller process log: `scheduling-loop crashed` at `2026-04-22 00:32:23.242 UTC`, with full stack leading to `sqlite3.IntegrityError: UNIQUE constraint failed: task_attempts.task_id, task_attempts.attempt_id`.
+7. Confirmed zero `Scheduling cycle` / `ManagedThread` / `_run_scheduling` log lines after the crash — thread never respawned.
+8. Queried the checkpoint for tasks where `max(task_attempts.attempt_id) > tasks.current_attempt_id`. One result: `/larry/iris-run-job-20260421-153324/:reservation:/0` — 68 attempt rows (ids 0..67, all WORKER_FAILED), `current_attempt_id = -1`, state PENDING, `is_reservation_holder = 1`.
+9. Read `fail_worker` at `transitions.py:2140-2210`. The reservation-holder branch at 2170-2180 was the only place in the codebase that set `current_attempt_id = -1`. It DELETEd only the current attempt row (`attempt_id = current_attempt_id`), leaving any accumulated earlier attempts behind.
+10. Dispatched a second senior-engineer agent to review the proposed fix (replace branch with `_terminate_task`, pass `preemption_count=0`). Verdict: APPROVE WITH CHANGES — required a regression test and flagged that the change drops the `error = NULL` semantic.
+11. **User:** "let's do the following" — write a migration, answer whether the try/except in `_run_scheduling_loop` would infinite-loop, send a third agent to add a scheduling regression test.
+12. Dispatched third senior-engineer agent to apply the fix and add a multi-cycle regression test. Agent also updated a pre-existing test (`test_holder_task_worker_death_no_failure_record`) whose `len(attempts) == 0` assertion had been pinning the buggy behavior.
+
+## User course corrections
+
+- **"budgets aren't the problem"** — cut off a wrong branch early. User knew the cluster's budgets have always been zero-limit and they're advisory, not enforcing.
+- **"don't take a checkpoint, copy the previous from GCS"** — rejected the default `iris cluster controller checkpoint` workflow (would have stalled the controller while the scheduling loop was already dead) in favor of pulling an existing checkpoint from GCS. Faster, zero cluster impact.
+- **"gcloud storage cp"** — overrode reflex `gsutil` (deprecated tooling in this org).
+- **"it looks like the scheduling loop crashed"** — pivoted the investigation. The model was still drilling into gate-by-gate reasons a diagnostic might be missing; the user's thread-level hypothesis was correct and shortened the path by ~30 minutes.
+- **"is there a simple fix? e.g. never preempt reservation jobs"** — proposed a constraint that turned out to be unrelated to the bug (crash was in `fail_worker`, not `preempt_task`). Clarifying why it wouldn't help led to the actual one-line fix.
+- **"reservation jobs shouldn't have any children"** — let us skip the `_cascade_children` / `TERMINATE_CHILDREN` concern the code-review agent flagged. Scoped the test correctly.
+
+## Root cause
+
+`lib/iris/src/iris/cluster/controller/transitions.py:2170-2180` — the `_remove_failed_worker` reservation-holder branch. It reset `tasks.current_attempt_id = -1` while DELETing only the single current-attempt row, leaving attempts `0..N-1` in the table. On the next scheduler cycle, `queue_assignments` at `transitions.py:1667` computed `attempt_id = current_attempt_id + 1 = 0` and `insert_task_attempt` raised `sqlite3.IntegrityError` against the still-present `(task_id, 0)` row.
+
+The exception unwound out of `_run_scheduling_loop`, through `ManagedThread._safe_target`, which caught-and-logged-and-returned. No supervisor respawned the thread. For the following ~90 minutes, no scheduling cycle ran, no diagnostics were cached, no new assignments were made. Workers continued heartbeating (separate thread) so the cluster *looked* alive.
+
+Class of bug: **cross-table invariant violation** between `tasks.current_attempt_id` and `task_attempts`. The holder-specific reset logic fell out of sync with the non-holder path that the rest of the codebase assumed.
+
+## Fix
+
+**Code** — `lib/iris/src/iris/cluster/controller/transitions.py:2167-2186`. Replaced the holder-specific DELETE+reset branch with a unified `_terminate_task` call; only `preemption_count` differs between holder (0) and non-holder (computed from retry budget). The holder attempt row is now preserved in `WORKER_FAILED` state like any other terminal attempt.
+
+**Migration** — `lib/iris/src/iris/cluster/controller/migrations/0036_reconcile_reservation_holder_attempt_ids.py`. On next controller restart, advances `tasks.current_attempt_id` to `max(task_attempts.attempt_id)` for any task where the invariant was already broken. Dry-run on the live checkpoint healed the single poisoned row (`/larry/iris-run-job-20260421-153324/:reservation:/0`: `-1 → 67`).
+
+**Regression test** — `lib/iris/tests/cluster/controller/test_reservation_holder_reset_regression.py::test_reservation_holder_reassignment_across_successive_worker_failures`. Fails a holder + non-holder across three successive workers, asserts `current_attempt_id` advances `0→1→2`, three `WORKER_FAILED` attempt rows accumulate, no IntegrityError raised, non-holder re-schedules each cycle.
+
+**Contract change called out** — `test_holder_task_worker_death_no_failure_record` in `test_reservation.py` previously asserted `len(holder_task.attempts) == 0` on each worker-death cycle, pinning the buggy behavior. Updated to assert attempts accumulate as `WORKER_FAILED` rows while `preemption_count`/`failure_count` stay zero. Worth checking if any dashboard component relied on holders having zero attempt rows.
+
+**Defense-in-depth not applied:** wrapping `outcome = self._run_scheduling()` at `controller.py:1372` in try/except was discussed. With the poisoned row, a bare try/except would hot-loop at the exponential backoff ceiling indefinitely. Correct form would be per-assignment `SAVEPOINT` inside `queue_assignments` so one bad task doesn't take down the cycle. Left as follow-up.
+
+## How OPS.md could have shortened this
+
+Generic patterns — suggestions apply beyond this incident.
+
+1. **`lib/iris/OPS.md` → new section "Parquet log queries".** The investigation's biggest speedup came from duckdb over the controller's parquet log shards in GCS. Currently undocumented. The parquet schema (`seq, key, source, data, epoch_ms, level`) with the `key='/system/controller'` filter for controller-only lines should be named, and the runnable recipe below should be the canonical entrypoint. Querying directly against GCS (no local download) is ~10× faster and avoids the temptation to grab only a few shards:
+
+   ```python
+   import duckdb, gcsfs, pyarrow.dataset as ds
+
+   fs = gcsfs.GCSFileSystem(project='hai-gcp-models')
+   files = sorted(fs.glob('gs://marin-us-central2/iris/marin/state/logs/logs_*.parquet'))[-20:]
+   dataset = ds.dataset(files, format='parquet', filesystem=fs)
+   con = duckdb.connect()
+   con.register('logs', dataset)
+
+   con.execute("""
+       SELECT epoch_ms, substr(data, 1, 200)
+       FROM logs
+       WHERE key='/system/controller'
+         AND data LIKE '%Traceback%'
+       ORDER BY epoch_ms DESC LIMIT 50
+   """).fetchall()
+   ```
+
+   Auth is ADC (`gcloud auth application-default login`). DuckDB's native `gs://` httpfs extension requires HMAC keys and rejects ADC — the pyarrow-dataset + `con.register` path is the one that works. Document this explicitly; otherwise the next engineer (human or model) will burn 10 minutes on the `CREATE SECRET` dead end.
+
+2. **`lib/iris/OPS.md` → "Offline checkpoint analysis": prefer copying an existing GCS checkpoint over triggering a new one.** Current guidance says "trigger a checkpoint, then query offline." That's fine when the controller is healthy but wrong when it's stuck — `iris cluster controller checkpoint` briefly stalls the controller, and checkpoints already land in GCS every ~hour. Add:
+
+   ```bash
+   # List existing checkpoints (timestamps are epoch-ms)
+   gcloud storage ls gs://<bucket>/iris/<cluster>/state/controller-state/
+
+   # Copy the most recent; decompress
+   gcloud storage cp gs://<bucket>/.../<ts>/controller.sqlite3.zst /tmp/
+   zstd -df /tmp/controller.sqlite3.zst
+   ```
+
+   Note `gcloud storage cp`, not `gsutil` (deprecated at this org).
+
+3. **`lib/iris/OPS.md` → "Known Bugs" (or a new "Silent-thread failure modes" section): background threads managed by `ManagedThread` can die silently.** `ManagedThread._safe_target` catches exceptions, logs `<thread-name> crashed`, and returns — no supervisor respawns. The cluster looks alive (heartbeats continue; other threads run) but critical work silently halts. Generic diagnostic: when a subsystem appears frozen but the controller is reachable, check recent parquet logs for `ManagedThread.*crashed` before assuming the code path is just slow.
+
+4. **`lib/iris/OPS.md` → "Troubleshooting" table: add a row for "same pending-reason text on many/all pending jobs."** This is a generic smell for cache-update failure in the controller — whatever populates the per-job diagnostic cache has stopped running. The specific string varies by code path, but the pattern (uniform fallback text across unrelated jobs) is diagnostic.
+
+## Artifacts
+
+- Checkpoint (decompressed): `gs://marin-us-central2/iris/marin/state/controller-state/1776818488274/controller.sqlite3.zst` — taken 2026-04-22T00:41:28 UTC, ~18 min after crash. Contains the poisoned row.
+- Parquet log shards covering crash window: `gs://marin-us-central2/iris/marin/state/logs/logs_00000000029{66141366..91964120}.parquet`. Crash line: `seq=2984329155, epoch_ms=1776817943242`. Query directly via duckdb + gcsfs (see "Parquet log queries" above); no need to `gcloud storage cp` locally.
+- Fix PR: (not yet filed)
+- Migration: `lib/iris/src/iris/cluster/controller/migrations/0036_reconcile_reservation_holder_attempt_ids.py`
+- Fix: `lib/iris/src/iris/cluster/controller/transitions.py:2167-2186`
+- Test: `lib/iris/tests/cluster/controller/test_reservation_holder_reset_regression.py::test_reservation_holder_reassignment_across_successive_worker_failures`

--- a/.agents/ops/2026-04-21-iris-tpu-wedge-and-holder-poll.md
+++ b/.agents/ops/2026-04-21-iris-tpu-wedge-and-holder-poll.md
@@ -1,0 +1,194 @@
+---
+date: 2026-04-21
+system: iris
+severity: degraded
+resolution: fixed
+pr: none
+issue: none
+---
+
+# Iris TPU worker wedge + reservation-holder poll storm
+
+## TL;DR
+
+- User-visible symptom: jobs on TPU v5p-preemptible-8 workers looping with `TPU init failure ("Couldn't open iommu group")` / `RuntimeError: No accelerator found`; `docker ps` on a suspect VM showed 3 `iris-managed=true` containers while the controller listed only 2 tasks for that worker.
+- Three independent bugs stacked:
+  1. `ManagedThread._safe_target` never fired `on_stop` on the natural-return path (`lib/iris/src/iris/managed_thread.py:85-115`), so task-container `docker kill`+`docker rm` were skipped. Containers that wedged on the vfio driver stayed `Up`, still owning the iommu group, and every subsequent task on the VM failed identically.
+  2. `_apply_task_transitions` treated `ASSIGNED -> WORKER_FAILED` as a free retry (`lib/iris/src/iris/cluster/controller/transitions.py:1878`): no `preemption_count` bump and no health-tracker signal. A host that kept losing the iommu race stayed in rotation indefinitely while child tasks looped at full scheduler velocity.
+  3. `get_running_tasks_for_poll` (`lib/iris/src/iris/cluster/controller/transitions.py:3116`) did not filter `is_reservation_holder = 1` rows. Every 60s poll cycle, reservation-holder tasks were shipped to the claimed worker in `PollTasksRequest.expected_tasks`, the worker's `_reconcile_expected_tasks` missed them (holders are virtual), and the controller applied `WORKER_FAILED("Task not found on worker")`. Five active holders were each accumulating ~51 attempts/hour against the same claimed worker.
+- Fixes: fire `on_stop` unconditionally in the ManagedThread finally; add a `build_failed` health-tracker bump on `ASSIGNED -> WORKER_FAILED`; add `JOIN jobs j ON j.job_id = t.job_id ... AND j.is_reservation_holder = 0` to the poll SQL.
+- Mitigation applied live: operator SSH'd the poisoned VM and `sudo docker kill`'d the wedged iris-managed containers. Worker recovered immediately, no hardware intervention.
+- Not rolled out yet: existing orphans on other workers will bleed off naturally via preemption. No automated sweep added.
+
+## Original problem report
+
+> {"worker_id": "marin-tpu-v5p-preemptible-8-us-east5-a-20260421-0641-2a0d895e-worker-0",
+>  "updates": [{"task_id": "/larry/iris-run-job-20260422-004848/grug-train-partial-rope-every_layer-d1280-2.83e-19/0",
+>               "attempt_id": 61,
+>               "state": "TASK_STATE_WORKER_FAILED",
+>               "exit_code": 1,
+>               "error": "TPU init failure (\"Couldn't open iommu group\"): Exit code: 1. stderr: RuntimeError: No accelerator found. Please run on a TPU or GPU."}]}
+>
+> this means they've been scheduled to an invalid worker. the fix we applied seems invalid. research and report
+
+Follow-up observation from the user after SSH'ing the VM:
+
+> it looks like this worker has "stale tasks": [3 iris-task docker containers, ages 46m / 47m / 11h] -- but the worker status only shows 2 tasks -- /larry/.../grug-train-partial-rope-... Running, /tonyhlee/.../ Succeeded -- can you check the worker docker logs, is it out of sync with the controller, or with docker?
+
+## Investigation path
+
+1. Confirmed the failing task was NOT a reservation-holder (no `:reservation:` segment in task_id) — ruled out that the 2026-04-21 holder-reset fix (`a0fcf0fd2` era) was the regression. The fix only touched `_remove_failed_worker`'s holder branch at `transitions.py:2160-2183`.
+2. Read `_apply_task_transitions` at `transitions.py:1851-1892`. Found that `ASSIGNED -> WORKER_FAILED` unconditionally retries to PENDING without incrementing `preemption_count` or `failure_count` (line 1878-1880). Only `EXECUTING -> WORKER_FAILED` bumps the budget (1873, 1886-1891). TPU init failure dies during container startup → task never reaches RUNNING → retry budget never drains.
+3. Checked `WorkerHealthTracker` (`lib/iris/src/iris/cluster/controller/worker_health.py`): only hooks are `ping` (liveness-loop failure) and `build_failed` (BUILDING→FAILED). No hook on ASSIGNED→WORKER_FAILED and no hook on generic launch failure. Worker's pings kept succeeding (workerd alive, only TPU broken), so `workers_over_threshold()` returned `[]` forever.
+4. User clarified this was not a bad machine and to check for co-schedule — "check that worker, i suspect another job is scheduled to the same machine." Walked the reservation taint logic at `controller.py:718-759 _inject_taint_constraints`. Observed that descendants of reservation jobs get *no* taint constraint (line 753, `elif job_id in has_reservation: modified[job_id] = req`) while non-reservation jobs get `NOT_EXISTS`. Hypothesised cross-reservation co-scheduling. User then reported live `docker ps` showing 3 iris containers vs controller's 2 tasks — confirming a container-vs-controller desync rather than a scheduler bug.
+5. Read `worker.py:794-826 _reconcile_expected_tasks`. Confirmed it iterates `self._tasks` only, never `docker ps` — so any container present in Docker but missing from the in-memory task dict is invisible to reconcile and never killed. `_TERMINAL_STATES` check at line 824 also skips tasks whose status is already terminal, so a failed attempt that didn't get its container removed is never revisited.
+6. Fetched `sudo docker logs iris-worker` from the poisoned VM (`marin-tpu-v5p-preemptible-8-us-east5-a-20260421-0641-2a0d895e`, zone `us-east5-a`). Single iris-worker container, 15h uptime, no restart. 548 KB / 2661 lines. Ran `logscan` (gemini) and then line-level grep for `on_stop`, iommu, and specific task_ids.
+7. Pattern: every task-completion moment — including natural success and the 58× `/tim/iris-run-job-20260421-181136/train_lm/0` iommu failures — ends with `W iris.managed_thread on_stop callback for task-<id> did not complete`. This fires before the next attempt even submits. No `adopt_running_containers`, no `_reset_worker_state`, no `Container not found`, no `failed to remove` anywhere in the log.
+8. Read `lib/iris/src/iris/managed_thread.py:85-115`. Identified the bug: the watcher thread blocks on `self._stop_event.wait()` inside `_watch_stop`. `_stop_event` is only set by explicit `ManagedThread.stop()` (line 137). Natural return from the target never sets it → watcher parks forever → `finally` joins with 1s timeout → warning logged → `on_stop` never invoked → `attempt.stop(force=True)` (which does `container.kill() + container.remove()`) never runs → container lingers. If the container's PID 1 happens to be wedged in a kernel-level vfio teardown, the container stays `Up`, still holding the iommu group, and every subsequent task on the host fails identically.
+9. Operator `sudo docker kill`'d the wedged iris-managed containers on the VM. Worker immediately started accepting new tasks successfully. Confirmed the wedge was a plain orphan (SIGKILL reachable), not kernel D-state — meaning the only missing step all along was our `docker kill` invocation that `on_stop` should have issued.
+10. Queried the controller checkpoint at `/tmp/iris-debug/controller.sqlite3` (decompressed from `gs://marin-us-central2/iris/marin/state/controller-state/1776818488274/controller.sqlite3.zst`, ~2h old) for fleet-wide scope: `SELECT task_id, COUNT(*) FROM task_attempts GROUP BY task_id HAVING attempts > 50`. 51 hits. Restricting to "active in the last 60 minutes" returned exclusively reservation-holder tasks (`:reservation:/0`) at ~51 attempts/hour each — a different failure mode than the iommu loop.
+11. Pulled `SELECT attempt_id, state, worker_id, error, started_at_ms, finished_at_ms FROM task_attempts WHERE task_id = '/larry/iris-run-job-20260420-220049/:reservation:/0' ORDER BY attempt_id DESC LIMIT 15`. Every row: `state=7 (WORKER_FAILED)`, `error='Task not found on worker'`, `started_at_ms IS NULL`, `finished_at_ms` ~60s apart, same worker repeatedly. User confirmed reservations are virtual and should never appear on a worker — "somehow this path has been lost."
+12. `grep -n 'running_tasks\b' cluster/controller/*.py`. Inventoried every producer: `drain_dispatch` (`transitions.py:2630`) filters holders, `drain_dispatch_all` (`transitions.py:2686`) filters holders, `_building_counts` (`controller.py:613`) filters holders, `drain_for_direct_provider` (`transitions.py:3384`) filters holders. `get_running_tasks_for_poll` at `transitions.py:3116` did NOT filter — only path feeding `PollTasksRequest.expected_tasks` via `controller.py:2321 _poll_all_workers` → `worker_provider.py:332 poll_workers` → `PollTasksRequest`.
+
+## User course corrections
+
+- **"this is NOT a bad machine"** — cut off the hardware-failure branch and the instinct to fail the worker. Correct: the machine was healthy, only a wedged container held the TPU.
+- **"i suspect another job is scheduled to the same machine. the reserved job logic is complicated. make a diagram prove you understand this"** — forced a reread of reservation taint injection and preference pass before writing any code. Model was drifting toward a generic "retry budget" patch; the user's framing pushed toward state-desync investigation.
+- **"check the worker docker logs, is it out of sync with the controller, or with docker?"** — distinguished the two orthogonal desync axes. Correct answer was worker↔docker, not worker↔controller. Framing the question as a binary kept the investigation from conflating the cases.
+- **"after i manually docker killed the running tasks, the worker recovered"** — confirmed the wedge was plain-orphan (SIGKILL reachable), not kernel D-state. Collapsed the remaining solution space: fix the code path that was supposed to issue `docker kill` and didn't.
+- **"yes, reservations are _never_ found on a worker because they are virtual. somehow this path has been lost"** — accelerated the diagnosis once it narrowed to the poll loop. Told the model exactly which invariant had been violated, so the model could skip hypotheses about holder lifecycle and go directly to finding the unfiltered SQL.
+- **"what's this docker run --init, would that help"** — tested whether defensive hardening would substitute for the real fix. Answer: no (signal was never sent; tini can't route a signal you didn't issue, and kernel D-state is beyond tini anyway). Kept the scope tight.
+
+## Root cause
+
+Three separate defects in different files, each independently sufficient to produce the observed failure modes:
+
+### A. ManagedThread drops on_stop on the natural-return path
+
+`lib/iris/src/iris/managed_thread.py:85-115`. `_safe_target` spawns a watcher that runs `on_stop` when `_stop_event` fires. `_stop_event` is only set by `ManagedThread.stop()`; when the target returns normally, the watcher stays blocked on `.wait()`, the 1s `watcher.join` times out, a warning is logged, and `on_stop` is silently skipped. For task threads `on_stop` is `attempt.stop(force=True)` → `container.kill() + container.remove()`. So every task that completes without an explicit stop — whether it succeeded, failed, or WORKER_FAILED — leaks its container. Most become harmless `Exited` rows in `docker ps -a`, but any container whose PID 1 was wedged in the vfio teardown path of a failed TPU init stays `Up`, holds the iommu group, and poisons the VM.
+
+Class: **missed default case in a signal/event-driven cleanup handshake** — callback only runs on the "external stop" branch, not the "work completed" branch.
+
+### B. ASSIGNED → WORKER_FAILED has no budget cost and no health signal
+
+`lib/iris/src/iris/cluster/controller/transitions.py:1878-1880`. Only `EXECUTING_TASK_STATES -> WORKER_FAILED` bumps `preemption_count` (line 1873-1877) and only `BUILDING -> FAILED` bumps `self._health.build_failed` (line 1871-1872). A task that dies during ASSIGNED (TPU init, image pre-flight, any setup before BUILDING completes) retries to PENDING with zero cost to the retry budget and zero signal to `WorkerHealthTracker`. Combined with (A), the scheduler loop could send the same task to the same wedged worker forever.
+
+### C. Poll loop sends virtual reservation holders to real workers
+
+`lib/iris/src/iris/cluster/controller/transitions.py:3116-3154`. `get_running_tasks_for_poll` feeds `PollTasksRequest.expected_tasks` through `_poll_all_workers` (`controller.py:2321`, 60s cadence). Its SELECT lacked the `is_reservation_holder = 0` filter that every sibling path uses. Holder tasks have `current_worker_id` set (scheduler anchor) and `state=RUNNING` (from `_assign_task`), so they match the filter. The worker's `_reconcile_expected_tasks` looks the holder up in `self._tasks`, fails, and returns `WORKER_FAILED("Task not found on worker")`. Controller applies the update, holder retries to PENDING, scheduler re-assigns the same claimed worker. One `WORKER_FAILED` per holder per 60s — 51 active holders were each taking ~51 attempts/hour. Holders avoided going terminal only because `_remove_failed_worker`'s holder path resets `preemption_count=0`; per-task-update `WORKER_FAILED` does not reset, so slow drain toward the retry ceiling was also happening.
+
+Class: **invariant drift in a replicated SQL filter** — five places apply the same "exclude holders from worker-facing snapshots" rule; one grew apart.
+
+## Fix
+
+### A. ManagedThread — always run on_stop in finally
+
+`lib/iris/src/iris/managed_thread.py`, single edit inside `_safe_target.finally`:
+
+```python
+finally:
+    if watcher:
+        # Wake the watcher regardless of how the target exited so on_stop runs
+        # on the natural-completion path too. Otherwise cleanup (e.g. docker
+        # kill+rm for task containers) is silently skipped whenever the target
+        # returns without an explicit stop() — leaving wedged containers that
+        # keep holding TPU vfio/iommu groups and break subsequent tasks.
+        self._stop_event.set()
+        watcher.join(timeout=5.0)
+        if watcher.is_alive():
+            logger.warning("on_stop callback for %s did not complete", name)
+```
+
+Join timeout widened from 1s → 5s because `docker kill` + `docker rm` legitimately need more than 1s. New test file: `lib/iris/tests/test_managed_thread.py` — four cases: stop()-called, natural return, target raises, no-double-fire.
+
+### B. ASSIGNED → WORKER_FAILED bumps health tracker
+
+`lib/iris/src/iris/cluster/controller/transitions.py:1878-1886`. Added:
+
+```python
+if update.new_state == job_pb2.TASK_STATE_WORKER_FAILED and prior_state == job_pb2.TASK_STATE_ASSIGNED:
+    task_state = job_pb2.TASK_STATE_PENDING
+    terminal_ms = None
+    # ASSIGNED -> WORKER_FAILED means the worker accepted the task but
+    # couldn't bring it up (e.g. TPU iommu/vfio already held by another
+    # process on the VM). Attribute the failure to the worker so a host
+    # that keeps failing launches gets reaped; otherwise the task loops
+    # forever without draining preemption budget.
+    if worker_id is not None:
+        self._health.build_failed(WorkerId(str(worker_id)))
+```
+
+Reuses the existing `build_failures` counter and `BUILD_FAILURE_THRESHOLD` — no new field, no new threshold. Task-side retry policy unchanged (still free retry, by design: launch failures shouldn't cost task budget; the cost goes to the worker). Regression test: `lib/iris/tests/cluster/controller/test_transitions.py::test_worker_failed_from_assigned_bumps_health_tracker`.
+
+**Caveat worth future work**: bug C made holders emit `WORKER_FAILED` per poll cycle. Under fix B in isolation, that would have reaped every reservation-claimed worker within ~3 minutes. Fix C must ship with or before B. Post-C this is academic, but if the poll path ever reintroduces virtual-task polling, B will amplify it.
+
+### C. Poll SQL filters reservation holders
+
+`lib/iris/src/iris/cluster/controller/transitions.py:3137-3150`. Added JOIN + filter:
+
+```sql
+SELECT t.task_id, t.current_attempt_id, t.current_worker_id
+FROM tasks t JOIN jobs j ON j.job_id = t.job_id
+WHERE t.current_worker_id IN (...) AND t.state IN (?, ?, ?)
+AND j.is_reservation_holder = 0
+ORDER BY t.task_id ASC
+```
+
+Mirrors the filter in `drain_dispatch` (2652-2662), `drain_dispatch_all` (2715), `_building_counts` (`controller.py:624`), `drain_for_direct_provider` (`transitions.py:3411`). Regression test: `lib/iris/tests/cluster/controller/test_reservation.py::test_get_running_tasks_for_poll_excludes_reservation_holders`.
+
+### Data repair
+
+None staged in code. Fleet-wide orphan cleanup not attempted — user opted to let existing orphan containers bleed off naturally as preemptibles recycle. A one-shot `docker kill` / `docker rm --label iris.managed=true` sweep across active workers would clean them sooner; not worth the blast-radius for most cases.
+
+## How OPS.md could have shortened this
+
+Generic patterns only; none specific to this bug.
+
+1. **`lib/iris/OPS.md` → new subsection "Worker-VM inspection recipes"** under the existing worker operations area. Current OPS.md has no canonical command for `gcloud compute tpus tpu-vm ssh ... --impersonate-service-account=iris-controller@hai-gcp-models.iam.gserviceaccount.com` nor for `sudo docker logs iris-worker 2>&1 | gzip`. Those two invocations recurred through the session. Add:
+
+   ```bash
+   # SSH to a TPU worker VM (strip "-worker-N" suffix for the VM name)
+   gcloud compute tpus tpu-vm ssh <vm-name> --zone=<zone> \
+     --impersonate-service-account=iris-controller@hai-gcp-models.iam.gserviceaccount.com \
+     --command='sudo <command>'
+
+   # Pull the workerd container log, gzipped, straight to local disk
+   gcloud compute tpus tpu-vm ssh <vm-name> --zone=<zone> \
+     --impersonate-service-account=iris-controller@hai-gcp-models.iam.gserviceaccount.com \
+     --command='sudo docker logs iris-worker 2>&1 | gzip' > /tmp/iris-debug/iris-worker.log.gz
+
+   # Enumerate iris-managed task containers on a VM
+   gcloud compute tpus tpu-vm ssh <vm-name> --zone=<zone> \
+     --impersonate-service-account=iris-controller@hai-gcp-models.iam.gserviceaccount.com \
+     --command='sudo docker ps --filter label=iris.managed=true --format "{{.ID}}\t{{.CreatedAt}}\t{{.Status}}\t{{.Label \"iris.task_id\"}}"'
+   ```
+
+   These are needed any time a worker misbehaves. Note `sudo` — docker.sock is root-owned on these VMs. Document this explicitly; otherwise the next engineer burns several minutes on "permission denied while trying to connect to the Docker daemon socket."
+
+2. **`lib/iris/OPS.md` → new subsection "Worker-vs-Docker desync: diagnostic pattern"** under troubleshooting. Recurring smell, generic across bugs: `docker ps` on a worker shows more iris-labeled containers than the controller lists for that worker. Diagnostic steps (not a fix for any specific bug):
+
+   - Compare `docker ps --filter label=iris.managed=true` vs `iris rpc controller get-worker-state <worker-id>` (or the equivalent RPC that returns the worker's running-tasks list).
+   - If container count > controller count: `docker inspect <container-id> --format '{{.Config.Labels.iris.task_id}} / attempt={{.Config.Labels.iris.attempt_id}} / worker={{.Config.Labels.iris.worker_id}}'`. If `iris.worker_id` matches the current worker, the orphan was born on this process (cleanup path skipped). If it differs, a previous worker process left it behind and `adopt_running_containers` didn't reclaim it.
+   - Workerd's own memory: `sudo docker logs iris-worker 2>&1 | grep -E 'on_stop callback|Cleanup|adopt_running_containers|Resetting worker state'`. The presence of many `on_stop callback ... did not complete` warnings is a generic signal that container cleanup is being skipped — *class of bug*, not this specific one.
+
+3. **`lib/iris/OPS.md` → add a row to "Troubleshooting" table: "same failure reason text on many pending attempts → cache-update or snapshot-source is unfiltered."** This is a generic smell that recurs. Whenever a pending-reason field or error string is identical across many unrelated tasks, the snapshot-building query that populates it has probably lost a filter. Same shape as the previous ops-log's "Pending scheduler feedback" pattern. Name the pattern so the next engineer recognizes it without re-reading this log.
+
+4. **`lib/iris/OPS.md` → "Replicated SQL filter" invariant under code-review checklist.** Five places in the controller enforce "exclude reservation holders from worker-facing snapshots" (`drain_dispatch`, `drain_dispatch_all`, `_building_counts`, `drain_for_direct_provider`, and — now — `get_running_tasks_for_poll`). When adding a sixth path that sends tasks to a worker, *grep for `is_reservation_holder = 0` and copy the filter*. This is a recurring category of drift; worth naming in OPS.md's "when adding new worker-RPC paths" section, if one exists, or as a new short note.
+
+5. **`lib/iris/OPS.md` → "Retry budgets" explainer.** The ASSIGNED→WORKER_FAILED free-retry rule is non-obvious on first read. One paragraph explaining that `preemption_count` bumps only on `EXECUTING -> WORKER_FAILED` (line 1873) and `build_failures` bumps only on `BUILDING -> FAILED` (line 1871), with ASSIGNED being a no-signal state, would save the next engineer from rediscovering it. This is generic to "why is my task looping?" triage.
+
+## Artifacts
+
+- Worker log (548 KB, 2661 lines) fetched during investigation: `/tmp/iris-debug/iris-worker.log` — local, already discarded by now; re-fetch with the command in "How OPS.md could have shortened this" §1.
+- Controller checkpoint used for fleet-wide queries: `gs://marin-us-central2/iris/marin/state/controller-state/1776818488274/controller.sqlite3.zst` (taken 2026-04-22T00:41:28 UTC). Queries in the "Investigation path" §10-11 reproduce.
+- Affected worker (confirmed wedged, cleared): `marin-tpu-v5p-preemptible-8-us-east5-a-20260421-0641-2a0d895e-worker-0` (zone `us-east5-a`).
+- Other workers showing the high-attempt signature at investigation time: `marin-tpu-v5p-preemptible-8-us-central1-20260421-0625-801865e5-worker-0` (in-sync, not wedged), `marin-tpu-v5p-preemptible-8-us-central1-20260421-0137-dad717ca-worker-0` (zero iris containers live; controller snapshot stale), `marin-tpu-v5p-preemptible-8-us-east5-a-20260421-1628-2b4231e7-worker-0` (possibly out-of-sync; snapshot was 2h old at check time).
+- Code changes:
+  - `lib/iris/src/iris/managed_thread.py:111-120`
+  - `lib/iris/src/iris/cluster/controller/transitions.py:1878-1886`
+  - `lib/iris/src/iris/cluster/controller/transitions.py:3137-3150`
+- Tests:
+  - `lib/iris/tests/test_managed_thread.py` (new file)
+  - `lib/iris/tests/cluster/controller/test_transitions.py::test_worker_failed_from_assigned_bumps_health_tracker`
+  - `lib/iris/tests/cluster/controller/test_reservation.py::test_get_running_tasks_for_poll_excludes_reservation_holders`
+- Prior ops log that lightly touches this cluster: `.agents/ops/2026-04-21-iris-scheduler-freeze.md` — different bug (scheduler-loop crash via task_attempts IntegrityError); the `_remove_failed_worker` holder fix landed there was confirmed not responsible for today's symptoms.

--- a/.agents/skills/ops-log/SKILL.md
+++ b/.agents/skills/ops-log/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: ops-log
+description: Write a postmortem-style ops log for a debugging or incident-response conversation into `.agents/ops/`. Use when asked to "log this", "summarize for ops", "write a postmortem", or at the end of a live-infrastructure debugging session so future sysops engineers inherit the context.
+---
+
+# Skill: Ops Log
+
+Summarize a debugging / incident-response conversation as a standalone
+postmortem entry under `.agents/ops/`. The audience is a future sysops
+engineer (probably another Claude session) who has no memory of this
+conversation and needs to reconstruct: what broke, what was tried, what the
+user steered, what fixed it, and how OPS.md guidance could have shortened the
+investigation.
+
+## Filename
+
+`.agents/ops/YYYY-MM-DD-<slug>.md`
+
+The `.agents/ops/` directory is checked into git; `.agents/ops/logs/` is
+gitignored (matched by the global `logs/` pattern), so do not nest logs
+under a `logs/` subdirectory.
+
+- Use the date the issue was investigated, not today's arbitrary date.
+- `<slug>` is 3-6 words, kebab-case, naming the system + symptom. Examples:
+  `iris-scheduler-freeze`, `coreweave-nodepool-stuck-delete`,
+  `zephyr-coordinator-oom`.
+- If a log already exists for this incident, extend it with a new section
+  rather than creating a parallel file.
+
+## Structure
+
+Write a single markdown file with these sections in order. Don't invent
+extra sections; omit any section that genuinely has nothing to say.
+
+### Frontmatter
+
+```yaml
+---
+date: YYYY-MM-DD
+system: iris | zephyr | fray | coreweave | gcp | <component>
+severity: outage | degraded | near-miss | diagnostic-only
+resolution: fixed | mitigated | wontfix | investigating
+pr: <url or "none">
+issue: <url or "none">
+---
+```
+
+### TL;DR (3-6 bullets)
+
+One screen. A future engineer reading just this should know whether this log
+is relevant to their current incident. Include: the user-visible symptom,
+the real root cause, the fix applied, and any lingering caveat.
+
+### Original problem report
+
+Quote or paraphrase the user's opening message. What they *observed*, not
+what the real bug turned out to be. This is the pattern-match hook for
+future searches — preserve the exact error string / dashboard text / command
+that the next engineer will also be typing into ripgrep.
+
+### Investigation path
+
+Narrative, not a log dump. What was checked, in order, and why each step was
+chosen. Include the dead ends — they teach the next engineer what *not* to
+spend time on. Cite file paths and line numbers for code you read, and
+commit/log timestamps for live data.
+
+Format as a numbered list of short paragraphs. Five to twelve steps is
+typical; if it's longer, you're narrating tool calls instead of decisions.
+
+### User course corrections
+
+Explicit list of points where the user redirected the investigation. Each
+entry: what the model was about to do, what the user said instead, and why
+it was the right call. This is the most load-bearing section — it captures
+judgment the model didn't have.
+
+### Root cause
+
+Tight technical description. One or two paragraphs. Cite the specific
+file:line of the bug. If there's a class of bug (e.g. "invariant
+violation between tables X and Y"), name it.
+
+### Fix
+
+What was actually changed, with file paths and a short diff-style excerpt
+if the change is subtle. Include the migration / data repair step
+separately from the code change. If the fix is deferred, say so and link
+the tracking issue.
+
+### How OPS.md could have shortened this
+
+Concrete, actionable suggestions for `lib/<component>/OPS.md` edits that
+would have saved time. Each suggestion: the section to edit, the sentence
+or command to add, and the signal it would have unblocked.
+
+**Generic patterns only.** OPS.md is for recurring diagnostic workflows
+across many incidents — not for this one bug. Before writing a
+suggestion, ask: *would this have helped an engineer debugging a
+completely different incident in the same subsystem?* If not, drop it.
+
+Good OPS.md additions look like:
+- A new tool/workflow the investigation relied on (e.g. "query parquet
+  logs directly with duckdb + gcsfs" — applies to every future log dive).
+- A recurring smell mapped to a class of cause (e.g. "same pending-reason
+  text on many jobs → diagnostic cache has stopped updating" — applies
+  across any future cache-update bug, not just this one).
+- A default that burned time (e.g. "prefer copying an existing GCS
+  checkpoint over triggering a new one when the controller is stuck" —
+  applies to any stuck-controller incident).
+
+Bad OPS.md additions look like:
+- Troubleshooting rows keyed on the exact literal string this incident
+  produced. That's Known-Bugs material at best, and after the fix ships,
+  it's just noise.
+- SQL queries that only detect the invariant violation this specific
+  bug produced.
+- "Watch out for bug X" entries that duplicate the git log.
+
+If a lesson is genuinely incident-specific, put it in the "Root cause" /
+"Fix" sections of this log; don't propose it for OPS.md. Avoid vague
+"improve documentation" — name the exact section and the exact text to
+add.
+
+This is the section that pays forward. Take it seriously.
+
+### Artifacts
+
+Links or paths to supporting evidence, in order of usefulness:
+
+- Local files staged during the investigation (checkpoints, logs) — only
+  if still present; don't link to `/tmp` paths that are already gone.
+- GCS/S3 paths to parquet / sqlite / log bundles.
+- Grafana / dashboard URLs.
+- Parent PR and follow-up issues.
+
+## Writing style
+
+- Past tense, third person. The conversation is over; you're writing for
+  someone who wasn't there.
+- Short, dense sentences. A sysops engineer reading this is busy.
+- No praise, no "we" language, no apology. Just: what happened and what to
+  do about it.
+- No emojis.
+- Absolute file paths relative to the repo root (e.g.
+  `lib/iris/src/iris/cluster/controller/transitions.py:2167`).
+- Command-line snippets that the next engineer can paste verbatim.
+- If you cite a log message, preserve its exact text — that is the string
+  they will grep for.
+
+## What to skip
+
+- Minute-by-minute narration of tool calls.
+- Code that's already obvious from the fix diff.
+- Generic reminders ("remember to check logs first"). OPS.md is for general
+  guidance; this file is for this specific incident.
+- Hedged conclusions. If the root cause is known, state it. If it isn't,
+  say so explicitly under "Investigating".
+
+## After writing
+
+Do not add an index file or update `MEMORY.md`. The logs are discoverable
+by `ls .agents/ops/` and by full-text search. If you notice the
+directory is getting unwieldy (>30 entries), flag it to the user — they
+may want an index.


### PR DESCRIPTION
Move postmortem logs from .agents/ops/logs/ to .agents/ops/ since the global logs/ gitignore pattern silently dropped the previous location. Update the ops-log skill to write to .agents/ops/<date>-<slug>.md and include the first ops log entry.