### PR TITLE
[Design] workflow_scripts

### DIFF
--- a/.agents/projects/workflow_scripts/design.md
+++ b/.agents/projects/workflow_scripts/design.md
@@ -1,0 +1,79 @@
+# Workflow Scripts
+
+Marin's GitHub Actions workflows should be thin triggers around local, reproducible workflow programs. Today, the same operational logic appears as long YAML blocks across smoke tests, canaries, ferries, wheel publishing, diagnostics, and issue/PR automation, which makes failures harder to reproduce locally and makes workflow names hard to reason about in the Actions UI. This design introduces `scripts/workflows/` as the home for workflow-owned Python CLIs, standardizes workflow/job naming, and sets a policy for when GitHub Actions YAML is allowed to contain logic.
+
+Success means every workflow has a documented local reproduction command, new workflow logic is covered by the `scripts/workflows` audit, all non-allowlisted third-party actions are SHA-pinned, and the copied Iris polling/diagnostics blocks are removed from the smoke, ferry, and integration workflows. The migration should reduce long inline `run: |` blocks to short workflow glue, not merely move names around.
+
+## Challenges
+
+The difficult part is not moving shell into Python one block at a time; it is drawing boundaries that stay useful after the first cleanup PR. Some workflow behavior is repo-local and should run inside the Marin `uv run` environment, while other operational tools are deliberately standalone uv scripts and should remain usable without installing the repo. GitHub Actions also has native reuse tools, especially reusable workflows, but they reuse job topology rather than making behavior locally reproducible. We need a design that uses Python scripts for behavior first, then only adds reusable workflows when duplicated job structure remains after the scripts exist.
+
+The second challenge is naming. Issue #5067 proposes `type-domain-test`; prior triage noted that most existing files already start with the domain. This design chooses domain-first naming because it keeps team-owned workflows adjacent in `ls`, GitHub's Actions sidebar, and branch-protection discussions.
+
+## Costs / Risks
+
+- Renaming workflow files, workflow names, or job names can affect required-check configuration. The cleanup needs an explicit branch-protection coordination step before changing any status context that gates merges.
+- Moving scripts under stricter linting and type checking will create some initial friction, especially because `scripts/**` is currently excluded from ruff and pyrefly.
+- Replacing third-party logic actions with local scripts creates code Marin owns and must maintain. That is a good trade for load-bearing automation, but not for basic primitives like checkout or tool setup.
+- This is mostly infrastructure hygiene. The immediate user-visible benefit is faster diagnosis and more reliable local reproduction, not new product behavior.
+
+## Design
+
+Create `scripts/workflows/` for Python CLIs that implement behavior currently embedded in `.github/workflows/*.yaml`. Workflow YAML remains responsible for triggers, permissions, runner selection, matrices, secrets binding, artifact upload/download, and calling scripts. Long `run:` blocks should become one-line invocations unless the block is only shell glue that GitHub Actions itself owns.
+
+The default execution model is repo-local:
+
+```bash
+uv run python scripts/workflows/<domain>_<command>.py <subcommand> ...
+```
+
+Repo-local scripts may import Marin workspace packages and shared helpers. This is the right default for Iris, Zephyr, Marin, Levanter, Haliax, and Fray workflows because their behavior usually depends on checked-out repo code and the locked workspace environment. Standalone uv scripts remain appropriate for tools that do not depend on the repo, such as `scripts/logscan.py` and operational notification utilities like `scripts/ops/discord.py`; those can keep PEP 723 metadata and `#!/usr/bin/env -S uv run --script` when that is what makes them portable.
+
+All new `scripts/workflows/**` CLIs use Click. Each script exposes a small set of explicit commands and options, writes machine-readable outputs when a workflow step needs them, and keeps computation separate from I/O where practical. `scripts/rust_package.py` is the nearest existing model for workflow-owned logic: it documents local usage and prerequisites, owns subprocess orchestration in Python, and is called from `.github/workflows/dupekit-wheels.yaml` instead of embedding build/release logic in YAML. The main differences for new workflow scripts are Click instead of argparse and stricter lint/type expectations. See [research.md](research.md) for file references and prior art.
+
+Workflow names use:
+
+```text
+<domain>-<type>[-<variant>]
+```
+
+`domain` is the owning area: `iris`, `zephyr`, `marin`, `levanter`, `haliax`, `fray`, `dupekit`, or `ops`. `ops` is the bucket for repository automation such as stale issue handling, CodeQL, nightshift jobs, Claude automation, and workflow maintenance. `type` is the gate or automation kind: `unit`, `smoke`, `canary`, `integration`, `release`, `lint`, `docs`, or `dev`. `variant` is optional and should only remain when a matrix or script option cannot express the difference cleanly.
+
+Examples:
+
+- `iris-smoke` for a cross-provider Iris smoke workflow, with `cluster=gcp|coreweave` as a matrix or script option.
+- `iris-smoke-gcp` only if the GCP implementation must remain a separate status context.
+- `marin-canary-ferry` for the current Marin canary ferry.
+- `zephyr-integration-shuffle` instead of `zephyr-shuffle-itest`.
+- `haliax-unit` instead of `haliax-run_tests`.
+- `levanter-integration-gpt2-small` instead of `levanter-gpt2_small_itest`.
+- `dupekit-release-wheels` for wheel building and publishing.
+- `ops-stale`, `ops-codeql`, or `ops-nightshift-docs` for repository automation that is not owned by a product domain.
+
+Job names should follow the same shape when they create branch-protection contexts, with a short action suffix if needed: `iris-smoke / test (gcp)`, `dupekit-release / build (linux)`, `marin-canary-ferry / validate`. Step names should be imperative and stable: `Submit Iris job`, `Wait for Iris job`, `Collect Iris diagnostics`, `Create update PR`.
+
+Third-party actions are allowed in two tiers. A small explicit allowlist of trusted primitives may remain tag-pinned when that is already the project norm: checkout, setup, cache, artifact upload/download, CodeQL, GitHub app token creation, uv setup, Google auth/setup-gcloud, and Docker setup/login/build actions. All other third-party actions should be pinned to a full commit SHA. This follows GitHub's security guidance that SHA pinning is the only immutable reference for third-party actions and that tag pinning is a trust decision.
+
+The largest duplicated behavior is Iris job orchestration: submit/wait/status inspection and failure diagnostics are embedded across canary, smoke, and integration workflows. The first operational extraction should be behavior-level CLIs such as `iris_job.py wait` and `iris_diagnostics.py collect`, not a reusable workflow. Before that operational PR lands, the foundation PR creates the script/audit surface and converts lower-risk workflows so the live-infrastructure extraction has a stable pattern to follow.
+
+`scripts/workflows/**` should be included in ruff and pyrefly even though broader `scripts/**` remains excluded today. These scripts are CI infrastructure, not one-off local utilities, and breakage affects the development loop for everyone.
+
+Do not create a shared workflow package on day one. Start with concrete importable modules such as `scripts/workflows/iris_job.py`, `scripts/workflows/iris_diagnostics.py`, and `scripts/workflows/pull_request.py`. Add `scripts/workflows/lib/` only after at least two modules need the same non-trivial helper and the helper has a stable contract. The repo currently has `scripts/__init__.py`, but not a meaningful scripts package hierarchy; premature packaging would add more structure than the first extraction needs.
+
+The full migration should land as a small number of large PRs, not a long tail of tiny workflow edits:
+
+1. **Foundation and low-risk normalization.** Add `scripts/workflows/`, `.github/workflows/README.md`, the workflow inventory/audit script, path-change filtering, pull-request creation, and SHA pinning for non-trusted third-party actions. Bring `scripts/workflows/**` under ruff and pyrefly. Convert unit/docs/lint/release workflows that mostly run tests or packaging scripts, because they do not launch live infrastructure.
+2. **Iris and ferry behavior extraction.** Add the Iris job wait/status and diagnostics scripts, then migrate `iris-cloud-smoke-gcp`, `iris-coreweave-ci`, `marin-canary-ferry*`, `marin-datakit-*`, and `zephyr-shuffle-itest` to call those scripts. This is one large operational PR because these workflows share the same failure modes and should be reviewed together.
+3. **Names, file renames, and consolidation.** Rename workflow files and displayed workflow/job names to `domain-type[-variant]`, update branch-protection contexts with `gh api` where required, and consolidate workflows only where the scripts have made the provider/domain differences parameterizable. This is the right point to decide whether `iris-smoke-gcp` and `iris-smoke-coreweave` become one `iris-smoke` workflow.
+
+## Testing
+
+Each workflow script gets focused pytest coverage for argument parsing, output shape, and pure computation. I/O-heavy paths should be tested at the boundary with temporary files and subprocess fakes, not by mocking internal helper calls. Scripts that wrap Iris or GitHub should include a dry-run or fixture-driven mode where practical so CI can test command construction and status parsing without launching live infrastructure.
+
+The rollout test is staged. First, land scripts that can be run locally while workflows still call the old YAML blocks. Second, switch one low-risk workflow step to call the script and compare logs/output shape against the previous run. Third, migrate repeated blocks across workflows.
+
+Branch-protection-sensitive renames should be handled with `gh`, not manual clicking. `gh api repos/marin-community/marin/branches/main/protection` currently exposes the required contexts for `main`: `lint-and-format`, `build-docs`, `marin-tests`, `levanter-tests`, `levanter-entry-tests`, `levanter-torch-tests`, `haliax-tests`, `iris-tests`, `zephyr-tests`, `fray-tests`, and `marin-itest`. If a PR changes any required job context, the rollout first adds the target contexts while keeping the old ones, merges only after the renamed checks appear and pass, then removes the old contexts after the renamed workflows have run on `main`.
+
+## Open Questions
+
+- Should `iris-smoke-gcp` and `iris-smoke-coreweave` eventually merge into one `iris-smoke` workflow after script extraction, or stay separate because the providers are operationally different enough to deserve separate status contexts?

--- a/.agents/projects/workflow_scripts/research.md
+++ b/.agents/projects/workflow_scripts/research.md
@@ -1,0 +1,93 @@
+# Workflow Scripts Research
+
+Issue: https://github.com/marin-community/marin/issues/5067
+
+## Framing
+
+Marin has accumulated enough GitHub Actions workflows that workflow purpose, naming, and local reproducibility are no longer obvious from `.github/workflows/`. The proposal under discussion is to make workflows thin triggers around reproducible Python scripts, likely under `scripts/workflows/`, using `scripts/rust_package.py` as a rough model. The intended outcome is consistent workflow and step naming, less duplicated YAML, fewer third-party logic actions where Marin can reasonably own the behavior, and workflow scripts that share a consistent CLI style based on Click and uv.
+
+## Issue Context
+
+Issue #5067 asks for a consistent naming scheme for workflows and tests, plus a "minimal YAML" policy where workflow logic is primarily defined in independently runnable Python scripts. The issue explicitly calls out consolidation across related workflows, such as one parameterized smoke test instead of separate GCP and CoreWeave implementations.
+
+An existing issue comment triaged the current state as roughly 33-34 workflows and about 4.4K YAML lines. The main problems identified were naming drift, duplicated inline shell logic, and no index mapping workflow names to triggers and gate scale. The comment also proposed staged cleanup PRs, with open questions around domain-first versus type-first naming, allowed repo-infra domains, pytest marker rollout, branch-protection coordination, and whether GCP/CoreWeave smoke tests can share one helper.
+
+Related issue #5065, the Infra Stability Epic, frames the broader goal as making Iris and Zephyr gates easier to reason about and operate.
+
+## In-Repo Findings
+
+### Existing Script Patterns
+
+- `scripts/rust_package.py` is the strongest existing model for workflow-owned logic in Python. It documents usage and prerequisites at the top of the file, defines repo-root constants, runs subprocesses explicitly, and exposes clear command-line flags in `main()`:
+  - `https://github.com/marin-community/marin/blob/53bdadbad1b1ae45d3aeaba3f33ab7f5d850359a/scripts/rust_package.py#L5`
+  - `https://github.com/marin-community/marin/blob/53bdadbad1b1ae45d3aeaba3f33ab7f5d850359a/scripts/rust_package.py#L351`
+- `.github/workflows/dupekit-wheels.yaml` already demonstrates a minimal-YAML pattern: the workflow checks out code, installs the toolchain, and delegates build/release behavior to `scripts/rust_package.py`.
+  - `https://github.com/marin-community/marin/blob/53bdadbad1b1ae45d3aeaba3f33ab7f5d850359a/.github/workflows/dupekit-wheels.yaml#L56`
+  - `https://github.com/marin-community/marin/blob/53bdadbad1b1ae45d3aeaba3f33ab7f5d850359a/.github/workflows/dupekit-wheels.yaml#L77`
+- `scripts/python_libs_package.py` follows a similar release/build orchestration pattern for Python libraries.
+- `scripts/canary/validate_canary_metrics.py` is already workflow-called validation logic and should be evaluated for reuse or migration under the proposed workflow-script layout.
+- `scripts/gcp-ssh`, `scripts/iris/dev_tpu.py`, and `scripts/debug/decode_tokens.py` show existing Click-based command/group style in the repo.
+- `scripts/logscan.py` is a current example of a standalone uv script using `#!/usr/bin/env -S uv run --script` and PEP 723 inline dependencies:
+  - `https://github.com/marin-community/marin/blob/53bdadbad1b1ae45d3aeaba3f33ab7f5d850359a/scripts/logscan.py#L1`
+  - `https://github.com/marin-community/marin/blob/53bdadbad1b1ae45d3aeaba3f33ab7f5d850359a/scripts/logscan.py#L6`
+
+### Representative Pain Points
+
+- Workflow filename and displayed-name conventions drift across `.yaml` and `.yml`, underscore and hyphen naming, and suffixes such as `run_tests`, `itest`, `launch_small_fast`, `unit-tests`, and plain `tests`.
+- `marin-canary-ferry.yaml` includes a copied Iris job polling loop in YAML:
+  - `https://github.com/marin-community/marin/blob/53bdadbad1b1ae45d3aeaba3f33ab7f5d850359a/.github/workflows/marin-canary-ferry.yaml#L101`
+- The same workflow embeds a long failure-diagnostics shell block with `gcloud compute ssh`, Docker logs, and inline Python/SQLite:
+  - `https://github.com/marin-community/marin/blob/53bdadbad1b1ae45d3aeaba3f33ab7f5d850359a/.github/workflows/marin-canary-ferry.yaml#L159`
+- Similar submit/wait/diagnose patterns appear in `marin-datakit-smoke.yaml`, `zephyr-shuffle-itest.yaml`, `iris-cloud-smoke-gcp.yaml`, and `iris-coreweave-ci.yaml`.
+- `dupekit-wheels.yaml` uses `peter-evans/create-pull-request@v7` for PR creation:
+  - `https://github.com/marin-community/marin/blob/53bdadbad1b1ae45d3aeaba3f33ab7f5d850359a/.github/workflows/dupekit-wheels.yaml#L80`
+  No action matching the example `rando-user/pull-request@7` was found in the current checkout.
+
+### Tooling Constraints
+
+- The repo requires Python `>=3.11`:
+  - `https://github.com/marin-community/marin/blob/53bdadbad1b1ae45d3aeaba3f33ab7f5d850359a/pyproject.toml#L10`
+- Root dependencies are intentionally kept small:
+  - `https://github.com/marin-community/marin/blob/53bdadbad1b1ae45d3aeaba3f33ab7f5d850359a/pyproject.toml#L21`
+- Current repo configuration excludes `scripts/` from ruff formatting/linting and pyrefly type checking:
+  - `https://github.com/marin-community/marin/blob/53bdadbad1b1ae45d3aeaba3f33ab7f5d850359a/pyproject.toml#L75`
+  - `https://github.com/marin-community/marin/blob/53bdadbad1b1ae45d3aeaba3f33ab7f5d850359a/pyproject.toml#L139`
+  The design should decide whether new workflow scripts inherit that exclusion or define stricter checks.
+
+## Related Designs
+
+- `.agents/projects/ferry_framework.md` frames ferries as high-signal integration workflows and proposes launch/monitor helpers. Its run-record fields overlap with workflow-script output/reporting needs.
+- `.agents/projects/20260212_iris_testing_design.md` motivates fast local Iris E2E testing and includes pytest marker conventions and `uv run pytest ...` examples that can inform gate naming.
+- `.agents/projects/20260203_iris_job_name_design.md` is not workflow-specific, but is useful precedent for canonical naming and no-backward-compat migration framing.
+
+## Prior Art
+
+- GitHub reusable workflows are the native mechanism for reusing complete jobs or job graphs. They live directly in `.github/workflows/`, use `workflow_call`, and can be invoked from the same repo with `./.github/workflows/<file>`. GitHub positions them as the way to avoid copy-pasting whole workflow structures.
+- GitHub distinguishes reusable workflows from composite actions: reusable workflows can contain jobs, choose runners, and show each job/step in logs, while composite actions package steps inside a job. For Marin's smoke/ferry orchestration, reusable workflows fit shared job topology; Python scripts fit reusable behavior inside a step.
+- GitHub's security guidance says third-party actions can access secrets and repository tokens, and recommends pinning third-party actions to full-length SHAs, auditing action source, and using tags only for trusted creators. This supports treating third-party logic actions as design-reviewed dependencies rather than casual YAML conveniences.
+- PEP 723 defines inline metadata for single-file Python scripts, including `requires-python`, `dependencies`, and optional `[tool]` metadata. This is the standard shape used by uv scripts.
+- uv supports `uv run` for project-backed commands, `uv run --script` and uv shebangs for PEP 723 scripts, adjacent lockfiles for scripts, and `exclude-newer` metadata for stronger reproducibility.
+- Click is the established Python CLI library for command groups, options, argument parsing, help output, and composable command-line interfaces. Using Click for all new workflow scripts would make local execution and GitHub Actions invocation consistent.
+
+Sources:
+
+- GitHub reusable workflows: https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows
+- GitHub reusable workflows vs composite actions: https://docs.github.com/en/actions/sharing-automations/avoiding-duplication
+- GitHub Actions secure use reference: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions
+- uv scripts guide: https://docs.astral.sh/uv/guides/scripts/
+- PEP 723: https://peps.python.org/pep-0723/
+- Click documentation: https://click.palletsprojects.com/
+
+## Design Questions
+
+- Canonical workflow names should use domain-first `domain-type[-variant]` ordering. This matches the existing dominant convention and keeps team-owned workflows adjacent.
+- `scripts/workflows/` should default to repo-local `uv run python scripts/workflows/...` scripts. Standalone PEP 723 uv scripts remain appropriate for tools that are intentionally usable outside a Marin checkout or environment, such as notification and ops helpers.
+- New workflow scripts should be brought under ruff and pyrefly even though broader `scripts/**` remains excluded today.
+- Native/trusted setup primitives are acceptable: `actions/*`, GitHub-owned actions, cloud setup/auth actions, Docker setup/login/build actions, and `astral-sh/setup-uv`. Other third-party actions should be pinned to full commit SHAs. No separate review registry is needed for this design; pinning is the policy.
+- Repeated Iris submit/wait/diagnostics behavior should be exposed as Python scripts first. Reusable workflow consolidation can wait until script extraction shows whether duplicated job topology remains.
+- Branch protection can be checked with `gh api repos/marin-community/marin/branches/main/protection`. As of this research pass, main requires these classic contexts: `lint-and-format`, `build-docs`, `marin-tests`, `levanter-tests`, `levanter-entry-tests`, `levanter-torch-tests`, `haliax-tests`, `iris-tests`, `zephyr-tests`, `fray-tests`, and `marin-itest`. The repo also has an active `protect main` ruleset, but the required status checks are visible through classic branch protection. If the token has admin permission, the contexts can be updated with `gh api --method PATCH repos/marin-community/marin/branches/main/protection`; workflow/job renames should include that command in the rollout step instead of hand-waving about manual settings.
+
+## Resolved Design Decisions
+
+- Use `ops` for repository automation workflows such as stale issue handling, CodeQL, nightshift jobs, Claude automation, and workflow maintenance. It is clearer than `repo` because these workflows are operations-owned automation, not a product domain.
+- Do not create a shared package under `scripts/workflows/` at the start. Use concrete modules such as `scripts/workflows/iris_job.py`, `scripts/workflows/iris_diagnostics.py`, and `scripts/workflows/pull_request.py`. Add `scripts/workflows/lib/` only when at least two modules need the same non-trivial helper and the helper has a stable contract.

--- a/.agents/projects/workflow_scripts/spec.md
+++ b/.agents/projects/workflow_scripts/spec.md
@@ -1,0 +1,461 @@
+# Workflow Scripts Spec
+
+This spec defines the target contracts for moving Marin's GitHub Actions workflows to the workflow-scripts model. The implementation can land in large staged PRs, but each stage must preserve the contracts below.
+
+## File Layout
+
+| Path | Contract |
+| --- | --- |
+| `scripts/workflows/__init__.py` | Empty package marker for workflow-owned Python modules. No exported convenience API. |
+| `scripts/workflows/changes.py` | Repo-local replacement for path-filter logic used by unit/docs/lint workflows. |
+| `scripts/workflows/pull_request.py` | Repo-local replacement for third-party create-PR workflow logic. |
+| `scripts/workflows/github_actions.py` | Workflow inventory and policy checks: naming, `.yaml`, third-party SHA pins, and required-status inventory. |
+| `scripts/workflows/iris_job.py` | Iris job status, wait, and GitHub Actions output helpers. |
+| `scripts/workflows/iris_diagnostics.py` | Failure diagnostics collection for Iris-backed workflows. |
+| `.github/workflows/README.md` | Human index of workflows: target name, trigger, gate type, owner domain, and local reproduction command. |
+| `pyproject.toml` | Includes `scripts/workflows/**` in ruff and pyrefly while leaving unrelated legacy scripts excluded. |
+
+Do not add `scripts/workflows/lib/` in the first migration. If two or more modules need the same non-trivial helper, add a concrete helper module named for the concept, not a generic utility module. Docker image build orchestration can be added later if the cleanup shows real duplicated behavior after trusted Docker setup/login/build actions remain in YAML.
+
+## CLI Contracts
+
+All `scripts/workflows/*.py` modules are repo-local commands invoked as:
+
+```bash
+uv run python scripts/workflows/<name>.py <command> [options]
+```
+
+All new workflow scripts use Click. Commands must fail non-zero on operational failure, print concise human-readable progress to stderr, and write machine-readable data either to stdout or to `$GITHUB_OUTPUT` when `--github-output` is supplied. Commands that can affect GitHub state must support `--dry-run`.
+
+### `changes.py`
+
+```python
+@dataclass(frozen=True)
+class PathDecision:
+    name: str
+    matched: bool
+    paths: tuple[str, ...]
+
+
+def changed_paths(base_ref: str, head_ref: str, *, repo: Path) -> tuple[str, ...]:
+    """Return paths changed between two refs, sorted and relative to repo root.
+
+    Uses `git diff --name-only --diff-filter=ACMRTUXB base_ref...head_ref` for pull requests
+    and `base_ref..head_ref` for push comparisons. Raises ValueError when either ref is missing.
+    """
+
+
+def match_groups(paths: Iterable[str], groups: Mapping[str, Sequence[str]]) -> tuple[PathDecision, ...]:
+    """Match changed paths against named glob groups.
+
+    Patterns use pathlib-style `PurePath.match` semantics with `**` support. Negated patterns are
+    accepted with a leading `!` and are applied after positive patterns in declaration order.
+    """
+```
+
+CLI:
+
+```bash
+uv run python scripts/workflows/changes.py match \
+  --base "$BASE_SHA" \
+  --head "$HEAD_SHA" \
+  --group marin='lib/marin/**,tests/**,pyproject.toml,uv.lock' \
+  --github-output
+```
+
+Output contract:
+
+- stdout JSON: `{"groups": [{"name": "marin", "matched": true, "paths": ["..."]}]}`
+- `$GITHUB_OUTPUT`: one lower-case boolean per group, e.g. `marin=true`
+
+For `pull_request` events, callers pass the PR base SHA and head SHA and the command uses merge-base diff semantics. For `push` events, callers pass before/after SHAs and the command uses direct range semantics. For `schedule` and `workflow_dispatch`, workflows must either skip `changes.py` or pass `--always-match`, which marks every group as matched and records `reason="manual-or-scheduled"` in stdout JSON. Deleted-only files do not trigger groups because the command excludes `D` from the diff filter; renames trigger on the new path.
+
+### `pull_request.py`
+
+```python
+@dataclass(frozen=True)
+class PullRequestRequest:
+    branch: str
+    title: str
+    body: str
+    commit_message: str
+    labels: tuple[str, ...]
+    base: str = "main"
+    author_name: str = "github-actions[bot]"
+    author_email: str = "41898282+github-actions[bot]@users.noreply.github.com"
+    draft: bool = False
+
+
+def create_or_update_pull_request(request: PullRequestRequest, *, repo: str, dry_run: bool) -> str | None:
+    """Commit current worktree changes, push `request.branch`, and create or update a pull request.
+
+    Returns the PR URL, or None in dry-run mode. Raises ValueError for an empty diff or invalid request.
+    """
+```
+
+CLI:
+
+```bash
+uv run python scripts/workflows/pull_request.py create \
+  --branch auto/update-dupekit-wheels \
+  --title "chore: update dupekit wheels" \
+  --body-file pr-body.md \
+  --commit-message "chore: pin dupekit wheels to $GITHUB_SHA" \
+  --label agent-generated
+```
+
+This command replaces `peter-evans/create-pull-request@v7` in `dupekit-wheels.yaml` and any future in-workflow PR creation.
+
+Supported behavior is intentionally narrower than the third-party action: commit the current worktree diff, push or force-with-lease the named branch, create a PR if none exists, update title/body/labels on an existing open PR from the same branch, and exit zero with `pr_created=false` when the diff is empty. Unsupported behavior: reviewers, assignees, branch deletion, signed commits, path-scoped commits, multi-commit preservation, and automatic base-branch rebasing. The workflow must grant `contents: write` and `pull-requests: write`.
+
+### `github_actions.py`
+
+```python
+@dataclass(frozen=True)
+class WorkflowRecord:
+    path: Path
+    workflow_name: str
+    jobs: tuple[WorkflowJob, ...]
+    third_party_actions: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class WorkflowJob:
+    job_id: str
+    job_name: str | None
+    matrix_context: str | None
+    required_context: str | None
+
+
+def workflow_records(workflows_dir: Path) -> tuple[WorkflowRecord, ...]:
+    """Parse workflow files and return workflow names, jobs, matrix context shapes, and action refs."""
+
+
+def required_status_contexts(repo: str, branch: str) -> tuple[str, ...]:
+    """Return branch-protection required status contexts using the GitHub API."""
+```
+
+CLI:
+
+```bash
+uv run python scripts/workflows/github_actions.py audit --workflows-dir .github/workflows
+uv run python scripts/workflows/github_actions.py required-contexts --repo marin-community/marin --branch main
+```
+
+Audit failures:
+
+- workflow file does not end in `.yaml`
+- workflow name does not follow `Domain - Type [- Variant]`
+- job id does not follow lower-case kebab-case
+- non-trusted third-party action is not pinned to a 40-character SHA
+- required branch-protection context is missing from the workflow inventory
+
+Trusted tag-pinned actions:
+
+- `actions/`
+- `github/codeql-action/init`
+- `github/codeql-action/analyze`
+- `actions/checkout`
+- `actions/setup-python`
+- `actions/setup-node`
+- `actions/cache`
+- `actions/upload-artifact`
+- `actions/download-artifact`
+- `actions/create-github-app-token`
+- `astral-sh/setup-uv`
+- `google-github-actions/auth`
+- `google-github-actions/setup-gcloud`
+- `docker/setup-buildx-action`
+- `docker/login-action`
+- `docker/build-push-action`
+
+All other external actions must be SHA-pinned.
+
+### `iris_job.py`
+
+```python
+class IrisJobState(StrEnum):
+    PENDING = "JOB_STATE_PENDING"
+    BUILDING = "JOB_STATE_BUILDING"
+    RUNNING = "JOB_STATE_RUNNING"
+    SUCCEEDED = "JOB_STATE_SUCCEEDED"
+    FAILED = "JOB_STATE_FAILED"
+    CANCELLED = "JOB_STATE_CANCELLED"
+
+
+@dataclass(frozen=True)
+class IrisJobStatus:
+    job_id: str
+    state: IrisJobState
+    error: str | None
+
+
+def job_status(job_id: str, *, iris_config: Path | None, prefix: str | None = None) -> IrisJobStatus:
+    """Return the exact Iris job status by running `iris job list --json --prefix <prefix>`."""
+
+
+def wait_for_job(
+    job_id: str,
+    *,
+    iris_config: Path | None,
+    prefix: str | None,
+    poll_interval: int,
+    timeout: int | None,
+) -> IrisJobStatus:
+    """Poll until the Iris job reaches a terminal state.
+
+    `poll_interval` and `timeout` are seconds. Raises TimeoutError on timeout and RuntimeError for
+    FAILED, CANCELLED, missing job, malformed JSON, or Iris CLI failure.
+    """
+```
+
+CLI:
+
+```bash
+uv run python scripts/workflows/iris_job.py wait \
+  --job-id "$JOB_ID" \
+  --iris-config "$IRIS_CONFIG" \
+  --poll-interval 30 \
+  --github-output
+```
+
+The command shells out to `.venv/bin/iris` when present, otherwise `uv run iris`. It passes `--config <iris_config>` when supplied, selects the exact `job_id` from JSON output, and treats unknown terminal states as failure. `--github-output` writes `job_id`, `state`, and `succeeded` before exiting on both success and known terminal failure; it may be absent only when the command cannot parse status at all. `SIGINT` and `SIGTERM` stop polling and exit non-zero without cancelling the remote job.
+
+### `iris_diagnostics.py`
+
+```python
+@dataclass(frozen=True)
+class DiagnosticsRequest:
+    job_id: str
+    output_dir: Path
+    iris_config: Path | None
+    provider: Literal["gcp", "coreweave"]
+    project: str | None
+    controller_label: str | None
+    namespace: str | None
+
+
+def collect_diagnostics(request: DiagnosticsRequest) -> Path:
+    """Collect Iris controller, job tree, and provider-specific task diagnostics into `output_dir`."""
+```
+
+CLI:
+
+```bash
+uv run python scripts/workflows/iris_diagnostics.py collect \
+  --job-id "$JOB_ID" \
+  --iris-config "$IRIS_CONFIG" \
+  --provider gcp \
+  --output-dir "$DIAG_DIR"
+```
+
+Output directory contract:
+
+```text
+<output-dir>/
+  controller-process.log
+  job-tree.json
+  controller-<name>.log          # GCP only, when controller SSH succeeds
+  kubernetes-pods.json           # CoreWeave only, when namespace is supplied
+  summary.json
+```
+
+`summary.json` contains `job_id`, `provider`, `files`, `required_files`, `missing_required_files`, and `errors`.
+
+Required artifacts:
+
+- All providers: `job-tree.json` and `summary.json`
+- GCP: at least one `controller-<name>.log`
+- CoreWeave: `kubernetes-pods.json`
+
+Diagnostics collection is best-effort for optional artifacts, but the command exits non-zero when no required provider artifact can be collected. Workflows should run the diagnostics step under `if: failure() || cancelled()` and `continue-on-error: true`, then always upload whatever files were written so diagnostics regressions are visible without hiding the original workflow failure.
+
+## Workflow Naming Contracts
+
+Workflow files use `.yaml` and lower-case kebab-case. Display names use title case with the same semantic parts.
+
+| Current file | Target file | Target workflow name |
+| --- | --- | --- |
+| `claude-review.yml` | `ops-claude-review.yaml` | `Ops - Claude Review` |
+| `claude.yml` | `ops-claude.yaml` | `Ops - Claude` |
+| `docker-images.yaml` | `ops-docker-images.yaml` | `Ops - Docker Images` |
+| `dupekit-unit-tests.yaml` | `dupekit-unit.yaml` | `Dupekit - Unit` |
+| `dupekit-wheels.yaml` | `dupekit-release-wheels.yaml` | `Dupekit - Release Wheels` |
+| `fray-unit-tests.yaml` | `fray-unit.yaml` | `Fray - Unit` |
+| `grug-variant-diff.yaml` | `ops-grug-variant-diff.yaml` | `Ops - Grug Variant Diff` |
+| `haliax-run_tests.yaml` | `haliax-unit.yaml` | `Haliax - Unit` |
+| `iris-cloud-smoke-gcp.yaml` | `iris-smoke-gcp.yaml` | `Iris - Smoke - GCP` |
+| `iris-coreweave-ci.yaml` | `iris-smoke-coreweave.yaml` | `Iris - Smoke - CoreWeave` |
+| `iris-dev-restart.yaml` | `iris-dev-restart.yaml` | `Iris - Dev Restart` |
+| `iris-iap-proxy.yaml` | `iris-release-iap-proxy.yaml` | `Iris - Release IAP Proxy` |
+| `iris-unit-tests.yaml` | `iris-unit.yaml` | `Iris - Unit` |
+| `levanter-gpt2_small_itest.yaml` | `levanter-integration-gpt2-small.yaml` | `Levanter - Integration - GPT-2 Small` |
+| `levanter-launch_small_fast.yaml` | `levanter-dev-launch-small-fast.yaml` | `Levanter - Dev - Launch Small Fast` |
+| `levanter-tests.yaml` | `levanter-unit.yaml` | `Levanter - Unit` |
+| `marin-canary-ferry-cw.yaml` | `marin-canary-ferry-coreweave.yaml` | `Marin - Canary Ferry - CoreWeave` |
+| `marin-canary-ferry.yaml` | `marin-canary-ferry.yaml` | `Marin - Canary Ferry` |
+| `marin-codeql.yml` | `ops-codeql.yaml` | `Ops - CodeQL` |
+| `marin-datakit-nemotron-ferry.yaml` | `marin-canary-datakit-nemotron.yaml` | `Marin - Canary - Datakit Nemotron` |
+| `marin-datakit-smoke.yaml` | `marin-smoke-datakit.yaml` | `Marin - Smoke - Datakit` |
+| `marin-docs.yaml` | `marin-docs.yaml` | `Marin - Docs` |
+| `marin-infra-dashboard.yaml` | `ops-infra-dashboard.yaml` | `Ops - Infra Dashboard` |
+| `marin-itest.yaml` | `marin-integration.yaml` | `Marin - Integration` |
+| `marin-libs-wheels.yaml` | `marin-release-libs-wheels.yaml` | `Marin - Release Libs Wheels` |
+| `marin-lint-and-format.yaml` | `marin-lint.yaml` | `Marin - Lint` |
+| `marin-metrics.yaml` | `marin-dev-metrics.yaml` | `Marin - Dev Metrics` |
+| `marin-unit-tests.yaml` | `marin-unit.yaml` | `Marin - Unit` |
+| `nightshift-cleanup.yml` | `ops-nightshift-cleanup.yaml` | `Ops - Nightshift Cleanup` |
+| `nightshift-doc-drift.yml` | `ops-nightshift-doc-drift.yaml` | `Ops - Nightshift Doc Drift` |
+| `stale.yml` | `ops-stale.yaml` | `Ops - Stale` |
+| `zephyr-shuffle-itest.yaml` | `zephyr-integration-shuffle.yaml` | `Zephyr - Integration - Shuffle` |
+| `zephyr-unit-tests.yaml` | `zephyr-unit.yaml` | `Zephyr - Unit` |
+
+Required status contexts are job contexts, not file names. Any rename of required job ids must include a branch-protection update for `main`. Current required contexts are:
+
+```text
+lint-and-format
+build-docs
+marin-tests
+levanter-tests
+levanter-entry-tests
+levanter-torch-tests
+haliax-tests
+iris-tests
+zephyr-tests
+fray-tests
+marin-itest
+```
+
+Target required contexts after final renaming:
+
+```text
+marin-lint
+marin-docs
+marin-unit
+levanter-unit
+levanter-entry
+levanter-torch
+haliax-unit
+iris-unit
+zephyr-unit
+fray-unit
+marin-integration
+```
+
+Required-context mapping:
+
+| Current workflow | Current job id / context | Target workflow | Target job id / context |
+| --- | --- | --- | --- |
+| `marin-lint-and-format.yaml` | `lint-and-format` | `marin-lint.yaml` | `marin-lint` |
+| `marin-docs.yaml` | `build-docs` | `marin-docs.yaml` | `marin-docs` |
+| `marin-unit-tests.yaml` | `marin-tests` | `marin-unit.yaml` | `marin-unit` |
+| `levanter-tests.yaml` | `levanter-tests` | `levanter-unit.yaml` | `levanter-unit` |
+| `levanter-tests.yaml` | `levanter-entry-tests` | `levanter-unit.yaml` | `levanter-entry` |
+| `levanter-tests.yaml` | `levanter-torch-tests` | `levanter-unit.yaml` | `levanter-torch` |
+| `haliax-run_tests.yaml` | `haliax-tests` | `haliax-unit.yaml` | `haliax-unit` |
+| `iris-unit-tests.yaml` | `iris-tests` | `iris-unit.yaml` | `iris-unit` |
+| `zephyr-unit-tests.yaml` | `zephyr-tests` | `zephyr-unit.yaml` | `zephyr-unit` |
+| `fray-unit-tests.yaml` | `fray-tests` | `fray-unit.yaml` | `fray-unit` |
+| `marin-itest.yaml` | `marin-itest` | `marin-integration.yaml` | `marin-integration` |
+
+Required checks should use stable job ids as the context source. If a job also sets a display `name:`, it must either equal the job id for required jobs or be verified in GitHub before branch protection is patched. Matrix jobs must not become required contexts unless the matrix-expanded context names are explicitly listed in this table.
+
+## Landing Sequence
+
+The work should land in three large PRs.
+
+### PR 1: Foundation and Low-Risk Workflows
+
+Required content:
+
+- Add `scripts/workflows/changes.py`, `pull_request.py`, and `github_actions.py`.
+- Add `.github/workflows/README.md`.
+- Update `pyproject.toml` so `scripts/workflows/**` is linted and type checked.
+- Replace `dorny/paths-filter` usages in unit/docs/lint/release workflows with `changes.py`.
+- Replace `peter-evans/create-pull-request@v7` in `dupekit-wheels.yaml` with `pull_request.py`.
+- Pin all non-trusted third-party actions to full SHAs, including `dorny/paths-filter`, `peaceiris/actions-gh-pages`, `actions/github-script` if retained, `actions/stale`, `anthropics/claude-code-action`, and `conda-incubator/setup-miniconda`.
+- Keep existing required job ids unchanged in this PR unless branch protection is updated in the same PR window.
+
+Workflow scope:
+
+- `dupekit-unit-tests.yaml`
+- `dupekit-wheels.yaml`
+- `fray-unit-tests.yaml`
+- `haliax-run_tests.yaml`
+- `iris-unit-tests.yaml`
+- `levanter-tests.yaml`
+- `marin-docs.yaml`
+- `marin-lint-and-format.yaml`
+- `marin-unit-tests.yaml`
+- `zephyr-unit-tests.yaml`
+- `grug-variant-diff.yaml`
+- `stale.yml`
+
+### PR 2: Iris, Ferries, and Live-Infrastructure Workflows
+
+Required content:
+
+- Add `scripts/workflows/iris_job.py` and `iris_diagnostics.py`.
+- Migrate all copied Iris wait loops to `iris_job.py wait`.
+- Migrate all copied GCP/CoreWeave diagnostics to `iris_diagnostics.py collect`.
+- Convert workflow-specific notification shell to existing `scripts/ops/discord.py` where practical.
+- Preserve provider-specific setup in YAML until the behavior is proven scriptable. Do not restart or bounce Iris clusters as part of this migration.
+
+Workflow scope:
+
+- `iris-cloud-smoke-gcp.yaml`
+- `iris-coreweave-ci.yaml`
+- `iris-dev-restart.yaml`
+- `marin-canary-ferry.yaml`
+- `marin-canary-ferry-cw.yaml`
+- `marin-datakit-smoke.yaml`
+- `marin-datakit-nemotron-ferry.yaml`
+- `zephyr-shuffle-itest.yaml`
+- `levanter-gpt2_small_itest.yaml`
+- `levanter-launch_small_fast.yaml`
+
+### PR 3: Names, Branch Protection, and Remaining Consolidation
+
+Required content:
+
+- Rename workflow files to the target table above.
+- Rename displayed workflow names and non-required job ids to the target convention.
+- Rename required job ids with a two-step branch-protection rollout:
+
+1. Before merging the rename PR, add the target contexts to branch protection while keeping the current contexts. This is safe because the target contexts will be pending until the rename PR runs them, so the PR itself should not be merged until those checks appear and pass.
+2. Merge the rename PR after both old and new required checks are satisfied or after maintainers confirm that old contexts are no longer emitted for that branch.
+3. After the renamed workflows have run once on `main`, remove the old contexts from branch protection and leave only the target contexts.
+
+Verification commands:
+
+```bash
+gh api repos/marin-community/marin/branches/main/protection \
+  --jq '.required_status_checks.contexts'
+gh pr checks <rename-pr-number> --required
+```
+
+Patch command:
+
+```bash
+gh api --method PATCH repos/marin-community/marin/branches/main/protection \
+  --input branch-protection.json
+```
+
+`branch-protection.json` must preserve all existing protection settings and replace only `required_status_checks.contexts` / `required_status_checks.checks` as needed.
+
+Rollback: if renamed workflows fail to emit the expected contexts, restore the previous workflow/job names in git and patch branch protection back to the previous context list captured from the verification command. The active `protect main` ruleset should be checked with `gh api repos/marin-community/marin/rulesets`; if required checks move into rulesets before implementation, the same add-new-before-remove-old sequence applies through the rulesets API instead of classic branch protection.
+
+- Consolidate workflows only when scripts have made differences parameterizable. The main candidate is `iris-smoke-gcp.yaml` plus `iris-smoke-coreweave.yaml` into `iris-smoke.yaml`; this is optional and should not block naming cleanup.
+- Run `github_actions.py audit` in CI so new workflows follow the model.
+
+Workflow scope:
+
+- All 33 workflows.
+
+## Out of Scope
+
+- Replacing trusted setup/auth/build primitives such as `actions/checkout`, `actions/setup-python`, `actions/cache`, `actions/upload-artifact`, `astral-sh/setup-uv`, `google-github-actions/*`, and Docker setup/login/build actions.
+- Introducing reusable workflows before scripts remove duplicated behavior.
+- Changing what tests run inside unit/integration/smoke workflows, except where required by script extraction.
+- Changing live Iris cluster lifecycle policy.
+- Creating a generic `scripts/workflows/lib/` package before repeated helper pressure exists.


### PR DESCRIPTION
Organize Marin GitHub Actions around repo-owned Python workflow scripts so YAML becomes mostly triggers, permissions, runners, matrices, and script invocation. The design standardizes domain-first workflow naming, makes workflow behavior locally reproducible through scripts/workflows, pins non-trusted third-party actions by SHA, and stages the migration across foundation, Iris/ferry extraction, and final rename/branch-protection PRs. Part of #5067.

Design: https://github.com/marin-community/marin/blob/design/workflow_scripts/.agents/projects/workflow_scripts/design.md
Spec: https://github.com/marin-community/marin/blob/design/workflow_scripts/.agents/projects/workflow_scripts/spec.md
Research: https://github.com/marin-community/marin/blob/design/workflow_scripts/.agents/projects/workflow_scripts/research.md

Discussion welcome — see Open Questions in design.md.