### PR TITLE
[test fixture] zephyr-perf gate: shrink _READ_BLOCK_SIZE to surface r…

### DIFF
--- a/lib/zephyr/src/zephyr/readers.py
+++ b/lib/zephyr/src/zephyr/readers.py
@@ -130,7 +130,7 @@ def iter_parquet_row_groups(
 
 
 # 16 MB read blocks with background prefetch for S3/remote reads.
-_READ_BLOCK_SIZE = 16_000_000
+_READ_BLOCK_SIZE = 16_000
 _READ_CACHE_TYPE = "background"
 _READ_MAX_BLOCKS = 2
 


### PR DESCRIPTION
…egression

No-op fixture for testing the zephyr-perf skill (PR #5313). Drops the parquet/jsonl read block size from 16 MB to 16 KB. Local zephyr tests pass (284 passed, 1 xfailed) — the regression only shows up at scale, which is exactly what the perf gate is for.

DO NOT MERGE.