### PR TITLE
Document Iris accelerator routing guidance

### DIFF
--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -82,6 +82,34 @@ iris rpc controller get-provider-status         # scheduling events, cluster cap
 iris cluster vm status                          # scale groups with slice counts
 ```
 
+### Inspect Current Accelerator Availability
+
+Use autoscaler status for Iris's current per-scale-group accelerator view.
+
+```bash
+uv run iris --config=lib/iris/examples/marin.yaml rpc controller get-autoscaler-status \
+  2>&1 | sed -n '/^{/,$p' | jq -r '
+.status.groups[]
+| select(.config.resources.device_type | test("TPU|GPU"))
+  | [
+      .config.resources.device_variant,
+      (.config.slice_template.gcp.zone // .config.slice_template.coreweave.region // ""),
+      .availability_status,
+      .availability_reason,
+      .current_demand,
+      (.slice_state_counts.ready // 0),
+      (.slice_state_counts.requesting // 0),
+      (.slice_state_counts.failed // 0),
+      .config.max_slices
+    ] | @tsv' | column -t -s $'\t'
+```
+
+Read `availability_status` with `availability_reason`: `available` means Iris
+can attempt scale-up, not that the cloud will definitely allocate a slice.
+`quota_exceeded`, `backoff`, and `at_max_slices` are blocked; `requesting` is
+capacity in flight; `cooldown` is temporarily deferred. `cluster vm status`
+shows slice inventory but omits these active block reasons.
+
 Priority bands: `PRIORITY_BAND_INTERACTIVE` (default), `PRIORITY_BAND_PRODUCTION` (can preempt interactive), `PRIORITY_BAND_BATCH` (preemptible). See [`docs/priority-bands.md`](docs/priority-bands.md) for the user-facing guide on when to pick each band.
 
 ## SQL Queries

--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -38,6 +38,7 @@ iris job bug-report /user/job-name      # structured diagnostic dump
 - **`--memory` not `--ram`** — unrecognized flags silently pass through to the command string.
 - **`-e KEY VALUE`** uses two positional args. If `$VALUE` is unset, the parser eats the next token. Always quote: `-e KEY "${VALUE}"`.
 - **`--extra gpu`** installs CUDA jaxlib but does NOT request GPU hardware. Need both `--gpu H100x8 --extra gpu`.
+- **Do not pin `region`/`zone` for ordinary accelerator jobs.** Request the accelerator (`--tpu ...` or `--gpu ...`) and let Iris route to a configured scale group. Add region or zone constraints only for debugging, data locality, known bad pools, or quota experiments.
 - **`--reserve`** holds capacity for scheduling only — does not attach accelerator devices. Use `--tpu`/`--gpu` on the task that needs hardware.
 - **`executor_main` parent jobs** (e.g., canary ferries) submit GPU sub-tasks via Fray. The parent must be CPU-only (`--cpu 1 --memory 2g`), otherwise it hogs the GPU node and deadlocks. Memory at or above 4 GB requires `--enable-extra-resources` (see "Validator opt-in" below).
 
@@ -212,6 +213,28 @@ gcloud compute ssh iris-controller-marin --zone=us-central1-a \
 
 Configs: `marin.yaml` (production), `marin-dev.yaml` (dev, smaller scale caps).
 
+### Configured Accelerator Locations
+
+This table is for debugging scheduler/autoscaler behavior, not for ordinary job
+submission. For normal jobs, request the accelerator and let Iris choose among
+matching scale groups. `lib/iris/examples/marin.yaml` is the source of truth;
+live availability still depends on quota, backoff, and current cluster state.
+
+| Accelerator family | Configured locations | Notes |
+|--------------------|----------------------|-------|
+| TPU v5e (`v5litepod`) | `europe-west4-b`, `us-west4-a` | Serving sizes: 4, 8. Preemptible sizes: 16-256. |
+| TPU v6e | `europe-west4-a`, `us-east1-d`, `us-east5-b` | Preemptible sizes: 4-256. |
+| TPU v5p | `us-central1-a`, `us-east5-a` | Preemptible sizes: 8-2048. |
+| TPU v4 | `us-central2-b` | Preemptible sizes: 8-4096. Reserved sizes: 32-4096. |
+
+Check live routing and capacity before concluding a location is usable:
+
+```bash
+iris rpc controller get-scheduler-state
+iris rpc controller get-autoscaler-status
+iris cluster vm status
+```
+
 ### GCP Resources
 
 ```bash
@@ -252,6 +275,10 @@ State dir: `gs://marin-us-central2/iris/<cluster>/state/` — contains `bundles/
 ---
 
 ## CoreWeave (GPU) Operations
+
+`lib/iris/examples/coreweave.yaml` is the source of truth for CoreWeave scale
+groups. The current production-style GPU group is `h100-8x` in `US-WEST-04A`
+using CoreWeave instance type `gd-8xh100ib-i128`.
 
 ### Connecting
 

--- a/lib/iris/README.md
+++ b/lib/iris/README.md
@@ -44,6 +44,7 @@ job.wait()
 
 For accelerator jobs, request the accelerator on the task itself with `--tpu ...` or `--gpu ...`.
 `--reserve ...` only holds capacity for scheduling and does not attach accelerator devices to the task container.
+Do not pin a region or zone for ordinary accelerator jobs; let Iris route to a matching scale group.
 
 ## Architecture
 
@@ -287,6 +288,7 @@ iris --config=... cluster dashboard --port 8080
 iris --config cluster.yaml job run -- python train.py
 iris --config cluster.yaml job run --tpu v5litepod-16 -e WANDB_API_KEY $WANDB_API_KEY -- python train.py
 iris --config cluster.yaml job run --no-wait -- python long_job.py
+# Advanced: pin a zone only for debugging, data locality, or quota experiments.
 iris --config cluster.yaml job run --zone us-central2-b -- python train.py
 
 # Stream logs for a job (batch-fetches from all tasks in one RPC)

--- a/lib/iris/docs/constraints.md
+++ b/lib/iris/docs/constraints.md
@@ -59,6 +59,11 @@ objects declaring type, allowed operators, and whether the constraint is:
 | `gpu-variant` | no | no | scheduler-only |
 | `gpu-count` | no | no | scheduler-only (consumable) |
 
+For ordinary accelerator jobs, prefer the device constraints generated from
+`--tpu ...` or `--gpu ...` and let Iris route across matching scale groups.
+Use explicit `region` or `zone` constraints only for operator/debugging cases
+such as data locality, known bad pools, or quota experiments.
+
 ## How constraints flow through the system
 
 ### Job submission → proto constraints


### PR DESCRIPTION
Context: My codex keeps scheduling workloads in regions that don't have the request accelerator. This update makes it more clear to either not ask for a specific region, or ask for a region that has the accelerator.

Clarify that ordinary accelerator jobs should request TPU/GPU resources and let Iris route rather than pinning region or zone. Add an operator-facing accelerator location table sourced from marin.yaml/coreweave.yaml for debugging scheduler and autoscaler behavior.