### PR TITLE
[codex] Add Iris inference routing MVP

### DIFF
--- a/lib/marin/src/marin/inference/iris_service.py
+++ b/lib/marin/src/marin/inference/iris_service.py
@@ -1,0 +1,599 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import threading
+import time
+import uuid
+from collections.abc import Callable, Iterator
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass, field
+from enum import StrEnum
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from types import TracebackType
+from typing import cast
+
+import requests
+from fray.actor import ActorFuture, ActorGroup, ActorHandle, current_actor
+from fray.client import Client
+from fray.types import ResourceConfig
+
+from marin.inference.types import ModelDeployment, OpenAIEndpoint, RunningModel
+
+logger = logging.getLogger(__name__)
+
+MARIN_REQUEST_ID_HEADER = "X-Marin-Inference-Request-Id"
+JSON_CONTENT_TYPE = "application/json"
+DEFAULT_LEASE_TIMEOUT = 30.0
+DEFAULT_REQUEST_TIMEOUT = 300.0
+DEFAULT_WORKER_LEASE_WAIT_TIMEOUT = 1.0
+DEFAULT_WORKER_READY_TIMEOUT = 900.0
+DEFAULT_CLEANUP_TIMEOUT = 10.0
+
+
+class OpenAIEndpointKind(StrEnum):
+    """OpenAI-compatible endpoint routed by the Iris inference proxy."""
+
+    COMPLETIONS = "completions"
+    CHAT_COMPLETIONS = "chat_completions"
+
+    @property
+    def http_path(self) -> str:
+        match self:
+            case OpenAIEndpointKind.COMPLETIONS:
+                return "/v1/completions"
+            case OpenAIEndpointKind.CHAT_COMPLETIONS:
+                return "/v1/chat/completions"
+
+    @property
+    def api_path(self) -> str:
+        match self:
+            case OpenAIEndpointKind.COMPLETIONS:
+                return "completions"
+            case OpenAIEndpointKind.CHAT_COMPLETIONS:
+                return "chat/completions"
+
+    @staticmethod
+    def from_http_path(path: str) -> OpenAIEndpointKind | None:
+        if path == OpenAIEndpointKind.COMPLETIONS.http_path:
+            return OpenAIEndpointKind.COMPLETIONS
+        if path == OpenAIEndpointKind.CHAT_COMPLETIONS.http_path:
+            return OpenAIEndpointKind.CHAT_COMPLETIONS
+        return None
+
+
+@dataclass(frozen=True)
+class OpenAIHttpRequestEnvelope:
+    """Opaque OpenAI-compatible HTTP request body plus logical request identity."""
+
+    request_id: str
+    endpoint: OpenAIEndpointKind
+    payload_json: str
+
+
+@dataclass(frozen=True)
+class OpenAIHttpResponseEnvelope:
+    """Opaque OpenAI-compatible HTTP response body returned through the broker."""
+
+    status_code: int
+    payload_json: str
+    content_type: str = JSON_CONTENT_TYPE
+
+
+@dataclass(frozen=True)
+class InferenceLease:
+    """A broker lease for one request."""
+
+    lease_id: str
+    worker_id: str
+    request: OpenAIHttpRequestEnvelope
+    expires_at: float
+
+
+@dataclass(frozen=True)
+class LeaseResult:
+    """Lease RPC result.
+
+    ``lease=None`` means no work was available before the lease call timed out.
+    ``stopped=True`` means the broker is shutting down and workers should exit.
+    """
+
+    lease: InferenceLease | None
+    stopped: bool = False
+
+
+class BrokerRequestStatus(StrEnum):
+    """Broker-visible request lifecycle."""
+
+    PENDING = "pending"
+    LEASED = "leased"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+    @property
+    def terminal(self) -> bool:
+        return self in {BrokerRequestStatus.SUCCEEDED, BrokerRequestStatus.FAILED}
+
+
+@dataclass
+class _BrokerEntry:
+    request: OpenAIHttpRequestEnvelope
+    status: BrokerRequestStatus = BrokerRequestStatus.PENDING
+    response: OpenAIHttpResponseEnvelope | None = None
+    lease_id: str | None = None
+    worker_id: str | None = None
+    lease_expires_at: float | None = None
+
+
+class IrisInferenceBroker:
+    """In-memory request broker for one eval-scoped Iris inference service."""
+
+    def __init__(self, lease_timeout: float = DEFAULT_LEASE_TIMEOUT, now: Callable[[], float] = time.monotonic) -> None:
+        if lease_timeout <= 0:
+            raise ValueError("lease_timeout must be positive.")
+        self._lease_timeout = lease_timeout
+        self._now = now
+        self._lock = threading.RLock()
+        self._condition = threading.Condition(self._lock)
+        self._entries: dict[str, _BrokerEntry] = {}
+        self._stopped = False
+
+    def submit(self, request: OpenAIHttpRequestEnvelope) -> bool:
+        """Submit a logical request.
+
+        Returns True for a new request and False when the same request was
+        already known. Re-submitting a known request id with different contents
+        is rejected because it would break replay dedupe.
+        """
+        with self._condition:
+            if self._stopped:
+                raise RuntimeError("IrisInferenceBroker is stopped.")
+
+            existing = self._entries.get(request.request_id)
+            if existing is not None:
+                if existing.request != request:
+                    raise ValueError(f"request_id {request.request_id!r} was already submitted with different data.")
+                return False
+
+            self._entries[request.request_id] = _BrokerEntry(request=request)
+            self._condition.notify_all()
+            return True
+
+    def lease(self, worker_id: str, wait_timeout: float | None = None) -> LeaseResult:
+        """Lease pending work, requeueing any expired leases first."""
+        if wait_timeout is not None and wait_timeout < 0:
+            raise ValueError("wait_timeout must be non-negative.")
+
+        deadline = None if wait_timeout is None else self._now() + wait_timeout
+        with self._condition:
+            while True:
+                if self._stopped:
+                    return LeaseResult(lease=None, stopped=True)
+
+                self._expire_leases_locked()
+                lease = self._next_lease_locked(worker_id)
+                if lease is not None:
+                    return LeaseResult(lease=lease)
+
+                if wait_timeout == 0:
+                    return LeaseResult(lease=None)
+
+                if deadline is None:
+                    self._condition.wait()
+                    continue
+
+                remaining = deadline - self._now()
+                if remaining <= 0:
+                    return LeaseResult(lease=None)
+                self._condition.wait(timeout=remaining)
+
+    def complete(self, request_id: str, response: OpenAIHttpResponseEnvelope) -> bool:
+        """Store a successful terminal response if no terminal result exists."""
+        return self._finish(request_id, BrokerRequestStatus.SUCCEEDED, response)
+
+    def fail(self, request_id: str, response: OpenAIHttpResponseEnvelope) -> bool:
+        """Store a failed terminal response if no terminal result exists."""
+        return self._finish(request_id, BrokerRequestStatus.FAILED, response)
+
+    def poll(self, request_id: str) -> OpenAIHttpResponseEnvelope | None:
+        """Return a terminal response if the request has one."""
+        with self._condition:
+            entry = self._entries.get(request_id)
+            if entry is None or not entry.status.terminal:
+                return None
+            return entry.response
+
+    def wait(self, request_id: str, timeout: float | None = None) -> OpenAIHttpResponseEnvelope | None:
+        """Wait for a terminal response, returning None on timeout."""
+        if timeout is not None and timeout < 0:
+            raise ValueError("timeout must be non-negative.")
+
+        deadline = None if timeout is None else self._now() + timeout
+        with self._condition:
+            while True:
+                response = self.poll(request_id)
+                if response is not None:
+                    return response
+
+                if request_id not in self._entries:
+                    return None
+
+                if timeout == 0:
+                    return None
+
+                if deadline is None:
+                    self._condition.wait()
+                    continue
+
+                remaining = deadline - self._now()
+                if remaining <= 0:
+                    return None
+                self._condition.wait(timeout=remaining)
+
+    def status(self, request_id: str) -> BrokerRequestStatus | None:
+        """Return the broker lifecycle state for a request."""
+        with self._condition:
+            entry = self._entries.get(request_id)
+            if entry is None:
+                return None
+            return entry.status
+
+    def stop(self) -> None:
+        """Wake blocked workers and stop accepting new submissions."""
+        with self._condition:
+            self._stopped = True
+            self._condition.notify_all()
+
+    def _finish(
+        self,
+        request_id: str,
+        status: BrokerRequestStatus,
+        response: OpenAIHttpResponseEnvelope,
+    ) -> bool:
+        with self._condition:
+            entry = self._entries.get(request_id)
+            if entry is None:
+                raise KeyError(f"Unknown request_id {request_id!r}.")
+            if entry.status.terminal:
+                return False
+
+            entry.status = status
+            entry.response = response
+            entry.lease_id = None
+            entry.worker_id = None
+            entry.lease_expires_at = None
+            self._condition.notify_all()
+            return True
+
+    def _expire_leases_locked(self) -> None:
+        now = self._now()
+        for entry in self._entries.values():
+            if entry.status != BrokerRequestStatus.LEASED:
+                continue
+            if entry.lease_expires_at is None or entry.lease_expires_at > now:
+                continue
+            entry.status = BrokerRequestStatus.PENDING
+            entry.lease_id = None
+            entry.worker_id = None
+            entry.lease_expires_at = None
+
+    def _next_lease_locked(self, worker_id: str) -> InferenceLease | None:
+        for entry in self._entries.values():
+            if entry.status != BrokerRequestStatus.PENDING:
+                continue
+
+            lease_id = uuid.uuid4().hex
+            expires_at = self._now() + self._lease_timeout
+            entry.status = BrokerRequestStatus.LEASED
+            entry.lease_id = lease_id
+            entry.worker_id = worker_id
+            entry.lease_expires_at = expires_at
+            return InferenceLease(
+                lease_id=lease_id,
+                worker_id=worker_id,
+                request=entry.request,
+                expires_at=expires_at,
+            )
+        return None
+
+
+class IrisInferenceWorker:
+    """Worker actor that forwards leased requests to a local OpenAI-compatible engine."""
+
+    def __init__(
+        self,
+        broker: ActorHandle,
+        engine_base_url: str,
+        *,
+        request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
+        lease_wait_timeout: float = DEFAULT_WORKER_LEASE_WAIT_TIMEOUT,
+    ) -> None:
+        if request_timeout <= 0:
+            raise ValueError("request_timeout must be positive.")
+        if lease_wait_timeout <= 0:
+            raise ValueError("lease_wait_timeout must be positive.")
+
+        self._broker = broker
+        self._engine_base_url = engine_base_url.rstrip("/")
+        self._request_timeout = request_timeout
+        self._lease_wait_timeout = lease_wait_timeout
+        self._worker_id = self._resolve_worker_id()
+
+    def run(self, max_requests: int | None = None) -> int:
+        """Process broker work until stopped or ``max_requests`` is reached."""
+        if max_requests is not None and max_requests < 0:
+            raise ValueError("max_requests must be non-negative.")
+
+        processed = 0
+        while max_requests is None or processed < max_requests:
+            result = self._broker.lease(self._worker_id, wait_timeout=self._lease_wait_timeout)
+            if result.stopped:
+                return processed
+            if result.lease is None:
+                continue
+
+            self._forward(result.lease.request)
+            processed += 1
+
+        return processed
+
+    def _forward(self, request: OpenAIHttpRequestEnvelope) -> None:
+        url = f"{self._engine_base_url}/{request.endpoint.api_path}"
+        try:
+            response = requests.post(
+                url,
+                data=request.payload_json.encode("utf-8"),
+                headers={"Content-Type": JSON_CONTENT_TYPE},
+                timeout=self._request_timeout,
+            )
+        except requests.RequestException as exc:
+            self._broker.fail(
+                request.request_id,
+                OpenAIHttpResponseEnvelope(
+                    status_code=502,
+                    payload_json=json.dumps(
+                        {
+                            "error": "engine request failed",
+                            "request_id": request.request_id,
+                            "detail": str(exc),
+                        }
+                    ),
+                ),
+            )
+            return
+
+        self._broker.complete(
+            request.request_id,
+            OpenAIHttpResponseEnvelope(
+                status_code=response.status_code,
+                payload_json=response.text,
+                content_type=response.headers.get("Content-Type", JSON_CONTENT_TYPE),
+            ),
+        )
+
+    def _resolve_worker_id(self) -> str:
+        try:
+            actor = current_actor()
+        except RuntimeError:
+            return f"worker-{uuid.uuid4().hex[:8]}"
+        return f"{actor.group_name}-{actor.index}"
+
+
+@dataclass(frozen=True)
+class RunningIrisInferenceProxy:
+    """Handle for a running local proxy."""
+
+    base_url: str
+    request_id_header: str = MARIN_REQUEST_ID_HEADER
+
+
+class _IrisInferenceProxyServer(HTTPServer):
+    broker: ActorHandle
+    request_timeout: float
+
+
+class _IrisInferenceProxyHandler(BaseHTTPRequestHandler):
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        logger.debug("Iris inference proxy: " + format, *args)
+
+    def do_POST(self) -> None:
+        endpoint = OpenAIEndpointKind.from_http_path(self.path)
+        if endpoint is None:
+            self._write_json(404, {"error": "not found"})
+            return
+
+        request_id = self.headers.get(MARIN_REQUEST_ID_HEADER) or uuid.uuid4().hex
+        request = OpenAIHttpRequestEnvelope(
+            request_id=request_id,
+            endpoint=endpoint,
+            payload_json=self._read_body(),
+        )
+
+        try:
+            self._proxy_server.broker.submit(request)
+        except ValueError as exc:
+            self._write_json(409, {"error": str(exc), "request_id": request_id})
+            return
+
+        future = self._proxy_server.broker.wait.submit(request_id, self._proxy_server.request_timeout)
+        try:
+            response = future.result(timeout=self._proxy_server.request_timeout + DEFAULT_CLEANUP_TIMEOUT)
+        except TimeoutError:
+            self._write_json(504, {"error": "inference request timed out", "request_id": request_id})
+            return
+
+        if response is None:
+            self._write_json(504, {"error": "inference request timed out", "request_id": request_id})
+            return
+
+        self._write_response(response, request_id)
+
+    @property
+    def _proxy_server(self) -> _IrisInferenceProxyServer:
+        return cast(_IrisInferenceProxyServer, self.server)
+
+    def _read_body(self) -> str:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        return self.rfile.read(content_length).decode("utf-8")
+
+    def _write_json(self, status: int, payload: dict[str, object]) -> None:
+        self._write_response(
+            OpenAIHttpResponseEnvelope(status_code=status, payload_json=json.dumps(payload)),
+            request_id=str(payload.get("request_id", "")),
+        )
+
+    def _write_response(self, response: OpenAIHttpResponseEnvelope, request_id: str) -> None:
+        body = response.payload_json.encode("utf-8")
+        self.send_response(response.status_code)
+        self.send_header("Content-Type", response.content_type)
+        self.send_header("Content-Length", str(len(body)))
+        if request_id:
+            self.send_header(MARIN_REQUEST_ID_HEADER, request_id)
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@contextmanager
+def serve_iris_inference_proxy(
+    broker: ActorHandle,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 0,
+    request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
+) -> Iterator[RunningIrisInferenceProxy]:
+    """Run a local OpenAI-compatible proxy backed by a broker actor."""
+    if request_timeout <= 0:
+        raise ValueError("request_timeout must be positive.")
+
+    server = _IrisInferenceProxyServer((host, port), _IrisInferenceProxyHandler)
+    server.broker = broker
+    server.request_timeout = request_timeout
+    context = contextvars.copy_context()
+    thread = threading.Thread(target=context.run, args=(server.serve_forever,))
+    thread.start()
+    try:
+        yield RunningIrisInferenceProxy(base_url=f"http://{host}:{server.server_port}/v1")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+@dataclass(frozen=True)
+class IrisInferenceLauncherConfig:
+    """Launcher wiring for broker, proxy, and workers.
+
+    The engine itself is deliberately external. Each worker forwards to
+    ``engine_base_url`` from the worker process, so Iris deployments should
+    start the OpenAI-compatible engine beside the worker before using this
+    routing layer.
+    """
+
+    engine_base_url: str
+    worker_count: int = 1
+    lease_timeout: float = DEFAULT_LEASE_TIMEOUT
+    request_timeout: float = DEFAULT_REQUEST_TIMEOUT
+    worker_lease_wait_timeout: float = DEFAULT_WORKER_LEASE_WAIT_TIMEOUT
+    worker_ready_timeout: float = DEFAULT_WORKER_READY_TIMEOUT
+    proxy_host: str = "127.0.0.1"
+    proxy_port: int = 0
+    service_name: str | None = None
+    broker_resources: ResourceConfig = field(
+        default_factory=lambda: ResourceConfig.with_cpu(cpu=0, ram="512m", disk="1g", preemptible=False)
+    )
+    worker_resources: ResourceConfig = field(default_factory=lambda: ResourceConfig.with_cpu(cpu=1, ram="1g"))
+
+    def __post_init__(self) -> None:
+        if self.worker_count <= 0:
+            raise ValueError("worker_count must be positive.")
+        if self.lease_timeout <= 0:
+            raise ValueError("lease_timeout must be positive.")
+        if self.request_timeout <= 0:
+            raise ValueError("request_timeout must be positive.")
+        if self.worker_lease_wait_timeout <= 0:
+            raise ValueError("worker_lease_wait_timeout must be positive.")
+        if self.worker_ready_timeout <= 0:
+            raise ValueError("worker_ready_timeout must be positive.")
+
+
+@dataclass(frozen=True)
+class IrisInferenceLauncher:
+    """ModelLauncher-compatible MVP for Iris inference routing."""
+
+    client: Client
+    config: IrisInferenceLauncherConfig
+
+    def launch(self, deployment: ModelDeployment) -> AbstractContextManager[RunningModel]:
+        """Launch broker, proxy, and workers around an already-running engine."""
+        return _IrisInferenceServiceContext(self.client, self.config, deployment)
+
+
+class _IrisInferenceServiceContext(AbstractContextManager[RunningModel]):
+    def __init__(self, client: Client, config: IrisInferenceLauncherConfig, deployment: ModelDeployment) -> None:
+        self._client = client
+        self._config = config
+        self._deployment = deployment
+        self._broker: ActorHandle | None = None
+        self._worker_group: ActorGroup | None = None
+        self._worker_futures: list[ActorFuture] = []
+        self._proxy_context: AbstractContextManager[RunningIrisInferenceProxy] | None = None
+
+    def __enter__(self) -> RunningModel:
+        service_name = self._config.service_name or f"iris-inference-{uuid.uuid4().hex[:8]}"
+        self._broker = self._client.create_actor(
+            IrisInferenceBroker,
+            self._config.lease_timeout,
+            name=f"{service_name}-broker",
+            resources=self._config.broker_resources,
+        )
+        self._worker_group = self._client.create_actor_group(
+            IrisInferenceWorker,
+            self._broker,
+            self._config.engine_base_url,
+            name=f"{service_name}-workers",
+            count=self._config.worker_count,
+            resources=self._config.worker_resources,
+            request_timeout=self._config.request_timeout,
+            lease_wait_timeout=self._config.worker_lease_wait_timeout,
+        )
+        workers = self._worker_group.wait_ready(timeout=self._config.worker_ready_timeout)
+        self._worker_futures = [worker.run.submit(max_requests=None) for worker in workers]
+
+        self._proxy_context = serve_iris_inference_proxy(
+            self._broker,
+            host=self._config.proxy_host,
+            port=self._config.proxy_port,
+            request_timeout=self._config.request_timeout,
+        )
+        proxy = self._proxy_context.__enter__()
+        return RunningModel(
+            endpoint=OpenAIEndpoint(base_url=proxy.base_url, model=self._deployment.model_name),
+            tokenizer=self._deployment.tokenizer,
+        )
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        if self._proxy_context is not None:
+            self._proxy_context.__exit__(exc_type, exc_value, traceback)
+            self._proxy_context = None
+
+        if self._broker is not None:
+            self._broker.stop.remote().result(timeout=DEFAULT_CLEANUP_TIMEOUT)
+
+        for future in self._worker_futures:
+            future.result(timeout=DEFAULT_CLEANUP_TIMEOUT)
+        self._worker_futures = []
+
+        if self._worker_group is not None:
+            self._worker_group.shutdown()
+            self._worker_group = None
+
+        return None

--- a/lib/marin/src/marin/inference/iris_service.py
+++ b/lib/marin/src/marin/inference/iris_service.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import contextvars
 import json
 import logging
+import re
 import threading
 import time
 import uuid
@@ -28,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 MARIN_REQUEST_ID_HEADER = "X-Marin-Inference-Request-Id"
 JSON_CONTENT_TYPE = "application/json"
+REQUEST_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
 DEFAULT_LEASE_TIMEOUT = 30.0
 DEFAULT_REQUEST_TIMEOUT = 300.0
 DEFAULT_WORKER_LEASE_WAIT_TIMEOUT = 1.0
@@ -409,7 +411,12 @@ class _IrisInferenceProxyHandler(BaseHTTPRequestHandler):
             self._write_json(404, {"error": "not found"})
             return
 
-        request_id = self.headers.get(MARIN_REQUEST_ID_HEADER) or uuid.uuid4().hex
+        try:
+            request_id = self._request_id()
+        except ValueError as exc:
+            self._write_json(400, {"error": str(exc)})
+            return
+
         request = OpenAIHttpRequestEnvelope(
             request_id=request_id,
             endpoint=endpoint,
@@ -445,6 +452,14 @@ class _IrisInferenceProxyHandler(BaseHTTPRequestHandler):
     def _read_body(self) -> str:
         content_length = int(self.headers.get("Content-Length", "0"))
         return self.rfile.read(content_length).decode("utf-8")
+
+    def _request_id(self) -> str:
+        request_id = self.headers.get(MARIN_REQUEST_ID_HEADER)
+        if request_id is None:
+            return uuid.uuid4().hex
+        if REQUEST_ID_PATTERN.fullmatch(request_id) is None:
+            raise ValueError(f"{MARIN_REQUEST_ID_HEADER} must match {REQUEST_ID_PATTERN.pattern}.")
+        return request_id
 
     def _write_json(self, status: int, payload: dict[str, object]) -> None:
         self._write_response(

--- a/lib/marin/src/marin/inference/iris_service.py
+++ b/lib/marin/src/marin/inference/iris_service.py
@@ -219,6 +219,9 @@ class IrisInferenceBroker:
                 if response is not None:
                     return response
 
+                if self._stopped:
+                    return None
+
                 if request_id not in self._entries:
                     return None
 
@@ -418,6 +421,9 @@ class _IrisInferenceProxyHandler(BaseHTTPRequestHandler):
         except ValueError as exc:
             self._write_json(409, {"error": str(exc), "request_id": request_id})
             return
+        except RuntimeError as exc:
+            self._write_json(503, {"error": str(exc), "request_id": request_id})
+            return
 
         future = self._proxy_server.broker.wait.submit(request_id, self._proxy_server.request_timeout)
         try:
@@ -543,37 +549,41 @@ class _IrisInferenceServiceContext(AbstractContextManager[RunningModel]):
         self._proxy_context: AbstractContextManager[RunningIrisInferenceProxy] | None = None
 
     def __enter__(self) -> RunningModel:
-        service_name = self._config.service_name or f"iris-inference-{uuid.uuid4().hex[:8]}"
-        self._broker = self._client.create_actor(
-            IrisInferenceBroker,
-            self._config.lease_timeout,
-            name=f"{service_name}-broker",
-            resources=self._config.broker_resources,
-        )
-        self._worker_group = self._client.create_actor_group(
-            IrisInferenceWorker,
-            self._broker,
-            self._config.engine_base_url,
-            name=f"{service_name}-workers",
-            count=self._config.worker_count,
-            resources=self._config.worker_resources,
-            request_timeout=self._config.request_timeout,
-            lease_wait_timeout=self._config.worker_lease_wait_timeout,
-        )
-        workers = self._worker_group.wait_ready(timeout=self._config.worker_ready_timeout)
-        self._worker_futures = [worker.run.submit(max_requests=None) for worker in workers]
+        try:
+            service_name = self._config.service_name or f"iris-inference-{uuid.uuid4().hex[:8]}"
+            self._broker = self._client.create_actor(
+                IrisInferenceBroker,
+                self._config.lease_timeout,
+                name=f"{service_name}-broker",
+                resources=self._config.broker_resources,
+            )
+            self._worker_group = self._client.create_actor_group(
+                IrisInferenceWorker,
+                self._broker,
+                self._config.engine_base_url,
+                name=f"{service_name}-workers",
+                count=self._config.worker_count,
+                resources=self._config.worker_resources,
+                request_timeout=self._config.request_timeout,
+                lease_wait_timeout=self._config.worker_lease_wait_timeout,
+            )
+            workers = self._worker_group.wait_ready(timeout=self._config.worker_ready_timeout)
+            self._worker_futures = [worker.run.submit(max_requests=None) for worker in workers]
 
-        self._proxy_context = serve_iris_inference_proxy(
-            self._broker,
-            host=self._config.proxy_host,
-            port=self._config.proxy_port,
-            request_timeout=self._config.request_timeout,
-        )
-        proxy = self._proxy_context.__enter__()
-        return RunningModel(
-            endpoint=OpenAIEndpoint(base_url=proxy.base_url, model=self._deployment.model_name),
-            tokenizer=self._deployment.tokenizer,
-        )
+            self._proxy_context = serve_iris_inference_proxy(
+                self._broker,
+                host=self._config.proxy_host,
+                port=self._config.proxy_port,
+                request_timeout=self._config.request_timeout,
+            )
+            proxy = self._proxy_context.__enter__()
+            return RunningModel(
+                endpoint=OpenAIEndpoint(base_url=proxy.base_url, model=self._deployment.model_name),
+                tokenizer=self._deployment.tokenizer,
+            )
+        except BaseException as exc:
+            self.__exit__(type(exc), exc, exc.__traceback__)
+            raise
 
     def __exit__(
         self,
@@ -581,19 +591,23 @@ class _IrisInferenceServiceContext(AbstractContextManager[RunningModel]):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> bool | None:
-        if self._proxy_context is not None:
-            self._proxy_context.__exit__(exc_type, exc_value, traceback)
-            self._proxy_context = None
+        try:
+            if self._proxy_context is not None:
+                self._proxy_context.__exit__(exc_type, exc_value, traceback)
+                self._proxy_context = None
 
-        if self._broker is not None:
-            self._broker.stop.remote().result(timeout=DEFAULT_CLEANUP_TIMEOUT)
+            if self._broker is not None:
+                self._broker.stop.remote().result(timeout=DEFAULT_CLEANUP_TIMEOUT)
 
-        for future in self._worker_futures:
-            future.result(timeout=DEFAULT_CLEANUP_TIMEOUT)
-        self._worker_futures = []
+            for future in self._worker_futures:
+                future.result(timeout=DEFAULT_CLEANUP_TIMEOUT)
+        finally:
+            self._worker_futures = []
 
-        if self._worker_group is not None:
-            self._worker_group.shutdown()
-            self._worker_group = None
+            if self._worker_group is not None:
+                self._worker_group.shutdown()
+                self._worker_group = None
+
+            self._broker = None
 
         return None

--- a/scripts/iris/run_inference_service_smoke.py
+++ b/scripts/iris/run_inference_service_smoke.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Manual smoke for the Iris inference routing MVP.
+
+This script intentionally does not launch vLLM or Levanter. Start an
+OpenAI-compatible engine separately on each worker, then point this smoke at
+the engine's worker-local API root, for example http://127.0.0.1:8000/v1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from dataclasses import dataclass
+
+from fray.client import Client
+from fray.local_backend import LocalClient
+from marin.evaluation.lm_eval import LmEvalAdapter, LmEvalRun, run_lm_eval
+from marin.inference.iris_service import IrisInferenceLauncher, IrisInferenceLauncherConfig
+from marin.inference.types import ModelDeployment
+
+
+@dataclass(frozen=True)
+class SmokeArgs:
+    engine_base_url: str
+    model: str
+    task: str
+    output_path: str
+    tokenizer: str | None
+    controller_url: str | None
+    workspace: str | None
+    service_name: str
+    worker_count: int
+    request_timeout: float
+    apply_chat_template: bool
+    limit: int | None
+    num_fewshot: int | None
+    dry_run: bool
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.dry_run:
+        _print_dry_run(args)
+        return
+
+    if args.controller_url is None:
+        client = LocalClient()
+        try:
+            _run_smoke(client, args)
+        finally:
+            client.shutdown(wait=True)
+        return
+
+    _run_iris_smoke(args)
+
+
+def _run_smoke(client: Client, args: SmokeArgs) -> None:
+    deployment = ModelDeployment(
+        model_name=args.model,
+        model_path=args.model,
+        tokenizer=args.tokenizer,
+    )
+    launcher = IrisInferenceLauncher(
+        client=client,
+        config=IrisInferenceLauncherConfig(
+            engine_base_url=args.engine_base_url,
+            worker_count=args.worker_count,
+            request_timeout=args.request_timeout,
+            service_name=args.service_name,
+        ),
+    )
+    adapter = LmEvalAdapter.LOCAL_CHAT_COMPLETIONS if args.apply_chat_template else LmEvalAdapter.LOCAL_COMPLETIONS
+    with launcher.launch(deployment) as running_model:
+        run_lm_eval(
+            running_model,
+            LmEvalRun(
+                tasks=[args.task],
+                output_path=args.output_path,
+                adapter=adapter,
+                apply_chat_template=args.apply_chat_template,
+                limit=args.limit,
+                num_fewshot=args.num_fewshot,
+                batch_size=1,
+                extra_model_args={
+                    "tokenizer_backend": "huggingface",
+                    "tokenized_requests": False,
+                    "timeout": int(args.request_timeout),
+                    "max_retries": 1,
+                },
+            ),
+        )
+
+
+def _run_iris_smoke(args: SmokeArgs) -> None:
+    from fray.iris_backend import FrayIrisClient
+    from iris.client.client import IrisClient, IrisContext, iris_ctx_scope
+    from iris.cluster.types import Entrypoint, ResourceSpec
+
+    iris_client = IrisClient.remote(args.controller_url, workspace=args.workspace)
+    client = FrayIrisClient.from_iris_client(iris_client)
+    parent_job = iris_client.submit(
+        entrypoint=Entrypoint.from_callable(_hold_parent_job),
+        name=f"{args.service_name}-launcher",
+        resources=ResourceSpec(cpu=1, memory="1g", disk="4g"),
+    )
+    try:
+        with iris_ctx_scope(IrisContext(job_id=parent_job.job_id, client=iris_client)):
+            _run_smoke(client, args)
+    finally:
+        iris_client.terminate(parent_job.job_id)
+        client.shutdown(wait=True)
+
+
+def _hold_parent_job() -> None:
+    while True:
+        time.sleep(3600)
+
+
+def _parse_args() -> SmokeArgs:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--engine-base-url", required=True, help="OpenAI API root visible from workers, ending in /v1.")
+    parser.add_argument("--model", required=True, help="Model id passed through to lm-eval and the engine.")
+    parser.add_argument("--task", default="mmlu_sl_verb_5shot", help="lm-eval task to run.")
+    parser.add_argument("--output-path", default="/tmp/marin-iris-inference-smoke")
+    parser.add_argument("--tokenizer", help="Hugging Face tokenizer id/path for lm-eval.")
+    parser.add_argument("--controller-url", help="Iris controller URL. Omit to run through LocalClient.")
+    parser.add_argument("--workspace", help="Workspace path for IrisClient.remote().")
+    parser.add_argument("--service-name", default="iris-inference-smoke")
+    parser.add_argument("--worker-count", type=int, default=1)
+    parser.add_argument("--request-timeout", type=float, default=300.0)
+    parser.add_argument("--apply-chat-template", action="store_true")
+    parser.add_argument("--limit", type=int, default=1)
+    parser.add_argument("--num-fewshot", type=int)
+    parser.add_argument("--dry-run", action="store_true")
+    parsed = parser.parse_args()
+    return SmokeArgs(**vars(parsed))
+
+
+def _print_dry_run(args: SmokeArgs) -> None:
+    backend = "FrayIrisClient" if args.controller_url is not None else "LocalClient"
+    adapter = "local-chat-completions" if args.apply_chat_template else "local-completions"
+    print(f"backend={backend}")
+    print(f"engine_base_url={args.engine_base_url}")
+    print(f"model={args.model}")
+    print(f"task={args.task}")
+    print(f"adapter={adapter}")
+    print(f"worker_count={args.worker_count}")
+    print("engine launch is external to this smoke; workers must reach the engine URL directly")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/evals/test_iris_inference_service.py
+++ b/tests/evals/test_iris_inference_service.py
@@ -9,9 +9,11 @@ from pathlib import Path
 from statistics import mean
 
 import pytest
+import requests
 from fray.local_backend import LocalClient
 from marin.evaluation.lm_eval import LmEvalRun, build_lm_eval_model_args
 from marin.inference.iris_service import (
+    MARIN_REQUEST_ID_HEADER,
     BrokerRequestStatus,
     IrisInferenceBroker,
     IrisInferenceLauncher,
@@ -115,6 +117,25 @@ def test_proxy_worker_end_to_end_routes_completions_and_chat_to_engine() -> None
 
             assert len(stub.requests_for("/v1/completions")) == 1
             assert len(stub.requests_for("/v1/chat/completions")) == 1
+    finally:
+        client.shutdown(wait=True)
+
+
+def test_proxy_rejects_unsafe_request_id_header() -> None:
+    client = LocalClient()
+    try:
+        with serve_deterministic_openai_stub(model="gpt2") as stub:
+            with _launch_local_service(client, stub) as running_model:
+                response = requests.post(
+                    running_model.endpoint.url("completions"),
+                    json={"model": stub.model, "prompt": "A"},
+                    headers={MARIN_REQUEST_ID_HEADER: "unsafe/request/id"},
+                    timeout=5,
+                )
+
+            assert response.status_code == 400
+            assert MARIN_REQUEST_ID_HEADER not in response.headers
+            assert stub.requests_for("/v1/completions") == []
     finally:
         client.shutdown(wait=True)
 

--- a/tests/evals/test_iris_inference_service.py
+++ b/tests/evals/test_iris_inference_service.py
@@ -1,0 +1,249 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import mean
+
+import pytest
+from fray.local_backend import LocalClient
+from marin.evaluation.lm_eval import LmEvalRun, build_lm_eval_model_args
+from marin.inference.iris_service import (
+    BrokerRequestStatus,
+    IrisInferenceBroker,
+    IrisInferenceLauncher,
+    IrisInferenceLauncherConfig,
+    OpenAIEndpointKind,
+    OpenAIHttpRequestEnvelope,
+    OpenAIHttpResponseEnvelope,
+)
+from marin.inference.types import ModelDeployment, RunningModel
+
+from tests.evals.openai_stub import (
+    DeterministicOpenAIStub,
+    assert_chat_generation_contract,
+    assert_completions_scoring_contract,
+    serve_deterministic_openai_stub,
+)
+
+
+@dataclass
+class ManualClock:
+    now: float = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, amount: float) -> None:
+        self.now += amount
+
+
+def _completion_request(request_id: str = "request-1") -> OpenAIHttpRequestEnvelope:
+    return OpenAIHttpRequestEnvelope(
+        request_id=request_id,
+        endpoint=OpenAIEndpointKind.COMPLETIONS,
+        payload_json='{"model":"gpt2","prompt":"A B","echo":true,"logprobs":1}',
+    )
+
+
+def _response(text: str = "ok") -> OpenAIHttpResponseEnvelope:
+    return OpenAIHttpResponseEnvelope(status_code=200, payload_json=f'{{"result":"{text}"}}')
+
+
+def test_broker_submit_lease_complete_wait_returns_exact_response() -> None:
+    clock = ManualClock()
+    broker = IrisInferenceBroker(lease_timeout=10.0, now=clock)
+    request = _completion_request()
+    response = _response()
+
+    assert broker.submit(request) is True
+    lease = broker.lease("worker-1", wait_timeout=0).lease
+    assert lease is not None
+    assert lease.request == request
+    assert broker.status(request.request_id) == BrokerRequestStatus.LEASED
+
+    assert broker.complete(request.request_id, response) is True
+    assert broker.wait(request.request_id, timeout=0) == response
+    assert broker.poll(request.request_id) == response
+    assert broker.status(request.request_id) == BrokerRequestStatus.SUCCEEDED
+
+
+def test_broker_releases_expired_work_again() -> None:
+    clock = ManualClock()
+    broker = IrisInferenceBroker(lease_timeout=5.0, now=clock)
+    request = _completion_request()
+
+    broker.submit(request)
+    first = broker.lease("worker-1", wait_timeout=0).lease
+    assert first is not None
+    assert broker.lease("worker-2", wait_timeout=0).lease is None
+
+    clock.advance(5.1)
+    second = broker.lease("worker-2", wait_timeout=0).lease
+    assert second is not None
+    assert second.request == request
+    assert second.lease_id != first.lease_id
+    assert second.worker_id == "worker-2"
+
+
+def test_broker_duplicate_terminal_result_keeps_first_response() -> None:
+    clock = ManualClock()
+    broker = IrisInferenceBroker(lease_timeout=10.0, now=clock)
+    request = _completion_request()
+    first = _response("first")
+    duplicate = _response("duplicate")
+
+    broker.submit(request)
+    assert broker.lease("worker-1", wait_timeout=0).lease is not None
+
+    assert broker.complete(request.request_id, first) is True
+    assert broker.fail(request.request_id, duplicate) is False
+    assert broker.complete(request.request_id, duplicate) is False
+    assert broker.wait(request.request_id, timeout=0) == first
+
+
+def test_proxy_worker_end_to_end_routes_completions_and_chat_to_engine() -> None:
+    client = LocalClient()
+    try:
+        with serve_deterministic_openai_stub(model="gpt2") as stub:
+            with _launch_local_service(client, stub) as running_model:
+                assert_completions_scoring_contract(running_model.endpoint.base_url, stub.model)
+                assert_chat_generation_contract(running_model.endpoint.base_url, stub.model)
+
+            assert len(stub.requests_for("/v1/completions")) == 1
+            assert len(stub.requests_for("/v1/chat/completions")) == 1
+    finally:
+        client.shutdown(wait=True)
+
+
+def test_real_lm_eval_local_completions_scoring_through_proxy_worker(
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("torch")
+    pytest.importorskip("tiktoken")
+    pytest.importorskip("lm_eval")
+
+    from lm_eval.api.instance import Instance
+    from lm_eval.api.task import Task, TaskConfig
+    from lm_eval.evaluator import simple_evaluate
+    from lm_eval.loggers import EvaluationTracker
+
+    class TinyScoringTask(Task):
+        OUTPUT_TYPE = "loglikelihood"
+
+        def __init__(self) -> None:
+            super().__init__()
+            self._config = TaskConfig(
+                task="marin_tiny_scoring",
+                output_type="loglikelihood",
+                num_fewshot=0,
+                repeats=1,
+            )
+            self.task_name = "marin_tiny_scoring"
+
+        def download(self, data_dir=None, cache_dir=None, download_mode=None) -> None:
+            self.dataset = {"test": [{"ctx": "A", "target": " B"}]}
+
+        def has_training_docs(self) -> bool:
+            return False
+
+        def has_validation_docs(self) -> bool:
+            return False
+
+        def has_test_docs(self) -> bool:
+            return True
+
+        def test_docs(self) -> list[dict[str, str]]:
+            return self.dataset["test"]
+
+        def doc_to_text(self, doc: dict[str, str]) -> str:
+            return doc["ctx"]
+
+        def doc_to_target(self, doc: dict[str, str]) -> str:
+            return doc["target"]
+
+        def construct_requests(self, doc: dict[str, str], ctx: str, **kwargs: object) -> Instance:
+            return Instance(
+                request_type="loglikelihood",
+                doc=doc,
+                arguments=(ctx, self.doc_to_target(doc)),
+                idx=0,
+                metadata=kwargs["metadata"],
+            )
+
+        def process_results(self, doc: dict[str, str], results: list[tuple[float, bool]]) -> dict[str, float]:
+            loglikelihood, is_greedy = results[0]
+            return {"loglikelihood": loglikelihood, "greedy": float(is_greedy)}
+
+        def aggregation(self) -> dict[str, object]:
+            return {"loglikelihood": mean, "greedy": mean}
+
+        def higher_is_better(self) -> dict[str, bool]:
+            return {"loglikelihood": True, "greedy": True}
+
+    client = LocalClient()
+    try:
+        with serve_deterministic_openai_stub(model="gpt2") as stub:
+            with _launch_local_service(client, stub) as running_model:
+                run = LmEvalRun(
+                    tasks=["marin_tiny_scoring"],
+                    output_path=str(tmp_path / "lm_eval_results"),
+                    extra_model_args={
+                        "tokenizer_backend": "tiktoken",
+                        "tokenized_requests": False,
+                        "max_retries": 1,
+                        "timeout": 5,
+                    },
+                )
+                evaluation_tracker = EvaluationTracker(output_path=run.output_path)
+                results = simple_evaluate(
+                    model="local-completions",
+                    tasks=[TinyScoringTask()],
+                    model_args=build_lm_eval_model_args(running_model, run),
+                    batch_size=1,
+                    bootstrap_iters=0,
+                    evaluation_tracker=evaluation_tracker,
+                    log_samples=True,
+                    random_seed=0,
+                    numpy_random_seed=0,
+                    torch_random_seed=0,
+                    fewshot_random_seed=0,
+                )
+
+            assert results is not None
+            samples = results.pop("samples")
+            evaluation_tracker.save_results_aggregated(results=results, samples=samples)
+            for task_name in results["configs"].keys():
+                evaluation_tracker.save_results_samples(task_name=task_name, samples=samples[task_name])
+
+            completion_requests = stub.requests_for("/v1/completions")
+            assert len(completion_requests) == 1
+            assert completion_requests[0].payload == {
+                "model": "gpt2",
+                "prompt": "A B",
+                "temperature": 0,
+                "max_tokens": 1,
+                "logprobs": 1,
+                "seed": 1234,
+                "echo": True,
+            }
+            assert results["results"]["marin_tiny_scoring"]["loglikelihood,none"] == pytest.approx(-0.1)
+            assert results["results"]["marin_tiny_scoring"]["greedy,none"] == 1.0
+    finally:
+        client.shutdown(wait=True)
+
+
+def _launch_local_service(client: LocalClient, stub: DeterministicOpenAIStub) -> AbstractContextManager[RunningModel]:
+    deployment = ModelDeployment(model_name=stub.model, model_path="deterministic-openai-stub")
+    launcher = IrisInferenceLauncher(
+        client=client,
+        config=IrisInferenceLauncherConfig(
+            engine_base_url=stub.base_url,
+            request_timeout=5.0,
+            worker_lease_wait_timeout=0.05,
+        ),
+    )
+    return launcher.launch(deployment)


### PR DESCRIPTION
## Summary

This is a prototype/MVP for Iris inference routing. The point is to exercise the shape where eval code talks to the existing `RunningModel` / OpenAI-compatible endpoint abstraction, while model/backend instantiation stays behind launcher and worker wiring.

The important boundary is: the eval runner does not know whether the model is backed by Levanter, vLLM, or a deterministic local stub. It only sees an OpenAI API root and model name.

## What Changed

- Added typed opaque OpenAI HTTP request/response envelopes.
- Added an in-memory broker actor with submit, lease, complete/fail, poll/wait, lease expiry, idempotent duplicate submit, and first-terminal-result-wins behavior.
- Added a local OpenAI-compatible proxy for `/v1/completions` and `/v1/chat/completions`.
- Added a worker actor that leases broker work and forwards it to an already-running OpenAI-compatible engine URL.
- Added a `ModelLauncher`-compatible helper that returns the existing `RunningModel` abstraction.
- Added a manual smoke wrapper for `LocalClient` or `FrayIrisClient` wiring, with engine launch intentionally external.

## What Works Locally

- Broker lifecycle, lease expiry, and duplicate terminal-result behavior are covered with deterministic tests.
- Proxy + worker + broker route both completions and chat-completions through the deterministic OpenAI stub using `fray.LocalClient`.
- The proxy validates request IDs before echoing them in response headers.
- The real `lm_eval` tiny scoring path is represented as a normal CI-safe test and runs when `torch`, `tiktoken`, and `lm_eval` are installed.

## Intentional Boundaries

- No persistent broker storage.
- No server-driven streaming or cancellation semantics.
- No vLLM or Levanter engine startup inside the broker/proxy/worker contract.
- No production throughput tuning; the local proxy is single-threaded so Iris actor context is preserved cleanly in this MVP.
- No broad eval-framework migration.

## Future Work

- Run the full Iris manual milestone: `mmlu_sl_verb_5shot` and `humaneval_5shot` on the 1e22 MoE on `v5p-8`.
- Add backend launch/readiness wiring beside workers, starting with Levanter and then vLLM where feasible.
- Measure production throughput and decide whether the proxy/broker shape needs concurrency changes.
- Add durable observability and request accounting.
- Add cancellation and streaming semantics only once the non-streaming path is proven.
- Expand coverage beyond lm-eval once the OpenAI routing contract is stable.

<details>
<summary>Validation</summary>

- `uv run --package marin --group test pytest tests/evals/test_iris_inference_service.py -q` -> `5 passed, 1 skipped`.
- `uv run --package marin --group test pytest tests/evals/test_lm_eval.py tests/evals/test_served_lm_eval.py tests/evals/test_iris_inference_service.py -q` -> `9 passed, 2 skipped, 2 deselected`.
- The skipped Iris test is the real `lm_eval` path, gated on optional `torch`, `tiktoken`, and `lm_eval` dependencies.
- `./infra/pre-commit.py --all-files --fix` -> passed.
- Commit hook on all commits -> passed.

</details>