### PR TITLE
finelog: fixup `/var/cache/finelog` permissions

### DIFF
--- a/lib/finelog/src/finelog/deploy/bootstrap.py
+++ b/lib/finelog/src/finelog/deploy/bootstrap.py
@@ -61,6 +61,8 @@ sudo systemctl start docker || true
 # Cache directory on the boot disk. Finelog offloads parquet segments to GCS
 # via FINELOG_REMOTE_DIR, so the boot disk only needs working space.
 sudo mkdir -p {{ cache_dir }}
+# 1000 matches the finelog user **inside** the container
+sudo chown 1000:1000 {{ cache_dir }}
 
 echo "[finelog-init] Pulling image: {{ docker_image }}"
 sudo docker pull {{ docker_image }}


### PR DESCRIPTION
* fixes https://github.com/marin-community/marin/issues/5296
* before https://github.com/marin-community/marin/pull/5271 was deployed, I've deployed it on `marin-dev`
  * there were permission errors on `marin-dev` on access to `/var/cache/finelog`
    * `/var/cache/finelog` was owned by root
  * on prod `/var/cache/finelog` was owned by `1000`
    * after making the same manual fix on dev - marin-dev looked healthy and I was able to send logs using both new and legacy endpoints
* this PR fixes the finelog startup script to set `/var/cache/finelog` owner to 1000, which because the numbers align will allow the finelog user in the container to write to the host dir

FYI the https://github.com/marin-community/marin/pull/5271 fix was then deployed to prod, and I confirmed that the affected workers resumed logging:

> < logging errors >
> 2026-04-30 02:01:50,757 INFO iris.log_server.client LogPusher: invalidating cached endpoint for /system/log-server (ConnectError(UNAVAILABLE))
2026-04-30 02:02:21,350 INFO iris.log_server.client LogPusher resolved /system/log-server -> http://10.128.0.128:10001
> < no logging errors >