### PR TITLE
[zephyr] Add zephyr-perf skill and helper scripts

### DIFF
--- a/.agents/skills/zephyr-perf/SKILL.md
+++ b/.agents/skills/zephyr-perf/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: zephyr-perf
+description: Run an A/B perf gate on a PR that touches Zephyr internals — submit control + treatment ferries on Iris, compare metrics, post the verdict back to the PR. Use when a PR modifies `lib/zephyr/src/zephyr/**` and a reviewer (or label) asks for a perf gate.
+---
+
+# Skill: Zephyr Perf Gate
+
+A/B perf gate for Zephyr-internals PRs. The agent picks a gate based on touched
+paths, submits the same ferry on the PR's merge-base (control) and PR head
+(treatment), compares metrics, and posts a single canonical comment to the PR.
+
+This skill **only** triggers on changes to Zephyr internals
+(`lib/zephyr/src/zephyr/**`). Datakit / dedup / normalize / tokenize live in
+`lib/marin/...` and are explicitly out of scope — they consume Zephyr but are
+not Zephyr core. If a PR touches both, run this skill on the Zephyr part and
+let the datakit smoke / nemotron ferry workflows cover the rest.
+
+## Autonomy
+
+The agent may, without asking:
+
+- Read the PR diff and decide gate / scope via `select_gate.py`.
+- Create temporary git worktrees at the PR's merge-base and head SHAs.
+- Submit Iris ferry jobs at production priority for both runs.
+- Poll job state and pull coordinator logs.
+- Post **one** canonical comment on the PR (sentinel-marked, idempotent).
+- Open a regression issue when the verdict is `❌ fail` (label
+  `zephyr-perf-regression` + `agent-generated`).
+
+The agent must ask before:
+
+- Promoting a PR from Gate 1 to Gate 2 against `select_gate.py`'s recommendation
+  (Gate 2 is overnight and expensive).
+- Re-running on a different cluster than `lib/iris/examples/marin.yaml`.
+- Stopping a ferry that has not crossed its gate timeout.
+
+## Trigger / Scope
+
+Run this skill when:
+
+1. A PR's diff has at least one file matching the Zephyr-internals globs in
+   `select_gate.py` (canonical list: `lib/zephyr/src/zephyr/**/*.py`,
+   `lib/zephyr/pyproject.toml`), AND
+2. None of those touched files are test-only (`lib/zephyr/tests/**`,
+   `lib/zephyr/src/zephyr/_test_helpers.py`).
+
+Out of scope (do **not** trigger):
+
+- `lib/marin/src/marin/processing/classification/deduplication/**` (dedup)
+- `lib/marin/src/marin/datakit/normalize/**` (normalize)
+- `lib/marin/src/marin/processing/tokenize/**` (tokenize)
+- `lib/fray/**` (execution backend — flag it in the PR comment but don't
+  auto-gate; ask the reviewer)
+- Any docs-only diff (`*.md`, `lib/zephyr/AGENTS.md`, `lib/zephyr/OPS.md`)
+
+When unsure, run `select_gate.py` and trust its `in_scope` field.
+
+## Gate ladder
+
+| Gate | Ferry | Wall-time | Default for | Notes |
+|---|---|---|---|---|
+| **1 — fineweb smoke** | `experiments.ferries.datakit_ferry` (FineWeb-Edu sample/10BT) | ~30–60 min | every in-scope PR | Cheap; runs scatter, dedup, consolidate, tokenize end-to-end at small scale. |
+| **2 — full nemotron** | `experiments.ferries.datakit_nemotron_ferry` (Nemotron-CC medium, ~3.4 TiB) | overnight (≤24 h) | PRs touching the high-blast-radius set below | Expensive; requires reviewer approval. |
+
+**Gate 2 trigger paths** (any one of these in the diff escalates to Gate 2):
+
+- `lib/zephyr/src/zephyr/shuffle.py` (scatter pipeline)
+- `lib/zephyr/src/zephyr/plan.py` (operation fusion)
+- `lib/zephyr/src/zephyr/execution.py` (coord/worker loop)
+- `lib/zephyr/src/zephyr/external_sort.py` (k-way merge)
+- `lib/zephyr/src/zephyr/spill.py` (on-disk spill)
+
+Reviewer can promote/demote with PR labels `perf-gate:1` / `perf-gate:2` /
+`perf-gate:skip`.
+
+A medium tier ("Nemotron 1-slice", ~few hours) is intentionally **not** in this
+ladder yet — there is no script for it. Track as future work; for now, in-scope
+PRs go to Gate 1 by default and escalate straight to Gate 2 when the path set
+fires.
+
+## Workflow
+
+### 1. Decide scope and gate
+
+```bash
+uv run python scripts/zephyr/perf/select_gate.py --pr <PR_NUMBER>
+```
+
+Output is JSON:
+
+```json
+{"in_scope": true, "gate": "1", "reason": "...", "touched_zephyr_files": [...]}
+```
+
+If `in_scope` is `false`, stop here and post nothing. If `gate` is `"2"`,
+confirm with the reviewer (or check for the `perf-gate:2` label) before
+launching.
+
+### 2. Resolve SHAs
+
+```bash
+gh pr view <PR_NUMBER> --json headRefOid,baseRefOid,baseRefName -q '...'
+git fetch origin <baseRefName>
+CONTROL_SHA=$(git merge-base origin/<baseRefName> <headRefOid>)
+TREATMENT_SHA=<headRefOid>
+```
+
+Re-running control at the PR's merge-base is the default. Reusing a recent
+weekly nemotron ferry as control is a future optimization — do not skip control
+in v1.
+
+### 3. Set up worktrees
+
+Iris bundles the working directory; submit each run from a worktree at the
+right SHA.
+
+```bash
+git worktree add ../zephyr-perf-control "$CONTROL_SHA"
+git worktree add ../zephyr-perf-treatment "$TREATMENT_SHA"
+```
+
+### 4. Submit both ferries
+
+```bash
+uv run python scripts/zephyr/perf/submit_perf_run.py \
+  --gate 1 \
+  --label control \
+  --cwd ../zephyr-perf-control \
+  --pr <PR_NUMBER> \
+  --status-out gs://marin-us-central1/tmp/ttl=7d/zephyr-perf/<PR>/control.json
+
+uv run python scripts/zephyr/perf/submit_perf_run.py \
+  --gate 1 \
+  --label treatment \
+  --cwd ../zephyr-perf-treatment \
+  --pr <PR_NUMBER> \
+  --status-out gs://marin-us-central1/tmp/ttl=7d/zephyr-perf/<PR>/treatment.json
+```
+
+The script prints the Iris job ID and writes the status JSON path to stdout.
+
+### 5. Babysit
+
+Both runs babysat with the **babysit-zephyr** skill (or **babysit-job** for the
+outer Iris job). Do not poll in a tight loop — Gate 1 is ~30–60 min, Gate 2 is
+overnight. Sleep at least 10 min between checks for Gate 1, 30 min for Gate 2.
+
+If a run fails (worker pool wedged, coordinator zombie), escalate to
+**debug-infra** for triage and re-submit the failed leg only after the
+underlying issue is understood. Never silently retry — a flaky run masks a real
+regression.
+
+### 6. Collect metrics
+
+```bash
+uv run python scripts/zephyr/perf/collect_perf_metrics.py \
+  --status gs://marin-us-central1/tmp/ttl=7d/zephyr-perf/<PR>/control.json \
+  --out /tmp/zephyr-perf/<PR>/control_metrics.json
+
+uv run python scripts/zephyr/perf/collect_perf_metrics.py \
+  --status gs://marin-us-central1/tmp/ttl=7d/zephyr-perf/<PR>/treatment.json \
+  --out /tmp/zephyr-perf/<PR>/treatment_metrics.json
+```
+
+The collector pulls per-stage wall-times from the coordinator's progress logs,
+the final counter snapshot via `iris actor call`, and the worker-pool death
+count from `iris rpc controller list-tasks`. Only post the comment after both
+runs reach a terminal state (`SUCCEEDED` or `FAILED`).
+
+### 7. Compare and verdict
+
+```bash
+uv run python scripts/zephyr/perf/compare_perf_runs.py \
+  --control /tmp/zephyr-perf/<PR>/control_metrics.json \
+  --treatment /tmp/zephyr-perf/<PR>/treatment_metrics.json \
+  --gate 1 \
+  --markdown-out /tmp/zephyr-perf/<PR>/comment.md \
+  --verdict-out /tmp/zephyr-perf/<PR>/verdict.json
+```
+
+Default thresholds (overridable via `--thresholds <yaml>`):
+
+| Signal | Warn | Hard fail |
+|---|---|---|
+| Per-stage wall-time delta vs control | > +5% | > +10% |
+| New OOMs | any | — |
+| New failed shards | — | any |
+| Total wall-time delta | > +5% | > +10% |
+
+Verdict precedence: any hard-fail → `❌ fail`; otherwise any warn → `⚠ warn`;
+otherwise `✅ pass`.
+
+### 8. Post one canonical comment
+
+```bash
+uv run python scripts/zephyr/perf/post_pr_comment.py \
+  --pr <PR_NUMBER> \
+  --body /tmp/zephyr-perf/<PR>/comment.md
+```
+
+The script upserts a comment marked with `<!-- zephyr-perf-gate -->` so re-runs
+replace the prior comment instead of stacking. Open a regression issue when the
+verdict is `❌ fail`:
+
+```bash
+gh issue create \
+  --title "[zephyr-perf] regression on #<PR_NUMBER>" \
+  --label zephyr-perf-regression --label agent-generated \
+  --body-file /tmp/zephyr-perf/<PR>/comment.md
+```
+
+### 9. Clean up
+
+```bash
+git worktree remove ../zephyr-perf-control
+git worktree remove ../zephyr-perf-treatment
+```
+
+## Comment format (canonical)
+
+```markdown
+<!-- zephyr-perf-gate -->
+🤖 ## Zephyr perf gate — Gate 1 (fineweb)
+
+**Verdict:** ✅ pass | ⚠ warn | ❌ fail
+
+| | Control | Treatment |
+|---|---|---|
+| SHA | `abc1234` | `def5678` |
+| Iris job | [`...`](...) | [`...`](...) |
+| W&B | [link](...) | [link](...) |
+| Total wall-time | 31m 12s | 32m 04s (+2.8%) |
+
+### Stage timings
+
+| Stage | Control (s) | Treatment (s) | Δ | Verdict |
+|---|---|---|---|---|
+| download | 12 | 12 | +0% | ✅ |
+| normalize | 845 | 870 | +3.0% | ✅ |
+| minhash | 410 | 421 | +2.7% | ✅ |
+| fuzzy_dups | 188 | 192 | +2.1% | ✅ |
+| consolidate | 220 | 224 | +1.8% | ✅ |
+| tokenize | 197 | 205 | +4.1% | ✅ |
+
+### Workers
+
+| | Control | Treatment |
+|---|---|---|
+| OOMs | 0 | 0 |
+| Failed shards | 0 | 0 |
+| Peak worker memory (MB) | 14202 | 14180 |
+
+<details><summary>Counters</summary>
+
+(zephyr counter deltas, JSON)
+
+</details>
+```
+
+The comment **must** begin with `🤖` per repo convention (see
+`/AGENTS.md` → "Communication & Commits").
+
+## Failure modes
+
+- **Control flakes, treatment passes**: re-submit control; do not call the gate
+  pass on a single run.
+- **Both flake at the same stage**: not a regression — a real environmental
+  problem. Open an `agent-generated` issue and ping the reviewer; do not post a
+  pass/fail verdict.
+- **Treatment OOMs at a stage that control survives**: hard fail. Always
+  surface the worker-pool death log with the OOM line in the comment so the
+  author can act without re-pulling logs.
+- **`select_gate.py` says out-of-scope but the reviewer disagrees**: reviewer
+  applies `perf-gate:1` or `perf-gate:2` label; the agent re-runs with the
+  forced gate.
+
+## Composes with
+
+- `babysit-zephyr` — for monitoring each run while in flight.
+- `babysit-job` — for the outer Iris job lifecycle.
+- `debug-infra` — when a leg flakes and the cause is unclear.
+- `file-issue` — for the regression issue path.
+
+## Open questions
+
+- Should weekly scheduled nemotron ferries auto-feed control results so PRs can
+  skip the control re-run? (Currently no — re-run for safety.)
+- Add a Gate 1.5 scale-stress lane (10k workers, minimal RAM) to surface
+  scatter OOMs and controller back-pressure faster than Gate 2? Not built yet.

--- a/scripts/zephyr/perf/collect_perf_metrics.py
+++ b/scripts/zephyr/perf/collect_perf_metrics.py
@@ -1,0 +1,272 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Collect zephyr perf metrics from a finished ferry run.
+
+Inputs:
+  --status   gs:// path written by the ferry's ``_write_status`` helper.
+             Contract: ``{"status": "...", "marin_prefix": "gs://..."}``.
+  --job-id   Iris job id of the ferry leg. Used to pull coordinator logs and
+             worker-pool exit signals.
+
+Output (JSON, written to ``--out`` and stdout):
+
+    {
+      "status": "succeeded" | "failed" | ...,
+      "wall_seconds_total": 1872.4,
+      "stage_wall_seconds": {"download": 12.0, "normalize": 845.0, ...},
+      "ooms": 0,
+      "failed_shards": 0,
+      "peak_worker_memory_mb": 14202,
+      "counters": {"documents_processed": 9268156, ...},
+      "wandb_url": "https://wandb.ai/...",
+      "iris_job_id": "...",
+      "ferry_module": "experiments.ferries.datakit_ferry"
+    }
+
+Many fields are best-effort — collectors that can't pull a value emit ``null``
+and add a note to the ``warnings`` list rather than crashing. The compare step
+treats null fields as "no signal" instead of inventing a regression.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import subprocess
+import sys
+from typing import Any
+
+from rigging.filesystem import url_to_fs
+
+logger = logging.getLogger(__name__)
+
+
+STAGE_PROGRESS_RE = re.compile(r"\[(?P<stage>stage\d+-[A-Za-z0-9_→ ]+)\]\s+" r"(?P<done>\d+)/(?P<total>\d+)\s+complete")
+WALL_TIME_RE = re.compile(
+    r"Datakit \w+ ferry total wall time.*?(?P<seconds>\d+\.\d+)s",
+    re.IGNORECASE,
+)
+
+
+def _read_status(status_url: str) -> dict[str, Any]:
+    fs, _ = url_to_fs(status_url)
+    if not fs.exists(status_url):
+        return {"status": "unknown", "marin_prefix": None}
+    with fs.open(status_url, "r") as f:
+        return json.loads(f.read())
+
+
+def _coord_logs(iris_config: str, job_id: str) -> str:
+    """Pull the latest-attempt coordinator logs for ``job_id``.
+
+    Best-effort: returns the empty string if the iris CLI fails (e.g. job
+    expired). Caller should treat absence as "no signal".
+    """
+    try:
+        return subprocess.check_output(
+            [
+                ".venv/bin/iris",
+                f"--config={iris_config}",
+                "rpc",
+                "controller",
+                "get-task-logs",
+                "--id",
+                job_id,
+                "--max-total-lines",
+                "20000",
+                "--attempt-id",
+                "-1",
+                "--tail",
+            ],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError as e:
+        logger.warning("Failed to pull coord logs for %s: %s", job_id, e)
+        return ""
+
+
+def _list_tasks(iris_config: str, job_id: str) -> list[dict[str, Any]]:
+    try:
+        raw = subprocess.check_output(
+            [
+                ".venv/bin/iris",
+                f"--config={iris_config}",
+                "rpc",
+                "controller",
+                "list-tasks",
+                "--job-id",
+                job_id,
+                "--json",
+            ],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, list) else parsed.get("tasks", [])
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        logger.warning("Failed to list tasks for %s: %s", job_id, e)
+        return []
+
+
+def _stage_wall_seconds(coord_logs: str) -> dict[str, float]:
+    """Extract per-stage durations from coordinator progress lines.
+
+    The coordinator prints a progress line every ~5s with the current stage and
+    an in-progress count. We use the timestamps of the first and last line per
+    stage as the stage's start/end.
+    """
+    timestamps: dict[str, list[float]] = {}
+    for line in coord_logs.splitlines():
+        m = STAGE_PROGRESS_RE.search(line)
+        if not m:
+            continue
+        # Iris log lines start with an ISO-ish timestamp; pull the leading
+        # timestamp if present, otherwise skip — wall-time is best-effort.
+        ts_match = re.match(r"^([0-9TZ:.\-+]+)\s", line)
+        if not ts_match:
+            continue
+        try:
+            ts = _parse_iso_seconds(ts_match.group(1))
+        except ValueError:
+            continue
+        timestamps.setdefault(m.group("stage"), []).append(ts)
+    return {stage: round(max(values) - min(values), 1) for stage, values in timestamps.items() if len(values) >= 2}
+
+
+def _parse_iso_seconds(ts: str) -> float:
+    import datetime as _dt
+
+    ts = ts.rstrip("Z")
+    return _dt.datetime.fromisoformat(ts).replace(tzinfo=_dt.timezone.utc).timestamp()
+
+
+def _ooms_and_failures(tasks: list[dict[str, Any]]) -> tuple[int, int]:
+    ooms = 0
+    fails = 0
+    for t in tasks:
+        state = (t.get("state") or "").upper()
+        exit_reason = (t.get("exitReason") or t.get("exit_reason") or "").lower()
+        if "oom" in exit_reason or t.get("oomKilled"):
+            ooms += 1
+        if state in {"FAILED", "KILLED"} and "oom" not in exit_reason:
+            fails += 1
+    return ooms, fails
+
+
+def _peak_memory_mb(tasks: list[dict[str, Any]]) -> int | None:
+    peaks = []
+    for t in tasks:
+        usage = t.get("resourceUsage") or t.get("resource_usage") or {}
+        peak = usage.get("memoryPeakMb")
+        if isinstance(peak, (int, float)):
+            peaks.append(int(peak))
+    return max(peaks) if peaks else None
+
+
+def _total_wall(coord_logs: str) -> float | None:
+    m = WALL_TIME_RE.search(coord_logs)
+    return float(m.group("seconds")) if m else None
+
+
+def _counters(iris_config: str, coord_actor: str | None) -> dict[str, int]:
+    """Pull final counter snapshot via `iris actor call get_counters`.
+
+    Skipped when ``coord_actor`` is None — the caller hasn't found the
+    coordinator endpoint. Returns an empty dict on any failure.
+    """
+    if not coord_actor:
+        return {}
+    try:
+        raw = subprocess.check_output(
+            [
+                ".venv/bin/iris",
+                f"--config={iris_config}",
+                "actor",
+                "call",
+                coord_actor,
+                "get_counters",
+            ],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        parsed = json.loads(raw)
+        return parsed.get("counters", parsed) if isinstance(parsed, dict) else {}
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        return {}
+
+
+def collect(
+    *,
+    status_url: str,
+    job_id: str | None,
+    iris_config: str,
+    coord_actor: str | None,
+    ferry_module: str | None,
+    wandb_url: str | None,
+) -> dict[str, Any]:
+    warnings: list[str] = []
+    status_payload = _read_status(status_url)
+    if status_payload.get("status") == "unknown":
+        warnings.append(f"status file not found at {status_url}")
+
+    coord_logs = _coord_logs(iris_config, job_id) if job_id else ""
+    tasks = _list_tasks(iris_config, job_id) if job_id else []
+    if job_id and not tasks:
+        warnings.append(f"no tasks returned for {job_id}")
+
+    stage_wall = _stage_wall_seconds(coord_logs)
+    if not stage_wall and coord_logs:
+        warnings.append("no stage transitions parsed from coord logs")
+
+    ooms, failed_shards = _ooms_and_failures(tasks)
+    return {
+        "status": status_payload.get("status"),
+        "marin_prefix": status_payload.get("marin_prefix"),
+        "wall_seconds_total": _total_wall(coord_logs),
+        "stage_wall_seconds": stage_wall,
+        "ooms": ooms,
+        "failed_shards": failed_shards,
+        "peak_worker_memory_mb": _peak_memory_mb(tasks),
+        "counters": _counters(iris_config, coord_actor),
+        "wandb_url": wandb_url,
+        "iris_job_id": job_id,
+        "ferry_module": ferry_module,
+        "warnings": warnings,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--status", required=True, help="gs:// path to ferry_run_status.json")
+    parser.add_argument("--job-id", help="Iris job id of the ferry leg.")
+    parser.add_argument("--iris-config", default="lib/iris/examples/marin.yaml")
+    parser.add_argument(
+        "--coord-actor",
+        help="Coordinator actor endpoint (from coord task logs); enables counter snapshot.",
+    )
+    parser.add_argument("--ferry-module", help="Ferry module name (passthrough into output).")
+    parser.add_argument("--wandb-url")
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    payload = collect(
+        status_url=args.status,
+        job_id=args.job_id,
+        iris_config=args.iris_config,
+        coord_actor=args.coord_actor,
+        ferry_module=args.ferry_module,
+        wandb_url=args.wandb_url,
+    )
+
+    with open(args.out, "w") as f:
+        json.dump(payload, f, indent=2)
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/zephyr/perf/compare_perf_runs.py
+++ b/scripts/zephyr/perf/compare_perf_runs.py
@@ -1,0 +1,303 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compare control vs treatment metric JSONs and emit a verdict + comment.
+
+Inputs are the JSON files produced by ``collect_perf_metrics.py`` for the two
+legs of a zephyr perf gate.
+
+Outputs:
+  --verdict-out   JSON: {"verdict": "pass"|"warn"|"fail", "reasons": [...], ...}
+  --markdown-out  The exact comment body to post on the PR (sentinel-marked,
+                  ready to feed into ``post_pr_comment.py``).
+
+Default thresholds (tunable via --thresholds <yaml>):
+  hard fail when:
+    * any new OOM in treatment (and not in control)
+    * any new failed shard in treatment (and not in control)
+    * total wall-time delta > +10%
+    * any per-stage wall-time delta > +10%
+  warn when:
+    * total wall-time delta in (+5%, +10%]
+    * any per-stage wall-time delta in (+5%, +10%]
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as _dt
+import json
+import sys
+from typing import Any
+
+DEFAULT_THRESHOLDS = {
+    "stage_warn_pct": 5.0,
+    "stage_fail_pct": 10.0,
+    "total_warn_pct": 5.0,
+    "total_fail_pct": 10.0,
+}
+
+GATE_LABELS = {
+    "1": "Gate 1 (fineweb)",
+    "2": "Gate 2 (full nemotron)",
+}
+
+SENTINEL = "<!-- zephyr-perf-gate -->"
+
+
+@dataclasses.dataclass
+class StageRow:
+    name: str
+    control: float | None
+    treatment: float | None
+    delta_pct: float | None
+    verdict: str  # ✅ / ⚠ / ❌ / —
+
+
+def _pct(control: float | None, treatment: float | None) -> float | None:
+    if control is None or treatment is None or control == 0:
+        return None
+    return (treatment - control) / control * 100.0
+
+
+def _stage_verdict(delta_pct: float | None, t: dict[str, float]) -> str:
+    if delta_pct is None:
+        return "—"
+    if delta_pct > t["stage_fail_pct"]:
+        return "❌"
+    if delta_pct > t["stage_warn_pct"]:
+        return "⚠"
+    return "✅"
+
+
+def compare(
+    *,
+    control: dict[str, Any],
+    treatment: dict[str, Any],
+    gate: str,
+    pr: int,
+    thresholds: dict[str, float],
+) -> tuple[dict[str, Any], str]:
+    reasons_fail: list[str] = []
+    reasons_warn: list[str] = []
+
+    # OOMs / failed shards: hard fail if any new ones in treatment.
+    new_ooms = max(0, (treatment.get("ooms") or 0) - (control.get("ooms") or 0))
+    new_fails = max(0, (treatment.get("failed_shards") or 0) - (control.get("failed_shards") or 0))
+    if new_ooms:
+        reasons_fail.append(f"{new_ooms} new OOM(s) in treatment")
+    if new_fails:
+        reasons_fail.append(f"{new_fails} new failed shard(s) in treatment")
+
+    # Total wall-time.
+    total_delta = _pct(control.get("wall_seconds_total"), treatment.get("wall_seconds_total"))
+    if total_delta is not None:
+        if total_delta > thresholds["total_fail_pct"]:
+            reasons_fail.append(f"total wall-time +{total_delta:.1f}%")
+        elif total_delta > thresholds["total_warn_pct"]:
+            reasons_warn.append(f"total wall-time +{total_delta:.1f}%")
+
+    # Per-stage wall-times. Stages may differ between control and treatment if
+    # the diff renames or splits a stage; rows for stages missing on one side
+    # render with "—" and don't count toward the verdict.
+    all_stages = sorted(set(control.get("stage_wall_seconds") or {}) | set(treatment.get("stage_wall_seconds") or {}))
+    stage_rows: list[StageRow] = []
+    for stage in all_stages:
+        c = (control.get("stage_wall_seconds") or {}).get(stage)
+        t = (treatment.get("stage_wall_seconds") or {}).get(stage)
+        delta = _pct(c, t)
+        v = _stage_verdict(delta, thresholds)
+        stage_rows.append(StageRow(name=stage, control=c, treatment=t, delta_pct=delta, verdict=v))
+        if delta is not None:
+            if delta > thresholds["stage_fail_pct"]:
+                reasons_fail.append(f"{stage} +{delta:.1f}%")
+            elif delta > thresholds["stage_warn_pct"]:
+                reasons_warn.append(f"{stage} +{delta:.1f}%")
+
+    if reasons_fail:
+        verdict = "fail"
+    elif reasons_warn:
+        verdict = "warn"
+    else:
+        verdict = "pass"
+
+    summary = {
+        "verdict": verdict,
+        "gate": gate,
+        "pr": pr,
+        "reasons_fail": reasons_fail,
+        "reasons_warn": reasons_warn,
+        "total_wall_delta_pct": total_delta,
+        "new_ooms": new_ooms,
+        "new_failed_shards": new_fails,
+        "stage_deltas_pct": {row.name: row.delta_pct for row in stage_rows if row.delta_pct is not None},
+        "thresholds": thresholds,
+        "generated_at_utc": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+    }
+    markdown = _render_markdown(
+        verdict=verdict,
+        gate=gate,
+        control=control,
+        treatment=treatment,
+        stage_rows=stage_rows,
+        total_delta=total_delta,
+        reasons_fail=reasons_fail,
+        reasons_warn=reasons_warn,
+    )
+    return summary, markdown
+
+
+def _fmt_pct(p: float | None) -> str:
+    if p is None:
+        return "—"
+    sign = "+" if p >= 0 else ""
+    return f"{sign}{p:.1f}%"
+
+
+def _fmt_seconds(s: float | None) -> str:
+    if s is None:
+        return "—"
+    if s < 90:
+        return f"{s:.1f}s"
+    minutes, secs = divmod(int(s), 60)
+    if minutes < 90:
+        return f"{minutes}m {secs:02d}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h {minutes:02d}m"
+
+
+def _render_markdown(
+    *,
+    verdict: str,
+    gate: str,
+    control: dict[str, Any],
+    treatment: dict[str, Any],
+    stage_rows: list[StageRow],
+    total_delta: float | None,
+    reasons_fail: list[str],
+    reasons_warn: list[str],
+) -> str:
+    icon = {"pass": "✅ pass", "warn": "⚠ warn", "fail": "❌ fail"}[verdict]
+    gate_label = GATE_LABELS.get(gate, f"Gate {gate}")
+
+    lines: list[str] = []
+    lines.append(SENTINEL)
+    lines.append(f"🤖 ## Zephyr perf gate — {gate_label}")
+    lines.append("")
+    lines.append(f"**Verdict:** {icon}")
+    lines.append("")
+    if reasons_fail:
+        lines.append("**Hard fails:** " + "; ".join(reasons_fail))
+    if reasons_warn:
+        lines.append("**Warns:** " + "; ".join(reasons_warn))
+    if reasons_fail or reasons_warn:
+        lines.append("")
+
+    lines.append("| | Control | Treatment |")
+    lines.append("|---|---|---|")
+    lines.append(f"| Iris job | `{control.get('iris_job_id') or '—'}` | `{treatment.get('iris_job_id') or '—'}` |")
+    lines.append(f"| Status | {control.get('status') or '—'} | {treatment.get('status') or '—'} |")
+    lines.append(f"| W&B | {_link(control.get('wandb_url'))} | {_link(treatment.get('wandb_url'))} |")
+    lines.append(
+        f"| Total wall-time | {_fmt_seconds(control.get('wall_seconds_total'))} "
+        f"| {_fmt_seconds(treatment.get('wall_seconds_total'))} ({_fmt_pct(total_delta)}) |"
+    )
+    lines.append("")
+
+    lines.append("### Stage timings")
+    lines.append("")
+    lines.append("| Stage | Control | Treatment | Δ | Verdict |")
+    lines.append("|---|---|---|---|---|")
+    for row in stage_rows:
+        lines.append(
+            f"| `{row.name}` | {_fmt_seconds(row.control)} | {_fmt_seconds(row.treatment)} "
+            f"| {_fmt_pct(row.delta_pct)} | {row.verdict} |"
+        )
+    lines.append("")
+
+    lines.append("### Workers")
+    lines.append("")
+    lines.append("| | Control | Treatment |")
+    lines.append("|---|---|---|")
+    lines.append(f"| OOMs | {control.get('ooms', 0)} | {treatment.get('ooms', 0)} |")
+    lines.append(f"| Failed shards | {control.get('failed_shards', 0)} | {treatment.get('failed_shards', 0)} |")
+    lines.append(
+        f"| Peak worker memory (MB) | {control.get('peak_worker_memory_mb') or '—'} "
+        f"| {treatment.get('peak_worker_memory_mb') or '—'} |"
+    )
+    lines.append("")
+
+    counters = treatment.get("counters") or {}
+    if counters:
+        lines.append("<details><summary>Counters (treatment)</summary>")
+        lines.append("")
+        lines.append("```json")
+        lines.append(json.dumps(counters, indent=2, sort_keys=True))
+        lines.append("```")
+        lines.append("</details>")
+        lines.append("")
+
+    warnings = (control.get("warnings") or []) + (treatment.get("warnings") or [])
+    if warnings:
+        lines.append("<details><summary>Collector warnings</summary>")
+        lines.append("")
+        for w in warnings:
+            lines.append(f"- {w}")
+        lines.append("</details>")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _link(url: str | None) -> str:
+    return f"[link]({url})" if url else "—"
+
+
+def _load_thresholds(path: str | None) -> dict[str, float]:
+    if not path:
+        return dict(DEFAULT_THRESHOLDS)
+    import yaml
+
+    with open(path) as f:
+        raw = yaml.safe_load(f) or {}
+    merged = dict(DEFAULT_THRESHOLDS)
+    merged.update({k: float(v) for k, v in raw.items()})
+    return merged
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--control", required=True)
+    parser.add_argument("--treatment", required=True)
+    parser.add_argument("--gate", required=True, choices=sorted(GATE_LABELS))
+    parser.add_argument("--pr", required=True, type=int)
+    parser.add_argument("--thresholds", help="YAML overriding default thresholds.")
+    parser.add_argument("--markdown-out", required=True)
+    parser.add_argument("--verdict-out", required=True)
+    args = parser.parse_args()
+
+    with open(args.control) as f:
+        control = json.load(f)
+    with open(args.treatment) as f:
+        treatment = json.load(f)
+
+    thresholds = _load_thresholds(args.thresholds)
+    summary, markdown = compare(
+        control=control,
+        treatment=treatment,
+        gate=args.gate,
+        pr=args.pr,
+        thresholds=thresholds,
+    )
+
+    with open(args.verdict_out, "w") as f:
+        json.dump(summary, f, indent=2)
+    with open(args.markdown_out, "w") as f:
+        f.write(markdown)
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/zephyr/perf/post_pr_comment.py
+++ b/scripts/zephyr/perf/post_pr_comment.py
@@ -1,0 +1,99 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Upsert a single canonical zephyr-perf-gate comment on a PR.
+
+Idempotent: looks for an existing comment whose body starts with the
+``<!-- zephyr-perf-gate -->`` sentinel and edits it in place; otherwise creates
+a new comment. Re-runs of the gate replace prior comments instead of stacking.
+
+Body must already start with the sentinel — this script does not insert one,
+so the comparison output stays the canonical source of the comment shape.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+
+logger = logging.getLogger(__name__)
+
+SENTINEL = "<!-- zephyr-perf-gate -->"
+
+
+def _list_comments(repo: str, pr: int) -> list[dict[str, object]]:
+    raw = subprocess.check_output(
+        ["gh", "api", "--paginate", f"repos/{repo}/issues/{pr}/comments"],
+        text=True,
+    )
+    parsed = json.loads(raw)
+    return parsed if isinstance(parsed, list) else []
+
+
+def _find_existing(comments: list[dict[str, object]]) -> int | None:
+    for c in comments:
+        body = c.get("body") or ""
+        if isinstance(body, str) and body.lstrip().startswith(SENTINEL):
+            cid = c.get("id")
+            if isinstance(cid, int):
+                return cid
+    return None
+
+
+def upsert(repo: str, pr: int, body: str) -> dict[str, object]:
+    if not body.lstrip().startswith(SENTINEL):
+        raise ValueError(f"comment body must start with the sentinel `{SENTINEL}` " "(produced by compare_perf_runs.py)")
+
+    comments = _list_comments(repo, pr)
+    existing = _find_existing(comments)
+
+    if existing is not None:
+        subprocess.check_call(
+            [
+                "gh",
+                "api",
+                "--method",
+                "PATCH",
+                f"repos/{repo}/issues/comments/{existing}",
+                "-f",
+                f"body={body}",
+            ]
+        )
+        return {"action": "updated", "comment_id": existing}
+
+    out = subprocess.check_output(
+        [
+            "gh",
+            "api",
+            "--method",
+            "POST",
+            f"repos/{repo}/issues/{pr}/comments",
+            "-f",
+            f"body={body}",
+        ],
+        text=True,
+    )
+    parsed = json.loads(out)
+    return {"action": "created", "comment_id": parsed.get("id")}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default="marin-community/marin")
+    parser.add_argument("--pr", required=True, type=int)
+    parser.add_argument("--body", required=True, help="Path to a markdown file (output of compare_perf_runs.py).")
+    args = parser.parse_args()
+
+    with open(args.body) as f:
+        body = f.read()
+
+    result = upsert(args.repo, args.pr, body)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/zephyr/perf/select_gate.py
+++ b/scripts/zephyr/perf/select_gate.py
@@ -1,0 +1,132 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Decide whether a PR is in scope for the zephyr perf gate, and which gate to run.
+
+In scope = at least one non-test file under ``lib/zephyr/src/zephyr/**``.
+Datakit / dedup / normalize / tokenize live under ``lib/marin/...`` and are
+explicitly out of scope; ``lib/fray/**`` is also out of scope (flagged in the
+reason but not auto-gated).
+
+Gate 2 (full nemotron) is selected when the diff touches any file in
+``HEAVY_PATHS``; otherwise Gate 1 (fineweb smoke).
+
+Output is JSON on stdout. Exit code is always 0 unless the PR cannot be read.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import logging
+import subprocess
+import sys
+
+logger = logging.getLogger(__name__)
+
+INCLUDE_GLOBS = (
+    "lib/zephyr/src/zephyr/*.py",
+    "lib/zephyr/src/zephyr/**/*.py",
+    "lib/zephyr/pyproject.toml",
+)
+
+EXCLUDE_GLOBS = (
+    "lib/zephyr/tests/**",
+    "lib/zephyr/src/zephyr/_test_helpers.py",
+    "**/*.md",
+)
+
+HEAVY_PATHS = frozenset(
+    {
+        "lib/zephyr/src/zephyr/shuffle.py",
+        "lib/zephyr/src/zephyr/plan.py",
+        "lib/zephyr/src/zephyr/execution.py",
+        "lib/zephyr/src/zephyr/external_sort.py",
+        "lib/zephyr/src/zephyr/spill.py",
+    }
+)
+
+FRAY_GLOB = "lib/fray/**"
+
+
+def _matches_any(path: str, globs: tuple[str, ...]) -> bool:
+    return any(fnmatch.fnmatch(path, g) for g in globs)
+
+
+def _changed_files_from_pr(pr: int) -> list[str]:
+    raw = subprocess.check_output(
+        ["gh", "pr", "diff", str(pr), "--name-only"],
+        text=True,
+    )
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def _changed_files_from_diff(merge_base: str, head: str) -> list[str]:
+    raw = subprocess.check_output(
+        ["git", "diff", "--name-only", f"{merge_base}...{head}"],
+        text=True,
+    )
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def classify(changed: list[str]) -> dict[str, object]:
+    """Pure, side-effect-free classification.
+
+    Exposed as a function so callers (CI, the orchestrator, tests) can pass an
+    explicit file list without shelling out to git/gh.
+    """
+    zephyr_internals = [p for p in changed if _matches_any(p, INCLUDE_GLOBS) and not _matches_any(p, EXCLUDE_GLOBS)]
+
+    if not zephyr_internals:
+        return {
+            "in_scope": False,
+            "gate": None,
+            "reason": "no non-test files under lib/zephyr/src/zephyr/** in diff",
+            "touched_zephyr_files": [],
+            "touched_fray_files": [p for p in changed if fnmatch.fnmatch(p, FRAY_GLOB)],
+        }
+
+    heavy_hits = sorted(set(zephyr_internals) & HEAVY_PATHS)
+    gate = "2" if heavy_hits else "1"
+    reason = f"heavy path(s) touched: {heavy_hits}" if heavy_hits else "non-heavy zephyr internals only"
+    return {
+        "in_scope": True,
+        "gate": gate,
+        "reason": reason,
+        "touched_zephyr_files": sorted(zephyr_internals),
+        "touched_fray_files": sorted(p for p in changed if fnmatch.fnmatch(p, FRAY_GLOB)),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--pr", type=int, help="GitHub PR number; uses `gh pr diff`.")
+    src.add_argument(
+        "--diff-range",
+        help="Local git range, e.g. `origin/main...HEAD`. Format: <base>...<head>.",
+    )
+    src.add_argument(
+        "--files-from",
+        help="Read newline-delimited file list from this path (testing/debug).",
+    )
+    args = parser.parse_args()
+
+    if args.files_from:
+        with open(args.files_from) as f:
+            changed = [line.strip() for line in f if line.strip()]
+    elif args.pr is not None:
+        changed = _changed_files_from_pr(args.pr)
+    else:
+        base, _, head = args.diff_range.partition("...")
+        if not base or not head:
+            parser.error("--diff-range must be of the form <base>...<head>")
+        changed = _changed_files_from_diff(base, head)
+
+    print(json.dumps(classify(changed), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/zephyr/perf/submit_perf_run.py
+++ b/scripts/zephyr/perf/submit_perf_run.py
@@ -1,0 +1,203 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Submit one leg (control or treatment) of a zephyr perf gate ferry on Iris.
+
+Caller is responsible for setting up the working directory at the right SHA
+(typically a `git worktree add ../zephyr-perf-{control,treatment} <sha>`); this
+script does **not** check out code, it only fires `iris job run` from
+``--cwd``.
+
+Outputs a single JSON line on stdout::
+
+    {"job_id": "...", "label": "control", "gate": "1",
+     "ferry_module": "experiments.ferries.datakit_ferry",
+     "status_path": "gs://...", "run_id": "...", "cwd": "..."}
+
+The status JSON path is the standard ``FERRY_STATUS_PATH`` contract (see
+``experiments/ferries/datakit_ferry.py``); the ferry writes ``status`` and
+``marin_prefix`` there on completion.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as _dt
+import json
+import logging
+import shlex
+import subprocess
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class GateConfig:
+    ferry_module: str
+    region: str | None
+    memory: str
+    disk: str
+    cpu: str
+    extra: str
+    priority: str
+
+    @property
+    def iris_args(self) -> list[str]:
+        args = [
+            f"--memory={self.memory}",
+            f"--disk={self.disk}",
+            f"--cpu={self.cpu}",
+            f"--extra={self.extra}",
+            f"--priority={self.priority}",
+        ]
+        if self.region:
+            args.append(f"--region={self.region}")
+        return args
+
+
+# Mirrors the canonical workflow YAMLs:
+#   .github/workflows/marin-datakit-smoke.yaml          -> Gate 1
+#   .github/workflows/marin-datakit-nemotron-ferry.yaml -> Gate 2
+GATES: dict[str, GateConfig] = {
+    "1": GateConfig(
+        ferry_module="experiments.ferries.datakit_ferry",
+        region=None,
+        memory="2G",
+        disk="4G",
+        cpu="1",
+        extra="cpu",
+        priority="production",
+    ),
+    "2": GateConfig(
+        ferry_module="experiments.ferries.datakit_nemotron_ferry",
+        region="europe-west4",
+        memory="3G",
+        disk="5G",
+        cpu="1",
+        extra="cpu",
+        priority="production",
+    ),
+}
+
+
+def _build_run_id(pr: int, gate: str, label: str) -> str:
+    ts = _dt.datetime.now(_dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"zephyr-perf-pr{pr}-g{gate}-{label}-{ts}"
+
+
+def _build_status_path(pr: int, run_id: str, override: str | None) -> str:
+    if override:
+        return override
+    return "gs://marin-us-central1/tmp/ttl=7d/zephyr-perf/" f"pr{pr}/{run_id}/ferry_run_status.json"
+
+
+def submit(
+    *,
+    gate: str,
+    label: str,
+    pr: int,
+    cwd: str,
+    iris_config: str,
+    status_path_override: str | None,
+    wandb_entity: str,
+    wandb_project: str,
+    dry_run: bool,
+) -> dict[str, object]:
+    if gate not in GATES:
+        raise ValueError(f"Unknown gate {gate!r}; expected one of {sorted(GATES)}")
+    if label not in {"control", "treatment"}:
+        raise ValueError(f"Unknown label {label!r}; expected control|treatment")
+
+    cfg = GATES[gate]
+    run_id = _build_run_id(pr, gate, label)
+    status_path = _build_status_path(pr, run_id, status_path_override)
+
+    cmd = [
+        ".venv/bin/iris",
+        f"--config={iris_config}",
+        "job",
+        "run",
+        "--no-wait",
+        *cfg.iris_args,
+        "-e",
+        "SMOKE_RUN_ID",
+        run_id,
+        "-e",
+        "FERRY_STATUS_PATH",
+        status_path,
+        "-e",
+        "WANDB_ENTITY",
+        wandb_entity,
+        "-e",
+        "WANDB_PROJECT",
+        wandb_project,
+        "-e",
+        "WANDB_API_KEY",
+        "$WANDB_API_KEY",
+        "-e",
+        "HF_TOKEN",
+        "$HF_TOKEN",
+        "--",
+        "python",
+        "-m",
+        cfg.ferry_module,
+    ]
+
+    if dry_run:
+        logger.info("dry-run cmd (cwd=%s): %s", cwd, " ".join(shlex.quote(c) for c in cmd))
+        job_id = "DRY-RUN"
+    else:
+        out = subprocess.check_output(cmd, cwd=cwd, text=True)
+        job_id = out.strip().splitlines()[-1].strip()
+
+    return {
+        "job_id": job_id,
+        "label": label,
+        "gate": gate,
+        "ferry_module": cfg.ferry_module,
+        "status_path": status_path,
+        "run_id": run_id,
+        "cwd": cwd,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gate", required=True, choices=sorted(GATES))
+    parser.add_argument("--label", required=True, choices=("control", "treatment"))
+    parser.add_argument("--pr", required=True, type=int)
+    parser.add_argument("--cwd", required=True, help="Path to a worktree at the target SHA.")
+    parser.add_argument(
+        "--iris-config",
+        default="lib/iris/examples/marin.yaml",
+        help="Iris cluster config; resolved relative to --cwd.",
+    )
+    parser.add_argument(
+        "--status-out",
+        default=None,
+        help="Override FERRY_STATUS_PATH. Default lives under gs://marin-us-central1/tmp/ttl=7d/.",
+    )
+    parser.add_argument("--wandb-entity", default="marin-community")
+    parser.add_argument("--wandb-project", default="marin")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    payload = submit(
+        gate=args.gate,
+        label=args.label,
+        pr=args.pr,
+        cwd=args.cwd,
+        iris_config=args.iris_config,
+        status_path_override=args.status_out,
+        wandb_entity=args.wandb_entity,
+        wandb_project=args.wandb_project,
+        dry_run=args.dry_run,
+    )
+    print(json.dumps(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds an agent-runnable A/B perf gate for PRs touching Zephyr internals
(lib/zephyr/src/zephyr/**). Trigger excludes datakit/dedup/normalize and
test/docs paths. Two-gate ladder: Gate 1 fineweb smoke as default;
Gate 2 full nemotron when shuffle/plan/execution/external_sort/spill
is touched.

Helper scripts under scripts/zephyr/perf/ handle gate selection, ferry
submission, metric collection, comparison, and idempotent PR comment
upserts. Companion to the design doc in #5199.