### PR TITLE
hplt: stream filter inline

### DIFF
--- a/experiments/pretraining_datasets/hplt.py
+++ b/experiments/pretraining_datasets/hplt.py
@@ -11,7 +11,11 @@ adding ~612.7B unique tokens from European web crawls.
 import os.path
 
 from fray import ResourceConfig
-from marin.datakit.download.hplt import download_hplt_v3_step, normalize_hplt_v3_step
+from marin.datakit.download.hplt import (
+    download_hplt_v3_raw_step,
+    filter_hplt_v3_step,
+    normalize_hplt_v3_step,
+)
 from marin.execution.executor import ExecutorStep, output_path_of, this_output_path, versioned
 from marin.processing.tokenize import TokenizeConfig, tokenize
 from marin.processing.tokenize.data_configs import TokenizerStep
@@ -20,9 +24,10 @@ HPLT_DATASETS = {
     "all": ["*.parquet"],
 }
 
-_hplt_v3_download_spec = download_hplt_v3_step()
-hplt_v3_download = _hplt_v3_download_spec.as_executor_step()
-hplt_v3_normalized = normalize_hplt_v3_step(_hplt_v3_download_spec).as_executor_step()
+_hplt_v3_raw_spec = download_hplt_v3_raw_step()
+_hplt_v3_filtered_spec = filter_hplt_v3_step(_hplt_v3_raw_spec)
+hplt_v3_download = _hplt_v3_filtered_spec.as_executor_step()
+hplt_v3_normalized = normalize_hplt_v3_step(_hplt_v3_filtered_spec).as_executor_step()
 
 
 def tokenize_hplt_v3(

--- a/experiments/pretraining_datasets/hplt.py
+++ b/experiments/pretraining_datasets/hplt.py
@@ -11,11 +11,7 @@ adding ~612.7B unique tokens from European web crawls.
 import os.path
 
 from fray import ResourceConfig
-from marin.datakit.download.hplt import (
-    download_hplt_v3_raw_step,
-    filter_hplt_v3_step,
-    normalize_hplt_v3_step,
-)
+from marin.datakit.download.hplt import download_hplt_v3_step, normalize_hplt_v3_step
 from marin.execution.executor import ExecutorStep, output_path_of, this_output_path, versioned
 from marin.processing.tokenize import TokenizeConfig, tokenize
 from marin.processing.tokenize.data_configs import TokenizerStep
@@ -24,10 +20,9 @@ HPLT_DATASETS = {
     "all": ["*.parquet"],
 }
 
-_hplt_v3_raw_spec = download_hplt_v3_raw_step()
-_hplt_v3_filtered_spec = filter_hplt_v3_step(_hplt_v3_raw_spec)
-hplt_v3_download = _hplt_v3_filtered_spec.as_executor_step()
-hplt_v3_normalized = normalize_hplt_v3_step(_hplt_v3_filtered_spec).as_executor_step()
+_hplt_v3_download_spec = download_hplt_v3_step()
+hplt_v3_download = _hplt_v3_download_spec.as_executor_step()
+hplt_v3_normalized = normalize_hplt_v3_step(_hplt_v3_download_spec).as_executor_step()
 
 
 def tokenize_hplt_v3(

--- a/lib/marin/src/marin/datakit/download/hplt.py
+++ b/lib/marin/src/marin/datakit/download/hplt.py
@@ -1,31 +1,22 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Download and filter HPLT v3.0 dataset, keeping only non-Common Crawl sources (WIDE, survey).
-
-The pipeline is split into two stages so that the filter can iterate without
-re-paying the cost (and external-failure risk) of HPLT downloads:
-
-1. ``download_hplt_v3_raw`` — stream non-CC records from each shard URL and
-   write them to parquet untouched (apart from the structural CC drop).
-2. ``filter_hplt_v3`` — read the cached raw parquet, apply the register-based
-   quality filter, emit dolma-format records.
-"""
+"""Download and filter HPLT v3.0 dataset, keeping only non-Common Crawl sources (WIDE, survey)."""
 
 import json
 import logging
 import os
-import time
 from collections.abc import Iterator
 from contextlib import closing
+from dataclasses import dataclass
+from functools import cache
 
 import requests
-import urllib3
 import zstandard
 from fray import ResourceConfig
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
-from zephyr import Dataset, ZephyrContext, counters, load_parquet
+from zephyr import Dataset, ZephyrContext, counters
 
 from marin.datakit.normalize import normalize_step
 from marin.execution.step_spec import StepSpec
@@ -109,17 +100,17 @@ def _iter_jsonl_from_zstd_stream(raw_stream) -> Iterator[dict]:
 
 
 def passes_quality_filter(doc: dict, wds_tier: int) -> bool:
-    """Apply register-based quality filter to a raw HPLT record.
+    """Apply register-based quality filter to an HPLT document.
 
     Filter rules derived from empirical analysis with Haiku as ground truth classifier,
     achieving ~99% agreement on coherent/incoherent classification.
     """
-    wr = doc["web_register"]
+    wr = doc.get("web-register", {})
     mt = wr.get("MT", 0)  # Machine Translated score
     ds = wr.get("ds", 0)  # Description with Intent to Sell score
 
     # Hard rejections
-    if doc["pii"]:
+    if doc.get("pii"):
         return False
     if mt >= 0.2:
         return False
@@ -153,17 +144,32 @@ def _is_non_cc_source(crawl_id: str) -> bool:
     return any(crawl_id.startswith(prefix) for prefix in NON_CC_PREFIXES)
 
 
-def _get_all_shard_urls() -> list[tuple[int, int, str]]:
-    """Return (wds_tier, shard_num, url) for every HPLT English shard."""
+@dataclass(frozen=True)
+class HpltShard:
+    """Identifier and source URL for a single HPLT English shard."""
+
+    tier: int
+    shard: int
+    url: str
+
+
+def _get_all_shards() -> list[HpltShard]:
+    """Return one ``HpltShard`` for every HPLT English shard."""
     shards = []
     for tier, count in HPLT_SHARD_COUNTS.items():
         for shard in range(1, count + 1):
             url = f"{HPLT_BASE_URL}/{tier}_{shard}.jsonl.zst"
-            shards.append((tier, shard, url))
+            shards.append(HpltShard(tier=tier, shard=shard, url=url))
     return shards
 
 
+@cache
 def _make_session() -> requests.Session:
+    """Return a per-process ``requests.Session`` with retry-aware HTTPS adapter.
+
+    Cached so repeated shard tasks on the same worker reuse the connection pool
+    instead of opening a new one per shard.
+    """
     session = requests.Session()
     retries = Retry(total=5, backoff_factor=1.0, status_forcelist=[500, 502, 503, 504], allowed_methods=["GET"])
     adapter = HTTPAdapter(max_retries=retries)
@@ -172,150 +178,89 @@ def _make_session() -> requests.Session:
     return session
 
 
-MAX_SHARD_RETRIES = 3
+def _download_and_filter_shard(shard: HpltShard) -> Iterator[dict]:
+    """Stream filtered HPLT records from a shard URL.
 
-
-def _stream_raw_shard(tier: int, shard: int, url: str) -> Iterator[dict]:
-    """Stream raw non-CC HPLT records from a shard URL.
-
-    Records are yielded inline; if the connection drops mid-stream the
-    generator raises and zephyr restarts the whole shard task (which discards
-    the partial output via ``write_parquet``'s atomic writes). The local
-    ``MAX_SHARD_RETRIES`` only covers retries that happen before any record
-    has been yielded — once we start yielding we hand retry responsibility to
-    zephyr.
+    CC + quality filters applied inline; records are yielded one at a time so
+    worker memory stays O(record) rather than O(shard). Mid-stream failures
+    propagate to zephyr, which retries the whole shard task (atomic parquet
+    writes mean the partial output is discarded). The session adapter handles
+    transient connection-level retries before any record is yielded.
     """
     session = _make_session()
-    for attempt in range(MAX_SHARD_RETRIES):
-        try:
-            logger.info(f"Downloading HPLT shard {tier}_{shard} (attempt {attempt + 1}/{MAX_SHARD_RETRIES})")
-            response = session.get(url, headers={"user-agent": "marin-hplt-ingress/1.0"}, stream=True)
-            response.raise_for_status()
+    logger.info(f"Processing HPLT shard {shard.tier}_{shard.shard}")
+    response = session.get(shard.url, headers={"user-agent": "marin-hplt-ingress/1.0"}, stream=True)
+    response.raise_for_status()
 
-            num_input = 0
-            num_non_cc = 0
-            with closing(response):
-                for record in _iter_jsonl_from_zstd_stream(response.raw):
-                    num_input += 1
-                    crawl_id = record.get("crawl_id", "")
-                    if not _is_non_cc_source(crawl_id):
-                        continue
-                    num_non_cc += 1
-                    yield {
-                        "id": record.get("id", ""),
-                        "text": record.get("text", ""),
-                        "crawl_id": crawl_id,
-                        "url": record.get("u", ""),
-                        "timestamp": record.get("ts", ""),
-                        "web_register": record.get("web-register", {}),
-                        "doc_scores": record.get("doc_scores", []),
-                        "pii": bool(record.get("pii")),
-                        "wds_tier": tier,
-                    }
-            counters.increment("hplt/raw_input", num_input)
-            counters.increment("hplt/raw_non_cc", num_non_cc)
-            return
-        except (
-            requests.exceptions.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-            urllib3.exceptions.ProtocolError,
-        ) as e:
-            if attempt + 1 == MAX_SHARD_RETRIES:
-                raise
-            wait = 2 ** (attempt + 1)
-            logger.warning(f"Shard {tier}_{shard} failed (attempt {attempt + 1}): {e}. Retrying in {wait}s.")
-            time.sleep(wait)
-    raise RuntimeError(f"unreachable: retry loop for shard {tier}_{shard} exited without return or raise")
+    num_input = 0
+    num_non_cc = 0
+    num_kept = 0
+    try:
+        with closing(response):
+            for record in _iter_jsonl_from_zstd_stream(response.raw):
+                num_input += 1
+                crawl_id = record.get("crawl_id", "")
+                if not _is_non_cc_source(crawl_id):
+                    continue
+                num_non_cc += 1
+
+                if not passes_quality_filter(record, shard.tier):
+                    continue
+                num_kept += 1
+                yield {
+                    "id": record.get("id", ""),
+                    "text": record.get("text", ""),
+                    "source": f"hplt_v3_{crawl_id}",
+                    "format": "text",
+                    "metadata": {
+                        "hplt_wds_tier": shard.tier,
+                        "hplt_crawl_id": crawl_id,
+                        "hplt_url": record.get("u", ""),
+                        "hplt_timestamp": record.get("ts", ""),
+                        "hplt_web_register": record.get("web-register", {}),
+                        "hplt_doc_scores": record.get("doc_scores", []),
+                    },
+                }
+    finally:
+        counters.increment("hplt/input", num_input)
+        counters.increment("hplt/non_cc", num_non_cc)
+        counters.increment("hplt/kept", num_kept)
 
 
-def _filter_to_dolma(record: dict) -> Iterator[dict]:
-    """Apply the quality filter and emit a dolma-format record if it passes."""
-    if not passes_quality_filter(record, record["wds_tier"]):
-        return
-    crawl_id = record["crawl_id"]
-    yield {
-        "id": record["id"],
-        "text": record["text"],
-        "source": f"hplt_v3_{crawl_id}",
-        "format": "text",
-        "metadata": {
-            "hplt_wds_tier": record["wds_tier"],
-            "hplt_crawl_id": crawl_id,
-            "hplt_url": record["url"],
-            "hplt_timestamp": record["timestamp"],
-            "hplt_web_register": record["web_register"],
-            "hplt_doc_scores": record["doc_scores"],
-        },
-    }
-    counters.increment("hplt/kept", 1)
-
-
-def download_hplt_v3_raw(output_path: str) -> None:
-    """Stage 1: download raw HPLT v3.0 English non-CC shards (no quality filter)."""
-    all_shards = _get_all_shard_urls()
-    logger.info(f"Downloading {len(all_shards)} HPLT shards to {output_path}")
+def download_hplt_v3(output_path: str) -> None:
+    """Download and filter HPLT v3.0 English dataset, keeping only non-CC sources."""
+    all_shards = _get_all_shards()
+    logger.info(f"Processing {len(all_shards)} HPLT shards")
 
     pipeline = (
         Dataset.from_list(all_shards)
-        .flat_map(lambda info: _stream_raw_shard(info[0], info[1], info[2]))
+        .flat_map(_download_and_filter_shard)
         .write_parquet(os.path.join(output_path, "data-{shard:05d}-of-{total:05d}.parquet"), skip_existing=True)
     )
 
     ctx = ZephyrContext(
-        name="download-hplt-v3-raw",
-        max_workers=128,
+        name="download-hplt-v3",
+        max_workers=512,
         resources=ResourceConfig(cpu=1, ram="8g", disk="5g"),
     )
     ctx.execute(pipeline)
 
-    logger.info(f"Wrote raw HPLT v3 shards to {output_path}")
+    logger.info(f"Downloaded HPLT v3 files to {output_path}")
 
 
-def filter_hplt_v3(input_path: str, output_path: str) -> None:
-    """Stage 2: apply register-based quality filter to cached raw HPLT records."""
-    logger.info(f"Filtering raw HPLT v3 records from {input_path} into {output_path}")
-
-    pipeline = (
-        Dataset.from_files(os.path.join(input_path, "*.parquet"))
-        .flat_map(load_parquet)
-        .flat_map(_filter_to_dolma)
-        .write_parquet(os.path.join(output_path, "data-{shard:05d}-of-{total:05d}.parquet"), skip_existing=True)
-    )
-
-    ctx = ZephyrContext(
-        name="filter-hplt-v3",
-        max_workers=128,
-        resources=ResourceConfig(cpu=1, ram="8g", disk="2g"),
-    )
-    ctx.execute(pipeline)
-
-    logger.info(f"Wrote filtered HPLT v3 records to {output_path}")
-
-
-def download_hplt_v3_raw_step() -> StepSpec:
-    """Stage 1 StepSpec: raw HPLT v3 download (non-CC, no quality filter)."""
-    return StepSpec(
-        name="raw/hplt_v3_unfiltered",
-        fn=lambda output_path: download_hplt_v3_raw(output_path=output_path),
-        override_output_path="raw/hplt_v3_unfiltered",
-    )
-
-
-def filter_hplt_v3_step(raw: StepSpec) -> StepSpec:
-    """Stage 2 StepSpec: register-based quality filter over cached raw HPLT v3."""
+def download_hplt_v3_step() -> StepSpec:
+    """Create a StepSpec that downloads and filters the HPLT v3 English dataset."""
     return StepSpec(
         name="raw/hplt_v3",
-        fn=lambda output_path: filter_hplt_v3(input_path=raw.output_path, output_path=output_path),
-        deps=[raw],
-        override_output_path="raw/hplt_v3",
+        fn=lambda output_path: download_hplt_v3(output_path=output_path),
     )
 
 
-def normalize_hplt_v3_step(filtered: StepSpec) -> StepSpec:
+def normalize_hplt_v3_step(download: StepSpec) -> StepSpec:
     """Normalize HPLT v3: generate content-hash IDs, preserve HPLT id as source_id."""
     return normalize_step(
         name="normalized/hplt_v3",
-        download=filtered,
+        download=download,
         text_field="text",
         id_field="id",
         file_extensions=(".parquet",),
@@ -323,7 +268,6 @@ def normalize_hplt_v3_step(filtered: StepSpec) -> StepSpec:
 
 
 def hplt_v3_normalize_steps() -> tuple[StepSpec, ...]:
-    """Return the ``(raw_download, filter, normalize)`` chain for HPLT v3."""
-    raw = download_hplt_v3_raw_step()
-    filtered = filter_hplt_v3_step(raw)
-    return (raw, filtered, normalize_hplt_v3_step(filtered))
+    """Return the ``(download, normalize)`` chain for HPLT v3."""
+    download = download_hplt_v3_step()
+    return (download, normalize_hplt_v3_step(download))

--- a/lib/marin/src/marin/datakit/download/hplt.py
+++ b/lib/marin/src/marin/datakit/download/hplt.py
@@ -1,7 +1,16 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Download and filter HPLT v3.0 dataset, keeping only non-Common Crawl sources (WIDE, survey)."""
+"""Download and filter HPLT v3.0 dataset, keeping only non-Common Crawl sources (WIDE, survey).
+
+The pipeline is split into two stages so that the filter can iterate without
+re-paying the cost (and external-failure risk) of HPLT downloads:
+
+1. ``download_hplt_v3_raw`` — stream non-CC records from each shard URL and
+   write them to parquet untouched (apart from the structural CC drop).
+2. ``filter_hplt_v3`` — read the cached raw parquet, apply the register-based
+   quality filter, emit dolma-format records.
+"""
 
 import json
 import logging
@@ -13,9 +22,10 @@ from contextlib import closing
 import requests
 import urllib3
 import zstandard
+from fray import ResourceConfig
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
-from zephyr import Dataset, ZephyrContext, counters
+from zephyr import Dataset, ZephyrContext, counters, load_parquet
 
 from marin.datakit.normalize import normalize_step
 from marin.execution.step_spec import StepSpec
@@ -99,17 +109,17 @@ def _iter_jsonl_from_zstd_stream(raw_stream) -> Iterator[dict]:
 
 
 def passes_quality_filter(doc: dict, wds_tier: int) -> bool:
-    """Apply register-based quality filter to an HPLT document.
+    """Apply register-based quality filter to a raw HPLT record.
 
     Filter rules derived from empirical analysis with Haiku as ground truth classifier,
     achieving ~99% agreement on coherent/incoherent classification.
     """
-    wr = doc.get("web-register", {})
+    wr = doc["web_register"]
     mt = wr.get("MT", 0)  # Machine Translated score
     ds = wr.get("ds", 0)  # Description with Intent to Sell score
 
     # Hard rejections
-    if doc.get("pii"):
+    if doc["pii"]:
         return False
     if mt >= 0.2:
         return False
@@ -165,53 +175,45 @@ def _make_session() -> requests.Session:
 MAX_SHARD_RETRIES = 3
 
 
-def _download_and_filter_shard(tier: int, shard: int, url: str) -> Iterator[dict]:
-    """Download an HPLT shard, filter, and yield dolma-format records with retries."""
+def _stream_raw_shard(tier: int, shard: int, url: str) -> Iterator[dict]:
+    """Stream raw non-CC HPLT records from a shard URL.
+
+    Records are yielded inline; if the connection drops mid-stream the
+    generator raises and zephyr restarts the whole shard task (which discards
+    the partial output via ``write_parquet``'s atomic writes). The local
+    ``MAX_SHARD_RETRIES`` only covers retries that happen before any record
+    has been yielded — once we start yielding we hand retry responsibility to
+    zephyr.
+    """
     session = _make_session()
     for attempt in range(MAX_SHARD_RETRIES):
         try:
-            logger.info(f"Processing HPLT shard {tier}_{shard} (attempt {attempt + 1}/{MAX_SHARD_RETRIES})")
+            logger.info(f"Downloading HPLT shard {tier}_{shard} (attempt {attempt + 1}/{MAX_SHARD_RETRIES})")
             response = session.get(url, headers={"user-agent": "marin-hplt-ingress/1.0"}, stream=True)
             response.raise_for_status()
 
             num_input = 0
             num_non_cc = 0
-            num_kept = 0
-            filtered_records = []
             with closing(response):
                 for record in _iter_jsonl_from_zstd_stream(response.raw):
                     num_input += 1
                     crawl_id = record.get("crawl_id", "")
-
                     if not _is_non_cc_source(crawl_id):
                         continue
                     num_non_cc += 1
-
-                    if not passes_quality_filter(record, tier):
-                        continue
-
-                    num_kept += 1
-                    filtered_records.append(
-                        {
-                            "id": record.get("id", ""),
-                            "text": record.get("text", ""),
-                            "source": f"hplt_v3_{crawl_id}",
-                            "format": "text",
-                            "metadata": {
-                                "hplt_wds_tier": tier,
-                                "hplt_crawl_id": crawl_id,
-                                "hplt_url": record.get("u", ""),
-                                "hplt_timestamp": record.get("ts", ""),
-                                "hplt_web_register": record.get("web-register", {}),
-                                "hplt_doc_scores": record.get("doc_scores", []),
-                            },
-                        }
-                    )
-
-            counters.increment("hplt/input", num_input)
-            counters.increment("hplt/non_cc", num_non_cc)
-            counters.increment("hplt/kept", num_kept)
-            yield from filtered_records
+                    yield {
+                        "id": record.get("id", ""),
+                        "text": record.get("text", ""),
+                        "crawl_id": crawl_id,
+                        "url": record.get("u", ""),
+                        "timestamp": record.get("ts", ""),
+                        "web_register": record.get("web-register", {}),
+                        "doc_scores": record.get("doc_scores", []),
+                        "pii": bool(record.get("pii")),
+                        "wds_tier": tier,
+                    }
+            counters.increment("hplt/raw_input", num_input)
+            counters.increment("hplt/raw_non_cc", num_non_cc)
             return
         except (
             requests.exceptions.ConnectionError,
@@ -226,37 +228,94 @@ def _download_and_filter_shard(tier: int, shard: int, url: str) -> Iterator[dict
     raise RuntimeError(f"unreachable: retry loop for shard {tier}_{shard} exited without return or raise")
 
 
-def download_hplt_v3(output_path: str) -> None:
-    """Download and filter HPLT v3.0 English dataset, keeping only non-CC sources."""
+def _filter_to_dolma(record: dict) -> Iterator[dict]:
+    """Apply the quality filter and emit a dolma-format record if it passes."""
+    if not passes_quality_filter(record, record["wds_tier"]):
+        return
+    crawl_id = record["crawl_id"]
+    yield {
+        "id": record["id"],
+        "text": record["text"],
+        "source": f"hplt_v3_{crawl_id}",
+        "format": "text",
+        "metadata": {
+            "hplt_wds_tier": record["wds_tier"],
+            "hplt_crawl_id": crawl_id,
+            "hplt_url": record["url"],
+            "hplt_timestamp": record["timestamp"],
+            "hplt_web_register": record["web_register"],
+            "hplt_doc_scores": record["doc_scores"],
+        },
+    }
+    counters.increment("hplt/kept", 1)
+
+
+def download_hplt_v3_raw(output_path: str) -> None:
+    """Stage 1: download raw HPLT v3.0 English non-CC shards (no quality filter)."""
     all_shards = _get_all_shard_urls()
-    logger.info(f"Processing {len(all_shards)} HPLT shards")
+    logger.info(f"Downloading {len(all_shards)} HPLT shards to {output_path}")
 
     pipeline = (
         Dataset.from_list(all_shards)
-        .flat_map(lambda info: _download_and_filter_shard(info[0], info[1], info[2]))
+        .flat_map(lambda info: _stream_raw_shard(info[0], info[1], info[2]))
         .write_parquet(os.path.join(output_path, "data-{shard:05d}-of-{total:05d}.parquet"), skip_existing=True)
     )
 
-    ctx = ZephyrContext(name="download-hplt-v3", max_workers=32)
+    ctx = ZephyrContext(
+        name="download-hplt-v3-raw",
+        max_workers=128,
+        resources=ResourceConfig(cpu=1, ram="8g", disk="5g"),
+    )
     ctx.execute(pipeline)
 
-    logger.info(f"Downloaded HPLT v3 files to {output_path}")
+    logger.info(f"Wrote raw HPLT v3 shards to {output_path}")
 
 
-def download_hplt_v3_step() -> StepSpec:
-    """Create a StepSpec that downloads and filters the HPLT v3 English dataset."""
+def filter_hplt_v3(input_path: str, output_path: str) -> None:
+    """Stage 2: apply register-based quality filter to cached raw HPLT records."""
+    logger.info(f"Filtering raw HPLT v3 records from {input_path} into {output_path}")
+
+    pipeline = (
+        Dataset.from_files(os.path.join(input_path, "*.parquet"))
+        .flat_map(load_parquet)
+        .flat_map(_filter_to_dolma)
+        .write_parquet(os.path.join(output_path, "data-{shard:05d}-of-{total:05d}.parquet"), skip_existing=True)
+    )
+
+    ctx = ZephyrContext(
+        name="filter-hplt-v3",
+        max_workers=128,
+        resources=ResourceConfig(cpu=1, ram="8g", disk="2g"),
+    )
+    ctx.execute(pipeline)
+
+    logger.info(f"Wrote filtered HPLT v3 records to {output_path}")
+
+
+def download_hplt_v3_raw_step() -> StepSpec:
+    """Stage 1 StepSpec: raw HPLT v3 download (non-CC, no quality filter)."""
+    return StepSpec(
+        name="raw/hplt_v3_unfiltered",
+        fn=lambda output_path: download_hplt_v3_raw(output_path=output_path),
+        override_output_path="raw/hplt_v3_unfiltered",
+    )
+
+
+def filter_hplt_v3_step(raw: StepSpec) -> StepSpec:
+    """Stage 2 StepSpec: register-based quality filter over cached raw HPLT v3."""
     return StepSpec(
         name="raw/hplt_v3",
-        fn=lambda output_path: download_hplt_v3(output_path=output_path),
+        fn=lambda output_path: filter_hplt_v3(input_path=raw.output_path, output_path=output_path),
+        deps=[raw],
         override_output_path="raw/hplt_v3",
     )
 
 
-def normalize_hplt_v3_step(download: StepSpec) -> StepSpec:
+def normalize_hplt_v3_step(filtered: StepSpec) -> StepSpec:
     """Normalize HPLT v3: generate content-hash IDs, preserve HPLT id as source_id."""
     return normalize_step(
         name="normalized/hplt_v3",
-        download=download,
+        download=filtered,
         text_field="text",
         id_field="id",
         file_extensions=(".parquet",),
@@ -264,6 +323,7 @@ def normalize_hplt_v3_step(download: StepSpec) -> StepSpec:
 
 
 def hplt_v3_normalize_steps() -> tuple[StepSpec, ...]:
-    """Return the ``(download, normalize)`` chain for HPLT v3."""
-    download = download_hplt_v3_step()
-    return (download, normalize_hplt_v3_step(download))
+    """Return the ``(raw_download, filter, normalize)`` chain for HPLT v3."""
+    raw = download_hplt_v3_raw_step()
+    filtered = filter_hplt_v3_step(raw)
+    return (raw, filtered, normalize_hplt_v3_step(filtered))


### PR DESCRIPTION
* fix worker OOM on the largest HPLT shards by streaming filtered records inline
* `_download_and_filter_shard` now yields one filtered record at a time instead of materializing the per-shard `filtered_records` list before a trailing `yield from` — memory becomes O(record) instead of O(shard) (the prior buffer hit the 16 GB worker limit on tier-5/6 shards)
* drop the in-function `MAX_SHARD_RETRIES` retry loop — once we yield mid-stream we can no longer restart from scratch
  * exceptions propagate to zephyr instead, which retries each shard up to `MAX_SHARD_FAILURES=3` (TASK kind), regardless of exception type [^1]
* replace the `(tier, shard, url)` tuple with a frozen `HpltShard` dataclass
* `@cache` on `_make_session()` so workers reuse the urllib3 connection pool across shards on the same process instead of opening a new pool per task
* bump worker resources to `cpu=1, ram=8g, disk=5g` with `max_workers=512`

[^1]: see `lib/zephyr/src/zephyr/execution.py:1414` (worker's bare `except Exception` → `coordinator.report_error`) and `:670` (`_record_shard_failure` re-queues TASK-kind up to `MAX_SHARD_FAILURES`); covered by `test_report_error_requeues_until_max_shard_failures` in `lib/zephyr/tests/test_execution.py`.