### PR TITLE
Stop region prefixes leaking into Marin executor identity hashes

### DIFF
--- a/experiments/dedup/poc_nemotron.py
+++ b/experiments/dedup/poc_nemotron.py
@@ -105,7 +105,7 @@ def fuzzy_dedup_steps() -> list[StepSpec]:
         q: normalize_step(
             name=f"normalized_nemotron/{q}",
             download=raw_data_step,
-            input_path=path,
+            relative_input_path=path,
         )
         for q, path in quality_paths.items()
     }

--- a/experiments/dedup/poc_nemotron.py
+++ b/experiments/dedup/poc_nemotron.py
@@ -95,10 +95,8 @@ def fuzzy_dedup_steps() -> list[StepSpec]:
     # Normalize each quality bucket separately so we get one MinHashAttrData per
     # source dataset, and dedup them globally in a single fuzzy_dups step.
     quality_paths = {
-        "high": os.path.join(raw_data_step.output_path, "contrib/Nemotron/Nemotron-CC/data-jsonl/quality=high"),
-        "medium-high": os.path.join(
-            raw_data_step.output_path, "contrib/Nemotron/Nemotron-CC/data-jsonl/quality=medium-high"
-        ),
+        "high": "contrib/Nemotron/Nemotron-CC/data-jsonl/quality=high",
+        "medium-high": "contrib/Nemotron/Nemotron-CC/data-jsonl/quality=medium-high",
     }
 
     normalize_steps = {

--- a/experiments/dedup/reference.py
+++ b/experiments/dedup/reference.py
@@ -24,7 +24,7 @@ def build_steps() -> list[StepSpec]:
     normalized = normalize_step(
         name="normalized/fineweb-edu-sample-10bt",
         download=raw,
-        input_path=raw.output_path + "/sample/10BT",
+        relative_input_path=raw.output_path + "/sample/10BT",
     )
     minhash = StepSpec(
         name="minhash/fineweb-edu-sample-10bt",

--- a/experiments/dedup/reference.py
+++ b/experiments/dedup/reference.py
@@ -24,7 +24,7 @@ def build_steps() -> list[StepSpec]:
     normalized = normalize_step(
         name="normalized/fineweb-edu-sample-10bt",
         download=raw,
-        relative_input_path=raw.output_path + "/sample/10BT",
+        relative_input_path="sample/10BT",
     )
     minhash = StepSpec(
         name="minhash/fineweb-edu-sample-10bt",

--- a/experiments/ferries/datakit_ferry.py
+++ b/experiments/ferries/datakit_ferry.py
@@ -57,7 +57,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
     normalized = normalize_step(
         name="datakit-smoke/normalize",
         download=downloaded,
-        input_path=f"{downloaded.output_path}/sample/10BT",
+        relative_input_path=f"{downloaded.output_path}/sample/10BT",
         worker_resources=ResourceConfig(cpu=2, ram="16g", disk="20g"),
         override_output_path=f"{base}/normalize",
     )

--- a/experiments/ferries/datakit_ferry.py
+++ b/experiments/ferries/datakit_ferry.py
@@ -57,7 +57,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
     normalized = normalize_step(
         name="datakit-smoke/normalize",
         download=downloaded,
-        relative_input_path=f"{downloaded.output_path}/sample/10BT",
+        relative_input_path="sample/10BT",
         worker_resources=ResourceConfig(cpu=2, ram="16g", disk="20g"),
         override_output_path=f"{base}/normalize",
     )

--- a/experiments/ferries/datakit_nemotron_ferry.py
+++ b/experiments/ferries/datakit_nemotron_ferry.py
@@ -96,7 +96,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
         download=download,
         text_field="text",
         id_field="id",
-        input_path=medium_input,
+        relative_input_path=medium_input,
         worker_resources=ResourceConfig(cpu=2, ram="16g", disk="5g"),
         max_workers=512,
         override_output_path=f"{base}/normalize",

--- a/experiments/ferries/datakit_nemotron_ferry.py
+++ b/experiments/ferries/datakit_nemotron_ferry.py
@@ -87,8 +87,6 @@ def build_steps(run_id: str) -> list[StepSpec]:
         override_output_path=NEMOTRON_RAW_PATH,
     )
 
-    medium_input = f"{download.output_path}/{NEMOTRON_DATA_SUBDIR}/{NEMOTRON_MEDIUM_DIR}"
-
     # Sizes mirror validate_normalize_phase1.py, which ran successfully on
     # nemotron_v1 in eu-west4. 512 workers across all fan-out stages.
     normalized = normalize_step(
@@ -96,7 +94,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
         download=download,
         text_field="text",
         id_field="id",
-        relative_input_path=medium_input,
+        relative_input_path=f"{NEMOTRON_DATA_SUBDIR}/{NEMOTRON_MEDIUM_DIR}",
         worker_resources=ResourceConfig(cpu=2, ram="16g", disk="5g"),
         max_workers=512,
         override_output_path=f"{base}/normalize",

--- a/lib/marin/src/marin/datakit/download/hf_simple_util.py
+++ b/lib/marin/src/marin/datakit/download/hf_simple_util.py
@@ -76,13 +76,12 @@ def hf_normalize_steps(
         override_output_path=staged_path,
     )
 
-    input_path = f"{download.output_path}/{data_subdir}" if data_subdir else download.output_path
     normalize = _normalize_step(
         name=f"normalized/{marin_name}",
         download=download,
         text_field=text_field,
         id_field=id_field,
-        input_path=input_path,
+        relative_input_path=data_subdir or None,
         file_extensions=file_extensions,
     )
     return (download, normalize)

--- a/lib/marin/src/marin/datakit/download/nemotron_v1.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_v1.py
@@ -158,5 +158,5 @@ def normalize_nemotron_v1_step(download: StepSpec, *, split: str) -> StepSpec:
         text_field="text",
         id_field="id",
         file_extensions=(".jsonl.zst",),
-        relative_input_path=f"{download.output_path}/{_NEMOTRON_V1_DATA_ROOT}/{rel_path}",
+        relative_input_path=f"{_NEMOTRON_V1_DATA_ROOT}/{rel_path}",
     )

--- a/lib/marin/src/marin/datakit/download/nemotron_v1.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_v1.py
@@ -158,5 +158,5 @@ def normalize_nemotron_v1_step(download: StepSpec, *, split: str) -> StepSpec:
         text_field="text",
         id_field="id",
         file_extensions=(".jsonl.zst",),
-        input_path=f"{download.output_path}/{_NEMOTRON_V1_DATA_ROOT}/{rel_path}",
+        relative_input_path=f"{download.output_path}/{_NEMOTRON_V1_DATA_ROOT}/{rel_path}",
     )

--- a/lib/marin/src/marin/datakit/download/nemotron_v2.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_v2.py
@@ -192,7 +192,7 @@ def normalize_nemotron_v2_step(download: StepSpec, *, family: str, subset: str) 
         text_field=info.subset_text_fields.get(subset, "text"),
         id_field="id",
         file_extensions=(".parquet",),
-        input_path=f"{download.output_path}/{subset_dir}",
+        relative_input_path=subset_dir,
         worker_resources=info.subset_normalize_worker_resources.get(subset),
     )
 

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -456,7 +456,11 @@ def normalize_step(
             Defaults to ``DedupMode.EXACT``; use ``DedupMode.NONE`` to skip.
     """
     if relative_input_path:
-        resolved_input = f"{download.output_path}/{relative_input_path}"
+        # ``os.path.join`` collapses redundant separators when ``download.output_path``
+        # ends with ``/`` (e.g. ``override_output_path="gs://.../nemotro-cc-eeb783/"``);
+        # naive f-string concatenation would yield ``gs://.../nemotro-cc-eeb783//<rel>``,
+        # which ``_discover_files`` then fails to resolve on GCS.
+        resolved_input = os.path.join(download.output_path, relative_input_path)
     else:
         resolved_input = download.output_path
 

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -430,7 +430,7 @@ def normalize_step(
     worker_resources: ResourceConfig | None = None,
     max_workers: int | None = None,
     override_output_path: str | None = None,
-    input_path: str | None = None,
+    relative_input_path: str | None = None,
     file_extensions: tuple[str, ...] | None = None,
     dedup_mode: DedupMode = DedupMode.EXACT,
 ) -> StepSpec:
@@ -447,7 +447,7 @@ def normalize_step(
         max_workers: Maximum number of Zephyr workers. Defaults to Zephyr's
             own default (128 for distributed backends).
         override_output_path: Override the computed output path.
-        input_path: Override the input path. Defaults to ``download.output_path``.
+        relative_input_path: Override the input path relative to the download output.
             Useful when normalizing a subdirectory of the download output.
         file_extensions: Tuple of file extensions to include (e.g.
             ``(".parquet",)``).  Defaults to all extensions supported by
@@ -455,7 +455,10 @@ def normalize_step(
         dedup_mode: How to deduplicate records within each output shard.
             Defaults to ``DedupMode.EXACT``; use ``DedupMode.NONE`` to skip.
     """
-    resolved_input = input_path or download.output_path
+    if relative_input_path:
+        resolved_input = f"{download.output_path}/{relative_input_path}"
+    else:
+        resolved_input = download.output_path
 
     return StepSpec(
         name=name,
@@ -477,7 +480,7 @@ def normalize_step(
             "id_field": id_field,
             "target_partition_bytes": target_partition_bytes,
             "max_whitespace_run_chars": max_whitespace_run_chars,
-            "input_path": resolved_input,
+            "relative_input_path": relative_input_path,
             "file_extensions": file_extensions,
             "dedup_mode": dedup_mode,
         },

--- a/lib/marin/src/marin/execution/executor.py
+++ b/lib/marin/src/marin/execution/executor.py
@@ -1206,6 +1206,7 @@ class Executor:
         self.is_pseudo_dep: dict[ExecutorStep, bool] = {}
         self.version_strs: dict[ExecutorStep, str] = {}
         self.version_str_to_step: dict[str, ExecutorStep] = {}
+        self.hashed_versions: dict[ExecutorStep, str] = {}
         self.output_paths: dict[ExecutorStep, str] = {}
         self.steps: list[ExecutorStep] = []
         self.step_infos: list[ExecutorStepInfo] = []
@@ -1442,6 +1443,7 @@ class Executor:
         self.dependencies[step] = list(map(self.canonicalize, computed_deps.dependencies))
         self.versions[step] = version
         self.version_strs[step] = version_str
+        self.hashed_versions[step] = hashed_version
         self.output_paths[step] = output_path
         self.is_pseudo_dep[step] = is_pseudo_dep
 
@@ -1460,10 +1462,18 @@ class Executor:
         return depth
 
     def _dep_version(self, dep: ExecutorStep) -> dict[str, Any] | str:
-        """Full version dict for shallow deps, output path for deep ones."""
+        """Full version dict for shallow deps, region-stable name+hash for deep ones.
+
+        Using ``output_paths[dep]`` here would bake the bucket prefix
+        (e.g. ``gs://marin-us-central1``) into the hashed version, so the same
+        logical pipeline rehashed under a different ``MARIN_PREFIX`` would
+        produce a different identity. ``{name}-{hashed_version}`` is the
+        region-independent suffix that already encodes the dep's full transitive
+        version.
+        """
         if self._dep_depth(dep) <= self._MAX_INLINE_DEPTH:
             return self.versions[dep]
-        return self.output_paths[dep]
+        return f"{dep.name}-{self.hashed_versions[dep]}"
 
     def canonicalize(self, step: ExecutorStep) -> ExecutorStep:
         """Multiple instances of `ExecutorStep` might have the same version."""

--- a/lib/marin/src/marin/execution/executor.py
+++ b/lib/marin/src/marin/execution/executor.py
@@ -676,7 +676,16 @@ def resolve_executor_step(
     # Short-circuit for StepSpec -> ExecutorStep -> StepSpec round-trip.
     original: StepSpec | None = getattr(step, "_original_step_spec", None)
     if original is not None:
-        return dataclasses.replace(original, deps=deps or [])
+        # ``as_executor_step()`` pins ``override_output_path=original.output_path``
+        # on the ExecutorStep so the executor preserves the original placement.
+        # Mirror that pin on the resolved StepSpec — otherwise replacing deps
+        # with executor-built stubs (which lack the originals' ``hash_attrs``)
+        # would change ``name_with_hash`` and silently shift ``output_path``.
+        return dataclasses.replace(
+            original,
+            deps=deps or list(original.deps),
+            override_output_path=original.output_path,
+        )
 
     remote_callable = step.fn if isinstance(step.fn, RemoteCallable) else None
     if remote_callable is not None:

--- a/lib/marin/src/marin/execution/step_spec.py
+++ b/lib/marin/src/marin/execution/step_spec.py
@@ -75,14 +75,19 @@ class StepSpec:
 
     @cached_property
     def dep_paths(self) -> list[str]:
-        """Output paths of all dependencies."""
+        """Physical and resolved output paths of all dependencies."""
         return [dep.output_path for dep in self.deps]
+
+    @cached_property
+    def dep_names(self) -> list[str]:
+        """Logical names with hashes of all dependencies, used for hashing and reporting."""
+        return [dep.name_with_hash for dep in self.deps]
 
     @cached_property
     def hash_id(self) -> str:
         """Hash ID of the step, used for cache invalidation and output path generation."""
         content = json.dumps(
-            {"name": self.name, "attrs": self.hash_attrs, "deps": sorted(self.dep_paths)},
+            {"name": self.name, "attrs": self.hash_attrs, "deps": sorted(self.dep_names)},
             sort_keys=True,
         )
         return hashlib.sha256(content.encode("utf-8")).hexdigest()[:8]

--- a/tests/datakit/test_fineweb_edu.py
+++ b/tests/datakit/test_fineweb_edu.py
@@ -17,12 +17,12 @@ def test_normalize_subset_distinct_cache_keys():
     data_step = normalize_step(
         name="normalized/fineweb_edu",
         download=dl,
-        relative_input_path=f"{dl.output_path}/data",
+        relative_input_path="data",
     )
     sample_step = normalize_step(
         name="normalized/fineweb_edu",
         download=dl,
-        relative_input_path=f"{dl.output_path}/sample/10BT",
+        relative_input_path="sample/10BT",
     )
     assert data_step.name == sample_step.name
     assert data_step.output_path != sample_step.output_path

--- a/tests/datakit/test_fineweb_edu.py
+++ b/tests/datakit/test_fineweb_edu.py
@@ -17,12 +17,12 @@ def test_normalize_subset_distinct_cache_keys():
     data_step = normalize_step(
         name="normalized/fineweb_edu",
         download=dl,
-        input_path=f"{dl.output_path}/data",
+        relative_input_path=f"{dl.output_path}/data",
     )
     sample_step = normalize_step(
         name="normalized/fineweb_edu",
         download=dl,
-        input_path=f"{dl.output_path}/sample/10BT",
+        relative_input_path=f"{dl.output_path}/sample/10BT",
     )
     assert data_step.name == sample_step.name
     assert data_step.output_path != sample_step.output_path

--- a/tests/execution/test_executor.py
+++ b/tests/execution/test_executor.py
@@ -457,6 +457,66 @@ def test_versioning():
         assert_same_version(b_m=2)
 
 
+def test_executor_version_stable_across_prefixes():
+    """Regression for marin-community/marin#5216 (legacy ``Executor`` path).
+
+    Identity hashes for ``ExecutorStep`` chains must not depend on the Marin
+    bucket prefix. The same logical pipeline resolved under
+    ``gs://marin-us-central1`` vs ``gs://marin-us-east5`` was producing
+    distinct hashes once the chain exceeded ``Executor._MAX_INLINE_DEPTH``,
+    because ``_dep_version`` falls back to the deep dep's absolute
+    ``output_paths[dep]`` which carries the prefix.
+
+    The chain below has depth 6 at the leaf, which exceeds the default
+    ``_MAX_INLINE_DEPTH`` of 4 and forces the fallback for every step from
+    ``f`` onward.
+    """
+
+    def fn(config):
+        pass
+
+    def build_chain_leaf():
+        prev = ExecutorStep(name="a", fn=fn, config=None)
+        for name in ("b", "c", "d", "e", "f", "g"):
+            prev = ExecutorStep(
+                name=name,
+                fn=fn,
+                config=MyConfig(
+                    input_path=output_path_of(prev),
+                    output_path=this_output_path(),
+                    n=1,
+                    m=1,
+                ),
+            )
+        return prev  # leaf "g" has depth 6
+
+    leaf_central = build_chain_leaf()
+    leaf_east = build_chain_leaf()
+
+    central = Executor(prefix="gs://marin-us-central1", executor_info_base_path="gs://marin-us-central1")
+    central.compute_version(leaf_central, is_pseudo_dep=False)
+
+    east = Executor(prefix="gs://marin-us-east5", executor_info_base_path="gs://marin-us-east5")
+    east.compute_version(leaf_east, is_pseudo_dep=False)
+
+    # Sanity: deep-dep fallback must actually be active, otherwise the test
+    # would silently pass even with the bug present.
+    assert central._dep_depth(leaf_central) > Executor._MAX_INLINE_DEPTH
+
+    # Per-step hashes must match across regions.
+    central_steps = sorted(central.steps, key=lambda s: s.name)
+    east_steps = sorted(east.steps, key=lambda s: s.name)
+    for c, e in zip(central_steps, east_steps, strict=True):
+        assert c.name == e.name
+        c_hash = central.output_paths[c].rsplit("-", 1)[-1]
+        e_hash = east.output_paths[e].rsplit("-", 1)[-1]
+        assert c_hash == e_hash, f"{c.name} hash flipped across prefixes: {c_hash} vs {e_hash}"
+
+    # Output paths themselves must still differ — that's where the prefix lives.
+    assert central.output_paths[leaf_central].startswith("gs://marin-us-central1/")
+    assert east.output_paths[leaf_east].startswith("gs://marin-us-east5/")
+
+
 def test_dedup_version():
     """Make sure that two `ExecutorStep`s resolve to the same."""
 

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -248,6 +248,75 @@ def test_step_spec_as_executor_step_round_trip():
     assert resolved.dep_paths == [dep.output_path]
 
 
+def _build_three_level_dag(prefix: str) -> tuple[StepSpec, StepSpec, StepSpec]:
+    """download → normalize → tokenize, all rooted at ``prefix``."""
+    download = StepSpec(
+        name="download",
+        output_path_prefix=prefix,
+        hash_attrs={"source": "fineweb-edu", "revision": "87f0914"},
+    )
+    normalize = StepSpec(
+        name="normalize",
+        output_path_prefix=prefix,
+        deps=[download],
+        hash_attrs={"text_field": "text", "relative_input_path": "sample/10BT"},
+    )
+    tokenize = StepSpec(
+        name="tokenize",
+        output_path_prefix=prefix,
+        deps=[normalize],
+        hash_attrs={"tokenizer": "gpt2"},
+    )
+    return download, normalize, tokenize
+
+
+def test_step_spec_hash_id_stable_across_prefixes():
+    """Identity hashes must not depend on the Marin bucket prefix.
+
+    Regression for marin-community/marin#5216: the same logical pipeline
+    resolved under different ``MARIN_PREFIX`` values (e.g. region failover
+    from ``gs://marin-us-central1`` to ``gs://marin-us-east5``) was producing
+    distinct hashes, changing output paths, checkpoint ids, and W&B run ids.
+    """
+    central = _build_three_level_dag("gs://marin-us-central1")
+    east = _build_three_level_dag("gs://marin-us-east5")
+
+    for c, e in zip(central, east, strict=True):
+        assert c.hash_id == e.hash_id, f"{c.name} hash flipped across prefixes: {c.hash_id} vs {e.hash_id}"
+        assert c.name_with_hash == e.name_with_hash
+
+    # Output paths must still differ — that's where the prefix lives.
+    for c, e in zip(central, east, strict=True):
+        assert c.output_path != e.output_path
+        assert c.output_path.startswith("gs://marin-us-central1/")
+        assert e.output_path.startswith("gs://marin-us-east5/")
+
+
+def test_step_spec_hash_id_via_marin_prefix_env(monkeypatch):
+    """Same as above, but driven by the ``MARIN_PREFIX`` env var path."""
+    monkeypatch.setenv("MARIN_PREFIX", "gs://marin-us-central1")
+    central = [
+        StepSpec(name="download", hash_attrs={"source": "fineweb-edu"}),
+    ]
+    central.append(StepSpec(name="normalize", deps=[central[0]], hash_attrs={"text_field": "text"}))
+    central.append(StepSpec(name="tokenize", deps=[central[1]], hash_attrs={"tokenizer": "gpt2"}))
+    central_paths = [s.output_path for s in central]  # force prefix resolution into cached_property
+
+    monkeypatch.setenv("MARIN_PREFIX", "gs://marin-us-east5")
+    east = [
+        StepSpec(name="download", hash_attrs={"source": "fineweb-edu"}),
+    ]
+    east.append(StepSpec(name="normalize", deps=[east[0]], hash_attrs={"text_field": "text"}))
+    east.append(StepSpec(name="tokenize", deps=[east[1]], hash_attrs={"tokenizer": "gpt2"}))
+    east_paths = [s.output_path for s in east]
+
+    for c, e in zip(central, east, strict=True):
+        assert c.hash_id == e.hash_id
+
+    assert all(p.startswith("gs://marin-us-central1/") for p in central_paths)
+    assert all(p.startswith("gs://marin-us-east5/") for p in east_paths)
+
+
 # ---------------------------------------------------------------------------
 # StepRunner tests: three-step pipeline
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix marin-community/marin#5216: region-specific bucket paths (e.g. `gs://marin-us-central1` vs `gs://marin-us-east5`) were leaking into executor identity hashes, so the same logical pipeline produced different output paths, checkpoint ids, and W&B run ids on a region failover. Delphi 1e20 midtraining hit this — `delphi-1e20-p67m33-20b-lr0.5-f74454` became a new namespace and `p33m67/lr0.67` flipped from `3c967b` to `8fbf99`.

The branch contains five commits, ordered for review:

- **`baseline fix`** (pre-existing): `StepSpec.hash_id` now hashes deps by `name_with_hash` instead of `output_path`, and `normalize_step` stores a `relative_input_path` in `hash_attrs` instead of an absolute one. Also `nemotron_v2` passes the relative `subset_dir`.
- **Pass true relative paths into normalize_step callers**: the baseline rename was applied mechanically, but most callers still passed the joined absolute path under the new kwarg, leaving the hash region-fragile and producing a doubled path at runtime. Reduces each call site to the suffix only.
- **Test StepSpec hash stability across MARIN_PREFIX**: 3-level DAG built twice with different prefixes; asserts `hash_id`/`name_with_hash` match while `output_path`s correctly differ. Covers both the explicit `output_path_prefix` and `MARIN_PREFIX` env-var paths. Verified by reverting the baseline fix locally and watching the test fail (`283ee59a` vs `e047ff85`).
- **Make Executor compute_version region-stable for deep DAGs**: the legacy `Executor` path had the same bug — once a chain exceeded `_MAX_INLINE_DEPTH` (4), `_dep_version` fell back to `output_paths[dep]` which carried the bucket prefix. Records `hashed_version` per step and uses `{name}-{hashed_version}` as the deep-dep summary; same compactness, no region leak. Includes a 7-step linear-chain regression test.
- **Pin output_path on round-tripped StepSpec from resolve_executor_step**: the dep-name hash change exposed a first-pass identity drift in the `StepSpec → ExecutorStep → StepSpec` round-trip. Real runtime survives because `_resolve_steps` does a second pass that swaps stubs for resolved StepSpecs, but any direct caller (and the existing round-trip test) saw the drift. Mirrors `as_executor_step()`'s `override_output_path` pin on the resolved spec.

## Cache invalidation

Not deferred-friendly — first runs after this lands will rehash and write to new output paths:
- All non-leaf `StepSpec`s (baseline `dep_paths → dep_names`).
- All `normalize_step` callers (`input_path → relative_input_path` is a key+value change in `hash_attrs`).
- Pure `ExecutorStep` chains with dependency depth > 4 (this branch's `_dep_version` fix).

Unaffected: leaf `StepSpec`s, shallow `ExecutorStep` chains, anything pinned via `override_output_path`.

## Known gaps

The issue suggested a generic `canonicalize_marin_paths_for_hash` helper. Deferred — this PR fixes the structural dep-graph leak and the obvious `normalize_step` call site, but other StepSpec/ExecutorStep configs that hardcode absolute Marin paths into `hash_attrs` remain region-fragile. Tracking separately.

## Test plan

- [x] `uv run pytest tests/execution/test_executor.py tests/execution/test_step_runner.py tests/datakit/test_fineweb_edu.py` — 74 passed, 1 skipped post-rebase.
- [x] StepSpec regression test fails on the pre-fix version of `step_spec.py` (verified by temporary revert).
- [x] Executor regression test fails on the pre-fix `_dep_version` (`1c134a` vs `bb2db9`).
- [ ] Confirm a known-deep pipeline (e.g. Delphi midtraining) rehashes consistently across `gs://marin-us-central1` and `gs://marin-eu-west4` resolution.