### PR TITLE
Fix served LM eval import grouping

### DIFF
--- a/tests/evals/test_served_lm_eval.py
+++ b/tests/evals/test_served_lm_eval.py
@@ -6,9 +6,9 @@ from pathlib import Path
 from statistics import mean
 
 import pytest
-
 from marin.evaluation.served_lm_eval import LmEvalAdapter, LmEvalRun, build_lm_eval_model_args
 from marin.inference.served_model import OpenAIEndpoint, RunningModel
+
 from tests.evals.openai_stub import (
     DeterministicOpenAIStub,
     assert_chat_generation_contract,


### PR DESCRIPTION
Title: Fix served LM eval import grouping

Body:
Reorder the imports in the served LM eval test so Ruff's grouping rule passes on origin/main. This fixes the current pre-commit failure without changing behavior.