### PR TITLE
[iris] CoreWeave RNO2A + USW09B clusters & cwobject S3 wiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,3 +237,4 @@ scr/*
 
 .worktrees
 .obsidian
+.cw_env

--- a/experiments/dedup/fineweb_10bt_exact.py
+++ b/experiments/dedup/fineweb_10bt_exact.py
@@ -12,6 +12,7 @@ import argparse
 import logging
 import os
 
+from fray import ResourceConfig
 from marin.datakit.canonical import fineweb_edu
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
@@ -27,6 +28,7 @@ OUTPUT_PREFIX = os.environ.get("OUTPUT_PREFIX", "exact-para-dedup-fineweb-10bt")
 def build_steps(max_parallelism: int) -> list[StepSpec]:
     download = fineweb_edu.download(
         hf_urls_glob=["sample/10BT/*.parquet"],
+        worker_resources=ResourceConfig(cpu=2, ram="8g"),
     )
 
     dedup_step = StepSpec(

--- a/lib/iris/Dockerfile
+++ b/lib/iris/Dockerfile
@@ -35,8 +35,9 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
     google-cloud-cli \
     && rm -rf /var/lib/apt/lists/*
 
-# kubectl
-RUN curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+# kubectl — TARGETARCH is auto-set by buildx (amd64 on x86 nodes, arm64 on Grace).
+ARG TARGETARCH
+RUN curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
         -o /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \
     && kubectl version --client

--- a/lib/iris/examples/coreweave-rno2a.yaml
+++ b/lib/iris/examples/coreweave-rno2a.yaml
@@ -1,0 +1,100 @@
+# Iris on CoreWeave RNO2A (GH200, 1 GPU per node).
+#
+# Single GPU NodePool: gd-1xgh200. The controller is pinned onto this same pool
+# because the cluster has no CPU nodes — see CAVEAT below.
+#
+# Setup:
+#   1. Split the multi-context kubeconfig (~/.kube/coreweave-rno2a holds both
+#      rno2a and usw09b) into a single-context file:
+#        KUBECONFIG=~/.kube/coreweave-rno2a \
+#          kubectl config view --minify --flatten --context=rno2a \
+#          > ~/.kube/cw-rno2a.yaml
+#        chmod 600 ~/.kube/cw-rno2a.yaml
+#   2. R2 credentials in env (consumed by `iris cluster start`):
+#        export R2_ACCESS_KEY_ID=<...>
+#        export R2_SECRET_ACCESS_KEY=<...>
+#   3. Start the cluster:
+#        cd lib/iris && uv run --group dev iris \
+#          --config=examples/coreweave-rno2a.yaml cluster start
+#
+# CAVEAT: the controller Deployment does NOT get the nvidia.com/gpu toleration
+# automatically. After the GPU NodePool scales up the first node, verify with
+# `kubectl describe node | grep -i taint`. If the GPU taint is present, either
+# (a) patch _build_controller_deployment in providers/k8s/controller.py to add
+# NVIDIA_GPU_TOLERATION when the controller scale_group is a GPU pool, or
+# (b) add a small CPU NodePool on this cluster and route the controller there.
+
+platform:
+  label_prefix: iris-rno2a
+  coreweave:
+    region: RNO2A
+    namespace: iris
+    kubeconfig_path: ~/.kube/cw-rno2a.yaml
+    # CoreWeave native object storage: virtual-hosted-style addressing
+    # (bucket goes in the subdomain). iris auto-detects cwobject.com domains
+    # and sets s3 addressing_style=virtual — see _needs_virtual_host_addressing.
+    # Bucket-less base endpoint. Virtual-host addressing prepends the bucket
+    # name as a subdomain at request time (s3://marin-poc/foo →
+    # https://marin-poc.cwobject.com/foo). Including the bucket here would
+    # double it (https://marin-poc.marin-poc.cwobject.com/...).
+    object_storage_endpoint: https://cwobject.com
+
+storage:
+  remote_state_dir: s3://marin-poc/iris/state/rno2a
+
+kubernetes_provider:
+  namespace: iris
+  default_image: ghcr.io/marin-community/iris-task:latest
+  host_network: true
+  cache_dir: /mnt/local/iris-cache
+  controller_address: http://iris-controller-svc.iris.svc.cluster.local:10000
+
+controller:
+  image: ghcr.io/marin-community/iris-controller:latest
+  coreweave:
+    port: 10000
+    service_name: iris-controller-svc
+    scale_group: gh200-1x
+
+defaults:
+  autoscaler:
+    evaluation_interval:
+      milliseconds: 10000
+    scale_up_delay:
+      milliseconds: 60000
+    scale_down_delay:
+      milliseconds: 300000
+    startup_grace_period:
+      milliseconds: 2400000    # 40 min — covers bare-metal node provisioning + Pod startup
+  task_env:
+    MARIN_PREFIX: s3://marin-na/marin
+  worker:
+    docker_image: ghcr.io/marin-community/iris-worker:latest
+    port: 10001
+    cache_dir: /mnt/local/iris-cache
+    runtime: kubernetes
+    default_task_image: ghcr.io/marin-community/iris-task:latest
+
+scale_groups:
+  gh200-1x:
+    num_vms: 1
+    resources:
+      cpu: 64
+      ram: 256GB
+      disk: 1TB
+      device_type: gpu
+      device_variant: H200
+      device_count: 1
+      capacity_type: on-demand
+    worker:
+      attributes:
+        pool: gh200-1x
+    # buffer_slices keeps one node warm so the controller always has a home.
+    buffer_slices: 1
+    max_slices: 4
+    priority: 100
+    slice_template:
+      num_vms: 1
+      coreweave:
+        region: RNO2A
+        instance_type: gd-1xgh200

--- a/lib/iris/examples/coreweave-usw09b.yaml
+++ b/lib/iris/examples/coreweave-usw09b.yaml
@@ -1,0 +1,100 @@
+# Iris on CoreWeave US-WEST-09B (B200, 8 GPUs per node).
+#
+# Single GPU NodePool: b200-8x. The controller is pinned onto this same pool
+# because the cluster has no CPU nodes — see CAVEAT below.
+#
+# Setup:
+#   1. Split the multi-context kubeconfig (~/.kube/coreweave-rno2a holds both
+#      rno2a and usw09b) into a single-context file:
+#        KUBECONFIG=~/.kube/coreweave-rno2a \
+#          kubectl config view --minify --flatten --context=usw09b \
+#          > ~/.kube/cw-usw09b.yaml
+#        chmod 600 ~/.kube/cw-usw09b.yaml
+#   2. R2 credentials in env (consumed by `iris cluster start`):
+#        export R2_ACCESS_KEY_ID=<...>
+#        export R2_SECRET_ACCESS_KEY=<...>
+#   3. Start the cluster:
+#        cd lib/iris && uv run --group dev iris \
+#          --config=examples/coreweave-usw09b.yaml cluster start
+#
+# CAVEAT: the controller Deployment does NOT get the nvidia.com/gpu toleration
+# automatically. After the GPU NodePool scales up the first node, verify with
+# `kubectl describe node | grep -i taint`. If the GPU taint is present, either
+# (a) patch _build_controller_deployment in providers/k8s/controller.py to add
+# NVIDIA_GPU_TOLERATION when the controller scale_group is a GPU pool, or
+# (b) add a small CPU NodePool on this cluster and route the controller there.
+
+platform:
+  label_prefix: iris-usw09b
+  coreweave:
+    region: US-WEST-09B
+    namespace: iris
+    kubeconfig_path: ~/.kube/cw-usw09b.yaml
+    # CoreWeave native object storage. The marin-poc bucket lives in RNO2A;
+    # accessing it from US-WEST-09B is cross-region but works (just slower).
+    # iris auto-detects cwobject.com and switches addressing_style=virtual.
+    # Bucket-less base endpoint. Virtual-host addressing prepends the bucket
+    # name as a subdomain at request time (s3://marin-poc/foo →
+    # https://marin-poc.cwobject.com/foo). Including the bucket here would
+    # double it (https://marin-poc.marin-poc.cwobject.com/...).
+    object_storage_endpoint: https://cwobject.com
+
+storage:
+  remote_state_dir: s3://marin-poc/iris/state/usw09b
+
+kubernetes_provider:
+  namespace: iris
+  default_image: ghcr.io/marin-community/iris-task:latest
+  host_network: true
+  cache_dir: /mnt/local/iris-cache
+  controller_address: http://iris-controller-svc.iris.svc.cluster.local:10000
+
+controller:
+  image: ghcr.io/marin-community/iris-controller:latest
+  coreweave:
+    port: 10000
+    service_name: iris-controller-svc
+    scale_group: b200-8x
+
+defaults:
+  autoscaler:
+    evaluation_interval:
+      milliseconds: 10000
+    scale_up_delay:
+      milliseconds: 60000
+    scale_down_delay:
+      milliseconds: 300000
+    startup_grace_period:
+      milliseconds: 2400000    # 40 min — covers bare-metal node provisioning + Pod startup
+  task_env:
+    MARIN_PREFIX: s3://marin-na/marin
+  worker:
+    docker_image: ghcr.io/marin-community/iris-worker:latest
+    port: 10001
+    cache_dir: /mnt/local/iris-cache
+    runtime: kubernetes
+    default_task_image: ghcr.io/marin-community/iris-task:latest
+
+scale_groups:
+  b200-8x:
+    num_vms: 1
+    resources:
+      cpu: 128
+      ram: 2048GB
+      disk: 1TB
+      device_type: gpu
+      device_variant: B200
+      device_count: 8
+      capacity_type: on-demand
+    worker:
+      attributes:
+        pool: b200-8x
+    # buffer_slices keeps one node warm so the controller always has a home.
+    buffer_slices: 1
+    max_slices: 2
+    priority: 100
+    slice_template:
+      num_vms: 1
+      coreweave:
+        region: US-WEST-09B
+        instance_type: b200-8x

--- a/lib/iris/src/iris/cli/cluster.py
+++ b/lib/iris/src/iris/cli/cluster.py
@@ -107,7 +107,7 @@ def _build_and_push_for_tag(image_tag: str, image_type: str, verbose: bool = Fal
         tag=local_tag,
         push=True,
         context=None,
-        platform="linux/amd64",
+        platform="linux/amd64,linux/arm64",
         ghcr_org=org,
         verbose=verbose,
     )
@@ -136,7 +136,7 @@ def _build_and_push_task_image(task_tag: str, verbose: bool = False) -> None:
         tag=local_tag,
         push=True,
         context=marin_root,
-        platform="linux/amd64",
+        platform="linux/amd64,linux/arm64",
         ghcr_org=org,
         verbose=verbose,
     )

--- a/lib/iris/src/iris/cluster/controller/checkpoint.py
+++ b/lib/iris/src/iris/cluster/controller/checkpoint.py
@@ -376,7 +376,12 @@ def _sync_dir(source_dir: str, local_dir: Path) -> None:
         basename = entry.rstrip("/").rsplit("/", 1)[-1]
         dest = local_dir / basename
         tmp = dest.with_suffix(dest.suffix + ".download.tmp")
-        _fsspec_copy(entry, str(tmp))
+        # `fs.ls` returns bare keys for non-local schemes (e.g. s3 returns
+        # "marin-na/path/file" without the "s3://" prefix). Pass the bytes
+        # directly via fs.open so we don't accidentally fall back to the
+        # local filesystem when the entry has no protocol.
+        with fs.open(entry, "rb") as f_src, open(tmp, "wb") as f_dst:
+            f_dst.write(f_src.read())
         tmp.rename(dest)
 
 

--- a/lib/iris/src/iris/cluster/providers/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/controller.py
@@ -23,6 +23,7 @@ from urllib.parse import urlparse
 from rigging.timing import Deadline
 
 from iris.cluster.config import config_to_dict
+from iris.cluster.providers.k8s.constants import NVIDIA_GPU_TOLERATION
 from iris.cluster.providers.k8s.service import K8sService
 from iris.cluster.providers.k8s.types import K8sResource
 from iris.cluster.providers.types import InfraError, Labels
@@ -80,8 +81,11 @@ def configure_client_s3(config: config_pb2.IrisClusterConfig) -> None:
         fsspec_conf: dict = {"endpoint_url": endpoint}
         if _needs_virtual_host_addressing(endpoint):
             fsspec_conf["config_kwargs"] = {"s3": {"addressing_style": "virtual"}}
-        if ".r2.cloudflarestorage.com" in endpoint:
-            fsspec_conf.setdefault("client_kwargs", {})["region_name"] = "auto"
+        # Non-AWS S3-compatible endpoints (R2, CoreWeave Object Storage, etc.)
+        # don't honor the AWS region scheme; signing with the wrong region
+        # surfaces as 400 Bad Request. "auto" tells boto3 to skip region
+        # validation and let the endpoint route the request itself.
+        fsspec_conf.setdefault("client_kwargs", {})["region_name"] = "auto"
         os.environ["FSSPEC_S3"] = json.dumps(fsspec_conf)
 
     # Flush fsspec/s3fs cached instances so they pick up the new config.
@@ -161,6 +165,10 @@ def _build_controller_deployment(
                 "spec": {
                     "serviceAccountName": "iris-controller",
                     "nodeSelector": node_selector,
+                    # Tolerate the standard NVIDIA GPU taint so the controller
+                    # can schedule onto GPU-only clusters (no CPU NodePool).
+                    # Harmless on untainted nodes.
+                    "tolerations": [NVIDIA_GPU_TOLERATION],
                     "containers": [
                         {
                             "name": "iris-controller",
@@ -689,7 +697,13 @@ class K8sControllerProvider:
             fsspec_conf: dict = {"endpoint_url": endpoint}
             if _needs_virtual_host_addressing(endpoint):
                 fsspec_conf["config_kwargs"] = {"s3": {"addressing_style": "virtual"}}
+            # Non-AWS S3-compatible endpoints (R2, CoreWeave Object Storage)
+            # reject the default us-east-1 region in the v4 signature with
+            # 400 Bad Request. "auto" tells boto3 to skip region validation.
+            fsspec_conf.setdefault("client_kwargs", {})["region_name"] = "auto"
             env.append({"name": "FSSPEC_S3", "value": json.dumps(fsspec_conf)})
+            env.append({"name": "AWS_REGION", "value": "auto"})
+            env.append({"name": "AWS_DEFAULT_REGION", "value": "auto"})
         return env
 
     # -- Deployment readiness --------------------------------------------------

--- a/lib/iris/src/iris/cluster/providers/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/controller.py
@@ -76,6 +76,8 @@ def configure_client_s3(config: config_pb2.IrisClusterConfig) -> None:
         os.environ.setdefault("AWS_SECRET_ACCESS_KEY", r2_secret)
 
     os.environ.setdefault("AWS_ENDPOINT_URL", endpoint)
+    os.environ.setdefault("AWS_REGION", "auto")
+    os.environ.setdefault("AWS_DEFAULT_REGION", "auto")
 
     if "FSSPEC_S3" not in os.environ:
         fsspec_conf: dict = {"endpoint_url": endpoint}
@@ -694,6 +696,8 @@ class K8sControllerProvider:
         endpoint = self._config.object_storage_endpoint
         if endpoint:
             env.append({"name": "AWS_ENDPOINT_URL", "value": endpoint})
+            env.append({"name": "AWS_REGION", "value": "auto"})
+            env.append({"name": "AWS_DEFAULT_REGION", "value": "auto"})
             fsspec_conf: dict = {"endpoint_url": endpoint}
             if _needs_virtual_host_addressing(endpoint):
                 fsspec_conf["config_kwargs"] = {"s3": {"addressing_style": "virtual"}}
@@ -702,8 +706,6 @@ class K8sControllerProvider:
             # 400 Bad Request. "auto" tells boto3 to skip region validation.
             fsspec_conf.setdefault("client_kwargs", {})["region_name"] = "auto"
             env.append({"name": "FSSPEC_S3", "value": json.dumps(fsspec_conf)})
-            env.append({"name": "AWS_REGION", "value": "auto"})
-            env.append({"name": "AWS_DEFAULT_REGION", "value": "auto"})
         return env
 
     # -- Deployment readiness --------------------------------------------------

--- a/lib/marin/src/marin/datakit/canonical/fineweb_edu.py
+++ b/lib/marin/src/marin/datakit/canonical/fineweb_edu.py
@@ -16,6 +16,8 @@ Subsets available on HuggingFace:
 - sample/350BT   — 350B token sample
 """
 
+from fray import ResourceConfig
+
 from marin.datakit.download.huggingface import download_hf_step
 from marin.execution.step_spec import StepSpec
 
@@ -24,6 +26,7 @@ def download(
     *,
     revision: str = "87f0914",
     hf_urls_glob: list[str] | None = None,
+    worker_resources: ResourceConfig | None = None,
 ) -> StepSpec:
     """Download FineWeb-Edu from HuggingFace."""
     return download_hf_step(
@@ -32,4 +35,5 @@ def download(
         revision=revision,
         hf_urls_glob=hf_urls_glob,
         override_output_path=f"raw/fineweb-edu-{revision}",
+        worker_resources=worker_resources,
     )

--- a/lib/marin/src/marin/datakit/download/huggingface.py
+++ b/lib/marin/src/marin/datakit/download/huggingface.py
@@ -15,6 +15,7 @@ import time
 from dataclasses import dataclass, field
 
 import huggingface_hub
+from fray import ResourceConfig
 from huggingface_hub.errors import HfHubHTTPError
 from packaging.version import Version
 from rigging.filesystem import open_url, url_to_fs
@@ -103,6 +104,11 @@ class DownloadConfig:
     source_url_override: str | None = None
     """Optional fsspec URL to read from instead of HuggingFace. Bypasses HF-specific
     listing and revision handling; mainly intended for hermetic tests."""
+
+    worker_resources: ResourceConfig | None = None
+    """Per-worker resources for the Zephyr download workers. None falls back to
+    ZephyrContext defaults (1 CPU / 1 GB RAM). Bump for large parquet shards or
+    when HF streaming buffers spike memory."""
 
 
 def _strip_hf_protocol(path: str) -> str:
@@ -374,7 +380,10 @@ def download_hf(cfg: DownloadConfig) -> None:
             f"{cfg.gcs_output_path}/.metrics/success-part-{{shard:05d}}-of-{{total:05d}}.jsonl", skip_existing=True
         )
     )
-    ctx = ZephyrContext(name="download-hf", max_workers=cfg.zephyr_max_parallelism)
+    ctx_kwargs: dict = {"name": "download-hf", "max_workers": cfg.zephyr_max_parallelism}
+    if cfg.worker_resources is not None:
+        ctx_kwargs["resources"] = cfg.worker_resources
+    ctx = ZephyrContext(**ctx_kwargs)
     ctx.execute(pipeline)
 
     # Write Provenance JSON
@@ -396,6 +405,7 @@ def download_hf_step(
     zephyr_max_parallelism: int = 8,
     deps: list[StepSpec] | None = None,
     override_output_path: str | None = None,
+    worker_resources: ResourceConfig | None = None,
 ) -> StepSpec:
     """Create a StepSpec that downloads a HuggingFace dataset.
 
@@ -425,6 +435,7 @@ def download_hf_step(
                 gcs_output_path=output_path,
                 append_sha_to_path=append_sha_to_path,
                 zephyr_max_parallelism=zephyr_max_parallelism,
+                worker_resources=worker_resources,
             )
         )
 


### PR DESCRIPTION

## Summary

Bootstraps two CoreWeave CKS clusters under Iris (RNO2A/GH200 arm64 and USW09B/B200 amd64) and switches storage from R2 to CoreWeave Object Storage. Validated end-to-end: `experiments/dedup/fineweb_10bt_exact.py` ran successfully on RNO2A (download + dedup) and is in flight on USW09B.

### Changes

- **Cluster configs**: `lib/iris/examples/coreweave-{rno2a,usw09b}.yaml` — single-GPU NodePool per region, controller scheduled onto the same GPU pool with NVIDIA_GPU_TOLERATION, `object_storage_endpoint: https://cwobject.com` (bucket-less base; virtual-host addressing prepends `marin-poc.` at request time).
- **Multi-arch images**: `lib/iris/Dockerfile` parameterizes kubectl URL via `TARGETARCH` (Grace = arm64); `lib/iris/cli/cluster.py` builds `linux/amd64,linux/arm64` so the same image works on RNO2A and USW09B.
- **S3-compatible region quirk**: `controller.py` sets `AWS_REGION=auto` / `AWS_DEFAULT_REGION=auto` and `fsspec` `region_name=auto` for any object_storage_endpoint. Non-AWS endpoints reject the default `us-east-1` SigV4 with 400 Bad Request on HeadObject.
- **Virtual-host addressing**: auto-detected for `cwobject.com` / `cwlota.com` domains; the FSSPEC_S3 config sets `config_kwargs.s3.addressing_style=virtual`.
- **Checkpoint sync fix**: `checkpoint.py:_sync_dir` switched from `fsspec.core.open` to `fs.open(entry, "rb")` — bare s3 keys were being treated as local paths during recovery.
- **Worker resources plumbing**: `marin.datakit.download.huggingface.DownloadConfig` accepts an optional `worker_resources: ResourceConfig` and threads it through ZephyrContext; `fineweb_edu.download` exposes the same param. `experiments/dedup/fineweb_10bt_exact.py` requests `cpu=2, ram=8g` for the HF download workers (default 1 GiB OOMs on 10BT shards).

### How to run

R2/CW creds in `.cw_env` (gitignored):
```bash
export R2_ACCESS_KEY_ID=...
export R2_SECRET_ACCESS_KEY=...
export AWS_ACCESS_KEY_ID="\$R2_ACCESS_KEY_ID"
export AWS_SECRET_ACCESS_KEY="\$R2_SECRET_ACCESS_KEY"
export AWS_ENDPOINT_URL=https://cwobject.com
```

Bootstrap a cluster (one-time per region):
```bash
set -a && source .cw_env && set +a
uv run iris --cluster lib/iris/examples/coreweave-rno2a.yaml cluster start
# repeat with coreweave-usw09b.yaml for the other region
```

Submit the dedup job — env vars are passed via `-e` on the entrypoint job (the controller Deployment also has them, but they don't propagate to task pods automatically):
```bash
set -a && source .cw_env && set +a
export FSSPEC_S3='{"endpoint_url":"https://cwobject.com","config_kwargs":{"s3":{"addressing_style":"virtual"}},"client_kwargs":{"region_name":"auto"}}'

# Run from repo root (NOT --directory lib/iris) so the workspace bundle
# includes all marin-* workspace members (~5.6 MB vs ~1.4 MB).
uv run iris --cluster lib/iris/examples/coreweave-rno2a.yaml job run \\
  --job-name fineweb-10bt-exact-rno2a \\
  --cpu 4 --memory 8GB --disk 64GB --enable-extra-resources \\
  -e AWS_ACCESS_KEY_ID "\$AWS_ACCESS_KEY_ID" \\
  -e AWS_SECRET_ACCESS_KEY "\$AWS_SECRET_ACCESS_KEY" \\
  -e AWS_ENDPOINT_URL "\$AWS_ENDPOINT_URL" \\
  -e AWS_REGION auto \\
  -e AWS_DEFAULT_REGION auto \\
  -e FSSPEC_S3 "\$FSSPEC_S3" \\
  -e MARIN_PREFIX s3://marin-poc/marin/rno2a \\
  --no-wait \\
  -- python experiments/dedup/fineweb_10bt_exact.py
```

For USW09B swap the cluster yaml and the MARIN_PREFIX suffix to `/usw09b`.