### PR TITLE
iris: register cluster endpoints before spawning autoscaler

### DIFF
--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -808,7 +808,7 @@ Examples:
         "requested by worker tasks spawned by the job."
     ),
 )
-@click.option("--cpu", type=float, default=0.5, show_default=True, help="Number of CPUs to request")
+@click.option("--cpu", type=float, default=0.1, show_default=True, help="Number of CPUs to request")
 @click.option("--memory", type=str, default="1GB", show_default=True, help="Memory size to request (e.g., 8GB, 512MB)")
 @click.option(
     "--disk", type=str, default="5GB", show_default=True, help="Ephemeral disk size to request (e.g., 64GB, 1TB)"

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -1369,6 +1369,16 @@ class Controller:
         self._server = uvicorn.Server(server_config)
         self._threads.spawn_server(self._server, name="controller-server")
 
+        # Register cluster endpoints BEFORE spawning the autoscaler. Otherwise the
+        # autoscaler's first tick can create buffer slices whose workers query the
+        # controller for /system/log-server before this dict is populated, returning
+        # an empty result. The slice creation fails, the group enters backoff, and
+        # any task constrained to that group hangs until the backoff expires.
+        for name, url in self._config.endpoints.items():
+            self._service._system_endpoints[name] = url
+            logger.info("Registered system endpoint %s -> %s", name, url)
+        self._service._system_endpoints["/system/log-server"] = self._log_service_address
+
         if self._autoscaler:
             logger.info("Autoscaler configured with %d scale groups", len(self._autoscaler.groups))
             self._autoscaler_thread = self._threads.spawn(self._run_autoscaler_loop, name="autoscaler-loop")
@@ -1386,17 +1396,6 @@ class Controller:
             lambda: self._server is not None and self._server.started,
             timeout=Duration.from_seconds(5.0),
         )
-
-        # Register configured cluster endpoints so workers can resolve them via ListEndpoints.
-        # Endpoints are pre-resolved (scheme dispatched) by the daemon entrypoint.
-        for name, url in self._config.endpoints.items():
-            self._service._system_endpoints[name] = url
-            logger.info("Registered system endpoint %s -> %s", name, url)
-
-        # Always advertise the in-use log server address under /system/log-server.
-        # If the daemon supplied it via endpoints, this is a no-op overwrite with
-        # the same value; in tests the in-process server's address lands here.
-        self._service._system_endpoints["/system/log-server"] = self._log_service_address
 
     def stop(self) -> None:
         """Stop all background components gracefully. Idempotent.

--- a/lib/iris/src/iris/cluster/providers/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/tasks.py
@@ -412,26 +412,31 @@ def _build_pod_manifest(
     if run_req.HasField("resources"):
         res = run_req.resources
         limits: dict[str, str] = {}
+        requests: dict[str, str] = {}
         if res.cpu_millicores:
-            limits["cpu"] = f"{res.cpu_millicores}m"
+            # CPU as a request only (no limits.cpu) so containers can burst onto
+            # idle node CPU. The scheduler still places by cpu_millicores, and
+            # under contention CFS shares CPU proportionally to requests. This
+            # matches the soft-cap behavior the docker runtime uses for
+            # CAPACITY_TYPE_ON_DEMAND workers.
+            requests["cpu"] = f"{res.cpu_millicores}m"
         if res.memory_bytes:
+            # Memory stays a hard cap — overshoot is fatal, not just slow.
             limits["memory"] = str(res.memory_bytes)
+            requests["memory"] = str(res.memory_bytes)
         if res.HasField("device"):
             gpu_count = get_gpu_count(res.device)
             has_tpu = res.device.HasField("tpu")
             if gpu_count > 0:
+                # K8s treats accelerator limits as implicit requests.
                 limits["nvidia.com/gpu"] = str(gpu_count)
                 if host_network:
                     # Request RDMA/IB devices for multi-host NCCL over InfiniBand.
                     limits["rdma/ib"] = str(gpu_count)
         if limits:
             resources["limits"] = limits
-            # Set requests = limits for CPU/memory so K8s schedules based on
-            # actual resource needs. GPU/RDMA are excluded (K8s treats GPU
-            # limits as implicit requests).
-            requests = {k: v for k, v in limits.items() if k in ("cpu", "memory")}
-            if requests:
-                resources.setdefault("requests", {}).update(requests)
+        if requests:
+            resources.setdefault("requests", {}).update(requests)
         if res.disk_bytes:
             disk_gi = max(1, res.disk_bytes // (1024**3))
             resources.setdefault("requests", {})["ephemeral-storage"] = f"{disk_gi}Gi"

--- a/lib/iris/src/iris/cluster/runtime/docker.py
+++ b/lib/iris/src/iris/cluster/runtime/docker.py
@@ -52,7 +52,7 @@ from iris.cluster.runtime.types import (
     MountSpec,
 )
 from iris.cluster.worker.worker_types import LogLine, TaskLogs
-from iris.rpc import job_pb2
+from iris.rpc import config_pb2, job_pb2
 
 logger = logging.getLogger(__name__)
 
@@ -687,8 +687,13 @@ exec {quoted_cmd}
         # Resource limits (cgroups v2) — always applied
         cpu_millicores = config.get_cpu_millicores()
         if cpu_millicores:
-            cpus = cpu_millicores / 1000
-            cmd.extend(["--cpus", str(cpus)])
+            if self.runtime.capacity_type == config_pb2.CAPACITY_TYPE_ON_DEMAND:
+                # Soft weight: on-demand workers let containers burst onto idle
+                # host CPU; the scheduler still places by cpu_millicores.
+                shares = max(2, int(cpu_millicores * 1024 / 1000))
+                cmd.extend(["--cpu-shares", str(shares)])
+            else:
+                cmd.extend(["--cpus", str(cpu_millicores / 1000)])
         effective_memory_mb = memory_limit_mb or config.get_memory_mb()
         if effective_memory_mb:
             cmd.extend(["--memory", f"{effective_memory_mb}m"])
@@ -865,8 +870,13 @@ class DockerRuntime:
     Tracks all created containers for cleanup on shutdown.
     """
 
-    def __init__(self, cache_dir: Path) -> None:
+    def __init__(self, cache_dir: Path, capacity_type: int = 0) -> None:
         self._cache_dir = cache_dir
+        # Drives whether per-container CPU is a hard cap (`--cpus`) or a soft
+        # weight (`--cpu-shares`). On-demand workers use soft weights so small
+        # entrypoint/coordinator containers can burst onto otherwise-idle host
+        # CPU; preemptible/reserved keep the hard cap for predictability.
+        self.capacity_type = capacity_type
         self._handles: list[DockerContainerHandle] = []
         self._created_containers: set[str] = set()
         # Serializes `docker pull` per image tag so that concurrent task threads

--- a/lib/iris/src/iris/cluster/worker/main.py
+++ b/lib/iris/src/iris/cluster/worker/main.py
@@ -67,7 +67,7 @@ def serve(worker_config: str):
 
     config = worker_config_from_proto(wc_proto, resolve_image=resolve_image)
 
-    container_runtime = DockerRuntime(cache_dir=config.cache_dir)
+    container_runtime = DockerRuntime(cache_dir=config.cache_dir, capacity_type=config.capacity_type)
 
     worker = Worker(config, container_runtime=container_runtime)
 

--- a/lib/iris/src/iris/cluster/worker/worker.py
+++ b/lib/iris/src/iris/cluster/worker/worker.py
@@ -171,7 +171,7 @@ class Worker:
             controller_address=config.controller_address,
             max_cache_items=100,
         )
-        self._runtime = container_runtime or DockerRuntime(cache_dir=self._cache_dir)
+        self._runtime = container_runtime or DockerRuntime(cache_dir=self._cache_dir, capacity_type=config.capacity_type)
         self._port_allocator = port_allocator or PortAllocator(config.port_range)
 
         # Resolve worker metadata: explicit > environment_provider > hardware probe

--- a/lib/iris/tests/cluster/providers/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_pod_manifest.py
@@ -96,9 +96,12 @@ def test_build_pod_manifest_fields():
     assert container["command"][1] == "-lc"
     assert "exec python train.py" in container["command"][2]
 
-    resources = container["resources"]["limits"]
-    assert resources["cpu"] == "1000m"
-    assert resources["memory"] == str(4 * 1024**3)
+    # CPU is requested only (no limit) so containers can burst onto idle node
+    # CPU; memory is both requested and limited (overshoot is fatal).
+    assert container["resources"]["requests"]["cpu"] == "1000m"
+    assert "cpu" not in container["resources"].get("limits", {})
+    assert container["resources"]["limits"]["memory"] == str(4 * 1024**3)
+    assert container["resources"]["requests"]["memory"] == str(4 * 1024**3)
 
 
 def test_build_pod_manifest_env_vars():

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -1693,7 +1693,7 @@ class ZephyrContext:
     max_workers: int | None = None
     resources: ResourceConfig = field(default_factory=lambda: ResourceConfig(cpu=1, ram="1g"))
     coordinator_resources: ResourceConfig = field(
-        default_factory=lambda: ResourceConfig(cpu=1, ram="2g", preemptible=False)
+        default_factory=lambda: ResourceConfig(cpu=0.1, ram="1g", preemptible=False)
     )
     chunk_storage_prefix: str | None = None
     name: str = ""


### PR DESCRIPTION
* fix controller startup race where the autoscaler thread was spawned before `self._service._system_endpoints` was populated
  * its first tick (eval interval 500ms in test mode) could create buffer slices whose workers queried `/system/log-server` and got an empty response
  * the slice creation failed, the group entered backoff, and any task constrained to that group hung until backoff expired
* surfaced as a zephyr CI flake when the coordinator was constrained to a non-preemptible group whose buffer slice failed to create — the coordinator job sat pending until the 60s pytest-timeout