### PR TITLE
[CI] Bump CW integration-pipeline timeout from 600s to 900s

### DIFF
--- a/.github/workflows/iris-coreweave-ci.yaml
+++ b/.github/workflows/iris-coreweave-ci.yaml
@@ -176,7 +176,7 @@ jobs:
           FSSPEC_S3: '{"endpoint_url": "https://74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com"}'
         run: |
           export IRIS_CONTROLLER_URL="http://localhost:${LOCAL_PORT}"
-          timeout 600 uv run pytest tests/test_integration_test.py \
+          timeout 900 uv run pytest tests/test_integration_test.py \
             -m integration -o "addopts=" --timeout=600 -v -s
 
       - name: Stop port-forward


### PR DESCRIPTION
🤖 ## Summary
Bump the outer shell `timeout` on the CW integration-pipeline step in `.github/workflows/iris-coreweave-ci.yaml` from 600 s to 900 s. One-word change on line 179.

## Why
The `Run full integration pipeline` step is wrapped in a shell `timeout 600`. On recent green runs on `main` the step consumes ~579 s (e.g. run 24803104923, the `cw-ci-test` job), which is 96 % of the 600 s budget. Any cold-worker-pod reset (observed +23 s of overhead in the failing run) pushes it over. [Run 24806172401](https://github.com/marin-community/marin/actions/runs/24806172401/job/72600752854) failed with exit code 124 for exactly this reason: the step hit the 600 s wall ~42 s after the final training checkpoint finished saving, before pytest could clean up.

Raising the outer shell timeout to 900 s leaves >50 % headroom for cold-pod startup variance.

## Not touched
The inner `pytest --timeout=600` on line 180 stays. That is the real per-test deadline and surfaces a proper traceback if a test genuinely hangs. The outer shell `timeout` is a belt-and-braces fallback that today fires prematurely on cold-pod runs.

## Related
PR #5111 (test-side fix that removes a duplicate HF save in the same step, saving ~3–4 s). Both are needed: #5111 alone isn't enough to reliably keep the step under 600 s given the observed cold-start variance.

## Test plan
- [x] `./infra/pre-commit.py --fix .github/workflows/iris-coreweave-ci.yaml` — green.
- [ ] Re-run CW `cw-ci-test` on this branch to confirm the step completes well inside 900 s.