### PR TITLE
[zephyr] Migrate stale ctx.execute() callers to ZephyrExecutionResult

### DIFF
--- a/experiments/swe_rebench_trace/pipeline.py
+++ b/experiments/swe_rebench_trace/pipeline.py
@@ -122,7 +122,7 @@ def main() -> None:
         args.task_image,
     )
 
-    output_files = list(ctx.execute(pipeline))
+    output_files = ctx.execute(pipeline).results
     logger.info("Pipeline complete: wrote %d shard files", len(output_files))
     for f in output_files:
         print(f)

--- a/experiments/train_test_overlap/aggregate_total.py
+++ b/experiments/train_test_overlap/aggregate_total.py
@@ -64,7 +64,7 @@ def _compute_dataset_sizes(dataset_steps: list[ExecutorStep]) -> dict[str, int]:
         pattern = os.path.join(path.rstrip("/"), "**", "*.jsonl*")
         pipeline = Dataset.from_files(pattern, empty_glob_ok=True).flat_map(load_file).map(lambda _: 1).reduce(sum)
         ctx = ZephyrContext(name="overlap-size")
-        results = ctx.execute(pipeline)
+        results = ctx.execute(pipeline).results
         return results[0]
 
     size_map: dict[str, int] = {}
@@ -209,7 +209,7 @@ def aggregate_single_dataset(
         Dataset.from_list(shard_paths)
         .flat_map(extract_overlap_records)
         .write_jsonl(f"{intermediate_dir}/overlap-{{shard:05d}}.jsonl.gz", skip_existing=True)
-    )
+    ).results
 
     logger.info(f"Wrote {len(intermediate_paths)} intermediate files to {intermediate_dir}")
 

--- a/lib/marin/src/marin/datakit/download/coderforge.py
+++ b/lib/marin/src/marin/datakit/download/coderforge.py
@@ -95,7 +95,7 @@ def transform(input_path: str, output_path: str) -> None:
         .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
     )
     ctx = ZephyrContext(name="coderforge-transform", resources=ResourceConfig(cpu=1, ram="8g"))
-    list(ctx.execute(pipeline))
+    ctx.execute(pipeline)
 
 
 def download_coderforge_step() -> StepSpec:

--- a/lib/marin/src/marin/datakit/download/gpt_oss_rollouts.py
+++ b/lib/marin/src/marin/datakit/download/gpt_oss_rollouts.py
@@ -64,7 +64,7 @@ def transform(input_path: str, output_path: str) -> None:
         .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
     )
     ctx = ZephyrContext(name="gpt-oss-rollouts-transform", resources=ResourceConfig(cpu=1, ram="8g"))
-    list(ctx.execute(pipeline))
+    ctx.execute(pipeline)
 
 
 def download_gpt_oss_rollouts_step() -> StepSpec:

--- a/lib/marin/src/marin/datakit/download/nemotron_terminal.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_terminal.py
@@ -55,7 +55,7 @@ def transform(input_path: str, output_path: str) -> None:
         .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
     )
     ctx = ZephyrContext(name="nemotron-terminal-transform", resources=ResourceConfig(cpu=1, ram="32g"))
-    list(ctx.execute(pipeline))
+    ctx.execute(pipeline)
 
 
 def download_nemotron_terminal_step() -> StepSpec:

--- a/lib/marin/src/marin/datakit/download/principia.py
+++ b/lib/marin/src/marin/datakit/download/principia.py
@@ -58,7 +58,7 @@ def transform(input_path: str, output_path: str) -> None:
         .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
     )
     ctx = ZephyrContext(name="principia-transform", resources=ResourceConfig(cpu=1, ram="4g"))
-    list(ctx.execute(pipeline))
+    ctx.execute(pipeline)
 
 
 def download_principia_step() -> StepSpec:

--- a/lib/marin/src/marin/datakit/download/superior_reasoning.py
+++ b/lib/marin/src/marin/datakit/download/superior_reasoning.py
@@ -60,7 +60,7 @@ def transform(input_path: str, output_path: str) -> None:
         .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
     )
     ctx = ZephyrContext(name="superior-reasoning-transform", resources=ResourceConfig(cpu=1, ram="8g"))
-    list(ctx.execute(pipeline))
+    ctx.execute(pipeline)
 
 
 def download_superior_reasoning_step() -> StepSpec:

--- a/lib/marin/src/marin/datakit/download/swe_rebench_openhands.py
+++ b/lib/marin/src/marin/datakit/download/swe_rebench_openhands.py
@@ -64,7 +64,7 @@ def transform(input_path: str, output_path: str) -> None:
         .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
     )
     ctx = ZephyrContext(name="swe-rebench-openhands-transform", resources=ResourceConfig(cpu=1, ram="32g"))
-    list(ctx.execute(pipeline))
+    ctx.execute(pipeline)
 
 
 def download_swe_rebench_openhands_step() -> StepSpec:

--- a/lib/marin/src/marin/datakit/download/synthetic1.py
+++ b/lib/marin/src/marin/datakit/download/synthetic1.py
@@ -72,7 +72,7 @@ def transform(input_path: str, output_path: str) -> None:
         .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
     )
     ctx = ZephyrContext(name="synthetic1-transform", resources=ResourceConfig(cpu=1, ram="4g"))
-    list(ctx.execute(pipeline))
+    ctx.execute(pipeline)
 
 
 def download_synthetic1_step() -> StepSpec:


### PR DESCRIPTION
ZephyrContext.execute now returns a ZephyrExecutionResult dataclass with results and counters fields. Replace lingering list(ctx.execute(pipeline)) wrappers with bare calls (or .results when the caller actually uses the output), and fix aggregate_total.py call sites that indexed/iterated the bare dataclass as a list.