### PR TITLE
Add nyuuzyou/svgfind to datakit sources (creativecommons)

### DIFF
--- a/experiments/pretraining_datasets/svg.py
+++ b/experiments/pretraining_datasets/svg.py
@@ -1,0 +1,22 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""SVG (nyuuzyou/svgfind) dataset download, normalization, and tokenization."""
+
+from experiments.marin_models import marin_tokenizer
+from marin.datakit.download.svgfind import svgfind_creativecommons_normalize_steps
+from marin.execution.executor import ExecutorStep, output_path_of, this_output_path, versioned
+from marin.processing.tokenize import TokenizeConfig, tokenize
+
+svg_normalized = svgfind_creativecommons_normalize_steps()[-1].as_executor_step()
+
+svg_tokenized = ExecutorStep(
+    name="tokenized/svg",
+    fn=tokenize,
+    config=TokenizeConfig(
+        train_paths=[output_path_of(svg_normalized, "outputs/main/*.parquet")],
+        validation_paths=versioned([]),
+        cache_path=this_output_path(),
+        tokenizer=versioned(marin_tokenizer),
+    ),
+)

--- a/experiments/pretraining_datasets/svg.py
+++ b/experiments/pretraining_datasets/svg.py
@@ -5,7 +5,7 @@
 
 from experiments.marin_models import marin_tokenizer
 from marin.datakit.download.svgfind import svgfind_creativecommons_normalize_steps
-from marin.execution.executor import ExecutorStep, output_path_of, this_output_path, versioned
+from marin.execution.executor import ExecutorStep, executor_main, output_path_of, this_output_path, versioned
 from marin.processing.tokenize import TokenizeConfig, tokenize
 
 svg_normalized = svgfind_creativecommons_normalize_steps()[-1].as_executor_step()
@@ -20,3 +20,7 @@ svg_tokenized = ExecutorStep(
         tokenizer=versioned(marin_tokenizer),
     ),
 )
+
+
+if __name__ == "__main__":
+    executor_main(steps=[svg_tokenized])

--- a/experiments/pretraining_datasets/svg.py
+++ b/experiments/pretraining_datasets/svg.py
@@ -3,10 +3,11 @@
 
 """SVG (nyuuzyou/svgfind) dataset download, normalization, and tokenization."""
 
-from experiments.marin_models import marin_tokenizer
 from marin.datakit.download.svgfind import svgfind_creativecommons_normalize_steps
 from marin.execution.executor import ExecutorStep, executor_main, output_path_of, this_output_path, versioned
 from marin.processing.tokenize import TokenizeConfig, tokenize
+
+from experiments.marin_models import marin_tokenizer
 
 svg_normalized = svgfind_creativecommons_normalize_steps()[-1].as_executor_step()
 

--- a/lib/marin/src/marin/datakit/download/svgfind.py
+++ b/lib/marin/src/marin/datakit/download/svgfind.py
@@ -1,0 +1,101 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""nyuuzyou/svgfind dataset download and transform.
+
+The HF dataset stores rows as zstd-compressed JSONL, sharded by license. Each
+row carries a title, a data-pack name (which encodes icon style — e.g.
+``ui-outlines``, ``basic-ui-solid``), a list of search tags, and the raw SVG
+markup as a string.
+
+We render each row to a single SFT document where a short description prefix
+conditions the model and the raw SVG markup is the target completion::
+
+    Create an SVG which matches the following description.
+    Title: messaging
+    Data Pack: ui-outlines
+    Tags: messaging, messaging app, chat app, chat
+
+    <svg ...>...</svg>
+
+Only the ``CREATIVECOMMONS`` shards are wired up; the ``PUBLICDOMAIN`` shard
+can be added later if needed.
+"""
+
+from fray import ResourceConfig
+from zephyr import Dataset, ZephyrContext, counters, load_jsonl
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.normalize import normalize_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "nyuuzyou/svgfind"
+HF_REVISION = "4d29c79273411f989625fa9f06419b9753ec5e12"
+
+CC_GLOBS = ["svgfind-CREATIVECOMMONS_*.jsonl.zst"]
+
+
+def svgfind_row_to_doc(row: dict) -> list[dict]:
+    title = row.get("title") or ""
+    svg = row.get("svg_content") or ""
+    if not title or not svg:
+        counters.increment("svgfind/cc/dropped")
+        return []
+
+    tags = ", ".join(row.get("tags") or [])
+    data_pack = row.get("data_pack") or ""
+    text = (
+        "Create an SVG which matches the following description.\n"
+        f"Title: {title}\n"
+        f"Data Pack: {data_pack}\n"
+        f"Tags: {tags}\n\n"
+        f"{svg}"
+    )
+
+    counters.increment("svgfind/cc/kept")
+    return [
+        {
+            "id": row["id"],
+            "text": text,
+            "source": "nyuuzyou/svgfind/creativecommons",
+        }
+    ]
+
+
+def transform_svgfind_creativecommons(input_path: str, output_path: str) -> None:
+    pipeline = (
+        Dataset.from_files(f"{input_path}/svgfind-CREATIVECOMMONS_*.jsonl.zst")
+        .flat_map(load_jsonl)
+        .flat_map(svgfind_row_to_doc)
+        .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
+    )
+    ctx = ZephyrContext(name="svgfind-cc-transform", resources=ResourceConfig(cpu=1, ram="32g"))
+    ctx.execute(pipeline)
+
+
+def download_svgfind_creativecommons_step() -> StepSpec:
+    """Download and render svgfind's CREATIVECOMMONS shards as SFT docs."""
+    dl = download_hf_step(
+        "raw/svgfind-creativecommons",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=CC_GLOBS,
+    )
+    return StepSpec(
+        name="processed/svgfind-creativecommons",
+        deps=[dl],
+        fn=lambda output_path: transform_svgfind_creativecommons(
+            input_path=dl.output_path,
+            output_path=output_path,
+        ),
+        hash_attrs={"version": "v1"},
+    )
+
+
+def svgfind_creativecommons_normalize_steps() -> tuple[StepSpec, ...]:
+    """Return the full ``(download+transform, normalize)`` chain for svgfind CC."""
+    processed = download_svgfind_creativecommons_step()
+    return (
+        processed,
+        normalize_step(name="normalized/svgfind-creativecommons", download=processed),
+    )

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -150,8 +150,7 @@ def all_sources() -> dict[str, DatakitSource]:
         ("nemotron-terminal", nemotron_terminal_normalize_steps, 6.08),
         ("nsf_awards", nsf_awards_normalize_steps, 0.17),
         ("superior-reasoning", superior_reasoning_normalize_steps, 7.08),
-        # Token count is a rough estimate from a 100-row sample: ~1700 chars/doc, ~3.5 chars/tok.
-        ("svg", svgfind_creativecommons_normalize_steps, 1.70),
+        ("svg", svgfind_creativecommons_normalize_steps, 8.95),
         ("swe-rebench-openhands", swe_rebench_openhands_normalize_steps, 2.47),
         ("synthetic-1", synthetic1_normalize_steps, 7.32),
     )

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -32,6 +32,7 @@ from marin.datakit.download.nemotron_v2 import nemotron_v2_normalize_steps
 from marin.datakit.download.nsf_awards import nsf_awards_normalize_steps
 from marin.datakit.download.starcoder2_extras import starcoder2_extras_normalize_steps
 from marin.datakit.download.superior_reasoning import superior_reasoning_normalize_steps
+from marin.datakit.download.svgfind import svgfind_creativecommons_normalize_steps
 from marin.datakit.download.swe_rebench_openhands import swe_rebench_openhands_normalize_steps
 from marin.datakit.download.synthetic1 import synthetic1_normalize_steps
 from marin.execution.step_spec import StepSpec
@@ -149,6 +150,8 @@ def all_sources() -> dict[str, DatakitSource]:
         ("nemotron-terminal", nemotron_terminal_normalize_steps, 6.08),
         ("nsf_awards", nsf_awards_normalize_steps, 0.17),
         ("superior-reasoning", superior_reasoning_normalize_steps, 7.08),
+        # Token count is a rough estimate from a 100-row sample: ~1700 chars/doc, ~3.5 chars/tok.
+        ("svg", svgfind_creativecommons_normalize_steps, 1.70),
         ("swe-rebench-openhands", swe_rebench_openhands_normalize_steps, 2.47),
         ("synthetic-1", synthetic1_normalize_steps, 7.32),
     )

--- a/tests/datakit/download/test_svgfind.py
+++ b/tests/datakit/download/test_svgfind.py
@@ -1,0 +1,67 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the svgfind row → SFT document formatter."""
+
+from marin.datakit.download.svgfind import svgfind_row_to_doc
+
+SAMPLE_ROW = {
+    "id": "10000206",
+    "title": "messaging",
+    "data_pack": "ui-outlines",
+    "tags": [
+        "messaging",
+        "messaging app",
+        "messaging service",
+        "chat app",
+        "chat service",
+        "chat",
+    ],
+    "license": "CREATIVECOMMONS",
+    "license_owner": "Adrian Adam",
+    "download_url": "https://www.svgfind.com/download/10000206/messaging.svg",
+    "svg_content": (
+        '<svg fill="#000" width="800" height="800" viewBox="144 144 512 512" '
+        'xmlns="http://www.w3.org/2000/svg"><path d="m1 2 3 4z"/></svg>'
+    ),
+}
+
+
+def test_svgfind_row_to_doc_matches_expected_layout():
+    expected_text = (
+        "Create an SVG which matches the following description.\n"
+        "Title: messaging\n"
+        "Data Pack: ui-outlines\n"
+        "Tags: messaging, messaging app, messaging service, chat app, chat service, chat\n"
+        "\n"
+        '<svg fill="#000" width="800" height="800" viewBox="144 144 512 512" '
+        'xmlns="http://www.w3.org/2000/svg"><path d="m1 2 3 4z"/></svg>'
+    )
+    [doc] = svgfind_row_to_doc(SAMPLE_ROW)
+    assert doc == {
+        "id": "10000206",
+        "text": expected_text,
+        "source": "nyuuzyou/svgfind/creativecommons",
+    }
+
+
+def test_svgfind_row_to_doc_preserves_svg_verbatim():
+    [doc] = svgfind_row_to_doc(SAMPLE_ROW)
+    assert doc["text"].endswith(SAMPLE_ROW["svg_content"])
+
+
+def test_svgfind_row_to_doc_preserves_tag_order_and_duplicates():
+    row = {**SAMPLE_ROW, "tags": ["a", "a b", "a", "c"]}
+    [doc] = svgfind_row_to_doc(row)
+    assert "Tags: a, a b, a, c\n" in doc["text"]
+
+
+def test_svgfind_row_to_doc_handles_empty_tags():
+    row = {**SAMPLE_ROW, "tags": []}
+    [doc] = svgfind_row_to_doc(row)
+    assert "Tags: \n" in doc["text"]
+
+
+def test_svgfind_row_to_doc_drops_rows_missing_title_or_svg():
+    assert svgfind_row_to_doc({**SAMPLE_ROW, "title": ""}) == []
+    assert svgfind_row_to_doc({**SAMPLE_ROW, "svg_content": ""}) == []


### PR DESCRIPTION
## Summary
- New `svg` Datakit source backed by the CREATIVECOMMONS shards of [`nyuuzyou/svgfind`](https://huggingface.co/datasets/nyuuzyou/svgfind) (~3.6M icons, pinned to revision `4d29c79`).
- Each row renders to one SFT document — a `Title:` / `Data Pack:` / `Tags:` prefix followed by the raw `<svg>...</svg>` markup verbatim. The prefix conditions the model on a short description; the SVG is the target completion.
- Registered in `all_sources()` with rough token count `1.70`B (extrapolated from a 100-row sample at ~1700 chars/doc, ~3.5 chars/tok). Worth refining once the normalize finishes.

## Example document
```
Create an SVG which matches the following description.
Title: messaging
Data Pack: ui-outlines
Tags: messaging, messaging app, messaging service, chat app, chat service, chat

<svg fill="#000" width="800" height="800" viewBox="144 144 512 512" xmlns="http://www.w3.org/2000/svg"><g><path d="m211.07 169.09c-23.078.0-41.984 18.906-41.984 41.984v377.86c0 23.078 18.906 41.984 41.984 41.984h377.86c23.078.0 41.984-18.906 41.984-41.984v-377.86c0-23.078-18.906-41.984-41.984-41.984zm0 20.992h377.86c11.812.0 20.992 9.1797 20.992 20.992v252.15c-29.691-35.902-59.352-71.992-89.051-107.81-14.934-16.016-42.66-15.07-55.656 1.3516-34.887 40.996-69.797 82.004-104.7 123-4.6484 5.4648-12.832 5.7148-18.039.57422l-63.859-63.059c-15.715-15.516-41.438-15.094-56.641.92188l-31.898 33.574v-240.71c0-11.812 9.1797-20.992 20.992-20.992zm294.61 179.87 104.24 126.26v92.719c0 11.812-9.1797 20.992-20.992 20.992h-377.86c-11.812.0-20.992-9.1797-20.992-20.992v-106.64l47.109-49.629c7.293-7.6836 19.152-7.875 26.691-.42969l63.859 63.059c13.613 13.441 36.273 12.773 48.77-1.9062l104.53-122.82c7.8438-8.1445 16.82-8.8086 24.641-.61328z"/><path d="m300.29 242.56c-31.758.0-57.727 25.969-57.727 57.727s25.969 57.727 57.727 57.727 57.727-25.969 57.727-57.727-25.969-57.727-57.727-57.727zm0 20.992c20.414.0 36.734 16.324 36.734 36.734.0 20.414-16.324 36.734-36.734 36.734-20.414.0-36.734-16.324-36.734-36.734.0-20.414 16.324-36.734 36.734-36.734z"/></g></svg>
```

## Test plan
- [x] `uv run pytest tests/datakit/download/test_svgfind.py -v` — 5 passing
- [x] `./infra/pre-commit.py --fix lib/marin/src/marin/datakit/download/svgfind.py tests/datakit/download/test_svgfind.py lib/marin/src/marin/datakit/sources.py` — clean (ruff + black + pyrefly)
- [x] Smoke-test: `from marin.datakit.sources import all_sources; all_sources()['svg']` returns a `DatakitSource` with the expected `(processed/svgfind-creativecommons, normalized/svgfind-creativecommons)` chain.
- [ ] Full normalize via `scripts/datakit/run_source_normalizations.py` on Iris (in progress as `/held/svg-normalize`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)