### PR TITLE
tokenize: split into datakit attribute and store stages

### DIFF
--- a/lib/marin/src/marin/processing/tokenize/_core.py
+++ b/lib/marin/src/marin/processing/tokenize/_core.py
@@ -1,0 +1,314 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared internals for tokenization.
+
+Used by:
+* :func:`marin.processing.tokenize.tokenize.tokenize` — legacy raw → Levanter store path.
+* :func:`marin.processing.tokenize.attributes.tokenize_attributes` — datakit Stage A
+  (NormalizedData → attribute parquet).
+* :func:`marin.processing.tokenize.store_builder.build_from_datasets` — datakit Stage B
+  (tokenized records → Levanter store).
+
+Public API lives in those modules; helpers here are package-private.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+from collections.abc import Iterator, Mapping, Sequence
+
+import braceexpand
+import fsspec
+import pyarrow.parquet as pq
+from levanter.data._preprocessor import BatchProcessor
+from levanter.data.text import LmDatasetFormatBase, preprocessor_for_format
+from levanter.tokenizers import MarinTokenizer, load_tokenizer
+from rigging.filesystem import url_to_fs
+from zephyr import Dataset, zephyr_worker_ctx
+from zephyr.dataset import FileEntry
+from zephyr.readers import InputFileSpec
+
+from marin.datakit.normalize import generate_id
+from marin.utils import fsspec_isdir
+
+logger = logging.getLogger(__name__)
+
+MIN_GROUP_BYTES = 100_000_000  # 100 MB floor to avoid degenerate tiny shards
+# Empirical upper bound on the zephyr window size (see
+# https://github.com/marin-community/marin/issues/2829#issuecomment-3963661943).
+_MAX_WINDOW_SIZE = 64
+
+_TOKENIZE_EXTENSIONS = ["json.{gz,zst,zstd}", "jsonl.{gz,zst,zstd}", "parquet"]
+
+# NOTE(chris): Marin's `default_download` writes a `provenance.json` sidecar next to
+# downloaded HF data. Downstream tokenize jobs glob those directories and must
+# exclude sidecars so we don't train on provenance records.
+_MARIN_SIDECAR_NAMES = frozenset({"provenance.json"})
+
+
+def avg_parquet_row_group_rows(path: str) -> int | None:
+    """Return the mean rows-per-row-group from ``path``.
+
+    Returns ``None`` if the file has no row groups (empty parquet footer).
+    """
+    fs, resolved = url_to_fs(path)
+    with fs.open(resolved, "rb") as f:
+        meta = pq.ParquetFile(f).metadata
+    if meta.num_row_groups == 0:
+        return None
+    return max(1, meta.num_rows // meta.num_row_groups)
+
+
+def compute_target_group_bytes(total_input_bytes: int, max_workers: int) -> int:
+    """Compute target group size to produce approximately ``max_workers`` groups.
+
+    Applies a floor of ``MIN_GROUP_BYTES`` to avoid degenerate tiny shards.
+    """
+    return max(total_input_bytes // max_workers, MIN_GROUP_BYTES)
+
+
+def drop_sidecars(files: list[FileEntry]) -> list[FileEntry]:
+    return [f for f in files if os.path.basename(f.path) not in _MARIN_SIDECAR_NAMES]
+
+
+def glob_with_sizes(patterns: list[str]) -> list[FileEntry]:
+    """Glob patterns and return FileEntry objects (spec + size).
+
+    Uses fsspec ``glob(detail=True)`` which returns file metadata from the same
+    list-objects API call — no per-file stat RPCs needed. Works for gs://, hf://, s3://, local.
+    """
+    results: list[FileEntry] = []
+    for pattern in patterns:
+        pattern = re.sub(r"(?<!:)//+", "/", pattern)
+        fs, _ = url_to_fs(pattern)
+        protocol = fsspec.core.split_protocol(pattern)[0]
+        for expanded in braceexpand.braceexpand(pattern):
+            detail = fs.glob(expanded, detail=True)
+            for path, info in detail.items():
+                full = f"{protocol}://{path}" if protocol else path
+                results.append(FileEntry(spec=InputFileSpec(path=full), size=info.get("size", 0)))
+    return results
+
+
+def expand_tokenize_paths(input_paths: list[str]) -> list[str]:
+    """Expand input paths into glob patterns for tokenizable file types.
+
+    Directories get expanded to recursive globs for each supported extension.
+    Concrete paths/patterns pass through unchanged.
+    """
+    patterns: list[str] = []
+    for path in input_paths:
+        assert path != "/"
+        if path.endswith("/") or fsspec_isdir(path):
+            logger.info(f"Getting all {_TOKENIZE_EXTENSIONS} files in {path}")
+            for ex in _TOKENIZE_EXTENSIONS:
+                patterns.append(os.path.join(path, f"**/*.{ex}"))
+        else:
+            patterns.append(path)
+    return patterns
+
+
+def bundle_files_by_size(files: list[FileEntry], max_bytes: int) -> Iterator[list[str]]:
+    """Bundle files into groups, with each group having a total size less than ``max_bytes``."""
+    current_group: list[str] = []
+    current_size = 0
+
+    for f in files:
+        if current_size + f.size >= max_bytes and current_group:
+            yield current_group
+            current_group = []
+            current_size = 0
+        current_group.append(f.path)
+        current_size += f.size
+
+    if current_group:
+        yield current_group
+
+
+def attach_id(record: dict, text_field: str = "text") -> dict:
+    """Ensure record has an ``id`` field.
+
+    If ``id`` is already present and non-null, leave the record unchanged.
+    Otherwise, generate a deterministic xxh3_128 id via
+    :func:`marin.datakit.normalize.generate_id` from ``record[text_field]``,
+    falling back to a JSON serialization of the record if ``text_field`` is
+    absent.
+
+    Datakit-normalized inputs always carry ``id`` and skip the hashing branch.
+    """
+    if record.get("id") is not None:
+        return record
+    if text_field in record and record[text_field] is not None:
+        return {**record, "id": generate_id(str(record[text_field]))}
+    return {**record, "id": generate_id(json.dumps(record, sort_keys=True, default=str))}
+
+
+class IdPreservingPreprocessor:
+    """Wrap a Levanter ``BatchProcessor`` to thread input ``id`` onto each output.
+
+    Levanter's ``BatchProcessor`` interface explicitly allows non-1:1 input→output
+    (see :class:`levanter.data._preprocessor.BatchProcessor`). All currently used
+    processors (``BatchTokenizer``, ``ChatProcessor``, ``PrebuiltCacheProcessor``,
+    ``PreferenceChatProcessor``) are 1:1, but a future packing/SFT-splitting
+    processor would silently misalign ids if we naively zipped. This wrapper
+    asserts the 1:1 invariant so misalignment fails loudly.
+    """
+
+    def __init__(self, inner: BatchProcessor):
+        self.inner = inner
+
+    def __call__(self, batch: Sequence[dict]) -> list[dict]:
+        outputs = self.inner(batch)
+        # BatchResult is Sequence[U] | Mapping[str, Sequence] (struct-of-arrays)
+        if isinstance(outputs, Mapping):
+            keys = list(outputs.keys())
+            n_out = len(outputs[keys[0]]) if keys else 0
+            outputs_list: list[dict] = [{k: outputs[k][i] for k in keys} for i in range(n_out)]
+        else:
+            outputs_list = list(outputs)
+            n_out = len(outputs_list)
+
+        if n_out != len(batch):
+            raise RuntimeError(
+                f"IdPreservingPreprocessor: 1:1 input→output expected, got "
+                f"{len(batch)} input → {n_out} output records from "
+                f"{type(self.inner).__name__}. id alignment cannot be preserved; "
+                "if this processor packs or splits records, route ids via a custom path."
+            )
+
+        return [{**out, "id": rec["id"]} for rec, out in zip(batch, outputs_list, strict=True)]
+
+
+def tokenize_batches_with_id(
+    *,
+    data_format: LmDatasetFormatBase,
+    batches: Iterator[Sequence[dict]],
+) -> Iterator[dict]:
+    """Tokenize batches and yield ``{id, input_ids, ...}`` per input doc.
+
+    Each input record must already carry ``id`` (apply :func:`attach_id` upstream).
+    The worker tokenizer config is read from zephyr's shared context — caller is
+    responsible for ``ctx.put('tokenizer_name', ...)`` and
+    ``ctx.put('tokenizer_backend', ...)`` before pipeline execution.
+    """
+    ctx = zephyr_worker_ctx()
+    name = ctx.get_shared("tokenizer_name")
+    backend = ctx.get_shared("tokenizer_backend")
+    # load_tokenizer is @lru_cache, so this only loads once per worker process.
+    tokenizer: MarinTokenizer = load_tokenizer(name, backend=backend)
+    inner = preprocessor_for_format(data_format, tokenizer)
+    # Levanter's BatchTokenizer ships ``long_string_workaround`` opt-in but the
+    # behavior is desirable always: per-record texts above ``_workaround_len``
+    # (10K chars) get split at safe whitespace boundaries before the underlying
+    # ``encode_batch`` is called, then merged back. No-op for short records.
+    # Without this, a single multi-MB outlier passes one giant string to the
+    # Rust tokenizer and OOMs the worker.
+    if hasattr(inner, "_long_string_workaround"):
+        inner._long_string_workaround = True
+    processor = IdPreservingPreprocessor(inner)
+
+    batch_count = 0
+    record_count = 0
+    token_count = 0
+    start_time = time.monotonic()
+
+    for batch in batches:
+        batch_count += 1
+        for record in processor(batch):
+            record_count += 1
+            token_count += len(record.get("input_ids", []))
+            yield record
+        if batch_count % 10 == 0:
+            elapsed = time.monotonic() - start_time
+            tok_per_sec = token_count / elapsed if elapsed > 0 else 0
+            doc_per_sec = record_count / elapsed if elapsed > 0 else 0
+            avg_tok_per_doc = token_count / record_count if record_count > 0 else 0
+            logger.info(
+                f"Tokenized {batch_count:,} batches, {record_count:,} docs, {token_count:,} tokens "
+                f"in {elapsed:.1f}s ({tok_per_sec:,.0f} tokens/s, {doc_per_sec:,.1f} docs/s, "
+                f"{avg_tok_per_doc:,.0f} avg tokens/doc)"
+            )
+
+    elapsed = time.monotonic() - start_time
+    tok_per_sec = token_count / elapsed if elapsed > 0 else 0
+    doc_per_sec = record_count / elapsed if elapsed > 0 else 0
+    avg_tok_per_doc = token_count / record_count if record_count > 0 else 0
+    logger.info(
+        f"Tokenization done: {batch_count:,} batches, {record_count:,} docs, {token_count:,} tokens "
+        f"in {elapsed:.1f}s ({tok_per_sec:,.0f} tokens/s, {doc_per_sec:,.1f} docs/s, "
+        f"{avg_tok_per_doc:,.0f} avg tokens/doc)"
+    )
+
+
+def parquet_window_hint(file_groups: list[list[str]]) -> str | None:
+    """Return a sample parquet path from ``file_groups`` if any, else ``None``.
+
+    Used to align zephyr's window and Levanter's cache batch with parquet
+    row-group size on parquet inputs; ignored for non-parquet inputs.
+    """
+    return next((p for group in file_groups for p in group if p.endswith(".parquet")), None)
+
+
+def resolve_window_and_batch(
+    sample_parquet_path: str | None,
+    requested_batch_size: int | None,
+) -> tuple[int, int | None]:
+    """Pick zephyr window and Levanter batch sizes.
+
+    For parquet sources, align both with the parquet row-group size so each unit
+    of work is exactly one row group end-to-end. Non-parquet inputs fall through
+    to defaults.
+    """
+    window_size = _MAX_WINDOW_SIZE
+    batch_size = requested_batch_size
+    if sample_parquet_path is None:
+        return window_size, batch_size
+    avg_rg_rows = avg_parquet_row_group_rows(sample_parquet_path)
+    if avg_rg_rows is None:
+        return window_size, batch_size
+    half_rg = max(avg_rg_rows // 2, 1)
+    window_size = min(half_rg, _MAX_WINDOW_SIZE)
+    if requested_batch_size is None:
+        batch_size = half_rg
+    logger.info(
+        "Parquet source: avg rows/row-group=%d (from %s) → window=%d, levanter batch_size=%s",
+        avg_rg_rows,
+        sample_parquet_path,
+        window_size,
+        batch_size,
+    )
+    return window_size, batch_size
+
+
+def tokenize_pipeline(
+    ds: Dataset,
+    *,
+    data_format: LmDatasetFormatBase,
+    text_field: str = "text",
+    sample_count: int | None,
+    sample_parquet_path: str | None,
+    levanter_batch_size: int | None,
+) -> tuple[Dataset, int | None]:
+    """Build the tokenize pipeline tail.
+
+    Attaches ``id`` to each input record, optionally subsamples per shard, windows,
+    and tokenizes. Returns the dataset of ``{id, input_ids, ...}`` records and the
+    chosen Levanter cache batch size (``None`` keeps Levanter's default).
+    """
+    window_size, batch_size = resolve_window_and_batch(sample_parquet_path, levanter_batch_size)
+
+    ds = ds.map(lambda r, tf=text_field: attach_id(r, text_field=tf))
+
+    if sample_count is not None:
+        ds = ds.take_per_shard(sample_count)
+
+    return (
+        ds.window(window_size).map_shard(
+            lambda batches, _, fmt=data_format: tokenize_batches_with_id(data_format=fmt, batches=batches)
+        ),
+        batch_size,
+    )

--- a/lib/marin/src/marin/processing/tokenize/attributes.py
+++ b/lib/marin/src/marin/processing/tokenize/attributes.py
@@ -17,7 +17,8 @@ datakit invariants hold by construction:
 Downstream:
 
 * :func:`marin.processing.tokenize.store_builder.build_levanter_store` consumes
-  one or more :class:`TokenizedAttrData` artifacts to produce a Levanter ``TreeStore``.
+  one or more :class:`TokenizedAttrData` artifacts to produce a Levanter cache
+  per split (sharded layout).
 * Other datakit attribute consumers (joins, mixing) can use the ``id`` column to
   align tokens with quality scores, dedup flags, etc.
 """

--- a/lib/marin/src/marin/processing/tokenize/attributes.py
+++ b/lib/marin/src/marin/processing/tokenize/attributes.py
@@ -1,0 +1,302 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stage A of the split tokenize pipeline: NormalizedData → datakit attribute parquet.
+
+Reads one or more :class:`~marin.datakit.normalize.NormalizedData` sources, runs
+the shared tokenization core, and writes co-partitioned attribute parquet shards
+with columns ``id`` and ``input_ids`` (one row per input document).
+
+Each output shard mirrors the basename of its source shard, which ensures the
+datakit invariants hold by construction:
+
+* Same shard count as source (co-partitioned).
+* Sorted by ``id`` within each shard (sources are already sorted; the
+  tokenize pipeline preserves order).
+
+Downstream:
+
+* :func:`marin.processing.tokenize.store_builder.build_levanter_store` consumes
+  one or more :class:`TokenizedData` artifacts to produce a Levanter ``TreeStore``.
+* Other datakit attribute consumers (joins, mixing) can use the ``id`` column to
+  align tokens with quality scores, dedup flags, etc.
+"""
+from __future__ import annotations
+
+import dataclasses
+import logging
+import os
+
+import pyarrow as pa
+from fray import ResourceConfig
+from levanter.data.text import LmDatasetFormatBase, TextLmDatasetFormat
+from levanter.tokenizers import TokenizerBackend
+from pydantic import BaseModel
+from zephyr import Dataset, ZephyrContext
+from zephyr.readers import load_file
+
+from marin.datakit.normalize import NormalizedData
+from marin.execution.artifact import Artifact
+from marin.execution.step_spec import StepSpec
+from marin.processing.tokenize._core import tokenize_pipeline
+from marin.utils import fsspec_glob
+
+logger = logging.getLogger(__name__)
+
+
+class TokenizedData(BaseModel):
+    """Per-split datakit attribute datasets produced by :func:`tokenize_attributes`.
+
+    Each split's attribute parquet shards live under ``output_dirs[split]/`` with
+    columns ``id: string`` and ``input_ids: list<int>``. Shards mirror their source
+    :class:`~marin.datakit.normalize.NormalizedData` partitions 1:1 (same basename,
+    same row order, same id range), so the dataset is sorted by ``id`` per partition
+    and co-partitioned with the source — both datakit invariants.
+
+    Persisted as the step's ``.artifact``. Load via
+    ``Artifact.load(step, TokenizedData)``.
+
+    Attributes:
+        version: Schema version.
+        output_dirs: Map from split name (e.g. ``"train"``, ``"validation"``) to the
+            directory containing that split's attribute parquet shards.
+        source_main_dirs: Map from split name to the source ``NormalizedData.main_output_dir``
+            whose shards this dataset mirrors. Used by consumers to verify
+            co-partitioning.
+        tokenizer: Tokenizer name/path used (informational; consumers should re-verify
+            against any other inputs they combine this with).
+        tokenizer_backend: Tokenizer backend, as ``TokenizerBackend.value``.
+        counters: Aggregated zephyr counters per split.
+    """
+
+    version: str = "v1"
+    output_dirs: dict[str, str]
+    source_main_dirs: dict[str, str]
+    tokenizer: str
+    tokenizer_backend: str
+    counters: dict[str, dict[str, int]]
+
+    def shard_paths(self, split: str) -> list[str]:
+        """Return parquet shard paths for ``split`` in order, or ``[]`` if absent."""
+        d = self.output_dirs.get(split)
+        if d is None:
+            return []
+        return sorted(fsspec_glob(f"{d.rstrip('/')}/*.parquet"))
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class TokenizeAttributesConfig:
+    """Config for :func:`tokenize_attributes`.
+
+    At least one of ``train_source`` or ``validation_source`` must be provided.
+    Each is an independent :class:`NormalizedData` artifact whose shards become
+    the corresponding split's co-partitioned attribute parquet output.
+    """
+
+    train_source: NormalizedData | None = None
+    validation_source: NormalizedData | None = None
+    output_path: str
+    tokenizer: str
+    tokenizer_backend: TokenizerBackend = TokenizerBackend.HF
+    format: LmDatasetFormatBase = TextLmDatasetFormat()  # noqa: RUF009
+    sample_count: int | None = None
+    text_field: str = "text"
+    max_workers: int = 4096
+    worker_resources: ResourceConfig = dataclasses.field(default_factory=lambda: ResourceConfig(ram="10g", disk="5g"))
+
+    def __post_init__(self):
+        if self.train_source is None and self.validation_source is None:
+            raise ValueError("at least one of train_source / validation_source must be provided")
+
+
+_ATTRIBUTE_SCHEMA = pa.schema(
+    [
+        pa.field("id", pa.string()),
+        pa.field("input_ids", pa.list_(pa.int32())),
+    ]
+)
+
+
+def _process_split(
+    *,
+    source: NormalizedData,
+    split: str,
+    config: TokenizeAttributesConfig,
+) -> tuple[str, dict[str, int]]:
+    """Tokenize one split's NormalizedData into co-partitioned attribute parquet.
+
+    Returns ``(split_output_dir, counters)``.
+    """
+    source_shards = sorted(fsspec_glob(f"{source.main_output_dir.rstrip('/')}/*.parquet"))
+    if not source_shards:
+        raise FileNotFoundError(f"No parquet shards found under {source.main_output_dir}")
+
+    split_dir = os.path.join(config.output_path, split)
+    output_basenames = tuple(os.path.basename(p) for p in source_shards)
+
+    def _output_path(shard_idx: int, total_shards: int, sd: str = split_dir, bn: tuple = output_basenames) -> str:
+        return f"{sd}/{bn[shard_idx]}"
+
+    logger.info(
+        "Tokenizing %s (split=%s): %d source shards → %s",
+        source.main_output_dir,
+        split,
+        len(source_shards),
+        split_dir,
+    )
+
+    ds = Dataset.from_list(source_shards).flat_map(load_file)
+    tokenized_ds, _ = tokenize_pipeline(
+        ds,
+        data_format=config.format,
+        text_field=config.text_field,
+        sample_count=config.sample_count,
+        # The first source shard is parquet by construction; pass it for the
+        # row-group-aware window sizing in the shared core.
+        sample_parquet_path=source_shards[0],
+        levanter_batch_size=None,
+    )
+
+    pipeline = tokenized_ds.write_parquet(
+        _output_path,
+        schema=_attribute_schema(config.format),
+        skip_existing=True,
+    )
+
+    ctx = ZephyrContext(
+        resources=config.worker_resources,
+        max_workers=min(config.max_workers, len(source_shards)),
+        name=f"tokenize-attributes-{split}",
+    )
+    ctx.put("tokenizer_name", config.tokenizer)
+    ctx.put("tokenizer_backend", config.tokenizer_backend)
+
+    outcome = ctx.execute(pipeline, verbose=True)
+    return split_dir, dict(outcome.counters)
+
+
+def _attribute_schema(data_format: LmDatasetFormatBase) -> pa.Schema | None:
+    """Return the parquet schema for attribute output, or ``None`` to let zephyr infer.
+
+    For text formats we pin ``id: string`` and ``input_ids: list<int32>`` to keep
+    files compact and stable across workers. For chat or other multi-output formats,
+    we let zephyr infer from the first record so additional columns like
+    ``assistant_masks`` flow through unchanged.
+    """
+    if isinstance(data_format, TextLmDatasetFormat):
+        return _ATTRIBUTE_SCHEMA
+    return None
+
+
+def tokenize_attributes(config: TokenizeAttributesConfig) -> TokenizedData:
+    """Tokenize :class:`NormalizedData` source(s) into datakit attribute parquet.
+
+    Each split's source shards become co-partitioned attribute parquet files
+    sharing basenames with the source. Output records carry ``{id, input_ids}``
+    (plus any extra fields produced by the format processor for non-text formats).
+
+    Args:
+        config: See :class:`TokenizeAttributesConfig`.
+
+    Returns:
+        A :class:`TokenizedData` describing the per-split output directories,
+        source linkage, tokenizer config, and counters.
+    """
+    output_dirs: dict[str, str] = {}
+    source_main_dirs: dict[str, str] = {}
+    counters: dict[str, dict[str, int]] = {}
+
+    splits: list[tuple[str, NormalizedData]] = []
+    if config.train_source is not None:
+        splits.append(("train", config.train_source))
+    if config.validation_source is not None:
+        splits.append(("validation", config.validation_source))
+
+    for split, source in splits:
+        split_dir, split_counters = _process_split(source=source, split=split, config=config)
+        output_dirs[split] = split_dir
+        source_main_dirs[split] = source.main_output_dir
+        counters[split] = split_counters
+
+    return TokenizedData(
+        output_dirs=output_dirs,
+        source_main_dirs=source_main_dirs,
+        tokenizer=config.tokenizer,
+        tokenizer_backend=config.tokenizer_backend.value,
+        counters=counters,
+    )
+
+
+def tokenize_attributes_step(
+    *,
+    name: str,
+    train_normalize: StepSpec | None = None,
+    validation_normalize: StepSpec | None = None,
+    tokenizer: str,
+    tokenizer_backend: TokenizerBackend = TokenizerBackend.HF,
+    data_format: LmDatasetFormatBase | None = None,
+    sample_count: int | None = None,
+    text_field: str = "text",
+    max_workers: int = 4096,
+    worker_resources: ResourceConfig | None = None,
+    override_output_path: str | None = None,
+) -> StepSpec:
+    """Create a :class:`StepSpec` that tokenizes :class:`NormalizedData` source(s) into attribute parquet.
+
+    At least one of ``train_normalize`` or ``validation_normalize`` must be provided;
+    each upstream step's output is loaded as :class:`NormalizedData` and routed to
+    the corresponding split. The artifact persisted at the step's output path is
+    a :class:`TokenizedData`.
+
+    Args:
+        name: Step name (e.g. ``"fineweb/tokenize"``).
+        train_normalize: Upstream normalize step whose output feeds the train split.
+        validation_normalize: Upstream normalize step whose output feeds the validation split.
+        tokenizer: Tokenizer name/path forwarded to :class:`TokenizeAttributesConfig`.
+        tokenizer_backend: Tokenizer backend.
+        data_format: Levanter :class:`LmDatasetFormatBase`. Defaults to ``TextLmDatasetFormat()``.
+        sample_count: Per-shard sample cap, or ``None`` for full data.
+        text_field: Record field used for id fallback when input lacks ``id``.
+            Datakit-normalized inputs always carry ``id`` so this only matters
+            on non-normalized paths (not used here, but mirrored to the config).
+        max_workers: Zephyr worker cap.
+        worker_resources: Per-worker resources; defaults inside the config.
+        override_output_path: Optional explicit output path.
+    """
+    if train_normalize is None and validation_normalize is None:
+        raise ValueError("tokenize_attributes_step: at least one of train_normalize / validation_normalize required")
+
+    fmt = data_format or TextLmDatasetFormat()
+    deps: list[StepSpec] = [s for s in (train_normalize, validation_normalize) if s is not None]
+
+    def _fn(output_path: str) -> TokenizedData:
+        kwargs: dict = {
+            "output_path": output_path,
+            "tokenizer": tokenizer,
+            "tokenizer_backend": tokenizer_backend,
+            "format": fmt,
+            "sample_count": sample_count,
+            "text_field": text_field,
+            "max_workers": max_workers,
+        }
+        if train_normalize is not None:
+            kwargs["train_source"] = Artifact.load(train_normalize, NormalizedData)
+        if validation_normalize is not None:
+            kwargs["validation_source"] = Artifact.load(validation_normalize, NormalizedData)
+        if worker_resources is not None:
+            kwargs["worker_resources"] = worker_resources
+        return tokenize_attributes(TokenizeAttributesConfig(**kwargs))
+
+    return StepSpec(
+        name=name,
+        deps=deps,
+        fn=_fn,
+        hash_attrs={
+            "tokenizer": tokenizer,
+            "tokenizer_backend": tokenizer_backend.value,
+            "format": repr(fmt),
+            "sample_count": sample_count,
+            "text_field": text_field,
+        },
+        override_output_path=override_output_path,
+    )

--- a/lib/marin/src/marin/processing/tokenize/attributes.py
+++ b/lib/marin/src/marin/processing/tokenize/attributes.py
@@ -17,7 +17,7 @@ datakit invariants hold by construction:
 Downstream:
 
 * :func:`marin.processing.tokenize.store_builder.build_levanter_store` consumes
-  one or more :class:`TokenizedData` artifacts to produce a Levanter ``TreeStore``.
+  one or more :class:`TokenizedAttrData` artifacts to produce a Levanter ``TreeStore``.
 * Other datakit attribute consumers (joins, mixing) can use the ``id`` column to
   align tokens with quality scores, dedup flags, etc.
 """
@@ -44,7 +44,7 @@ from marin.utils import fsspec_glob
 logger = logging.getLogger(__name__)
 
 
-class TokenizedData(BaseModel):
+class TokenizedAttrData(BaseModel):
     """Per-split datakit attribute datasets produced by :func:`tokenize_attributes`.
 
     Each split's attribute parquet shards live under ``output_dirs[split]/`` with
@@ -54,7 +54,7 @@ class TokenizedData(BaseModel):
     and co-partitioned with the source — both datakit invariants.
 
     Persisted as the step's ``.artifact``. Load via
-    ``Artifact.load(step, TokenizedData)``.
+    ``Artifact.load(step, TokenizedAttrData)``.
 
     Attributes:
         version: Schema version.
@@ -188,7 +188,7 @@ def _attribute_schema(data_format: LmDatasetFormatBase) -> pa.Schema | None:
     return None
 
 
-def tokenize_attributes(config: TokenizeAttributesConfig) -> TokenizedData:
+def tokenize_attributes(config: TokenizeAttributesConfig) -> TokenizedAttrData:
     """Tokenize :class:`NormalizedData` source(s) into datakit attribute parquet.
 
     Each split's source shards become co-partitioned attribute parquet files
@@ -199,7 +199,7 @@ def tokenize_attributes(config: TokenizeAttributesConfig) -> TokenizedData:
         config: See :class:`TokenizeAttributesConfig`.
 
     Returns:
-        A :class:`TokenizedData` describing the per-split output directories,
+        A :class:`TokenizedAttrData` describing the per-split output directories,
         source linkage, tokenizer config, and counters.
     """
     output_dirs: dict[str, str] = {}
@@ -218,7 +218,7 @@ def tokenize_attributes(config: TokenizeAttributesConfig) -> TokenizedData:
         source_main_dirs[split] = source.main_output_dir
         counters[split] = split_counters
 
-    return TokenizedData(
+    return TokenizedAttrData(
         output_dirs=output_dirs,
         source_main_dirs=source_main_dirs,
         tokenizer=config.tokenizer,
@@ -246,7 +246,7 @@ def tokenize_attributes_step(
     At least one of ``train_normalize`` or ``validation_normalize`` must be provided;
     each upstream step's output is loaded as :class:`NormalizedData` and routed to
     the corresponding split. The artifact persisted at the step's output path is
-    a :class:`TokenizedData`.
+    a :class:`TokenizedAttrData`.
 
     Args:
         name: Step name (e.g. ``"fineweb/tokenize"``).
@@ -269,7 +269,7 @@ def tokenize_attributes_step(
     fmt = data_format or TextLmDatasetFormat()
     deps: list[StepSpec] = [s for s in (train_normalize, validation_normalize) if s is not None]
 
-    def _fn(output_path: str) -> TokenizedData:
+    def _fn(output_path: str) -> TokenizedAttrData:
         kwargs: dict = {
             "output_path": output_path,
             "tokenizer": tokenizer,

--- a/lib/marin/src/marin/processing/tokenize/store_builder.py
+++ b/lib/marin/src/marin/processing/tokenize/store_builder.py
@@ -11,7 +11,7 @@ Two entry points:
   on the legacy hot path (no parquet round-trip) and by :func:`build_levanter_store`.
 
 * :func:`build_levanter_store` — convenience wrapper. Reads attribute parquet
-  partitions from one or more :class:`TokenizedData` artifacts and builds a single
+  partitions from one or more :class:`TokenizedAttrData` artifacts and builds a single
   ``TreeStore`` per split.
 """
 from __future__ import annotations
@@ -22,16 +22,18 @@ import logging
 import os
 import time
 
+import pyarrow.parquet as pq
 from fray import ResourceConfig
 from levanter.store.cache import CacheLedger, consolidate_shard_cache_ledgers
 from pydantic import BaseModel
-from rigging.filesystem import open_url
+from rigging.filesystem import open_url, url_to_fs
 from zephyr import Dataset, ZephyrContext
 from zephyr.readers import load_file
 
 from marin.execution.artifact import Artifact
 from marin.execution.step_spec import StepSpec
-from marin.processing.tokenize.attributes import TokenizedData
+from marin.processing.tokenize.attributes import TokenizedAttrData
+from marin.utils import fsspec_exists
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +64,7 @@ class LevanterStoreData(BaseModel):
             ``cache_path/<split>``.
         splits: Map from split name to per-split stats.
         source_dirs: For provenance — the ``output_dirs`` of each source
-            :class:`TokenizedData` flattened in input order.
+            :class:`TokenizedAttrData` flattened in input order.
         tokenizer: Tokenizer name copied from the first source (informational).
     """
 
@@ -170,14 +172,14 @@ def write_stats_json(output_path: str, ledger: CacheLedger) -> tuple[str, dict[s
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class BuildLevanterStoreConfig:
-    """Config for assembling a Levanter ``TreeStore`` from one or more :class:`TokenizedData` sources.
+    """Config for assembling a Levanter ``TreeStore`` from one or more :class:`TokenizedAttrData` sources.
 
     All sources must agree on tokenizer/format — that's the caller's responsibility.
     The store builder concatenates attribute records across sources in the order
     provided and writes one consolidated cache per split.
     """
 
-    sources: list[TokenizedData]
+    sources: list[TokenizedAttrData]
     cache_path: str
     max_workers: int = 4096
     levanter_batch_size: int | None = None
@@ -188,7 +190,7 @@ class BuildLevanterStoreConfig:
             raise ValueError("BuildLevanterStoreConfig: at least one source required")
 
 
-def _split_shard_paths(sources: list[TokenizedData], split: str) -> list[str]:
+def _split_shard_paths(sources: list[TokenizedAttrData], split: str) -> list[str]:
     """Collect the parquet shard paths for a given split across all sources."""
     paths: list[str] = []
     for source in sources:
@@ -199,23 +201,26 @@ def _split_shard_paths(sources: list[TokenizedData], split: str) -> list[str]:
     return paths
 
 
-def _exemplar_from_attribute_path(attr_path: str) -> dict:
-    """Read the first record from an attribute parquet file and return its post-strip exemplar."""
-    import pyarrow.parquet as pq
-    from rigging.filesystem import url_to_fs
+def _first_nonempty_exemplar(shard_paths: list[str]) -> dict:
+    """Return the first record (id stripped) from the first non-empty shard.
 
-    fs, resolved = url_to_fs(attr_path)
-    with fs.open(resolved, "rb") as f:
-        pf = pq.ParquetFile(f)
-        if pf.metadata.num_rows == 0:
-            raise ValueError(f"Attribute parquet {attr_path} is empty; cannot derive exemplar")
-        first_batch = next(pf.iter_batches(batch_size=1))
-    record = first_batch.to_pylist()[0]
-    return _strip_id(record)
+    Co-partitioned attribute datasets may legitimately have empty partitions
+    (filtering, sparse splits); skipping them lets the store build proceed as
+    long as at least one shard has rows.
+    """
+    for path in shard_paths:
+        fs, resolved = url_to_fs(path)
+        with fs.open(resolved, "rb") as f:
+            pf = pq.ParquetFile(f)
+            if pf.metadata.num_rows == 0:
+                continue
+            first_batch = next(pf.iter_batches(batch_size=1))
+        return _strip_id(first_batch.to_pylist()[0])
+    raise ValueError(f"All {len(shard_paths)} attribute shards are empty; cannot derive exemplar")
 
 
 def build_levanter_store(config: BuildLevanterStoreConfig) -> LevanterStoreData:
-    """Build one consolidated Levanter store per split from :class:`TokenizedData` sources.
+    """Build one consolidated Levanter store per split from :class:`TokenizedAttrData` sources.
 
     For each split that exists in any source, this:
 
@@ -243,7 +248,7 @@ def build_levanter_store(config: BuildLevanterStoreConfig) -> LevanterStoreData:
             continue
 
         split_output = os.path.join(config.cache_path, split)
-        exemplar = _exemplar_from_attribute_path(shard_paths[0])
+        exemplar = _first_nonempty_exemplar(shard_paths)
 
         if _ledger_exists(split_output):
             logger.info("Shard ledger already exists for %s at %s; loading", split, split_output)
@@ -290,8 +295,6 @@ def build_levanter_store(config: BuildLevanterStoreConfig) -> LevanterStoreData:
 
 def _ledger_exists(cache_path: str) -> bool:
     """Return whether a consolidated Levanter ledger already exists at ``cache_path``."""
-    from marin.utils import fsspec_exists
-
     return fsspec_exists(os.path.join(cache_path, "shard_ledger.json"))
 
 
@@ -305,7 +308,7 @@ def build_levanter_store_step(
     override_output_path: str | None = None,
 ) -> StepSpec:
     """Create a :class:`StepSpec` that assembles a Levanter store from one or more
-    :class:`TokenizedData` step outputs.
+    :class:`TokenizedAttrData` step outputs.
 
     The step's output path becomes ``LevanterStoreData.cache_path``; per-split
     consolidated caches live at ``cache_path/<split>``.
@@ -325,7 +328,7 @@ def build_levanter_store_step(
 
     def _fn(output_path: str) -> LevanterStoreData:
         kwargs: dict = {
-            "sources": [Artifact.load(s, TokenizedData) for s in tokenize_steps],
+            "sources": [Artifact.load(s, TokenizedAttrData) for s in tokenize_steps],
             "cache_path": output_path,
             "max_workers": max_workers,
             "levanter_batch_size": levanter_batch_size,

--- a/lib/marin/src/marin/processing/tokenize/store_builder.py
+++ b/lib/marin/src/marin/processing/tokenize/store_builder.py
@@ -1,18 +1,26 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Stage B of the split tokenize pipeline: tokenized records → consolidated Levanter store.
+"""Stage B of the split tokenize pipeline: tokenized records → Levanter cache.
 
 Two entry points:
 
 * :func:`build_from_datasets` — modular core. Takes a caller-prepared zephyr
-  ``Dataset`` of ``{id, input_ids, ...}`` records and writes one consolidated
-  Levanter ``TreeStore``. Used by :func:`marin.processing.tokenize.tokenize.tokenize`
+  ``Dataset`` of ``{id, input_ids, ...}`` records and writes a Levanter cache
+  with a top-level sharded ledger referencing per-shard subdirectories under
+  ``output_path``. Used by :func:`marin.processing.tokenize.tokenize.tokenize`
   on the legacy hot path (no parquet round-trip) and by :func:`build_levanter_store`.
 
 * :func:`build_levanter_store` — convenience wrapper. Reads attribute parquet
-  partitions from one or more :class:`TokenizedAttrData` artifacts and builds a single
-  ``TreeStore`` per split.
+  partitions from one or more :class:`TokenizedAttrData` artifacts and builds a
+  Levanter cache per split.
+
+The output layout is the "sharded" layout introduced by Levanter ``#5430``:
+``cache_dir/shard_ledger.json`` aggregates the per-shard ledgers, while the
+shard data itself lives under ``cache_dir/part-NNNNN-of-MMMMM/`` and must NOT
+be removed — those subdirectories are the cache. Downstream readers load via
+``TreeCache.load`` (or ``UrlDatasetSourceConfig``), which transparently
+dispatches on the sharded layout.
 """
 from __future__ import annotations
 
@@ -42,9 +50,11 @@ class LevanterSplitStats(BaseModel):
     """Per-split summary of a built Levanter store.
 
     Attributes:
-        path: Cache directory for this split (consolidated Levanter ``TreeStore``).
+        path: Cache directory for this split. Contains a top-level
+            ``shard_ledger.json`` plus the per-shard subdirectories it references;
+            load via ``TreeCache.load``.
         total_elements: Document count, mirrors ``CacheLedger.total_num_rows``.
-        total_tokens: Total tokens across all documents (``input_ids`` data size).
+        total_tokens: Total tokens across all documents (``input_ids`` field count).
     """
 
     path: str
@@ -60,7 +70,7 @@ class LevanterStoreData(BaseModel):
 
     Attributes:
         version: Schema version.
-        cache_path: Base directory; each split's consolidated cache lives in
+        cache_path: Base directory; each split's Levanter cache lives in
             ``cache_path/<split>``.
         splits: Map from split name to per-split stats.
         source_dirs: For provenance — the ``output_dirs`` of each source
@@ -91,7 +101,7 @@ def build_from_datasets(
     batch_size: int | None = None,
     skip_existing: bool = True,
 ) -> CacheLedger:
-    """Write a consolidated Levanter ``TreeStore`` from a tokenized records dataset.
+    """Write a Levanter cache from a tokenized records dataset.
 
     The dataset is expected to yield per-doc records shaped like
     ``{id, input_ids, ...}``. ``id`` is stripped before writing because
@@ -99,9 +109,11 @@ def build_from_datasets(
     exemplar must already be in the post-strip shape (no ``id``); pass an
     exemplar derived from the post-tokenize record after dropping ``id``.
 
-    The dataset's shard structure determines the number of intermediate
-    Levanter shard caches written under ``{output_path}/part-NNNNN-of-MMMMM``;
-    those are consolidated into ``output_path`` and removed from caller view.
+    The dataset's shard structure determines the number of per-shard Levanter
+    caches written under ``{output_path}/part-NNNNN-of-MMMMM``. Those shard
+    directories *are* the cache and must remain in place; the consolidation
+    step only writes a top-level ``shard_ledger.json`` that references them by
+    relative path (sharded layout, see Levanter ``#5430``).
 
     Args:
         ctx: Zephyr context. The caller is responsible for setting any tokenizer
@@ -109,15 +121,16 @@ def build_from_datasets(
             if the upstream dataset relies on them.
         dataset: Zephyr ``Dataset`` of tokenized records.
         output_path: Destination cache directory.
-        exemplar: Output exemplar (without ``id``). Used by
-            :func:`consolidate_shard_cache_ledgers` to resolve the TreeStore tree shape.
+        exemplar: Output exemplar (without ``id``). Used as a fallback by
+            :func:`consolidate_shard_cache_ledgers` to derive ``field_counts``
+            for any shard whose own ledger lacks them.
         batch_size: Per-shard Levanter cache flush size. ``None`` keeps Levanter's
             default (16384). Lower values reduce peak memory for datasets with
             very large documents.
         skip_existing: Skip writing intermediate shards whose output already exists.
 
     Returns:
-        The consolidated ``CacheLedger``.
+        The merged sharded ``CacheLedger``.
     """
     if "id" in exemplar:
         raise ValueError("build_from_datasets: exemplar must not contain 'id'; pass a stripped exemplar")
@@ -157,7 +170,7 @@ def build_from_datasets(
 
 
 def write_stats_json(output_path: str, ledger: CacheLedger) -> tuple[str, dict[str, int]]:
-    """Write a ``.stats.json`` summary next to a consolidated Levanter cache.
+    """Write a ``.stats.json`` summary next to a Levanter cache.
 
     Returns ``(stats_path, stats_dict)`` where ``stats_dict`` carries
     ``total_tokens`` and ``total_elements``.
@@ -172,11 +185,11 @@ def write_stats_json(output_path: str, ledger: CacheLedger) -> tuple[str, dict[s
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class BuildLevanterStoreConfig:
-    """Config for assembling a Levanter ``TreeStore`` from one or more :class:`TokenizedAttrData` sources.
+    """Config for assembling a Levanter cache from one or more :class:`TokenizedAttrData` sources.
 
     All sources must agree on tokenizer/format — that's the caller's responsibility.
     The store builder concatenates attribute records across sources in the order
-    provided and writes one consolidated cache per split.
+    provided and writes one Levanter cache per split (sharded layout).
     """
 
     sources: list[TokenizedAttrData]
@@ -220,17 +233,18 @@ def _first_nonempty_exemplar(shard_paths: list[str]) -> dict:
 
 
 def build_levanter_store(config: BuildLevanterStoreConfig) -> LevanterStoreData:
-    """Build one consolidated Levanter store per split from :class:`TokenizedAttrData` sources.
+    """Build one Levanter cache per split from :class:`TokenizedAttrData` sources.
 
     For each split that exists in any source, this:
 
     1. Collects parquet shard paths across all sources.
-    2. Derives an exemplar from the first shard's first record.
-    3. Runs :func:`build_from_datasets` to write and consolidate.
-    4. Writes ``.stats.json`` next to the consolidated cache.
+    2. Derives an exemplar from the first non-empty shard's first record.
+    3. Runs :func:`build_from_datasets` to write per-shard caches and a
+       top-level sharded ledger.
+    4. Writes ``.stats.json`` next to the ledger.
 
-    Splits with no shards are skipped. If a split's consolidated ledger already
-    exists, this loads the existing stats rather than rebuilding.
+    Splits with no shards are skipped. If a split's ledger already exists,
+    this loads the existing stats rather than rebuilding.
 
     Returns:
         :class:`LevanterStoreData` describing the cache layout and per-split counts.
@@ -294,7 +308,7 @@ def build_levanter_store(config: BuildLevanterStoreConfig) -> LevanterStoreData:
 
 
 def _ledger_exists(cache_path: str) -> bool:
-    """Return whether a consolidated Levanter ledger already exists at ``cache_path``."""
+    """Return whether a Levanter cache ledger already exists at ``cache_path``."""
     return fsspec_exists(os.path.join(cache_path, "shard_ledger.json"))
 
 
@@ -310,8 +324,8 @@ def build_levanter_store_step(
     """Create a :class:`StepSpec` that assembles a Levanter store from one or more
     :class:`TokenizedAttrData` step outputs.
 
-    The step's output path becomes ``LevanterStoreData.cache_path``; per-split
-    consolidated caches live at ``cache_path/<split>``.
+    The step's output path becomes ``LevanterStoreData.cache_path``; each
+    split's Levanter cache lives at ``cache_path/<split>``.
 
     Args:
         name: Step name.

--- a/lib/marin/src/marin/processing/tokenize/store_builder.py
+++ b/lib/marin/src/marin/processing/tokenize/store_builder.py
@@ -1,0 +1,345 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stage B of the split tokenize pipeline: tokenized records → consolidated Levanter store.
+
+Two entry points:
+
+* :func:`build_from_datasets` — modular core. Takes a caller-prepared zephyr
+  ``Dataset`` of ``{id, input_ids, ...}`` records and writes one consolidated
+  Levanter ``TreeStore``. Used by :func:`marin.processing.tokenize.tokenize.tokenize`
+  on the legacy hot path (no parquet round-trip) and by :func:`build_levanter_store`.
+
+* :func:`build_levanter_store` — convenience wrapper. Reads attribute parquet
+  partitions from one or more :class:`TokenizedData` artifacts and builds a single
+  ``TreeStore`` per split.
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+import os
+import time
+
+from fray import ResourceConfig
+from levanter.store.cache import CacheLedger, consolidate_shard_cache_ledgers
+from pydantic import BaseModel
+from rigging.filesystem import open_url
+from zephyr import Dataset, ZephyrContext
+from zephyr.readers import load_file
+
+from marin.execution.artifact import Artifact
+from marin.execution.step_spec import StepSpec
+from marin.processing.tokenize.attributes import TokenizedData
+
+logger = logging.getLogger(__name__)
+
+
+class LevanterSplitStats(BaseModel):
+    """Per-split summary of a built Levanter store.
+
+    Attributes:
+        path: Cache directory for this split (consolidated Levanter ``TreeStore``).
+        total_elements: Document count, mirrors ``CacheLedger.total_num_rows``.
+        total_tokens: Total tokens across all documents (``input_ids`` data size).
+    """
+
+    path: str
+    total_elements: int
+    total_tokens: int
+
+
+class LevanterStoreData(BaseModel):
+    """Outcome of :func:`build_levanter_store`: a Levanter cache per split.
+
+    Persisted as the step's ``.artifact``. Load via
+    ``Artifact.load(step, LevanterStoreData)``.
+
+    Attributes:
+        version: Schema version.
+        cache_path: Base directory; each split's consolidated cache lives in
+            ``cache_path/<split>``.
+        splits: Map from split name to per-split stats.
+        source_dirs: For provenance — the ``output_dirs`` of each source
+            :class:`TokenizedData` flattened in input order.
+        tokenizer: Tokenizer name copied from the first source (informational).
+    """
+
+    version: str = "v1"
+    cache_path: str
+    splits: dict[str, LevanterSplitStats]
+    source_dirs: list[dict[str, str]]
+    tokenizer: str
+
+
+def _strip_id(record: dict) -> dict:
+    """Drop ``id`` from a record. Levanter ``TreeStore`` is positional, not keyed."""
+    if "id" not in record:
+        return record
+    return {k: v for k, v in record.items() if k != "id"}
+
+
+def build_from_datasets(
+    *,
+    ctx: ZephyrContext,
+    dataset: Dataset,
+    output_path: str,
+    exemplar: dict,
+    batch_size: int | None = None,
+    skip_existing: bool = True,
+) -> CacheLedger:
+    """Write a consolidated Levanter ``TreeStore`` from a tokenized records dataset.
+
+    The dataset is expected to yield per-doc records shaped like
+    ``{id, input_ids, ...}``. ``id`` is stripped before writing because
+    ``TreeStore`` stores positional concatenated arrays, not keyed rows. The
+    exemplar must already be in the post-strip shape (no ``id``); pass an
+    exemplar derived from the post-tokenize record after dropping ``id``.
+
+    The dataset's shard structure determines the number of intermediate
+    Levanter shard caches written under ``{output_path}/part-NNNNN-of-MMMMM``;
+    those are consolidated into ``output_path`` and removed from caller view.
+
+    Args:
+        ctx: Zephyr context. The caller is responsible for setting any tokenizer
+            shared values (``ctx.put('tokenizer_name', ...)`` etc.) before calling
+            if the upstream dataset relies on them.
+        dataset: Zephyr ``Dataset`` of tokenized records.
+        output_path: Destination cache directory.
+        exemplar: Output exemplar (without ``id``). Used by
+            :func:`consolidate_shard_cache_ledgers` to resolve the TreeStore tree shape.
+        batch_size: Per-shard Levanter cache flush size. ``None`` keeps Levanter's
+            default (16384). Lower values reduce peak memory for datasets with
+            very large documents.
+        skip_existing: Skip writing intermediate shards whose output already exists.
+
+    Returns:
+        The consolidated ``CacheLedger``.
+    """
+    if "id" in exemplar:
+        raise ValueError("build_from_datasets: exemplar must not contain 'id'; pass a stripped exemplar")
+
+    pipeline_start = time.monotonic()
+
+    temp_shards = dataset.map(_strip_id).write_levanter_cache(
+        f"{output_path}/part-{{shard:05d}}-of-{{total:05d}}",
+        metadata={},
+        skip_existing=skip_existing,
+        batch_size=batch_size,
+    )
+
+    tokenize_start = time.monotonic()
+    shard_paths = ctx.execute(temp_shards).results
+    tokenize_elapsed = time.monotonic() - tokenize_start
+
+    consolidate_start = time.monotonic()
+    logger.info("Consolidating %d shards into %s", len(shard_paths), output_path)
+    ledger = consolidate_shard_cache_ledgers(
+        shard_cache_paths=shard_paths,
+        output_path=output_path,
+        exemplar=exemplar,
+    )
+    consolidate_elapsed = time.monotonic() - consolidate_start
+
+    pipeline_elapsed = time.monotonic() - pipeline_start
+    logger.info(
+        "build_from_datasets done: %s in %.1fs (write: %.1fs, consolidate: %.1fs)",
+        output_path,
+        pipeline_elapsed,
+        tokenize_elapsed,
+        consolidate_elapsed,
+    )
+
+    return ledger
+
+
+def write_stats_json(output_path: str, ledger: CacheLedger) -> tuple[str, dict[str, int]]:
+    """Write a ``.stats.json`` summary next to a consolidated Levanter cache.
+
+    Returns ``(stats_path, stats_dict)`` where ``stats_dict`` carries
+    ``total_tokens`` and ``total_elements``.
+    """
+    total_tokens = ledger.field_counts.get("input_ids", 0)
+    stats = {"total_tokens": total_tokens, "total_elements": ledger.total_num_rows}
+    stats_path = os.path.join(output_path, ".stats.json")
+    with open_url(stats_path, "w") as f:
+        json.dump(stats, f)
+    return stats_path, stats
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class BuildLevanterStoreConfig:
+    """Config for assembling a Levanter ``TreeStore`` from one or more :class:`TokenizedData` sources.
+
+    All sources must agree on tokenizer/format — that's the caller's responsibility.
+    The store builder concatenates attribute records across sources in the order
+    provided and writes one consolidated cache per split.
+    """
+
+    sources: list[TokenizedData]
+    cache_path: str
+    max_workers: int = 4096
+    levanter_batch_size: int | None = None
+    worker_resources: ResourceConfig = dataclasses.field(default_factory=lambda: ResourceConfig(ram="10g", disk="5g"))
+
+    def __post_init__(self):
+        if not self.sources:
+            raise ValueError("BuildLevanterStoreConfig: at least one source required")
+
+
+def _split_shard_paths(sources: list[TokenizedData], split: str) -> list[str]:
+    """Collect the parquet shard paths for a given split across all sources."""
+    paths: list[str] = []
+    for source in sources:
+        split_dir = source.output_dirs.get(split)
+        if split_dir is None:
+            continue
+        paths.extend(sorted(source.shard_paths(split)))
+    return paths
+
+
+def _exemplar_from_attribute_path(attr_path: str) -> dict:
+    """Read the first record from an attribute parquet file and return its post-strip exemplar."""
+    import pyarrow.parquet as pq
+    from rigging.filesystem import url_to_fs
+
+    fs, resolved = url_to_fs(attr_path)
+    with fs.open(resolved, "rb") as f:
+        pf = pq.ParquetFile(f)
+        if pf.metadata.num_rows == 0:
+            raise ValueError(f"Attribute parquet {attr_path} is empty; cannot derive exemplar")
+        first_batch = next(pf.iter_batches(batch_size=1))
+    record = first_batch.to_pylist()[0]
+    return _strip_id(record)
+
+
+def build_levanter_store(config: BuildLevanterStoreConfig) -> LevanterStoreData:
+    """Build one consolidated Levanter store per split from :class:`TokenizedData` sources.
+
+    For each split that exists in any source, this:
+
+    1. Collects parquet shard paths across all sources.
+    2. Derives an exemplar from the first shard's first record.
+    3. Runs :func:`build_from_datasets` to write and consolidate.
+    4. Writes ``.stats.json`` next to the consolidated cache.
+
+    Splits with no shards are skipped. If a split's consolidated ledger already
+    exists, this loads the existing stats rather than rebuilding.
+
+    Returns:
+        :class:`LevanterStoreData` describing the cache layout and per-split counts.
+    """
+    splits = sorted({s for src in config.sources for s in src.output_dirs.keys()})
+    if not splits:
+        raise ValueError("No splits found across sources; nothing to build")
+
+    split_stats: dict[str, LevanterSplitStats] = {}
+
+    for split in splits:
+        shard_paths = _split_shard_paths(config.sources, split)
+        if not shard_paths:
+            logger.info("No shards for split %s; skipping", split)
+            continue
+
+        split_output = os.path.join(config.cache_path, split)
+        exemplar = _exemplar_from_attribute_path(shard_paths[0])
+
+        if _ledger_exists(split_output):
+            logger.info("Shard ledger already exists for %s at %s; loading", split, split_output)
+            ledger = CacheLedger.load(split_output)
+        else:
+            ctx = ZephyrContext(
+                resources=config.worker_resources,
+                max_workers=min(config.max_workers, len(shard_paths)),
+                name=f"build-levanter-store-{split}",
+            )
+
+            dataset = Dataset.from_list(shard_paths).flat_map(load_file)
+            ledger = build_from_datasets(
+                ctx=ctx,
+                dataset=dataset,
+                output_path=split_output,
+                exemplar=exemplar,
+                batch_size=config.levanter_batch_size,
+            )
+
+        stats_path, stats = write_stats_json(split_output, ledger)
+        split_stats[split] = LevanterSplitStats(
+            path=split_output,
+            total_elements=stats["total_elements"],
+            total_tokens=stats["total_tokens"],
+        )
+        logger.info(
+            "build_levanter_store: split=%s docs=%d tokens=%d shards=%d → %s (stats: %s)",
+            split,
+            stats["total_elements"],
+            stats["total_tokens"],
+            len(shard_paths),
+            split_output,
+            stats_path,
+        )
+
+    return LevanterStoreData(
+        cache_path=config.cache_path,
+        splits=split_stats,
+        source_dirs=[dict(src.output_dirs) for src in config.sources],
+        tokenizer=config.sources[0].tokenizer,
+    )
+
+
+def _ledger_exists(cache_path: str) -> bool:
+    """Return whether a consolidated Levanter ledger already exists at ``cache_path``."""
+    from marin.utils import fsspec_exists
+
+    return fsspec_exists(os.path.join(cache_path, "shard_ledger.json"))
+
+
+def build_levanter_store_step(
+    *,
+    name: str,
+    tokenize_steps: list[StepSpec],
+    max_workers: int = 4096,
+    levanter_batch_size: int | None = None,
+    worker_resources: ResourceConfig | None = None,
+    override_output_path: str | None = None,
+) -> StepSpec:
+    """Create a :class:`StepSpec` that assembles a Levanter store from one or more
+    :class:`TokenizedData` step outputs.
+
+    The step's output path becomes ``LevanterStoreData.cache_path``; per-split
+    consolidated caches live at ``cache_path/<split>``.
+
+    Args:
+        name: Step name.
+        tokenize_steps: Upstream :func:`tokenize_attributes_step` results to combine.
+            Records are concatenated across sources in the given order; sources
+            must agree on tokenizer/format (caller's responsibility).
+        max_workers: Zephyr worker cap.
+        levanter_batch_size: Per-shard Levanter cache flush size.
+        worker_resources: Per-worker resources; defaults inside the config.
+        override_output_path: Optional explicit output path.
+    """
+    if not tokenize_steps:
+        raise ValueError("build_levanter_store_step: at least one tokenize step required")
+
+    def _fn(output_path: str) -> LevanterStoreData:
+        kwargs: dict = {
+            "sources": [Artifact.load(s, TokenizedData) for s in tokenize_steps],
+            "cache_path": output_path,
+            "max_workers": max_workers,
+            "levanter_batch_size": levanter_batch_size,
+        }
+        if worker_resources is not None:
+            kwargs["worker_resources"] = worker_resources
+        return build_levanter_store(BuildLevanterStoreConfig(**kwargs))
+
+    return StepSpec(
+        name=name,
+        deps=list(tokenize_steps),
+        fn=_fn,
+        hash_attrs={
+            "levanter_batch_size": levanter_batch_size,
+        },
+        override_output_path=override_output_path,
+    )

--- a/lib/marin/src/marin/processing/tokenize/store_builder.py
+++ b/lib/marin/src/marin/processing/tokenize/store_builder.py
@@ -32,10 +32,11 @@ import time
 
 import pyarrow.parquet as pq
 from fray import ResourceConfig
-from levanter.store.cache import CacheLedger, consolidate_shard_cache_ledgers
+from levanter.store.cache import CacheLedger, consolidate_shard_cache_ledgers, write_levanter_cache
 from pydantic import BaseModel
 from rigging.filesystem import open_url, url_to_fs
 from zephyr import Dataset, ZephyrContext
+from zephyr.dataset import format_shard_path
 from zephyr.readers import load_file
 
 from marin.execution.artifact import Artifact
@@ -137,12 +138,23 @@ def build_from_datasets(
 
     pipeline_start = time.monotonic()
 
-    temp_shards = dataset.map(_strip_id).write_levanter_cache(
-        f"{output_path}/part-{{shard:05d}}-of-{{total:05d}}",
-        metadata={},
-        skip_existing=skip_existing,
-        batch_size=batch_size,
-    )
+    output_pattern = f"{output_path}/part-{{shard:05d}}-of-{{total:05d}}"
+    write_kwargs: dict = {"metadata": {}}
+    if batch_size is not None:
+        write_kwargs["batch_size"] = batch_size
+
+    def _write_shard(records, shard_info):
+        shard_path = format_shard_path(output_pattern, shard_info.shard_idx, shard_info.total_shards)
+        if skip_existing:
+            fs = url_to_fs(shard_path)[0]
+            if fs.exists(f"{shard_path}/.success"):
+                logger.info("Skipping write, output exists: %s", shard_path)
+                yield shard_path
+                return
+        result = write_levanter_cache(records, shard_path, **write_kwargs)
+        yield result["path"]
+
+    temp_shards = dataset.map(_strip_id).map_shard(_write_shard)
 
     tokenize_start = time.monotonic()
     shard_paths = ctx.execute(temp_shards).results

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -1,25 +1,26 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Tokenize datasets using zephyr pipeline and write to Levanter cache format.
+"""Tokenize datasets directly into a Levanter cache (legacy end-to-end path).
 
 Supports both regular file paths and HuggingFace datasets. For HF datasets, downloads
-them first then tokenizes the downloaded files.
+them first then tokenizes the downloaded files. The output is a single consolidated
+Levanter ``TreeStore`` per split (train/validation), as it was before the datakit
+split. No intermediate parquet round-trip is performed on this path.
+
+For datakit-style separation (per-doc attribute parquet → store assembly), see
+:mod:`marin.processing.tokenize.attributes` and :mod:`marin.processing.tokenize.store_builder`.
+The shared tokenization core lives in :mod:`marin.processing.tokenize._core`.
 """
 import abc
 import dataclasses
-import json
 import logging
 import os
 import re
 import time
-from collections.abc import Iterator, Sequence
+from collections.abc import Sequence
 
-import braceexpand
 import draccus
-import fsspec
-import pyarrow.parquet as pq
 from datasets import load_dataset_builder
 from fray import ResourceConfig
 from levanter.data.text import (
@@ -28,46 +29,46 @@ from levanter.data.text import (
     LmDatasetSourceConfigBase,
     TextLmDatasetFormat,
     UrlDatasetSourceConfig,
-    preprocessor_for_format,
 )
-from levanter.store.cache import consolidate_shard_cache_ledgers, write_levanter_cache
-from levanter.tokenizers import MarinTokenizer, TokenizerBackend, load_tokenizer
-from rigging.filesystem import open_url, url_to_fs
+from levanter.tokenizers import TokenizerBackend
 from rigging.log_setup import configure_logging
-from zephyr import Dataset, ZephyrContext, zephyr_worker_ctx
-from zephyr.dataset import FileEntry, format_shard_path
-from zephyr.readers import InputFileSpec, load_file
+from zephyr import Dataset, ZephyrContext
+from zephyr.dataset import FileEntry
+from zephyr.readers import load_file
 
 from marin.execution.executor import InputName, VersionedValue
-from marin.utils import fsspec_exists, fsspec_isdir
+from marin.processing.tokenize._core import (
+    MIN_GROUP_BYTES,
+    bundle_files_by_size,
+    compute_target_group_bytes,
+    drop_sidecars,
+    expand_tokenize_paths,
+    glob_with_sizes,
+    parquet_window_hint,
+    tokenize_pipeline,
+)
+from marin.processing.tokenize.store_builder import build_from_datasets, write_stats_json
+from marin.utils import fsspec_exists
 
 logger = logging.getLogger(__name__)
 
-MIN_GROUP_BYTES = 100_000_000  # 100 MB floor to avoid degenerate tiny shards
-# Empirical upper bound on the zephyr window size (see
-# https://github.com/marin-community/marin/issues/2829#issuecomment-3963661943).
-_MAX_WINDOW_SIZE = 64
 
+# Re-exports for callers / tests that import these from tokenize.py.
+__all__ = [
+    "MIN_GROUP_BYTES",
+    "HfDatasetSpec",
+    "HfTokenizeConfig",
+    "TokenizeConfig",
+    "TokenizeConfigBase",
+    "_bundle_files_by_size",
+    "_compute_target_group_bytes",
+    "main",
+    "tokenize",
+]
 
-def _avg_parquet_row_group_rows(path: str) -> int | None:
-    """Return the mean rows-per-row-group from ``path``.
-
-    Returns ``None`` if the file has no row groups (empty parquet footer).
-    """
-    fs, resolved = url_to_fs(path)
-    with fs.open(resolved, "rb") as f:
-        meta = pq.ParquetFile(f).metadata
-    if meta.num_row_groups == 0:
-        return None
-    return max(1, meta.num_rows // meta.num_row_groups)
-
-
-def _compute_target_group_bytes(total_input_bytes: int, max_workers: int) -> int:
-    """Compute target group size to produce approximately max_workers groups.
-
-    Applies a floor of MIN_GROUP_BYTES to avoid degenerate tiny shards.
-    """
-    return max(total_input_bytes // max_workers, MIN_GROUP_BYTES)
+# Backward-compatible aliases — kept because tests import these names.
+_bundle_files_by_size = bundle_files_by_size
+_compute_target_group_bytes = compute_target_group_bytes
 
 
 @dataclasses.dataclass(frozen=True)
@@ -223,135 +224,136 @@ def _validate_train_urls(train_paths: list[str | InputName], warn):
                 )
 
 
-_TOKENIZE_EXTENSIONS = ["json.{gz,zst,zstd}", "jsonl.{gz,zst,zstd}", "parquet"]
-
-
-# NOTE(chris): Marin's `default_download` writes a `provenance.json` sidecar next to
-# downloaded HF data. Downstream TokenizeConfig jobs glob those directories and must
-# exclude sidecars so we don't train on provenance records. Applied uniformly to both
-# splits and both config types — HF hub datasets don't ship sidecars named this way,
-# so the filter is a no-op on the HfTokenizeConfig path.
-_MARIN_SIDECAR_NAMES = frozenset({"provenance.json"})
-
-
-def _drop_sidecars(files: list[FileEntry]) -> list[FileEntry]:
-    return [f for f in files if os.path.basename(f.path) not in _MARIN_SIDECAR_NAMES]
-
-
-def _glob_with_sizes(patterns: list[str]) -> list[FileEntry]:
-    """Glob patterns and return FileEntry objects (spec + size).
-
-    Uses fsspec glob(detail=True) which returns file metadata from the same
-    list-objects API call — no per-file stat RPCs needed. Works for gs://, hf://, s3://, local.
-    """
-    results: list[FileEntry] = []
-    for pattern in patterns:
-        pattern = re.sub(r"(?<!:)//+", "/", pattern)
-        fs, _ = url_to_fs(pattern)
-        protocol = fsspec.core.split_protocol(pattern)[0]
-        for expanded in braceexpand.braceexpand(pattern):
-            detail = fs.glob(expanded, detail=True)
-            for path, info in detail.items():
-                full = f"{protocol}://{path}" if protocol else path
-                results.append(FileEntry(spec=InputFileSpec(path=full), size=info.get("size", 0)))
-    return results
-
-
-def _expand_tokenize_paths(input_paths: list[str]) -> list[str]:
-    """Expand input paths into glob patterns for tokenizable file types.
-
-    Directories get expanded to recursive globs for each supported extension.
-    Concrete paths/patterns pass through unchanged.
-    """
+def _resolve_input_paths(input_paths: list[str] | VersionedValue) -> list[str]:
+    """Unwrap a ``VersionedValue`` if needed and return the concrete path list."""
     if isinstance(input_paths, VersionedValue):
-        input_paths = input_paths.value
-
-    patterns: list[str] = []
-    for path in input_paths:
-        assert path != "/"
-        if path.endswith("/") or fsspec_isdir(path):
-            logger.info(f"Getting all {_TOKENIZE_EXTENSIONS} files in {path}")
-            for ex in _TOKENIZE_EXTENSIONS:
-                patterns.append(os.path.join(path, f"**/*.{ex}"))
-        else:
-            patterns.append(path)
-    return patterns
+        return list(input_paths.value)
+    return list(input_paths)
 
 
-def _bundle_files_by_size(files: list[FileEntry], max_bytes: int):
-    """Bundle files into groups, with each group having a total size less than max_bytes."""
-    current_group: list[str] = []
-    current_size = 0
-
-    for f in files:
-        if current_size + f.size >= max_bytes and current_group:
-            yield current_group
-            current_group = []
-            current_size = 0
-        current_group.append(f.path)
-        current_size += f.size
-
-    if current_group:
-        yield current_group
-
-
-def _tokenize_batches(*, config: TokenizeConfig | HfTokenizeConfig, batches: Iterator[Sequence[dict]]) -> Iterator[dict]:
-    """Tokenize a list of batches using the specified tokenizer and format."""
-    ctx = zephyr_worker_ctx()
-    name = ctx.get_shared("tokenizer_name")
-    backend = ctx.get_shared("tokenizer_backend")
-    # load_tokenizer is @lru_cache, so this only loads once per worker process.
-    tokenizer: MarinTokenizer = load_tokenizer(name, backend=backend)
-    batch_processor = preprocessor_for_format(config.format, tokenizer)
-    # Levanter's BatchTokenizer ships ``long_string_workaround`` opt-in but the
-    # behavior is desirable always: per-record texts above ``_workaround_len``
-    # (10K chars) get split at safe whitespace boundaries before the underlying
-    # ``encode_batch`` is called, then merged back. No-op for short records.
-    # Without this, a single multi-MB outlier passes one giant string to the
-    # Rust tokenizer and OOMs the worker.
-    batch_processor._long_string_workaround = True
-
-    batch_count = 0
-    record_count = 0
-    token_count = 0
-    start_time = time.monotonic()
-
-    for batch in batches:
-        batch_count += 1
-        for record in batch_processor(batch):
-            record_count += 1
-            token_count += len(record.get("input_ids", []))
-            yield record
-        if batch_count % 10 == 0:
-            elapsed = time.monotonic() - start_time
-            tok_per_sec = token_count / elapsed if elapsed > 0 else 0
-            doc_per_sec = record_count / elapsed if elapsed > 0 else 0
-            avg_tok_per_doc = token_count / record_count if record_count > 0 else 0
-            logger.info(
-                f"Tokenized {batch_count:,} batches, {record_count:,} docs, {token_count:,} tokens in {elapsed:.1f}s "
-                f"({tok_per_sec:,.0f} tokens/s, {doc_per_sec:,.1f} docs/s, {avg_tok_per_doc:,.0f} avg tokens/doc)"
-            )
-
-    elapsed = time.monotonic() - start_time
-    tok_per_sec = token_count / elapsed if elapsed > 0 else 0
-    doc_per_sec = record_count / elapsed if elapsed > 0 else 0
-    avg_tok_per_doc = token_count / record_count if record_count > 0 else 0
+def _local_preprocess_paths(files: list[FileEntry], config: TokenizeConfigBase) -> list[list[str]]:
+    """Bundle files into size-balanced groups for distributed processing."""
+    files = sorted(files, key=lambda f: f.path)
+    total_input_bytes = sum(f.size for f in files)
+    if config.num_shards is not None:
+        target_group_bytes = compute_target_group_bytes(total_input_bytes, config.num_shards)
+    else:
+        target_group_bytes = compute_target_group_bytes(total_input_bytes, config.max_workers)
+    file_groups = list(bundle_files_by_size(files, target_group_bytes))
     logger.info(
-        f"Tokenization done: {batch_count:,} batches, {record_count:,} docs, {token_count:,} tokens in {elapsed:.1f}s "
-        f"({tok_per_sec:,.0f} tokens/s, {doc_per_sec:,.1f} docs/s, {avg_tok_per_doc:,.0f} avg tokens/doc)"
+        f"Grouped {len(files):,} files ({total_input_bytes / 1e9:.2f} GB) into {len(file_groups):,} groups "
+        f"(target {target_group_bytes / 1e9:.2f} GB/group)."
+    )
+    return file_groups
+
+
+def _split_already_done(cache_path: str, split_name: str) -> bool:
+    ledger_path = os.path.join(cache_path, split_name, "shard_ledger.json")
+    if fsspec_exists(ledger_path):
+        logger.info("Shard ledger already exists for %s at %s; skipping", split_name, ledger_path)
+        return True
+    return False
+
+
+def _exemplar_for(
+    file_groups: list[list[str]],
+    *,
+    config: TokenizeConfigBase,
+) -> dict:
+    """Compute a post-tokenize exemplar by running one record through the pipeline.
+
+    The exemplar still carries ``id`` (because the shared tokenize pipeline emits
+    ``{id, input_ids, ...}``); :func:`build_from_datasets` strips it before opening
+    the TreeStore.
+    """
+    sample_path = parquet_window_hint(file_groups)
+    ds = Dataset.from_list(file_groups[0][0:1]).flat_map(load_file)
+    pipeline, _ = tokenize_pipeline(
+        ds,
+        data_format=config.format,
+        sample_count=1,
+        sample_parquet_path=sample_path,
+        levanter_batch_size=None,
+    )
+    ctx = ZephyrContext(
+        resources=config.worker_resources,
+        max_workers=1,
+        name="tokenize-exemplar",
+    )
+    ctx.put("tokenizer_name", config.tokenizer)
+    ctx.put("tokenizer_backend", config.tokenizer_backend)
+    return ctx.execute(pipeline, verbose=False).results[0]
+
+
+def _strip_id(record: dict) -> dict:
+    if "id" not in record:
+        return record
+    return {k: v for k, v in record.items() if k != "id"}
+
+
+def _run_split(
+    *,
+    config: TokenizeConfigBase,
+    file_groups: list[list[str]],
+    split_name: str,
+) -> None:
+    """End-to-end pipeline for one split: glob → tokenize → consolidate → stats."""
+    prefix = os.path.join(config.cache_path, split_name)
+    pipeline_start = time.monotonic()
+
+    sample_path = parquet_window_hint(file_groups)
+    ds = Dataset.from_list(file_groups).flat_map(lambda file_list: file_list).flat_map(load_file)
+    tokenized_ds, batch_size = tokenize_pipeline(
+        ds,
+        data_format=config.format,
+        sample_count=config.sample_count,
+        sample_parquet_path=sample_path,
+        levanter_batch_size=config.levanter_batch_size,
+    )
+
+    ctx = ZephyrContext(
+        resources=config.worker_resources,
+        max_workers=min(config.max_workers, len(file_groups)),
+        name=f"tokenize-{split_name}",
+    )
+    # Broadcast tokenizer config to workers. We send name + backend rather than
+    # the tokenizer object because not all backends support pickling.
+    ctx.put("tokenizer_name", config.tokenizer)
+    ctx.put("tokenizer_backend", config.tokenizer_backend)
+
+    logger.info("Computing exemplar for cache consolidation")
+    exemplar = _strip_id(_exemplar_for(file_groups, config=config))
+
+    ledger = build_from_datasets(
+        ctx=ctx,
+        dataset=tokenized_ds,
+        output_path=prefix,
+        exemplar=exemplar,
+        batch_size=batch_size,
+    )
+
+    stats_path, _ = write_stats_json(prefix, exemplar, ledger)
+    pipeline_elapsed = time.monotonic() - pipeline_start
+    logger.info(
+        "%s pipeline complete: %d docs in %.1fs. Wrote stats to %s",
+        split_name,
+        ledger.total_num_rows,
+        pipeline_elapsed,
+        stats_path,
     )
 
 
-def tokenize(config: TokenizeConfigBase):
+def tokenize(config: TokenizeConfigBase) -> None:
     """Tokenize datasets using zephyr pipeline.
 
     Processes train and validation splits separately, writing to Levanter cache format.
     For HuggingFace datasets, downloads them first then tokenizes the downloaded files.
     """
-
     if isinstance(config, TokenizeConfig):
-        train_patterns = _expand_tokenize_paths(config.train_paths) if config.train_paths else []
-        validation_patterns = _expand_tokenize_paths(config.validation_paths) if config.validation_paths else []
+        train_patterns = expand_tokenize_paths(_resolve_input_paths(config.train_paths)) if config.train_paths else []
+        validation_patterns = (
+            expand_tokenize_paths(_resolve_input_paths(config.validation_paths)) if config.validation_paths else []
+        )
     elif isinstance(config, HfTokenizeConfig):
         logger.info(f"Loading dataset metadata for {config.id}" + (f" (config: {config.name})" if config.name else ""))
 
@@ -370,8 +372,8 @@ def tokenize(config: TokenizeConfigBase):
         raise ValueError(f"Unknown config type: {type(config)}")
 
     # Resolve patterns → concrete files with sizes (single list-objects call per pattern)
-    train_files = _drop_sidecars(_glob_with_sizes(train_patterns))
-    validation_files = _drop_sidecars(_glob_with_sizes(validation_patterns))
+    train_files = drop_sidecars(glob_with_sizes(train_patterns))
+    validation_files = drop_sidecars(glob_with_sizes(validation_patterns))
 
     if isinstance(config, TokenizeConfig):
         _validate_train_urls([f.path for f in train_files], warn=config.allow_test_in_train)
@@ -388,150 +390,14 @@ def tokenize(config: TokenizeConfigBase):
     if not train_files and not validation_files:
         raise ValueError("No input files specified. Nothing to do.")
 
-    def local_preprocess_paths(files: list[FileEntry]) -> list[list[str]]:
-        """Bundle files into size-balanced groups for distributed processing."""
-        files = sorted(files, key=lambda f: f.path)
-        total_input_bytes = sum(f.size for f in files)
-        if config.num_shards is not None:
-            target_group_bytes = _compute_target_group_bytes(total_input_bytes, config.num_shards)
-        else:
-            target_group_bytes = _compute_target_group_bytes(total_input_bytes, config.max_workers)
-        file_groups = list(_bundle_files_by_size(files, target_group_bytes))
-        logger.info(
-            f"Grouped {len(files):,} files ({total_input_bytes / 1e9:.2f} GB) into {len(file_groups):,} groups "
-            f"(target {target_group_bytes / 1e9:.2f} GB/group)."
-        )
-        return file_groups
-
-    def split_already_done(split_name: str) -> bool:
-        ledger_path = os.path.join(config.cache_path, split_name, "shard_ledger.json")
-        if fsspec_exists(ledger_path):
-            logger.info(
-                "Shard ledger already exists for %s at %s; skipping",
-                split_name,
-                ledger_path,
-            )
-            return True
-        return False
-
-    def run_pipeline(ctx: ZephyrContext, file_groups: list[list[str]], split_name: str) -> None:
-        prefix = os.path.join(config.cache_path, split_name)
-        pipeline_start = time.monotonic()
-
-        # For parquet sources, align zephyr's window and levanter's cache batch
-        # with the parquet row-group size so each unit of work is exactly one
-        # row group end-to-end. Non-parquet inputs fall through to the defaults.
-        sample_path = next(
-            (p for group in file_groups for p in group if p.endswith(".parquet")),
-            None,
-        )
-        window_size = _MAX_WINDOW_SIZE
-        batch_size = config.levanter_batch_size
-        if sample_path is not None:
-            avg_rg_rows = _avg_parquet_row_group_rows(sample_path)
-            if avg_rg_rows is not None:
-                half_rg = max(avg_rg_rows // 2, 1)
-                window_size = min(half_rg, _MAX_WINDOW_SIZE)
-                batch_size = half_rg if config.levanter_batch_size is None else config.levanter_batch_size
-                logger.info(
-                    "Parquet source: avg rows/row-group=%d (from %s) → window=%d, levanter batch_size=%d",
-                    avg_rg_rows,
-                    sample_path,
-                    window_size,
-                    batch_size,
-                )
-
-        ds = Dataset.from_list(file_groups).flat_map(lambda file_list: file_list).flat_map(load_file)
-
-        if config.sample_count is not None:
-            logger.info(f"Sampling {config.sample_count} examples from {split_name} set for tokenization")
-            ds = ds.take_per_shard(config.sample_count)
-
-        output_pattern = f"{prefix}/part-{{shard:05d}}-of-{{total:05d}}"
-        _batch_size = batch_size
-
-        def _write_shard(batches, shard_info):
-            output_path = format_shard_path(output_pattern, shard_info.shard_idx, shard_info.total_shards)
-            success_path = f"{output_path}/.success"
-            fs = url_to_fs(output_path)[0]
-            if fs.exists(success_path):
-                logger.info("Skipping write, output exists: %s", output_path)
-                yield output_path
-                return
-            kwargs: dict = {"metadata": {}}
-            if _batch_size is not None:
-                kwargs["batch_size"] = _batch_size
-            result = write_levanter_cache(
-                _tokenize_batches(config=config, batches=batches),
-                output_path,
-                **kwargs,
-            )
-            yield result["path"]
-
-        temp_shards = ds.window(window_size).map_shard(_write_shard)
-
-        # Broadcast tokenizer config to workers. We send name + backend rather than
-        # the tokenizer object because not all backends support pickling.
-        ctx.put("tokenizer_name", config.tokenizer)
-        ctx.put("tokenizer_backend", config.tokenizer_backend)
-
-        tokenize_start = time.monotonic()
-        shard_paths = ctx.execute(temp_shards).results
-        tokenize_elapsed = time.monotonic() - tokenize_start
-
-        logger.info("Computing exemplar for cache consolidation")
-        exemplar = ctx.execute(
-            Dataset.from_list(file_groups[0][0:1])
-            .flat_map(load_file)
-            .take_per_shard(1)
-            .map_shard(lambda example, _: _tokenize_batches(config=config, batches=[example])),
-            verbose=False,
-        ).results[0]
-
-        consolidate_start = time.monotonic()
-        logger.info(f"Consolidating {len(shard_paths)} shards into {prefix}")
-        ledger = consolidate_shard_cache_ledgers(
-            shard_cache_paths=shard_paths,
-            output_path=prefix,
-            exemplar=exemplar,
-        )
-        consolidate_elapsed = time.monotonic() - consolidate_start
-
-        total_elements = ledger.total_num_rows
-        total_tokens = ledger.field_counts.get("input_ids", 0)
-
-        stats_path = os.path.join(prefix, ".stats.json")
-        with open_url(stats_path, "w") as f:
-            json.dump({"total_tokens": total_tokens, "total_elements": total_elements}, f)
-
-        pipeline_elapsed = time.monotonic() - pipeline_start
-        overall_tok_per_sec = total_tokens / tokenize_elapsed if tokenize_elapsed > 0 else 0
-        overall_doc_per_sec = total_elements / tokenize_elapsed if tokenize_elapsed > 0 else 0
-        logger.info(
-            f"{split_name} pipeline complete: {total_elements:,} docs, {total_tokens:,} tokens "
-            f"in {pipeline_elapsed:.1f}s (tokenize: {tokenize_elapsed:.1f}s at {overall_tok_per_sec:,.0f} tokens/s "
-            f"{overall_doc_per_sec:,.1f} docs/s, consolidate: {consolidate_elapsed:.1f}s). "
-            f"Wrote stats to {stats_path}"
-        )
-
     # TODO (rav): both train and val could run at the same time
-    if train_files and not split_already_done("train"):
-        train_groups = local_preprocess_paths(train_files)
-        ctx = ZephyrContext(
-            resources=config.worker_resources,
-            max_workers=min(config.max_workers, len(train_groups)),
-            name="tokenize-train",
-        )
-        run_pipeline(ctx, train_groups, "train")
+    if train_files and not _split_already_done(config.cache_path, "train"):
+        train_groups = _local_preprocess_paths(train_files, config)
+        _run_split(config=config, file_groups=train_groups, split_name="train")
 
-    if validation_files and not split_already_done("validation"):
-        validation_groups = local_preprocess_paths(validation_files)
-        ctx = ZephyrContext(
-            resources=config.worker_resources,
-            max_workers=min(config.max_workers, len(validation_groups)),
-            name="tokenize-validation",
-        )
-        run_pipeline(ctx, validation_groups, "validation")
+    if validation_files and not _split_already_done(config.cache_path, "validation"):
+        validation_groups = _local_preprocess_paths(validation_files, config)
+        _run_split(config=config, file_groups=validation_groups, split_name="validation")
 
 
 @draccus.wrap()

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -333,7 +333,7 @@ def _run_split(
         batch_size=batch_size,
     )
 
-    stats_path, _ = write_stats_json(prefix, exemplar, ledger)
+    stats_path, _ = write_stats_json(prefix, ledger)
     pipeline_elapsed = time.monotonic() - pipeline_start
     logger.info(
         "%s pipeline complete: %d docs in %.1fs. Wrote stats to %s",

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -4,9 +4,10 @@
 """Tokenize datasets directly into a Levanter cache (legacy end-to-end path).
 
 Supports both regular file paths and HuggingFace datasets. For HF datasets, downloads
-them first then tokenizes the downloaded files. The output is a single consolidated
-Levanter ``TreeStore`` per split (train/validation), as it was before the datakit
-split. No intermediate parquet round-trip is performed on this path.
+them first then tokenizes the downloaded files. The output is a Levanter cache per
+split (train/validation): a top-level sharded ``shard_ledger.json`` plus per-shard
+subdirectories under ``cache_path/<split>/part-NNNNN-of-MMMMM/``. No intermediate
+parquet round-trip is performed on this path.
 
 For datakit-style separation (per-doc attribute parquet → store assembly), see
 :mod:`marin.processing.tokenize.attributes` and :mod:`marin.processing.tokenize.store_builder`.
@@ -263,8 +264,8 @@ def _exemplar_for(
     """Compute a post-tokenize exemplar by running one record through the pipeline.
 
     The exemplar still carries ``id`` (because the shared tokenize pipeline emits
-    ``{id, input_ids, ...}``); :func:`build_from_datasets` strips it before opening
-    the TreeStore.
+    ``{id, input_ids, ...}``); :func:`build_from_datasets` strips it before
+    writing the cache.
     """
     sample_path = parquet_window_hint(file_groups)
     ds = Dataset.from_list(file_groups[0][0:1]).flat_map(load_file)

--- a/tests/processing/tokenize/test_split_tokenize.py
+++ b/tests/processing/tokenize/test_split_tokenize.py
@@ -22,12 +22,13 @@ from marin.execution.step_spec import StepSpec
 from marin.processing.tokenize._core import IdPreservingPreprocessor, attach_id
 from marin.processing.tokenize.attributes import (
     TokenizeAttributesConfig,
-    TokenizedData,
+    TokenizedAttrData,
     tokenize_attributes,
     tokenize_attributes_step,
 )
 from marin.processing.tokenize.store_builder import (
     BuildLevanterStoreConfig,
+    _first_nonempty_exemplar,
     build_levanter_store,
     build_levanter_store_step,
 )
@@ -151,7 +152,7 @@ def test_split_pipeline_matches_legacy_tokenize(tmp_path):
         tokenizer="gpt2",
         format=TextLmDatasetFormat(),
     )
-    tokenized: TokenizedData = tokenize_attributes(attr_config)
+    tokenized: TokenizedAttrData = tokenize_attributes(attr_config)
 
     train_shards = tokenized.shard_paths("train")
     assert len(train_shards) == 1, f"expected 1 attribute shard, got {len(train_shards)}: {train_shards}"
@@ -269,6 +270,34 @@ def test_build_levanter_store_step_wires_deps():
 def test_build_levanter_store_step_requires_at_least_one_source():
     with pytest.raises(ValueError, match="at least one"):
         build_levanter_store_step(name="store", tokenize_steps=[])
+
+
+def _write_attr_shard(path, ids: list[str], input_ids_lists: list[list[int]]) -> None:
+    """Write a small attribute parquet file with the canonical {id, input_ids} schema."""
+    schema = pa.schema([("id", pa.string()), ("input_ids", pa.list_(pa.int32()))])
+    table = pa.Table.from_pylist(
+        [{"id": i, "input_ids": ii} for i, ii in zip(ids, input_ids_lists, strict=True)],
+        schema=schema,
+    )
+    pq.write_table(table, str(path))
+
+
+def test_first_nonempty_exemplar_skips_empty_leading_shards(tmp_path):
+    """Empty shards must not block exemplar derivation when later shards have rows."""
+    empty = tmp_path / "part-00000-of-00002.parquet"
+    nonempty = tmp_path / "part-00001-of-00002.parquet"
+    _write_attr_shard(empty, ids=[], input_ids_lists=[])
+    _write_attr_shard(nonempty, ids=["abc"], input_ids_lists=[[1, 2, 3]])
+
+    exemplar = _first_nonempty_exemplar([str(empty), str(nonempty)])
+    assert exemplar == {"input_ids": [1, 2, 3]}
+
+
+def test_first_nonempty_exemplar_raises_when_all_empty(tmp_path):
+    p = tmp_path / "part-00000-of-00001.parquet"
+    _write_attr_shard(p, ids=[], input_ids_lists=[])
+    with pytest.raises(ValueError, match="empty"):
+        _first_nonempty_exemplar([str(p)])
 
 
 def test_build_levanter_store_step_hash_id_changes_with_batch_size():

--- a/tests/processing/tokenize/test_split_tokenize.py
+++ b/tests/processing/tokenize/test_split_tokenize.py
@@ -1,0 +1,278 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the split tokenize pipeline (Stage A: attribute parquet, Stage B: store builder).
+
+Unit tests cover the pure helpers (``attach_id``, ``IdPreservingPreprocessor``).
+The slow integration test exercises the A→B pipeline end-to-end against the
+legacy ``tokenize()`` path on a tiny local parquet fixture.
+"""
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from levanter.data.text import TextLmDatasetFormat
+from levanter.store.cache import CacheLedger, TreeCache
+from marin.datakit.normalize import NormalizedData, generate_id
+from marin.execution.step_spec import StepSpec
+from marin.processing.tokenize._core import IdPreservingPreprocessor, attach_id
+from marin.processing.tokenize.attributes import (
+    TokenizeAttributesConfig,
+    TokenizedData,
+    tokenize_attributes,
+    tokenize_attributes_step,
+)
+from marin.processing.tokenize.store_builder import (
+    BuildLevanterStoreConfig,
+    build_levanter_store,
+    build_levanter_store_step,
+)
+from marin.processing.tokenize.tokenize import TokenizeConfig, tokenize
+
+
+class _FakeProcessor:
+    """1:1 processor stub: copies input shape into output."""
+
+    def __init__(self, returns: object | None = None):
+        self._returns = returns
+
+    def __call__(self, batch):
+        if self._returns is not None:
+            return self._returns
+        return [{"input_ids": [i, i + 1]} for i, _ in enumerate(batch)]
+
+
+def test_attach_id_preserves_existing_id():
+    record = {"id": "abc", "text": "hello"}
+    assert attach_id(record) is record
+
+
+def test_attach_id_treats_none_as_missing():
+    record = {"id": None, "text": "hello"}
+    out = attach_id(record)
+    assert out["id"] == generate_id("hello")
+
+
+def test_attach_id_uses_text_field():
+    record = {"text": "hello world"}
+    out = attach_id(record)
+    assert out["id"] == generate_id("hello world")
+    assert out["text"] == "hello world"
+
+
+def test_attach_id_custom_text_field():
+    record = {"body": "hello"}
+    out = attach_id(record, text_field="body")
+    assert out["id"] == generate_id("hello")
+
+
+def test_attach_id_falls_back_to_record_serialization():
+    """Records lacking the configured text field still get a deterministic id."""
+    record = {"messages": [{"role": "user", "content": "hi"}]}
+    a = attach_id(record, text_field="text")
+    b = attach_id(record, text_field="text")
+    assert a["id"] == b["id"]
+    # Falls back to a JSON-of-record hash, which differs from hashing 'text'.
+    assert a["id"] != generate_id("hi")
+
+
+def test_attach_id_is_deterministic_across_dict_orders():
+    record_a = {"messages": [{"role": "user", "content": "hi"}]}
+    record_b = {"messages": [{"role": "user", "content": "hi"}]}
+    assert attach_id(record_a, text_field="text")["id"] == attach_id(record_b, text_field="text")["id"]
+
+
+def test_id_preserving_preprocessor_threads_id_through():
+    inner = _FakeProcessor()
+    wrapped = IdPreservingPreprocessor(inner)
+    batch = [{"id": "a", "text": "x"}, {"id": "b", "text": "y"}]
+    out = wrapped(batch)
+    assert [r["id"] for r in out] == ["a", "b"]
+    assert all("input_ids" in r for r in out)
+
+
+def test_id_preserving_preprocessor_handles_struct_of_arrays():
+    """Some processors return a Mapping of column-arrays instead of a list of dicts."""
+    soa = {"input_ids": [[1, 2], [3, 4]]}
+    inner = _FakeProcessor(returns=soa)
+    wrapped = IdPreservingPreprocessor(inner)
+    batch = [{"id": "a"}, {"id": "b"}]
+    out = wrapped(batch)
+    assert [r["id"] for r in out] == ["a", "b"]
+    assert [r["input_ids"] for r in out] == [[1, 2], [3, 4]]
+
+
+def test_id_preserving_preprocessor_raises_on_non_1_to_1():
+    """A processor that drops or splits records must fail loudly, not silently misalign ids."""
+    inner = _FakeProcessor(returns=[{"input_ids": [1]}])  # 1 output for 2 inputs
+    wrapped = IdPreservingPreprocessor(inner)
+    with pytest.raises(RuntimeError, match="1:1"):
+        wrapped([{"id": "a"}, {"id": "b"}])
+
+
+def _write_normalized_fixture(tmp_path, texts: list[str]) -> NormalizedData:
+    """Write a small datakit-normalized parquet shard with {id, text} columns."""
+    main_dir = tmp_path / "normalized" / "outputs" / "main"
+    main_dir.mkdir(parents=True, exist_ok=True)
+    rows = sorted(
+        ({"id": generate_id(t), "text": t} for t in texts),
+        key=lambda r: r["id"],
+    )
+    table = pa.Table.from_pylist(rows, schema=pa.schema([("id", pa.string()), ("text", pa.string())]))
+    pq.write_table(table, str(main_dir / "part-00000-of-00001.parquet"))
+    return NormalizedData(
+        main_output_dir=str(main_dir),
+        dup_output_dir=str(tmp_path / "normalized" / "outputs" / "dups"),
+        counters={},
+    )
+
+
+@pytest.mark.slow
+def test_split_pipeline_matches_legacy_tokenize(tmp_path):
+    """Stage A → Stage B should produce a Levanter cache with the same token count
+    as the legacy raw-input ``tokenize()`` path on the same texts."""
+    texts = [
+        "The quick brown fox jumps over the lazy dog.",
+        "Pack my box with five dozen liquor jugs.",
+        "Sphinx of black quartz, judge my vow.",
+        "How vexingly quick daft zebras jump!",
+        "Bright vixens jump; dozy fowl quack.",
+    ]
+    source = _write_normalized_fixture(tmp_path, texts)
+
+    # --- Stage A: tokenize → attribute parquet ---
+    attr_config = TokenizeAttributesConfig(
+        train_source=source,
+        output_path=str(tmp_path / "attrs"),
+        tokenizer="gpt2",
+        format=TextLmDatasetFormat(),
+    )
+    tokenized: TokenizedData = tokenize_attributes(attr_config)
+
+    train_shards = tokenized.shard_paths("train")
+    assert len(train_shards) == 1, f"expected 1 attribute shard, got {len(train_shards)}: {train_shards}"
+    attr_table = pq.read_table(train_shards[0])
+    assert set(attr_table.column_names) == {"id", "input_ids"}
+    assert attr_table.num_rows == len(texts)
+    # Datakit invariant: sorted by id within each partition.
+    ids = attr_table["id"].to_pylist()
+    assert ids == sorted(ids)
+
+    # --- Stage B: attribute parquet → Levanter store ---
+    store_config = BuildLevanterStoreConfig(
+        sources=[tokenized],
+        cache_path=str(tmp_path / "store"),
+        max_workers=2,
+    )
+    build_levanter_store(store_config)
+
+    split_ledger = CacheLedger.load(str(tmp_path / "store" / "train"))
+    assert split_ledger.is_finished
+    assert split_ledger.total_num_rows == len(texts)
+
+    exemplar = {"input_ids": np.array([0], dtype=np.int32)}
+    split_cache = TreeCache.load(str(tmp_path / "store" / "train"), exemplar=exemplar)
+    split_total_tokens = sum(len(split_cache[i]["input_ids"]) for i in range(len(split_cache)))
+
+    # --- Reference: legacy tokenize() on the same texts as raw jsonl ---
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    raw_path = raw_dir / "data.jsonl"
+    with open(raw_path, "w") as f:
+        import json as _json
+
+        for t in texts:
+            f.write(_json.dumps({"text": t}) + "\n")
+
+    legacy_config = TokenizeConfig(
+        train_paths=[str(raw_path)],
+        validation_paths=[],
+        cache_path=str(tmp_path / "legacy_store"),
+        tokenizer="gpt2",
+        format=TextLmDatasetFormat(),
+        # pytest tmp paths contain "test"; opt out of the train-path guard for this fixture.
+        allow_test_in_train=True,
+    )
+    tokenize(legacy_config)
+
+    legacy_ledger = CacheLedger.load(str(tmp_path / "legacy_store" / "train"))
+    legacy_cache = TreeCache.load(str(tmp_path / "legacy_store" / "train"), exemplar=exemplar)
+    legacy_total_tokens = sum(len(legacy_cache[i]["input_ids"]) for i in range(len(legacy_cache)))
+
+    assert split_ledger.total_num_rows == legacy_ledger.total_num_rows
+    assert split_total_tokens == legacy_total_tokens
+
+    # Both stats files written.
+    assert os.path.exists(tmp_path / "store" / "train" / ".stats.json")
+    assert os.path.exists(tmp_path / "legacy_store" / "train" / ".stats.json")
+
+
+# ---------------------------------------------------------------------------
+# StepSpec wrapper tests
+# ---------------------------------------------------------------------------
+
+
+def _stub_normalize_step(name: str = "normalize") -> StepSpec:
+    """Return a StepSpec stub usable as an upstream `normalize` dep.
+
+    The stub never gets executed; we only inspect identity/deps/hash_id.
+    """
+    return StepSpec(name=name, hash_attrs={"stub": name})
+
+
+def test_tokenize_attributes_step_wires_deps_and_hash_attrs():
+    train = _stub_normalize_step("normalize-train")
+    val = _stub_normalize_step("normalize-validation")
+    step = tokenize_attributes_step(
+        name="fineweb/tokenize",
+        train_normalize=train,
+        validation_normalize=val,
+        tokenizer="gpt2",
+        sample_count=1000,
+    )
+    assert step.name == "fineweb/tokenize"
+    assert step.deps == [train, val]
+    assert step.hash_attrs["tokenizer"] == "gpt2"
+    assert step.hash_attrs["sample_count"] == 1000
+    assert "format" in step.hash_attrs
+
+
+def test_tokenize_attributes_step_requires_at_least_one_source():
+    with pytest.raises(ValueError, match="at least one"):
+        tokenize_attributes_step(name="x", tokenizer="gpt2")
+
+
+def test_tokenize_attributes_step_hash_id_changes_with_tokenizer():
+    train = _stub_normalize_step()
+    a = tokenize_attributes_step(name="x", train_normalize=train, tokenizer="gpt2")
+    b = tokenize_attributes_step(name="x", train_normalize=train, tokenizer="meta-llama/Llama-3.1-8B")
+    assert a.hash_id != b.hash_id
+
+
+def test_tokenize_attributes_step_hash_id_changes_with_sample_count():
+    train = _stub_normalize_step()
+    a = tokenize_attributes_step(name="x", train_normalize=train, tokenizer="gpt2")
+    b = tokenize_attributes_step(name="x", train_normalize=train, tokenizer="gpt2", sample_count=100)
+    assert a.hash_id != b.hash_id
+
+
+def test_build_levanter_store_step_wires_deps():
+    tok = StepSpec(name="upstream-tokens", hash_attrs={"x": 1})
+    step = build_levanter_store_step(name="store", tokenize_steps=[tok])
+    assert step.deps == [tok]
+
+
+def test_build_levanter_store_step_requires_at_least_one_source():
+    with pytest.raises(ValueError, match="at least one"):
+        build_levanter_store_step(name="store", tokenize_steps=[])
+
+
+def test_build_levanter_store_step_hash_id_changes_with_batch_size():
+    tok = StepSpec(name="upstream-tokens", hash_attrs={"x": 1})
+    a = build_levanter_store_step(name="store", tokenize_steps=[tok])
+    b = build_levanter_store_step(name="store", tokenize_steps=[tok], levanter_batch_size=4096)
+    assert a.hash_id != b.hash_id


### PR DESCRIPTION
* part of https://github.com/marin-community/marin/issues/2355
* split `processing/tokenize` into datakit-style stage A + stage B with a shared core
* `attributes.py` — `tokenize_attributes(NormalizedData) → TokenizedData` (parquet of `{id, input_ids}` per doc, co-partitioned with the source via basename mirroring)
* `store_builder.py` — `build_from_datasets` modular core + `build_levanter_store(BuildLevanterStoreConfig) → LevanterStoreData` reading one or more `TokenizedData` sources
* `_core.py` — extracted helpers (`attach_id`, `IdPreservingPreprocessor`[^1], `tokenize_pipeline`)
* legacy `tokenize(TokenizeConfig)` external signature unchanged; internally composes the same core + `build_from_datasets` in one zephyr context (no parquet round-trip)
* `StepSpec` factories `tokenize_attributes_step` and `build_levanter_store_step` mirror the `compute_minhash_attrs_step` pattern
* ids reuse from `NormalizedData` when present; fallback computes via `marin.datakit.normalize.generate_id` (xxh3_128, 32 hex)

[^1]: levanter's `BatchProcessor` interface explicitly allows non-1:1 input→output; today's processors are 1:1 but the wrapper asserts it loudly so a future packing/SFT processor fails fast instead of silently misaligning ids