### PR TITLE
Add Levanter completion echo logprobs

### DIFF
--- a/lib/levanter/src/levanter/inference/engine.py
+++ b/lib/levanter/src/levanter/inference/engine.py
@@ -30,6 +30,7 @@ from levanter.inference.jit_scheduler import (
 )
 from levanter.inference.page_table import PageTable
 from levanter.inference.utils import INVALID, is_valid
+from levanter.layers.attention import AttentionMask
 from levanter.layers.kv_cache import PageCache
 from levanter.layers.sampler import Sampler
 from levanter.models.lm_model import LmHeadModel
@@ -744,6 +745,58 @@ class GenerationResult:
     total_generated: int
 
 
+FIRST_TOKEN_LOGPROB = 0.0
+
+
+@dataclass(frozen=True)
+class TokenSequenceLogprobs:
+    """Causal logprobs aligned with an input token sequence."""
+
+    token_logprobs: list[float]
+    top_token_logprobs: list[dict[int, float]]
+
+
+def score_token_sequence_logprobs(
+    model: LmHeadModel,
+    token_ids: Sequence[int],
+    top_k: int,
+) -> TokenSequenceLogprobs:
+    """Score a token sequence with a causal full forward pass."""
+    if top_k < 1:
+        raise ValueError("top_k must be at least 1")
+
+    token_id_list = [int(token_id) for token_id in token_ids]
+    if not token_id_list:
+        return TokenSequenceLogprobs(token_logprobs=[], top_token_logprobs=[])
+
+    token_logprobs = [FIRST_TOKEN_LOGPROB]
+    top_token_logprobs = [{token_id_list[0]: FIRST_TOKEN_LOGPROB}]
+    if len(token_id_list) == 1:
+        return TokenSequenceLogprobs(token_logprobs=token_logprobs, top_token_logprobs=top_token_logprobs)
+
+    Pos = hax.Axis("position", len(token_id_list))
+    input_ids = hax.named(jnp.array(token_id_list, dtype=jnp.int32), Pos)
+    pos_ids = hax.named(jnp.arange(len(token_id_list), dtype=jnp.int32), Pos)
+    logits = model(input_ids=input_ids, attn_mask=AttentionMask.causal(), pos_ids=pos_ids, key=None)
+
+    logits_array = logits.astype(jnp.float32).rearrange((Pos, model.Vocab)).array
+    next_token_logprobs = jax.nn.log_softmax(logits_array[:-1], axis=-1)
+    target_ids = jnp.array(token_id_list[1:], dtype=jnp.int32)
+    scored_logprobs = next_token_logprobs[jnp.arange(len(target_ids)), target_ids]
+    token_logprobs.extend(float(logprob) for logprob in jax.device_get(scored_logprobs))
+
+    vocab_top_k = min(top_k, next_token_logprobs.shape[-1])
+    top_values, top_indices = jax.lax.top_k(next_token_logprobs, vocab_top_k)
+    top_values = np.asarray(jax.device_get(top_values))
+    top_indices = np.asarray(jax.device_get(top_indices))
+    for values, indices in zip(top_values, top_indices, strict=True):
+        top_token_logprobs.append(
+            {int(token_id): float(logprob) for token_id, logprob in zip(indices, values, strict=True)}
+        )
+
+    return TokenSequenceLogprobs(token_logprobs=token_logprobs, top_token_logprobs=top_token_logprobs)
+
+
 class InferenceEngine:
     """Encapsulates batch inference: prefill + decode + output extraction.
 
@@ -844,6 +897,10 @@ class InferenceEngine:
         self.local_map.clear()
         self.sequences.clear()
         self.results = {}
+
+    def score_token_logprobs(self, token_ids: Sequence[int], top_k: int) -> TokenSequenceLogprobs:
+        """Score a token sequence under this engine's model."""
+        return score_token_sequence_logprobs(self.model, token_ids, top_k)
 
     def _prefill_batch(self, batch: Sequence[Request]) -> _DecodeOutputs | None:
         """Admit a batch from the head of the queue that fits in free slots/pages.

--- a/lib/levanter/src/levanter/inference/engine.py
+++ b/lib/levanter/src/levanter/inference/engine.py
@@ -750,7 +750,11 @@ FIRST_TOKEN_LOGPROB = 0.0
 
 @dataclass(frozen=True)
 class TokenSequenceLogprobs:
-    """Causal logprobs aligned with an input token sequence."""
+    """Causal logprobs aligned with an input token sequence.
+
+    The first token has no preceding context, so its logprob is the synthetic
+    ``FIRST_TOKEN_LOGPROB`` sentinel and its top-token map contains only itself.
+    """
 
     token_logprobs: list[float]
     top_token_logprobs: list[dict[int, float]]

--- a/lib/levanter/src/levanter/inference/openai.py
+++ b/lib/levanter/src/levanter/inference/openai.py
@@ -87,6 +87,7 @@ class InferenceRequest:
     seed: int | None
     future: asyncio.Future
     n_generations: int = 1
+    echo_logprobs_top_k: int | None = None
 
 
 @dataclass
@@ -99,6 +100,8 @@ class InferenceResponse:
     prompt_tokens: int
     completion_tokens: int
     logprobs: Optional[List[float]] = None
+    echo_token_ids: List[int] | None = None
+    echo_logprobs: TokenSequenceLogprobs | None = None
 
 
 class InferenceBatch(list):
@@ -203,17 +206,6 @@ class InferenceContext:
                 elapsed = time.time() - start
             logger.info(f"Model reloaded in {elapsed:.2f}s")
 
-    def score_token_logprobs(self, token_ids: List[int], top_k: int) -> TokenSequenceLogprobs:
-        """Score a full token sequence under the current model."""
-        with (
-            self.model_lock,
-            hax.partitioning.set_mesh(self.config.trainer.device_mesh),
-            hax.axis_mapping(self.config.trainer.compute_axis_mapping),
-        ):
-            if self.engine is None:
-                raise RuntimeError("Inference model is not initialized.")
-            return self.engine.score_token_logprobs(token_ids, top_k)
-
     def submit_request(
         self,
         prompt_tokens: List[int],
@@ -223,6 +215,7 @@ class InferenceContext:
         seed: int | None,
         future: asyncio.Future,
         n_generations: int = 1,
+        echo_logprobs_top_k: int | None = None,
     ) -> str:
         """Submit a request to the inference queue"""
         assert self.shutdown_event.is_set() is False, "InferenceContext is shut down"
@@ -238,6 +231,7 @@ class InferenceContext:
             seed=seed,
             future=future,
             n_generations=n_generations,
+            echo_logprobs_top_k=echo_logprobs_top_k,
         )
 
         logger.info("Enqueuing request %s", request)
@@ -371,6 +365,14 @@ class InferenceContext:
                         text = self.tokenizer.decode(generated_tokens, skip_special_tokens=True)
 
                         result_logprobs = result.logprobs[output_idx] if result.logprobs is not None else None
+                        echo_token_ids = None
+                        echo_logprobs = None
+                        if req.echo_logprobs_top_k is not None:
+                            echo_token_ids = req.prompt_tokens + generated_tokens
+                            echo_logprobs = self.engine.score_token_logprobs(
+                                echo_token_ids,
+                                req.echo_logprobs_top_k,
+                            )
 
                         req_outputs.append(
                             InferenceResponse(
@@ -380,6 +382,8 @@ class InferenceContext:
                                 prompt_tokens=len(req.prompt_tokens),
                                 completion_tokens=len(generated_tokens),
                                 request_id=req.request_id,
+                                echo_token_ids=echo_token_ids,
+                                echo_logprobs=echo_logprobs,
                             )
                         )
                         output_idx += 1
@@ -477,9 +481,18 @@ async def _create_completion(ctx: InferenceContext, request: CompletionRequest) 
         for prompt in prompts:
             # Tokenize prompt
             prompt_tokens = ctx.tokenizer.encode(prompt, add_special_tokens=False)
+            if request.echo and request.logprobs and len(prompt_tokens) > ctx.config.service.max_seq_len:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "echo logprobs are not supported for prompts longer than "
+                        f"max_seq_len={ctx.config.service.max_seq_len}"
+                    ),
+                )
             prompt_token_lists.append(prompt_tokens)
             total_prompt_tokens += len(prompt_tokens)
 
+        for prompt_tokens in prompt_token_lists:
             # Create future for this request
             future: asyncio.Future = asyncio.Future()
             futures.append(future)
@@ -493,6 +506,7 @@ async def _create_completion(ctx: InferenceContext, request: CompletionRequest) 
                 seed=request.seed,
                 future=future,
                 n_generations=request.n or 1,
+                echo_logprobs_top_k=int(request.logprobs) if request.echo and request.logprobs else None,
             )
 
         # Wait for all results
@@ -500,7 +514,7 @@ async def _create_completion(ctx: InferenceContext, request: CompletionRequest) 
 
         # Format responses
         choice_idx = 0
-        for prompt, prompt_tokens, result in zip(prompts, prompt_token_lists, results, strict=True):
+        for prompt, result in zip(prompts, results, strict=True):
             for generation in result:
                 choice_text = f"{prompt}{generation.text}" if request.echo else generation.text
 
@@ -508,9 +522,13 @@ async def _create_completion(ctx: InferenceContext, request: CompletionRequest) 
                 logprobs = None
                 if request.logprobs:
                     if request.echo:
-                        scored_token_ids = prompt_tokens + generation.tokens
-                        sequence_logprobs = ctx.score_token_logprobs(scored_token_ids, int(request.logprobs))
-                        echo_logprobs = _completion_logprobs(ctx.tokenizer, scored_token_ids, sequence_logprobs)
+                        if generation.echo_token_ids is None or generation.echo_logprobs is None:
+                            raise RuntimeError("Echo logprobs requested but missing from generation result.")
+                        echo_logprobs = _completion_logprobs(
+                            ctx.tokenizer,
+                            generation.echo_token_ids,
+                            generation.echo_logprobs,
+                        )
                         logprobs = Logprobs(
                             tokens=echo_logprobs.tokens,
                             token_logprobs=echo_logprobs.token_logprobs,
@@ -562,6 +580,8 @@ async def _create_completion(ctx: InferenceContext, request: CompletionRequest) 
             ),
         )
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error("Error in completion.", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))

--- a/lib/levanter/src/levanter/inference/openai.py
+++ b/lib/levanter/src/levanter/inference/openai.py
@@ -33,7 +33,12 @@ from openai.types.chat.chat_completion import ChoiceLogprobs
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
 from openai.types.chat.chat_completion_token_logprob import ChatCompletionTokenLogprob
 from openai.types.completion_choice import CompletionChoice, Logprobs
-from levanter.inference.engine import InferenceEngine, InferenceEngineConfig, Request
+from levanter.inference.engine import (
+    InferenceEngine,
+    InferenceEngineConfig,
+    Request,
+    TokenSequenceLogprobs,
+)
 from levanter.inference.jit_scheduler import SeqDecodingParams
 from levanter.inference.openai_protocol import (
     ChatCompletionRequest,
@@ -197,6 +202,17 @@ class InferenceContext:
                 )
                 elapsed = time.time() - start
             logger.info(f"Model reloaded in {elapsed:.2f}s")
+
+    def score_token_logprobs(self, token_ids: List[int], top_k: int) -> TokenSequenceLogprobs:
+        """Score a full token sequence under the current model."""
+        with (
+            self.model_lock,
+            hax.partitioning.set_mesh(self.config.trainer.device_mesh),
+            hax.axis_mapping(self.config.trainer.compute_axis_mapping),
+        ):
+            if self.engine is None:
+                raise RuntimeError("Inference model is not initialized.")
+            return self.engine.score_token_logprobs(token_ids, top_k)
 
     def submit_request(
         self,
@@ -392,6 +408,55 @@ def _health_check() -> dict:
     return {"status": "healthy", "service": "levanter-inference"}
 
 
+def _decoded_token_pieces(tokenizer: MarinTokenizer, token_ids: List[int]) -> List[str]:
+    return [tokenizer.decode([token_id], skip_special_tokens=False) for token_id in token_ids]
+
+
+def _token_text_offsets(tokens: List[str]) -> List[int]:
+    offsets = []
+    offset = 0
+    for token in tokens:
+        offsets.append(offset)
+        offset += len(token)
+    return offsets
+
+
+@dataclass(frozen=True)
+class CompletionLogprobData:
+    tokens: List[str]
+    token_logprobs: List[float]
+    top_logprobs: List[dict[str, float]]
+    text_offset: List[int]
+
+
+def _completion_logprobs(
+    tokenizer: MarinTokenizer,
+    token_ids: List[int],
+    sequence_logprobs: TokenSequenceLogprobs,
+) -> CompletionLogprobData:
+    tokens = _decoded_token_pieces(tokenizer, token_ids)
+    if len(tokens) != len(sequence_logprobs.token_logprobs):
+        raise ValueError(f"Expected {len(tokens)} token logprobs, got {len(sequence_logprobs.token_logprobs)}")
+    if len(tokens) != len(sequence_logprobs.top_token_logprobs):
+        raise ValueError(
+            f"Expected {len(tokens)} top-logprob entries, got {len(sequence_logprobs.top_token_logprobs)}"
+        )
+
+    top_logprobs = [
+        {
+            tokenizer.decode([token_id], skip_special_tokens=False): logprob
+            for token_id, logprob in token_logprobs.items()
+        }
+        for token_logprobs in sequence_logprobs.top_token_logprobs
+    ]
+    return CompletionLogprobData(
+        tokens=tokens,
+        token_logprobs=sequence_logprobs.token_logprobs,
+        top_logprobs=top_logprobs,
+        text_offset=_token_text_offsets(tokens),
+    )
+
+
 async def _create_completion(ctx: InferenceContext, request: CompletionRequest) -> Completion:
     """Create a text completion using OpenAI API format."""
     try:
@@ -407,10 +472,12 @@ async def _create_completion(ctx: InferenceContext, request: CompletionRequest) 
         choices = []
         total_prompt_tokens = 0
         total_completion_tokens = 0
+        prompt_token_lists: List[List[int]] = []
 
-        for i, prompt in enumerate(prompts):
+        for prompt in prompts:
             # Tokenize prompt
             prompt_tokens = ctx.tokenizer.encode(prompt, add_special_tokens=False)
+            prompt_token_lists.append(prompt_tokens)
             total_prompt_tokens += len(prompt_tokens)
 
             # Create future for this request
@@ -433,34 +500,47 @@ async def _create_completion(ctx: InferenceContext, request: CompletionRequest) 
 
         # Format responses
         choice_idx = 0
-        for result in results:
+        for prompt, prompt_tokens, result in zip(prompts, prompt_token_lists, results, strict=True):
             for generation in result:
+                choice_text = f"{prompt}{generation.text}" if request.echo else generation.text
+
                 # Format logprobs if available
                 logprobs = None
                 if request.logprobs:
-                    # Convert logprobs to API format
-                    generated_tokens = generation.tokens
+                    if request.echo:
+                        scored_token_ids = prompt_tokens + generation.tokens
+                        sequence_logprobs = ctx.score_token_logprobs(scored_token_ids, int(request.logprobs))
+                        echo_logprobs = _completion_logprobs(ctx.tokenizer, scored_token_ids, sequence_logprobs)
+                        logprobs = Logprobs(
+                            tokens=echo_logprobs.tokens,
+                            token_logprobs=echo_logprobs.token_logprobs,
+                            text_offset=echo_logprobs.text_offset,
+                            top_logprobs=echo_logprobs.top_logprobs,
+                        )
+                    else:
+                        # Convert logprobs to API format
+                        generated_tokens = generation.tokens
 
-                    # Create token logprobs in OpenAI format
-                    tokens = []
-                    token_logprobs = []
-                    if generation.logprobs:
-                        for token_id, lp in zip(generated_tokens, generation.logprobs):
-                            # Use convert_ids_to_tokens to preserve BPE format
-                            token_str = ctx.tokenizer.convert_ids_to_tokens(token_id)
-                            tokens.append(token_str)
-                            token_logprobs.append(float(lp))
+                        # Create token logprobs in OpenAI format
+                        tokens = []
+                        token_logprobs = []
+                        if generation.logprobs:
+                            for token_id, lp in zip(generated_tokens, generation.logprobs):
+                                # Use convert_ids_to_tokens to preserve BPE format
+                                token_str = ctx.tokenizer.convert_ids_to_tokens(token_id)
+                                tokens.append(token_str)
+                                token_logprobs.append(float(lp))
 
-                    logprobs = Logprobs(
-                        tokens=tokens,
-                        token_logprobs=token_logprobs,
-                        text_offset=None,
-                        top_logprobs=None,
-                    )
+                        logprobs = Logprobs(
+                            tokens=tokens,
+                            token_logprobs=token_logprobs,
+                            text_offset=None,
+                            top_logprobs=None,
+                        )
 
                 choices.append(
                     CompletionChoice(
-                        text=generation.text,
+                        text=choice_text,
                         index=choice_idx,
                         finish_reason="stop",
                         logprobs=logprobs,

--- a/lib/levanter/src/levanter/inference/openai.py
+++ b/lib/levanter/src/levanter/inference/openai.py
@@ -477,15 +477,17 @@ async def _create_completion(ctx: InferenceContext, request: CompletionRequest) 
         total_prompt_tokens = 0
         total_completion_tokens = 0
         prompt_token_lists: List[List[int]] = []
+        echo_logprobs_top_k = int(request.logprobs) if request.echo and request.logprobs else None
 
         for prompt in prompts:
             # Tokenize prompt
             prompt_tokens = ctx.tokenizer.encode(prompt, add_special_tokens=False)
-            if request.echo and request.logprobs and len(prompt_tokens) > ctx.config.service.max_seq_len:
+            scored_token_budget = len(prompt_tokens) + request.max_tokens
+            if echo_logprobs_top_k is not None and scored_token_budget > ctx.config.service.max_seq_len:
                 raise HTTPException(
                     status_code=400,
                     detail=(
-                        "echo logprobs are not supported for prompts longer than "
+                        "echo logprobs are not supported when prompt tokens plus max_tokens exceeds "
                         f"max_seq_len={ctx.config.service.max_seq_len}"
                     ),
                 )
@@ -506,7 +508,7 @@ async def _create_completion(ctx: InferenceContext, request: CompletionRequest) 
                 seed=request.seed,
                 future=future,
                 n_generations=request.n or 1,
-                echo_logprobs_top_k=int(request.logprobs) if request.echo and request.logprobs else None,
+                echo_logprobs_top_k=echo_logprobs_top_k,
             )
 
         # Wait for all results

--- a/lib/levanter/tests/inference/test_inference_server.py
+++ b/lib/levanter/tests/inference/test_inference_server.py
@@ -302,8 +302,8 @@ def test_completion_echo_logprobs_are_lm_eval_aligned():
     assert logprobs["top_logprobs"][2][" X"] == pytest.approx(expected_completion_logprob)
 
 
-def test_completion_echo_logprobs_rejects_prompt_truncation():
-    ctx = _FakeCompletionContext(max_seq_len=1)
+def test_completion_echo_logprobs_rejects_scored_sequence_over_context():
+    ctx = _FakeCompletionContext(max_seq_len=2)
     app = InferenceServer._create_app(ctx)
 
     with TestClient(app) as client:
@@ -323,6 +323,18 @@ def test_completion_echo_logprobs_rejects_prompt_truncation():
     assert response.status_code == 400, response.text
     assert "echo logprobs" in response.json()["detail"]
     assert ctx.submitted_requests == 0
+
+
+def test_score_token_sequence_logprobs_empty_and_single_token_sequences():
+    model = _DeterministicCompletionScoringModel()
+
+    empty_result = score_token_sequence_logprobs(model, [], top_k=1)
+    assert empty_result.token_logprobs == []
+    assert empty_result.top_token_logprobs == []
+
+    single_token_result = score_token_sequence_logprobs(model, [2], top_k=3)
+    assert single_token_result.token_logprobs == [0.0]
+    assert single_token_result.top_token_logprobs == [{2: 0.0}]
 
 
 @pytest.mark.slow

--- a/lib/levanter/tests/inference/test_inference_server.py
+++ b/lib/levanter/tests/inference/test_inference_server.py
@@ -23,7 +23,6 @@ try:
 
     from levanter.inference.engine import (
         InferenceEngineConfig,
-        TokenSequenceLogprobs,
         score_token_sequence_logprobs,
     )
     from levanter.inference.openai import InferenceResponse, InferenceServer, InferenceServerConfig
@@ -184,6 +183,8 @@ class _OpenAITestTokenizer:
     def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
         if add_special_tokens:
             raise ValueError("The test tokenizer does not define special tokens.")
+        if text == "A":
+            return [0]
         if text == "A B":
             return [0, 1]
         if text == " X":
@@ -220,13 +221,11 @@ class _DeterministicCompletionScoringModel(eqx.Module):
 
 
 class _FakeCompletionContext:
-    def __init__(self):
-        self.config = InferenceServerConfig()
+    def __init__(self, max_seq_len: int = 4096):
+        self.config = InferenceServerConfig(service=InferenceEngineConfig(max_seq_len=max_seq_len))
         self.model = _DeterministicCompletionScoringModel()
         self.tokenizer = _OpenAITestTokenizer()
-
-    def score_token_logprobs(self, token_ids: list[int], top_k: int) -> TokenSequenceLogprobs:
-        return score_token_sequence_logprobs(self.model, token_ids, top_k)
+        self.submitted_requests = 0
 
     def submit_request(
         self,
@@ -237,6 +236,7 @@ class _FakeCompletionContext:
         seed: int | None,
         future,
         n_generations: int = 1,
+        echo_logprobs_top_k: int | None = None,
     ) -> str:
         if (
             prompt_tokens != [0, 1]
@@ -245,8 +245,11 @@ class _FakeCompletionContext:
             or stop_tokens is not None
             or seed != 1234
             or n_generations != 1
+            or echo_logprobs_top_k != 1
         ):
             raise ValueError("The deterministic test context only supports one fixed completion request.")
+        self.submitted_requests += 1
+        echo_token_ids = prompt_tokens + [3]
         future.set_result(
             [
                 InferenceResponse(
@@ -256,6 +259,8 @@ class _FakeCompletionContext:
                     prompt_tokens=len(prompt_tokens),
                     completion_tokens=1,
                     logprobs=[-123.0],
+                    echo_token_ids=echo_token_ids,
+                    echo_logprobs=score_token_sequence_logprobs(self.model, echo_token_ids, echo_logprobs_top_k),
                 )
             ]
         )
@@ -295,6 +300,29 @@ def test_completion_echo_logprobs_are_lm_eval_aligned():
     assert logprobs["top_logprobs"][0] == {"A": 0.0}
     assert logprobs["top_logprobs"][1][" B"] == pytest.approx(expected_prompt_logprob)
     assert logprobs["top_logprobs"][2][" X"] == pytest.approx(expected_completion_logprob)
+
+
+def test_completion_echo_logprobs_rejects_prompt_truncation():
+    ctx = _FakeCompletionContext(max_seq_len=1)
+    app = InferenceServer._create_app(ctx)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/completions",
+            json={
+                "model": "gpt2",
+                "prompt": ["A", "A B"],
+                "temperature": 0,
+                "max_tokens": 1,
+                "logprobs": 1,
+                "seed": 1234,
+                "echo": True,
+            },
+        )
+
+    assert response.status_code == 400, response.text
+    assert "echo logprobs" in response.json()["detail"]
+    assert ctx.submitted_requests == 0
 
 
 @pytest.mark.slow

--- a/lib/levanter/tests/inference/test_inference_server.py
+++ b/lib/levanter/tests/inference/test_inference_server.py
@@ -5,6 +5,7 @@ import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
 
+import equinox as eqx
 import haliax as hax
 import jax
 import jax.numpy as jnp
@@ -20,8 +21,12 @@ try:
     from openai.types import Completion
     from openai.types.chat import ChatCompletion
 
-    from levanter.inference.engine import InferenceEngineConfig
-    from levanter.inference.openai import InferenceServer, InferenceServerConfig
+    from levanter.inference.engine import (
+        InferenceEngineConfig,
+        TokenSequenceLogprobs,
+        score_token_sequence_logprobs,
+    )
+    from levanter.inference.openai import InferenceResponse, InferenceServer, InferenceServerConfig
 
 except ImportError:
     pytest.skip("Serving imports not installed, use --extra=serve", allow_module_level=True)
@@ -171,6 +176,125 @@ def test_endpoints_exist(test_client):
     assert "/health" in routes
     assert "/v1/completions" in routes
     assert "/v1/chat/completions" in routes
+
+
+class _OpenAITestTokenizer:
+    _id_to_piece = {0: "A", 1: " B", 2: " C", 3: " X"}
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        if add_special_tokens:
+            raise ValueError("The test tokenizer does not define special tokens.")
+        if text == "A B":
+            return [0, 1]
+        if text == " X":
+            return [3]
+        raise ValueError(f"Unexpected test text: {text}")
+
+    def decode(self, token_ids: list[int], skip_special_tokens: bool = True) -> str:
+        return "".join(self._id_to_piece[int(token_id)] for token_id in token_ids)
+
+    def convert_ids_to_tokens(self, token_id: int) -> str:
+        return self._id_to_piece[int(token_id)]
+
+
+class _DeterministicCompletionScoringModel(eqx.Module):
+    Vocab: hax.Axis = eqx.field(static=True)
+
+    def __init__(self):
+        self.Vocab = hax.Axis("vocab", 4)
+
+    def __call__(
+        self,
+        input_ids: hax.NamedArray,
+        attn_mask: object,
+        pos_ids: hax.NamedArray,
+        key: object,
+    ) -> hax.NamedArray:
+        Pos = input_ids.resolve_axis("position")
+        logits = jnp.full((Pos.size, self.Vocab.size), -8.0, dtype=jnp.float32)
+        if Pos.size > 0:
+            logits = logits.at[0, 1].set(4.0)
+        if Pos.size > 1:
+            logits = logits.at[1, 3].set(3.0)
+        return hax.named(logits, (Pos, self.Vocab))
+
+
+class _FakeCompletionContext:
+    def __init__(self):
+        self.config = InferenceServerConfig()
+        self.model = _DeterministicCompletionScoringModel()
+        self.tokenizer = _OpenAITestTokenizer()
+
+    def score_token_logprobs(self, token_ids: list[int], top_k: int) -> TokenSequenceLogprobs:
+        return score_token_sequence_logprobs(self.model, token_ids, top_k)
+
+    def submit_request(
+        self,
+        prompt_tokens: list[int],
+        max_tokens: int,
+        temperature: float,
+        stop_tokens: list[int] | None,
+        seed: int | None,
+        future,
+        n_generations: int = 1,
+    ) -> str:
+        if (
+            prompt_tokens != [0, 1]
+            or max_tokens != 1
+            or temperature != 0
+            or stop_tokens is not None
+            or seed != 1234
+            or n_generations != 1
+        ):
+            raise ValueError("The deterministic test context only supports one fixed completion request.")
+        future.set_result(
+            [
+                InferenceResponse(
+                    request_id="req_0",
+                    text=" X",
+                    tokens=[3],
+                    prompt_tokens=len(prompt_tokens),
+                    completion_tokens=1,
+                    logprobs=[-123.0],
+                )
+            ]
+        )
+        return "req_0"
+
+
+def test_completion_echo_logprobs_are_lm_eval_aligned():
+    ctx = _FakeCompletionContext()
+    app = InferenceServer._create_app(ctx)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/completions",
+            json={
+                "model": "gpt2",
+                "prompt": "A B",
+                "temperature": 0,
+                "max_tokens": 1,
+                "logprobs": 1,
+                "seed": 1234,
+                "echo": True,
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    choice = response.json()["choices"][0]
+    logprobs = choice["logprobs"]
+    expected_prompt_logprob = float(jax.nn.log_softmax(jnp.array([-8.0, 4.0, -8.0, -8.0]))[1])
+    expected_completion_logprob = float(jax.nn.log_softmax(jnp.array([-8.0, -8.0, -8.0, 3.0]))[3])
+
+    assert choice["text"] == "A B X"
+    assert logprobs["tokens"] == ["A", " B", " X"]
+    assert logprobs["token_logprobs"] == pytest.approx([0.0, expected_prompt_logprob, expected_completion_logprob])
+    assert logprobs["text_offset"] == [0, 1, 3]
+    assert len(logprobs["tokens"]) == len(logprobs["token_logprobs"])
+    assert len(logprobs["tokens"]) == len(logprobs["top_logprobs"])
+    assert logprobs["top_logprobs"][0] == {"A": 0.0}
+    assert logprobs["top_logprobs"][1][" B"] == pytest.approx(expected_prompt_logprob)
+    assert logprobs["top_logprobs"][2][" X"] == pytest.approx(expected_completion_logprob)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
# Levanter completions echo logprobs

Adds `/v1/completions` support for `echo=true` prompt-plus-completion logprobs in the Levanter OpenAI-compatible server.

The goal is to make stock `lm_eval local-completions` scoring work against Levanter without coupling eval logic to Levanter model construction. The OpenAI adapter now handles the HTTP response contract, while the inference engine exposes a small token-sequence scoring helper that can be reused by served eval code.

## What changed

- Added causal full-forward token scoring for an explicit token sequence.
- Added OpenAI completions formatting for echoed prompt-plus-generated tokens:
  - `choice.text` includes the prompt when `echo=true`.
  - `tokens`, `token_logprobs`, `top_logprobs`, and `text_offset` are aligned with `prompt_tokens + generated_tokens`.
- Kept echo-logprob rescoring inside the generation batch/model lock, so reloads cannot mix generated tokens from one model with logprobs from another.
- Rejected `echo=true`/`logprobs` requests whose prompt-plus-`max_tokens` scoring budget would exceed `max_seq_len`.
- Kept the existing generation path intact for non-echo completions.
- Added a focused regression test for the `lm_eval local-completions` slicing contract.

This is intentionally correctness-first. For `echo=true` and `logprobs>0`, Levanter runs a second full forward pass over `prompt_tokens + generated_tokens` in the same generation batch, then formats the OpenAI response from those scores.

## Testing

- Levanter endpoint regression for lm-eval-aligned echo logprobs: passed.
- Marin served lm-eval tests, including real `lm_eval local-completions` against a deterministic fake OpenAI-compatible server: passed.
- Local Levanter CPU smoke with real `lm_eval local-completions` and `timinar/baby-llama-58m`: passed.
- Iris native vLLM `/v1/completions` smoke on `v5litepod-4`: passed.
- Same-model manual backend checks with `HuggingFaceTB/SmolLM2-135M-Instruct`: see details below.
- Repository pre-commit: passed.

<details>
<summary>Validation matrix</summary>

| Layer | What it covers | Result |
| --- | --- | --- |
| Levanter endpoint contract | Echoed completion text; prompt and generated-token logprobs; `top_logprobs`; `text_offset`; lm-eval slicing alignment; rejection before the scored sequence can exceed context | `3 passed in 25.19s` |
| Marin served lm-eval contracts | Adapter args, OpenAI subset behavior, and real `lm_eval local-completions` request/parse path against a deterministic fake server | `5 passed in 12.49s` |
| Existing Levanter logprob coverage | Existing completions logprobs and full-forward matching behavior | `2 passed, 2 warnings in 37.65s` |
| Local Levanter CPU integration | Real Levanter OpenAI server on CPU, real `lm_eval local-completions`, tiny one-document scoring task | `SMOKE_OK`; `loglikelihood=-5.14166259765625`; `greedy=0.0` |
| Iris native vLLM smoke | Real Iris job, native vLLM, `v5litepod-4`, `/v1/completions` response path | Succeeded; child TPU run returned in `160.6s` |
| Manual backend prompt-logprob comparison | Same HF model through Levanter and native vLLM `/v1/completions`, using `echo=true`, `logprobs=5`, `max_tokens=1` | Levanter returned aligned continuation logprobs; native vLLM returned HTTP 500 on all three requests |
| Manual backend generation comparison | Same HF model through Levanter and native vLLM `/v1/completions`, using `echo=false`, `temperature=0`, `seed=1234`, `max_tokens=8`, `logprobs=5` | HTTP 200 on both; exact generated text matched; generated-token metadata shape differed |
| Pre-commit | Repo lint/format/type/check entry point | `OK` |

</details>

<details>
<summary>Manual backend comparison notes</summary>

These checks used `HuggingFaceTB/SmolLM2-135M-Instruct` on both Levanter and native vLLM. They are meant as evidence for the API boundary, not as committed test infrastructure.

For prompt-logprob scoring, Levanter returned HTTP 200 and aligned continuation-token logprobs for:

| Prompt | Continuation token ids | Continuation logprobs |
| --- | --- | --- |
| `The capital of France is Paris` | `[7042]` | `[-0.7235682606697083]` |
| `2 + 2 = 4` | `[216, 36]` | `[-0.1042003184556961, -1.8896193504333496]` |
| `A B C` | `[340]` | `[-6.166558265686035]` |

Native vLLM reached readiness on Iris, but returned HTTP 500 for the same `echo=true` prompt-logprob requests:

| Prompt | vLLM error |
| --- | --- |
| `The capital of France is Paris` | `{"message":"3575","type":"InternalServerError"}` |
| `2 + 2 = 4` | `{"message":"list index out of range","type":"InternalServerError"}` |
| `A B C` | `{"message":"389","type":"InternalServerError"}` |

For generation, both backends returned HTTP 200 and exact text matches:

| Prompt | Generated text | Text match |
| --- | --- | --- |
| `The capital of France is` | `" Paris. Paris is a major city in"` | yes |
| `2 + 2 =` | `" 3.\n\nNow, we"` | yes |
| `A B` | `")\n\nThe sum of the first"` | yes |

Generated-token logprob metadata still differed. Levanter returned `tokens=8` and `token_logprobs=8`, but `top_logprobs=null` and `text_offset=null`; vLLM returned all four as length-8 arrays. `finish_reason` also differed: Levanter returned `stop`, while vLLM returned `length`.

</details>

## Follow-up work

- Throughput: the current bridge does a second full forward pass for `echo=true` scoring. This is simple and validated, but production throughput still needs measurement. If it is too slow, the next implementation should plumb prefill/prompt logprobs through the serving path instead of rescoring.
- Long-context behavior: this PR rejects echo-logprob requests whose prompt-plus-`max_tokens` scoring budget would exceed `max_seq_len`. Max-context policy and coverage for large benchmark suites still need a separate decision.
- Native vLLM prompt-logprob behavior: vLLM generation works, but the stock `lm_eval local-completions` `echo=true` prompt-logprob request still returns HTTP 500 in the same-model smoke. Keep that tracked separately from this Levanter adapter change.
- Generated-token metadata parity: deterministic `echo=false` generation text matched native vLLM, but Levanter does not yet mirror vLLM/OpenAI metadata for `top_logprobs`, `text_offset`, or `finish_reason` on generated-token logprobs.
