### PR TITLE
[tests] Bump hf_save_steps to avoid end-of-train HF save duplicate

### DIFF
--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -144,7 +144,10 @@ def create_steps(prefix: str, synth_data: str) -> list[ExecutorStep]:
             },
             train_config=TrainLmConfig(
                 data=lm_data_config(tokenize_step),
-                hf_save_steps=1,
+                # hf_save_steps=2 (not 1): at num_train_steps=2, final info.step=1 doesn't match
+                # every=2, so Trainer.train's end-of-train run_hooks(force=True) flushes the HF
+                # save exactly once. hf_save_steps=1 would double-fire on info.step=1.
+                hf_save_steps=2,
                 model=Gpt2Config(
                     num_layers=2,
                     num_heads=2,


### PR DESCRIPTION
🤖 ## Summary

Change `hf_save_steps=1` → `hf_save_steps=2` in the CW integration test.

## Why

With `hf_save_steps=1` and `num_train_steps=2`, the final `info.step` is `1`, which satisfies `every=1`. That makes the HF-save hook fire twice on the same step:

1. Once during the regular per-step `run_hooks(info)` at `trainer.py:508`.
2. Again during `Trainer.train`'s end-of-train `run_hooks(info, force=True)` at `trainer.py:574`.

Both land on the same destination path and upload the full model twice, adding ~3–4 s of duplicated S3 I/O on top of a 600 s CI budget that's already tight. CW run [24806172401](https://github.com/marin-community/marin/actions/runs/24806172401/job/72600752854) showed two back-to-back `Saving HF-compatible checkpoint … step-1` sequences with distinct `/tmp/tmp*` temp paths, confirming two real `converter.save_pretrained` invocations.

<details>
<summary>Supporting log lines from run 24806172401 (click to expand)</summary>

```
I20260422 22:48:42  levanter.compat.hf_checkpoints  Saving HF-compatible checkpoint to s3://.../hf/step-1
I20260422 22:48:42  levanter.compat.hf_checkpoints  Saving shard model.safetensors to s3://.../hf/step-1 via temp path /tmp/tmph92kzbu0
I20260422 22:48:43  levanter.compat.hf_checkpoints  Saving metadata to s3://.../hf/step-1             via temp path /tmp/tmpkgwkdsav
I20260422 22:48:44  levanter.compat.hf_checkpoints  Finished saving HF-compatible checkpoint to s3://.../hf/step-1

I20260422 22:48:44  levanter.compat.hf_checkpoints  Saving HF-compatible checkpoint to s3://.../hf/step-1
I20260422 22:48:44  levanter.compat.hf_checkpoints  Saving shard model.safetensors to s3://.../hf/step-1 via temp path /tmp/tmpnr8kbjc3
I20260422 22:48:45  levanter.compat.hf_checkpoints  Saving metadata to s3://.../hf/step-1             via temp path /tmp/tmp6_s17ub1
I20260422 22:48:46  levanter.compat.hf_checkpoints  Finished saving HF-compatible checkpoint to s3://.../hf/step-1
```

Distinct temp paths (`tmph92kzbu0`+`tmpkgwkdsav` vs. `tmpnr8kbjc3`+`tmp6_s17ub1`) = two real executions of `save_pretrained`, not duplicated log lines from one call.

</details>

## Not a library bug

The end-of-train `run_hooks(info, force=True)` at `trainer.py:574` is load-bearing: [`Checkpointer.on_step`](lib/levanter/src/levanter/checkpoint.py#L501) uses `force=True` to flush a final permanent checkpoint regardless of interval alignment (`my_save_permanent_ckpt = force`). Changing the framework to suppress already-fired hooks would regress that guarantee.

The HF-save duplicate only fires when `(num_train_steps − 1) % hf_save_steps == 0`. In production configs (e.g., `num_train_steps=50000, hf_save_steps=5000`) the alignment never hits. The integration test reproduces it because `hf_save_steps=1` makes every final step a save boundary by definition — a CI-only pathology.

## Fix

`hf_save_steps=2` keeps the test exercising the HF-save path end-to-end (via the forced end-of-train fire — the per-step schedule never fires since neither `info.step=0` nor `info.step=1` is a multiple of 2) and avoids the duplicate. No library change needed.

## Test plan

- [x] `./infra/pre-commit.py --fix tests/integration_test.py` — green.
- [ ] Re-run CW `cw-ci-test` and confirm a single `Saving HF-compatible checkpoint … step-1` sequence in the logs.
