### PR TITLE
[levanter] Fix BatchTokenizer dropping BOS after kitoken migration

### DIFF
--- a/lib/levanter/src/levanter/data/text/_batch_tokenizer.py
+++ b/lib/levanter/src/levanter/data/text/_batch_tokenizer.py
@@ -41,31 +41,14 @@ class BatchTokenizer(BatchProcessor[dict, dict]):
         self.max_length = max_length
         self._long_string_workaround = long_string_workaround
 
-        if tokenizer.bos_token_id is None:
-            enforce_bos = False
-        if tokenizer.eos_token_id is None:
-            enforce_eos = False
-
-        if enforce_eos or enforce_bos:
-            input_ids = tokenizer.encode("hi there", add_special_tokens=True)
-            should_append_eos = input_ids[-1] != tokenizer.eos_token_id and enforce_eos
-            should_append_bos = input_ids[0] != tokenizer.bos_token_id and enforce_bos
-        else:
-            should_append_eos = False
-            should_append_bos = False
-
-        self._need_to_add_eos = should_append_eos
-        self._need_to_add_bos = should_append_bos
+        self._append_bos = enforce_bos and tokenizer.bos_token_id is not None
+        self._append_eos = enforce_eos and tokenizer.eos_token_id is not None
         self._workaround_len = _workaround_len
 
     def __call__(self, batch: Sequence[dict]) -> list[dict]:
         batch_text = [example[self.text_field] for example in batch]
 
-        if self._need_to_add_bos:
-            bos = self.tokenizer.bos_token
-            assert bos is not None
-            batch_text = [bos + " " + d for d in batch_text]
-        if self._need_to_add_eos:
+        if self._append_eos:
             eos = self.tokenizer.eos_token
             assert eos is not None
             batch_text = [d + " " + eos for d in batch_text]
@@ -75,7 +58,16 @@ class BatchTokenizer(BatchProcessor[dict, dict]):
         else:
             needs_merge = []
 
-        encoded = self.tokenizer.encode_batch(batch_text)
+        encoded = self.tokenizer.encode_batch(batch_text, add_special_tokens=False)
+
+        if self._append_bos:
+            bos_id = self.tokenizer.bos_token_id
+            assert bos_id is not None
+            if needs_merge:
+                # Prepend BOS only to first chunks so the merged doc has a single BOS.
+                encoded = [[bos_id, *enc] if not merge else enc for enc, merge in zip(encoded, needs_merge)]
+            else:
+                encoded = [[bos_id, *enc] for enc in encoded]
 
         # Build a dict-of-lists structure analogous to the old BatchEncoding.
         encoding: dict[str, list] = {"input_ids": encoded}
@@ -120,8 +112,8 @@ class BatchTokenizer(BatchProcessor[dict, dict]):
             "return_attention_mask": self.return_attention_mask,
             "padding": self.padding,
             "max_length": self.max_length,
-            "append_bos": self._need_to_add_bos,
-            "append_eos": self._need_to_add_eos,
+            "append_bos": self._append_bos,
+            "append_eos": self._append_eos,
         }
 
     @property

--- a/lib/levanter/tests/test_text.py
+++ b/lib/levanter/tests/test_text.py
@@ -128,6 +128,146 @@ def test_merge_split_encodings(local_gpt2_marin_tokenizer):
     assert short_out == reg_out
 
 
+# ---------------------------------------------------------------------------
+# BOS / EOS handling — regression tests for #5034
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def marin_tokenizer_with_bos():
+    """Real marin-tokenizer (Llama-3 BPE, BOS-only TemplateProcessing post-processor)."""
+    try:
+        return load_tokenizer("marin-community/marin-tokenizer")
+    except Exception as e:
+        pytest.skip(f"Cannot load marin-community/marin-tokenizer: {e}")
+
+
+def test_batch_tokenizer_prepends_bos(marin_tokenizer_with_bos):
+    """Every doc in the output must start with BOS when enforce_bos=True.
+
+    Regression test for https://github.com/marin-community/marin/issues/5034:
+    BatchTokenizer silently stopped prepending BOS after the kitoken backend
+    migration because the init probe ran with add_special_tokens=True but the
+    hot-path encode_batch did not, inverting the prepend decision.
+    """
+    tokenizer = marin_tokenizer_with_bos
+    bos_id = tokenizer.bos_token_id
+    assert bos_id is not None
+
+    bt = BatchTokenizer(tokenizer, enforce_bos=True, enforce_eos=False)
+    batch = [{"text": "hello world"}, {"text": "Anonymous 01/04/19 posted"}, {"text": "x"}]
+    out = bt(batch)
+
+    for i, item in enumerate(out):
+        ids = item["input_ids"]
+        assert ids[0] == bos_id, f"doc {i}: expected BOS at position 0, got {ids[:5]}"
+        assert ids.count(bos_id) == 1, f"doc {i}: expected exactly one BOS, got {ids.count(bos_id)}"
+
+
+def test_batch_tokenizer_appends_eos(marin_tokenizer_with_bos):
+    """Every doc must end with EOS when enforce_eos=True."""
+    tokenizer = marin_tokenizer_with_bos
+    eos_id = tokenizer.eos_token_id
+    assert eos_id is not None
+
+    bt = BatchTokenizer(tokenizer, enforce_bos=False, enforce_eos=True)
+    batch = [{"text": "hello world"}, {"text": "another doc"}]
+    out = bt(batch)
+
+    for i, item in enumerate(out):
+        ids = item["input_ids"]
+        assert ids[-1] == eos_id, f"doc {i}: expected EOS at end, got {ids[-5:]}"
+
+
+def test_batch_tokenizer_bos_disabled(marin_tokenizer_with_bos):
+    """With enforce_bos=False, doc must not start with BOS even though the tokenizer has one."""
+    tokenizer = marin_tokenizer_with_bos
+    bos_id = tokenizer.bos_token_id
+
+    bt = BatchTokenizer(tokenizer, enforce_bos=False, enforce_eos=False)
+    out = bt([{"text": "hello world"}])
+    ids = out[0]["input_ids"]
+    assert bos_id not in ids
+
+
+def test_batch_tokenizer_output_equals_direct_encode_plus_bos(marin_tokenizer_with_bos):
+    """BatchTokenizer(enforce_bos=True, enforce_eos=False) must equal [BOS] + encode(text)."""
+    tokenizer = marin_tokenizer_with_bos
+    bos_id = tokenizer.bos_token_id
+
+    bt = BatchTokenizer(tokenizer, enforce_bos=True, enforce_eos=False)
+    texts = ["hello world", "Anonymous 01/04/19", "The quick brown fox", "  leading space"]
+    out = bt([{"text": t} for t in texts])
+
+    for t, item in zip(texts, out):
+        expected = [bos_id] + tokenizer.encode(t, add_special_tokens=False)
+        assert item["input_ids"] == expected, f"text={t!r}: got {item['input_ids'][:10]}, expected {expected[:10]}"
+
+
+def test_batch_tokenizer_metadata_reflects_user_intent(marin_tokenizer_with_bos):
+    """metadata['append_bos'/'append_eos'] must track user intent, not internal detail.
+
+    Post-migration caches stored append_bos=False despite enforce_bos=True; this
+    invariant makes the metadata field a reliable signal for cache comparability.
+    """
+    tokenizer = marin_tokenizer_with_bos
+
+    bt_on = BatchTokenizer(tokenizer, enforce_bos=True, enforce_eos=True)
+    assert bt_on.metadata["append_bos"] is True
+    assert bt_on.metadata["append_eos"] is True
+
+    bt_off = BatchTokenizer(tokenizer, enforce_bos=False, enforce_eos=False)
+    assert bt_off.metadata["append_bos"] is False
+    assert bt_off.metadata["append_eos"] is False
+
+
+def test_batch_tokenizer_bos_survives_long_string_split(marin_tokenizer_with_bos):
+    """Long-string workaround must not duplicate or drop BOS across chunk boundaries."""
+    tokenizer = marin_tokenizer_with_bos
+    bos_id = tokenizer.bos_token_id
+
+    lorem = (
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et "
+        "dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip "
+        "ex ea commodo consequat."
+    )
+
+    bt_split = BatchTokenizer(
+        tokenizer,
+        enforce_bos=True,
+        enforce_eos=False,
+        _workaround_len=len(lorem) // 3,
+        long_string_workaround=True,
+    )
+    bt_whole = BatchTokenizer(
+        tokenizer,
+        enforce_bos=True,
+        enforce_eos=False,
+        _workaround_len=50000,
+    )
+    batch = [{"text": lorem}]
+
+    split_out = bt_split(batch)
+    whole_out = bt_whole(batch)
+
+    assert split_out == whole_out
+    ids = split_out[0]["input_ids"]
+    assert ids[0] == bos_id
+    assert ids.count(bos_id) == 1
+
+
+def test_batch_tokenizer_no_bos_when_tokenizer_has_none(local_gpt2_marin_tokenizer):
+    """Tokenizer without a BOS id: enforce_bos=True is a no-op (and doesn't crash)."""
+    tokenizer = local_gpt2_marin_tokenizer
+    assert tokenizer.bos_token_id is None
+
+    bt = BatchTokenizer(tokenizer, enforce_bos=True, enforce_eos=False)
+    assert bt.metadata["append_bos"] is False
+
+    out = bt([{"text": "hello world"}])
+    assert len(out[0]["input_ids"]) > 0
+
+
 def test_prebuilt_cache_with_loss_weights(tmp_path):
     records = [
         {"input_ids": [1, 2, 3, 4], "loss_weights": [1.0, 0.5, 0.0, 1.0]},


### PR DESCRIPTION
BatchTokenizer's init probe used add_special_tokens=True but the hot path did
not, so kitoken's explicit BOS gate stayed off and text caches built after the
migration were missing BOS. Drop the probe; manually prepend BOS after
encode_batch. Metadata append_bos now tracks enforce_bos, so post-migration
caches with append_bos=False will rebuild on next use.

Fixes #5034