### PR TITLE
dedup: add per-shard resume to compute_minhash_attrs

### DIFF
--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
@@ -18,12 +18,13 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Iterator
 
 import dupekit
 import pyarrow as pa
 from fray import ResourceConfig
 from pydantic import BaseModel
-from zephyr import Dataset, ZephyrContext, counters, write_parquet_file
+from zephyr import Dataset, ZephyrContext, counters
 
 from marin.datakit.normalize import NormalizedData
 from marin.execution.artifact import Artifact
@@ -106,21 +107,10 @@ def _attr_records(batch: pa.RecordBatch, params: MinHashParams) -> list[dict]:
     return out
 
 
-def _make_shard_processor(attr_dir: str, params: MinHashParams):
-    """Return a per-shard map fn that loads one source parquet, runs MinHash, writes attr parquet."""
-
-    def process(shard_path: str) -> dict:
-        basename = os.path.basename(shard_path)
-        attr_path = f"{attr_dir}/{basename}"
-
-        def records():
-            for batch in _load_batches(shard_path, columns=["id", "text"]):
-                yield from _attr_records(batch, params)
-
-        result = write_parquet_file(records(), attr_path)
-        return {"source_path": shard_path, "attr_path": attr_path, "count": result["count"]}
-
-    return process
+def _shard_attr_records(shard_path: str, params: MinHashParams) -> Iterator[dict]:
+    """Stream ``{id, buckets}`` attr records for one source parquet shard."""
+    for batch in _load_batches(shard_path, columns=["id", "text"]):
+        yield from _attr_records(batch, params)
 
 
 def compute_minhash_attrs(
@@ -184,7 +174,21 @@ def compute_minhash_attrs(
         ctx_kwargs["max_workers"] = max_workers
     ctx = ZephyrContext(**ctx_kwargs)
 
-    pipeline = Dataset.from_list(source_shards).map(_make_shard_processor(attr_dir, params))
+    # Per-shard write paths mirror the source basenames (preserves the
+    # co-partition convention documented on ``MinHashAttrData``). The output
+    # pattern closes over the ordered shard list so shard_idx → source path is
+    # deterministic; ``Dataset.from_list`` assigns ``shard_idx = i`` per item
+    # (zephyr/plan.py:553).
+    output_basenames = tuple(os.path.basename(p) for p in source_shards)
+
+    def _output_path(shard_idx: int, total_shards: int, ad: str = attr_dir, bn: tuple = output_basenames) -> str:
+        return f"{ad}/{bn[shard_idx]}"
+
+    pipeline = (
+        Dataset.from_list(source_shards)
+        .flat_map(lambda path, p=params: _shard_attr_records(path, p))
+        .write_parquet(_output_path, skip_existing=True)
+    )
     outcome = ctx.execute(pipeline, verbose=True)
 
     return MinHashAttrData(

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
@@ -174,11 +174,7 @@ def compute_minhash_attrs(
         ctx_kwargs["max_workers"] = max_workers
     ctx = ZephyrContext(**ctx_kwargs)
 
-    # Per-shard write paths mirror the source basenames (preserves the
-    # co-partition convention documented on ``MinHashAttrData``). The output
-    # pattern closes over the ordered shard list so shard_idx → source path is
-    # deterministic; ``Dataset.from_list`` assigns ``shard_idx = i`` per item
-    # (zephyr/plan.py:553).
+    # Preserve source basenames; zephyr's `{basename}` placeholder is synthetic.
     output_basenames = tuple(os.path.basename(p) for p in source_shards)
 
     def _output_path(shard_idx: int, total_shards: int, ad: str = attr_dir, bn: tuple = output_basenames) -> str:


### PR DESCRIPTION
## Summary

- Replace the bespoke per-shard `map(_make_shard_processor)` helper in `compute_minhash_attrs` with a standard zephyr `Dataset` pipeline (`from_list → flat_map → write_parquet`) using `skip_existing=True`, so a partially-completed minhash step resumes per-shard on rerun instead of recomputing every shard from scratch.
- Output basenames still mirror source shards via a callable `output_pattern` keyed off `shard_idx`. `Dataset.from_list` assigns `shard_idx = i` per item (`zephyr/plan.py:553`), so the 1:1 co-partition documented on `MinHashAttrData` is preserved.
- `skip_existing` short-circuits at the `Write` op via `return` (`zephyr/plan.py:797–808`) before the lazy `flat_map` upstream is consumed, so no load + dupekit work is paid for already-written shards. All zephyr file writers use `atomic_rename` (`zephyr/writers.py`), so on-disk files are always complete and `skip_existing` cannot mistake a partial write for a finished one.

### Why

A multi-source fuzzy-dedup run on `experiments/dedup/dedup_all_sources.py` hit a transient zephyr coord stall on a handful of large minhash steps (~8000 shards each). Without per-shard resume, retrying these steps from scratch would redo many hours of compute that already landed on GCS.

### Behavior change worth flagging

`MinHashAttrData.counters` now reflects only shards computed in the current invocation. On a partial-resume run, counters are partial. Today's downstream consumer (`compute_fuzzy_dups_attrs`) does not depend on these counters; it globs the attr directory and keys off `(source_tag, basename)` from the attr files themselves.

## Test plan

- [ ] CI lint/type/AST pass (ran `./infra/pre-commit.py --fix` locally — clean).
- [ ] Smoke ferry (`experiments/ferries/datakit_ferry.py`) green on a fresh run.
- [ ] Manual resume test: kill a minhash step partway, rerun, confirm via logs the `zephyr/partitions_skipped` counter increments for already-written shards and the produced `MinHashAttrData.attr_dir` is bit-identical to the no-resume run.