### PR TITLE
[Design] executor_in_training_job

### DIFF
--- a/.agents/projects/executor_in_training_job/design.md
+++ b/.agents/projects/executor_in_training_job/design.md
@@ -1,0 +1,110 @@
+# Run the executor inside the training job
+
+_Why are we doing this? What's the benefit?_
+
+Today an executor entrypoint runs in one Iris job, walks the full DAG (tokenize → train), and pins itself and every downstream job to whichever GCP region the entrypoint happened to land in. When the training step is preempted, Iris may schedule it in a different region than the one its data was created in — at which point we either crash or silently pay cross-region egress to copy tens to hundreds of GB. We want training data, by definition, to live in the region the training job runs in.
+
+The fix is to invert the launch model: the entrypoint is just an `IrisClient.submit(...)` call — region-agnostic, no reservation, fire-and-forget. The training job, when it runs, calls `Executor.run(...)` on its own upstream deps inside its assigned region. Region pinning becomes a property of training, not of the entrypoint.
+
+## Background
+
+Each `@remote` step is already its own Fray/Iris job (`lib/marin/src/marin/execution/step_runner.py:345`, `remote.py:74-85`); only the *DAG walk* runs in-process inside `executor_main`. The executor already handles concurrent execution of the same step via a distributed lock + status file (`step_runner.py:341`, `executor_step_status.py`); peers and sweep members converge naturally with no extra coordination. Per-region prefix resolution already works via `rigging.filesystem.marin_prefix()` (`lib/rigging/src/rigging/filesystem.py:132-147`), which reads GCS metadata and returns `gs://marin-{region}` automatically. The executor's GCS-path-based region inference (`lib/marin/src/marin/execution/executor.py:561-631`) stays — it's how a step whose outputs land in `gs://marin-us-east5/...` ends up pinned to `us-east5`. The piece that goes away is Iris's parent-task → child-job region inheritance, currently implemented at `lib/iris/src/iris/cluster/worker/task_attempt.py:696` by stamping `IRIS_WORKER_REGION` into the child task's environment.
+
+## Design
+
+Two changes.
+
+**1. Entrypoint stops calling `executor_main`. It calls the iris client directly.** The pipeline file's `__main__` block becomes a submission of the training step's `@remote` callable:
+
+```python
+if __name__ == "__main__":
+    training_step.fn(training_step.config)   # @remote → IrisClient.submit
+```
+
+`@remote` already submits via `IrisClient.submit` and blocks on the result (`lib/marin/src/marin/execution/remote.py:74-85`); the entrypoint inherits that — submit and wait for completion is the default, matching today's `executor_main` behaviour. A non-blocking variant for users who want fire-and-forget can be added later if a real caller needs it. The entrypoint Iris job is CPU-only, region-agnostic, no reservation, short-lived. For sweeps, the entrypoint submits N training jobs (sequential `submit + wait`, or parallel via threads / a small concurrency helper) — same DAG, different configs.
+
+**2. Training functions call `Executor.run(upstream_deps)` at the top of their bodies.** The training step's `@remote` function (e.g. `run_grug_base_trial`) gains a small wrapper that, before training, materialises its data dependencies:
+
+```python
+def run_grug_base_trial(config: GrugBaseLaunchConfig):
+    Executor().run(upstream_steps(config))   # tokenize, etc.
+    train(config)                             # JAX init + training loop
+```
+
+`upstream_steps(config)` is a new public helper in `marin.execution` that recursively walks any object and returns the `ExecutorStep` instances embedded in it — the same traversal `Executor` already does privately in `_build_dependency_graph` (`executor.py:418, 462`), exposed as a top-level function (mirrors `collect_gcs_paths` in `rigging/filesystem.py:300-313`). The training function only receives `config`, not the `ExecutorStep` itself, and the upstream tokenize steps are nested inside `config.data.components` etc. (see `lm_varying_mixture_data_config(components=...)` in `experiments/references/reference_training_pipeline.py:68-75`). The `ExecutorStep` objects are serialised into the `JobRequest` via the `@remote` decorator's pickle path.
+
+`Executor.run` walks this DAG locally:
+
+- Sub-jobs (tokenize etc.) are submitted as `@remote` Fray/Iris jobs from inside the training job. Their output paths resolve under `marin_prefix()`, which is `gs://marin-{R}` for the training job's region R; the executor's path-based inference (`executor.py:561-631`) then stamps `regions=[R]` onto each sub-job's `ResourceConfig`, keeping data co-located with training.
+- Multi-VM TPU jobs: every task calls `Executor.run`. The existing `step_lock` (`step_runner.py:341`) ensures exactly one task per step actually runs the work; the rest read `STATUS_SUCCESS` and skip. No leader logic, no sentinels, no `task_index == 0` branch.
+- Sweeps: every member calls `Executor.run` on its own DAG view. Shared upstream steps are computed exactly once across the whole sweep — `step_lock` is the cross-process coordinator.
+
+**3. Iris change.** Remove the implicit `IRIS_WORKER_REGION` injection at `lib/iris/src/iris/cluster/worker/task_attempt.py:696`. After this, a parent task in `us-central1` submitting a child job with no explicit region produces a region-unconstrained child. Region pinning is now only via (a) explicit `regions=[...]` on `ResourceConfig`, or (b) the executor's path-based inference firing because outputs land under a region-specific prefix. `JobInfo.worker_region` (`lib/iris/src/iris/cluster/client/job_info.py:122`) stays available for callers that explicitly want to know where they're running.
+
+## Migration
+
+`grep -rl executor_main experiments/` returns 89 files. Per-file changes are mechanical. Concretely, the reference pipeline (`experiments/references/reference_training_pipeline.py:112-113`) goes from:
+
+```python
+# Before — entrypoint walks the DAG, pinning everything to one region
+from marin.execution.executor import ExecutorStep, executor_main, this_output_path
+
+# ... (model, data, training_step definitions unchanged) ...
+
+if __name__ == "__main__":
+    executor_main(steps=[training_step])
+```
+
+to:
+
+```python
+# After — entrypoint just submits the training job
+from marin.execution.executor import ExecutorStep, this_output_path
+
+# ... (model, data, training_step definitions unchanged) ...
+
+if __name__ == "__main__":
+    training_step.fn(training_step.config)   # @remote → IrisClient.submit, blocks
+```
+
+Everything between the imports and `__main__` (model config, tokenize step construction, `lm_varying_mixture_data_config(components=...)`, training_step definition) stays identical. The upstream tokenize `ExecutorStep` objects are still embedded in `training_step.config.data.components`; they are now materialised inside the training job rather than from the entrypoint. See `spec.md` for the full rewritten pipeline.
+
+The training-side change is a single line per training launcher (one place per launcher — `run_grug_base_trial`, `train_lm`, etc., not 89 places):
+
+```python
+def run_grug_base_trial(config: GrugBaseLaunchConfig):
+    Executor().run(upstream_steps(config))   # new — materialise deps
+    train(config)                             # existing body unchanged
+```
+
+The bulk of the 89 files are pipeline definitions like the one above; the per-experiment migration is the entrypoint one-liner.
+
+This design doc covers the framework changes (entrypoint pattern, `upstream_steps` helper, Iris inheritance removal). The actual per-experiment migration sweeps are deferred to follow-up PRs:
+
+- **PR 1 (this design)**: framework changes + migrate `experiments/references/reference_training_pipeline.py` as the proof-of-concept.
+- **PR 2..N**: sweep the remaining 88 callers in batches, grouped by training launcher (so each PR touches one launcher + its experiments).
+- **Final PR**: delete `executor_main` once nothing references it.
+
+We do not maintain dual paths; once a launcher is migrated all of its experiments migrate with it.
+
+## Costs / Risks
+
+- **Storage duplication.** Training data is re-tokenized in each region a job lands in. Accepted.
+- **Cold-start cost on first run in a new region.** A preempted training job restarting in a fresh region pays the full tokenize time before training resumes. Acceptable — replaces a worse failure mode (crash or large egress bill).
+- **New pattern: an Iris job submitting other Iris jobs.** Not used elsewhere in `experiments/`; we are the first consumer. Constraint plumbing (env, packages, bundle propagation through the `@remote` payload) needs care.
+- **Migration burden.** A grep for `executor_main` in `experiments/` returns 89 callers. We migrate the reference pipeline first; the rest sweep in a follow-up PR series. We do not maintain dual paths.
+
+## Testing
+
+- **Unit**: training-function wrapper invokes `Executor.run(deps)` then `train(config)`; concurrent calls with overlapping DAGs converge via `step_lock` (already covered by executor tests, but extend with a multi-process case).
+- **Iris integration test** on the dev cluster: 2-task fake training job whose "executor.run" sleeps; assert exactly one task does the work and both reach the post-executor code.
+- **End-to-end on the reference pipeline**: launch via the new entrypoint, verify (a) entrypoint job has no region constraint, (b) tokenize sub-jobs land in the same region as the training job, (c) data is written under that region's `marin-*` bucket, (d) `TransferBudget.bytes_used` (`rigging/filesystem.py:444`) is near zero.
+- **Cross-region preemption smoke test**: kill training mid-run; if Iris reschedules it to a different region, executor runs again locally and training resumes without cross-region reads.
+- **Iris regression test** for the inheritance removal: a parent task in `us-central1` submits a child with no explicit region; child must be region-unconstrained.
+- **Sweep coordination**: launch a small sweep where members share an upstream tokenize step; verify the shared step runs exactly once across the sweep.
+
+## Open Questions
+
+- **Non-training executor pipelines.** Are there pipelines today that use `executor_main` for non-training work (eval-only, dataset-only) where there's no obvious "leaf training step" to wrap with the new pattern? If so, we either keep `executor_main` available for those or come up with an analogous "leaf step calls executor on its own deps" wrapper.
+- **Sweep concurrency in the entrypoint.** A sweep entrypoint that loops `submit + wait` runs sweep members serially. Most users will want them parallel. Do we ship a small concurrency helper (`submit_all([step1, step2, ...])` that submits all then awaits) in the same PR, or punt until the first sweep caller migrates?
+- **Reservations interaction.** This design works whether `--reserve` exists or not. #4631 (replace reservations with allocations) is parallel work; mention it for context but not blocking.

--- a/.agents/projects/executor_in_training_job/design.md
+++ b/.agents/projects/executor_in_training_job/design.md
@@ -23,21 +23,23 @@ if __name__ == "__main__":
 
 `@remote` already submits via `IrisClient.submit` and blocks on the result (`lib/marin/src/marin/execution/remote.py:74-85`); the entrypoint inherits that — submit and wait for completion is the default, matching today's `executor_main` behaviour. A non-blocking variant for users who want fire-and-forget can be added later if a real caller needs it. The entrypoint Iris job is CPU-only, region-agnostic, no reservation, short-lived. For sweeps, the entrypoint submits N training jobs (sequential `submit + wait`, or parallel via threads / a small concurrency helper) — same DAG, different configs.
 
-**2. Training functions call `Executor.run(upstream_deps)` at the top of their bodies.** The training step's `@remote` function (e.g. `run_grug_base_trial`) gains a small wrapper that, before training, materialises its data dependencies:
+**2. Training functions call `materialize(config)` at the top of their bodies.** The training step's `@remote` function (e.g. `run_grug_base_trial`) gains a small wrapper that, before training, runs its upstream `ExecutorStep`s and replaces every `InputName` / `OutputName` placeholder in `config` with the now-known concrete path:
 
 ```python
 def run_grug_base_trial(config: GrugBaseLaunchConfig):
-    Executor().run(upstream_steps(config))   # tokenize, etc.
+    config = materialize(config)              # run upstream steps + substitute placeholders
     train(config)                             # JAX init + training loop
 ```
 
-`upstream_steps(config)` is a new public helper in `marin.execution` that recursively walks any object and returns the `ExecutorStep` instances embedded in it — the same traversal `Executor` already does privately in `_build_dependency_graph` (`executor.py:418, 462`), exposed as a top-level function (mirrors `collect_gcs_paths` in `rigging/filesystem.py:300-313`). The training function only receives `config`, not the `ExecutorStep` itself, and the upstream tokenize steps are nested inside `config.data.components` etc. (see `lm_varying_mixture_data_config(components=...)` in `experiments/references/reference_training_pipeline.py:68-75`). The `ExecutorStep` objects are serialised into the `JobRequest` via the `@remote` decorator's pickle path.
+Why both halves are required: today's entrypoint runs `executor_main`, which calls `instantiate_config` (`executor.py:1446`) to substitute `InputName` / `OutputName` / `VersionedValue` placeholders before the `@remote` payload is pickled. In the new design the entrypoint is just `training_step.fn(training_step.config)` — there is no Executor in the entrypoint, so the worker receives a config with raw `InputName` placeholders still embedded in `config.data.components`. Running the upstream steps without then substituting their output paths would leave `train(config)` reading `InputName(step=…)` as a path and crashing. `materialize` composes both halves: walk + run + substitute, returning a config that `train` can use directly.
 
-`Executor.run` walks this DAG locally:
+`upstream_steps(config)` is a new public helper in `marin.execution` that recursively walks any object and returns the `ExecutorStep` instances embedded in it — the same traversal `collect_dependencies_and_version` already does privately (`executor.py:1037`, with the `recurse` closure at `:1062`), exposed as a top-level function (mirrors `collect_gcs_paths` in `rigging/filesystem.py:300-313`). The training function only receives `config`, not the `ExecutorStep` itself, and the upstream tokenize steps are nested inside `config.data.components` etc. (see `lm_varying_mixture_data_config(components=...)` in `experiments/references/reference_training_pipeline.py:68-75`). The `ExecutorStep` objects are serialised into the `JobRequest` via the `@remote` decorator's pickle path.
+
+`materialize` walks this DAG locally (it composes `upstream_steps` + `Executor.run` + `instantiate_config`):
 
 - Sub-jobs (tokenize etc.) are submitted as `@remote` Fray/Iris jobs from inside the training job. Their output paths resolve under `marin_prefix()`, which is `gs://marin-{R}` for the training job's region R; the executor's path-based inference (`executor.py:561-631`) then stamps `regions=[R]` onto each sub-job's `ResourceConfig`, keeping data co-located with training.
-- Multi-VM TPU jobs: every task calls `Executor.run`. The existing `step_lock` (`step_runner.py:341`) ensures exactly one task per step actually runs the work; the rest read `STATUS_SUCCESS` and skip. No leader logic, no sentinels, no `task_index == 0` branch.
-- Sweeps: every member calls `Executor.run` on its own DAG view. Shared upstream steps are computed exactly once across the whole sweep — `step_lock` is the cross-process coordinator.
+- Multi-VM TPU jobs: every task calls `materialize`. The existing `step_lock` (`step_runner.py:341`) ensures exactly one task per step actually runs the work; the rest read `STATUS_SUCCESS` and skip. No leader logic, no sentinels, no `task_index == 0` branch.
+- Sweeps: every member calls `materialize` on its own config. Shared upstream steps are computed exactly once across the whole sweep — `step_lock` is the cross-process coordinator.
 
 **3. Iris change.** Remove the implicit `IRIS_WORKER_REGION` injection at `lib/iris/src/iris/cluster/worker/task_attempt.py:696`. After this, a parent task in `us-central1` submitting a child job with no explicit region produces a region-unconstrained child. Region pinning is now only via (a) explicit `regions=[...]` on `ResourceConfig`, or (b) the executor's path-based inference firing because outputs land under a region-specific prefix. `JobInfo.worker_region` (`lib/iris/src/iris/cluster/client/job_info.py:122`) stays available for callers that explicitly want to know where they're running.
 
@@ -73,7 +75,7 @@ The training-side change is a single line per training launcher (one place per l
 
 ```python
 def run_grug_base_trial(config: GrugBaseLaunchConfig):
-    Executor().run(upstream_steps(config))   # new — materialise deps
+    config = materialize(config)              # new — run upstream steps + substitute placeholders
     train(config)                             # existing body unchanged
 ```
 
@@ -96,8 +98,8 @@ We do not maintain dual paths; once a launcher is migrated all of its experiment
 
 ## Testing
 
-- **Unit**: training-function wrapper invokes `Executor.run(deps)` then `train(config)`; concurrent calls with overlapping DAGs converge via `step_lock` (already covered by executor tests, but extend with a multi-process case).
-- **Iris integration test** on the dev cluster: 2-task fake training job whose "executor.run" sleeps; assert exactly one task does the work and both reach the post-executor code.
+- **Unit**: `materialize(config)` runs upstream steps and returns a config with placeholders substituted; concurrent calls with overlapping DAGs converge via `step_lock` (already covered by executor tests, but extend with a multi-process case). Idempotence: a config containing no placeholders round-trips unchanged with no sub-jobs submitted.
+- **Iris integration test** on the dev cluster: 2-task fake training job whose `materialize` sub-step sleeps; assert exactly one task does the work and both reach the post-`materialize` code with identically-substituted configs.
 - **End-to-end on the reference pipeline**: launch via the new entrypoint, verify (a) entrypoint job has no region constraint, (b) tokenize sub-jobs land in the same region as the training job, (c) data is written under that region's `marin-*` bucket, (d) `TransferBudget.bytes_used` (`rigging/filesystem.py:444`) is near zero.
 - **Cross-region preemption smoke test**: kill training mid-run; if Iris reschedules it to a different region, executor runs again locally and training resumes without cross-region reads.
 - **Iris regression test** for the inheritance removal: a parent task in `us-central1` submits a child with no explicit region; child must be region-unconstrained.
@@ -108,3 +110,4 @@ We do not maintain dual paths; once a launcher is migrated all of its experiment
 - **Non-training executor pipelines.** Are there pipelines today that use `executor_main` for non-training work (eval-only, dataset-only) where there's no obvious "leaf training step" to wrap with the new pattern? If so, we either keep `executor_main` available for those or come up with an analogous "leaf step calls executor on its own deps" wrapper.
 - **Sweep concurrency in the entrypoint.** A sweep entrypoint that loops `submit + wait` runs sweep members serially. Most users will want them parallel. Do we ship a small concurrency helper (`submit_all([step1, step2, ...])` that submits all then awaits) in the same PR, or punt until the first sweep caller migrates?
 - **Reservations interaction.** This design works whether `--reserve` exists or not. #4631 (replace reservations with allocations) is parallel work; mention it for context but not blocking.
+- **Where does `materialize` get the "current step's `output_path`"?** `instantiate_config` (`executor.py:1137`) takes `output_path: str` for resolving `OutputName` placeholders. Two options: (a) read it from `config.output_path` if the launcher convention exposes one — matches `GrugBaseLaunchConfig.output_path = this_output_path()` in the worked example; (b) read it from the Iris worker context (e.g. an Iris client method exposing the running task's output path). (a) is simpler and already the launcher convention; (b) is more general. Default proposal: (a), require launchers to expose `output_path: str` on their config, and revisit if a launcher emerges that can't.

--- a/.agents/projects/executor_in_training_job/research.md
+++ b/.agents/projects/executor_in_training_job/research.md
@@ -1,0 +1,74 @@
+# Research: executor inside the training job
+
+## In-repo findings
+
+### Current launch flow
+
+- Users invoke `iris job run --reserve <tpu> experiments/.../pipeline.py`. The entrypoint is the script itself, and it terminates by calling `executor_main(steps=[...])` (`lib/marin/src/marin/execution/executor.py:1628`). `executor_main` constructs an `Executor` and calls `Executor.run()` (`:1275`).
+- `Executor.run()` walks the DAG and dispatches each `ExecutorStep` to a `StepRunner`. For `@remote`-wrapped fns, `StepRunner._do_launch` (`lib/marin/src/marin/execution/step_runner.py:217`) routes to `_run_remote_step` (`:345`), which submits the step as a Fray job via `RemoteCallable.__call__` (`lib/marin/src/marin/execution/remote.py:74-85`, calling `fray_client.submit(JobRequest(...))`).
+- **Each `@remote` step is already its own Fray/Iris job today.** The inversion in this design is at the orchestrator level (where the DAG walk happens), not at the step level.
+
+### Region pinning in the executor
+
+- `_maybe_attach_inferred_region_constraint` (`lib/marin/src/marin/execution/executor.py:561-631`) infers a region from any GCS path in a step's config/deps/output_path via `_infer_gcs_regions` (`:201-264`), and injects `regions=[pinned_region]` into the step's `ResourceConfig`. Cross-region deps within a single step raise (`:244-246`).
+- This stays in the new design: a step that explicitly references a `gs://marin-us-central1/...` path still pins to `us-central1`. We are *not* removing this.
+
+### Region pinning in Iris
+
+- Iris's `IrisClient.submit(...)` accepts `region_constraint(...)` (`lib/iris/src/iris/client/client.py:41`).
+- When a job submitted *from inside another Iris task* lands at the controller, the child inherits the parent's `worker_region` as an automatic region constraint. This is the implicit pinning the user wants removed: an entrypoint job that lands in `us-central1` (because of where Iris ran its scheduler-of-the-day) should not force every downstream training job to also be `us-central1`.
+- `worker_region` comes from `IRIS_WORKER_REGION` (`lib/iris/src/iris/cluster/client/job_info.py:122`); inheritance happens during child submission.
+
+### Multi-VM coordination — already handled by `step_lock`
+
+- `step_runner.py:341` wraps step execution in `with step_lock(output_path, step_label) as status_file:` — a distributed lock with heartbeat that blocks until either the lock is obtained or the step is observed complete. `step_runner.py:124`: "steps (STATUS_SUCCESS on disk) are skipped automatically."
+- This means concurrent calls to `Executor.run` on the same DAG converge: all peers in a multi-VM training job (and all members of a sweep) call `Executor.run`; `step_lock` ensures exactly one wins per step, the rest read SUCCESS and skip.
+- No leader / sentinel / barrier logic is needed at the design layer — it would duplicate `step_lock`.
+- `JobInfo.task_index` (`lib/iris/src/iris/cluster/client/job_info.py:73`) and `JobInfo.worker_region` (`:122`) are still useful for diagnostics / explicit region-aware code paths, but they are not required for the design's correctness.
+
+### Per-region prefix resolution
+
+- `marin_prefix()` (`lib/rigging/src/rigging/filesystem.py:132-147`) already does the right thing: env `MARIN_PREFIX` first, else GCS metadata server → `gs://marin-{region}`, else `/tmp/marin`. Region overrides exist for europe-west4. So a training job that lands in any supported region resolves the correct bucket without configuration.
+- `marin_region()` (`:150-157`) gives the current region from metadata or `MARIN_PREFIX`.
+- `mirror://` and `CrossRegionGuardedFS` (`:551`, `:723`) handle the rare case where a job legitimately needs to read a remote-region file.
+- All canonical region buckets exist already (`REGION_TO_DATA_BUCKET`, `:72-79`).
+
+### Reservations
+
+- `--reserve` and `IrisClient.submit(reservation=...)` (`client.py:565`) pre-provision workers but do not pin region. Issue #4631 ("get rid of reservations") is open and the user has confirmed the feature will be deleted in a follow-up PR.
+
+### Reference pipeline
+
+- `experiments/references/reference_training_pipeline.py:81-110` defines a single training `ExecutorStep` whose config references tokenize `ExecutorStep` objects (DCLM, Dolmino, SmolTalk). When `executor_main` runs in the entrypoint today, those tokenize steps are walked first and run as Fray sub-jobs before training launches.
+- Under the new design the entrypoint never walks the DAG. The training job receives the same root step and walks the DAG itself, running the upstream tokenize steps (now as children of the training job's region) before training.
+
+### Existing patterns that change
+
+- No examples in `experiments/` of an Iris job using `IrisClient.submit()` to launch sibling top-level jobs. This is a new pattern; we'll need a small launcher helper alongside the executor.
+- `mirrored()` wrapper (`executor.py:948-955`, `mirror_budget` at `filesystem.py:491`) remains available for opt-in cross-region access during the transition (e.g. if a user wants to read an already-tokenized dataset that only exists in `us-central1`).
+
+### Related design docs
+
+- `.agents/projects/20260302_iris_reservation_design.md` — reservations are demand pre-provisioning; orthogonal to region pinning.
+- `.agents/projects/iris-log-store-gcs-fallback.md` — unrelated.
+
+### Related issues
+
+- #4631 (open) — get rid of reservations. Adjacent; this design doc clears one major use case.
+- #4969, #3981 — root-region prefix leakage into child jobs. Removing implicit region inheritance in Iris should fix or simplify these.
+- #4428 — move TPU region inference behind a public Iris API. Compatible with this design (executor still does its own inference).
+- #4223 — `.mirrored()` for cross-region reads. Stays available.
+
+## User decisions (from Q&A)
+
+1. **Multi-VM**: every task calls `Executor.run`; the existing `step_lock` (`step_runner.py:341`) is the coordinator. No leader logic, no sentinel files.
+2. **Per-region prefix**: already done — `rigging.filesystem.marin_prefix()`.
+3. **Scope of "remove implicit region pinning"**: the *Iris* parent → child region inheritance is removed (`task_attempt.py:696`). The *executor*'s GCS path-based region inference (`executor.py:561-631`) stays.
+4. **Reservations**: deleted in a follow-up PR. Out of scope here.
+5. **Existing data**: re-tokenized in the region where the job lands. We accept the storage cost.
+6. **Entrypoint**: just an `IrisClient.submit(...)` call — no `executor_main`, no new helper, no DAG walk in the entrypoint.
+7. **Sweeps**: same path — entrypoint submits N training jobs; members compete for shared upstream steps via `step_lock`.
+
+## Web prior-art pass
+
+Skipped. This is an internal orchestration refactor (move the DAG walk from outer to inner job, drop one source of constraint inheritance), not a new category of system.

--- a/.agents/projects/executor_in_training_job/spec.md
+++ b/.agents/projects/executor_in_training_job/spec.md
@@ -1,0 +1,246 @@
+# Spec: executor inside the training job
+
+Concrete contracts the design implies. Read alongside `design.md`.
+
+## New public API
+
+### `marin.execution.upstream_steps`
+
+Where it lives: `lib/marin/src/marin/execution/dag.py` (new module — keeps `executor.py` from growing further).
+
+```python
+from typing import Any
+from marin.execution.executor import ExecutorStep
+
+def upstream_steps(obj: Any) -> list[ExecutorStep]:
+    """Recursively walk obj and return every ExecutorStep referenced from it.
+
+    Walks dataclasses (via `dataclasses.fields`), dicts (values), lists/tuples/sets
+    (elements), and `ExecutorStep` instances themselves. The same step appearing
+    multiple times in the object graph is returned exactly once. Order is
+    deterministic (depth-first, fields/keys/elements in declaration order).
+
+    Does NOT walk into the returned steps' configs — it returns the steps the
+    caller's `obj` references directly. Transitive dependencies are discovered
+    by `Executor.run()` itself (which already walks step configs to build
+    its dependency graph).
+
+    Args:
+        obj: Any object — typically a config dataclass like
+            `GrugBaseLaunchConfig`, but accepts any value.
+
+    Returns:
+        Deterministically ordered list of unique ExecutorStep instances.
+    """
+```
+
+The implementation is a port of the private traversal already used in `Executor._build_dependency_graph` (`lib/marin/src/marin/execution/executor.py:418, 462`). Extract that traversal into `dag.py` and have `Executor` call into the public function.
+
+## Entrypoint contract
+
+Pipeline files' `__main__` block:
+
+```python
+if __name__ == "__main__":
+    training_step.fn(training_step.config)
+```
+
+`training_step.fn` is a `RemoteCallable` (`lib/marin/src/marin/execution/remote.py:44`); calling it submits a top-level Iris job via `IrisClient.submit` and blocks until the job terminates (success, failure, or cancellation). Exit code of the entrypoint reflects the inner job's terminal status — same observable behaviour as today's `executor_main(steps=[training_step])`.
+
+No new helper function is introduced for the entrypoint. `executor_main` is not deleted in this PR; it remains in place for callers that haven't migrated.
+
+## Training-launcher contract
+
+Each `@remote`-wrapped training launcher (e.g. `run_grug_base_trial` at `experiments/grug/base/launch.py`, `train_lm` at `lib/marin/src/marin/training/...`) gains exactly one new line:
+
+```python
+def run_grug_base_trial(config: GrugBaseLaunchConfig):
+    Executor().run(upstream_steps(config))   # new — materialise deps
+    train(config)                             # existing body
+```
+
+Behaviour:
+- `Executor().run(steps)` walks each step's transitive deps, submits any that aren't `STATUS_SUCCESS`, blocks on completion (`step_runner.py:341` distributed lock + heartbeat handles cross-task / cross-process coordination).
+- If `upstream_steps(config)` returns `[]`, `Executor().run([])` is a no-op and training proceeds immediately.
+- Exceptions propagate; if dependency materialisation fails, training is not attempted.
+
+No new decorator, no new wrapper class — the launcher composes the two existing pieces explicitly.
+
+## Iris contract change
+
+**File**: `lib/iris/src/iris/cluster/worker/task_attempt.py`
+
+**Removed**: line 696, the `env["IRIS_WORKER_REGION"] = region_attr.string_value` injection into child task environments.
+
+**Result**: a parent task in region R submitting a child job with no explicit `regions=[...]` produces a region-unconstrained child. Region pinning becomes opt-in via:
+- Explicit `regions=[...]` on `ResourceConfig` at the call site, OR
+- The executor's path-based inference (`lib/marin/src/marin/execution/executor.py:561-631`) firing because step output paths land under a region-specific prefix.
+
+**Retained**: `JobInfo.worker_region` (`lib/iris/src/iris/cluster/client/job_info.py:56, 122`) remains populated from the worker's actual region, for callers that explicitly want to know where they're running. Only the *automatic propagation into child constraints* goes away.
+
+## File paths
+
+| Piece | Path |
+|---|---|
+| `upstream_steps` (new) | `lib/marin/src/marin/execution/dag.py` |
+| `Executor` (modified to call into `dag.py`) | `lib/marin/src/marin/execution/executor.py` |
+| Iris inheritance removal | `lib/iris/src/iris/cluster/worker/task_attempt.py:696` |
+| Reference pipeline migration (proof-of-concept) | `experiments/references/reference_training_pipeline.py` |
+| Training launcher wrapper (one line per launcher) | `experiments/grug/base/launch.py`, `lib/marin/src/marin/training/...` |
+
+## Worked example: rewritten `reference_training_pipeline.py`
+
+The full migrated pipeline. The only changes from the current file (`experiments/references/reference_training_pipeline.py`) are: the import of `executor_main` is dropped, and the `__main__` block calls the training step's `@remote` callable directly. Model config, schedule, data construction, mixture, and `training_step` definition are byte-identical to the current file.
+
+```python
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reference: Single-run pretraining → midtraining → SFT pipeline.
+
+Demonstrates that pretrain/midtrain/SFT are all just data mixing phases.
+The entire pipeline is one training run with time-varying mixture weights:
+
+  1. Pretrain (steps 0-40k): DCLM baseline
+  2. Midtrain (steps 40k-50k): Blend DCLM + Dolmino math
+  3. SFT (steps 50k-52k): SmolTalk instruction data
+"""
+
+import dataclasses
+
+from levanter.data.text import ChatLmDatasetFormat
+from levanter.optim import AdamConfig
+from levanter.tracker.wandb import WandbConfig
+
+from experiments.defaults import default_tokenize, default_validation_sets
+from experiments.grug.base.launch import GrugBaseLaunchConfig, run_grug_base_trial
+from experiments.grug.base.model import GrugModelConfig
+from experiments.grug.base.train import GrugEvalConfig
+from experiments.marin_models import marin_tokenizer
+from experiments.posttrain.instruction_datasets import get_instruction_dataset
+from experiments.pretraining_datasets.dclm import dclm_components_llama3
+from experiments.pretraining_datasets.dolmino import tokenize_dolmino
+from fray.cluster import ResourceConfig
+from marin.execution.executor import ExecutorStep, this_output_path   # <-- executor_main removed
+from marin.execution.remote import remote
+from marin.processing.tokenize import add_validation_sets_to_mixture
+from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
+
+# --- Model: 600M Grug ---
+model = GrugModelConfig(
+    vocab_size=128_256,
+    max_seq_len=4096,
+    hidden_dim=1024,
+    intermediate_dim=3584,
+    num_heads=16,
+    num_kv_heads=8,
+    num_layers=24,
+)
+
+# --- Schedule ---
+PRETRAIN_STEPS = 40_000
+MIDTRAIN_STEPS = 10_000
+SFT_STEPS = 2_000
+TOTAL_STEPS = PRETRAIN_STEPS + MIDTRAIN_STEPS + SFT_STEPS
+
+# --- Data components (unchanged: these still produce ExecutorSteps) ---
+pretrain = {"dclm": dclm_components_llama3["dclm_baseline"]}
+
+dolmino = tokenize_dolmino()
+midtrain = {"dolmino_math": dolmino["dolmino/math/metamath-owmfilter"]}
+
+smoltalk = get_instruction_dataset("HuggingFaceTB/smoltalk", splits=["train"])
+sft = {
+    "smoltalk": default_tokenize(
+        name="smoltalk_marin",
+        dataset=smoltalk / "**/*.jsonl.gz",
+        tokenizer=marin_tokenizer,
+        format=ChatLmDatasetFormat(),
+    )
+}
+
+# --- Time-varying mixture weights (unchanged) ---
+data = lm_varying_mixture_data_config(
+    components={**pretrain, **midtrain, **sft},
+    weights_list=[
+        (0, {"dclm": 1.0, "dolmino_math": 0.0, "smoltalk": 0.0}),
+        (PRETRAIN_STEPS, {"dclm": 0.7, "dolmino_math": 0.3, "smoltalk": 0.0}),
+        (PRETRAIN_STEPS + MIDTRAIN_STEPS, {"dclm": 0.0, "dolmino_math": 0.0, "smoltalk": 1.0}),
+    ],
+)
+data = dataclasses.replace(data, tokenizer=marin_tokenizer)
+data = add_validation_sets_to_mixture(data, default_validation_sets(tokenizer=data.tokenizer))
+
+# --- Training step (unchanged: still an ExecutorStep with embedded upstream deps) ---
+training_step = ExecutorStep(
+    name="reference-pipeline",
+    fn=remote(run_grug_base_trial, resources=ResourceConfig.with_tpu("v4-8")),
+    config=GrugBaseLaunchConfig(
+        model=model,
+        data=data,
+        output_path=this_output_path(),
+        run_id="reference-pipeline",
+        resources=ResourceConfig.with_tpu("v4-8"),
+        steps=TOTAL_STEPS,
+        batch_size=256,
+        seed=0,
+        mp="params=float32,compute=bfloat16,output=bfloat16",
+        tracker=WandbConfig(
+            project="marin",
+            tags=["reference", "pipeline"],
+            group="reference-pipeline",
+            name=None,
+        ),
+        optimizer=AdamConfig(
+            learning_rate=3e-3,
+            weight_decay=0.1,
+            warmup=0.05,
+            decay=0.2,
+        ),
+        eval=GrugEvalConfig(
+            steps_per_eval=500,
+        ),
+    ),
+)
+
+if __name__ == "__main__":
+    # @remote → IrisClient.submit, blocks until the training job terminates.
+    # No DAG walk in this entrypoint; the training job materialises its own
+    # tokenize deps once it lands on a TPU in a specific region.
+    training_step.fn(training_step.config)
+```
+
+### And the matching change in `experiments/grug/base/launch.py`
+
+```python
+# Before
+def run_grug_base_trial(config: GrugBaseLaunchConfig) -> None:
+    train(config)
+
+# After
+def run_grug_base_trial(config: GrugBaseLaunchConfig) -> None:
+    Executor().run(upstream_steps(config))   # materialise tokenize deps
+    train(config)
+```
+
+That is the entire training-side change. `Executor().run([])` is a no-op; launchers whose configs reference no `ExecutorStep`s gain the line for free with no behaviour change.
+
+## Errors
+
+No new error types. Existing executor errors (`PreviousTaskFailedError` at `lib/marin/src/marin/execution/executor_step_status.py:50`, fsspec errors, Iris job-failure exceptions) propagate up through the training launcher and into the entrypoint as today.
+
+One behavioural change worth calling out: cross-region GCS dependencies inside a single step still raise (`executor.py:244-246`) — that's pre-existing and unchanged. What changes is that the *transitive* graph is no longer pinned to one region by Iris-side inheritance, so a training job in `us-east5` can run with deps that live in `us-east5` (re-tokenized locally) rather than failing because some upstream produced data in `us-central1`.
+
+## Persisted shapes
+
+No new persisted formats. Existing executor status files (`{output_path}/.executor_status`, `executor_step_status.py:42`) and step output directories continue to be the source of truth. The new pattern relies on the existing distributed lock + status protocol — it doesn't add markers, sentinels, or sidecar files.
+
+The only new on-disk consequence is duplication: if the same upstream step runs in `us-east5` and `us-central1`, two copies of its output exist (one per regional `marin-{region}` bucket). Step IDs are identical; only the prefix differs.
+
+## Out of scope
+
+- `executor_main` deletion (deferred to the final cleanup PR after all 89 callers migrate).
+- Reservation removal (#4631 — parallel work).
+- A non-blocking entrypoint variant (deferred until a real caller wants it).
+- A sweep-concurrency helper (open question in `design.md`; deferred to first sweep migration).
+- Eval-only / dataset-only pipelines (open question — may need a separate analogous wrapper).

--- a/.agents/projects/executor_in_training_job/spec.md
+++ b/.agents/projects/executor_in_training_job/spec.md
@@ -34,7 +34,50 @@ def upstream_steps(obj: Any) -> list[ExecutorStep]:
     """
 ```
 
-The implementation is a port of the private traversal already used in `Executor._build_dependency_graph` (`lib/marin/src/marin/execution/executor.py:418, 462`). Extract that traversal into `dag.py` and have `Executor` call into the public function.
+The implementation is a refactor of the existing `collect_dependencies_and_version` walker (`lib/marin/src/marin/execution/executor.py:1037`, with the `recurse` closure at `:1062`), which already walks dataclasses / lists / dicts and collects `ExecutorStep` instances embedded as values or as `InputName.step` references. `upstream_steps` is the same traversal restricted to the dependency-collection branch (no version-string assembly). Extract the shared walker into `dag.py` and have `collect_dependencies_and_version` delegate its dep-collection responsibility to it.
+
+### `marin.execution.materialize`
+
+Where it lives: same module, `lib/marin/src/marin/execution/dag.py`.
+
+```python
+from typing import TypeVar
+ConfigT = TypeVar("ConfigT")
+
+def materialize(config: ConfigT, *, prefix: str | None = None) -> ConfigT:
+    """Run any ExecutorSteps embedded in `config`, then return a copy of `config`
+    with all InputName / OutputName / VersionedValue / ExecutorStep placeholders
+    replaced by concrete paths.
+
+    Composes three existing pieces:
+      1. `upstream_steps(config)` — find embedded ExecutorSteps.
+      2. `Executor(prefix=...).run(steps)` — submit them as `@remote` sub-jobs and
+         block on completion. Distributed `step_lock` (`step_runner.py:341`) keeps
+         concurrent callers (sweep members, multi-VM TPU tasks) coordinated; only
+         one runs each step, the rest read `STATUS_SUCCESS` and skip.
+      3. `instantiate_config(config, output_path=config.output_path,
+                             output_paths=executor.output_paths, prefix=prefix)`
+         — substitute placeholders using the just-computed paths.
+
+    Args:
+        config: A launcher config dataclass (e.g. `GrugBaseLaunchConfig`). Must
+            expose an `output_path: str` field — `materialize` reads it as the
+            "current step's" output path passed to `instantiate_config`.
+        prefix: Storage prefix for newly-submitted sub-jobs. Defaults to
+            `marin_prefix()` (the worker's regional `gs://marin-{R}` bucket),
+            which is what makes upstream data co-located with training.
+
+    Returns:
+        A copy of `config` with all placeholders substituted to concrete paths.
+        A config containing no placeholders round-trips unchanged (idempotent).
+
+    Raises:
+        Existing executor errors (`PreviousTaskFailedError`, fsspec errors,
+        Iris job-failure exceptions) propagate from sub-step submission.
+    """
+```
+
+This is the function called from training launchers. `Executor.run` and `instantiate_config` remain available as separate primitives for callers that need finer control; `materialize` is the launcher-facing convenience.
 
 ## Entrypoint contract
 
@@ -55,16 +98,18 @@ Each `@remote`-wrapped training launcher (e.g. `run_grug_base_trial` at `experim
 
 ```python
 def run_grug_base_trial(config: GrugBaseLaunchConfig):
-    Executor().run(upstream_steps(config))   # new — materialise deps
+    config = materialize(config)              # new — run upstream steps + substitute placeholders
     train(config)                             # existing body
 ```
 
 Behaviour:
-- `Executor().run(steps)` walks each step's transitive deps, submits any that aren't `STATUS_SUCCESS`, blocks on completion (`step_runner.py:341` distributed lock + heartbeat handles cross-task / cross-process coordination).
-- If `upstream_steps(config)` returns `[]`, `Executor().run([])` is a no-op and training proceeds immediately.
+- `materialize(config)` walks `config` for embedded `ExecutorStep`s, submits each (and its transitive deps) that isn't `STATUS_SUCCESS`, blocks on completion (`step_runner.py:341` distributed lock + heartbeat handles cross-task / cross-process coordination), then returns a copy of `config` with `InputName` / `OutputName` / `VersionedValue` / `ExecutorStep` placeholders substituted with the resulting concrete paths.
+- If `config` contains no placeholders, `materialize(config)` runs no sub-jobs and returns `config` unchanged.
 - Exceptions propagate; if dependency materialisation fails, training is not attempted.
 
-No new decorator, no new wrapper class — the launcher composes the two existing pieces explicitly.
+Why both halves are bundled: the entrypoint no longer calls `executor_main`, so `instantiate_config` (`executor.py:1446`) — the substitution pass that today happens in the entrypoint before `@remote` payloads are pickled — has to happen on the worker. Running upstream steps without substituting their output paths into `config` would leave `train(config)` reading `InputName(step=…)` placeholders as paths and crashing. `materialize` is the single entry point launchers call so that "run deps" and "substitute paths" can't get out of sync.
+
+`Executor.run` and `instantiate_config` remain unchanged and continue to be used by `executor_main` for un-migrated callers.
 
 ## Iris contract change
 
@@ -83,7 +128,8 @@ No new decorator, no new wrapper class — the launcher composes the two existin
 | Piece | Path |
 |---|---|
 | `upstream_steps` (new) | `lib/marin/src/marin/execution/dag.py` |
-| `Executor` (modified to call into `dag.py`) | `lib/marin/src/marin/execution/executor.py` |
+| `materialize` (new) | `lib/marin/src/marin/execution/dag.py` |
+| `collect_dependencies_and_version` (refactored to delegate to `dag.py`) | `lib/marin/src/marin/execution/executor.py:1037` |
 | Iris inheritance removal | `lib/iris/src/iris/cluster/worker/task_attempt.py:696` |
 | Reference pipeline migration (proof-of-concept) | `experiments/references/reference_training_pipeline.py` |
 | Training launcher wrapper (one line per launcher) | `experiments/grug/base/launch.py`, `lib/marin/src/marin/training/...` |
@@ -219,11 +265,11 @@ def run_grug_base_trial(config: GrugBaseLaunchConfig) -> None:
 
 # After
 def run_grug_base_trial(config: GrugBaseLaunchConfig) -> None:
-    Executor().run(upstream_steps(config))   # materialise tokenize deps
+    config = materialize(config)             # run upstream steps + substitute placeholders
     train(config)
 ```
 
-That is the entire training-side change. `Executor().run([])` is a no-op; launchers whose configs reference no `ExecutorStep`s gain the line for free with no behaviour change.
+That is the entire training-side change. A config containing no `ExecutorStep`s round-trips unchanged through `materialize`; launchers whose configs reference no upstream steps gain the line for free with no behaviour change.
 
 ## Errors
 

--- a/.agents/skills/design-doc/SKILL.md
+++ b/.agents/skills/design-doc/SKILL.md
@@ -79,7 +79,7 @@ Read `.agents/projects/design-template.md`, fill in each section. Guidelines:
 - Open Questions section is non-empty — if the design has no unknowns, ask the user what they want feedback on.
 - Don't add a backwards-compat section by default. Mention compat only if the change genuinely needs migration (persisted data, public API consumed externally, etc.).
 
-Show the draft inline, accept edits in conversation. Iterate until the user says the design is settled. **Do not write `spec.md` yet** — it derives from the stable design, and writing it before the design has converged means rewriting it.
+Write the draft to `.agents/projects/<slug>/design.md` from the start (don't keep it as conversation-only snippets) and iterate on the file. Tools like Codex's in-app diff and any reviewer who pulls the branch work on the file; conversation-only drafts are invisible to them. Summarize the diff inline as you go so the user can react quickly without leaving the chat — but the file is the source of truth. Iterate until the user says the design is settled. **Do not write `spec.md` yet** — it derives from the stable design, and writing it before the design has converged means rewriting it.
 
 ## 5. Spec
 
@@ -100,7 +100,7 @@ What does **not** go in `spec.md`: algorithm pseudocode, sequenced implementatio
 
 For genuinely tiny changes — a one-function refactor, a single config flag — `spec.md` may be very short (a single function signature with a docstring is a valid spec). It still exists; the act of writing it forces you to commit to the surface.
 
-Show the spec inline, accept edits, iterate until the user says it's settled.
+Write the spec to `.agents/projects/<slug>/spec.md` from the start, the same way as `design.md`. Summarize the contract decisions inline (function signatures, key tradeoffs) so the user can push back without opening the file — but the file is the source of truth. Iterate on the file until the user says it's settled.
 
 ## 6. Stress-test (senior review)
 

--- a/.agents/skills/design-doc/SKILL.md
+++ b/.agents/skills/design-doc/SKILL.md
@@ -127,25 +127,8 @@ Once both have happened, you're done. Feedback lives on the PR; the user can sta
 
 # Linking conventions
 
-Two failure modes worth heading off — neither is intuitive, and reviewers complain about both:
-
-1. **Code citations in `design.md` / `spec.md` / `research.md` go stale.** Plain `path:line` text (e.g. `executor.py:1037`) is fine while you're drafting locally, but the file evolves and the line number drifts within days. **Anything you expect a reviewer to click should be a commit-pinned permalink:**
-
-   ```
-   https://github.com/marin-community/marin/blob/<sha>/lib/marin/src/marin/execution/executor.py#L1037
-   ```
-
-   Use the design-branch HEAD SHA (`git rev-parse HEAD`) — the citation freezes to a known state, and a reviewer six weeks later still lands on the right line. Run a permalink pass at the end of Phase 4 (Draft) and Phase 5 (Spec) to convert key citations from `path:line` text into permalinks. Plain text refs are OK for incidental mentions; permalinks for anything load-bearing.
-
-2. **Relative paths in the PR description don't render.** A PR body with `[design.md](.agents/projects/<slug>/design.md)` *looks* like a working link in the editor, but GitHub does not resolve relative paths from PR descriptions — the link 404s. **In the PR body, use absolute branch-rooted URLs:**
-
-   ```
-   https://github.com/marin-community/marin/blob/design/<slug>/.agents/projects/<slug>/design.md
-   ```
-
-   Branch (not SHA) is right here: reviewers want the latest version when they click through during review. Inside the docs, the inverse — pin to a SHA so citations are reproducible.
-
-Both rules apply equally to spec.md / research.md / Discord pings and to inline references inside design.md. If a reviewer says "these links don't work but the bottom ones do," it's almost always rule 2.
+- **Code citations inside the docs.** Use SHA-pinned permalinks for anything load-bearing: `https://github.com/marin-community/marin/blob/<sha>/path#Lnnn` (SHA from `git rev-parse main`). Plain `path:line` text drifts within days. Run a permalink pass at the end of Phase 4/5.
+- **Sibling-file links from the PR body.** Use absolute branch-rooted URLs — `https://github.com/marin-community/marin/blob/design/<slug>/.agents/projects/<slug>/design.md`. Relative paths 404 from PR descriptions. Use the branch name (not a SHA) so the link follows future edits to the design.
 
 ---
 

--- a/.agents/skills/design-doc/SKILL.md
+++ b/.agents/skills/design-doc/SKILL.md
@@ -117,7 +117,7 @@ Show the user a brief summary: what you incorporated (in design vs spec), what y
 
 Two actions, can run together. After this, the skill is done.
 
-1. **Commit and PR** via the `pull-request` skill. Branch `design/<slug>`. Single commit adding the `.agents/projects/<slug>/` directory (design.md, research.md, and spec.md — all three are always present). PR title `[Design] <slug>`. PR body is `design.md` itself plus a one-line "Discussion welcome — see Open Questions." footer, with links to the sibling `research.md` and `spec.md` files. Labels `design` and `agent-generated`.
+1. **Commit and PR** via the `pull-request` skill. Branch `design/<slug>`. Single commit adding the `.agents/projects/<slug>/` directory (design.md, research.md, and spec.md — all three are always present). PR title `[Design] <slug>`. **PR body is a short summary (3–6 sentences) of the proposal — the framing paragraph plus the one-line gist of the design — with explicit links to the three sibling files (`design.md`, `spec.md`, `research.md`) and a "Discussion welcome — see Open Questions in `design.md`" footer.** The full 1-pager lives in `design.md` on the branch, not in the PR description; reviewers click through. This keeps the PR body, `design.md`, `spec.md`, and `research.md` as four peer artifacts (one summary + three files) rather than duplicating `design.md` into the PR body. Labels `design` and `agent-generated`.
 
 2. **Discord ping.** Run `python scripts/ops/discord.py --channel code-review` with a 2-line message: PR title + URL + the framing paragraph (or a one-sentence compression of it). Send it; no need to confirm exact text unless the user asked.
 

--- a/.agents/skills/design-doc/SKILL.md
+++ b/.agents/skills/design-doc/SKILL.md
@@ -74,7 +74,7 @@ Bad questions are ones research could have answered. Don't ask things you could 
 Read `.agents/projects/design-template.md`, fill in each section. Guidelines:
 
 - **~1000 words is the target, not a hard limit.** Concision is a virtue; spend words where they buy clarity. If you're at 1200, look for cuts. If 800 is genuinely tighter than 600, ship 800. The goal is "good design" not "short doc" — but a doc that's mostly load-bearing detail is better than one that buries the decision in throat-clearing.
-- Reference real `file.py:line` paths from research, not placeholders.
+- Reference real `file.py:line` paths from research, not placeholders. For load-bearing citations (anything you expect a reviewer to click), convert to commit-pinned permalinks before publishing — see "Linking conventions" below.
 - One small code snippet (10-30 lines) only if prose is genuinely worse. Default to no snippet.
 - Open Questions section is non-empty — if the design has no unknowns, ask the user what they want feedback on.
 - Don't add a backwards-compat section by default. Mention compat only if the change genuinely needs migration (persisted data, public API consumed externally, etc.).
@@ -117,11 +117,35 @@ Show the user a brief summary: what you incorporated (in design vs spec), what y
 
 Two actions, can run together. After this, the skill is done.
 
-1. **Commit and PR** via the `pull-request` skill. Branch `design/<slug>`. Single commit adding the `.agents/projects/<slug>/` directory (design.md, research.md, and spec.md — all three are always present). PR title `[Design] <slug>`. **PR body is a short summary (3–6 sentences) of the proposal — the framing paragraph plus the one-line gist of the design — with explicit links to the three sibling files (`design.md`, `spec.md`, `research.md`) and a "Discussion welcome — see Open Questions in `design.md`" footer.** The full 1-pager lives in `design.md` on the branch, not in the PR description; reviewers click through. This keeps the PR body, `design.md`, `spec.md`, and `research.md` as four peer artifacts (one summary + three files) rather than duplicating `design.md` into the PR body. Labels `design` and `agent-generated`.
+1. **Commit and PR** via the `pull-request` skill. Branch `design/<slug>`. Single commit adding the `.agents/projects/<slug>/` directory (design.md, research.md, and spec.md — all three are always present). PR title `[Design] <slug>`. **PR body is a short summary (3–6 sentences) of the proposal — the framing paragraph plus the one-line gist of the design — with explicit links to the three sibling files (`design.md`, `spec.md`, `research.md`) and a "Discussion welcome — see Open Questions in `design.md`" footer.** Use absolute branch-rooted URLs for those file links (relative paths 404 from PR descriptions — see "Linking conventions"). The full 1-pager lives in `design.md` on the branch, not in the PR description; reviewers click through. This keeps the PR body, `design.md`, `spec.md`, and `research.md` as four peer artifacts (one summary + three files) rather than duplicating `design.md` into the PR body. Labels `design` and `agent-generated`.
 
 2. **Discord ping.** Run `python scripts/ops/discord.py --channel code-review` with a 2-line message: PR title + URL + the framing paragraph (or a one-sentence compression of it). Send it; no need to confirm exact text unless the user asked.
 
 Once both have happened, you're done. Feedback lives on the PR; the user can start implementation in parallel; the 1-pager is a snapshot, not a living doc.
+
+---
+
+# Linking conventions
+
+Two failure modes worth heading off — neither is intuitive, and reviewers complain about both:
+
+1. **Code citations in `design.md` / `spec.md` / `research.md` go stale.** Plain `path:line` text (e.g. `executor.py:1037`) is fine while you're drafting locally, but the file evolves and the line number drifts within days. **Anything you expect a reviewer to click should be a commit-pinned permalink:**
+
+   ```
+   https://github.com/marin-community/marin/blob/<sha>/lib/marin/src/marin/execution/executor.py#L1037
+   ```
+
+   Use the design-branch HEAD SHA (`git rev-parse HEAD`) — the citation freezes to a known state, and a reviewer six weeks later still lands on the right line. Run a permalink pass at the end of Phase 4 (Draft) and Phase 5 (Spec) to convert key citations from `path:line` text into permalinks. Plain text refs are OK for incidental mentions; permalinks for anything load-bearing.
+
+2. **Relative paths in the PR description don't render.** A PR body with `[design.md](.agents/projects/<slug>/design.md)` *looks* like a working link in the editor, but GitHub does not resolve relative paths from PR descriptions — the link 404s. **In the PR body, use absolute branch-rooted URLs:**
+
+   ```
+   https://github.com/marin-community/marin/blob/design/<slug>/.agents/projects/<slug>/design.md
+   ```
+
+   Branch (not SHA) is right here: reviewers want the latest version when they click through during review. Inside the docs, the inverse — pin to a SHA so citations are reproducible.
+
+Both rules apply equally to spec.md / research.md / Discord pings and to inline references inside design.md. If a reviewer says "these links don't work but the bottom ones do," it's almost always rule 2.
 
 ---
 

--- a/.agents/skills/design-doc/SKILL.md
+++ b/.agents/skills/design-doc/SKILL.md
@@ -15,9 +15,11 @@ The template lives at `.agents/projects/design-template.md`. New docs go to a sl
 
 - `design.md` — the 1-pager (always)
 - `research.md` — in-repo refs, prior art, Q&A summary (always — even a short one)
-- `spec.md` — concrete contracts: full proto file, public client API signatures, persisted shapes, error types (only when the design adds new external contracts; skip for internal-only refactors)
+- `spec.md` — concrete contracts: public function/class signatures, file paths, persisted shapes, error types, proto definitions (always — written *after* the design has stabilised so the contracts reflect the final decision)
 
-`spec.md` is the contract layer, not an implementation plan. The full `.proto`, the public class signatures with types, the schema-registry table CREATE, the directory layout — yes. Algorithm pseudocode, sequenced steps, file-by-file plans — no, those belong in the PR description or get deleted in favor of writing the code.
+`spec.md` is the contract layer, not an implementation plan. The full `.proto`, the public class signatures with types, the schema-registry table CREATE, the directory layout, the file paths where each piece will live — yes. Algorithm pseudocode, sequenced steps, file-by-file plans, "how" rather than "what" — no, those belong in the PR description or get deleted in favor of writing the code.
+
+Even an "internal" refactor has a public surface — a function someone else will import, a flag someone else will pass, a config key someone else will set. The spec pins that surface explicitly so reviewers know what they're agreeing to. If you can't write a spec, you don't have a design yet.
 
 ## When to use this skill
 
@@ -31,7 +33,7 @@ If none of those apply, just open the PR — don't manufacture a design doc for 
 
 # Workflow
 
-Five phases. Confirm with the user at natural decision points (after Research, after Draft, before Publish), but don't ask permission to move forward when the next step is obvious.
+Six phases. Confirm with the user at natural decision points (after Research, after Draft, after Spec, before Publish), but don't ask permission to move forward when the next step is obvious.
 
 ## 1. Frame
 
@@ -77,38 +79,45 @@ Read `.agents/projects/design-template.md`, fill in each section. Guidelines:
 - Open Questions section is non-empty — if the design has no unknowns, ask the user what they want feedback on.
 - Don't add a backwards-compat section by default. Mention compat only if the change genuinely needs migration (persisted data, public API consumed externally, etc.).
 
-Show the draft inline, accept edits in conversation. Iterate until the user says ship.
+Show the draft inline, accept edits in conversation. Iterate until the user says the design is settled. **Do not write `spec.md` yet** — it derives from the stable design, and writing it before the design has converged means rewriting it.
 
-### Spec doc (when needed)
+## 5. Spec
 
-If the design adds new external contracts — a new proto, a new public client API, a new persisted format, a new on-disk layout — also produce `.agents/projects/<slug>/spec.md` alongside `design.md`. The spec is the contract layer:
+Once `design.md` is settled, write `.agents/projects/<slug>/spec.md` — the contract layer the design implies. This phase is non-negotiable; every design produces a spec. If you find yourself unable to write one, the design isn't actually concrete enough and you should go back to Draft.
 
-- The full `.proto` file content (or close to it — name every RPC, message, and field).
-- Public client API: full Python class signatures with parameter types and return types. Not implementation bodies.
-- Persisted shapes: schema-registry table CREATE statements, on-disk directory layout, file naming.
-- Error types and what triggers each.
-- File paths where each piece will live (e.g. "proto at `lib/finelog/src/finelog/proto/stats.proto`, client at `lib/finelog/src/finelog/client/stats.py`").
+What goes in `spec.md`:
 
-What does **not** go in spec.md: algorithm pseudocode, sequenced implementation steps, file-by-file plans, "how" rather than "what." Those belong in the PR description that ships the actual code, or get deleted in favor of just writing the code.
+- **Public API**: full Python class/function signatures with parameter types, return types, and a one-paragraph contract docstring per symbol (what it does, edge cases, ordering guarantees). Not implementation bodies.
+- **Proto definitions**: the full `.proto` file content (or close to it — name every RPC, message, and field).
+- **File paths**: where each new piece lives (e.g. "proto at `lib/finelog/src/finelog/proto/stats.proto`, client at `lib/finelog/src/finelog/client/stats.py`"). A summary table at the bottom of the spec is good.
+- **Persisted shapes**: schema-registry table `CREATE` statements, on-disk directory layout, file naming conventions, JSON / proto envelope formats.
+- **Errors**: every new error type with the exact condition that triggers it, plus any behavioural changes in existing error paths.
+- **Out of scope**: an explicit list of related changes the design *doesn't* commit to (e.g. "deletion of `executor_main` deferred to follow-up PR"). Reviewers use this to know what to *not* push back on.
 
-Spec.md has no length cap — it should be exactly as long as the contracts. Reviewers should be able to read `design.md` for the why, then `spec.md` to check "would I actually build this exact API?" Skip spec.md for internal-only refactors where there are no new contracts to pin down.
+What does **not** go in `spec.md`: algorithm pseudocode, sequenced implementation steps, file-by-file rollout plans, "how" rather than "what." Those belong in the PR description for the implementation, or get deleted in favor of just writing the code.
 
-## 5. Stress-test (senior review)
+`spec.md` has no length cap — it should be exactly as long as the contracts. Reviewers should be able to read `design.md` for the why, then `spec.md` to check "would I actually build this exact API?"
 
-Before publishing, hand the draft to a senior reviewer subagent (`Plan` agent — software architect) with a prompt like: *"Review this design doc thoroughly. Identify underspecified areas, weak motivation, missing tradeoffs, places where two reasonable engineers would implement different things, and concrete suggestions for tightening the proposal."*
+For genuinely tiny changes — a one-function refactor, a single config flag — `spec.md` may be very short (a single function signature with a docstring is a valid spec). It still exists; the act of writing it forces you to commit to the surface.
+
+Show the spec inline, accept edits, iterate until the user says it's settled.
+
+## 6. Stress-test (senior review)
+
+Before publishing, hand both `design.md` and `spec.md` to a senior reviewer subagent (`Plan` agent — software architect). Reviewer prompt: *"Review this design doc and its spec. Identify underspecified areas, weak motivation, missing tradeoffs, places where two reasonable engineers would implement different things, mismatches between the design's intent and the spec's contracts, and concrete suggestions for tightening the proposal."*
 
 When the reviewer returns:
 
-- **Incorporate obvious improvements directly into the draft.** Tightening prose, fixing a confused tradeoff, adding a missing file:line reference, moving a clear ambiguity into Open Questions — just do it.
+- **Incorporate obvious improvements directly into both files.** Tightening prose, fixing a confused tradeoff, adding a missing file:line reference, sharpening a function signature in the spec, moving a clear ambiguity into Open Questions — just do it.
 - **Query the user only on ambiguous or load-bearing decisions** — places where the reviewer surfaced a real tradeoff and you can't tell which way the user wants to go.
 
-Show the user a brief summary: what you incorporated, what you're punting on, what needs their call.
+Show the user a brief summary: what you incorporated (in design vs spec), what you're punting on, what needs their call.
 
-## 6. Publish
+## 7. Publish
 
 Two actions, can run together. After this, the skill is done.
 
-1. **Commit and PR** via the `pull-request` skill. Branch `design/<slug>`. Single commit adding the `.agents/projects/<slug>/` directory (design.md, research.md, and spec.md if produced). PR title `[Design] <slug>`. PR body is `design.md` itself plus a one-line "Discussion welcome — see Open Questions." footer, with links to the sibling `research.md` and `spec.md` files. Labels `design` and `agent-generated`.
+1. **Commit and PR** via the `pull-request` skill. Branch `design/<slug>`. Single commit adding the `.agents/projects/<slug>/` directory (design.md, research.md, and spec.md — all three are always present). PR title `[Design] <slug>`. PR body is `design.md` itself plus a one-line "Discussion welcome — see Open Questions." footer, with links to the sibling `research.md` and `spec.md` files. Labels `design` and `agent-generated`.
 
 2. **Discord ping.** Run `python scripts/ops/discord.py --channel code-review` with a 2-line message: PR title + URL + the framing paragraph (or a one-sentence compression of it). Send it; no need to confirm exact text unless the user asked.
 
@@ -120,5 +129,5 @@ Once both have happened, you're done. Feedback lives on the PR; the user can sta
 
 - **The template and canonical worked example live in `.agents/projects/design-template.md`.** Read it before drafting. Don't use other docs in `.agents/projects/` as style references — they predate this skill and are inconsistent.
 - `agent-generated` and `design` labels: create the `design` label if it doesn't exist (`gh label create design --description "Design doc / 1-pager for review"`).
-- If the user wants to skip a phase ("just write it, I know what I want"), honor that — but still produce the Open Questions section and still run the Stress-test in Phase 5. Those are the cheapest, highest-value steps.
+- If the user wants to skip a phase ("just write it, I know what I want"), honor that — but still produce the Open Questions section in `design.md`, still write `spec.md` (Phase 5), and still run the Stress-test (Phase 6). Those are the cheapest, highest-value steps and the spec is what makes review meaningful.
 - Implementation is out of scope. After Publish, the skill is done — hand off to `fix-issue` or `pull-request` for the work itself only if the user asks.


### PR DESCRIPTION
# Run the executor inside the training job

Today an executor entrypoint walks the full DAG (tokenize → train) inside one Iris job and pins every downstream step to whichever GCP region the entrypoint happened to land in — when training is preempted into a different region, this either crashes or silently incurs cross-region egress on tens to hundreds of GB of tokenized data.

This proposal inverts the launch model: the entrypoint becomes a region-agnostic `IrisClient.submit(...)` of the training step, and the training function calls `materialize(config)` inside its body to run upstream `ExecutorStep`s and substitute placeholder paths once it knows what region it's running in. Region pinning becomes a property of training, not of the entrypoint. Iris's implicit `IRIS_WORKER_REGION` inheritance is removed; region pinning becomes opt-in via explicit `regions=[...]` or path-based inference.

This PR is the design + spec only — framework changes and the reference-pipeline migration ship in a follow-up; the remaining 88 callers of `executor_main` migrate in batched PRs after that.

**Read the full design and contracts in the branch:**

- 📄 [design.md](https://github.com/marin-community/marin/blob/design/executor_in_training_job/.agents/projects/executor_in_training_job/design.md) — the 1-pager: motivation, design, costs/risks, testing, open questions
- 📐 [spec.md](https://github.com/marin-community/marin/blob/design/executor_in_training_job/.agents/projects/executor_in_training_job/spec.md) — concrete contracts: `upstream_steps` and `materialize` signatures, file paths, entrypoint/launcher/Iris contracts, persisted shapes
- 🔍 [research.md](https://github.com/marin-community/marin/blob/design/executor_in_training_job/.agents/projects/executor_in_training_job/research.md) — in-repo refs and prior-art notes that shaped the design

Discussion welcome — see Open Questions in `design.md`.