### PR TITLE
finelog: accept legacy iris.logging url path on the server

### DIFF
--- a/lib/finelog/src/finelog/server/asgi.py
+++ b/lib/finelog/src/finelog/server/asgi.py
@@ -26,10 +26,12 @@ from finelog.server.service import LogServiceImpl
 # duckdb_store.py.
 _MAX_CONCURRENT_FETCH_LOGS = 4
 
+# CRON(2026-05-12) -- remove this legacy workaround as all workers & clients
+# will be updated by this point.
 # Pre-#5212 (b212f0015) the LogService proto package was iris.logging, so old
 # worker images push to /iris.logging.LogService/*. Wire format is identical
 # (same field numbers across PushLogsRequest/LogEntry/etc.), so we rewrite
-# the path before routing. Drop this once all worker images are post-#5212.
+# the path before routing.
 _LEGACY_PATH_PREFIX = "/iris.logging.LogService/"
 _CURRENT_PATH_PREFIX = "/finelog.logging.LogService/"
 

--- a/lib/finelog/src/finelog/server/asgi.py
+++ b/lib/finelog/src/finelog/server/asgi.py
@@ -9,10 +9,12 @@ from collections.abc import Iterable
 
 from connectrpc.interceptor import Interceptor
 from starlette.applications import Starlette
+from starlette.middleware import Middleware
 from starlette.middleware.wsgi import WSGIMiddleware
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from starlette.routing import Mount, Route
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from finelog.rpc.logging_connect import LogServiceWSGIApplication
 from finelog.server.interceptors import ConcurrencyLimitInterceptor
@@ -23,6 +25,27 @@ from finelog.server.service import LogServiceImpl
 # page cache and wedges the process. Tune alongside the working-set caps in
 # duckdb_store.py.
 _MAX_CONCURRENT_FETCH_LOGS = 4
+
+# Pre-#5212 (b212f0015) the LogService proto package was iris.logging, so old
+# worker images push to /iris.logging.LogService/*. Wire format is identical
+# (same field numbers across PushLogsRequest/LogEntry/etc.), so we rewrite
+# the path before routing. Drop this once all worker images are post-#5212.
+_LEGACY_PATH_PREFIX = "/iris.logging.LogService/"
+_CURRENT_PATH_PREFIX = "/finelog.logging.LogService/"
+
+
+class _LegacyIrisLoggingPathMiddleware:
+    """Rewrite legacy iris.logging.LogService URLs onto the current path."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self._app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http" and scope.get("path", "").startswith(_LEGACY_PATH_PREFIX):
+            tail = scope["path"][len(_LEGACY_PATH_PREFIX) :]
+            new_path = _CURRENT_PATH_PREFIX + tail
+            scope = {**scope, "path": new_path, "raw_path": new_path.encode()}
+        await self._app(scope, receive, send)
 
 
 def build_log_server_asgi(
@@ -48,4 +71,4 @@ def build_log_server_asgi(
         Route("/health", _health),
         Mount(log_wsgi_app.path, app=WSGIMiddleware(log_wsgi_app)),
     ]
-    return Starlette(routes=routes)
+    return Starlette(routes=routes, middleware=[Middleware(_LegacyIrisLoggingPathMiddleware)])

--- a/lib/finelog/tests/test_server.py
+++ b/lib/finelog/tests/test_server.py
@@ -118,3 +118,38 @@ def test_push_then_fetch_round_trip(tmp_path: Path):
         assert [e["data"] for e in entries] == ["hello", "world"]
     finally:
         svc.close()
+
+
+def test_legacy_iris_logging_path_compat():
+    """Pre-#5212 workers send to /iris.logging.LogService/* (the package was
+    renamed when finelog was extracted from iris). The wire format is
+    identical between iris.logging and finelog.logging — same field numbers
+    on PushLogsRequest/LogEntry/etc — so a server-side path rewrite restores
+    delivery without any worker-side change. Removable once those workers
+    have rotated out.
+    """
+    from finelog.store.mem_store import MemStore
+
+    svc = LogServiceImpl(log_store=MemStore())
+    try:
+        app = build_log_server_asgi(svc)
+        with TestClient(app) as client:
+            push_resp = client.post(
+                "/iris.logging.LogService/PushLogs",
+                json={
+                    "key": "/legacy/probe",
+                    "entries": [{"source": "stdout", "data": "old-worker", "timestamp": {"epoch_ms": 1}}],
+                },
+                headers={"Content-Type": "application/json"},
+            )
+            assert push_resp.status_code == 200
+
+            fetch_resp = client.post(
+                "/iris.logging.LogService/FetchLogs",
+                json={"source": "/legacy/probe"},
+                headers={"Content-Type": "application/json"},
+            )
+            assert fetch_resp.status_code == 200
+            assert [e["data"] for e in fetch_resp.json().get("entries", [])] == ["old-worker"]
+    finally:
+        svc.close()


### PR DESCRIPTION
* fixes https://github.com/marin-community/marin/issues/5268
* server-side path rewrite from `/iris.logging.LogService/*` → `/finelog.logging.LogService/*` so pre-#5212 worker images keep working against the renamed package
* root cause: the proto package was renamed in #5212; post-#5212 finelog only mounts the new path, old workers get 404 → `Code.UNIMPLEMENTED` → not retryable in `is_retryable_error` → `_invalidate()` skipped → cached client never recycles → buffer overflows[^1]
* add `_LegacyIrisLoggingPathMiddleware` in `lib/finelog/src/finelog/server/asgi.py`, wired into `build_log_server_asgi` via the `Middleware(...)` constructor kwarg
* wire format is identical between `iris.logging` and `finelog.logging` — matching field numbers on `PushLogsRequest`/`PushLogsResponse`/`LogEntry`/`FetchLogsRequest`/`FetchLogsResponse`/`LogLevel`, `Timestamp` differs structurally but is wire-identical (`int64 epoch_ms = 1`) — so a pure path rewrite is sufficient
* removable once all worker images are post-#5212
* adds regression test `test_legacy_iris_logging_path_compat`

[^1]: confirmed on wedged production worker `marin-cpu-vm-e2-highmem-2-ondemand-us-ea-20260425-...` — kernel showed an ESTABLISHED TCP connection to finelog; same connection: `POST /iris.logging.LogService/PushLogs → 404`, `POST /finelog.logging.LogService/PushLogs → 200`
