### PR TITLE
Fix ragged_dot Pallas API usage

### DIFF
--- a/lib/haliax/src/haliax/nn/ragged_dot.py
+++ b/lib/haliax/src/haliax/nn/ragged_dot.py
@@ -76,15 +76,15 @@ def _triton_ragged_dot_kernel(
         def body(i, acc):
             start_k = i * block_k
             span_k = pl.ds(start_k, block_k)
-            a = pl.load(a_ref, (span_m, span_k))
-            b = pl.load(b_ref, (span_k, pl.ds(0, b_ref.shape[1])))
+            a = plgpu.load(a_ref.at[span_m, span_k])
+            b = plgpu.load(b_ref.at[span_k, pl.ds(0, b_ref.shape[1])])
             dtype = jnp.result_type(a, b)
             return acc + pl.dot(a.astype(dtype), b.astype(dtype))
 
         num_k_blocks = pl.cdiv(k, block_k)
         acc = jax.lax.fori_loop(0, num_k_blocks, body, acc)
         mask = (start_m + jnp.arange(block_m)) < hi
-        pl.store(out_ref, (span_m, pl.ds(0, out_ref.shape[1])), acc.astype(out_ref.dtype), mask=mask[:, None])
+        plgpu.store(out_ref.at[span_m, pl.ds(0, out_ref.shape[1])], acc.astype(out_ref.dtype), mask=mask[:, None])
 
 
 def _triton_pallas_call(lhs: jax.Array, rhs: jax.Array, group_sizes: jax.Array) -> jax.Array:

--- a/lib/haliax/tests/test_ragged_dot_dispatch.py
+++ b/lib/haliax/tests/test_ragged_dot_dispatch.py
@@ -2,9 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib
+
+import jax
 import jax.numpy as jnp
+import pytest
 
 from haliax.nn import ragged_dot
+
+ragged_dot_module = importlib.import_module("haliax.nn.ragged_dot")
 
 
 def _inputs():
@@ -21,3 +27,47 @@ def test_ragged_dot_platform_default_is_close_to_xla_call():
     xla_out = ragged_dot(lhs, rhs, group_sizes, implementation="xla")
 
     assert jnp.allclose(default_out, xla_out, rtol=1e-5, atol=1e-5)
+
+
+def test_triton_kernel_traces_with_jax_0_9_pallas_memory_api_on_cpu_interpreter():
+    if not ragged_dot_module._has_pallas_triton:
+        pytest.skip("Pallas Triton backend is not available")
+
+    lhs = jnp.arange(4, dtype=jnp.float32).reshape(2, 2)
+    rhs = jnp.arange(6, dtype=jnp.float32).reshape(2, 3)
+    lo = jnp.array(0, dtype=jnp.int32)
+    hi = jnp.array(lhs.shape[0], dtype=jnp.int32)
+
+    pallas_call = ragged_dot_module.pl.pallas_call(
+        lambda a, b, lo, hi, out: ragged_dot_module._triton_ragged_dot_kernel(
+            a, b, lo, hi, out, block_m=lhs.shape[0], block_k=lhs.shape[1]
+        ),
+        out_shape=jax.ShapeDtypeStruct((lhs.shape[0], rhs.shape[1]), lhs.dtype),
+        in_specs=[
+            ragged_dot_module.pl.no_block_spec,
+            ragged_dot_module.pl.no_block_spec,
+            ragged_dot_module.pl.no_block_spec,
+            ragged_dot_module.pl.no_block_spec,
+        ],
+        out_specs=ragged_dot_module.pl.no_block_spec,
+        grid=(1,),
+        interpret=True,
+    )
+
+    assert jnp.allclose(pallas_call(lhs, rhs, lo, hi), lhs @ rhs, rtol=1e-5, atol=1e-5)
+
+
+def test_ragged_dot_gpu_auto_uses_triton_when_available(monkeypatch):
+    lhs, rhs, group_sizes = _inputs()
+    expected = jnp.full((lhs.shape[0], rhs.shape[2]), 17.0, dtype=lhs.dtype)
+    monkeypatch.setattr(ragged_dot_module.jax, "default_backend", lambda: "gpu")
+    monkeypatch.setattr(ragged_dot_module, "_has_pallas_triton", True)
+
+    def triton_result(lhs, rhs, group_sizes):
+        return jnp.full((lhs.shape[0], rhs.shape[2]), expected[0, 0], dtype=lhs.dtype)
+
+    monkeypatch.setattr(ragged_dot_module, "_ragged_dot_triton_impl", triton_result)
+
+    auto_out = ragged_dot(lhs, rhs, group_sizes, implementation="auto")
+
+    assert jnp.array_equal(auto_out, expected)


### PR DESCRIPTION
## Summary

Fix the Grug MoE GPU canary crash in `haliax.nn.ragged_dot` after the JAX 0.9.2 upgrade.

| Area | Change |
| --- | --- |
| Pallas API | Replace removed `pl.load/store` with `plgpu.load/store(ref.at[...])`. |
| GPU behavior | Preserve pre-upgrade `auto`: try Triton when available, then XLA fallback. |
| Fallback scope | Keep fallback limited to deliberate backend failures: `NotImplementedError`, `RuntimeError`. |
| Tests | Add CPU trace coverage for the Triton kernel and public GPU-auto dispatch behavior. |

## Root Cause

GPU `auto` selected the Triton Pallas path on H100. That kernel still used `jax.experimental.pallas.load/store`, which JAX 0.9.2 no longer exports, so training crashed at step 0 with `AttributeError`.

| Link | URL |
| --- | --- |
| Failing canary | https://github.com/marin-community/marin/actions/runs/25212026573 |
| Issue | https://github.com/marin-community/marin/issues/5341 |

## Validation

| Check | Ref | Result |
| --- | --- | --- |
| `test_ragged_dot_dispatch.py` | current head `a65b73185` | 3 passed |
| `test_moe_linear.py` | current head `a65b73185` | 3 passed, 1 skipped |
| pre-commit wrapper | pre-rebase head `4bca23810` | passed for touched Python files |
| TPU canary | `25218486389`, prior equivalent patch head | passed |
| GPU canary | `25218710264`, prior equivalent patch head | original Pallas `AttributeError` gone; later `ncclAlltoAll` failure remains |
| H100x8 NCCL probe | `/romain/codex-nccl-a2a-probe-20260501-1514` | simple `pmap(lax.all_to_all)` passed |
| JAX before/after perf | `/romain/codex-ragged-dot-jax-compare-20260501-1557` | no Triton steady-state regression vs JAX 0.8.0 baseline |

## GPU Perf

H100x8, bf16, 3 warmups, 10 measured iterations.

| Shape | JAX 0.8.0 old API Triton | JAX 0.9.2 patched Triton | Current vs old | Diff vs XLA |
| --- | ---: | ---: | ---: | ---: |
| `M=32768 K=1024 N=1024 E=64` | `0.000262s` | `0.000260s` | `1.007x` | max/mean `0.0/0.0` |
| `M=32768 K=512 N=1024 E=64` | `0.000214s` | `0.000212s` | `1.011x` | max/mean `0.0/0.0` |

Current patched Triton vs current XLA, from `/romain/codex-ragged-dot-perf-20260501-1537`:

| Shape | XLA steady | Triton steady | Speedup |
| --- | ---: | ---: | ---: |
| `M=32768 K=1024 N=1024 E=64` | `0.006267s` | `0.000258s` | `24.31x` |
| `M=32768 K=512 N=1024 E=64` | `0.003188s` | `0.000231s` | `13.83x` |

## Note

This PR fixes the JAX 0.9.2 Pallas API regression and keeps the Triton path as the GPU default fast path. The remaining full GPU canary failure is a later `ncclAlltoAll(...): unhandled system error`, tracked separately from this ragged-dot API fix.