### PR TITLE
[levanter] Remove era shuffle

### DIFF
--- a/lib/levanter/config/data/dclm_gpt_neo.yaml
+++ b/lib/levanter/config/data/dclm_gpt_neo.yaml
@@ -3,7 +3,10 @@ tokenizer: EleutherAI/gpt-neox-20b
 cache_options:
   batch_size: 256
 stop_strategy: restart
-shuffle: 100000
+shuffle:
+  io_block_size: 256
+  window_blocks: 512
+  perm_type: feistel
 train_weights:
   dclm: 1.0
   paloma/4chan: 0.0

--- a/lib/levanter/config/llama2_small_fast_mix.yaml
+++ b/lib/levanter/config/llama2_small_fast_mix.yaml
@@ -1,7 +1,10 @@
 data:
   tokenizer: NousResearch/Llama-2-7b-hf
   cache_dir: gs://levanter-data/new-tokenized/pile_mix/
-  shuffle: 10000
+  shuffle:
+    io_block_size: 256
+    window_blocks: 512
+    perm_type: feistel
   train_weights:
     pile_cc: 0.1811
     pubmed_central: 0.144

--- a/lib/levanter/docs/design/Data-Loader-Design.md
+++ b/lib/levanter/docs/design/Data-Loader-Design.md
@@ -116,21 +116,12 @@ Along with the cache, we introduce interfaces and classes for working with the c
 - [levanter.data.text.TokenSeqDataset][]: This is an async dataset that does the chunking of documents into examples. It
   takes a cache and a `max_seq_len` and returns examples of length `max_seq_len`.
 - [levanter.data.PermutationDataset][]: This is a dataset that permutes the indices of another dataset. It is used for shuffling.
-- [levanter.data.EraShufflingDataset][]: This is a dataset that emulates the behavior of a shuffle buffer, while
-  still support random access. It is used for shuffling while still building the cache.
 - [levanter.data.MixtureDataset][]: This is a dataset that mixes together multiple datasets with different weights.
 
 ### [levanter.data.PermutationDataset][]
 
 The PermutationDataset is a dataset that permutes the indices of another dataset. It is backed by a pseudo-random
 permutation (PRP). PRPs give you random access to a permutation with O(1) time and memory.
-
-### [levanter.data.EraShufflingDataset][]
-
-The EraShufflingDataset is a dataset that emulates the behavior of a shuffle buffer, while still supporting random access.
-It works by defining an "era" length, which is the number of samples that are shuffled together. After an era is exhausted,
-the dataset shuffles the next era.
-
 
 ### [levanter.data.MixtureDataset][]
 

--- a/lib/levanter/docs/guides/Training-Data-Guide.md
+++ b/lib/levanter/docs/guides/Training-Data-Guide.md
@@ -117,13 +117,12 @@ https://github.com/huggingface/transformers/blob/main/src/transformers/tokenizat
 
 - `true`: full permutation shuffle (best mixing, highest random-access IO pressure)
 - `false`: no shuffle
-- positive integer: era shuffle with that era length
 - object: hierarchical block shuffle (`BlockShuffleConfig`)
 - omitted: hierarchical block shuffle with `io_block_size: 256`, `window_blocks: 512`, and `perm_type: feistel`
 
 ```yaml
 data:
-  # Default block shuffle
+  # Hierarchical block shuffle (default)
   shuffle:
     io_block_size: 256
     window_blocks: 512
@@ -136,25 +135,8 @@ data:
   shuffle: true
 ```
 
-```yaml
-data:
-  # Era shuffle with 131072-example eras
-  shuffle: 131072
-  permutation_type: feistel
-```
-
-```yaml
-data:
-  # Hierarchical block shuffle
-  shuffle:
-    io_block_size: 256
-    window_blocks: 512
-    perm_type: feistel
-```
-
-Block shuffle is designed for TensorStore-backed training caches: it preserves more IO locality than full shuffle while
-still mixing globally better than era shuffle. Internally it shuffles full blocks, then shuffles examples within a
-window of blocks.
+Block shuffle is designed for TensorStore-backed training caches: it preserves more IO locality than full shuffle.
+Internally it shuffles full blocks, then shuffles examples within a window of blocks.
 
 Practical defaults:
 

--- a/lib/levanter/src/levanter/data/__init__.py
+++ b/lib/levanter/src/levanter/data/__init__.py
@@ -5,7 +5,7 @@ from ._preprocessor import BatchProcessor
 from .dataset import AsyncDataset, ListAsyncDataset, MappedAsyncDataset, SyncDataset
 from .loader import DataLoader
 from .mixture import ConcatDataset, MixtureDataset, StopStrategy
-from .permutation import BlockShufflingDataset, EraShufflingDataset, PermutationDataset
+from .permutation import BlockShufflingDataset, PermutationDataset
 from .sharded_datasource import ShardedDataSource, datasource_from_hf, datasource_from_json, datasource_from_jsonl
 from .utils import batched
 
@@ -16,7 +16,6 @@ __all__ = [
     "BlockShufflingDataset",
     "DataLoader",
     "ConcatDataset",
-    "EraShufflingDataset",
     "ListAsyncDataset",
     "MappedAsyncDataset",
     "MixtureDataset",

--- a/lib/levanter/src/levanter/data/audio.py
+++ b/lib/levanter/src/levanter/data/audio.py
@@ -448,9 +448,8 @@ class AudioMixtureDatasetConfig(AudioTaskConfig):
     """ configuration of each dataset source (urls, hf dataset id, etc.) """
     train_weights: Dict[str, float] = field(default_factory=dict)
     """ weights for each dataset source. They will be normalized to sum to 1. """
-    shuffle: bool | int = False
-    """whether to shuffle the dataset. True means shuffle the whole dataset, False means don't shuffle.
-    If you want to shuffle in eras, set this to the era length"""
+    shuffle: bool = False
+    """whether to shuffle the dataset. True means shuffle the whole dataset, False means don't shuffle."""
     stop_strategy: str = field(default=StopStrategy.RESTART_STRATEGY)
     mixture_block_size: int = 2048
     """ block size for the mixture dataset."""
@@ -483,8 +482,6 @@ class AudioMixtureDatasetConfig(AudioTaskConfig):
         def shuffle_ds(ds, key):
             if self.shuffle is True:
                 ds = ds.shuffle(key)
-            elif isinstance(self.shuffle, int):
-                ds = ds.era_shuffle(self.shuffle, key=key)
 
             return ds
 

--- a/lib/levanter/src/levanter/data/dataset.py
+++ b/lib/levanter/src/levanter/data/dataset.py
@@ -102,11 +102,6 @@ class AsyncDataset(DatasetBase[T_co]):
 
         return permutation.PermutationDataset(self, key, perm_type=perm_type)
 
-    def era_shuffle(self, era_length: int, key: PRNGKeyArray, *, perm_type: PermType = "feistel"):
-        import levanter.data.permutation as permutation
-
-        return permutation.EraShufflingDataset(self, era_length, key=key, perm_type=perm_type)
-
     def block_shuffle(
         self,
         *,

--- a/lib/levanter/src/levanter/data/permutation.py
+++ b/lib/levanter/src/levanter/data/permutation.py
@@ -6,7 +6,6 @@ from functools import lru_cache
 from typing import Optional, Sequence
 
 import jax.random
-from async_lru import alru_cache
 from jaxtyping import PRNGKeyArray
 
 from levanter.data._prp import PermType, Permutation
@@ -58,90 +57,6 @@ class PermutationDataset(AsyncDataset[T_co]):
         if self._permutation is None:
             self._permutation = Permutation.make(self._perm_type, await self.async_len(), self.key)
         return self._permutation
-
-
-class EraShufflingDataset(AsyncDataset[T_co]):
-    r"""
-    A dataset that shuffles the data in "eras" of fixed length. Era shuffling is somewhere in between a shuffle buffer
-    and a permutation. It's a "local" permutation where pi(i) \in [ (i//L) * L, (i//L + 1) * L ) for some era length L.
-
-    The advantages of era shuffling are:
-    - It's stateless, so resumes are easy
-    - Like shuffle buffers, it's a decent compromise between full shuffling and no shuffling
-    - Like a shuffle buffer, it's streaming: we don't need to know the length of the data in advance
-
-    The disadvantages are:
-    - It's not as good as full shuffling
-    - It distributes less well than a shuffle buffer does. It's more like a "local" shuffle buffer.
-    - You have to wait for an era to fill before you can start shuffling it. With prefetching, this is less of an issue.
-
-
-    # TODO: given the way tokenization works (where it runs way ahead of training), we can probably increase the era
-    length # over time. This would be a nice feature to have.
-    """
-
-    def __init__(
-        self, dataset: AsyncDataset[T_co], era_length: int, *, key: jax.random.PRNGKey, perm_type: PermType = "feistel"
-    ):
-        self.dataset = dataset
-        self.era_length = era_length
-
-        # Force key to CPU (like MixtureDataset does) to prevent JAX device placement errors
-        with local_cpu_mesh():
-            if isinstance(key, int):
-                key = jax.random.PRNGKey(key)
-            else:
-                key = _key_on_local_cpu(key)
-
-        self.key = key
-        self._perm_type = perm_type
-
-        @alru_cache(maxsize=4)  # we're mostly going to be going sequentially
-        async def gen_era_permutation(era: int) -> Permutation:
-            # TODO: support epochs
-            if self.dataset.is_finite():
-                # edge case: final era may be shorter than era_length
-                dataset_len = await self.dataset.async_len()
-                remaining = dataset_len - era * self.era_length
-                if remaining <= 0:
-                    raise IndexError(
-                        f"Era {era} is out of bounds for dataset length {dataset_len} with era length {self.era_length}"
-                    )
-                era_length_val = min(self.era_length, remaining)
-            else:
-                era_length_val = self.era_length
-
-            mix_key = _fold_in_on_local_cpu(key, era)
-            return Permutation.make(self._perm_type, era_length_val, mix_key)
-
-        self.gen_era_permutation = gen_era_permutation
-
-    async def _get_index(self, idx: int) -> int:
-        if idx < 0:
-            raise ValueError("Negative indices are not supported")
-        era = idx // self.era_length
-        permutation = await self.gen_era_permutation(era)
-        out = permutation(idx - era * self.era_length) + era * self.era_length
-
-        return out
-
-    async def async_len(self) -> int:
-        return await self.dataset.async_len()
-
-    def is_finite(self) -> bool:
-        return self.dataset.is_finite()
-
-    async def getitem_async(self, index: int) -> T_co:
-        return await self.dataset.getitem_async(await self._get_index(index))
-
-    async def get_batch(self, indices: Sequence[int]) -> Sequence[T_co]:
-        return await self.dataset.get_batch([await self._get_index(i) for i in indices])
-
-    def __repr__(self):
-        return f"EraShufflingDataset({repr(self.dataset)}, era_length={self.era_length})"
-
-    def __str__(self):
-        return f"EraShufflingDataset({str(self.dataset)})"
 
 
 @dataclass(frozen=True)

--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -576,17 +576,16 @@ class LmDataConfig:
 
     chat_template: str | None = None  # If set, use this template for chat datasets. Otherwise, use the tokenizer's.
 
-    shuffle: bool | int | BlockShuffleConfig = DEFAULT_LM_DATA_SHUFFLE
+    shuffle: bool | BlockShuffleConfig = DEFAULT_LM_DATA_SHUFFLE
     """Shuffle policy.
 
     - `True`: full permutation shuffle
     - `False`: no shuffle
-    - positive `int`: era shuffle with this era length
     - `BlockShuffleConfig`: hierarchical block shuffle
     """
     permutation_type: Literal["feistel", "linear"] = "feistel"
     """
-    Type of permutation to use for full and era shuffle.
+    Type of permutation to use for full shuffle.
     """
 
     block_cross_document_attention: bool = True
@@ -748,8 +747,6 @@ class LmDataConfig:
                 )
             elif shuffle_cfg is True:
                 ds = ds.shuffle(k, perm_type=perm_type)
-            elif isinstance(shuffle_cfg, int) and not isinstance(shuffle_cfg, bool) and shuffle_cfg > 0:
-                ds = ds.era_shuffle(shuffle_cfg, key=k, perm_type=perm_type)
             return ds
 
         if shuffle_cfg:

--- a/lib/levanter/src/levanter/main/train_dpo.py
+++ b/lib/levanter/src/levanter/main/train_dpo.py
@@ -101,7 +101,7 @@ def _get_training_components(config: PreferenceLmDataConfig) -> dict[str, Any]:
 
 def _shuffle_dpo_dataset(
     dataset: AsyncDataset[DpoExample],
-    shuffle: bool | int | BlockShuffleConfig,
+    shuffle: bool | BlockShuffleConfig,
     *,
     key: jrandom.PRNGKey,
     perm_type: Literal["feistel", "linear"],
@@ -115,8 +115,6 @@ def _shuffle_dpo_dataset(
         )
     if shuffle is True:
         return dataset.shuffle(key, perm_type=perm_type)
-    if isinstance(shuffle, int) and not isinstance(shuffle, bool) and shuffle > 0:
-        return dataset.era_shuffle(shuffle, key=key, perm_type=perm_type)
     return dataset
 
 

--- a/lib/levanter/tests/test_newdataset.py
+++ b/lib/levanter/tests/test_newdataset.py
@@ -4,7 +4,7 @@
 import jax.random
 import pytest
 
-from levanter.data import BlockShufflingDataset, EraShufflingDataset, PermutationDataset
+from levanter.data import BlockShufflingDataset, PermutationDataset
 from levanter.data.dataset import ListAsyncDataset
 
 
@@ -42,50 +42,6 @@ async def test_permutation_dataset_is_at_least_sometimes_permuted():
             ok += 1
 
     assert ok > 5, "Permutation dataset is not actually permuting"
-
-
-@pytest.mark.asyncio
-async def test_era_shuffling_dataset_returns_correct_length():
-    data = list(range(100))
-    dataset = ListAsyncDataset(data)
-    era_length = 10
-    key = jax.random.PRNGKey(0)
-    shuffling_dataset = EraShufflingDataset(dataset, era_length, key=key)
-    assert shuffling_dataset.is_finite()
-    assert await shuffling_dataset.async_len() == 100
-
-
-@pytest.mark.asyncio
-async def test_era_shuffling_dataset_get_batch_returns_shuffled_batch():
-    data = list(range(20))
-    dataset = ListAsyncDataset(data)
-    era_length = 5
-    key = jax.random.PRNGKey(0)
-    shuffling_dataset = EraShufflingDataset(dataset, era_length, key=key)
-    batch_indices = [0, 1, 2, 3, 4]
-    batch = await shuffling_dataset.get_batch(batch_indices)
-    assert set(batch) == set([0, 1, 2, 3, 4])  # Ensures all elements are from the first era but does not assume order
-    assert batch != [0, 1, 2, 3, 4]  # Ensures the batch is shuffled
-
-
-@pytest.mark.asyncio
-async def test_era_shuffling_returns_full_finite_length():
-    data = list(range(16))
-    dataset = ListAsyncDataset(data)
-    era_length = 5
-    key = jax.random.PRNGKey(0)
-    shuffling_dataset = EraShufflingDataset(dataset, era_length, key=key)
-    assert await shuffling_dataset.async_len() == 16
-    batch = await shuffling_dataset.get_batch(list(range(16)))
-    assert set(batch) == set(range(16))
-
-
-@pytest.mark.asyncio
-async def test_era_shuffling_raises_on_out_of_bounds_index():
-    dataset = ListAsyncDataset(list(range(16)))
-    shuffling_dataset = EraShufflingDataset(dataset, era_length=5, key=jax.random.PRNGKey(0))
-    with pytest.raises(IndexError, match="out of bounds"):
-        await shuffling_dataset.getitem_async(16)
 
 
 @pytest.mark.asyncio

--- a/lib/marin/src/marin/processing/tokenize/data_configs.py
+++ b/lib/marin/src/marin/processing/tokenize/data_configs.py
@@ -55,7 +55,7 @@ def lm_data_config(
     training_set: TokenizerStep | InputName,
     *,
     validation_sets: dict[str, TokenizerStep] | None = None,
-    shuffle: bool | int | BlockShuffleConfig = DEFAULT_LM_DATA_SHUFFLE,
+    shuffle: bool | BlockShuffleConfig = DEFAULT_LM_DATA_SHUFFLE,
     max_train_batches: dict[str, int] | None = None,
     num_validation_sequences: dict[str, int] | None = None,
     block_cross_document_attention: bool = True,
@@ -69,8 +69,7 @@ def lm_data_config(
         training_set: The training set to use
         validation_sets: A sequence of validation sets to use
         shuffle: Shuffle policy. Defaults to hierarchical block shuffle.
-            `True` = full shuffle, positive `int` = era shuffle,
-            `BlockShuffleConfig` = hierarchical block shuffle.
+            `True` = full shuffle, `BlockShuffleConfig` = hierarchical block shuffle.
         max_train_batches: Maximum number of batches to use for the training set per dataset.
         num_validation_sequences: Number of validation sequences to take from the training set per dataset.
         block_cross_document_attention: Whether to mask attention across document boundaries.
@@ -102,7 +101,7 @@ def lm_mixture_data_config(
     components: dict[str, TokenizerStep | TokenizeConfig],
     weights: dict[str, float],
     *,
-    shuffle: bool | int | BlockShuffleConfig = DEFAULT_LM_DATA_SHUFFLE,
+    shuffle: bool | BlockShuffleConfig = DEFAULT_LM_DATA_SHUFFLE,
     missing_weights_are_validation: bool = True,
     include_raw_paths: bool = True,
     max_train_batches: dict[str, int] | None = None,
@@ -117,8 +116,8 @@ def lm_mixture_data_config(
     Args:
         components: dict from names of datasets to the steps that produced them.
         weights: dict from names of datasets to their weights.
-        shuffle: shuffling policy. Defaults to hierarchical block shuffle. int means era shuffling (~shuffle buffer);
-            `BlockShuffleConfig` enables hierarchical block shuffling.
+        shuffle: shuffling policy. Defaults to hierarchical block shuffle.
+            `True` enables a full permutation shuffle; `BlockShuffleConfig` enables hierarchical block shuffling.
         missing_weights_are_validation: whether to pad out missing weights with 0's, indicating validation-only sets
         include_raw_paths: whether to include raw paths in the dataset config. This is mostly for logging purposes.
         max_train_batches: Maximum number of batches to use for the training set per dataset.
@@ -197,7 +196,7 @@ def lm_varying_mixture_data_config(
     components: dict[str, TokenizerStep],
     weights_list: list[tuple[int, dict[str, float]]],
     *,
-    shuffle: bool | int | BlockShuffleConfig = DEFAULT_LM_DATA_SHUFFLE,
+    shuffle: bool | BlockShuffleConfig = DEFAULT_LM_DATA_SHUFFLE,
     missing_weights_are_validation: bool = True,
     include_raw_paths: bool = True,
     mixture_block_size: int | None = None,
@@ -214,8 +213,8 @@ def lm_varying_mixture_data_config(
             weights_dict maps dataset names to their weights.
             The weights will change at each start_seq_index. start_seq_index's must be sorted in ascending order.
             Note that start_seq_index should be the index of the sequence (not batch) where the transition should occur.
-        shuffle: shuffling policy. Defaults to hierarchical block shuffle. int means era shuffling (~shuffle buffer);
-            `BlockShuffleConfig` enables hierarchical block shuffling.
+        shuffle: shuffling policy. Defaults to hierarchical block shuffle.
+            `True` enables a full permutation shuffle; `BlockShuffleConfig` enables hierarchical block shuffling.
         missing_weights_are_validation: whether to pad out missing weights with 0's, indicating validation-only sets
         include_raw_paths: whether to include raw paths in the dataset config. This is mostly for logging purposes.
         mixture_block_size: The block size to use for the mixture.


### PR DESCRIPTION
Remove era shuffle (EraShufflingDataset, AsyncDataset.era_shuffle, and the int branch in LM/DPO/audio dispatchers) now that hierarchical block shuffle is the default. Era shuffle had zero cross-era mixing within an epoch, silently degrading training on temporally-segmented caches. Migrates the two checked-in YAMLs that used era shuffle to BlockShuffleConfig.

Fixes #5257
Follows #5246