### PR TITLE
Add MoE depth MuP LR sweep

### DIFF
--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -65,3 +65,24 @@
 - Interpretation: local behavior is wired correctly; no TPU jobs launched yet.
 - Next action: run broader contract checks, then decide whether to submit the
   sweep jobs.
+
+### 2026-04-25 11:33 - Iris submission blocked
+
+- Hypothesis: the depth MuP LR sweep can be submitted through the standard MoE
+  Iris command once the branch is pushed.
+- Command:
+  - `.venv/bin/iris --config lib/iris/examples/marin.yaml job run --no-wait --reserve v5p-8 -e WANDB_API_KEY "$WANDB_API_KEY" -- python -m experiments.grug.moe.depth_mup_lr_sweep`
+  - `.venv/bin/iris --config lib/iris/examples/marin-dev.yaml job run --no-wait --reserve v5p-8 -e WANDB_API_KEY "$WANDB_API_KEY" -- python -m experiments.grug.moe.depth_mup_lr_sweep`
+- Config:
+  - active GCP account: `kaiyuew@stanford.edu`
+  - GCP project: `hai-gcp-models`
+  - `WANDB_API_KEY`: present
+  - controller tunnel: none found on `localhost:10000`
+- Result: both production and dev configs failed before creating a job:
+  `GCP API error 403: Required 'compute.instances.list' permission for
+  'projects/hai-gcp-models'`.
+- Interpretation: the run submission is blocked by local GCP permissions, not
+  by the experiment code or Iris job configuration.
+- Next action: retry submission after authenticating with an account that can
+  list controller VMs in `hai-gcp-models`, or provide an explicit
+  `--controller-url` for an existing Iris tunnel.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -427,3 +427,29 @@
   full restart of completed points.
 - Next action: continue short-cadence monitoring until the restarted tasks show
   sustained post-retry training progress, then return to the normal cadence.
+
+### 2026-04-25 19:26 - recovery heartbeat and CI closure
+
+- Hypothesis: after the replacement launch stabilizes, the sweep should behave
+  like a normal executor run with 8 concurrent child steps.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260426-020352`
+  - `uv run iris --config lib/iris/examples/marin.yaml job logs --since-seconds 900 --max-lines 1800 --tail /kaiyue/iris-run-job-20260426-020352`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+  - `curl -fsS ... /repos/marin-community/marin/commits/117f0f414/check-runs`
+- Result:
+  - Iris shows 8 active child runs plus the parent, all `JOB_STATE_RUNNING`.
+  - No active child has nonzero `failure_count` or a `pending_reason`.
+  - Recent logs show d768 `4x` around 9.66k/10.3k steps after Paloma macro
+    3.8426, so it should finish soon.
+  - d1024 children are making post-retry progress: `0.354x` is around
+    3.35k/12.6k, `0.5x` around 3.00k/12.6k, and `2x` around 2.35k/12.6k.
+  - W&B still reports `model.depth_mup_residual_scaling=True` for every
+    started run.
+  - GitHub checks on `117f0f414` are complete: relevant checks passed and the
+    rest were skipped.
+- Interpretation: no intervention is needed. The missing d1024 `2.83x`/`4x`
+  and d1280 runs are expected because `StepRunner` defaults to 8 concurrent
+  steps; they should enqueue after current active children finish or skip.
+- Next action: return to the normal babysit cadence and wait for d768 `4x` to
+  finish or for the next executor wave to launch.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -105,3 +105,25 @@
   cleared. The experiment is now in the Iris startup window.
 - Next action: perform the 120-second startup check, then monitor on the normal
   babysit cadence.
+
+### 2026-04-25 11:51 - Startup check
+
+- Hypothesis: transient TPU init failures should be recoverable by Iris task
+  retries if subsequent attempts get a usable v5p-8 worker.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260425-184727`
+  - `uv run iris --config lib/iris/examples/marin.yaml job summary --json /kaiyue/iris-run-job-20260425-184727/grug-train-moe-depth-mup-lr-d512-lr1x`
+  - `uv run iris --config lib/iris/examples/marin.yaml job logs --since-seconds 900 --max-lines 500 /kaiyue/iris-run-job-20260425-184727/grug-train-moe-depth-mup-lr-d512-lr1x`
+- Result:
+  - coordinator: `JOB_STATE_RUNNING`
+  - d512 children visible: 8, all `JOB_STATE_RUNNING`
+  - sampled d512 `lr1x` child: 2 recovered preemptions from TPU init failures
+    (`Device or resource busy` / `No accelerator found`), then a running
+    attempt loading caches
+  - sample W&B run:
+    `https://wandb.ai/understanding-sam/marin_moe/runs/moe-depth-mup-lr-d512-lr1x`
+- Interpretation: Iris recovered from the initial bad-node symptoms without
+  job-level intervention. No training loss yet; cache/eval setup is still in
+  progress.
+- Next action: switch to the normal babysit cadence and watch for first loss
+  lines, terminal states, or repeated TPU bad-node errors.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -571,3 +571,39 @@
   is poor by ~1k).
 - Next action: continue d1024 to completion and let the executor launch d1024
   `4x` and then d1280 before making the gate-2 scaling-law call.
+
+### 2026-04-25 22:13 - d1024 ~6k checkpoint
+
+- Hypothesis: the d1024 central-basin optimum should become clearer once the
+  `0.5x`, `0.707x`, `1x`, and `1.41x` runs all publish comparable ~6k evals.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260426-020352`
+  - `uv run iris --config lib/iris/examples/marin.yaml job logs --since-seconds 900 --max-lines 1800 --tail /kaiyue/iris-run-job-20260426-020352`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris shows the parent plus 8 running d1024 children and 1 succeeded d768
+    child; there are still no active child failures or pending reasons.
+  - All sampled started W&B configs still report
+    `model.depth_mup_residual_scaling=True`.
+  - d1024 latest W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Notes |
+    | --- | --- | ---: | ---: | ---: | --- |
+    | 0.25x | running | 6283 | 3.4918 | 3.1274 | ~6k eval |
+    | 0.354x | running | 6442 | 3.4441 | 3.1142 | ~6k eval |
+    | 0.5x | running | 6082 | 3.4266 | 3.0811 | ~6k eval, current best |
+    | 0.707x | running | 6233 | 3.4394 | 3.1220 | ~6k eval |
+    | 1x | running | 6230 | 3.4777 | 3.1569 | ~6k eval |
+    | 1.41x | running | 6219 | 3.5561 | 3.1399 | ~6k eval |
+    | 2x | running | 5450 | 3.7702 | 3.4310 | latest eval around 5k |
+    | 2.83x | running | 2639 | 4.2020 | 3.7672 | latest eval around 2k |
+    | 4x | missing | n/a | n/a | n/a | queued |
+
+- Interpretation: the d1024 best point is still `0.5x`, now with `0.707x`
+  and `0.354x` both close enough to define a central basin. This remains a
+  useful LR-sensitivity signal, but not a clean scale-invariance result:
+  d512/d768 completed best at `1x`, while d1024 is currently best one LR step
+  lower. The high-LR side is consistently poor; `2x` remains much worse at
+  around 5k, and `2.83x` remains poor by around 2k.
+- Next action: continue d1024 until `4x` launches and the d1024 sweep
+  finishes, then continue through d1280 for the full gate-2 procedure.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -789,3 +789,38 @@
   still pending.
 - Next action: continue d1024 to completion so `4x` can launch, then continue
   through d1280 for the full gate-2 procedure.
+
+### 2026-04-26 03:35 - d1024 ~12k checkpoint
+
+- Hypothesis: as d1024 approaches the target step count, the LR optimum should
+  either stabilize at `1x` or expose whether the previous `1x` lead was a
+  transient staggered-eval artifact.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260426-020352`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris still shows 9 running jobs and 1 succeeded child; there are no active
+    failures or pending reasons.
+  - All sampled started W&B configs still report
+    `model.depth_mup_residual_scaling=True`.
+  - d1024 latest W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Notes |
+    | --- | --- | ---: | ---: | ---: | --- |
+    | 0.25x | running | 12239 | 3.3155 | 3.0738 | ~12k eval |
+    | 0.354x | running | 12378 | 3.2565 | 2.8767 | ~12k eval |
+    | 0.5x | running | 12008 | 3.2136 | 2.8795 | ~12k eval |
+    | 0.707x | running | 12203 | 3.1862 | 2.8542 | ~12k eval |
+    | 1x | running | 12171 | 3.1725 | 2.8307 | ~12k eval, current best |
+    | 1.41x | running | 12155 | 3.1810 | 2.8783 | ~12k eval |
+    | 2x | running | 11382 | 3.2994 | 2.9638 | latest eval around 11k |
+    | 2.83x | running | 8565 | 3.6840 | 3.4015 | latest eval around 8k |
+    | 4x | missing | n/a | n/a | n/a | queued |
+
+- Interpretation: d1024's central optimum has stabilized at `1x` by the
+  near-final central checkpoint. This now matches the completed d512/d768
+  optima, and the central basin remains broad: `1.41x` and `0.707x` are within
+  about 0.014 Paloma macro of `1x`. The high-LR side is still poor, with `2x`
+  behind the central basin and `2.83x` much worse.
+- Next action: continue until the d1024 children finish and `4x` launches, then
+  continue through d1280 for the full gate-2 procedure.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -352,3 +352,40 @@
   at this checkpoint.
 - Next action: continue the normal babysit cadence until d768 `4x` finishes or
   the next d1024 launches/evals create a clearer scale trend.
+
+### 2026-04-25 18:59 - d1024 third eval snapshot
+
+- Hypothesis: the ~3k-step d1024 eval should test whether the `0.707x` best
+  point from the previous checkpoint is stable or whether the basin shifts back
+  toward `1x`.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job logs --since-seconds 900 --max-lines 1500 --tail /kaiyue/iris-run-job-20260425-184727`
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260425-184727`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris shows 17 succeeded jobs and 9 running jobs; no terminal failures.
+  - d768 `4x` is still running at W&B step 8864 with Paloma macro 4.0186 after
+    one preemption.
+  - d1024 `0.5x` also picked up one preemption and has not posted its ~3k-step
+    eval yet.
+  - d1024 W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Tok/s |
+    | --- | --- | ---: | ---: | ---: | ---: |
+    | 0.25x | running | 3081 | 3.7652 | 3.3393 | 177,525 |
+    | 0.354x | running | 3105 | 3.6933 | 3.3829 | 178,385 |
+    | 0.5x | running | 2860 | 3.8318 | 3.3356 | 176,744 |
+    | 0.707x | running | 3085 | 3.6647 | 3.3696 | 177,297 |
+    | 1x | running | 3053 | 3.7080 | 3.3664 | 177,281 |
+    | 1.41x | running | 3061 | 3.8062 | 3.4856 | 177,299 |
+    | 2x | running | 2116 | 4.0351 | 3.7342 | 177,468 |
+    | 2.83x | missing | n/a | n/a | n/a | n/a |
+    | 4x | missing | n/a | n/a | n/a | n/a |
+
+- Interpretation: the third d1024 checkpoint keeps `0.707x` as the best
+  observed multiplier, with `0.354x` and `1x` close but worse. The missing
+  `0.5x` third eval makes the center of the basin incomplete, but the optimum
+  still appears to overlap the d512/d768 `0.707x`-`1x` region rather than
+  moving far with scale.
+- Next action: continue monitoring until d1024 `0.5x` catches up, d768 `4x`
+  finishes, or the next d1024 jobs launch.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -1,0 +1,67 @@
+# MoE Depth MuP LR Sweep: Research Logbook
+
+## Scope
+
+- Goal: test whether depth MuP residual scaling makes the current Grug MoE
+  recipe less learning-rate-sensitive across model scale.
+- Primary metrics: final `eval/paloma/macro_loss`, LR optimum curvature per
+  scale.
+- Secondary metrics: `throughput/tokens_per_second`,
+  `throughput/total_tokens`, effective speedup versus the compute-optimal MoE
+  baseline.
+- Issue: https://github.com/marin-community/marin/issues/5178
+- Prior LR sweep: https://github.com/marin-community/marin/issues/4225
+
+## Baseline
+
+- Date: 2026-04-25
+- Code refs:
+  - `experiments/grug/moe/README.md`
+  - `experiments/grug/moe/model.py`
+  - `experiments/grug/moe/heuristic.py`
+- Baseline numbers: compute-optimal d512, d768, d1024, and d1280 table in
+  `experiments/grug/moe/README.md`.
+
+## Experiment Log
+
+### 2026-04-25 11:25 - Kickoff
+
+- Hypothesis: scaling each layer's residual updates by `1 / sqrt(num_layers)`
+  will reduce depth-dependent residual growth and flatten the LR optimum across
+  MoE scales.
+- Command: local implementation only so far.
+- Config:
+  - architecture: current `experiments/grug/moe` recipe
+  - intervention: depth MuP residual update scale
+  - sweep scales: d512, d768, d1024, d1280 compute-optimal budgets from the
+    README
+  - LR multipliers: planned around the existing v16 LR formula
+- Result: pending.
+- Interpretation: pending.
+- Next action: add tests for explicit residual scale behavior and sweep step
+  construction, then implement the model and launch wiring.
+
+### 2026-04-25 11:45 - Implementation scaffold
+
+- Hypothesis: the smallest safe implementation is an opt-in model config flag,
+  keeping the baseline recipe unchanged while the sweep enables depth MuP.
+- Command:
+  - `uv run --with pytest --with pytest-timeout python -m pytest tests/test_grug_moe_depth_mup.py`
+  - `uv run --with pytest --with pytest-timeout python -m pytest tests/test_grug_variant_contracts.py -k moe`
+  - `uv run --with pyrefly pyrefly check experiments/grug/moe/model.py experiments/grug/moe/heuristic.py experiments/grug/moe/depth_mup_lr_sweep.py tests/test_grug_moe_depth_mup.py`
+  - `./infra/pre-commit.py --fix experiments/grug/moe/model.py experiments/grug/moe/heuristic.py experiments/grug/moe/depth_mup_lr_sweep.py experiments/grug/moe/README.md experiments/grug/moe/agent.md tests/test_grug_moe_depth_mup.py .agents/logbooks/moe-depth-mup-lr-sweep.md`
+- Config:
+  - `GrugModelConfig.depth_mup_residual_scaling=True`
+  - residual update scale: `1 / sqrt(num_layers)`
+  - sweep module: `experiments/grug/moe/depth_mup_lr_sweep.py`
+  - sweep grid: d512, d768, d1024, d1280 x 9 LR multipliers
+- Result:
+  - red phase: 3 expected failures for missing config field, block scale, and
+    sweep module
+  - green phase: 3 depth-MuP tests passed after implementation
+  - MoE contract slice: 3 passed
+  - targeted Pyrefly: 0 errors
+  - targeted pre-commit: OK
+- Interpretation: local behavior is wired correctly; no TPU jobs launched yet.
+- Next action: run broader contract checks, then decide whether to submit the
+  sweep jobs.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -216,3 +216,35 @@
   moving dramatically.
 - Next action: continue normal cadence until `d512-lr4x` finishes and the
   remaining d768 LR points launch.
+
+### 2026-04-25 13:35 - d512 complete
+
+- Hypothesis: including the delayed `4x` run should sharpen the d512 LR curve
+  and confirm whether the first scale is centered near the baseline multiplier.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260425-184727`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris shows 9 succeeded jobs and 9 running jobs; no terminal failures.
+  - All d512 runs are finished.
+  - d768 `2.83x` has launched and is running; d768 `4x` has not launched yet.
+  - Completed d512 W&B summaries:
+
+    | LR multiplier | Paloma macro | Train loss | Tok/s | Tokens |
+    | --- | ---: | ---: | ---: | ---: |
+    | 0.25x | 4.0652 | 3.7375 | 406,349 | 837,156,864 |
+    | 0.354x | 3.9475 | 3.6286 | 406,406 | 837,156,864 |
+    | 0.5x | 3.8671 | 3.5483 | 407,291 | 837,156,864 |
+    | 0.707x | 3.8302 | 3.5066 | 405,839 | 837,156,864 |
+    | 1x | 3.8188 | 3.4932 | 406,669 | 837,156,864 |
+    | 1.41x | 3.8284 | 3.5006 | 406,452 | 837,156,864 |
+    | 2x | 3.8695 | 3.5429 | 405,423 | 837,156,864 |
+    | 2.83x | 3.9301 | 3.6019 | 406,235 | 837,156,864 |
+    | 4x | 4.0568 | 3.7285 | 406,238 | 837,156,864 |
+
+- Interpretation: the completed d512 sweep is best at `1x`, with a relatively
+  shallow basin around `0.707x`-`1.41x` and clear degradation at both extremes.
+  Compared with the README baseline macro 3.8104, depth MuP at d512 is neutral
+  to slightly worse but does not require a shifted LR at this scale.
+- Next action: continue monitoring d768 through final summaries and the launch
+  of `d768-lr4x`.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -824,3 +824,40 @@
   behind the central basin and `2.83x` much worse.
 - Next action: continue until the d1024 children finish and `4x` launches, then
   continue through d1280 for the full gate-2 procedure.
+
+### 2026-04-26 04:17 - d1024 central finals and d1280 launch
+
+- Hypothesis: final central d1024 runs should confirm whether the near-final
+  `1x` lead was stable, while d1280 startup should preserve the
+  `depth_mup_residual_scaling=True` configuration on new children.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260426-020352`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris shows 16 jobs under the resubmitted parent: 9 running and 7
+    succeeded, with no active failures or pending reasons.
+  - d1280 has expanded through `1x` on Iris and W&B. Visible d1280 W&B runs
+    for `0.25x`, `0.354x`, `0.5x`, `0.707x`, and `1x` all report
+    `model.depth_mup_residual_scaling=True`.
+  - d1024 latest W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Notes |
+    | --- | --- | ---: | ---: | ---: | --- |
+    | 0.25x | finished | 12648 | 3.3098 | 2.9255 | final |
+    | 0.354x | finished | 12648 | 3.2494 | 2.8670 | final |
+    | 0.5x | finished | 12648 | 3.2040 | 2.8200 | final |
+    | 0.707x | finished | 12648 | 3.1743 | 2.7920 | final |
+    | 1x | finished | 12648 | 3.1564 | 2.7747 | final, current best |
+    | 1.41x | finished | 12648 | 3.1582 | 2.7814 | final |
+    | 2x | running | 12129 | 3.2204 | 2.8781 | latest eval around 12k |
+    | 2.83x | running | 9306 | 3.5865 | 3.1841 | latest eval around 9k |
+    | 4x | running | 208 | 11.7908 | 5.5612 | started |
+
+- Interpretation: d1024 now has a stable final central optimum at `1x`,
+  matching the completed d512 and d768 optima. The central basin remains broad:
+  `1.41x` is only 0.0018 Paloma macro behind `1x`, and `0.707x` is 0.0179
+  behind. This is the strongest evidence so far that depth MuP reduced
+  cross-scale LR drift in the useful LR range, although gate-2 still depends on
+  the d1024 high-LR tail and the full d1280 sweep.
+- Next action: continue monitoring d1024 high-LR tail and the full d1280 sweep
+  through completion before fitting the variant scaling law.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -127,3 +127,28 @@
   progress.
 - Next action: switch to the normal babysit cadence and watch for first loss
   lines, terminal states, or repeated TPU bad-node errors.
+
+### 2026-04-25 12:04 - First progress check
+
+- Hypothesis: once the d512 children pass cache setup and first eval, the run
+  should produce comparable early loss/progress lines without more bad-node
+  intervention.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260425-184727`
+  - `uv run iris --config lib/iris/examples/marin.yaml job logs --since-seconds 900 --max-lines 1200 --tail /kaiyue/iris-run-job-20260425-184727`
+- Result:
+  - 9 jobs visible: coordinator + 8 d512 children, all `JOB_STATE_RUNNING`
+  - each visible child still has `preemption_count=2` from the recovered TPU
+    init failures
+  - first eval/progress logs are present; sampled values:
+    - d512 `lr1x`: Paloma macro 4.830 at first post-start eval, train progress
+      ~1.35k / 6.39k steps with loss ~4.23
+    - d512 `lr0.5x`: Paloma macro 5.137, train progress ~1.35k / 6.39k steps
+      with loss ~4.38
+    - d512 `lr2.83x`: Paloma macro 5.147, train progress ~1.35k / 6.39k
+      steps with loss ~4.75
+- Interpretation: the sweep is now doing real training. Early d512 logs make
+  `lr1x` look better than the sampled lower/higher LR points, but this is still
+  too early to draw conclusions.
+- Next action: continue normal cadence until the d512 slice finishes and the
+  executor advances to the next scale.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -86,3 +86,22 @@
 - Next action: retry submission after authenticating with an account that can
   list controller VMs in `hai-gcp-models`, or provide an explicit
   `--controller-url` for an existing Iris tunnel.
+
+### 2026-04-25 11:47 - Iris submission accepted
+
+- Hypothesis: after switching local GCP/ADC auth to `kaiyuewen3@gmail.com`,
+  the production Marin Iris controller can accept the depth MuP sweep.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job run --no-wait --cpu 1 --memory 2G --extra cpu -e WANDB_API_KEY "$WANDB_API_KEY" -- python -m experiments.grug.moe.depth_mup_lr_sweep`
+- Config:
+  - submission worktree: `/tmp/marin-depth-mup-run-94fb32af1`
+  - code commit: `94fb32af1`
+  - coordinator resources: CPU-only (`cpu=1`, `memory=2G`, `extra=cpu`)
+  - child step resources: `ResourceConfig.with_tpu("v5p-8")`
+  - sweep grid: 36 steps (4 scales x 9 LR multipliers)
+- Result: Iris accepted coordinator job
+  `/kaiyue/iris-run-job-20260425-184727`.
+- Interpretation: the prior GCP permission/controller discovery blocker is
+  cleared. The experiment is now in the Iris startup window.
+- Next action: perform the 120-second startup check, then monitor on the normal
+  babysit cadence.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -861,3 +861,55 @@
   the d1024 high-LR tail and the full d1280 sweep.
 - Next action: continue monitoring d1024 high-LR tail and the full d1280 sweep
   through completion before fitting the variant scaling law.
+
+### 2026-04-26 07:24 - d1024 high-LR tail and first d1280 evals
+
+- Hypothesis: d1024's high-LR tail should not overturn the central `1x`
+  optimum, and the first d1280 evals should show whether the central-basin
+  optimum remains near `1x` at the next model scale.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260426-020352`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris shows 18 jobs under the resubmitted parent: 9 running and 9
+    succeeded, with no active failures or pending reasons.
+  - All sampled started W&B configs still report
+    `model.depth_mup_residual_scaling=True`. This now includes the newly
+    visible d1280 `2x` run.
+  - d1024 latest W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Notes |
+    | --- | --- | ---: | ---: | ---: | --- |
+    | 0.25x | finished | 12648 | 3.3098 | 2.9255 | final |
+    | 0.354x | finished | 12648 | 3.2494 | 2.8670 | final |
+    | 0.5x | finished | 12648 | 3.2040 | 2.8200 | final |
+    | 0.707x | finished | 12648 | 3.1743 | 2.7920 | final |
+    | 1x | finished | 12648 | 3.1564 | 2.7747 | final, current best |
+    | 1.41x | finished | 12648 | 3.1582 | 2.7814 | final |
+    | 2x | finished | 12648 | 3.1881 | 2.8087 | final |
+    | 2.83x | finished | 12648 | 3.2337 | 2.8533 | final |
+    | 4x | running | 3668 | 4.3954 | 4.0098 | latest eval around 3.6k |
+
+  - d1280 latest W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Notes |
+    | --- | --- | ---: | ---: | ---: | --- |
+    | 0.25x | running | 1290 | 4.5794 | 3.7965 | first useful eval |
+    | 0.354x | running | 1280 | 4.2801 | 3.5666 | first useful eval |
+    | 0.5x | running | 1256 | 4.0786 | 3.5370 | first useful eval |
+    | 0.707x | running | 1262 | 3.9623 | 3.4835 | first useful eval |
+    | 1x | running | 1205 | 3.8947 | 3.5163 | first useful eval, current best |
+    | 1.41x | running | 990 | 11.8015 | 3.5376 | pre-first useful eval |
+    | 2x | running | n/a | n/a | n/a | launched |
+    | 2.83x | missing | n/a | n/a | n/a | queued |
+    | 4x | missing | n/a | n/a | n/a | queued |
+
+- Interpretation: d1024's high-LR side is now almost fully characterized. The
+  `2x` and `2.83x` finals are worse than the central basin, so d1024 remains
+  best at `1x`, with `1.41x` essentially tied and `0.707x` still close. The
+  first d1280 useful evals are early but point in the same direction: among the
+  runs that have reached a useful eval, `1x` is currently best and the loss
+  improves monotonically from `0.25x` through `1x`. Need the `1.41x+` d1280
+  runs to reach useful evals before interpreting the d1280 optimum.
+- Next action: continue monitoring d1024 `4x` and all d1280 runs through
+  completion.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -753,3 +753,39 @@
   is currently best one step lower.
 - Next action: continue d1024 to completion so `4x` can launch, then continue
   through d1280 for the full gate-2 procedure.
+
+### 2026-04-26 02:42 - d1024 ~11k checkpoint
+
+- Hypothesis: if the d1024 LR optimum is moving toward the completed d512/d768
+  optimum as training progresses, the 11k checkpoint should put `1x` at or
+  near the top of the central basin.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260426-020352`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris still shows 9 running jobs and 1 succeeded child; there are no active
+    failures or pending reasons.
+  - All sampled started W&B configs still report
+    `model.depth_mup_residual_scaling=True`.
+  - d1024 latest W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Notes |
+    | --- | --- | ---: | ---: | ---: | --- |
+    | 0.25x | running | 11250 | 3.3310 | 2.9703 | ~11k eval |
+    | 0.354x | running | 11393 | 3.2769 | 3.0313 | ~11k eval |
+    | 0.5x | running | 11025 | 3.2383 | 2.9207 | ~11k eval |
+    | 0.707x | running | 11207 | 3.2212 | 2.9555 | ~11k eval |
+    | 1x | running | 11180 | 3.2178 | 2.9406 | ~11k eval, current best |
+    | 1.41x | running | 11172 | 3.2408 | 2.8913 | ~11k eval |
+    | 2x | running | 10398 | 3.3750 | 3.1257 | latest eval around 10k |
+    | 2.83x | running | 7579 | 3.7899 | 3.3614 | latest eval around 7k |
+    | 4x | missing | n/a | n/a | n/a | queued |
+
+- Interpretation: d1024 now prefers `1x`, matching the completed d512/d768
+  optima for the first time in this sweep. The margin is narrow: `0.707x` is
+  only about 0.003 Paloma macro behind, and `0.5x`/`1.41x` remain within about
+  0.023. This is the best LR-sensitivity result so far, but it is still partial
+  because the d1024 sweep has not finished, `4x` has not launched, and d1280 is
+  still pending.
+- Next action: continue d1024 to completion so `4x` can launch, then continue
+  through d1280 for the full gate-2 procedure.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -248,3 +248,38 @@
   to slightly worse but does not require a shifted LR at this scale.
 - Next action: continue monitoring d768 through final summaries and the launch
   of `d768-lr4x`.
+
+### 2026-04-25 16:09 - d768 partial completion and d1024 startup
+
+- Hypothesis: the first finished d768 points should show whether the LR optimum
+  shifts materially from the d512 optimum before the delayed high-LR points
+  finish.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260425-184727`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris shows 16 succeeded jobs and 9 running jobs; no terminal failures.
+  - Seven d768 low-to-2x jobs are finished.
+  - d768 `2.83x` is still running at W&B step 8160 with Paloma macro 3.8212.
+  - d768 `4x` has launched and is running at W&B step 47.
+  - The first six d1024 jobs have launched (`0.25x` through `1.41x`), with no
+    W&B training summaries yet.
+  - Finished d768 W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Tok/s |
+    | --- | --- | ---: | ---: | ---: | ---: |
+    | 0.25x | finished | 10342 | 3.5921 | 3.3211 | 273,923 |
+    | 0.354x | finished | 10342 | 3.5244 | 3.2554 | 275,041 |
+    | 0.5x | finished | 10342 | 3.4701 | 3.2025 | 275,812 |
+    | 0.707x | finished | 10342 | 3.4387 | 3.1675 | 274,990 |
+    | 1x | finished | 10342 | 3.4279 | 3.1535 | 274,617 |
+    | 1.41x | finished | 10342 | 3.4295 | 3.1581 | 273,881 |
+    | 2x | finished | 10342 | 3.4724 | 3.1922 | 274,267 |
+    | 2.83x | running | 8160 | 3.8212 | 3.4842 | 272,446 |
+    | 4x | running | 47 | 11.7911 | 10.9101 | 277,573 |
+
+- Interpretation: among finished d768 points, the optimum remains at `1x`, with
+  `1.41x` effectively tied and `0.707x` close. This matches the d512 optimum
+  more than it suggests a scale-dependent LR shift, but the high-LR tail is not
+  finished yet.
+- Next action: continue monitoring d768 `2.83x`/`4x` and d1024 startup.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -607,3 +607,40 @@
   around 5k, and `2.83x` remains poor by around 2k.
 - Next action: continue d1024 until `4x` launches and the d1024 sweep
   finishes, then continue through d1280 for the full gate-2 procedure.
+
+### 2026-04-25 23:04 - d1024 ~7k checkpoint
+
+- Hypothesis: if the d1024 optimum is settling, the next comparable central
+  checkpoint should identify whether the best point remains at `0.5x` or
+  moves toward the completed d512/d768 `1x` optimum.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260426-020352`
+  - `uv run iris --config lib/iris/examples/marin.yaml job logs --since-seconds 600 --max-lines 1600 --tail /kaiyue/iris-run-job-20260426-020352`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris shows 9 running jobs and 1 succeeded child; there are no active
+    failures or pending reasons.
+  - All sampled started W&B configs still report
+    `model.depth_mup_residual_scaling=True`.
+  - d1024 latest W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Notes |
+    | --- | --- | ---: | ---: | ---: | --- |
+    | 0.25x | running | 7213 | 3.4436 | 3.0721 | ~7k eval |
+    | 0.354x | running | 7372 | 3.3989 | 3.1928 | ~7k eval |
+    | 0.5x | running | 7010 | 3.3799 | 3.0645 | ~7k eval, current best |
+    | 0.707x | running | 7164 | 3.3868 | 3.1016 | ~7k eval |
+    | 1x | running | 7156 | 3.4217 | 3.1752 | ~7k eval |
+    | 1.41x | running | 7155 | 3.5006 | 3.1962 | ~7k eval |
+    | 2x | running | 6378 | 3.6968 | 3.3081 | latest eval around 6k |
+    | 2.83x | running | 3564 | 4.1101 | 3.7340 | latest eval around 3k |
+    | 4x | missing | n/a | n/a | n/a | queued |
+
+- Interpretation: the d1024 best point remains `0.5x`, but the `0.707x`
+  point is very close. The central basin is strengthening as training
+  progresses, while `1x` remains behind and the high-LR side remains clearly
+  worse. This still does not match strong depth-wise LR invariance, because
+  the completed d512/d768 sweeps prefer `1x` while d1024 continues to prefer
+  a lower multiplier.
+- Next action: continue d1024 until the current 8 active children complete and
+  the executor launches d1024 `4x`, then continue into d1280.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -913,3 +913,40 @@
   runs to reach useful evals before interpreting the d1280 optimum.
 - Next action: continue monitoring d1024 `4x` and all d1280 runs through
   completion.
+
+### 2026-04-26 13:00 - d1280 ~3.4k checkpoint
+
+- Hypothesis: if the d1280 first-eval `1x` lead was only startup noise, the
+  central basin should separate after a few thousand steps.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260426-020352`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris shows 18 jobs under the resubmitted parent: 9 running and 9
+    succeeded, with no active failures or pending reasons.
+  - All sampled started W&B configs still report
+    `model.depth_mup_residual_scaling=True`.
+  - d1024 `4x` remains running at step 9386 with Paloma macro 3.7908, still far
+    worse than the completed d1024 central basin.
+  - d1280 latest W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Notes |
+    | --- | --- | ---: | ---: | ---: | --- |
+    | 0.25x | running | 3418 | 3.5127 | 3.1934 | latest eval around 3.4k |
+    | 0.354x | running | 3352 | 3.4541 | 3.1222 | latest eval around 3.3k |
+    | 0.5x | running | 3417 | 3.4267 | 3.0511 | latest eval, current best |
+    | 0.707x | running | 3312 | 3.4378 | 3.0896 | latest eval, close second |
+    | 1x | running | 3306 | 3.4820 | 3.1645 | latest eval |
+    | 1.41x | running | 3127 | 3.5648 | 3.2401 | latest eval |
+    | 2x | running | 2027 | 3.8160 | 3.4494 | latest eval |
+    | 2.83x | missing | n/a | n/a | n/a | queued |
+    | 4x | missing | n/a | n/a | n/a | queued |
+
+- Interpretation: d1280 no longer mirrors the d512/d768/d1024 `1x` optimum
+  at this checkpoint. The best visible point has moved to `0.5x`, with
+  `0.707x` close behind and `1x` about 0.055 Paloma macro worse. This may still
+  move as training progresses, but the d1280 trend is now closer to the early
+  d1024 behavior than to the completed d1024 central final. The high-LR side is
+  not competitive so far: `1.41x` and `2x` are clearly behind.
+- Next action: continue monitoring d1024 `4x`, finish the visible d1280 runs,
+  and let d1280 `2.83x`/`4x` launch when slots free.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -283,3 +283,37 @@
   more than it suggests a scale-dependent LR shift, but the high-LR tail is not
   finished yet.
 - Next action: continue monitoring d768 `2.83x`/`4x` and d1024 startup.
+
+### 2026-04-25 17:12 - d1024 first meaningful eval
+
+- Hypothesis: early d1024 evals should show whether the LR basin remains near
+  the d512/d768 optimum as model scale increases.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260425-184727`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris shows 17 succeeded jobs and 9 running jobs; no terminal failures.
+  - d768 `2.83x` finished with Paloma macro 3.5249; d768 `4x` remains running
+    at W&B step 3545 with Paloma macro 4.7201.
+  - d1024 `0.25x` through `2x` are running. The first six d1024 runs have
+    moved beyond placeholder evals; `2x` has just launched and still has only
+    the initial placeholder eval.
+  - d1024 W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Tok/s |
+    | --- | --- | ---: | ---: | ---: | ---: |
+    | 0.25x | running | 1111 | 5.2304 | 4.4190 | 177,844 |
+    | 0.354x | running | 1127 | 4.7424 | 4.0443 | 178,745 |
+    | 0.5x | running | 1121 | 4.4787 | 4.0458 | 177,431 |
+    | 0.707x | running | 1114 | 4.2972 | 3.8251 | 177,874 |
+    | 1x | running | 1084 | 4.1957 | 3.7822 | 177,617 |
+    | 1.41x | running | 1091 | 4.1650 | 3.7849 | 177,541 |
+    | 2x | running | 134 | 11.7908 | 8.6933 | 179,158 |
+    | 2.83x | missing | n/a | n/a | n/a | n/a |
+    | 4x | missing | n/a | n/a | n/a | n/a |
+
+- Interpretation: early d1024 is best at `1.41x`, with `1x` close behind and
+  the lower LR points clearly worse. This is still early, but the best point is
+  within one sweep step of the d512/d768 optimum rather than moving far away.
+- Next action: continue monitoring d1024 through later evals and wait for
+  d768 `4x` to finish.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -317,3 +317,38 @@
   within one sweep step of the d512/d768 optimum rather than moving far away.
 - Next action: continue monitoring d1024 through later evals and wait for
   d768 `4x` to finish.
+
+### 2026-04-25 18:05 - d1024 second eval snapshot
+
+- Hypothesis: the next d1024 eval should clarify whether the early best point
+  remains at the high side of the basin or moves back toward the d512/d768
+  optimum.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job logs --since-seconds 900 --max-lines 1500 --tail /kaiyue/iris-run-job-20260425-184727`
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260425-184727`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris shows 17 succeeded jobs and 9 running jobs; no terminal failures.
+  - d768 `4x` is still running at W&B step 6453 with Paloma macro 4.3554.
+  - d1024 `0.25x` through `2x` are running. `2.83x`, `4x`, and all d1280
+    runs have not launched yet.
+  - d1024 W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Tok/s |
+    | --- | --- | ---: | ---: | ---: | ---: |
+    | 0.25x | running | 2086 | 4.0084 | 3.6512 | 177,663 |
+    | 0.354x | running | 2103 | 3.8979 | 3.4492 | 178,420 |
+    | 0.5x | running | 2093 | 3.8318 | 3.5104 | 176,989 |
+    | 0.707x | running | 2088 | 3.8059 | 3.4784 | 177,492 |
+    | 1x | running | 2060 | 3.8305 | 3.4729 | 177,034 |
+    | 1.41x | running | 2066 | 3.9059 | 3.5336 | 177,487 |
+    | 2x | running | 1122 | 4.1707 | 3.7606 | 177,537 |
+    | 2.83x | missing | n/a | n/a | n/a | n/a |
+    | 4x | missing | n/a | n/a | n/a | n/a |
+
+- Interpretation: by the second d1024 eval, the best observed point has moved
+  to `0.707x`, with `0.5x` and `1x` essentially close behind. The basin still
+  overlaps the d512/d768 optimum, but the early `1.41x` advantage did not hold
+  at this checkpoint.
+- Next action: continue the normal babysit cadence until d768 `4x` finishes or
+  the next d1024 launches/evals create a clearer scale trend.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -152,3 +152,34 @@
   too early to draw conclusions.
 - Next action: continue normal cadence until the d512 slice finishes and the
   executor advances to the next scale.
+
+### 2026-04-25 12:42 - d512 partial completion
+
+- Hypothesis: final d512 W&B summaries should identify whether depth MuP shifts
+  the LR optimum away from the baseline formula before larger scales finish.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260425-184727`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - 8 d512 runs finished; delayed `d512-lr4x` is still running.
+  - 7 d768 runs are running.
+  - Completed d512 W&B summaries:
+
+    | LR multiplier | State | Paloma macro | Tok/s | Tokens |
+    | --- | --- | ---: | ---: | ---: |
+    | 0.25x | finished | 4.0652 | 406,349 | 837,156,864 |
+    | 0.354x | finished | 3.9475 | 406,406 | 837,156,864 |
+    | 0.5x | finished | 3.8671 | 407,291 | 837,156,864 |
+    | 0.707x | finished | 3.8302 | 405,839 | 837,156,864 |
+    | 1x | finished | 3.8188 | 406,669 | 837,156,864 |
+    | 1.41x | finished | 3.8284 | 406,452 | 837,156,864 |
+    | 2x | finished | 3.8695 | 405,423 | 837,156,864 |
+    | 2.83x | finished | 3.9301 | 406,235 | 837,156,864 |
+    | 4x | running | n/a | n/a | n/a |
+
+- Interpretation: among completed points, d512 is best at `1x` LR with Paloma
+  macro 3.8188. The compute-optimal baseline d512 macro is 3.8104, so depth MuP
+  is roughly neutral/slightly worse at this first scale before the delayed 4x
+  point finishes.
+- Next action: continue monitoring `d512-lr4x` and d768 startup; wait for d768
+  first eval before making scale-sensitivity claims.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -453,3 +453,48 @@
   steps; they should enqueue after current active children finish or skip.
 - Next action: return to the normal babysit cadence and wait for d768 `4x` to
   finish or for the next executor wave to launch.
+
+### 2026-04-25 19:41 - d768 sweep complete
+
+- Hypothesis: if depth MuP reduces LR sensitivity across small MoE scales, the
+  d512 and d768 LR optima should stay near the same multiplier, even if the
+  quality delta versus baseline is small.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260426-020352`
+  - `uv run iris --config lib/iris/examples/marin.yaml job logs --since-seconds 420 --max-lines 1200 --tail /kaiyue/iris-run-job-20260426-020352`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+  - `uv run python - <<'PY' ... effective_speedup(...) ... PY`
+- Result:
+  - d768 `4x` finished successfully with Paloma macro 3.6372 and 274,573 tok/s.
+  - The executor immediately launched d1024 `2.83x`.
+  - The completed d768 LR curve is:
+
+    | LR multiplier | Paloma macro | Tok/s |
+    | --- | ---: | ---: |
+    | 0.25x | 3.5921 | 273,923 |
+    | 0.354x | 3.5244 | 275,041 |
+    | 0.5x | 3.4701 | 275,812 |
+    | 0.707x | 3.4387 | 274,990 |
+    | 1x | 3.4279 | 274,617 |
+    | 1.41x | 3.4295 | 273,881 |
+    | 2x | 3.4724 | 274,267 |
+    | 2.83x | 3.5249 | 273,856 |
+    | 4x | 3.6372 | 274,573 |
+
+  - Effective-speedup comparison against README baselines:
+
+    | Scale | Best depth-MuP LR | Baseline macro | Depth-MuP macro | Baseline tok/s | Depth-MuP tok/s | Speedup |
+    | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+    | d512 | 1x | 3.8104 | 3.8188 | 405,630 | 406,669 | 0.963 |
+    | d768 | 1x | 3.4339 | 3.4279 | 273,532 | 274,617 | 1.040 |
+
+  - d1024 `0.5x` caught up and posted Paloma macro 3.6554 at the ~3k-step
+    eval, which is slightly better than the previous best observed `0.707x`
+    checkpoint at 3.6647.
+- Interpretation: depth MuP does not pass gate 1 as a promotable change at the
+  current small-scale optima because d512 is slower than baseline on effective
+  speedup. The LR-optimum stability signal is still useful: both completed
+  small scales prefer `1x`, and the d1024 partial curve is currently centered
+  in the `0.5x`-`0.707x`-`1x` basin rather than moving to an extreme LR.
+- Next action: continue d1024 through `2.83x`/`4x`, then continue to d1280 for
+  the full MoE procedure before making a final recommendation.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -680,3 +680,40 @@
   prefers one LR step lower.
 - Next action: continue d1024 until `4x` launches and the d1024 sweep finishes,
   then continue through the d1280 sweep before fitting the gate-2 scaling law.
+
+### 2026-04-26 00:54 - d1024 ~9k checkpoint
+
+- Hypothesis: if the d1024 optimum is drifting within the central basin, the
+  next comparable checkpoint should show whether `0.5x` remains best or whether
+  `0.707x`/`1x` catch up as training progresses.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260426-020352`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris still shows 9 running jobs and 1 succeeded child; there are no active
+    failures or pending reasons.
+  - All sampled started W&B configs still report
+    `model.depth_mup_residual_scaling=True`.
+  - d1024 latest W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Notes |
+    | --- | --- | ---: | ---: | ---: | --- |
+    | 0.25x | running | 9246 | 3.3779 | 3.0685 | ~9k eval |
+    | 0.354x | running | 9392 | 3.3301 | 3.0579 | ~9k eval |
+    | 0.5x | running | 9028 | 3.3026 | 3.0315 | ~9k eval |
+    | 0.707x | running | 9201 | 3.2986 | 2.9236 | ~9k eval, current best |
+    | 1x | running | 9184 | 3.3198 | 3.0911 | ~9k eval |
+    | 1.41x | running | 9173 | 3.3655 | 3.0964 | ~9k eval |
+    | 2x | running | 8396 | 3.5443 | 3.2410 | latest eval around 8k |
+    | 2.83x | running | 5586 | 3.9453 | 3.5868 | latest eval around 5k |
+    | 4x | missing | n/a | n/a | n/a | queued |
+
+- Interpretation: the d1024 best point moved from `0.5x` at ~8k to `0.707x`
+  at ~9k, with `0.5x` only about 0.004 Paloma macro behind. This is a stronger
+  central-basin result than the earlier checkpoints, but it is still not strong
+  LR scale-invariance: completed d512/d768 prefer `1x`, while d1024 is best
+  one LR step lower at the current checkpoint. The high-LR side remains much
+  worse.
+- Next action: continue d1024 until the current children finish and the
+  executor launches d1024 `4x`, then continue through d1280 for the full gate-2
+  procedure.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -717,3 +717,39 @@
 - Next action: continue d1024 until the current children finish and the
   executor launches d1024 `4x`, then continue through d1280 for the full gate-2
   procedure.
+
+### 2026-04-26 01:48 - d1024 ~10k checkpoint
+
+- Hypothesis: if depth MuP is reducing LR sensitivity at d1024, the later
+  checkpoints should keep the useful region broad and central rather than
+  collapsing to a single low-LR point.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260426-020352`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris still shows 9 running jobs and 1 succeeded child; there are no active
+    failures or pending reasons.
+  - All sampled started W&B configs still report
+    `model.depth_mup_residual_scaling=True`.
+  - d1024 latest W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Notes |
+    | --- | --- | ---: | ---: | ---: | --- |
+    | 0.25x | running | 10239 | 3.3537 | 2.9764 | ~10k eval |
+    | 0.354x | running | 10384 | 3.3016 | 3.0810 | ~10k eval |
+    | 0.5x | running | 10016 | 3.2694 | 2.9634 | ~10k eval |
+    | 0.707x | running | 10191 | 3.2568 | 2.9816 | ~10k eval, current best |
+    | 1x | running | 10171 | 3.2648 | 2.9873 | ~10k eval |
+    | 1.41x | running | 10163 | 3.2983 | 2.9167 | ~10k eval |
+    | 2x | running | 9387 | 3.4593 | 3.1498 | latest eval around 9k |
+    | 2.83x | running | 6570 | 3.8586 | 3.4723 | latest eval around 6k |
+    | 4x | missing | n/a | n/a | n/a | queued |
+
+- Interpretation: d1024 remains best at `0.707x`, but `1x` is only about
+  0.008 Paloma macro behind and `0.5x` is about 0.013 behind. This is the
+  strongest central-basin result so far: the useful region now spans `0.5x`
+  through `1.41x`, with `0.707x`/`1x` clearly ahead. It still does not prove
+  strong LR scale-invariance because d512/d768 completed at `1x`, while d1024
+  is currently best one step lower.
+- Next action: continue d1024 to completion so `4x` can launch, then continue
+  through d1280 for the full gate-2 procedure.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -644,3 +644,39 @@
   a lower multiplier.
 - Next action: continue d1024 until the current 8 active children complete and
   the executor launches d1024 `4x`, then continue into d1280.
+
+### 2026-04-26 00:01 - d1024 ~8k checkpoint
+
+- Hypothesis: after the partial ~8k evals, `0.5x` needed one more checkpoint
+  to determine whether d1024's best point had moved to `0.707x` or remained at
+  the lower central multiplier.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260426-020352`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris still shows 9 running jobs and 1 succeeded child; there are no active
+    failures or pending reasons.
+  - All sampled started W&B configs still report
+    `model.depth_mup_residual_scaling=True`.
+  - d1024 latest W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Notes |
+    | --- | --- | ---: | ---: | ---: | --- |
+    | 0.25x | running | 8282 | 3.4091 | 3.1121 | ~8k eval |
+    | 0.354x | running | 8431 | 3.3613 | 3.1196 | ~8k eval |
+    | 0.5x | running | 8068 | 3.3354 | 3.0344 | ~8k eval, current best |
+    | 0.707x | running | 8236 | 3.3393 | 3.0529 | ~8k eval |
+    | 1x | running | 8216 | 3.3648 | 3.0430 | ~8k eval |
+    | 1.41x | running | 8212 | 3.4289 | 3.2039 | ~8k eval |
+    | 2x | running | 7439 | 3.6178 | 3.2974 | latest eval around 7k |
+    | 2.83x | running | 4627 | 4.0216 | 3.6519 | latest eval around 4k |
+    | 4x | missing | n/a | n/a | n/a | queued |
+
+- Interpretation: the d1024 best point remains `0.5x`, but `0.707x` is only
+  about 0.004 Paloma macro behind at comparable progress. The useful LR basin
+  is now clearly central (`0.354x` through `1x`), while `2x` and `2.83x` are
+  still much worse at their latest evals. This does not show strong LR
+  scale-invariance, because completed d512/d768 prefer `1x` and d1024 still
+  prefers one LR step lower.
+- Next action: continue d1024 until `4x` launches and the d1024 sweep finishes,
+  then continue through the d1280 sweep before fitting the gate-2 scaling law.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -1002,3 +1002,39 @@
   finals and the four-point scaling-law projection.
 - Next action: continue monitoring d1280 through completion, including the
   newly launched `2.83x` run and queued `4x`.
+
+### 2026-04-26 17:13 - d1280 central 5k checkpoint
+
+- Hypothesis: the d1280 lower-LR shift seen around 3.4k steps should either
+  persist after the central runs reach a comparable 5k eval boundary, or move
+  back toward the d512/d768/d1024 `1x` optimum if it was transient.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260426-020352`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris shows 19 jobs under the resubmitted parent: 9 running and 10
+    succeeded, with no active failures or pending reasons.
+  - All sampled started d1280 runs report
+    `model.depth_mup_residual_scaling=True`.
+  - d1280 latest W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Notes |
+    | --- | --- | ---: | ---: | ---: | --- |
+    | 0.25x | running | 5125 | 3.3413 | 3.0819 | latest eval around 5k |
+    | 0.354x | running | 5061 | 3.2959 | 2.9775 | latest eval around 5k |
+    | 0.5x | running | 5000 | 3.2837 | 2.9756 | latest eval, current best |
+    | 0.707x | running | 5012 | 3.2984 | 3.0002 | latest eval, close |
+    | 1x | running | 5015 | 3.3493 | 2.9842 | latest eval |
+    | 1.41x | running | 4853 | 3.4855 | 3.1420 | latest eval around 4.8k |
+    | 2x | running | 3745 | 3.6977 | 3.2900 | latest eval around 3.7k |
+    | 2.83x | running | 414 | 11.8015 | 4.0294 | startup placeholder |
+    | 4x | missing | n/a | n/a | n/a | queued |
+
+- Interpretation: the d1280 lower-LR shift has persisted through the comparable
+  central 5k boundary. The best visible run is `0.5x`, with `0.354x` and
+  `0.707x` close; `1x` is about 0.066 Paloma macro behind `0.5x`. This is the
+  first clear sign that the depth-MuP LR optimum may still drift down at the
+  largest scale, despite the completed d512/d768/d1024 optima all landing at
+  `1x`. This is still a checkpoint, not a final d1280 result.
+- Next action: continue monitoring to d1280 finals, let `2.83x` reach useful
+  evals, and wait for queued `4x` to launch.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -389,3 +389,41 @@
   moving far with scale.
 - Next action: continue monitoring until d1024 `0.5x` catches up, d768 `4x`
   finishes, or the next d1024 jobs launch.
+
+### 2026-04-25 19:10 - interruption recovery
+
+- Context: while responding to a corrected instruction, the original Iris
+  parent job `/kaiyue/iris-run-job-20260425-184727` was stopped after it had
+  completed 17 children and still had 8 active children.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job stop /kaiyue/iris-run-job-20260425-184727`
+  - `uv run iris --config lib/iris/examples/marin.yaml job run --no-wait --cpu 1 --memory 2G --extra cpu -e WANDB_API_KEY "$WANDB_API_KEY" -- python -m experiments.grug.moe.depth_mup_lr_sweep`
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260426-020352`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Replacement parent job: `/kaiyue/iris-run-job-20260426-020352`.
+  - The executor relaunched only the 8 unfinished children plus the parent, so
+    the completed d512 and d768 low-to-2.83x runs were not rerun.
+  - Several early replacement attempts hit TPU device-busy startup errors
+    (`No accelerator found` / `Device or resource busy`), but Iris retried.
+  - At the 19:10 check all 8 unfinished children were running in Iris, and W&B
+    had recovered the checked run IDs to `running` with
+    `model.depth_mup_residual_scaling=True`.
+  - Recovery checkpoint W&B summaries:
+
+    | Run | State | Step | Paloma macro | Train loss |
+    | --- | --- | ---: | ---: | ---: |
+    | d768 4x | running | 8999 | 4.0186 | 3.4979 |
+    | d1024 0.25x | running | 3155 | 3.7652 | 3.4442 |
+    | d1024 0.354x | running | 3179 | 3.6933 | 3.4104 |
+    | d1024 0.5x | running | 2900 | 3.8318 | 3.3211 |
+    | d1024 0.707x | running | 3155 | 3.6647 | 3.3581 |
+    | d1024 1x | running | 3132 | 3.7080 | 3.3675 |
+    | d1024 1.41x | running | 3136 | 3.8062 | 3.4573 |
+    | d1024 2x | running | 2190 | 4.0351 | 3.6537 |
+
+- Interpretation: the depth MuP sweep remains valid and continuing after
+  recovery. The replacement job is a continuation of unfinished work, not a
+  full restart of completed points.
+- Next action: continue short-cadence monitoring until the restarted tasks show
+  sustained post-retry training progress, then return to the normal cadence.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -183,3 +183,36 @@
   point finishes.
 - Next action: continue monitoring `d512-lr4x` and d768 startup; wait for d768
   first eval before making scale-sensitivity claims.
+
+### 2026-04-25 13:14 - d768 first meaningful eval
+
+- Hypothesis: d768 should reveal whether depth MuP keeps the LR optimum near
+  the same multiplier as d512 after the initial placeholder evals disappear.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260425-184727`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris still shows 8 succeeded jobs and 9 running jobs; no terminal failures.
+  - `d512-lr4x` remains running at W&B step 4042 with Paloma macro 4.7823.
+  - Seven d768 runs are running around W&B steps 1366-1391. The two highest LR
+    points, `2.83x` and `4x`, have not launched yet.
+  - Current d768 W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Tok/s |
+    | --- | --- | ---: | ---: | ---: | ---: |
+    | 0.25x | running | 1374 | 5.6296 | 4.4109 | 275,963 |
+    | 0.354x | running | 1382 | 5.2119 | 4.0573 | 275,795 |
+    | 0.5x | running | 1391 | 4.8381 | 4.0311 | 276,564 |
+    | 0.707x | running | 1371 | 4.6411 | 3.9799 | 274,922 |
+    | 1x | running | 1374 | 4.5468 | 3.9933 | 275,879 |
+    | 1.41x | running | 1367 | 4.5297 | 3.9370 | 274,950 |
+    | 2x | running | 1366 | 4.5989 | 4.0871 | 275,213 |
+    | 2.83x | missing | n/a | n/a | n/a | n/a |
+    | 4x | missing | n/a | n/a | n/a | n/a |
+
+- Interpretation: at this early d768 point, the best observed LR multiplier is
+  `1.41x`, with `1x` close behind and `2x` already slightly worse. This is not
+  final, but the usable LR band is centered near the d512 optimum rather than
+  moving dramatically.
+- Next action: continue normal cadence until `d512-lr4x` finishes and the
+  remaining d768 LR points launch.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -950,3 +950,55 @@
   not competitive so far: `1.41x` and `2x` are clearly behind.
 - Next action: continue monitoring d1024 `4x`, finish the visible d1280 runs,
   and let d1280 `2.83x`/`4x` launch when slots free.
+
+### 2026-04-26 16:03 - d1024 complete and d1280 2.83x launched
+
+- Hypothesis: the d1024 high-LR tail should not overturn the central `1x`
+  optimum, and freeing that slot should let the queued d1280 tail begin.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260426-020352`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris shows 19 jobs under the resubmitted parent: 9 running and 10
+    succeeded, with no active failures or pending reasons.
+  - d1024 is now fully complete. All d1024 W&B configs report
+    `model.depth_mup_residual_scaling=True`.
+  - d1280 `2.83x` has launched and its W&B config reports
+    `model.depth_mup_residual_scaling=True`; d1280 `4x` is still queued.
+  - d1024 final W&B summaries and speedups against the README baseline
+    (`loss=3.1605`, `tokens_per_second=175165`, `budget=9.00e18`):
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Tok/s | Effective speedup | Notes |
+    | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
+    | 0.25x | finished | 12648 | 3.3098 | 2.9255 | 178025 | 0.385 | final |
+    | 0.354x | finished | 12648 | 3.2494 | 2.8670 | 177079 | 0.561 | final |
+    | 0.5x | finished | 12648 | 3.2040 | 2.8200 | 177231 | 0.755 | final |
+    | 0.707x | finished | 12648 | 3.1743 | 2.7920 | 177528 | 0.923 | final |
+    | 1x | finished | 12648 | 3.1564 | 2.7747 | 177045 | 1.039 | final, best |
+    | 1.41x | finished | 12648 | 3.1582 | 2.7814 | 176738 | 1.025 | final, near tie |
+    | 2x | finished | 12648 | 3.1881 | 2.8087 | 176511 | 0.837 | final |
+    | 2.83x | finished | 12648 | 3.2337 | 2.8533 | 176451 | 0.619 | final |
+    | 4x | finished | 12648 | 3.3533 | 2.9729 | 177390 | 0.294 | final |
+
+  - d1280 latest W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Notes |
+    | --- | --- | ---: | ---: | ---: | --- |
+    | 0.25x | running | 4664 | 3.4018 | 3.0257 | latest eval around 4.6k |
+    | 0.354x | running | 4598 | 3.3561 | 2.9663 | latest eval around 4.6k |
+    | 0.5x | running | 4539 | 3.3485 | 2.9807 | latest eval, current best |
+    | 0.707x | running | 4550 | 3.3581 | 2.9503 | latest eval, close |
+    | 1x | running | 4551 | 3.4037 | 3.0608 | latest eval |
+    | 1.41x | running | 4368 | 3.4855 | 3.1594 | latest eval |
+    | 2x | running | 3263 | 3.6977 | 3.3666 | latest eval |
+    | 2.83x | running | n/a | n/a | n/a | launched |
+    | 4x | missing | n/a | n/a | n/a | queued |
+
+- Interpretation: d1024 passes the per-scale effective speedup check, but only
+  narrowly. The useful basin remains centered at `1x` with `1.41x` essentially
+  tied, while the high-LR tail is clearly worse. Across d512, d768, and d1024,
+  the completed optima are all at `1x`; d1280 is the only scale currently
+  trending lower (`0.5x` at this checkpoint). Gate 2 still depends on d1280
+  finals and the four-point scaling-law projection.
+- Next action: continue monitoring d1280 through completion, including the
+  newly launched `2.83x` run and queued `4x`.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -534,3 +534,40 @@
 - Next action: continue d1024 until `2.83x` and `4x` have comparable evals and
   the d1024 runs complete; then proceed through d1280 before final scaling-law
   interpretation.
+
+### 2026-04-25 21:16 - d1024 ~5k checkpoint
+
+- Hypothesis: if the apparent d1024 optimum shift at ~4k was transient, the
+  next central-basin checkpoint should move back toward the completed d512/d768
+  `1x` optimum; if it persists, the best point should remain below `1x`.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260426-020352`
+  - `uv run iris --config lib/iris/examples/marin.yaml job logs --since-seconds 180 --max-lines 500 --tail /kaiyue/iris-run-job-20260426-020352`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris still shows the parent plus 8 running d1024 children and 1 succeeded
+    d768 child; active children have no failure counts or pending reasons.
+  - All sampled started W&B configs still have
+    `model.depth_mup_residual_scaling=True`.
+  - d1024 latest W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Notes |
+    | --- | --- | ---: | ---: | ---: | --- |
+    | 0.25x | running | 5181 | 3.5508 | 3.1868 | ~5k eval |
+    | 0.354x | running | 5380 | 3.5036 | 3.1477 | ~5k eval |
+    | 0.5x | running | 5014 | 3.4841 | 3.1850 | ~5k eval, current best |
+    | 0.707x | running | 5165 | 3.5002 | 3.1170 | ~5k eval |
+    | 1x | running | 5141 | 3.5450 | 3.2167 | ~5k eval |
+    | 1.41x | running | 5135 | 3.6300 | 3.2511 | ~5k eval |
+    | 2x | running | 4358 | 3.8529 | 3.4772 | latest eval around 4k |
+    | 2.83x | running | 1555 | 4.3148 | 3.9647 | latest eval around 1k |
+    | 4x | missing | n/a | n/a | n/a | queued |
+
+- Interpretation: the d1024 best point remains `0.5x`, with `0.707x` and
+  `0.354x` close behind. This is still a central LR basin, but it is not
+  scale-invariant in the strong sense: the completed d512/d768 sweeps prefer
+  `1x`, while d1024 is currently best one LR step lower. The high-LR side is
+  clearly worse at comparable progress (`2x` is much worse by ~4k, and `2.83x`
+  is poor by ~1k).
+- Next action: continue d1024 to completion and let the executor launch d1024
+  `4x` and then d1280 before making the gate-2 scaling-law call.

--- a/.agents/logbooks/moe-depth-mup-lr-sweep.md
+++ b/.agents/logbooks/moe-depth-mup-lr-sweep.md
@@ -498,3 +498,39 @@
   in the `0.5x`-`0.707x`-`1x` basin rather than moving to an extreme LR.
 - Next action: continue d1024 through `2.83x`/`4x`, then continue to d1280 for
   the full MoE procedure before making a final recommendation.
+
+### 2026-04-25 20:22 - d1024 ~4k checkpoint
+
+- Hypothesis: after the d512 and d768 optima landed at `1x`, the next d1024
+  checkpoint tests whether depth MuP keeps the best LR in the same central
+  basin or shifts the optimum with scale.
+- Command:
+  - `uv run iris --config lib/iris/examples/marin.yaml job list --json --prefix /kaiyue/iris-run-job-20260426-020352`
+  - `uv run iris --config lib/iris/examples/marin.yaml job logs --since-seconds 480 --max-lines 1400 --tail /kaiyue/iris-run-job-20260426-020352`
+  - `uv run python - <<'PY' ... wandb.Api().runs('understanding-sam/marin_moe', filters={'display_name': name}) ... PY`
+- Result:
+  - Iris shows the parent plus 8 running d1024 children and 1 succeeded d768
+    child; all active children have `failure_count=0` and no `pending_reason`.
+  - d1024 `0.5x` posted its ~4k eval, completing the central-basin checkpoint.
+  - d1024 latest W&B summaries:
+
+    | LR multiplier | State | Step | Paloma macro | Train loss | Notes |
+    | --- | --- | ---: | ---: | ---: | --- |
+    | 0.25x | running | 4199 | 3.6384 | 3.2433 | ~4k eval |
+    | 0.354x | running | 4373 | 3.5845 | 3.2604 | ~4k eval |
+    | 0.5x | running | 4006 | 3.5592 | 3.2101 | ~4k eval, current best |
+    | 0.707x | running | 4152 | 3.5724 | 3.1670 | ~4k eval |
+    | 1x | running | 4156 | 3.6264 | 3.2520 | ~4k eval |
+    | 1.41x | running | 4155 | 3.7062 | 3.3162 | ~4k eval |
+    | 2x | running | 3379 | 3.9430 | 3.5878 | latest eval around 3k |
+    | 2.83x | running | 572 | 11.7908 | 4.0274 | startup eval only |
+    | 4x | missing | n/a | n/a | n/a | queued |
+
+- Interpretation: d1024 currently prefers `0.5x`, with `0.707x` close behind.
+  This is one LR step lower than the completed d512/d768 `1x` optima, so depth
+  MuP has not made the LR optimum perfectly scale-invariant. It has not moved
+  to an extreme LR either: the useful basin remains central (`0.354x`-`1x`),
+  and high LR points are clearly worse at the available checkpoints.
+- Next action: continue d1024 until `2.83x` and `4x` have comparable evals and
+  the d1024 runs complete; then proceed through d1280 before final scaling-law
+  interpretation.

--- a/.agents/ops/2026-04-25-iris-controller-discovery-permission.md
+++ b/.agents/ops/2026-04-25-iris-controller-discovery-permission.md
@@ -1,0 +1,130 @@
+---
+date: 2026-04-25
+system: iris
+severity: diagnostic-only
+resolution: investigating
+pr: https://github.com/marin-community/marin/pull/5179
+issue: https://github.com/marin-community/marin/issues/5178
+---
+
+## TL;DR
+
+- A MoE depth MuP LR sweep was ready to submit through Iris, but job submission
+  failed before job creation.
+- The active GCP account was `kaiyuew@stanford.edu` on project
+  `hai-gcp-models`.
+- Iris could not discover the Marin controller because GCP returned
+  `GCP API error 403: Required 'compute.instances.list' permission for
+  'projects/hai-gcp-models'`.
+- No Iris job was created. No cluster or controller state was changed.
+- Retrying requires an account with controller VM list permission or an explicit
+  `--controller-url` to an existing controller tunnel.
+
+## Original problem report
+
+The user requested that MoE experiment work always submit the run to Iris and
+continue until the full MoE procedure is finished. The attempted command was:
+
+```bash
+.venv/bin/iris --config lib/iris/examples/marin.yaml job run \
+  --no-wait \
+  --reserve v5p-8 \
+  -e WANDB_API_KEY "$WANDB_API_KEY" \
+  -- python -m experiments.grug.moe.depth_mup_lr_sweep
+```
+
+The command failed with:
+
+```text
+GCP API error 403: Required 'compute.instances.list' permission for 'projects/hai-gcp-models'
+RuntimeError: No controller VM found (label=iris-marin-controller=true, project=hai-gcp-models)
+```
+
+## Investigation path
+
+1. The workflow first verified local GitHub auth as `WhenWen`, created issue
+   #5178, pushed PR #5179, and prepared the depth MuP sweep module.
+
+2. The Iris preflight confirmed `.venv/bin/iris` was executable and
+   `WANDB_API_KEY` was present.
+
+3. `gcloud auth list --filter=status:ACTIVE --format='value(account)'` showed
+   the active account was `kaiyuew@stanford.edu`.
+
+4. `iris --config lib/iris/examples/marin.yaml job list` failed during
+   controller discovery with a GCP 403 on `compute.instances.list`. This meant
+   the CLI could not find the controller VM and could not open its config-based
+   tunnel.
+
+5. `lib/iris/OPS.md` confirmed the two normal connection modes:
+   `--config=PATH` for auto-tunnels, or `--controller-url=URL` for an existing
+   manual tunnel.
+
+6. The required production submission command was attempted anyway. It failed
+   before job creation with the same GCP permission error.
+
+7. The dev config, `lib/iris/examples/marin-dev.yaml`, was tried as a fallback.
+   It also failed before job creation with the same permission error, but with
+   the dev controller label.
+
+8. The environment had no `IRIS_*` or controller URL variables, no listener on
+   localhost ports 10000 or 10001, and `curl -sf http://localhost:10000/health`
+   returned nothing. There was no existing tunnel to reuse.
+
+## User course corrections
+
+- The user instructed that future GitHub issues and PRs must not use the
+  connector and should be submitted as `whenwen`. The MoE guide was updated to
+  require local GitHub auth as `whenwen`.
+- The user then instructed that future MoE work must always submit the run to
+  Iris and continue through the full MoE procedure. The MoE guide was updated
+  to make Iris submission mandatory unless a hard blocker prevents it.
+
+## Root cause
+
+The active local GCP account lacked permission to list Compute Engine instances
+in `hai-gcp-models`. Iris config-based controller discovery depends on listing
+the controller VM by label. Without `compute.instances.list`, the CLI cannot
+discover or tunnel to either the production or dev Marin controller.
+
+This was an authentication and project permission blocker, not a code or
+scheduler failure. The submission failed before any Iris job was created.
+
+## Fix
+
+No infrastructure fix was applied. The code workflow was updated in
+`experiments/grug/moe/agent.md` to require Iris submission and full procedure
+completion for MoE experiments.
+
+Operationally, one of these is needed before retrying:
+
+```bash
+gcloud auth login
+gcloud auth application-default login
+gcloud auth list --filter=status:ACTIVE --format='value(account)'
+```
+
+The active account must have enough access on `hai-gcp-models` to discover the
+Iris controller, or the caller must provide an explicit controller URL:
+
+```bash
+.venv/bin/iris --controller-url=http://localhost:10000 job run ...
+```
+
+## How OPS.md could have shortened this
+
+- In `lib/iris/OPS.md` under "GCP Operations / Connecting", add a preflight
+  command for controller discovery permissions:
+  `gcloud compute instances list --project=hai-gcp-models --filter="labels.iris-marin-controller=true" --format="value(name)"`.
+  This would distinguish missing controller VMs from missing GCP permissions
+  before running `iris job run`.
+- In `lib/iris/OPS.md` under "Troubleshooting", add a row for controller
+  discovery failures that says a `compute.instances.list` 403 is an auth
+  blocker and should be fixed by switching GCP account or using an explicit
+  `--controller-url`.
+
+## Artifacts
+
+- PR: https://github.com/marin-community/marin/pull/5179
+- Experiment issue: https://github.com/marin-community/marin/issues/5178
+- Research logbook: `.agents/logbooks/moe-depth-mup-lr-sweep.md`

--- a/experiments/grug/moe/README.md
+++ b/experiments/grug/moe/README.md
@@ -25,6 +25,11 @@ z-loss only). The architecture choices are hardcoded in
   experts (not softmax).
 - **Shared expert**: one always-on dense MLP per block in parallel with the
   routed experts (contributes to every token).
+- **Depth MuP residual scaling**: optional, controlled by
+  `depth_mup_residual_scaling` in `GrugModelConfig`. When enabled, each
+  attention and MLP residual update is scaled by `1 / sqrt(num_layers)`.
+  The baseline recipe leaves this off; `depth_mup_lr_sweep.py` enables it for
+  the depth MuP ablation.
 - **GatedNorm**: rank-128 low-rank gating on RMS-normalized input pre-attention
   and pre-MLP. Acts as a learned per-token gate over the hidden dimension.
 - **XSA (Exclusive Self-Attention)**: after attention, subtract the component
@@ -60,6 +65,19 @@ R²=0.995) and are all anchored at **seq_len = 4096**.
 entry point — `launch.py` uses it to produce the baseline step. Callers that
 want full manual control pass `GrugModelConfig` and `GrugMoeAdamHConfig`
 directly to `GrugMoeLaunchConfig`.
+
+## Depth MuP LR sweep
+
+`depth_mup_lr_sweep.py` launches the depth MuP ablation. It uses the same
+compute-optimal d512, d768, d1024, and d1280 budgets as the baseline table
+below, enables `depth_mup_residual_scaling=True`, and sweeps a log-spaced set of
+LR multipliers around the v16 Adam/AdamH formula:
+
+`0.25x, 0.354x, 0.5x, 0.707x, 1x, 1.414x, 2x, 2.828x, 4x`
+
+Both the Adam LR and AdamH LR are multiplied by the same factor. The intended
+readout is whether the fitted LR optimum has lower scale sensitivity than the
+v16 fit from #4225.
 
 ## v16 isoflop sweep
 
@@ -164,5 +182,7 @@ Predicted macro uses `loss(C) = 1.6 + 95.18 · C^(-0.0941)`.
   `build_from_heuristic` entry point.
 - [`launch.py`](./launch.py) — `GrugMoeLaunchConfig`, baseline `ExecutorStep`,
   and `executor_main` wiring.
+- [`depth_mup_lr_sweep.py`](./depth_mup_lr_sweep.py) — depth MuP residual
+  scaling LR sweep across the compute-optimal MoE scales.
 - [`adamh.py`](./adamh.py) — shared AdamH utilities.
 - [`agent.md`](./agent.md) — agent guide for running ablation experiments on Iris.

--- a/experiments/grug/moe/agent.md
+++ b/experiments/grug/moe/agent.md
@@ -10,8 +10,10 @@ agent is authorized to:
 - Submit Iris jobs and kill only jobs submitted by self
 - Run experiments through both gates autonomously
 
-Do not stop to ask for confirmation at any step. If something fails, diagnose
-and retry or report the failure — do not block waiting for input.
+Do not stop to ask for confirmation at any step. Do not stop at a code change,
+commit, or PR: submit the run to Iris and continue through the full gate
+procedure below. If something fails, diagnose and retry or report the failure —
+do not block waiting for input.
 
 ## Objective
 
@@ -166,6 +168,10 @@ Assume the user has already completed these before job submission:
 ## Job Submission
 
 Jobs in this directory are submitted to **Iris** on a **v5p-8**.
+Always submit the relevant MoE experiment run to Iris as part of this workflow.
+Do not leave a MoE experiment at "ready to run" unless a hard blocker prevents
+submission, such as missing authentication, unavailable required environment
+variables, or an Iris outage.
 
 ### Submission command
 

--- a/experiments/grug/moe/agent.md
+++ b/experiments/grug/moe/agent.md
@@ -173,12 +173,18 @@ Do not leave a MoE experiment at "ready to run" unless a hard blocker prevents
 submission, such as missing authentication, unavailable required environment
 variables, or an Iris outage.
 
+The Iris entrypoint runs `executor_main`, so keep that parent job CPU-only. The
+`ExecutorStep` configs in the launch modules request `ResourceConfig.with_tpu("v5p-8")`
+for the training children.
+
 ### Submission command
 
 ```bash
 .venv/bin/iris --config lib/iris/examples/marin.yaml job run \
   --no-wait \
-  --reserve v5p-8 \
+  --cpu 1 \
+  --memory 2G \
+  --extra cpu \
   -e WANDB_API_KEY "$WANDB_API_KEY" \
   -- python -m experiments.grug.moe.launch
 ```

--- a/experiments/grug/moe/agent.md
+++ b/experiments/grug/moe/agent.md
@@ -6,7 +6,7 @@ This workflow is designed to run end-to-end without human confirmation. The
 agent is authorized to:
 
 - Create branches, commit, and push without asking
-- Create GitHub experiment issues and post comments
+- Create GitHub experiment issues and post comments as `whenwen`
 - Submit Iris jobs and kill only jobs submitted by self
 - Run experiments through both gates autonomously
 
@@ -117,6 +117,13 @@ Most promotable changes will land in one of three files:
 ## Documentation & GitHub Issues
 
 Create a new branch for each experiment issue. Branch off `main`.
+
+For GitHub write actions in this workflow, **do not use the GitHub connector**.
+Create experiment issues, PRs, labels, issue comments, and review-thread updates
+through local GitHub auth as `whenwen` (for example `gh`, or GitHub
+REST/GraphQL with the local token if `gh` is unavailable). Before the first
+write action, verify the authenticated user is `whenwen`; if it is not, stop and
+report the mismatch.
 
 Follow `.agents/skills/agent-research/SKILL.md` for all documentation, logbooks,
 W&B tracking, and GitHub experiment issue management tied to work in this

--- a/experiments/grug/moe/depth_mup_lr_sweep.py
+++ b/experiments/grug/moe/depth_mup_lr_sweep.py
@@ -1,0 +1,157 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Depth MuP LR sweep for the current Grug MoE recipe."""
+
+import dataclasses
+from dataclasses import dataclass
+
+from fray.cluster import ResourceConfig
+from levanter.tracker.wandb import WandbConfig
+from marin.execution.executor import ExecutorStep, executor_main, this_output_path, versioned
+
+from experiments.grug.moe.heuristic import MoeAdamHHeuristic, build_from_heuristic
+from experiments.grug.moe.launch import (
+    NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
+    GrugMoeLaunchConfig,
+    run_grug_moe_trial,
+)
+from experiments.grug.moe.optimizer import GrugMoeAdamHConfig
+from experiments.grug.moe.train import GrugEvalConfig, GrugTrainerConfig
+
+DEPTH_MUP_TARGET_STEPS: int = 2**14
+DEPTH_MUP_WANDB_GROUP: str = "moe-depth-mup-lr-sweep"
+
+
+@dataclass(frozen=True)
+class DepthMupSweepScale:
+    label: str
+    budget: float
+    hidden_dim: int
+
+
+DEPTH_MUP_SWEEP_SCALES: tuple[DepthMupSweepScale, ...] = (
+    DepthMupSweepScale(label="d512", budget=2.19e17, hidden_dim=512),
+    DepthMupSweepScale(label="d768", budget=1.70e18, hidden_dim=768),
+    DepthMupSweepScale(label="d1024", budget=9.00e18, hidden_dim=1024),
+    DepthMupSweepScale(label="d1280", budget=2.83e19, hidden_dim=1280),
+)
+
+DEPTH_MUP_LR_MULTIPLIERS: tuple[float, ...] = (
+    0.25,
+    0.3535533905932738,
+    0.5,
+    0.7071067811865476,
+    1.0,
+    1.4142135623730951,
+    2.0,
+    2.8284271247461903,
+    4.0,
+)
+
+
+def _format_lr_multiplier(multiplier: float) -> str:
+    if multiplier <= 0:
+        raise ValueError(f"lr_multiplier must be positive, got {multiplier}")
+    if multiplier.is_integer():
+        return f"{int(multiplier)}x"
+    return f"{multiplier:.3g}".replace(".", "p") + "x"
+
+
+def _scale_optimizer_lrs(optimizer: GrugMoeAdamHConfig, lr_multiplier: float) -> GrugMoeAdamHConfig:
+    if lr_multiplier <= 0:
+        raise ValueError(f"lr_multiplier must be positive, got {lr_multiplier}")
+    expert_lr = optimizer.expert_lr * lr_multiplier if optimizer.expert_lr is not None else None
+    return dataclasses.replace(
+        optimizer,
+        learning_rate=optimizer.learning_rate * lr_multiplier,
+        adam_lr=optimizer.adam_lr * lr_multiplier,
+        expert_lr=expert_lr,
+    )
+
+
+def build_depth_mup_lr_sweep_config(
+    scale: DepthMupSweepScale,
+    lr_multiplier: float,
+    *,
+    output_path: str,
+    seed: int = 0,
+) -> GrugMoeLaunchConfig:
+    heuristic = MoeAdamHHeuristic(depth_mup_residual_scaling=True)
+    model, optimizer, batch_size, steps = build_from_heuristic(
+        budget=scale.budget,
+        hidden_dim=scale.hidden_dim,
+        heuristic=heuristic,
+        target_steps=DEPTH_MUP_TARGET_STEPS,
+    )
+    optimizer = _scale_optimizer_lrs(optimizer, lr_multiplier)
+    run_id = f"moe-depth-mup-lr-{scale.label}-lr{_format_lr_multiplier(lr_multiplier)}"
+
+    return GrugMoeLaunchConfig(
+        model=model,
+        data=NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
+        output_path=output_path,
+        run_id=run_id,
+        resources=ResourceConfig.with_tpu("v5p-8"),
+        steps=steps,
+        batch_size=batch_size,
+        seed=seed,
+        mp="params=float32,compute=bfloat16,output=bfloat16",
+        tracker=WandbConfig(
+            project="marin_moe",
+            tags=["moe", "depth-mup", "lr-sweep"],
+            group=DEPTH_MUP_WANDB_GROUP,
+            name=None,
+        ),
+        optimizer=optimizer,
+        grug_trainer=GrugTrainerConfig(
+            z_loss_weight=1e-4,
+            ema_beta=None,
+            log_every=1,
+        ),
+        eval=GrugEvalConfig(
+            eval_batch_size=512,
+            steps_per_eval=1000,
+            max_eval_batches=8,
+            eval_current=True,
+            eval_ema=False,
+        ),
+    )
+
+
+def _versioned_launch_config(config: GrugMoeLaunchConfig) -> GrugMoeLaunchConfig:
+    return dataclasses.replace(
+        config,
+        model=versioned(config.model),
+        resources=versioned(config.resources),
+        steps=versioned(config.steps),
+        batch_size=versioned(config.batch_size),
+        seed=versioned(config.seed),
+        mp=versioned(config.mp),
+        optimizer=versioned(config.optimizer),
+        grug_trainer=versioned(config.grug_trainer),
+        eval=versioned(config.eval) if config.eval is not None else None,
+    )
+
+
+def build_depth_mup_lr_sweep_step(scale: DepthMupSweepScale, lr_multiplier: float) -> ExecutorStep:
+    config = build_depth_mup_lr_sweep_config(scale, lr_multiplier, output_path=this_output_path())
+    return ExecutorStep(
+        name=f"grug/moe_depth_mup_lr/{config.run_id}",
+        fn=run_grug_moe_trial,
+        config=_versioned_launch_config(config),
+    )
+
+
+depth_mup_lr_sweep_steps: tuple[ExecutorStep, ...] = tuple(
+    build_depth_mup_lr_sweep_step(scale, lr_multiplier)
+    for scale in DEPTH_MUP_SWEEP_SCALES
+    for lr_multiplier in DEPTH_MUP_LR_MULTIPLIERS
+)
+
+
+if __name__ == "__main__":
+    executor_main(
+        steps=list(depth_mup_lr_sweep_steps),
+        description="Depth MuP residual scaling LR sweep for Grug MoE.",
+    )

--- a/experiments/grug/moe/heuristic.py
+++ b/experiments/grug/moe/heuristic.py
@@ -116,6 +116,7 @@ class MoeAdamHHeuristic:
     base_hidden_layer_ratio: int = 64
     layer_scaling_factor: float = 4.0
     layer_formula_offset: int = 9
+    depth_mup_residual_scaling: bool = False
 
     # --- Constraints ---
     max_learning_rate: float = 0.05
@@ -219,6 +220,7 @@ class MoeAdamHHeuristic:
             sliding_window=seq_len,
             initializer_std=0.5 / math.sqrt(hidden_size),
             qk_mult=1.3,
+            depth_mup_residual_scaling=self.depth_mup_residual_scaling,
         )
 
 

--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -8,6 +8,7 @@ No load-balancing loss; router z-loss only. All layers are MoE (no dense layers)
 """
 
 import dataclasses
+import math
 
 from dataclasses import dataclass
 
@@ -72,6 +73,7 @@ class GrugModelConfig:
     initializer_std: float = 0.02
     qk_mult: float = 1.0
     router_z_loss_coef: float = 0.001
+    depth_mup_residual_scaling: bool = False
     moe_implementation: MoeImplementation | None = None
     rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
 
@@ -83,6 +85,8 @@ class GrugModelConfig:
             raise ValueError("vocab_size must be positive")
         if self.max_seq_len <= 0:
             raise ValueError("max_seq_len must be positive")
+        if self.num_layers <= 0:
+            raise ValueError("num_layers must be positive")
         if self.num_experts <= 0:
             raise ValueError("num_experts must be positive")
         if self.num_experts_per_token <= 0:
@@ -101,6 +105,12 @@ class GrugModelConfig:
                 f"hidden_dim={self.hidden_dim} is not divisible by num_heads={self.num_heads}; set head_dim explicitly"
             )
         return self.hidden_dim // self.num_heads
+
+    @property
+    def residual_update_scale(self) -> float:
+        if not self.depth_mup_residual_scaling:
+            return 1.0
+        return 1.0 / math.sqrt(self.num_layers)
 
 
 def rms_norm(x: jax.Array, eps: float = 1e-6) -> jax.Array:
@@ -416,6 +426,7 @@ class Block(eqx.Module):
     mlp_gated_norm: GatedNorm
     mlp: MoEMLP
     shared: DenseMLP | None
+    residual_update_scale: float = eqx.field(static=True)
 
     @staticmethod
     def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "Block":
@@ -433,6 +444,7 @@ class Block(eqx.Module):
             mlp_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=gn_mlp_key),
             mlp=MoEMLP.init(cfg, key=mlp_key),
             shared=shared,
+            residual_update_scale=cfg.residual_update_scale,
         )
 
     @named_call
@@ -442,12 +454,12 @@ class Block(eqx.Module):
         mask: AttentionMask | jax.Array,
     ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
         attn_in = self.attn_gated_norm(self.rms_attn(x))
-        x = x + self.attn(attn_in, mask)
+        x = x + self.residual_update_scale * self.attn(attn_in, mask)
         mlp_in = self.mlp_gated_norm(self.rms_mlp(x))
         mlp_out, router_stats = self.mlp(mlp_in)
         if self.shared is not None:
             mlp_out = mlp_out + self.shared(mlp_in, activation=ActivationFunctionEnum.silu)
-        x = x + mlp_out
+        x = x + self.residual_update_scale * mlp_out
         return x, router_stats
 
 

--- a/tests/test_grug_moe_depth_mup.py
+++ b/tests/test_grug_moe_depth_mup.py
@@ -1,0 +1,88 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+
+from experiments.grug.moe import model as moe_model
+from experiments.grug.moe.heuristic import build_from_heuristic
+
+
+class _Identity(eqx.Module):
+    def __call__(self, x):
+        return x
+
+
+class _ConstantAttention(eqx.Module):
+    value: float = eqx.field(static=True)
+
+    def __call__(self, x, mask):
+        return jnp.full_like(x, self.value)
+
+
+class _ConstantMlp(eqx.Module):
+    value: float = eqx.field(static=True)
+
+    def __call__(self, x):
+        return jnp.full_like(x, self.value), {"router_z_loss": jnp.array(0.0)}
+
+
+def test_depth_mup_residual_scale_uses_inverse_sqrt_layer_count():
+    cfg = moe_model.GrugModelConfig(
+        vocab_size=128,
+        hidden_dim=32,
+        num_heads=2,
+        num_kv_heads=2,
+        num_layers=4,
+        num_experts=4,
+        num_experts_per_token=2,
+        depth_mup_residual_scaling=True,
+    )
+
+    assert cfg.residual_update_scale == 0.5
+
+
+def test_block_depth_mup_scales_attention_and_mlp_residual_updates():
+    block = moe_model.Block(
+        rms_attn=_Identity(),
+        attn_gated_norm=_Identity(),
+        attn=_ConstantAttention(2.0),
+        rms_mlp=_Identity(),
+        mlp_gated_norm=_Identity(),
+        mlp=_ConstantMlp(3.0),
+        shared=None,
+        residual_update_scale=0.5,
+    )
+    x = jnp.full((1, 2, 3), 10.0, dtype=jnp.float32)
+
+    out, _ = block(x, mask=None)
+
+    np.testing.assert_allclose(out, jnp.full_like(x, 12.5), rtol=1e-6)
+
+
+def test_depth_mup_lr_sweep_config_enables_scaling_and_scales_optimizer_lrs():
+    from experiments.grug.moe import depth_mup_lr_sweep
+
+    scale = depth_mup_lr_sweep.DEPTH_MUP_SWEEP_SCALES[0]
+    lr_multiplier = 2.0
+    config = depth_mup_lr_sweep.build_depth_mup_lr_sweep_config(
+        scale,
+        lr_multiplier,
+        output_path="/tmp/moe-depth-mup-test",
+    )
+    _baseline_model, baseline_optimizer, baseline_batch, baseline_steps = build_from_heuristic(
+        budget=scale.budget,
+        hidden_dim=scale.hidden_dim,
+        target_steps=depth_mup_lr_sweep.DEPTH_MUP_TARGET_STEPS,
+    )
+
+    assert config.model.depth_mup_residual_scaling is True
+    np.testing.assert_allclose(config.model.residual_update_scale, 1 / math.sqrt(config.model.num_layers), rtol=1e-12)
+    assert config.batch_size == baseline_batch
+    assert config.steps == baseline_steps
+    np.testing.assert_allclose(config.optimizer.learning_rate, baseline_optimizer.learning_rate * lr_multiplier)
+    np.testing.assert_allclose(config.optimizer.adam_lr, baseline_optimizer.adam_lr * lr_multiplier)
+    assert config.run_id == f"moe-depth-mup-lr-{scale.label}-lr2x"


### PR DESCRIPTION
Adds opt-in depth MuP residual scaling for Grug MoE and a 36-run LR sweep across d512, d768, d1024, and d1280. The baseline recipe stays unchanged; the dedicated sweep module enables the new residual scaling. Includes focused tests, MoE docs updates, and the research logbook.

Part of #5178