### PR TITLE
Somehow the log server entry wasn't committed previously, making logs disappear.

### DIFF
--- a/lib/iris/examples/marin.yaml
+++ b/lib/iris/examples/marin.yaml
@@ -1,6 +1,8 @@
 # Iris production configuration for Marin cluster
 # Usage: uv run iris --cluster=marin cluster start
 
+log_server_config: marin
+
 platform:
   label_prefix: marin
   gcp:


### PR DESCRIPTION
It's possible we have a few workers with a stale log configuration during the ~5 minute window we were down, but most jobs look okay. I'm just going to let those workers stale out.