### PR TITLE
[iris] Generic HTTP endpoint proxy

### DIFF
--- a/.agents/projects/iris_endpoint_proxy/design.md
+++ b/.agents/projects/iris_endpoint_proxy/design.md
@@ -1,0 +1,102 @@
+# Iris Endpoint Proxy
+
+_Why are we doing this? What's the benefit?_
+
+Per-task dashboards (Ray, JAX, TensorBoard, custom UIs) currently require a user to either know a worker's IP and reach it directly, or build their own ad-hoc tunnel. We want a single, authed entry point: hit `iris-controller/proxy/<endpoint-name>/<sub-path>` and the controller forwards normal HTTP/2 to the registered endpoint. This piggybacks on infrastructure that already exists — the endpoint registry, an in-memory store, and a working `ActorProxy` — and turns "expose a dashboard from a job" into a one-line `register_endpoint` call. Explicit non-goals: WebSockets, link-rewriting, server-sent-event semantics. This is for dashboards, not gateway features.
+
+## Background
+
+Iris already has a task-scoped endpoint registry (`EndpointRow` in `lib/iris/src/iris/cluster/controller/schema.py:1566`, write-through cache `EndpointStore` at `lib/iris/src/iris/cluster/controller/stores.py:97`, RPCs `register_endpoint` / `list_endpoints` / `unregister_endpoint` at `lib/iris/src/iris/cluster/controller/service.py:1702-1793`) and one consumer of it: `ActorProxy` at `lib/iris/src/iris/cluster/controller/actor_proxy.py:48`, which forwards `POST /iris.actor.ActorService/{method}` to the endpoint resolved from an `X-Iris-Actor-Endpoint` header. The new proxy is structurally the same — `httpx.AsyncClient`, hop-by-hop header filtering, `502` on upstream failure — but routes by URL path instead of header, supports any HTTP method, streams response bodies, and preserves query strings. See `research.md` for the full digest.
+
+## Challenges
+
+The only real design point is how to encode the endpoint name in the URL. Iris names are wire-format paths (`/user/<job_id>/<actor>`); embedding a `/`-containing string in `/proxy/<name>/<sub-path>` is ambiguous unless the name is escaped or the registry is queried for a longest prefix. Everything else — streaming, auth, header forwarding, lifecycle — is a copy of the `ActorProxy` shape with small extensions.
+
+## Costs / Risks
+
+- Every registered endpoint becomes implicitly proxyable for any authenticated controller user. Acceptable under the current threat model — the controller is the trust boundary and dashboards are not generally secret.
+- Names containing `.` won't round-trip through the URL transform. Worse than unreachable: if `/user/job/foo.bar` and `/user/job/foo/bar` are both registered, the URL `/proxy/user.job.foo.bar/...` silently routes to the second one. Current callsites use slash-only wire-format names so this collision is theoretical, but it's a footgun if a future registrar gets clever. We accept it: the controller is single-tenant in trust terms, the registrar is the same user making the request, and the downside is "your dashboard URL doesn't go where you expected" rather than a privilege boundary.
+- New surface area on the controller HTTP server: a Starlette catch-all route. If an endpoint is unhealthy or slow, traffic to its dashboard sits on the controller's connection pool. A 30s timeout is the only backstop; a body-size cap is left to a follow-up if it becomes necessary.
+- Cookie and `Authorization` stripping (both directions for cookies; client→upstream for Authorization) means dashboards with their own cookie-based state or bearer-token auth lose access to those credentials. Acceptable for the use case — controller auth has already gated the request, and forwarding the controller's session JWT to an arbitrary dashboard upstream is a credential leak. If a specific dashboard genuinely needs either, that's a follow-up opt-in (`metadata["proxy_pass_cookies"]`, `metadata["proxy_pass_auth"]`).
+
+## Design
+
+Add `EndpointProxy` next to `ActorProxy`, mounted on the controller's `Starlette` app at `/proxy/{endpoint_name:str}/{sub_path:path}`. Endpoint name uses **domain-style encoding**: a registered name `/user/job/coordinator` is reachable at `/proxy/user.job.coordinator/...`. The transform is one-way at the proxy boundary — `.` → `/` on lookup. Names containing `.` are not reachable via the proxy URL (they resolve to a `/`-substituted form that won't match); this is documented, not enforced. No `register_endpoint` change.
+
+```python
+# lib/iris/src/iris/cluster/controller/endpoint_proxy.py (new)
+
+PROXY_ROUTE = "/proxy/{endpoint_name:str}/{sub_path:path}"
+PROXY_TIMEOUT_SECONDS = 30.0
+_HOP_BY_HOP = frozenset({"host", "transfer-encoding", "connection",
+                         "keep-alive", "upgrade", "te", "trailer", "proxy-authorization",
+                         "cookie", "set-cookie", "authorization"})
+
+class EndpointProxy:
+    def __init__(self, store: ControllerStore):
+        self._store = store
+        self._client = httpx.AsyncClient(timeout=PROXY_TIMEOUT_SECONDS, follow_redirects=False)
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def handle(self, request: Request) -> Response:
+        url_name = request.path_params["endpoint_name"]
+        sub_path = request.path_params["sub_path"]
+        name = url_name.replace(".", "/")  # bijective; "." disallowed at registration
+        row = self._store.endpoints.resolve(name)
+        if row is None:
+            return JSONResponse({"error": f"No endpoint '{url_name}'"}, status_code=404)
+
+        base = row.address if "://" in row.address else f"http://{row.address}"
+        upstream_url = f"{base}/{sub_path}"
+        if request.url.query:
+            upstream_url += f"?{request.url.query}"
+        forward_headers = {k: v for k, v in request.headers.items()
+                           if k.lower() not in _HOP_BY_HOP}
+
+        upstream_req = self._client.build_request(
+            request.method, upstream_url, headers=forward_headers, content=request.stream(),
+        )
+        try:
+            upstream_resp = await self._client.send(upstream_req, stream=True)
+        except httpx.HTTPError as exc:
+            return JSONResponse({"error": f"Upstream error: {exc}"}, status_code=502)
+
+        return StreamingResponse(
+            upstream_resp.aiter_raw(),
+            status_code=upstream_resp.status_code,
+            headers={k: v for k, v in upstream_resp.headers.items()
+                     if k.lower() not in _HOP_BY_HOP},
+            background=BackgroundTask(upstream_resp.aclose),
+        )
+```
+
+Wiring (`dashboard.py:322-340`): add the route alongside `PROXY_ROUTE` for the actor proxy, decorate the handler with `@requires_auth`, and chain `endpoint_proxy.close` into the existing `on_shutdown(...)` lifespan.
+
+The proxy uses `EndpointStore.resolve()` exclusively — no DB hit on the request path, no new index, no schema or proto change.
+
+### Relationship to `ActorProxy`
+
+`ActorProxy` (`actor_proxy.py:48`) is functionally subsumed by this design: an actor RPC at `controller/iris.actor.ActorService/Call` with header `X-Iris-Actor-Endpoint: /user/job/actor` is the same upstream call as `controller/proxy/user.job.actor/iris.actor.ActorService/Call`. The actor `ProxyResolver` (`lib/iris/src/iris/actor/resolver.py`, source of `ACTOR_ENDPOINT_HEADER`) currently builds a single Connect transport pointed at the controller and stamps the endpoint name into a header; it can instead build a per-actor transport with base URL `controller/proxy/<name-with-dots>` and drop the header.
+
+**Subsumption applies to unary RPC only.** Connect streaming RPCs use chunked envelopes with in-band trailers and rely on long-lived connections, both of which collide with the response-body cap and 30s timeout. The current `ActorService` is unary, so this is fine for the migration. If streaming actors are ever introduced, they need their own proxy path with separate caps — or skip the proxy and address the actor server directly.
+
+**Out of scope for the initial PR.** This design lands `EndpointProxy` alongside `ActorProxy` without touching the resolver. A follow-up PR migrates the resolver (path-based base URL, drop `ACTOR_ENDPOINT_HEADER`) and deletes `actor_proxy.py`. Splitting it keeps the first PR small and lets the actor migration ship behind a real-cluster validation pass.
+
+## Testing
+
+Two integration tests in `lib/iris/tests/actor/test_endpoint_proxy.py` (mirroring `test_actor_proxy.py`):
+
+1. **Round-trip with a real upstream.** Spawn a tiny Starlette app on `127.0.0.1:0` exposing `/foo`, `/bar?x=1`, and a 1 MiB binary asset. Register it under `/user/jobX/dash` via the controller's endpoint store. Assert that `GET /proxy/user.jobX.dash/foo`, query string preservation, header forwarding, and the large asset (streamed) all return correct status / body / content-type.
+2. **Failure modes.** Unknown endpoint → `404`. Upstream returns `500` → proxy returns `500` (passthrough, not `502`). Upstream connection refused → `502`. Endpoint registered with a `.` in its name → reachable at the slash-substituted URL is `404` (documented limitation).
+
+Plus a unit test on the `.` → `/` transform. We do not re-test `EndpointStore` semantics — `test_endpoint_store.py` already covers them.
+
+For live-cluster validation, expose Levanter's stats dashboard on a worker via `register_endpoint`, hit it through `iris-controller/proxy/...`, and confirm the page renders.
+
+## Open Questions
+
+- **Per-job rate limiting / concurrency cap?** A misbehaving dashboard polled by an open browser tab can keep a connection slot occupied indefinitely (within the 30s timeout). Probably not worth solving in v1, but worth flagging.
+- **Address normalization at registration.** Today the proxy does a substring `://` test on `row.address` and prepends `http://` if missing. Cleaner to validate / normalize once at `register_endpoint` time and store a canonical form. Out of scope here, but a small follow-up.
+- **CORS preflight.** Browser-driven dashboards may issue `OPTIONS` preflights; the controller's existing CORS posture (if any) needs to permit `/proxy/...`. If we discover a real consumer needs it, add it; not gating v1.

--- a/.agents/projects/iris_endpoint_proxy/research.md
+++ b/.agents/projects/iris_endpoint_proxy/research.md
@@ -1,0 +1,93 @@
+# Research — iris_endpoint_proxy
+
+## Framing
+
+A generic HTTP proxy on the Iris controller: `iris-controller/proxy/<name>/<sub-path>` forwards normal HTTP/2 requests to a registered endpoint's `host:port`. Target use case is exposing per-task dashboards (Ray, JAX, TensorBoard, custom UIs) through the controller's web origin without each user reaching the worker IP directly. Explicit non-goals: WebSockets, server-sent-event streaming with backpressure, link rewriting.
+
+## In-repo findings
+
+### Endpoint registry — already exists
+
+The endpoint concept is fully wired up; the proxy just consumes it.
+
+- `EndpointRow` dataclass: `lib/iris/src/iris/cluster/controller/schema.py:1566` — `endpoint_id`, `name`, `address`, `task_id`, `metadata: dict`, `registered_at`.
+- SQLite schema: `schema.py:1049` (`ENDPOINTS = Table(...)`) — task-scoped, auto-cleaned on retry.
+- In-memory write-through cache `EndpointStore`: `lib/iris/src/iris/cluster/controller/stores.py:97`. Reads never touch the DB.
+  - `EndpointStore.resolve(name)` at `stores.py:203` — exact-name lookup, returns one row.
+  - `EndpointStore.query(EndpointQuery(name_prefix=...))` at `stores.py:172` — prefix scan.
+  - `EndpointStore.all()` at `stores.py:216` — full snapshot, used to build prefix index.
+- RPC: `register_endpoint`, `unregister_endpoint`, `list_endpoints` in `lib/iris/src/iris/cluster/controller/service.py:1702-1793`.
+- Proto: `lib/iris/src/iris/rpc/controller.proto:281-312`.
+- Client API: `lib/iris/src/iris/cluster/client/remote_client.py:330` (`register_endpoint`).
+
+Names are typically wire-formatted (`/user/<job_id>/<actor>`); `metadata` is a free-form `map<string,string>` already used to stash dashboard URLs and ports in some callsites.
+
+### Existing proxy — `ActorProxy`
+
+The shape we want to copy. `lib/iris/src/iris/cluster/controller/actor_proxy.py:48-105`.
+
+Key patterns to reuse verbatim:
+- `httpx.AsyncClient(timeout=PROXY_TIMEOUT_SECONDS)` constructed once, stored on the proxy instance.
+- `_HOP_BY_HOP_HEADERS` filter (`actor_proxy.py:36`): `host`, `transfer-encoding`, `connection`, `keep-alive`, `upgrade`. We add `x-iris-actor-endpoint`-style headers for the new proxy too.
+- Address normalization: accept `host:port` or `scheme://host:port` (`actor_proxy.py:75`).
+- Error codes: `400` (bad request), `404` (endpoint missing), `502` (upstream error). We adopt the same.
+- Lifespan: `Starlette(routes=routes, lifespan=on_shutdown(self._actor_proxy.close))` at `dashboard.py:340`. Same pattern for the new proxy's `aclose()`.
+
+What ActorProxy does *not* do that we must add:
+- Path forwarding — ActorProxy hard-codes `POST /iris.actor.ActorService/{method}`. We need any method, any sub-path.
+- Streaming response bodies — ActorProxy buffers `upstream_resp.content` (line 94). Dashboards serve large static assets; we use `httpx.AsyncClient.stream()` and Starlette `StreamingResponse`.
+- Query string forwarding — ActorProxy doesn't preserve `request.url.query`. We do.
+
+### Controller HTTP server
+
+- Framework: **Starlette + uvicorn**, all async. Not FastAPI.
+- `ControllerDashboard`: `lib/iris/src/iris/cluster/controller/dashboard.py:214`.
+- Route table: `dashboard.py:322-340`. New route slots in here.
+- Auth middleware: `_RouteAuthMiddleware` at `dashboard.py:78`. Default-deny; routes must be decorated `@public` or `@requires_auth` (imported from `iris.cluster.dashboard_common`). The new proxy route uses `@requires_auth`.
+- `lifespan=on_shutdown(...)` chain (line 340) — append the new proxy's `close` here.
+
+### Auth
+
+- JWT cookie / Bearer token, validated by `resolve_auth(token, verifier, optional)`.
+- Existing browser sessions (controller dashboard SPA) carry the cookie and will satisfy `@requires_auth` automatically — dashboards opened via the proxy URL Just Work for logged-in users.
+- CSRF check (`_check_csrf` at `dashboard.py:150`) only fires on auth state-changing endpoints; we don't need it on the proxy.
+
+### Network
+
+Controller has direct TCP to all workers (Iris assumes flat L3 within a VPC / k8s). No tunneling. Endpoint `address` is reachable from the controller process. This is the same assumption ActorProxy already relies on.
+
+### HTTP client
+
+`httpx>=0.28.1` (`lib/iris/pyproject.toml`) — already used by `ActorProxy` and `ProxyControllerDashboard`. No new dependency needed.
+
+### Tests for similar shape
+
+- `lib/iris/tests/actor/test_actor_proxy.py` — uses a `StandaloneActorProxy` helper with a dict-backed registry; spawns a real `ActorServer` on localhost; asserts round-trips, missing-header (`400`), unknown-endpoint (`404`). Same structure works for the new proxy: spin a tiny Starlette app with one `/foo` route, register it under a name, hit `/proxy/<name>/foo` through a controller test fixture.
+- `lib/iris/tests/cluster/controller/test_endpoint_store.py` — covers the registry semantics; we don't re-test those.
+
+## Prior-art pass
+
+Skipped intentionally. This is a reverse proxy of a well-understood shape (httpx → Starlette `StreamingResponse`); the in-repo `ActorProxy` is the relevant reference implementation. Re-deriving "what does an HTTP reverse proxy look like" from OSS examples would not improve the design.
+
+## Q&A summary (decisions surfaced before drafting)
+
+**Q1 — name disambiguation in URL.** Iris names contain `/` (e.g. `/user/<job_id>/<actor>`). Options considered:
+- (a) Longest-prefix match against `EndpointStore`.
+- (b) UUID in URL.
+- (c) Opt-in proxy alias stored in `metadata["proxy_alias"]`.
+- (d) **Domain-style transform**: `/user/job/task` ↔ `user.job.task`. URL is `/proxy/user.job.task/<sub-path>`; parse single `:str` segment, transform `.` → `/`, look up via `EndpointStore.resolve()`.
+
+**Decision: (d).** Bijective and trivially reversible, URLs are short and human-readable, every endpoint is automatically proxyable with no registry changes, no alias-collision problem, single O(1) `resolve()`. Bijectivity requires that registered names not contain `.`; we enforce this at `register_endpoint` time (raise `INVALID_ARGUMENT` if name contains `.`) — current callsites all use slash-only wire-format names so no migration is needed.
+
+**Q2 — auth.** `@requires_auth`. The controller is the existing trust boundary; "logged-in dashboard user can see proxied dashboards" is the natural policy and matches the cookie that the SPA already carries.
+
+**Q3 — streaming.** Use `httpx.AsyncClient.stream()` + Starlette `StreamingResponse`. Dashboards serve large assets (JS bundles, plot tiles); buffering them all in memory is wasteful and would block the event loop.
+
+**Q4 — methods.** `GET POST PUT DELETE PATCH HEAD OPTIONS`. No `CONNECT`, no WebSocket upgrade, no SSE-specific handling (per user: "not for websockets or anything fancy").
+
+**Q5 — backwards compat.** N/A — this is a new feature. No migration.
+
+## Open follow-ups (surfaced in design.md)
+
+- The `.` → `/` transform requires names not contain `.`. Survey current callsites of `register_endpoint` to confirm no `.`-containing names exist; add a `register_endpoint` boundary validation. Confirm with cluster-aware reviewer that no real callsite is harmed.
+- Every registered endpoint becomes globally proxyable for any authed controller user. Acceptable for the current threat model (controller is the trust boundary), but worth flagging.

--- a/.agents/projects/iris_endpoint_proxy/spec.md
+++ b/.agents/projects/iris_endpoint_proxy/spec.md
@@ -1,0 +1,184 @@
+# Spec — iris_endpoint_proxy
+
+Concrete contracts for the `EndpointProxy` design. Read alongside `design.md`.
+
+## Files
+
+| File | Status | Purpose |
+|------|--------|---------|
+| `lib/iris/src/iris/cluster/controller/endpoint_proxy.py` | new | `EndpointProxy` class, constants, route handler |
+| `lib/iris/src/iris/cluster/controller/dashboard.py` | modified | Add route + handler + lifespan chain |
+| `lib/iris/tests/cluster/controller/test_endpoint_proxy.py` | new | Integration tests |
+
+No proto changes. No schema changes. No `register_endpoint` changes. No new dependencies (httpx, starlette, BackgroundTask all already imported elsewhere).
+
+## Module-level constants
+
+In `endpoint_proxy.py`:
+
+```python
+PROXY_ROUTE = "/proxy/{endpoint_name:str}/{sub_path:path}"
+PROXY_TIMEOUT_SECONDS: float = 30.0
+
+# Headers stripped in both directions. `cookie` / `set-cookie` / `authorization`
+# strip is a security choice (see design.md "Cookie stripping"); the rest are
+# standard hop-by-hop.
+_HOP_BY_HOP: frozenset[str] = frozenset({
+    "host", "transfer-encoding", "connection", "keep-alive", "upgrade",
+    "te", "trailer", "proxy-authorization", "proxy-authenticate",
+    "cookie", "set-cookie", "authorization",
+})
+
+ALLOWED_METHODS: tuple[str, ...] = ("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")
+
+# httpx connection pool. Defaults (100/100) are fine for now; making it explicit
+# so the limits don't drift silently when httpx changes defaults.
+_HTTPX_LIMITS = httpx.Limits(max_connections=100, max_keepalive_connections=20)
+```
+
+No body-size cap. The 30s timeout is the only backstop. Adding a cap is a follow-up if a real misbehaving upstream forces it.
+
+## Public API: `EndpointProxy`
+
+```python
+class EndpointProxy:
+    """Forwards arbitrary HTTP requests to a registered endpoint.
+
+    The proxy resolves the endpoint name (with `.` → `/` substitution) against
+    `ControllerStore.endpoints`, then forwards request method, path suffix,
+    query string, and filtered headers to the upstream's `address`. Bodies are
+    streamed in both directions with no size cap. Hop-by-hop headers,
+    `Cookie` / `Set-Cookie`, and `Authorization` are stripped (see `_HOP_BY_HOP`).
+
+    Lifecycle: construct once on dashboard startup; await `close()` on
+    shutdown to drain the underlying httpx connection pool. The proxy is safe
+    for concurrent use across requests.
+    """
+
+    def __init__(self, store: ControllerStore) -> None: ...
+
+    async def close(self) -> None:
+        """Close the underlying httpx.AsyncClient. Idempotent."""
+
+    async def handle(self, request: starlette.requests.Request) -> starlette.responses.Response:
+        """Handle one proxied request.
+
+        Path params expected: `endpoint_name` (single segment, may contain `.`),
+        `sub_path` (anything after, possibly empty).
+
+        Returns a streaming response on success, or a JSONResponse with the
+        error contract below on failure. Never raises.
+        """
+```
+
+### Error contract (status codes returned by `handle`)
+
+| Status | Condition | Body shape |
+|--------|-----------|------------|
+| `<upstream>` | Upstream responded — pass through verbatim status, headers (filtered), body (streamed) | upstream body |
+| `404 Not Found` | `EndpointStore.resolve(name.replace(".", "/"))` returns `None` | `{"error": "No endpoint '<url_name>'"}` |
+| `405 Method Not Allowed` | Method not in `ALLOWED_METHODS` (Starlette enforces via `methods=` arg before reaching `handle`; specified for completeness) | Starlette default |
+| `502 Bad Gateway` | `httpx.ConnectError`, `httpx.RemoteProtocolError`, or any non-timeout `httpx.HTTPError` while connecting / sending | `{"error": "Upstream error: <repr>"}` |
+| `504 Gateway Timeout` | `httpx.ConnectTimeout` or `httpx.ReadTimeout` (covers PROXY_TIMEOUT_SECONDS expiry on connect or read) | `{"error": "Upstream timeout after 30s"}` |
+
+If the upstream connection drops mid-stream after the proxy has already emitted status + headers, the response is truncated at the TCP layer. There is no clean error path — status is committed. Document this; do not attempt to handle it in code.
+
+## Wiring change in `dashboard.py`
+
+Three edits inside `ControllerDashboard`:
+
+**1. Construct the proxy in `__init__`** (next to the existing `self._actor_proxy = ActorProxy(...)`):
+
+```python
+self._endpoint_proxy = EndpointProxy(service.store)
+```
+
+**2. Add the route + handler** in the `routes = [...]` list at `dashboard.py:322`. The handler is a small wrapper that delegates to `self._endpoint_proxy.handle` so the auth decorator binds to the dashboard's method, not the proxy class:
+
+```python
+@requires_auth
+async def _proxy_endpoint(self, request: Request) -> Response:
+    return await self._endpoint_proxy.handle(request)
+
+# in routes list, alongside the existing actor PROXY_ROUTE entry:
+Route(endpoint_proxy.PROXY_ROUTE, self._proxy_endpoint, methods=list(endpoint_proxy.ALLOWED_METHODS)),
+```
+
+**3. Chain shutdown** — replace `lifespan=on_shutdown(self._actor_proxy.close)` (`dashboard.py:340`) with a chained version. `on_shutdown` accepts multiple callables; pass both:
+
+```python
+lifespan=on_shutdown(self._actor_proxy.close, self._endpoint_proxy.close)
+```
+
+(If `on_shutdown` doesn't already accept varargs, this is the moment to make it do so — it's a private helper in `iris.cluster.dashboard_common`.)
+
+## Test contract: `tests/cluster/controller/test_endpoint_proxy.py`
+
+Top-level pytest fixtures, parameterized where useful. No mocks at the proxy boundary — spin a real upstream Starlette app on `127.0.0.1:0` and a real `EndpointStore`-backed proxy. Mirror `test_actor_proxy.py` patterns.
+
+```python
+@pytest.fixture
+def upstream() -> Iterator[UpstreamHandle]:
+    """Spin up a fixture Starlette app exposing /echo, /large, /slow, /500."""
+
+@pytest.fixture
+def proxy(upstream) -> Iterator[ProxyHandle]:
+    """Construct EndpointProxy + minimal Starlette host with the proxy route,
+    register the upstream under name '/user/jobX/dash'."""
+
+def test_round_trip_get(proxy):
+    """GET /proxy/user.jobX.dash/echo?q=1 forwards method, path, query, body."""
+
+def test_round_trip_post_body(proxy):
+    """POST forwards a 1 MiB JSON body intact."""
+
+def test_streams_large_response(proxy):
+    """GET /proxy/user.jobX.dash/large returns 9 MiB body without buffering
+    (assert via memory profile or by reading in chunks before upstream finishes)."""
+
+def test_unknown_endpoint_returns_404(proxy):
+    """Endpoint name not in store → 404 with JSON error body."""
+
+def test_upstream_5xx_passes_through(proxy):
+    """Upstream returns 500 → proxy returns 500, not 502."""
+
+def test_upstream_connection_refused_returns_502(proxy):
+    """Endpoint registered with unreachable address → 502."""
+
+def test_upstream_timeout_returns_504(proxy):
+    """Upstream takes > PROXY_TIMEOUT_SECONDS → 504."""
+
+def test_cookies_stripped_both_directions(proxy):
+    """Client sends Cookie: session=x → upstream sees no Cookie header.
+    Upstream sends Set-Cookie: foo=bar → client sees no Set-Cookie header."""
+
+def test_authorization_stripped(proxy):
+    """Client sends Authorization: Bearer abc → upstream sees no Authorization."""
+
+def test_dot_to_slash_transform(proxy):
+    """name '/user/jobX/dash' resolves at /proxy/user.jobX.dash/...; a
+    name registered as 'literal.dot' is unreachable through the proxy
+    (404 — documented limitation)."""
+
+def test_method_not_allowed_returns_405(proxy):
+    """CONNECT / TRACE return 405 (Starlette route filter)."""
+
+def test_disallowed_methods_not_listed():
+    """Unit test: ALLOWED_METHODS contains GET/POST/PUT/PATCH/DELETE/HEAD/
+    OPTIONS only; no CONNECT, no TRACE."""
+```
+
+A short auth integration test lives separately (one test in the existing dashboard auth test file): unauthenticated request to `/proxy/...` returns 401, mirroring how other `@requires_auth` routes are tested.
+
+## Out of scope (explicit)
+
+These are not part of this PR. Reviewers should not request them as blockers.
+
+- WebSocket / SSE proxying.
+- Link / URL rewriting in proxied HTML or JS responses.
+- Removal of `ActorProxy` and migration of `iris.actor.resolver.ProxyResolver` to the path-based proxy. Tracked as a follow-up; design.md "Relationship to `ActorProxy`".
+- An opt-in `metadata["proxy_pass_cookies"]` / `proxy_pass_auth` flag for endpoints that need credentials. Add only if a real consumer needs it.
+- Per-endpoint timeout overrides via `metadata`. Constant is global for v1.
+- Body-size cap (request or response). Add later if a real misbehaving upstream forces it.
+- Rate limiting or concurrency caps per endpoint.
+- HTTP/3, HTTP/2 server-push.

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -39,7 +39,9 @@ from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Re
 from starlette.routing import Mount, Route
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from iris.cluster.controller import endpoint_proxy
 from iris.cluster.controller.actor_proxy import PROXY_ROUTE, ActorProxy
+from iris.cluster.controller.endpoint_proxy import EndpointProxy
 from iris.cluster.controller.service import ControllerServiceImpl
 from iris.cluster.dashboard_common import (
     _AUTH_POLICY_ATTR,
@@ -314,10 +316,15 @@ class ControllerDashboard:
         rpc_app = WSGIMiddleware(rpc_wsgi_app)
 
         self._actor_proxy = ActorProxy(self._service._store)
+        self._endpoint_proxy = EndpointProxy(self._service._store)
 
         @requires_auth
         async def _proxy_actor_rpc(request: Request) -> Response:
             return await self._actor_proxy.handle(request)
+
+        @requires_auth
+        async def _proxy_endpoint(request: Request) -> Response:
+            return await self._endpoint_proxy.handle(request)
 
         routes = [
             Route("/", self._dashboard),
@@ -332,6 +339,11 @@ class ControllerDashboard:
             Route("/blobs/{blob_id:str}", self._blob_download),
             Route("/health", self._health),
             Route(PROXY_ROUTE, _proxy_actor_rpc, methods=["POST"]),
+            Route(
+                endpoint_proxy.PROXY_ROUTE,
+                _proxy_endpoint,
+                methods=list(endpoint_proxy.ALLOWED_METHODS),
+            ),
             Mount(log_wsgi_app.path, app=log_app),
             Mount(_LEGACY_LOG_SERVICE_PATH, app=log_app),
             Mount(rpc_wsgi_app.path, app=rpc_app),
@@ -341,7 +353,7 @@ class ControllerDashboard:
 
         app: Starlette | _RouteAuthMiddleware = Starlette(
             routes=routes,
-            lifespan=on_shutdown(self._actor_proxy.close),
+            lifespan=on_shutdown(self._actor_proxy.close, self._endpoint_proxy.close),
         )
         if self._auth_verifier is not None and self._auth_provider is not None:
             app = _RouteAuthMiddleware(app, self._auth_verifier, optional=self._auth_optional)

--- a/lib/iris/src/iris/cluster/controller/endpoint_proxy.py
+++ b/lib/iris/src/iris/cluster/controller/endpoint_proxy.py
@@ -1,0 +1,153 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic HTTP reverse proxy for registered task endpoints.
+
+External clients hit ``/proxy/<endpoint_name>/<sub_path>`` on the controller
+dashboard; the proxy resolves the endpoint via :class:`EndpointStore` (with
+``.`` -> ``/`` substitution on the URL-encoded name) and forwards method,
+path, query string, and filtered headers to the upstream's ``address``.
+Bodies are streamed in both directions with no size cap; the only backstop
+is :data:`PROXY_TIMEOUT_SECONDS`.
+
+Hop-by-hop headers, ``Cookie`` / ``Set-Cookie``, and ``Authorization`` are
+stripped (in both directions for cookies; client -> upstream for
+``Authorization``). Forwarding the controller's session JWT to an arbitrary
+upstream would be a credential leak, and dashboards that maintain their own
+cookie state would shadow the controller session — both are intentionally
+prevented here.
+
+Route pattern::
+
+    <ANY-METHOD> /proxy/{endpoint_name:str}/{sub_path:path}
+"""
+
+import logging
+
+import httpx
+from starlette.background import BackgroundTask
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+
+from iris.cluster.controller.stores import ControllerStore
+
+logger = logging.getLogger(__name__)
+
+PROXY_ROUTE = "/proxy/{endpoint_name:str}/{sub_path:path}"
+PROXY_TIMEOUT_SECONDS: float = 30.0
+
+# Methods exposed via the proxy. CONNECT and TRACE are intentionally absent —
+# CONNECT has no meaningful proxy semantics here, TRACE is a recurring source
+# of header-disclosure issues.
+ALLOWED_METHODS: tuple[str, ...] = ("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")
+
+# Headers stripped on the request (client -> upstream) and response
+# (upstream -> client) hops. The bottom three (cookie / set-cookie /
+# authorization) are a deliberate security choice; the rest are standard
+# hop-by-hop per RFC 7230 §6.1 and RFC 9110 §7.6.1.
+_HOP_BY_HOP: frozenset[str] = frozenset(
+    {
+        "host",
+        "transfer-encoding",
+        "connection",
+        "keep-alive",
+        "upgrade",
+        "te",
+        "trailer",
+        "proxy-authorization",
+        "proxy-authenticate",
+        "cookie",
+        "set-cookie",
+        "authorization",
+    }
+)
+
+# Bound the connection pool explicitly so httpx default drift cannot silently
+# change resource usage on the controller.
+_HTTPX_LIMITS = httpx.Limits(max_connections=100, max_keepalive_connections=20)
+
+
+class EndpointProxy:
+    """Forwards arbitrary HTTP requests to a registered endpoint.
+
+    The proxy resolves the endpoint name (with ``.`` -> ``/`` substitution)
+    against ``ControllerStore.endpoints``, then forwards request method,
+    path suffix, query string, and filtered headers to the upstream's
+    ``address``. Bodies are streamed in both directions with no size cap.
+    Hop-by-hop headers, ``Cookie`` / ``Set-Cookie``, and ``Authorization``
+    are stripped (see :data:`_HOP_BY_HOP`).
+
+    Lifecycle: construct once on dashboard startup; await :meth:`close` on
+    shutdown to drain the underlying httpx connection pool. The proxy is
+    safe for concurrent use across requests.
+    """
+
+    def __init__(self, store: ControllerStore, *, timeout_seconds: float = PROXY_TIMEOUT_SECONDS) -> None:
+        self._store = store
+        self._timeout_seconds = timeout_seconds
+        self._client = httpx.AsyncClient(
+            timeout=timeout_seconds,
+            follow_redirects=False,
+            limits=_HTTPX_LIMITS,
+        )
+
+    async def close(self) -> None:
+        """Close the underlying httpx.AsyncClient. Idempotent."""
+        await self._client.aclose()
+
+    async def handle(self, request: Request) -> Response:
+        """Handle one proxied request.
+
+        On success returns a :class:`StreamingResponse` whose body is the
+        upstream's body streamed chunk-by-chunk. On failure returns a
+        :class:`JSONResponse` with the error contract documented in the
+        spec. Never raises.
+        """
+        url_name = request.path_params["endpoint_name"]
+        sub_path = request.path_params["sub_path"]
+        # Iris wire-format names start with '/'. Try the slash-prefixed form
+        # first (the common case for task-registered endpoints), then the bare
+        # form for endpoints registered without a leading slash.
+        slashed = url_name.replace(".", "/")
+        row = self._store.endpoints.resolve(f"/{slashed}") or self._store.endpoints.resolve(slashed)
+        if row is None:
+            return JSONResponse(
+                {"error": f"No endpoint '{url_name}'"},
+                status_code=404,
+            )
+
+        base = row.address if "://" in row.address else f"http://{row.address}"
+        upstream_url = f"{base}/{sub_path}"
+        if request.url.query:
+            upstream_url = f"{upstream_url}?{request.url.query}"
+
+        forward_headers = {k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP}
+
+        upstream_req = self._client.build_request(
+            request.method,
+            upstream_url,
+            headers=forward_headers,
+            content=request.stream(),
+        )
+        try:
+            upstream_resp = await self._client.send(upstream_req, stream=True)
+        except (httpx.ConnectTimeout, httpx.ReadTimeout) as exc:
+            logger.warning("Proxy timeout for %s: %s", url_name, exc)
+            return JSONResponse(
+                {"error": f"Upstream timeout after {self._timeout_seconds:g}s"},
+                status_code=504,
+            )
+        except httpx.HTTPError as exc:
+            logger.warning("Proxy upstream error for %s: %s", url_name, exc)
+            return JSONResponse(
+                {"error": f"Upstream error: {exc!r}"},
+                status_code=502,
+            )
+
+        response_headers = {k: v for k, v in upstream_resp.headers.items() if k.lower() not in _HOP_BY_HOP}
+        return StreamingResponse(
+            upstream_resp.aiter_raw(),
+            status_code=upstream_resp.status_code,
+            headers=response_headers,
+            background=BackgroundTask(upstream_resp.aclose),
+        )

--- a/lib/iris/tests/cluster/controller/test_endpoint_proxy.py
+++ b/lib/iris/tests/cluster/controller/test_endpoint_proxy.py
@@ -1,0 +1,389 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for the endpoint proxy.
+
+Spin up a real upstream Starlette app on 127.0.0.1:0, route through a real
+EndpointProxy hosted on its own Starlette app, and verify the full
+round-trip: method, path suffix, query string, headers, and streaming
+bodies. Mirrors the structure of test_actor_proxy.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import httpx
+import pytest
+import uvicorn
+from iris.cluster.controller.endpoint_proxy import ALLOWED_METHODS, PROXY_ROUTE, EndpointProxy
+from iris.cluster.controller.schema import EndpointRow
+from iris.cluster.dashboard_common import on_shutdown
+from iris.cluster.types import JobName
+from iris.managed_thread import ThreadContainer
+from rigging.timing import Duration, ExponentialBackoff, Timestamp
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse, Response, StreamingResponse
+from starlette.routing import Route
+
+# Endpoint name registered in the fake store; reachable at /proxy/user.jobX.dash/...
+ENDPOINT_NAME = "/user/jobX/dash"
+ENDPOINT_URL_NAME = "user.jobX.dash"
+
+
+class _FakeEndpointStore:
+    """In-memory stand-in for ``EndpointStore`` that exposes ``resolve``.
+
+    Only the methods used by ``EndpointProxy`` are implemented. This mirrors
+    the ``StandaloneActorProxy`` pattern in ``test_actor_proxy.py``: keep
+    the proxy under test real, swap out the persistent store.
+    """
+
+    def __init__(self) -> None:
+        self._rows: dict[str, EndpointRow] = {}
+
+    def register(self, name: str, address: str) -> None:
+        self._rows[name] = EndpointRow(
+            endpoint_id=f"e-{len(self._rows)}",
+            name=name,
+            address=address,
+            task_id=JobName.from_wire("/user/jobX/dash"),
+            metadata={},
+            registered_at=Timestamp.now(),
+        )
+
+    def resolve(self, name: str) -> EndpointRow | None:
+        return self._rows.get(name)
+
+
+class _FakeStore:
+    """Duck-typed stand-in for ``ControllerStore`` used by the proxy.
+
+    ``EndpointProxy`` only touches ``store.endpoints.resolve``; we ignore the
+    declared ``ControllerStore`` type at the construction sites.
+    """
+
+    def __init__(self) -> None:
+        self.endpoints = _FakeEndpointStore()
+
+
+@dataclass
+class UpstreamHandle:
+    port: int
+    received_headers: list[dict[str, str]]
+    received_bodies: list[bytes]
+    received_paths: list[str]
+    received_methods: list[str]
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_server(server: uvicorn.Server) -> None:
+    ExponentialBackoff(initial=0.05, maximum=0.5).wait_until(
+        lambda: server.started,
+        timeout=Duration.from_seconds(5.0),
+    )
+
+
+def _build_upstream_app(handle: UpstreamHandle) -> Starlette:
+    """Starlette app exposing the routes used in the test contract."""
+
+    async def _record(request: Request) -> None:
+        handle.received_headers.append({k.lower(): v for k, v in request.headers.items()})
+        handle.received_bodies.append(await request.body())
+        handle.received_paths.append(request.url.path + (f"?{request.url.query}" if request.url.query else ""))
+        handle.received_methods.append(request.method)
+
+    async def echo(request: Request) -> Response:
+        await _record(request)
+        body = handle.received_bodies[-1]
+        # Echo back path, query, body length, method, and a sentinel header.
+        return JSONResponse(
+            {
+                "path": request.url.path,
+                "query": request.url.query,
+                "body_len": len(body),
+                "method": request.method,
+                "x_custom_in": request.headers.get("x-custom"),
+            },
+            headers={"x-upstream-saw": request.headers.get("x-custom", "<missing>")},
+        )
+
+    async def upstream_500(request: Request) -> Response:
+        await _record(request)
+        return PlainTextResponse("upstream blew up", status_code=500)
+
+    async def slow(request: Request) -> Response:
+        await _record(request)
+        # Sleep long enough to outlast any reasonable test-side proxy timeout.
+        # The timeout test uses a 0.5s proxy timeout, so 5s here is plenty.
+        await asyncio.sleep(5.0)
+        return PlainTextResponse("late", status_code=200)
+
+    async def large(request: Request) -> Response:
+        await _record(request)
+        # 9 MiB streamed in 64 KiB chunks. Reading on the client side before
+        # the upstream finishes producing it demonstrates streaming.
+        chunk = b"x" * 65536
+
+        async def gen():
+            for _ in range(144):  # 144 * 64 KiB = 9 MiB
+                yield chunk
+
+        return StreamingResponse(gen(), media_type="application/octet-stream")
+
+    async def cookie_setter(request: Request) -> Response:
+        await _record(request)
+        return PlainTextResponse(
+            "ok",
+            headers={"set-cookie": "upstream_session=abc; Path=/"},
+        )
+
+    routes = [
+        Route("/echo", echo, methods=list(ALLOWED_METHODS)),
+        Route("/500", upstream_500),
+        Route("/slow", slow),
+        Route("/large", large),
+        Route("/cookie", cookie_setter),
+    ]
+    return Starlette(routes=routes)
+
+
+@pytest.fixture
+def threads() -> Iterator[ThreadContainer]:
+    container = ThreadContainer()
+    try:
+        yield container
+    finally:
+        container.stop()
+
+
+@pytest.fixture
+def upstream(threads: ThreadContainer) -> UpstreamHandle:
+    handle = UpstreamHandle(
+        port=_free_port(), received_headers=[], received_bodies=[], received_paths=[], received_methods=[]
+    )
+    app = _build_upstream_app(handle)
+    config = uvicorn.Config(app, host="127.0.0.1", port=handle.port, log_level="error", log_config=None)
+    server = uvicorn.Server(config)
+    threads.spawn_server(server, name=f"upstream-{handle.port}")
+    _wait_for_server(server)
+    return handle
+
+
+@dataclass
+class ProxyHandle:
+    base_url: str
+    upstream: UpstreamHandle
+    store: _FakeStore
+
+
+def _build_proxy_app(proxy: EndpointProxy) -> Starlette:
+    return Starlette(
+        routes=[Route(PROXY_ROUTE, proxy.handle, methods=list(ALLOWED_METHODS))],
+        lifespan=on_shutdown(proxy.close),
+    )
+
+
+@pytest.fixture
+def proxy(upstream: UpstreamHandle, threads: ThreadContainer) -> ProxyHandle:
+    store = _FakeStore()
+    store.endpoints.register(ENDPOINT_NAME, f"127.0.0.1:{upstream.port}")
+    ep_proxy = EndpointProxy(store)  # type: ignore[arg-type]
+    app = _build_proxy_app(ep_proxy)
+    port = _free_port()
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error", log_config=None)
+    server = uvicorn.Server(config)
+    threads.spawn_server(server, name=f"proxy-{port}")
+    _wait_for_server(server)
+    return ProxyHandle(base_url=f"http://127.0.0.1:{port}", upstream=upstream, store=store)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_get(proxy: ProxyHandle) -> None:
+    with httpx.Client() as client:
+        resp = client.get(
+            f"{proxy.base_url}/proxy/{ENDPOINT_URL_NAME}/echo",
+            params={"q": "1"},
+            headers={"x-custom": "hello"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["path"] == "/echo"
+    assert body["query"] == "q=1"
+    assert body["method"] == "GET"
+    assert body["x_custom_in"] == "hello"
+    assert resp.headers["x-upstream-saw"] == "hello"
+    # Upstream actually saw the request.
+    assert proxy.upstream.received_methods[-1] == "GET"
+    assert proxy.upstream.received_paths[-1] == "/echo?q=1"
+
+
+def test_round_trip_post_body(proxy: ProxyHandle) -> None:
+    payload = (b"a" * 1024) * 1024  # 1 MiB
+    with httpx.Client() as client:
+        resp = client.post(
+            f"{proxy.base_url}/proxy/{ENDPOINT_URL_NAME}/echo",
+            content=payload,
+            headers={"content-type": "application/octet-stream"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["method"] == "POST"
+    assert body["body_len"] == len(payload)
+    assert proxy.upstream.received_bodies[-1] == payload
+
+
+def test_streams_large_response(proxy: ProxyHandle) -> None:
+    # Stream-read; assert we can pull bytes incrementally and that the total
+    # equals the upstream's 9 MiB without tripping any internal cap.
+    total = 0
+    first_chunk_at: float | None = None
+    started = time.monotonic()
+    with httpx.Client(timeout=10.0) as client:
+        with client.stream("GET", f"{proxy.base_url}/proxy/{ENDPOINT_URL_NAME}/large") as resp:
+            assert resp.status_code == 200
+            for chunk in resp.iter_bytes():
+                if first_chunk_at is None:
+                    first_chunk_at = time.monotonic()
+                total += len(chunk)
+    assert total == 9 * 1024 * 1024
+    # Sanity: we received the first byte well before the full transfer would
+    # complete on a buffered (non-streaming) implementation. This is a weak
+    # signal but it's the best we can do without a memory profile.
+    assert first_chunk_at is not None
+    assert first_chunk_at - started < 5.0
+
+
+def test_unknown_endpoint_returns_404(proxy: ProxyHandle) -> None:
+    with httpx.Client() as client:
+        resp = client.get(f"{proxy.base_url}/proxy/no.such.endpoint/whatever")
+    assert resp.status_code == 404
+    assert "no.such.endpoint" in resp.json()["error"]
+
+
+def test_upstream_5xx_passes_through(proxy: ProxyHandle) -> None:
+    with httpx.Client() as client:
+        resp = client.get(f"{proxy.base_url}/proxy/{ENDPOINT_URL_NAME}/500")
+    assert resp.status_code == 500
+    assert resp.text == "upstream blew up"
+
+
+def test_upstream_connection_refused_returns_502(threads: ThreadContainer) -> None:
+    store = _FakeStore()
+    # Bind a port and immediately release it; the address is dead by the time
+    # the proxy connects.
+    dead_port = _free_port()
+    store.endpoints.register(ENDPOINT_NAME, f"127.0.0.1:{dead_port}")
+    ep_proxy = EndpointProxy(store)  # type: ignore[arg-type]
+    app = _build_proxy_app(ep_proxy)
+    port = _free_port()
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error", log_config=None)
+    server = uvicorn.Server(config)
+    threads.spawn_server(server, name=f"proxy-{port}")
+    _wait_for_server(server)
+
+    with httpx.Client() as client:
+        resp = client.get(f"http://127.0.0.1:{port}/proxy/{ENDPOINT_URL_NAME}/anything")
+    assert resp.status_code == 502
+    assert "Upstream error" in resp.json()["error"]
+
+
+def test_upstream_timeout_returns_504(threads: ThreadContainer, upstream: UpstreamHandle) -> None:
+    # Use a short proxy timeout so the test runs quickly. The /slow upstream
+    # sleeps far longer than the proxy timeout, guaranteeing a ReadTimeout.
+    store = _FakeStore()
+    store.endpoints.register(ENDPOINT_NAME, f"127.0.0.1:{upstream.port}")
+    ep_proxy = EndpointProxy(store, timeout_seconds=0.5)  # type: ignore[arg-type]
+    app = _build_proxy_app(ep_proxy)
+    port = _free_port()
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error", log_config=None)
+    server = uvicorn.Server(config)
+    threads.spawn_server(server, name=f"proxy-{port}")
+    _wait_for_server(server)
+
+    with httpx.Client(timeout=10.0) as client:
+        resp = client.get(f"http://127.0.0.1:{port}/proxy/{ENDPOINT_URL_NAME}/slow")
+    assert resp.status_code == 504
+    assert "timeout" in resp.json()["error"].lower()
+
+
+def test_cookies_stripped_both_directions(proxy: ProxyHandle) -> None:
+    with httpx.Client() as client:
+        resp = client.get(
+            f"{proxy.base_url}/proxy/{ENDPOINT_URL_NAME}/cookie",
+            headers={"cookie": "session=secret"},
+        )
+    assert resp.status_code == 200
+    # Upstream did not see the inbound Cookie.
+    last_in = proxy.upstream.received_headers[-1]
+    assert "cookie" not in last_in
+    # Client did not see the outbound Set-Cookie.
+    assert "set-cookie" not in {k.lower() for k in resp.headers.keys()}
+
+
+def test_authorization_stripped(proxy: ProxyHandle) -> None:
+    with httpx.Client() as client:
+        resp = client.get(
+            f"{proxy.base_url}/proxy/{ENDPOINT_URL_NAME}/echo",
+            headers={"authorization": "Bearer abc"},
+        )
+    assert resp.status_code == 200
+    last_in = proxy.upstream.received_headers[-1]
+    assert "authorization" not in last_in
+
+
+def test_dot_to_slash_transform(threads: ThreadContainer, upstream: UpstreamHandle) -> None:
+    """``.`` in the URL maps to ``/`` at lookup; literal-``.`` names are unreachable."""
+    store = _FakeStore()
+    store.endpoints.register("/user/jobX/dash", f"127.0.0.1:{upstream.port}")
+    # A name with a literal '.' would only be reachable via /proxy/literal.dot/...,
+    # but that URL transforms to 'literal/dot' on lookup and won't match.
+    store.endpoints.register("literal.dot", f"127.0.0.1:{upstream.port}")
+    ep_proxy = EndpointProxy(store)  # type: ignore[arg-type]
+    app = _build_proxy_app(ep_proxy)
+    port = _free_port()
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error", log_config=None)
+    server = uvicorn.Server(config)
+    threads.spawn_server(server, name=f"proxy-{port}")
+    _wait_for_server(server)
+
+    with httpx.Client() as client:
+        # Slash-substituted name reaches the upstream.
+        ok = client.get(f"http://127.0.0.1:{port}/proxy/user.jobX.dash/echo")
+        assert ok.status_code == 200
+
+        # Literal-dot name is unreachable: 'literal.dot' -> 'literal/dot' on lookup.
+        miss = client.get(f"http://127.0.0.1:{port}/proxy/literal.dot/echo")
+        assert miss.status_code == 404
+
+
+def test_method_not_allowed_returns_405(proxy: ProxyHandle) -> None:
+    # Starlette filters by registered methods before the handler runs.
+    # TRACE / CONNECT are not in ALLOWED_METHODS.
+    with httpx.Client() as client:
+        resp = client.request(
+            "TRACE",
+            f"{proxy.base_url}/proxy/{ENDPOINT_URL_NAME}/echo",
+        )
+    assert resp.status_code == 405
+
+
+def test_disallowed_methods_not_listed() -> None:
+    """ALLOWED_METHODS should not include CONNECT or TRACE."""
+    assert "CONNECT" not in ALLOWED_METHODS
+    assert "TRACE" not in ALLOWED_METHODS
+    assert set(ALLOWED_METHODS) == {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}


### PR DESCRIPTION
## Summary

Adds `/proxy/<endpoint-name>/<sub-path>` on the controller dashboard. Hitting the controller forwards normal HTTP/2 to an endpoint registered via `register_endpoint`, resolved through the existing `EndpointStore` via a `.` → `/` name transform (so `/user/jobX/dash` is reachable at `/proxy/user.jobX.dash/...`). Bodies stream in both directions, `@requires_auth` gates access, and `Cookie` / `Set-Cookie` / `Authorization` are stripped.

The motivation is exposing per-task dashboards (Ray, JAX, TensorBoard, custom) behind controller auth without each user reaching a worker IP directly. `ActorProxy` is functionally subsumed by this design once the actor resolver moves to path-based routing — explicitly tracked as a follow-up PR so this one stays small.

Three sibling artifacts live under `.agents/projects/iris_endpoint_proxy/`:

- [design.md](https://github.com/marin-community/marin/blob/iris-endpoint-proxy/.agents/projects/iris_endpoint_proxy/design.md) — the 1-pager (motivation, tradeoffs, open questions)
- [spec.md](https://github.com/marin-community/marin/blob/iris-endpoint-proxy/.agents/projects/iris_endpoint_proxy/spec.md) — concrete contracts (signatures, error codes, header lists, test contract)
- [research.md](https://github.com/marin-community/marin/blob/iris-endpoint-proxy/.agents/projects/iris_endpoint_proxy/research.md) — in-repo refs and Q&A that shaped the design

Discussion welcome — see Open Questions in `design.md`.

## Test plan

- [x] New: `lib/iris/tests/cluster/controller/test_endpoint_proxy.py` — 12 integration tests against a real upstream Starlette app on `127.0.0.1:0`. Covers round-trip, streaming, query/header forwarding, `Cookie`/`Set-Cookie`/`Authorization` strip, 404 / 502 / 504 / 405, the `.` → `/` transform.
- [x] Regression: `lib/iris/tests/actor/test_actor_proxy.py` (4 tests) still passes — `on_shutdown` was extended to varargs.
- [x] `./infra/pre-commit.py --fix` clean on all touched files.
- [ ] Live cluster validation: register a real dashboard endpoint and confirm the page renders through `iris-controller/proxy/...`.