### PR TITLE
[zephyr] Raise coordinator heartbeat-check interval from 0.5s to 2.0s

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -463,7 +463,7 @@ class ZephyrCoordinator:
                 self.abort("Coordinator loop crashed unexpectedly")
                 return
 
-            self._shutdown_event.wait(timeout=0.5)
+            self._shutdown_event.wait(timeout=2.0)
 
     def _check_worker_group(self) -> None:
         """Abort the pipeline if the worker job has permanently terminated."""


### PR DESCRIPTION
`_coordinator_loop` woke every 0.5s to check whether the worker ActorGroup had permanently died. 

That event takes seconds to manifest and is handled via the same abort path as any other error, so sub-second polling was pure overhead. 2.0s is plenty responsive.