### PR TITLE
[zephyr] Surface expected vs. actual schema on parquet/vortex write failures

### DIFF
--- a/lib/zephyr/src/zephyr/writers.py
+++ b/lib/zephyr/src/zephyr/writers.py
@@ -175,6 +175,7 @@ def _accumulate_tables(
     chunks: list[pa.Table] = []
     bytesize = 0
     convert: Callable | None = None
+    schema_inferred = schema is None
 
     for micro_batch in batchify(records, n=_MICRO_BATCH_SIZE):
         if convert is None:
@@ -183,7 +184,20 @@ def _accumulate_tables(
         if schema is None:
             # NOTE: the _MICRO_BATCH_SIZE is fairly small, here we hope it's enough to infer "real" schema
             schema = infer_arrow_schema(dicts)
-        table = pa.Table.from_pylist(dicts, schema=schema)
+        try:
+            table = pa.Table.from_pylist(dicts, schema=schema)
+        except (pa.ArrowInvalid, pa.ArrowTypeError, pa.ArrowNotImplementedError) as e:
+            actual_schema = pa.Table.from_pylist(dicts).schema
+            origin = (
+                f"inferred from first {_MICRO_BATCH_SIZE} records (no explicit schema passed)"
+                if schema_inferred
+                else "explicitly provided by caller"
+            )
+            raise pa.ArrowInvalid(
+                f"Schema mismatch converting batch to Arrow: {e}\n"
+                f"Expected schema ({origin}):\n{schema}\n"
+                f"Got schema:\n{actual_schema}"
+            ) from e
         chunks.append(table)
         bytesize += table.nbytes
         if bytesize >= target_bytes:

--- a/lib/zephyr/tests/test_writers.py
+++ b/lib/zephyr/tests/test_writers.py
@@ -151,6 +151,23 @@ def test_write_parquet_file_basic():
         assert len(table) == 2
 
 
+def test_write_parquet_file_schema_mismatch_surfaces_both_schemas():
+    """On schema divergence, the raised error includes expected + actual schemas and inference origin."""
+    # First micro-batch (_MICRO_BATCH_SIZE=8) has `x` all None → inferred as pa.null().
+    # A later record with a real value for `x` then fails to fit that schema.
+    records = [{"x": None}] * 8 + [{"x": "hello"}]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = str(Path(tmpdir) / "test.parquet")
+        with pytest.raises(pa.ArrowInvalid) as excinfo:
+            write_parquet_file(records, output_path)
+    msg = str(excinfo.value)
+    assert "Expected schema" in msg
+    assert "Got schema" in msg
+    assert "inferred from first" in msg
+    assert "x: null" in msg
+    assert "x: string" in msg
+
+
 def test_write_parquet_file_empty():
     """Test writing an empty parquet file."""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
When a micro-batch fails to convert to Arrow against the pinned schema, re-raise with both the expected schema (noting whether it was inferred from the first _MICRO_BATCH_SIZE records or explicitly provided) and the schema inferred from the failing batch, so the diverging field is visible without extra instrumentation. Adds a regression test covering the inferred-schema case.