### PR TITLE
[codex] Fix step lock terminal status race

### DIFF
--- a/lib/marin/src/marin/execution/executor_step_status.py
+++ b/lib/marin/src/marin/execution/executor_step_status.py
@@ -4,7 +4,7 @@
 """
 Each `ExecutorStep` produces an `output_path`.
 We associate each `output_path` with:
-- A status file (`output_path/.executor_status`) containing simple text: SUCCESS, FAILURE, or RUNNING
+- A status file (`output_path/.executor_status`) containing simple text: SUCCESS, FAILED, DEP_FAILED, or RUNNING
 - A LOCK file (`output_path/.executor_status.lock`) for distributed locking
 
 The LOCK file contains JSON with {worker_id, timestamp} and is refreshed periodically.
@@ -50,9 +50,9 @@ class StatusFile:
     Two types of files:
     - LOCK file (JSON): Single file for distributed lock acquisition.
       Contains {worker_id, timestamp}. Must be refreshed periodically.
-    - Status file (simple text): Final state - SUCCESS, FAILURE, or RUNNING.
+    - Status file (simple text): Step state - SUCCESS, FAILED, DEP_FAILED, or RUNNING.
 
-    Lock acquisition delegates to ``rigging.distributed_lock``.
+    Lock acquisition and release delegate to ``rigging.distributed_lock``.
     """
 
     def __init__(self, output_path: str, worker_id: str):
@@ -108,10 +108,12 @@ class StatusFile:
         return last_status
 
     def write_status(self, status: str) -> None:
-        """Write status (SUCCESS/FAILURE/RUNNING).
+        """Write the status file without changing lock ownership.
 
-        For terminal statuses (SUCCESS/FAILED), the lock is released.
-        For RUNNING, the lock is maintained so heartbeat can continue refreshing it.
+        ``step_lock`` owns the lock lifetime: it stops the heartbeat before
+        releasing the lock. Keeping status writes separate from lock release
+        prevents the heartbeat from observing our own terminal cleanup as lease
+        loss.
         """
         parent = os.path.dirname(self.path)
         if not self.fs.exists(parent):
@@ -119,20 +121,13 @@ class StatusFile:
         with self.fs.open(self.path, "w") as f:
             f.write(status)
 
-        if status != STATUS_RUNNING:
-            logger.info(
-                "Releasing lock path=%s worker=%s reason=terminal_status:%s",
-                self._lock_path,
-                self.worker_id,
-                status,
-            )
-            self.release_lock()
         logger.debug("[%s] Wrote status %s to %s", self.worker_id, status, self.path)
 
     def refresh_lock(self) -> None:
         """Refresh a lock held by the current worker.
 
-        Raises ``LeaseLostError`` if another worker holds the lock.
+        Raises ``LeaseLostError`` if another worker holds the lock, or if the
+        lock disappeared before the heartbeat stopped.
         """
         self._lock.refresh()
 
@@ -227,7 +222,9 @@ def step_lock(output_path: str, step_label: str, *, force_run_failed: bool = Tru
     """Context manager that acquires a distributed lock with heartbeat refresh.
 
     Acquires the lock, starts a daemon heartbeat thread, yields the
-    ``StatusFile``, then tears down the heartbeat and releases the lock.
+    ``StatusFile``, then tears down the heartbeat and releases the lock. Status
+    writes inside the context do not release the lock; this context manager owns
+    release ordering so the heartbeat is stopped first.
 
     Raises ``StepAlreadyDone`` if another worker completed the step
     while we waited for the lock.

--- a/tests/execution/test_executor.py
+++ b/tests/execution/test_executor.py
@@ -8,11 +8,12 @@ import re
 import tempfile
 import time
 from dataclasses import asdict, dataclass
-from threading import Thread
+from threading import Event, Thread
 
 import pytest
 from draccus.utils import Dataclass
 from fray.types import ResourceConfig
+import marin.execution.executor_step_status as executor_step_status
 from marin.execution import THIS_OUTPUT_PATH
 from marin.evaluation.perplexity_gap import GapFinderModelConfig, default_model_perplexity_gap, raw_text_dataset
 from marin.execution.executor import (
@@ -30,6 +31,7 @@ from marin.execution.executor import (
 from marin.execution.executor_step_status import (
     STATUS_SUCCESS,
     StatusFile,
+    step_lock,
 )
 
 
@@ -151,6 +153,31 @@ def test_status_file_reads_legacy_format(tmp_path):
 
     status_file = StatusFile(str(output_dir), worker_id="legacy-reader")
     assert status_file.status == "SUCCESS"
+
+
+def test_step_lock_terminal_status_does_not_race_heartbeat(tmp_path, monkeypatch):
+    terminal_status_written = Event()
+    heartbeat_waiting = Event()
+    heartbeat_after_terminal_status = Event()
+    original_refresh_lock = StatusFile.refresh_lock
+
+    def refresh_lock(status_file: StatusFile) -> None:
+        heartbeat_waiting.set()
+        assert terminal_status_written.wait(timeout=1)
+        try:
+            original_refresh_lock(status_file)
+        finally:
+            heartbeat_after_terminal_status.set()
+
+    monkeypatch.setattr(executor_step_status, "HEARTBEAT_INTERVAL", 0)
+    monkeypatch.setattr(StatusFile, "refresh_lock", refresh_lock)
+
+    with step_lock(str(tmp_path), "step") as status_file:
+        assert heartbeat_waiting.wait(timeout=1)
+        status_file.write_status(STATUS_SUCCESS)
+        terminal_status_written.set()
+        assert heartbeat_after_terminal_status.wait(timeout=1)
+    assert not StatusFile(str(tmp_path), "check").has_active_lock()
 
 
 def test_perplexity_gap_step_hash_changes_when_tokenizer_changes():


### PR DESCRIPTION
## Summary

Fixes #5026.

`StatusFile.write_status()` now only writes the executor status file. Lock release stays with the `step_lock` context manager, which already stops the heartbeat thread before releasing the lock. This avoids the terminal-status self-race where `write_status(SUCCESS)` deletes `.executor_status.lock` while the heartbeat can still refresh it and report `LeaseLostError`.

Also updates the nearby docstrings so the status-vs-lock ownership boundary is explicit.

<details>
<summary>Why this is safe</summary>

This PR does not remove lock release. It removes one duplicate release site that ran at the wrong time.

Before this change, terminal `write_status(SUCCESS/FAILED)` released `.executor_status.lock` immediately, while `step_lock()` still had a live heartbeat thread. That allowed this interleaving:

```text
main thread:      write_status(SUCCESS)
main thread:      release_lock() deletes .executor_status.lock
heartbeat thread: refresh_lock()
heartbeat thread: lock file missing -> LeaseLostError
main thread:      step_lock exits and re-raises LeaseLostError
```

After this change, `write_status()` only writes `.executor_status`. `step_lock()` remains responsible for cleanup:

```text
stop heartbeat
join heartbeat thread
raise only if the heartbeat observed real lease loss
release lock
```

The production paths still release locks:

- Success: `run_step()` writes `SUCCESS` inside `with step_lock(...)`; exiting the context releases the lock.
- Failure: `run_step()` writes `FAILED`, re-raises, and Python still runs `step_lock()` cleanup.
- Cache hit: `check_cache()` returns before `step_lock()` is entered, so no lock was acquired.
- Concurrent completion: `should_run()` still explicitly releases the lock if it acquires one and then rechecks `SUCCESS`.
- `disk_cache.py` direct status writes do not acquire locks through that `StatusFile` instance; when composed with `distributed_lock()`, `step_lock()` owns the release.

The remaining tradeoff is process death after writing a terminal status but before `step_lock()` cleanup. In that case the lock can remain until lease timeout. For `SUCCESS`, later workers skip based on status; for `FAILED`, retry may wait for stale lease takeover. That is preferable to the current false-failure mode for successful jobs.

</details>

## Testing

- `uv run --package marin pytest tests/execution/test_executor.py::test_step_lock_terminal_status_does_not_race_heartbeat tests/execution/test_disk_cache.py tests/execution/test_step_runner.py -q`
- `uv run --package marin pytest tests/execution/test_executor.py -q`
- `./infra/pre-commit.py --all-files --fix`