### PR TITLE
Create convenience decorator `as_step_fn` for building `StepSpec`s

### DIFF
--- a/experiments/dedup/fineweb_10bt_exact.py
+++ b/experiments/dedup/fineweb_10bt_exact.py
@@ -33,9 +33,8 @@ def build_steps() -> list[StepSpec]:
         name="exact_dedup_fineweb_10bt",
         output_path_prefix=f"{marin_prefix()}/tmp/{OUTPUT_PREFIX}",
         deps=[download],
-        fn=lambda op: dedup_exact_paragraph(
+        fn=dedup_exact_paragraph(
             input_paths=os.path.join(download.output_path, "sample/10BT"),
-            output_path=op,
             max_parallelism=128,
         ),
     )

--- a/lib/marin/src/marin/execution/step_spec.py
+++ b/lib/marin/src/marin/execution/step_spec.py
@@ -8,11 +8,28 @@ import hashlib
 import json
 from collections.abc import Callable
 from dataclasses import dataclass
-from functools import cached_property
+from functools import cached_property, wraps
 from typing import Any
 from urllib.parse import urlparse
 
 from rigging.filesystem import marin_prefix
+
+
+def as_step_fn(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorator that allows a function to either be called normally with output_path,
+    or curried by omitting output_path, returning a Callable[[str], Any] suitable for StepSpec.fn."""
+
+    @wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if "output_path" not in kwargs:
+
+            def inner(output_path: str) -> Any:
+                return fn(*args, output_path=output_path, **kwargs)
+
+            return inner
+        return fn(*args, **kwargs)
+
+    return wrapper
 
 
 def _is_relative_path(url_or_path: str) -> bool:

--- a/lib/marin/src/marin/processing/classification/deduplication/exact.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/exact.py
@@ -23,6 +23,7 @@ import logging
 from fray import ResourceConfig
 from zephyr import ZephyrContext, counters, write_parquet_file
 from zephyr.dataset import Dataset
+from marin.execution.step_spec import as_step_fn
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,7 @@ def _iter_has_more_than_one(records: Iterator[T]) -> tuple[bool, T, Iterator[T]]
     return has_more_than_one, first, itertools.chain([first], rest)
 
 
+@as_step_fn
 def dedup_exact_paragraph(
     *,
     input_paths: str | list[str],


### PR DESCRIPTION
This allows for decorating a function that you want to use in a `StepSpec` and avoiding the `lambda op: ...` boilerplate.

Curious if people think this is useful enough to add.