### PR TITLE
Enable Ruff I001 import sorting

### DIFF
--- a/docs/design/plot_plateau_detection.py
+++ b/docs/design/plot_plateau_detection.py
@@ -7,7 +7,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
-
 from marin.rl.curriculum import LessonStats, PerformanceStats, is_plateaued
 
 sns.set_theme(style="darkgrid")

--- a/experiments/common_pile/tokenize_common_pile.py
+++ b/experiments/common_pile/tokenize_common_pile.py
@@ -3,11 +3,12 @@
 
 """Tokenization and mixture configs for the Common Pile v0.1 dataset."""
 
-from experiments.defaults import default_tokenize
-from experiments.llama import llama3_tokenizer
 from marin.datakit.download.huggingface import DownloadConfig, download_hf
 from marin.execution.executor import ExecutorStep, executor_main, this_output_path
 from marin.processing.tokenize.data_configs import TokenizerStep, lm_mixture_data_config
+
+from experiments.defaults import default_tokenize
+from experiments.llama import llama3_tokenizer
 
 # Common Pile v0.1 filtered dataset download steps
 arxiv_abstracts_filtered = ExecutorStep(

--- a/experiments/datakit_testbed/baseline.py
+++ b/experiments/datakit_testbed/baseline.py
@@ -23,12 +23,11 @@ from __future__ import annotations
 import logging
 import os
 
-from rigging.filesystem import marin_prefix
-from rigging.log_setup import configure_logging
-
 from marin.execution.executor import Executor, ExecutorMainConfig, ExecutorStep, executor_main
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
+from rigging.filesystem import marin_prefix
+from rigging.log_setup import configure_logging
 
 from experiments.datakit_testbed.mixture import weights_from_tokenized_bucket_stats
 from experiments.datakit_testbed.sampler import build_testbed_steps

--- a/experiments/datakit_testbed/sampler.py
+++ b/experiments/datakit_testbed/sampler.py
@@ -37,8 +37,6 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pyarrow.parquet as pq
 from fray import ResourceConfig
-from rigging.filesystem import url_to_fs
-
 from marin.datakit.normalize import NormalizedData
 from marin.datakit.sources import DatakitSource, all_sources
 from marin.execution.artifact import Artifact
@@ -46,6 +44,7 @@ from marin.execution.remote import remote
 from marin.execution.step_runner import check_cache
 from marin.execution.step_spec import StepSpec
 from marin.utils import fsspec_glob, fsspec_mkdirs
+from rigging.filesystem import url_to_fs
 
 from experiments.datakit_testbed.settings import RAW_TARGET_TOTAL_TOKENS_B
 

--- a/experiments/datakit_testbed/variants.py
+++ b/experiments/datakit_testbed/variants.py
@@ -19,9 +19,6 @@ import logging
 import os
 
 from fray import ResourceConfig
-from rigging.filesystem import marin_prefix
-from rigging.log_setup import configure_logging
-
 from marin.datakit.normalize import NormalizedData
 from marin.execution.artifact import Artifact
 from marin.execution.executor import Executor, ExecutorMainConfig, ExecutorStep, executor_main
@@ -30,6 +27,8 @@ from marin.execution.step_spec import StepSpec
 from marin.processing.classification.consolidate import FilterConfig, FilterType, consolidate
 from marin.processing.classification.deduplication.fuzzy_dups import FuzzyDupsAttrData, compute_fuzzy_dups_attrs
 from marin.processing.classification.deduplication.fuzzy_minhash import MinHashAttrData, compute_minhash_attrs
+from rigging.filesystem import marin_prefix
+from rigging.log_setup import configure_logging
 
 from experiments.datakit_testbed.mixture import weights_from_tokenized_bucket_stats
 from experiments.datakit_testbed.sampler import build_testbed_steps

--- a/experiments/dclm/exp433_dclm_run.py
+++ b/experiments/dclm/exp433_dclm_run.py
@@ -1,16 +1,17 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from fray.cluster import ResourceConfig
+from levanter.data.text import TextLmDatasetFormat
+from marin.execution.executor import executor_main
+from marin.processing.tokenize.data_configs import lm_mixture_data_config
+
 from experiments.defaults import SimpleTrainConfig, default_tokenize, default_train
 from experiments.evals.evals import default_eval
 from experiments.evals.task_configs import CORE_TASKS_PLUS_MMLU
 from experiments.llama import LlamaConfig
 from experiments.pretraining_datasets.dclm import DCLM_BASELINE_ONLY_MIXTURE, DCLM_MIXTURE_WEIGHTS
 from experiments.pretraining_datasets.simple import downloads
-from fray.cluster import ResourceConfig
-from levanter.data.text import TextLmDatasetFormat
-from marin.execution.executor import executor_main
-from marin.processing.tokenize.data_configs import lm_mixture_data_config
 
 gpt_neox_tokenizer = "EleutherAI/gpt-neox-20b"
 

--- a/experiments/dedup/fineweb_10bt_exact.py
+++ b/experiments/dedup/fineweb_10bt_exact.py
@@ -12,13 +12,12 @@ import argparse
 import logging
 import os
 
-from rigging.log_setup import configure_logging
-from rigging.filesystem import marin_prefix
-
 from marin.datakit.canonical import fineweb_edu
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from marin.processing.classification.deduplication.exact import dedup_exact_paragraph
+from rigging.filesystem import marin_prefix
+from rigging.log_setup import configure_logging
 
 logger = logging.getLogger(__name__)
 

--- a/experiments/dedup/poc_nemotron.py
+++ b/experiments/dedup/poc_nemotron.py
@@ -3,14 +3,11 @@
 
 # Copyright 2025 The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
-from rigging.log_setup import configure_logging
-
+import logging
 import os
 from typing import TypeVar
 
 from fray import ResourceConfig
-from rigging.filesystem import marin_temp_bucket, region_from_metadata, check_path_in_region
-
 from marin.datakit.normalize import NormalizedData, normalize_step
 from marin.execution.artifact import Artifact
 from marin.execution.step_runner import StepRunner
@@ -21,8 +18,8 @@ from marin.processing.classification.deduplication.fuzzy_minhash import (
     MinHashAttrData,
     compute_minhash_attrs,
 )
-
-import logging
+from rigging.filesystem import check_path_in_region, marin_temp_bucket, region_from_metadata
+from rigging.log_setup import configure_logging
 
 logger = logging.getLogger(__name__)
 

--- a/experiments/dedup/reference.py
+++ b/experiments/dedup/reference.py
@@ -1,9 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from rigging.log_setup import configure_logging
-from rigging.filesystem import marin_prefix
-
 from marin.datakit.normalize import NormalizedData, normalize_step
 from marin.execution.artifact import Artifact
 from marin.execution.step_runner import StepRunner
@@ -13,6 +10,8 @@ from marin.processing.classification.deduplication.fuzzy_minhash import (
     MinHashAttrData,
     compute_minhash_attrs,
 )
+from rigging.filesystem import marin_prefix
+from rigging.log_setup import configure_logging
 
 
 def build_steps() -> list[StepSpec]:

--- a/experiments/defaults.py
+++ b/experiments/defaults.py
@@ -15,7 +15,6 @@ from typing import Any
 
 import jmp
 from fray import ResourceConfig
-from marin.execution.remote import remote
 from haliax.partitioning import ResourceAxis
 from haliax.quantization import QuantizationConfig
 from levanter.checkpoint import CheckpointerConfig
@@ -36,16 +35,9 @@ from levanter.schedule import BatchSchedule
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
 from levanter.utils import fsspec_utils
-
-from experiments.evals.task_configs import CORE_TASKS
-from marin.evaluation.evaluation_config import convert_to_levanter_task_config
-from experiments.paloma import paloma_raw_validation_sets, paloma_tokenized
-from experiments.simple_dpo_config import SimpleDPOConfig
-from experiments.simple_sft_config import SimpleSFTConfig
-from experiments.simple_train_config import SimpleTrainConfig
 from levanter.utils.mesh import MeshConfig
 from marin.datakit.download.huggingface import DownloadConfig, download_hf
-from marin.evaluation.evaluation_config import EvalTaskConfig
+from marin.evaluation.evaluation_config import EvalTaskConfig, convert_to_levanter_task_config
 from marin.execution.executor import (
     ExecutorStep,
     InputName,
@@ -55,6 +47,7 @@ from marin.execution.executor import (
     unwrap_versioned_value,
     versioned,
 )
+from marin.execution.remote import remote
 from marin.processing.tokenize import (
     HfDatasetSpec,
     TokenizeConfig,
@@ -70,6 +63,12 @@ from marin.training.training import (
     run_levanter_train_dpo,
     run_levanter_train_lm,
 )
+
+from experiments.evals.task_configs import CORE_TASKS
+from experiments.paloma import paloma_raw_validation_sets, paloma_tokenized
+from experiments.simple_dpo_config import SimpleDPOConfig
+from experiments.simple_sft_config import SimpleSFTConfig
+from experiments.simple_train_config import SimpleTrainConfig
 
 logger = logging.getLogger(__name__)
 

--- a/experiments/dolma/exp442_dolma.py
+++ b/experiments/dolma/exp442_dolma.py
@@ -6,14 +6,15 @@ Train Dolma/OLMo models.
 https://github.com/marin-community/marin/issues/442
 """
 
-from experiments.defaults import default_train
-from experiments.llama import llama_1_4b, llama_1_4b_train_config
-from experiments.pretraining_datasets import DOLMA_OLMO_MIXTURE_WEIGHTS, tokenize_dolma
-from experiments.simple_train_config import SimpleTrainConfig
 from fray.cluster import ResourceConfig
 from levanter.models.llama import LlamaConfig
 from marin.execution.executor import executor_main
 from marin.processing.tokenize.data_configs import lm_mixture_data_config
+
+from experiments.defaults import default_train
+from experiments.llama import llama_1_4b, llama_1_4b_train_config
+from experiments.pretraining_datasets import DOLMA_OLMO_MIXTURE_WEIGHTS, tokenize_dolma
+from experiments.simple_train_config import SimpleTrainConfig
 
 EXPERIMENT_TAG = ["442_dolma"]
 

--- a/experiments/dpo_ultrafeedback.py
+++ b/experiments/dpo_ultrafeedback.py
@@ -5,7 +5,10 @@
 Run DPO on the Ultrafeedback preference dataset using Marin's executor framework.
 """
 
+from fray.cluster import ResourceConfig
 from levanter.data.text import PreferenceChatLmDatasetFormat
+from marin.execution.executor import executor_main, output_path_of
+from marin.processing.tokenize import lm_data_config
 
 from experiments.defaults import default_dpo, default_tokenize
 from experiments.llama import LLAMA3_CHAT_STOP_TOKEN_IDS, llama_8b
@@ -13,9 +16,6 @@ from experiments.marin_models import marin_tokenizer
 from experiments.models import llama_3_1_8b
 from experiments.posttrain.preference_datasets import get_preference_dataset
 from experiments.simple_dpo_config import SimpleDPOConfig
-from fray.cluster import ResourceConfig
-from marin.execution.executor import executor_main, output_path_of
-from marin.processing.tokenize import lm_data_config
 
 DATASET_NAME = "HuggingFaceH4/ultrafeedback_binarized"
 

--- a/experiments/evals/evalchemy_results_compiler.py
+++ b/experiments/evals/evalchemy_results_compiler.py
@@ -17,10 +17,9 @@ import traceback
 
 import fsspec
 import pandas as pd
+from marin.evaluation.evaluation_config import WANDB_PROJECT
 from rigging.filesystem import filesystem as marin_filesystem
 from rigging.filesystem import open_url
-
-from marin.evaluation.evaluation_config import WANDB_PROJECT
 
 logger = logging.getLogger(__name__)
 

--- a/experiments/evals/evals.py
+++ b/experiments/evals/evals.py
@@ -13,7 +13,6 @@ from fray.cluster import ResourceConfig
 from marin.evaluation.evaluation_config import EvalTaskConfig, EvaluationConfig
 from marin.evaluation.evaluators.harbor_evaluator import HARBOR_EVAL_ENV_KEYS, env_vars_from_keys
 from marin.evaluation.run import evaluate
-from marin.execution.remote import remote
 from marin.execution.executor import (
     ExecutorStep,
     InputName,
@@ -23,6 +22,7 @@ from marin.execution.executor import (
     this_output_path,
     versioned,
 )
+from marin.execution.remote import remote
 
 from experiments.evals.engine_configs import DEFAULT_LM_EVAL_MODEL_KWARGS
 from experiments.evals.evalchemy_results_compiler import compile_evalchemy_results_fn

--- a/experiments/evals/exp1600_uncheatable_evals.py
+++ b/experiments/evals/exp1600_uncheatable_evals.py
@@ -10,16 +10,12 @@ This experiment evaluates models' perplexity on diverse, high-quality, and fresh
 Reference: https://github.com/Jellyfish042/uncheatable_eval
 """
 
+import logging
 import os
 import os.path
-import logging
 from dataclasses import dataclass
 from functools import lru_cache
 
-
-from experiments.defaults import default_tokenize
-from experiments.llama import llama3_tokenizer
-from experiments.models import ModelConfig as HFModelConfig, download_model_step
 from fray.cluster import ResourceConfig
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from marin.datakit.download.uncheatable_eval import make_uncheatable_eval_step
@@ -27,6 +23,11 @@ from marin.evaluation.log_probs import default_lm_log_probs
 from marin.execution.executor import ExecutorStep, executor_main, output_path_of
 from marin.processing.tokenize import TokenizeConfig
 from marin.processing.tokenize.data_configs import TokenizerStep, mixture_for_evaluation
+
+from experiments.defaults import default_tokenize
+from experiments.llama import llama3_tokenizer
+from experiments.models import ModelConfig as HFModelConfig
+from experiments.models import download_model_step
 
 logger = logging.getLogger(__name__)
 

--- a/experiments/evals/exp1602_lm_eval_harness.py
+++ b/experiments/evals/exp1602_lm_eval_harness.py
@@ -6,6 +6,9 @@ Comprehensive LM Evaluation Harness Testing
 Reference: https://github.com/EleutherAI/lm-evaluation-harness
 """
 
+from fray.cluster import ResourceConfig
+from marin.execution.executor import executor_main
+
 from experiments.evals.evals import default_eval
 from experiments.evals.task_configs import (
     ACTION_TASKS,
@@ -20,9 +23,6 @@ from experiments.evals.task_configs import (
     TRUTHFULNESS_TASKS,
 )
 from experiments.models import qwen3_32b
-from fray.cluster import ResourceConfig
-from marin.execution.executor import executor_main
-
 from experiments.tootsie.exp1529_32b_mantis_cooldown import tootsie_32b_cooldown_mantis as marin_32b
 
 # List of models to evaluate

--- a/experiments/evals/exp5062_game_music_evals.py
+++ b/experiments/evals/exp5062_game_music_evals.py
@@ -23,8 +23,8 @@ from marin.datakit.ingestion_manifest import (
     UsagePolicy,
 )
 from marin.evaluation.perplexity_gap import RawTextEvaluationDataset, raw_text_dataset
-from marin.execution.step_spec import StepSpec
 from marin.execution.step_runner import StepRunner
+from marin.execution.step_spec import StepSpec
 
 ISSUE_5062 = 5062
 EPIC_5005 = 5005

--- a/experiments/evals/exp_evalchemy_eval.py
+++ b/experiments/evals/exp_evalchemy_eval.py
@@ -35,7 +35,8 @@ Here are a couple of examples:
 import argparse
 import sys
 
-from experiments.evals.evals import run_evalchemy_experiment
+from fray.cluster import ResourceConfig
+
 from experiments.evals.evalchemy_task_configs import (
     AIME24,
     AIME25,
@@ -52,7 +53,7 @@ from experiments.evals.evalchemy_task_configs import (
     OLYMPIADBENCH,
     OLYMPIADBENCH_PHYSICS,
 )
-from fray.cluster import ResourceConfig
+from experiments.evals.evals import run_evalchemy_experiment
 
 # =============================================================================
 # Model Configuration

--- a/experiments/evals/exp_evalchemy_eval_reproduce_openthoughts.py
+++ b/experiments/evals/exp_evalchemy_eval_reproduce_openthoughts.py
@@ -8,7 +8,8 @@ Evalchemy (https://github.com/mlfoundations/evalchemy) provides specialized
 reasoning tasks including AIME24/25, MATH500, HumanEval+, MBPP+, and more.
 """
 
-from experiments.evals.evals import run_evalchemy_experiment
+from fray.cluster import ResourceConfig
+
 from experiments.evals.evalchemy_task_configs import (
     AIME24,
     AIME25,
@@ -22,7 +23,7 @@ from experiments.evals.evalchemy_task_configs import (
     LIVECODEBENCH,
     MATH500,
 )
-from fray.cluster import ResourceConfig
+from experiments.evals.evals import run_evalchemy_experiment
 
 # =============================================================================
 # Model Configuration

--- a/experiments/evals/fineweb2_multilingual.py
+++ b/experiments/evals/fineweb2_multilingual.py
@@ -12,11 +12,12 @@ import os.path
 from collections.abc import Sequence
 from typing import Literal
 
-from experiments.defaults import default_tokenize
-from experiments.llama import llama3_tokenizer
 from marin.evaluation.perplexity_gap import RawTextEvaluationDataset, raw_text_dataset
 from marin.execution.executor import executor_main
 from marin.processing.tokenize.data_configs import TokenizerStep
+
+from experiments.defaults import default_tokenize
+from experiments.llama import llama3_tokenizer
 
 FINEWEB2_DATASET_ID = "HuggingFaceFW/fineweb-2"
 FINEWEB2_PARQUET_REVISION = "345aeeb34ec379862323beb9b5530d9e7f94522d"

--- a/experiments/evals/perplexity_gap_registry.py
+++ b/experiments/evals/perplexity_gap_registry.py
@@ -17,11 +17,6 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 
 from fray.types import ResourceConfig
-
-from experiments.defaults import default_raw_validation_sets
-from experiments.evals.fineweb2_multilingual import fineweb2_multilingual_raw_validation_sets
-from experiments.evals.long_tail_ppl_runnable import runnable_long_tail_raw_validation_sets
-from experiments.marin_models import marin_tokenizer
 from marin.evaluation.perplexity_gap import (
     GapFinderModelConfig,
     RawTextEvaluationDataset,
@@ -29,6 +24,11 @@ from marin.evaluation.perplexity_gap import (
     model_perplexity_scores,
 )
 from marin.execution.executor import ExecutorStep
+
+from experiments.defaults import default_raw_validation_sets
+from experiments.evals.fineweb2_multilingual import fineweb2_multilingual_raw_validation_sets
+from experiments.evals.long_tail_ppl_runnable import runnable_long_tail_raw_validation_sets
+from experiments.marin_models import marin_tokenizer
 
 DEFAULT_MAX_EVAL_LENGTH = 4096
 DEFAULT_MAX_DOCS_PER_DATASET = 256

--- a/experiments/evals/run_base_model_evals.py
+++ b/experiments/evals/run_base_model_evals.py
@@ -9,9 +9,10 @@ MAP-NEO 7B, and Amber Base 7B models on CORE_TASKS (augmented with OLMo Eval Tas
 as dedicated MMLU 0-shot and 5-shot configurations.
 """
 
+from marin.execution.executor import executor_main
+
 from experiments.evals.evals import default_base_eval
 from experiments.models import amber_base_7b, llama_3_1_8b, map_neo_7b, olmo_2_base_8b
-from marin.execution.executor import executor_main
 
 if __name__ == "__main__":
     # Model path for deeper starling

--- a/experiments/evals/run_key_evals.py
+++ b/experiments/evals/run_key_evals.py
@@ -1,9 +1,10 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from experiments.evals.evals import default_key_evals
 from fray.cluster import ResourceConfig
 from marin.execution.executor import executor_main
+
+from experiments.evals.evals import default_key_evals
 
 # Insert your model path here
 # model_path = "gs://marin-us-central2/checkpoints/llama-8b-control-00f31b/hf/step-210388"

--- a/experiments/evals/run_on_gpu.py
+++ b/experiments/evals/run_on_gpu.py
@@ -6,10 +6,11 @@ For evals that need to be run on GPUs (e.g. LM Evaluation Harness).
 """
 
 # nodryrun
-from experiments.dclm.exp433_dclm_run import dclm_baseline_only_model
-from experiments.evals.evals import default_eval, evaluate_lm_evaluation_harness
 from marin.evaluation.evaluation_config import EvalTaskConfig
 from marin.execution.executor import executor_main
+
+from experiments.dclm.exp433_dclm_run import dclm_baseline_only_model
+from experiments.evals.evals import default_eval, evaluate_lm_evaluation_harness
 
 # example of how to eval a specific checkpoint
 quickstart_eval_step = evaluate_lm_evaluation_harness(

--- a/experiments/evals/run_sft_model_evals.py
+++ b/experiments/evals/run_sft_model_evals.py
@@ -9,10 +9,11 @@ MAP-NEO 7B, and Amber Base 7B models on CORE_TASKS (augmented with OLMo Eval Tas
 as dedicated MMLU 0-shot and 5-shot configurations.
 """
 
+from marin.execution.executor import executor_main
+
 from experiments.evals.evals import default_sft_eval
 from experiments.models import llama_3_1_8b_instruct, tulu_3_1_8b_instruct
 from experiments.tootsie.exp1237_starling_sft import mixture_sft_deeper_starling
-from marin.execution.executor import executor_main
 
 if __name__ == "__main__":
     # Run all evaluations on all models

--- a/experiments/evals/security_artifact_slices.py
+++ b/experiments/evals/security_artifact_slices.py
@@ -24,13 +24,14 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
-from experiments.defaults import default_download
 from marin.evaluation.perplexity_gap import RawTextEvaluationDataset, raw_text_dataset
 from marin.execution.executor import ExecutorStep, this_output_path
 from marin.transform.security_artifacts.zeek_to_dolma import (
     ZeekToDolmaConfig,
     convert_zeek_to_dolma,
 )
+
+from experiments.defaults import default_download
 
 # Canonical Zeek conn.log field order as documented at
 # https://docs.zeek.org/en/master/logs/conn.html. Kept as a tuple so it can be

--- a/experiments/exp1337_delphi_suite.py
+++ b/experiments/exp1337_delphi_suite.py
@@ -31,21 +31,20 @@ from levanter.main import train_lm
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
 from levanter.utils.mesh import MeshConfig
+from marin.execution.executor import ExecutorStep, executor_main, this_output_path
+from marin.processing.tokenize import step_to_lm_mixture_component
+from marin.scaling_laws import ScalingFit, predict_optimal_config
+from marin.training.training import TrainLmOnPodConfig, run_levanter_train_lm
 
 from experiments.defaults import default_validation_sets
 from experiments.isoflop_sweep import (
-    IsoFlopAnalysisConfig,
     MARIN_SCALING_SUITES,
+    IsoFlopAnalysisConfig,
     nemotron_mix,
     run_isoflop_analysis_step,
 )
 from experiments.llama import llama3_tokenizer
 from experiments.scaling_law_sweeps.completed_adamh import completed_adamh_heuristic
-from marin.execution.executor import ExecutorStep, executor_main, this_output_path
-from marin.processing.tokenize import step_to_lm_mixture_component
-from marin.scaling_laws import ScalingFit, predict_optimal_config
-
-from marin.training.training import TrainLmOnPodConfig, run_levanter_train_lm
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/experiments/exp1337_eval_suite.py
+++ b/experiments/exp1337_eval_suite.py
@@ -62,6 +62,8 @@ Launch via iris:
 """
 
 from fray.cluster import ResourceConfig
+from marin.evaluation.evaluation_config import EvalTaskConfig
+from marin.execution.executor import ExecutorStep, InputName, executor_main
 
 from experiments.evals.evals import (
     evaluate_levanter_lm_evaluation_harness,
@@ -83,8 +85,6 @@ from experiments.models import (
     qwen3_8b_base,
     qwen3_14b_base,
 )
-from marin.evaluation.evaluation_config import EvalTaskConfig
-from marin.execution.executor import ExecutorStep, InputName, executor_main
 
 # Env vars plumbed through to each iris child worker running ``vllm serve``.
 # The coordinator's ``os.environ`` does NOT propagate to iris-spawned children;

--- a/experiments/exp1775_nanochat_three_stage.py
+++ b/experiments/exp1775_nanochat_three_stage.py
@@ -16,6 +16,10 @@ Schedule details
 """
 import dataclasses
 
+from fray.cluster import ResourceConfig
+from marin.execution.executor import executor_main, output_path_of
+from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
+
 from experiments.defaults import default_sft, default_train
 from experiments.exp808_sft_mixture import mixture_config as sft_mixture_llama3
 from experiments.llama import llama3_tokenizer, llama_600m
@@ -23,9 +27,6 @@ from experiments.midtraining_datasets import finemath_3_plus_tokenized, megamath
 from experiments.pretraining_datasets.dclm import DCLM_MIXTURE_WEIGHTS, dclm_components_llama3
 from experiments.simple_sft_config import SimpleSFTConfig
 from experiments.simple_train_config import SimpleTrainConfig
-from fray.cluster import ResourceConfig
-from marin.execution.executor import executor_main, output_path_of
-from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
 
 # ------------------------------------------------------------------------------------
 # Shared hyperparameters and helpers

--- a/experiments/exp1880_sft_baseline.py
+++ b/experiments/exp1880_sft_baseline.py
@@ -14,7 +14,10 @@ import dataclasses
 import math
 import re
 
-from levanter.data.text import DEFAULT_LM_DATA_SHUFFLE
+from fray.cluster import ResourceConfig
+from levanter.data.text import DEFAULT_LM_DATA_SHUFFLE, ChatLmDatasetFormat
+from marin.execution.executor import ExecutorStep, executor_main
+from marin.processing.tokenize import lm_mixture_data_config
 
 from experiments.defaults import default_sft, default_tokenize
 from experiments.evals.evals import default_sft_eval
@@ -27,10 +30,6 @@ from experiments.posttrain.instruction_datasets import (
     get_instruction_dataset,
 )
 from experiments.simple_sft_config import SimpleSFTConfig
-from fray.cluster import ResourceConfig
-from levanter.data.text import ChatLmDatasetFormat
-from marin.execution.executor import ExecutorStep, executor_main
-from marin.processing.tokenize import lm_mixture_data_config
 
 SLUGIFY_PATTERN = re.compile(r"[^a-z0-9]+")
 

--- a/experiments/exp1994_32b_sft.py
+++ b/experiments/exp1994_32b_sft.py
@@ -8,6 +8,9 @@ and uses the mixture frmo 1880
 
 import dataclasses
 
+from fray.cluster import ResourceConfig
+from marin.execution.executor import executor_main
+
 from experiments.defaults import default_sft
 from experiments.evals.evals import default_sft_eval
 from experiments.exp1880_sft_baseline import mixture_config
@@ -17,8 +20,6 @@ from experiments.tootsie.exp1529_32b_mantis_cooldown import (
     qwen3_32b_remat,
     tootsie_32b_cooldown_mantis,
 )
-from fray.cluster import ResourceConfig
-from marin.execution.executor import executor_main
 
 TRAIN_BATCH_SIZE = 2048
 # Matches the 3-epoch budget from exp1880_sft_baseline (computed against that mixture).

--- a/experiments/exp2166_scaling_ladder_analysis.py
+++ b/experiments/exp2166_scaling_ladder_analysis.py
@@ -28,21 +28,21 @@ from levanter.main import train_lm
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
 from levanter.utils.mesh import MeshConfig
-
-from experiments.defaults import default_validation_sets
-from experiments.isoflop_sweep import (
-    IsoFlopAnalysisConfig,
-    MARIN_SCALING_SUITES,
-    nemotron_mix,
-    run_isoflop_analysis_step,
-)
-from experiments.scaling_law_sweeps.c_adamc import c_adamc_heuristic
-from experiments.llama import llama3_tokenizer
 from marin.execution.executor import ExecutorStep, executor_main, this_output_path
 from marin.processing.tokenize import step_to_lm_mixture_component
 from marin.scaling_laws import ScalingFit, predict_optimal_config
 from marin.scaling_laws.tpu_utils import V5P_SPEC, pick_v5p_type
 from marin.training.training import TrainLmOnPodConfig, run_levanter_train_lm
+
+from experiments.defaults import default_validation_sets
+from experiments.isoflop_sweep import (
+    MARIN_SCALING_SUITES,
+    IsoFlopAnalysisConfig,
+    nemotron_mix,
+    run_isoflop_analysis_step,
+)
+from experiments.llama import llama3_tokenizer
+from experiments.scaling_law_sweeps.c_adamc import c_adamc_heuristic
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/experiments/exp606_sft.py
+++ b/experiments/exp606_sft.py
@@ -9,12 +9,12 @@ This module provides the `tulu3_llama_data_old` dataset configuration and
 """
 
 from fray.cluster import ResourceConfig
+from marin.processing.tokenize import lm_data_config
 
 from experiments.defaults import default_tokenize
 from experiments.llama import llama3_instruct_chat_format, llama3_instruct_tokenizer
 from experiments.posttrain.instruction_datasets import get_instruction_dataset
 from experiments.simple_sft_config import SimpleSFTConfig
-from marin.processing.tokenize import lm_data_config
 
 # Get instruction dataset
 tulu_3_dataset = get_instruction_dataset("allenai/tulu-3-sft-mixture")

--- a/experiments/exp808_sft_mixture.py
+++ b/experiments/exp808_sft_mixture.py
@@ -10,16 +10,16 @@ different number of datasets you will need to change the number of training step
 accordingly.
 """
 
+from fray.cluster import ResourceConfig
 from levanter.data.text import DEFAULT_LM_DATA_SHUFFLE, ChatLmDatasetFormat
+from marin.execution.executor import ExecutorStep, executor_main
+from marin.processing.tokenize import lm_mixture_data_config
 
 from experiments.defaults import default_sft, default_tokenize
 from experiments.llama import llama_8b
 from experiments.marin_models import marin_tokenizer
 from experiments.posttrain.instruction_datasets import get_instruction_dataset
 from experiments.simple_sft_config import SimpleSFTConfig
-from fray.cluster import ResourceConfig
-from marin.execution.executor import ExecutorStep, executor_main
-from marin.processing.tokenize import lm_mixture_data_config
 
 
 def create_tokenization_step(dataset_name: str) -> ExecutorStep:

--- a/experiments/exp_model_perplexity_gap_coverage_matrix.py
+++ b/experiments/exp_model_perplexity_gap_coverage_matrix.py
@@ -10,9 +10,9 @@ This expands the canonical bundle/model registry into:
 """
 
 from fray.types import ResourceConfig
+from marin.execution.executor import executor_main
 
 from experiments.evals.perplexity_gap_registry import build_registered_perplexity_gap_coverage_plan
-from marin.execution.executor import executor_main
 
 RESOURCE_CONFIG = ResourceConfig.with_tpu("v5p-8", regions=["us-central1"])
 PLAN = build_registered_perplexity_gap_coverage_plan(resource_config=RESOURCE_CONFIG)

--- a/experiments/exp_model_perplexity_gap_fineweb2_multilingual.py
+++ b/experiments/exp_model_perplexity_gap_fineweb2_multilingual.py
@@ -2,15 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from fray.types import ResourceConfig
-
-from experiments.defaults import default_raw_validation_sets
-from experiments.evals.fineweb2_multilingual import fineweb2_multilingual_raw_validation_sets
 from marin.evaluation.perplexity_gap import (
     GapFinderModelConfig,
     model_perplexity_gap_from_scores,
     model_perplexity_scores,
 )
 from marin.execution.executor import executor_main
+
+from experiments.defaults import default_raw_validation_sets
+from experiments.evals.fineweb2_multilingual import fineweb2_multilingual_raw_validation_sets
 
 RESOURCE_CONFIG = ResourceConfig.with_tpu("v5p-8", regions=["us-central1"])
 MAX_DOCS_PER_DATASET = 256

--- a/experiments/exp_model_perplexity_gap_long_tail_runnable.py
+++ b/experiments/exp_model_perplexity_gap_long_tail_runnable.py
@@ -7,14 +7,14 @@ See https://github.com/marin-community/marin/issues/5005.
 """
 
 from fray.types import ResourceConfig
-
-from experiments.evals.long_tail_ppl_runnable import runnable_long_tail_raw_validation_sets
 from marin.evaluation.perplexity_gap import (
     GapFinderModelConfig,
     model_perplexity_gap_from_scores,
     model_perplexity_scores,
 )
 from marin.execution.executor import executor_main
+
+from experiments.evals.long_tail_ppl_runnable import runnable_long_tail_raw_validation_sets
 
 RESOURCE_CONFIG = ResourceConfig.with_tpu("v5p-8", regions=["us-central1"])
 MAX_DOCS_PER_DATASET = 256

--- a/experiments/exp_model_perplexity_gap_marin_vs_llama.py
+++ b/experiments/exp_model_perplexity_gap_marin_vs_llama.py
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from fray.types import ResourceConfig
-
-from experiments.defaults import default_raw_validation_sets
 from marin.evaluation.perplexity_gap import (
     GapFinderModelConfig,
     model_perplexity_gap_from_scores,
     model_perplexity_scores,
 )
 from marin.execution.executor import executor_main
+
+from experiments.defaults import default_raw_validation_sets
 
 RESOURCE_CONFIG = ResourceConfig.with_tpu(
     "v5p-8",

--- a/experiments/exp_simple_rl.py
+++ b/experiments/exp_simple_rl.py
@@ -18,13 +18,12 @@ Key simplifications:
 import argparse
 
 import equinox as eqx
+import haliax as hax
 import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
 from jax.sharding import Mesh
-
-import haliax as hax
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, load_tokenizer
 from levanter.layers.attention import AttentionBackend, AttentionMask
 from levanter.models.llama import LlamaConfig

--- a/experiments/ferries/datakit_ferry.py
+++ b/experiments/ferries/datakit_ferry.py
@@ -11,10 +11,6 @@ import json
 import logging
 import os
 
-from rigging.filesystem import marin_temp_bucket, url_to_fs
-from rigging.log_setup import configure_logging
-from rigging.timing import log_time
-
 from fray import ResourceConfig
 from marin.datakit.download.huggingface import download_hf_step
 from marin.datakit.normalize import NormalizedData, normalize_step
@@ -35,6 +31,9 @@ from marin.processing.classification.deduplication.fuzzy_minhash import (
     compute_minhash_attrs,
 )
 from marin.processing.tokenize.tokenize import TokenizeConfig, tokenize
+from rigging.filesystem import marin_temp_bucket, url_to_fs
+from rigging.log_setup import configure_logging
+from rigging.timing import log_time
 
 logger = logging.getLogger(__name__)
 

--- a/experiments/ferries/datakit_nemotron_ferry.py
+++ b/experiments/ferries/datakit_nemotron_ferry.py
@@ -16,15 +16,6 @@ import json
 import logging
 import os
 
-from rigging.filesystem import (
-    check_path_in_region,
-    marin_temp_bucket,
-    region_from_metadata,
-    url_to_fs,
-)
-from rigging.log_setup import configure_logging
-from rigging.timing import log_time
-
 from fray import ResourceConfig
 from marin.datakit.normalize import NormalizedData, normalize_step
 from marin.execution.artifact import Artifact
@@ -44,6 +35,14 @@ from marin.processing.classification.deduplication.fuzzy_minhash import (
     compute_minhash_attrs,
 )
 from marin.processing.tokenize.tokenize import TokenizeConfig, tokenize
+from rigging.filesystem import (
+    check_path_in_region,
+    marin_temp_bucket,
+    region_from_metadata,
+    url_to_fs,
+)
+from rigging.log_setup import configure_logging
+from rigging.timing import log_time
 
 logger = logging.getLogger(__name__)
 

--- a/experiments/ferries/ferry_10_31_muonh_feistel.py
+++ b/experiments/ferries/ferry_10_31_muonh_feistel.py
@@ -6,13 +6,11 @@
 
 import dataclasses
 
-from levanter.optim import MuonHConfig
-
-from experiments.defaults import SimpleTrainConfig, default_train
-from experiments.qwen3 import qwen3_1_7b, qwen3_8b
 from fray.cluster import ResourceConfig
+from levanter.optim import MuonHConfig
 from marin.execution.executor import executor_main
 
+from experiments.defaults import SimpleTrainConfig, default_train
 from experiments.ferries.initial_ferry import (
     BATCH_SIZE_1B,
     BATCH_SIZE_8B,
@@ -22,6 +20,7 @@ from experiments.ferries.initial_ferry import (
 from experiments.ferries.initial_ferry import (
     _build_varying_mixture_for_steps as _base_build_varying_mixture_for_steps,
 )
+from experiments.qwen3 import qwen3_1_7b, qwen3_8b
 
 muonh_cfg_1b = MuonHConfig(
     learning_rate=0.01,

--- a/experiments/ferries/initial_ferry.py
+++ b/experiments/ferries/initial_ferry.py
@@ -5,23 +5,24 @@
 
 import math
 
+from fray.cluster import ResourceConfig
+from marin.execution.executor import executor_main
+from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
+
 from experiments.defaults import SimpleTrainConfig, default_train
-from experiments.qwen3 import qwen3_1_7b, qwen3_8b
-from experiments.pretraining_datasets.dclm import dclm_components_llama3
-from experiments.pretraining_datasets import (
-    NEMOTRON_WEIGHTS,
-    tokenize_nemotron,
-)
 from experiments.exp934_hq_vs_pt import pt_vs_hq_components
 from experiments.midtraining_datasets import (
     megamath_token_counts,
     megamath_tokenized,
     stackv2_edu_filtered_python_tokenized,
 )
+from experiments.pretraining_datasets import (
+    NEMOTRON_WEIGHTS,
+    tokenize_nemotron,
+)
+from experiments.pretraining_datasets.dclm import dclm_components_llama3
+from experiments.qwen3 import qwen3_1_7b, qwen3_8b
 from experiments.tootsie.exp600_tootsie import phase_3_tokenized, starling_components
-from fray.cluster import ResourceConfig
-from marin.execution.executor import executor_main
-from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
 
 SEQ_LEN = 4096
 BATCH_SIZE_1B = 128

--- a/experiments/grug/base/model.py
+++ b/experiments/grug/base/model.py
@@ -13,7 +13,6 @@ from jax import random
 from jax.sharding import PartitionSpec as P
 from jax.sharding import reshard
 from jaxtyping import Array, Float, Int, PRNGKeyArray
-
 from levanter.grug.attention import AttentionMask, RotaryConfig, apply_rotary_embedding, attention
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
 from levanter.grug.sharding import Pbatch, Pembed_vocab, Plm_head, Plogits, unshard

--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass, field
 import jax
 import jax.numpy as jnp
 import jmp
+import levanter.callbacks as callbacks
+import levanter.tracker
 import optax
 from fray.cluster import ResourceConfig
 from haliax import Axis
@@ -19,9 +21,6 @@ from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jax.tree_util import register_dataclass
 from jaxtyping import PRNGKeyArray
-
-import levanter.callbacks as callbacks
-import levanter.tracker
 from levanter.callbacks.state_adapter import StateCallbackRunner
 from levanter.callbacks.watch import WatchConfig, compute_watch_stats
 from levanter.data import AsyncDataset, DataLoader
@@ -37,9 +36,9 @@ from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.jax_utils import parameter_count
 from levanter.utils.logging import LoadingTimeTrackerIterator
 
+from experiments.grug.base.model import GrugModelConfig, Transformer
 from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
 from experiments.grug.dispatch import dispatch_grug_training_run
-from experiments.grug.base.model import GrugModelConfig, Transformer
 
 logger = logging.getLogger(__name__)
 

--- a/experiments/grug/checkpointing.py
+++ b/experiments/grug/checkpointing.py
@@ -13,7 +13,6 @@ from typing import TypeVar
 import fsspec
 import jax
 from fsspec import AbstractFileSystem
-
 from levanter.checkpoint import load_checkpoint
 
 logger = logging.getLogger(__name__)

--- a/experiments/grug/dispatch.py
+++ b/experiments/grug/dispatch.py
@@ -8,10 +8,9 @@ import re
 from collections.abc import Callable
 from typing import TypeVar
 
-from fray.cluster import ResourceConfig
 from fray.client import current_client
-from fray.types import Entrypoint, JobRequest, create_environment
-from fray.types import GpuConfig, TpuConfig
+from fray.cluster import ResourceConfig
+from fray.types import Entrypoint, GpuConfig, JobRequest, TpuConfig, create_environment
 
 logger = logging.getLogger(__name__)
 

--- a/experiments/grug/modular_opt/model.py
+++ b/experiments/grug/modular_opt/model.py
@@ -13,7 +13,6 @@ from jax import random
 from jax.sharding import PartitionSpec as P
 from jax.sharding import reshard
 from jaxtyping import Array, Float, Int, PRNGKeyArray
-
 from levanter.grug.attention import AttentionMask, RotaryConfig, apply_rotary_embedding, attention
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
 from levanter.grug.sharding import Pbatch, Pembed_vocab, Plm_head, Plogits, unshard

--- a/experiments/grug/modular_opt/train.py
+++ b/experiments/grug/modular_opt/train.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass, field
 import jax
 import jax.numpy as jnp
 import jmp
+import levanter.callbacks as callbacks
+import levanter.tracker
 import optax
 from fray.cluster import ResourceConfig
 from haliax import Axis
@@ -19,9 +21,6 @@ from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jax.tree_util import register_dataclass
 from jaxtyping import PRNGKeyArray
-
-import levanter.callbacks as callbacks
-import levanter.tracker
 from levanter.callbacks.state_adapter import StateCallbackRunner
 from levanter.callbacks.watch import WatchConfig, compute_watch_stats
 from levanter.data import AsyncDataset, DataLoader

--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -8,7 +8,6 @@ No load-balancing loss; router z-loss only. All layers are MoE (no dense layers)
 """
 
 import dataclasses
-
 from dataclasses import dataclass
 
 import equinox as eqx
@@ -26,7 +25,6 @@ try:
 except ModuleNotFoundError:
     from jax.experimental.shard_map import shard_map
 from jaxtyping import Array, Float, Int, PRNGKeyArray
-
 from levanter.grug.attention import AttentionMask, RotaryConfig, align_kv_heads, apply_rotary_embedding, attention
 from levanter.grug.grug_moe import MoeActivation, MoeImplementation, moe_mlp
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss

--- a/experiments/grug/moe/optimizer.py
+++ b/experiments/grug/moe/optimizer.py
@@ -5,10 +5,10 @@ from dataclasses import dataclass
 
 import jax
 import optax
-
 from levanter.optim import OptimizerConfig
-from experiments.grug.moe.adamh import scale_by_adamh
 from levanter.utils.jax_utils import leaf_key_paths
+
+from experiments.grug.moe.adamh import scale_by_adamh
 
 
 @OptimizerConfig.register_subclass("grug_moe_adamh_v2")

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -9,9 +9,12 @@ import logging
 import time
 from dataclasses import dataclass, field
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jmp
+import levanter.callbacks as callbacks
+import levanter.tracker
 import optax
 from fray.cluster import ResourceConfig
 from haliax import Axis
@@ -19,9 +22,6 @@ from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jax.tree_util import register_dataclass
 from jaxtyping import PRNGKeyArray
-
-import levanter.callbacks as callbacks
-import levanter.tracker
 from levanter.callbacks.state_adapter import StateCallbackRunner
 from levanter.callbacks.watch import WatchConfig, compute_watch_stats
 from levanter.data import AsyncDataset, DataLoader
@@ -37,7 +37,6 @@ from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.jax_utils import parameter_count
 from levanter.utils.logging import LoadingTimeTrackerIterator
 
-import equinox as eqx
 from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
 from experiments.grug.dispatch import dispatch_grug_training_run
 from experiments.grug.moe.model import GrugModelConfig, Transformer

--- a/experiments/isoflop_sweep.py
+++ b/experiments/isoflop_sweep.py
@@ -15,6 +15,11 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 import fsspec
+from marin.execution.executor import executor_main
+from marin.processing.tokenize import lm_mixture_data_config
+from marin.scaling_laws import FitScalingLawsResult, IsoFlopRecord, fit_scaling_laws, round_flops_to_bucket
+from marin.scaling_laws.eval_metrics_reader import read_eval_records
+from marin.utilities.wandb_utils import WANDB_ENTITY, WANDB_PROJECT
 
 from experiments.common_pile.tokenize_common_pile import comma_main_mixture
 from experiments.defaults import default_tokenize
@@ -23,11 +28,6 @@ from experiments.pretraining_datasets.simple import downloads
 from experiments.scaling_law_sweeps import c_adamc as c_adamc_heuristic
 from experiments.scaling_law_sweeps import completed_adamh as completed_adamh_heuristic
 from experiments.tootsie.exp1295_32b import nemotron_mix
-from marin.execution.executor import executor_main
-from marin.processing.tokenize import lm_mixture_data_config
-from marin.scaling_laws import FitScalingLawsResult, IsoFlopRecord, fit_scaling_laws, round_flops_to_bucket
-from marin.scaling_laws.eval_metrics_reader import read_eval_records
-from marin.utilities.wandb_utils import WANDB_ENTITY, WANDB_PROJECT
 
 logger = logging.getLogger(__name__)
 

--- a/experiments/llama.py
+++ b/experiments/llama.py
@@ -5,14 +5,13 @@
 Specifies a sequence of Llama 3 models from small to large.
 """
 
+from fray.cluster import ResourceConfig
+from levanter.data.text import ChatLmDatasetFormat
 from levanter.layers.rotary import Llama3RotaryEmbeddingsConfig
 from levanter.models.llama import LlamaConfig
 from levanter.utils.activation import ActivationFunctionEnum
 
 from experiments.simple_train_config import SimpleTrainConfig
-from fray.cluster import ResourceConfig
-
-from levanter.data.text import ChatLmDatasetFormat
 
 llama3_tokenizer = "meta-llama/Meta-Llama-3.1-8B"
 llama3_tokenizer_vocab_size = 128_256

--- a/experiments/llama_3_8b_rl_math500.py
+++ b/experiments/llama_3_8b_rl_math500.py
@@ -16,7 +16,6 @@ import datetime
 import logging
 import os
 
-from experiments.models import llama_3_1_8b_instruct
 from levanter.checkpoint import CheckpointDebugConfig
 from levanter.models.llama import LlamaConfig
 from marin.execution.executor import executor_main
@@ -30,6 +29,8 @@ from marin.rl.rl_experiment_utils import (
     make_rl_step,
 )
 from marin.rl.rl_losses import RLOOLoss
+
+from experiments.models import llama_3_1_8b_instruct
 
 logger = logging.getLogger(__name__)
 

--- a/experiments/midtraining_datasets.py
+++ b/experiments/midtraining_datasets.py
@@ -1,9 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from experiments.common_pile.tokenize_common_pile import stackv2_edu_filtered
-from experiments.defaults import default_download, default_tokenize
-from experiments.llama import llama3_tokenizer
 from marin.datakit.download.huggingface import DownloadConfig, download_hf
 from marin.execution import versioned
 from marin.execution.executor import ExecutorStep, this_output_path
@@ -13,6 +10,10 @@ from marin.transform.common_pile.filter_by_extension import (
     filter_dataset_by_metadata_extension,
 )
 from marin.transform.medical.lavita_to_dolma import LavitaToDolmaConfig, convert_lavita_split_to_dolma
+
+from experiments.common_pile.tokenize_common_pile import stackv2_edu_filtered
+from experiments.defaults import default_download, default_tokenize
+from experiments.llama import llama3_tokenizer
 
 finemath_commit_hash = "8f233cf"
 finemath = ExecutorStep(

--- a/experiments/multilingual/exp1457_multilingual_cpt.py
+++ b/experiments/multilingual/exp1457_multilingual_cpt.py
@@ -11,12 +11,14 @@ The training uses a linear LR decay from 1.7e-3 to 1.7e-5 over 80,000 steps (~1.
 import dataclasses
 
 from levanter.schedule import ScheduleStep
+from marin.execution.executor import executor_main
+from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
 
-from experiments.pretraining_datasets.dclm import DCLM_MIXTURE_WEIGHTS
 from experiments.defaults import default_train
 from experiments.llama import llama_8b
 from experiments.multilingual_fineweb2_hq.constants import FINEWEB2_HQ_MIXTURE_BYTES
 from experiments.multilingual_fineweb2_hq.download_and_tokenize_fineweb2_hq import tokenize_fineweb2hq_steps
+from experiments.pretraining_datasets.dclm import DCLM_MIXTURE_WEIGHTS
 from experiments.tootsie.exp600_tootsie import (
     PHASE_1_END,
     PHASE_3_START,
@@ -30,8 +32,6 @@ from experiments.tootsie.exp600_tootsie import (
     phase_4_warmup_weights,
     starling_hq_cooldown_weights,
 )
-from marin.execution.executor import executor_main
-from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
 
 ##############################################################
 # Phase 5: Starling second cooldown and Multilingual CPT Start

--- a/experiments/multilingual/exp1457_multilingual_cpt_eval.py
+++ b/experiments/multilingual/exp1457_multilingual_cpt_eval.py
@@ -8,13 +8,14 @@ Evaluate the multilingual CPT continuation (exp1457) and baseline 7B/8B models o
 from collections.abc import Iterable
 from dataclasses import replace
 
-from experiments.evals.evals import default_eval
-from experiments.evals.task_configs import MULTILINGUAL_LM_EVAL_LOGPROB_TASKS
-from experiments.multilingual.exp1457_multilingual_cpt import multilingual_cpt_8b_fineweb2_hq
-from experiments.models import apertus_8b, llama_3_1_8b, olmo_2_base_8b, olmo_3_1025_7b, qwen2_5_7b
 from fray.cluster import ResourceConfig
 from marin.evaluation.evaluation_config import EvalTaskConfig
 from marin.execution.executor import ExecutorStep, executor_main
+
+from experiments.evals.evals import default_eval
+from experiments.evals.task_configs import MULTILINGUAL_LM_EVAL_LOGPROB_TASKS
+from experiments.models import apertus_8b, llama_3_1_8b, olmo_2_base_8b, olmo_3_1025_7b, qwen2_5_7b
+from experiments.multilingual.exp1457_multilingual_cpt import multilingual_cpt_8b_fineweb2_hq
 
 SINGLE_TPU_V5p_8 = ResourceConfig.with_tpu("v5p-8")
 

--- a/experiments/multilingual_fineweb2_hq/download_and_tokenize_fineweb2_hq.py
+++ b/experiments/multilingual_fineweb2_hq/download_and_tokenize_fineweb2_hq.py
@@ -10,13 +10,13 @@ Fineweb2 dataset.
 
 import os.path
 
-
-from experiments.llama import llama3_tokenizer
-from experiments.multilingual_fineweb2_hq.constants import FINEWEB2_DATASETS
 from marin.datakit.download.huggingface import DownloadConfig, download_hf
 from marin.execution.executor import ExecutorStep, executor_main, output_path_of, this_output_path, versioned
 from marin.processing.tokenize import TokenizeConfig, tokenize
 from marin.processing.tokenize.data_configs import TokenizerStep
+
+from experiments.llama import llama3_tokenizer
+from experiments.multilingual_fineweb2_hq.constants import FINEWEB2_DATASETS
 
 fineweb2_raw = ExecutorStep(
     name="raw/fineweb2_hq",

--- a/experiments/paloma.py
+++ b/experiments/paloma.py
@@ -9,7 +9,8 @@ https://huggingface.co/datasets/allenai/paloma
 
 import os.path
 
-from marin.datakit.download.huggingface import DownloadConfig as HfDownloadConfig, download_hf
+from marin.datakit.download.huggingface import DownloadConfig as HfDownloadConfig
+from marin.datakit.download.huggingface import download_hf
 
 # cyclic dependency
 # from experiments.llama import llama3_tokenizer

--- a/experiments/plantcad/exp1729_plantcad_eval.py
+++ b/experiments/plantcad/exp1729_plantcad_eval.py
@@ -14,17 +14,16 @@ from dataclasses import dataclass
 
 import fsspec
 import haliax as hax
-from rigging.filesystem import open_url
 import haliax.haxtyping as ht
 import jax.numpy as jnp
 import numpy as np
 import torch
 from datasets import Dataset, load_dataset
 from huggingface_hub import HfApi
-from transformers import AutoModelForCausalLM, AutoTokenizer
-
 from marin.execution.executor import ExecutorStep, executor_main, this_output_path, versioned
 from marin.utilities.json_encoder import CustomJsonEncoder
+from rigging.filesystem import open_url
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 logger = logging.getLogger(__name__)
 

--- a/experiments/plantcad/exp1729_plantcad_train.py
+++ b/experiments/plantcad/exp1729_plantcad_train.py
@@ -5,13 +5,15 @@
 PlantCAD training experiment: A single 600M model pretrained on 16 Angiosperm genomes
 """
 
-import jax
 import logging
+
+import jax
 from fray.cluster import ResourceConfig
 from levanter.data.text import TextLmDatasetFormat
-from marin.execution.executor import executor_main, versioned
 from levanter.models.llama import LlamaConfig
-from experiments.defaults import default_train, default_tokenize
+from marin.execution.executor import executor_main, versioned
+
+from experiments.defaults import default_tokenize, default_train
 from experiments.simple_train_config import SimpleTrainConfig
 
 logger = logging.getLogger(__name__)

--- a/experiments/posttrain/instruction_datasets.py
+++ b/experiments/posttrain/instruction_datasets.py
@@ -44,8 +44,6 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
-from experiments.defaults import default_tokenize
-from experiments.llama import llama3_tokenizer
 from marin.execution.executor import (
     ExecutorStep,
     executor_main,
@@ -53,15 +51,18 @@ from marin.execution.executor import (
     this_output_path,
     versioned,
 )
+from marin.transform.conversation.adapters import InputDatasetFormat, TransformAdapter
 from marin.transform.conversation.conversation_to_dolma import (
     ConversationToDolmaConfig,
     convert_conversation_to_dolma,
 )
-from marin.transform.conversation.adapters import InputDatasetFormat, TransformAdapter
 from marin.transform.conversation.transform_conversation import (
     TransformSFTDatasetConfig,
     transform_hf_dataset,
 )
+
+from experiments.defaults import default_tokenize
+from experiments.llama import llama3_tokenizer
 
 SMOLTALK2_SPLITS = [
     "LongAlign_64k_Qwen3_32B_yarn_131k_think",

--- a/experiments/prebuilt_caches.py
+++ b/experiments/prebuilt_caches.py
@@ -19,8 +19,9 @@ my_model = default_train(..., tokenized=fineweb_edu_subcache_10B, ...)
 
 """
 
-from experiments.marin_models import marin_tokenizer
 from marin.processing.tokenize.download_pretokenized import download_pretokenized_cache
+
+from experiments.marin_models import marin_tokenizer
 
 fineweb_edu_10B_repo_id = "marin-community/fineweb-edu-pretokenized-10B"
 fineweb_edu_subcache_10B = download_pretokenized_cache("fineweb-edu-10B", fineweb_edu_10B_repo_id, marin_tokenizer)

--- a/experiments/pretraining_datasets/__init__.py
+++ b/experiments/pretraining_datasets/__init__.py
@@ -12,12 +12,13 @@ Dataset families are organized in separate modules:
 - simple: Single-corpus datasets
 """
 
+from marin.datakit.download.dolma import DOLMA_DATASETS
+
 from experiments.pretraining_datasets.dolma import (
     DOLMA_LLAMA3_OVERRIDES,
     DOLMA_OLMO_MIXTURE_WEIGHTS,
     tokenize_dolma,
 )
-from marin.datakit.download.dolma import DOLMA_DATASETS
 from experiments.pretraining_datasets.dolmino import (
     DOLMINO_DATASETS,
     DOLMINO_LLAMA3_OVERRIDES,

--- a/experiments/pretraining_datasets/common_corpus.py
+++ b/experiments/pretraining_datasets/common_corpus.py
@@ -4,7 +4,6 @@
 """Common Corpus dataset definitions and tokenization."""
 
 from fray import ResourceConfig
-
 from marin.datakit.download.common_corpus import (
     download_common_corpus_raw_step,
     filter_common_corpus_step,

--- a/experiments/pretraining_datasets/dclm.py
+++ b/experiments/pretraining_datasets/dclm.py
@@ -4,12 +4,12 @@
 import dataclasses
 
 from levanter.data.text import TextLmDatasetFormat
+from marin.execution.executor import executor_main
+from marin.processing.tokenize import lm_mixture_data_config
 
 from experiments.defaults import default_tokenize
 from experiments.llama import llama3_tokenizer
 from experiments.pretraining_datasets.simple import downloads, tokenized
-from marin.execution.executor import executor_main
-from marin.processing.tokenize import lm_mixture_data_config
 
 DCLM_MIXTURE_WEIGHTS = {
     # token counts are for neox tokenizer

--- a/experiments/pretraining_datasets/nemotron.py
+++ b/experiments/pretraining_datasets/nemotron.py
@@ -7,14 +7,14 @@ import dataclasses
 import os.path
 
 from fray.types import ResourceConfig
-
 from levanter.data.text import DEFAULT_LM_DATA_SHUFFLE
-from experiments.pretraining_datasets.dclm import dclm_components_llama3
 from marin.datakit.download.nemotron_v1 import download_nemotron_v1_step
 from marin.execution.executor import ExecutorStep, InputName, this_output_path, versioned
 from marin.execution.remote import remote
 from marin.processing.tokenize import TokenizeConfig, lm_mixture_data_config, tokenize
 from marin.processing.tokenize.data_configs import TokenizerStep
+
+from experiments.pretraining_datasets.dclm import dclm_components_llama3
 
 # Fray resources for running a single Nemotron tokenize split as a remote job.
 # TODO (rav): debug why this needs 32g - probably levanter store consolidation

--- a/experiments/pretraining_datasets/nsf_awards.py
+++ b/experiments/pretraining_datasets/nsf_awards.py
@@ -3,10 +3,11 @@
 
 """NSF awards dataset download, normalization, and tokenization."""
 
-from experiments.marin_models import marin_tokenizer
 from marin.datakit.download.nsf_awards import download_nsf_awards_step, normalize_nsf_awards_step
 from marin.execution.executor import ExecutorStep, output_path_of, this_output_path, versioned
 from marin.processing.tokenize import TokenizeConfig, tokenize
+
+from experiments.marin_models import marin_tokenizer
 
 nsf_awards_download = normalize_nsf_awards_step(download_nsf_awards_step()).as_executor_step()
 

--- a/experiments/pretraining_datasets/starcoder2_extras.py
+++ b/experiments/pretraining_datasets/starcoder2_extras.py
@@ -3,8 +3,6 @@
 
 """StarCoder2 data extras: download and tokenize ir_cpp, ir_python, ir_rust, ir_low_resource, documentation."""
 
-from experiments.defaults import default_tokenize
-from experiments.marin_models import marin_tokenizer
 from fray import ResourceConfig
 from levanter.data.text.formats import TextLmDatasetFormat
 from marin.datakit.download.starcoder2_extras import (
@@ -14,6 +12,9 @@ from marin.datakit.download.starcoder2_extras import (
 from marin.datakit.normalize import normalize_step
 from marin.execution.executor import executor_main
 from marin.processing.tokenize.data_configs import TokenizerStep
+
+from experiments.defaults import default_tokenize
+from experiments.marin_models import marin_tokenizer
 
 
 def tokenize_starcoder2_extras(*, tokenizer: str = marin_tokenizer) -> list[TokenizerStep]:

--- a/experiments/references/reference_hyperparameter_sweep.py
+++ b/experiments/references/reference_hyperparameter_sweep.py
@@ -16,17 +16,17 @@ from dataclasses import dataclass, replace
 from typing import Any
 
 import fsspec
+from fray.cluster import ResourceConfig
 from levanter.optim import AdamHConfig
 from levanter.tracker.wandb import WandbConfig
+from marin.execution.executor import ExecutorStep, executor_main, this_output_path
+from marin.execution.remote import remote
+from marin.processing.tokenize import add_validation_sets_to_mixture
 
 from experiments.defaults import default_validation_sets
 from experiments.grug.base.launch import GRUG_130M_MODEL, GrugBaseLaunchConfig, run_grug_base_trial
 from experiments.grug.base.train import GrugEvalConfig, GrugTrainerConfig
 from experiments.pretraining_datasets.nemotron import nemotron_mix
-from fray.cluster import ResourceConfig
-from marin.execution.executor import ExecutorStep, executor_main, this_output_path
-from marin.execution.remote import remote
-from marin.processing.tokenize import add_validation_sets_to_mixture
 
 logger = logging.getLogger(__name__)
 

--- a/experiments/references/reference_training_pipeline.py
+++ b/experiments/references/reference_training_pipeline.py
@@ -13,9 +13,14 @@ The entire pipeline is one training run with time-varying mixture weights:
 
 import dataclasses
 
+from fray.cluster import ResourceConfig
 from levanter.data.text import ChatLmDatasetFormat
 from levanter.optim import AdamConfig
 from levanter.tracker.wandb import WandbConfig
+from marin.execution.executor import ExecutorStep, executor_main, this_output_path
+from marin.execution.remote import remote
+from marin.processing.tokenize import add_validation_sets_to_mixture
+from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
 
 from experiments.defaults import default_tokenize, default_validation_sets
 from experiments.grug.base.launch import GrugBaseLaunchConfig, run_grug_base_trial
@@ -25,11 +30,6 @@ from experiments.marin_models import marin_tokenizer
 from experiments.posttrain.instruction_datasets import get_instruction_dataset
 from experiments.pretraining_datasets.dclm import dclm_components_llama3
 from experiments.pretraining_datasets.dolmino import tokenize_dolmino
-from fray.cluster import ResourceConfig
-from marin.execution.executor import ExecutorStep, executor_main, this_output_path
-from marin.execution.remote import remote
-from marin.processing.tokenize import add_validation_sets_to_mixture
-from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
 
 # --- Model: 600M Grug ---
 model = GrugModelConfig(

--- a/experiments/rollout_data/coderforge.py
+++ b/experiments/rollout_data/coderforge.py
@@ -12,6 +12,7 @@ from marin.datakit.download.coderforge import download_coderforge_step
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from marin.processing.tokenize import TokenizeConfig, tokenize
+
 from experiments.marin_models import marin_tokenizer
 
 

--- a/experiments/rollout_data/gpt_oss_rollouts.py
+++ b/experiments/rollout_data/gpt_oss_rollouts.py
@@ -12,6 +12,7 @@ from marin.datakit.download.gpt_oss_rollouts import download_gpt_oss_rollouts_st
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from marin.processing.tokenize import TokenizeConfig, tokenize
+
 from experiments.marin_models import marin_tokenizer
 
 

--- a/experiments/rollout_data/nemotron_terminal.py
+++ b/experiments/rollout_data/nemotron_terminal.py
@@ -13,6 +13,7 @@ from marin.datakit.download.nemotron_terminal import download_nemotron_terminal_
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from marin.processing.tokenize import TokenizeConfig, tokenize
+
 from experiments.marin_models import marin_tokenizer
 
 

--- a/experiments/rollout_data/principia.py
+++ b/experiments/rollout_data/principia.py
@@ -12,6 +12,7 @@ from marin.datakit.download.principia import download_principia_step
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from marin.processing.tokenize import TokenizeConfig, tokenize
+
 from experiments.marin_models import marin_tokenizer
 
 

--- a/experiments/rollout_data/superior_reasoning.py
+++ b/experiments/rollout_data/superior_reasoning.py
@@ -13,6 +13,7 @@ from marin.datakit.download.superior_reasoning import download_superior_reasonin
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from marin.processing.tokenize import TokenizeConfig, tokenize
+
 from experiments.marin_models import marin_tokenizer
 
 

--- a/experiments/rollout_data/swe_rebench_openhands.py
+++ b/experiments/rollout_data/swe_rebench_openhands.py
@@ -13,6 +13,7 @@ from marin.datakit.download.swe_rebench_openhands import download_swe_rebench_op
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from marin.processing.tokenize import TokenizeConfig, tokenize
+
 from experiments.marin_models import marin_tokenizer
 
 

--- a/experiments/rollout_data/synthetic1.py
+++ b/experiments/rollout_data/synthetic1.py
@@ -12,6 +12,7 @@ from marin.datakit.download.synthetic1 import download_synthetic1_step
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from marin.processing.tokenize import TokenizeConfig, tokenize
+
 from experiments.marin_models import marin_tokenizer
 
 

--- a/experiments/scaling_law_sweeps/c_adamc.py
+++ b/experiments/scaling_law_sweeps/c_adamc.py
@@ -26,20 +26,20 @@ import math
 from collections.abc import Iterator
 from dataclasses import dataclass, replace
 
+from fray.cluster import ResourceConfig
 from levanter.data.text import LMMixtureDatasetConfig
 from levanter.layers.rotary import Llama3RotaryEmbeddingsConfig
 from levanter.models.llama import LlamaConfig
 from levanter.models.qwen import Qwen3Config
 from levanter.optim.cautious import CautiousConfig
+from marin.execution.executor import ExecutorStep, InputName
+from marin.processing.tokenize import get_vocab_size_for_tokenizer
+from marin.scaling_laws import CandidateConfig, pick_v5p_type
 
 from experiments.defaults import default_train
 from experiments.evals.evals import default_eval
 from experiments.evals.task_configs import EvalTaskConfig
 from experiments.simple_train_config import SimpleTrainConfig
-from fray.cluster import ResourceConfig
-from marin.execution.executor import ExecutorStep, InputName
-from marin.processing.tokenize import get_vocab_size_for_tokenizer
-from marin.scaling_laws import CandidateConfig, pick_v5p_type
 
 # --- Constants ---
 SEQ_LEN: int = 4096

--- a/experiments/scaling_law_sweeps/completed_adamh.py
+++ b/experiments/scaling_law_sweeps/completed_adamh.py
@@ -35,21 +35,21 @@ import math
 from collections.abc import Iterator
 from dataclasses import dataclass, replace
 
+from fray.cluster import ResourceConfig
 from levanter.data.text import LMMixtureDatasetConfig
 from levanter.layers.rotary import Llama3RotaryEmbeddingsConfig
 from levanter.models.llama import LlamaConfig
 from levanter.models.qwen import Qwen3Config
 from levanter.optim import AdamHConfig
+from marin.execution.executor import ExecutorStep, InputName
+from marin.processing.tokenize import get_vocab_size_for_tokenizer
+from marin.scaling_laws import CandidateConfig, pick_v4_type
+from marin.scaling_laws.tpu_utils import V4_SPEC
 
 from experiments.defaults import default_train
 from experiments.evals.evals import default_eval
 from experiments.evals.task_configs import EvalTaskConfig
 from experiments.simple_train_config import SimpleTrainConfig
-from fray.cluster import ResourceConfig
-from marin.execution.executor import ExecutorStep, InputName
-from marin.processing.tokenize import get_vocab_size_for_tokenizer
-from marin.scaling_laws import CandidateConfig, pick_v4_type
-from marin.scaling_laws.tpu_utils import V4_SPEC
 
 # --- Constants ---
 SEQ_LEN: int = 4096

--- a/experiments/simple_sft_config.py
+++ b/experiments/simple_sft_config.py
@@ -3,9 +3,8 @@
 
 from dataclasses import dataclass
 
-from levanter.schedule import IntSchedule
-
 from fray.cluster import ResourceConfig
+from levanter.schedule import IntSchedule
 
 
 def compute_per_device_parallelism(

--- a/experiments/swe_rebench_trace/test_run_one.py
+++ b/experiments/swe_rebench_trace/test_run_one.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 from experiments.swe_rebench_trace.run_one import (
     SANDBOX_ENTRYPOINT_PATH,
     SANDBOX_TRACER_PATH,

--- a/experiments/test_dpo_generation_config.py
+++ b/experiments/test_dpo_generation_config.py
@@ -11,16 +11,16 @@ After the run completes, check the HF checkpoint output for generation_config.js
 Expected content: {"eos_token_id": [128001, 128009], "bos_token_id": 128000}
 """
 
+from fray.cluster import ResourceConfig
 from levanter.data.text import PreferenceChatLmDatasetFormat
+from marin.execution.executor import executor_main
+from marin.processing.tokenize import lm_data_config
 
 from experiments.defaults import default_dpo, default_tokenize
 from experiments.llama import LLAMA3_CHAT_STOP_TOKEN_IDS, llama_8b
 from experiments.marin_models import marin_tokenizer
 from experiments.posttrain.preference_datasets import get_preference_dataset
 from experiments.simple_dpo_config import SimpleDPOConfig
-from fray.cluster import ResourceConfig
-from marin.execution.executor import executor_main
-from marin.processing.tokenize import lm_data_config
 
 DATASET_NAME = "HuggingFaceH4/ultrafeedback_binarized"
 

--- a/experiments/tokenize/fineweb_benchmark.py
+++ b/experiments/tokenize/fineweb_benchmark.py
@@ -22,18 +22,17 @@ import os
 import tempfile
 from collections.abc import Iterator, Sequence
 
-from levanter.tokenizers import TokenizerBackend, load_tokenizer
-from rigging.filesystem import marin_prefix
-from rigging.log_setup import configure_logging
-from zephyr import Dataset, ZephyrContext, zephyr_worker_ctx
-from zephyr.readers import load_file
-
 from fray import ResourceConfig
+from levanter.data.text import TextLmDatasetFormat
+from levanter.tokenizers import TokenizerBackend, load_tokenizer
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from marin.processing.tokenize import TokenizeConfig, tokenize
 from marin.processing.tokenize.tokenize import _get_filepaths_to_tokenize
-from levanter.data.text import TextLmDatasetFormat
+from rigging.filesystem import marin_prefix
+from rigging.log_setup import configure_logging
+from zephyr import Dataset, ZephyrContext, zephyr_worker_ctx
+from zephyr.readers import load_file
 
 logger = logging.getLogger(__name__)
 

--- a/experiments/tootsie/exp1063_upload_tootsie.py
+++ b/experiments/tootsie/exp1063_upload_tootsie.py
@@ -25,8 +25,8 @@ executor_main([upload_step])
 
 from dataclasses import dataclass, field
 
-from marin.utilities.upload_gcs_to_hf import UploadConfig, upload_gcs_to_hf
 from marin.execution.executor import ExecutorStep, executor_main
+from marin.utilities.upload_gcs_to_hf import UploadConfig, upload_gcs_to_hf
 
 
 @dataclass(frozen=True)

--- a/experiments/tootsie/exp1237_starling_sft.py
+++ b/experiments/tootsie/exp1237_starling_sft.py
@@ -12,13 +12,14 @@ GitHub Issue: https://github.com/marin-community/marin/issues/1237
 
 import dataclasses
 
+from marin.execution.executor import executor_main
+
 from experiments.defaults import default_sft
 from experiments.evals.evals import default_sft_eval
 from experiments.exp808_sft_mixture import mixture_config as sft_mixture_llama3
 from experiments.llama import llama_8b
 from experiments.tootsie.exp600_tootsie import tootsie_8b_deeper_starling
 from experiments.tootsie.exp916_tootsie_spoonbill_cooldown import spoonbill_zloss_tulu3_sft_config
-from marin.execution.executor import executor_main
 
 sft_experiments = []
 deeper_sft_config = dataclasses.replace(

--- a/experiments/tootsie/exp1295_32b.py
+++ b/experiments/tootsie/exp1295_32b.py
@@ -11,17 +11,17 @@ Train 32B on on Nemotron with Starcoderdata and Proofpile 2
 import dataclasses
 
 import haliax
+from fray.cluster import ResourceConfig
 from levanter.callbacks.watch import WatchConfig
 from levanter.optim import AdamConfig
 from levanter.optim.clip_update_norm import ClipUpdateNormConfig
 from levanter.schedule import ScheduleStep
+from marin.execution import executor_main
 
 from experiments.defaults import default_train
 from experiments.llama import llama_32b
 from experiments.pretraining_datasets import nemotron_mix
 from experiments.simple_train_config import SimpleTrainConfig
-from fray.cluster import ResourceConfig
-from marin.execution import executor_main
 
 ## 32b experiments
 

--- a/experiments/tootsie/exp1380_muon32b.py
+++ b/experiments/tootsie/exp1380_muon32b.py
@@ -7,12 +7,12 @@ Train 32B on Nemotron with Starcoderdata and Proofpile 2 using Muon
 
 import dataclasses
 
+from fray.cluster import ResourceConfig
 from levanter.optim import MuonConfig
+from marin.execution import executor_main
 
 from experiments.defaults import default_train
 from experiments.tootsie.exp1295_32b import llama_32b_remat, llama_32b_tootsie, llama_32b_train_config, nemotron_mix
-from fray.cluster import ResourceConfig
-from marin.execution import executor_main
 
 warmstart_checkpoint = llama_32b_tootsie.cd("checkpoints/step-77096/").nonblocking()
 

--- a/experiments/tootsie/exp1388_nadamw32b.py
+++ b/experiments/tootsie/exp1388_nadamw32b.py
@@ -7,13 +7,13 @@ Train 32B on Nemotron with Starcoderdata and Proofpile 2 using NAdamW
 
 import dataclasses
 
+from fray.cluster import ResourceConfig
 from levanter.optim import AdamConfig
+from marin.execution import executor_main
 
 from experiments.defaults import default_train
 from experiments.llama import llama_32b
 from experiments.tootsie.exp1295_32b import llama_32b_tootsie, llama_32b_train_config, nemotron_mix
-from fray.cluster import ResourceConfig
-from marin.execution import executor_main
 
 warmstart_checkpoint = llama_32b_tootsie.cd("checkpoints/step-77096/").nonblocking()
 

--- a/experiments/tootsie/exp1390_32b_necro.py
+++ b/experiments/tootsie/exp1390_32b_necro.py
@@ -7,13 +7,13 @@ Resurrect the 32B with doctored opt state to clip the updates
 
 import dataclasses
 
+from fray.cluster import ResourceConfig
 from levanter.optim import AdamConfig
 from levanter.optim.clip_update_norm import ClipUpdateNormConfig
+from marin.execution import executor_main
 
 from experiments.defaults import default_train
 from experiments.tootsie.exp1295_32b import llama_32b_remat, llama_32b_tootsie, llama_32b_train_config, nemotron_mix
-from fray.cluster import ResourceConfig
-from marin.execution import executor_main
 
 # We have doctored the opt state to include update history from
 # gs://marin-us-central2/checkpoints/llama-32b-tootsie-2/checkpoints/step-77096 for clipping

--- a/experiments/tootsie/exp1395_qwen3_32b.py
+++ b/experiments/tootsie/exp1395_qwen3_32b.py
@@ -8,14 +8,14 @@ Switch over to Qwen3 architecture, warmstarting from the llama-32b-tootsie
 import dataclasses
 
 import haliax
+from fray.cluster import ResourceConfig
 from levanter.optim import AdamConfig
 from levanter.optim.clip_update_norm import ClipUpdateNormConfig
+from marin.execution import executor_main
 
 from experiments.defaults import default_train
 from experiments.qwen3 import qwen3_32b
 from experiments.tootsie.exp1295_32b import llama_32b_tootsie, llama_32b_train_config, nemotron_mix
-from marin.execution import executor_main
-from fray.cluster import ResourceConfig
 
 # We have doctored the opt state to include update history from
 # gs://marin-us-central2/checkpoints/llama-32b-tootsie-2/checkpoints/step-77096 for clipping

--- a/experiments/tootsie/exp1529_32b_bison_cooldown.py
+++ b/experiments/tootsie/exp1529_32b_bison_cooldown.py
@@ -12,28 +12,28 @@ Cooldown run for 32B Tootsie Model using the same data mixture as in Starling fo
 
 import dataclasses
 
+from fray.cluster import ResourceConfig
 from levanter.optim import AdamConfig
 from levanter.optim.clip_update_norm import ClipUpdateNormConfig
 from levanter.schedule import ScheduleStep
+from marin.execution import executor_main, output_path_of
+from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
 
 from experiments.defaults import default_train
-from experiments.tootsie.exp1395_qwen3_32b import (
-    marin_32b_qwen,
-    qwen3_32b_remat,
-    qwen_32b_warmstart_train,
-)
 from experiments.evals.evals import default_base_eval
+from experiments.exp934_hq_vs_pt import pt_vs_hq_components
 from experiments.models import ModelConfig, download_model_step
 from experiments.pretraining_datasets import (
     NEMOTRON_WEIGHTS,
     tokenize_nemotron,
 )
 from experiments.pretraining_datasets.dclm import dclm_components_llama3
-from experiments.exp934_hq_vs_pt import pt_vs_hq_components
 from experiments.tootsie.exp600_tootsie import phase_3_tokenized, starling_components
-from fray.cluster import ResourceConfig
-from marin.execution import executor_main, output_path_of
-from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
+from experiments.tootsie.exp1395_qwen3_32b import (
+    marin_32b_qwen,
+    qwen3_32b_remat,
+    qwen_32b_warmstart_train,
+)
 
 PHASE_3_START = 160_000
 PHASE_3_END = 192_000  # 20% of Training for Cooldown

--- a/experiments/tootsie/exp1529_32b_mantis_cooldown.py
+++ b/experiments/tootsie/exp1529_32b_mantis_cooldown.py
@@ -12,33 +12,33 @@ Cooldown run for the 32B Tootsie model using MegaMath in place of the Dolmino ma
 
 import dataclasses
 
+from fray.cluster import ResourceConfig
 from levanter.optim import AdamConfig
 from levanter.optim.clip_update_norm import ClipUpdateNormConfig
 from levanter.schedule import ScheduleStep
+from marin.execution import executor_main, output_path_of
+from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
 
 from experiments.defaults import default_train
-from experiments.tootsie.exp1395_qwen3_32b import (
-    marin_32b_qwen,
-    qwen3_32b_remat,
-    qwen_32b_warmstart_train,
-)
 from experiments.evals.evals import default_base_eval
-from experiments.models import ModelConfig, download_model_step
-from experiments.pretraining_datasets import (
-    NEMOTRON_WEIGHTS,
-    tokenize_nemotron,
-)
-from experiments.pretraining_datasets.dclm import dclm_components_llama3
 from experiments.exp934_hq_vs_pt import pt_vs_hq_components
 from experiments.midtraining_datasets import (
     megamath_token_counts,
     megamath_tokenized,
     stackv2_edu_filtered_python_tokenized,
 )
+from experiments.models import ModelConfig, download_model_step
+from experiments.pretraining_datasets import (
+    NEMOTRON_WEIGHTS,
+    tokenize_nemotron,
+)
+from experiments.pretraining_datasets.dclm import dclm_components_llama3
 from experiments.tootsie.exp600_tootsie import phase_3_tokenized, starling_components
-from fray.cluster import ResourceConfig
-from marin.execution import executor_main, output_path_of
-from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
+from experiments.tootsie.exp1395_qwen3_32b import (
+    marin_32b_qwen,
+    qwen3_32b_remat,
+    qwen_32b_warmstart_train,
+)
 
 PHASE_3_START = 160_000
 PHASE_3_END = 192_000  # 20% of Training for Cooldown

--- a/experiments/tootsie/exp1984_convert_32b_phases.py
+++ b/experiments/tootsie/exp1984_convert_32b_phases.py
@@ -13,15 +13,15 @@ from collections.abc import Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 
+from fray.cluster import ResourceConfig
 from levanter.trainer import TrainerConfig
+from marin.execution.executor import ExecutorStep, executor_main
+from marin.export import convert_checkpoint_to_hf_step
 
 from experiments.tootsie.exp1295_32b import llama_32b_remat, llama_32b_tootsie
 from experiments.tootsie.exp1380_muon32b import llama_32b_muon
 from experiments.tootsie.exp1390_32b_necro import marin_32b_necro
 from experiments.tootsie.exp1395_qwen3_32b import marin_32b_qwen, qwen3_32b_remat
-from fray.cluster import ResourceConfig
-from marin.execution.executor import ExecutorStep, executor_main
-from marin.export import convert_checkpoint_to_hf_step
 
 BASE_CHECKPOINT_PREFIX = "gs://marin-us-central2/checkpoints"
 CONVERSION_RESOURCES = ResourceConfig.with_tpu("v4-8")

--- a/experiments/tootsie/exp2062_long_context_8b.py
+++ b/experiments/tootsie/exp2062_long_context_8b.py
@@ -16,15 +16,19 @@ UI shows the intended target (field is new; "roll with it").
 
 import dataclasses
 
-from experiments.marin_models import marin_tokenizer
-from experiments.pretraining_datasets.dclm import DCLM_MIXTURE_WEIGHTS
 from fray import ResourceConfig
 from levanter.data.text import ChatLmDatasetFormat
 from levanter.layers.rotary import Llama3RotaryEmbeddingsConfig
+from levanter.optim import AdamConfig
+from marin.execution.executor import executor_main
+from marin.processing.tokenize.data_configs import (
+    interpolate_mixture_weights,
+    lm_mixture_data_config,
+    lm_varying_mixture_data_config,
+)
 
 from experiments.defaults import default_tokenize, default_train
 from experiments.llama import llama_8b
-from experiments.posttrain.instruction_datasets import get_instruction_dataset
 from experiments.long_context_datasets import (
     finepdfs_edu_by_language,
     finepdfs_edu_token_counts,
@@ -32,28 +36,24 @@ from experiments.long_context_datasets import (
     longmino_bucket_token_counts,
     longmino_by_bucket,
 )
+from experiments.marin_models import marin_tokenizer
+from experiments.posttrain.instruction_datasets import get_instruction_dataset
+from experiments.pretraining_datasets.dclm import DCLM_MIXTURE_WEIGHTS
+from experiments.simple_train_config import SimpleTrainConfig
 from experiments.tootsie.exp600_tootsie import (
-    tootsie_8b_sensible_starling,
-    starling_cooldown_weights,
-    starling_components,
     PHASE_3_START,
-    PHASE_4_START,
     PHASE_4_END,
     PHASE_4_REWARMUP_DURATION,
-    phase_4_warmup_weights,
-    cooldown_mixture_weights_v1,
-    phase_4_steady_state_weights,
+    PHASE_4_START,
     STARLING_END,
+    cooldown_mixture_weights_v1,
     cooldown_train_config,
+    phase_4_steady_state_weights,
+    phase_4_warmup_weights,
+    starling_components,
+    starling_cooldown_weights,
+    tootsie_8b_sensible_starling,
 )
-from levanter.optim import AdamConfig
-from marin.processing.tokenize.data_configs import (
-    lm_mixture_data_config,
-    interpolate_mixture_weights,
-    lm_varying_mixture_data_config,
-)
-from experiments.simple_train_config import SimpleTrainConfig
-from marin.execution.executor import executor_main
 
 # ---------------------------
 # Phases

--- a/experiments/tootsie/exp600_tootsie.py
+++ b/experiments/tootsie/exp600_tootsie.py
@@ -20,26 +20,30 @@ For now, we're training on DCLM's best mix, but that will change.
 
 import dataclasses
 
+from fray.cluster import ResourceConfig
 from levanter.schedule import ScheduleStep
+from marin.execution.executor import executor_main
+from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
 
-from experiments.pretraining_datasets.dclm import (
-    DCLM_MIXTURE_WEIGHTS,
-    dclm_components_llama3,
-    dclm_mixture_config_llama3,
-)
 from experiments.defaults import default_train
-from experiments.pretraining_datasets import tokenize_dolma
-from experiments.pretraining_datasets import tokenize_dolmino_math, tokenize_dolmino_subset
 from experiments.evals.evals import default_base_eval
 from experiments.evals.task_configs import CORE_TASKS_PLUS_MMLU
 from experiments.exp934_hq_vs_pt import pt_vs_hq_components
 from experiments.llama import llama3_tokenizer, llama_8b, llama_8b_old_rotary
 from experiments.midtraining_datasets import finemath_3_plus_tokenized
-from experiments.pretraining_datasets import NEMOTRON_WEIGHTS, tokenize_nemotron
+from experiments.pretraining_datasets import (
+    NEMOTRON_WEIGHTS,
+    tokenize_dolma,
+    tokenize_dolmino_math,
+    tokenize_dolmino_subset,
+    tokenize_nemotron,
+)
+from experiments.pretraining_datasets.dclm import (
+    DCLM_MIXTURE_WEIGHTS,
+    dclm_components_llama3,
+    dclm_mixture_config_llama3,
+)
 from experiments.simple_train_config import SimpleTrainConfig
-from marin.execution.executor import executor_main
-from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
-from fray.cluster import ResourceConfig
 
 # Phases/Runs in this file:
 # 1. Kestrel: WSD-S on DCLM+Starcode+Proofpile on 2x v5litepod-256 (from scratch)

--- a/experiments/tootsie/exp750_tootsie70b.py
+++ b/experiments/tootsie/exp750_tootsie70b.py
@@ -17,15 +17,15 @@ Mix is still DCLM+Math+Code
 
 import dataclasses
 
+from fray.cluster import ResourceConfig
 from levanter.schedule import ScheduleStep
+from marin.execution.executor import executor_main
 
 from experiments.defaults import default_train
 from experiments.llama import llama_70b
 from experiments.pretraining_datasets.dclm import dclm_mixture_config_llama3
 from experiments.simple_train_config import SimpleTrainConfig
 from experiments.tootsie.exp859_big_tootsies import dclm_mixture_config_llama3_zoned
-from fray.cluster import ResourceConfig
-from marin.execution.executor import executor_main
 
 llama_70b_train_config_mk6 = SimpleTrainConfig(
     num_train_steps=1_000_000,  # we won't actually go this long. will adjust as needed

--- a/experiments/tootsie/exp826_viz_tootsie.py
+++ b/experiments/tootsie/exp826_viz_tootsie.py
@@ -16,12 +16,13 @@ The differences were structural formatting differences in the eval data:
 The cooldown seems to function as a kind of sharpening/annealing
 """
 
-from experiments.defaults import default_validation_sets
-from experiments.llama import llama_8b_old_rotary
-from experiments.tootsie.exp600_tootsie import llama3_tokenizer, llama_8b
 from marin.evaluation.visualize import VizLmConfig, visualize_lm_log_probs
 from marin.execution.executor import ExecutorStep, executor_main, versioned
 from marin.processing.tokenize.data_configs import mixture_for_evaluation
+
+from experiments.defaults import default_validation_sets
+from experiments.llama import llama_8b_old_rotary
+from experiments.tootsie.exp600_tootsie import llama3_tokenizer, llama_8b
 
 COMPARISON_MODEL = "gs://marin-us-central2/checkpoints/llama-8b-tootsie-phase2/checkpoints/step-730000/"
 

--- a/experiments/tootsie/exp859_big_tootsies.py
+++ b/experiments/tootsie/exp859_big_tootsies.py
@@ -20,20 +20,20 @@ Also buried in here is a 56B model that I thought was a 70B model. Always double
 
 import dataclasses
 
+from fray.cluster import ResourceConfig
 from levanter.layers.rotary import DefaultRotaryEmbeddingsConfig
 from levanter.schedule import ScheduleStep
+from marin.execution.executor import executor_main
+from marin.processing.tokenize import lm_mixture_data_config
 
+from experiments.defaults import default_train
+from experiments.llama import llama_13b, llama_24b, llama_56b
 from experiments.pretraining_datasets.dclm import (
     DCLM_MIXTURE_WEIGHTS,
     dclm_components_llama3,
     dclm_mixture_config_llama3,
 )
-from experiments.defaults import default_train
-from experiments.llama import llama_13b, llama_24b, llama_56b
 from experiments.simple_train_config import SimpleTrainConfig
-from fray.cluster import ResourceConfig
-from marin.execution.executor import executor_main
-from marin.processing.tokenize import lm_mixture_data_config
 
 # data
 

--- a/experiments/tootsie/exp883_viz_compare_tootsie_llama.py
+++ b/experiments/tootsie/exp883_viz_compare_tootsie_llama.py
@@ -8,12 +8,13 @@ The goal was to see if there were any structural differences in the log probabil
 
 """
 
-from experiments.defaults import default_validation_sets
-from experiments.posttrain.instruction_datasets import tulu3_flat_llama_tokenized_as_validation
-from experiments.tootsie.exp600_tootsie import llama3_tokenizer, llama_8b
 from marin.evaluation.visualize import VizLmConfig, visualize_lm_log_probs
 from marin.execution.executor import ExecutorStep, executor_main, versioned
 from marin.processing.tokenize.data_configs import mixture_for_evaluation
+
+from experiments.defaults import default_validation_sets
+from experiments.posttrain.instruction_datasets import tulu3_flat_llama_tokenized_as_validation
+from experiments.tootsie.exp600_tootsie import llama3_tokenizer, llama_8b
 
 # We compare the models in CHECKPOINTS to Meta's Llama 3.1 8B  base model.
 COMPARISON_MODEL = "meta-llama/Meta-Llama-3.1-8B"

--- a/experiments/tootsie/exp898_deeper_cooldown.py
+++ b/experiments/tootsie/exp898_deeper_cooldown.py
@@ -15,6 +15,10 @@ Starting from cooldown v1 (monumental-jellyfish ) we're going to just keep the s
 
 import dataclasses
 
+from fray.cluster import ResourceConfig
+from marin.execution.executor import executor_main, output_path_of
+from marin.processing.tokenize import add_validation_sets_to_mixture
+
 from experiments.defaults import default_train
 from experiments.llama import llama_8b
 from experiments.posttrain.instruction_datasets import tulu3_flat_llama_tokenized_as_validation
@@ -24,9 +28,6 @@ from experiments.tootsie.exp600_tootsie import (
     llama_8b_train_config_phase3,
     phase_3_data_mixture,
 )
-from fray.cluster import ResourceConfig
-from marin.execution.executor import executor_main, output_path_of
-from marin.processing.tokenize import add_validation_sets_to_mixture
 
 # 3072 * 4096 * 10000 is 125B tokens
 COOLDOWN_LEN = 10000

--- a/experiments/tootsie/exp916_tootsie_spoonbill_cooldown.py
+++ b/experiments/tootsie/exp916_tootsie_spoonbill_cooldown.py
@@ -16,17 +16,20 @@ that point the loss started to increase again. I still don't know why.
 
 import dataclasses
 
+from fray.cluster import ResourceConfig
 from levanter.callbacks.watch import WatchConfig
+from marin.execution.executor import executor_main, output_path_of
+from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
 
-from experiments.pretraining_datasets.dclm import DCLM_MIXTURE_WEIGHTS
 from experiments.defaults import default_sft, default_train
-from experiments.pretraining_datasets import tokenize_dolmino_subset
 from experiments.exp606_sft import tulu3_llama_data_old, tulu_sft_config
 from experiments.llama import llama_8b
 from experiments.posttrain.instruction_datasets import (
     tulu3_flat_llama_tokenized_as_train,
     tulu3_flat_llama_tokenized_as_validation,
 )
+from experiments.pretraining_datasets import tokenize_dolmino_subset
+from experiments.pretraining_datasets.dclm import DCLM_MIXTURE_WEIGHTS
 from experiments.tootsie.exp600_tootsie import (
     PHASE_3_END,
     PHASE_3_START,
@@ -35,9 +38,6 @@ from experiments.tootsie.exp600_tootsie import (
     llama_8b_train_config_phase3,
     phase_3_tokenized,
 )
-from fray.cluster import ResourceConfig
-from marin.execution.executor import executor_main, output_path_of
-from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
 
 # 3072 * 4096 * 10000 is 125B tokens
 COOLDOWN_LEN = 10000

--- a/experiments/tootsie/exp945_spoonbill_sft_sweep.py
+++ b/experiments/tootsie/exp945_spoonbill_sft_sweep.py
@@ -10,10 +10,11 @@ We try learning rates of [1e-5, 2e-5, 3e-5, 5e-5, 1e-4] to find the optimal rate
 
 import dataclasses
 
+from marin.execution.executor import executor_main
+
 from experiments.defaults import default_sft
 from experiments.exp606_sft import tulu3_llama_data_old
 from experiments.tootsie.exp916_tootsie_spoonbill_cooldown import llama_8b_fp32_attn, spoonbill_zloss_tulu3_sft_config
-from marin.execution.executor import executor_main
 
 # Define the learning rates to sweep through
 LEARNING_RATES = [1e-5, 2e-5, 3e-5, 5e-5, 1e-4]

--- a/experiments/tootsie/exp977_phoenix_cooldown.py
+++ b/experiments/tootsie/exp977_phoenix_cooldown.py
@@ -12,8 +12,9 @@ same mix as exp934_hq_vs_pt's best mix's full mix
 We also add z-loss, since in spoonbill we found that to be very helpful
 """
 
-from experiments.tootsie.exp600_tootsie import tootsie_8b_sensible_starling
 from marin.execution.executor import executor_main
+
+from experiments.tootsie.exp600_tootsie import tootsie_8b_sensible_starling
 
 if __name__ == "__main__":
     executor_main(

--- a/experiments/train_test_overlap/aggregate_total.py
+++ b/experiments/train_test_overlap/aggregate_total.py
@@ -21,9 +21,9 @@ import os
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 
-from rigging.filesystem import open_url
 from marin.execution.executor import ExecutorStep, executor_main, this_output_path
 from marin.utils import fsspec_glob
+from rigging.filesystem import open_url
 from zephyr import Dataset, ZephyrContext, load_file, load_jsonl
 
 from experiments.train_test_overlap.eval_datasets_overlap import EVAL_DATASET_STEPS

--- a/experiments/train_test_overlap/train_test_total.py
+++ b/experiments/train_test_overlap/train_test_total.py
@@ -35,9 +35,9 @@ from marin.execution.executor import ExecutorStep, executor_main, this_output_pa
 from marin.processing.classification.decon import DeconConfig, DeconMode, NGramConfig, decontaminate
 
 from experiments.midtraining_datasets import finemath_3_plus
-from experiments.pretraining_datasets.simple import downloads
 from experiments.pretraining_datasets.dolmino import downloads as dolmino_downloads
 from experiments.pretraining_datasets.nemotron import nemotron_cc_download
+from experiments.pretraining_datasets.simple import downloads
 from experiments.train_test_overlap.eval_datasets_overlap import EVAL_DATASET_STEPS
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")

--- a/experiments/tutorials/exp1077_reproduce_dclm_1b1x.py
+++ b/experiments/tutorials/exp1077_reproduce_dclm_1b1x.py
@@ -18,10 +18,10 @@ Example usage:
 
 from fray.cluster import ResourceConfig
 from levanter.models.llama import LlamaConfig
+from marin.execution.executor import executor_main
 
 from experiments.defaults import SimpleTrainConfig, default_train
 from experiments.pretraining_datasets.dclm import dclm_mixture_config_llama3
-from marin.execution.executor import executor_main
 
 # Define the LlamaConfig for a 1.4B parameter model
 # This follows the 1B-1x competition scale in the DCLM benchmark

--- a/experiments/tutorials/exp1078_reproduce_dclm_7b1x.py
+++ b/experiments/tutorials/exp1078_reproduce_dclm_7b1x.py
@@ -18,10 +18,10 @@ Example usage:
 
 from fray.cluster import ResourceConfig
 from levanter.models.llama import LlamaConfig
+from marin.execution.executor import executor_main
 
 from experiments.defaults import SimpleTrainConfig, default_train
 from experiments.pretraining_datasets.dclm import dclm_mixture_config_llama3
-from marin.execution.executor import executor_main
 
 # Define the LlamaConfig for a 7B parameter model
 # This follows the 7B-1x competition scale in the DCLM benchmark

--- a/experiments/tutorials/hello_world.py
+++ b/experiments/tutorials/hello_world.py
@@ -12,9 +12,8 @@ import logging
 import os
 from dataclasses import dataclass
 
-from rigging.filesystem import open_url
-
 from marin.execution.executor import ExecutorStep, executor_main, output_path_of, this_output_path
+from rigging.filesystem import open_url
 
 logger = logging.getLogger(__name__)
 

--- a/experiments/tutorials/train_125m_fineweb_edu_gpu.py
+++ b/experiments/tutorials/train_125m_fineweb_edu_gpu.py
@@ -15,8 +15,8 @@ from marin.execution.executor import executor_main
 
 from experiments.defaults import default_train
 from experiments.llama import llama_150m
-from experiments.simple_train_config import SimpleTrainConfig
 from experiments.prebuilt_caches import fineweb_edu_subcache_10M
+from experiments.simple_train_config import SimpleTrainConfig
 
 llama_150m_train_config = SimpleTrainConfig(
     resources=ResourceConfig.with_gpu("H100", count=1),

--- a/experiments/tutorials/train_tiny_sweep_dclm_tpu.py
+++ b/experiments/tutorials/train_tiny_sweep_dclm_tpu.py
@@ -8,13 +8,12 @@ on a 30M parameter DCLM model using TPU hardware.
 import dataclasses
 
 from fray.cluster import ResourceConfig
-
-from experiments.evals.task_configs import CORE_TASKS
-from experiments.pretraining_datasets.dclm import dclm_mixture_config_llama3
 from marin.execution.executor import executor_main, versioned
 
 from experiments.defaults import default_train
+from experiments.evals.task_configs import CORE_TASKS
 from experiments.llama import llama_30m
+from experiments.pretraining_datasets.dclm import dclm_mixture_config_llama3
 from experiments.simple_train_config import SimpleTrainConfig
 
 RESOURCES = ResourceConfig.with_tpu("v4-8")

--- a/experiments/two_stage/data.py
+++ b/experiments/two_stage/data.py
@@ -1,13 +1,14 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from marin.datakit.download.huggingface import DownloadConfig, download_hf
+from marin.execution.executor import ExecutorStep, this_output_path
+
 from experiments.defaults import default_tokenize
 from experiments.llama import llama3_tokenizer
 from experiments.midtraining_datasets import finemath_3_plus_tokenized
 from experiments.pretraining_datasets import tokenize_dolma
 from experiments.pretraining_datasets.simple import tokenized
-from marin.datakit.download.huggingface import DownloadConfig, download_hf
-from marin.execution.executor import ExecutorStep, this_output_path
 
 dolma_components = tokenize_dolma()
 

--- a/experiments/two_stage/single_run.py
+++ b/experiments/two_stage/single_run.py
@@ -1,8 +1,9 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from experiments.two_stage.two_stage_config import TwoStageConfig, two_stage_train_step
 from marin.execution.executor import executor_main
+
+from experiments.two_stage.two_stage_config import TwoStageConfig, two_stage_train_step
 
 if __name__ == "__main__":
     train_steps = [

--- a/experiments/two_stage/two_stage_config.py
+++ b/experiments/two_stage/two_stage_config.py
@@ -7,23 +7,22 @@ from datetime import timedelta
 
 import jmp
 import numpy as np
+from fray.cluster import ResourceConfig
 from levanter.checkpoint import CheckpointerConfig
+from levanter.data.text import LMMixtureDatasetConfig
 from levanter.eval_harness import LmEvalHarnessConfig
 from levanter.main.train_lm import TrainLmConfig
 from levanter.optim import AdamConfig
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
+from marin.evaluation.evaluation_config import EvalTaskConfig, convert_to_levanter_task_config
+from marin.execution.executor import ExecutorStep, this_output_path
+from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
+from marin.training.training import TrainLmOnPodConfig, run_levanter_train_lm
 
 from experiments.defaults import _prepare_data_config
-from marin.evaluation.evaluation_config import convert_to_levanter_task_config
 from experiments.two_stage.data import data_dict
 from experiments.two_stage.models import model_dict
-from marin.evaluation.evaluation_config import EvalTaskConfig
-from marin.execution.executor import ExecutorStep, this_output_path
-from levanter.data.text import LMMixtureDatasetConfig
-from marin.processing.tokenize.data_configs import lm_varying_mixture_data_config
-from fray.cluster import ResourceConfig
-from marin.training.training import TrainLmOnPodConfig, run_levanter_train_lm
 
 
 @dataclass

--- a/infra/configure_buckets.py
+++ b/infra/configure_buckets.py
@@ -27,7 +27,6 @@ import sys
 import tempfile
 
 import click
-
 from rigging.filesystem import ALLOWED_TTL_DAYS, REGION_TO_DATA_BUCKET, TEMP_PATH_PREFIX
 
 logger = logging.getLogger(__name__)

--- a/infra/iris-iap-proxy/main.py
+++ b/infra/iris-iap-proxy/main.py
@@ -13,12 +13,11 @@ import logging
 from contextlib import asynccontextmanager
 
 import httpx
+from discovery import get_controller_url
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
-
-from discovery import get_controller_url
 
 logger = logging.getLogger(__name__)
 

--- a/lib/finelog/src/finelog/store/duckdb_store.py
+++ b/lib/finelog/src/finelog/store/duckdb_store.py
@@ -63,16 +63,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from threading import Condition, Lock
 
-
 import duckdb
 import fsspec.core
 import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.parquet as pq
+from rigging.timing import RateLimiter
 
 from finelog.rpc import logging_pb2
 from finelog.types import _EST_BYTES_PER_ROW, REGEX_META_RE, LogReadResult, parse_attempt_id, str_to_log_level
-from rigging.timing import RateLimiter
 
 logger = logging.getLogger(__name__)
 

--- a/lib/finelog/tests/test_client.py
+++ b/lib/finelog/tests/test_client.py
@@ -10,9 +10,8 @@ import time
 import pytest
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
-
-from finelog.client import pusher as pusher_mod
 from finelog.client import LogPusher, RemoteLogHandler
+from finelog.client import pusher as pusher_mod
 from finelog.rpc import logging_pb2
 
 

--- a/lib/finelog/tests/test_config.py
+++ b/lib/finelog/tests/test_config.py
@@ -9,7 +9,6 @@ import textwrap
 from pathlib import Path
 
 import pytest
-
 from finelog.deploy.config import (
     Deployment,
     FinelogConfig,

--- a/lib/finelog/tests/test_deploy_k8s.py
+++ b/lib/finelog/tests/test_deploy_k8s.py
@@ -5,9 +5,7 @@
 
 from __future__ import annotations
 
-
 import pytest
-
 from finelog.deploy._k8s import _K8S_MANIFEST_DIR, _MANIFESTS, _render_manifest
 from finelog.deploy.config import Deployment, FinelogConfig, K8sDeployment
 

--- a/lib/finelog/tests/test_duckdb_store.py
+++ b/lib/finelog/tests/test_duckdb_store.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-
 from finelog.rpc import logging_pb2
 from finelog.store.duckdb_store import DuckDBLogStore
 

--- a/lib/finelog/tests/test_mem_store.py
+++ b/lib/finelog/tests/test_mem_store.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import pytest
-
 from finelog.rpc import logging_pb2
 from finelog.store.mem_store import MemStore
 

--- a/lib/finelog/tests/test_server.py
+++ b/lib/finelog/tests/test_server.py
@@ -11,10 +11,9 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
-from starlette.testclient import TestClient
-
 from finelog.server.asgi import build_log_server_asgi
 from finelog.server.service import LogServiceImpl
+from starlette.testclient import TestClient
 
 
 @pytest.fixture

--- a/lib/fray/src/fray/iris_backend.py
+++ b/lib/fray/src/fray/iris_backend.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from typing import Any, cast
 
 import cloudpickle
-
 from iris.actor.client import ActorClient
 from iris.actor.server import ActorServer
 from iris.client.client import IrisClient as IrisClientLib

--- a/lib/fray/tests/test_actor.py
+++ b/lib/fray/tests/test_actor.py
@@ -6,7 +6,6 @@
 import threading
 
 import pytest
-
 from fray import LocalClient
 
 

--- a/lib/fray/tests/test_client.py
+++ b/lib/fray/tests/test_client.py
@@ -7,7 +7,6 @@ import threading
 import time
 
 import pytest
-
 from fray import (
     Entrypoint,
     JobFailed,

--- a/lib/fray/tests/test_current_client.py
+++ b/lib/fray/tests/test_current_client.py
@@ -6,7 +6,6 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from fray.client import current_client, set_current_client
 from fray.local_backend import LocalClient
 

--- a/lib/fray/tests/test_iris.py
+++ b/lib/fray/tests/test_iris.py
@@ -11,7 +11,6 @@ import pickle
 from unittest.mock import MagicMock
 
 import pytest
-
 from fray.iris_backend import (
     FrayIrisClient,
     IrisActorHandle,

--- a/lib/fray/tests/test_operation_future.py
+++ b/lib/fray/tests/test_operation_future.py
@@ -6,7 +6,6 @@
 import time
 
 import pytest
-
 from fray.iris_backend import OperationFuture
 from iris.actor import ActorClient, ActorServer
 from iris.actor.resolver import FixedResolver

--- a/lib/iris/scripts/benchmark_db_queries.py
+++ b/lib/iris/scripts/benchmark_db_queries.py
@@ -27,12 +27,11 @@ import tempfile
 import threading
 import time
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
-from collections.abc import Callable
 
 import click
-
 from iris.cluster.controller.checkpoint import download_checkpoint_to_local
 from iris.cluster.controller.controller import (
     _building_counts,
@@ -53,6 +52,7 @@ from iris.cluster.controller.db import (
 from iris.cluster.controller.schema import (
     JOB_CONFIG_JOIN,
     JOB_DETAIL_PROJECTION,
+    EndpointRow,
 )
 from iris.cluster.controller.service import (
     USER_JOB_STATES,
@@ -71,7 +71,6 @@ from iris.cluster.controller.service import (
     _worker_addresses_for_tasks,
     _worker_roster,
 )
-from iris.cluster.controller.schema import EndpointRow
 from iris.cluster.controller.stores import ControllerStore
 from iris.cluster.controller.transitions import (
     Assignment,
@@ -81,8 +80,7 @@ from iris.cluster.controller.transitions import (
     TaskUpdate,
 )
 from iris.cluster.types import TERMINAL_JOB_STATES, JobName, WorkerId
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Timestamp
 
 _results: list[tuple[str, float, float, int]] = []

--- a/lib/iris/scripts/benchmark_log_store.py
+++ b/lib/iris/scripts/benchmark_log_store.py
@@ -29,7 +29,6 @@ from tempfile import TemporaryDirectory
 
 import click
 import duckdb
-
 from finelog.rpc import logging_pb2
 from finelog.store.duckdb_store import DuckDBLogStore as LogStore
 from iris.cluster.log_store_helpers import task_log_key

--- a/lib/iris/scripts/dashboard-eval-loop.py
+++ b/lib/iris/scripts/dashboard-eval-loop.py
@@ -29,7 +29,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
-from claude_agent_sdk import query, ClaudeAgentOptions, TextBlock
+from claude_agent_sdk import ClaudeAgentOptions, TextBlock, query
 
 
 @dataclass

--- a/lib/iris/src/iris/actor/__init__.py
+++ b/lib/iris/src/iris/actor/__init__.py
@@ -14,8 +14,8 @@ from iris.actor.resolver import (
     FixedResolver,
     ProxyResolver,
     ResolvedEndpoint,
-    ResolveResult,
     Resolver,
+    ResolveResult,
 )
 from iris.actor.server import ActorId, ActorServer
 

--- a/lib/iris/src/iris/actor/client.py
+++ b/lib/iris/src/iris/actor/client.py
@@ -28,12 +28,12 @@ from typing import Any
 import cloudpickle
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
+from rigging.timing import ExponentialBackoff
 
 from iris.actor.resolver import Resolver
 from iris.rpc import actor_pb2
 from iris.rpc.actor_connect import ActorServiceClientSync
 from iris.rpc.errors import call_with_retry
-from rigging.timing import ExponentialBackoff
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/actor/pool.py
+++ b/lib/iris/src/iris/actor/pool.py
@@ -12,13 +12,13 @@ from dataclasses import dataclass
 from typing import Any, Generic, TypeVar
 
 import cloudpickle
+from rigging.timing import ExponentialBackoff
 
 from iris.actor.client import unwrap_actor_response
-from iris.actor.resolver import ResolvedEndpoint, ResolveResult, Resolver
+from iris.actor.resolver import ResolvedEndpoint, Resolver, ResolveResult
 from iris.rpc import actor_pb2
 from iris.rpc.actor_connect import ActorServiceClientSync
 from iris.rpc.errors import call_with_retry
-from rigging.timing import ExponentialBackoff
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/actor/server.py
+++ b/lib/iris/src/iris/actor/server.py
@@ -27,11 +27,11 @@ import uvicorn
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from connectrpc.request import RequestContext
+from rigging.timing import Duration, ExponentialBackoff, Timestamp
 
 from iris.managed_thread import ThreadContainer, get_thread_container
 from iris.rpc import actor_pb2
 from iris.rpc.actor_connect import ActorServiceASGIApplication
-from rigging.timing import Duration, ExponentialBackoff, Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/chaos.py
+++ b/lib/iris/src/iris/chaos.py
@@ -19,8 +19,8 @@ Usage:
 """
 
 import random
-import time
 import threading
+import time
 from dataclasses import dataclass, field
 
 

--- a/lib/iris/src/iris/cli/bug_report.py
+++ b/lib/iris/src/iris/cli/bug_report.py
@@ -12,14 +12,14 @@ import subprocess
 from dataclasses import dataclass, field
 
 from finelog.rpc import logging_pb2
+from finelog.rpc.logging_connect import LogServiceClientSync
+
 from iris.cluster.log_store_helpers import build_log_source
 from iris.cluster.types import JobName
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import controller_pb2, job_pb2
 from iris.rpc.auth import AuthTokenInjector, TokenProvider
-from iris.rpc.proto_utils import job_state_friendly, task_state_friendly
 from iris.rpc.controller_connect import ControllerServiceClientSync
-from finelog.rpc.logging_connect import LogServiceClientSync
+from iris.rpc.proto_utils import job_state_friendly, task_state_friendly
 from iris.time_proto import timestamp_from_proto
 
 logger = logging.getLogger(__name__)

--- a/lib/iris/src/iris/cli/cluster.py
+++ b/lib/iris/src/iris/cli/cluster.py
@@ -15,6 +15,8 @@ from pathlib import Path
 import click
 from connectrpc.errors import ConnectError
 from finelog.deploy.cli import down_cmd, logs_cmd, restart_cmd, status_cmd, up_cmd
+from rigging.config_discovery import list_cluster_configs
+from rigging.timing import Duration, ExponentialBackoff, Timestamp
 
 from iris.cli.build import (
     build_image,
@@ -28,14 +30,9 @@ from iris.cluster.controller.autoscaler.scaling_group import (
     prepare_slice_config,
 )
 from iris.cluster.providers.types import Labels
-from iris.rpc import config_pb2
-from iris.rpc import vm_pb2
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import config_pb2, controller_pb2, job_pb2, vm_pb2
 from iris.rpc.proto_utils import format_accelerator_display, vm_state_name
 from iris.time_proto import timestamp_from_proto
-from rigging.config_discovery import list_cluster_configs
-from rigging.timing import Duration, ExponentialBackoff, Timestamp
 
 # =============================================================================
 # Helpers

--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -19,6 +19,7 @@ import click
 import humanfriendly
 import yaml
 from google.protobuf import json_format
+from rigging.timing import Duration, Timestamp
 from tabulate import tabulate
 
 from iris.cli.bug_report import file_github_issue, format_bug_report, gather_bug_report
@@ -51,7 +52,6 @@ from iris.rpc import job_pb2
 from iris.rpc.auth import TokenProvider
 from iris.rpc.proto_utils import PRIORITY_BAND_NAMES, job_state_friendly, priority_band_value, task_state_friendly
 from iris.time_proto import timestamp_from_proto
-from rigging.timing import Duration, Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cli/main.py
+++ b/lib/iris/src/iris/cli/main.py
@@ -11,10 +11,10 @@ import sys
 from pathlib import Path
 
 import click
-
-from iris.cli.token_store import cluster_name_from_url, load_any_token, load_token, store_token
 from rigging.config_discovery import resolve_cluster_config
 from rigging.log_setup import configure_logging
+
+from iris.cli.token_store import cluster_name_from_url, load_any_token, load_token, store_token
 from iris.rpc import config_pb2, job_pb2
 from iris.rpc import controller_pb2 as _controller_pb2
 from iris.rpc.auth import AuthTokenInjector, GcpAccessTokenProvider, StaticTokenProvider, TokenProvider
@@ -460,10 +460,10 @@ def budget_list(ctx):
 
 # Register subcommand groups — imported at module level to ensure they are
 # always available when the ``iris`` group is used.
+from iris.cli.actor import actor as actor_cmd  # noqa: E402
 from iris.cli.build import build  # noqa: E402
 from iris.cli.cluster import cluster  # noqa: E402
 from iris.cli.job import job  # noqa: E402
-from iris.cli.actor import actor as actor_cmd  # noqa: E402
 from iris.cli.process_status import register_process_status_commands  # noqa: E402
 from iris.cli.query import query_cmd  # noqa: E402
 from iris.cli.rpc import register_rpc_commands  # noqa: E402

--- a/lib/iris/src/iris/cli/process_status.py
+++ b/lib/iris/src/iris/cli/process_status.py
@@ -11,11 +11,11 @@ controller itself.
 
 import click
 import humanfriendly
+from finelog.rpc import logging_pb2
+from finelog.rpc.logging_connect import LogServiceClientSync
 
 from iris.cli.main import require_controller_url, rpc_client
 from iris.cluster.runtime.profile import SYSTEM_PROCESS_TARGET
-from finelog.rpc import logging_pb2
-from finelog.rpc.logging_connect import LogServiceClientSync
 from iris.rpc import job_pb2
 
 _CONTROLLER_LOG_TARGET = "/system/controller"

--- a/lib/iris/src/iris/client/client.py
+++ b/lib/iris/src/iris/client/client.py
@@ -27,6 +27,7 @@ from typing import Protocol, cast
 
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
+from rigging.timing import Duration, Timestamp
 
 from iris.actor.resolver import ResolvedEndpoint, Resolver, ResolveResult
 from iris.cluster.client import (
@@ -36,10 +37,9 @@ from iris.cluster.client import (
     get_job_info,
     resolve_job_user,
 )
-from iris.rpc.auth import AuthTokenInjector, TokenProvider
-from iris.cluster.providers.local.cluster import LocalCluster, make_local_cluster_config
 from iris.cluster.constraints import Constraint, WellKnownAttribute, merge_constraints, region_constraint
 from iris.cluster.log_store_helpers import build_log_source
+from iris.cluster.providers.local.cluster import LocalCluster, make_local_cluster_config
 from iris.cluster.types import (
     CoschedulingConfig,
     Entrypoint,
@@ -53,9 +53,9 @@ from iris.cluster.types import (
     is_job_finished,
 )
 from iris.rpc import controller_pb2, job_pb2
+from iris.rpc.auth import AuthTokenInjector, TokenProvider
 from iris.rpc.proto_utils import job_state_friendly
 from iris.time_proto import timestamp_from_proto
-from rigging.timing import Duration, Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/client/worker_pool.py
+++ b/lib/iris/src/iris/client/worker_pool.py
@@ -40,15 +40,15 @@ from typing import Any, Generic, TypeVar
 
 import cloudpickle
 from connectrpc.errors import ConnectError
+from rigging.timing import Duration, ExponentialBackoff
 
 from iris.actor import ActorServer
 from iris.actor.client import ActorClient
 from iris.actor.resolver import Resolver
 from iris.client.client import IrisClient, Job, iris_ctx
 from iris.cluster.client import get_job_info
-from iris.cluster.types import EnvironmentSpec, Entrypoint, JobName, ResourceSpec
+from iris.cluster.types import Entrypoint, EnvironmentSpec, JobName, ResourceSpec
 from iris.managed_thread import ThreadContainer, get_thread_container
-from rigging.timing import Duration, ExponentialBackoff
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/client/job_info.py
+++ b/lib/iris/src/iris/cluster/client/job_info.py
@@ -6,10 +6,10 @@
 For the full IrisContext with client/registry/resolver, use iris.client.
 """
 
-import json
-import os
 import getpass
+import json
 import logging
+import os
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 

--- a/lib/iris/src/iris/cluster/client/protocol.py
+++ b/lib/iris/src/iris/cluster/client/protocol.py
@@ -6,10 +6,10 @@
 from typing import Protocol
 
 from finelog.rpc import logging_pb2
-from iris.cluster.types import Entrypoint, JobName, TaskAttempt
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
 from rigging.timing import Duration
+
+from iris.cluster.types import Entrypoint, JobName, TaskAttempt
+from iris.rpc import controller_pb2, job_pb2
 
 
 class ClusterClient(Protocol):

--- a/lib/iris/src/iris/cluster/client/remote_client.py
+++ b/lib/iris/src/iris/cluster/client/remote_client.py
@@ -6,27 +6,25 @@
 import logging
 import time
 import uuid
-from pathlib import Path
-
 from collections.abc import Iterable
+from pathlib import Path
 
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from connectrpc.interceptor import InterceptorSync
+from finelog.rpc import logging_pb2
+from finelog.rpc.logging_connect import LogServiceClientSync
+from rigging.timing import Deadline, Duration, ExponentialBackoff
 
 from iris.cluster.client.bundle import BundleCreator
-from finelog.rpc import logging_pb2
 from iris.cluster.log_store_helpers import build_log_source
 from iris.cluster.runtime.entrypoint import build_runtime_entrypoint
 from iris.cluster.types import Entrypoint, EnvironmentSpec, JobName, TaskAttempt, adjust_tpu_replicas, is_job_finished
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import controller_pb2, job_pb2
 from iris.rpc.controller_connect import ControllerServiceClientSync
-from finelog.rpc.logging_connect import LogServiceClientSync
 from iris.rpc.errors import call_with_retry, format_connect_error, poll_with_retries
 from iris.time_proto import duration_to_proto
 from iris.version import client_revision_date
-from rigging.timing import Deadline, Duration, ExponentialBackoff
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -23,16 +23,16 @@ from pathlib import Path
 
 import yaml
 from google.protobuf.json_format import MessageToDict, ParseDict
+from rigging.timing import Duration
 
 from iris.cluster.constraints import WellKnownAttribute
+from iris.cluster.controller.worker_provider import WorkerProvider
 from iris.cluster.providers.k8s.tasks import K8sTaskProvider
 from iris.cluster.providers.protocols import WorkerInfraProvider
-from iris.cluster.controller.worker_provider import WorkerProvider
 from iris.cluster.types import TPU_FAMILY_VARIANT_PREFIX, get_tpu_topology, parse_memory_string, tpu_variant_name
 from iris.managed_thread import ThreadContainer, get_thread_container
 from iris.rpc import config_pb2
 from iris.time_proto import duration_from_proto, duration_to_proto
-from rigging.timing import Duration
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/constraints.py
+++ b/lib/iris/src/iris/cluster/constraints.py
@@ -24,8 +24,7 @@ from dataclasses import dataclass
 from enum import Enum, IntEnum, StrEnum
 from typing import Any, ClassVar
 
-from iris.rpc import config_pb2
-from iris.rpc import job_pb2
+from iris.rpc import config_pb2, job_pb2
 
 
 class WellKnownAttribute(StrEnum):

--- a/lib/iris/src/iris/cluster/controller/auth.py
+++ b/lib/iris/src/iris/cluster/controller/auth.py
@@ -16,6 +16,7 @@ import secrets
 import time
 
 import jwt
+from rigging.timing import Timestamp
 
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.schema import API_KEY_PROJECTION, ApiKeyRow
@@ -27,7 +28,6 @@ from iris.rpc.auth import (
     VerifiedIdentity,
     hash_token,
 )
-from rigging.timing import Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/controller/autoscaler/__init__.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/__init__.py
@@ -3,4 +3,4 @@
 
 """Autoscaler package public API."""
 
-from iris.cluster.controller.autoscaler.runtime import Autoscaler, DEFAULT_UNRESOLVABLE_TIMEOUT
+from iris.cluster.controller.autoscaler.runtime import DEFAULT_UNRESOLVABLE_TIMEOUT, Autoscaler

--- a/lib/iris/src/iris/cluster/controller/autoscaler/operations.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/operations.py
@@ -9,12 +9,13 @@ import logging
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
-from iris.cluster.providers.gcp.bootstrap import build_worker_bootstrap_script
-from iris.cluster.providers.types import SliceHandle
+from rigging.timing import Duration, Timestamp
+
 from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup
 from iris.cluster.controller.db import ControllerDB
+from iris.cluster.providers.gcp.bootstrap import build_worker_bootstrap_script
+from iris.cluster.providers.types import SliceHandle
 from iris.rpc import config_pb2, vm_pb2
-from rigging.timing import Duration, Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/controller/autoscaler/planning.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/planning.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from rigging.timing import Timestamp
+
 from iris.cluster.controller.autoscaler.models import RoutingDecision, ScalingAction, ScalingDecision
 from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup, SliceLifecycleState
-from rigging.timing import Timestamp
 
 
 @dataclass(frozen=True)

--- a/lib/iris/src/iris/cluster/controller/autoscaler/routing.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/routing.py
@@ -11,6 +11,8 @@ import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 
+from rigging.timing import Timestamp
+
 from iris.cluster.constraints import (
     Constraint,
     ConstraintIndex,
@@ -31,7 +33,6 @@ from iris.cluster.controller.autoscaler.models import (
 )
 from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability, ScalingGroup, SliceLifecycleState
 from iris.rpc import config_pb2
-from rigging.timing import Timestamp
 
 
 def additive_req(entry: DemandEntry) -> AdditiveReq:

--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -23,14 +23,9 @@ import logging
 from collections import deque
 from collections.abc import Sequence
 
+from rigging.timing import Duration, Timestamp
+
 from iris.cluster.constraints import Constraint
-from iris.cluster.providers.protocols import WorkerInfraProvider
-from iris.cluster.providers.types import (
-    CloudSliceState,
-    QuotaExhaustedError,
-    RemoteWorkerHandle,
-    SliceHandle,
-)
 from iris.cluster.controller.autoscaler.models import (
     DemandEntry,
     ScalingAction,
@@ -38,6 +33,8 @@ from iris.cluster.controller.autoscaler.models import (
 )
 from iris.cluster.controller.autoscaler.operations import (
     restart_worker as restart_worker_operation,
+)
+from iris.cluster.controller.autoscaler.operations import (
     terminate_slices_for_workers as terminate_slices_for_workers_operation,
 )
 from iris.cluster.controller.autoscaler.planning import ScalePlan, build_scale_plan
@@ -50,11 +47,17 @@ from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup, build
 from iris.cluster.controller.autoscaler.status import PendingHint, build_job_pending_hints, routing_decision_to_proto
 from iris.cluster.controller.autoscaler.worker_registry import TrackedWorker, WorkerRegistry
 from iris.cluster.controller.db import ControllerDB
+from iris.cluster.providers.protocols import WorkerInfraProvider
+from iris.cluster.providers.types import (
+    CloudSliceState,
+    QuotaExhaustedError,
+    RemoteWorkerHandle,
+    SliceHandle,
+)
 from iris.cluster.types import WorkerStatusMap
 from iris.managed_thread import ThreadContainer, get_thread_container
 from iris.rpc import config_pb2, vm_pb2
 from iris.time_proto import duration_from_proto, timestamp_to_proto
-from rigging.timing import Duration, Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -14,16 +14,15 @@ from __future__ import annotations
 import json
 import logging
 import threading
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum, StrEnum
 
-from collections.abc import Sequence
+from rigging.timing import Deadline, Duration, Timestamp, TokenBucket
 
-from iris.cluster.providers.protocols import WorkerInfraProvider
-from iris.cluster.providers.types import Labels, QuotaExhaustedError, SliceHandle
 from iris.cluster.constraints import (
-    AttributeValue,
     CONSTRAINT_REGISTRY,
+    AttributeValue,
     Constraint,
     DeviceType,
     ResourceCapacity,
@@ -33,15 +32,15 @@ from iris.cluster.constraints import (
     is_cpu_device_type_constraint,
 )
 from iris.cluster.controller.db import ControllerDB
+from iris.cluster.providers.protocols import WorkerInfraProvider
+from iris.cluster.providers.types import Labels, QuotaExhaustedError, SliceHandle
 from iris.cluster.types import (
     WorkerStatusMap,
     get_gpu_count,
     get_tpu_count,
 )
-from iris.rpc import config_pb2, time_pb2, vm_pb2
-from iris.rpc import job_pb2
+from iris.rpc import config_pb2, job_pb2, time_pb2, vm_pb2
 from iris.time_proto import timestamp_to_proto
-from rigging.timing import Deadline, Duration, Timestamp, TokenBucket
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/controller/autoscaler/worker_registry.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/worker_registry.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 
+from rigging.timing import Duration
+
 from iris.cluster.providers.types import (
     CloudWorkerState,
     CommandResult,
@@ -15,7 +17,6 @@ from iris.cluster.providers.types import (
     WorkerStatus,
 )
 from iris.rpc import vm_pb2
-from rigging.timing import Duration
 
 
 class _RestoredWorkerHandle:

--- a/lib/iris/src/iris/cluster/controller/checkpoint.py
+++ b/lib/iris/src/iris/cluster/controller/checkpoint.py
@@ -37,9 +37,9 @@ from pathlib import Path
 
 import fsspec.core
 import zstandard
+from rigging.timing import Duration, Timestamp
 
 from iris.cluster.controller.db import ControllerDB
-from rigging.timing import Duration, Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -17,6 +17,12 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 import uvicorn
+from finelog.client import LogPusher, LogServiceProxy, RemoteLogHandler
+from finelog.server import LogServiceImpl
+from finelog.server.asgi import build_log_server_asgi
+from finelog.store.mem_store import MemStore
+from rigging.log_setup import slow_log
+from rigging.timing import Duration, ExponentialBackoff, RateLimiter, Timer, Timestamp, TokenBucket
 
 from iris.cluster.bundle import BundleStore
 from iris.cluster.constraints import (
@@ -30,21 +36,33 @@ from iris.cluster.constraints import (
     extract_placement_requirements,
     get_device_variant,
     merge_constraints,
+)
+from iris.cluster.constraints import (
     region_constraint as make_region_constraint,
 )
+from iris.cluster.controller.auth import ControllerAuth
 from iris.cluster.controller.autoscaler import Autoscaler
-from iris.cluster.controller.codec import (
-    constraints_from_json,
-    reservation_entries_from_json,
-    resource_spec_from_scalars,
-)
 from iris.cluster.controller.autoscaler.models import DemandEntry
+from iris.cluster.controller.budget import (
+    UserBudgetDefaults,
+    UserTask,
+    compute_effective_band,
+    compute_user_spend,
+    interleave_by_user,
+    resource_value,
+)
 from iris.cluster.controller.checkpoint import (
     CheckpointResult,
     backup_databases,
     upload_checkpoint,
     write_checkpoint,
 )
+from iris.cluster.controller.codec import (
+    constraints_from_json,
+    reservation_entries_from_json,
+    resource_spec_from_scalars,
+)
+from iris.cluster.controller.dashboard import ControllerDashboard
 from iris.cluster.controller.db import (
     ControllerDB,
     healthy_active_workers_with_attributes,
@@ -53,6 +71,14 @@ from iris.cluster.controller.db import (
     running_tasks_by_worker,
     task_row_can_be_scheduled,
     timed_out_executing_tasks,
+)
+from iris.cluster.controller.provider import TaskProvider
+from iris.cluster.controller.scheduler import (
+    JobRequirements,
+    Scheduler,
+    SchedulingContext,
+    WorkerCapacity,
+    WorkerSnapshot,
 )
 from iris.cluster.controller.schema import (
     ATTEMPT_PROJECTION,
@@ -72,33 +98,14 @@ from iris.cluster.controller.schema import (
     proto_decoder,
     tasks_with_attempts,
 )
-from iris.cluster.controller.budget import (
-    UserBudgetDefaults,
-    UserTask,
-    compute_effective_band,
-    compute_user_spend,
-    interleave_by_user,
-    resource_value,
-)
-from iris.cluster.controller.dashboard import ControllerDashboard
-from iris.cluster.providers.k8s.tasks import K8sTaskProvider
-from iris.cluster.controller.provider import TaskProvider
-from iris.cluster.controller.scheduler import (
-    JobRequirements,
-    Scheduler,
-    SchedulingContext,
-    WorkerCapacity,
-    WorkerSnapshot,
-)
-from iris.cluster.controller.auth import ControllerAuth
 from iris.cluster.controller.service import ControllerServiceImpl
 from iris.cluster.controller.stores import ControllerStore
 from iris.cluster.controller.transitions import (
+    DIRECT_PROVIDER_PROMOTION_RATE,
     RESERVATION_HOLDER_JOB_NAME,
     Assignment,
     ClusterCapacity,
     ControllerTransitions,
-    DIRECT_PROVIDER_PROMOTION_RATE,
     HeartbeatApplyRequest,
     ReservationClaim,
     SchedulingEvent,
@@ -106,28 +113,21 @@ from iris.cluster.controller.transitions import (
     log_event,
 )
 from iris.cluster.controller.worker_health import WorkerHealthTracker
-from finelog.client import LogPusher, LogServiceProxy, RemoteLogHandler
-from finelog.server import LogServiceImpl
-from finelog.server.asgi import build_log_server_asgi
-from finelog.store.mem_store import MemStore
 from iris.cluster.log_store_helpers import CONTROLLER_LOG_KEY
+from iris.cluster.providers.k8s.tasks import K8sTaskProvider
 from iris.cluster.providers.types import find_free_port, resolve_external_host
-from iris.rpc.auth import AuthTokenInjector, NullAuthInterceptor, StaticTokenProvider
 from iris.cluster.types import (
     JobName,
+    WorkerId,
     WorkerStatus,
     WorkerStatusMap,
-    WorkerId,
     get_gpu_count,
     get_tpu_count,
     is_job_finished,
 )
-from rigging.log_setup import slow_log
 from iris.managed_thread import ManagedThread, ThreadContainer, get_thread_container
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
-from iris.rpc.auth import TokenVerifier
-from rigging.timing import Duration, ExponentialBackoff, RateLimiter, Timer, Timestamp, TokenBucket
+from iris.rpc import controller_pb2, job_pb2
+from iris.rpc.auth import AuthTokenInjector, NullAuthInterceptor, StaticTokenProvider, TokenVerifier
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -29,6 +29,9 @@ from http.cookies import SimpleCookie
 from urllib.parse import urlparse
 
 import httpx
+from finelog.client import LogServiceProxy
+from finelog.rpc.logging_connect import LogServiceWSGIApplication
+from finelog.server import LogServiceImpl
 from starlette.applications import Starlette
 from starlette.middleware.wsgi import WSGIMiddleware
 from starlette.requests import Request
@@ -47,9 +50,6 @@ from iris.cluster.dashboard_common import (
     requires_auth,
     static_files_mount,
 )
-from finelog.client import LogServiceProxy
-from finelog.rpc.logging_connect import LogServiceWSGIApplication
-from finelog.server import LogServiceImpl
 from iris.rpc.auth import SESSION_COOKIE, NullAuthInterceptor, TokenVerifier, extract_bearer_token, resolve_auth
 from iris.rpc.controller_connect import ControllerServiceWSGIApplication
 from iris.rpc.interceptors import SLOW_RPC_THRESHOLD_MS, ConcurrencyLimitInterceptor, RequestTimingInterceptor

--- a/lib/iris/src/iris/cluster/controller/db.py
+++ b/lib/iris/src/iris/cluster/controller/db.py
@@ -10,16 +10,18 @@ import queue
 import sqlite3
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from dataclasses import dataclass, field, replace as dc_replace
+from dataclasses import dataclass, field
+from dataclasses import replace as dc_replace
 from pathlib import Path
 from threading import Lock, RLock
 from typing import Any
+
+from rigging.timing import Deadline, Duration, Timestamp
 
 from iris.cluster.constraints import AttributeValue
 from iris.cluster.controller.schema import decode_timestamp_ms, decode_worker_id
 from iris.cluster.types import TERMINAL_TASK_STATES, JobName, WorkerId
 from iris.rpc import job_pb2
-from rigging.timing import Deadline, Duration, Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/controller/main.py
+++ b/lib/iris/src/iris/cluster/controller/main.py
@@ -17,16 +17,15 @@ import signal
 import threading
 from pathlib import Path
 
-
 import click
 from finelog.deploy.config import derive_endpoint_uri, load_finelog_config
+from rigging.timing import Duration, Timestamp
 
 from iris.cluster.controller.auth import ControllerAuth, create_controller_auth
 from iris.cluster.controller.budget import reconcile_user_budget_tiers
 from iris.cluster.controller.controller import Controller, ControllerConfig
 from iris.cluster.endpoints import resolve_endpoint_uri
 from iris.rpc import config_pb2
-from rigging.timing import Duration, Timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -333,8 +332,9 @@ def serve(
     state_dir: Path | None,
 ):
     """Start the Iris controller service."""
-    from iris.cluster.config import load_config
     from rigging.log_setup import configure_logging
+
+    from iris.cluster.config import load_config
 
     configure_logging(level=getattr(logging, log_level))
 

--- a/lib/iris/src/iris/cluster/controller/migrations/0017_job_scheduling_fields.py
+++ b/lib/iris/src/iris/cluster/controller/migrations/0017_job_scheduling_fields.py
@@ -36,8 +36,7 @@ def migrate(conn: sqlite3.Connection) -> None:
     if not _has_column(conn, "jobs", "request_proto"):
         return  # Column already removed by 0028; backfill not needed.
 
-    from iris.rpc import job_pb2
-    from iris.rpc import controller_pb2
+    from iris.rpc import controller_pb2, job_pb2
 
     rows = conn.execute("SELECT job_id, request_proto FROM jobs WHERE request_proto IS NOT NULL").fetchall()
     for job_id, request_blob in rows:

--- a/lib/iris/src/iris/cluster/controller/schema.py
+++ b/lib/iris/src/iris/cluster/controller/schema.py
@@ -17,8 +17,9 @@ from dataclasses import dataclass
 from threading import Lock
 from typing import Any, Generic, TypeVar
 
-from iris.cluster.types import JobName, WorkerId
 from rigging.timing import Timestamp
+
+from iris.cluster.types import JobName, WorkerId
 
 T = TypeVar("T")
 RowDecoder = Callable[[sqlite3.Row], Any]

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -8,6 +8,7 @@ creates N tasks). Tasks are the unit of scheduling and execution. Job state is
 aggregated from task states.
 """
 
+import dataclasses
 import json
 import logging
 import re
@@ -15,7 +16,6 @@ import secrets
 import threading
 import time
 import uuid
-import dataclasses
 from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Any, Protocol
@@ -23,24 +23,13 @@ from typing import Any, Protocol
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from connectrpc.request import RequestContext
+from finelog.client import LogServiceProxy
+from finelog.rpc import logging_pb2
+from finelog.server import LogServiceImpl
+from rigging.timing import Timer, Timestamp
 
+from iris.cluster.bundle import BundleStore
 from iris.cluster.constraints import Constraint, constraints_from_resources, merge_constraints, validate_tpu_request
-from iris.cluster.redaction import redact_request_env_vars
-from iris.cluster.controller.codec import (
-    constraints_from_json,
-    proto_from_json,
-    reservation_entries_from_json,
-    resource_spec_from_scalars,
-)
-from iris.cluster.controller.budget import (
-    UserBudgetDefaults,
-    UserTask,
-    compute_effective_band,
-    compute_user_spend,
-    interleave_by_user,
-    resource_value,
-)
-from iris.rpc.proto_utils import priority_band_name
 from iris.cluster.controller.auth import (
     DEFAULT_JWT_TTL_SECONDS,
     ControllerAuth,
@@ -49,15 +38,21 @@ from iris.cluster.controller.auth import (
     revoke_api_key,
     revoke_login_keys_for_user,
 )
-from iris.rpc.auth import (
-    AuthzAction,
-    authorize,
-    authorize_resource_owner,
-    get_verified_identity,
-    get_verified_user,
-    require_identity,
+from iris.cluster.controller.autoscaler.status import PendingHint
+from iris.cluster.controller.budget import (
+    UserBudgetDefaults,
+    UserTask,
+    compute_effective_band,
+    compute_user_spend,
+    interleave_by_user,
+    resource_value,
 )
-from iris.cluster.bundle import BundleStore
+from iris.cluster.controller.codec import (
+    constraints_from_json,
+    proto_from_json,
+    reservation_entries_from_json,
+    resource_spec_from_scalars,
+)
 from iris.cluster.controller.db import (
     ACTIVE_TASK_STATES,
     ControllerDB,
@@ -68,6 +63,9 @@ from iris.cluster.controller.db import (
     running_tasks_by_worker,
     task_row_can_be_scheduled,
 )
+from iris.cluster.controller.provider import ProviderError
+from iris.cluster.controller.query import execute_raw_query
+from iris.cluster.controller.scheduler import SchedulingContext
 from iris.cluster.controller.schema import (
     API_KEY_PROJECTION,
     ATTEMPT_PROJECTION,
@@ -86,22 +84,15 @@ from iris.cluster.controller.schema import (
     WorkerRow,
     tasks_with_attempts,
 )
-from iris.cluster.controller.autoscaler.status import PendingHint
-from iris.cluster.controller.query import execute_raw_query
-from iris.rpc import query_pb2
-from iris.cluster.controller.scheduler import SchedulingContext
 from iris.cluster.controller.stores import TASK_RESOURCE_HISTORY_RETENTION, ControllerStore
 from iris.cluster.controller.transitions import (
     ControllerTransitions,
     HeartbeatApplyRequest,
     task_updates_from_proto,
 )
-from iris.cluster.controller.provider import ProviderError
-from finelog.client import LogServiceProxy
-from finelog.rpc import logging_pb2
-from finelog.server import LogServiceImpl
 from iris.cluster.log_store_helpers import build_log_source, worker_log_key
 from iris.cluster.process_status import get_process_status
+from iris.cluster.redaction import redact_request_env_vars
 from iris.cluster.runtime.profile import is_system_target, parse_profile_target, profile_local_process
 from iris.cluster.types import (
     TERMINAL_JOB_STATES,
@@ -112,14 +103,18 @@ from iris.cluster.types import (
     get_tpu_count,
     is_job_finished,
 )
+from iris.rpc import controller_pb2, job_pb2, query_pb2, vm_pb2, worker_pb2
 from iris.rpc import logging_pb2 as iris_logging_pb2
-from iris.rpc import vm_pb2
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
-from iris.rpc import worker_pb2
-from iris.rpc.proto_utils import job_state_friendly, task_state_friendly
+from iris.rpc.auth import (
+    AuthzAction,
+    authorize,
+    authorize_resource_owner,
+    get_verified_identity,
+    get_verified_user,
+    require_identity,
+)
+from iris.rpc.proto_utils import job_state_friendly, priority_band_name, task_state_friendly
 from iris.time_proto import timestamp_to_proto
-from rigging.timing import Timestamp, Timer
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/controller/stores.py
+++ b/lib/iris/src/iris/cluster/controller/stores.py
@@ -35,6 +35,8 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from threading import RLock
 
+from rigging.timing import Duration, Timestamp
+
 from iris.cluster.constraints import AttributeValue
 from iris.cluster.controller.codec import resource_spec_from_scalars
 from iris.cluster.controller.db import (
@@ -59,7 +61,6 @@ from iris.cluster.controller.schema import (
 )
 from iris.cluster.types import TERMINAL_JOB_STATES, TERMINAL_TASK_STATES, JobName, WorkerId, get_gpu_count, get_tpu_count
 from iris.rpc import job_pb2
-from rigging.timing import Duration, Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -6,13 +6,15 @@
 Read-only queries do NOT belong here — callers use db.read_snapshot() directly.
 """
 
-import threading
-import time
 import json
 import logging
-from dataclasses import dataclass, field
+import threading
+import time
 from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
 from typing import NamedTuple
+
+from rigging.timing import Duration, Timestamp
 
 from iris.cluster.constraints import AttributeValue, Constraint, constraints_from_resources, merge_constraints
 from iris.cluster.controller.codec import (
@@ -35,28 +37,28 @@ from iris.cluster.controller.db import (
     task_row_can_be_scheduled,
     task_row_is_finished,
 )
+from iris.cluster.controller.schema import (
+    EndpointRow,
+    JobDetailRow,
+    WorkerDetailRow,
+)
 from iris.cluster.controller.stores import (
     ActiveTaskRow,
     ControllerStore,
     EndpointStore,
     JobConfigInsertParams,
     JobInsertParams,
-    ResourceUsageInsertParams,
     JobStore,
+    ResourceUsageInsertParams,
     TaskAttemptStore,
     TaskAttemptUpdateParams,
+    TaskInsertParams,
     TaskScope,
     TaskStateUpdateParams,
-    TaskInsertParams,
     TaskStore,
     WorkerAttributeParams,
     WorkerStore,
     WorkerUpsertParams,
-)
-from iris.cluster.controller.schema import (
-    EndpointRow,
-    JobDetailRow,
-    WorkerDetailRow,
 )
 from iris.cluster.controller.worker_health import WorkerHealthTracker
 from iris.cluster.types import (
@@ -67,10 +69,8 @@ from iris.cluster.types import (
     get_gpu_count,
     get_tpu_count,
 )
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import controller_pb2, job_pb2
 from iris.time_proto import duration_from_proto
-from rigging.timing import Duration, Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/controller/vm_lifecycle.py
+++ b/lib/iris/src/iris/cluster/controller/vm_lifecycle.py
@@ -28,18 +28,19 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from rigging.timing import Deadline, Duration, ExponentialBackoff, Timer
+
+from iris.cluster.providers.gcp.bootstrap import (
+    build_controller_bootstrap_script_from_config,
+)
+from iris.cluster.providers.gcp.ssh import OS_LOGIN_METADATA
 from iris.cluster.providers.protocols import WorkerInfraProvider
 from iris.cluster.providers.types import (
     Labels,
     RemoteWorkerHandle,
     StandaloneWorkerHandle,
 )
-from iris.cluster.providers.gcp.bootstrap import (
-    build_controller_bootstrap_script_from_config,
-)
-from iris.cluster.providers.gcp.ssh import OS_LOGIN_METADATA
 from iris.rpc import config_pb2
-from rigging.timing import Deadline, Duration, ExponentialBackoff, Timer
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/controller/worker_provider.py
+++ b/lib/iris/src/iris/cluster/controller/worker_provider.py
@@ -9,6 +9,8 @@ import threading
 from dataclasses import dataclass
 from typing import Protocol
 
+from rigging.timing import Duration
+
 from iris.chaos import chaos
 from iris.cluster.controller.provider import ProviderError
 from iris.cluster.controller.transitions import (
@@ -17,10 +19,8 @@ from iris.cluster.controller.transitions import (
     task_updates_from_proto,
 )
 from iris.cluster.types import WorkerId
-from iris.rpc import job_pb2
-from iris.rpc import worker_pb2
+from iris.rpc import job_pb2, worker_pb2
 from iris.rpc.worker_connect import WorkerServiceClient
-from rigging.timing import Duration
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/process_status.py
+++ b/lib/iris/src/iris/cluster/process_status.py
@@ -13,9 +13,10 @@ import resource
 import sys
 import threading
 
+from rigging.timing import Timer
+
 from iris.cluster.runtime.process import _read_proc_cpu_millicores
 from iris.rpc import job_pb2
-from rigging.timing import Timer
 
 # Persistent CPU sampling state so delta-based measurement works across requests.
 _prev_cpu_total: float = 0.0

--- a/lib/iris/src/iris/cluster/providers/_worker_base.py
+++ b/lib/iris/src/iris/cluster/providers/_worker_base.py
@@ -18,13 +18,14 @@ import shlex
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
+from rigging.timing import Duration
+
 from iris.cluster.providers.remote_exec import (
     RemoteExec,
     run_streaming_with_retry,
     wait_for_connection,
 )
 from iris.cluster.providers.types import CommandResult
-from rigging.timing import Duration
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
@@ -13,11 +13,11 @@ from __future__ import annotations
 import json
 import logging
 import re
+from collections.abc import Callable
 
 import yaml
 from google.protobuf.json_format import MessageToDict
 
-from collections.abc import Callable
 from iris.rpc import config_pb2
 
 logger = logging.getLogger(__name__)

--- a/lib/iris/src/iris/cluster/providers/gcp/controller.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/controller.py
@@ -16,21 +16,22 @@ from collections.abc import Iterator
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from dataclasses import dataclass
 
+from rigging.timing import ExponentialBackoff, retry_with_backoff
+
 from iris.cluster.controller.vm_lifecycle import restart_controller as vm_restart_controller
 from iris.cluster.controller.vm_lifecycle import start_controller as vm_start_controller
 from iris.cluster.controller.vm_lifecycle import stop_controller as vm_stop_controller
-from iris.cluster.providers.gcp.workers import GcpWorkerProvider
 from iris.cluster.providers.gcp.ssh import ssh_impersonate_service_account, ssh_key_file
+from iris.cluster.providers.gcp.workers import GcpWorkerProvider
+from iris.cluster.providers.remote_exec import resolve_current_os_login_user
 from iris.cluster.providers.types import (
     Labels,
     default_stop_all,
     find_free_port,
     wait_for_port,
 )
-from iris.cluster.providers.remote_exec import resolve_current_os_login_user
 from iris.cluster.service_mode import ServiceMode
 from iris.rpc import config_pb2
-from rigging.timing import ExponentialBackoff, retry_with_backoff
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/providers/gcp/fake.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/fake.py
@@ -18,12 +18,9 @@ import logging
 import uuid
 from pathlib import Path
 
-from iris.cluster.providers.types import (
-    InfraError,
-    Labels,
-    QuotaExhaustedError,
-    find_free_port,
-)
+from rigging.timing import Duration, Timestamp
+
+from iris.cluster.providers.gcp.local import LocalSliceHandle
 from iris.cluster.providers.gcp.service import (
     KNOWN_GCP_ZONES,
     KNOWN_TPU_TYPES,
@@ -37,12 +34,16 @@ from iris.cluster.providers.gcp.service import (
     validate_tpu_create,
     validate_vm_create,
 )
-from iris.cluster.providers.gcp.local import LocalSliceHandle
+from iris.cluster.providers.types import (
+    InfraError,
+    Labels,
+    QuotaExhaustedError,
+    find_free_port,
+)
 from iris.cluster.service_mode import ServiceMode
 from iris.cluster.worker.port_allocator import PortAllocator
 from iris.managed_thread import ThreadContainer
 from iris.rpc import config_pb2
-from rigging.timing import Duration, Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/providers/gcp/handles.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/handles.py
@@ -16,8 +16,17 @@ import re
 import threading
 from dataclasses import dataclass
 
+from rigging.timing import Duration, Timestamp
+
+from iris.cluster.providers._worker_base import RemoteExecWorkerBase
 from iris.cluster.providers.gcp.service import GcpService
 from iris.cluster.providers.gcp.ssh import ssh_impersonate_service_account, ssh_key_file, uses_os_login
+from iris.cluster.providers.remote_exec import (
+    DirectSshRemoteExec,
+    GceRemoteExec,
+    GcloudRemoteExec,
+    resolve_current_os_login_user,
+)
 from iris.cluster.providers.types import (
     CloudSliceState,
     CloudWorkerState,
@@ -27,16 +36,8 @@ from iris.cluster.providers.types import (
     WorkerStatus,
 )
 from iris.cluster.types import get_tpu_topology
-from iris.cluster.providers._worker_base import RemoteExecWorkerBase
-from iris.cluster.providers.remote_exec import (
-    DirectSshRemoteExec,
-    GceRemoteExec,
-    GcloudRemoteExec,
-    resolve_current_os_login_user,
-)
 from iris.rpc import config_pb2
 from iris.time_proto import duration_from_proto
-from rigging.timing import Duration, Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/providers/gcp/local.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/local.py
@@ -14,6 +14,8 @@ import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
+from rigging.timing import Duration, Timestamp
+
 from iris.cluster.providers.types import (
     CloudSliceState,
     CloudWorkerState,
@@ -23,7 +25,6 @@ from iris.cluster.providers.types import (
     WorkerStatus,
 )
 from iris.cluster.worker.worker import Worker
-from rigging.timing import Duration, Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/providers/gcp/service.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/service.py
@@ -17,17 +17,17 @@ import google.auth.credentials
 import google.auth.transport.requests
 import httpx
 from google.cloud import tpu_v2alpha1
+from rigging.timing import Timestamp
 
+from iris.cluster.providers.gcp.local import LocalSliceHandle
 from iris.cluster.providers.types import (
     InfraError,
     QuotaExhaustedError,
     ResourceNotFoundError,
 )
-from iris.cluster.providers.gcp.local import LocalSliceHandle
 from iris.cluster.service_mode import ServiceMode
 from iris.cluster.types import TPU_TOPOLOGIES
 from iris.rpc import config_pb2
-from rigging.timing import Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/providers/gcp/workers.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/workers.py
@@ -12,11 +12,13 @@ from __future__ import annotations
 
 import logging
 import threading
-from collections.abc import Callable
-from datetime import datetime, timedelta, timezone
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
+
+from rigging.timing import Deadline, Duration, Timestamp
 
 from iris.cluster.providers.gcp.bootstrap import (
     build_worker_bootstrap_script,
@@ -24,11 +26,11 @@ from iris.cluster.providers.gcp.bootstrap import (
     zone_to_multi_region,
 )
 from iris.cluster.providers.gcp.handles import (
+    _ACTIVE_VM_SLICE_STATES,
     CloudSliceState,
     GcpSliceHandle,
     GcpStandaloneWorkerHandle,
     GcpVmSliceHandle,
-    _ACTIVE_VM_SLICE_STATES,
     _build_gce_resource_name,
 )
 from iris.cluster.providers.gcp.service import (
@@ -40,6 +42,7 @@ from iris.cluster.providers.gcp.service import (
     VmCreateRequest,
 )
 from iris.cluster.providers.gcp.ssh import OS_LOGIN_METADATA, ssh_impersonate_service_account, ssh_key_file
+from iris.cluster.providers.remote_exec import GceRemoteExec
 from iris.cluster.providers.types import (
     InfraError,
     Labels,
@@ -49,9 +52,7 @@ from iris.cluster.providers.types import (
 from iris.cluster.service_mode import ServiceMode
 from iris.cluster.types import get_tpu_topology
 from iris.cluster.worker.env_probe import construct_worker_id
-from iris.cluster.providers.remote_exec import GceRemoteExec
 from iris.rpc import config_pb2
-from rigging.timing import Deadline, Duration, Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/providers/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/controller.py
@@ -20,12 +20,13 @@ from contextlib import AbstractContextManager
 from datetime import datetime
 from urllib.parse import urlparse
 
+from rigging.timing import Deadline
+
 from iris.cluster.config import config_to_dict
 from iris.cluster.providers.k8s.service import K8sService
 from iris.cluster.providers.k8s.types import K8sResource
 from iris.cluster.providers.types import InfraError, Labels
 from iris.rpc import config_pb2
-from rigging.timing import Deadline
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/providers/k8s/fake.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/fake.py
@@ -22,8 +22,6 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
-from iris.cluster.service_mode import ServiceMode
-
 from iris.cluster.providers.k8s.types import (
     ExecResult,
     K8sResource,
@@ -33,6 +31,7 @@ from iris.cluster.providers.k8s.types import (
     PodResourceUsage,
     parse_k8s_quantity,
 )
+from iris.cluster.service_mode import ServiceMode
 
 # Resource types that K8s recognizes in container resource requests/limits.
 logger = logging.getLogger(__name__)

--- a/lib/iris/src/iris/cluster/providers/k8s/service.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/service.py
@@ -31,6 +31,9 @@ except ImportError:
     DynamicClient = None  # type: ignore[assignment,misc]
 
 
+from rigging.log_setup import slow_log
+from rigging.timing import Deadline, ExponentialBackoff
+
 from iris.cluster.providers.k8s.types import (
     ExecResult,
     K8sResource,
@@ -42,8 +45,6 @@ from iris.cluster.providers.k8s.types import (
     parse_k8s_quantity,
 )
 from iris.cluster.providers.types import find_free_port
-from rigging.log_setup import slow_log
-from rigging.timing import Deadline, ExponentialBackoff
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/providers/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/tasks.py
@@ -23,22 +23,27 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
-from iris.cluster.controller.transitions import ClusterCapacity, DirectProviderSyncResult, SchedulingEvent
-from iris.cluster.controller.transitions import DirectProviderBatch, RunningTaskEntry, TaskUpdate
 from finelog.rpc import logging_pb2
 from finelog.types import LogPusherProtocol, str_to_log_level
+from rigging.log_setup import parse_log_level
+from rigging.timing import Timestamp
+
+from iris.cluster.controller.transitions import (
+    ClusterCapacity,
+    DirectProviderBatch,
+    DirectProviderSyncResult,
+    RunningTaskEntry,
+    SchedulingEvent,
+    TaskUpdate,
+)
 from iris.cluster.log_store_helpers import task_log_key
 from iris.cluster.providers.k8s.constants import NVIDIA_GPU_TOLERATION
 from iris.cluster.providers.k8s.service import K8sService
 from iris.cluster.providers.k8s.types import K8sResource, KubectlError, KubectlLogLine, parse_k8s_quantity
 from iris.cluster.runtime.env import build_common_iris_env, normalize_workdir_relative_path
 from iris.cluster.types import JobName, TaskAttempt, get_gpu_count
-from rigging.log_setup import parse_log_level
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
-from iris.rpc import worker_pb2
+from iris.rpc import controller_pb2, job_pb2, worker_pb2
 from iris.time_proto import timestamp_to_proto
-from rigging.timing import Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/providers/local/cluster.py
+++ b/lib/iris/src/iris/cluster/providers/local/cluster.py
@@ -20,22 +20,24 @@ import tempfile
 import threading
 from pathlib import Path
 
+from rigging.timing import Duration, Timestamp
+
 from iris.cluster.config import make_local_config
 from iris.cluster.constraints import worker_attributes_from_resources
 from iris.cluster.controller.auth import create_api_key, create_controller_auth
 from iris.cluster.controller.autoscaler import Autoscaler
-from iris.cluster.controller.controller import (
-    Controller,
-    ControllerConfig,
-)
-from iris.cluster.controller.worker_provider import RpcWorkerStubFactory, WorkerProvider
-from iris.cluster.controller.db import ControllerDB
-from iris.cluster.controller.vm_lifecycle import ControllerStatus
 from iris.cluster.controller.autoscaler.scaling_group import (
     DEFAULT_SCALE_DOWN_RATE_LIMIT,
     DEFAULT_SCALE_UP_RATE_LIMIT,
     ScalingGroup,
 )
+from iris.cluster.controller.controller import (
+    Controller,
+    ControllerConfig,
+)
+from iris.cluster.controller.db import ControllerDB
+from iris.cluster.controller.vm_lifecycle import ControllerStatus
+from iris.cluster.controller.worker_provider import RpcWorkerStubFactory, WorkerProvider
 from iris.cluster.providers.gcp.fake import InMemoryGcpService
 from iris.cluster.providers.gcp.workers import GcpWorkerProvider
 from iris.cluster.providers.types import find_free_port
@@ -45,7 +47,6 @@ from iris.managed_thread import ThreadContainer
 from iris.rpc import config_pb2
 from iris.rpc.auth import hash_token
 from iris.time_proto import duration_from_proto
-from rigging.timing import Duration, Timestamp
 
 
 def create_local_autoscaler(

--- a/lib/iris/src/iris/cluster/providers/manual/provider.py
+++ b/lib/iris/src/iris/cluster/providers/manual/provider.py
@@ -14,9 +14,14 @@ from collections.abc import Callable
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, field
 
+from rigging.timing import Duration, Timestamp
+
 from iris.cluster.controller.vm_lifecycle import restart_controller as vm_restart_controller
 from iris.cluster.controller.vm_lifecycle import start_controller as vm_start_controller
 from iris.cluster.controller.vm_lifecycle import stop_controller as vm_stop_controller
+from iris.cluster.providers._worker_base import RemoteExecWorkerBase
+from iris.cluster.providers.gcp.bootstrap import build_worker_bootstrap_script
+from iris.cluster.providers.remote_exec import DirectSshRemoteExec
 from iris.cluster.providers.types import (
     CloudSliceState,
     CloudWorkerState,
@@ -27,13 +32,9 @@ from iris.cluster.providers.types import (
     default_stop_all,
     generate_slice_suffix,
 )
-from iris.cluster.providers._worker_base import RemoteExecWorkerBase
-from iris.cluster.providers.gcp.bootstrap import build_worker_bootstrap_script
-from iris.cluster.providers.remote_exec import DirectSshRemoteExec
 from iris.cluster.worker.env_probe import construct_worker_id
 from iris.rpc import config_pb2
 from iris.time_proto import duration_from_proto
-from rigging.timing import Duration, Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/runtime/docker.py
+++ b/lib/iris/src/iris/cluster/runtime/docker.py
@@ -26,6 +26,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
+from rigging.timing import Timestamp
+
 from iris.cluster.bundle import BundleStore
 from iris.cluster.runtime.env import write_workdir_files
 from iris.cluster.runtime.profile import (
@@ -51,7 +53,6 @@ from iris.cluster.runtime.types import (
 )
 from iris.cluster.worker.worker_types import LogLine, TaskLogs
 from iris.rpc import job_pb2
-from rigging.timing import Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/runtime/process.py
+++ b/lib/iris/src/iris/cluster/runtime/process.py
@@ -43,8 +43,8 @@ from iris.cluster.runtime.profile import (
     build_pyspy_cmd,
     resolve_cpu_spec,
     resolve_memory_spec,
+    run_pyspy_dump,
 )
-from iris.cluster.runtime.profile import run_pyspy_dump
 from iris.cluster.runtime.types import (
     ContainerConfig,
     ContainerPhase,

--- a/lib/iris/src/iris/cluster/runtime/types.py
+++ b/lib/iris/src/iris/cluster/runtime/types.py
@@ -16,10 +16,10 @@ tasks are in the BUILDING state per worker, preventing resource exhaustion from
 too many concurrent uv sync operations.
 """
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
-from collections.abc import Callable
 from typing import Protocol
 
 from iris.cluster.bundle import BundleStore

--- a/lib/iris/src/iris/cluster/worker/dashboard.py
+++ b/lib/iris/src/iris/cluster/worker/dashboard.py
@@ -9,8 +9,8 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse
 from starlette.routing import Mount, Route
 
-from iris.cluster.worker.service import WorkerServiceImpl
 from iris.cluster.dashboard_common import favicon_route, html_shell, static_files_mount
+from iris.cluster.worker.service import WorkerServiceImpl
 from iris.rpc.worker_connect import WorkerServiceWSGIApplication
 
 

--- a/lib/iris/src/iris/cluster/worker/env_probe.py
+++ b/lib/iris/src/iris/cluster/worker/env_probe.py
@@ -17,12 +17,12 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Protocol
 
+from rigging.timing import Timestamp
+
 from iris.cluster.constraints import WellKnownAttribute, accelerator_type_to_string
 from iris.cluster.types import get_tpu_topology
-from iris.rpc import config_pb2
-from iris.rpc import job_pb2
+from iris.rpc import config_pb2, job_pb2
 from iris.time_proto import timestamp_to_proto
-from rigging.timing import Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/worker/main.py
+++ b/lib/iris/src/iris/cluster/worker/main.py
@@ -12,12 +12,12 @@ from pathlib import Path
 
 import click
 from google.protobuf.json_format import ParseDict
+from rigging.log_setup import configure_logging
 
 from iris.cluster.providers.factory import create_provider_bundle
 from iris.cluster.runtime.docker import DockerRuntime
 from iris.cluster.worker.env_probe import detect_gcp_zone
 from iris.cluster.worker.worker import Worker, worker_config_from_proto
-from rigging.log_setup import configure_logging
 from iris.rpc import config_pb2
 
 

--- a/lib/iris/src/iris/cluster/worker/service.py
+++ b/lib/iris/src/iris/cluster/worker/service.py
@@ -9,14 +9,13 @@ from typing import Protocol
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from connectrpc.request import RequestContext
+from rigging.timing import Timer
 
 from iris.cluster.process_status import get_process_status as _get_process_status
 from iris.cluster.runtime.profile import is_system_target, parse_profile_target, profile_local_process
 from iris.cluster.worker.worker_types import TaskInfo
-from iris.rpc import job_pb2
-from iris.rpc import worker_pb2
+from iris.rpc import job_pb2, worker_pb2
 from iris.rpc.errors import rpc_error_handler
-from rigging.timing import Timer
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/worker/task_attempt.py
+++ b/lib/iris/src/iris/cluster/worker/task_attempt.py
@@ -16,7 +16,15 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+from finelog.client import LogPusher
+from finelog.rpc import logging_pb2
+from finelog.types import str_to_log_level
+from rigging.log_setup import parse_log_level
+from rigging.timing import Duration, Timestamp
+
 from iris.chaos import chaos, chaos_raise
+from iris.cluster.bundle import BundleStore
+from iris.cluster.log_store_helpers import task_log_key
 from iris.cluster.runtime.types import (
     ContainerConfig,
     ContainerErrorKind,
@@ -25,30 +33,24 @@ from iris.cluster.runtime.types import (
     ContainerPhase,
     ContainerRuntime,
     DiscoveredContainer,
-    RuntimeLogReader,
     MountKind,
     MountSpec,
+    RuntimeLogReader,
 )
 from iris.cluster.types import (
     JobName,
-    TaskAttempt as TaskAttemptIdentity,
     is_task_finished,
 )
-from iris.cluster.bundle import BundleStore
+from iris.cluster.types import (
+    TaskAttempt as TaskAttemptIdentity,
+)
 from iris.cluster.worker.port_allocator import PortAllocator
 from iris.cluster.worker.tpu_health import detect_tpu_init_failure
 from iris.cluster.worker.worker_types import LogLine
-from iris.cluster.log_store_helpers import task_log_key
-from finelog.client import LogPusher
-from finelog.types import str_to_log_level
-from rigging.log_setup import parse_log_level
-from finelog.rpc import logging_pb2
-from iris.rpc import job_pb2
-from iris.rpc import worker_pb2
-from iris.rpc.job_pb2 import TaskState, WorkerMetadata
+from iris.rpc import job_pb2, worker_pb2
 from iris.rpc.errors import format_exception_with_traceback
+from iris.rpc.job_pb2 import TaskState, WorkerMetadata
 from iris.time_proto import timestamp_to_proto
-from rigging.timing import Duration, Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/worker/worker.py
+++ b/lib/iris/src/iris/cluster/worker/worker.py
@@ -11,14 +11,16 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import uvicorn
+from finelog.client import LogPusher, RemoteLogHandler
+from rigging.timing import Deadline, Duration, ExponentialBackoff, Timestamp
 
 from iris.chaos import chaos
+from iris.cluster.bundle import BundleStore
 from iris.cluster.log_store_helpers import worker_log_key
 from iris.cluster.runtime.docker import DockerRuntime
-from finelog.client import LogPusher, RemoteLogHandler
 from iris.cluster.runtime.types import ContainerRuntime, ExecutionStage
-from iris.cluster.types import JobName, TaskAttempt as TaskAttemptId
-from iris.cluster.bundle import BundleStore
+from iris.cluster.types import JobName
+from iris.cluster.types import TaskAttempt as TaskAttemptId
 from iris.cluster.worker.dashboard import WorkerDashboard
 from iris.cluster.worker.env_probe import (
     EnvironmentProvider,
@@ -36,14 +38,10 @@ from iris.cluster.worker.service import WorkerServiceImpl
 from iris.cluster.worker.task_attempt import TaskAttempt, TaskAttemptConfig
 from iris.cluster.worker.worker_types import TaskInfo
 from iris.managed_thread import ThreadContainer, get_thread_container
-from iris.rpc import config_pb2
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
-from iris.rpc import worker_pb2
+from iris.rpc import config_pb2, controller_pb2, job_pb2, worker_pb2
 from iris.rpc.auth import AuthTokenInjector, StaticTokenProvider
 from iris.rpc.controller_connect import ControllerServiceClientSync
 from iris.time_proto import timestamp_to_proto
-from rigging.timing import Deadline, Duration, ExponentialBackoff, Timestamp
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/cluster/worker/worker_types.py
+++ b/lib/iris/src/iris/cluster/worker/worker_types.py
@@ -6,12 +6,12 @@
 from datetime import datetime, timezone
 from typing import Protocol
 
-from pydantic import BaseModel
-
 from finelog.rpc import logging_pb2
+from pydantic import BaseModel
+from rigging.timing import Timestamp
+
 from iris.rpc import job_pb2
 from iris.rpc.job_pb2 import TaskState
-from rigging.timing import Timestamp
 
 
 class LogLine(BaseModel):

--- a/lib/iris/src/iris/rpc/__init__.py
+++ b/lib/iris/src/iris/rpc/__init__.py
@@ -3,10 +3,10 @@
 
 # Import order matters for proto descriptor pool: each module must be loaded
 # after its dependencies. Chain: time → config → vm → query → job → controller/worker.
-from iris.rpc import time_pb2 as time_pb2
 from iris.rpc import config_pb2 as config_pb2
-from iris.rpc import vm_pb2 as vm_pb2
-from iris.rpc import query_pb2 as query_pb2
-from iris.rpc import job_pb2 as job_pb2
 from iris.rpc import controller_pb2 as controller_pb2
+from iris.rpc import job_pb2 as job_pb2
+from iris.rpc import query_pb2 as query_pb2
+from iris.rpc import time_pb2 as time_pb2
+from iris.rpc import vm_pb2 as vm_pb2
 from iris.rpc import worker_pb2 as worker_pb2

--- a/lib/iris/src/iris/rpc/errors.py
+++ b/lib/iris/src/iris/rpc/errors.py
@@ -6,17 +6,17 @@
 import logging
 import time
 import traceback
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from typing import TypeVar
-from collections.abc import Callable, Generator
 
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from google.protobuf.any_pb2 import Any as AnyProto
+from rigging.timing import Deadline, ExponentialBackoff, Timestamp, retry_with_backoff
 
 from iris.rpc import errors_pb2
 from iris.time_proto import timestamp_to_proto
-from rigging.timing import Deadline, ExponentialBackoff, Timestamp, retry_with_backoff
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/rpc/interceptors.py
+++ b/lib/iris/src/iris/rpc/interceptors.py
@@ -7,10 +7,10 @@ import threading
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from google.protobuf.message import Message
+from rigging.timing import Timer
 
 from iris.rpc.errors import connect_error_sanitized, connect_error_with_traceback
 from iris.rpc.stats import RpcStatsCollector
-from rigging.timing import Timer
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/rpc/proto_utils.py
+++ b/lib/iris/src/iris/rpc/proto_utils.py
@@ -3,7 +3,7 @@
 
 """Protobuf enum utilities."""
 
-from iris.rpc import vm_pb2, job_pb2, config_pb2
+from iris.rpc import config_pb2, job_pb2, vm_pb2
 
 
 def vm_state_name(state: int) -> str:

--- a/lib/iris/src/iris/runtime/jax_init.py
+++ b/lib/iris/src/iris/runtime/jax_init.py
@@ -15,10 +15,11 @@ import atexit
 import logging
 import os
 
+from rigging.timing import Duration, ExponentialBackoff
+
 from iris.actor.resolver import Resolver
 from iris.client.client import iris_ctx
 from iris.cluster.client.job_info import get_job_info
-from rigging.timing import Duration, ExponentialBackoff
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/src/iris/time_proto.py
+++ b/lib/iris/src/iris/time_proto.py
@@ -7,8 +7,9 @@ These functions bridge rigging's Duration/Timestamp (which have no proto
 dependency) with iris's time_pb2 proto messages.
 """
 
-from iris.rpc import time_pb2
 from rigging.timing import Duration, Timestamp
+
+from iris.rpc import time_pb2
 
 
 def duration_to_proto(d: Duration) -> time_pb2.Duration:

--- a/lib/iris/tests/actor/test_actor_e2e.py
+++ b/lib/iris/tests/actor/test_actor_e2e.py
@@ -4,7 +4,6 @@
 """End-to-end tests for actor server and client."""
 
 import pytest
-
 from iris.actor import ActorClient, ActorServer
 from iris.actor.resolver import FixedResolver
 

--- a/lib/iris/tests/actor/test_actor_lro.py
+++ b/lib/iris/tests/actor/test_actor_lro.py
@@ -6,7 +6,6 @@
 import time
 
 import pytest
-
 from iris.actor import ActorClient, ActorServer
 from iris.actor.resolver import FixedResolver
 from iris.rpc import actor_pb2

--- a/lib/iris/tests/actor/test_actor_pool.py
+++ b/lib/iris/tests/actor/test_actor_pool.py
@@ -3,8 +3,8 @@
 
 """Tests for ActorPool round-robin and broadcast functionality."""
 
-from iris.actor.resolver import FixedResolver
 from iris.actor.pool import ActorPool
+from iris.actor.resolver import FixedResolver
 from iris.actor.server import ActorServer
 
 

--- a/lib/iris/tests/actor/test_actor_proxy.py
+++ b/lib/iris/tests/actor/test_actor_proxy.py
@@ -8,15 +8,14 @@ Tests the full round-trip: external client → proxy → actor server.
 
 import httpx
 import uvicorn
-from starlette.applications import Starlette
-from starlette.routing import Route
-
 from iris.actor import ActorClient, ActorServer
 from iris.actor.resolver import ACTOR_ENDPOINT_HEADER, ProxyResolver
 from iris.cluster.controller.actor_proxy import PROXY_ROUTE
 from iris.cluster.dashboard_common import on_shutdown
 from iris.managed_thread import ThreadContainer
 from rigging.timing import Duration, ExponentialBackoff
+from starlette.applications import Starlette
+from starlette.routing import Route
 
 
 class StatusActor:

--- a/lib/iris/tests/actor/test_actor_retry.py
+++ b/lib/iris/tests/actor/test_actor_retry.py
@@ -7,11 +7,10 @@ import threading
 
 import pytest
 from connectrpc.errors import ConnectError
-
 from iris.actor import ActorClient, ActorPool
-from rigging.timing import ExponentialBackoff
 from iris.actor.resolver import FixedResolver, ResolveResult
 from iris.actor.server import ActorServer
+from rigging.timing import ExponentialBackoff
 
 
 class Counter:

--- a/lib/iris/tests/cli/test_image_tag_parsing.py
+++ b/lib/iris/tests/cli/test_image_tag_parsing.py
@@ -4,7 +4,6 @@
 """Tests for image tag parsing in cluster.py."""
 
 import pytest
-
 from iris.cli.cluster import _parse_ghcr_tag
 
 

--- a/lib/iris/tests/cli/test_job.py
+++ b/lib/iris/tests/cli/test_job.py
@@ -5,7 +5,6 @@
 
 import click
 import pytest
-
 from iris.cli.job import (
     _parse_tpu_alternatives,
     _render_job_summary_text,
@@ -16,7 +15,6 @@ from iris.cli.job import (
     validate_extra_resources,
     validate_region_zone,
 )
-from iris.rpc import job_pb2 as _job_pb2
 from iris.cluster.constraints import (
     Constraint,
     WellKnownAttribute,
@@ -25,6 +23,7 @@ from iris.cluster.constraints import (
     region_constraint,
 )
 from iris.rpc import config_pb2
+from iris.rpc import job_pb2 as _job_pb2
 
 
 def _make_config_with_zones(zones: list[str]) -> config_pb2.IrisClusterConfig:

--- a/lib/iris/tests/cli/test_job_multinode.py
+++ b/lib/iris/tests/cli/test_job_multinode.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
 from iris.cli.job import resolve_multinode_defaults
 
 

--- a/lib/iris/tests/cli/test_token_store.py
+++ b/lib/iris/tests/cli/test_token_store.py
@@ -8,7 +8,6 @@ import os
 from pathlib import Path
 
 import pytest
-
 from iris.cli.token_store import (
     ClusterCredential,
     cluster_name_from_url,

--- a/lib/iris/tests/cluster/client/test_bundle.py
+++ b/lib/iris/tests/cluster/client/test_bundle.py
@@ -8,7 +8,6 @@ import re
 from unittest.mock import patch
 
 import pytest
-
 from iris.cluster.client.bundle import MAX_BUNDLE_SIZE_BYTES, collect_workspace_files, create_workspace_zip
 
 

--- a/lib/iris/tests/cluster/conftest.py
+++ b/lib/iris/tests/cluster/conftest.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from unittest.mock import Mock
 
 import pytest
-
+from finelog.server import LogServiceImpl
 from iris.cluster.bundle import BundleStore
 from iris.cluster.constraints import Constraint, ConstraintOp, WellKnownAttribute
 from iris.cluster.controller.db import ControllerDB
@@ -30,13 +30,11 @@ from iris.cluster.controller.transitions import (
     HeartbeatApplyRequest,
     TaskUpdate,
 )
-from finelog.server import LogServiceImpl
 from iris.cluster.providers.k8s.fake import FakeNodeResources, InMemoryK8sService
 from iris.cluster.providers.k8s.tasks import K8sTaskProvider
 from iris.cluster.providers.k8s.types import K8sResource
 from iris.cluster.types import JobName, WorkerId
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Timestamp
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/controller/conftest.py
+++ b/lib/iris/tests/cluster/controller/conftest.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, Mock
 
 import pytest
-
+from finelog.server import LogServiceImpl
 from iris.cluster.bundle import BundleStore
 from iris.cluster.constraints import (
     Constraint,
@@ -52,7 +52,6 @@ from iris.cluster.controller.schema import (
 )
 from iris.cluster.controller.service import ControllerServiceImpl
 from iris.cluster.controller.stores import ControllerStore
-from finelog.server import LogServiceImpl
 from iris.cluster.controller.transitions import (
     Assignment,
     ControllerTransitions,
@@ -64,11 +63,10 @@ from iris.cluster.providers.gcp.workers import GcpWorkerProvider
 from iris.cluster.providers.types import CloudSliceState
 from iris.cluster.service_mode import ServiceMode
 from iris.cluster.types import TERMINAL_TASK_STATES, JobName, WorkerId, is_job_finished
-from iris.rpc import config_pb2
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import config_pb2, controller_pb2, job_pb2
 from iris.time_proto import duration_to_proto
 from rigging.timing import Duration, Timestamp
+
 from tests.cluster.providers.conftest import make_mock_platform
 
 check_task_can_be_scheduled = task_row_can_be_scheduled

--- a/lib/iris/tests/cluster/controller/replay/test_replay_goldens.py
+++ b/lib/iris/tests/cluster/controller/replay/test_replay_goldens.py
@@ -13,11 +13,10 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from rigging.timing import Timestamp
-
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.stores import ControllerStore
 from iris.cluster.controller.transitions import ControllerTransitions
+from rigging.timing import Timestamp
 
 from tests.cluster.controller.replay.db_dump import deterministic_dump
 from tests.cluster.controller.replay.scenarios import SCENARIO_NAMES, SCENARIOS, frozen_clock

--- a/lib/iris/tests/cluster/controller/test_api_keys.py
+++ b/lib/iris/tests/cluster/controller/test_api_keys.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock
 import pytest
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
-
+from finelog.server import LogServiceImpl
 from iris.cluster.bundle import BundleStore
 from iris.cluster.controller.auth import (
     WORKER_USER,
@@ -19,16 +19,13 @@ from iris.cluster.controller.auth import (
     create_controller_auth,
     list_api_keys,
 )
-from iris.rpc.auth import VerifiedIdentity, hash_token
-from rigging.timing import Timestamp
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.service import ControllerServiceImpl
 from iris.cluster.controller.stores import ControllerStore
 from iris.cluster.controller.transitions import ControllerTransitions
-from finelog.server import LogServiceImpl
-from iris.rpc import config_pb2
-from iris.rpc import job_pb2
-from iris.rpc.auth import _verified_identity
+from iris.rpc import config_pb2, job_pb2
+from iris.rpc.auth import VerifiedIdentity, _verified_identity, hash_token
+from rigging.timing import Timestamp
 
 
 @pytest.fixture

--- a/lib/iris/tests/cluster/controller/test_auth.py
+++ b/lib/iris/tests/cluster/controller/test_auth.py
@@ -7,10 +7,8 @@ import sqlite3
 from unittest.mock import Mock
 
 import pytest
-from starlette.testclient import TestClient
-
-from iris.cluster.bundle import BundleStore
 from finelog.server import LogServiceImpl
+from iris.cluster.bundle import BundleStore
 from iris.cluster.controller.auth import (
     JwtTokenManager,
     _get_or_create_signing_key,
@@ -27,6 +25,7 @@ from iris.cluster.controller.stores import ControllerStore
 from iris.cluster.controller.transitions import ControllerTransitions
 from iris.rpc.auth import SESSION_COOKIE, StaticTokenVerifier, hash_token, resolve_auth
 from rigging.timing import Timestamp
+from starlette.testclient import TestClient
 
 _TEST_TOKEN = "valid-test-token"
 _TEST_USER = "test-user"
@@ -453,11 +452,9 @@ def test_route_auth_middleware_uses_resolve_auth(service, verifier, token, optio
     We build a dashboard with a @requires_auth route injected and verify it
     agrees with resolve_auth for every (token, optional) combination.
     """
-    from iris.cluster.controller.dashboard import ControllerDashboard, requires_auth
-
-    from iris.cluster.controller.dashboard import _RouteAuthMiddleware
-    from starlette.routing import Route
+    from iris.cluster.controller.dashboard import ControllerDashboard, _RouteAuthMiddleware, requires_auth
     from starlette.responses import JSONResponse as _J
+    from starlette.routing import Route
 
     @requires_auth
     def _protected(_request):

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -13,8 +13,8 @@ Integration tests with real GcpWorkerProvider are in test_autoscaler_integration
 import time
 
 import pytest
-
-from iris.cluster.controller.autoscaler import Autoscaler, DEFAULT_UNRESOLVABLE_TIMEOUT
+from iris.cluster.constraints import DeviceType, WellKnownAttribute
+from iris.cluster.controller.autoscaler import DEFAULT_UNRESOLVABLE_TIMEOUT, Autoscaler
 from iris.cluster.controller.autoscaler.models import ScalingAction, ScalingDecision
 from iris.cluster.controller.autoscaler.routing import route_demand
 from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup
@@ -23,23 +23,27 @@ from iris.cluster.providers.types import (
     QuotaExhaustedError,
     SliceStatus,
 )
+from iris.cluster.types import WorkerStatus
+from iris.rpc import config_pb2, vm_pb2
+from iris.time_proto import duration_to_proto
+from rigging.timing import Duration, Timestamp
+
 from tests.cluster.providers.conftest import (
     FakeSliceHandle,
     make_mock_platform,
     make_mock_slice_handle,
     make_mock_worker_handle,
 )
-from iris.cluster.constraints import DeviceType, WellKnownAttribute
-from iris.cluster.types import WorkerStatus
-from iris.rpc import config_pb2, vm_pb2
-from iris.time_proto import duration_to_proto
-from rigging.timing import Duration, Timestamp
 
 from .conftest import (
     make_autoscaler,
     make_demand_entries,
-    make_big_demand_entries as _make_big_demand_entries,
     make_scale_group_config,
+)
+from .conftest import (
+    make_big_demand_entries as _make_big_demand_entries,
+)
+from .conftest import (
     mark_discovered_ready as _mark_discovered_ready,
 )
 

--- a/lib/iris/tests/cluster/controller/test_autoscaler_integration.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler_integration.py
@@ -10,10 +10,10 @@ backed by in-memory fakes rather than MagicMock.
 
 import threading
 
+from iris.cluster.constraints import DeviceType
 from iris.cluster.controller.autoscaler import Autoscaler
 from iris.cluster.controller.autoscaler.models import DemandEntry, ScalingAction
 from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability, ScalingGroup
-from iris.cluster.constraints import DeviceType
 from iris.cluster.providers.gcp.fake import InMemoryGcpService
 from iris.cluster.providers.gcp.workers import GcpWorkerProvider
 from iris.cluster.providers.types import CloudSliceState
@@ -25,10 +25,14 @@ from rigging.timing import Duration, Timestamp
 from tests.cluster.controller.conftest import (
     advance_all_tpus,
     make_autoscaler,
-    make_big_demand_entries as _make_big_demand_entries,
     make_demand_entries,
     make_gcp_provider,
     make_scale_group_config,
+)
+from tests.cluster.controller.conftest import (
+    make_big_demand_entries as _make_big_demand_entries,
+)
+from tests.cluster.controller.conftest import (
     mark_all_slices_ready as _mark_all_slices_ready,
 )
 

--- a/lib/iris/tests/cluster/controller/test_bundle_store.py
+++ b/lib/iris/tests/cluster/controller/test_bundle_store.py
@@ -6,7 +6,6 @@
 import hashlib
 
 import pytest
-
 from iris.cluster.bundle import BundleStore
 
 

--- a/lib/iris/tests/cluster/controller/test_dashboard.py
+++ b/lib/iris/tests/cluster/controller/test_dashboard.py
@@ -11,39 +11,38 @@ import re
 from unittest.mock import Mock
 
 import pytest
-from starlette.testclient import TestClient
-
+from finelog.server import LogServiceImpl
 from iris.cluster.bundle import BundleStore
+from iris.cluster.constraints import WellKnownAttribute
 from iris.cluster.controller.autoscaler.status import PendingHint
 from iris.cluster.controller.codec import constraints_from_json, resource_spec_from_scalars
 from iris.cluster.controller.dashboard import ControllerDashboard
-from finelog.server import LogServiceImpl
 from iris.cluster.controller.db import (
     healthy_active_workers_with_attributes,
 )
+from iris.cluster.controller.scheduler import JobRequirements, Scheduler
 from iris.cluster.controller.schema import (
     JOB_CONFIG_JOIN,
     JOB_DETAIL_PROJECTION,
     EndpointRow,
 )
-from iris.cluster.controller.scheduler import JobRequirements, Scheduler
 from iris.cluster.controller.service import ControllerServiceImpl
 from iris.cluster.controller.transitions import Assignment, ControllerTransitions, HeartbeatApplyRequest, TaskUpdate
-from iris.cluster.constraints import WellKnownAttribute
 from iris.cluster.providers.k8s.types import K8sResource
 from iris.cluster.types import JobName, WorkerId
-from iris.rpc import config_pb2, vm_pb2
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import config_pb2, controller_pb2, job_pb2, vm_pb2
 from iris.time_proto import timestamp_to_proto
 from rigging.timing import Timestamp
+from starlette.testclient import TestClient
 
 from .conftest import (
     check_task_can_be_scheduled,
     make_test_entrypoint,
     make_worker_metadata,
-    query_tasks_with_attempts as _query_tasks_with_attempts,
     register_worker,
+)
+from .conftest import (
+    query_tasks_with_attempts as _query_tasks_with_attempts,
 )
 
 # =============================================================================

--- a/lib/iris/tests/cluster/controller/test_db.py
+++ b/lib/iris/tests/cluster/controller/test_db.py
@@ -286,9 +286,8 @@ def test_replace_from_reattaches_auth_db(tmp_path: Path) -> None:
 
 def test_replace_from_reattaches_profiles_db(tmp_path: Path) -> None:
     """replace_from() must re-attach the profiles DB so profile tables remain accessible."""
-    from rigging.timing import Timestamp
-
     from iris.cluster.controller.db import get_task_profiles, insert_task_profile
+    from rigging.timing import Timestamp
 
     db = ControllerDB(db_dir=tmp_path)
     insert_task_profile(db, "task-1", b"profile-data", Timestamp.now())

--- a/lib/iris/tests/cluster/controller/test_demand_routing.py
+++ b/lib/iris/tests/cluster/controller/test_demand_routing.py
@@ -8,14 +8,6 @@ and first_fit_decreasing() directly -- no platform or provider is needed.
 """
 
 import pytest
-
-from iris.cluster.controller.autoscaler.models import AdditiveReq, DemandEntry
-from iris.cluster.controller.autoscaler.routing import (
-    RoutingBudget,
-    first_fit_decreasing,
-    route_demand,
-)
-from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup
 from iris.cluster.constraints import (
     Constraint,
     ConstraintOp,
@@ -25,20 +17,30 @@ from iris.cluster.constraints import (
     region_constraint,
     zone_constraint,
 )
-from iris.rpc import config_pb2
-from iris.rpc import job_pb2
-from rigging.timing import Duration, Timestamp
-from tests.cluster.providers.conftest import (
-    make_mock_platform,
-    make_mock_slice_handle,
+from iris.cluster.controller.autoscaler.models import AdditiveReq, DemandEntry
+from iris.cluster.controller.autoscaler.routing import (
+    RoutingBudget,
+    first_fit_decreasing,
+    route_demand,
 )
+from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup
+from iris.rpc import config_pb2, job_pb2
+from rigging.timing import Duration, Timestamp
 
 from tests.cluster.controller.conftest import (
     DEFAULT_RESOURCES,
-    make_big_demand_entries as _make_big_demand_entries,
-    mark_discovered_ready as _mark_discovered_ready,
     make_demand_entries,
     make_scale_group_config,
+)
+from tests.cluster.controller.conftest import (
+    make_big_demand_entries as _make_big_demand_entries,
+)
+from tests.cluster.controller.conftest import (
+    mark_discovered_ready as _mark_discovered_ready,
+)
+from tests.cluster.providers.conftest import (
+    make_mock_platform,
+    make_mock_slice_handle,
 )
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/controller/test_direct_controller.py
+++ b/lib/iris/tests/cluster/controller/test_direct_controller.py
@@ -3,6 +3,7 @@
 
 """Tests for KubernetesProvider integration with controller and transitions."""
 
+from finelog.rpc import logging_pb2
 from iris.cluster.controller.schema import TASK_DETAIL_PROJECTION
 from iris.cluster.controller.transitions import (
     DirectProviderBatch,
@@ -10,7 +11,6 @@ from iris.cluster.controller.transitions import (
     TaskUpdate,
 )
 from iris.cluster.types import JobName
-from finelog.rpc import logging_pb2
 from iris.rpc import job_pb2
 from rigging.timing import Timestamp
 

--- a/lib/iris/tests/cluster/controller/test_dry_run.py
+++ b/lib/iris/tests/cluster/controller/test_dry_run.py
@@ -6,10 +6,10 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from iris.cluster.controller.schema import TASK_DETAIL_PROJECTION
 from iris.cluster.types import JobName
 from iris.rpc import job_pb2
+
 from tests.cluster.controller.conftest import (
     make_job_request,
     make_worker_metadata,

--- a/lib/iris/tests/cluster/controller/test_endpoint_store.py
+++ b/lib/iris/tests/cluster/controller/test_endpoint_store.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import threading
 
 import pytest
-
 from iris.cluster.controller.db import EndpointQuery
 from iris.cluster.controller.schema import ENDPOINT_PROJECTION, EndpointRow
 from iris.cluster.controller.stores import EndpointStore

--- a/lib/iris/tests/cluster/controller/test_list_tasks_resource_bench.py
+++ b/lib/iris/tests/cluster/controller/test_list_tasks_resource_bench.py
@@ -18,7 +18,6 @@ import sqlite3
 import time
 
 import pytest
-
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.service import _tasks_for_listing
 from iris.cluster.types import JobName

--- a/lib/iris/tests/cluster/controller/test_main_endpoints.py
+++ b/lib/iris/tests/cluster/controller/test_main_endpoints.py
@@ -12,7 +12,6 @@ from unittest.mock import patch
 
 import pytest
 import yaml
-
 from iris.cluster.controller.main import LOG_SERVER_ENDPOINT_NAME, _resolve_cluster_endpoints
 from iris.rpc import config_pb2
 

--- a/lib/iris/tests/cluster/controller/test_preemption.py
+++ b/lib/iris/tests/cluster/controller/test_preemption.py
@@ -4,7 +4,6 @@
 """Tests for the preemption loop — higher-priority tasks evict lower-priority running tasks."""
 
 from iris.cluster.controller.budget import UserBudgetDefaults, compute_effective_band
-from iris.cluster.controller.transitions import RESERVATION_HOLDER_JOB_NAME, _resolve_task_failure_state
 from iris.cluster.controller.controller import (
     PreemptionCandidate,
     RunningTaskInfo,
@@ -12,11 +11,15 @@ from iris.cluster.controller.controller import (
     _run_preemption_pass,
 )
 from iris.cluster.controller.scheduler import JobRequirements, WorkerCapacity
+from iris.cluster.controller.transitions import (
+    RESERVATION_HOLDER_JOB_NAME,
+    Assignment,
+    HeartbeatApplyRequest,
+    TaskUpdate,
+    _resolve_task_failure_state,
+)
 from iris.cluster.types import JobName, WorkerId
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
-
-from iris.cluster.controller.transitions import Assignment, HeartbeatApplyRequest, TaskUpdate
+from iris.rpc import controller_pb2, job_pb2
 
 from .conftest import (
     ControllerTestHarness,

--- a/lib/iris/tests/cluster/controller/test_reservation.py
+++ b/lib/iris/tests/cluster/controller/test_reservation.py
@@ -13,7 +13,15 @@ Tests cover:
 """
 
 import pytest
-
+from iris.cluster.constraints import (
+    AttributeValue,
+    Constraint,
+    ConstraintOp,
+    WellKnownAttribute,
+    device_variant_constraint,
+    get_device_type,
+    get_device_variant,
+)
 from iris.cluster.controller.codec import constraints_from_json
 from iris.cluster.controller.controller import (
     RESERVATION_TAINT_KEY,
@@ -27,9 +35,8 @@ from iris.cluster.controller.controller import (
     _worker_matches_reservation_entry,
     job_requirements_from_job,
 )
-from iris.cluster.controller.scheduler import JobRequirements, Scheduler, SchedulingContext
-
 from iris.cluster.controller.db import task_row_can_be_scheduled
+from iris.cluster.controller.scheduler import JobRequirements, Scheduler, SchedulingContext
 from iris.cluster.controller.schema import WorkerRow
 from iris.cluster.controller.transitions import (
     RESERVATION_HOLDER_JOB_NAME,
@@ -38,30 +45,41 @@ from iris.cluster.controller.transitions import (
     HeartbeatApplyRequest,
     TaskUpdate,
 )
-from iris.cluster.constraints import (
-    AttributeValue,
-    Constraint,
-    ConstraintOp,
-    WellKnownAttribute,
-    device_variant_constraint,
-    get_device_type,
-    get_device_variant,
-)
 from iris.cluster.types import JobName, WorkerId, is_job_finished
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Timestamp
+
 from tests.cluster.controller.conftest import (
     hydrate_worker_attributes as _with_attrs,
+)
+from tests.cluster.controller.conftest import (
     make_job_request,
+)
+from tests.cluster.controller.conftest import (
     query_job as _query_job,
+)
+from tests.cluster.controller.conftest import (
     query_job_row as _query_job_row,
+)
+from tests.cluster.controller.conftest import (
     query_task as _query_task,
+)
+from tests.cluster.controller.conftest import (
     query_task_with_attempts as _query_task_with_attempts,
+)
+from tests.cluster.controller.conftest import (
     query_tasks_for_job as _query_tasks_for_job,
+)
+from tests.cluster.controller.conftest import (
     query_worker as _query_worker,
+)
+from tests.cluster.controller.conftest import (
     schedulable_tasks as _schedulable_tasks,
+)
+from tests.cluster.controller.conftest import (
     submit_job as _submit_job_tasks,
+)
+from tests.cluster.controller.conftest import (
     worker_running_tasks as _worker_running_tasks,
 )
 

--- a/lib/iris/tests/cluster/controller/test_reservation_holder_reset_regression.py
+++ b/lib/iris/tests/cluster/controller/test_reservation_holder_reset_regression.py
@@ -18,21 +18,19 @@ transitions.py:2030-2111.
 """
 
 from iris.cluster.controller.transitions import (
+    RESERVATION_HOLDER_JOB_NAME,
     Assignment,
     HeartbeatApplyRequest,
-    RESERVATION_HOLDER_JOB_NAME,
     TaskUpdate,
 )
 from iris.rpc import job_pb2
 
 from tests.cluster.controller.conftest import (
     fail_worker,
+    make_job_request,
     query_task,
     query_task_with_attempts,
     query_tasks_for_job,
-)
-from tests.cluster.controller.conftest import (
-    make_job_request,
     submit_job,
 )
 from tests.cluster.controller.test_reservation import (

--- a/lib/iris/tests/cluster/controller/test_scheduler.py
+++ b/lib/iris/tests/cluster/controller/test_scheduler.py
@@ -9,8 +9,8 @@ modify state, or run threads.
 """
 
 import pytest
-
 from iris.cluster.constraints import WellKnownAttribute
+from iris.cluster.controller.autoscaler.status import PendingHint, build_job_pending_hints
 from iris.cluster.controller.codec import constraints_from_json, resource_spec_from_scalars
 from iris.cluster.controller.db import (
     _decode_attribute_rows,
@@ -22,29 +22,41 @@ from iris.cluster.controller.scheduler import (
 )
 from iris.cluster.controller.transitions import Assignment, ControllerTransitions, HeartbeatApplyRequest, TaskUpdate
 from iris.cluster.types import JobName, WorkerId
-from iris.cluster.controller.autoscaler.status import PendingHint, build_job_pending_hints
-from iris.rpc import config_pb2, vm_pb2
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import config_pb2, controller_pb2, job_pb2, vm_pb2
 from iris.time_proto import duration_to_proto
 from rigging.timing import Duration, Timestamp
 
 from tests.cluster.conftest import eq_constraint, in_constraint
+
 from .conftest import (
     building_counts as _building_counts,
+)
+from .conftest import (
     check_task_can_be_scheduled,
     healthy_active_workers,
     make_job_request,
-    make_test_entrypoint as _make_test_entrypoint,
     make_worker_metadata,
-    query_job as _query_job,
-    query_task as _query_task,
     query_task_with_attempts,
-    query_tasks_for_job as _query_tasks_for_job,
-    query_worker as _query_worker,
     register_worker,
-    schedulable_tasks as _schedulable_tasks,
     submit_job,
+)
+from .conftest import (
+    make_test_entrypoint as _make_test_entrypoint,
+)
+from .conftest import (
+    query_job as _query_job,
+)
+from .conftest import (
+    query_task as _query_task,
+)
+from .conftest import (
+    query_tasks_for_job as _query_tasks_for_job,
+)
+from .conftest import (
+    query_worker as _query_worker,
+)
+from .conftest import (
+    schedulable_tasks as _schedulable_tasks,
 )
 
 

--- a/lib/iris/tests/cluster/controller/test_scheduling_fairness.py
+++ b/lib/iris/tests/cluster/controller/test_scheduling_fairness.py
@@ -9,8 +9,7 @@ from iris.cluster.controller.budget import UserBudgetDefaults, UserTask, compute
 from iris.cluster.controller.controller import SchedulingOutcome, _schedulable_tasks
 from iris.cluster.controller.schema import TASK_DETAIL_PROJECTION
 from iris.cluster.types import JobName, WorkerId
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Timestamp
 
 from .conftest import (

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -12,16 +12,15 @@ from datetime import date, timedelta
 import pytest
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
-
+from finelog.server import LogServiceImpl
 from iris.cluster.constraints import ConstraintOp, WellKnownAttribute, device_variant_constraint
+from iris.cluster.controller.codec import constraints_from_json
 from iris.cluster.controller.service import (
     FEATURE_INTRODUCTION_DATE,
     FRESHNESS_WINDOW,
     ControllerServiceImpl,
     _check_client_freshness,
 )
-from finelog.server import LogServiceImpl
-from iris.cluster.controller.codec import constraints_from_json
 from iris.cluster.controller.transitions import (
     Assignment,
     ControllerTransitions,
@@ -29,15 +28,18 @@ from iris.cluster.controller.transitions import (
     TaskUpdate,
 )
 from iris.cluster.types import JobName, WorkerId, tpu_device
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Timestamp
 
 from .conftest import (
     make_job_request,
     make_test_entrypoint,
     make_worker_metadata,
+)
+from .conftest import (
     query_job as _query_job,
+)
+from .conftest import (
     query_tasks_with_attempts as _query_tasks_with_attempts,
 )
 
@@ -664,7 +666,7 @@ def test_terminate_job_skips_already_finished_children(service, state):
 
 def test_terminate_job_allowed_by_owner(service):
     """Job owner can terminate their own job."""
-    from iris.rpc.auth import _verified_identity, VerifiedIdentity
+    from iris.rpc.auth import VerifiedIdentity, _verified_identity
 
     service.launch_job(make_job_request("/alice/my-job"), None)
 
@@ -683,7 +685,7 @@ def test_terminate_job_rejected_for_non_owner(state, mock_controller, tmp_path):
     """Non-owner gets PERMISSION_DENIED when trying to terminate another user's job."""
     from iris.cluster.bundle import BundleStore
     from iris.cluster.controller.auth import ControllerAuth
-    from iris.rpc.auth import _verified_identity, VerifiedIdentity
+    from iris.rpc.auth import VerifiedIdentity, _verified_identity
 
     auth_service = ControllerServiceImpl(
         state,
@@ -714,7 +716,7 @@ def test_launch_child_job_rejected_for_non_owner(state, mock_controller, tmp_pat
     """Cannot submit a child job under another user's hierarchy."""
     from iris.cluster.bundle import BundleStore
     from iris.cluster.controller.auth import ControllerAuth
-    from iris.rpc.auth import _verified_identity, VerifiedIdentity
+    from iris.rpc.auth import VerifiedIdentity, _verified_identity
 
     auth_service = ControllerServiceImpl(
         state,
@@ -1064,7 +1066,7 @@ def test_worker_addresses_for_tasks(state, service):
 
 def test_list_workers_returns_all(service, state):
     """Verify list_workers returns all registered workers."""
-    from iris.rpc.auth import _verified_identity, VerifiedIdentity
+    from iris.rpc.auth import VerifiedIdentity, _verified_identity
 
     db = state._db
     db.ensure_user("system:worker", Timestamp.now(), role="worker")
@@ -1172,7 +1174,7 @@ def test_register_requires_worker_role(state, mock_controller, tmp_path):
     """Non-worker user gets PERMISSION_DENIED on register()."""
     from iris.cluster.bundle import BundleStore
     from iris.cluster.controller.auth import ControllerAuth
-    from iris.rpc.auth import _verified_identity, VerifiedIdentity
+    from iris.rpc.auth import VerifiedIdentity, _verified_identity
 
     db = state._db
     now = Timestamp.now()
@@ -1208,7 +1210,7 @@ def test_register_allows_worker_role(state, mock_controller, tmp_path):
     """Worker-role user can call register()."""
     from iris.cluster.bundle import BundleStore
     from iris.cluster.controller.auth import ControllerAuth
-    from iris.rpc.auth import _verified_identity, VerifiedIdentity
+    from iris.rpc.auth import VerifiedIdentity, _verified_identity
 
     db = state._db
     now = Timestamp.now()

--- a/lib/iris/tests/cluster/controller/test_task_profiles.py
+++ b/lib/iris/tests/cluster/controller/test_task_profiles.py
@@ -6,7 +6,6 @@
 from pathlib import Path
 
 import pytest
-
 from iris.cluster.controller.db import (
     ControllerDB,
     get_task_profiles,

--- a/lib/iris/tests/cluster/controller/test_task_resource_history.py
+++ b/lib/iris/tests/cluster/controller/test_task_resource_history.py
@@ -17,7 +17,7 @@ from iris.cluster.controller.transitions import (
     TaskUpdate,
 )
 from iris.cluster.types import JobName, WorkerId
-from iris.rpc import job_pb2, controller_pb2
+from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Timestamp
 
 

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -12,16 +12,17 @@ They focus on:
 
 import threading
 
-
+from finelog.rpc import logging_pb2
 from iris.cluster.constraints import DeviceType, WellKnownAttribute, constraints_from_resources
-from iris.cluster.controller.codec import constraints_from_json, resource_spec_from_scalars
 from iris.cluster.controller.autoscaler.models import DemandEntry
+from iris.cluster.controller.codec import constraints_from_json, resource_spec_from_scalars
 from iris.cluster.controller.controller import compute_demand_entries
 from iris.cluster.controller.db import (
     ControllerDB,
     EndpointQuery,
     attempt_is_terminal,
 )
+from iris.cluster.controller.scheduler import JobRequirements, Scheduler
 from iris.cluster.controller.schema import (
     ATTEMPT_PROJECTION,
     JOB_DETAIL_PROJECTION,
@@ -29,41 +30,52 @@ from iris.cluster.controller.schema import (
     WORKER_DETAIL_PROJECTION,
     EndpointRow,
 )
-from iris.cluster.controller.scheduler import JobRequirements, Scheduler
 from iris.cluster.controller.stores import ControllerStore
 from iris.cluster.controller.transitions import (
+    MAX_REPLICAS_PER_JOB,
     Assignment,
     ControllerTransitions,
     HeartbeatApplyRequest,
-    MAX_REPLICAS_PER_JOB,
     PruneResult,
     TaskUpdate,
 )
 from iris.cluster.types import JobName, WorkerId
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
-from finelog.rpc import logging_pb2
+from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Duration, Timestamp
 
 from .conftest import (
     building_counts as _building_counts,
+)
+from .conftest import (
     check_task_can_be_scheduled,
     check_task_is_finished,
     dispatch_task,
     fail_worker,
     healthy_active_workers,
     make_job_request,
-    make_test_entrypoint as _make_test_entrypoint,
     make_worker_metadata,
-    query_job as _query_job,
-    query_task as _query_task,
-    query_tasks_for_job as _query_tasks_for_job,
-    query_worker as _query_worker,
     register_worker,
-    schedulable_tasks as _schedulable_tasks,
     submit_job,
     transition_task,
     worker_running_tasks,
+)
+from .conftest import (
+    make_test_entrypoint as _make_test_entrypoint,
+)
+from .conftest import (
+    query_job as _query_job,
+)
+from .conftest import (
+    query_task as _query_task,
+)
+from .conftest import (
+    query_tasks_for_job as _query_tasks_for_job,
+)
+from .conftest import (
+    query_worker as _query_worker,
+)
+from .conftest import (
+    schedulable_tasks as _schedulable_tasks,
 )
 
 # =============================================================================

--- a/lib/iris/tests/cluster/controller/test_vm_lifecycle.py
+++ b/lib/iris/tests/cluster/controller/test_vm_lifecycle.py
@@ -32,7 +32,6 @@ from collections.abc import Callable
 from contextlib import AbstractContextManager, nullcontext
 
 import pytest
-
 from iris.cluster.controller.vm_lifecycle import (
     _build_controller_vm_config,
     start_controller,

--- a/lib/iris/tests/cluster/controller/test_worker_health.py
+++ b/lib/iris/tests/cluster/controller/test_worker_health.py
@@ -9,7 +9,6 @@ Exercises the two independent termination paths:
 """
 
 import pytest
-
 from iris.cluster.controller.worker_health import WorkerHealthTracker
 from iris.cluster.types import WorkerId
 

--- a/lib/iris/tests/cluster/providers/conftest.py
+++ b/lib/iris/tests/cluster/providers/conftest.py
@@ -19,6 +19,8 @@ from iris.cluster.providers.types import (
     CommandResult,
     Labels,
     SliceStatus,
+)
+from iris.cluster.providers.types import (
     WorkerStatus as CloudWorkerStatus,
 )
 from iris.rpc import config_pb2, vm_pb2

--- a/lib/iris/tests/cluster/providers/gcp/test_bootstrap.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_bootstrap.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import pytest
-
 from iris.cluster.providers.gcp.bootstrap import (
     build_controller_bootstrap_script_from_config,
     build_worker_bootstrap_script,

--- a/lib/iris/tests/cluster/providers/gcp/test_cloud_service_integration.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_cloud_service_integration.py
@@ -18,7 +18,6 @@ from dataclasses import dataclass, field
 
 import httpx
 import pytest
-
 from iris.cluster.providers.gcp.service import (
     CloudGcpService,
     TpuCreateRequest,

--- a/lib/iris/tests/cluster/providers/gcp/test_gcp_service.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_gcp_service.py
@@ -16,16 +16,15 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from iris.cluster.providers.gcp.fake import InMemoryGcpService
 from iris.cluster.providers.gcp.service import (
     CloudGcpService,
     TpuCreateRequest,
     VmCreateRequest,
 )
-from iris.rpc import config_pb2
 from iris.cluster.providers.types import InfraError, QuotaExhaustedError, ResourceNotFoundError
 from iris.cluster.service_mode import ServiceMode
+from iris.rpc import config_pb2
 
 
 @pytest.fixture

--- a/lib/iris/tests/cluster/providers/gcp/test_platform.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_platform.py
@@ -15,17 +15,16 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 
 import pytest
-
 from iris.cluster.providers.gcp.controller import GcpControllerProvider
 from iris.cluster.providers.gcp.fake import InMemoryGcpService
 from iris.cluster.providers.gcp.handles import GcpVmSliceHandle, _build_gce_resource_name
-from iris.cluster.providers.remote_exec import DirectSshRemoteExec, GceRemoteExec, GcloudRemoteExec
 from iris.cluster.providers.gcp.workers import (
     GcpWorkerProvider,
     _run_vm_slice_bootstrap,
     _validate_slice_config,
 )
 from iris.cluster.providers.manual.provider import ManualControllerProvider, ManualWorkerProvider
+from iris.cluster.providers.remote_exec import DirectSshRemoteExec, GceRemoteExec, GcloudRemoteExec
 from iris.cluster.providers.types import (
     CloudSliceState,
     InfraError,

--- a/lib/iris/tests/cluster/providers/gcp/test_ssh.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_ssh.py
@@ -10,7 +10,6 @@ import threading
 from unittest.mock import patch
 
 import pytest
-
 from iris.cluster.providers.gcp.ssh import OsLoginKeyProvisioner, ssh_key_file, uses_os_login
 from iris.rpc import config_pb2
 

--- a/lib/iris/tests/cluster/providers/k8s/conftest.py
+++ b/lib/iris/tests/cluster/providers/k8s/conftest.py
@@ -6,20 +6,19 @@
 from __future__ import annotations
 
 import pytest
-
+from finelog.rpc import logging_pb2
+from finelog.server import LogServiceImpl
 from iris.cluster.controller.transitions import DirectProviderBatch
-from iris.cluster.runtime.env import build_common_iris_env
 from iris.cluster.providers.k8s.fake import InMemoryK8sService
-from iris.cluster.providers.k8s.types import K8sResource
 from iris.cluster.providers.k8s.tasks import (
-    K8sTaskProvider,
-    PodConfig,
     _LABEL_MANAGED,
     _LABEL_RUNTIME,
     _RUNTIME_LABEL_VALUE,
+    K8sTaskProvider,
+    PodConfig,
 )
-from finelog.server import LogServiceImpl
-from finelog.rpc import logging_pb2
+from iris.cluster.providers.k8s.types import K8sResource
+from iris.cluster.runtime.env import build_common_iris_env
 from iris.rpc import job_pb2
 
 

--- a/lib/iris/tests/cluster/providers/k8s/test_cloud_k8s_service.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_cloud_k8s_service.py
@@ -10,7 +10,6 @@ replaced the old _api_path_for_manifest and _api_path_for_resource functions.
 from __future__ import annotations
 
 import pytest
-
 from iris.cluster.providers.k8s.types import K8sResource
 
 

--- a/lib/iris/tests/cluster/providers/k8s/test_coreweave.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_coreweave.py
@@ -16,17 +16,16 @@ import threading
 import time
 
 import pytest
-
 from iris.cluster.providers.k8s.controller import (
-    K8sControllerProvider,
     _CONTROLLER_CPU_REQUEST,
     _CONTROLLER_MEMORY_REQUEST,
+    K8sControllerProvider,
 )
 from iris.cluster.providers.k8s.fake import InMemoryK8sService
 from iris.cluster.providers.k8s.types import K8sResource
 from iris.cluster.providers.types import (
-    Labels,
     InfraError,
+    Labels,
 )
 from iris.rpc import config_pb2
 

--- a/lib/iris/tests/cluster/providers/k8s/test_k8s_parsers.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_k8s_parsers.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import pytest
-
 from iris.cluster.providers.k8s.types import parse_k8s_cpu, parse_k8s_quantity
 
 

--- a/lib/iris/tests/cluster/providers/k8s/test_k8s_service.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_k8s_service.py
@@ -10,7 +10,6 @@ that matters to K8sTaskProvider and CoreWeave controller consumers.
 from __future__ import annotations
 
 import pytest
-
 from iris.cluster.providers.k8s.fake import FakeNodeResources, InMemoryK8sService
 from iris.cluster.providers.k8s.types import K8sResource, KubectlError
 

--- a/lib/iris/tests/cluster/providers/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_pod_manifest.py
@@ -6,7 +6,7 @@
 import json
 
 import pytest
-
+from iris.cluster.controller.transitions import RunningTaskEntry
 from iris.cluster.providers.k8s.tasks import (
     _INFRASTRUCTURE_FAILURE_REASONS,
     _LABEL_JOB_ID,
@@ -26,7 +26,6 @@ from iris.cluster.providers.k8s.tasks import (
     _task_update_from_pod,
 )
 from iris.cluster.providers.k8s.types import parse_k8s_quantity
-from iris.cluster.controller.transitions import RunningTaskEntry
 from iris.cluster.types import JobName
 from iris.rpc import job_pb2
 

--- a/lib/iris/tests/cluster/providers/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_provider.py
@@ -5,32 +5,30 @@
 
 from __future__ import annotations
 
-import pytest
-
-from iris.cluster.controller.transitions import ClusterCapacity, RunningTaskEntry, SchedulingEvent
 import time
 
-from iris.cluster.log_store_helpers import task_log_key
-from iris.cluster.types import TaskAttempt
-from finelog.server import LogServiceImpl
+import pytest
 from finelog.rpc import logging_pb2
+from finelog.server import LogServiceImpl
+from iris.cluster.controller.transitions import ClusterCapacity, RunningTaskEntry, SchedulingEvent
+from iris.cluster.log_store_helpers import task_log_key
 from iris.cluster.providers.k8s.tasks import (
-    K8sTaskProvider,
     _GC_MAX_AGE_SECONDS,
     _LABEL_JOB_ID,
     _LABEL_MANAGED,
     _LABEL_RUNTIME,
     _LABEL_TASK_HASH,
-    _LogPod,
     _MANAGED_POD_LABELS,
     _POD_NOT_FOUND_GRACE_CYCLES,
     _RUNTIME_LABEL_VALUE,
+    K8sTaskProvider,
+    _LogPod,
     _pod_name,
     _sanitize_label_value,
     _task_hash,
 )
 from iris.cluster.providers.k8s.types import ExecResult, K8sResource, PodResourceUsage
-from iris.cluster.types import JobName
+from iris.cluster.types import JobName, TaskAttempt
 from iris.rpc import job_pb2
 
 from .conftest import make_batch, make_run_req, populate_node, populate_pod, populate_running_pod_resource
@@ -953,7 +951,7 @@ def _seed_configmap(k8s, name: str, task_hash: str, created: str) -> None:
 
 
 def test_gc_deletes_old_terminal_pods_and_configmaps(provider, k8s):
-    from datetime import datetime, timezone, timedelta
+    from datetime import datetime, timedelta, timezone
 
     now = datetime.now(timezone.utc)
     old_ts = (now - timedelta(seconds=_GC_MAX_AGE_SECONDS + 600)).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -987,7 +985,7 @@ def test_gc_deletes_old_terminal_pods_and_configmaps(provider, k8s):
 
 def test_gc_respects_interval(provider, k8s):
     """_maybe_gc_terminal_resources should only run every _GC_INTERVAL_SECONDS."""
-    from datetime import datetime, timezone, timedelta
+    from datetime import datetime, timedelta, timezone
 
     now = datetime.now(timezone.utc)
     old_ts = (now - timedelta(seconds=_GC_MAX_AGE_SECONDS + 600)).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -1071,7 +1069,7 @@ def test_gc_skips_hashes_with_active_pods(provider, k8s):
     terminal (old) and attempt 1 is still Running, deleting by task_hash would
     remove the active attempt's configmap and PDB protection.
     """
-    from datetime import datetime, timezone, timedelta
+    from datetime import datetime, timedelta, timezone
 
     now = datetime.now(timezone.utc)
     old_ts = (now - timedelta(seconds=_GC_MAX_AGE_SECONDS + 600)).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -1157,9 +1155,10 @@ def test_log_collector_set_pods_adds_and_removes(k8s, log_pusher):
 
 def test_log_collector_set_pods_preserves_cursor_state(k8s, log_pusher):
     """set_pods() preserves last_timestamp for pods that remain tracked."""
+    from datetime import datetime, timezone
+
     from iris.cluster.providers.k8s.tasks import LogCollector
     from iris.cluster.types import JobName
-    from datetime import datetime, timezone
 
     collector = LogCollector(k8s, log_pusher, concurrency=1)
     task_id = JobName.from_wire("/job/0")

--- a/lib/iris/tests/cluster/providers/test_config.py
+++ b/lib/iris/tests/cluster/providers/test_config.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import pytest
 import yaml
-
 from iris.cluster.config import (
     config_to_dict,
     connect_cluster,
@@ -21,10 +20,9 @@ from iris.cluster.config import (
     make_local_config,
     validate_config,
 )
-from iris.cluster.providers.factory import create_provider_bundle
 from iris.cluster.constraints import WellKnownAttribute
-from iris.rpc import config_pb2
-from iris.rpc import controller_pb2
+from iris.cluster.providers.factory import create_provider_bundle
+from iris.rpc import config_pb2, controller_pb2
 from iris.rpc.controller_connect import ControllerServiceClientSync
 from iris.time_proto import duration_to_proto
 from rigging.timing import Duration, ExponentialBackoff

--- a/lib/iris/tests/cluster/providers/test_scaling_group.py
+++ b/lib/iris/tests/cluster/providers/test_scaling_group.py
@@ -26,6 +26,7 @@ from iris.cluster.providers.types import (
 from iris.cluster.types import WorkerStatus
 from iris.rpc import config_pb2, vm_pb2
 from rigging.timing import Duration, Timestamp
+
 from tests.cluster.providers.conftest import (
     FakeSliceHandle,
     FakeWorkerHandle,

--- a/lib/iris/tests/cluster/runtime/test_docker_runtime.py
+++ b/lib/iris/tests/cluster/runtime/test_docker_runtime.py
@@ -9,7 +9,6 @@ import subprocess
 from unittest.mock import Mock
 
 import pytest
-
 from iris.cluster.bundle import BundleStore
 from iris.cluster.runtime.docker import DockerRuntime
 from iris.cluster.runtime.types import MountKind, MountSpec

--- a/lib/iris/tests/cluster/runtime/test_entrypoint.py
+++ b/lib/iris/tests/cluster/runtime/test_entrypoint.py
@@ -4,9 +4,8 @@
 """Tests for entrypoint construction and bash script generation."""
 
 import pytest
-
-from iris.cluster.types import Entrypoint
 from iris.cluster.runtime.entrypoint import build_runtime_entrypoint, runtime_entrypoint_to_bash_script
+from iris.cluster.types import Entrypoint
 from iris.rpc import job_pb2
 
 

--- a/lib/iris/tests/cluster/runtime/test_env_parity.py
+++ b/lib/iris/tests/cluster/runtime/test_env_parity.py
@@ -12,7 +12,6 @@ before the shared function was introduced.
 import json
 
 import pytest
-
 from iris.cluster.providers.k8s.tasks import PodConfig, _build_pod_manifest
 from iris.cluster.runtime.env import build_common_iris_env
 from iris.rpc import job_pb2

--- a/lib/iris/tests/cluster/test_attempt_logs.py
+++ b/lib/iris/tests/cluster/test_attempt_logs.py
@@ -7,8 +7,7 @@ Verifies that task status correctly records multiple attempts after
 failure + retry, using the ServiceTestHarness (parameterized GCP + K8s).
 """
 
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import controller_pb2, job_pb2
 
 from .conftest import ServiceTestHarness
 

--- a/lib/iris/tests/cluster/test_client.py
+++ b/lib/iris/tests/cluster/test_client.py
@@ -9,10 +9,8 @@ both GCP and K8s providers via the ServiceTestHarness.
 
 import pytest
 from connectrpc.errors import ConnectError
-
 from iris.cluster.types import JobName
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import controller_pb2, job_pb2
 
 from .conftest import ServiceTestHarness
 

--- a/lib/iris/tests/cluster/test_constraints.py
+++ b/lib/iris/tests/cluster/test_constraints.py
@@ -4,28 +4,26 @@
 """Tests for the ConstraintDescriptor registry and constraint evaluation."""
 
 import pytest
-
 from iris.cluster.constraints import (
+    INHERITED_CONSTRAINT_KEYS,
     AttributeValue,
     Constraint,
     ConstraintIndex,
     ConstraintOp,
     DeviceType,
-    INHERITED_CONSTRAINT_KEYS,
     PlacementRequirements,
     WellKnownAttribute,
     evaluate_constraint,
+    extract_placement_requirements,
     infer_preemptible_constraint,
     is_cpu_device_type_constraint,
     looks_like_executor,
     merge_constraints,
-    extract_placement_requirements,
     preemptible_constraint,
     routing_constraints,
     soft_constraint_score,
     split_hard_soft,
 )
-
 from iris.rpc import job_pb2
 
 from .conftest import eq_constraint, in_constraint

--- a/lib/iris/tests/cluster/test_endpoints.py
+++ b/lib/iris/tests/cluster/test_endpoints.py
@@ -10,7 +10,6 @@ import subprocess
 from unittest.mock import mock_open, patch
 
 import pytest
-
 from iris.cluster import endpoints
 from iris.cluster.endpoints import register_scheme, resolve_endpoint_uri
 

--- a/lib/iris/tests/cluster/test_env_propagation.py
+++ b/lib/iris/tests/cluster/test_env_propagation.py
@@ -16,7 +16,6 @@ from dataclasses import dataclass, field
 from unittest.mock import patch
 
 import pytest
-
 from iris.client import IrisClient, IrisContext, iris_ctx_scope
 from iris.cluster.client.job_info import JobInfo
 from iris.cluster.constraints import Constraint, ConstraintOp, WellKnownAttribute

--- a/lib/iris/tests/cluster/test_types.py
+++ b/lib/iris/tests/cluster/test_types.py
@@ -4,7 +4,6 @@
 """Tests for iris.cluster.types — Entrypoint, EnvironmentSpec, and constraint helpers."""
 
 import pytest
-
 from iris.cluster.constraints import (
     Constraint,
     ConstraintOp,

--- a/lib/iris/tests/cluster/worker/conftest.py
+++ b/lib/iris/tests/cluster/worker/conftest.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass, field
 from unittest.mock import Mock
 
 import pytest
-
 from iris.cluster.bundle import BundleStore
 from iris.cluster.runtime.docker import DockerRuntime
 from iris.cluster.runtime.types import ContainerPhase, ContainerStats, ContainerStatus

--- a/lib/iris/tests/cluster/worker/test_bundle_store.py
+++ b/lib/iris/tests/cluster/worker/test_bundle_store.py
@@ -8,7 +8,6 @@ import io
 import zipfile
 
 import pytest
-
 from iris.cluster.bundle import BundleStore
 
 

--- a/lib/iris/tests/cluster/worker/test_dashboard.py
+++ b/lib/iris/tests/cluster/worker/test_dashboard.py
@@ -9,17 +9,16 @@ import pytest
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from connectrpc.request import RequestContext
-
 from iris.cluster.types import JobName
 from iris.cluster.worker.dashboard import WorkerDashboard
 from iris.cluster.worker.service import WorkerServiceImpl
 from iris.cluster.worker.worker import Worker, WorkerConfig
-from iris.rpc import job_pb2
-from iris.rpc import worker_pb2
+from iris.rpc import job_pb2, worker_pb2
+from iris.test_util import wait_for_condition
 from rigging.timing import Duration
 from starlette.testclient import TestClient
+
 from tests.cluster.worker.conftest import create_run_task_request
-from iris.test_util import wait_for_condition
 
 pytestmark = pytest.mark.timeout(10)
 

--- a/lib/iris/tests/cluster/worker/test_env_probe.py
+++ b/lib/iris/tests/cluster/worker/test_env_probe.py
@@ -6,9 +6,8 @@
 import sys
 import time
 
-import pytest
-
 import iris.cluster.worker.env_probe as env_probe
+import pytest
 from iris.cluster.constraints import WellKnownAttribute
 from iris.cluster.worker.env_probe import (
     DefaultEnvironmentProvider,

--- a/lib/iris/tests/cluster/worker/test_worker.py
+++ b/lib/iris/tests/cluster/worker/test_worker.py
@@ -11,7 +11,6 @@ from unittest.mock import Mock
 
 import pytest
 from connectrpc.request import RequestContext
-
 from iris.cluster.runtime.docker import DockerRuntime
 from iris.cluster.runtime.types import (
     ContainerErrorKind,
@@ -22,21 +21,21 @@ from iris.cluster.runtime.types import (
     ExecutionStage,
 )
 from iris.cluster.types import Entrypoint, JobName
-from iris.cluster.worker.task_attempt import TaskAttempt
 from iris.cluster.worker.port_allocator import PortAllocator
 from iris.cluster.worker.service import WorkerServiceImpl
+from iris.cluster.worker.task_attempt import TaskAttempt
 from iris.cluster.worker.worker import Worker, WorkerConfig
-from iris.rpc import job_pb2
-from iris.rpc import worker_pb2
-from rigging.timing import Duration
 from iris.cluster.worker.worker_types import LogLine
+from iris.rpc import job_pb2, worker_pb2
+from iris.test_util import wait_for_condition
+from rigging.timing import Duration
+
 from tests.cluster.worker.conftest import (
     FakeContainerHandle,
     FakeLogReader,
     create_mock_container_handle,
     create_run_task_request,
 )
-from iris.test_util import wait_for_condition
 
 pytestmark = pytest.mark.timeout(10)
 

--- a/lib/iris/tests/conftest.py
+++ b/lib/iris/tests/conftest.py
@@ -7,11 +7,11 @@ import logging
 import os
 import subprocess
 import sys
-from pathlib import Path
 import threading
 import time
 import traceback
 import warnings
+from pathlib import Path
 
 import pytest
 from iris.cluster.config import load_config, make_local_config

--- a/lib/iris/tests/e2e/_docker_cluster.py
+++ b/lib/iris/tests/e2e/_docker_cluster.py
@@ -14,22 +14,21 @@ import time
 import uuid
 from collections.abc import Callable
 from pathlib import Path
+
+from finelog.rpc import logging_pb2
+from finelog.rpc.logging_connect import LogServiceClientSync
 from iris.client import IrisClient
+from iris.cluster.bundle import BundleStore
 from iris.cluster.controller.controller import Controller, ControllerConfig
 from iris.cluster.controller.worker_provider import RpcWorkerStubFactory, WorkerProvider
 from iris.cluster.providers.local.cluster import LocalCluster
 from iris.cluster.providers.types import find_free_port
 from iris.cluster.runtime.docker import DockerRuntime
 from iris.cluster.types import Entrypoint, EnvironmentSpec, JobName, ResourceSpec
-from iris.cluster.bundle import BundleStore
 from iris.cluster.worker.env_probe import EnvironmentProvider
 from iris.cluster.worker.worker import Worker, WorkerConfig
-from finelog.rpc import logging_pb2
-from iris.rpc import config_pb2
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import config_pb2, controller_pb2, job_pb2
 from iris.rpc.controller_connect import ControllerServiceClientSync
-from finelog.rpc.logging_connect import LogServiceClientSync
 from iris.time_proto import duration_to_proto
 from rigging.timing import Duration
 

--- a/lib/iris/tests/e2e/benchmark_controller.py
+++ b/lib/iris/tests/e2e/benchmark_controller.py
@@ -43,11 +43,9 @@ import psutil
 from iris.client.client import IrisClient, Job, ResourceSpec
 from iris.cluster.config import connect_cluster, load_config, make_local_config
 from iris.cluster.types import Entrypoint, EnvironmentSpec, get_tpu_topology, tpu_device
-from rigging.log_setup import configure_logging
-from iris.rpc import config_pb2
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import config_pb2, controller_pb2, job_pb2
 from iris.rpc.controller_connect import ControllerServiceClientSync
+from rigging.log_setup import configure_logging
 
 logger = logging.getLogger(__name__)
 

--- a/lib/iris/tests/e2e/conftest.py
+++ b/lib/iris/tests/e2e/conftest.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
+from finelog.rpc import logging_pb2
+from finelog.rpc.logging_connect import LogServiceClientSync
 from iris.chaos import reset_chaos
 from iris.client.client import IrisClient, Job
 from iris.cluster.config import connect_cluster, load_config, make_local_config
@@ -36,12 +38,8 @@ from iris.cluster.types import (
     ResourceSpec,
     is_job_finished,
 )
-from finelog.rpc import logging_pb2
-from iris.rpc import config_pb2
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import config_pb2, controller_pb2, job_pb2
 from iris.rpc.controller_connect import ControllerServiceClientSync
-from finelog.rpc.logging_connect import LogServiceClientSync
 from rigging.timing import Duration
 
 from .chronos import VirtualClock

--- a/lib/iris/tests/e2e/test_chaos.py
+++ b/lib/iris/tests/e2e/test_chaos.py
@@ -21,11 +21,10 @@ import time
 
 import pytest
 from iris.chaos import enable_chaos, reset_chaos
-from iris.cluster.controller.worker_health import PING_FAILURE_THRESHOLD
 from iris.cluster.constraints import WellKnownAttribute
+from iris.cluster.controller.worker_health import PING_FAILURE_THRESHOLD
 from iris.cluster.types import CoschedulingConfig
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import controller_pb2, job_pb2
 from iris.test_util import SentinelFile
 from rigging.timing import Duration
 

--- a/lib/iris/tests/e2e/test_cli.py
+++ b/lib/iris/tests/e2e/test_cli.py
@@ -19,10 +19,9 @@ import yaml
 from click.testing import CliRunner
 from iris.cli import iris
 from iris.client import IrisClient
-from iris.cluster.types import Entrypoint, ResourceSpec
 from iris.cluster.providers.local.cluster import LocalCluster
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.cluster.types import Entrypoint, ResourceSpec
+from iris.rpc import controller_pb2, job_pb2
 from iris.rpc.controller_connect import ControllerServiceClientSync
 
 pytestmark = pytest.mark.e2e

--- a/lib/iris/tests/e2e/test_demo_notebook.py
+++ b/lib/iris/tests/e2e/test_demo_notebook.py
@@ -9,9 +9,9 @@ from pathlib import Path
 
 import pytest
 from iris.client import IrisClient
-from iris.cluster.types import Entrypoint, ResourceSpec
 from iris.cluster.config import IrisConfig
 from iris.cluster.providers.local.cluster import LocalCluster
+from iris.cluster.types import Entrypoint, ResourceSpec
 from iris.rpc import config_pb2
 
 pytestmark = pytest.mark.e2e

--- a/lib/iris/tests/e2e/test_docker.py
+++ b/lib/iris/tests/e2e/test_docker.py
@@ -14,8 +14,7 @@ from pathlib import Path
 import pytest
 from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec
 from iris.cluster.worker.env_probe import FixedEnvironmentProvider, HardwareProbe, build_worker_metadata
-from iris.rpc import config_pb2
-from iris.rpc import job_pb2
+from iris.rpc import config_pb2, job_pb2
 
 from tests.e2e._docker_cluster import E2ECluster
 

--- a/lib/iris/tests/e2e/test_env_propagation.py
+++ b/lib/iris/tests/e2e/test_env_propagation.py
@@ -13,7 +13,6 @@ import json
 from unittest.mock import patch
 
 import pytest
-
 from iris.client import IrisContext, iris_ctx_scope
 from iris.client.client import IrisClient, LocalClientConfig
 from iris.cluster.client.job_info import JobInfo

--- a/lib/iris/tests/e2e/test_iris_run.py
+++ b/lib/iris/tests/e2e/test_iris_run.py
@@ -10,9 +10,8 @@ from pathlib import Path
 
 import pytest
 import yaml
-
-from iris.client import IrisClient
 from iris.cli.job import load_env_vars, run_iris_job
+from iris.client import IrisClient
 from iris.cluster.config import connect_cluster, load_config, make_local_config
 
 pytestmark = pytest.mark.e2e

--- a/lib/iris/tests/e2e/test_local_client.py
+++ b/lib/iris/tests/e2e/test_local_client.py
@@ -8,10 +8,9 @@ import re
 import time
 
 import pytest
-
+from finelog.rpc import logging_pb2
 from iris.client.client import IrisClient, Job
 from iris.cluster.types import Entrypoint, EnvironmentSpec, JobName
-from finelog.rpc import logging_pb2
 from iris.rpc import job_pb2
 
 pytestmark = pytest.mark.e2e

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 import pytest
 from connectrpc.errors import ConnectError
+from finelog.rpc import logging_pb2
+from finelog.rpc.logging_connect import LogServiceClientSync
 from iris.client.client import IrisClient
 from iris.cluster.config import connect_cluster, load_config, make_local_config
 from iris.cluster.constraints import Constraint, ConstraintOp, WellKnownAttribute, region_constraint
@@ -26,12 +28,8 @@ from iris.cluster.types import (
     ResourceSpec,
     gpu_device,
 )
-from finelog.rpc import logging_pb2
-from iris.rpc import config_pb2
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import config_pb2, controller_pb2, job_pb2
 from iris.rpc.controller_connect import ControllerServiceClientSync
-from finelog.rpc.logging_connect import LogServiceClientSync
 from rigging.timing import Duration, ExponentialBackoff
 
 from .conftest import (
@@ -39,8 +37,8 @@ from .conftest import (
     MARIN_ROOT,
     ClusterCapabilities,
     IrisTestCluster,
-    _NoOpPage,
     _add_coscheduling_group,
+    _NoOpPage,
     assert_visible,
     dashboard_goto,
     discover_capabilities,

--- a/lib/iris/tests/rpc/test_auth.py
+++ b/lib/iris/tests/rpc/test_auth.py
@@ -7,7 +7,6 @@ import pytest
 from connectrpc._headers import Headers
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
-
 from iris.rpc.auth import (
     AuthInterceptor,
     AuthTokenInjector,

--- a/lib/iris/tests/rpc/test_errors.py
+++ b/lib/iris/tests/rpc/test_errors.py
@@ -5,7 +5,6 @@
 import pytest
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
-
 from iris.rpc.errors import (
     call_with_retry,
     connect_error_sanitized,

--- a/lib/iris/tests/rpc/test_interceptors.py
+++ b/lib/iris/tests/rpc/test_interceptors.py
@@ -10,7 +10,6 @@ from unittest.mock import Mock
 import pytest
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
-
 from iris.rpc.errors import extract_error_details
 from iris.rpc.interceptors import ConcurrencyLimitInterceptor, RequestTimingInterceptor
 

--- a/lib/iris/tests/test_auth.py
+++ b/lib/iris/tests/test_auth.py
@@ -5,8 +5,7 @@
 import pytest
 from iris.cluster.providers.local.cluster import LocalCluster
 from iris.cluster.types import Entrypoint, ResourceSpec
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import controller_pb2, job_pb2
 from iris.rpc.controller_connect import ControllerServiceClientSync
 
 from .conftest import _make_controller_only_config

--- a/lib/iris/tests/test_budget.py
+++ b/lib/iris/tests/test_budget.py
@@ -7,7 +7,7 @@ and the admin API RPCs that expose them."""
 import pytest
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
-
+from finelog.server import LogServiceImpl
 from iris.cluster.bundle import BundleStore
 from iris.cluster.controller.auth import ControllerAuth
 from iris.cluster.controller.budget import (
@@ -21,7 +21,6 @@ from iris.cluster.controller.budget import (
 from iris.cluster.controller.service import ControllerServiceImpl
 from iris.cluster.controller.transitions import Assignment, HeartbeatApplyRequest, TaskUpdate
 from iris.cluster.types import JobName, WorkerId
-from finelog.server import LogServiceImpl
 from iris.rpc import controller_pb2, job_pb2
 from iris.rpc.auth import VerifiedIdentity, _verified_identity
 from iris.rpc.proto_utils import PRIORITY_BAND_VALUES, priority_band_name, priority_band_value

--- a/lib/iris/tests/test_checkpoint_restore.py
+++ b/lib/iris/tests/test_checkpoint_restore.py
@@ -2,17 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 """Checkpoint/restore test for Iris controller."""
 
-from pathlib import Path
-
 import time
+from pathlib import Path
 
 import pytest
 from iris.client.client import IrisClient, Job
 from iris.cluster.config import load_config, make_local_config
 from iris.cluster.providers.local.cluster import LocalCluster
 from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec, is_job_finished
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import controller_pb2, job_pb2
 from iris.rpc.controller_connect import ControllerServiceClientSync
 
 IRIS_ROOT = Path(__file__).resolve().parents[1]

--- a/lib/iris/tests/test_dev_tpu.py
+++ b/lib/iris/tests/test_dev_tpu.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
 from iris.dev_tpu import DevTpuState, DevTpuWorker, GcpNodeRef, parse_worker_host
 
 

--- a/lib/iris/tests/test_distributed_lock.py
+++ b/lib/iris/tests/test_distributed_lock.py
@@ -7,7 +7,6 @@ import time
 from unittest.mock import patch
 
 import pytest
-
 from rigging.distributed_lock import (
     HEARTBEAT_TIMEOUT,
     GcsLease,

--- a/lib/iris/tests/test_env_resources.py
+++ b/lib/iris/tests/test_env_resources.py
@@ -7,7 +7,6 @@ import os
 
 import pytest
 from google.protobuf import json_format
-
 from iris.env_resources import TaskResources, _read_iris_resource_proto, _read_proc_meminfo_total
 from iris.rpc import job_pb2
 

--- a/lib/iris/tests/test_iris_run.py
+++ b/lib/iris/tests/test_iris_run.py
@@ -6,7 +6,6 @@
 import sys
 
 import pytest
-
 from iris.cli.job import (
     build_resources,
     load_env_vars,

--- a/lib/iris/tests/test_jax_init.py
+++ b/lib/iris/tests/test_jax_init.py
@@ -10,7 +10,7 @@ import pytest
 
 pytest.importorskip("jax")
 
-from iris.actor.resolver import ResolveResult, ResolvedEndpoint
+from iris.actor.resolver import ResolvedEndpoint, ResolveResult
 from iris.cluster.client.job_info import JobInfo
 from iris.cluster.types import JobName
 from iris.runtime.jax_init import _poll_for_coordinator, initialize_jax

--- a/lib/iris/tests/test_jax_init_integration.py
+++ b/lib/iris/tests/test_jax_init_integration.py
@@ -27,7 +27,7 @@ import pytest
 
 pytest.importorskip("jax")
 
-from iris.actor.resolver import ResolveResult, ResolvedEndpoint
+from iris.actor.resolver import ResolvedEndpoint, ResolveResult
 from iris.cluster.client.job_info import JobInfo
 from iris.cluster.types import JobName
 from iris.runtime.jax_init import _poll_for_coordinator, initialize_jax

--- a/lib/iris/tests/test_logging.py
+++ b/lib/iris/tests/test_logging.py
@@ -4,7 +4,6 @@
 import logging
 
 import pytest
-
 from rigging.log_setup import (
     BufferedLogRecord,
     LevelPrefixFormatter,

--- a/lib/iris/tests/test_marin_fs.py
+++ b/lib/iris/tests/test_marin_fs.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from rigging.filesystem import (
     MARIN_CROSS_REGION_OVERRIDE_ENV,
     CrossRegionGuardedFS,

--- a/lib/iris/tests/test_utils.py
+++ b/lib/iris/tests/test_utils.py
@@ -8,7 +8,6 @@ import time
 from pathlib import Path
 
 import pytest
-
 from iris.test_util import SentinelFile, wait_for_condition
 from rigging.timing import Duration
 

--- a/lib/iris/tests/test_version.py
+++ b/lib/iris/tests/test_version.py
@@ -7,7 +7,6 @@ import re
 import subprocess
 
 import pytest
-
 from iris import version as iris_version
 
 

--- a/lib/marin/src/marin/datakit/download/ar5iv.py
+++ b/lib/marin/src/marin/datakit/download/ar5iv.py
@@ -14,10 +14,11 @@ from dataclasses import dataclass
 
 import draccus
 from rigging.filesystem import open_url
-from marin.execution.step_spec import StepSpec
+from rigging.log_setup import configure_logging
 from zephyr import Dataset, ZephyrContext
 from zephyr.writers import atomic_rename
-from rigging.log_setup import configure_logging
+
+from marin.execution.step_spec import StepSpec
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/datakit/download/common_corpus.py
+++ b/lib/marin/src/marin/datakit/download/common_corpus.py
@@ -6,11 +6,11 @@
 import os
 
 from fray import ResourceConfig
+from zephyr import Dataset, ZephyrContext, counters
 
 from marin.datakit.download.huggingface import download_hf_step
 from marin.datakit.normalize import normalize_step
 from marin.execution.step_spec import StepSpec
-from zephyr import Dataset, ZephyrContext, counters
 
 HF_DATASET_ID = "PleIAs/common_corpus"
 OPEN_TYPES = ["Open Science", "Open Government", "Open Culture"]

--- a/lib/marin/src/marin/datakit/download/huggingface.py
+++ b/lib/marin/src/marin/datakit/download/huggingface.py
@@ -15,15 +15,16 @@ import time
 from dataclasses import dataclass, field
 
 import huggingface_hub
-from rigging.filesystem import open_url, url_to_fs
 from huggingface_hub.errors import HfHubHTTPError
 from packaging.version import Version
+from rigging.filesystem import open_url, url_to_fs
+from rigging.log_setup import configure_logging
+from zephyr import Dataset, ZephyrContext
+from zephyr.writers import atomic_rename
+
 from marin.execution.executor import THIS_OUTPUT_PATH
 from marin.execution.step_spec import StepSpec
 from marin.utilities.validation_utils import write_provenance_json
-from zephyr import Dataset, ZephyrContext
-from zephyr.writers import atomic_rename
-from rigging.log_setup import configure_logging
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/datakit/download/nemotron_terminal.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_terminal.py
@@ -14,8 +14,8 @@ from fray import ResourceConfig
 from zephyr import Dataset, ZephyrContext, counters
 
 from marin.datakit.download.huggingface import download_hf_step
-from marin.datakit.normalize import normalize_step
 from marin.datakit.download.rollout_transforms import load_parquet_batched
+from marin.datakit.normalize import normalize_step
 from marin.execution.step_spec import StepSpec
 
 HF_DATASET_ID = "nvidia/Nemotron-Terminal-Corpus"

--- a/lib/marin/src/marin/datakit/download/nemotron_v1.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_v1.py
@@ -10,15 +10,16 @@ from collections.abc import Iterator
 
 import requests
 import zstandard
-from rigging.filesystem import open_url
-from marin.datakit.normalize import normalize_step
-from marin.execution.step_spec import StepSpec
-from marin.utils import fsspec_exists
 from fray.cluster import ResourceConfig
 from requests.adapters import HTTPAdapter
+from rigging.filesystem import open_url
 from urllib3.util import Retry
 from zephyr import Dataset, ZephyrContext
 from zephyr.writers import atomic_rename
+
+from marin.datakit.normalize import normalize_step
+from marin.execution.step_spec import StepSpec
+from marin.utils import fsspec_exists
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/datakit/download/nsf_awards.py
+++ b/lib/marin/src/marin/datakit/download/nsf_awards.py
@@ -15,10 +15,11 @@ import zipfile
 from io import BytesIO
 
 import requests
-from marin.datakit.normalize import normalize_step
-from marin.execution.step_spec import StepSpec
 from zephyr import Dataset, ZephyrContext, counters
 from zephyr.writers import write_parquet_file
+
+from marin.datakit.normalize import normalize_step
+from marin.execution.step_spec import StepSpec
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/datakit/download/superior_reasoning.py
+++ b/lib/marin/src/marin/datakit/download/superior_reasoning.py
@@ -14,8 +14,8 @@ from zephyr import Dataset, ZephyrContext, counters
 from zephyr.readers import load_jsonl
 
 from marin.datakit.download.huggingface import download_hf_step
-from marin.datakit.normalize import normalize_step
 from marin.datakit.download.rollout_transforms import strip_think_tags
+from marin.datakit.normalize import normalize_step
 from marin.execution.step_spec import StepSpec
 
 HF_DATASET_ID = "Alibaba-Apsara/Superior-Reasoning-SFT-gpt-oss-120b"

--- a/lib/marin/src/marin/datakit/download/swe_rebench_openhands.py
+++ b/lib/marin/src/marin/datakit/download/swe_rebench_openhands.py
@@ -14,8 +14,8 @@ from fray import ResourceConfig
 from zephyr import Dataset, ZephyrContext, counters
 
 from marin.datakit.download.huggingface import download_hf_step
-from marin.datakit.normalize import normalize_step
 from marin.datakit.download.rollout_transforms import load_parquet_batched
+from marin.datakit.normalize import normalize_step
 from marin.execution.step_spec import StepSpec
 
 HF_DATASET_ID = "nebius/SWE-rebench-openhands-trajectories"

--- a/lib/marin/src/marin/datakit/download/synthetic1.py
+++ b/lib/marin/src/marin/datakit/download/synthetic1.py
@@ -13,8 +13,8 @@ from fray import ResourceConfig
 from zephyr import Dataset, ZephyrContext, counters, load_parquet
 
 from marin.datakit.download.huggingface import download_hf_step
-from marin.datakit.normalize import normalize_step
 from marin.datakit.download.rollout_transforms import strip_think_tags
+from marin.datakit.normalize import normalize_step
 from marin.execution.step_spec import StepSpec
 
 HF_DATASET_ID = "PrimeIntellect/SYNTHETIC-1"

--- a/lib/marin/src/marin/datakit/download/uncheatable_eval.py
+++ b/lib/marin/src/marin/datakit/download/uncheatable_eval.py
@@ -15,14 +15,15 @@ from dataclasses import dataclass
 from typing import Any
 
 import requests
-from rigging.filesystem import open_url
-from marin.execution import THIS_OUTPUT_PATH, ExecutorStep, VersionedValue
-from marin.execution.step_spec import StepSpec
-from marin.utils import fsspec_mkdirs
 from requests.adapters import HTTPAdapter
+from rigging.filesystem import open_url
 from urllib3.util import Retry
 from zephyr import Dataset, ZephyrContext
 from zephyr.writers import atomic_rename
+
+from marin.execution import THIS_OUTPUT_PATH, ExecutorStep, VersionedValue
+from marin.execution.step_spec import StepSpec
+from marin.utils import fsspec_mkdirs
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/datakit/download/wikipedia.py
+++ b/lib/marin/src/marin/datakit/download/wikipedia.py
@@ -17,10 +17,11 @@ from collections.abc import Iterable
 
 import requests
 from rigging.filesystem import open_url
-from marin.execution.step_spec import StepSpec
-from marin.utils import fsspec_size
 from tqdm_loggable.auto import tqdm
 from zephyr import Dataset, ZephyrContext, atomic_rename, load_jsonl
+
+from marin.execution.step_spec import StepSpec
+from marin.utils import fsspec_size
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/evaluation/evaluators/evalchemy_evaluator.py
+++ b/lib/marin/src/marin/evaluation/evaluators/evalchemy_evaluator.py
@@ -32,12 +32,13 @@ import sys
 import traceback
 from collections.abc import Sequence
 from typing import ClassVar
+
 from rigging.filesystem import filesystem as marin_filesystem
 
 from marin.evaluation.evaluation_config import WANDB_PROJECT, EvalTaskConfig
 from marin.evaluation.evaluators.evaluator import Evaluator, ModelConfig
-from marin.inference.vllm_server import resolve_model_name_or_path
 from marin.evaluation.utils import is_remote_path, upload_to_gcs
+from marin.inference.vllm_server import resolve_model_name_or_path
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/evaluation/evaluators/levanter_lm_eval_evaluator.py
+++ b/lib/marin/src/marin/evaluation/evaluators/levanter_lm_eval_evaluator.py
@@ -7,12 +7,12 @@ import logging
 import os
 
 import jmp
-from rigging.filesystem import filesystem as marin_filesystem
 import levanter
 import levanter.eval_harness as eval_harness
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
+from rigging.filesystem import filesystem as marin_filesystem
 
 from marin.evaluation.evaluation_config import EvalTaskConfig, convert_to_levanter_task_config
 from marin.evaluation.evaluators.evaluator import Evaluator, ModelConfig

--- a/lib/marin/src/marin/evaluation/perplexity_gap.py
+++ b/lib/marin/src/marin/evaluation/perplexity_gap.py
@@ -14,13 +14,17 @@ from levanter.analysis.perplexity_gap import write_report_files
 from levanter.data.text import DatasetComponent, HfDatasetSourceConfig, TextLmDatasetFormat, UrlDatasetSourceConfig
 from levanter.main.perplexity_gap import (
     GapFinderModelConfig as LevanterGapFinderModelConfig,
+)
+from levanter.main.perplexity_gap import (
     ModelPerplexityConfig as LevanterModelPerplexityConfig,
+)
+from levanter.main.perplexity_gap import (
     score_main,
 )
 from levanter.models.lm_model import LmConfig
 from levanter.tokenizers import TokenizerBackend
-from levanter.trainer import TrainerConfig
 from levanter.tracker.wandb import WandbConfig
+from levanter.trainer import TrainerConfig
 
 from marin.execution.executor import ExecutorStep, InputName, VersionedValue, this_output_path, versioned
 from marin.processing.tokenize import HfDatasetSpec

--- a/lib/marin/src/marin/evaluation/run.py
+++ b/lib/marin/src/marin/evaluation/run.py
@@ -17,8 +17,8 @@ import time
 import draccus
 
 from marin.evaluation.evaluation_config import EvaluationConfig
-from marin.evaluation.evaluators.evaluator import Evaluator, ModelConfig
 from marin.evaluation.evaluators.evalchemy_evaluator import EvalchemyEvaluator
+from marin.evaluation.evaluators.evaluator import Evaluator, ModelConfig
 from marin.evaluation.evaluators.harbor_evaluator import HarborEvaluator
 from marin.evaluation.evaluators.levanter_lm_eval_evaluator import LevanterLmEvalEvaluator
 from marin.evaluation.evaluators.lm_evaluation_harness_evaluator import LMEvaluationHarnessEvaluator

--- a/lib/marin/src/marin/evaluation/save_logprobs.py
+++ b/lib/marin/src/marin/evaluation/save_logprobs.py
@@ -19,17 +19,16 @@ from dataclasses import dataclass, field, replace
 
 import equinox as eqx
 import fsspec
-import jax
-
-import jmp
-import numpy as np
-from jax.experimental import multihost_utils
-
 import haliax as hax
+import jax
+import jmp
+import levanter
+import numpy as np
+from fray import current_client
+from fray.types import Entrypoint, JobRequest, ResourceConfig, TpuConfig, create_environment
 from haliax import Axis
 from haliax.partitioning import round_axis_for_partitioning
-
-import levanter
+from jax.experimental import multihost_utils
 from levanter.checkpoint import latest_checkpoint_path, load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, RepoRef
 from levanter.data import DataLoader
@@ -41,9 +40,6 @@ from levanter.tracker import NoopConfig
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
 from levanter.utils.tree_utils import inference_mode
-
-from fray import current_client
-from fray.types import Entrypoint, JobRequest, ResourceConfig, TpuConfig, create_environment
 
 from marin.execution.executor import ExecutorStep, InputName, this_output_path
 from marin.utilities.executor_utils import ckpt_path_to_step_name

--- a/lib/marin/src/marin/execution/artifact.py
+++ b/lib/marin/src/marin/execution/artifact.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from typing import TypeVar, overload, Any
 from dataclasses import asdict, dataclass, is_dataclass
-from marin.execution.step_spec import StepSpec
+from typing import Any, TypeVar, overload
 
-from rigging.filesystem import open_url
 from pydantic import BaseModel
+from rigging.filesystem import open_url
+
+from marin.execution.step_spec import StepSpec
 
 T = TypeVar("T")
 

--- a/lib/marin/src/marin/execution/disk_cache.py
+++ b/lib/marin/src/marin/execution/disk_cache.py
@@ -9,16 +9,16 @@ import functools
 import hashlib
 import logging
 from collections.abc import Callable
-from typing import Generic, TypeVar, ParamSpec
+from typing import Generic, ParamSpec, TypeVar
 
 import cloudpickle
 from rigging.filesystem import marin_temp_bucket, open_url
 
 from marin.execution.executor_step_status import (
-    StepAlreadyDone,
     STATUS_FAILED,
     STATUS_SUCCESS,
     StatusFile,
+    StepAlreadyDone,
     worker_id,
 )
 

--- a/lib/marin/src/marin/execution/executor.py
+++ b/lib/marin/src/marin/execution/executor.py
@@ -99,21 +99,24 @@ import draccus
 import levanter.utils.fsspec_utils as fsspec_utils
 from fray.types import TpuConfig
 from iris.cluster.constraints import WellKnownAttribute
-from rigging.filesystem import collect_gcs_paths
-from rigging.filesystem import get_bucket_location, open_url
-from rigging.filesystem import marin_prefix
-from rigging.filesystem import region_from_prefix
-from rigging.filesystem import split_gcs_path
+from rigging.filesystem import (
+    collect_gcs_paths,
+    get_bucket_location,
+    marin_prefix,
+    open_url,
+    region_from_prefix,
+    split_gcs_path,
+)
+from rigging.log_setup import configure_logging
 
-from marin.execution.step_spec import StepSpec
-from marin.execution.step_runner import StepRunner, worker_id
-from marin.execution.remote import RemoteCallable
 from marin.execution.executor_step_status import (
     STATUS_SUCCESS,
     StatusFile,
 )
+from marin.execution.remote import RemoteCallable
+from marin.execution.step_runner import StepRunner, worker_id
+from marin.execution.step_spec import StepSpec
 from marin.utilities.json_encoder import CustomJsonEncoder
-from rigging.log_setup import configure_logging
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/execution/remote.py
+++ b/lib/marin/src/marin/execution/remote.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass, field
 from typing import Generic, ParamSpec, TypeVar, overload
 
 from fray import client as fray_client
-from fray.types import ResourceConfig, Entrypoint, JobRequest, create_environment
+from fray.types import Entrypoint, JobRequest, ResourceConfig, create_environment
 
 P = ParamSpec("P")
 R = TypeVar("R")

--- a/lib/marin/src/marin/execution/step_runner.py
+++ b/lib/marin/src/marin/execution/step_runner.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import contextvars
 import dataclasses
-from datetime import timedelta
 import json
 import logging
 import os
@@ -27,27 +26,29 @@ import time
 import uuid
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
 
 import levanter.utils.fsspec_utils as fsspec_utils
-from rigging.filesystem import open_url, url_to_fs
-
 from fray.client import JobHandle, JobStatus
 from fray.local_backend import LocalJobHandle
+from rigging.filesystem import open_url, url_to_fs
+
 from marin.execution.artifact import Artifact
+
+# Re-export for backward compatibility
 from marin.execution.executor_step_status import (
     STATUS_DEP_FAILED,
     STATUS_FAILED,
     STATUS_SUCCESS,
-    StepAlreadyDone,
+    PreviousTaskFailedError,
     StatusFile,
+    StepAlreadyDone,
     step_lock,
+    worker_id,
 )
 from marin.execution.remote import RemoteCallable
 from marin.execution.step_spec import StepSpec
 from marin.utilities.json_encoder import CustomJsonEncoder
-
-# Re-export for backward compatibility
-from marin.execution.executor_step_status import PreviousTaskFailedError, worker_id
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/execution/step_spec.py
+++ b/lib/marin/src/marin/execution/step_spec.py
@@ -122,7 +122,7 @@ class StepSpec:
         The exists to allow for incremental migration from ``ExecutorStep`` to ``StepSpec``:
         steps can be authored as ``StepSpec`` and used in existing pipelines without modification.
         """
-        from marin.execution.executor import ExecutorStep, VersionedValue, THIS_OUTPUT_PATH
+        from marin.execution.executor import THIS_OUTPUT_PATH, ExecutorStep, VersionedValue
 
         dep_steps = [dep.as_executor_step() for dep in self.deps]
 

--- a/lib/marin/src/marin/export/hf_upload.py
+++ b/lib/marin/src/marin/export/hf_upload.py
@@ -12,9 +12,9 @@ from urllib.parse import urlparse
 import fsspec
 import humanfriendly
 from fsspec.implementations.local import LocalFileSystem
+from huggingface_hub import create_commit, upload_folder
 from rigging.filesystem import open_url
 from rigging.timing import ExponentialBackoff, retry_with_backoff
-from huggingface_hub import create_commit, upload_folder
 from tqdm_loggable.auto import tqdm
 
 from marin.execution import ExecutorStep, InputName

--- a/lib/marin/src/marin/mcp/babysitter.py
+++ b/lib/marin/src/marin/mcp/babysitter.py
@@ -11,6 +11,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
+from finelog.rpc import logging_pb2
+from finelog.rpc.logging_connect import LogServiceClientSync
 from google.protobuf import json_format
 from iris.cli.bug_report import gather_bug_report
 from iris.cli.job import build_job_summary
@@ -18,11 +20,9 @@ from iris.cli.token_store import cluster_name_from_url, load_any_token, load_tok
 from iris.cluster.log_store_helpers import build_log_source
 from iris.cluster.runtime.profile import SYSTEM_PROCESS_TARGET
 from iris.cluster.types import JobName
-from finelog.rpc import logging_pb2
 from iris.rpc import controller_pb2, job_pb2
 from iris.rpc.auth import AuthTokenInjector, StaticTokenProvider, TokenProvider
 from iris.rpc.controller_connect import ControllerServiceClientSync
-from finelog.rpc.logging_connect import LogServiceClientSync
 from iris.rpc.proto_utils import job_state_friendly, task_state_friendly
 from mcp.server.fastmcp import FastMCP
 from rigging.timing import Timestamp

--- a/lib/marin/src/marin/processing/classification/consolidate.py
+++ b/lib/marin/src/marin/processing/classification/consolidate.py
@@ -22,12 +22,13 @@ from dataclasses import dataclass
 from enum import StrEnum
 
 from fray import ResourceConfig
+from zephyr import Dataset, ZephyrContext, ZephyrExecutionResult
+
 from marin.utils import (
     fsspec_exists,
     fsspec_glob,
     rebase_file_path,
 )
-from zephyr import Dataset, ZephyrContext, ZephyrExecutionResult
 
 
 class FilterType(StrEnum):

--- a/lib/marin/src/marin/processing/classification/decon.py
+++ b/lib/marin/src/marin/processing/classification/decon.py
@@ -15,22 +15,22 @@ import os
 from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import StrEnum, auto
-import dupekit
 
-from marin.execution.executor import THIS_OUTPUT_PATH
 import draccus
+import dupekit
 import msgspec
 from rigging.filesystem import url_to_fs
+from rigging.log_setup import configure_logging
+from zephyr import Dataset, ZephyrContext
+from zephyr.readers import load_file
 
+from marin.execution.executor import THIS_OUTPUT_PATH
 from marin.processing.classification.deduplication.dedup_commons import (
     DEFAULT_FILETYPES,
     _collect_input_files,
     _get_extension,
 )
 from marin.utils import rebase_file_path
-from zephyr import Dataset, ZephyrContext
-from zephyr.readers import load_file
-from rigging.log_setup import configure_logging
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/processing/classification/deduplication/connected_components.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/connected_components.py
@@ -6,7 +6,7 @@ from collections.abc import Iterator, Sequence
 from typing import Any, TypedDict
 
 import dupekit
-from zephyr import Dataset, ZephyrContext, counters, write_parquet_file, ShardInfo
+from zephyr import Dataset, ShardInfo, ZephyrContext, counters, write_parquet_file
 
 from marin.utils import fsspec_glob
 

--- a/lib/marin/src/marin/processing/classification/deduplication/dedup_commons.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/dedup_commons.py
@@ -1,18 +1,19 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import Callable, Iterator
-from enum import StrEnum, auto
 import logging
 import os
+from collections.abc import Callable, Iterator
+from enum import StrEnum, auto
+
 import pyarrow as pa
 import pyarrow.json as pa_json
 import wandb
+from zephyr import counters, write_parquet_file
+from zephyr.readers import SUPPORTED_EXTENSIONS, open_file
 
 from marin.utilities.wandb_utils import init_wandb
 from marin.utils import fsspec_glob, rebase_file_path
-from zephyr import counters, write_parquet_file
-from zephyr.readers import SUPPORTED_EXTENSIONS, open_file
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/processing/classification/deduplication/exact.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/exact.py
@@ -1,9 +1,16 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 import itertools
+import logging
+from collections.abc import Iterator
 from typing import Any, TypeVar
 
-from collections.abc import Iterator
+import dupekit
+import pyarrow as pa
+from fray import ResourceConfig
+from zephyr import ZephyrContext, counters, write_parquet_file
+from zephyr.dataset import Dataset
+
 from marin.processing.classification.deduplication.dedup_commons import (
     DEFAULT_FILETYPES,
     DedupMode,
@@ -16,13 +23,7 @@ from marin.processing.classification.deduplication.dedup_commons import (
     group_files,
     make_document_dedup_aggregator,
 )
-import dupekit
 from marin.utils import rebase_file_path
-import pyarrow as pa
-import logging
-from fray import ResourceConfig
-from zephyr import ZephyrContext, counters, write_parquet_file
-from zephyr.dataset import Dataset
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/processing/tokenize/data_configs.py
+++ b/lib/marin/src/marin/processing/tokenize/data_configs.py
@@ -7,7 +7,6 @@ import os
 from functools import lru_cache
 
 import numpy
-
 from levanter.data.text import DEFAULT_LM_DATA_SHUFFLE, BlockShuffleConfig, DatasetComponent, LmDataConfig
 from levanter.tokenizers import MarinTokenizer, load_tokenizer
 

--- a/lib/marin/src/marin/processing/tokenize/download_pretokenized.py
+++ b/lib/marin/src/marin/processing/tokenize/download_pretokenized.py
@@ -20,6 +20,8 @@ from levanter.store.cache import CacheOptions
 
 from marin.datakit.download.huggingface import (
     DownloadConfig as HfDownloadConfig,
+)
+from marin.datakit.download.huggingface import (
     download_hf as hf_download_logic,
 )
 from marin.execution import THIS_OUTPUT_PATH, ExecutorStep, InputName, ensure_versioned

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -20,7 +20,6 @@ import braceexpand
 import draccus
 import fsspec
 import pyarrow.parquet as pq
-from rigging.filesystem import open_url, url_to_fs
 from datasets import load_dataset_builder
 from fray import ResourceConfig
 from levanter.data.text import (
@@ -31,16 +30,17 @@ from levanter.data.text import (
     UrlDatasetSourceConfig,
     preprocessor_for_format,
 )
-from levanter.tokenizers import MarinTokenizer, TokenizerBackend, load_tokenizer
 from levanter.store.cache import consolidate_shard_caches
 from levanter.store.tree_store import TreeStore
+from levanter.tokenizers import MarinTokenizer, TokenizerBackend, load_tokenizer
+from rigging.filesystem import open_url, url_to_fs
+from rigging.log_setup import configure_logging
 from zephyr import Dataset, ZephyrContext, zephyr_worker_ctx
 from zephyr.dataset import FileEntry
 from zephyr.readers import InputFileSpec, load_file
 
 from marin.execution.executor import InputName, VersionedValue
 from marin.utils import fsspec_exists, fsspec_isdir
-from rigging.log_setup import configure_logging
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/profiling/__init__.py
+++ b/lib/marin/src/marin/profiling/__init__.py
@@ -3,6 +3,7 @@
 
 """Utilities for ingesting and querying JAX/xprof profile artifacts."""
 
+from marin.profiling.compare_bundle import ComparisonBundleResult, run_profile_comparison_bundle
 from marin.profiling.ingest import (
     DEFAULT_ARTIFACT_ALIAS,
     download_latest_profile_artifact_for_run,
@@ -10,7 +11,6 @@ from marin.profiling.ingest import (
     summarize_profile_artifact,
     summarize_trace,
 )
-from marin.profiling.compare_bundle import ComparisonBundleResult, run_profile_comparison_bundle
 from marin.profiling.publish import (
     PROFILE_SUMMARY_ARTIFACT_TYPE,
     publish_profile_summary_artifact,

--- a/lib/marin/src/marin/profiling/cli.py
+++ b/lib/marin/src/marin/profiling/cli.py
@@ -9,6 +9,7 @@ import argparse
 import json
 from pathlib import Path
 
+from marin.profiling.compare_bundle import run_profile_comparison_bundle
 from marin.profiling.ingest import (
     DEFAULT_ARTIFACT_ALIAS,
     download_latest_profile_artifact_for_run,
@@ -16,7 +17,6 @@ from marin.profiling.ingest import (
     summarize_profile_artifact,
     summarize_trace,
 )
-from marin.profiling.compare_bundle import run_profile_comparison_bundle
 from marin.profiling.publish import publish_profile_summary_artifact
 from marin.profiling.query import compare_profile_summaries, query_profile_summary
 from marin.profiling.report import build_markdown_report

--- a/lib/marin/src/marin/profiling/ingest.py
+++ b/lib/marin/src/marin/profiling/ingest.py
@@ -20,12 +20,6 @@ from urllib.parse import urlparse
 
 import wandb
 
-from marin.profiling.semantics import (
-    canonical_op_name,
-    classify_semantic_family,
-    estimate_flop_proxy,
-    extract_shape_signature,
-)
 from marin.profiling.schema import (
     BreakdownPart,
     CommunicationOp,
@@ -41,8 +35,14 @@ from marin.profiling.schema import (
     StepClassSummary,
     StepTimeSummary,
     TimeBreakdown,
-    TraceProvenance,
     TraceOverview,
+    TraceProvenance,
+)
+from marin.profiling.semantics import (
+    canonical_op_name,
+    classify_semantic_family,
+    estimate_flop_proxy,
+    extract_shape_signature,
 )
 
 logger = logging.getLogger(__name__)

--- a/lib/marin/src/marin/profiling/query.py
+++ b/lib/marin/src/marin/profiling/query.py
@@ -9,7 +9,6 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-from marin.profiling.semantics import classify_semantic_family, estimate_flop_proxy
 from marin.profiling.schema import (
     GapBeforeOp,
     GapRegionContext,
@@ -19,6 +18,7 @@ from marin.profiling.schema import (
     SemanticFamilyAggregate,
     StepClassSummary,
 )
+from marin.profiling.semantics import classify_semantic_family, estimate_flop_proxy
 
 
 @dataclass(frozen=True)

--- a/lib/marin/src/marin/rl/curriculum.py
+++ b/lib/marin/src/marin/rl/curriculum.py
@@ -16,9 +16,9 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 
 import numpy as np
-from rigging.filesystem import url_to_fs
 from marin.rl.environments.base import EnvConfig
 from marin.rl.types import RolloutStats
+from rigging.filesystem import url_to_fs
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/rl/environments/base.py
+++ b/lib/marin/src/marin/rl/environments/base.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-import jax
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
+import jax
 from marin.rl.environments.inference_ctx.base import BaseInferenceContext
 from marin.rl.types import RolloutGroup
 

--- a/lib/marin/src/marin/rl/environments/inference_ctx/__init__.py
+++ b/lib/marin/src/marin/rl/environments/inference_ctx/__init__.py
@@ -1,16 +1,16 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from .async_vllm import AsyncvLLMInferenceContext
 from .base import BaseInferenceContext
 from .levanter import LevanterInferenceContext, LevanterInferenceContextConfig
 from .vllm import (
-    vLLMInferenceContext,
-    vLLMInferenceContextConfig,
-    VLLMSamplingConfig,
     MODEL_MAPPINGS,
     MODEL_TRANSPOSE_KEYS,
+    VLLMSamplingConfig,
+    vLLMInferenceContext,
+    vLLMInferenceContextConfig,
 )
-from .async_vllm import AsyncvLLMInferenceContext
 
 __all__ = [
     "MODEL_MAPPINGS",

--- a/lib/marin/src/marin/rl/environments/inference_ctx/async_vllm.py
+++ b/lib/marin/src/marin/rl/environments/inference_ctx/async_vllm.py
@@ -1,12 +1,11 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import logging
+import os
 
 import numpy as np
 from levanter.models.lm_model import LmHeadModel
-
 from marin.rl.environments.inference_ctx.vllm import InferenceMode, vLLMInferenceContext, vLLMInferenceContextConfig
 
 logger = logging.getLogger(__name__)

--- a/lib/marin/src/marin/rl/environments/inference_ctx/base.py
+++ b/lib/marin/src/marin/rl/environments/inference_ctx/base.py
@@ -12,11 +12,10 @@ import logging
 from typing import Any
 
 import numpy as np
+from levanter.models.lm_model import LmHeadModel
+from marin.rl.types import Rollout
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion import Choice
-from marin.rl.types import Rollout
-
-from levanter.models.lm_model import LmHeadModel
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/rl/environments/inference_ctx/inflight/worker.py
+++ b/lib/marin/src/marin/rl/environments/inference_ctx/inflight/worker.py
@@ -5,8 +5,8 @@ import logging
 
 import numpy as np
 from marin.rl.environments.inference_ctx.inflight.async_bridge import AsyncBridge
-from marin.rl.weight_utils import levanter_state_dict_to_nnx_state_on_cpu
 from marin.rl.environments.inference_ctx.vllm_utils import MODEL_MAPPINGS, MODEL_TRANSPOSE_KEYS
+from marin.rl.weight_utils import levanter_state_dict_to_nnx_state_on_cpu
 
 logger = logging.getLogger(__name__)
 
@@ -34,11 +34,11 @@ def _apply_worker_extension_mro_fix():
     See: https://github.com/vllm-project/vllm/issues/XXXX (TODO: file upstream issue)
     """
     try:
-        from vllm.v1.worker.worker_base import WorkerWrapperBase
         from vllm.config import set_current_vllm_config
-        from vllm.utils.import_utils import resolve_obj_by_qualname
         from vllm.multimodal import MULTIMODAL_REGISTRY
         from vllm.multimodal.cache import worker_receiver_cache_from_config
+        from vllm.utils.import_utils import resolve_obj_by_qualname
+        from vllm.v1.worker.worker_base import WorkerWrapperBase
     except ImportError:
         logger.warning("Could not import vLLM V1 worker modules for MRO fix")
         return

--- a/lib/marin/src/marin/rl/environments/inference_ctx/levanter.py
+++ b/lib/marin/src/marin/rl/environments/inference_ctx/levanter.py
@@ -9,20 +9,21 @@ as well as methods for tokenization and logprob extraction from an OpenAI ChatCo
 """
 
 import asyncio
-from dataclasses import dataclass
 import logging
 import threading
+from dataclasses import dataclass
+
+import haliax as hax
 from jax.sharding import Mesh
 from levanter.inference.openai import InferenceServer, InferenceServerConfig
-from openai import AsyncOpenAI
-from openai.types.chat import ChatCompletion
-from levanter.tokenizers import MarinTokenizer
 from levanter.models.lm_model import LmHeadModel
-import haliax as hax
+from levanter.tokenizers import MarinTokenizer
 from marin.rl.environments.inference_ctx.base import BaseInferenceContext
 
 # TODO(chris): use a different weight transfer method update model, take it out from here
 from marin.rl.weight_transfer.arrow_flight import update_model
+from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletion
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/rl/environments/inference_ctx/vllm.py
+++ b/lib/marin/src/marin/rl/environments/inference_ctx/vllm.py
@@ -11,16 +11,16 @@ from enum import StrEnum
 import numpy as np
 from levanter.models.lm_model import LmHeadModel
 from levanter.tokenizers import load_tokenizer
+from marin.rl.environments.inference_ctx.base import BaseInferenceContext
+from marin.rl.environments.inference_ctx.inflight.worker import SyncVLLMWrapper
+from marin.rl.environments.inference_ctx.render import Llama3Renderer, Message, Qwen3Renderer, Renderer
+from marin.rl.environments.inference_ctx.vllm_utils import MODEL_MAPPINGS, MODEL_TRANSPOSE_KEYS
+from marin.rl.weight_utils import levanter_state_dict_to_nnx_state_on_cpu
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion import Choice, ChoiceLogprobs
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
-from openai.types.completion_usage import CompletionUsage
 from openai.types.chat.chat_completion_token_logprob import ChatCompletionTokenLogprob, TopLogprob
-from marin.rl.environments.inference_ctx.base import BaseInferenceContext
-from marin.rl.environments.inference_ctx.inflight.worker import SyncVLLMWrapper
-from marin.rl.environments.inference_ctx.render import Llama3Renderer, Qwen3Renderer, Renderer, Message
-from marin.rl.environments.inference_ctx.vllm_utils import MODEL_MAPPINGS, MODEL_TRANSPOSE_KEYS
-from marin.rl.weight_utils import levanter_state_dict_to_nnx_state_on_cpu
+from openai.types.completion_usage import CompletionUsage
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/rl/environments/math_env.py
+++ b/lib/marin/src/marin/rl/environments/math_env.py
@@ -10,14 +10,15 @@ from typing import Any
 
 import jax
 import numpy as np
-
+from marin.rl.environments.inference_ctx.base import BaseInferenceContext
 from marin.rl.environments.tinker_environments.math_env import (
     MathEnv as TinkerMathEnvBase,
+)
+from marin.rl.environments.tinker_environments.math_env import (
     _get_hendrycks_math_test,
     _get_hendrycks_math_train,
 )
 from marin.rl.environments.tinker_environments.math_grading import extract_boxed, grade_answer, normalize_answer
-from marin.rl.environments.inference_ctx.base import BaseInferenceContext
 from marin.rl.math_utils import last_boxed_only_string
 from marin.rl.types import Rollout, RolloutGroup
 

--- a/lib/marin/src/marin/rl/environments/mock_env.py
+++ b/lib/marin/src/marin/rl/environments/mock_env.py
@@ -11,7 +11,6 @@ from typing import Any, ClassVar, Protocol
 import jax
 import numpy as np
 from levanter.tokenizers import MarinTokenizer
-
 from marin.rl.environments.inference_ctx.base import BaseInferenceContext
 from marin.rl.types import RolloutGroup
 

--- a/lib/marin/src/marin/rl/environments/prime_intellect_env.py
+++ b/lib/marin/src/marin/rl/environments/prime_intellect_env.py
@@ -10,10 +10,9 @@ from typing import Any, ClassVar, cast
 
 import jax.numpy as jnp
 import numpy as np
-
 from marin.rl.environments import MarinEnv
-from marin.rl.environments.process_vllm_results import process_vllm_chat_results
 from marin.rl.environments.inference_ctx import BaseInferenceContext
+from marin.rl.environments.process_vllm_results import process_vllm_chat_results
 from marin.rl.types import Rollout, RolloutGroup
 
 logger = logging.getLogger(__name__)
@@ -86,8 +85,9 @@ class PrimeIntellectEnv(MarinEnv):
         """Sample problems and generate responses using the model."""
         del prng_key, system_prompt
         self._ensure_verifiers_installed()
-        from verifiers.types import GenerateOutputs
         import subprocess
+
+        from verifiers.types import GenerateOutputs
 
         # Download/install the environment
         subprocess.run(["prime", "env", "install", self.env_id], check=True)

--- a/lib/marin/src/marin/rl/model_utils.py
+++ b/lib/marin/src/marin/rl/model_utils.py
@@ -17,10 +17,10 @@ import jax
 from jax.sharding import Mesh
 from levanter.checkpoint import latest_checkpoint_path, load_checkpoint
 from levanter.compat.hf_checkpoints import (
-    HFCheckpointConverter,
     PYTORCH_WEIGHTS_INDEX_NAME,
-    RepoRef,
     SAFE_TENSORS_INDEX_NAME,
+    HFCheckpointConverter,
+    RepoRef,
 )
 from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.trainer import TrainerConfig

--- a/lib/marin/src/marin/rl/replay_buffer.py
+++ b/lib/marin/src/marin/rl/replay_buffer.py
@@ -16,7 +16,6 @@ from collections import defaultdict
 from dataclasses import dataclass
 
 import numpy as np
-
 from marin.rl.rl_losses import RLLossModule
 
 from .rollout_storage import RolloutReader

--- a/lib/marin/src/marin/rl/rl_experiment_utils.py
+++ b/lib/marin/src/marin/rl/rl_experiment_utils.py
@@ -16,10 +16,9 @@ from levanter.layers.attention import AttentionBackend
 from levanter.optim import AdamConfig
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
-from marin.execution.artifact import PathMetadata
 from levanter.utils.fsspec_utils import join_path
 from levanter.utils.mesh import MeshConfig
-
+from marin.execution.artifact import PathMetadata
 from marin.execution.executor import ExecutorMainConfig, ExecutorStep, InputName, output_path_of, this_output_path
 from marin.execution.remote import remote
 from marin.rl.curriculum import CurriculumConfig

--- a/lib/marin/src/marin/rl/rl_job.py
+++ b/lib/marin/src/marin/rl/rl_job.py
@@ -31,7 +31,7 @@ from marin.rl.environments.inference_ctx import (
 from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_losses import RLLossModule
 from marin.rl.rollout_storage import RolloutStorageConfig, StorageType
-from marin.rl.rollout_worker import RolloutWorkerConfig, RolloutTrackerConfig
+from marin.rl.rollout_worker import RolloutTrackerConfig, RolloutWorkerConfig
 from marin.rl.train_worker import TrainWorkerConfig
 from marin.rl.weight_transfer import WeightTransferConfig
 from marin.utilities.json_encoder import CustomJsonEncoder

--- a/lib/marin/src/marin/rl/rl_losses.py
+++ b/lib/marin/src/marin/rl/rl_losses.py
@@ -8,15 +8,14 @@ from dataclasses import dataclass
 from typing import Protocol
 
 import equinox as eqx
+import haliax as hax
 import jax
 import jax.numpy as jnp
 import numpy as np
-import haliax as hax
 from levanter.layers.attention import AttentionMask
+from levanter.metrics import Metric, ReductionType
 from levanter.models.lm_model import LmHeadModel
 from levanter.models.loss import fused_cross_entropy_loss_and_logsumexp_penalty
-from levanter.metrics import Metric, ReductionType
-
 from marin.rl.types import Rollout, TrainingBatch
 
 # TODO(power) - these should be refactored to accept the precomputed logits instead

--- a/lib/marin/src/marin/rl/rollout_worker.py
+++ b/lib/marin/src/marin/rl/rollout_worker.py
@@ -20,7 +20,7 @@ import threading
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 import equinox as eqx
 import haliax as hax
@@ -31,15 +31,11 @@ import wandb
 from jax.experimental import multihost_utils
 from levanter.inference.openai import InferenceServer
 from levanter.models.lm_model import LmConfig
+from levanter.tokenizers import MarinTokenizer
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import barrier_sync
-from levanter.tokenizers import MarinTokenizer
-from typing import Literal
-
 from levanter.utils.mesh import MeshConfig
 from marin.rl.curriculum import CurriculumConfig
-from marin.rl.runtime import RLRuntimeHandles
-from marin.rl.run_state import RolloutTransferCounters
 from marin.rl.environments import MarinEnv
 from marin.rl.environments.base import load_environment_from_spec
 from marin.rl.environments.inference_ctx import (
@@ -55,6 +51,8 @@ from marin.rl.environments.inference_ctx.staging import (
 )
 from marin.rl.metrics import pass_at_k_estimator
 from marin.rl.model_utils import load_model_from_checkpoint
+from marin.rl.run_state import RolloutTransferCounters
+from marin.rl.runtime import RLRuntimeHandles
 
 from .rollout_storage import RolloutStorageConfig, RolloutWriter
 from .types import (
@@ -63,8 +61,8 @@ from .types import (
     RolloutMetadata,
     RolloutStats,
 )
-from .weight_transfer.base import WeightUpdate
 from .weight_transfer import WeightTransferClient, WeightTransferConfig, create_weight_transfer_client
+from .weight_transfer.base import WeightUpdate
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/rl/scripts/export_env_prompts.py
+++ b/lib/marin/src/marin/rl/scripts/export_env_prompts.py
@@ -24,9 +24,8 @@ import jax
 import jax.random as jrandom
 from levanter.inference.openai import ChatCompletionRequest, ChatMessage
 from levanter.tokenizers import load_tokenizer
-
-from rigging.log_setup import configure_logging
 from marin.rl.environments import EnvConfig, load_environment_from_spec
+from rigging.log_setup import configure_logging
 
 configure_logging(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/lib/marin/src/marin/rl/scripts/view_rollout.py
+++ b/lib/marin/src/marin/rl/scripts/view_rollout.py
@@ -17,7 +17,6 @@ import pickle
 from typing import Any
 
 from levanter.tokenizers import load_tokenizer
-
 from marin.rl.types import RolloutBatch
 
 

--- a/lib/marin/src/marin/rl/train_worker.py
+++ b/lib/marin/src/marin/rl/train_worker.py
@@ -23,19 +23,17 @@ import jax.random as jrandom
 import levanter
 import wandb
 from levanter import callbacks
+from levanter.callbacks.tensorstore_callbacks import install_tensorstore_metrics_hook
 from levanter.checkpoint import (
     register_debug_checkpointer_state_provider,
     unregister_debug_checkpointer_state_provider,
 )
-from levanter.callbacks.tensorstore_callbacks import install_tensorstore_metrics_hook
 from levanter.layers.attention import DEFAULT_SPLASH_BLOCK_SIZE, AttentionBackend
 from levanter.models.flash_attention import BLOCK_SIZE as DEFAULT_FLASH_BLOCK_SIZE
-from levanter.models.lm_model import LmConfig
-from levanter.models.lm_model import LmHeadModel
+from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.optim import OptimizerConfig
-from levanter.trainer import Trainer, TrainerConfig
 from levanter.tokenizers import MarinTokenizer
-
+from levanter.trainer import Trainer, TrainerConfig
 from marin.rl import weight_transfer
 from marin.rl.curriculum import CurriculumConfig
 from marin.rl.model_utils import load_model_from_checkpoint

--- a/lib/marin/src/marin/rl/weight_transfer/checkpoint.py
+++ b/lib/marin/src/marin/rl/weight_transfer/checkpoint.py
@@ -16,10 +16,10 @@ from collections import deque
 
 import jax
 import levanter.checkpoint as levanter_checkpoint
-from rigging.filesystem import url_to_fs
 from haliax.partitioning import ResourceMapping
 from jax.sharding import Mesh
 from jaxtyping import PyTree
+from rigging.filesystem import url_to_fs
 
 from .base import (
     WeightTransferClient,

--- a/lib/marin/src/marin/rl/weight_utils.py
+++ b/lib/marin/src/marin/rl/weight_utils.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import jax
-from flax import nnx
 import jax.numpy as jnp
+from flax import nnx
 from levanter.models.lm_model import LmHeadModel
 
 

--- a/lib/marin/src/marin/run/slurm_run.py
+++ b/lib/marin/src/marin/run/slurm_run.py
@@ -45,9 +45,8 @@ import sys
 import tempfile
 import time
 
-from huggingface_hub import HfFolder
-
 import wandb
+from huggingface_hub import HfFolder
 from rigging.log_setup import configure_logging
 
 # Setup logger

--- a/lib/marin/src/marin/scaling_laws/__init__.py
+++ b/lib/marin/src/marin/scaling_laws/__init__.py
@@ -17,19 +17,19 @@ from marin.scaling_laws.isoflop_analysis import (
     predict_optimal_config,
     round_flops_to_bucket,
 )
-from marin.scaling_laws.tpu_utils import (
-    TpuSpec,
-    V4_SPEC,
-    V5P_SPEC,
-    pick_tpu_type,
-    pick_v4_type,
-    pick_v5p_type,
-)
 from marin.scaling_laws.scaling_plots import (
     create_isoflop_plot,
     create_scaling_plot,
     save_plots,
     upload_plots_to_wandb,
+)
+from marin.scaling_laws.tpu_utils import (
+    V4_SPEC,
+    V5P_SPEC,
+    TpuSpec,
+    pick_tpu_type,
+    pick_v4_type,
+    pick_v5p_type,
 )
 
 __all__ = [

--- a/lib/marin/src/marin/scaling_laws/isoflop_analysis.py
+++ b/lib/marin/src/marin/scaling_laws/isoflop_analysis.py
@@ -25,7 +25,6 @@ from typing import NamedTuple, Protocol
 
 import jax.numpy as jnp
 from jaxopt import ScipyMinimize
-
 from levanter.optim.config import OptimizerConfig
 
 logger = logging.getLogger(__name__)

--- a/lib/marin/src/marin/scaling_laws/scaling_plots.py
+++ b/lib/marin/src/marin/scaling_laws/scaling_plots.py
@@ -16,11 +16,10 @@ import jax.numpy as jnp
 import pandas as pd
 import plotly.graph_objects as go
 import plotly.io as pio
+import wandb
 
 from marin.scaling_laws.isoflop_analysis import QuadraticFitCoeffs, ScalingFit
 from marin.utilities.wandb_utils import WANDB_ENTITY, WANDB_PROJECT
-
-import wandb
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/tokenize/slice_cache.py
+++ b/lib/marin/src/marin/tokenize/slice_cache.py
@@ -18,7 +18,6 @@ import time
 from dataclasses import dataclass
 
 import humanfriendly
-from rigging.filesystem import open_url
 from jax.random import PRNGKey
 from levanter.data.text import (
     HfDatasetSourceConfig,
@@ -27,11 +26,11 @@ from levanter.data.text import (
 )
 from levanter.store import SerialCacheWriter, TreeCache
 from levanter.tokenizers import load_tokenizer
-from tqdm_loggable.auto import tqdm
-
 from marin.execution import THIS_OUTPUT_PATH, ExecutorStep, InputName
 from marin.processing.tokenize.tokenize import TokenizeConfigBase
+from rigging.filesystem import open_url
 from rigging.log_setup import configure_logging
+from tqdm_loggable.auto import tqdm
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/training/training.py
+++ b/lib/marin/src/marin/training/training.py
@@ -6,8 +6,8 @@ import importlib
 import logging
 import os
 import urllib.parse
-from copy import deepcopy
 from collections.abc import Callable
+from copy import deepcopy
 from dataclasses import dataclass, replace
 from typing import TypeVar
 
@@ -23,8 +23,8 @@ from fray import (
     current_client,
 )
 from mergedeep import mergedeep
-
 from rigging.filesystem import check_gcs_paths_same_region, marin_temp_bucket
+
 from marin.training.run_environment import add_run_env_variables
 
 logger = logging.getLogger(__name__)

--- a/lib/marin/src/marin/transform/conversation/transform_conversation.py
+++ b/lib/marin/src/marin/transform/conversation/transform_conversation.py
@@ -25,10 +25,10 @@ from typing import Any
 import datasets
 import draccus
 import fsspec
-from rigging.filesystem import url_to_fs
 from marin.core.conversation import DolmaConversationOutput, OpenAIChatMessage
 from marin.execution import unwrap_versioned_value
 from marin.utils import fsspec_mkdirs, load_dataset_with_backoff
+from rigging.filesystem import url_to_fs
 from zephyr import Dataset, ZephyrContext, load_jsonl, write_jsonl_file
 
 from .adapters import TransformAdapter

--- a/lib/marin/src/marin/transform/conversation/transform_preference_data.py
+++ b/lib/marin/src/marin/transform/conversation/transform_preference_data.py
@@ -19,10 +19,9 @@ import datasets
 import draccus
 import fsspec
 from datasets import get_dataset_config_info
+from marin.utils import is_path_like
 from rigging.filesystem import url_to_fs
 from zephyr import Dataset, ZephyrContext, write_jsonl_file
-
-from marin.utils import is_path_like
 
 from .preference_data_adapters import PreferenceTransformAdapter, get_preference_adapter
 

--- a/lib/marin/src/marin/transform/security_artifacts/zeek_to_dolma.py
+++ b/lib/marin/src/marin/transform/security_artifacts/zeek_to_dolma.py
@@ -25,8 +25,6 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from typing import Any
 
-from zephyr import Dataset, ZephyrContext, load_jsonl, load_parquet
-
 from marin.transform.security_artifacts.renderers import (
     DEFAULT_ZEEK_EMPTY_FIELD,
     DEFAULT_ZEEK_SEPARATOR,
@@ -34,6 +32,7 @@ from marin.transform.security_artifacts.renderers import (
     DEFAULT_ZEEK_UNSET_FIELD,
     render_zeek_tsv_log,
 )
+from zephyr import Dataset, ZephyrContext, load_jsonl, load_parquet
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/transform/stackexchange/transform_stackexchange.py
+++ b/lib/marin/src/marin/transform/stackexchange/transform_stackexchange.py
@@ -14,11 +14,10 @@ import random
 from dataclasses import dataclass
 
 import draccus
-from zephyr import Dataset, ZephyrContext, load_jsonl
-
 from marin.schemas.web.convert import ExtractionConfig
 from marin.utils import fsspec_glob
 from marin.web.convert import convert_page
+from zephyr import Dataset, ZephyrContext, load_jsonl
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/utilities/validation_utils.py
+++ b/lib/marin/src/marin/utilities/validation_utils.py
@@ -13,8 +13,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
-from rigging.filesystem import open_url
 from pydantic import BaseModel
+from rigging.filesystem import open_url
 
 
 # === General Pydantic Schema for Quick & Easy Ser/De + Validation ==

--- a/lib/marin/src/marin/utils.py
+++ b/lib/marin/src/marin/utils.py
@@ -15,9 +15,9 @@ import braceexpand
 import datasets
 import fsspec
 import requests
+from huggingface_hub.utils import HfHubHTTPError
 from rigging.filesystem import url_to_fs
 from rigging.timing import ExponentialBackoff, retry_with_backoff
-from huggingface_hub.utils import HfHubHTTPError
 
 logger = logging.getLogger(__name__)
 T = TypeVar("T")

--- a/lib/marin/src/marin/validate/validate.py
+++ b/lib/marin/src/marin/validate/validate.py
@@ -18,8 +18,8 @@ from dataclasses import dataclass
 
 import draccus
 import numpy as np
-from rigging.filesystem import open_url
 from marin.utilities.validation_utils import compute_global_mean_std, summarize_document
+from rigging.filesystem import open_url
 from zephyr import Dataset, ZephyrContext, load_jsonl
 
 

--- a/lib/marin/tools/get_hf_dataset_schema.py
+++ b/lib/marin/tools/get_hf_dataset_schema.py
@@ -14,7 +14,7 @@ import os
 import warnings
 
 import requests
-from datasets import load_dataset, get_dataset_split_names, get_dataset_config_names
+from datasets import get_dataset_config_names, get_dataset_split_names, load_dataset
 from datasets.utils.info_utils import VerificationMode
 
 HF_DATASET_SIZE_URL = "https://datasets-server.huggingface.co/size"

--- a/lib/rigging/src/rigging/config_discovery.py
+++ b/lib/rigging/src/rigging/config_discovery.py
@@ -10,9 +10,10 @@ marin sub-package.
 
 import functools
 import logging
-import tomllib
 from collections.abc import Sequence
 from pathlib import Path
+
+import tomllib
 
 logger = logging.getLogger(__name__)
 

--- a/lib/rigging/tests/test_config_discovery.py
+++ b/lib/rigging/tests/test_config_discovery.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
 from rigging.config_discovery import (
     find_configs,
     find_project_root,

--- a/lib/rigging/tests/test_mirror_fs.py
+++ b/lib/rigging/tests/test_mirror_fs.py
@@ -5,7 +5,6 @@ import os
 
 import fsspec
 import pytest
-
 from rigging.filesystem import (
     MirrorFileSystem,
     TransferBudget,

--- a/lib/rigging/tests/test_record_transfer.py
+++ b/lib/rigging/tests/test_record_transfer.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
 from rigging import filesystem as rfs
 from rigging.filesystem import TransferBudget, TransferBudgetExceeded, record_transfer
 

--- a/lib/rigging/tests/test_timing.py
+++ b/lib/rigging/tests/test_timing.py
@@ -6,7 +6,6 @@ import threading
 import time
 
 import pytest
-
 from rigging.timing import (
     Deadline,
     Duration,

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -19,29 +19,28 @@ import logging
 import os
 import pickle
 import sys
-from datetime import datetime, timezone
 import threading
 import time
 import traceback
 import uuid
 from collections import Counter, defaultdict, deque
-from concurrent.futures import ThreadPoolExecutor
 from collections.abc import Callable, Iterable, Iterator
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from contextvars import ContextVar
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any, Protocol
 
 import cloudpickle
-from rigging.filesystem import open_url, url_to_fs
 from fray import ActorConfig, ActorFuture, ActorHandle, Client, ResourceConfig
 from fray.client import JobHandle
 from fray.types import Entrypoint, JobRequest
-from rigging.filesystem import marin_temp_bucket
-from rigging.timing import ExponentialBackoff, log_time
-
 from iris.client import get_iris_ctx
 from iris.cluster.client.job_info import get_job_info
+from rigging.filesystem import marin_temp_bucket, open_url, url_to_fs
+from rigging.timing import ExponentialBackoff, log_time
+
 from zephyr.dataset import Dataset
 from zephyr.plan import (
     Join,

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -24,8 +24,7 @@ import msgspec
 import xxhash
 from iris.env_resources import TaskResources as _TaskResources
 from rigging.filesystem import url_to_fs
-
-from zephyr.external_sort import external_sort_merge
+from rigging.log_setup import configure_logging
 
 from zephyr.dataset import (
     Dataset,
@@ -48,8 +47,8 @@ from zephyr.dataset import (
     resolve_glob,
 )
 from zephyr.expr import Expr
+from zephyr.external_sort import external_sort_merge
 from zephyr.readers import InputFileSpec
-from rigging.log_setup import configure_logging
 
 logger = logging.getLogger(__name__)
 

--- a/lib/zephyr/src/zephyr/readers.py
+++ b/lib/zephyr/src/zephyr/readers.py
@@ -17,11 +17,11 @@ from dataclasses import dataclass
 from typing import Literal
 
 import fsspec
-from rigging.filesystem import open_url, url_to_fs
 import msgspec
 import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
+from rigging.filesystem import open_url, url_to_fs
 
 from zephyr import counters
 from zephyr.expr import Expr

--- a/lib/zephyr/src/zephyr/writers.py
+++ b/lib/zephyr/src/zephyr/writers.py
@@ -5,6 +5,9 @@
 
 from __future__ import annotations
 
+import itertools
+import logging
+import os
 import queue
 import tempfile
 import threading
@@ -12,14 +15,12 @@ import uuid
 from collections.abc import Callable, Iterable
 from contextlib import contextmanager
 from dataclasses import asdict, is_dataclass
-import itertools
-import os
 from typing import Any
 
+import msgspec
 import pyarrow as pa
 from rigging.filesystem import open_url, url_to_fs
-import msgspec
-import logging
+
 from zephyr import counters
 
 logger = logging.getLogger(__name__)

--- a/lib/zephyr/tests/benchmark_parquet_reader.py
+++ b/lib/zephyr/tests/benchmark_parquet_reader.py
@@ -258,7 +258,6 @@ def read_rowgroups_scatter_no_skip(path: str, limit: int | None = None) -> dict[
     row-group-level predicate pushdown.
     """
     import pyarrow.compute as pc
-
     from zephyr.readers import iter_parquet_row_groups
 
     target_shard = _NUM_SHARDS // 2

--- a/lib/zephyr/tests/benchmark_shuffle.py
+++ b/lib/zephyr/tests/benchmark_shuffle.py
@@ -42,9 +42,8 @@ import time
 from collections.abc import Iterator
 
 import click
-from rigging.log_setup import configure_logging
-
 from fray import ResourceConfig
+from rigging.log_setup import configure_logging
 from zephyr import Dataset
 from zephyr.dataset import ShardInfo
 from zephyr.execution import ZephyrContext

--- a/lib/zephyr/tests/conftest.py
+++ b/lib/zephyr/tests/conftest.py
@@ -2,23 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Pytest fixtures for zephyr tests."""
-import tempfile
-
 import atexit
 import os
 import sys
+import tempfile
 import threading
 import time
 import traceback
 import warnings
 from pathlib import Path
 
-from rigging.timing import ExponentialBackoff
-
 import pytest
 from fray import ResourceConfig
 from fray.iris_backend import FrayIrisClient
 from fray.local_backend import LocalClient
+from rigging.timing import ExponentialBackoff
 from zephyr import load_file
 from zephyr.execution import ZephyrContext
 
@@ -32,7 +30,7 @@ IRIS_CONFIG = Path(__file__).resolve().parents[2] / "iris" / "examples" / "test.
 @pytest.fixture(scope="session")
 def iris_cluster():
     """Start local Iris cluster for testing - reused across all tests."""
-    from iris.cluster.config import load_config, make_local_config, connect_cluster
+    from iris.cluster.config import connect_cluster, load_config, make_local_config
 
     config = load_config(IRIS_CONFIG)
     config = make_local_config(config)

--- a/lib/zephyr/tests/test_dataset.py
+++ b/lib/zephyr/tests/test_dataset.py
@@ -8,7 +8,6 @@ from functools import partial
 from pathlib import Path
 
 import pytest
-
 from fray import ResourceConfig
 from fray.local_backend import LocalClient
 from zephyr import Dataset, load_file, load_parquet

--- a/lib/zephyr/tests/test_groupby.py
+++ b/lib/zephyr/tests/test_groupby.py
@@ -2,12 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for deduplicate and group_by operations."""
-import pyarrow as pa
-
 import hashlib
 
+import pyarrow as pa
 import pytest
-
 from zephyr import Dataset
 
 

--- a/lib/zephyr/tests/test_readers.py
+++ b/lib/zephyr/tests/test_readers.py
@@ -6,7 +6,6 @@
 
 import pyarrow as pa
 import pyarrow.parquet as pq
-
 from zephyr.expr import ColumnExpr, CompareExpr, LiteralExpr
 from zephyr.readers import InputFileSpec, iter_parquet_row_groups, load_parquet
 

--- a/lib/zephyr/tests/test_vortex.py
+++ b/lib/zephyr/tests/test_vortex.py
@@ -4,7 +4,6 @@
 """Tests for vortex file format support."""
 
 import pytest
-
 from fray import ResourceConfig
 from fray.local_backend import LocalClient
 from zephyr import Dataset

--- a/lib/zephyr/tests/test_writers.py
+++ b/lib/zephyr/tests/test_writers.py
@@ -7,12 +7,10 @@ import os
 import tempfile
 from pathlib import Path
 
+import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 import vortex
-
-import pyarrow as pa
-
 from zephyr.writers import (
     atomic_rename,
     infer_arrow_schema,
@@ -245,6 +243,7 @@ def test_atomic_rename_s3_directory_preserves_layout(tmp_path):
     that.
     """
     from unittest.mock import patch
+
     from fsspec.implementations.local import LocalFileSystem
 
     dest = tmp_path / "dest"
@@ -265,6 +264,7 @@ def test_atomic_rename_s3_directory_preserves_layout(tmp_path):
 def test_atomic_rename_s3_single_file(tmp_path):
     """S3 atomic_rename works correctly for single-file outputs."""
     from unittest.mock import patch
+
     from fsspec.implementations.local import LocalFileSystem
 
     dest = tmp_path / "output.jsonl"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ extend-exclude = ["scripts/"]
 
 [tool.ruff.lint]
 select = ["A", "B", "E", "F", "I", "NPY", "RUF", "UP", "W"]
-ignore = ["F722", "B008", "UP015", "A005", "I001", "E741"]
+ignore = ["F722", "B008", "UP015", "A005", "E741"]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402", "F401"]

--- a/rust/dupekit/tests/bench/conftest.py
+++ b/rust/dupekit/tests/bench/conftest.py
@@ -1,10 +1,11 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
+from typing import Any
+
 import pyarrow as pa
 import pyarrow.parquet as pq
-from typing import Any
+import pytest
 from huggingface_hub import hf_hub_download
 
 REPO_ID = "HuggingFaceFW/fineweb-edu"

--- a/rust/dupekit/tests/bench/test_batch_tuning.py
+++ b/rust/dupekit/tests/bench/test_batch_tuning.py
@@ -1,10 +1,11 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
-import pyarrow as pa
 from typing import Any
+
 import dupekit
+import pyarrow as pa
+import pytest
 
 
 @pytest.mark.parametrize("batch_size", [1, 128, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072])

--- a/rust/dupekit/tests/bench/test_dedupe.py
+++ b/rust/dupekit/tests/bench/test_dedupe.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import hashlib
-import pytest
-import pyarrow as pa
 from typing import Any
+
 import dupekit
+import pyarrow as pa
+import pytest
 
 # Legacy Python Implementations for baseline
 

--- a/rust/dupekit/tests/bench/test_hashing.py
+++ b/rust/dupekit/tests/bench/test_hashing.py
@@ -1,13 +1,13 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any
-from collections.abc import Callable
-
-import pytest
-import pyarrow as pa
 import hashlib
+from collections.abc import Callable
+from typing import Any
+
 import dupekit
+import pyarrow as pa
+import pytest
 
 
 def _py_blake2b(text: bytes) -> bytes:

--- a/rust/dupekit/tests/bench/test_io.py
+++ b/rust/dupekit/tests/bench/test_io.py
@@ -6,10 +6,11 @@ Benchmarks focusing on End-to-End I/O performance:
 Disk -> Parquet Parsing -> Memory -> Rust -> Output Data.
 """
 
-import pytest
-import pyarrow.parquet as pq
 from typing import Any
+
 import dupekit
+import pyarrow.parquet as pq
+import pytest
 
 
 def test_rust_native(benchmark: Any, small_parquet_path: str) -> None:

--- a/rust/dupekit/tests/bench/test_marshaling.py
+++ b/rust/dupekit/tests/bench/test_marshaling.py
@@ -6,10 +6,11 @@ Benchmarks focusing purely on Memory -> Rust FFI overhead.
 Benchmarks include the cost of converting Arrow data to target format (Dicts, Structs) if applicable.
 """
 
-import pytest
-import pyarrow as pa
 from typing import Any
+
 import dupekit
+import pyarrow as pa
+import pytest
 
 
 @pytest.mark.parametrize(

--- a/rust/dupekit/tests/bench/test_minhash.py
+++ b/rust/dupekit/tests/bench/test_minhash.py
@@ -1,9 +1,10 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import pyarrow as pa
 from typing import Any
+
 import dupekit
+import pyarrow as pa
 from dupekit import Transformation
 
 # Python is slow, can't use too many rows

--- a/rust/dupekit/tests/test_hashing.py
+++ b/rust/dupekit/tests/test_hashing.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import hashlib
-from dupekit import hash_blake2, hash_blake3, hash_xxh3_64, hash_xxh3_128, hash_xxh3_64_batch
+
+from dupekit import hash_blake2, hash_blake3, hash_xxh3_64, hash_xxh3_64_batch, hash_xxh3_128
 
 
 def test_blake2_compliance():

--- a/scripts/canary/validate_canary_metrics.py
+++ b/scripts/canary/validate_canary_metrics.py
@@ -19,9 +19,8 @@ import os
 import sys
 from collections.abc import Callable
 
-from rigging.filesystem import open_url
-
 from marin.execution.executor import Executor
+from rigging.filesystem import open_url
 
 
 def _env_float(key: str, default: float) -> float:

--- a/scripts/datakit/run_source_sampling.py
+++ b/scripts/datakit/run_source_sampling.py
@@ -19,6 +19,8 @@ so they're auto-deleted after the configured TTL — no manual cleanup.
 import logging
 import os
 
+from marin.datakit.sources import all_sources
+from marin.execution.step_runner import StepRunner, check_cache
 from rigging.filesystem import marin_temp_bucket
 from rigging.log_setup import configure_logging
 
@@ -26,8 +28,6 @@ from experiments.datakit_testbed.sampler import (
     proportional_sample_fractions,
     sample_normalized_shards_step,
 )
-from marin.datakit.sources import all_sources
-from marin.execution.step_runner import StepRunner, check_cache
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/debug/decode_tokens.py
+++ b/scripts/debug/decode_tokens.py
@@ -12,8 +12,8 @@ from prompt_toolkit import prompt
 from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.history import InMemoryHistory
 from rich.console import Console
-from rich.table import Table
 from rich.panel import Panel
+from rich.table import Table
 from transformers import AutoTokenizer
 
 console = Console()

--- a/scripts/iris/dev_tpu.py
+++ b/scripts/iris/dev_tpu.py
@@ -23,16 +23,15 @@ from pathlib import Path
 
 import click
 import yaml
-from watchdog.events import FileSystemEventHandler
-from watchdog.observers import Observer
-
 from iris.client import IrisClient, JobAlreadyExists
-from iris.cluster.constraints import zone_constraint
 from iris.cluster.config import IrisConfig
+from iris.cluster.constraints import zone_constraint
 from iris.cluster.types import Entrypoint, JobName, ResourceSpec, tpu_device
 from iris.dev_tpu import DevTpuState, DevTpuWorker, GcpNodeRef, parse_worker_host
 from iris.rpc import job_pb2
 from marin.cluster import gcp
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/ops/cross_region.py
+++ b/scripts/ops/cross_region.py
@@ -31,7 +31,6 @@ from pathlib import Path
 import click
 import duckdb
 import fsspec
-
 from iris.cluster.config import IrisConfig
 from iris.cluster.controller.checkpoint import _find_latest_checkpoint_dir, download_checkpoint_to_local
 from rigging.filesystem import get_bucket_location, region_from_prefix

--- a/scripts/ops/storage/dashboard/server.py
+++ b/scripts/ops/storage/dashboard/server.py
@@ -33,9 +33,6 @@ import uvicorn
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
-from starlette.responses import FileResponse, JSONResponse
-
-
 from scripts.storage.constants import (
     GCS_DISCOUNT,
     continent_for_region,
@@ -51,6 +48,7 @@ from scripts.storage.db import (
     flush_protect_rules,
     init_db,
 )
+from starlette.responses import FileResponse, JSONResponse
 
 log = logging.getLogger(__name__)
 

--- a/scripts/ops/storage/delete_files.py
+++ b/scripts/ops/storage/delete_files.py
@@ -48,7 +48,6 @@ from rich.live import Live
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
-
 from scripts.storage.constants import STORAGE_CLASS_PRICING, human_bytes
 from scripts.storage.report import _download_gcs_parquet
 

--- a/scripts/ops/storage/distributed_scan.py
+++ b/scripts/ops/storage/distributed_scan.py
@@ -28,7 +28,8 @@ import threading
 import time
 import uuid
 from collections import deque
-from dataclasses import dataclass, field as dataclass_field
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from typing import Any
 
 import click
@@ -36,7 +37,6 @@ import google.auth
 import pyarrow as pa
 import pyarrow.parquet as pq
 from google.cloud import storage
-
 from scripts.storage.constants import (
     ADAPTIVE_MAX_DEPTH,
     ADAPTIVE_SPLIT_THRESHOLD,

--- a/scripts/pm/gh_issues_from_markdown.py
+++ b/scripts/pm/gh_issues_from_markdown.py
@@ -17,10 +17,11 @@ Usage: python gh_issues_from_markdown.py <markdown_file>
 
 """
 
+import json
 import os
 from datetime import datetime
+
 import requests
-import json
 
 # Configuration
 GITHUB_REPO = "stanford-crfm/marin"

--- a/scripts/pm/itemize_experiment_issues.py
+++ b/scripts/pm/itemize_experiment_issues.py
@@ -13,11 +13,12 @@ Usage:
 """
 
 import os
-from pathlib import Path
 import re
-from github import Github
+from pathlib import Path
 from urllib.parse import urlparse
+
 import wandb
+from github import Github
 
 
 def clean_title(title):

--- a/scripts/pm/replace_crfm_links.py
+++ b/scripts/pm/replace_crfm_links.py
@@ -18,9 +18,10 @@ Requires:
     export GITHUB_TOKEN=your_token
 """
 
+import argparse
 import os
 import re
-import argparse
+
 from github import Github
 
 

--- a/scripts/pm/replace_wandb_links.py
+++ b/scripts/pm/replace_wandb_links.py
@@ -17,9 +17,10 @@ Requires:
     export GITHUB_TOKEN=your_token
 """
 
+import argparse
 import os
 import re
-import argparse
+
 from github import Github
 
 

--- a/scripts/training/scaling_law/calc_model_stats.py
+++ b/scripts/training/scaling_law/calc_model_stats.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-import yaml
-
 from pathlib import Path
+
+import yaml
 from levanter.utils.flop_utils import lm_flops_per_token
 
 

--- a/scripts/training/time_to_train/parse_wandb_runs.py
+++ b/scripts/training/time_to_train/parse_wandb_runs.py
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import pytz
-import wandb
+from datetime import datetime
 
 import pandas as pd
-from datetime import datetime
+import pytz
+import wandb
 
 WANDB_ENTITY = os.getenv("WANDB_ENTITY", "stanford-mercury")
 WANDB_PROJECT = "marin"

--- a/tests/datakit/download/test_ar5iv.py
+++ b/tests/datakit/download/test_ar5iv.py
@@ -6,8 +6,8 @@ import json
 import zipfile
 
 import pytest
-
-from marin.datakit.download.ar5iv import Ar5ivDownloadConfig as DownloadConfig, download
+from marin.datakit.download.ar5iv import Ar5ivDownloadConfig as DownloadConfig
+from marin.datakit.download.ar5iv import download
 
 
 @pytest.fixture

--- a/tests/datakit/download/test_game_music_evals.py
+++ b/tests/datakit/download/test_game_music_evals.py
@@ -7,10 +7,9 @@ import io
 import json
 from pathlib import Path
 
+import marin.datakit.download.game_music_evals as game_music_evals
 import pytest
 import zstandard
-
-import marin.datakit.download.game_music_evals as game_music_evals
 from marin.datakit.download.game_music_evals import (
     HfJsonTextStagingConfig,
     LichessPgnStagingConfig,

--- a/tests/datakit/download/test_huggingface.py
+++ b/tests/datakit/download/test_huggingface.py
@@ -7,8 +7,6 @@ import json
 
 import pytest
 from huggingface_hub.errors import HfHubHTTPError
-from requests import Response
-
 from marin.datakit.download import huggingface as hf_download
 from marin.datakit.download.huggingface import (
     DownloadConfig,
@@ -16,6 +14,7 @@ from marin.datakit.download.huggingface import (
     download_hf,
     stream_file_to_fsspec,
 )
+from requests import Response
 
 
 def _write(root, relative_path: str, content: bytes) -> None:

--- a/tests/datakit/download/test_nemotron_cc.py
+++ b/tests/datakit/download/test_nemotron_cc.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 import pytest
 import zstandard as zstd
-
 from marin.datakit.download.nemotron_v1 import NCC_PATHS_SUFFIX, download_nemotron_cc
 
 SAMPLE_NEMOTRON_RECORDS = [

--- a/tests/datakit/download/test_npm_registry_metadata.py
+++ b/tests/datakit/download/test_npm_registry_metadata.py
@@ -9,7 +9,6 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
-
 from marin.datakit.download.npm_registry_metadata import (
     DEFAULT_OUTPUT_FILENAME,
     DownloadNpmRegistryMetadataConfig,

--- a/tests/datakit/download/test_uwf_zeek.py
+++ b/tests/datakit/download/test_uwf_zeek.py
@@ -5,9 +5,8 @@ import gzip
 import json
 from pathlib import Path
 
-import pytest
-
 import marin.datakit.download.uwf_zeek as uwf_zeek
+import pytest
 from marin.datakit.download.uwf_zeek import (
     DEFAULT_OUTPUT_FILENAME,
     UwfZeekSampleSource,

--- a/tests/datakit/test_datakit.py
+++ b/tests/datakit/test_datakit.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import numpy as np
 import pytest
 from levanter.store.cache import CacheLedger, TreeCache
-
 from marin.datakit.download.huggingface import download_hf_step
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec

--- a/tests/datakit/test_normalize.py
+++ b/tests/datakit/test_normalize.py
@@ -10,7 +10,6 @@ from pathlib import Path
 import pyarrow.parquet as pq
 import pytest
 from fray import LocalClient, set_current_client
-
 from marin.datakit.normalize import generate_id, normalize_to_parquet
 
 

--- a/tests/datakit_testbed/test_sampler.py
+++ b/tests/datakit_testbed/test_sampler.py
@@ -9,14 +9,13 @@ from pathlib import Path
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-
 from marin.datakit.normalize import NormalizedData
+from marin.datakit.sources import DatakitSource
 
 from experiments.datakit_testbed.sampler import (
     proportional_sample_fractions,
     sample_normalized_shards,
 )
-from marin.datakit.sources import DatakitSource
 
 
 def _write_normalized_shard(path: Path, ids: list[str]) -> None:

--- a/tests/datakit_testbed/test_sampler_pipeline.py
+++ b/tests/datakit_testbed/test_sampler_pipeline.py
@@ -4,9 +4,9 @@
 """Structural tests for the Datakit Testbed ferry DAG."""
 
 import pytest
+from marin.datakit.sources import DatakitSource, all_sources
 
 from experiments.datakit_testbed.sampler import build_testbed_steps
-from marin.datakit.sources import DatakitSource, all_sources
 
 _ALL = all_sources()
 _ALL_LIST = list(_ALL.values())

--- a/tests/datakit_testbed/test_train.py
+++ b/tests/datakit_testbed/test_train.py
@@ -9,9 +9,10 @@ Llama-3 tokenizer (gated repo) via ``default_validation_sets``, so its
 end-to-end shape is validated by a live smoke run rather than unit tests.
 """
 
+from marin.datakit.sources import all_sources
+
 from experiments.datakit_testbed.sampler import build_testbed_steps
 from experiments.datakit_testbed.train import testbed_tokenize as _testbed_tokenize
-from marin.datakit.sources import all_sources
 
 _SMOKE_SOURCE = all_sources()["nemotron_cc_code_v1/all"]
 

--- a/tests/evals/test_long_tail_ppl.py
+++ b/tests/evals/test_long_tail_ppl.py
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from levanter.data.text import HfDatasetSourceConfig
+from marin.evaluation.perplexity_gap import _to_dataset_component, raw_text_dataset
+from marin.processing.tokenize import HfDatasetSpec
 
 from experiments.evals.long_tail_ppl import (
     GAME_MUSIC_ISSUE,
@@ -9,9 +12,6 @@ from experiments.evals.long_tail_ppl import (
     long_tail_raw_validation_sets,
     render_long_tail_ppl_registry_markdown,
 )
-from levanter.data.text import HfDatasetSourceConfig
-from marin.evaluation.perplexity_gap import _to_dataset_component, raw_text_dataset
-from marin.processing.tokenize import HfDatasetSpec
 
 
 def test_long_tail_raw_validation_sets_render_deterministic_paths_and_tags():

--- a/tests/execution/test_disk_cache.py
+++ b/tests/execution/test_disk_cache.py
@@ -6,11 +6,9 @@ import os
 from pathlib import Path
 
 import cloudpickle
-
 from marin.execution.artifact import Artifact
 from marin.execution.disk_cache import disk_cache
-from marin.execution.executor_step_status import distributed_lock
-from marin.execution.executor_step_status import STATUS_SUCCESS, StatusFile
+from marin.execution.executor_step_status import STATUS_SUCCESS, StatusFile, distributed_lock
 from marin.execution.step_spec import StepSpec
 
 

--- a/tests/execution/test_executor.py
+++ b/tests/execution/test_executor.py
@@ -10,16 +10,16 @@ import time
 from dataclasses import asdict, dataclass
 from threading import Event, Thread
 
+import marin.execution.executor_step_status as executor_step_status
 import pytest
 from draccus.utils import Dataclass
 from fray.types import ResourceConfig
-import marin.execution.executor_step_status as executor_step_status
-from marin.execution import THIS_OUTPUT_PATH
 from marin.evaluation.perplexity_gap import (
     GapFinderModelConfig,
     model_perplexity_scores,
     raw_text_dataset,
 )
+from marin.execution import THIS_OUTPUT_PATH
 from marin.execution.executor import (
     Executor,
     ExecutorStep,

--- a/tests/execution/test_executor_utils.py
+++ b/tests/execution/test_executor_utils.py
@@ -4,7 +4,6 @@
 from types import SimpleNamespace
 
 import pytest
-
 from marin.execution.executor import InputName
 from marin.utilities.executor_utils import ckpt_path_to_step_name
 

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -9,13 +9,12 @@ from unittest.mock import patch
 
 import pytest
 from fray.types import ResourceConfig
-from rigging.filesystem import MARIN_CROSS_REGION_OVERRIDE_ENV
-
 from marin.execution.artifact import Artifact, PathMetadata
-from marin.execution.executor import _dag_tpu_regions, Executor, ExecutorStep, resolve_executor_step
+from marin.execution.executor import Executor, ExecutorStep, _dag_tpu_regions, resolve_executor_step
 from marin.execution.remote import RemoteCallable, remote
-from marin.execution.step_spec import StepSpec
 from marin.execution.step_runner import StepRunner
+from marin.execution.step_spec import StepSpec
+from rigging.filesystem import MARIN_CROSS_REGION_OVERRIDE_ENV
 
 # ---------------------------------------------------------------------------
 # Artifact types

--- a/tests/integration/iris/cluster.py
+++ b/tests/integration/iris/cluster.py
@@ -8,6 +8,7 @@ import time
 from contextlib import contextmanager
 from dataclasses import dataclass
 
+from finelog.rpc import logging_pb2
 from iris.client.client import IrisClient, Job
 from iris.cluster.constraints import Constraint
 from iris.cluster.types import (
@@ -17,7 +18,6 @@ from iris.cluster.types import (
     ReservationEntry,
     ResourceSpec,
 )
-from finelog.rpc import logging_pb2
 from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Duration
 

--- a/tests/integration/iris/test_iris_integration.py
+++ b/tests/integration/iris/test_iris_integration.py
@@ -14,25 +14,24 @@ import time
 import uuid
 
 import pytest
+from finelog.rpc import logging_pb2
 from iris.cluster.constraints import region_constraint
 from iris.cluster.types import (
     ReservationEntry,
     ResourceSpec,
     gpu_device,
 )
-from finelog.rpc import logging_pb2
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Duration, ExponentialBackoff
 
 from .jobs import (
     busy_loop,
+    fail,
     log_verbose,
     noop,
     quick,
-    fail,
-    sleep,
     register_endpoint,
+    sleep,
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/iris/test_iris_kind.py
+++ b/tests/integration/iris/test_iris_kind.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
-
+from finelog.server.service import LogServiceImpl
 from fray.iris_backend import FrayIrisClient
 from fray.types import Entrypoint as FrayEntrypoint
 from fray.types import GpuConfig, JobRequest, ResourceConfig
@@ -33,14 +33,12 @@ from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.service import ControllerServiceImpl
 from iris.cluster.controller.stores import ControllerStore
 from iris.cluster.controller.transitions import ControllerTransitions
-from finelog.server.service import LogServiceImpl
 from iris.cluster.providers.k8s.fake import FakeNodeResources, InMemoryK8sService
 from iris.cluster.providers.k8s.service import CloudK8sService
-from iris.cluster.providers.k8s.tasks import K8sTaskProvider, _LABEL_MANAGED, _LABEL_RUNTIME, _RUNTIME_LABEL_VALUE
+from iris.cluster.providers.k8s.tasks import _LABEL_MANAGED, _LABEL_RUNTIME, _RUNTIME_LABEL_VALUE, K8sTaskProvider
 from iris.cluster.providers.k8s.types import K8sResource
 from iris.cluster.types import Entrypoint, EnvironmentSpec, JobName, ResourceSpec, TaskAttempt
-from iris.rpc import job_pb2
-from iris.rpc import controller_pb2
+from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Duration
 
 # ---------------------------------------------------------------------------

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -27,7 +27,6 @@ import fsspec
 from fray import ResourceConfig, set_current_client
 from fray.iris_backend import FrayIrisClient
 from fray.types import Entrypoint, JobRequest, create_environment
-from rigging.log_setup import configure_logging
 from levanter.main.train_lm import TrainLmConfig
 from levanter.models.gpt2 import Gpt2Config
 from levanter.trainer import TrainerConfig
@@ -47,6 +46,7 @@ from marin.processing.tokenize.tokenize import TokenizeConfig, tokenize
 from marin.schemas.web.convert import ResiliparseConfig
 from marin.training.training import TrainLmOnPodConfig, run_levanter_train_lm
 from marin.transform.simple_html_to_md.process import SimpleHtmlToMdConfig, html_to_md
+from rigging.log_setup import configure_logging
 
 configure_logging(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/tests/mcp/test_babysitter.py
+++ b/tests/mcp/test_babysitter.py
@@ -3,7 +3,6 @@
 
 from iris.cli.token_store import store_token
 from iris.rpc import controller_pb2, job_pb2, time_pb2
-
 from marin.mcp.babysitter import (
     IrisBabysitter,
     IrisConnectionConfig,

--- a/tests/processing/classification/conftest.py
+++ b/tests/processing/classification/conftest.py
@@ -1,9 +1,10 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
 import os
 import tempfile
+
+import pytest
 from zephyr import write_jsonl_file
 
 

--- a/tests/processing/classification/deduplication/test_exact.py
+++ b/tests/processing/classification/deduplication/test_exact.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from marin.processing.classification.deduplication.dedup_commons import DedupMode
-from marin.processing.classification.deduplication.exact import dedup_exact_paragraph, dedup_exact_document
+from marin.processing.classification.deduplication.exact import dedup_exact_document, dedup_exact_paragraph
+
 from tests.processing.classification.deduplication.conftest import load_dedup_parquet_outputs
 
 

--- a/tests/processing/classification/deduplication/test_fuzzy.py
+++ b/tests/processing/classification/deduplication/test_fuzzy.py
@@ -7,8 +7,6 @@ from pathlib import Path
 import pyarrow.parquet as pq
 import pytest
 from fray import LocalClient, set_current_client
-from zephyr import write_parquet_file
-
 from marin.datakit.normalize import NormalizedData, generate_id, normalize_to_parquet
 from marin.processing.classification.deduplication.fuzzy_dups import compute_fuzzy_dups_attrs
 from marin.processing.classification.deduplication.fuzzy_minhash import (
@@ -16,6 +14,7 @@ from marin.processing.classification.deduplication.fuzzy_minhash import (
     MinHashParams,
     compute_minhash_attrs,
 )
+from zephyr import write_parquet_file
 
 TEST_MINHASH_PARAMS = MinHashParams(num_perms=286, num_bands=26, ngram_size=5, seed=42)
 

--- a/tests/processing/classification/test_decon.py
+++ b/tests/processing/classification/test_decon.py
@@ -4,10 +4,9 @@
 import os
 from pathlib import Path
 
-from zephyr import load_jsonl
-from marin.utils import fsspec_exists
-
 from marin.processing.classification.decon import DeconConfig, DeconMode, NGramConfig, decontaminate
+from marin.utils import fsspec_exists
+from zephyr import load_jsonl
 
 
 def load_dedup_outputs(output_dir: str) -> dict[str, dict]:

--- a/tests/rl/environments/test_load_environment.py
+++ b/tests/rl/environments/test_load_environment.py
@@ -4,8 +4,8 @@
 """Tests for environment loading from EnvConfig."""
 
 from marin.rl.environments import EnvConfig, load_environment_from_spec
-from marin.rl.environments.mock_env import MockEnv
 from marin.rl.environments.math_env import MathEnv
+from marin.rl.environments.mock_env import MockEnv
 
 
 def test_load_mock_environment():

--- a/tests/rl/environments/test_math_env.py
+++ b/tests/rl/environments/test_math_env.py
@@ -6,13 +6,12 @@
 import jax.random
 import numpy as np
 import pytest
+from marin.rl.environments.inference_ctx import LevanterInferenceContext
+from marin.rl.environments.math_env import MathEnv
 from openai.types.chat import ChatCompletion, ChatCompletionMessage
 from openai.types.chat.chat_completion import Choice
 from openai.types.chat.chat_completion_token_logprob import ChatCompletionTokenLogprob
 from openai.types.completion_usage import CompletionUsage
-
-from marin.rl.environments.math_env import MathEnv
-from marin.rl.environments.inference_ctx import LevanterInferenceContext
 
 
 def create_mock_chat_completion(tokenizer) -> ChatCompletion:

--- a/tests/rl/environments/test_mock_env.py
+++ b/tests/rl/environments/test_mock_env.py
@@ -4,10 +4,6 @@
 import jax.numpy as jnp
 import numpy as np
 import pytest
-from openai.types.chat import ChatCompletion, ChatCompletionMessage
-from openai.types.chat.chat_completion import Choice, ChoiceLogprobs
-from openai.types.completion_usage import CompletionUsage
-
 from marin.rl.environments.mock_env import (
     AdditionTask,
     MoarCatsTask,
@@ -16,6 +12,9 @@ from marin.rl.environments.mock_env import (
     compute_soft_reward,
 )
 from marin.rl.types import Rollout, RolloutGroup
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice, ChoiceLogprobs
+from openai.types.completion_usage import CompletionUsage
 
 
 def create_test_tokenizer():

--- a/tests/rl/environments/test_prime_intellect_env.py
+++ b/tests/rl/environments/test_prime_intellect_env.py
@@ -8,14 +8,13 @@ from unittest.mock import AsyncMock, patch
 import jax.random
 import numpy as np
 import pytest
+from levanter.tokenizers import load_tokenizer
 from openai.types.chat import ChatCompletion, ChatCompletionMessage
 from openai.types.chat.chat_completion import Choice
 from openai.types.completion_usage import CompletionUsage
-from levanter.tokenizers import load_tokenizer
 
 try:
     import verifiers as vf
-
     from marin.rl.environments.prime_intellect_env import PrimeIntellectEnv
 except ImportError:
     pytest.skip("verifiers library not installed", allow_module_level=True)

--- a/tests/rl/environments/test_process_vllm_results.py
+++ b/tests/rl/environments/test_process_vllm_results.py
@@ -4,14 +4,13 @@
 """Tests for vLLM result processing functions."""
 
 import pytest
-from openai.types.chat import ChatCompletion, ChatCompletionMessage
-from openai.types.chat.chat_completion import Choice, ChoiceLogprobs, ChatCompletionTokenLogprob
-from openai.types.completion_usage import CompletionUsage
-
 from marin.rl.environments.process_vllm_results import (
-    parse_chat_completion_tokens_from_bytes,
     parse_chat_completion_logprobs,
+    parse_chat_completion_tokens_from_bytes,
 )
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import ChatCompletionTokenLogprob, Choice, ChoiceLogprobs
+from openai.types.completion_usage import CompletionUsage
 
 
 @pytest.fixture

--- a/tests/rl/integration/config.py
+++ b/tests/rl/integration/config.py
@@ -22,32 +22,31 @@ import jax.numpy as jnp
 import jax.random as jrandom
 import jmp
 import numpy as np
+from fray import current_client
 from levanter.checkpoint import CheckpointerConfig
 from levanter.inference.engine import InferenceEngine, InferenceEngineConfig, Request
 from levanter.inference.jit_scheduler import SeqDecodingParams
 from levanter.inference.openai import InferenceServerConfig
+from levanter.layers.rotary import Llama3RotaryEmbeddingsConfig
 from levanter.models.llama import LlamaConfig
 from levanter.models.qwen import Qwen3Config
-from levanter.layers.rotary import Llama3RotaryEmbeddingsConfig
-from marin.rl.environments.inference_ctx import vLLMInferenceContextConfig
 from levanter.optim import AdamConfig
+from levanter.tokenizers import load_tokenizer
 from levanter.tracker.json_logger import JsonLoggerConfig
 from levanter.trainer import TrainerConfig
-from optax import softmax_cross_entropy_with_integer_labels
-from levanter.tokenizers import load_tokenizer
-
-from fray import current_client
 from marin.rl.curriculum import Curriculum
-from marin.rl.runtime import RLRuntimeHandles, WeightTransferRuntime
+from marin.rl.environments.inference_ctx import vLLMInferenceContextConfig
 from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_losses import RLOOLoss
 from marin.rl.rollout_storage import RolloutStorageConfig
 from marin.rl.rollout_worker import RolloutWorker, find_open_port
 from marin.rl.run_state import RLRunState
+from marin.rl.runtime import RLRuntimeHandles, WeightTransferRuntime
 from marin.rl.train_worker import TrainWorker, TrainWorkerConfig
 from marin.rl.weight_transfer import WeightTransferConfig
 from marin.rl.weight_transfer.arrow_flight import ArrowFlightCoordinator
 from marin.rl.weight_transfer.base import WeightTransferMode
+from optax import softmax_cross_entropy_with_integer_labels
 
 logger = logging.getLogger(__name__)
 

--- a/tests/rl/integration/tasks.py
+++ b/tests/rl/integration/tasks.py
@@ -6,8 +6,8 @@
 import time
 
 import numpy as np
-
 from marin.rl.types import Rollout, RolloutBatch, RolloutGroup, RolloutMetadata
+
 from tests.rl.integration.config import (
     DummyTokenizer,
     compute_model_logprobs,

--- a/tests/rl/integration/test_cats_integration.py
+++ b/tests/rl/integration/test_cats_integration.py
@@ -10,10 +10,10 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-
 from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
 from marin.rl.rl_losses import RLOOLoss
+
 from tests.rl.integration.config import (
     DummyTokenizer,
     RolloutBatchFeeder,
@@ -23,11 +23,11 @@ from tests.rl.integration.config import (
     create_nano_llama_config,
     create_nano_optimizer_config,
     create_nano_trainer_config,
+    create_qwen_config,
+    create_qwen_tokenizer,
     create_test_curriculum_config,
     create_test_rollout_storage_config,
     create_vllm_inference_config,
-    create_qwen_config,
-    create_qwen_tokenizer,
 )
 from tests.rl.integration.tasks import create_cats_rollout_batch, validate_cats_model
 

--- a/tests/rl/integration/test_checkpoint_restart.py
+++ b/tests/rl/integration/test_checkpoint_restart.py
@@ -9,9 +9,9 @@ from datetime import timedelta
 from pathlib import Path
 
 import pytest
-
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
 from marin.rl.rl_losses import RLOOLoss
+
 from tests.rl.integration.config import (
     DummyTokenizer,
     TrainWorkerRunner,

--- a/tests/rl/integration/test_llama_math_integration.py
+++ b/tests/rl/integration/test_llama_math_integration.py
@@ -9,22 +9,22 @@ import logging
 import os
 
 import jmp
-from levanter.utils.mesh import MeshConfig
 import pytest
 from levanter.checkpoint import CheckpointerConfig
 from levanter.models.llama import LlamaConfig
 from levanter.optim import AdamConfig
+from levanter.tokenizers import load_tokenizer
 from levanter.tracker.json_logger import JsonLoggerConfig
 from levanter.trainer import TrainerConfig
-from levanter.tokenizers import load_tokenizer
-from transformers import AutoConfig
-
+from levanter.utils.mesh import MeshConfig
 from marin.rl.curriculum import CurriculumConfig, LessonConfig, SamplingParams
 from marin.rl.environments import EnvConfig
 from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
 from marin.rl.rl_losses import RLOOLoss
 from marin.rl.weight_transfer import WeightTransferConfig, WeightTransferMode
+from transformers import AutoConfig
+
 from tests.rl.integration.config import (
     RolloutWorkerRunner,
     create_test_rollout_storage_config,

--- a/tests/rl/integration/test_rollout_worker.py
+++ b/tests/rl/integration/test_rollout_worker.py
@@ -7,9 +7,9 @@ import os
 import time
 
 import pytest
-
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
 from marin.rl.rl_losses import RLOOLoss
+
 from tests.rl.integration.config import (
     DummyTokenizer,
     RolloutWorkerRunner,

--- a/tests/rl/integration/test_train_worker.py
+++ b/tests/rl/integration/test_train_worker.py
@@ -6,9 +6,9 @@
 import os
 
 import pytest
-
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
 from marin.rl.rl_losses import RLOOLoss
+
 from tests.rl.integration.config import (
     DummyTokenizer,
     RolloutBatchFeeder,

--- a/tests/rl/integration/test_weight_sync.py
+++ b/tests/rl/integration/test_weight_sync.py
@@ -7,9 +7,9 @@ import os
 import time
 
 import pytest
-
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
 from marin.rl.rl_losses import RLOOLoss
+
 from tests.rl.integration.config import (
     DummyTokenizer,
     RolloutWorkerRunner,

--- a/tests/rl/test_compute_logprobs.py
+++ b/tests/rl/test_compute_logprobs.py
@@ -1,12 +1,11 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from types import SimpleNamespace
+
 import jax
 import jax.numpy as jnp
 import pytest
-
-from types import SimpleNamespace
-
 from marin.rl.rl_losses import compute_logprobs, importance_sampling_ratio
 
 

--- a/tests/rl/test_curriculum.py
+++ b/tests/rl/test_curriculum.py
@@ -5,7 +5,6 @@
 
 import numpy as np
 import pytest
-
 from marin.rl.curriculum import (
     Curriculum,
     CurriculumConfig,

--- a/tests/rl/test_inference_ctx.py
+++ b/tests/rl/test_inference_ctx.py
@@ -5,27 +5,25 @@
 
 import sys
 from dataclasses import dataclass
-from types import SimpleNamespace
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import numpy as np
 import pytest
 from levanter.inference.openai import ChatMessage
-from openai.types.chat import ChatCompletionMessage
-from openai.types.chat.chat_completion import ChatCompletionTokenLogprob, Choice, ChoiceLogprobs
-from transformers import AutoTokenizer
-
 from marin.rl.environments.inference_ctx import (
-    LevanterInferenceContext,
-    LevanterInferenceContextConfig,
     MODEL_MAPPINGS,
     MODEL_TRANSPOSE_KEYS,
+    LevanterInferenceContext,
+    LevanterInferenceContextConfig,
     VLLMSamplingConfig,
     vLLMInferenceContext,
     vLLMInferenceContextConfig,
 )
-from marin.rl.environments.inference_ctx.vllm import InferenceMode
 from marin.rl.environments.inference_ctx.inflight.worker import WorkerExtension
+from marin.rl.environments.inference_ctx.vllm import InferenceMode
+from openai.types.chat import ChatCompletionMessage
+from openai.types.chat.chat_completion import ChatCompletionTokenLogprob, Choice, ChoiceLogprobs
+from transformers import AutoTokenizer
 
 _LLAMA3_MODEL_ID = "NousResearch/Meta-Llama-3-8B-Instruct"
 

--- a/tests/rl/test_loss.py
+++ b/tests/rl/test_loss.py
@@ -1,8 +1,8 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
 import numpy as np
+import pytest
 from marin.rl.rl_losses import RLOOLoss, compute_ppo_loss_objective, compute_rloo_advantages
 from marin.rl.types import Rollout
 

--- a/tests/rl/test_orchestration.py
+++ b/tests/rl/test_orchestration.py
@@ -6,7 +6,6 @@ import sys
 from types import SimpleNamespace
 
 import pytest
-
 from fray.types import JobStatus
 from marin.rl.orchestration import _HostedRuntime, _run_rl_coordinator, _train_worker_entry
 from marin.rl.rl_job import RunConfig

--- a/tests/rl/test_rollout_storage.py
+++ b/tests/rl/test_rollout_storage.py
@@ -9,7 +9,6 @@ import time
 import jax.numpy as jnp
 import numpy as np
 import pytest
-
 from marin.rl.rollout_storage import (
     RolloutStorageConfig,
     StorageType,

--- a/tests/rl/test_rollout_worker.py
+++ b/tests/rl/test_rollout_worker.py
@@ -6,10 +6,8 @@ from types import SimpleNamespace
 
 import fsspec
 import pytest
-
 from marin.rl.environments.inference_ctx.staging import stage_vllm_metadata_locally
 from marin.rl.environments.inference_ctx.vllm import VLLMSamplingConfig, vLLMInferenceContextConfig
-from marin.rl.run_state import RolloutTransferCounters
 from marin.rl.rollout_worker import (
     RolloutTracker,
     RolloutTrackerConfig,
@@ -19,6 +17,7 @@ from marin.rl.rollout_worker import (
     _should_run_micro_eval,
     create_inference_context,
 )
+from marin.rl.run_state import RolloutTransferCounters
 
 
 def test_rollout_tracker_uses_explicit_name_when_provided(monkeypatch):

--- a/tests/rl/test_rollout_worker_pass_at_k.py
+++ b/tests/rl/test_rollout_worker_pass_at_k.py
@@ -4,7 +4,6 @@
 import math
 
 import pytest
-
 from marin.rl.metrics import pass_at_k_estimator
 
 

--- a/tests/rl/test_train_batch.py
+++ b/tests/rl/test_train_batch.py
@@ -5,7 +5,6 @@
 
 import numpy as np
 import pytest
-
 from marin.rl import train_batch
 from marin.rl.types import Rollout, RolloutWithAdvantage
 

--- a/tests/test_consolidate_metadata.py
+++ b/tests/test_consolidate_metadata.py
@@ -14,7 +14,6 @@ import tempfile
 
 import jax
 import numpy as np
-
 from levanter.store.cache import (
     CacheLedger,
     _consolidate_metadata,

--- a/tests/test_data_configs.py
+++ b/tests/test_data_configs.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
 from marin.processing.tokenize.data_configs import _are_tokenizers_equivalent
 
 

--- a/tests/test_download_pretokenized.py
+++ b/tests/test_download_pretokenized.py
@@ -10,7 +10,6 @@ import requests  # For requests.exceptions.RequestException
 from huggingface_hub.utils import HfHubHTTPError
 from levanter.store import TreeCache
 from levanter.tokenizers import load_tokenizer
-
 from marin.processing.tokenize.download_pretokenized import (
     PretokenizedCacheDownloadConfig,
     _actually_download_pretokenized_cache,

--- a/tests/test_grug_checkpointing.py
+++ b/tests/test_grug_checkpointing.py
@@ -9,9 +9,9 @@ from pathlib import Path
 
 import jax.numpy as jnp
 import pytest
+from levanter.checkpoint import Checkpointer, CheckpointInterval
 
 from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
-from levanter.checkpoint import CheckpointInterval, Checkpointer
 
 
 def _write_checkpoint_metadata(checkpoint_dir: Path, *, step: int, timestamp: str) -> None:

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -25,7 +25,6 @@ import pytest
 from fray.cluster import ResourceConfig
 from jax._src import config as jax_config
 from jax.sharding import use_abstract_mesh
-
 from levanter.checkpoint import CheckpointerConfig
 from levanter.data.dataset import ListAsyncDataset
 from levanter.data.text import DirectDatasetComponent, LmDataConfig

--- a/tests/test_hfdataset_spec.py
+++ b/tests/test_hfdataset_spec.py
@@ -1,10 +1,11 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from experiments.defaults import default_download, default_tokenize
 from marin.datakit.download.huggingface import DownloadConfig
 from marin.processing.tokenize import HfDatasetSpec
 from marin.processing.tokenize.tokenize import HfTokenizeConfig, TokenizeConfig
+
+from experiments.defaults import default_download, default_tokenize
 
 
 def test_default_tokenize_with_dataset_name():

--- a/tests/test_marin_chat_template.py
+++ b/tests/test_marin_chat_template.py
@@ -5,14 +5,14 @@ import tempfile
 from collections.abc import Sequence
 
 import pytest
+from levanter.data.text import ChatProcessor
+from levanter.tokenizers import load_tokenizer
 
 from experiments.create_marin_tokenizer import (
     create_marin_tokenizer,
     load_llama3_tokenizer,
     run_all_tests,
 )
-from levanter.data.text import ChatProcessor
-from levanter.tokenizers import load_tokenizer
 
 
 @pytest.fixture()

--- a/tests/test_scaling_laws.py
+++ b/tests/test_scaling_laws.py
@@ -8,7 +8,6 @@ the snapshot test which ensures reproducibility of config generation.
 """
 
 import jax.numpy as jnp
-
 from marin.scaling_laws.isoflop_analysis import (
     DEFAULT_SEQ_LEN,
     CandidateConfig,
@@ -182,6 +181,7 @@ def test_end_to_end_analysis_pipeline():
     pipeline: metrics transformation -> curve fitting -> scaling law extraction.
     """
     from marin.scaling_laws import round_flops_to_bucket
+
     from experiments.isoflop_sweep import transform_levanter_metrics
 
     # Transform metrics using the Levanter transform function

--- a/tests/test_slice_cache.py
+++ b/tests/test_slice_cache.py
@@ -9,8 +9,8 @@ import pytest
 from levanter.data import ShardedDataSource
 from levanter.data.text import LmDatasetSourceConfigBase, UrlDatasetSourceConfig
 from levanter.store import SerialCacheWriter, TreeCache
-
 from marin.tokenize.slice_cache import SliceCacheConfig, _do_slice_cache, _short_desc_from_lm_config
+
 from tests.test_utils import skip_in_ci
 
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -11,7 +11,6 @@ from fray import ResourceConfig
 from levanter.checkpoint import CheckpointerConfig
 from levanter.main import train_lm
 from levanter.trainer import TrainerConfig
-
 from marin.training.training import (
     TrainLmOnPodConfig,
     _doublecheck_paths,

--- a/tests/transform/security_artifacts/test_renderers.py
+++ b/tests/transform/security_artifacts/test_renderers.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import pytest
-
 from marin.transform.security_artifacts.renderers import (
     DEFAULT_ZEEK_EMPTY_FIELD,
     DEFAULT_ZEEK_UNSET_FIELD,

--- a/tests/transform/security_artifacts/test_zeek_to_dolma.py
+++ b/tests/transform/security_artifacts/test_zeek_to_dolma.py
@@ -9,7 +9,6 @@ import gzip
 import json
 from pathlib import Path
 
-
 from marin.transform.security_artifacts.zeek_to_dolma import (
     ZEEK_RENDER_TAG,
     ZeekToDolmaConfig,

--- a/tests/transform/test_conversation.py
+++ b/tests/transform/test_conversation.py
@@ -9,8 +9,8 @@ from marin.transform.conversation.adapters import InputDatasetFormat, TransformA
 from marin.transform.conversation.conversation_to_dolma import transform_conversation_to_dolma
 from marin.transform.conversation.preference_data_adapters import PreferenceTransformAdapter
 from marin.transform.conversation.transform_conversation import (
-    transform_row,
     TransformSFTDatasetConfig,
+    transform_row,
 )
 
 OPENAI_FORMAT_SAMPLE = {

--- a/tests/transform/test_huggingface_dataset_to_eval.py
+++ b/tests/transform/test_huggingface_dataset_to_eval.py
@@ -7,7 +7,6 @@ import gzip
 import json
 
 from datasets import Dataset
-
 from marin.transform.huggingface.dataset_to_eval import (
     DatasetConversionConfig,
     OutputFormatOptions,

--- a/tests/vllm/test_llm_inference.py
+++ b/tests/vllm/test_llm_inference.py
@@ -5,7 +5,6 @@
 
 
 import pytest
-
 from marin.evaluation.evaluators.evaluator import ModelConfig
 from marin.inference.vllm_server import resolve_model_name_or_path
 


### PR DESCRIPTION
Remove I001 from the ruff ignore list so import order is auto-fixed. Sweep the repo via ruff --fix to resolve 489 existing violations, preventing import-order churn from appearing as cruft in unrelated PRs.