### PR TITLE
datakit-smoke: verify source staging in us-central1

### DIFF
--- a/.github/workflows/marin-datakit-smoke.yaml
+++ b/.github/workflows/marin-datakit-smoke.yaml
@@ -184,13 +184,52 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
+  # Parallel lane: verify every DatakitSource.staged_path resolves to a
+  # non-empty prefix under gs://marin-us-central1. Cheap (metadata only) and
+  # independent of the ferry, so runs alongside datakit-smoke.
+  datakit-sources-staged:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: datakit-sources-staged
+      cancel-in-progress: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-packages --extra=cpu --no-default-groups
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
+
+      - name: Verify datakit source staging paths
+        shell: bash -l {0}
+        run: .venv/bin/python scripts/datakit/validate_source_staging.py
+
   # Separate job so Slack always fires, even if the main job is force-killed
-  # after its grace window. `needs.datakit-smoke.result` reflects the main
-  # job outcome; failure()/cancelled() context functions only see this job's
+  # after its grace window. `needs.*.result` reflects the upstream job
+  # outcomes; failure()/cancelled() context functions only see this job's
   # steps.
   notify-slack:
-    needs: datakit-smoke
-    if: always() && (needs.datakit-smoke.result == 'failure' || needs.datakit-smoke.result == 'cancelled') && github.event_name == 'schedule'
+    needs: [datakit-smoke, datakit-sources-staged]
+    if: |
+      always() && github.event_name == 'schedule' && (
+        needs.datakit-smoke.result == 'failure' || needs.datakit-smoke.result == 'cancelled'
+        || needs.datakit-sources-staged.result == 'failure' || needs.datakit-sources-staged.result == 'cancelled'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Download Slack message

--- a/scripts/datakit/validate_source_staging.py
+++ b/scripts/datakit/validate_source_staging.py
@@ -1,12 +1,13 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Verify every Datakit source's staged_path exists under gs://marin-us-central1.
+"""Verify every Datakit source's staged dump terminated SUCCESS.
 
 Each :class:`marin.datakit.sources.DatakitSource` with a non-empty ``staged_path``
-must resolve to a GCS prefix with at least one object — otherwise the ferry's
-verify-only download step will 404 at runtime. Enforced daily as a parallel
-lane of the datakit-smoke workflow.
+must resolve to a GCS prefix under ``gs://marin-us-central1`` whose
+``.executor_status`` file (plain text or legacy JSON-lines) reports ``SUCCESS`` —
+otherwise the ferry's verify-only download step is pointing at a partial or
+missing dump. Enforced daily as a parallel lane of the datakit-smoke workflow.
 """
 
 import logging
@@ -14,22 +15,21 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 
 from marin.datakit.sources import all_sources
-from rigging.filesystem import url_to_fs
+from marin.execution.executor_step_status import STATUS_SUCCESS, StatusFile
 from rigging.log_setup import configure_logging
 
 logger = logging.getLogger(__name__)
 
 BUCKET = "gs://marin-us-central1"
 MAX_WORKERS = 16
+WORKER_ID = "datakit-smoke-sources-check"
 
 
-def _check(full_path: str) -> tuple[str, bool]:
-    fs, _ = url_to_fs(full_path)
-    try:
-        children = fs.ls(full_path, detail=False)
-    except FileNotFoundError:
-        return full_path, False
-    return full_path, bool(children)
+def _check(staged_path: str) -> tuple[str, str]:
+    """Return (output_path, status) where status is ``SUCCESS`` or a failure token."""
+    output_path = f"{BUCKET}/{staged_path}"
+    status = StatusFile(output_path, worker_id=WORKER_ID).status
+    return output_path, status or "MISSING"
 
 
 def main() -> None:
@@ -37,20 +37,19 @@ def main() -> None:
     sources = all_sources()
     unique_paths = sorted({s.staged_path for s in sources.values() if s.staged_path})
     logger.info("Verifying %d unique staged paths under %s", len(unique_paths), BUCKET)
-    urls = [f"{BUCKET}/{p}" for p in unique_paths]
 
-    missing: list[str] = []
+    bad: list[tuple[str, str]] = []
     with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
-        for full, exists in pool.map(_check, urls):
-            if exists:
-                logger.debug("OK: %s", full)
+        for output_path, status in pool.map(_check, unique_paths):
+            if status == STATUS_SUCCESS:
+                logger.debug("OK: %s", output_path)
             else:
-                logger.error("MISSING: %s", full)
-                missing.append(full)
+                logger.error("%s: %s", status, output_path)
+                bad.append((output_path, status))
 
-    if missing:
-        raise SystemExit(f"{len(missing)}/{len(unique_paths)} staged paths missing under {BUCKET}")
-    logger.info("All %d staged paths present under %s", len(unique_paths), BUCKET)
+    if bad:
+        raise SystemExit(f"{len(bad)}/{len(unique_paths)} staged paths not SUCCESS under {BUCKET}")
+    logger.info("All %d staged paths report SUCCESS under %s", len(unique_paths), BUCKET)
 
 
 if __name__ == "__main__":

--- a/scripts/datakit/validate_source_staging.py
+++ b/scripts/datakit/validate_source_staging.py
@@ -1,0 +1,63 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify every Datakit source's staged_path exists under gs://marin-us-central1.
+
+Each :class:`marin.datakit.sources.DatakitSource` with a non-empty ``staged_path``
+must resolve to a GCS prefix with at least one object — otherwise the ferry's
+verify-only download step will 404 at runtime. Enforced daily as a parallel
+lane of the datakit-smoke workflow.
+"""
+
+import logging
+import sys
+from concurrent.futures import ThreadPoolExecutor
+
+from marin.datakit.sources import all_sources
+from rigging.filesystem import url_to_fs
+from rigging.log_setup import configure_logging
+
+logger = logging.getLogger(__name__)
+
+BUCKET = "gs://marin-us-central1"
+MAX_WORKERS = 16
+
+
+def _check(full_path: str) -> tuple[str, bool]:
+    fs, _ = url_to_fs(full_path)
+    try:
+        children = fs.ls(full_path, detail=False)
+    except FileNotFoundError:
+        return full_path, False
+    return full_path, bool(children)
+
+
+def main() -> None:
+    configure_logging()
+    sources = all_sources()
+    unique_paths = sorted({s.staged_path for s in sources.values() if s.staged_path})
+    logger.info("Verifying %d unique staged paths under %s", len(unique_paths), BUCKET)
+    urls = [f"{BUCKET}/{p}" for p in unique_paths]
+
+    missing: list[str] = []
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        for full, exists in pool.map(_check, urls):
+            if exists:
+                logger.debug("OK: %s", full)
+            else:
+                logger.error("MISSING: %s", full)
+                missing.append(full)
+
+    if missing:
+        raise SystemExit(f"{len(missing)}/{len(unique_paths)} staged paths missing under {BUCKET}")
+    logger.info("All %d staged paths present under %s", len(unique_paths), BUCKET)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as exc:
+        logger.error("Validation failed: %s", exc)
+        sys.exit(1)


### PR DESCRIPTION
* new parallel job `datakit-sources-staged` in `marin-datakit-smoke.yaml`, runs alongside the ferry on the same schedule
* add `scripts/datakit/validate_source_staging.py` — `ThreadPoolExecutor` over `StatusFile(<full_path>).status` for the 70 unique `DatakitSource.staged_path` prefixes under `gs://marin-us-central1`, exits non-zero with a per-path `<status>: <url>` report when any is not `SUCCESS` [^1]
  * covers every source with a non-None `staged_path`, not just the pinned subset
  * reuses `marin.execution.executor_step_status.StatusFile` so both the plain-text and legacy JSON-lines `.executor_status` formats are handled
* `notify-slack` now fans in from both lanes via `needs: [datakit-smoke, datakit-sources-staged]` — either failure pages Slack on scheduled runs
* claude-triage stays scoped to the ferry; the sources lane is self-describing from its own error output
* local probe today: 70/70 paths report `SUCCESS` — the two previous offenders (`common_corpus_english-b78a5c1`, `finetranslations_d17a789b`) were dropped from the registry on main, so this lane goes green on day one

[^1]: `fs.ls` non-empty was the earlier bar, which both of the now-dropped paths passed; tightening to `SUCCESS` is the point — a half-written or abandoned dump must not quietly flow into a ferry.