### PR TITLE
Design Iris inference service

### DIFF
--- a/.agents/projects/iris_inference_service/design.md
+++ b/.agents/projects/iris_inference_service/design.md
@@ -1,0 +1,108 @@
+# Iris vLLM Inference Service
+
+Run Marin evals against vLLM on Iris without making each evaluator start or
+manage a model. Evaluators should keep consuming `RunningModel` and
+OpenAI-compatible HTTP. Iris should own vLLM startup, readiness, request
+routing, worker cleanup, and diagnostics.
+
+The first milestone is a standard Hugging Face model that vLLM already serves
+well. That is enough to validate the service boundary, worker lifecycle,
+OpenAI proxy, result upload, and one real lm-eval generation path. Harder
+model- and scoring-specific checks stay as follow-up compatibility work, not
+as blockers for the service shape.
+
+See [research.md](./research.md) for code references and pressure-test
+evidence. See [spec.md](./spec.md) for the concrete API contracts.
+
+## Challenges
+
+The HTTP API is not the hard part; vLLM already exposes OpenAI-compatible
+endpoints. The hard part is where lifecycle and failure handling live.
+
+- Workers are elastic Iris jobs. They need to start vLLM, wait for readiness,
+  pull work, forward requests locally, and report terminal results.
+- The eval-side proxy must wait on long-running broker operations without
+  losing Iris/Fray actor context.
+- Prompt-logprob scoring uses `/v1/completions`, which has different failure
+  modes from generation through `/v1/chat/completions`.
+- The first implementation should prove batch eval serving, not become a
+  multi-tenant online inference gateway.
+
+## Costs / Risks
+
+- vLLM is the only served engine. If vLLM cannot serve a scoring task, that
+  task stays on an existing eval path until vLLM is fixed.
+- The broker is a single in-memory coordinator. Broker or eval-job restart
+  loses in-flight requests.
+- A pull-broker design adds latency and one more failure surface between
+  lm-eval and vLLM.
+- The MVP does not include streaming, cancellation, persistent queues,
+  always-on serving, Harbor/Evalchemy migration, or in-training-loop weight
+  updates.
+
+## Design
+
+The service has three roles.
+
+- **Eval job:** runs the evaluator and a local OpenAI-compatible proxy. It sees
+  `RunningModel(endpoint=OpenAIEndpoint(...))`, not vLLM process details.
+- **Broker actor:** owns one eval run's in-memory request table. It accepts
+  opaque OpenAI request envelopes, leases pending work to workers, expires old
+  leases, and accepts terminal results only from the current lease.
+- **vLLM worker group:** runs one Iris job with `N` replicas. Each replica
+  starts native vLLM, waits for `/v1/models`, records readiness, leases work
+  from the broker, forwards to `http://127.0.0.1:<port>/v1`, and reports the
+  vLLM response.
+
+The proxy exposes only:
+
+- `/v1/completions`
+- `/v1/chat/completions`
+
+The proxy validates the minimal HTTP shape: JSON object body, supported path,
+safe request id, bounded request size, and no streaming. It forwards the body
+opaquely to the broker, waits for a terminal broker result, and returns the
+worker response. Duplicate submits with the same request id are idempotent only
+when the endpoint and payload match exactly.
+
+The worker also treats payloads opaquely. It chooses the local vLLM endpoint
+from the envelope path and forwards the JSON body. It does not parse lm-eval,
+Harbor, Evalchemy, or OpenAI semantics.
+
+This design intentionally uses a pull broker instead of direct proxy
+load-balancing. Replacement workers can pick up expired work without the proxy
+tracking worker liveness. The tradeoff is one in-memory coordinator, which is
+acceptable for first batch-eval serving.
+
+Implementation should reuse `VllmEnvironment` for native vLLM startup,
+readiness, and diagnostics, then wrap it in an Iris/Fray `ModelLauncher`. The
+launcher returns a `RunningModel` whose endpoint base URL points at the local
+proxy and whose model id matches vLLM's served model name. Engine kwargs remain
+vLLM kwargs; they are not generic service fields.
+
+## Testing
+
+Normal CI should not require real Iris or real vLLM. It should cover:
+
+- broker lifecycle: submit, lease, expiry, complete/fail, duplicate submit,
+  stale lease result ignored, and first valid terminal result kept;
+- proxy safety: request id validation before echoing headers, invalid JSON,
+  oversized body, unsupported path, and `stream: true`;
+- proxy -> broker -> worker -> deterministic OpenAI-compatible stub for both
+  completions and chat completions;
+- a tiny lm-eval path when optional eval dependencies are installed.
+
+The manual Iris smoke should run stock lm-eval generation against a standard
+vLLM-friendly Hugging Face model. The saved lm-eval artifact is the source of
+truth for the actual task and few-shot settings. Follow-up manual runs should
+exercise prompt-logprob scoring through `/v1/completions`.
+
+## Open Questions
+
+- Which standard Hugging Face model should be the named MVP smoke target?
+- What minimum throughput makes the single-broker design acceptable for near
+  term eval runs?
+- Should manual pressure-test results upload directly to GCS, or is local
+  output plus Iris logs enough for the first implementation PR?
+- What vLLM changes are needed before prompt-logprob scoring is reliable on
+  the target TPU serving stack?

--- a/.agents/projects/iris_inference_service/research.md
+++ b/.agents/projects/iris_inference_service/research.md
@@ -1,0 +1,105 @@
+# Research — iris_inference_service
+
+The design is vLLM-only. Earlier drafts considered both vLLM and Levanter/JAX
+behind OpenAI-compatible HTTP, but current team direction is to serve this path
+through vLLM and keep Levanter on existing non-served eval paths.
+
+## In-Repo Findings
+
+- Served evals already have the right boundary:
+  [`OpenAIEndpoint`, `RunningModel`, `ModelDeployment`, and `ModelLauncher`](https://github.com/marin-community/marin/blob/ce77573c01a590dcb7a39abaf18aa541903c9036/lib/marin/src/marin/inference/types.py#L10-L45).
+  Evaluators should consume `RunningModel`; launchers should own model
+  lifecycle and cleanup.
+- `run_lm_eval` converts `RunningModel` into `local-completions` or
+  `local-chat-completions` args and writes results with `EvaluationTracker`:
+  [`run_lm_eval`](https://github.com/marin-community/marin/blob/ce77573c01a590dcb7a39abaf18aa541903c9036/lib/marin/src/marin/evaluation/lm_eval.py#L42-L70)
+  and [`build_lm_eval_model_args`](https://github.com/marin-community/marin/blob/ce77573c01a590dcb7a39abaf18aa541903c9036/lib/marin/src/marin/evaluation/lm_eval.py#L73-L92).
+- `LMEvaluationHarnessEvaluator` already starts local vLLM and points lm-eval
+  at `/v1/completions` or `/v1/chat/completions`, but it couples evaluator
+  code to serving lifecycle:
+  [`LMEvaluationHarnessEvaluator.evaluate`](https://github.com/marin-community/marin/blob/ce77573c01a590dcb7a39abaf18aa541903c9036/lib/marin/src/marin/evaluation/evaluators/lm_evaluation_harness_evaluator.py#L86-L190).
+- `VllmEnvironment` owns native vLLM startup, readiness, diagnostics, and the
+  `/v1` API root:
+  [`VllmEnvironment`](https://github.com/marin-community/marin/blob/ce77573c01a590dcb7a39abaf18aa541903c9036/lib/marin/src/marin/inference/vllm_server.py#L360-L430).
+  Iris rejects Docker sidecar mode:
+  [`resolve_vllm_mode`](https://github.com/marin-community/marin/blob/ce77573c01a590dcb7a39abaf18aa541903c9036/lib/marin/src/marin/inference/vllm_server.py#L241-L252).
+- vLLM readiness is `GET {server_url}/models == 200`, where `server_url` ends
+  in `/v1`:
+  [`_poll_until_ready`](https://github.com/marin-community/marin/blob/ce77573c01a590dcb7a39abaf18aa541903c9036/lib/marin/src/marin/inference/vllm_server.py#L306-L344)
+  and [`_get_first_model_id`](https://github.com/marin-community/marin/blob/ce77573c01a590dcb7a39abaf18aa541903c9036/lib/marin/src/marin/inference/vllm_server.py#L347-L357).
+- Fray has short `.remote()` calls and long-running `.submit()` calls. Proxy
+  waits should use the long-running path:
+  [`ActorMethod.submit`](https://github.com/marin-community/marin/blob/ce77573c01a590dcb7a39abaf18aa541903c9036/lib/fray/src/fray/actor.py#L97-L112).
+- Fray actor context lives in `ContextVar`s, and child threads do not inherit
+  it automatically:
+  [`current_actor`](https://github.com/marin-community/marin/blob/ce77573c01a590dcb7a39abaf18aa541903c9036/lib/fray/src/fray/actor.py#L62-L76).
+  This matters for any threaded eval-side proxy.
+- `FrayIrisClient` already maps Fray jobs and actors to Iris jobs and
+  replicas:
+  [`FrayIrisClient.submit`](https://github.com/marin-community/marin/blob/ce77573c01a590dcb7a39abaf18aa541903c9036/lib/fray/src/fray/iris_backend.py#L550-L576).
+
+## Prototype Findings
+
+Closed prototype PR [#5351](https://github.com/marin-community/marin/pull/5351)
+validated the shape locally with `fray.LocalClient`.
+
+- eval client -> OpenAI proxy -> broker actor -> worker actor ->
+  deterministic OpenAI-compatible server -> client response worked locally.
+- The proxy should expose `/v1/completions` and `/v1/chat/completions`.
+  Workers should receive an engine API root ending in `/v1`.
+- Broker submit must be idempotent for identical `(request_id, envelope)` and
+  reject conflicting reuse of a request id.
+- The broker should keep the first valid current-lease terminal result and
+  ignore stale leases.
+- The first proxy was single-threaded to preserve Iris context. That is enough
+  for the MVP, but not throughput evidence.
+- CodeQL flagged echoing arbitrary request-id headers. The proxy should
+  validate request ids before reflecting them.
+
+## Pressure-Test Findings
+
+The 2026-05 pressure test used existing Marin `VllmEnvironment`, lm-eval on
+Iris, and a manual runner because the service implementation does not exist
+yet.
+
+- PR #5712 is the implementation base for new pressure-test work. It moves the
+  serving lane to `vllm-tpu==0.19.0`, `tpu-inference==0.19.0`, and
+  `libtpu==0.0.39`.
+- The explicit 1e22 MoE artifact found in project artifacts is
+  `gs://marin-us-central2/grug/moe-v7-1e22-d3200-v4-56ba43/checkpoints/step-77725/`.
+  It is Orbax/OCDBT-shaped and not directly loadable by current vLLM.
+- The closest vLLM-loadable 1e22 stand-in found in repo-configured eval suites
+  is
+  `gs://marin-us-central2/adamh-scaling-ladder-nemotron-optimal-1e+22-v5-025b0e/hf/step-38234/`.
+  A patched MMLU submission against it was accepted on `v5p-8`, then remained
+  pending on capacity and was stopped before runtime evidence.
+- Issue #5672 tracks the Delphi/1e22 RPA scoped-VMEM startup failure. Treat it
+  as target-model follow-up work, not as a blocker for the standard-model
+  service path.
+- Small-model HumanEval on v6e-4 succeeded through
+  `local-chat-completions` and `/v1/chat/completions`, with saved lm-eval
+  result and sample artifacts.
+- The saved HumanEval config still reported `num_fewshot: 0` and `n-shot: 0`
+  even when the runner passed
+  `EvalTaskConfig("humaneval", 5, task_alias="humaneval_5shot")`. This proves
+  the generation endpoint, not exact 5-shot semantics.
+- Small-model MMLU reached `local-completions` and `/v1/completions`, but TPU
+  vLLM 0.18.0 returned HTTP 500 on prompt-logprob scoring. A direct
+  non-lm-eval request reproduced the failure with `echo=true`, `logprobs=1`,
+  and `max_tokens=1`; server logs raised `KeyError: 425` in
+  `_create_completion_logprobs`.
+- lm-eval and the Iris-installed vLLM package were skewed:
+  `lm_eval.models.vllm_causallms` imports `vllm.utils.get_open_port`, which
+  was missing in that installed vLLM package. The manual runner used a
+  scratch-only shim. Production code should fix dependency versions or avoid
+  that import path.
+- The standard-model runner now defaults to `standard_humaneval_smoke` with
+  `Qwen/Qwen3-0.6B`, matching the MVP proof: model readiness, OpenAI
+  chat-completions plumbing, result upload, and cleanup.
+
+## Conclusion
+
+`RunningModel` plus `OpenAIEndpoint` is the right evaluator boundary.
+Generation over `/v1/chat/completions` is viable enough for the MVP. Prompt
+logprob scoring over `/v1/completions` and target-model readiness remain
+follow-up compatibility gates.

--- a/.agents/projects/iris_inference_service/spec.md
+++ b/.agents/projects/iris_inference_service/spec.md
@@ -1,0 +1,396 @@
+# Spec — iris_inference_service
+
+This is the contract layer for the vLLM-only Iris inference service. It names
+the files, public shapes, routing behavior, and test obligations reviewers are
+approving.
+
+## Files
+
+| File | Status | Purpose |
+|---|---|---|
+| `lib/marin/src/marin/inference/iris_vllm.py` | new | Iris vLLM launcher, proxy, broker, worker actors |
+| `tests/evals/test_iris_vllm_inference.py` | new | CI-safe broker/proxy/worker tests with a deterministic OpenAI stub |
+| `scripts/iris/run_vllm_eval_pressure_test.py` | new, manual-only | Iris pressure-test runner |
+
+No proto changes. No persistent schema. No new engine abstraction layer.
+
+Reused contracts:
+
+- `OpenAIEndpoint`, `RunningModel`, `ModelDeployment`, `ModelLauncher` from
+  `marin.inference.types`
+- `LmEvalRun`, `LmEvalAdapter`, `run_lm_eval` from `marin.evaluation.lm_eval`
+- `VllmEnvironment` from `marin.inference.vllm_server`
+
+## Scope
+
+This service supports native vLLM only. It must not introduce
+`EngineKind.LEVANTER`, a JAX OpenAI HTTP server, or a generic engine adapter.
+
+The first manual pressure-test lane uses a standard vLLM-friendly Hugging Face
+model and stock lm-eval generation. Scoring tasks that require prompt logprobs
+remain follow-up compatibility checks until the TPU vLLM `/v1/completions`
+contract is reliable.
+
+## Constants
+
+```python
+MARIN_REQUEST_ID_HEADER = "X-Marin-Inference-Request-Id"
+JSON_CONTENT_TYPE = "application/json"
+REQUEST_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
+MAX_REQUEST_BODY_BYTES: int = 8 * 1024 * 1024
+DEFAULT_REQUEST_TIMEOUT: float = 3600.0
+DEFAULT_LEASE_TIMEOUT: float = DEFAULT_REQUEST_TIMEOUT + 60.0
+DEFAULT_WORKER_LEASE_WAIT_TIMEOUT: float = 1.0
+DEFAULT_WORKER_READY_TIMEOUT: float = 900.0
+DEFAULT_CLEANUP_TIMEOUT: float = 10.0
+```
+
+`lease_timeout` must be greater than `request_timeout`. The proxy may echo
+`MARIN_REQUEST_ID_HEADER` only after validation or generation.
+
+## Endpoint Kind
+
+```python
+class OpenAIEndpointKind(StrEnum):
+    COMPLETIONS = "completions"
+    CHAT_COMPLETIONS = "chat_completions"
+
+    @property
+    def http_path(self) -> str: ...
+
+    @property
+    def api_path(self) -> str: ...
+
+    @staticmethod
+    def from_http_path(path: str) -> "OpenAIEndpointKind | None": ...
+```
+
+`http_path` is `/v1/completions` or `/v1/chat/completions`. `api_path` is the
+path appended under a vLLM `/v1` API root.
+
+## Broker Shapes
+
+```python
+@dataclass(frozen=True)
+class OpenAIRequestEnvelope:
+    request_id: str
+    endpoint: OpenAIEndpointKind
+    payload_json: str
+
+
+@dataclass(frozen=True)
+class OpenAIResponseEnvelope:
+    status_code: int
+    payload_json: str
+    content_type: str = JSON_CONTENT_TYPE
+
+
+@dataclass(frozen=True)
+class InferenceLease:
+    lease_id: str
+    worker_id: str
+    request: OpenAIRequestEnvelope
+    expires_at: float
+
+
+@dataclass(frozen=True)
+class WorkerReadyState:
+    worker_id: str
+    model_id: str
+
+
+class BrokerRequestStatus(StrEnum):
+    PENDING = "pending"
+    LEASED = "leased"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+    @property
+    def terminal(self) -> bool: ...
+
+
+class BrokerWaitOutcome(StrEnum):
+    READY = "ready"
+    TIMEOUT = "timeout"
+    UNKNOWN_REQUEST = "unknown_request"
+    BROKER_STOPPED = "broker_stopped"
+
+
+@dataclass(frozen=True)
+class BrokerWaitResult:
+    outcome: BrokerWaitOutcome
+    response: OpenAIResponseEnvelope | None = None
+
+
+@dataclass(frozen=True)
+class LeaseResult:
+    lease: InferenceLease | None
+    stopped: bool = False
+```
+
+`BrokerWaitResult.response` is set only for `READY`. `LeaseResult.lease=None`
+means no work was available before timeout unless `stopped=True`.
+
+## Broker API
+
+```python
+class IrisInferenceBroker:
+    """In-memory broker scoped to one eval run."""
+
+    def __init__(
+        self,
+        lease_timeout: float = DEFAULT_LEASE_TIMEOUT,
+        now: Callable[[], float] = time.monotonic,
+    ) -> None: ...
+
+    def submit(self, request: OpenAIRequestEnvelope) -> bool: ...
+
+    def lease(self, worker_id: str, wait_timeout: float | None = None) -> LeaseResult: ...
+
+    def complete(
+        self,
+        request_id: str,
+        lease_id: str,
+        response: OpenAIResponseEnvelope,
+    ) -> bool: ...
+
+    def fail(
+        self,
+        request_id: str,
+        lease_id: str,
+        response: OpenAIResponseEnvelope,
+    ) -> bool: ...
+
+    def poll(self, request_id: str) -> OpenAIResponseEnvelope | None: ...
+
+    def wait(self, request_id: str, timeout: float | None = None) -> BrokerWaitResult: ...
+
+    def status(self, request_id: str) -> BrokerRequestStatus | None: ...
+
+    def record_worker_ready(self, state: WorkerReadyState) -> None: ...
+
+    def wait_for_workers_ready(
+        self,
+        worker_count: int,
+        timeout: float,
+    ) -> tuple[WorkerReadyState, ...]: ...
+
+    def stop(self) -> None: ...
+```
+
+Broker behavior:
+
+- `submit` returns `True` for a new request and `False` for an identical
+  duplicate. Reusing a request id with different endpoint or payload raises
+  `ValueError`.
+- `lease` expires overdue leases before choosing work. Expired work becomes
+  pending again.
+- `complete` and `fail` store a terminal response only for the current lease.
+  Stale lease ids and already-terminal requests return `False`.
+- `wait` distinguishes ready, timeout, unknown request, and stopped broker.
+- `record_worker_ready` is idempotent for the same `(worker_id, model_id)` and
+  raises on conflicting model ids.
+- Mutations are linearizable under one lock. Blocked lease, wait, and readiness
+  calls wake on submit, terminal result, readiness, lease expiry, and stop.
+
+The broker has no persistence contract. Restarting it starts with an empty
+request table.
+
+## Worker API
+
+```python
+@dataclass(frozen=True)
+class IrisVllmWorkerConfig:
+    model: ModelDeployment
+    host: str = "127.0.0.1"
+    port: int | None = None
+    vllm_timeout: int = 3600
+    request_timeout: float = DEFAULT_REQUEST_TIMEOUT
+    lease_wait_timeout: float = DEFAULT_WORKER_LEASE_WAIT_TIMEOUT
+    extra_vllm_args: tuple[str, ...] = ()
+
+
+class IrisVllmWorker:
+    """Actor that starts vLLM and forwards broker leases."""
+
+    def __init__(self, broker: ActorHandle, config: IrisVllmWorkerConfig) -> None: ...
+
+    def run(self, max_requests: int | None = None) -> int: ...
+```
+
+Worker behavior:
+
+- Use `VllmEnvironment` in native mode.
+- Set `ModelConfig.name = deployment.model_name`,
+  `ModelConfig.path = deployment.model_path`, and
+  `ModelConfig.engine_kwargs = dict(deployment.engine_kwargs)`.
+- Add `--served-model-name <deployment.model_name>` and reject
+  `extra_vllm_args` that include another `--served-model-name`.
+- Wait for `/v1/models`, record readiness, lease work, forward JSON bodies
+  opaquely, and return the vLLM response body/status to the broker.
+- Map network failures while forwarding to a `502` response via `broker.fail`.
+  Let vLLM startup failures and non-network worker exceptions propagate.
+
+Endpoint mapping:
+
+| Envelope endpoint | Worker target |
+|---|---|
+| `COMPLETIONS` | `{env.server_url}/completions` |
+| `CHAT_COMPLETIONS` | `{env.server_url}/chat/completions` |
+
+## Proxy API
+
+```python
+@dataclass(frozen=True)
+class RunningIrisInferenceProxy:
+    base_url: str
+    request_id_header: str = MARIN_REQUEST_ID_HEADER
+
+
+def serve_iris_inference_proxy(
+    broker: ActorHandle,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 0,
+    request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
+) -> AbstractContextManager[RunningIrisInferenceProxy]: ...
+```
+
+The yielded `base_url` is an OpenAI API root ending in `/v1`.
+
+Supported paths:
+
+| Method | Path |
+|---|---|
+| `POST` | `/v1/completions` |
+| `POST` | `/v1/chat/completions` |
+
+Proxy errors:
+
+| Status | Condition |
+|---|---|
+| `400` | unsafe request id, invalid JSON, non-object JSON, or `stream: true` |
+| `404` | unsupported path |
+| `409` | request id reused with different endpoint or payload |
+| `413` | body exceeds `MAX_REQUEST_BODY_BYTES` |
+| `415` | explicit non-JSON content type |
+| `503` | broker stopped or reports unknown request after submit |
+| `504` | broker wait timed out |
+
+The proxy should call the long-running actor operation for `broker.wait`. Its
+HTTP serving implementation must either be single-threaded, copy Iris/Fray
+context into handler threads, or capture a broker handle that does not depend
+on thread-local context lookups.
+
+## Launcher API
+
+```python
+@dataclass(frozen=True)
+class IrisVllmLauncherConfig:
+    worker_count: int
+    worker_resources: ResourceConfig
+    broker_resources: ResourceConfig
+    lease_timeout: float = DEFAULT_LEASE_TIMEOUT
+    request_timeout: float = DEFAULT_REQUEST_TIMEOUT
+    worker_lease_wait_timeout: float = DEFAULT_WORKER_LEASE_WAIT_TIMEOUT
+    worker_ready_timeout: float = DEFAULT_WORKER_READY_TIMEOUT
+    proxy_host: str = "127.0.0.1"
+    proxy_port: int = 0
+    service_name: str | None = None
+    extra_vllm_args: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class IrisVllmLauncher(ModelLauncher):
+    client: Client
+    config: IrisVllmLauncherConfig
+
+    def launch(self, deployment: ModelDeployment) -> AbstractContextManager[RunningModel]: ...
+```
+
+Launcher validation:
+
+- `worker_count > 0`
+- all timeout values are positive
+- `lease_timeout > request_timeout`
+- `extra_vllm_args` does not include `--served-model-name`
+- `worker_resources` requests the accelerator topology for each worker replica
+
+Startup:
+
+1. Create the broker.
+2. Start worker replicas.
+3. Wait for `worker_count` readiness records within `worker_ready_timeout`.
+4. Require every readiness model id to equal `deployment.model_name`.
+5. Start the local proxy.
+6. Yield `RunningModel(OpenAIEndpoint(base_url=proxy.base_url, model=deployment.model_name), tokenizer=deployment.tokenizer)`.
+
+Context exit:
+
+1. Stop the proxy.
+2. Call `broker.stop()`.
+3. Wait up to `DEFAULT_CLEANUP_TIMEOUT` for worker operations to end.
+4. Surface partial-start and cleanup failures with broker state, worker ids,
+   and vLLM diagnostics when available.
+
+## Manual Pressure-Test Runner
+
+`scripts/iris/run_vllm_eval_pressure_test.py` should accept:
+
+```text
+--model-name <served name>
+--model-path <gs://... or hf id>
+--tokenizer <hf id or local path>
+--output-path <local or gs:// path>
+--tpu-type <iris tpu type>
+--worker-count <int>
+--task standard_humaneval_smoke|mmlu_sl_verb_5shot|humaneval_5shot
+--limit <int>
+--dry-run
+```
+
+Runner behavior:
+
+- Default to `standard_humaneval_smoke` with
+  `LmEvalAdapter.LOCAL_CHAT_COMPLETIONS` and `apply_chat_template=True`.
+- Treat `mmlu_sl_verb_5shot` as a follow-up prompt-logprob check using
+  `LmEvalAdapter.LOCAL_COMPLETIONS`.
+- Treat `humaneval_5shot` as valid only if saved lm-eval artifacts record the
+  requested few-shot setting.
+- Record Iris job ids, served model id from `/v1/models`, output directory,
+  request counts by endpoint, throughput if available, and failure diagnostics.
+- Upload lm-eval outputs when `--output-path` is `gs://`; otherwise write
+  locally.
+
+This script is manual-only and must not run in normal CI.
+
+## Tests
+
+CI should cover:
+
+- broker submit/lease/complete/wait lifecycle;
+- expired lease requeue;
+- stale lease terminal result ignored;
+- duplicate terminal result keeps the first valid response;
+- conflicting duplicate submit returns `409` through the proxy;
+- unsafe request id returns `400` and is not echoed;
+- invalid JSON, non-object JSON, `stream: true`, non-JSON content type, and
+  oversized body errors;
+- proxy/worker routing for completions and chat completions against a
+  deterministic OpenAI-compatible stub;
+- tiny real lm-eval path gated by optional dependencies.
+
+Manual testing should run the standard-model pressure test on Iris before the
+first implementation PR is treated as production-shaped. Prompt-logprob scoring
+is a follow-up compatibility gate.
+
+## Out of Scope
+
+- Levanter/JAX behind OpenAI HTTP.
+- Engine polymorphism.
+- Persistent broker queue or broker restart recovery.
+- OpenAI server-sent streaming.
+- Cancellation of in-flight vLLM requests.
+- Multi-tenant always-on inference service.
+- Harbor/Evalchemy migration in the first implementation PR.
+- Parameter syncing for RL or in-training-loop evals.

--- a/lib/marin/src/marin/evaluation/evaluators/lm_evaluation_harness_evaluator.py
+++ b/lib/marin/src/marin/evaluation/evaluators/lm_evaluation_harness_evaluator.py
@@ -117,6 +117,7 @@ class LMEvaluationHarnessEvaluator(Evaluator):
                             tasks=[eval_task.name],
                             num_fewshot=eval_task.num_fewshot,
                             model_args=pretrained_args_local,
+                            gen_kwargs=model.generation_params or None,
                             apply_chat_template=resolved_model.apply_chat_template,
                             batch_size="auto",
                             confirm_run_unsafe_code=True,


### PR DESCRIPTION
Define a vLLM-only Iris inference service for Marin evals where evaluators keep using RunningModel and OpenAI-compatible HTTP while Iris owns vLLM lifecycle, readiness, request brokering, cleanup, and diagnostics. The RFC uses standard-model validation as the MVP, keeps prompt-logprob scoring as follow-up compatibility work, and includes the lm-eval generation-params fix needed by the pressure-test runner.