### PR TITLE
[iris] Migrate transitions SQL behind typed store layer

### DIFF
--- a/.agents/projects/iris-sql-store.md
+++ b/.agents/projects/iris-sql-store.md
@@ -1,0 +1,176 @@
+# Iris: Introduce Stores Layer Between `transitions.py` and `db.py`
+
+## Context
+
+`lib/iris/src/iris/cluster/controller/transitions.py` has grown to ~3,350 lines containing ~174 inline SQL queries that operate directly against `ControllerDB`. SQL and domain logic are tangled, there's no typed API boundary around the DB, and write-through caches (like `EndpointRegistry`) live either inside `db.py` or floating beside `transitions.py`.
+
+Goal: introduce a **stores layer** so the dependency chain is:
+
+```
+db.py        — connections, migrations, transaction/snapshot context managers, no schema knowledge
+schema.py    — table DDL, row dataclasses, projections (unchanged)
+stores.py    — depends on { db, schema }; typed per-entity stores + ControllerStore wrapper
+transitions.py — depends on stores; NO direct db.py SQL
+```
+
+All store operations take a transaction (read or write) explicitly, e.g. `JobStore.list_task_attempts(tx, job_id)`. Stores own their write-through caches (e.g. `EndpointStore` absorbs today's `EndpointRegistry`).
+
+This refactor is **low-risk and phased** — we do not try to migrate all 174 queries at once. Phase 1 scaffolds the layer and moves `EndpointRegistry` (the natural first candidate, since it's already a write-through cache). Subsequent phases migrate one entity at a time.
+
+## Current State (verified during exploration)
+
+- **DB access**: `ControllerDB.transaction()` yields `TransactionCursor`, `ControllerDB.read_snapshot()` yields `QuerySnapshot` (from a 32-conn pool). Post-commit hooks via `cur.on_commit(fn)` already underpin cache coherence.
+- **Existing typed rows/projections in [schema.py](lib/iris/src/iris/cluster/controller/schema.py)**: `JobRow`, `JobSchedulingRow`, `JobDetailRow`, `TaskRow`, `TaskDetailRow`, `WorkerRow`, `WorkerDetailRow`, `AttemptRow`, `EndpointRow`, `ApiKeyRow`, `UserBudgetRow`, with matching `*_PROJECTION` objects. These are the return types we'll lean on.
+- **Existing write-through cache**: [`EndpointRegistry`](lib/iris/src/iris/cluster/controller/endpoint_registry.py:43) — loads all rows at init, mutates memory in `cur.on_commit(...)` hooks. This is exactly the pattern stores will use.
+- **Existing in-DB cache**: `ControllerDB._attr_cache` ([db.py:321](lib/iris/src/iris/cluster/controller/db.py:321)) is a worker-attribute map that belongs semantically in `WorkerStore`. Still actively used by `healthy_active_workers_with_attributes` ([db.py:908](lib/iris/src/iris/cluster/controller/db.py:908)) from multiple controller.py call sites and written from transitions.py on worker register/remove — stays put in Phase 1, relocates in Phase 5.
+- **SQL entities in transitions.py** (count of queries per entity): jobs (~20), tasks (~35), task_attempts (~12), workers (~15), dispatch_queue (~5), endpoints (delegated to EndpointRegistry), task_resource_history (~6), worker_resource_history / worker_task_history (~6), reservation_claims (~2), meta (~3), users / user_budgets (~2). Full inventory captured during exploration.
+
+## Design
+
+### New file: `lib/iris/src/iris/cluster/controller/stores.py`
+
+```python
+from iris.cluster.controller.db import ControllerDB, TransactionCursor, QuerySnapshot
+from iris.cluster.controller.schema import JobRow, TaskRow, WorkerRow, AttemptRow, EndpointRow, ...
+
+# Type used by read methods that accept either a write cursor or a read snapshot.
+# Writes require TransactionCursor explicitly.
+Tx = TransactionCursor | QuerySnapshot
+
+
+class JobStore:
+    def __init__(self, db: ControllerDB) -> None:
+        self._db = db  # opaque handle for the rare case a store needs the connection itself
+
+    # reads
+    def get(self, tx: Tx, job_id: JobName) -> JobRow | None: ...
+    def get_config(self, tx: Tx, job_id: JobName) -> JobConfigRow | None: ...
+    def list_descendants(self, tx: Tx, job_id: JobName) -> list[JobName]: ...
+    def list_terminal_ids(self, tx: Tx) -> list[JobName]: ...
+
+    # writes
+    def insert(self, tx: TransactionCursor, job: JobInsert) -> None: ...
+    def update_state(self, tx: TransactionCursor, job_id: JobName, state: JobState,
+                     error: str | None, finished_at_ms: int | None) -> None: ...
+    def delete(self, tx: TransactionCursor, job_id: JobName) -> None: ...
+
+
+class TaskStore: ...          # tasks table + task_resource_history
+class TaskAttemptStore: ...    # task_attempts
+class WorkerStore: ...         # workers + worker_attributes (+ the attr cache currently in db.py)
+class EndpointStore: ...       # former EndpointRegistry, renamed and relocated
+class DispatchQueueStore: ...  # dispatch_queue
+class ReservationStore: ...    # reservation_claims + meta(last_submission_ms)
+
+
+class ControllerStore:
+    """Bundle of per-entity stores with direct access to transactions/snapshots."""
+    def __init__(self, db: ControllerDB) -> None:
+        self._db = db
+        self.jobs = JobStore(db)
+        self.tasks = TaskStore(db)
+        self.attempts = TaskAttemptStore(db)
+        self.workers = WorkerStore(db)
+        self.endpoints = EndpointStore(db)
+        self.dispatch = DispatchQueueStore(db)
+        self.reservations = ReservationStore(db)
+
+    def transaction(self): return self._db.transaction()
+    def read_snapshot(self): return self._db.read_snapshot()
+```
+
+### Transaction rule
+
+- **Reads**: accept `Tx = TransactionCursor | QuerySnapshot`. Store methods internally call `tx.fetchall(...)` / `tx.fetchone(...)`. (Both types already expose these; where signatures diverge, the store normalizes.)
+- **Writes**: require `TransactionCursor` specifically. Static typing enforces the invariant.
+- **No store method opens its own transaction.** Callers are responsible for transaction scope. This matches today's pattern in `transitions.py` and keeps batching/atomicity in caller control.
+
+### Validation in stores
+
+Light and unambitious for phase 1:
+- Reject writes with impossible state combinations (e.g., `update_state` asserting the new state is in `JobState`).
+- Decode rows into the existing `*Row` dataclasses at the boundary — callers never see `sqlite3.Row`.
+- No business rules (retry counts, cascade logic) — those stay in `transitions.py`.
+
+### EndpointStore (rename of EndpointRegistry)
+
+Move [`endpoint_registry.py`](lib/iris/src/iris/cluster/controller/endpoint_registry.py) → `EndpointStore` inside `stores.py`. Semantically identical: write-through cache keyed by id/name/task with post-commit hooks.
+
+- Replace `db.endpoints` accessor in [db.py:334](lib/iris/src/iris/cluster/controller/db.py:334) with `store.endpoints`.
+- Delete `endpoint_registry.py`; migrate its test file [test_endpoint_registry.py](lib/iris/tests/cluster/controller/test_endpoint_registry.py) to construct `EndpointStore` directly.
+
+### transitions.py integration
+
+Change the `ControllerTransitions` constructor:
+
+```python
+# before
+def __init__(self, db: ControllerDB, ...): self._db = db
+
+# after
+def __init__(self, store: ControllerStore, ...):
+    self._store = store
+    self._db = store._db  # phased: kept only while unmigrated queries remain
+```
+
+The `self._db` escape hatch exists **only during the phased migration** and is deleted at the end. This lets each phase move a subset of queries without breaking the file.
+
+## Phasing
+
+Low-risk means small, verifiable PRs. Proposed sequence:
+
+**Phase 1 (this PR) — scaffolding + EndpointStore**
+1. Create `stores.py` with empty `JobStore`, `TaskStore`, `TaskAttemptStore`, `WorkerStore`, `DispatchQueueStore`, `ReservationStore` skeletons.
+2. Fold `EndpointRegistry` into `stores.py` as `EndpointStore`.
+3. Add `ControllerStore`; instantiate in [controller.py:~1035](lib/iris/src/iris/cluster/controller/controller.py:1035) and pass to `ControllerTransitions`.
+4. Update transitions.py to take `store: ControllerStore`; route endpoint calls through `self._store.endpoints`; keep `self._db` as temporary escape hatch.
+5. Update tests: `make_controller_state` in [conftest.py:186](lib/iris/tests/cluster/controller/conftest.py:186) constructs `ControllerStore`; update [test_endpoint_registry.py](lib/iris/tests/cluster/controller/test_endpoint_registry.py).
+
+**Phase 2 — JobStore migration**
+Move the ~20 jobs/job_config/users/user_budgets queries from transitions.py into `JobStore`/`ReservationStore`. Prefer one method per call site; collapse duplicates only when obvious.
+
+**Phase 3 — TaskStore migration**
+Move ~35 task and task_resource_history queries.
+
+**Phase 4 — TaskAttemptStore migration**
+Move ~12 task_attempts queries.
+
+**Phase 5 — WorkerStore migration**
+Move ~15 worker queries + `worker_attributes` + `_attr_cache` from `ControllerDB` into `WorkerStore`. Remove `_attr_cache` / `get_worker_attributes` / `set_worker_attributes` / `remove_worker_from_attr_cache` from [db.py](lib/iris/src/iris/cluster/controller/db.py:338).
+
+**Phase 6 — Cleanup**
+DispatchQueueStore + ReservationStore remaining queries. Drop `self._db` escape hatch on `ControllerTransitions`. Confirm transitions.py has zero `self._db.transaction()` / `self._db.fetchone()` calls — only `self._store.transaction()` + store method calls.
+
+Out of scope for now: [service.py](lib/iris/src/iris/cluster/controller/service.py) (47 queries), [controller.py](lib/iris/src/iris/cluster/controller/controller.py) (22), [checkpoint.py](lib/iris/src/iris/cluster/controller/checkpoint.py), autoscaler. They keep using `ControllerDB` directly; the layering rule "transitions → stores, never db" is a per-file invariant, not global. We can migrate them later if the pattern proves out.
+
+## Files to Modify (Phase 1 only)
+
+- **New**: `lib/iris/src/iris/cluster/controller/stores.py`
+- **Delete**: `lib/iris/src/iris/cluster/controller/endpoint_registry.py` (folded into stores.py as `EndpointStore`)
+- **Edit**: [lib/iris/src/iris/cluster/controller/db.py](lib/iris/src/iris/cluster/controller/db.py) — remove `endpoints` property and `EndpointRegistry` import (lines ~327-334); `_attr_cache` stays for now (moves in Phase 5).
+- **Edit**: [lib/iris/src/iris/cluster/controller/transitions.py](lib/iris/src/iris/cluster/controller/transitions.py) — constructor signature, route `add_endpoint`/`remove_endpoint`/`delete_task_endpoints` through `self._store.endpoints`.
+- **Edit**: [lib/iris/src/iris/cluster/controller/controller.py:~1035](lib/iris/src/iris/cluster/controller/controller.py:1035) — construct `ControllerStore(db)`, pass to transitions.
+- **Edit**: [lib/iris/src/iris/cluster/controller/service.py:1683](lib/iris/src/iris/cluster/controller/service.py:1683) — replace `db.endpoints.query(...)` with `store.endpoints.query(...)` (or keep going through db if service still takes `db` — decide based on simplest diff).
+- **Edit**: [lib/iris/tests/cluster/controller/conftest.py:186](lib/iris/tests/cluster/controller/conftest.py:186) — `make_controller_state` wires `ControllerStore`.
+- **Edit**: [lib/iris/tests/cluster/controller/test_endpoint_registry.py](lib/iris/tests/cluster/controller/test_endpoint_registry.py) — rename or retarget to `EndpointStore`.
+
+## Reuse Notes
+
+- Row dataclasses + projections in [schema.py](lib/iris/src/iris/cluster/controller/schema.py) are the return types — do not invent parallel types.
+- Post-commit hook pattern (`cur.on_commit(fn)`) already powers `EndpointRegistry` — reuse it verbatim for any write-through caches inside stores.
+- `ProtoCache` ([schema.py:33](lib/iris/src/iris/cluster/controller/schema.py:33)) remains where it is; stores don't need to touch it.
+- Predicate helpers (`task_is_finished`, `attempt_is_terminal`, etc. in [db.py:111-185](lib/iris/src/iris/cluster/controller/db.py:111)) stay as top-level functions; stores can call them when validating.
+
+## Verification
+
+**Phase 1:**
+- `uv run pytest lib/iris/tests/cluster/controller/test_endpoint_registry.py` — existing behavior preserved under new class name.
+- `uv run pytest lib/iris/tests/cluster/controller/test_transitions.py` — endpoint paths through `ControllerTransitions` work.
+- `uv run pytest lib/iris/tests/cluster/controller/test_service.py` — RPC `list_endpoints` still serves from cache.
+- `uv run pytest lib/iris/tests/cluster/controller/` — full controller test suite green.
+- `./infra/pre-commit.py --all-files --fix` + `uv run pyrefly`.
+
+**Later phases (each phase):**
+- Same pytest targets — behavioral parity is the bar.
+- Spot-check that migrated SQL in the store matches original semantics (diff review).
+- Grep transitions.py after each phase: the count of `self._db.transaction()` / direct SQL strings should decrease monotonically. Final state: zero.

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -1456,13 +1456,16 @@ class Controller:
         assert isinstance(self._provider, K8sTaskProvider)
         provider = self._provider
         max_promotions = self._promotion_bucket.available
-        batch = self._transitions.drain_for_direct_provider(
-            max_promotions=max_promotions,
-        )
+        with self._store.transaction() as cur:
+            batch = self._transitions.drain_for_direct_provider(
+                cur,
+                max_promotions=max_promotions,
+            )
         if batch.tasks_to_run:
             self._promotion_bucket.try_acquire(len(batch.tasks_to_run))
         result = provider.sync(batch)
-        tx_result = self._transitions.apply_direct_provider_updates(result.updates)
+        with self._store.transaction() as cur:
+            tx_result = self._transitions.apply_direct_provider_updates(cur, result.updates)
         self._provider_scheduling_events = list(result.scheduling_events) if result.scheduling_events else []
         self._provider_capacity = result.capacity
         if tx_result.tasks_to_kill:
@@ -1625,7 +1628,8 @@ class Controller:
         for wid in stale:
             del claims[wid]
         if stale and persisted:
-            self._transitions.replace_reservation_claims(claims)
+            with self._store.transaction() as cur:
+                self._transitions.replace_reservation_claims(cur, claims)
             log_event("reservation_claims_cleaned", "controller", count=len(stale))
         return bool(stale)
 
@@ -1673,7 +1677,8 @@ class Controller:
                     changed = True
                     break
         if changed and persisted:
-            self._transitions.replace_reservation_claims(claims)
+            with self._store.transaction() as cur:
+                self._transitions.replace_reservation_claims(cur, claims)
             log_event("reservation_claims_updated", "controller", total_claims=len(claims))
         return changed
 
@@ -1769,7 +1774,8 @@ class Controller:
             if self._config.dry_run:
                 logger.info("[DRY-RUN] Would update %d reservation claims", len(claims))
             else:
-                self._transitions.replace_reservation_claims(claims)
+                with self._store.transaction() as cur:
+                    self._transitions.replace_reservation_claims(cur, claims)
         return claims
 
     def _read_scheduling_state(self) -> _SchedulingStateRead:
@@ -1982,7 +1988,10 @@ class Controller:
             )
             preemptions = _run_preemption_pass(unscheduled, running_info, context)
             for preemptor_name, victim_id in preemptions:
-                preempt_result = self._transitions.preempt_task(victim_id, reason=f"Preempted by {preemptor_name}")
+                with self._store.transaction() as cur:
+                    preempt_result = self._transitions.preempt_task(
+                        cur, victim_id, reason=f"Preempted by {preemptor_name}"
+                    )
                 self.kill_tasks_on_workers(preempt_result.tasks_to_kill)
             if preemptions:
                 logger.info("Preemption pass: %d tasks preempted", len(preemptions))
@@ -2052,7 +2061,8 @@ class Controller:
         for task in timed_out:
             logger.warning("Task %s exceeded execution timeout, killing", task.task_id)
         task_ids = {t.task_id for t in timed_out}
-        result = self._transitions.cancel_tasks_for_timeout(task_ids, reason="Execution timeout exceeded")
+        with self._store.transaction() as cur:
+            result = self._transitions.cancel_tasks_for_timeout(cur, task_ids, reason="Execution timeout exceeded")
         if result.tasks_to_kill:
             self.kill_tasks_on_workers(result.tasks_to_kill, result.task_kill_workers)
 
@@ -2067,10 +2077,12 @@ class Controller:
         else:
             timeout = None
         logger.warning(f"Task {task.task_id} exceeded scheduling timeout ({timeout}), marking as UNSCHEDULABLE")
-        result = self._transitions.mark_task_unschedulable(
-            task.task_id,
-            reason=f"Scheduling timeout exceeded ({timeout})",
-        )
+        with self._store.transaction() as cur:
+            result = self._transitions.mark_task_unschedulable(
+                cur,
+                task.task_id,
+                reason=f"Scheduling timeout exceeded ({timeout})",
+            )
         if result.tasks_to_kill:
             self.kill_tasks_on_workers(result.tasks_to_kill, result.task_kill_workers)
 
@@ -2099,8 +2111,9 @@ class Controller:
             self._stop_tasks_direct(task_ids, task_kill_workers)
             return
         # K8s: buffer direct kills for the provider sync loop.
-        for task_id in task_ids:
-            self._transitions.buffer_direct_kill(task_id.to_wire())
+        with self._store.transaction() as cur:
+            for task_id in task_ids:
+                self._transitions.buffer_direct_kill(cur, task_id.to_wire())
 
     # =========================================================================
     # Worker lifecycle RPC dispatch (StartTasks / StopTasks / Ping / PollTasks)
@@ -2116,7 +2129,8 @@ class Controller:
                 logger.info("[DRY-RUN] Would assign task %s to worker %s", task_id, worker_id)
             return
         command = [Assignment(task_id=task_id, worker_id=worker_id) for task_id, worker_id in assignments]
-        result = self._transitions.queue_assignments(command, direct_dispatch=True)
+        with self._store.transaction() as cur:
+            result = self._transitions.queue_assignments(cur, command, direct_dispatch=True)
 
         # Group StartTasks payloads by (worker_id, address)
         by_worker: dict[tuple[WorkerId, str], list[job_pb2.RunTaskRequest]] = {}
@@ -2245,7 +2259,8 @@ class Controller:
                         self._health.ping(result.worker_id, healthy=True)
                         ping_snapshots[result.worker_id] = result.resource_snapshot if update_resources else None
 
-                self._transitions.update_worker_pings(ping_snapshots)
+                with self._store.transaction() as cur:
+                    self._transitions.update_worker_pings(cur, ping_snapshots)
 
                 unhealthy = self._health.workers_over_threshold()
                 if unhealthy:
@@ -2268,7 +2283,8 @@ class Controller:
         """Poll all workers for task state and feed results into the updater queue."""
         if self._config.dry_run:
             return
-        running, addresses = self._transitions.get_running_tasks_for_poll()
+        with self._store.read_snapshot() as snap:
+            running, addresses = self._transitions.get_running_tasks_for_poll(snap)
         if not running:
             return
         poll_results = self._provider.poll_workers(running, addresses)
@@ -2296,7 +2312,8 @@ class Controller:
             if not requests or stop_event.is_set():
                 continue
             try:
-                results = self._transitions.apply_heartbeats_batch(requests)
+                with self._store.transaction() as cur:
+                    results = self._transitions.apply_heartbeats_batch(cur, requests)
                 all_tasks_to_kill: set[JobName] = set()
                 all_task_kill_workers: dict[JobName, WorkerId] = {}
                 for result in results:

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -1375,17 +1375,17 @@ class Controller:
                 break
 
             try:
-                self._transitions.prune_worker_task_history()
+                self._store.workers.prune_task_history()
             except Exception:
                 logger.exception("Worker task history cleanup failed")
 
             if resource_history_limiter.should_run():
                 try:
-                    self._transitions.prune_worker_resource_history()
+                    self._store.workers.prune_resource_history()
                 except Exception:
                     logger.exception("Worker resource history cleanup failed")
                 try:
-                    self._transitions.prune_task_resource_history()
+                    self._store.tasks.prune_resource_history()
                 except Exception:
                     logger.exception("Task resource history cleanup failed")
 

--- a/lib/iris/src/iris/cluster/controller/db.py
+++ b/lib/iris/src/iris/cluster/controller/db.py
@@ -155,6 +155,9 @@ EXECUTING_TASK_STATES: frozenset[int] = frozenset(
     }
 )
 
+# All non-terminal task states (ACTIVE plus PENDING). Complement of TERMINAL_TASK_STATES.
+NON_TERMINAL_TASK_STATES: frozenset[int] = ACTIVE_TASK_STATES | {job_pb2.TASK_STATE_PENDING}
+
 # Failure states that trigger coscheduled sibling cascades.
 FAILURE_TASK_STATES: frozenset[int] = frozenset(
     {

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -90,9 +90,8 @@ from iris.cluster.controller.autoscaler.status import PendingHint
 from iris.cluster.controller.query import execute_raw_query
 from iris.rpc import query_pb2
 from iris.cluster.controller.scheduler import SchedulingContext
-from iris.cluster.controller.stores import ControllerStore
+from iris.cluster.controller.stores import TASK_RESOURCE_HISTORY_RETENTION, ControllerStore
 from iris.cluster.controller.transitions import (
-    TASK_RESOURCE_HISTORY_RETENTION,
     ControllerTransitions,
     HeartbeatApplyRequest,
     task_updates_from_proto,

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -1149,36 +1149,40 @@ class ControllerServiceImpl:
                     f"(state={job_pb2.JobState.Name(parent_state)})",
                 )
 
-        existing_job = _read_job(self._db, job_id)
-        if existing_job:
-            policy = request.existing_job_policy
-            if policy == job_pb2.EXISTING_JOB_POLICY_ERROR:
-                raise ConnectError(
-                    Code.ALREADY_EXISTS,
-                    f"Job {job_id} already exists (state={job_pb2.JobState.Name(existing_job.state)})",
-                )
-            elif policy == job_pb2.EXISTING_JOB_POLICY_KEEP:
-                if not is_job_finished(existing_job.state):
-                    return controller_pb2.Controller.LaunchJobResponse(job_id=job_id.to_wire())
-                # Job finished, replace it (KEEP only preserves running jobs)
-                with self._store.transaction() as cur:
+        # Existence check + conditional cleanup run in one transaction so a
+        # concurrent submitter cannot land a row between the read and the
+        # cleanup write. The new job's ``submit_job`` still opens its own
+        # transaction further down — between the two txs another submitter
+        # can race, but ``INSERT INTO jobs`` then PK-conflicts, which is a
+        # legitimate error rather than a correctness bug.
+        with self._store.transaction() as cur:
+            existing_state = self._store.jobs.get_state(cur, job_id)
+            if existing_state is not None:
+                policy = request.existing_job_policy
+                if policy == job_pb2.EXISTING_JOB_POLICY_ERROR:
+                    raise ConnectError(
+                        Code.ALREADY_EXISTS,
+                        f"Job {job_id} already exists (state={job_pb2.JobState.Name(existing_state)})",
+                    )
+                elif policy == job_pb2.EXISTING_JOB_POLICY_KEEP:
+                    if not is_job_finished(existing_state):
+                        return controller_pb2.Controller.LaunchJobResponse(job_id=job_id.to_wire())
+                    # Job finished, replace it (KEEP only preserves running jobs)
                     self._transitions.remove_finished_job(cur, job_id)
-            elif policy == job_pb2.EXISTING_JOB_POLICY_RECREATE:
-                with self._store.transaction() as cur:
-                    if not is_job_finished(existing_job.state):
+                elif policy == job_pb2.EXISTING_JOB_POLICY_RECREATE:
+                    if not is_job_finished(existing_state):
                         self._transitions.cancel_job(cur, job_id, "Replaced by new submission")
                     self._transitions.remove_finished_job(cur, job_id)
-            elif is_job_finished(existing_job.state):
-                # Default/UNSPECIFIED: replace finished jobs
-                logger.info(
-                    "Replacing finished job %s (state=%s) with new submission",
-                    job_id,
-                    job_pb2.JobState.Name(existing_job.state),
-                )
-                with self._store.transaction() as cur:
+                elif is_job_finished(existing_state):
+                    # Default/UNSPECIFIED: replace finished jobs
+                    logger.info(
+                        "Replacing finished job %s (state=%s) with new submission",
+                        job_id,
+                        job_pb2.JobState.Name(existing_state),
+                    )
                     self._transitions.remove_finished_job(cur, job_id)
-            else:
-                raise ConnectError(Code.ALREADY_EXISTS, f"Job {job_id} already exists and is still running")
+                else:
+                    raise ConnectError(Code.ALREADY_EXISTS, f"Job {job_id} already exists and is still running")
 
         # Handle bundle_blob: upload to bundle store, then replace blob
         # with the resulting GCS path (preserving all other fields).

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -1161,11 +1161,13 @@ class ControllerServiceImpl:
                 if not is_job_finished(existing_job.state):
                     return controller_pb2.Controller.LaunchJobResponse(job_id=job_id.to_wire())
                 # Job finished, replace it (KEEP only preserves running jobs)
-                self._transitions.remove_finished_job(job_id)
+                with self._store.transaction() as cur:
+                    self._transitions.remove_finished_job(cur, job_id)
             elif policy == job_pb2.EXISTING_JOB_POLICY_RECREATE:
-                if not is_job_finished(existing_job.state):
-                    self._transitions.cancel_job(job_id, "Replaced by new submission")
-                self._transitions.remove_finished_job(job_id)
+                with self._store.transaction() as cur:
+                    if not is_job_finished(existing_job.state):
+                        self._transitions.cancel_job(cur, job_id, "Replaced by new submission")
+                    self._transitions.remove_finished_job(cur, job_id)
             elif is_job_finished(existing_job.state):
                 # Default/UNSPECIFIED: replace finished jobs
                 logger.info(
@@ -1173,7 +1175,8 @@ class ControllerServiceImpl:
                     job_id,
                     job_pb2.JobState.Name(existing_job.state),
                 )
-                self._transitions.remove_finished_job(job_id)
+                with self._store.transaction() as cur:
+                    self._transitions.remove_finished_job(cur, job_id)
             else:
                 raise ConnectError(Code.ALREADY_EXISTS, f"Job {job_id} already exists and is still running")
 
@@ -1228,7 +1231,8 @@ class ControllerServiceImpl:
                     f"Job {job_id} is unschedulable: {error} (constraints: {constraints})",
                 )
 
-        self._transitions.submit_job(job_id, request, Timestamp.now())
+        with self._store.transaction() as cur:
+            self._transitions.submit_job(cur, job_id, request, Timestamp.now())
         self._controller.wake()
 
         with self._db.read_snapshot() as q:
@@ -1380,7 +1384,8 @@ class ControllerServiceImpl:
         self._authorize_job_owner(job_id)
         # cancel_job uses a recursive CTE to walk the full subtree in a single
         # transaction, so there is no need to recurse manually.
-        result = self._transitions.cancel_job(job_id, reason="Terminated by user")
+        with self._store.transaction() as cur:
+            result = self._transitions.cancel_job(cur, job_id, reason="Terminated by user")
         if result.tasks_to_kill:
             self._controller.kill_tasks_on_workers(result.tasks_to_kill, result.task_kill_workers)
         return job_pb2.Empty()
@@ -1625,14 +1630,16 @@ class ControllerServiceImpl:
             )
         worker_id = WorkerId(request.worker_id)
 
-        self._transitions.register_or_refresh_worker(
-            worker_id=worker_id,
-            address=request.address,
-            metadata=request.metadata,
-            ts=Timestamp.now(),
-            slice_id=request.slice_id,
-            scale_group=request.scale_group,
-        )
+        with self._store.transaction() as cur:
+            self._transitions.register_or_refresh_worker(
+                cur,
+                worker_id=worker_id,
+                address=request.address,
+                metadata=request.metadata,
+                ts=Timestamp.now(),
+                slice_id=request.slice_id,
+                scale_group=request.scale_group,
+            )
 
         logger.info("Worker registered: %s at %s", worker_id, request.address)
         return controller_pb2.Controller.RegisterResponse(
@@ -1711,7 +1718,9 @@ class ControllerServiceImpl:
             registered_at=Timestamp.now(),
         )
 
-        if not self._transitions.add_endpoint(endpoint):
+        with self._store.transaction() as cur:
+            added = self._transitions.add_endpoint(cur, endpoint)
+        if not added:
             raise ConnectError(
                 Code.FAILED_PRECONDITION,
                 f"Task {request.task_id} is already terminal; endpoint not registered",
@@ -1725,7 +1734,8 @@ class ControllerServiceImpl:
         ctx: Any,
     ) -> job_pb2.Empty:
         """Unregister a service endpoint. Idempotent."""
-        self._transitions.remove_endpoint(request.endpoint_id)
+        with self._store.transaction() as cur:
+            self._transitions.remove_endpoint(cur, request.endpoint_id)
         return job_pb2.Empty()
 
     def list_endpoints(
@@ -2683,12 +2693,14 @@ class ControllerServiceImpl:
         """
         updates = task_updates_from_proto(request.updates)
         if updates:
-            self._transitions.apply_task_updates(
-                HeartbeatApplyRequest(
-                    worker_id=WorkerId(request.worker_id),
-                    worker_resource_snapshot=None,
-                    updates=updates,
+            with self._store.transaction() as cur:
+                self._transitions.apply_task_updates(
+                    cur,
+                    HeartbeatApplyRequest(
+                        worker_id=WorkerId(request.worker_id),
+                        worker_resource_snapshot=None,
+                        updates=updates,
+                    ),
                 )
-            )
             self._controller.wake()
         return controller_pb2.Controller.UpdateTaskStatusResponse()

--- a/lib/iris/src/iris/cluster/controller/stores.py
+++ b/lib/iris/src/iris/cluster/controller/stores.py
@@ -43,10 +43,12 @@ from iris.cluster.controller.schema import (
     JOB_CONFIG_JOIN,
     JOB_DETAIL_PROJECTION,
     TASK_DETAIL_PROJECTION,
+    WORKER_DETAIL_PROJECTION,
     AttemptRow,
     EndpointRow,
     JobDetailRow,
     TaskDetailRow,
+    WorkerDetailRow,
 )
 from iris.cluster.types import TERMINAL_JOB_STATES, TERMINAL_TASK_STATES, JobName, WorkerId, get_gpu_count, get_tpu_count
 from iris.rpc import job_pb2
@@ -464,6 +466,54 @@ class WorkerAttributeParams:
     str_value: str | None
     int_value: int | None
     float_value: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerUpsertParams:
+    """All scalar columns written by a worker registration/refresh.
+
+    The upsert leaves ``committed_*`` counters and attributes untouched —
+    attributes are replaced via :meth:`WorkerStore.replace_attributes` and
+    resource commitment is tracked incrementally via
+    :meth:`WorkerStore.add_committed_resources` / ``decommit_resources``.
+    """
+
+    worker_id: WorkerId
+    address: str
+    last_heartbeat_ms: int
+    total_cpu_millicores: int
+    total_memory_bytes: int
+    total_gpu_count: int
+    total_tpu_count: int
+    device_type: str
+    device_variant: str
+    slice_id: str
+    scale_group: str
+    md_hostname: str
+    md_ip_address: str
+    md_cpu_count: int
+    md_memory_bytes: int
+    md_disk_bytes: int
+    md_tpu_name: str
+    md_tpu_worker_hostnames: str
+    md_tpu_worker_id: str
+    md_tpu_chips_per_host_bounds: str
+    md_gpu_count: int
+    md_gpu_name: str
+    md_gpu_memory_mb: int
+    md_gce_instance_name: str
+    md_gce_zone: str
+    md_git_hash: str
+    md_device_json: str
+
+
+@dataclass(frozen=True, slots=True)
+class ActiveWorkerStatus:
+    """Minimal row used by the worker-failure path: confirms the worker is
+    active (non-None return) and reports its last heartbeat timestamp.
+    """
+
+    last_heartbeat_ms: int | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -1361,6 +1411,208 @@ class WorkerStore:
     def address(self, tx: Tx, worker_id: WorkerId) -> str | None:
         row = tx.fetchone("SELECT address FROM workers WHERE worker_id = ?", (str(worker_id),))
         return str(row["address"]) if row is not None else None
+
+    def get_detail(self, tx: Tx, worker_id: WorkerId) -> WorkerDetailRow | None:
+        row = tx.fetchone(
+            f"SELECT {WORKER_DETAIL_PROJECTION.select_clause()} FROM workers w WHERE w.worker_id = ?",
+            (str(worker_id),),
+        )
+        return WORKER_DETAIL_PROJECTION.decode_one([row]) if row is not None else None
+
+    def get_active_status(self, tx: Tx, worker_id: WorkerId) -> ActiveWorkerStatus | None:
+        """Return heartbeat info for an active worker, or None if missing/inactive."""
+        row = tx.fetchone(
+            "SELECT last_heartbeat_ms FROM workers WHERE worker_id = ? AND active = 1",
+            (str(worker_id),),
+        )
+        if row is None:
+            return None
+        hb = row["last_heartbeat_ms"]
+        return ActiveWorkerStatus(last_heartbeat_ms=int(hb) if hb is not None else None)
+
+    def list_active_healthy(self, tx: Tx) -> dict[WorkerId, str]:
+        """Return ``{worker_id: address}`` for all active+healthy workers."""
+        rows = tx.fetchall("SELECT worker_id, address FROM workers WHERE active = 1 AND healthy = 1")
+        return {WorkerId(str(row["worker_id"])): str(row["address"]) for row in rows}
+
+    def list_active_by_ids(self, tx: Tx, worker_ids: Iterable[str]) -> list[WorkerDetailRow]:
+        """Return :class:`WorkerDetailRow` for all active workers whose id is in ``worker_ids``."""
+        ids = sorted({str(wid) for wid in worker_ids})
+        if not ids:
+            return []
+        placeholders = ",".join("?" for _ in ids)
+        rows = tx.fetchall(
+            f"SELECT {WORKER_DETAIL_PROJECTION.select_clause()} "
+            f"FROM workers w WHERE w.active = 1 AND w.worker_id IN ({placeholders})",
+            tuple(ids),
+        )
+        return WORKER_DETAIL_PROJECTION.decode(rows)
+
+    def filter_existing(self, tx: Tx, worker_ids: Iterable[WorkerId]) -> set[str]:
+        """Return the subset of ``worker_ids`` (as strings) that have a ``workers`` row."""
+        ids = [str(wid) for wid in worker_ids]
+        if not ids:
+            return set()
+        placeholders = ",".join("?" for _ in ids)
+        rows = tx.fetchall(
+            f"SELECT worker_id FROM workers WHERE worker_id IN ({placeholders})",
+            tuple(ids),
+        )
+        return {str(r["worker_id"]) for r in rows}
+
+    def upsert(self, cur: TransactionCursor, params: WorkerUpsertParams) -> None:
+        """Insert a new worker row or refresh every field of an existing one.
+
+        On conflict the row is reset to healthy/active with zero
+        consecutive_failures (registration re-establishes a worker as good).
+        ``committed_*`` counters are left untouched because they reflect
+        concurrent scheduling decisions, not registration metadata.
+        """
+        cur.execute(
+            "INSERT INTO workers("
+            "worker_id, address, healthy, active, consecutive_failures, last_heartbeat_ms, "
+            "committed_cpu_millicores, committed_mem_bytes, committed_gpu, committed_tpu, "
+            "total_cpu_millicores, total_memory_bytes, total_gpu_count, total_tpu_count, "
+            "device_type, device_variant, slice_id, scale_group, "
+            "md_hostname, md_ip_address, md_cpu_count, md_memory_bytes, md_disk_bytes, "
+            "md_tpu_name, md_tpu_worker_hostnames, md_tpu_worker_id, md_tpu_chips_per_host_bounds, "
+            "md_gpu_count, md_gpu_name, md_gpu_memory_mb, "
+            "md_gce_instance_name, md_gce_zone, md_git_hash, md_device_json"
+            ") VALUES (?, ?, 1, 1, 0, ?, 0, 0, 0, 0, ?, ?, ?, ?, ?, ?, ?, ?, "
+            "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(worker_id) DO UPDATE SET "
+            "address=excluded.address, healthy=1, active=1, "
+            "consecutive_failures=0, last_heartbeat_ms=excluded.last_heartbeat_ms, "
+            "total_cpu_millicores=excluded.total_cpu_millicores, total_memory_bytes=excluded.total_memory_bytes, "
+            "total_gpu_count=excluded.total_gpu_count, total_tpu_count=excluded.total_tpu_count, "
+            "device_type=excluded.device_type, device_variant=excluded.device_variant, "
+            "slice_id=excluded.slice_id, scale_group=excluded.scale_group, "
+            "md_hostname=excluded.md_hostname, md_ip_address=excluded.md_ip_address, "
+            "md_cpu_count=excluded.md_cpu_count, md_memory_bytes=excluded.md_memory_bytes, "
+            "md_disk_bytes=excluded.md_disk_bytes, md_tpu_name=excluded.md_tpu_name, "
+            "md_tpu_worker_hostnames=excluded.md_tpu_worker_hostnames, "
+            "md_tpu_worker_id=excluded.md_tpu_worker_id, "
+            "md_tpu_chips_per_host_bounds=excluded.md_tpu_chips_per_host_bounds, "
+            "md_gpu_count=excluded.md_gpu_count, md_gpu_name=excluded.md_gpu_name, "
+            "md_gpu_memory_mb=excluded.md_gpu_memory_mb, "
+            "md_gce_instance_name=excluded.md_gce_instance_name, md_gce_zone=excluded.md_gce_zone, "
+            "md_git_hash=excluded.md_git_hash, md_device_json=excluded.md_device_json",
+            (
+                str(params.worker_id),
+                params.address,
+                params.last_heartbeat_ms,
+                params.total_cpu_millicores,
+                params.total_memory_bytes,
+                params.total_gpu_count,
+                params.total_tpu_count,
+                params.device_type,
+                params.device_variant,
+                params.slice_id,
+                params.scale_group,
+                params.md_hostname,
+                params.md_ip_address,
+                params.md_cpu_count,
+                params.md_memory_bytes,
+                params.md_disk_bytes,
+                params.md_tpu_name,
+                params.md_tpu_worker_hostnames,
+                params.md_tpu_worker_id,
+                params.md_tpu_chips_per_host_bounds,
+                params.md_gpu_count,
+                params.md_gpu_name,
+                params.md_gpu_memory_mb,
+                params.md_gce_instance_name,
+                params.md_gce_zone,
+                params.md_git_hash,
+                params.md_device_json,
+            ),
+        )
+
+    def mark_unhealthy(self, cur: TransactionCursor, worker_id: WorkerId) -> None:
+        cur.execute("UPDATE workers SET healthy = 0 WHERE worker_id = ?", (str(worker_id),))
+
+    def apply_snapshots(
+        self,
+        cur: TransactionCursor,
+        items: Sequence[tuple[WorkerId, job_pb2.WorkerResourceSnapshot | None]],
+        now_ms: int,
+        *,
+        reset_health: bool,
+    ) -> None:
+        """Bump ``last_heartbeat_ms`` for every worker; for entries with a
+        snapshot also rewrite ``snapshot_*`` columns and append a
+        ``worker_resource_history`` row.
+
+        A ``None`` snapshot is a liveness-only update: the heartbeat path emits
+        these for workers that skipped their resource refresh this cycle, and
+        the ping path emits these on cycles where it skips the resource
+        refresh.
+
+        ``reset_health=True`` also clears ``healthy``/``active``/
+        ``consecutive_failures`` because a successful heartbeat proves
+        recovery. Ping path passes ``False`` — the ping loop tracks failures
+        in-memory and removes workers via ``fail_workers_batch``.
+        """
+        if not items:
+            return
+
+        health_prefix = "healthy = 1, active = 1, consecutive_failures = 0, " if reset_health else ""
+
+        liveness_only = [(now_ms, str(wid)) for wid, snap in items if snap is None]
+        if liveness_only:
+            cur.executemany(
+                f"UPDATE workers SET {health_prefix}last_heartbeat_ms = ? WHERE worker_id = ?",
+                liveness_only,
+            )
+
+        snapshot_binds = [
+            {
+                "worker_id": str(wid),
+                "now_ms": now_ms,
+                "host_cpu_percent": snap.host_cpu_percent,
+                "memory_used_bytes": snap.memory_used_bytes,
+                "memory_total_bytes": snap.memory_total_bytes,
+                "disk_used_bytes": snap.disk_used_bytes,
+                "disk_total_bytes": snap.disk_total_bytes,
+                "running_task_count": snap.running_task_count,
+                "total_process_count": snap.total_process_count,
+                "net_recv_bps": snap.net_recv_bps,
+                "net_sent_bps": snap.net_sent_bps,
+            }
+            for wid, snap in items
+            if snap is not None
+        ]
+        if not snapshot_binds:
+            return
+
+        cur.executemany(
+            f"UPDATE workers SET {health_prefix}last_heartbeat_ms = :now_ms, "
+            "snapshot_host_cpu_percent = :host_cpu_percent, "
+            "snapshot_memory_used_bytes = :memory_used_bytes, "
+            "snapshot_memory_total_bytes = :memory_total_bytes, "
+            "snapshot_disk_used_bytes = :disk_used_bytes, "
+            "snapshot_disk_total_bytes = :disk_total_bytes, "
+            "snapshot_running_task_count = :running_task_count, "
+            "snapshot_total_process_count = :total_process_count, "
+            "snapshot_net_recv_bps = :net_recv_bps, "
+            "snapshot_net_sent_bps = :net_sent_bps "
+            "WHERE worker_id = :worker_id",
+            snapshot_binds,
+        )
+        cur.executemany(
+            "INSERT INTO worker_resource_history ("
+            "worker_id, snapshot_host_cpu_percent, snapshot_memory_used_bytes, "
+            "snapshot_memory_total_bytes, snapshot_disk_used_bytes, snapshot_disk_total_bytes, "
+            "snapshot_running_task_count, snapshot_total_process_count, "
+            "snapshot_net_recv_bps, snapshot_net_sent_bps, timestamp_ms"
+            ") VALUES ("
+            ":worker_id, :host_cpu_percent, :memory_used_bytes, "
+            ":memory_total_bytes, :disk_used_bytes, :disk_total_bytes, "
+            ":running_task_count, :total_process_count, "
+            ":net_recv_bps, :net_sent_bps, :now_ms"
+            ")",
+            snapshot_binds,
+        )
 
     def add_committed_resources(
         self,

--- a/lib/iris/src/iris/cluster/controller/stores.py
+++ b/lib/iris/src/iris/cluster/controller/stores.py
@@ -592,6 +592,31 @@ def _decode_active_task_row(row) -> ActiveTaskRow:
     )
 
 
+@dataclass(frozen=True, slots=True)
+class PendingDispatchRow:
+    """Scheduling payload for a pending task awaiting direct-provider promotion.
+
+    Unlike :class:`ActiveTaskRow`, this row carries the full serialized
+    runtime configuration (entrypoint / environment / ports / constraints
+    / task_image / timeout) so the caller can assemble a
+    ``RunTaskRequest``. Kept separate so other active-task queries don't
+    pay for loading these JSON blobs.
+    """
+
+    task_id: JobName
+    job_id: JobName
+    current_attempt_id: int
+    num_tasks: int
+    resources: job_pb2.ResourceSpecProto
+    entrypoint_json: str
+    environment_json: str
+    bundle_id: str
+    ports_json: str
+    constraints_json: str | None
+    task_image: str
+    timeout_ms: int | None
+
+
 class JobStore:
     """Jobs, job_config, users, user_budgets.
 
@@ -1086,6 +1111,55 @@ class TaskStore:
             (task_id.to_wire(),),
         )
         return _decode_active_task_row(row) if row is not None else None
+
+    def list_pending_for_direct_provider(
+        self,
+        tx: Tx,
+        limit: int,
+    ) -> list[PendingDispatchRow]:
+        """Return pending non-holder tasks eligible for direct-provider dispatch.
+
+        Joins ``job_config`` to return the full runtime payload (entrypoint,
+        environment, ports, constraints, task_image, timeout) that the caller
+        needs to assemble a ``RunTaskRequest``. Returns at most ``limit`` rows.
+        """
+        if limit <= 0:
+            return []
+        rows = tx.fetchall(
+            "SELECT t.task_id, t.job_id, t.current_attempt_id, j.num_tasks, "
+            "jc.res_cpu_millicores, jc.res_memory_bytes, jc.res_disk_bytes, jc.res_device_json, "
+            "jc.entrypoint_json, jc.environment_json, jc.bundle_id, jc.ports_json, "
+            "jc.constraints_json, jc.task_image, jc.timeout_ms "
+            f"FROM tasks t JOIN jobs j ON j.job_id = t.job_id {JOB_CONFIG_JOIN} "
+            "WHERE t.state = ? AND j.is_reservation_holder = 0 "
+            "LIMIT ?",
+            (job_pb2.TASK_STATE_PENDING, limit),
+        )
+        result: list[PendingDispatchRow] = []
+        for row in rows:
+            timeout_ms = row["timeout_ms"]
+            result.append(
+                PendingDispatchRow(
+                    task_id=JobName.from_wire(str(row["task_id"])),
+                    job_id=JobName.from_wire(str(row["job_id"])),
+                    current_attempt_id=int(row["current_attempt_id"]),
+                    num_tasks=int(row["num_tasks"]),
+                    resources=resource_spec_from_scalars(
+                        int(row["res_cpu_millicores"]),
+                        int(row["res_memory_bytes"]),
+                        int(row["res_disk_bytes"]),
+                        row["res_device_json"],
+                    ),
+                    entrypoint_json=str(row["entrypoint_json"]),
+                    environment_json=str(row["environment_json"]),
+                    bundle_id=str(row["bundle_id"]),
+                    ports_json=str(row["ports_json"]),
+                    constraints_json=row["constraints_json"],
+                    task_image=str(row["task_image"]),
+                    timeout_ms=int(timeout_ms) if timeout_ms is not None else None,
+                )
+            )
+        return result
 
     # -- Writes --------------------------------------------------------------
 

--- a/lib/iris/src/iris/cluster/controller/stores.py
+++ b/lib/iris/src/iris/cluster/controller/stores.py
@@ -2070,3 +2070,6 @@ class ControllerStore:
 
     def read_snapshot(self):
         return self._db.read_snapshot()
+
+    def optimize(self) -> None:
+        self._db.optimize()

--- a/lib/iris/src/iris/cluster/controller/stores.py
+++ b/lib/iris/src/iris/cluster/controller/stores.py
@@ -2001,11 +2001,14 @@ class DispatchQueueStore:
             (str(worker_id), payload_proto, now_ms),
         )
 
-    def enqueue_kill(self, cur: TransactionCursor, worker_id: WorkerId | None, task_id: JobName, now_ms: int) -> None:
+    def enqueue_kill(self, cur: TransactionCursor, worker_id: WorkerId | None, task_id: str, now_ms: int) -> None:
+        """Insert a kill entry. ``task_id`` is stored verbatim — direct-provider
+        callers may pass non-canonical IDs (e.g. K8s pod-derived strings) and
+        the dispatch_queue.task_id column is plain TEXT."""
         cur.execute(
             "INSERT INTO dispatch_queue(worker_id, kind, payload_proto, task_id, created_at_ms) "
             "VALUES (?, 'kill', NULL, ?, ?)",
-            (str(worker_id) if worker_id is not None else None, task_id.to_wire(), now_ms),
+            (str(worker_id) if worker_id is not None else None, task_id, now_ms),
         )
 
     def drain_direct_kills(self, cur: TransactionCursor) -> list[str]:

--- a/lib/iris/src/iris/cluster/controller/stores.py
+++ b/lib/iris/src/iris/cluster/controller/stores.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from threading import RLock
 
@@ -713,6 +713,14 @@ class JobStore:
         )
         return JobName.from_wire(str(row["job_id"])) if row is not None else None
 
+    def get_workdir_files(self, tx: Tx, job_id: JobName) -> dict[str, bytes]:
+        """Return ``{filename: data}`` for all workdir files attached to a job."""
+        rows = tx.fetchall(
+            "SELECT filename, data FROM job_workdir_files WHERE job_id = ?",
+            (job_id.to_wire(),),
+        )
+        return {str(row["filename"]): bytes(row["data"]) for row in rows}
+
     # -- Writes --------------------------------------------------------------
 
     def update_state_if_not_terminal(
@@ -874,6 +882,27 @@ class JobStore:
     def delete(self, cur: TransactionCursor, job_id: JobName) -> None:
         """Delete a job row. ON DELETE CASCADE handles tasks, attempts, endpoints."""
         cur.execute("DELETE FROM jobs WHERE job_id = ?", (job_id.to_wire(),))
+
+    def insert_workdir_files(
+        self,
+        cur: TransactionCursor,
+        job_id: JobName,
+        files: Mapping[str, bytes],
+    ) -> None:
+        """Insert each ``{filename: data}`` pair as a row in ``job_workdir_files``."""
+        if not files:
+            return
+        cur.executemany(
+            "INSERT INTO job_workdir_files(job_id, filename, data) VALUES (?, ?, ?)",
+            [(job_id.to_wire(), name, data) for name, data in files.items()],
+        )
+
+    def reserve_priority_insertion_base(self, cur: TransactionCursor) -> int:
+        """Bump the ``task_priority_insertion`` sequence and return the new value.
+
+        Callers reserving N task slots use ``base + i`` for ``i in range(N)``.
+        """
+        return self._db.next_sequence("task_priority_insertion", cur=cur)
 
     # -- users / user_budgets ------------------------------------------------
 

--- a/lib/iris/src/iris/cluster/controller/stores.py
+++ b/lib/iris/src/iris/cluster/controller/stores.py
@@ -931,6 +931,27 @@ class TaskStore:
             return None
         return TASK_DETAIL_PROJECTION.decode_one([row])
 
+    def bulk_get_detail(self, tx: Tx, task_ids: Iterable[JobName]) -> dict[JobName, TaskDetailRow]:
+        """Return ``{task_id: TaskDetailRow}`` for all ``task_ids`` that exist.
+
+        Missing ids are silently absent from the result. Chunks internally
+        to stay under SQLite's statement-parameter limit.
+        """
+        result: dict[JobName, TaskDetailRow] = {}
+        ids = list(task_ids)
+        for chunk_start in range(0, len(ids), 900):
+            chunk = ids[chunk_start : chunk_start + 900]
+            if not chunk:
+                continue
+            placeholders = ",".join("?" for _ in chunk)
+            rows = tx.fetchall(
+                f"SELECT {TASK_DETAIL_PROJECTION.select_clause()} " f"FROM tasks t WHERE t.task_id IN ({placeholders})",
+                tuple(tid.to_wire() for tid in chunk),
+            )
+            for task in TASK_DETAIL_PROJECTION.decode(rows):
+                result[task.task_id] = task
+        return result
+
     def get_job_id(self, tx: Tx, task_id: JobName) -> JobName | None:
         row = tx.fetchone("SELECT job_id FROM tasks WHERE task_id = ?", (task_id.to_wire(),))
         return JobName.from_wire(str(row["job_id"])) if row is not None else None

--- a/lib/iris/src/iris/cluster/controller/stores.py
+++ b/lib/iris/src/iris/cluster/controller/stores.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass
 from threading import RLock
 
 from iris.cluster.constraints import AttributeValue
+from iris.cluster.controller.codec import resource_spec_from_scalars
 from iris.cluster.controller.db import ControllerDB, EndpointQuery, QuerySnapshot, TransactionCursor
 from iris.cluster.controller.schema import (
     ATTEMPT_PROJECTION,
@@ -465,6 +466,82 @@ class WorkerAttributeParams:
     float_value: float | None
 
 
+@dataclass(frozen=True, slots=True)
+class TaskScope:
+    """Scope predicate for :meth:`TaskStore.list_active`.
+
+    Exactly one field must be set. The store validates at the call boundary.
+    ``null_worker=True`` matches rows where ``current_worker_id IS NULL``
+    (direct-provider-promoted tasks).
+    """
+
+    job_id: JobName | None = None
+    job_subtree: Sequence[JobName] | None = None
+    worker_id: WorkerId | None = None
+    worker_ids: Sequence[WorkerId] | None = None
+    task_ids: Sequence[JobName] | None = None
+    null_worker: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ActiveTaskRow:
+    """Task projection joined with ``jobs`` + ``job_config``.
+
+    Shared by every cascade/scheduling query (``_kill_non_terminal_tasks``,
+    ``_find_coscheduled_siblings``, ``cancel_job``, ``preempt_task``,
+    ``cancel_tasks_for_timeout``, ``_remove_failed_worker``, poll paths). The
+    resource columns are decoded into a single ``ResourceSpecProto`` so
+    callers stop re-running ``resource_spec_from_scalars(...)`` at every
+    site. Reservation-holder rows carry a populated ``resources`` that
+    callers are expected to ignore (they never commit resources).
+    """
+
+    task_id: JobName
+    job_id: JobName
+    state: int
+    current_attempt_id: int
+    current_worker_id: WorkerId | None
+    failure_count: int
+    preemption_count: int
+    max_retries_failure: int
+    max_retries_preemption: int
+    is_reservation_holder: bool
+    has_coscheduling: bool
+    resources: job_pb2.ResourceSpecProto
+
+
+_ACTIVE_TASK_PROJECTION = (
+    "t.task_id, t.job_id, t.state, t.current_attempt_id, t.current_worker_id, "
+    "t.failure_count, t.preemption_count, t.max_retries_failure, t.max_retries_preemption, "
+    "j.is_reservation_holder, "
+    "jc.has_coscheduling, "
+    "jc.res_cpu_millicores, jc.res_memory_bytes, jc.res_disk_bytes, jc.res_device_json"
+)
+
+
+def _decode_active_task_row(row) -> ActiveTaskRow:
+    worker_id = row["current_worker_id"]
+    return ActiveTaskRow(
+        task_id=JobName.from_wire(str(row["task_id"])),
+        job_id=JobName.from_wire(str(row["job_id"])),
+        state=int(row["state"]),
+        current_attempt_id=int(row["current_attempt_id"]),
+        current_worker_id=WorkerId(str(worker_id)) if worker_id is not None else None,
+        failure_count=int(row["failure_count"]),
+        preemption_count=int(row["preemption_count"]),
+        max_retries_failure=int(row["max_retries_failure"]),
+        max_retries_preemption=int(row["max_retries_preemption"]),
+        is_reservation_holder=bool(int(row["is_reservation_holder"])),
+        has_coscheduling=bool(int(row["has_coscheduling"])),
+        resources=resource_spec_from_scalars(
+            int(row["res_cpu_millicores"]),
+            int(row["res_memory_bytes"]),
+            int(row["res_disk_bytes"]),
+            row["res_device_json"],
+        ),
+    )
+
+
 class JobStore:
     """Jobs, job_config, users, user_budgets.
 
@@ -803,6 +880,112 @@ class TaskStore:
             (job_id.to_wire(),),
         )
         return str(row["error"]) if row is not None else None
+
+    def list_active(
+        self,
+        tx: Tx,
+        scope: TaskScope,
+        *,
+        states: Iterable[int],
+        exclude_task_id: JobName | None = None,
+        exclude_reservation_holders: bool = False,
+        order_by_task_id: bool = False,
+        limit: int | None = None,
+    ) -> list[ActiveTaskRow]:
+        """Return :class:`ActiveTaskRow` rows matching ``scope`` and ``states``.
+
+        ``scope`` picks which side of the query the filter binds to
+        (single job, job subtree, worker, explicit task list, or NULL
+        worker). ``states`` is the required ``tasks.state`` filter —
+        typical values are ``ACTIVE_TASK_STATES``,
+        ``EXECUTING_TASK_STATES``, or ``NON_TERMINAL_TASK_STATES``. Pass
+        an empty ``states`` (or an empty ``task_ids``/``job_subtree``
+        scope) to short-circuit to an empty list.
+        """
+        scope_set = sum(
+            1
+            for x in (scope.job_id, scope.job_subtree, scope.worker_id, scope.worker_ids, scope.task_ids)
+            if x is not None
+        ) + (1 if scope.null_worker else 0)
+        if scope_set != 1:
+            raise ValueError(
+                "TaskScope must set exactly one of: " "job_id, job_subtree, worker_id, worker_ids, task_ids, null_worker"
+            )
+
+        where_parts: list[str] = []
+        params: list[object] = []
+
+        if scope.job_id is not None:
+            where_parts.append("t.job_id = ?")
+            params.append(scope.job_id.to_wire())
+        elif scope.job_subtree is not None:
+            if not scope.job_subtree:
+                return []
+            wires = [jid.to_wire() for jid in scope.job_subtree]
+            ph = ",".join("?" for _ in wires)
+            where_parts.append(f"t.job_id IN ({ph})")
+            params.extend(wires)
+        elif scope.worker_id is not None:
+            where_parts.append("t.current_worker_id = ?")
+            params.append(str(scope.worker_id))
+        elif scope.worker_ids is not None:
+            if not scope.worker_ids:
+                return []
+            wids = [str(wid) for wid in scope.worker_ids]
+            ph = ",".join("?" for _ in wids)
+            where_parts.append(f"t.current_worker_id IN ({ph})")
+            params.extend(wids)
+        elif scope.task_ids is not None:
+            if not scope.task_ids:
+                return []
+            wires = [tid.to_wire() for tid in scope.task_ids]
+            ph = ",".join("?" for _ in wires)
+            where_parts.append(f"t.task_id IN ({ph})")
+            params.extend(wires)
+        else:  # null_worker
+            where_parts.append("t.current_worker_id IS NULL")
+
+        if exclude_task_id is not None:
+            where_parts.append("t.task_id != ?")
+            params.append(exclude_task_id.to_wire())
+
+        if exclude_reservation_holders:
+            where_parts.append("j.is_reservation_holder = 0")
+
+        states_tuple = tuple(states)
+        if not states_tuple:
+            return []
+        state_ph = ",".join("?" for _ in states_tuple)
+        where_parts.append(f"t.state IN ({state_ph})")
+        params.extend(states_tuple)
+
+        sql = (
+            f"SELECT {_ACTIVE_TASK_PROJECTION} "
+            f"FROM tasks t JOIN jobs j ON j.job_id = t.job_id {JOB_CONFIG_JOIN} "
+            f"WHERE {' AND '.join(where_parts)}"
+        )
+        if order_by_task_id:
+            sql += " ORDER BY t.task_id ASC"
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+
+        rows = tx.fetchall(sql, tuple(params))
+        return [_decode_active_task_row(row) for row in rows]
+
+    def get_with_resources(self, tx: Tx, task_id: JobName) -> ActiveTaskRow | None:
+        """Fetch a single task with its job_config resource projection.
+
+        Unlike :meth:`list_active`, no state filter is applied; callers
+        (``preempt_task``) check the returned ``state`` themselves.
+        """
+        row = tx.fetchone(
+            f"SELECT {_ACTIVE_TASK_PROJECTION} "
+            f"FROM tasks t JOIN jobs j ON j.job_id = t.job_id {JOB_CONFIG_JOIN} "
+            f"WHERE t.task_id = ?",
+            (task_id.to_wire(),),
+        )
+        return _decode_active_task_row(row) if row is not None else None
 
     # -- Writes --------------------------------------------------------------
 

--- a/lib/iris/src/iris/cluster/controller/stores.py
+++ b/lib/iris/src/iris/cluster/controller/stores.py
@@ -34,18 +34,39 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from threading import RLock
 
+from iris.cluster.constraints import AttributeValue
 from iris.cluster.controller.db import ControllerDB, EndpointQuery, QuerySnapshot, TransactionCursor
 from iris.cluster.controller.schema import (
+    ATTEMPT_PROJECTION,
     ENDPOINT_PROJECTION,
     JOB_CONFIG_JOIN,
     JOB_DETAIL_PROJECTION,
+    TASK_DETAIL_PROJECTION,
+    AttemptRow,
     EndpointRow,
     JobDetailRow,
+    TaskDetailRow,
 )
-from iris.cluster.types import TERMINAL_JOB_STATES, TERMINAL_TASK_STATES, JobName
+from iris.cluster.types import TERMINAL_JOB_STATES, TERMINAL_TASK_STATES, JobName, WorkerId, get_gpu_count, get_tpu_count
 from iris.rpc import job_pb2
+from rigging.timing import Duration, Timestamp
 
 logger = logging.getLogger(__name__)
+
+WORKER_TASK_HISTORY_RETENTION = 500
+"""Maximum worker_task_history rows retained per worker."""
+
+WORKER_RESOURCE_HISTORY_RETENTION = 500
+"""Maximum worker_resource_history rows retained per worker."""
+
+TASK_RESOURCE_HISTORY_RETENTION = 50
+"""Maximum task_resource_history rows retained per (task_id, attempt_id)."""
+
+TASK_RESOURCE_HISTORY_TERMINAL_TTL = Duration.from_hours(1)
+"""After a task reaches a terminal state, fully evict its resource history after this delay."""
+
+TASK_RESOURCE_HISTORY_DELETE_CHUNK = 1000
+"""Maximum task_ids per DELETE in task_resource_history pruning."""
 
 
 # Store read methods accept either a write cursor or a read snapshot. Writes
@@ -369,6 +390,81 @@ class JobRecomputeBasis:
     max_task_failures: int
 
 
+@dataclass(frozen=True, slots=True)
+class TaskInsertParams:
+    """Fields needed to insert one row into the ``tasks`` table."""
+
+    task_id: JobName
+    job_id: JobName
+    task_index: int
+    state: int
+    submitted_at_ms: int
+    max_retries_failure: int
+    max_retries_preemption: int
+    priority_neg_depth: int
+    priority_root_submitted_ms: int
+    priority_insertion: int
+    priority_band: int
+
+
+@dataclass(frozen=True, slots=True)
+class TaskAttemptInsertParams:
+    """Fields needed to insert one row into ``task_attempts``."""
+
+    task_id: JobName
+    attempt_id: int
+    worker_id: WorkerId | None
+    state: int
+    created_at_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class TaskAttemptUpdateParams:
+    """Fields for applying a worker/direct-provider attempt update."""
+
+    task_id: JobName
+    attempt_id: int
+    state: int
+    started_at_ms: int | None
+    finished_at_ms: int | None
+    exit_code: int | None
+    error: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class TaskStateUpdateParams:
+    """Fields for applying a computed task state update."""
+
+    task_id: JobName
+    state: int
+    error: str | None
+    exit_code: int | None
+    started_at_ms: int | None
+    finished_at_ms: int | None
+    failure_count: int
+    preemption_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceUsageInsertParams:
+    task_id: JobName
+    attempt_id: int
+    cpu_millicores: int
+    memory_mb: int
+    disk_mb: int
+    memory_peak_mb: int
+    timestamp_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerAttributeParams:
+    key: str
+    value_type: str
+    str_value: str | None
+    int_value: int | None
+    float_value: float | None
+
+
 class JobStore:
     """Jobs, job_config, users, user_budgets.
 
@@ -668,12 +764,402 @@ class TaskStore:
     def __init__(self, db: ControllerDB) -> None:
         self._db = db
 
+    # -- Reads ---------------------------------------------------------------
+
+    def get_detail(self, tx: Tx, task_id: JobName) -> TaskDetailRow | None:
+        row = tx.fetchone(
+            f"SELECT {TASK_DETAIL_PROJECTION.select_clause()} FROM tasks t WHERE t.task_id = ?",
+            (task_id.to_wire(),),
+        )
+        if row is None:
+            return None
+        return TASK_DETAIL_PROJECTION.decode_one([row])
+
+    def get_job_id(self, tx: Tx, task_id: JobName) -> JobName | None:
+        row = tx.fetchone("SELECT job_id FROM tasks WHERE task_id = ?", (task_id.to_wire(),))
+        return JobName.from_wire(str(row["job_id"])) if row is not None else None
+
+    def get_current_attempt_id(self, tx: Tx, task_id: JobName) -> int | None:
+        row = tx.fetchone("SELECT current_attempt_id FROM tasks WHERE task_id = ?", (task_id.to_wire(),))
+        return int(row["current_attempt_id"]) if row is not None else None
+
+    def get_priority_band_for_job(self, tx: Tx, job_id: JobName) -> int | None:
+        row = tx.fetchone(
+            "SELECT priority_band FROM tasks WHERE job_id = ? LIMIT 1",
+            (job_id.to_wire(),),
+        )
+        return int(row["priority_band"]) if row is not None else None
+
+    def state_counts_for_job(self, tx: Tx, job_id: JobName) -> dict[int, int]:
+        rows = tx.fetchall(
+            "SELECT state, COUNT(*) AS c FROM tasks WHERE job_id = ? GROUP BY state",
+            (job_id.to_wire(),),
+        )
+        return {int(row["state"]): int(row["c"]) for row in rows}
+
+    def first_error_for_job(self, tx: Tx, job_id: JobName) -> str | None:
+        row = tx.fetchone(
+            "SELECT error FROM tasks WHERE job_id = ? AND error IS NOT NULL ORDER BY task_index LIMIT 1",
+            (job_id.to_wire(),),
+        )
+        return str(row["error"]) if row is not None else None
+
+    # -- Writes --------------------------------------------------------------
+
+    def insert(self, cur: TransactionCursor, params: TaskInsertParams) -> None:
+        cur.execute(
+            "INSERT INTO tasks("
+            "task_id, job_id, task_index, state, error, exit_code, submitted_at_ms, started_at_ms, "
+            "finished_at_ms, max_retries_failure, max_retries_preemption, failure_count, preemption_count, "
+            "current_attempt_id, priority_neg_depth, priority_root_submitted_ms, "
+            "priority_insertion, priority_band"
+            ") VALUES (?, ?, ?, ?, NULL, NULL, ?, NULL, NULL, ?, ?, 0, 0, -1, ?, ?, ?, ?)",
+            (
+                params.task_id.to_wire(),
+                params.job_id.to_wire(),
+                params.task_index,
+                params.state,
+                params.submitted_at_ms,
+                params.max_retries_failure,
+                params.max_retries_preemption,
+                params.priority_neg_depth,
+                params.priority_root_submitted_ms,
+                params.priority_insertion,
+                params.priority_band,
+            ),
+        )
+
+    def mark_assigned(
+        self,
+        cur: TransactionCursor,
+        task_id: JobName,
+        attempt_id: int,
+        worker_id: WorkerId | None,
+        worker_address: str | None,
+        now_ms: int,
+    ) -> None:
+        if worker_id is not None:
+            cur.execute(
+                "UPDATE tasks SET state = ?, current_attempt_id = ?, "
+                "current_worker_id = ?, current_worker_address = ?, "
+                "started_at_ms = COALESCE(started_at_ms, ?) WHERE task_id = ?",
+                (job_pb2.TASK_STATE_ASSIGNED, attempt_id, str(worker_id), worker_address, now_ms, task_id.to_wire()),
+            )
+            return
+        cur.execute(
+            "UPDATE tasks SET state = ?, current_attempt_id = ?, "
+            "started_at_ms = COALESCE(started_at_ms, ?) WHERE task_id = ?",
+            (job_pb2.TASK_STATE_ASSIGNED, attempt_id, now_ms, task_id.to_wire()),
+        )
+
+    def assign(
+        self,
+        cur: TransactionCursor,
+        attempts: TaskAttemptStore,
+        task_id: JobName,
+        worker_id: WorkerId | None,
+        worker_address: str | None,
+        attempt_id: int,
+        now_ms: int,
+    ) -> None:
+        attempts.insert(
+            cur,
+            TaskAttemptInsertParams(
+                task_id=task_id,
+                attempt_id=attempt_id,
+                worker_id=worker_id,
+                state=job_pb2.TASK_STATE_ASSIGNED,
+                created_at_ms=now_ms,
+            ),
+        )
+        self.mark_assigned(cur, task_id, attempt_id, worker_id, worker_address, now_ms)
+
+    def apply_state_update(
+        self,
+        cur: TransactionCursor,
+        params: TaskStateUpdateParams,
+        active_states: set[int],
+    ) -> None:
+        if params.state in active_states:
+            cur.execute(
+                "UPDATE tasks SET state = ?, error = COALESCE(?, error), exit_code = COALESCE(?, exit_code), "
+                "started_at_ms = COALESCE(started_at_ms, ?), finished_at_ms = ?, "
+                "failure_count = ?, preemption_count = ? "
+                "WHERE task_id = ?",
+                (
+                    params.state,
+                    params.error,
+                    params.exit_code,
+                    params.started_at_ms,
+                    params.finished_at_ms,
+                    params.failure_count,
+                    params.preemption_count,
+                    params.task_id.to_wire(),
+                ),
+            )
+            return
+        cur.execute(
+            "UPDATE tasks SET state = ?, error = COALESCE(?, error), exit_code = COALESCE(?, exit_code), "
+            "started_at_ms = COALESCE(started_at_ms, ?), finished_at_ms = ?, "
+            "failure_count = ?, preemption_count = ?, "
+            "current_worker_id = NULL, current_worker_address = NULL "
+            "WHERE task_id = ?",
+            (
+                params.state,
+                params.error,
+                params.exit_code,
+                params.started_at_ms,
+                params.finished_at_ms,
+                params.failure_count,
+                params.preemption_count,
+                params.task_id.to_wire(),
+            ),
+        )
+
+    def mark_terminal(
+        self,
+        cur: TransactionCursor,
+        task_id: JobName,
+        state: int,
+        error: str | None,
+        finished_at_ms: int | None,
+        *,
+        failure_count: int | None = None,
+        preemption_count: int | None = None,
+        active_states: set[int],
+    ) -> None:
+        if finished_at_ms is not None:
+            set_clauses = ["state = ?", "error = ?", "finished_at_ms = COALESCE(finished_at_ms, ?)"]
+        else:
+            set_clauses = ["state = ?", "error = ?", "finished_at_ms = ?"]
+        params: list[object] = [state, error, finished_at_ms]
+
+        if failure_count is not None:
+            set_clauses.append("failure_count = ?")
+            params.append(failure_count)
+        if preemption_count is not None:
+            set_clauses.append("preemption_count = ?")
+            params.append(preemption_count)
+        if state not in active_states:
+            set_clauses.append("current_worker_id = NULL")
+            set_clauses.append("current_worker_address = NULL")
+
+        params.append(task_id.to_wire())
+        cur.execute(
+            f"UPDATE tasks SET {', '.join(set_clauses)} WHERE task_id = ?",
+            tuple(params),
+        )
+
+    def bulk_kill_non_terminal(
+        self,
+        cur: TransactionCursor,
+        job_ids: Sequence[JobName],
+        reason: str,
+        finished_at_ms: int,
+        terminal_states: set[int],
+    ) -> None:
+        if not job_ids:
+            return
+        wire_ids = [jid.to_wire() for jid in job_ids]
+        job_placeholders = ",".join("?" for _ in wire_ids)
+        terminal_placeholders = ",".join("?" for _ in terminal_states)
+        cur.execute(
+            f"UPDATE tasks SET state = ?, error = ?, finished_at_ms = COALESCE(finished_at_ms, ?), "
+            "current_worker_id = NULL, current_worker_address = NULL "
+            f"WHERE job_id IN ({job_placeholders}) AND state NOT IN ({terminal_placeholders})",
+            (
+                job_pb2.TASK_STATE_KILLED,
+                reason,
+                finished_at_ms,
+                *wire_ids,
+                *terminal_states,
+            ),
+        )
+
+    def update_container_id(self, cur: TransactionCursor, task_id: JobName, container_id: str) -> None:
+        cur.execute(
+            "UPDATE tasks SET container_id = ? WHERE task_id = ?",
+            (container_id, task_id.to_wire()),
+        )
+
+    def insert_resource_usage(self, cur: TransactionCursor, params: ResourceUsageInsertParams) -> None:
+        cur.execute(
+            "INSERT INTO task_resource_history"
+            "(task_id, attempt_id, cpu_millicores, memory_mb, disk_mb, memory_peak_mb, timestamp_ms) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                params.task_id.to_wire(),
+                params.attempt_id,
+                params.cpu_millicores,
+                params.memory_mb,
+                params.disk_mb,
+                params.memory_peak_mb,
+                params.timestamp_ms,
+            ),
+        )
+
+    def insert_resource_usage_many(
+        self,
+        cur: TransactionCursor,
+        params: Sequence[ResourceUsageInsertParams],
+    ) -> None:
+        if not params:
+            return
+        cur.executemany(
+            "INSERT INTO task_resource_history"
+            "(task_id, attempt_id, cpu_millicores, memory_mb, disk_mb, memory_peak_mb, timestamp_ms) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [
+                (
+                    p.task_id.to_wire(),
+                    p.attempt_id,
+                    p.cpu_millicores,
+                    p.memory_mb,
+                    p.disk_mb,
+                    p.memory_peak_mb,
+                    p.timestamp_ms,
+                )
+                for p in params
+            ],
+        )
+
+    def prune_resource_history(self) -> int:
+        """Prune task_resource_history rows using TTL eviction and logarithmic downsampling."""
+        now_ms = Timestamp.now().epoch_ms()
+        ttl_cutoff_ms = now_ms - TASK_RESOURCE_HISTORY_TERMINAL_TTL.to_ms()
+        terminal_placeholders = ",".join("?" for _ in TERMINAL_TASK_STATES)
+
+        with self._db.read_snapshot() as snap:
+            terminal_ids = [
+                str(row["task_id"])
+                for row in snap.fetchall(
+                    f"SELECT task_id FROM tasks "
+                    f"WHERE state IN ({terminal_placeholders}) "
+                    f"AND finished_at_ms IS NOT NULL AND finished_at_ms < ?",
+                    (*TERMINAL_TASK_STATES, ttl_cutoff_ms),
+                )
+            ]
+
+        evicted_terminal = 0
+        for chunk_start in range(0, len(terminal_ids), TASK_RESOURCE_HISTORY_DELETE_CHUNK):
+            chunk = terminal_ids[chunk_start : chunk_start + TASK_RESOURCE_HISTORY_DELETE_CHUNK]
+            placeholders = ",".join("?" * len(chunk))
+            with self._db.transaction() as cur:
+                cur.execute(f"DELETE FROM task_resource_history WHERE task_id IN ({placeholders})", tuple(chunk))
+                evicted_terminal += cur.rowcount
+
+        threshold = TASK_RESOURCE_HISTORY_RETENTION * 2
+        with self._db.transaction() as cur:
+            overflows = cur.execute(
+                "SELECT task_id, attempt_id, COUNT(*) as cnt "
+                "FROM task_resource_history "
+                "GROUP BY task_id, attempt_id HAVING cnt > ?",
+                (threshold,),
+            ).fetchall()
+            ids_to_delete: list[int] = []
+            for row in overflows:
+                task_id, attempt_id = row["task_id"], row["attempt_id"]
+                all_ids = [
+                    r["id"]
+                    for r in cur.execute(
+                        "SELECT id FROM task_resource_history WHERE task_id = ? AND attempt_id = ? ORDER BY id ASC",
+                        (task_id, attempt_id),
+                    ).fetchall()
+                ]
+                older = all_ids[: len(all_ids) - TASK_RESOURCE_HISTORY_RETENTION]
+                ids_to_delete.extend(older[1::2])
+
+            total_deleted = 0
+            for chunk_start in range(0, len(ids_to_delete), 900):
+                chunk = ids_to_delete[chunk_start : chunk_start + 900]
+                placeholders = ",".join("?" * len(chunk))
+                cur.execute(f"DELETE FROM task_resource_history WHERE id IN ({placeholders})", tuple(chunk))
+                total_deleted += cur.rowcount
+        if evicted_terminal > 0:
+            logger.info("Evicted %d task_resource_history rows (terminal TTL)", evicted_terminal)
+        if total_deleted > 0:
+            logger.info("Pruned %d task_resource_history rows (log downsampling)", total_deleted)
+        return evicted_terminal + total_deleted
+
 
 class TaskAttemptStore:
     """Task attempts."""
 
     def __init__(self, db: ControllerDB) -> None:
         self._db = db
+
+    # -- Reads ---------------------------------------------------------------
+
+    def get(self, tx: Tx, task_id: JobName, attempt_id: int) -> AttemptRow | None:
+        row = tx.fetchone(
+            f"SELECT {ATTEMPT_PROJECTION.select_clause()} FROM task_attempts ta "
+            "WHERE ta.task_id = ? AND ta.attempt_id = ?",
+            (task_id.to_wire(), attempt_id),
+        )
+        if row is None:
+            return None
+        return ATTEMPT_PROJECTION.decode_one([row])
+
+    def get_state(self, tx: Tx, task_id: JobName, attempt_id: int) -> int | None:
+        row = tx.fetchone(
+            "SELECT state FROM task_attempts WHERE task_id = ? AND attempt_id = ?",
+            (task_id.to_wire(), attempt_id),
+        )
+        return int(row["state"]) if row is not None else None
+
+    def get_worker_id(self, tx: Tx, task_id: JobName, attempt_id: int) -> WorkerId | None:
+        row = tx.fetchone(
+            "SELECT worker_id FROM task_attempts WHERE task_id = ? AND attempt_id = ?",
+            (task_id.to_wire(), attempt_id),
+        )
+        if row is None or row["worker_id"] is None:
+            return None
+        return WorkerId(str(row["worker_id"]))
+
+    # -- Writes --------------------------------------------------------------
+
+    def insert(self, cur: TransactionCursor, params: TaskAttemptInsertParams) -> None:
+        cur.execute(
+            "INSERT INTO task_attempts(task_id, attempt_id, worker_id, state, created_at_ms) VALUES (?, ?, ?, ?, ?)",
+            (
+                params.task_id.to_wire(),
+                params.attempt_id,
+                str(params.worker_id) if params.worker_id is not None else None,
+                params.state,
+                params.created_at_ms,
+            ),
+        )
+
+    def mark_finished(
+        self,
+        cur: TransactionCursor,
+        task_id: JobName,
+        attempt_id: int,
+        state: int,
+        finished_at_ms: int,
+        error: str | None,
+    ) -> None:
+        cur.execute(
+            "UPDATE task_attempts SET state = ?, finished_at_ms = COALESCE(finished_at_ms, ?), error = ? "
+            "WHERE task_id = ? AND attempt_id = ?",
+            (state, finished_at_ms, error, task_id.to_wire(), attempt_id),
+        )
+
+    def apply_update(self, cur: TransactionCursor, params: TaskAttemptUpdateParams) -> None:
+        cur.execute(
+            "UPDATE task_attempts SET state = ?, started_at_ms = COALESCE(started_at_ms, ?), "
+            "finished_at_ms = COALESCE(finished_at_ms, ?), exit_code = COALESCE(?, exit_code), "
+            "error = COALESCE(?, error) WHERE task_id = ? AND attempt_id = ?",
+            (
+                params.state,
+                params.started_at_ms,
+                params.finished_at_ms,
+                params.exit_code,
+                params.error,
+                params.task_id.to_wire(),
+                params.attempt_id,
+            ),
+        )
 
 
 class WorkerStore:
@@ -682,6 +1168,141 @@ class WorkerStore:
     def __init__(self, db: ControllerDB) -> None:
         self._db = db
 
+    def active_healthy_address(self, tx: Tx, worker_id: WorkerId) -> str | None:
+        row = tx.fetchone(
+            "SELECT address FROM workers WHERE worker_id = ? AND active = 1 AND healthy = 1",
+            (str(worker_id),),
+        )
+        return str(row["address"]) if row is not None else None
+
+    def address(self, tx: Tx, worker_id: WorkerId) -> str | None:
+        row = tx.fetchone("SELECT address FROM workers WHERE worker_id = ?", (str(worker_id),))
+        return str(row["address"]) if row is not None else None
+
+    def add_committed_resources(
+        self,
+        cur: TransactionCursor,
+        worker_id: WorkerId,
+        resources: job_pb2.ResourceSpecProto,
+    ) -> None:
+        cur.execute(
+            "UPDATE workers SET committed_cpu_millicores = committed_cpu_millicores + ?, "
+            "committed_mem_bytes = committed_mem_bytes + ?, committed_gpu = committed_gpu + ?, "
+            "committed_tpu = committed_tpu + ? WHERE worker_id = ?",
+            (
+                int(resources.cpu_millicores),
+                int(resources.memory_bytes),
+                int(get_gpu_count(resources.device)),
+                int(get_tpu_count(resources.device)),
+                str(worker_id),
+            ),
+        )
+
+    def decommit_resources(
+        self,
+        cur: TransactionCursor,
+        worker_id: WorkerId,
+        resources: job_pb2.ResourceSpecProto,
+    ) -> None:
+        cur.execute(
+            "UPDATE workers SET committed_cpu_millicores = MAX(0, committed_cpu_millicores - ?), "
+            "committed_mem_bytes = MAX(0, committed_mem_bytes - ?), "
+            "committed_gpu = MAX(0, committed_gpu - ?), committed_tpu = MAX(0, committed_tpu - ?) "
+            "WHERE worker_id = ?",
+            (
+                int(resources.cpu_millicores),
+                int(resources.memory_bytes),
+                int(get_gpu_count(resources.device)),
+                int(get_tpu_count(resources.device)),
+                str(worker_id),
+            ),
+        )
+
+    def replace_attributes(
+        self,
+        cur: TransactionCursor,
+        worker_id: WorkerId,
+        attrs: Sequence[WorkerAttributeParams],
+    ) -> None:
+        cur.execute("DELETE FROM worker_attributes WHERE worker_id = ?", (str(worker_id),))
+        for attr in attrs:
+            cur.execute(
+                "INSERT INTO worker_attributes(worker_id, key, value_type, str_value, int_value, float_value) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (str(worker_id), attr.key, attr.value_type, attr.str_value, attr.int_value, attr.float_value),
+            )
+
+    def set_attribute_for_test(
+        self,
+        cur: TransactionCursor,
+        worker_id: WorkerId,
+        attr: WorkerAttributeParams,
+    ) -> None:
+        cur.execute(
+            "INSERT INTO worker_attributes(worker_id, key, value_type, str_value, int_value, float_value) "
+            "VALUES (?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(worker_id, key) DO UPDATE SET "
+            "value_type=excluded.value_type, "
+            "str_value=excluded.str_value, "
+            "int_value=excluded.int_value, "
+            "float_value=excluded.float_value",
+            (str(worker_id), attr.key, attr.value_type, attr.str_value, attr.int_value, attr.float_value),
+        )
+
+    def update_attr_cache(self, worker_id: WorkerId, attrs: dict[str, AttributeValue]) -> None:
+        self._db.set_worker_attributes(worker_id, attrs)
+
+    def remove_from_attr_cache(self, worker_id: WorkerId) -> None:
+        self._db.remove_worker_from_attr_cache(worker_id)
+
+    def remove(self, cur: TransactionCursor, worker_id: WorkerId) -> None:
+        cur.execute("UPDATE task_attempts SET worker_id = NULL WHERE worker_id = ?", (str(worker_id),))
+        cur.execute("UPDATE tasks SET current_worker_id = NULL WHERE current_worker_id = ?", (str(worker_id),))
+        cur.execute("DELETE FROM dispatch_queue WHERE worker_id = ?", (str(worker_id),))
+        cur.execute("DELETE FROM workers WHERE worker_id = ?", (str(worker_id),))
+
+    def prune_task_history(self) -> int:
+        return self._prune_per_worker_history(
+            "worker_task_history",
+            WORKER_TASK_HISTORY_RETENTION,
+            order_by="assigned_at_ms DESC, id DESC",
+        )
+
+    def prune_resource_history(self) -> int:
+        return self._prune_per_worker_history(
+            "worker_resource_history",
+            WORKER_RESOURCE_HISTORY_RETENTION,
+        )
+
+    def _prune_per_worker_history(
+        self,
+        table: str,
+        retention: int,
+        order_by: str = "id DESC",
+    ) -> int:
+        with self._db.transaction() as cur:
+            rows = cur.execute(
+                f"SELECT worker_id, COUNT(*) as cnt FROM {table} GROUP BY worker_id HAVING cnt > ?",
+                (retention,),
+            ).fetchall()
+            total_deleted = 0
+            for row in rows:
+                worker_id = row["worker_id"]
+                cur.execute(
+                    f"DELETE FROM {table} "
+                    "WHERE worker_id = ? "
+                    f"AND id NOT IN ("
+                    f"  SELECT id FROM {table} "
+                    "  WHERE worker_id = ? "
+                    f"  ORDER BY {order_by} LIMIT ?"
+                    ")",
+                    (worker_id, worker_id, retention),
+                )
+                total_deleted += cur.rowcount
+        if total_deleted > 0:
+            logger.info("Pruned %d %s rows", total_deleted, table)
+        return total_deleted
+
 
 class DispatchQueueStore:
     """The dispatch_queue table."""
@@ -689,12 +1310,53 @@ class DispatchQueueStore:
     def __init__(self, db: ControllerDB) -> None:
         self._db = db
 
+    def enqueue_run(self, cur: TransactionCursor, worker_id: WorkerId, payload_proto: bytes, now_ms: int) -> None:
+        cur.execute(
+            "INSERT INTO dispatch_queue(worker_id, kind, payload_proto, task_id, created_at_ms) "
+            "VALUES (?, 'run', ?, NULL, ?)",
+            (str(worker_id), payload_proto, now_ms),
+        )
+
+    def enqueue_kill(self, cur: TransactionCursor, worker_id: WorkerId | None, task_id: JobName, now_ms: int) -> None:
+        cur.execute(
+            "INSERT INTO dispatch_queue(worker_id, kind, payload_proto, task_id, created_at_ms) "
+            "VALUES (?, 'kill', NULL, ?, ?)",
+            (str(worker_id) if worker_id is not None else None, task_id.to_wire(), now_ms),
+        )
+
+    def drain_direct_kills(self, cur: TransactionCursor) -> list[str]:
+        rows = cur.execute(
+            "SELECT task_id FROM dispatch_queue WHERE worker_id IS NULL AND kind = 'kill'",
+        ).fetchall()
+        tasks_to_kill = [str(row["task_id"]) for row in rows if row["task_id"] is not None]
+        if rows:
+            cur.execute("DELETE FROM dispatch_queue WHERE worker_id IS NULL AND kind = 'kill'")
+        return tasks_to_kill
+
 
 class ReservationStore:
     """Reservation claims and the meta(last_submission_ms) counter."""
 
     def __init__(self, db: ControllerDB) -> None:
         self._db = db
+
+    def replace_claims(self, cur: TransactionCursor, claims: dict[WorkerId, tuple[str, int]]) -> None:
+        cur.execute("DELETE FROM reservation_claims")
+        for worker_id, (job_id, entry_idx) in claims.items():
+            cur.execute(
+                "INSERT INTO reservation_claims(worker_id, job_id, entry_idx) VALUES (?, ?, ?)",
+                (str(worker_id), job_id, entry_idx),
+            )
+
+    def next_submission_ms(self, cur: TransactionCursor, submitted_ms: int) -> int:
+        row = cur.execute("SELECT value FROM meta WHERE key = 'last_submission_ms'").fetchone()
+        last_submission_ms = int(row["value"]) if row is not None else 0
+        effective_submission_ms = max(submitted_ms, last_submission_ms + 1)
+        if row is None:
+            cur.execute("INSERT INTO meta(key, value) VALUES ('last_submission_ms', ?)", (effective_submission_ms,))
+        else:
+            cur.execute("UPDATE meta SET value = ? WHERE key = 'last_submission_ms'", (effective_submission_ms,))
+        return effective_submission_ms
 
 
 # =============================================================================

--- a/lib/iris/src/iris/cluster/controller/stores.py
+++ b/lib/iris/src/iris/cluster/controller/stores.py
@@ -30,13 +30,20 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Iterable, Mapping, Sequence
+import time
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from threading import RLock
 
 from iris.cluster.constraints import AttributeValue
 from iris.cluster.controller.codec import resource_spec_from_scalars
-from iris.cluster.controller.db import ControllerDB, EndpointQuery, QuerySnapshot, TransactionCursor
+from iris.cluster.controller.db import (
+    ACTIVE_TASK_STATES,
+    ControllerDB,
+    EndpointQuery,
+    QuerySnapshot,
+    TransactionCursor,
+)
 from iris.cluster.controller.schema import (
     ATTEMPT_PROJECTION,
     ENDPOINT_PROJECTION,
@@ -1438,6 +1445,89 @@ class TaskStore:
             logger.info("Pruned %d task_resource_history rows (log downsampling)", total_deleted)
         return evicted_terminal + total_deleted
 
+    def _batch_prune_profiles(
+        self,
+        sql: str,
+        params: tuple[object, ...],
+        *,
+        stopped: Callable[[], bool],
+        pause_between_s: float,
+    ) -> int:
+        """Repeatedly delete one batch per transaction, sleeping between commits.
+
+        Each iteration commits its batch before sleeping so the writer lock
+        is released and other RPCs can interleave with pruning.
+        """
+        total = 0
+        while not stopped():
+            with self._db.transaction() as cur:
+                batch = cur.execute(sql, params).rowcount
+            if batch == 0:
+                break
+            total += batch
+            time.sleep(pause_between_s)
+        return total
+
+    def prune_stale_profiles(
+        self,
+        *,
+        cutoff_ms: int,
+        stopped: Callable[[], bool],
+        pause_between_s: float,
+    ) -> int:
+        """Delete ``task_profiles`` rows older than ``cutoff_ms`` in 1000-row batches."""
+        return self._batch_prune_profiles(
+            "DELETE FROM profiles.task_profiles WHERE rowid IN "
+            "(SELECT rowid FROM profiles.task_profiles WHERE captured_at_ms < ? LIMIT 1000)",
+            (cutoff_ms,),
+            stopped=stopped,
+            pause_between_s=pause_between_s,
+        )
+
+    def prune_orphan_profiles(
+        self,
+        *,
+        stopped: Callable[[], bool],
+        pause_between_s: float,
+    ) -> int:
+        """Delete ``task_profiles`` rows whose task has been pruned."""
+        return self._batch_prune_profiles(
+            "DELETE FROM profiles.task_profiles WHERE rowid IN "
+            "(SELECT p.rowid FROM profiles.task_profiles p"
+            " LEFT JOIN tasks t ON p.task_id = t.task_id"
+            " WHERE t.task_id IS NULL LIMIT 1000)",
+            (),
+            stopped=stopped,
+            pause_between_s=pause_between_s,
+        )
+
+    def set_state_for_test(
+        self,
+        cur: TransactionCursor,
+        task_id: JobName,
+        state: int,
+        *,
+        error: str | None = None,
+        exit_code: int | None = None,
+    ) -> None:
+        """Test helper: overwrite ``state`` / ``error`` / ``exit_code`` directly.
+
+        For non-active target states, also clears ``current_worker_id`` /
+        ``current_worker_address`` so the row is consistent with production
+        terminal-transition writes.
+        """
+        if state in ACTIVE_TASK_STATES:
+            cur.execute(
+                "UPDATE tasks SET state = ?, error = ?, exit_code = ? WHERE task_id = ?",
+                (state, error, exit_code, task_id.to_wire()),
+            )
+            return
+        cur.execute(
+            "UPDATE tasks SET state = ?, error = ?, exit_code = ?, "
+            "current_worker_id = NULL, current_worker_address = NULL WHERE task_id = ?",
+            (state, error, exit_code, task_id.to_wire()),
+        )
+
 
 class TaskAttemptStore:
     """Task attempts."""
@@ -1654,6 +1744,41 @@ class WorkerStore:
 
     def mark_unhealthy(self, cur: TransactionCursor, worker_id: WorkerId) -> None:
         cur.execute("UPDATE workers SET healthy = 0 WHERE worker_id = ?", (str(worker_id),))
+
+    def record_task_assignment(
+        self,
+        cur: TransactionCursor,
+        worker_id: WorkerId,
+        task_id: JobName,
+        now_ms: int,
+    ) -> None:
+        """Append a row to ``worker_task_history`` at task-assign time."""
+        cur.execute(
+            "INSERT INTO worker_task_history(worker_id, task_id, assigned_at_ms) VALUES (?, ?, ?)",
+            (str(worker_id), task_id.to_wire(), now_ms),
+        )
+
+    def find_prunable(self, tx: Tx, before_ms: int) -> WorkerId | None:
+        """Return one inactive-or-unhealthy worker whose heartbeat predates ``before_ms``."""
+        row = tx.fetchone(
+            "SELECT worker_id FROM workers " "WHERE (active = 0 OR healthy = 0) AND last_heartbeat_ms < ? LIMIT 1",
+            (before_ms,),
+        )
+        return WorkerId(str(row["worker_id"])) if row is not None else None
+
+    def set_health_for_test(self, cur: TransactionCursor, worker_id: WorkerId, healthy: bool) -> None:
+        """Test helper: overwrite ``healthy`` and reset/raise ``consecutive_failures``."""
+        cur.execute(
+            "UPDATE workers SET healthy = ?, consecutive_failures = ? WHERE worker_id = ?",
+            (1 if healthy else 0, 0 if healthy else 1, str(worker_id)),
+        )
+
+    def set_consecutive_failures_for_test(self, cur: TransactionCursor, worker_id: WorkerId, count: int) -> None:
+        """Test helper: overwrite ``consecutive_failures`` directly."""
+        cur.execute(
+            "UPDATE workers SET consecutive_failures = ? WHERE worker_id = ?",
+            (count, str(worker_id)),
+        )
 
     def apply_snapshots(
         self,

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -1078,9 +1078,10 @@ class ControllerTransitions:
     ) -> TxResult:
         """Register a new worker or refresh an existing one. Caller owns the transaction.
 
-        Returns the attribute dict that the caller should pass to
-        ``store.workers.update_attr_cache(worker_id, attrs)`` AFTER commit
-        so the in-memory scheduling cache stays in sync.
+        The in-memory worker-attribute scheduling cache and the
+        ``worker_registered`` audit line are scheduled as post-commit
+        hooks on ``cur``; they fire only if the caller's transaction
+        commits.
         """
         attrs: list[WorkerAttributeParams] = []
         for key, proto in metadata.attributes.items():

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -28,12 +28,14 @@ from iris.cluster.controller.db import (
     ACTIVE_TASK_STATES,
     EXECUTING_TASK_STATES,
     FAILURE_TASK_STATES,
+    NON_TERMINAL_TASK_STATES,
     ControllerDB,
     TransactionCursor,
     task_row_can_be_scheduled,
     task_row_is_finished,
 )
 from iris.cluster.controller.stores import (
+    ActiveTaskRow,
     ControllerStore,
     EndpointStore,
     JobConfigInsertParams,
@@ -42,6 +44,7 @@ from iris.cluster.controller.stores import (
     JobStore,
     TaskAttemptStore,
     TaskAttemptUpdateParams,
+    TaskScope,
     TaskStateUpdateParams,
     TaskInsertParams,
     TaskStore,
@@ -412,39 +415,32 @@ def _terminate_task(
 
 
 def _kill_non_terminal_tasks(
-    cur: Any,
+    cur: TransactionCursor,
     attempts: TaskAttemptStore,
     tasks: TaskStore,
     workers: WorkerStore,
     registry,
-    job_id_wire: str,
+    job_id: JobName,
     reason: str,
     now_ms: int,
 ) -> tuple[set[JobName], dict[JobName, WorkerId]]:
     """Kill all non-terminal tasks for a single job, decommit resources, and delete endpoints."""
-    terminal_states = tuple(sorted(TERMINAL_TASK_STATES))
-    placeholders = ",".join("?" * len(terminal_states))
-    rows = cur.execute(
-        "SELECT t.task_id, t.current_attempt_id, t.current_worker_id, "
-        "jc.res_cpu_millicores, jc.res_memory_bytes, jc.res_disk_bytes, jc.res_device_json, "
-        "j.is_reservation_holder "
-        "FROM tasks t "
-        "JOIN jobs j ON j.job_id = t.job_id "
-        f"{JOB_CONFIG_JOIN} "
-        f"WHERE t.job_id = ? AND t.state NOT IN ({placeholders})",
-        (job_id_wire, *terminal_states),
-    ).fetchall()
+    rows = tasks.list_active(
+        cur,
+        TaskScope(job_id=job_id),
+        states=NON_TERMINAL_TASK_STATES,
+    )
     tasks_to_kill: set[JobName] = set()
     task_kill_workers: dict[JobName, WorkerId] = {}
     for row in rows:
-        task_id = str(row["task_id"])
-        worker_id = row["current_worker_id"]
-        task_name = JobName.from_wire(task_id)
-        is_reservation_holder = bool(int(row["is_reservation_holder"]))
+        task_name = row.task_id
+        task_id = task_name.to_wire()
+        worker_id = row.current_worker_id
+        is_reservation_holder = row.is_reservation_holder
         decommit_worker: str | None = None
         decommit_resources = None
         if worker_id is not None:
-            task_kill_workers[task_name] = WorkerId(str(worker_id))
+            task_kill_workers[task_name] = worker_id
             # Reservation holders never commit resources on assignment,
             # so they must not decommit on termination —
             # otherwise we subtract chips that were never added, which floors
@@ -452,12 +448,7 @@ def _kill_non_terminal_tasks(
             # the scheduler double-book the worker.
             if not is_reservation_holder:
                 decommit_worker = str(worker_id)
-                decommit_resources = resource_spec_from_scalars(
-                    int(row["res_cpu_millicores"]),
-                    int(row["res_memory_bytes"]),
-                    int(row["res_disk_bytes"]),
-                    row["res_device_json"],
-                )
+                decommit_resources = row.resources
         _terminate_task(
             cur,
             attempts,
@@ -465,7 +456,7 @@ def _kill_non_terminal_tasks(
             workers,
             registry,
             task_id,
-            int(row["current_attempt_id"]),
+            row.current_attempt_id,
             job_pb2.TASK_STATE_KILLED,
             reason,
             now_ms,
@@ -506,7 +497,7 @@ def _cascade_children(
             store.tasks,
             store.workers,
             store.endpoints,
-            child_job_id.to_wire(),
+            child_job_id,
             reason,
             now_ms,
         )
@@ -530,7 +521,7 @@ def _cascade_terminal_job(
         store.tasks,
         store.workers,
         store.endpoints,
-        job_id.to_wire(),
+        job_id,
         reason,
         now_ms,
     )
@@ -540,54 +531,31 @@ def _cascade_terminal_job(
     return tasks_to_kill, task_kill_workers
 
 
-@dataclass(frozen=True, slots=True)
-class _CoscheduledSibling:
-    task_id: str  # wire format
-    attempt_id: int
-    max_retries_preemption: int
-    worker_id: str | None
-
-
 def _find_coscheduled_siblings(
-    cur: Any,
+    tx: "TransactionCursor",
+    tasks: TaskStore,
     job_id: JobName,
     exclude_task_id: JobName,
     has_coscheduling: bool,
-) -> list[_CoscheduledSibling]:
+) -> list[ActiveTaskRow]:
     """Find active siblings in a coscheduled job (read-only)."""
     if not has_coscheduling:
         return []
-    rows = cur.execute(
-        "SELECT t.task_id, t.current_attempt_id, t.max_retries_preemption, "
-        "t.current_worker_id AS worker_id "
-        "FROM tasks t "
-        "WHERE t.job_id = ? AND t.task_id != ? AND t.state IN (?, ?, ?)",
-        (
-            job_id.to_wire(),
-            exclude_task_id.to_wire(),
-            job_pb2.TASK_STATE_ASSIGNED,
-            job_pb2.TASK_STATE_BUILDING,
-            job_pb2.TASK_STATE_RUNNING,
-        ),
-    ).fetchall()
-    return [
-        _CoscheduledSibling(
-            task_id=str(r["task_id"]),
-            attempt_id=int(r["current_attempt_id"]),
-            max_retries_preemption=int(r["max_retries_preemption"]),
-            worker_id=str(r["worker_id"]) if r["worker_id"] is not None else None,
-        )
-        for r in rows
-    ]
+    return tasks.list_active(
+        tx,
+        TaskScope(job_id=job_id),
+        states=ACTIVE_TASK_STATES,
+        exclude_task_id=exclude_task_id,
+    )
 
 
 def _terminate_coscheduled_siblings(
-    cur: Any,
+    cur: TransactionCursor,
     attempts: TaskAttemptStore,
     tasks: TaskStore,
     workers: WorkerStore,
     registry,
-    siblings: Iterable[_CoscheduledSibling],
+    siblings: Iterable[ActiveTaskRow],
     failed_task_id: JobName,
     resources: "job_pb2.ResourceSpecProto",
     now_ms: int,
@@ -602,24 +570,25 @@ def _terminate_coscheduled_siblings(
     error = f"Coscheduled sibling {failed_task_id.to_wire()} failed"
 
     for sib in siblings:
+        worker_id_str = str(sib.current_worker_id) if sib.current_worker_id is not None else None
         _terminate_task(
             cur,
             attempts,
             tasks,
             workers,
             registry,
-            sib.task_id,
-            sib.attempt_id,
+            sib.task_id.to_wire(),
+            sib.current_attempt_id,
             job_pb2.TASK_STATE_WORKER_FAILED,
             error,
             now_ms,
-            worker_id=sib.worker_id,
-            resources=resources if sib.worker_id is not None else None,
+            worker_id=worker_id_str,
+            resources=resources if sib.current_worker_id is not None else None,
             preemption_count=sib.max_retries_preemption + 1,
         )
-        if sib.worker_id is not None:
-            task_kill_workers[JobName.from_wire(sib.task_id)] = WorkerId(sib.worker_id)
-        tasks_to_kill.add(JobName.from_wire(sib.task_id))
+        if sib.current_worker_id is not None:
+            task_kill_workers[sib.task_id] = sib.current_worker_id
+        tasks_to_kill.add(sib.task_id)
 
     return tasks_to_kill, task_kill_workers
 
@@ -671,7 +640,7 @@ def _finalize_terminal_job(
         store.tasks,
         store.workers,
         store.endpoints,
-        job_id.to_wire(),
+        job_id,
         reason,
         now_ms,
     )
@@ -1196,29 +1165,14 @@ class ControllerTransitions:
             subtree = self._store.jobs.list_subtree(cur, job_id)
             if not subtree:
                 return TxResult()
-            subtree_ids = [jid.to_wire() for jid in subtree]
-            placeholders = ",".join("?" for _ in subtree_ids)
-            running_rows = cur.execute(
-                f"SELECT t.task_id, t.current_worker_id AS worker_id, "
-                f"j.is_reservation_holder, "
-                f"jc.res_cpu_millicores, jc.res_memory_bytes, jc.res_disk_bytes, jc.res_device_json "
-                f"FROM tasks t "
-                f"JOIN jobs j ON j.job_id = t.job_id "
-                f"{JOB_CONFIG_JOIN} "
-                f"WHERE t.job_id IN ({placeholders}) "
-                "AND t.state IN (?, ?, ?)",
-                (
-                    *subtree_ids,
-                    job_pb2.TASK_STATE_ASSIGNED,
-                    job_pb2.TASK_STATE_BUILDING,
-                    job_pb2.TASK_STATE_RUNNING,
-                ),
-            ).fetchall()
-            tasks_to_kill = {JobName.from_wire(str(row["task_id"])) for row in running_rows}
+            running_rows = self._store.tasks.list_active(
+                cur,
+                TaskScope(job_subtree=subtree),
+                states=ACTIVE_TASK_STATES,
+            )
+            tasks_to_kill = {row.task_id for row in running_rows}
             task_kill_workers = {
-                JobName.from_wire(str(row["task_id"])): WorkerId(str(row["worker_id"]))
-                for row in running_rows
-                if row["worker_id"] is not None
+                row.task_id: row.current_worker_id for row in running_rows if row.current_worker_id is not None
             }
             # Decommit resources for each active task on its assigned worker.
             # cancel_job marks tasks as KILLED, but apply_heartbeat skips
@@ -1226,14 +1180,8 @@ class ControllerTransitions:
             # heartbeat decommit path never fires for cancelled tasks.
             # Direct-provider tasks have NULL worker_id — skip decommit for them.
             for row in running_rows:
-                if row["worker_id"] is not None and not int(row["is_reservation_holder"]):
-                    resources = resource_spec_from_scalars(
-                        int(row["res_cpu_millicores"]),
-                        int(row["res_memory_bytes"]),
-                        int(row["res_disk_bytes"]),
-                        row["res_device_json"],
-                    )
-                    self._store.workers.decommit_resources(cur, WorkerId(str(row["worker_id"])), resources)
+                if row.current_worker_id is not None and not row.is_reservation_holder:
+                    self._store.workers.decommit_resources(cur, row.current_worker_id, row.resources)
             now_ms = Timestamp.now().epoch_ms()
             self._store.tasks.bulk_kill_non_terminal(cur, subtree, reason, now_ms, TERMINAL_TASK_STATES)
             # Deliberately excludes JOB_STATE_WORKER_FAILED from the guard set:
@@ -1675,7 +1623,7 @@ class ControllerTransitions:
             # Coscheduled jobs: a terminal host failure should cascade to siblings.
             if jc is not None and task_state in FAILURE_TASK_STATES:
                 has_cosched = bool(int(jc["has_coscheduling"]))
-                siblings = _find_coscheduled_siblings(cur, task.job_id, update.task_id, has_cosched)
+                siblings = _find_coscheduled_siblings(cur, self._store.tasks, task.job_id, update.task_id, has_cosched)
                 resources = resource_spec_from_scalars(
                     int(jc["res_cpu_millicores"]),
                     int(jc["res_memory_bytes"]),
@@ -1844,46 +1792,42 @@ class ControllerTransitions:
         """Remove a definitively failed worker and cascade its task state."""
         tasks_to_kill: set[JobName] = set()
         task_kill_workers: dict[JobName, WorkerId] = {}
-        task_rows = cur.execute(
-            "SELECT t.task_id, t.current_attempt_id, t.state, t.preemption_count, t.max_retries_preemption, "
-            "j.is_reservation_holder "
-            "FROM tasks t "
-            "JOIN jobs j ON j.job_id = t.job_id "
-            "WHERE t.current_worker_id = ? AND t.state IN (?, ?, ?)",
-            (str(worker_id), *ACTIVE_TASK_STATES),
-        ).fetchall()
+        task_rows = self._store.tasks.list_active(
+            cur,
+            TaskScope(worker_id=worker_id),
+            states=ACTIVE_TASK_STATES,
+        )
         for task_row in task_rows:
-            tid = str(task_row["task_id"])
-            prior_state = int(task_row["state"])
-            is_reservation_holder = bool(int(task_row["is_reservation_holder"]))
+            prior_state = task_row.state
+            is_reservation_holder = task_row.is_reservation_holder
             if is_reservation_holder:
                 new_task_state = job_pb2.TASK_STATE_PENDING
-                preemption_count = int(task_row["preemption_count"])
+                preemption_count = task_row.preemption_count
             else:
                 new_task_state, preemption_count = _resolve_task_failure_state(
                     prior_state,
-                    int(task_row["preemption_count"]),
-                    int(task_row["max_retries_preemption"]),
+                    task_row.preemption_count,
+                    task_row.max_retries_preemption,
                     job_pb2.TASK_STATE_WORKER_FAILED,
                 )
             # Reservation holders retry to PENDING with preemption_count reset so the
             # reservation can re-acquire a worker without counting the failure as a preemption.
             holder_preemption_count = 0 if is_reservation_holder else preemption_count
+            task_id = task_row.task_id
             _terminate_task(
                 cur,
                 self._store.attempts,
                 self._store.tasks,
                 self._store.workers,
                 self._store.endpoints,
-                tid,
-                int(task_row["current_attempt_id"]),
+                task_id.to_wire(),
+                task_row.current_attempt_id,
                 new_task_state,
                 f"Worker {worker_id} failed: {error}",
                 now_ms,
                 attempt_state=job_pb2.TASK_STATE_WORKER_FAILED,
                 preemption_count=holder_preemption_count,
             )
-            task_id = JobName.from_wire(tid)
             parent_job_id, _ = task_id.require_task()
             new_job_state = self._recompute_job_state(cur, parent_job_id)
             if new_job_state is not None and new_job_state in TERMINAL_JOB_STATES:
@@ -2027,39 +1971,25 @@ class ControllerTransitions:
         tasks_to_kill: set[JobName] = set()
         task_kill_workers: dict[JobName, WorkerId] = {}
         with self._db.transaction() as cur:
-            row = cur.execute(
-                "SELECT t.task_id, t.job_id, t.state, t.current_attempt_id, "
-                "t.preemption_count, t.max_retries_preemption, "
-                "jc.res_cpu_millicores, jc.res_memory_bytes, jc.res_disk_bytes, jc.res_device_json "
-                f"FROM tasks t JOIN jobs j ON j.job_id = t.job_id {JOB_CONFIG_JOIN} "
-                "WHERE t.task_id = ?",
-                (task_id.to_wire(),),
-            ).fetchone()
+            row = self._store.tasks.get_with_resources(cur, task_id)
             if row is None:
                 return TxResult()
 
-            prior_state = int(row["state"])
+            prior_state = row.state
             if prior_state not in ACTIVE_TASK_STATES:
                 return TxResult()
 
             now_ms = Timestamp.now().epoch_ms()
             new_state, preemption_count = _resolve_task_failure_state(
                 prior_state,
-                int(row["preemption_count"]),
-                int(row["max_retries_preemption"]),
+                row.preemption_count,
+                row.max_retries_preemption,
                 job_pb2.TASK_STATE_PREEMPTED,
             )
             # Fetch worker_id from the attempt for resource decommit.
-            attempt_worker = self._store.attempts.get_worker_id(cur, task_id, int(row["current_attempt_id"]))
+            attempt_worker = self._store.attempts.get_worker_id(cur, task_id, row.current_attempt_id)
             attempt_worker_id = str(attempt_worker) if attempt_worker is not None else None
-            attempt_resources = None
-            if attempt_worker_id is not None:
-                attempt_resources = resource_spec_from_scalars(
-                    int(row["res_cpu_millicores"]),
-                    int(row["res_memory_bytes"]),
-                    int(row["res_disk_bytes"]),
-                    row["res_device_json"],
-                )
+            attempt_resources = row.resources if attempt_worker_id is not None else None
 
             _terminate_task(
                 cur,
@@ -2068,7 +1998,7 @@ class ControllerTransitions:
                 self._store.workers,
                 self._store.endpoints,
                 task_id.to_wire(),
-                int(row["current_attempt_id"]),
+                row.current_attempt_id,
                 new_state,
                 reason,
                 now_ms,
@@ -2079,7 +2009,7 @@ class ControllerTransitions:
             )
 
             # Recompute job state and cascade if terminal
-            job_id = JobName.from_wire(str(row["job_id"]))
+            job_id = row.job_id
             new_job_state = self._recompute_job_state(cur, job_id)
             if new_job_state is not None and new_job_state in TERMINAL_JOB_STATES:
                 cascade_kills, cascade_workers = _finalize_terminal_job(cur, self._store, job_id, new_job_state, now_ms)
@@ -2119,35 +2049,30 @@ class ControllerTransitions:
         if not task_ids:
             return TxResult()
         with self._db.transaction() as cur:
-            wires = [tid.to_wire() for tid in task_ids]
-            placeholders = ",".join("?" for _ in wires)
-            rows = cur.execute(
-                f"SELECT t.task_id, t.job_id, t.current_worker_id AS worker_id, t.current_attempt_id, "
-                f"t.failure_count, j.is_reservation_holder, "
-                f"jc.res_cpu_millicores, jc.res_memory_bytes, jc.res_disk_bytes, jc.res_device_json, "
-                f"jc.has_coscheduling "
-                f"FROM tasks t JOIN jobs j ON j.job_id = t.job_id {JOB_CONFIG_JOIN} "
-                f"WHERE t.task_id IN ({placeholders}) AND t.state IN (?, ?)",
-                (*wires, *EXECUTING_TASK_STATES),
-            ).fetchall()
+            rows = self._store.tasks.list_active(
+                cur,
+                TaskScope(task_ids=sorted(task_ids, key=lambda tid: tid.to_wire())),
+                states=EXECUTING_TASK_STATES,
+            )
 
             # -- Phase 1: read all state before any mutations. --
             now_ms = Timestamp.now().epoch_ms()
-            job_row_cache: dict[str, dict] = {}
+            # Resources per job (all direct-timeout tasks in a job share job_config).
+            job_resources_cache: dict[str, job_pb2.ResourceSpecProto] = {}
             # Collect directly-timed-out task wires for dedup against siblings.
             direct_task_wires: set[str] = set()
             # Per-job list of siblings to cascade (collected across all timed-out tasks).
-            siblings_by_job: dict[str, list[_CoscheduledSibling]] = {}
+            siblings_by_job: dict[str, list[ActiveTaskRow]] = {}
 
             for row in rows:
-                task_id_wire = str(row["task_id"])
+                task_id_wire = row.task_id.to_wire()
                 direct_task_wires.add(task_id_wire)
-                job_id_wire = str(row["job_id"])
-                if job_id_wire not in job_row_cache:
-                    job_row_cache[job_id_wire] = dict(row)
-                has_cosched = bool(int(row["has_coscheduling"]))
-                tid = JobName.from_wire(task_id_wire)
-                siblings = _find_coscheduled_siblings(cur, JobName.from_wire(job_id_wire), tid, has_cosched)
+                job_id_wire = row.job_id.to_wire()
+                if job_id_wire not in job_resources_cache:
+                    job_resources_cache[job_id_wire] = row.resources
+                siblings = _find_coscheduled_siblings(
+                    cur, self._store.tasks, row.job_id, row.task_id, row.has_coscheduling
+                )
                 if siblings:
                     existing = siblings_by_job.get(job_id_wire, [])
                     existing.extend(siblings)
@@ -2158,10 +2083,11 @@ class ControllerTransitions:
             # trigger tasks within the same job.
             for job_id_wire, siblings in siblings_by_job.items():
                 seen: set[str] = set()
-                deduped: list[_CoscheduledSibling] = []
+                deduped: list[ActiveTaskRow] = []
                 for sib in siblings:
-                    if sib.task_id not in direct_task_wires and sib.task_id not in seen:
-                        seen.add(sib.task_id)
+                    sib_wire = sib.task_id.to_wire()
+                    if sib_wire not in direct_task_wires and sib_wire not in seen:
+                        seen.add(sib_wire)
                         deduped.append(sib)
                 siblings_by_job[job_id_wire] = deduped
 
@@ -2171,54 +2097,39 @@ class ControllerTransitions:
             jobs_to_update: set[str] = set()
 
             for row in rows:
-                task_id_wire = str(row["task_id"])
-                tid = JobName.from_wire(task_id_wire)
-                job_id_wire = str(row["job_id"])
-                worker_id_str = row["worker_id"]
+                tid = row.task_id
                 tasks_to_kill.add(tid)
                 decommit_worker = None
                 decommit_resources = None
-                if worker_id_str is not None:
-                    task_kill_workers[tid] = WorkerId(str(worker_id_str))
-                    if not int(row["is_reservation_holder"]):
-                        decommit_worker = str(worker_id_str)
-                        decommit_resources = resource_spec_from_scalars(
-                            int(row["res_cpu_millicores"]),
-                            int(row["res_memory_bytes"]),
-                            int(row["res_disk_bytes"]),
-                            row["res_device_json"],
-                        )
-                attempt_id = row["current_attempt_id"]
+                if row.current_worker_id is not None:
+                    task_kill_workers[tid] = row.current_worker_id
+                    if not row.is_reservation_holder:
+                        decommit_worker = str(row.current_worker_id)
+                        decommit_resources = row.resources
                 _terminate_task(
                     cur,
                     self._store.attempts,
                     self._store.tasks,
                     self._store.workers,
                     self._store.endpoints,
-                    task_id_wire,
-                    int(attempt_id) if attempt_id is not None else None,
+                    tid.to_wire(),
+                    row.current_attempt_id,
                     job_pb2.TASK_STATE_FAILED,
                     reason,
                     now_ms,
                     worker_id=decommit_worker,
                     resources=decommit_resources,
-                    failure_count=int(row["failure_count"]) + 1,
+                    failure_count=row.failure_count + 1,
                 )
-                jobs_to_update.add(job_id_wire)
+                jobs_to_update.add(row.job_id.to_wire())
 
             # Terminate coscheduled siblings (deduplicated, all reads already done).
             for job_id_wire, siblings in siblings_by_job.items():
                 if not siblings:
                     continue
-                jc_row = job_row_cache[job_id_wire]
-                job_resources = resource_spec_from_scalars(
-                    int(jc_row["res_cpu_millicores"]),
-                    int(jc_row["res_memory_bytes"]),
-                    int(jc_row["res_disk_bytes"]),
-                    jc_row["res_device_json"],
-                )
+                job_resources = job_resources_cache[job_id_wire]
                 # Pick the first direct-timeout task in this job as the "cause" for the error message.
-                cause_tid = next(JobName.from_wire(str(r["task_id"])) for r in rows if str(r["job_id"]) == job_id_wire)
+                cause_tid = next(r.task_id for r in rows if r.job_id.to_wire() == job_id_wire)
                 cascade_kill, cascade_workers = _terminate_coscheduled_siblings(
                     cur,
                     self._store.attempts,
@@ -2440,39 +2351,39 @@ class ControllerTransitions:
         with self._db.read_snapshot() as snap:
             worker_rows = snap.fetchall("SELECT worker_id, address FROM workers WHERE active = 1 AND healthy = 1")
             worker_addresses: dict[WorkerId, str] = {}
-            worker_ids: list[str] = []
+            worker_ids: list[WorkerId] = []
             for row in worker_rows:
                 wid = WorkerId(str(row["worker_id"]))
                 worker_addresses[wid] = str(row["address"])
-                worker_ids.append(str(row["worker_id"]))
+                worker_ids.append(wid)
 
             if not worker_ids:
                 return {}, {}
 
-            placeholders = ",".join("?" for _ in worker_ids)
             # Reservation holders are virtual — they live on ``current_worker_id``
             # only as a scheduling anchor and never get a RunTaskRequest. Sending
             # them in PollTasksRequest.expected_tasks makes the worker reconcile
             # against its _tasks dict, miss, and return WORKER_FAILED every cycle,
             # which drains the holder's preemption budget and (post the build-
             # failure health hook) reaps the claimed worker for a harmless miss.
-            task_rows = snap.fetchall(
-                f"SELECT t.task_id, t.current_attempt_id, t.current_worker_id "
-                f"FROM tasks t JOIN jobs j ON j.job_id = t.job_id "
-                f"WHERE t.current_worker_id IN ({placeholders}) AND t.state IN (?, ?, ?) "
-                f"AND j.is_reservation_holder = 0 "
-                f"ORDER BY t.task_id ASC",
-                (*worker_ids, *ACTIVE_TASK_STATES),
+            task_rows = self._store.tasks.list_active(
+                snap,
+                TaskScope(worker_ids=worker_ids),
+                states=ACTIVE_TASK_STATES,
+                exclude_reservation_holders=True,
+                order_by_task_id=True,
             )
 
         running: dict[WorkerId, list[RunningTaskEntry]] = {}
         for row in task_rows:
-            wid = WorkerId(str(row["current_worker_id"]))
+            # list_active only returns rows where current_worker_id matched the IN filter,
+            # so current_worker_id cannot be None here.
+            assert row.current_worker_id is not None
             entry = RunningTaskEntry(
-                task_id=JobName.from_wire(str(row["task_id"])),
-                attempt_id=int(row["current_attempt_id"]),
+                task_id=row.task_id,
+                attempt_id=row.current_attempt_id,
             )
-            running.setdefault(wid, []).append(entry)
+            running.setdefault(row.current_worker_id, []).append(entry)
         return running, worker_addresses
 
     def fail_workers_batch(
@@ -2651,22 +2562,19 @@ class ControllerTransitions:
                 newly_promoted.add(task_id)
 
             # Snapshot already-running tasks with NULL worker_id (excluding newly promoted).
-            active_states = tuple(sorted(ACTIVE_TASK_STATES))
-            placeholders = ",".join("?" * len(active_states))
-            running_rows = cur.execute(
-                "SELECT t.task_id, t.current_attempt_id "
-                "FROM tasks t "
-                f"WHERE t.current_worker_id IS NULL AND t.state IN ({placeholders}) "
-                "ORDER BY t.task_id ASC",
-                active_states,
-            ).fetchall()
+            running_rows = self._store.tasks.list_active(
+                cur,
+                TaskScope(null_worker=True),
+                states=ACTIVE_TASK_STATES,
+                order_by_task_id=True,
+            )
             running_tasks = [
                 RunningTaskEntry(
-                    task_id=JobName.from_wire(str(row["task_id"])),
-                    attempt_id=int(row["current_attempt_id"]),
+                    task_id=row.task_id,
+                    attempt_id=row.current_attempt_id,
                 )
                 for row in running_rows
-                if str(row["task_id"]) not in newly_promoted
+                if row.task_id.to_wire() not in newly_promoted
             ]
 
             tasks_to_kill = self._store.dispatch.drain_direct_kills(cur)
@@ -2835,7 +2743,9 @@ class ControllerTransitions:
                 # Coscheduled sibling cascade.
                 if jc_row is not None and task_state in FAILURE_TASK_STATES:
                     has_cosched = bool(int(jc_row["has_coscheduling"]))
-                    siblings = _find_coscheduled_siblings(cur, task.job_id, update.task_id, has_cosched)
+                    siblings = _find_coscheduled_siblings(
+                        cur, self._store.tasks, task.job_id, update.task_id, has_cosched
+                    )
                     job_resources = resource_spec_from_scalars(
                         int(jc_row["res_cpu_millicores"]),
                         int(jc_row["res_memory_bytes"]),

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -921,15 +921,10 @@ class ControllerTransitions:
             )
 
             # Store workdir files in separate table.
-            if request.entrypoint.workdir_files:
-                for filename, data in request.entrypoint.workdir_files.items():
-                    cur.execute(
-                        "INSERT INTO job_workdir_files(job_id, filename, data) VALUES (?, ?, ?)",
-                        (job_id.to_wire(), filename, data),
-                    )
+            self._store.jobs.insert_workdir_files(cur, job_id, dict(request.entrypoint.workdir_files))
 
             if validation_error is None:
-                insertion_base = self._db.next_sequence("task_priority_insertion", cur=cur)
+                insertion_base = self._store.jobs.reserve_priority_insertion_base(cur)
                 for idx in range(replicas):
                     task_id = job_id.task(idx).to_wire()
                     created_task_ids.append(JobName.from_wire(task_id))
@@ -1025,7 +1020,7 @@ class ControllerTransitions:
                             task_image="",
                         ),
                     )
-                    holder_base = self._db.next_sequence("task_priority_insertion", cur=cur)
+                    holder_base = self._store.jobs.reserve_priority_insertion_base(cur)
                     for idx in range(len(request.reservation.entries)):
                         created_task_ids.append(holder_id.task(idx))
                         self._store.tasks.insert(
@@ -1237,12 +1232,8 @@ class ControllerTransitions:
                     self._store.workers.add_committed_resources(cur, assignment.worker_id, resources)
                     entrypoint = proto_from_json(job.entrypoint_json, job_pb2.RuntimeEntrypoint)
                     # Load inline workdir files from the job_workdir_files table.
-                    wf_rows = cur.execute(
-                        "SELECT filename, data FROM job_workdir_files WHERE job_id = ?",
-                        (job_id_wire,),
-                    ).fetchall()
-                    for wf_row in wf_rows:
-                        entrypoint.workdir_files[wf_row["filename"]] = bytes(wf_row["data"])
+                    for filename, data in self._store.jobs.get_workdir_files(cur, task.job_id).items():
+                        entrypoint.workdir_files[filename] = data
                     run_request = job_pb2.RunTaskRequest(
                         task_id=assignment.task_id.to_wire(),
                         num_tasks=job.num_tasks,
@@ -2393,13 +2384,9 @@ class ControllerTransitions:
 
                 entrypoint = proto_from_json(str(row["entrypoint_json"]), job_pb2.RuntimeEntrypoint)
                 # Load inline workdir files from the job_workdir_files table.
-                job_id_wire = str(row["job_id"])
-                wf_rows = cur.execute(
-                    "SELECT filename, data FROM job_workdir_files WHERE job_id = ?",
-                    (job_id_wire,),
-                ).fetchall()
-                for wf_row in wf_rows:
-                    entrypoint.workdir_files[wf_row["filename"]] = bytes(wf_row["data"])
+                job_id = JobName.from_wire(str(row["job_id"]))
+                for filename, data in self._store.jobs.get_workdir_files(cur, job_id).items():
+                    entrypoint.workdir_files[filename] = data
 
                 run_req = job_pb2.RunTaskRequest(
                     task_id=task_id,

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -11,7 +11,7 @@ import time
 import json
 import logging
 from dataclasses import dataclass, field
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Iterable, Mapping
 from typing import NamedTuple
 
 from iris.cluster.constraints import AttributeValue, Constraint, constraints_from_resources, merge_constraints
@@ -1231,10 +1231,7 @@ class ControllerTransitions:
                             cur, assignment.worker_id, run_request.SerializeToString(), now_ms
                         )
                     has_real_dispatch = True
-                cur.execute(
-                    "INSERT INTO worker_task_history(worker_id, task_id, assigned_at_ms) VALUES (?, ?, ?)",
-                    (str(assignment.worker_id), assignment.task_id.to_wire(), now_ms),
-                )
+                self._store.workers.record_task_assignment(cur, assignment.worker_id, assignment.task_id, now_ms)
                 jobs_to_update.add(job_id_wire)
                 accepted.append(assignment)
             for job_id_wire in jobs_to_update:
@@ -2030,27 +2027,6 @@ class ControllerTransitions:
         self._store.workers.remove_from_attr_cache(worker_id)
         return detail
 
-    def _batch_delete(
-        self,
-        sql: str,
-        params: tuple[object, ...],
-        stopped: Callable[[], bool],
-        pause_between_s: float,
-    ) -> int:
-        """Delete rows in batches, sleeping between transactions.
-
-        Returns the total number of rows deleted.
-        """
-        total = 0
-        while not stopped():
-            with self._db.transaction() as cur:
-                batch = cur.execute(sql, params).rowcount
-            if batch == 0:
-                break
-            total += batch
-            time.sleep(pause_between_s)
-        return total
-
     def prune_old_data(
         self,
         *,
@@ -2100,38 +2076,25 @@ class ControllerTransitions:
         workers_deleted = 0
         while not _stopped():
             with self._db.read_snapshot() as snap:
-                row = snap.fetchone(
-                    "SELECT worker_id FROM workers WHERE (active = 0 OR healthy = 0) AND last_heartbeat_ms < ? LIMIT 1",
-                    (worker_cutoff_ms,),
-                )
-            if row is None:
+                worker_id = self._store.workers.find_prunable(snap, worker_cutoff_ms)
+            if worker_id is None:
                 break
-            worker_id = row["worker_id"]
             with self._db.transaction() as cur:
-                _remove_worker(cur, self._store.workers, WorkerId(str(worker_id)))
+                _remove_worker(cur, self._store.workers, worker_id)
             log_event("worker_pruned", str(worker_id))
             workers_deleted += 1
             time.sleep(pause_between_s)
 
         # 3. Task profiles: batch of 1000 per transaction
         profile_cutoff_ms = now_ms - profile_retention.to_ms()
-        # 4a. Delete stale profiles by age.
-        profiles_deleted = self._batch_delete(
-            "DELETE FROM profiles.task_profiles WHERE rowid IN "
-            "(SELECT rowid FROM profiles.task_profiles WHERE captured_at_ms < ? LIMIT 1000)",
-            (profile_cutoff_ms,),
-            _stopped,
-            pause_between_s,
+        profiles_deleted = self._store.tasks.prune_stale_profiles(
+            cutoff_ms=profile_cutoff_ms,
+            stopped=_stopped,
+            pause_between_s=pause_between_s,
         )
-        # 4b. Delete orphan profiles whose task no longer exists.
-        profiles_deleted += self._batch_delete(
-            "DELETE FROM profiles.task_profiles WHERE rowid IN "
-            "(SELECT p.rowid FROM profiles.task_profiles p"
-            " LEFT JOIN tasks t ON p.task_id = t.task_id"
-            " WHERE t.task_id IS NULL LIMIT 1000)",
-            (),
-            _stopped,
-            pause_between_s,
+        profiles_deleted += self._store.tasks.prune_orphan_profiles(
+            stopped=_stopped,
+            pause_between_s=pause_between_s,
         )
 
         result = PruneResult(
@@ -2274,10 +2237,8 @@ class ControllerTransitions:
 
     def set_worker_health_for_test(self, worker_id: WorkerId, healthy: bool) -> None:
         """Test helper: set worker health in DB."""
-        self._db.execute(
-            "UPDATE workers SET healthy = ?, consecutive_failures = ? WHERE worker_id = ?",
-            (1 if healthy else 0, 0 if healthy else 1, str(worker_id)),
-        )
+        with self._store.transaction() as cur:
+            self._store.workers.set_health_for_test(cur, worker_id, healthy)
 
     def set_worker_attribute_for_test(self, worker_id: WorkerId, key: str, value: AttributeValue) -> None:
         """Test helper: upsert one worker attribute in DB."""
@@ -2590,10 +2551,8 @@ class ControllerTransitions:
 
     def set_worker_consecutive_failures_for_test(self, worker_id: WorkerId, consecutive_failures: int) -> None:
         """Test helper: set worker consecutive failure count in DB."""
-        self._db.execute(
-            "UPDATE workers SET consecutive_failures = ? WHERE worker_id = ?",
-            (consecutive_failures, str(worker_id)),
-        )
+        with self._store.transaction() as cur:
+            self._store.workers.set_consecutive_failures_for_test(cur, worker_id, consecutive_failures)
 
     def set_task_state_for_test(
         self,
@@ -2604,17 +2563,8 @@ class ControllerTransitions:
         exit_code: int | None = None,
     ) -> None:
         """Test helper: set task state directly in DB."""
-        if state in ACTIVE_TASK_STATES:
-            self._db.execute(
-                "UPDATE tasks SET state = ?, error = ?, exit_code = ? WHERE task_id = ?",
-                (state, error, exit_code, task_id.to_wire()),
-            )
-        else:
-            self._db.execute(
-                "UPDATE tasks SET state = ?, error = ?, exit_code = ?, "
-                "current_worker_id = NULL, current_worker_address = NULL WHERE task_id = ?",
-                (state, error, exit_code, task_id.to_wire()),
-            )
+        with self._store.transaction() as cur:
+            self._store.tasks.set_state_for_test(cur, task_id, state, error=error, exit_code=exit_code)
 
     def create_attempt_for_test(self, task_id: JobName, worker_id: WorkerId) -> int:
         """Test helper: append a new task_attempt without finalizing prior attempt."""

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -38,7 +38,15 @@ from iris.cluster.controller.stores import (
     EndpointStore,
     JobConfigInsertParams,
     JobInsertParams,
+    ResourceUsageInsertParams,
     JobStore,
+    TaskAttemptStore,
+    TaskAttemptUpdateParams,
+    TaskStateUpdateParams,
+    TaskInsertParams,
+    TaskStore,
+    WorkerAttributeParams,
+    WorkerStore,
 )
 from iris.cluster.controller.schema import (
     JOB_CONFIG_JOIN,
@@ -135,31 +143,6 @@ immediately. Catches workers restored from a checkpoint whose backing VMs
 no longer exist — without this, the controller would need 10 consecutive
 RPC failures (50s) per worker to notice, during which they appear healthy
 in the dashboard and block scheduling capacity."""
-
-WORKER_TASK_HISTORY_RETENTION = 500
-"""Maximum worker_task_history rows retained per worker."""
-
-WORKER_RESOURCE_HISTORY_RETENTION = 500
-"""Maximum worker_resource_history rows retained per worker."""
-
-TASK_RESOURCE_HISTORY_RETENTION = 50
-"""Maximum task_resource_history rows retained per (task_id, attempt_id).
-Logarithmic downsampling triggers at 2x this value."""
-
-TASK_RESOURCE_HISTORY_TERMINAL_TTL = Duration.from_hours(1)
-"""After a task reaches a terminal state, its resource history is fully
-evicted this long after the finish timestamp. Dashboards surface peak
-memory from tasks.peak_memory_mb once a task is done; retaining per-sample
-rows forever bloats the DB (~85% of task_resource_history on prod is for
-terminal tasks) and amplifies writer contention during heartbeat batches."""
-
-TASK_RESOURCE_HISTORY_DELETE_CHUNK = 1000
-"""Maximum task_ids per DELETE in prune_task_resource_history. Each chunk
-is its own write transaction so the writer lock releases between chunks.
-Sweep on a 1M-row prod checkpoint: chunk=1000 gives p95 ~400ms / max 1.3s
-writer hold; chunk=5000 gives p95 1.6s / max 1.7s. The background loop
-runs every 10 min so total wall-time is irrelevant — bounding worst-case
-writer hold is what matters for concurrent RPCs."""
 
 DIRECT_PROVIDER_PROMOTION_RATE = 128
 """Token bucket capacity for task promotion (pods per minute).
@@ -357,71 +340,7 @@ def delete_task_endpoints(cur: TransactionCursor, endpoints: EndpointStore, task
     endpoints.remove_by_task(cur, JobName.from_wire(task_id))
 
 
-def enqueue_run_dispatch(
-    cur: TransactionCursor,
-    worker_id: str,
-    payload_proto: bytes,
-    now_ms: int,
-) -> None:
-    """Queue a 'run' dispatch entry for delivery on the next heartbeat."""
-    cur.execute(
-        "INSERT INTO dispatch_queue(worker_id, kind, payload_proto, task_id, created_at_ms) "
-        "VALUES (?, 'run', ?, NULL, ?)",
-        (worker_id, payload_proto, now_ms),
-    )
-
-
-def enqueue_kill_dispatch(
-    cur: TransactionCursor,
-    worker_id: str | None,
-    task_id: str,
-    now_ms: int,
-) -> None:
-    """Queue a 'kill' dispatch entry for delivery on the next heartbeat."""
-    cur.execute(
-        "INSERT INTO dispatch_queue(worker_id, kind, payload_proto, task_id, created_at_ms) "
-        "VALUES (?, 'kill', NULL, ?, ?)",
-        (worker_id, task_id, now_ms),
-    )
-
-
-def insert_task_attempt(
-    cur: TransactionCursor,
-    task_id: str,
-    attempt_id: int,
-    worker_id: str | None,
-    state: int,
-    now_ms: int,
-) -> None:
-    """Record a new task attempt row."""
-    cur.execute(
-        "INSERT INTO task_attempts(task_id, attempt_id, worker_id, state, created_at_ms) " "VALUES (?, ?, ?, ?, ?)",
-        (task_id, attempt_id, worker_id, state, now_ms),
-    )
-
-
-def _decommit_worker_resources(
-    cur: TransactionCursor,
-    worker_id: str,
-    resources: "job_pb2.ResourceSpecProto",
-) -> None:
-    """Subtract a task's resource reservation from a worker, flooring at zero."""
-    cur.execute(
-        "UPDATE workers SET committed_cpu_millicores = MAX(0, committed_cpu_millicores - ?), "
-        "committed_mem_bytes = MAX(0, committed_mem_bytes - ?), "
-        "committed_gpu = MAX(0, committed_gpu - ?), committed_tpu = MAX(0, committed_tpu - ?) "
-        "WHERE worker_id = ?",
-        (
-            int(resources.cpu_millicores),
-            int(resources.memory_bytes),
-            int(get_gpu_count(resources.device)),
-            int(get_tpu_count(resources.device)),
-            worker_id,
-        ),
-    )
-
-
-def _remove_worker(cur: TransactionCursor, worker_id: str) -> None:
+def _remove_worker(cur: TransactionCursor, workers: WorkerStore, worker_id: WorkerId) -> None:
     """Remove a worker and sever all its foreign-key references.
 
     Must be called inside an existing transaction. The four statements
@@ -429,43 +348,14 @@ def _remove_worker(cur: TransactionCursor, worker_id: str) -> None:
     remain in task_attempts, tasks, or dispatch_queue after the worker
     row is deleted.
     """
-    cur.execute("UPDATE task_attempts SET worker_id = NULL WHERE worker_id = ?", (worker_id,))
-    cur.execute("UPDATE tasks SET current_worker_id = NULL WHERE current_worker_id = ?", (worker_id,))
-    cur.execute("DELETE FROM dispatch_queue WHERE worker_id = ?", (worker_id,))
-    cur.execute("DELETE FROM workers WHERE worker_id = ?", (worker_id,))
-
-
-def _assign_task(
-    cur: TransactionCursor,
-    task_id: str,
-    worker_id: str | None,
-    worker_address: str | None,
-    attempt_id: int,
-    now_ms: int,
-) -> None:
-    """Create an attempt and mark a task as ASSIGNED in one consistent step.
-
-    worker_id may be None for direct-provider tasks that have no backing
-    worker daemon.
-    """
-    insert_task_attempt(cur, task_id, attempt_id, worker_id, job_pb2.TASK_STATE_ASSIGNED, now_ms)
-    if worker_id is not None:
-        cur.execute(
-            "UPDATE tasks SET state = ?, current_attempt_id = ?, "
-            "current_worker_id = ?, current_worker_address = ?, "
-            "started_at_ms = COALESCE(started_at_ms, ?) WHERE task_id = ?",
-            (job_pb2.TASK_STATE_ASSIGNED, attempt_id, worker_id, worker_address, now_ms, task_id),
-        )
-    else:
-        cur.execute(
-            "UPDATE tasks SET state = ?, current_attempt_id = ?, "
-            "started_at_ms = COALESCE(started_at_ms, ?) WHERE task_id = ?",
-            (job_pb2.TASK_STATE_ASSIGNED, attempt_id, now_ms, task_id),
-        )
+    workers.remove(cur, worker_id)
 
 
 def _terminate_task(
     cur: TransactionCursor,
+    attempts: TaskAttemptStore,
+    tasks: TaskStore,
+    workers: WorkerStore,
     registry,
     task_id: str,
     attempt_id: int | None,
@@ -495,49 +385,37 @@ def _terminate_task(
     effective_attempt_state = attempt_state if attempt_state is not None else state
 
     if attempt_id is not None and attempt_id >= 0:
-        cur.execute(
-            "UPDATE task_attempts SET state = ?, "
-            "finished_at_ms = COALESCE(finished_at_ms, ?), error = ? "
-            "WHERE task_id = ? AND attempt_id = ?",
-            (effective_attempt_state, now_ms, error, task_id, attempt_id),
+        attempts.mark_finished(
+            cur,
+            JobName.from_wire(task_id),
+            attempt_id,
+            effective_attempt_state,
+            now_ms,
+            error,
         )
 
-    # Build the UPDATE tasks statement dynamically based on optional counters.
-    # Use COALESCE for finished_at_ms when non-NULL to preserve any existing
-    # timestamp (defensive against double-termination). When NULL (retrying to
-    # PENDING), assign directly so the column is cleared.
-    if finished_at_ms is not None:
-        set_clauses = ["state = ?", "error = ?", "finished_at_ms = COALESCE(finished_at_ms, ?)"]
-    else:
-        set_clauses = ["state = ?", "error = ?", "finished_at_ms = ?"]
-    params: list[object] = [state, error, finished_at_ms]
-
-    if failure_count is not None:
-        set_clauses.append("failure_count = ?")
-        params.append(failure_count)
-    if preemption_count is not None:
-        set_clauses.append("preemption_count = ?")
-        params.append(preemption_count)
-
-    # Always clear worker columns when leaving active state.
-    if state not in ACTIVE_TASK_STATES:
-        set_clauses.append("current_worker_id = NULL")
-        set_clauses.append("current_worker_address = NULL")
-
-    params.append(task_id)
-    cur.execute(
-        f"UPDATE tasks SET {', '.join(set_clauses)} WHERE task_id = ?",
-        tuple(params),
+    tasks.mark_terminal(
+        cur,
+        JobName.from_wire(task_id),
+        state,
+        error,
+        finished_at_ms,
+        failure_count=failure_count,
+        preemption_count=preemption_count,
+        active_states=ACTIVE_TASK_STATES,
     )
 
     delete_task_endpoints(cur, registry, task_id)
 
     if worker_id is not None and resources is not None:
-        _decommit_worker_resources(cur, worker_id, resources)
+        workers.decommit_resources(cur, WorkerId(worker_id), resources)
 
 
 def _kill_non_terminal_tasks(
     cur: Any,
+    attempts: TaskAttemptStore,
+    tasks: TaskStore,
+    workers: WorkerStore,
     registry,
     job_id_wire: str,
     reason: str,
@@ -567,8 +445,8 @@ def _kill_non_terminal_tasks(
         decommit_resources = None
         if worker_id is not None:
             task_kill_workers[task_name] = WorkerId(str(worker_id))
-            # Reservation holders never commit resources on assignment
-            # (see _assign_task), so they must not decommit on termination —
+            # Reservation holders never commit resources on assignment,
+            # so they must not decommit on termination —
             # otherwise we subtract chips that were never added, which floors
             # committed_* below a co-tenant's legitimate reservation and lets
             # the scheduler double-book the worker.
@@ -582,6 +460,9 @@ def _kill_non_terminal_tasks(
                 )
         _terminate_task(
             cur,
+            attempts,
+            tasks,
+            workers,
             registry,
             task_id,
             int(row["current_attempt_id"]),
@@ -620,7 +501,14 @@ def _cascade_children(
     )
     for child_job_id in descendants:
         child_tasks_to_kill, child_task_kill_workers = _kill_non_terminal_tasks(
-            cur, store.endpoints, child_job_id.to_wire(), reason, now_ms
+            cur,
+            store.attempts,
+            store.tasks,
+            store.workers,
+            store.endpoints,
+            child_job_id.to_wire(),
+            reason,
+            now_ms,
         )
         tasks_to_kill.update(child_tasks_to_kill)
         task_kill_workers.update(child_task_kill_workers)
@@ -636,7 +524,16 @@ def _cascade_terminal_job(
     reason: str,
 ) -> tuple[set[JobName], dict[JobName, WorkerId]]:
     """Kill remaining tasks and descendant jobs when a job reaches a terminal state."""
-    tasks_to_kill, task_kill_workers = _kill_non_terminal_tasks(cur, store.endpoints, job_id.to_wire(), reason, now_ms)
+    tasks_to_kill, task_kill_workers = _kill_non_terminal_tasks(
+        cur,
+        store.attempts,
+        store.tasks,
+        store.workers,
+        store.endpoints,
+        job_id.to_wire(),
+        reason,
+        now_ms,
+    )
     child_tasks_to_kill, child_task_kill_workers = _cascade_children(cur, store, job_id, now_ms, reason)
     tasks_to_kill.update(child_tasks_to_kill)
     task_kill_workers.update(child_task_kill_workers)
@@ -686,6 +583,9 @@ def _find_coscheduled_siblings(
 
 def _terminate_coscheduled_siblings(
     cur: Any,
+    attempts: TaskAttemptStore,
+    tasks: TaskStore,
+    workers: WorkerStore,
     registry,
     siblings: Iterable[_CoscheduledSibling],
     failed_task_id: JobName,
@@ -704,6 +604,9 @@ def _terminate_coscheduled_siblings(
     for sib in siblings:
         _terminate_task(
             cur,
+            attempts,
+            tasks,
+            workers,
             registry,
             sib.task_id,
             sib.attempt_id,
@@ -762,7 +665,16 @@ def _finalize_terminal_job(
     Non-succeeded jobs cascade only if the preemption policy is TERMINATE_CHILDREN.
     """
     reason = _TERMINAL_STATE_REASONS.get(terminal_state, "Job finalized")
-    tasks_to_kill, task_kill_workers = _kill_non_terminal_tasks(cur, store.endpoints, job_id.to_wire(), reason, now_ms)
+    tasks_to_kill, task_kill_workers = _kill_non_terminal_tasks(
+        cur,
+        store.attempts,
+        store.tasks,
+        store.workers,
+        store.endpoints,
+        job_id.to_wire(),
+        reason,
+        now_ms,
+    )
     should_cascade = True
     if terminal_state != job_pb2.JOB_STATE_SUCCEEDED:
         policy = _resolve_preemption_policy(store.jobs, cur, job_id)
@@ -963,11 +875,7 @@ class ControllerTransitions:
         current_state = basis.state
         if current_state in TERMINAL_JOB_STATES:
             return current_state
-        counts_rows = cur.fetchall(
-            "SELECT state, COUNT(*) AS c FROM tasks WHERE job_id = ? GROUP BY state",
-            (job_id.to_wire(),),
-        )
-        counts = {int(r["state"]): int(r["c"]) for r in counts_rows}
+        counts = self._store.tasks.state_counts_for_job(cur, job_id)
         total = sum(counts.values())
         new_state = current_state
         now_ms = Timestamp.now().epoch_ms()
@@ -998,23 +906,17 @@ class ControllerTransitions:
             new_state = job_pb2.JOB_STATE_PENDING
         if new_state == current_state:
             return new_state
-        error_row = cur.fetchone(
-            "SELECT error FROM tasks WHERE job_id = ? AND error IS NOT NULL ORDER BY task_index LIMIT 1",
-            (job_id.to_wire(),),
-        )
-        error = str(error_row["error"]) if error_row is not None else None
+        error = self._store.tasks.first_error_for_job(cur, job_id)
         self._store.jobs.apply_recomputed_state(cur, job_id, new_state, now_ms, error)
         return new_state
 
     def replace_reservation_claims(self, claims: dict[WorkerId, ReservationClaim]) -> None:
         """Replace all reservation claims atomically."""
         with self._db.transaction() as cur:
-            cur.execute("DELETE FROM reservation_claims")
-            for worker_id, claim in claims.items():
-                cur.execute(
-                    "INSERT INTO reservation_claims(worker_id, job_id, entry_idx) VALUES (?, ?, ?)",
-                    (str(worker_id), claim.job_id, claim.entry_idx),
-                )
+            self._store.reservations.replace_claims(
+                cur,
+                {worker_id: (claim.job_id, claim.entry_idx) for worker_id, claim in claims.items()},
+            )
 
     # =========================================================================
     # Command API
@@ -1031,13 +933,7 @@ class ControllerTransitions:
         created_task_ids: list[JobName] = []
 
         with self._db.transaction() as cur:
-            row = cur.execute("SELECT value FROM meta WHERE key = 'last_submission_ms'").fetchone()
-            last_submission_ms = int(row["value"]) if row is not None else 0
-            effective_submission_ms = max(submitted_ms, last_submission_ms + 1)
-            if row is None:
-                cur.execute("INSERT INTO meta(key, value) VALUES ('last_submission_ms', ?)", (effective_submission_ms,))
-            else:
-                cur.execute("UPDATE meta SET value = ? WHERE key = 'last_submission_ms'", (effective_submission_ms,))
+            effective_submission_ms = self._store.reservations.next_submission_ms(cur, submitted_ms)
 
             parent_job_id = job_id.parent.to_wire() if job_id.parent is not None else None
             root_submitted_ms = effective_submission_ms
@@ -1067,13 +963,10 @@ class ControllerTransitions:
             requested_band = int(request.priority_band)
             if requested_band != job_pb2.PRIORITY_BAND_UNSPECIFIED:
                 band_sort_key = requested_band
-            elif parent_job_id is not None:
-                parent_band_row = cur.execute(
-                    "SELECT priority_band FROM tasks WHERE job_id = ? LIMIT 1",
-                    (parent_job_id,),
-                ).fetchone()
-                if parent_band_row is not None:
-                    band_sort_key = parent_band_row["priority_band"]
+            elif job_id.parent is not None:
+                parent_band = self._store.tasks.get_priority_band_for_job(cur, job_id.parent)
+                if parent_band is not None:
+                    band_sort_key = parent_band
                 else:
                     band_sort_key = job_pb2.PRIORITY_BAND_INTERACTIVE
             else:
@@ -1182,25 +1075,20 @@ class ControllerTransitions:
                 for idx in range(replicas):
                     task_id = job_id.task(idx).to_wire()
                     created_task_ids.append(JobName.from_wire(task_id))
-                    cur.execute(
-                        "INSERT INTO tasks("
-                        "task_id, job_id, task_index, state, error, exit_code, submitted_at_ms, started_at_ms, "
-                        "finished_at_ms, max_retries_failure, max_retries_preemption, failure_count, preemption_count, "
-                        "current_attempt_id, priority_neg_depth, priority_root_submitted_ms, "
-                        "priority_insertion, priority_band"
-                        ") VALUES (?, ?, ?, ?, NULL, NULL, ?, NULL, NULL, ?, ?, 0, 0, -1, ?, ?, ?, ?)",
-                        (
-                            task_id,
-                            job_id.to_wire(),
-                            idx,
-                            job_pb2.TASK_STATE_PENDING,
-                            effective_submission_ms,
-                            int(request.max_retries_failure),
-                            int(request.max_retries_preemption),
-                            -job_id.depth,
-                            root_submitted_ms,
-                            insertion_base + idx,
-                            band_sort_key,
+                    self._store.tasks.insert(
+                        cur,
+                        TaskInsertParams(
+                            task_id=JobName.from_wire(task_id),
+                            job_id=job_id,
+                            task_index=idx,
+                            state=job_pb2.TASK_STATE_PENDING,
+                            submitted_at_ms=effective_submission_ms,
+                            max_retries_failure=int(request.max_retries_failure),
+                            max_retries_preemption=int(request.max_retries_preemption),
+                            priority_neg_depth=-job_id.depth,
+                            priority_root_submitted_ms=root_submitted_ms,
+                            priority_insertion=insertion_base + idx,
+                            priority_band=band_sort_key,
                         ),
                     )
                 if request.HasField("reservation") and request.reservation.entries:
@@ -1282,26 +1170,20 @@ class ControllerTransitions:
                     holder_base = self._db.next_sequence("task_priority_insertion", cur=cur)
                     for idx in range(len(request.reservation.entries)):
                         created_task_ids.append(holder_id.task(idx))
-                        cur.execute(
-                            "INSERT INTO tasks("
-                            "task_id, job_id, task_index, state, error, exit_code, submitted_at_ms, started_at_ms, "
-                            "finished_at_ms, max_retries_failure, max_retries_preemption, "
-                            "failure_count, preemption_count, "
-                            "current_attempt_id, priority_neg_depth, priority_root_submitted_ms, "
-                            "priority_insertion, priority_band"
-                            ") VALUES (?, ?, ?, ?, NULL, NULL, ?, NULL, NULL, ?, ?, 0, 0, -1, ?, ?, ?, ?)",
-                            (
-                                holder_id.task(idx).to_wire(),
-                                holder_id.to_wire(),
-                                idx,
-                                job_pb2.TASK_STATE_PENDING,
-                                effective_submission_ms,
-                                0,
-                                DEFAULT_MAX_RETRIES_PREEMPTION,
-                                -holder_id.depth,
-                                root_submitted_ms,
-                                holder_base + idx,
-                                band_sort_key,
+                        self._store.tasks.insert(
+                            cur,
+                            TaskInsertParams(
+                                task_id=holder_id.task(idx),
+                                job_id=holder_id,
+                                task_index=idx,
+                                state=job_pb2.TASK_STATE_PENDING,
+                                submitted_at_ms=effective_submission_ms,
+                                max_retries_failure=0,
+                                max_retries_preemption=DEFAULT_MAX_RETRIES_PREEMPTION,
+                                priority_neg_depth=-holder_id.depth,
+                                priority_root_submitted_ms=root_submitted_ms,
+                                priority_insertion=holder_base + idx,
+                                priority_band=band_sort_key,
                             ),
                         )
 
@@ -1351,21 +1233,9 @@ class ControllerTransitions:
                         int(row["res_disk_bytes"]),
                         row["res_device_json"],
                     )
-                    _decommit_worker_resources(cur, str(row["worker_id"]), resources)
+                    self._store.workers.decommit_resources(cur, WorkerId(str(row["worker_id"])), resources)
             now_ms = Timestamp.now().epoch_ms()
-            task_terminal_placeholders = ",".join("?" for _ in TERMINAL_TASK_STATES)
-            cur.execute(
-                f"UPDATE tasks SET state = ?, error = ?, finished_at_ms = COALESCE(finished_at_ms, ?), "
-                f"current_worker_id = NULL, current_worker_address = NULL "
-                f"WHERE job_id IN ({placeholders}) AND state NOT IN ({task_terminal_placeholders})",
-                (
-                    job_pb2.TASK_STATE_KILLED,
-                    reason,
-                    now_ms,
-                    *subtree_ids,
-                    *TERMINAL_TASK_STATES,
-                ),
-            )
+            self._store.tasks.bulk_kill_non_terminal(cur, subtree, reason, now_ms, TERMINAL_TASK_STATES)
             # Deliberately excludes JOB_STATE_WORKER_FAILED from the guard set:
             # worker-failed jobs should still be cancellable (transitioned to KILLED).
             cancel_guard_states = TERMINAL_JOB_STATES - {job_pb2.JOB_STATE_WORKER_FAILED}
@@ -1391,15 +1261,15 @@ class ControllerTransitions:
         scale_group: str = "",
     ) -> TxResult:
         """Register a new worker or refresh an existing one."""
-        attrs: list[tuple[str, str, str | None, int | None, float | None]] = []
+        attrs: list[WorkerAttributeParams] = []
         for key, proto in metadata.attributes.items():
             value = AttributeValue.from_proto(proto).value
             if isinstance(value, int):
-                attrs.append((key, "int", None, int(value), None))
+                attrs.append(WorkerAttributeParams(key, "int", None, int(value), None))
             elif isinstance(value, float):
-                attrs.append((key, "float", None, None, float(value)))
+                attrs.append(WorkerAttributeParams(key, "float", None, None, float(value)))
             else:
-                attrs.append((key, "str", str(value), None, None))
+                attrs.append(WorkerAttributeParams(key, "str", str(value), None, None))
         now_ms = ts.epoch_ms()
         gpu_count = get_gpu_count(metadata.device)
         tpu_count = get_tpu_count(metadata.device)
@@ -1473,24 +1343,18 @@ class ControllerTransitions:
                     md_device_json,
                 ),
             )
-            cur.execute("DELETE FROM worker_attributes WHERE worker_id = ?", (str(worker_id),))
-            for key, value_type, str_value, int_value, float_value in attrs:
-                cur.execute(
-                    "INSERT INTO worker_attributes(worker_id, key, value_type, str_value, int_value, float_value) "
-                    "VALUES (?, ?, ?, ?, ?, ?)",
-                    (str(worker_id), key, value_type, str_value, int_value, float_value),
-                )
+            self._store.workers.replace_attributes(cur, worker_id, attrs)
         log_event("worker_registered", str(worker_id), address=address)
         # Update in-memory attribute cache so scheduling sees the new worker immediately.
         attr_dict: dict[str, AttributeValue] = {}
-        for key, value_type, str_value, int_value, float_value in attrs:
-            if value_type == "int":
-                attr_dict[key] = AttributeValue(int(int_value))
-            elif value_type == "float":
-                attr_dict[key] = AttributeValue(float(float_value))
+        for attr in attrs:
+            if attr.value_type == "int":
+                attr_dict[attr.key] = AttributeValue(int(attr.int_value))
+            elif attr.value_type == "float":
+                attr_dict[attr.key] = AttributeValue(float(attr.float_value))
             else:
-                attr_dict[key] = AttributeValue(str(str_value or ""))
-        self._db.set_worker_attributes(worker_id, attr_dict)
+                attr_dict[attr.key] = AttributeValue(str(attr.str_value or ""))
+        self._store.workers.update_attr_cache(worker_id, attr_dict)
         return TxResult()
 
     def register_worker(
@@ -1528,19 +1392,11 @@ class ControllerTransitions:
             job_cache: dict[str, JobDetailRow] = {}
             jobs_to_update: set[str] = set()
             for assignment in assignments:
-                task_row = cur.execute(
-                    f"SELECT {TASK_DETAIL_PROJECTION.select_clause()} " "FROM tasks t WHERE t.task_id = ?",
-                    (assignment.task_id.to_wire(),),
-                ).fetchone()
-                worker_row = cur.execute(
-                    "SELECT worker_id, address, active, healthy "
-                    "FROM workers WHERE worker_id = ? AND active = 1 AND healthy = 1",
-                    (str(assignment.worker_id),),
-                ).fetchone()
-                if task_row is None or worker_row is None:
+                task = self._store.tasks.get_detail(cur, assignment.task_id)
+                worker_address = self._store.workers.active_healthy_address(cur, assignment.worker_id)
+                if task is None or worker_address is None:
                     rejected.append(assignment)
                     continue
-                task = TASK_DETAIL_PROJECTION.decode_one([task_row])
                 if not task_row_can_be_scheduled(task):
                     rejected.append(assignment)
                     continue
@@ -1552,12 +1408,13 @@ class ControllerTransitions:
                         continue
                     job_cache[job_id_wire] = decoded_job
                 job = job_cache[job_id_wire]
-                attempt_id = int(task_row["current_attempt_id"]) + 1
-                _assign_task(
+                attempt_id = task.current_attempt_id + 1
+                self._store.tasks.assign(
                     cur,
-                    assignment.task_id.to_wire(),
-                    str(assignment.worker_id),
-                    str(worker_row["address"]),
+                    self._store.attempts,
+                    assignment.task_id,
+                    assignment.worker_id,
+                    worker_address,
                     attempt_id,
                     now_ms,
                 )
@@ -1568,18 +1425,7 @@ class ControllerTransitions:
                         job.res_disk_bytes,
                         job.res_device_json,
                     )
-                    cur.execute(
-                        "UPDATE workers SET committed_cpu_millicores = committed_cpu_millicores + ?, "
-                        "committed_mem_bytes = committed_mem_bytes + ?, committed_gpu = committed_gpu + ?, "
-                        "committed_tpu = committed_tpu + ? WHERE worker_id = ?",
-                        (
-                            int(resources.cpu_millicores),
-                            int(resources.memory_bytes),
-                            int(get_gpu_count(resources.device)),
-                            int(get_tpu_count(resources.device)),
-                            str(assignment.worker_id),
-                        ),
-                    )
+                    self._store.workers.add_committed_resources(cur, assignment.worker_id, resources)
                     entrypoint = proto_from_json(job.entrypoint_json, job_pb2.RuntimeEntrypoint)
                     # Load inline workdir files from the job_workdir_files table.
                     wf_rows = cur.execute(
@@ -1601,9 +1447,11 @@ class ControllerTransitions:
                         task_image=job.task_image,
                     )
                     if direct_dispatch:
-                        start_requests.append((assignment.worker_id, worker_row["address"], run_request))
+                        start_requests.append((assignment.worker_id, worker_address, run_request))
                     else:
-                        enqueue_run_dispatch(cur, str(assignment.worker_id), run_request.SerializeToString(), now_ms)
+                        self._store.dispatch.enqueue_run(
+                            cur, assignment.worker_id, run_request.SerializeToString(), now_ms
+                        )
                     has_real_dispatch = True
                 cur.execute(
                     "INSERT INTO worker_task_history(worker_id, task_id, assigned_at_ms) VALUES (?, ?, ?)",
@@ -1661,17 +1509,14 @@ class ControllerTransitions:
             ):
                 continue
             if update.attempt_id != int(task_row["current_attempt_id"]):
-                stale = cur.execute(
-                    "SELECT state FROM task_attempts WHERE task_id = ? AND attempt_id = ?",
-                    (update.task_id.to_wire(), update.attempt_id),
-                ).fetchone()
-                if stale is not None and int(stale["state"]) not in TERMINAL_TASK_STATES:
+                stale_state = self._store.attempts.get_state(cur, update.task_id, update.attempt_id)
+                if stale_state is not None and stale_state not in TERMINAL_TASK_STATES:
                     logger.error(
                         "Stale attempt precondition violation: task=%s reported=%d current=%d stale_state=%s",
                         update.task_id,
                         update.attempt_id,
                         int(task_row["current_attempt_id"]),
-                        int(stale["state"]),
+                        stale_state,
                     )
                 continue
 
@@ -1682,40 +1527,35 @@ class ControllerTransitions:
             if update.new_state == prior_state and not has_new_data:
                 continue
 
-            attempt_row = cur.execute(
-                "SELECT * FROM task_attempts WHERE task_id = ? AND attempt_id = ?",
-                (update.task_id.to_wire(), update.attempt_id),
-            ).fetchone()
-            if attempt_row is None:
+            attempt = self._store.attempts.get(cur, update.task_id, update.attempt_id)
+            if attempt is None:
                 continue
             # The attempt is already terminal (e.g. preempted, killed) but the task has
             # been rolled back to PENDING for retry and current_attempt_id still points
             # at the dead attempt. Reviving it would produce an inconsistent row where
             # state contradicts finished_at_ms/error.
-            if int(attempt_row["state"]) in TERMINAL_TASK_STATES:
+            if attempt.state in TERMINAL_TASK_STATES:
                 logger.debug(
                     "Dropping late update for terminal attempt: task=%s attempt=%d attempt_state=%d reported=%d",
                     update.task_id,
                     update.attempt_id,
-                    int(attempt_row["state"]),
+                    attempt.state,
                     int(update.new_state),
                 )
                 continue
-            worker_id = attempt_row["worker_id"]
+            worker_id = attempt.worker_id
             if update.resource_usage is not None:
                 ru = update.resource_usage
-                cur.execute(
-                    "INSERT INTO task_resource_history"
-                    "(task_id, attempt_id, cpu_millicores, memory_mb, disk_mb, memory_peak_mb, timestamp_ms) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                    (
-                        update.task_id.to_wire(),
-                        update.attempt_id,
-                        ru.cpu_millicores,
-                        ru.memory_mb,
-                        ru.disk_mb,
-                        ru.memory_peak_mb,
-                        now_ms,
+                self._store.tasks.insert_resource_usage(
+                    cur,
+                    ResourceUsageInsertParams(
+                        task_id=update.task_id,
+                        attempt_id=update.attempt_id,
+                        cpu_millicores=ru.cpu_millicores,
+                        memory_mb=ru.memory_mb,
+                        disk_mb=ru.disk_mb,
+                        memory_peak_mb=ru.memory_peak_mb,
+                        timestamp_ms=now_ms,
                     ),
                 )
             terminal_ms: int | None = None
@@ -1786,56 +1626,32 @@ class ControllerTransitions:
             # tracks the task's finished_at_ms; the attempt needs its own stamp.
             attempt_terminal_ms = now_ms if int(update.new_state) in TERMINAL_TASK_STATES else None
 
-            cur.execute(
-                "UPDATE task_attempts SET state = ?, started_at_ms = COALESCE(started_at_ms, ?), "
-                "finished_at_ms = COALESCE(finished_at_ms, ?), exit_code = COALESCE(?, exit_code), "
-                "error = COALESCE(?, error) WHERE task_id = ? AND attempt_id = ?",
-                (
-                    int(update.new_state),
-                    started_ms,
-                    attempt_terminal_ms,
-                    task_exit,
-                    update.error,
-                    update.task_id.to_wire(),
-                    update.attempt_id,
+            self._store.attempts.apply_update(
+                cur,
+                TaskAttemptUpdateParams(
+                    task_id=update.task_id,
+                    attempt_id=update.attempt_id,
+                    state=int(update.new_state),
+                    started_at_ms=started_ms,
+                    finished_at_ms=attempt_terminal_ms,
+                    exit_code=task_exit,
+                    error=update.error,
                 ),
             )
-            # Clear denormalized worker columns when task leaves active state.
-            if task_state in ACTIVE_TASK_STATES:
-                cur.execute(
-                    "UPDATE tasks SET state = ?, error = COALESCE(?, error), exit_code = COALESCE(?, exit_code), "
-                    "started_at_ms = COALESCE(started_at_ms, ?), finished_at_ms = ?, "
-                    "failure_count = ?, preemption_count = ? "
-                    "WHERE task_id = ?",
-                    (
-                        task_state,
-                        task_error,
-                        task_exit,
-                        started_ms,
-                        terminal_ms,
-                        failure_count,
-                        preemption_count,
-                        update.task_id.to_wire(),
-                    ),
-                )
-            else:
-                cur.execute(
-                    "UPDATE tasks SET state = ?, error = COALESCE(?, error), exit_code = COALESCE(?, exit_code), "
-                    "started_at_ms = COALESCE(started_at_ms, ?), finished_at_ms = ?, "
-                    "failure_count = ?, preemption_count = ?, "
-                    "current_worker_id = NULL, current_worker_address = NULL "
-                    "WHERE task_id = ?",
-                    (
-                        task_state,
-                        task_error,
-                        task_exit,
-                        started_ms,
-                        terminal_ms,
-                        failure_count,
-                        preemption_count,
-                        update.task_id.to_wire(),
-                    ),
-                )
+            self._store.tasks.apply_state_update(
+                cur,
+                TaskStateUpdateParams(
+                    task_id=update.task_id,
+                    state=task_state,
+                    error=task_error,
+                    exit_code=task_exit,
+                    started_at_ms=started_ms,
+                    finished_at_ms=terminal_ms,
+                    failure_count=failure_count,
+                    preemption_count=preemption_count,
+                ),
+                ACTIVE_TASK_STATES,
+            )
 
             # Fetch and cache job_config row (avoids re-querying per task in same job).
             job_id_wire = task.job_id.to_wire()
@@ -1851,7 +1667,7 @@ class ControllerTransitions:
                         int(jc["res_disk_bytes"]),
                         jc["res_device_json"],
                     )
-                    _decommit_worker_resources(cur, str(worker_id), resources)
+                    self._store.workers.decommit_resources(cur, worker_id, resources)
 
             if update.new_state in TERMINAL_TASK_STATES:
                 delete_task_endpoints(cur, self._store.endpoints, update.task_id.to_wire())
@@ -1867,7 +1683,15 @@ class ControllerTransitions:
                     jc["res_device_json"],
                 )
                 cascade_kill, cascade_workers = _terminate_coscheduled_siblings(
-                    cur, self._store.endpoints, siblings, update.task_id, resources, now_ms
+                    cur,
+                    self._store.attempts,
+                    self._store.tasks,
+                    self._store.workers,
+                    self._store.endpoints,
+                    siblings,
+                    update.task_id,
+                    resources,
+                    now_ms,
                 )
                 tasks_to_kill.update(cascade_kill)
                 task_kill_workers.update(cascade_workers)
@@ -1945,7 +1769,7 @@ class ControllerTransitions:
             task_row_map = _bulk_fetch_tasks(cur, all_task_ids)
 
             # ── Classify and split ────────────────────────────────────────
-            task_history_params: list[tuple[str, int, int, int, int, int, int]] = []
+            task_history_params: list[ResourceUsageInsertParams] = []
             # (request_index, transition_request) pairs so results stay aligned.
             transition_entries: list[tuple[int, HeartbeatApplyRequest]] = []
 
@@ -1976,14 +1800,14 @@ class ControllerTransitions:
                         if update.resource_usage is not None:
                             u = update.resource_usage
                             task_history_params.append(
-                                (
-                                    task_id_wire,
-                                    update.attempt_id,
-                                    u.cpu_millicores,
-                                    u.memory_mb,
-                                    u.disk_mb,
-                                    u.memory_peak_mb,
-                                    now_ms,
+                                ResourceUsageInsertParams(
+                                    task_id=JobName.from_wire(task_id_wire),
+                                    attempt_id=update.attempt_id,
+                                    cpu_millicores=u.cpu_millicores,
+                                    memory_mb=u.memory_mb,
+                                    disk_mb=u.disk_mb,
+                                    memory_peak_mb=u.memory_peak_mb,
+                                    timestamp_ms=now_ms,
                                 )
                             )
 
@@ -2000,13 +1824,7 @@ class ControllerTransitions:
                     )
 
             # ── Pass 2a: batch task resource history writes ─────────────────
-            if task_history_params:
-                cur.executemany(
-                    "INSERT INTO task_resource_history"
-                    "(task_id, attempt_id, cpu_millicores, memory_mb, disk_mb, memory_peak_mb, timestamp_ms) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                    task_history_params,
-                )
+            self._store.tasks.insert_resource_usage_many(cur, task_history_params)
 
             # ── Pass 2b: transitions via existing state machine ───────────
             for req_idx, treq in transition_entries:
@@ -2053,6 +1871,9 @@ class ControllerTransitions:
             holder_preemption_count = 0 if is_reservation_holder else preemption_count
             _terminate_task(
                 cur,
+                self._store.attempts,
+                self._store.tasks,
+                self._store.workers,
                 self._store.endpoints,
                 tid,
                 int(task_row["current_attempt_id"]),
@@ -2086,7 +1907,7 @@ class ControllerTransitions:
                     task_kill_workers.update(child_task_kill_workers)
             if new_task_state == job_pb2.TASK_STATE_WORKER_FAILED:
                 tasks_to_kill.add(task_id)
-        _remove_worker(cur, str(worker_id))
+        _remove_worker(cur, self._store.workers, worker_id)
         return TxResult(tasks_to_kill=tasks_to_kill, task_kill_workers=task_kill_workers)
 
     def _record_worker_failure(
@@ -2166,7 +1987,7 @@ class ControllerTransitions:
                         removed_workers.append((worker_id, worker_address))
 
         for worker_id, _ in removed_workers:
-            self._db.remove_worker_from_attr_cache(worker_id)
+            self._store.workers.remove_from_attr_cache(worker_id)
         return WorkerFailureBatchResult(
             tasks_to_kill=all_tasks_to_kill,
             task_kill_workers=all_task_kill_workers,
@@ -2177,12 +1998,15 @@ class ControllerTransitions:
     def mark_task_unschedulable(self, task_id: JobName, reason: str) -> TxResult:
         """Mark a task as unschedulable using the task transition engine."""
         with self._db.transaction() as cur:
-            row = cur.execute("SELECT job_id FROM tasks WHERE task_id = ?", (task_id.to_wire(),)).fetchone()
-            if row is None:
+            job_id = self._store.tasks.get_job_id(cur, task_id)
+            if job_id is None:
                 return TxResult()
             now_ms = Timestamp.now().epoch_ms()
             _terminate_task(
                 cur,
+                self._store.attempts,
+                self._store.tasks,
+                self._store.workers,
                 self._store.endpoints,
                 task_id.to_wire(),
                 None,
@@ -2190,7 +2014,7 @@ class ControllerTransitions:
                 reason,
                 now_ms,
             )
-            self._recompute_job_state(cur, JobName.from_wire(str(row["job_id"])))
+            self._recompute_job_state(cur, job_id)
         log_event("task_unschedulable", task_id.to_wire(), reason=reason)
         return TxResult()
 
@@ -2226,11 +2050,8 @@ class ControllerTransitions:
                 job_pb2.TASK_STATE_PREEMPTED,
             )
             # Fetch worker_id from the attempt for resource decommit.
-            attempt_row = cur.execute(
-                "SELECT worker_id FROM task_attempts WHERE task_id = ? AND attempt_id = ?",
-                (task_id.to_wire(), int(row["current_attempt_id"])),
-            ).fetchone()
-            attempt_worker_id = str(attempt_row["worker_id"]) if attempt_row and attempt_row["worker_id"] else None
+            attempt_worker = self._store.attempts.get_worker_id(cur, task_id, int(row["current_attempt_id"]))
+            attempt_worker_id = str(attempt_worker) if attempt_worker is not None else None
             attempt_resources = None
             if attempt_worker_id is not None:
                 attempt_resources = resource_spec_from_scalars(
@@ -2242,6 +2063,9 @@ class ControllerTransitions:
 
             _terminate_task(
                 cur,
+                self._store.attempts,
+                self._store.tasks,
+                self._store.workers,
                 self._store.endpoints,
                 task_id.to_wire(),
                 int(row["current_attempt_id"]),
@@ -2367,6 +2191,9 @@ class ControllerTransitions:
                 attempt_id = row["current_attempt_id"]
                 _terminate_task(
                     cur,
+                    self._store.attempts,
+                    self._store.tasks,
+                    self._store.workers,
                     self._store.endpoints,
                     task_id_wire,
                     int(attempt_id) if attempt_id is not None else None,
@@ -2393,7 +2220,15 @@ class ControllerTransitions:
                 # Pick the first direct-timeout task in this job as the "cause" for the error message.
                 cause_tid = next(JobName.from_wire(str(r["task_id"])) for r in rows if str(r["job_id"]) == job_id_wire)
                 cascade_kill, cascade_workers = _terminate_coscheduled_siblings(
-                    cur, self._store.endpoints, siblings, cause_tid, job_resources, now_ms
+                    cur,
+                    self._store.attempts,
+                    self._store.tasks,
+                    self._store.workers,
+                    self._store.endpoints,
+                    siblings,
+                    cause_tid,
+                    job_resources,
+                    now_ms,
                 )
                 tasks_to_kill.update(cascade_kill)
                 task_kill_workers.update(cascade_workers)
@@ -2443,133 +2278,10 @@ class ControllerTransitions:
             row = cur.execute("SELECT * FROM workers WHERE worker_id = ?", (str(worker_id),)).fetchone()
             if row is None:
                 return None
-            _remove_worker(cur, str(worker_id))
+            _remove_worker(cur, self._store.workers, worker_id)
         log_event("worker_removed", str(worker_id))
-        self._db.remove_worker_from_attr_cache(worker_id)
+        self._store.workers.remove_from_attr_cache(worker_id)
         return WORKER_DETAIL_PROJECTION.decode_one([row])
-
-    def _prune_per_worker_history(
-        self,
-        table: str,
-        retention: int,
-        order_by: str = "id DESC",
-    ) -> int:
-        """Trim a per-worker history table to *retention* rows per worker.
-
-        Used by the background prune thread. The NOT IN subquery per worker is
-        expensive; batching all workers in a single transaction amortizes the
-        overhead versus running it on every assign/heartbeat.
-        """
-        with self._db.transaction() as cur:
-            rows = cur.execute(
-                f"SELECT worker_id, COUNT(*) as cnt FROM {table} GROUP BY worker_id HAVING cnt > ?",
-                (retention,),
-            ).fetchall()
-            total_deleted = 0
-            for row in rows:
-                wid = row["worker_id"]
-                cur.execute(
-                    f"DELETE FROM {table} "
-                    "WHERE worker_id = ? "
-                    f"AND id NOT IN ("
-                    f"  SELECT id FROM {table} "
-                    "  WHERE worker_id = ? "
-                    f"  ORDER BY {order_by} LIMIT ?"
-                    ")",
-                    (wid, wid, retention),
-                )
-                total_deleted += cur.rowcount
-        if total_deleted > 0:
-            logger.info("Pruned %d %s rows", total_deleted, table)
-        return total_deleted
-
-    def prune_worker_task_history(self) -> int:
-        """Trim worker_task_history to WORKER_TASK_HISTORY_RETENTION rows per worker."""
-        return self._prune_per_worker_history(
-            "worker_task_history",
-            WORKER_TASK_HISTORY_RETENTION,
-            order_by="assigned_at_ms DESC, id DESC",
-        )
-
-    def prune_worker_resource_history(self) -> int:
-        """Trim worker_resource_history to WORKER_RESOURCE_HISTORY_RETENTION rows per worker."""
-        return self._prune_per_worker_history(
-            "worker_resource_history",
-            WORKER_RESOURCE_HISTORY_RETENTION,
-        )
-
-    def prune_task_resource_history(self) -> int:
-        """Two-pass prune:
-
-        1. Evict all history for tasks that have been in a terminal state
-           longer than TASK_RESOURCE_HISTORY_TERMINAL_TTL. Dashboards read
-           peak memory from tasks.peak_memory_mb after termination; the
-           per-sample rows are dead weight and are ~85% of the table on
-           prod.
-        2. Logarithmic downsampling for anything that remains: when a
-           (task, attempt) exceeds 2*N rows, thin the older half by deleting
-           every other row so older data grows exponentially sparser.
-
-        Deletes are chunked so the writer lock releases between chunks.
-        """
-        now_ms = Timestamp.now().epoch_ms()
-        ttl_cutoff_ms = now_ms - TASK_RESOURCE_HISTORY_TERMINAL_TTL.to_ms()
-        terminal_placeholders = ",".join("?" for _ in TERMINAL_TASK_STATES)
-
-        with self._db.read_snapshot() as snap:
-            terminal_ids = [
-                str(r["task_id"])
-                for r in snap.fetchall(
-                    f"SELECT task_id FROM tasks "
-                    f"WHERE state IN ({terminal_placeholders}) "
-                    f"AND finished_at_ms IS NOT NULL AND finished_at_ms < ?",
-                    (*TERMINAL_TASK_STATES, ttl_cutoff_ms),
-                )
-            ]
-
-        evicted_terminal = 0
-        for chunk_start in range(0, len(terminal_ids), TASK_RESOURCE_HISTORY_DELETE_CHUNK):
-            chunk = terminal_ids[chunk_start : chunk_start + TASK_RESOURCE_HISTORY_DELETE_CHUNK]
-            ph = ",".join("?" * len(chunk))
-            with self._db.transaction() as cur:
-                cur.execute(f"DELETE FROM task_resource_history WHERE task_id IN ({ph})", tuple(chunk))
-                evicted_terminal += cur.rowcount
-
-        threshold = TASK_RESOURCE_HISTORY_RETENTION * 2
-        with self._db.transaction() as cur:
-            overflows = cur.execute(
-                "SELECT task_id, attempt_id, COUNT(*) as cnt "
-                "FROM task_resource_history "
-                "GROUP BY task_id, attempt_id HAVING cnt > ?",
-                (threshold,),
-            ).fetchall()
-            ids_to_delete: list[int] = []
-            for row in overflows:
-                tid, aid = row["task_id"], row["attempt_id"]
-                # Load all IDs into Python for index-based thinning.
-                # Bounded by 2*N + heartbeats-per-prune-cycle (~160 rows max at N=50).
-                all_ids = [
-                    r["id"]
-                    for r in cur.execute(
-                        "SELECT id FROM task_resource_history " "WHERE task_id = ? AND attempt_id = ? ORDER BY id ASC",
-                        (tid, aid),
-                    ).fetchall()
-                ]
-                # Keep the newest N rows untouched; thin the older portion by 2x.
-                older = all_ids[: len(all_ids) - TASK_RESOURCE_HISTORY_RETENTION]
-                ids_to_delete.extend(older[1::2])
-
-            total_deleted = 0
-            for chunk_start in range(0, len(ids_to_delete), 900):
-                chunk = ids_to_delete[chunk_start : chunk_start + 900]
-                ph = ",".join("?" * len(chunk))
-                cur.execute(f"DELETE FROM task_resource_history WHERE id IN ({ph})", tuple(chunk))
-                total_deleted += cur.rowcount
-        if evicted_terminal > 0:
-            logger.info("Evicted %d task_resource_history rows (terminal TTL)", evicted_terminal)
-        if total_deleted > 0:
-            logger.info("Pruned %d task_resource_history rows (log downsampling)", total_deleted)
-        return evicted_terminal + total_deleted
 
     def _batch_delete(
         self,
@@ -2649,7 +2361,7 @@ class ControllerTransitions:
                 break
             worker_id = row["worker_id"]
             with self._db.transaction() as cur:
-                _remove_worker(cur, str(worker_id))
+                _remove_worker(cur, self._store.workers, WorkerId(str(worker_id)))
             log_event("worker_pruned", str(worker_id))
             workers_deleted += 1
             time.sleep(pause_between_s)
@@ -2846,16 +2558,12 @@ class ControllerTransitions:
         else:
             str_value = str(value.value)
 
-        self._db.execute(
-            "INSERT INTO worker_attributes(worker_id, key, value_type, str_value, int_value, float_value) "
-            "VALUES (?, ?, ?, ?, ?, ?) "
-            "ON CONFLICT(worker_id, key) DO UPDATE SET "
-            "value_type=excluded.value_type, "
-            "str_value=excluded.str_value, "
-            "int_value=excluded.int_value, "
-            "float_value=excluded.float_value",
-            (str(worker_id), key, value_type, str_value, int_value, float_value),
-        )
+        with self._store.transaction() as cur:
+            self._store.workers.set_attribute_for_test(
+                cur,
+                worker_id,
+                WorkerAttributeParams(key, value_type, str_value, int_value, float_value),
+            )
 
     # =========================================================================
     # Direct provider methods
@@ -2903,7 +2611,15 @@ class ControllerTransitions:
                     row["res_device_json"],
                 )
 
-                _assign_task(cur, task_id, None, None, attempt_id, now_ms)
+                self._store.tasks.assign(
+                    cur,
+                    self._store.attempts,
+                    JobName.from_wire(task_id),
+                    None,
+                    None,
+                    attempt_id,
+                    now_ms,
+                )
 
                 entrypoint = proto_from_json(str(row["entrypoint_json"]), job_pb2.RuntimeEntrypoint)
                 # Load inline workdir files from the job_workdir_files table.
@@ -2953,13 +2669,7 @@ class ControllerTransitions:
                 if str(row["task_id"]) not in newly_promoted
             ]
 
-            # Drain kill entries with NULL worker_id.
-            kill_rows = cur.execute(
-                "SELECT task_id FROM dispatch_queue WHERE worker_id IS NULL AND kind = 'kill'",
-            ).fetchall()
-            tasks_to_kill = [str(row["task_id"]) for row in kill_rows if row["task_id"] is not None]
-            if kill_rows:
-                cur.execute("DELETE FROM dispatch_queue WHERE worker_id IS NULL AND kind = 'kill'")
+            tasks_to_kill = self._store.dispatch.drain_direct_kills(cur)
 
         return DirectProviderBatch(
             tasks_to_run=tasks_to_run,
@@ -2991,59 +2701,48 @@ class ControllerTransitions:
                 ):
                     continue
                 if update.attempt_id != int(task_row["current_attempt_id"]):
-                    stale = cur.execute(
-                        "SELECT state FROM task_attempts WHERE task_id = ? AND attempt_id = ?",
-                        (update.task_id.to_wire(), update.attempt_id),
-                    ).fetchone()
-                    if stale is not None and int(stale["state"]) not in TERMINAL_TASK_STATES:
+                    stale_state = self._store.attempts.get_state(cur, update.task_id, update.attempt_id)
+                    if stale_state is not None and stale_state not in TERMINAL_TASK_STATES:
                         logger.error(
                             "Stale attempt precondition violation: task=%s reported=%d current=%d stale_state=%s",
                             update.task_id,
                             update.attempt_id,
                             int(task_row["current_attempt_id"]),
-                            int(stale["state"]),
+                            stale_state,
                         )
                     continue
-                attempt_row = cur.execute(
-                    "SELECT * FROM task_attempts WHERE task_id = ? AND attempt_id = ?",
-                    (update.task_id.to_wire(), update.attempt_id),
-                ).fetchone()
-                if attempt_row is None:
+                attempt = self._store.attempts.get(cur, update.task_id, update.attempt_id)
+                if attempt is None:
                     continue
                 # See _apply_task_transitions for rationale: the current attempt may
                 # be terminal while the task is retrying in PENDING; late reports
                 # must not revive it.
-                if int(attempt_row["state"]) in TERMINAL_TASK_STATES:
+                if attempt.state in TERMINAL_TASK_STATES:
                     logger.debug(
                         "Dropping late update for terminal attempt: task=%s attempt=%d attempt_state=%d reported=%d",
                         update.task_id,
                         update.attempt_id,
-                        int(attempt_row["state"]),
+                        attempt.state,
                         int(update.new_state),
                     )
                     continue
 
                 if update.resource_usage is not None:
                     ru = update.resource_usage
-                    cur.execute(
-                        "INSERT INTO task_resource_history"
-                        "(task_id, attempt_id, cpu_millicores, memory_mb, disk_mb, memory_peak_mb, timestamp_ms) "
-                        "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                        (
-                            update.task_id.to_wire(),
-                            update.attempt_id,
-                            ru.cpu_millicores,
-                            ru.memory_mb,
-                            ru.disk_mb,
-                            ru.memory_peak_mb,
-                            now_ms,
+                    self._store.tasks.insert_resource_usage(
+                        cur,
+                        ResourceUsageInsertParams(
+                            task_id=update.task_id,
+                            attempt_id=update.attempt_id,
+                            cpu_millicores=ru.cpu_millicores,
+                            memory_mb=ru.memory_mb,
+                            disk_mb=ru.disk_mb,
+                            memory_peak_mb=ru.memory_peak_mb,
+                            timestamp_ms=now_ms,
                         ),
                     )
                 if update.container_id is not None:
-                    cur.execute(
-                        "UPDATE tasks SET container_id = ? WHERE task_id = ?",
-                        (update.container_id, update.task_id.to_wire()),
-                    )
+                    self._store.tasks.update_container_id(cur, update.task_id, update.container_id)
 
                 terminal_ms: int | None = None
                 started_ms: int | None = None
@@ -3102,55 +2801,32 @@ class ControllerTransitions:
                 # if the TASK rolls back to PENDING for a retry.
                 attempt_terminal_ms = now_ms if int(update.new_state) in TERMINAL_TASK_STATES else None
 
-                cur.execute(
-                    "UPDATE task_attempts SET state = ?, started_at_ms = COALESCE(started_at_ms, ?), "
-                    "finished_at_ms = COALESCE(finished_at_ms, ?), exit_code = COALESCE(?, exit_code), "
-                    "error = COALESCE(?, error) WHERE task_id = ? AND attempt_id = ?",
-                    (
-                        int(update.new_state),
-                        started_ms,
-                        attempt_terminal_ms,
-                        task_exit,
-                        update.error,
-                        update.task_id.to_wire(),
-                        update.attempt_id,
+                self._store.attempts.apply_update(
+                    cur,
+                    TaskAttemptUpdateParams(
+                        task_id=update.task_id,
+                        attempt_id=update.attempt_id,
+                        state=int(update.new_state),
+                        started_at_ms=started_ms,
+                        finished_at_ms=attempt_terminal_ms,
+                        exit_code=task_exit,
+                        error=update.error,
                     ),
                 )
-                if task_state in ACTIVE_TASK_STATES:
-                    cur.execute(
-                        "UPDATE tasks SET state = ?, error = COALESCE(?, error), exit_code = COALESCE(?, exit_code), "
-                        "started_at_ms = COALESCE(started_at_ms, ?), finished_at_ms = ?, "
-                        "failure_count = ?, preemption_count = ? "
-                        "WHERE task_id = ?",
-                        (
-                            task_state,
-                            task_error,
-                            task_exit,
-                            started_ms,
-                            terminal_ms,
-                            failure_count,
-                            preemption_count,
-                            update.task_id.to_wire(),
-                        ),
-                    )
-                else:
-                    cur.execute(
-                        "UPDATE tasks SET state = ?, error = COALESCE(?, error), exit_code = COALESCE(?, exit_code), "
-                        "started_at_ms = COALESCE(started_at_ms, ?), finished_at_ms = ?, "
-                        "failure_count = ?, preemption_count = ?, "
-                        "current_worker_id = NULL, current_worker_address = NULL "
-                        "WHERE task_id = ?",
-                        (
-                            task_state,
-                            task_error,
-                            task_exit,
-                            started_ms,
-                            terminal_ms,
-                            failure_count,
-                            preemption_count,
-                            update.task_id.to_wire(),
-                        ),
-                    )
+                self._store.tasks.apply_state_update(
+                    cur,
+                    TaskStateUpdateParams(
+                        task_id=update.task_id,
+                        state=task_state,
+                        error=task_error,
+                        exit_code=task_exit,
+                        started_at_ms=started_ms,
+                        finished_at_ms=terminal_ms,
+                        failure_count=failure_count,
+                        preemption_count=preemption_count,
+                    ),
+                    ACTIVE_TASK_STATES,
+                )
                 jc_row = self._store.jobs.get_config(cur, task.job_id)
 
                 if update.new_state in TERMINAL_TASK_STATES:
@@ -3167,7 +2843,15 @@ class ControllerTransitions:
                         jc_row["res_device_json"],
                     )
                     cascade_kill, cascade_workers = _terminate_coscheduled_siblings(
-                        cur, self._store.endpoints, siblings, update.task_id, job_resources, now_ms
+                        cur,
+                        self._store.attempts,
+                        self._store.tasks,
+                        self._store.workers,
+                        self._store.endpoints,
+                        siblings,
+                        update.task_id,
+                        job_resources,
+                        now_ms,
                     )
                     tasks_to_kill.update(cascade_kill)
                     task_kill_workers.update(cascade_workers)
@@ -3196,7 +2880,7 @@ class ControllerTransitions:
         Drained by drain_for_direct_provider().
         """
         with self._db.transaction() as cur:
-            enqueue_kill_dispatch(cur, None, task_id, Timestamp.now().epoch_ms())
+            self._store.dispatch.enqueue_kill(cur, None, JobName.from_wire(task_id), Timestamp.now().epoch_ms())
 
     # =========================================================================
     # Test helpers
@@ -3232,13 +2916,22 @@ class ControllerTransitions:
 
     def create_attempt_for_test(self, task_id: JobName, worker_id: WorkerId) -> int:
         """Test helper: append a new task_attempt without finalizing prior attempt."""
-        task = self._db.fetchone("SELECT current_attempt_id FROM tasks WHERE task_id = ?", (task_id.to_wire(),))
-        if task is None:
+        with self._store.read_snapshot() as snap:
+            current_attempt_id = self._store.tasks.get_current_attempt_id(snap, task_id)
+        if current_attempt_id is None:
             raise ValueError(f"unknown task: {task_id}")
-        worker_row = self._db.fetchone("SELECT address FROM workers WHERE worker_id = ?", (str(worker_id),))
-        worker_address = str(worker_row["address"]) if worker_row is not None else str(worker_id)
-        next_attempt_id = int(task["current_attempt_id"]) + 1
+        with self._store.read_snapshot() as snap:
+            worker_address = self._store.workers.address(snap, worker_id) or str(worker_id)
+        next_attempt_id = current_attempt_id + 1
         now_ms = Timestamp.now().epoch_ms()
         with self._db.transaction() as cur:
-            _assign_task(cur, task_id.to_wire(), str(worker_id), worker_address, next_attempt_id, now_ms)
+            self._store.tasks.assign(
+                cur,
+                self._store.attempts,
+                task_id,
+                worker_id,
+                worker_address,
+                next_attempt_id,
+                now_ms,
+            )
         return next_attempt_id

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -53,7 +53,6 @@ from iris.cluster.controller.stores import (
     WorkerUpsertParams,
 )
 from iris.cluster.controller.schema import (
-    JOB_CONFIG_JOIN,
     EndpointRow,
     JobDetailRow,
     WorkerDetailRow,
@@ -2322,64 +2321,43 @@ class ControllerTransitions:
             newly_promoted: set[str] = set()
             tasks_to_run: list[job_pb2.RunTaskRequest] = []
 
-            if max_promotions <= 0:
-                pending_rows = []
-            else:
-                pending_rows = cur.execute(
-                    "SELECT t.task_id, t.job_id, t.current_attempt_id, j.num_tasks, j.is_reservation_holder, "
-                    "jc.res_cpu_millicores, jc.res_memory_bytes, jc.res_disk_bytes, jc.res_device_json, "
-                    "jc.entrypoint_json, jc.environment_json, jc.bundle_id, jc.ports_json, "
-                    "jc.constraints_json, jc.task_image, jc.timeout_ms "
-                    f"FROM tasks t JOIN jobs j ON j.job_id = t.job_id {JOB_CONFIG_JOIN} "
-                    "WHERE t.state = ? AND j.is_reservation_holder = 0 "
-                    "LIMIT ?",
-                    (job_pb2.TASK_STATE_PENDING, max_promotions),
-                ).fetchall()
+            pending_rows = self._store.tasks.list_pending_for_direct_provider(cur, max_promotions)
 
             for row in pending_rows:
-                task_id = str(row["task_id"])
-                attempt_id = int(row["current_attempt_id"]) + 1
-                resources = resource_spec_from_scalars(
-                    int(row["res_cpu_millicores"]),
-                    int(row["res_memory_bytes"]),
-                    int(row["res_disk_bytes"]),
-                    row["res_device_json"],
-                )
+                attempt_id = row.current_attempt_id + 1
 
                 self._store.tasks.assign(
                     cur,
                     self._store.attempts,
-                    JobName.from_wire(task_id),
+                    row.task_id,
                     None,
                     None,
                     attempt_id,
                     now_ms,
                 )
 
-                entrypoint = proto_from_json(str(row["entrypoint_json"]), job_pb2.RuntimeEntrypoint)
+                entrypoint = proto_from_json(row.entrypoint_json, job_pb2.RuntimeEntrypoint)
                 # Load inline workdir files from the job_workdir_files table.
-                job_id = JobName.from_wire(str(row["job_id"]))
-                for filename, data in self._store.jobs.get_workdir_files(cur, job_id).items():
+                for filename, data in self._store.jobs.get_workdir_files(cur, row.job_id).items():
                     entrypoint.workdir_files[filename] = data
 
                 run_req = job_pb2.RunTaskRequest(
-                    task_id=task_id,
-                    num_tasks=int(row["num_tasks"]),
+                    task_id=row.task_id.to_wire(),
+                    num_tasks=row.num_tasks,
                     entrypoint=entrypoint,
-                    environment=proto_from_json(str(row["environment_json"]), job_pb2.EnvironmentConfig),
-                    bundle_id=str(row["bundle_id"]),
-                    resources=resources,
-                    ports=json.loads(str(row["ports_json"])),
+                    environment=proto_from_json(row.environment_json, job_pb2.EnvironmentConfig),
+                    bundle_id=row.bundle_id,
+                    resources=row.resources,
+                    ports=json.loads(row.ports_json),
                     attempt_id=attempt_id,
-                    constraints=[c.to_proto() for c in constraints_from_json(row["constraints_json"])],
-                    task_image=str(row["task_image"]),
+                    constraints=[c.to_proto() for c in constraints_from_json(row.constraints_json)],
+                    task_image=row.task_image,
                 )
                 # Propagate timeout for K8s activeDeadlineSeconds (Kubernetes-native enforcement).
-                timeout_ms = row["timeout_ms"]
-                if timeout_ms is not None and int(timeout_ms) > 0:
-                    run_req.timeout.milliseconds = int(timeout_ms)
+                if row.timeout_ms is not None and row.timeout_ms > 0:
+                    run_req.timeout.milliseconds = row.timeout_ms
                 tasks_to_run.append(run_req)
-                newly_promoted.add(task_id)
+                newly_promoted.add(row.task_id.to_wire())
 
             # Snapshot already-running tasks with NULL worker_id (excluding newly promoted).
             running_rows = self._store.tasks.list_active(

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -30,6 +30,7 @@ from iris.cluster.controller.db import (
     FAILURE_TASK_STATES,
     NON_TERMINAL_TASK_STATES,
     ControllerDB,
+    QuerySnapshot,
     TransactionCursor,
     task_row_can_be_scheduled,
     task_row_is_finished,
@@ -697,12 +698,18 @@ class ControllerTransitions:
         health: WorkerHealthTracker | None = None,
     ):
         self._store = store
-        # Escape hatch kept only while the phased migration moves SQL out of
-        # this file. Direct ``self._db`` calls should decrease every phase
-        # (jobs, tasks, attempts, workers, dispatch) and hit zero at the end;
-        # new code should go through ``self._store`` instead.
-        self._db: ControllerDB = store._db
         self._health = health or WorkerHealthTracker()
+
+    @property
+    def _db(self) -> "ControllerDB":
+        """Compatibility shim for tests that read directly via ``state._db``.
+
+        Production code in this module never touches ``_db``; it routes
+        through ``self._store`` (transactions, snapshots) or store
+        sub-objects. This property exists only so existing tests can continue
+        to call ``state._db.snapshot(...)`` for ad-hoc reads.
+        """
+        return self._store._db
 
     def _recompute_job_state(self, cur: TransactionCursor, job_id: JobName) -> int | None:
         basis = self._store.jobs.get_recompute_basis(cur, job_id)
@@ -746,13 +753,12 @@ class ControllerTransitions:
         self._store.jobs.apply_recomputed_state(cur, job_id, new_state, now_ms, error)
         return new_state
 
-    def replace_reservation_claims(self, claims: dict[WorkerId, ReservationClaim]) -> None:
-        """Replace all reservation claims atomically."""
-        with self._db.transaction() as cur:
-            self._store.reservations.replace_claims(
-                cur,
-                {worker_id: (claim.job_id, claim.entry_idx) for worker_id, claim in claims.items()},
-            )
+    def replace_reservation_claims(self, cur: TransactionCursor, claims: dict[WorkerId, ReservationClaim]) -> None:
+        """Replace all reservation claims."""
+        self._store.reservations.replace_claims(
+            cur,
+            {worker_id: (claim.job_id, claim.entry_idx) for worker_id, claim in claims.items()},
+        )
 
     # =========================================================================
     # Command API
@@ -760,309 +766,309 @@ class ControllerTransitions:
 
     def submit_job(
         self,
+        cur: TransactionCursor,
         job_id: JobName,
         request: controller_pb2.Controller.LaunchJobRequest,
         ts: Timestamp,
     ) -> SubmitJobResult:
-        """Submit a job and expand its tasks in one DB transaction."""
+        """Insert the job row and expand its tasks. Caller owns the transaction."""
         submitted_ms = ts.epoch_ms()
         created_task_ids: list[JobName] = []
 
-        with self._db.transaction() as cur:
-            effective_submission_ms = self._store.reservations.next_submission_ms(cur, submitted_ms)
+        effective_submission_ms = self._store.reservations.next_submission_ms(cur, submitted_ms)
 
-            parent_job_id = job_id.parent.to_wire() if job_id.parent is not None else None
-            root_submitted_ms = effective_submission_ms
-            if job_id.parent is not None:
-                # `launch_job` is responsible for rejecting submissions with a
-                # missing parent; if we reach here the parent row must exist.
-                parent_root = self._store.jobs.get_root_submitted_at_ms(cur, job_id.parent)
-                if parent_root is None:
-                    raise ValueError(f"Cannot submit job {job_id}: parent {parent_job_id} is absent from the database")
-                root_submitted_ms = parent_root
+        parent_job_id = job_id.parent.to_wire() if job_id.parent is not None else None
+        root_submitted_ms = effective_submission_ms
+        if job_id.parent is not None:
+            # `launch_job` is responsible for rejecting submissions with a
+            # missing parent; if we reach here the parent row must exist.
+            parent_root = self._store.jobs.get_root_submitted_at_ms(cur, job_id.parent)
+            if parent_root is None:
+                raise ValueError(f"Cannot submit job {job_id}: parent {parent_job_id} is absent from the database")
+            root_submitted_ms = parent_root
 
-            deadline_epoch_ms: int | None = None
-            if request.HasField("scheduling_timeout") and request.scheduling_timeout.milliseconds > 0:
-                deadline_epoch_ms = (
-                    Timestamp.from_ms(effective_submission_ms)
-                    .add(duration_from_proto(request.scheduling_timeout))
-                    .epoch_ms()
-                )
+        deadline_epoch_ms: int | None = None
+        if request.HasField("scheduling_timeout") and request.scheduling_timeout.milliseconds > 0:
+            deadline_epoch_ms = (
+                Timestamp.from_ms(effective_submission_ms)
+                .add(duration_from_proto(request.scheduling_timeout))
+                .epoch_ms()
+            )
 
-            self._store.jobs.ensure_user(cur, job_id.user, effective_submission_ms)
-            # No user_budgets row is created here: absence means "apply
-            # UserBudgetDefaults". Rows exist only for tier seeds from cluster
-            # config (see reconcile_user_budget_tiers) and admin overrides via
-            # set_user_budget.
+        self._store.jobs.ensure_user(cur, job_id.user, effective_submission_ms)
+        # No user_budgets row is created here: absence means "apply
+        # UserBudgetDefaults". Rows exist only for tier seeds from cluster
+        # config (see reconcile_user_budget_tiers) and admin overrides via
+        # set_user_budget.
 
-            # Resolve priority band: use explicit request value, inherit from parent, or default to INTERACTIVE.
-            requested_band = int(request.priority_band)
-            if requested_band != job_pb2.PRIORITY_BAND_UNSPECIFIED:
-                band_sort_key = requested_band
-            elif job_id.parent is not None:
-                parent_band = self._store.tasks.get_priority_band_for_job(cur, job_id.parent)
-                if parent_band is not None:
-                    band_sort_key = parent_band
-                else:
-                    band_sort_key = job_pb2.PRIORITY_BAND_INTERACTIVE
+        # Resolve priority band: use explicit request value, inherit from parent, or default to INTERACTIVE.
+        requested_band = int(request.priority_band)
+        if requested_band != job_pb2.PRIORITY_BAND_UNSPECIFIED:
+            band_sort_key = requested_band
+        elif job_id.parent is not None:
+            parent_band = self._store.tasks.get_priority_band_for_job(cur, job_id.parent)
+            if parent_band is not None:
+                band_sort_key = parent_band
             else:
                 band_sort_key = job_pb2.PRIORITY_BAND_INTERACTIVE
+        else:
+            band_sort_key = job_pb2.PRIORITY_BAND_INTERACTIVE
 
-            replicas = int(request.replicas)
-            validation_error: str | None = None
-            if replicas < 1:
-                validation_error = f"Job {job_id} has invalid replicas={replicas}; must be >= 1"
-                replicas = 0
-            elif replicas > MAX_REPLICAS_PER_JOB:
-                validation_error = f"Job {job_id} replicas={replicas} exceeds max {MAX_REPLICAS_PER_JOB}"
-                replicas = 0
+        replicas = int(request.replicas)
+        validation_error: str | None = None
+        if replicas < 1:
+            validation_error = f"Job {job_id} has invalid replicas={replicas}; must be >= 1"
+            replicas = 0
+        elif replicas > MAX_REPLICAS_PER_JOB:
+            validation_error = f"Job {job_id} replicas={replicas} exceeds max {MAX_REPLICAS_PER_JOB}"
+            replicas = 0
 
-            state = job_pb2.JOB_STATE_PENDING if validation_error is None else job_pb2.JOB_STATE_FAILED
-            finished_ms = None if validation_error is None else effective_submission_ms
-            has_reservation = _has_reservation_flag(request)
+        state = job_pb2.JOB_STATE_PENDING if validation_error is None else job_pb2.JOB_STATE_FAILED
+        finished_ms = None if validation_error is None else effective_submission_ms
+        has_reservation = _has_reservation_flag(request)
 
-            # Scheduling fields extracted from request proto.
-            res = request.resources if request.HasField("resources") else None
-            res_cpu = int(res.cpu_millicores) if res else 0
-            res_mem = int(res.memory_bytes) if res else 0
-            res_disk = int(res.disk_bytes) if res else 0
-            res_device = proto_to_json(res.device) if res else None
-            constraints_json = constraints_to_json(request.constraints)
-            has_cosched = 1 if request.HasField("coscheduling") else 0
-            cosched_group = request.coscheduling.group_by if has_cosched else ""
-            sched_timeout: int | None = (
-                int(request.scheduling_timeout.milliseconds)
-                if request.HasField("scheduling_timeout") and request.scheduling_timeout.milliseconds > 0
-                else None
-            )
-            max_failures = int(request.max_task_failures)
-            # Serialize dispatch config fields for job_config.
-            entrypoint_json = entrypoint_to_json(request.entrypoint)
-            environment_json = proto_to_json(request.environment)
-            ports_json = json.dumps(list(request.ports)) if request.ports else "[]"
-            reservation_json = reservation_to_json(request)
-            timeout_ms: int | None = int(request.timeout.milliseconds) if request.timeout.milliseconds > 0 else None
+        # Scheduling fields extracted from request proto.
+        res = request.resources if request.HasField("resources") else None
+        res_cpu = int(res.cpu_millicores) if res else 0
+        res_mem = int(res.memory_bytes) if res else 0
+        res_disk = int(res.disk_bytes) if res else 0
+        res_device = proto_to_json(res.device) if res else None
+        constraints_json = constraints_to_json(request.constraints)
+        has_cosched = 1 if request.HasField("coscheduling") else 0
+        cosched_group = request.coscheduling.group_by if has_cosched else ""
+        sched_timeout: int | None = (
+            int(request.scheduling_timeout.milliseconds)
+            if request.HasField("scheduling_timeout") and request.scheduling_timeout.milliseconds > 0
+            else None
+        )
+        max_failures = int(request.max_task_failures)
+        # Serialize dispatch config fields for job_config.
+        entrypoint_json = entrypoint_to_json(request.entrypoint)
+        environment_json = proto_to_json(request.environment)
+        ports_json = json.dumps(list(request.ports)) if request.ports else "[]"
+        reservation_json = reservation_to_json(request)
+        timeout_ms: int | None = int(request.timeout.milliseconds) if request.timeout.milliseconds > 0 else None
 
-            job_name_lower = request.name.lower()
-            self._store.jobs.insert(
-                cur,
-                JobInsertParams(
-                    job_id=job_id,
-                    user_id=job_id.user,
-                    parent_job_id=parent_job_id,
-                    root_job_id=job_id.root_job.to_wire(),
-                    depth=job_id.depth,
-                    state=state,
-                    submitted_at_ms=effective_submission_ms,
-                    root_submitted_at_ms=root_submitted_ms,
-                    started_at_ms=None,
-                    finished_at_ms=finished_ms,
-                    scheduling_deadline_epoch_ms=deadline_epoch_ms,
-                    error=validation_error,
-                    exit_code=None,
-                    num_tasks=replicas,
-                    is_reservation_holder=False,
-                    name=job_name_lower,
-                    has_reservation=bool(has_reservation),
-                ),
-            )
-            self._store.jobs.insert_config(
-                cur,
-                JobConfigInsertParams(
-                    job_id=job_id,
-                    name=job_name_lower,
-                    has_reservation=bool(has_reservation),
-                    res_cpu_millicores=res_cpu,
-                    res_memory_bytes=res_mem,
-                    res_disk_bytes=res_disk,
-                    res_device_json=res_device,
-                    constraints_json=constraints_json,
-                    has_coscheduling=bool(has_cosched),
-                    coscheduling_group_by=cosched_group,
-                    scheduling_timeout_ms=sched_timeout,
-                    max_task_failures=max_failures,
-                    entrypoint_json=entrypoint_json,
-                    environment_json=environment_json,
-                    bundle_id=request.bundle_id,
-                    ports_json=ports_json,
-                    max_retries_failure=int(request.max_retries_failure),
-                    max_retries_preemption=int(request.max_retries_preemption),
-                    timeout_ms=timeout_ms,
-                    preemption_policy=int(request.preemption_policy),
-                    existing_job_policy=int(request.existing_job_policy),
-                    priority_band=int(request.priority_band),
-                    task_image=request.task_image,
-                    submit_argv_json=json.dumps(list(request.submit_argv)),
-                    reservation_json=reservation_json,
-                    fail_if_exists=bool(request.fail_if_exists),
-                ),
-            )
+        job_name_lower = request.name.lower()
+        self._store.jobs.insert(
+            cur,
+            JobInsertParams(
+                job_id=job_id,
+                user_id=job_id.user,
+                parent_job_id=parent_job_id,
+                root_job_id=job_id.root_job.to_wire(),
+                depth=job_id.depth,
+                state=state,
+                submitted_at_ms=effective_submission_ms,
+                root_submitted_at_ms=root_submitted_ms,
+                started_at_ms=None,
+                finished_at_ms=finished_ms,
+                scheduling_deadline_epoch_ms=deadline_epoch_ms,
+                error=validation_error,
+                exit_code=None,
+                num_tasks=replicas,
+                is_reservation_holder=False,
+                name=job_name_lower,
+                has_reservation=bool(has_reservation),
+            ),
+        )
+        self._store.jobs.insert_config(
+            cur,
+            JobConfigInsertParams(
+                job_id=job_id,
+                name=job_name_lower,
+                has_reservation=bool(has_reservation),
+                res_cpu_millicores=res_cpu,
+                res_memory_bytes=res_mem,
+                res_disk_bytes=res_disk,
+                res_device_json=res_device,
+                constraints_json=constraints_json,
+                has_coscheduling=bool(has_cosched),
+                coscheduling_group_by=cosched_group,
+                scheduling_timeout_ms=sched_timeout,
+                max_task_failures=max_failures,
+                entrypoint_json=entrypoint_json,
+                environment_json=environment_json,
+                bundle_id=request.bundle_id,
+                ports_json=ports_json,
+                max_retries_failure=int(request.max_retries_failure),
+                max_retries_preemption=int(request.max_retries_preemption),
+                timeout_ms=timeout_ms,
+                preemption_policy=int(request.preemption_policy),
+                existing_job_policy=int(request.existing_job_policy),
+                priority_band=int(request.priority_band),
+                task_image=request.task_image,
+                submit_argv_json=json.dumps(list(request.submit_argv)),
+                reservation_json=reservation_json,
+                fail_if_exists=bool(request.fail_if_exists),
+            ),
+        )
 
-            # Store workdir files in separate table.
-            self._store.jobs.insert_workdir_files(cur, job_id, dict(request.entrypoint.workdir_files))
+        # Store workdir files in separate table.
+        self._store.jobs.insert_workdir_files(cur, job_id, dict(request.entrypoint.workdir_files))
 
-            if validation_error is None:
-                insertion_base = self._store.jobs.reserve_priority_insertion_base(cur)
-                for idx in range(replicas):
-                    task_id = job_id.task(idx).to_wire()
-                    created_task_ids.append(JobName.from_wire(task_id))
+        if validation_error is None:
+            insertion_base = self._store.jobs.reserve_priority_insertion_base(cur)
+            for idx in range(replicas):
+                task_id = job_id.task(idx).to_wire()
+                created_task_ids.append(JobName.from_wire(task_id))
+                self._store.tasks.insert(
+                    cur,
+                    TaskInsertParams(
+                        task_id=JobName.from_wire(task_id),
+                        job_id=job_id,
+                        task_index=idx,
+                        state=job_pb2.TASK_STATE_PENDING,
+                        submitted_at_ms=effective_submission_ms,
+                        max_retries_failure=int(request.max_retries_failure),
+                        max_retries_preemption=int(request.max_retries_preemption),
+                        priority_neg_depth=-job_id.depth,
+                        priority_root_submitted_ms=root_submitted_ms,
+                        priority_insertion=insertion_base + idx,
+                        priority_band=band_sort_key,
+                    ),
+                )
+            if request.HasField("reservation") and request.reservation.entries:
+                holder_id = job_id.child(RESERVATION_HOLDER_JOB_NAME)
+                entry = request.reservation.entries[0]
+                holder_request = controller_pb2.Controller.LaunchJobRequest(
+                    name=holder_id.to_wire(),
+                    entrypoint=request.entrypoint,
+                    resources=entry.resources,
+                    environment=request.environment,
+                    replicas=len(request.reservation.entries),
+                    max_retries_preemption=DEFAULT_MAX_RETRIES_PREEMPTION,
+                )
+                merged = merge_constraints(
+                    constraints_from_resources(entry.resources),
+                    [Constraint.from_proto(c) for c in entry.constraints or request.constraints],
+                )
+                for constraint in merged:
+                    holder_request.constraints.append(constraint.to_proto())
+                holder_res = holder_request.resources if holder_request.HasField("resources") else None
+                holder_res_cpu = int(holder_res.cpu_millicores) if holder_res else 0
+                holder_res_mem = int(holder_res.memory_bytes) if holder_res else 0
+                holder_res_disk = int(holder_res.disk_bytes) if holder_res else 0
+                holder_res_device = proto_to_json(holder_res.device) if holder_res else None
+                holder_constraints_json = constraints_to_json(holder_request.constraints)
+                holder_name_lower = holder_request.name.lower()
+                self._store.jobs.insert(
+                    cur,
+                    JobInsertParams(
+                        job_id=holder_id,
+                        user_id=holder_id.user,
+                        parent_job_id=job_id.to_wire(),
+                        root_job_id=holder_id.root_job.to_wire(),
+                        depth=holder_id.depth,
+                        state=job_pb2.JOB_STATE_PENDING,
+                        submitted_at_ms=effective_submission_ms,
+                        root_submitted_at_ms=root_submitted_ms,
+                        started_at_ms=None,
+                        finished_at_ms=None,
+                        scheduling_deadline_epoch_ms=None,
+                        error=None,
+                        exit_code=None,
+                        num_tasks=len(request.reservation.entries),
+                        is_reservation_holder=True,
+                        name=holder_name_lower,
+                        has_reservation=False,
+                    ),
+                )
+                holder_entrypoint_json = entrypoint_to_json(holder_request.entrypoint)
+                holder_environment_json = proto_to_json(holder_request.environment)
+                self._store.jobs.insert_config(
+                    cur,
+                    JobConfigInsertParams(
+                        job_id=holder_id,
+                        name=holder_name_lower,
+                        has_reservation=False,
+                        res_cpu_millicores=holder_res_cpu,
+                        res_memory_bytes=holder_res_mem,
+                        res_disk_bytes=holder_res_disk,
+                        res_device_json=holder_res_device,
+                        constraints_json=holder_constraints_json,
+                        has_coscheduling=False,
+                        coscheduling_group_by="",
+                        scheduling_timeout_ms=None,
+                        max_task_failures=0,
+                        entrypoint_json=holder_entrypoint_json,
+                        environment_json=holder_environment_json,
+                        bundle_id="",
+                        ports_json="[]",
+                        max_retries_failure=0,
+                        max_retries_preemption=DEFAULT_MAX_RETRIES_PREEMPTION,
+                        timeout_ms=None,
+                        preemption_policy=0,
+                        existing_job_policy=0,
+                        priority_band=0,
+                        task_image="",
+                    ),
+                )
+                holder_base = self._store.jobs.reserve_priority_insertion_base(cur)
+                for idx in range(len(request.reservation.entries)):
+                    created_task_ids.append(holder_id.task(idx))
                     self._store.tasks.insert(
                         cur,
                         TaskInsertParams(
-                            task_id=JobName.from_wire(task_id),
-                            job_id=job_id,
+                            task_id=holder_id.task(idx),
+                            job_id=holder_id,
                             task_index=idx,
                             state=job_pb2.TASK_STATE_PENDING,
                             submitted_at_ms=effective_submission_ms,
-                            max_retries_failure=int(request.max_retries_failure),
-                            max_retries_preemption=int(request.max_retries_preemption),
-                            priority_neg_depth=-job_id.depth,
+                            max_retries_failure=0,
+                            max_retries_preemption=DEFAULT_MAX_RETRIES_PREEMPTION,
+                            priority_neg_depth=-holder_id.depth,
                             priority_root_submitted_ms=root_submitted_ms,
-                            priority_insertion=insertion_base + idx,
+                            priority_insertion=holder_base + idx,
                             priority_band=band_sort_key,
                         ),
                     )
-                if request.HasField("reservation") and request.reservation.entries:
-                    holder_id = job_id.child(RESERVATION_HOLDER_JOB_NAME)
-                    entry = request.reservation.entries[0]
-                    holder_request = controller_pb2.Controller.LaunchJobRequest(
-                        name=holder_id.to_wire(),
-                        entrypoint=request.entrypoint,
-                        resources=entry.resources,
-                        environment=request.environment,
-                        replicas=len(request.reservation.entries),
-                        max_retries_preemption=DEFAULT_MAX_RETRIES_PREEMPTION,
-                    )
-                    merged = merge_constraints(
-                        constraints_from_resources(entry.resources),
-                        [Constraint.from_proto(c) for c in entry.constraints or request.constraints],
-                    )
-                    for constraint in merged:
-                        holder_request.constraints.append(constraint.to_proto())
-                    holder_res = holder_request.resources if holder_request.HasField("resources") else None
-                    holder_res_cpu = int(holder_res.cpu_millicores) if holder_res else 0
-                    holder_res_mem = int(holder_res.memory_bytes) if holder_res else 0
-                    holder_res_disk = int(holder_res.disk_bytes) if holder_res else 0
-                    holder_res_device = proto_to_json(holder_res.device) if holder_res else None
-                    holder_constraints_json = constraints_to_json(holder_request.constraints)
-                    holder_name_lower = holder_request.name.lower()
-                    self._store.jobs.insert(
-                        cur,
-                        JobInsertParams(
-                            job_id=holder_id,
-                            user_id=holder_id.user,
-                            parent_job_id=job_id.to_wire(),
-                            root_job_id=holder_id.root_job.to_wire(),
-                            depth=holder_id.depth,
-                            state=job_pb2.JOB_STATE_PENDING,
-                            submitted_at_ms=effective_submission_ms,
-                            root_submitted_at_ms=root_submitted_ms,
-                            started_at_ms=None,
-                            finished_at_ms=None,
-                            scheduling_deadline_epoch_ms=None,
-                            error=None,
-                            exit_code=None,
-                            num_tasks=len(request.reservation.entries),
-                            is_reservation_holder=True,
-                            name=holder_name_lower,
-                            has_reservation=False,
-                        ),
-                    )
-                    holder_entrypoint_json = entrypoint_to_json(holder_request.entrypoint)
-                    holder_environment_json = proto_to_json(holder_request.environment)
-                    self._store.jobs.insert_config(
-                        cur,
-                        JobConfigInsertParams(
-                            job_id=holder_id,
-                            name=holder_name_lower,
-                            has_reservation=False,
-                            res_cpu_millicores=holder_res_cpu,
-                            res_memory_bytes=holder_res_mem,
-                            res_disk_bytes=holder_res_disk,
-                            res_device_json=holder_res_device,
-                            constraints_json=holder_constraints_json,
-                            has_coscheduling=False,
-                            coscheduling_group_by="",
-                            scheduling_timeout_ms=None,
-                            max_task_failures=0,
-                            entrypoint_json=holder_entrypoint_json,
-                            environment_json=holder_environment_json,
-                            bundle_id="",
-                            ports_json="[]",
-                            max_retries_failure=0,
-                            max_retries_preemption=DEFAULT_MAX_RETRIES_PREEMPTION,
-                            timeout_ms=None,
-                            preemption_policy=0,
-                            existing_job_policy=0,
-                            priority_band=0,
-                            task_image="",
-                        ),
-                    )
-                    holder_base = self._store.jobs.reserve_priority_insertion_base(cur)
-                    for idx in range(len(request.reservation.entries)):
-                        created_task_ids.append(holder_id.task(idx))
-                        self._store.tasks.insert(
-                            cur,
-                            TaskInsertParams(
-                                task_id=holder_id.task(idx),
-                                job_id=holder_id,
-                                task_index=idx,
-                                state=job_pb2.TASK_STATE_PENDING,
-                                submitted_at_ms=effective_submission_ms,
-                                max_retries_failure=0,
-                                max_retries_preemption=DEFAULT_MAX_RETRIES_PREEMPTION,
-                                priority_neg_depth=-holder_id.depth,
-                                priority_root_submitted_ms=root_submitted_ms,
-                                priority_insertion=holder_base + idx,
-                                priority_band=band_sort_key,
-                            ),
-                        )
 
         log_event("job_submitted", job_id.to_wire(), num_tasks=replicas, error=validation_error)
         return SubmitJobResult(job_id=job_id, task_ids=created_task_ids)
 
-    def cancel_job(self, job_id: JobName, reason: str) -> TxResult:
-        """Cancel a job tree and return tasks that need kill RPCs."""
-        with self._db.transaction() as cur:
-            subtree = self._store.jobs.list_subtree(cur, job_id)
-            if not subtree:
-                return TxResult()
-            running_rows = self._store.tasks.list_active(
-                cur,
-                TaskScope(job_subtree=subtree),
-                states=ACTIVE_TASK_STATES,
-            )
-            tasks_to_kill = {row.task_id for row in running_rows}
-            task_kill_workers = {
-                row.task_id: row.current_worker_id for row in running_rows if row.current_worker_id is not None
-            }
-            # Decommit resources for each active task on its assigned worker.
-            # cancel_job marks tasks as KILLED, but apply_heartbeat skips
-            # already-finished tasks (is_finished() check), so the normal
-            # heartbeat decommit path never fires for cancelled tasks.
-            # Direct-provider tasks have NULL worker_id — skip decommit for them.
-            for row in running_rows:
-                if row.current_worker_id is not None and not row.is_reservation_holder:
-                    self._store.workers.decommit_resources(cur, row.current_worker_id, row.resources)
-            now_ms = Timestamp.now().epoch_ms()
-            self._store.tasks.bulk_kill_non_terminal(cur, subtree, reason, now_ms, TERMINAL_TASK_STATES)
-            # Deliberately excludes JOB_STATE_WORKER_FAILED from the guard set:
-            # worker-failed jobs should still be cancellable (transitioned to KILLED).
-            cancel_guard_states = TERMINAL_JOB_STATES - {job_pb2.JOB_STATE_WORKER_FAILED}
-            self._store.jobs.bulk_update_state(
-                cur,
-                subtree,
-                job_pb2.JOB_STATE_KILLED,
-                reason,
-                now_ms,
-                cancel_guard_states,
-            )
-            self._store.endpoints.remove_by_job_ids(cur, subtree)
+    def cancel_job(self, cur: TransactionCursor, job_id: JobName, reason: str) -> TxResult:
+        """Cancel a job tree and return tasks that need kill RPCs. Caller owns the transaction."""
+        subtree = self._store.jobs.list_subtree(cur, job_id)
+        if not subtree:
+            return TxResult()
+        running_rows = self._store.tasks.list_active(
+            cur,
+            TaskScope(job_subtree=subtree),
+            states=ACTIVE_TASK_STATES,
+        )
+        tasks_to_kill = {row.task_id for row in running_rows}
+        task_kill_workers = {
+            row.task_id: row.current_worker_id for row in running_rows if row.current_worker_id is not None
+        }
+        # Decommit resources for each active task on its assigned worker.
+        # cancel_job marks tasks as KILLED, but apply_heartbeat skips
+        # already-finished tasks (is_finished() check), so the normal
+        # heartbeat decommit path never fires for cancelled tasks.
+        # Direct-provider tasks have NULL worker_id — skip decommit for them.
+        for row in running_rows:
+            if row.current_worker_id is not None and not row.is_reservation_holder:
+                self._store.workers.decommit_resources(cur, row.current_worker_id, row.resources)
+        now_ms = Timestamp.now().epoch_ms()
+        self._store.tasks.bulk_kill_non_terminal(cur, subtree, reason, now_ms, TERMINAL_TASK_STATES)
+        # Deliberately excludes JOB_STATE_WORKER_FAILED from the guard set:
+        # worker-failed jobs should still be cancellable (transitioned to KILLED).
+        cancel_guard_states = TERMINAL_JOB_STATES - {job_pb2.JOB_STATE_WORKER_FAILED}
+        self._store.jobs.bulk_update_state(
+            cur,
+            subtree,
+            job_pb2.JOB_STATE_KILLED,
+            reason,
+            now_ms,
+            cancel_guard_states,
+        )
+        self._store.endpoints.remove_by_job_ids(cur, subtree)
         log_event("job_cancelled", job_id.to_wire(), reason=reason)
         return TxResult(tasks_to_kill=tasks_to_kill, task_kill_workers=task_kill_workers)
 
     def register_or_refresh_worker(
         self,
+        cur: TransactionCursor,
         worker_id: WorkerId,
         address: str,
         metadata: job_pb2.WorkerMetadata,
@@ -1070,7 +1076,12 @@ class ControllerTransitions:
         slice_id: str = "",
         scale_group: str = "",
     ) -> TxResult:
-        """Register a new worker or refresh an existing one."""
+        """Register a new worker or refresh an existing one. Caller owns the transaction.
+
+        Returns the attribute dict that the caller should pass to
+        ``store.workers.update_attr_cache(worker_id, attrs)`` AFTER commit
+        so the in-memory scheduling cache stays in sync.
+        """
         attrs: list[WorkerAttributeParams] = []
         for key, proto in metadata.attributes.items():
             value = AttributeValue.from_proto(proto).value
@@ -1092,42 +1103,41 @@ class ControllerTransitions:
         else:
             device_type = ""
             device_variant = ""
-        with self._db.transaction() as cur:
-            self._store.workers.upsert(
-                cur,
-                WorkerUpsertParams(
-                    worker_id=worker_id,
-                    address=address,
-                    last_heartbeat_ms=now_ms,
-                    total_cpu_millicores=metadata.cpu_count * 1000,
-                    total_memory_bytes=metadata.memory_bytes,
-                    total_gpu_count=gpu_count,
-                    total_tpu_count=tpu_count,
-                    device_type=device_type,
-                    device_variant=device_variant,
-                    slice_id=slice_id,
-                    scale_group=scale_group,
-                    md_hostname=metadata.hostname,
-                    md_ip_address=metadata.ip_address,
-                    md_cpu_count=metadata.cpu_count,
-                    md_memory_bytes=metadata.memory_bytes,
-                    md_disk_bytes=metadata.disk_bytes,
-                    md_tpu_name=metadata.tpu_name,
-                    md_tpu_worker_hostnames=metadata.tpu_worker_hostnames,
-                    md_tpu_worker_id=metadata.tpu_worker_id,
-                    md_tpu_chips_per_host_bounds=metadata.tpu_chips_per_host_bounds,
-                    md_gpu_count=metadata.gpu_count,
-                    md_gpu_name=metadata.gpu_name,
-                    md_gpu_memory_mb=metadata.gpu_memory_mb,
-                    md_gce_instance_name=metadata.gce_instance_name,
-                    md_gce_zone=metadata.gce_zone,
-                    md_git_hash=metadata.git_hash,
-                    md_device_json=proto_to_json(metadata.device),
-                ),
-            )
-            self._store.workers.replace_attributes(cur, worker_id, attrs)
-        log_event("worker_registered", str(worker_id), address=address)
-        # Update in-memory attribute cache so scheduling sees the new worker immediately.
+        self._store.workers.upsert(
+            cur,
+            WorkerUpsertParams(
+                worker_id=worker_id,
+                address=address,
+                last_heartbeat_ms=now_ms,
+                total_cpu_millicores=metadata.cpu_count * 1000,
+                total_memory_bytes=metadata.memory_bytes,
+                total_gpu_count=gpu_count,
+                total_tpu_count=tpu_count,
+                device_type=device_type,
+                device_variant=device_variant,
+                slice_id=slice_id,
+                scale_group=scale_group,
+                md_hostname=metadata.hostname,
+                md_ip_address=metadata.ip_address,
+                md_cpu_count=metadata.cpu_count,
+                md_memory_bytes=metadata.memory_bytes,
+                md_disk_bytes=metadata.disk_bytes,
+                md_tpu_name=metadata.tpu_name,
+                md_tpu_worker_hostnames=metadata.tpu_worker_hostnames,
+                md_tpu_worker_id=metadata.tpu_worker_id,
+                md_tpu_chips_per_host_bounds=metadata.tpu_chips_per_host_bounds,
+                md_gpu_count=metadata.gpu_count,
+                md_gpu_name=metadata.gpu_name,
+                md_gpu_memory_mb=metadata.gpu_memory_mb,
+                md_gce_instance_name=metadata.gce_instance_name,
+                md_gce_zone=metadata.gce_zone,
+                md_git_hash=metadata.git_hash,
+                md_device_json=proto_to_json(metadata.device),
+            ),
+        )
+        self._store.workers.replace_attributes(cur, worker_id, attrs)
+        # Update in-memory attribute cache only after commit so a rolled-back tx
+        # doesn't leave the scheduling cache ahead of the durable row.
         attr_dict: dict[str, AttributeValue] = {}
         for attr in attrs:
             if attr.value_type == "int":
@@ -1136,11 +1146,13 @@ class ControllerTransitions:
                 attr_dict[attr.key] = AttributeValue(float(attr.float_value))
             else:
                 attr_dict[attr.key] = AttributeValue(str(attr.str_value or ""))
-        self._store.workers.update_attr_cache(worker_id, attr_dict)
+        cur.on_commit(lambda: self._store.workers.update_attr_cache(worker_id, attr_dict))
+        cur.on_commit(lambda: log_event("worker_registered", str(worker_id), address=address))
         return TxResult()
 
     def register_worker(
         self,
+        cur: TransactionCursor,
         worker_id: WorkerId,
         address: str,
         metadata: job_pb2.WorkerMetadata,
@@ -1149,6 +1161,7 @@ class ControllerTransitions:
         scale_group: str = "",
     ) -> WorkerRegistrationResult:
         self.register_or_refresh_worker(
+            cur,
             worker_id=worker_id,
             address=address,
             metadata=metadata,
@@ -1158,7 +1171,13 @@ class ControllerTransitions:
         )
         return WorkerRegistrationResult(worker_id=worker_id)
 
-    def queue_assignments(self, assignments: list[Assignment], *, direct_dispatch: bool = False) -> AssignmentResult:
+    def queue_assignments(
+        self,
+        cur: TransactionCursor,
+        assignments: list[Assignment],
+        *,
+        direct_dispatch: bool = False,
+    ) -> AssignmentResult:
         """Commit assignments and enqueue dispatches in one transaction.
 
         When direct_dispatch=True, collects (worker_id, address, RunTaskRequest)
@@ -1169,73 +1188,70 @@ class ControllerTransitions:
         rejected: list[Assignment] = []
         start_requests: list[tuple[WorkerId, str, job_pb2.RunTaskRequest]] = []
         has_real_dispatch = False
-        with self._db.transaction() as cur:
-            now_ms = Timestamp.now().epoch_ms()
-            job_cache: dict[str, JobDetailRow] = {}
-            jobs_to_update: set[str] = set()
-            for assignment in assignments:
-                task = self._store.tasks.get_detail(cur, assignment.task_id)
-                worker_address = self._store.workers.active_healthy_address(cur, assignment.worker_id)
-                if task is None or worker_address is None:
+        now_ms = Timestamp.now().epoch_ms()
+        job_cache: dict[str, JobDetailRow] = {}
+        jobs_to_update: set[str] = set()
+        for assignment in assignments:
+            task = self._store.tasks.get_detail(cur, assignment.task_id)
+            worker_address = self._store.workers.active_healthy_address(cur, assignment.worker_id)
+            if task is None or worker_address is None:
+                rejected.append(assignment)
+                continue
+            if not task_row_can_be_scheduled(task):
+                rejected.append(assignment)
+                continue
+            job_id_wire = task.job_id.to_wire()
+            if job_id_wire not in job_cache:
+                decoded_job = self._store.jobs.get_detail(cur, task.job_id)
+                if decoded_job is None:
                     rejected.append(assignment)
                     continue
-                if not task_row_can_be_scheduled(task):
-                    rejected.append(assignment)
-                    continue
-                job_id_wire = task.job_id.to_wire()
-                if job_id_wire not in job_cache:
-                    decoded_job = self._store.jobs.get_detail(cur, task.job_id)
-                    if decoded_job is None:
-                        rejected.append(assignment)
-                        continue
-                    job_cache[job_id_wire] = decoded_job
-                job = job_cache[job_id_wire]
-                attempt_id = task.current_attempt_id + 1
-                self._store.tasks.assign(
-                    cur,
-                    self._store.attempts,
-                    assignment.task_id,
-                    assignment.worker_id,
-                    worker_address,
-                    attempt_id,
-                    now_ms,
+                job_cache[job_id_wire] = decoded_job
+            job = job_cache[job_id_wire]
+            attempt_id = task.current_attempt_id + 1
+            self._store.tasks.assign(
+                cur,
+                self._store.attempts,
+                assignment.task_id,
+                assignment.worker_id,
+                worker_address,
+                attempt_id,
+                now_ms,
+            )
+            if not job.is_reservation_holder:
+                resources = resource_spec_from_scalars(
+                    job.res_cpu_millicores,
+                    job.res_memory_bytes,
+                    job.res_disk_bytes,
+                    job.res_device_json,
                 )
-                if not job.is_reservation_holder:
-                    resources = resource_spec_from_scalars(
-                        job.res_cpu_millicores,
-                        job.res_memory_bytes,
-                        job.res_disk_bytes,
-                        job.res_device_json,
-                    )
-                    self._store.workers.add_committed_resources(cur, assignment.worker_id, resources)
-                    entrypoint = proto_from_json(job.entrypoint_json, job_pb2.RuntimeEntrypoint)
-                    # Load inline workdir files from the job_workdir_files table.
-                    for filename, data in self._store.jobs.get_workdir_files(cur, task.job_id).items():
-                        entrypoint.workdir_files[filename] = data
-                    run_request = job_pb2.RunTaskRequest(
-                        task_id=assignment.task_id.to_wire(),
-                        num_tasks=job.num_tasks,
-                        entrypoint=entrypoint,
-                        environment=proto_from_json(job.environment_json, job_pb2.EnvironmentConfig),
-                        bundle_id=job.bundle_id,
-                        resources=resources,
-                        ports=json.loads(job.ports_json),
-                        attempt_id=attempt_id,
-                        constraints=[c.to_proto() for c in constraints_from_json(job.constraints_json)],
-                        task_image=job.task_image,
-                    )
-                    if direct_dispatch:
-                        start_requests.append((assignment.worker_id, worker_address, run_request))
-                    else:
-                        self._store.dispatch.enqueue_run(
-                            cur, assignment.worker_id, run_request.SerializeToString(), now_ms
-                        )
-                    has_real_dispatch = True
-                self._store.workers.record_task_assignment(cur, assignment.worker_id, assignment.task_id, now_ms)
-                jobs_to_update.add(job_id_wire)
-                accepted.append(assignment)
-            for job_id_wire in jobs_to_update:
-                self._store.jobs.mark_running_if_pending(cur, JobName.from_wire(job_id_wire), now_ms)
+                self._store.workers.add_committed_resources(cur, assignment.worker_id, resources)
+                entrypoint = proto_from_json(job.entrypoint_json, job_pb2.RuntimeEntrypoint)
+                # Load inline workdir files from the job_workdir_files table.
+                for filename, data in self._store.jobs.get_workdir_files(cur, task.job_id).items():
+                    entrypoint.workdir_files[filename] = data
+                run_request = job_pb2.RunTaskRequest(
+                    task_id=assignment.task_id.to_wire(),
+                    num_tasks=job.num_tasks,
+                    entrypoint=entrypoint,
+                    environment=proto_from_json(job.environment_json, job_pb2.EnvironmentConfig),
+                    bundle_id=job.bundle_id,
+                    resources=resources,
+                    ports=json.loads(job.ports_json),
+                    attempt_id=attempt_id,
+                    constraints=[c.to_proto() for c in constraints_from_json(job.constraints_json)],
+                    task_image=job.task_image,
+                )
+                if direct_dispatch:
+                    start_requests.append((assignment.worker_id, worker_address, run_request))
+                else:
+                    self._store.dispatch.enqueue_run(cur, assignment.worker_id, run_request.SerializeToString(), now_ms)
+                has_real_dispatch = True
+            self._store.workers.record_task_assignment(cur, assignment.worker_id, assignment.task_id, now_ms)
+            jobs_to_update.add(job_id_wire)
+            accepted.append(assignment)
+        for job_id_wire in jobs_to_update:
+            self._store.jobs.mark_running_if_pending(cur, JobName.from_wire(job_id_wire), now_ms)
         for a in accepted:
             log_event("assignment_queued", a.task_id.to_wire(), worker=str(a.worker_id))
         return AssignmentResult(
@@ -1502,17 +1518,16 @@ class ControllerTransitions:
             task_kill_workers=task_kill_workers,
         )
 
-    def apply_task_updates(self, req: HeartbeatApplyRequest) -> TxResult:
-        """Apply a batch of worker task updates atomically."""
-        with self._db.transaction() as cur:
-            now_ms = Timestamp.now().epoch_ms()
-            if not self._update_worker_health(cur, req, now_ms):
-                return TxResult()
-            result = self._apply_task_transitions(cur, req, now_ms)
+    def apply_task_updates(self, cur: TransactionCursor, req: HeartbeatApplyRequest) -> TxResult:
+        """Apply a batch of worker task updates within the caller's transaction."""
+        now_ms = Timestamp.now().epoch_ms()
+        if not self._update_worker_health(cur, req, now_ms):
+            return TxResult()
+        result = self._apply_task_transitions(cur, req, now_ms)
 
         return result
 
-    def apply_heartbeats_batch(self, requests: list[HeartbeatApplyRequest]) -> list[TxResult]:
+    def apply_heartbeats_batch(self, cur: TransactionCursor, requests: list[HeartbeatApplyRequest]) -> list[TxResult]:
         """Apply multiple heartbeats in a single transaction.
 
         Two-pass architecture to minimise SQL round-trips:
@@ -1528,96 +1543,95 @@ class ControllerTransitions:
         _empty = TxResult(tasks_to_kill=set())
         results: list[TxResult] = [_empty] * len(requests)
 
-        with self._db.transaction() as cur:
-            now_ms = Timestamp.now().epoch_ms()
+        now_ms = Timestamp.now().epoch_ms()
 
-            # ── Batch worker health updates ───────────────────────────────
-            existing_workers = self._store.workers.filter_existing(cur, [req.worker_id for req in requests])
-            self._store.workers.apply_snapshots(
-                cur,
-                [
-                    (req.worker_id, req.worker_resource_snapshot)
-                    for req in requests
-                    if str(req.worker_id) in existing_workers
-                ],
-                now_ms,
-                reset_health=True,
-            )
+        # ── Batch worker health updates ───────────────────────────────
+        existing_workers = self._store.workers.filter_existing(cur, [req.worker_id for req in requests])
+        self._store.workers.apply_snapshots(
+            cur,
+            [
+                (req.worker_id, req.worker_resource_snapshot)
+                for req in requests
+                if str(req.worker_id) in existing_workers
+            ],
+            now_ms,
+            reset_health=True,
+        )
 
-            # ── Bulk-fetch task rows for classification ───────────────────
-            all_task_ids: list[JobName] = []
-            for req in requests:
-                if str(req.worker_id) not in existing_workers:
+        # ── Bulk-fetch task rows for classification ───────────────────
+        all_task_ids: list[JobName] = []
+        for req in requests:
+            if str(req.worker_id) not in existing_workers:
+                continue
+            for update in req.updates:
+                if update.new_state not in (
+                    job_pb2.TASK_STATE_UNSPECIFIED,
+                    job_pb2.TASK_STATE_PENDING,
+                ):
+                    all_task_ids.append(update.task_id)
+
+        task_map = self._store.tasks.bulk_get_detail(cur, all_task_ids)
+
+        # ── Classify and split ────────────────────────────────────────
+        task_history_params: list[ResourceUsageInsertParams] = []
+        # (request_index, transition_request) pairs so results stay aligned.
+        transition_entries: list[tuple[int, HeartbeatApplyRequest]] = []
+
+        for req_idx, req in enumerate(requests):
+            if str(req.worker_id) not in existing_workers:
+                continue
+
+            transition_updates: list[TaskUpdate] = []
+            for update in req.updates:
+                task = task_map.get(update.task_id)
+                if task is None:
                     continue
-                for update in req.updates:
-                    if update.new_state not in (
-                        job_pb2.TASK_STATE_UNSPECIFIED,
-                        job_pb2.TASK_STATE_PENDING,
-                    ):
-                        all_task_ids.append(update.task_id)
 
-            task_map = self._store.tasks.bulk_get_detail(cur, all_task_ids)
+                prior_state = task.state
+                is_state_change = update.new_state != prior_state
+                has_terminal_data = update.error is not None or update.exit_code is not None
 
-            # ── Classify and split ────────────────────────────────────────
-            task_history_params: list[ResourceUsageInsertParams] = []
-            # (request_index, transition_request) pairs so results stay aligned.
-            transition_entries: list[tuple[int, HeartbeatApplyRequest]] = []
-
-            for req_idx, req in enumerate(requests):
-                if str(req.worker_id) not in existing_workers:
-                    continue
-
-                transition_updates: list[TaskUpdate] = []
-                for update in req.updates:
-                    task = task_map.get(update.task_id)
-                    if task is None:
+                if is_state_change or has_terminal_data:
+                    transition_updates.append(update)
+                else:
+                    # Steady-state: check finished / stale attempt before writing.
+                    if task_row_is_finished(task):
                         continue
-
-                    prior_state = task.state
-                    is_state_change = update.new_state != prior_state
-                    has_terminal_data = update.error is not None or update.exit_code is not None
-
-                    if is_state_change or has_terminal_data:
-                        transition_updates.append(update)
-                    else:
-                        # Steady-state: check finished / stale attempt before writing.
-                        if task_row_is_finished(task):
-                            continue
-                        if update.attempt_id != task.current_attempt_id:
-                            continue
-                        if update.resource_usage is not None:
-                            u = update.resource_usage
-                            task_history_params.append(
-                                ResourceUsageInsertParams(
-                                    task_id=update.task_id,
-                                    attempt_id=update.attempt_id,
-                                    cpu_millicores=u.cpu_millicores,
-                                    memory_mb=u.memory_mb,
-                                    disk_mb=u.disk_mb,
-                                    memory_peak_mb=u.memory_peak_mb,
-                                    timestamp_ms=now_ms,
-                                )
+                    if update.attempt_id != task.current_attempt_id:
+                        continue
+                    if update.resource_usage is not None:
+                        u = update.resource_usage
+                        task_history_params.append(
+                            ResourceUsageInsertParams(
+                                task_id=update.task_id,
+                                attempt_id=update.attempt_id,
+                                cpu_millicores=u.cpu_millicores,
+                                memory_mb=u.memory_mb,
+                                disk_mb=u.disk_mb,
+                                memory_peak_mb=u.memory_peak_mb,
+                                timestamp_ms=now_ms,
                             )
-
-                if transition_updates:
-                    transition_entries.append(
-                        (
-                            req_idx,
-                            HeartbeatApplyRequest(
-                                worker_id=req.worker_id,
-                                worker_resource_snapshot=None,  # already handled above
-                                updates=transition_updates,
-                            ),
                         )
+
+            if transition_updates:
+                transition_entries.append(
+                    (
+                        req_idx,
+                        HeartbeatApplyRequest(
+                            worker_id=req.worker_id,
+                            worker_resource_snapshot=None,  # already handled above
+                            updates=transition_updates,
+                        ),
                     )
+                )
 
-            # ── Pass 2a: batch task resource history writes ─────────────────
-            self._store.tasks.insert_resource_usage_many(cur, task_history_params)
+        # ── Pass 2a: batch task resource history writes ─────────────────
+        self._store.tasks.insert_resource_usage_many(cur, task_history_params)
 
-            # ── Pass 2b: transitions via existing state machine ───────────
-            for req_idx, treq in transition_entries:
-                tx_result = self._apply_task_transitions(cur, treq, now_ms)
-                results[req_idx] = TxResult(tasks_to_kill=tx_result.tasks_to_kill)
+        # ── Pass 2b: transitions via existing state machine ───────────
+        for req_idx, treq in transition_entries:
+            tx_result = self._apply_task_transitions(cur, treq, now_ms)
+            results[req_idx] = TxResult(tasks_to_kill=tx_result.tasks_to_kill)
 
         return results
 
@@ -1741,7 +1755,7 @@ class ControllerTransitions:
 
         for chunk_start in range(0, len(failures), chunk_size):
             chunk = failures[chunk_start : chunk_start + chunk_size]
-            with self._db.transaction() as cur:
+            with self._store.transaction() as cur:
                 now_ms = Timestamp.now().epoch_ms()
                 for worker_id, worker_address, error in chunk:
                     result = self._record_worker_failure(
@@ -1772,30 +1786,29 @@ class ControllerTransitions:
             results=results,
         )
 
-    def mark_task_unschedulable(self, task_id: JobName, reason: str) -> TxResult:
+    def mark_task_unschedulable(self, cur: TransactionCursor, task_id: JobName, reason: str) -> TxResult:
         """Mark a task as unschedulable using the task transition engine."""
-        with self._db.transaction() as cur:
-            job_id = self._store.tasks.get_job_id(cur, task_id)
-            if job_id is None:
-                return TxResult()
-            now_ms = Timestamp.now().epoch_ms()
-            _terminate_task(
-                cur,
-                self._store.attempts,
-                self._store.tasks,
-                self._store.workers,
-                self._store.endpoints,
-                task_id.to_wire(),
-                None,
-                job_pb2.TASK_STATE_UNSCHEDULABLE,
-                reason,
-                now_ms,
-            )
-            self._recompute_job_state(cur, job_id)
+        job_id = self._store.tasks.get_job_id(cur, task_id)
+        if job_id is None:
+            return TxResult()
+        now_ms = Timestamp.now().epoch_ms()
+        _terminate_task(
+            cur,
+            self._store.attempts,
+            self._store.tasks,
+            self._store.workers,
+            self._store.endpoints,
+            task_id.to_wire(),
+            None,
+            job_pb2.TASK_STATE_UNSCHEDULABLE,
+            reason,
+            now_ms,
+        )
+        self._recompute_job_state(cur, job_id)
         log_event("task_unschedulable", task_id.to_wire(), reason=reason)
         return TxResult()
 
-    def preempt_task(self, task_id: JobName, reason: str) -> TxResult:
+    def preempt_task(self, cur: TransactionCursor, task_id: JobName, reason: str) -> TxResult:
         """Preempt a running task, consuming from preemption retry budget.
 
         Marks the task as PREEMPTED (or retries as PENDING if budget remains),
@@ -1803,73 +1816,72 @@ class ControllerTransitions:
         """
         tasks_to_kill: set[JobName] = set()
         task_kill_workers: dict[JobName, WorkerId] = {}
-        with self._db.transaction() as cur:
-            row = self._store.tasks.get_with_resources(cur, task_id)
-            if row is None:
-                return TxResult()
+        row = self._store.tasks.get_with_resources(cur, task_id)
+        if row is None:
+            return TxResult()
 
-            prior_state = row.state
-            if prior_state not in ACTIVE_TASK_STATES:
-                return TxResult()
+        prior_state = row.state
+        if prior_state not in ACTIVE_TASK_STATES:
+            return TxResult()
 
-            now_ms = Timestamp.now().epoch_ms()
-            new_state, preemption_count = _resolve_task_failure_state(
-                prior_state,
-                row.preemption_count,
-                row.max_retries_preemption,
-                job_pb2.TASK_STATE_PREEMPTED,
-            )
-            # Fetch worker_id from the attempt for resource decommit.
-            attempt_worker = self._store.attempts.get_worker_id(cur, task_id, row.current_attempt_id)
-            attempt_worker_id = str(attempt_worker) if attempt_worker is not None else None
-            attempt_resources = row.resources if attempt_worker_id is not None else None
+        now_ms = Timestamp.now().epoch_ms()
+        new_state, preemption_count = _resolve_task_failure_state(
+            prior_state,
+            row.preemption_count,
+            row.max_retries_preemption,
+            job_pb2.TASK_STATE_PREEMPTED,
+        )
+        # Fetch worker_id from the attempt for resource decommit.
+        attempt_worker = self._store.attempts.get_worker_id(cur, task_id, row.current_attempt_id)
+        attempt_worker_id = str(attempt_worker) if attempt_worker is not None else None
+        attempt_resources = row.resources if attempt_worker_id is not None else None
 
-            _terminate_task(
-                cur,
-                self._store.attempts,
-                self._store.tasks,
-                self._store.workers,
-                self._store.endpoints,
-                task_id.to_wire(),
-                row.current_attempt_id,
-                new_state,
-                reason,
-                now_ms,
-                attempt_state=job_pb2.TASK_STATE_PREEMPTED,
-                worker_id=attempt_worker_id,
-                resources=attempt_resources,
-                preemption_count=preemption_count,
-            )
+        _terminate_task(
+            cur,
+            self._store.attempts,
+            self._store.tasks,
+            self._store.workers,
+            self._store.endpoints,
+            task_id.to_wire(),
+            row.current_attempt_id,
+            new_state,
+            reason,
+            now_ms,
+            attempt_state=job_pb2.TASK_STATE_PREEMPTED,
+            worker_id=attempt_worker_id,
+            resources=attempt_resources,
+            preemption_count=preemption_count,
+        )
 
-            # Recompute job state and cascade if terminal
-            job_id = row.job_id
-            new_job_state = self._recompute_job_state(cur, job_id)
-            if new_job_state is not None and new_job_state in TERMINAL_JOB_STATES:
-                cascade_kills, cascade_workers = _finalize_terminal_job(cur, self._store, job_id, new_job_state, now_ms)
-                tasks_to_kill.update(cascade_kills)
-                task_kill_workers.update(cascade_workers)
-            elif new_state == job_pb2.TASK_STATE_PENDING:
-                policy = _resolve_preemption_policy(self._store.jobs, cur, job_id)
-                if policy == job_pb2.JOB_PREEMPTION_POLICY_TERMINATE_CHILDREN:
-                    child_kills, child_workers = _cascade_children(
-                        cur,
-                        self._store,
-                        job_id,
-                        now_ms,
-                        reason,
-                        exclude_reservation_holders=True,
-                    )
-                    tasks_to_kill.update(child_kills)
-                    task_kill_workers.update(child_workers)
+        # Recompute job state and cascade if terminal
+        job_id = row.job_id
+        new_job_state = self._recompute_job_state(cur, job_id)
+        if new_job_state is not None and new_job_state in TERMINAL_JOB_STATES:
+            cascade_kills, cascade_workers = _finalize_terminal_job(cur, self._store, job_id, new_job_state, now_ms)
+            tasks_to_kill.update(cascade_kills)
+            task_kill_workers.update(cascade_workers)
+        elif new_state == job_pb2.TASK_STATE_PENDING:
+            policy = _resolve_preemption_policy(self._store.jobs, cur, job_id)
+            if policy == job_pb2.JOB_PREEMPTION_POLICY_TERMINATE_CHILDREN:
+                child_kills, child_workers = _cascade_children(
+                    cur,
+                    self._store,
+                    job_id,
+                    now_ms,
+                    reason,
+                    exclude_reservation_holders=True,
+                )
+                tasks_to_kill.update(child_kills)
+                task_kill_workers.update(child_workers)
 
-            if new_state == job_pb2.TASK_STATE_PREEMPTED:
-                tasks_to_kill.add(task_id)
+        if new_state == job_pb2.TASK_STATE_PREEMPTED:
+            tasks_to_kill.add(task_id)
 
         log_event("task_preempted", task_id.to_wire(), reason=reason)
 
         return TxResult(tasks_to_kill=tasks_to_kill, task_kill_workers=task_kill_workers)
 
-    def cancel_tasks_for_timeout(self, task_ids: set[JobName], reason: str) -> TxResult:
+    def cancel_tasks_for_timeout(self, cur: TransactionCursor, task_ids: set[JobName], reason: str) -> TxResult:
         """Mark executing tasks as FAILED due to execution timeout and return kill set.
 
         Each task is moved to TASK_STATE_FAILED with the given reason.
@@ -1881,116 +1893,113 @@ class ControllerTransitions:
         """
         if not task_ids:
             return TxResult()
-        with self._db.transaction() as cur:
-            rows = self._store.tasks.list_active(
+        rows = self._store.tasks.list_active(
+            cur,
+            TaskScope(task_ids=sorted(task_ids, key=lambda tid: tid.to_wire())),
+            states=EXECUTING_TASK_STATES,
+        )
+
+        # -- Phase 1: read all state before any mutations. --
+        now_ms = Timestamp.now().epoch_ms()
+        # Resources per job (all direct-timeout tasks in a job share job_config).
+        job_resources_cache: dict[str, job_pb2.ResourceSpecProto] = {}
+        # Collect directly-timed-out task wires for dedup against siblings.
+        direct_task_wires: set[str] = set()
+        # Per-job list of siblings to cascade (collected across all timed-out tasks).
+        siblings_by_job: dict[str, list[ActiveTaskRow]] = {}
+
+        for row in rows:
+            task_id_wire = row.task_id.to_wire()
+            direct_task_wires.add(task_id_wire)
+            job_id_wire = row.job_id.to_wire()
+            if job_id_wire not in job_resources_cache:
+                job_resources_cache[job_id_wire] = row.resources
+            siblings = _find_coscheduled_siblings(cur, self._store.tasks, row.job_id, row.task_id, row.has_coscheduling)
+            if siblings:
+                existing = siblings_by_job.get(job_id_wire, [])
+                existing.extend(siblings)
+                siblings_by_job[job_id_wire] = existing
+
+        # Deduplicate siblings: drop any that will already be terminated
+        # directly as timed-out tasks, and deduplicate across multiple
+        # trigger tasks within the same job.
+        for job_id_wire, siblings in siblings_by_job.items():
+            seen: set[str] = set()
+            deduped: list[ActiveTaskRow] = []
+            for sib in siblings:
+                sib_wire = sib.task_id.to_wire()
+                if sib_wire not in direct_task_wires and sib_wire not in seen:
+                    seen.add(sib_wire)
+                    deduped.append(sib)
+            siblings_by_job[job_id_wire] = deduped
+
+        # -- Phase 2: apply all mutations. --
+        tasks_to_kill: set[JobName] = set()
+        task_kill_workers: dict[JobName, WorkerId] = {}
+        jobs_to_update: set[str] = set()
+
+        for row in rows:
+            tid = row.task_id
+            tasks_to_kill.add(tid)
+            decommit_worker = None
+            decommit_resources = None
+            if row.current_worker_id is not None:
+                task_kill_workers[tid] = row.current_worker_id
+                if not row.is_reservation_holder:
+                    decommit_worker = str(row.current_worker_id)
+                    decommit_resources = row.resources
+            _terminate_task(
                 cur,
-                TaskScope(task_ids=sorted(task_ids, key=lambda tid: tid.to_wire())),
-                states=EXECUTING_TASK_STATES,
+                self._store.attempts,
+                self._store.tasks,
+                self._store.workers,
+                self._store.endpoints,
+                tid.to_wire(),
+                row.current_attempt_id,
+                job_pb2.TASK_STATE_FAILED,
+                reason,
+                now_ms,
+                worker_id=decommit_worker,
+                resources=decommit_resources,
+                failure_count=row.failure_count + 1,
             )
+            jobs_to_update.add(row.job_id.to_wire())
 
-            # -- Phase 1: read all state before any mutations. --
-            now_ms = Timestamp.now().epoch_ms()
-            # Resources per job (all direct-timeout tasks in a job share job_config).
-            job_resources_cache: dict[str, job_pb2.ResourceSpecProto] = {}
-            # Collect directly-timed-out task wires for dedup against siblings.
-            direct_task_wires: set[str] = set()
-            # Per-job list of siblings to cascade (collected across all timed-out tasks).
-            siblings_by_job: dict[str, list[ActiveTaskRow]] = {}
+        # Terminate coscheduled siblings (deduplicated, all reads already done).
+        for job_id_wire, siblings in siblings_by_job.items():
+            if not siblings:
+                continue
+            job_resources = job_resources_cache[job_id_wire]
+            # Pick the first direct-timeout task in this job as the "cause" for the error message.
+            cause_tid = next(r.task_id for r in rows if r.job_id.to_wire() == job_id_wire)
+            cascade_kill, cascade_workers = _terminate_coscheduled_siblings(
+                cur,
+                self._store.attempts,
+                self._store.tasks,
+                self._store.workers,
+                self._store.endpoints,
+                siblings,
+                cause_tid,
+                job_resources,
+                now_ms,
+            )
+            tasks_to_kill.update(cascade_kill)
+            task_kill_workers.update(cascade_workers)
+            jobs_to_update.add(job_id_wire)
 
-            for row in rows:
-                task_id_wire = row.task_id.to_wire()
-                direct_task_wires.add(task_id_wire)
-                job_id_wire = row.job_id.to_wire()
-                if job_id_wire not in job_resources_cache:
-                    job_resources_cache[job_id_wire] = row.resources
-                siblings = _find_coscheduled_siblings(
-                    cur, self._store.tasks, row.job_id, row.task_id, row.has_coscheduling
+        for job_wire in jobs_to_update:
+            new_job_state = self._recompute_job_state(cur, JobName.from_wire(job_wire))
+            if new_job_state in TERMINAL_JOB_STATES:
+                final_kill, final_workers = _finalize_terminal_job(
+                    cur, self._store, JobName.from_wire(job_wire), new_job_state, now_ms
                 )
-                if siblings:
-                    existing = siblings_by_job.get(job_id_wire, [])
-                    existing.extend(siblings)
-                    siblings_by_job[job_id_wire] = existing
-
-            # Deduplicate siblings: drop any that will already be terminated
-            # directly as timed-out tasks, and deduplicate across multiple
-            # trigger tasks within the same job.
-            for job_id_wire, siblings in siblings_by_job.items():
-                seen: set[str] = set()
-                deduped: list[ActiveTaskRow] = []
-                for sib in siblings:
-                    sib_wire = sib.task_id.to_wire()
-                    if sib_wire not in direct_task_wires and sib_wire not in seen:
-                        seen.add(sib_wire)
-                        deduped.append(sib)
-                siblings_by_job[job_id_wire] = deduped
-
-            # -- Phase 2: apply all mutations. --
-            tasks_to_kill: set[JobName] = set()
-            task_kill_workers: dict[JobName, WorkerId] = {}
-            jobs_to_update: set[str] = set()
-
-            for row in rows:
-                tid = row.task_id
-                tasks_to_kill.add(tid)
-                decommit_worker = None
-                decommit_resources = None
-                if row.current_worker_id is not None:
-                    task_kill_workers[tid] = row.current_worker_id
-                    if not row.is_reservation_holder:
-                        decommit_worker = str(row.current_worker_id)
-                        decommit_resources = row.resources
-                _terminate_task(
-                    cur,
-                    self._store.attempts,
-                    self._store.tasks,
-                    self._store.workers,
-                    self._store.endpoints,
-                    tid.to_wire(),
-                    row.current_attempt_id,
-                    job_pb2.TASK_STATE_FAILED,
-                    reason,
-                    now_ms,
-                    worker_id=decommit_worker,
-                    resources=decommit_resources,
-                    failure_count=row.failure_count + 1,
-                )
-                jobs_to_update.add(row.job_id.to_wire())
-
-            # Terminate coscheduled siblings (deduplicated, all reads already done).
-            for job_id_wire, siblings in siblings_by_job.items():
-                if not siblings:
-                    continue
-                job_resources = job_resources_cache[job_id_wire]
-                # Pick the first direct-timeout task in this job as the "cause" for the error message.
-                cause_tid = next(r.task_id for r in rows if r.job_id.to_wire() == job_id_wire)
-                cascade_kill, cascade_workers = _terminate_coscheduled_siblings(
-                    cur,
-                    self._store.attempts,
-                    self._store.tasks,
-                    self._store.workers,
-                    self._store.endpoints,
-                    siblings,
-                    cause_tid,
-                    job_resources,
-                    now_ms,
-                )
-                tasks_to_kill.update(cascade_kill)
-                task_kill_workers.update(cascade_workers)
-                jobs_to_update.add(job_id_wire)
-
-            for job_wire in jobs_to_update:
-                new_job_state = self._recompute_job_state(cur, JobName.from_wire(job_wire))
-                if new_job_state in TERMINAL_JOB_STATES:
-                    final_kill, final_workers = _finalize_terminal_job(
-                        cur, self._store, JobName.from_wire(job_wire), new_job_state, now_ms
-                    )
-                    tasks_to_kill.update(final_kill)
-                    task_kill_workers.update(final_workers)
+                tasks_to_kill.update(final_kill)
+                task_kill_workers.update(final_workers)
         for tid in tasks_to_kill:
             log_event("task_timeout", tid.to_wire(), reason=reason)
         return TxResult(tasks_to_kill=tasks_to_kill, task_kill_workers=task_kill_workers)
 
-    def remove_finished_job(self, job_id: JobName) -> bool:
+    def remove_finished_job(self, cur: TransactionCursor, job_id: JobName) -> bool:
         """Remove a finished job and its tasks from state.
 
         Only removes jobs that are in a terminal state (SUCCEEDED, FAILED, KILLED,
@@ -2002,29 +2011,27 @@ class ControllerTransitions:
         Returns:
             True if the job was removed, False if it doesn't exist or is not finished
         """
-        with self._db.transaction() as cur:
-            state = self._store.jobs.get_state(cur, job_id)
-            if state is None:
-                return False
-            if state not in (
-                job_pb2.JOB_STATE_SUCCEEDED,
-                job_pb2.JOB_STATE_FAILED,
-                job_pb2.JOB_STATE_KILLED,
-                job_pb2.JOB_STATE_UNSCHEDULABLE,
-            ):
-                return False
-            self._store.jobs.delete(cur, job_id)
+        state = self._store.jobs.get_state(cur, job_id)
+        if state is None:
+            return False
+        if state not in (
+            job_pb2.JOB_STATE_SUCCEEDED,
+            job_pb2.JOB_STATE_FAILED,
+            job_pb2.JOB_STATE_KILLED,
+            job_pb2.JOB_STATE_UNSCHEDULABLE,
+        ):
+            return False
+        self._store.jobs.delete(cur, job_id)
         log_event("job_removed", job_id.to_wire(), state=state)
         return True
 
-    def remove_worker(self, worker_id: WorkerId) -> WorkerDetailRow | None:
-        with self._db.transaction() as cur:
-            detail = self._store.workers.get_detail(cur, worker_id)
-            if detail is None:
-                return None
-            _remove_worker(cur, self._store.workers, worker_id)
-        log_event("worker_removed", str(worker_id))
-        self._store.workers.remove_from_attr_cache(worker_id)
+    def remove_worker(self, cur: TransactionCursor, worker_id: WorkerId) -> WorkerDetailRow | None:
+        detail = self._store.workers.get_detail(cur, worker_id)
+        if detail is None:
+            return None
+        _remove_worker(cur, self._store.workers, worker_id)
+        cur.on_commit(lambda: log_event("worker_removed", str(worker_id)))
+        cur.on_commit(lambda: self._store.workers.remove_from_attr_cache(worker_id))
         return detail
 
     def prune_old_data(
@@ -2059,11 +2066,11 @@ class ControllerTransitions:
         # 1. Jobs: one at a time (CASCADE to tasks → attempts, endpoints)
         jobs_deleted = 0
         while not _stopped():
-            with self._db.read_snapshot() as snap:
+            with self._store.read_snapshot() as snap:
                 job_name = self._store.jobs.find_prunable(snap, job_cutoff_ms)
             if job_name is None:
                 break
-            with self._db.transaction() as cur:
+            with self._store.transaction() as cur:
                 # Invalidate endpoint cache BEFORE the CASCADE so the cache
                 # drops rows SQLite is about to delete for us.
                 self._store.endpoints.remove_by_job_ids(cur, [job_name])
@@ -2075,11 +2082,11 @@ class ControllerTransitions:
         # 2. Workers: one at a time (CASCADE to attributes, task_history, resource_history)
         workers_deleted = 0
         while not _stopped():
-            with self._db.read_snapshot() as snap:
+            with self._store.read_snapshot() as snap:
                 worker_id = self._store.workers.find_prunable(snap, worker_cutoff_ms)
             if worker_id is None:
                 break
-            with self._db.transaction() as cur:
+            with self._store.transaction() as cur:
                 _remove_worker(cur, self._store.workers, worker_id)
             log_event("worker_pruned", str(worker_id))
             workers_deleted += 1
@@ -2109,7 +2116,7 @@ class ControllerTransitions:
                 result.workers_deleted,
                 result.profiles_deleted,
             )
-            self._db.optimize()
+            self._store.optimize()
 
         return result
 
@@ -2119,9 +2126,10 @@ class ControllerTransitions:
 
     def update_worker_pings(
         self,
+        cur: TransactionCursor,
         snapshots: Mapping[WorkerId, job_pb2.WorkerResourceSnapshot | None],
     ) -> None:
-        """Apply a batch of Ping RPC results in a single transaction.
+        """Apply a batch of Ping RPC results within the caller's transaction.
 
         For each entry, bumps last_heartbeat_ms; if the value is a snapshot,
         also rewrites the worker's snapshot_* columns and appends a row to
@@ -2135,37 +2143,37 @@ class ControllerTransitions:
             return
         now_ms = Timestamp.now().epoch_ms()
         items = list(snapshots.items())
-        with self._db.transaction() as cur:
-            self._store.workers.apply_snapshots(cur, items, now_ms, reset_health=False)
+        self._store.workers.apply_snapshots(cur, items, now_ms, reset_health=False)
 
     def get_running_tasks_for_poll(
         self,
+        snap: QuerySnapshot | TransactionCursor,
     ) -> tuple[dict[WorkerId, list[RunningTaskEntry]], dict[WorkerId, str]]:
         """Snapshot running tasks and worker addresses for PollTasks RPCs.
 
+        Caller passes an open read snapshot or transaction cursor.
         Returns (running_by_worker, worker_addresses) where running_by_worker
         maps worker_id to its list of running task entries and worker_addresses
         maps worker_id to its RPC address.
         """
-        with self._db.read_snapshot() as snap:
-            worker_addresses = self._store.workers.list_active_healthy(snap)
-            if not worker_addresses:
-                return {}, {}
-            worker_ids = list(worker_addresses.keys())
+        worker_addresses = self._store.workers.list_active_healthy(snap)
+        if not worker_addresses:
+            return {}, {}
+        worker_ids = list(worker_addresses.keys())
 
-            # Reservation holders are virtual — they live on ``current_worker_id``
-            # only as a scheduling anchor and never get a RunTaskRequest. Sending
-            # them in PollTasksRequest.expected_tasks makes the worker reconcile
-            # against its _tasks dict, miss, and return WORKER_FAILED every cycle,
-            # which drains the holder's preemption budget and (post the build-
-            # failure health hook) reaps the claimed worker for a harmless miss.
-            task_rows = self._store.tasks.list_active(
-                snap,
-                TaskScope(worker_ids=worker_ids),
-                states=ACTIVE_TASK_STATES,
-                exclude_reservation_holders=True,
-                order_by_task_id=True,
-            )
+        # Reservation holders are virtual — they live on ``current_worker_id``
+        # only as a scheduling anchor and never get a RunTaskRequest. Sending
+        # them in PollTasksRequest.expected_tasks makes the worker reconcile
+        # against its _tasks dict, miss, and return WORKER_FAILED every cycle,
+        # which drains the holder's preemption budget and (post the build-
+        # failure health hook) reaps the claimed worker for a harmless miss.
+        task_rows = self._store.tasks.list_active(
+            snap,
+            TaskScope(worker_ids=worker_ids),
+            states=ACTIVE_TASK_STATES,
+            exclude_reservation_holders=True,
+            order_by_task_id=True,
+        )
 
         running: dict[WorkerId, list[RunningTaskEntry]] = {}
         for row in task_rows:
@@ -2192,7 +2200,7 @@ class ControllerTransitions:
         """
         if not worker_ids:
             return WorkerFailureBatchResult()
-        with self._db.read_snapshot() as snap:
+        with self._store.read_snapshot() as snap:
             rows = self._store.workers.list_active_by_ids(snap, worker_ids)
         failures = [(row.worker_id, row.address, reason) for row in rows]
         if not failures:
@@ -2206,30 +2214,30 @@ class ControllerTransitions:
         )
 
     def load_workers_from_config(self, configs: list[WorkerConfig]) -> None:
-        """Load workers from static configuration."""
+        """Load workers from static configuration in a single transaction."""
         now = Timestamp.now()
-        for cfg in configs:
-            self.register_or_refresh_worker(
-                worker_id=WorkerId(cfg.worker_id),
-                address=cfg.address,
-                metadata=cfg.metadata,
-                ts=now,
-            )
+        with self._store.transaction() as cur:
+            for cfg in configs:
+                self.register_or_refresh_worker(
+                    cur,
+                    worker_id=WorkerId(cfg.worker_id),
+                    address=cfg.address,
+                    metadata=cfg.metadata,
+                    ts=now,
+                )
 
     # --- Endpoint Management ---
 
-    def add_endpoint(self, endpoint: EndpointRow) -> bool:
+    def add_endpoint(self, cur: TransactionCursor, endpoint: EndpointRow) -> bool:
         """Add an endpoint row through the store's endpoint cache.
 
         Returns True if the endpoint was inserted, False if the task is already
         terminal (to prevent orphaned endpoints that would never be cleaned up).
         """
-        with self._store.transaction() as cur:
-            return self._store.endpoints.add(cur, endpoint)
+        return self._store.endpoints.add(cur, endpoint)
 
-    def remove_endpoint(self, endpoint_id: str) -> EndpointRow | None:
-        with self._store.transaction() as cur:
-            return self._store.endpoints.remove(cur, endpoint_id)
+    def remove_endpoint(self, cur: TransactionCursor, endpoint_id: str) -> EndpointRow | None:
+        return self._store.endpoints.remove(cur, endpoint_id)
 
     # ---------------------------------------------------------------------
     # Test-only SQL mutation helpers
@@ -2266,6 +2274,7 @@ class ControllerTransitions:
 
     def drain_for_direct_provider(
         self,
+        cur: TransactionCursor,
         max_promotions: int = DIRECT_PROVIDER_PROMOTION_RATE,
     ) -> DirectProviderBatch:
         """Drain pending tasks and snapshot running tasks for a direct provider sync cycle.
@@ -2276,67 +2285,66 @@ class ControllerTransitions:
         - Already ASSIGNED/BUILDING/RUNNING tasks with NULL worker_id -> running_tasks
         - Kill entries with NULL worker_id -> tasks_to_kill (deleted from queue)
         """
-        with self._db.transaction() as cur:
-            now_ms = Timestamp.now().epoch_ms()
+        now_ms = Timestamp.now().epoch_ms()
 
-            newly_promoted: set[str] = set()
-            tasks_to_run: list[job_pb2.RunTaskRequest] = []
+        newly_promoted: set[str] = set()
+        tasks_to_run: list[job_pb2.RunTaskRequest] = []
 
-            pending_rows = self._store.tasks.list_pending_for_direct_provider(cur, max_promotions)
+        pending_rows = self._store.tasks.list_pending_for_direct_provider(cur, max_promotions)
 
-            for row in pending_rows:
-                attempt_id = row.current_attempt_id + 1
+        for row in pending_rows:
+            attempt_id = row.current_attempt_id + 1
 
-                self._store.tasks.assign(
-                    cur,
-                    self._store.attempts,
-                    row.task_id,
-                    None,
-                    None,
-                    attempt_id,
-                    now_ms,
-                )
-
-                entrypoint = proto_from_json(row.entrypoint_json, job_pb2.RuntimeEntrypoint)
-                # Load inline workdir files from the job_workdir_files table.
-                for filename, data in self._store.jobs.get_workdir_files(cur, row.job_id).items():
-                    entrypoint.workdir_files[filename] = data
-
-                run_req = job_pb2.RunTaskRequest(
-                    task_id=row.task_id.to_wire(),
-                    num_tasks=row.num_tasks,
-                    entrypoint=entrypoint,
-                    environment=proto_from_json(row.environment_json, job_pb2.EnvironmentConfig),
-                    bundle_id=row.bundle_id,
-                    resources=row.resources,
-                    ports=json.loads(row.ports_json),
-                    attempt_id=attempt_id,
-                    constraints=[c.to_proto() for c in constraints_from_json(row.constraints_json)],
-                    task_image=row.task_image,
-                )
-                # Propagate timeout for K8s activeDeadlineSeconds (Kubernetes-native enforcement).
-                if row.timeout_ms is not None and row.timeout_ms > 0:
-                    run_req.timeout.milliseconds = row.timeout_ms
-                tasks_to_run.append(run_req)
-                newly_promoted.add(row.task_id.to_wire())
-
-            # Snapshot already-running tasks with NULL worker_id (excluding newly promoted).
-            running_rows = self._store.tasks.list_active(
+            self._store.tasks.assign(
                 cur,
-                TaskScope(null_worker=True),
-                states=ACTIVE_TASK_STATES,
-                order_by_task_id=True,
+                self._store.attempts,
+                row.task_id,
+                None,
+                None,
+                attempt_id,
+                now_ms,
             )
-            running_tasks = [
-                RunningTaskEntry(
-                    task_id=row.task_id,
-                    attempt_id=row.current_attempt_id,
-                )
-                for row in running_rows
-                if row.task_id.to_wire() not in newly_promoted
-            ]
 
-            tasks_to_kill = self._store.dispatch.drain_direct_kills(cur)
+            entrypoint = proto_from_json(row.entrypoint_json, job_pb2.RuntimeEntrypoint)
+            # Load inline workdir files from the job_workdir_files table.
+            for filename, data in self._store.jobs.get_workdir_files(cur, row.job_id).items():
+                entrypoint.workdir_files[filename] = data
+
+            run_req = job_pb2.RunTaskRequest(
+                task_id=row.task_id.to_wire(),
+                num_tasks=row.num_tasks,
+                entrypoint=entrypoint,
+                environment=proto_from_json(row.environment_json, job_pb2.EnvironmentConfig),
+                bundle_id=row.bundle_id,
+                resources=row.resources,
+                ports=json.loads(row.ports_json),
+                attempt_id=attempt_id,
+                constraints=[c.to_proto() for c in constraints_from_json(row.constraints_json)],
+                task_image=row.task_image,
+            )
+            # Propagate timeout for K8s activeDeadlineSeconds (Kubernetes-native enforcement).
+            if row.timeout_ms is not None and row.timeout_ms > 0:
+                run_req.timeout.milliseconds = row.timeout_ms
+            tasks_to_run.append(run_req)
+            newly_promoted.add(row.task_id.to_wire())
+
+        # Snapshot already-running tasks with NULL worker_id (excluding newly promoted).
+        running_rows = self._store.tasks.list_active(
+            cur,
+            TaskScope(null_worker=True),
+            states=ACTIVE_TASK_STATES,
+            order_by_task_id=True,
+        )
+        running_tasks = [
+            RunningTaskEntry(
+                task_id=row.task_id,
+                attempt_id=row.current_attempt_id,
+            )
+            for row in running_rows
+            if row.task_id.to_wire() not in newly_promoted
+        ]
+
+        tasks_to_kill = self._store.dispatch.drain_direct_kills(cur)
 
         return DirectProviderBatch(
             tasks_to_run=tasks_to_run,
@@ -2344,7 +2352,7 @@ class ControllerTransitions:
             tasks_to_kill=tasks_to_kill,
         )
 
-    def apply_direct_provider_updates(self, updates: list[TaskUpdate]) -> TxResult:
+    def apply_direct_provider_updates(self, cur: TransactionCursor, updates: list[TaskUpdate]) -> TxResult:
         """Apply a batch of task state updates from a KubernetesProvider.
 
         Same state machine as apply_task_updates but without worker lookup,
@@ -2353,197 +2361,190 @@ class ControllerTransitions:
         tasks_to_kill: set[JobName] = set()
         task_kill_workers: dict[JobName, WorkerId] = {}
 
-        with self._db.transaction() as cur:
-            now_ms = Timestamp.now().epoch_ms()
-            cascaded_jobs: set[JobName] = set()
+        now_ms = Timestamp.now().epoch_ms()
+        cascaded_jobs: set[JobName] = set()
 
-            for update in updates:
-                task = self._store.tasks.get_detail(cur, update.task_id)
-                if task is None:
-                    continue
-                if task_row_is_finished(task) or update.new_state in (
-                    job_pb2.TASK_STATE_UNSPECIFIED,
-                    job_pb2.TASK_STATE_PENDING,
-                ):
-                    continue
-                if update.attempt_id != task.current_attempt_id:
-                    stale_state = self._store.attempts.get_state(cur, update.task_id, update.attempt_id)
-                    if stale_state is not None and stale_state not in TERMINAL_TASK_STATES:
-                        logger.error(
-                            "Stale attempt precondition violation: task=%s reported=%d current=%d stale_state=%s",
-                            update.task_id,
-                            update.attempt_id,
-                            task.current_attempt_id,
-                            stale_state,
-                        )
-                    continue
-                attempt = self._store.attempts.get(cur, update.task_id, update.attempt_id)
-                if attempt is None:
-                    continue
-                # See _apply_task_transitions for rationale: the current attempt may
-                # be terminal while the task is retrying in PENDING; late reports
-                # must not revive it.
-                if attempt.state in TERMINAL_TASK_STATES:
-                    logger.debug(
-                        "Dropping late update for terminal attempt: task=%s attempt=%d attempt_state=%d reported=%d",
+        for update in updates:
+            task = self._store.tasks.get_detail(cur, update.task_id)
+            if task is None:
+                continue
+            if task_row_is_finished(task) or update.new_state in (
+                job_pb2.TASK_STATE_UNSPECIFIED,
+                job_pb2.TASK_STATE_PENDING,
+            ):
+                continue
+            if update.attempt_id != task.current_attempt_id:
+                stale_state = self._store.attempts.get_state(cur, update.task_id, update.attempt_id)
+                if stale_state is not None and stale_state not in TERMINAL_TASK_STATES:
+                    logger.error(
+                        "Stale attempt precondition violation: task=%s reported=%d current=%d stale_state=%s",
                         update.task_id,
                         update.attempt_id,
-                        attempt.state,
-                        int(update.new_state),
+                        task.current_attempt_id,
+                        stale_state,
                     )
-                    continue
+                continue
+            attempt = self._store.attempts.get(cur, update.task_id, update.attempt_id)
+            if attempt is None:
+                continue
+            # See _apply_task_transitions for rationale: the current attempt may
+            # be terminal while the task is retrying in PENDING; late reports
+            # must not revive it.
+            if attempt.state in TERMINAL_TASK_STATES:
+                logger.debug(
+                    "Dropping late update for terminal attempt: task=%s attempt=%d attempt_state=%d reported=%d",
+                    update.task_id,
+                    update.attempt_id,
+                    attempt.state,
+                    int(update.new_state),
+                )
+                continue
 
-                if update.resource_usage is not None:
-                    ru = update.resource_usage
-                    self._store.tasks.insert_resource_usage(
-                        cur,
-                        ResourceUsageInsertParams(
-                            task_id=update.task_id,
-                            attempt_id=update.attempt_id,
-                            cpu_millicores=ru.cpu_millicores,
-                            memory_mb=ru.memory_mb,
-                            disk_mb=ru.disk_mb,
-                            memory_peak_mb=ru.memory_peak_mb,
-                            timestamp_ms=now_ms,
-                        ),
-                    )
-                if update.container_id is not None:
-                    self._store.tasks.update_container_id(cur, update.task_id, update.container_id)
-
-                terminal_ms: int | None = None
-                started_ms: int | None = None
-                task_state = task.state
-                task_error = update.error
-                task_exit = update.exit_code
-                failure_count = task.failure_count
-                preemption_count = task.preemption_count
-
-                if update.new_state == job_pb2.TASK_STATE_RUNNING:
-                    started_ms = now_ms
-                    task_state = job_pb2.TASK_STATE_RUNNING
-                elif update.new_state == job_pb2.TASK_STATE_BUILDING:
-                    task_state = job_pb2.TASK_STATE_BUILDING
-                elif update.new_state in (
-                    job_pb2.TASK_STATE_FAILED,
-                    job_pb2.TASK_STATE_WORKER_FAILED,
-                    job_pb2.TASK_STATE_KILLED,
-                    job_pb2.TASK_STATE_UNSCHEDULABLE,
-                    job_pb2.TASK_STATE_SUCCEEDED,
-                ):
-                    terminal_ms = now_ms
-                    task_state = int(update.new_state)
-                    if update.new_state == job_pb2.TASK_STATE_SUCCEEDED and task_exit is None:
-                        task_exit = 0
-                    if update.new_state == job_pb2.TASK_STATE_UNSCHEDULABLE and task_error is None:
-                        task_error = "Scheduling timeout exceeded"
-                    if update.new_state == job_pb2.TASK_STATE_FAILED:
-                        failure_count += 1
-                    if update.new_state == job_pb2.TASK_STATE_WORKER_FAILED and task.state in EXECUTING_TASK_STATES:
-                        preemption_count += 1
-                    # WORKER_FAILED while still ASSIGNED -> retry immediately as PENDING
-                    if (
-                        update.new_state == job_pb2.TASK_STATE_WORKER_FAILED
-                        and task.state == job_pb2.TASK_STATE_ASSIGNED
-                    ):
-                        task_state = job_pb2.TASK_STATE_PENDING
-                        terminal_ms = None
-                    if update.new_state == job_pb2.TASK_STATE_FAILED and failure_count <= task.max_retries_failure:
-                        task_state = job_pb2.TASK_STATE_PENDING
-                        terminal_ms = None
-                    if (
-                        update.new_state == job_pb2.TASK_STATE_WORKER_FAILED
-                        and preemption_count <= task.max_retries_preemption
-                        and task.state in EXECUTING_TASK_STATES
-                    ):
-                        task_state = job_pb2.TASK_STATE_PENDING
-                        terminal_ms = None
-
-                # An attempt is terminal whenever the update itself is terminal, even
-                # if the TASK rolls back to PENDING for a retry.
-                attempt_terminal_ms = now_ms if int(update.new_state) in TERMINAL_TASK_STATES else None
-
-                self._store.attempts.apply_update(
+            if update.resource_usage is not None:
+                ru = update.resource_usage
+                self._store.tasks.insert_resource_usage(
                     cur,
-                    TaskAttemptUpdateParams(
+                    ResourceUsageInsertParams(
                         task_id=update.task_id,
                         attempt_id=update.attempt_id,
-                        state=int(update.new_state),
-                        started_at_ms=started_ms,
-                        finished_at_ms=attempt_terminal_ms,
-                        exit_code=task_exit,
-                        error=update.error,
+                        cpu_millicores=ru.cpu_millicores,
+                        memory_mb=ru.memory_mb,
+                        disk_mb=ru.disk_mb,
+                        memory_peak_mb=ru.memory_peak_mb,
+                        timestamp_ms=now_ms,
                     ),
                 )
-                self._store.tasks.apply_state_update(
+            if update.container_id is not None:
+                self._store.tasks.update_container_id(cur, update.task_id, update.container_id)
+
+            terminal_ms: int | None = None
+            started_ms: int | None = None
+            task_state = task.state
+            task_error = update.error
+            task_exit = update.exit_code
+            failure_count = task.failure_count
+            preemption_count = task.preemption_count
+
+            if update.new_state == job_pb2.TASK_STATE_RUNNING:
+                started_ms = now_ms
+                task_state = job_pb2.TASK_STATE_RUNNING
+            elif update.new_state == job_pb2.TASK_STATE_BUILDING:
+                task_state = job_pb2.TASK_STATE_BUILDING
+            elif update.new_state in (
+                job_pb2.TASK_STATE_FAILED,
+                job_pb2.TASK_STATE_WORKER_FAILED,
+                job_pb2.TASK_STATE_KILLED,
+                job_pb2.TASK_STATE_UNSCHEDULABLE,
+                job_pb2.TASK_STATE_SUCCEEDED,
+            ):
+                terminal_ms = now_ms
+                task_state = int(update.new_state)
+                if update.new_state == job_pb2.TASK_STATE_SUCCEEDED and task_exit is None:
+                    task_exit = 0
+                if update.new_state == job_pb2.TASK_STATE_UNSCHEDULABLE and task_error is None:
+                    task_error = "Scheduling timeout exceeded"
+                if update.new_state == job_pb2.TASK_STATE_FAILED:
+                    failure_count += 1
+                if update.new_state == job_pb2.TASK_STATE_WORKER_FAILED and task.state in EXECUTING_TASK_STATES:
+                    preemption_count += 1
+                # WORKER_FAILED while still ASSIGNED -> retry immediately as PENDING
+                if update.new_state == job_pb2.TASK_STATE_WORKER_FAILED and task.state == job_pb2.TASK_STATE_ASSIGNED:
+                    task_state = job_pb2.TASK_STATE_PENDING
+                    terminal_ms = None
+                if update.new_state == job_pb2.TASK_STATE_FAILED and failure_count <= task.max_retries_failure:
+                    task_state = job_pb2.TASK_STATE_PENDING
+                    terminal_ms = None
+                if (
+                    update.new_state == job_pb2.TASK_STATE_WORKER_FAILED
+                    and preemption_count <= task.max_retries_preemption
+                    and task.state in EXECUTING_TASK_STATES
+                ):
+                    task_state = job_pb2.TASK_STATE_PENDING
+                    terminal_ms = None
+
+            # An attempt is terminal whenever the update itself is terminal, even
+            # if the TASK rolls back to PENDING for a retry.
+            attempt_terminal_ms = now_ms if int(update.new_state) in TERMINAL_TASK_STATES else None
+
+            self._store.attempts.apply_update(
+                cur,
+                TaskAttemptUpdateParams(
+                    task_id=update.task_id,
+                    attempt_id=update.attempt_id,
+                    state=int(update.new_state),
+                    started_at_ms=started_ms,
+                    finished_at_ms=attempt_terminal_ms,
+                    exit_code=task_exit,
+                    error=update.error,
+                ),
+            )
+            self._store.tasks.apply_state_update(
+                cur,
+                TaskStateUpdateParams(
+                    task_id=update.task_id,
+                    state=task_state,
+                    error=task_error,
+                    exit_code=task_exit,
+                    started_at_ms=started_ms,
+                    finished_at_ms=terminal_ms,
+                    failure_count=failure_count,
+                    preemption_count=preemption_count,
+                ),
+                ACTIVE_TASK_STATES,
+            )
+            jc_row = self._store.jobs.get_config(cur, task.job_id)
+
+            if update.new_state in TERMINAL_TASK_STATES:
+                delete_task_endpoints(cur, self._store.endpoints, update.task_id.to_wire())
+
+            # Coscheduled sibling cascade.
+            if jc_row is not None and task_state in FAILURE_TASK_STATES:
+                has_cosched = bool(int(jc_row["has_coscheduling"]))
+                siblings = _find_coscheduled_siblings(cur, self._store.tasks, task.job_id, update.task_id, has_cosched)
+                job_resources = resource_spec_from_scalars(
+                    int(jc_row["res_cpu_millicores"]),
+                    int(jc_row["res_memory_bytes"]),
+                    int(jc_row["res_disk_bytes"]),
+                    jc_row["res_device_json"],
+                )
+                cascade_kill, cascade_workers = _terminate_coscheduled_siblings(
                     cur,
-                    TaskStateUpdateParams(
-                        task_id=update.task_id,
-                        state=task_state,
-                        error=task_error,
-                        exit_code=task_exit,
-                        started_at_ms=started_ms,
-                        finished_at_ms=terminal_ms,
-                        failure_count=failure_count,
-                        preemption_count=preemption_count,
-                    ),
-                    ACTIVE_TASK_STATES,
+                    self._store.attempts,
+                    self._store.tasks,
+                    self._store.workers,
+                    self._store.endpoints,
+                    siblings,
+                    update.task_id,
+                    job_resources,
+                    now_ms,
                 )
-                jc_row = self._store.jobs.get_config(cur, task.job_id)
+                tasks_to_kill.update(cascade_kill)
+                task_kill_workers.update(cascade_workers)
 
-                if update.new_state in TERMINAL_TASK_STATES:
-                    delete_task_endpoints(cur, self._store.endpoints, update.task_id.to_wire())
-
-                # Coscheduled sibling cascade.
-                if jc_row is not None and task_state in FAILURE_TASK_STATES:
-                    has_cosched = bool(int(jc_row["has_coscheduling"]))
-                    siblings = _find_coscheduled_siblings(
-                        cur, self._store.tasks, task.job_id, update.task_id, has_cosched
+            if task.job_id not in cascaded_jobs:
+                new_job_state = self._recompute_job_state(cur, task.job_id)
+                if new_job_state in TERMINAL_JOB_STATES:
+                    final_tasks_to_kill, final_task_kill_workers = _finalize_terminal_job(
+                        cur, self._store, task.job_id, new_job_state, now_ms
                     )
-                    job_resources = resource_spec_from_scalars(
-                        int(jc_row["res_cpu_millicores"]),
-                        int(jc_row["res_memory_bytes"]),
-                        int(jc_row["res_disk_bytes"]),
-                        jc_row["res_device_json"],
-                    )
-                    cascade_kill, cascade_workers = _terminate_coscheduled_siblings(
-                        cur,
-                        self._store.attempts,
-                        self._store.tasks,
-                        self._store.workers,
-                        self._store.endpoints,
-                        siblings,
-                        update.task_id,
-                        job_resources,
-                        now_ms,
-                    )
-                    tasks_to_kill.update(cascade_kill)
-                    task_kill_workers.update(cascade_workers)
+                    tasks_to_kill.update(final_tasks_to_kill)
+                    task_kill_workers.update(final_task_kill_workers)
+                    cascaded_jobs.add(task.job_id)
 
-                if task.job_id not in cascaded_jobs:
-                    new_job_state = self._recompute_job_state(cur, task.job_id)
-                    if new_job_state in TERMINAL_JOB_STATES:
-                        final_tasks_to_kill, final_task_kill_workers = _finalize_terminal_job(
-                            cur, self._store, task.job_id, new_job_state, now_ms
-                        )
-                        tasks_to_kill.update(final_tasks_to_kill)
-                        task_kill_workers.update(final_task_kill_workers)
-                        cascaded_jobs.add(task.job_id)
-
-            if tasks_to_kill or cascaded_jobs:
-                log_event("direct_provider_updates_applied", "direct")
-                for job_id in cascaded_jobs:
-                    log_event("job_terminated", job_id.to_wire(), trigger="direct_provider_updates_applied")
+        if tasks_to_kill or cascaded_jobs:
+            log_event("direct_provider_updates_applied", "direct")
+            for job_id in cascaded_jobs:
+                log_event("job_terminated", job_id.to_wire(), trigger="direct_provider_updates_applied")
 
         return TxResult(tasks_to_kill=tasks_to_kill, task_kill_workers=task_kill_workers)
 
-    def buffer_direct_kill(self, task_id: str) -> None:
+    def buffer_direct_kill(self, cur: TransactionCursor, task_id: str) -> None:
         """Buffer a kill request for a direct-provider task.
 
         Inserts a kill entry into dispatch_queue with worker_id=NULL.
         Drained by drain_for_direct_provider().
         """
-        with self._db.transaction() as cur:
-            self._store.dispatch.enqueue_kill(cur, None, JobName.from_wire(task_id), Timestamp.now().epoch_ms())
+        self._store.dispatch.enqueue_kill(cur, None, JobName.from_wire(task_id), Timestamp.now().epoch_ms())
 
     # =========================================================================
     # Test helpers
@@ -2576,7 +2577,7 @@ class ControllerTransitions:
             worker_address = self._store.workers.address(snap, worker_id) or str(worker_id)
         next_attempt_id = current_attempt_id + 1
         now_ms = Timestamp.now().epoch_ms()
-        with self._db.transaction() as cur:
+        with self._store.transaction() as cur:
             self._store.tasks.assign(
                 cur,
                 self._store.attempts,

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -2543,9 +2543,11 @@ class ControllerTransitions:
         """Buffer a kill request for a direct-provider task.
 
         Inserts a kill entry into dispatch_queue with worker_id=NULL.
-        Drained by drain_for_direct_provider().
+        Drained by drain_for_direct_provider(). ``task_id`` is stored
+        verbatim — callers in direct-provider land may pass IDs that
+        aren't canonical ``JobName`` strings.
         """
-        self._store.dispatch.enqueue_kill(cur, None, JobName.from_wire(task_id), Timestamp.now().epoch_ms())
+        self._store.dispatch.enqueue_kill(cur, None, task_id, Timestamp.now().epoch_ms())
 
     # =========================================================================
     # Test helpers

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -12,7 +12,7 @@ import json
 import logging
 from dataclasses import dataclass, field
 from collections.abc import Callable, Iterable, Mapping
-from typing import Any, NamedTuple
+from typing import NamedTuple
 
 from iris.cluster.constraints import AttributeValue, Constraint, constraints_from_resources, merge_constraints
 from iris.cluster.controller.codec import (
@@ -54,7 +54,6 @@ from iris.cluster.controller.stores import (
 )
 from iris.cluster.controller.schema import (
     JOB_CONFIG_JOIN,
-    TASK_DETAIL_PROJECTION,
     EndpointRow,
     JobDetailRow,
     WorkerDetailRow,
@@ -678,26 +677,6 @@ def _resolve_task_failure_state(
 
 
 # =============================================================================
-# Batch helpers for apply_heartbeats_batch
-# =============================================================================
-
-
-def _bulk_fetch_tasks(cur: TransactionCursor, task_ids: list[str]) -> dict[str, Any]:
-    """Fetch task rows for all given IDs in chunked IN queries."""
-    result: dict[str, Any] = {}
-    for chunk_start in range(0, len(task_ids), 900):
-        chunk = task_ids[chunk_start : chunk_start + 900]
-        ph = ",".join("?" * len(chunk))
-        rows = cur.execute(
-            f"SELECT * FROM tasks WHERE task_id IN ({ph})",
-            tuple(chunk),
-        ).fetchall()
-        for r in rows:
-            result[str(r["task_id"])] = r
-    return result
-
-
-# =============================================================================
 # Controller Transitions
 # =============================================================================
 
@@ -1307,28 +1286,27 @@ class ControllerTransitions:
         job_config_cache: dict[str, dict | None] = {}
 
         for update in req.updates:
-            task_row = cur.execute("SELECT * FROM tasks WHERE task_id = ?", (update.task_id.to_wire(),)).fetchone()
-            if task_row is None:
+            task = self._store.tasks.get_detail(cur, update.task_id)
+            if task is None:
                 continue
-            task = TASK_DETAIL_PROJECTION.decode_one([task_row])
             if task_row_is_finished(task) or update.new_state in (
                 job_pb2.TASK_STATE_UNSPECIFIED,
                 job_pb2.TASK_STATE_PENDING,
             ):
                 continue
-            if update.attempt_id != int(task_row["current_attempt_id"]):
+            if update.attempt_id != task.current_attempt_id:
                 stale_state = self._store.attempts.get_state(cur, update.task_id, update.attempt_id)
                 if stale_state is not None and stale_state not in TERMINAL_TASK_STATES:
                     logger.error(
                         "Stale attempt precondition violation: task=%s reported=%d current=%d stale_state=%s",
                         update.task_id,
                         update.attempt_id,
-                        int(task_row["current_attempt_id"]),
+                        task.current_attempt_id,
                         stale_state,
                     )
                 continue
 
-            prior_state = int(task_row["state"])
+            prior_state = task.state
 
             # Fast path: task already in the reported state with no new data to apply.
             has_new_data = update.error is not None or update.exit_code is not None or update.resource_usage is not None
@@ -1371,8 +1349,8 @@ class ControllerTransitions:
             task_state = prior_state
             task_error = update.error
             task_exit = update.exit_code
-            failure_count = int(task_row["failure_count"])
-            preemption_count = int(task_row["preemption_count"])
+            failure_count = task.failure_count
+            preemption_count = task.preemption_count
 
             if update.new_state == job_pb2.TASK_STATE_RUNNING:
                 started_ms = now_ms
@@ -1416,14 +1394,12 @@ class ControllerTransitions:
                     # forever without draining preemption budget.
                     if worker_id is not None:
                         self._health.build_failed(WorkerId(str(worker_id)))
-                if update.new_state == job_pb2.TASK_STATE_FAILED and failure_count <= int(
-                    task_row["max_retries_failure"]
-                ):
+                if update.new_state == job_pb2.TASK_STATE_FAILED and failure_count <= task.max_retries_failure:
                     task_state = job_pb2.TASK_STATE_PENDING
                     terminal_ms = None
                 if (
                     update.new_state == job_pb2.TASK_STATE_WORKER_FAILED
-                    and preemption_count <= int(task_row["max_retries_preemption"])
+                    and preemption_count <= task.max_retries_preemption
                     and prior_state in EXECUTING_TASK_STATES
                 ):
                     task_state = job_pb2.TASK_STATE_PENDING
@@ -1573,7 +1549,7 @@ class ControllerTransitions:
             )
 
             # ── Bulk-fetch task rows for classification ───────────────────
-            all_task_ids: list[str] = []
+            all_task_ids: list[JobName] = []
             for req in requests:
                 if str(req.worker_id) not in existing_workers:
                     continue
@@ -1582,9 +1558,9 @@ class ControllerTransitions:
                         job_pb2.TASK_STATE_UNSPECIFIED,
                         job_pb2.TASK_STATE_PENDING,
                     ):
-                        all_task_ids.append(update.task_id.to_wire())
+                        all_task_ids.append(update.task_id)
 
-            task_row_map = _bulk_fetch_tasks(cur, all_task_ids)
+            task_map = self._store.tasks.bulk_get_detail(cur, all_task_ids)
 
             # ── Classify and split ────────────────────────────────────────
             task_history_params: list[ResourceUsageInsertParams] = []
@@ -1597,12 +1573,11 @@ class ControllerTransitions:
 
                 transition_updates: list[TaskUpdate] = []
                 for update in req.updates:
-                    task_id_wire = update.task_id.to_wire()
-                    task_row = task_row_map.get(task_id_wire)
-                    if task_row is None:
+                    task = task_map.get(update.task_id)
+                    if task is None:
                         continue
 
-                    prior_state = int(task_row["state"])
+                    prior_state = task.state
                     is_state_change = update.new_state != prior_state
                     has_terminal_data = update.error is not None or update.exit_code is not None
 
@@ -1610,16 +1585,15 @@ class ControllerTransitions:
                         transition_updates.append(update)
                     else:
                         # Steady-state: check finished / stale attempt before writing.
-                        task = self._db.decode_task(task_row)
                         if task_row_is_finished(task):
                             continue
-                        if update.attempt_id != int(task_row["current_attempt_id"]):
+                        if update.attempt_id != task.current_attempt_id:
                             continue
                         if update.resource_usage is not None:
                             u = update.resource_usage
                             task_history_params.append(
                                 ResourceUsageInsertParams(
-                                    task_id=JobName.from_wire(task_id_wire),
+                                    task_id=update.task_id,
                                     attempt_id=update.attempt_id,
                                     cpu_millicores=u.cpu_millicores,
                                     memory_mb=u.memory_mb,
@@ -2445,23 +2419,22 @@ class ControllerTransitions:
             cascaded_jobs: set[JobName] = set()
 
             for update in updates:
-                task_row = cur.execute("SELECT * FROM tasks WHERE task_id = ?", (update.task_id.to_wire(),)).fetchone()
-                if task_row is None:
+                task = self._store.tasks.get_detail(cur, update.task_id)
+                if task is None:
                     continue
-                task = TASK_DETAIL_PROJECTION.decode_one([task_row])
                 if task_row_is_finished(task) or update.new_state in (
                     job_pb2.TASK_STATE_UNSPECIFIED,
                     job_pb2.TASK_STATE_PENDING,
                 ):
                     continue
-                if update.attempt_id != int(task_row["current_attempt_id"]):
+                if update.attempt_id != task.current_attempt_id:
                     stale_state = self._store.attempts.get_state(cur, update.task_id, update.attempt_id)
                     if stale_state is not None and stale_state not in TERMINAL_TASK_STATES:
                         logger.error(
                             "Stale attempt precondition violation: task=%s reported=%d current=%d stale_state=%s",
                             update.task_id,
                             update.attempt_id,
-                            int(task_row["current_attempt_id"]),
+                            task.current_attempt_id,
                             stale_state,
                         )
                     continue
@@ -2500,11 +2473,11 @@ class ControllerTransitions:
 
                 terminal_ms: int | None = None
                 started_ms: int | None = None
-                task_state = int(task_row["state"])
+                task_state = task.state
                 task_error = update.error
                 task_exit = update.exit_code
-                failure_count = int(task_row["failure_count"])
-                preemption_count = int(task_row["preemption_count"])
+                failure_count = task.failure_count
+                preemption_count = task.preemption_count
 
                 if update.new_state == job_pb2.TASK_STATE_RUNNING:
                     started_ms = now_ms
@@ -2526,27 +2499,22 @@ class ControllerTransitions:
                         task_error = "Scheduling timeout exceeded"
                     if update.new_state == job_pb2.TASK_STATE_FAILED:
                         failure_count += 1
-                    if (
-                        update.new_state == job_pb2.TASK_STATE_WORKER_FAILED
-                        and int(task_row["state"]) in EXECUTING_TASK_STATES
-                    ):
+                    if update.new_state == job_pb2.TASK_STATE_WORKER_FAILED and task.state in EXECUTING_TASK_STATES:
                         preemption_count += 1
                     # WORKER_FAILED while still ASSIGNED -> retry immediately as PENDING
                     if (
                         update.new_state == job_pb2.TASK_STATE_WORKER_FAILED
-                        and int(task_row["state"]) == job_pb2.TASK_STATE_ASSIGNED
+                        and task.state == job_pb2.TASK_STATE_ASSIGNED
                     ):
                         task_state = job_pb2.TASK_STATE_PENDING
                         terminal_ms = None
-                    if update.new_state == job_pb2.TASK_STATE_FAILED and failure_count <= int(
-                        task_row["max_retries_failure"]
-                    ):
+                    if update.new_state == job_pb2.TASK_STATE_FAILED and failure_count <= task.max_retries_failure:
                         task_state = job_pb2.TASK_STATE_PENDING
                         terminal_ms = None
                     if (
                         update.new_state == job_pb2.TASK_STATE_WORKER_FAILED
-                        and preemption_count <= int(task_row["max_retries_preemption"])
-                        and int(task_row["state"]) in EXECUTING_TASK_STATES
+                        and preemption_count <= task.max_retries_preemption
+                        and task.state in EXECUTING_TASK_STATES
                     ):
                         task_state = job_pb2.TASK_STATE_PENDING
                         terminal_ms = None

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -11,7 +11,7 @@ import time
 import json
 import logging
 from dataclasses import dataclass, field
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping
 from typing import Any, NamedTuple
 
 from iris.cluster.constraints import AttributeValue, Constraint, constraints_from_resources, merge_constraints
@@ -50,11 +50,11 @@ from iris.cluster.controller.stores import (
     TaskStore,
     WorkerAttributeParams,
     WorkerStore,
+    WorkerUpsertParams,
 )
 from iris.cluster.controller.schema import (
     JOB_CONFIG_JOIN,
     TASK_DETAIL_PROJECTION,
-    WORKER_DETAIL_PROJECTION,
     EndpointRow,
     JobDetailRow,
     WorkerDetailRow,
@@ -678,119 +678,8 @@ def _resolve_task_failure_state(
 
 
 # =============================================================================
-# Worker resource snapshot writers
-# =============================================================================
-
-
-def _write_worker_snapshots(
-    cur: TransactionCursor,
-    items: Sequence[tuple[str, job_pb2.WorkerResourceSnapshot | None]],
-    now_ms: int,
-    *,
-    reset_health: bool,
-) -> None:
-    """Bump last_heartbeat for every worker; for entries with a snapshot, also
-    rewrite snapshot_* columns and append a worker_resource_history row.
-
-    A None snapshot means liveness-only: heartbeat path emits these for
-    workers that didn't ship a fresh resource snapshot this cycle, ping path
-    emits these on cycles where it skips the resource refresh.
-
-    Heartbeat path passes ``reset_health=True`` because a successful heartbeat
-    means the worker has recovered. Ping path passes False — the ping loop
-    tracks failures in-memory and removes workers via ``fail_workers_batch``.
-    """
-    if not items:
-        return
-
-    health_prefix = "healthy = 1, active = 1, consecutive_failures = 0, " if reset_health else ""
-
-    liveness_only = [(now_ms, wid) for wid, snap in items if snap is None]
-    if liveness_only:
-        cur.executemany(
-            f"UPDATE workers SET {health_prefix}last_heartbeat_ms = ? WHERE worker_id = ?",
-            liveness_only,
-        )
-
-    snapshot_binds = [
-        {
-            "worker_id": wid,
-            "now_ms": now_ms,
-            "host_cpu_percent": snap.host_cpu_percent,
-            "memory_used_bytes": snap.memory_used_bytes,
-            "memory_total_bytes": snap.memory_total_bytes,
-            "disk_used_bytes": snap.disk_used_bytes,
-            "disk_total_bytes": snap.disk_total_bytes,
-            "running_task_count": snap.running_task_count,
-            "total_process_count": snap.total_process_count,
-            "net_recv_bps": snap.net_recv_bps,
-            "net_sent_bps": snap.net_sent_bps,
-        }
-        for wid, snap in items
-        if snap is not None
-    ]
-    if not snapshot_binds:
-        return
-
-    cur.executemany(
-        f"UPDATE workers SET {health_prefix}last_heartbeat_ms = :now_ms, "
-        "snapshot_host_cpu_percent = :host_cpu_percent, "
-        "snapshot_memory_used_bytes = :memory_used_bytes, "
-        "snapshot_memory_total_bytes = :memory_total_bytes, "
-        "snapshot_disk_used_bytes = :disk_used_bytes, "
-        "snapshot_disk_total_bytes = :disk_total_bytes, "
-        "snapshot_running_task_count = :running_task_count, "
-        "snapshot_total_process_count = :total_process_count, "
-        "snapshot_net_recv_bps = :net_recv_bps, "
-        "snapshot_net_sent_bps = :net_sent_bps "
-        "WHERE worker_id = :worker_id",
-        snapshot_binds,
-    )
-    cur.executemany(
-        "INSERT INTO worker_resource_history ("
-        "worker_id, snapshot_host_cpu_percent, snapshot_memory_used_bytes, "
-        "snapshot_memory_total_bytes, snapshot_disk_used_bytes, snapshot_disk_total_bytes, "
-        "snapshot_running_task_count, snapshot_total_process_count, "
-        "snapshot_net_recv_bps, snapshot_net_sent_bps, timestamp_ms"
-        ") VALUES ("
-        ":worker_id, :host_cpu_percent, :memory_used_bytes, "
-        ":memory_total_bytes, :disk_used_bytes, :disk_total_bytes, "
-        ":running_task_count, :total_process_count, "
-        ":net_recv_bps, :net_sent_bps, :now_ms"
-        ")",
-        snapshot_binds,
-    )
-
-
-# =============================================================================
 # Batch helpers for apply_heartbeats_batch
 # =============================================================================
-
-
-def _batch_worker_health(
-    cur: TransactionCursor,
-    requests: list["HeartbeatApplyRequest"],
-    now_ms: int,
-) -> set[str]:
-    """Batch-update worker health, resource snapshots, and history.
-
-    Returns the set of worker IDs that actually exist in the DB so callers
-    can skip updates from stale/removed workers.
-    """
-    worker_ids = [str(req.worker_id) for req in requests]
-    if not worker_ids:
-        return set()
-
-    placeholders = ",".join("?" * len(worker_ids))
-    rows = cur.execute(
-        f"SELECT worker_id FROM workers WHERE worker_id IN ({placeholders})",
-        tuple(worker_ids),
-    ).fetchall()
-    existing = {str(r["worker_id"]) for r in rows}
-
-    items = [(str(req.worker_id), req.worker_resource_snapshot) for req in requests if str(req.worker_id) in existing]
-    _write_worker_snapshots(cur, items, now_ms, reset_health=True)
-    return existing
 
 
 def _bulk_fetch_tasks(cur: TransactionCursor, task_ids: list[str]) -> dict[str, Any]:
@@ -1231,64 +1120,36 @@ class ControllerTransitions:
             device_type = ""
             device_variant = ""
         with self._db.transaction() as cur:
-            md_device_json = proto_to_json(metadata.device)
-            cur.execute(
-                "INSERT INTO workers("
-                "worker_id, address, healthy, active, consecutive_failures, last_heartbeat_ms, "
-                "committed_cpu_millicores, committed_mem_bytes, committed_gpu, committed_tpu, "
-                "total_cpu_millicores, total_memory_bytes, total_gpu_count, total_tpu_count, "
-                "device_type, device_variant, slice_id, scale_group, "
-                "md_hostname, md_ip_address, md_cpu_count, md_memory_bytes, md_disk_bytes, "
-                "md_tpu_name, md_tpu_worker_hostnames, md_tpu_worker_id, md_tpu_chips_per_host_bounds, "
-                "md_gpu_count, md_gpu_name, md_gpu_memory_mb, "
-                "md_gce_instance_name, md_gce_zone, md_git_hash, md_device_json"
-                ") VALUES (?, ?, 1, 1, 0, ?, 0, 0, 0, 0, ?, ?, ?, ?, ?, ?, ?, ?, "
-                "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
-                "ON CONFLICT(worker_id) DO UPDATE SET "
-                "address=excluded.address, healthy=1, active=1, "
-                "consecutive_failures=0, last_heartbeat_ms=excluded.last_heartbeat_ms, "
-                "total_cpu_millicores=excluded.total_cpu_millicores, total_memory_bytes=excluded.total_memory_bytes, "
-                "total_gpu_count=excluded.total_gpu_count, total_tpu_count=excluded.total_tpu_count, "
-                "device_type=excluded.device_type, device_variant=excluded.device_variant, "
-                "slice_id=excluded.slice_id, scale_group=excluded.scale_group, "
-                "md_hostname=excluded.md_hostname, md_ip_address=excluded.md_ip_address, "
-                "md_cpu_count=excluded.md_cpu_count, md_memory_bytes=excluded.md_memory_bytes, "
-                "md_disk_bytes=excluded.md_disk_bytes, md_tpu_name=excluded.md_tpu_name, "
-                "md_tpu_worker_hostnames=excluded.md_tpu_worker_hostnames, "
-                "md_tpu_worker_id=excluded.md_tpu_worker_id, "
-                "md_tpu_chips_per_host_bounds=excluded.md_tpu_chips_per_host_bounds, "
-                "md_gpu_count=excluded.md_gpu_count, md_gpu_name=excluded.md_gpu_name, "
-                "md_gpu_memory_mb=excluded.md_gpu_memory_mb, "
-                "md_gce_instance_name=excluded.md_gce_instance_name, md_gce_zone=excluded.md_gce_zone, "
-                "md_git_hash=excluded.md_git_hash, md_device_json=excluded.md_device_json",
-                (
-                    str(worker_id),
-                    address,
-                    now_ms,
-                    metadata.cpu_count * 1000,
-                    metadata.memory_bytes,
-                    gpu_count,
-                    tpu_count,
-                    device_type,
-                    device_variant,
-                    slice_id,
-                    scale_group,
-                    metadata.hostname,
-                    metadata.ip_address,
-                    metadata.cpu_count,
-                    metadata.memory_bytes,
-                    metadata.disk_bytes,
-                    metadata.tpu_name,
-                    metadata.tpu_worker_hostnames,
-                    metadata.tpu_worker_id,
-                    metadata.tpu_chips_per_host_bounds,
-                    metadata.gpu_count,
-                    metadata.gpu_name,
-                    metadata.gpu_memory_mb,
-                    metadata.gce_instance_name,
-                    metadata.gce_zone,
-                    metadata.git_hash,
-                    md_device_json,
+            self._store.workers.upsert(
+                cur,
+                WorkerUpsertParams(
+                    worker_id=worker_id,
+                    address=address,
+                    last_heartbeat_ms=now_ms,
+                    total_cpu_millicores=metadata.cpu_count * 1000,
+                    total_memory_bytes=metadata.memory_bytes,
+                    total_gpu_count=gpu_count,
+                    total_tpu_count=tpu_count,
+                    device_type=device_type,
+                    device_variant=device_variant,
+                    slice_id=slice_id,
+                    scale_group=scale_group,
+                    md_hostname=metadata.hostname,
+                    md_ip_address=metadata.ip_address,
+                    md_cpu_count=metadata.cpu_count,
+                    md_memory_bytes=metadata.memory_bytes,
+                    md_disk_bytes=metadata.disk_bytes,
+                    md_tpu_name=metadata.tpu_name,
+                    md_tpu_worker_hostnames=metadata.tpu_worker_hostnames,
+                    md_tpu_worker_id=metadata.tpu_worker_id,
+                    md_tpu_chips_per_host_bounds=metadata.tpu_chips_per_host_bounds,
+                    md_gpu_count=metadata.gpu_count,
+                    md_gpu_name=metadata.gpu_name,
+                    md_gpu_memory_mb=metadata.gpu_memory_mb,
+                    md_gce_instance_name=metadata.gce_instance_name,
+                    md_gce_zone=metadata.gce_zone,
+                    md_git_hash=metadata.git_hash,
+                    md_device_json=proto_to_json(metadata.device),
                 ),
             )
             self._store.workers.replace_attributes(cur, worker_id, attrs)
@@ -1424,8 +1285,16 @@ class ControllerTransitions:
 
         Returns False if the worker doesn't exist (caller should bail).
         """
-        existing = _batch_worker_health(cur, [req], now_ms)
-        return str(req.worker_id) in existing
+        existing = self._store.workers.filter_existing(cur, [req.worker_id])
+        if str(req.worker_id) not in existing:
+            return False
+        self._store.workers.apply_snapshots(
+            cur,
+            [(req.worker_id, req.worker_resource_snapshot)],
+            now_ms,
+            reset_health=True,
+        )
+        return True
 
     def _apply_task_transitions(
         self,
@@ -1700,7 +1569,17 @@ class ControllerTransitions:
             now_ms = Timestamp.now().epoch_ms()
 
             # ── Batch worker health updates ───────────────────────────────
-            existing_workers = _batch_worker_health(cur, requests, now_ms)
+            existing_workers = self._store.workers.filter_existing(cur, [req.worker_id for req in requests])
+            self._store.workers.apply_snapshots(
+                cur,
+                [
+                    (req.worker_id, req.worker_resource_snapshot)
+                    for req in requests
+                    if str(req.worker_id) in existing_workers
+                ],
+                now_ms,
+                reset_health=True,
+            )
 
             # ── Bulk-fetch task rows for classification ───────────────────
             all_task_ids: list[str] = []
@@ -1863,20 +1742,13 @@ class ControllerTransitions:
         now_ms: int | None = None,
     ) -> WorkerFailureResult:
         """Remove a failed worker inside an existing transaction."""
-        row = cur.execute(
-            "SELECT last_heartbeat_ms FROM workers WHERE worker_id = ? AND active = 1",
-            (str(worker_id),),
-        ).fetchone()
-        if row is None:
+        status = self._store.workers.get_active_status(cur, worker_id)
+        if status is None:
             return WorkerFailureResult(worker_removed=True)
 
         now_ms = now_ms or Timestamp.now().epoch_ms()
-        last_heartbeat_ms = row["last_heartbeat_ms"]
-        last_contact_age_ms = None if last_heartbeat_ms is None else max(0, now_ms - int(last_heartbeat_ms))
-        cur.execute(
-            "UPDATE workers SET healthy = 0 WHERE worker_id = ?",
-            (str(worker_id),),
-        )
+        last_contact_age_ms = None if status.last_heartbeat_ms is None else max(0, now_ms - status.last_heartbeat_ms)
+        self._store.workers.mark_unhealthy(cur, worker_id)
         removal = self._remove_failed_worker(cur, worker_id, error, now_ms=now_ms)
         return WorkerFailureResult(
             tasks_to_kill=removal.tasks_to_kill,
@@ -2186,13 +2058,13 @@ class ControllerTransitions:
 
     def remove_worker(self, worker_id: WorkerId) -> WorkerDetailRow | None:
         with self._db.transaction() as cur:
-            row = cur.execute("SELECT * FROM workers WHERE worker_id = ?", (str(worker_id),)).fetchone()
-            if row is None:
+            detail = self._store.workers.get_detail(cur, worker_id)
+            if detail is None:
                 return None
             _remove_worker(cur, self._store.workers, worker_id)
         log_event("worker_removed", str(worker_id))
         self._store.workers.remove_from_attr_cache(worker_id)
-        return WORKER_DETAIL_PROJECTION.decode_one([row])
+        return detail
 
     def _batch_delete(
         self,
@@ -2335,9 +2207,9 @@ class ControllerTransitions:
         if not snapshots:
             return
         now_ms = Timestamp.now().epoch_ms()
-        items = [(str(wid), snap) for wid, snap in snapshots.items()]
+        items = list(snapshots.items())
         with self._db.transaction() as cur:
-            _write_worker_snapshots(cur, items, now_ms, reset_health=False)
+            self._store.workers.apply_snapshots(cur, items, now_ms, reset_health=False)
 
     def get_running_tasks_for_poll(
         self,
@@ -2349,16 +2221,10 @@ class ControllerTransitions:
         maps worker_id to its RPC address.
         """
         with self._db.read_snapshot() as snap:
-            worker_rows = snap.fetchall("SELECT worker_id, address FROM workers WHERE active = 1 AND healthy = 1")
-            worker_addresses: dict[WorkerId, str] = {}
-            worker_ids: list[WorkerId] = []
-            for row in worker_rows:
-                wid = WorkerId(str(row["worker_id"]))
-                worker_addresses[wid] = str(row["address"])
-                worker_ids.append(wid)
-
-            if not worker_ids:
+            worker_addresses = self._store.workers.list_active_healthy(snap)
+            if not worker_addresses:
                 return {}, {}
+            worker_ids = list(worker_addresses.keys())
 
             # Reservation holders are virtual — they live on ``current_worker_id``
             # only as a scheduling anchor and never get a RunTaskRequest. Sending
@@ -2399,15 +2265,8 @@ class ControllerTransitions:
         """
         if not worker_ids:
             return WorkerFailureBatchResult()
-        target_set = sorted(set(worker_ids))
-        placeholders = ",".join("?" for _ in target_set)
         with self._db.read_snapshot() as snap:
-            rows = WORKER_DETAIL_PROJECTION.decode(
-                snap.fetchall(
-                    f"SELECT * FROM workers WHERE active = 1 AND worker_id IN ({placeholders})",
-                    tuple(target_set),
-                )
-            )
+            rows = self._store.workers.list_active_by_ids(snap, worker_ids)
         failures = [(row.worker_id, row.address, reason) for row in rows]
         if not failures:
             return WorkerFailureBatchResult()

--- a/lib/iris/tests/cluster/conftest.py
+++ b/lib/iris/tests/cluster/conftest.py
@@ -223,9 +223,11 @@ class ServiceTestHarness:
     def sync_k8s(self) -> None:
         """Run one K8s direct provider sync cycle."""
         assert self.k8s_provider is not None, "sync_k8s requires K8s harness"
-        batch = self.state.drain_for_direct_provider()
+        with self.state._store.transaction() as cur:
+            batch = self.state.drain_for_direct_provider(cur)
         result = self.k8s_provider.sync(batch)
-        self.state.apply_direct_provider_updates(result.updates)
+        with self.state._store.transaction() as cur:
+            self.state.apply_direct_provider_updates(cur, result.updates)
 
     # ── GCP-specific ────────────────────────────────────────────
 
@@ -250,7 +252,8 @@ class ServiceTestHarness:
         metadata.attributes["device-type"].string_value = device_type
         metadata.attributes["preemptible"].string_value = str(preemptible).lower()
         metadata.attributes["region"].string_value = region
-        self.state.register_or_refresh_worker(wid, f"{worker_id}:8080", metadata, Timestamp.now())
+        with self.state._store.transaction() as cur:
+            self.state.register_or_refresh_worker(cur, wid, f"{worker_id}:8080", metadata, Timestamp.now())
         return wid
 
     # ── Private drivers ─────────────────────────────────────────
@@ -340,7 +343,10 @@ class ServiceTestHarness:
                 workers = WORKER_DETAIL_PROJECTION.decode(q.fetchall("SELECT * FROM workers"))
             if not workers:
                 raise ValueError("No GCP workers registered -- call register_gcp_worker first")
-            self.state.queue_assignments([Assignment(task_id=task_id, worker_id=WorkerId(workers[0].worker_id))])
+            with self.state._store.transaction() as cur:
+                self.state.queue_assignments(
+                    cur, [Assignment(task_id=task_id, worker_id=WorkerId(workers[0].worker_id))]
+                )
 
         worker_id, attempt_id = self._current_attempt_info(task_id)
         if worker_id is None:
@@ -356,7 +362,25 @@ class ServiceTestHarness:
             )
             and task.state != job_pb2.TASK_STATE_RUNNING
         ):
+            with self.state._store.transaction() as cur:
+                self.state.apply_task_updates(
+                    cur,
+                    HeartbeatApplyRequest(
+                        worker_id=worker_id,
+                        worker_resource_snapshot=None,
+                        updates=[
+                            TaskUpdate(
+                                task_id=task_id,
+                                attempt_id=attempt_id,
+                                new_state=job_pb2.TASK_STATE_RUNNING,
+                            )
+                        ],
+                    ),
+                )
+
+        with self.state._store.transaction() as cur:
             self.state.apply_task_updates(
+                cur,
                 HeartbeatApplyRequest(
                     worker_id=worker_id,
                     worker_resource_snapshot=None,
@@ -364,25 +388,11 @@ class ServiceTestHarness:
                         TaskUpdate(
                             task_id=task_id,
                             attempt_id=attempt_id,
-                            new_state=job_pb2.TASK_STATE_RUNNING,
+                            new_state=new_state,
                         )
                     ],
-                )
+                ),
             )
-
-        self.state.apply_task_updates(
-            HeartbeatApplyRequest(
-                worker_id=worker_id,
-                worker_resource_snapshot=None,
-                updates=[
-                    TaskUpdate(
-                        task_id=task_id,
-                        attempt_id=attempt_id,
-                        new_state=new_state,
-                    )
-                ],
-            )
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/controller/conftest.py
+++ b/lib/iris/tests/cluster/controller/conftest.py
@@ -287,8 +287,9 @@ def submit_direct_job(
 ) -> list[JobName]:
     jid = JobName.root("test-user", name)
     req = make_direct_job_request(name, replicas, task_image=task_image)
-    state.submit_job(jid, req, Timestamp.now())
-    with state._db.snapshot() as q:
+    with state._store.transaction() as cur:
+        state.submit_job(cur, jid, req, Timestamp.now())
+    with state._store.read_snapshot() as q:
         tasks = TASK_DETAIL_PROJECTION.decode(q.fetchall("SELECT * FROM tasks WHERE job_id = ?", (jid.to_wire(),)))
     return [t.task_id for t in tasks]
 
@@ -299,14 +300,14 @@ def submit_direct_job(
 
 
 def query_task(state: ControllerTransitions, task_id: JobName):
-    with state._db.snapshot() as q:
+    with state._db.read_snapshot() as q:
         return TASK_DETAIL_PROJECTION.decode_one(
             q.fetchall("SELECT * FROM tasks WHERE task_id = ? LIMIT 1", (task_id.to_wire(),)),
         )
 
 
 def query_attempt(state: ControllerTransitions, task_id: JobName, attempt_id: int):
-    with state._db.snapshot() as q:
+    with state._db.read_snapshot() as q:
         rows = ATTEMPT_PROJECTION.decode(
             q.fetchall(
                 "SELECT * FROM task_attempts WHERE task_id = ? AND attempt_id = ?",
@@ -317,7 +318,7 @@ def query_attempt(state: ControllerTransitions, task_id: JobName, attempt_id: in
 
 
 def query_job(state: ControllerTransitions, job_id: JobName) -> JobDetailRow | None:
-    with state._db.snapshot() as q:
+    with state._db.read_snapshot() as q:
         return JOB_DETAIL_PROJECTION.decode_one(
             q.fetchall(
                 f"SELECT j.*, jc.* FROM jobs j {JOB_CONFIG_JOIN} WHERE j.job_id = ? LIMIT 1",
@@ -328,7 +329,7 @@ def query_job(state: ControllerTransitions, job_id: JobName) -> JobDetailRow | N
 
 def query_job_row(state: ControllerTransitions, job_id: JobName):
     """Query a job as a JobSchedulingRow (scheduling projection with resources/constraints)."""
-    with state._db.snapshot() as q:
+    with state._db.read_snapshot() as q:
         return JOB_SCHEDULING_PROJECTION.decode_one(
             q.fetchall(
                 f"SELECT j.*, jc.* FROM jobs j {JOB_CONFIG_JOIN} WHERE j.job_id = ? LIMIT 1",
@@ -338,21 +339,21 @@ def query_job_row(state: ControllerTransitions, job_id: JobName):
 
 
 def query_worker(state: ControllerTransitions, worker_id: WorkerId) -> WorkerRow | None:
-    with state._db.snapshot() as q:
+    with state._db.read_snapshot() as q:
         return WORKER_ROW_PROJECTION.decode_one(
             q.fetchall("SELECT * FROM workers WHERE worker_id = ? LIMIT 1", (str(worker_id),)),
         )
 
 
 def query_tasks_for_job(state: ControllerTransitions, job_id: JobName) -> list[TaskDetailRow]:
-    with state._db.snapshot() as q:
+    with state._db.read_snapshot() as q:
         return TASK_DETAIL_PROJECTION.decode(q.fetchall("SELECT * FROM tasks WHERE job_id = ?", (job_id.to_wire(),)))
 
 
 def schedulable_tasks(state: ControllerTransitions):
     """Return non-terminal tasks eligible for scheduling, in priority order."""
     terminal_placeholders = ",".join("?" for _ in TERMINAL_TASK_STATES)
-    with state._db.snapshot() as q:
+    with state._db.read_snapshot() as q:
         tasks = TASK_DETAIL_PROJECTION.decode(
             q.fetchall(
                 f"SELECT * FROM tasks WHERE state IS NOT NULL AND state NOT IN ({terminal_placeholders})"
@@ -365,7 +366,7 @@ def schedulable_tasks(state: ControllerTransitions):
 
 def building_counts(state: ControllerTransitions) -> dict[WorkerId, int]:
     """Count tasks in BUILDING/ASSIGNED state per worker, excluding reservation holders."""
-    with state._db.snapshot() as snapshot:
+    with state._db.read_snapshot() as snapshot:
         rows = snapshot.raw(
             "SELECT a.worker_id, COUNT(*) as c FROM tasks t "
             "JOIN task_attempts a ON t.task_id = a.task_id AND t.current_attempt_id = a.attempt_id "
@@ -391,16 +392,18 @@ def register_worker(
     scale_group: str = "",
 ) -> WorkerId:
     wid = WorkerId(worker_id)
-    state.register_or_refresh_worker(
-        worker_id=wid,
-        address=address,
-        metadata=metadata,
-        ts=Timestamp.now(),
-        slice_id=slice_id,
-        scale_group=scale_group,
-    )
-    if not healthy:
-        state._db.execute("UPDATE workers SET healthy = 0 WHERE worker_id = ?", (str(wid),))
+    with state._store.transaction() as cur:
+        state.register_or_refresh_worker(
+            cur,
+            worker_id=wid,
+            address=address,
+            metadata=metadata,
+            ts=Timestamp.now(),
+            slice_id=slice_id,
+            scale_group=scale_group,
+        )
+        if not healthy:
+            state._store.workers.set_health_for_test(cur, wid, healthy=False)
     return wid
 
 
@@ -435,11 +438,13 @@ def submit_job(
     inject_device_constraints(request)
     jid = JobName.from_string(job_id) if job_id.startswith("/") else JobName.root("test-user", job_id)
     request.name = jid.to_wire()
-    state.submit_job(
-        jid,
-        request,
-        Timestamp.from_ms(timestamp_ms) if timestamp_ms is not None else Timestamp.now(),
-    )
+    with state._store.transaction() as cur:
+        state.submit_job(
+            cur,
+            jid,
+            request,
+            Timestamp.from_ms(timestamp_ms) if timestamp_ms is not None else Timestamp.now(),
+        )
     return query_tasks_for_job(state, jid)
 
 
@@ -450,7 +455,7 @@ def submit_job(
 
 
 def query_tasks_with_attempts(state: ControllerTransitions, job_id: JobName) -> list[TaskDetailRow]:
-    with state._db.snapshot() as q:
+    with state._db.read_snapshot() as q:
         tasks = TASK_DETAIL_PROJECTION.decode(
             q.fetchall("SELECT * FROM tasks WHERE job_id = ? ORDER BY task_index ASC", (job_id.to_wire(),)),
         )
@@ -469,7 +474,7 @@ def query_tasks_with_attempts(state: ControllerTransitions, job_id: JobName) -> 
 
 def query_task_with_attempts(state: ControllerTransitions, task_id: JobName) -> TaskDetailRow | None:
     wire = task_id.to_wire()
-    with state._db.snapshot() as q:
+    with state._db.read_snapshot() as q:
         tasks = TASK_DETAIL_PROJECTION.decode(q.fetchall("SELECT * FROM tasks WHERE task_id = ?", (wire,)))
         attempts = ATTEMPT_PROJECTION.decode(
             q.fetchall("SELECT * FROM task_attempts WHERE task_id = ? ORDER BY attempt_id ASC", (wire,)),
@@ -553,7 +558,7 @@ def make_worker_metadata(
 
 
 def worker_running_tasks(state: ControllerTransitions, worker_id: WorkerId) -> frozenset[JobName]:
-    with state._db.snapshot() as q:
+    with state._db.read_snapshot() as q:
         rows = q.raw(
             "SELECT t.task_id FROM tasks t "
             "JOIN task_attempts a ON t.task_id = a.task_id AND t.current_attempt_id = a.attempt_id "
@@ -569,7 +574,7 @@ def hydrate_worker_attributes(state: ControllerTransitions, workers: list) -> li
         return workers
     worker_ids = [str(w.worker_id) for w in workers]
     placeholders = ",".join("?" for _ in worker_ids)
-    with state._db.snapshot() as q:
+    with state._db.read_snapshot() as q:
         attrs = q.raw(
             f"SELECT worker_id, key, value_type, str_value, int_value, float_value"
             f" FROM worker_attributes WHERE worker_id IN ({placeholders})",
@@ -590,26 +595,29 @@ def hydrate_worker_attributes(state: ControllerTransitions, workers: list) -> li
 
 
 def healthy_active_workers(state: ControllerTransitions) -> list[WorkerRow]:
-    with state._db.snapshot() as q:
+    with state._db.read_snapshot() as q:
         workers = WORKER_ROW_PROJECTION.decode(q.fetchall("SELECT * FROM workers WHERE healthy = 1 AND active = 1"))
     return hydrate_worker_attributes(state, workers)
 
 
 def dispatch_task(state: ControllerTransitions, task: TaskDetailRow, worker_id: WorkerId) -> None:
-    state.queue_assignments([Assignment(task_id=task.task_id, worker_id=worker_id)])
-    state.apply_task_updates(
-        HeartbeatApplyRequest(
-            worker_id=worker_id,
-            worker_resource_snapshot=None,
-            updates=[
-                TaskUpdate(
-                    task_id=task.task_id,
-                    attempt_id=query_task(state, task.task_id).current_attempt_id,
-                    new_state=job_pb2.TASK_STATE_RUNNING,
-                )
-            ],
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=task.task_id, worker_id=worker_id)])
+    with state._store.transaction() as cur:
+        state.apply_task_updates(
+            cur,
+            HeartbeatApplyRequest(
+                worker_id=worker_id,
+                worker_resource_snapshot=None,
+                updates=[
+                    TaskUpdate(
+                        task_id=task.task_id,
+                        attempt_id=query_task(state, task.task_id).current_attempt_id,
+                        new_state=job_pb2.TASK_STATE_RUNNING,
+                    )
+                ],
+            ),
         )
-    )
 
 
 def transition_task(
@@ -623,7 +631,8 @@ def transition_task(
     task = query_task_with_attempts(state, task_id)
     assert task is not None
     if new_state == job_pb2.TASK_STATE_KILLED:
-        return state.cancel_job(task.job_id, reason=error or "killed")
+        with state._store.transaction() as cur:
+            return state.cancel_job(cur, task.job_id, reason=error or "killed")
     # Compute worker_id: prefer current attempt's worker, fall back to current_worker_id.
     current_attempt = task.attempts[-1] if task.attempts else None
     worker_id = current_attempt.worker_id if current_attempt is not None else task.current_worker_id
@@ -635,21 +644,23 @@ def transition_task(
             exit_code=exit_code,
         )
         return state
-    return state.apply_task_updates(
-        HeartbeatApplyRequest(
-            worker_id=worker_id,
-            worker_resource_snapshot=None,
-            updates=[
-                TaskUpdate(
-                    task_id=task_id,
-                    attempt_id=task.current_attempt_id,
-                    new_state=new_state,
-                    error=error,
-                    exit_code=exit_code,
-                )
-            ],
+    with state._store.transaction() as cur:
+        return state.apply_task_updates(
+            cur,
+            HeartbeatApplyRequest(
+                worker_id=worker_id,
+                worker_resource_snapshot=None,
+                updates=[
+                    TaskUpdate(
+                        task_id=task_id,
+                        attempt_id=task.current_attempt_id,
+                        new_state=new_state,
+                        error=error,
+                        exit_code=exit_code,
+                    )
+                ],
+            ),
         )
-    )
 
 
 def fail_worker(state: ControllerTransitions, worker_id: WorkerId, error: str) -> None:

--- a/lib/iris/tests/cluster/controller/replay/events.py
+++ b/lib/iris/tests/cluster/controller/replay/events.py
@@ -154,56 +154,60 @@ IrisEvent = (
 
 
 def apply_event(transitions: ControllerTransitions, event: IrisEvent) -> Any:
-    """Dispatch ``event`` to the matching method on ``ControllerTransitions``.
+    """Dispatch ``event`` to the matching method, opening one write transaction.
 
-    Each transition method opens its own transaction — the dispatcher is
-    a thin match on the event variant. Returns whatever the underlying
-    method returns (``TxResult``, ``SubmitJobResult``,
-    ``DirectProviderBatch``, etc.).
+    On this branch ``ControllerTransitions`` methods take an explicit
+    ``cur`` and the caller owns transaction scope. ``apply_event`` opens
+    one transaction per event so scenarios stay branch-agnostic — same
+    granularity as the main-flavor dispatcher that opens its own tx
+    inside each method.
     """
-    match event:
-        case SubmitJob(job_id, request, ts):
-            return transitions.submit_job(job_id, request, ts)
-        case CancelJob(job_id, reason):
-            return transitions.cancel_job(job_id, reason)
-        case RegisterOrRefreshWorker(worker_id, address, metadata, ts, slice_id, scale_group):
-            return transitions.register_or_refresh_worker(
-                worker_id=worker_id,
-                address=address,
-                metadata=metadata,
-                ts=ts,
-                slice_id=slice_id,
-                scale_group=scale_group,
-            )
-        case QueueAssignments(assignments, direct_dispatch):
-            return transitions.queue_assignments(assignments, direct_dispatch=direct_dispatch)
-        case ApplyTaskUpdates(request):
-            return transitions.apply_task_updates(request)
-        case ApplyHeartbeatsBatch(requests):
-            return transitions.apply_heartbeats_batch(requests)
-        case PreemptTask(task_id, reason):
-            return transitions.preempt_task(task_id, reason)
-        case CancelTasksForTimeout(task_ids, reason):
-            return transitions.cancel_tasks_for_timeout(set(task_ids), reason)
-        case MarkTaskUnschedulable(task_id, reason):
-            return transitions.mark_task_unschedulable(task_id, reason)
-        case RemoveFinishedJob(job_id):
-            return transitions.remove_finished_job(job_id)
-        case RemoveWorker(worker_id):
-            return transitions.remove_worker(worker_id)
-        case UpdateWorkerPings(snapshots):
-            return transitions.update_worker_pings(snapshots)
-        case DrainForDirectProvider(max_promotions):
-            return transitions.drain_for_direct_provider(max_promotions)
-        case ApplyDirectProviderUpdates(updates):
-            return transitions.apply_direct_provider_updates(updates)
-        case BufferDirectKill(task_id):
-            return transitions.buffer_direct_kill(task_id)
-        case AddEndpoint(endpoint):
-            return transitions.add_endpoint(endpoint)
-        case RemoveEndpoint(endpoint_id):
-            return transitions.remove_endpoint(endpoint_id)
-        case ReplaceReservationClaims(claims):
-            return transitions.replace_reservation_claims(claims)
-        case _:
-            raise TypeError(f"unhandled IrisEvent variant: {type(event).__name__}")
+    store = transitions._store
+    with store.transaction() as cur:
+        match event:
+            case SubmitJob(job_id, request, ts):
+                return transitions.submit_job(cur, job_id, request, ts)
+            case CancelJob(job_id, reason):
+                return transitions.cancel_job(cur, job_id, reason)
+            case RegisterOrRefreshWorker(worker_id, address, metadata, ts, slice_id, scale_group):
+                return transitions.register_or_refresh_worker(
+                    cur,
+                    worker_id=worker_id,
+                    address=address,
+                    metadata=metadata,
+                    ts=ts,
+                    slice_id=slice_id,
+                    scale_group=scale_group,
+                )
+            case QueueAssignments(assignments, direct_dispatch):
+                return transitions.queue_assignments(cur, assignments, direct_dispatch=direct_dispatch)
+            case ApplyTaskUpdates(request):
+                return transitions.apply_task_updates(cur, request)
+            case ApplyHeartbeatsBatch(requests):
+                return transitions.apply_heartbeats_batch(cur, requests)
+            case PreemptTask(task_id, reason):
+                return transitions.preempt_task(cur, task_id, reason)
+            case CancelTasksForTimeout(task_ids, reason):
+                return transitions.cancel_tasks_for_timeout(cur, set(task_ids), reason)
+            case MarkTaskUnschedulable(task_id, reason):
+                return transitions.mark_task_unschedulable(cur, task_id, reason)
+            case RemoveFinishedJob(job_id):
+                return transitions.remove_finished_job(cur, job_id)
+            case RemoveWorker(worker_id):
+                return transitions.remove_worker(cur, worker_id)
+            case UpdateWorkerPings(snapshots):
+                return transitions.update_worker_pings(cur, snapshots)
+            case DrainForDirectProvider(max_promotions):
+                return transitions.drain_for_direct_provider(cur, max_promotions)
+            case ApplyDirectProviderUpdates(updates):
+                return transitions.apply_direct_provider_updates(cur, updates)
+            case BufferDirectKill(task_id):
+                return transitions.buffer_direct_kill(cur, task_id)
+            case AddEndpoint(endpoint):
+                return transitions.add_endpoint(cur, endpoint)
+            case RemoveEndpoint(endpoint_id):
+                return transitions.remove_endpoint(cur, endpoint_id)
+            case ReplaceReservationClaims(claims):
+                return transitions.replace_reservation_claims(cur, claims)
+            case _:
+                raise TypeError(f"unhandled IrisEvent variant: {type(event).__name__}")

--- a/lib/iris/tests/cluster/controller/test_dashboard.py
+++ b/lib/iris/tests/cluster/controller/test_dashboard.py
@@ -59,7 +59,8 @@ def submit_job(
     """Submit a job through the state command API."""
     jid = JobName.from_string(job_id) if job_id.startswith("/") else JobName.root("test-user", job_id)
     request.name = jid.to_wire()
-    state.submit_job(jid, request, Timestamp.now())
+    with state._store.transaction() as cur:
+        state.submit_job(cur, jid, request, Timestamp.now())
     return jid
 
 
@@ -301,26 +302,30 @@ def test_endpoints_only_returned_for_running_jobs(client, state, job_request):
     set_job_state(state, succeeded_id, job_pb2.JOB_STATE_SUCCEEDED)
 
     # Add endpoints only for non-terminal jobs
-    state.add_endpoint(
-        EndpointRow(
-            endpoint_id="ep1",
-            name="pending-svc",
-            address="h:1",
-            task_id=pending_id.task(0),
-            metadata={},
-            registered_at=Timestamp.now(),
-        ),
-    )
-    state.add_endpoint(
-        EndpointRow(
-            endpoint_id="ep2",
-            name="running-svc",
-            address="h:2",
-            task_id=running_id.task(0),
-            metadata={},
-            registered_at=Timestamp.now(),
-        ),
-    )
+    with state._store.transaction() as cur:
+        state.add_endpoint(
+            cur,
+            EndpointRow(
+                endpoint_id="ep1",
+                name="pending-svc",
+                address="h:1",
+                task_id=pending_id.task(0),
+                metadata={},
+                registered_at=Timestamp.now(),
+            ),
+        )
+    with state._store.transaction() as cur:
+        state.add_endpoint(
+            cur,
+            EndpointRow(
+                endpoint_id="ep2",
+                name="running-svc",
+                address="h:2",
+                task_id=running_id.task(0),
+                metadata={},
+                registered_at=Timestamp.now(),
+            ),
+        )
 
     resp = rpc_post(client, "ListEndpoints", {"prefix": ""})
     endpoints = resp.get("endpoints", [])
@@ -336,16 +341,18 @@ def test_list_endpoints_returns_task_id(client, state, job_request):
     set_job_state(state, job_id, job_pb2.JOB_STATE_RUNNING)
 
     task_id = job_id.task(0)
-    state.add_endpoint(
-        EndpointRow(
-            endpoint_id="ep-task",
-            name="my-actor",
-            address="h:1",
-            task_id=task_id,
-            metadata={},
-            registered_at=Timestamp.now(),
-        ),
-    )
+    with state._store.transaction() as cur:
+        state.add_endpoint(
+            cur,
+            EndpointRow(
+                endpoint_id="ep-task",
+                name="my-actor",
+                address="h:1",
+                task_id=task_id,
+                metadata={},
+                registered_at=Timestamp.now(),
+            ),
+        )
 
     resp = rpc_post(client, "ListEndpoints", {"prefix": ""})
     endpoints = resp.get("endpoints", [])
@@ -754,21 +761,26 @@ def test_get_worker_status_recent_tasks_have_timestamps(client, state, job_reque
     job_id = submit_job(state, "ts-job", job_request)
     task_id = job_id.task(0)
 
-    state.queue_assignments([Assignment(task_id=task_id, worker_id=wid)])
-    state.apply_task_updates(
-        HeartbeatApplyRequest(
-            worker_id=wid,
-            worker_resource_snapshot=None,
-            updates=[TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING)],
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=task_id, worker_id=wid)])
+    with state._store.transaction() as cur:
+        state.apply_task_updates(
+            cur,
+            HeartbeatApplyRequest(
+                worker_id=wid,
+                worker_resource_snapshot=None,
+                updates=[TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING)],
+            ),
         )
-    )
-    state.apply_task_updates(
-        HeartbeatApplyRequest(
-            worker_id=wid,
-            worker_resource_snapshot=None,
-            updates=[TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_SUCCEEDED)],
+    with state._store.transaction() as cur:
+        state.apply_task_updates(
+            cur,
+            HeartbeatApplyRequest(
+                worker_id=wid,
+                worker_resource_snapshot=None,
+                updates=[TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_SUCCEEDED)],
+            ),
         )
-    )
 
     resp = rpc_post(client, "GetWorkerStatus", {"id": "w1"})
     tasks = resp.get("recentTasks", [])
@@ -793,12 +805,15 @@ def test_get_worker_status_includes_running_tasks_and_resource_history(client, s
     wid = register_worker(state, "w1", "10.0.0.5:8080", make_worker_metadata())
     job_id = submit_job(state, "worker-detail-res", job_request)
     task_id = job_id.task(0)
-    state.queue_assignments([Assignment(task_id=task_id, worker_id=wid)])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=task_id, worker_id=wid)])
 
     first = job_pb2.WorkerResourceSnapshot(host_cpu_percent=25, running_task_count=1)
     second = job_pb2.WorkerResourceSnapshot(host_cpu_percent=50, running_task_count=1)
-    state.apply_task_updates(HeartbeatApplyRequest(worker_id=wid, worker_resource_snapshot=first, updates=[]))
-    state.apply_task_updates(HeartbeatApplyRequest(worker_id=wid, worker_resource_snapshot=second, updates=[]))
+    with state._store.transaction() as cur:
+        state.apply_task_updates(cur, HeartbeatApplyRequest(worker_id=wid, worker_resource_snapshot=first, updates=[]))
+    with state._store.transaction() as cur:
+        state.apply_task_updates(cur, HeartbeatApplyRequest(worker_id=wid, worker_resource_snapshot=second, updates=[]))
 
     resp = rpc_post(client, "GetWorkerStatus", {"id": "w1"})
     running_job_ids = resp.get("worker", {}).get("runningJobIds", [])

--- a/lib/iris/tests/cluster/controller/test_direct_controller.py
+++ b/lib/iris/tests/cluster/controller/test_direct_controller.py
@@ -59,7 +59,8 @@ def test_drain_pending_creates_attempt_rows(state):
     task_before = query_task(state, task_id)
     assert task_before.state == job_pb2.TASK_STATE_PENDING
 
-    batch = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch = state.drain_for_direct_provider(cur)
 
     assert len(batch.tasks_to_run) == 1
     assert batch.tasks_to_run[0].task_id == task_id.to_wire()
@@ -78,7 +79,8 @@ def test_drain_propagates_task_image(state):
     """task_image set on the LaunchJobRequest is copied into RunTaskRequest."""
     [task_id] = submit_direct_job(state, "drain-task-image", task_image="custom/swetrace:dev")
 
-    batch = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch = state.drain_for_direct_provider(cur)
 
     assert len(batch.tasks_to_run) == 1
     assert batch.tasks_to_run[0].task_id == task_id.to_wire()
@@ -89,7 +91,8 @@ def test_drain_default_task_image_is_empty(state):
     """When the LaunchJobRequest omits task_image, the dispatched RunTaskRequest is empty."""
     submit_direct_job(state, "drain-default-image")
 
-    batch = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch = state.drain_for_direct_provider(cur)
 
     assert len(batch.tasks_to_run) == 1
     assert batch.tasks_to_run[0].task_image == ""
@@ -110,9 +113,11 @@ def test_drain_includes_workdir_files(state):
         environment=job_pb2.EnvironmentConfig(),
         replicas=1,
     )
-    state.submit_job(job_name, req, Timestamp.now())
+    with state._store.transaction() as cur:
+        state.submit_job(cur, job_name, req, Timestamp.now())
 
-    batch = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch = state.drain_for_direct_provider(cur)
 
     assert len(batch.tasks_to_run) == 1
     run_req = batch.tasks_to_run[0]
@@ -125,12 +130,14 @@ def test_drain_skips_already_assigned(state):
     [task_id] = submit_direct_job(state, "drain-skip")
 
     # First drain promotes to ASSIGNED.
-    batch1 = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch1 = state.drain_for_direct_provider(cur)
     assert len(batch1.tasks_to_run) == 1
     assert len(batch1.running_tasks) == 0
 
     # Second drain: task is already ASSIGNED, so appears only in running_tasks.
-    batch2 = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch2 = state.drain_for_direct_provider(cur)
     assert len(batch2.tasks_to_run) == 0
     assert len(batch2.running_tasks) == 1
     assert batch2.running_tasks[0].task_id == task_id
@@ -141,11 +148,14 @@ def test_drain_kill_queue(state):
     [task_id] = submit_direct_job(state, "drain-kill")
 
     # Promote to ASSIGNED first.
-    state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        state.drain_for_direct_provider(cur)
 
-    state.buffer_direct_kill(task_id.to_wire())
+    with state._store.transaction() as cur:
+        state.buffer_direct_kill(cur, task_id.to_wire())
 
-    batch = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch = state.drain_for_direct_provider(cur)
     assert task_id.to_wire() in batch.tasks_to_kill
 
 
@@ -157,14 +167,17 @@ def test_drain_kill_queue(state):
 def test_apply_running(state):
     """ASSIGNED -> RUNNING via direct provider update."""
     [task_id] = submit_direct_job(state, "apply-running")
-    batch = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch = state.drain_for_direct_provider(cur)
     attempt_id = batch.tasks_to_run[0].attempt_id
 
-    result = state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_RUNNING),
-        ]
-    )
+    with state._store.transaction() as cur:
+        result = state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_RUNNING),
+            ],
+        )
 
     task = query_task(state, task_id)
     assert task.state == job_pb2.TASK_STATE_RUNNING
@@ -174,22 +187,27 @@ def test_apply_running(state):
 def test_apply_succeeded(state):
     """RUNNING -> SUCCEEDED via direct provider update."""
     [task_id] = submit_direct_job(state, "apply-succeeded")
-    batch = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch = state.drain_for_direct_provider(cur)
     attempt_id = batch.tasks_to_run[0].attempt_id
 
     # First move to RUNNING.
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_RUNNING),
-        ]
-    )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_RUNNING),
+            ],
+        )
 
     # Then to SUCCEEDED.
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_SUCCEEDED),
-        ]
-    )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_SUCCEEDED),
+            ],
+        )
 
     task = query_task(state, task_id)
     assert task.state == job_pb2.TASK_STATE_SUCCEEDED
@@ -201,24 +219,30 @@ def test_apply_failed_with_retry(state):
     jid = JobName.root("test-user", "retry-job")
     req = make_direct_job_request("retry-job")
     req.max_retries_failure = 2
-    state.submit_job(jid, req, Timestamp.now())
+    with state._store.transaction() as cur:
+        state.submit_job(cur, jid, req, Timestamp.now())
     with state._db.snapshot() as q:
         tasks = TASK_DETAIL_PROJECTION.decode(q.fetchall("SELECT * FROM tasks WHERE job_id = ?", (jid.to_wire(),)))
     task_id = tasks[0].task_id
 
-    batch = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch = state.drain_for_direct_provider(cur)
     attempt_id = batch.tasks_to_run[0].attempt_id
 
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_RUNNING),
-        ]
-    )
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_FAILED, error="boom"),
-        ]
-    )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_RUNNING),
+            ],
+        )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_FAILED, error="boom"),
+            ],
+        )
 
     task = query_task(state, task_id)
     # Should be back to PENDING because failure_count(1) <= max_retries_failure(2).
@@ -231,24 +255,30 @@ def test_apply_failed_no_retry(state):
     jid = JobName.root("test-user", "no-retry-job")
     req = make_direct_job_request("no-retry-job")
     req.max_retries_failure = 0
-    state.submit_job(jid, req, Timestamp.now())
+    with state._store.transaction() as cur:
+        state.submit_job(cur, jid, req, Timestamp.now())
     with state._db.snapshot() as q:
         tasks = TASK_DETAIL_PROJECTION.decode(q.fetchall("SELECT * FROM tasks WHERE job_id = ?", (jid.to_wire(),)))
     task_id = tasks[0].task_id
 
-    batch = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch = state.drain_for_direct_provider(cur)
     attempt_id = batch.tasks_to_run[0].attempt_id
 
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_RUNNING),
-        ]
-    )
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_FAILED, error="fatal"),
-        ]
-    )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_RUNNING),
+            ],
+        )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_FAILED, error="fatal"),
+            ],
+        )
 
     task = query_task(state, task_id)
     assert task.state == job_pb2.TASK_STATE_FAILED
@@ -258,19 +288,22 @@ def test_apply_failed_no_retry(state):
 def test_apply_failed_directly_from_assigned(state):
     """ASSIGNED -> FAILED without going through RUNNING (e.g. ConfigMap too large)."""
     [task_id] = submit_direct_job(state, "fail-on-apply")
-    batch = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch = state.drain_for_direct_provider(cur)
     attempt_id = batch.tasks_to_run[0].attempt_id
 
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(
-                task_id=task_id,
-                attempt_id=attempt_id,
-                new_state=job_pb2.TASK_STATE_FAILED,
-                error="kubectl apply failed: RequestEntityTooLarge",
-            ),
-        ]
-    )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(
+                    task_id=task_id,
+                    attempt_id=attempt_id,
+                    new_state=job_pb2.TASK_STATE_FAILED,
+                    error="kubectl apply failed: RequestEntityTooLarge",
+                ),
+            ],
+        )
 
     task = query_task(state, task_id)
     assert task.state == job_pb2.TASK_STATE_FAILED
@@ -282,24 +315,30 @@ def test_apply_worker_failed_from_running_retries(state):
     jid = JobName.root("test-user", "wf-retry")
     req = make_direct_job_request("wf-retry")
     req.max_retries_preemption = 5
-    state.submit_job(jid, req, Timestamp.now())
+    with state._store.transaction() as cur:
+        state.submit_job(cur, jid, req, Timestamp.now())
     with state._db.snapshot() as q:
         tasks = TASK_DETAIL_PROJECTION.decode(q.fetchall("SELECT * FROM tasks WHERE job_id = ?", (jid.to_wire(),)))
     task_id = tasks[0].task_id
 
-    batch = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch = state.drain_for_direct_provider(cur)
     attempt_id = batch.tasks_to_run[0].attempt_id
 
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_RUNNING),
-        ]
-    )
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_WORKER_FAILED),
-        ]
-    )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_RUNNING),
+            ],
+        )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_WORKER_FAILED),
+            ],
+        )
 
     task = query_task(state, task_id)
     assert task.state == job_pb2.TASK_STATE_PENDING
@@ -309,15 +348,18 @@ def test_apply_worker_failed_from_running_retries(state):
 def test_apply_worker_failed_from_assigned(state):
     """WORKER_FAILED from ASSIGNED returns to PENDING without incrementing preemption_count."""
     [task_id] = submit_direct_job(state, "wf-assigned")
-    batch = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch = state.drain_for_direct_provider(cur)
     attempt_id = batch.tasks_to_run[0].attempt_id
 
     # Task is ASSIGNED after drain (not yet RUNNING).
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_WORKER_FAILED),
-        ]
-    )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_WORKER_FAILED),
+            ],
+        )
 
     task = query_task(state, task_id)
     assert task.state == job_pb2.TASK_STATE_PENDING
@@ -326,7 +368,8 @@ def test_apply_worker_failed_from_assigned(state):
 
 def test_buffer_direct_kill(state):
     """buffer_direct_kill inserts a kill entry with NULL worker_id."""
-    state.buffer_direct_kill("some-task-id")
+    with state._store.transaction() as cur:
+        state.buffer_direct_kill(cur, "some-task-id")
 
     rows = state._db.fetchall(
         "SELECT worker_id, kind, task_id FROM dispatch_queue WHERE worker_id IS NULL",
@@ -348,7 +391,8 @@ def test_drain_multiple_tasks(state):
     task_ids = submit_direct_job(state, "multi-task", replicas=3)
     assert len(task_ids) == 3
 
-    batch = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch = state.drain_for_direct_provider(cur)
     assert len(batch.tasks_to_run) == 3
 
     promoted_ids = {req.task_id for req in batch.tasks_to_run}
@@ -359,15 +403,18 @@ def test_drain_multiple_tasks(state):
 def test_apply_ignores_stale_attempt(state):
     """Updates with a mismatched attempt_id are silently skipped."""
     [task_id] = submit_direct_job(state, "stale-attempt")
-    batch = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch = state.drain_for_direct_provider(cur)
     attempt_id = batch.tasks_to_run[0].attempt_id
 
     # Apply with wrong attempt_id.
-    result = state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=attempt_id + 99, new_state=job_pb2.TASK_STATE_RUNNING),
-        ]
-    )
+    with state._store.transaction() as cur:
+        result = state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=attempt_id + 99, new_state=job_pb2.TASK_STATE_RUNNING),
+            ],
+        )
 
     task = query_task(state, task_id)
     # Should still be ASSIGNED (the update was skipped).
@@ -378,27 +425,34 @@ def test_apply_ignores_stale_attempt(state):
 def test_apply_ignores_finished_task(state):
     """Updates to already-finished tasks are silently skipped."""
     [task_id] = submit_direct_job(state, "finished-task")
-    batch = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch = state.drain_for_direct_provider(cur)
     attempt_id = batch.tasks_to_run[0].attempt_id
 
     # Move to SUCCEEDED.
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_RUNNING),
-        ]
-    )
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_SUCCEEDED),
-        ]
-    )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_RUNNING),
+            ],
+        )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_SUCCEEDED),
+            ],
+        )
 
     # Try to move to FAILED after already succeeded.
-    result = state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_FAILED),
-        ]
-    )
+    with state._store.transaction() as cur:
+        result = state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_FAILED),
+            ],
+        )
 
     task = query_task(state, task_id)
     assert task.state == job_pb2.TASK_STATE_SUCCEEDED

--- a/lib/iris/tests/cluster/controller/test_preemption.py
+++ b/lib/iris/tests/cluster/controller/test_preemption.py
@@ -274,7 +274,8 @@ def test_preempted_task_retries():
         assert query_task(state, task.task_id).state == job_pb2.TASK_STATE_RUNNING
 
         # Preempt
-        state.preempt_task(task.task_id, reason="Preempted by /bob/prod-job:0")
+        with state._store.transaction() as cur:
+            state.preempt_task(cur, task.task_id, reason="Preempted by /bob/prod-job:0")
 
         # Task should be PENDING (retry)
         updated = query_task(state, task.task_id)
@@ -300,7 +301,8 @@ def test_preempted_task_exhausted_retries():
         harness.dispatch(task, w1)
         assert query_task(state, task.task_id).state == job_pb2.TASK_STATE_RUNNING
 
-        state.preempt_task(task.task_id, reason="preempted")
+        with state._store.transaction() as cur:
+            state.preempt_task(cur, task.task_id, reason="preempted")
 
         updated = query_task(state, task.task_id)
         assert updated.state == job_pb2.TASK_STATE_PREEMPTED
@@ -496,10 +498,12 @@ def test_preempted_assigned_task_always_retries():
         task = tasks[0]
 
         # Only assign, don't advance to RUNNING
-        state.queue_assignments([Assignment(task_id=task.task_id, worker_id=w1)])
+        with state._store.transaction() as cur:
+            state.queue_assignments(cur, [Assignment(task_id=task.task_id, worker_id=w1)])
         assert query_task(state, task.task_id).state == job_pb2.TASK_STATE_ASSIGNED
 
-        state.preempt_task(task.task_id, reason="preempted while assigned")
+        with state._store.transaction() as cur:
+            state.preempt_task(cur, task.task_id, reason="preempted while assigned")
 
         updated = query_task(state, task.task_id)
         assert updated.state == job_pb2.TASK_STATE_PENDING, "ASSIGNED tasks should always retry on preemption"
@@ -604,7 +608,8 @@ def test_preemption_across_multiple_workers():
 def test_preemption_nonexistent_task_is_noop():
     """Preempting a non-existent task is a no-op."""
     with make_controller_state() as state:
-        result = state.preempt_task(JobName.from_wire("/ghost/job:0"), reason="does not exist")
+        with state._store.transaction() as cur:
+            result = state.preempt_task(cur, JobName.from_wire("/ghost/job:0"), reason="does not exist")
         assert result.tasks_to_kill == set()
 
 
@@ -623,7 +628,8 @@ def test_preemption_terminal_task_is_noop():
         assert query_task(state, task.task_id).state == job_pb2.TASK_STATE_SUCCEEDED
 
         # Preempt should be no-op
-        state.preempt_task(task.task_id, reason="too late")
+        with state._store.transaction() as cur:
+            state.preempt_task(cur, task.task_id, reason="too late")
         assert query_task(state, task.task_id).state == job_pb2.TASK_STATE_SUCCEEDED
 
 
@@ -714,7 +720,8 @@ def test_preempt_task_retries_when_budget_remains():
         assert query_task(state, task.task_id).state == job_pb2.TASK_STATE_RUNNING
 
         attempt_id_before = query_task(state, task.task_id).current_attempt_id
-        state.preempt_task(task.task_id, reason="Evicted by /bob/prod:0")
+        with state._store.transaction() as cur:
+            state.preempt_task(cur, task.task_id, reason="Evicted by /bob/prod:0")
 
         # Task retries to PENDING
         updated = query_task(state, task.task_id)
@@ -742,7 +749,8 @@ def test_preempt_task_terminal_when_budget_exhausted():
         task = tasks[0]
         harness.dispatch(task, w1)
 
-        result = state.preempt_task(task.task_id, reason="budget gone")
+        with state._store.transaction() as cur:
+            result = state.preempt_task(cur, task.task_id, reason="budget gone")
 
         updated = query_task(state, task.task_id)
         assert updated.state == job_pb2.TASK_STATE_PREEMPTED
@@ -794,14 +802,16 @@ def test_preempt_task_cascades_coscheduled_siblings():
             dispatch_task(state, task, WorkerId(f"w{i}"))
 
         # Preempt the first task — it goes terminal PREEMPTED
-        result0 = state.preempt_task(tasks[0].task_id, reason="preempted by prod")
+        with state._store.transaction() as cur:
+            result0 = state.preempt_task(cur, tasks[0].task_id, reason="preempted by prod")
         assert query_task(state, tasks[0].task_id).state == job_pb2.TASK_STATE_PREEMPTED
 
         # Second task is still running (preempt_task doesn't directly cascade siblings)
         assert query_task(state, tasks[1].task_id).state == job_pb2.TASK_STATE_RUNNING
 
         # Preempt the second task — now ALL tasks are terminal, job finalizes
-        result1 = state.preempt_task(tasks[1].task_id, reason="preempted by prod")
+        with state._store.transaction() as cur:
+            result1 = state.preempt_task(cur, tasks[1].task_id, reason="preempted by prod")
         assert query_task(state, tasks[1].task_id).state == job_pb2.TASK_STATE_PREEMPTED
 
         # Both tasks should be in the combined kill set
@@ -879,7 +889,8 @@ def test_preemption_retry_preserves_reservation_holder():
         dispatch_task(state, child_tasks[0], w2)
 
         # Preempt the parent task — it should retry (go PENDING)
-        state.preempt_task(parent_task.task_id, reason="Preempted by higher priority")
+        with state._store.transaction() as cur:
+            state.preempt_task(cur, parent_task.task_id, reason="Preempted by higher priority")
 
         # Parent task should be PENDING (retry)
         updated_parent = query_task(state, parent_task.task_id)
@@ -941,7 +952,8 @@ def test_late_heartbeat_after_preempt_to_pending_does_not_revive_attempt():
         dead_attempt_id = query_task(state, task.task_id).current_attempt_id
         assert dead_attempt_id == 0
 
-        state.preempt_task(task.task_id, reason="Preempted by /bob/prod-job:0")
+        with state._store.transaction() as cur:
+            state.preempt_task(cur, task.task_id, reason="Preempted by /bob/prod-job:0")
 
         # Sanity: task went to PENDING (budget remains), attempt row is PREEMPTED-terminal.
         assert query_task(state, task.task_id).state == job_pb2.TASK_STATE_PENDING
@@ -953,19 +965,21 @@ def test_late_heartbeat_after_preempt_to_pending_does_not_revive_attempt():
 
         # Late heartbeat for the (now-dead) attempt 0 arrives: worker still thinks
         # it is RUNNING. This simulates the RPC-in-flight race.
-        state.apply_task_updates(
-            HeartbeatApplyRequest(
-                worker_id=worker_id,
-                worker_resource_snapshot=None,
-                updates=[
-                    TaskUpdate(
-                        task_id=task.task_id,
-                        attempt_id=dead_attempt_id,
-                        new_state=job_pb2.TASK_STATE_RUNNING,
-                    )
-                ],
+        with state._store.transaction() as cur:
+            state.apply_task_updates(
+                cur,
+                HeartbeatApplyRequest(
+                    worker_id=worker_id,
+                    worker_resource_snapshot=None,
+                    updates=[
+                        TaskUpdate(
+                            task_id=task.task_id,
+                            attempt_id=dead_attempt_id,
+                            new_state=job_pb2.TASK_STATE_RUNNING,
+                        )
+                    ],
+                ),
             )
-        )
 
         # The attempt row must remain in a consistent terminal state — NOT flipped
         # back to RUNNING with preemption error/finished_at still set.

--- a/lib/iris/tests/cluster/controller/test_reservation.py
+++ b/lib/iris/tests/cluster/controller/test_reservation.py
@@ -210,12 +210,14 @@ def _register_worker(
     metadata: job_pb2.WorkerMetadata | None = None,
 ) -> WorkerId:
     wid = WorkerId(worker_id)
-    state.register_or_refresh_worker(
-        worker_id=wid,
-        address=f"{worker_id}:8080",
-        metadata=metadata or _cpu_metadata(),
-        ts=Timestamp.now(),
-    )
+    with state._store.transaction() as cur:
+        state.register_or_refresh_worker(
+            cur,
+            worker_id=wid,
+            address=f"{worker_id}:8080",
+            metadata=metadata or _cpu_metadata(),
+            ts=Timestamp.now(),
+        )
     return wid
 
 
@@ -226,7 +228,8 @@ def _submit_job(
 ) -> JobName:
     jid = JobName.root("test-user", job_id)
     request.name = jid.to_wire()
-    state.submit_job(jid, request, Timestamp.now())
+    with state._store.transaction() as cur:
+        state.submit_job(cur, jid, request, Timestamp.now())
     return jid
 
 
@@ -449,7 +452,8 @@ def test_cleanup_removes_dead_worker_claims(ctrl):
         job_id=JobName.root("test-user", "j1").to_wire(),
         entry_idx=99,
     )
-    ctrl.state.replace_reservation_claims(claims)
+    with ctrl.state._store.transaction() as cur:
+        ctrl.state.replace_reservation_claims(cur, claims)
     assert len(ctrl.reservation_claims) == 2
 
     ctrl._cleanup_stale_claims()
@@ -470,7 +474,8 @@ def test_cleanup_removes_finished_job_claims(ctrl):
     assert len(ctrl.reservation_claims) == 1
 
     # Kill the job to mark it as finished.
-    ctrl.state.cancel_job(jid, reason="test")
+    with ctrl.state._store.transaction() as cur:
+        ctrl.state.cancel_job(cur, jid, reason="test")
 
     job = _query_job(ctrl.state, jid)
     assert is_job_finished(job.state)
@@ -1016,7 +1021,8 @@ def test_find_reservation_ancestor_returns_parent_with_reservation(ctrl):
         environment=job_pb2.EnvironmentConfig(),
         replicas=1,
     )
-    ctrl.state.submit_job(child_jid, child_req, Timestamp.now())
+    with ctrl.state._store.transaction() as cur:
+        ctrl.state.submit_job(cur, child_jid, child_req, Timestamp.now())
 
     result = _find_reservation_ancestor(ctrl._db, child_jid)
     assert result == parent_jid
@@ -1039,7 +1045,8 @@ def test_find_reservation_ancestor_returns_grandparent(ctrl):
         environment=job_pb2.EnvironmentConfig(),
         replicas=1,
     )
-    ctrl.state.submit_job(parent_jid, parent_req, Timestamp.now())
+    with ctrl.state._store.transaction() as cur:
+        ctrl.state.submit_job(cur, parent_jid, parent_req, Timestamp.now())
 
     # Grandchild
     gc_jid = JobName.from_string("/test-user/gp/parent/gc")
@@ -1050,7 +1057,8 @@ def test_find_reservation_ancestor_returns_grandparent(ctrl):
         environment=job_pb2.EnvironmentConfig(),
         replicas=1,
     )
-    ctrl.state.submit_job(gc_jid, gc_req, Timestamp.now())
+    with ctrl.state._store.transaction() as cur:
+        ctrl.state.submit_job(cur, gc_jid, gc_req, Timestamp.now())
 
     result = _find_reservation_ancestor(ctrl._db, gc_jid)
     assert result == gp_jid
@@ -1088,7 +1096,8 @@ def test_find_reservation_ancestor_returns_none_when_no_ancestor_has_reservation
         environment=job_pb2.EnvironmentConfig(),
         replicas=1,
     )
-    ctrl.state.submit_job(child_jid, child_req, Timestamp.now())
+    with ctrl.state._store.transaction() as cur:
+        ctrl.state.submit_job(cur, child_jid, child_req, Timestamp.now())
 
     assert _find_reservation_ancestor(ctrl._db, child_jid) is None
 
@@ -1127,7 +1136,8 @@ def test_taint_exemption_for_children_of_reservation_job(ctrl):
         environment=job_pb2.EnvironmentConfig(),
         replicas=1,
     )
-    ctrl.state.submit_job(child_jid, child_req, Timestamp.now())
+    with ctrl.state._store.transaction() as cur:
+        ctrl.state.submit_job(cur, child_jid, child_req, Timestamp.now())
 
     # Build scheduling state — child should be in has_reservation
     pending = _schedulable_tasks(ctrl.state)
@@ -1192,7 +1202,8 @@ def test_grandchildren_inherit_reservation_from_ancestor(ctrl):
         ],
     )
     child_a_req.name = child_a_jid.to_wire()
-    ctrl.state.submit_job(child_a_jid, child_a_req, Timestamp.now())
+    with ctrl.state._store.transaction() as cur:
+        ctrl.state.submit_job(cur, child_a_jid, child_a_req, Timestamp.now())
 
     # Child-B reserves 2 A100
     child_b_jid = JobName.from_string("/test-user/root/child-b")
@@ -1203,7 +1214,8 @@ def test_grandchildren_inherit_reservation_from_ancestor(ctrl):
         ],
     )
     child_b_req.name = child_b_jid.to_wire()
-    ctrl.state.submit_job(child_b_jid, child_b_req, Timestamp.now())
+    with ctrl.state._store.transaction() as cur:
+        ctrl.state.submit_job(cur, child_b_jid, child_b_req, Timestamp.now())
 
     ctrl._claim_workers_for_reservations()
     assert len(ctrl.reservation_claims) == 4
@@ -1221,7 +1233,8 @@ def test_grandchildren_inherit_reservation_from_ancestor(ctrl):
         environment=job_pb2.EnvironmentConfig(),
         replicas=1,
     )
-    ctrl.state.submit_job(gc_a_jid, gc_a_req, Timestamp.now())
+    with ctrl.state._store.transaction() as cur:
+        ctrl.state.submit_job(cur, gc_a_jid, gc_a_req, Timestamp.now())
 
     # Grandchild-B (under child-B) requesting A100
     gc_b_jid = JobName.from_string("/test-user/root/child-b/gc-b")
@@ -1236,7 +1249,8 @@ def test_grandchildren_inherit_reservation_from_ancestor(ctrl):
         environment=job_pb2.EnvironmentConfig(),
         replicas=1,
     )
-    ctrl.state.submit_job(gc_b_jid, gc_b_req, Timestamp.now())
+    with ctrl.state._store.transaction() as cur:
+        ctrl.state.submit_job(cur, gc_b_jid, gc_b_req, Timestamp.now())
 
     # Build scheduling state
     pending = _schedulable_tasks(ctrl.state)
@@ -1381,7 +1395,8 @@ def test_holder_task_worker_death_no_failure_record(state):
         worker_id = _register_worker(state, f"worker-{cycle}")
 
         # Assign the holder task to the worker (mimics what the scheduler does).
-        state.queue_assignments([Assignment(task_id=holder_task.task_id, worker_id=worker_id)])
+        with state._store.transaction() as cur:
+            state.queue_assignments(cur, [Assignment(task_id=holder_task.task_id, worker_id=worker_id)])
         current_holder = _query_task_with_attempts(state, holder_task.task_id)
         assert current_holder is not None
         assert current_holder.state == job_pb2.TASK_STATE_ASSIGNED
@@ -1439,14 +1454,17 @@ def test_get_running_tasks_for_poll_excludes_reservation_holders(state):
     (real_task,) = _submit_job_tasks(state, "real-job", real_request)
 
     worker_id = _register_worker(state, "w1")
-    state.queue_assignments(
-        [
-            Assignment(task_id=holder_task.task_id, worker_id=worker_id),
-            Assignment(task_id=real_task.task_id, worker_id=worker_id),
-        ]
-    )
+    with state._store.transaction() as cur:
+        state.queue_assignments(
+            cur,
+            [
+                Assignment(task_id=holder_task.task_id, worker_id=worker_id),
+                Assignment(task_id=real_task.task_id, worker_id=worker_id),
+            ],
+        )
 
-    running, _addresses = state.get_running_tasks_for_poll()
+    with state._store.read_snapshot() as snap:
+        running, _addresses = state.get_running_tasks_for_poll(snap)
 
     task_ids = {entry.task_id for entry in running.get(worker_id, [])}
     assert real_task.task_id in task_ids, "real task must still appear for polling"
@@ -1482,27 +1500,31 @@ def test_holder_task_removed_from_worker_when_parent_succeeds(state):
     wid_holder = _register_worker(state, "worker-holder")
     wid_parent = _register_worker(state, "worker-parent")
 
-    state.queue_assignments([Assignment(task_id=holder_task.task_id, worker_id=wid_holder)])
-    state.queue_assignments([Assignment(task_id=parent_task.task_id, worker_id=wid_parent)])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=holder_task.task_id, worker_id=wid_holder)])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=parent_task.task_id, worker_id=wid_parent)])
 
     assert holder_task.task_id in _worker_running_tasks(state, wid_holder)
 
     # Parent task succeeds → _finalize_job_state(SUCCEEDED) → _cancel_child_jobs
     # → holder task killed → running_tasks entry discarded.
     parent_task = _query_task_with_attempts(state, parent_task.task_id)
-    state.apply_task_updates(
-        HeartbeatApplyRequest(
-            worker_id=wid_parent,
-            worker_resource_snapshot=None,
-            updates=[
-                TaskUpdate(
-                    task_id=parent_task.task_id,
-                    attempt_id=parent_task.current_attempt_id,
-                    new_state=job_pb2.TASK_STATE_SUCCEEDED,
-                )
-            ],
+    with state._store.transaction() as cur:
+        state.apply_task_updates(
+            cur,
+            HeartbeatApplyRequest(
+                worker_id=wid_parent,
+                worker_resource_snapshot=None,
+                updates=[
+                    TaskUpdate(
+                        task_id=parent_task.task_id,
+                        attempt_id=parent_task.current_attempt_id,
+                        new_state=job_pb2.TASK_STATE_SUCCEEDED,
+                    )
+                ],
+            ),
         )
-    )
 
     holder_task = _query_task(state, holder_task.task_id)
     assert holder_task is not None
@@ -1533,7 +1555,8 @@ def test_holder_task_removed_from_worker_when_parent_cancelled_all_tasks_already
     parent_task = parent_tasks[0]
 
     wid = _register_worker(state, "worker")
-    state.queue_assignments([Assignment(task_id=holder_task.task_id, worker_id=wid)])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=holder_task.task_id, worker_id=wid)])
 
     assert holder_task.task_id in _worker_running_tasks(state, wid)
 
@@ -1550,7 +1573,8 @@ def test_holder_task_removed_from_worker_when_parent_cancelled_all_tasks_already
     # Fire JobCancelledEvent. All parent tasks are now terminal so the loop
     # skips them. Only the explicit _cancel_child_jobs call at the end of
     # _on_job_cancelled can clean up the holder.
-    state.cancel_job(parent_job_id, reason="manual cancel")
+    with state._store.transaction() as cur:
+        state.cancel_job(cur, parent_job_id, reason="manual cancel")
 
     holder_task = _query_task(state, holder_task.task_id)
     assert holder_task is not None

--- a/lib/iris/tests/cluster/controller/test_reservation_holder_reset_regression.py
+++ b/lib/iris/tests/cluster/controller/test_reservation_holder_reset_regression.py
@@ -85,35 +85,39 @@ def test_non_holder_task_not_reset_like_reservation_holder_on_worker_failure(sta
     other_task = other_tasks[0]
 
     worker_id = _register_worker(state, "co-located-worker")
-    state.queue_assignments(
-        [
-            Assignment(task_id=holder_task.task_id, worker_id=worker_id),
-            Assignment(task_id=parent_task.task_id, worker_id=worker_id),
-            Assignment(task_id=other_task.task_id, worker_id=worker_id),
-        ]
-    )
+    with state._store.transaction() as cur:
+        state.queue_assignments(
+            cur,
+            [
+                Assignment(task_id=holder_task.task_id, worker_id=worker_id),
+                Assignment(task_id=parent_task.task_id, worker_id=worker_id),
+                Assignment(task_id=other_task.task_id, worker_id=worker_id),
+            ],
+        )
 
     # Move the non-holder task to RUNNING so WORKER_FAILED counts as a
     # preemption (not a delivery failure). This matches the production shape:
     # task had actually executed on the worker before it died.
-    state.apply_task_updates(
-        HeartbeatApplyRequest(
-            worker_id=worker_id,
-            worker_resource_snapshot=None,
-            updates=[
-                TaskUpdate(
-                    task_id=parent_task.task_id,
-                    attempt_id=query_task(state, parent_task.task_id).current_attempt_id,
-                    new_state=job_pb2.TASK_STATE_RUNNING,
-                ),
-                TaskUpdate(
-                    task_id=other_task.task_id,
-                    attempt_id=query_task(state, other_task.task_id).current_attempt_id,
-                    new_state=job_pb2.TASK_STATE_RUNNING,
-                ),
-            ],
+    with state._store.transaction() as cur:
+        state.apply_task_updates(
+            cur,
+            HeartbeatApplyRequest(
+                worker_id=worker_id,
+                worker_resource_snapshot=None,
+                updates=[
+                    TaskUpdate(
+                        task_id=parent_task.task_id,
+                        attempt_id=query_task(state, parent_task.task_id).current_attempt_id,
+                        new_state=job_pb2.TASK_STATE_RUNNING,
+                    ),
+                    TaskUpdate(
+                        task_id=other_task.task_id,
+                        attempt_id=query_task(state, other_task.task_id).current_attempt_id,
+                        new_state=job_pb2.TASK_STATE_RUNNING,
+                    ),
+                ],
+            ),
         )
-    )
 
     # Capture the non-holder task's pre-failure attempt state so we can
     # assert on preservation.
@@ -200,11 +204,14 @@ def test_resubmitted_task_does_not_inherit_prior_worker_task_history(state):
 
     worker_id = _register_worker(state, "history-worker")
     # queue_assignments inserts worker_task_history(worker_id, task_id, ...).
-    state.queue_assignments([Assignment(task_id=task_v1.task_id, worker_id=worker_id)])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=task_v1.task_id, worker_id=worker_id)])
     # Cancel to terminal, then remove the finished job. The job's tasks + attempts
     # cascade; worker_task_history does NOT (no FK on task_id).
-    state.cancel_job(job_id, "Terminated by user")
-    assert state.remove_finished_job(job_id) is True
+    with state._store.transaction() as cur:
+        state.cancel_job(cur, job_id, "Terminated by user")
+    with state._store.transaction() as cur:
+        assert state.remove_finished_job(cur, job_id) is True
 
     # === Round 2: re-submit the same job name ========================
     request2 = make_job_request("reusable-job-name", max_retries_preemption=0)
@@ -257,7 +264,8 @@ def test_reservation_holder_task_is_still_reset_on_worker_failure(state):
     holder_task = query_tasks_for_job(state, holder_job_id)[0]
 
     worker_id = _register_worker(state, "w-holder-only")
-    state.queue_assignments([Assignment(task_id=holder_task.task_id, worker_id=worker_id)])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=holder_task.task_id, worker_id=worker_id)])
 
     fail_worker(state, worker_id, "crash")
 
@@ -292,12 +300,14 @@ def test_reservation_holder_reassignment_across_successive_worker_failures(state
     for cycle_idx, worker_name in enumerate(("w-res-1", "w-res-2", "w-res-3")):
         worker_id = _register_worker(state, worker_name)
         # Assignment issued by scheduler: attempt_id = current_attempt_id + 1.
-        state.queue_assignments(
-            [
-                Assignment(task_id=holder_task.task_id, worker_id=worker_id),
-                Assignment(task_id=non_holder_task.task_id, worker_id=worker_id),
-            ]
-        )
+        with state._store.transaction() as cur:
+            state.queue_assignments(
+                cur,
+                [
+                    Assignment(task_id=holder_task.task_id, worker_id=worker_id),
+                    Assignment(task_id=non_holder_task.task_id, worker_id=worker_id),
+                ],
+            )
         expected_attempts += 1
 
         holder_assigned = query_task_with_attempts(state, holder_task.task_id)

--- a/lib/iris/tests/cluster/controller/test_reservation_holder_reset_regression.py
+++ b/lib/iris/tests/cluster/controller/test_reservation_holder_reset_regression.py
@@ -272,7 +272,7 @@ def test_reservation_holder_reassignment_across_successive_worker_failures(state
     ``tasks.current_attempt_id = -1`` while only DELETing the single current
     attempt row. Across repeated worker failures this left orphan attempt rows
     in ``task_attempts`` whose primary key collided with the next
-    ``_assign_task`` INSERT, raising ``sqlite3.IntegrityError`` and killing the
+    assignment attempt insert, raising ``sqlite3.IntegrityError`` and killing the
     scheduling thread.
 
     The fix routes holders through ``_terminate_task``, so the attempt row is

--- a/lib/iris/tests/cluster/controller/test_scheduler.py
+++ b/lib/iris/tests/cluster/controller/test_scheduler.py
@@ -73,39 +73,44 @@ def _worker_attr(state: ControllerTransitions, worker_id: WorkerId, key: str):
 
 
 def assign_task_to_worker(state: ControllerTransitions, task, worker_id: WorkerId) -> None:
-    state.queue_assignments([Assignment(task_id=task.task_id, worker_id=worker_id)])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=task.task_id, worker_id=worker_id)])
 
 
 def transition_task_to_running(state: ControllerTransitions, task) -> None:
-    state.apply_task_updates(
-        HeartbeatApplyRequest(
-            worker_id=task.current_worker_id,
-            worker_resource_snapshot=None,
-            updates=[
-                TaskUpdate(
-                    task_id=task.task_id,
-                    attempt_id=task.current_attempt_id,
-                    new_state=job_pb2.TASK_STATE_RUNNING,
-                )
-            ],
+    with state._store.transaction() as cur:
+        state.apply_task_updates(
+            cur,
+            HeartbeatApplyRequest(
+                worker_id=task.current_worker_id,
+                worker_resource_snapshot=None,
+                updates=[
+                    TaskUpdate(
+                        task_id=task.task_id,
+                        attempt_id=task.current_attempt_id,
+                        new_state=job_pb2.TASK_STATE_RUNNING,
+                    )
+                ],
+            ),
         )
-    )
 
 
 def transition_task_to_state(state: ControllerTransitions, task, new_state: int) -> None:
-    state.apply_task_updates(
-        HeartbeatApplyRequest(
-            worker_id=task.current_worker_id,
-            worker_resource_snapshot=None,
-            updates=[
-                TaskUpdate(
-                    task_id=task.task_id,
-                    attempt_id=task.current_attempt_id,
-                    new_state=new_state,
-                )
-            ],
+    with state._store.transaction() as cur:
+        state.apply_task_updates(
+            cur,
+            HeartbeatApplyRequest(
+                worker_id=task.current_worker_id,
+                worker_resource_snapshot=None,
+                updates=[
+                    TaskUpdate(
+                        task_id=task.task_id,
+                        attempt_id=task.current_attempt_id,
+                        new_state=new_state,
+                    )
+                ],
+            ),
         )
-    )
 
 
 def _build_context(scheduler, state):

--- a/lib/iris/tests/cluster/controller/test_scheduling_fairness.py
+++ b/lib/iris/tests/cluster/controller/test_scheduling_fairness.py
@@ -131,7 +131,8 @@ def test_depth_boost_within_band():
             environment=parent_req.environment,
             replicas=1,
         )
-        state.submit_job(child_id, child_req, Timestamp.now())
+        with state._store.transaction() as cur:
+            state.submit_job(cur, child_id, child_req, Timestamp.now())
         child_tasks = query_tasks_for_job(state, child_id)
 
         schedulable = _schedulable_tasks(state._db)
@@ -171,7 +172,8 @@ def test_child_inherits_parent_band():
             environment=parent_req.environment,
             replicas=1,
         )
-        state.submit_job(child_id, child_req, Timestamp.now())
+        with state._store.transaction() as cur:
+            state.submit_job(cur, child_id, child_req, Timestamp.now())
         child_tasks = query_tasks_for_job(state, child_id)
 
         # Child should have inherited PRODUCTION band
@@ -309,21 +311,25 @@ def test_unplaceable_tasks_do_not_starve_placeable_tasks(make_controller, tmp_pa
         tpu_req.resources.device.tpu.variant = "v5p-8"
         inject_device_constraints(tpu_req)
         jid = JobName.from_string(f"/alice/tpu-job-{i}")
-        ctrl._transitions.submit_job(jid, tpu_req, Timestamp.now())
+        with ctrl._transitions._store.transaction() as cur:
+            ctrl._transitions.submit_job(cur, jid, tpu_req, Timestamp.now())
 
     # Submit 1 CPU task for alice — this should be placeable on the CPU worker
     cpu_jid = JobName.from_string("/alice/cpu-job")
     cpu_req = make_job_request(name="/alice/cpu-job", cpu=1, replicas=1)
     inject_device_constraints(cpu_req)
-    ctrl._transitions.submit_job(cpu_jid, cpu_req, Timestamp.now())
+    with ctrl._transitions._store.transaction() as cur:
+        ctrl._transitions.submit_job(cur, cpu_jid, cpu_req, Timestamp.now())
 
     # Register exactly 1 CPU worker — no TPU workers
-    ctrl._transitions.register_or_refresh_worker(
-        worker_id=WorkerId("cpu-worker"),
-        address="cpu-worker:8080",
-        metadata=make_worker_metadata(cpu=4, memory_bytes=8 * 1024**3),
-        ts=Timestamp.now(),
-    )
+    with ctrl._transitions._store.transaction() as cur:
+        ctrl._transitions.register_or_refresh_worker(
+            cur,
+            worker_id=WorkerId("cpu-worker"),
+            address="cpu-worker:8080",
+            metadata=make_worker_metadata(cpu=4, memory_bytes=8 * 1024**3),
+            ts=Timestamp.now(),
+        )
 
     outcome = ctrl._run_scheduling()
 

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -54,12 +54,14 @@ def _register_worker(state: ControllerTransitions, worker_id: WorkerId) -> None:
         memory_bytes=16 * 1024**3,
         disk_bytes=100 * 1024**3,
     )
-    state.register_or_refresh_worker(
-        worker_id=worker_id,
-        address=f"{worker_id}:8080",
-        metadata=metadata,
-        ts=Timestamp.now(),
-    )
+    with state._store.transaction() as cur:
+        state.register_or_refresh_worker(
+            cur,
+            worker_id=worker_id,
+            address=f"{worker_id}:8080",
+            metadata=metadata,
+            ts=Timestamp.now(),
+        )
 
 
 def _set_job_state(state: ControllerTransitions, job_id: JobName, state_value: int) -> None:
@@ -77,22 +79,27 @@ def _assign_and_transition(
     *,
     error: str | None = None,
 ) -> None:
-    state.queue_assignments([Assignment(task_id=task_id, worker_id=worker_id)])
-    state.apply_task_updates(
-        HeartbeatApplyRequest(
-            worker_id=worker_id,
-            worker_resource_snapshot=None,
-            updates=[TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING)],
-        )
-    )
-    if target_state != job_pb2.TASK_STATE_RUNNING:
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=task_id, worker_id=worker_id)])
+    with state._store.transaction() as cur:
         state.apply_task_updates(
+            cur,
             HeartbeatApplyRequest(
                 worker_id=worker_id,
                 worker_resource_snapshot=None,
-                updates=[TaskUpdate(task_id=task_id, attempt_id=0, new_state=target_state, error=error)],
-            )
+                updates=[TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING)],
+            ),
         )
+    if target_state != job_pb2.TASK_STATE_RUNNING:
+        with state._store.transaction() as cur:
+            state.apply_task_updates(
+                cur,
+                HeartbeatApplyRequest(
+                    worker_id=worker_id,
+                    worker_resource_snapshot=None,
+                    updates=[TaskUpdate(task_id=task_id, attempt_id=0, new_state=target_state, error=error)],
+                ),
+            )
 
 
 @pytest.fixture
@@ -385,7 +392,8 @@ def test_get_job_status_reports_has_children(service, state):
         environment=job_pb2.EnvironmentConfig(),
     )
     child_req.entrypoint.run_command.argv[:] = ["python", "-c", "pass"]
-    state.submit_job(child_id, child_req, Timestamp.now())
+    with state._store.transaction() as cur:
+        state.submit_job(cur, child_id, child_req, Timestamp.now())
 
     parent = service.get_job_status(controller_pb2.Controller.GetJobStatusRequest(job_id=parent_id.to_wire()), None)
     assert parent.job.has_children is True
@@ -927,7 +935,8 @@ def test_list_jobs_all_scope_includes_descendants(service, state):
         environment=job_pb2.EnvironmentConfig(),
     )
     child_req.entrypoint.run_command.argv[:] = ["python", "-c", "pass"]
-    state.submit_job(child_id, child_req, Timestamp.now())
+    with state._store.transaction() as cur:
+        state.submit_job(cur, child_id, child_req, Timestamp.now())
 
     request = controller_pb2.Controller.ListJobsRequest()
     response = service.list_jobs(request, None)
@@ -951,7 +960,8 @@ def test_list_jobs_job_query_roots_and_children(service, state):
         environment=job_pb2.EnvironmentConfig(),
     )
     child_req.entrypoint.run_command.argv[:] = ["python", "-c", "pass"]
-    state.submit_job(child_id, child_req, Timestamp.now())
+    with state._store.transaction() as cur:
+        state.submit_job(cur, child_id, child_req, Timestamp.now())
 
     roots_response = service.list_jobs(
         controller_pb2.Controller.ListJobsRequest(
@@ -1035,7 +1045,8 @@ def test_worker_addresses_for_tasks(state, service):
     service.launch_job(make_job_request("assigned-job"), None)
     job_id = JobName.root("test-user", "assigned-job")
     task_id = JobName.from_wire(job_id.to_wire() + "/0")
-    state.queue_assignments([Assignment(task_id=task_id, worker_id=WorkerId("w-1"))])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=task_id, worker_id=WorkerId("w-1"))])
 
     # Get tasks with attempts
     tasks = _query_tasks_with_attempts(state, job_id)
@@ -1244,21 +1255,24 @@ def test_get_scheduler_state_with_running_task(controller_service, state):
         environment=job_pb2.EnvironmentConfig(),
         replicas=1,
     )
-    state.submit_job(job_id, request, Timestamp.now())
+    with state._store.transaction() as cur:
+        state.submit_job(cur, job_id, request, Timestamp.now())
 
     w1 = WorkerId("w1")
-    state.register_or_refresh_worker(
-        worker_id=w1,
-        address="w1:8080",
-        metadata=job_pb2.WorkerMetadata(
-            hostname="w1",
-            ip_address="127.0.0.1",
-            cpu_count=8,
-            memory_bytes=16 * 1024**3,
-            disk_bytes=100 * 1024**3,
-        ),
-        ts=Timestamp.now(),
-    )
+    with state._store.transaction() as cur:
+        state.register_or_refresh_worker(
+            cur,
+            worker_id=w1,
+            address="w1:8080",
+            metadata=job_pb2.WorkerMetadata(
+                hostname="w1",
+                ip_address="127.0.0.1",
+                cpu_count=8,
+                memory_bytes=16 * 1024**3,
+                disk_bytes=100 * 1024**3,
+            ),
+            ts=Timestamp.now(),
+        )
     task_id = job_id.task(0)
     _assign_and_transition(state, task_id, w1, job_pb2.TASK_STATE_RUNNING)
 

--- a/lib/iris/tests/cluster/controller/test_task_resource_history.py
+++ b/lib/iris/tests/cluster/controller/test_task_resource_history.py
@@ -5,14 +5,16 @@
 
 import pytest
 from iris.cluster.controller.db import ControllerDB
-from iris.cluster.controller.stores import ControllerStore
+from iris.cluster.controller.stores import (
+    TASK_RESOURCE_HISTORY_RETENTION,
+    TASK_RESOURCE_HISTORY_TERMINAL_TTL,
+    ControllerStore,
+)
 from iris.cluster.controller.transitions import (
     Assignment,
     ControllerTransitions,
     HeartbeatApplyRequest,
     TaskUpdate,
-    TASK_RESOURCE_HISTORY_RETENTION,
-    TASK_RESOURCE_HISTORY_TERMINAL_TTL,
 )
 from iris.cluster.types import JobName, WorkerId
 from iris.rpc import job_pb2, controller_pb2
@@ -126,7 +128,7 @@ def test_prune_logarithmic_downsampling(state):
 
     assert _count_history_rows(state, task_id) == threshold + 1
 
-    deleted = state.prune_task_resource_history()
+    deleted = state._store.tasks.prune_resource_history()
     assert deleted > 0
 
     remaining = _count_history_rows(state, task_id)
@@ -154,7 +156,7 @@ def test_prune_preserves_newest_rows(state):
             )
         ]
 
-    state.prune_task_resource_history()
+    state._store.tasks.prune_resource_history()
 
     # All of the newest N rows should still exist.
     with state._db.read_snapshot() as q:
@@ -175,7 +177,7 @@ def test_prune_noop_below_threshold(state):
     for i in range(TASK_RESOURCE_HISTORY_RETENTION):
         _send_resource_heartbeat(state, task_id, cpu=i, mem=i)
 
-    deleted = state.prune_task_resource_history()
+    deleted = state._store.tasks.prune_resource_history()
     assert deleted == 0
     assert _count_history_rows(state, task_id) == TASK_RESOURCE_HISTORY_RETENTION
 
@@ -199,7 +201,7 @@ def test_prune_evicts_terminal_task_history_past_ttl(state):
 
     _force_terminal(state, task_id, finished_age_ms=TASK_RESOURCE_HISTORY_TERMINAL_TTL.to_ms() * 2)
 
-    deleted = state.prune_task_resource_history()
+    deleted = state._store.tasks.prune_resource_history()
     assert deleted == 2
     assert _count_history_rows(state, task_id) == 0
 
@@ -213,7 +215,7 @@ def test_prune_keeps_terminal_task_history_within_ttl(state):
     # Terminal at half the TTL — must survive.
     _force_terminal(state, task_id, finished_age_ms=TASK_RESOURCE_HISTORY_TERMINAL_TTL.to_ms() // 2)
 
-    deleted = state.prune_task_resource_history()
+    deleted = state._store.tasks.prune_resource_history()
     assert deleted == 0
     assert _count_history_rows(state, task_id) == 2
 
@@ -233,7 +235,7 @@ def test_prune_keeps_running_task_history_regardless_of_finished_at(state):
         (stale_ms, task_id.to_wire()),
     )
 
-    deleted = state.prune_task_resource_history()
+    deleted = state._store.tasks.prune_resource_history()
     assert deleted == 0
     assert _count_history_rows(state, task_id) == 1
 

--- a/lib/iris/tests/cluster/controller/test_task_resource_history.py
+++ b/lib/iris/tests/cluster/controller/test_task_resource_history.py
@@ -43,23 +43,31 @@ def _setup_running_task(state: ControllerTransitions) -> tuple[JobName, JobName]
     Returns (job_id, task_id).
     """
     wid = WorkerId("w1")
-    state.register_or_refresh_worker(worker_id=wid, address="host:8080", metadata=WORKER_META, ts=Timestamp.now())
+    with state._store.transaction() as cur:
+        state.register_or_refresh_worker(
+            cur, worker_id=wid, address="host:8080", metadata=WORKER_META, ts=Timestamp.now()
+        )
 
     job_id = JobName.from_wire("/user/test-job")
-    state.submit_job(
-        job_id,
-        controller_pb2.Controller.LaunchJobRequest(name="/user/test-job", replicas=1),
-        Timestamp.now(),
-    )
-    task_id = job_id.task(0)
-    state.queue_assignments([Assignment(task_id=task_id, worker_id=wid)])
-    state.apply_task_updates(
-        HeartbeatApplyRequest(
-            worker_id=wid,
-            worker_resource_snapshot=None,
-            updates=[TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING)],
+    with state._store.transaction() as cur:
+        state.submit_job(
+            cur,
+            job_id,
+            controller_pb2.Controller.LaunchJobRequest(name="/user/test-job", replicas=1),
+            Timestamp.now(),
         )
-    )
+    task_id = job_id.task(0)
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=task_id, worker_id=wid)])
+    with state._store.transaction() as cur:
+        state.apply_task_updates(
+            cur,
+            HeartbeatApplyRequest(
+                worker_id=wid,
+                worker_resource_snapshot=None,
+                updates=[TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING)],
+            ),
+        )
     return job_id, task_id
 
 
@@ -75,22 +83,24 @@ def _count_history_rows(state: ControllerTransitions, task_id: JobName, attempt_
 def _send_resource_heartbeat(state: ControllerTransitions, task_id: JobName, cpu: int = 1000, mem: int = 512):
     """Send a steady-state heartbeat with resource usage."""
     usage = job_pb2.ResourceUsage(cpu_millicores=cpu, memory_mb=mem, disk_mb=10)
-    state.apply_heartbeats_batch(
-        [
-            HeartbeatApplyRequest(
-                worker_id=WorkerId("w1"),
-                worker_resource_snapshot=job_pb2.WorkerResourceSnapshot(),
-                updates=[
-                    TaskUpdate(
-                        task_id=task_id,
-                        attempt_id=0,
-                        new_state=job_pb2.TASK_STATE_RUNNING,
-                        resource_usage=usage,
-                    ),
-                ],
-            )
-        ]
-    )
+    with state._store.transaction() as cur:
+        state.apply_heartbeats_batch(
+            cur,
+            [
+                HeartbeatApplyRequest(
+                    worker_id=WorkerId("w1"),
+                    worker_resource_snapshot=job_pb2.WorkerResourceSnapshot(),
+                    updates=[
+                        TaskUpdate(
+                            task_id=task_id,
+                            attempt_id=0,
+                            new_state=job_pb2.TASK_STATE_RUNNING,
+                            resource_usage=usage,
+                        ),
+                    ],
+                )
+            ],
+        )
 
 
 def test_heartbeat_inserts_history(state):
@@ -248,7 +258,9 @@ def test_cascade_delete_on_job_removal(state):
     assert _count_history_rows(state, task_id) == 1
 
     # Cancel the job (makes it terminal), then remove it.
-    state.cancel_job(job_id, reason="test cleanup")
-    state.remove_finished_job(job_id)
+    with state._store.transaction() as cur:
+        state.cancel_job(cur, job_id, reason="test cleanup")
+    with state._store.transaction() as cur:
+        state.remove_finished_job(cur, job_id)
 
     assert _count_history_rows(state, task_id) == 0

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -151,7 +151,8 @@ def test_db_snapshot_projection_inferrs_typed_values(state) -> None:
         replicas=1,
     )
     [task] = submit_job(state, "projection", request)
-    state.queue_assignments([Assignment(task_id=task.task_id, worker_id=wid)])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=task.task_id, worker_id=wid)])
 
     running = worker_running_tasks(state, wid)
 
@@ -249,7 +250,8 @@ def test_job_cancellation_kills_all_tasks(harness):
     harness.dispatch(tasks[0], worker_id)
     harness.dispatch(tasks[1], worker_id)
 
-    harness.state.cancel_job(job_id, reason="User cancelled")
+    with harness.state._store.transaction() as cur:
+        harness.state.cancel_job(cur, job_id, reason="User cancelled")
 
     assert harness.query_job(job_id).state == job_pb2.JOB_STATE_KILLED
     for task in tasks:
@@ -274,7 +276,8 @@ def test_cancel_job_releases_committed_worker_resources(harness):
     assert _query_worker(harness.state, w1).committed_mem == 1024**3
     assert _query_worker(harness.state, w2).committed_cpu_millicores == 1000
 
-    harness.state.cancel_job(JobName.root("test-user", "j1"), reason="User cancelled")
+    with harness.state._store.transaction() as cur:
+        harness.state.cancel_job(cur, JobName.root("test-user", "j1"), reason="User cancelled")
 
     assert _query_worker(harness.state, w1).committed_cpu_millicores == 0, "w1 leaked committed_cpu_millicores"
     assert _query_worker(harness.state, w1).committed_mem == 0, "w1 leaked committed_mem"
@@ -294,7 +297,8 @@ def test_cancel_job_preserves_kill_worker_mapping_after_clearing_tasks(harness):
     harness.dispatch(tasks[0], w1)
     harness.dispatch(tasks[1], w2)
 
-    result = harness.state.cancel_job(JobName.root("test-user", "j1"), reason="User cancelled")
+    with harness.state._store.transaction() as cur:
+        result = harness.state.cancel_job(cur, JobName.root("test-user", "j1"), reason="User cancelled")
 
     assert result.tasks_to_kill == {tasks[0].task_id, tasks[1].task_id}
     assert result.task_kill_workers == {
@@ -318,30 +322,35 @@ def test_cancel_job_removes_endpoints_for_job_tree(state):
     dispatch_task(state, parent_tasks[0], parent_worker)
     dispatch_task(state, child_tasks[0], child_worker)
 
-    state.add_endpoint(
-        EndpointRow(
-            endpoint_id="parent-ep",
-            name="parent/actor",
-            address="host1:9000",
-            task_id=parent_tasks[0].task_id,
-            metadata={},
-            registered_at=Timestamp.now(),
-        ),
-    )
-    state.add_endpoint(
-        EndpointRow(
-            endpoint_id="child-ep",
-            name="parent/child/actor",
-            address="host2:9000",
-            task_id=child_tasks[0].task_id,
-            metadata={},
-            registered_at=Timestamp.now(),
-        ),
-    )
+    with state._store.transaction() as cur:
+        state.add_endpoint(
+            cur,
+            EndpointRow(
+                endpoint_id="parent-ep",
+                name="parent/actor",
+                address="host1:9000",
+                task_id=parent_tasks[0].task_id,
+                metadata={},
+                registered_at=Timestamp.now(),
+            ),
+        )
+    with state._store.transaction() as cur:
+        state.add_endpoint(
+            cur,
+            EndpointRow(
+                endpoint_id="child-ep",
+                name="parent/child/actor",
+                address="host2:9000",
+                task_id=child_tasks[0].task_id,
+                metadata={},
+                registered_at=Timestamp.now(),
+            ),
+        )
 
     assert len(_endpoints(state, EndpointQuery())) == 2
 
-    state.cancel_job(JobName.root("test-user", "parent"), reason="User cancelled")
+    with state._store.transaction() as cur:
+        state.cancel_job(cur, JobName.root("test-user", "parent"), reason="User cancelled")
 
     assert _endpoints(state, EndpointQuery()) == []
 
@@ -353,7 +362,8 @@ def test_cancelled_job_tasks_excluded_from_demand(harness):
     job_id = JobName.root("test-user", "j1")
 
     harness.dispatch(tasks[0], worker_id)
-    harness.state.cancel_job(job_id, reason="User cancelled")
+    with harness.state._store.transaction() as cur:
+        harness.state.cancel_job(cur, job_id, reason="User cancelled")
 
     assert harness.query_job(job_id).state == job_pb2.JOB_STATE_KILLED
     for task in tasks:
@@ -434,7 +444,8 @@ def test_dispatch_failure_marks_worker_failed_and_requeues_task(state):
     task = tasks[0]
 
     # Task gets assigned (creates attempt, puts in ASSIGNED state)
-    state.queue_assignments([Assignment(task_id=task.task_id, worker_id=worker_id)])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=task.task_id, worker_id=worker_id)])
     assert _query_task(state, task.task_id).state == job_pb2.TASK_STATE_ASSIGNED
     assert _query_task(state, task.task_id).current_attempt_id == 0
 
@@ -470,8 +481,10 @@ def test_task_assigned_to_missing_worker_is_ignored(state):
     task = tasks[0]
 
     # Worker disappears between scheduling and assignment commit.
-    state.remove_worker(worker_id)
-    state.queue_assignments([Assignment(task_id=task.task_id, worker_id=worker_id)])
+    with state._store.transaction() as cur:
+        state.remove_worker(cur, worker_id)
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=task.task_id, worker_id=worker_id)])
 
     # Task remains schedulable and no attempt/resources are committed.
     assert _query_task(state, task.task_id).state == job_pb2.TASK_STATE_PENDING
@@ -597,7 +610,8 @@ def test_terminal_states_clean_up_endpoints(state):
         metadata={},
         registered_at=Timestamp.now(),
     )
-    state.add_endpoint(ep)
+    with state._store.transaction() as cur:
+        state.add_endpoint(cur, ep)
 
     # Verify endpoint visible while running
     assert len(_endpoints(state, EndpointQuery(exact_name="j1/actor"))) == 1
@@ -627,7 +641,8 @@ def test_endpoint_visibility_by_job_state(state):
         metadata={},
         registered_at=Timestamp.now(),
     )
-    state.add_endpoint(ep)
+    with state._store.transaction() as cur:
+        state.add_endpoint(cur, ep)
 
     # Visible while pending
     assert len(_endpoints(state, EndpointQuery(exact_name="ns-1/actor"))) == 1
@@ -663,7 +678,8 @@ def test_endpoint_deleted_on_task_failure_with_retry(state):
         metadata={},
         registered_at=Timestamp.now(),
     )
-    state.add_endpoint(ep)
+    with state._store.transaction() as cur:
+        state.add_endpoint(cur, ep)
     assert len(_endpoints(state, EndpointQuery(exact_name="ns-1/actor"))) == 1
 
     # Task fails but retries (goes back to PENDING)
@@ -694,7 +710,8 @@ def test_endpoint_deleted_on_worker_failure(state):
         metadata={},
         registered_at=Timestamp.now(),
     )
-    state.add_endpoint(ep)
+    with state._store.transaction() as cur:
+        state.add_endpoint(cur, ep)
     assert len(_endpoints(state, EndpointQuery(exact_name="ns-1/actor"))) == 1
 
     # Worker fails -> task retries to PENDING
@@ -715,21 +732,24 @@ def test_endpoint_survives_building_state(state):
     task = tasks[0]
 
     # Assign task and transition to BUILDING
-    state.queue_assignments([Assignment(task_id=task.task_id, worker_id=worker_id)])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=task.task_id, worker_id=worker_id)])
     task = _query_task(state, task.task_id)
-    state.apply_task_updates(
-        HeartbeatApplyRequest(
-            worker_id=worker_id,
-            worker_resource_snapshot=None,
-            updates=[
-                TaskUpdate(
-                    task_id=task.task_id,
-                    attempt_id=task.current_attempt_id,
-                    new_state=job_pb2.TASK_STATE_BUILDING,
-                )
-            ],
+    with state._store.transaction() as cur:
+        state.apply_task_updates(
+            cur,
+            HeartbeatApplyRequest(
+                worker_id=worker_id,
+                worker_resource_snapshot=None,
+                updates=[
+                    TaskUpdate(
+                        task_id=task.task_id,
+                        attempt_id=task.current_attempt_id,
+                        new_state=job_pb2.TASK_STATE_BUILDING,
+                    )
+                ],
+            ),
         )
-    )
 
     # Register endpoint during BUILDING (e.g. jax_init.py pre-registration)
     ep = EndpointRow(
@@ -740,23 +760,26 @@ def test_endpoint_survives_building_state(state):
         metadata={},
         registered_at=Timestamp.now(),
     )
-    state.add_endpoint(ep)
+    with state._store.transaction() as cur:
+        state.add_endpoint(cur, ep)
     assert len(_endpoints(state, EndpointQuery(exact_name="ns-1/actor"))) == 1
 
     # Transition to RUNNING — endpoint should survive
-    state.apply_task_updates(
-        HeartbeatApplyRequest(
-            worker_id=worker_id,
-            worker_resource_snapshot=None,
-            updates=[
-                TaskUpdate(
-                    task_id=task.task_id,
-                    attempt_id=_query_task(state, task.task_id).current_attempt_id,
-                    new_state=job_pb2.TASK_STATE_RUNNING,
-                )
-            ],
+    with state._store.transaction() as cur:
+        state.apply_task_updates(
+            cur,
+            HeartbeatApplyRequest(
+                worker_id=worker_id,
+                worker_resource_snapshot=None,
+                updates=[
+                    TaskUpdate(
+                        task_id=task.task_id,
+                        attempt_id=_query_task(state, task.task_id).current_attempt_id,
+                        new_state=job_pb2.TASK_STATE_RUNNING,
+                    )
+                ],
+            ),
         )
-    )
     assert len(_endpoints(state, EndpointQuery(exact_name="ns-1/actor"))) == 1
 
 
@@ -775,26 +798,30 @@ def test_namespace_isolation(state):
     dispatch_task(state, tasks1[0], worker_id)
     dispatch_task(state, tasks2[0], worker_id)
 
-    state.add_endpoint(
-        EndpointRow(
-            endpoint_id="ep-1",
-            name="ns-1/actor",
-            address="10.0.0.1:8080",
-            task_id=tasks1[0].task_id,
-            metadata={},
-            registered_at=Timestamp.now(),
+    with state._store.transaction() as cur:
+        state.add_endpoint(
+            cur,
+            EndpointRow(
+                endpoint_id="ep-1",
+                name="ns-1/actor",
+                address="10.0.0.1:8080",
+                task_id=tasks1[0].task_id,
+                metadata={},
+                registered_at=Timestamp.now(),
+            ),
         )
-    )
-    state.add_endpoint(
-        EndpointRow(
-            endpoint_id="ep-2",
-            name="ns-2/actor",
-            address="10.0.0.2:8080",
-            task_id=tasks2[0].task_id,
-            metadata={},
-            registered_at=Timestamp.now(),
+    with state._store.transaction() as cur:
+        state.add_endpoint(
+            cur,
+            EndpointRow(
+                endpoint_id="ep-2",
+                name="ns-2/actor",
+                address="10.0.0.2:8080",
+                task_id=tasks2[0].task_id,
+                metadata={},
+                registered_at=Timestamp.now(),
+            ),
         )
-    )
 
     # Each namespace only sees its own endpoint
     results_ns1 = _endpoints(state, EndpointQuery(exact_name="ns-1/actor"))
@@ -1295,19 +1322,21 @@ def test_stale_attempt_ignored(state):
     assert _query_task(state, task.task_id).state == job_pb2.TASK_STATE_RUNNING
 
     # Stale report from old attempt should be ignored
-    state.apply_task_updates(
-        HeartbeatApplyRequest(
-            worker_id=worker_id,
-            worker_resource_snapshot=None,
-            updates=[
-                TaskUpdate(
-                    task_id=task.task_id,
-                    attempt_id=old_attempt_id,
-                    new_state=job_pb2.TASK_STATE_SUCCEEDED,
-                )
-            ],
+    with state._store.transaction() as cur:
+        state.apply_task_updates(
+            cur,
+            HeartbeatApplyRequest(
+                worker_id=worker_id,
+                worker_resource_snapshot=None,
+                updates=[
+                    TaskUpdate(
+                        task_id=task.task_id,
+                        attempt_id=old_attempt_id,
+                        new_state=job_pb2.TASK_STATE_SUCCEEDED,
+                    )
+                ],
+            ),
         )
-    )
 
     # Task should still be RUNNING on the new attempt
     assert _query_task(state, task.task_id).state == job_pb2.TASK_STATE_RUNNING
@@ -1341,13 +1370,15 @@ def test_stale_attempt_error_log_for_non_terminal(state, caplog):
     assert not attempt_is_terminal(attempts[0].state)
 
     with caplog.at_level(logging.ERROR, logger="iris.cluster.controller.transitions"):
-        state.apply_task_updates(
-            HeartbeatApplyRequest(
-                worker_id=worker_id,
-                worker_resource_snapshot=None,
-                updates=[TaskUpdate(task_id=task.task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_SUCCEEDED)],
+        with state._store.transaction() as cur:
+            state.apply_task_updates(
+                cur,
+                HeartbeatApplyRequest(
+                    worker_id=worker_id,
+                    worker_resource_snapshot=None,
+                    updates=[TaskUpdate(task_id=task.task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_SUCCEEDED)],
+                ),
             )
-        )
 
     assert any("Stale attempt precondition violation" in r.message for r in caplog.records)
 
@@ -2017,7 +2048,8 @@ def test_worker_failed_from_assigned_is_delivery_failure(state):
     task = tasks[0]
 
     # Assign but do NOT transition to RUNNING
-    state.queue_assignments([Assignment(task_id=task.task_id, worker_id=worker_id)])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=task.task_id, worker_id=worker_id)])
     assert _query_task(state, task.task_id).state == job_pb2.TASK_STATE_ASSIGNED
 
     # Worker reports WORKER_FAILED (e.g., "Task not found on worker")
@@ -2073,7 +2105,8 @@ def test_worker_failed_from_building_counts_as_preemption(state):
     task = tasks[0]
 
     # Assign and transition to BUILDING (worker confirmed it received the task)
-    state.queue_assignments([Assignment(task_id=task.task_id, worker_id=worker_id)])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=task.task_id, worker_id=worker_id)])
     transition_task(state, task.task_id, job_pb2.TASK_STATE_BUILDING)
     assert _query_task(state, task.task_id).state == job_pb2.TASK_STATE_BUILDING
 
@@ -2104,7 +2137,8 @@ def test_worker_failed_from_assigned_bumps_health_tracker(state):
     tasks = submit_job(state, "j1", req)
     task = tasks[0]
 
-    state.queue_assignments([Assignment(task_id=task.task_id, worker_id=worker_id)])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=task.task_id, worker_id=worker_id)])
     assert _query_task(state, task.task_id).state == job_pb2.TASK_STATE_ASSIGNED
     assert state._health.snapshot().get(worker_id) is None
 
@@ -2136,7 +2170,8 @@ def test_failed_from_building_bumps_health_tracker(state):
     tasks = submit_job(state, "j1", req)
     task = tasks[0]
 
-    state.queue_assignments([Assignment(task_id=task.task_id, worker_id=worker_id)])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=task.task_id, worker_id=worker_id)])
     transition_task(state, task.task_id, job_pb2.TASK_STATE_BUILDING)
     assert _query_task(state, task.task_id).state == job_pb2.TASK_STATE_BUILDING
 
@@ -2628,7 +2663,8 @@ def test_holder_tasks_consume_zero_resources(state):
     gpus_before = worker_before.total_gpu_count - worker_before.committed_gpu
 
     # Assign holder task
-    state.queue_assignments([Assignment(task_id=holder_tasks[0].task_id, worker_id=wid)])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=holder_tasks[0].task_id, worker_id=wid)])
 
     # Worker's available GPUs should NOT decrease (zero resources)
     worker_after = _query_worker(state, wid)
@@ -2653,14 +2689,16 @@ def test_holder_task_cleanup_releases_no_resources(state):
     holder_tasks = _query_tasks_for_job(state, holder_job_id)
 
     # Assign holder task
-    state.queue_assignments([Assignment(task_id=holder_tasks[0].task_id, worker_id=wid)])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=holder_tasks[0].task_id, worker_id=wid)])
 
     worker_before = _query_worker(state, wid)
     gpus_before = worker_before.total_gpu_count - worker_before.committed_gpu
 
     # Kill the holder task via parent job cancellation
     parent_job_id = JobName.root("test-user", "j1")
-    state.cancel_job(parent_job_id, reason="test")
+    with state._store.transaction() as cur:
+        state.cancel_job(cur, parent_job_id, reason="test")
 
     # Worker GPUs should be unchanged (nothing to release)
     worker_after = _query_worker(state, wid)
@@ -2688,7 +2726,8 @@ def test_holder_tasks_excluded_from_building_counts(state):
     assert len(holder_tasks) == 1
 
     # Assign holder task — it goes to ASSIGNED state
-    state.queue_assignments([Assignment(task_id=holder_tasks[0].task_id, worker_id=wid)])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=holder_tasks[0].task_id, worker_id=wid)])
     assert _query_task(state, holder_tasks[0].task_id).state == job_pb2.TASK_STATE_ASSIGNED
 
     # Building counts should NOT include the holder task
@@ -2717,10 +2756,12 @@ def test_holder_tasks_excluded_from_poll_expected_tasks(state):
     assert len(holder_tasks) == 1
 
     # Assign holder task to worker
-    state.queue_assignments([Assignment(task_id=holder_tasks[0].task_id, worker_id=wid)])
+    with state._store.transaction() as cur:
+        state.queue_assignments(cur, [Assignment(task_id=holder_tasks[0].task_id, worker_id=wid)])
 
     # Poll snapshot must NOT include the holder task
-    running, _ = state.get_running_tasks_for_poll()
+    with state._store.read_snapshot() as snap:
+        running, _ = state.get_running_tasks_for_poll(snap)
     running_task_ids = {entry.task_id for entry in running.get(wid, [])}
     assert holder_tasks[0].task_id not in running_task_ids
 
@@ -2968,7 +3009,8 @@ def test_endpoint_registered_after_task_terminal_is_orphaned(state):
         metadata={},
         registered_at=Timestamp.now(),
     )
-    state.add_endpoint(ep)
+    with state._store.transaction() as cur:
+        state.add_endpoint(cur, ep)
 
     # BUG: The endpoint is now orphaned — the task is terminal so no
     # future transition will clean it up.
@@ -3092,10 +3134,12 @@ def test_dispatch_propagates_task_image(state):
 
     req = make_job_request("img-job", task_image="custom/swetrace:dev")
     tasks = submit_job(state, "img-job", req)
-    result = state.queue_assignments(
-        [Assignment(task_id=tasks[0].task_id, worker_id=wid)],
-        direct_dispatch=True,
-    )
+    with state._store.transaction() as cur:
+        result = state.queue_assignments(
+            cur,
+            [Assignment(task_id=tasks[0].task_id, worker_id=wid)],
+            direct_dispatch=True,
+        )
     assert len(result.start_requests) == 1
     _, _, run_request = result.start_requests[0]
     assert run_request.task_image == "custom/swetrace:dev"
@@ -3138,7 +3182,8 @@ def _submit_job_direct(
         max_retries_failure=max_retries_failure,
         max_retries_preemption=max_retries_preemption,
     )
-    result = state.submit_job(job_id, request, Timestamp.now())
+    with state._store.transaction() as cur:
+        result = state.submit_job(cur, job_id, request, Timestamp.now())
     return result.task_ids
 
 
@@ -3158,10 +3203,12 @@ def _task_row_direct(state: ControllerTransitions, task_id: JobName):
 
 def _run_direct_tasks(state: ControllerTransitions, task_ids: list[JobName]) -> None:
     """Drain and transition tasks to RUNNING via direct provider."""
-    state.drain_for_direct_provider()
-    state.apply_direct_provider_updates(
-        [TaskUpdate(task_id=t, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING) for t in task_ids]
-    )
+    with state._store.transaction() as cur:
+        state.drain_for_direct_provider(cur)
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur, [TaskUpdate(task_id=t, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING) for t in task_ids]
+        )
 
 
 def test_drain_pending_creates_attempt_rows(state):
@@ -3169,7 +3216,8 @@ def test_drain_pending_creates_attempt_rows(state):
     task_ids = _submit_job_direct(state, "/user/job1")
     task_id = task_ids[0]
 
-    batch = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch = state.drain_for_direct_provider(cur)
 
     assert len(batch.tasks_to_run) == 1
     assert batch.tasks_to_run[0].task_id == task_id.to_wire()
@@ -3192,11 +3240,13 @@ def test_drain_skips_already_assigned(state):
     task_id = task_ids[0]
 
     # First drain promotes to ASSIGNED.
-    batch1 = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch1 = state.drain_for_direct_provider(cur)
     assert len(batch1.tasks_to_run) == 1
 
     # Second drain: no new tasks to run, but task appears in running_tasks.
-    batch2 = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch2 = state.drain_for_direct_provider(cur)
     assert len(batch2.tasks_to_run) == 0
     assert len(batch2.running_tasks) == 1
     assert batch2.running_tasks[0].task_id == task_id
@@ -3207,11 +3257,13 @@ def test_drain_caps_promotions_per_cycle(state):
     """Promotions are capped by max_promotions per drain call."""
     _submit_job_direct(state, "/user/big-job", replicas=200)
 
-    batch1 = state.drain_for_direct_provider(max_promotions=128)
+    with state._store.transaction() as cur:
+        batch1 = state.drain_for_direct_provider(cur, max_promotions=128)
     assert len(batch1.tasks_to_run) == 128
 
     # Remaining tasks promoted with another budget.
-    batch2 = state.drain_for_direct_provider(max_promotions=128)
+    with state._store.transaction() as cur:
+        batch2 = state.drain_for_direct_provider(cur, max_promotions=128)
     assert len(batch2.tasks_to_run) == 72
 
 
@@ -3219,11 +3271,13 @@ def test_drain_max_promotions_limits_batch(state):
     """max_promotions caps the number of tasks promoted per cycle."""
     _submit_job_direct(state, "/user/cap-job", replicas=250)
 
-    batch1 = state.drain_for_direct_provider(max_promotions=50)
+    with state._store.transaction() as cur:
+        batch1 = state.drain_for_direct_provider(cur, max_promotions=50)
     assert len(batch1.tasks_to_run) == 50
 
     # Remaining tasks still available with a fresh budget.
-    batch2 = state.drain_for_direct_provider(max_promotions=50)
+    with state._store.transaction() as cur:
+        batch2 = state.drain_for_direct_provider(cur, max_promotions=50)
     assert len(batch2.tasks_to_run) == 50
 
 
@@ -3232,13 +3286,16 @@ def test_drain_kill_queue(state):
     task_ids = _submit_job_direct(state, "/user/job1")
     task_id = task_ids[0]
 
-    state.buffer_direct_kill(task_id.to_wire())
+    with state._store.transaction() as cur:
+        state.buffer_direct_kill(cur, task_id.to_wire())
 
-    batch = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch = state.drain_for_direct_provider(cur)
     assert task_id.to_wire() in batch.tasks_to_kill
 
     # Second drain should be empty (kills were consumed).
-    batch2 = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch2 = state.drain_for_direct_provider(cur)
     assert len(batch2.tasks_to_kill) == 0
 
 
@@ -3246,13 +3303,16 @@ def test_apply_running(state):
     """Applying a RUNNING update transitions task from ASSIGNED to RUNNING."""
     task_ids = _submit_job_direct(state, "/user/job1")
     task_id = task_ids[0]
-    state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        state.drain_for_direct_provider(cur)
 
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING),
-        ]
-    )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING),
+            ],
+        )
 
     assert _task_state_direct(state, task_id) == job_pb2.TASK_STATE_RUNNING
 
@@ -3261,18 +3321,23 @@ def test_apply_succeeded(state):
     """Applying SUCCEEDED transitions task to terminal state with exit_code=0."""
     task_ids = _submit_job_direct(state, "/user/job1")
     task_id = task_ids[0]
-    state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        state.drain_for_direct_provider(cur)
 
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING),
-        ]
-    )
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_SUCCEEDED),
-        ]
-    )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING),
+            ],
+        )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_SUCCEEDED),
+            ],
+        )
 
     task = _task_row_direct(state, task_id)
     assert task.state == job_pb2.TASK_STATE_SUCCEEDED
@@ -3284,18 +3349,23 @@ def test_apply_failed_with_retry(state):
     """FAILED with retries remaining returns task to PENDING."""
     task_ids = _submit_job_direct(state, "/user/job1", max_retries_failure=1)
     task_id = task_ids[0]
-    state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        state.drain_for_direct_provider(cur)
 
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING),
-        ]
-    )
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_FAILED, error="boom"),
-        ]
-    )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING),
+            ],
+        )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_FAILED, error="boom"),
+            ],
+        )
 
     # Task should be PENDING again (1 failure <= 1 max_retries_failure).
     assert _task_state_direct(state, task_id) == job_pb2.TASK_STATE_PENDING
@@ -3312,7 +3382,8 @@ def test_apply_failed_with_retry(state):
     assert attempts[0].finished_at is not None
 
     # Draining again should promote it for a second attempt.
-    batch = state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        batch = state.drain_for_direct_provider(cur)
     assert len(batch.tasks_to_run) == 1
     assert batch.tasks_to_run[0].attempt_id == 1
 
@@ -3321,18 +3392,23 @@ def test_apply_failed_no_retry(state):
     """FAILED with no retries remaining leaves task in FAILED terminal state."""
     task_ids = _submit_job_direct(state, "/user/job1", max_retries_failure=0)
     task_id = task_ids[0]
-    state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        state.drain_for_direct_provider(cur)
 
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING),
-        ]
-    )
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_FAILED, error="boom"),
-        ]
-    )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING),
+            ],
+        )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_FAILED, error="boom"),
+            ],
+        )
 
     task = _task_row_direct(state, task_id)
     assert task.state == job_pb2.TASK_STATE_FAILED
@@ -3344,18 +3420,23 @@ def test_apply_worker_failed(state):
     """WORKER_FAILED on a RUNNING task increments preemption_count and retries if allowed."""
     task_ids = _submit_job_direct(state, "/user/job1", max_retries_preemption=1)
     task_id = task_ids[0]
-    state.drain_for_direct_provider()
+    with state._store.transaction() as cur:
+        state.drain_for_direct_provider(cur)
 
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING),
-        ]
-    )
-    state.apply_direct_provider_updates(
-        [
-            TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_WORKER_FAILED, error="node died"),
-        ]
-    )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING),
+            ],
+        )
+    with state._store.transaction() as cur:
+        state.apply_direct_provider_updates(
+            cur,
+            [
+                TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_WORKER_FAILED, error="node died"),
+            ],
+        )
 
     # Should be retried (preemption_count=1 <= max_retries_preemption=1).
     assert _task_state_direct(state, task_id) == job_pb2.TASK_STATE_PENDING
@@ -3365,7 +3446,8 @@ def test_apply_worker_failed(state):
 
 def test_buffer_direct_kill(state):
     """buffer_direct_kill inserts a NULL-worker_id kill entry in dispatch_queue."""
-    state.buffer_direct_kill("/user/job1:task-0")
+    with state._store.transaction() as cur:
+        state.buffer_direct_kill(cur, "/user/job1:task-0")
 
     row = state._db.fetchone(
         "SELECT worker_id, kind, task_id FROM dispatch_queue WHERE task_id = ?",
@@ -3381,7 +3463,8 @@ def test_cancel_job_kills_direct_provider_tasks(state):
     task_ids = _submit_job_direct(state, "/user/job1", replicas=2)
     _run_direct_tasks(state, task_ids)
 
-    result = state.cancel_job(JobName.from_wire("/user/job1"), reason="test cancel")
+    with state._store.transaction() as cur:
+        result = state.cancel_job(cur, JobName.from_wire("/user/job1"), reason="test cancel")
 
     assert result.tasks_to_kill == set(task_ids)
 
@@ -3393,7 +3476,8 @@ def test_kill_non_terminal_direct_provider_tasks(state):
 
     # Trigger via cancel_job which calls _kill_non_terminal_tasks indirectly through
     # cascade, or call it via a job failure path. Use cancel_job for simplicity.
-    result = state.cancel_job(JobName.from_wire("/user/job1"), reason="test kill")
+    with state._store.transaction() as cur:
+        result = state.cancel_job(cur, JobName.from_wire("/user/job1"), reason="test kill")
 
     assert task_ids[0] in result.tasks_to_kill
 
@@ -3463,9 +3547,10 @@ def test_max_failures_kills_direct_provider_tasks(state):
 
     # Fail one task — with max_task_failures=0 (default) this should kill the job,
     # triggering _kill_non_terminal_tasks for the sibling.
-    result = state.apply_direct_provider_updates(
-        [TaskUpdate(task_id=task_ids[0], attempt_id=0, new_state=job_pb2.TASK_STATE_FAILED, error="boom")]
-    )
+    with state._store.transaction() as cur:
+        result = state.apply_direct_provider_updates(
+            cur, [TaskUpdate(task_id=task_ids[0], attempt_id=0, new_state=job_pb2.TASK_STATE_FAILED, error="boom")]
+        )
 
     # The sibling task (task_ids[1]) should be in tasks_to_kill.
     assert task_ids[1] in result.tasks_to_kill
@@ -3511,12 +3596,14 @@ def test_job_expands_to_replicas_and_retry_limits(harness) -> None:
 
 def test_job_becomes_unschedulable_when_task_unschedulable(harness) -> None:
     tasks = harness.submit("unsched", replicas=2)
-    harness.state.mark_task_unschedulable(tasks[0].task_id, reason="no capacity")
+    with harness.state._store.transaction() as cur:
+        harness.state.mark_task_unschedulable(cur, tasks[0].task_id, reason="no capacity")
     assert harness.query_job(JobName.root("test-user", "unsched")).state == job_pb2.JOB_STATE_UNSCHEDULABLE
 
 
 def test_job_cancel_marks_job_killed(harness) -> None:
     harness.submit("killed", replicas=2)
     jid = JobName.root("test-user", "killed")
-    harness.state.cancel_job(jid, reason="manual")
+    with harness.state._store.transaction() as cur:
+        harness.state.cancel_job(cur, jid, reason="manual")
     assert harness.query_job(jid).state == job_pb2.JOB_STATE_KILLED

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -3403,7 +3403,7 @@ def test_kill_non_terminal_reservation_holder_does_not_decommit_co_tenant(harnes
 
     Regression: ``_kill_non_terminal_tasks`` passed ``resources`` into
     ``_terminate_task`` unconditionally. Reservation-holder tasks never commit
-    on assignment (see ``_assign_task``), so decommitting them on termination
+    on assignment, so decommitting them on termination
     subtracts chips that were never added — on a worker co-tenanted by a real
     task, this floored ``committed_*`` below the co-tenant's true reservation,
     letting the scheduler double-book the VM (seen in prod: two v5p-8 jobs on
@@ -3438,6 +3438,9 @@ def test_kill_non_terminal_reservation_holder_does_not_decommit_co_tenant(harnes
     with harness.state._db.transaction() as cur:
         _kill_non_terminal_tasks(
             cur,
+            harness.state._store.attempts,
+            harness.state._store.tasks,
+            harness.state._store.workers,
             harness.state._store.endpoints,
             holder_job_id.to_wire(),
             "Job finalized",

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -3442,7 +3442,7 @@ def test_kill_non_terminal_reservation_holder_does_not_decommit_co_tenant(harnes
             harness.state._store.tasks,
             harness.state._store.workers,
             harness.state._store.endpoints,
-            holder_job_id.to_wire(),
+            holder_job_id,
             "Job finalized",
             0,
         )

--- a/lib/iris/tests/e2e/test_local_client.py
+++ b/lib/iris/tests/e2e/test_local_client.py
@@ -45,7 +45,8 @@ def test_command_entrypoint_preserves_env_vars(client):
 
     resources = job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3)
 
-    client.submit_job(job_id=job_id, entrypoint=entrypoint, resources=resources)
+    with client._store.transaction() as cur:
+        client.submit_job(cur, job_id=job_id, entrypoint=entrypoint, resources=resources)
 
     # Wait for job completion
     status = client.wait_for_job(job_id, timeout=10.0, poll_interval=0.1)
@@ -69,7 +70,8 @@ def test_log_streaming_captures_output_without_trailing_newline(client):
 
     resources = job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3)
 
-    client.submit_job(job_id=job_id, entrypoint=entrypoint, resources=resources)
+    with client._store.transaction() as cur:
+        client.submit_job(cur, job_id=job_id, entrypoint=entrypoint, resources=resources)
 
     # Wait for job completion
     status = client.wait_for_job(job_id, timeout=10.0, poll_interval=0.1)
@@ -93,7 +95,8 @@ def test_callable_entrypoint_succeeds(client):
 
     resources = job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3)
 
-    client.submit_job(job_id=job_id, entrypoint=entrypoint, resources=resources)
+    with client._store.transaction() as cur:
+        client.submit_job(cur, job_id=job_id, entrypoint=entrypoint, resources=resources)
 
     status = client.wait_for_job(job_id, timeout=10.0, poll_interval=0.1)
 
@@ -110,12 +113,14 @@ def test_command_entrypoint_with_custom_env_var(client):
     resources = job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3)
     environment = EnvironmentSpec(env_vars={"CUSTOM_VAR": "custom_value"}).to_proto()
 
-    client.submit_job(
-        job_id=job_id,
-        entrypoint=entrypoint,
-        resources=resources,
-        environment=environment,
-    )
+    with client._store.transaction() as cur:
+        client.submit_job(
+            cur,
+            job_id=job_id,
+            entrypoint=entrypoint,
+            resources=resources,
+            environment=environment,
+        )
 
     # Wait for job completion
     status = client.wait_for_job(job_id, timeout=10.0, poll_interval=0.1)
@@ -136,7 +141,8 @@ def test_job_wait_with_stream_logs(client, iris_client, caplog):
     entrypoint = Entrypoint.from_command("sh", "-c", "echo 'hello from streaming'")
     resources = job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3)
 
-    client.submit_job(job_id=job_id, entrypoint=entrypoint, resources=resources)
+    with client._store.transaction() as cur:
+        client.submit_job(cur, job_id=job_id, entrypoint=entrypoint, resources=resources)
     job = Job(iris, job_id)
 
     with caplog.at_level(logging.INFO, logger="iris.client.client"):
@@ -209,7 +215,8 @@ def test_child_job_logs_sorted_by_timestamp(client):
     entrypoint = Entrypoint.from_callable(_parent_with_two_children)
     resources = job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3)
 
-    client.submit_job(job_id=parent_id, entrypoint=entrypoint, resources=resources)
+    with client._store.transaction() as cur:
+        client.submit_job(cur, job_id=parent_id, entrypoint=entrypoint, resources=resources)
 
     status = client.wait_for_job(parent_id, timeout=60.0, poll_interval=0.2)
     assert status.state == job_pb2.JOB_STATE_SUCCEEDED, f"Parent job failed: {status}"
@@ -228,7 +235,8 @@ def test_wait_stream_logs_discovers_child_tasks(client, iris_client, caplog):
     entrypoint = Entrypoint.from_callable(_parent_with_delayed_child)
     resources = job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3)
 
-    client.submit_job(job_id=parent_id, entrypoint=entrypoint, resources=resources)
+    with client._store.transaction() as cur:
+        client.submit_job(cur, job_id=parent_id, entrypoint=entrypoint, resources=resources)
     job = Job(iris, parent_id)
 
     with caplog.at_level(logging.INFO, logger="iris.client.client"):
@@ -266,7 +274,8 @@ def test_stream_logs_surfaces_child_failure(client, iris_client):
     entrypoint = Entrypoint.from_callable(_parent_with_failing_child)
     resources = job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3)
 
-    client.submit_job(job_id=parent_id, entrypoint=entrypoint, resources=resources)
+    with client._store.transaction() as cur:
+        client.submit_job(cur, job_id=parent_id, entrypoint=entrypoint, resources=resources)
     job = Job(iris, parent_id)
 
     status = job.wait(

--- a/lib/iris/tests/test_budget.py
+++ b/lib/iris/tests/test_budget.py
@@ -202,31 +202,37 @@ def _start_running_job(
         include_resources=include_resources,
         replicas=replicas,
     )
-    state.submit_job(job_id, request, Timestamp.now())
+    with state._store.transaction() as cur:
+        state.submit_job(cur, job_id, request, Timestamp.now())
 
     worker_id = WorkerId(f"w-{user}")
-    state.register_or_refresh_worker(
-        worker_id=worker_id,
-        address=f"{worker_id}:8080",
-        metadata=job_pb2.WorkerMetadata(
-            hostname=str(worker_id),
-            ip_address="127.0.0.1",
-            cpu_count=16,
-            memory_bytes=64 * GiB,
-            disk_bytes=100 * GiB,
-        ),
-        ts=Timestamp.now(),
-    )
+    with state._store.transaction() as cur:
+        state.register_or_refresh_worker(
+            cur,
+            worker_id=worker_id,
+            address=f"{worker_id}:8080",
+            metadata=job_pb2.WorkerMetadata(
+                hostname=str(worker_id),
+                ip_address="127.0.0.1",
+                cpu_count=16,
+                memory_bytes=64 * GiB,
+                disk_bytes=100 * GiB,
+            ),
+            ts=Timestamp.now(),
+        )
     for idx in range(replicas):
         task_id = job_id.task(idx)
-        state.queue_assignments([Assignment(task_id=task_id, worker_id=worker_id)])
-        state.apply_task_updates(
-            HeartbeatApplyRequest(
-                worker_id=worker_id,
-                worker_resource_snapshot=None,
-                updates=[TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING)],
+        with state._store.transaction() as cur:
+            state.queue_assignments(cur, [Assignment(task_id=task_id, worker_id=worker_id)])
+        with state._store.transaction() as cur:
+            state.apply_task_updates(
+                cur,
+                HeartbeatApplyRequest(
+                    worker_id=worker_id,
+                    worker_resource_snapshot=None,
+                    updates=[TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING)],
+                ),
             )
-        )
 
 
 def test_compute_user_spend_empty(state):
@@ -245,7 +251,8 @@ def test_compute_user_spend_excludes_pending(state):
     """Tasks that never reach RUNNING/ASSIGNED/BUILDING do not contribute."""
     job_id = JobName.root("bob", "pending")
     request = _launch_request(job_id.to_wire(), cpu_millicores=2000, memory_bytes=8 * GiB)
-    state.submit_job(job_id, request, Timestamp.now())
+    with state._store.transaction() as cur:
+        state.submit_job(cur, job_id, request, Timestamp.now())
     with state._db.snapshot() as snap:
         assert compute_user_spend(snap).get("bob", 0) == 0
 

--- a/tests/integration/iris/test_iris_kind.py
+++ b/tests/integration/iris/test_iris_kind.py
@@ -76,9 +76,11 @@ class ServiceTestHarness:
 
     def sync_k8s(self) -> None:
         assert self.k8s_provider is not None, "sync_k8s requires K8s harness"
-        batch = self.state.drain_for_direct_provider()
+        with self.state._store.transaction() as cur:
+            batch = self.state.drain_for_direct_provider(cur)
         result = self.k8s_provider.sync(batch)
-        self.state.apply_direct_provider_updates(result.updates)
+        with self.state._store.transaction() as cur:
+            self.state.apply_direct_provider_updates(cur, result.updates)
 
 
 def _make_test_entrypoint() -> job_pb2.RuntimeEntrypoint:


### PR DESCRIPTION
ControllerTransitions had ~30 inline SQL sites mixing schema knowledge
with domain logic. Move every query behind typed methods on TaskStore,
WorkerStore, and JobStore, and lift transaction scope from inside each
method to the entrypoint (service.py / controller.py). Adds a
TaskScope ADT for the active-task query family and on-commit hooks for
attribute-cache updates. Closes the submit-with-replace TOCTOU. Spec
at .agents/projects/iris-sql-store.md. Behavioral equivalence proven by
the replay goldens added in #5165 — all 13 scenarios produce byte-identical
DB state on this branch versus main.