### PR TITLE
[dna] Add exp142 source-curation sweep (v31/v32/v33)

### DIFF
--- a/experiments/dna/exp142_curation_sweep.py
+++ b/experiments/dna/exp142_curation_sweep.py
@@ -32,10 +32,6 @@ Environment variables:
     SWEEP_DATASETS   CSV of dataset names to run (default: all in
                      ``TRAIN_DATASETS``). Useful for ``v31``, ``v32``, or
                      ``v33`` in isolation.
-    WARMUP_MODE      'yes'/'no' (default 'no'). When 'yes', each run is
-                     truncated to ``WARMUP_NUM_TRAIN_STEPS`` with
-                     ``WARMUP_EVALS_PER_RUN`` evals so the LR schedule and
-                     eval cadence (both derived from this) compress together.
 
 https://github.com/Open-Athena/bolinas-dna/issues/142
 """
@@ -130,10 +126,6 @@ EVALS_PER_RUN = 10
 CHECKPOINTS_PER_RUN = 3
 CHECKPOINT_TIME_INTERVAL = timedelta(hours=1)
 
-# Warmup mode (WARMUP_MODE=yes): smoke-test the full pipeline end-to-end.
-WARMUP_NUM_TRAIN_STEPS = 100
-WARMUP_EVALS_PER_RUN = 3
-
 WANDB_PROJECT = "marin"
 
 _EXPECTED_VOCAB_SIZE_WARNING = f"Tokenizer {TOKENIZER!r} not found in _KNOWN_VOCAB_SIZES"
@@ -145,13 +137,6 @@ logging.getLogger("marin.processing.tokenize.data_configs").addFilter(
 # =============================================================================
 # Environment overrides
 # =============================================================================
-
-
-def _warmup_mode() -> bool:
-    value = os.getenv("WARMUP_MODE", "no").lower()
-    if value not in ("yes", "no"):
-        raise ValueError(f"WARMUP_MODE must be 'yes' or 'no', got {value!r}")
-    return value == "yes"
 
 
 def _selected_datasets() -> dict[str, str]:
@@ -239,16 +224,9 @@ def _checkpointer(num_train_steps: int) -> CheckpointerConfig:
 
 
 def _build_train_step(strategy: str, dataset: str) -> ExecutorStep:
-    warmup = _warmup_mode()
-    num_train_steps = WARMUP_NUM_TRAIN_STEPS if warmup else NUM_TRAIN_STEPS
-    evals_per_run = WARMUP_EVALS_PER_RUN if warmup else EVALS_PER_RUN
-    steps_per_eval = max(1, num_train_steps // evals_per_run)
-
-    warmup_suffix = "-warmup" if warmup else ""
-    run_name = f"dna-bolinas-curation-sweep-{VERSION}{warmup_suffix}-{strategy}"
+    steps_per_eval = max(1, NUM_TRAIN_STEPS // EVALS_PER_RUN)
+    run_name = f"dna-bolinas-curation-sweep-{VERSION}-{strategy}"
     tags = ("dna", "exp142", "curation_sweep", VERSION, f"strategy={strategy}")
-    if warmup:
-        tags = (*tags, "warmup")
 
     inner = TrainLmConfig(
         data=_build_data_mixture(strategy, dataset),
@@ -267,9 +245,9 @@ def _build_train_step(strategy: str, dataset: str) -> ExecutorStep:
             ),
             mp=jmp.get_policy("p=f32,c=bfloat16"),
             train_batch_size=BATCH_SIZE,
-            num_train_steps=num_train_steps,
+            num_train_steps=NUM_TRAIN_STEPS,
             steps_per_eval=steps_per_eval,
-            checkpointer=_checkpointer(num_train_steps),
+            checkpointer=_checkpointer(NUM_TRAIN_STEPS),
             mesh=MeshConfig(axes={"replica": 1, "data": -1, "model": 1}),
             allow_nondivisible_batch_size=True,
         ),

--- a/experiments/dna/exp142_curation_sweep.py
+++ b/experiments/dna/exp142_curation_sweep.py
@@ -23,10 +23,10 @@ Evaluations:
 - TraitGym Mendelian v2 (255 bp) via the lm_eval harness during training.
 - LL gap = LL(functional) - LL(nonfunctional) on the v30 enhancer validation
   set, computed post-hoc from W&B as
-  ``eval/val_v30_nonfunctional/loss - eval/val_v30_functional/loss``. Note:
-  using the v30 validation set across all four arms gives v30 a
-  training-distribution match advantage on the LL gap; rely on TraitGym for
-  cross-domain confirmation (see #136 caveat).
+  ``eval/val_v30_nonfunctional/loss - eval/val_v30_functional/loss``. The val
+  set is derived from v30's filter, so v30 has a slight distribution-match
+  advantage; minor here since all four arms are projection-based enhancer
+  datasets, and TraitGym remains the cross-domain anchor.
 
 Environment variables:
     SWEEP_DATASETS   CSV of dataset names to run (default: all in

--- a/experiments/dna/exp142_curation_sweep.py
+++ b/experiments/dna/exp142_curation_sweep.py
@@ -1,0 +1,296 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Bolinas DNA source-curation sweep (projection-based enhancers).
+
+Follow-up to #136, where ``proj_v30`` (ENCODE cCRE conserved enhancers
+projected onto 20 mammals via mmseqs2) outperformed segmentation-based
+curation on TraitGym Mendelian v2 distal AUPRC. This experiment varies the
+upstream cCRE conservation filter while keeping projection method, target
+genome set (``mammals_seg20``), windowing, and downstream training recipe
+identical to v30. Together with the existing v30 baseline, it forms a 2x2
+across {conservation track} x {per-cCRE bp filter}:
+
+- v30 (baseline, already trained as ``proj_v30`` in exp136 — not re-run here):
+  phyloP-241way ≥2.27 / ≥20 bp.
+- v31: phyloP-241way ≥2.27 / ≥50 bp.
+- v32: phastCons-43p ≥0.961 / ≥20 bp.
+- v33: phastCons-43p ≥0.961 / ≥50 bp.
+
+Evaluations:
+
+- TraitGym Mendelian v2 (255 bp) via the lm_eval harness during training.
+- LL gap = LL(functional) - LL(nonfunctional) on the v30 enhancer validation
+  set, computed post-hoc from W&B as
+  ``eval/val_v30_nonfunctional/loss - eval/val_v30_functional/loss``. Note:
+  using the v30 validation set across all four arms gives v30 a
+  training-distribution match advantage on the LL gap; rely on TraitGym for
+  cross-domain confirmation (see #136 caveat).
+
+Environment variables:
+    SWEEP_DATASETS   CSV of dataset names to run (default: all in
+                     ``TRAIN_DATASETS``). Useful for ``v31``, ``v32``, or
+                     ``v33`` in isolation.
+    WARMUP_MODE      'yes'/'no' (default 'no'). When 'yes', each run is
+                     truncated to ``WARMUP_NUM_TRAIN_STEPS`` with
+                     ``WARMUP_EVALS_PER_RUN`` evals so the LR schedule and
+                     eval cadence (both derived from this) compress together.
+
+https://github.com/Open-Athena/bolinas-dna/issues/142
+"""
+
+import dataclasses
+import logging
+import os
+from datetime import timedelta
+from functools import lru_cache
+
+import jmp
+from levanter.checkpoint import CheckpointerConfig
+from levanter.data.text import DNALmDatasetFormat
+from levanter.data.text.datasets import LmDataConfig
+from levanter.eval_harness import LmEvalHarnessConfig
+from levanter.main.train_lm import TrainLmConfig
+from levanter.models.qwen import Qwen3Config
+from levanter.optim import AdamConfig
+from levanter.tracker.wandb import WandbConfig
+from levanter.trainer import TrainerConfig
+from levanter.utils.mesh import MeshConfig
+
+from experiments.defaults import default_tokenize
+from experiments.dna.defaults import dna_effective_seq_len
+from experiments.evals.task_configs import TRAITGYM_MENDELIAN_V2_255, convert_to_levanter_task_config
+from experiments.qwen3 import qwen3_0_6b_hd128
+from fray.cluster import ResourceConfig
+from marin.execution.executor import ExecutorStep, executor_main, this_output_path
+from marin.execution.remote import remote
+from marin.processing.tokenize import lm_mixture_data_config
+from marin.training.training import TrainLmOnPodConfig, run_levanter_train_lm
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+VERSION = "v0.1"
+TOKENIZER = "bolinas-dna/tokenizer-char-bos"
+DNA_BASE_SEQ_LEN = 255  # bp (256 - 1 for BOS)
+
+# Three new projection-based enhancer datasets sharing the ``mammals_seg20``
+# target genome set, varying the upstream cCRE conservation filter. v30 is
+# the already-trained baseline (the ``proj_v30`` arm of exp136) and is
+# intentionally excluded from this sweep.
+TRAIN_DATASETS = {
+    "v31": "bolinas-dna/genomes-v5-genome_set-mammals_seg20-intervals-v31_255_128",
+    "v32": "bolinas-dna/genomes-v5-genome_set-mammals_seg20-intervals-v32_255_128",
+    "v33": "bolinas-dna/genomes-v5-genome_set-mammals_seg20-intervals-v33_255_128",
+}
+
+# Single validation dataset with phyloP-derived uppercase/lowercase encoding;
+# tokenize twice (functional and nonfunctional) for the LL-gap signal.
+VALIDATION_DATASET = "bolinas-dna/genomes-v5-validation-intervals-v30_255_255"
+
+# Training masks lowercase positions to 1% loss weight (consistent across
+# Bolinas DNA experiments).
+TRAIN_FORMAT = DNALmDatasetFormat(lowercase_weight=0.01)
+
+# Validation tokenization specs — only the two terms of the LL gap; we
+# deliberately skip a "default" matched-to-training variant since it adds eval
+# cost without informing the strategy comparison.
+VAL_SPECS: tuple[tuple[str, DNALmDatasetFormat], ...] = (
+    ("functional", DNALmDatasetFormat(uppercase_weight=1.0, lowercase_weight=0.0)),
+    ("nonfunctional", DNALmDatasetFormat(uppercase_weight=0.0, lowercase_weight=1.0)),
+)
+
+# Architecture: ~0.6B Qwen3 (h=1024, L=28, head_dim=128) — imported from
+# the canonical preset so this file picks up any upstream changes
+# automatically; max_seq_len is overridden to the DNA context size below.
+
+BATCH_SIZE = 4096
+TPU_TYPES: tuple[str, ...] = ("v5p-8",)
+
+# Optimizer (AdamConfig defaults; schedule shape from exp_bolinas_4b_sweep.py).
+LEARNING_RATE = 1e-3
+WEIGHT_DECAY = 0.1
+BETA1 = 0.9
+BETA2 = 0.95
+EPSILON = 1e-8
+MAX_GRAD_NORM = 1.0
+WARMUP_FRACTION = 0.1
+DECAY_FRACTION = 0.2
+LR_SCHEDULE = "linear"
+MIN_LR_RATIO = 0.0
+
+# Training horizon. Matches the #136 reference scale (~14h on v5p-8); the
+# enhancer datasets are small enough that this is several epochs each.
+NUM_TRAIN_STEPS = 10_000
+
+# Eval cadence and checkpoint policy.
+EVALS_PER_RUN = 10
+CHECKPOINTS_PER_RUN = 3
+CHECKPOINT_TIME_INTERVAL = timedelta(hours=1)
+
+# Warmup mode (WARMUP_MODE=yes): smoke-test the full pipeline end-to-end.
+WARMUP_NUM_TRAIN_STEPS = 100
+WARMUP_EVALS_PER_RUN = 3
+
+WANDB_PROJECT = "marin"
+
+_EXPECTED_VOCAB_SIZE_WARNING = f"Tokenizer {TOKENIZER!r} not found in _KNOWN_VOCAB_SIZES"
+logging.getLogger("marin.processing.tokenize.data_configs").addFilter(
+    lambda record: _EXPECTED_VOCAB_SIZE_WARNING not in record.getMessage()
+)
+
+
+# =============================================================================
+# Environment overrides
+# =============================================================================
+
+
+def _warmup_mode() -> bool:
+    value = os.getenv("WARMUP_MODE", "no").lower()
+    if value not in ("yes", "no"):
+        raise ValueError(f"WARMUP_MODE must be 'yes' or 'no', got {value!r}")
+    return value == "yes"
+
+
+def _selected_datasets() -> dict[str, str]:
+    """Return the subset of TRAIN_DATASETS named in SWEEP_DATASETS (or all if unset)."""
+    raw = os.getenv("SWEEP_DATASETS")
+    if not raw:
+        return dict(TRAIN_DATASETS)
+    requested = tuple(s.strip() for s in raw.split(","))
+    invalid = [n for n in requested if n not in TRAIN_DATASETS]
+    if invalid:
+        raise ValueError(f"Invalid SWEEP_DATASETS {invalid}; available: {sorted(TRAIN_DATASETS)}")
+    return {n: TRAIN_DATASETS[n] for n in requested}
+
+
+# =============================================================================
+# Builders
+# =============================================================================
+
+
+@lru_cache(maxsize=1)
+def _model_seq_len() -> int:
+    """Model context size = base DNA seq len + special tokens (BOS)."""
+    return dna_effective_seq_len(DNA_BASE_SEQ_LEN, TOKENIZER)
+
+
+def _tokenize(name: str, dataset: str, dataset_format: DNALmDatasetFormat) -> ExecutorStep:
+    return default_tokenize(
+        name=name,
+        dataset=dataset,
+        tokenizer=TOKENIZER,
+        format=dataset_format,
+    )
+
+
+def _build_data_mixture(strategy: str, dataset: str) -> LmDataConfig:
+    """One training component + the v30 validation set tokenized per VAL_SPEC.
+
+    Validation entries are absent from ``weights`` and so receive weight=0 via
+    ``missing_weights_are_validation=True`` — sampled only at eval time.
+    """
+    components: dict[str, ExecutorStep] = {
+        strategy: _tokenize(f"bolinas-v5-{strategy}-char-bos", dataset, TRAIN_FORMAT),
+    }
+    for suffix, fmt in VAL_SPECS:
+        key = f"val_v30_{suffix}"
+        components[key] = _tokenize(f"bolinas-v5-{key}-char-bos", VALIDATION_DATASET, fmt)
+    return lm_mixture_data_config(
+        components=components,
+        weights={strategy: 1.0},
+    )
+
+
+def _build_model_config() -> Qwen3Config:
+    return dataclasses.replace(qwen3_0_6b_hd128, max_seq_len=_model_seq_len())
+
+
+def _build_optimizer() -> AdamConfig:
+    return AdamConfig(
+        learning_rate=LEARNING_RATE,
+        weight_decay=WEIGHT_DECAY,
+        beta1=BETA1,
+        beta2=BETA2,
+        epsilon=EPSILON,
+        max_grad_norm=MAX_GRAD_NORM,
+        warmup=WARMUP_FRACTION,
+        decay=DECAY_FRACTION,
+        lr_schedule=LR_SCHEDULE,
+        min_lr_ratio=MIN_LR_RATIO,
+    )
+
+
+def _eval_harness_config() -> LmEvalHarnessConfig:
+    return LmEvalHarnessConfig(
+        task_spec=convert_to_levanter_task_config([TRAITGYM_MENDELIAN_V2_255]),
+        include_path="experiments/evals/custom_tasks",
+        max_packed_segments=1,
+    )
+
+
+def _checkpointer(num_train_steps: int) -> CheckpointerConfig:
+    return CheckpointerConfig(
+        save_interval=CHECKPOINT_TIME_INTERVAL,
+        keep=[dict(every=max(1, num_train_steps // CHECKPOINTS_PER_RUN))],
+    )
+
+
+def _build_train_step(strategy: str, dataset: str) -> ExecutorStep:
+    warmup = _warmup_mode()
+    num_train_steps = WARMUP_NUM_TRAIN_STEPS if warmup else NUM_TRAIN_STEPS
+    evals_per_run = WARMUP_EVALS_PER_RUN if warmup else EVALS_PER_RUN
+    steps_per_eval = max(1, num_train_steps // evals_per_run)
+
+    warmup_suffix = "-warmup" if warmup else ""
+    run_name = f"dna-bolinas-curation-sweep-{VERSION}{warmup_suffix}-{strategy}"
+    tags = ("dna", "exp142", "curation_sweep", VERSION, f"strategy={strategy}")
+    if warmup:
+        tags = (*tags, "warmup")
+
+    inner = TrainLmConfig(
+        data=_build_data_mixture(strategy, dataset),
+        model=_build_model_config(),
+        train_seq_len=_model_seq_len(),
+        optimizer=_build_optimizer(),
+        eval_harness=_eval_harness_config(),
+        eval_harness_steps=steps_per_eval,
+        trainer=TrainerConfig(
+            tracker=WandbConfig(
+                project=WANDB_PROJECT,
+                tags=list(tags),
+                group=f"exp142-curation-sweep-{VERSION}",
+                name=run_name,
+                replicate_path=this_output_path(),
+            ),
+            mp=jmp.get_policy("p=f32,c=bfloat16"),
+            train_batch_size=BATCH_SIZE,
+            num_train_steps=num_train_steps,
+            steps_per_eval=steps_per_eval,
+            checkpointer=_checkpointer(num_train_steps),
+            mesh=MeshConfig(axes={"replica": 1, "data": -1, "model": 1}),
+            allow_nondivisible_batch_size=True,
+        ),
+    )
+    pod_config = TrainLmOnPodConfig(
+        train_config=inner,
+        resources=ResourceConfig.with_tpu(TPU_TYPES),
+        output_path=this_output_path(),
+    )
+    return ExecutorStep(
+        name=os.path.join("checkpoints", run_name),
+        fn=remote(run_levanter_train_lm, resources=ResourceConfig.with_cpu()),
+        config=pod_config,
+    )
+
+
+def main():
+    selected = _selected_datasets()
+    steps = [_build_train_step(strategy, dataset) for strategy, dataset in selected.items()]
+    executor_main(steps=steps, description=f"DNA Bolinas source-curation sweep {VERSION}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds `experiments/dna/exp142_curation_sweep.py`: train a 0.6B Qwen3 gLM on three new projection-based enhancer datasets that vary the upstream cCRE conservation filter (phyloP-241way vs phastCons-43p × ≥20 bp vs ≥50 bp), comparing against the existing exp136 v30 baseline rather than re-running it. Same model, same eval set, same training recipe as exp136. No in-code region pin per [#136 comment](https://github.com/Open-Athena/bolinas-dna/issues/136#issuecomment-4345320251); operationally `--zone us-central1-a` at the iris CLI.

Results posted in [Open-Athena/bolinas-dna#142](https://github.com/Open-Athena/bolinas-dna/issues/142). Implements Open-Athena/bolinas-dna#142.