### PR TITLE
RFC: Served Model Eval Handoff

### DIFF
--- a/.agents/projects/served_lm_eval.md
+++ b/.agents/projects/served_lm_eval.md
@@ -1,0 +1,229 @@
+# RFC: Served LM Eval
+
+## Goal
+
+This RFC is a small step toward running more Marin evaluations against served
+models, instead of requiring every evaluator to work with an in-process model
+object. It is not the full inference-service plan. The goal here is to define
+the handoff object between model-serving code and eval code.
+
+That boundary should keep eval runners focused on eval frameworks, while
+letting serving code deal with vLLM, Iris, Fray, Docker, TPUs, auth, and
+cleanup. `lm_eval` is the first consumer, but the useful abstraction is the
+generic `RunningModel`: a model that has already been launched or connected to,
+and can now be evaluated.
+
+Related context:
+
+- [archived inference-service drafts](https://github.com/marin-community/marin/tree/archive/served-lm-eval-rfcs/.agents/projects/inference-service)
+  are background only. They are not part of this review and should not be
+  treated as the current spec.
+
+## Proposal
+
+Split served-model evals into two pieces.
+
+Launchers own serving. A launcher can start or connect to vLLM, run through
+Iris or Fray, choose native or Docker mode, set up auth, manage package
+versions, allocate resources, collect diagnostics, and clean up. Once all of
+that is ready, it returns a `RunningModel`.
+
+The eval runner owns `lm_eval`. It receives a `RunningModel`, turns it into the
+right `lm_eval` adapter name and model args, calls
+`lm_eval.evaluator.simple_evaluate`, and writes results with
+`EvaluationTracker`.
+
+In production, the shape should look like this:
+
+```python
+deployment = ModelDeployment(
+    model_name="llama-200m",
+    model_path="gs://...",
+    tokenizer="gs://...",
+)
+
+with launcher.launch(deployment) as running_model:
+    run_lm_eval(
+        running_model,
+        LmEvalRun(tasks=["arc_easy"], output_path="..."),
+    )
+```
+
+Concrete launchers, such as a future Iris/vLLM launcher, implement
+`ModelLauncher`. Eval code should not instantiate vLLM, Iris, or Fray objects
+directly.
+
+Core contract:
+
+```python
+@dataclass(frozen=True)
+class OpenAIEndpoint:
+    base_url: str  # API root, e.g. http://127.0.0.1:8000/v1
+    model: str
+    api_key: str | None = None
+
+    def url(self, path: str) -> str:
+        return f"{self.base_url.rstrip('/')}/{path.lstrip('/')}"
+
+
+@dataclass(frozen=True)
+class RunningModel:
+    endpoint: OpenAIEndpoint
+    tokenizer: str | None = None
+
+
+@dataclass(frozen=True)
+class ModelDeployment:
+    model_name: str
+    model_path: str
+    tokenizer: str | None = None
+    engine_kwargs: Mapping[str, object] = field(default_factory=dict)
+
+
+class ModelLauncher(Protocol):
+    def launch(self, deployment: ModelDeployment) -> AbstractContextManager[RunningModel]:
+        ...
+
+
+class LmEvalAdapter(StrEnum):
+    LOCAL_COMPLETIONS = "local-completions"
+    LOCAL_CHAT_COMPLETIONS = "local-chat-completions"
+
+
+@dataclass(frozen=True)
+class LmEvalRun:
+    tasks: Sequence[str]
+    output_path: str
+    adapter: LmEvalAdapter = LmEvalAdapter.LOCAL_COMPLETIONS
+    apply_chat_template: bool = False
+    limit: int | None = None
+    num_fewshot: int | None = None
+    batch_size: int | str | None = None
+    extra_model_args: Mapping[str, str | int | float | bool] = field(default_factory=dict)
+
+
+def run_lm_eval(model: RunningModel, run: LmEvalRun) -> None:
+    ...
+```
+
+`OpenAIEndpoint.base_url` is the API root. The runner derives the endpoint that
+`lm_eval` expects:
+
+- `local-completions` gets `base_url={endpoint.base_url}/completions`.
+- `local-chat-completions` gets
+  `base_url={endpoint.base_url}/chat/completions`.
+
+`OpenAIEndpoint.model` is the server-side served-model id that clients should
+send in OpenAI-compatible requests. It is not meant to be a human display name.
+Launchers should choose a stable id that the backing server accepts.
+
+`RunningModel.tokenizer` is the tokenizer staging handoff. If the checkpoint
+needs a local tokenizer path or a Hugging Face tokenizer id, the launcher is
+responsible for resolving that before it yields `RunningModel`; eval runners
+only consume the resulting string.
+
+Default model args are `model`, `base_url`, `tokenizer_backend=huggingface`,
+and `tokenized_requests=False`. `api_key` and `tokenizer` are included only
+when present. `extra_model_args` is applied last so callers can override these
+defaults when needed.
+
+`LmEvalRun.output_path` is an output directory. With today's
+`EvaluationTracker`, results land under
+`<output_path>/<model_name_sanitized>/results_<date>.json`, with samples in
+`samples_<task>_<date>.jsonl`.
+
+## lm-eval Adapter Contract
+
+The runner should match the OpenAI adapter shape that `lm_eval` actually uses.
+For text scoring, `local-completions` wants the endpoint-specific URL, not the
+`/v1` API root. It also needs tokenizer information for context length
+calculation, even when the HTTP request itself uses string prompts.
+
+The tested scoring path sends `max_tokens=1`, not `max_tokens=0`, and it does
+not require `stop`. Prompt-logprob responses need echoed prompt tokens plus one
+generated token, because `lm_eval` scores the `token_logprobs[ctxlen:-1]`
+slice.
+
+Observed scoring request:
+
+```json
+{
+  "model": "gpt2",
+  "prompt": "A B",
+  "temperature": 0,
+  "max_tokens": 1,
+  "logprobs": 1,
+  "seed": 1234,
+  "echo": true
+}
+```
+
+## vLLM Stance
+
+Real vLLM should remain a manual validation step for this RFC. Validation so
+far showed native TPU vLLM generation on Iris through both generation routes:
+
+- `/v1/chat/completions`
+- `/v1/completions`
+
+The representative `lm_eval` prompt-logprob path did not pass. vLLM reached
+readiness, then the first `/v1/completions` loglikelihood request returned HTTP
+500:
+
+```json
+{"error":{"message":"14924","type":"Internal Server Error","param":null,"code":500}}
+```
+
+So this served lm-eval boundary should not claim that served vLLM supports
+MCQ/loglikelihood evals. Generation compatibility is useful, but it is not the
+same contract as
+`lm_eval` scoring compatibility. This RFC leaves the existing Levanter-backed
+path as the supported route for MCQ/loglikelihood evals.
+
+## Tests
+
+Use a focused test with real `lm_eval` and a deterministic fake
+OpenAI-compatible server to catch adapter-contract drift. The test should run a
+tiny `loglikelihood` task through `local-completions`, then check the request
+payload and `EvaluationTracker` output layout.
+
+Manual validation should separately run real vLLM generation smokes through
+Iris, with pinned and logged native vLLM TPU packages.
+
+## Non-Goals
+
+- legacy evaluator call-site migration;
+- Harbor, Evalchemy, raw perplexity, long-tail perplexity, FineWeb2, or
+  perplexity-gap work;
+- Levanter parity or Iris inference-service implementation;
+- served vLLM MCQ/loglikelihood scoring.
+
+## Follow-Up Work
+
+The next steps should stay separate from this RFC so the first PR remains a
+small interface brick.
+
+- Levanter OpenAI HTTP parity: make Levanter's `/v1/completions` response
+  satisfy the real `lm_eval local-completions` prompt-logprob contract,
+  including echoed prompt-token logprobs.
+- Iris served-model launcher: build an Iris-facing launcher that returns
+  `RunningModel` and owns tokenizer staging, endpoint discovery, auth setup,
+  and context-manager cleanup.
+- vLLM scoring: track prompt-logprob support separately. Until that passes,
+  served vLLM should be treated as generation-compatible but not as a
+  MCQ/loglikelihood backend.
+- Additional eval frameworks: add Harbor and Evalchemy adapters as
+  framework-specific consumers of `RunningModel`, without moving their config
+  concepts into the generic served-model boundary.
+- Results: decide whether Marin should expose raw `EvaluationTracker` layout
+  or add a normalized result artifact.
+- Conformance tests: promote reusable OpenAI subset assertions once Levanter
+  and vLLM contract work has stabilized.
+
+## Pressure-Test Result
+
+Follow-up probing exercised this boundary against Levanter's OpenAI request
+schemas, a fake Iris launcher, and Harbor's hosted-vLLM config shape. It did
+not find a reason to add fields beyond `base_url`, `model`, `api_key`, and
+`tokenizer`. In particular, typed request headers and Harbor-style `model_info`
+should stay out of `RunningModel` until a real consumer needs them.

--- a/lib/levanter/src/levanter/inference/openai.py
+++ b/lib/levanter/src/levanter/inference/openai.py
@@ -18,7 +18,7 @@ import threading
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import Dict, List, Literal, Optional, Union
+from typing import List, Optional, Union
 
 import haliax as hax
 import jax.numpy as jnp
@@ -33,98 +33,21 @@ from openai.types.chat.chat_completion import ChoiceLogprobs
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
 from openai.types.chat.chat_completion_token_logprob import ChatCompletionTokenLogprob
 from openai.types.completion_choice import CompletionChoice, Logprobs
-from pydantic import BaseModel, Field
 from levanter.inference.engine import InferenceEngine, InferenceEngineConfig, Request
 from levanter.inference.jit_scheduler import SeqDecodingParams
+from levanter.inference.openai_protocol import (
+    ChatCompletionRequest,
+    ChatMessage,
+    CompletionRequest,
+    TokenList,
+    TokensRequest,
+    TokensResponse,
+)
 from levanter.models.lm_model import LmHeadModel
 from levanter.tokenizers import MarinTokenizer
 from levanter.trainer import TrainerConfig
 
 logger = logging.getLogger(__name__)
-
-
-# OpenAI requests are all defined as TypedDicts, which FastAPI struggles to
-# encode in a useful way. Since we control this half of the API, we'll define
-# our own equivalent Pydantic models here.
-
-
-class ChatMessage(BaseModel):
-    """A single chat message in the conversation."""
-
-    role: Literal["system", "user", "assistant", "tool", "function", "developer"]
-    content: Optional[str] = None
-    name: Optional[str] = None
-    tool_calls: Optional[List[Dict]] = None
-    tool_call_id: Optional[str] = None
-    function_call: Optional[Dict] = None
-
-
-class ChatCompletionRequest(BaseModel):
-    """Request model for chat completions endpoint."""
-
-    model: str
-    messages: List[ChatMessage]
-    frequency_penalty: Optional[float] = None
-    logit_bias: Optional[Dict[str, int]] = None
-    logprobs: bool = Field(default=False, description="Whether to include logprobs in the response")
-    top_logprobs: Optional[int] = None
-    max_tokens: int = Field(default=1024, description="Maximum number of tokens to generate")
-    n: Optional[int] = None
-    presence_penalty: Optional[float] = None
-    response_format: Optional[Dict] = None
-    seed: Optional[int] = None
-    service_tier: Optional[str] = None
-    stop: Optional[Union[str, List[str]]] = None
-    stream: Optional[bool] = None
-    stream_options: Optional[Dict] = None
-    temperature: float = Field(default=1.0, description="Sampling temperature")
-    top_p: Optional[float] = None
-    tools: Optional[List[Dict]] = None
-    tool_choice: Optional[Union[str, Dict]] = None
-    parallel_tool_calls: Optional[bool] = None
-    user: Optional[str] = None
-
-
-class CompletionRequest(BaseModel):
-    """Request model for text completions endpoint."""
-
-    model: str
-    prompt: Union[str, List[str]]
-    best_of: Optional[int] = None
-    echo: Optional[bool] = None
-    frequency_penalty: Optional[float] = None
-    logit_bias: Optional[Dict[str, int]] = None
-    logprobs: Optional[int] = None
-    max_tokens: int = Field(default=1024, description="Maximum number of tokens to generate")
-    n: Optional[int] = None
-    presence_penalty: Optional[float] = None
-    seed: Optional[int] = None
-    stop: Optional[Union[str, List[str]]] = None
-    stream: Optional[bool] = None
-    stream_options: Optional[Dict] = None
-    suffix: Optional[str] = None
-    temperature: float = Field(default=1.0, description="Sampling temperature")
-    top_p: Optional[float] = None
-    user: Optional[str] = None
-
-
-class TokensRequest(BaseModel):
-    """Request tokens from the given prompts after system prompt injection and encoding."""
-
-    model: str = "marin-default"
-    message_list: list[list[ChatMessage]]  # List of messages dicts representing prompts
-
-
-class TokenList(BaseModel):
-    """List of token IDs."""
-
-    tokens: list[int]
-
-
-class TokensResponse(BaseModel):
-    """Response containing tokenized prompts."""
-
-    results: list[TokenList]
 
 
 @dataclass

--- a/lib/levanter/src/levanter/inference/openai_protocol.py
+++ b/lib/levanter/src/levanter/inference/openai_protocol.py
@@ -1,0 +1,87 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lightweight OpenAI-compatible protocol models shared by servers and tests."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class ChatMessage(BaseModel):
+    """A single chat message in the conversation."""
+
+    role: Literal["system", "user", "assistant", "tool", "function", "developer"]
+    content: str | None = None
+    name: str | None = None
+    tool_calls: list[dict[str, object]] | None = None
+    tool_call_id: str | None = None
+    function_call: dict[str, object] | None = None
+
+
+class ChatCompletionRequest(BaseModel):
+    """Request model for chat completions endpoint."""
+
+    model: str
+    messages: list[ChatMessage]
+    frequency_penalty: float | None = None
+    logit_bias: dict[str, int] | None = None
+    logprobs: bool = Field(default=False, description="Whether to include logprobs in the response")
+    top_logprobs: int | None = None
+    max_tokens: int = Field(default=1024, description="Maximum number of tokens to generate")
+    n: int | None = None
+    presence_penalty: float | None = None
+    response_format: dict[str, object] | None = None
+    seed: int | None = None
+    service_tier: str | None = None
+    stop: str | list[str] | None = None
+    stream: bool | None = None
+    stream_options: dict[str, object] | None = None
+    temperature: float = Field(default=1.0, description="Sampling temperature")
+    top_p: float | None = None
+    tools: list[dict[str, object]] | None = None
+    tool_choice: str | dict[str, object] | None = None
+    parallel_tool_calls: bool | None = None
+    user: str | None = None
+
+
+class CompletionRequest(BaseModel):
+    """Request model for text completions endpoint."""
+
+    model: str
+    prompt: str | list[str]
+    best_of: int | None = None
+    echo: bool | None = None
+    frequency_penalty: float | None = None
+    logit_bias: dict[str, int] | None = None
+    logprobs: int | None = None
+    max_tokens: int = Field(default=1024, description="Maximum number of tokens to generate")
+    n: int | None = None
+    presence_penalty: float | None = None
+    seed: int | None = None
+    stop: str | list[str] | None = None
+    stream: bool | None = None
+    stream_options: dict[str, object] | None = None
+    suffix: str | None = None
+    temperature: float = Field(default=1.0, description="Sampling temperature")
+    top_p: float | None = None
+    user: str | None = None
+
+
+class TokensRequest(BaseModel):
+    """Request tokens from the given prompts after system prompt injection and encoding."""
+
+    model: str = "marin-default"
+    message_list: list[list[ChatMessage]]
+
+
+class TokenList(BaseModel):
+    """List of token IDs."""
+
+    tokens: list[int]
+
+
+class TokensResponse(BaseModel):
+    """Response containing tokenized prompts."""
+
+    results: list[TokenList]

--- a/lib/marin/src/marin/evaluation/served_lm_eval.py
+++ b/lib/marin/src/marin/evaluation/served_lm_eval.py
@@ -1,0 +1,106 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+from marin.inference.served_model import RunningModel
+
+LmEvalModelArgValue = str | int | float | bool
+
+
+class LmEvalAdapter(StrEnum):
+    """lm-eval OpenAI-compatible adapter names supported by the served runner."""
+
+    LOCAL_COMPLETIONS = "local-completions"
+    LOCAL_CHAT_COMPLETIONS = "local-chat-completions"
+
+    @property
+    def endpoint_path(self) -> str:
+        match self:
+            case LmEvalAdapter.LOCAL_COMPLETIONS:
+                return "completions"
+            case LmEvalAdapter.LOCAL_CHAT_COMPLETIONS:
+                return "chat/completions"
+
+
+@dataclass(frozen=True)
+class LmEvalRun:
+    """A single lm-eval run against an already served model."""
+
+    tasks: Sequence[str]
+    output_path: str
+    adapter: LmEvalAdapter = LmEvalAdapter.LOCAL_COMPLETIONS
+    apply_chat_template: bool = False
+    limit: int | None = None
+    num_fewshot: int | None = None
+    batch_size: int | str | None = None
+    extra_model_args: Mapping[str, LmEvalModelArgValue] = field(default_factory=dict)
+
+
+def run_lm_eval(model: RunningModel, run: LmEvalRun) -> None:
+    """Run lm-eval against a launcher-neutral served model."""
+    if not run.tasks:
+        raise ValueError("LmEvalRun.tasks must contain at least one task.")
+
+    from lm_eval.evaluator import simple_evaluate
+    from lm_eval.loggers import EvaluationTracker
+
+    evaluation_tracker = EvaluationTracker(output_path=run.output_path)
+    results = simple_evaluate(
+        model=run.adapter.value,
+        tasks=list(run.tasks),
+        num_fewshot=run.num_fewshot,
+        model_args=build_lm_eval_model_args(model, run),
+        apply_chat_template=run.apply_chat_template,
+        batch_size=run.batch_size,
+        confirm_run_unsafe_code=True,
+        limit=run.limit,
+        evaluation_tracker=evaluation_tracker,
+        log_samples=True,
+    )
+    if results is None:
+        raise RuntimeError("lm-eval returned no results.")
+
+    samples = results.pop("samples")
+    evaluation_tracker.save_results_aggregated(results=results, samples=samples)
+    for task_name in results["configs"].keys():
+        evaluation_tracker.save_results_samples(task_name=task_name, samples=samples[task_name])
+
+
+def build_lm_eval_model_args(model: RunningModel, run: LmEvalRun) -> str:
+    """Build the comma-delimited model_args string consumed by lm-eval API models."""
+    model_args: dict[str, object] = {
+        "model": model.endpoint.model,
+        "base_url": _lm_eval_base_url(model, run),
+        "tokenizer_backend": "huggingface",
+        "tokenized_requests": False,
+    }
+    if model.endpoint.api_key is not None:
+        model_args["api_key"] = model.endpoint.api_key
+    if model.tokenizer is not None:
+        model_args["tokenizer"] = model.tokenizer
+    model_args.update(run.extra_model_args)
+    return ",".join(
+        f"{_format_model_arg_key(key)}={_format_model_arg_value(value)}" for key, value in model_args.items()
+    )
+
+
+def _lm_eval_base_url(model: RunningModel, run: LmEvalRun) -> str:
+    return model.endpoint.url(run.adapter.endpoint_path)
+
+
+def _format_model_arg_key(key: str) -> str:
+    if not key:
+        raise ValueError("lm-eval model_args keys must be non-empty.")
+    if "," in key or "=" in key:
+        raise ValueError(f"lm-eval model_args key cannot contain ',' or '=': {key!r}")
+    return key
+
+
+def _format_model_arg_value(value: object) -> str:
+    text = str(value)
+    if "," in text:
+        raise ValueError(f"lm-eval model_args value cannot contain ',': {text!r}")
+    return text

--- a/lib/marin/src/marin/inference/served_model.py
+++ b/lib/marin/src/marin/inference/served_model.py
@@ -1,0 +1,46 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Mapping
+from contextlib import AbstractContextManager
+from dataclasses import dataclass, field
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class OpenAIEndpoint:
+    """OpenAI-compatible HTTP endpoint for a served model."""
+
+    base_url: str
+    model: str
+    api_key: str | None = None
+
+    def url(self, path: str) -> str:
+        """Return an endpoint URL under the API root."""
+        return f"{self.base_url.rstrip('/')}/{path.lstrip('/')}"
+
+
+@dataclass(frozen=True)
+class RunningModel:
+    """A model that is already being served by a launcher-owned backend."""
+
+    endpoint: OpenAIEndpoint
+    tokenizer: str | None = None
+
+
+@dataclass(frozen=True)
+class ModelDeployment:
+    """Configuration needed by a launcher to serve a model artifact."""
+
+    model_name: str
+    model_path: str
+    tokenizer: str | None = None
+    engine_kwargs: Mapping[str, object] = field(default_factory=dict)
+
+
+class ModelLauncher(Protocol):
+    """Launch a model and own its serving lifecycle."""
+
+    def launch(self, deployment: ModelDeployment) -> AbstractContextManager[RunningModel]:
+        """Return a context manager that yields a running served model."""
+        ...

--- a/tests/evals/openai_stub.py
+++ b/tests/evals/openai_stub.py
@@ -1,0 +1,239 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import cast
+
+import requests
+from levanter.inference.openai_protocol import ChatCompletionRequest, CompletionRequest
+from pydantic import ValidationError
+
+
+@dataclass(frozen=True)
+class OpenAIStubRequest:
+    path: str
+    payload: dict[str, object]
+
+
+@dataclass
+class OpenAIStubState:
+    requests: list[OpenAIStubRequest] = field(default_factory=list)
+
+
+@dataclass
+class DeterministicOpenAIStub:
+    base_url: str
+    model: str
+    state: OpenAIStubState
+
+    def requests_for(self, path: str) -> list[OpenAIStubRequest]:
+        return [request for request in self.state.requests if request.path == path]
+
+
+class _DeterministicOpenAIServer(ThreadingHTTPServer):
+    model: str
+    state: OpenAIStubState
+
+
+class _DeterministicOpenAIHandler(BaseHTTPRequestHandler):
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        pass
+
+    def do_GET(self) -> None:
+        if self.path != "/v1/models":
+            self._write_json(404, {"error": "not found"})
+            return
+        self._write_json(200, {"object": "list", "data": [{"id": self._stub_server.model, "object": "model"}]})
+
+    def do_POST(self) -> None:
+        payload = self._read_json()
+        if self.path == "/v1/completions":
+            self._handle_completions(payload)
+            return
+        if self.path == "/v1/chat/completions":
+            self._handle_chat_completions(payload)
+            return
+        self._write_json(404, {"error": "not found"})
+
+    @property
+    def _stub_server(self) -> _DeterministicOpenAIServer:
+        return cast(_DeterministicOpenAIServer, self.server)
+
+    def _handle_completions(self, payload: dict[str, object]) -> None:
+        self._stub_server.state.requests.append(OpenAIStubRequest(path=self.path, payload=payload))
+        try:
+            request = CompletionRequest.model_validate(payload)
+        except ValidationError as exc:
+            self._write_json(400, {"error": str(exc)})
+            return
+        if request.model != self._stub_server.model:
+            self._write_json(400, {"error": "wrong model"})
+            return
+
+        prompt = request.prompt
+        if not isinstance(prompt, str):
+            self._write_json(400, {"error": "prompt must be a string"})
+            return
+        if request.echo is not True or request.logprobs is None:
+            self._write_json(400, {"error": "scoring requests must set echo=true and logprobs"})
+            return
+        text = prompt
+        if request.max_tokens > 0:
+            text += " answer"
+        tokens, offsets = _tokenize_with_offsets(text)
+        token_logprobs = [_token_logprob(token) for token in tokens]
+        self._write_json(
+            200,
+            {
+                "id": "cmpl-stub",
+                "object": "text_completion",
+                "model": self._stub_server.model,
+                "choices": [
+                    {
+                        "text": text,
+                        "index": 0,
+                        "logprobs": {
+                            "tokens": tokens,
+                            "token_logprobs": token_logprobs,
+                            "top_logprobs": [
+                                {token: score} for token, score in zip(tokens, token_logprobs, strict=True)
+                            ],
+                            "text_offset": offsets,
+                        },
+                        "finish_reason": "length",
+                    }
+                ],
+            },
+        )
+
+    def _handle_chat_completions(self, payload: dict[str, object]) -> None:
+        self._stub_server.state.requests.append(OpenAIStubRequest(path=self.path, payload=payload))
+        try:
+            request = ChatCompletionRequest.model_validate(payload)
+        except ValidationError as exc:
+            self._write_json(400, {"error": str(exc)})
+            return
+        if request.model != self._stub_server.model:
+            self._write_json(400, {"error": "wrong model"})
+            return
+        self._write_json(
+            200,
+            {
+                "id": "chatcmpl-stub",
+                "object": "chat.completion",
+                "model": self._stub_server.model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "stub response"},
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+        )
+
+    def _read_json(self) -> dict[str, object]:
+        content_length = int(self.headers["Content-Length"])
+        return json.loads(self.rfile.read(content_length))
+
+    def _write_json(self, status: int, payload: dict[str, object]) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@contextmanager
+def serve_deterministic_openai_stub(
+    *,
+    model: str = "gpt2",
+) -> Iterator[DeterministicOpenAIStub]:
+    state = OpenAIStubState()
+    server = _DeterministicOpenAIServer(("127.0.0.1", 0), _DeterministicOpenAIHandler)
+    server.model = model
+    server.state = state
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        yield DeterministicOpenAIStub(base_url=f"http://127.0.0.1:{server.server_port}/v1", model=model, state=state)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def assert_completions_scoring_contract(base_url: str, model: str) -> None:
+    response = requests.post(
+        f"{base_url}/completions",
+        json={
+            "model": model,
+            "prompt": "Marin eval",
+            "max_tokens": 1,
+            "temperature": 0,
+            "seed": 1,
+            "echo": True,
+            "logprobs": 1,
+        },
+        timeout=5,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    choice = payload["choices"][0]
+    assert choice["text"] == "Marin eval answer"
+    assert choice["index"] == 0
+    assert choice["logprobs"]["tokens"] == ["Marin", " eval", " answer"]
+    assert choice["logprobs"]["token_logprobs"] == [-0.0, -0.1, -0.3]
+    assert choice["logprobs"]["top_logprobs"] == [{"Marin": -0.0}, {" eval": -0.1}, {" answer": -0.3}]
+    assert choice["logprobs"]["text_offset"] == [0, 5, 10]
+
+
+def assert_chat_generation_contract(base_url: str, model: str) -> None:
+    response = requests.post(
+        f"{base_url}/chat/completions",
+        json={
+            "model": model,
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 4,
+            "temperature": 0,
+            "stop": None,
+            "seed": 1,
+        },
+        timeout=5,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    choice = payload["choices"][0]
+    assert choice["index"] == 0
+    assert choice["message"]["content"] == "stub response"
+
+
+def _tokenize_with_offsets(text: str) -> tuple[list[str], list[int]]:
+    if not text:
+        return [], []
+    pieces = text.split(" ")
+    tokens = [pieces[0], *[f" {piece}" for piece in pieces[1:]]]
+    offsets: list[int] = []
+    offset = 0
+    for token in tokens:
+        offsets.append(offset)
+        offset += len(token)
+    return tokens, offsets
+
+
+def _token_logprob(token: str) -> float:
+    if token == " B":
+        return -0.1
+    if token == " C":
+        return -2.0
+    if token == " eval":
+        return -0.1
+    if token == " answer":
+        return -0.3
+    return -0.0

--- a/tests/evals/test_served_lm_eval.py
+++ b/tests/evals/test_served_lm_eval.py
@@ -1,0 +1,207 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Iterator
+from pathlib import Path
+from statistics import mean
+
+import pytest
+
+from marin.evaluation.served_lm_eval import LmEvalAdapter, LmEvalRun, build_lm_eval_model_args
+from marin.inference.served_model import OpenAIEndpoint, RunningModel
+from tests.evals.openai_stub import (
+    DeterministicOpenAIStub,
+    assert_chat_generation_contract,
+    assert_completions_scoring_contract,
+    serve_deterministic_openai_stub,
+)
+
+
+@pytest.fixture
+def deterministic_openai_stub() -> Iterator[DeterministicOpenAIStub]:
+    with serve_deterministic_openai_stub(model="gpt2") as stub:
+        yield stub
+
+
+def test_lm_eval_model_args_selects_completions_endpoint() -> None:
+    running_model = RunningModel(
+        endpoint=OpenAIEndpoint(base_url="http://127.0.0.1:8000/v1", model="served-model", api_key="test-key"),
+        tokenizer="hf-tokenizer",
+    )
+    run = LmEvalRun(
+        tasks=["arc_easy"],
+        output_path="out",
+        extra_model_args={"num_concurrent": 2, "timeout": 30},
+    )
+
+    assert build_lm_eval_model_args(running_model, run) == (
+        "model=served-model,"
+        "base_url=http://127.0.0.1:8000/v1/completions,"
+        "tokenizer_backend=huggingface,"
+        "tokenized_requests=False,"
+        "api_key=test-key,"
+        "tokenizer=hf-tokenizer,"
+        "num_concurrent=2,"
+        "timeout=30"
+    )
+
+
+def test_lm_eval_model_args_selects_chat_endpoint() -> None:
+    running_model = RunningModel(endpoint=OpenAIEndpoint(base_url="http://127.0.0.1:8000/v1/", model="served-model"))
+    run = LmEvalRun(
+        tasks=["ifeval"],
+        output_path="out",
+        adapter=LmEvalAdapter.LOCAL_CHAT_COMPLETIONS,
+        apply_chat_template=True,
+    )
+
+    assert build_lm_eval_model_args(running_model, run).startswith(
+        "model=served-model,base_url=http://127.0.0.1:8000/v1/chat/completions,"
+    )
+
+
+def test_lm_eval_model_args_allow_explicit_overrides() -> None:
+    running_model = RunningModel(endpoint=OpenAIEndpoint(base_url="http://127.0.0.1:8000/v1", model="gpt2"))
+    run = LmEvalRun(
+        tasks=["arc_easy"],
+        output_path="out",
+        extra_model_args={"tokenizer_backend": "tiktoken", "tokenized_requests": False, "timeout": 5},
+    )
+
+    assert build_lm_eval_model_args(running_model, run) == (
+        "model=gpt2,"
+        "base_url=http://127.0.0.1:8000/v1/completions,"
+        "tokenizer_backend=tiktoken,"
+        "tokenized_requests=False,"
+        "timeout=5"
+    )
+
+
+def test_marin_openai_subset_conformance_against_deterministic_stub(
+    deterministic_openai_stub: DeterministicOpenAIStub,
+) -> None:
+    assert_completions_scoring_contract(deterministic_openai_stub.base_url, deterministic_openai_stub.model)
+    assert_chat_generation_contract(deterministic_openai_stub.base_url, deterministic_openai_stub.model)
+
+
+def test_real_lm_eval_local_completions_scoring_against_deterministic_stub(
+    deterministic_openai_stub: DeterministicOpenAIStub, tmp_path: Path
+) -> None:
+    pytest.importorskip("torch")
+    pytest.importorskip("tiktoken")
+    pytest.importorskip("lm_eval")
+
+    from lm_eval.api.instance import Instance
+    from lm_eval.api.task import Task, TaskConfig
+    from lm_eval.evaluator import simple_evaluate
+    from lm_eval.loggers import EvaluationTracker
+
+    class TinyScoringTask(Task):
+        OUTPUT_TYPE = "loglikelihood"
+
+        def __init__(self) -> None:
+            super().__init__()
+            self._config = TaskConfig(
+                task="marin_tiny_scoring",
+                output_type="loglikelihood",
+                num_fewshot=0,
+                repeats=1,
+            )
+            self.task_name = "marin_tiny_scoring"
+
+        def download(self, data_dir=None, cache_dir=None, download_mode=None) -> None:
+            self.dataset = {"test": [{"ctx": "A", "target": " B"}]}
+
+        def has_training_docs(self) -> bool:
+            return False
+
+        def has_validation_docs(self) -> bool:
+            return False
+
+        def has_test_docs(self) -> bool:
+            return True
+
+        def test_docs(self) -> list[dict[str, str]]:
+            return self.dataset["test"]
+
+        def doc_to_text(self, doc: dict[str, str]) -> str:
+            return doc["ctx"]
+
+        def doc_to_target(self, doc: dict[str, str]) -> str:
+            return doc["target"]
+
+        def construct_requests(self, doc: dict[str, str], ctx: str, **kwargs: object) -> Instance:
+            return Instance(
+                request_type="loglikelihood",
+                doc=doc,
+                arguments=(ctx, self.doc_to_target(doc)),
+                idx=0,
+                metadata=kwargs["metadata"],
+            )
+
+        def process_results(self, doc: dict[str, str], results: list[tuple[float, bool]]) -> dict[str, float]:
+            loglikelihood, is_greedy = results[0]
+            return {"loglikelihood": loglikelihood, "greedy": float(is_greedy)}
+
+        def aggregation(self) -> dict[str, object]:
+            return {"loglikelihood": mean, "greedy": mean}
+
+        def higher_is_better(self) -> dict[str, bool]:
+            return {"loglikelihood": True, "greedy": True}
+
+    task = TinyScoringTask()
+    running_model = RunningModel(endpoint=OpenAIEndpoint(base_url=deterministic_openai_stub.base_url, model="gpt2"))
+    run = LmEvalRun(
+        tasks=["marin_tiny_scoring"],
+        output_path=str(tmp_path / "lm_eval_results"),
+        extra_model_args={
+            "tokenizer_backend": "tiktoken",
+            "tokenized_requests": False,
+            "max_retries": 1,
+            "timeout": 5,
+        },
+    )
+    evaluation_tracker = EvaluationTracker(output_path=run.output_path)
+
+    results = simple_evaluate(
+        model="local-completions",
+        tasks=[task],
+        model_args=build_lm_eval_model_args(running_model, run),
+        batch_size=1,
+        bootstrap_iters=0,
+        evaluation_tracker=evaluation_tracker,
+        log_samples=True,
+        random_seed=0,
+        numpy_random_seed=0,
+        torch_random_seed=0,
+        fewshot_random_seed=0,
+    )
+    assert results is not None
+    samples = results.pop("samples")
+    evaluation_tracker.save_results_aggregated(results=results, samples=samples)
+    for task_name in results["configs"].keys():
+        evaluation_tracker.save_results_samples(task_name=task_name, samples=samples[task_name])
+
+    completion_requests = deterministic_openai_stub.requests_for("/v1/completions")
+    assert len(completion_requests) == 1
+    payload = completion_requests[0].payload
+    assert payload == {
+        "model": "gpt2",
+        "prompt": "A B",
+        "temperature": 0,
+        "max_tokens": 1,
+        "logprobs": 1,
+        "seed": 1234,
+        "echo": True,
+    }
+    assert "stop" not in payload
+
+    assert results["results"]["marin_tiny_scoring"]["loglikelihood,none"] == pytest.approx(-0.1)
+    assert results["results"]["marin_tiny_scoring"]["greedy,none"] == 1.0
+
+    result_dirs = list((tmp_path / "lm_eval_results").glob("gpt2"))
+    assert len(result_dirs) == 1
+    result_files = list(result_dirs[0].glob("results_*.json"))
+    sample_files = list(result_dirs[0].glob("samples_marin_tiny_scoring_*.jsonl"))
+    assert len(result_files) == 1
+    assert len(sample_files) == 1


### PR DESCRIPTION
This PR introduces the handoff object between model-serving code and eval code.

Launchers instantiate or connect to the model and return a `RunningModel`. Eval runners consume that `RunningModel` and translate it into framework-specific args. `lm_eval` is the first implementation of that pattern.

```text
ModelDeployment -> ModelLauncher -> RunningModel -> eval adapter
```

## What Is Included

- A short design doc: `.agents/projects/served_lm_eval.md`
- Generic served-model types: `OpenAIEndpoint`, `RunningModel`, `ModelDeployment`, and `ModelLauncher`
- The `lm_eval` runner boundary: `LmEvalAdapter`, `LmEvalRun`, `build_lm_eval_model_args`, and `run_lm_eval`
- Shared Levanter OpenAI request schemas, reused by both Levanter serving code and the deterministic test server
- Focused tests using real `lm_eval` against a deterministic OpenAI-compatible HTTP server

## How This Is Instantiated

The intended production shape is:

```python
deployment = ModelDeployment(
    model_name="llama-200m",
    model_path="gs://...",
    tokenizer="gs://...",
)

with launcher.launch(deployment) as running_model:
    run_lm_eval(
        running_model,
        LmEvalRun(tasks=["arc_easy"], output_path="..."),
    )
```

Concrete launchers, such as a future Iris/vLLM launcher, implement `ModelLauncher`. Eval code should not instantiate vLLM, Iris, or Fray objects directly.

## What Is Deliberately Left Out

- vLLM runtime/package changes
- manual Iris or vLLM smoke-test CLI code
- legacy evaluator call-site migration
- production Harbor/Evalchemy adapters

## What Follow-Up Probing Found

Follow-up probing exercised this boundary against Levanter request schemas, a fake Iris launcher, and Harbor hosted-vLLM config derivation. The conclusions are reflected in the design doc.

The main result: the boundary held up. There was no evidence that `RunningModel` needs fields beyond `base_url`, `model`, `api_key`, and `tokenizer`.

Concretely:

- tokenizer staging should stay launcher-owned and flow through `RunningModel.tokenizer`
- `OpenAIEndpoint.model` should be treated as the server-side served-model id
- `api_key` is enough for current consumers; typed request headers should wait for a concrete need
- Harbor-style `model_info` belongs at the eval-framework layer, not in the generic served-model boundary

<details>
<summary>Background drafts and manual vLLM context</summary>

The archived inference-service drafts are background only, not part of this review: https://github.com/marin-community/marin/tree/archive/served-lm-eval-rfcs/.agents/projects/inference-service

Manual vLLM context:

- generation through real Iris/native TPU vLLM worked for both `/v1/chat/completions` and `/v1/completions`
- representative `lm_eval` prompt-logprob scoring against vLLM returned HTTP 500, so served vLLM MCQ/loglikelihood remains explicitly deferred

</details>

## Next Steps

- **Levanter OpenAI HTTP parity:** make Levanter `/v1/completions` satisfy the real `lm_eval local-completions` prompt-logprob response shape.
- **Iris served-model launcher:** build an Iris-facing launcher that returns `RunningModel` and owns tokenizer staging, endpoint discovery, auth setup, and cleanup.
- **vLLM scoring:** track prompt-logprob support separately before claiming served MCQ/loglikelihood support.
- **Other eval frameworks:** add Harbor/Evalchemy consumers on top of `RunningModel` without moving framework-specific config into the generic boundary.

## Validation

- `uv run --package marin --extra eval pytest tests/evals/test_served_lm_eval.py` -> 5 passed
- `./infra/pre-commit.py --fix .agents/projects/served_lm_eval.md lib/levanter/src/levanter/inference/openai.py lib/levanter/src/levanter/inference/openai_protocol.py lib/marin/src/marin/evaluation/served_lm_eval.py lib/marin/src/marin/inference/served_model.py tests/evals/openai_stub.py tests/evals/test_served_lm_eval.py` -> OK