### PR TITLE
levanter: make trainer robust against W&B failures

### DIFF
--- a/lib/levanter/src/levanter/tracker/__init__.py
+++ b/lib/levanter/src/levanter/tracker/__init__.py
@@ -1,6 +1,7 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from levanter.tracker.background import BackgroundTracker
 from levanter.tracker.helpers import capture_time, log_optimizer_hyperparams
 from levanter.tracker.tracker import CompositeTracker, NoopConfig, NoopTracker, Tracker, TrackerConfig
 from levanter.tracker.tracker_fns import (
@@ -21,6 +22,7 @@ from levanter.tracker.tracker_fns import (
 __all__ = [
     "Tracker",
     "TrackerConfig",
+    "BackgroundTracker",
     "CompositeTracker",
     "log_optimizer_hyperparams",
     "NoopTracker",

--- a/lib/levanter/src/levanter/tracker/background.py
+++ b/lib/levanter/src/levanter/tracker/background.py
@@ -1,0 +1,221 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Background-thread wrapper around any :class:`~levanter.tracker.Tracker`.
+
+Many trackers (notably W&B) talk to a remote service that can fail
+intermittently — quota exhausted, network blips, transient 5xx responses.
+Those failures should not crash a long-running training job, and the trainer
+thread should not block on tracker I/O. :class:`BackgroundTracker` provides
+both guarantees:
+
+* All forwarded calls are pushed onto a bounded queue and executed serially
+  on a daemon thread, so the trainer thread returns immediately.
+* Exceptions raised by the wrapped tracker are caught and logged; the worker
+  keeps running so subsequent updates still go through.
+* If the queue fills up (e.g. the wrapped tracker is wedged), additional
+  updates are dropped with a rate-limited warning rather than blocking.
+
+Tracker initialization is *not* wrapped. If e.g. ``wandb.init()`` fails
+because of bad auth, that's a fatal configuration problem and the run
+should refuse to start.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+import typing
+from typing import Any, Optional
+
+from levanter.tracker.tracker import Tracker
+
+
+logger = logging.getLogger(__name__)
+
+
+class _Shutdown:
+    """Sentinel placed on the queue to stop the worker."""
+
+
+_SHUTDOWN = _Shutdown()
+
+# Number of times we log a warning when the queue is full before throttling.
+_DROP_LOG_BURST = 5
+_DROP_LOG_PERIOD = 1000
+
+
+class BackgroundTracker(Tracker):
+    """Run another tracker's calls on a background thread, swallowing failures.
+
+    Args:
+        wrapped: Tracker whose ``log_*``/``finish`` calls will be deferred.
+        max_queue_size: Maximum number of pending updates. When the queue is
+            full, additional updates are dropped (with a warning) rather than
+            blocking the producer.
+        finish_timeout: Maximum time in seconds to wait for the queue to drain
+            and the wrapped tracker to finish during :meth:`finish`.
+    """
+
+    def __init__(
+        self,
+        wrapped: Tracker,
+        *,
+        max_queue_size: int = 10000,
+        finish_timeout: float = 120.0,
+    ):
+        self.wrapped = wrapped
+        # Mirror the wrapped tracker's name so get_tracker() lookups still work.
+        self.name = getattr(wrapped, "name", "background")
+        self._queue: queue.Queue = queue.Queue(maxsize=max_queue_size)
+        self._finish_timeout = finish_timeout
+        self._dropped = 0
+        self._stopped = False
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(
+            target=self._worker,
+            name=f"BackgroundTracker[{self.name}]",
+            daemon=True,
+        )
+        self._thread.start()
+
+    # ---- worker -------------------------------------------------------------
+
+    def _worker(self) -> None:
+        while True:
+            item = self._queue.get()
+            try:
+                if item is _SHUTDOWN:
+                    return
+                method, args, kwargs = item
+                try:
+                    method(*args, **kwargs)
+                except Exception:
+                    logger.exception(
+                        "Background tracker '%s' raised while processing %s; " "dropping update and continuing.",
+                        self.name,
+                        getattr(method, "__name__", repr(method)),
+                    )
+            finally:
+                self._queue.task_done()
+
+    def _enqueue(self, method, *args, **kwargs) -> None:
+        if self._stopped:
+            logger.debug(
+                "Background tracker '%s' already stopped; dropping %s",
+                self.name,
+                getattr(method, "__name__", repr(method)),
+            )
+            return
+        try:
+            self._queue.put_nowait((method, args, kwargs))
+        except queue.Full:
+            with self._lock:
+                self._dropped += 1
+                dropped = self._dropped
+            if dropped <= _DROP_LOG_BURST or dropped % _DROP_LOG_PERIOD == 0:
+                logger.warning(
+                    "Background tracker '%s' queue full; dropped %d update(s) so far.",
+                    self.name,
+                    dropped,
+                )
+
+    # ---- Tracker API --------------------------------------------------------
+
+    def log_hyperparameters(self, hparams: dict[str, Any]) -> None:
+        self._enqueue(self.wrapped.log_hyperparameters, hparams)
+
+    def log(
+        self,
+        metrics: typing.Mapping[str, Any],
+        *,
+        step: Optional[int],
+        commit: Optional[bool] = None,
+    ) -> None:
+        self._enqueue(self.wrapped.log, metrics, step=step, commit=commit)
+
+    def log_summary(self, metrics: dict[str, Any]) -> None:
+        self._enqueue(self.wrapped.log_summary, metrics)
+
+    def log_artifact(
+        self,
+        artifact_path,
+        *,
+        name: Optional[str] = None,
+        type: Optional[str] = None,
+    ) -> None:
+        self._enqueue(self.wrapped.log_artifact, artifact_path, name=name, type=type)
+
+    def finish(self) -> None:
+        with self._lock:
+            if self._stopped:
+                return
+            self._stopped = True
+
+        deadline = time.monotonic() + self._finish_timeout
+
+        # Enqueue the wrapped finish() so it runs after any pending logs.
+        try:
+            self._queue.put_nowait((self.wrapped.finish, (), {}))
+        except queue.Full:
+            logger.warning(
+                "Background tracker '%s' queue full at shutdown; finish() may "
+                "not be called on the wrapped tracker.",
+                self.name,
+            )
+
+        # Wait for the worker to drain everything before sending the sentinel.
+        # This is a best-effort drain — if the wrapped tracker is wedged we
+        # still want to bound how long we block.
+        remaining = max(deadline - time.monotonic(), 1.0)
+        try:
+            self._queue.put(_SHUTDOWN, timeout=remaining)
+        except queue.Full:
+            logger.warning(
+                "Background tracker '%s' did not accept shutdown sentinel within %.1fs.",
+                self.name,
+                remaining,
+            )
+
+        remaining = max(deadline - time.monotonic(), 0.0)
+        self._thread.join(timeout=remaining)
+        if self._thread.is_alive():
+            logger.warning(
+                "Background tracker '%s' did not exit within %.1fs; " "abandoning thread (some updates may be lost).",
+                self.name,
+                self._finish_timeout,
+            )
+        if self._dropped:
+            logger.warning(
+                "Background tracker '%s' dropped %d update(s) total during run.",
+                self.name,
+                self._dropped,
+            )
+
+    # ---- Helpers (mostly for tests) -----------------------------------------
+
+    @property
+    def dropped_count(self) -> int:
+        """Return the number of updates dropped because the queue was full."""
+        with self._lock:
+            return self._dropped
+
+    def _wait_until_idle(self, timeout: float = 5.0) -> bool:
+        """Block until every queued item has been processed.
+
+        Returns ``True`` if the queue drained within ``timeout``, else
+        ``False``. Intended for tests.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with self._queue.all_tasks_done:
+                if self._queue.unfinished_tasks == 0:
+                    return True
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._queue.all_tasks_done.wait(timeout=remaining)
+        with self._queue.all_tasks_done:
+            return self._queue.unfinished_tasks == 0

--- a/lib/levanter/src/levanter/tracker/background.py
+++ b/lib/levanter/src/levanter/tracker/background.py
@@ -94,20 +94,16 @@ class BackgroundTracker(Tracker):
                     method(*args, **kwargs)
                 except Exception:
                     logger.exception(
-                        "Background tracker '%s' raised while processing %s; " "dropping update and continuing.",
+                        "Background tracker '%s' raised while processing %s; dropping update and continuing.",
                         self.name,
-                        getattr(method, "__name__", repr(method)),
+                        method.__name__,
                     )
             finally:
                 self._queue.task_done()
 
     def _enqueue(self, method, *args, **kwargs) -> None:
         if self._stopped:
-            logger.debug(
-                "Background tracker '%s' already stopped; dropping %s",
-                self.name,
-                getattr(method, "__name__", repr(method)),
-            )
+            logger.debug("Background tracker '%s' already stopped; dropping %s", self.name, method.__name__)
             return
         try:
             self._queue.put_nowait((method, args, kwargs))
@@ -183,7 +179,7 @@ class BackgroundTracker(Tracker):
         self._thread.join(timeout=remaining)
         if self._thread.is_alive():
             logger.warning(
-                "Background tracker '%s' did not exit within %.1fs; " "abandoning thread (some updates may be lost).",
+                "Background tracker '%s' did not exit within %.1fs; abandoning thread (some updates may be lost).",
                 self.name,
                 self._finish_timeout,
             )
@@ -196,26 +192,31 @@ class BackgroundTracker(Tracker):
 
     # ---- Helpers (mostly for tests) -----------------------------------------
 
-    @property
-    def dropped_count(self) -> int:
-        """Return the number of updates dropped because the queue was full."""
-        with self._lock:
-            return self._dropped
-
     def _wait_until_idle(self, timeout: float = 5.0) -> bool:
         """Block until every queued item has been processed.
 
         Returns ``True`` if the queue drained within ``timeout``, else
-        ``False``. Intended for tests.
+        ``False``. Intended for tests; mirrors :meth:`queue.Queue.join` but
+        with a deadline.
         """
         deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            with self._queue.all_tasks_done:
-                if self._queue.unfinished_tasks == 0:
-                    return True
+        with self._queue.all_tasks_done:
+            while self._queue.unfinished_tasks:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     return False
                 self._queue.all_tasks_done.wait(timeout=remaining)
-        with self._queue.all_tasks_done:
-            return self._queue.unfinished_tasks == 0
+            return True
+
+
+def maybe_wrap_background(
+    tracker: Tracker,
+    *,
+    enabled: bool,
+    max_queue_size: int,
+    finish_timeout: float,
+) -> Tracker:
+    """Return ``tracker`` wrapped in a :class:`BackgroundTracker` iff ``enabled``."""
+    if not enabled:
+        return tracker
+    return BackgroundTracker(tracker, max_queue_size=max_queue_size, finish_timeout=finish_timeout)

--- a/lib/levanter/src/levanter/tracker/background.py
+++ b/lib/levanter/src/levanter/tracker/background.py
@@ -112,7 +112,7 @@ class BackgroundTracker(Tracker):
                 self._dropped += 1
                 dropped = self._dropped
             if dropped <= _DROP_LOG_BURST or dropped % _DROP_LOG_PERIOD == 0:
-                logger.warning(
+                logger.error(
                     "Background tracker '%s' queue full; dropped %d update(s) so far.",
                     self.name,
                     dropped,

--- a/lib/levanter/src/levanter/tracker/tracker.py
+++ b/lib/levanter/src/levanter/tracker/tracker.py
@@ -3,10 +3,14 @@
 
 import abc
 import dataclasses
+import logging
 import typing
 from typing import Any, List, Optional
 
 import draccus
+
+
+logger = logging.getLogger(__name__)
 
 
 class Tracker(abc.ABC):
@@ -73,35 +77,44 @@ class Tracker(abc.ABC):
 
 
 class CompositeTracker(Tracker):
+    """A tracker that fans calls out to a list of trackers.
+
+    Exceptions from any single member tracker are caught and logged so that one
+    failing backend (e.g. W&B losing connectivity) doesn't take down the others.
+    Wrap members in :class:`~levanter.tracker.BackgroundTracker` if you also
+    want isolation from latency.
+    """
+
     def __init__(self, loggers: List[Tracker]):
         self.loggers = loggers
 
-    def log_hyperparameters(self, hparams: dict[str, Any]):
-        for tracker in self.loggers:
-            tracker.log_hyperparameters(hparams)
-
-    def log(self, metrics: typing.Mapping[str, Any], *, step, commit=None):
-        for tracker in self.loggers:
-            tracker.log(metrics, step=step, commit=commit)
-
-    def log_summary(self, metrics: dict[str, Any]):
-        for tracker in self.loggers:
-            tracker.log_summary(metrics)
-
-    def log_artifact(self, artifact_path, *, name: Optional[str] = None, type: Optional[str] = None):
-        for tracker in self.loggers:
-            tracker.log_artifact(artifact_path, name=name, type=type)
-
-    def finish(self):
-        excs = []
+    def _for_each(self, op: str, fn) -> None:
         for tracker in self.loggers:
             try:
-                tracker.finish()
-            except Exception as e:
-                excs.append(e)
+                fn(tracker)
+            except Exception:
+                logger.exception(
+                    "Tracker '%s' raised during %s; continuing with remaining trackers.",
+                    getattr(tracker, "name", type(tracker).__name__),
+                    op,
+                )
 
-        if excs:
-            raise RuntimeError("Errors occurred when finishing trackers") from excs[0]
+    def log_hyperparameters(self, hparams: dict[str, Any]):
+        self._for_each("log_hyperparameters", lambda t: t.log_hyperparameters(hparams))
+
+    def log(self, metrics: typing.Mapping[str, Any], *, step, commit=None):
+        self._for_each("log", lambda t: t.log(metrics, step=step, commit=commit))
+
+    def log_summary(self, metrics: dict[str, Any]):
+        self._for_each("log_summary", lambda t: t.log_summary(metrics))
+
+    def log_artifact(self, artifact_path, *, name: Optional[str] = None, type: Optional[str] = None):
+        self._for_each("log_artifact", lambda t: t.log_artifact(artifact_path, name=name, type=type))
+
+    def finish(self):
+        # finish() exceptions are logged and swallowed too; a tracker failing to
+        # flush at the very end of a run shouldn't crash the trainer's shutdown.
+        self._for_each("finish", lambda t: t.finish())
 
 
 class TrackerConfig(draccus.PluginRegistry, abc.ABC):

--- a/lib/levanter/src/levanter/tracker/tracker.py
+++ b/lib/levanter/src/levanter/tracker/tracker.py
@@ -88,10 +88,10 @@ class CompositeTracker(Tracker):
     def __init__(self, loggers: List[Tracker]):
         self.loggers = loggers
 
-    def _for_each(self, op: str, fn) -> None:
+    def _for_each(self, op: str, *args, **kwargs) -> None:
         for tracker in self.loggers:
             try:
-                fn(tracker)
+                getattr(tracker, op)(*args, **kwargs)
             except Exception:
                 logger.exception(
                     "Tracker '%s' raised during %s; continuing with remaining trackers.",
@@ -100,21 +100,21 @@ class CompositeTracker(Tracker):
                 )
 
     def log_hyperparameters(self, hparams: dict[str, Any]):
-        self._for_each("log_hyperparameters", lambda t: t.log_hyperparameters(hparams))
+        self._for_each("log_hyperparameters", hparams)
 
     def log(self, metrics: typing.Mapping[str, Any], *, step, commit=None):
-        self._for_each("log", lambda t: t.log(metrics, step=step, commit=commit))
+        self._for_each("log", metrics, step=step, commit=commit)
 
     def log_summary(self, metrics: dict[str, Any]):
-        self._for_each("log_summary", lambda t: t.log_summary(metrics))
+        self._for_each("log_summary", metrics)
 
     def log_artifact(self, artifact_path, *, name: Optional[str] = None, type: Optional[str] = None):
-        self._for_each("log_artifact", lambda t: t.log_artifact(artifact_path, name=name, type=type))
+        self._for_each("log_artifact", artifact_path, name=name, type=type)
 
     def finish(self):
         # finish() exceptions are logged and swallowed too; a tracker failing to
         # flush at the very end of a run shouldn't crash the trainer's shutdown.
-        self._for_each("finish", lambda t: t.finish())
+        self._for_each("finish")
 
 
 class TrackerConfig(draccus.PluginRegistry, abc.ABC):

--- a/lib/levanter/src/levanter/tracker/trackio.py
+++ b/lib/levanter/src/levanter/tracker/trackio.py
@@ -13,6 +13,7 @@ import numpy as np
 from draccus import field
 
 from levanter.tracker import Tracker
+from levanter.tracker.background import BackgroundTracker
 from levanter.tracker.histogram import Histogram
 from levanter.tracker.tracker import NoopTracker, TrackerConfig
 
@@ -118,6 +119,13 @@ class TrackioConfig(TrackerConfig):
 
     resume: str = "auto"
 
+    background: bool = True
+    """If True (default), forward all log calls through a background thread that catches
+    exceptions from Trackio. Keeps training jobs alive across transient tracker failures."""
+
+    background_max_queue_size: int = 10000
+    background_finish_timeout: float = 120.0
+
     def init(self, run_id: Optional[str]) -> Tracker:
         import trackio
 
@@ -147,4 +155,11 @@ class TrackioConfig(TrackerConfig):
             resume=resume,
             embed=False,
         )
-        return TrackioTracker(r)
+        tracker: Tracker = TrackioTracker(r)
+        if self.background:
+            tracker = BackgroundTracker(
+                tracker,
+                max_queue_size=self.background_max_queue_size,
+                finish_timeout=self.background_finish_timeout,
+            )
+        return tracker

--- a/lib/levanter/src/levanter/tracker/trackio.py
+++ b/lib/levanter/src/levanter/tracker/trackio.py
@@ -13,7 +13,7 @@ import numpy as np
 from draccus import field
 
 from levanter.tracker import Tracker
-from levanter.tracker.background import BackgroundTracker
+from levanter.tracker.background import maybe_wrap_background
 from levanter.tracker.histogram import Histogram
 from levanter.tracker.tracker import NoopTracker, TrackerConfig
 
@@ -155,11 +155,9 @@ class TrackioConfig(TrackerConfig):
             resume=resume,
             embed=False,
         )
-        tracker: Tracker = TrackioTracker(r)
-        if self.background:
-            tracker = BackgroundTracker(
-                tracker,
-                max_queue_size=self.background_max_queue_size,
-                finish_timeout=self.background_finish_timeout,
-            )
-        return tracker
+        return maybe_wrap_background(
+            TrackioTracker(r),
+            enabled=self.background,
+            max_queue_size=self.background_max_queue_size,
+            finish_timeout=self.background_finish_timeout,
+        )

--- a/lib/levanter/src/levanter/tracker/wandb.py
+++ b/lib/levanter/src/levanter/tracker/wandb.py
@@ -17,7 +17,7 @@ from draccus import field
 from git import InvalidGitRepositoryError, NoSuchPathError, Repo
 
 from levanter.tracker import Tracker
-from levanter.tracker.background import BackgroundTracker
+from levanter.tracker.background import maybe_wrap_background
 from levanter.tracker.helpers import generate_pip_freeze, infer_experiment_git_root
 from levanter.tracker.histogram import Histogram
 from levanter.tracker.tracker import TrackerConfig
@@ -331,14 +331,12 @@ class WandbConfig(TrackerConfig):
         wandb.summary["num_hosts"] = jax.process_count()  # type: ignore
         wandb.summary["backend"] = jax.default_backend()  # type: ignore
 
-        tracker: Tracker = WandbTracker(r, replicate_path=self.replicate_path)
-        if self.background:
-            tracker = BackgroundTracker(
-                tracker,
-                max_queue_size=self.background_max_queue_size,
-                finish_timeout=self.background_finish_timeout,
-            )
-        return tracker
+        return maybe_wrap_background(
+            WandbTracker(r, replicate_path=self.replicate_path),
+            enabled=self.background,
+            max_queue_size=self.background_max_queue_size,
+            finish_timeout=self.background_finish_timeout,
+        )
 
     def _git_settings(self):
         other_settings = dict()

--- a/lib/levanter/src/levanter/tracker/wandb.py
+++ b/lib/levanter/src/levanter/tracker/wandb.py
@@ -17,6 +17,7 @@ from draccus import field
 from git import InvalidGitRepositoryError, NoSuchPathError, Repo
 
 from levanter.tracker import Tracker
+from levanter.tracker.background import BackgroundTracker
 from levanter.tracker.helpers import generate_pip_freeze, infer_experiment_git_root
 from levanter.tracker.histogram import Histogram
 from levanter.tracker.tracker import TrackerConfig
@@ -237,7 +238,20 @@ class WandbConfig(TrackerConfig):
     replicate_path: Optional[str] = None
     """If set, write config and summary to this path (local or GCS) on finish()."""
 
-    def init(self, run_id: Optional[str]) -> WandbTracker:
+    background: bool = True
+    """If True (default), forward all log calls through a background thread that catches
+    exceptions from W&B. This keeps long-running training jobs alive when W&B is
+    unreachable, runs out of storage quota, or returns transient errors. Set to False
+    only if you need synchronous, fail-fast behavior (e.g. from tests)."""
+
+    background_max_queue_size: int = 10000
+    """Max number of pending tracker calls. If exceeded, additional calls are dropped
+    with a rate-limited warning rather than blocking the trainer."""
+
+    background_finish_timeout: float = 120.0
+    """Maximum seconds to wait for the background thread to drain on finish()."""
+
+    def init(self, run_id: Optional[str]) -> Tracker:
         import wandb
 
         if run_id is not None and self.id is not None and run_id != self.id:
@@ -317,7 +331,14 @@ class WandbConfig(TrackerConfig):
         wandb.summary["num_hosts"] = jax.process_count()  # type: ignore
         wandb.summary["backend"] = jax.default_backend()  # type: ignore
 
-        return WandbTracker(r, replicate_path=self.replicate_path)
+        tracker: Tracker = WandbTracker(r, replicate_path=self.replicate_path)
+        if self.background:
+            tracker = BackgroundTracker(
+                tracker,
+                max_queue_size=self.background_max_queue_size,
+                finish_timeout=self.background_finish_timeout,
+            )
+        return tracker
 
     def _git_settings(self):
         other_settings = dict()

--- a/lib/levanter/tests/test_background_tracker.py
+++ b/lib/levanter/tests/test_background_tracker.py
@@ -1,0 +1,333 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the BackgroundTracker wrapper.
+
+These tests cover the behavior we want for robustness against W&B failures:
+
+* Calls run on a background thread (don't block the producer)
+* Exceptions from the wrapped tracker are caught and logged, never raised
+* finish() drains pending updates
+* Queue-full updates are dropped, not blocked
+* Hardened CompositeTracker continues calling later trackers when an earlier
+  one raises
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from levanter.tracker import BackgroundTracker, CompositeTracker
+from levanter.tracker.tracker import Tracker
+
+
+class RecordingTracker(Tracker):
+    """A tracker that records calls and optionally raises on demand."""
+
+    name = "recording"
+
+    def __init__(self, *, raise_on_log: BaseException | None = None) -> None:
+        self.logs: list[tuple[dict[str, Any], int | None, bool | None]] = []
+        self.summary: list[dict[str, Any]] = []
+        self.hparams: list[dict[str, Any]] = []
+        self.artifacts: list[tuple[Any, str | None, str | None]] = []
+        self.finished = False
+        self._raise_on_log = raise_on_log
+
+    def log_hyperparameters(self, hparams):
+        self.hparams.append(dict(hparams))
+
+    def log(self, metrics, *, step, commit=None):
+        if self._raise_on_log is not None:
+            exc = self._raise_on_log
+            self._raise_on_log = None
+            raise exc
+        self.logs.append((dict(metrics), step, commit))
+
+    def log_summary(self, metrics):
+        self.summary.append(dict(metrics))
+
+    def log_artifact(self, artifact_path, *, name=None, type=None):
+        self.artifacts.append((artifact_path, name, type))
+
+    def finish(self):
+        self.finished = True
+
+
+class AlwaysRaisingTracker(Tracker):
+    """A tracker that raises on every call. Used to verify exception isolation."""
+
+    name = "always-raises"
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def _boom(self):
+        self.call_count += 1
+        raise RuntimeError(f"boom #{self.call_count}")
+
+    def log_hyperparameters(self, hparams):
+        self._boom()
+
+    def log(self, metrics, *, step, commit=None):
+        self._boom()
+
+    def log_summary(self, metrics):
+        self._boom()
+
+    def log_artifact(self, artifact_path, *, name=None, type=None):
+        self._boom()
+
+    def finish(self):
+        self._boom()
+
+
+def test_background_tracker_forwards_calls():
+    inner = RecordingTracker()
+    bt = BackgroundTracker(inner)
+    try:
+        bt.log_hyperparameters({"lr": 0.1})
+        bt.log({"loss": 1.0}, step=0)
+        bt.log({"loss": 0.5}, step=1, commit=True)
+        bt.log_summary({"final_loss": 0.5})
+        bt.log_artifact("/tmp/x", name="x", type="model")
+        assert bt._wait_until_idle(timeout=5)
+    finally:
+        bt.finish()
+
+    assert inner.hparams == [{"lr": 0.1}]
+    assert inner.logs == [({"loss": 1.0}, 0, None), ({"loss": 0.5}, 1, True)]
+    assert inner.summary == [{"final_loss": 0.5}]
+    assert inner.artifacts == [("/tmp/x", "x", "model")]
+    assert inner.finished is True
+
+
+def test_background_tracker_swallows_exceptions(caplog):
+    """Exceptions from the wrapped tracker must not crash the producer."""
+    inner = RecordingTracker(raise_on_log=RuntimeError("wandb storage exceeded"))
+    bt = BackgroundTracker(inner)
+    try:
+        with caplog.at_level(logging.ERROR, logger="levanter.tracker.background"):
+            # First log raises in worker -- producer thread must not see it.
+            bt.log({"loss": 1.0}, step=0)
+            # Subsequent logs should still be processed.
+            bt.log({"loss": 0.5}, step=1)
+            assert bt._wait_until_idle(timeout=5)
+    finally:
+        bt.finish()
+
+    # The first call raised before recording; the second succeeded.
+    assert inner.logs == [({"loss": 0.5}, 1, None)]
+    # An ERROR log should have captured the wandb exception.
+    assert any(
+        "wandb storage exceeded" in r.getMessage() or "raised while processing" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_background_tracker_runs_off_caller_thread():
+    """The wrapped tracker must not run on the calling thread."""
+    caller_thread = threading.get_ident()
+    seen_threads: list[int] = []
+
+    class ThreadRecording(Tracker):
+        name = "threadrec"
+
+        def log_hyperparameters(self, hparams):
+            seen_threads.append(threading.get_ident())
+
+        def log(self, metrics, *, step, commit=None):
+            seen_threads.append(threading.get_ident())
+
+        def log_summary(self, metrics):
+            seen_threads.append(threading.get_ident())
+
+        def log_artifact(self, artifact_path, *, name=None, type=None):
+            seen_threads.append(threading.get_ident())
+
+        def finish(self):
+            seen_threads.append(threading.get_ident())
+
+    bt = BackgroundTracker(ThreadRecording())
+    try:
+        bt.log({"loss": 1.0}, step=0)
+        assert bt._wait_until_idle(timeout=5)
+    finally:
+        bt.finish()
+
+    assert seen_threads, "wrapped tracker was never called"
+    for tid in seen_threads:
+        assert tid != caller_thread, "wrapped tracker ran on caller thread"
+
+
+def test_background_tracker_does_not_block_producer():
+    """Producer thread must not block, even if wrapped tracker is slow."""
+    block_event = threading.Event()
+    release_event = threading.Event()
+
+    class SlowTracker(Tracker):
+        name = "slow"
+
+        def log(self, metrics, *, step, commit=None):
+            block_event.set()
+            release_event.wait(timeout=10)
+
+        def log_hyperparameters(self, hparams):
+            pass
+
+        def log_summary(self, metrics):
+            pass
+
+        def log_artifact(self, artifact_path, *, name=None, type=None):
+            pass
+
+        def finish(self):
+            pass
+
+    bt = BackgroundTracker(SlowTracker())
+    try:
+        # First log() blocks the worker indefinitely (until release_event).
+        start = time.monotonic()
+        bt.log({"loss": 1.0}, step=0)
+        # While the worker is blocked, more logs should still return quickly.
+        block_event.wait(timeout=5)
+        for i in range(10):
+            bt.log({"loss": float(i)}, step=i + 1)
+        elapsed = time.monotonic() - start
+        # Without queueing, this would have blocked ~10s. With queueing, it
+        # must return effectively instantly.
+        assert elapsed < 1.0, f"producer was blocked for {elapsed:.2f}s"
+    finally:
+        release_event.set()
+        bt.finish()
+
+
+def test_background_tracker_drops_when_queue_full(caplog):
+    """When the queue is full, additional log calls are dropped, not blocked."""
+    block_event = threading.Event()
+    release_event = threading.Event()
+
+    class GatedTracker(Tracker):
+        name = "gated"
+
+        def log(self, metrics, *, step, commit=None):
+            block_event.set()
+            release_event.wait(timeout=10)
+
+        def log_hyperparameters(self, hparams):
+            pass
+
+        def log_summary(self, metrics):
+            pass
+
+        def log_artifact(self, artifact_path, *, name=None, type=None):
+            pass
+
+        def finish(self):
+            pass
+
+    bt = BackgroundTracker(GatedTracker(), max_queue_size=2)
+    try:
+        with caplog.at_level(logging.WARNING, logger="levanter.tracker.background"):
+            # Saturate worker.
+            bt.log({"i": 0}, step=0)
+            block_event.wait(timeout=5)
+            # Fill the queue (capacity 2).
+            bt.log({"i": 1}, step=1)
+            bt.log({"i": 2}, step=2)
+            # These should be dropped, not blocked.
+            start = time.monotonic()
+            for i in range(100):
+                bt.log({"i": i + 3}, step=i + 3)
+            elapsed = time.monotonic() - start
+            assert elapsed < 1.0
+            assert bt.dropped_count >= 50
+    finally:
+        release_event.set()
+        bt.finish()
+
+
+def test_background_tracker_finish_calls_wrapped_finish():
+    inner = RecordingTracker()
+    bt = BackgroundTracker(inner)
+    bt.log({"x": 1}, step=0)
+    bt.finish()
+    assert inner.finished is True
+    assert inner.logs == [({"x": 1}, 0, None)]
+
+
+def test_background_tracker_finish_is_idempotent():
+    inner = RecordingTracker()
+    bt = BackgroundTracker(inner)
+    bt.finish()
+    # second call should be a no-op, not raise.
+    bt.finish()
+
+
+def test_background_tracker_logs_after_finish_are_dropped():
+    inner = RecordingTracker()
+    bt = BackgroundTracker(inner)
+    bt.finish()
+    bt.log({"x": 1}, step=0)
+    # finish() already drained; the call after finish is a no-op.
+    assert inner.logs == []
+
+
+def test_composite_tracker_isolates_failures(caplog):
+    """A failing member tracker must not prevent later members from being called."""
+    bad = AlwaysRaisingTracker()
+    good = RecordingTracker()
+    composite = CompositeTracker([bad, good])
+
+    with caplog.at_level(logging.ERROR, logger="levanter.tracker.tracker"):
+        composite.log_hyperparameters({"lr": 0.1})
+        composite.log({"loss": 1.0}, step=0)
+        composite.log_summary({"final": 0.5})
+        composite.log_artifact("/tmp/x", name="a", type="model")
+        composite.finish()
+
+    assert good.hparams == [{"lr": 0.1}]
+    assert good.logs == [({"loss": 1.0}, 0, None)]
+    assert good.summary == [{"final": 0.5}]
+    assert good.artifacts == [("/tmp/x", "a", "model")]
+    assert good.finished is True
+    assert bad.call_count == 5  # one per method call
+    assert any("continuing with remaining trackers" in r.getMessage() for r in caplog.records)
+
+
+def test_composite_tracker_finish_does_not_raise():
+    """Even if every member raises, finish() should not propagate."""
+    bad1 = AlwaysRaisingTracker()
+    bad2 = AlwaysRaisingTracker()
+    composite = CompositeTracker([bad1, bad2])
+    # Should log and swallow rather than raise.
+    composite.finish()
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        RuntimeError("network unreachable"),
+        ConnectionError("dns resolve failed"),
+        OSError("disk full"),
+        ValueError("storage quota exceeded"),
+    ],
+)
+def test_background_tracker_swallows_various_exceptions(exc, caplog):
+    """Sample of error types we expect from W&B at runtime."""
+    inner = RecordingTracker(raise_on_log=exc)
+    bt = BackgroundTracker(inner)
+    try:
+        with caplog.at_level(logging.ERROR, logger="levanter.tracker.background"):
+            bt.log({"loss": 1.0}, step=0)
+            bt.log({"loss": 0.5}, step=1)
+            assert bt._wait_until_idle(timeout=5)
+    finally:
+        bt.finish()
+    # Second call (after the raise) should still have been recorded.
+    assert inner.logs == [({"loss": 0.5}, 1, None)]

--- a/lib/levanter/tests/test_background_tracker.py
+++ b/lib/levanter/tests/test_background_tracker.py
@@ -246,7 +246,7 @@ def test_background_tracker_drops_when_queue_full(caplog):
                 bt.log({"i": i + 3}, step=i + 3)
             elapsed = time.monotonic() - start
             assert elapsed < 1.0
-            assert bt.dropped_count >= 50
+            assert bt._dropped >= 50
     finally:
         release_event.set()
         bt.finish()


### PR DESCRIPTION
## Summary

Wraps network-bound trackers (W&B, Trackio) in a new `BackgroundTracker` that serialises calls onto a daemon thread and catches/logs exceptions instead of propagating. Long-running training jobs now survive transient W&B failures (storage quota, network, 5xx) instead of crashing.

Also hardens `CompositeTracker` so a failing member doesn't take down the others.

Auth/init failures still propagate, so a misconfigured run refuses to start.

Fixes #5329