### PR TITLE
[iris] tolerate non-Python children in py-spy dump

### DIFF
--- a/lib/iris/src/iris/cluster/runtime/profile.py
+++ b/lib/iris/src/iris/cluster/runtime/profile.py
@@ -176,6 +176,12 @@ def profile_local_process(duration_seconds: int, profile_type: job_pb2.ProfileTy
         raise RuntimeError("ProfileType must specify cpu, memory, or threads profiler")
 
 
+# Workaround for https://github.com/benfred/py-spy/issues/846: py-spy dump --subprocesses
+# exits non-zero when it walks into a non-Python child (e.g. wandb-core, a Go binary), even
+# though the parent dump already went to stdout. Drop this once py-spy fixes the upstream bug.
+_PYSPY_NON_PYTHON_CHILD_ERROR = "Failed to find python version from target process"
+
+
 def run_pyspy_dump(
     pid: str, py_spy_bin: str = "py-spy", *, include_locals: bool = False, subprocesses: bool = True
 ) -> bytes:
@@ -183,7 +189,9 @@ def run_pyspy_dump(
     cmd = build_pyspy_dump_cmd(pid, py_spy_bin, include_locals=include_locals, subprocesses=subprocesses)
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
     if result.returncode != 0:
-        raise RuntimeError(f"py-spy dump failed: {result.stderr}")
+        partial_ok = subprocesses and bool(result.stdout.strip()) and _PYSPY_NON_PYTHON_CHILD_ERROR in result.stderr
+        if not partial_ok:
+            raise RuntimeError(f"py-spy dump failed: {result.stderr}")
     return result.stdout.encode("utf-8")
 
 

--- a/lib/iris/tests/cluster/runtime/test_profile.py
+++ b/lib/iris/tests/cluster/runtime/test_profile.py
@@ -18,15 +18,10 @@ from iris.cluster.runtime.profile import (
     build_pyspy_cmd,
     resolve_cpu_spec,
     resolve_memory_spec,
-    run_pyspy_dump,
 )
 from iris.rpc import job_pb2
 
-try:
-    import memray
-except ImportError:
-    memray = None
-needs_memray = pytest.mark.skipif(memray is None, reason="memray not installed")
+memray = pytest.importorskip("memray")
 
 # ---------------------------------------------------------------------------
 # resolve_cpu_spec: enum → (py_spy_format, ext) mapping and defaults
@@ -92,67 +87,6 @@ def test_build_pyspy_cmd_includes_subprocesses_flag_by_default():
     spec = resolve_cpu_spec(cfg, duration_seconds=5, pid="1")
     cmd = build_pyspy_cmd(spec, py_spy_bin="py-spy", output_path="/tmp/out.svg")
     assert "--subprocesses" in cmd
-
-
-# ---------------------------------------------------------------------------
-# run_pyspy_dump: workaround for https://github.com/benfred/py-spy/issues/846
-# (py-spy --subprocesses exits non-zero when it walks into a non-Python child)
-# ---------------------------------------------------------------------------
-
-
-def _stub_subprocess_run(monkeypatch, *, returncode: int, stdout: str, stderr: str):
-    from subprocess import CompletedProcess
-
-    def fake_run(cmd, **kwargs):
-        return CompletedProcess(args=cmd, returncode=returncode, stdout=stdout, stderr=stderr)
-
-    monkeypatch.setattr("iris.cluster.runtime.profile.subprocess.run", fake_run)
-
-
-def test_run_pyspy_dump_returns_partial_stdout_on_non_python_child(monkeypatch):
-    _stub_subprocess_run(
-        monkeypatch,
-        returncode=1,
-        stdout="Process 1: python -u main.py\nThread 1 (idle): MainThread\n",
-        stderr="Error: Failed to find python version from target process\n",
-    )
-    out = run_pyspy_dump("1", subprocesses=True)
-    assert b"Process 1: python -u main.py" in out
-
-
-def test_run_pyspy_dump_raises_when_real_failure(monkeypatch):
-    _stub_subprocess_run(
-        monkeypatch,
-        returncode=1,
-        stdout="",
-        stderr="Error: Permission denied (ptrace)\n",
-    )
-    with pytest.raises(RuntimeError, match="Permission denied"):
-        run_pyspy_dump("1", subprocesses=True)
-
-
-def test_run_pyspy_dump_raises_when_stdout_empty_even_with_known_error(monkeypatch):
-    """If we never got the parent dump, propagate the failure — empty output is not partial success."""
-    _stub_subprocess_run(
-        monkeypatch,
-        returncode=1,
-        stdout="",
-        stderr="Error: Failed to find python version from target process\n",
-    )
-    with pytest.raises(RuntimeError):
-        run_pyspy_dump("1", subprocesses=True)
-
-
-def test_run_pyspy_dump_raises_when_subprocesses_disabled(monkeypatch):
-    """Without --subprocesses, py-spy can't have walked into a child — treat any failure as fatal."""
-    _stub_subprocess_run(
-        monkeypatch,
-        returncode=1,
-        stdout="Process 1: python -u main.py\n",
-        stderr="Error: Failed to find python version from target process\n",
-    )
-    with pytest.raises(RuntimeError):
-        run_pyspy_dump("1", subprocesses=False)
 
 
 # ---------------------------------------------------------------------------
@@ -246,7 +180,6 @@ def test_resolve_memory_spec_flamegraph_is_not_raw():
     assert spec.is_raw is False
 
 
-@needs_memray
 @pytest.mark.parametrize(
     "proto_format",
     [
@@ -265,7 +198,6 @@ def test_run_memray_profile_returns_nonempty_output(proto_format):
     assert len(result) > 0
 
 
-@needs_memray
 def test_run_memray_profile_stats_returns_valid_json():
     """Stats reporter returns parseable JSON, not a file-path string."""
     _allocate_during(1)

--- a/lib/iris/tests/cluster/runtime/test_profile.py
+++ b/lib/iris/tests/cluster/runtime/test_profile.py
@@ -18,10 +18,15 @@ from iris.cluster.runtime.profile import (
     build_pyspy_cmd,
     resolve_cpu_spec,
     resolve_memory_spec,
+    run_pyspy_dump,
 )
 from iris.rpc import job_pb2
 
-memray = pytest.importorskip("memray")
+try:
+    import memray
+except ImportError:
+    memray = None
+needs_memray = pytest.mark.skipif(memray is None, reason="memray not installed")
 
 # ---------------------------------------------------------------------------
 # resolve_cpu_spec: enum → (py_spy_format, ext) mapping and defaults
@@ -87,6 +92,67 @@ def test_build_pyspy_cmd_includes_subprocesses_flag_by_default():
     spec = resolve_cpu_spec(cfg, duration_seconds=5, pid="1")
     cmd = build_pyspy_cmd(spec, py_spy_bin="py-spy", output_path="/tmp/out.svg")
     assert "--subprocesses" in cmd
+
+
+# ---------------------------------------------------------------------------
+# run_pyspy_dump: workaround for https://github.com/benfred/py-spy/issues/846
+# (py-spy --subprocesses exits non-zero when it walks into a non-Python child)
+# ---------------------------------------------------------------------------
+
+
+def _stub_subprocess_run(monkeypatch, *, returncode: int, stdout: str, stderr: str):
+    from subprocess import CompletedProcess
+
+    def fake_run(cmd, **kwargs):
+        return CompletedProcess(args=cmd, returncode=returncode, stdout=stdout, stderr=stderr)
+
+    monkeypatch.setattr("iris.cluster.runtime.profile.subprocess.run", fake_run)
+
+
+def test_run_pyspy_dump_returns_partial_stdout_on_non_python_child(monkeypatch):
+    _stub_subprocess_run(
+        monkeypatch,
+        returncode=1,
+        stdout="Process 1: python -u main.py\nThread 1 (idle): MainThread\n",
+        stderr="Error: Failed to find python version from target process\n",
+    )
+    out = run_pyspy_dump("1", subprocesses=True)
+    assert b"Process 1: python -u main.py" in out
+
+
+def test_run_pyspy_dump_raises_when_real_failure(monkeypatch):
+    _stub_subprocess_run(
+        monkeypatch,
+        returncode=1,
+        stdout="",
+        stderr="Error: Permission denied (ptrace)\n",
+    )
+    with pytest.raises(RuntimeError, match="Permission denied"):
+        run_pyspy_dump("1", subprocesses=True)
+
+
+def test_run_pyspy_dump_raises_when_stdout_empty_even_with_known_error(monkeypatch):
+    """If we never got the parent dump, propagate the failure — empty output is not partial success."""
+    _stub_subprocess_run(
+        monkeypatch,
+        returncode=1,
+        stdout="",
+        stderr="Error: Failed to find python version from target process\n",
+    )
+    with pytest.raises(RuntimeError):
+        run_pyspy_dump("1", subprocesses=True)
+
+
+def test_run_pyspy_dump_raises_when_subprocesses_disabled(monkeypatch):
+    """Without --subprocesses, py-spy can't have walked into a child — treat any failure as fatal."""
+    _stub_subprocess_run(
+        monkeypatch,
+        returncode=1,
+        stdout="Process 1: python -u main.py\n",
+        stderr="Error: Failed to find python version from target process\n",
+    )
+    with pytest.raises(RuntimeError):
+        run_pyspy_dump("1", subprocesses=False)
 
 
 # ---------------------------------------------------------------------------
@@ -180,6 +246,7 @@ def test_resolve_memory_spec_flamegraph_is_not_raw():
     assert spec.is_raw is False
 
 
+@needs_memray
 @pytest.mark.parametrize(
     "proto_format",
     [
@@ -198,6 +265,7 @@ def test_run_memray_profile_returns_nonempty_output(proto_format):
     assert len(result) > 0
 
 
+@needs_memray
 def test_run_memray_profile_stats_returns_valid_json():
     """Stats reporter returns parseable JSON, not a file-path string."""
     _allocate_during(1)


### PR DESCRIPTION
* works around https://github.com/benfred/py-spy/issues/846
* `py-spy dump --pid <PID> --subprocesses` exits non-zero on the first non-Python child (e.g. `wandb-core`, a Go binary) — `run_pyspy_dump` was discarding the parent's stdout on any non-zero exit, so dashboard "thread dump" returned nothing on training jobs
* `run_pyspy_dump` now returns partial stdout when `--subprocesses` was set, stdout is non-empty, and stderr matches `Failed to find python version from target process` [^1]
  * other failure modes (target died, ptrace denied, timeout, empty stdout) still raise as before
* search for `_PYSPY_NON_PYTHON_CHILD_ERROR` to delete once py-spy ships a fix upstream

[^1]: narrow string match (not "non-empty stdout" alone), so genuine errors that happened to produce some stdout first still surface