### PR TITLE
[datakit] stamp partition_id on normalize output

### DIFF
--- a/docs/design/2355_datakit.md
+++ b/docs/design/2355_datakit.md
@@ -27,6 +27,7 @@ Convert raw data into the **datakit standard format**:
 * **Mandatory columns**:
   * `id` \- unique document identifier (see [ID Column](#id-column) below)
   * `text` \- primary text content \- we enforce UTF-8
+  * `partition_id` \- int, the row's output shard at normalize time. Stamped at write time and preserved by every downstream stage. Shufflers (e.g. fuzzy/exact dedup) use it as the `group_by` key to land output co-partitioned with the source. The shard count itself lives on the artifact (`NormalizedData.num_partitions`), not on every row.
 * **Arbitrary additional columns**: any fields present in the raw data are preserved
 * **Directory structure**: preserver original directory structure
 * **Partition structure**: partition layout from the source does NOT need to be preserved at this point \- and in most cases it will not be
@@ -93,7 +94,7 @@ This means:
 * All downstream stages (embed, classify, dedup) preserve this structure \- same shard count, same ID ranges per shard
 * Consolidation can use Zephyr's `sorted_merge_join` without a costly `group_by` shuffle
 
-This is enforced by convention: each processing stage reads source partitions 1:1 and writes output partitions with matching structure.
+For per-document stages (embed, per-doc classify) this falls out of reading source partitions 1:1. For stages that shuffle globally (fuzzy/exact dedup, anything graph-structured), records carry their `partition_id` through the shuffle and the writer does `group_by(partition_id)` to land output back in matching files — so co-partitioning is enforced by data, not by filename arithmetic.
 
 ## Attributes Datasets {#attributes-datasets}
 

--- a/lib/marin/src/marin/datakit/__init__.py
+++ b/lib/marin/src/marin/datakit/__init__.py
@@ -1,2 +1,24 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
+
+"""Datakit: composable pipeline stages with a standard Parquet format.
+
+The standard format pins three mandatory columns on every normalized record:
+``id`` (deterministic content hash), ``text`` (UTF-8 primary content), and
+``partition_id`` (int, the output shard the row was written to at normalize
+time). The shard count itself lives on the artifact, not the row.
+
+Downstream stages preserve ``partition_id`` and use it as the ``group_by`` key
+when a global shuffle (e.g. cross-document dedup) needs to land output back
+co-partitioned with the source.
+"""
+
+
+def partition_filename(partition_id: int, num_partitions: int) -> str:
+    """Return the standard datakit partition filename for the given index.
+
+    Datakit shards follow ``part-NNNNN-of-MMMMM.parquet`` naming. Routing
+    output through this helper keeps shuffler-written attribute files
+    discoverable by consolidate's filename-based join.
+    """
+    return f"part-{partition_id:05d}-of-{num_partitions:05d}.parquet"

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -5,9 +5,14 @@
 
 Reads raw files (JSONL, Parquet, etc.) discovered recursively under a single
 input directory, transforms each record into the standard schema (``id``,
-``text``, plus all original columns), deduplicates by content, sorts by ``id``
-within each partition, and writes Parquet output with
-``part-{shard}-of-{total}`` naming.
+``text``, ``partition_id``, plus all original columns), deduplicates by
+content, sorts by ``id`` within each partition, and writes Parquet output
+with ``part-{shard}-of-{total}`` naming.
+
+``partition_id`` (int) is stamped at write time and equals the row's output
+shard index. The shard count itself lives on the artifact
+(``NormalizedData.num_partitions``) — downstream stages use the column as the
+``group_by`` key for global shuffles and the field for filename construction.
 
 All discovered files are merged into a single output: main records land in
 ``<output_path>/outputs/main/`` and (when dedup is enabled) duplicates land in
@@ -32,6 +37,7 @@ from zephyr import Dataset, ShardInfo, ZephyrContext, counters, write_parquet_fi
 from zephyr.readers import SUPPORTED_EXTENSIONS, load_file
 from zephyr.writers import ThreadedBatchWriter
 
+from marin.datakit import partition_filename
 from marin.execution.step_spec import StepSpec
 
 logger = logging.getLogger(__name__)
@@ -69,12 +75,19 @@ class NormalizedData(BaseModel):
     Attributes:
         main_output_dir: Directory containing the main output Parquet files.
         dup_output_dir: Directory containing the duplicate side output Parquet files.
+        num_partitions: Number of output shards. Matches the ``-of-NNNNN``
+            suffix in filenames and the ``partition_id`` column's value range
+            (``0 <= partition_id < num_partitions``). Downstream shufflers
+            need this to construct co-partitioned filenames without globbing.
+            ``None`` on legacy ``v1`` artifacts that pre-date the field;
+            always populated on ``v2``+ writes.
         counters: Aggregated zephyr counters.
     """
 
-    version: str = "v1"
+    version: str = "v2"
     main_output_dir: str
     dup_output_dir: str
+    num_partitions: int | None = None
     counters: dict[str, int]
 
 
@@ -260,8 +273,9 @@ def _make_split_writer(
         shard: ShardInfo,
     ) -> Iterator[dict[str, dict[str, Any]]]:
         # NOTE: we could add support for split_existing - but we intentionally don't
-        main_path = f"{output_dir}/outputs/main/part-{shard.shard_idx:05d}-of-{shard.total_shards:05d}.parquet"
-        dup_path = f"{output_dir}/outputs/dups/part-{shard.shard_idx:05d}-of-{shard.total_shards:05d}.parquet"
+        filename = partition_filename(shard.shard_idx, shard.total_shards)
+        main_path = f"{output_dir}/outputs/main/{filename}"
+        dup_path = f"{output_dir}/outputs/dups/{filename}"
 
         # Results are populated by each writer thread. Safe to read only after
         # the ThreadedBatchWriter context exits (which joins the thread).
@@ -278,6 +292,9 @@ def _make_split_writer(
             ThreadedBatchWriter(write_to(dup_path, "dup")) as dup_writer,
         ):
             for item in records:
+                # Stamp partition_id at the writer so it reflects the actual
+                # output shard, not anything inferred upstream of group_by.
+                item.data["partition_id"] = shard.shard_idx
                 if isinstance(item, MainOutput):
                     counters.increment("normalize/unique_records_out")
                     main_writer.submit(item.data)
@@ -444,6 +461,7 @@ def normalize_to_parquet(
     return NormalizedData(
         main_output_dir=os.path.join(output_path, "outputs/main"),
         dup_output_dir=os.path.join(output_path, "outputs/dups"),
+        num_partitions=num_shards,
         counters=counters_dict,
     )
 
@@ -463,6 +481,7 @@ def normalize_step(
     relative_input_path: str | None = None,
     file_extensions: tuple[str, ...] | None = None,
     dedup_mode: DedupMode = DedupMode.EXACT,
+    version: str | None = None,
 ) -> StepSpec:
     """Create a StepSpec that normalizes downloaded data to Parquet.
 
@@ -485,6 +504,14 @@ def normalize_step(
             ``zephyr.readers.load_file``.
         dedup_mode: How to deduplicate records within each output shard.
             Defaults to ``DedupMode.EXACT``; use ``DedupMode.NONE`` to skip.
+        version: Opt-in cache-invalidation knob. When set (e.g. ``"v2"``),
+            the value is included in ``hash_attrs`` so the step's ``hash_id``
+            differs from any prior cached run. Use this when you need
+            ``partition_id``-aware downstream consumers and are willing to
+            recompute. Default ``None`` keeps cache identity with pre-v2
+            step specs — ``normalize_to_parquet`` itself always stamps
+            ``partition_id``, so existing caches stay hits but new runs still
+            produce v2 output.
     """
     if relative_input_path:
         # ``os.path.join`` collapses redundant separators when ``download.output_path``
@@ -494,6 +521,20 @@ def normalize_step(
         resolved_input = os.path.join(download.output_path, relative_input_path)
     else:
         resolved_input = download.output_path
+
+    hash_attrs: dict[str, Any] = {
+        "text_field": text_field,
+        "id_field": id_field,
+        "target_partition_bytes": target_partition_bytes,
+        "max_whitespace_run_chars": max_whitespace_run_chars,
+        "relative_input_path": relative_input_path,
+        "file_extensions": file_extensions,
+        "dedup_mode": dedup_mode,
+    }
+    # Only include the version key when the caller explicitly opts in, so
+    # default callers preserve their existing hash_id and cache hits.
+    if version is not None:
+        hash_attrs["version"] = version
 
     return StepSpec(
         name=name,
@@ -510,15 +551,7 @@ def normalize_step(
             dedup_mode=dedup_mode,
         ),
         deps=[download],
-        hash_attrs={
-            "text_field": text_field,
-            "id_field": id_field,
-            "target_partition_bytes": target_partition_bytes,
-            "max_whitespace_run_chars": max_whitespace_run_chars,
-            "relative_input_path": relative_input_path,
-            "file_extensions": file_extensions,
-            "dedup_mode": dedup_mode,
-        },
+        hash_attrs=hash_attrs,
         output_path_prefix=output_path_prefix,
         override_output_path=override_output_path,
     )

--- a/tests/datakit/test_normalize.py
+++ b/tests/datakit/test_normalize.py
@@ -5,11 +5,13 @@
 
 import gzip
 import json
+import re
 from pathlib import Path
 
 import pyarrow.parquet as pq
 import pytest
 from fray import LocalClient, set_current_client
+from marin.datakit import partition_filename
 from marin.datakit.normalize import generate_id, normalize_to_parquet
 
 
@@ -215,6 +217,94 @@ def test_whitespace_compaction(tmp_path: Path, write_jsonl_gz):
     assert by_source["pathological"]["id"] == generate_id("before" + " " * 100 + "after")
     # Normal docs are untouched
     assert by_source["normal"]["text"] == "Hello world"
+
+
+def test_partition_id_stamped_single_shard(tmp_path: Path, write_jsonl_gz):
+    """Every output row carries an int partition_id; with a single shard it's 0."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+
+    write_jsonl_gz(
+        input_dir / "data.jsonl.gz",
+        [{"text": "doc one"}, {"text": "doc two"}, {"text": "doc three"}],
+    )
+
+    result = normalize_to_parquet(input_path=str(input_dir), output_path=str(output_dir))
+
+    assert result.num_partitions == 1
+    rows = _read_all_parquet(output_dir)
+    assert len(rows) == 3
+    assert all(isinstance(r["partition_id"], int) for r in rows)
+    assert all(r["partition_id"] == 0 for r in rows)
+
+    # Filename matches the helper's output and the single partition.
+    main_files = sorted((output_dir / "outputs" / "main").glob("*.parquet"))
+    assert [p.name for p in main_files] == [partition_filename(0, 1)]
+
+
+def test_partition_id_matches_filename_across_shards(tmp_path: Path, write_jsonl_gz):
+    """With multiple output shards, every row's partition_id matches its filename suffix."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+
+    # Varied per-record content so xxh3_128 distributes ids across shards;
+    # tiny target_partition_bytes forces multi-shard output.
+    records = [{"text": f"document {i} with unique content payload {i * 7919}"} for i in range(50)]
+    write_jsonl_gz(input_dir / "data.jsonl.gz", records)
+
+    result = normalize_to_parquet(
+        input_path=str(input_dir),
+        output_path=str(output_dir),
+        target_partition_bytes=50,
+    )
+
+    assert result.num_partitions > 1
+
+    main_dir = output_dir / "outputs" / "main"
+    files = sorted(main_dir.glob("*.parquet"))
+    assert files, "expected at least one output file"
+
+    seen_partition_ids: set[int] = set()
+    filename_re = re.compile(r"part-(\d+)-of-(\d+)\.parquet")
+    for pf in files:
+        m = filename_re.match(pf.name)
+        assert m, f"unexpected filename: {pf.name}"
+        expected_id = int(m.group(1))
+        assert int(m.group(2)) == result.num_partitions
+
+        rows = pq.read_table(str(pf)).to_pylist()
+        for row in rows:
+            assert row["partition_id"] == expected_id
+        if rows:
+            seen_partition_ids.add(expected_id)
+
+    # Sanity: hash distribution actually spread records across partitions.
+    assert len(seen_partition_ids) > 1
+
+
+def test_partition_id_stamped_on_dup_side_output(tmp_path: Path, write_jsonl_gz):
+    """Duplicate records also receive partition_id matching their dup-shard filename."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+
+    write_jsonl_gz(
+        input_dir / "data.jsonl.gz",
+        [
+            {"text": "Duplicate text", "source": "first"},
+            {"text": "Duplicate text", "source": "second"},
+            {"text": "Unique text"},
+        ],
+    )
+
+    normalize_to_parquet(input_path=str(input_dir), output_path=str(output_dir))
+
+    dup_files = sorted((output_dir / "outputs" / "dups").glob("*.parquet"))
+    assert dup_files, "expected at least one dup-side output"
+    dup_rows: list[dict] = []
+    for pf in dup_files:
+        dup_rows.extend(pq.read_table(str(pf)).to_pylist())
+    assert len(dup_rows) == 1
+    assert dup_rows[0]["partition_id"] == 0
 
 
 def test_no_input_files_raises(tmp_path: Path):


### PR DESCRIPTION
* part of https://github.com/marin-community/marin/issues/2355
* stamp `partition_id: int` on every normalize row equal to the row's output shard idx, lift `num_partitions` onto `NormalizedData` (optional `int | None`; `None` on legacy `v1` artifacts so cached pre-v2 outputs still load)
* `partition_filename(partition_id, num_partitions) -> str` helper added at `marin.datakit` returning the existing `part-NNNNN-of-MMMMM.parquet` convention; future shufflers can route writes through it
* opt-in `version` kwarg on `normalize_step` — when set (e.g. `version="v2"`), included in `hash_attrs` so the step's `hash_id` differs from any prior cached run; default `None` preserves cache identity with pre-v2 step specs [^1]
* fuzzy/exact dedup not modified in this PR — partition_id-aware shuffler routing follows in a separate change

[^1]: `normalize_to_parquet` always stamps `partition_id`, so even with `version=None` new runs produce v2 output; cache hits keep returning their old (pre-`partition_id`) parquets, which is fine until a downstream consumer needs the column