### PR TITLE
Add accelerator stack validation skill

### DIFF
--- a/.agents/skills/accelerator-stack-validation/SKILL.md
+++ b/.agents/skills/accelerator-stack-validation/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: accelerator-stack-validation
+description: Plan a layered real GPU/TPU cluster validation ladder for Marin training or inference/evals accelerator-stack changes, get one explicit approval for the ladder, then run approved work to a final report. Use for JAX/jaxlib/libtpu, CUDA/cuDNN/cuBLAS/NCCL, vLLM/tpu-inference, Levanter/Grug/Haliax kernels, or Iris resource config that selects those runtimes when correctness, loss, throughput, MFU, profile, or eval behavior must be checked beyond local tests. Not for general Iris debugging, dataset work, or unit-test-only changes.
+---
+
+# Accelerator Stack Validation
+
+Use cheap tests to catch obvious runtime failures, then progress to
+higher-signal checks when the risk or claim warrants it. The end product is a
+clear ship, rollback, or escalate recommendation with evidence.
+
+## Scope
+
+In scope:
+- **Training**: Levanter, Grug MoE, Haliax/Pallas kernels, JAX/jaxlib, libtpu,
+  CUDA, cuBLAS, NCCL, TPU/GPU dependency extras.
+- **Inference/evals**: vLLM, tpu-inference, OpenAI-compatible eval flow,
+  LM-eval/Levanter eval entrypoints, eval dependency groups.
+- **Iris accelerator plumbing**: only when Iris resource requests, images,
+  dependency extras, or cluster configs select the intended TPU/GPU runtime.
+
+Out of scope:
+- General Iris controller debugging, cluster lifecycle work, or log-server bugs
+  unless they block validation. Use `.agents/skills/debug-infra/` or
+  `.agents/skills/babysit-job/`.
+- General research management. For multi-day benchmark studies, layer
+  `.agents/skills/agent-research/` for branch/issue/logbook cadence.
+
+Hard gate: propose the full ladder once, including cost/time, stop criteria,
+and evidence, then get explicit requester approval. After approval, keep working
+until the agreed stop condition or final report. Ask again only if the plan
+materially changes: higher cost, new hardware/cluster, cluster mutation, stopping
+shared jobs, or destructive recovery.
+
+## Working Notes
+
+- Keep a local markdown log in `/tmp` with newest entries first and
+  minute-resolution timestamps. Record main actions, outcomes, and learnings.
+  Do not commit it unless explicitly requested.
+- For commands likely to emit large output, redirect stdout/stderr to a local
+  `/tmp` file, then inspect it with `rg`, `tail`, or small excerpts. Record the
+  tmp path in the log and final report.
+
+## Authoritative Pointers
+
+Do not read every source. Pick by trigger, and patch the source doc when you
+find a sharp edge.
+
+- Real Iris cluster work, GPU/TPU resource flags, CoreWeave, smoke commands:
+  `lib/iris/OPS.md`
+- Canary/daily ferry is a selected layer, or monitoring must run to terminal:
+  `.agents/skills/ferries/SKILL.md`, then `.agents/skills/babysit-job/SKILL.md`
+- Fast one-off TPU probe before a full Iris job: `.agents/skills/dev-tpu/SKILL.md`
+- MFU/throughput/profile claim or profile artifact analysis:
+  `.agents/skills/agent-profiling/SKILL.md`
+- Inference/evals stack is touched: `docs/tutorials/run-lm-evals.md` and
+  `experiments/evals/evals.py`
+- Canary thresholds or recipe interpretation is needed:
+  `scripts/canary/validate_canary_metrics.py` and
+  `experiments/ferries/canary_ferry.py`
+
+## First Pass
+
+1. Identify the touched surface: `training`, `inference/evals`, or `mixed`.
+2. Identify impacted hardware: TPU, GPU, or both. JAX changes often need both;
+   CUDA/NCCL usually means GPU; libtpu/tpu-inference usually means TPU.
+3. Identify the runtime selector under test: package extra, lockfile section,
+   container/image, Iris config, env vars, or model/kernel code path.
+4. Propose the whole ladder at once: layers, expected cost/time, continue/stop
+   criteria, evidence, and the exact approval requested.
+5. After approval, run the ladder without repeatedly interrupting the user.
+
+## Validation Ladder
+
+| Layer | Use When | Cost/Time | Evidence |
+|---|---|---:|---|
+| Local dependency checks | Lockfile/extras/runtime selector changed | Minutes, no cluster | `uv lock --check`, export/tree checks for every impacted extra; absence of unwanted CUDA/TPU packages on unrelated extras |
+| Tiny real-accelerator smoke | Driver/runtime/JAX/vLLM might fail only on hardware | Low; warm GPU/TPU minutes, CoreWeave cold start often 20-30 min | `nvidia-smi` or TPU device probe, `jax.devices()`, backend, tiny matmul or one generate call, warnings |
+| Short task smoke | Need launch/compile/data/W&B/profiler coverage | Low to medium | terminal state, first steps/tokens, W&B link, child job ID, traceback-free logs |
+| 40-100 step canary/benchmark | Need directional training correctness/perf | Medium | final loss, p50/p90 step time, tokens/sec, MFU, profiler artifact if relevant |
+| Full canary ferry | Need production-like training stack confidence | Medium/high; workflow timeouts are hours | canary workflow, Iris parent+child jobs, W&B run, `validate_canary_metrics.py`, profile summary |
+| Selected inference/eval smoke | Inference/evals stack touched and a known-working selected task exists | Variable | server startup/generation logs, selected task metrics, W&B/artifacts, retry/preemption behavior |
+| Full/key eval run | Current eval suite is known working and its metrics are decision-relevant | High/variable | task metrics plus evidence that failures are from the changed stack, not eval infra |
+| Daily/research benchmark | Broad performance or quality claim | High; often 4-5h+ monitoring | issue/logbook, repeated runs, sealed commit/tag, W&B report |
+
+Do not skip straight to expensive layers unless cheaper layers cannot exercise
+the risk. Do not stop at a cheap layer when the change can regress loss, MFU,
+collectives, profiler stop/upload, or eval serving after warmup.
+
+Post-merge/nightly checks can be acceptable as an added backstop, but choose that
+with caution. Do not rely on post-merge coverage as the only signal for a
+high-risk change when useful pre-merge checks are available.
+
+## Training
+
+- For GPU runtime changes, use `lib/iris/OPS.md` bounded GPU smoke guidance
+  across affected rows. H100-only evidence does not prove GH200/B200 behavior.
+- For TPU runtime changes, use `.agents/skills/dev-tpu/` for fast one-off checks;
+  use the canary path when production-like behavior matters.
+- For Grug/Levanter correctness, run the smallest test slice that exercises the
+  changed path, then a short real training smoke if hardware behavior matters.
+- For perf claims, compare baseline/candidate on the same hardware shape when
+  possible; separate compile/first-step from steady-state.
+- For profile-backed claims, use `.agents/skills/agent-profiling/`.
+- For ferry-scale validation, use `.agents/skills/ferries/`, then
+  `.agents/skills/babysit-job/` until terminal state.
+
+## Inference/Evals
+
+- Validate impacted dependency groups first: usually `eval`, `vllm`, `tpu`, and
+  unrelated extras that must not inherit the changed runtime.
+- Pass child-worker env through `env_vars=` on the eval helper. Launcher shell
+  env stays on the coordinator; Iris `remote()` child tasks only receive env
+  that is serialized into the step config.
+- Do not assume full/key evals are currently green or high-signal. First check
+  recent repo context and the eval docs, then prefer a tiny selected eval or
+  server/generate smoke unless a full suite is known working and relevant.
+
+## Hardware Notes
+
+- GPU: request hardware with `--gpu` and dependencies with `--extra`; both are
+  required for GPU JAX jobs. Use the cluster/config mapping in `lib/iris/OPS.md`.
+- TPU: request devices with `--tpu`; `--reserve` alone does not attach TPU
+  devices to the task container.
+- Multi-host GPU canary success is correctness/cost evidence unless the run was
+  explicitly designed as a perf benchmark.
+- Executor parent jobs can be CPU-only while child jobs do the real accelerator
+  work. Record both parent and child job IDs.
+
+## Evidence Required
+
+Every validation report must include:
+- branch, commit SHA, PR/issue, and exact dependency/runtime selector under test,
+- chosen layer and why it is sufficient or intentionally partial,
+- cluster/config, hardware type/count, dependency extra, env vars, and command or workflow,
+- Iris job IDs, child job IDs when present, W&B run links, log/artifact paths,
+- terminal state plus correctness signals: loss, eval metrics, first-loss parity,
+  or generated-response smoke result as appropriate,
+- performance signals when claimed: warmup policy, measured steps, p50/p90 step
+  time, tokens/sec, MFU, compile/first-step time separately, profile summary if used,
+- explicit `Not run` section and residual risk.
+
+## What Not To Do
+
+- Do not launch cluster jobs outside the approved ladder. Do not scale
+  nodepools, restart clusters, stop shared jobs, or increase hardware scope
+  without fresh approval.
+- Do not claim performance from tiny smokes, compile-only runs, cold-start time,
+  or 2-step training jobs.
+- Do not treat `validate_canary_metrics.py` as a quality gate; its thresholds are
+  intentionally loose and catch gross failures.
+- Do not treat a healthy loss curve as proof of success if the job crashes later.
+  Profiler stop/upload, log collection, and teardown can be the failing path.
+- Do not hide missing logs. Say which evidence is unavailable and whether W&B,
+  Iris summary, workflow logs, or profile artifacts compensate.
+- Do not duplicate long Iris/eval/profiling instructions here; patch the source
+  docs or skills when you find a sharp edge.
+
+## Recent Regression Lessons
+
+Use current GitHub context before relying on these examples; they are 2026-04/05
+patterns, not permanent truth.
+
+- TPU inference/JAX update: targeted real-TPU tests caught a JAX strictness break
+  before merge.
+- CUDA 13 GPU update: H100/GH200/B200 JAX smokes proved package/driver viability,
+  but training smokes/full canary were still needed.
+- Grug MoE perf work: paired same-hardware baseline/candidate runs supported the
+  speedup claim; full canary supplied loss confidence.
+- TPU canary failure: healthy W&B loss/MFU did not imply success; the job failed
+  around profiler stop/upload. Terminal state and child task history matter.

--- a/.agents/skills/agent-research/SKILL.md
+++ b/.agents/skills/agent-research/SKILL.md
@@ -23,8 +23,11 @@ process here.
 
 - For Pallas kernel work, use `.agents/skills/add-pallas-kernel/SKILL.md` as
   a specialization layered on top of this skill.
+- For accelerator stack validation after JAX/CUDA/libtpu/vLLM/tpu-inference
+  changes, use `.agents/skills/accelerator-stack-validation/SKILL.md` for
+  validation-layer selection and evidence requirements.
 - Keep branch/issue/logbook/snapshot cadence in `agent-research`; keep
-  kernel-specific safety/perf rules in `add-pallas-kernel`.
+  domain-specific safety/perf rules in the specialization skill.
 
 ## Naming
 Use **research logbook** consistently in prose and file naming.

--- a/.agents/skills/ferries/SKILL.md
+++ b/.agents/skills/ferries/SKILL.md
@@ -12,6 +12,10 @@ Use this skill to run the two ferry lanes:
 
 Both ferries should keep core data assumptions aligned and share the same monitoring/triage discipline.
 
+If the request is to validate a JAX/CUDA/libtpu/vLLM/tpu-inference or accelerator
+runtime change, use `.agents/skills/accelerator-stack-validation/` first to pick
+the validation layer. Return here when the selected layer is a ferry run.
+
 ## Ferry Lanes
 Templates:
 - `experiments/ferries/canary_ferry.py` (MoE canary, TPU and GPU via `CANARY_ACCELERATOR`)

--- a/lib/iris/docs/coreweave.md
+++ b/lib/iris/docs/coreweave.md
@@ -207,8 +207,27 @@ iris --controller-url=http://localhost:10000 ...
 Do not change the GH200 row to `GH200x1`: the RNO2A pool currently accepts
 `H200x1`, then reports `NVIDIA GH200 480GB` from `nvidia-smi`.
 
-Before the full GPU canary, run one tiny direct JAX job for each row. It should
-prove `nvidia-smi`, GPU-backed JAX, and a tiny matmul.
+### Bounded GPU Smoke Tests
+
+Before the full GPU canary, run one tiny direct JAX job for each GPU row. It
+should prove `nvidia-smi`, GPU-backed JAX, and a tiny matmul. This is a
+runtime/device smoke only, not a throughput claim.
+
+Use a streaming direct job so stdout and terminal state are preserved. Keep the
+sharp flags: install the controller extra first in a fresh venv, include
+`--enable-extra-resources`, request hardware with `--gpu`, and install the exact
+runtime extra under test with `--extra`.
+
+```bash
+uv run iris --cluster=<cluster> job run \
+  --enable-extra-resources --cpu=4 --memory=16G --disk=32G \
+  --gpu=<gpu-request> --extra=<runtime-extra> \
+  -- python -c '<probe nvidia-smi, jax backend/devices, and one tiny matmul>'
+```
+
+Use the `--cluster`/`--config` and `--gpu` values from "GPU Configs". For GH200,
+the GPU request is still `H200x1`. Capture the Iris job ID and logs, and check
+for CUDA, cuBLAS, NCCL, or driver warnings before moving to a training canary.
 
 ### KubernetesProvider Operations
 


### PR DESCRIPTION
## Summary

- Add `.agents/skills/accelerator-stack-validation/` as a scoped skill for layered real GPU/TPU validation after accelerator stack changes.
- Make the operating model explicit: propose the whole validation ladder once, get one approval, then run approved work to the agreed stop condition/final report without repeatedly interrupting the user.
- Add skill guidance to keep a newest-first `/tmp` markdown action log and redirect large command output to `/tmp` files for later grepping.
- Keep execution detail in authoritative pointers with trigger text so agents read only the relevant source.
- Patch the authoritative CoreWeave runbook with bounded GPU smoke sharp edges found by actually running the smoke: fresh CoreWeave controller extras are required, direct accelerator entrypoint jobs need `--enable-extra-resources`, and tiny smokes should stream logs instead of using `--no-wait`.

## Base update

#5431 has merged into `main`, and this branch is now rebased onto current `origin/main` (`a92b2a6a3`). The CoreWeave details from the earlier stack live in `lib/iris/docs/coreweave.md`, so this PR no longer changes `lib/iris/OPS.md` directly.

## Real-cluster validation

- First H100 smoke attempt on `coreweave-ci` failed before submission: `ImportError: Install iris[controller] to use CloudK8sService`.
- After installing `marin-iris[controller]`, second H100 attempt reached the controller but Iris rejected the command because `--gpu` direct entrypoint jobs require `--enable-extra-resources`.
- After adding `--enable-extra-resources`, the `--no-wait` H100 smoke submitted as `/romain/iris-run-job-20260505-165531` but failed at the infra layer with `Pod not found` and no task logs; this motivated removing `--no-wait` from the tiny smoke docs.
- Streaming H100 retry `/romain/iris-run-job-20260505-165827` was stopped because the shared `iris-ci-h100-8x` pool was occupied and capped at one H100 node (`Insufficient nvidia.com/gpu`).
- Streaming GH200 smoke on `coreweave-rno2a`, job `/romain/iris-run-job-20260505-170054`, succeeded. `nvidia-smi` reported `NVIDIA GH200 480GB`, JAX reported `0.9.2 backend gpu`, devices `[CudaDevice(id=0)]`, and `matmul_sum 512.0`. `iris job summary --json` reported `state: succeeded`, `failure_count: 0`, `preemption_count: 0`.

## Local validation

- `./infra/pre-commit.py --fix .agents/skills/accelerator-stack-validation/SKILL.md .agents/skills/agent-research/SKILL.md .agents/skills/ferries/SKILL.md lib/iris/docs/coreweave.md`
- `git diff --check origin/main...HEAD`

The requested local action log and command output captures were kept under `/tmp/marin-accelerator-stack-validation/` and are not included in this PR.