### PR TITLE
Charge cross-region transfer budget on tensorstore checkpoint I/O

### DIFF
--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -25,6 +25,8 @@ from haliax.util import is_named_array
 from jax.sharding import Mesh, Sharding
 from jaxtyping import PyTree
 
+from rigging.filesystem import record_transfer
+
 from levanter._debug_logging import flush_debug_output
 from levanter.utils import fsspec_utils, jax_utils
 
@@ -189,6 +191,12 @@ def tree_serialize_leaves_tensorstore(
     for path in paths:
         spec = _create_ocdbt_spec(checkpoint_dir, path)
         tspecs.append(spec)
+
+    # Pre-charge the cross-region transfer budget before kicking off the
+    # async writes — tensorstore bypasses fsspec, so the CrossRegionGuardedFS
+    # interceptor never sees these bytes.  No-op when checkpoint_dir is local
+    # or in the same region as the VM.
+    record_transfer(total_array_bytes, checkpoint_dir)
 
     if debug_checkpointer:
         logger.info("Checkpoint tensorstore serialize entering manager.serialize for %s", checkpoint_dir)
@@ -380,6 +388,20 @@ def tree_deserialize_leaves_tensorstore(
     """
     if manager is None:
         manager = array_ser.GlobalAsyncCheckpointManager()
+
+    # Pre-charge the cross-region transfer budget before kicking off the
+    # async reads.  Tensorstore bypasses fsspec, so the CrossRegionGuardedFS
+    # interceptor never sees these bytes.  We use the exemplar pytree's
+    # shapes/dtypes as an upper bound — if `allow_missing=True` and some
+    # leaves aren't on disk we'll over-charge slightly, but the common case
+    # (no missing arrays) is exact.  No-op when checkpoint_dir is local or
+    # in the same region as the VM.
+    estimated_bytes = sum(
+        _estimate_array_nbytes(leaf.array if is_named_array(leaf) else leaf)
+        for leaf in jtu.tree_leaves(pytree, is_leaf=_is_named_or_none)
+        if leaf is not None
+    )
+    record_transfer(estimated_bytes, checkpoint_dir)
 
     shardings: PyTree[Optional[Sharding]] = jtu.tree_map(
         partial(_sharding_from_leaf, axis_mapping=axis_mapping, mesh=mesh), pytree, is_leaf=_is_named_or_none

--- a/lib/rigging/src/rigging/filesystem.py
+++ b/lib/rigging/src/rigging/filesystem.py
@@ -540,6 +540,57 @@ def _is_gcs_protocol(protocol: str) -> bool:
     return protocol in ("gs", "gcs")
 
 
+def _bucket_from_gcs_url(url: str) -> str | None:
+    """Return the bucket name from a ``gs://``/``gcs://`` URL, or ``None``."""
+    for scheme in ("gs://", "gcs://"):
+        if url.startswith(scheme):
+            return url[len(scheme) :].split("/", 1)[0]
+    return None
+
+
+def _is_cross_region_url(url: str) -> bool:
+    """Return True if *url* points to a GCS bucket in a different region than the VM."""
+    if os.environ.get(MARIN_CROSS_REGION_OVERRIDE_ENV):
+        return False
+    bucket = _bucket_from_gcs_url(url)
+    if bucket is None:
+        return False
+    vm_region = _cached_marin_region()
+    if vm_region is None:
+        return False
+    bucket_location = _cached_bucket_location(bucket)
+    if bucket_location is None:
+        return False
+    return not _regions_match(vm_region, bucket_location)
+
+
+def record_transfer(size: int, url: str, *, budget: TransferBudget | None = None) -> None:
+    """Charge *size* bytes against the cross-region transfer budget.
+
+    Always safe to call: no-op for non-GCS URLs, same-region buckets, when the
+    VM region is unknown, or when the override env var is set.  Raises
+    :class:`TransferBudgetExceeded` if the recorded transfer would push the
+    cumulative total past the budget.
+
+    Used by callers (e.g. tensorstore-based code) that bypass fsspec but still
+    want to charge against the shared cross-region transfer budget.
+
+    Args:
+        size: Number of bytes to charge.
+        url: GCS URL (``gs://bucket/key``) being read or written.  Used both
+            to decide whether the transfer is cross-region and as the path
+            string in any raised :class:`TransferBudgetExceeded`.
+        budget: Budget to charge against.  Defaults to the process-global
+            singleton shared with :class:`CrossRegionGuardedFS` and
+            :class:`MirrorFileSystem`.
+    """
+    if size <= 0:
+        return
+    if not _is_cross_region_url(url):
+        return
+    (budget if budget is not None else _global_transfer_budget).record(size, url)
+
+
 class CrossRegionGuardedFS:
     """Wrapper around a GCS fsspec filesystem that enforces a cross-region transfer budget.
 

--- a/lib/rigging/tests/test_record_transfer.py
+++ b/lib/rigging/tests/test_record_transfer.py
@@ -1,0 +1,40 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from rigging import filesystem as rfs
+from rigging.filesystem import TransferBudget, TransferBudgetExceeded, record_transfer
+
+
+@pytest.fixture()
+def patched_regions(monkeypatch):
+    """VM is in us-central1; bucket lookup is faked from the URL."""
+    monkeypatch.setattr(rfs, "_cached_marin_region", lambda: "us-central1")
+    monkeypatch.setattr(
+        rfs,
+        "_cached_bucket_location",
+        lambda bucket: {
+            "marin-us-central1": "us-central1",
+            "marin-us-central2": "us-central2",
+        }.get(bucket),
+    )
+
+
+def test_record_transfer_charges_cross_region(patched_regions):
+    budget = TransferBudget(limit_bytes=1024 * 1024)
+    record_transfer(1000, "gs://marin-us-central2/checkpoint", budget=budget)
+    assert budget.bytes_used == 1000
+
+
+def test_record_transfer_skips_same_region_and_local(patched_regions):
+    budget = TransferBudget(limit_bytes=1024 * 1024)
+    record_transfer(1000, "gs://marin-us-central1/checkpoint", budget=budget)
+    record_transfer(1000, "/tmp/checkpoint", budget=budget)
+    assert budget.bytes_used == 0
+
+
+def test_record_transfer_raises_when_budget_exceeded(patched_regions):
+    budget = TransferBudget(limit_bytes=500)
+    with pytest.raises(TransferBudgetExceeded):
+        record_transfer(1000, "gs://marin-us-central2/checkpoint", budget=budget)


### PR DESCRIPTION
Tensorstore reads/writes bypass fsspec, so CrossRegionGuardedFS never sees their bytes. Add record_transfer() to rigging.filesystem and call it from tree_serialize_leaves_tensorstore and tree_deserialize_leaves_tensorstore using estimated array byte counts, so cross-region checkpoint traffic is charged before the async I/O starts. No-op for local or same-region checkpoint dirs.