### PR TITLE
[CI] Allow manual multi-host CoreWeave GPU canary runs

### DIFF
--- a/.github/workflows/marin-canary-ferry-cw.yaml
+++ b/.github/workflows/marin-canary-ferry-cw.yaml
@@ -1,9 +1,9 @@
 name: Marin - CoreWeave GPU Canary Ferry
 
 # The canary submits a small training job to the shared `iris-ci` controller
-# and reuses the warm `iris-ci-h100-8x` NodePool. We do *not* provision a
-# separate H100 — CoreWeave's account quota in US-WEST-04A only allows one
-# `gd-8xh100ib-i128` at a time, which the permanent iris-ci nodepool holds.
+# and reuses the warm `iris-ci-h100-8x` NodePool. Scheduled runs use the warm
+# single H100 host; manual multi-host runs may autoscale the same NodePool to a
+# second `gd-8xh100ib-i128` host.
 #
 # `iris cluster start --fresh` rebuilds the controller/worker/task images from
 # the current checkout and rolls the shared controller deployment to pick them
@@ -18,6 +18,11 @@ on:
       target_tokens:
         description: 'Override training token budget'
         type: number
+        required: false
+      multi_host:
+        description: 'Run across two H100 hosts'
+        type: boolean
+        default: false
         required: false
 
 permissions:
@@ -42,6 +47,7 @@ jobs:
       RUN_ID: canary-gpu-${{ github.run_id }}-${{ github.run_attempt }}
       CANARY_ACCELERATOR: gpu
       CANARY_BATCH_SIZE: "16"
+      CANARY_MULTI_HOST: ${{ github.event_name == 'workflow_dispatch' && inputs.multi_host && '1' || '' }}
       CANARY_TARGET_TOKENS: "6553600"
       CANARY_MIN_STEPS: "40"
       CANARY_MAX_LOSS: "8.0"
@@ -110,12 +116,14 @@ jobs:
           LOCAL_PORT=$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()")
           kubectl port-forward -n "$IRIS_NAMESPACE" svc/iris-ci-controller-svc "${LOCAL_PORT}:10000" &
           PF_PID=$!
-          echo "PF_PID=$PF_PID" >> "$GITHUB_ENV"
-          echo "LOCAL_PORT=$LOCAL_PORT" >> "$GITHUB_ENV"
-          echo "IRIS_CONTROLLER_URL=http://localhost:${LOCAL_PORT}" >> "$GITHUB_ENV"
+          {
+            echo "PF_PID=$PF_PID"
+            echo "LOCAL_PORT=$LOCAL_PORT"
+            echo "IRIS_CONTROLLER_URL=http://localhost:${LOCAL_PORT}"
+          } >> "$GITHUB_ENV"
 
           # Konnectivity can take ~20s to become usable after controller restart.
-          for i in $(seq 1 60); do
+          for _ in $(seq 1 60); do
             if ! kill -0 "$PF_PID" 2>/dev/null; then
               kubectl port-forward -n "$IRIS_NAMESPACE" svc/iris-ci-controller-svc "${LOCAL_PORT}:10000" &
               PF_PID=$!
@@ -136,6 +144,7 @@ jobs:
         id: submit
         shell: bash -l {0}
         run: |
+          echo "Multi-host canary: ${CANARY_MULTI_HOST:-0}"
           JOB_ID=$(.venv/bin/iris --controller-url="$IRIS_CONTROLLER_URL" \
             job run --no-wait \
             --memory=2G --disk=4G --cpu=1 --extra=cpu \
@@ -143,6 +152,7 @@ jobs:
             -e RUN_ID "$RUN_ID" \
             -e CANARY_ACCELERATOR "$CANARY_ACCELERATOR" \
             -e CANARY_BATCH_SIZE "$CANARY_BATCH_SIZE" \
+            -e CANARY_MULTI_HOST "$CANARY_MULTI_HOST" \
             -e CANARY_TARGET_TOKENS "$CANARY_TARGET_TOKENS" \
             -e WANDB_ENTITY "$WANDB_ENTITY" \
             -e WANDB_PROJECT "$WANDB_PROJECT" \

--- a/lib/iris/examples/coreweave-ci.yaml
+++ b/lib/iris/examples/coreweave-ci.yaml
@@ -1,5 +1,6 @@
-# Persistent CoreWeave CI cluster. Both scale groups are pinned at min=max=1
-# so nodes stay warm between runs — only controller and worker pods are reset.
+# Persistent CoreWeave CI cluster. The CPU pool and the first H100 node stay
+# warm between runs; the H100 pool may autoscale to a second node for manual
+# multi-host canary runs.
 
 platform:
   label_prefix: iris-ci
@@ -80,7 +81,7 @@ scale_groups:
       attributes:
         pool: h100-8x
     buffer_slices: 1
-    max_slices: 1
+    max_slices: 2
     priority: 100
     slice_template:
       num_vms: 1


### PR DESCRIPTION
Allow manual two-host H100 canary runs on CoreWeave while keeping scheduled canaries at the current one-warm-H100 footprint.

Why scheduled runs should not burn extra 8xH100 capacity:

- The H100 scale group stays `num_vms: 1` and `buffer_slices: 1`; only `max_slices` changes from `1` to `2`. That keeps the CoreWeave NodePool minimum at one H100 node while allowing a second node on demand.
- Scheduled workflow runs do not set `CANARY_MULTI_HOST`, so they keep using the existing single-host GPU path.
- The second H100 path is only selected by manual workflow dispatch with `multi_host=true`.

Live validation:

- Representative manual run succeeded on the main `iris-ci` CoreWeave canary cluster.
- The run scaled `iris-ci-h100-8x` from one to two 8xH100 nodes, ran the real Grug MoE canary across two distinct H100 hosts, and then scaled back to one node.
- Grug MoE initialized JAX distributed with `num_tasks=2`, completed `100/100` train steps, synced W&B metrics, and passed final-loss validation (`6.6870 <= 8.0`).
- After the run, the live NodePool was restored to the main-branch shape: `minNodes=1`, `maxNodes=1`, `targetNodes=1`.

This does not make performance claims. It only enables and validates manual multi-host correctness and baseline-cost behavior.

<details>
<summary>Live validation details</summary>

GHA run: https://github.com/marin-community/marin/actions/runs/25384472520

Iris job: `/runner/iris-run-job-20260505-150820`

Grug child job: `/runner/iris-run-job-20260505-150820/grug-train-canary-gpu-25384472520-1`

W&B run: https://wandb.ai/marin-community/marin/runs/canary-gpu-25384472520-1

Observed result:

- Baseline before test: one live H100 node.
- Workflow log showed `Multi-host canary: 1`.
- Two Grug task pods from the same child job ran on distinct H100 nodes: `g13c908` and `g11db12`.
- The second H100 node scaled up in about six minutes.
- The first Grug attempt timed out during distributed rendezvous while the second H100 was stabilizing; Iris retried the task set, and the retry succeeded across both hosts.
- After cleanup, `iris-ci-h100-8x` returned to `currentNodes=1`.
- CoreWeave/K8s daemon, probe, and monitoring pods did not keep the second H100 node hot.

</details>

<details>
<summary>Local and workflow validation</summary>

- Loaded `lib/iris/examples/coreweave-ci.yaml` with `iris.cluster.config.load_config` and confirmed `h100-8x` resolves to `num_vms=1`, `minNodes=1`, `maxNodes=2`.
- Ran `uv run --package marin-iris --group dev pytest lib/iris/tests/cluster/providers/k8s/test_coreweave.py::test_ensure_nodepools_scales_multihost_groups_by_num_vms lib/iris/tests/cluster/providers/k8s/test_coreweave.py::test_ensure_nodepools_keeps_one_multihost_slice_warm`: 2 passed.
- Ran `actionlint .github/workflows/marin-canary-ferry-cw.yaml`: OK.
- Ran `./infra/pre-commit.py --all-files --fix`: OK.
- PR CI passed, including `cw-ci-test`, `cloud-smoke-test`, `marin-itest`, `lint-and-format`, and library tests.

</details>

<details>
<summary>Post-merge validation protocol</summary>

After merge, the first scheduled canary should be checked for baseline-cost behavior:

1. Confirm the scheduled canary logs show `Multi-host canary: 0`.
2. Check `iris-ci-h100-8x` while no manual multi-host canary is running and confirm it stays at one live H100 node.
3. Confirm NodePool shape is `minNodes=1`, `maxNodes=2`, `targetNodes=1`, `currentNodes=1`.
4. When manually testing multi-host later, confirm the second H100 node scales down and `currentNodes` returns to `1`.

</details>
