### PR TITLE
Add lambda/hermes-agent-reasoning-traces as a Datakit source

### DIFF
--- a/experiments/rollout_data/hermes_agent_reasoning_traces.py
+++ b/experiments/rollout_data/hermes_agent_reasoning_traces.py
@@ -1,0 +1,42 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""lambda/hermes-agent-reasoning-traces tokenization terminal.
+
+Usage:
+    uv run iris --cluster=marin job run --preemptible --region=us-central1 \
+      --cpu=1 --memory=2G \
+      -- python -m experiments.rollout_data.hermes_agent_reasoning_traces
+"""
+
+from marin.datakit.download.hermes_agent_reasoning_traces import (
+    download_hermes_agent_reasoning_traces_step,
+)
+from marin.execution.step_runner import StepRunner
+from marin.execution.step_spec import StepSpec
+from marin.processing.tokenize import TokenizeConfig, tokenize
+from experiments.marin_models import marin_tokenizer
+
+
+def build_steps() -> list[StepSpec]:
+    processed = download_hermes_agent_reasoning_traces_step()
+
+    tokenized = StepSpec(
+        name="tokenized/hermes-agent-reasoning-traces",
+        deps=[processed],
+        fn=lambda output_path: tokenize(
+            TokenizeConfig(
+                train_paths=[processed.output_path],
+                validation_paths=[],
+                cache_path=output_path,
+                tokenizer=marin_tokenizer,
+            )
+        ),
+        hash_attrs={"tokenizer": marin_tokenizer},
+    )
+
+    return [*processed.deps, processed, tokenized]
+
+
+if __name__ == "__main__":
+    StepRunner().run(build_steps())

--- a/lib/marin/src/marin/datakit/download/hermes_agent_reasoning_traces.py
+++ b/lib/marin/src/marin/datakit/download/hermes_agent_reasoning_traces.py
@@ -1,0 +1,92 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""lambda/hermes-agent-reasoning-traces dataset download and transform.
+
+Multi-turn tool-calling trajectories produced by the Hermes agent harness,
+with two source-model configs (kimi, glm-5.1). Each row carries a ShareGPT
+conversation (``from``/``value`` turns) interleaving ``<think>`` reasoning,
+``<tool_call>`` invocations, and ``<tool_response>`` execution results, plus
+a JSON ``tools`` definition listing the tools available to the agent.
+"""
+
+import hashlib
+
+from fray import ResourceConfig
+from zephyr import Dataset, ZephyrContext, counters
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.normalize import normalize_step
+from marin.datakit.download.rollout_transforms import load_parquet_batched
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "lambda/hermes-agent-reasoning-traces"
+HF_REVISION = "b92885e"
+
+CONFIGS = ("kimi", "glm-5.1")
+
+
+def render_message(msg: dict) -> str:
+    role = msg.get("from", "unknown")
+    value = msg.get("value") or ""
+    return f"<{role}>\n{value}\n</{role}>"
+
+
+def row_to_doc(row: dict) -> list[dict]:
+    conversations = row.get("conversations")
+    if not conversations:
+        counters.increment("hermes_agent_reasoning_traces/dropped")
+        return []
+
+    tools = row.get("tools") or ""
+    rendered = "\n\n".join(render_message(m) for m in conversations)
+    text = f"<tools>\n{tools}\n</tools>\n\n{rendered}" if tools else rendered
+
+    counters.increment("hermes_agent_reasoning_traces/kept")
+    return [
+        {
+            "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "text": text,
+            "source": HF_DATASET_ID,
+        }
+    ]
+
+
+def transform(input_path: str, output_path: str) -> None:
+    pipeline = (
+        Dataset.from_files(f"{input_path}/data/**/train.parquet")
+        .flat_map(load_parquet_batched)
+        .flat_map(row_to_doc)
+        .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
+    )
+    ctx = ZephyrContext(name="hermes-agent-reasoning-traces-transform", resources=ResourceConfig(cpu=1, ram="32g"))
+    ctx.execute(pipeline)
+
+
+def download_hermes_agent_reasoning_traces_step() -> StepSpec:
+    """Download and transform hermes-agent-reasoning-traces into JSONL documents."""
+    dl = download_hf_step(
+        "raw/hermes-agent-reasoning-traces",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=[f"data/{config}/train.parquet" for config in CONFIGS],
+    )
+
+    return StepSpec(
+        name="processed/hermes-agent-reasoning-traces",
+        deps=[dl],
+        fn=lambda output_path: transform(
+            input_path=dl.output_path,
+            output_path=output_path,
+        ),
+        hash_attrs={"version": "v1"},
+    )
+
+
+def hermes_agent_reasoning_traces_normalize_steps() -> tuple[StepSpec, ...]:
+    """Return the full ``(download+transform, normalize)`` chain for hermes-agent-reasoning-traces."""
+    processed = download_hermes_agent_reasoning_traces_step()
+    return (
+        processed,
+        normalize_step(name="normalized/hermes-agent-reasoning-traces", download=processed),
+    )

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -27,6 +27,7 @@ from marin.datakit.download.davinci_dev import (
 from marin.datakit.download.diagnostic_logs import GHALOGS_ROUGH_TOKENS_B, ghalogs_public_normalize_steps
 from marin.datakit.download.finepdfs import finepdfs_normalize_steps
 from marin.datakit.download.gpt_oss_rollouts import gpt_oss_rollouts_normalize_steps
+from marin.datakit.download.hermes_agent_reasoning_traces import hermes_agent_reasoning_traces_normalize_steps
 from marin.datakit.download.hplt import hplt_v3_normalize_steps
 from marin.datakit.download.institutional_books import institutional_books_normalize_steps
 from marin.datakit.download.massive import massive_normalize_steps
@@ -149,6 +150,7 @@ def all_sources() -> dict[str, DatakitSource]:
         ("davinci-dev/env-native", davinci_dev_env_native_normalize_steps, 2.58),
         ("ghalogs/public", ghalogs_public_normalize_steps, GHALOGS_ROUGH_TOKENS_B),
         ("gpt-oss-rollouts", gpt_oss_rollouts_normalize_steps, 3.20),
+        ("hermes-agent-reasoning-traces", hermes_agent_reasoning_traces_normalize_steps, 0.38),
         ("hplt_v3", hplt_v3_normalize_steps, 612.7),
         ("institutional_books", institutional_books_normalize_steps, 203.63),
         ("massive_function_calling", massive_normalize_steps, 11.39),


### PR DESCRIPTION
🤖 Authored by Claude on behalf of @Helw150.

## What is hermes-agent-reasoning-traces?

[lambda/hermes-agent-reasoning-traces](https://huggingface.co/datasets/lambda/hermes-agent-reasoning-traces) is a multi-turn tool-calling reasoning corpus produced by the Hermes agent harness. Each row carries:

- `conversations` — a ShareGPT-style turn list (`from`/`value`) interleaving `<think>` reasoning, `<tool_call>` invocations, and `<tool_response>` execution results
- `tools` — the JSON tool-spec block listing the tools available to the agent for that trajectory

The dataset ships two source-model configs, `kimi` and `glm-5.1`, both materialized as `data/<config>/train.parquet` (the older flat-parquet layout in the repo root is ignored — globbing on `data/<config>/train.parquet` keeps us on the maintained shards). For pretraining we render each row as `<tools>...JSON...</tools>` followed by `\n\n`-joined `<from>\n{value}\n</from>` blocks so the trajectory keeps its role/tool structure as plain text. 14,701 trajectories total.

## Summary

- New download module `lib/marin/src/marin/datakit/download/hermes_agent_reasoning_traces.py` that pulls the per-config train parquets (revision `b92885e`) and renders rows into the format above.
- Registry entry in `lib/marin/src/marin/datakit/sources.py` so the standard normalize chain runs alongside the other datakit sources.
- Tokenization terminal in `experiments/rollout_data/hermes_agent_reasoning_traces.py` mirroring `synthetic1.py` / `nemotron_terminal.py`; uses `marin-community/marin-tokenizer`.

Live tokenize run on the marin cluster (us-central1) produced **381,715,971** tokens (~0.38 B) across 14,701 docs; output landed at `gs://marin-us-central1/tokenized/hermes-agent-reasoning-traces_f2ee2f0a/`. Registry token estimate set to 0.38 (measured with the marin tokenizer, not strictly apples-to-apples vs the Llama-3 quotes in the docstring).

## Test plan

- [x] `./infra/pre-commit.py --fix` on the three changed files — clean (ruff/black/pyrefly all OK)
- [x] End-to-end run on `marin` cluster (us-central1): download → transform → tokenize all succeeded; outputs verified on GCS (`shard_ledger.json` is `is_finished: true`).
- [ ] Re-run via `scripts/datakit/run_source_normalizations.py` to confirm the registry chain cache-skips cleanly and produces the `normalized/` artifact.