### PR TITLE
[iris-cw-ci] Bump integration pipeline timeouts to 30m/15m

### DIFF
--- a/.github/workflows/iris-coreweave-ci.yaml
+++ b/.github/workflows/iris-coreweave-ci.yaml
@@ -176,8 +176,8 @@ jobs:
           FSSPEC_S3: '{"endpoint_url": "https://74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com"}'
         run: |
           export IRIS_CONTROLLER_URL="http://localhost:${LOCAL_PORT}"
-          timeout 900 uv run pytest tests/test_integration_test.py \
-            -m integration -o "addopts=" --timeout=600 -v -s
+          timeout 1800 uv run pytest tests/test_integration_test.py \
+            -m integration -o "addopts=" --timeout=900 -v -s
 
       - name: Stop port-forward
         if: always()


### PR DESCRIPTION
The full marin pipeline test runs 8 sequential Iris sub-jobs, each paying ~60-90s of pod startup + dep sync overhead. On the last CoreWeave CI run, train_lm completed just 34s after pytest-timeout fired at 600s. Bump the shell wrapper from 900s to 1800s and pytest-timeout from 600s to 900s.