### PR TITLE
[grug] Add MoE AdamH global gradient normalization

### DIFF
--- a/.agents/logbooks/moe-adamh-global-grad-norm.md
+++ b/.agents/logbooks/moe-adamh-global-grad-norm.md
@@ -82,3 +82,28 @@
   baselines using the `agent.md` effective-speedup formula.
 - Next action: monitor to terminal state; launch gate 2 only if both gate-1
   effective speedups exceed 1.0.
+
+### 2026-04-25 18:53 - MOE-AGGN-001 preemption recovery fix
+
+- Hypothesis: the gate-1 parent launcher inherited its storage prefix from the
+  launcher worker region, so a parent preemption could move the executor prefix
+  from `gs://marin-us-central1` to `gs://marin-us-east5` and make child jobs
+  miss existing checkpoints.
+- Command:
+  `.venv/bin/iris --config lib/iris/examples/marin.yaml job stop /kaiyue/iris-run-job-20260426-011219`
+- Config:
+  - observed saved checkpoint:
+    `gs://marin-us-central1/grug/moe-adamh-global-grad-norm/d512-2p19e17-2406f6/checkpoints/step-4000`
+  - observed restart search path:
+    `gs://marin-us-east5/grug/moe-adamh-global-grad-norm/d512-2p19e17-2406f6/checkpoints`
+  - fix: default `launch_adamh_global_grad_norm.py` to
+    `ExecutorMainConfig(prefix=os.environ.get("MARIN_PREFIX", "gs://marin-us-central1"))`.
+- Result: stopped the self-submitted gate-1 parent and both child jobs after
+  the prefix mismatch appeared. Focused optimizer tests and launch selector
+  smoke still passed after the prefix fix.
+- Interpretation: gate 1 should be resubmitted in `us-central1` with
+  `MARIN_PREFIX=gs://marin-us-central1`; d512 can restore from the existing
+  central1 checkpoint, and future parent preemptions should not change the
+  storage prefix.
+- Next action: lint, commit, push, then resubmit gate 1 with a pinned launcher
+  region and continue monitoring to terminal state.

--- a/.agents/logbooks/moe-adamh-global-grad-norm.md
+++ b/.agents/logbooks/moe-adamh-global-grad-norm.md
@@ -340,3 +340,26 @@
   four-point evidence and scaling-law fit.
 - Next action: continue monitoring d1280 to terminal state, then compute the
   final d1280 speedup and four-point scaling-law projection.
+
+### 2026-04-26 16:13 - MOE-AGGN-001 d1280 in progress heartbeat
+
+- Result: d1280 remains healthy and continues training; d1024 is already
+  finished.
+- Status:
+  - Iris parent: `JOB_STATE_RUNNING`, `failure_count=0`
+  - d1024: `JOB_STATE_SUCCEEDED`, `failure_count=0`,
+    `preemption_count=3`
+  - d1280: `JOB_STATE_RUNNING`, `failure_count=0`,
+    `preemption_count=8`
+- W&B:
+  - d1024 final eval/paloma/macro_loss: `3.166934013366699`
+  - d1024 final throughput/tokens_per_second: `177281.21442588005`
+  - d1024 effective speedup: `0.9687810633605517`
+  - d1280 global_step: `6789`
+  - d1280 eval/paloma/macro_loss: `3.298739433288574`
+  - d1280 throughput/tokens_per_second: `128181.8846961277`
+  - d1280 throughput/total_tokens: `7119831040`
+- Interpretation: gate 2 is already blocked by the d1024 speedup miss, but
+  d1280 is still running to complete the four-point evidence and final
+  scaling-law projection.
+- Next action: continue monitoring d1280 until terminal state.

--- a/.agents/logbooks/moe-adamh-global-grad-norm.md
+++ b/.agents/logbooks/moe-adamh-global-grad-norm.md
@@ -280,3 +280,22 @@
   Continue monitoring at a longer cadence until terminal state.
 - Next action: wait for W&B summaries to report training/eval metrics, then
   keep polling until both gate-2 runs finish.
+
+### 2026-04-26 02:16 - MOE-AGGN-001 gate 2 in progress
+
+- Result: both gate-2 runs remain healthy after early checkpoints and evals.
+- Status:
+  - d1024: `JOB_STATE_RUNNING`, `failure_count=0`, `preemption_count=2`
+  - d1280: `JOB_STATE_RUNNING`, `failure_count=0`, `preemption_count=3`
+- W&B:
+  - d1024 global_step: `4253`
+  - d1024 eval/paloma/macro_loss: `3.633437633514404`
+  - d1024 throughput/tokens_per_second: `177121.1369216933`
+  - d1024 throughput/total_tokens: `2230321152`
+  - d1280 global_step: `1448`
+  - d1280 eval/paloma/macro_loss: `3.872636079788208`
+  - d1280 throughput/tokens_per_second: `128544.70010125235`
+  - d1280 throughput/total_tokens: `1519386624`
+- Interpretation: both large runs are past startup and first meaningful evals.
+  Current losses are still early; final gate-2 decision remains pending.
+- Next action: continue polling until both runs reach terminal state.

--- a/.agents/logbooks/moe-adamh-global-grad-norm.md
+++ b/.agents/logbooks/moe-adamh-global-grad-norm.md
@@ -150,3 +150,86 @@
   already passes `MARIN_PREFIX=gs://marin-us-central1`.
 - Next action: run pre-commit, commit and push the PR fix, then continue
   monitoring gate 1.
+
+### 2026-04-25 19:36 - MOE-AGGN-001 d512 gate-1 result
+
+- Result: d512 finished successfully on Iris.
+- Metrics:
+  - W&B run:
+    https://wandb.ai/understanding-sam/marin_moe/runs/moe-adamh-global-grad-norm-d512-2p19e17
+  - global_step: `6386`
+  - eval/paloma/macro_loss: `3.807736158370972`
+  - throughput/tokens_per_second: `406222.9291489406`
+  - effective speedup vs README baseline: `1.0143777998139154`
+- Interpretation: the d512 gate-1 point passes the `>1.0` threshold. Gate 1
+  is still blocked on d768, which remains running.
+- Next action: continue monitoring d768 to terminal state, then compute the
+  gate-1 decision.
+
+### 2026-04-25 22:01 - MOE-AGGN-001 gate 1 passed; gate 2 launched
+
+- Result: d768 finished successfully on Iris.
+- Metrics:
+  - W&B run:
+    https://wandb.ai/understanding-sam/marin_moe/runs/moe-adamh-global-grad-norm-d768-1p70e18
+  - global_step: `10342`
+  - eval/paloma/macro_loss: `3.4274773597717285`
+  - throughput/tokens_per_second: `275023.52176416403`
+  - effective speedup vs README baseline: `1.043646604830193`
+- Gate 1 decision:
+  - d512 effective speedup: `1.0143777998139154`
+  - d768 effective speedup: `1.043646604830193`
+  - both points exceed `1.0`, so gate 2 should run.
+- Command:
+  `.venv/bin/iris --config lib/iris/examples/marin.yaml job run --no-wait --memory=2G --disk=4G --cpu=1 --extra=cpu --region us-central1 --no-preemptible -e WANDB_API_KEY "$WANDB_API_KEY" -e MARIN_PREFIX gs://marin-us-central1 -e GRUG_MOE_ADAMH_GLOBAL_GRAD_NORM_GATE gate2 -- python -m experiments.grug.moe.launch_adamh_global_grad_norm`
+- Config:
+  - commit: `6d26ec0ea`
+  - Iris parent job: `/kaiyue/iris-run-job-20260426-050129`
+  - data browser:
+    https://marin.community/data-browser/experiment?path=gs%3A//marin-us-central1/experiments/launch_adamh_global_grad_norm-e8d8ad.json
+  - d1024 output:
+    `gs://marin-us-central1/grug/moe-adamh-global-grad-norm/d1024-9p00e18-9f3972`
+  - d1024 W&B:
+    https://wandb.ai/understanding-sam/marin_moe/runs/moe-adamh-global-grad-norm-d1024-9p00e18
+  - d1280 output:
+    `gs://marin-us-central1/grug/moe-adamh-global-grad-norm/d1280-2p83e19-ed47e1`
+  - d1280 W&B:
+    https://wandb.ai/understanding-sam/marin_moe/runs/moe-adamh-global-grad-norm-d1280-2p83e19
+  - issue update, submitted with raw GitHub REST:
+    https://github.com/marin-community/marin/issues/5182#issuecomment-4321300353
+- Startup status: parent and both child jobs reached `JOB_STATE_RUNNING`.
+  The first allocations hit the TPU device-busy/no-accelerator signature and
+  Iris retried automatically. Both children later reached `Progress on:train`.
+- Next action: monitor gate 2 to terminal state.
+
+### 2026-04-25 22:10 - MOE-AGGN-001 d1280 overflow fix
+
+- Result: the first gate-2 attempt was stopped after d1280 reproduced a code
+  failure twice.
+- Evidence:
+  - Iris parent job:
+    `/kaiyue/iris-run-job-20260426-050129`
+  - d1024 remained running on the old commit with `failure_count=0`.
+  - d1280 reached the first train step, then failed in
+    `normalize_gradients_to_unit_rms` with:
+    `OverflowError: An overflow was encountered while parsing an argument to a jitted computation, whose argument path is x2.`
+  - The failing expression was `square_sum / num_elements`; d1280 has enough
+    parameters for the Python integer element count to exceed signed int32
+    when staged by JAX.
+- Fix:
+  - Convert the accumulated element count to a floating JAX scalar before the
+    RMS division.
+  - Added a regression test using a tiny fake gradient leaf with
+    `size = 2**31`.
+- Validation:
+  - The new regression failed before the fix with the same overflow.
+  - `uv run --with pytest --with pytest-timeout pytest tests/test_grug_moe_adamh_global_norm.py -q`
+    passed after the fix.
+  - `WANDB_MODE=disabled uv run python experiments/grug/moe/launch_adamh_global_grad_norm.py --dry_run True --executor_info_base_path "$tmp" --prefix "$tmp"`
+    passed after the fix.
+- Command:
+  `.venv/bin/iris --config lib/iris/examples/marin.yaml job stop /kaiyue/iris-run-job-20260426-050129`
+- Interpretation: gate 2 must be resubmitted on a fixed commit; the d1024
+  partial run was also stopped so both gate-2 points use the same code.
+- Next action: run pre-commit, commit and push the overflow fix, resubmit
+  gate 2, update the issue via raw GitHub REST, and continue monitoring.

--- a/.agents/logbooks/moe-adamh-global-grad-norm.md
+++ b/.agents/logbooks/moe-adamh-global-grad-norm.md
@@ -386,3 +386,31 @@
   d1280 is now past the 9k eval and should finish after the remaining long
   tail of training and final eval/checkpoint.
 - Next action: continue monitoring d1280 until terminal state.
+
+### 2026-04-27 04:42 - MOE-AGGN-001 final gate-2 result
+
+- Result: d1280 and the gate-2 parent finished successfully on Iris.
+- Metrics:
+  - d1280 W&B:
+    https://wandb.ai/understanding-sam/marin_moe/runs/moe-adamh-global-grad-norm-d1280-2p83e19
+  - d1280 Iris child:
+    `/kaiyue/iris-run-job-20260426-051330/grug-train-moe-adamh-global-grad-norm-d1280-2p83e19`
+  - d1280 global_step: `11806`
+  - d1280 eval/paloma/macro_loss: `3.0103940963745117`
+  - d1280 throughput/tokens_per_second: `128145.97386012795`
+  - d1280 throughput/total_tokens: `12380536832`
+  - d1280 effective speedup vs README baseline: `0.970053895309745`
+- Gate-2 effective speedups:
+  - d512: `1.0143777998139154`
+  - d768: `1.043646604830193`
+  - d1024: `0.9687810633605517`
+  - d1280: `0.970053895309745`
+- Four-point scaling-law fit with `L_inf=1.6`:
+  - fit: `loss(C) = 1.6 + 87.61568636886787 * C^-0.09219276663884278`
+  - projection at `1e21`: `2.6151582960317317` vs baseline `2.606`
+  - projection at `1e23`: `2.263969660031245` vs baseline `2.252`
+- Interpretation: the variant fails gate 2. It misses the required
+  effective-speedup threshold at both large scales and projects slightly worse
+  than the baseline at both requested budgets.
+- Next action: post the final issue update and close the experiment issue as a
+  negative result.

--- a/.agents/logbooks/moe-adamh-global-grad-norm.md
+++ b/.agents/logbooks/moe-adamh-global-grad-norm.md
@@ -47,3 +47,38 @@
   only if both small-scale effective speedups exceed 1.0.
 - Next action: add focused optimizer tests, implement the global-normalized
   optimizer and launch wiring, then submit gate 1 to Iris.
+
+### 2026-04-25 18:12 - MOE-AGGN-001 gate 1 submitted
+
+- Hypothesis: global gradient RMS normalization can recover the d512 point
+  while preserving the d768 improvement seen in #5180.
+- Command:
+  `.venv/bin/iris --config lib/iris/examples/marin.yaml job run --no-wait --memory=2G --disk=4G --cpu=1 --extra=cpu --reserve v5p-8 -e WANDB_API_KEY "$WANDB_API_KEY" -e GRUG_MOE_ADAMH_GLOBAL_GRAD_NORM_GATE gate1 -- python -m experiments.grug.moe.launch_adamh_global_grad_norm`
+- Config:
+  - commit: `6c6675b3e9e633ef5344b1ee83b4931db2cd18a8`
+  - issue: https://github.com/marin-community/marin/issues/5182
+  - PR: https://github.com/marin-community/marin/pull/5183
+  - Iris parent job: `/kaiyue/iris-run-job-20260426-011219`
+  - data browser:
+    https://marin.community/data-browser/experiment?path=gs%3A//marin-us-central1/experiments/launch_adamh_global_grad_norm-374368.json
+  - d512 step:
+    `grug/moe-adamh-global-grad-norm/d512-2p19e17_b769d61c`
+  - d512 output:
+    `gs://marin-us-central1/grug/moe-adamh-global-grad-norm/d512-2p19e17-2406f6`
+  - d512 W&B:
+    https://wandb.ai/understanding-sam/marin_moe/runs/moe-adamh-global-grad-norm-d512-2p19e17
+  - d768 step:
+    `grug/moe-adamh-global-grad-norm/d768-1p70e18_e21b2843`
+  - d768 output:
+    `gs://marin-us-central1/grug/moe-adamh-global-grad-norm/d768-1p70e18-591709`
+  - d768 W&B:
+    https://wandb.ai/understanding-sam/marin_moe/runs/moe-adamh-global-grad-norm-d768-1p70e18
+- Result: submitted to Iris and dispatched both Fray TPU child jobs. Initial
+  allocations hit the TPU device-busy/no-accelerator bad-node signature, then
+  Iris retried automatically. At startup stabilization both child jobs were
+  `JOB_STATE_RUNNING` with `failure_count=0`.
+- Interpretation: gate 1 is now a live Iris run. Continue babysitting until
+  both d512 and d768 reach terminal state, then compare against the README
+  baselines using the `agent.md` effective-speedup formula.
+- Next action: monitor to terminal state; launch gate 2 only if both gate-1
+  effective speedups exceed 1.0.

--- a/.agents/logbooks/moe-adamh-global-grad-norm.md
+++ b/.agents/logbooks/moe-adamh-global-grad-norm.md
@@ -1,0 +1,49 @@
+# MoE AdamH Global Gradient Normalization: Research Logbook
+
+## Scope
+
+- Goal: test whether normalizing the full gradient tree to RMS 1 before
+  optimizer moment updates improves Grug MoE training relative to the current
+  AdamH recipe.
+- Primary metrics: final `eval/paloma/macro_loss`, effective speedup versus
+  the compute-optimal MoE baseline.
+- Secondary metrics: `throughput/tokens_per_second`,
+  `throughput/total_tokens`, training stability.
+- Constraints: compare at the README compute-optimal d512, d768, d1024, and
+  d1280 budgets; run gate 1 before gate 2.
+- Issue: https://github.com/marin-community/marin/issues/5182
+
+## Baseline
+
+- Date: 2026-04-25
+- Code refs:
+  - `experiments/grug/moe/README.md`
+  - `experiments/grug/moe/adamh.py`
+  - `experiments/grug/moe/optimizer.py`
+  - `experiments/grug/moe/launch.py`
+- Baseline numbers: compute-optimal d512, d768, d1024, and d1280 table in
+  `experiments/grug/moe/README.md`.
+- Prior related result: #5180 tested per-module gradient normalization. It
+  improved d768 but failed d512, so gate 1 failed overall.
+
+## Experiment Log
+
+### 2026-04-25 18:10 - Kickoff
+
+- Hypothesis: one global RMS normalization preserves relative gradient scales
+  across modules while controlling the absolute gradient scale entering AdamH,
+  avoiding the d512 regression from per-module reweighting.
+- Command: local implementation and unit tests.
+- Config:
+  - optimizer: `GrugMoeAdamHGlobalGradientNormConfig`
+  - normalization: scale the full gradient tree to combined RMS 1 before
+    AdamH/Adam moment updates.
+  - gate 1 launch:
+    `GRUG_MOE_ADAMH_GLOBAL_GRAD_NORM_GATE=gate1 python -m experiments.grug.moe.launch_adamh_global_grad_norm`
+  - gate 2 launch:
+    `GRUG_MOE_ADAMH_GLOBAL_GRAD_NORM_GATE=gate2 python -m experiments.grug.moe.launch_adamh_global_grad_norm`
+- Result: pending implementation.
+- Interpretation: gate 1 should run d512 and d768 first; gate 2 should run
+  only if both small-scale effective speedups exceed 1.0.
+- Next action: add focused optimizer tests, implement the global-normalized
+  optimizer and launch wiring, then submit gate 1 to Iris.

--- a/.agents/logbooks/moe-adamh-global-grad-norm.md
+++ b/.agents/logbooks/moe-adamh-global-grad-norm.md
@@ -233,3 +233,50 @@
   partial run was also stopped so both gate-2 points use the same code.
 - Next action: run pre-commit, commit and push the overflow fix, resubmit
   gate 2, update the issue via raw GitHub REST, and continue monitoring.
+
+### 2026-04-25 22:13 - MOE-AGGN-001 gate 2 resubmitted
+
+- Result: fixed gate 2 submitted to Iris.
+- Command:
+  `.venv/bin/iris --config lib/iris/examples/marin.yaml job run --no-wait --memory=2G --disk=4G --cpu=1 --extra=cpu --region us-central1 --no-preemptible -e WANDB_API_KEY "$WANDB_API_KEY" -e MARIN_PREFIX gs://marin-us-central1 -e GRUG_MOE_ADAMH_GLOBAL_GRAD_NORM_GATE gate2 -- python -m experiments.grug.moe.launch_adamh_global_grad_norm`
+- Config:
+  - commit: `30fc0cb4a`
+  - Iris parent job: `/kaiyue/iris-run-job-20260426-051330`
+  - data browser:
+    https://marin.community/data-browser/experiment?path=gs%3A//marin-us-central1/experiments/launch_adamh_global_grad_norm-ab8ea2.json
+  - d1024 output:
+    `gs://marin-us-central1/grug/moe-adamh-global-grad-norm/d1024-9p00e18-9f3972`
+  - d1280 output:
+    `gs://marin-us-central1/grug/moe-adamh-global-grad-norm/d1280-2p83e19-ed47e1`
+  - issue update, submitted with raw GitHub REST:
+    https://github.com/marin-community/marin/issues/5182#issuecomment-4321313483
+- Startup status: parent, d1024 child, and d1280 child are all
+  `JOB_STATE_RUNNING` with `failure_count=0` and `preemption_count=0`.
+- Next action: watch both children for restored checkpoints and
+  `Progress on:train`, then monitor to terminal state.
+
+### 2026-04-25 22:20 - MOE-AGGN-001 gate 2 startup stabilized
+
+- Result: the fixed gate-2 children moved past the previous overflow failure.
+- Status:
+  - Iris parent job: `JOB_STATE_RUNNING`
+  - d1024 child: `JOB_STATE_RUNNING`, `failure_count=0`,
+    `preemption_count=2`
+  - d1280 child: `JOB_STATE_RUNNING`, `failure_count=0`,
+    `preemption_count=2`
+- Logs:
+  - Both children initially hit the TPU device-busy/no-accelerator startup
+    signature and Iris retried automatically.
+  - d1024 found no valid checkpoint under
+    `gs://marin-us-central1/grug/moe-adamh-global-grad-norm/d1024-9p00e18-9f3972/checkpoints`
+    and started from scratch.
+  - d1280 found no valid checkpoint under
+    `gs://marin-us-central1/grug/moe-adamh-global-grad-norm/d1280-2p83e19-ed47e1/checkpoints`
+    and started from scratch.
+  - Both children reached `Progress on:train`; d1024 reached step 1 and
+    entered the first eval.
+  - No `OverflowError` appeared after the fixed commit.
+- Interpretation: the fixed code is past the known d1280 staging failure.
+  Continue monitoring at a longer cadence until terminal state.
+- Next action: wait for W&B summaries to report training/eval metrics, then
+  keep polling until both gate-2 runs finish.

--- a/.agents/logbooks/moe-adamh-global-grad-norm.md
+++ b/.agents/logbooks/moe-adamh-global-grad-norm.md
@@ -96,8 +96,8 @@
     `gs://marin-us-central1/grug/moe-adamh-global-grad-norm/d512-2p19e17-2406f6/checkpoints/step-4000`
   - observed restart search path:
     `gs://marin-us-east5/grug/moe-adamh-global-grad-norm/d512-2p19e17-2406f6/checkpoints`
-  - fix: default `launch_adamh_global_grad_norm.py` to
-    `ExecutorMainConfig(prefix=os.environ.get("MARIN_PREFIX", "gs://marin-us-central1"))`.
+  - fix: default `MARIN_PREFIX` to `gs://marin-us-central1` before the
+    launch file builds import-time data configs.
 - Result: stopped the self-submitted gate-1 parent and both child jobs after
   the prefix mismatch appeared. Focused optimizer tests and launch selector
   smoke still passed after the prefix fix.
@@ -107,3 +107,46 @@
   storage prefix.
 - Next action: lint, commit, push, then resubmit gate 1 with a pinned launcher
   region and continue monitoring to terminal state.
+
+### 2026-04-25 18:56 - MOE-AGGN-001 gate 1 resubmitted
+
+- Hypothesis: pinning the launcher to `us-central1` and setting
+  `MARIN_PREFIX=gs://marin-us-central1` will keep executor output paths stable
+  across parent restarts and allow checkpoint restore.
+- Command:
+  `.venv/bin/iris --config lib/iris/examples/marin.yaml job run --no-wait --memory=2G --disk=4G --cpu=1 --extra=cpu --region us-central1 --no-preemptible -e WANDB_API_KEY "$WANDB_API_KEY" -e MARIN_PREFIX gs://marin-us-central1 -e GRUG_MOE_ADAMH_GLOBAL_GRAD_NORM_GATE gate1 -- python -m experiments.grug.moe.launch_adamh_global_grad_norm`
+- Config:
+  - commit: `dabbc2b52`
+  - Iris parent job: `/kaiyue/iris-run-job-20260426-015624`
+  - data browser:
+    https://marin.community/data-browser/experiment?path=gs%3A//marin-us-central1/experiments/launch_adamh_global_grad_norm-7d0e46.json
+  - d512 output:
+    `gs://marin-us-central1/grug/moe-adamh-global-grad-norm/d512-2p19e17-2406f6`
+  - d768 output:
+    `gs://marin-us-central1/grug/moe-adamh-global-grad-norm/d768-1p70e18-591709`
+- Result: d512 restored from
+  `gs://marin-us-central1/grug/moe-adamh-global-grad-norm/d512-2p19e17-2406f6/checkpoints/step-3000`;
+  d768 restored from
+  `gs://marin-us-central1/grug/moe-adamh-global-grad-norm/d768-1p70e18-591709/checkpoints/step-1000`.
+- Interpretation: the storage-prefix issue is fixed for the live run. The
+  incomplete d512 step-4000 save was skipped automatically; step-3000 is the
+  latest loadable checkpoint.
+- Next action: continue monitoring gate 1 to terminal state.
+
+### 2026-04-25 19:11 - MOE-AGGN-001 launch dry-run fix
+
+- Hypothesis: the launch file can keep the manual `us-central1` default while
+  still honoring CI's `--prefix` dry-run argument if it mirrors that CLI prefix
+  into `MARIN_PREFIX` before importing the shared MoE launch data config.
+- Command:
+  `WANDB_MODE=disabled uv run python experiments/grug/moe/launch_adamh_global_grad_norm.py --dry_run True --executor_info_base_path "$tmp" --prefix "$tmp"`
+- Result: dry-run output paths now stay under the temporary executor prefix,
+  including raw dataset overrides. The runpy dry-run path used by
+  `tests/test_dry_run.py` also passed, and
+  `uv run --with pytest --with pytest-timeout pytest tests/test_grug_moe_adamh_global_norm.py -q`
+  passed.
+- Interpretation: this should fix the PR CI timeout and temporary-directory
+  collision from commit `dabbc2b52` without changing the live Iris run, which
+  already passes `MARIN_PREFIX=gs://marin-us-central1`.
+- Next action: run pre-commit, commit and push the PR fix, then continue
+  monitoring gate 1.

--- a/.agents/logbooks/moe-adamh-global-grad-norm.md
+++ b/.agents/logbooks/moe-adamh-global-grad-norm.md
@@ -320,3 +320,23 @@
   state; d1280 remains the long pole.
 - Next action: continue monitoring until d1024 finishes, record its final
   metrics, and keep d1280 running to completion for the gate-2 decision.
+
+### 2026-04-26 10:11 - MOE-AGGN-001 d1024 gate-2 result
+
+- Result: d1024 finished successfully on Iris.
+- Metrics:
+  - W&B run:
+    https://wandb.ai/understanding-sam/marin_moe/runs/moe-adamh-global-grad-norm-d1024-9p00e18
+  - Iris child:
+    `/kaiyue/iris-run-job-20260426-051330/grug-train-moe-adamh-global-grad-norm-d1024-9p00e18`
+  - global_step: `12648`
+  - eval/paloma/macro_loss: `3.166934013366699`
+  - throughput/tokens_per_second: `177281.21442588005`
+  - throughput/total_tokens: `6631718912`
+  - effective speedup vs README baseline: `0.9687810633605517`
+- Interpretation: d1024 misses the `>1.0` effective-speedup criterion. Under
+  the all-four-points gate-2 rule, this variant cannot pass gate 2 even if
+  d1280 improves. d1280 is still running so the experiment has the complete
+  four-point evidence and scaling-law fit.
+- Next action: continue monitoring d1280 to terminal state, then compute the
+  final d1280 speedup and four-point scaling-law projection.

--- a/.agents/logbooks/moe-adamh-global-grad-norm.md
+++ b/.agents/logbooks/moe-adamh-global-grad-norm.md
@@ -299,3 +299,24 @@
 - Interpretation: both large runs are past startup and first meaningful evals.
   Current losses are still early; final gate-2 decision remains pending.
 - Next action: continue polling until both runs reach terminal state.
+
+### 2026-04-26 08:16 - MOE-AGGN-001 gate 2 six-hour heartbeat
+
+- Result: both gate-2 runs remain healthy and continue making progress.
+- Status:
+  - Iris parent: `JOB_STATE_RUNNING`, `failure_count=0`
+  - d1024: `JOB_STATE_RUNNING`, `failure_count=0`, `preemption_count=2`
+  - d1280: `JOB_STATE_RUNNING`, `failure_count=0`, `preemption_count=3`
+- W&B:
+  - d1024 global_step: `10922`
+  - d1024 eval/paloma/macro_loss: `3.2749111652374268`
+  - d1024 throughput/tokens_per_second: `176874.8128817064`
+  - d1024 throughput/total_tokens: `5726797824`
+  - d1280 global_step: `3882`
+  - d1280 eval/paloma/macro_loss: `3.494645118713379`
+  - d1280 throughput/tokens_per_second: `128412.9145324166`
+  - d1280 throughput/total_tokens: `4071620608`
+- Interpretation: no intervention is needed. d1024 is approaching terminal
+  state; d1280 remains the long pole.
+- Next action: continue monitoring until d1024 finishes, record its final
+  metrics, and keep d1280 running to completion for the gate-2 decision.

--- a/.agents/logbooks/moe-adamh-global-grad-norm.md
+++ b/.agents/logbooks/moe-adamh-global-grad-norm.md
@@ -363,3 +363,26 @@
   d1280 is still running to complete the four-point evidence and final
   scaling-law projection.
 - Next action: continue monitoring d1280 until terminal state.
+
+### 2026-04-26 22:21 - MOE-AGGN-001 d1280 in progress heartbeat
+
+- Result: d1280 remains healthy and continues training; d1024 remains
+  finished.
+- Status:
+  - Iris parent: `JOB_STATE_RUNNING`, `failure_count=0`
+  - d1024: `JOB_STATE_SUCCEEDED`, `failure_count=0`,
+    `preemption_count=3`
+  - d1280: `JOB_STATE_RUNNING`, `failure_count=0`,
+    `preemption_count=8`
+- W&B:
+  - d1024 final eval/paloma/macro_loss: `3.166934013366699`
+  - d1024 final throughput/tokens_per_second: `177281.21442588005`
+  - d1024 effective speedup: `0.9687810633605517`
+  - d1280 global_step: `9266`
+  - d1280 eval/paloma/macro_loss: `3.1323108673095703`
+  - d1280 throughput/tokens_per_second: `128158.1291560675`
+  - d1280 throughput/total_tokens: `9717153792`
+- Interpretation: the variant remains blocked on the d1024 speedup miss, but
+  d1280 is now past the 9k eval and should finish after the remaining long
+  tail of training and final eval/checkpoint.
+- Next action: continue monitoring d1280 until terminal state.

--- a/experiments/grug/moe/adamh.py
+++ b/experiments/grug/moe/adamh.py
@@ -35,7 +35,8 @@ def normalize_gradients_to_unit_rms(updates: optax.Updates, eps: float = 1e-16) 
     if num_elements == 0:
         return updates
 
-    inv_rms = jax.lax.rsqrt(square_sum / num_elements + eps)
+    element_count = jnp.array(float(num_elements), dtype=square_sum.dtype)
+    inv_rms = jax.lax.rsqrt(square_sum / element_count + eps)
     for index, leaf in enumerate(leaves):
         if leaf is None or not hasattr(leaf, "shape"):
             continue

--- a/experiments/grug/moe/adamh.py
+++ b/experiments/grug/moe/adamh.py
@@ -19,6 +19,44 @@ class ScaleByAdamHState(NamedTuple):
     nu: optax.Updates
 
 
+def normalize_gradients_to_unit_rms(updates: optax.Updates, eps: float = 1e-16) -> optax.Updates:
+    """Normalize the full gradient tree to combined RMS 1."""
+    leaves, treedef = jax.tree_util.tree_flatten(updates, is_leaf=lambda x: x is None)
+    normalized_leaves = list(leaves)
+
+    square_sum = jnp.array(0.0, dtype=jnp.float32)
+    num_elements = 0
+    for leaf in leaves:
+        if leaf is None or not hasattr(leaf, "shape"):
+            continue
+        square_sum = square_sum + jnp.sum(jnp.square(leaf.astype(jnp.float32)))
+        num_elements += int(leaf.size)
+
+    if num_elements == 0:
+        return updates
+
+    inv_rms = jax.lax.rsqrt(square_sum / num_elements + eps)
+    for index, leaf in enumerate(leaves):
+        if leaf is None or not hasattr(leaf, "shape"):
+            continue
+        normalized_leaves[index] = leaf * inv_rms.astype(leaf.dtype)
+
+    return jax.tree_util.tree_unflatten(treedef, normalized_leaves)
+
+
+def normalize_by_global_gradient_rms(eps: float = 1e-16) -> optax.GradientTransformation:
+    """Scale update trees so the combined gradient RMS is 1."""
+
+    def init_fn(params):
+        return optax.EmptyState()
+
+    def update_fn(updates, state, params=None):
+        del params
+        return normalize_gradients_to_unit_rms(updates, eps=eps), state
+
+    return optax.GradientTransformation(init_fn, update_fn)
+
+
 def scale_by_adamh(
     b1: float = 0.9,
     b2: float = 0.999,
@@ -75,4 +113,9 @@ def scale_by_adamh(
     return optax.GradientTransformation(init_fn, update_fn)
 
 
-__all__ = ["ScaleByAdamHState", "scale_by_adamh"]
+__all__ = [
+    "ScaleByAdamHState",
+    "normalize_by_global_gradient_rms",
+    "normalize_gradients_to_unit_rms",
+    "scale_by_adamh",
+]

--- a/experiments/grug/moe/launch_adamh_global_grad_norm.py
+++ b/experiments/grug/moe/launch_adamh_global_grad_norm.py
@@ -1,14 +1,34 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E402
 
 """Launch MoE AdamH global gradient-normalization ablations."""
 
 import dataclasses
 import os
+import sys
+
+_DEFAULT_PREFIX: str = "gs://marin-us-central1"
+
+
+def _prefix_from_cli_args(args: list[str]) -> str | None:
+    for idx, arg in enumerate(args):
+        if arg == "--prefix" and idx + 1 < len(args):
+            return args[idx + 1]
+        if arg.startswith("--prefix="):
+            return arg.split("=", 1)[1]
+    return None
+
+
+# The shared MoE launch module builds data configs at import time, so set the
+# manual-launch default before importing it. Dry-run tests pass --prefix and
+# must keep their local test prefix.
+if "MARIN_PREFIX" not in os.environ:
+    os.environ["MARIN_PREFIX"] = _prefix_from_cli_args(sys.argv[1:]) or _DEFAULT_PREFIX
 
 from fray.cluster import ResourceConfig
 from levanter.tracker.wandb import WandbConfig
-from marin.execution.executor import ExecutorMainConfig, ExecutorStep, executor_main, this_output_path, versioned
+from marin.execution.executor import ExecutorStep, executor_main, this_output_path, versioned
 
 from experiments.grug.moe.heuristic import build_from_heuristic
 from experiments.grug.moe.launch import (
@@ -20,7 +40,6 @@ from experiments.grug.moe.optimizer import GrugMoeAdamHConfig, GrugMoeAdamHGloba
 from experiments.grug.moe.train import GrugEvalConfig, GrugTrainerConfig
 
 _TARGET_STEPS: int = 2**14
-_DEFAULT_PREFIX: str = "gs://marin-us-central1"
 _GATE_SPECS: dict[str, tuple[tuple[str, float, int], ...]] = {
     "gate1": (
         ("d512-2p19e17", 2.19e17, 512),
@@ -102,7 +121,6 @@ def _selected_specs() -> tuple[tuple[str, float, int], ...]:
 
 if __name__ == "__main__":
     executor_main(
-        ExecutorMainConfig(prefix=os.environ.get("MARIN_PREFIX", _DEFAULT_PREFIX)),
         steps=[_make_step(label, budget, hidden_dim) for label, budget, hidden_dim in _selected_specs()],
         description="Grug MoE AdamH with global gradient RMS normalization.",
     )

--- a/experiments/grug/moe/launch_adamh_global_grad_norm.py
+++ b/experiments/grug/moe/launch_adamh_global_grad_norm.py
@@ -8,7 +8,7 @@ import os
 
 from fray.cluster import ResourceConfig
 from levanter.tracker.wandb import WandbConfig
-from marin.execution.executor import ExecutorStep, executor_main, this_output_path, versioned
+from marin.execution.executor import ExecutorMainConfig, ExecutorStep, executor_main, this_output_path, versioned
 
 from experiments.grug.moe.heuristic import build_from_heuristic
 from experiments.grug.moe.launch import (
@@ -20,6 +20,7 @@ from experiments.grug.moe.optimizer import GrugMoeAdamHConfig, GrugMoeAdamHGloba
 from experiments.grug.moe.train import GrugEvalConfig, GrugTrainerConfig
 
 _TARGET_STEPS: int = 2**14
+_DEFAULT_PREFIX: str = "gs://marin-us-central1"
 _GATE_SPECS: dict[str, tuple[tuple[str, float, int], ...]] = {
     "gate1": (
         ("d512-2p19e17", 2.19e17, 512),
@@ -101,6 +102,7 @@ def _selected_specs() -> tuple[tuple[str, float, int], ...]:
 
 if __name__ == "__main__":
     executor_main(
+        ExecutorMainConfig(prefix=os.environ.get("MARIN_PREFIX", _DEFAULT_PREFIX)),
         steps=[_make_step(label, budget, hidden_dim) for label, budget, hidden_dim in _selected_specs()],
         description="Grug MoE AdamH with global gradient RMS normalization.",
     )

--- a/experiments/grug/moe/launch_adamh_global_grad_norm.py
+++ b/experiments/grug/moe/launch_adamh_global_grad_norm.py
@@ -1,0 +1,106 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Launch MoE AdamH global gradient-normalization ablations."""
+
+import dataclasses
+import os
+
+from fray.cluster import ResourceConfig
+from levanter.tracker.wandb import WandbConfig
+from marin.execution.executor import ExecutorStep, executor_main, this_output_path, versioned
+
+from experiments.grug.moe.heuristic import build_from_heuristic
+from experiments.grug.moe.launch import (
+    GrugMoeLaunchConfig,
+    NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
+    run_grug_moe_trial,
+)
+from experiments.grug.moe.optimizer import GrugMoeAdamHConfig, GrugMoeAdamHGlobalGradientNormConfig
+from experiments.grug.moe.train import GrugEvalConfig, GrugTrainerConfig
+
+_TARGET_STEPS: int = 2**14
+_GATE_SPECS: dict[str, tuple[tuple[str, float, int], ...]] = {
+    "gate1": (
+        ("d512-2p19e17", 2.19e17, 512),
+        ("d768-1p70e18", 1.70e18, 768),
+    ),
+    "gate2": (
+        ("d1024-9p00e18", 9.00e18, 1024),
+        ("d1280-2p83e19", 2.83e19, 1280),
+    ),
+}
+
+
+def _global_gradient_norm_optimizer(optimizer: GrugMoeAdamHConfig) -> GrugMoeAdamHGlobalGradientNormConfig:
+    return GrugMoeAdamHGlobalGradientNormConfig(**dataclasses.asdict(optimizer))
+
+
+def _resolve_run_id(label: str) -> str:
+    run_id = os.environ.get("GRUG_RUN_ID", f"moe-adamh-global-grad-norm-{label}")
+    ferry_date = os.environ.get("FERRY_DATE")
+    if ferry_date:
+        run_id = f"{run_id}-{ferry_date}"
+    return run_id
+
+
+def _make_step(label: str, budget: float, hidden_dim: int) -> ExecutorStep:
+    model, optimizer, batch_size, steps = build_from_heuristic(
+        budget=budget,
+        hidden_dim=hidden_dim,
+        target_steps=_TARGET_STEPS,
+    )
+    return ExecutorStep(
+        name=f"grug/moe-adamh-global-grad-norm/{label}",
+        fn=run_grug_moe_trial,
+        config=GrugMoeLaunchConfig(
+            model=versioned(model),
+            data=NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
+            output_path=this_output_path(),
+            run_id=_resolve_run_id(label),
+            resources=versioned(ResourceConfig.with_tpu("v5p-8")),
+            steps=versioned(steps),
+            batch_size=versioned(batch_size),
+            seed=versioned(0),
+            mp=versioned("params=float32,compute=bfloat16,output=bfloat16"),
+            tracker=WandbConfig(
+                project="marin_moe",
+                tags=["moe", "adamh-global-grad-norm"],
+                group="moe-adamh-global-grad-norm",
+                name=None,
+            ),
+            optimizer=versioned(_global_gradient_norm_optimizer(optimizer)),
+            grug_trainer=versioned(
+                GrugTrainerConfig(
+                    z_loss_weight=1e-4,
+                    ema_beta=None,
+                    log_every=1,
+                )
+            ),
+            eval=versioned(
+                GrugEvalConfig(
+                    eval_batch_size=512,
+                    steps_per_eval=1000,
+                    max_eval_batches=8,
+                    eval_current=True,
+                    eval_ema=False,
+                )
+            ),
+        ),
+    )
+
+
+def _selected_specs() -> tuple[tuple[str, float, int], ...]:
+    gate = os.environ.get("GRUG_MOE_ADAMH_GLOBAL_GRAD_NORM_GATE", "gate1")
+    if gate == "all":
+        return _GATE_SPECS["gate1"] + _GATE_SPECS["gate2"]
+    if gate not in _GATE_SPECS:
+        raise ValueError(f"Unknown GRUG_MOE_ADAMH_GLOBAL_GRAD_NORM_GATE={gate!r}. Expected gate1, gate2, or all.")
+    return _GATE_SPECS[gate]
+
+
+if __name__ == "__main__":
+    executor_main(
+        steps=[_make_step(label, budget, hidden_dim) for label, budget, hidden_dim in _selected_specs()],
+        description="Grug MoE AdamH with global gradient RMS normalization.",
+    )

--- a/experiments/grug/moe/optimizer.py
+++ b/experiments/grug/moe/optimizer.py
@@ -7,7 +7,7 @@ import jax
 import optax
 
 from levanter.optim import OptimizerConfig
-from experiments.grug.moe.adamh import scale_by_adamh
+from experiments.grug.moe.adamh import normalize_by_global_gradient_rms, scale_by_adamh
 from levanter.utils.jax_utils import leaf_key_paths
 
 
@@ -28,6 +28,34 @@ class GrugMoeAdamHConfig(OptimizerConfig):
     adam_lr: float = 6e-4
     expert_lr: float | None = None
 
+    def _scale_by_adamh(self, learning_rate):
+        return scale_by_adamh(self.beta1, self.beta2, self.epsilon, learning_rate)
+
+    def _adamh_transform(self, learning_rate, *, include_clip: bool = True):
+        components = []
+        if include_clip and self.max_grad_norm:
+            components.append(optax.clip_by_global_norm(self.max_grad_norm))
+        components.append(self._scale_by_adamh(learning_rate))
+        return optax.chain(*components)
+
+    def _adam_transform(self, adam_lr, *, include_clip: bool = True):
+        components = []
+        if include_clip and self.max_grad_norm:
+            components.append(optax.clip_by_global_norm(self.max_grad_norm))
+        components.append(optax.scale_by_adam(self.beta1, self.beta2, self.epsilon))
+        components.append(optax.scale(-adam_lr))
+        return optax.chain(*components)
+
+    def _multi_transform(self, learning_rate, adam_lr, expert_lr, *, include_clip: bool = True):
+        return optax.multi_transform(
+            {
+                "adamh": self._adamh_transform(learning_rate, include_clip=include_clip),
+                "adamh_expert": self._adamh_transform(expert_lr, include_clip=include_clip),
+                "adam": self._adam_transform(adam_lr, include_clip=include_clip),
+            },
+            self.create_mask,
+        )
+
     def build(self, num_train_steps):
         learning_rate_schedule = self.lr_scheduler(num_train_steps)
         adam_lr_schedule = self.lr_scheduler(num_train_steps, override_lr=self.adam_lr)
@@ -35,36 +63,7 @@ class GrugMoeAdamHConfig(OptimizerConfig):
         expert_lr_schedule = self.lr_scheduler(num_train_steps, override_lr=expert_lr_val)
 
         def optimizer(learning_rate, adam_lr, expert_lr):
-            def adamh_transform():
-                components = []
-                if self.max_grad_norm:
-                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
-                components.append(scale_by_adamh(self.beta1, self.beta2, self.epsilon, learning_rate))
-                return optax.chain(*components)
-
-            def adamh_expert_transform():
-                components = []
-                if self.max_grad_norm:
-                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
-                components.append(scale_by_adamh(self.beta1, self.beta2, self.epsilon, expert_lr))
-                return optax.chain(*components)
-
-            def adam_transform():
-                components = []
-                if self.max_grad_norm:
-                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
-                components.append(optax.scale_by_adam(self.beta1, self.beta2, self.epsilon))
-                components.append(optax.scale(-adam_lr))
-                return optax.chain(*components)
-
-            return optax.multi_transform(
-                {
-                    "adamh": adamh_transform(),
-                    "adamh_expert": adamh_expert_transform(),
-                    "adam": adam_transform(),
-                },
-                self.create_mask,
-            )
+            return self._multi_transform(learning_rate, adam_lr, expert_lr)
 
         return optax.inject_hyperparams(optimizer)(
             learning_rate=learning_rate_schedule,
@@ -91,4 +90,32 @@ class GrugMoeAdamHConfig(OptimizerConfig):
         return jax.tree.map(mask_fn, params, paths)
 
 
-__all__ = ["GrugMoeAdamHConfig"]
+@OptimizerConfig.register_subclass("grug_moe_adamh_global_grad_norm")
+@dataclass(frozen=True)
+class GrugMoeAdamHGlobalGradientNormConfig(GrugMoeAdamHConfig):
+    """AdamH for Grug MoE with one global gradient RMS normalization."""
+
+    gradient_norm_eps: float = 1e-16
+
+    def build(self, num_train_steps):
+        learning_rate_schedule = self.lr_scheduler(num_train_steps)
+        adam_lr_schedule = self.lr_scheduler(num_train_steps, override_lr=self.adam_lr)
+        expert_lr_val = self.expert_lr if self.expert_lr is not None else self.learning_rate
+        expert_lr_schedule = self.lr_scheduler(num_train_steps, override_lr=expert_lr_val)
+
+        def optimizer(learning_rate, adam_lr, expert_lr):
+            components = []
+            if self.max_grad_norm:
+                components.append(optax.clip_by_global_norm(self.max_grad_norm))
+            components.append(normalize_by_global_gradient_rms(eps=self.gradient_norm_eps))
+            components.append(self._multi_transform(learning_rate, adam_lr, expert_lr, include_clip=False))
+            return optax.chain(*components)
+
+        return optax.inject_hyperparams(optimizer)(
+            learning_rate=learning_rate_schedule,
+            adam_lr=adam_lr_schedule,
+            expert_lr=expert_lr_schedule,
+        )
+
+
+__all__ = ["GrugMoeAdamHConfig", "GrugMoeAdamHGlobalGradientNormConfig"]

--- a/tests/test_grug_moe_adamh_global_norm.py
+++ b/tests/test_grug_moe_adamh_global_norm.py
@@ -1,0 +1,98 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from experiments.grug.moe.adamh import normalize_gradients_to_unit_rms
+from experiments.grug.moe.optimizer import GrugMoeAdamHConfig, GrugMoeAdamHGlobalGradientNormConfig
+
+
+def _assert_tree_allclose(actual, expected, *, rtol=1e-6, atol=1e-6):
+    actual_leaves = jax.tree.leaves(actual)
+    expected_leaves = jax.tree.leaves(expected)
+    assert len(actual_leaves) == len(expected_leaves)
+    for actual_leaf, expected_leaf in zip(actual_leaves, expected_leaves, strict=True):
+        np.testing.assert_allclose(actual_leaf, expected_leaf, rtol=rtol, atol=atol)
+
+
+def _tree_rms(tree):
+    leaves = jax.tree.leaves(tree)
+    square_sum = sum((jnp.sum(jnp.square(leaf.astype(jnp.float32))) for leaf in leaves), jnp.array(0.0))
+    count = sum(leaf.size for leaf in leaves)
+    return jnp.sqrt(square_sum / count)
+
+
+def test_global_gradient_normalization_scales_full_tree_to_unit_rms():
+    grads = {
+        "block": {
+            "attn": {"w_q": jnp.full((2, 2), 2.0, dtype=jnp.float32)},
+            "mlp": {"w_gate_up": jnp.full((2,), 6.0, dtype=jnp.float32)},
+        }
+    }
+
+    normalized = normalize_gradients_to_unit_rms(grads, eps=0.0)
+
+    expected_inv_rms = jax.lax.rsqrt((4 * 2.0**2 + 2 * 6.0**2) / 6)
+    np.testing.assert_allclose(_tree_rms(normalized), 1.0, rtol=1e-6)
+    np.testing.assert_allclose(normalized["block"]["attn"]["w_q"], jnp.full((2, 2), 2.0 * expected_inv_rms))
+    np.testing.assert_allclose(normalized["block"]["mlp"]["w_gate_up"], jnp.full((2,), 6.0 * expected_inv_rms))
+
+
+def test_global_gradient_normalized_config_matches_manual_global_normalization():
+    params = {
+        "blocks": {
+            "0": {
+                "attn": {"w_q": jnp.arange(1, 5, dtype=jnp.float32).reshape(2, 2)},
+                "mlp": {"w_gate_up": jnp.arange(1, 9, dtype=jnp.float32).reshape(2, 2, 2)},
+                "rms_attn": {"weight": jnp.ones((2,), dtype=jnp.float32)},
+            }
+        }
+    }
+    grads = {
+        "blocks": {
+            "0": {
+                "attn": {"w_q": jnp.full((2, 2), 2.0, dtype=jnp.float32)},
+                "mlp": {"w_gate_up": jnp.full((2, 2, 2), 6.0, dtype=jnp.float32)},
+                "rms_attn": {"weight": jnp.full((2,), 3.0, dtype=jnp.float32)},
+            }
+        }
+    }
+    baseline = GrugMoeAdamHConfig(
+        learning_rate=0.05,
+        adam_lr=0.05,
+        expert_lr=0.05,
+        max_grad_norm=None,
+    ).build(4)
+    global_norm = GrugMoeAdamHGlobalGradientNormConfig(
+        learning_rate=0.05,
+        adam_lr=0.05,
+        expert_lr=0.05,
+        max_grad_norm=None,
+        gradient_norm_eps=0.0,
+    ).build(4)
+
+    manually_normalized = normalize_gradients_to_unit_rms(grads, eps=0.0)
+    expected_updates, _ = baseline.update(manually_normalized, baseline.init(params), params)
+    actual_updates, _ = global_norm.update(grads, global_norm.init(params), params)
+
+    _assert_tree_allclose(actual_updates, expected_updates)
+
+
+def test_global_gradient_normalized_adamh_config_keeps_baseline_parameter_groups():
+    params = {
+        "token_embed": jnp.ones((8, 4), dtype=jnp.float32),
+        "blocks": {
+            "0": {
+                "attn": {"w_q": jnp.ones((4, 4), dtype=jnp.float32)},
+                "mlp": {"w_gate_up": jnp.ones((2, 4, 8), dtype=jnp.float32)},
+                "rms_attn": {"weight": jnp.ones((4,), dtype=jnp.float32)},
+            }
+        },
+    }
+
+    baseline_mask = GrugMoeAdamHConfig().create_mask(params)
+    grad_norm_mask = GrugMoeAdamHGlobalGradientNormConfig().create_mask(params)
+
+    assert grad_norm_mask == baseline_mask

--- a/tests/test_grug_moe_adamh_global_norm.py
+++ b/tests/test_grug_moe_adamh_global_norm.py
@@ -9,6 +9,18 @@ from experiments.grug.moe.adamh import normalize_gradients_to_unit_rms
 from experiments.grug.moe.optimizer import GrugMoeAdamHConfig, GrugMoeAdamHGlobalGradientNormConfig
 
 
+class _FakeHugeGradientLeaf:
+    shape = (1,)
+    size = 2**31
+    dtype = jnp.float32
+
+    def astype(self, dtype):
+        return jnp.array([2.0], dtype=dtype)
+
+    def __mul__(self, value):
+        return self.astype(self.dtype) * value
+
+
 def _assert_tree_allclose(actual, expected, *, rtol=1e-6, atol=1e-6):
     actual_leaves = jax.tree.leaves(actual)
     expected_leaves = jax.tree.leaves(expected)
@@ -38,6 +50,13 @@ def test_global_gradient_normalization_scales_full_tree_to_unit_rms():
     np.testing.assert_allclose(_tree_rms(normalized), 1.0, rtol=1e-6)
     np.testing.assert_allclose(normalized["block"]["attn"]["w_q"], jnp.full((2, 2), 2.0 * expected_inv_rms))
     np.testing.assert_allclose(normalized["block"]["mlp"]["w_gate_up"], jnp.full((2,), 6.0 * expected_inv_rms))
+
+
+def test_global_gradient_normalization_handles_more_than_int32_elements():
+    normalized = normalize_gradients_to_unit_rms({"huge": _FakeHugeGradientLeaf()}, eps=0.0)
+
+    expected_inv_rms = jax.lax.rsqrt(jnp.array(4.0, dtype=jnp.float32) / jnp.array(2**31, dtype=jnp.float32))
+    np.testing.assert_allclose(normalized["huge"], jnp.array([2.0 * expected_inv_rms]), rtol=1e-6)
 
 
 def test_global_gradient_normalized_config_matches_manual_global_normalization():


### PR DESCRIPTION
Add a Grug MoE AdamH variant that normalizes the full gradient tree to RMS 1 before optimizer moment updates. Includes gate-specific launch wiring for d512/d768 and d1024/d1280 comparison runs plus focused optimizer tests.

Part of #5182