### PR TITLE
datakit: stitch BHL pages into per-item documents

### DIFF
--- a/lib/marin/src/marin/datakit/download/biodiversity.py
+++ b/lib/marin/src/marin/datakit/download/biodiversity.py
@@ -1,0 +1,103 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""common-pile/biodiversity_heritage_library download + stitch + normalize.
+
+Upstream publishes one record per scanned page. This module inserts a
+stitch step between download and normalize that groups pages by
+``item_id`` (the BHL volume/book id), orders them by ``page_num``, and
+joins them into a single ``text`` per item with a blank-line separator.
+Per-page metadata is dropped; normalize then synthesizes the canonical
+``id`` from the joined text via xxh3_128 and preserves ``item_id`` as
+``source_id``.
+
+Modeled on :mod:`marin.datakit.download.institutional_books`. The only
+structural difference: BHL pages live in separate rows (so we need a
+Zephyr ``group_by``) rather than as a list field on a single row (a
+per-row ``flat_map``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from fray import ResourceConfig
+from zephyr import Dataset, ZephyrContext, counters, load_file
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.normalize import normalize_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "common-pile/biodiversity_heritage_library_filtered"
+HF_REVISION = "0486ed6"
+STAGED_PATH = f"raw/common_pile/biodiversity_heritage_library_filtered-{HF_REVISION}"
+
+PAGE_SEPARATOR = "\n\n"
+SOURCE_NAME = "biodiversity-heritage-library"
+
+
+def stitch_pages(item_id: str, pages: Iterator[dict]) -> list[dict]:
+    """Reducer: join ordered page texts into one item-level record.
+
+    Pages arrive sorted by ``page_num`` via the group_by ``sort_by`` key.
+    Empty page texts are dropped; items left with no usable pages emit
+    nothing and are counted under ``biodiversity/dropped_items``.
+    """
+    texts = [str(p["text"]) for p in pages if p.get("text")]
+    if not texts:
+        counters.increment("biodiversity/dropped_items")
+        return []
+    counters.increment("biodiversity/kept_items")
+    counters.increment("biodiversity/pages_stitched", len(texts))
+    return [
+        {
+            "text": PAGE_SEPARATOR.join(texts),
+            "source": SOURCE_NAME,
+            "item_id": item_id,
+        }
+    ]
+
+
+def transform(input_path: str, output_path: str) -> None:
+    """Stitch BHL pages into one parquet row per item."""
+    pipeline = (
+        Dataset.from_files(f"{input_path}/*.json.gz")
+        .flat_map(load_file)
+        .group_by(
+            key=lambda r: r["item_id"],
+            reducer=stitch_pages,
+            sort_by=lambda r: r["page_num"],
+        )
+        .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
+    )
+    ctx = ZephyrContext(name="biodiversity-stitch", resources=ResourceConfig(cpu=1, ram="8g"))
+    ctx.execute(pipeline)
+
+
+def download_biodiversity_step() -> StepSpec:
+    """Download + stitch BHL pages into Dolma-shaped parquet items."""
+    dl = download_hf_step(
+        "raw/common-pile/biodiversity_heritage_library",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        override_output_path=STAGED_PATH,
+    )
+    return StepSpec(
+        name="processed/cp/biodiversity",
+        deps=[dl],
+        fn=lambda output_path: transform(input_path=dl.output_path, output_path=output_path),
+        hash_attrs={"version": "v1", "page_separator": PAGE_SEPARATOR},
+    )
+
+
+def biodiversity_normalize_steps() -> tuple[StepSpec, ...]:
+    """Return the ``(download+stitch, normalize)`` chain for cp/biodiversity."""
+    processed = download_biodiversity_step()
+    return (
+        processed,
+        normalize_step(
+            name="normalized/cp/biodiversity",
+            download=processed,
+            id_field="item_id",
+        ),
+    )

--- a/lib/marin/src/marin/datakit/download/biodiversity.py
+++ b/lib/marin/src/marin/datakit/download/biodiversity.py
@@ -66,6 +66,8 @@ def transform(input_path: str, output_path: str) -> None:
         .group_by(
             key=lambda r: r["item_id"],
             reducer=stitch_pages,
+            # page_num is a zero-padded fixed-width string ("0001", "0696", …),
+            # so lexicographic sort matches numeric page order.
             sort_by=lambda r: r["page_num"],
         )
         .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)

--- a/lib/marin/src/marin/datakit/download/common_pile.py
+++ b/lib/marin/src/marin/datakit/download/common_pile.py
@@ -30,12 +30,9 @@ _COMMON_PILE_ENTRIES: tuple[tuple[str, str, str, str], ...] = (
         "raw/common_pile/arxiv_abstracts_filtered-f1d7a9a",
     ),
     ("cp/arxiv_papers", "common-pile/arxiv_papers_filtered", "033cf7f", "raw/common_pile/arxiv_papers_filtered-033cf7f"),
-    (
-        "cp/biodiversity",
-        "common-pile/biodiversity_heritage_library_filtered",
-        "0486ed6",
-        "raw/common_pile/biodiversity_heritage_library_filtered-0486ed6",
-    ),
+    # Note: cp/biodiversity is carved out into its own module
+    # (``marin.datakit.download.biodiversity``) because BHL ships one row per
+    # scanned page; we stitch pages into per-item documents before normalize.
     (
         "cp/caselaw",
         "common-pile/caselaw_access_project_filtered",

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -17,6 +17,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from functools import cache
 
+from marin.datakit.download.biodiversity import biodiversity_normalize_steps
 from marin.datakit.download.coderforge import coderforge_normalize_steps
 from marin.datakit.download.common_pile import common_pile_normalize_steps
 from marin.datakit.download.davinci_dev import (
@@ -138,6 +139,9 @@ def all_sources() -> dict[str, DatakitSource]:
     # returning ``tuple[StepSpec, ...]``; the registry pairs the chain with
     # a rough token count.
     single_sources: tuple[_SourceRow, ...] = (
+        # cp/biodiversity is carved out of common_pile (see common_pile.py)
+        # because it needs page-stitching before normalize.
+        ("cp/biodiversity", biodiversity_normalize_steps, 8.60),
         ("coderforge", coderforge_normalize_steps, 10.29),
         ("davinci-dev/ctx-native", davinci_dev_ctx_native_normalize_steps, 57.57),
         ("davinci-dev/env-native", davinci_dev_env_native_normalize_steps, 2.58),
@@ -172,7 +176,6 @@ def all_sources() -> dict[str, DatakitSource]:
         {
             "cp/arxiv_abstracts": 0.54,
             "cp/arxiv_papers": 6.63,
-            "cp/biodiversity": 8.60,
             "cp/caselaw": 17.55,
             "cp/data_provenance": 0.82,
             "cp/doab": 2.93,


### PR DESCRIPTION
* carve `cp/biodiversity` out of common-pile and stitch pages into per-item documents before normalize
* upstream `common-pile/biodiversity_heritage_library_filtered` ships one record per scanned page; the new transform does `Dataset.from_files(...).flat_map(load_file).group_by(key=item_id, sort_by=page_num, reducer=stitch_pages).write_parquet(...)` and joins page texts with `\n\n` into one record per item with `text`, `source`, `item_id`
* per-page metadata (`metadata.{license,provenance,url}`, `added`, `page_id`, `page_num`) is dropped; `normalize_step` is called with `id_field="item_id"` so the BHL item id is preserved as `source_id` and `id` becomes `xxh3_128(stitched_text)`
* new module `lib/marin/src/marin/datakit/download/biodiversity.py`; entry removed from `_COMMON_PILE_ENTRIES` in `common_pile.py` and re-registered in `single_sources` of `sources.py` with the same 8.60 B token count
* mirrors `institutional_books.py`[^1]

[^1]: only structural difference: BHL pages live in separate rows (so we need a Zephyr `group_by`) rather than as a list field on a single row (a per-row `flat_map`).