### PR TITLE
[evals] Add capped issue 5005 gap-analysis launcher

### DIFF
--- a/docs/explanations/diff_patch_ppl_leakage_checks.md
+++ b/docs/explanations/diff_patch_ppl_leakage_checks.md
@@ -1,0 +1,21 @@
+# Diff/Patch PPL Leakage Checks
+
+Issue: #5095
+
+This checklist applies to the diff/patch raw eval slices in `experiments/exp5095_diff_patch_ppl.py`.
+
+1. Remove provenance-only identifiers before linearizing eval text.
+For SWE-bench slices, drop `instance_id`, `repo`, `base_commit`, `version`, `FAIL_TO_PASS`, and `PASS_TO_PASS`.
+For CommitPack slices, drop `repo_name`, `commit_hash`, and `url`.
+
+2. Keep patch-only and context-plus-patch metrics separate.
+Patch-only slices (`*_patch_text`) measure code edit modeling directly.
+Context-plus-patch slices (`*_context_plus_patch`) measure issue/commit-message conditioning plus patch quality.
+
+3. Run train/eval overlap checks before publishing metrics.
+Use exact and normalized hashes on patch bodies and context text separately.
+Fail the run if any eval row shares a hash with training rows after normalization.
+
+4. Keep eval source snapshots immutable.
+Pin source revisions (dataset snapshot or commit hash) in the build logs.
+Do not regenerate eval rows from moving HEAD references.

--- a/docs/explanations/diff_patch_ppl_leakage_checks.md
+++ b/docs/explanations/diff_patch_ppl_leakage_checks.md
@@ -19,3 +19,7 @@ Fail the run if any eval row shares a hash with training rows after normalizatio
 4. Keep eval source snapshots immutable.
 Pin source revisions (dataset snapshot or commit hash) in the build logs.
 Do not regenerate eval rows from moving HEAD references.
+
+5. Cap held-out samples per source.
+Use small held-out caps to avoid full-corpus downloads during eval wiring.
+Current caps: SWE-bench issue-to-patch 256, SWE-bench raw git diff 256, CommitPack commit-message-plus-diff 512.

--- a/docs/reports/diagnostic_logs_training_sources_5094.md
+++ b/docs/reports/diagnostic_logs_training_sources_5094.md
@@ -1,0 +1,61 @@
+# Public Diagnostic Logs Training Sources (#5094)
+
+Last verified: April 23, 2026.
+
+This inventory scopes training-data sourcing only. Eval slicing is tracked separately in issue #5093.
+
+| Source | License / Rights | Size (compressed) | Format | Status | Contamination Risk |
+| --- | --- | ---: | --- | --- | --- |
+| GHALogs (Zenodo 14796970) | Zenodo `access_right=open`, no explicit `rights` license field | 143,425,404,506 bytes | `runs.json.gz`, `repositories.json.gz`, `github_run_logs.zip` | Blocked pending license clarification | High (CI logs can include tokens, internal paths) |
+| LogChunks (Zenodo 3632351) | Zenodo `access_right=open`, no explicit `rights` license field | 24,108,826 bytes | `LogChunks.zip` (XML) | Blocked pending license clarification | Medium (failure chunks may include identifiers) |
+| LogHub (`logpai/loghub`) | Custom research/academic-only license text | 7,513,088 bytes (repo metadata) | mixed plaintext logs | Blocked for training | Medium |
+| GitHub fixture/golden/stack traces from accepted source corpora | Inherits accepted source-corpus licensing and provenance | Upstream corpus size-dependent (StarCoderData reference: 310,802,033,041 bytes) | parquet -> sanitized jsonl | Training-ready (sample-only in this issue) | Medium |
+| Marin-owned CI/Iris/Zephyr logs | Internal | n/a | internal logs | Eval-only | High |
+| #5093 heldout eval slices | Eval holdout policy | n/a | eval slices | Eval-only | High |
+
+Source metadata came from the official APIs on April 23, 2026:
+- `https://zenodo.org/api/records/14796970`
+- `https://zenodo.org/api/records/3632351`
+- `https://api.github.com/repos/logpai/loghub`
+
+## Split Policy
+
+Use deterministic hash partitioning on stable source keys (repo + path):
+
+- `issue_5093_holdout`: 1% reserved and never trainable
+- `dev`: 1%
+- `test`: 1%
+- `train`: 97%
+
+This policy is codified in `marin.datakit.download.diagnostic_logs.assign_partition`.
+
+## Sanitization Rules
+
+Apply sanitization before partition materialization and tokenization:
+
+- redact GitHub tokens (`ghp_`, `github_pat_`, etc.)
+- redact AWS access keys (`AKIA...`)
+- redact key/value secrets (`token=...`, `password: ...`, `api_key=...`)
+- redact email addresses
+- redact user home paths (`/Users/<name>`, `/home/<name>`, `C:\Users\<name>`)
+- redact internal Marin GCS paths (`gs://marin-*`)
+
+Rules are codified in `marin.datakit.download.diagnostic_logs.sanitize_diagnostic_log_text`.
+
+## Sample-Only Ingest Plan (This Issue)
+
+This issue intentionally avoids full-corpus pull. Executable wiring is capped:
+
+- max parquet files: 8
+- max rows scanned: 200,000
+- output: partitioned sanitized jsonl + metadata counters
+
+The experiment entry point is `experiments/exp5094_public_diagnostic_logs.py` with required `--source_path` to an already staged corpus path.
+
+## Initial Tranche Estimate
+
+Given the sample cap and observed diagnostic-log path sparsity in code corpora, the first training tranche should be treated as a pilot:
+
+- expected retained sample bytes: ~50MB to ~500MB
+- expected retained sample tokens: ~0.01B to ~0.15B
+- promotion to full ingest is deferred until license/governance decisions land for GHALogs/LogChunks/LogHub.

--- a/experiments/evals/asr_ocr_noisy_ppl.py
+++ b/experiments/evals/asr_ocr_noisy_ppl.py
@@ -1,0 +1,188 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Opt-in ASR/OCR noisy-text raw eval slices for perplexity-gap reports.
+
+This module materializes paired noisy/clean text from ASR and OCR sources, then
+registers both variants as raw-text datasets so gap reports can compute deltas.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+import fsspec
+from datasets import load_dataset
+from fray.v2 import ResourceConfig
+from levanter.utils import fsspec_utils
+
+from marin.evaluation.perplexity_gap import RawTextEvaluationDataset, raw_text_dataset
+from marin.execution.executor import ExecutorStep, this_output_path
+from marin.execution.remote import remote
+from marin.processing.tokenize import HfDatasetSpec
+
+ASR_OCR_NOISY_DATASET_ROOT = "asr_ocr_noisy_ppl"
+NOISY_TEXT_FIELD = "noisy_text"
+CLEAN_TEXT_FIELD = "clean_text"
+DEFAULT_RAW_SHARD_NAME = "data-00000-of-00001.jsonl.gz"
+
+
+class NoisyTextFamily(StrEnum):
+    ASR = "asr"
+    OCR = "ocr"
+
+
+@dataclass(frozen=True)
+class NoisyTextSlice:
+    registry_name: str
+    family: NoisyTextFamily
+    source_url: str
+    hf_dataset: HfDatasetSpec
+    split: str
+    noisy_key: str
+    clean_key: str
+    max_rows: int
+    notes: str = ""
+
+    @property
+    def tags(self) -> tuple[str, ...]:
+        return (ASR_OCR_NOISY_DATASET_ROOT, f"family:{self.family.value}", f"source:{self.registry_name}")
+
+
+ASR_OCR_NOISY_SLICES: tuple[NoisyTextSlice, ...] = (
+    NoisyTextSlice(
+        registry_name="hypr_librispeech_without_lm_test_clean",
+        family=NoisyTextFamily.ASR,
+        source_url="https://huggingface.co/datasets/ASR-HypR/LibriSpeech_withoutLM",
+        hf_dataset=HfDatasetSpec(id="ASR-HypR/LibriSpeech_withoutLM"),
+        split="test_clean",
+        noisy_key="hyps",
+        clean_key="ref",
+        max_rows=512,
+        notes=(
+            "HypR exposes n-best ASR hypotheses per utterance. We linearize top-1 for noisy_text and keep ref "
+            "as clean_text. Verify downstream use remains compatible with LibriSpeech-derived licensing terms."
+        ),
+    ),
+    NoisyTextSlice(
+        registry_name="rtm_sgt_ocr_v1_train",
+        family=NoisyTextFamily.OCR,
+        source_url="https://huggingface.co/datasets/ReadingTimeMachine/rtm-sgt-ocr-v1",
+        hf_dataset=HfDatasetSpec(id="ReadingTimeMachine/rtm-sgt-ocr-v1"),
+        split="train",
+        noisy_key="source",
+        clean_key="target",
+        max_rows=512,
+        notes=(
+            "ReadingTimeMachine OCR post-correction pairs may inherit source-specific archival rights. Treat as "
+            "eval-only until redistribution terms are reviewed per source collection."
+        ),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class NoisyAsrOcrRawConfig:
+    output_path: str = field(default_factory=this_output_path)  # type: ignore[arg-type]
+    max_rows_per_slice_override: int | None = None
+    slices: tuple[NoisyTextSlice, ...] = ASR_OCR_NOISY_SLICES
+
+
+def _coerce_text(value: object) -> str | None:
+    if isinstance(value, str):
+        return value if value.strip() else None
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        for item in value:
+            text = _coerce_text(item)
+            if text is not None:
+                return text
+        return None
+    return None
+
+
+def linearize_noisy_clean_row(
+    row: Mapping[str, object],
+    *,
+    noisy_key: str,
+    clean_key: str,
+) -> dict[str, str] | None:
+    """Extract paired noisy/clean text fields from one source row."""
+    noisy_text = _coerce_text(row.get(noisy_key))
+    clean_text = _coerce_text(row.get(clean_key))
+    if noisy_text is None or clean_text is None:
+        return None
+    return {NOISY_TEXT_FIELD: noisy_text, CLEAN_TEXT_FIELD: clean_text}
+
+
+def _iter_linearized_rows(slice_: NoisyTextSlice) -> Iterable[dict[str, str]]:
+    dataset = load_dataset(
+        slice_.hf_dataset.id,
+        name=slice_.hf_dataset.name,
+        split=slice_.split,
+        streaming=True,
+    )
+    for row in dataset:
+        linearized = linearize_noisy_clean_row(row, noisy_key=slice_.noisy_key, clean_key=slice_.clean_key)
+        if linearized is not None:
+            yield linearized
+
+
+def _slice_output_path(output_path: str, registry_name: str) -> str:
+    return os.path.join(output_path, registry_name, DEFAULT_RAW_SHARD_NAME)
+
+
+def materialize_noisy_asr_ocr_raw(config: NoisyAsrOcrRawConfig) -> None:
+    """Materialize paired noisy/clean text rows into jsonl.gz shards."""
+    fsspec_utils.mkdirs(config.output_path)
+    for slice_ in config.slices:
+        output_file = _slice_output_path(config.output_path, slice_.registry_name)
+        fsspec_utils.mkdirs(os.path.dirname(output_file))
+        row_cap = slice_.max_rows if config.max_rows_per_slice_override is None else config.max_rows_per_slice_override
+        if row_cap <= 0:
+            raise ValueError(f"row cap must be positive, got {row_cap}.")
+        with fsspec.open(output_file, "wt", compression="gzip") as sink:
+            for index, record in enumerate(_iter_linearized_rows(slice_)):
+                if index >= row_cap:
+                    break
+                sink.write(json.dumps(record, ensure_ascii=True))
+                sink.write("\n")
+
+
+noisy_asr_ocr_raw = ExecutorStep(
+    name=os.path.join("raw", "evals", ASR_OCR_NOISY_DATASET_ROOT),
+    description="Materialize paired ASR/OCR noisy-clean raw eval slices from Hugging Face.",
+    fn=remote(
+        materialize_noisy_asr_ocr_raw,
+        resources=ResourceConfig.with_cpu(cpu=4, ram="32g", disk="40g"),
+        pip_dependency_groups=["cpu"],
+    ),
+    config=NoisyAsrOcrRawConfig(),
+)
+
+
+def noisy_asr_ocr_raw_validation_sets(
+    *,
+    noisy_asr_ocr_raw: ExecutorStep = noisy_asr_ocr_raw,
+) -> dict[str, RawTextEvaluationDataset]:
+    """Register clean and noisy variants for each ASR/OCR raw slice."""
+    datasets: dict[str, RawTextEvaluationDataset] = {}
+    for slice_ in ASR_OCR_NOISY_SLICES:
+        raw_pattern = os.path.join(slice_.registry_name, "data-*.jsonl.gz")
+        key_root = os.path.join(ASR_OCR_NOISY_DATASET_ROOT, slice_.registry_name)
+
+        datasets[os.path.join(key_root, "noisy")] = raw_text_dataset(
+            noisy_asr_ocr_raw.cd(raw_pattern),
+            text_key=NOISY_TEXT_FIELD,
+            tags=(*slice_.tags, "variant:noisy"),
+        )
+        datasets[os.path.join(key_root, "clean")] = raw_text_dataset(
+            noisy_asr_ocr_raw.cd(raw_pattern),
+            text_key=CLEAN_TEXT_FIELD,
+            tags=(*slice_.tags, "variant:clean"),
+        )
+
+    return datasets

--- a/experiments/evals/diagnostic_log_eval_builders.py
+++ b/experiments/evals/diagnostic_log_eval_builders.py
@@ -1,0 +1,280 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sample-capped builders for diagnostic-log eval slices.
+
+These helpers intentionally require pre-staged sample inputs (local paths or
+fsspec URLs). They never fetch full public corpora directly.
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import json
+import os
+import posixpath
+from dataclasses import dataclass
+from json import JSONDecodeError
+from collections.abc import Callable
+
+import fsspec
+from rigging.filesystem import url_to_fs
+
+GHALOGS_TEXT_FIELDS = ("message", "log", "text", "line", "content")
+GHALOGS_ALLOWED_SUFFIXES = (".jsonl", ".json", ".ndjson", ".log", ".txt", ".jsonl.gz", ".json.gz", ".log.gz")
+LOGHUB_ALLOWED_SUFFIXES = (".log", ".txt")
+DIAGNOSTIC_LOG_EVAL_OUTPUTS = {
+    "ghalogs": "diagnostic_logs/ghalogs/runs.jsonl.gz",
+    "loghub_apache": "diagnostic_logs/loghub/apache.jsonl.gz",
+}
+
+
+@dataclass(frozen=True)
+class DiagnosticLogMaterializationStats:
+    source_name: str
+    files_seen: int
+    files_used: int
+    rows_written: int
+    bytes_written: int
+    max_files: int
+    max_rows: int
+    max_bytes: int
+
+
+def _validate_cap(name: str, value: int) -> None:
+    if value <= 0:
+        raise ValueError(f"{name} must be positive, got {value}")
+
+
+def _protocol_path(fs: fsspec.AbstractFileSystem, relative_path: str) -> str:
+    protocol = fs.protocol
+    if isinstance(protocol, tuple):
+        protocol = protocol[0]
+    if protocol in ("", None, "file"):
+        return relative_path
+    return f"{protocol}://{relative_path}"
+
+
+def _list_source_files(
+    source_path: str, *, allowed_suffixes: tuple[str, ...]
+) -> tuple[fsspec.AbstractFileSystem, list[str]]:
+    fs, source_root = url_to_fs(source_path)
+    if fs.exists(source_root) and fs.isfile(source_root):
+        return fs, [source_root]
+
+    if not fs.exists(source_root) or not fs.isdir(source_root):
+        raise ValueError(f"Expected a pre-staged file or directory at {source_path}")
+
+    matches: set[str] = set()
+    root = source_root.rstrip("/")
+    for suffix in allowed_suffixes:
+        pattern = os.path.join(root, "**", f"*{suffix}")
+        for match in fs.glob(pattern):
+            if fs.isfile(match):
+                matches.add(match)
+
+    files = sorted(matches)
+    if not files:
+        raise ValueError(f"No supported input files found at {source_path}")
+    return fs, files
+
+
+def _write_capped_jsonl(
+    *,
+    source_name: str,
+    source_path: str,
+    output_path: str,
+    max_files: int,
+    max_rows: int,
+    max_bytes: int,
+    allowed_suffixes: tuple[str, ...],
+    line_parser: Callable[[str], str | None],
+) -> DiagnosticLogMaterializationStats:
+    _validate_cap("max_files", max_files)
+    _validate_cap("max_rows", max_rows)
+    _validate_cap("max_bytes", max_bytes)
+
+    source_fs, source_files = _list_source_files(source_path, allowed_suffixes=allowed_suffixes)
+    selected_files = source_files[:max_files]
+
+    output_fs, output_file = url_to_fs(output_path)
+    output_dir = os.path.dirname(output_file)
+    if output_dir:
+        output_fs.makedirs(output_dir, exist_ok=True)
+
+    rows_written = 0
+    bytes_written = 0
+    files_used = 0
+    stop = False
+
+    with output_fs.open(output_file, "wb") as raw_handle:
+        with gzip.GzipFile(fileobj=raw_handle, mode="wb") as gzip_handle:
+            with io.TextIOWrapper(gzip_handle, encoding="utf-8") as writer:
+                for source_file in selected_files:
+                    wrote_from_file = False
+                    source_file_path = _protocol_path(source_fs, source_file)
+                    with fsspec.open(
+                        source_file_path,
+                        mode="rt",
+                        compression="infer",
+                        encoding="utf-8",
+                        errors="replace",
+                    ) as reader:
+                        for raw_line in reader:
+                            text = line_parser(raw_line)
+                            if text is None:
+                                continue
+
+                            record = {"text": text}
+                            payload = json.dumps(record, ensure_ascii=False) + "\n"
+                            payload_bytes = len(payload.encode("utf-8"))
+
+                            if bytes_written + payload_bytes > max_bytes:
+                                stop = True
+                                break
+
+                            writer.write(payload)
+                            rows_written += 1
+                            bytes_written += payload_bytes
+                            wrote_from_file = True
+
+                            if rows_written >= max_rows:
+                                stop = True
+                                break
+
+                    if wrote_from_file:
+                        files_used += 1
+                    if stop:
+                        break
+
+    return DiagnosticLogMaterializationStats(
+        source_name=source_name,
+        files_seen=len(source_files),
+        files_used=files_used,
+        rows_written=rows_written,
+        bytes_written=bytes_written,
+        max_files=max_files,
+        max_rows=max_rows,
+        max_bytes=max_bytes,
+    )
+
+
+def _plain_log_line(line: str) -> str | None:
+    text = line.strip()
+    if not text:
+        return None
+    return text
+
+
+def _ghalogs_line(line: str) -> str | None:
+    text = line.strip()
+    if not text:
+        return None
+
+    try:
+        parsed = json.loads(text)
+    except JSONDecodeError:
+        return text
+
+    if isinstance(parsed, str):
+        stripped = parsed.strip()
+        if not stripped:
+            return None
+        return stripped
+
+    if isinstance(parsed, dict):
+        for field in GHALOGS_TEXT_FIELDS:
+            value = parsed.get(field)
+            if isinstance(value, str):
+                stripped = value.strip()
+                if stripped:
+                    return stripped
+        return json.dumps(parsed, ensure_ascii=False, sort_keys=True)
+
+    return json.dumps(parsed, ensure_ascii=False)
+
+
+def materialize_ghalogs_eval_sample(
+    *,
+    source_path: str,
+    output_path: str,
+    max_files: int = 4,
+    max_rows: int = 4_000,
+    max_bytes: int = 8_000_000,
+) -> DiagnosticLogMaterializationStats:
+    """Build a capped `ghalogs` eval slice from pre-staged sample files."""
+    return _write_capped_jsonl(
+        source_name="ghalogs",
+        source_path=source_path,
+        output_path=output_path,
+        max_files=max_files,
+        max_rows=max_rows,
+        max_bytes=max_bytes,
+        allowed_suffixes=GHALOGS_ALLOWED_SUFFIXES,
+        line_parser=_ghalogs_line,
+    )
+
+
+def materialize_loghub_eval_sample(
+    *,
+    source_path: str,
+    output_path: str,
+    max_files: int = 4,
+    max_rows: int = 4_000,
+    max_bytes: int = 8_000_000,
+) -> DiagnosticLogMaterializationStats:
+    """Build a capped `loghub_apache` eval slice from pre-staged sample files."""
+    return _write_capped_jsonl(
+        source_name="loghub_apache",
+        source_path=source_path,
+        output_path=output_path,
+        max_files=max_files,
+        max_rows=max_rows,
+        max_bytes=max_bytes,
+        allowed_suffixes=LOGHUB_ALLOWED_SUFFIXES,
+        line_parser=_plain_log_line,
+    )
+
+
+def diagnostic_log_eval_output_path(raw_root: str, *, slice_name: str) -> str:
+    """Return the long-tail raw path for a supported diagnostic eval slice."""
+    if slice_name not in DIAGNOSTIC_LOG_EVAL_OUTPUTS:
+        raise ValueError(f"Unsupported slice_name {slice_name!r}. Expected one of {sorted(DIAGNOSTIC_LOG_EVAL_OUTPUTS)}")
+    return posixpath.join(raw_root, DIAGNOSTIC_LOG_EVAL_OUTPUTS[slice_name])
+
+
+def materialize_ghalogs_eval_slice(
+    *,
+    raw_root: str,
+    source_path: str,
+    max_files: int = 4,
+    max_rows: int = 4_000,
+    max_bytes: int = 8_000_000,
+) -> DiagnosticLogMaterializationStats:
+    """Build the `ghalogs` long-tail eval slice under ``raw_root``."""
+    return materialize_ghalogs_eval_sample(
+        source_path=source_path,
+        output_path=diagnostic_log_eval_output_path(raw_root, slice_name="ghalogs"),
+        max_files=max_files,
+        max_rows=max_rows,
+        max_bytes=max_bytes,
+    )
+
+
+def materialize_loghub_apache_eval_slice(
+    *,
+    raw_root: str,
+    source_path: str,
+    max_files: int = 4,
+    max_rows: int = 4_000,
+    max_bytes: int = 8_000_000,
+) -> DiagnosticLogMaterializationStats:
+    """Build the `loghub_apache` long-tail eval slice under ``raw_root``."""
+    return materialize_loghub_eval_sample(
+        source_path=source_path,
+        output_path=diagnostic_log_eval_output_path(raw_root, slice_name="loghub_apache"),
+        max_files=max_files,
+        max_rows=max_rows,
+        max_bytes=max_bytes,
+    )

--- a/experiments/evals/gh_archive_structured_output.py
+++ b/experiments/evals/gh_archive_structured_output.py
@@ -1,0 +1,97 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Opt-in GH Archive structured-output PPL/gap eval wiring for issue #5098."""
+
+from __future__ import annotations
+
+import posixpath
+from dataclasses import dataclass
+
+from marin.datakit.download.gh_archive import (
+    GH_ARCHIVE_OPTIONAL_EVENT_TYPES,
+    GH_ARCHIVE_REQUIRED_EVENT_TYPES,
+    make_gh_archive_step,
+)
+from marin.evaluation.perplexity_gap import RawTextEvaluationDataset, raw_text_dataset
+from marin.execution.executor import ExecutorStep
+
+EPIC_5005 = 5005
+GH_ARCHIVE_STRUCTURED_OUTPUT_ISSUE = 5098
+
+# Small held-out hour window to avoid broad GH Archive pulls.
+GH_ARCHIVE_EVAL_START_DATE = "2024-02-01"
+GH_ARCHIVE_EVAL_END_DATE = "2024-02-01"
+GH_ARCHIVE_EVAL_START_HOUR = 0
+GH_ARCHIVE_EVAL_END_HOUR = 1
+GH_ARCHIVE_EVAL_MAX_EVENTS_PER_EVENT_TYPE = 512
+
+
+@dataclass(frozen=True)
+class GhArchiveStructuredOutputSlice:
+    event_type: str
+    optional: bool = False
+
+    @property
+    def registry_key(self) -> str:
+        return posixpath.join("gh_archive_structured_output", self.event_type)
+
+    @property
+    def raw_relative_glob(self) -> str:
+        return posixpath.join(self.event_type, "*.jsonl.gz")
+
+    @property
+    def tags(self) -> tuple[str, ...]:
+        return (
+            "gh_archive_structured_output",
+            f"epic:{EPIC_5005}",
+            f"issue:{GH_ARCHIVE_STRUCTURED_OUTPUT_ISSUE}",
+            f"event_type:{self.event_type}",
+        )
+
+
+GH_ARCHIVE_STRUCTURED_OUTPUT_SLICES: tuple[GhArchiveStructuredOutputSlice, ...] = (
+    *(GhArchiveStructuredOutputSlice(event_type=event_type) for event_type in GH_ARCHIVE_REQUIRED_EVENT_TYPES),
+    *(
+        GhArchiveStructuredOutputSlice(event_type=event_type, optional=True)
+        for event_type in GH_ARCHIVE_OPTIONAL_EVENT_TYPES
+    ),
+)
+
+gh_archive_structured_output_eval = make_gh_archive_step(
+    name="raw/gh_archive/structured_output_eval_2024_02_01_h00_01",
+    start_date=GH_ARCHIVE_EVAL_START_DATE,
+    end_date=GH_ARCHIVE_EVAL_END_DATE,
+    start_hour=GH_ARCHIVE_EVAL_START_HOUR,
+    end_hour=GH_ARCHIVE_EVAL_END_HOUR,
+    event_types=tuple(slice_.event_type for slice_ in GH_ARCHIVE_STRUCTURED_OUTPUT_SLICES),
+    max_events_per_event_type=GH_ARCHIVE_EVAL_MAX_EVENTS_PER_EVENT_TYPE,
+)
+
+
+def gh_archive_structured_output_raw_validation_sets(
+    *,
+    raw_root: str | None = None,
+    gh_archive_raw: ExecutorStep | None = None,
+    include_optional_event_types: bool = True,
+) -> dict[str, RawTextEvaluationDataset]:
+    """Materialize GH Archive structured-output slices as opt-in raw validation datasets."""
+    if raw_root is not None and gh_archive_raw is not None:
+        raise ValueError("Provide either raw_root or gh_archive_raw, not both.")
+
+    if raw_root is None and gh_archive_raw is None:
+        gh_archive_raw = gh_archive_structured_output_eval
+
+    datasets: dict[str, RawTextEvaluationDataset] = {}
+    for slice_ in GH_ARCHIVE_STRUCTURED_OUTPUT_SLICES:
+        if slice_.optional and not include_optional_event_types:
+            continue
+
+        if raw_root is not None:
+            source = posixpath.join(raw_root, slice_.raw_relative_glob)
+        else:
+            assert gh_archive_raw is not None
+            source = gh_archive_raw.cd(slice_.raw_relative_glob)
+
+        datasets[slice_.registry_key] = raw_text_dataset(source, tags=slice_.tags)
+    return datasets

--- a/experiments/evals/long_tail_ppl.py
+++ b/experiments/evals/long_tail_ppl.py
@@ -24,6 +24,7 @@ TIME_SERIES_ISSUE = 5059
 FORMAL_HARDWARE_ISSUE = 5060
 PACKAGE_METADATA_ISSUE = 5061
 GAME_MUSIC_ISSUE = 5062
+DIAGNOSTIC_LOGS_ISSUE = 5093
 
 
 class LongTailPplFamily(StrEnum):
@@ -36,6 +37,7 @@ class LongTailPplFamily(StrEnum):
     FORMAL_HARDWARE = "formal_hardware"
     PACKAGE_METADATA = "package_metadata"
     GAME_MUSIC = "game_music"
+    DIAGNOSTIC_LOGS = "diagnostic_logs"
 
 
 @dataclass(frozen=True)
@@ -443,6 +445,125 @@ LONG_TAIL_PPL_SLICES: tuple[LongTailPplSlice, ...] = (
         surface_form="abc_notation",
         raw_relative_path="music/abc/notation.jsonl.gz",
         notes="Keep ABC headers, barlines, and note-length annotations.",
+    ),
+    # Diagnostic logs — surfaces from issue #5093 DoD: held-out PPL/gap eval
+    # registers that agents read during debugging (CI logs, compiler/linker
+    # output, pytest failures, stack traces, package install errors, system
+    # and application logs). Entries are metadata-only; they stay outside
+    # default_raw_validation_sets so worst-doc artifacts only show up when an
+    # experiment opts in via long_tail_raw_validation_sets(family=...).
+    _slice(
+        name="ghalogs",
+        family=LongTailPplFamily.DIAGNOSTIC_LOGS,
+        issue_number=DIAGNOSTIC_LOGS_ISSUE,
+        source_url="https://zenodo.org/records/14796970",
+        surface_form="github_actions_log",
+        raw_relative_path="diagnostic_logs/ghalogs/runs.jsonl.gz",
+        notes="Preserve GHA timestamps, ANSI control codes, step boundaries, and exit-status lines.",
+    ),
+    _slice(
+        name="logchunks",
+        family=LongTailPplFamily.DIAGNOSTIC_LOGS,
+        issue_number=DIAGNOSTIC_LOGS_ISSUE,
+        source_url="https://papertalk.org/papertalks/24713",
+        surface_form="failure_log_chunk",
+        raw_relative_path="diagnostic_logs/logchunks/chunks.jsonl.gz",
+        notes="Keep chunked failure-context windows and surrounding log boundaries intact.",
+    ),
+    _slice(
+        name="loghub_apache",
+        family=LongTailPplFamily.DIAGNOSTIC_LOGS,
+        issue_number=DIAGNOSTIC_LOGS_ISSUE,
+        source_url="https://github.com/logpai/loghub",
+        surface_form="application_log",
+        raw_relative_path="diagnostic_logs/loghub/apache.jsonl.gz",
+        notes="Preserve Apache access/error log line layout, IPs, and status codes.",
+    ),
+    _slice(
+        name="loghub_linux",
+        family=LongTailPplFamily.DIAGNOSTIC_LOGS,
+        issue_number=DIAGNOSTIC_LOGS_ISSUE,
+        source_url="https://github.com/logpai/loghub",
+        surface_form="system_log",
+        raw_relative_path="diagnostic_logs/loghub/linux.jsonl.gz",
+        notes="Preserve syslog timestamps, hostnames, daemon names, and PIDs literal.",
+    ),
+    _slice(
+        name="loghub_hdfs",
+        family=LongTailPplFamily.DIAGNOSTIC_LOGS,
+        issue_number=DIAGNOSTIC_LOGS_ISSUE,
+        source_url="https://github.com/logpai/loghub",
+        surface_form="distributed_system_log",
+        raw_relative_path="diagnostic_logs/loghub/hdfs.jsonl.gz",
+        notes="Preserve block IDs, datanode hosts, and Hadoop log severity prefixes.",
+    ),
+    _slice(
+        name="loghub_openssh",
+        family=LongTailPplFamily.DIAGNOSTIC_LOGS,
+        issue_number=DIAGNOSTIC_LOGS_ISSUE,
+        source_url="https://github.com/logpai/loghub",
+        surface_form="auth_log",
+        raw_relative_path="diagnostic_logs/loghub/openssh.jsonl.gz",
+        notes="Keep sshd auth-failure templates, user/IP fields, and reason strings literal.",
+    ),
+    _slice(
+        name="loghub_thunderbird",
+        family=LongTailPplFamily.DIAGNOSTIC_LOGS,
+        issue_number=DIAGNOSTIC_LOGS_ISSUE,
+        source_url="https://github.com/logpai/loghub",
+        surface_form="hpc_supercomputer_log",
+        raw_relative_path="diagnostic_logs/loghub/thunderbird.jsonl.gz",
+        notes="Preserve Thunderbird HPC node IDs, kernel events, and alert prefixes.",
+    ),
+    _slice(
+        name="pytest_failures",
+        family=LongTailPplFamily.DIAGNOSTIC_LOGS,
+        issue_number=DIAGNOSTIC_LOGS_ISSUE,
+        source_url="https://github.com/marin-community/marin/issues/5093",
+        surface_form="pytest_failure_output",
+        raw_relative_path="diagnostic_logs/pytest_failures/failures.jsonl.gz",
+        notes="Keep traceback layout, FAILED/ERROR markers, and assertion-diff blocks intact.",
+    ),
+    _slice(
+        name="compiler_linker_output",
+        family=LongTailPplFamily.DIAGNOSTIC_LOGS,
+        issue_number=DIAGNOSTIC_LOGS_ISSUE,
+        source_url="https://github.com/marin-community/marin/issues/5093",
+        surface_form="compiler_diagnostic_text",
+        raw_relative_path="diagnostic_logs/compiler_linker/output.jsonl.gz",
+        notes="Preserve file:line:col diagnostic format, error codes, and template-instantiation traces.",
+    ),
+    _slice(
+        name="stack_traces",
+        family=LongTailPplFamily.DIAGNOSTIC_LOGS,
+        issue_number=DIAGNOSTIC_LOGS_ISSUE,
+        source_url="https://github.com/marin-community/marin/issues/5093",
+        surface_form="exception_stack_trace",
+        raw_relative_path="diagnostic_logs/stack_traces/traces.jsonl.gz",
+        notes="Keep frame-by-frame layout, exception class names, and 'Caused by'/'During handling' markers.",
+    ),
+    _slice(
+        name="package_install_errors",
+        family=LongTailPplFamily.DIAGNOSTIC_LOGS,
+        issue_number=DIAGNOSTIC_LOGS_ISSUE,
+        source_url="https://github.com/marin-community/marin/issues/5093",
+        surface_form="package_install_failure",
+        raw_relative_path="diagnostic_logs/package_install_errors/errors.jsonl.gz",
+        notes="Preserve pip/uv/apt/conda resolver output, dependency conflict tables, and exit codes.",
+    ),
+    _slice(
+        name="marin_internal_logs_sanitized",
+        family=LongTailPplFamily.DIAGNOSTIC_LOGS,
+        issue_number=DIAGNOSTIC_LOGS_ISSUE,
+        source_url="https://github.com/marin-community/marin/issues/5093",
+        surface_form="marin_gha_iris_zephyr_log",
+        raw_relative_path="diagnostic_logs/marin_internal/sanitized.jsonl.gz",
+        notes=(
+            "Held-out eval-only slice from Marin GHA / Iris / Zephyr logs. "
+            "Mirror only after PII + secret + GCS-path scrub; never include in any training mixture. "
+            "Leakage policy: contributors' GitHub handles, internal hostnames, bucket names, "
+            "and access tokens must be redacted before this path is populated."
+        ),
     ),
 )
 

--- a/experiments/evals/paired_robustness_ppl.py
+++ b/experiments/evals/paired_robustness_ppl.py
@@ -1,0 +1,370 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Opt-in paired paraphrase/translation robustness PPL slices for issue #5096."""
+
+from __future__ import annotations
+
+import logging
+import os
+import posixpath
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+import datasets
+from fray.v2 import ResourceConfig
+from marin.evaluation.perplexity_gap import RawTextEvaluationDataset, raw_text_dataset
+from marin.execution.executor import ExecutorStep, this_output_path
+from marin.execution.remote import remote
+from zephyr import write_jsonl_file
+
+logger = logging.getLogger(__name__)
+
+EPIC_5005 = 5005
+PAIR_ROBUSTNESS_ISSUE = 5096
+DEFAULT_SAMPLE_CAP = 1_024
+DEFAULT_SHARD_SIZE = 512
+
+
+class PairedRobustnessFamily(StrEnum):
+    PARAPHRASE = "paraphrase"
+    TRANSLATION = "translation"
+
+
+class PairedTextView(StrEnum):
+    SOURCE = "source"
+    TARGET = "target"
+    TARGET_GIVEN_SOURCE = "target_given_source"
+
+
+ALL_PAIRED_TEXT_VIEWS: tuple[PairedTextView, ...] = (
+    PairedTextView.SOURCE,
+    PairedTextView.TARGET,
+    PairedTextView.TARGET_GIVEN_SOURCE,
+)
+
+
+@dataclass(frozen=True)
+class PairedRobustnessSlice:
+    """Definition of one held-out paired robustness source split."""
+
+    name: str
+    family: PairedRobustnessFamily
+    source_url: str
+    hf_dataset_id: str
+    hf_dataset_name: str | None
+    split: str
+    source_field: str
+    target_field: str
+    source_label: str
+    target_label: str
+    max_pairs: int
+    trust_remote_code: bool = False
+    label_field: str | None = None
+    required_label: int | None = None
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        if (self.label_field is None) != (self.required_label is None):
+            raise ValueError("label_field and required_label must both be set or both be None.")
+        if self.source_field == self.target_field:
+            raise ValueError("source_field and target_field must differ for paired eval slices.")
+        if self.max_pairs <= 0:
+            raise ValueError(f"max_pairs must be positive, got {self.max_pairs}.")
+
+    @property
+    def raw_step_key(self) -> str:
+        return posixpath.join(self.family.value, self.name, self.split)
+
+    @property
+    def dataset_root(self) -> str:
+        return posixpath.join("paired_robustness_ppl", self.family.value, self.name, self.split)
+
+    def dataset_key(self, view: PairedTextView) -> str:
+        return posixpath.join(self.dataset_root, view.value)
+
+    def tags_for_view(self, view: PairedTextView) -> tuple[str, ...]:
+        return (
+            "paired_robustness_ppl",
+            f"epic:{EPIC_5005}",
+            f"issue:{PAIR_ROBUSTNESS_ISSUE}",
+            f"family:{self.family.value}",
+            f"source:{self.name}",
+            f"split:{self.split}",
+            f"view:{view.value}",
+        )
+
+
+PAIRED_ROBUSTNESS_SLICES: tuple[PairedRobustnessSlice, ...] = (
+    PairedRobustnessSlice(
+        name="paws_labeled_final",
+        family=PairedRobustnessFamily.PARAPHRASE,
+        source_url="https://huggingface.co/datasets/google-research-datasets/paws",
+        hf_dataset_id="google-research-datasets/paws",
+        hf_dataset_name="labeled_final",
+        split="validation",
+        source_field="sentence1",
+        target_field="sentence2",
+        source_label="sentence_1",
+        target_label="sentence_2",
+        label_field="label",
+        required_label=1,
+        max_pairs=DEFAULT_SAMPLE_CAP,
+        notes="Held-out PAWS validation paraphrase pairs, positives only.",
+    ),
+    PairedRobustnessSlice(
+        name="paws_labeled_final",
+        family=PairedRobustnessFamily.PARAPHRASE,
+        source_url="https://huggingface.co/datasets/google-research-datasets/paws",
+        hf_dataset_id="google-research-datasets/paws",
+        hf_dataset_name="labeled_final",
+        split="test",
+        source_field="sentence1",
+        target_field="sentence2",
+        source_label="sentence_1",
+        target_label="sentence_2",
+        label_field="label",
+        required_label=1,
+        max_pairs=DEFAULT_SAMPLE_CAP,
+        notes="Held-out PAWS test paraphrase pairs, positives only.",
+    ),
+    PairedRobustnessSlice(
+        name="flores_eng_deu",
+        family=PairedRobustnessFamily.TRANSLATION,
+        source_url="https://huggingface.co/datasets/facebook/flores",
+        hf_dataset_id="facebook/flores",
+        hf_dataset_name="eng_Latn-deu_Latn",
+        split="dev",
+        source_field="sentence_eng_Latn",
+        target_field="sentence_deu_Latn",
+        source_label="English",
+        target_label="German",
+        trust_remote_code=True,
+        max_pairs=512,
+        notes="FLORES-200 held-out dev translation pairs (en->de), capped sample.",
+    ),
+    PairedRobustnessSlice(
+        name="flores_eng_deu",
+        family=PairedRobustnessFamily.TRANSLATION,
+        source_url="https://huggingface.co/datasets/facebook/flores",
+        hf_dataset_id="facebook/flores",
+        hf_dataset_name="eng_Latn-deu_Latn",
+        split="devtest",
+        source_field="sentence_eng_Latn",
+        target_field="sentence_deu_Latn",
+        source_label="English",
+        target_label="German",
+        trust_remote_code=True,
+        max_pairs=512,
+        notes="FLORES-200 held-out devtest translation pairs (en->de), capped sample.",
+    ),
+)
+
+PAIRED_ROBUSTNESS_REGISTRY: dict[str, PairedRobustnessSlice] = {
+    slice_.raw_step_key: slice_ for slice_ in PAIRED_ROBUSTNESS_SLICES
+}
+
+
+@dataclass(frozen=True)
+class PairedRobustnessMaterializeConfig:
+    """Config for materializing one paired robustness slice into `{text: ...}` records."""
+
+    name: str
+    family: PairedRobustnessFamily
+    source_url: str
+    hf_dataset_id: str
+    hf_dataset_name: str | None
+    split: str
+    source_field: str
+    target_field: str
+    source_label: str
+    target_label: str
+    max_pairs: int
+    trust_remote_code: bool = False
+    label_field: str | None = None
+    required_label: int | None = None
+    notes: str = ""
+    output_path: str = field(default_factory=this_output_path)  # type: ignore[arg-type]
+    shard_size: int = DEFAULT_SHARD_SIZE
+
+
+def paired_robustness_slices(*, family: PairedRobustnessFamily | None = None) -> tuple[PairedRobustnessSlice, ...]:
+    if family is None:
+        return PAIRED_ROBUSTNESS_SLICES
+    return tuple(slice_ for slice_ in PAIRED_ROBUSTNESS_SLICES if slice_.family == family)
+
+
+def linearized_text_views_for_example(
+    slice_: PairedRobustnessSlice, example: Mapping[str, object]
+) -> dict[PairedTextView, str] | None:
+    if slice_.label_field is not None:
+        label_value = example.get(slice_.label_field)
+        if label_value != slice_.required_label:
+            return None
+
+    source_text = _field_as_text(example, slice_.source_field)
+    target_text = _field_as_text(example, slice_.target_field)
+
+    return {
+        PairedTextView.SOURCE: f"{slice_.source_label}: {source_text}",
+        PairedTextView.TARGET: f"{slice_.target_label}: {target_text}",
+        PairedTextView.TARGET_GIVEN_SOURCE: (
+            f"{slice_.source_label}: {source_text}\n{slice_.target_label}: {target_text}"
+        ),
+    }
+
+
+def materialize_paired_robustness_slice(config: PairedRobustnessMaterializeConfig) -> None:
+    slice_ = _slice_from_config(config)
+    dataset = datasets.load_dataset(
+        path=config.hf_dataset_id,
+        name=config.hf_dataset_name,
+        split=config.split,
+        streaming=True,
+        trust_remote_code=config.trust_remote_code,
+    )
+
+    buffers = {view: [] for view in ALL_PAIRED_TEXT_VIEWS}
+    shard_index = {view: 0 for view in ALL_PAIRED_TEXT_VIEWS}
+    counts = {view: 0 for view in ALL_PAIRED_TEXT_VIEWS}
+    kept_pairs = 0
+
+    for example in dataset:
+        views = linearized_text_views_for_example(slice_, example)
+        if views is None:
+            continue
+        kept_pairs += 1
+        for view, text in views.items():
+            buffers[view].append({"text": text})
+            if len(buffers[view]) >= config.shard_size:
+                _flush_view_shard(config.output_path, view, shard_index, counts, buffers)
+        if kept_pairs >= config.max_pairs:
+            break
+
+    for view in ALL_PAIRED_TEXT_VIEWS:
+        _flush_view_shard(config.output_path, view, shard_index, counts, buffers)
+
+    if kept_pairs == 0:
+        raise ValueError(
+            f"Slice {config.name}/{config.split} produced zero paired examples with the configured filters."
+        )
+
+    logger.info(
+        "Materialized paired robustness slice %s/%s with %d pairs; source=%d target=%d target_given_source=%d",
+        config.name,
+        config.split,
+        kept_pairs,
+        counts[PairedTextView.SOURCE],
+        counts[PairedTextView.TARGET],
+        counts[PairedTextView.TARGET_GIVEN_SOURCE],
+    )
+
+
+def paired_robustness_raw_steps(
+    *,
+    slices: Sequence[PairedRobustnessSlice] = PAIRED_ROBUSTNESS_SLICES,
+    name_prefix: str = "raw/paired_robustness_ppl",
+    resources: ResourceConfig | None = None,
+) -> dict[str, ExecutorStep]:
+    if resources is None:
+        resources = ResourceConfig.with_cpu(cpu=4, ram="16g", disk="30g")
+
+    steps: dict[str, ExecutorStep] = {}
+    for slice_ in slices:
+        steps[slice_.raw_step_key] = ExecutorStep(
+            name=posixpath.join(name_prefix, slice_.family.value, slice_.name, slice_.split),
+            description=f"Materialize capped held-out paired robustness eval records for {slice_.name}/{slice_.split}.",
+            fn=remote(materialize_paired_robustness_slice, resources=resources, pip_dependency_groups=["cpu"]),
+            config=_materialize_config(slice_),
+        )
+    return steps
+
+
+def paired_robustness_raw_validation_sets(
+    *,
+    slices: Sequence[PairedRobustnessSlice] = PAIRED_ROBUSTNESS_SLICES,
+    include_views: Sequence[PairedTextView] = ALL_PAIRED_TEXT_VIEWS,
+    raw_steps: Mapping[str, ExecutorStep] | None = None,
+) -> dict[str, RawTextEvaluationDataset]:
+    if raw_steps is None:
+        raw_steps = paired_robustness_raw_steps(slices=slices)
+
+    selected_views = tuple(include_views)
+    datasets_out: dict[str, RawTextEvaluationDataset] = {}
+    for slice_ in slices:
+        raw_step = raw_steps[slice_.raw_step_key]
+        for view in selected_views:
+            datasets_out[slice_.dataset_key(view)] = raw_text_dataset(
+                raw_step.cd(posixpath.join(view.value, "shard-*.jsonl.gz")),
+                tags=slice_.tags_for_view(view),
+            )
+    return datasets_out
+
+
+def _materialize_config(slice_: PairedRobustnessSlice) -> PairedRobustnessMaterializeConfig:
+    return PairedRobustnessMaterializeConfig(
+        name=slice_.name,
+        family=slice_.family,
+        source_url=slice_.source_url,
+        hf_dataset_id=slice_.hf_dataset_id,
+        hf_dataset_name=slice_.hf_dataset_name,
+        split=slice_.split,
+        source_field=slice_.source_field,
+        target_field=slice_.target_field,
+        source_label=slice_.source_label,
+        target_label=slice_.target_label,
+        max_pairs=slice_.max_pairs,
+        trust_remote_code=slice_.trust_remote_code,
+        label_field=slice_.label_field,
+        required_label=slice_.required_label,
+        notes=slice_.notes,
+    )
+
+
+def _slice_from_config(config: PairedRobustnessMaterializeConfig) -> PairedRobustnessSlice:
+    return PairedRobustnessSlice(
+        name=config.name,
+        family=config.family,
+        source_url=config.source_url,
+        hf_dataset_id=config.hf_dataset_id,
+        hf_dataset_name=config.hf_dataset_name,
+        split=config.split,
+        source_field=config.source_field,
+        target_field=config.target_field,
+        source_label=config.source_label,
+        target_label=config.target_label,
+        max_pairs=config.max_pairs,
+        trust_remote_code=config.trust_remote_code,
+        label_field=config.label_field,
+        required_label=config.required_label,
+        notes=config.notes,
+    )
+
+
+def _field_as_text(example: Mapping[str, object], field_name: str) -> str:
+    if field_name not in example:
+        raise KeyError(f"Expected field {field_name!r} in paired robustness example.")
+    value = example[field_name]
+    if value is None:
+        raise ValueError(f"Field {field_name!r} cannot be None for paired robustness linearization.")
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _flush_view_shard(
+    output_path: str,
+    view: PairedTextView,
+    shard_index: dict[PairedTextView, int],
+    counts: dict[PairedTextView, int],
+    buffers: dict[PairedTextView, list[dict[str, str]]],
+) -> None:
+    records = buffers[view]
+    if not records:
+        return
+    shard_path = os.path.join(output_path, view.value, f"shard-{shard_index[view]:05d}.jsonl.gz")
+    result = write_jsonl_file(records, shard_path)
+    counts[view] += int(result["count"])
+    shard_index[view] += 1
+    buffers[view] = []

--- a/experiments/exp5094_public_diagnostic_logs.py
+++ b/experiments/exp5094_public_diagnostic_logs.py
@@ -1,0 +1,125 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Issue #5094: opt-in public diagnostic-log sourcing for training."""
+
+import json
+
+import click
+from marin.execution.executor import ExecutorStep, executor_main, this_output_path, versioned
+from marin.processing.tokenize import TokenizeConfig, tokenize
+
+from experiments.llama import llama3_tokenizer
+from marin.datakit.download.diagnostic_logs import (
+    DEFAULT_SAMPLE_MAX_PARQUET_FILES,
+    DEFAULT_SAMPLE_MAX_ROWS,
+    DiagnosticSourceStatus,
+    extract_starcoder_fixture_logs_step,
+    source_inventory,
+)
+
+
+def _inventory_payload() -> list[dict[str, object]]:
+    payload = []
+    for source in source_inventory():
+        payload.append(
+            {
+                "name": source.name,
+                "status": source.status.value,
+                "source_url": source.source_url,
+                "license": source.source_license,
+                "format": source.source_format,
+                "compressed_size_bytes": source.compressed_size_bytes,
+                "rough_tokens_b": source.rough_tokens_b,
+                "risk": source.contamination_risk,
+                "provenance_notes": source.provenance_notes,
+            }
+        )
+    return payload
+
+
+def _extract_step(source_path: str, max_parquet_files: int, max_rows: int) -> ExecutorStep:
+    return extract_starcoder_fixture_logs_step(
+        source_path=source_path,
+        max_parquet_files=max_parquet_files,
+        max_rows=max_rows,
+    ).as_executor_step()
+
+
+def _tokenize_step(extracted_step: ExecutorStep) -> ExecutorStep:
+    return ExecutorStep(
+        name="tokenized/diagnostic_logs/github_fixtures_sample",
+        fn=tokenize,
+        config=TokenizeConfig(
+            train_paths=[extracted_step.as_input_name() / "train/*.jsonl"],
+            validation_paths=versioned([extracted_step.as_input_name() / "dev/*.jsonl"]),
+            cache_path=this_output_path(),
+            tokenizer=versioned(llama3_tokenizer),
+        ),
+    )
+
+
+@click.group(invoke_without_command=True)
+@click.option("--dry_run", type=str, hidden=True, help="Passed by test framework; ignored by this CLI.")
+@click.option("--executor_info_base_path", type=str, hidden=True, help="Passed by test framework; ignored by this CLI.")
+@click.option("--prefix", type=str, hidden=True, help="Passed by test framework; ignored by this CLI.")
+@click.pass_context
+def cli(
+    ctx: click.Context,
+    dry_run: str | None,
+    executor_info_base_path: str | None,
+    prefix: str | None,
+) -> None:
+    """Public diagnostic-log sourcing workflow."""
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(inventory_cmd)
+
+
+@cli.command("inventory")
+def inventory_cmd() -> None:
+    """Print source inventory and gating status as JSON."""
+    click.echo(json.dumps(_inventory_payload(), indent=2, sort_keys=True))
+
+
+@cli.command("extract")
+@click.option("--source_path", required=True, help="Path to already-staged StarCoder parquet shards.")
+@click.option("--max_parquet_files", default=DEFAULT_SAMPLE_MAX_PARQUET_FILES, show_default=True, type=int)
+@click.option("--max_rows", default=DEFAULT_SAMPLE_MAX_ROWS, show_default=True, type=int)
+def extract_cmd(source_path: str, max_parquet_files: int, max_rows: int) -> None:
+    """Extract a capped sample of partitioned diagnostic logs from staged source corpora."""
+    step = _extract_step(source_path, max_parquet_files, max_rows)
+    executor_main(steps=[step], description="Issue #5094 extract public diagnostic logs sample")
+
+
+@cli.command("tokenize")
+@click.option("--source_path", required=True, help="Path to already-staged StarCoder parquet shards.")
+@click.option("--max_parquet_files", default=DEFAULT_SAMPLE_MAX_PARQUET_FILES, show_default=True, type=int)
+@click.option("--max_rows", default=DEFAULT_SAMPLE_MAX_ROWS, show_default=True, type=int)
+def tokenize_cmd(source_path: str, max_parquet_files: int, max_rows: int) -> None:
+    """Tokenize the same capped sample (train/dev only)."""
+    extract_step = _extract_step(source_path, max_parquet_files, max_rows)
+    tokenize_step = _tokenize_step(extract_step)
+    executor_main(steps=[extract_step, tokenize_step], description="Issue #5094 tokenize diagnostic logs sample")
+
+
+@cli.command("all")
+@click.option("--source_path", required=True, help="Path to already-staged StarCoder parquet shards.")
+@click.option("--max_parquet_files", default=DEFAULT_SAMPLE_MAX_PARQUET_FILES, show_default=True, type=int)
+@click.option("--max_rows", default=DEFAULT_SAMPLE_MAX_ROWS, show_default=True, type=int)
+def all_cmd(source_path: str, max_parquet_files: int, max_rows: int) -> None:
+    """Run sample extraction and tokenization for approved training-ready diagnostic logs."""
+    extract_step = _extract_step(source_path, max_parquet_files, max_rows)
+    tokenize_step = _tokenize_step(extract_step)
+    executor_main(
+        steps=[extract_step, tokenize_step],
+        description="Issue #5094 public diagnostic logs sample",
+    )
+
+
+if __name__ == "__main__":
+    blocked = [entry.name for entry in source_inventory() if entry.status == DiagnosticSourceStatus.BLOCKED_LICENSE]
+    if blocked:
+        click.echo(
+            "Blocked external sources (license/provenance review required before training ingest): " + ", ".join(blocked)
+        )
+    cli()

--- a/experiments/exp5095_diff_patch_ppl.py
+++ b/experiments/exp5095_diff_patch_ppl.py
@@ -43,6 +43,7 @@ class DiffPatchSlice:
     name: str
     relative_path: str
     metrics: tuple[DiffPatchMetric, ...]
+    held_out_sample_cap: int
 
     @property
     def tags(self) -> tuple[str, ...]:
@@ -65,18 +66,21 @@ DIFF_PATCH_SLICES: tuple[DiffPatchSlice, ...] = (
         name="issue_to_patch",
         relative_path="swe_bench/issue_to_patch.jsonl.gz",
         metrics=(DiffPatchMetric.PATCH_TEXT, DiffPatchMetric.CONTEXT_PLUS_PATCH),
+        held_out_sample_cap=256,
     ),
     DiffPatchSlice(
         source="swe_bench",
         name="raw_git_diff",
         relative_path="swe_bench/raw_git_diff.jsonl.gz",
         metrics=(DiffPatchMetric.PATCH_TEXT,),
+        held_out_sample_cap=256,
     ),
     DiffPatchSlice(
         source="commitpack",
         name="commit_message_plus_diff",
         relative_path="commitpack/commit_message_plus_diff.jsonl.gz",
         metrics=(DiffPatchMetric.PATCH_TEXT, DiffPatchMetric.CONTEXT_PLUS_PATCH),
+        held_out_sample_cap=512,
     ),
 )
 
@@ -152,6 +156,26 @@ def build_diff_patch_raw_validation_sets(
         for metric in slice_spec.metrics:
             datasets[slice_spec.dataset_key(metric)] = slice_spec.to_raw_dataset(raw_root, metric)
     return datasets
+
+
+def diff_patch_source_sampling_plan(
+    *,
+    slices: tuple[DiffPatchSlice, ...] = DIFF_PATCH_SLICES,
+) -> dict[str, dict[str, object]]:
+    """Small held-out sampling plan for source builders.
+
+    The plan is intentionally metadata-only so source integration can cap
+    downloads before data ingestion.
+    """
+
+    return {
+        f"{slice_spec.source}/{slice_spec.name}": {
+            "held_out_sample_cap": slice_spec.held_out_sample_cap,
+            "split": "validation",
+            "source": slice_spec.source,
+        }
+        for slice_spec in slices
+    }
 
 
 ACTIVE_DIFF_PATCH_DATASETS: dict[str, RawTextEvaluationDataset] = build_diff_patch_raw_validation_sets()

--- a/experiments/exp5095_diff_patch_ppl.py
+++ b/experiments/exp5095_diff_patch_ppl.py
@@ -2,31 +2,176 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Registry helpers for diff and patch perplexity-gap slices.
+Diff/patch perplexity-gap slice registry and row builders.
 
-Slices cover agent-facing surface forms (raw ``git diff``, commit-message-plus-diff,
-PR-review-plus-diff, issue-to-patch). Source builders are intentionally deferred;
-this module only establishes the ``diff_patch/<slice>`` namespace and the active
-registry that downstream experiments read.
+This module keeps diff/patch evaluation opt-in by exposing a dedicated
+``diff_patch/<slice>`` namespace without wiring into default eval bundles.
 """
 
-import os
-from collections.abc import Mapping
+from __future__ import annotations
 
-from marin.evaluation.perplexity_gap import RawTextEvaluationDataset
+import json
+import posixpath
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+
+from marin.evaluation.perplexity_gap import RawTextEvaluationDataset, raw_text_dataset
 
 DIFF_PATCH_PREFIX = "diff_patch"
+ISSUE_5095 = 5095
 
-ACTIVE_DIFF_PATCH_DATASETS: dict[str, RawTextEvaluationDataset] = {}
+SWE_BENCH_PROVENANCE_FIELDS: tuple[str, ...] = (
+    "instance_id",
+    "repo",
+    "base_commit",
+    "version",
+    "FAIL_TO_PASS",
+    "PASS_TO_PASS",
+)
+COMMITPACK_PROVENANCE_FIELDS: tuple[str, ...] = ("repo_name", "commit_hash", "url")
+
+
+class DiffPatchMetric(StrEnum):
+    PATCH_TEXT = "patch_text"
+    CONTEXT_PLUS_PATCH = "context_plus_patch"
+
+
+@dataclass(frozen=True)
+class DiffPatchSlice:
+    source: str
+    name: str
+    relative_path: str
+    metrics: tuple[DiffPatchMetric, ...]
+
+    @property
+    def tags(self) -> tuple[str, ...]:
+        return ("diff_patch", f"issue:{ISSUE_5095}", f"source:{self.source}", f"slice:{self.name}")
+
+    def dataset_key(self, metric: DiffPatchMetric) -> str:
+        return f"{self.source}/{self.name}_{metric.value}"
+
+    def to_raw_dataset(self, raw_root: str, metric: DiffPatchMetric) -> RawTextEvaluationDataset:
+        path_stem = self.relative_path.removesuffix(".jsonl.gz")
+        return raw_text_dataset(
+            posixpath.join(raw_root, f"{path_stem}_{metric.value}.jsonl.gz"),
+            tags=(*self.tags, f"metric:{metric.value}"),
+        )
+
+
+DIFF_PATCH_SLICES: tuple[DiffPatchSlice, ...] = (
+    DiffPatchSlice(
+        source="swe_bench",
+        name="issue_to_patch",
+        relative_path="swe_bench/issue_to_patch.jsonl.gz",
+        metrics=(DiffPatchMetric.PATCH_TEXT, DiffPatchMetric.CONTEXT_PLUS_PATCH),
+    ),
+    DiffPatchSlice(
+        source="swe_bench",
+        name="raw_git_diff",
+        relative_path="swe_bench/raw_git_diff.jsonl.gz",
+        metrics=(DiffPatchMetric.PATCH_TEXT,),
+    ),
+    DiffPatchSlice(
+        source="commitpack",
+        name="commit_message_plus_diff",
+        relative_path="commitpack/commit_message_plus_diff.jsonl.gz",
+        metrics=(DiffPatchMetric.PATCH_TEXT, DiffPatchMetric.CONTEXT_PLUS_PATCH),
+    ),
+)
+
+
+def strip_provenance_fields(
+    row: Mapping[str, object],
+    *,
+    masked_fields: tuple[str, ...],
+) -> dict[str, object]:
+    """Return a shallow copy with masked provenance fields removed."""
+
+    return {key: value for key, value in row.items() if key not in masked_fields}
+
+
+def build_diff_patch_eval_text(
+    row: Mapping[str, object],
+    *,
+    patch_field: str,
+    context_fields: tuple[tuple[str, str], ...],
+    masked_fields: tuple[str, ...] = (),
+) -> dict[DiffPatchMetric, str]:
+    """Build patch-only and context+patch eval text from a structured row."""
+
+    sanitized = strip_provenance_fields(row, masked_fields=masked_fields)
+    patch_text = _normalize_field(sanitized.get(patch_field))
+    if not patch_text:
+        raise ValueError(f"Expected non-empty patch field '{patch_field}'")
+
+    sections: list[str] = []
+    for label, field_name in context_fields:
+        context = _normalize_field(sanitized.get(field_name))
+        if context:
+            sections.append(f"{label}:\n{context}")
+    sections.append(f"Patch:\n{patch_text}")
+
+    return {
+        DiffPatchMetric.PATCH_TEXT: patch_text,
+        DiffPatchMetric.CONTEXT_PLUS_PATCH: "\n\n".join(sections),
+    }
+
+
+def build_swe_bench_issue_to_patch_eval_text(row: Mapping[str, object]) -> dict[DiffPatchMetric, str]:
+    """Linearize SWE-bench issue+patch rows for diff/patch PPL slices."""
+
+    return build_diff_patch_eval_text(
+        row,
+        patch_field="patch",
+        context_fields=(("Issue", "problem_statement"), ("Hints", "hints_text")),
+        masked_fields=SWE_BENCH_PROVENANCE_FIELDS,
+    )
+
+
+def build_commitpack_commit_message_plus_diff_eval_text(row: Mapping[str, object]) -> dict[DiffPatchMetric, str]:
+    """Linearize CommitPack rows for commit-message-plus-diff PPL slices."""
+
+    return build_diff_patch_eval_text(
+        row,
+        patch_field="diff",
+        context_fields=(("Commit Message", "commit_message"),),
+        masked_fields=COMMITPACK_PROVENANCE_FIELDS,
+    )
+
+
+def build_diff_patch_raw_validation_sets(
+    raw_root: str = "raw/diff_patch",
+    *,
+    slices: tuple[DiffPatchSlice, ...] = DIFF_PATCH_SLICES,
+) -> dict[str, RawTextEvaluationDataset]:
+    """Render raw-text eval datasets keyed by source + slice + metric."""
+
+    datasets: dict[str, RawTextEvaluationDataset] = {}
+    for slice_spec in slices:
+        for metric in slice_spec.metrics:
+            datasets[slice_spec.dataset_key(metric)] = slice_spec.to_raw_dataset(raw_root, metric)
+    return datasets
+
+
+ACTIVE_DIFF_PATCH_DATASETS: dict[str, RawTextEvaluationDataset] = build_diff_patch_raw_validation_sets()
 
 
 def prefixed_diff_patch_validation_sets(
     datasets: Mapping[str, RawTextEvaluationDataset],
 ) -> dict[str, RawTextEvaluationDataset]:
     """Prefix diff/patch slice names with ``diff_patch/``."""
-    return {os.path.join(DIFF_PATCH_PREFIX, slice_name): dataset for slice_name, dataset in datasets.items()}
+    return {posixpath.join(DIFF_PATCH_PREFIX, slice_name): dataset for slice_name, dataset in datasets.items()}
 
 
 def diff_patch_raw_validation_sets() -> dict[str, RawTextEvaluationDataset]:
     """Diff/patch evaluation slices keyed by ``diff_patch/<slice>``."""
     return prefixed_diff_patch_validation_sets(ACTIVE_DIFF_PATCH_DATASETS)
+
+
+def _normalize_field(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    return json.dumps(value, sort_keys=True, ensure_ascii=True)

--- a/experiments/exp5095_diff_patch_ppl.py
+++ b/experiments/exp5095_diff_patch_ppl.py
@@ -1,0 +1,32 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Registry helpers for diff and patch perplexity-gap slices.
+
+Slices cover agent-facing surface forms (raw ``git diff``, commit-message-plus-diff,
+PR-review-plus-diff, issue-to-patch). Source builders are intentionally deferred;
+this module only establishes the ``diff_patch/<slice>`` namespace and the active
+registry that downstream experiments read.
+"""
+
+import os
+from collections.abc import Mapping
+
+from marin.evaluation.perplexity_gap import RawTextEvaluationDataset
+
+DIFF_PATCH_PREFIX = "diff_patch"
+
+ACTIVE_DIFF_PATCH_DATASETS: dict[str, RawTextEvaluationDataset] = {}
+
+
+def prefixed_diff_patch_validation_sets(
+    datasets: Mapping[str, RawTextEvaluationDataset],
+) -> dict[str, RawTextEvaluationDataset]:
+    """Prefix diff/patch slice names with ``diff_patch/``."""
+    return {os.path.join(DIFF_PATCH_PREFIX, slice_name): dataset for slice_name, dataset in datasets.items()}
+
+
+def diff_patch_raw_validation_sets() -> dict[str, RawTextEvaluationDataset]:
+    """Diff/patch evaluation slices keyed by ``diff_patch/<slice>``."""
+    return prefixed_diff_patch_validation_sets(ACTIVE_DIFF_PATCH_DATASETS)

--- a/experiments/exp_model_perplexity_gap_5093_5098_marin32_vs_qwen3.py
+++ b/experiments/exp_model_perplexity_gap_5093_5098_marin32_vs_qwen3.py
@@ -12,8 +12,9 @@ PPL slices without expanding default validation sets:
 - #5097 ASR/OCR noisy text: https://github.com/marin-community/marin/issues/5097
 - #5098 GH Archive structured events: https://github.com/marin-community/marin/issues/5098
 
-Run with ``--run_only <bundle-name> --max_concurrent 1`` to submit one bundle
-at a time from the same script.
+The report step combines all bundles so the 32B checkpoints are loaded once.
+Keep ``--max_concurrent 1`` on the executor run so raw materializers and the
+single TPU report do not overlap.
 """
 
 from __future__ import annotations
@@ -481,50 +482,34 @@ GH_ARCHIVE_RAW = make_gh_archive_step(
     max_events_per_event_type=MAX_DOCS_PER_DATASET,
 )
 
-DIAGNOSTIC_LOG_REPORT = _report_step(
-    bundle_name="diagnostic-logs",
-    datasets=diagnostic_log_sample_validation_sets(DIAGNOSTIC_LOG_RAW),
-    issue_ids=(5093,),
+DIAGNOSTIC_LOG_DATASETS = diagnostic_log_sample_validation_sets(DIAGNOSTIC_LOG_RAW)
+DIFF_PATCH_DATASETS = diff_patch_sample_validation_sets(DIFF_PATCH_RAW)
+PAIRED_ROBUSTNESS_DATASETS = paired_robustness_raw_validation_sets(
+    slices=PAIRED_ROBUSTNESS_CAPPED_SLICES,
+    raw_steps=PAIRED_ROBUSTNESS_RAW_STEPS,
 )
+ASR_OCR_DATASETS = noisy_asr_ocr_raw_validation_sets(noisy_asr_ocr_raw=ASR_OCR_RAW)
+GH_ARCHIVE_DATASETS = gh_archive_structured_output_raw_validation_sets(gh_archive_raw=GH_ARCHIVE_RAW)
 
-DIFF_PATCH_REPORT = _report_step(
-    bundle_name="diff-patch",
-    datasets=diff_patch_sample_validation_sets(DIFF_PATCH_RAW),
-    issue_ids=(5095,),
-)
-
-PAIRED_ROBUSTNESS_REPORT = _report_step(
-    bundle_name="paired-robustness",
-    datasets=paired_robustness_raw_validation_sets(
-        slices=PAIRED_ROBUSTNESS_CAPPED_SLICES,
-        raw_steps=PAIRED_ROBUSTNESS_RAW_STEPS,
-    ),
-    issue_ids=(5096,),
-)
-
-ASR_OCR_REPORT = _report_step(
-    bundle_name="asr-ocr-noisy",
-    datasets=noisy_asr_ocr_raw_validation_sets(noisy_asr_ocr_raw=ASR_OCR_RAW),
-    issue_ids=(5097,),
-)
-
-GH_ARCHIVE_REPORT = _report_step(
-    bundle_name="gh-archive-structured-output",
-    datasets=gh_archive_structured_output_raw_validation_sets(gh_archive_raw=GH_ARCHIVE_RAW),
-    issue_ids=(5098,),
+COMBINED_REPORT = _report_step(
+    bundle_name="5093-5098-combined",
+    datasets={
+        **DIAGNOSTIC_LOG_DATASETS,
+        **DIFF_PATCH_DATASETS,
+        **PAIRED_ROBUSTNESS_DATASETS,
+        **ASR_OCR_DATASETS,
+        **GH_ARCHIVE_DATASETS,
+    },
+    issue_ids=(5093, 5095, 5096, 5097, 5098),
 )
 
 ALL_STEPS = [
     DIAGNOSTIC_LOG_RAW,
-    DIAGNOSTIC_LOG_REPORT,
     DIFF_PATCH_RAW,
-    DIFF_PATCH_REPORT,
     *PAIRED_ROBUSTNESS_RAW_STEPS.values(),
-    PAIRED_ROBUSTNESS_REPORT,
     ASR_OCR_RAW,
-    ASR_OCR_REPORT,
     GH_ARCHIVE_RAW,
-    GH_ARCHIVE_REPORT,
+    COMBINED_REPORT,
 ]
 
 

--- a/experiments/exp_model_perplexity_gap_5093_5098_marin32_vs_qwen3.py
+++ b/experiments/exp_model_perplexity_gap_5093_5098_marin32_vs_qwen3.py
@@ -1,0 +1,430 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the first capped #5005 eval wave for issues #5093, #5095-#5098.
+
+This experiment compares Marin 32B against Qwen3 32B on newly wired long-tail
+PPL slices without expanding default validation sets:
+
+- #5093 diagnostic logs: https://github.com/marin-community/marin/issues/5093
+- #5095 diff/patch text: https://github.com/marin-community/marin/issues/5095
+- #5096 paired paraphrase/translation robustness: https://github.com/marin-community/marin/issues/5096
+- #5097 ASR/OCR noisy text: https://github.com/marin-community/marin/issues/5097
+- #5098 GH Archive structured events: https://github.com/marin-community/marin/issues/5098
+
+Run with ``--run_only <bundle-name> --max_concurrent 1`` to submit one bundle
+at a time from the same script.
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import json
+import os
+import posixpath
+import urllib.request
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field, replace
+
+import fsspec
+from datasets import load_dataset
+from fray.v2 import ResourceConfig
+
+from experiments.evals.asr_ocr_noisy_ppl import (
+    NoisyAsrOcrRawConfig,
+    materialize_noisy_asr_ocr_raw,
+    noisy_asr_ocr_raw_validation_sets,
+)
+from experiments.evals.gh_archive_structured_output import (
+    GH_ARCHIVE_EVAL_END_DATE,
+    GH_ARCHIVE_EVAL_END_HOUR,
+    GH_ARCHIVE_EVAL_START_DATE,
+    GH_ARCHIVE_EVAL_START_HOUR,
+    GH_ARCHIVE_STRUCTURED_OUTPUT_SLICES,
+    gh_archive_structured_output_raw_validation_sets,
+)
+from experiments.evals.paired_robustness_ppl import (
+    PAIRED_ROBUSTNESS_SLICES,
+    paired_robustness_raw_steps,
+    paired_robustness_raw_validation_sets,
+)
+from experiments.exp5095_diff_patch_ppl import (
+    DIFF_PATCH_SLICES,
+    SWE_BENCH_PROVENANCE_FIELDS,
+    DiffPatchMetric,
+    DiffPatchSlice,
+    build_commitpack_commit_message_plus_diff_eval_text,
+    build_diff_patch_eval_text,
+    build_swe_bench_issue_to_patch_eval_text,
+)
+from marin.datakit.download.gh_archive import make_gh_archive_step
+from marin.evaluation.perplexity_gap import GapFinderModelConfig, RawTextEvaluationDataset, default_model_perplexity_gap
+from marin.evaluation.perplexity_gap import raw_text_dataset
+from marin.execution.executor import ExecutorStep, executor_main, this_output_path
+from marin.execution.remote import remote
+
+RESOURCE_CONFIG = ResourceConfig.with_tpu("v5p-8", regions=["us-central1"])
+CPU_MATERIALIZE_RESOURCES = ResourceConfig.with_cpu(cpu=4, ram="16g", disk="30g", regions=["us-central1"])
+MAX_DOCS_PER_DATASET = 128
+MAX_DOC_BYTES = 32_768
+MAX_EVAL_LENGTH = 4096
+PER_DEVICE_BATCH_SIZE = 1
+
+MARIN_32B_MODEL = GapFinderModelConfig(
+    checkpoint_path="marin-community/marin-32b-base",
+    checkpoint_is_hf=True,
+    tokenizer="marin-community/marin-32b-base",
+)
+
+QWEN3_32B_MODEL = GapFinderModelConfig(
+    checkpoint_path="Qwen/Qwen3-32B",
+    checkpoint_is_hf=True,
+    tokenizer="Qwen/Qwen3-32B",
+)
+
+
+@dataclass(frozen=True)
+class UrlTextSample:
+    name: str
+    url: str
+    output_relative_path: str
+    compression: str | None
+    max_rows: int
+    max_bytes: int
+
+
+@dataclass(frozen=True)
+class DiagnosticLogUrlSampleConfig:
+    output_path: str = field(default_factory=this_output_path)  # type: ignore[arg-type]
+    samples: tuple[UrlTextSample, ...] = (
+        UrlTextSample(
+            name="ghalogs_runs",
+            url="https://zenodo.org/api/records/14796970/files/runs.json.gz/content",
+            output_relative_path="ghalogs/runs.jsonl.gz",
+            compression="gzip",
+            max_rows=64,
+            max_bytes=8_000_000,
+        ),
+        UrlTextSample(
+            name="loghub_apache_2k",
+            url="https://raw.githubusercontent.com/logpai/loghub/master/Apache/Apache_2k.log",
+            output_relative_path="loghub/apache.jsonl.gz",
+            compression=None,
+            max_rows=512,
+            max_bytes=2_000_000,
+        ),
+        UrlTextSample(
+            name="loghub_linux_2k",
+            url="https://raw.githubusercontent.com/logpai/loghub/master/Linux/Linux_2k.log",
+            output_relative_path="loghub/linux.jsonl.gz",
+            compression=None,
+            max_rows=512,
+            max_bytes=2_000_000,
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class DiffPatchRawConfig:
+    output_path: str = field(default_factory=this_output_path)  # type: ignore[arg-type]
+    swe_bench_max_rows: int = MAX_DOCS_PER_DATASET
+    commitpack_max_rows: int = MAX_DOCS_PER_DATASET
+
+
+def materialize_diagnostic_log_url_samples(config: DiagnosticLogUrlSampleConfig) -> None:
+    for sample in config.samples:
+        output_file = posixpath.join(config.output_path, sample.output_relative_path)
+        _write_text_rows_from_url(
+            url=sample.url,
+            output_file=output_file,
+            compression=sample.compression,
+            max_rows=sample.max_rows,
+            max_bytes=sample.max_bytes,
+        )
+
+
+def materialize_diff_patch_raw(config: DiffPatchRawConfig) -> None:
+    buffers = _empty_diff_patch_buffers()
+
+    swe_bench_rows = load_dataset("princeton-nlp/SWE-bench_Verified", split="test", streaming=True)
+    for row_index, row in enumerate(swe_bench_rows):
+        if row_index >= config.swe_bench_max_rows:
+            break
+        _append_metric_texts(
+            buffers,
+            "swe_bench/issue_to_patch",
+            build_swe_bench_issue_to_patch_eval_text(row),
+        )
+        _append_metric_texts(
+            buffers,
+            "swe_bench/raw_git_diff",
+            build_diff_patch_eval_text(
+                row,
+                patch_field="patch",
+                context_fields=(),
+                masked_fields=SWE_BENCH_PROVENANCE_FIELDS,
+            ),
+        )
+
+    commitpack_rows = load_dataset("bigcode/commitpackft", "diff", split="train", streaming=True)
+    for row_index, row in enumerate(commitpack_rows):
+        if row_index >= config.commitpack_max_rows:
+            break
+        normalized_row = _commitpack_diff_row(row)
+        _append_metric_texts(
+            buffers,
+            "commitpack/commit_message_plus_diff",
+            build_commitpack_commit_message_plus_diff_eval_text(normalized_row),
+        )
+
+    for path_stem, metrics in buffers.items():
+        for metric, records in metrics.items():
+            if not records:
+                continue
+            output_file = posixpath.join(config.output_path, f"{path_stem}_{metric.value}.jsonl.gz")
+            _write_jsonl_records(output_file, records)
+
+
+def diagnostic_log_sample_validation_sets(
+    raw_step: ExecutorStep,
+) -> dict[str, RawTextEvaluationDataset]:
+    return {
+        "diagnostic_logs/ghalogs/runs": raw_text_dataset(
+            raw_step.cd("ghalogs/runs.jsonl.gz"),
+            tags=("diagnostic_logs", "issue:5093", "source:ghalogs"),
+        ),
+        "diagnostic_logs/loghub/apache": raw_text_dataset(
+            raw_step.cd("loghub/apache.jsonl.gz"),
+            tags=("diagnostic_logs", "issue:5093", "source:loghub", "subset:apache"),
+        ),
+        "diagnostic_logs/loghub/linux": raw_text_dataset(
+            raw_step.cd("loghub/linux.jsonl.gz"),
+            tags=("diagnostic_logs", "issue:5093", "source:loghub", "subset:linux"),
+        ),
+    }
+
+
+def diff_patch_sample_validation_sets(raw_step: ExecutorStep) -> dict[str, RawTextEvaluationDataset]:
+    datasets: dict[str, RawTextEvaluationDataset] = {}
+    for slice_spec in DIFF_PATCH_SLICES:
+        for metric in slice_spec.metrics:
+            datasets[slice_spec.dataset_key(metric)] = raw_text_dataset(
+                raw_step.cd(_diff_patch_relative_path(slice_spec, metric)),
+                tags=(*slice_spec.tags, f"metric:{metric.value}"),
+            )
+    return {posixpath.join("diff_patch", name): dataset for name, dataset in datasets.items()}
+
+
+def _write_text_rows_from_url(
+    *,
+    url: str,
+    output_file: str,
+    compression: str | None,
+    max_rows: int,
+    max_bytes: int,
+) -> None:
+    if max_rows <= 0:
+        raise ValueError(f"max_rows must be positive, got {max_rows}.")
+    if max_bytes <= 0:
+        raise ValueError(f"max_bytes must be positive, got {max_bytes}.")
+
+    rows_written = 0
+    bytes_written = 0
+    with urllib.request.urlopen(url, timeout=120) as response:
+        raw_stream = gzip.GzipFile(fileobj=response) if compression == "gzip" else response
+        with io.TextIOWrapper(raw_stream, encoding="utf-8", errors="replace") as reader:
+            with _open_jsonl_gzip_writer(output_file) as writer:
+                for raw_line in reader:
+                    text = raw_line.strip()
+                    if not text:
+                        continue
+                    payload = json.dumps({"text": text}, ensure_ascii=False) + "\n"
+                    payload_bytes = len(payload.encode("utf-8"))
+                    if bytes_written + payload_bytes > max_bytes:
+                        break
+                    writer.write(payload)
+                    rows_written += 1
+                    bytes_written += payload_bytes
+                    if rows_written >= max_rows:
+                        break
+
+    if rows_written == 0:
+        raise ValueError(f"No rows were materialized from {url}.")
+
+
+def _open_jsonl_gzip_writer(path: str):
+    fs, fs_path = fsspec.core.url_to_fs(path)
+    output_dir = os.path.dirname(fs_path)
+    if output_dir:
+        fs.makedirs(output_dir, exist_ok=True)
+    return fsspec.open(path, mode="wt", compression="gzip")
+
+
+def _write_jsonl_records(path: str, records: Sequence[Mapping[str, str]]) -> None:
+    with _open_jsonl_gzip_writer(path) as writer:
+        for record in records:
+            writer.write(json.dumps(record, ensure_ascii=False))
+            writer.write("\n")
+
+
+def _empty_diff_patch_buffers() -> dict[str, dict[DiffPatchMetric, list[dict[str, str]]]]:
+    buffers: dict[str, dict[DiffPatchMetric, list[dict[str, str]]]] = {}
+    for slice_spec in DIFF_PATCH_SLICES:
+        buffers[_diff_patch_path_stem(slice_spec)] = {metric: [] for metric in slice_spec.metrics}
+    return buffers
+
+
+def _append_metric_texts(
+    buffers: dict[str, dict[DiffPatchMetric, list[dict[str, str]]]],
+    path_stem: str,
+    metric_texts: Mapping[DiffPatchMetric, str],
+) -> None:
+    for metric, text in metric_texts.items():
+        if metric in buffers[path_stem]:
+            buffers[path_stem][metric].append({"text": text})
+
+
+def _diff_patch_path_stem(slice_spec: DiffPatchSlice) -> str:
+    return slice_spec.relative_path.removesuffix(".jsonl.gz")
+
+
+def _diff_patch_relative_path(slice_spec: DiffPatchSlice, metric: DiffPatchMetric) -> str:
+    return f"{_diff_patch_path_stem(slice_spec)}_{metric.value}.jsonl.gz"
+
+
+def _commitpack_diff_row(row: Mapping[str, object]) -> dict[str, object]:
+    message = row.get("message") or row.get("subject")
+    return {
+        "diff": row.get("new_contents") or row.get("old_contents"),
+        "commit_message": message,
+        "commit_hash": row.get("commit"),
+        "repo_name": row.get("repos"),
+    }
+
+
+def _report_step(
+    *,
+    bundle_name: str,
+    datasets: dict[str, RawTextEvaluationDataset],
+    issue_ids: Iterable[int],
+) -> ExecutorStep:
+    return default_model_perplexity_gap(
+        name=f"issue5005-{bundle_name}-marin-32b-base-vs-qwen3-32b-doccap{MAX_DOCS_PER_DATASET}",
+        model_a=MARIN_32B_MODEL,
+        model_b=QWEN3_32B_MODEL,
+        datasets=datasets,
+        resource_config=RESOURCE_CONFIG,
+        per_device_batch_size=PER_DEVICE_BATCH_SIZE,
+        max_eval_length=MAX_EVAL_LENGTH,
+        max_docs_per_dataset=MAX_DOCS_PER_DATASET,
+        max_doc_bytes=MAX_DOC_BYTES,
+        wandb_tags=[
+            "eval=perplexity-gap",
+            "epic=5005",
+            f"bundle={bundle_name}",
+            "model_a=marin-community/marin-32b-base",
+            "model_b=Qwen/Qwen3-32B",
+            "region=us-central1",
+            f"max_docs_per_dataset={MAX_DOCS_PER_DATASET}",
+            *(f"issue={issue_id}" for issue_id in issue_ids),
+        ],
+    )
+
+
+DIAGNOSTIC_LOG_RAW = ExecutorStep(
+    name="raw/evals/issue5005/diagnostic_logs_marin32_qwen3_sample",
+    description="Materialize capped public diagnostic log samples for issue #5093.",
+    fn=remote(
+        materialize_diagnostic_log_url_samples,
+        resources=CPU_MATERIALIZE_RESOURCES,
+        pip_dependency_groups=["cpu"],
+    ),
+    config=DiagnosticLogUrlSampleConfig(),
+)
+
+DIFF_PATCH_RAW = ExecutorStep(
+    name="raw/evals/issue5005/diff_patch_marin32_qwen3_sample",
+    description="Materialize capped SWE-bench and CommitPack diff/patch eval samples for issue #5095.",
+    fn=remote(materialize_diff_patch_raw, resources=CPU_MATERIALIZE_RESOURCES, pip_dependency_groups=["cpu"]),
+    config=DiffPatchRawConfig(),
+)
+
+ASR_OCR_RAW = ExecutorStep(
+    name="raw/evals/issue5005/asr_ocr_noisy_marin32_qwen3_sample",
+    description="Materialize capped ASR/OCR noisy-clean eval samples for issue #5097.",
+    fn=remote(materialize_noisy_asr_ocr_raw, resources=CPU_MATERIALIZE_RESOURCES, pip_dependency_groups=["cpu"]),
+    config=NoisyAsrOcrRawConfig(max_rows_per_slice_override=MAX_DOCS_PER_DATASET),
+)
+
+PAIRED_ROBUSTNESS_CAPPED_SLICES = tuple(
+    replace(slice_, max_pairs=min(slice_.max_pairs, MAX_DOCS_PER_DATASET)) for slice_ in PAIRED_ROBUSTNESS_SLICES
+)
+PAIRED_ROBUSTNESS_RAW_STEPS = paired_robustness_raw_steps(
+    slices=PAIRED_ROBUSTNESS_CAPPED_SLICES,
+    name_prefix="raw/evals/issue5005/paired_robustness_marin32_qwen3_sample",
+    resources=CPU_MATERIALIZE_RESOURCES,
+)
+
+GH_ARCHIVE_RAW = make_gh_archive_step(
+    name="raw/evals/issue5005/gh_archive_structured_output_marin32_qwen3_sample",
+    start_date=GH_ARCHIVE_EVAL_START_DATE,
+    end_date=GH_ARCHIVE_EVAL_END_DATE,
+    start_hour=GH_ARCHIVE_EVAL_START_HOUR,
+    end_hour=GH_ARCHIVE_EVAL_END_HOUR,
+    event_types=tuple(slice_.event_type for slice_ in GH_ARCHIVE_STRUCTURED_OUTPUT_SLICES),
+    max_events_per_event_type=MAX_DOCS_PER_DATASET,
+)
+
+DIAGNOSTIC_LOG_REPORT = _report_step(
+    bundle_name="diagnostic-logs",
+    datasets=diagnostic_log_sample_validation_sets(DIAGNOSTIC_LOG_RAW),
+    issue_ids=(5093,),
+)
+
+DIFF_PATCH_REPORT = _report_step(
+    bundle_name="diff-patch",
+    datasets=diff_patch_sample_validation_sets(DIFF_PATCH_RAW),
+    issue_ids=(5095,),
+)
+
+PAIRED_ROBUSTNESS_REPORT = _report_step(
+    bundle_name="paired-robustness",
+    datasets=paired_robustness_raw_validation_sets(
+        slices=PAIRED_ROBUSTNESS_CAPPED_SLICES,
+        raw_steps=PAIRED_ROBUSTNESS_RAW_STEPS,
+    ),
+    issue_ids=(5096,),
+)
+
+ASR_OCR_REPORT = _report_step(
+    bundle_name="asr-ocr-noisy",
+    datasets=noisy_asr_ocr_raw_validation_sets(noisy_asr_ocr_raw=ASR_OCR_RAW),
+    issue_ids=(5097,),
+)
+
+GH_ARCHIVE_REPORT = _report_step(
+    bundle_name="gh-archive-structured-output",
+    datasets=gh_archive_structured_output_raw_validation_sets(gh_archive_raw=GH_ARCHIVE_RAW),
+    issue_ids=(5098,),
+)
+
+ALL_STEPS = [
+    DIAGNOSTIC_LOG_RAW,
+    DIAGNOSTIC_LOG_REPORT,
+    DIFF_PATCH_RAW,
+    DIFF_PATCH_REPORT,
+    *PAIRED_ROBUSTNESS_RAW_STEPS.values(),
+    PAIRED_ROBUSTNESS_REPORT,
+    ASR_OCR_RAW,
+    ASR_OCR_REPORT,
+    GH_ARCHIVE_RAW,
+    GH_ARCHIVE_REPORT,
+]
+
+
+if __name__ == "__main__":
+    executor_main(
+        ALL_STEPS,
+        description="Run capped issue #5005 long-tail perplexity-gap bundles for Marin 32B vs Qwen3 32B.",
+    )

--- a/experiments/exp_model_perplexity_gap_5093_5098_marin32_vs_qwen3.py
+++ b/experiments/exp_model_perplexity_gap_5093_5098_marin32_vs_qwen3.py
@@ -45,8 +45,11 @@ from experiments.evals.gh_archive_structured_output import (
     gh_archive_structured_output_raw_validation_sets,
 )
 from experiments.evals.paired_robustness_ppl import (
+    ALL_PAIRED_TEXT_VIEWS,
     PAIRED_ROBUSTNESS_SLICES,
-    paired_robustness_raw_steps,
+    PairedRobustnessMaterializeConfig,
+    PairedRobustnessSlice,
+    linearized_text_views_for_example,
     paired_robustness_raw_validation_sets,
 )
 from experiments.exp5095_diff_patch_ppl import (
@@ -130,6 +133,39 @@ class DiffPatchRawConfig:
     output_path: str = field(default_factory=this_output_path)  # type: ignore[arg-type]
     swe_bench_max_rows: int = MAX_DOCS_PER_DATASET
     commitpack_max_rows: int = MAX_DOCS_PER_DATASET
+
+
+def materialize_paired_robustness_slice_for_gap_run(config: PairedRobustnessMaterializeConfig) -> None:
+    slice_ = _paired_slice_from_config(config)
+    dataset = load_dataset(
+        path=config.hf_dataset_id,
+        name=config.hf_dataset_name,
+        split=config.split,
+        streaming=config.hf_dataset_id != "Muennighoff/flores200",
+        trust_remote_code=config.trust_remote_code,
+    )
+
+    buffers = {view: [] for view in ALL_PAIRED_TEXT_VIEWS}
+    kept_pairs = 0
+
+    for example in dataset:
+        views = linearized_text_views_for_example(slice_, example)
+        if views is None:
+            continue
+        kept_pairs += 1
+        for view, text in views.items():
+            buffers[view].append({"text": text})
+        if kept_pairs >= config.max_pairs:
+            break
+
+    if kept_pairs == 0:
+        raise ValueError(f"Slice {config.name}/{config.split} produced zero paired examples.")
+
+    for view, records in buffers.items():
+        _write_jsonl_records(
+            posixpath.join(config.output_path, view.value, "shard-00000.jsonl.gz"),
+            records,
+        )
 
 
 def materialize_diagnostic_log_url_samples(config: DiagnosticLogUrlSampleConfig) -> None:
@@ -303,6 +339,81 @@ def _commitpack_diff_row(row: Mapping[str, object]) -> dict[str, object]:
     }
 
 
+def _paired_slice_for_gap_run(slice_: PairedRobustnessSlice) -> PairedRobustnessSlice:
+    capped_slice = replace(slice_, max_pairs=min(slice_.max_pairs, MAX_DOCS_PER_DATASET))
+    if slice_.hf_dataset_id != "facebook/flores":
+        return capped_slice
+    return replace(
+        capped_slice,
+        source_url="https://huggingface.co/datasets/Muennighoff/flores200",
+        hf_dataset_id="Muennighoff/flores200",
+        trust_remote_code=True,
+    )
+
+
+def _paired_materialize_config(slice_: PairedRobustnessSlice) -> PairedRobustnessMaterializeConfig:
+    return PairedRobustnessMaterializeConfig(
+        name=slice_.name,
+        family=slice_.family,
+        source_url=slice_.source_url,
+        hf_dataset_id=slice_.hf_dataset_id,
+        hf_dataset_name=slice_.hf_dataset_name,
+        split=slice_.split,
+        source_field=slice_.source_field,
+        target_field=slice_.target_field,
+        source_label=slice_.source_label,
+        target_label=slice_.target_label,
+        max_pairs=slice_.max_pairs,
+        trust_remote_code=slice_.trust_remote_code,
+        label_field=slice_.label_field,
+        required_label=slice_.required_label,
+        notes=slice_.notes,
+    )
+
+
+def _paired_slice_from_config(config: PairedRobustnessMaterializeConfig) -> PairedRobustnessSlice:
+    return PairedRobustnessSlice(
+        name=config.name,
+        family=config.family,
+        source_url=config.source_url,
+        hf_dataset_id=config.hf_dataset_id,
+        hf_dataset_name=config.hf_dataset_name,
+        split=config.split,
+        source_field=config.source_field,
+        target_field=config.target_field,
+        source_label=config.source_label,
+        target_label=config.target_label,
+        max_pairs=config.max_pairs,
+        trust_remote_code=config.trust_remote_code,
+        label_field=config.label_field,
+        required_label=config.required_label,
+        notes=config.notes,
+    )
+
+
+def _paired_robustness_raw_steps_for_gap_run(
+    slices: Sequence[PairedRobustnessSlice],
+) -> dict[str, ExecutorStep]:
+    steps: dict[str, ExecutorStep] = {}
+    for slice_ in slices:
+        steps[slice_.raw_step_key] = ExecutorStep(
+            name=posixpath.join(
+                "raw/evals/issue5005/paired_robustness_marin32_qwen3_sample",
+                slice_.family.value,
+                slice_.name,
+                slice_.split,
+            ),
+            description=f"Materialize capped paired robustness eval records for {slice_.name}/{slice_.split}.",
+            fn=remote(
+                materialize_paired_robustness_slice_for_gap_run,
+                resources=CPU_MATERIALIZE_RESOURCES,
+                pip_dependency_groups=["cpu"],
+            ),
+            config=_paired_materialize_config(slice_),
+        )
+    return steps
+
+
 def _report_step(
     *,
     bundle_name: str,
@@ -357,14 +468,8 @@ ASR_OCR_RAW = ExecutorStep(
     config=NoisyAsrOcrRawConfig(max_rows_per_slice_override=MAX_DOCS_PER_DATASET),
 )
 
-PAIRED_ROBUSTNESS_CAPPED_SLICES = tuple(
-    replace(slice_, max_pairs=min(slice_.max_pairs, MAX_DOCS_PER_DATASET)) for slice_ in PAIRED_ROBUSTNESS_SLICES
-)
-PAIRED_ROBUSTNESS_RAW_STEPS = paired_robustness_raw_steps(
-    slices=PAIRED_ROBUSTNESS_CAPPED_SLICES,
-    name_prefix="raw/evals/issue5005/paired_robustness_marin32_qwen3_sample",
-    resources=CPU_MATERIALIZE_RESOURCES,
-)
+PAIRED_ROBUSTNESS_CAPPED_SLICES = tuple(_paired_slice_for_gap_run(slice_) for slice_ in PAIRED_ROBUSTNESS_SLICES)
+PAIRED_ROBUSTNESS_RAW_STEPS = _paired_robustness_raw_steps_for_gap_run(PAIRED_ROBUSTNESS_CAPPED_SLICES)
 
 GH_ARCHIVE_RAW = make_gh_archive_step(
     name="raw/evals/issue5005/gh_archive_structured_output_marin32_qwen3_sample",

--- a/experiments/exp_model_perplexity_gap_asr_ocr_noisy.py
+++ b/experiments/exp_model_perplexity_gap_asr_ocr_noisy.py
@@ -1,0 +1,79 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run opt-in ASR/OCR noisy-text perplexity-gap reports for issue #5097."""
+
+from fray.v2.types import ResourceConfig
+
+from experiments.defaults import default_raw_validation_sets
+from experiments.evals.asr_ocr_noisy_ppl import noisy_asr_ocr_raw_validation_sets
+from marin.evaluation.perplexity_gap import GapFinderModelConfig, default_model_perplexity_gap
+from marin.execution.executor import executor_main
+
+RESOURCE_CONFIG = ResourceConfig.with_tpu("v5p-8", regions=["us-central1"])
+MAX_DOCS_PER_DATASET = 256
+MAX_DOC_BYTES = 32_768
+
+DATASETS = {
+    **default_raw_validation_sets(),
+    **noisy_asr_ocr_raw_validation_sets(),
+}
+
+MARIN_MODEL = GapFinderModelConfig(
+    checkpoint_path="marin-community/marin-8b-base",
+    checkpoint_is_hf=True,
+    tokenizer="meta-llama/Llama-3.1-8B",
+)
+
+MARIN_VS_LLAMA = default_model_perplexity_gap(
+    name="asr-ocr-noisy-marin-8b-base-vs-llama-3.1-8b-base-doccap256",
+    model_a=MARIN_MODEL,
+    model_b=GapFinderModelConfig(
+        checkpoint_path="meta-llama/Llama-3.1-8B",
+        checkpoint_is_hf=True,
+        tokenizer="meta-llama/Llama-3.1-8B",
+    ),
+    datasets=DATASETS,
+    resource_config=RESOURCE_CONFIG,
+    per_device_batch_size=4,
+    max_eval_length=4096,
+    max_docs_per_dataset=MAX_DOCS_PER_DATASET,
+    max_doc_bytes=MAX_DOC_BYTES,
+    wandb_tags=[
+        "eval=perplexity-gap",
+        "bundle=asr_ocr_noisy_ppl",
+        "model_a=marin-community/marin-8b-base",
+        "model_b=meta-llama/Llama-3.1-8B",
+        f"max_docs_per_dataset={MAX_DOCS_PER_DATASET}",
+    ],
+)
+
+MARIN_VS_QWEN3 = default_model_perplexity_gap(
+    name="asr-ocr-noisy-marin-8b-base-vs-qwen3-8b-base-doccap256",
+    model_a=MARIN_MODEL,
+    model_b=GapFinderModelConfig(
+        checkpoint_path="Qwen/Qwen3-8B-Base",
+        checkpoint_is_hf=True,
+        tokenizer="Qwen/Qwen3-8B",
+    ),
+    datasets=DATASETS,
+    resource_config=RESOURCE_CONFIG,
+    per_device_batch_size=4,
+    max_eval_length=4096,
+    max_docs_per_dataset=MAX_DOCS_PER_DATASET,
+    max_doc_bytes=MAX_DOC_BYTES,
+    wandb_tags=[
+        "eval=perplexity-gap",
+        "bundle=asr_ocr_noisy_ppl",
+        "model_a=marin-community/marin-8b-base",
+        "model_b=Qwen/Qwen3-8B-Base",
+        f"max_docs_per_dataset={MAX_DOCS_PER_DATASET}",
+    ],
+)
+
+
+if __name__ == "__main__":
+    executor_main(
+        [MARIN_VS_LLAMA, MARIN_VS_QWEN3],
+        description="Run Marin perplexity-gap reports on opt-in ASR/OCR noisy-text slices.",
+    )

--- a/experiments/exp_model_perplexity_gap_gh_archive_structured_output.py
+++ b/experiments/exp_model_perplexity_gap_gh_archive_structured_output.py
@@ -1,0 +1,73 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from fray.v2.types import ResourceConfig
+
+from experiments.evals.gh_archive_structured_output import gh_archive_structured_output_raw_validation_sets
+from marin.evaluation.perplexity_gap import GapFinderModelConfig, default_model_perplexity_gap
+from marin.execution.executor import executor_main
+
+RESOURCE_CONFIG = ResourceConfig.with_tpu("v5p-8", regions=["us-central1"])
+MAX_DOCS_PER_DATASET = 256
+MAX_DOC_BYTES = 32_768
+
+DATASETS = gh_archive_structured_output_raw_validation_sets()
+
+MARIN_MODEL = GapFinderModelConfig(
+    checkpoint_path="marin-community/marin-8b-base",
+    checkpoint_is_hf=True,
+    tokenizer="meta-llama/Llama-3.1-8B",
+)
+
+MARIN_VS_LLAMA = default_model_perplexity_gap(
+    name="gh-archive-structured-output-marin-8b-base-vs-llama-3.1-8b-base-doccap256",
+    model_a=MARIN_MODEL,
+    model_b=GapFinderModelConfig(
+        checkpoint_path="meta-llama/Llama-3.1-8B",
+        checkpoint_is_hf=True,
+        tokenizer="meta-llama/Llama-3.1-8B",
+    ),
+    datasets=DATASETS,
+    resource_config=RESOURCE_CONFIG,
+    per_device_batch_size=4,
+    max_eval_length=4096,
+    max_docs_per_dataset=MAX_DOCS_PER_DATASET,
+    max_doc_bytes=MAX_DOC_BYTES,
+    wandb_tags=[
+        "eval=perplexity-gap",
+        "bundle=gh_archive_structured_output",
+        "epic=5005",
+        "issue=5098",
+        f"max_docs_per_dataset={MAX_DOCS_PER_DATASET}",
+    ],
+)
+
+MARIN_VS_QWEN3 = default_model_perplexity_gap(
+    name="gh-archive-structured-output-marin-8b-base-vs-qwen3-8b-base-doccap256",
+    model_a=MARIN_MODEL,
+    model_b=GapFinderModelConfig(
+        checkpoint_path="Qwen/Qwen3-8B-Base",
+        checkpoint_is_hf=True,
+        tokenizer="Qwen/Qwen3-8B",
+    ),
+    datasets=DATASETS,
+    resource_config=RESOURCE_CONFIG,
+    per_device_batch_size=4,
+    max_eval_length=4096,
+    max_docs_per_dataset=MAX_DOCS_PER_DATASET,
+    max_doc_bytes=MAX_DOC_BYTES,
+    wandb_tags=[
+        "eval=perplexity-gap",
+        "bundle=gh_archive_structured_output",
+        "epic=5005",
+        "issue=5098",
+        f"max_docs_per_dataset={MAX_DOCS_PER_DATASET}",
+    ],
+)
+
+
+if __name__ == "__main__":
+    executor_main(
+        [MARIN_VS_LLAMA, MARIN_VS_QWEN3],
+        description="Run perplexity-gap reports on GH Archive structured-output eval slices.",
+    )

--- a/experiments/exp_model_perplexity_gap_paired_robustness.py
+++ b/experiments/exp_model_perplexity_gap_paired_robustness.py
@@ -1,0 +1,85 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run opt-in paired robustness perplexity-gap reports for issue #5096."""
+
+from fray.v2.types import ResourceConfig
+
+from experiments.defaults import default_raw_validation_sets
+from experiments.evals.paired_robustness_ppl import paired_robustness_raw_steps, paired_robustness_raw_validation_sets
+from marin.evaluation.perplexity_gap import GapFinderModelConfig, default_model_perplexity_gap
+from marin.execution.executor import executor_main
+
+RESOURCE_CONFIG = ResourceConfig.with_tpu("v5p-8", regions=["us-central1"])
+MAX_DOCS_PER_DATASET = 256
+MAX_DOC_BYTES = 32_768
+
+PAIRED_ROBUSTNESS_RAW_STEPS = paired_robustness_raw_steps()
+
+DATASETS = {
+    **default_raw_validation_sets(),
+    **paired_robustness_raw_validation_sets(raw_steps=PAIRED_ROBUSTNESS_RAW_STEPS),
+}
+
+MARIN_MODEL = GapFinderModelConfig(
+    checkpoint_path="marin-community/marin-8b-base",
+    checkpoint_is_hf=True,
+    tokenizer="meta-llama/Llama-3.1-8B",
+)
+
+MARIN_VS_LLAMA = default_model_perplexity_gap(
+    name="paired-robustness-marin-8b-base-vs-llama-3.1-8b-base-doccap256",
+    model_a=MARIN_MODEL,
+    model_b=GapFinderModelConfig(
+        checkpoint_path="meta-llama/Llama-3.1-8B",
+        checkpoint_is_hf=True,
+        tokenizer="meta-llama/Llama-3.1-8B",
+    ),
+    datasets=DATASETS,
+    resource_config=RESOURCE_CONFIG,
+    per_device_batch_size=4,
+    max_eval_length=4096,
+    max_docs_per_dataset=MAX_DOCS_PER_DATASET,
+    max_doc_bytes=MAX_DOC_BYTES,
+    wandb_tags=[
+        "eval=perplexity-gap",
+        "rerun=paired-robustness",
+        "model_a=marin-community/marin-8b-base",
+        "model_b=meta-llama/Llama-3.1-8B",
+        "dataset_bundle=default_raw_plus_paired_robustness",
+        "region=us-central1",
+        f"max_docs_per_dataset={MAX_DOCS_PER_DATASET}",
+    ],
+)
+
+MARIN_VS_QWEN3 = default_model_perplexity_gap(
+    name="paired-robustness-marin-8b-base-vs-qwen3-8b-base-doccap256",
+    model_a=MARIN_MODEL,
+    model_b=GapFinderModelConfig(
+        checkpoint_path="Qwen/Qwen3-8B-Base",
+        checkpoint_is_hf=True,
+        tokenizer="Qwen/Qwen3-8B",
+    ),
+    datasets=DATASETS,
+    resource_config=RESOURCE_CONFIG,
+    per_device_batch_size=4,
+    max_eval_length=4096,
+    max_docs_per_dataset=MAX_DOCS_PER_DATASET,
+    max_doc_bytes=MAX_DOC_BYTES,
+    wandb_tags=[
+        "eval=perplexity-gap",
+        "rerun=paired-robustness",
+        "model_a=marin-community/marin-8b-base",
+        "model_b=Qwen/Qwen3-8B-Base",
+        "dataset_bundle=default_raw_plus_paired_robustness",
+        "region=us-central1",
+        f"max_docs_per_dataset={MAX_DOCS_PER_DATASET}",
+    ],
+)
+
+
+if __name__ == "__main__":
+    executor_main(
+        [*PAIRED_ROBUSTNESS_RAW_STEPS.values(), MARIN_VS_LLAMA, MARIN_VS_QWEN3],
+        description="Run Marin perplexity-gap reports with opt-in paired paraphrase and translation robustness slices.",
+    )

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -1,0 +1,380 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public diagnostic-log source inventory and extraction helpers for training."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+import hashlib
+import json
+import logging
+import os.path
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+
+import fsspec
+from marin.utils import fsspec_mkdirs
+
+from marin.datakit.download.rollout_transforms import load_parquet_batched
+from marin.execution.step_spec import StepSpec
+
+logger = logging.getLogger(__name__)
+
+GHALOGS_RECORD_URL = "https://zenodo.org/records/14796970"
+LOGCHUNKS_RECORD_URL = "https://zenodo.org/records/3632351"
+LOGHUB_REPO_URL = "https://github.com/logpai/loghub"
+STARCODERDATA_URL = "https://huggingface.co/datasets/bigcode/starcoderdata"
+
+GHALOGS_TOTAL_BYTES = 143_425_404_506
+LOGCHUNKS_TOTAL_BYTES = 24_108_826
+LOGHUB_REPO_SIZE_BYTES = 7_513_088
+STARCODERDATA_TOTAL_BYTES = 310_802_033_041
+
+STARCODERDATA_REVISION = "9fc30b5"
+DEFAULT_SAMPLE_MAX_PARQUET_FILES = 8
+DEFAULT_SAMPLE_MAX_ROWS = 200_000
+
+_PARTITION_BUCKETS = 10_000
+_ISSUE_5093_HOLDOUT_BUCKETS = 100
+_DEV_BUCKETS = 100
+_TEST_BUCKETS = 100
+_PARTITION_HASH_PERSON = b"diag-log-v1"
+
+_PATH_SIGNAL_PATTERNS = (
+    "/log/",
+    "/logs/",
+    "stacktrace",
+    "stack-trace",
+    "traceback",
+    "stderr",
+    "stdout",
+    "golden",
+    "snapshot",
+    "fixture",
+    "failure",
+    "error",
+)
+_PATH_SIGNAL_RE = re.compile("|".join(re.escape(signal) for signal in _PATH_SIGNAL_PATTERNS))
+
+_CONTENT_SIGNAL_RE = re.compile(
+    r"(?im)"
+    r"(traceback \(most recent call last\)|"
+    r"\bexception\b|"
+    r"\berror\b|"
+    r"\bfailed\b|"
+    r"\bpanic:|"
+    r"\bstack trace\b|"
+    r"\bassertionerror\b|"
+    r"\bsegmentation fault\b)"
+)
+
+_REDACTION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}\b"), "<REDACTED_GITHUB_TOKEN>"),
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"), "<REDACTED_GITHUB_TOKEN>"),
+    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "<REDACTED_AWS_ACCESS_KEY>"),
+    (
+        re.compile(
+            r"(?im)(?P<key>\b(?:api[_-]?key|token|secret|password|passwd)\b)\s*[:=]\s*['\"]?[A-Za-z0-9_\-./+=]{8,}"
+        ),
+        r"\g<key>=<REDACTED_SECRET>",
+    ),
+    (re.compile(r"\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[A-Za-z]{2,}\b"), "<REDACTED_EMAIL>"),
+    (re.compile(r"(?:(?:/Users|/home)/[^/\s]+)"), "<REDACTED_USER_HOME>"),
+    (re.compile(r"\b[A-Za-z]:\\Users\\[^\\\s]+"), "<REDACTED_WINDOWS_USER_HOME>"),
+    (re.compile(r"gs://marin-[^)\s]+"), "gs://<REDACTED_INTERNAL_BUCKET>"),
+)
+
+
+class DiagnosticSourceStatus(StrEnum):
+    """Training eligibility for a candidate source."""
+
+    TRAINING_READY = "training_ready"
+    BLOCKED_LICENSE = "blocked_license"
+    EVAL_ONLY = "eval_only"
+
+
+class DiagnosticPartition(StrEnum):
+    """Stable split assignment for diagnostic logs."""
+
+    TRAIN = "train"
+    DEV = "dev"
+    TEST = "test"
+    ISSUE_5093_HOLDOUT = "issue_5093_holdout"
+
+
+@dataclass(frozen=True)
+class DiagnosticLogSource:
+    """Metadata and policy for one diagnostic-log candidate source."""
+
+    name: str
+    source_url: str
+    source_license: str
+    source_format: str
+    compressed_size_bytes: int | None
+    contamination_risk: str
+    status: DiagnosticSourceStatus
+    provenance_notes: str
+    rough_tokens_b: float | None
+
+
+SOURCE_INVENTORY: tuple[DiagnosticLogSource, ...] = (
+    DiagnosticLogSource(
+        name="ghalogs",
+        source_url=GHALOGS_RECORD_URL,
+        source_license="unspecified (Zenodo access_right=open; no explicit rights metadata)",
+        source_format="runs.json.gz, repositories.json.gz, github_run_logs.zip",
+        compressed_size_bytes=GHALOGS_TOTAL_BYTES,
+        contamination_risk="high: public CI logs can contain secrets and internal paths",
+        status=DiagnosticSourceStatus.BLOCKED_LICENSE,
+        provenance_notes="DOI 10.5281/zenodo.14796970, published 2025-02-03.",
+        rough_tokens_b=None,
+    ),
+    DiagnosticLogSource(
+        name="logchunks",
+        source_url=LOGCHUNKS_RECORD_URL,
+        source_license="unspecified (Zenodo access_right=open; no explicit rights metadata)",
+        source_format="LogChunks.zip (XML chunk annotations)",
+        compressed_size_bytes=LOGCHUNKS_TOTAL_BYTES,
+        contamination_risk="medium: labeled failure snippets may include local paths and user names",
+        status=DiagnosticSourceStatus.BLOCKED_LICENSE,
+        provenance_notes="DOI 10.5281/zenodo.3632351, published 2020-01-31.",
+        rough_tokens_b=None,
+    ),
+    DiagnosticLogSource(
+        name="loghub",
+        source_url=LOGHUB_REPO_URL,
+        source_license="custom research/academic-only license",
+        source_format="mixed plain-text log files grouped by dataset",
+        compressed_size_bytes=LOGHUB_REPO_SIZE_BYTES,
+        contamination_risk="medium: includes system identifiers and infrastructure paths",
+        status=DiagnosticSourceStatus.BLOCKED_LICENSE,
+        provenance_notes="LICENSE file restricts usage to research/academic work.",
+        rough_tokens_b=None,
+    ),
+    DiagnosticLogSource(
+        name="github_fixture_logs_from_source_corpora",
+        source_url=STARCODERDATA_URL,
+        source_license="inherits accepted source-corpus licensing and per-repo provenance",
+        source_format="parquet rows with repo path + content",
+        compressed_size_bytes=STARCODERDATA_TOTAL_BYTES,
+        contamination_risk="medium: fixtures often include tokens, email addresses, and host paths",
+        status=DiagnosticSourceStatus.TRAINING_READY,
+        provenance_notes=(
+            "Extract only files with diagnostic path/content signals from existing source corpora; "
+            "apply sanitization before any split is materialized."
+        ),
+        rough_tokens_b=0.15,
+    ),
+    DiagnosticLogSource(
+        name="marin_owned_ci_iris_zephyr_logs",
+        source_url="internal",
+        source_license="not public",
+        source_format="internal run logs",
+        compressed_size_bytes=None,
+        contamination_risk="high: internal infra identifiers and sensitive traces",
+        status=DiagnosticSourceStatus.EVAL_ONLY,
+        provenance_notes="Eval-only until governance and sanitization policy is explicitly approved.",
+        rough_tokens_b=None,
+    ),
+    DiagnosticLogSource(
+        name="issue_5093_eval_slices",
+        source_url="https://github.com/marin-community/marin/issues/5093",
+        source_license="eval holdout policy",
+        source_format="held-out eval slices",
+        compressed_size_bytes=None,
+        contamination_risk="high: direct eval contamination",
+        status=DiagnosticSourceStatus.EVAL_ONLY,
+        provenance_notes="Never include in training.",
+        rough_tokens_b=None,
+    ),
+)
+
+
+def source_inventory() -> tuple[DiagnosticLogSource, ...]:
+    """Return the immutable source inventory for public diagnostic logs."""
+    return SOURCE_INVENTORY
+
+
+def training_ready_sources() -> tuple[DiagnosticLogSource, ...]:
+    """Return only source entries that are approved for training ingestion."""
+    return tuple(source for source in SOURCE_INVENTORY if source.status == DiagnosticSourceStatus.TRAINING_READY)
+
+
+def sanitize_diagnostic_log_text(text: str) -> str:
+    """Redact sensitive tokens, identities, and internal paths from log text."""
+    sanitized = text
+    for pattern, replacement in _REDACTION_RULES:
+        sanitized = pattern.sub(replacement, sanitized)
+    return sanitized
+
+
+def looks_like_diagnostic_log_row(path: str, content: str) -> bool:
+    """Return True if path/content indicate a diagnostic log fixture or stack trace."""
+    path_value = path.lower()
+    if not _PATH_SIGNAL_RE.search(path_value):
+        return False
+    return _CONTENT_SIGNAL_RE.search(content) is not None
+
+
+def assign_partition(split_key: str) -> DiagnosticPartition:
+    """Assign a stable partition with a dedicated #5093 holdout slice."""
+    digest = hashlib.blake2b(split_key.encode("utf-8"), digest_size=8, person=_PARTITION_HASH_PERSON).digest()
+    bucket = int.from_bytes(digest, byteorder="big") % _PARTITION_BUCKETS
+
+    if bucket < _ISSUE_5093_HOLDOUT_BUCKETS:
+        return DiagnosticPartition.ISSUE_5093_HOLDOUT
+    if bucket < _ISSUE_5093_HOLDOUT_BUCKETS + _DEV_BUCKETS:
+        return DiagnosticPartition.DEV
+    if bucket < _ISSUE_5093_HOLDOUT_BUCKETS + _DEV_BUCKETS + _TEST_BUCKETS:
+        return DiagnosticPartition.TEST
+    return DiagnosticPartition.TRAIN
+
+
+def starcoder_fixture_row_to_record(row: Mapping[str, object]) -> dict[str, str] | None:
+    """Convert one StarCoder row into a sanitized diagnostic-log record."""
+    content = row.get("content")
+    path = row.get("max_stars_repo_path")
+    repo = row.get("max_stars_repo_name")
+
+    if not isinstance(content, str) or not content.strip():
+        return None
+    if not isinstance(path, str) or not path:
+        return None
+    if not isinstance(repo, str) or not repo:
+        return None
+    if not looks_like_diagnostic_log_row(path, content):
+        return None
+
+    split_key = f"{repo}:{path}"
+    partition = assign_partition(split_key)
+    sanitized = sanitize_diagnostic_log_text(content)
+    row_id = hashlib.sha256(split_key.encode("utf-8")).hexdigest()
+
+    return {
+        "id": row_id,
+        "text": sanitized,
+        "source": "github_fixture_logs",
+        "repo_name": repo,
+        "repo_path": path,
+        "partition": partition.value,
+    }
+
+
+def _source_path(fs: fsspec.AbstractFileSystem, relative_path: str) -> str:
+    protocol = fs.protocol
+    if isinstance(protocol, tuple):
+        protocol = protocol[0]
+    if protocol in (None, "", "file"):
+        return relative_path
+    return f"{protocol}://{relative_path}"
+
+
+def _list_parquet_files(input_path: str) -> list[str]:
+    fs, relative_root = fsspec.core.url_to_fs(input_path)
+    pattern = os.path.join(relative_root.rstrip("/"), "**", "*.parquet")
+    paths = sorted(fs.glob(pattern, recursive=True))
+    return [_source_path(fs, path) for path in paths]
+
+
+def extract_starcoder_fixture_logs(
+    input_path: str,
+    output_path: str,
+    *,
+    max_parquet_files: int = DEFAULT_SAMPLE_MAX_PARQUET_FILES,
+    max_rows: int = DEFAULT_SAMPLE_MAX_ROWS,
+) -> None:
+    """Extract a capped sample of partitioned diagnostic fixture logs from StarCoderData parquet shards."""
+    if max_parquet_files <= 0:
+        raise ValueError(f"max_parquet_files must be positive, got {max_parquet_files}")
+    if max_rows <= 0:
+        raise ValueError(f"max_rows must be positive, got {max_rows}")
+
+    counters = {"seen_rows": 0, "kept_rows": 0}
+    partition_counts = {partition.value: 0 for partition in DiagnosticPartition}
+    parquet_files = _list_parquet_files(input_path)
+
+    if not parquet_files:
+        raise ValueError(f"No parquet files found at {input_path}")
+
+    sampled_files = parquet_files[:max_parquet_files]
+    logger.info(
+        "Sampling %d/%d parquet shards from %s with row cap=%d",
+        len(sampled_files),
+        len(parquet_files),
+        input_path,
+        max_rows,
+    )
+
+    output_file_paths: dict[str, str] = {}
+    for partition in DiagnosticPartition:
+        partition_dir = os.path.join(output_path, partition.value)
+        fsspec_mkdirs(partition_dir, exist_ok=True)
+        output_file_paths[partition.value] = os.path.join(partition_dir, "data-00000-of-00001.jsonl")
+
+    with ExitStack() as stack:
+        writers = {
+            partition.value: stack.enter_context(fsspec.open(path, "wt", encoding="utf-8"))
+            for partition, path in ((partition, output_file_paths[partition.value]) for partition in DiagnosticPartition)
+        }
+
+        row_budget_exhausted = False
+        for parquet_file in sampled_files:
+            for row in load_parquet_batched(parquet_file):
+                if counters["seen_rows"] >= max_rows:
+                    row_budget_exhausted = True
+                    break
+                counters["seen_rows"] += 1
+
+                record = starcoder_fixture_row_to_record(row)
+                if record is None:
+                    continue
+
+                counters["kept_rows"] += 1
+                partition = record["partition"]
+                partition_counts[partition] += 1
+                writers[partition].write(json.dumps(record, ensure_ascii=False))
+                writers[partition].write("\n")
+            if row_budget_exhausted:
+                break
+
+    metadata = {
+        "source": "bigcode/starcoderdata",
+        "revision": STARCODERDATA_REVISION,
+        "sample_limits": {"max_parquet_files": max_parquet_files, "max_rows": max_rows},
+        "sampling": {"available_parquet_files": len(parquet_files), "sampled_parquet_files": len(sampled_files)},
+        "counters": counters,
+        "partition_counts": partition_counts,
+        "training_ready_sources": [source.name for source in training_ready_sources()],
+    }
+    with fsspec.open(os.path.join(output_path, "metadata.json"), "wt", encoding="utf-8") as handle:
+        json.dump(metadata, handle, indent=2, sort_keys=True)
+
+
+def extract_starcoder_fixture_logs_step(
+    *,
+    source_path: str,
+    max_parquet_files: int = DEFAULT_SAMPLE_MAX_PARQUET_FILES,
+    max_rows: int = DEFAULT_SAMPLE_MAX_ROWS,
+) -> StepSpec:
+    """Return a StepSpec that materializes a capped sample of partitioned diagnostic logs."""
+    return StepSpec(
+        name="processed/diagnostic_logs/github_fixtures_sample",
+        fn=lambda output_path: extract_starcoder_fixture_logs(
+            source_path,
+            output_path,
+            max_parquet_files=max_parquet_files,
+            max_rows=max_rows,
+        ),
+        hash_attrs={
+            "version": "v1",
+            "sample_only": True,
+            "source_path": source_path,
+            "max_parquet_files": max_parquet_files,
+            "max_rows": max_rows,
+            "split_policy": "97% train / 1% dev / 1% test / 1% issue_5093_holdout",
+            "sanitization_rules": "gh token/aws key/secret kv/email/user path/internal gs path",
+        },
+    )

--- a/lib/marin/src/marin/datakit/download/gh_archive.py
+++ b/lib/marin/src/marin/datakit/download/gh_archive.py
@@ -163,7 +163,10 @@ def _bucket_hash(value: str) -> str:
 
 
 def _bucket_url(value: str) -> str:
-    parsed = urlsplit(value)
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return "<URL>"
     if not parsed.scheme or not parsed.netloc:
         return value
 

--- a/lib/marin/src/marin/datakit/download/gh_archive.py
+++ b/lib/marin/src/marin/datakit/download/gh_archive.py
@@ -1,0 +1,438 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Download and normalize held-out GH Archive event slices for PPL/gap evals."""
+
+from __future__ import annotations
+
+import gzip
+import io
+import json
+import logging
+import posixpath
+import re
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from contextlib import ExitStack
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import requests
+from rigging.filesystem import open_url
+from zephyr.writers import atomic_rename
+
+from marin.execution import ExecutorStep
+from marin.execution.step_spec import StepSpec
+from marin.utils import fsspec_exists, fsspec_mkdirs
+
+logger = logging.getLogger(__name__)
+
+GH_ARCHIVE_BASE_URL = "https://data.gharchive.org"
+GH_ARCHIVE_REQUIRED_EVENT_TYPES: tuple[str, ...] = (
+    "PushEvent",
+    "PullRequestEvent",
+    "IssuesEvent",
+    "IssueCommentEvent",
+)
+GH_ARCHIVE_OPTIONAL_EVENT_TYPES: tuple[str, ...] = ("WorkflowRunEvent",)
+GH_ARCHIVE_DEFAULT_EVENT_TYPES: tuple[str, ...] = (*GH_ARCHIVE_REQUIRED_EVENT_TYPES, *GH_ARCHIVE_OPTIONAL_EVENT_TYPES)
+
+HASH_KEY_FIELDS = frozenset({"sha", "before", "after", "head", "head_sha", "base_sha", "tree_id", "commit_id"})
+ID_KEY_FIELDS = frozenset(
+    {
+        "id",
+        "node_id",
+        "actor_id",
+        "repo_id",
+        "comment_id",
+        "issue_id",
+        "pull_request_id",
+        "run_id",
+    }
+)
+TIMESTAMP_KEY_FIELDS = frozenset(
+    {"created_at", "updated_at", "closed_at", "merged_at", "run_started_at", "run_completed_at", "published_at"}
+)
+
+HEX_RE = re.compile(r"^[0-9a-f]{16,}$", flags=re.IGNORECASE)
+SHA_RE = re.compile(r"^[0-9a-f]{7,64}$", flags=re.IGNORECASE)
+LONG_INT_RE = re.compile(r"^\d{8,}$")
+UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", flags=re.IGNORECASE)
+TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{24,}$")
+ISO_8601_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
+
+
+@dataclass(frozen=True)
+class GhArchiveDownloadConfig:
+    output_path: str
+    start_date: str
+    end_date: str
+    start_hour: int = 0
+    end_hour: int = 23
+    event_types: tuple[str, ...] = GH_ARCHIVE_DEFAULT_EVENT_TYPES
+    max_events_per_event_type: int | None = None
+    request_timeout: int = 120
+    base_url: str = GH_ARCHIVE_BASE_URL
+    metadata_filename: str = "metadata.json"
+    skip_existing: bool = True
+
+
+def _parse_date(value: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"Expected date in YYYY-MM-DD format, got {value!r}") from exc
+
+
+def _validate_download_config(cfg: GhArchiveDownloadConfig) -> None:
+    start = _parse_date(cfg.start_date)
+    end = _parse_date(cfg.end_date)
+    if start > end:
+        raise ValueError(f"start_date must be <= end_date, got {cfg.start_date} > {cfg.end_date}")
+    if not 0 <= cfg.start_hour <= 23:
+        raise ValueError(f"start_hour must be in [0, 23], got {cfg.start_hour}")
+    if not 0 <= cfg.end_hour <= 23:
+        raise ValueError(f"end_hour must be in [0, 23], got {cfg.end_hour}")
+    if cfg.start_hour > cfg.end_hour:
+        raise ValueError(f"start_hour must be <= end_hour, got {cfg.start_hour} > {cfg.end_hour}")
+    if not cfg.event_types:
+        raise ValueError("event_types must include at least one event type")
+    if len(set(cfg.event_types)) != len(cfg.event_types):
+        raise ValueError("event_types must be unique")
+    if cfg.max_events_per_event_type is not None and cfg.max_events_per_event_type <= 0:
+        raise ValueError("max_events_per_event_type must be positive")
+    if cfg.request_timeout <= 0:
+        raise ValueError("request_timeout must be positive")
+
+
+def gh_archive_hour_urls(
+    *,
+    start_date: str,
+    end_date: str,
+    start_hour: int = 0,
+    end_hour: int = 23,
+    base_url: str = GH_ARCHIVE_BASE_URL,
+) -> list[str]:
+    start = _parse_date(start_date)
+    end = _parse_date(end_date)
+    if start > end:
+        raise ValueError(f"start_date must be <= end_date, got {start_date} > {end_date}")
+    if start_hour > end_hour:
+        raise ValueError(f"start_hour must be <= end_hour, got {start_hour} > {end_hour}")
+    if not 0 <= start_hour <= 23 or not 0 <= end_hour <= 23:
+        raise ValueError("start_hour and end_hour must be in [0, 23]")
+
+    urls: list[str] = []
+    current = start
+    while current <= end:
+        day = current.isoformat()
+        for hour in range(start_hour, end_hour + 1):
+            urls.append(f"{base_url.rstrip('/')}/{day}-{hour}.json.gz")
+        current += timedelta(days=1)
+    return urls
+
+
+def _bucket_identifier(value: str, *, force: bool = False) -> str:
+    if LONG_INT_RE.fullmatch(value):
+        return f"<INT_{len(value)}>"
+    if UUID_RE.fullmatch(value):
+        return "<UUID>"
+    if HEX_RE.fullmatch(value):
+        return f"<HEX_{len(value)}>"
+    if SHA_RE.fullmatch(value):
+        return f"<SHA_{len(value)}>"
+    if TOKEN_RE.fullmatch(value):
+        return f"<ID_{len(value)}>"
+    if force:
+        return "<ID>"
+    return value
+
+
+def _bucket_timestamp(value: str) -> str:
+    if ISO_8601_RE.fullmatch(value):
+        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return f"<DATE:{timestamp.date().isoformat()}>"
+    return value
+
+
+def _bucket_hash(value: str) -> str:
+    if SHA_RE.fullmatch(value) or HEX_RE.fullmatch(value):
+        return f"<SHA_{len(value)}>"
+    return "<SHA>"
+
+
+def _bucket_url(value: str) -> str:
+    parsed = urlsplit(value)
+    if not parsed.scheme or not parsed.netloc:
+        return value
+
+    bucketed_segments = [_bucket_identifier(segment) for segment in parsed.path.split("/")]
+
+    query_pairs = []
+    for key, query_value in parse_qsl(parsed.query, keep_blank_values=True):
+        bucketed_query_value = _bucket_scalar(query_value, path=(key,))
+        if not isinstance(bucketed_query_value, str):
+            bucketed_query_value = str(bucketed_query_value)
+        query_pairs.append((key, bucketed_query_value))
+
+    return urlunsplit(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            "/".join(bucketed_segments),
+            urlencode(query_pairs, doseq=True),
+            parsed.fragment,
+        )
+    )
+
+
+def _bucket_scalar(value: str, *, path: tuple[str, ...]) -> str:
+    key = path[-1] if path else ""
+
+    if key in HASH_KEY_FIELDS:
+        return _bucket_hash(value)
+    if key in ID_KEY_FIELDS:
+        return _bucket_identifier(value, force=True)
+    if key in TIMESTAMP_KEY_FIELDS:
+        return _bucket_timestamp(value)
+    if value.startswith(("https://", "http://")):
+        return _bucket_url(value)
+    if ISO_8601_RE.fullmatch(value):
+        return _bucket_timestamp(value)
+    if LONG_INT_RE.fullmatch(value):
+        return f"<INT_{len(value)}>"
+    if SHA_RE.fullmatch(value):
+        return f"<SHA_{len(value)}>"
+    return value
+
+
+def _mask_json_value(value: Any, *, path: tuple[str, ...]) -> Any:
+    if isinstance(value, dict):
+        return {key: _mask_json_value(item, path=(*path, key)) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_mask_json_value(item, path=path) for item in value]
+    if isinstance(value, str):
+        return _bucket_scalar(value, path=path)
+    if isinstance(value, int) and path and path[-1] in ID_KEY_FIELDS:
+        return f"<INT_{len(str(abs(value)))}>"
+    return value
+
+
+def stable_json_serialize(value: Any) -> str:
+    """Serialize JSON with deterministic key order and separators."""
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def normalize_gh_archive_event(
+    event: dict[str, Any],
+    *,
+    event_types: set[str],
+) -> tuple[str, dict[str, str]] | None:
+    event_type = event.get("type")
+    if not isinstance(event_type, str):
+        return None
+    if event_type not in event_types:
+        return None
+
+    masked_event = _mask_json_value(event, path=())
+    return event_type, {"text": stable_json_serialize(masked_event)}
+
+
+def read_gh_archive_hour(url: str, timeout: int) -> Iterator[dict[str, Any]]:
+    """Yield GH Archive events from one hourly ``.json.gz`` file."""
+    with requests.get(url, timeout=timeout, stream=True) as response:
+        if response.status_code == 404:
+            logger.info("GH Archive hour not found, skipping: %s", url)
+            return
+        response.raise_for_status()
+        with gzip.GzipFile(fileobj=response.raw) as gz_file:
+            with io.TextIOWrapper(gz_file, encoding="utf-8") as reader:
+                for line_number, line in enumerate(reader, start=1):
+                    text = line.strip()
+                    if not text:
+                        continue
+                    try:
+                        payload = json.loads(text)
+                    except json.JSONDecodeError as exc:
+                        raise ValueError(f"Invalid JSON in {url} line {line_number}") from exc
+                    if not isinstance(payload, dict):
+                        continue
+                    yield payload
+
+
+def _event_output_path(output_path: str, event_type: str) -> str:
+    return posixpath.join(output_path, event_type, "part-00000.jsonl.gz")
+
+
+def _all_event_type_caps_reached(counts: dict[str, int], cap: int | None) -> bool:
+    if cap is None:
+        return False
+    return all(value >= cap for value in counts.values())
+
+
+def _write_metadata(path: str, payload: dict[str, Any]) -> None:
+    with atomic_rename(path) as temp_path:
+        with open_url(temp_path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def download_gh_archive_events(
+    cfg: GhArchiveDownloadConfig,
+    *,
+    read_hour_events: Callable[[str, int], Iterable[dict[str, Any]]] = read_gh_archive_hour,
+) -> dict[str, Any]:
+    _validate_download_config(cfg)
+
+    event_types = tuple(cfg.event_types)
+    counts = {event_type: 0 for event_type in event_types}
+    output_files = {event_type: _event_output_path(cfg.output_path, event_type) for event_type in event_types}
+    metadata_path = posixpath.join(cfg.output_path, cfg.metadata_filename)
+
+    if cfg.skip_existing and all(fsspec_exists(path) for path in output_files.values()) and fsspec_exists(metadata_path):
+        logger.info("Skipping GH Archive download; output already exists at %s", cfg.output_path)
+        with open_url(metadata_path, "r", encoding="utf-8") as handle:
+            metadata = json.load(handle)
+        return {
+            "success": True,
+            "skipped": True,
+            "counts": metadata.get("counts", counts),
+            "output_files": output_files,
+        }
+
+    scanned_hour_urls: list[str] = []
+    event_type_set = set(event_types)
+
+    with ExitStack() as stack:
+        writers: dict[str, Any] = {}
+        for event_type, output_file in output_files.items():
+            fsspec_mkdirs(posixpath.dirname(output_file), exist_ok=True)
+            temp_path = stack.enter_context(atomic_rename(output_file))
+            writers[event_type] = stack.enter_context(open_url(temp_path, "wt", encoding="utf-8", compression="gzip"))
+
+        for hour_url in gh_archive_hour_urls(
+            start_date=cfg.start_date,
+            end_date=cfg.end_date,
+            start_hour=cfg.start_hour,
+            end_hour=cfg.end_hour,
+            base_url=cfg.base_url,
+        ):
+            scanned_hour_urls.append(hour_url)
+            for event in read_hour_events(hour_url, cfg.request_timeout):
+                normalized = normalize_gh_archive_event(event, event_types=event_type_set)
+                if normalized is None:
+                    continue
+                event_type, row = normalized
+                if cfg.max_events_per_event_type is not None and counts[event_type] >= cfg.max_events_per_event_type:
+                    continue
+                json.dump(row, writers[event_type], ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+                writers[event_type].write("\n")
+                counts[event_type] += 1
+            if _all_event_type_caps_reached(counts, cfg.max_events_per_event_type):
+                break
+
+    metadata = {
+        "start_date": cfg.start_date,
+        "end_date": cfg.end_date,
+        "start_hour": cfg.start_hour,
+        "end_hour": cfg.end_hour,
+        "base_url": cfg.base_url,
+        "event_types": event_types,
+        "max_events_per_event_type": cfg.max_events_per_event_type,
+        "counts": counts,
+        "output_files": output_files,
+        "hours_scanned": scanned_hour_urls,
+    }
+    _write_metadata(metadata_path, metadata)
+
+    return {
+        "success": True,
+        "counts": counts,
+        "output_files": output_files,
+        "metadata_file": metadata_path,
+        "hours_scanned": scanned_hour_urls,
+    }
+
+
+def gh_archive_step(
+    *,
+    name: str = "raw/gh_archive/structured_output_eval",
+    start_date: str,
+    end_date: str,
+    start_hour: int = 0,
+    end_hour: int = 23,
+    event_types: Sequence[str] = GH_ARCHIVE_DEFAULT_EVENT_TYPES,
+    max_events_per_event_type: int | None = None,
+    request_timeout: int = 120,
+    base_url: str = GH_ARCHIVE_BASE_URL,
+    metadata_filename: str = "metadata.json",
+    skip_existing: bool = True,
+    deps: list[StepSpec] | None = None,
+    output_path_prefix: str | None = None,
+    override_output_path: str | None = None,
+) -> StepSpec:
+    resolved_event_types = tuple(dict.fromkeys(event_types))
+
+    def _run(output_path: str) -> dict[str, Any]:
+        cfg = GhArchiveDownloadConfig(
+            output_path=output_path,
+            start_date=start_date,
+            end_date=end_date,
+            start_hour=start_hour,
+            end_hour=end_hour,
+            event_types=resolved_event_types,
+            max_events_per_event_type=max_events_per_event_type,
+            request_timeout=request_timeout,
+            base_url=base_url,
+            metadata_filename=metadata_filename,
+            skip_existing=skip_existing,
+        )
+        return download_gh_archive_events(cfg)
+
+    return StepSpec(
+        name=name,
+        fn=_run,
+        deps=deps or [],
+        hash_attrs={
+            "start_date": start_date,
+            "end_date": end_date,
+            "start_hour": start_hour,
+            "end_hour": end_hour,
+            "event_types": resolved_event_types,
+            "max_events_per_event_type": max_events_per_event_type,
+            "base_url": base_url,
+            "metadata_filename": metadata_filename,
+        },
+        output_path_prefix=output_path_prefix,
+        override_output_path=override_output_path,
+    )
+
+
+def make_gh_archive_step(
+    *,
+    name: str = "raw/gh_archive/structured_output_eval",
+    start_date: str,
+    end_date: str,
+    start_hour: int = 0,
+    end_hour: int = 23,
+    event_types: Sequence[str] = GH_ARCHIVE_DEFAULT_EVENT_TYPES,
+    max_events_per_event_type: int | None = None,
+    request_timeout: int = 120,
+    base_url: str = GH_ARCHIVE_BASE_URL,
+    metadata_filename: str = "metadata.json",
+    skip_existing: bool = True,
+) -> ExecutorStep:
+    """Create an ExecutorStep that downloads and normalizes held-out GH Archive events."""
+    return gh_archive_step(
+        name=name,
+        start_date=start_date,
+        end_date=end_date,
+        start_hour=start_hour,
+        end_hour=end_hour,
+        event_types=event_types,
+        max_events_per_event_type=max_events_per_event_type,
+        request_timeout=request_timeout,
+        base_url=base_url,
+        metadata_filename=metadata_filename,
+        skip_existing=skip_existing,
+    ).as_executor_step()

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -1,0 +1,124 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from marin.datakit.download.diagnostic_logs import (
+    DiagnosticSourceStatus,
+    extract_starcoder_fixture_logs,
+    sanitize_diagnostic_log_text,
+    source_inventory,
+    starcoder_fixture_row_to_record,
+    training_ready_sources,
+)
+
+
+def _write_parquet(path: str, rows: list[dict[str, object]]) -> None:
+    table = pa.Table.from_pylist(rows)
+    pq.write_table(table, path)
+
+
+def _read_jsonl(path: str) -> list[dict[str, object]]:
+    if not os.path.exists(path):
+        return []
+    with open(path) as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+def test_source_inventory_contains_required_candidates():
+    inventory = {entry.name: entry for entry in source_inventory()}
+
+    assert "ghalogs" in inventory
+    assert "logchunks" in inventory
+    assert "loghub" in inventory
+    assert "github_fixture_logs_from_source_corpora" in inventory
+    assert inventory["ghalogs"].status == DiagnosticSourceStatus.BLOCKED_LICENSE
+    assert inventory["logchunks"].status == DiagnosticSourceStatus.BLOCKED_LICENSE
+    assert inventory["loghub"].status == DiagnosticSourceStatus.BLOCKED_LICENSE
+
+
+def test_training_ready_sources_are_opt_in_and_narrow():
+    ready = training_ready_sources()
+    assert [source.name for source in ready] == ["github_fixture_logs_from_source_corpora"]
+
+
+def test_sanitize_diagnostic_log_text_redacts_secrets_and_identifiers():
+    text = (
+        "token=supersecretvalue123 ghp_abcdefghijklmnopqrstuvwxyz123456 "
+        "email me at foo@example.com path=/Users/alice/project"
+    )
+    redacted = sanitize_diagnostic_log_text(text)
+    assert "supersecretvalue123" not in redacted
+    assert "foo@example.com" not in redacted
+    assert "/Users/alice" not in redacted
+    assert "<REDACTED_SECRET>" in redacted
+    assert "<REDACTED_GITHUB_TOKEN>" in redacted
+    assert "<REDACTED_EMAIL>" in redacted
+    assert "<REDACTED_USER_HOME>" in redacted
+
+
+def test_starcoder_fixture_row_to_record_detects_and_sanitizes():
+    row = {
+        "max_stars_repo_path": "tests/fixtures/build_logs/stderr.log",
+        "max_stars_repo_name": "example/repo",
+        "content": "ERROR token=abc123456789 traceback (most recent call last)",
+    }
+
+    record = starcoder_fixture_row_to_record(row)
+    assert record is not None
+    assert record["source"] == "github_fixture_logs"
+    assert record["repo_name"] == "example/repo"
+    assert record["repo_path"] == "tests/fixtures/build_logs/stderr.log"
+    assert "abc123456789" not in record["text"]
+    assert "<REDACTED_SECRET>" in record["text"]
+
+
+def test_extract_starcoder_fixture_logs_is_sample_capped(tmp_path):
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    shard_dir = input_dir / "nested"
+    shard_dir.mkdir(parents=True)
+
+    _write_parquet(
+        str(shard_dir / "a.parquet"),
+        [
+            {
+                "max_stars_repo_path": "ci/logs/stderr.log",
+                "max_stars_repo_name": "a/repo",
+                "content": "ERROR token=abc123456789 traceback (most recent call last)",
+            },
+            {
+                "max_stars_repo_path": "src/main.py",
+                "max_stars_repo_name": "a/repo",
+                "content": "print('hello')",
+            },
+        ],
+    )
+    _write_parquet(
+        str(shard_dir / "b.parquet"),
+        [
+            {
+                "max_stars_repo_path": "tests/golden/failure.log",
+                "max_stars_repo_name": "b/repo",
+                "content": "FAILED: build panic: something bad happened",
+            }
+        ],
+    )
+
+    extract_starcoder_fixture_logs(str(input_dir), str(output_dir), max_parquet_files=1, max_rows=1)
+
+    metadata = json.loads((output_dir / "metadata.json").read_text())
+    assert metadata["sample_limits"]["max_parquet_files"] == 1
+    assert metadata["sample_limits"]["max_rows"] == 1
+    assert metadata["sampling"]["sampled_parquet_files"] == 1
+    assert metadata["counters"]["seen_rows"] == 1
+    assert metadata["counters"]["kept_rows"] == 1
+
+    kept_records = []
+    for partition in ("train", "dev", "test", "issue_5093_holdout"):
+        kept_records.extend(_read_jsonl(str(output_dir / partition / "data-00000-of-00001.jsonl")))
+    assert len(kept_records) == 1

--- a/tests/evals/test_asr_ocr_noisy_ppl.py
+++ b/tests/evals/test_asr_ocr_noisy_ppl.py
@@ -1,0 +1,80 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import gzip
+import json
+
+from experiments.evals.asr_ocr_noisy_ppl import (
+    ASR_OCR_NOISY_DATASET_ROOT,
+    ASR_OCR_NOISY_SLICES,
+    NoisyAsrOcrRawConfig,
+    NoisyTextFamily,
+    NoisyTextSlice,
+    linearize_noisy_clean_row,
+    materialize_noisy_asr_ocr_raw,
+    noisy_asr_ocr_raw_validation_sets,
+)
+from marin.processing.tokenize import HfDatasetSpec
+
+
+def test_linearize_noisy_clean_row_uses_first_hypothesis_and_preserves_reference():
+    row = {"hyps": ["THE CAT SAT", "THE CATS AT"], "ref": "the cat sat"}
+
+    linearized = linearize_noisy_clean_row(row, noisy_key="hyps", clean_key="ref")
+
+    assert linearized == {"noisy_text": "THE CAT SAT", "clean_text": "the cat sat"}
+
+
+def test_noisy_asr_ocr_raw_validation_sets_registers_clean_and_noisy_slices():
+    class _SyntheticRawStep:
+        def cd(self, path: str) -> str:
+            return f"gs://synthetic/{path}"
+
+    datasets = noisy_asr_ocr_raw_validation_sets(noisy_asr_ocr_raw=_SyntheticRawStep())
+
+    first_slice = ASR_OCR_NOISY_SLICES[0]
+    noisy_key = f"{ASR_OCR_NOISY_DATASET_ROOT}/{first_slice.registry_name}/noisy"
+    clean_key = f"{ASR_OCR_NOISY_DATASET_ROOT}/{first_slice.registry_name}/clean"
+
+    assert datasets[noisy_key].text_key == "noisy_text"
+    assert datasets[clean_key].text_key == "clean_text"
+    assert isinstance(datasets[noisy_key].input_path, str)
+    assert f"/{first_slice.registry_name}/data-*.jsonl.gz" in datasets[noisy_key].input_path
+    assert datasets[noisy_key].tags[-1] == "variant:noisy"
+    assert datasets[clean_key].tags[-1] == "variant:clean"
+
+
+def test_materialize_noisy_asr_ocr_raw_respects_per_slice_cap(tmp_path, monkeypatch):
+    from experiments.evals import asr_ocr_noisy_ppl
+
+    rows = [
+        {"hyps": ["NOISY ONE"], "ref": "clean one"},
+        {"hyps": ["NOISY TWO"], "ref": "clean two"},
+        {"hyps": ["NOISY THREE"], "ref": "clean three"},
+    ]
+
+    def _fake_load_dataset(*args, **kwargs):
+        del args, kwargs
+        return rows
+
+    monkeypatch.setattr(asr_ocr_noisy_ppl, "load_dataset", _fake_load_dataset)
+    slice_ = NoisyTextSlice(
+        registry_name="synthetic",
+        family=NoisyTextFamily.ASR,
+        source_url="https://example.com",
+        hf_dataset=HfDatasetSpec(id="synthetic/dataset"),
+        split="test",
+        noisy_key="hyps",
+        clean_key="ref",
+        max_rows=2,
+    )
+
+    materialize_noisy_asr_ocr_raw(NoisyAsrOcrRawConfig(output_path=str(tmp_path), slices=(slice_,)))
+
+    with gzip.open(tmp_path / "synthetic" / "data-00000-of-00001.jsonl.gz", "rt") as handle:
+        materialized = [json.loads(line) for line in handle]
+
+    assert materialized == [
+        {"noisy_text": "NOISY ONE", "clean_text": "clean one"},
+        {"noisy_text": "NOISY TWO", "clean_text": "clean two"},
+    ]

--- a/tests/evals/test_diagnostic_log_eval_builders.py
+++ b/tests/evals/test_diagnostic_log_eval_builders.py
@@ -1,0 +1,121 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import gzip
+import json
+from pathlib import Path
+
+from experiments.evals.diagnostic_log_eval_builders import (
+    diagnostic_log_eval_output_path,
+    materialize_ghalogs_eval_sample,
+    materialize_loghub_eval_sample,
+)
+from experiments.evals.long_tail_ppl import LongTailPplFamily, long_tail_raw_validation_sets
+
+
+def _write_lines(path: Path, lines: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n")
+
+
+def _read_jsonl_gz(path: Path) -> list[dict[str, str]]:
+    records: list[dict[str, str]] = []
+    with gzip.open(path, "rt", encoding="utf-8") as handle:
+        for line in handle:
+            if line.strip():
+                records.append(json.loads(line))
+    return records
+
+
+def test_materialize_ghalogs_eval_sample_converts_pre_staged_logs(tmp_path):
+    source_root = tmp_path / "ghalogs_source"
+    output_path = tmp_path / "raw" / "diagnostic_logs" / "ghalogs" / "runs.jsonl.gz"
+
+    _write_lines(
+        source_root / "a.jsonl",
+        [
+            json.dumps({"message": "Run started"}),
+            json.dumps({"log": "Step failed: exit status 1"}),
+            "stderr: traceback (most recent call last)",
+        ],
+    )
+    _write_lines(source_root / "b.log", ["plain line from second file"])
+
+    stats = materialize_ghalogs_eval_sample(
+        source_path=str(source_root),
+        output_path=str(output_path),
+        max_files=2,
+        max_rows=3,
+        max_bytes=10_000,
+    )
+    records = _read_jsonl_gz(output_path)
+
+    assert [record["text"] for record in records] == [
+        "Run started",
+        "Step failed: exit status 1",
+        "stderr: traceback (most recent call last)",
+    ]
+    assert stats.files_used == 1
+    assert stats.rows_written == 3
+
+
+def test_materialize_loghub_eval_sample_respects_file_and_row_caps(tmp_path):
+    source_root = tmp_path / "loghub_source"
+    output_path = tmp_path / "raw" / "diagnostic_logs" / "loghub" / "apache.jsonl.gz"
+
+    _write_lines(source_root / "apache" / "a.log", ["line one", "line two", "line three"])
+    _write_lines(source_root / "apache" / "b.log", ["line four"])
+
+    stats = materialize_loghub_eval_sample(
+        source_path=str(source_root),
+        output_path=str(output_path),
+        max_files=1,
+        max_rows=2,
+        max_bytes=10_000,
+    )
+    records = _read_jsonl_gz(output_path)
+
+    assert [record["text"] for record in records] == ["line one", "line two"]
+    assert stats.files_used == 1
+    assert stats.rows_written == 2
+
+
+def test_materialize_loghub_eval_sample_enforces_max_bytes(tmp_path):
+    source_root = tmp_path / "loghub_source"
+    output_path = tmp_path / "raw" / "diagnostic_logs" / "loghub" / "apache.jsonl.gz"
+
+    _write_lines(
+        source_root / "apache" / "a.log",
+        [
+            "ERROR this is a long diagnostic line with details 0001",
+            "ERROR this is a long diagnostic line with details 0002",
+            "ERROR this is a long diagnostic line with details 0003",
+        ],
+    )
+
+    stats = materialize_loghub_eval_sample(
+        source_path=str(source_root),
+        output_path=str(output_path),
+        max_files=1,
+        max_rows=100,
+        max_bytes=140,
+    )
+    records = _read_jsonl_gz(output_path)
+
+    assert 0 < len(records) < 3
+    assert stats.rows_written == len(records)
+    assert stats.bytes_written <= 140
+
+
+def test_diagnostic_log_output_paths_match_long_tail_registry_paths():
+    raw_root = "gs://example-bucket/raw/long_tail"
+    datasets = long_tail_raw_validation_sets(raw_root=raw_root, family=LongTailPplFamily.DIAGNOSTIC_LOGS)
+
+    assert (
+        diagnostic_log_eval_output_path(raw_root, slice_name="ghalogs")
+        == datasets["long_tail_ppl/diagnostic_logs/ghalogs"].input_path
+    )
+    assert (
+        diagnostic_log_eval_output_path(raw_root, slice_name="loghub_apache")
+        == datasets["long_tail_ppl/diagnostic_logs/loghub_apache"].input_path
+    )

--- a/tests/evals/test_exp5095_diff_patch_ppl.py
+++ b/tests/evals/test_exp5095_diff_patch_ppl.py
@@ -1,0 +1,34 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from experiments import exp5095_diff_patch_ppl as diff_patch
+from marin.evaluation.perplexity_gap import RawTextEvaluationDataset
+
+
+def test_prefixed_diff_patch_validation_sets_prefixes_each_slice() -> None:
+    raw_diff = RawTextEvaluationDataset(input_path="raw/diff_patch/swe_bench_raw_diff.jsonl.gz")
+    commit_plus_diff = RawTextEvaluationDataset(input_path="raw/diff_patch/commitpack_msg_plus_diff.jsonl.gz")
+
+    prefixed = diff_patch.prefixed_diff_patch_validation_sets(
+        {
+            "swe_bench_raw_diff": raw_diff,
+            "commitpack_msg_plus_diff": commit_plus_diff,
+        }
+    )
+
+    assert prefixed == {
+        os.path.join(diff_patch.DIFF_PATCH_PREFIX, "swe_bench_raw_diff"): raw_diff,
+        os.path.join(diff_patch.DIFF_PATCH_PREFIX, "commitpack_msg_plus_diff"): commit_plus_diff,
+    }
+
+
+def test_diff_patch_raw_validation_sets_reads_active_registry(monkeypatch) -> None:
+    issue_to_patch = RawTextEvaluationDataset(input_path="raw/diff_patch/swe_bench_issue_to_patch.jsonl.gz")
+
+    monkeypatch.setattr(diff_patch, "ACTIVE_DIFF_PATCH_DATASETS", {"swe_bench_issue_to_patch": issue_to_patch})
+
+    assert diff_patch.diff_patch_raw_validation_sets() == {
+        os.path.join(diff_patch.DIFF_PATCH_PREFIX, "swe_bench_issue_to_patch"): issue_to_patch
+    }

--- a/tests/evals/test_exp5095_diff_patch_ppl.py
+++ b/tests/evals/test_exp5095_diff_patch_ppl.py
@@ -71,3 +71,12 @@ def test_diff_patch_raw_validation_sets_prefixes_namespace() -> None:
     prefixed = diff_patch.diff_patch_raw_validation_sets()
     assert "diff_patch/swe_bench/issue_to_patch_patch_text" in prefixed
     assert "diff_patch/commitpack/commit_message_plus_diff_context_plus_patch" in prefixed
+
+
+def test_diff_patch_sampling_plan_uses_small_held_out_caps() -> None:
+    plan = diff_patch.diff_patch_source_sampling_plan()
+
+    assert plan["swe_bench/issue_to_patch"]["held_out_sample_cap"] == 256
+    assert plan["swe_bench/raw_git_diff"]["held_out_sample_cap"] == 256
+    assert plan["commitpack/commit_message_plus_diff"]["held_out_sample_cap"] == 512
+    assert all(entry["split"] == "validation" for entry in plan.values())

--- a/tests/evals/test_exp5095_diff_patch_ppl.py
+++ b/tests/evals/test_exp5095_diff_patch_ppl.py
@@ -1,34 +1,73 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-
 from experiments import exp5095_diff_patch_ppl as diff_patch
-from marin.evaluation.perplexity_gap import RawTextEvaluationDataset
 
 
-def test_prefixed_diff_patch_validation_sets_prefixes_each_slice() -> None:
-    raw_diff = RawTextEvaluationDataset(input_path="raw/diff_patch/swe_bench_raw_diff.jsonl.gz")
-    commit_plus_diff = RawTextEvaluationDataset(input_path="raw/diff_patch/commitpack_msg_plus_diff.jsonl.gz")
+def test_build_diff_patch_raw_validation_sets_emits_two_sources_and_split_metrics() -> None:
+    datasets = diff_patch.build_diff_patch_raw_validation_sets(raw_root="gs://example-bucket/raw/diff_patch")
 
-    prefixed = diff_patch.prefixed_diff_patch_validation_sets(
-        {
-            "swe_bench_raw_diff": raw_diff,
-            "commitpack_msg_plus_diff": commit_plus_diff,
-        }
+    swe_patch = datasets["swe_bench/issue_to_patch_patch_text"]
+    swe_context = datasets["swe_bench/issue_to_patch_context_plus_patch"]
+    commitpack_patch = datasets["commitpack/commit_message_plus_diff_patch_text"]
+
+    assert swe_patch.input_path == "gs://example-bucket/raw/diff_patch/swe_bench/issue_to_patch_patch_text.jsonl.gz"
+    assert (
+        swe_context.input_path
+        == "gs://example-bucket/raw/diff_patch/swe_bench/issue_to_patch_context_plus_patch.jsonl.gz"
     )
+    assert commitpack_patch.input_path == (
+        "gs://example-bucket/raw/diff_patch/commitpack/commit_message_plus_diff_patch_text.jsonl.gz"
+    )
+    assert swe_patch.tags is not None and "metric:patch_text" in swe_patch.tags
+    assert swe_context.tags is not None and "metric:context_plus_patch" in swe_context.tags
 
-    assert prefixed == {
-        os.path.join(diff_patch.DIFF_PATCH_PREFIX, "swe_bench_raw_diff"): raw_diff,
-        os.path.join(diff_patch.DIFF_PATCH_PREFIX, "commitpack_msg_plus_diff"): commit_plus_diff,
+
+def test_build_swe_bench_issue_to_patch_eval_text_masks_provenance_fields() -> None:
+    row = {
+        "instance_id": "django__django-12345",
+        "repo": "django/django",
+        "base_commit": "abc123",
+        "problem_statement": "Fix template regression when None is rendered.",
+        "hints_text": "Regression introduced in parser cleanup.",
+        "patch": "diff --git a/a.py b/a.py\n+return 'fixed'\n",
     }
 
+    rendered = diff_patch.build_swe_bench_issue_to_patch_eval_text(row)
 
-def test_diff_patch_raw_validation_sets_reads_active_registry(monkeypatch) -> None:
-    issue_to_patch = RawTextEvaluationDataset(input_path="raw/diff_patch/swe_bench_issue_to_patch.jsonl.gz")
+    patch_only = rendered[diff_patch.DiffPatchMetric.PATCH_TEXT]
+    context_plus_patch = rendered[diff_patch.DiffPatchMetric.CONTEXT_PLUS_PATCH]
 
-    monkeypatch.setattr(diff_patch, "ACTIVE_DIFF_PATCH_DATASETS", {"swe_bench_issue_to_patch": issue_to_patch})
+    assert patch_only.startswith("diff --git a/a.py b/a.py")
+    assert "Issue:\nFix template regression when None is rendered." in context_plus_patch
+    assert "Hints:\nRegression introduced in parser cleanup." in context_plus_patch
+    assert "repo" not in context_plus_patch
+    assert "django__django-12345" not in context_plus_patch
+    assert "base_commit" not in context_plus_patch
 
-    assert diff_patch.diff_patch_raw_validation_sets() == {
-        os.path.join(diff_patch.DIFF_PATCH_PREFIX, "swe_bench_issue_to_patch"): issue_to_patch
+
+def test_build_commitpack_eval_text_separates_patch_and_commit_message() -> None:
+    row = {
+        "repo_name": "org/repo",
+        "commit_hash": "f00dbabe",
+        "url": "https://example.invalid/commit/f00dbabe",
+        "commit_message": "Fix null handling in adapter.",
+        "diff": "diff --git a/adapter.py b/adapter.py\n+if value is None:\n+    return ''\n",
     }
+
+    rendered = diff_patch.build_commitpack_commit_message_plus_diff_eval_text(row)
+
+    assert rendered[diff_patch.DiffPatchMetric.PATCH_TEXT] == (
+        "diff --git a/adapter.py b/adapter.py\n+if value is None:\n+    return ''"
+    )
+    assert rendered[diff_patch.DiffPatchMetric.CONTEXT_PLUS_PATCH].startswith(
+        "Commit Message:\nFix null handling in adapter."
+    )
+    assert "repo_name" not in rendered[diff_patch.DiffPatchMetric.CONTEXT_PLUS_PATCH]
+    assert "f00dbabe" not in rendered[diff_patch.DiffPatchMetric.CONTEXT_PLUS_PATCH]
+
+
+def test_diff_patch_raw_validation_sets_prefixes_namespace() -> None:
+    prefixed = diff_patch.diff_patch_raw_validation_sets()
+    assert "diff_patch/swe_bench/issue_to_patch_patch_text" in prefixed
+    assert "diff_patch/commitpack/commit_message_plus_diff_context_plus_patch" in prefixed

--- a/tests/evals/test_gh_archive_structured_output.py
+++ b/tests/evals/test_gh_archive_structured_output.py
@@ -33,6 +33,7 @@ def _event(
             "comment": {
                 "id": 112233445566,
                 "html_url": "https://api.github.com/repos/marin-community/marin/issues/comments/112233445566",
+                "malformed_url": "https://[hsjobeki] /not-a-valid-url",
             },
         },
     }
@@ -95,6 +96,7 @@ def test_download_gh_archive_events_filters_masks_and_serializes(tmp_path: Path)
     assert push_payload["payload"]["after"] == "<SHA_40>"
     assert push_payload["payload"]["before"] == "<SHA_40>"
     assert push_payload["payload"]["comment"]["html_url"].endswith("/issues/comments/<INT_12>")
+    assert push_payload["payload"]["comment"]["malformed_url"] == "<URL>"
     assert push_payload["repo"]["id"] == "<INT_10>"
     assert push_payload["created_at"] == "<DATE:2024-02-01>"
     assert push_text == json.dumps(push_payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)

--- a/tests/evals/test_gh_archive_structured_output.py
+++ b/tests/evals/test_gh_archive_structured_output.py
@@ -1,0 +1,145 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import gzip
+import json
+from pathlib import Path
+
+from experiments.evals.gh_archive_structured_output import (
+    GH_ARCHIVE_OPTIONAL_EVENT_TYPES,
+    GH_ARCHIVE_REQUIRED_EVENT_TYPES,
+    gh_archive_structured_output_raw_validation_sets,
+)
+from marin.datakit.download.gh_archive import GhArchiveDownloadConfig, download_gh_archive_events, gh_archive_step
+
+
+def _event(
+    *,
+    event_type: str,
+    event_id: str,
+    before_sha: str = "a" * 40,
+    after_sha: str = "b" * 40,
+) -> dict:
+    return {
+        "id": event_id,
+        "type": event_type,
+        "created_at": "2024-02-01T12:34:56Z",
+        "actor": {"id": 9132456789, "login": "octocat", "node_id": "MDQ6VXNlcjE="},
+        "repo": {"id": 9988776655, "name": "marin-community/marin"},
+        "payload": {
+            "before": before_sha,
+            "after": after_sha,
+            "head": "c" * 40,
+            "comment": {
+                "id": 112233445566,
+                "html_url": "https://api.github.com/repos/marin-community/marin/issues/comments/112233445566",
+            },
+        },
+    }
+
+
+def _read_jsonl_gz(path: Path) -> list[dict]:
+    rows: list[dict] = []
+    with gzip.open(path, "rt", encoding="utf-8") as handle:
+        for line in handle:
+            rows.append(json.loads(line))
+    return rows
+
+
+def test_download_gh_archive_events_filters_masks_and_serializes(tmp_path: Path):
+    base_url = "https://example-gh-archive"
+    cfg = GhArchiveDownloadConfig(
+        output_path=str(tmp_path / "gh_archive_eval"),
+        start_date="2024-02-01",
+        end_date="2024-02-01",
+        start_hour=0,
+        end_hour=1,
+        base_url=base_url,
+        event_types=(*GH_ARCHIVE_REQUIRED_EVENT_TYPES, *GH_ARCHIVE_OPTIONAL_EVENT_TYPES),
+        max_events_per_event_type=None,
+        request_timeout=30,
+    )
+
+    url_to_events = {
+        f"{base_url}/2024-02-01-0.json.gz": [
+            _event(event_type="PushEvent", event_id="1234567890123"),
+            _event(event_type="WatchEvent", event_id="1234567890124"),
+            _event(event_type="PullRequestEvent", event_id="1234567890125"),
+        ],
+        f"{base_url}/2024-02-01-1.json.gz": [
+            _event(event_type="IssuesEvent", event_id="1234567890126"),
+            _event(event_type="IssueCommentEvent", event_id="1234567890127"),
+            _event(event_type="WorkflowRunEvent", event_id="1234567890128"),
+        ],
+    }
+
+    def read_hour_events(url: str, timeout: int):
+        assert timeout == 30
+        return url_to_events.get(url, ())
+
+    result = download_gh_archive_events(cfg, read_hour_events=read_hour_events)
+
+    assert result["counts"] == {
+        "IssueCommentEvent": 1,
+        "IssuesEvent": 1,
+        "PullRequestEvent": 1,
+        "PushEvent": 1,
+        "WorkflowRunEvent": 1,
+    }
+
+    push_rows = _read_jsonl_gz(tmp_path / "gh_archive_eval" / "PushEvent" / "part-00000.jsonl.gz")
+    assert len(push_rows) == 1
+    push_text = push_rows[0]["text"]
+    push_payload = json.loads(push_text)
+    assert push_payload["id"] == "<INT_13>"
+    assert push_payload["payload"]["after"] == "<SHA_40>"
+    assert push_payload["payload"]["before"] == "<SHA_40>"
+    assert push_payload["payload"]["comment"]["html_url"].endswith("/issues/comments/<INT_12>")
+    assert push_payload["repo"]["id"] == "<INT_10>"
+    assert push_payload["created_at"] == "<DATE:2024-02-01>"
+    assert push_text == json.dumps(push_payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+    assert not (tmp_path / "gh_archive_eval" / "WatchEvent").exists()
+
+
+def test_gh_archive_structured_output_raw_validation_sets_paths_and_tags():
+    datasets = gh_archive_structured_output_raw_validation_sets(raw_root="gs://example-bucket/raw/gha")
+
+    push = datasets["gh_archive_structured_output/PushEvent"]
+    workflow = datasets["gh_archive_structured_output/WorkflowRunEvent"]
+
+    assert push.input_path == "gs://example-bucket/raw/gha/PushEvent/*.jsonl.gz"
+    assert push.tags == (
+        "gh_archive_structured_output",
+        "epic:5005",
+        "issue:5098",
+        "event_type:PushEvent",
+    )
+    assert workflow.input_path == "gs://example-bucket/raw/gha/WorkflowRunEvent/*.jsonl.gz"
+
+
+def test_gh_archive_raw_validation_sets_can_drop_optional_event_types():
+    datasets = gh_archive_structured_output_raw_validation_sets(
+        raw_root="gs://example-bucket/raw/gha",
+        include_optional_event_types=False,
+    )
+    assert "gh_archive_structured_output/WorkflowRunEvent" not in datasets
+
+
+def test_gh_archive_step_hash_attrs_include_window_and_caps():
+    step = gh_archive_step(
+        start_date="2024-02-01",
+        end_date="2024-02-02",
+        start_hour=6,
+        end_hour=8,
+        event_types=("PushEvent", "IssuesEvent"),
+        max_events_per_event_type=64,
+        base_url="https://example-gh-archive",
+    )
+    assert step.hash_attrs["start_date"] == "2024-02-01"
+    assert step.hash_attrs["end_date"] == "2024-02-02"
+    assert step.hash_attrs["start_hour"] == 6
+    assert step.hash_attrs["end_hour"] == 8
+    assert step.hash_attrs["event_types"] == ("PushEvent", "IssuesEvent")
+    assert step.hash_attrs["max_events_per_event_type"] == 64
+    assert step.hash_attrs["base_url"] == "https://example-gh-archive"

--- a/tests/evals/test_long_tail_ppl.py
+++ b/tests/evals/test_long_tail_ppl.py
@@ -4,8 +4,10 @@
 import pytest
 
 from experiments.evals.long_tail_ppl import (
+    DIAGNOSTIC_LOGS_ISSUE,
     GAME_MUSIC_ISSUE,
     LongTailPplFamily,
+    long_tail_ppl_slices,
     long_tail_raw_validation_sets,
     render_long_tail_ppl_registry_markdown,
 )
@@ -50,3 +52,54 @@ def test_hf_backed_raw_dataset_preserves_requested_split():
 def test_file_backed_raw_dataset_rejects_non_validation_split():
     with pytest.raises(ValueError, match="Hugging Face dataset sources"):
         raw_text_dataset("gs://example-bucket/eval.jsonl", split="test")
+
+
+def test_diagnostic_logs_slices_render_with_issue_5093_tag_and_marin_leakage_note():
+    datasets = long_tail_raw_validation_sets(
+        raw_root="gs://example-bucket/raw/long_tail",
+        family=LongTailPplFamily.DIAGNOSTIC_LOGS,
+    )
+
+    ghalogs_key = "long_tail_ppl/diagnostic_logs/ghalogs"
+    marin_key = "long_tail_ppl/diagnostic_logs/marin_internal_logs_sanitized"
+
+    assert datasets[ghalogs_key].input_path == "gs://example-bucket/raw/long_tail/diagnostic_logs/ghalogs/runs.jsonl.gz"
+    expected_tags = ("long_tail_ppl", "epic:5005", f"issue:{DIAGNOSTIC_LOGS_ISSUE}", "diagnostic_logs")
+    assert datasets[ghalogs_key].tags == expected_tags
+    assert datasets[marin_key].tags == expected_tags
+
+    slice_names = {s.name for s in long_tail_ppl_slices(family=LongTailPplFamily.DIAGNOSTIC_LOGS)}
+    # DoD requires at least two public log sources plus a Marin-internal slice.
+    assert {"ghalogs", "logchunks", "marin_internal_logs_sanitized"}.issubset(slice_names)
+
+    # Leakage / contamination handling for Marin-owned logs must be documented in-place.
+    marin_notes = next(
+        s.notes
+        for s in long_tail_ppl_slices(family=LongTailPplFamily.DIAGNOSTIC_LOGS)
+        if s.name == "marin_internal_logs_sanitized"
+    )
+    assert "scrub" in marin_notes.lower()
+    assert "never" in marin_notes.lower() and "training" in marin_notes.lower()
+
+
+def test_diagnostic_logs_slices_excluded_from_unfiltered_default_root():
+    # The new family must register through the metadata-only registry, not be wired
+    # into default_raw_validation_sets. The unfiltered call uses the default raw_root
+    # ("raw/long_tail_ppl") and should still surface the new slices, while a
+    # family-filter call must not leak entries from other families.
+    all_datasets = long_tail_raw_validation_sets()
+    diagnostic_only = long_tail_raw_validation_sets(family=LongTailPplFamily.DIAGNOSTIC_LOGS)
+
+    assert "long_tail_ppl/diagnostic_logs/ghalogs" in all_datasets
+    assert all(key.startswith("long_tail_ppl/diagnostic_logs/") for key in diagnostic_only)
+    assert len(diagnostic_only) >= 3
+
+
+def test_diagnostic_logs_registry_markdown_includes_issue_link():
+    markdown = render_long_tail_ppl_registry_markdown(family=LongTailPplFamily.DIAGNOSTIC_LOGS)
+
+    assert "long_tail_ppl/diagnostic_logs/loghub_apache" in markdown
+    assert "github.com/logpai/loghub" in markdown
+    assert f"#{DIAGNOSTIC_LOGS_ISSUE}" in markdown
+    # Confirm the GAME_MUSIC family does not bleed into a filtered render.
+    assert f"#{GAME_MUSIC_ISSUE}" not in markdown

--- a/tests/evals/test_long_tail_ppl.py
+++ b/tests/evals/test_long_tail_ppl.py
@@ -11,7 +11,9 @@ from experiments.evals.long_tail_ppl import (
     long_tail_raw_validation_sets,
     render_long_tail_ppl_registry_markdown,
 )
+from experiments.defaults import default_raw_validation_sets
 from levanter.data.text import HfDatasetSourceConfig
+from levanter.data.text import UrlDatasetSourceConfig
 from marin.evaluation.perplexity_gap import _to_dataset_component, raw_text_dataset
 from marin.processing.tokenize import HfDatasetSpec
 
@@ -93,6 +95,27 @@ def test_diagnostic_logs_slices_excluded_from_unfiltered_default_root():
     assert "long_tail_ppl/diagnostic_logs/ghalogs" in all_datasets
     assert all(key.startswith("long_tail_ppl/diagnostic_logs/") for key in diagnostic_only)
     assert len(diagnostic_only) >= 3
+
+
+def test_diagnostic_logs_are_opt_in_and_not_added_to_default_validation_bundles():
+    default_validation_sets = default_raw_validation_sets()
+    assert all(not key.startswith("long_tail_ppl/diagnostic_logs/") for key in default_validation_sets)
+
+
+def test_diagnostic_logs_convert_to_gap_finder_dataset_components():
+    datasets = long_tail_raw_validation_sets(
+        raw_root="gs://example-bucket/raw/long_tail",
+        family=LongTailPplFamily.DIAGNOSTIC_LOGS,
+    )
+
+    apache_component = _to_dataset_component(datasets["long_tail_ppl/diagnostic_logs/loghub_apache"])
+
+    assert isinstance(apache_component.source, UrlDatasetSourceConfig)
+    assert apache_component.source.validation_urls == [
+        "gs://example-bucket/raw/long_tail/diagnostic_logs/loghub/apache.jsonl.gz"
+    ]
+    assert apache_component.split == "validation"
+    assert apache_component.tags == ["long_tail_ppl", "epic:5005", f"issue:{DIAGNOSTIC_LOGS_ISSUE}", "diagnostic_logs"]
 
 
 def test_diagnostic_logs_registry_markdown_includes_issue_link():

--- a/tests/evals/test_paired_robustness_ppl.py
+++ b/tests/evals/test_paired_robustness_ppl.py
@@ -1,0 +1,77 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from experiments.evals.paired_robustness_ppl import (
+    DEFAULT_SAMPLE_CAP,
+    PairedRobustnessFamily,
+    PairedTextView,
+    linearized_text_views_for_example,
+    paired_robustness_raw_steps,
+    paired_robustness_raw_validation_sets,
+    paired_robustness_slices,
+)
+from marin.execution.executor import InputName
+
+
+def test_paired_robustness_slices_are_held_out_and_capped():
+    paraphrase_slices = paired_robustness_slices(family=PairedRobustnessFamily.PARAPHRASE)
+    translation_slices = paired_robustness_slices(family=PairedRobustnessFamily.TRANSLATION)
+
+    assert {slice_.split for slice_ in paraphrase_slices} == {"validation", "test"}
+    assert {slice_.split for slice_ in translation_slices} == {"dev", "devtest"}
+    assert all(slice_.max_pairs <= DEFAULT_SAMPLE_CAP for slice_ in (*paraphrase_slices, *translation_slices))
+
+
+def test_paws_linearization_uses_stable_labels_and_filters_negative_pairs():
+    paws_validation = next(
+        slice_
+        for slice_ in paired_robustness_slices(family=PairedRobustnessFamily.PARAPHRASE)
+        if slice_.split == "validation"
+    )
+
+    positive_example = {
+        "id": 7,
+        "label": 1,
+        "sentence1": "The cat sat on the mat.",
+        "sentence2": "The cat was sitting on the mat.",
+    }
+    negative_example = {
+        "id": 8,
+        "label": 0,
+        "sentence1": "A short sentence.",
+        "sentence2": "A different meaning.",
+    }
+
+    views = linearized_text_views_for_example(paws_validation, positive_example)
+
+    assert views is not None
+    assert views[PairedTextView.SOURCE] == "sentence_1: The cat sat on the mat."
+    assert views[PairedTextView.TARGET] == "sentence_2: The cat was sitting on the mat."
+    assert views[PairedTextView.TARGET_GIVEN_SOURCE] == (
+        "sentence_1: The cat sat on the mat.\nsentence_2: The cat was sitting on the mat."
+    )
+    assert linearized_text_views_for_example(paws_validation, negative_example) is None
+
+
+def test_paired_raw_validation_sets_register_conditional_view_paths_and_tags():
+    slices = tuple(
+        slice_
+        for slice_ in paired_robustness_slices()
+        if (slice_.family == PairedRobustnessFamily.PARAPHRASE and slice_.split == "validation")
+        or (slice_.family == PairedRobustnessFamily.TRANSLATION and slice_.split == "devtest")
+    )
+    raw_steps = paired_robustness_raw_steps(slices=slices)
+    datasets = paired_robustness_raw_validation_sets(slices=slices, raw_steps=raw_steps)
+
+    paws_key = "paired_robustness_ppl/paraphrase/paws_labeled_final/validation/target_given_source"
+    flores_key = "paired_robustness_ppl/translation/flores_eng_deu/devtest/source"
+
+    assert isinstance(datasets[paws_key].input_path, InputName)
+    assert datasets[paws_key].input_path.name == "target_given_source/shard-*.jsonl.gz"
+    assert "split:validation" in datasets[paws_key].tags
+    assert "view:target_given_source" in datasets[paws_key].tags
+
+    assert isinstance(datasets[flores_key].input_path, InputName)
+    assert datasets[flores_key].input_path.name == "source/shard-*.jsonl.gz"
+    assert "split:devtest" in datasets[flores_key].tags
+    assert "family:translation" in datasets[flores_key].tags


### PR DESCRIPTION
Add a capped Marin 32B vs Qwen3 32B gap-analysis launcher that composes the first-wave log, diff/patch, robustness, ASR/OCR, and GH Archive eval slices into one combined report, and harden GH Archive URL normalization for malformed payloads seen in the run. Kept as draft because it depends on the child eval wiring PRs.

Part of #5005