### PR TITLE
[RL] Add vLLM engine seed for inference

### DIFF
--- a/lib/marin/src/marin/rl/environments/inference_ctx/inflight/worker.py
+++ b/lib/marin/src/marin/rl/environments/inference_ctx/inflight/worker.py
@@ -185,6 +185,7 @@ class SyncVLLMWrapper:
         load_format: str = "auto",
         enforce_eager: bool = True,
         kv_cache_metrics: bool = False,
+        seed: int = 0,
     ):
         if AsyncEngineArgs is None:
             raise RuntimeError("vLLM async engine is not available. Please install vLLM v1 with: pip install vllm")
@@ -193,16 +194,18 @@ class SyncVLLMWrapper:
         self.bridge.start()
 
         # Initialize async engine from sync code
-        engine_args = AsyncEngineArgs(
-            model=model,
-            max_model_len=max_model_len,
-            worker_extension_cls="marin.rl.environments.inference_ctx.inflight.worker.WorkerExtension",
-            tensor_parallel_size=tensor_parallel_size,
-            gpu_memory_utilization=gpu_memory_utilization,
-            load_format=load_format,
-            enforce_eager=enforce_eager,
-            kv_cache_metrics=kv_cache_metrics,
-        )
+        engine_kwargs = {
+            "model": model,
+            "max_model_len": max_model_len,
+            "worker_extension_cls": "marin.rl.environments.inference_ctx.inflight.worker.WorkerExtension",
+            "tensor_parallel_size": tensor_parallel_size,
+            "gpu_memory_utilization": gpu_memory_utilization,
+            "load_format": load_format,
+            "enforce_eager": enforce_eager,
+            "kv_cache_metrics": kv_cache_metrics,
+            "seed": seed,
+        }
+        engine_args = AsyncEngineArgs(**engine_kwargs)
 
         self.engine = self.bridge.run(self._init_engine(engine_args))
 

--- a/lib/marin/src/marin/rl/environments/inference_ctx/vllm.py
+++ b/lib/marin/src/marin/rl/environments/inference_ctx/vllm.py
@@ -86,6 +86,8 @@ class vLLMInferenceContextConfig:
     tensor_parallel_size: int
     gpu_memory_utilization: float
     sampling_params: VLLMSamplingConfig
+    seed: int = 0
+    """Engine-level vLLM seed. TPU vLLM does not support per-request sampling seeds."""
     canonical_model_name: str | None = None
     mode: InferenceMode = InferenceMode.SYNC
     load_format: str = "auto"
@@ -184,15 +186,18 @@ class vLLMInferenceContext(BaseInferenceContext):
         else:
             raise ValueError(f"Invalid inference mode: {inference_config.mode}")
 
-        return llm_engine_cls(
-            model=inference_config.model_name,
-            max_model_len=inference_config.max_model_len,
-            tensor_parallel_size=inference_config.tensor_parallel_size,
-            gpu_memory_utilization=inference_config.gpu_memory_utilization,
-            load_format=inference_config.load_format,
-            enforce_eager=inference_config.enforce_eager,
-            kv_cache_metrics=inference_config.kv_cache_metrics,
-        )
+        engine_kwargs = {
+            "model": inference_config.model_name,
+            "max_model_len": inference_config.max_model_len,
+            "tensor_parallel_size": inference_config.tensor_parallel_size,
+            "gpu_memory_utilization": inference_config.gpu_memory_utilization,
+            "load_format": inference_config.load_format,
+            "enforce_eager": inference_config.enforce_eager,
+            "kv_cache_metrics": inference_config.kv_cache_metrics,
+            "seed": inference_config.seed,
+        }
+
+        return llm_engine_cls(**engine_kwargs)
 
     def tokenize_prompt(self, prompt: str, choice: Choice | None = None, system_prompt: str | None = None) -> np.ndarray:
         """Tokenize the prompt with the choice's prompt token IDs.

--- a/tests/rl/test_inference_ctx.py
+++ b/tests/rl/test_inference_ctx.py
@@ -303,6 +303,31 @@ def test_vllm_sync_engine_receives_kv_cache_metrics_flag(monkeypatch):
     vLLMInferenceContext._get_llm_engine(config)
 
     assert calls["kv_cache_metrics"] is True
+    assert calls["seed"] == 0
+
+
+def test_vllm_sync_engine_receives_engine_seed(monkeypatch):
+    calls = {}
+
+    class _FakeLLM:
+        def __init__(self, **kwargs):
+            calls.update(kwargs)
+
+    monkeypatch.setattr(vLLMInferenceContext, "_patch_tpu_inference_registry", staticmethod(lambda: None))
+    monkeypatch.setattr("marin.rl.environments.inference_ctx.vllm.LLM", _FakeLLM)
+
+    config = vLLMInferenceContextConfig(
+        model_name="test-model",
+        max_model_len=1024,
+        tensor_parallel_size=2,
+        gpu_memory_utilization=0.9,
+        sampling_params=VLLMSamplingConfig(),
+        seed=1234,
+    )
+
+    vLLMInferenceContext._get_llm_engine(config)
+
+    assert calls["seed"] == 1234
 
 
 def test_vllm_async_engine_receives_kv_cache_metrics_flag(monkeypatch):
@@ -328,6 +353,32 @@ def test_vllm_async_engine_receives_kv_cache_metrics_flag(monkeypatch):
     vLLMInferenceContext._get_llm_engine(config)
 
     assert calls["kv_cache_metrics"] is True
+    assert calls["seed"] == 0
+
+
+def test_vllm_async_engine_receives_engine_seed(monkeypatch):
+    calls = {}
+
+    class _FakeSyncVLLMWrapper:
+        def __init__(self, **kwargs):
+            calls.update(kwargs)
+
+    monkeypatch.setattr(vLLMInferenceContext, "_patch_tpu_inference_registry", staticmethod(lambda: None))
+    monkeypatch.setattr("marin.rl.environments.inference_ctx.vllm.SyncVLLMWrapper", _FakeSyncVLLMWrapper)
+
+    config = vLLMInferenceContextConfig(
+        model_name="test-model",
+        max_model_len=1024,
+        tensor_parallel_size=2,
+        gpu_memory_utilization=0.9,
+        sampling_params=VLLMSamplingConfig(),
+        mode=InferenceMode.ASYNC,
+        seed=1234,
+    )
+
+    vLLMInferenceContext._get_llm_engine(config)
+
+    assert calls["seed"] == 1234
 
 
 def test_worker_extension_uses_public_sync_weights():


### PR DESCRIPTION
Add an explicit engine-level seed to the RL vLLM inference config and pass it through both sync and async vLLM engine construction. The default is now a concrete seed of 0, which keeps TPU inference seeding at the engine level rather than adding unsupported per-request SamplingParams seeds.

Fixes #5255