### PR TITLE
Remove `group_files` function and usage

### DIFF
--- a/lib/marin/src/marin/processing/classification/deduplication/dedup_commons.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/dedup_commons.py
@@ -49,23 +49,8 @@ def _aggregate_shard_counters(shard_results: list[dict], method: str, level: str
     }
 
 
-def group_files(files: list[str], num_groups: int) -> list[list[str]]:
-    """Group files into at most num_groups buckets deterministically.
-
-    Files are sorted then distributed round-robin, so the same set of files always
-    produces the same grouping. Use this to cap Zephyr shard count when
-    num_files >> max_parallelism.
-    """
-    sorted_files = sorted(files)
-    n = min(num_groups, len(sorted_files))
-    groups: list[list[str]] = [[] for _ in range(n)]
-    for i, f in enumerate(sorted_files):
-        groups[i % n].append(f)
-    return groups
-
-
 def _collect_input_files(*, input_paths: str | list[str], filetypes: list[str]) -> list[str]:
-    """Given an input path or list of paths, collect all matching files"""
+    """Given an input path or list of paths, collect all matching files and return them sorted."""
     input_paths = input_paths if isinstance(input_paths, list) else [input_paths]
     all_files = []
     ext_glob = ",".join(set(filetypes))
@@ -79,7 +64,7 @@ def _collect_input_files(*, input_paths: str | list[str], filetypes: list[str]) 
                 raise FileNotFoundError(f"No files found in path: {path}")
             all_files.append(path)  # Assume it's a single file
     assert all_files, "No input files found for deduplication."
-    return all_files
+    return sorted(all_files)
 
 
 def _init_wandb(*, mode: DedupMode, input_paths: str | list[str], processes: int = 1):

--- a/lib/marin/src/marin/processing/classification/deduplication/exact.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/exact.py
@@ -20,7 +20,6 @@ from marin.processing.classification.deduplication.dedup_commons import (
     _init_wandb,
     _load_batches,
     finalize_dedup,
-    group_files,
     make_document_dedup_aggregator,
 )
 from marin.utils import rebase_file_path
@@ -61,7 +60,7 @@ def dedup_exact_paragraph(
         filetypes = DEFAULT_FILETYPES
 
     input_files = _collect_input_files(input_paths=input_paths, filetypes=filetypes)
-    idx_to_path = dict(list(enumerate(sorted(input_files))))
+    idx_to_path = dict(list(enumerate(input_files)))
     path_to_idx = {v: k for k, v in idx_to_path.items()}
 
     _init_wandb(mode=DedupMode.EXACT_PARAGRAPH, input_paths=input_paths)
@@ -154,17 +153,15 @@ def dedup_exact_paragraph(
                 "file_idx": item["file_idx"],
             }
 
-    def _flat_map_paragraph_hashes(paths: list[str]) -> Iterator[dict]:
-        for path in paths:
-            for batch in _load_batches(path):
-                hashes = compute_paragraph_hashes(batch).to_pylist()
-                counters.increment("hash/paragraphs", len(hashes))
-                for hash_record in hashes:
-                    yield {"file_idx": path_to_idx[path], "id": hash_record.pop("doc_id"), **hash_record}
+    def _flat_map_paragraph_hashes(path: str) -> Iterator[dict]:
+        for batch in _load_batches(path):
+            hashes = compute_paragraph_hashes(batch).to_pylist()
+            counters.increment("hash/paragraphs", len(hashes))
+            for hash_record in hashes:
+                yield {"file_idx": path_to_idx[path], "id": hash_record.pop("doc_id"), **hash_record}
 
-    file_groups = group_files(input_files, max_parallelism)
     shard_results = ctx.execute(
-        Dataset.from_list(file_groups)
+        Dataset.from_list(input_files)
         .flat_map(_flat_map_paragraph_hashes)
         .group_by(
             lambda record: record["hash"],
@@ -198,7 +195,7 @@ def dedup_exact_document(
         filetypes = DEFAULT_FILETYPES
 
     input_files = _collect_input_files(input_paths=input_paths, filetypes=filetypes)
-    idx_to_path = dict(list(enumerate(sorted(input_files))))
+    idx_to_path = dict(list(enumerate(input_files)))
     path_to_idx = {v: k for k, v in idx_to_path.items()}
 
     _init_wandb(mode=DedupMode.EXACT_DOCUMENT, input_paths=input_paths)
@@ -240,17 +237,15 @@ def dedup_exact_document(
                 "file_idx": item["file_idx"],
             }
 
-    def _flat_map_document_hashes(paths: list[str]) -> Iterator[dict]:
-        for path in paths:
-            for batch in _load_batches(path):
-                hashes = compute_document_hashes(batch).to_pylist()
-                counters.increment("hash/documents", len(hashes))
-                for hash_record in hashes:
-                    yield {"file_idx": path_to_idx[path], **hash_record}
+    def _flat_map_document_hashes(path: str) -> Iterator[dict]:
+        for batch in _load_batches(path):
+            hashes = compute_document_hashes(batch).to_pylist()
+            counters.increment("hash/documents", len(hashes))
+            for hash_record in hashes:
+                yield {"file_idx": path_to_idx[path], **hash_record}
 
-    file_groups = group_files(input_files, max_parallelism)
     shard_results = ctx.execute(
-        Dataset.from_list(file_groups)
+        Dataset.from_list(input_files)
         .flat_map(_flat_map_document_hashes)
         .group_by(
             lambda record: record["hash"],


### PR DESCRIPTION
Remove `group_files` from `dedup_commons.py` and update `exact.py` to directly use the list of input files. Also pushes sorting into `_collect_input_files` since that seems like a logical place for it.

NOTE: Technically this changes the behaviour of the call to `_collect_input_files` in `decon.py`, but I'm assuming that's okay.