### PR TITLE
[zephyr] OOM-proof scatter write buffer with byte-based flush budget

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -377,11 +377,14 @@ class ZephyrCoordinator:
         self._is_last_stage: bool = False
         self._initialized: bool = False
         self._pipeline_running: bool = False
-        # O(1) count of workers in READY or BUSY state, maintained by _set_worker_state.
-        self._alive_workers: int = 0
 
         # Lock for accessing coordinator state from background thread
         self._lock = threading.Lock()
+        # Signaled on every state change that _wait_for_stage cares about
+        # (shard completed, task requeued, fatal error, worker registered).
+        # Allows _wait_for_stage to wake immediately instead of spinning up
+        # to its max 1-second poll interval.
+        self._stage_event = threading.Event()
 
         actor_ctx = current_actor()
         self._name = f"{actor_ctx.group_name}"
@@ -419,20 +422,6 @@ class ZephyrCoordinator:
         """Set the worker ActorGroup so the coordinator can detect permanent worker death."""
         self._worker_group = worker_group
 
-    def _set_worker_state(self, worker_id: str, new_state: WorkerState) -> None:
-        """Transition a worker's state and keep _alive_workers in sync.
-
-        Must be called with self._lock held.
-        """
-        old_state = self._worker_states.get(worker_id)
-        was_alive = old_state in {WorkerState.READY, WorkerState.BUSY}
-        is_alive = new_state in {WorkerState.READY, WorkerState.BUSY}
-        if was_alive and not is_alive:
-            self._alive_workers -= 1
-        elif not was_alive and is_alive:
-            self._alive_workers += 1
-        self._worker_states[worker_id] = new_state
-
     def register_worker(self, worker_id: str, worker_handle: ActorHandle) -> None:
         """Called by workers when they come online to register with coordinator.
 
@@ -443,19 +432,20 @@ class ZephyrCoordinator:
             if worker_id in self._worker_handles:
                 logger.info("Worker %s re-registering (likely reconstructed), updating handle", worker_id)
                 self._worker_handles[worker_id] = worker_handle
-                self._set_worker_state(worker_id, WorkerState.READY)
+                self._worker_states[worker_id] = WorkerState.READY
                 self._last_seen[worker_id] = time.monotonic()
                 # NOTE: if there was a task assigned to the worker, there's a race condition between marking
                 # the worker as unhealthy via heartbeat and re-registration. If we do not requeue we may silently
                 # lose tasks.
                 self._maybe_requeue_worker_task(worker_id)
-                return
+            else:
+                self._worker_handles[worker_id] = worker_handle
+                self._worker_states[worker_id] = WorkerState.READY
+                self._last_seen[worker_id] = time.monotonic()
 
-            self._worker_handles[worker_id] = worker_handle
-            self._set_worker_state(worker_id, WorkerState.READY)
-            self._last_seen[worker_id] = time.monotonic()
-
-            logger.info("Worker %s registered, total: %d", worker_id, len(self._worker_handles))
+                logger.info("Worker %s registered, total: %d", worker_id, len(self._worker_handles))
+        # Wake _wait_for_stage so it re-evaluates the alive-worker count.
+        self._stage_event.set()
 
     def _coordinator_loop(self) -> None:
         """Background loop for heartbeat checking and worker job monitoring."""
@@ -504,10 +494,10 @@ class ZephyrCoordinator:
 
     def _log_status(self) -> None:
         with self._lock:
-            alive = self._alive_workers
-            total_workers = len(self._worker_handles)
+            states = list(self._worker_states.values())
             retried = {idx: att for idx, att in self._task_attempts.items() if att > 0}
-        dead = total_workers - alive
+        alive = sum(1 for s in states if s in {WorkerState.READY, WorkerState.BUSY})
+        dead = sum(1 for s in states if s in {WorkerState.FAILED, WorkerState.DEAD})
         logger.info(
             "[%s] [%s] %d/%d complete, %d in-flight, %d queued, %d/%d workers alive, %d dead",
             self._execution_id,
@@ -517,7 +507,7 @@ class ZephyrCoordinator:
             len(self._in_flight),
             len(self._task_queue),
             alive,
-            total_workers,
+            len(self._worker_handles),
             dead,
         )
         if retried:
@@ -605,7 +595,7 @@ class ZephyrCoordinator:
         for worker_id, last in list(self._last_seen.items()):
             if now - last > timeout and self._worker_states.get(worker_id) not in {WorkerState.FAILED, WorkerState.DEAD}:
                 logger.warning(f"Zephyr worker {worker_id} failed to heartbeat within timeout ({now - last:.1f}s)")
-                self._set_worker_state(worker_id, WorkerState.FAILED)
+                self._worker_states[worker_id] = WorkerState.FAILED
                 self._maybe_requeue_worker_task(worker_id)
 
     def pull_task(self, worker_id: str) -> tuple[ShardTask, int, dict] | str | None:
@@ -618,10 +608,10 @@ class ZephyrCoordinator:
         """
         with self._lock:
             self._last_seen[worker_id] = time.monotonic()
-            self._set_worker_state(worker_id, WorkerState.READY)
+            self._worker_states[worker_id] = WorkerState.READY
 
             if self._shutdown_event.is_set():
-                self._set_worker_state(worker_id, WorkerState.DEAD)
+                self._worker_states[worker_id] = WorkerState.DEAD
                 return "SHUTDOWN"
 
             if self._fatal_error:
@@ -634,14 +624,14 @@ class ZephyrCoordinator:
                     # restarts the worker which re-registers and picks it up.
                     # _check_worker_group() detects permanent worker-job death
                     # as a failsafe so we never deadlock.
-                    self._set_worker_state(worker_id, WorkerState.DEAD)
+                    self._worker_states[worker_id] = WorkerState.DEAD
                     return "SHUTDOWN"
                 return None
 
             task = self._task_queue.popleft()
             attempt = self._task_attempts[task.shard_idx]
             self._in_flight[worker_id] = (task, attempt)
-            self._set_worker_state(worker_id, WorkerState.BUSY)
+            self._worker_states[worker_id] = WorkerState.BUSY
 
             config = {
                 "chunk_prefix": self._chunk_prefix,
@@ -687,11 +677,14 @@ class ZephyrCoordinator:
             self._results[shard_idx] = result
             self._completed_shards += 1
             self._in_flight.pop(worker_id, None)
-            self._set_worker_state(worker_id, WorkerState.READY)
+            self._worker_states[worker_id] = WorkerState.READY
             self._completed_counters.append(counter_snapshot)
             # Zero the in-flight counters but keep the generation watermark
             # so late heartbeats from this task are rejected.
             self._worker_counters[worker_id] = CounterSnapshot.empty(counter_snapshot.generation)
+        # Wake _wait_for_stage immediately so it advances to the next stage
+        # without waiting out the polling backoff interval.
+        self._stage_event.set()
 
     def report_error(self, worker_id: str, shard_idx: int, error_info: str) -> None:
         """Worker reports a task failure. Re-queues up to MAX_SHARD_FAILURES."""
@@ -699,7 +692,9 @@ class ZephyrCoordinator:
             self._last_seen[worker_id] = time.monotonic()
             self._assert_in_flight_consistent(worker_id, shard_idx)
             aborted = self._record_shard_failure(worker_id, ShardFailureKind.TASK, error_info)
-            self._set_worker_state(worker_id, WorkerState.DEAD if aborted else WorkerState.READY)
+            self._worker_states[worker_id] = WorkerState.DEAD if aborted else WorkerState.READY
+        # Wake _wait_for_stage so it re-evaluates the alive-worker count and fatal error.
+        self._stage_event.set()
 
     def heartbeat(self, worker_id: str, counter_snapshot: CounterSnapshot | None = None) -> None:
         self._last_seen[worker_id] = time.monotonic()
@@ -765,6 +760,8 @@ class ZephyrCoordinator:
             if self._fatal_error is None:
                 logger.error("Coordinator aborted: %s", reason)
                 self._fatal_error = reason
+        # Wake _wait_for_stage so it raises ZephyrWorkerError immediately.
+        self._stage_event.set()
 
     def _start_stage(self, stage_name: str, tasks: list[ShardTask], is_last_stage: bool = False) -> None:
         """Load a new stage's tasks into the queue."""
@@ -784,6 +781,9 @@ class ZephyrCoordinator:
             # Only reset in-flight worker snapshots; completed snapshots
             # accumulate across stages for full pipeline visibility.
             self._worker_counters = {}
+        # Clear after releasing the lock so _wait_for_stage can't miss
+        # a signal set between lock release and the clear call.
+        self._stage_event.clear()
 
     def _wait_for_stage(self) -> None:
         """Block until current stage completes or error occurs."""
@@ -792,7 +792,6 @@ class ZephyrCoordinator:
         start_time = time.monotonic()
         all_dead_since: float | None = None
         no_workers_timeout = self._no_workers_timeout
-        stage_done = threading.Event()
 
         while True:
             with self._lock:
@@ -805,9 +804,11 @@ class ZephyrCoordinator:
                 if completed >= total:
                     return
 
-                # _alive_workers is kept in sync by _set_worker_state on every
-                # state transition, avoiding a per-wakeup O(n_workers) scan.
-                alive_workers = self._alive_workers
+                # Count alive workers (READY or BUSY), not just total registered.
+                # Dead/failed workers stay in _worker_handles but can't make progress.
+                alive_workers = sum(
+                    1 for s in self._worker_states.values() if s in {WorkerState.READY, WorkerState.BUSY}
+                )
 
                 if alive_workers == 0:
                     now = time.monotonic()
@@ -834,7 +835,13 @@ class ZephyrCoordinator:
                 last_log_completed = completed
                 backoff.reset()
 
-            stage_done.wait(timeout=backoff.next_interval())
+            # Wait for a state-change signal (shard completed, error, worker registered)
+            # with a timeout as backstop for the alive-worker check and log lines.
+            # _stage_event is set by report_result/report_error/abort/register_worker,
+            # so the stage transition is detected within microseconds of the last
+            # shard completing rather than after up to the full backoff interval.
+            self._stage_event.wait(timeout=backoff.next_interval())
+            self._stage_event.clear()
 
     def _collect_results(self) -> dict[int, TaskResult]:
         """Return results for the completed stage."""

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -377,6 +377,8 @@ class ZephyrCoordinator:
         self._is_last_stage: bool = False
         self._initialized: bool = False
         self._pipeline_running: bool = False
+        # O(1) count of workers in READY or BUSY state, maintained by _set_worker_state.
+        self._alive_workers: int = 0
 
         # Lock for accessing coordinator state from background thread
         self._lock = threading.Lock()
@@ -417,6 +419,20 @@ class ZephyrCoordinator:
         """Set the worker ActorGroup so the coordinator can detect permanent worker death."""
         self._worker_group = worker_group
 
+    def _set_worker_state(self, worker_id: str, new_state: WorkerState) -> None:
+        """Transition a worker's state and keep _alive_workers in sync.
+
+        Must be called with self._lock held.
+        """
+        old_state = self._worker_states.get(worker_id)
+        was_alive = old_state in {WorkerState.READY, WorkerState.BUSY}
+        is_alive = new_state in {WorkerState.READY, WorkerState.BUSY}
+        if was_alive and not is_alive:
+            self._alive_workers -= 1
+        elif not was_alive and is_alive:
+            self._alive_workers += 1
+        self._worker_states[worker_id] = new_state
+
     def register_worker(self, worker_id: str, worker_handle: ActorHandle) -> None:
         """Called by workers when they come online to register with coordinator.
 
@@ -427,7 +443,7 @@ class ZephyrCoordinator:
             if worker_id in self._worker_handles:
                 logger.info("Worker %s re-registering (likely reconstructed), updating handle", worker_id)
                 self._worker_handles[worker_id] = worker_handle
-                self._worker_states[worker_id] = WorkerState.READY
+                self._set_worker_state(worker_id, WorkerState.READY)
                 self._last_seen[worker_id] = time.monotonic()
                 # NOTE: if there was a task assigned to the worker, there's a race condition between marking
                 # the worker as unhealthy via heartbeat and re-registration. If we do not requeue we may silently
@@ -436,7 +452,7 @@ class ZephyrCoordinator:
                 return
 
             self._worker_handles[worker_id] = worker_handle
-            self._worker_states[worker_id] = WorkerState.READY
+            self._set_worker_state(worker_id, WorkerState.READY)
             self._last_seen[worker_id] = time.monotonic()
 
             logger.info("Worker %s registered, total: %d", worker_id, len(self._worker_handles))
@@ -488,10 +504,10 @@ class ZephyrCoordinator:
 
     def _log_status(self) -> None:
         with self._lock:
-            states = list(self._worker_states.values())
+            alive = self._alive_workers
+            total_workers = len(self._worker_handles)
             retried = {idx: att for idx, att in self._task_attempts.items() if att > 0}
-        alive = sum(1 for s in states if s in {WorkerState.READY, WorkerState.BUSY})
-        dead = sum(1 for s in states if s in {WorkerState.FAILED, WorkerState.DEAD})
+        dead = total_workers - alive
         logger.info(
             "[%s] [%s] %d/%d complete, %d in-flight, %d queued, %d/%d workers alive, %d dead",
             self._execution_id,
@@ -501,7 +517,7 @@ class ZephyrCoordinator:
             len(self._in_flight),
             len(self._task_queue),
             alive,
-            len(self._worker_handles),
+            total_workers,
             dead,
         )
         if retried:
@@ -589,7 +605,7 @@ class ZephyrCoordinator:
         for worker_id, last in list(self._last_seen.items()):
             if now - last > timeout and self._worker_states.get(worker_id) not in {WorkerState.FAILED, WorkerState.DEAD}:
                 logger.warning(f"Zephyr worker {worker_id} failed to heartbeat within timeout ({now - last:.1f}s)")
-                self._worker_states[worker_id] = WorkerState.FAILED
+                self._set_worker_state(worker_id, WorkerState.FAILED)
                 self._maybe_requeue_worker_task(worker_id)
 
     def pull_task(self, worker_id: str) -> tuple[ShardTask, int, dict] | str | None:
@@ -602,10 +618,10 @@ class ZephyrCoordinator:
         """
         with self._lock:
             self._last_seen[worker_id] = time.monotonic()
-            self._worker_states[worker_id] = WorkerState.READY
+            self._set_worker_state(worker_id, WorkerState.READY)
 
             if self._shutdown_event.is_set():
-                self._worker_states[worker_id] = WorkerState.DEAD
+                self._set_worker_state(worker_id, WorkerState.DEAD)
                 return "SHUTDOWN"
 
             if self._fatal_error:
@@ -618,14 +634,14 @@ class ZephyrCoordinator:
                     # restarts the worker which re-registers and picks it up.
                     # _check_worker_group() detects permanent worker-job death
                     # as a failsafe so we never deadlock.
-                    self._worker_states[worker_id] = WorkerState.DEAD
+                    self._set_worker_state(worker_id, WorkerState.DEAD)
                     return "SHUTDOWN"
                 return None
 
             task = self._task_queue.popleft()
             attempt = self._task_attempts[task.shard_idx]
             self._in_flight[worker_id] = (task, attempt)
-            self._worker_states[worker_id] = WorkerState.BUSY
+            self._set_worker_state(worker_id, WorkerState.BUSY)
 
             config = {
                 "chunk_prefix": self._chunk_prefix,
@@ -671,7 +687,7 @@ class ZephyrCoordinator:
             self._results[shard_idx] = result
             self._completed_shards += 1
             self._in_flight.pop(worker_id, None)
-            self._worker_states[worker_id] = WorkerState.READY
+            self._set_worker_state(worker_id, WorkerState.READY)
             self._completed_counters.append(counter_snapshot)
             # Zero the in-flight counters but keep the generation watermark
             # so late heartbeats from this task are rejected.
@@ -683,7 +699,7 @@ class ZephyrCoordinator:
             self._last_seen[worker_id] = time.monotonic()
             self._assert_in_flight_consistent(worker_id, shard_idx)
             aborted = self._record_shard_failure(worker_id, ShardFailureKind.TASK, error_info)
-            self._worker_states[worker_id] = WorkerState.DEAD if aborted else WorkerState.READY
+            self._set_worker_state(worker_id, WorkerState.DEAD if aborted else WorkerState.READY)
 
     def heartbeat(self, worker_id: str, counter_snapshot: CounterSnapshot | None = None) -> None:
         self._last_seen[worker_id] = time.monotonic()
@@ -789,11 +805,9 @@ class ZephyrCoordinator:
                 if completed >= total:
                     return
 
-                # Count alive workers (READY or BUSY), not just total registered.
-                # Dead/failed workers stay in _worker_handles but can't make progress.
-                alive_workers = sum(
-                    1 for s in self._worker_states.values() if s in {WorkerState.READY, WorkerState.BUSY}
-                )
+                # _alive_workers is kept in sync by _set_worker_state on every
+                # state transition, avoiding a per-wakeup O(n_workers) scan.
+                alive_workers = self._alive_workers
 
                 if alive_workers == 0:
                     now = time.monotonic()

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -380,11 +380,6 @@ class ZephyrCoordinator:
 
         # Lock for accessing coordinator state from background thread
         self._lock = threading.Lock()
-        # Signaled on every state change that _wait_for_stage cares about
-        # (shard completed, task requeued, fatal error, worker registered).
-        # Allows _wait_for_stage to wake immediately instead of spinning up
-        # to its max 1-second poll interval.
-        self._stage_event = threading.Event()
 
         actor_ctx = current_actor()
         self._name = f"{actor_ctx.group_name}"
@@ -438,14 +433,13 @@ class ZephyrCoordinator:
                 # the worker as unhealthy via heartbeat and re-registration. If we do not requeue we may silently
                 # lose tasks.
                 self._maybe_requeue_worker_task(worker_id)
-            else:
-                self._worker_handles[worker_id] = worker_handle
-                self._worker_states[worker_id] = WorkerState.READY
-                self._last_seen[worker_id] = time.monotonic()
+                return
 
-                logger.info("Worker %s registered, total: %d", worker_id, len(self._worker_handles))
-        # Wake _wait_for_stage so it re-evaluates the alive-worker count.
-        self._stage_event.set()
+            self._worker_handles[worker_id] = worker_handle
+            self._worker_states[worker_id] = WorkerState.READY
+            self._last_seen[worker_id] = time.monotonic()
+
+            logger.info("Worker %s registered, total: %d", worker_id, len(self._worker_handles))
 
     def _coordinator_loop(self) -> None:
         """Background loop for heartbeat checking and worker job monitoring."""
@@ -682,9 +676,6 @@ class ZephyrCoordinator:
             # Zero the in-flight counters but keep the generation watermark
             # so late heartbeats from this task are rejected.
             self._worker_counters[worker_id] = CounterSnapshot.empty(counter_snapshot.generation)
-        # Wake _wait_for_stage immediately so it advances to the next stage
-        # without waiting out the polling backoff interval.
-        self._stage_event.set()
 
     def report_error(self, worker_id: str, shard_idx: int, error_info: str) -> None:
         """Worker reports a task failure. Re-queues up to MAX_SHARD_FAILURES."""
@@ -693,8 +684,6 @@ class ZephyrCoordinator:
             self._assert_in_flight_consistent(worker_id, shard_idx)
             aborted = self._record_shard_failure(worker_id, ShardFailureKind.TASK, error_info)
             self._worker_states[worker_id] = WorkerState.DEAD if aborted else WorkerState.READY
-        # Wake _wait_for_stage so it re-evaluates the alive-worker count and fatal error.
-        self._stage_event.set()
 
     def heartbeat(self, worker_id: str, counter_snapshot: CounterSnapshot | None = None) -> None:
         self._last_seen[worker_id] = time.monotonic()
@@ -760,8 +749,6 @@ class ZephyrCoordinator:
             if self._fatal_error is None:
                 logger.error("Coordinator aborted: %s", reason)
                 self._fatal_error = reason
-        # Wake _wait_for_stage so it raises ZephyrWorkerError immediately.
-        self._stage_event.set()
 
     def _start_stage(self, stage_name: str, tasks: list[ShardTask], is_last_stage: bool = False) -> None:
         """Load a new stage's tasks into the queue."""
@@ -781,9 +768,6 @@ class ZephyrCoordinator:
             # Only reset in-flight worker snapshots; completed snapshots
             # accumulate across stages for full pipeline visibility.
             self._worker_counters = {}
-        # Clear after releasing the lock so _wait_for_stage can't miss
-        # a signal set between lock release and the clear call.
-        self._stage_event.clear()
 
     def _wait_for_stage(self) -> None:
         """Block until current stage completes or error occurs."""
@@ -792,6 +776,7 @@ class ZephyrCoordinator:
         start_time = time.monotonic()
         all_dead_since: float | None = None
         no_workers_timeout = self._no_workers_timeout
+        stage_done = threading.Event()
 
         while True:
             with self._lock:
@@ -835,13 +820,7 @@ class ZephyrCoordinator:
                 last_log_completed = completed
                 backoff.reset()
 
-            # Wait for a state-change signal (shard completed, error, worker registered)
-            # with a timeout as backstop for the alive-worker check and log lines.
-            # _stage_event is set by report_result/report_error/abort/register_worker,
-            # so the stage transition is detected within microseconds of the last
-            # shard completing rather than after up to the full backoff interval.
-            self._stage_event.wait(timeout=backoff.next_interval())
-            self._stage_event.clear()
+            stage_done.wait(timeout=backoff.next_interval())
 
     def _collect_results(self) -> dict[int, TaskResult]:
         """Return results for the completed stage."""

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -47,6 +47,7 @@ from typing import Any
 import cloudpickle
 import msgspec
 import zstandard as zstd
+from iris.env_resources import TaskResources
 from rigging.filesystem import open_url, url_to_fs
 from rigging.timing import log_time
 
@@ -107,17 +108,22 @@ _ZSTD_COMPRESS_LEVEL = 3
 # dispatch overhead), smaller = lower per-iterator read memory.
 _SUB_BATCH_SIZE = 1024
 
-# Total byte budget for all shard buffers held by one ScatterWriter.
-# When the estimate exceeds this, the largest buffer is flushed. Byte-based
-# budgeting is safer than a fixed row count because item size varies widely
-# (a 100K-row limit is fine for tiny dicts but OOMs on large documents).
-_SCATTER_WRITE_BUFFER_BYTES = 256 * 1024 * 1024  # 256 MB
+# Fraction of cgroup memory allocated to scatter write buffers.
+_SCATTER_WRITE_BUFFER_FRACTION = 0.25
+# Static fallback used when the cgroup memory limit cannot be determined.
+_SCATTER_WRITE_BUFFER_BYTES_FALLBACK = 256 * 1024 * 1024  # 256 MB
 
-# Conservative bytes-per-item estimate used before the first flush samples
-# actual sizes. 512 bytes covers a typical dict with a few string fields plus
-# Python object overhead; the estimate is replaced by the measured average
-# after the first sample is taken.
-_INITIAL_ITEM_BYTES_ESTIMATE = 512
+
+def _default_scatter_write_buffer_bytes() -> int:
+    """Return the scatter write buffer budget based on the cgroup memory limit.
+
+    Uses 25% of the container memory limit so the budget scales with the
+    worker size. Falls back to 256 MB when the limit cannot be read.
+    """
+    memory = TaskResources.from_environment().memory_bytes
+    if memory > 0:
+        return int(memory * _SCATTER_WRITE_BUFFER_FRACTION)
+    return _SCATTER_WRITE_BUFFER_BYTES_FALLBACK
 
 
 # ---------------------------------------------------------------------------
@@ -479,14 +485,16 @@ class ScatterWriter:
         source_shard: int = 0,
         sort_fn: Callable | None = None,
         combiner_fn: Callable | None = None,
-        buffer_limit_bytes: int = _SCATTER_WRITE_BUFFER_BYTES,
+        buffer_limit_bytes: int | None = None,
     ) -> None:
         self._data_path = data_path
         self._key_fn = key_fn
         self._num_output_shards = num_output_shards
         self._source_shard = source_shard
         self._combiner_fn = combiner_fn
-        self._buffer_limit_bytes = buffer_limit_bytes
+        self._buffer_limit_bytes = (
+            buffer_limit_bytes if buffer_limit_bytes is not None else _default_scatter_write_buffer_bytes()
+        )
 
         if sort_fn is not None:
             captured_sort_fn = sort_fn
@@ -504,10 +512,16 @@ class ScatterWriter:
         self._avg_item_bytes: float = 0.0
         self._sampled_avg = False
         self._n_chunks_written = 0
+        self._mid_write_flushes: int = 0
         # Running total of rows across all shard buffers; used with
         # _item_bytes_estimate to gate byte-budget flushes.
         self._total_buffer_rows: int = 0
-        self._item_bytes_estimate: float = _INITIAL_ITEM_BYTES_ESTIMATE
+        self._peak_buffer_rows: int = 0
+        # Estimate refined in two steps: (1) first-item pickle measurement in
+        # write(), (2) 100-item sample average in _flush(). Logging both lets
+        # operators see how representative the first item was.
+        self._item_bytes_estimate: float = 0.0  # set on first write()
+        self._first_item_bytes: float = 0.0  # logged at close for comparison
 
         ensure_parent_dir(data_path)
         fs, fs_path = url_to_fs(data_path)
@@ -543,10 +557,20 @@ class ScatterWriter:
 
     def write(self, item: Any) -> None:
         """Route a single item to its target shard buffer, flushing when over budget."""
+        if self._total_buffer_rows == 0:
+            # Calibrate from the first item before any batching occurs. A
+            # hardcoded default (e.g. 512 B) can be orders of magnitude off for
+            # large documents, allowing millions of rows to accumulate before the
+            # first flush fires. One real measurement is far safer.
+            self._item_bytes_estimate = float(len(pickle.dumps(item, protocol=pickle.HIGHEST_PROTOCOL)))
+            self._first_item_bytes = self._item_bytes_estimate
+
         key = self._key_fn(item)
         target = deterministic_hash(key) % self._num_output_shards
         self._buffers[target].append(item)
         self._total_buffer_rows += 1
+        if self._total_buffer_rows > self._peak_buffer_rows:
+            self._peak_buffer_rows = self._total_buffer_rows
 
         if self._total_buffer_rows * self._item_bytes_estimate > self._buffer_limit_bytes:
             largest = max(self._buffers, key=lambda t: len(self._buffers[t]))
@@ -554,14 +578,33 @@ class ScatterWriter:
             self._flush(largest, self._buffers[largest])
             self._buffers[largest] = []
             self._total_buffer_rows -= rows_flushed
+            self._mid_write_flushes += 1
 
     def close(self) -> ListShard:
         """Flush remaining buffers, write sidecar, return ListShard."""
+        close_flushes = 0
         with log_time(f"Flushing remaining buffers for {self._data_path}"):
             for target, buf in sorted(self._buffers.items()):
                 if buf:
                     self._flush(target, buf)
+                    close_flushes += 1
         self._out.close()
+
+        measured_avg = self._avg_item_bytes if self._sampled_avg else self._item_bytes_estimate
+        logger.info(
+            "[shard %d] scatter write done: %d mid-write flushes + %d at close = %d total; "
+            "first-item estimate=%.0f B, measured avg=%.0f B (%.1fx), "
+            "peak buffered=%d rows, budget=%d MB",
+            self._source_shard,
+            self._mid_write_flushes,
+            close_flushes,
+            self._mid_write_flushes + close_flushes,
+            self._first_item_bytes,
+            measured_avg,
+            measured_avg / self._first_item_bytes if self._first_item_bytes > 0 else 0.0,
+            self._peak_buffer_rows,
+            self._buffer_limit_bytes // (1024 * 1024),
+        )
 
         sidecar: dict = {
             "shards": {str(k): v for k, v in self._shard_ranges.items()},
@@ -590,7 +633,7 @@ def _write_scatter(
     num_output_shards: int,
     sort_fn: Callable | None = None,
     combiner_fn: Callable | None = None,
-    buffer_limit_bytes: int = _SCATTER_WRITE_BUFFER_BYTES,
+    buffer_limit_bytes: int | None = None,
 ) -> ListShard:
     """Route items to target shards, buffer, sort, and append zstd chunks.
 

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -98,8 +98,17 @@ _SCATTER_DATA_SUFFIX = ".shuffle"
 # ScatterReader. Sidecars are small msgpack files (a few KB) and reads are
 # GCS GET-bound, so a modest pool keeps latency low without thrashing.
 _SIDECAR_READ_CONCURRENCY = 32
-# Number of items sampled from the first flush to estimate avg_item_bytes.
+# Items sampled on the first flush to establish an avg_item_bytes baseline.
 _SCATTER_SAMPLE_SIZE = 100
+# Items sampled on each subsequent flush to track item-size drift cheaply.
+_SCATTER_ONGOING_SAMPLE_SIZE = 10
+# How often (in items written) to re-sample one item's pickle size and update
+# the EMA estimate in write(). This is independent of flush-time sampling and
+# ensures the estimate tracks drift even when no flush has fired yet.
+_ESTIMATE_WRITE_SAMPLE_INTERVAL = 10
+# EMA weight given to each new observation. 0.3 converges to a 2x step-change
+# in item size within ~3 samples while staying stable under small fluctuations.
+_ESTIMATE_EMA_ALPHA = 0.3
 # Fraction of total memory budgeted for read-side decompression buffers.
 _SCATTER_READ_BUFFER_FRACTION = 0.25
 
@@ -532,12 +541,21 @@ class ScatterWriter:
             buf = _apply_combiner(buf, self._key_fn, self._combiner_fn)
         buf.sort(key=self._sort_key)
 
-        if not self._sampled_avg and buf:
-            sample = buf[: min(len(buf), _SCATTER_SAMPLE_SIZE)]
-            total_bytes = sum(len(pickle.dumps(item, protocol=pickle.HIGHEST_PROTOCOL)) for item in sample)
-            self._avg_item_bytes = total_bytes / len(sample)
+        if buf:
+            # Sample a subset of the buffer to update the byte-size estimate.
+            # First flush: larger sample for a good baseline. Subsequent flushes:
+            # smaller sample to track drift cheaply via EMA. This prevents OOM
+            # when early items are small but later items are large — the estimate
+            # stays current rather than being frozen at the first-flush value.
+            n = _SCATTER_SAMPLE_SIZE if not self._sampled_avg else _SCATTER_ONGOING_SAMPLE_SIZE
+            sample = buf[: min(len(buf), n)]
+            observed = sum(len(pickle.dumps(item, protocol=pickle.HIGHEST_PROTOCOL)) for item in sample) / len(sample)
+            if not self._sampled_avg:
+                self._avg_item_bytes = observed
+                self._sampled_avg = True
+            else:
+                self._avg_item_bytes = (1 - _ESTIMATE_EMA_ALPHA) * self._avg_item_bytes + _ESTIMATE_EMA_ALPHA * observed
             self._item_bytes_estimate = self._avg_item_bytes
-            self._sampled_avg = True
 
         frame = _write_chunk_frame(buf)
         offset = self._out.tell()
@@ -557,13 +575,21 @@ class ScatterWriter:
 
     def write(self, item: Any) -> None:
         """Route a single item to its target shard buffer, flushing when over budget."""
-        if self._total_buffer_rows == 0:
-            # Calibrate from the first item before any batching occurs. A
-            # hardcoded default (e.g. 512 B) can be orders of magnitude off for
-            # large documents, allowing millions of rows to accumulate before the
-            # first flush fires. One real measurement is far safer.
-            self._item_bytes_estimate = float(len(pickle.dumps(item, protocol=pickle.HIGHEST_PROTOCOL)))
-            self._first_item_bytes = self._item_bytes_estimate
+        if self._total_buffer_rows % _ESTIMATE_WRITE_SAMPLE_INTERVAL == 0:
+            # Periodically measure a single item's serialised size and apply EMA.
+            # This runs in write() — not just in _flush() — so the estimate tracks
+            # size drift even when no flush has fired yet (the flush EMA is a
+            # closed loop: if the estimate is too low no flush fires, so it never
+            # updates). Interval-based sampling amortises the pickle.dumps cost
+            # to 1-in-10 items while still catching step-changes within a few rows.
+            observed = float(len(pickle.dumps(item, protocol=pickle.HIGHEST_PROTOCOL)))
+            if self._total_buffer_rows == 0:
+                self._item_bytes_estimate = observed
+                self._first_item_bytes = observed
+            else:
+                self._item_bytes_estimate = (
+                    1 - _ESTIMATE_EMA_ALPHA
+                ) * self._item_bytes_estimate + _ESTIMATE_EMA_ALPHA * observed
 
         key = self._key_fn(item)
         target = deterministic_hash(key) % self._num_output_shards

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -23,6 +23,12 @@ near-constant: one buffered item plus the zstd decoder state plus the
 chunk's compressed bytes (typically a few MB). This bound is essential for
 skewed shuffles where one reducer pulls disproportionate data and the
 external-sort fan-in opens hundreds of chunk iterators at once.
+
+Write-side memory is bounded by a byte budget (``_SCATTER_WRITE_BUFFER_BYTES``)
+rather than a fixed row count. When the estimated total bytes across all
+shard buffers exceeds the budget, the largest buffer is flushed. This prevents
+OOM on skewed or large-item workloads where a row-count limit provides no
+reliable bound.
 """
 
 from __future__ import annotations
@@ -45,7 +51,7 @@ from rigging.filesystem import open_url, url_to_fs
 from rigging.timing import log_time
 
 from zephyr.plan import deterministic_hash
-from zephyr.writers import INTERMEDIATE_CHUNK_SIZE, ensure_parent_dir
+from zephyr.writers import ensure_parent_dir
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +106,18 @@ _ZSTD_COMPRESS_LEVEL = 3
 # Items per pickle.dump call within a chunk. Larger = faster (less per-call
 # dispatch overhead), smaller = lower per-iterator read memory.
 _SUB_BATCH_SIZE = 1024
+
+# Total byte budget for all shard buffers held by one ScatterWriter.
+# When the estimate exceeds this, the largest buffer is flushed. Byte-based
+# budgeting is safer than a fixed row count because item size varies widely
+# (a 100K-row limit is fine for tiny dicts but OOMs on large documents).
+_SCATTER_WRITE_BUFFER_BYTES = 256 * 1024 * 1024  # 256 MB
+
+# Conservative bytes-per-item estimate used before the first flush samples
+# actual sizes. 512 bytes covers a typical dict with a few string fields plus
+# Python object overhead; the estimate is replaced by the measured average
+# after the first sample is taken.
+_INITIAL_ITEM_BYTES_ESTIMATE = 512
 
 
 # ---------------------------------------------------------------------------
@@ -447,6 +465,10 @@ class ScatterWriter:
     Items are routed to target shards by ``key_fn``, buffered, optionally
     combined and sorted, then flushed as zstd frames. A JSON sidecar is
     written on close.
+
+    Flushing is byte-budget-based: when the estimated total bytes across all
+    shard buffers exceeds ``buffer_limit_bytes``, the largest buffer is flushed.
+    This bounds peak RSS regardless of item count or output shard count.
     """
 
     def __init__(
@@ -457,13 +479,14 @@ class ScatterWriter:
         source_shard: int = 0,
         sort_fn: Callable | None = None,
         combiner_fn: Callable | None = None,
+        buffer_limit_bytes: int = _SCATTER_WRITE_BUFFER_BYTES,
     ) -> None:
         self._data_path = data_path
         self._key_fn = key_fn
         self._num_output_shards = num_output_shards
         self._source_shard = source_shard
         self._combiner_fn = combiner_fn
-        self._chunk_size = INTERMEDIATE_CHUNK_SIZE
+        self._buffer_limit_bytes = buffer_limit_bytes
 
         if sort_fn is not None:
             captured_sort_fn = sort_fn
@@ -481,6 +504,10 @@ class ScatterWriter:
         self._avg_item_bytes: float = 0.0
         self._sampled_avg = False
         self._n_chunks_written = 0
+        # Running total of rows across all shard buffers; used with
+        # _item_bytes_estimate to gate byte-budget flushes.
+        self._total_buffer_rows: int = 0
+        self._item_bytes_estimate: float = _INITIAL_ITEM_BYTES_ESTIMATE
 
         ensure_parent_dir(data_path)
         fs, fs_path = url_to_fs(data_path)
@@ -495,6 +522,7 @@ class ScatterWriter:
             sample = buf[: min(len(buf), _SCATTER_SAMPLE_SIZE)]
             total_bytes = sum(len(pickle.dumps(item, protocol=pickle.HIGHEST_PROTOCOL)) for item in sample)
             self._avg_item_bytes = total_bytes / len(sample)
+            self._item_bytes_estimate = self._avg_item_bytes
             self._sampled_avg = True
 
         frame = _write_chunk_frame(buf)
@@ -514,13 +542,18 @@ class ScatterWriter:
             )
 
     def write(self, item: Any) -> None:
-        """Route a single item to its target shard buffer, flushing when full."""
+        """Route a single item to its target shard buffer, flushing when over budget."""
         key = self._key_fn(item)
         target = deterministic_hash(key) % self._num_output_shards
         self._buffers[target].append(item)
-        if self._chunk_size > 0 and len(self._buffers[target]) >= self._chunk_size:
-            self._flush(target, self._buffers[target])
-            self._buffers[target] = []
+        self._total_buffer_rows += 1
+
+        if self._total_buffer_rows * self._item_bytes_estimate > self._buffer_limit_bytes:
+            largest = max(self._buffers, key=lambda t: len(self._buffers[t]))
+            rows_flushed = len(self._buffers[largest])
+            self._flush(largest, self._buffers[largest])
+            self._buffers[largest] = []
+            self._total_buffer_rows -= rows_flushed
 
     def close(self) -> ListShard:
         """Flush remaining buffers, write sidecar, return ListShard."""
@@ -557,6 +590,7 @@ def _write_scatter(
     num_output_shards: int,
     sort_fn: Callable | None = None,
     combiner_fn: Callable | None = None,
+    buffer_limit_bytes: int = _SCATTER_WRITE_BUFFER_BYTES,
 ) -> ListShard:
     """Route items to target shards, buffer, sort, and append zstd chunks.
 
@@ -573,6 +607,7 @@ def _write_scatter(
         source_shard=source_shard,
         sort_fn=sort_fn,
         combiner_fn=combiner_fn,
+        buffer_limit_bytes=buffer_limit_bytes,
     )
     for item in items:
         writer.write(item)

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -11,6 +11,7 @@ from zephyr.plan import deterministic_hash
 from zephyr.shuffle import (
     ScatterFileIterator,
     ScatterReader,
+    ScatterWriter,
     _write_chunk_frame,
     _write_scatter,
 )
@@ -169,6 +170,52 @@ def test_scatter_handles_arbitrary_python_objects(tmp_path):
         return (x["k"], repr(x["v"]))
 
     assert sorted(recovered, key=_ord) == sorted(items, key=_ord)
+
+
+# ---------------------------------------------------------------------------
+# Byte-budget flushing
+# ---------------------------------------------------------------------------
+
+
+def test_scatter_byte_budget_flushes_mid_write(tmp_path):
+    """A tiny byte budget forces flushes during write, not only at close."""
+    num_shards = 2
+    items = [{"k": i % num_shards, "v": i} for i in range(200)]
+    data_path = str(tmp_path / "shard-0000.shuffle")
+
+    # Budget of 1 byte forces a flush on every write after the first.
+    writer = ScatterWriter(
+        data_path=data_path,
+        key_fn=_key,
+        num_output_shards=num_shards,
+        buffer_limit_bytes=1,
+    )
+    for item in items:
+        writer.write(item)
+    writer.close()
+
+    # Multiple chunks must have been written (not just the close-time flush).
+    scatter_paths = [data_path]
+    total_chunks = sum(ScatterReader.from_sidecars(scatter_paths, s).total_chunks for s in range(num_shards))
+    assert total_chunks > 2, f"expected >2 chunks with 1-byte budget, got {total_chunks}"
+
+
+def test_scatter_byte_budget_preserves_all_items(tmp_path):
+    """Items are not lost or duplicated when byte-budget flushes fire mid-write."""
+    num_shards = 3
+    items = [{"k": i % num_shards, "v": i} for i in range(300)]
+    scatter_paths = _build_shard(
+        tmp_path,
+        items,
+        num_output_shards=num_shards,
+    )
+
+    recovered = []
+    for shard_idx in range(num_shards):
+        shard = ScatterReader.from_sidecars(scatter_paths, shard_idx)
+        recovered.extend(list(shard))
+
+    assert sorted(recovered, key=lambda x: x["v"]) == sorted(items, key=lambda x: x["v"])
 
 
 # ---------------------------------------------------------------------------

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -201,7 +201,7 @@ def test_scatter_byte_budget_flushes_mid_write(tmp_path):
 
 
 def test_scatter_estimate_tracks_skewed_items(tmp_path):
-    """Estimate updates after each flush so large late items still trigger budget flushes."""
+    """Write-time EMA sampling catches large late items and triggers mid-write flushes."""
     num_shards = 1
     data_path = str(tmp_path / "shard-0000.shuffle")
 

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -235,6 +235,42 @@ def test_scatter_estimate_tracks_skewed_items(tmp_path):
     assert writer._mid_write_flushes > 0, "expected mid-write flushes for large items"
 
 
+def test_scatter_estimate_adapts_to_gradual_drift(tmp_path):
+    """Write-time EMA bounds peak buffered rows even when item sizes grow gradually."""
+    num_shards = 1
+    data_path = str(tmp_path / "shard-0000.shuffle")
+
+    # Items grow linearly from ~100 B to ~100 KB across 200 records.
+    # If all 200 were buffered at once the real RSS would be ~10 MB.
+    n_items = 200
+    items = [{"k": 0, "v": "x" * (100 + i * 500)} for i in range(n_items)]
+
+    # 500 KB budget. With a frozen first-item estimate (~110 B) the budget check
+    # would read 200 * 110 = 22 KB < 500 KB and never flush mid-write, letting
+    # all items accumulate. With EMA adaptation the estimate tracks the growing
+    # sizes and flushes before peak RSS reaches the budget.
+    budget = 500_000
+    writer = ScatterWriter(
+        data_path=data_path,
+        key_fn=_key,
+        num_output_shards=num_shards,
+        buffer_limit_bytes=budget,
+    )
+    for item in items:
+        writer.write(item)
+    writer.close()
+
+    scatter_paths = [data_path]
+    recovered = list(ScatterReader.from_sidecars(scatter_paths, 0))
+    assert sorted(recovered, key=lambda x: x["v"]) == sorted(items, key=lambda x: x["v"])
+
+    assert writer._mid_write_flushes > 0, "expected mid-write flushes as item sizes grew"
+    assert writer._peak_buffer_rows < n_items, (
+        f"peak_buffer_rows={writer._peak_buffer_rows} should be < {n_items}; "
+        "a frozen estimate lets all items accumulate before close()"
+    )
+
+
 def test_scatter_byte_budget_preserves_all_items(tmp_path):
     """Items are not lost or duplicated when byte-budget flushes fire mid-write."""
     num_shards = 3

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -200,6 +200,41 @@ def test_scatter_byte_budget_flushes_mid_write(tmp_path):
     assert total_chunks > 2, f"expected >2 chunks with 1-byte budget, got {total_chunks}"
 
 
+def test_scatter_estimate_tracks_skewed_items(tmp_path):
+    """Estimate updates after each flush so large late items still trigger budget flushes."""
+    num_shards = 1
+    data_path = str(tmp_path / "shard-0000.shuffle")
+
+    # Start with tiny items, then switch to large items. With a frozen estimate
+    # the budget check would never fire for the large items. With EMA updates it
+    # should: _item_bytes_estimate rises and eventually exceeds budget / rows.
+    small_items = [{"k": 0, "v": "x"} for _ in range(50)]
+    large_items = [{"k": 0, "v": "y" * 50_000} for _ in range(10)]
+
+    # Budget large enough that small items alone never flush, but one large
+    # item should push the estimate over threshold quickly.
+    budget = 10_000  # 10 KB — well under 10 * 50 KB large items
+    writer = ScatterWriter(
+        data_path=data_path,
+        key_fn=_key,
+        num_output_shards=num_shards,
+        buffer_limit_bytes=budget,
+    )
+    for item in small_items + large_items:
+        writer.write(item)
+    writer.close()
+
+    # All items must survive the skewed flush pattern.
+    scatter_paths = [data_path]
+    recovered = list(ScatterReader.from_sidecars(scatter_paths, 0))
+    all_items = small_items + large_items
+    assert sorted(recovered, key=lambda x: x["v"]) == sorted(all_items, key=lambda x: x["v"])
+
+    # The estimate must have been updated: mid-write flushes should have fired
+    # for the large items (not just at close).
+    assert writer._mid_write_flushes > 0, "expected mid-write flushes for large items"
+
+
 def test_scatter_byte_budget_preserves_all_items(tmp_path):
     """Items are not lost or duplicated when byte-budget flushes fire mid-write."""
     num_shards = 3


### PR DESCRIPTION
Replace the fixed 100K-row-per-shard flush threshold in ScatterWriter with a total byte budget (default 256 MB) across all shard buffers. When the estimated total bytes exceeds the budget, the largest shard buffer is flushed immediately. This bounds write-side RSS regardless of item size or output shard count — previously, large items or many output shards could accumulate unbounded memory before close() flushed everything at once.