### PR TITLE
[codex] Distinguish Iris dashboard titles

### DIFF
--- a/lib/iris/src/iris/cluster/dashboard_common.py
+++ b/lib/iris/src/iris/cluster/dashboard_common.py
@@ -9,8 +9,11 @@ the frontend hasn't been built yet (e.g. in tests or local dev).
 """
 
 import logging
+import os
+import re
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from html import escape
 from pathlib import Path
 from typing import Any
 
@@ -63,6 +66,7 @@ DOCKER_VUE_DIST_DIR = Path("/app/dashboard/dist")
 
 # Allow browsers to cache static assets for up to 10 minutes before revalidating.
 STATIC_MAX_AGE_SECONDS = 600
+DASHBOARD_TITLE_ENV_VAR = "IRIS_DASHBOARD_TITLE"
 
 
 class _CacheControlStaticFiles:
@@ -163,6 +167,40 @@ _NOT_BUILT_HTML = """\
 """
 
 
+def dashboard_title_from_config(config: Any | None) -> str | None:
+    """Return a human-readable dashboard title from cluster config."""
+    if config is None:
+        return None
+    platform = getattr(config, "platform", None)
+    for value in (getattr(config, "name", ""), getattr(platform, "label_prefix", "")):
+        if value is None:
+            continue
+        title = str(value).strip()
+        if title:
+            return title
+    return None
+
+
+def _configured_dashboard_title(dashboard_title: str | None) -> str | None:
+    title = dashboard_title if dashboard_title is not None else os.environ.get(DASHBOARD_TITLE_ENV_VAR, "")
+    title = title.strip()
+    return title or None
+
+
+def _with_dashboard_title(html: str, dashboard_title: str | None) -> str:
+    title = _configured_dashboard_title(dashboard_title)
+    if title is None:
+        return html
+    escaped_title = escape(f"{title} | Iris", quote=False)
+    return re.sub(
+        r"<title>.*?</title>",
+        f"<title>{escaped_title}</title>",
+        html,
+        count=1,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+
+
 def html_shell(title: str, dashboard_type: str = "controller") -> str:
     """Return the pre-built HTML page for a dashboard.
 
@@ -178,4 +216,4 @@ def html_shell(title: str, dashboard_type: str = "controller") -> str:
     if not index_path.exists():
         logger.warning("Dashboard HTML %s not found; serving placeholder", index_path)
         return _NOT_BUILT_HTML
-    return index_path.read_text()
+    return _with_dashboard_title(index_path.read_text(), None)

--- a/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
@@ -13,11 +13,13 @@ from __future__ import annotations
 import json
 import logging
 import re
+import shlex
 
 import yaml
 from google.protobuf.json_format import MessageToDict
 
 from collections.abc import Callable
+from iris.cluster.dashboard_common import DASHBOARD_TITLE_ENV_VAR, dashboard_title_from_config
 from iris.rpc import config_pb2
 
 logger = logging.getLogger(__name__)
@@ -362,6 +364,7 @@ sudo docker run -d --name {{ container_name }} \\
     --ulimit core=0:0 \\
     -v /var/cache/iris:/var/cache/iris \\
     {{ config_volume }} \\
+    {{ dashboard_env }} \\
     {{ docker_image }} \\
     .venv/bin/python -m iris.cluster.controller.main serve \\
         --host 0.0.0.0 --port {{ port }} {{ config_flag }} {{ fresh_flag }}
@@ -434,6 +437,7 @@ def build_controller_bootstrap_script(
     docker_image: str,
     port: int,
     config_yaml: str = "",
+    dashboard_title: str | None = None,
     fresh: bool = False,
 ) -> str:
     """Build bootstrap script for controller VM.
@@ -442,6 +446,7 @@ def build_controller_bootstrap_script(
         docker_image: Docker image to run
         port: Controller port
         config_yaml: Optional YAML config to write to /etc/iris/config.yaml
+        dashboard_title: Optional browser title prefix for the dashboard
         fresh: When True, pass ``--fresh`` to the controller serve command so
             it starts with an empty local database and skips checkpoint restore.
     """
@@ -453,6 +458,8 @@ def build_controller_bootstrap_script(
         config_setup = "# No config file provided"
         config_volume = ""
         config_flag = ""
+    dashboard_title = (dashboard_title or "").strip()
+    dashboard_env = f"-e {DASHBOARD_TITLE_ENV_VAR}={shlex.quote(dashboard_title)}" if dashboard_title else ""
 
     return render_template(
         CONTROLLER_BOOTSTRAP_SCRIPT,
@@ -461,6 +468,7 @@ def build_controller_bootstrap_script(
         port=port,
         config_setup=config_setup,
         config_volume=config_volume,
+        dashboard_env=dashboard_env,
         config_flag=config_flag,
         fresh_flag="--fresh" if fresh else "",
     )
@@ -493,4 +501,10 @@ def build_controller_bootstrap_script_from_config(
 
     image = resolve_image(image, zone)
 
-    return build_controller_bootstrap_script(image, port, config_yaml, fresh=fresh)
+    return build_controller_bootstrap_script(
+        image,
+        port,
+        config_yaml,
+        dashboard_title=dashboard_title_from_config(config),
+        fresh=fresh,
+    )

--- a/lib/iris/src/iris/cluster/providers/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/controller.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from urllib.parse import urlparse
 
 from iris.cluster.config import config_to_dict
+from iris.cluster.dashboard_common import DASHBOARD_TITLE_ENV_VAR, dashboard_title_from_config
 from iris.cluster.providers.k8s.service import K8sService
 from iris.cluster.providers.k8s.types import K8sResource
 from iris.cluster.providers.types import InfraError, Labels
@@ -135,6 +136,7 @@ def _build_controller_deployment(
     port: int,
     node_selector: dict[str, str],
     s3_env_vars: list[dict],
+    dashboard_title: str | None = None,
     fresh: bool = False,
 ) -> dict:
     """Build the controller Deployment manifest as a dict."""
@@ -144,6 +146,9 @@ def _build_controller_deployment(
         "requests": {"cpu": _CONTROLLER_CPU_REQUEST, "memory": _CONTROLLER_MEMORY_REQUEST},
         "limits": {"cpu": _CONTROLLER_CPU_REQUEST, "memory": _CONTROLLER_MEMORY_REQUEST},
     }
+    env_vars = list(s3_env_vars)
+    if dashboard_title:
+        env_vars.append({"name": DASHBOARD_TITLE_ENV_VAR, "value": dashboard_title})
     return {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -176,7 +181,7 @@ def _build_controller_deployment(
                                 *(["--fresh"] if fresh else []),
                             ],
                             "ports": [{"containerPort": port}],
-                            "env": s3_env_vars,
+                            "env": env_vars,
                             "securityContext": {"capabilities": {"add": ["SYS_PTRACE"]}},
                             "resources": controller_resources,
                             "volumeMounts": [
@@ -311,6 +316,7 @@ class K8sControllerProvider:
             port=port,
             node_selector={self._iris_labels.iris_scale_group: cw.scale_group},
             s3_env_vars=s3_env,
+            dashboard_title=dashboard_title_from_config(config),
             fresh=fresh,
         )
         self._kubectl.apply_json(deploy_manifest)

--- a/lib/iris/tests/cluster/providers/gcp/test_bootstrap.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_bootstrap.py
@@ -14,6 +14,7 @@ from iris.cluster.providers.gcp.bootstrap import (
     rewrite_ghcr_to_ar_remote,
     zone_to_multi_region,
 )
+from iris.cluster.dashboard_common import DASHBOARD_TITLE_ENV_VAR
 from iris.rpc import config_pb2
 
 
@@ -155,6 +156,19 @@ def test_build_controller_bootstrap_script_from_config_rewrites_ghcr_to_ar() -> 
         in script
     )
     assert 'sudo gcloud auth configure-docker "$AR_HOST" -q || true' in script
+
+
+def test_build_controller_bootstrap_script_sets_dashboard_title() -> None:
+    config = config_pb2.IrisClusterConfig()
+    config.platform.label_prefix = "marin-dev"
+    config.controller.image = "ghcr.io/marin-community/iris-controller:latest"
+    config.controller.gcp.zone = "us-central1-a"
+    config.controller.gcp.port = 10000
+    config.platform.gcp.project_id = "hai-gcp-models"
+
+    script = build_controller_bootstrap_script_from_config(config, resolve_image=lambda image, zone=None: image)
+
+    assert f"-e {DASHBOARD_TITLE_ENV_VAR}=marin-dev" in script
 
 
 # --- GcpWorkerProvider.resolve_image() tests ---

--- a/lib/iris/tests/cluster/providers/k8s/test_coreweave.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_coreweave.py
@@ -22,6 +22,7 @@ from iris.cluster.providers.k8s.controller import (
     _CONTROLLER_CPU_REQUEST,
     _CONTROLLER_MEMORY_REQUEST,
 )
+from iris.cluster.dashboard_common import DASHBOARD_TITLE_ENV_VAR
 from iris.cluster.providers.k8s.fake import InMemoryK8sService
 from iris.cluster.providers.k8s.types import K8sResource
 from iris.cluster.providers.types import (
@@ -163,10 +164,11 @@ def test_start_controller_creates_all_resources():
 
     # Verify controller uses S3 env vars (no GCS credentials)
     container = deploy_spec["template"]["spec"]["containers"][0]
-    env_names = [e["name"] for e in container["env"]]
-    assert "AWS_ACCESS_KEY_ID" in env_names
-    assert "AWS_SECRET_ACCESS_KEY" in env_names
-    assert "GOOGLE_APPLICATION_CREDENTIALS" not in env_names
+    env_by_name = {e["name"]: e for e in container["env"]}
+    assert "AWS_ACCESS_KEY_ID" in env_by_name
+    assert "AWS_SECRET_ACCESS_KEY" in env_by_name
+    assert "GOOGLE_APPLICATION_CREDENTIALS" not in env_by_name
+    assert env_by_name[DASHBOARD_TITLE_ENV_VAR]["value"] == "iris"
     assert container["resources"]["requests"] == {"cpu": _CONTROLLER_CPU_REQUEST, "memory": _CONTROLLER_MEMORY_REQUEST}
     assert container["resources"]["limits"] == {"cpu": _CONTROLLER_CPU_REQUEST, "memory": _CONTROLLER_MEMORY_REQUEST}
 

--- a/lib/iris/tests/cluster/test_dashboard_common.py
+++ b/lib/iris/tests/cluster/test_dashboard_common.py
@@ -1,0 +1,52 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from iris.cluster import dashboard_common
+from iris.rpc import config_pb2
+
+
+def test_dashboard_title_from_config_prefers_name() -> None:
+    config = config_pb2.IrisClusterConfig()
+    config.name = "marin"
+    config.platform.label_prefix = "marin-dev"
+
+    assert dashboard_common.dashboard_title_from_config(config) == "marin"
+
+
+def test_dashboard_title_from_config_falls_back_to_label_prefix() -> None:
+    config = config_pb2.IrisClusterConfig()
+    config.platform.label_prefix = "cw"
+
+    assert dashboard_common.dashboard_title_from_config(config) == "cw"
+
+
+def test_html_shell_uses_deployed_dashboard_title(monkeypatch, tmp_path) -> None:
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "controller.html").write_text(
+        "<!doctype html><html><head><title>Iris Dashboard</title></head><body></body></html>"
+    )
+
+    monkeypatch.setattr(dashboard_common, "VUE_DIST_DIR", dist)
+    monkeypatch.setattr(dashboard_common, "DOCKER_VUE_DIST_DIR", tmp_path / "missing")
+    monkeypatch.setenv(dashboard_common.DASHBOARD_TITLE_ENV_VAR, "marin-dev")
+
+    html = dashboard_common.html_shell("Iris Controller", "controller")
+
+    assert "<title>marin-dev | Iris</title>" in html
+
+
+def test_html_shell_escapes_deployed_dashboard_title(monkeypatch, tmp_path) -> None:
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "controller.html").write_text(
+        "<!doctype html><html><head><title>Iris Dashboard</title></head><body></body></html>"
+    )
+
+    monkeypatch.setattr(dashboard_common, "VUE_DIST_DIR", dist)
+    monkeypatch.setattr(dashboard_common, "DOCKER_VUE_DIST_DIR", tmp_path / "missing")
+    monkeypatch.setenv(dashboard_common.DASHBOARD_TITLE_ENV_VAR, "<cw>")
+
+    html = dashboard_common.html_shell("Iris Controller", "controller")
+
+    assert "<title>&lt;cw&gt; | Iris</title>" in html


### PR DESCRIPTION
## Summary

Distinguish Iris dashboard browser tab titles using deploy-time configuration instead of URL parameters or build-time dashboard assets.

- Adds `IRIS_DASHBOARD_TITLE` as the runtime title contract for the dashboard HTML shell.
- Derives the title from cluster config once at deployment/startup: `config.name` first, then `platform.label_prefix`.
- Passes the title into GCP controller containers and CoreWeave/K8s controller Deployments.
- Keeps the dashboard build/image generic, so shared `iris-controller` images still work for `marin`, `marin-dev`, and `cw`.

## Why

The dashboard assets are built before the controller image and copied into the image, while the example cluster configs reuse the same `ghcr.io/marin-community/iris-controller:latest` image. A build-time `rsbuild` title would therefore not distinguish shared-image deployments. Hostname-based titles also fail for localhost/tunnel workflows.

This approach lets each deployed controller provide the title once through runtime config, while the browser still sees a normal static dashboard page.

## Validation

- `./infra/pre-commit.py --fix lib/iris/dashboard/src/template.html lib/iris/src/iris/cli/main.py lib/iris/src/iris/cli/cluster.py lib/iris/src/iris/cluster/dashboard_common.py lib/iris/src/iris/cluster/providers/gcp/bootstrap.py lib/iris/src/iris/cluster/providers/k8s/controller.py lib/iris/tests/cluster/test_dashboard_common.py lib/iris/tests/cluster/providers/gcp/test_bootstrap.py lib/iris/tests/cluster/providers/k8s/test_coreweave.py`
- `uv run pytest lib/iris/tests/cluster/test_dashboard_common.py lib/iris/tests/cluster/providers/gcp/test_bootstrap.py::test_build_controller_bootstrap_script_sets_dashboard_title lib/iris/tests/cluster/providers/gcp/test_bootstrap.py::test_build_controller_bootstrap_script_from_config_rewrites_ghcr_to_ar lib/iris/tests/cluster/providers/k8s/test_coreweave.py::test_start_controller_creates_all_resources`
- `npm run build` from `lib/iris/dashboard`
- Playwright smoke against a local Starlette server serving `html_shell` with `IRIS_DASHBOARD_TITLE=marin-dev`; verified browser title `marin-dev | Iris` and saved screenshot at `/tmp/iris-dashboard-title-screenshots/runtime-env-title-marin-dev-desktop.png`.