### PR TITLE
Fix infra dashboard history order

### DIFF
--- a/infra/status-page/web/src/components/BuildPanel.tsx
+++ b/infra/status-page/web/src/components/BuildPanel.tsx
@@ -172,6 +172,9 @@ export function BuildPanel() {
   const { data, isLoading, error, dataUpdatedAt } = useBuilds();
   const latest = data?.commits?.[0];
   const successRate = data?.successRate ?? null;
+  // GitHub history is newest-first, but the visual strip should move forward
+  // in time left-to-right so the latest commit lands at the right edge.
+  const visualCommits = [...(data?.commits ?? [])].reverse();
   const finalized = (data?.commits ?? []).filter(
     (c) => c.state === "SUCCESS" || c.state === "FAILURE" || c.state === "ERROR",
   ).length;
@@ -211,7 +214,7 @@ export function BuildPanel() {
                 1px on mobile so 100 dots aren't dominated by spacing
                 in a ~340px wide card. */}
             <div className="mt-3 flex gap-px sm:gap-[3px]">
-              {data.commits.map((c) => (
+              {visualCommits.map((c) => (
                 <a
                   key={c.oid}
                   href={c.url}

--- a/infra/status-page/web/src/components/FerryPanel.tsx
+++ b/infra/status-page/web/src/components/FerryPanel.tsx
@@ -94,6 +94,9 @@ function formatRelative(iso: string): string {
 function WorkflowCard({ wf }: { wf: FerryWorkflowStatus }) {
   const latest = wf.latest;
   const successRate = wf.successRate;
+  // The API keeps history newest-first for latest-run math. The strip reads
+  // more naturally oldest-to-newest, with the most recent run on the right.
+  const visualHistory = wf.history.map((run, index) => ({ run, index })).reverse();
   // Match the denominator the server uses for `successRate`
   // (githubActions.ts:computeSuccessRate) — completed runs only, not
   // the raw history length which can include queued/in-progress runs.
@@ -141,10 +144,10 @@ function WorkflowCard({ wf }: { wf: FerryWorkflowStatus }) {
               so all 30 fit on a ~340px phone content area without
               wrapping to a second row. */}
           <div className="mt-3 flex gap-px sm:gap-1">
-            {wf.history.map((run, i) => {
+            {visualHistory.map(({ run, index }) => {
               const a = runAppearance(run);
-              const slow = isSlowRun(wf.history, i);
-              const baseline = slow ? slowRunBaseline(wf.history, i) : null;
+              const slow = isSlowRun(wf.history, index);
+              const baseline = slow ? slowRunBaseline(wf.history, index) : null;
               return (
                 <a
                   key={run.id}


### PR DESCRIPTION
## Summary

Render the infra status page history strips oldest-to-newest so the most recent GitHub Build and Ferry status squares appear on the right.

## Root Cause

The GitHub APIs return workflow runs and commit history newest-first. The dashboard used those arrays directly for the compact status strips, so time flowed right-to-left even though the latest-line logic correctly treated index 0 as newest.

## Changes

- Reverse the rendered Build strip while keeping `commits[0]` as the latest commit.
- Reverse the rendered Ferry strip using original indices so slow-run detection and baseline math still use the newest-first source order.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run build`