### PR TITLE
[execution] Recurse into tuples in executor configs

### DIFF
--- a/lib/marin/src/marin/execution/executor.py
+++ b/lib/marin/src/marin/execution/executor.py
@@ -928,6 +928,8 @@ def unwrap_versioned_value(value: VersionedValue[T_co] | T_co) -> T_co:
             return {k: recurse(v) for k, v in obj.items()}
         if isinstance(obj, list):
             return [recurse(x) for x in obj]
+        if isinstance(obj, tuple):
+            return tuple(recurse(x) for x in obj)
         return obj
 
     return recurse(value)  # type: ignore
@@ -1091,6 +1093,10 @@ def collect_dependencies_and_version(obj: Any) -> _Dependencies:
             # Recurse through lists
             for i, x in enumerate(obj):
                 recurse(x, new_prefix + f"[{i}]")
+        elif isinstance(obj, tuple):
+            # Recurse through tuples
+            for i, x in enumerate(obj):
+                recurse(x, new_prefix + f"[{i}]")
         elif isinstance(obj, dict):
             # Recurse through dicts
             for i, x in obj.items():
@@ -1124,6 +1130,9 @@ def _max_mirror_budget(config: Any) -> float | None:
             for field in fields(obj):
                 recurse(getattr(obj, field.name))
         elif isinstance(obj, list):
+            for x in obj:
+                recurse(x)
+        elif isinstance(obj, tuple):
             for x in obj:
                 recurse(x)
         elif isinstance(obj, dict):
@@ -1181,6 +1190,9 @@ def instantiate_config(
         elif isinstance(obj, list):
             # Recurse through lists
             return [recurse(x) for x in obj]
+        elif isinstance(obj, tuple):
+            # Recurse through tuples
+            return tuple(recurse(x) for x in obj)
         elif isinstance(obj, dict):
             # Recurse through dicts
             return dict((i, recurse(x)) for i, x in obj.items())

--- a/lib/marin/src/marin/execution/executor.py
+++ b/lib/marin/src/marin/execution/executor.py
@@ -99,21 +99,24 @@ import draccus
 import levanter.utils.fsspec_utils as fsspec_utils
 from fray.types import TpuConfig
 from iris.cluster.constraints import WellKnownAttribute
-from rigging.filesystem import collect_gcs_paths
-from rigging.filesystem import get_bucket_location, open_url
-from rigging.filesystem import marin_prefix
-from rigging.filesystem import region_from_prefix
-from rigging.filesystem import split_gcs_path
+from rigging.filesystem import (
+    collect_gcs_paths,
+    get_bucket_location,
+    marin_prefix,
+    open_url,
+    region_from_prefix,
+    split_gcs_path,
+)
+from rigging.log_setup import configure_logging
 
-from marin.execution.step_spec import StepSpec
-from marin.execution.step_runner import StepRunner, worker_id
-from marin.execution.remote import RemoteCallable
 from marin.execution.executor_step_status import (
     STATUS_SUCCESS,
     StatusFile,
 )
+from marin.execution.remote import RemoteCallable
+from marin.execution.step_runner import StepRunner, worker_id
+from marin.execution.step_spec import StepSpec
 from marin.utilities.json_encoder import CustomJsonEncoder
-from rigging.log_setup import configure_logging
 
 logger = logging.getLogger(__name__)
 
@@ -1187,15 +1190,12 @@ def instantiate_config(
                 value = getattr(obj, field.name)
                 result[field.name] = recurse(value)
             return replace(obj, **result)
-        elif isinstance(obj, tuple) and hasattr(obj, "_fields"):
+        elif isinstance(obj, tuple):
             # Preserve NamedTuple subclasses when resolving nested values.
             return type(obj)(*(recurse(x) for x in obj))
         elif isinstance(obj, list):
             # Recurse through lists
             return [recurse(x) for x in obj]
-        elif isinstance(obj, tuple):
-            # Recurse through tuples
-            return type(obj)(recurse(x) for x in obj)
         elif isinstance(obj, dict):
             # Recurse through dicts
             return dict((i, recurse(x)) for i, x in obj.items())

--- a/lib/marin/src/marin/execution/executor.py
+++ b/lib/marin/src/marin/execution/executor.py
@@ -1190,9 +1190,12 @@ def instantiate_config(
                 value = getattr(obj, field.name)
                 result[field.name] = recurse(value)
             return replace(obj, **result)
-        elif isinstance(obj, tuple):
+        elif isinstance(obj, tuple) and hasattr(obj, "_fields"):
             # Preserve NamedTuple subclasses when resolving nested values.
             return type(obj)(*(recurse(x) for x in obj))
+        elif isinstance(obj, tuple):
+            # Plain tuples must be rebuilt from a single iterable.
+            return tuple(recurse(x) for x in obj)
         elif isinstance(obj, list):
             # Recurse through lists
             return [recurse(x) for x in obj]

--- a/lib/marin/src/marin/execution/executor.py
+++ b/lib/marin/src/marin/execution/executor.py
@@ -1187,12 +1187,15 @@ def instantiate_config(
                 value = getattr(obj, field.name)
                 result[field.name] = recurse(value)
             return replace(obj, **result)
+        elif isinstance(obj, tuple) and hasattr(obj, "_fields"):
+            # Preserve NamedTuple subclasses when resolving nested values.
+            return type(obj)(*(recurse(x) for x in obj))
         elif isinstance(obj, list):
             # Recurse through lists
             return [recurse(x) for x in obj]
         elif isinstance(obj, tuple):
             # Recurse through tuples
-            return tuple(recurse(x) for x in obj)
+            return type(obj)(recurse(x) for x in obj)
         elif isinstance(obj, dict):
             # Recurse through dicts
             return dict((i, recurse(x)) for i, x in obj.items())

--- a/tests/execution/test_executor.py
+++ b/tests/execution/test_executor.py
@@ -766,6 +766,35 @@ def test_mirrored_instantiate_config():
     assert resolved.input_path == "mirror://documents/data"
 
 
+def test_tuple_values_are_resolved_in_executor_configs():
+    @dataclass(frozen=True)
+    class Cfg:
+        values: tuple[object, ...]
+
+    dependency = ExecutorStep(name="dependency", fn=lambda _: None, config=None)
+    cfg = Cfg(
+        values=(
+            output_path_of(dependency, "artifact"),
+            this_output_path("tracker"),
+            {"mirrored": mirrored(versioned("documents/data"), budget_gb=10)},
+        )
+    )
+
+    deps = collect_dependencies_and_version(cfg)
+    assert deps.dependencies == [dependency]
+    assert deps.version == {
+        "values.[0]": "DEP[0]/artifact",
+        "values.[2].mirrored": "documents/data",
+    }
+
+    resolved = instantiate_config(cfg, output_path="/out", output_paths={dependency: "/dependency"}, prefix="/bucket")
+    assert resolved.values == (
+        "/dependency/artifact",
+        "/out/tracker",
+        {"mirrored": "mirror://documents/data"},
+    )
+
+
 def test_mirrored_nesting_raises():
     with pytest.raises(ValueError, match="nest"):
         mirrored(mirrored("x"))

--- a/tests/execution/test_executor.py
+++ b/tests/execution/test_executor.py
@@ -796,6 +796,27 @@ def test_tuple_values_are_resolved_in_executor_configs():
     )
 
 
+def test_plain_tuple_values_are_resolved_without_type_error():
+    @dataclass(frozen=True)
+    class Cfg:
+        values: tuple[object, ...]
+
+    dependency = ExecutorStep(name="dependency", fn=lambda _: None, config=None)
+    cfg = Cfg(
+        values=(
+            output_path_of(dependency, "artifact"),
+            this_output_path("tracker"),
+        )
+    )
+
+    resolved = instantiate_config(cfg, output_path="/out", output_paths={dependency: "/dependency"}, prefix="/bucket")
+
+    assert resolved.values == (
+        "/dependency/artifact",
+        "/out/tracker",
+    )
+
+
 def test_namedtuple_values_are_resolved_without_losing_type():
     class Coords(NamedTuple):
         x: object

--- a/tests/execution/test_executor.py
+++ b/tests/execution/test_executor.py
@@ -9,6 +9,7 @@ import tempfile
 import time
 from dataclasses import asdict, dataclass
 from threading import Event, Thread
+from typing import NamedTuple
 
 import pytest
 from draccus.utils import Dataclass
@@ -793,6 +794,30 @@ def test_tuple_values_are_resolved_in_executor_configs():
         "/out/tracker",
         {"mirrored": "mirror://documents/data"},
     )
+
+
+def test_namedtuple_values_are_resolved_without_losing_type():
+    class Coords(NamedTuple):
+        x: object
+        y: object
+
+    @dataclass(frozen=True)
+    class Cfg:
+        coords: Coords
+
+    dependency = ExecutorStep(name="dependency", fn=lambda _: None, config=None)
+    cfg = Cfg(
+        coords=Coords(
+            output_path_of(dependency, "artifact"),
+            this_output_path("tracker"),
+        )
+    )
+
+    resolved = instantiate_config(cfg, output_path="/out", output_paths={dependency: "/dependency"}, prefix="/bucket")
+
+    assert isinstance(resolved.coords, Coords)
+    assert resolved.coords.x == "/dependency/artifact"
+    assert resolved.coords.y == "/out/tracker"
 
 
 def test_mirrored_nesting_raises():


### PR DESCRIPTION
Handle tuple-valued executor config fields the same way as lists so dependency collection, config instantiation, VersionedValue unwrapping, and mirror-budget discovery work for tuple containers. Adds a regression test covering output paths, this_output_path, and mirrored versioned values inside a tuple.

Part of #4963