### PR TITLE
[iris] Same-variant slice preemption for coscheduled jobs

### DIFF
--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -28,6 +28,7 @@ from iris.cluster.constraints import (
     constraints_from_resources,
     evaluate_constraint,
     extract_placement_requirements,
+    get_device_variant,
     merge_constraints,
     region_constraint as make_region_constraint,
 )
@@ -181,6 +182,10 @@ class RunningTaskInfo:
     resource_value: int
     is_coscheduled: bool
     resources: job_pb2.ResourceSpecProto
+    # Device variant (e.g. "v5p-64") the task is running on, derived from the
+    # task's own resource spec. Used to gate preemption to same-variant victims
+    # so a v5p-64 request can never reclaim a v5p-256 slice and vice versa.
+    device_variant: str | None = None
     already_preempted: bool = False
 
 
@@ -493,6 +498,7 @@ def _get_running_tasks_with_band_and_value(
                 ),
                 is_coscheduled=bool(int(row.has_coscheduling)),
                 resources=resources,
+                device_variant=get_device_variant(resources.device),
             )
         )
     return result
@@ -510,12 +516,45 @@ def _run_preemption_pass(
     - INTERACTIVE preempts BATCH only.
     - BATCH never preempts.
     - Within same band, no preemption (compete via scheduling order only).
-    - Coscheduled tasks are not preemptible (v1).
+    - Solo (non-coscheduled) preemptors only evict solo victims of the same
+      device-variant.
+    - Coscheduled preemptors evict an entire victim *slice* (all running tasks
+      of one coscheduled job) of the same device-variant and at least the
+      preemptor's task count. A non-coscheduled preemptor never tears down a
+      slice. Same-variant + slice-shaped guarantees the freed capacity matches
+      the request, which avoids large/small thrashing.
     """
     preemptions: list[tuple[JobName, JobName]] = []
 
-    # Sort victims: lowest priority first (highest band_sort_key), then cheapest
-    victims = sorted(running_tasks_info, key=lambda t: (-t.band_sort_key, t.resource_value))
+    # Solo victims: existing per-worker preemption path (same-variant gated).
+    solo_victims = sorted(
+        (v for v in running_tasks_info if not v.is_coscheduled),
+        key=lambda t: (-t.band_sort_key, t.resource_value),
+    )
+
+    # Lazy: only build coscheduled-victim slice index if some preemptor needs
+    # one. The common case (no coscheduled preemptors) skips the bucketing.
+    sorted_groups: list[tuple[JobName, list[RunningTaskInfo]]] = []
+    if any(c.requirements.is_coscheduled for c in unscheduled_tasks):
+        grouped: dict[JobName, list[RunningTaskInfo]] = {}
+        for v in running_tasks_info:
+            if not v.is_coscheduled or v.device_variant is None:
+                continue
+            parent = v.task_id.parent
+            if parent is None:
+                continue
+            grouped.setdefault(parent, []).append(v)
+        sorted_groups = sorted(
+            grouped.items(),
+            key=lambda kv: (
+                -max(t.band_sort_key for t in kv[1]),
+                sum(t.resource_value for t in kv[1]),
+            ),
+        )
+
+    # Track preemptor jobs whose siblings have already been satisfied by a
+    # slice eviction this pass; the remaining N-1 siblings short-circuit.
+    satisfied_preemptor_jobs: set[JobName] = set()
 
     for candidate in unscheduled_tasks:
         task_id, req, task_band_key = candidate.job_name, candidate.requirements, candidate.band
@@ -523,41 +562,74 @@ def _run_preemption_pass(
         if task_band_key >= job_pb2.PRIORITY_BAND_BATCH:
             continue
 
-        for victim in victims:
-            if victim.already_preempted:
-                continue
-            if victim.is_coscheduled:
-                continue
-            # Can only preempt strictly lower priority (higher band_sort_key)
-            if victim.band_sort_key <= task_band_key:
-                continue
+        parent = task_id.parent
+        if parent is not None and parent in satisfied_preemptor_jobs:
+            continue
 
-            cap = context.capacities.get(victim.worker_id)
-            if cap is None:
-                continue
+        wanted_variant = get_device_variant(req.resources.device)
 
-            if not cap.matches_constraints(req.constraints):
-                continue
+        if not req.is_coscheduled:
+            for victim in solo_victims:
+                if victim.already_preempted:
+                    continue
+                # Same-variant gate: only preempt victims that free the
+                # exact device-variant the preemptor requested. Skips any
+                # variant comparison when the preemptor is unconstrained
+                # (CPU-only) and the victim is too — both are None.
+                if victim.device_variant != wanted_variant:
+                    continue
+                # Can only preempt strictly lower priority (higher band_sort_key)
+                if victim.band_sort_key <= task_band_key:
+                    continue
 
-            # If current capacity already fits, no preemption needed
-            if cap.can_fit(req) is None:
-                continue
+                cap = context.capacities.get(victim.worker_id)
+                if cap is None:
+                    continue
 
-            # Check if freeing the victim's resources would create enough capacity
-            hypothetical = WorkerCapacity(
-                worker_id=cap.worker_id,
-                available_cpu_millicores=cap.available_cpu_millicores + victim.resources.cpu_millicores,
-                available_memory=cap.available_memory + victim.resources.memory_bytes,
-                available_gpus=cap.available_gpus + get_gpu_count(victim.resources.device),
-                available_tpus=cap.available_tpus + get_tpu_count(victim.resources.device),
-                attributes=cap.attributes,
-                building_task_count=max(0, cap.building_task_count - 1),
-                max_building_tasks=cap.max_building_tasks,
-            )
-            if hypothetical.can_fit(req) is None:
-                preemptions.append((task_id, victim.task_id))
-                victim.already_preempted = True
-                break
+                if not cap.matches_constraints(req.constraints):
+                    continue
+
+                # If current capacity already fits, no preemption needed
+                if cap.can_fit(req) is None:
+                    continue
+
+                # Check if freeing the victim's resources would create enough capacity
+                hypothetical = WorkerCapacity(
+                    worker_id=cap.worker_id,
+                    available_cpu_millicores=cap.available_cpu_millicores + victim.resources.cpu_millicores,
+                    available_memory=cap.available_memory + victim.resources.memory_bytes,
+                    available_gpus=cap.available_gpus + get_gpu_count(victim.resources.device),
+                    available_tpus=cap.available_tpus + get_tpu_count(victim.resources.device),
+                    attributes=cap.attributes,
+                    building_task_count=max(0, cap.building_task_count - 1),
+                    max_building_tasks=cap.max_building_tasks,
+                )
+                if hypothetical.can_fit(req) is None:
+                    preemptions.append((task_id, victim.task_id))
+                    victim.already_preempted = True
+                    break
+            continue
+
+        # Coscheduled preemptor → evict a same-variant victim slice as a unit.
+        if wanted_variant is None:
+            continue
+        n_required = sum(1 for c in unscheduled_tasks if c.job_name.parent == parent)
+        for _victim_job, members in sorted_groups:
+            if any(m.already_preempted for m in members):
+                continue
+            if members[0].device_variant != wanted_variant:
+                continue
+            # Strict band: every sibling must be lower priority than the preemptor.
+            if any(m.band_sort_key <= task_band_key for m in members):
+                continue
+            if len(members) < n_required:
+                continue
+            for m in members:
+                preemptions.append((task_id, m.task_id))
+                m.already_preempted = True
+            if parent is not None:
+                satisfied_preemptor_jobs.add(parent)
+            break
 
     return preemptions
 
@@ -1987,13 +2059,17 @@ class Controller:
                 user_budget_defaults=self._config.user_budget_defaults,
             )
             preemptions = _run_preemption_pass(unscheduled, running_info, context)
-            for preemptor_name, victim_id in preemptions:
-                with self._store.transaction() as cur:
-                    preempt_result = self._transitions.preempt_task(
-                        cur, victim_id, reason=f"Preempted by {preemptor_name}"
-                    )
-                self.kill_tasks_on_workers(preempt_result.tasks_to_kill)
+            # Apply all preemptions in one transaction so slice evictions
+            # (N siblings of a coscheduled preemptor) are all-or-nothing.
+            kills: set[JobName] = set()
             if preemptions:
+                with self._store.transaction() as cur:
+                    for preemptor_name, victim_id in preemptions:
+                        preempt_result = self._transitions.preempt_task(
+                            cur, victim_id, reason=f"Preempted by {preemptor_name}"
+                        )
+                        kills |= preempt_result.tasks_to_kill
+                self.kill_tasks_on_workers(kills)
                 logger.info("Preemption pass: %d tasks preempted", len(preemptions))
         return preemptions
 

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -504,6 +504,91 @@ def _get_running_tasks_with_band_and_value(
     return result
 
 
+def _preempt_solo(
+    candidate: PreemptionCandidate,
+    wanted_variant: str | None,
+    solo_victims: list[RunningTaskInfo],
+    context: SchedulingContext,
+) -> tuple[JobName, JobName] | None:
+    """Find a single solo victim whose eviction would free enough capacity for
+    a non-coscheduled preemptor. Mutates the chosen victim's already_preempted
+    flag so subsequent candidates skip it. Returns the (preemptor, victim) pair
+    or None if no victim qualifies.
+
+    The same-variant gate ensures the freed slot shape matches the preemptor;
+    the hypothetical-capacity check covers partial-worker tenancy (e.g. a
+    victim using only some of a worker's CPUs or TPUs).
+    """
+    req = candidate.requirements
+    for victim in solo_victims:
+        if victim.already_preempted:
+            continue
+        if victim.device_variant != wanted_variant:
+            continue
+        # Can only preempt strictly lower priority (higher band_sort_key)
+        if victim.band_sort_key <= candidate.band:
+            continue
+
+        cap = context.capacities.get(victim.worker_id)
+        if cap is None:
+            continue
+        if not cap.matches_constraints(req.constraints):
+            continue
+        # If current capacity already fits, no preemption needed
+        if cap.can_fit(req) is None:
+            continue
+
+        # Would freeing this victim's resources create enough capacity?
+        hypothetical = WorkerCapacity(
+            worker_id=cap.worker_id,
+            available_cpu_millicores=cap.available_cpu_millicores + victim.resources.cpu_millicores,
+            available_memory=cap.available_memory + victim.resources.memory_bytes,
+            available_gpus=cap.available_gpus + get_gpu_count(victim.resources.device),
+            available_tpus=cap.available_tpus + get_tpu_count(victim.resources.device),
+            attributes=cap.attributes,
+            building_task_count=max(0, cap.building_task_count - 1),
+            max_building_tasks=cap.max_building_tasks,
+        )
+        if hypothetical.can_fit(req) is None:
+            victim.already_preempted = True
+            return (candidate.job_name, victim.task_id)
+    return None
+
+
+def _preempt_coscheduled(
+    candidate: PreemptionCandidate,
+    wanted_variant: str | None,
+    n_required: int,
+    sorted_groups: list[tuple[JobName, list[RunningTaskInfo]]],
+) -> list[tuple[JobName, JobName]]:
+    """Find a victim slice (all running tasks of one coscheduled job) whose
+    eviction satisfies a coscheduled preemptor. Returns one (preemptor, victim)
+    pair per slice member, or [] if no slice qualifies. Mutates already_preempted
+    on every member of the chosen slice.
+
+    Coscheduled tasks own their workers whole, so once variant matches and the
+    slice is at least as large as the preemptor, freeing it yields exactly the
+    shape the preemptor needs — no per-worker capacity arithmetic required.
+    """
+    if wanted_variant is None:
+        return []
+    for _victim_job, members in sorted_groups:
+        if any(m.already_preempted for m in members):
+            continue
+        if members[0].device_variant != wanted_variant:
+            continue
+        # Strict band: every sibling must be lower priority than the preemptor.
+        if any(m.band_sort_key <= candidate.band for m in members):
+            continue
+        if len(members) < n_required:
+            continue
+        pairs = [(candidate.job_name, m.task_id) for m in members]
+        for m in members:
+            m.already_preempted = True
+        return pairs
+    return []
+
+
 def _run_preemption_pass(
     unscheduled_tasks: list[PreemptionCandidate],
     running_tasks_info: list[RunningTaskInfo],
@@ -540,10 +625,10 @@ def _run_preemption_pass(
         for v in running_tasks_info:
             if not v.is_coscheduled or v.device_variant is None:
                 continue
-            parent = v.task_id.parent
-            if parent is None:
+            vparent = v.task_id.parent
+            if vparent is None:
                 continue
-            grouped.setdefault(parent, []).append(v)
+            grouped.setdefault(vparent, []).append(v)
         sorted_groups = sorted(
             grouped.items(),
             key=lambda kv: (
@@ -552,84 +637,37 @@ def _run_preemption_pass(
             ),
         )
 
-    # Track preemptor jobs whose siblings have already been satisfied by a
-    # slice eviction this pass; the remaining N-1 siblings short-circuit.
+    # Preemptor jobs whose siblings have already been satisfied by a slice
+    # eviction this pass; the remaining N-1 siblings short-circuit.
     satisfied_preemptor_jobs: set[JobName] = set()
+    sibling_count: dict[JobName, int] = defaultdict(int)
+    for c in unscheduled_tasks:
+        if c.job_name.parent is not None:
+            sibling_count[c.job_name.parent] += 1
 
     for candidate in unscheduled_tasks:
-        task_id, req, task_band_key = candidate.job_name, candidate.requirements, candidate.band
         # Batch never preempts
-        if task_band_key >= job_pb2.PRIORITY_BAND_BATCH:
+        if candidate.band >= job_pb2.PRIORITY_BAND_BATCH:
             continue
 
-        parent = task_id.parent
+        parent = candidate.job_name.parent
         if parent is not None and parent in satisfied_preemptor_jobs:
             continue
 
-        wanted_variant = get_device_variant(req.resources.device)
+        wanted_variant = get_device_variant(candidate.requirements.resources.device)
 
-        if not req.is_coscheduled:
-            for victim in solo_victims:
-                if victim.already_preempted:
-                    continue
-                # Same-variant gate: only preempt victims that free the
-                # exact device-variant the preemptor requested. Skips any
-                # variant comparison when the preemptor is unconstrained
-                # (CPU-only) and the victim is too — both are None.
-                if victim.device_variant != wanted_variant:
-                    continue
-                # Can only preempt strictly lower priority (higher band_sort_key)
-                if victim.band_sort_key <= task_band_key:
-                    continue
-
-                cap = context.capacities.get(victim.worker_id)
-                if cap is None:
-                    continue
-
-                if not cap.matches_constraints(req.constraints):
-                    continue
-
-                # If current capacity already fits, no preemption needed
-                if cap.can_fit(req) is None:
-                    continue
-
-                # Check if freeing the victim's resources would create enough capacity
-                hypothetical = WorkerCapacity(
-                    worker_id=cap.worker_id,
-                    available_cpu_millicores=cap.available_cpu_millicores + victim.resources.cpu_millicores,
-                    available_memory=cap.available_memory + victim.resources.memory_bytes,
-                    available_gpus=cap.available_gpus + get_gpu_count(victim.resources.device),
-                    available_tpus=cap.available_tpus + get_tpu_count(victim.resources.device),
-                    attributes=cap.attributes,
-                    building_task_count=max(0, cap.building_task_count - 1),
-                    max_building_tasks=cap.max_building_tasks,
-                )
-                if hypothetical.can_fit(req) is None:
-                    preemptions.append((task_id, victim.task_id))
-                    victim.already_preempted = True
-                    break
+        if not candidate.requirements.is_coscheduled:
+            pair = _preempt_solo(candidate, wanted_variant, solo_victims, context)
+            if pair is not None:
+                preemptions.append(pair)
             continue
 
-        # Coscheduled preemptor → evict a same-variant victim slice as a unit.
-        if wanted_variant is None:
-            continue
-        n_required = sum(1 for c in unscheduled_tasks if c.job_name.parent == parent)
-        for _victim_job, members in sorted_groups:
-            if any(m.already_preempted for m in members):
-                continue
-            if members[0].device_variant != wanted_variant:
-                continue
-            # Strict band: every sibling must be lower priority than the preemptor.
-            if any(m.band_sort_key <= task_band_key for m in members):
-                continue
-            if len(members) < n_required:
-                continue
-            for m in members:
-                preemptions.append((task_id, m.task_id))
-                m.already_preempted = True
+        n_required = sibling_count.get(parent, 1) if parent is not None else 1
+        pairs = _preempt_coscheduled(candidate, wanted_variant, n_required, sorted_groups)
+        if pairs:
+            preemptions.extend(pairs)
             if parent is not None:
                 satisfied_preemptor_jobs.add(parent)
-            break
 
     return preemptions
 

--- a/lib/iris/tests/cluster/controller/test_preemption.py
+++ b/lib/iris/tests/cluster/controller/test_preemption.py
@@ -60,6 +60,33 @@ def _cpu_requirements(cpu_cores: int = 1) -> JobRequirements:
     )
 
 
+def _tpu_resources(variant: str, count: int = 4) -> job_pb2.ResourceSpecProto:
+    spec = job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3)
+    spec.device.tpu.variant = variant
+    spec.device.tpu.count = count
+    return spec
+
+
+def _tpu_requirements(variant: str, *, is_coscheduled: bool = False) -> JobRequirements:
+    return JobRequirements(
+        resources=_tpu_resources(variant),
+        constraints=[],
+        is_coscheduled=is_coscheduled,
+        coscheduling_group_by="tpu-name" if is_coscheduled else None,
+    )
+
+
+def _tpu_capacity(worker_id: WorkerId) -> WorkerCapacity:
+    """Worker fully committed to a TPU task (0 available)."""
+    return WorkerCapacity(
+        worker_id=worker_id,
+        available_cpu_millicores=0,
+        available_memory=0,
+        available_gpus=0,
+        available_tpus=0,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Unit tests for _run_preemption_pass
 # ---------------------------------------------------------------------------
@@ -247,6 +274,182 @@ def test_coscheduled_not_preempted():
 
     preemptions = _run_preemption_pass(unscheduled, [victim], ctx)
     assert len(preemptions) == 0
+
+
+# ---------------------------------------------------------------------------
+# Same-variant gating + slice eviction
+# ---------------------------------------------------------------------------
+
+
+def test_solo_preempts_same_variant_tpu():
+    """A solo PRODUCTION TPU task evicts a solo BATCH victim of the same variant."""
+    w1 = WorkerId("w1")
+    ctx = _make_simple_context([_tpu_capacity(w1)])
+
+    victim = RunningTaskInfo(
+        task_id=JobName.from_wire("/alice/batch-job:0"),
+        worker_id=w1,
+        band_sort_key=job_pb2.PRIORITY_BAND_BATCH,
+        resource_value=1000,
+        is_coscheduled=False,
+        resources=_tpu_resources("v5p-8"),
+        device_variant="v5p-8",
+    )
+
+    preemptor_id = JobName.from_wire("/bob/prod-job:0")
+    unscheduled = [
+        PreemptionCandidate(preemptor_id, _tpu_requirements("v5p-8"), job_pb2.PRIORITY_BAND_PRODUCTION),
+    ]
+
+    preemptions = _run_preemption_pass(unscheduled, [victim], ctx)
+    assert preemptions == [(preemptor_id, victim.task_id)]
+
+
+def test_solo_does_not_preempt_different_variant():
+    """A v5p-256 preemptor cannot evict a v5p-8 solo victim (variant mismatch)."""
+    w1 = WorkerId("w1")
+    ctx = _make_simple_context([_tpu_capacity(w1)])
+
+    victim = RunningTaskInfo(
+        task_id=JobName.from_wire("/alice/batch-job:0"),
+        worker_id=w1,
+        band_sort_key=job_pb2.PRIORITY_BAND_BATCH,
+        resource_value=1000,
+        is_coscheduled=False,
+        resources=_tpu_resources("v5p-8"),
+        device_variant="v5p-8",
+    )
+
+    preemptor_id = JobName.from_wire("/bob/prod-job:0")
+    unscheduled = [
+        PreemptionCandidate(preemptor_id, _tpu_requirements("v5p-256"), job_pb2.PRIORITY_BAND_PRODUCTION),
+    ]
+
+    preemptions = _run_preemption_pass(unscheduled, [victim], ctx)
+    assert preemptions == []
+
+
+def test_coscheduled_preemptor_evicts_same_variant_slice():
+    """A coscheduled PROD job of N tasks evicts an entire coscheduled BATCH slice
+    of the same variant; one slice eviction satisfies all N preemptor siblings."""
+    workers = [WorkerId(f"w{i}") for i in range(4)]
+    ctx = _make_simple_context([_tpu_capacity(w) for w in workers])
+
+    victim_job = JobName.from_wire("/alice/cosched-batch")
+    victims = [
+        RunningTaskInfo(
+            task_id=victim_job.child(str(i)),
+            worker_id=workers[i],
+            band_sort_key=job_pb2.PRIORITY_BAND_BATCH,
+            resource_value=1000,
+            is_coscheduled=True,
+            resources=_tpu_resources("v5p-8"),
+            device_variant="v5p-8",
+        )
+        for i in range(4)
+    ]
+
+    preemptor_job = JobName.from_wire("/bob/cosched-prod")
+    req = _tpu_requirements("v5p-8", is_coscheduled=True)
+    unscheduled = [
+        PreemptionCandidate(preemptor_job.child(str(i)), req, job_pb2.PRIORITY_BAND_PRODUCTION) for i in range(4)
+    ]
+
+    preemptions = _run_preemption_pass(unscheduled, victims, ctx)
+    # Exactly N pairs emitted, one preemptor task per victim sibling.
+    assert len(preemptions) == 4
+    assert {p[1] for p in preemptions} == {v.task_id for v in victims}
+    # All pairs are attributed to a single preemptor sibling — the rest
+    # short-circuit via the satisfied_preemptor_jobs guard.
+    preemptors_used = {p[0] for p in preemptions}
+    assert len(preemptors_used) == 1
+
+
+def test_coscheduled_preemptor_does_not_evict_different_variant_slice():
+    """v5p-256 coscheduled preemptor cannot tear down a v5p-8 slice."""
+    workers = [WorkerId(f"w{i}") for i in range(4)]
+    ctx = _make_simple_context([_tpu_capacity(w) for w in workers])
+
+    victim_job = JobName.from_wire("/alice/cosched-batch")
+    victims = [
+        RunningTaskInfo(
+            task_id=victim_job.child(str(i)),
+            worker_id=workers[i],
+            band_sort_key=job_pb2.PRIORITY_BAND_BATCH,
+            resource_value=1000,
+            is_coscheduled=True,
+            resources=_tpu_resources("v5p-8"),
+            device_variant="v5p-8",
+        )
+        for i in range(4)
+    ]
+
+    preemptor_job = JobName.from_wire("/bob/cosched-prod")
+    req = _tpu_requirements("v5p-256", is_coscheduled=True)
+    unscheduled = [
+        PreemptionCandidate(preemptor_job.child(str(i)), req, job_pb2.PRIORITY_BAND_PRODUCTION) for i in range(4)
+    ]
+
+    preemptions = _run_preemption_pass(unscheduled, victims, ctx)
+    assert preemptions == []
+
+
+def test_coscheduled_preemptor_skips_undersized_slice():
+    """Slice eviction requires len(victim_group) >= preemptor sibling count."""
+    workers = [WorkerId(f"w{i}") for i in range(2)]
+    ctx = _make_simple_context([_tpu_capacity(w) for w in workers])
+
+    victim_job = JobName.from_wire("/alice/small-batch")
+    victims = [
+        RunningTaskInfo(
+            task_id=victim_job.child(str(i)),
+            worker_id=workers[i],
+            band_sort_key=job_pb2.PRIORITY_BAND_BATCH,
+            resource_value=1000,
+            is_coscheduled=True,
+            resources=_tpu_resources("v5p-8"),
+            device_variant="v5p-8",
+        )
+        for i in range(2)
+    ]
+
+    preemptor_job = JobName.from_wire("/bob/big-prod")
+    req = _tpu_requirements("v5p-8", is_coscheduled=True)
+    unscheduled = [
+        PreemptionCandidate(preemptor_job.child(str(i)), req, job_pb2.PRIORITY_BAND_PRODUCTION)
+        for i in range(4)  # needs 4, slice has 2
+    ]
+
+    preemptions = _run_preemption_pass(unscheduled, victims, ctx)
+    assert preemptions == []
+
+
+def test_solo_preemptor_does_not_tear_down_slice():
+    """A non-coscheduled preemptor never evicts a coscheduled slice, even on a variant match."""
+    workers = [WorkerId(f"w{i}") for i in range(4)]
+    ctx = _make_simple_context([_tpu_capacity(w) for w in workers])
+
+    victim_job = JobName.from_wire("/alice/cosched-batch")
+    victims = [
+        RunningTaskInfo(
+            task_id=victim_job.child(str(i)),
+            worker_id=workers[i],
+            band_sort_key=job_pb2.PRIORITY_BAND_BATCH,
+            resource_value=1000,
+            is_coscheduled=True,
+            resources=_tpu_resources("v5p-8"),
+            device_variant="v5p-8",
+        )
+        for i in range(4)
+    ]
+
+    preemptor_id = JobName.from_wire("/bob/solo-prod:0")
+    unscheduled = [
+        PreemptionCandidate(preemptor_id, _tpu_requirements("v5p-8"), job_pb2.PRIORITY_BAND_PRODUCTION),
+    ]
+
+    preemptions = _run_preemption_pass(unscheduled, victims, ctx)
+    assert preemptions == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Coscheduled victims were previously immune to preemption. Allow a higher-band coscheduled preemptor to evict an entire victim slice (all running tasks of one coscheduled job) when the slice's device-variant matches the request and the slice is at least as large as the preemptor. Solo preemption now also gates on matching device-variant, so a v5p-256 request can never reclaim a v5p-8 slot. All victims of a pass tear down in a single transaction.