### PR TITLE
[codex] docs: retire remaining Ray references

### DIFF
--- a/.agents/docs/zephyr-migration.md
+++ b/.agents/docs/zephyr-migration.md
@@ -1,14 +1,10 @@
-# Zephyr Migration Patterns
+# Archived Zephyr Migration Patterns
 
-**Last Updated**: 2025-01-07
+**Last Updated**: 2026-04-27
 
-## Status Summary
+This document is archived historical guidance for recognizing old Ray-style data-processing loops and replacing them with Zephyr patterns. Ray is no longer a supported Marin execution backend, and this document predates the current `ZephyrContext` API. For current Zephyr usage, read `lib/zephyr/README.md` and `lib/zephyr/AGENTS.md`.
 
-**Completed**: 19 files migrated ✅
-**Remaining**: 33 files to migrate
-**Not Suitable**: ~39 files (TPU orchestration, RL training, stateful orchestration, infrastructure, etc.)
-
-This document describes concrete patterns for migrating Ray boilerplate to zephyr. Each section shows a real codebase example with before/after code.
+The examples below intentionally preserve Ray-shaped "before" snippets because they document what the migration removed.
 
 ## Backend Configuration: `flow_backend()` vs `create_backend()`
 

--- a/.agents/skills/design-doc/SKILL.md
+++ b/.agents/skills/design-doc/SKILL.md
@@ -77,13 +77,13 @@ Include test approach as one bullet. Don't include detailed phases, substeps, fi
 
 The Executor framework (`lib/marin/src/marin/execution/executor.py`) provides no visibility into step execution times. When pipelines run slow (e.g., 6 hours for 50 steps), developers can't identify bottlenecks without manual instrumentation.
 
-**Current behavior**: `_launch_step()` at line 664 launches Ray tasks but never records timing. `ExecutorStepInfo` (line 324) has no timing fields.
+**Current behavior**: `_launch_step()` at line 664 submits distributed work but never records timing. `ExecutorStepInfo` (line 324) has no timing fields.
 
 ## Goals
 
 - Capture execution time per step with <1% overhead
 - Expose timing in `.executor_info` JSON and status events
-- Distinguish Ray scheduling overhead from actual execution time
+- Distinguish scheduling overhead from actual execution time
 - Backwards compatible (existing experiments unchanged)
 
 **Non-goals**: Distributed tracing, real-time metrics, CPU/memory profiling
@@ -143,12 +143,12 @@ def _create_timed_wrapper(self, original_fn, output_path):
 
 - Wrapper overhead <1% for typical multi-second steps
 - Uses existing status infrastructure (no new systems)
-- `total_duration_seconds` includes Ray scheduling overhead; `duration_seconds` is execution only
+- `total_duration_seconds` includes scheduling overhead; `duration_seconds` is execution only
 
 ## Future Work
 
 - Pipeline visualization (Gantt charts)
-- Integration with Ray tracing for distributed view
+- Integration with executor or Iris traces for distributed view
 - CPU/memory metrics per step
 - Alerting on timing regressions
 

--- a/.agents/skills/logscan/SKILL.md
+++ b/.agents/skills/logscan/SKILL.md
@@ -13,7 +13,7 @@ be used independently or piped together.
 
 - Log files too large to read in context (>1000 lines)
 - Searching for errors, anomalies, or patterns in job/worker/controller logs
-- Triaging failures from Iris, Ray, Zephyr, or training jobs
+- Triaging failures from Iris, Zephyr, or training jobs
 - Any time you need to understand what happened in a big log file
 
 ## Prerequisites

--- a/docs/design/actor-lro.md
+++ b/docs/design/actor-lro.md
@@ -144,7 +144,7 @@ existing `Call` RPC stays in the proto — no breaking change.
 
 ## Notes
 
-- **Backwards compatible** — existing `Call` RPC stays for synchronous use and other backends (Ray, local)
+- **Backwards compatible** — existing `Call` RPC stays for synchronous use and the local backend
 - **No persistence** — operations are in-memory; server restart loses them. Acceptable since Iris already handles job-level restarts.
 - **Cancellation is cooperative** — `CancelOperation` sets an event; the actor method must check it. For methods that don't check, cancellation just marks the operation as cancelled and discards the result.
 - **Polling overhead** — one short RPC per `poll_interval` seconds. At 1s interval, negligible for hour-long pipelines.

--- a/docs/dev-guide/tpu_observability.md
+++ b/docs/dev-guide/tpu_observability.md
@@ -15,9 +15,9 @@ This document serves as the central reference for operational observability rega
 The CLI commands below provide the most accurate view of TPU state. For exact current counts, prefer zonal `tpu-vm list`; use Cloud Asset Inventory for cross-zone aggregation (slight lag). Dashboard metrics may lag or underreport.
 
 ### Quick Fleet Summary
-Get a quick summary of READY TPUs across all zones:
+Get a quick summary of READY TPU nodes across all zones:
 
-*Note: This uses Cloud Asset Inventory for cross-zone aggregation. It may lag slightly; cores are inferred from the `ray-user-node-type` label (estimate). Use `tpu-vm list` for ground truth within a specific zone.*
+*Note: This uses Cloud Asset Inventory for cross-zone aggregation. It may lag slightly. Use `tpu-vm list` for ground-truth core counts within a specific zone.*
 ```shell
 gcloud asset search-all-resources \
   --scope=projects/hai-gcp-models \
@@ -29,23 +29,16 @@ gcloud asset search-all-resources \
       .[]
       | select(.state=="READY")
       | {
-          zone: .location,
-          cores: (
-            try (
-              .labels["ray-user-node-type"]
-              | capture("_(?<n>[0-9]+)$").n
-              | tonumber
-            ) catch 0
-          )
+          zone: .location
         }
     ]
     | sort_by(.zone)
     | group_by(.zone)
-    | map({zone: .[0].zone, nodes: length, cores: (map(.cores) | add)})
-    | sort_by(.cores)
+    | map({zone: .[0].zone, nodes: length})
+    | sort_by(.nodes)
     | reverse
     | .[]
-    | "\(.zone): \(.nodes) READY nodes, \(.cores) READY cores"
+    | "\(.zone): \(.nodes) READY nodes"
   '
 ```
 
@@ -179,7 +172,7 @@ gcloud logging read \
 
 ### Check Specific TPU Node Status
 ```shell
-NODE_NAME="ray-marin-us-central2-worker-xxxxx-tpu"
+NODE_NAME="<tpu-node-name>"
 ZONE="us-central2-b"
 
 gcloud compute tpus tpu-vm describe "$NODE_NAME" \
@@ -194,7 +187,7 @@ gcloud asset search-all-resources \
   --scope=projects/hai-gcp-models \
   --asset-types=tpu.googleapis.com/Node \
   --limit=5000 \
-  --format="table(displayName, location, labels.ray-user-node-type, state)"
+  --format="table(displayName, location, labels.iris-marin-scale-group, labels.iris-marin-managed, state)"
 ```
 
 # Dashboard
@@ -247,7 +240,7 @@ Fleet size over time = periodic count of READY TPU nodes; not `duty_cycle` serie
 
 ### Detecting Stockout Periods
 Look at **TPU Acquisition Success Rate**:
-- **Normal operation**: 20-30% success rate (Ray retries are expected)
+- **Normal operation**: 20-30% success rate (autoscaler retries are expected)
 - **Stockout**: <10% success rate sustained for >1 hour
 - **Easy period**: >40% success rate
 

--- a/docs/tutorials/train_test_overlap.md
+++ b/docs/tutorials/train_test_overlap.md
@@ -33,7 +33,7 @@ The system uses a two-step process:
 
 - Make sure you've followed the [installation guide](installation.md) to do the basic installation.
 - Access to your training and evaluation datasets
-- Ray cluster set up (if running distributed)
+- Iris cluster access (if running distributed)
 
 ### Running on Existing Datasets
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -37,26 +37,26 @@ abstraction that handles parallelism and fault tolerance automatically.
 ### Quick Example
 
 ```python
-from zephyr import Dataset, flow_backend
+from zephyr import Dataset, ZephyrContext
 
 def process_file(input_path: str, output_path: str) -> None:
     # Your processing logic here - no manual worker orchestration needed
     ...
 
 def main():
-    backend = flow_backend()  # Backend configured via CLI flags
+    ctx = ZephyrContext(max_workers=100)
     pipeline = (
         Dataset.from_list(input_files)
-        .filter(lambda f: not output_exists(f))
-        .map(lambda f: process_file(f["input"], f["output"]))
+        .filter(lambda task: not output_exists(task["output"]))
+        .map(lambda task: process_file(task["input"], task["output"]))
     )
-    list(backend.execute(pipeline))
+    ctx.execute(pipeline)
 ```
 
 ### Documentation
 
 - **Quick start**: See `lib/zephyr/README.md`
-- **Design & API**: See `lib/zephyr/docs/design.md`
+- **Operational notes**: See `lib/zephyr/OPS.md`
 - **Archived migration patterns**: See `.agents/docs/zephyr-migration.md` for historical examples of replacing legacy distributed loops with Zephyr patterns
 
 ### Design Principles

--- a/infra/README.md
+++ b/infra/README.md
@@ -40,7 +40,7 @@ abstraction that handles parallelism and fault tolerance automatically.
 from zephyr import Dataset, flow_backend
 
 def process_file(input_path: str, output_path: str) -> None:
-    # Your processing logic here - no @ray.remote needed
+    # Your processing logic here - no manual worker orchestration needed
     ...
 
 def main():
@@ -57,7 +57,7 @@ def main():
 
 - **Quick start**: See `lib/zephyr/README.md`
 - **Design & API**: See `lib/zephyr/docs/design.md`
-- **Migration patterns**: See `.agents/docs/zephyr-migration.md` for patterns like bounded parallel map, flat_map for file processing, and nested parallelism
+- **Archived migration patterns**: See `.agents/docs/zephyr-migration.md` for historical examples of replacing legacy distributed loops with Zephyr patterns
 
 ### Design Principles
 

--- a/lib/iris/AGENTS.md
+++ b/lib/iris/AGENTS.md
@@ -1,6 +1,6 @@
 # Iris Agent Notes
 
-Distributed job orchestration replacing Ray with simpler primitives. Start with the shared instructions in `/AGENTS.md`; only Iris-specific conventions are below.
+Distributed job orchestration for Marin. Start with the shared instructions in `/AGENTS.md`; only Iris-specific conventions are below.
 
 ## Key Docs
 

--- a/lib/iris/README.md
+++ b/lib/iris/README.md
@@ -1,6 +1,6 @@
 # Iris
 
-Distributed job orchestration replacing Ray with simpler primitives.
+Distributed job orchestration for Marin.
 
 ## Quick Start
 

--- a/lib/iris/src/iris/cluster/client/bundle.py
+++ b/lib/iris/src/iris/cluster/client/bundle.py
@@ -136,10 +136,10 @@ def create_workspace_dir(
     *,
     exclude: re.Pattern[str] | None = None,
 ) -> str:
-    """Copy workspace files into a temporary directory for Ray's working_dir.
+    """Copy workspace files into a temporary directory for upload.
 
-    Ray's JobSubmissionClient expects a directory path: it zips and uploads it
-    internally. The temp directory is cleaned up at process exit via atexit.
+    The Iris client zips and uploads the directory. The temp directory is
+    cleaned up at process exit via atexit.
     """
     workspace = Path(workspace)
     files = collect_workspace_files(workspace, exclude=exclude)

--- a/lib/levanter/docs/Training-On-Your-Data.md
+++ b/lib/levanter/docs/Training-On-Your-Data.md
@@ -194,7 +194,7 @@ end of documents.
 
 ### Online Preprocessing
 
-We have a sophisticated caching mechanism using [Ray](https://docs.ray.io/en/latest/)
+We have a sophisticated caching mechanism using Zephyr-backed preprocessing
 that builds a cache of preprocessed data on the fly. Online caching happens transparently
 in the background, using the mostly-idle CPU-cores of the machine(s) you are training on.
 

--- a/lib/levanter/docs/Training-On-Your-Data.md
+++ b/lib/levanter/docs/Training-On-Your-Data.md
@@ -183,27 +183,25 @@ validation data.
 
 ## Data Preprocessing
 
-Levanter supports both online and offline preprocessing. Online preprocessing is done on-the-fly
-during training. With online preprocessing, you don't need to think about preprocessing your data
-except to make sure it's in the right format and where you'd like to store the cached preprocessing
-results.
+Levanter supports both automatic and direct cache construction. With automatic cache construction,
+you don't need to think about preprocessing your data except to make sure it's in the right format
+and where you'd like to store the cached preprocessing results.
 
 Our data loading pipeline will automatically break and concatenate documents into chunks equal
 to the model's `seq_len` parameter. It will also automatically add special tokens to the
 end of documents.
 
-### Online Preprocessing
+### Automatic Cache Construction
 
 We have a sophisticated caching mechanism using Zephyr-backed preprocessing
-that builds a cache of preprocessed data on the fly. Online caching happens transparently
-in the background, using the mostly-idle CPU-cores of the machine(s) you are training on.
+that builds a cache of preprocessed data when a training run needs an uncached dataset.
 
 The cache that is built is fully reproducible, and can be used for future training runs.
-Training will start as soon as the system has the data it needs.
+Training will use the cache once construction and consolidation complete.
 
 ### Direct Cache Construction
 
-For offline preprocessing, use direct cache construction. This is useful if you want to build caches without launching training, or if you need a custom cache format.
+Use direct cache construction if you want to build caches without launching training, or if you need a custom cache format.
 See our guide on [Direct Cache Construction](./guides/Direct-Cache-Construction.md) for more details.
 
 

--- a/lib/levanter/docs/design/Data-Loader-Design.md
+++ b/lib/levanter/docs/design/Data-Loader-Design.md
@@ -95,27 +95,13 @@ In code, this is modeled in [levanter.store.TreeStore][].
 
 ### Cache Construction
 
-We use Ray to handle the construction of the cache. There are 4 types of processes/actors that we create using Ray:
+We use Zephyr to handle cache construction. The cache builder turns each input shard into a Zephyr task, each task
+reads and preprocesses its shard, and each task writes a temporary shard cache. After all shard caches are complete,
+Levanter consolidates them into the final `TreeCache` and writes the cache ledger.
 
-- `_TreeStoreCacheBuilder`: This actor is responsible for building the cache. It forks off actors for reading
-  shards and processing documents. It acts as a callback for these processes.
-- `_OrderedCacheWriter`: This actor is responsible for writing to the cache. It is responsible for writing the
-  processed documents to the cache in the correct order.
-- `WorkQueueDispatcherActor`: This actor is responsible for reading batches of documents from a group of shards. It dispatches
-  documents to a group of processors, which are responsible for processing the documents.
-- `_BatchProcessorQueue`: This actor is responsible for managing the queue of batches of documents to be processed. It
-  actually calls the processors to process the documents and then forwards the results to the writer.
-
-The basic flow is that the builder forks off a bunch of `WorkQueueDispatcherActor`s, which read from the shards and
-dispatch the documents to the processors. The processors process the documents and send the results to the writer,
-which writes them to the cache.
-
-The writer is responsible for writing the documents to the cache in the correct order. In particular, fix a batch
-size B. The writer writes the documents in batches of size B, round-robin from the shards. Once a shard is exhausted,
-it is removed from the list of shards.
-
-The writer maintains a "ledger" of the cache, which has the number of documents processed in each shard, as well as
-whether or not the shard is done. This ledger is used for resuming cache construction.
+The shard caches preserve deterministic per-shard order. Consolidation appends the shard caches into the final cache
+and writes a ledger containing the number of documents processed in each shard and whether each shard is complete. This
+ledger is used for resuming cache construction.
 
 ## Datasets and the Data Loader
 

--- a/lib/levanter/docs/faq.md
+++ b/lib/levanter/docs/faq.md
@@ -53,14 +53,3 @@ into your Google Cloud account on the machine:
 gcloud auth login
 gcloud auth application-default login
 ```
-
-## Ray Issues
-
-### RuntimeError: Failed to start ray head with exit code 256
-
-Probably ray is still running and Levanter didn't clean up the ray cluster (or another user is using the same port).
-If the former, you can kill the ray cluster with `ray stop`. If the latter, there's not much you can do about it.
-[Ray doesn't work super well when multiple users are running Ray on the same machine.](https://github.com/ray-project/ray/issues/20634)
-Try docker?
-
-Another reason could be the ports are not open in your VM. If using GCP, check the firewall settings of your VPC and expose port `61964` (used by ray).

--- a/lib/levanter/docs/guides/Direct-Cache-Construction.md
+++ b/lib/levanter/docs/guides/Direct-Cache-Construction.md
@@ -2,10 +2,10 @@
 
 (See also [Training on Your Own Data](../Training-On-Your-Data.md) for more details on training on your own data.)
 
-Levanter typically handles cache construction automatically, but if you have custom preprocessing logic or Ray isn't
-working for you for some reason, you can directly construct a cache of preprocessed data.
+Levanter typically handles cache construction automatically, but if you have custom preprocessing logic or need a
+scripted one-off cache build, you can directly construct a cache of preprocessed data.
 
-You can directly construct a cache of preprocessed data without using Ray. To do so, you can use [levanter.store.SerialCacheWriter](https://github.com/stanford-crfm/levanter/blob/main/src/levanter/store/cache.py)
+You can directly construct a cache of preprocessed data without going through the automatic Zephyr-backed cache builder. To do so, you can use [levanter.store.SerialCacheWriter](https://github.com/stanford-crfm/levanter/blob/main/src/levanter/store/cache.py)
 to write batches directly. Here's an example:
 
 ```python

--- a/lib/levanter/docs/guides/Training-Data-Guide.md
+++ b/lib/levanter/docs/guides/Training-Data-Guide.md
@@ -201,7 +201,7 @@ Run with:
 python -m levanter.main.train_lm --config_path my_config.yaml
 ```
 
-The cache will build on-the-fly using Ray, and training will begin as soon as data is ready.
+The cache will build on-the-fly using Levanter's Zephyr-backed preprocessing pipeline, and training will begin as soon as data is ready.
 
 ---
 

--- a/lib/levanter/docs/guides/Training-Data-Guide.md
+++ b/lib/levanter/docs/guides/Training-Data-Guide.md
@@ -201,7 +201,7 @@ Run with:
 python -m levanter.main.train_lm --config_path my_config.yaml
 ```
 
-The cache will build on-the-fly using Levanter's Zephyr-backed preprocessing pipeline, and training will begin as soon as data is ready.
+If the configured cache is missing, Levanter will first build it using the Zephyr-backed preprocessing pipeline. Training will use the cache after construction and consolidation complete.
 
 ---
 

--- a/lib/levanter/docs/guides/Training-On-Audio-Data.md
+++ b/lib/levanter/docs/guides/Training-On-Audio-Data.md
@@ -81,7 +81,7 @@ so it can transparently handle compressed files and files in cloud storage (like
 
 
 ### Data Preprocessing
-Using Levanter's Zephyr-backed preprocessing and caching, you can apply further tokenization and feature extraction in the background while your model is training.
+Using Levanter's Zephyr-backed preprocessing and caching, you can apply further tokenization and feature extraction while building the cache that training will consume.
 
 By default, you can define both the `tokenizer` and `preprocessor` from HuggingFace. By default, if no tokenizer is provided Levanter will fall back to the one defined by the `preprocessor`. Regardless of the tokenization, the Pre-Processor will always be used to convert the time-domain audio data into the expected input for your model, such as Log-Mel-Spectrograms for Whisper.
 

--- a/lib/levanter/docs/guides/Training-On-Audio-Data.md
+++ b/lib/levanter/docs/guides/Training-On-Audio-Data.md
@@ -81,7 +81,7 @@ so it can transparently handle compressed files and files in cloud storage (like
 
 
 ### Data Preprocessing
-Using Levanter's [Ray](https://docs.ray.io/en/latest/) based pre-processing and caching, you can apply further tokenization and feature extraction in the background while your model is training.
+Using Levanter's Zephyr-backed preprocessing and caching, you can apply further tokenization and feature extraction in the background while your model is training.
 
 By default, you can define both the `tokenizer` and `preprocessor` from HuggingFace. By default, if no tokenizer is provided Levanter will fall back to the one defined by the `preprocessor`. Regardless of the tokenization, the Pre-Processor will always be used to convert the time-domain audio data into the expected input for your model, such as Log-Mel-Spectrograms for Whisper.
 

--- a/lib/levanter/docs/reference/Configuration.md
+++ b/lib/levanter/docs/reference/Configuration.md
@@ -281,20 +281,6 @@ trainer:
       logdir: logs
 ```
 
-## Ray Config
-
-Levanter does not automatically start a Ray cluster by default. You can enable
-this behavior using `auto_start_cluster: true`, which will start a Ray cluster
-with all the machines being used for training for distributed preprocessing.
-
-
-| Parameter            | Description                                                             | Default |
-|----------------------|-------------------------------------------------------------------------|---------|
-| `address`            | The address of the Ray cluster to connect to.                           | `None`  |
-| `start_workers`      | Whether to start Ray workers. If `False`, you must start them yourself. | `True`  |
-| `auto_start_cluster` | Whether to start a Ray cluster automatically.                           | `False` |
-
-
 ## Distributed Config
 
 JAX can automatically sniff out clusters in SLURM and TPU environments.
@@ -308,8 +294,6 @@ If you're not using SLURM or TPUs, you can specify the cluster manually using th
 | `num_processes`       | The number of processes in the cluster.                                   | `None`                  |
 | `process_id`          | The process id of this process.                                           | `None`                  |
 | `local_device_ids`    | The local device ids of this process.                                     | ${CUDA_VISIBLE_DEVICES} |
-
-
 
 ## Optimizer
 

--- a/lib/levanter/src/levanter/data/_preprocessor.py
+++ b/lib/levanter/src/levanter/data/_preprocessor.py
@@ -48,7 +48,7 @@ class BatchProcessor(Generic[T_contra, U_co], ABC):
 
     @property
     def resources(self) -> Dict[str, float]:
-        """Any resources that this processor needs to run. Ray uses this to schedule tasks."""
+        """Any resources that this processor needs to run."""
         return {}
 
     @property

--- a/lib/levanter/src/levanter/data/sharded_datasource.py
+++ b/lib/levanter/src/levanter/data/sharded_datasource.py
@@ -70,10 +70,10 @@ class ShardedDataSource(Generic[T_co]):
         path: str,
     ) -> AsyncDataset[T]:
         """
-        Constructs a shard cache version of this dataset using Ray.
+        Constructs a shard cache version of this dataset.
 
         Levanter's preprocessing pipeline offers the following features/guarantees:
-        * distributed, sharded preprocessing using Ray
+        * distributed, sharded preprocessing using Zephyr
         * deterministic ordering of data
         * interruptible and resumable
         * streaming results (no need to wait for everything to finish)

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -219,7 +219,7 @@ class CacheMetadata:
 
 class SerialCacheWriter:
     """
-    Writes TreeCache-compatible caches to disk without Ray. Mostly for scripts and debugging.
+    Writes TreeCache-compatible caches to disk directly. Mostly for scripts and debugging.
     """
 
     def __init__(

--- a/lib/levanter/tests/test_audio.py
+++ b/lib/levanter/tests/test_audio.py
@@ -51,11 +51,11 @@ def test_hf_audio_loading_source():
         audio, sample, text = next(audio_iterator)
 
 
-@pytest.mark.skip("Ray randomly OSErrors.")
+@pytest.mark.skip("Audio cache pipeline is flaky in this test environment.")
 @skip_if_no_soundlibs
 @skip_if_hf_model_not_accessible("openai/whisper-tiny")
 @pytest.mark.asyncio
-async def test_hf_audio_ray_pipeline():
+async def test_hf_audio_cache_pipeline():
     # Use the Real Librispeech Valudation. Testing one doesn't support streaming.
     with tempfile.TemporaryDirectory() as tmpdir:
         ac = AudioIODatasetConfig(

--- a/lib/marin/src/marin/inference/vllm_smoke_test.py
+++ b/lib/marin/src/marin/inference/vllm_smoke_test.py
@@ -159,12 +159,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--tpu-type",
         default="v5p-8",
-        help="TPU type to request when launching via Ray/Fray (default: v5p-8).",
+        help="TPU type to request when launching via Fray (default: v5p-8).",
     )
     parser.add_argument(
         "--local",
         action="store_true",
-        help="Run in the current process instead of launching a Ray/Fray job.",
+        help="Run in the current process instead of launching a Fray job.",
     )
     args = parser.parse_args(argv)
 

--- a/lib/marin/src/marin/rl/curriculum.py
+++ b/lib/marin/src/marin/rl/curriculum.py
@@ -142,7 +142,7 @@ class CurriculumConfig:
     """Temperature for sampling weight distribution."""
 
     actor_name: str = "curriculum"
-    """Name for the Ray actor (shared between rollout and train workers)."""
+    """Name for the curriculum actor shared between rollout and train workers."""
 
     minimum_sample_probability: float = 0.1
     """Minimum probability for sampling any active lesson."""

--- a/lib/marin/src/marin/rl/weight_transfer/arrow_flight.py
+++ b/lib/marin/src/marin/rl/weight_transfer/arrow_flight.py
@@ -241,7 +241,7 @@ def deserialize_arrow_to_pytree(param_name: str, reader: pa.RecordBatchReader) -
 
 
 class ArrowFlightCoordinator:
-    """Ray actor for coordinating Arrow Flight weight transfers."""
+    """Actor for coordinating Arrow Flight weight transfers."""
 
     _server_info: ServerInfo | None
 

--- a/lib/marin/src/marin/training/training.py
+++ b/lib/marin/src/marin/training/training.py
@@ -314,10 +314,9 @@ def run_levanter_train_lm(config: TrainLmOnPodConfig):
 
 
 def run_levanter_train_dpo(config: TrainDpoOnPodConfig):
-    """Run the Levanter DPO training main function on a Ray cluster.
+    """Run the Levanter DPO training main function through Fray.
 
     This function is designed to be run on your machine or with sufficient variables in the env dict/os env.
-    It should also be run with a Ray cluster already running.
     """
     config, train_config, env, extras = _prepare_training_run(config)
 
@@ -352,7 +351,7 @@ def _add_default_env_variables(env: dict, default_env: dict | None):
         default_env = deepcopy(default_env)
         env = mergedeep.merge(default_env, env)
 
-    # Ray gets mad if the values aren't all strings, but e.g. ints
+    # Task environment values are serialized as strings.
     env = {str(k): str(v) for k, v in env.items()}
     return env
 

--- a/lib/marin/src/marin/utils.py
+++ b/lib/marin/src/marin/utils.py
@@ -247,10 +247,10 @@ def _hacky_remove_tpu_lockfile():
     This is a hack to remove the lockfile that TPU pods create on the host filesystem.
 
     libtpu only allows one process to access the TPU at a time, and it uses a lockfile to enforce this.
-    Ordinarily a lockfile would be removed when the process exits, but in the case of Ray, the process is
-    a long-running daemon that doesn't typically exit until the node is shut down. This means that the lockfile
-    persists across Ray tasks. This doesn't apply to tasks that fork a new process to do the TPU work, but
-    does apply to tasks that run the TPU code in the same process as the Ray worker.
+    Ordinarily a lockfile would be removed when the process exits, but a long-running worker process may not exit until
+    the node is shut down. This means that the lockfile can persist across tasks. This doesn't apply to tasks that fork a
+    new process to do the TPU work, but does apply to tasks that run the TPU code in the same long-running worker
+    process.
     """
     try:
         os.unlink("/tmp/libtpu_lockfile")

--- a/lib/zephyr/AGENTS.md
+++ b/lib/zephyr/AGENTS.md
@@ -50,6 +50,6 @@ Shared data is uploaded to filesystem by `ZephyrContext._upload_shared_data()` b
 
 ## Notes
 
-### MacOS
+### Backends
 
-Ray 2.53 enables a `uv run` runtime_env hook by default. When tests run via `uv run pytest`, this can start workers with a different Python version or fail with psutil errors in sandboxed environments. Disable it for tests. See https://github.com/ray-project/ray/issues/59639.
+`ZephyrContext` uses `fray.current_client()`: Iris is auto-detected inside an Iris job, and `LocalClient` is the fallback for local tests and scripts.

--- a/lib/zephyr/README.md
+++ b/lib/zephyr/README.md
@@ -1,6 +1,6 @@
-# zephyr
+# Zephyr
 
-Simple data processing library for Marin pipelines. Build lazy dataset pipelines that run on Ray clusters, thread pools, or synchronously.
+Simple data processing library for Marin pipelines. Build lazy dataset pipelines that run on Iris jobs or a local backend.
 
 ## Quick Start
 
@@ -42,7 +42,7 @@ ctx.execute(pipeline)
 - `.write_vortex(pattern)` - write to a Vortex file
 
 **Execution (`ZephyrContext`):**
-- `ZephyrContext(max_workers=N)` — auto-detects backend (Ray, Iris, or local) via `fray.current_client()`
+- `ZephyrContext(max_workers=N)` — auto-detects the backend (Iris inside an Iris job, local otherwise) via `fray.current_client()`
 - `ZephyrContext(client=LocalClient())` — explicit local backend (testing)
 - `ctx.execute(pipeline)` — runs the pipeline; returns a `ZephyrExecutionResult(results, counters)`
 
@@ -112,20 +112,19 @@ uv run pytest lib/zephyr/tests
 ```bash
 uv run pytest lib/zephyr/tests -k "local"
 uv run pytest lib/zephyr/tests -k "iris"
-uv run pytest lib/zephyr/tests -k "ray"
 ```
 
 The Iris cluster is started once per test session and reused across all tests for efficiency.
 
 ## Design
 
-Zephyr consolidates 100+ ad-hoc Ray/HF dataset patterns in Marin into a simple abstraction.
+Zephyr consolidates ad-hoc distributed and Hugging Face dataset processing patterns in Marin into a simple abstraction.
 
 **Key Features:**
 - Lazy evaluation with operation fusion
 - Disk-based inter-stage data flow for low memory footprint
 - Chunk-by-chunk streaming to minimize memory pressure
-- Distributed execution with bounded parallelism (Ray/Iris/local backends)
+- Distributed execution with bounded parallelism (Iris/local backends)
 - Automatic chunking to prevent large object overhead
 - fsspec integration (GCS, S3, local)
 - Type-safe operation chaining

--- a/lib/zephyr/src/zephyr/_test_helpers.py
+++ b/lib/zephyr/src/zephyr/_test_helpers.py
@@ -1,7 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Helpers shared by tests to avoid pickling import issues on Ray workers."""
+"""Helpers shared by tests to avoid pickling import issues on distributed workers."""
 
 from __future__ import annotations
 

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -278,7 +278,7 @@ class ZephyrWorkerError(RuntimeError):
 # Application errors that should never be retried by the execute() retry loop.
 # These are deterministic errors (bad plan, invalid config, programming bugs)
 # that would fail identically on every attempt. Infrastructure errors (OSError,
-# RuntimeError from dead actors, Ray actor errors) are NOT listed here so they
+# RuntimeError from dead actors, backend actor errors) are NOT listed here so they
 # remain retryable.
 _NON_RETRYABLE_ERRORS = (ZephyrWorkerError, ValueError, TypeError, KeyError, AttributeError, MemoryError)
 

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -1470,7 +1470,7 @@ def _run_coordinator_job(config_path: str, result_path: str) -> None:
     finally:
         # Signal coordinator shutdown first so workers receive SHUTDOWN from
         # pull_task and self-terminate via shutdown_event → exit_actor()
-        # before worker_group.shutdown() sends __ray_terminate__.
+        # before worker_group.shutdown() tears down any remaining actors.
         with suppress(Exception):
             coordinator.shutdown.remote().result(timeout=10.0)
         if worker_group is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,7 @@ missing-import = false
 # Unexpected keyword arguments (47 occurrences) - dynamic configs from transformers, dataclasses
 unexpected-keyword = false
 
-# Missing attributes (315 occurrences) - often from untyped libraries like ray, jax, etc.
+# Missing attributes (315 occurrences) - often from untyped libraries like JAX, etc.
 # These are mostly false positives from libraries without complete type stubs
 missing-attribute = false
 

--- a/tests/execution/test_executor.py
+++ b/tests/execution/test_executor.py
@@ -41,7 +41,7 @@ class MyConfig:
     m: int
 
 
-# Different Ray processes running `ExecutorStep`s cannot share variables, so use filesystem.
+# Different processes running `ExecutorStep`s cannot share variables, so use filesystem.
 # Helper functions
 
 

--- a/tests/rl/test_curriculum.py
+++ b/tests/rl/test_curriculum.py
@@ -869,7 +869,7 @@ def test_rollout_stats_dataclass():
     assert rollout_stats.episode_reward == 1.5
     assert rollout_stats.env_example_id == "example_123"
 
-    # Test that it's serializable (important for Ray)
+    # Test that it's serializable for distributed execution.
     from dataclasses import asdict
 
     stats_dict = asdict(rollout_stats)


### PR DESCRIPTION
## Summary
- Replace remaining active Ray-era doc wording with Iris, Fray, and Zephyr terminology.
- Update TPU observability examples to use Iris labels and current TPU node guidance instead of Ray VM labels.
- Refresh Zephyr and Levanter cache docs plus related comments/docstrings to match current Zephyr-backed workflows.
- Fix the active Zephyr example in `infra/README.md`, remove a dead Zephyr design-doc link, and mark the old Zephyr migration guide as archived historical material.

Closes #5029.

## Testing
- `./infra/pre-commit.py --fix $(git diff --name-only)`
- `./infra/pre-commit.py --fix infra/README.md lib/levanter/docs/Training-On-Your-Data.md lib/levanter/docs/guides/Training-Data-Guide.md lib/levanter/docs/guides/Training-On-Audio-Data.md lib/zephyr/src/zephyr/execution.py`
- `git diff --check`
- `rg -n '\bRay\b|\bray\b|ray-user-node-type|ray-marin-|ray_run|launch_on_ray|ray_tpu|scripts/ray/|RAY_AUTH_TOKEN' docs lib/*/docs lib/*/README.md lib/*/AGENTS.md infra/README.md .agents/skills -g '*.md' --glob '!docs/reports/summary.md' --glob '!lib/levanter/docs/Levanter-1.0-Release.md'` returned no matches in active docs.
- `rg -n 'ray-user-node-type|ray-marin-|(^|[^[:alnum:]_])ray_run([^[:alnum:]_]|$)|launch_on_ray|(^|[^[:alnum:]_])ray_tpu([^[:alnum:]_]|$)|scripts/ray/|RAY_AUTH_TOKEN|__ray_terminate__|(^|[^[:alnum:]_])flow_backend([^[:alnum:]_]|$)|lib/zephyr/docs/design.md' docs lib .agents infra experiments scripts tests pyproject.toml -g '*.md' -g '*.py' -g '*.toml' --glob '!docs/reports/summary.md' --glob '!lib/levanter/docs/Levanter-1.0-Release.md' --glob '!.agents/projects/**' --glob '!.agents/docs/zephyr-migration.md'` returned no matches for stale deleted-entrypoint/API/comment tokens.
- `rg -n '\bRay\b|\bray\b|ray-user-node-type|ray-marin-' lib/fray/AGENTS.md docs/dev-guide/tpu_observability.md lib/zephyr/README.md lib/zephyr/AGENTS.md` returned no matches for the issue's residual files.
- `rg -n 'on-the-fly|on the fly|in the background while your model is training|background, using the mostly-idle|Online Preprocessing|online preprocessing' lib/levanter/docs/Training-On-Your-Data.md lib/levanter/docs/guides/Training-Data-Guide.md lib/levanter/docs/guides/Training-On-Audio-Data.md` returned no matches for the stale background-cache wording.

Historical release/report/project material and the archived migration guide are intentionally excluded from the broad stale-token grep.