### PR TITLE
iris: wire log pusher before adopting containers

### DIFF
--- a/lib/iris/src/iris/cluster/worker/worker.py
+++ b/lib/iris/src/iris/cluster/worker/worker.py
@@ -191,13 +191,15 @@ class Worker:
 
         self._host_metrics = HostMetricsCollector(disk_path=str(self._cache_dir))
 
-        # LogPusher and RemoteLogHandler are created before registration so
-        # pre-register failures (container bring-up, disk/health probes,
-        # registration rejection) leave remote logs. Attachment relies on
-        # ``self._worker_id`` having been resolved locally (IRIS_WORKER_ID,
-        # slice_id + TPU index, or GCE instance name); the rare case where
-        # the controller assigns the id is handled by re-attaching post-
-        # register.
+        # LogPusher and RemoteLogHandler are created in start() before container
+        # adoption and registration. Building before adoption ensures adopted
+        # attempts capture a live pusher (regression #5261). Building before
+        # registration ensures pre-register failures (container bring-up,
+        # disk/health probes, registration rejection) leave remote logs.
+        # Attachment relies on ``self._worker_id`` having been resolved locally
+        # (IRIS_WORKER_ID, slice_id + TPU index, or GCE instance name); the rare
+        # case where the controller assigns the id is handled by re-attaching
+        # post-register.
         self._log_pusher: LogPusher | None = None
         self._log_handler: RemoteLogHandler | None = None
 
@@ -226,6 +228,20 @@ class Worker:
         self._heartbeat_deadline = Deadline.from_seconds(float("inf"))
 
     def start(self) -> None:
+        # Build the LogPusher *before* adopting containers so adopted attempts
+        # capture a live pusher rather than a permanent ``None`` (regression #5261).
+        # The pusher only depends on auth + the resolver callback, neither of
+        # which need the uvicorn server or controller client to exist yet.
+        interceptors: tuple[AuthTokenInjector, ...] = ()
+        if self._config.controller_address and self._config.auth_token:
+            interceptors = (AuthTokenInjector(StaticTokenProvider(self._config.auth_token)),)
+        if self._config.controller_address:
+            self._log_pusher = LogPusher(
+                "/system/log-server",
+                interceptors=interceptors,
+                resolver=self._resolve_log_service,
+            )
+
         # Try to adopt running containers from a previous worker process.
         # If adoption succeeds, skip the destructive cleanup that would kill them.
         adopted = self.adopt_running_containers()
@@ -255,18 +271,10 @@ class Worker:
 
         # Create controller client if controller configured
         if self._config.controller_address:
-            interceptors = ()
-            if self._config.auth_token:
-                interceptors = (AuthTokenInjector(StaticTokenProvider(self._config.auth_token)),)
             self._controller_client = ControllerServiceClientSync(
                 address=self._config.controller_address,
                 timeout_ms=10_000,
                 interceptors=interceptors,
-            )
-            self._log_pusher = LogPusher(
-                "/system/log-server",
-                interceptors=interceptors,
-                resolver=self._resolve_log_service,
             )
 
             # Start lifecycle thread: register + serve + reset loop

--- a/lib/iris/tests/cluster/worker/test_worker.py
+++ b/lib/iris/tests/cluster/worker/test_worker.py
@@ -1089,6 +1089,39 @@ def test_stop_preserve_containers_does_not_kill_tasks(mock_worker, mock_runtime)
     assert task.status == job_pb2.TASK_STATE_RUNNING
 
 
+def test_start_wires_log_pusher_into_adopted_attempts(mock_bundle_store, mock_runtime, tmp_path):
+    """Regression for #5261.
+
+    Worker.start() must construct the LogPusher *before* adopting containers,
+    otherwise adopted TaskAttempts capture ``log_pusher=None`` permanently
+    and silently drop every container log line for the rest of the task.
+    """
+    container = _make_discovered_container()
+    mock_runtime.discover_containers = Mock(return_value=[container])
+
+    config = WorkerConfig(
+        port=0,
+        port_range=(50000, 50100),
+        cache_dir=tmp_path / "cache",
+        default_task_image="mock-image",
+        # Unreachable controller; lifecycle thread retries register and exits on stop().
+        controller_address="http://127.0.0.1:1",
+        poll_interval=Duration.from_seconds(0.05),
+    )
+    worker = Worker(config, bundle_store=mock_bundle_store, container_runtime=mock_runtime)
+
+    try:
+        worker.start()
+
+        assert worker._log_pusher is not None
+        task = worker.get_task(container.task_id, container.attempt_id)
+        assert task is not None
+        # The adopted attempt must reference the worker's live pusher, not None.
+        assert task._log_pusher is worker._log_pusher
+    finally:
+        worker.stop()
+
+
 def test_task_attempt_adopt_factory():
     """TaskAttempt.adopt() creates a properly initialized attempt."""
     port_allocator = PortAllocator(port_range=(50000, 50100))


### PR DESCRIPTION
* fixes https://github.com/marin-community/marin/issues/5261
* hoist `LogPusher` construction in `Worker.start()` above `adopt_running_containers()` so adopted `TaskAttempt`s capture a live pusher instead of `None`
* before this, only attempts created via `Worker.submit_task` saw the pusher (it was wired correctly there); attempts adopted after a `restart-worker` permanently fed every log line into `_push_logs`'s `if not self._log_pusher: return` short-circuit [^1]
* add regression test `test_start_wires_log_pusher_into_adopted_attempts` that drives `Worker.start()` end-to-end with a discovered container and asserts the adopted attempt's `_log_pusher` is the worker's pusher

[^1]: container logs were still produced (visible inside the container and in wandb's `output.log`) — they just never reached finelog, so `iris job logs` and `iris rpc controller get-task-logs` returned zero entries for the rest of the task's lifetime.