### PR TITLE
[evals] Fix main CI: stale fray.v2 imports and removed default_model_perplexity_gap

### DIFF
--- a/experiments/evals/perplexity_gap_registry.py
+++ b/experiments/evals/perplexity_gap_registry.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 
-from fray.v2.types import ResourceConfig
+from fray.types import ResourceConfig
 
 from experiments.defaults import default_raw_validation_sets
 from experiments.evals.fineweb2_multilingual import fineweb2_multilingual_raw_validation_sets

--- a/experiments/exp_model_perplexity_gap_coverage_matrix.py
+++ b/experiments/exp_model_perplexity_gap_coverage_matrix.py
@@ -9,7 +9,7 @@ This expands the canonical bundle/model registry into:
 - the default pairwise gap reports derived from those cached scores
 """
 
-from fray.v2.types import ResourceConfig
+from fray.types import ResourceConfig
 
 from experiments.evals.perplexity_gap_registry import build_registered_perplexity_gap_coverage_plan
 from marin.execution.executor import executor_main

--- a/experiments/exp_model_perplexity_gap_fineweb2_multilingual.py
+++ b/experiments/exp_model_perplexity_gap_fineweb2_multilingual.py
@@ -5,12 +5,18 @@ from fray.types import ResourceConfig
 
 from experiments.defaults import default_raw_validation_sets
 from experiments.evals.fineweb2_multilingual import fineweb2_multilingual_raw_validation_sets
-from marin.evaluation.perplexity_gap import GapFinderModelConfig, default_model_perplexity_gap
+from marin.evaluation.perplexity_gap import (
+    GapFinderModelConfig,
+    model_perplexity_gap_from_scores,
+    model_perplexity_scores,
+)
 from marin.execution.executor import executor_main
 
 RESOURCE_CONFIG = ResourceConfig.with_tpu("v5p-8", regions=["us-central1"])
 MAX_DOCS_PER_DATASET = 256
 MAX_DOC_BYTES = 32_768
+MAX_EVAL_LENGTH = 4096
+PER_DEVICE_BATCH_SIZE = 4
 
 DATASETS = {
     **default_raw_validation_sets(),
@@ -22,21 +28,48 @@ MARIN_MODEL = GapFinderModelConfig(
     checkpoint_is_hf=True,
     tokenizer="meta-llama/Llama-3.1-8B",
 )
+LLAMA_MODEL = GapFinderModelConfig(
+    checkpoint_path="meta-llama/Llama-3.1-8B",
+    checkpoint_is_hf=True,
+    tokenizer="meta-llama/Llama-3.1-8B",
+)
+QWEN3_MODEL = GapFinderModelConfig(
+    checkpoint_path="Qwen/Qwen3-8B-Base",
+    checkpoint_is_hf=True,
+    tokenizer="Qwen/Qwen3-8B",
+)
 
-MARIN_VS_LLAMA = default_model_perplexity_gap(
-    name="fineweb2-multilingual-marin-8b-base-vs-llama-3.1-8b-base-doccap256",
-    model_a=MARIN_MODEL,
-    model_b=GapFinderModelConfig(
-        checkpoint_path="meta-llama/Llama-3.1-8B",
-        checkpoint_is_hf=True,
-        tokenizer="meta-llama/Llama-3.1-8B",
-    ),
+COMMON_SCORE_KWARGS = dict(
     datasets=DATASETS,
     resource_config=RESOURCE_CONFIG,
-    per_device_batch_size=4,
-    max_eval_length=4096,
+    per_device_batch_size=PER_DEVICE_BATCH_SIZE,
+    max_eval_length=MAX_EVAL_LENGTH,
     max_docs_per_dataset=MAX_DOCS_PER_DATASET,
     max_doc_bytes=MAX_DOC_BYTES,
+)
+
+MARIN_SCORES = model_perplexity_scores(
+    model=MARIN_MODEL,
+    wandb_tags=["model=marin-community/marin-8b-base", "dataset_bundle=default_raw_plus_fineweb2_multilingual"],
+    **COMMON_SCORE_KWARGS,
+)
+LLAMA_SCORES = model_perplexity_scores(
+    model=LLAMA_MODEL,
+    wandb_tags=["model=meta-llama/Llama-3.1-8B", "dataset_bundle=default_raw_plus_fineweb2_multilingual"],
+    **COMMON_SCORE_KWARGS,
+)
+QWEN3_SCORES = model_perplexity_scores(
+    model=QWEN3_MODEL,
+    wandb_tags=["model=Qwen/Qwen3-8B-Base", "dataset_bundle=default_raw_plus_fineweb2_multilingual"],
+    **COMMON_SCORE_KWARGS,
+)
+
+MARIN_VS_LLAMA = model_perplexity_gap_from_scores(
+    name="fineweb2-multilingual-marin-8b-base-vs-llama-3.1-8b-base-doccap256",
+    model_a_name="marin-community/marin-8b-base",
+    model_b_name="meta-llama/Llama-3.1-8B",
+    model_a_scores_path=MARIN_SCORES.as_input_name(),
+    model_b_scores_path=LLAMA_SCORES.as_input_name(),
     wandb_tags=[
         "eval=perplexity-gap",
         "rerun=fineweb2-multilingual",
@@ -48,20 +81,12 @@ MARIN_VS_LLAMA = default_model_perplexity_gap(
     ],
 )
 
-MARIN_VS_QWEN3 = default_model_perplexity_gap(
+MARIN_VS_QWEN3 = model_perplexity_gap_from_scores(
     name="fineweb2-multilingual-marin-8b-base-vs-qwen3-8b-base-doccap256",
-    model_a=MARIN_MODEL,
-    model_b=GapFinderModelConfig(
-        checkpoint_path="Qwen/Qwen3-8B-Base",
-        checkpoint_is_hf=True,
-        tokenizer="Qwen/Qwen3-8B",
-    ),
-    datasets=DATASETS,
-    resource_config=RESOURCE_CONFIG,
-    per_device_batch_size=4,
-    max_eval_length=4096,
-    max_docs_per_dataset=MAX_DOCS_PER_DATASET,
-    max_doc_bytes=MAX_DOC_BYTES,
+    model_a_name="marin-community/marin-8b-base",
+    model_b_name="Qwen/Qwen3-8B-Base",
+    model_a_scores_path=MARIN_SCORES.as_input_name(),
+    model_b_scores_path=QWEN3_SCORES.as_input_name(),
     wandb_tags=[
         "eval=perplexity-gap",
         "rerun=fineweb2-multilingual",

--- a/experiments/exp_model_perplexity_gap_fineweb2_multilingual.py
+++ b/experiments/exp_model_perplexity_gap_fineweb2_multilingual.py
@@ -15,8 +15,6 @@ from marin.execution.executor import executor_main
 RESOURCE_CONFIG = ResourceConfig.with_tpu("v5p-8", regions=["us-central1"])
 MAX_DOCS_PER_DATASET = 256
 MAX_DOC_BYTES = 32_768
-MAX_EVAL_LENGTH = 4096
-PER_DEVICE_BATCH_SIZE = 4
 
 DATASETS = {
     **default_raw_validation_sets(),
@@ -28,40 +26,41 @@ MARIN_MODEL = GapFinderModelConfig(
     checkpoint_is_hf=True,
     tokenizer="meta-llama/Llama-3.1-8B",
 )
-LLAMA_MODEL = GapFinderModelConfig(
-    checkpoint_path="meta-llama/Llama-3.1-8B",
-    checkpoint_is_hf=True,
-    tokenizer="meta-llama/Llama-3.1-8B",
-)
-QWEN3_MODEL = GapFinderModelConfig(
-    checkpoint_path="Qwen/Qwen3-8B-Base",
-    checkpoint_is_hf=True,
-    tokenizer="Qwen/Qwen3-8B",
-)
-
-COMMON_SCORE_KWARGS = dict(
-    datasets=DATASETS,
-    resource_config=RESOURCE_CONFIG,
-    per_device_batch_size=PER_DEVICE_BATCH_SIZE,
-    max_eval_length=MAX_EVAL_LENGTH,
-    max_docs_per_dataset=MAX_DOCS_PER_DATASET,
-    max_doc_bytes=MAX_DOC_BYTES,
-)
 
 MARIN_SCORES = model_perplexity_scores(
     model=MARIN_MODEL,
-    wandb_tags=["model=marin-community/marin-8b-base", "dataset_bundle=default_raw_plus_fineweb2_multilingual"],
-    **COMMON_SCORE_KWARGS,
+    datasets=DATASETS,
+    resource_config=RESOURCE_CONFIG,
+    per_device_batch_size=4,
+    max_eval_length=4096,
+    max_docs_per_dataset=MAX_DOCS_PER_DATASET,
+    max_doc_bytes=MAX_DOC_BYTES,
 )
 LLAMA_SCORES = model_perplexity_scores(
-    model=LLAMA_MODEL,
-    wandb_tags=["model=meta-llama/Llama-3.1-8B", "dataset_bundle=default_raw_plus_fineweb2_multilingual"],
-    **COMMON_SCORE_KWARGS,
+    model=GapFinderModelConfig(
+        checkpoint_path="meta-llama/Llama-3.1-8B",
+        checkpoint_is_hf=True,
+        tokenizer="meta-llama/Llama-3.1-8B",
+    ),
+    datasets=DATASETS,
+    resource_config=RESOURCE_CONFIG,
+    per_device_batch_size=4,
+    max_eval_length=4096,
+    max_docs_per_dataset=MAX_DOCS_PER_DATASET,
+    max_doc_bytes=MAX_DOC_BYTES,
 )
 QWEN3_SCORES = model_perplexity_scores(
-    model=QWEN3_MODEL,
-    wandb_tags=["model=Qwen/Qwen3-8B-Base", "dataset_bundle=default_raw_plus_fineweb2_multilingual"],
-    **COMMON_SCORE_KWARGS,
+    model=GapFinderModelConfig(
+        checkpoint_path="Qwen/Qwen3-8B-Base",
+        checkpoint_is_hf=True,
+        tokenizer="Qwen/Qwen3-8B",
+    ),
+    datasets=DATASETS,
+    resource_config=RESOURCE_CONFIG,
+    per_device_batch_size=4,
+    max_eval_length=4096,
+    max_docs_per_dataset=MAX_DOCS_PER_DATASET,
+    max_doc_bytes=MAX_DOC_BYTES,
 )
 
 MARIN_VS_LLAMA = model_perplexity_gap_from_scores(


### PR DESCRIPTION
## Summary

Main is currently red on the dry-run suite (e.g. [run 25091673582](https://github.com/marin-community/marin/actions/runs/25091673582/job/73518977399)).
Two PRs landed close together and each missed an experiments file the other touched:

- **#5140** (`fray.v2` → `fray` rename) left two stale `fray.v2.types` imports.
- **#5169** (perplexity gap caching refactor) removed `default_model_perplexity_gap` from `marin.evaluation.perplexity_gap` but didn't update one experiments file that still imported it.

This PR:

- `experiments/evals/perplexity_gap_registry.py` and `experiments/exp_model_perplexity_gap_coverage_matrix.py`: `fray.v2.types` → `fray.types`.
- `experiments/exp_model_perplexity_gap_fineweb2_multilingual.py`: ported to the new two-step `model_perplexity_scores` + `model_perplexity_gap_from_scores` API (Marin scores reused across both pairs), matching the pattern in `exp_model_perplexity_gap_marin_vs_llama.py`.

## Test plan

- [x] `uv run pytest tests/test_dry_run.py -k perplexity` — 4 passed, 1 skipped (skipped count matches main; only the two previously-failing cases changed status).
- [x] `./infra/pre-commit.py` clean on the three modified files.