### PR TITLE
[test fixture] zephyr-perf gate: comment-only tweak in shuffle.py

### DIFF
--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -85,6 +85,7 @@ class ListShard:
 # ---------------------------------------------------------------------------
 
 _SCATTER_META_SUFFIX = ".scatter_meta"
+# Suffix for the scatter data file written alongside the .scatter_meta sidecar.
 _SCATTER_DATA_SUFFIX = ".shuffle"
 
 # Number of parallel sidecar reads each reducer issues when building its


### PR DESCRIPTION
No-op fixture for testing the zephyr-perf skill (PR #5313). Touches a hot file with a trivial diff; the gate should recommend Gate 1, not Gate 2.

DO NOT MERGE.
