### PR TITLE
[data] Add shared ingestion manifest schema

### DIFF
--- a/lib/marin/src/marin/datakit/ingestion_manifest.py
+++ b/lib/marin/src/marin/datakit/ingestion_manifest.py
@@ -8,30 +8,25 @@ from __future__ import annotations
 import hashlib
 import json
 import posixpath
-from dataclasses import asdict, dataclass, field
 from enum import StrEnum
 from typing import Any
 
+from pydantic import BaseModel, ConfigDict, Field
 from rigging.filesystem import open_url
+from typing_extensions import TypeAliasType
 from zephyr.writers import atomic_rename
 
 from marin.utils import fsspec_mkdirs
 
 JsonScalar = str | int | float | bool | None
-JsonValue = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+JsonValue = TypeAliasType("JsonValue", JsonScalar | list["JsonValue"] | dict[str, "JsonValue"])
 INGESTION_METADATA_SCHEMA_VERSION = 1
 
 
-def _json_ready(value: Any) -> Any:
-    if isinstance(value, StrEnum):
-        return str(value)
-    if isinstance(value, tuple):
-        return [_json_ready(item) for item in value]
-    if isinstance(value, list):
-        return [_json_ready(item) for item in value]
-    if isinstance(value, dict):
-        return {key: _json_ready(item) for key, item in value.items()}
-    return value
+class ManifestModel(BaseModel):
+    """Strict base model for ingestion metadata payloads."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
 
 class UsagePolicy(StrEnum):
@@ -57,8 +52,7 @@ class SecretRedaction(StrEnum):
     REQUIRED = "required"
 
 
-@dataclass(frozen=True)
-class IngestionPolicy:
+class IngestionPolicy(ManifestModel):
     """Policy and risk metadata for an ingestible source."""
 
     usage_policy: UsagePolicy
@@ -78,8 +72,7 @@ class IngestionPolicy:
         return self.usage_policy == UsagePolicy.EVAL_ONLY
 
 
-@dataclass(frozen=True)
-class SampleCapConfig:
+class SampleCapConfig(ManifestModel):
     """Optional source-level sampling caps used by a staging or extraction step."""
 
     max_bytes_per_source: int | None = None
@@ -90,8 +83,7 @@ class SampleCapConfig:
     max_examples: int | None = None
 
 
-@dataclass(frozen=True)
-class StagingMetadata:
+class StagingMetadata(ManifestModel):
     """How a source is rendered into downstream text records.
 
     This block is the source -> text projection contract. Keep only fields
@@ -105,11 +97,10 @@ class StagingMetadata:
     split: str | None = None
     subset: str | None = None
     preserve_header: bool | None = None
-    metadata: dict[str, JsonValue] = field(default_factory=dict)
+    metadata: dict[str, JsonValue] = Field(default_factory=dict)
 
 
-@dataclass(frozen=True)
-class IngestionSourceManifest:
+class IngestionSourceManifest(ManifestModel):
     """Typed source manifest for a reusable ingestion registry entry."""
 
     dataset_key: str
@@ -123,13 +114,13 @@ class IngestionSourceManifest:
     staging: StagingMetadata
     epic_issue: int | None = None
     issue_numbers: tuple[int, ...] = ()
-    sample_caps: SampleCapConfig = field(default_factory=SampleCapConfig)
+    sample_caps: SampleCapConfig = Field(default_factory=SampleCapConfig)
     compressed_size_bytes: int | None = None
     rough_tokens_b: float | None = None
-    source_metadata: dict[str, JsonValue] = field(default_factory=dict)
+    source_metadata: dict[str, JsonValue] = Field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        payload = _json_ready(asdict(self))
+        payload = self.model_dump(mode="json")
         payload["policy"]["training_allowed"] = self.policy.training_allowed
         payload["policy"]["eval_only"] = self.policy.eval_only
         return payload
@@ -141,24 +132,22 @@ class IngestionSourceManifest:
         issue links, descriptive policy text, and other provenance-only fields
         so additive metadata evolution does not force unnecessary rebuilds.
         """
-        return _json_ready(
-            {
-                "dataset_key": self.dataset_key,
-                "slice_key": self.slice_key,
-                "source_label": self.source_label,
-                "source_urls": self.source_urls,
-                "source_format": self.source_format,
-                "surface_form": self.surface_form,
-                "policy": {
-                    "requires_sanitization": self.policy.requires_sanitization,
-                    "identity_treatment": self.policy.identity_treatment,
-                    "secret_redaction": self.policy.secret_redaction,
-                },
-                "staging": asdict(self.staging),
-                "sample_caps": asdict(self.sample_caps),
-                "source_metadata": self.source_metadata,
-            }
-        )
+        return {
+            "dataset_key": self.dataset_key,
+            "slice_key": self.slice_key,
+            "source_label": self.source_label,
+            "source_urls": list(self.source_urls),
+            "source_format": self.source_format,
+            "surface_form": self.surface_form,
+            "policy": {
+                "requires_sanitization": self.policy.requires_sanitization,
+                "identity_treatment": str(self.policy.identity_treatment),
+                "secret_redaction": str(self.policy.secret_redaction),
+            },
+            "staging": self.staging.model_dump(mode="json"),
+            "sample_caps": self.sample_caps.model_dump(mode="json"),
+            "source_metadata": self.source_metadata,
+        }
 
     def fingerprint(self) -> str:
         """Return the content hash used for cache keys and config validation."""
@@ -171,8 +160,7 @@ class IngestionSourceManifest:
         return hashlib.sha256(blob.encode("utf-8")).hexdigest()
 
 
-@dataclass(frozen=True)
-class MaterializedOutputMetadata:
+class MaterializedOutputMetadata(ManifestModel):
     """Runtime output metadata for a concrete staging or extraction run."""
 
     input_path: str
@@ -180,10 +168,10 @@ class MaterializedOutputMetadata:
     output_file: str
     record_count: int
     bytes_written: int
-    metadata: dict[str, JsonValue] = field(default_factory=dict)
+    metadata: dict[str, JsonValue] = Field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        return _json_ready(asdict(self))
+        return self.model_dump(mode="json")
 
 
 def render_ingestion_metadata(

--- a/lib/marin/src/marin/datakit/ingestion_manifest.py
+++ b/lib/marin/src/marin/datakit/ingestion_manifest.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import hashlib
 import json
 import posixpath
-from enum import StrEnum
+from enum import StrEnum, auto
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -32,24 +32,24 @@ class ManifestModel(BaseModel):
 class UsagePolicy(StrEnum):
     """Policy gate for whether a source is allowed in training or eval."""
 
-    TRAINING_ALLOWED = "training_allowed"
-    EVAL_ONLY = "eval_only"
-    BLOCKED = "blocked"
+    TRAINING_ALLOWED = auto()
+    EVAL_ONLY = auto()
+    BLOCKED = auto()
 
 
 class IdentityTreatment(StrEnum):
     """How person-identifying strings should be handled during ingestion."""
 
-    PRESERVE = "preserve"
-    PSEUDONYMIZE = "pseudonymize"
-    DROP = "drop"
+    PRESERVE = auto()
+    PSEUDONYMIZE = auto()
+    DROP = auto()
 
 
 class SecretRedaction(StrEnum):
     """Whether source text requires secret redaction before downstream use."""
 
-    NONE = "none"
-    REQUIRED = "required"
+    NONE = auto()
+    REQUIRED = auto()
 
 
 class IngestionPolicy(ManifestModel):

--- a/lib/marin/src/marin/datakit/ingestion_manifest.py
+++ b/lib/marin/src/marin/datakit/ingestion_manifest.py
@@ -1,0 +1,183 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed source manifests for small ingestion registries and sidecar metadata."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import posixpath
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from rigging.filesystem import open_url
+from zephyr.writers import atomic_rename
+
+from marin.utils import fsspec_mkdirs
+
+JsonScalar = str | int | float | bool | None
+JsonValue = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+
+
+def _json_ready(value: Any) -> Any:
+    if isinstance(value, StrEnum):
+        return str(value)
+    if isinstance(value, tuple):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, list):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _json_ready(item) for key, item in value.items()}
+    return value
+
+
+class UsagePolicy(StrEnum):
+    """Policy gate for whether a source is allowed in training or eval."""
+
+    TRAINING_ALLOWED = "training_allowed"
+    EVAL_ONLY = "eval_only"
+    BLOCKED = "blocked"
+
+
+class IdentityTreatment(StrEnum):
+    """How person-identifying strings should be handled during ingestion."""
+
+    PRESERVE = "preserve"
+    PSEUDONYMIZE = "pseudonymize"
+    DROP = "drop"
+
+
+class SecretRedaction(StrEnum):
+    """Whether source text requires secret redaction before downstream use."""
+
+    NONE = "none"
+    REQUIRED = "required"
+
+
+@dataclass(frozen=True)
+class IngestionPolicy:
+    """Policy and risk metadata for an ingestible source."""
+
+    usage_policy: UsagePolicy
+    use_policy: str
+    requires_sanitization: bool = False
+    identity_treatment: IdentityTreatment = IdentityTreatment.PRESERVE
+    secret_redaction: SecretRedaction = SecretRedaction.NONE
+    contamination_risk: str = ""
+    provenance_notes: str = ""
+
+    @property
+    def training_allowed(self) -> bool:
+        return self.usage_policy == UsagePolicy.TRAINING_ALLOWED
+
+    @property
+    def eval_only(self) -> bool:
+        return self.usage_policy == UsagePolicy.EVAL_ONLY
+
+
+@dataclass(frozen=True)
+class SampleCapConfig:
+    """Optional source-level sampling caps used by a staging or extraction step."""
+
+    max_bytes_per_source: int | None = None
+    max_bytes_per_document: int | None = None
+    max_records: int | None = None
+    max_files: int | None = None
+    max_members: int | None = None
+    max_examples: int | None = None
+
+
+@dataclass(frozen=True)
+class StagingMetadata:
+    """How a source is rendered into downstream text records."""
+
+    transform_name: str
+    serializer_name: str | None = None
+    split: str | None = None
+    subset: str | None = None
+    preserve_header: bool | None = None
+    output_filename: str = "staged.jsonl.gz"
+    record_provenance_fields: tuple[str, ...] = ()
+    metadata: dict[str, JsonValue] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class IngestionSourceManifest:
+    """Typed source manifest for a reusable ingestion registry entry."""
+
+    dataset_key: str
+    slice_key: str
+    source_label: str
+    source_urls: tuple[str, ...]
+    source_license: str
+    source_format: str
+    surface_form: str
+    policy: IngestionPolicy
+    staging: StagingMetadata
+    epic_issue: int | None = None
+    issue_numbers: tuple[int, ...] = ()
+    sample_caps: SampleCapConfig = field(default_factory=SampleCapConfig)
+    compressed_size_bytes: int | None = None
+    rough_tokens_b: float | None = None
+    source_metadata: dict[str, JsonValue] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = _json_ready(asdict(self))
+        payload["policy"]["training_allowed"] = self.policy.training_allowed
+        payload["policy"]["eval_only"] = self.policy.eval_only
+        return payload
+
+    def fingerprint(self) -> str:
+        blob = json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class MaterializedOutputMetadata:
+    """Runtime output metadata for a concrete staging or extraction run."""
+
+    input_path: str
+    output_path: str
+    output_file: str
+    record_count: int
+    bytes_written: int
+    metadata: dict[str, JsonValue] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return _json_ready(asdict(self))
+
+
+def render_ingestion_metadata(
+    manifest: IngestionSourceManifest,
+    materialized_output: MaterializedOutputMetadata,
+) -> dict[str, Any]:
+    """Render the sidecar payload for a materialized source."""
+
+    return {
+        "schema_version": 1,
+        "manifest_fingerprint": manifest.fingerprint(),
+        "source_manifest": manifest.to_dict(),
+        "materialized_output": materialized_output.to_dict(),
+    }
+
+
+def write_ingestion_metadata_json(
+    *,
+    manifest: IngestionSourceManifest,
+    materialized_output: MaterializedOutputMetadata,
+    metadata_filename: str = "metadata.json",
+) -> str:
+    """Write ``metadata.json`` for a materialized source and return its path."""
+
+    fsspec_mkdirs(materialized_output.output_path, exist_ok=True)
+    metadata_path = posixpath.join(materialized_output.output_path, metadata_filename)
+    payload = render_ingestion_metadata(manifest, materialized_output)
+
+    with atomic_rename(metadata_path) as temp_path:
+        with open_url(temp_path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+
+    return metadata_path

--- a/lib/marin/src/marin/datakit/ingestion_manifest.py
+++ b/lib/marin/src/marin/datakit/ingestion_manifest.py
@@ -19,6 +19,7 @@ from marin.utils import fsspec_mkdirs
 
 JsonScalar = str | int | float | bool | None
 JsonValue = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+INGESTION_METADATA_SCHEMA_VERSION = 1
 
 
 def _json_ready(value: Any) -> Any:
@@ -91,15 +92,19 @@ class SampleCapConfig:
 
 @dataclass(frozen=True)
 class StagingMetadata:
-    """How a source is rendered into downstream text records."""
+    """How a source is rendered into downstream text records.
+
+    This block is the source -> text projection contract. Keep only fields
+    that affect or meaningfully describe the emitted text surface here.
+    Filesystem plumbing and runtime output details belong in
+    ``MaterializedOutputMetadata`` instead.
+    """
 
     transform_name: str
     serializer_name: str | None = None
     split: str | None = None
     subset: str | None = None
     preserve_header: bool | None = None
-    output_filename: str = "staged.jsonl.gz"
-    record_provenance_fields: tuple[str, ...] = ()
     metadata: dict[str, JsonValue] = field(default_factory=dict)
 
 
@@ -129,7 +134,39 @@ class IngestionSourceManifest:
         payload["policy"]["eval_only"] = self.policy.eval_only
         return payload
 
+    def content_fingerprint_payload(self) -> dict[str, Any]:
+        """Return the subset of manifest fields that can affect staged bytes.
+
+        This payload is for executor hashing and config validation. It excludes
+        issue links, descriptive policy text, and other provenance-only fields
+        so additive metadata evolution does not force unnecessary rebuilds.
+        """
+        return _json_ready(
+            {
+                "dataset_key": self.dataset_key,
+                "slice_key": self.slice_key,
+                "source_label": self.source_label,
+                "source_urls": self.source_urls,
+                "source_format": self.source_format,
+                "surface_form": self.surface_form,
+                "policy": {
+                    "requires_sanitization": self.policy.requires_sanitization,
+                    "identity_treatment": self.policy.identity_treatment,
+                    "secret_redaction": self.policy.secret_redaction,
+                },
+                "staging": asdict(self.staging),
+                "sample_caps": asdict(self.sample_caps),
+                "source_metadata": self.source_metadata,
+            }
+        )
+
     def fingerprint(self) -> str:
+        """Return the content hash used for cache keys and config validation."""
+        blob = json.dumps(self.content_fingerprint_payload(), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+    def provenance_fingerprint(self) -> str:
+        """Return an exact hash over the full manifest payload."""
         blob = json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
         return hashlib.sha256(blob.encode("utf-8")).hexdigest()
 
@@ -156,8 +193,9 @@ def render_ingestion_metadata(
     """Render the sidecar payload for a materialized source."""
 
     return {
-        "schema_version": 1,
-        "manifest_fingerprint": manifest.fingerprint(),
+        "schema_version": INGESTION_METADATA_SCHEMA_VERSION,
+        "manifest_fingerprint": manifest.provenance_fingerprint(),
+        "content_fingerprint": manifest.fingerprint(),
         "source_manifest": manifest.to_dict(),
         "materialized_output": materialized_output.to_dict(),
     }

--- a/tests/datakit/test_ingestion_manifest.py
+++ b/tests/datakit/test_ingestion_manifest.py
@@ -1,0 +1,90 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from dataclasses import replace
+
+from marin.datakit.ingestion_manifest import (
+    IdentityTreatment,
+    IngestionPolicy,
+    IngestionSourceManifest,
+    MaterializedOutputMetadata,
+    SampleCapConfig,
+    SecretRedaction,
+    StagingMetadata,
+    UsagePolicy,
+    render_ingestion_metadata,
+    write_ingestion_metadata_json,
+)
+
+
+def _manifest() -> IngestionSourceManifest:
+    return IngestionSourceManifest(
+        dataset_key="GEM/totto",
+        slice_key="structured_text/totto/validation",
+        source_label="totto:validation",
+        source_urls=("https://huggingface.co/datasets/GEM/totto",),
+        source_license="CC BY-SA 3.0",
+        source_format="huggingface_parquet_table_records",
+        surface_form="wikipedia_table_tsv_plus_summary_sentence",
+        policy=IngestionPolicy(
+            usage_policy=UsagePolicy.EVAL_ONLY,
+            use_policy="Eval-only probe slice.",
+            requires_sanitization=False,
+            identity_treatment=IdentityTreatment.PRESERVE,
+            secret_redaction=SecretRedaction.NONE,
+            contamination_risk="high: direct eval contamination if reused for training",
+            provenance_notes="Pinned HF revision.",
+        ),
+        staging=StagingMetadata(
+            transform_name="stage_table_record_source",
+            serializer_name="totto",
+            split="validation",
+            output_filename="staged.jsonl.gz",
+            record_provenance_fields=("dataset", "split", "serializer", "index"),
+        ),
+        epic_issue=5005,
+        issue_numbers=(5059,),
+        sample_caps=SampleCapConfig(max_bytes_per_source=30 * 1024 * 1024),
+        compressed_size_bytes=123_456,
+        rough_tokens_b=0.012,
+        source_metadata={"hf_revision": "abc123"},
+    )
+
+
+def test_manifest_fingerprint_changes_when_policy_metadata_changes():
+    manifest = _manifest()
+    updated = replace(
+        manifest,
+        policy=replace(
+            manifest.policy,
+            contamination_risk="medium: still held out, but with different review outcome",
+        ),
+    )
+
+    assert manifest.fingerprint() != updated.fingerprint()
+
+
+def test_write_ingestion_metadata_json_includes_policy_and_runtime_fields(tmp_path):
+    manifest = _manifest()
+    materialized_output = MaterializedOutputMetadata(
+        input_path="raw://totto",
+        output_path=str(tmp_path),
+        output_file=str(tmp_path / "staged.jsonl.gz"),
+        record_count=17,
+        bytes_written=4096,
+        metadata={"source_file_count": 3},
+    )
+    metadata_path = write_ingestion_metadata_json(
+        manifest=manifest,
+        materialized_output=materialized_output,
+    )
+
+    payload = json.loads((tmp_path / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata_path == str(tmp_path / "metadata.json")
+    assert payload == render_ingestion_metadata(manifest, materialized_output)
+    assert payload["source_manifest"]["policy"]["training_allowed"] is False
+    assert payload["source_manifest"]["policy"]["eval_only"] is True
+    assert payload["source_manifest"]["compressed_size_bytes"] == 123_456
+    assert payload["source_manifest"]["rough_tokens_b"] == 0.012
+    assert payload["materialized_output"]["record_count"] == 17

--- a/tests/datakit/test_ingestion_manifest.py
+++ b/tests/datakit/test_ingestion_manifest.py
@@ -13,7 +13,6 @@ from marin.datakit.ingestion_manifest import (
     SecretRedaction,
     StagingMetadata,
     UsagePolicy,
-    render_ingestion_metadata,
     write_ingestion_metadata_json,
 )
 
@@ -99,11 +98,23 @@ def test_write_ingestion_metadata_json_includes_policy_and_runtime_fields(tmp_pa
 
     payload = json.loads((tmp_path / "metadata.json").read_text(encoding="utf-8"))
     assert metadata_path == str(tmp_path / "metadata.json")
-    assert payload == render_ingestion_metadata(manifest, materialized_output)
+    assert set(payload) == {
+        "schema_version",
+        "manifest_fingerprint",
+        "content_fingerprint",
+        "source_manifest",
+        "materialized_output",
+    }
+    assert payload["schema_version"] == 1
     assert payload["manifest_fingerprint"] == manifest.provenance_fingerprint()
     assert payload["content_fingerprint"] == manifest.fingerprint()
+    assert payload["source_manifest"]["dataset_key"] == "GEM/totto"
     assert payload["source_manifest"]["policy"]["training_allowed"] is False
     assert payload["source_manifest"]["policy"]["eval_only"] is True
     assert payload["source_manifest"]["compressed_size_bytes"] == 123_456
     assert payload["source_manifest"]["rough_tokens_b"] == 0.012
+    assert payload["source_manifest"]["staging"]["serializer_name"] == "totto"
+    assert payload["source_manifest"]["staging"]["metadata"]["output_filename"] == "staged.jsonl.gz"
+    assert payload["materialized_output"]["output_file"] == str(tmp_path / "staged.jsonl.gz")
     assert payload["materialized_output"]["record_count"] == 17
+    assert payload["materialized_output"]["metadata"]["source_file_count"] == 3

--- a/tests/datakit/test_ingestion_manifest.py
+++ b/tests/datakit/test_ingestion_manifest.py
@@ -40,8 +40,10 @@ def _manifest() -> IngestionSourceManifest:
             transform_name="stage_table_record_source",
             serializer_name="totto",
             split="validation",
-            output_filename="staged.jsonl.gz",
-            record_provenance_fields=("dataset", "split", "serializer", "index"),
+            metadata={
+                "output_filename": "staged.jsonl.gz",
+                "provenance_fields": ["dataset", "split", "serializer", "index"],
+            },
         ),
         epic_issue=5005,
         issue_numbers=(5059,),
@@ -52,7 +54,7 @@ def _manifest() -> IngestionSourceManifest:
     )
 
 
-def test_manifest_fingerprint_changes_when_policy_metadata_changes():
+def test_content_fingerprint_ignores_provenance_only_metadata():
     manifest = _manifest()
     updated = replace(
         manifest,
@@ -62,7 +64,22 @@ def test_manifest_fingerprint_changes_when_policy_metadata_changes():
         ),
     )
 
+    assert manifest.fingerprint() == updated.fingerprint()
+    assert manifest.provenance_fingerprint() != updated.provenance_fingerprint()
+
+
+def test_content_fingerprint_changes_when_text_projection_changes():
+    manifest = _manifest()
+    updated = replace(
+        manifest,
+        staging=replace(
+            manifest.staging,
+            serializer_name="wikitablequestions",
+        ),
+    )
+
     assert manifest.fingerprint() != updated.fingerprint()
+    assert manifest.provenance_fingerprint() != updated.provenance_fingerprint()
 
 
 def test_write_ingestion_metadata_json_includes_policy_and_runtime_fields(tmp_path):
@@ -83,6 +100,8 @@ def test_write_ingestion_metadata_json_includes_policy_and_runtime_fields(tmp_pa
     payload = json.loads((tmp_path / "metadata.json").read_text(encoding="utf-8"))
     assert metadata_path == str(tmp_path / "metadata.json")
     assert payload == render_ingestion_metadata(manifest, materialized_output)
+    assert payload["manifest_fingerprint"] == manifest.provenance_fingerprint()
+    assert payload["content_fingerprint"] == manifest.fingerprint()
     assert payload["source_manifest"]["policy"]["training_allowed"] is False
     assert payload["source_manifest"]["policy"]["eval_only"] is True
     assert payload["source_manifest"]["compressed_size_bytes"] == 123_456

--- a/tests/datakit/test_ingestion_manifest.py
+++ b/tests/datakit/test_ingestion_manifest.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from dataclasses import replace
 
 from marin.datakit.ingestion_manifest import (
     IdentityTreatment,
@@ -55,12 +54,12 @@ def _manifest() -> IngestionSourceManifest:
 
 def test_content_fingerprint_ignores_provenance_only_metadata():
     manifest = _manifest()
-    updated = replace(
-        manifest,
-        policy=replace(
-            manifest.policy,
-            contamination_risk="medium: still held out, but with different review outcome",
-        ),
+    updated = manifest.model_copy(
+        update={
+            "policy": manifest.policy.model_copy(
+                update={"contamination_risk": "medium: still held out, but with different review outcome"}
+            )
+        }
     )
 
     assert manifest.fingerprint() == updated.fingerprint()
@@ -69,12 +68,8 @@ def test_content_fingerprint_ignores_provenance_only_metadata():
 
 def test_content_fingerprint_changes_when_text_projection_changes():
     manifest = _manifest()
-    updated = replace(
-        manifest,
-        staging=replace(
-            manifest.staging,
-            serializer_name="wikitablequestions",
-        ),
+    updated = manifest.model_copy(
+        update={"staging": manifest.staging.model_copy(update={"serializer_name": "wikitablequestions"})}
     )
 
     assert manifest.fingerprint() != updated.fingerprint()


### PR DESCRIPTION
Add a typed ingestion source manifest and metadata writer so the long-tail eval branches share one policy and provenance schema instead of each inventing one. This captures source policy, sample caps, staging metadata, and runtime sidecars for follow-on branches like #5121 and #5129. Part of #5005