### PR TITLE
[zephyr] Regression guard for SubprocessRunner parametrization

### DIFF
--- a/lib/zephyr/tests/test_runners.py
+++ b/lib/zephyr/tests/test_runners.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 import uuid
 
 import pytest
@@ -87,6 +88,42 @@ def test_exception_preserves_user_frame(local_client, tmp_path, runner_factory):
         chained += str(cur) + "".join(getattr(cur, "__notes__", []))
         cur = cur.__cause__ or cur.__context__
     assert "buggy" in chained or "tuple index out of range" in chained, chained
+
+
+def _record_worker_pid(x: int) -> int:
+    counters.increment(f"shard_pid_{os.getpid()}", 1)
+    return x
+
+
+@pytest.mark.parametrize(
+    "runner_cls",
+    [
+        pytest.param(InlineRunner, id="inline"),
+        pytest.param(
+            SubprocessRunner,
+            id="subprocess",
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason="subprocess gives each shard a unique PID; strict=True catches silent fallback to inline.",
+            ),
+        ),
+    ],
+)
+def test_runner_parametrization_isolates_processes(local_client, tmp_path, runner_cls):
+    """Regression guard that subprocess parametrization actually spawns subprocesses.
+
+    Inline reuses the worker actor (≤ max_workers PIDs); subprocess gets one PID per shard.
+    """
+    ctx = _ctx(local_client, tmp_path, stage_runner_factory=runner_cls)
+    try:
+        ds = Dataset.from_list(list(range(5))).map(_record_worker_pid)
+        outcome = ctx.execute(ds)
+    finally:
+        ctx.shutdown()
+
+    pid_counters = {k: v for k, v in outcome.counters.items() if k.startswith("shard_pid_")}
+    assert sum(pid_counters.values()) == 5, pid_counters
+    assert len(pid_counters) <= 2, pid_counters
 
 
 def test_subprocess_runner_isolates_native_crash(local_client, tmp_path):

--- a/lib/zephyr/tests/test_runners.py
+++ b/lib/zephyr/tests/test_runners.py
@@ -90,11 +90,6 @@ def test_exception_preserves_user_frame(local_client, tmp_path, runner_factory):
     assert "buggy" in chained or "tuple index out of range" in chained, chained
 
 
-def _record_worker_pid(x: int) -> int:
-    counters.increment(f"shard_pid_{os.getpid()}", 1)
-    return x
-
-
 @pytest.mark.parametrize(
     "runner_cls",
     [
@@ -104,6 +99,7 @@ def _record_worker_pid(x: int) -> int:
             id="subprocess",
             marks=pytest.mark.xfail(
                 strict=True,
+                raises=AssertionError,
                 reason="subprocess gives each shard a unique PID; strict=True catches silent fallback to inline.",
             ),
         ),
@@ -114,9 +110,14 @@ def test_runner_parametrization_isolates_processes(local_client, tmp_path, runne
 
     Inline reuses the worker actor (≤ max_workers PIDs); subprocess gets one PID per shard.
     """
+
+    def record_pid(x: int) -> int:
+        counters.increment(f"shard_pid_{os.getpid()}", 1)
+        return x
+
     ctx = _ctx(local_client, tmp_path, stage_runner_factory=runner_cls)
     try:
-        ds = Dataset.from_list(list(range(5))).map(_record_worker_pid)
+        ds = Dataset.from_list(list(range(5))).map(record_pid)
         outcome = ctx.execute(ds)
     finally:
         ctx.shutdown()


### PR DESCRIPTION
## Summary
- Add `test_runner_parametrization_isolates_processes` to `test_runners.py`: each shard records `os.getpid()` into a counter, and the test asserts ≤ `max_workers` distinct PIDs across 5 shards.
- Inline runs every shard inside the worker actor (passes); subprocess gives each shard a fresh `python -m zephyr.runners` child (5 distinct PIDs → fails). The subprocess case is marked `xfail(strict=True)` so silent fallback to in-process execution would flip to XPASS and fail the suite.
- Counter propagation on both runners is already covered by the pre-existing `test_user_counters_propagate`; this adds the missing guard that the parametrization itself is real.

## Test plan
- [x] `uv run pytest lib/zephyr/tests/test_runners.py -v` → 8 passed, 1 xfailed (subprocess case as expected)
- [x] `./infra/pre-commit.py lib/zephyr/tests/test_runners.py --fix` clean
- [x] `uv run pyrefly check lib/zephyr/tests/test_runners.py` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)