### PR TITLE
[zephyr] skip status log when no counters recorded

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -488,17 +488,10 @@ class ZephyrCoordinator:
         dead = sum(1 for s in states if s in {WorkerState.FAILED, WorkerState.DEAD})
 
         totals = self.get_counters()
-        items = totals.get(ZEPHYR_STAGE_ITEM_COUNT_KEY.format(stage_name=self._stage_name), 0)
-        bytes_processed = totals.get(ZEPHYR_STAGE_BYTES_PROCESSED_KEY.format(stage_name=self._stage_name), 0)
-        elapsed = time.monotonic() - (
-            self._stage_monotonic_start if self._stage_monotonic_start is not None else float("inf")
-        )
-        item_rate = items / elapsed
-        byte_rate = bytes_processed / elapsed
-
-        logger.info(
-            "[%s] [%s] %d/%d complete, %d in-flight, %d queued, %d/%d workers alive, %d dead; "
-            "items=%d (%.1f/s), bytes_processed=%.1fMiB (%.1fMiB/s)",
+        item_key = ZEPHYR_STAGE_ITEM_COUNT_KEY.format(stage_name=self._stage_name)
+        byte_key = ZEPHYR_STAGE_BYTES_PROCESSED_KEY.format(stage_name=self._stage_name)
+        base_msg = "[%s] [%s] %d/%d complete, %d in-flight, %d queued, %d/%d workers alive, %d dead"
+        base_args = (
             self._execution_id,
             self._stage_name,
             self._completed_shards,
@@ -508,11 +501,29 @@ class ZephyrCoordinator:
             alive,
             len(self._worker_handles),
             dead,
-            items,
-            item_rate,
-            bytes_processed / (1024 * 1024),
-            byte_rate / (1024 * 1024),
         )
+
+        # Map-only stages don't yield through StatisticsGenerator and never
+        # populate these counters. Drop the items/bytes_processed segment for
+        # those stages — see ``subprocess_worker._periodic_status_logger``.
+        if item_key in totals or byte_key in totals:
+            items = totals.get(item_key, 0)
+            bytes_processed = totals.get(byte_key, 0)
+            elapsed = time.monotonic() - (
+                self._stage_monotonic_start if self._stage_monotonic_start is not None else float("inf")
+            )
+            item_rate = items / elapsed
+            byte_rate = bytes_processed / elapsed
+            logger.info(
+                base_msg + "; items=%d (%.1f/s), bytes_processed=%.1fMiB (%.1fMiB/s)",
+                *base_args,
+                items,
+                item_rate,
+                bytes_processed / (1024 * 1024),
+                byte_rate / (1024 * 1024),
+            )
+        else:
+            logger.info(base_msg, *base_args)
         if retried:
             attempts_histogram = dict(sorted(Counter(retried.values()).items()))
             logger.warning("[%s] Shards retried (attempts: shard count): %s", self._execution_id, attempts_histogram)

--- a/lib/zephyr/src/zephyr/subprocess_worker.py
+++ b/lib/zephyr/src/zephyr/subprocess_worker.py
@@ -149,6 +149,12 @@ def _periodic_status_logger(
     while not stop_event.wait(timeout=interval):
         if sys.is_finalizing():
             return
+        # Stages that don't yield through StatisticsGenerator (e.g. map-only
+        # stages whose output isn't observed item-by-item) never populate these
+        # counters. Logging zeros for them is misleading, so skip the line
+        # entirely until at least one counter has been recorded.
+        if item_key not in ctx._counters and byte_key not in ctx._counters:
+            continue
         items = ctx._counters.get(item_key, 0)
         bytes_processed = ctx._counters.get(byte_key, 0)
         elapsed = time.monotonic() - monotonic_start

--- a/lib/zephyr/tests/subprocess_worker_test.py
+++ b/lib/zephyr/tests/subprocess_worker_test.py
@@ -3,6 +3,9 @@
 
 """Tests for zephyr.subprocess_worker."""
 
+import logging
+import threading
+
 import cloudpickle
 
 import zephyr.subprocess_worker as sw
@@ -40,3 +43,54 @@ def test_execute_shard_sets_stage_scoped_output_counters(tmp_path):
 
     assert counters_out[ZEPHYR_STAGE_ITEM_COUNT_KEY.format(stage_name=stage_name)] == 10
     assert counters_out[ZEPHYR_STAGE_BYTES_PROCESSED_KEY.format(stage_name=stage_name)] > 0
+
+
+def _run_status_logger_once(ctx: sw._SubprocessWorkerContext, stage_name: str) -> threading.Thread:
+    """Spin up the status-logger thread, let one tick fire, then stop it."""
+    stop_event = threading.Event()
+
+    def _target():
+        sw._periodic_status_logger(
+            stop_event=stop_event,
+            ctx=ctx,
+            stage_name=stage_name,
+            execution_id="exec-id",
+            shard_idx=0,
+            total_shards=1,
+            monotonic_start=0.0,
+            interval=0.01,
+        )
+
+    thread = threading.Thread(target=_target, daemon=True)
+    thread.start()
+    # Give the loop time to wake at least once.
+    thread.join(timeout=0.1)
+    stop_event.set()
+    thread.join(timeout=1.0)
+    return thread
+
+
+def test_periodic_status_logger_skips_when_no_counters(caplog):
+    """Map-only stages never populate item/byte counters; we shouldn't log zeros."""
+    stage_name = "map-only"
+    ctx = sw._SubprocessWorkerContext(chunk_prefix="x", execution_id="exec-id")
+
+    with caplog.at_level(logging.INFO, logger=sw.__name__):
+        _run_status_logger_once(ctx, stage_name)
+
+    status_records = [r for r in caplog.records if "shard 0/1" in r.getMessage()]
+    assert status_records == []
+
+
+def test_periodic_status_logger_logs_when_counters_present(caplog):
+    """Once a counter has been recorded, the status line is emitted."""
+    stage_name = "with-stats"
+    ctx = sw._SubprocessWorkerContext(chunk_prefix="x", execution_id="exec-id")
+    ctx._counters[ZEPHYR_STAGE_ITEM_COUNT_KEY.format(stage_name=stage_name)] = 5
+
+    with caplog.at_level(logging.INFO, logger=sw.__name__):
+        _run_status_logger_once(ctx, stage_name)
+
+    status_records = [r for r in caplog.records if "shard 0/1" in r.getMessage()]
+    assert status_records, "expected at least one status log line"
+    assert "items=5" in status_records[0].getMessage()

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -358,6 +358,53 @@ def test_status_reports_alive_workers_not_total(actor_context, tmp_path):
     assert len(coord._task_queue) == 1  # task was requeued
 
 
+def test_log_status_omits_throughput_when_counters_missing(actor_context, tmp_path, caplog):
+    """Map-only stages don't populate item/byte counters, so the coordinator's
+    status log should drop the ``items=... bytes_processed=...`` segment rather
+    than print misleading zeros. Once either counter is recorded, the segment
+    reappears."""
+    from zephyr.execution import ZEPHYR_STAGE_BYTES_PROCESSED_KEY, ZEPHYR_STAGE_ITEM_COUNT_KEY
+
+    coord = ZephyrCoordinator()
+    coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
+    task = ShardTask(
+        shard_idx=0,
+        total_shards=1,
+        shard=ListShard(refs=[]),
+        operations=[],
+        stage_name="map_only",
+    )
+    coord._start_stage("map_only", [task])
+
+    # No counters recorded → throughput segment is suppressed.
+    with caplog.at_level(logging.INFO, logger="zephyr.execution"):
+        caplog.clear()
+        coord._log_status()
+    msgs = [r.getMessage() for r in caplog.records if "complete" in r.getMessage()]
+    assert msgs, "expected a status line"
+    assert all("items=" not in m and "bytes_processed=" not in m for m in msgs), msgs
+
+    # Once a counter snapshot exists, the throughput segment reappears.
+    coord._worker_counters["worker-A"] = CounterSnapshot(
+        counters={ZEPHYR_STAGE_ITEM_COUNT_KEY.format(stage_name="map_only"): 7}, generation=1
+    )
+    with caplog.at_level(logging.INFO, logger="zephyr.execution"):
+        caplog.clear()
+        coord._log_status()
+    msgs = [r.getMessage() for r in caplog.records if "complete" in r.getMessage()]
+    assert msgs and "items=7" in msgs[-1] and "bytes_processed=0.0MiB" in msgs[-1], msgs
+
+    # Same when only the byte counter is present.
+    coord._worker_counters["worker-A"] = CounterSnapshot(
+        counters={ZEPHYR_STAGE_BYTES_PROCESSED_KEY.format(stage_name="map_only"): 1024}, generation=2
+    )
+    with caplog.at_level(logging.INFO, logger="zephyr.execution"):
+        caplog.clear()
+        coord._log_status()
+    msgs = [r.getMessage() for r in caplog.records if "complete" in r.getMessage()]
+    assert msgs and "items=0" in msgs[-1] and "bytes_processed=" in msgs[-1], msgs
+
+
 def test_no_duplicate_results_on_heartbeat_timeout(actor_context, tmp_path):
     """When a task is requeued after heartbeat timeout, the original worker's
     stale result (from a previous attempt) is rejected by the coordinator."""


### PR DESCRIPTION
Fixes #5175.

Map-only stages don't run their output through `StatisticsGenerator`, so the periodic status logger in `subprocess_worker._periodic_status_logger` kept emitting `items=0 (0.0/s), bytes_processed=0.0MiB` for the entire shard runtime — noisy and misleading. Now we skip the log line entirely until at least one of the item/byte counters has been recorded.

Generated with [Claude Code](https://claude.ai/code)