### PR TITLE
Use TOML deps for native vLLM smoke

### DIFF
--- a/lib/marin/src/marin/inference/vllm_server.py
+++ b/lib/marin/src/marin/inference/vllm_server.py
@@ -26,7 +26,10 @@ from marin.evaluation.evaluators.evaluator import ModelConfig
 logger = logging.getLogger(__name__)
 DEFAULT_VLLM_TPU_DOCKER_IMAGE: str = "vllm/vllm-tpu:nightly-20260104-4a1e25b-0d4044e"
 DEFAULT_VLLM_GPU_DOCKER_IMAGE: str = "nvcr.io/nvidia/vllm:25.12.post1-py3"
-VLLM_NATIVE_PIP_PACKAGES: tuple[str, ...] = ("vllm-tpu==0.18.0", "tpu-inference==0.18.0")
+VLLM_DOCKER_SIDECAR_UNSUPPORTED_MESSAGE = (
+    "Docker sidecar vLLM mode is not supported for Iris jobs because Iris workers do not mount "
+    "/var/run/docker.sock; use native vLLM by leaving MARIN_VLLM_MODE unset or setting it to 'native'."
+)
 
 _SENSITIVE_ENV_KEYS = frozenset(
     {
@@ -236,14 +239,17 @@ class NativeVllmServerBackend(VllmServerBackend):
 
 
 def resolve_vllm_mode(mode: Literal["native", "docker"] | None) -> Literal["native", "docker"]:
-    # Default to native vLLM. The Docker sidecar path requires a mounted
-    # /var/run/docker.sock (docker-alongside-docker), which Iris workers do not
-    # provide. Set MARIN_VLLM_MODE=docker to opt in for Ray-era flows that still
-    # need the sidecar.
+    # Native is the only supported Iris vLLM mode. The old Docker sidecar path
+    # requires docker-alongside-docker, and Iris workers do not mount
+    # /var/run/docker.sock. See GitHub issue #4750.
     mode_str = (mode if mode is not None else os.environ.get("MARIN_VLLM_MODE", "native")).lower()
-    if mode_str not in ("native", "docker"):
-        raise ValueError(f"Unknown MARIN_VLLM_MODE={mode_str!r}; expected 'native' or 'docker'.")
-    return mode_str  # type: ignore[return-value]
+    if mode_str == "native":
+        return mode_str
+    if mode_str == "docker":
+        raise ValueError(VLLM_DOCKER_SIDECAR_UNSUPPORTED_MESSAGE)
+    raise ValueError(
+        f"Unknown MARIN_VLLM_MODE={mode_str!r}; expected 'native'. Docker sidecar mode is unsupported on Iris."
+    )
 
 
 def _resolve_vllm_backend(

--- a/lib/marin/src/marin/inference/vllm_smoke_test.py
+++ b/lib/marin/src/marin/inference/vllm_smoke_test.py
@@ -14,7 +14,7 @@ from fray import current_client
 from fray.types import Entrypoint, JobRequest, ResourceConfig, create_environment
 
 from marin.evaluation.evaluators.evaluator import ModelConfig
-from marin.inference.vllm_server import VLLM_NATIVE_PIP_PACKAGES, VllmEnvironment, resolve_vllm_mode
+from marin.inference.vllm_server import VllmEnvironment, resolve_vllm_mode
 from marin.utils import remove_tpu_lockfile_on_exit
 
 
@@ -101,7 +101,7 @@ def run_one_query(
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Smoke-test vLLM TPU Docker sidecar via OpenAI-compatible HTTP API.")
+    parser = argparse.ArgumentParser(description="Smoke-test a vLLM TPU server via OpenAI-compatible HTTP API.")
     parser.add_argument(
         "--model",
         required=True,
@@ -138,7 +138,10 @@ def main(argv: list[str] | None = None) -> int:
         "--mode",
         choices=["docker", "native"],
         default=None,
-        help="Override MARIN_VLLM_MODE (default: use env; native if unset).",
+        help=(
+            "Override MARIN_VLLM_MODE (default: use env; native if unset). "
+            "Docker sidecar mode is unsupported on Iris."
+        ),
     )
     parser.add_argument(
         "--docker-image",
@@ -193,7 +196,7 @@ def main(argv: list[str] | None = None) -> int:
             print(output)
         return 0
 
-    mode_str = resolve_vllm_mode(args.mode)
+    resolve_vllm_mode(args.mode)
 
     env_vars: dict[str, str] = {}
     if args.mode is not None:
@@ -233,8 +236,8 @@ def main(argv: list[str] | None = None) -> int:
         entrypoint=Entrypoint.from_callable(_run),
         resources=resources,
         environment=create_environment(
-            extras=["eval", "tpu"],
-            pip_packages=VLLM_NATIVE_PIP_PACKAGES if mode_str == "native" else (),
+            extras=["eval", "tpu", "vllm"],
+            pip_packages=(),
             env_vars=env_vars or None,
         ),
     )


### PR DESCRIPTION
## Summary

- Removed the native-only `VLLM_NATIVE_PIP_PACKAGES` override.
- Updated the native vLLM smoke-test Fray environment to use Marin TOML dependencies via extras `eval`, `tpu`, and `vllm` with `pip_packages=()`.
- Kept the Docker-sidecar backend and Docker-specific options in place; sidecar removal is out of scope for this PR.
- Reject `MARIN_VLLM_MODE=docker` with an explicit error before Fray environment creation. Docker sidecar mode requires Docker-alongside-Docker, and Iris workers do not mount `/var/run/docker.sock`.
- No TOML changes are required here: #5278 already moved `lib/marin/pyproject.toml` to `vllm-tpu==0.18.0`, `tpu-inference==0.18.0`, and the matching `tpu` extra pins. This PR changes the native smoke environment to consume those existing extras instead of re-declaring packages in code.

<details>
<summary>Docker sidecar rationale</summary>

Issue #4750 records the underlying Iris limitation: shared Iris clusters do not allow Docker-alongside-Docker, and a v5p-8 smoke failed with a Docker daemon socket permission error while native vLLM succeeded.

PR #4753 was the earlier mitigation: it switched vLLM mode resolution to native by default because Iris workers do not mount `/var/run/docker.sock`, while leaving Docker as an opt-in Ray-era path.

This PR keeps the sidecar implementation in place, but makes `MARIN_VLLM_MODE=docker` fail with a clear unsupported-mode error before creating a Fray environment that cannot work on Iris. Removing the sidecar code should be a follow-up PR.

</details>

## Validation

- `python3 ~/llms/gh_sync.py ~/dev/marin`
  - Passed; refreshed the local GitHub SQLite cache before checking #4750/#4753.
- `uv run --package marin --group lint black --check lib/marin/src/marin/inference/vllm_server.py lib/marin/src/marin/inference/vllm_smoke_test.py`
  - Passed.
- `uv run --package marin --group lint ruff check lib/marin/src/marin/inference/vllm_server.py lib/marin/src/marin/inference/vllm_smoke_test.py`
  - Passed.
- `uv run --package marin pyrefly check lib/marin/src/marin/inference/vllm_server.py lib/marin/src/marin/inference/vllm_smoke_test.py`
  - Passed: `0 errors`.
- `uv lock --check`
  - Passed.

## TPU Validation

Already run for the previous state of this branch:

- Package probe job: `/romain/codex-vllm-toml-probe-20260430`
  - Environment shape: extras `eval`, `tpu`, `vllm`; `pip_packages=()`.
  - Passed and printed `vllm-tpu==0.18.0`, `tpu-inference==0.18.0`, `jax==0.9.2`, `jaxlib==0.9.2`, `libtpu==0.0.38`, and `jax.default_backend == 'tpu'`.
- Native vLLM smoke driver job: `/romain/codex-vllm-native-smoke-20260430`
- Native vLLM smoke TPU child job: `/romain/codex-vllm-native-smoke-20260430/vllm-smoke:v5p-8`
  - Passed; native vLLM server became ready and completed one served request.