### PR TITLE
[iris]: link aggregated job log lines to originating task

### DIFF
--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
+import { RouterLink } from 'vue-router'
 import { logServiceRpcCall } from '@/composables/useRpc'
 import { useAutoRefresh } from '@/composables/useAutoRefresh'
 import type { FetchLogsResponse, LogEntry, TaskAttempt } from '@/types/rpc'
@@ -159,7 +160,40 @@ watch(() => props.workerId, resetAndFetch)
 
 onMounted(resetAndFetch)
 
-const filteredLogs = computed<LogEntry[]>(() => entries.value)
+// Job-aggregate mode shows logs from many tasks; render a per-line link to the
+// originating task. Single-task mode would link every line to itself, so skip.
+const showTaskLinks = computed(() => {
+  if (!props.taskId) return false
+  return !/\/\d+$/.test(props.taskId)
+})
+
+interface TaskRef {
+  taskId: string
+  taskIndex: string
+}
+
+function parseTaskFromKey(key: string | undefined): TaskRef | null {
+  if (!key) return null
+  const colonIdx = key.lastIndexOf(':')
+  const taskId = colonIdx > 0 ? key.slice(0, colonIdx) : key
+  const lastSlash = taskId.lastIndexOf('/')
+  if (lastSlash < 0) return null
+  const taskIndex = taskId.slice(lastSlash + 1)
+  if (!/^\d+$/.test(taskIndex)) return null
+  return { taskId, taskIndex }
+}
+
+interface LogRow {
+  entry: LogEntry
+  taskRef: TaskRef | null
+}
+
+const logRows = computed<LogRow[]>(() =>
+  entries.value.map(entry => ({
+    entry,
+    taskRef: showTaskLinks.value ? parseTaskFromKey(entry.key) : null,
+  })),
+)
 
 defineExpose({ selectedAttemptId })
 </script>
@@ -211,7 +245,7 @@ defineExpose({ selectedAttemptId })
         {{ autoRefreshActive ? 'Auto ⟳' : 'Paused' }}
       </button>
       <span class="ml-auto text-xs text-text-muted font-mono">
-        {{ filteredLogs.length }} lines
+        {{ logRows.length }} lines
       </span>
     </div>
 
@@ -227,27 +261,35 @@ defineExpose({ selectedAttemptId })
       :style="{ maxHeight: maxHeight }"
     >
       <div
-        v-if="loading && filteredLogs.length === 0"
+        v-if="loading && logRows.length === 0"
         class="py-12 text-center text-text-muted text-sm"
       >
         Loading logs...
       </div>
       <div
-        v-else-if="filteredLogs.length === 0"
+        v-else-if="logRows.length === 0"
         class="py-12 text-center text-text-muted text-sm"
       >
         No log entries
       </div>
       <div
-        v-for="(entry, i) in filteredLogs"
+        v-for="(row, i) in logRows"
         :key="i"
         :class="[
           'px-3 py-0.5 font-mono text-xs leading-relaxed hover:bg-surface-sunken',
-          logLevelClass(entry.level),
+          logLevelClass(row.entry.level),
         ]"
       >
-        <span class="text-text-muted mr-2">{{ formatLogTime(timestampMs(entry.timestamp)) }}</span>
-        <span class="whitespace-pre-wrap break-all">{{ entry.data }}</span>
+        <RouterLink
+          v-if="row.taskRef && props.taskId"
+          :to="`/job/${encodeURIComponent(props.taskId)}/task/${encodeURIComponent(row.taskRef.taskId)}`"
+          class="text-accent hover:underline mr-2"
+          :title="row.taskRef.taskId"
+        >
+          T{{ row.taskRef.taskIndex }}
+        </RouterLink>
+        <span class="text-text-muted mr-2">{{ formatLogTime(timestampMs(row.entry.timestamp)) }}</span>
+        <span class="whitespace-pre-wrap break-all">{{ row.entry.data }}</span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
* in the job dashboard's aggregated `Job Logs`, each line now starts with a `T<N>` link to the originating task's detail page
* parses the task path from `LogEntry.key`[^1], already populated by the log store — no backend changes
* only renders in job-aggregate mode (`taskId` set and not itself a task path); single-task and system-log views are unchanged

[^1]: `entry.source` is what the producer writes and is typically empty for task logs; `entry.key` is the storage key (`<taskId>:<attemptId>`) set by the duckdb store on read in `lib/iris/src/iris/cluster/log_store/duckdb_store.py`.