### PR TITLE
[Design] iris_worker_cordon

### DIFF
--- a/.agents/projects/iris_worker_cordon/design.md
+++ b/.agents/projects/iris_worker_cordon/design.md
@@ -1,0 +1,88 @@
+# Iris Worker Cordon
+
+_Why are we doing this? What's the benefit?_
+
+Today the only manual worker-recycling primitive is `RestartWorker`, which hard-kills in-flight tasks ([`controller.proto:473-480`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/rpc/controller.proto#L473-L480)). Operators have no way to say "stop assigning new tasks here; let the running ones finish; then take this worker out." Surfaced concretely during #5268 triage: 7 wedged CPU on-demand workers were each running coordinator/parent jobs, and the only options were to wait or to hard-restart and lose those coordinators.
+
+This design adds **`CordonWorker` / `UncordonWorker`** — a sticky eligibility flag on the worker row, mirrored to all sibling workers in the same slice. A small reaper terminates cordoned workers once they finish their last in-flight task. The autoscaler is left to scale up replacements on its own, driven by unmet demand. A separate "drain with timeout / forced recycle" primitive is **explicitly out of scope** for this round (see Open Questions); we want the simplest thing that addresses the wedged-worker case before adding more verbs.
+
+Background notes — including prior-art comparison with K8s/Nomad/Slurm and the autoscaler hazard analysis — are in [`research.md`](./research.md).
+
+## Challenges
+
+The proposal is small in surface area but interacts with two pieces of state machinery that are easy to get wrong:
+
+**Autoscaler interactions.** The autoscaler's `ScalingGroup.scale_down_if_idle()` ([`scaling_group.py:835-890`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py#L835-L890)) only terminates an idle slice when demand has fallen (`ready + pending <= target_capacity`). A cordoned worker that finishes its last task while demand is still high will sit idle indefinitely if we rely on autoscaler scale-down. Conversely, we want the autoscaler to *replace* the cordoned worker with a fresh one — that path works automatically, but only if the cordoned worker stops counting toward `target_capacity`. So cordon needs two effects on the autoscaler: hide cordoned workers from capacity totals (to provoke scale-up) and own termination of cordoned-and-idle workers (since scale-down won't fire).
+
+**Multi-VM slices.** Iris slices can have multiple VMs (e.g. v5e-64 = 16 VMs). Per-worker cordon on a multi-VM slice is meaningless: terminating one VM means terminating the whole slice. The user-facing semantic is therefore "cordon at slice granularity" — cordoning a worker propagates the flag to all siblings in its slice. This keeps the operator mental model simple and makes recycle straightforward. Cordon is only ever applied to slices in `READY` state (workers don't exist as DB rows until the slice is ready); cordoning a `worker_id` for an INITIALIZING/BOOTING slice returns `WORKER_NOT_FOUND`.
+
+## Costs / Risks
+
+- New RPC verb pair, new SQLite column, new CLI subcommands. Modest churn.
+- Cordon is sticky — an operator who cordons a worker and forgets about it leaves capacity unreachable until uncordoned. Mitigation: surface cordoned workers prominently in `iris cluster status` and stamp a `cordoned_at` timestamp so stale cordons are visible. We considered but rejected (for this round) a TTL on the flag, a `--reason` field, and a per-cordon audit row; revisit if cordon-and-forget incidents recur.
+- The reaper introduces a second termination path alongside autoscaler scale-down. Race is benign (both go through `detach_slice()` under `_slices_lock`, the loser observes `None` and no-ops, and cloud termination is idempotent), but worth a regression test.
+- No timeout / forced-recycle. If a cordoned worker has a wedged task that never terminates, the worker stays alive forever. Operators can still fall back to `RestartWorker` (hard kill); a follow-up `DrainWorker(worker_id, timeout)` is the natural extension if we hit this in practice.
+
+### Alternatives considered
+
+- **`RestartWorker(graceful=true)`** instead of a new verb pair. Rejected: cordon is naturally sticky and idempotent, restart is naturally one-shot. Conflating them via a flag complicates `RestartWorker`'s contract and loses the "cordon many before recycling any" pattern that K8s and Nomad both standardize on.
+- **Reaper as a standalone loop** (not embedded in the autoscaler cycle). Rejected for this round: the autoscaler already runs a per-cycle reconciliation pass, already holds the slice/group state we need, and already handles termination. Coupling the reaper to its tick keeps the new code minimal. Cost: cordon recycle latency is bounded by autoscaler tick (currently fast); if we ever pause or slow the autoscaler for unrelated reasons, recycle slows too.
+
+## Design
+
+### State
+
+Add a `cordoned INTEGER CHECK (cordoned IN (0, 1)) DEFAULT 0` column to the `workers` table ([`schema.py:839-925`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cluster/controller/schema.py#L839-L925)) and a matching `cordoned: bool` field on `WorkerRow` ([`schema.py:1481-1502`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cluster/controller/schema.py#L1481-L1502)). Binary flag, mirrors `healthy` and `active`. No new enum.
+
+### RPCs
+
+- `CordonWorker(worker_id) -> {accepted, error, cordoned_worker_ids}` — sets `cordoned=1` for the named worker and **all sibling workers in its slice** (multi-VM cordon-the-slice rule). Idempotent: cordoning an already-cordoned worker is a no-op success. Returns the full list of worker_ids touched so the operator sees the slice expansion.
+- `UncordonWorker(worker_id) -> {accepted, error, uncordoned_worker_ids}` — symmetric reverse. Only meaningful before the reaper has terminated the slice; after termination the worker is gone and uncordon returns `not_found`. Also idempotent.
+
+Both RPCs follow the existing `RestartWorker` shape (`accepted`, `error` fields). CLI surface follows the existing pattern in [`cli/cluster.py:1050`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cli/cluster.py#L1050):
+
+```
+iris rpc controller cordon-worker --json '{"worker_id":"..."}'
+iris rpc controller uncordon-worker --json '{"worker_id":"..."}'
+```
+
+### Scheduler
+
+One-line change to `db.healthy_active_workers_with_attributes()`: append `AND cordoned = 0` to the eligibility predicate. The scheduler ([`scheduler.py`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cluster/controller/scheduler.py)) is unchanged — it never sees cordoned workers in its candidate pool, so no logic in `try_schedule_task` needs to know about cordon.
+
+### Autoscaler
+
+Two narrow changes, both in `lib/iris/src/iris/cluster/controller/autoscaler/`:
+
+1. **Capacity accounting.** When the routing layer ([`routing.py:189-210`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cluster/controller/autoscaler/routing.py#L189-L210)) computes ready capacity, slices where every worker is cordoned are excluded from `max_vms`. This makes the autoscaler see the cordoned slice as "missing" from the fleet and provision a replacement after the standard 1-minute scale-up cooldown. (We exclude at slice granularity rather than worker granularity because cordon is slice-scoped and a partially-cordoned slice is impossible by construction.)
+
+2. **Cordon reaper.** Add a small reconciliation step to the autoscaler's per-cycle loop in `runtime.py`, called immediately after `scale_down_if_idle`. For each fully-cordoned slice with zero in-flight tasks (checked via `db.running_tasks_by_worker`), call `terminate_slices_for_workers([worker_ids])` ([`operations.py`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cluster/controller/autoscaler/operations.py)). Runs alongside `scale_down_if_idle` but never on the same slices: cordoned slices are excluded from scale-down (they're already excluded from `target_capacity`, so the predicate would not fire anyway, but we add an explicit guard to make the contract clear).
+
+The combination yields the desired flow: cordon a worker → slice marked ineligible → scheduler stops sending new tasks → autoscaler provisions a replacement → in-flight tasks drain naturally → reaper terminates the original slice. **Ownership boundary:** the reaper terminates cordoned-and-idle slices; autoscaler scale-down terminates uncordoned-and-surplus slices.
+
+### OPS.md
+
+New section "Recovering a wedged worker" added to `lib/iris/OPS.md` covering the cordon/uncordon recipe and how to verify the slice is recycled. Full text in `spec.md`.
+
+## Testing
+
+The smallest test that catches a regression is an integration test against the dev cluster (or `provider/k8s/fake.py`) that:
+
+1. Submits N+1 tasks to a cluster of N workers; confirms all run.
+2. Cordons one worker mid-flight; confirms (a) the cordoned worker's existing task continues to completion, (b) no new task is assigned to it, (c) the autoscaler provisions a replacement and the queue drains.
+3. After the cordoned worker's task completes, confirms the slice is terminated within one autoscaler cycle.
+4. Repeats the cordon, then uncordons before completion, and confirms the worker rejoins eligibility without recycle.
+
+A unit test on `db.healthy_active_workers_with_attributes` covers the SQL filter directly. The reaper logic gets a unit test against an in-memory DB with a fake `terminate_slices_for_workers`. Multi-VM-slice behavior gets one parametrized integration test.
+
+## Open Questions
+
+- **Naming: `CordonWorker` vs `CordonSlice`?** The user-facing semantic is slice-scoped, but the issue and operator mental model talk about workers. We've kept "Worker" in the RPC name to match the existing `RestartWorker`, returning the slice's full worker list in the response. Alternative: introduce `CordonSlice(slice_id)` as the primary verb with `CordonWorker` as a thin wrapper. Reviewers' call.
+- **Forced-recycle / drain follow-up.** This design intentionally omits a timeout fallback. If we hit cases in production where cordoned workers stay alive indefinitely because of a wedged task, the natural follow-up is a `DrainWorker(worker_id, timeout)` RPC that calls `RestartWorker` once the deadline passes. Worth filing as a tracking issue if we ship cordon and observe the gap.
+
+### Out of scope (for this design)
+
+- **Drain semantics.** No timeout, no forced-recycle, no `DrainWorker` RPC. The reaper waits forever for in-flight tasks to finish naturally.
+- **Cluster-wide / batch cordon.** No "cordon all workers matching attribute X" verb.
+- **In-task signaling.** We do not send a SIGTERM-style "wrap up" signal to running tasks on a cordoned worker.
+- **Per-job disruption budgets.** No PDB analog, no eviction-vs-delete split.

--- a/.agents/projects/iris_worker_cordon/research.md
+++ b/.agents/projects/iris_worker_cordon/research.md
@@ -1,0 +1,84 @@
+# Research: Iris worker cordon
+
+Background notes that fed `design.md` and `spec.md`. References pinned to `main@9bec9c06b`.
+
+## Problem framing
+
+From [#5270](https://github.com/marin-community/marin/issues/5270): `RestartWorker` is the only manual recycle primitive and it hard-kills in-flight tasks. Surfaced during #5268 triage when 7 wedged CPU on-demand workers were running coordinator/parent jobs. The original DoD asked for a `DrainWorker` (cordon + wait + recycle, with timeout fallback). After investigation we narrowed scope to **cordon + uncordon only**; the wait-and-recycle "drain" semantics are deferred. See `design.md` § Open Questions and "Out of scope" for the why.
+
+## In-repo findings
+
+### `RestartWorker` today
+
+- Proto: [`controller.proto:473-480`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/rpc/controller.proto#L473-L480) — `RestartWorkerRequest{worker_id}`, `RestartWorkerResponse{accepted, error}`.
+- Service handler: [`service.py:2404-2430`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cluster/controller/service.py#L2404-L2430) — calls `autoscaler.restart_worker(worker_id)`.
+- Autoscaler op: [`operations.py:39-78`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cluster/controller/autoscaler/operations.py#L39-L78) — looks up `slice_id`, calls `slice_handle.restart_worker(handle)`. Worker process restarts in-place; in-flight tasks are dropped at the process level (no scheduler-side coordination).
+
+### Worker state representation
+
+- `WorkerRow`: [`schema.py:1481-1502`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cluster/controller/schema.py#L1481-L1502) — fields include `worker_id`, `address`, `healthy: bool`, `active: bool`, `consecutive_failures`, `last_heartbeat`, resource committed/total, `attributes`.
+- Worker table: [`schema.py:839-925`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cluster/controller/schema.py#L839-L925) — `healthy INTEGER CHECK (0 or 1)`, `active INTEGER CHECK (0 or 1)`. Binary flags pattern, no enum. New `cordoned INTEGER CHECK (0 or 1) DEFAULT 0` column slots in cleanly.
+
+### Scheduler eligibility
+
+- Worker query: `db.healthy_active_workers_with_attributes()` returns rows where both flags are 1. Adding `AND cordoned = 0` is the minimal-surface change (filtered at DB layer).
+- Scheduler: [`scheduler.py`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cluster/controller/scheduler.py) — `try_schedule_task()` (line ~458) iterates candidate workers from constraint matching, then capacity. Filtering at the DB layer keeps the scheduler unchanged.
+- Scheduling cycle: `controller.create_scheduling_context(workers)` (controller.py:~2047) builds the snapshot from filtered worker rows.
+
+### In-flight task tracking
+
+- `db.running_tasks_by_worker(db, worker_ids)` ([`db.py:822`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cluster/controller/db.py#L822)) returns `dict[WorkerId, set[JobName]]`. Already exists; used at controller.py:1681, 1842, 2531.
+
+### Autoscaler
+
+- Scale-down: `ScalingGroup.scale_down_if_idle()` ([`scaling_group.py:835-890`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py#L835-L890)) terminates idle slices when `ready + pending <= target_capacity` and the slice has been idle. Idle is computed from `worker_status_map` updated by the scheduler's `last_active`.
+- Scale-up cooldown: `can_scale_up()` (line ~938-958) enforces 1-minute cooldown.
+- Routing: `routing.py:189-210` computes `max_vms` as sum of REQUESTING+BOOTING+INITIALIZING+READY slices. Counts slices, not individual workers.
+- Slice ownership: `ScalingGroup._slices` dict guarded by `_slices_lock` (line 308). `detach_slice()` (line ~635) is the single termination path.
+- **Hazard A (load-bearing).** A cordoned worker that finishes its last task becomes idle. The autoscaler's existing `scale_down_if_idle` will only terminate it if `ready + pending <= target_capacity` — i.e., demand has dropped. While there is still demand for the slice's shape, the autoscaler will keep it alive even when idle, so termination won't happen on its own. **Implication:** the cordon path itself must drive termination of cordoned-and-idle workers, not rely on autoscaler scale-down.
+- **Hazard B.** If demand still requires N workers and we cordon one, autoscaler will scale up a replacement (after the 1-min cooldown). This is the *desired* behavior per #5270 framing — replace the wedged worker without losing in-flight tasks. We just need cordoned workers to not count toward `target_capacity`.
+- **Hazard C.** Race between cordon-reaper terminating an idle cordoned slice and autoscaler scale-down terminating the same slice for unrelated reasons (demand fell). `detach_slice()` is guarded by `_slices_lock`; the second caller gets `None` from the dict. Cloud termination should be idempotent. Low risk but worth a sentinel — see `design.md` § "Termination ownership".
+
+### CLI
+
+- Pattern in [`cli/cluster.py:1050`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cli/cluster.py#L1050): `client.restart_worker(controller_pb2.Controller.RestartWorkerRequest(worker_id=wid))`. New verbs follow this exactly.
+
+### K8s provider taint code
+
+- Lives at `lib/iris/src/iris/cluster/providers/k8s/tasks.py` and `.../k8s/fake.py`. Concrete to GPU-pod admission (NVIDIA_GPU_TOLERATION etc.). Not reusable as a cordon abstraction; cordon here is a SQLite flag and scheduler filter, not a K8s taint.
+
+### OPS.md
+
+- `lib/iris/OPS.md` covers cluster lifecycle, job/task management, scheduler/autoscaler queries. No drain or cordon documentation today. Insertion point: new section "Recovering a wedged worker" after "Task Operations".
+
+### Adjacent designs in `.agents/projects/`
+
+- `20260303_iris_autoscaler_design.md` — autoscaler demand/routing/cooldown. Adjacent, no overlap; cordon adds a per-worker eligibility gate orthogonal to scaling decisions.
+- `20260129_iris_chaos_design.md` — chaos injection. Unrelated.
+- No prior cordon/drain design in tree.
+
+## Prior art (cluster-manager cordon/drain)
+
+Short comparison; full pass under 200 words.
+
+- **Kubernetes.** Splits cordon and drain. Cordon is `Node.Spec.Unschedulable: bool` (sticky, declarative) plus a mirrored `node.kubernetes.io/unschedulable:NoSchedule` taint. The scheduler has a dedicated `NodeUnschedulable` filter plugin. `kubectl drain` is a *client-side loop*: cordon, then iterate pods and POST to the eviction API (which goes through PodDisruptionBudget admission). No server-side drain coordinator. ([safely-drain-node](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/), [api-eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/api-eviction/)).
+- **Nomad.** Splits eligibility (`node eligibility -disable` = cordon) from drain (`node drain -enable` = cordon + drain with deadline). `-keep-ineligible` preserves cordon when drain is cancelled. Best practice: cordon many before draining any, to avoid task ping-pong.
+- **Slurm.** Single state machine `DRAIN -> DRAINING -> DRAINED`; no separate cordon. Older design.
+
+### Lessons applied to this design
+
+1. **Cordon as a sticky declarative flag is the right primitive.** Both K8s and Nomad split it from active operations. Crash-safe: if the controller restarts mid-cordon, the flag persists and new tasks are still blocked.
+2. **Server-side ownership beats client-side polling for Iris.** K8s went client-side because clusters are multi-tenant and disruption policy is per-workload (PDBs). Iris is single-operator and owns the scheduler — a server-driven cordon-and-reap loop avoids reinventing a polling CLI and survives operator disconnects.
+3. **No PDB analog needed.** Iris has no per-job disruption budget; skip the eviction-vs-delete split until that concept exists.
+4. **Drain naming is loaded.** Since we're not implementing the wait-and-recycle behavior in this round, calling the RPC `CordonWorker`/`UncordonWorker` (not `DrainWorker`) signals scope honestly and leaves room for a later `DrainWorker` if we add explicit timeouts/forced-recycle.
+
+## Q&A summary that shaped the design
+
+User answers from interrogation phase:
+
+1. *Split or single?* → Cordon + Uncordon only, no Drain.
+2. *Recycle on completion?* → Yes — when the cordoned worker completes all in-flight tasks, terminate it. Let the autoscaler scale up a replacement if demand requires.
+3. *Timeout fallback?* → N/A; no drain.
+4. *Multi-VM slices?* → Cordon at slice granularity. Cordoning a worker on a multi-VM slice cordons the entire slice.
+5. *Open questions?* → Simplified per scope.
+6. *Out of scope?* → No drain in this round; explicit in `design.md`.

--- a/.agents/projects/iris_worker_cordon/spec.md
+++ b/.agents/projects/iris_worker_cordon/spec.md
@@ -1,0 +1,285 @@
+# Spec: Iris Worker Cordon
+
+Concrete contracts implied by [`design.md`](./design.md). This file is the surface reviewers should read to check "would I build this exact API?" — not an implementation plan.
+
+## Schema delta
+
+`workers` table ([`schema.py:839-925`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cluster/controller/schema.py#L839-L925)) gains two columns in a new schema migration (next available migration number, follows existing `# Migration NNNN` comment convention):
+
+```sql
+ALTER TABLE workers
+ADD COLUMN cordoned INTEGER NOT NULL CHECK (cordoned IN (0, 1)) DEFAULT 0;
+
+ALTER TABLE workers
+ADD COLUMN cordoned_at INTEGER NULL;  -- unix epoch ms, set when cordoned flips 0→1, NULL otherwise
+
+CREATE INDEX idx_workers_cordoned ON workers(cordoned) WHERE cordoned = 1;
+```
+
+The partial index keeps the common-case eligibility query (cordoned = 0) fast and gives the reaper an O(cordoned-count) scan rather than a fleet-wide table scan. `cordoned_at` is set when the flag flips 0→1 (so `iris cluster status` can render "CORDONED 12m ago") and reset to NULL when the flag flips 1→0.
+
+`WorkerRow` dataclass ([`schema.py:1481-1502`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cluster/controller/schema.py#L1481-L1502)) gains matching fields:
+
+```python
+@dataclass(frozen=True)
+class WorkerRow:
+    worker_id: WorkerId
+    address: str
+    healthy: bool
+    active: bool
+    cordoned: bool                  # NEW: ineligible for new task assignment; reaper-owned termination once idle
+    cordoned_at: datetime | None    # NEW: when cordoned flipped to True; None when not cordoned
+    consecutive_failures: int
+    last_heartbeat: datetime | None
+    # ... existing fields unchanged
+```
+
+## Proto
+
+Added to `lib/iris/src/iris/rpc/controller.proto`, immediately after `RestartWorker` (line 477):
+
+```proto
+// Mark a worker (and all sibling workers in its slice) as ineligible for new
+// task assignments. Existing in-flight tasks continue until completion. Once
+// every worker in the cordoned slice has zero in-flight tasks, the controller
+// terminates the slice. The autoscaler may scale up a replacement slice
+// independently if demand requires it. Cordon is only valid for workers on
+// slices in READY state.
+//
+// Idempotent: cordoning an already-cordoned worker returns accepted=true and
+// the same slice_worker_ids (slice membership is unchanged by re-cordon).
+//
+// Error conditions (returned via `accepted=false` and `error` string; CLIs
+// match on the prefix before any colon):
+//   - "worker_not_found": worker_id does not match a registered worker on a
+//     READY slice. This includes pre-READY (BOOTING/INITIALIZING) workers and
+//     workers whose slice has already been terminated by the reaper.
+rpc CordonWorker(CordonWorkerRequest) returns (CordonWorkerResponse);
+
+message CordonWorkerRequest {
+  string worker_id = 1;
+}
+
+message CordonWorkerResponse {
+  bool accepted = 1;
+  string error = 2;
+  // All worker_ids on the slice the request targeted. Always returns the full
+  // slice membership regardless of whether this call modified any flags
+  // (idempotent: re-cordon returns the same list). For single-VM slices this
+  // is a 1-element list. Empty when accepted=false.
+  repeated string slice_worker_ids = 3;
+}
+
+// Reverse a cordon. Clears the `cordoned` flag and `cordoned_at` timestamp on
+// the named worker and all sibling workers in its slice. Only meaningful
+// before the reaper has terminated the slice; after termination the worker
+// no longer exists and the call returns "worker_not_found: already_terminated".
+//
+// Idempotent: uncordoning a non-cordoned worker returns accepted=true with
+// the slice's worker_ids (no flags were changed).
+//
+// Error conditions (same string-prefix matching contract as CordonWorker):
+//   - "worker_not_found": worker_id does not match a registered worker on a
+//     READY slice.
+//   - "worker_not_found: already_terminated": the worker existed but its
+//     slice has been reaped since cordon. Distinct error string so the CLI
+//     can render "you raced the reaper" rather than "typo in worker id".
+rpc UncordonWorker(UncordonWorkerRequest) returns (UncordonWorkerResponse);
+
+message UncordonWorkerRequest {
+  string worker_id = 1;
+}
+
+message UncordonWorkerResponse {
+  bool accepted = 1;
+  string error = 2;
+  // All worker_ids on the slice the request targeted. Always returns the full
+  // slice membership regardless of whether this call modified any flags.
+  // Empty when accepted=false.
+  repeated string slice_worker_ids = 3;
+}
+```
+
+## Service handler signatures
+
+In `lib/iris/src/iris/cluster/controller/service.py`, paralleling `restart_worker` at line 2404. Both handlers use the existing `ScalingGroup.find_slice_for_worker(worker_id)` and `ScalingGroup.get_slice_worker_ids(slice_id)` helpers (`scaling_group.py:1142, 1151`) for slice membership lookup — no new SQL membership query is introduced for the RPC path.
+
+```python
+def cordon_worker(
+    self,
+    request: controller_pb2.Controller.CordonWorkerRequest,
+    context: grpc.ServicerContext,
+) -> controller_pb2.Controller.CordonWorkerResponse:
+    """Set cordoned=1 and cordoned_at=now for the named worker and all
+    siblings on the same slice.
+
+    Atomic: a single UPDATE statement of the form
+
+        UPDATE workers
+        SET cordoned = 1,
+            cordoned_at = COALESCE(cordoned_at, :now_ms)
+        WHERE slice_id = (SELECT slice_id FROM workers WHERE worker_id = :wid)
+          AND slice_id IS NOT NULL
+
+    sets the flag on every member of the slice in one statement, so the
+    scheduler never observes a partially cordoned slice. `cordoned_at` is
+    preserved on re-cordon (`COALESCE`). Idempotent.
+    """
+
+def uncordon_worker(
+    self,
+    request: controller_pb2.Controller.UncordonWorkerRequest,
+    context: grpc.ServicerContext,
+) -> controller_pb2.Controller.UncordonWorkerResponse:
+    """Reverse cordon_worker. Clears cordoned=0 and cordoned_at=NULL for
+    every worker on the slice in a single UPDATE.
+
+    Returns "worker_not_found: already_terminated" if the slice has been
+    reaped since cordon (worker_id no longer in workers table). Idempotent
+    on already-uncordoned workers.
+    """
+```
+
+## Autoscaler operations
+
+New module-level helper in `lib/iris/src/iris/cluster/controller/autoscaler/operations.py`. The cordon/uncordon SQL lives in `db.py` (next section) since it is pure DB state; only the reaper needs an `operations.py` helper because it ties DB state to slice termination.
+
+```python
+def reap_cordoned_idle_slices(
+    db: ControllerDb,
+    groups: dict[GroupKey, ScalingGroup],
+) -> list[SliceId]:
+    """Per-cycle reconciliation step.
+
+    Calls `db.cordoned_idle_slices(db)` to get the list of slice_ids whose
+    every worker is cordoned AND has zero in-flight tasks (single SQL JOIN,
+    not N+1). For each, calls `terminate_slices_for_workers` to release it.
+    Returns the list of slice_ids actually terminated (possibly empty).
+
+    Idempotent across cycles: a slice already terminated does not reappear
+    in `cordoned_idle_slices`. Concurrent termination races are safe: the
+    autoscaler's `scale_down_if_idle` skips cordoned slices via the explicit
+    guard, and if some other path races us into `detach_slice`, the loser
+    observes `_slices.pop` returning `None` and no-ops. Cloud termination
+    via the platform layer is idempotent.
+    """
+```
+
+## DB query changes
+
+`db.healthy_active_workers_with_attributes` ([`db.py`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cluster/controller/db.py)) gains one predicate:
+
+```python
+# BEFORE
+WHERE healthy = 1 AND active = 1
+
+# AFTER
+WHERE healthy = 1 AND active = 1 AND cordoned = 0
+```
+
+New query function added next to it:
+
+```python
+def cordoned_idle_slices(db: ControllerDb) -> list[SliceId]:
+    """Return slice_ids where every worker is cordoned AND no worker has
+    any in-flight task. Single query (joins `workers` with `task_attempts`
+    filtered on RUNNING/BUILDING/ASSIGNED states), not N+1.
+
+    By design, cordon propagates to all siblings, so "every worker cordoned"
+    and "any worker cordoned" coincide. Used exclusively by the reaper.
+    """
+```
+
+## Autoscaler routing change
+
+`routing.py` ([`routing.py:189-210`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cluster/controller/autoscaler/routing.py#L189-L210)) excludes cordoned READY slices from the ready-capacity total. Routing today computes `max_vms` from slice-state counts (REQUESTING + BOOTING + INITIALIZING + READY + headroom), not by enumerating workers. The change subtracts cordoned READY slices from the READY contribution:
+
+```python
+# Conceptual change in compute_max_vms:
+# READY contribution = (READY slices) - (READY slices fully cordoned)
+# REQUESTING, BOOTING, INITIALIZING contributions: unchanged. Cordon is only
+# valid for READY slices (workers don't exist as DB rows pre-READY), so other
+# states cannot be cordoned and need no exclusion logic.
+# Fully-cordoned READY slices are treated as "missing from the fleet" so the
+# autoscaler provisions a replacement when demand requires.
+```
+
+Partial cordon of a slice is structurally impossible (CordonWorker propagates to all siblings), so "fully-cordoned" and "any-cordoned" coincide.
+
+## Autoscaler scale-down guard
+
+`ScalingGroup.scale_down_if_idle` ([`scaling_group.py:835-890`](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py#L835-L890)) gets an explicit cordoned-slice skip near the top of its candidate-selection loop. Belt-and-suspenders: the existing predicate would not fire on cordoned slices anyway (they are excluded from `target_capacity`), but the guard makes the ownership boundary unambiguous and survives future refactors of the capacity-counting logic.
+
+## CLI
+
+In `lib/iris/src/iris/cli/cluster.py` (paralleling `restart-worker` at [line 1050](https://github.com/marin-community/marin/blob/9bec9c06b/lib/iris/src/iris/cli/cluster.py#L1050)):
+
+```
+iris rpc controller cordon-worker --json '{"worker_id": "<id>"}'
+iris rpc controller uncordon-worker --json '{"worker_id": "<id>"}'
+```
+
+Both follow the existing `client.<rpc_name>(proto_request)` pattern; no new CLI dispatch machinery needed. Output is the JSON-rendered response (including `cordoned_worker_ids` / `uncordoned_worker_ids` so the operator sees the slice expansion).
+
+`iris cluster status` is extended to show a `CORDONED` badge for cordoned workers in its tabular output. Implementation: one new column read from `WorkerRow.cordoned`.
+
+## Errors
+
+Errors are returned via the existing `accepted=false; error="..."` pattern (matching `RestartWorker`). The error string follows a known shape: a snake_case prefix optionally followed by `: <detail>`. CLIs match on the prefix.
+
+| Error string | Trigger |
+|--------------|---------|
+| `worker_not_found` | `worker_id` does not match a registered worker on a READY slice (typo, pre-READY worker, etc.). Raised by both RPCs. |
+| `worker_not_found: already_terminated` | Distinct shape returned by `UncordonWorker` only, when the worker existed but its slice has been reaper-terminated since cordon was set. Lets the CLI render "you raced the reaper" rather than "typo". |
+
+No new proto error enum. Idempotent success cases (already cordoned / already uncordoned) return `accepted=true` with the slice's full worker-id list.
+
+## OPS.md addition
+
+A new section in `lib/iris/OPS.md`, inserted after the existing "Task Operations" section. Exact text:
+
+````markdown
+## Recovering a wedged worker
+
+If a worker is reachable but should stop receiving new tasks (e.g. broken-but-running, pre-deploy maintenance, reserved-capacity in a known-bad state), use cordon. Existing in-flight tasks finish naturally; the slice is recycled and a replacement provisioned by the autoscaler.
+
+```
+# Identify the wedged worker
+iris cluster status                              # CORDONED column shows current cordon state
+
+# Cordon it (also cordons siblings on the same slice)
+iris rpc controller cordon-worker --json '{"worker_id":"<id>"}'
+
+# Confirm it stopped receiving new tasks; watch in-flight ones drain
+iris cluster tasks --worker-id <id>
+
+# To cancel before recycle:
+iris rpc controller uncordon-worker --json '{"worker_id":"<id>"}'
+```
+
+The slice is recycled automatically when every cordoned worker on it has zero in-flight tasks. Cordon is sticky across controller restarts. There is no timeout — a wedged task will keep its worker alive indefinitely; in that case fall back to `restart-worker` for hard recycle.
+````
+
+## File summary
+
+| Concern | File | Change |
+|---------|------|--------|
+| Proto | `lib/iris/src/iris/rpc/controller.proto` | Add `CordonWorker` + `UncordonWorker` RPCs and 4 messages |
+| Schema | `lib/iris/src/iris/cluster/controller/schema.py` | New `cordoned` and `cordoned_at` columns + index; matching `WorkerRow` fields; new migration |
+| DB queries | `lib/iris/src/iris/cluster/controller/db.py` | Filter cordoned in `healthy_active_workers_with_attributes`; add `cordoned_idle_slices` |
+| Service | `lib/iris/src/iris/cluster/controller/service.py` | Add `cordon_worker` and `uncordon_worker` handlers; both use existing `find_slice_for_worker` / `get_slice_worker_ids` for membership |
+| Autoscaler ops | `lib/iris/src/iris/cluster/controller/autoscaler/operations.py` | Add `reap_cordoned_idle_slices` |
+| Autoscaler routing | `lib/iris/src/iris/cluster/controller/autoscaler/routing.py` | Exclude cordoned slices from `max_vms` |
+| Autoscaler scale-down | `lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py` | Guard skipping cordoned slices in `scale_down_if_idle` |
+| Autoscaler runtime | `lib/iris/src/iris/cluster/controller/autoscaler/runtime.py` | Call `reap_cordoned_idle_slices` once per cycle |
+| CLI | `lib/iris/src/iris/cli/cluster.py` | Add `cordon-worker` / `uncordon-worker` subcommands; CORDONED badge in status |
+| Docs | `lib/iris/OPS.md` | Add "Recovering a wedged worker" section |
+
+## Out of scope
+
+- `DrainWorker` RPC (with timeout / forced-recycle fallback) — deferred; if cordoned-with-wedged-task becomes a recurring issue, file follow-up.
+- `CordonSlice(slice_id)` as primary verb — see Open Questions in `design.md`.
+- Cluster-wide / batch cordon (e.g. "cordon all workers in zone X").
+- In-task SIGTERM-style "wrap up" signaling.
+- Per-job disruption budgets (PDB analog).
+- Migrating `RestartWorker` to use cordon under the hood.


### PR DESCRIPTION
🤖 Design doc for [#5270](https://github.com/marin-community/marin/issues/5270): graceful worker recycling for Iris.

Today `RestartWorker` is the only manual worker-recycling primitive and it hard-kills in-flight tasks — surfaced during #5268 triage when 7 wedged CPU on-demand workers were running coordinator/parent jobs. This proposes adding **`CordonWorker` / `UncordonWorker`** RPCs: a sticky, slice-scoped eligibility flag that blocks new task assignment, plus a small autoscaler-cycle reaper that terminates cordoned slices once their last in-flight task completes. The autoscaler scales up replacements on its own, driven by unmet demand. Drain-with-timeout semantics are explicitly deferred.

- [design.md](https://github.com/marin-community/marin/blob/design/iris_worker_cordon/.agents/projects/iris_worker_cordon/design.md) — the 1-pager
- [spec.md](https://github.com/marin-community/marin/blob/design/iris_worker_cordon/.agents/projects/iris_worker_cordon/spec.md) — concrete contracts (proto, schema delta, signatures, file summary)
- [research.md](https://github.com/marin-community/marin/blob/design/iris_worker_cordon/.agents/projects/iris_worker_cordon/research.md) — in-repo refs, autoscaler hazard analysis, K8s/Nomad/Slurm prior art

Discussion welcome — see Open Questions in `design.md`.