### PR TITLE
finelog: include config/ in docker build context

### DIFF
--- a/lib/finelog/deploy/Dockerfile.dockerignore
+++ b/lib/finelog/deploy/Dockerfile.dockerignore
@@ -4,6 +4,7 @@
 
 !lib/finelog/pyproject.toml
 !lib/finelog/src/
+!lib/finelog/config/
 
 !lib/rigging/
 


### PR DESCRIPTION
The Dockerfile copies lib/finelog/config/ (required by hatchling's force-include during wheel build, and by the deploy CLI's bundled-config fallback) but Dockerfile.dockerignore excluded it via the default-deny allowlist, breaking the finelog-image job. Add the directory to the allowlist.