### PR TITLE
[iris] Stop controller-test RemoteLogHandler leak across test session

### DIFF
--- a/lib/iris/pyproject.toml
+++ b/lib/iris/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
     "pytest-playwright>=0.6.2",
     "pytest-timeout",
     "pytest-xdist",
-    "pytest>=8.3.2",
+    "pytest>=8.4",
 ]
 
 [tool.hatch.build.hooks.custom]

--- a/lib/iris/pyproject.toml
+++ b/lib/iris/pyproject.toml
@@ -89,6 +89,10 @@ markers = [
     "e2e: end-to-end cluster tests (chaos, dashboard, scheduling)",
 ]
 filterwarnings = ["ignore::DeprecationWarning"]
+# Cap assertion-diff output even under -v, so a single bad assertion
+# can't dump tens of KB of proto repr into CI logs.
+truncation_limit_lines = 100
+truncation_limit_chars = 10000
 log_level = "INFO"
 log_format = "%(asctime)s %(levelname)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -1039,6 +1039,7 @@ class Controller:
             )
 
         self._config = config
+        self._stopped = False
         self._provider: TaskProvider | K8sTaskProvider = provider
         self._provider_scheduling_events: list[SchedulingEvent] = []
         self._provider_capacity: ClusterCapacity | None = None
@@ -1287,7 +1288,7 @@ class Controller:
         3. Shut down the autoscaler (stops monitors, terminates VMs, stops platform).
         4. Stop remaining threads (server) and executors.
         """
-        if getattr(self, "_stopped", False):
+        if self._stopped:
             return
         self._stopped = True
         # Unregister atexit hook before closing DB connections.

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -1279,7 +1279,7 @@ class Controller:
         logger.info("Registered system endpoint /system/log-server -> %s", self._log_service_address)
 
     def stop(self) -> None:
-        """Stop all background components gracefully.
+        """Stop all background components gracefully. Idempotent.
 
         Shutdown ordering:
         1. Unregister atexit hook so it doesn't fire against a closed DB.
@@ -1287,6 +1287,9 @@ class Controller:
         3. Shut down the autoscaler (stops monitors, terminates VMs, stops platform).
         4. Stop remaining threads (server) and executors.
         """
+        if getattr(self, "_stopped", False):
+            return
+        self._stopped = True
         # Unregister atexit hook before closing DB connections.
         if self._atexit_registered:
             atexit.unregister(self._atexit_checkpoint)

--- a/lib/iris/tests/cluster/controller/conftest.py
+++ b/lib/iris/tests/cluster/controller/conftest.py
@@ -28,6 +28,8 @@ from iris.cluster.constraints import (
 )
 from iris.cluster.controller.autoscaler import Autoscaler
 from iris.cluster.controller.autoscaler.models import DemandEntry
+from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup
+from iris.cluster.controller.controller import Controller, ControllerConfig
 from iris.cluster.controller.db import (
     ACTIVE_TASK_STATES,
     ControllerDB,
@@ -35,6 +37,7 @@ from iris.cluster.controller.db import (
     task_row_can_be_scheduled,
     task_row_is_finished,
 )
+from iris.cluster.controller.provider import ProviderUnsupportedError
 from iris.cluster.controller.schema import (
     ATTEMPT_PROJECTION,
     JOB_CONFIG_JOIN,
@@ -47,9 +50,6 @@ from iris.cluster.controller.schema import (
     WorkerRow,
     tasks_with_attempts,
 )
-from iris.cluster.controller.controller import Controller, ControllerConfig
-from iris.cluster.controller.provider import ProviderUnsupportedError
-from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup
 from iris.cluster.controller.service import ControllerServiceImpl
 from iris.log_server.server import LogServiceImpl
 from iris.cluster.controller.transitions import (
@@ -213,11 +213,21 @@ def make_controller(tmp_path):
     monkeypatched ``LogServiceClientSync``. The factory tracks every
     constructed controller and ``stop()``s them at fixture teardown.
 
+    Pass ``db=`` to inject a pre-built ``ControllerDB`` (otherwise the
+    ``Controller`` opens one under ``config.local_state_dir``). Pass
+    ``provider=`` to override the default ``FakeProvider``. Any remaining
+    keyword arguments are forwarded to ``ControllerConfig``.
+
     Usage::
 
-        def test_foo(make_controller):
+        def test_foo(make_controller, tmp_path):
             ctrl = make_controller(remote_state_dir="file:///tmp/iris-state")
-            ...
+            # Or inject an existing DB / provider:
+            ctrl = make_controller(
+                remote_state_dir="file:///tmp/iris-state",
+                local_state_dir=tmp_path,
+                db=my_db,
+            )
     """
     created: list[Controller] = []
 
@@ -242,8 +252,14 @@ def make_controller(tmp_path):
         return controller
 
     yield _factory
+    errors: list[BaseException] = []
     for controller in created:
-        controller.stop()
+        try:
+            controller.stop()
+        except BaseException as exc:
+            errors.append(exc)
+    if errors:
+        raise errors[0]
 
 
 def make_test_entrypoint() -> job_pb2.RuntimeEntrypoint:

--- a/lib/iris/tests/cluster/controller/conftest.py
+++ b/lib/iris/tests/cluster/controller/conftest.py
@@ -47,6 +47,7 @@ from iris.cluster.controller.schema import (
     WorkerRow,
     tasks_with_attempts,
 )
+from iris.cluster.controller.controller import Controller, ControllerConfig
 from iris.cluster.controller.provider import ProviderUnsupportedError
 from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup
 from iris.cluster.controller.service import ControllerServiceImpl
@@ -199,6 +200,50 @@ def make_controller_state(**kwargs):
         db.close()
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
+
+
+@pytest.fixture
+def make_controller(tmp_path):
+    """Factory for building ``Controller`` instances with automatic teardown.
+
+    ``Controller.__init__`` attaches a ``RemoteLogHandler`` to the ``iris``
+    logger and spawns a ``LogPusher`` drain thread. Without ``stop()``, those
+    leak across the test session and pull every ``iris.*`` log record into
+    their internal queue — which can then be flushed into another test's
+    monkeypatched ``LogServiceClientSync``. The factory tracks every
+    constructed controller and ``stop()``s them at fixture teardown.
+
+    Usage::
+
+        def test_foo(make_controller):
+            ctrl = make_controller(remote_state_dir="file:///tmp/iris-state")
+            ...
+    """
+    created: list[Controller] = []
+
+    def _factory(
+        config: ControllerConfig | None = None,
+        *,
+        provider=None,
+        db: ControllerDB | None = None,
+        **config_kwargs,
+    ) -> Controller:
+        if config is None:
+            config_kwargs.setdefault("remote_state_dir", f"file://{tmp_path}/remote")
+            config = ControllerConfig(**config_kwargs)
+        elif config_kwargs:
+            raise TypeError("make_controller: pass either a config or config kwargs, not both")
+        controller = Controller(
+            config=config,
+            provider=provider if provider is not None else FakeProvider(),
+            db=db,
+        )
+        created.append(controller)
+        return controller
+
+    yield _factory
+    for controller in created:
+        controller.stop()
 
 
 def make_test_entrypoint() -> job_pb2.RuntimeEntrypoint:

--- a/lib/iris/tests/cluster/controller/test_checkpoint.py
+++ b/lib/iris/tests/cluster/controller/test_checkpoint.py
@@ -3,40 +3,19 @@
 
 """Tests for controller checkpoint: remote-only write and download-before-create restore."""
 
-from pathlib import Path
-
 from iris.cluster.controller.checkpoint import (
     download_checkpoint_to_local,
     prune_old_checkpoints,
     write_checkpoint,
 )
-from iris.cluster.controller.controller import (
-    Controller,
-    ControllerConfig,
-)
 from iris.cluster.controller.db import ControllerDB
 from rigging.timing import Duration
-from tests.cluster.controller.conftest import FakeProvider
 
 
-def _local_state_dir(tmp_path: Path, name: str = "state") -> Path:
-    d = tmp_path / name
-    d.mkdir(parents=True, exist_ok=True)
-    return d
-
-
-def _make_controller(tmp_path: Path, remote_state_dir: str | None = None, **kwargs) -> Controller:
-    if remote_state_dir is None:
-        remote_state_dir = f"file://{tmp_path}/remote"
-    state_dir = _local_state_dir(tmp_path)
-    config = ControllerConfig(remote_state_dir=remote_state_dir, local_state_dir=state_dir, **kwargs)
-    return Controller(config=config, provider=FakeProvider())
-
-
-def test_write_checkpoint_uploads_compressed(tmp_path):
+def test_write_checkpoint_uploads_compressed(tmp_path, make_controller):
     """write_checkpoint creates a timestamped directory with .zst files."""
     remote_dir = f"file://{tmp_path}/remote"
-    controller = _make_controller(tmp_path, remote_state_dir=remote_dir)
+    controller = make_controller(remote_state_dir=remote_dir)
 
     path, result = write_checkpoint(controller._db, remote_dir)
 
@@ -55,10 +34,10 @@ def test_write_checkpoint_uploads_compressed(tmp_path):
     controller._db.close()
 
 
-def test_begin_checkpoint_returns_remote_path(tmp_path):
+def test_begin_checkpoint_returns_remote_path(tmp_path, make_controller):
     """begin_checkpoint returns a remote path string."""
     remote_dir = f"file://{tmp_path}/remote"
-    controller = _make_controller(tmp_path, remote_state_dir=remote_dir)
+    controller = make_controller(remote_state_dir=remote_dir)
 
     path, result = controller.begin_checkpoint()
 
@@ -68,10 +47,10 @@ def test_begin_checkpoint_returns_remote_path(tmp_path):
     controller._db.close()
 
 
-def test_atexit_checkpoint_writes_to_remote(tmp_path):
+def test_atexit_checkpoint_writes_to_remote(tmp_path, make_controller):
     """_atexit_checkpoint writes directly to remote storage."""
     remote_dir = f"file://{tmp_path}/remote"
-    controller = _make_controller(tmp_path, remote_state_dir=remote_dir)
+    controller = make_controller(remote_state_dir=remote_dir)
 
     controller._atexit_checkpoint()
 
@@ -117,10 +96,10 @@ def test_download_from_explicit_path(tmp_path):
     assert (local_db_dir / "controller.sqlite3").exists()
 
 
-def test_write_checkpoint_roundtrip(tmp_path):
+def test_write_checkpoint_roundtrip(tmp_path, make_controller):
     """Write then download produces a valid DB."""
     remote_dir = f"file://{tmp_path}/remote"
-    controller = _make_controller(tmp_path, remote_state_dir=remote_dir)
+    controller = make_controller(remote_state_dir=remote_dir)
     write_checkpoint(controller._db, remote_dir)
     controller._db.close()
 
@@ -130,10 +109,10 @@ def test_write_checkpoint_roundtrip(tmp_path):
     restored_db.close()
 
 
-def test_write_checkpoint_cleans_up_temp_file(tmp_path):
+def test_write_checkpoint_cleans_up_temp_file(tmp_path, make_controller):
     """write_checkpoint does not leave temp files in the DB directory."""
     remote_dir = f"file://{tmp_path}/remote"
-    controller = _make_controller(tmp_path, remote_state_dir=remote_dir)
+    controller = make_controller(remote_state_dir=remote_dir)
     db_dir = controller._db.db_path.parent
 
     files_before = set(db_dir.iterdir())
@@ -217,11 +196,10 @@ def test_download_from_explicit_path_pairs_profiles_db(tmp_path):
     assert (local_db_dir / "profiles.sqlite3").exists(), "profiles DB should be downloaded into local_db_dir"
 
 
-def test_periodic_checkpoint_inline(tmp_path):
+def test_periodic_checkpoint_inline(tmp_path, make_controller):
     """Controller writes periodic checkpoints when limiter fires."""
     remote_dir = f"file://{tmp_path}/remote"
-    controller = _make_controller(
-        tmp_path,
+    controller = make_controller(
         remote_state_dir=remote_dir,
         checkpoint_interval=Duration.from_seconds(0),
     )

--- a/lib/iris/tests/cluster/controller/test_checkpoint.py
+++ b/lib/iris/tests/cluster/controller/test_checkpoint.py
@@ -31,8 +31,6 @@ def test_write_checkpoint_uploads_compressed(tmp_path, make_controller):
     assert result.task_count == 0
     assert result.worker_count == 0
 
-    controller._db.close()
-
 
 def test_begin_checkpoint_returns_remote_path(tmp_path, make_controller):
     """begin_checkpoint returns a remote path string."""
@@ -43,8 +41,6 @@ def test_begin_checkpoint_returns_remote_path(tmp_path, make_controller):
 
     assert path.startswith(f"file://{tmp_path}/remote/controller-state/")
     assert result.job_count == 0
-
-    controller._db.close()
 
 
 def test_atexit_checkpoint_writes_to_remote(tmp_path, make_controller):
@@ -58,8 +54,6 @@ def test_atexit_checkpoint_writes_to_remote(tmp_path, make_controller):
     timestamped_dirs = [d for d in remote_state.iterdir() if d.is_dir()]
     assert len(timestamped_dirs) >= 1
     assert (timestamped_dirs[0] / "controller.sqlite3.zst").exists()
-
-    controller._db.close()
 
 
 def test_download_checkpoint_to_local(tmp_path):
@@ -101,7 +95,6 @@ def test_write_checkpoint_roundtrip(tmp_path, make_controller):
     remote_dir = f"file://{tmp_path}/remote"
     controller = make_controller(remote_state_dir=remote_dir)
     write_checkpoint(controller._db, remote_dir)
-    controller._db.close()
 
     local_db_dir = tmp_path / "restored"
     download_checkpoint_to_local(remote_dir, local_db_dir)
@@ -122,8 +115,6 @@ def test_write_checkpoint_cleans_up_temp_file(tmp_path, make_controller):
     new_files = files_after - files_before
     sqlite_temps = [f for f in new_files if ".sqlite3" in f.name and f.name != ControllerDB.DB_FILENAME]
     assert len(sqlite_temps) == 0
-
-    controller._db.close()
 
 
 def test_local_db_exists_skips_remote_download(tmp_path):
@@ -212,8 +203,6 @@ def test_periodic_checkpoint_inline(tmp_path, make_controller):
     timestamped_dirs = [d for d in remote_state.iterdir() if d.is_dir()]
     assert len(timestamped_dirs) >= 1
     assert (timestamped_dirs[0] / "controller.sqlite3.zst").exists()
-
-    controller._db.close()
 
 
 def test_download_uncompressed_fallback(tmp_path):

--- a/lib/iris/tests/cluster/controller/test_dry_run.py
+++ b/lib/iris/tests/cluster/controller/test_dry_run.py
@@ -7,13 +7,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from iris.cluster.controller.controller import Controller, ControllerConfig
-from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.schema import TASK_DETAIL_PROJECTION
 from iris.cluster.types import JobName
 from iris.rpc import job_pb2
 from tests.cluster.controller.conftest import (
-    FakeProvider,
     make_job_request,
     make_worker_metadata,
     register_worker,
@@ -24,16 +21,8 @@ pytestmark = pytest.mark.timeout(15)
 
 
 @pytest.fixture
-def dry_run_controller(tmp_path):
-    db = ControllerDB(db_dir=tmp_path / "db")
-    config = ControllerConfig(
-        dry_run=True,
-        remote_state_dir=f"file://{tmp_path}/remote",
-        local_state_dir=tmp_path,
-    )
-    controller = Controller(config=config, provider=FakeProvider(), db=db)
-    yield controller
-    controller.stop()
+def dry_run_controller(make_controller):
+    return make_controller(dry_run=True)
 
 
 def test_dry_run_controller_starts_and_stops(dry_run_controller):

--- a/lib/iris/tests/cluster/controller/test_heartbeat.py
+++ b/lib/iris/tests/cluster/controller/test_heartbeat.py
@@ -8,13 +8,12 @@ import time
 
 import iris.cluster.controller.worker_provider as worker_provider_module
 import pytest
-from iris.cluster.controller.controller import Controller, ControllerConfig, _SyncFailureAccumulator
+from iris.cluster.controller.controller import _SyncFailureAccumulator
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.schema import (
     TASK_DETAIL_PROJECTION,
     WORKER_DETAIL_PROJECTION,
 )
-from tests.cluster.controller.conftest import FakeProvider
 from iris.cluster.controller.transitions import (
     Assignment,
     ControllerTransitions,
@@ -122,11 +121,14 @@ def test_fail_heartbeat_returns_transient_and_worker_stays_alive(state, worker_m
         assert q.fetchone("SELECT 1 FROM workers WHERE worker_id = ?", ("worker1",)) is not None
 
 
-def test_ping_failures_accumulate_and_terminate_inline(tmp_path, worker_metadata):
+def test_ping_failures_accumulate_and_terminate_inline(tmp_path, worker_metadata, make_controller):
     """Ten consecutive ping failures via _handle_failed_heartbeats terminates the worker inline."""
     db = ControllerDB(db_dir=tmp_path)
-    config = ControllerConfig(remote_state_dir="file:///tmp/iris-test-state", local_state_dir=tmp_path)
-    controller = Controller(config=config, provider=FakeProvider(), db=db)
+    controller = make_controller(
+        remote_state_dir="file:///tmp/iris-test-state",
+        local_state_dir=tmp_path,
+        db=db,
+    )
     state = controller.state
     _register_worker(state, "worker1", worker_metadata, address="10.0.0.1:10001")
 
@@ -149,9 +151,6 @@ def test_ping_failures_accumulate_and_terminate_inline(tmp_path, worker_metadata
     assert controller._health.workers_over_threshold() == []
     with db.snapshot() as q:
         assert q.fetchone("SELECT 1 FROM workers WHERE worker_id = ?", ("worker1",)) is None
-
-    controller.stop()
-    db.close()
 
 
 def test_complete_heartbeat_unhealthy_worker_increments_failures(state, worker_metadata):
@@ -263,10 +262,13 @@ class _FakeStubFactory:
         pass
 
 
-def test_handle_failed_heartbeats_logs_diagnostics(tmp_path, worker_metadata, caplog):
+def test_handle_failed_heartbeats_logs_diagnostics(tmp_path, worker_metadata, caplog, make_controller):
     db = ControllerDB(db_dir=tmp_path)
-    config = ControllerConfig(remote_state_dir="file:///tmp/iris-test-state", local_state_dir=tmp_path)
-    controller = Controller(config=config, provider=FakeProvider(), db=db)
+    controller = make_controller(
+        remote_state_dir="file:///tmp/iris-test-state",
+        local_state_dir=tmp_path,
+        db=db,
+    )
     state = controller.state
     _register_worker(state, "worker1", worker_metadata, address="10.0.0.1:10001")
 
@@ -291,8 +293,6 @@ def test_handle_failed_heartbeats_logs_diagnostics(tmp_path, worker_metadata, ca
     assert "action=transient_failure" in caplog.text
     assert "last_success_age_s=" in caplog.text
     assert "deadline exceeded after 12000ms" in caplog.text
-
-    controller.stop()
 
 
 def test_rpc_worker_stub_factory_default_timeout(monkeypatch):

--- a/lib/iris/tests/cluster/controller/test_reservation.py
+++ b/lib/iris/tests/cluster/controller/test_reservation.py
@@ -12,11 +12,12 @@ Tests cover:
   and non-reservation jobs get NOT_EXISTS constraint.
 """
 
+import pytest
+
 from iris.cluster.controller.codec import constraints_from_json
 from iris.cluster.controller.controller import (
     RESERVATION_TAINT_KEY,
     Controller,
-    ControllerConfig,
     ReservationClaim,
     _find_reservation_ancestor,
     _inject_reservation_taints,
@@ -51,7 +52,6 @@ from iris.rpc import job_pb2
 from iris.rpc import controller_pb2
 from rigging.timing import Timestamp
 from tests.cluster.controller.conftest import (
-    FakeProvider,
     hydrate_worker_attributes as _with_attrs,
     query_job as _query_job,
     query_job_row as _query_job_row,
@@ -191,12 +191,15 @@ def _make_job_request_with_reservation(
     return req
 
 
-def _make_controller() -> Controller:
-    """Create a Controller with minimal config for unit testing."""
-    config = ControllerConfig(
-        remote_state_dir="file:///tmp/iris-test-bundles",
-    )
-    return Controller(config=config, provider=FakeProvider())
+@pytest.fixture
+def ctrl(make_controller) -> Controller:
+    """Minimal Controller for reservation unit tests.
+
+    Uses the shared ``make_controller`` factory so the Controller's
+    RemoteLogHandler is detached and its LogPusher drain thread stopped
+    at teardown.
+    """
+    return make_controller(remote_state_dir="file:///tmp/iris-test-bundles")
 
 
 def _register_worker(
@@ -291,9 +294,8 @@ def test_worker_rejects_unmet_constraint():
 # =============================================================================
 
 
-def test_claim_eligible_worker():
+def test_claim_eligible_worker(ctrl):
     """An eligible worker is claimed for a reservation entry."""
-    ctrl = _make_controller()
     _register_worker(ctrl.state, "w1")
     req = _make_job_request_with_reservation(
         reservation_entries=[_make_reservation_entry()],
@@ -308,9 +310,8 @@ def test_claim_eligible_worker():
     assert claim.entry_idx == 0
 
 
-def test_claim_rejects_wrong_device():
+def test_claim_rejects_wrong_device(ctrl):
     """A worker with the wrong device type is not claimed."""
-    ctrl = _make_controller()
     _register_worker(ctrl.state, "w1", _cpu_metadata())
     req = _make_job_request_with_reservation(
         reservation_entries=[_make_reservation_entry(_gpu_device("H100"))],
@@ -322,9 +323,8 @@ def test_claim_rejects_wrong_device():
     assert len(ctrl.reservation_claims) == 0
 
 
-def test_claim_one_per_worker():
+def test_claim_one_per_worker(ctrl):
     """A single worker cannot be claimed by two different reservation entries."""
-    ctrl = _make_controller()
     _register_worker(ctrl.state, "w1")
     req = _make_job_request_with_reservation(
         reservation_entries=[_make_reservation_entry(), _make_reservation_entry()],
@@ -337,9 +337,8 @@ def test_claim_one_per_worker():
     assert WorkerId("w1") in ctrl.reservation_claims
 
 
-def test_claim_respects_entry_count():
+def test_claim_respects_entry_count(ctrl):
     """Two workers can satisfy a 2-entry reservation."""
-    ctrl = _make_controller()
     _register_worker(ctrl.state, "w1")
     _register_worker(ctrl.state, "w2")
     req = _make_job_request_with_reservation(
@@ -355,9 +354,8 @@ def test_claim_respects_entry_count():
     assert claimed_entries == {0, 1}
 
 
-def test_claim_does_not_exceed_entry_count():
+def test_claim_does_not_exceed_entry_count(ctrl):
     """Extra workers beyond entry count are not claimed."""
-    ctrl = _make_controller()
     _register_worker(ctrl.state, "w1")
     _register_worker(ctrl.state, "w2")
     _register_worker(ctrl.state, "w3")
@@ -371,9 +369,8 @@ def test_claim_does_not_exceed_entry_count():
     assert len(ctrl.reservation_claims) == 1
 
 
-def test_claim_independent_per_job():
+def test_claim_independent_per_job(ctrl):
     """Claims for different jobs don't interfere with each other."""
-    ctrl = _make_controller()
     _register_worker(ctrl.state, "w1")
     _register_worker(ctrl.state, "w2")
 
@@ -399,9 +396,8 @@ def test_claim_independent_per_job():
     }
 
 
-def test_claim_skips_unhealthy_worker():
+def test_claim_skips_unhealthy_worker(ctrl):
     """Unhealthy workers are not claimed."""
-    ctrl = _make_controller()
     _register_worker(ctrl.state, "w1")
     # Mark worker unhealthy
     ctrl.state.set_worker_health_for_test(WorkerId("w1"), False)
@@ -416,9 +412,8 @@ def test_claim_skips_unhealthy_worker():
     assert len(ctrl.reservation_claims) == 0
 
 
-def test_claim_idempotent():
+def test_claim_idempotent(ctrl):
     """Running claiming twice doesn't duplicate claims."""
-    ctrl = _make_controller()
     _register_worker(ctrl.state, "w1")
     req = _make_job_request_with_reservation(
         reservation_entries=[_make_reservation_entry()],
@@ -436,9 +431,8 @@ def test_claim_idempotent():
 # =============================================================================
 
 
-def test_cleanup_removes_dead_worker_claims():
+def test_cleanup_removes_dead_worker_claims(ctrl):
     """Claims for workers no longer in state are removed."""
-    ctrl = _make_controller()
     w1 = _register_worker(ctrl.state, "w1")
     req = _make_job_request_with_reservation(
         reservation_entries=[_make_reservation_entry()],
@@ -463,9 +457,8 @@ def test_cleanup_removes_dead_worker_claims():
     assert w1 in ctrl.reservation_claims
 
 
-def test_cleanup_removes_finished_job_claims():
+def test_cleanup_removes_finished_job_claims(ctrl):
     """Claims for finished jobs are removed."""
-    ctrl = _make_controller()
     _register_worker(ctrl.state, "w1")
     req = _make_job_request_with_reservation(
         reservation_entries=[_make_reservation_entry()],
@@ -485,9 +478,8 @@ def test_cleanup_removes_finished_job_claims():
     assert len(ctrl.reservation_claims) == 0
 
 
-def test_cleanup_preserves_valid_claims():
+def test_cleanup_preserves_valid_claims(ctrl):
     """Valid claims (healthy worker, active job) are preserved."""
-    ctrl = _make_controller()
     _register_worker(ctrl.state, "w1")
     req = _make_job_request_with_reservation(
         reservation_entries=[_make_reservation_entry()],
@@ -505,9 +497,8 @@ def test_cleanup_preserves_valid_claims():
 # =============================================================================
 
 
-def test_gate_satisfied_when_claims_meet_entries():
+def test_gate_satisfied_when_claims_meet_entries(ctrl):
     """Gate opens when claimed workers >= reservation entries."""
-    ctrl = _make_controller()
     _register_worker(ctrl.state, "w1")
     req = _make_job_request_with_reservation(
         reservation_entries=[_make_reservation_entry()],
@@ -519,9 +510,8 @@ def test_gate_satisfied_when_claims_meet_entries():
     assert ctrl._is_reservation_satisfied(job)
 
 
-def test_gate_unsatisfied_when_claims_below_entries():
+def test_gate_unsatisfied_when_claims_below_entries(ctrl):
     """Gate stays closed when fewer workers are claimed than entries required."""
-    ctrl = _make_controller()
     _register_worker(ctrl.state, "w1")
     req = _make_job_request_with_reservation(
         reservation_entries=[_make_reservation_entry(), _make_reservation_entry()],
@@ -534,9 +524,8 @@ def test_gate_unsatisfied_when_claims_below_entries():
     assert not ctrl._is_reservation_satisfied(job)
 
 
-def test_gate_satisfied_for_jobs_without_reservation():
+def test_gate_satisfied_for_jobs_without_reservation(ctrl):
     """Jobs without a reservation always pass the gate."""
-    ctrl = _make_controller()
     req = controller_pb2.Controller.LaunchJobRequest(
         name="no-res",
         entrypoint=_entrypoint(),
@@ -897,9 +886,8 @@ def test_preference_pass_deducts_capacity():
 # =============================================================================
 
 
-def test_region_constraint_injected_from_claimed_workers():
+def test_region_constraint_injected_from_claimed_workers(ctrl):
     """Region constraint is injected when claimed workers have a region attribute."""
-    ctrl = _make_controller()
     w1 = _register_worker(ctrl.state, "w1")
     # Set region attribute on worker
     ctrl.state.set_worker_attribute_for_test(w1, WellKnownAttribute.REGION, AttributeValue("us-central1"))
@@ -921,9 +909,8 @@ def test_region_constraint_injected_from_claimed_workers():
     assert result[0].values[0].value == "us-central1"
 
 
-def test_region_constraint_not_injected_when_already_present():
+def test_region_constraint_not_injected_when_already_present(ctrl):
     """Existing region constraint prevents injection."""
-    ctrl = _make_controller()
     w1 = _register_worker(ctrl.state, "w1")
     ctrl.state.set_worker_attribute_for_test(w1, WellKnownAttribute.REGION, AttributeValue("us-central1"))
 
@@ -943,9 +930,8 @@ def test_region_constraint_not_injected_when_already_present():
     assert result[0] is existing
 
 
-def test_region_constraint_not_injected_when_no_region_attr():
+def test_region_constraint_not_injected_when_no_region_attr(ctrl):
     """No injection when claimed workers lack region attributes."""
-    ctrl = _make_controller()
     _register_worker(ctrl.state, "w1")
 
     req = _make_job_request_with_reservation(reservation_entries=[_make_reservation_entry()])
@@ -962,9 +948,8 @@ def test_region_constraint_not_injected_when_no_region_attr():
     assert result == []
 
 
-def test_region_constraint_multiple_regions():
+def test_region_constraint_multiple_regions(ctrl):
     """IN constraint injected when claimed workers span multiple regions."""
-    ctrl = _make_controller()
     w1 = _register_worker(ctrl.state, "w1")
     w2 = _register_worker(ctrl.state, "w2")
     ctrl.state.set_worker_attribute_for_test(w1, WellKnownAttribute.REGION, AttributeValue("us-central1"))
@@ -989,9 +974,8 @@ def test_region_constraint_multiple_regions():
     assert {v.value for v in result[0].values} == {"us-central1", "us-east1"}
 
 
-def test_no_injection_for_non_reservation_job():
+def test_no_injection_for_non_reservation_job(ctrl):
     """No claims for this job → constraints returned unchanged."""
-    ctrl = _make_controller()
     w1 = _register_worker(ctrl.state, "w1")
     ctrl.state.set_worker_attribute_for_test(w1, WellKnownAttribute.REGION, AttributeValue("us-central1"))
 
@@ -1015,9 +999,8 @@ def test_no_injection_for_non_reservation_job():
 # =============================================================================
 
 
-def test_find_reservation_ancestor_returns_parent_with_reservation():
+def test_find_reservation_ancestor_returns_parent_with_reservation(ctrl):
     """Direct parent with reservation is found."""
-    ctrl = _make_controller()
     parent_req = _make_job_request_with_reservation(
         reservation_entries=[_make_reservation_entry()],
     )
@@ -1037,9 +1020,8 @@ def test_find_reservation_ancestor_returns_parent_with_reservation():
     assert result == parent_jid
 
 
-def test_find_reservation_ancestor_returns_grandparent():
+def test_find_reservation_ancestor_returns_grandparent(ctrl):
     """Grandparent with reservation is found when parent has none."""
-    ctrl = _make_controller()
     # Grandparent with reservation
     gp_req = _make_job_request_with_reservation(
         reservation_entries=[_make_reservation_entry()],
@@ -1072,9 +1054,8 @@ def test_find_reservation_ancestor_returns_grandparent():
     assert result == gp_jid
 
 
-def test_find_reservation_ancestor_returns_none_for_root_job():
+def test_find_reservation_ancestor_returns_none_for_root_job(ctrl):
     """Root job with no reservation returns None."""
-    ctrl = _make_controller()
     req = controller_pb2.Controller.LaunchJobRequest(
         name="no-res",
         entrypoint=_entrypoint(),
@@ -1086,9 +1067,8 @@ def test_find_reservation_ancestor_returns_none_for_root_job():
     assert _find_reservation_ancestor(ctrl._db, jid) is None
 
 
-def test_find_reservation_ancestor_returns_none_when_no_ancestor_has_reservation():
+def test_find_reservation_ancestor_returns_none_when_no_ancestor_has_reservation(ctrl):
     """Child of a non-reservation parent returns None."""
-    ctrl = _make_controller()
     parent_req = controller_pb2.Controller.LaunchJobRequest(
         name="plain-parent",
         entrypoint=_entrypoint(),
@@ -1116,9 +1096,8 @@ def test_find_reservation_ancestor_returns_none_when_no_ancestor_has_reservation
 # =============================================================================
 
 
-def test_taint_exemption_for_children_of_reservation_job():
+def test_taint_exemption_for_children_of_reservation_job(ctrl):
     """Children of a reservation job are not blocked from claimed workers."""
-    ctrl = _make_controller()
     _register_worker(ctrl.state, "w1", _gpu_metadata("H100"))
     _register_worker(ctrl.state, "w2", _gpu_metadata("H100"))
 
@@ -1185,9 +1164,8 @@ def test_taint_exemption_for_children_of_reservation_job():
         assert parent_constraints[0].op == job_pb2.CONSTRAINT_OP_EQ
 
 
-def test_grandchildren_inherit_reservation_from_ancestor():
+def test_grandchildren_inherit_reservation_from_ancestor(ctrl):
     """Grandchildren of a reservation job inherit taint exemption."""
-    ctrl = _make_controller()
     _register_worker(ctrl.state, "h1", _gpu_metadata("H100"))
     _register_worker(ctrl.state, "h2", _gpu_metadata("H100"))
     _register_worker(ctrl.state, "a1", _gpu_metadata("A100"))
@@ -1317,9 +1295,8 @@ def test_grandchildren_inherit_reservation_from_ancestor():
     assert not_exists[0].op == job_pb2.CONSTRAINT_OP_NOT_EXISTS
 
 
-def test_unrelated_job_blocked_when_all_workers_claimed():
+def test_unrelated_job_blocked_when_all_workers_claimed(ctrl):
     """A job with no reservation ancestor gets NOT_EXISTS and is blocked from claimed workers."""
-    ctrl = _make_controller()
     _register_worker(ctrl.state, "w1", _gpu_metadata("H100"))
     _register_worker(ctrl.state, "w2", _gpu_metadata("H100"))
 

--- a/lib/iris/tests/cluster/controller/test_scheduling_fairness.py
+++ b/lib/iris/tests/cluster/controller/test_scheduling_fairness.py
@@ -3,13 +3,10 @@
 
 """Integration tests for priority bands, per-user fairness, and scheduling caps."""
 
-import shutil
-import tempfile
 from collections import defaultdict
-from pathlib import Path
 
 from iris.cluster.controller.budget import UserTask, compute_effective_band, interleave_by_user
-from iris.cluster.controller.controller import Controller, ControllerConfig, SchedulingOutcome, _schedulable_tasks
+from iris.cluster.controller.controller import SchedulingOutcome, _schedulable_tasks
 from iris.cluster.controller.schema import TASK_DETAIL_PROJECTION
 from iris.cluster.types import JobName, WorkerId
 from iris.rpc import job_pb2
@@ -17,7 +14,6 @@ from iris.rpc import controller_pb2
 from rigging.timing import Timestamp
 
 from .conftest import (
-    FakeProvider,
     inject_device_constraints,
     make_controller_state,
     make_job_request,
@@ -281,7 +277,7 @@ def test_zero_budget_means_unlimited():
             assert band == job_pb2.PRIORITY_BAND_INTERACTIVE
 
 
-def test_unplaceable_tasks_do_not_starve_placeable_tasks():
+def test_unplaceable_tasks_do_not_starve_placeable_tasks(make_controller, tmp_path):
     """A user's CPU task is scheduled even when they have many unplaceable TPU tasks.
 
     Regression test: a per-user input cap (max_tasks_per_user_per_cycle) applied before
@@ -290,57 +286,49 @@ def test_unplaceable_tasks_do_not_starve_placeable_tasks():
     actual assignments, not scheduling candidates.
     """
     OLD_CAP = 8  # historical default — must exceed this many TPU tasks
-    tmpdir = Path(tempfile.mkdtemp(prefix="iris_ctrl_test_"))
-    try:
-        config = ControllerConfig(
-            remote_state_dir=f"file://{tmpdir}/remote",
-            local_state_dir=tmpdir / "local",
+    ctrl = make_controller(local_state_dir=tmp_path / "local")
+
+    # Submit OLD_CAP+2 unplaceable TPU tasks for alice (no TPU workers will be registered)
+    for i in range(OLD_CAP + 2):
+        tpu_req = controller_pb2.Controller.LaunchJobRequest(
+            name=f"/alice/tpu-job-{i}",
+            entrypoint=make_job_request().entrypoint,
+            resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
+            environment=job_pb2.EnvironmentConfig(),
+            replicas=1,
         )
-        ctrl = Controller(config=config, provider=FakeProvider())
+        tpu_req.resources.device.tpu.variant = "v5p-8"
+        inject_device_constraints(tpu_req)
+        jid = JobName.from_string(f"/alice/tpu-job-{i}")
+        ctrl._transitions.submit_job(jid, tpu_req, Timestamp.now())
 
-        # Submit OLD_CAP+2 unplaceable TPU tasks for alice (no TPU workers will be registered)
-        for i in range(OLD_CAP + 2):
-            tpu_req = controller_pb2.Controller.LaunchJobRequest(
-                name=f"/alice/tpu-job-{i}",
-                entrypoint=make_job_request().entrypoint,
-                resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
-                environment=job_pb2.EnvironmentConfig(),
-                replicas=1,
-            )
-            tpu_req.resources.device.tpu.variant = "v5p-8"
-            inject_device_constraints(tpu_req)
-            jid = JobName.from_string(f"/alice/tpu-job-{i}")
-            ctrl._transitions.submit_job(jid, tpu_req, Timestamp.now())
+    # Submit 1 CPU task for alice — this should be placeable on the CPU worker
+    cpu_jid = JobName.from_string("/alice/cpu-job")
+    cpu_req = make_job_request(name="/alice/cpu-job", cpu=1, replicas=1)
+    inject_device_constraints(cpu_req)
+    ctrl._transitions.submit_job(cpu_jid, cpu_req, Timestamp.now())
 
-        # Submit 1 CPU task for alice — this should be placeable on the CPU worker
-        cpu_jid = JobName.from_string("/alice/cpu-job")
-        cpu_req = make_job_request(name="/alice/cpu-job", cpu=1, replicas=1)
-        inject_device_constraints(cpu_req)
-        ctrl._transitions.submit_job(cpu_jid, cpu_req, Timestamp.now())
+    # Register exactly 1 CPU worker — no TPU workers
+    ctrl._transitions.register_or_refresh_worker(
+        worker_id=WorkerId("cpu-worker"),
+        address="cpu-worker:8080",
+        metadata=make_worker_metadata(cpu=4, memory_bytes=8 * 1024**3),
+        ts=Timestamp.now(),
+    )
 
-        # Register exactly 1 CPU worker — no TPU workers
-        ctrl._transitions.register_or_refresh_worker(
-            worker_id=WorkerId("cpu-worker"),
-            address="cpu-worker:8080",
-            metadata=make_worker_metadata(cpu=4, memory_bytes=8 * 1024**3),
-            ts=Timestamp.now(),
+    outcome = ctrl._run_scheduling()
+
+    assert outcome == SchedulingOutcome.ASSIGNMENTS_MADE, f"Expected ASSIGNMENTS_MADE, got {outcome}"
+
+    with ctrl._db.snapshot() as q:
+        cpu_tasks = TASK_DETAIL_PROJECTION.decode(
+            q.fetchall("SELECT * FROM tasks WHERE job_id = ?", (cpu_jid.to_wire(),))
         )
 
-        outcome = ctrl._run_scheduling()
-
-        assert outcome == SchedulingOutcome.ASSIGNMENTS_MADE, f"Expected ASSIGNMENTS_MADE, got {outcome}"
-
-        with ctrl._db.snapshot() as q:
-            cpu_tasks = TASK_DETAIL_PROJECTION.decode(
-                q.fetchall("SELECT * FROM tasks WHERE job_id = ?", (cpu_jid.to_wire(),))
-            )
-
-        assert len(cpu_tasks) == 1
-        assert (
-            cpu_tasks[0].state == job_pb2.TASK_STATE_ASSIGNED
-        ), f"CPU task state={cpu_tasks[0].state}; unplaceable TPU tasks may be blocking it"
-    finally:
-        shutil.rmtree(tmpdir, ignore_errors=True)
+    assert len(cpu_tasks) == 1
+    assert (
+        cpu_tasks[0].state == job_pb2.TASK_STATE_ASSIGNED
+    ), f"CPU task state={cpu_tasks[0].state}; unplaceable TPU tasks may be blocking it"
 
 
 def test_submit_with_explicit_band_stores_band():

--- a/lib/iris/tests/test_remote_log_handler.py
+++ b/lib/iris/tests/test_remote_log_handler.py
@@ -201,7 +201,11 @@ def test_log_pusher_flushes_at_batch_size(tracked_log_service_client):
         import time as _time
 
         _time.sleep(0.05)
-        assert tracked_log_service_client == [] or tracked_log_service_client[0].pushes == []
+        # Length checks only — don't let a (buggy) populated pushes list dump its
+        # entire proto repr into the failure output.
+        n_clients = len(tracked_log_service_client)
+        n_pushes = len(tracked_log_service_client[0].pushes) if n_clients else 0
+        assert n_clients == 0 or n_pushes == 0, f"expected no pushes before batch_size reached, got {n_pushes}"
 
         pusher.push("k", [entry])
         _wait_for(lambda: len(tracked_log_service_client) == 1 and len(tracked_log_service_client[0].pushes) == 1)

--- a/uv.lock
+++ b/uv.lock
@@ -5150,7 +5150,7 @@ dev = [
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "playwright", specifier = ">=1.49.0" },
     { name = "pyarrow", specifier = ">=19.0.0" },
-    { name = "pytest", specifier = ">=8.3.2" },
+    { name = "pytest", specifier = ">=8.4" },
     { name = "pytest-asyncio" },
     { name = "pytest-flakefinder", specifier = ">=1.1.0" },
     { name = "pytest-playwright", specifier = ">=0.6.2" },


### PR DESCRIPTION
Controller.__init__ attaches a RemoteLogHandler to the iris logger and spawns a LogPusher drain thread; tests that constructed a Controller without calling stop() leaked both across the session, so later tests that monkeypatched LogServiceClientSync could receive the stale backlog (seen as flaky CI failures with tens of KB of protobuf repr). Introduces a shared make_controller fixture that tracks and stops every controller at teardown, migrates per-file helpers to use it, and makes Controller.stop() idempotent. Also caps pytest assertion truncation so a future leak cannot flood CI logs again.