### PR TITLE
[finelog] FetchLogs path for CLI, log-server observability, safe deploy

### DIFF
--- a/lib/finelog/scripts/safe_deploy.py
+++ b/lib/finelog/scripts/safe_deploy.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Safe finelog deploy with rollout / rollback.
+
+Wraps the GCE bootstrap path used by ``finelog deploy restart`` with:
+  - capture of the currently-running container's pinned image digest *before*
+    the restart,
+  - persistence of that digest under ``~/.cache/finelog/deploy-state/<name>.json``,
+  - on health failure, an automatic re-bootstrap with the captured digest,
+  - a separate ``rollback`` subcommand to restore the last good digest later.
+
+Usage:
+    uv run python lib/finelog/scripts/safe_deploy.py rollout marin-dev
+    uv run python lib/finelog/scripts/safe_deploy.py rollback marin-dev
+    uv run python lib/finelog/scripts/safe_deploy.py rollback marin-dev --to ghcr.io/...@sha256:...
+    uv run python lib/finelog/scripts/safe_deploy.py status marin-dev
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import click
+from finelog.deploy._gcp import _resolve_image_digest, _ssh_args, _wait_health
+from finelog.deploy.bootstrap import CONTAINER_NAME, render_bootstrap
+from finelog.deploy.build import build_image as build_finelog_image
+from finelog.deploy.config import FinelogConfig, load_finelog_config
+
+STATE_DIR = Path.home() / ".cache" / "finelog" / "deploy-state"
+
+
+def _state_path(cfg: FinelogConfig) -> Path:
+    return STATE_DIR / f"{cfg.name}.json"
+
+
+def _read_state(cfg: FinelogConfig) -> dict:
+    path = _state_path(cfg)
+    if not path.is_file():
+        return {}
+    return json.loads(path.read_text())
+
+
+def _write_state(cfg: FinelogConfig, **updates: str | None) -> Path:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    state = _read_state(cfg)
+    state.update({k: v for k, v in updates.items() if v is not None})
+    path = _state_path(cfg)
+    path.write_text(json.dumps(state, indent=2, sort_keys=True))
+    return path
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _running_repo_digest(cfg: FinelogConfig) -> str | None:
+    """Return the currently-running container's pinned ``ghcr.io/...@sha256:...``
+    image, or ``None`` if no container is running or the digest is unavailable.
+
+    Two-step inspect: container --> image config sha (``.Image``), then image
+    --> ``RepoDigests``. Container-level inspect doesn't expose RepoDigests.
+    Locally-built images with no published digest yield an empty list and
+    we return ``None``.
+    """
+    # Bash heredoc keeps Go template braces literal; pipes the image id from
+    # `docker inspect <container>` into `docker image inspect`.
+    digests_tpl = "{{range .RepoDigests}}{{.}}|{{end}}"
+    cmd = (
+        f"set -e; "
+        f"img=$(sudo docker inspect --format='{{{{.Image}}}}' {CONTAINER_NAME} 2>/dev/null) || exit 0; "
+        f"sudo docker image inspect --format='{digests_tpl}' \"$img\" 2>/dev/null || true"
+    )
+    result = subprocess.run(_ssh_args(cfg, cmd), capture_output=True, text=True)
+    for chunk in result.stdout.replace("\n", "|").split("|"):
+        chunk = chunk.strip().strip("'")
+        if "@sha256:" in chunk:
+            return chunk
+    return None
+
+
+def _require_gcp(cfg: FinelogConfig) -> None:
+    if cfg.deployment.gcp is None:
+        raise click.ClickException("safe_deploy only supports GCP deployments.")
+
+
+def _bootstrap_with_image(cfg: FinelogConfig, image: str) -> None:
+    """Re-render and re-run the bootstrap with an explicit image (no pinning)."""
+    bootstrap = render_bootstrap(image=image, port=cfg.port, remote_log_dir=cfg.remote_log_dir)
+    result = subprocess.run(_ssh_args(cfg, "bash -s"), input=bootstrap, text=True)
+    if result.returncode != 0:
+        raise click.ClickException(f"Bootstrap failed for image {image}; see SSH output above")
+
+
+def _verify_health(cfg: FinelogConfig) -> bool:
+    assert cfg.deployment.gcp is not None
+    gcp = cfg.deployment.gcp
+    return _wait_health(cfg.name, gcp.project, gcp.zone, cfg.port)
+
+
+@click.group()
+def cli() -> None:
+    """Safe finelog deploy: rollout with auto-rollback, plus explicit rollback."""
+
+
+@cli.command("rollout")
+@click.argument("name")
+@click.option(
+    "--auto-rollback/--no-auto-rollback",
+    default=True,
+    help="On health failure, re-bootstrap with the captured previous digest.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Re-bootstrap even when the new pinned digest matches the running one.",
+)
+@click.option(
+    "--build/--no-build",
+    default=True,
+    help="Build and push cfg.image before resolving its digest. Default: build.",
+)
+def rollout_cmd(name: str, auto_rollback: bool, force: bool, build: bool) -> None:
+    """Roll forward to the digest pinned from cfg.image; capture the previous digest."""
+    cfg = load_finelog_config(name)
+    _require_gcp(cfg)
+
+    click.echo(f"== rollout: {cfg.name} ==")
+
+    if build:
+        click.echo(f"building & pushing {cfg.image}...")
+        build_finelog_image(image=cfg.image)
+
+    old_digest = _running_repo_digest(cfg)
+    if old_digest is None:
+        click.echo(
+            "warning: no running container or digest unavailable; auto-rollback disabled.",
+            err=True,
+        )
+        auto_rollback = False
+    else:
+        click.echo(f"captured running digest: {old_digest}")
+
+    new_digest = _resolve_image_digest(cfg.image)
+    if "@sha256:" not in new_digest:
+        raise click.ClickException(f"Could not pin {cfg.image} to a content digest; refusing to deploy a mutable tag.")
+    click.echo(f"new pinned digest:       {new_digest}")
+
+    if old_digest == new_digest and not force:
+        click.echo("new digest matches running digest; nothing to do (pass --force to redeploy).")
+        return
+    if old_digest == new_digest:
+        click.echo("--force: redeploying the same digest.")
+
+    state_path = _write_state(
+        cfg,
+        previous_digest=old_digest,
+        attempted_digest=new_digest,
+        rollout_started_at=_now(),
+    )
+    click.echo(f"state recorded at {state_path}")
+
+    click.echo("re-running bootstrap with new image...")
+    _bootstrap_with_image(cfg, new_digest)
+
+    click.echo("waiting for /health...")
+    if _verify_health(cfg):
+        _write_state(cfg, current_digest=new_digest, rollout_succeeded_at=_now())
+        click.echo(f"OK — {cfg.name} healthy on {new_digest}")
+        if old_digest:
+            click.echo(f"rollback target preserved: {old_digest}")
+        return
+
+    click.echo("FAIL — finelog did not become healthy on the new image.", err=True)
+    if not auto_rollback or old_digest is None:
+        raise click.ClickException(
+            "Health check failed. Run `safe_deploy rollback <name>` (optionally with --to) to recover."
+        )
+
+    click.echo(f"auto-rolling back to {old_digest}...", err=True)
+    _bootstrap_with_image(cfg, old_digest)
+    if not _verify_health(cfg):
+        raise click.ClickException(f"Rollback to {old_digest} ALSO failed — manual intervention required.")
+    _write_state(
+        cfg,
+        current_digest=old_digest,
+        rolled_back_from=new_digest,
+        rolled_back_at=_now(),
+    )
+    raise click.ClickException(
+        f"Rolled back to {old_digest}. Investigate the failed image {new_digest} before retrying."
+    )
+
+
+@cli.command("rollback")
+@click.argument("name")
+@click.option(
+    "--to",
+    "to_digest",
+    default=None,
+    help="Image (tag or digest) to restore. Defaults to the previous_digest captured on the last rollout.",
+)
+def rollback_cmd(name: str, to_digest: str | None) -> None:
+    """Restore a previously-captured (or explicitly given) image digest."""
+    cfg = load_finelog_config(name)
+    _require_gcp(cfg)
+
+    click.echo(f"== rollback: {cfg.name} ==")
+
+    if to_digest is None:
+        state = _read_state(cfg)
+        to_digest = state.get("previous_digest")
+        if not to_digest:
+            raise click.ClickException(f"No previous_digest recorded for {cfg.name}; pass --to <image> explicitly.")
+        click.echo(f"using previous_digest from state: {to_digest}")
+    else:
+        click.echo(f"using explicit target: {to_digest}")
+
+    running = _running_repo_digest(cfg)
+    if running:
+        click.echo(f"currently running:       {running}")
+        if running == to_digest:
+            click.echo("rollback target matches running digest; nothing to do.")
+            return
+
+    _bootstrap_with_image(cfg, to_digest)
+    if not _verify_health(cfg):
+        raise click.ClickException(f"Rollback to {to_digest} did not become healthy.")
+    _write_state(
+        cfg,
+        current_digest=to_digest,
+        rolled_back_at=_now(),
+        rolled_back_from=running,
+    )
+    click.echo(f"OK — {cfg.name} healthy on {to_digest}")
+
+
+@cli.command("status")
+@click.argument("name")
+def status_cmd(name: str) -> None:
+    """Show recorded state and the currently-running container digest."""
+    cfg = load_finelog_config(name)
+    _require_gcp(cfg)
+
+    state = _read_state(cfg)
+    click.echo(f"== status: {cfg.name} ==")
+    click.echo(f"state file: {_state_path(cfg)}")
+    if state:
+        for key in (
+            "current_digest",
+            "previous_digest",
+            "attempted_digest",
+            "rollout_started_at",
+            "rollout_succeeded_at",
+            "rolled_back_from",
+            "rolled_back_at",
+        ):
+            if key in state:
+                click.echo(f"  {key}: {state[key]}")
+    else:
+        click.echo("  (no recorded state)")
+
+    running = _running_repo_digest(cfg)
+    click.echo(f"running digest: {running or '<unavailable>'}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/lib/finelog/src/finelog/client/__init__.py
+++ b/lib/finelog/src/finelog/client/__init__.py
@@ -4,7 +4,7 @@
 """Finelog client APIs.
 
 :class:`LogClient` is the single user-facing entry point; it covers both the
-legacy log surface (``write_batch`` / ``query``) and the stats surface
+log surface (``write_batch`` / ``fetch_logs``) and the stats surface
 (``get_table`` / ``drop_table``). :class:`RemoteLogHandler` plugs Python's
 ``logging`` into a :class:`LogClient`.
 

--- a/lib/finelog/src/finelog/client/log_client.py
+++ b/lib/finelog/src/finelog/client/log_client.py
@@ -37,6 +37,7 @@ from finelog.errors import (
 from finelog.rpc import finelog_stats_pb2 as stats_pb2
 from finelog.rpc import logging_pb2
 from finelog.rpc.finelog_stats_connect import StatsServiceClientSync
+from finelog.rpc.logging_connect import LogServiceClientSync
 from finelog.store.log_namespace import LOG_REGISTERED_SCHEMA
 from finelog.store.schema import (
     IMPLICIT_SEQ_COLUMN,
@@ -47,8 +48,7 @@ from finelog.store.schema import (
     schema_to_arrow,
     schema_to_proto,
 )
-from finelog.store.sql_escape import quote_literal
-from finelog.types import REGEX_META_RE, is_retryable_error, parse_attempt_id, str_to_log_level
+from finelog.types import is_retryable_error
 
 
 class _QuietStreamHandler(logging.StreamHandler):
@@ -413,9 +413,10 @@ class LogClient:
         self._lock = threading.Lock()
         self._closed = False
         self._stats_client: StatsServiceClientSync | None = None
+        self._log_service_client: LogServiceClientSync | None = None
 
         # The log namespace's Table is constructed lazily on first
-        # write_batch/query so connect() does not pay the resolver cost
+        # write_batch/fetch_logs so connect() does not pay the resolver cost
         # when a caller only needs stats.
         self._tables: dict[str, Table] = {}
 
@@ -462,9 +463,13 @@ class LogClient:
         with self._lock:
             self._closed = True
             stats_client = self._stats_client
+            log_service_client = self._log_service_client
             self._stats_client = None
+            self._log_service_client = None
         if stats_client is not None:
             stats_client.close()
+        if log_service_client is not None:
+            log_service_client.close()
 
     def write_batch(self, key: str, messages: Sequence[logging_pb2.LogEntry]) -> None:
         """Append ``messages`` to the ``log`` namespace under ``key``."""
@@ -473,11 +478,23 @@ class LogClient:
         table = self._get_log_table()
         table.write(_log_entries_to_rows(key, messages))
 
-    def query(self, request: logging_pb2.FetchLogsRequest) -> logging_pb2.FetchLogsResponse:
-        """Read from the ``log`` namespace via ``StatsService.Query``."""
-        sql = _logs_query_sql(request)
-        result = self._stats_query(sql)
-        return _logs_query_response_from_arrow(result, request)
+    def fetch_logs(self, request: logging_pb2.FetchLogsRequest) -> logging_pb2.FetchLogsResponse:
+        """Read from the ``log`` namespace via ``LogService.FetchLogs``.
+
+        Uses the purpose-built log read path (warm cached DuckDB connection,
+        single-namespace scan, tail-aware short-circuit) instead of the
+        general SQL ``StatsService.Query`` surface.
+        """
+        client = self._get_log_service_client()
+        try:
+            return client.fetch_logs(request)
+        except ConnectError as exc:
+            if is_retryable_error(exc):
+                self._invalidate(_format_exc_summary(exc))
+            raise _translate_connect_error(exc) from exc
+        except (ConnectionError, OSError, TimeoutError) as exc:
+            self._invalidate(_format_exc_summary(exc))
+            raise
 
     def flush(self, timeout: float | None = None) -> FlushResult:
         """Flush the ``log`` namespace's Table, if any."""
@@ -583,6 +600,21 @@ class LogClient:
             logger.info("LogClient resolved %s -> %s (stats)", self._server_url, address)
             return self._stats_client
 
+    def _get_log_service_client(self) -> LogServiceClientSync:
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("LogClient is closed")
+            if self._log_service_client is not None:
+                return self._log_service_client
+            address = self._resolve()
+            self._log_service_client = LogServiceClientSync(
+                address=address,
+                timeout_ms=self._timeout_ms,
+                interceptors=self._interceptors,
+            )
+            logger.info("LogClient resolved %s -> %s (log)", self._server_url, address)
+            return self._log_service_client
+
     def _resolve(self) -> str:
         address = self._resolver(self._server_url)
         if not address:
@@ -592,11 +624,16 @@ class LogClient:
     def _invalidate(self, reason: str) -> None:
         with self._lock:
             stats_client = self._stats_client
+            log_service_client = self._log_service_client
             self._stats_client = None
-        if stats_client is None:
+            self._log_service_client = None
+        if stats_client is None and log_service_client is None:
             return
         logger.info("LogClient: invalidating cached endpoint for %s (%s)", self._server_url, reason)
-        stats_client.close()
+        if stats_client is not None:
+            stats_client.close()
+        if log_service_client is not None:
+            log_service_client.close()
 
     def _stats_query(self, sql: str) -> pa.Table:
         client = self._get_stats_client()
@@ -681,89 +718,6 @@ def _log_entries_to_rows(key: str, messages: Sequence[logging_pb2.LogEntry]) -> 
             )
         )
     return rows
-
-
-_LOG_QUERY_COLUMNS = ("seq", "key", "source", "data", "epoch_ms", "level")
-_DEFAULT_FETCH_MAX_LINES = 1000
-
-
-def _logs_query_sql(request: logging_pb2.FetchLogsRequest) -> str:
-    """Translate a FetchLogsRequest into SQL against the ``log`` view.
-
-    ``source`` is matched literally unless it contains regex metacharacters.
-    ``min_level`` always keeps level=UNKNOWN rows so unparsed lines remain
-    visible.
-    """
-    where_parts: list[str] = []
-    source = request.source
-
-    if source:
-        if REGEX_META_RE.search(source):
-            where_parts.append(f"regexp_matches(key, {quote_literal(source)})")
-        else:
-            where_parts.append(f"key = {quote_literal(source)}")
-
-    cursor = request.cursor
-    if cursor:
-        where_parts.append(f"seq > {int(cursor)}")
-
-    if request.since_ms:
-        where_parts.append(f"epoch_ms > {int(request.since_ms)}")
-
-    if request.substring:
-        where_parts.append(f"contains(data, {quote_literal(request.substring)})")
-
-    min_level_enum = str_to_log_level(request.min_level)
-    if min_level_enum > 0:
-        where_parts.append(f"(level = 0 OR level >= {int(min_level_enum)})")
-
-    max_lines = request.max_lines if request.max_lines > 0 else _DEFAULT_FETCH_MAX_LINES
-
-    where_clause = " WHERE " + " AND ".join(where_parts) if where_parts else ""
-    order = "ORDER BY seq DESC" if request.tail else "ORDER BY seq"
-    select_cols = ", ".join(_LOG_QUERY_COLUMNS)
-
-    return f'SELECT {select_cols} FROM "{LOG_NAMESPACE}"' f"{where_clause} {order} LIMIT {int(max_lines)}"
-
-
-def _logs_query_response_from_arrow(
-    table: pa.Table,
-    request: logging_pb2.FetchLogsRequest,
-) -> logging_pb2.FetchLogsResponse:
-    # Tail-mode rows arrive newest-first; reverse so callers always see
-    # chronological output. Cursor is max(seq).
-    seqs = table.column("seq").to_pylist()
-    keys = table.column("key").to_pylist()
-    sources = table.column("source").to_pylist()
-    datas = table.column("data").to_pylist()
-    epochs = table.column("epoch_ms").to_pylist()
-    levels = table.column("level").to_pylist()
-
-    rows: list[tuple] = list(zip(seqs, keys, sources, datas, epochs, levels, strict=True))
-
-    if request.tail and request.max_lines > 0:
-        rows.reverse()
-
-    if not rows:
-        return logging_pb2.FetchLogsResponse(entries=[], cursor=request.cursor)
-
-    is_pattern = bool(REGEX_META_RE.search(request.source)) if request.source else True
-    fixed_attempt = parse_attempt_id(request.source) if (request.source and not is_pattern) else 0
-
-    entries = []
-    for seq, key, source, data, epoch_ms, level in rows:
-        del seq  # cursor uses the max below
-        entry = logging_pb2.LogEntry(source=source, data=data, level=level)
-        entry.timestamp.epoch_ms = epoch_ms
-        if is_pattern:
-            entry.key = key
-            entry.attempt_id = parse_attempt_id(key)
-        else:
-            entry.attempt_id = fixed_attempt
-        entries.append(entry)
-
-    max_seq = max(seqs)
-    return logging_pb2.FetchLogsResponse(entries=entries, cursor=max_seq)
 
 
 def _translate_connect_error(exc: ConnectError) -> Exception:

--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -69,6 +69,14 @@ _LOG_PREFIX = "logs_"
 
 _ROW_GROUP_SIZE = 16_384
 
+# Append calls slower than this emit a warning so lock contention vs prepare
+# work vs critical-section work is visible in production logs.
+_SLOW_APPEND_THRESHOLD_MS = 200
+
+# Background loop heartbeat cadence — emits a one-line snapshot of buffer
+# and segment state regardless of whether a flush or compaction fires.
+_BG_HEARTBEAT_INTERVAL_SEC = 10.0
+
 # Hard ceiling on the per-read parquet working set; safety net for body-LIKE
 # queries that cannot be pruned by row-group statistics.
 _MAX_PARQUET_BYTES_PER_READ = 2_500 * 1024 * 1024
@@ -168,7 +176,11 @@ def _stamp_seq_column(batch: pa.RecordBatch, first_seq: int, arrow_schema: pa.Sc
 
 
 def _build_log_table(buffer: list[tuple], arrow_schema: pa.Schema) -> pa.Table:
-    """Build an Arrow table from log-namespace ``(seq, key, source, data, epoch_ms, level)`` tuples."""
+    """Build an Arrow table from log-namespace ``(seq, key, source, data, epoch_ms, level)`` tuples.
+
+    Used by :class:`MemoryLogNamespace`. The disk path goes through
+    :meth:`RamBuffers.append_table` with pre-built columnar arrays.
+    """
     if not buffer:
         return arrow_schema.empty_table()
     n = 6
@@ -185,6 +197,94 @@ def _build_log_table(buffer: list[tuple], arrow_schema: pa.Schema) -> pa.Table:
         pa.array(cols[5], type=pa.int32()),
     ]
     return pa.table(arrays, schema=arrow_schema)
+
+
+class RamBuffers:
+    """Owns the in-RAM write state for a single namespace.
+
+    Holds the merged log chunks plus the in-flight ``flushing`` table, the
+    seq counter, and a maintained ``_ram_bytes`` tally so callers don't
+    rescan ``self._chunks`` on every append. Not thread-safe — the
+    enclosing namespace serializes calls under ``_insertion_lock``.
+
+    ``pa.concat_tables`` (used by ``_merge_chunks``) is zero-copy for
+    primitive columns and shares string buffers via Arrow's reference
+    counting, so total ``nbytes`` is conserved across merges. We can
+    therefore maintain ``_ram_bytes`` incrementally rather than scanning.
+    """
+
+    def __init__(self, *, arrow_schema: pa.Schema, next_seq: int) -> None:
+        self._arrow_schema = arrow_schema
+        self._chunks: list[pa.Table] = []
+        self._flushing: _SealedBuffer | None = None
+        self._next_seq = next_seq
+        self._ram_bytes = 0
+
+    @property
+    def next_seq(self) -> int:
+        return self._next_seq
+
+    def allocate_seq(self, count: int) -> int:
+        first = self._next_seq
+        self._next_seq += count
+        return first
+
+    def append_table(self, table: pa.Table) -> None:
+        added = table.nbytes
+        self._chunks.append(table)
+        self._chunks = _merge_chunks(self._chunks)
+        self._ram_bytes += added
+
+    def ram_bytes(self) -> int:
+        flushing_b = self._flushing.table.nbytes if self._flushing is not None else 0
+        return self._ram_bytes + flushing_b
+
+    def chunk_count(self) -> int:
+        return len(self._chunks)
+
+    def has_chunks(self) -> bool:
+        return bool(self._chunks)
+
+    def seal(self) -> _SealedBuffer | None:
+        """Move accumulated chunks into a sealed flushing buffer.
+
+        Returns ``None`` if there is nothing to flush. The returned buffer
+        is also stored on ``self._flushing`` so queries see in-flight rows.
+        """
+        if not self._chunks:
+            return None
+        tables = self._chunks
+        self._chunks = []
+        self._ram_bytes = 0
+        visible_table = pa.concat_tables(tables) if len(tables) > 1 else tables[0]
+        seq_col = visible_table.column(IMPLICIT_SEQ_COLUMN)
+        sealed = _SealedBuffer(
+            table=visible_table,
+            min_seq=pc.min(seq_col).as_py(),
+            max_seq=pc.max(seq_col).as_py(),
+        )
+        self._flushing = sealed
+        return sealed
+
+    def commit_flush(self) -> None:
+        """Drop the in-flight flushing buffer (parquet write succeeded)."""
+        self._flushing = None
+
+    def restore_flush(self) -> None:
+        """Push the in-flight buffer back to the head of chunks (write failed)."""
+        if self._flushing is None:
+            return
+        table = self._flushing.table
+        self._chunks.insert(0, table)
+        self._ram_bytes += table.nbytes
+        self._flushing = None
+
+    def query_snapshot(self) -> list[pa.Table]:
+        """Return chunks plus any in-flight flushing table (for read paths)."""
+        snap = list(self._chunks)
+        if self._flushing is not None:
+            snap.append(self._flushing.table)
+        return snap
 
 
 class LogNamespaceProtocol(Protocol):
@@ -270,9 +370,10 @@ class DiskLogNamespace:
         self._compaction_conn = compaction_conn
         self._read_pool = read_pool
 
-        self._next_seq = _recover_next_seq(data_dir)
-        self._chunks: list[pa.Table] = []
-        self._flushing: _SealedBuffer | None = None
+        self._buffers = RamBuffers(
+            arrow_schema=self._arrow_schema,
+            next_seq=_recover_next_seq(data_dir),
+        )
         self._local_segments: deque[LocalSegment] = deque()
 
         # Drop stale tmp segments left behind by a prior compaction that
@@ -320,33 +421,75 @@ class DiskLogNamespace:
         self._bg_thread.start()
 
     def append_log_batch(self, items: list[tuple[str, list]]) -> None:
-        """Log-namespace-only append for ``PushLogs`` RPCs."""
+        """Log-namespace-only append for ``PushLogs`` RPCs.
+
+        Pre-builds all five non-seq columns from the protobuf entries
+        outside the lock — that's the bulk of the per-row Python work.
+        Inside the lock we only allocate the seq range, materialize the
+        seq array, assemble the Arrow table, and hand it to the buffer.
+        """
+        t_enter = time.monotonic()
+        # Outside the lock: flatten items into one combined columnar batch.
+        keys: list[str] = []
+        sources: list[str] = []
+        datas: list[str] = []
+        epoch_ms: list[int] = []
+        levels: list[int] = []
+        for key, entries in items:
+            if not entries:
+                continue
+            n = len(entries)
+            keys.extend([key] * n)
+            sources.extend(e.source for e in entries)
+            datas.extend(e.data for e in entries)
+            epoch_ms.extend(e.timestamp.epoch_ms for e in entries)
+            levels.extend(int(e.level) for e in entries)
+        total = len(keys)
+        if total == 0:
+            return
+        keys_arr = pa.array(keys, type=pa.string())
+        sources_arr = pa.array(sources, type=pa.string())
+        datas_arr = pa.array(datas, type=pa.string())
+        ts_arr = pa.array(epoch_ms, type=pa.int64())
+        levels_arr = pa.array(levels, type=pa.int32())
+        t_prepared = time.monotonic()
+
+        wait_start = time.monotonic()
         with self._insertion_lock:
-            for key, entries in items:
-                if not entries:
-                    continue
-                first_seq = self._next_seq
-                self._next_seq += len(entries)
-                rows = [
-                    (first_seq + i, key, e.source, e.data, e.timestamp.epoch_ms, e.level) for i, e in enumerate(entries)
-                ]
-                self._chunks.append(_build_log_table(rows, self._arrow_schema))
-            self._chunks = _merge_chunks(self._chunks)
-            needs_drain = self._ram_bytes_locked() >= self._segment_target_bytes
+            critical_start = time.monotonic()
+            first_seq = self._buffers.allocate_seq(total)
+            seqs_arr = pa.array(range(first_seq, first_seq + total), type=pa.int64())
+            self._buffers.append_table(
+                pa.table(
+                    [seqs_arr, keys_arr, sources_arr, datas_arr, ts_arr, levels_arr],
+                    schema=self._arrow_schema,
+                )
+            )
+            needs_drain = self._buffers.ram_bytes() >= self._segment_target_bytes
+        critical_end = time.monotonic()
         if needs_drain:
             self._wake.set()
+
+        total_ms = int((critical_end - t_enter) * 1000)
+        if total_ms >= _SLOW_APPEND_THRESHOLD_MS:
+            logger.warning(
+                "slow append: items=%d rows=%d prepare_ms=%d lock_wait_ms=%d critical_ms=%d total_ms=%d",
+                len(items),
+                total,
+                int((t_prepared - t_enter) * 1000),
+                int((critical_start - wait_start) * 1000),
+                int((critical_end - critical_start) * 1000),
+                total_ms,
+            )
 
     def append_record_batch(self, batch: pa.RecordBatch) -> None:
         """Stamp ``seq`` values onto ``batch`` and append it to the in-RAM chunks."""
         if batch.num_rows == 0:
             return
         with self._insertion_lock:
-            first_seq = self._next_seq
-            self._next_seq += batch.num_rows
-            stamped = _stamp_seq_column(batch, first_seq, self._arrow_schema)
-            self._chunks.append(stamped)
-            self._chunks = _merge_chunks(self._chunks)
-            needs_drain = self._ram_bytes_locked() >= self._segment_target_bytes
+            first_seq = self._buffers.allocate_seq(batch.num_rows)
+            self._buffers.append_table(_stamp_seq_column(batch, first_seq, self._arrow_schema))
+            needs_drain = self._buffers.ram_bytes() >= self._segment_target_bytes
         if needs_drain:
             self._wake.set()
 
@@ -407,54 +550,85 @@ class DiskLogNamespace:
         self.schema = new_schema
         self._arrow_schema = schema_to_arrow(new_schema)
 
-    def _ram_bytes_locked(self) -> int:
-        chunks_b = sum(t.nbytes for t in self._chunks)
-        flushing_b = self._flushing.table.nbytes if self._flushing is not None else 0
-        return chunks_b + flushing_b
-
     def _bg_loop(self) -> None:
+        last_heartbeat = 0.0
+        last_flush_at = time.monotonic()
+        last_compact_at = time.monotonic()
         while not self._stop.is_set():
             with self._insertion_lock:
-                force_drain = self._ram_bytes_locked() >= self._segment_target_bytes
+                ram_bytes = self._buffers.ram_bytes()
+                chunk_count = self._buffers.chunk_count()
+                next_seq = self._buffers.next_seq
                 tmp_count = sum(1 for s in self._local_segments if _is_tmp_path(s.path))
-                force_compaction = tmp_count > self._max_tmp_segments_before_compact
+                logs_count = len(self._local_segments) - tmp_count
+            force_drain = ram_bytes >= self._segment_target_bytes
+            force_compaction = tmp_count > self._max_tmp_segments_before_compact
+
+            now = time.monotonic()
+            if now - last_heartbeat >= _BG_HEARTBEAT_INTERVAL_SEC:
+                logger.info(
+                    "bg-loop tick: chunks=%d ram_bytes=%d tmp=%d logs=%d next_seq=%d "
+                    "since_flush_ms=%d since_compact_ms=%d",
+                    chunk_count,
+                    ram_bytes,
+                    tmp_count,
+                    logs_count,
+                    next_seq,
+                    int((now - last_flush_at) * 1000),
+                    int((now - last_compact_at) * 1000),
+                )
+                last_heartbeat = now
+
             if force_drain:
                 self._flush_step()
                 self._flush_rl.mark_run()
+                last_flush_at = time.monotonic()
             elif self._flush_rl.should_run():
                 self._flush_step()
+                last_flush_at = time.monotonic()
             if force_compaction or self._compaction_rl.should_run():
                 self._compaction_step()
                 self._compaction_rl.mark_run()
+                last_compact_at = time.monotonic()
 
             self._wake.wait(timeout=min(self._flush_rl.time_until_next(), 1.0))
             self._wake.clear()
 
     def _flush_step(self) -> None:
         with self._flush_lock:
+            flush_start = time.monotonic()
             with self._insertion_lock:
-                if not self._chunks:
-                    return
-                tables = list(self._chunks)
-                self._chunks = []
-                visible_table = pa.concat_tables(tables) if len(tables) > 1 else tables[0]
-                min_seq, max_seq = self._derive_seq_bounds_locked(visible_table)
-                visible = _SealedBuffer(table=visible_table, min_seq=min_seq, max_seq=max_seq)
-                self._flushing = visible
+                ram_bytes_before = self._buffers.ram_bytes()
+                chunks_before = self._buffers.chunk_count()
+                visible = self._buffers.seal()
+            if visible is None:
+                return
+
+            logger.info(
+                "flush starting: rows=%d ram_bytes=%d chunks=%d seq=[%d,%d]",
+                visible.table.num_rows,
+                ram_bytes_before,
+                chunks_before,
+                visible.min_seq,
+                visible.max_seq,
+            )
 
             sealed = _SealedBuffer(
-                table=self._sort_for_flush(visible_table),
-                min_seq=min_seq,
-                max_seq=max_seq,
+                table=self._sort_for_flush(visible.table),
+                min_seq=visible.min_seq,
+                max_seq=visible.max_seq,
             )
 
             try:
                 self._write_new_segment(sealed)
             except Exception:
-                logger.warning("Flush failed, restoring data to chunks", exc_info=True)
+                logger.warning(
+                    "Flush failed after %d ms, restoring data to chunks",
+                    int((time.monotonic() - flush_start) * 1000),
+                    exc_info=True,
+                )
                 with self._insertion_lock:
-                    self._chunks.insert(0, visible.table)
-                    self._flushing = None
+                    self._buffers.restore_flush()
                 return
 
             with self._flush_generation_cond:
@@ -483,13 +657,21 @@ class DiskLogNamespace:
 
         filepath = self._data_dir / filename
         tmp_path = filepath.with_suffix(".parquet.tmp")
+        # Materialize parquet in memory and flush in one write(). pyarrow's
+        # path-based writer uses an unbuffered FileOutputStream that emits
+        # ~40 syscalls per segment (most <100B — page headers, footer
+        # fragments). On a contended boot disk those serialize against the
+        # I/O queue and dominate flush latency.
+        buf = pa.BufferOutputStream()
         pq.write_table(
             sealed.table,
-            tmp_path,
+            buf,
             compression="zstd",
             row_group_size=_ROW_GROUP_SIZE,
             write_page_index=True,
         )
+        with pa.OSFile(str(tmp_path), "wb") as out:
+            out.write(buf.getvalue())
         tmp_path.rename(filepath)
         seg = LocalSegment(
             path=str(filepath),
@@ -500,7 +682,7 @@ class DiskLogNamespace:
 
         with self._insertion_lock:
             self._local_segments.append(seg)
-            self._flushing = None
+            self._buffers.commit_flush()
 
         logger.info(
             "Wrote tmp segment %s: rows=%d bytes=%d seq=[%d,%d] elapsed_ms=%d",
@@ -632,10 +814,7 @@ class DiskLogNamespace:
     def query_snapshot(self) -> tuple[list[LocalSegment], list[pa.Table]]:
         """Return all currently queryable local segments and RAM tables."""
         with self._insertion_lock:
-            ram_tables = list(self._chunks)
-            if self._flushing is not None:
-                ram_tables.append(self._flushing.table)
-            return list(self._local_segments), ram_tables
+            return list(self._local_segments), self._buffers.query_snapshot()
 
     def all_segments_unlocked(self) -> list[LocalSegment]:
         """Snapshot every locally-tracked segment. Caller MUST hold the insertion lock."""
@@ -734,9 +913,7 @@ class DiskLogNamespace:
     ) -> list[tuple]:
         with self._insertion_lock:
             segments = list(self._local_segments)
-            ram_tables: list[pa.Table] = list(self._chunks)
-            if self._flushing is not None:
-                ram_tables.append(self._flushing.table)
+            ram_tables: list[pa.Table] = self._buffers.query_snapshot()
 
         segments = _cap_segments(segments)
         parquet_files = [s.path for s in segments]

--- a/lib/finelog/tests/test_client.py
+++ b/lib/finelog/tests/test_client.py
@@ -150,6 +150,33 @@ def tracked_clients(monkeypatch):
     return clients
 
 
+class _FakeLogServiceClient:
+    def __init__(self, address, **_kwargs):
+        self.address = address
+        self.requests: list[logging_pb2.FetchLogsRequest] = []
+        self.response: logging_pb2.FetchLogsResponse = logging_pb2.FetchLogsResponse()
+
+    def fetch_logs(self, request):
+        self.requests.append(request)
+        return self.response
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def tracked_log_service_clients(monkeypatch):
+    """Patch LogServiceClientSync; expose request/response on the singleton fake."""
+    fake = _FakeLogServiceClient(address=None)
+
+    def factory(address, timeout_ms=10_000, interceptors=()):
+        fake.address = address
+        return fake
+
+    monkeypatch.setattr(log_client_mod, "LogServiceClientSync", factory)
+    return fake
+
+
 def test_connect_returns_usable_client(tracked_clients):
     client = LogClient.connect("http://h:1")
     try:
@@ -227,29 +254,20 @@ def test_invalidates_on_connection_refused(tracked_clients, monkeypatch):
         client.close()
 
 
-def test_query_round_trips(tracked_clients):
+def test_fetch_logs_round_trips(tracked_log_service_clients):
     client = LogClient.connect("http://h:1")
     try:
+        request = logging_pb2.FetchLogsRequest(source="key", max_lines=10)
+        canned = logging_pb2.FetchLogsResponse(
+            entries=[logging_pb2.LogEntry(source="stdout", data="hi", level=2)],
+            cursor=42,
+        )
+        canned.entries[0].timestamp.epoch_ms = 1700000000000
+        tracked_log_service_clients.response = canned
 
-        def handler(_sql: str) -> pa.Table:
-            return pa.table(
-                {
-                    "seq": pa.array([42], type=pa.int64()),
-                    "key": ["key"],
-                    "source": ["stdout"],
-                    "data": ["hi"],
-                    "epoch_ms": pa.array([1700000000000], type=pa.int64()),
-                    "level": pa.array([2], type=pa.int32()),
-                }
-            )
+        resp = client.fetch_logs(request)
 
-        client.get_table("iris.worker", WorkerStat)
-        tracked_clients[0].query_handler = handler
-        resp = client.query(logging_pb2.FetchLogsRequest(source="key", max_lines=10))
-        sql = tracked_clients[0].queries[0]
-        assert '"log"' in sql
-        assert "key = 'key'" in sql
-        assert "LIMIT 10" in sql
+        assert tracked_log_service_clients.requests == [request]
         assert resp.cursor == 42
         assert [e.data for e in resp.entries] == ["hi"]
     finally:

--- a/lib/iris/src/iris/cli/bug_report.py
+++ b/lib/iris/src/iris/cli/bug_report.py
@@ -160,7 +160,7 @@ def _gather(
         try:
             # Fetch all attempts for this task, taking only the last `tail` lines.
             source = build_log_source(JobName.from_wire(task.task_id))
-            log_resp = log_client.query(
+            log_resp = log_client.fetch_logs(
                 logging_pb2.FetchLogsRequest(
                     source=source,
                     max_lines=tail,

--- a/lib/iris/src/iris/cli/process_status.py
+++ b/lib/iris/src/iris/cli/process_status.py
@@ -107,7 +107,7 @@ def logs(ctx, target: str | None, level: str, follow: bool, max_lines: int, subs
             if substring:
                 req.substring = substring
 
-            resp = log_client.query(req)
+            resp = log_client.fetch_logs(req)
             for entry in resp.entries:
                 ts = ""
                 if entry.timestamp and entry.timestamp.epoch_ms:

--- a/lib/iris/src/iris/cluster/client/remote_client.py
+++ b/lib/iris/src/iris/cluster/client/remote_client.py
@@ -468,7 +468,7 @@ class RemoteClusterClient:
         )
 
         def _call():
-            return self._log_client.query(request)
+            return self._log_client.fetch_logs(request)
 
         return call_with_retry(f"fetch_logs({source})", _call)
 

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -1002,7 +1002,7 @@ class ControllerServiceImpl:
         store: Controller store bundle (per-entity stores + transaction / read_snapshot).
         controller: Controller runtime for scheduling and worker management
         bundle_store: Bundle store for zip storage.
-        log_client: LogClient for reading task logs through StatsService.Query.
+        log_client: LogClient for reading task logs through LogService.FetchLogs.
     """
 
     def __init__(
@@ -1892,7 +1892,7 @@ class ControllerServiceImpl:
             min_level=request.min_level,
         )
 
-        fetch_response = self._log_client.query(fetch_request)
+        fetch_response = self._log_client.fetch_logs(fetch_request)
         entries = fetch_response.entries
 
         batch = controller_pb2.Controller.TaskLogBatch(

--- a/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
@@ -198,9 +198,9 @@ for i in $(seq 1 60); do
     if ! sudo docker ps -q -f name=iris-worker | grep -q .; then
         echo "[iris-init] ERROR: Worker container exited unexpectedly"
         echo "[iris-init] Container status:"
-        sudo docker ps -a -f name=iris-worker --format "table {{.Status}}\\t{{.State}}"
+        sudo docker ps -a -f name=iris-worker --format "table {{.Status}}\\t{{.State}}" 2>&1 | sed 's/^/[iris-init] /'
         echo "[iris-init] Container logs:"
-        sudo docker logs iris-worker --tail 100
+        sudo docker logs iris-worker --tail 100 2>&1 | sed 's/^/[iris-init] /'
         exit 1
     fi
 
@@ -216,9 +216,9 @@ done
 
 echo "[iris-init] ERROR: Worker failed to become healthy after 120s"
 echo "[iris-init] Container status:"
-sudo docker ps -a -f name=iris-worker --format "table {{.Status}}\\t{{.State}}"
+sudo docker ps -a -f name=iris-worker --format "table {{.Status}}\\t{{.State}}" 2>&1 | sed 's/^/[iris-init] /'
 echo "[iris-init] Container logs:"
-sudo docker logs iris-worker --tail 100
+sudo docker logs iris-worker --tail 100 2>&1 | sed 's/^/[iris-init] /'
 exit 1
 """
 


### PR DESCRIPTION
Route LogClient.fetch_logs through LogService.FetchLogs instead of translating to SQL on StatsService.Query, which avoided a fresh DuckDB connection and full-namespace view rebuild on every poll. Extract RamBuffers from DiskLogNamespace and add slow-append warnings plus a background-loop heartbeat for production diagnosis. Add safe_deploy.py to capture the running image digest before bootstrap and auto-rollback on health failure.