### PR TITLE
Only consolidate shard ledger in tokenize 

### DIFF
--- a/experiments/ferries/canary_ferry.py
+++ b/experiments/ferries/canary_ferry.py
@@ -17,6 +17,7 @@ to the Iris container. workflow_dispatch inputs override CANARY_TARGET_TOKENS.
     CANARY_PROFILER_NUM_STEPS profiler duration in steps
     CANARY_PROFILER_START_STEP profiler start step
     CANARY_STEPS         explicit training step count; overrides CANARY_TARGET_TOKENS
+    CANARY_CACHE_COPY_MAX_WORKERS gpu-only cache-copy worker cap
     CANARY_TARGET_TOKENS total training tokens
     CANARY_TRACKER       wandb | json_logger
     RUN_ID               unique run identifier
@@ -97,7 +98,6 @@ def _build_step_from_env() -> ExecutorStep:
         wandb_tags = ["canary", "ferry", "grug", "moe"]
     else:
         batch_size = _env_int("CANARY_BATCH_SIZE", 32)
-        cache_copy_max_workers = _env_int("CANARY_CACHE_COPY_MAX_WORKERS", 12)
         target_tokens = _env_int("CANARY_TARGET_TOKENS", batch_size * GRUG_MOE_TRIAL_MODEL.max_seq_len * 50)
         gpu_type = os.environ.get("CANARY_GPU_TYPE", "H100")
         gpu_count = _env_int("CANARY_GPU_COUNT", 8)
@@ -116,7 +116,6 @@ def _build_step_from_env() -> ExecutorStep:
                 tokenize_step.config,
                 # SlimPajama-6B tokenization OOMs at the default 10g worker_resources.
                 worker_resources=ResourceConfig(ram="64g", disk="64g"),
-                cache_copy_max_workers=cache_copy_max_workers,
             ),
         )
         data = lm_data_config(

--- a/experiments/pretraining_datasets/nemotron.py
+++ b/experiments/pretraining_datasets/nemotron.py
@@ -70,7 +70,6 @@ def tokenize_nemotron(
     *,
     tokenizer: str | None = None,
     max_workers: int = 4096,
-    cache_copy_max_workers: int = 128,
 ) -> dict[str, TokenizerStep]:
     """Generate tokenization steps for all Nemotron CC dataset splits.
 
@@ -99,7 +98,6 @@ def tokenize_nemotron(
                 cache_path=this_output_path(),
                 tokenizer=versioned(tokenizer),
                 max_workers=max_workers,
-                cache_copy_max_workers=cache_copy_max_workers,
             ),
         )
 

--- a/lib/levanter/src/levanter/data/text/cache.py
+++ b/lib/levanter/src/levanter/data/text/cache.py
@@ -60,4 +60,4 @@ def load_lm_dataset_cache(
 def cached_token_count(cache_path: str, field: str = "input_ids") -> int:
     """Return the total number of tokens stored in a finished TreeCache."""
     cache = TreeCache.load(cache_path, {field: np.zeros((0,), dtype=np.int32)})
-    return cache.store.tree[field].data_size
+    return cache.flat_field_length(field)

--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -929,6 +929,8 @@ def count_corpus_sizes(
         )
         train_seqs = len(train_set.as_sync_dataset())
         stats[f"{metric_prefix}total_seqs"] = train_seqs
+        if train_seqs == 0 or seq_len == 0:
+            continue
         padding_fraction = 1 - (total_tokens / (train_seqs * seq_len))
         if padding_fraction < 0:
             stats[f"{metric_prefix}truncation_fraction"] = -padding_fraction

--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import abc
-import asyncio
 import dataclasses
 import functools
 import logging
@@ -16,7 +15,6 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
-import tensorstore as ts
 from draccus import ChoiceRegistry, field
 from haliax import Axis
 from jaxtyping import PRNGKeyArray
@@ -47,8 +45,6 @@ from levanter.data.text.formats import (
 from levanter.models.lm_model import LmExample
 from levanter.schedule import BatchSchedule
 from levanter.store.cache import CacheOptions, TreeCache
-from levanter.store.jagged_array import JaggedArrayStore
-from levanter.store.tree_store import TreeStore
 from levanter.utils import fsspec_utils
 from levanter.tokenizers import MarinTokenizer, load_tokenizer as load_marin_tokenizer
 from levanter.utils.jax_utils import key_iterator
@@ -73,28 +69,9 @@ class TokenSeqDataset(AsyncDataset[np.ndarray]):
     def __init__(self, doc_cache: TreeCache[dict], seq_len: int):
         self.doc_cache = doc_cache
         self.seq_len = seq_len
-        self._store: TreeStore | None = None if doc_cache.is_sharded else doc_cache.store
-        self._shard_token_stores: dict[str, JaggedArrayStore] = {}
-        self._shard_token_counts: np.ndarray | None = None
-        self._shard_token_offsets: np.ndarray | None = None
 
     async def async_len(self) -> int:
-        token_count = self.doc_cache.ledger.field_counts.get("input_ids")
-        if token_count is not None:
-            return token_count // self.seq_len
-
-        if self.doc_cache.is_sharded:
-            if self.doc_cache.ledger.total_num_rows == 0:
-                return 0
-            raise ValueError("Sharded cache ledger missing aggregate input_ids count")
-
-        token_arrays = await self._await_token_cache()
-        return token_arrays.data_size // self.seq_len
-
-    async def _await_token_cache(self) -> JaggedArrayStore:
-        if self._store is None:
-            self._store = self.doc_cache.store
-        return self._store.tree["input_ids"]
+        return await self.doc_cache.async_flat_field_length("input_ids") // self.seq_len
 
     def is_finite(self) -> bool:
         return True
@@ -107,72 +84,8 @@ class TokenSeqDataset(AsyncDataset[np.ndarray]):
         if ds_len < max(indices) + 1:
             raise ValueError("Requested indices beyond the end of the dataset")
 
-        if self.doc_cache.is_sharded:
-            return await asyncio.gather(*[self._get_sharded_sequence(int(index) * self.seq_len) for index in indices])
-
-        token_arrays = await self._await_token_cache()
-        # logger.info(f"Time to get token cache: {time.time() - time_in}")
         offsets = np.array(indices, dtype=np.int64) * self.seq_len
-        with ts.Batch():
-            out = []
-            for offset in offsets:
-                out.append(token_arrays.data[offset : offset + self.seq_len].read())
-
-        out = await asyncio.gather(*out)
-        return out
-
-    def _ensure_shard_token_offsets(self) -> tuple[list[str], np.ndarray]:
-        if self._shard_token_offsets is not None:
-            return self.doc_cache.ledger.finished_shards, self._shard_token_offsets
-
-        shard_names = self.doc_cache.ledger.finished_shards
-        counts = []
-        for shard_name in shard_names:
-            try:
-                counts.append(self.doc_cache.ledger.field_counts_by_shard[shard_name]["input_ids"])
-            except KeyError as exc:
-                raise ValueError(f"Sharded cache ledger missing input_ids count for shard {shard_name}") from exc
-
-        self._shard_token_counts = np.array(counts, dtype=np.int64)
-        self._shard_token_offsets = np.cumsum(self._shard_token_counts)
-        return shard_names, self._shard_token_offsets
-
-    def _shard_token_store(self, shard_name: str) -> JaggedArrayStore:
-        store = self._shard_token_stores.get(shard_name)
-        if store is None:
-            tree_store = TreeStore.open(
-                {"input_ids": np.array([0], dtype=np.int32)},
-                self.doc_cache.shard_path(shard_name),
-                mode="r",
-                cache_metadata=True,
-            )
-            store = tree_store.tree["input_ids"]
-            self._shard_token_stores[shard_name] = store
-        return store
-
-    async def _get_sharded_sequence(self, offset: int) -> np.ndarray:
-        shard_names, shard_offsets = self._ensure_shard_token_offsets()
-        remaining = self.seq_len
-        position = offset
-        chunks = []
-
-        while remaining > 0:
-            shard_index = int(np.searchsorted(shard_offsets, position, side="right"))
-            if shard_index >= len(shard_names):
-                raise ValueError("Requested indices beyond the end of the dataset")
-
-            shard_start = int(shard_offsets[shard_index - 1]) if shard_index > 0 else 0
-            local_start = position - shard_start
-            available = int(shard_offsets[shard_index] - position)
-            take = min(remaining, available)
-            token_store = self._shard_token_store(shard_names[shard_index])
-            chunks.append(await token_store.data[local_start : local_start + take].read())
-            position += take
-            remaining -= take
-
-        if len(chunks) == 1:
-            return chunks[0]
-        return np.concatenate(chunks)
+        return await self.doc_cache.get_flat_field_batch("input_ids", offsets, self.seq_len)
 
 
 def _single_cpu_sharding() -> jax.sharding.SingleDeviceSharding:
@@ -987,7 +900,7 @@ def count_corpus_sizes(
     prefix: str = "data/stats/",
     seq_len: int = 4096,
 ) -> dict:
-    stats = {}
+    stats: dict[str, int | float] = {}
     train_caches = config.build_caches("train")
     Pos = Axis("position", seq_len)
 
@@ -1004,8 +917,9 @@ def count_corpus_sizes(
         metric_prefix = f"{prefix}train/{name}/"
         component = config.components[name]
         token_key = _get_token_key_for_component(component)
-        stats[f"{metric_prefix}total_tokens"] = cache.store.tree[token_key].data_size
-        stats[f"{metric_prefix}total_docs"] = cache.store.tree[token_key].num_rows
+        total_tokens = cache.flat_field_length(token_key)
+        stats[f"{metric_prefix}total_tokens"] = total_tokens
+        stats[f"{metric_prefix}total_docs"] = cache.flat_field_num_rows(token_key)
         train_set = dataset_for_component(
             component,
             Pos,
@@ -1015,7 +929,7 @@ def count_corpus_sizes(
         )
         train_seqs = len(train_set.as_sync_dataset())
         stats[f"{metric_prefix}total_seqs"] = train_seqs
-        padding_fraction = 1 - (cache.store.tree[token_key].data_size / (train_seqs * seq_len))
+        padding_fraction = 1 - (total_tokens / (train_seqs * seq_len))
         if padding_fraction < 0:
             stats[f"{metric_prefix}truncation_fraction"] = -padding_fraction
         else:
@@ -1031,8 +945,8 @@ def count_corpus_sizes(
         metric_prefix = f"{prefix}validation/{name}/"
         component = config.components[name]
         token_key = _get_token_key_for_component(component)
-        stats[f"{metric_prefix}total_tokens"] = cache.store.tree[token_key].data_size
-        stats[f"{metric_prefix}total_docs"] = cache.store.tree[token_key].num_rows
+        stats[f"{metric_prefix}total_tokens"] = cache.flat_field_length(token_key)
+        stats[f"{metric_prefix}total_docs"] = cache.flat_field_num_rows(token_key)
         validation_set = dataset_for_component(
             component,
             Pos,

--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -73,9 +73,16 @@ class TokenSeqDataset(AsyncDataset[np.ndarray]):
     def __init__(self, doc_cache: TreeCache[dict], seq_len: int):
         self.doc_cache = doc_cache
         self.seq_len = seq_len
-        self._store: TreeStore | None = doc_cache.store
+        self._store: TreeStore | None = None if doc_cache.is_sharded else doc_cache.store
+        self._shard_token_stores: dict[str, JaggedArrayStore] = {}
+        self._shard_token_counts: np.ndarray | None = None
+        self._shard_token_offsets: np.ndarray | None = None
 
     async def async_len(self) -> int:
+        token_count = self.doc_cache.ledger.field_counts.get("input_ids")
+        if token_count is not None:
+            return token_count // self.seq_len
+
         token_arrays = await self._await_token_cache()
         return token_arrays.data_size // self.seq_len
 
@@ -91,11 +98,15 @@ class TokenSeqDataset(AsyncDataset[np.ndarray]):
         if not indices:
             return []
 
-        token_arrays = await self._await_token_cache()
-        # logger.info(f"Time to get token cache: {time.time() - time_in}")
         ds_len = await self.async_len()
         if ds_len < max(indices) + 1:
             raise ValueError("Requested indices beyond the end of the dataset")
+
+        if self.doc_cache.is_sharded:
+            return await asyncio.gather(*[self._get_sharded_sequence(int(index) * self.seq_len) for index in indices])
+
+        token_arrays = await self._await_token_cache()
+        # logger.info(f"Time to get token cache: {time.time() - time_in}")
         offsets = np.array(indices, dtype=np.int64) * self.seq_len
         with ts.Batch():
             out = []
@@ -104,6 +115,59 @@ class TokenSeqDataset(AsyncDataset[np.ndarray]):
 
         out = await asyncio.gather(*out)
         return out
+
+    def _ensure_shard_token_offsets(self) -> tuple[list[str], np.ndarray]:
+        if self._shard_token_offsets is not None:
+            return self.doc_cache.ledger.finished_shards, self._shard_token_offsets
+
+        shard_names = self.doc_cache.ledger.finished_shards
+        counts = []
+        for shard_name in shard_names:
+            try:
+                counts.append(self.doc_cache.ledger.field_counts_by_shard[shard_name]["input_ids"])
+            except KeyError as exc:
+                raise ValueError(f"Sharded cache ledger missing input_ids count for shard {shard_name}") from exc
+
+        self._shard_token_counts = np.array(counts, dtype=np.int64)
+        self._shard_token_offsets = np.cumsum(self._shard_token_counts)
+        return shard_names, self._shard_token_offsets
+
+    def _shard_token_store(self, shard_name: str) -> JaggedArrayStore:
+        store = self._shard_token_stores.get(shard_name)
+        if store is None:
+            tree_store = TreeStore.open(
+                {"input_ids": np.array([0], dtype=np.int32)},
+                self.doc_cache.shard_path(shard_name),
+                mode="r",
+                cache_metadata=True,
+            )
+            store = tree_store.tree["input_ids"]
+            self._shard_token_stores[shard_name] = store
+        return store
+
+    async def _get_sharded_sequence(self, offset: int) -> np.ndarray:
+        shard_names, shard_offsets = self._ensure_shard_token_offsets()
+        remaining = self.seq_len
+        position = offset
+        chunks = []
+
+        while remaining > 0:
+            shard_index = int(np.searchsorted(shard_offsets, position, side="right"))
+            if shard_index >= len(shard_names):
+                raise ValueError("Requested indices beyond the end of the dataset")
+
+            shard_start = int(shard_offsets[shard_index - 1]) if shard_index > 0 else 0
+            local_start = position - shard_start
+            available = int(shard_offsets[shard_index] - position)
+            take = min(remaining, available)
+            token_store = self._shard_token_store(shard_names[shard_index])
+            chunks.append(await token_store.data[local_start : local_start + take].read())
+            position += take
+            remaining -= take
+
+        if len(chunks) == 1:
+            return chunks[0]
+        return np.concatenate(chunks)
 
 
 def _single_cpu_sharding() -> jax.sharding.SingleDeviceSharding:

--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -83,6 +83,11 @@ class TokenSeqDataset(AsyncDataset[np.ndarray]):
         if token_count is not None:
             return token_count // self.seq_len
 
+        if self.doc_cache.is_sharded:
+            if self.doc_cache.ledger.total_num_rows == 0:
+                return 0
+            raise ValueError("Sharded cache ledger missing aggregate input_ids count")
+
         token_arrays = await self._await_token_cache()
         return token_arrays.data_size // self.seq_len
 

--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -352,7 +352,7 @@ class PackedTokenDataset(MappedAsyncDataset[tuple[dict, dict], GrugLmExample]):
         block_cross_document_attention: bool = True,
     ):
         self.packed: GreedyPrepackedDataset[dict] = GreedyPrepackedDataset(
-            cache.store.tree,
+            cache.jagged_array_tree(),
             Pos.size,
             max_segments_per_example=max_segments_per_example,
             slice_strategy=slice_strategy,
@@ -395,7 +395,7 @@ class ChatDataset(MappedAsyncDataset[tuple[ProcessedChatDict, ProcessedChatDict]
         block_cross_document_attention: bool = True,
     ):
         self.packed: GreedyPrepackedDataset[ProcessedChatDict] = GreedyPrepackedDataset(
-            cache.store.tree,
+            cache.jagged_array_tree(),
             Pos.size,
             max_segments_per_example=max_segments_per_example,
             slice_strategy=slice_strategy,

--- a/lib/levanter/src/levanter/data/text/preference.py
+++ b/lib/levanter/src/levanter/data/text/preference.py
@@ -246,7 +246,7 @@ class PreferencePairDataset(
         mask_user_turns: bool = True,
     ):
         self.packed: GreedyPrepackedDataset[ProcessedPreferenceChatDict] = GreedyPrepackedDataset(
-            cache.store.tree,
+            cache.jagged_array_tree(),
             Pos.size,
             max_segments_per_example=max_segments_per_example,
             slice_strategy=slice_strategy,

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -196,9 +196,19 @@ class TreeCache(AsyncDataset[T_co]):
         offsets = self._flat_field_offsets.get(field)
         if offsets is not None:
             return offsets
+        return blocking_wait(self._ensure_flat_field_offsets_async(field))
 
-        pieces = [np.array([self.ledger.total_num_rows], dtype=np.int64)]
-        data_offset = 0
+    async def _ensure_flat_field_offsets_async(self, field: str) -> np.ndarray:
+        offsets = self._flat_field_offsets.get(field)
+        if offsets is not None:
+            return offsets
+
+        async def read_shard_offsets(shard_name: str, row_count: int):
+            field_store = await self._shard_field_store_async(shard_name, field)
+            return await field_store.offsets[1 : row_count + 1].read()
+
+        read_tasks = []
+        shard_row_counts = []
         for shard_name in self.ledger.finished_shards:
             row_count = self.ledger.shard_rows[shard_name]
             if row_count == 0:
@@ -207,8 +217,16 @@ class TreeCache(AsyncDataset[T_co]):
             if field not in self.ledger.field_counts_by_shard.get(shard_name, {}):
                 raise ValueError(f"Sharded cache ledger missing {field} count for shard {shard_name}")
 
-            field_store = self._shard_field_store(shard_name, field)
-            shard_offsets = np.asarray(field_store.offsets[1 : row_count + 1].read().result(), dtype=np.int64)
+            read_tasks.append(read_shard_offsets(shard_name, row_count))
+            shard_row_counts.append(row_count)
+
+        shard_offset_arrays = await asyncio.gather(*read_tasks)
+
+        pieces = [np.array([self.ledger.total_num_rows], dtype=np.int64)]
+        data_offset = 0
+        for shard_offsets, row_count in zip(shard_offset_arrays, shard_row_counts, strict=True):
+            shard_offsets = np.asarray(shard_offsets, dtype=np.int64)
+            assert len(shard_offsets) == row_count
             pieces.append(shard_offsets + data_offset)
             data_offset += int(shard_offsets[-1]) if len(shard_offsets) else 0
 
@@ -238,6 +256,20 @@ class TreeCache(AsyncDataset[T_co]):
         store = self._shard_field_stores.get(key)
         if store is None:
             tree_store = TreeStore.open(
+                _field_exemplar(self._exemplar, field),
+                self._shard_path(shard_name),
+                mode="r",
+                cache_metadata=True,
+            )
+            store = _tree_field(tree_store.tree, field)
+            self._shard_field_stores[key] = store
+        return store
+
+    async def _shard_field_store_async(self, shard_name: str, field: str):
+        key = (shard_name, field)
+        store = self._shard_field_stores.get(key)
+        if store is None:
+            tree_store = await TreeStore.open_async(
                 _field_exemplar(self._exemplar, field),
                 self._shard_path(shard_name),
                 mode="r",
@@ -648,7 +680,13 @@ class _ShardedJaggedArrayOffsets:
         self._field = field
 
     def __getitem__(self, item):
-        return _ArrayRead(lambda: self._cache._ensure_flat_field_offsets(self._field)[item])
+        async def read_offsets():
+            return (await self._cache._ensure_flat_field_offsets_async(self._field))[item]
+
+        return _ArrayRead(
+            lambda: self._cache._ensure_flat_field_offsets(self._field)[item],
+            read_offsets,
+        )
 
 
 class _ShardedJaggedArrayStore:

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -615,6 +615,17 @@ def _validate_sharded_ledger(ledger: CacheLedger) -> None:
         if shard_name not in seen_shards:
             raise ValueError(f"Sharded cache ledger has field counts for unknown shard {shard_name}")
 
+    field_counts: Dict[str, int] = {}
+    for shard_name in ledger.finished_shards:
+        for field, count in ledger.field_counts_by_shard.get(shard_name, {}).items():
+            field_counts[field] = field_counts.get(field, 0) + count
+
+    if field_counts != ledger.field_counts:
+        raise ValueError(
+            "Sharded cache ledger field count mismatch: "
+            f"sum(finished shard field counts)={field_counts}, field_counts={ledger.field_counts}"
+        )
+
 
 def _tree_field(tree, field: str):
     value = tree

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -2,8 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import copy
 import dataclasses
+import gc
 import logging as pylogging
+import operator
 import os
 import threading
 import time
@@ -21,6 +24,7 @@ import tensorstore as ts
 from dataclasses_json import dataclass_json
 from fray import ResourceConfig
 from fsspec import AbstractFileSystem
+from jaxtyping import PyTree
 from tqdm_loggable.tqdm_logging import tqdm_logging
 from zephyr import Dataset, ZephyrContext
 from zephyr import counters as zephyr_counters
@@ -32,7 +36,7 @@ from levanter.utils.thread_utils import blocking_wait
 
 from ..data._preprocessor import BatchProcessor, BatchResult, dict_from_record_batch
 from ..data.sharded_datasource import ShardedDataSource
-from .jagged_array import _no_cache_read_context
+from .jagged_array import JaggedArrayStore, _no_cache_read_context
 from .tree_store import TreeStore
 
 T = TypeVar("T")
@@ -827,15 +831,117 @@ def consolidate_shard_caches(
     output_path: str,
     exemplar,
     metadata: CacheMetadata | None = None,
+    copy_max_workers: int = 128,
 ) -> CacheLedger:
     """
-    Consolidate multiple shard cache ledgers into a single sharded cache ledger.
+    Consolidate multiple shard caches into a single materialized cache directory.
 
     Args:
         shard_cache_paths: List of shard cache directories.
         output_path: Destination cache directory.
         exemplar: Output exemplar structure.
         metadata: CacheMetadata to use for the final ledger.
+        copy_max_workers: Maximum Zephyr fanout for the cache copy phase.
+    """
+    if metadata is None:
+        metadata = CacheMetadata.empty()
+    if copy_max_workers < 1:
+        raise ValueError(f"copy_max_workers must be positive, got {copy_max_workers}")
+
+    if not shard_cache_paths:
+        TreeStore.open(exemplar, output_path, mode="w", cache_metadata=True)
+        ledger = CacheLedger(
+            total_num_rows=0,
+            shard_rows={},
+            is_finished=True,
+            finished_shards=[],
+            field_counts={},
+            metadata=metadata,
+        )
+        ledger._serialize_and_commit(output_path)
+        return ledger
+
+    logger.info(f"Consolidating {len(shard_cache_paths)} shard caches into {output_path}")
+
+    with _no_cache_read_context():
+        first_cache = TreeStore.open(exemplar, shard_cache_paths[0], mode="r", cache_metadata=True)
+        data_offset_tree = jax.tree.map(lambda x: 0, first_cache.tree)
+
+    shard_info: list[dict] = []
+    total_rows = 0
+
+    def _probe_shard(shard_path):
+        ledger = CacheLedger.load(shard_path, metadata)
+        with _no_cache_read_context():
+            store = TreeStore.open(exemplar, shard_path, mode="r", cache_metadata=True)
+            data_sizes = jax.tree.map(lambda x: x.data_size, store.tree)
+        return (data_sizes, ledger)
+
+    probe_ctx = ZephyrContext(
+        resources=ResourceConfig(ram="5g", cpu=2),
+        max_workers=min(CONSOLIDATE_DATA_SIZE_WORKERS, len(shard_cache_paths)),
+        name="levanter-cache-probe",
+    )
+    probe_results = probe_ctx.execute(
+        Dataset.from_list(shard_cache_paths).map(_probe_shard),
+    ).results
+    per_shard_sizes = [r[0] for r in probe_results]
+    shard_ledgers = [r[1] for r in probe_results]
+    per_shard_field_counts = [_field_counts_from_data_sizes(data_sizes) for data_sizes in per_shard_sizes]
+
+    for shard_path, ledger, this_offsets in zip(shard_cache_paths, shard_ledgers, per_shard_sizes, strict=True):
+        shard_name = os.path.basename(shard_path)
+        shard_info.append(
+            {
+                "path": shard_path,
+                "shard_name": shard_name,
+                "row_offset": total_rows,
+                "data_offset_tree": copy.deepcopy(data_offset_tree),
+                "ledger": ledger,
+            }
+        )
+        total_rows += ledger.total_num_rows
+        data_offset_tree = jax.tree.map(operator.add, data_offset_tree, this_offsets)
+
+    TreeStore.open(exemplar, output_path, mode="w", cache_metadata=True)
+
+    def _copy_shard(info: dict):
+        asyncio.run(
+            _extend_cache_with_other_cache(
+                output_path, info["path"], exemplar, info["data_offset_tree"], info["row_offset"]
+            )
+        )
+
+    ctx = ZephyrContext(
+        resources=ResourceConfig(ram="10g", disk="16g"),
+        max_workers=min(copy_max_workers, len(shard_info)),
+        name="levanter-cache-copy",
+    )
+    ctx.execute(
+        Dataset.from_list(shard_info).map(_copy_shard),
+        verbose=False,
+    )
+
+    asyncio.run(_consolidate_metadata(output_path, exemplar, shard_info))
+
+    final_ledger = _merge_materialized_ledgers(
+        output_path, shard_cache_paths, shard_ledgers, per_shard_field_counts, metadata
+    )
+    _expose_cache_rows(output_path, exemplar, final_ledger.total_num_rows)
+    return final_ledger
+
+
+def consolidate_shard_cache_ledgers(
+    shard_cache_paths: list[str],
+    output_path: str,
+    exemplar,
+    metadata: CacheMetadata | None = None,
+) -> CacheLedger:
+    """
+    Consolidate multiple shard cache ledgers into one sharded cache ledger.
+
+    The output points at the original shard directories instead of copying their
+    arrays into a top-level TreeStore.
     """
     if metadata is None:
         metadata = CacheMetadata.empty()
@@ -880,10 +986,37 @@ def consolidate_shard_caches(
     per_shard_field_counts = [r[0] for r in probe_results]
     shard_ledgers = [r[1] for r in probe_results]
 
-    return _merge_ledgers(output_path, shard_cache_paths, shard_ledgers, per_shard_field_counts, metadata)
+    return _merge_sharded_ledgers(output_path, shard_cache_paths, shard_ledgers, per_shard_field_counts, metadata)
 
 
-def _merge_ledgers(
+def _merge_materialized_ledgers(
+    output_path: str,
+    shard_cache_paths: list[str],
+    shard_ledgers: list[CacheLedger],
+    per_shard_field_counts: list[dict[str, int]],
+    metadata: CacheMetadata,
+) -> CacheLedger:
+    final_ledger = CacheLedger(
+        total_num_rows=0,
+        shard_rows={},
+        finished_shards=[],
+        field_counts={},
+        metadata=metadata,
+    )
+    for shard_path, ledger, field_counts in zip(shard_cache_paths, shard_ledgers, per_shard_field_counts, strict=True):
+        shard_name = os.path.basename(shard_path)
+        final_ledger.shard_rows[shard_name] = ledger.total_num_rows
+        final_ledger.finished_shards.append(shard_name)
+        final_ledger.total_num_rows += ledger.total_num_rows
+        for field, count in field_counts.items():
+            final_ledger.field_counts[field] = final_ledger.field_counts.get(field, 0) + count
+
+    final_ledger.is_finished = True
+    final_ledger._serialize_and_commit(output_path)
+    return final_ledger
+
+
+def _merge_sharded_ledgers(
     output_path: str,
     shard_cache_paths: list[str],
     shard_ledgers: list[CacheLedger],
@@ -972,6 +1105,100 @@ def _expose_cache_rows(cache_path: str, exemplar: T, num_rows: int) -> None:
         future.result()
 
 
+async def _extend_cache_with_other_cache(
+    dest_path: str, source_path: str, exemplar: dict, data_offset_tree: PyTree[int], row_offset
+) -> int:
+    try:
+        logger.info(f"Copying data from {source_path} to {dest_path}.")
+        with _no_cache_read_context():
+            dest = TreeStore.open(exemplar, dest_path, mode="a", cache_metadata=False)
+            source = TreeStore.open(exemplar, source_path, mode="r", cache_metadata=True)
+
+            source_num_rows = await source.async_len()
+
+            async def _copy_one_array(dest_array: JaggedArrayStore, source_array: JaggedArrayStore, data_offset: int):
+                data_size = source_array.data_size
+                data = source_array.data
+                max_elems = 64 * 1024 * 1024
+                await _copy_in_batches(dest_array.data, data_offset, data, data_size, max_elems)
+
+            futures = jax.tree.map(_copy_one_array, dest.tree, source.tree, data_offset_tree)
+            await asyncio.gather(*jax.tree.leaves(futures))
+            del dest, source
+        gc.collect()
+        logger.info(f"Finished copying data from {source_path} to {dest_path}.")
+        return source_num_rows
+    except Exception as e:  # noqa: BLE001
+        logger.exception(f"Failed to copy data from {source_path} to {dest_path}: {e}")
+        raise
+
+
+async def _copy_in_batches(dest_array, dest_offset, src_array, src_len, elems_per_batch):
+    start = 0
+    out_start = dest_offset
+    while start < src_len:
+        num_to_copy = min(elems_per_batch, src_len - start)
+        end = start + num_to_copy
+        out_end = out_start + num_to_copy
+
+        chunk = await src_array[start:end].read()
+        await dest_array[out_start:out_end].write(chunk)
+        del chunk
+
+        start += num_to_copy
+        out_start += num_to_copy
+
+
+async def _consolidate_metadata(dest_path: str, exemplar: dict, shard_infos: list[dict]) -> None:
+    dest = TreeStore.open(exemplar, dest_path, mode="a")
+    start = time.monotonic()
+
+    delay = 4
+    while True:
+        write_futures = []
+        try:
+            async with ts.Transaction() as txn:
+                for info in shard_infos:
+                    with _no_cache_read_context():
+                        source = TreeStore.open(exemplar, info["path"], mode="r", cache_metadata=True)
+                    source_num_rows = info["ledger"].total_num_rows
+                    row_offset = info["row_offset"]
+
+                    for dest_array, source_array, data_offset in zip(
+                        jax.tree.leaves(dest.tree),
+                        jax.tree.leaves(source.tree),
+                        jax.tree.leaves(info["data_offset_tree"]),
+                        strict=True,
+                    ):
+                        if source_array.shapes is not None:
+                            assert dest_array.shapes is not None
+                            source_shapes = await source_array.shapes[:source_num_rows].read()
+                            out_end = row_offset + source_num_rows
+                            write_futures.append(
+                                dest_array.shapes.with_transaction(txn)[row_offset:out_end].write(source_shapes)
+                            )
+
+                        source_offsets = await source_array.offsets[1 : source_num_rows + 1].read()
+                        source_offsets = np.asarray(source_offsets) + data_offset
+                        out_end = 1 + row_offset + source_num_rows
+                        write_futures.append(
+                            dest_array.offsets.with_transaction(txn)[row_offset + 1 : out_end].write(source_offsets)
+                        )
+
+            await asyncio.gather(*write_futures)
+            elapsed = time.monotonic() - start
+            logger.info(f"Metadata consolidation complete: {len(shard_infos)} shards in {elapsed:.1f}s")
+            break
+        except ValueError as e:
+            if "Please reduce your request rate." not in str(e):
+                raise
+            logger.info(f"Rate limit exceeded during metadata consolidation. Retrying in {delay}s.")
+            await asyncio.sleep(delay)
+            delay *= 2
+            if delay > 120:
+                raise
+
+
 def _relative_shard_path(output_path: str, shard_path: str) -> str:
     if "://" in shard_path:
         prefix = output_path.rstrip("/") + "/"
@@ -1049,6 +1276,7 @@ __all__ = [
     "CacheLedger",
     "CacheMetadata",
     "CacheOptions",
+    "consolidate_shard_cache_ledgers",
     "consolidate_shard_caches",
     "write_levanter_cache",
 ]

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -12,7 +12,7 @@ import threading
 import time
 from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Protocol, Sequence, TypeVar, Union, cast
+from typing import Any, Dict, List, Optional, Protocol, Sequence, Tuple, TypeVar, Union, cast
 
 import deepdiff
 import jax
@@ -100,11 +100,11 @@ class TreeCache(AsyncDataset[T_co]):
         self.cache_dir = cache_dir
         self.ledger = ledger
         self._exemplar = exemplar
-        self._shard_stores: dict[str, TreeStore[T_co]] = {}
-        self._shard_row_offsets: np.ndarray | None = None
-        self._shard_field_stores: dict[tuple[str, str], Any] = {}
-        self._shard_field_offsets: dict[str, np.ndarray] = {}
-        self._flat_field_offsets: dict[str, np.ndarray] = {}
+        self._shard_stores: Dict[str, TreeStore[T_co]] = {}
+        self._shard_row_offsets: Optional[np.ndarray] = None
+        self._shard_field_stores: Dict[Tuple[str, str], Any] = {}
+        self._shard_field_offsets: Dict[str, np.ndarray] = {}
+        self._flat_field_offsets: Dict[str, np.ndarray] = {}
 
         if not ledger.is_finished:
             raise RuntimeError(f"Cache at {cache_dir} is not finished.")
@@ -165,7 +165,7 @@ class TreeCache(AsyncDataset[T_co]):
     async def get_flat_field_batch(self, field: str, offsets: Sequence[int], length: int) -> Sequence[np.ndarray]:
         return await self._reader.get_flat_field_batch(field, offsets, length)
 
-    def _ensure_shard_row_offsets(self) -> tuple[list[str], np.ndarray]:
+    def _ensure_shard_row_offsets(self) -> Tuple[List[str], np.ndarray]:
         if self._shard_row_offsets is not None:
             return self.ledger.finished_shards, self._shard_row_offsets
 
@@ -173,7 +173,7 @@ class TreeCache(AsyncDataset[T_co]):
         self._shard_row_offsets = np.cumsum(np.array(counts, dtype=np.int64))
         return self.ledger.finished_shards, self._shard_row_offsets
 
-    def _ensure_shard_field_offsets(self, field: str) -> tuple[list[str], np.ndarray]:
+    def _ensure_shard_field_offsets(self, field: str) -> Tuple[List[str], np.ndarray]:
         offsets = self._shard_field_offsets.get(field)
         if offsets is not None:
             return self.ledger.finished_shards, offsets
@@ -247,12 +247,12 @@ class TreeCache(AsyncDataset[T_co]):
             self._shard_field_stores[key] = store
         return store
 
-    async def _get_sharded_batch(self, indices: Sequence[int]) -> list[T_co]:
+    async def _get_sharded_batch(self, indices: Sequence[int]) -> List[T_co]:
         if len(indices) == 0:
             return []
 
         shard_names, shard_offsets = self._ensure_shard_row_offsets()
-        shard_batches: dict[int, list[tuple[int, int]]] = {}
+        shard_batches: Dict[int, List[Tuple[int, int]]] = {}
         for output_index, index in enumerate(indices):
             index = int(index)
             if index < 0 or index >= self.ledger.total_num_rows:
@@ -262,9 +262,9 @@ class TreeCache(AsyncDataset[T_co]):
             shard_start = int(shard_offsets[shard_index - 1]) if shard_index > 0 else 0
             shard_batches.setdefault(shard_index, []).append((output_index, index - shard_start))
 
-        output: list[T_co | None] = [None] * len(indices)
+        output: List[Optional[T_co]] = [None] * len(indices)
 
-        async def read_shard(shard_index: int, batch: list[tuple[int, int]]) -> None:
+        async def read_shard(shard_index: int, batch: List[Tuple[int, int]]) -> None:
             local_indices = [local_index for _, local_index in batch]
             shard_batch = await self._shard_store(shard_names[shard_index]).get_batch(local_indices)
             for (output_index, _), row in zip(batch, shard_batch, strict=True):
@@ -277,12 +277,12 @@ class TreeCache(AsyncDataset[T_co]):
             rows.append(row)
         return rows
 
-    def _get_sharded_batch_sync(self, indices: Sequence[int]) -> list[T_co]:
+    def _get_sharded_batch_sync(self, indices: Sequence[int]) -> List[T_co]:
         if len(indices) == 0:
             return []
 
         shard_names, shard_offsets = self._ensure_shard_row_offsets()
-        shard_batches: dict[int, list[tuple[int, int]]] = {}
+        shard_batches: Dict[int, List[Tuple[int, int]]] = {}
         for output_index, index in enumerate(indices):
             index = int(index)
             if index < 0 or index >= self.ledger.total_num_rows:
@@ -292,7 +292,7 @@ class TreeCache(AsyncDataset[T_co]):
             shard_start = int(shard_offsets[shard_index - 1]) if shard_index > 0 else 0
             shard_batches.setdefault(shard_index, []).append((output_index, index - shard_start))
 
-        output: list[T_co | None] = [None] * len(indices)
+        output: List[Optional[T_co]] = [None] * len(indices)
         for shard_index, batch in shard_batches.items():
             local_indices = [local_index for _, local_index in batch]
             shard_batch = self._shard_store(shard_names[shard_index]).get_batch_sync(local_indices)
@@ -365,11 +365,11 @@ class _TreeCacheReader(Protocol[T_co]):
 
     def __len__(self) -> int: ...
 
-    def __getitem__(self, item) -> T_co | Sequence[T_co]: ...
+    def __getitem__(self, item) -> Union[T_co, Sequence[T_co]]: ...
 
     def __iter__(self) -> Iterator[T_co]: ...
 
-    async def get_batch(self, indices: Sequence[int] | slice) -> Sequence[T_co]: ...
+    async def get_batch(self, indices: Union[Sequence[int], slice]) -> Sequence[T_co]: ...
 
     def get_batch_sync(self, indices_or_slice, *, timeout: Optional[float] = None) -> Sequence[T_co]: ...
 
@@ -398,14 +398,14 @@ class _MaterializedTreeCacheReader:
     def __len__(self) -> int:
         return len(self._store)
 
-    def __getitem__(self, item) -> T_co | Sequence[T_co]:
+    def __getitem__(self, item) -> Union[T_co, Sequence[T_co]]:
         return self._store[item]
 
     def __iter__(self) -> Iterator[T_co]:
         for row in self._store:
             yield cast(T_co, row)
 
-    async def get_batch(self, indices: Sequence[int] | slice) -> Sequence[T_co]:
+    async def get_batch(self, indices: Union[Sequence[int], slice]) -> Sequence[T_co]:
         if isinstance(indices, slice):
             start, stop, step = indices.indices(len(self))
             indices = range(start, stop, step)
@@ -453,7 +453,7 @@ class _ShardedTreeCacheReader:
     def __len__(self) -> int:
         return self._cache.ledger.total_num_rows
 
-    def __getitem__(self, item) -> T_co | Sequence[T_co]:
+    def __getitem__(self, item) -> Union[T_co, Sequence[T_co]]:
         if isinstance(item, slice):
             start, stop, step = item.indices(len(self))
             return self.get_batch_sync(range(start, stop, step))
@@ -463,7 +463,7 @@ class _ShardedTreeCacheReader:
         for index in range(len(self)):
             yield cast(T_co, self.get_batch_sync([index])[0])
 
-    async def get_batch(self, indices: Sequence[int] | slice) -> Sequence[T_co]:
+    async def get_batch(self, indices: Union[Sequence[int], slice]) -> Sequence[T_co]:
         if isinstance(indices, slice):
             start, stop, step = indices.indices(len(self))
             indices = range(start, stop, step)
@@ -1024,10 +1024,10 @@ def consolidate_shard_caches(
 
 
 def consolidate_shard_cache_ledgers(
-    shard_cache_paths: list[str],
+    shard_cache_paths: List[str],
     output_path: str,
     exemplar,
-    metadata: CacheMetadata | None = None,
+    metadata: Optional[CacheMetadata] = None,
 ) -> CacheLedger:
     """
     Consolidate multiple shard cache ledgers into one sharded cache ledger.
@@ -1083,9 +1083,9 @@ def consolidate_shard_cache_ledgers(
 
 def _merge_materialized_ledgers(
     output_path: str,
-    shard_cache_paths: list[str],
-    shard_ledgers: list[CacheLedger],
-    per_shard_field_counts: list[dict[str, int]],
+    shard_cache_paths: List[str],
+    shard_ledgers: List[CacheLedger],
+    per_shard_field_counts: List[Dict[str, int]],
     metadata: CacheMetadata,
 ) -> CacheLedger:
     final_ledger = CacheLedger(
@@ -1110,9 +1110,9 @@ def _merge_materialized_ledgers(
 
 def _merge_sharded_ledgers(
     output_path: str,
-    shard_cache_paths: list[str],
-    shard_ledgers: list[CacheLedger],
-    per_shard_field_counts: list[dict[str, int]],
+    shard_cache_paths: List[str],
+    shard_ledgers: List[CacheLedger],
+    per_shard_field_counts: List[Dict[str, int]],
     metadata: CacheMetadata,
 ) -> CacheLedger:
     final_ledger = CacheLedger(
@@ -1306,12 +1306,12 @@ def _relative_shard_path(output_path: str, shard_path: str) -> str:
     return relative_path
 
 
-def _field_counts_from_store(store: TreeStore) -> dict[str, int]:
+def _field_counts_from_store(store: TreeStore) -> Dict[str, int]:
     return _field_counts_from_data_sizes(jax.tree.map(lambda array: array.data_size, store.tree))
 
 
-def _field_counts_from_data_sizes(data_sizes) -> dict[str, int]:
-    counts: dict[str, int] = {}
+def _field_counts_from_data_sizes(data_sizes) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
     for path, value in jtu.tree_leaves_with_path(data_sizes):
         field = "/".join(_render_path_elem(part) for part in path)
         counts[field] = int(value)

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import concurrent.futures
 import copy
 import dataclasses
 import gc
@@ -105,6 +106,8 @@ class TreeCache(AsyncDataset[T_co]):
         self._shard_field_stores: Dict[Tuple[str, str], Any] = {}
         self._shard_field_offsets: Dict[str, np.ndarray] = {}
         self._flat_field_offsets: Dict[str, np.ndarray] = {}
+        self._flat_field_offset_futures: Dict[str, concurrent.futures.Future[np.ndarray]] = {}
+        self._flat_field_offsets_lock = threading.Lock()
 
         if not ledger.is_finished:
             raise RuntimeError(f"Cache at {cache_dir} is not finished.")
@@ -191,16 +194,40 @@ class TreeCache(AsyncDataset[T_co]):
         return self.ledger.finished_shards, offsets
 
     def _ensure_flat_field_offsets(self, field: str) -> np.ndarray:
-        offsets = self._flat_field_offsets.get(field)
-        if offsets is not None:
-            return offsets
         return blocking_wait(self._ensure_flat_field_offsets_async(field))
 
     async def _ensure_flat_field_offsets_async(self, field: str) -> np.ndarray:
-        offsets = self._flat_field_offsets.get(field)
-        if offsets is not None:
-            return offsets
+        with self._flat_field_offsets_lock:
+            offsets = self._flat_field_offsets.get(field)
+            if offsets is not None:
+                return offsets
 
+            future = self._flat_field_offset_futures.get(field)
+            if future is None:
+                future = concurrent.futures.Future()
+                self._flat_field_offset_futures[field] = future
+                should_build = True
+            else:
+                should_build = False
+
+        if not should_build:
+            return await asyncio.shield(asyncio.wrap_future(future))
+
+        try:
+            offsets = await self._build_flat_field_offsets_async(field)
+        except BaseException as exc:
+            with self._flat_field_offsets_lock:
+                self._flat_field_offset_futures.pop(field, None)
+            future.set_exception(exc)
+            raise
+
+        with self._flat_field_offsets_lock:
+            self._flat_field_offsets[field] = offsets
+            self._flat_field_offset_futures.pop(field, None)
+        future.set_result(offsets)
+        return offsets
+
+    async def _build_flat_field_offsets_async(self, field: str) -> np.ndarray:
         async def read_shard_offsets(shard_name: str, row_count: int):
             field_store = await self._shard_field_store_async(shard_name, field)
             return await field_store.offsets[1 : row_count + 1].read()

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -1,12 +1,8 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import asyncio
-import copy
 import dataclasses
-import gc
 import logging as pylogging
-import operator
 import os
 import threading
 import time
@@ -16,14 +12,13 @@ from typing import Any, Dict, List, Optional, Sequence, TypeVar, Union
 
 import deepdiff
 import jax
+import jax.tree_util as jtu
 from rigging.filesystem import open_url, url_to_fs
 import numpy as np
 import pyarrow as pa
-import tensorstore as ts
 from dataclasses_json import dataclass_json
 from fray import ResourceConfig
 from fsspec import AbstractFileSystem
-from jaxtyping import PyTree
 from tqdm_loggable.tqdm_logging import tqdm_logging
 from zephyr import Dataset, ZephyrContext
 from zephyr import counters as zephyr_counters
@@ -34,9 +29,7 @@ from levanter.utils.jax_utils import broadcast_one_to_all
 
 from ..data._preprocessor import BatchProcessor, BatchResult, dict_from_record_batch
 from ..data.sharded_datasource import ShardedDataSource
-from ..utils.fsspec_utils import exists as fsspec_exists
-from ..utils.fsspec_utils import remove as fsspec_remove
-from .jagged_array import JaggedArrayStore, _no_cache_read_context
+from .jagged_array import _no_cache_read_context
 from .tree_store import TreeStore
 
 T = TypeVar("T")
@@ -47,6 +40,8 @@ logger = pylogging.getLogger(__name__)
 
 LEDGER_FILE_NAME = "shard_ledger.json"
 CONSOLIDATE_DATA_SIZE_WORKERS = 32
+CACHE_LAYOUT_CONSOLIDATED = "consolidated"
+CACHE_LAYOUT_SHARDED = "sharded"
 
 DEFAULT_LOG_LEVEL = pylogging.INFO
 LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
@@ -102,16 +97,33 @@ class TreeCache(AsyncDataset[T_co]):
         if not ledger.is_finished:
             raise RuntimeError(f"Cache at {cache_dir} is not finished.")
 
-        self._store = TreeStore.open(self._exemplar, self.cache_dir, mode="r", cache_metadata=False)
+        self._store = None
+        if not self.is_sharded:
+            self._store = TreeStore.open(self._exemplar, self.cache_dir, mode="r", cache_metadata=False)
 
     @property
     def store(self) -> TreeStore[T_co]:
+        if self._store is None:
+            raise RuntimeError(f"Cache at {self.cache_dir} is sharded and has no top-level TreeStore.")
         return self._store
 
+    @property
+    def is_sharded(self) -> bool:
+        return self.ledger.layout == CACHE_LAYOUT_SHARDED
+
+    def shard_path(self, shard_name: str) -> str:
+        if "://" in shard_name:
+            return shard_name
+        return os.path.join(self.cache_dir, shard_name)
+
     async def async_len(self) -> int:
+        if self.is_sharded:
+            return self.ledger.total_num_rows
         return len(self.store)
 
     def __len__(self):
+        if self.is_sharded:
+            return self.ledger.total_num_rows
         return len(self.store)
 
     def is_finite(self) -> bool:
@@ -167,6 +179,8 @@ class CacheLedger:
     is_finished: bool = False
     finished_shards: List[str] = dataclasses.field(default_factory=list)
     field_counts: Dict[str, int] = dataclasses.field(default_factory=dict)
+    field_counts_by_shard: Dict[str, Dict[str, int]] = dataclasses.field(default_factory=dict)
+    layout: str = CACHE_LAYOUT_CONSOLIDATED
     metadata: "CacheMetadata" = dataclasses.field(default_factory=lambda: CacheMetadata({}))
 
     @staticmethod
@@ -248,7 +262,7 @@ class SerialCacheWriter:
             is_finished=True,
             shard_rows={self._shard_name: len(self._tree_store)},
             finished_shards=[self._shard_name],
-            field_counts={},
+            field_counts=_field_counts_from_store(self._tree_store),
             metadata=self.metadata or CacheMetadata.empty(),
         )
 
@@ -370,7 +384,7 @@ def build_cache(
         ledger._serialize_and_commit(cache_dir)
         return ledger
 
-    temp_root = os.path.join(cache_dir, "__shards__")
+    temp_root = cache_dir
     shard_jobs = [{"shard_name": name, "index": idx} for idx, name in enumerate(shard_names)]
 
     def process_shard(job: dict):
@@ -399,7 +413,6 @@ def build_cache(
         exemplar=processor.output_exemplar,
         metadata=metadata,
     )
-    _safe_remove(temp_root)
     return ledger
 
 
@@ -458,22 +471,18 @@ def consolidate_shard_caches(
     output_path: str,
     exemplar,
     metadata: CacheMetadata | None = None,
-    copy_max_workers: int = 128,
 ) -> CacheLedger:
     """
-    Consolidate multiple shard caches into a single cache directory.
+    Consolidate multiple shard cache ledgers into a single sharded cache ledger.
 
     Args:
         shard_cache_paths: List of shard cache directories.
         output_path: Destination cache directory.
         exemplar: Output exemplar structure.
         metadata: CacheMetadata to use for the final ledger.
-        copy_max_workers: Maximum Zephyr fanout for the cache copy phase.
     """
     if metadata is None:
         metadata = CacheMetadata.empty()
-    if copy_max_workers < 1:
-        raise ValueError(f"copy_max_workers must be positive, got {copy_max_workers}")
 
     if not shard_cache_paths:
         ledger = CacheLedger(
@@ -482,28 +491,27 @@ def consolidate_shard_caches(
             is_finished=True,
             finished_shards=[],
             field_counts={},
+            field_counts_by_shard={},
+            layout=CACHE_LAYOUT_SHARDED,
             metadata=metadata,
         )
         ledger._serialize_and_commit(output_path)
         return ledger
 
-    logger.info(f"Consolidating {len(shard_cache_paths)} shard caches into {output_path}")
-
-    with _no_cache_read_context():
-        first_cache = TreeStore.open(exemplar, shard_cache_paths[0], mode="r", cache_metadata=True)
-        data_offset_tree = jax.tree.map(lambda x: 0, first_cache.tree)
-
-    shard_info: list[dict] = []
-    total_rows = 0
+    logger.info(f"Consolidating {len(shard_cache_paths)} shard cache ledgers into {output_path}")
 
     # Distributed: load ledger + read data_size for each shard in parallel.
     # Both operations are S3 I/O-bound; distributing across zephyr workers
     # avoids serializing thousands of S3 calls in the coordinator process.
     def _probe_shard(shard_path):
         ledger = CacheLedger.load(shard_path, metadata)
-        store = TreeStore.open(exemplar, shard_path, mode="r", cache_metadata=True)
-        data_sizes = jax.tree.map(lambda x: x.data_size, store.tree)
-        return (data_sizes, ledger)
+        if ledger.field_counts:
+            field_counts = ledger.field_counts
+        else:
+            with _no_cache_read_context():
+                store = TreeStore.open(exemplar, shard_path, mode="r", cache_metadata=True)
+                field_counts = _field_counts_from_store(store)
+        return (field_counts, ledger)
 
     probe_ctx = ZephyrContext(
         resources=ResourceConfig(ram="5g", cpu=2),
@@ -513,68 +521,35 @@ def consolidate_shard_caches(
     probe_results = probe_ctx.execute(
         Dataset.from_list(shard_cache_paths).map(_probe_shard),
     ).results
-    per_shard_sizes = [r[0] for r in probe_results]
+    per_shard_field_counts = [r[0] for r in probe_results]
     shard_ledgers = [r[1] for r in probe_results]
 
-    # Serial: accumulate row_offset and data_offset_tree (order-dependent)
-    for shard_path, ledger, this_offsets in zip(shard_cache_paths, shard_ledgers, per_shard_sizes):
-        shard_name = os.path.basename(shard_path)
-        shard_info.append(
-            {
-                "path": shard_path,
-                "shard_name": shard_name,
-                "row_offset": total_rows,
-                "data_offset_tree": copy.deepcopy(data_offset_tree),
-                "ledger": ledger,
-            }
-        )
-        total_rows += ledger.total_num_rows
-        data_offset_tree = jax.tree.map(operator.add, data_offset_tree, this_offsets)
-
-    TreeStore.open(exemplar, output_path, mode="w", cache_metadata=True)
-
-    def _copy_shard(info: dict):
-        asyncio.run(
-            _extend_cache_with_other_cache(
-                output_path, info["path"], exemplar, info["data_offset_tree"], info["row_offset"]
-            )
-        )
-
-    ctx = ZephyrContext(
-        resources=ResourceConfig(ram="10g", disk="16g"),
-        max_workers=min(copy_max_workers, len(shard_info)),
-        name="levanter-cache-copy",
-    )
-    ctx.execute(
-        Dataset.from_list(shard_info).map(_copy_shard),
-        verbose=False,
-    )
-
-    # Single shared transaction to coalesce metadata writes (see #4100, tensorstore#202)
-    asyncio.run(_consolidate_metadata(output_path, exemplar, shard_info))
-
-    final_ledger = _merge_ledgers(output_path, shard_cache_paths, shard_ledgers, metadata)
-    # as a final step, set the total num rows in the final cache
-    _expose_cache_rows(output_path, exemplar, final_ledger.total_num_rows)
-    return final_ledger
+    return _merge_ledgers(output_path, shard_cache_paths, shard_ledgers, per_shard_field_counts, metadata)
 
 
 def _merge_ledgers(
-    output_path: str, shard_cache_paths: list[str], shard_ledgers: list[CacheLedger], metadata: CacheMetadata
+    output_path: str,
+    shard_cache_paths: list[str],
+    shard_ledgers: list[CacheLedger],
+    per_shard_field_counts: list[dict[str, int]],
+    metadata: CacheMetadata,
 ) -> CacheLedger:
     final_ledger = CacheLedger(
         total_num_rows=0,
         shard_rows={},
         finished_shards=[],
         field_counts={},
+        field_counts_by_shard={},
+        layout=CACHE_LAYOUT_SHARDED,
         metadata=metadata,
     )
-    for shard_path, ledger in zip(shard_cache_paths, shard_ledgers):
-        shard_name = os.path.basename(shard_path)
+    for shard_path, ledger, field_counts in zip(shard_cache_paths, shard_ledgers, per_shard_field_counts, strict=True):
+        shard_name = _relative_shard_path(output_path, shard_path)
         final_ledger.shard_rows[shard_name] = ledger.total_num_rows
         final_ledger.finished_shards.append(shard_name)
         final_ledger.total_num_rows += ledger.total_num_rows
-        for field, count in ledger.field_counts.items():
+        final_ledger.field_counts_by_shard[shard_name] = field_counts
+        for field, count in field_counts.items():
             final_ledger.field_counts[field] = final_ledger.field_counts.get(field, 0) + count
 
     final_ledger.is_finished = True
@@ -630,14 +605,6 @@ def _distributed_build_cache(
             raise RuntimeError("Unexpected status received during distributed cache build.")
 
 
-def _safe_remove(path: str):
-    try:
-        if fsspec_exists(path):
-            fsspec_remove(path, recursive=True)
-    except Exception:  # noqa: BLE001
-        logger.exception(f"Failed to remove temporary cache path {path}")
-
-
 def _expose_cache_rows(cache_path: str, exemplar: T, num_rows: int) -> None:
     cache = TreeStore.open(exemplar, cache_path, mode="a", cache_metadata=False)
     futures = jax.tree.leaves(jax.tree.map(lambda x: x.offsets[0].write(num_rows), cache.tree))
@@ -645,104 +612,42 @@ def _expose_cache_rows(cache_path: str, exemplar: T, num_rows: int) -> None:
         future.result()
 
 
-async def _extend_cache_with_other_cache(
-    dest_path: str, source_path: str, exemplar: dict, data_offset_tree: PyTree[int], row_offset
-) -> int:
+def _relative_shard_path(output_path: str, shard_path: str) -> str:
+    if "://" in shard_path:
+        prefix = output_path.rstrip("/") + "/"
+        if shard_path.startswith(prefix):
+            return shard_path[len(prefix) :]
+        return shard_path
     try:
-        logger.info(f"Copying data from {source_path} to {dest_path}.")
-        with _no_cache_read_context():
-            dest = TreeStore.open(exemplar, dest_path, mode="a", cache_metadata=False)
-            source = TreeStore.open(exemplar, source_path, mode="r", cache_metadata=True)
-
-            source_num_rows = await source.async_len()
-
-            async def _copy_one_array(dest_array: JaggedArrayStore, source_array: JaggedArrayStore, data_offset: int):
-                data_size = source_array.data_size
-                data = source_array.data
-                MAX_ELEMS = 64 * 1024 * 1024
-                await _copy_in_batches(dest_array.data, data_offset, data, data_size, MAX_ELEMS)
-
-            futures = jax.tree.map(_copy_one_array, dest.tree, source.tree, data_offset_tree)
-            await asyncio.gather(*jax.tree.leaves(futures))
-            del dest, source
-        gc.collect()
-        logger.info(f"Finished copying data from {source_path} to {dest_path}.")
-        return source_num_rows
-    except Exception as e:  # noqa: BLE001
-        logger.exception(f"Failed to copy data from {source_path} to {dest_path}: {e}")
-        raise
+        return os.path.relpath(shard_path, output_path)
+    except ValueError:
+        return shard_path
 
 
-async def _copy_in_batches(dest_array, dest_offset, src_array, src_len, elems_per_batch):
-    start = 0
-    out_start = dest_offset
-    while start < src_len:
-        num_to_copy = min(elems_per_batch, src_len - start)
-        end = start + num_to_copy
-        out_end = out_start + num_to_copy
-
-        # Materialize into numpy to avoid holding TensorStore internal references
-        # across iterations. Direct ts-to-ts copy leaks ~14 MiB/shard (#4196).
-        chunk = await src_array[start:end].read()
-        await dest_array[out_start:out_end].write(chunk)
-        del chunk
-
-        start += num_to_copy
-        out_start += num_to_copy
+def _field_counts_from_store(store: TreeStore) -> dict[str, int]:
+    return _field_counts_from_data_sizes(jax.tree.map(lambda array: array.data_size, store.tree))
 
 
-async def _consolidate_metadata(dest_path: str, exemplar: dict, shard_infos: list[dict]) -> None:
-    """Copy metadata (offsets + shapes) from all shards into dest using a single shared transaction.
+def _field_counts_from_data_sizes(data_sizes) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for path, value in jtu.tree_leaves_with_path(data_sizes):
+        field = "/".join(_render_path_elem(part) for part in path)
+        counts[field] = int(value)
+    return counts
 
-    Replaces the old per-shard loop that committed a transaction per shard, causing
-    O(num_shards) read-modify-write cycles on the same zarr3 chunks (tensorstore#202).
-    """
-    dest = TreeStore.open(exemplar, dest_path, mode="a")
-    start = time.monotonic()
 
-    delay = 4
-    while True:
-        write_futures = []
-        try:
-            async with ts.Transaction() as txn:
-                for info in shard_infos:
-                    with _no_cache_read_context():
-                        source = TreeStore.open(exemplar, info["path"], mode="r", cache_metadata=True)
-                    source_num_rows = info["ledger"].total_num_rows
-                    row_offset = info["row_offset"]
-
-                    for dest_array, source_array, data_offset in zip(
-                        jax.tree.leaves(dest.tree),
-                        jax.tree.leaves(source.tree),
-                        jax.tree.leaves(info["data_offset_tree"]),
-                    ):
-                        if source_array.shapes is not None:
-                            assert dest_array.shapes is not None
-                            source_shapes = await source_array.shapes[:source_num_rows].read()
-                            out_end = row_offset + source_num_rows
-                            write_futures.append(
-                                dest_array.shapes.with_transaction(txn)[row_offset:out_end].write(source_shapes)
-                            )
-
-                        source_offsets = await source_array.offsets[1 : source_num_rows + 1].read()
-                        source_offsets = np.asarray(source_offsets) + data_offset
-                        out_end = 1 + row_offset + source_num_rows
-                        write_futures.append(
-                            dest_array.offsets.with_transaction(txn)[row_offset + 1 : out_end].write(source_offsets)
-                        )
-
-            await asyncio.gather(*write_futures)
-            elapsed = time.monotonic() - start
-            logger.info(f"Metadata consolidation complete: {len(shard_infos)} shards in {elapsed:.1f}s")
-            break
-        except ValueError as e:
-            if "Please reduce your request rate." not in str(e):
-                raise
-            logger.info(f"Rate limit exceeded during metadata consolidation. Retrying in {delay}s.")
-            await asyncio.sleep(delay)
-            delay *= 2
-            if delay > 120:
-                raise
+def _render_path_elem(path_elem) -> str:
+    match path_elem:
+        case jtu.DictKey(key):
+            return str(key)
+        case jtu.GetAttrKey(key):
+            return str(key)
+        case jtu.SequenceKey(i):
+            return str(i)
+        case jtu.FlattenedIndexKey(i):
+            return str(i)
+        case _:
+            return str(path_elem)
 
 
 def _sanitize_shard_name(name: str) -> str:

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -28,6 +28,7 @@ from zephyr.writers import ThreadedBatchWriter, atomic_rename, batchify, ensure_
 
 from levanter.data.dataset import AsyncDataset
 from levanter.utils.jax_utils import broadcast_one_to_all
+from levanter.utils.thread_utils import blocking_wait
 
 from ..data._preprocessor import BatchProcessor, BatchResult, dict_from_record_batch
 from ..data.sharded_datasource import ShardedDataSource
@@ -99,6 +100,7 @@ class TreeCache(AsyncDataset[T_co]):
         self._shard_row_offsets: np.ndarray | None = None
         self._shard_field_stores: dict[tuple[str, str], Any] = {}
         self._shard_field_offsets: dict[str, np.ndarray] = {}
+        self._flat_field_offsets: dict[str, np.ndarray] = {}
 
         if not ledger.is_finished:
             raise RuntimeError(f"Cache at {cache_dir} is not finished.")
@@ -144,6 +146,13 @@ class TreeCache(AsyncDataset[T_co]):
                 return self.get_batch_sync(range(start, stop, step))
             return self.get_batch_sync([item])[0]
         return self.store[item]
+
+    def __iter__(self):
+        if self.is_sharded:
+            for index in range(len(self)):
+                yield self[index]
+            return
+        yield from self.store
 
     async def get_batch(self, indices: Sequence[int] | slice):
         if isinstance(indices, slice):
@@ -192,6 +201,16 @@ class TreeCache(AsyncDataset[T_co]):
             return self.ledger.total_num_rows
         return _tree_field(self.store.tree, field).num_rows
 
+    def jagged_array_tree(self):
+        if not self.is_sharded:
+            return self.store.tree
+
+        def field_store(path, _):
+            field = "/".join(_render_path_elem(part) for part in path)
+            return _ShardedJaggedArrayStore(self, field)
+
+        return jtu.tree_map_with_path(field_store, self._exemplar)
+
     async def get_flat_field_batch(self, field: str, offsets: Sequence[int], length: int) -> Sequence[np.ndarray]:
         if len(offsets) == 0:
             return []
@@ -221,14 +240,51 @@ class TreeCache(AsyncDataset[T_co]):
 
         counts = []
         for shard_name in self.ledger.finished_shards:
-            try:
-                counts.append(self.ledger.field_counts_by_shard[shard_name][field])
-            except KeyError as exc:
-                raise ValueError(f"Sharded cache ledger missing {field} count for shard {shard_name}") from exc
+            field_count = self.ledger.field_counts_by_shard.get(shard_name, {}).get(field)
+            if field_count is None:
+                if self.ledger.shard_rows[shard_name] == 0:
+                    field_count = 0
+                else:
+                    raise ValueError(f"Sharded cache ledger missing {field} count for shard {shard_name}")
+            counts.append(field_count)
 
         offsets = np.cumsum(np.array(counts, dtype=np.int64))
         self._shard_field_offsets[field] = offsets
         return self.ledger.finished_shards, offsets
+
+    def _ensure_flat_field_offsets(self, field: str) -> np.ndarray:
+        offsets = self._flat_field_offsets.get(field)
+        if offsets is not None:
+            return offsets
+
+        pieces = [np.array([self.ledger.total_num_rows], dtype=np.int64)]
+        data_offset = 0
+        for shard_name in self.ledger.finished_shards:
+            row_count = self.ledger.shard_rows[shard_name]
+            if row_count == 0:
+                continue
+
+            if field not in self.ledger.field_counts_by_shard.get(shard_name, {}):
+                raise ValueError(f"Sharded cache ledger missing {field} count for shard {shard_name}")
+
+            field_store = self._shard_field_store(shard_name, field)
+            shard_offsets = np.asarray(field_store.offsets[1 : row_count + 1].read().result(), dtype=np.int64)
+            pieces.append(shard_offsets + data_offset)
+            data_offset += int(shard_offsets[-1]) if len(shard_offsets) else 0
+
+        offsets = np.concatenate(pieces)
+        self._flat_field_offsets[field] = offsets
+        return offsets
+
+    async def _read_sharded_flat_field_slice(self, field: str, item: slice) -> np.ndarray:
+        start, stop, step = item.indices(self.flat_field_length(field))
+        if step != 1:
+            data = await self._get_sharded_flat_field(field, start, max(stop - start, 0))
+            return data[::step]
+        return await self._get_sharded_flat_field(field, start, max(stop - start, 0))
+
+    def _read_sharded_flat_field_slice_sync(self, field: str, item: slice) -> np.ndarray:
+        return blocking_wait(self._read_sharded_flat_field_slice(field, item))
 
     def _shard_store(self, shard_name: str) -> TreeStore[T_co]:
         store = self._shard_stores.get(shard_name)
@@ -310,6 +366,9 @@ class TreeCache(AsyncDataset[T_co]):
         return rows
 
     async def _get_sharded_flat_field(self, field: str, offset: int, length: int) -> np.ndarray:
+        if length == 0:
+            return np.array([], dtype=np.asarray(_tree_field(self._exemplar, field)).dtype)
+
         shard_names, shard_offsets = self._ensure_shard_field_offsets(field)
         remaining = length
         position = offset
@@ -446,6 +505,73 @@ def _field_exemplar(exemplar, field: str):
     if "/" not in field and isinstance(exemplar, Mapping):
         return {field: exemplar[field]}
     return exemplar
+
+
+class _ArrayRead:
+    def __init__(self, sync_reader, async_reader=None):
+        self._sync_reader = sync_reader
+        self._async_reader = async_reader
+
+    def read(self):
+        return _ArrayReadFuture(self._sync_reader, self._async_reader)
+
+
+class _ArrayReadFuture:
+    def __init__(self, sync_reader, async_reader=None):
+        self._sync_reader = sync_reader
+        self._async_reader = async_reader
+
+    def result(self):
+        return self._sync_reader()
+
+    def __await__(self):
+        async def read_async():
+            if self._async_reader is not None:
+                return await self._async_reader()
+            return self._sync_reader()
+
+        return read_async().__await__()
+
+
+class _ShardedJaggedArrayData:
+    def __init__(self, cache: TreeCache, field: str):
+        self._cache = cache
+        self._field = field
+
+    def __getitem__(self, item):
+        if not isinstance(item, slice):
+            item = slice(item, item + 1)
+        return _ArrayRead(
+            lambda: self._cache._read_sharded_flat_field_slice_sync(self._field, item),
+            lambda: self._cache._read_sharded_flat_field_slice(self._field, item),
+        )
+
+
+class _ShardedJaggedArrayOffsets:
+    def __init__(self, cache: TreeCache, field: str):
+        self._cache = cache
+        self._field = field
+
+    def __getitem__(self, item):
+        return _ArrayRead(lambda: self._cache._ensure_flat_field_offsets(self._field)[item])
+
+
+class _ShardedJaggedArrayStore:
+    def __init__(self, cache: TreeCache, field: str):
+        self._cache = cache
+        self._field = field
+        self.offsets = _ShardedJaggedArrayOffsets(cache, field)
+        self.data = _ShardedJaggedArrayData(cache, field)
+        self.shapes = None
+        self.item_rank = 1
+
+    @property
+    def num_rows(self) -> int:
+        return self._cache.flat_field_num_rows(self._field)
+
+    @property
+    def data_size(self) -> int:
+        return self._cache.flat_field_length(self._field)
 
 
 @dataclass_json

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -125,8 +125,6 @@ class TreeCache(AsyncDataset[T_co]):
         return self.ledger.layout == CACHE_LAYOUT_SHARDED
 
     def _shard_path(self, shard_name: str) -> str:
-        if "://" in shard_name:
-            return shard_name
         return os.path.join(self.cache_dir, shard_name)
 
     async def async_len(self) -> int:
@@ -596,6 +594,9 @@ def _validate_sharded_ledger(ledger: CacheLedger) -> None:
         if shard_name in seen_shards:
             raise ValueError(f"Sharded cache ledger contains duplicate shard {shard_name}")
         seen_shards.add(shard_name)
+
+        if "://" in shard_name or os.path.isabs(shard_name):
+            raise ValueError(f"Sharded cache ledger shard path must be relative: {shard_name}")
 
         if shard_name not in ledger.shard_rows:
             raise ValueError(f"Sharded cache ledger missing row count for shard {shard_name}")
@@ -1082,8 +1083,8 @@ def consolidate_shard_cache_ledgers(
     """
     Consolidate multiple shard cache ledgers into one sharded cache ledger.
 
-    The output points at the original shard directories instead of copying their
-    arrays into a top-level TreeStore.
+    Shard directories must be under output_path. The output ledger stores their
+    relative paths instead of copying their arrays into a top-level TreeStore.
     """
     if metadata is None:
         metadata = CacheMetadata.empty()
@@ -1101,6 +1102,9 @@ def consolidate_shard_cache_ledgers(
         )
         ledger._serialize_and_commit(output_path)
         return ledger
+
+    for shard_path in shard_cache_paths:
+        _relative_shard_path(output_path, shard_path)
 
     logger.info(f"Consolidating {len(shard_cache_paths)} shard cache ledgers into {output_path}")
 
@@ -1342,17 +1346,23 @@ async def _consolidate_metadata(dest_path: str, exemplar: dict, shard_infos: lis
 
 
 def _relative_shard_path(output_path: str, shard_path: str) -> str:
-    if "://" in shard_path:
+    if "://" in output_path or "://" in shard_path:
         prefix = output_path.rstrip("/") + "/"
         if shard_path.startswith(prefix):
             return shard_path[len(prefix) :]
-        return shard_path
+        raise ValueError(f"Sharded cache path {shard_path} is not under output path {output_path}")
+
+    output_abs = os.path.abspath(output_path)
+    shard_abs = os.path.abspath(shard_path)
     try:
-        relative_path = os.path.relpath(shard_path, output_path)
-    except ValueError:
-        return shard_path
-    if relative_path == os.pardir or relative_path.startswith(os.pardir + os.sep):
-        return shard_path
+        common_path = os.path.commonpath([output_abs, shard_abs])
+    except ValueError as exc:
+        raise ValueError(f"Sharded cache path {shard_path} is not under output path {output_path}") from exc
+
+    if shard_abs == output_abs or common_path != output_abs:
+        raise ValueError(f"Sharded cache path {shard_path} is not under output path {output_path}")
+
+    relative_path = os.path.relpath(shard_abs, output_abs)
     return relative_path
 
 

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -1,12 +1,13 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import dataclasses
 import logging as pylogging
 import os
 import threading
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Sequence, TypeVar, Union
 
@@ -16,6 +17,7 @@ import jax.tree_util as jtu
 from rigging.filesystem import open_url, url_to_fs
 import numpy as np
 import pyarrow as pa
+import tensorstore as ts
 from dataclasses_json import dataclass_json
 from fray import ResourceConfig
 from fsspec import AbstractFileSystem
@@ -93,6 +95,10 @@ class TreeCache(AsyncDataset[T_co]):
         self.cache_dir = cache_dir
         self.ledger = ledger
         self._exemplar = exemplar
+        self._shard_stores: dict[str, TreeStore[T_co]] = {}
+        self._shard_row_offsets: np.ndarray | None = None
+        self._shard_field_stores: dict[tuple[str, str], Any] = {}
+        self._shard_field_offsets: dict[str, np.ndarray] = {}
 
         if not ledger.is_finished:
             raise RuntimeError(f"Cache at {cache_dir} is not finished.")
@@ -113,7 +119,7 @@ class TreeCache(AsyncDataset[T_co]):
     def is_sharded(self) -> bool:
         return self.ledger.layout == CACHE_LAYOUT_SHARDED
 
-    def shard_path(self, shard_name: str) -> str:
+    def _shard_path(self, shard_name: str) -> str:
         if "://" in shard_name:
             return shard_name
         return os.path.join(self.cache_dir, shard_name)
@@ -132,11 +138,18 @@ class TreeCache(AsyncDataset[T_co]):
         return True
 
     def __getitem__(self, item):
+        if self.is_sharded:
+            if isinstance(item, slice):
+                start, stop, step = item.indices(len(self))
+                return self.get_batch_sync(range(start, stop, step))
+            return self.get_batch_sync([item])[0]
         return self.store[item]
 
     async def get_batch(self, indices: Sequence[int] | slice):
         if isinstance(indices, slice):
             indices = range(indices.start or 0, indices.stop or len(self), indices.step or 1)
+        if self.is_sharded:
+            return await self._get_sharded_batch(indices)
         return await self.store.get_batch(indices)
 
     def get_batch_sync(self, indices_or_slice, *, timeout: Optional[float] = None):
@@ -146,7 +159,179 @@ class TreeCache(AsyncDataset[T_co]):
                 indices_or_slice.stop or len(self),
                 indices_or_slice.step or 1,
             )
+        if self.is_sharded:
+            return self._get_sharded_batch_sync(indices_or_slice)
         return self.store.get_batch_sync(indices_or_slice)
+
+    def flat_field_length(self, field: str) -> int:
+        field_count = self.ledger.field_counts.get(field)
+        if field_count is not None:
+            return field_count
+
+        if self.is_sharded:
+            if self.ledger.total_num_rows == 0:
+                return 0
+            raise ValueError(f"Sharded cache ledger missing aggregate {field} count")
+
+        return _tree_field(self.store.tree, field).data_size
+
+    async def async_flat_field_length(self, field: str) -> int:
+        field_count = self.ledger.field_counts.get(field)
+        if field_count is not None:
+            return field_count
+
+        if self.is_sharded:
+            if self.ledger.total_num_rows == 0:
+                return 0
+            raise ValueError(f"Sharded cache ledger missing aggregate {field} count")
+
+        return await _tree_field(self.store.tree, field).data_size_async()
+
+    def flat_field_num_rows(self, field: str) -> int:
+        if self.is_sharded:
+            return self.ledger.total_num_rows
+        return _tree_field(self.store.tree, field).num_rows
+
+    async def get_flat_field_batch(self, field: str, offsets: Sequence[int], length: int) -> Sequence[np.ndarray]:
+        if len(offsets) == 0:
+            return []
+
+        if self.is_sharded:
+            return await asyncio.gather(
+                *[self._get_sharded_flat_field(field, int(offset), length) for offset in offsets]
+            )
+
+        field_store = _tree_field(self.store.tree, field)
+        with ts.Batch():
+            futures = [field_store.data[int(offset) : int(offset) + length].read() for offset in offsets]
+        return await asyncio.gather(*futures)
+
+    def _ensure_shard_row_offsets(self) -> tuple[list[str], np.ndarray]:
+        if self._shard_row_offsets is not None:
+            return self.ledger.finished_shards, self._shard_row_offsets
+
+        counts = [self.ledger.shard_rows[shard_name] for shard_name in self.ledger.finished_shards]
+        self._shard_row_offsets = np.cumsum(np.array(counts, dtype=np.int64))
+        return self.ledger.finished_shards, self._shard_row_offsets
+
+    def _ensure_shard_field_offsets(self, field: str) -> tuple[list[str], np.ndarray]:
+        offsets = self._shard_field_offsets.get(field)
+        if offsets is not None:
+            return self.ledger.finished_shards, offsets
+
+        counts = []
+        for shard_name in self.ledger.finished_shards:
+            try:
+                counts.append(self.ledger.field_counts_by_shard[shard_name][field])
+            except KeyError as exc:
+                raise ValueError(f"Sharded cache ledger missing {field} count for shard {shard_name}") from exc
+
+        offsets = np.cumsum(np.array(counts, dtype=np.int64))
+        self._shard_field_offsets[field] = offsets
+        return self.ledger.finished_shards, offsets
+
+    def _shard_store(self, shard_name: str) -> TreeStore[T_co]:
+        store = self._shard_stores.get(shard_name)
+        if store is None:
+            store = TreeStore.open(self._exemplar, self._shard_path(shard_name), mode="r", cache_metadata=True)
+            self._shard_stores[shard_name] = store
+        return store
+
+    def _shard_field_store(self, shard_name: str, field: str):
+        key = (shard_name, field)
+        store = self._shard_field_stores.get(key)
+        if store is None:
+            tree_store = TreeStore.open(
+                _field_exemplar(self._exemplar, field),
+                self._shard_path(shard_name),
+                mode="r",
+                cache_metadata=True,
+            )
+            store = _tree_field(tree_store.tree, field)
+            self._shard_field_stores[key] = store
+        return store
+
+    async def _get_sharded_batch(self, indices: Sequence[int]) -> list[T_co]:
+        if len(indices) == 0:
+            return []
+
+        shard_names, shard_offsets = self._ensure_shard_row_offsets()
+        shard_batches: dict[int, list[tuple[int, int]]] = {}
+        for output_index, index in enumerate(indices):
+            index = int(index)
+            if index < 0 or index >= self.ledger.total_num_rows:
+                raise ValueError("Requested indices beyond the end of the dataset")
+
+            shard_index = int(np.searchsorted(shard_offsets, index, side="right"))
+            shard_start = int(shard_offsets[shard_index - 1]) if shard_index > 0 else 0
+            shard_batches.setdefault(shard_index, []).append((output_index, index - shard_start))
+
+        output: list[T_co | None] = [None] * len(indices)
+
+        async def read_shard(shard_index: int, batch: list[tuple[int, int]]) -> None:
+            local_indices = [local_index for _, local_index in batch]
+            shard_batch = await self._shard_store(shard_names[shard_index]).get_batch(local_indices)
+            for (output_index, _), row in zip(batch, shard_batch, strict=True):
+                output[output_index] = row
+
+        await asyncio.gather(*[read_shard(shard_index, batch) for shard_index, batch in shard_batches.items()])
+        rows = []
+        for row in output:
+            assert row is not None
+            rows.append(row)
+        return rows
+
+    def _get_sharded_batch_sync(self, indices: Sequence[int]) -> list[T_co]:
+        if len(indices) == 0:
+            return []
+
+        shard_names, shard_offsets = self._ensure_shard_row_offsets()
+        shard_batches: dict[int, list[tuple[int, int]]] = {}
+        for output_index, index in enumerate(indices):
+            index = int(index)
+            if index < 0 or index >= self.ledger.total_num_rows:
+                raise ValueError("Requested indices beyond the end of the dataset")
+
+            shard_index = int(np.searchsorted(shard_offsets, index, side="right"))
+            shard_start = int(shard_offsets[shard_index - 1]) if shard_index > 0 else 0
+            shard_batches.setdefault(shard_index, []).append((output_index, index - shard_start))
+
+        output: list[T_co | None] = [None] * len(indices)
+        for shard_index, batch in shard_batches.items():
+            local_indices = [local_index for _, local_index in batch]
+            shard_batch = self._shard_store(shard_names[shard_index]).get_batch_sync(local_indices)
+            for (output_index, _), row in zip(batch, shard_batch, strict=True):
+                output[output_index] = row
+
+        rows = []
+        for row in output:
+            assert row is not None
+            rows.append(row)
+        return rows
+
+    async def _get_sharded_flat_field(self, field: str, offset: int, length: int) -> np.ndarray:
+        shard_names, shard_offsets = self._ensure_shard_field_offsets(field)
+        remaining = length
+        position = offset
+        chunks = []
+
+        while remaining > 0:
+            shard_index = int(np.searchsorted(shard_offsets, position, side="right"))
+            if shard_index >= len(shard_names):
+                raise ValueError("Requested field offsets beyond the end of the dataset")
+
+            shard_start = int(shard_offsets[shard_index - 1]) if shard_index > 0 else 0
+            local_start = position - shard_start
+            available = int(shard_offsets[shard_index] - position)
+            take = min(remaining, available)
+            field_store = self._shard_field_store(shard_names[shard_index], field)
+            chunks.append(await field_store.data[local_start : local_start + take].read())
+            position += take
+            remaining -= take
+
+        if len(chunks) == 1:
+            return chunks[0]
+        return np.concatenate(chunks)
 
     @staticmethod
     def load(cache_dir: str, exemplar: T, options: Optional["CacheMetadata"] = None) -> "TreeCache":
@@ -243,6 +428,24 @@ def _validate_sharded_ledger(ledger: CacheLedger) -> None:
     for shard_name in ledger.field_counts_by_shard:
         if shard_name not in seen_shards:
             raise ValueError(f"Sharded cache ledger has field counts for unknown shard {shard_name}")
+
+
+def _tree_field(tree, field: str):
+    value = tree
+    for part in field.split("/"):
+        if isinstance(value, Mapping):
+            value = value[part]
+        elif isinstance(value, (list, tuple)):
+            value = value[int(part)]
+        else:
+            value = getattr(value, part)
+    return value
+
+
+def _field_exemplar(exemplar, field: str):
+    if "/" not in field and isinstance(exemplar, Mapping):
+        return {field: exemplar[field]}
+    return exemplar
 
 
 @dataclass_json

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -10,9 +10,9 @@ import operator
 import os
 import threading
 import time
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Sequence, TypeVar, Union
+from typing import Any, Dict, List, Optional, Protocol, Sequence, TypeVar, Union, cast
 
 import deepdiff
 import jax
@@ -109,17 +109,16 @@ class TreeCache(AsyncDataset[T_co]):
         if not ledger.is_finished:
             raise RuntimeError(f"Cache at {cache_dir} is not finished.")
 
-        self._store = None
         if self.is_sharded:
             _validate_sharded_ledger(ledger)
+            self._reader: _TreeCacheReader[T_co] = _ShardedTreeCacheReader(self)
         else:
-            self._store = TreeStore.open(self._exemplar, self.cache_dir, mode="r", cache_metadata=False)
+            store = TreeStore.open(self._exemplar, self.cache_dir, mode="r", cache_metadata=False)
+            self._reader = _MaterializedTreeCacheReader(store)
 
     @property
     def store(self) -> TreeStore[T_co]:
-        if self._store is None:
-            raise RuntimeError(f"Cache at {self.cache_dir} is sharded and has no top-level TreeStore.")
-        return self._store
+        return self._reader.store
 
     @property
     def is_sharded(self) -> bool:
@@ -131,101 +130,40 @@ class TreeCache(AsyncDataset[T_co]):
         return os.path.join(self.cache_dir, shard_name)
 
     async def async_len(self) -> int:
-        if self.is_sharded:
-            return self.ledger.total_num_rows
-        return len(self.store)
+        return await self._reader.async_len()
 
     def __len__(self):
-        if self.is_sharded:
-            return self.ledger.total_num_rows
-        return len(self.store)
+        return len(self._reader)
 
     def is_finite(self) -> bool:
         return True
 
     def __getitem__(self, item):
-        if self.is_sharded:
-            if isinstance(item, slice):
-                start, stop, step = item.indices(len(self))
-                return self.get_batch_sync(range(start, stop, step))
-            return self.get_batch_sync([item])[0]
-        return self.store[item]
+        return self._reader[item]
 
     def __iter__(self):
-        if self.is_sharded:
-            for index in range(len(self)):
-                yield self[index]
-            return
-        yield from self.store
+        yield from self._reader
 
-    async def get_batch(self, indices: Sequence[int] | slice):
-        if isinstance(indices, slice):
-            start, stop, step = indices.indices(len(self))
-            indices = range(start, stop, step)
-        if self.is_sharded:
-            return await self._get_sharded_batch(indices)
-        return await self.store.get_batch(indices)
+    async def get_batch(self, indices: Sequence[int]) -> Sequence[T_co]:
+        return await self._reader.get_batch(indices)
 
-    def get_batch_sync(self, indices_or_slice, *, timeout: Optional[float] = None):
-        if isinstance(indices_or_slice, slice):
-            start, stop, step = indices_or_slice.indices(len(self))
-            indices_or_slice = range(start, stop, step)
-        if self.is_sharded:
-            return self._get_sharded_batch_sync(indices_or_slice)
-        return self.store.get_batch_sync(indices_or_slice)
+    def get_batch_sync(self, indices_or_slice, *, timeout: Optional[float] = None) -> Sequence[T_co]:
+        return self._reader.get_batch_sync(indices_or_slice, timeout=timeout)
 
     def flat_field_length(self, field: str) -> int:
-        field_count = self.ledger.field_counts.get(field)
-        if field_count is not None:
-            return field_count
-
-        if self.is_sharded:
-            if self.ledger.total_num_rows == 0:
-                return 0
-            raise ValueError(f"Sharded cache ledger missing aggregate {field} count")
-
-        return _tree_field(self.store.tree, field).data_size
+        return self._reader.flat_field_length(field)
 
     async def async_flat_field_length(self, field: str) -> int:
-        field_count = self.ledger.field_counts.get(field)
-        if field_count is not None:
-            return field_count
-
-        if self.is_sharded:
-            if self.ledger.total_num_rows == 0:
-                return 0
-            raise ValueError(f"Sharded cache ledger missing aggregate {field} count")
-
-        return await _tree_field(self.store.tree, field).data_size_async()
+        return await self._reader.async_flat_field_length(field)
 
     def flat_field_num_rows(self, field: str) -> int:
-        if self.is_sharded:
-            return self.ledger.total_num_rows
-        return _tree_field(self.store.tree, field).num_rows
+        return self._reader.flat_field_num_rows(field)
 
     def jagged_array_tree(self):
-        if not self.is_sharded:
-            return self.store.tree
-
-        def field_store(path, _):
-            field = "/".join(_render_path_elem(part) for part in path)
-            return _ShardedJaggedArrayStore(self, field)
-
-        return jtu.tree_map_with_path(field_store, self._exemplar)
+        return self._reader.jagged_array_tree()
 
     async def get_flat_field_batch(self, field: str, offsets: Sequence[int], length: int) -> Sequence[np.ndarray]:
-        if len(offsets) == 0:
-            return []
-
-        if self.is_sharded:
-            return await asyncio.gather(
-                *[self._get_sharded_flat_field(field, int(offset), length) for offset in offsets]
-            )
-
-        field_store = _tree_field(self.store.tree, field)
-        with ts.Batch():
-            futures = [field_store.data[int(offset) : int(offset) + length].read() for offset in offsets]
-        return await asyncio.gather(*futures)
+        return await self._reader.get_flat_field_batch(field, offsets, length)
 
     def _ensure_shard_row_offsets(self) -> tuple[list[str], np.ndarray]:
         if self._shard_row_offsets is not None:
@@ -417,6 +355,160 @@ class TreeCache(AsyncDataset[T_co]):
     @property
     def is_finished(self):
         return True
+
+
+class _TreeCacheReader(Protocol[T_co]):
+    @property
+    def store(self) -> TreeStore[T_co]: ...
+
+    async def async_len(self) -> int: ...
+
+    def __len__(self) -> int: ...
+
+    def __getitem__(self, item) -> T_co | Sequence[T_co]: ...
+
+    def __iter__(self) -> Iterator[T_co]: ...
+
+    async def get_batch(self, indices: Sequence[int] | slice) -> Sequence[T_co]: ...
+
+    def get_batch_sync(self, indices_or_slice, *, timeout: Optional[float] = None) -> Sequence[T_co]: ...
+
+    def flat_field_length(self, field: str) -> int: ...
+
+    async def async_flat_field_length(self, field: str) -> int: ...
+
+    def flat_field_num_rows(self, field: str) -> int: ...
+
+    def jagged_array_tree(self) -> Any: ...
+
+    async def get_flat_field_batch(self, field: str, offsets: Sequence[int], length: int) -> Sequence[np.ndarray]: ...
+
+
+class _MaterializedTreeCacheReader:
+    def __init__(self, store: TreeStore[T_co]):
+        self._store = store
+
+    @property
+    def store(self) -> TreeStore[T_co]:
+        return self._store
+
+    async def async_len(self) -> int:
+        return len(self._store)
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+    def __getitem__(self, item) -> T_co | Sequence[T_co]:
+        return self._store[item]
+
+    def __iter__(self) -> Iterator[T_co]:
+        for row in self._store:
+            yield cast(T_co, row)
+
+    async def get_batch(self, indices: Sequence[int] | slice) -> Sequence[T_co]:
+        if isinstance(indices, slice):
+            start, stop, step = indices.indices(len(self))
+            indices = range(start, stop, step)
+        return await self._store.get_batch(indices)
+
+    def get_batch_sync(self, indices_or_slice, *, timeout: Optional[float] = None) -> Sequence[T_co]:
+        if isinstance(indices_or_slice, slice):
+            start, stop, step = indices_or_slice.indices(len(self))
+            indices_or_slice = range(start, stop, step)
+        return self._store.get_batch_sync(indices_or_slice)
+
+    def flat_field_length(self, field: str) -> int:
+        return _tree_field(self._store.tree, field).data_size
+
+    async def async_flat_field_length(self, field: str) -> int:
+        return await _tree_field(self._store.tree, field).data_size_async()
+
+    def flat_field_num_rows(self, field: str) -> int:
+        return _tree_field(self._store.tree, field).num_rows
+
+    def jagged_array_tree(self) -> Any:
+        return self._store.tree
+
+    async def get_flat_field_batch(self, field: str, offsets: Sequence[int], length: int) -> Sequence[np.ndarray]:
+        if len(offsets) == 0:
+            return []
+
+        field_store = _tree_field(self._store.tree, field)
+        with ts.Batch():
+            futures = [field_store.data[int(offset) : int(offset) + length].read() for offset in offsets]
+        return await asyncio.gather(*futures)
+
+
+class _ShardedTreeCacheReader:
+    def __init__(self, cache: TreeCache[T_co]):
+        self._cache = cache
+
+    @property
+    def store(self) -> TreeStore[T_co]:
+        raise RuntimeError(f"Cache at {self._cache.cache_dir} is sharded and has no top-level TreeStore.")
+
+    async def async_len(self) -> int:
+        return self._cache.ledger.total_num_rows
+
+    def __len__(self) -> int:
+        return self._cache.ledger.total_num_rows
+
+    def __getitem__(self, item) -> T_co | Sequence[T_co]:
+        if isinstance(item, slice):
+            start, stop, step = item.indices(len(self))
+            return self.get_batch_sync(range(start, stop, step))
+        return self.get_batch_sync([item])[0]
+
+    def __iter__(self) -> Iterator[T_co]:
+        for index in range(len(self)):
+            yield cast(T_co, self.get_batch_sync([index])[0])
+
+    async def get_batch(self, indices: Sequence[int] | slice) -> Sequence[T_co]:
+        if isinstance(indices, slice):
+            start, stop, step = indices.indices(len(self))
+            indices = range(start, stop, step)
+        return await self._cache._get_sharded_batch(indices)
+
+    def get_batch_sync(self, indices_or_slice, *, timeout: Optional[float] = None) -> Sequence[T_co]:
+        if isinstance(indices_or_slice, slice):
+            start, stop, step = indices_or_slice.indices(len(self))
+            indices_or_slice = range(start, stop, step)
+        return self._cache._get_sharded_batch_sync(indices_or_slice)
+
+    def flat_field_length(self, field: str) -> int:
+        field_count = self._cache.ledger.field_counts.get(field)
+        if field_count is not None:
+            return field_count
+
+        if self._cache.ledger.total_num_rows == 0:
+            return 0
+        raise ValueError(f"Sharded cache ledger missing aggregate {field} count")
+
+    async def async_flat_field_length(self, field: str) -> int:
+        field_count = self._cache.ledger.field_counts.get(field)
+        if field_count is not None:
+            return field_count
+
+        if self._cache.ledger.total_num_rows == 0:
+            return 0
+        raise ValueError(f"Sharded cache ledger missing aggregate {field} count")
+
+    def flat_field_num_rows(self, field: str) -> int:
+        return self._cache.ledger.total_num_rows
+
+    def jagged_array_tree(self) -> Any:
+        def field_store(path, _):
+            field = "/".join(_render_path_elem(part) for part in path)
+            return _ShardedJaggedArrayStore(self._cache, field)
+
+        return jtu.tree_map_with_path(field_store, self._cache._exemplar)
+
+    async def get_flat_field_batch(self, field: str, offsets: Sequence[int], length: int) -> Sequence[np.ndarray]:
+        if len(offsets) == 0:
+            return []
+        return await asyncio.gather(
+            *[self._cache._get_sharded_flat_field(field, int(offset), length) for offset in offsets]
+        )
 
 
 @dataclass_json

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -156,7 +156,8 @@ class TreeCache(AsyncDataset[T_co]):
 
     async def get_batch(self, indices: Sequence[int] | slice):
         if isinstance(indices, slice):
-            indices = range(indices.start or 0, indices.stop or len(self), indices.step or 1)
+            start, stop, step = indices.indices(len(self))
+            indices = range(start, stop, step)
         if self.is_sharded:
             return await self._get_sharded_batch(indices)
         return await self.store.get_batch(indices)

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -98,7 +98,9 @@ class TreeCache(AsyncDataset[T_co]):
             raise RuntimeError(f"Cache at {cache_dir} is not finished.")
 
         self._store = None
-        if not self.is_sharded:
+        if self.is_sharded:
+            _validate_sharded_ledger(ledger)
+        else:
             self._store = TreeStore.open(self._exemplar, self.cache_dir, mode="r", cache_metadata=False)
 
     @property
@@ -214,6 +216,33 @@ class CacheLedger:
     def _serialize_and_commit(self, cache_dir):
         path = os.path.join(cache_dir, LEDGER_FILE_NAME)
         return _serialize_json_and_commit(path, self)  # type: ignore[arg-type]
+
+
+def _validate_sharded_ledger(ledger: CacheLedger) -> None:
+    seen_shards: set[str] = set()
+    total_num_rows = 0
+    for shard_name in ledger.finished_shards:
+        if shard_name in seen_shards:
+            raise ValueError(f"Sharded cache ledger contains duplicate shard {shard_name}")
+        seen_shards.add(shard_name)
+
+        if shard_name not in ledger.shard_rows:
+            raise ValueError(f"Sharded cache ledger missing row count for shard {shard_name}")
+
+        num_rows = ledger.shard_rows[shard_name]
+        if num_rows < 0:
+            raise ValueError(f"Sharded cache ledger has negative row count for shard {shard_name}: {num_rows}")
+        total_num_rows += num_rows
+
+    if total_num_rows != ledger.total_num_rows:
+        raise ValueError(
+            "Sharded cache ledger row count mismatch: "
+            f"sum(finished shard rows)={total_num_rows}, total_num_rows={ledger.total_num_rows}"
+        )
+
+    for shard_name in ledger.field_counts_by_shard:
+        if shard_name not in seen_shards:
+            raise ValueError(f"Sharded cache ledger has field counts for unknown shard {shard_name}")
 
 
 @dataclass_json
@@ -545,6 +574,9 @@ def _merge_ledgers(
     )
     for shard_path, ledger, field_counts in zip(shard_cache_paths, shard_ledgers, per_shard_field_counts, strict=True):
         shard_name = _relative_shard_path(output_path, shard_path)
+        if shard_name in final_ledger.shard_rows:
+            raise ValueError(f"Multiple shard cache paths resolve to the same ledger shard path: {shard_name}")
+
         final_ledger.shard_rows[shard_name] = ledger.total_num_rows
         final_ledger.finished_shards.append(shard_name)
         final_ledger.total_num_rows += ledger.total_num_rows
@@ -553,6 +585,7 @@ def _merge_ledgers(
             final_ledger.field_counts[field] = final_ledger.field_counts.get(field, 0) + count
 
     final_ledger.is_finished = True
+    _validate_sharded_ledger(final_ledger)
     final_ledger._serialize_and_commit(output_path)
     return final_ledger
 
@@ -619,9 +652,12 @@ def _relative_shard_path(output_path: str, shard_path: str) -> str:
             return shard_path[len(prefix) :]
         return shard_path
     try:
-        return os.path.relpath(shard_path, output_path)
+        relative_path = os.path.relpath(shard_path, output_path)
     except ValueError:
         return shard_path
+    if relative_path == os.pardir or relative_path.startswith(os.pardir + os.sep):
+        return shard_path
+    return relative_path
 
 
 def _field_counts_from_store(store: TreeStore) -> dict[str, int]:

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -164,11 +164,8 @@ class TreeCache(AsyncDataset[T_co]):
 
     def get_batch_sync(self, indices_or_slice, *, timeout: Optional[float] = None):
         if isinstance(indices_or_slice, slice):
-            indices_or_slice = range(
-                indices_or_slice.start or 0,
-                indices_or_slice.stop or len(self),
-                indices_or_slice.step or 1,
-            )
+            start, stop, step = indices_or_slice.indices(len(self))
+            indices_or_slice = range(start, stop, step)
         if self.is_sharded:
             return self._get_sharded_batch_sync(indices_or_slice)
         return self.store.get_batch_sync(indices_or_slice)

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -312,7 +312,7 @@ class TreeCache(AsyncDataset[T_co]):
         shard_names, shard_offsets = self._ensure_shard_field_offsets(field)
         remaining = length
         position = offset
-        chunks = []
+        reads = []
 
         while remaining > 0:
             shard_index = int(np.searchsorted(shard_offsets, position, side="right"))
@@ -324,10 +324,11 @@ class TreeCache(AsyncDataset[T_co]):
             available = int(shard_offsets[shard_index] - position)
             take = min(remaining, available)
             field_store = self._shard_field_store(shard_names[shard_index], field)
-            chunks.append(await field_store.data[local_start : local_start + take].read())
+            reads.append(field_store.data[local_start : local_start + take].read())
             position += take
             remaining -= take
 
+        chunks = await asyncio.gather(*reads)
         if len(chunks) == 1:
             return chunks[0]
         return np.concatenate(chunks)

--- a/lib/levanter/src/levanter/store/tree_store.py
+++ b/lib/levanter/src/levanter/store/tree_store.py
@@ -58,6 +58,14 @@ class TreeStore(Generic[T]):
         tree = _construct_builder_tree(exemplar, path, mode, cache_metadata)
         return TreeStore(tree, path, mode)
 
+    @staticmethod
+    async def open_async(exemplar: T, path: str, *, mode="a", cache_metadata: bool = False) -> "TreeStore":
+        """
+        Open a TreeStoreBuilder from a file asynchronously.
+        """
+        tree = await _construct_builder_tree_async(exemplar, path, mode, cache_metadata)
+        return TreeStore(tree, path, mode)
+
     def append(self, ex: T):
         return self.extend([ex])
 
@@ -185,6 +193,25 @@ def _construct_builder_tree(exemplar, path, mode, cache_metadata):
         )
 
     return jtu.tree_map_with_path(open_builder, exemplar, is_leaf=heuristic_is_leaf)
+
+
+async def _construct_builder_tree_async(exemplar, path, mode, cache_metadata):
+    def open_builder(tree_path, item):
+        item = np.asarray(item)
+        rank = item.ndim
+        render_tree_path = "/".join(_render_path_elem(x) for x in tree_path)
+        return JaggedArrayStore.open_async(
+            os.path.join(path, render_tree_path),
+            mode=mode,
+            item_rank=rank,
+            dtype=item.dtype,
+            cache_metadata=cache_metadata,
+        )
+
+    tree_futures = jtu.tree_map_with_path(open_builder, exemplar, is_leaf=heuristic_is_leaf)
+    leaves, treedef = jtu.tree_flatten(tree_futures)
+    opened_leaves = await asyncio.gather(*leaves)
+    return jtu.tree_unflatten(treedef, opened_leaves)
 
 
 def _render_path_elem(x):

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -1,6 +1,7 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, Iterator, Sequence
@@ -11,7 +12,15 @@ from zephyr.execution import ZephyrWorkerError
 
 from levanter.data import BatchProcessor, ShardedDataSource, batched
 from levanter.data.sharded_datasource import TextUrlDataSource
-from levanter.store.cache import SerialCacheWriter, TreeStore, build_or_load_cache, write_levanter_cache
+from levanter.store.cache import (
+    CACHE_LAYOUT_SHARDED,
+    CacheLedger,
+    SerialCacheWriter,
+    TreeCache,
+    TreeStore,
+    build_or_load_cache,
+    write_levanter_cache,
+)
 
 
 class TestProcessor(BatchProcessor[Sequence[int], dict[str, np.ndarray]]):
@@ -112,6 +121,82 @@ def test_serial_cache_writer():
 
         for i, x in enumerate(builder):
             np.testing.assert_array_equal(x["data"], np.asarray([i % 10 + i // 10 * 10] * 10))
+
+
+@pytest.mark.asyncio
+async def test_tree_store_open_async_reads_cache():
+    exemplar = {"data": np.array([0], dtype=np.int64)}
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with SerialCacheWriter(tmpdir, exemplar) as writer:
+            writer.write_batch([{"data": np.asarray([1, 2])}, {"data": np.asarray([3])}])
+
+        store = await TreeStore.open_async(exemplar, tmpdir, mode="r", cache_metadata=True)
+
+        assert len(store) == 2
+        np.testing.assert_array_equal(store[0]["data"], np.asarray([1, 2]))
+        np.testing.assert_array_equal(store[1]["data"], np.asarray([3]))
+
+
+def test_sharded_flat_field_offsets_read_shards_concurrently(monkeypatch):
+    shard_names = ["shard_0", "shard_1", "shard_2"]
+    field_counts_by_shard = {
+        "shard_0": {"data": 2},
+        "shard_1": {"data": 3},
+        "shard_2": {"data": 4},
+    }
+    ledger = CacheLedger(
+        total_num_rows=3,
+        shard_rows={shard_name: 1 for shard_name in shard_names},
+        is_finished=True,
+        finished_shards=shard_names,
+        field_counts={"data": 9},
+        field_counts_by_shard=field_counts_by_shard,
+        layout=CACHE_LAYOUT_SHARDED,
+    )
+    cache = TreeCache("/unused", {"data": np.array([0], dtype=np.int64)}, ledger)
+    active_reads = 0
+    max_active_reads = 0
+
+    class FakeRead:
+        def __init__(self, value: int):
+            self.value = value
+
+        def __await__(self):
+            async def read():
+                nonlocal active_reads, max_active_reads
+                active_reads += 1
+                max_active_reads = max(max_active_reads, active_reads)
+                await asyncio.sleep(0)
+                active_reads -= 1
+                return np.array([self.value], dtype=np.int64)
+
+            return read().__await__()
+
+    class FakeOffsets:
+        def __init__(self, value: int):
+            self.value = value
+
+        def __getitem__(self, item):
+            return self
+
+        def read(self):
+            return FakeRead(self.value)
+
+    class FakeFieldStore:
+        def __init__(self, value: int):
+            self.offsets = FakeOffsets(value)
+
+    async def shard_field_store(shard_name: str, field: str):
+        assert field == "data"
+        return FakeFieldStore(field_counts_by_shard[shard_name][field])
+
+    monkeypatch.setattr(cache, "_shard_field_store_async", shard_field_store)
+
+    offsets = cache.jagged_array_tree()["data"].offsets[0:4].read().result()
+
+    np.testing.assert_array_equal(offsets, np.array([3, 2, 5, 9], dtype=np.int64))
+    assert max_active_reads == len(shard_names)
 
 
 def test_full_end_to_end_cache():

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -199,6 +199,21 @@ def test_sharded_flat_field_offsets_read_shards_concurrently(monkeypatch):
     assert max_active_reads == len(shard_names)
 
 
+def test_sharded_cache_rejects_drifted_aggregate_field_counts():
+    ledger = CacheLedger(
+        total_num_rows=2,
+        shard_rows={"shard_0": 1, "shard_1": 1},
+        is_finished=True,
+        finished_shards=["shard_0", "shard_1"],
+        field_counts={"data": 4},
+        field_counts_by_shard={"shard_0": {"data": 2}, "shard_1": {"data": 3}},
+        layout=CACHE_LAYOUT_SHARDED,
+    )
+
+    with pytest.raises(ValueError, match="field count mismatch"):
+        TreeCache("/unused", {"data": np.array([0], dtype=np.int64)}, ledger)
+
+
 def test_full_end_to_end_cache():
     td = tempfile.TemporaryDirectory()
     with td as tmpdir:

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -199,6 +199,55 @@ def test_sharded_flat_field_offsets_read_shards_concurrently(monkeypatch):
     assert max_active_reads == len(shard_names)
 
 
+@pytest.mark.asyncio
+async def test_sharded_flat_field_offsets_share_in_flight_build(monkeypatch):
+    shard_names = ["shard_0", "shard_1", "shard_2"]
+    ledger = CacheLedger(
+        total_num_rows=3,
+        shard_rows={shard_name: 1 for shard_name in shard_names},
+        is_finished=True,
+        finished_shards=shard_names,
+        field_counts={"data": 9},
+        field_counts_by_shard={
+            "shard_0": {"data": 2},
+            "shard_1": {"data": 3},
+            "shard_2": {"data": 4},
+        },
+        layout=CACHE_LAYOUT_SHARDED,
+    )
+    cache = TreeCache("/unused", {"data": np.array([0], dtype=np.int64)}, ledger)
+    build_count = 0
+    build_started = asyncio.Event()
+    release_build = asyncio.Event()
+    expected_offsets = np.array([3, 2, 5, 9], dtype=np.int64)
+
+    async def build_offsets(field: str):
+        nonlocal build_count
+        assert field == "data"
+        build_count += 1
+        build_started.set()
+        await release_build.wait()
+        return expected_offsets
+
+    monkeypatch.setattr(cache, "_build_flat_field_offsets_async", build_offsets)
+
+    first = asyncio.create_task(cache._ensure_flat_field_offsets_async("data"))
+    await build_started.wait()
+    second = asyncio.create_task(cache._ensure_flat_field_offsets_async("data"))
+
+    await asyncio.sleep(0)
+    release_build.set()
+    first_offsets, second_offsets = await asyncio.gather(first, second)
+
+    np.testing.assert_array_equal(first_offsets, expected_offsets)
+    np.testing.assert_array_equal(second_offsets, expected_offsets)
+    assert build_count == 1
+
+    cached_offsets = await cache._ensure_flat_field_offsets_async("data")
+    np.testing.assert_array_equal(cached_offsets, expected_offsets)
+    assert build_count == 1
+
+
 def test_sharded_cache_rejects_drifted_aggregate_field_counts():
     ledger = CacheLedger(
         total_num_rows=2,

--- a/lib/levanter/tests/test_text.py
+++ b/lib/levanter/tests/test_text.py
@@ -26,6 +26,7 @@ from levanter.data.text import (
     PrebuiltLmDatasetFormat,
     UrlDatasetSourceConfig,
     build_lm_dataset_cache,
+    count_corpus_sizes,
     dataset_for_component,
     grug_lm_example_from_named,
     named_lm_example_from_grug,
@@ -52,6 +53,40 @@ def test_dont_blow_up_without_validation_set():
         Pos = hax.Axis("position", 10)
         # mostly just making sure this doesn't blow up
         assert config.validation_sets(Pos) == {}
+
+
+def test_count_corpus_sizes_handles_empty_train_cache(monkeypatch):
+    class EmptyCache:
+        def flat_field_length(self, _field):
+            return 0
+
+        async def async_flat_field_length(self, _field):
+            return 0
+
+        def flat_field_num_rows(self, _field):
+            return 0
+
+    config = LmDataConfig(
+        components={"empty": DatasetComponent()},
+        tokenizer="passthrough",
+        vocab_size=64,
+    )
+
+    def build_caches(_self, split):
+        if split == "train":
+            return {"empty": EmptyCache()}
+        return {}
+
+    monkeypatch.setattr(LmDataConfig, "build_caches", build_caches)
+
+    stats = count_corpus_sizes(config)
+
+    prefix = "data/stats/train/empty/"
+    assert stats[f"{prefix}total_tokens"] == 0
+    assert stats[f"{prefix}total_docs"] == 0
+    assert stats[f"{prefix}total_seqs"] == 0
+    assert f"{prefix}padding_fraction" not in stats
+    assert f"{prefix}truncation_fraction" not in stats
 
 
 def test_lm_example_handles_ignore_id():

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -31,7 +31,6 @@ from levanter.data.text import (
     preprocessor_for_format,
 )
 from levanter.store.cache import consolidate_shard_caches, write_levanter_cache
-from levanter.store.tree_store import TreeStore
 from levanter.tokenizers import MarinTokenizer, TokenizerBackend, load_tokenizer
 from rigging.filesystem import open_url, url_to_fs
 from rigging.log_setup import configure_logging
@@ -84,7 +83,6 @@ class TokenizeConfigBase(abc.ABC):
     """Base class for tokenize configs."""
 
     max_workers: int = 4096
-    cache_copy_max_workers: int = 128
     worker_resources: ResourceConfig = dataclasses.field(default_factory=lambda: ResourceConfig(ram="10g", disk="5g"))
 
     tokenizer_backend: TokenizerBackend = TokenizerBackend.HF
@@ -496,13 +494,11 @@ def tokenize(config: TokenizeConfigBase):
             shard_cache_paths=shard_paths,
             output_path=prefix,
             exemplar=exemplar,
-            copy_max_workers=config.cache_copy_max_workers,
         )
         consolidate_elapsed = time.monotonic() - consolidate_start
 
         total_elements = ledger.total_num_rows
-        store = TreeStore.open(exemplar, prefix, mode="r", cache_metadata=True)
-        total_tokens = store.tree["input_ids"].data_size if "input_ids" in store.tree else 0
+        total_tokens = ledger.field_counts.get("input_ids", 0)
 
         stats_path = os.path.join(prefix, ".stats.json")
         with open_url(stats_path, "w") as f:

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -30,7 +30,7 @@ from levanter.data.text import (
     UrlDatasetSourceConfig,
     preprocessor_for_format,
 )
-from levanter.store.cache import consolidate_shard_caches, write_levanter_cache
+from levanter.store.cache import consolidate_shard_cache_ledgers, write_levanter_cache
 from levanter.tokenizers import MarinTokenizer, TokenizerBackend, load_tokenizer
 from rigging.filesystem import open_url, url_to_fs
 from rigging.log_setup import configure_logging
@@ -490,7 +490,7 @@ def tokenize(config: TokenizeConfigBase):
 
         consolidate_start = time.monotonic()
         logger.info(f"Consolidating {len(shard_paths)} shards into {prefix}")
-        ledger = consolidate_shard_caches(
+        ledger = consolidate_shard_cache_ledgers(
             shard_cache_paths=shard_paths,
             output_path=prefix,
             exemplar=exemplar,

--- a/tests/test_consolidate_metadata.py
+++ b/tests/test_consolidate_metadata.py
@@ -1,7 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for ledger-only shard cache consolidation."""
+"""Tests for shard cache consolidation metadata."""
 
 import os
 import tempfile
@@ -10,11 +10,13 @@ import numpy as np
 import pytest
 from levanter.data.text.datasets import TokenSeqDataset
 from levanter.store.cache import (
+    CACHE_LAYOUT_CONSOLIDATED,
     CACHE_LAYOUT_SHARDED,
     CacheLedger,
     TreeCache,
     _expose_cache_rows,
     _relative_shard_path,
+    consolidate_shard_cache_ledgers,
     consolidate_shard_caches,
 )
 from levanter.store.tree_store import TreeStore
@@ -45,7 +47,7 @@ def _build_shard_cache(shard_path: str, shard_index: int) -> None:
     ledger._serialize_and_commit(shard_path)
 
 
-def test_consolidate_shard_caches_writes_only_ledger():
+def test_consolidate_shard_cache_ledgers_writes_only_ledger():
     with tempfile.TemporaryDirectory(prefix="levanter-test-consolidate-") as tmpdir:
         shard_paths = []
         for i in range(NUM_SHARDS):
@@ -53,7 +55,7 @@ def test_consolidate_shard_caches_writes_only_ledger():
             _build_shard_cache(shard_path, i)
             shard_paths.append(shard_path)
 
-        ledger = consolidate_shard_caches(shard_paths, tmpdir, EXEMPLAR_FLAT)
+        ledger = consolidate_shard_cache_ledgers(shard_paths, tmpdir, EXEMPLAR_FLAT)
 
         assert ledger.layout == CACHE_LAYOUT_SHARDED
         assert ledger.total_num_rows == NUM_SHARDS * ROWS_PER_SHARD
@@ -62,6 +64,30 @@ def test_consolidate_shard_caches_writes_only_ledger():
 
         with pytest.raises(FileNotFoundError):
             TreeStore.open(EXEMPLAR_FLAT, tmpdir, mode="r", cache_metadata=True)
+
+
+def test_consolidate_shard_caches_writes_materialized_tree_store():
+    with tempfile.TemporaryDirectory(prefix="levanter-test-consolidate-materialized-") as tmpdir:
+        output_path = os.path.join(tmpdir, "output")
+        shard_paths = []
+        for i in range(NUM_SHARDS):
+            shard_path = os.path.join(tmpdir, f"part-{i:05d}")
+            _build_shard_cache(shard_path, i)
+            shard_paths.append(shard_path)
+
+        ledger = consolidate_shard_caches(shard_paths, output_path, EXEMPLAR_FLAT)
+
+        assert ledger.layout == CACHE_LAYOUT_CONSOLIDATED
+        assert ledger.total_num_rows == NUM_SHARDS * ROWS_PER_SHARD
+        assert ledger.field_counts == {"input_ids": NUM_SHARDS * ROWS_PER_SHARD * ROW_WIDTH}
+
+        cache = TreeCache.load(output_path, EXEMPLAR_FLAT)
+        assert cache.store.tree["input_ids"].data_size == NUM_SHARDS * ROWS_PER_SHARD * ROW_WIDTH
+        np.testing.assert_array_equal(cache[0]["input_ids"], np.arange(ROW_WIDTH, dtype=np.int32))
+        np.testing.assert_array_equal(
+            cache[ROWS_PER_SHARD]["input_ids"],
+            np.arange(ROW_WIDTH, dtype=np.int32) + 100,
+        )
 
 
 def test_relative_shard_path_keeps_external_local_paths_absolute():
@@ -85,7 +111,7 @@ async def test_consolidate_external_shards_uses_absolute_paths():
             _build_shard_cache(shard_path, i)
             shard_paths.append(shard_path)
 
-        ledger = consolidate_shard_caches(shard_paths, output_path, EXEMPLAR_FLAT)
+        ledger = consolidate_shard_cache_ledgers(shard_paths, output_path, EXEMPLAR_FLAT)
 
         assert ledger.finished_shards == shard_paths
         cache = TreeCache.load(output_path, EXEMPLAR_FLAT)
@@ -162,7 +188,7 @@ async def test_token_seq_dataset_reads_sharded_cache():
             for row_index in range(ROWS_PER_SHARD):
                 all_tokens.extend(np.arange(ROW_WIDTH, dtype=np.int32) + i * 100 + row_index * 10)
 
-        consolidate_shard_caches(shard_paths, tmpdir, EXEMPLAR_FLAT)
+        consolidate_shard_cache_ledgers(shard_paths, tmpdir, EXEMPLAR_FLAT)
         cache = TreeCache.load(tmpdir, EXEMPLAR_FLAT)
         dataset = TokenSeqDataset(cache, SEQ_LEN)
 
@@ -184,7 +210,7 @@ async def test_tree_cache_get_batch_reads_sharded_rows():
             _build_shard_cache(shard_path, i)
             shard_paths.append(shard_path)
 
-        consolidate_shard_caches(shard_paths, tmpdir, EXEMPLAR_FLAT)
+        consolidate_shard_cache_ledgers(shard_paths, tmpdir, EXEMPLAR_FLAT)
         cache = TreeCache.load(tmpdir, EXEMPLAR_FLAT)
 
         batch = await cache.get_batch([0, ROWS_PER_SHARD, NUM_SHARDS * ROWS_PER_SHARD - 1])
@@ -206,7 +232,7 @@ async def test_tree_cache_get_batch_slice_uses_python_slice_semantics():
             _build_shard_cache(shard_path, i)
             shard_paths.append(shard_path)
 
-        consolidate_shard_caches(shard_paths, tmpdir, EXEMPLAR_FLAT)
+        consolidate_shard_cache_ledgers(shard_paths, tmpdir, EXEMPLAR_FLAT)
         cache = TreeCache.load(tmpdir, EXEMPLAR_FLAT)
 
         assert await cache.get_batch(slice(0, 0)) == []
@@ -222,7 +248,7 @@ def test_tree_cache_get_batch_sync_slice_uses_python_slice_semantics():
             _build_shard_cache(shard_path, i)
             shard_paths.append(shard_path)
 
-        consolidate_shard_caches(shard_paths, tmpdir, EXEMPLAR_FLAT)
+        consolidate_shard_cache_ledgers(shard_paths, tmpdir, EXEMPLAR_FLAT)
         cache = TreeCache.load(tmpdir, EXEMPLAR_FLAT)
 
         assert cache.get_batch_sync(slice(0, 0)) == []

--- a/tests/test_consolidate_metadata.py
+++ b/tests/test_consolidate_metadata.py
@@ -74,7 +74,8 @@ def test_relative_shard_path_keeps_external_local_paths_absolute():
         assert _relative_shard_path(output_path, external_shard) == external_shard
 
 
-def test_consolidate_external_shards_uses_absolute_paths():
+@pytest.mark.asyncio
+async def test_consolidate_external_shards_uses_absolute_paths():
     with tempfile.TemporaryDirectory(prefix="levanter-test-external-shards-") as tmpdir:
         source_dir = os.path.join(tmpdir, "source")
         output_path = os.path.join(tmpdir, "output")
@@ -88,7 +89,11 @@ def test_consolidate_external_shards_uses_absolute_paths():
 
         assert ledger.finished_shards == shard_paths
         cache = TreeCache.load(output_path, EXEMPLAR_FLAT)
-        assert cache.shard_path(shard_paths[0]) == shard_paths[0]
+        dataset = TokenSeqDataset(cache, SEQ_LEN)
+
+        batch = await dataset.get_batch([0])
+
+        np.testing.assert_array_equal(batch[0], np.arange(SEQ_LEN, dtype=np.int32))
 
 
 def test_sharded_cache_rejects_duplicate_shards():
@@ -168,3 +173,25 @@ async def test_token_seq_dataset_reads_sharded_cache():
         np.testing.assert_array_equal(batch[0], np.array(all_tokens[0:4], dtype=np.int32))
         np.testing.assert_array_equal(batch[1], np.array(all_tokens[12:16], dtype=np.int32))
         np.testing.assert_array_equal(batch[2], np.array(all_tokens[16:20], dtype=np.int32))
+
+
+@pytest.mark.asyncio
+async def test_tree_cache_get_batch_reads_sharded_rows():
+    with tempfile.TemporaryDirectory(prefix="levanter-test-sharded-tree-cache-") as tmpdir:
+        shard_paths = []
+        for i in range(NUM_SHARDS):
+            shard_path = os.path.join(tmpdir, f"part-{i:05d}")
+            _build_shard_cache(shard_path, i)
+            shard_paths.append(shard_path)
+
+        consolidate_shard_caches(shard_paths, tmpdir, EXEMPLAR_FLAT)
+        cache = TreeCache.load(tmpdir, EXEMPLAR_FLAT)
+
+        batch = await cache.get_batch([0, ROWS_PER_SHARD, NUM_SHARDS * ROWS_PER_SHARD - 1])
+
+        np.testing.assert_array_equal(batch[0]["input_ids"], np.arange(ROW_WIDTH, dtype=np.int32))
+        np.testing.assert_array_equal(batch[1]["input_ids"], np.arange(ROW_WIDTH, dtype=np.int32) + 100)
+        np.testing.assert_array_equal(
+            batch[2]["input_ids"],
+            np.arange(ROW_WIDTH, dtype=np.int32) + (NUM_SHARDS - 1) * 100 + (ROWS_PER_SHARD - 1) * 10,
+        )

--- a/tests/test_consolidate_metadata.py
+++ b/tests/test_consolidate_metadata.py
@@ -90,18 +90,29 @@ def test_consolidate_shard_caches_writes_materialized_tree_store():
         )
 
 
-def test_relative_shard_path_keeps_external_local_paths_absolute():
+def test_relative_shard_path_requires_child_paths():
     with tempfile.TemporaryDirectory(prefix="levanter-test-shard-paths-") as tmpdir:
         output_path = os.path.join(tmpdir, "output")
         internal_shard = os.path.join(output_path, "part-00000")
         external_shard = os.path.join(tmpdir, "source", "part-00000")
 
         assert _relative_shard_path(output_path, internal_shard) == "part-00000"
-        assert _relative_shard_path(output_path, external_shard) == external_shard
+        with pytest.raises(ValueError, match="not under output path"):
+            _relative_shard_path(output_path, external_shard)
+
+
+def test_relative_shard_path_requires_child_uri_paths():
+    output_path = "gs://bucket/cache/train"
+    internal_shard = "gs://bucket/cache/train/part-00000"
+    external_shard = "gs://bucket/other/train/part-00000"
+
+    assert _relative_shard_path(output_path, internal_shard) == "part-00000"
+    with pytest.raises(ValueError, match="not under output path"):
+        _relative_shard_path(output_path, external_shard)
 
 
 @pytest.mark.asyncio
-async def test_consolidate_external_shards_uses_absolute_paths():
+async def test_consolidate_external_shards_rejected():
     with tempfile.TemporaryDirectory(prefix="levanter-test-external-shards-") as tmpdir:
         source_dir = os.path.join(tmpdir, "source")
         output_path = os.path.join(tmpdir, "output")
@@ -111,15 +122,8 @@ async def test_consolidate_external_shards_uses_absolute_paths():
             _build_shard_cache(shard_path, i)
             shard_paths.append(shard_path)
 
-        ledger = consolidate_shard_cache_ledgers(shard_paths, output_path, EXEMPLAR_FLAT)
-
-        assert ledger.finished_shards == shard_paths
-        cache = TreeCache.load(output_path, EXEMPLAR_FLAT)
-        dataset = TokenSeqDataset(cache, SEQ_LEN)
-
-        batch = await dataset.get_batch([0])
-
-        np.testing.assert_array_equal(batch[0], np.arange(SEQ_LEN, dtype=np.int32))
+        with pytest.raises(ValueError, match="not under output path"):
+            consolidate_shard_cache_ledgers(shard_paths, output_path, EXEMPLAR_FLAT)
 
 
 def test_sharded_cache_rejects_duplicate_shards():
@@ -145,6 +149,22 @@ def test_sharded_cache_requires_row_counts_for_finished_shards():
     )
 
     with pytest.raises(ValueError, match="missing row count"):
+        TreeCache("unused", EXEMPLAR_FLAT, ledger)
+
+
+@pytest.mark.parametrize("shard_name", ["/tmp/part-00000", "gs://bucket/cache/part-00000"])
+def test_sharded_cache_rejects_absolute_shard_paths(shard_name: str):
+    ledger = CacheLedger(
+        total_num_rows=1,
+        shard_rows={shard_name: 1},
+        is_finished=True,
+        finished_shards=[shard_name],
+        field_counts={"input_ids": ROW_WIDTH},
+        field_counts_by_shard={shard_name: {"input_ids": ROW_WIDTH}},
+        layout=CACHE_LAYOUT_SHARDED,
+    )
+
+    with pytest.raises(ValueError, match="must be relative"):
         TreeCache("unused", EXEMPLAR_FLAT, ledger)
 
 

--- a/tests/test_consolidate_metadata.py
+++ b/tests/test_consolidate_metadata.py
@@ -1,153 +1,88 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright The Levanter Authors
-# SPDX-License-Identifier: Apache-2.0
+"""Tests for ledger-only shard cache consolidation."""
 
-"""Tests for consolidated metadata copy using a shared ts.Transaction (#4100)."""
-
-import asyncio
-import copy
-import operator
 import os
 import tempfile
 
-import jax
 import numpy as np
+import pytest
+from levanter.data.text.datasets import TokenSeqDataset
 from levanter.store.cache import (
+    CACHE_LAYOUT_SHARDED,
     CacheLedger,
-    _consolidate_metadata,
+    TreeCache,
     _expose_cache_rows,
-    _extend_cache_with_other_cache,
     consolidate_shard_caches,
 )
 from levanter.store.tree_store import TreeStore
 
-NUM_SHARDS = 8
-ROWS_PER_SHARD = 32
-ROW_WIDTH = 16
+NUM_SHARDS = 4
+ROWS_PER_SHARD = 3
+ROW_WIDTH = 5
+SEQ_LEN = 4
 
-# rank-1 only (no shapes metadata)
 EXEMPLAR_FLAT = {"input_ids": np.array([0], dtype=np.int32)}
 
-# multi-field with a rank-2 leaf (triggers shapes metadata)
-EXEMPLAR_SHAPED = {
-    "input_ids": np.array([0], dtype=np.int32),
-    "spans": np.zeros((0, 2), dtype=np.int32),
-}
 
-
-def _build_and_consolidate(exemplar, make_row) -> TreeStore:
-    """Build shards, copy data + metadata, return the merged store."""
-    with tempfile.TemporaryDirectory(prefix="levanter-test-consolidate-") as tmpdir:
-        shard_root = os.path.join(tmpdir, "shards")
-        os.makedirs(shard_root)
-
-        data_offset_tree = jax.tree.map(lambda _: 0, exemplar)
-        total_rows = 0
-        shard_infos = []
-
-        for i in range(NUM_SHARDS):
-            shard_path = os.path.join(shard_root, f"shard_{i}")
-            store = TreeStore.open(exemplar, shard_path, mode="w", cache_metadata=True)
-            store.extend([make_row(i) for _ in range(ROWS_PER_SHARD)])
-
-            shard_infos.append(
-                {
-                    "path": shard_path,
-                    "row_offset": total_rows,
-                    "data_offset_tree": copy.deepcopy(data_offset_tree),
-                    "ledger": CacheLedger(total_num_rows=ROWS_PER_SHARD, shard_rows={}, is_finished=True),
-                }
-            )
-            total_rows += ROWS_PER_SHARD
-
-            this_offsets = jax.tree.map(lambda x: x.data_size, store.tree)
-            data_offset_tree = jax.tree.map(operator.add, data_offset_tree, this_offsets)
-
-        dest_path = os.path.join(tmpdir, "dest")
-        TreeStore.open(exemplar, dest_path, mode="w", cache_metadata=True)
-
-        for info in shard_infos:
-            asyncio.run(
-                _extend_cache_with_other_cache(
-                    dest_path,
-                    info["path"],
-                    exemplar,
-                    info["data_offset_tree"],
-                    info["row_offset"],
-                )
-            )
-        asyncio.run(_consolidate_metadata(dest_path, exemplar, shard_infos))
-        _expose_cache_rows(dest_path, exemplar, total_rows)
-
-        merged = TreeStore.open(exemplar, dest_path, mode="r", cache_metadata=True)
-        assert len(merged) == NUM_SHARDS * ROWS_PER_SHARD
-
-        for i, info in enumerate(shard_infos):
-            row = merged[info["row_offset"]]
-            assert row["input_ids"][0] == i, f"shard {i} data mismatch"
-
-        return merged
-
-
-def test_consolidate_metadata_flat():
-    """Round-trip with a single rank-1 field (no shapes metadata)."""
-
-    def make_row(shard_index):
-        return {"input_ids": np.full((ROW_WIDTH,), shard_index, dtype=np.int32)}
-
-    _build_and_consolidate(EXEMPLAR_FLAT, make_row)
-
-
-def test_consolidate_metadata_shaped():
-    """Round-trip with multiple fields including rank-2 (exercises shapes metadata)."""
-
-    def make_row(shard_index):
-        return {
-            "input_ids": np.full((ROW_WIDTH,), shard_index, dtype=np.int32),
-            "spans": np.full((3, 2), shard_index, dtype=np.int32),
-        }
-
-    merged = _build_and_consolidate(EXEMPLAR_SHAPED, make_row)
-    row = merged[0]
-    assert row["spans"].shape == (3, 2)
-
-
-def _build_shard_cache(shard_path: str, exemplar, rows: list[dict]) -> None:
-    """Build a shard cache directory with data and a serialized ledger."""
-    store = TreeStore.open(exemplar, shard_path, mode="w", cache_metadata=True)
+def _build_shard_cache(shard_path: str, shard_index: int) -> None:
+    store = TreeStore.open(EXEMPLAR_FLAT, shard_path, mode="w", cache_metadata=True)
+    rows = [
+        {"input_ids": np.arange(ROW_WIDTH, dtype=np.int32) + shard_index * 100 + row_index * 10}
+        for row_index in range(ROWS_PER_SHARD)
+    ]
     store.extend(rows)
-    _expose_cache_rows(shard_path, exemplar, len(rows))
+    _expose_cache_rows(shard_path, EXEMPLAR_FLAT, len(rows))
     ledger = CacheLedger(
         total_num_rows=len(rows),
         shard_rows={os.path.basename(shard_path): len(rows)},
         is_finished=True,
         finished_shards=[os.path.basename(shard_path)],
-        field_counts={},
+        field_counts={"input_ids": ROWS_PER_SHARD * ROW_WIDTH},
     )
     ledger._serialize_and_commit(shard_path)
 
 
-def test_consolidate_shard_caches_end_to_end():
-    """Call consolidate_shard_caches directly, exercising the threaded pre-pass and Zephyr data copy."""
-    with tempfile.TemporaryDirectory(prefix="levanter-test-consolidate-e2e-") as tmpdir:
+def test_consolidate_shard_caches_writes_only_ledger():
+    with tempfile.TemporaryDirectory(prefix="levanter-test-consolidate-") as tmpdir:
         shard_paths = []
         for i in range(NUM_SHARDS):
-            shard_path = os.path.join(tmpdir, f"shard_{i}")
-            rows = [{"input_ids": np.full((ROW_WIDTH,), i, dtype=np.int32)} for _ in range(ROWS_PER_SHARD)]
-            _build_shard_cache(shard_path, EXEMPLAR_FLAT, rows)
+            shard_path = os.path.join(tmpdir, f"part-{i:05d}")
+            _build_shard_cache(shard_path, i)
             shard_paths.append(shard_path)
 
-        dest_path = os.path.join(tmpdir, "merged")
-        ledger = consolidate_shard_caches(shard_paths, dest_path, EXEMPLAR_FLAT, copy_max_workers=1)
+        ledger = consolidate_shard_caches(shard_paths, tmpdir, EXEMPLAR_FLAT)
 
+        assert ledger.layout == CACHE_LAYOUT_SHARDED
         assert ledger.total_num_rows == NUM_SHARDS * ROWS_PER_SHARD
-        assert ledger.is_finished
+        assert ledger.field_counts == {"input_ids": NUM_SHARDS * ROWS_PER_SHARD * ROW_WIDTH}
+        assert ledger.finished_shards == [os.path.basename(path) for path in shard_paths]
 
-        merged = TreeStore.open(EXEMPLAR_FLAT, dest_path, mode="r", cache_metadata=True)
-        assert len(merged) == NUM_SHARDS * ROWS_PER_SHARD
+        with pytest.raises(FileNotFoundError):
+            TreeStore.open(EXEMPLAR_FLAT, tmpdir, mode="r", cache_metadata=True)
 
+
+@pytest.mark.asyncio
+async def test_token_seq_dataset_reads_sharded_cache():
+    with tempfile.TemporaryDirectory(prefix="levanter-test-sharded-read-") as tmpdir:
+        shard_paths = []
+        all_tokens = []
         for i in range(NUM_SHARDS):
-            row = merged[i * ROWS_PER_SHARD]
-            assert row["input_ids"][0] == i, f"shard {i} data mismatch"
+            shard_path = os.path.join(tmpdir, f"part-{i:05d}")
+            _build_shard_cache(shard_path, i)
+            shard_paths.append(shard_path)
+            for row_index in range(ROWS_PER_SHARD):
+                all_tokens.extend(np.arange(ROW_WIDTH, dtype=np.int32) + i * 100 + row_index * 10)
+
+        consolidate_shard_caches(shard_paths, tmpdir, EXEMPLAR_FLAT)
+        cache = TreeCache.load(tmpdir, EXEMPLAR_FLAT)
+        dataset = TokenSeqDataset(cache, SEQ_LEN)
+
+        assert await dataset.async_len() == len(all_tokens) // SEQ_LEN
+
+        batch = await dataset.get_batch([0, 3, 4])
+
+        np.testing.assert_array_equal(batch[0], np.array(all_tokens[0:4], dtype=np.int32))
+        np.testing.assert_array_equal(batch[1], np.array(all_tokens[12:16], dtype=np.int32))
+        np.testing.assert_array_equal(batch[2], np.array(all_tokens[16:20], dtype=np.int32))

--- a/tests/test_consolidate_metadata.py
+++ b/tests/test_consolidate_metadata.py
@@ -212,3 +212,19 @@ async def test_tree_cache_get_batch_slice_uses_python_slice_semantics():
         assert await cache.get_batch(slice(0, 0)) == []
         with pytest.raises(ValueError, match="slice step cannot be zero"):
             await cache.get_batch(slice(None, None, 0))
+
+
+def test_tree_cache_get_batch_sync_slice_uses_python_slice_semantics():
+    with tempfile.TemporaryDirectory(prefix="levanter-test-sharded-get-batch-sync-slice-") as tmpdir:
+        shard_paths = []
+        for i in range(NUM_SHARDS):
+            shard_path = os.path.join(tmpdir, f"part-{i:05d}")
+            _build_shard_cache(shard_path, i)
+            shard_paths.append(shard_path)
+
+        consolidate_shard_caches(shard_paths, tmpdir, EXEMPLAR_FLAT)
+        cache = TreeCache.load(tmpdir, EXEMPLAR_FLAT)
+
+        assert cache.get_batch_sync(slice(0, 0)) == []
+        with pytest.raises(ValueError, match="slice step cannot be zero"):
+            cache.get_batch_sync(slice(None, None, 0))

--- a/tests/test_consolidate_metadata.py
+++ b/tests/test_consolidate_metadata.py
@@ -195,3 +195,20 @@ async def test_tree_cache_get_batch_reads_sharded_rows():
             batch[2]["input_ids"],
             np.arange(ROW_WIDTH, dtype=np.int32) + (NUM_SHARDS - 1) * 100 + (ROWS_PER_SHARD - 1) * 10,
         )
+
+
+@pytest.mark.asyncio
+async def test_tree_cache_get_batch_slice_uses_python_slice_semantics():
+    with tempfile.TemporaryDirectory(prefix="levanter-test-sharded-get-batch-slice-") as tmpdir:
+        shard_paths = []
+        for i in range(NUM_SHARDS):
+            shard_path = os.path.join(tmpdir, f"part-{i:05d}")
+            _build_shard_cache(shard_path, i)
+            shard_paths.append(shard_path)
+
+        consolidate_shard_caches(shard_paths, tmpdir, EXEMPLAR_FLAT)
+        cache = TreeCache.load(tmpdir, EXEMPLAR_FLAT)
+
+        assert await cache.get_batch(slice(0, 0)) == []
+        with pytest.raises(ValueError, match="slice step cannot be zero"):
+            await cache.get_batch(slice(None, None, 0))

--- a/tests/test_consolidate_metadata.py
+++ b/tests/test_consolidate_metadata.py
@@ -8,6 +8,7 @@ import tempfile
 
 import numpy as np
 import pytest
+from levanter.data.packing import GreedyPrepackedDataset
 from levanter.data.text.datasets import TokenSeqDataset
 from levanter.store.cache import (
     CACHE_LAYOUT_CONSOLIDATED,
@@ -219,6 +220,56 @@ async def test_token_seq_dataset_reads_sharded_cache():
         np.testing.assert_array_equal(batch[0], np.array(all_tokens[0:4], dtype=np.int32))
         np.testing.assert_array_equal(batch[1], np.array(all_tokens[12:16], dtype=np.int32))
         np.testing.assert_array_equal(batch[2], np.array(all_tokens[16:20], dtype=np.int32))
+
+
+@pytest.mark.asyncio
+async def test_greedy_prepacked_dataset_reads_sharded_cache():
+    with tempfile.TemporaryDirectory(prefix="levanter-test-sharded-packing-") as tmpdir:
+        shard_paths = []
+        for i in range(NUM_SHARDS):
+            shard_path = os.path.join(tmpdir, f"part-{i:05d}")
+            _build_shard_cache(shard_path, i)
+            shard_paths.append(shard_path)
+
+        consolidate_shard_cache_ledgers(shard_paths, tmpdir, EXEMPLAR_FLAT)
+        cache = TreeCache.load(tmpdir, EXEMPLAR_FLAT)
+        packed = GreedyPrepackedDataset(
+            cache.jagged_array_tree(),
+            max_length=2 * ROW_WIDTH,
+            max_segments_per_example=2,
+            pad_with_zeros=True,
+            slice_strategy="raise",
+        )
+
+        batch = await packed.get_batch([0, 1])
+
+        np.testing.assert_array_equal(
+            batch[0][0]["input_ids"],
+            np.concatenate(
+                [
+                    np.arange(ROW_WIDTH, dtype=np.int32),
+                    np.arange(ROW_WIDTH, dtype=np.int32) + 10,
+                ]
+            ),
+        )
+        np.testing.assert_array_equal(
+            batch[0][1]["input_ids"],
+            np.array([0] * ROW_WIDTH + [1] * ROW_WIDTH),
+        )
+
+        np.testing.assert_array_equal(
+            batch[1][0]["input_ids"],
+            np.concatenate(
+                [
+                    np.arange(ROW_WIDTH, dtype=np.int32) + 20,
+                    np.arange(ROW_WIDTH, dtype=np.int32) + 100,
+                ]
+            ),
+        )
+        np.testing.assert_array_equal(
+            batch[1][1]["input_ids"],
+            np.array([2] * ROW_WIDTH + [3] * ROW_WIDTH),
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_consolidate_metadata.py
+++ b/tests/test_consolidate_metadata.py
@@ -14,6 +14,7 @@ from levanter.store.cache import (
     CacheLedger,
     TreeCache,
     _expose_cache_rows,
+    _relative_shard_path,
     consolidate_shard_caches,
 )
 from levanter.store.tree_store import TreeStore
@@ -61,6 +62,87 @@ def test_consolidate_shard_caches_writes_only_ledger():
 
         with pytest.raises(FileNotFoundError):
             TreeStore.open(EXEMPLAR_FLAT, tmpdir, mode="r", cache_metadata=True)
+
+
+def test_relative_shard_path_keeps_external_local_paths_absolute():
+    with tempfile.TemporaryDirectory(prefix="levanter-test-shard-paths-") as tmpdir:
+        output_path = os.path.join(tmpdir, "output")
+        internal_shard = os.path.join(output_path, "part-00000")
+        external_shard = os.path.join(tmpdir, "source", "part-00000")
+
+        assert _relative_shard_path(output_path, internal_shard) == "part-00000"
+        assert _relative_shard_path(output_path, external_shard) == external_shard
+
+
+def test_consolidate_external_shards_uses_absolute_paths():
+    with tempfile.TemporaryDirectory(prefix="levanter-test-external-shards-") as tmpdir:
+        source_dir = os.path.join(tmpdir, "source")
+        output_path = os.path.join(tmpdir, "output")
+        shard_paths = []
+        for i in range(NUM_SHARDS):
+            shard_path = os.path.join(source_dir, f"part-{i:05d}")
+            _build_shard_cache(shard_path, i)
+            shard_paths.append(shard_path)
+
+        ledger = consolidate_shard_caches(shard_paths, output_path, EXEMPLAR_FLAT)
+
+        assert ledger.finished_shards == shard_paths
+        cache = TreeCache.load(output_path, EXEMPLAR_FLAT)
+        assert cache.shard_path(shard_paths[0]) == shard_paths[0]
+
+
+def test_sharded_cache_rejects_duplicate_shards():
+    ledger = CacheLedger(
+        total_num_rows=2,
+        shard_rows={"part-00000": 1},
+        is_finished=True,
+        finished_shards=["part-00000", "part-00000"],
+        layout=CACHE_LAYOUT_SHARDED,
+    )
+
+    with pytest.raises(ValueError, match="duplicate shard"):
+        TreeCache("unused", EXEMPLAR_FLAT, ledger)
+
+
+def test_sharded_cache_requires_row_counts_for_finished_shards():
+    ledger = CacheLedger(
+        total_num_rows=1,
+        shard_rows={},
+        is_finished=True,
+        finished_shards=["part-00000"],
+        layout=CACHE_LAYOUT_SHARDED,
+    )
+
+    with pytest.raises(ValueError, match="missing row count"):
+        TreeCache("unused", EXEMPLAR_FLAT, ledger)
+
+
+def test_sharded_cache_rejects_total_row_mismatch():
+    ledger = CacheLedger(
+        total_num_rows=2,
+        shard_rows={"part-00000": 1},
+        is_finished=True,
+        finished_shards=["part-00000"],
+        layout=CACHE_LAYOUT_SHARDED,
+    )
+
+    with pytest.raises(ValueError, match="row count mismatch"):
+        TreeCache("unused", EXEMPLAR_FLAT, ledger)
+
+
+@pytest.mark.asyncio
+async def test_empty_sharded_token_seq_len_is_zero():
+    ledger = CacheLedger(
+        total_num_rows=0,
+        shard_rows={},
+        is_finished=True,
+        finished_shards=[],
+        layout=CACHE_LAYOUT_SHARDED,
+    )
+    cache = TreeCache("unused", EXEMPLAR_FLAT, ledger)
+    dataset = TokenSeqDataset(cache, SEQ_LEN)
+
+    assert await dataset.async_len() == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Related to #4445, rework of #4814

Turns out reading 1000s of ledger metadata has a big overhead. So we do need to consolidate that, and skip only the data files.