### PR TITLE
[finelog] Catalog table for namespace stats; versioned migrations

### DIFF
--- a/lib/finelog/dashboard/src/pages/NamespacesPage.vue
+++ b/lib/finelog/dashboard/src/pages/NamespacesPage.vue
@@ -3,20 +3,17 @@ import { computed, onMounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'
 import { statsRpcCall } from '@/composables/useRpc'
 import { useAutoRefresh, DEFAULT_REFRESH_MS } from '@/composables/useAutoRefresh'
-import { decodeArrowIpc } from '@/utils/arrow'
-import { formatNumber } from '@/utils/formatting'
+import { formatBytes, formatNumber } from '@/utils/formatting'
 import type { ProtoSchema } from '@/types/stats'
 import InfoCard from '@/components/shared/InfoCard.vue'
 import DataTable, { type Column } from '@/components/shared/DataTable.vue'
 
-interface QueryResponse {
-  arrowIpc?: string
-  rowCount?: string | number
-}
-
 interface NamespaceInfo {
   namespace: string
   schema?: ProtoSchema
+  rowCount?: string | number
+  byteSize?: string | number
+  segmentCount?: number
 }
 
 interface ListNamespacesResponse {
@@ -26,7 +23,9 @@ interface ListNamespacesResponse {
 interface NamespaceRow {
   namespace: string
   columnCount: number
-  rowCount: number | null
+  rowCount: number
+  byteSize: number
+  segmentCount: number
 }
 
 const rows = ref<NamespaceRow[]>([])
@@ -37,9 +36,11 @@ const columns: Column[] = [
   { key: 'namespace', label: 'Namespace', sortable: true, mono: true },
   { key: 'columnCount', label: 'Cols', sortable: true, align: 'right' },
   { key: 'rowCount', label: 'Rows', sortable: true, align: 'right' },
+  { key: 'byteSize', label: 'Bytes', sortable: true, align: 'right' },
+  { key: 'segmentCount', label: 'Segments', sortable: true, align: 'right' },
 ]
 
-const sortKey = ref<'namespace' | 'columnCount' | 'rowCount'>('namespace')
+const sortKey = ref<'namespace' | 'columnCount' | 'rowCount' | 'byteSize' | 'segmentCount'>('namespace')
 const sortDir = ref<'asc' | 'desc'>('asc')
 
 const sorted = computed<NamespaceRow[]>(() => {
@@ -53,29 +54,18 @@ const sorted = computed<NamespaceRow[]>(() => {
   })
 })
 
-async function fetchRowCount(ns: string): Promise<number | null> {
-  try {
-    const resp = await statsRpcCall<QueryResponse>('Query', {
-      sql: `SELECT count(*) AS n FROM "${ns}"`,
-    })
-    const r = decodeArrowIpc(resp.arrowIpc)
-    return Number(r.rows[0]?.n ?? 0)
-  } catch {
-    return null
-  }
-}
-
 async function refresh() {
   loading.value = true
   error.value = null
   try {
     const list = await statsRpcCall<ListNamespacesResponse>('ListNamespaces', {})
     const infos = list.namespaces ?? []
-    const counts = await Promise.all(infos.map((info) => fetchRowCount(info.namespace)))
-    rows.value = infos.map((info, i) => ({
+    rows.value = infos.map((info) => ({
       namespace: info.namespace,
       columnCount: info.schema?.columns?.length ?? 0,
-      rowCount: counts[i],
+      rowCount: Number(info.rowCount ?? 0),
+      byteSize: Number(info.byteSize ?? 0),
+      segmentCount: info.segmentCount ?? 0,
     }))
   } catch (e) {
     error.value = e instanceof Error ? e.message : String(e)
@@ -88,7 +78,7 @@ useAutoRefresh(refresh, DEFAULT_REFRESH_MS)
 onMounted(refresh)
 
 function setSort(key: string) {
-  const k = key as 'namespace' | 'columnCount' | 'rowCount'
+  const k = key as 'namespace' | 'columnCount' | 'rowCount' | 'byteSize' | 'segmentCount'
   if (sortKey.value === k) {
     sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc'
   } else {
@@ -127,7 +117,13 @@ function setSort(key: string) {
           {{ formatNumber(value as number) }}
         </template>
         <template #cell-rowCount="{ value }">
-          {{ value === null ? '—' : formatNumber(value as number) }}
+          {{ formatNumber(value as number) }}
+        </template>
+        <template #cell-byteSize="{ value }">
+          {{ formatBytes(value as number) }}
+        </template>
+        <template #cell-segmentCount="{ value }">
+          {{ formatNumber(value as number) }}
         </template>
       </DataTable>
     </InfoCard>

--- a/lib/finelog/src/finelog/proto/finelog_stats.proto
+++ b/lib/finelog/src/finelog/proto/finelog_stats.proto
@@ -107,9 +107,19 @@ message DropTableResponse {
 // Metadata for one registered namespace. Names are returned in registration
 // order. The privileged "log" namespace is included so dashboards can see
 // every queryable surface.
+//
+// Stats fields (3-7) are aggregated across all parquet segments and the
+// in-RAM write buffer. They cover every row currently visible to queries,
+// without scanning the data — clients can use them to render namespace
+// summary tables without issuing per-namespace `count(*)` queries.
 message NamespaceInfo {
   string namespace = 1;
   Schema schema = 2;
+  int64 row_count = 3;        // total visible rows (sealed + RAM)
+  int64 byte_size = 4;        // sealed parquet bytes + RAM buffer bytes
+  int64 min_seq = 5;          // 0 if empty
+  int64 max_seq = 6;          // 0 if empty
+  int32 segment_count = 7;    // sealed (logs_*) + in-flight (tmp_*) parquet files
 }
 
 message ListNamespacesRequest {}

--- a/lib/finelog/src/finelog/rpc/finelog_stats_pb2.py
+++ b/lib/finelog/src/finelog/rpc/finelog_stats_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x13\x66inelog_stats.proto\x12\rfinelog.stats\"g\n\x06\x43olumn\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12-\n\x04type\x18\x02 \x01(\x0e\x32\x19.finelog.stats.ColumnTypeR\x04type\x12\x1a\n\x08nullable\x18\x03 \x01(\x08R\x08nullable\"X\n\x06Schema\x12/\n\x07\x63olumns\x18\x01 \x03(\x0b\x32\x15.finelog.stats.ColumnR\x07\x63olumns\x12\x1d\n\nkey_column\x18\x02 \x01(\tR\tkeyColumn\"c\n\x14RegisterTableRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\x12-\n\x06schema\x18\x02 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x06schema\"Y\n\x15RegisterTableResponse\x12@\n\x10\x65\x66\x66\x65\x63tive_schema\x18\x01 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x0f\x65\x66\x66\x65\x63tiveSchema\"M\n\x10WriteRowsRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\x12\x1b\n\tarrow_ipc\x18\x02 \x01(\x0cR\x08\x61rrowIpc\"6\n\x11WriteRowsResponse\x12!\n\x0crows_written\x18\x01 \x01(\x03R\x0browsWritten\" \n\x0cQueryRequest\x12\x10\n\x03sql\x18\x01 \x01(\tR\x03sql\"I\n\rQueryResponse\x12\x1b\n\tarrow_ipc\x18\x01 \x01(\x0cR\x08\x61rrowIpc\x12\x1b\n\trow_count\x18\x02 \x01(\x03R\x08rowCount\"0\n\x10\x44ropTableRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\"\x13\n\x11\x44ropTableResponse\"\\\n\rNamespaceInfo\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\x12-\n\x06schema\x18\x02 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x06schema\"\x17\n\x15ListNamespacesRequest\"V\n\x16ListNamespacesResponse\x12<\n\nnamespaces\x18\x01 \x03(\x0b\x32\x1c.finelog.stats.NamespaceInfoR\nnamespaces\"5\n\x15GetTableSchemaRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\"G\n\x16GetTableSchemaResponse\x12-\n\x06schema\x18\x01 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x06schema*\xcf\x01\n\nColumnType\x12\x17\n\x13\x43OLUMN_TYPE_UNKNOWN\x10\x00\x12\x16\n\x12\x43OLUMN_TYPE_STRING\x10\x01\x12\x15\n\x11\x43OLUMN_TYPE_INT64\x10\x02\x12\x17\n\x13\x43OLUMN_TYPE_FLOAT64\x10\x03\x12\x14\n\x10\x43OLUMN_TYPE_BOOL\x10\x04\x12\x1c\n\x18\x43OLUMN_TYPE_TIMESTAMP_MS\x10\x05\x12\x15\n\x11\x43OLUMN_TYPE_BYTES\x10\x06\x12\x15\n\x11\x43OLUMN_TYPE_INT32\x10\x07\x32\x8c\x04\n\x0cStatsService\x12Z\n\rRegisterTable\x12#.finelog.stats.RegisterTableRequest\x1a$.finelog.stats.RegisterTableResponse\x12N\n\tWriteRows\x12\x1f.finelog.stats.WriteRowsRequest\x1a .finelog.stats.WriteRowsResponse\x12\x42\n\x05Query\x12\x1b.finelog.stats.QueryRequest\x1a\x1c.finelog.stats.QueryResponse\x12N\n\tDropTable\x12\x1f.finelog.stats.DropTableRequest\x1a .finelog.stats.DropTableResponse\x12]\n\x0eListNamespaces\x12$.finelog.stats.ListNamespacesRequest\x1a%.finelog.stats.ListNamespacesResponse\x12]\n\x0eGetTableSchema\x12$.finelog.stats.GetTableSchemaRequest\x1a%.finelog.stats.GetTableSchemaResponseB{\n\x11\x63om.finelog.statsB\x11\x46inelogStatsProtoP\x01\xa2\x02\x03\x46SX\xaa\x02\rFinelog.Stats\xca\x02\rFinelog\\Stats\xe2\x02\x19\x46inelog\\Stats\\GPBMetadata\xea\x02\x0e\x46inelog::Statsb\x08\x65\x64itionsp\xe8\x07')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x13\x66inelog_stats.proto\x12\rfinelog.stats\"g\n\x06\x43olumn\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12-\n\x04type\x18\x02 \x01(\x0e\x32\x19.finelog.stats.ColumnTypeR\x04type\x12\x1a\n\x08nullable\x18\x03 \x01(\x08R\x08nullable\"X\n\x06Schema\x12/\n\x07\x63olumns\x18\x01 \x03(\x0b\x32\x15.finelog.stats.ColumnR\x07\x63olumns\x12\x1d\n\nkey_column\x18\x02 \x01(\tR\tkeyColumn\"c\n\x14RegisterTableRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\x12-\n\x06schema\x18\x02 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x06schema\"Y\n\x15RegisterTableResponse\x12@\n\x10\x65\x66\x66\x65\x63tive_schema\x18\x01 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x0f\x65\x66\x66\x65\x63tiveSchema\"M\n\x10WriteRowsRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\x12\x1b\n\tarrow_ipc\x18\x02 \x01(\x0cR\x08\x61rrowIpc\"6\n\x11WriteRowsResponse\x12!\n\x0crows_written\x18\x01 \x01(\x03R\x0browsWritten\" \n\x0cQueryRequest\x12\x10\n\x03sql\x18\x01 \x01(\tR\x03sql\"I\n\rQueryResponse\x12\x1b\n\tarrow_ipc\x18\x01 \x01(\x0cR\x08\x61rrowIpc\x12\x1b\n\trow_count\x18\x02 \x01(\x03R\x08rowCount\"0\n\x10\x44ropTableRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\"\x13\n\x11\x44ropTableResponse\"\xed\x01\n\rNamespaceInfo\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\x12-\n\x06schema\x18\x02 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x06schema\x12\x1b\n\trow_count\x18\x03 \x01(\x03R\x08rowCount\x12\x1b\n\tbyte_size\x18\x04 \x01(\x03R\x08\x62yteSize\x12\x17\n\x07min_seq\x18\x05 \x01(\x03R\x06minSeq\x12\x17\n\x07max_seq\x18\x06 \x01(\x03R\x06maxSeq\x12#\n\rsegment_count\x18\x07 \x01(\x05R\x0csegmentCount\"\x17\n\x15ListNamespacesRequest\"V\n\x16ListNamespacesResponse\x12<\n\nnamespaces\x18\x01 \x03(\x0b\x32\x1c.finelog.stats.NamespaceInfoR\nnamespaces\"5\n\x15GetTableSchemaRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\"G\n\x16GetTableSchemaResponse\x12-\n\x06schema\x18\x01 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x06schema*\xcf\x01\n\nColumnType\x12\x17\n\x13\x43OLUMN_TYPE_UNKNOWN\x10\x00\x12\x16\n\x12\x43OLUMN_TYPE_STRING\x10\x01\x12\x15\n\x11\x43OLUMN_TYPE_INT64\x10\x02\x12\x17\n\x13\x43OLUMN_TYPE_FLOAT64\x10\x03\x12\x14\n\x10\x43OLUMN_TYPE_BOOL\x10\x04\x12\x1c\n\x18\x43OLUMN_TYPE_TIMESTAMP_MS\x10\x05\x12\x15\n\x11\x43OLUMN_TYPE_BYTES\x10\x06\x12\x15\n\x11\x43OLUMN_TYPE_INT32\x10\x07\x32\x8c\x04\n\x0cStatsService\x12Z\n\rRegisterTable\x12#.finelog.stats.RegisterTableRequest\x1a$.finelog.stats.RegisterTableResponse\x12N\n\tWriteRows\x12\x1f.finelog.stats.WriteRowsRequest\x1a .finelog.stats.WriteRowsResponse\x12\x42\n\x05Query\x12\x1b.finelog.stats.QueryRequest\x1a\x1c.finelog.stats.QueryResponse\x12N\n\tDropTable\x12\x1f.finelog.stats.DropTableRequest\x1a .finelog.stats.DropTableResponse\x12]\n\x0eListNamespaces\x12$.finelog.stats.ListNamespacesRequest\x1a%.finelog.stats.ListNamespacesResponse\x12]\n\x0eGetTableSchema\x12$.finelog.stats.GetTableSchemaRequest\x1a%.finelog.stats.GetTableSchemaResponseB{\n\x11\x63om.finelog.statsB\x11\x46inelogStatsProtoP\x01\xa2\x02\x03\x46SX\xaa\x02\rFinelog.Stats\xca\x02\rFinelog\\Stats\xe2\x02\x19\x46inelog\\Stats\\GPBMetadata\xea\x02\x0e\x46inelog::Statsb\x08\x65\x64itionsp\xe8\x07')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -32,8 +32,8 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'finelog_stats_pb2', _global
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'\n\021com.finelog.statsB\021FinelogStatsProtoP\001\242\002\003FSX\252\002\rFinelog.Stats\312\002\rFinelog\\Stats\342\002\031Finelog\\Stats\\GPBMetadata\352\002\016Finelog::Stats'
-  _globals['_COLUMNTYPE']._serialized_start=1076
-  _globals['_COLUMNTYPE']._serialized_end=1283
+  _globals['_COLUMNTYPE']._serialized_start=1222
+  _globals['_COLUMNTYPE']._serialized_end=1429
   _globals['_COLUMN']._serialized_start=38
   _globals['_COLUMN']._serialized_end=141
   _globals['_SCHEMA']._serialized_start=143
@@ -54,16 +54,16 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_DROPTABLEREQUEST']._serialized_end=717
   _globals['_DROPTABLERESPONSE']._serialized_start=719
   _globals['_DROPTABLERESPONSE']._serialized_end=738
-  _globals['_NAMESPACEINFO']._serialized_start=740
-  _globals['_NAMESPACEINFO']._serialized_end=832
-  _globals['_LISTNAMESPACESREQUEST']._serialized_start=834
-  _globals['_LISTNAMESPACESREQUEST']._serialized_end=857
-  _globals['_LISTNAMESPACESRESPONSE']._serialized_start=859
-  _globals['_LISTNAMESPACESRESPONSE']._serialized_end=945
-  _globals['_GETTABLESCHEMAREQUEST']._serialized_start=947
-  _globals['_GETTABLESCHEMAREQUEST']._serialized_end=1000
-  _globals['_GETTABLESCHEMARESPONSE']._serialized_start=1002
-  _globals['_GETTABLESCHEMARESPONSE']._serialized_end=1073
-  _globals['_STATSSERVICE']._serialized_start=1286
-  _globals['_STATSSERVICE']._serialized_end=1810
+  _globals['_NAMESPACEINFO']._serialized_start=741
+  _globals['_NAMESPACEINFO']._serialized_end=978
+  _globals['_LISTNAMESPACESREQUEST']._serialized_start=980
+  _globals['_LISTNAMESPACESREQUEST']._serialized_end=1003
+  _globals['_LISTNAMESPACESRESPONSE']._serialized_start=1005
+  _globals['_LISTNAMESPACESRESPONSE']._serialized_end=1091
+  _globals['_GETTABLESCHEMAREQUEST']._serialized_start=1093
+  _globals['_GETTABLESCHEMAREQUEST']._serialized_end=1146
+  _globals['_GETTABLESCHEMARESPONSE']._serialized_start=1148
+  _globals['_GETTABLESCHEMARESPONSE']._serialized_end=1219
+  _globals['_STATSSERVICE']._serialized_start=1432
+  _globals['_STATSSERVICE']._serialized_end=1956
 # @@protoc_insertion_point(module_scope)

--- a/lib/finelog/src/finelog/rpc/finelog_stats_pb2.pyi
+++ b/lib/finelog/src/finelog/rpc/finelog_stats_pb2.pyi
@@ -97,12 +97,22 @@ class DropTableResponse(_message.Message):
     def __init__(self) -> None: ...
 
 class NamespaceInfo(_message.Message):
-    __slots__ = ("namespace", "schema")
+    __slots__ = ("namespace", "schema", "row_count", "byte_size", "min_seq", "max_seq", "segment_count")
     NAMESPACE_FIELD_NUMBER: _ClassVar[int]
     SCHEMA_FIELD_NUMBER: _ClassVar[int]
+    ROW_COUNT_FIELD_NUMBER: _ClassVar[int]
+    BYTE_SIZE_FIELD_NUMBER: _ClassVar[int]
+    MIN_SEQ_FIELD_NUMBER: _ClassVar[int]
+    MAX_SEQ_FIELD_NUMBER: _ClassVar[int]
+    SEGMENT_COUNT_FIELD_NUMBER: _ClassVar[int]
     namespace: str
     schema: Schema
-    def __init__(self, namespace: _Optional[str] = ..., schema: _Optional[_Union[Schema, _Mapping]] = ...) -> None: ...
+    row_count: int
+    byte_size: int
+    min_seq: int
+    max_seq: int
+    segment_count: int
+    def __init__(self, namespace: _Optional[str] = ..., schema: _Optional[_Union[Schema, _Mapping]] = ..., row_count: _Optional[int] = ..., byte_size: _Optional[int] = ..., min_seq: _Optional[int] = ..., max_seq: _Optional[int] = ..., segment_count: _Optional[int] = ...) -> None: ...
 
 class ListNamespacesRequest(_message.Message):
     __slots__ = ()

--- a/lib/finelog/src/finelog/server/stats_service.py
+++ b/lib/finelog/src/finelog/server/stats_service.py
@@ -112,8 +112,16 @@ class StatsServiceImpl:
         ctx: Any,
     ) -> stats_pb2.ListNamespacesResponse:
         infos = [
-            stats_pb2.NamespaceInfo(namespace=name, schema=schema_to_proto(schema))
-            for name, schema in self._log_store.list_namespaces()
+            stats_pb2.NamespaceInfo(
+                namespace=name,
+                schema=schema_to_proto(schema),
+                row_count=stats.row_count,
+                byte_size=stats.byte_size,
+                min_seq=stats.min_seq,
+                max_seq=stats.max_seq,
+                segment_count=stats.segment_count,
+            )
+            for name, schema, stats in self._log_store.list_namespaces_with_stats()
         ]
         return stats_pb2.ListNamespacesResponse(namespaces=infos)
 

--- a/lib/finelog/src/finelog/store/catalog.py
+++ b/lib/finelog/src/finelog/store/catalog.py
@@ -1,10 +1,9 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Sidecar DuckDB database persisting the namespace + segment catalog.
+"""Catalog: namespace + segment metadata in a sidecar DuckDB.
 
-The :class:`RegistryDB` persists two tables in a DuckDB file at
-``{data_dir}/_finelog_registry.duckdb``:
+Two tables in ``{data_dir}/_finelog_registry.duckdb``:
 
 * ``namespaces`` — one row per registered namespace holding its schema. Every
   ``RegisterTable`` mutates one row here. On finelog startup the table is
@@ -22,7 +21,7 @@ The DB is intentionally separate from the per-namespace Parquet directories:
 catalog metadata never lives in two places, so a row count or schema change
 is one ``UPDATE``, not a smear across every parquet footer in the namespace.
 
-Concurrency: the ``RegistryDB`` is not thread-safe by itself. Every caller
+Concurrency: the :class:`Catalog` is not thread-safe by itself. Every caller
 in :class:`finelog.store.duckdb_store.DuckDBLogStore` and
 :class:`finelog.store.log_namespace.DiskLogNamespace` already holds the
 shared ``_insertion_lock`` around mutating calls, which serializes access.
@@ -30,6 +29,7 @@ shared ``_insertion_lock`` around mutating calls, which serializes access.
 
 from __future__ import annotations
 
+import enum
 import logging
 import time
 from collections.abc import Sequence
@@ -43,26 +43,26 @@ from finelog.store.schema import Schema, schema_from_json, schema_to_json
 
 logger = logging.getLogger(__name__)
 
-REGISTRY_DB_FILENAME = "_finelog_registry.duckdb"
+CATALOG_DB_FILENAME = "_finelog_registry.duckdb"
 
-# Segment lifecycle states. ``tmp`` is a freshly-flushed segment awaiting
-# compaction; ``finalized`` is a compacted ``logs_*`` segment.
-SEGMENT_STATE_TMP = "tmp"
-SEGMENT_STATE_FINALIZED = "finalized"
+
+class SegmentState(enum.StrEnum):
+    """Lifecycle state for a parquet segment in the catalog.
+
+    Persisted as ``state`` (TEXT) on each ``segments`` row.
+    """
+
+    TMP = "tmp"  # freshly flushed, awaiting compaction
+    FINALIZED = "finalized"  # produced by compaction
 
 
 @dataclass(frozen=True)
 class SegmentRow:
-    """One persisted row in the segments catalog table.
-
-    ``state`` is :data:`SEGMENT_STATE_TMP` for in-flight ``tmp_*`` segments
-    written by ``_flush_step`` and :data:`SEGMENT_STATE_FINALIZED` for
-    ``logs_*`` segments produced by ``_compaction_step``.
-    """
+    """One persisted row in the segments catalog table."""
 
     namespace: str
     path: str
-    state: str
+    state: SegmentState
     min_seq: int
     max_seq: int
     row_count: int
@@ -89,8 +89,8 @@ class NamespaceStats:
         return cls(row_count=0, byte_size=0, min_seq=0, max_seq=0, segment_count=0)
 
 
-class RegistryDB:
-    """Thin wrapper around the sidecar DuckDB database.
+class Catalog:
+    """Sidecar DuckDB holding namespace schemas + segment metadata.
 
     Not concurrency-safe by itself — callers hold the shared insertion mutex
     around any mutating call.
@@ -105,7 +105,7 @@ class RegistryDB:
             self._path: Path | None = None
             self._conn = duckdb.connect(":memory:")
         else:
-            self._path = data_dir / REGISTRY_DB_FILENAME
+            self._path = data_dir / CATALOG_DB_FILENAME
             self._conn = duckdb.connect(str(self._path))
         # Schema is owned by ``finelog.store.migrations``; every additive
         # change (new column, new index, derived backfill) lands as a new
@@ -166,7 +166,19 @@ class RegistryDB:
             """,
             [namespace],
         ).fetchall()
-        return [SegmentRow(*row) for row in rows]
+        return [
+            SegmentRow(
+                namespace=ns,
+                path=path,
+                state=SegmentState(state),
+                min_seq=min_seq,
+                max_seq=max_seq,
+                row_count=row_count,
+                byte_size=byte_size,
+                created_at_ms=created_at_ms,
+            )
+            for ns, path, state, min_seq, max_seq, row_count, byte_size, created_at_ms in rows
+        ]
 
     def upsert_segment(self, segment: SegmentRow) -> None:
         """Insert or replace one segment row (used by flush + reconciliation)."""
@@ -186,7 +198,7 @@ class RegistryDB:
             [
                 segment.namespace,
                 segment.path,
-                segment.state,
+                segment.state.value,
                 segment.min_seq,
                 segment.max_seq,
                 segment.row_count,

--- a/lib/finelog/src/finelog/store/duckdb_store.py
+++ b/lib/finelog/src/finelog/store/duckdb_store.py
@@ -33,7 +33,7 @@ from finelog.store.log_namespace import (
     MemoryLogNamespace,
     _is_tmp_path,
 )
-from finelog.store.registry_db import RegistryDB
+from finelog.store.registry_db import NamespaceStats, RegistryDB
 from finelog.store.rwlock import RWLock
 from finelog.store.schema import (
     MAX_WRITE_ROWS_BYTES,
@@ -240,6 +240,7 @@ class DuckDBLogStore:
             insertion_lock=self._insertion_lock,
             query_visibility_lock=self._query_visibility_lock,
             read_pool=self._pool,
+            registry_db=self._registry_db,
             **self._disk_namespace_kwargs,
         )
 
@@ -304,6 +305,23 @@ class DuckDBLogStore:
                 key=lambda kv: self._namespace_registered_at.get(kv[0], 0),
             )
             return [(name, ns.schema) for name, ns in items]
+
+    def list_namespaces_with_stats(self) -> list[tuple[str, Schema, NamespaceStats]]:
+        """Like :meth:`list_namespaces`, but also returns per-namespace stats.
+
+        Each entry's stats are read from the namespace's in-memory state,
+        which is held in lockstep with the on-disk segment catalog. This is
+        the read path that backs ``StatsService.ListNamespaces`` — the
+        dashboard relies on it to render the namespace summary table without
+        issuing per-namespace ``count(*)`` queries against parquet.
+        """
+        with self._insertion_lock:
+            items = sorted(
+                self._namespaces.items(),
+                key=lambda kv: self._namespace_registered_at.get(kv[0], 0),
+            )
+            namespaces = [(name, ns) for name, ns in items]
+        return [(name, ns.schema, ns.stats()) for name, ns in namespaces]
 
     def get_table_schema(self, name: str) -> Schema:
         with self._insertion_lock:

--- a/lib/finelog/src/finelog/store/duckdb_store.py
+++ b/lib/finelog/src/finelog/store/duckdb_store.py
@@ -6,7 +6,7 @@
 :class:`DuckDBLogStore` holds the global locks (insertion mutex +
 query-visibility rwlock) and the shared connection pool, and routes RPCs to
 per-namespace storage (:class:`LogNamespaceProtocol`). Schemas persist via
-:class:`RegistryDB` and are rehydrated on startup. The ``log`` namespace is
+:class:`Catalog` and are rehydrated on startup. The ``log`` namespace is
 upserted on first boot for back-compat with deployments whose registry DB
 pre-dates the namespace registry.
 """
@@ -25,6 +25,7 @@ import duckdb
 import pyarrow as pa
 import pyarrow.ipc as paipc
 
+from finelog.store.catalog import Catalog, NamespaceStats
 from finelog.store.layout_migration import LOG_NAMESPACE_DIR
 from finelog.store.log_namespace import (
     LOG_REGISTERED_SCHEMA,
@@ -33,7 +34,6 @@ from finelog.store.log_namespace import (
     MemoryLogNamespace,
     _is_tmp_path,
 )
-from finelog.store.registry_db import NamespaceStats, RegistryDB
 from finelog.store.rwlock import RWLock
 from finelog.store.schema import (
     MAX_WRITE_ROWS_BYTES,
@@ -196,7 +196,7 @@ class DuckDBLogStore:
         self._insertion_lock = Lock()
         self._query_visibility_lock = RWLock()
         self._pool = _ConnectionPool(memory_limit=duckdb_memory_limit, threads=duckdb_threads)
-        self._registry_db = RegistryDB(self._data_dir)
+        self._catalog = Catalog(self._data_dir)
 
         # Global storage caps. Eviction picks the oldest sealed segment
         # across all namespaces (oldest-first by ``min_seq`` with namespace
@@ -240,12 +240,12 @@ class DuckDBLogStore:
             insertion_lock=self._insertion_lock,
             query_visibility_lock=self._query_visibility_lock,
             read_pool=self._pool,
-            registry_db=self._registry_db,
+            catalog=self._catalog,
             **self._disk_namespace_kwargs,
         )
 
     def _rehydrate_from_registry(self) -> None:
-        for name, schema in self._registry_db.list_all().items():
+        for name, schema in self._catalog.list_all().items():
             namespace_dir = self._namespace_dir(name)
             self._namespaces[name] = self._make_namespace(name, schema, namespace_dir)
             # Monotonic counter as the eviction tiebreak.
@@ -259,7 +259,7 @@ class DuckDBLogStore:
         resolve_key_column(LOG_REGISTERED_SCHEMA)
         stored_schema = with_implicit_seq(LOG_REGISTERED_SCHEMA)
         with self._insertion_lock:
-            self._registry_db.upsert(LOG_NAMESPACE_NAME, stored_schema)
+            self._catalog.upsert(LOG_NAMESPACE_NAME, stored_schema)
             self._namespaces[LOG_NAMESPACE_NAME] = self._make_namespace(LOG_NAMESPACE_NAME, stored_schema, log_dir)
             self._namespace_registered_at.setdefault(LOG_NAMESPACE_NAME, len(self._namespace_registered_at))
 
@@ -286,7 +286,7 @@ class DuckDBLogStore:
         with self._insertion_lock:
             existing_ns = self._namespaces.get(name)
             if existing_ns is None:
-                self._registry_db.upsert(name, stored_schema)
+                self._catalog.upsert(name, stored_schema)
                 self._namespaces[name] = self._make_namespace(name, stored_schema, namespace_dir)
                 self._namespace_registered_at[name] = len(self._namespace_registered_at)
                 return stored_schema
@@ -294,7 +294,7 @@ class DuckDBLogStore:
             # merge_schemas raises SchemaConflictError on non-additive change.
             effective = merge_schemas(existing_ns.schema, stored_schema)
             if effective != existing_ns.schema:
-                self._registry_db.upsert(name, effective)
+                self._catalog.upsert(name, effective)
                 existing_ns.update_schema(effective)
             return effective
 
@@ -422,7 +422,7 @@ class DuckDBLogStore:
             ns = self._namespaces.get(name)
             if ns is None:
                 raise NamespaceNotFoundError(f"namespace {name!r} is not registered")
-            self._registry_db.delete(name)
+            self._catalog.delete(name)
             del self._namespaces[name]
             self._namespace_registered_at.pop(name, None)
 
@@ -534,7 +534,7 @@ class DuckDBLogStore:
         for ns in self._namespaces.values():
             ns.close()
         self._pool.close()
-        self._registry_db.close()
+        self._catalog.close()
 
     # Test hooks below; forward to the registered "log" namespace.
 

--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -35,6 +35,13 @@ from rigging.timing import RateLimiter
 
 from finelog.rpc import finelog_stats_pb2 as stats_pb2
 from finelog.rpc import logging_pb2
+from finelog.store.registry_db import (
+    SEGMENT_STATE_FINALIZED,
+    SEGMENT_STATE_TMP,
+    NamespaceStats,
+    RegistryDB,
+    SegmentRow,
+)
 from finelog.store.rwlock import RWLock
 from finelog.store.schema import (
     IMPLICIT_SEQ_COLUMN,
@@ -103,20 +110,24 @@ def _min_seq_from_filename(name: str) -> int | None:
     return int(match.group(1))
 
 
-def _read_seq_bounds(path: Path) -> tuple[int, int]:
-    """Compute (min_seq, max_seq) for a segment via filename + parquet metadata."""
+def _read_segment_metadata(path: Path) -> tuple[int, int, int]:
+    """Compute ``(min_seq, max_seq, row_count)`` from filename + parquet footer.
+
+    Returns ``(0, 0, 0)`` for unparseable filenames or footer-read failures —
+    the caller treats that as an empty/discardable segment.
+    """
     min_seq = _min_seq_from_filename(path.name)
     if min_seq is None:
-        return 0, 0
+        return 0, 0, 0
     try:
         meta = pq.read_metadata(path)
         num_rows = meta.num_rows
     except Exception:
         logger.warning("Failed to read parquet metadata for %s; treating as empty", path, exc_info=True)
-        return 0, 0
+        return 0, 0, 0
     if num_rows <= 0:
-        return min_seq, min_seq
-    return min_seq, min_seq + num_rows - 1
+        return min_seq, min_seq, 0
+    return min_seq, min_seq + num_rows - 1, num_rows
 
 
 def _discover_segments(log_dir: Path) -> list[Path]:
@@ -126,7 +137,7 @@ def _discover_segments(log_dir: Path) -> list[Path]:
 def _recover_next_seq(log_dir: Path) -> int:
     next_seq = 1
     for p in _discover_segments(log_dir):
-        _, max_seq = _read_seq_bounds(p)
+        _, max_seq, _ = _read_segment_metadata(p)
         if max_seq + 1 > next_seq:
             next_seq = max_seq + 1
     return next_seq
@@ -161,6 +172,7 @@ class LocalSegment:
     size_bytes: int
     min_seq: int = 0
     max_seq: int = 0
+    row_count: int = 0
 
 
 def _stamp_seq_column(batch: pa.RecordBatch, first_seq: int, arrow_schema: pa.Schema) -> pa.Table:
@@ -219,6 +231,7 @@ class RamBuffers:
         self._flushing: _SealedBuffer | None = None
         self._next_seq = next_seq
         self._ram_bytes = 0
+        self._ram_rows = 0
 
     @property
     def next_seq(self) -> int:
@@ -234,10 +247,15 @@ class RamBuffers:
         self._chunks.append(table)
         self._chunks = _merge_chunks(self._chunks)
         self._ram_bytes += added
+        self._ram_rows += table.num_rows
 
     def ram_bytes(self) -> int:
         flushing_b = self._flushing.table.nbytes if self._flushing is not None else 0
         return self._ram_bytes + flushing_b
+
+    def ram_rows(self) -> int:
+        flushing_n = self._flushing.table.num_rows if self._flushing is not None else 0
+        return self._ram_rows + flushing_n
 
     def chunk_count(self) -> int:
         return len(self._chunks)
@@ -256,6 +274,7 @@ class RamBuffers:
         tables = self._chunks
         self._chunks = []
         self._ram_bytes = 0
+        self._ram_rows = 0
         visible_table = pa.concat_tables(tables) if len(tables) > 1 else tables[0]
         seq_col = visible_table.column(IMPLICIT_SEQ_COLUMN)
         sealed = _SealedBuffer(
@@ -277,6 +296,7 @@ class RamBuffers:
         table = self._flushing.table
         self._chunks.insert(0, table)
         self._ram_bytes += table.nbytes
+        self._ram_rows += table.num_rows
         self._flushing = None
 
     def query_snapshot(self) -> list[pa.Table]:
@@ -323,6 +343,8 @@ class LogNamespaceProtocol(Protocol):
 
     def stop_and_join(self) -> None: ...
 
+    def stats(self) -> NamespaceStats: ...
+
 
 class DiskLogNamespace:
     """Disk-backed per-namespace storage.
@@ -348,6 +370,7 @@ class DiskLogNamespace:
         query_visibility_lock: RWLock,
         compaction_conn: duckdb.DuckDBPyConnection,
         read_pool: _ReadPoolProtocol,
+        registry_db: RegistryDB,
         evict_hook: Callable[[], None] = lambda: None,
     ) -> None:
         self.name = name
@@ -369,6 +392,7 @@ class DiskLogNamespace:
 
         self._compaction_conn = compaction_conn
         self._read_pool = read_pool
+        self._registry_db = registry_db
 
         self._buffers = RamBuffers(
             arrow_schema=self._arrow_schema,
@@ -381,13 +405,14 @@ class DiskLogNamespace:
         # fully covered by a logs_ segment is a duplicate.
         discovered: list[LocalSegment] = []
         for p in _discover_segments(data_dir):
-            min_seq, max_seq = _read_seq_bounds(p)
+            min_seq, max_seq, row_count = _read_segment_metadata(p)
             discovered.append(
                 LocalSegment(
                     path=str(p),
                     size_bytes=p.stat().st_size,
                     min_seq=min_seq,
                     max_seq=max_seq,
+                    row_count=row_count,
                 )
             )
         log_ranges = [(s.min_seq, s.max_seq) for s in discovered if not _is_tmp_path(s.path)]
@@ -400,6 +425,16 @@ class DiskLogNamespace:
                     logger.warning("Failed to unlink stale tmp segment %s", s.path, exc_info=True)
                 continue
             self._local_segments.append(s)
+
+        # Reconcile the persistent catalog against the on-disk segment set.
+        # Parquet files are authoritative across crashes; the catalog rows
+        # for this namespace get rewritten to match exactly what's on disk
+        # right now so future reads from the catalog always agree with
+        # ``query_snapshot()``.
+        self._registry_db.reconcile_segments(
+            self.name,
+            [self._segment_to_row(seg) for seg in self._local_segments],
+        )
 
         self._flush_rl = RateLimiter(flush_interval_sec)
         self._compaction_rl = RateLimiter(compaction_interval_sec)
@@ -651,6 +686,20 @@ class DiskLogNamespace:
             return (self.schema.key_column, IMPLICIT_SEQ_COLUMN)
         return (IMPLICIT_SEQ_COLUMN,)
 
+    def _segment_to_row(self, seg: LocalSegment) -> SegmentRow:
+        """Build the catalog row that mirrors ``seg``."""
+        state = SEGMENT_STATE_TMP if _is_tmp_path(seg.path) else SEGMENT_STATE_FINALIZED
+        return SegmentRow(
+            namespace=self.name,
+            path=seg.path,
+            state=state,
+            min_seq=seg.min_seq,
+            max_seq=seg.max_seq,
+            row_count=seg.row_count,
+            byte_size=seg.size_bytes,
+            created_at_ms=int(time.time() * 1000),
+        )
+
     def _write_new_segment(self, sealed: _SealedBuffer) -> None:
         filename = _tmp_filename(sealed.min_seq)
         write_start = time.monotonic()
@@ -678,11 +727,13 @@ class DiskLogNamespace:
             size_bytes=filepath.stat().st_size,
             min_seq=sealed.min_seq,
             max_seq=sealed.max_seq,
+            row_count=sealed.table.num_rows,
         )
 
         with self._insertion_lock:
             self._local_segments.append(seg)
             self._buffers.commit_flush()
+            self._registry_db.upsert_segment(self._segment_to_row(seg))
 
         logger.info(
             "Wrote tmp segment %s: rows=%d bytes=%d seq=[%d,%d] elapsed_ms=%d",
@@ -723,6 +774,7 @@ class DiskLogNamespace:
             size_bytes=staging_path.stat().st_size,
             min_seq=min_seq,
             max_seq=max_seq,
+            row_count=sum(t.row_count for t in tmps),
         )
 
         tmp_paths = {t.path for t in tmps}
@@ -743,6 +795,11 @@ class DiskLogNamespace:
                 if not merged_inserted:
                     new_segments.append(merged_seg)
                 self._local_segments = new_segments
+                self._registry_db.replace_segments(
+                    self.name,
+                    removed_paths=list(tmp_paths),
+                    added=[self._segment_to_row(merged_seg)],
+                )
             for t in tmps:
                 try:
                     Path(t.path).unlink(missing_ok=True)
@@ -831,6 +888,7 @@ class DiskLogNamespace:
                     continue
                 new.append(s)
             self._local_segments = new
+            self._registry_db.remove_segment(self.name, path)
         try:
             Path(path).unlink(missing_ok=True)
         except OSError:
@@ -845,6 +903,8 @@ class DiskLogNamespace:
             except OSError:
                 logger.warning("Failed to delete %s during drop", s.path, exc_info=True)
         self._local_segments.clear()
+        # The catalog row for this namespace is dropped by ``RegistryDB.delete``
+        # in :meth:`DuckDBLogStore.drop_table`; segments are cascaded there too.
         # Sweep stragglers (e.g. half-written .parquet.tmp) before rmdir.
         for p in list(self._data_dir.glob("*")):
             try:
@@ -855,6 +915,36 @@ class DiskLogNamespace:
             self._data_dir.rmdir()
         except OSError:
             logger.warning("Namespace dir %s not empty after drop", self._data_dir)
+
+    def stats(self) -> NamespaceStats:
+        """Aggregate row/byte/seq stats over sealed segments + RAM buffer.
+
+        Read straight from in-memory state (which is held in lockstep with
+        the catalog) so the call is O(local_segments) and serves dashboard
+        list requests without touching parquet.
+        """
+        with self._insertion_lock:
+            if not self._local_segments and self._buffers.ram_rows() == 0:
+                return NamespaceStats.empty()
+            seg_rows = sum(s.row_count for s in self._local_segments)
+            seg_bytes = sum(s.size_bytes for s in self._local_segments)
+            seg_min = min((s.min_seq for s in self._local_segments if s.row_count > 0), default=0)
+            seg_max = max((s.max_seq for s in self._local_segments if s.row_count > 0), default=0)
+            ram_rows = self._buffers.ram_rows()
+            ram_bytes = self._buffers.ram_bytes()
+            next_seq = self._buffers.next_seq
+        # The seq counter is the high-water mark; ``ram_rows`` rows occupy
+        # ``[next_seq - ram_rows, next_seq - 1]``. If everything is in RAM
+        # (cold start before any flush) this gives a correct seq window too.
+        min_seq = seg_min if seg_min else (next_seq - ram_rows if ram_rows else 0)
+        max_seq = max(seg_max, next_seq - 1) if (seg_max or ram_rows) else 0
+        return NamespaceStats(
+            row_count=seg_rows + ram_rows,
+            byte_size=seg_bytes + ram_bytes,
+            min_seq=min_seq,
+            max_seq=max_seq,
+            segment_count=len(self._local_segments),
+        )
 
     def _offload_to_gcs(self, filename: str, filepath: Path) -> None:
         if not self._remote_log_dir:
@@ -1058,6 +1148,21 @@ class MemoryLogNamespace:
 
     def stop_and_join(self) -> None:
         return
+
+    def stats(self) -> NamespaceStats:
+        with self._insertion_lock:
+            num_rows = self._table.num_rows
+            byte_size = self._table.nbytes
+            next_seq = self._next_seq
+        if num_rows == 0:
+            return NamespaceStats.empty()
+        return NamespaceStats(
+            row_count=num_rows,
+            byte_size=byte_size,
+            min_seq=max(next_seq - num_rows, 1),
+            max_seq=next_seq - 1,
+            segment_count=0,
+        )
 
 
 class _ReadPoolProtocol(Protocol):

--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -24,7 +24,7 @@ from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from pathlib import Path
 from threading import Condition, Lock
-from typing import Protocol
+from typing import NamedTuple, Protocol
 
 import duckdb
 import fsspec.core
@@ -35,12 +35,11 @@ from rigging.timing import RateLimiter
 
 from finelog.rpc import finelog_stats_pb2 as stats_pb2
 from finelog.rpc import logging_pb2
-from finelog.store.registry_db import (
-    SEGMENT_STATE_FINALIZED,
-    SEGMENT_STATE_TMP,
+from finelog.store.catalog import (
+    Catalog,
     NamespaceStats,
-    RegistryDB,
     SegmentRow,
+    SegmentState,
 )
 from finelog.store.rwlock import RWLock
 from finelog.store.schema import (
@@ -110,24 +109,34 @@ def _min_seq_from_filename(name: str) -> int | None:
     return int(match.group(1))
 
 
-def _read_segment_metadata(path: Path) -> tuple[int, int, int]:
-    """Compute ``(min_seq, max_seq, row_count)`` from filename + parquet footer.
+class SegmentMetadata(NamedTuple):
+    """``(min_seq, max_seq, row_count)`` derived from a segment's filename + parquet footer."""
 
-    Returns ``(0, 0, 0)`` for unparseable filenames or footer-read failures —
-    the caller treats that as an empty/discardable segment.
+    min_seq: int
+    max_seq: int
+    row_count: int
+
+
+_EMPTY_SEGMENT_METADATA = SegmentMetadata(min_seq=0, max_seq=0, row_count=0)
+
+
+def _read_segment_metadata(path: Path) -> SegmentMetadata:
+    """Recover ``(min_seq, max_seq, row_count)`` from filename + parquet footer.
+
+    Returns ``_EMPTY_SEGMENT_METADATA`` for unparseable filenames or footer-read
+    failures — the caller treats that as an empty/discardable segment.
     """
     min_seq = _min_seq_from_filename(path.name)
     if min_seq is None:
-        return 0, 0, 0
+        return _EMPTY_SEGMENT_METADATA
     try:
-        meta = pq.read_metadata(path)
-        num_rows = meta.num_rows
+        num_rows = pq.read_metadata(path).num_rows
     except Exception:
         logger.warning("Failed to read parquet metadata for %s; treating as empty", path, exc_info=True)
-        return 0, 0, 0
+        return _EMPTY_SEGMENT_METADATA
     if num_rows <= 0:
-        return min_seq, min_seq, 0
-    return min_seq, min_seq + num_rows - 1, num_rows
+        return SegmentMetadata(min_seq=min_seq, max_seq=min_seq, row_count=0)
+    return SegmentMetadata(min_seq=min_seq, max_seq=min_seq + num_rows - 1, row_count=num_rows)
 
 
 def _discover_segments(log_dir: Path) -> list[Path]:
@@ -137,9 +146,9 @@ def _discover_segments(log_dir: Path) -> list[Path]:
 def _recover_next_seq(log_dir: Path) -> int:
     next_seq = 1
     for p in _discover_segments(log_dir):
-        _, max_seq, _ = _read_segment_metadata(p)
-        if max_seq + 1 > next_seq:
-            next_seq = max_seq + 1
+        meta = _read_segment_metadata(p)
+        if meta.max_seq + 1 > next_seq:
+            next_seq = meta.max_seq + 1
     return next_seq
 
 
@@ -170,9 +179,9 @@ class _SealedBuffer:
 class LocalSegment:
     path: str
     size_bytes: int
-    min_seq: int = 0
-    max_seq: int = 0
-    row_count: int = 0
+    min_seq: int
+    max_seq: int
+    row_count: int
 
 
 def _stamp_seq_column(batch: pa.RecordBatch, first_seq: int, arrow_schema: pa.Schema) -> pa.Table:
@@ -370,7 +379,7 @@ class DiskLogNamespace:
         query_visibility_lock: RWLock,
         compaction_conn: duckdb.DuckDBPyConnection,
         read_pool: _ReadPoolProtocol,
-        registry_db: RegistryDB,
+        catalog: Catalog,
         evict_hook: Callable[[], None] = lambda: None,
     ) -> None:
         self.name = name
@@ -392,7 +401,7 @@ class DiskLogNamespace:
 
         self._compaction_conn = compaction_conn
         self._read_pool = read_pool
-        self._registry_db = registry_db
+        self._catalog = catalog
 
         self._buffers = RamBuffers(
             arrow_schema=self._arrow_schema,
@@ -405,14 +414,14 @@ class DiskLogNamespace:
         # fully covered by a logs_ segment is a duplicate.
         discovered: list[LocalSegment] = []
         for p in _discover_segments(data_dir):
-            min_seq, max_seq, row_count = _read_segment_metadata(p)
+            meta = _read_segment_metadata(p)
             discovered.append(
                 LocalSegment(
                     path=str(p),
                     size_bytes=p.stat().st_size,
-                    min_seq=min_seq,
-                    max_seq=max_seq,
-                    row_count=row_count,
+                    min_seq=meta.min_seq,
+                    max_seq=meta.max_seq,
+                    row_count=meta.row_count,
                 )
             )
         log_ranges = [(s.min_seq, s.max_seq) for s in discovered if not _is_tmp_path(s.path)]
@@ -431,7 +440,7 @@ class DiskLogNamespace:
         # for this namespace get rewritten to match exactly what's on disk
         # right now so future reads from the catalog always agree with
         # ``query_snapshot()``.
-        self._registry_db.reconcile_segments(
+        self._catalog.reconcile_segments(
             self.name,
             [self._segment_to_row(seg) for seg in self._local_segments],
         )
@@ -688,7 +697,7 @@ class DiskLogNamespace:
 
     def _segment_to_row(self, seg: LocalSegment) -> SegmentRow:
         """Build the catalog row that mirrors ``seg``."""
-        state = SEGMENT_STATE_TMP if _is_tmp_path(seg.path) else SEGMENT_STATE_FINALIZED
+        state = SegmentState.TMP if _is_tmp_path(seg.path) else SegmentState.FINALIZED
         return SegmentRow(
             namespace=self.name,
             path=seg.path,
@@ -733,7 +742,7 @@ class DiskLogNamespace:
         with self._insertion_lock:
             self._local_segments.append(seg)
             self._buffers.commit_flush()
-            self._registry_db.upsert_segment(self._segment_to_row(seg))
+            self._catalog.upsert_segment(self._segment_to_row(seg))
 
         logger.info(
             "Wrote tmp segment %s: rows=%d bytes=%d seq=[%d,%d] elapsed_ms=%d",
@@ -795,7 +804,7 @@ class DiskLogNamespace:
                 if not merged_inserted:
                     new_segments.append(merged_seg)
                 self._local_segments = new_segments
-                self._registry_db.replace_segments(
+                self._catalog.replace_segments(
                     self.name,
                     removed_paths=list(tmp_paths),
                     added=[self._segment_to_row(merged_seg)],
@@ -888,7 +897,7 @@ class DiskLogNamespace:
                     continue
                 new.append(s)
             self._local_segments = new
-            self._registry_db.remove_segment(self.name, path)
+            self._catalog.remove_segment(self.name, path)
         try:
             Path(path).unlink(missing_ok=True)
         except OSError:
@@ -903,7 +912,7 @@ class DiskLogNamespace:
             except OSError:
                 logger.warning("Failed to delete %s during drop", s.path, exc_info=True)
         self._local_segments.clear()
-        # The catalog row for this namespace is dropped by ``RegistryDB.delete``
+        # The catalog row for this namespace is dropped by ``Catalog.delete``
         # in :meth:`DuckDBLogStore.drop_table`; segments are cascaded there too.
         # Sweep stragglers (e.g. half-written .parquet.tmp) before rmdir.
         for p in list(self._data_dir.glob("*")):

--- a/lib/finelog/src/finelog/store/migrations/0001_init.py
+++ b/lib/finelog/src/finelog/store/migrations/0001_init.py
@@ -1,0 +1,47 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Baseline registry schema.
+
+Creates ``namespaces`` (one row per registered namespace, holding its
+schema JSON) and ``segments`` (one row per locally-tracked parquet file,
+maintained in lockstep with the in-memory ``_local_segments`` deque).
+
+Both statements use ``IF NOT EXISTS``: existing deployments may already
+have ``namespaces`` from a release that pre-dates the migrations runner,
+or ``segments`` from an early build of the catalog branch. In either case
+this migration is a no-op against the DDL but records v1 in
+``schema_migrations`` so future versions have a defined starting point.
+"""
+
+from __future__ import annotations
+
+import duckdb
+
+
+def migrate(conn: duckdb.DuckDBPyConnection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS namespaces (
+            namespace        TEXT PRIMARY KEY,
+            schema_json      TEXT NOT NULL,
+            registered_at_ms BIGINT NOT NULL,
+            last_modified_ms BIGINT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS segments (
+            namespace     TEXT   NOT NULL,
+            path          TEXT   NOT NULL,
+            state         TEXT   NOT NULL,
+            min_seq       BIGINT NOT NULL,
+            max_seq       BIGINT NOT NULL,
+            row_count     BIGINT NOT NULL,
+            byte_size     BIGINT NOT NULL,
+            created_at_ms BIGINT NOT NULL,
+            PRIMARY KEY (namespace, path)
+        )
+        """
+    )

--- a/lib/finelog/src/finelog/store/migrations/__init__.py
+++ b/lib/finelog/src/finelog/store/migrations/__init__.py
@@ -1,0 +1,20 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Versioned migrations for the finelog registry DuckDB sidecar.
+
+Each ``NNNN_name.py`` file defines a ``migrate(conn)`` callable. The
+:func:`apply_migrations` runner in :mod:`._runner` walks the directory in
+filename order and applies any not yet recorded in the ``schema_migrations``
+table. Each migration runs inside a transaction that also inserts the
+``schema_migrations`` row, so partial application can't leave the catalog
+in a half-migrated state.
+
+Migration files must be idempotent against any pre-migrations on-disk
+state: pre-existing deployments are bootstrapped through 0001 even though
+their tables already exist.
+"""
+
+from finelog.store.migrations._runner import apply_migrations, transactional
+
+__all__ = ["apply_migrations", "transactional"]

--- a/lib/finelog/src/finelog/store/migrations/_runner.py
+++ b/lib/finelog/src/finelog/store/migrations/_runner.py
@@ -29,9 +29,6 @@ import duckdb
 
 logger = logging.getLogger(__name__)
 
-# Files starting with one of these prefixes are not migrations.
-_NON_MIGRATION_PREFIXES = ("_",)
-
 
 @contextmanager
 def transactional(conn: duckdb.DuckDBPyConnection) -> Iterator[duckdb.DuckDBPyConnection]:
@@ -53,12 +50,9 @@ def transactional(conn: duckdb.DuckDBPyConnection) -> Iterator[duckdb.DuckDBPyCo
 
 
 def _discover_migrations(migrations_dir: Path) -> list[Path]:
-    files: list[Path] = []
-    for path in sorted(migrations_dir.glob("*.py")):
-        if any(path.name.startswith(p) for p in _NON_MIGRATION_PREFIXES):
-            continue
-        files.append(path)
-    return files
+    """Migration files in numeric order. Anything starting with ``_`` (e.g.
+    ``_runner.py``, ``__init__.py``) is skipped."""
+    return [p for p in sorted(migrations_dir.glob("*.py")) if not p.name.startswith("_")]
 
 
 def _ensure_schema_migrations_table(conn: duckdb.DuckDBPyConnection) -> None:

--- a/lib/finelog/src/finelog/store/migrations/_runner.py
+++ b/lib/finelog/src/finelog/store/migrations/_runner.py
@@ -1,0 +1,116 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Versioned migrations runner for the registry DuckDB sidecar.
+
+Migration files live next to this module as ``NNNN_name.py`` and define a
+``migrate(conn)`` function. The runner discovers them in filename order,
+filters out any already recorded in the ``schema_migrations`` table, and
+applies the remainder. Each migration runs inside a transaction that also
+inserts its ``schema_migrations`` row — a crash mid-migration leaves no
+half-applied state.
+
+Migrations must be idempotent (``CREATE TABLE IF NOT EXISTS``,
+``ALTER TABLE ... ADD COLUMN IF NOT EXISTS``, etc.). Existing deployments
+may already have tables created by an earlier release that pre-dates this
+runner; the first migration just records that v1 has been observed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import duckdb
+
+logger = logging.getLogger(__name__)
+
+# Files starting with one of these prefixes are not migrations.
+_NON_MIGRATION_PREFIXES = ("_",)
+
+
+@contextmanager
+def transactional(conn: duckdb.DuckDBPyConnection) -> Iterator[duckdb.DuckDBPyConnection]:
+    """Run a block inside a DuckDB ``BEGIN``/``COMMIT`` transaction.
+
+    Any exception triggers ``ROLLBACK`` and propagates; a clean exit
+    ``COMMIT``s. Useful for callers that want all-or-nothing semantics
+    over multiple statements (compaction's segment swap, the migration
+    runner's apply-and-record pair).
+    """
+    conn.execute("BEGIN")
+    try:
+        yield conn
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+    else:
+        conn.execute("COMMIT")
+
+
+def _discover_migrations(migrations_dir: Path) -> list[Path]:
+    files: list[Path] = []
+    for path in sorted(migrations_dir.glob("*.py")):
+        if any(path.name.startswith(p) for p in _NON_MIGRATION_PREFIXES):
+            continue
+        files.append(path)
+    return files
+
+
+def _ensure_schema_migrations_table(conn: duckdb.DuckDBPyConnection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            name          TEXT PRIMARY KEY,
+            applied_at_ms BIGINT NOT NULL
+        )
+        """
+    )
+
+
+def _load_migration(path: Path):
+    """Load a migration module from a file path; return its ``migrate``."""
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None, f"failed to load migration spec for {path}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    if not hasattr(module, "migrate"):
+        raise RuntimeError(f"migration {path.name} missing required ``migrate(conn)`` callable")
+    return module.migrate
+
+
+def apply_migrations(
+    conn: duckdb.DuckDBPyConnection,
+    migrations_dir: Path | None = None,
+) -> None:
+    """Apply pending migrations from ``migrations_dir`` to ``conn``.
+
+    ``migrations_dir`` defaults to this package's directory so callers from
+    ``RegistryDB`` don't need to know where the files live.
+    """
+    if migrations_dir is None:
+        migrations_dir = Path(__file__).parent
+
+    _ensure_schema_migrations_table(conn)
+    applied = {row[0] for row in conn.execute("SELECT name FROM schema_migrations").fetchall()}
+    applied_stems = {Path(name).stem for name in applied}
+
+    pending = [p for p in _discover_migrations(migrations_dir) if p.stem not in applied_stems]
+    if not pending:
+        return
+
+    logger.info("Applying %d pending finelog registry migration(s): %s", len(pending), [p.name for p in pending])
+    for path in pending:
+        t0 = time.monotonic()
+        migrate = _load_migration(path)
+        with transactional(conn):
+            migrate(conn)
+            conn.execute(
+                "INSERT INTO schema_migrations(name, applied_at_ms) VALUES (?, ?)",
+                [path.name, int(time.time() * 1000)],
+            )
+        logger.info("finelog migration %s applied in %.3fs", path.name, time.monotonic() - t0)

--- a/lib/finelog/src/finelog/store/registry_db.py
+++ b/lib/finelog/src/finelog/store/registry_db.py
@@ -38,6 +38,7 @@ from pathlib import Path
 
 import duckdb
 
+from finelog.store.migrations import apply_migrations, transactional
 from finelog.store.schema import Schema, schema_from_json, schema_to_json
 
 logger = logging.getLogger(__name__)
@@ -106,31 +107,10 @@ class RegistryDB:
         else:
             self._path = data_dir / REGISTRY_DB_FILENAME
             self._conn = duckdb.connect(str(self._path))
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS namespaces (
-                namespace        TEXT PRIMARY KEY,
-                schema_json      TEXT NOT NULL,
-                registered_at_ms BIGINT NOT NULL,
-                last_modified_ms BIGINT NOT NULL
-            )
-            """
-        )
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS segments (
-                namespace     TEXT   NOT NULL,
-                path          TEXT   NOT NULL,
-                state         TEXT   NOT NULL,
-                min_seq       BIGINT NOT NULL,
-                max_seq       BIGINT NOT NULL,
-                row_count     BIGINT NOT NULL,
-                byte_size     BIGINT NOT NULL,
-                created_at_ms BIGINT NOT NULL,
-                PRIMARY KEY (namespace, path)
-            )
-            """
-        )
+        # Schema is owned by ``finelog.store.migrations``; every additive
+        # change (new column, new index, derived backfill) lands as a new
+        # numbered file in that package.
+        apply_migrations(self._conn)
 
     def close(self) -> None:
         self._conn.close()
@@ -227,8 +207,7 @@ class RegistryDB:
         segment. The whole swap must be visible-or-not visible to callers
         of :meth:`list_segments` — never half.
         """
-        self._conn.execute("BEGIN")
-        try:
+        with transactional(self._conn):
             for path in removed_paths:
                 self._conn.execute(
                     "DELETE FROM segments WHERE namespace = ? AND path = ?",
@@ -236,10 +215,6 @@ class RegistryDB:
                 )
             for seg in added:
                 self.upsert_segment(seg)
-            self._conn.execute("COMMIT")
-        except Exception:
-            self._conn.execute("ROLLBACK")
-            raise
 
     def remove_segment(self, namespace: str, path: str) -> None:
         """Drop one segment row. Idempotent."""
@@ -252,15 +227,10 @@ class RegistryDB:
         ``DiskLogNamespace`` boot we discover the on-disk segment set and
         push it through this method so the catalog matches reality.
         """
-        self._conn.execute("BEGIN")
-        try:
+        with transactional(self._conn):
             self._conn.execute("DELETE FROM segments WHERE namespace = ?", [namespace])
             for seg in segments:
                 self.upsert_segment(seg)
-            self._conn.execute("COMMIT")
-        except Exception:
-            self._conn.execute("ROLLBACK")
-            raise
 
     def aggregate_namespace_stats(self, namespace: str) -> NamespaceStats:
         """Single-namespace aggregate over the segments table."""

--- a/lib/finelog/src/finelog/store/registry_db.py
+++ b/lib/finelog/src/finelog/store/registry_db.py
@@ -1,27 +1,39 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Sidecar DuckDB database persisting the registered-schema table.
+"""Sidecar DuckDB database persisting the namespace + segment catalog.
 
-The :class:`RegistryDB` persists each namespace's registered schema in a
-DuckDB file at ``{data_dir}/_finelog_registry.duckdb``. Every
-``RegisterTable`` mutates one row here. On finelog startup the registry is
-read out and ``LogNamespace`` instances are rehydrated from the rows.
+The :class:`RegistryDB` persists two tables in a DuckDB file at
+``{data_dir}/_finelog_registry.duckdb``:
+
+* ``namespaces`` — one row per registered namespace holding its schema. Every
+  ``RegisterTable`` mutates one row here. On finelog startup the table is
+  read out and ``LogNamespace`` instances are rehydrated from the rows.
+
+* ``segments`` — one row per locally-tracked parquet file. Each
+  :class:`DiskLogNamespace` writes here in lockstep with its in-memory
+  ``_local_segments`` deque (insert on flush finalize, swap atomically on
+  compaction, delete on eviction). Aggregating this table answers every
+  shape-of-the-data query (row counts, seq ranges, byte totals,
+  per-namespace segment counts) without touching parquet — finelog's
+  catalog, in the Iceberg/ClickHouse-parts sense.
 
 The DB is intentionally separate from the per-namespace Parquet directories:
-schema metadata never lives in two places, so additive evolution is one
-``UPDATE``, not a smear across every parquet footer in the namespace.
+catalog metadata never lives in two places, so a row count or schema change
+is one ``UPDATE``, not a smear across every parquet footer in the namespace.
 
-This module only knows how to ``CREATE``/``UPSERT``/``SELECT`` rows. The
-register-time semantics (additive merge, conflict detection, ordering-key
-validation) live in :mod:`finelog.store.schema` and the routing/locking
-lives in :class:`finelog.store.duckdb_store.DuckDBLogStore`.
+Concurrency: the ``RegistryDB`` is not thread-safe by itself. Every caller
+in :class:`finelog.store.duckdb_store.DuckDBLogStore` and
+:class:`finelog.store.log_namespace.DiskLogNamespace` already holds the
+shared ``_insertion_lock`` around mutating calls, which serializes access.
 """
 
 from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Sequence
+from dataclasses import dataclass
 from pathlib import Path
 
 import duckdb
@@ -32,12 +44,55 @@ logger = logging.getLogger(__name__)
 
 REGISTRY_DB_FILENAME = "_finelog_registry.duckdb"
 
+# Segment lifecycle states. ``tmp`` is a freshly-flushed segment awaiting
+# compaction; ``finalized`` is a compacted ``logs_*`` segment.
+SEGMENT_STATE_TMP = "tmp"
+SEGMENT_STATE_FINALIZED = "finalized"
+
+
+@dataclass(frozen=True)
+class SegmentRow:
+    """One persisted row in the segments catalog table.
+
+    ``state`` is :data:`SEGMENT_STATE_TMP` for in-flight ``tmp_*`` segments
+    written by ``_flush_step`` and :data:`SEGMENT_STATE_FINALIZED` for
+    ``logs_*`` segments produced by ``_compaction_step``.
+    """
+
+    namespace: str
+    path: str
+    state: str
+    min_seq: int
+    max_seq: int
+    row_count: int
+    byte_size: int
+    created_at_ms: int
+
+
+@dataclass(frozen=True)
+class NamespaceStats:
+    """Aggregate counters for one namespace's persisted segments.
+
+    Live (in-RAM) buffer counts are layered on top of these by the namespace
+    in :meth:`finelog.store.log_namespace.DiskLogNamespace.stats`.
+    """
+
+    row_count: int
+    byte_size: int
+    min_seq: int
+    max_seq: int
+    segment_count: int
+
+    @classmethod
+    def empty(cls) -> NamespaceStats:
+        return cls(row_count=0, byte_size=0, min_seq=0, max_seq=0, segment_count=0)
+
 
 class RegistryDB:
     """Thin wrapper around the sidecar DuckDB database.
 
-    Not concurrency-safe by itself — the caller (``DuckDBLogStore``) holds
-    the registry's insertion mutex around any mutating call.
+    Not concurrency-safe by itself — callers hold the shared insertion mutex
+    around any mutating call.
     """
 
     def __init__(self, data_dir: Path | None) -> None:
@@ -61,9 +116,26 @@ class RegistryDB:
             )
             """
         )
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS segments (
+                namespace     TEXT   NOT NULL,
+                path          TEXT   NOT NULL,
+                state         TEXT   NOT NULL,
+                min_seq       BIGINT NOT NULL,
+                max_seq       BIGINT NOT NULL,
+                row_count     BIGINT NOT NULL,
+                byte_size     BIGINT NOT NULL,
+                created_at_ms BIGINT NOT NULL,
+                PRIMARY KEY (namespace, path)
+            )
+            """
+        )
 
     def close(self) -> None:
         self._conn.close()
+
+    # ----- namespaces table ---------------------------------------------
 
     def get(self, namespace: str) -> Schema | None:
         row = self._conn.execute("SELECT schema_json FROM namespaces WHERE namespace = ?", [namespace]).fetchone()
@@ -76,7 +148,8 @@ class RegistryDB:
         return {name: schema_from_json(payload) for name, payload in rows}
 
     def delete(self, namespace: str) -> None:
-        """Remove the row for ``namespace`` if it exists. Idempotent."""
+        """Remove the namespace row and any segment rows. Idempotent."""
+        self._conn.execute("DELETE FROM segments WHERE namespace = ?", [namespace])
         self._conn.execute("DELETE FROM namespaces WHERE namespace = ?", [namespace])
 
     def upsert(self, namespace: str, schema: Schema) -> None:
@@ -99,4 +172,117 @@ class RegistryDB:
                   last_modified_ms = excluded.last_modified_ms
             """,
             [namespace, schema_to_json(schema), registered_at, now_ms],
+        )
+
+    # ----- segments table -----------------------------------------------
+
+    def list_segments(self, namespace: str) -> list[SegmentRow]:
+        rows = self._conn.execute(
+            """
+            SELECT namespace, path, state, min_seq, max_seq, row_count, byte_size, created_at_ms
+            FROM segments
+            WHERE namespace = ?
+            ORDER BY min_seq
+            """,
+            [namespace],
+        ).fetchall()
+        return [SegmentRow(*row) for row in rows]
+
+    def upsert_segment(self, segment: SegmentRow) -> None:
+        """Insert or replace one segment row (used by flush + reconciliation)."""
+        self._conn.execute(
+            """
+            INSERT INTO segments
+                (namespace, path, state, min_seq, max_seq, row_count, byte_size, created_at_ms)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (namespace, path) DO UPDATE SET
+                state = excluded.state,
+                min_seq = excluded.min_seq,
+                max_seq = excluded.max_seq,
+                row_count = excluded.row_count,
+                byte_size = excluded.byte_size,
+                created_at_ms = excluded.created_at_ms
+            """,
+            [
+                segment.namespace,
+                segment.path,
+                segment.state,
+                segment.min_seq,
+                segment.max_seq,
+                segment.row_count,
+                segment.byte_size,
+                segment.created_at_ms,
+            ],
+        )
+
+    def replace_segments(
+        self,
+        namespace: str,
+        removed_paths: Sequence[str],
+        added: Sequence[SegmentRow],
+    ) -> None:
+        """Atomically swap ``removed_paths`` for ``added`` rows in one txn.
+
+        Used by compaction, where N tmp segments collapse into one finalized
+        segment. The whole swap must be visible-or-not visible to callers
+        of :meth:`list_segments` — never half.
+        """
+        self._conn.execute("BEGIN")
+        try:
+            for path in removed_paths:
+                self._conn.execute(
+                    "DELETE FROM segments WHERE namespace = ? AND path = ?",
+                    [namespace, path],
+                )
+            for seg in added:
+                self.upsert_segment(seg)
+            self._conn.execute("COMMIT")
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            raise
+
+    def remove_segment(self, namespace: str, path: str) -> None:
+        """Drop one segment row. Idempotent."""
+        self._conn.execute("DELETE FROM segments WHERE namespace = ? AND path = ?", [namespace, path])
+
+    def reconcile_segments(self, namespace: str, segments: Sequence[SegmentRow]) -> None:
+        """Replace this namespace's segment rows wholesale (startup recovery).
+
+        Parquet files on disk are authoritative across crashes; on every
+        ``DiskLogNamespace`` boot we discover the on-disk segment set and
+        push it through this method so the catalog matches reality.
+        """
+        self._conn.execute("BEGIN")
+        try:
+            self._conn.execute("DELETE FROM segments WHERE namespace = ?", [namespace])
+            for seg in segments:
+                self.upsert_segment(seg)
+            self._conn.execute("COMMIT")
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            raise
+
+    def aggregate_namespace_stats(self, namespace: str) -> NamespaceStats:
+        """Single-namespace aggregate over the segments table."""
+        row = self._conn.execute(
+            """
+            SELECT
+                COALESCE(SUM(row_count), 0),
+                COALESCE(SUM(byte_size), 0),
+                COALESCE(MIN(min_seq), 0),
+                COALESCE(MAX(max_seq), 0),
+                COUNT(*)
+            FROM segments
+            WHERE namespace = ?
+            """,
+            [namespace],
+        ).fetchone()
+        if row is None:
+            return NamespaceStats.empty()
+        return NamespaceStats(
+            row_count=int(row[0]),
+            byte_size=int(row[1]),
+            min_seq=int(row[2]),
+            max_seq=int(row[3]),
+            segment_count=int(row[4]),
         )

--- a/lib/finelog/tests/test_catalog_stats.py
+++ b/lib/finelog/tests/test_catalog_stats.py
@@ -15,13 +15,8 @@ from __future__ import annotations
 
 import pytest
 from finelog.rpc import logging_pb2
+from finelog.store.catalog import Catalog, NamespaceStats, SegmentState
 from finelog.store.duckdb_store import DuckDBLogStore
-from finelog.store.registry_db import (
-    SEGMENT_STATE_FINALIZED,
-    SEGMENT_STATE_TMP,
-    NamespaceStats,
-    RegistryDB,
-)
 
 from tests.conftest import _ipc_bytes, _seal, _worker_batch, _worker_schema
 
@@ -34,7 +29,7 @@ def _stats(store: DuckDBLogStore, namespace: str) -> NamespaceStats:
 
 
 def _segments(store: DuckDBLogStore, namespace: str):
-    return store._registry_db.list_segments(namespace)
+    return store._catalog.list_segments(namespace)
 
 
 # ---------------------------------------------------------------------------
@@ -72,7 +67,7 @@ def test_stats_after_flush_match_segments_table(store):
 
     segs = _segments(store, "iris.worker")
     assert len(segs) == 1
-    assert segs[0].state == SEGMENT_STATE_TMP
+    assert segs[0].state == SegmentState.TMP
     assert segs[0].row_count == 2
     assert segs[0].min_seq == 1
     assert segs[0].max_seq == 2
@@ -88,13 +83,13 @@ def test_compaction_replaces_tmp_rows_atomically(store):
     # Three tmp segments before compaction.
     pre = _segments(store, "iris.worker")
     assert len(pre) == 3
-    assert all(s.state == SEGMENT_STATE_TMP for s in pre)
+    assert all(s.state == SegmentState.TMP for s in pre)
 
     store._namespaces["iris.worker"]._compaction_step(compact_single=True)
 
     post = _segments(store, "iris.worker")
     assert len(post) == 1
-    assert post[0].state == SEGMENT_STATE_FINALIZED
+    assert post[0].state == SegmentState.FINALIZED
     assert post[0].row_count == 3
     assert post[0].min_seq == 1
     assert post[0].max_seq == 3
@@ -217,20 +212,20 @@ def test_log_namespace_stats_count_pushed_logs(store):
 
 
 # ---------------------------------------------------------------------------
-# RegistryDB unit checks
+# Catalog unit checks
 # ---------------------------------------------------------------------------
 
 
 def test_registry_replace_segments_is_atomic(tmp_path):
     """A failing upsert mid-replace must roll the whole swap back."""
-    db = RegistryDB(tmp_path)
+    db = Catalog(tmp_path)
     db.upsert("ns", _worker_schema())
-    from finelog.store.registry_db import SegmentRow
+    from finelog.store.catalog import SegmentRow
 
     initial = SegmentRow(
         namespace="ns",
         path="/old.parquet",
-        state=SEGMENT_STATE_TMP,
+        state=SegmentState.TMP,
         min_seq=1,
         max_seq=10,
         row_count=10,
@@ -245,7 +240,7 @@ def test_registry_replace_segments_is_atomic(tmp_path):
     bad = SegmentRow(
         namespace="ns",
         path="/new.parquet",
-        state=SEGMENT_STATE_FINALIZED,
+        state=SegmentState.FINALIZED,
         min_seq=1,
         max_seq=10,
         row_count=10,

--- a/lib/finelog/tests/test_catalog_stats.py
+++ b/lib/finelog/tests/test_catalog_stats.py
@@ -1,0 +1,270 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the per-segment catalog and the namespace stats it powers.
+
+The segment catalog (``segments`` table in ``_finelog_registry.duckdb``) is
+maintained in lockstep with each namespace's in-memory ``_local_segments``
+deque. These tests pin that contract: row counts and seq ranges surfaced by
+``DuckDBLogStore.list_namespaces_with_stats`` must match what's actually on
+disk and in RAM after every lifecycle event (write → flush → compact →
+evict → drop → restart).
+"""
+
+from __future__ import annotations
+
+import pytest
+from finelog.rpc import logging_pb2
+from finelog.store.duckdb_store import DuckDBLogStore
+from finelog.store.registry_db import (
+    SEGMENT_STATE_FINALIZED,
+    SEGMENT_STATE_TMP,
+    NamespaceStats,
+    RegistryDB,
+)
+
+from tests.conftest import _ipc_bytes, _seal, _worker_batch, _worker_schema
+
+
+def _stats(store: DuckDBLogStore, namespace: str) -> NamespaceStats:
+    for name, _schema, stats in store.list_namespaces_with_stats():
+        if name == namespace:
+            return stats
+    raise KeyError(namespace)
+
+
+def _segments(store: DuckDBLogStore, namespace: str):
+    return store._registry_db.list_segments(namespace)
+
+
+# ---------------------------------------------------------------------------
+# stats() tracks rows across the write → flush → compact lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_stats_reflect_ram_buffer_before_flush(store, tmp_path):
+    store.register_table("iris.worker", _worker_schema())
+    batch = _worker_batch(["w-0", "w-1", "w-2"], [10, 20, 30], [1, 2, 3])
+    store.write_rows("iris.worker", _ipc_bytes(batch))
+
+    stats = _stats(store, "iris.worker")
+    assert stats.row_count == 3
+    assert stats.byte_size > 0
+    assert stats.min_seq == 1
+    assert stats.max_seq == 3
+    # No segment has been flushed yet.
+    assert stats.segment_count == 0
+    assert _segments(store, "iris.worker") == []
+
+
+def test_stats_after_flush_match_segments_table(store):
+    store.register_table("iris.worker", _worker_schema())
+    batch = _worker_batch(["w-0", "w-1"], [1, 2], [10, 20])
+    store.write_rows("iris.worker", _ipc_bytes(batch))
+
+    store._namespaces["iris.worker"]._flush_step()
+
+    stats = _stats(store, "iris.worker")
+    assert stats.row_count == 2
+    assert stats.segment_count == 1
+    assert stats.min_seq == 1
+    assert stats.max_seq == 2
+
+    segs = _segments(store, "iris.worker")
+    assert len(segs) == 1
+    assert segs[0].state == SEGMENT_STATE_TMP
+    assert segs[0].row_count == 2
+    assert segs[0].min_seq == 1
+    assert segs[0].max_seq == 2
+
+
+def test_compaction_replaces_tmp_rows_atomically(store):
+    store.register_table("iris.worker", _worker_schema())
+    for i in range(3):
+        batch = _worker_batch([f"w-{i}"], [i], [i])
+        store.write_rows("iris.worker", _ipc_bytes(batch))
+        store._namespaces["iris.worker"]._flush_step()
+
+    # Three tmp segments before compaction.
+    pre = _segments(store, "iris.worker")
+    assert len(pre) == 3
+    assert all(s.state == SEGMENT_STATE_TMP for s in pre)
+
+    store._namespaces["iris.worker"]._compaction_step(compact_single=True)
+
+    post = _segments(store, "iris.worker")
+    assert len(post) == 1
+    assert post[0].state == SEGMENT_STATE_FINALIZED
+    assert post[0].row_count == 3
+    assert post[0].min_seq == 1
+    assert post[0].max_seq == 3
+
+    stats = _stats(store, "iris.worker")
+    assert stats.row_count == 3
+    assert stats.segment_count == 1
+
+
+def test_eviction_removes_segment_row(store):
+    store.register_table("iris.worker", _worker_schema())
+    batch = _worker_batch(["w-0"], [1], [1])
+    store.write_rows("iris.worker", _ipc_bytes(batch))
+    _seal(store, "iris.worker")
+
+    segs = _segments(store, "iris.worker")
+    assert len(segs) == 1
+    path = segs[0].path
+
+    store._namespaces["iris.worker"].evict_segment(path)
+
+    assert _segments(store, "iris.worker") == []
+    stats = _stats(store, "iris.worker")
+    assert stats.row_count == 0
+    assert stats.segment_count == 0
+
+
+def test_drop_table_clears_namespace_segments(store):
+    store.register_table("iris.worker", _worker_schema())
+    batch = _worker_batch(["w-0"], [1], [1])
+    store.write_rows("iris.worker", _ipc_bytes(batch))
+    _seal(store, "iris.worker")
+    assert _segments(store, "iris.worker") != []
+
+    store.drop_table("iris.worker")
+
+    # Catalog rows for the namespace go away with the namespace itself.
+    assert _segments(store, "iris.worker") == []
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation: catalog re-derives from on-disk parquet at startup
+# ---------------------------------------------------------------------------
+
+
+def test_segments_catalog_survives_restart(tmp_path):
+    log_dir = tmp_path / "store"
+    s1 = DuckDBLogStore(log_dir=log_dir)
+    s1.register_table("iris.worker", _worker_schema())
+    for i in range(2):
+        batch = _worker_batch([f"w-{i}"], [i], [i])
+        s1.write_rows("iris.worker", _ipc_bytes(batch))
+    _seal(s1, "iris.worker")
+    pre_segs = _segments(s1, "iris.worker")
+    pre_stats = _stats(s1, "iris.worker")
+    s1.close()
+
+    s2 = DuckDBLogStore(log_dir=log_dir)
+    try:
+        post_segs = _segments(s2, "iris.worker")
+        post_stats = _stats(s2, "iris.worker")
+        # File set is identical; reconciliation rewrites the rows but the
+        # post-rewrite content must match.
+        assert {s.path for s in post_segs} == {s.path for s in pre_segs}
+        assert sum(s.row_count for s in post_segs) == sum(s.row_count for s in pre_segs)
+        assert post_stats.row_count == pre_stats.row_count
+        assert post_stats.segment_count == pre_stats.segment_count
+        assert post_stats.min_seq == pre_stats.min_seq
+        assert post_stats.max_seq == pre_stats.max_seq
+    finally:
+        s2.close()
+
+
+def test_reconcile_drops_rows_for_missing_files(tmp_path):
+    """An out-of-band parquet deletion is reflected after a restart."""
+    log_dir = tmp_path / "store"
+    s1 = DuckDBLogStore(log_dir=log_dir)
+    s1.register_table("iris.worker", _worker_schema())
+    s1.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-0"], [1], [1])))
+    _seal(s1, "iris.worker")
+    seg_path = _segments(s1, "iris.worker")[0].path
+    s1.close()
+
+    # Delete the parquet behind the catalog's back.
+    import os
+
+    os.unlink(seg_path)
+
+    s2 = DuckDBLogStore(log_dir=log_dir)
+    try:
+        # Reconciliation rewrites the segment list to match the disk truth.
+        assert _segments(s2, "iris.worker") == []
+        stats = _stats(s2, "iris.worker")
+        assert stats.segment_count == 0
+        assert stats.row_count == 0
+    finally:
+        s2.close()
+
+
+# ---------------------------------------------------------------------------
+# stats are also surfaced for the privileged "log" namespace
+# ---------------------------------------------------------------------------
+
+
+def test_log_namespace_stats_count_pushed_logs(store):
+    entries = [
+        logging_pb2.LogEntry(
+            timestamp=logging_pb2.Timestamp(epoch_ms=ts),
+            source="stdout",
+            data=f"hello-{ts}",
+        )
+        for ts in (10, 20, 30)
+    ]
+    store.append("/system/test", entries)
+
+    stats = _stats(store, "log")
+    assert stats.row_count == 3
+    assert stats.min_seq == 1
+    assert stats.max_seq == 3
+
+
+# ---------------------------------------------------------------------------
+# RegistryDB unit checks
+# ---------------------------------------------------------------------------
+
+
+def test_registry_replace_segments_is_atomic(tmp_path):
+    """A failing upsert mid-replace must roll the whole swap back."""
+    db = RegistryDB(tmp_path)
+    db.upsert("ns", _worker_schema())
+    from finelog.store.registry_db import SegmentRow
+
+    initial = SegmentRow(
+        namespace="ns",
+        path="/old.parquet",
+        state=SEGMENT_STATE_TMP,
+        min_seq=1,
+        max_seq=10,
+        row_count=10,
+        byte_size=100,
+        created_at_ms=0,
+    )
+    db.upsert_segment(initial)
+
+    # Inject a row whose primary key collides with the row we keep — this
+    # would survive ON CONFLICT logic, but feed a row with a constraint
+    # violation: NULL in NOT NULL column. Easiest is to monkey-patch.
+    bad = SegmentRow(
+        namespace="ns",
+        path="/new.parquet",
+        state=SEGMENT_STATE_FINALIZED,
+        min_seq=1,
+        max_seq=10,
+        row_count=10,
+        byte_size=200,
+        created_at_ms=0,
+    )
+
+    real_upsert = db.upsert_segment
+
+    def boom(seg):
+        if seg.path == "/new.parquet":
+            raise RuntimeError("simulated insert failure")
+        real_upsert(seg)
+
+    db.upsert_segment = boom  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError):
+        db.replace_segments("ns", removed_paths=["/old.parquet"], added=[bad])
+
+    # Rollback restored the original row.
+    rows = db.list_segments("ns")
+    assert [r.path for r in rows] == ["/old.parquet"]
+    db.close()

--- a/lib/finelog/tests/test_migrations.py
+++ b/lib/finelog/tests/test_migrations.py
@@ -14,8 +14,8 @@ from pathlib import Path
 
 import duckdb
 import pytest
+from finelog.store.catalog import Catalog
 from finelog.store.migrations import apply_migrations, transactional
-from finelog.store.registry_db import RegistryDB
 
 
 def _list_tables(conn: duckdb.DuckDBPyConnection) -> set[str]:
@@ -32,7 +32,7 @@ def _applied_migrations(conn: duckdb.DuckDBPyConnection) -> list[str]:
 
 
 def test_fresh_registry_runs_baseline_migration(tmp_path):
-    db = RegistryDB(tmp_path)
+    db = Catalog(tmp_path)
     try:
         tables = _list_tables(db._conn)
         assert "namespaces" in tables
@@ -45,8 +45,8 @@ def test_fresh_registry_runs_baseline_migration(tmp_path):
 
 def test_reopen_is_idempotent(tmp_path):
     """Opening the same data dir twice does not re-apply migrations."""
-    RegistryDB(tmp_path).close()
-    db = RegistryDB(tmp_path)
+    Catalog(tmp_path).close()
+    db = Catalog(tmp_path)
     try:
         # Still exactly one row, not two.
         assert _applied_migrations(db._conn) == ["0001_init.py"]
@@ -76,7 +76,7 @@ def test_pre_migrations_database_inherits_baseline(tmp_path):
     legacy.execute('INSERT INTO namespaces VALUES (\'iris.worker\', \'{"columns":[],"key_column":""}\', 0, 0)')
     legacy.close()
 
-    db = RegistryDB(tmp_path)
+    db = Catalog(tmp_path)
     try:
         # Existing row preserved; segments table created; baseline recorded.
         assert db._conn.execute("SELECT namespace FROM namespaces").fetchall() == [("iris.worker",)]
@@ -126,30 +126,27 @@ def test_failed_migration_retries_on_next_apply(tmp_path):
     """A migration that failed once must run again on the next open."""
     fake_dir = tmp_path / "migs"
     fake_dir.mkdir()
-    (fake_dir / "0001_flaky.py").write_text(
-        "import duckdb, os\n"
-        "_FLAG = os.environ.get('FLAKY_PASS', '0')\n"
-        "def migrate(conn: duckdb.DuckDBPyConnection) -> None:\n"
+    migration_path = fake_dir / "0001_flaky.py"
+
+    # First version raises after a side-effect, simulating a half-failed apply.
+    migration_path.write_text(
+        "def migrate(conn):\n"
         "    conn.execute('CREATE TABLE IF NOT EXISTS marker (n INTEGER)')\n"
-        "    if _FLAG != '1':\n"
-        "        raise RuntimeError('not yet')\n"
+        "    raise RuntimeError('not yet')\n"
     )
 
     conn = duckdb.connect(":memory:")
     try:
-        # First attempt: env says fail.
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="not yet"):
             apply_migrations(conn, fake_dir)
         assert _applied_migrations(conn) == []
 
-        # Second attempt: env says pass. Migration is retried.
-        import os
-
-        os.environ["FLAKY_PASS"] = "1"
-        try:
-            apply_migrations(conn, fake_dir)
-        finally:
-            del os.environ["FLAKY_PASS"]
+        # Author fixes the migration; next apply picks it up because no row
+        # was inserted on the failed pass.
+        migration_path.write_text(
+            "def migrate(conn):\n    conn.execute('CREATE TABLE IF NOT EXISTS marker (n INTEGER)')\n"
+        )
+        apply_migrations(conn, fake_dir)
         assert _applied_migrations(conn) == ["0001_flaky.py"]
     finally:
         conn.close()
@@ -211,21 +208,18 @@ def test_underscore_prefixed_files_are_skipped(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_registry_segments_apis_function_after_migration(tmp_path):
-    """End-to-end check: write a segment row through the public RegistryDB API."""
-    from finelog.store.registry_db import (
-        SEGMENT_STATE_FINALIZED,
-        SegmentRow,
-    )
+def test_catalog_segments_apis_function_after_migration(tmp_path):
+    """End-to-end check: write a segment row through the public Catalog API."""
+    from finelog.store.catalog import SegmentRow, SegmentState
 
-    db = RegistryDB(tmp_path)
+    db = Catalog(tmp_path)
     try:
         # ``aggregate_namespace_stats`` and friends rely on the baseline schema.
         assert db.aggregate_namespace_stats("ns").row_count == 0
         seg = SegmentRow(
             namespace="ns",
             path=str(Path("/x/0001.parquet")),
-            state=SEGMENT_STATE_FINALIZED,
+            state=SegmentState.FINALIZED,
             min_seq=1,
             max_seq=10,
             row_count=10,

--- a/lib/finelog/tests/test_migrations.py
+++ b/lib/finelog/tests/test_migrations.py
@@ -1,0 +1,240 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the registry migrations runner.
+
+The runner backs every catalog schema change after the baseline; pinning
+its core invariants (idempotency, transactional apply, partial-failure
+rollback, legacy-database adoption) keeps future migration authors honest.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pytest
+from finelog.store.migrations import apply_migrations, transactional
+from finelog.store.registry_db import RegistryDB
+
+
+def _list_tables(conn: duckdb.DuckDBPyConnection) -> set[str]:
+    return {row[0] for row in conn.execute("SELECT table_name FROM duckdb_tables()").fetchall()}
+
+
+def _applied_migrations(conn: duckdb.DuckDBPyConnection) -> list[str]:
+    return [row[0] for row in conn.execute("SELECT name FROM schema_migrations ORDER BY name").fetchall()]
+
+
+# ---------------------------------------------------------------------------
+# Baseline: a fresh registry has all tables and 0001 recorded.
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_registry_runs_baseline_migration(tmp_path):
+    db = RegistryDB(tmp_path)
+    try:
+        tables = _list_tables(db._conn)
+        assert "namespaces" in tables
+        assert "segments" in tables
+        assert "schema_migrations" in tables
+        assert _applied_migrations(db._conn) == ["0001_init.py"]
+    finally:
+        db.close()
+
+
+def test_reopen_is_idempotent(tmp_path):
+    """Opening the same data dir twice does not re-apply migrations."""
+    RegistryDB(tmp_path).close()
+    db = RegistryDB(tmp_path)
+    try:
+        # Still exactly one row, not two.
+        assert _applied_migrations(db._conn) == ["0001_init.py"]
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Legacy adoption: a pre-migrations DB inherits the baseline cleanly.
+# ---------------------------------------------------------------------------
+
+
+def test_pre_migrations_database_inherits_baseline(tmp_path):
+    """A DB created by an old release (only ``namespaces`` table) opens cleanly."""
+    db_path = tmp_path / "_finelog_registry.duckdb"
+    legacy = duckdb.connect(str(db_path))
+    legacy.execute(
+        """
+        CREATE TABLE namespaces (
+            namespace        TEXT PRIMARY KEY,
+            schema_json      TEXT NOT NULL,
+            registered_at_ms BIGINT NOT NULL,
+            last_modified_ms BIGINT NOT NULL
+        )
+        """
+    )
+    legacy.execute('INSERT INTO namespaces VALUES (\'iris.worker\', \'{"columns":[],"key_column":""}\', 0, 0)')
+    legacy.close()
+
+    db = RegistryDB(tmp_path)
+    try:
+        # Existing row preserved; segments table created; baseline recorded.
+        assert db._conn.execute("SELECT namespace FROM namespaces").fetchall() == [("iris.worker",)]
+        assert "segments" in _list_tables(db._conn)
+        assert _applied_migrations(db._conn) == ["0001_init.py"]
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Transactional apply: a failing migration leaves no row in schema_migrations.
+# ---------------------------------------------------------------------------
+
+
+def test_failing_migration_rolls_back(tmp_path):
+    fake_dir = tmp_path / "migs"
+    fake_dir.mkdir()
+    # 0001 succeeds, 0002 fails. Both should be observable via the runner;
+    # only 0001 should be marked applied.
+    (fake_dir / "0001_ok.py").write_text(
+        "import duckdb\n"
+        "def migrate(conn: duckdb.DuckDBPyConnection) -> None:\n"
+        "    conn.execute('CREATE TABLE ok_marker (n INTEGER)')\n"
+    )
+    (fake_dir / "0002_boom.py").write_text(
+        "import duckdb\n"
+        "def migrate(conn: duckdb.DuckDBPyConnection) -> None:\n"
+        "    conn.execute('CREATE TABLE will_be_rolled_back (n INTEGER)')\n"
+        "    raise RuntimeError('simulated migration failure')\n"
+    )
+
+    conn = duckdb.connect(":memory:")
+    try:
+        with pytest.raises(RuntimeError, match="simulated migration failure"):
+            apply_migrations(conn, fake_dir)
+
+        # 0001 is recorded and its table exists.
+        assert _applied_migrations(conn) == ["0001_ok.py"]
+        assert "ok_marker" in _list_tables(conn)
+        # 0002's side-effect was rolled back: neither the table nor a row.
+        assert "will_be_rolled_back" not in _list_tables(conn)
+    finally:
+        conn.close()
+
+
+def test_failed_migration_retries_on_next_apply(tmp_path):
+    """A migration that failed once must run again on the next open."""
+    fake_dir = tmp_path / "migs"
+    fake_dir.mkdir()
+    (fake_dir / "0001_flaky.py").write_text(
+        "import duckdb, os\n"
+        "_FLAG = os.environ.get('FLAKY_PASS', '0')\n"
+        "def migrate(conn: duckdb.DuckDBPyConnection) -> None:\n"
+        "    conn.execute('CREATE TABLE IF NOT EXISTS marker (n INTEGER)')\n"
+        "    if _FLAG != '1':\n"
+        "        raise RuntimeError('not yet')\n"
+    )
+
+    conn = duckdb.connect(":memory:")
+    try:
+        # First attempt: env says fail.
+        with pytest.raises(RuntimeError):
+            apply_migrations(conn, fake_dir)
+        assert _applied_migrations(conn) == []
+
+        # Second attempt: env says pass. Migration is retried.
+        import os
+
+        os.environ["FLAKY_PASS"] = "1"
+        try:
+            apply_migrations(conn, fake_dir)
+        finally:
+            del os.environ["FLAKY_PASS"]
+        assert _applied_migrations(conn) == ["0001_flaky.py"]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# transactional helper exposed for callers (compaction's segment swap, etc.)
+# ---------------------------------------------------------------------------
+
+
+def test_transactional_commits_on_success():
+    conn = duckdb.connect(":memory:")
+    try:
+        conn.execute("CREATE TABLE t (n INTEGER)")
+        with transactional(conn):
+            conn.execute("INSERT INTO t VALUES (1)")
+            conn.execute("INSERT INTO t VALUES (2)")
+        assert conn.execute("SELECT count(*) FROM t").fetchone() == (2,)
+    finally:
+        conn.close()
+
+
+def test_transactional_rolls_back_on_exception():
+    conn = duckdb.connect(":memory:")
+    try:
+        conn.execute("CREATE TABLE t (n INTEGER)")
+        conn.execute("INSERT INTO t VALUES (1)")
+        with pytest.raises(ValueError):
+            with transactional(conn):
+                conn.execute("INSERT INTO t VALUES (2)")
+                raise ValueError("rollback please")
+        assert conn.execute("SELECT count(*) FROM t").fetchone() == (1,)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Discovery: hidden / dunder files are not picked up.
+# ---------------------------------------------------------------------------
+
+
+def test_underscore_prefixed_files_are_skipped(tmp_path):
+    fake_dir = tmp_path / "migs"
+    fake_dir.mkdir()
+    (fake_dir / "_runner.py").write_text("raise AssertionError('runner module should never be loaded as a migration')")
+    (fake_dir / "__init__.py").write_text("raise AssertionError('package init should never be loaded as a migration')")
+    (fake_dir / "0001_real.py").write_text("def migrate(conn): conn.execute('CREATE TABLE m (n INTEGER)')\n")
+
+    conn = duckdb.connect(":memory:")
+    try:
+        apply_migrations(conn, fake_dir)
+        assert _applied_migrations(conn) == ["0001_real.py"]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Integrity: a real production-shaped catalog still works after migrations.
+# ---------------------------------------------------------------------------
+
+
+def test_registry_segments_apis_function_after_migration(tmp_path):
+    """End-to-end check: write a segment row through the public RegistryDB API."""
+    from finelog.store.registry_db import (
+        SEGMENT_STATE_FINALIZED,
+        SegmentRow,
+    )
+
+    db = RegistryDB(tmp_path)
+    try:
+        # ``aggregate_namespace_stats`` and friends rely on the baseline schema.
+        assert db.aggregate_namespace_stats("ns").row_count == 0
+        seg = SegmentRow(
+            namespace="ns",
+            path=str(Path("/x/0001.parquet")),
+            state=SEGMENT_STATE_FINALIZED,
+            min_seq=1,
+            max_seq=10,
+            row_count=10,
+            byte_size=1024,
+            created_at_ms=0,
+        )
+        db.upsert_segment(seg)
+        stats = db.aggregate_namespace_stats("ns")
+        assert stats.row_count == 10
+        assert stats.segment_count == 1
+    finally:
+        db.close()


### PR DESCRIPTION
Add a segments catalog table to the registry DuckDB sidecar, maintained in
lockstep with each namespace's in-memory segment deque. Surface row counts,
byte sizes, and seq ranges through ListNamespaces so the dashboard reads them
without per-namespace count(*) (~5s on the marin log server). Lift inline DDL
into a numbered-file migrations runner with a transactional helper.