### PR TITLE
Use Triton ragged_dot backward for 3.1x Grug MoE speedup over main

### DIFF
--- a/lib/haliax/src/haliax/nn/ragged_dot.py
+++ b/lib/haliax/src/haliax/nn/ragged_dot.py
@@ -32,6 +32,11 @@ try:
 except (ImportError, ModuleNotFoundError):
     pass
 
+# Adapted from openxla/tokamax@ad75b704:
+# tokamax/_src/ops/ragged_dot/pallas_triton.py. In particular:
+# _ragged_dot_kernel/_ragged_dot for the default layout,
+# _ragged_contracting_dim_dot_kernel/_ragged_contracting_dim_dot for drhs, and
+# PallasTritonRaggedDot._fwd for the VJP layout dispatch.
 Implementation: TypeAlias = Literal["auto", "megablox", "triton", "xla"]
 _AUTO_FALLBACK_EXCEPTIONS = (NotImplementedError, RuntimeError)
 _HAS_WARNED_AUTO_FALLBACK = False
@@ -87,8 +92,8 @@ def _triton_ragged_dot_kernel(
         plgpu.store(out_ref.at[span_m, pl.ds(0, out_ref.shape[1])], acc.astype(out_ref.dtype), mask=mask[:, None])
 
 
-def _triton_pallas_call(lhs: jax.Array, rhs: jax.Array, group_sizes: jax.Array) -> jax.Array:
-    """Raw Pallas-Triton grouped matmul (forward only, not differentiable)."""
+def _triton_default_pallas_call(lhs: jax.Array, rhs: jax.Array, group_sizes: jax.Array) -> jax.Array:
+    """Raw Pallas-Triton grouped matmul for the default ragged-dot layout."""
     m, k = lhs.shape
     num_groups, _, n = rhs.shape
 
@@ -111,6 +116,81 @@ def _triton_pallas_call(lhs: jax.Array, rhs: jax.Array, group_sizes: jax.Array) 
         grid=(pl.cdiv(m, block_m), pl.cdiv(n, block_n), num_groups),
         compiler_params=plgpu.CompilerParams(num_warps=4, num_stages=4),
     )(lhs, rhs, cum_rows[:-1], cum_rows[1:])
+
+
+def _triton_ragged_contracting_dim_dot_kernel(
+    a_ref,
+    b_ref,
+    lo_ref,
+    hi_ref,
+    out_ref,
+    *,
+    block_m: int,
+    block_k: int,
+):
+    """Pallas-Triton ragged dot where the ragged dimension is also contracting."""
+    lo = lo_ref[()]
+    hi = hi_ref[()]
+
+    def body(i, acc, mask_k=False):
+        start_k = lo + i * block_k
+        span_k = pl.ds(start_k, block_k)
+        mask = None
+        other = None
+        if mask_k:
+            mask = (jnp.arange(block_k) < hi - start_k)[:, None]
+            other = 0.0
+        a = plgpu.load(a_ref.at[span_k], mask=mask, other=other)
+        b = plgpu.load(b_ref.at[span_k], mask=mask, other=other)
+        dtype = jnp.result_type(a, b)
+        return acc + pl.dot(a.astype(dtype).T, b.astype(dtype))
+
+    num_k_blocks = jnp.maximum(pl.cdiv(jnp.int32(hi - lo), block_k), 1)
+    acc = jnp.zeros((block_m, out_ref.shape[1]), dtype=jnp.float32)
+    acc = jax.lax.fori_loop(0, num_k_blocks - 1, body, acc)
+    acc = body(num_k_blocks - 1, acc, mask_k=True)
+    plgpu.store(out_ref, acc.astype(out_ref.dtype))
+
+
+def _triton_ragged_contracting_dim_pallas_call(
+    lhs: jax.Array,
+    rhs: jax.Array,
+    group_sizes: jax.Array,
+) -> jax.Array:
+    """Raw Pallas-Triton grouped matmul for drhs-style ragged contraction."""
+    k, m = lhs.shape
+    _, n = rhs.shape
+
+    block_m = min(128, int(pl.next_power_of_2(m)))
+    block_n = min(128, int(pl.next_power_of_2(n)))
+    block_k = min(32, int(pl.next_power_of_2(k)))
+
+    cum_rows = jnp.cumulative_sum(group_sizes, include_initial=True)
+
+    def one_group(lhs, rhs, lo, hi):
+        return pl.pallas_call(
+            lambda a, b, lo, hi, out: _triton_ragged_contracting_dim_dot_kernel(
+                a,
+                b,
+                lo,
+                hi,
+                out,
+                block_m=block_m,
+                block_k=block_k,
+            ),
+            out_shape=jax.ShapeDtypeStruct((m, n), lhs.dtype),
+            in_specs=[
+                pl.BlockSpec((k, block_m), lambda i, j: (0, i)),
+                pl.BlockSpec((k, block_n), lambda i, j: (0, j)),
+                pl.no_block_spec,
+                pl.no_block_spec,
+            ],
+            out_specs=pl.BlockSpec((block_m, block_n), lambda i, j: (i, j)),
+            grid=(pl.cdiv(m, block_m), pl.cdiv(n, block_n)),
+            compiler_params=plgpu.CompilerParams(num_warps=4, num_stages=4),
+        )(lhs, rhs, lo, hi)
+
+    return jax.vmap(one_group, in_axes=(None, None, 0, 0))(lhs, rhs, cum_rows[:-1], cum_rows[1:])
 
 
 _DEFAULT_DIM_NUMS = jax.lax.RaggedDotDimensionNumbers(
@@ -136,13 +216,29 @@ _DRHS_DIM_NUMS = jax.lax.RaggedDotDimensionNumbers(
 )
 
 
+def _triton_pallas_call(
+    lhs: jax.Array,
+    rhs: jax.Array,
+    group_sizes: jax.Array,
+    ragged_dot_dimension_numbers: jax.lax.RaggedDotDimensionNumbers = _DEFAULT_DIM_NUMS,
+) -> jax.Array:
+    """Raw Pallas-Triton grouped matmul for supported ragged-dot layouts."""
+    if ragged_dot_dimension_numbers == _DEFAULT_DIM_NUMS:
+        return _triton_default_pallas_call(lhs, rhs, group_sizes)
+    if ragged_dot_dimension_numbers == _DLHS_DIM_NUMS:
+        return _triton_default_pallas_call(lhs, rhs.mT, group_sizes)
+    if ragged_dot_dimension_numbers == _DRHS_DIM_NUMS:
+        return _triton_ragged_contracting_dim_pallas_call(lhs, rhs, group_sizes)
+    raise NotImplementedError(f"Unsupported ragged dot dimension numbers for Triton: {ragged_dot_dimension_numbers}")
+
+
 @functools.partial(jax.custom_vjp, nondiff_argnums=())
 def _ragged_dot_triton_impl(lhs: jax.Array, rhs: jax.Array, group_sizes: jax.Array) -> jax.Array:
     """Pallas-Triton grouped matmul with explicit backward pass.
 
-    Uses custom_vjp so JAX never tries to autodiff through pallas_call
-    (which lacks JVP rules in JAX 0.8.0). Both forward and backward use
-    the Triton kernel for the full 5x speedup over XLA.
+    Uses custom_vjp so JAX never tries to autodiff directly through pallas_call.
+    Direct autodiff still fails for this kernel on JAX 0.9.2, while the explicit
+    VJP can use the Triton kernels for each ragged-dot contraction layout.
     """
     if not _has_pallas_triton:
         raise NotImplementedError("Pallas Triton backend is not available")
@@ -157,25 +253,11 @@ def _ragged_dot_triton_fwd(lhs, rhs, group_sizes):
 def _ragged_dot_triton_bwd(residuals, dout):
     lhs, rhs, group_sizes = residuals
 
-    # dlhs[M,K] = ragged_dot_general(dout[M,N], rhs[G,K,N], gs)
-    # Contracts dout dim 1 (N) with rhs dim 2 (N) — different from forward's
-    # contracting dims, so we use XLA here. The Triton kernel only supports
-    # the standard (dim1, dim1) contraction.
-    dlhs = jax.lax.ragged_dot_general(
-        lhs=dout,
-        rhs=rhs,
-        group_sizes=group_sizes,
-        ragged_dot_dimension_numbers=_DLHS_DIM_NUMS,
-    )
+    # dlhs[M,K] = dout[M,N] @ rhs[G,K,N]^T
+    dlhs = _triton_pallas_call(dout, rhs, group_sizes, _DLHS_DIM_NUMS)
 
-    # drhs[G,K,N] = ragged_dot_general(lhs[M,K], dout[M,N], gs)
-    # Contracts over ragged M dimension — also non-standard for our kernel.
-    drhs = jax.lax.ragged_dot_general(
-        lhs=lhs,
-        rhs=dout,
-        group_sizes=group_sizes,
-        ragged_dot_dimension_numbers=_DRHS_DIM_NUMS,
-    )
+    # drhs[G,K,N] = lhs[M,K]^T @ dout[M,N]
+    drhs = _triton_pallas_call(lhs, dout, group_sizes, _DRHS_DIM_NUMS)
 
     return dlhs, drhs, None  # None for group_sizes (integer, no gradient)
 

--- a/lib/haliax/tests/test_ragged_dot_dispatch.py
+++ b/lib/haliax/tests/test_ragged_dot_dispatch.py
@@ -71,3 +71,43 @@ def test_ragged_dot_gpu_auto_uses_triton_when_available(monkeypatch):
     auto_out = ragged_dot(lhs, rhs, group_sizes, implementation="auto")
 
     assert jnp.array_equal(auto_out, expected)
+
+
+def test_triton_custom_vjp_routes_backward_through_triton_layouts(monkeypatch):
+    lhs, rhs, group_sizes = _inputs()
+    calls = []
+
+    def fake_triton_pallas_call(
+        lhs,
+        rhs,
+        group_sizes,
+        ragged_dot_dimension_numbers=ragged_dot_module._DEFAULT_DIM_NUMS,
+    ):
+        calls.append(ragged_dot_dimension_numbers)
+        return jax.lax.ragged_dot_general(
+            lhs=lhs,
+            rhs=rhs,
+            group_sizes=group_sizes,
+            ragged_dot_dimension_numbers=ragged_dot_dimension_numbers,
+        )
+
+    monkeypatch.setattr(ragged_dot_module, "_has_pallas_triton", True)
+    monkeypatch.setattr(ragged_dot_module, "_triton_pallas_call", fake_triton_pallas_call)
+
+    def triton_loss(lhs, rhs):
+        return jnp.sum(ragged_dot_module._ragged_dot_triton_impl(lhs, rhs, group_sizes))
+
+    def xla_loss(lhs, rhs):
+        return jnp.sum(ragged_dot(lhs, rhs, group_sizes, implementation="xla"))
+
+    triton_value, triton_grads = jax.value_and_grad(triton_loss, argnums=(0, 1))(lhs, rhs)
+    xla_value, xla_grads = jax.value_and_grad(xla_loss, argnums=(0, 1))(lhs, rhs)
+
+    assert jnp.allclose(triton_value, xla_value, rtol=1e-5, atol=1e-5)
+    assert jnp.allclose(triton_grads[0], xla_grads[0], rtol=1e-5, atol=1e-5)
+    assert jnp.allclose(triton_grads[1], xla_grads[1], rtol=1e-5, atol=1e-5)
+    assert calls == [
+        ragged_dot_module._DEFAULT_DIM_NUMS,
+        ragged_dot_module._DLHS_DIM_NUMS,
+        ragged_dot_module._DRHS_DIM_NUMS,
+    ]


### PR DESCRIPTION
## TL;DR

- Main-head comparison: Grug MoE train step improves from `0.530s` to `0.171s` avg median on H100x8, a `3.10x` steady-state speedup.
- #5394 compile memory: JAX 0.9.x temp memory drops from roughly `54.0 GiB` to roughly `7.2 GiB`.
- Full CoreWeave GPU canary passed: 99 reported steps, final loss `6.5599` against threshold `8.0`.

## Summary

Moves Haliax `ragged_dot` custom-VJP backward contractions from `jax.lax.ragged_dot_general` to explicit Pallas-Triton kernels for both `dlhs` and `drhs`.

This addresses #5394: on JAX/JAXLIB 0.9.x, the current main backward path can lower through a dense CHLO/XLA route with roughly 54 GiB of compile temp memory for the Grug MoE canary train step. The PR branch compile probe now uses roughly 7.2 GiB and no longer emits the dense ragged-dot buffer shapes seen in #5394.

Current head: `a65124a4b9d662a196383d3521e602420a6ab470`. `origin/main` is `3eba473d15d6e94de0c700e20f7cca1b58a54863`, matching the PR base.

## Validation

- 3x H100x8 main-vs-PR perf job: `PASS`, avg steady speedup `3.10x` over current main behavior.
- #5394 H100x8 compile-memory probe: `PASS`; temp memory dropped from ~54.0 GiB baseline to ~7.2 GiB on the PR branch.
- Full CoreWeave GPU canary GitHub Action: passed.
- Local checks: Haliax targeted tests passed; Levanter Grug MoE tests passed with `pytest-xdist`; pre-commit passed.

<details>
<summary>3x main-vs-PR perf report</summary>

Job: CoreWeave Iris H100x8 `/romain/pr5350-main-vs-pr-perf3x-213214`.

Config: PR head `a65124a4b9d662a196383d3521e602420a6ab470`, JAX/JAXLIB `0.9.2`, `GRUG_MOE_TRIAL_MODEL`, batch size `16`, sequence length `4096`, 3 paired repeats, 3 warmup steps and 20 measured steady-state steps per implementation.

Baseline is current main's `ragged_dot` behavior for this PR base: Triton forward with XLA `jax.lax.ragged_dot_general` backward. The PR variant uses Triton for forward and backward. The harness swaps only the `ragged_dot` implementation so both sides run in the same process and on the same host allocation.

| Run | Main median steady | PR median steady | Steady speedup | Main compile+first | PR compile+first | First loss abs diff |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 0 | `0.530312s` | `0.171201s` | `3.098x` | `62.983s` | `39.904s` | `1.81e-05` |
| 1 | `0.530034s` | `0.171184s` | `3.096x` | `40.185s` | `39.913s` | `8.58e-06` |
| 2 | `0.530730s` | `0.171183s` | `3.100x` | `40.649s` | `40.330s` | `3.81e-06` |
| Avg | `0.530359s` | `0.171189s` | `3.098x` | `47.939s` | `40.049s` | max `1.81e-05` |

Compile-plus-first is reported for completeness; steady-state timing is the primary metric. Final loss after repeatedly optimizing the same synthetic batch is not used as a correctness signal for this perf harness. Correctness confidence comes from first-loss parity here, the paired gradient checks from the earlier H100 comparison, and the full CW canary pass.

Saved artifacts:

- Logs: `/tmp/cw_canary_25250127727/pr5350-main-vs-pr-perf3x-213214.logs_20260503T214321Z.txt`
- Aggregate JSON: `/tmp/cw_canary_25250127727/pr5350-main-vs-pr-perf3x-213214.perf_aggregate_20260503T214350Z.json`

</details>

<details>
<summary>#5394 compile-memory probe details</summary>

Commit tested: `4fde15c7a9ae628668fdecff9b71d273779ec790`, rebased onto `main` at `3eba473d15d6e94de0c700e20f7cca1b58a54863`. The squashed head only removes the research logbook and keeps the same runtime logic.

Job: CoreWeave Iris H100x8 `/romain/codex-pr5350-grug-memfix-uvrun-194527`.

Probe config: JAX/JAXLIB `0.9.2`, batch size `16`, seq len `4096`, `GRUG_MOE_TRIAL_MODEL`, `PROBE_SEGMENT_IDS=true`, `PROBE_VARIANTS=nowatch,watch`, `RAGGED_DOT_IMPL=triton`.

| Variant | PR temp bytes | PR temp GiB | #5394 JAX 0.9.2 baseline | JAX 0.8.0 reference |
| --- | ---: | ---: | ---: | ---: |
| `nowatch` | `7,735,032,624` | `7.20 GiB` | `58,045,336,368` bytes (`54.05 GiB`) | `16,071,783,216` bytes (`14.97 GiB`) |
| `watch` | `7,713,390,624` | `7.18 GiB` | `58,032,508,960` bytes (`54.04 GiB`) | `16,072,327,712` bytes (`14.97 GiB`) |

XLA dump scan: 90 files scanned; zero occurrences of `bf16[64,32768,1024]` or `f32[64,32768,1024]`. Remaining `chlo` hits were unrelated `chlo.erf` composites.

</details>

<details>
<summary>CoreWeave canary details</summary>

GitHub Actions run: https://github.com/marin-community/marin/actions/runs/25289088043

- Workflow/job: `Marin - CoreWeave GPU Canary Ferry` / `canary-ferry-cw` (`74137978161`)
- Ref/SHA: `codex/20260501-ragged-dot-triton-bwd` / `4fde15c7a9ae628668fdecff9b71d273779ec790`
- Iris parent job: `/runner/iris-run-job-20260503-195208`
- Iris H100 child job: `/runner/iris-run-job-20260503-195208/grug-train-canary-gpu-25289088043-1`
- W&B run: https://wandb.ai/marin-community/marin/runs/canary-gpu-25289088043-1

`validate_canary_metrics.py` reported `PASSED: All metrics within thresholds.`

</details>

<details>
<summary>Local checks and source pointers</summary>

Local validation:

- `uv run --package marin-haliax --with pytest-timeout pytest -q lib/haliax/tests/test_ragged_dot_dispatch.py lib/haliax/tests/test_moe_linear.py` -> `7 passed, 1 skipped`
- `uv run --package marin-levanter --with pytest-timeout --with pytest-xdist pytest -q lib/levanter/tests/grug/test_grugformer_moe.py` -> `8 passed, 3 skipped`
- `./infra/pre-commit.py --fix lib/haliax/src/haliax/nn/ragged_dot.py lib/haliax/tests/test_ragged_dot_dispatch.py` -> passed
- After cleanup/source-pointer edit: Haliax targeted tests again -> `7 passed, 1 skipped`; pre-commit again -> passed

The Triton layout and backward dispatch are adapted from OpenXLA Tokamax at `openxla/tokamax@ad75b704`:

- Default ragged-dot kernel/call: https://github.com/openxla/tokamax/blob/ad75b704b1aaf8702c5b6206844479da085ea619/tokamax/_src/ops/ragged_dot/pallas_triton.py#L57-L240
- Ragged-contracting-dimension kernel/call used for `drhs`: https://github.com/openxla/tokamax/blob/ad75b704b1aaf8702c5b6206844479da085ea619/tokamax/_src/ops/ragged_dot/pallas_triton.py#L242-L339
- VJP layout dispatch, including transposed RHS handling: https://github.com/openxla/tokamax/blob/ad75b704b1aaf8702c5b6206844479da085ea619/tokamax/_src/ops/ragged_dot/pallas_triton.py#L341-L426

</details>