### PR TITLE
zephyr: run coord cleanup on every exit path

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -1606,7 +1606,8 @@ def _run_coordinator_job(config_path: str, result_path: str) -> None:
                 resources=config.worker_resources,
                 actor_config=ActorConfig(max_task_retries=10),
             )
-            worker_group.wait_ready(count=1, timeout=3600.0)
+            ready_wait_s = float(os.environ.get("ZEPHYR_WORKERS_READY_WAIT") or 12 * 60 * 60)
+            worker_group.wait_ready(count=1, timeout=ready_wait_s)
 
             # Let the coordinator poll worker job health in its maintenance loop
             coordinator.set_worker_group.remote(worker_group).result()

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -1576,53 +1576,57 @@ def _run_coordinator_job(config_path: str, result_path: str) -> None:
         actor_config=ActorConfig(max_concurrency=100),
     )
     coordinator = hosted.handle
-    coordinator.initialize.remote(
-        config.chunk_storage_prefix,
-        coordinator,
-        config.no_workers_timeout,
-    ).result()
-
-    # Create workers (child jobs)
-    num_shards = config.plan.num_shards
-    actual_workers = min(config.max_workers, num_shards) if num_shards > 0 else 0
     worker_group = None
-
-    if actual_workers > 0:
-        # Worker name includes attempt ID so that if a stale coordinator
-        # process from a previous attempt is still running, its shutdown
-        # targets the old name and cannot kill this attempt's workers.
-        worker_name = f"zephyr-{config.name}-p{config.pipeline_id}-workers-a{attempt_id}"
-        logger.info("Starting %d workers (max=%d, shards=%d)", actual_workers, config.max_workers, num_shards)
-        worker_group = client.create_actor_group(
-            ZephyrWorker,
-            coordinator,
-            config.stage_runner_factory,
-            name=worker_name,
-            count=actual_workers,
-            resources=config.worker_resources,
-            actor_config=ActorConfig(max_task_retries=10),
-        )
-        worker_group.wait_ready(count=1, timeout=3600.0)
-
-        # Let the coordinator poll worker job health in its maintenance loop
-        coordinator.set_worker_group.remote(worker_group).result()
-
+    # host_actor starts a non-daemon uvicorn thread; the finally below must
+    # run on every exit path or the process will stay alive after the main
+    # body raises and the Iris task will be stuck RUNNING.
     try:
-        results = coordinator.run_pipeline.submit(config.plan, config.execution_id).result()
-        counters = coordinator.get_counters.remote().result(timeout=10.0) or {}
-        payload = ZephyrExecutionResult(results=results, counters=counters)
+        coordinator.initialize.remote(
+            config.chunk_storage_prefix,
+            coordinator,
+            config.no_workers_timeout,
+        ).result()
 
-        ensure_parent_dir(result_path)
-        with open_url(result_path, "wb") as f:
-            f.write(cloudpickle.dumps(payload))
-    except Exception as e:
-        # Persist the exception so the caller can recover the original type
-        # (important for non-retryable error detection).
-        with suppress(Exception):
+        # Create workers (child jobs)
+        num_shards = config.plan.num_shards
+        actual_workers = min(config.max_workers, num_shards) if num_shards > 0 else 0
+
+        if actual_workers > 0:
+            # Worker name includes attempt ID so that if a stale coordinator
+            # process from a previous attempt is still running, its shutdown
+            # targets the old name and cannot kill this attempt's workers.
+            worker_name = f"zephyr-{config.name}-p{config.pipeline_id}-workers-a{attempt_id}"
+            logger.info("Starting %d workers (max=%d, shards=%d)", actual_workers, config.max_workers, num_shards)
+            worker_group = client.create_actor_group(
+                ZephyrWorker,
+                coordinator,
+                config.stage_runner_factory,
+                name=worker_name,
+                count=actual_workers,
+                resources=config.worker_resources,
+                actor_config=ActorConfig(max_task_retries=10),
+            )
+            worker_group.wait_ready(count=1, timeout=3600.0)
+
+            # Let the coordinator poll worker job health in its maintenance loop
+            coordinator.set_worker_group.remote(worker_group).result()
+
+        try:
+            results = coordinator.run_pipeline.submit(config.plan, config.execution_id).result()
+            counters = coordinator.get_counters.remote().result(timeout=10.0) or {}
+            payload = ZephyrExecutionResult(results=results, counters=counters)
+
             ensure_parent_dir(result_path)
             with open_url(result_path, "wb") as f:
-                f.write(cloudpickle.dumps(e))
-        raise
+                f.write(cloudpickle.dumps(payload))
+        except Exception as e:
+            # Persist the exception so the caller can recover the original type
+            # (important for non-retryable error detection).
+            with suppress(Exception):
+                ensure_parent_dir(result_path)
+                with open_url(result_path, "wb") as f:
+                    f.write(cloudpickle.dumps(e))
+            raise
     finally:
         # Signal coordinator shutdown first so workers receive SHUTDOWN from
         # pull_task and self-terminate via shutdown_event → exit_actor()


### PR DESCRIPTION
* run `_run_coordinator_job` cleanup on every exit path
* `host_actor()` spawns a non-daemon uvicorn thread; pre-fix the `try:` started after `wait_ready`, so a `TimeoutError` from `coordinator.initialize`, `create_actor_group`, or `wait_ready` unwound past it without calling `hosted.shutdown()` or `worker_group.shutdown()`
  * coord process stayed alive forever, iris saw `TASK_STATE_RUNNING`, and the workers job was never explicitly terminated[^1]
* move `try:` to immediately after `host_actor()` returns; existing `finally` now runs `coordinator.shutdown` → `worker_group.shutdown` (calls `iris.terminate` on the workers job) → `hosted.shutdown` (stops uvicorn)
* bump default `wait_ready` timeout from 1h to 12h, override via `ZEPHYR_WORKERS_READY_WAIT` (matching `ZEPHYR_MAX_WORKERS`)
  * 1h fired while the workers job was still `PENDING` under capacity pressure even though waiting longer would let pods schedule

[^1]: surfaced as 7 zombie coords pinning the `us-central1-a` `e2-highmem-2` scale group at `max_slices`, blocking the parent from scheduling its next bucket. feedback loop: workers stayed `PENDING` because the cluster was already saturated by previous zombies