### PR TITLE
[checkpoint] Cross-region temp checkpoint discovery via mirrortmp://

### DIFF
--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -33,6 +33,8 @@ from haliax.jax_utils import is_in_jit, is_jax_array_like
 from jax.experimental.array_serialization.serialization import GlobalAsyncCheckpointManager
 from jaxtyping import PyTree
 
+import rigging.filesystem  # noqa: F401  # registers mirror://, mirrortmp:// fsspec protocols
+
 from levanter._debug_logging import flush_debug_output
 from levanter.tensorstore_serialization import (
     tree_deserialize_leaves_tensorstore,
@@ -392,6 +394,7 @@ class Checkpointer:
         step_policies: Sequence[CheckpointInterval],
         *,
         temporary_base_path: Optional[PathLike] = None,
+        temporary_search_paths: Optional[Sequence[PathLike]] = None,
         keep_params: PyTree[FilterSpec] = True,
         dt_now_injection: Optional[Callable[[], datetime.datetime]] = None,
         delete_old_temp_checkpoints: bool = True,
@@ -413,6 +416,10 @@ class Checkpointer:
             temporary_base_path: separate base path for time-policy (temporary) checkpoints. When set,
                 temporary checkpoints are written here instead of base_path. Permanent (step-policy)
                 checkpoints always go to base_path. If None, all checkpoints go to base_path.
+            temporary_search_paths: additional roots searched **only** for prior-temporary-checkpoint
+                discovery (cleanup bookkeeping and resume). Writes never target these. Used to plug
+                in cross-region search URLs (e.g. ``mirrortmp://...``) so a multi-region resume can
+                find a temp checkpoint written in another region.
             keep_params: a PyTree of FilterSpecs that specifies which parameters to keep in the checkpoint
             dt_now_injection: a function that returns the current time. useful for testing
             delete_old_temp_checkpoints: if True, carry forward a temporary checkpoint discovered at startup so the
@@ -422,6 +429,9 @@ class Checkpointer:
         """
         self.base_path = str(base_path)
         self.temporary_base_path = str(temporary_base_path) if temporary_base_path is not None else None
+        self.temporary_search_paths: list[str] = (
+            [str(p) for p in temporary_search_paths] if temporary_search_paths else []
+        )
         self.save_interval = save_interval
         self.step_policies = list(step_policies)
         self.keep_params = keep_params
@@ -455,23 +465,24 @@ class Checkpointer:
             self._async_checkpoint_remover_thread.start()
             self._checkpoint_being_removed = None
 
-        # discover latest checkpoint and see if it's temporary
+        # discover latest checkpoint across base + temp + search-only roots and see if it's temporary
         self._last_temporary_checkpoint = None
-        # Check both base_path and temporary_base_path for prior temporary checkpoints
-        search_paths = [self.base_path]
+        cleanup_roots: list[str] = [self.base_path]
         if self.temporary_base_path is not None:
-            search_paths.append(self.temporary_base_path)
-        for search_path in search_paths:
-            latest_checkpoint = discover_latest_checkpoint(search_path)
-            if latest_checkpoint is not None and delete_old_temp_checkpoints:
+            cleanup_roots.append(self.temporary_base_path)
+        cleanup_roots.extend(self.temporary_search_paths)
+        latest_checkpoint = discover_latest_checkpoint(cleanup_roots[0], *cleanup_roots[1:]) if cleanup_roots else None
+        if latest_checkpoint is not None and delete_old_temp_checkpoints:
+            try:
                 metadata = _load_metadata(latest_checkpoint)
-                if metadata.get("is_temporary", False):
-                    logger.info(
-                        f"Found prior temporary checkpoint {latest_checkpoint}. We will delete it after"
-                        " saving a new checkpoint."
-                    )
-                    self._last_temporary_checkpoint = latest_checkpoint
-                    break
+            except FileNotFoundError:
+                metadata = {}
+            if metadata.get("is_temporary", False):
+                logger.info(
+                    f"Found prior temporary checkpoint {latest_checkpoint}. We will delete it after"
+                    " saving a new checkpoint."
+                )
+                self._last_temporary_checkpoint = latest_checkpoint
 
     def load_checkpoint(
         self,
@@ -792,6 +803,7 @@ def load_checkpoint(
 
     """
     checkpoint_path = str(checkpoint_path)
+    checkpoint_path = _stage_for_tensorstore(checkpoint_path)
 
     if is_in_jit():
         logger.warning("Loading checkpoint in jit. This is not recommended and probably won't work.")
@@ -963,12 +975,32 @@ def discover_latest_checkpoint(checkpoint_path: PathLike, *additional_paths: Pat
 
 
 def latest_checkpoint_path(checkpoint_path: PathLike, *additional_paths: PathLike) -> str:
-    """Return the latest concrete checkpoint path across one or more search roots."""
+    """Return the latest concrete checkpoint path across one or more search roots.
+
+    The returned URL is always tensorstore-readable: virtual schemes that expose a
+    ``stage_to_local`` hook on their fsspec filesystem (notably ``mirror://`` /
+    ``mirrortmp://``) are resolved to a concrete ``gs://`` / ``file://`` URL before
+    return.
+    """
     latest = discover_latest_checkpoint(checkpoint_path, *additional_paths)
     if latest is None:
         search_paths = [str(checkpoint_path)] + [str(path) for path in additional_paths]
         raise FileNotFoundError(f"Could not discover checkpoint under any of: {search_paths}")
-    return latest
+    return _stage_for_tensorstore(latest)
+
+
+def _stage_for_tensorstore(checkpoint_path: str) -> str:
+    """If the path's fsspec filesystem exposes ``stage_to_local``, apply it.
+
+    No-op for plain ``gs://`` / ``s3://`` / ``file://`` — they pass through.
+    For ``mirror://`` / ``mirrortmp://`` URLs this stages the discovered tree
+    locally and returns the local concrete URL, which TensorStore can then read.
+    """
+    fs, plain_path = _get_fs_and_plain_path(checkpoint_path)
+    stager = getattr(fs, "stage_to_local", None)
+    if stager is None:
+        return checkpoint_path
+    return stager(plain_path)
 
 
 def _discover_latest_checkpoint_single(checkpoint_path: str) -> Optional[str]:
@@ -1015,6 +1047,12 @@ class CheckpointerConfig:
     """Separate base path for temporary (time-policy) checkpoints. When set, temporary checkpoints
     are written here instead of base_path, allowing use of region-local storage with lifecycle TTL."""
 
+    temporary_search_paths: List[str] = field(default_factory=list)
+    """Additional roots searched **only** for prior-temporary-checkpoint discovery (cleanup
+    bookkeeping and resume).  Writes never target these.  Used to plug in cross-region search
+    URLs (e.g. ``mirrortmp://ttl=14d/checkpoints-temp/<run-id>``) so a multi-region resume can
+    find a temp checkpoint written in another region."""
+
     save_interval: timedelta = timedelta(minutes=15)
     # TODO: I'd like to write this, but it's not supported by draccus
     # keep: List[CheckpointInterval] = field(default_factory=lambda: [CheckpointInterval(every=1000)])
@@ -1046,6 +1084,17 @@ class CheckpointerConfig:
             return os.path.expanduser(os.path.join(self.temporary_base_path, run_id))
         return os.path.expanduser(self.temporary_base_path)
 
+    def expanded_temporary_search_paths(self, run_id) -> List[str]:
+        """Search-only roots; entries already include the run-id literal where needed.
+
+        We do **not** auto-append run-id here: callers compose these with the explicit
+        run-id (e.g. Marin's training wrapper does this in ``_enforce_run_id``), since
+        ``append_run_id_to_base_path`` may be ``False`` for imputed run-ids and the
+        bare ``checkpoints-temp/`` root must never be globbed.
+        """
+        del run_id
+        return [os.path.expanduser(p) for p in self.temporary_search_paths]
+
     def create(self, run_id) -> Checkpointer:
         keeps = [CheckpointInterval(**k) for k in self.keep]
         return Checkpointer(
@@ -1053,6 +1102,7 @@ class CheckpointerConfig:
             save_interval=self.save_interval,
             step_policies=keeps,
             temporary_base_path=self.expanded_temporary_path(run_id),
+            temporary_search_paths=self.expanded_temporary_search_paths(run_id),
             delete_old_temp_checkpoints=self.delete_old_temp_checkpoints,
             delete_previous_temporary_checkpoint_after_save=self.delete_previous_temporary_checkpoint_after_save,
             debug=self.debug,
@@ -1064,6 +1114,9 @@ class CheckpointerConfig:
             self.base_path = os.path.expanduser(self.base_path)
         if isinstance(self.temporary_base_path, str):
             self.temporary_base_path = os.path.expanduser(self.temporary_base_path)
+        self.temporary_search_paths = [
+            os.path.expanduser(p) if isinstance(p, str) else p for p in self.temporary_search_paths
+        ]
         if isinstance(self.debug, dict):
             self.debug = CheckpointDebugConfig(**self.debug)
 

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -865,6 +865,7 @@ class TrainerConfig:
         temp_path = self.checkpointer.expanded_temporary_path(run_id)
         if temp_path is not None:
             paths.append(temp_path)
+        paths.extend(self.checkpointer.expanded_temporary_search_paths(run_id))
         return paths
 
     initialize_from: Optional[str] = None  # Levanter trainer checkpoint to initialize from

--- a/lib/levanter/tests/test_checkpoint.py
+++ b/lib/levanter/tests/test_checkpoint.py
@@ -32,7 +32,9 @@ from levanter.checkpoint import (
     CheckpointInterval,
     _collect_debug_checkpointer_state,
     _load_metadata,
+    _stage_for_tensorstore,
     discover_latest_checkpoint,
+    latest_checkpoint_path,
     load_checkpoint,
     load_checkpoint_or_initialize,
     register_debug_checkpointer_state_provider,
@@ -778,3 +780,174 @@ def test_backward_compatibility_with_ocdbt():
         )
         assert all(np.isclose(restored_state.training_key, initial_state.training_key))
         assert restored_state.step == initial_state.step
+
+
+# ---------------------------------------------------------------------------
+# Cross-region temp-checkpoint discovery (mirrortmp:// search paths)
+# ---------------------------------------------------------------------------
+
+
+def test_checkpointer_config_temporary_search_paths_default_empty():
+    config = CheckpointerConfig()
+    assert config.temporary_search_paths == []
+    assert config.expanded_temporary_search_paths("run1") == []
+
+
+def test_checkpointer_config_temporary_search_paths_expanduser():
+    config = CheckpointerConfig(temporary_search_paths=["~/foo", "/abs/bar", "mirrortmp://x/y"])
+    # ~ expanded; absolute and mirror URLs preserved.
+    assert config.temporary_search_paths[0] == os.path.expanduser("~/foo")
+    assert config.temporary_search_paths[1] == "/abs/bar"
+    assert config.temporary_search_paths[2] == "mirrortmp://x/y"
+
+
+def test_checkpointer_config_expanded_temporary_search_paths_does_not_append_run_id():
+    """Search paths are *literal*: callers compose explicit run-ids into them, since
+    append_run_id_to_base_path may be False for imputed run-ids."""
+    config = CheckpointerConfig(temporary_search_paths=["mirrortmp://ttl=14d/checkpoints-temp/run-A"])
+    paths = config.expanded_temporary_search_paths("run-A")
+    assert paths == ["mirrortmp://ttl=14d/checkpoints-temp/run-A"]
+    # The bare prefix without the run-id should never appear.
+    assert "mirrortmp://ttl=14d/checkpoints-temp" not in paths
+
+
+def test_trainer_config_checkpoint_search_paths_includes_temp_search_paths():
+    config = dataclasses.replace(
+        TrainerConfig(),
+        checkpointer=CheckpointerConfig(
+            base_path="/tmp/test-perm",
+            temporary_base_path="/tmp/test-temp",
+            temporary_search_paths=["mirrortmp://ttl=14d/checkpoints-temp/run-A"],
+            append_run_id_to_base_path=True,
+        ),
+    )
+    paths = config.checkpoint_search_paths("run-A")
+    assert paths == [
+        "/tmp/test-perm/run-A",
+        "/tmp/test-temp/run-A",
+        "mirrortmp://ttl=14d/checkpoints-temp/run-A",
+    ]
+
+    # When load_checkpoint_path is set, it overrides everything (existing contract).
+    pinned = dataclasses.replace(config, load_checkpoint_path="/explicit/step-100")
+    assert pinned.checkpoint_search_paths("run-A") == ["/explicit/step-100"]
+
+
+def test_checkpointer_init_discovers_from_temporary_search_paths(tmp_path):
+    """Cleanup bookkeeping picks the global-max temp checkpoint across all roots."""
+    permanent = tmp_path / "perm"
+    permanent.mkdir()
+    local_temp = tmp_path / "tmp_local"
+    local_temp.mkdir()
+    remote_temp = tmp_path / "tmp_remote"
+    remote_temp.mkdir()
+
+    # local-temp at step 3 (older); remote-temp at step 7 (newer).
+    save_checkpoint({"x": 1}, step=3, checkpoint_path=str(local_temp / "step-3"), is_temporary=True)
+    save_checkpoint({"x": 1}, step=7, checkpoint_path=str(remote_temp / "step-7"), is_temporary=True)
+
+    checkpointer = Checkpointer(
+        base_path=str(permanent),
+        save_interval=timedelta(seconds=10),
+        step_policies=[CheckpointInterval(every=100, until=None)],
+        temporary_base_path=str(local_temp),
+        temporary_search_paths=[str(remote_temp)],
+    )
+    # Global max wins — step-7 (remote), not step-3 (local).
+    assert checkpointer._last_temporary_checkpoint == str(remote_temp / "step-7")
+
+
+def test_checkpointer_init_picks_global_max_via_search_paths_only(tmp_path):
+    """Even with no temporary_base_path, search paths still drive cleanup discovery."""
+    permanent = tmp_path / "perm"
+    permanent.mkdir()
+    remote_temp = tmp_path / "tmp_remote"
+    remote_temp.mkdir()
+    save_checkpoint({"x": 1}, step=42, checkpoint_path=str(remote_temp / "step-42"), is_temporary=True)
+
+    checkpointer = Checkpointer(
+        base_path=str(permanent),
+        save_interval=timedelta(seconds=10),
+        step_policies=[CheckpointInterval(every=100, until=None)],
+        temporary_base_path=None,
+        temporary_search_paths=[str(remote_temp)],
+    )
+    assert checkpointer._last_temporary_checkpoint == str(remote_temp / "step-42")
+
+
+def test_stage_for_tensorstore_passthrough_for_plain_filesystems(tmp_path):
+    """gs://, file://, s3:// (anything without a stage_to_local hook) returns the input unchanged."""
+    p = str(tmp_path / "step-1")
+    save_checkpoint({"x": 1}, step=1, checkpoint_path=p)
+    assert _stage_for_tensorstore(p) == p
+    assert _stage_for_tensorstore(f"file://{p}") == f"file://{p}"
+
+
+def test_stage_for_tensorstore_invokes_stager(monkeypatch, tmp_path):
+    """When the fs exposes stage_to_local, the helper calls it and returns its result."""
+    real_target = str(tmp_path / "step-1")
+    save_checkpoint({"x": 1}, step=1, checkpoint_path=real_target)
+
+    captured: dict[str, str] = {}
+
+    class _FakeFS:
+        def stage_to_local(self, path: str) -> str:
+            captured["path"] = path
+            return real_target
+
+    monkeypatch.setattr(
+        "levanter.checkpoint._get_fs_and_plain_path",
+        lambda p, fs=None: (_FakeFS(), "checkpoints-temp/run-A/step-1"),
+    )
+    out = _stage_for_tensorstore("mirrortmp://checkpoints-temp/run-A/step-1")
+    assert out == real_target
+    assert captured["path"] == "checkpoints-temp/run-A/step-1"
+
+
+def test_latest_checkpoint_path_returns_concrete_url(monkeypatch, tmp_path):
+    """latest_checkpoint_path returns a URL that has been passed through stage_to_local."""
+    real_target = str(tmp_path / "step-7")
+    save_checkpoint({"x": 1}, step=7, checkpoint_path=real_target, is_temporary=True)
+
+    discovered_virtual = "mirrortmp://run-A/step-7"
+
+    def fake_discover(*paths):
+        return discovered_virtual
+
+    class _FakeFS:
+        def stage_to_local(self, path: str) -> str:
+            assert path == "run-A/step-7"
+            return real_target
+
+    monkeypatch.setattr("levanter.checkpoint.discover_latest_checkpoint", fake_discover)
+    monkeypatch.setattr(
+        "levanter.checkpoint._get_fs_and_plain_path",
+        lambda p, fs=None: (_FakeFS(), "run-A/step-7"),
+    )
+    out = latest_checkpoint_path(discovered_virtual)
+    # URL is concrete (no virtual scheme) — TensorStore can read it.
+    assert out == real_target
+    assert "mirrortmp" not in out
+
+
+def test_load_checkpoint_invokes_stage_for_tensorstore(monkeypatch, tmp_path):
+    """A virtual URL passed to load_checkpoint is staged before TensorStore touches it."""
+    initial_state = _make_state(step=10, key=jax.random.PRNGKey(0))
+    real_target = str(tmp_path / "step-10")
+    save_checkpoint(initial_state, step=10, checkpoint_path=real_target)
+
+    class _FakeFS:
+        def stage_to_local(self, path: str) -> str:
+            return real_target
+
+    monkeypatch.setattr(
+        "levanter.checkpoint._get_fs_and_plain_path",
+        lambda p, fs=None: (_FakeFS(), "run-A/step-10"),
+    )
+    rep_state = _make_state(step=0, key=jax.random.PRNGKey(1))
+    restored = load_checkpoint(rep_state, "mirrortmp://run-A/step-10")
+    # If staging didn't happen, build_kvstore_spec would have raised on the mirrortmp:// URL.
+    assert_trees_all_close(
+        jax.tree_util.tree_leaves(arrays_only(restored.model)),
+        jax.tree_util.tree_leaves(arrays_only(initial_state.model)),
+    )

--- a/lib/marin/src/marin/training/training.py
+++ b/lib/marin/src/marin/training/training.py
@@ -169,9 +169,23 @@ def _enforce_run_id(config: TrainOnPodConfigT) -> TrainOnPodConfigT:
     else:
         merged_search_paths = existing_search_paths
 
+    # Align the temp *write* destination with the mirror search path: in midtraining
+    # (impute_run_id_from_output_path=True ⇒ append_run_id_to_base_path=False), Levanter's
+    # ``expanded_temporary_path(run_id)`` returns ``temporary_base_path`` *without* appending
+    # run_id, so writes would land at ``.../checkpoints-temp/step-N`` (no run-id segment) and
+    # the mirror search path ``mirrortmp://.../checkpoints-temp/{run_id}/`` would never match
+    # them.  Inline run_id here when Levanter wouldn't.  Idempotent — does not double-append
+    # if the user (or a re-entrant call) already supplied a run-id-suffixed path.
+    existing_temp_base = config.train_config.trainer.checkpointer.temporary_base_path
+    new_temp_base = existing_temp_base
+    if existing_temp_base is not None and not append_id_to_checkpoints:
+        if not existing_temp_base.rstrip("/").endswith(f"/{run_id}"):
+            new_temp_base = f"{existing_temp_base.rstrip('/')}/{run_id}"
+
     checkpointer_config = replace(
         config.train_config.trainer.checkpointer,
         append_run_id_to_base_path=append_id_to_checkpoints,
+        temporary_base_path=new_temp_base,
         temporary_search_paths=merged_search_paths,
     )
 

--- a/lib/marin/src/marin/training/training.py
+++ b/lib/marin/src/marin/training/training.py
@@ -157,8 +157,22 @@ def _enforce_run_id(config: TrainOnPodConfigT) -> TrainOnPodConfigT:
         logger.warning(f"Run ID not set. Using default: {run_id}")
 
     append_id_to_checkpoints = not config.impute_run_id_from_output_path
+
+    # Cross-region temp checkpoint discovery: include all marin-tmp-* buckets in the search
+    # via mirrortmp://.  Use the explicit run_id literal — append_run_id_to_base_path may be
+    # False for imputed run-ids, which would otherwise cause discovery to glob the shared
+    # ``checkpoints-temp/`` root across all runs.
+    mirror_search_path = f"mirrortmp://ttl=14d/checkpoints-temp/{run_id}"
+    existing_search_paths = list(config.train_config.trainer.checkpointer.temporary_search_paths)
+    if mirror_search_path not in existing_search_paths:
+        merged_search_paths = [*existing_search_paths, mirror_search_path]
+    else:
+        merged_search_paths = existing_search_paths
+
     checkpointer_config = replace(
-        config.train_config.trainer.checkpointer, append_run_id_to_base_path=append_id_to_checkpoints
+        config.train_config.trainer.checkpointer,
+        append_run_id_to_base_path=append_id_to_checkpoints,
+        temporary_search_paths=merged_search_paths,
     )
 
     inner_config = replace(

--- a/lib/rigging/src/rigging/filesystem.py
+++ b/lib/rigging/src/rigging/filesystem.py
@@ -694,22 +694,67 @@ def filesystem(protocol: str, **kwargs: Any) -> Any:
 # ---------------------------------------------------------------------------
 
 
+_BUCKET_FAMILY_MAPS: dict[str, dict[str, str]] = {
+    "data": REGION_TO_DATA_BUCKET,
+    "tmp": REGION_TO_TMP_BUCKET,
+}
+
+
+def _bucket_map_for_family(family: str) -> dict[str, str]:
+    try:
+        return _BUCKET_FAMILY_MAPS[family]
+    except KeyError as e:
+        raise ValueError(f"Unknown mirror bucket family: {family!r}") from e
+
+
 def _all_data_bucket_prefixes() -> list[str]:
     """Return gs:// prefixes for all known marin data buckets."""
     return [f"gs://{bucket}" for bucket in REGION_TO_DATA_BUCKET.values()]
 
 
-def _mirror_remote_prefixes(local_prefix: str) -> list[str]:
+def _mirror_remote_prefixes(local_prefix: str, family: str = "data") -> list[str]:
     """Remote marin buckets to scan for mirror reads.
 
     The cross-region mirror only exists on GCS, and scanning GCS buckets
     requires GCP credentials.  Return an empty list unless the local prefix
     is itself a ``gs://`` URL — otherwise non-GCP runs (CoreWeave S3, local
     dev) would emit anonymous-caller 401s from gcsfs on every mirror read.
+
+    *family* selects the bucket family: ``"data"`` (primary) or ``"tmp"``.
     """
     if not local_prefix.startswith("gs://"):
         return []
-    return [p for p in _all_data_bucket_prefixes() if not local_prefix.startswith(p)]
+    all_prefixes = [f"gs://{bucket}" for bucket in _bucket_map_for_family(family).values()]
+    return [p for p in all_prefixes if not local_prefix.startswith(p)]
+
+
+def _mirror_local_prefix(family: str) -> str:
+    """Local prefix for the mirror filesystem of *family*.
+
+    ``data``: ``marin_prefix()`` (``gs://marin-{region}`` or local fallback).
+    ``tmp``:  ``gs://marin-tmp-{region}`` on GCS with a known region;
+              ``<marin_prefix>/tmp`` (matching ``marin_temp_bucket``'s
+              non-GCS fallback) otherwise.
+
+    Note the asymmetry: the GCS tmp prefix is the *bucket-level* path
+    without ``/ttl={N}d``; the TTL segment must appear in callers' paths
+    (e.g. ``mirrortmp://ttl=14d/...``).
+    """
+    if family == "data":
+        return marin_prefix().rstrip("/")
+    if family == "tmp":
+        mp = marin_prefix().rstrip("/")
+        if mp.startswith("gs://"):
+            region = marin_region()
+            if region:
+                bucket = REGION_TO_TMP_BUCKET.get(region)
+                if bucket:
+                    return f"gs://{bucket}"
+            return f"{mp}/tmp"
+        if "://" not in mp:
+            mp = f"file://{mp}"
+        return f"{mp}/tmp"
+    raise ValueError(f"Unknown mirror bucket family: {family!r}")
 
 
 class MirrorFileSystem(fsspec.AbstractFileSystem):
@@ -720,9 +765,13 @@ class MirrorFileSystem(fsspec.AbstractFileSystem):
     Writes always target the local prefix.
 
     Cross-region copies are charged against the shared ``TransferBudget``.
+
+    Subclasses select a different bucket family by overriding ``_bucket_family``
+    (e.g. ``MirrorTmpFileSystem`` scopes to ``REGION_TO_TMP_BUCKET``).
     """
 
     protocol = "mirror"
+    _bucket_family: str = "data"
 
     def __init__(
         self,
@@ -731,8 +780,8 @@ class MirrorFileSystem(fsspec.AbstractFileSystem):
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
-        self._local_prefix = marin_prefix().rstrip("/")
-        self._remote_prefixes = _mirror_remote_prefixes(self._local_prefix)
+        self._local_prefix = _mirror_local_prefix(self._bucket_family)
+        self._remote_prefixes = _mirror_remote_prefixes(self._local_prefix, self._bucket_family)
         self._budget = budget if budget is not None else _global_transfer_budget
         self._worker_id = default_worker_id()
 
@@ -831,10 +880,113 @@ class MirrorFileSystem(fsspec.AbstractFileSystem):
 
         source_prefix = self._find_in_remote_prefixes(path)
         if source_prefix is None:
-            raise FileNotFoundError(f"mirror://{path} not found in any marin bucket")
+            raise FileNotFoundError(f"{self.protocol}://{path} not found in any marin bucket")
 
         self._copy_to_local(source_prefix, path)
         return local_url
+
+    def stage_to_local(self, path: str) -> str:
+        """Stage *path* (a directory or file) from the first matching remote
+        prefix into the local prefix and return the local concrete URL.
+
+        Re-stages *missing-or-mismatched* files when the local directory
+        already exists but is incomplete (e.g. a partial prior stage that
+        crashed mid-copy).  Used by readers that bypass fsspec — typically
+        TensorStore — and need a tensorstore-compatible URL.
+        """
+        path = self._strip_protocol(path)
+        local_url = self._local_url(path)
+        source_prefix = self._find_in_remote_prefixes(path)
+        if source_prefix is None:
+            if self._fs_exists(local_url):
+                return local_url
+            raise FileNotFoundError(f"{self.protocol}://{path} not found in any marin bucket")
+
+        self._stage_tree_to_local(source_prefix, path)
+        return local_url
+
+    def _stage_tree_to_local(self, source_prefix: str, path: str) -> None:
+        """Copy missing-or-mismatched files from a remote tree into the local tree.
+
+        Holds a single lock at the root path.  Charges the active budget for
+        the sum of bytes that need to be copied (re-staged bytes only — does
+        not double-charge files already present locally with matching size).
+        """
+        local_url = self._local_url(path)
+        remote_url = self._remote_url(source_prefix, path)
+        lock = create_lock(self._lock_path_for(path), self._worker_id)
+
+        if not lock.try_acquire():
+            for _ in range(60):
+                time.sleep(2)
+                if not lock.has_active_holder():
+                    break
+            if not lock.try_acquire():
+                raise RuntimeError(f"Could not acquire mirror lock for {path} after waiting")
+
+        try:
+            src_fs, src_root = self._get_fs_and_path(remote_url)
+
+            # Single-file source: fall back to the per-file path which has
+            # the same lock+budget+copy semantics.
+            if not src_fs.isdir(src_root):
+                src_size = self._fs_size(remote_url)
+                if self._fs_exists(local_url):
+                    local_size = self._fs_size(local_url)
+                    if src_size is not None and src_size == local_size:
+                        return
+                if src_size is not None:
+                    self._active_budget().record(src_size, remote_url)
+                logger.info("Mirror: copying %s → %s", remote_url, local_url)
+                self._fs_copy(remote_url, local_url)
+                return
+
+            info_map = src_fs.find(src_root, withdirs=False, detail=True)
+            if not info_map:
+                return
+
+            src_root_norm = src_root.rstrip("/")
+            remote_root_norm = remote_url.rstrip("/")
+            local_root_norm = local_url.rstrip("/")
+
+            plan: list[tuple[str, str]] = []
+            total_bytes = 0
+            expected_local_urls: list[str] = []
+
+            for src_path, info in info_map.items():
+                size = int(info.get("size") or 0)
+                rel = src_path
+                if rel.startswith(src_root_norm + "/"):
+                    rel = rel[len(src_root_norm) + 1 :]
+                elif rel == src_root_norm:
+                    rel = ""
+                file_remote_url = f"{remote_root_norm}/{rel}" if rel else remote_url
+                file_local_url = f"{local_root_norm}/{rel}" if rel else local_url
+                expected_local_urls.append(file_local_url)
+
+                if self._fs_exists(file_local_url):
+                    try:
+                        local_size = self._fs_size(file_local_url)
+                    except Exception:
+                        local_size = None
+                    if local_size is not None and local_size == size:
+                        continue
+
+                plan.append((file_remote_url, file_local_url))
+                total_bytes += size
+
+            if total_bytes > 0:
+                self._active_budget().record(total_bytes, remote_url)
+
+            for file_remote_url, file_local_url in plan:
+                logger.info("Mirror: copying %s → %s", file_remote_url, file_local_url)
+                self._fs_copy(file_remote_url, file_local_url)
+
+            for file_local_url in expected_local_urls:
+                if not self._fs_exists(file_local_url):
+                    raise RuntimeError(f"stage_to_local incomplete: {file_local_url} missing after copy")
+        finally:
+            lock.release()
 
     # -- fsspec interface: info/ls/exists -------------------------------------
 
@@ -953,5 +1105,20 @@ class MirrorFileSystem(fsspec.AbstractFileSystem):
         return self._budget.bytes_used
 
 
-# Register the mirror:// protocol with fsspec.
+class MirrorTmpFileSystem(MirrorFileSystem):
+    """Cross-region mirror over the ``marin-tmp-{region}`` bucket family.
+
+    Discovery only — temporary checkpoints are still *written* directly to
+    the region-local ``gs://marin-tmp-{region}`` bucket via Levanter's
+    ``temporary_base_path``.  The ``mirrortmp://`` protocol exists so the
+    resume search loop can union-list temp checkpoints across regions and
+    stage the freshest one to local before TensorStore reads it.
+    """
+
+    protocol = "mirrortmp"
+    _bucket_family = "tmp"
+
+
+# Register the mirror:// and mirrortmp:// protocols with fsspec.
 fsspec.register_implementation("mirror", MirrorFileSystem)
+fsspec.register_implementation("mirrortmp", MirrorTmpFileSystem)

--- a/lib/rigging/tests/test_mirror_fs.py
+++ b/lib/rigging/tests/test_mirror_fs.py
@@ -7,9 +7,13 @@ import fsspec
 import pytest
 
 from rigging.filesystem import (
+    REGION_TO_DATA_BUCKET,
+    REGION_TO_TMP_BUCKET,
     MirrorFileSystem,
+    MirrorTmpFileSystem,
     TransferBudget,
     TransferBudgetExceeded,
+    _mirror_local_prefix,
     _mirror_remote_prefixes,
 )
 
@@ -236,3 +240,161 @@ def test_mirror_filesystem_init_skips_gcs_on_s3_prefix(monkeypatch):
     fs = MirrorFileSystem()
     assert fs._local_prefix == "s3://marin-na/marin"
     assert fs._remote_prefixes == []
+
+
+# ---------------------------------------------------------------------------
+# MirrorTmpFileSystem (mirrortmp://) — bucket-family + remote-prefix tests
+# ---------------------------------------------------------------------------
+
+
+def test_mirrortmp_remote_prefixes_use_tmp_bucket_map():
+    """mirrortmp:// remote prefixes come from REGION_TO_TMP_BUCKET, never from data buckets."""
+    prefixes = _mirror_remote_prefixes("gs://marin-tmp-us-central1", family="tmp")
+    assert prefixes
+    tmp_bucket_urls = {f"gs://{b}" for b in REGION_TO_TMP_BUCKET.values()}
+    assert set(prefixes) <= tmp_bucket_urls
+    # Local prefix itself must be excluded.
+    assert "gs://marin-tmp-us-central1" not in prefixes
+    # Another tmp bucket should be present.
+    assert "gs://marin-tmp-eu-west4" in prefixes
+    # No primary data buckets should leak in.
+    data_bucket_urls = {f"gs://{b}" for b in REGION_TO_DATA_BUCKET.values()}
+    assert not (set(prefixes) & data_bucket_urls)
+
+
+def test_mirrortmp_remote_prefixes_empty_for_non_gcs():
+    """Regression for marin-community/marin#4656 applied to the tmp family."""
+    assert _mirror_remote_prefixes("s3://marin-na/marin", family="tmp") == []
+    assert _mirror_remote_prefixes("/tmp/marin", family="tmp") == []
+    assert _mirror_remote_prefixes("file:///tmp/marin", family="tmp") == []
+
+
+def test_mirrortmp_local_prefix_uses_region_tmp_bucket(monkeypatch):
+    """On a GCS marin prefix with a known region, the local prefix is the matching tmp bucket."""
+    monkeypatch.setenv("MARIN_PREFIX", "gs://marin-us-east5")
+    monkeypatch.setattr("rigging.filesystem.region_from_metadata", lambda: "us-east5")
+    assert _mirror_local_prefix("tmp") == "gs://marin-tmp-us-east5"
+
+
+def test_mirrortmp_local_prefix_falls_back_for_non_gcs(monkeypatch):
+    """Non-GCS marin prefix → ``<marin_prefix>/tmp`` (mirrors marin_temp_bucket fallback)."""
+    monkeypatch.setenv("MARIN_PREFIX", "/var/marin")
+    assert _mirror_local_prefix("tmp") == "file:///var/marin/tmp"
+    monkeypatch.setenv("MARIN_PREFIX", "s3://marin-na/marin")
+    assert _mirror_local_prefix("tmp") == "s3://marin-na/marin/tmp"
+
+
+def test_mirrortmp_filesystem_init_on_s3(monkeypatch):
+    """Full __init__ on a non-GCS prefix: empty remote prefixes, local prefix routes to tmp/."""
+    monkeypatch.setenv("MARIN_PREFIX", "s3://marin-na/marin")
+    fs = MirrorTmpFileSystem()
+    assert fs._local_prefix == "s3://marin-na/marin/tmp"
+    assert fs._remote_prefixes == []
+
+
+# ---------------------------------------------------------------------------
+# stage_to_local — recursive directory staging
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def stage_fs(mirror_env, tmp_path):
+    """A MirrorFileSystem (data family) with hand-set local + remote prefixes for staging tests."""
+    fs = MirrorFileSystem.__new__(MirrorFileSystem)
+    fsspec.AbstractFileSystem.__init__(fs)
+    fs._local_prefix = mirror_env["local_prefix"]
+    fs._remote_prefixes = mirror_env["remote_prefixes"]
+    fs._budget = TransferBudget(limit_bytes=10 * 1024 * 1024 * 1024)
+    fs._worker_id = "test-holder"
+    lock_dir = str(tmp_path / "stage_locks")
+    fs._lock_path_for = lambda path: os.path.join(lock_dir, f"{path.replace('/', '_')}.lock")
+    return fs
+
+
+def test_stage_to_local_copies_directory_recursively(stage_fs, mirror_env):
+    _write_file(mirror_env["remote1"], "ckpt/run-A/step-1/params.shard", b"P" * 100)
+    _write_file(mirror_env["remote1"], "ckpt/run-A/step-1/metadata.json", b'{"step": 1}')
+
+    local_url = stage_fs.stage_to_local("ckpt/run-A/step-1")
+
+    assert local_url == os.path.join(mirror_env["local_prefix"], "ckpt/run-A/step-1")
+    assert os.path.exists(os.path.join(local_url, "params.shard"))
+    assert os.path.exists(os.path.join(local_url, "metadata.json"))
+    with open(os.path.join(local_url, "params.shard"), "rb") as f:
+        assert f.read() == b"P" * 100
+
+
+def test_stage_to_local_complete_local_no_remote_returns_local(stage_fs, mirror_env):
+    """When local is fully populated and no remote source exists, return local without erroring."""
+    _write_file(mirror_env["local_dir"], "ckpt/local-only/file.bin", b"L")
+
+    bytes_before = stage_fs.bytes_copied
+    local_url = stage_fs.stage_to_local("ckpt/local-only")
+
+    assert local_url == os.path.join(mirror_env["local_prefix"], "ckpt/local-only")
+    assert stage_fs.bytes_copied == bytes_before  # no remote found ⇒ no debit
+
+
+def test_stage_to_local_no_source_anywhere_raises(stage_fs):
+    with pytest.raises(FileNotFoundError, match="not found in any marin bucket"):
+        stage_fs.stage_to_local("ckpt/never-existed")
+
+
+def test_stage_to_local_charges_budget_once(stage_fs, mirror_env):
+    _write_file(mirror_env["remote1"], "ckpt/run-B/step-2/a.bin", b"A" * 250)
+    _write_file(mirror_env["remote1"], "ckpt/run-B/step-2/b.bin", b"B" * 250)
+
+    bytes_before = stage_fs.bytes_copied
+    stage_fs.stage_to_local("ckpt/run-B/step-2")
+    assert stage_fs.bytes_copied == bytes_before + 500
+
+
+def test_stage_to_local_budget_exceeded_no_partial_copy(stage_fs, mirror_env):
+    stage_fs._budget.reset(limit_bytes=100)
+    _write_file(mirror_env["remote1"], "ckpt/big/step-3/a.bin", b"A" * 250)
+    _write_file(mirror_env["remote1"], "ckpt/big/step-3/b.bin", b"B" * 250)
+
+    with pytest.raises(TransferBudgetExceeded):
+        stage_fs.stage_to_local("ckpt/big/step-3")
+
+    # No partial files should have been written locally.
+    assert not os.path.exists(os.path.join(mirror_env["local_prefix"], "ckpt/big/step-3/a.bin"))
+    assert not os.path.exists(os.path.join(mirror_env["local_prefix"], "ckpt/big/step-3/b.bin"))
+
+
+def test_stage_to_local_repairs_partial_local_directory(stage_fs, mirror_env):
+    """Partial prior stage left local dir present but missing a file — repair, don't trust local."""
+    _write_file(mirror_env["remote1"], "ckpt/partial/step-4/a.bin", b"A" * 50)
+    _write_file(mirror_env["remote1"], "ckpt/partial/step-4/b.bin", b"B" * 70)
+    # Simulate a crashed prior stage: one file present locally, the other missing.
+    _write_file(mirror_env["local_dir"], "ckpt/partial/step-4/a.bin", b"A" * 50)
+
+    bytes_before = stage_fs.bytes_copied
+    stage_fs.stage_to_local("ckpt/partial/step-4")
+
+    # Both files now present locally.
+    assert os.path.exists(os.path.join(mirror_env["local_prefix"], "ckpt/partial/step-4/a.bin"))
+    assert os.path.exists(os.path.join(mirror_env["local_prefix"], "ckpt/partial/step-4/b.bin"))
+    # Only the missing file's bytes were charged — the already-present 50 bytes aren't double-counted.
+    assert stage_fs.bytes_copied == bytes_before + 70
+
+
+def test_stage_to_local_repairs_size_mismatch(stage_fs, mirror_env):
+    """Local file present but with wrong size → re-copy."""
+    _write_file(mirror_env["remote1"], "ckpt/mismatch/step-5/data.bin", b"R" * 100)
+    _write_file(mirror_env["local_dir"], "ckpt/mismatch/step-5/data.bin", b"OLD")  # 3 bytes
+
+    bytes_before = stage_fs.bytes_copied
+    stage_fs.stage_to_local("ckpt/mismatch/step-5")
+
+    with open(os.path.join(mirror_env["local_prefix"], "ckpt/mismatch/step-5/data.bin"), "rb") as f:
+        assert f.read() == b"R" * 100
+    assert stage_fs.bytes_copied == bytes_before + 100
+
+
+def test_stage_to_local_returns_concrete_local_url(stage_fs, mirror_env):
+    """Returned URL is the local concrete path (not mirror://...) so tensorstore can read it."""
+    _write_file(mirror_env["remote1"], "ckpt/scheme/step-6/x.bin", b"x")
+    url = stage_fs.stage_to_local("ckpt/scheme/step-6")
+    assert "mirror" not in url
+    assert url.startswith(mirror_env["local_prefix"])

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -14,6 +14,7 @@ from levanter.trainer import TrainerConfig
 from marin.training.training import (
     TrainLmOnPodConfig,
     _doublecheck_paths,
+    _enforce_run_id,
 )
 
 
@@ -116,3 +117,100 @@ def test_pathlib_path_handling(trainer_config):
         )
         with pytest.raises(ValueError, match="not in the same region"):
             _doublecheck_paths(config)
+
+
+# ---------------------------------------------------------------------------
+# Cross-region temp checkpoint search-path wiring (mirrortmp://)
+# ---------------------------------------------------------------------------
+
+
+def _make_train_config(*, output_path: str | None, run_id: str | None, impute: bool) -> TrainLmOnPodConfig:
+    return TrainLmOnPodConfig(
+        train_config=train_lm.TrainLmConfig(
+            data={"train_urls": ["gs://bucket/path"]},  # type: ignore[arg-type]
+            trainer=TrainerConfig(id=run_id, checkpointer=CheckpointerConfig()),
+        ),
+        resources=ResourceConfig.with_tpu("v4-8"),
+        output_path=output_path,
+        impute_run_id_from_output_path=impute,
+    )
+
+
+def test_enforce_run_id_imputed_includes_run_id_literal_in_mirror_search_path():
+    """impute_run_id_from_output_path=True ⇒ search path contains the imputed run-id literal,
+    not the bare ``checkpoints-temp/`` root (which would glob across all runs)."""
+    config = _make_train_config(
+        output_path="gs://marin-us-central1/runs/foo-abc123",
+        run_id=None,
+        impute=True,
+    )
+    enforced = _enforce_run_id(config)
+    search_paths = enforced.train_config.trainer.checkpointer.temporary_search_paths
+    assert "mirrortmp://ttl=14d/checkpoints-temp/foo-abc123" in search_paths
+    # Bare prefix without run-id must never appear.
+    assert "mirrortmp://ttl=14d/checkpoints-temp" not in search_paths
+    assert "mirrortmp://ttl=14d/checkpoints-temp/" not in search_paths
+
+
+def test_enforce_run_id_explicit_includes_run_id_literal_in_mirror_search_path():
+    config = _make_train_config(
+        output_path="gs://marin-us-central1/runs/whatever",
+        run_id="my-explicit-run",
+        impute=False,
+    )
+    enforced = _enforce_run_id(config)
+    search_paths = enforced.train_config.trainer.checkpointer.temporary_search_paths
+    assert "mirrortmp://ttl=14d/checkpoints-temp/my-explicit-run" in search_paths
+
+
+def test_enforce_run_id_appends_to_existing_search_paths():
+    """Pre-existing entries on the user-supplied config are preserved; mirror entry is appended."""
+    base_config = _make_train_config(
+        output_path="gs://marin-us-central1/runs/foo-abc123",
+        run_id=None,
+        impute=True,
+    )
+    base_config = dataclasses.replace(
+        base_config,
+        train_config=dataclasses.replace(
+            base_config.train_config,
+            trainer=dataclasses.replace(
+                base_config.train_config.trainer,
+                checkpointer=dataclasses.replace(
+                    base_config.train_config.trainer.checkpointer,
+                    temporary_search_paths=["custom://prior/entry"],
+                ),
+            ),
+        ),
+    )
+    enforced = _enforce_run_id(base_config)
+    paths = enforced.train_config.trainer.checkpointer.temporary_search_paths
+    assert paths == [
+        "custom://prior/entry",
+        "mirrortmp://ttl=14d/checkpoints-temp/foo-abc123",
+    ]
+
+
+def test_enforce_run_id_dedupes_existing_mirror_entry():
+    """Idempotent: re-running _enforce_run_id (or a user pre-supplying the entry) doesn't duplicate."""
+    config = _make_train_config(
+        output_path="gs://marin-us-central1/runs/foo-abc123",
+        run_id=None,
+        impute=True,
+    )
+    config = dataclasses.replace(
+        config,
+        train_config=dataclasses.replace(
+            config.train_config,
+            trainer=dataclasses.replace(
+                config.train_config.trainer,
+                checkpointer=dataclasses.replace(
+                    config.train_config.trainer.checkpointer,
+                    temporary_search_paths=["mirrortmp://ttl=14d/checkpoints-temp/foo-abc123"],
+                ),
+            ),
+        ),
+    )
+    enforced = _enforce_run_id(config)
+    paths = enforced.train_config.trainer.checkpointer.temporary_search_paths
+    assert paths.count("mirrortmp://ttl=14d/checkpoints-temp/foo-abc123") == 1

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -214,3 +214,110 @@ def test_enforce_run_id_dedupes_existing_mirror_entry():
     enforced = _enforce_run_id(config)
     paths = enforced.train_config.trainer.checkpointer.temporary_search_paths
     assert paths.count("mirrortmp://ttl=14d/checkpoints-temp/foo-abc123") == 1
+
+
+def _with_temp_base_path(config: TrainLmOnPodConfig, temp_base: str) -> TrainLmOnPodConfig:
+    """Inject a ``temporary_base_path`` (simulating ``_update_config_to_use_out_path``)."""
+    return dataclasses.replace(
+        config,
+        train_config=dataclasses.replace(
+            config.train_config,
+            trainer=dataclasses.replace(
+                config.train_config.trainer,
+                checkpointer=dataclasses.replace(
+                    config.train_config.trainer.checkpointer,
+                    temporary_base_path=temp_base,
+                ),
+            ),
+        ),
+    )
+
+
+def test_enforce_run_id_inlines_run_id_into_temp_base_path_in_midtraining():
+    """Midtraining (impute=True ⇒ append_run_id_to_base_path=False) ⇒ Levanter's
+    ``expanded_temporary_path`` would NOT append run_id, so writes would land at
+    ``.../checkpoints-temp/step-N`` and the mirror search path with run_id would never
+    match.  Marin must inline run_id into ``temporary_base_path`` so writes and search
+    agree on the same directory."""
+    config = _make_train_config(
+        output_path="gs://marin-us-central1/runs/foo-abc123",
+        run_id=None,
+        impute=True,
+    )
+    config = _with_temp_base_path(config, "gs://marin-tmp-us-central1/ttl=14d/checkpoints-temp")
+
+    enforced = _enforce_run_id(config)
+    cp = enforced.train_config.trainer.checkpointer
+
+    # 1. Run-id is inlined.
+    assert cp.temporary_base_path == "gs://marin-tmp-us-central1/ttl=14d/checkpoints-temp/foo-abc123"
+    # 2. expanded_temporary_path does NOT double-append (append_run_id_to_base_path=False).
+    assert cp.expanded_temporary_path("foo-abc123") == "gs://marin-tmp-us-central1/ttl=14d/checkpoints-temp/foo-abc123"
+    # 3. Aligned with the mirror search path — write destination and search root agree.
+    assert "mirrortmp://ttl=14d/checkpoints-temp/foo-abc123" in cp.temporary_search_paths
+
+
+def test_enforce_run_id_does_not_double_append_when_levanter_will_append():
+    """Non-midtraining (impute=False ⇒ append_run_id_to_base_path=True) ⇒ Levanter
+    *will* append run_id in ``expanded_temporary_path``.  Marin must NOT pre-inline,
+    or we'd end up with ``.../checkpoints-temp/run-X/run-X``."""
+    config = _make_train_config(
+        output_path="gs://marin-us-central1/runs/whatever",
+        run_id="my-explicit-run",
+        impute=False,
+    )
+    config = _with_temp_base_path(config, "gs://marin-tmp-us-central1/ttl=14d/checkpoints-temp")
+
+    enforced = _enforce_run_id(config)
+    cp = enforced.train_config.trainer.checkpointer
+
+    # Marin did NOT pre-inline; Levanter appends on its own.
+    assert cp.temporary_base_path == "gs://marin-tmp-us-central1/ttl=14d/checkpoints-temp"
+    assert cp.append_run_id_to_base_path is True
+    assert (
+        cp.expanded_temporary_path("my-explicit-run")
+        == "gs://marin-tmp-us-central1/ttl=14d/checkpoints-temp/my-explicit-run"
+    )
+
+
+def test_enforce_run_id_temp_base_path_inline_is_idempotent():
+    """Pre-supplied ``temporary_base_path`` already ending in ``/{run_id}`` is left alone."""
+    config = _make_train_config(
+        output_path="gs://marin-us-central1/runs/foo-abc123",
+        run_id=None,
+        impute=True,
+    )
+    config = _with_temp_base_path(config, "gs://marin-tmp-us-central1/ttl=14d/checkpoints-temp/foo-abc123")
+    enforced = _enforce_run_id(config)
+    cp = enforced.train_config.trainer.checkpointer
+    assert cp.temporary_base_path == "gs://marin-tmp-us-central1/ttl=14d/checkpoints-temp/foo-abc123"
+
+
+def test_enforce_run_id_leaves_temp_base_path_alone_if_none():
+    """No ``temporary_base_path`` set (e.g. ``_update_config_to_use_out_path`` short-circuited
+    on ``output_path is None``) ⇒ no inline; Marin doesn't fabricate a path."""
+    config = _make_train_config(output_path=None, run_id="my-run", impute=False)
+    enforced = _enforce_run_id(config)
+    cp = enforced.train_config.trainer.checkpointer
+    assert cp.temporary_base_path is None
+
+
+def test_enforce_run_id_temp_write_matches_mirror_search_in_midtraining():
+    """End-to-end alignment check: in midtraining, the directory the temp writes target
+    is exactly what the mirrortmp:// search path resolves to."""
+    config = _make_train_config(
+        output_path="gs://marin-us-central1/runs/foo-abc123",
+        run_id=None,
+        impute=True,
+    )
+    config = _with_temp_base_path(config, "gs://marin-tmp-us-central1/ttl=14d/checkpoints-temp")
+
+    enforced = _enforce_run_id(config)
+    cp = enforced.train_config.trainer.checkpointer
+
+    write_dir = cp.expanded_temporary_path("foo-abc123")
+    search_url = next(p for p in cp.temporary_search_paths if p.startswith("mirrortmp://"))
+
+    # Strip the bucket-family prefix from each side and compare the *path* portion.
+    assert write_dir.endswith("/ttl=14d/checkpoints-temp/foo-abc123")
+    assert search_url.endswith("/ttl=14d/checkpoints-temp/foo-abc123")

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -302,9 +302,10 @@ def test_enforce_run_id_leaves_temp_base_path_alone_if_none():
     assert cp.temporary_base_path is None
 
 
-def test_enforce_run_id_temp_write_matches_mirror_search_in_midtraining():
-    """End-to-end alignment check: in midtraining, the directory the temp writes target
-    is exactly what the mirrortmp:// search path resolves to."""
+def test_temp_write_path_matches_mirror_search_path_for_resume():
+    """Alignment invariant: the directory the temp writes target must equal the
+    directory the mirrortmp:// search path resolves to.  If they diverge, a cross-region
+    resume can't find the temp checkpoint written before preemption."""
     config = _make_train_config(
         output_path="gs://marin-us-central1/runs/foo-abc123",
         run_id=None,


### PR DESCRIPTION
mirrortmp:// (search-only) unions marin-tmp-* across regions so a cross-region resume finds temp checkpoints written in another region, instead of falling back to the older permanent step. MirrorFileSystem.stage_to_local re-stages missing or size-mismatched files rather than trusting local directory presence since a partial prior stage can leave a dir present but incomplete. Levanter's load_checkpoint and latest_checkpoint_path call the hook before TensorStore. Marin composes the search URL with the explicit run-id literal so discovery never globs the shared checkpoints-temp/ root.

Fixes #5217