### PR TITLE
Add max-parallelism command line parameter to fineweb_10bt_exact

### DIFF
--- a/experiments/dedup/fineweb_10bt_exact.py
+++ b/experiments/dedup/fineweb_10bt_exact.py
@@ -4,10 +4,11 @@
 """Download fineweb-edu 10BT sample (~10GB) and run exact paragraph dedup locally.
 
 Usage:
-    MARIN_PREFIX=/tmp/marin uv run iris --config=lib/iris/examples/local.yaml job run -- \
-        python experiments/dedup/fineweb_10bt_exact.py
+    MARIN_PREFIX=/tmp/marin uv run iris --config=lib/iris/examples/local.yaml job run -- \\
+        python experiments/dedup/fineweb_10bt_exact.py [--max-parallelism N]
 """
 
+import argparse
 import logging
 import os
 
@@ -24,7 +25,7 @@ logger = logging.getLogger(__name__)
 OUTPUT_PREFIX = os.environ.get("OUTPUT_PREFIX", "exact-para-dedup-fineweb-10bt")
 
 
-def build_steps() -> list[StepSpec]:
+def build_steps(max_parallelism: int) -> list[StepSpec]:
     download = fineweb_edu.download(
         hf_urls_glob=["sample/10BT/*.parquet"],
     )
@@ -36,12 +37,25 @@ def build_steps() -> list[StepSpec]:
         fn=lambda op: dedup_exact_paragraph(
             input_paths=os.path.join(download.output_path, "sample/10BT"),
             output_path=op,
-            max_parallelism=128,
+            max_parallelism=max_parallelism,
         ),
     )
     return [download, dedup_step]
 
 
-if __name__ == "__main__":
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--max-parallelism",
+        type=int,
+        default=128,
+        metavar="N",
+        help="Maximum parallelism passed to dedup_exact_paragraph (default: %(default)s).",
+    )
+    args = parser.parse_args()
     configure_logging(logging.INFO)
-    StepRunner().run(build_steps())
+    StepRunner().run(build_steps(max_parallelism=args.max_parallelism))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I use this script locally for testing Iris dashboard changes, so it's nice to be able to keep it from bogging down my laptop too much. I can also create my own copy of the script if that's preferable.
