### PR TITLE
Fix Arrow Flight host resolution and skip PlantCAD dry-run

### DIFF
--- a/experiments/plantcad/exp1729_plantcad_eval.py
+++ b/experiments/plantcad/exp1729_plantcad_eval.py
@@ -28,6 +28,8 @@ from marin.utilities.json_encoder import CustomJsonEncoder
 
 logger = logging.getLogger(__name__)
 
+# nodryrun
+
 
 # -----------------------------------------------------------------------------
 # Configuration

--- a/lib/marin/src/marin/rl/weight_transfer/arrow_flight.py
+++ b/lib/marin/src/marin/rl/weight_transfer/arrow_flight.py
@@ -95,8 +95,8 @@ def _resolve_advertise_host() -> str:
         pass
 
     hostname = socket.gethostname()
-    # gRPC's c-ares DNS resolver can't handle .local (mDNS) hostnames
-    if hostname.endswith(".local"):
+    # gRPC's c-ares DNS resolver can't handle .local (mDNS) or .localdomain hostnames
+    if hostname.endswith(".local") or hostname.endswith(".localdomain"):
         return "localhost"
     return hostname
 


### PR DESCRIPTION
Tests were failing locally, I let Claude loose to fix it (interestingly, since I cannot add labels to PRs, Claude can't label it as `agent-generated`).

Extend _resolve_advertise_host to treat .localdomain suffixes (e.g. Mac.localdomain) as localhost-only, the same way .local is already handled. gRPC's c-ares resolver resolves these to a network IP that can't reach the server bound to 0.0.0.0, causing connection refused in local tests.

Mark exp1729_plantcad_eval.py with nodryrun since it imports torch at module level, which is not available in the dev environment.