### PR TITLE
[iris] Fix endpoint proxy redirects behind IAP / load balancer

### DIFF
--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -1352,6 +1352,14 @@ class Controller:
         # timeout_keep_alive: uvicorn defaults to 5s, which races with client polling
         # intervals of the same length, causing TCP resets on idle connections. Use 120s
         # to safely cover long polling gaps during job waits.
+        # proxy_headers / forwarded_allow_ips: production traffic arrives via
+        # GCP IAP + an HTTPS load balancer. Without trusting their forwarded
+        # headers, ``scope["server"]`` is the controller's bind address, so
+        # any absolute URL built by Starlette (notably the trailing-slash
+        # redirect on routes like ``/proxy/<name>``) leaks the internal IP
+        # back to the browser as ``http://10.x.x.x:10000/...`` — unreachable
+        # outside the VPC. Trusting all upstream IPs is safe because the
+        # controller's only ingress is the LB.
         server_config = uvicorn.Config(
             self._dashboard.app,
             host=self._config.host,
@@ -1359,6 +1367,8 @@ class Controller:
             log_level="warning",
             log_config=None,
             timeout_keep_alive=120,
+            proxy_headers=True,
+            forwarded_allow_ips="*",
         )
         self._server = uvicorn.Server(server_config)
         self._threads.spawn_server(self._server, name="controller-server")

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -213,6 +213,100 @@ class _DashboardAuthInterceptor:
             _verified_identity.reset(reset_token)
 
 
+# DNS marker label that flags a Host as a per-endpoint subdomain. A request
+# whose Host contains a ``proxy`` label routes the labels left of it to the
+# endpoint proxy: ``<encoded_name>.proxy.<base>`` -> endpoint ``<encoded_name>``
+# (with ``.`` -> ``/`` decoding, mirroring the path-style ``/proxy/<name>``
+# route). Base-domain-agnostic: works for ``iris-dev.oa.dev``,
+# ``iris.oa.dev``, or any other public host.
+PROXY_HOST_LABEL = "proxy"
+
+
+def _extract_proxy_subdomain(host: str) -> str | None:
+    """Return the encoded endpoint name from a Host header, or None.
+
+    Splits on ``.`` and looks for ``proxy`` as a label. Everything to the
+    left of that label (rejoined with ``.``) is the encoded name.
+    """
+    if not host:
+        return None
+    bare = host.split(",", 1)[0].split(":", 1)[0].strip().lower()
+    labels = bare.split(".")
+    try:
+        idx = labels.index(PROXY_HOST_LABEL)
+    except ValueError:
+        return None
+    if idx == 0:
+        return None
+    return ".".join(labels[:idx])
+
+
+class _SubdomainProxyMiddleware:
+    """Dispatch ``<encoded_name>.proxy.<base>`` requests to the endpoint proxy.
+
+    Subdomain requests don't match any Starlette route on the inner app,
+    so :class:`_RouteAuthMiddleware`'s default-allow-on-no-route would
+    leave them unauthenticated. This middleware therefore enforces auth
+    itself — running ``resolve_auth(token, verifier, optional)`` with the
+    same policy as the route-level ``@requires_auth`` annotations before
+    dispatching to the proxy.
+
+    Hosts without a ``proxy`` label pass through to the wrapped app
+    unchanged.
+
+    The encoded name (everything left of the ``proxy`` label) is decoded
+    by the proxy using the same ``.`` -> ``/`` rule as the path-style
+    route, so ``user.jobX.dash.proxy.iris-dev.oa.dev`` resolves to
+    ``/user/jobX/dash``.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        endpoint_proxy: EndpointProxy,
+        auth_verifier: TokenVerifier | None = None,
+        auth_optional: bool = False,
+    ):
+        self._app = app
+        self._endpoint_proxy = endpoint_proxy
+        self._auth_verifier = auth_verifier
+        self._auth_optional = auth_optional
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            return await self._app(scope, receive, send)
+
+        encoded_name = _extract_proxy_subdomain(self._extract_host(scope))
+        if encoded_name is None:
+            return await self._app(scope, receive, send)
+
+        if self._auth_verifier is not None:
+            token = _extract_token_from_scope(scope)
+            try:
+                identity = resolve_auth(token, self._auth_verifier, self._auth_optional)
+            except ValueError:
+                response = JSONResponse({"error": "authentication required"}, status_code=401)
+                return await response(scope, receive, send)
+            if identity is not None:
+                scope["auth_identity"] = identity
+
+        request = Request(scope, receive=receive)
+        response = await self._endpoint_proxy.handle_subdomain(request, encoded_name)
+        await response(scope, receive, send)
+
+    @staticmethod
+    def _extract_host(scope: Scope) -> str:
+        """Return the raw public-facing host header value.
+
+        Trusts ``X-Forwarded-Host`` since uvicorn is configured with
+        ``forwarded_allow_ips="*"``; the controller's only ingress is the
+        IAP proxy.
+        """
+        headers = {k.decode().lower(): v.decode() for k, v in scope.get("headers", [])}
+        return headers.get("x-forwarded-host") or headers.get("host", "")
+
+
 class ControllerDashboard:
     """HTTP dashboard with Connect RPC and web UI.
 
@@ -336,6 +430,19 @@ class ControllerDashboard:
         async def _proxy_endpoint(request: Request) -> Response:
             return await self._endpoint_proxy.handle(request)
 
+        @requires_auth
+        async def _proxy_endpoint_redirect(request: Request) -> Response:
+            # ``/proxy/<name>`` (no trailing slash, no sub_path) needs a
+            # redirect to ``/proxy/<name>/`` so upstream apps resolve their
+            # relative assets correctly. We can't use Starlette's built-in
+            # redirect_slashes=True: that builds an *absolute* Location from
+            # scope["server"] / the Host header, which behind IAP is the
+            # internal bind IP. A path-only Location resolves against the
+            # browser's current origin, so no internal address leaks.
+            name = request.path_params["endpoint_name"]
+            query = f"?{request.url.query}" if request.url.query else ""
+            return RedirectResponse(f"/proxy/{name}/{query}", status_code=307)
+
         routes = [
             Route("/", self._dashboard),
             favicon_route(),
@@ -349,6 +456,11 @@ class ControllerDashboard:
             Route("/blobs/{blob_id:str}", self._blob_download),
             Route("/health", self._health),
             Route(PROXY_ROUTE, _proxy_actor_rpc, methods=["POST"]),
+            Route(
+                "/proxy/{endpoint_name:str}",
+                _proxy_endpoint_redirect,
+                methods=list(endpoint_proxy.ALLOWED_METHODS),
+            ),
             Route(
                 endpoint_proxy.PROXY_ROUTE,
                 _proxy_endpoint,
@@ -375,9 +487,19 @@ class ControllerDashboard:
         # ``redirect_slashes`` is a Router attribute, not a Starlette ctor
         # kwarg, so we flip it after construction.
         app.router.redirect_slashes = False
+        wrapped: ASGIApp = app
         if self._auth_verifier is not None and self._auth_provider is not None:
-            app = _RouteAuthMiddleware(app, self._auth_verifier, optional=self._auth_optional)
-        return app
+            wrapped = _RouteAuthMiddleware(app, self._auth_verifier, optional=self._auth_optional)
+        # Subdomain dispatch wraps everything: subdomain requests don't match
+        # any Starlette route, so _RouteAuthMiddleware would default-allow
+        # them. This middleware enforces auth itself before forwarding.
+        wrapped = _SubdomainProxyMiddleware(
+            wrapped,
+            endpoint_proxy=self._endpoint_proxy,
+            auth_verifier=self._auth_verifier,
+            auth_optional=self._auth_optional,
+        )
+        return wrapped
 
     @public
     def _dashboard(self, request: Request) -> Response:

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -316,10 +316,17 @@ class ControllerDashboard:
         rpc_app = WSGIMiddleware(rpc_wsgi_app)
 
         self._actor_proxy = ActorProxy(self._service._store)
-        self._endpoint_proxy = EndpointProxy(
-            self._service._store,
-            system_endpoints=self._service._system_endpoints,
-        )
+
+        def _resolve_endpoint(name: str) -> str | None:
+            # Task-registered endpoints live in the SQL store; system endpoints
+            # (``/system/...``) live in an in-memory dict on the service.
+            # Same fallback order as ListEndpoints' system-endpoint branch.
+            row = self._service._store.endpoints.resolve(name)
+            if row is not None:
+                return row.address
+            return self._service._system_endpoints.get(name)
+
+        self._endpoint_proxy = EndpointProxy(_resolve_endpoint)
 
         @requires_auth
         async def _proxy_actor_rpc(request: Request) -> Response:

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -316,7 +316,10 @@ class ControllerDashboard:
         rpc_app = WSGIMiddleware(rpc_wsgi_app)
 
         self._actor_proxy = ActorProxy(self._service._store)
-        self._endpoint_proxy = EndpointProxy(self._service._store)
+        self._endpoint_proxy = EndpointProxy(
+            self._service._store,
+            system_endpoints=self._service._system_endpoints,
+        )
 
         @requires_auth
         async def _proxy_actor_rpc(request: Request) -> Response:
@@ -355,6 +358,16 @@ class ControllerDashboard:
             routes=routes,
             lifespan=on_shutdown(self._actor_proxy.close, self._endpoint_proxy.close),
         )
+        # Starlette's default trailing-slash redirect builds an absolute
+        # Location from ``scope["server"]`` (or the request's Host header).
+        # Behind GCP IAP / a load balancer whose backend Host is the internal
+        # bind IP, that absolute URL leaks ``http://10.x.x.x:10000/...`` back
+        # to the browser — unreachable outside the VPC. Strict routing is
+        # fine here: the SPA handles its own paths client-side and the API
+        # surface is small enough that canonical URLs are easy to publish.
+        # ``redirect_slashes`` is a Router attribute, not a Starlette ctor
+        # kwarg, so we flip it after construction.
+        app.router.redirect_slashes = False
         if self._auth_verifier is not None and self._auth_provider is not None:
             app = _RouteAuthMiddleware(app, self._auth_verifier, optional=self._auth_optional)
         return app

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -77,6 +77,32 @@ def _extract_token_from_scope(scope: Scope) -> str | None:
     return None
 
 
+async def _enforce_http_auth(
+    scope: Scope,
+    receive: Receive,
+    send: Send,
+    verifier: TokenVerifier,
+    optional: bool,
+) -> bool:
+    """Resolve auth for an ASGI scope; on failure send a 401 and return False.
+
+    On success, sets ``scope["auth_identity"]`` if a verified identity is
+    present and returns True. Shared by ``_RouteAuthMiddleware`` (which
+    runs against route-annotated requests) and ``_SubdomainProxyMiddleware``
+    (which intercepts before any route can match).
+    """
+    token = _extract_token_from_scope(scope)
+    try:
+        identity = resolve_auth(token, verifier, optional)
+    except ValueError:
+        response = JSONResponse({"error": "authentication required"}, status_code=401)
+        await response(scope, receive, send)
+        return False
+    if identity is not None:
+        scope["auth_identity"] = identity
+    return True
+
+
 class _RouteAuthMiddleware:
     """ASGI middleware that enforces per-route auth policy annotations.
 
@@ -135,15 +161,9 @@ class _RouteAuthMiddleware:
         return "skip"
 
     async def _check_auth(self, scope: Scope, receive: Receive, send: Send) -> None:
-        token = _extract_token_from_scope(scope)
-        try:
-            identity = resolve_auth(token, self._verifier, self._optional)
-        except ValueError:
-            response = JSONResponse({"error": "authentication required"}, status_code=401)
-            return await response(scope, receive, send)
-        if identity is not None:
-            scope["auth_identity"] = identity
-        return await self._app(scope, receive, send)
+        if not await _enforce_http_auth(scope, receive, send, self._verifier, self._optional):
+            return
+        await self._app(scope, receive, send)
 
 
 _UNAUTHENTICATED_RPCS = {"Login", "GetAuthInfo"}
@@ -282,17 +302,16 @@ class _SubdomainProxyMiddleware:
             return await self._app(scope, receive, send)
 
         if self._auth_verifier is not None:
-            token = _extract_token_from_scope(scope)
-            try:
-                identity = resolve_auth(token, self._auth_verifier, self._auth_optional)
-            except ValueError:
-                response = JSONResponse({"error": "authentication required"}, status_code=401)
-                return await response(scope, receive, send)
-            if identity is not None:
-                scope["auth_identity"] = identity
+            if not await _enforce_http_auth(scope, receive, send, self._auth_verifier, self._auth_optional):
+                return
 
         request = Request(scope, receive=receive)
-        response = await self._endpoint_proxy.handle_subdomain(request, encoded_name)
+        response = await self._endpoint_proxy.dispatch(
+            request,
+            encoded_name=encoded_name,
+            sub_path=request.url.path.lstrip("/"),
+            proxy_prefix="",
+        )
         await response(scope, receive, send)
 
     @staticmethod
@@ -428,7 +447,13 @@ class ControllerDashboard:
 
         @requires_auth
         async def _proxy_endpoint(request: Request) -> Response:
-            return await self._endpoint_proxy.handle(request)
+            name = request.path_params["endpoint_name"]
+            return await self._endpoint_proxy.dispatch(
+                request,
+                encoded_name=name,
+                sub_path=request.path_params["sub_path"],
+                proxy_prefix=f"/proxy/{name}",
+            )
 
         @requires_auth
         async def _proxy_endpoint_redirect(request: Request) -> Response:

--- a/lib/iris/src/iris/cluster/controller/endpoint_proxy.py
+++ b/lib/iris/src/iris/cluster/controller/endpoint_proxy.py
@@ -3,12 +3,21 @@
 
 """Generic HTTP reverse proxy for registered task endpoints.
 
-External clients hit ``/proxy/<endpoint_name>/<sub_path>`` on the controller
-dashboard; the proxy resolves the endpoint name via a caller-supplied
-``resolve: (name) -> address | None`` callable (with ``.`` -> ``/``
-substitution on the URL-encoded name) and forwards method, path, query
-string, and filtered headers to the upstream's ``address``. Bodies are
-streamed in both directions with no size cap; the only backstop is
+Two equivalent dispatch styles share one forwarding pipeline:
+
+- Path-style: ``/proxy/<encoded_name>/<sub_path>`` on the controller's
+  base host. Handled by :meth:`EndpointProxy.handle`.
+- Subdomain-style: ``<encoded_name>.<base_host>/<sub_path>``. Handled by
+  :meth:`EndpointProxy.handle_subdomain`. The dashboard's
+  ``_SubdomainProxyMiddleware`` extracts ``encoded_name`` from the Host
+  header before invoking it.
+
+In both cases the encoded name maps to an Iris endpoint name with ``.``
+-> ``/`` substitution (so ``user.jobX.dash`` -> ``/user/jobX/dash``). The
+proxy resolves the name via a caller-supplied ``resolve: (name) ->
+address | None`` callable, then forwards method, path, query string, and
+filtered headers to the upstream's ``address``. Bodies are streamed in
+both directions with no size cap; the only backstop is
 :data:`PROXY_TIMEOUT_SECONDS`.
 
 Hop-by-hop headers, ``Cookie`` / ``Set-Cookie``, and ``Authorization`` are
@@ -18,16 +27,20 @@ upstream would be a credential leak, and dashboards that maintain their own
 cookie state would shadow the controller session — both are intentionally
 prevented here.
 
+``X-Forwarded-Host`` / ``X-Forwarded-Proto`` are set so upstreams that build
+self-URLs (e.g. Starlette ``url_for``, FastAPI ``request.url_for``) emit
+public-facing URLs. ``X-Forwarded-Prefix`` is set in path-style mode only,
+which Starlette/FastAPI (`root_path`), Werkzeug (`ProxyFix`), and most
+modern Python frameworks honor to mount themselves under the ``/proxy/<name>``
+prefix. Subdomain-style mode does not set ``X-Forwarded-Prefix``: the
+upstream effectively owns the whole origin.
+
 ``Location`` and ``Content-Location`` response headers are rewritten so 3xx
 redirects (and any other absolute-URL hints) keep the browser inside the
 proxy instead of escaping to the upstream's bind address. Without this,
 upstreams that emit absolute self-URLs (Starlette canonical-slash redirects,
 ``/`` -> ``/login`` flows, ...) would navigate the user out of
 ``iris-dev.oa.dev/proxy/<name>/`` straight to the upstream IP.
-
-Route pattern::
-
-    <ANY-METHOD> /proxy/{endpoint_name:str}/{sub_path:path}
 """
 
 import logging
@@ -86,6 +99,29 @@ _LOCATION_HEADERS: tuple[str, ...] = ("location", "content-location")
 # Bound the connection pool explicitly so httpx default drift cannot silently
 # change resource usage on the controller.
 _HTTPX_LIMITS = httpx.Limits(max_connections=100, max_keepalive_connections=20)
+
+
+def _build_forwarded_headers(request: Request, *, proxy_prefix: str) -> dict[str, str]:
+    """Compute X-Forwarded-* headers to send upstream.
+
+    Existing X-Forwarded-Host / X-Forwarded-Proto from the inbound chain
+    are preserved (so a multi-hop chain — IAP -> controller -> upstream —
+    keeps the originating values). X-Forwarded-Prefix is always set to
+    *this* hop's prefix (or omitted in subdomain mode where the upstream
+    owns the whole origin).
+
+    These headers let frameworks like Starlette/FastAPI (`root_path`),
+    Werkzeug (`ProxyFix`), and others mount themselves under the proxy
+    prefix and emit public-facing self-URLs.
+    """
+    fh: dict[str, str] = {}
+    inbound_host = request.headers.get("x-forwarded-host") or request.headers.get("host")
+    if inbound_host:
+        fh["x-forwarded-host"] = inbound_host
+    fh["x-forwarded-proto"] = request.headers.get("x-forwarded-proto") or request.url.scheme
+    if proxy_prefix:
+        fh["x-forwarded-prefix"] = proxy_prefix
+    return fh
 
 
 def _rewrite_location(loc: str, *, upstream_base: str, proxy_prefix: str) -> str:
@@ -170,24 +206,40 @@ class EndpointProxy:
         await self._client.aclose()
 
     async def handle(self, request: Request) -> Response:
-        """Handle one proxied request.
-
-        On success returns a :class:`StreamingResponse` whose body is the
-        upstream's body streamed chunk-by-chunk. On failure returns a
-        :class:`JSONResponse` with the error contract documented in the
-        spec. Never raises.
-        """
-        url_name = request.path_params["endpoint_name"]
+        """Handle a path-style ``/proxy/<encoded_name>/<sub_path>`` request."""
+        encoded_name = request.path_params["endpoint_name"]
         sub_path = request.path_params["sub_path"]
+        proxy_prefix = f"/proxy/{encoded_name}"
+        return await self._dispatch(request, encoded_name, sub_path, proxy_prefix=proxy_prefix)
+
+    async def handle_subdomain(self, request: Request, encoded_name: str) -> Response:
+        """Handle a subdomain-style ``<encoded_name>.<base_host>/<path>`` request.
+
+        ``encoded_name`` is the part of the Host header to the left of the
+        configured base host (already lowercased), e.g. ``user.jobX.dash``
+        for ``user.jobX.dash.iris-dev.oa.dev``. The full request path
+        (minus the leading ``/``) is forwarded verbatim to the upstream.
+        """
+        sub_path = request.url.path.lstrip("/")
+        return await self._dispatch(request, encoded_name, sub_path, proxy_prefix="")
+
+    async def _dispatch(
+        self,
+        request: Request,
+        encoded_name: str,
+        sub_path: str,
+        *,
+        proxy_prefix: str,
+    ) -> Response:
         # Iris wire-format names start with '/'. Try the slash-prefixed form
         # first (the common case for task-registered endpoints), then the bare
         # form for endpoints registered without a leading slash.
-        slashed = url_name.replace(".", "/")
+        slashed = encoded_name.replace(".", "/")
         address = self._resolve(f"/{slashed}") or self._resolve(slashed)
         if address is None:
-            logger.warning("Proxy %s %s -> no endpoint %r", request.method, request.url.path, url_name)
+            logger.warning("Proxy %s %s -> no endpoint %r", request.method, request.url.path, encoded_name)
             return JSONResponse(
-                {"error": f"No endpoint '{url_name}'"},
+                {"error": f"No endpoint '{encoded_name}'"},
                 status_code=404,
             )
 
@@ -199,6 +251,7 @@ class EndpointProxy:
         logger.info("Proxy %s %s -> %s", request.method, request.url.path, upstream_url)
 
         forward_headers = {k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP}
+        forward_headers.update(_build_forwarded_headers(request, proxy_prefix=proxy_prefix))
 
         upstream_req = self._client.build_request(
             request.method,
@@ -209,19 +262,18 @@ class EndpointProxy:
         try:
             upstream_resp = await self._client.send(upstream_req, stream=True)
         except (httpx.ConnectTimeout, httpx.ReadTimeout) as exc:
-            logger.warning("Proxy timeout for %s: %s", url_name, exc)
+            logger.warning("Proxy timeout for %s: %s", encoded_name, exc)
             return JSONResponse(
                 {"error": f"Upstream timeout after {self._timeout_seconds:g}s"},
                 status_code=504,
             )
         except httpx.HTTPError as exc:
-            logger.warning("Proxy upstream error for %s: %s", url_name, exc)
+            logger.warning("Proxy upstream error for %s: %s", encoded_name, exc)
             return JSONResponse(
                 {"error": f"Upstream error: {exc!r}"},
                 status_code=502,
             )
 
-        proxy_prefix = f"/proxy/{url_name}"
         response_headers: dict[str, str] = {}
         for k, v in upstream_resp.headers.items():
             lk = k.lower()

--- a/lib/iris/src/iris/cluster/controller/endpoint_proxy.py
+++ b/lib/iris/src/iris/cluster/controller/endpoint_proxy.py
@@ -3,14 +3,20 @@
 
 """Generic HTTP reverse proxy for registered task endpoints.
 
-Two equivalent dispatch styles share one forwarding pipeline:
+Two equivalent dispatch styles share one forwarding pipeline. Both call
+:meth:`EndpointProxy.dispatch`; the caller is responsible for computing
+``encoded_name`` / ``sub_path`` / ``proxy_prefix`` from whichever source
+identifies the request:
 
 - Path-style: ``/proxy/<encoded_name>/<sub_path>`` on the controller's
-  base host. Handled by :meth:`EndpointProxy.handle`.
-- Subdomain-style: ``<encoded_name>.<base_host>/<sub_path>``. Handled by
-  :meth:`EndpointProxy.handle_subdomain`. The dashboard's
-  ``_SubdomainProxyMiddleware`` extracts ``encoded_name`` from the Host
-  header before invoking it.
+  base host. The Starlette route handler reads ``encoded_name`` /
+  ``sub_path`` from path params and passes ``proxy_prefix=/proxy/<name>``
+  so upstream-emitted absolute URLs get re-prefixed back into the proxy.
+- Subdomain-style: ``<encoded_name>.<base_host>/<sub_path>``. The
+  dashboard's ``_SubdomainProxyMiddleware`` extracts ``encoded_name``
+  from the Host header, takes ``sub_path`` from ``request.url.path``,
+  and passes ``proxy_prefix=""`` because the browser already sees the
+  upstream as the entire origin.
 
 In both cases the encoded name maps to an Iris endpoint name with ``.``
 -> ``/`` substitution (so ``user.jobX.dash`` -> ``/user/jobX/dash``). The
@@ -205,32 +211,23 @@ class EndpointProxy:
         """Close the underlying httpx.AsyncClient. Idempotent."""
         await self._client.aclose()
 
-    async def handle(self, request: Request) -> Response:
-        """Handle a path-style ``/proxy/<encoded_name>/<sub_path>`` request."""
-        encoded_name = request.path_params["endpoint_name"]
-        sub_path = request.path_params["sub_path"]
-        proxy_prefix = f"/proxy/{encoded_name}"
-        return await self._dispatch(request, encoded_name, sub_path, proxy_prefix=proxy_prefix)
-
-    async def handle_subdomain(self, request: Request, encoded_name: str) -> Response:
-        """Handle a subdomain-style ``<encoded_name>.<base_host>/<path>`` request.
-
-        ``encoded_name`` is the part of the Host header to the left of the
-        configured base host (already lowercased), e.g. ``user.jobX.dash``
-        for ``user.jobX.dash.iris-dev.oa.dev``. The full request path
-        (minus the leading ``/``) is forwarded verbatim to the upstream.
-        """
-        sub_path = request.url.path.lstrip("/")
-        return await self._dispatch(request, encoded_name, sub_path, proxy_prefix="")
-
-    async def _dispatch(
+    async def dispatch(
         self,
         request: Request,
+        *,
         encoded_name: str,
         sub_path: str,
-        *,
         proxy_prefix: str,
     ) -> Response:
+        """Forward ``request`` to ``encoded_name`` and stream the response back.
+
+        ``encoded_name`` uses ``.`` for path separators (resolved with both
+        slash-prefixed and bare forms). ``sub_path`` is the upstream path
+        with no leading slash. ``proxy_prefix`` is prepended to rewritten
+        ``Location`` / ``Content-Location`` values and forwarded as
+        ``X-Forwarded-Prefix``; pass ``""`` when the public URL already
+        roots the upstream (subdomain style).
+        """
         # Iris wire-format names start with '/'. Try the slash-prefixed form
         # first (the common case for task-registered endpoints), then the bare
         # form for endpoints registered without a leading slash.

--- a/lib/iris/src/iris/cluster/controller/endpoint_proxy.py
+++ b/lib/iris/src/iris/cluster/controller/endpoint_proxy.py
@@ -185,6 +185,7 @@ class EndpointProxy:
         slashed = url_name.replace(".", "/")
         address = self._resolve(f"/{slashed}") or self._resolve(slashed)
         if address is None:
+            logger.warning("Proxy %s %s -> no endpoint %r", request.method, request.url.path, url_name)
             return JSONResponse(
                 {"error": f"No endpoint '{url_name}'"},
                 status_code=404,
@@ -194,6 +195,8 @@ class EndpointProxy:
         upstream_url = f"{base}/{sub_path}"
         if request.url.query:
             upstream_url = f"{upstream_url}?{request.url.query}"
+
+        logger.info("Proxy %s %s -> %s", request.method, request.url.path, upstream_url)
 
         forward_headers = {k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP}
 

--- a/lib/iris/src/iris/cluster/controller/endpoint_proxy.py
+++ b/lib/iris/src/iris/cluster/controller/endpoint_proxy.py
@@ -17,12 +17,20 @@ upstream would be a credential leak, and dashboards that maintain their own
 cookie state would shadow the controller session — both are intentionally
 prevented here.
 
+``Location`` and ``Content-Location`` response headers are rewritten so 3xx
+redirects (and any other absolute-URL hints) keep the browser inside the
+proxy instead of escaping to the upstream's bind address. Without this,
+upstreams that emit absolute self-URLs (Starlette canonical-slash redirects,
+``/`` -> ``/login`` flows, ...) would navigate the user out of
+``iris-dev.oa.dev/proxy/<name>/`` straight to the upstream IP.
+
 Route pattern::
 
     <ANY-METHOD> /proxy/{endpoint_name:str}/{sub_path:path}
 """
 
 import logging
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 from starlette.background import BackgroundTask
@@ -62,16 +70,67 @@ _HOP_BY_HOP: frozenset[str] = frozenset(
     }
 )
 
+# Response headers carrying URLs that point at the upstream. Rewritten so a
+# redirect (or content-negotiation hint) does not navigate the browser out of
+# the proxy. Other URL-bearing headers (Refresh, Link, ...) are uncommon for
+# the dashboards we proxy and are left alone for now.
+_LOCATION_HEADERS: tuple[str, ...] = ("location", "content-location")
+
 # Bound the connection pool explicitly so httpx default drift cannot silently
 # change resource usage on the controller.
 _HTTPX_LIMITS = httpx.Limits(max_connections=100, max_keepalive_connections=20)
+
+
+def _rewrite_location(loc: str, *, upstream_base: str, proxy_prefix: str) -> str:
+    """Rewrite a Location-style URL so it stays inside the proxy.
+
+    ``proxy_prefix`` is the request path prefix used by the dashboard,
+    e.g. ``/proxy/system.log-server`` (no trailing slash). ``upstream_base``
+    is the upstream origin the proxy forwards to, e.g.
+    ``http://10.128.0.31:10001``.
+
+    Cases:
+
+    - Absolute URL whose origin matches ``upstream_base`` -> path on the
+      dashboard origin, with ``proxy_prefix`` prepended.
+    - Protocol-relative URL (``//host/...``) on the same netloc -> same
+      treatment.
+    - Absolute path (``/foo``) -> ``proxy_prefix`` prepended.
+    - Anything else (cross-origin URL, relative path, fragment-only,
+      empty) -> passed through unchanged. Relative paths resolve against
+      the browser's current URL, which is already inside the proxy.
+
+    Upstream addresses with a non-empty path component (rare in this
+    codebase — endpoints register ``host:port`` only) are not stripped:
+    callers should register origin-only addresses.
+    """
+    if not loc:
+        return loc
+
+    parsed = urlsplit(loc)
+    base = urlsplit(upstream_base)
+
+    if parsed.netloc:
+        scheme_matches = not parsed.scheme or parsed.scheme == base.scheme
+        if scheme_matches and parsed.netloc == base.netloc:
+            new_path = f"{proxy_prefix}{parsed.path or '/'}"
+            return urlunsplit(("", "", new_path, parsed.query, parsed.fragment))
+        return loc
+
+    if parsed.path.startswith("/"):
+        new_path = f"{proxy_prefix}{parsed.path}"
+        return urlunsplit(("", "", new_path, parsed.query, parsed.fragment))
+
+    return loc
 
 
 class EndpointProxy:
     """Forwards arbitrary HTTP requests to a registered endpoint.
 
     The proxy resolves the endpoint name (with ``.`` -> ``/`` substitution)
-    against ``ControllerStore.endpoints``, then forwards request method,
+    against ``ControllerStore.endpoints`` and the service's in-memory
+    ``system_endpoints`` map (the latter is where ``/system/...`` entries
+    such as ``/system/log-server`` live), then forwards request method,
     path suffix, query string, and filtered headers to the upstream's
     ``address``. Bodies are streamed in both directions with no size cap.
     Hop-by-hop headers, ``Cookie`` / ``Set-Cookie``, and ``Authorization``
@@ -82,8 +141,20 @@ class EndpointProxy:
     safe for concurrent use across requests.
     """
 
-    def __init__(self, store: ControllerStore, *, timeout_seconds: float = PROXY_TIMEOUT_SECONDS) -> None:
+    def __init__(
+        self,
+        store: ControllerStore,
+        *,
+        system_endpoints: dict[str, str] | None = None,
+        timeout_seconds: float = PROXY_TIMEOUT_SECONDS,
+    ) -> None:
+        # System endpoints (``/system/...``) are held in an in-memory dict on
+        # ControllerServiceImpl rather than the SQLite-backed EndpointStore.
+        # The same dict object is shared by reference so updates by the
+        # controller (e.g. log-server registration during start()) are
+        # visible here without re-plumbing.
         self._store = store
+        self._system_endpoints = system_endpoints if system_endpoints is not None else {}
         self._timeout_seconds = timeout_seconds
         self._client = httpx.AsyncClient(
             timeout=timeout_seconds,
@@ -94,6 +165,19 @@ class EndpointProxy:
     async def close(self) -> None:
         """Close the underlying httpx.AsyncClient. Idempotent."""
         await self._client.aclose()
+
+    def _resolve(self, name: str) -> str | None:
+        """Resolve ``name`` to an upstream address.
+
+        Task-registered endpoints live in the SQLite-backed EndpointStore;
+        ``/system/...`` endpoints (e.g. ``/system/log-server``) live in the
+        controller service's in-memory ``system_endpoints`` map. Both are
+        consulted so the proxy mirrors what ``ListEndpoints`` exposes.
+        """
+        row = self._store.endpoints.resolve(name)
+        if row is not None:
+            return row.address
+        return self._system_endpoints.get(name)
 
     async def handle(self, request: Request) -> Response:
         """Handle one proxied request.
@@ -109,14 +193,15 @@ class EndpointProxy:
         # first (the common case for task-registered endpoints), then the bare
         # form for endpoints registered without a leading slash.
         slashed = url_name.replace(".", "/")
-        row = self._store.endpoints.resolve(f"/{slashed}") or self._store.endpoints.resolve(slashed)
-        if row is None:
+        canonical = f"/{slashed}"
+        address = self._resolve(canonical) or self._resolve(slashed)
+        if address is None:
             return JSONResponse(
                 {"error": f"No endpoint '{url_name}'"},
                 status_code=404,
             )
 
-        base = row.address if "://" in row.address else f"http://{row.address}"
+        base = address if "://" in address else f"http://{address}"
         upstream_url = f"{base}/{sub_path}"
         if request.url.query:
             upstream_url = f"{upstream_url}?{request.url.query}"
@@ -144,7 +229,16 @@ class EndpointProxy:
                 status_code=502,
             )
 
-        response_headers = {k: v for k, v in upstream_resp.headers.items() if k.lower() not in _HOP_BY_HOP}
+        proxy_prefix = f"/proxy/{url_name}"
+        response_headers: dict[str, str] = {}
+        for k, v in upstream_resp.headers.items():
+            lk = k.lower()
+            if lk in _HOP_BY_HOP:
+                continue
+            if lk in _LOCATION_HEADERS:
+                v = _rewrite_location(v, upstream_base=base, proxy_prefix=proxy_prefix)
+            response_headers[k] = v
+
         return StreamingResponse(
             upstream_resp.aiter_raw(),
             status_code=upstream_resp.status_code,

--- a/lib/iris/src/iris/cluster/controller/endpoint_proxy.py
+++ b/lib/iris/src/iris/cluster/controller/endpoint_proxy.py
@@ -4,11 +4,12 @@
 """Generic HTTP reverse proxy for registered task endpoints.
 
 External clients hit ``/proxy/<endpoint_name>/<sub_path>`` on the controller
-dashboard; the proxy resolves the endpoint via :class:`EndpointStore` (with
-``.`` -> ``/`` substitution on the URL-encoded name) and forwards method,
-path, query string, and filtered headers to the upstream's ``address``.
-Bodies are streamed in both directions with no size cap; the only backstop
-is :data:`PROXY_TIMEOUT_SECONDS`.
+dashboard; the proxy resolves the endpoint name via a caller-supplied
+``resolve: (name) -> address | None`` callable (with ``.`` -> ``/``
+substitution on the URL-encoded name) and forwards method, path, query
+string, and filtered headers to the upstream's ``address``. Bodies are
+streamed in both directions with no size cap; the only backstop is
+:data:`PROXY_TIMEOUT_SECONDS`.
 
 Hop-by-hop headers, ``Cookie`` / ``Set-Cookie``, and ``Authorization`` are
 stripped (in both directions for cookies; client -> upstream for
@@ -30,6 +31,7 @@ Route pattern::
 """
 
 import logging
+from collections.abc import Callable
 from urllib.parse import urlsplit, urlunsplit
 
 import httpx
@@ -37,9 +39,14 @@ from starlette.background import BackgroundTask
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response, StreamingResponse
 
-from iris.cluster.controller.stores import ControllerStore
-
 logger = logging.getLogger(__name__)
+
+# Resolves an endpoint wire name (e.g. ``/system/log-server``) to an
+# upstream address (``host:port`` or ``http(s)://host:port``), or None if
+# unknown. Decoupled from the storage layer so the proxy doesn't need to
+# know whether the address came from the SQL endpoint store, the
+# controller's in-memory ``system_endpoints`` map, or anywhere else.
+EndpointResolver = Callable[[str], str | None]
 
 PROXY_ROUTE = "/proxy/{endpoint_name:str}/{sub_path:path}"
 PROXY_TIMEOUT_SECONDS: float = 30.0
@@ -128,13 +135,16 @@ class EndpointProxy:
     """Forwards arbitrary HTTP requests to a registered endpoint.
 
     The proxy resolves the endpoint name (with ``.`` -> ``/`` substitution)
-    against ``ControllerStore.endpoints`` and the service's in-memory
-    ``system_endpoints`` map (the latter is where ``/system/...`` entries
-    such as ``/system/log-server`` live), then forwards request method,
-    path suffix, query string, and filtered headers to the upstream's
-    ``address``. Bodies are streamed in both directions with no size cap.
-    Hop-by-hop headers, ``Cookie`` / ``Set-Cookie``, and ``Authorization``
-    are stripped (see :data:`_HOP_BY_HOP`).
+    via the caller-supplied ``resolve`` callable, then forwards request
+    method, path suffix, query string, and filtered headers to the
+    upstream's ``address``. Bodies are streamed in both directions with no
+    size cap. Hop-by-hop headers, ``Cookie`` / ``Set-Cookie``, and
+    ``Authorization`` are stripped (see :data:`_HOP_BY_HOP`).
+
+    The dashboard wires ``resolve`` to consult both the SQL endpoint store
+    (task-registered endpoints) and the controller service's in-memory
+    ``system_endpoints`` map (``/system/...`` entries such as
+    ``/system/log-server``), mirroring ``ListEndpoints``.
 
     Lifecycle: construct once on dashboard startup; await :meth:`close` on
     shutdown to drain the underlying httpx connection pool. The proxy is
@@ -143,18 +153,11 @@ class EndpointProxy:
 
     def __init__(
         self,
-        store: ControllerStore,
+        resolve: EndpointResolver,
         *,
-        system_endpoints: dict[str, str] | None = None,
         timeout_seconds: float = PROXY_TIMEOUT_SECONDS,
     ) -> None:
-        # System endpoints (``/system/...``) are held in an in-memory dict on
-        # ControllerServiceImpl rather than the SQLite-backed EndpointStore.
-        # The same dict object is shared by reference so updates by the
-        # controller (e.g. log-server registration during start()) are
-        # visible here without re-plumbing.
-        self._store = store
-        self._system_endpoints = system_endpoints if system_endpoints is not None else {}
+        self._resolve = resolve
         self._timeout_seconds = timeout_seconds
         self._client = httpx.AsyncClient(
             timeout=timeout_seconds,
@@ -165,19 +168,6 @@ class EndpointProxy:
     async def close(self) -> None:
         """Close the underlying httpx.AsyncClient. Idempotent."""
         await self._client.aclose()
-
-    def _resolve(self, name: str) -> str | None:
-        """Resolve ``name`` to an upstream address.
-
-        Task-registered endpoints live in the SQLite-backed EndpointStore;
-        ``/system/...`` endpoints (e.g. ``/system/log-server``) live in the
-        controller service's in-memory ``system_endpoints`` map. Both are
-        consulted so the proxy mirrors what ``ListEndpoints`` exposes.
-        """
-        row = self._store.endpoints.resolve(name)
-        if row is not None:
-            return row.address
-        return self._system_endpoints.get(name)
 
     async def handle(self, request: Request) -> Response:
         """Handle one proxied request.
@@ -193,8 +183,7 @@ class EndpointProxy:
         # first (the common case for task-registered endpoints), then the bare
         # form for endpoints registered without a leading slash.
         slashed = url_name.replace(".", "/")
-        canonical = f"/{slashed}"
-        address = self._resolve(canonical) or self._resolve(slashed)
+        address = self._resolve(f"/{slashed}") or self._resolve(slashed)
         if address is None:
             return JSONResponse(
                 {"error": f"No endpoint '{url_name}'"},

--- a/lib/iris/tests/cluster/controller/test_auth.py
+++ b/lib/iris/tests/cluster/controller/test_auth.py
@@ -452,7 +452,12 @@ def test_route_auth_middleware_uses_resolve_auth(service, verifier, token, optio
     We build a dashboard with a @requires_auth route injected and verify it
     agrees with resolve_auth for every (token, optional) combination.
     """
-    from iris.cluster.controller.dashboard import ControllerDashboard, _RouteAuthMiddleware, requires_auth
+    from iris.cluster.controller.dashboard import (
+        ControllerDashboard,
+        _RouteAuthMiddleware,
+        _SubdomainProxyMiddleware,
+        requires_auth,
+    )
     from starlette.responses import JSONResponse as _J
     from starlette.routing import Route
 
@@ -467,13 +472,13 @@ def test_route_auth_middleware_uses_resolve_auth(service, verifier, token, optio
         auth_provider="static",
         auth_optional=optional,
     )
-    # Inject a @requires_auth route. The app may be wrapped in _RouteAuthMiddleware,
-    # so reach through to the inner Starlette app to add the route.
-    inner_app = dashboard.app
-    if isinstance(inner_app, _RouteAuthMiddleware):
-        inner_app._router.routes.insert(0, Route("/test-protected", _protected))
-    else:
-        inner_app.router.routes.insert(0, Route("/test-protected", _protected))
+    # Inject a @requires_auth route. The app is wrapped in
+    # _SubdomainProxyMiddleware → _RouteAuthMiddleware → Starlette; walk down
+    # to the Starlette router so the new route participates in route matching.
+    app = dashboard.app
+    while isinstance(app, _SubdomainProxyMiddleware | _RouteAuthMiddleware):
+        app = app._app
+    app.router.routes.insert(0, Route("/test-protected", _protected))
 
     client = TestClient(dashboard.app)
     headers = {}

--- a/lib/iris/tests/cluster/controller/test_endpoint_proxy.py
+++ b/lib/iris/tests/cluster/controller/test_endpoint_proxy.py
@@ -26,55 +26,17 @@ from iris.cluster.controller.endpoint_proxy import (
     EndpointProxy,
     _rewrite_location,
 )
-from iris.cluster.controller.schema import EndpointRow
 from iris.cluster.dashboard_common import on_shutdown
-from iris.cluster.types import JobName
 from iris.managed_thread import ThreadContainer
-from rigging.timing import Duration, ExponentialBackoff, Timestamp
+from rigging.timing import Duration, ExponentialBackoff
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse, PlainTextResponse, Response, StreamingResponse
 from starlette.routing import Route
 
-# Endpoint name registered in the fake store; reachable at /proxy/user.jobX.dash/...
+# Endpoint name registered with the proxy resolver; reachable at /proxy/user.jobX.dash/...
 ENDPOINT_NAME = "/user/jobX/dash"
 ENDPOINT_URL_NAME = "user.jobX.dash"
-
-
-class _FakeEndpointStore:
-    """In-memory stand-in for ``EndpointStore`` that exposes ``resolve``.
-
-    Only the methods used by ``EndpointProxy`` are implemented. This mirrors
-    the ``StandaloneActorProxy`` pattern in ``test_actor_proxy.py``: keep
-    the proxy under test real, swap out the persistent store.
-    """
-
-    def __init__(self) -> None:
-        self._rows: dict[str, EndpointRow] = {}
-
-    def register(self, name: str, address: str) -> None:
-        self._rows[name] = EndpointRow(
-            endpoint_id=f"e-{len(self._rows)}",
-            name=name,
-            address=address,
-            task_id=JobName.from_wire("/user/jobX/dash"),
-            metadata={},
-            registered_at=Timestamp.now(),
-        )
-
-    def resolve(self, name: str) -> EndpointRow | None:
-        return self._rows.get(name)
-
-
-class _FakeStore:
-    """Duck-typed stand-in for ``ControllerStore`` used by the proxy.
-
-    ``EndpointProxy`` only touches ``store.endpoints.resolve``; we ignore the
-    declared ``ControllerStore`` type at the construction sites.
-    """
-
-    def __init__(self) -> None:
-        self.endpoints = _FakeEndpointStore()
 
 
 @dataclass
@@ -220,7 +182,10 @@ def upstream(threads: ThreadContainer) -> UpstreamHandle:
 class ProxyHandle:
     base_url: str
     upstream: UpstreamHandle
-    store: _FakeStore
+    # Mutable name->address mapping that backs the proxy's resolver. Tests can
+    # add or remove entries at runtime to exercise the post-construction
+    # registration path used by the controller's system endpoints.
+    endpoints: dict[str, str]
 
 
 def _build_proxy_app(proxy: EndpointProxy) -> Starlette:
@@ -236,18 +201,35 @@ def _build_proxy_app(proxy: EndpointProxy) -> Starlette:
     return app
 
 
-@pytest.fixture
-def proxy(upstream: UpstreamHandle, threads: ThreadContainer) -> ProxyHandle:
-    store = _FakeStore()
-    store.endpoints.register(ENDPOINT_NAME, f"127.0.0.1:{upstream.port}")
-    ep_proxy = EndpointProxy(store)  # type: ignore[arg-type]
+def _start_proxy(
+    threads: ThreadContainer,
+    *,
+    endpoints: dict[str, str] | None = None,
+    timeout_seconds: float = 30.0,
+) -> tuple[str, dict[str, str], EndpointProxy]:
+    """Spin up an EndpointProxy + its hosting Starlette server.
+
+    Returns ``(base_url, endpoints, proxy)``. ``endpoints`` is the mutable
+    dict the proxy resolves against — callers can register or remove names
+    at runtime. The proxy uses ``endpoints.get`` directly as its resolver,
+    keeping the test wiring identical to production: a single ``name ->
+    address`` callable, no fakes for the persistent stores.
+    """
+    endpoints = endpoints if endpoints is not None else {}
+    ep_proxy = EndpointProxy(endpoints.get, timeout_seconds=timeout_seconds)
     app = _build_proxy_app(ep_proxy)
     port = _free_port()
     config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error", log_config=None)
     server = uvicorn.Server(config)
     threads.spawn_server(server, name=f"proxy-{port}")
     _wait_for_server(server)
-    return ProxyHandle(base_url=f"http://127.0.0.1:{port}", upstream=upstream, store=store)
+    return f"http://127.0.0.1:{port}", endpoints, ep_proxy
+
+
+@pytest.fixture
+def proxy(upstream: UpstreamHandle, threads: ThreadContainer) -> ProxyHandle:
+    base_url, endpoints, _ = _start_proxy(threads, endpoints={ENDPOINT_NAME: f"127.0.0.1:{upstream.port}"})
+    return ProxyHandle(base_url=base_url, upstream=upstream, endpoints=endpoints)
 
 
 # ---------------------------------------------------------------------------
@@ -325,21 +307,13 @@ def test_upstream_5xx_passes_through(proxy: ProxyHandle) -> None:
 
 
 def test_upstream_connection_refused_returns_502(threads: ThreadContainer) -> None:
-    store = _FakeStore()
     # Bind a port and immediately release it; the address is dead by the time
     # the proxy connects.
     dead_port = _free_port()
-    store.endpoints.register(ENDPOINT_NAME, f"127.0.0.1:{dead_port}")
-    ep_proxy = EndpointProxy(store)  # type: ignore[arg-type]
-    app = _build_proxy_app(ep_proxy)
-    port = _free_port()
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error", log_config=None)
-    server = uvicorn.Server(config)
-    threads.spawn_server(server, name=f"proxy-{port}")
-    _wait_for_server(server)
+    base_url, _, _ = _start_proxy(threads, endpoints={ENDPOINT_NAME: f"127.0.0.1:{dead_port}"})
 
     with httpx.Client() as client:
-        resp = client.get(f"http://127.0.0.1:{port}/proxy/{ENDPOINT_URL_NAME}/anything")
+        resp = client.get(f"{base_url}/proxy/{ENDPOINT_URL_NAME}/anything")
     assert resp.status_code == 502
     assert "Upstream error" in resp.json()["error"]
 
@@ -347,18 +321,14 @@ def test_upstream_connection_refused_returns_502(threads: ThreadContainer) -> No
 def test_upstream_timeout_returns_504(threads: ThreadContainer, upstream: UpstreamHandle) -> None:
     # Use a short proxy timeout so the test runs quickly. The /slow upstream
     # sleeps far longer than the proxy timeout, guaranteeing a ReadTimeout.
-    store = _FakeStore()
-    store.endpoints.register(ENDPOINT_NAME, f"127.0.0.1:{upstream.port}")
-    ep_proxy = EndpointProxy(store, timeout_seconds=0.5)  # type: ignore[arg-type]
-    app = _build_proxy_app(ep_proxy)
-    port = _free_port()
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error", log_config=None)
-    server = uvicorn.Server(config)
-    threads.spawn_server(server, name=f"proxy-{port}")
-    _wait_for_server(server)
+    base_url, _, _ = _start_proxy(
+        threads,
+        endpoints={ENDPOINT_NAME: f"127.0.0.1:{upstream.port}"},
+        timeout_seconds=0.5,
+    )
 
     with httpx.Client(timeout=10.0) as client:
-        resp = client.get(f"http://127.0.0.1:{port}/proxy/{ENDPOINT_URL_NAME}/slow")
+        resp = client.get(f"{base_url}/proxy/{ENDPOINT_URL_NAME}/slow")
     assert resp.status_code == 504
     assert "timeout" in resp.json()["error"].lower()
 
@@ -390,26 +360,23 @@ def test_authorization_stripped(proxy: ProxyHandle) -> None:
 
 def test_dot_to_slash_transform(threads: ThreadContainer, upstream: UpstreamHandle) -> None:
     """``.`` in the URL maps to ``/`` at lookup; literal-``.`` names are unreachable."""
-    store = _FakeStore()
-    store.endpoints.register("/user/jobX/dash", f"127.0.0.1:{upstream.port}")
     # A name with a literal '.' would only be reachable via /proxy/literal.dot/...,
     # but that URL transforms to 'literal/dot' on lookup and won't match.
-    store.endpoints.register("literal.dot", f"127.0.0.1:{upstream.port}")
-    ep_proxy = EndpointProxy(store)  # type: ignore[arg-type]
-    app = _build_proxy_app(ep_proxy)
-    port = _free_port()
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error", log_config=None)
-    server = uvicorn.Server(config)
-    threads.spawn_server(server, name=f"proxy-{port}")
-    _wait_for_server(server)
+    base_url, _, _ = _start_proxy(
+        threads,
+        endpoints={
+            "/user/jobX/dash": f"127.0.0.1:{upstream.port}",
+            "literal.dot": f"127.0.0.1:{upstream.port}",
+        },
+    )
 
     with httpx.Client() as client:
         # Slash-substituted name reaches the upstream.
-        ok = client.get(f"http://127.0.0.1:{port}/proxy/user.jobX.dash/echo")
+        ok = client.get(f"{base_url}/proxy/user.jobX.dash/echo")
         assert ok.status_code == 200
 
         # Literal-dot name is unreachable: 'literal.dot' -> 'literal/dot' on lookup.
-        miss = client.get(f"http://127.0.0.1:{port}/proxy/literal.dot/echo")
+        miss = client.get(f"{base_url}/proxy/literal.dot/echo")
         assert miss.status_code == 404
 
 
@@ -516,50 +483,22 @@ def test_external_redirect_passthrough(proxy: ProxyHandle) -> None:
     assert resp.headers["location"] == "https://other.example/landing"
 
 
-def test_system_endpoint_resolves_via_in_memory_map(threads: ThreadContainer, upstream: UpstreamHandle) -> None:
-    """``/system/...`` endpoints aren't in the SQL store; the proxy must consult
-    the service's in-memory ``system_endpoints`` dict — the same dict
-    ``ListEndpoints`` uses. This is how ``/system/log-server`` reaches finelog.
+def test_post_construction_registration_visible(threads: ThreadContainer, upstream: UpstreamHandle) -> None:
+    """The resolver is a callable closed over a mutable map — registrations
+    after the proxy is built must take effect on the next request. This is
+    how the controller's ``/system/log-server`` registration during start()
+    becomes visible to a dashboard already constructed in ``__init__``.
     """
-    store = _FakeStore()  # empty: no rows for /system/log-server
-    system_endpoints = {"/system/log-server": f"127.0.0.1:{upstream.port}"}
-    ep_proxy = EndpointProxy(store, system_endpoints=system_endpoints)  # type: ignore[arg-type]
-    app = _build_proxy_app(ep_proxy)
-    port = _free_port()
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error", log_config=None)
-    server = uvicorn.Server(config)
-    threads.spawn_server(server, name=f"proxy-{port}")
-    _wait_for_server(server)
+    base_url, endpoints, _ = _start_proxy(threads, endpoints={})
 
     with httpx.Client() as client:
-        resp = client.get(f"http://127.0.0.1:{port}/proxy/system.log-server/echo")
-    assert resp.status_code == 200
-    assert resp.json()["path"] == "/echo"
-
-
-def test_system_endpoints_dict_mutation_visible(threads: ThreadContainer, upstream: UpstreamHandle) -> None:
-    """Controller registers ``/system/log-server`` after the dashboard is built;
-    the dict is shared by reference so post-construction updates take effect.
-    """
-    store = _FakeStore()
-    system_endpoints: dict[str, str] = {}
-    ep_proxy = EndpointProxy(store, system_endpoints=system_endpoints)  # type: ignore[arg-type]
-    app = _build_proxy_app(ep_proxy)
-    port = _free_port()
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error", log_config=None)
-    server = uvicorn.Server(config)
-    threads.spawn_server(server, name=f"proxy-{port}")
-    _wait_for_server(server)
-
-    with httpx.Client() as client:
-        # Before registration: 404.
-        miss = client.get(f"http://127.0.0.1:{port}/proxy/system.log-server/echo")
+        miss = client.get(f"{base_url}/proxy/{ENDPOINT_URL_NAME}/echo")
         assert miss.status_code == 404
 
-        # Mutate the dict the proxy holds a reference to.
-        system_endpoints["/system/log-server"] = f"127.0.0.1:{upstream.port}"
+        # Mutate the dict the resolver closes over.
+        endpoints[ENDPOINT_NAME] = f"127.0.0.1:{upstream.port}"
 
-        ok = client.get(f"http://127.0.0.1:{port}/proxy/system.log-server/echo")
+        ok = client.get(f"{base_url}/proxy/{ENDPOINT_URL_NAME}/echo")
     assert ok.status_code == 200
 
 

--- a/lib/iris/tests/cluster/controller/test_endpoint_proxy.py
+++ b/lib/iris/tests/cluster/controller/test_endpoint_proxy.py
@@ -20,7 +20,12 @@ from dataclasses import dataclass
 import httpx
 import pytest
 import uvicorn
-from iris.cluster.controller.endpoint_proxy import ALLOWED_METHODS, PROXY_ROUTE, EndpointProxy
+from iris.cluster.controller.endpoint_proxy import (
+    ALLOWED_METHODS,
+    PROXY_ROUTE,
+    EndpointProxy,
+    _rewrite_location,
+)
 from iris.cluster.controller.schema import EndpointRow
 from iris.cluster.dashboard_common import on_shutdown
 from iris.cluster.types import JobName
@@ -148,12 +153,43 @@ def _build_upstream_app(handle: UpstreamHandle) -> Starlette:
             headers={"set-cookie": "upstream_session=abc; Path=/"},
         )
 
+    async def redirect_absolute(request: Request) -> Response:
+        # Mirrors what Starlette / many WSGI apps emit for canonical-slash
+        # redirects: an absolute URL containing the upstream's bind host.
+        await _record(request)
+        return PlainTextResponse(
+            "",
+            status_code=302,
+            headers={"location": f"http://127.0.0.1:{handle.port}/echo?from=abs"},
+        )
+
+    async def redirect_path(request: Request) -> Response:
+        # Absolute-path redirect (no scheme/host). Common for ``/`` -> ``/login``.
+        await _record(request)
+        return PlainTextResponse(
+            "",
+            status_code=302,
+            headers={"location": "/echo?from=path"},
+        )
+
+    async def redirect_external(request: Request) -> Response:
+        # Cross-origin redirect — proxy must NOT rewrite this.
+        await _record(request)
+        return PlainTextResponse(
+            "",
+            status_code=302,
+            headers={"location": "https://other.example/landing"},
+        )
+
     routes = [
         Route("/echo", echo, methods=list(ALLOWED_METHODS)),
         Route("/500", upstream_500),
         Route("/slow", slow),
         Route("/large", large),
         Route("/cookie", cookie_setter),
+        Route("/redirect-abs", redirect_absolute),
+        Route("/redirect-path", redirect_path),
+        Route("/redirect-ext", redirect_external),
     ]
     return Starlette(routes=routes)
 
@@ -188,10 +224,16 @@ class ProxyHandle:
 
 
 def _build_proxy_app(proxy: EndpointProxy) -> Starlette:
-    return Starlette(
+    # redirect_slashes=False mirrors the controller dashboard: Starlette's
+    # default slash-redirect builds an absolute URL from the request's Host
+    # header / bind address, which leaks the internal backend IP back to the
+    # browser when the controller sits behind IAP / a load balancer.
+    app = Starlette(
         routes=[Route(PROXY_ROUTE, proxy.handle, methods=list(ALLOWED_METHODS))],
         lifespan=on_shutdown(proxy.close),
     )
+    app.router.redirect_slashes = False
+    return app
 
 
 @pytest.fixture
@@ -387,3 +429,165 @@ def test_disallowed_methods_not_listed() -> None:
     assert "CONNECT" not in ALLOWED_METHODS
     assert "TRACE" not in ALLOWED_METHODS
     assert set(ALLOWED_METHODS) == {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}
+
+
+# ---------------------------------------------------------------------------
+# Location-rewrite unit tests
+# ---------------------------------------------------------------------------
+
+
+_UPSTREAM_BASE = "http://10.0.0.1:8080"
+_PROXY_PREFIX = "/proxy/myep"
+
+
+@pytest.mark.parametrize(
+    "loc, expected",
+    [
+        # Absolute URL with same origin → rewritten to dashboard-relative path.
+        ("http://10.0.0.1:8080/foo", "/proxy/myep/foo"),
+        ("http://10.0.0.1:8080/foo?a=1&b=2", "/proxy/myep/foo?a=1&b=2"),
+        ("http://10.0.0.1:8080/foo#frag", "/proxy/myep/foo#frag"),
+        ("http://10.0.0.1:8080/", "/proxy/myep/"),
+        # No path on the absolute URL — treat as root.
+        ("http://10.0.0.1:8080", "/proxy/myep/"),
+        # Protocol-relative on same netloc → rewritten.
+        ("//10.0.0.1:8080/foo", "/proxy/myep/foo"),
+        # Absolute path → prepended.
+        ("/foo", "/proxy/myep/foo"),
+        ("/foo?x=1", "/proxy/myep/foo?x=1"),
+        ("/", "/proxy/myep/"),
+        # Cross-origin absolute URL → passthrough.
+        ("http://other.host/foo", "http://other.host/foo"),
+        # Different scheme on same host → passthrough (HTTPS upstream is a
+        # different origin and we should not silently downgrade).
+        ("https://10.0.0.1:8080/foo", "https://10.0.0.1:8080/foo"),
+        # Protocol-relative on a different netloc → passthrough.
+        ("//other.host/foo", "//other.host/foo"),
+        # Relative path → browser resolves against current proxy URL.
+        ("foo", "foo"),
+        ("./foo", "./foo"),
+        ("../foo", "../foo"),
+        # Fragment-only and empty → passthrough.
+        ("#anchor", "#anchor"),
+        ("", ""),
+    ],
+)
+def test_rewrite_location(loc: str, expected: str) -> None:
+    assert _rewrite_location(loc, upstream_base=_UPSTREAM_BASE, proxy_prefix=_PROXY_PREFIX) == expected
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: redirects round-trip through the proxy
+# ---------------------------------------------------------------------------
+
+
+def test_absolute_redirect_rewritten_to_proxy(proxy: ProxyHandle) -> None:
+    """Upstream emits absolute self-URL Location; proxy must keep us inside."""
+    with httpx.Client() as client:
+        resp = client.get(
+            f"{proxy.base_url}/proxy/{ENDPOINT_URL_NAME}/redirect-abs",
+            follow_redirects=False,
+        )
+    assert resp.status_code == 302
+    # Browser would follow this; it must point back at the proxy, not at the
+    # upstream's bind address (which is unreachable from outside the cluster).
+    assert resp.headers["location"] == f"/proxy/{ENDPOINT_URL_NAME}/echo?from=abs"
+
+
+def test_path_redirect_rewritten_to_proxy(proxy: ProxyHandle) -> None:
+    """Upstream emits ``Location: /foo``; proxy prepends the /proxy/<name> prefix."""
+    with httpx.Client() as client:
+        resp = client.get(
+            f"{proxy.base_url}/proxy/{ENDPOINT_URL_NAME}/redirect-path",
+            follow_redirects=False,
+        )
+    assert resp.status_code == 302
+    assert resp.headers["location"] == f"/proxy/{ENDPOINT_URL_NAME}/echo?from=path"
+
+
+def test_external_redirect_passthrough(proxy: ProxyHandle) -> None:
+    """Cross-origin Location must NOT be rewritten; upstream may legitimately send users away."""
+    with httpx.Client() as client:
+        resp = client.get(
+            f"{proxy.base_url}/proxy/{ENDPOINT_URL_NAME}/redirect-ext",
+            follow_redirects=False,
+        )
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "https://other.example/landing"
+
+
+def test_system_endpoint_resolves_via_in_memory_map(threads: ThreadContainer, upstream: UpstreamHandle) -> None:
+    """``/system/...`` endpoints aren't in the SQL store; the proxy must consult
+    the service's in-memory ``system_endpoints`` dict — the same dict
+    ``ListEndpoints`` uses. This is how ``/system/log-server`` reaches finelog.
+    """
+    store = _FakeStore()  # empty: no rows for /system/log-server
+    system_endpoints = {"/system/log-server": f"127.0.0.1:{upstream.port}"}
+    ep_proxy = EndpointProxy(store, system_endpoints=system_endpoints)  # type: ignore[arg-type]
+    app = _build_proxy_app(ep_proxy)
+    port = _free_port()
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error", log_config=None)
+    server = uvicorn.Server(config)
+    threads.spawn_server(server, name=f"proxy-{port}")
+    _wait_for_server(server)
+
+    with httpx.Client() as client:
+        resp = client.get(f"http://127.0.0.1:{port}/proxy/system.log-server/echo")
+    assert resp.status_code == 200
+    assert resp.json()["path"] == "/echo"
+
+
+def test_system_endpoints_dict_mutation_visible(threads: ThreadContainer, upstream: UpstreamHandle) -> None:
+    """Controller registers ``/system/log-server`` after the dashboard is built;
+    the dict is shared by reference so post-construction updates take effect.
+    """
+    store = _FakeStore()
+    system_endpoints: dict[str, str] = {}
+    ep_proxy = EndpointProxy(store, system_endpoints=system_endpoints)  # type: ignore[arg-type]
+    app = _build_proxy_app(ep_proxy)
+    port = _free_port()
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error", log_config=None)
+    server = uvicorn.Server(config)
+    threads.spawn_server(server, name=f"proxy-{port}")
+    _wait_for_server(server)
+
+    with httpx.Client() as client:
+        # Before registration: 404.
+        miss = client.get(f"http://127.0.0.1:{port}/proxy/system.log-server/echo")
+        assert miss.status_code == 404
+
+        # Mutate the dict the proxy holds a reference to.
+        system_endpoints["/system/log-server"] = f"127.0.0.1:{upstream.port}"
+
+        ok = client.get(f"http://127.0.0.1:{port}/proxy/system.log-server/echo")
+    assert ok.status_code == 200
+
+
+def test_no_trailing_slash_does_not_redirect(proxy: ProxyHandle) -> None:
+    """``/proxy/<name>`` (no trailing slash) must NOT trigger Starlette's
+    slash-redirect. That redirect's Location is built from the request's
+    Host header (or scope["server"]); behind GCP IAP / a load balancer
+    that resolves to the internal bind IP, so the browser gets sent to
+    an unreachable backend address (ERR_ADDRESS_UNREACHABLE).
+    """
+    with httpx.Client() as client:
+        resp = client.get(
+            f"{proxy.base_url}/proxy/{ENDPOINT_URL_NAME}",
+            follow_redirects=False,
+        )
+    # Critical: 404, never 307. A 307 here means the dashboard is configured
+    # with redirect_slashes=True and will leak the internal IP.
+    assert resp.status_code == 404
+
+
+def test_redirect_followed_through_proxy_lands_on_upstream(proxy: ProxyHandle) -> None:
+    """End-to-end: client follows the rewritten Location and reaches the upstream's /echo."""
+    with httpx.Client(base_url=proxy.base_url) as client:
+        resp = client.get(
+            f"/proxy/{ENDPOINT_URL_NAME}/redirect-abs",
+            follow_redirects=True,
+        )
+    assert resp.status_code == 200
+    assert resp.json()["path"] == "/echo"
+    # The follow-up GET hit the upstream's /echo, not /redirect-abs again.
+    assert proxy.upstream.received_paths[-1] == "/echo?from=abs"

--- a/lib/iris/tests/cluster/controller/test_endpoint_proxy.py
+++ b/lib/iris/tests/cluster/controller/test_endpoint_proxy.py
@@ -204,10 +204,19 @@ def _build_proxy_app(proxy: EndpointProxy) -> Starlette:
         query = f"?{request.url.query}" if request.url.query else ""
         return RedirectResponse(f"/proxy/{name}/{query}", status_code=307)
 
+    async def _proxy_route(request: Request) -> Response:
+        name = request.path_params["endpoint_name"]
+        return await proxy.dispatch(
+            request,
+            encoded_name=name,
+            sub_path=request.path_params["sub_path"],
+            proxy_prefix=f"/proxy/{name}",
+        )
+
     app = Starlette(
         routes=[
             Route("/proxy/{endpoint_name:str}", _redirect_to_slash, methods=list(ALLOWED_METHODS)),
-            Route(PROXY_ROUTE, proxy.handle, methods=list(ALLOWED_METHODS)),
+            Route(PROXY_ROUTE, _proxy_route, methods=list(ALLOWED_METHODS)),
         ],
         lifespan=on_shutdown(proxy.close),
     )

--- a/lib/iris/tests/cluster/controller/test_endpoint_proxy.py
+++ b/lib/iris/tests/cluster/controller/test_endpoint_proxy.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 import httpx
 import pytest
 import uvicorn
+from iris.cluster.controller.dashboard import _extract_proxy_subdomain, _SubdomainProxyMiddleware
 from iris.cluster.controller.endpoint_proxy import (
     ALLOWED_METHODS,
     PROXY_ROUTE,
@@ -189,12 +190,25 @@ class ProxyHandle:
 
 
 def _build_proxy_app(proxy: EndpointProxy) -> Starlette:
-    # redirect_slashes=False mirrors the controller dashboard: Starlette's
-    # default slash-redirect builds an absolute URL from the request's Host
-    # header / bind address, which leaks the internal backend IP back to the
-    # browser when the controller sits behind IAP / a load balancer.
+    # Mirrors the controller dashboard's wiring:
+    # - ``/proxy/<name>`` (no trailing slash) -> path-only 307 to ``/proxy/<name>/``.
+    #   We can't use Starlette's ``redirect_slashes=True`` because it builds
+    #   an *absolute* Location from scope["server"] / Host, leaking the
+    #   internal bind IP behind IAP. A path-only Location resolves against
+    #   the browser's current origin instead.
+    # - ``/proxy/<name>/<sub_path>`` -> the proxy itself.
+    async def _redirect_to_slash(request: Request) -> Response:
+        from starlette.responses import RedirectResponse
+
+        name = request.path_params["endpoint_name"]
+        query = f"?{request.url.query}" if request.url.query else ""
+        return RedirectResponse(f"/proxy/{name}/{query}", status_code=307)
+
     app = Starlette(
-        routes=[Route(PROXY_ROUTE, proxy.handle, methods=list(ALLOWED_METHODS))],
+        routes=[
+            Route("/proxy/{endpoint_name:str}", _redirect_to_slash, methods=list(ALLOWED_METHODS)),
+            Route(PROXY_ROUTE, proxy.handle, methods=list(ALLOWED_METHODS)),
+        ],
         lifespan=on_shutdown(proxy.close),
     )
     app.router.redirect_slashes = False
@@ -502,21 +516,53 @@ def test_post_construction_registration_visible(threads: ThreadContainer, upstre
     assert ok.status_code == 200
 
 
-def test_no_trailing_slash_does_not_redirect(proxy: ProxyHandle) -> None:
-    """``/proxy/<name>`` (no trailing slash) must NOT trigger Starlette's
-    slash-redirect. That redirect's Location is built from the request's
-    Host header (or scope["server"]); behind GCP IAP / a load balancer
-    that resolves to the internal bind IP, so the browser gets sent to
-    an unreachable backend address (ERR_ADDRESS_UNREACHABLE).
+def test_no_trailing_slash_redirects_with_path_only_location(proxy: ProxyHandle) -> None:
+    """``/proxy/<name>`` (no trailing slash) must 307 to ``/proxy/<name>/``
+    with a *path-only* Location.
+
+    Starlette's built-in ``redirect_slashes=True`` would emit an absolute
+    Location built from scope["server"] / the Host header — behind IAP that
+    is the internal bind IP, sending the browser to an unreachable address.
+    Our handler emits a path-only Location instead, which the browser
+    resolves against its current origin.
     """
     with httpx.Client() as client:
         resp = client.get(
             f"{proxy.base_url}/proxy/{ENDPOINT_URL_NAME}",
             follow_redirects=False,
         )
-    # Critical: 404, never 307. A 307 here means the dashboard is configured
-    # with redirect_slashes=True and will leak the internal IP.
-    assert resp.status_code == 404
+    assert resp.status_code == 307
+    location = resp.headers["location"]
+    assert location == f"/proxy/{ENDPOINT_URL_NAME}/"
+    # Critical: no scheme, no netloc — anything else risks leaking the
+    # internal address (e.g. ``http://10.x.x.x:10000/...``).
+    assert "://" not in location
+
+
+def test_no_trailing_slash_redirect_preserves_query_string(proxy: ProxyHandle) -> None:
+    with httpx.Client() as client:
+        resp = client.get(
+            f"{proxy.base_url}/proxy/{ENDPOINT_URL_NAME}?a=1&b=2",
+            follow_redirects=False,
+        )
+    assert resp.status_code == 307
+    assert resp.headers["location"] == f"/proxy/{ENDPOINT_URL_NAME}/?a=1&b=2"
+
+
+def test_no_trailing_slash_redirect_followed_lands_on_upstream(proxy: ProxyHandle) -> None:
+    """End-to-end: client follows the slash redirect and reaches the upstream."""
+    with httpx.Client(base_url=proxy.base_url) as client:
+        resp = client.get(f"/proxy/{ENDPOINT_URL_NAME}/echo", follow_redirects=True)
+    # /echo doesn't need the slash redirect; just sanity-check the round trip works.
+    assert resp.status_code == 200
+    # And following ``/proxy/<name>`` (bare) -> ``/proxy/<name>/`` actually hits
+    # the upstream root. The upstream's "/" returns 404 (no route registered),
+    # so what we're really proving is that the redirect was followed at all.
+    with httpx.Client(base_url=proxy.base_url) as client:
+        bare = client.get(f"/proxy/{ENDPOINT_URL_NAME}", follow_redirects=True)
+    # The redirect target (/proxy/<name>/) maps to upstream "/", which the
+    # test upstream doesn't define -> 404 from upstream, NOT a connection error.
+    assert bare.status_code == 404
 
 
 def test_redirect_followed_through_proxy_lands_on_upstream(proxy: ProxyHandle) -> None:
@@ -530,3 +576,182 @@ def test_redirect_followed_through_proxy_lands_on_upstream(proxy: ProxyHandle) -
     assert resp.json()["path"] == "/echo"
     # The follow-up GET hit the upstream's /echo, not /redirect-abs again.
     assert proxy.upstream.received_paths[-1] == "/echo?from=abs"
+
+
+# ---------------------------------------------------------------------------
+# X-Forwarded-* headers
+# ---------------------------------------------------------------------------
+
+
+def test_forwarded_headers_path_mode(proxy: ProxyHandle) -> None:
+    """Path-mode requests forward X-Forwarded-Host/Proto/Prefix to the upstream.
+
+    Frameworks like Starlette/FastAPI (`root_path`) and Werkzeug
+    (`ProxyFix`) rely on these to mount themselves under ``/proxy/<name>``
+    and emit public-facing self-URLs.
+    """
+    with httpx.Client() as client:
+        resp = client.get(
+            f"{proxy.base_url}/proxy/{ENDPOINT_URL_NAME}/echo",
+            headers={"x-forwarded-host": "iris-dev.oa.dev", "x-forwarded-proto": "https"},
+        )
+    assert resp.status_code == 200
+    upstream = proxy.upstream.received_headers[-1]
+    # Inbound forwarded values flow through unchanged (we are one hop in a
+    # multi-hop chain).
+    assert upstream["x-forwarded-host"] == "iris-dev.oa.dev"
+    assert upstream["x-forwarded-proto"] == "https"
+    # The proxy adds its own prefix on top.
+    assert upstream["x-forwarded-prefix"] == f"/proxy/{ENDPOINT_URL_NAME}"
+
+
+def test_forwarded_headers_default_to_inbound_host(proxy: ProxyHandle) -> None:
+    """Without explicit X-Forwarded-* the proxy synthesizes them from the inbound request."""
+    with httpx.Client() as client:
+        resp = client.get(f"{proxy.base_url}/proxy/{ENDPOINT_URL_NAME}/echo")
+    assert resp.status_code == 200
+    upstream = proxy.upstream.received_headers[-1]
+    # Proxy is bound on http://127.0.0.1:<port>; that's what the upstream sees.
+    assert upstream["x-forwarded-proto"] == "http"
+    assert "x-forwarded-host" in upstream
+    assert "127.0.0.1" in upstream["x-forwarded-host"]
+    assert upstream["x-forwarded-prefix"] == f"/proxy/{ENDPOINT_URL_NAME}"
+
+
+# ---------------------------------------------------------------------------
+# Subdomain dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "host, expected",
+    [
+        # Single-label name (most common — flat endpoint name).
+        ("foo.proxy.iris-dev.oa.dev", "foo"),
+        # Multi-label name (Iris path-style names with embedded ``.``).
+        ("user.job1.dash.proxy.iris-dev.oa.dev", "user.job1.dash"),
+        # Port stripped from the inbound Host header.
+        ("foo.proxy.iris-dev.oa.dev:443", "foo"),
+        # DNS labels are case-insensitive — both marker and encoded name
+        # are returned lowercased. Endpoints registered with mixed case
+        # are unreachable via subdomain dispatch (use the path-style
+        # ``/proxy/<name>`` route instead).
+        ("FOO.PROXY.iris-dev.oa.dev", "foo"),
+        # First ``proxy`` label wins — anything to its right is the public domain.
+        ("foo.proxy.proxy.example.com", "foo"),
+        # No ``proxy`` label -> not a subdomain request.
+        ("iris-dev.oa.dev", None),
+        ("iris.oa.dev", None),
+        # ``proxy`` as the leftmost label means there is no encoded name.
+        ("proxy.iris-dev.oa.dev", None),
+        # Empty / missing host.
+        ("", None),
+    ],
+)
+def test_extract_proxy_subdomain(host: str, expected: str | None) -> None:
+    assert _extract_proxy_subdomain(host) == expected
+
+
+def _build_subdomain_app(proxy: EndpointProxy):
+    """Wrap an EndpointProxy with subdomain dispatch + a fall-through inner app.
+
+    The inner app responds 418 to any request that the middleware does not
+    capture — so tests can distinguish "fell through to the dashboard" from
+    "subdomain dispatch fired".
+    """
+
+    async def _inner(request: Request) -> Response:
+        return PlainTextResponse("inner", status_code=418)
+
+    inner = Starlette(routes=[Route("/{path:path}", _inner, methods=list(ALLOWED_METHODS))])
+    inner.router.redirect_slashes = False
+    return _SubdomainProxyMiddleware(inner, endpoint_proxy=proxy)
+
+
+def _start_subdomain_proxy(
+    threads: ThreadContainer,
+    *,
+    endpoints: dict[str, str],
+) -> str:
+    ep_proxy = EndpointProxy(endpoints.get)
+    app = _build_subdomain_app(ep_proxy)
+    port = _free_port()
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error", log_config=None)
+    server = uvicorn.Server(config)
+    threads.spawn_server(server, name=f"subdomain-{port}")
+    _wait_for_server(server)
+    return f"http://127.0.0.1:{port}"
+
+
+# DNS labels are case-insensitive, so subdomain mode lowercases the encoded
+# name before resolving. Use an all-lowercase Iris name for these tests.
+_SUB_ENDPOINT_NAME = "/user/job1/dash"
+_SUB_ENDPOINT_URL_NAME = "user.job1.dash"
+
+
+def test_subdomain_dispatch_round_trip(threads: ThreadContainer, upstream: UpstreamHandle) -> None:
+    """A request whose Host has a ``proxy`` label routes to the upstream."""
+    base_url = _start_subdomain_proxy(
+        threads,
+        endpoints={_SUB_ENDPOINT_NAME: f"127.0.0.1:{upstream.port}"},
+    )
+    with httpx.Client() as client:
+        # The Host header drives dispatch; the actual TCP target stays 127.0.0.1.
+        resp = client.get(
+            f"{base_url}/echo?q=1",
+            headers={"host": f"{_SUB_ENDPOINT_URL_NAME}.proxy.iris-dev.oa.dev"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["path"] == "/echo"
+    assert body["query"] == "q=1"
+    # Subdomain mode does not set X-Forwarded-Prefix — the upstream owns the origin.
+    upstream_headers = upstream.received_headers[-1]
+    assert "x-forwarded-prefix" not in upstream_headers
+
+
+def test_subdomain_unknown_endpoint_returns_404(threads: ThreadContainer) -> None:
+    base_url = _start_subdomain_proxy(threads, endpoints={})
+    with httpx.Client() as client:
+        resp = client.get(
+            f"{base_url}/anything",
+            headers={"host": "no-such.proxy.iris-dev.oa.dev"},
+        )
+    assert resp.status_code == 404
+
+
+def test_subdomain_passthrough_when_no_proxy_label(threads: ThreadContainer, upstream: UpstreamHandle) -> None:
+    """Hosts without a ``proxy`` label fall through to the inner app."""
+    base_url = _start_subdomain_proxy(
+        threads,
+        endpoints={_SUB_ENDPOINT_NAME: f"127.0.0.1:{upstream.port}"},
+    )
+    with httpx.Client() as client:
+        resp = client.get(
+            f"{base_url}/echo",
+            headers={"host": "iris-dev.oa.dev"},
+        )
+    # Inner app returned 418 — confirms the middleware passed through.
+    assert resp.status_code == 418
+    assert resp.text == "inner"
+
+
+def test_subdomain_redirect_rewrites_to_path_only(threads: ThreadContainer, upstream: UpstreamHandle) -> None:
+    """Absolute upstream redirects in subdomain mode strip back to a path on the same origin.
+
+    The browser is already on ``<name>.proxy.iris-dev.oa.dev``, so a path-only
+    Location lands it on the right host without rewriting through ``/proxy/<name>``.
+    """
+    base_url = _start_subdomain_proxy(
+        threads,
+        endpoints={_SUB_ENDPOINT_NAME: f"127.0.0.1:{upstream.port}"},
+    )
+    with httpx.Client() as client:
+        resp = client.get(
+            f"{base_url}/redirect-abs",
+            headers={"host": f"{_SUB_ENDPOINT_URL_NAME}.proxy.iris-dev.oa.dev"},
+            follow_redirects=False,
+        )
+    assert resp.status_code == 302
+    # No /proxy/<name> prefix — just the upstream path on the current origin.
+    assert resp.headers["location"] == "/echo?from=abs"


### PR DESCRIPTION
## Summary

Proxied dashboards behind GCP IAP (e.g. `/proxy/system.log-server/`) didn't work: redirects sent the browser to `http://10.x.x.x:10000/...`, which isn't routable from outside the VPC. Three independent sources of the bad URL, all fixed:

- **Uvicorn doesn't trust forwarded headers.** Without `proxy_headers=True` / `forwarded_allow_ips=\"*\"`, `scope[\"server\"]` is the controller's bind address, so any absolute URL Starlette builds uses the VPC-internal IP. The controller's only ingress is the LB, so trusting all upstreams is safe.
- **Starlette's trailing-slash redirect uses that same internal address.** Hitting `/proxy/<name>` (no slash) 307s to `http://10.x.x.x:10000/proxy/<name>/`. Disabled via `app.router.redirect_slashes = False`; the SPA handles its own paths and the API surface is small.
- **Upstream-emitted absolute redirects escape the proxy.** Dashboards behind `/proxy/<name>/` that 302 to `http://<upstream-ip>:port/login` (or set `Content-Location`) navigate the browser to an unreachable upstream IP. `EndpointProxy` now rewrites `Location` / `Content-Location`: same-origin upstream URLs and absolute paths get the `/proxy/<name>` prefix prepended; cross-origin and relative URLs pass through.

Also fixes a routing gap: `/system/...` endpoints (e.g. `/system/log-server`) live in the controller's in-memory `system_endpoints` map, not the SQL store, so proxy lookups 404'd. `EndpointProxy` no longer takes a `ControllerStore`; the dashboard injects a `resolve: (name) -> address | None` callable that consults both sources, mirroring `ListEndpoints`.

## Changes

- `controller.py`: enable `proxy_headers` / `forwarded_allow_ips=\"*\"` on the uvicorn config.
- `dashboard.py`: disable `redirect_slashes`; wire `EndpointProxy` to a resolver that falls back from the SQL store to `system_endpoints`.
- `endpoint_proxy.py`: replace `ControllerStore` dep with an `EndpointResolver` callable; rewrite `Location` / `Content-Location` headers via `_rewrite_location`; add request/404 logging.
- `test_endpoint_proxy.py`: updated to the resolver interface; added coverage for header rewriting (same-origin absolute, absolute-path, cross-origin pass-through, `Content-Location`).