### PR TITLE
[gitignore] Ignore .obsidian folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,4 @@ scr/*
 .entire
 
 .worktrees
+.obsidian


### PR DESCRIPTION
I've been trying out Obsidian for reading Markdown (I'm sort of indifferent TBH) but it creates these folders and ignoring them seems harmless.
