### PR TITLE
Updatetimeout and increase parallelism in CI

### DIFF
--- a/.github/workflows/marin-unit-tests.yaml
+++ b/.github/workflows/marin-unit-tests.yaml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20.10.0"
-      
+
       - name: Test with pytest
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -69,4 +69,4 @@ jobs:
           RAY_ENABLE_UV_RUN_RUNTIME_ENV: "0"
         run: |
           # Ensure we select the CPU torch wheels (and JAX CPU) for unit tests on GitHub runners.
-          PYTHONPATH=tests:. uv run --package marin --extra cpu --frozen pytest -n 2 --dist=worksteal --durations=5 --tb=short -m 'not slow and not tpu_ci' -v tests/
+          PYTHONPATH=tests:. uv run --package marin --extra cpu --frozen pytest -n 4 --dist=worksteal --durations=5 --tb=short -m 'not slow and not tpu_ci' -v tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,4 +229,4 @@ testpaths = ["tests", "experiments"]
 # Don't run TPU, slow, or integration tests by default. Integration tests
 # require external infrastructure (Iris cluster, GCS, gated HF repos, etc.)
 # and are run from dedicated CI workflows.
-addopts = "--session-timeout=480 -m 'not tpu_ci and not slow and not integration'"
+addopts = "--session-timeout=600 -m 'not tpu_ci and not slow and not integration'"


### PR DESCRIPTION
`marin-tests` is currently timing out for me in https://github.com/marin-community/marin/pull/5286. I think this runs on a machine with 4 vCPUs so increasing parallelism might help, but also bumping the timeout.
