### PR TITLE
[Marin] Guard region-pinned GCS access in training and Levanter

### DIFF
--- a/lib/iris/tests/test_marin_fs.py
+++ b/lib/iris/tests/test_marin_fs.py
@@ -24,6 +24,7 @@ from rigging.filesystem import (
     open_url,
     region_from_metadata,
     region_from_prefix,
+    runtime_gcp_region,
     url_to_fs,
 )
 
@@ -53,6 +54,8 @@ def test_region_from_metadata_returns_none_on_failure():
     [
         ("gs://marin-us-east1/scratch", "us-east1"),
         ("gs://marin-us-central2/data", "us-central2"),
+        ("gs://marin-tmp-us-east1/ttl=30d/cache", "us-east1"),
+        ("gs://marin-tmp-eu-west4/ttl=30d/cache", "europe-west4"),
         # Abbreviated bucket name normalizes to canonical GCP region.
         ("gs://marin-eu-west4/tokenized", "europe-west4"),
         ("gs://other-bucket/foo", None),
@@ -90,6 +93,19 @@ def test_marin_prefix_falls_back_to_local():
 def test_marin_region_from_metadata():
     with patch(
         "rigging.filesystem.urllib.request.urlopen", return_value=_mock_urlopen(b"projects/12345/zones/us-east1-c")
+    ):
+        assert marin_region() == "us-east1"
+
+
+def test_runtime_gcp_region_from_iris_worker_region():
+    with patch.dict(os.environ, {"IRIS_WORKER_REGION": "US-CENTRAL2", "MARIN_PREFIX": "gs://marin-us-east1"}):
+        assert runtime_gcp_region() == "us-central2"
+
+
+def test_marin_region_ignores_iris_worker_region():
+    with (
+        patch("rigging.filesystem.urllib.request.urlopen", side_effect=OSError("not on GCP")),
+        patch.dict(os.environ, {"IRIS_WORKER_REGION": "US-CENTRAL2", "MARIN_PREFIX": "gs://marin-us-east1"}),
     ):
         assert marin_region() == "us-east1"
 

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -38,6 +38,7 @@ from levanter.tensorstore_serialization import (
     tree_deserialize_leaves_tensorstore,
     tree_serialize_leaves_tensorstore,
 )
+from levanter.utils import cloud_utils
 from levanter.utils import fsspec_utils
 from levanter.utils.jax_utils import broadcast_one_to_all
 from levanter.utils.types import FilterSpec
@@ -446,6 +447,7 @@ class Checkpointer:
 
         # The default of 5 minutes is too short even for modestly sized models for some reason
         self._manager = GlobalAsyncCheckpointManager(timeout_secs=60 * 30)
+        cloud_utils.assert_gcs_path_region_compatible(self.base_path, purpose="checkpoint initialization")
 
         if jax.process_index() == 0:
             self._async_checkpoint_remover_queue: queue.Queue[str] = queue.Queue(maxsize=-1)
@@ -641,6 +643,7 @@ class Checkpointer:
         base = base_path_override if base_path_override is not None else self.base_path
         path = os.path.join(base, destination)
         logger.info(f"Saving checkpoint at step {step} to {path}")
+        cloud_utils.assert_gcs_path_region_compatible(path, purpose="checkpoint save")
 
         save_checkpoint(
             tree,
@@ -692,6 +695,7 @@ def save_checkpoint(
     checkpoint_path = str(checkpoint_path)
     checkpoint_debug = debug or CheckpointDebugConfig()
     logger.info(f"Saving checkpoint to {checkpoint_path} for step {step}")
+    cloud_utils.assert_gcs_path_region_compatible(checkpoint_path, purpose="checkpoint save")
     progress_logger: _CheckpointProgressLogger | None = None
     if checkpoint_debug.enabled:
         if not tracemalloc.is_tracing():
@@ -793,6 +797,7 @@ def load_checkpoint(
 
     """
     checkpoint_path = str(checkpoint_path)
+    cloud_utils.assert_gcs_path_region_compatible(checkpoint_path, purpose="checkpoint load")
 
     if is_in_jit():
         logger.warning("Loading checkpoint in jit. This is not recommended and probably won't work.")
@@ -943,6 +948,7 @@ def discover_latest_checkpoint(checkpoint_path: PathLike, *additional_paths: Pat
     best_key: tuple[datetime.datetime, int] | None = None
 
     for cp_path in all_paths:
+        cloud_utils.assert_gcs_path_region_compatible(cp_path, purpose="discover latest checkpoint")
         found = _discover_latest_checkpoint_single(cp_path)
         if found is None:
             continue
@@ -1087,6 +1093,7 @@ def is_checkpoint_path(path: str) -> bool:
     Check if a given path is a checkpoint path.
     """
     try:
+        cloud_utils.assert_gcs_path_region_compatible(path, purpose="checkpoint path check")
         if not fsspec_utils.exists(path):
             return False
         # Sometimes we have incomplete checkpoints due to preemption or other issues.

--- a/lib/levanter/src/levanter/compat/hf_checkpoints.py
+++ b/lib/levanter/src/levanter/compat/hf_checkpoints.py
@@ -53,6 +53,7 @@ from levanter.callbacks import StepInfo
 from levanter.compat.fsspec_safetensor import read_safetensors_fsspec
 from levanter.models.asr_model import ASRMixin
 from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.utils import cloud_utils
 from levanter.utils.cloud_utils import temp_dir_before_upload
 from levanter.tokenizers import MarinTokenizer
 from levanter.utils.hf_utils import HfTokenizer
@@ -314,6 +315,7 @@ def _load_torch(path, dtype, fs: AbstractFileSystem | None = None):
 
 def _load_safe_tensors(path, dtype, fs: AbstractFileSystem | None = None):
     """Stream a safetensors shard from remote storage and return JAX arrays."""
+    cloud_utils.assert_gcs_path_region_compatible(path, purpose="hf safetensors load")
     if fs is None:
         fs, stripped = url_to_fs(path, asynchronous=True)
         path = stripped
@@ -723,6 +725,7 @@ class HFCheckpointConverter(Generic[LevConfig]):
 
         final_state_dict = {}
 
+        cloud_utils.assert_gcs_path_region_compatible(url, purpose="hf checkpoint load")
         fs: AbstractFileSystem
         fs, path = url_to_fs(url)
 

--- a/lib/levanter/src/levanter/data/audio.py
+++ b/lib/levanter/src/levanter/data/audio.py
@@ -31,6 +31,7 @@ from levanter.data.mixture import MixtureDataset, StopStrategy
 from levanter.data.sharded_datasource import AudioTextUrlDataSource, ShardedDataSource, WrappedHFDataSource
 from levanter.data.text import BatchTokenizer
 from levanter.tokenizers import MarinTokenizer, load_tokenizer as load_marin_tokenizer
+from levanter.utils import cloud_utils
 
 # intercept the logging nonsense here
 from levanter.models.asr_model import AudioTextExample
@@ -210,6 +211,7 @@ class AudioDatasetSourceConfig:
             raise ValueError(f"Unknown split {split}")
 
         def fsspec_expand_glob(url):
+            cloud_utils.assert_gcs_path_region_compatible(url, purpose="audio glob expansion")
             if "*" in url:
                 fs = url_to_fs(url)[0]
                 return fs.glob(url)

--- a/lib/levanter/src/levanter/data/sharded_datasource.py
+++ b/lib/levanter/src/levanter/data/sharded_datasource.py
@@ -15,6 +15,7 @@ from rigging.filesystem import open_url
 import pyarrow.parquet as pq
 
 from levanter.utils import fsspec_utils
+from levanter.utils import cloud_utils
 
 from ..data import AsyncDataset
 from ..utils.fsspec_utils import expand_glob
@@ -233,6 +234,7 @@ class TextUrlDataSource(ShardedDataSource[str]):
 
     def open_shard_at_row(self, shard_name: str, row: int) -> Iterator[str]:
         url = self.base_ds._shard_name_to_url_mapping[shard_name]
+        cloud_utils.assert_gcs_path_region_compatible(url, purpose="text shard load")
         i = 0
         compression = "infer"
         if url.endswith(".zstd"):  # hacky way to detect zstd
@@ -314,7 +316,8 @@ class AudioTextUrlDataSource(UrlBackedShardedDataSource[Tuple[np.ndarray, int, s
         import librosa  # noqa F401
 
         def _load_audio_file(file_name, sampling_rate):
-            with open_url(audio_pointer, "rb", compression="infer") as f:
+            cloud_utils.assert_gcs_path_region_compatible(file_name, purpose="audio file load")
+            with open_url(file_name, "rb", compression="infer") as f:
                 array, sr = librosa.load(f, sr=sampling_rate)
             return {"array": array, "sampling_rate": sr}
 
@@ -339,6 +342,7 @@ class AudioTextUrlDataSource(UrlBackedShardedDataSource[Tuple[np.ndarray, int, s
 
     def open_shard_at_row(self, shard_name: str, row: int) -> Iterator[Tuple[np.ndarray, int, str]]:
         url = self._shard_name_to_url_mapping[shard_name]
+        cloud_utils.assert_gcs_path_region_compatible(url, purpose="audio shard load")
         i = 0
         with open_url(url, "r", compression="infer") as f:
             format = _sniff_format_for_dataset(url)
@@ -449,6 +453,7 @@ class JsonlDataSource(UrlBackedShardedDataSource[dict]):
 
     def open_shard_at_row(self, shard_name: str, row: int) -> Iterator[dict]:
         url = self._shard_name_to_url_mapping[shard_name]
+        cloud_utils.assert_gcs_path_region_compatible(url, purpose="jsonl shard load")
         i = 0
         with open_url(url, "r", compression="infer") as f:
             # TODO: would be nice if we could seek faster than this. Right now, all we do is skip json parsing
@@ -465,6 +470,7 @@ class JsonDataSource(UrlBackedShardedDataSource[dict]):
 
     def open_shard_at_row(self, shard_name: str, row: int) -> Iterator[dict]:
         url = self._shard_name_to_url_mapping[shard_name]
+        cloud_utils.assert_gcs_path_region_compatible(url, purpose="json shard load")
         with open_url(url, "r", compression="infer") as f:
             data = json.load(f)
             return iter(data[row:])

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -28,6 +28,7 @@ from zephyr import Dataset, ZephyrContext
 from zephyr.writers import write_levanter_cache
 
 from levanter.data.dataset import AsyncDataset
+from levanter.utils import cloud_utils
 from levanter.utils.jax_utils import broadcast_one_to_all
 
 from ..data._preprocessor import BatchProcessor, BatchResult, dict_from_record_batch
@@ -68,6 +69,7 @@ def build_or_load_cache(
     """
     Build or load a TreeCache from a sharded data source using a Zephyr backend.
     """
+    cloud_utils.assert_gcs_path_region_compatible(cache_dir, purpose="cache load or build")
     metadata = CacheMetadata(preprocessor_metadata=processor.metadata)
     try:
         return TreeCache.load(cache_dir, processor.output_exemplar, metadata)
@@ -135,6 +137,7 @@ class TreeCache(AsyncDataset[T_co]):
     @staticmethod
     def load(cache_dir: str, exemplar: T, options: Optional["CacheMetadata"] = None) -> "TreeCache":
         logger.info(f"Loading cache from {cache_dir}")
+        cloud_utils.assert_gcs_path_region_compatible(cache_dir, purpose="cache load")
         ledger = CacheLedger.load(cache_dir, options)
 
         if not ledger.is_finished:
@@ -185,6 +188,7 @@ class CacheLedger:
         ledger_path = os.path.join(cache_dir, LEDGER_FILE_NAME)
         try:
             logger.info(f"Attempting to load cache ledger from {ledger_path}")
+            cloud_utils.assert_gcs_path_region_compatible(ledger_path, purpose="cache ledger load")
             with open_url(ledger_path) as file:
                 cache_ledger = CacheLedger.from_json(file.read())  # type: ignore[arg-type]
             if metadata:

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -26,6 +26,7 @@ from jax.sharding import Mesh, Sharding
 from jaxtyping import PyTree
 
 from levanter._debug_logging import flush_debug_output
+from levanter.utils import cloud_utils
 from levanter.utils import fsspec_utils, jax_utils
 
 logger = logging.getLogger(__name__)
@@ -71,6 +72,7 @@ def build_kvstore_spec(path: str) -> dict:
 
         return spec
     elif parsed.scheme == "gs":
+        cloud_utils.assert_gcs_path_region_compatible(path, purpose="tensorstore kvstore")
         return {"driver": "gcs", "bucket": parsed.netloc, "path": parsed.path.lstrip("/")}
     elif parsed.scheme in ("", "file"):
         return {"driver": "file", "path": os.path.abspath(path)}

--- a/lib/levanter/src/levanter/utils/cloud_utils.py
+++ b/lib/levanter/src/levanter/utils/cloud_utils.py
@@ -8,13 +8,13 @@ import os
 import shutil
 import tempfile
 import time
-import urllib.parse
 from typing import Optional
 
 import fsspec
 import jax
 import requests  # type: ignore
 from fsspec import AbstractFileSystem
+from rigging.filesystem import check_path_in_region, runtime_gcp_region
 
 from levanter.utils.jax_utils import sync_global_devices
 
@@ -47,6 +47,19 @@ def _checked_delete(url):
     except requests.exceptions.RequestException:
         logger.exception(f"Could not delete {url} from metadata server. Is this a TPU VM?", exc_info=True)
         raise
+
+
+def assert_gcs_path_region_compatible(path: str, *, purpose: str | None = None) -> None:
+    """Raise if a gs:// path points at a bucket in a different region than the current host."""
+    if not path.startswith("gs://"):
+        return
+
+    current_region = runtime_gcp_region()
+    if current_region is None:
+        logger.debug("Skipping GCS region check for %s because the current region is unknown", path)
+        return
+
+    check_path_in_region(purpose or "GCS path", path, current_region, local_ok=True)
 
 
 def _shutdown_tpu_with_queued_resource():

--- a/lib/levanter/src/levanter/utils/cloud_utils.py
+++ b/lib/levanter/src/levanter/utils/cloud_utils.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import tempfile
 import time
+import urllib.parse
 from typing import Optional
 
 import fsspec

--- a/lib/levanter/src/levanter/utils/fsspec_utils.py
+++ b/lib/levanter/src/levanter/utils/fsspec_utils.py
@@ -8,15 +8,19 @@ import braceexpand
 import fsspec
 from rigging.filesystem import url_to_fs
 
+from . import cloud_utils
+
 
 def exists(url, **kwargs) -> bool:
     """Check if a file exists on a remote filesystem."""
+    cloud_utils.assert_gcs_path_region_compatible(url, purpose="filesystem exists")
     fs, path = url_to_fs(url, **kwargs)
     return fs.exists(path)
 
 
 def mkdirs(path):
     """Create a directory and any necessary parent directories."""
+    cloud_utils.assert_gcs_path_region_compatible(path, purpose="filesystem mkdirs")
     fs, path = url_to_fs(path)
     fs.makedirs(path, exist_ok=True)
 
@@ -31,6 +35,7 @@ def expand_glob(url):
     ['s3://bucket/2023/a.json', 's3://bucket/2024/b.json', ...]
     """
     for candidate in braceexpand.braceexpand(url):
+        cloud_utils.assert_gcs_path_region_compatible(candidate, purpose="glob expansion")
         fs, path = url_to_fs(candidate)
 
         if glob.has_magic(path):
@@ -44,6 +49,7 @@ def expand_glob(url):
 def remove(url, *, recursive=False, **kwargs):
     """Remove a file from a remote filesystem."""
     # TODO: better to use a STS deletion policy or job for this one.
+    cloud_utils.assert_gcs_path_region_compatible(url, purpose="filesystem remove")
     fs, path = url_to_fs(url, **kwargs)
 
     fs.rm(path, recursive=recursive)

--- a/lib/marin/src/marin/execution/executor.py
+++ b/lib/marin/src/marin/execution/executor.py
@@ -177,25 +177,34 @@ def _is_bucket_location_permission_error(exc: Exception) -> bool:
 
 
 def _region_for_gcs_path(path: str, *, step_name: str, bucket_region_cache: dict[str, str]) -> str | None:
-    region = region_from_prefix(path)
-    if region is not None:
-        return _normalize_region(region, step_name=step_name, path=path)
-
     bucket, _ = split_gcs_path(path)
-    if bucket not in bucket_region_cache:
-        try:
-            bucket_region_cache[bucket] = get_bucket_location(path)
-        except Exception as e:
-            if _is_bucket_location_permission_error(e):
-                logger.warning(
-                    "Could not infer bucket location for %s due to permission error; "
-                    "skipping this path for region inference.",
-                    path,
-                    exc_info=True,
-                )
-                return None
+    try:
+        if bucket not in bucket_region_cache:
+            bucket_region_cache[bucket] = get_bucket_location(bucket)
+        return _normalize_region(bucket_region_cache[bucket], step_name=step_name, path=path)
+    except Exception as e:
+        if not _is_bucket_location_permission_error(e):
             raise
-    return _normalize_region(bucket_region_cache[bucket], step_name=step_name, path=path)
+
+    region = region_from_prefix(path)
+    if region is None:
+        logger.warning(
+            "Could not infer bucket location for %s due to permission error; skipping this path for region inference.",
+            path,
+            exc_info=True,
+        )
+        return None
+
+    try:
+        return _normalize_region(region, step_name=step_name, path=path)
+    except ValueError:
+        logger.warning(
+            "Could not infer a concrete region for %s because bucket metadata access failed and the bucket name does "
+            "not encode a regional location.",
+            path,
+            exc_info=True,
+        )
+        return None
 
 
 def _infer_gcs_regions(
@@ -676,7 +685,18 @@ def resolve_executor_step(
     # Short-circuit for StepSpec -> ExecutorStep -> StepSpec round-trip.
     original: StepSpec | None = getattr(step, "_original_step_spec", None)
     if original is not None:
-        return dataclasses.replace(original, deps=deps or [])
+        original_fn = original.fn
+        if isinstance(original_fn, RemoteCallable):
+            original_fn = _maybe_attach_inferred_region_constraint(
+                step_name=step.name,
+                remote_fn=original_fn,
+                config=config,
+                output_path=output_path,
+                deps=deps,
+                dag_tpu_regions=dag_tpu_regions,
+                forced_region=forced_region,
+            )
+        return dataclasses.replace(original, deps=deps or [], fn=original_fn)
 
     remote_callable = step.fn if isinstance(step.fn, RemoteCallable) else None
     if remote_callable is not None:

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -20,7 +20,6 @@ import braceexpand
 import draccus
 import fsspec
 import pyarrow.parquet as pq
-from rigging.filesystem import open_url, url_to_fs
 from datasets import load_dataset_builder
 from fray import ResourceConfig
 from levanter.data.text import (
@@ -34,6 +33,7 @@ from levanter.data.text import (
 from levanter.tokenizers import MarinTokenizer, TokenizerBackend, load_tokenizer
 from levanter.store.cache import consolidate_shard_caches
 from levanter.store.tree_store import TreeStore
+from rigging.filesystem import check_gcs_paths_same_region, open_url, url_to_fs
 from zephyr import Dataset, ZephyrContext, zephyr_worker_ctx
 from zephyr.dataset import FileEntry
 from zephyr.readers import InputFileSpec, load_file
@@ -280,6 +280,27 @@ def _expand_tokenize_paths(input_paths: list[str]) -> list[str]:
     return patterns
 
 
+def _source_url_strings(split_name: str, paths: Sequence[object]) -> Iterator[tuple[str, str]]:
+    for index, path in enumerate(paths):
+        if isinstance(path, VersionedValue):
+            path = path.value
+        if isinstance(path, InputName):
+            path = path.name
+        if isinstance(path, str):
+            yield f"{split_name}[{index}]", path
+
+
+def _check_source_urls_same_region(train_paths: Sequence[object], validation_paths: Sequence[object]) -> None:
+    source_urls = {
+        **dict(_source_url_strings("train_urls", train_paths)),
+        **dict(_source_url_strings("validation_urls", validation_paths)),
+    }
+    gcs_source_urls = {key: path for key, path in source_urls.items() if path.startswith("gs://")}
+    if not gcs_source_urls:
+        return
+    check_gcs_paths_same_region(gcs_source_urls, local_ok=True, skip_if_prefix_contains=())
+
+
 def _bundle_files_by_size(files: list[FileEntry], max_bytes: int):
     """Bundle files into groups, with each group having a total size less than max_bytes."""
     current_group: list[str] = []
@@ -345,6 +366,7 @@ def tokenize(config: TokenizeConfigBase):
     """
 
     if isinstance(config, TokenizeConfig):
+        _check_source_urls_same_region(config.train_paths, config.validation_paths)
         train_patterns = _expand_tokenize_paths(config.train_paths) if config.train_paths else []
         validation_patterns = _expand_tokenize_paths(config.validation_paths) if config.validation_paths else []
     elif isinstance(config, HfTokenizeConfig):
@@ -361,6 +383,7 @@ def tokenize(config: TokenizeConfigBase):
 
         train_patterns = list(data_files.get("train", []))
         validation_patterns = list(data_files.get("validation", data_files.get("test", [])))
+        _check_source_urls_same_region(train_patterns, validation_patterns)
     else:
         raise ValueError(f"Unknown config type: {type(config)}")
 

--- a/lib/marin/src/marin/training/training.py
+++ b/lib/marin/src/marin/training/training.py
@@ -6,6 +6,7 @@ import importlib
 import logging
 import os
 import urllib.parse
+import re
 from copy import deepcopy
 from collections.abc import Callable
 from dataclasses import dataclass, replace
@@ -24,7 +25,16 @@ from fray import (
 )
 from mergedeep import mergedeep
 
-from rigging.filesystem import check_gcs_paths_same_region, marin_temp_bucket
+from rigging.filesystem import (
+    REGION_TO_TMP_BUCKET,
+    check_gcs_paths_same_region,
+    check_path_in_region,
+    collect_gcs_paths,
+    get_bucket_location,
+    marin_temp_bucket,
+    region_from_prefix,
+    split_gcs_path,
+)
 from marin.training.run_environment import add_run_env_variables
 
 logger = logging.getLogger(__name__)
@@ -87,6 +97,9 @@ DEFAULT_CHECKPOINTS_PATH = "checkpoints"
 DEFAULT_HF_CHECKPOINTS_PATH = "hf"
 TEMPORARY_CHECKPOINT_TTL_DAYS = 14
 TEMPORARY_CHECKPOINTS_PATH = "checkpoints-temp"
+_SOURCE_URL_FIELDS = ("train_urls", "validation_urls")
+_NON_REGIONAL_BUCKET_LOCATIONS = {"us", "eu", "asia", "nam4", "eur4", "asia1"}
+_GCP_REGION_PATTERN = re.compile(r"^[a-z]+-[a-z0-9]+[0-9]$")
 
 
 def _cli_helpers_module():
@@ -203,6 +216,126 @@ def _normalize_jax_compilation_cache_dir(path: str) -> str:
     return path
 
 
+def _skip_source_url_fields(include_source_urls: bool) -> tuple[str, ...]:
+    return () if include_source_urls else _SOURCE_URL_FIELDS
+
+
+def _normalize_region(region: str, *, path: str) -> str:
+    normalized = region.lower()
+    if normalized in _NON_REGIONAL_BUCKET_LOCATIONS or "+" in normalized or not _GCP_REGION_PATTERN.match(normalized):
+        raise ValueError(
+            f"Training config references {path!r} in a non-regional bucket location ({normalized!r}); "
+            "cannot infer a single TPU/VM region."
+        )
+    return normalized
+
+
+def _is_bucket_location_permission_error(exc: Exception) -> bool:
+    return isinstance(exc, PermissionError) or exc.__class__.__name__ in {"Forbidden", "PermissionDenied"}
+
+
+def _region_for_gcs_path(path: str, *, bucket_region_cache: dict[str, str]) -> str | None:
+    bucket, _ = split_gcs_path(path)
+
+    try:
+        if bucket not in bucket_region_cache:
+            bucket_region_cache[bucket] = get_bucket_location(bucket)
+        return _normalize_region(bucket_region_cache[bucket], path=path)
+    except Exception as e:
+        if not _is_bucket_location_permission_error(e):
+            raise
+
+    region = region_from_prefix(path)
+    if region is None:
+        logger.warning(
+            "Could not infer bucket location for %s due to permission error; skipping this path for training region "
+            "inference.",
+            path,
+            exc_info=True,
+        )
+        return None
+
+    try:
+        return _normalize_region(region, path=path)
+    except ValueError:
+        logger.warning(
+            "Could not infer a concrete region for %s because bucket metadata access failed and the bucket name does "
+            "not encode a regional location.",
+            path,
+            exc_info=True,
+        )
+        return None
+
+
+def _infer_single_gcs_region(train_config: object, *, include_source_urls: bool) -> str | None:
+    """Infer the one concrete region required by resolved GCS paths in a training config."""
+    bucket_region_cache: dict[str, str] = {}
+    region_to_evidence: dict[str, list[str]] = {}
+    skip_fields = _skip_source_url_fields(include_source_urls)
+
+    for key, path in collect_gcs_paths(train_config, skip_if_prefix_contains=skip_fields):
+        region = _region_for_gcs_path(path, bucket_region_cache=bucket_region_cache)
+        if region is None:
+            continue
+        region_to_evidence.setdefault(region, []).append(f"{key}={path}")
+
+    if not region_to_evidence:
+        return None
+    if len(region_to_evidence) > 1:
+        detail = "; ".join(
+            f"{region}: {', '.join(sorted(evidence)[:3])}" for region, evidence in sorted(region_to_evidence.items())
+        )
+        raise ValueError(
+            "Training config references GCS paths in multiple regions. "
+            f"Found regions {{{', '.join(sorted(region_to_evidence))}}}. {detail}"
+        )
+    return next(iter(region_to_evidence))
+
+
+def _regional_temp_bucket(region: str, *, ttl_days: int, prefix: str) -> str:
+    bucket = REGION_TO_TMP_BUCKET.get(region)
+    if bucket is None:
+        raise ValueError(f"No Marin temp bucket is configured for region {region!r}.")
+    path = f"gs://{bucket}/ttl={ttl_days}d"
+    if prefix:
+        path = f"{path}/{prefix.strip('/')}"
+    return path
+
+
+def _align_resources_to_gcs_region(config: TrainOnPodConfigT) -> tuple[TrainOnPodConfigT, str | None]:
+    """Pin child training resources to the region implied by resolved GCS paths."""
+    inferred_region = _infer_single_gcs_region(
+        config.train_config,
+        include_source_urls=config.auto_build_caches,
+    )
+    if inferred_region is None:
+        return config, None
+
+    resource_regions = config.resources.regions
+    if resource_regions:
+        explicit_regions = {region.lower() for region in resource_regions}
+        if inferred_region not in explicit_regions:
+            raise ValueError(
+                f"Training job resources allow regions {sorted(explicit_regions)}, but resolved GCS paths require "
+                f"{inferred_region!r}. Running this TPU/VM job elsewhere would read or write across regions."
+            )
+
+    resources = dataclasses.replace(config.resources, regions=[inferred_region])
+    return replace(config, resources=resources), inferred_region
+
+
+def _check_jax_compilation_cache_region(env: dict[str, str], *, region: str | None, local_ok: bool) -> None:
+    cache_dir = env.get("JAX_COMPILATION_CACHE_DIR")
+    if cache_dir is None:
+        return
+    if not cache_dir.startswith("gs://"):
+        return
+    if region is not None:
+        check_path_in_region("JAX_COMPILATION_CACHE_DIR", cache_dir, region, local_ok=local_ok)
+        return
+    check_gcs_paths_same_region({"JAX_COMPILATION_CACHE_DIR": cache_dir}, local_ok=local_ok)
+
+
 def _disable_xla_autotune_subcache(env: dict) -> None:
     """Disable XLA's per-fusion autotune sub-cache for remote compilation caches.
 
@@ -236,6 +369,18 @@ def _prepare_training_run(
         logger.info(f"Using output path: {config.output_path}")
         config = _update_config_to_use_out_path(config)
 
+    config = _enforce_run_id(config)
+    logger.info(f"Using run ID: {config.train_config.trainer.id}")
+
+    train_config = config.train_config
+    train_config = _maybe_override_auto_build_caches(train_config, config.auto_build_caches)
+    config = replace(config, train_config=train_config)
+
+    training_region: str | None = None
+    if not isinstance(config.resources.device, CpuConfig):
+        config, training_region = _align_resources_to_gcs_region(config)
+        train_config = config.train_config
+
     env = _add_default_env_variables(
         config.env_vars or {},
         default_launch_config.env_for_accel(config.resources.device.variant),
@@ -246,25 +391,26 @@ def _prepare_training_run(
     env = add_run_env_variables(env)
 
     if "JAX_COMPILATION_CACHE_DIR" not in env:
-        env["JAX_COMPILATION_CACHE_DIR"] = _normalize_jax_compilation_cache_dir(
-            marin_temp_bucket(ttl_days=30, prefix="compilation-cache")
+        cache_dir = (
+            _regional_temp_bucket(training_region, ttl_days=30, prefix="compilation-cache")
+            if training_region is not None
+            else marin_temp_bucket(ttl_days=30, prefix="compilation-cache")
         )
+        env["JAX_COMPILATION_CACHE_DIR"] = _normalize_jax_compilation_cache_dir(cache_dir)
         logger.info("JAX compilation cache: %s", env["JAX_COMPILATION_CACHE_DIR"])
     _disable_xla_autotune_subcache(env)
-
-    config = _enforce_run_id(config)
-    logger.info(f"Using run ID: {config.train_config.trainer.id}")
-
-    train_config = config.train_config
-    train_config = _maybe_override_auto_build_caches(train_config, config.auto_build_caches)
-
     # disable accelerator requirement when running without GPU/TPU resources
     if config.resources.device.kind == "cpu":
         trainer = replace(train_config.trainer, require_accelerator=False)
         train_config = replace(train_config, trainer=trainer)
 
     if not isinstance(config.resources.device, CpuConfig):
-        _doublecheck_paths(config)
+        _check_jax_compilation_cache_region(env, region=training_region, local_ok=False)
+        _doublecheck_paths(
+            config,
+            region=training_region,
+            include_source_urls=config.auto_build_caches,
+        )
 
     extras: list[str] = []
     if isinstance(config.resources.device, TpuConfig):
@@ -353,7 +499,12 @@ def run_levanter_train_dpo(config: TrainDpoOnPodConfig):
     )
 
 
-def _doublecheck_paths(config: TrainOnPodConfigT):
+def _doublecheck_paths(
+    config: TrainOnPodConfigT,
+    *,
+    region: str | None = None,
+    include_source_urls: bool = False,
+) -> TrainOnPodConfigT:
     """
     Double-check that we're not using local paths in some of the standard places that Levanter sets defaults.
     Also check that the paths are in the same region as the VM, to avoid performance issues and billing surprises.
@@ -365,6 +516,8 @@ def _doublecheck_paths(config: TrainOnPodConfigT):
     check_gcs_paths_same_region(
         config.train_config,
         local_ok=local_ok,
+        region=region,
+        skip_if_prefix_contains=_skip_source_url_fields(include_source_urls),
     )
     return config
 

--- a/lib/rigging/src/rigging/filesystem.py
+++ b/lib/rigging/src/rigging/filesystem.py
@@ -82,7 +82,20 @@ REGION_TO_DATA_BUCKET: dict[str, str] = {
 # Derived from REGION_TO_DATA_BUCKET so that region_from_prefix can return
 # canonical region names even when the bucket uses abbreviated naming
 # (e.g. "marin-eu-west4" → "europe-west4" instead of "eu-west4").
-_BUCKET_TO_REGION: dict[str, str] = {bucket: region for region, bucket in REGION_TO_DATA_BUCKET.items()}
+_REGION_ALIASES: dict[str, str] = {
+    "eu-west4": "europe-west4",
+}
+
+
+def _canonical_region(region: str) -> str:
+    normalized = region.lower()
+    return _REGION_ALIASES.get(normalized, normalized)
+
+
+_BUCKET_TO_REGION: dict[str, str] = {
+    **{bucket: _canonical_region(region) for region, bucket in REGION_TO_DATA_BUCKET.items()},
+    **{bucket: _canonical_region(region) for region, bucket in REGION_TO_TMP_BUCKET.items()},
+}
 
 
 # ---------------------------------------------------------------------------
@@ -155,6 +168,19 @@ def marin_region() -> str | None:
       2. Infer from ``MARIN_PREFIX`` environment variable
     """
     return region_from_metadata() or region_from_prefix(os.environ.get("MARIN_PREFIX", ""))
+
+
+def runtime_gcp_region() -> str | None:
+    """Return the runtime's concrete GCP region, if detectable.
+
+    Resolution order:
+      1. ``IRIS_WORKER_REGION`` environment variable
+      2. GCS instance metadata server
+    """
+    iris_worker_region = os.environ.get("IRIS_WORKER_REGION")
+    if iris_worker_region:
+        return _canonical_region(iris_worker_region)
+    return region_from_metadata()
 
 
 def _append_path_prefix(path: str, prefix: str) -> str:

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 from fray.types import ResourceConfig
 from rigging.filesystem import MARIN_CROSS_REGION_OVERRIDE_ENV
+from rigging.filesystem import region_from_prefix
 
 from marin.execution.artifact import Artifact, PathMetadata
 from marin.execution.executor import _dag_tpu_regions, Executor, ExecutorStep, resolve_executor_step
@@ -38,6 +39,21 @@ class TrainMetadata:
 class NestedMetadata:
     path: str
     resources: ResourceConfig
+
+
+class PermissionDenied(Exception):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _stub_bucket_location_for_marin_paths(monkeypatch):
+    def fake_get_bucket_location(bucket: str) -> str:
+        region = region_from_prefix(f"gs://{bucket}")
+        if region is None:
+            raise PermissionDenied(f"no bucket metadata access for {bucket}")
+        return region
+
+    monkeypatch.setattr("marin.execution.executor.get_bucket_location", fake_get_bucket_location)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -248,6 +248,33 @@ def test_step_spec_as_executor_step_round_trip():
     assert resolved.dep_paths == [dep.output_path]
 
 
+def test_step_spec_as_executor_step_infers_region_for_remote_fn():
+    @remote
+    def my_fn(output_path):
+        return output_path
+
+    step = StepSpec(
+        name="tokenize",
+        output_path_prefix="gs://marin-us-central2",
+        hash_attrs={"input_path": "gs://marin-us-central2/raw/data"},
+        fn=my_fn,
+    )
+
+    with (
+        patch("marin.execution.executor._iris_backend_is_active", return_value=True),
+        patch("marin.execution.executor._iris_worker_region_pin", return_value=None),
+    ):
+        resolved = resolve_executor_step(
+            step.as_executor_step(),
+            config={"attrs": step.hash_attrs},
+            output_path=step.output_path,
+            deps=[],
+        )
+
+    assert isinstance(resolved.fn, RemoteCallable)
+    assert resolved.fn.resources.regions == ["us-central2"]
+
+
 # ---------------------------------------------------------------------------
 # StepRunner tests: three-step pipeline
 # ---------------------------------------------------------------------------
@@ -880,6 +907,27 @@ def test_resolve_executor_step_raises_for_dual_region_bucket_location():
                 config={"input_path": "gs://external-bucket/path/to/data"},
                 output_path="/out/test-abc",
             )
+
+
+def test_resolve_executor_step_prefers_bucket_metadata_for_noncanonical_marin_bucket():
+    @remote
+    def my_fn(config):
+        pass
+
+    step = ExecutorStep(name="test", fn=my_fn, config=None)
+    with (
+        patch("marin.execution.executor._iris_backend_is_active", return_value=True),
+        patch("marin.execution.executor._iris_worker_region_pin", return_value=None),
+        patch("marin.execution.executor.get_bucket_location", return_value="us-central2"),
+    ):
+        resolved = resolve_executor_step(
+            step,
+            config={"input_path": "gs://marin-data/path/to/data"},
+            output_path="/out/test-abc",
+        )
+
+    assert isinstance(resolved.fn, RemoteCallable)
+    assert resolved.fn.resources.regions == ["us-central2"]
 
 
 def test_resolve_executor_step_skips_bucket_location_permission_failures():

--- a/tests/processing/tokenize/test_tokenize.py
+++ b/tests/processing/tokenize/test_tokenize.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+from unittest.mock import patch
 
 import jax
 import numpy as np
@@ -120,6 +121,31 @@ def test_mixed_paths_one_invalid_inputname():
         )
     assert "contains a forbidden pattern ('test' or 'validation')" in str(excinfo.value)
     assert "gs://bucket/data/test/file2.jsonl" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "train_paths, validation_paths, expected_key",
+    [
+        (["gs://bucket/data/train/file.jsonl"], [], "train_urls[0]"),
+        ([], ["gs://bucket/data/eval/file.jsonl"], "validation_urls[0]"),
+    ],
+)
+def test_tokenize_checks_source_regions_before_expanding_paths(train_paths, validation_paths, expected_key):
+    config = TokenizeConfig(
+        train_paths=train_paths,
+        validation_paths=validation_paths,
+        cache_path=DUMMY_CACHE_PATH,
+        tokenizer=DUMMY_TOKENIZER,
+    )
+
+    with (
+        patch("rigging.filesystem.marin_region", return_value="us-central1"),
+        patch("rigging.filesystem.get_bucket_location", return_value="us-east1"),
+    ):
+        with pytest.raises(ValueError, match="not in the same region") as excinfo:
+            tokenize(config)
+
+    assert expected_key in str(excinfo.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -15,6 +15,7 @@ from levanter.trainer import TrainerConfig
 from marin.training.training import (
     TrainLmOnPodConfig,
     _doublecheck_paths,
+    _region_for_gcs_path,
     _update_config_to_use_out_path,
     temporary_checkpoint_base_path,
 )
@@ -65,6 +66,13 @@ def test_lm_config_with_train_urls_allowed_out_of_region(trainer_config):
             resources=ResourceConfig.with_tpu("v4-8"),
         )
         _doublecheck_paths(config)
+
+
+def test_region_for_gcs_path_prefers_bucket_metadata_for_noncanonical_marin_bucket():
+    with patch("marin.training.training.get_bucket_location", return_value="us-central2"):
+        region = _region_for_gcs_path("gs://marin-data/cache", bucket_region_cache={})
+
+    assert region == "us-central2"
 
 
 def test_temporary_checkpoint_base_path_follows_output_path_region():


### PR DESCRIPTION
Infer and pin TPU job regions from resolved GCS paths so eager executor resolution cannot hand Levanter work to another region. Add tokenization source checks and Levanter GCS guards before checkpoint, cache, fsspec, and tensorstore opens.