### PR TITLE
datakit: download_step/normalize_step methods on DatakitSource

### DIFF
--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -11,6 +11,10 @@ ferry's normalize step needs to preserve provenance.
 from dataclasses import dataclass
 from functools import cache
 
+from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.normalize import normalize_step as _normalize_step
+from marin.execution.step_spec import StepSpec
+
 
 @dataclass(frozen=True)
 class DatakitSource:
@@ -75,6 +79,48 @@ class DatakitSource:
     Used as the initial per-source mixing weight. ``None`` means unknown —
     replace with a measured value from the tokenize step's stats later.
     """
+
+    def download_step(self) -> StepSpec:
+        """Build the canonical HF download ``StepSpec`` for this source.
+
+        Output lands at ``staged_path`` if set, else the executor's computed
+        path. Raises :class:`ValueError` if ``revision`` is unset or
+        ``hf_dataset_id`` is empty — sources with ``revision=None`` or
+        API-sourced entries (``nsf_awards``) need bespoke wiring. Filter via
+        :func:`pinned_sources` to stay inside the set this method handles.
+        """
+        if not self.hf_dataset_id:
+            raise ValueError(f"{self.name}: cannot build download_step without an hf_dataset_id")
+        if self.revision is None:
+            raise ValueError(f"{self.name}: cannot build download_step for unpinned source (revision=None)")
+        return download_hf_step(
+            f"raw/{self.hf_dataset_id.replace('/', '__')}",
+            hf_dataset_id=self.hf_dataset_id,
+            revision=self.revision,
+            hf_urls_glob=list(self.hf_urls_glob) if self.hf_urls_glob else None,
+            override_output_path=self.staged_path,
+        )
+
+    def normalize_step(self, download: StepSpec | None = None) -> StepSpec:
+        """Build the canonical ``normalize`` ``StepSpec`` for this source.
+
+        Output lands at ``$MARIN_PREFIX/normalized/<name>-<hash>/`` — a
+        run-independent artifact any downstream consumer can reference. If
+        ``download`` is omitted, ``download_step()`` is called to construct a
+        fresh one; callers composing a DAG with a shared family download
+        should pass it in explicitly so normalize depends on the same
+        ``StepSpec`` the rest of the graph uses.
+        """
+        dl = download if download is not None else self.download_step()
+        input_path = f"{dl.output_path}/{self.data_subdir}" if self.data_subdir else dl.output_path
+        return _normalize_step(
+            name=f"normalized/{self.name}",
+            download=dl,
+            text_field=self.text_field,
+            id_field=self.id_field,
+            input_path=input_path,
+            file_extensions=self.file_extensions,
+        )
 
 
 @cache

--- a/tests/datakit/test_sources_methods.py
+++ b/tests/datakit/test_sources_methods.py
@@ -1,0 +1,101 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavior tests for ``DatakitSource.download_step`` and ``.normalize_step``."""
+
+import pytest
+
+from marin.datakit.normalize import DedupMode
+from marin.datakit.sources import DatakitSource, all_sources
+
+
+def test_download_step_builds_for_pinned_source():
+    src = all_sources()["coderforge"]
+    step = src.download_step()
+    assert step.name.startswith("raw/")
+    # Staged-path sources pin the output; unstaged ones use the default.
+    if src.staged_path is not None:
+        assert step.override_output_path == src.staged_path
+
+
+def test_normalize_step_names_and_chains_on_download():
+    src = all_sources()["coderforge"]
+    norm = src.normalize_step()
+    assert norm.name == "normalized/coderforge"
+    # Normalize depends on its download, not on any run-specific step.
+    assert len(norm.deps) == 1
+    assert norm.deps[0].name.startswith("raw/")
+
+
+def test_normalize_step_reuses_caller_supplied_download():
+    """Shared family downloads must be honored — normalize should chain to the
+    same StepSpec passed in, not build a fresh one."""
+    src = all_sources()["nemotron_cc_v2_1/high_quality"]
+    dl = src.download_step()
+    norm = src.normalize_step(dl)
+    assert norm.deps[0] is dl
+
+
+def test_normalize_step_applies_data_subdir():
+    """data_subdir ⇒ normalize's input_path joins download.output_path + subdir."""
+    src = all_sources()["nemotron_cc_v2_1/high_quality"]
+    assert src.data_subdir == "High-Quality"
+    dl = src.download_step()
+    norm = src.normalize_step(dl)
+    assert norm.hash_attrs["input_path"].endswith("/High-Quality")
+
+
+def test_normalize_step_preserves_schema_fields_in_hash():
+    """text_field / id_field / file_extensions must flow into normalize's hash
+    so different schemas produce different cache dirs."""
+    src = all_sources()["starcoder2/ir_cpp"]  # text_field="content" is a common override
+    norm = src.normalize_step()
+    assert norm.hash_attrs["text_field"] == src.text_field
+    assert norm.hash_attrs["id_field"] == src.id_field
+    # DedupMode is part of normalize's hash — default is EXACT.
+    assert norm.hash_attrs["dedup_mode"] == DedupMode.EXACT
+
+
+def test_download_step_raises_for_unpinned_source():
+    src = all_sources()["hplt_v3"]
+    assert src.revision is None
+    with pytest.raises(ValueError, match="unpinned"):
+        src.download_step()
+
+
+def test_download_step_raises_for_api_sourced():
+    src = all_sources()["nsf_awards"]
+    assert src.hf_dataset_id == ""
+    with pytest.raises(ValueError, match="hf_dataset_id"):
+        src.download_step()
+
+
+def test_normalize_step_falls_back_to_self_download():
+    """Omitting the download arg builds one via download_step()."""
+    src = all_sources()["coderforge"]
+    norm = src.normalize_step()
+    dl = norm.deps[0]
+    # The fallback path should match what download_step() would produce.
+    assert dl.name == src.download_step().name
+    assert dl.override_output_path == src.download_step().override_output_path
+
+
+def test_normalize_step_inherits_download_raise_for_unpinned():
+    src = all_sources()["hplt_v3"]
+    with pytest.raises(ValueError, match="unpinned"):
+        src.normalize_step()
+
+
+def test_methods_do_not_mutate_the_source():
+    """The dataclass is frozen; methods must return fresh StepSpecs, not cache into fields."""
+    src = DatakitSource(
+        name="synthetic",
+        hf_dataset_id="fake/dataset",
+        revision="abc1234",
+    )
+    a = src.download_step()
+    b = src.download_step()
+    # Content-addressed: identical configs hash the same, so executor dedups —
+    # but the objects are independent instantiations, not memoized.
+    assert a is not b
+    assert a.name == b.name


### PR DESCRIPTION
* adds `DatakitSource.download_step()` and `DatakitSource.normalize_step(download=None)` so any consumer can go from a registry entry to a canonical download / normalize `StepSpec` without re-implementing the field-to-arg plumbing
* normalize output lands at `\$MARIN_PREFIX/normalized/<name>-<hash>/` — run-independent, reusable across experiments (previously only `experiments/datakit_testbed/dag.py` knew how to build it and scoped the output under a testbed-run dir, forcing re-normalization per run)
* `download_step()` raises `ValueError` for unpinned (`revision=None`) or API-sourced (`hf_dataset_id=""`) entries — callers should filter via `pinned_sources()`
* `normalize_step(download=None)` builds a fresh download as a fallback; DAG authors sharing a family download across sibling subsets [^1] pass the `StepSpec` in explicitly so normalize chains to the same object
* 10 behavior tests covering naming, dep chaining, `data_subdir` in `input_path`, schema fields in normalize's hash, the two raise paths, and the fallback-download path

[^1]: e.g. the 9 Nemotron-CC v2.1 subsets share one physical download at `raw/nemotron_cc_v2_1-a7afb6`; each subset's `normalize_step` should receive that shared download rather than building 9 content-identical copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)