### PR TITLE
Add allenai/Molmo2-Cap as a Datakit source

### DIFF
--- a/experiments/pretraining_datasets/molmo2_cap.py
+++ b/experiments/pretraining_datasets/molmo2_cap.py
@@ -1,0 +1,37 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Molmo2-Cap dataset tokenization."""
+
+from fray import ResourceConfig
+
+from marin.datakit.download.molmo2_cap import molmo2_cap_normalize_steps
+from marin.execution.executor import ExecutorStep, executor_main, this_output_path, versioned
+from marin.processing.tokenize import TokenizeConfig, tokenize
+from marin.processing.tokenize.data_configs import TokenizerStep
+
+molmo2_cap_normalized = molmo2_cap_normalize_steps()[-1].as_executor_step()
+
+
+def tokenize_molmo2_cap(*, tokenizer: str | None = None) -> TokenizerStep:
+    """Tokenize the normalized Molmo2-Cap captions."""
+    if tokenizer is None:
+        from experiments.marin_models import marin_tokenizer
+
+        tokenizer = marin_tokenizer
+
+    return ExecutorStep(
+        name="tokenized/molmo2_cap",
+        fn=tokenize,
+        config=TokenizeConfig(
+            train_paths=[molmo2_cap_normalized.as_input_name() / "outputs/main/*.parquet"],
+            validation_paths=versioned([]),
+            cache_path=this_output_path(),
+            tokenizer=versioned(tokenizer),
+            worker_resources=ResourceConfig(ram="16g", disk="5g", preemptible=True),
+        ),
+    )
+
+
+if __name__ == "__main__":
+    executor_main(steps=[tokenize_molmo2_cap()])

--- a/lib/marin/src/marin/datakit/download/molmo2_cap.py
+++ b/lib/marin/src/marin/datakit/download/molmo2_cap.py
@@ -1,0 +1,89 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""allenai/Molmo2-Cap dataset download and transform.
+
+Long-form video captioning dataset. Each row carries a paragraph-level
+``merged_caption`` plus per-frame captions with timestamps. We render each
+row as the merged caption followed by timestamp-labeled frame captions.
+"""
+
+import hashlib
+
+from fray import ResourceConfig
+from zephyr import Dataset, ZephyrContext, counters, load_parquet
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.normalize import normalize_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "allenai/Molmo2-Cap"
+HF_REVISION = "b1d59eb"
+
+
+def row_to_doc(row: dict) -> list[dict]:
+    merged = row.get("merged_caption") or ""
+    frame_timestamps = row.get("frame_timestamps") or []
+    frame_captions = row.get("frame_captions") or []
+
+    if not merged.strip():
+        counters.increment("molmo2_cap/dropped")
+        return []
+
+    parts = [merged.strip()]
+    for ts, cap in zip(frame_timestamps, frame_captions, strict=False):
+        cap = (cap or "").strip()
+        if not cap:
+            continue
+        parts.append(f"[Frame at {ts:.2f}s] {cap}")
+
+    text = "\n\n".join(parts)
+
+    counters.increment("molmo2_cap/kept")
+    return [
+        {
+            "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "text": text,
+            "source": HF_DATASET_ID,
+        }
+    ]
+
+
+def transform(input_path: str, output_path: str) -> None:
+    pipeline = (
+        Dataset.from_files(f"{input_path}/**/*.parquet")
+        .flat_map(load_parquet)
+        .flat_map(row_to_doc)
+        .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
+    )
+    ctx = ZephyrContext(name="molmo2-cap-transform", resources=ResourceConfig(cpu=1, ram="8g"))
+    ctx.execute(pipeline)
+
+
+def download_molmo2_cap_step() -> StepSpec:
+    """Download and transform Molmo2-Cap into JSONL documents."""
+    dl = download_hf_step(
+        "raw/molmo2-cap",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=["data/train-*.parquet"],
+    )
+
+    return StepSpec(
+        name="processed/molmo2-cap",
+        deps=[dl],
+        fn=lambda output_path: transform(
+            input_path=dl.output_path,
+            output_path=output_path,
+        ),
+        hash_attrs={"version": "v1"},
+    )
+
+
+def molmo2_cap_normalize_steps() -> tuple[StepSpec, ...]:
+    """Return the full ``(download+transform, normalize)`` chain for molmo2-cap."""
+    processed = download_molmo2_cap_step()
+    return (
+        processed,
+        normalize_step(name="normalized/molmo2-cap", download=processed),
+    )

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -22,6 +22,7 @@ from marin.datakit.download.common_pile import common_pile_normalize_steps
 from marin.datakit.download.finepdfs import finepdfs_normalize_steps
 from marin.datakit.download.gpt_oss_rollouts import gpt_oss_rollouts_normalize_steps
 from marin.datakit.download.institutional_books import institutional_books_normalize_steps
+from marin.datakit.download.molmo2_cap import molmo2_cap_normalize_steps
 from marin.datakit.download.nemotron_terminal import nemotron_terminal_normalize_steps
 from marin.datakit.download.nemotron_v2 import nemotron_v2_normalize_steps
 from marin.datakit.download.nsf_awards import nsf_awards_normalize_steps
@@ -138,6 +139,7 @@ def all_sources() -> dict[str, DatakitSource]:
         ("coderforge", coderforge_normalize_steps, 10.29),
         ("gpt-oss-rollouts", gpt_oss_rollouts_normalize_steps, 3.20),
         ("institutional_books", institutional_books_normalize_steps, 203.63),
+        ("molmo2-cap", molmo2_cap_normalize_steps, 0.36),
         ("nemotron-terminal", nemotron_terminal_normalize_steps, 6.08),
         ("nsf_awards", nsf_awards_normalize_steps, 0.17),
         ("superior-reasoning", superior_reasoning_normalize_steps, 7.08),


### PR DESCRIPTION
🤖 Authored by Claude on behalf of @Helw150.

## What is Molmo2-Cap?

[allenai/Molmo2-Cap](https://huggingface.co/datasets/allenai/Molmo2-Cap) is the long-form video captioning corpus released alongside the Molmo 2 vision-language family. Each row covers one video and carries:

- `merged_caption` — a paragraph-level natural-language description of the whole video
- `frame_captions` + `frame_timestamps` — per-frame captions tied to specific timestamps within the video

For text-only pretraining we render each row as the merged paragraph followed by timestamp-tagged per-frame lines (`[Frame at 12.40s] ...`). That gives the model dense, temporally-grounded narrative text without needing the underlying video frames. 104,002 train videos in total.

## Summary

- New download module `lib/marin/src/marin/datakit/download/molmo2_cap.py` that pulls the train parquets and renders rows into the format above.
- Registry entry in `lib/marin/src/marin/datakit/sources.py` so the standard normalize chain runs alongside the other datakit sources.
- Pretraining tokenization step in `experiments/pretraining_datasets/molmo2_cap.py` mirroring the `common_corpus.py` shape; uses `marin-community/marin-tokenizer`. Worker resources set to `preemptible=True` so the tokenize fan-out actually schedules under current cluster pressure.

Live tokenize run on the marin cluster (us-central1) produced **361,102,745** tokens (~0.36B) across the 104,002 docs; output landed at `gs://marin-us-central1/tokenized/molmo2_cap-337a24/`. The registry docstring quotes Llama-3 token counts, so this entry is measured with the marin tokenizer rather than strictly apples-to-apples — a directional 0.36 B that's closer than the prior 0.40 B back-of-envelope estimate.

## Test plan

- [x] `./infra/pre-commit.py --fix` on the three changed files — clean (ruff/black/pyrefly all OK)
- [x] End-to-end run on `marin` cluster (us-central1): download → transform → normalize → tokenize all succeeded; outputs verified on GCS.
- [ ] Re-run on a fresh worker via `scripts/datakit/run_source_normalizations.py` to confirm the registry chain cache-skips cleanly.