### PR TITLE
[zephyr] Design document for moving Zephyr to Arrow / Polars

### DIFF
--- a/.agents/projects/20260504-zephyr-arrow/api.md
+++ b/.agents/projects/20260504-zephyr-arrow/api.md
@@ -1,0 +1,77 @@
+# API Design
+
+## Constraints
+
+To get the maximum benefit from Zephyr's Arrow/Polars internals, users need to do two things:
+
+1. Use Polars as much as possible in `map` / `flat_map` to avoid doing data processing in Python.
+2. Use the new `group_by` and `reduce` functions so Zephyr can avoid creating Python objects in the reducer and combiner. This requires the preceding step to produce `DataFrame`s (not Python dicts).
+
+---
+
+## API Options
+### Option A: Separate `ArrowDataset` class
+
+Create two distinct dataset types:
+1. `Dataset` — unchanged; existing jobs continue to run with Python `dict` items.
+2. `ArrowDataset` — same pipeline API (`from_files`, `map`, `flat_map`, `group_by`, `reduce`) but `group_by` and `reduce` receive `pa.RecordBatch`.
+
+### Option B: New `group_by_arrow / `reduce_arrow` methods on `Dataset`
+
+Leave `Dataset` as-is and add suffixed variants.
+
+### Recommendation: Option A (`ArrowDataset`)
+
+`AGENTS.md` says "Use separate classes over boolean flags for variant behavior" — the same principle applies to `_polars`-suffixed method variants, which are just boolean dispatch with extra typing overhead.
+
+The separate class makes the "you're committing to Arrow/Polars processing" contract explicit at construction time. It make it less likely to have pipelines that interleave Python and Arrow processing functions in ways that are confusing or incorrect.
+
+The existing `Dataset` stays as-is for now. Per `AGENTS.md`, no backward-compat shims — update all call sites if/when we want to rename it.
+
+## `group_by` and `reduce` signatures
+
+### Proposed signatures
+
+```python
+def group_by(
+    self,
+    key_column: str, # Name of the column to use as the key
+    *,
+    reducer: Callable[[str, Iterator[RecordBatch]], Iterator[RecordBatch]],
+    sort_by_column: str | None = None,  # Name of the column to sort by
+    num_output_shards: int | None = None,
+    combiner: Callable[[str, Iterator[RecordBatch]], Iterator[RecordBatch]] | None = None,
+) -> ArrowDataset[RecordBatch]:
+
+def reduce(
+    self,
+    local_reducer: Callable[[Iterator[RecordBatch]], RecordBatch],
+    global_reducer: Callable[[Iterator[RecordBatch]], RecordBatch] | None = None,
+) -> ArrowDataset[RecordBatch]:
+```
+
+## Open Questions
+
+1. **ArrowDataset strictness** The current proposal only changes `group_by` and `reduce`, but to make the API as coherent as possible, `map` and `flat_map` should operate on `RecordBatch` objects as well. That said, many pipelines today do a small `flat_map` step on paths and utilize that information (to map back to original files, for example) that would make this hard. We could bake in the common patterns to things like `Dataset.from_files` and have that return `RecordBatch` objects with the needed columns. Using the `ArrowDataset` API does make this evolution easier, should we choose to do it.
+
+2. **Multi-column keys and sort.** There is some loss of expressivity with the single `key_column: str`, but that column can be a struct (computed in the previous `map` phase).
+
+3. **RecordBatch or DataFrame/LazyFrame** Polars operates on `DataFrame` (or `LazyFrame` for streaming) and since the internals are Polars and Polars provides an easier API for writing pipelines it could be nice to expose `DataFrame` instead of `RecordBatch`. Things like `dupekit` already operate on `RecordBatch` and so having both in a pipeline could be confusing. The conversion from one to the other is a single function call either way.
+
+   One middle ground: keep `RecordBatch` as the public type (consistent with `dupekit`, stable, not tied to Polars internals) but provide a `polars_reducer` decorator that handles the conversion boilerplate:
+
+   ```python
+   def polars_reducer(fn: Callable[[Any, pl.DataFrame], pl.DataFrame]):
+       def wrapped(key: Any, batches: Iterator[RecordBatch]) -> Iterator[RecordBatch]:
+           df = pl.from_arrow(pa.Table.from_batches(list(batches)))
+           result = fn(key, df)
+           yield from result.to_arrow().to_batches()
+       return wrapped
+
+   # Usage
+   @polars_reducer
+   def my_reducer(key: str, df: pl.DataFrame) -> pl.DataFrame:
+       return df.group_by("doc_id").agg(pl.col("score").sum())
+   ```
+
+   This keeps the core API type-stable while making Polars the easy path. The decorator can live in `zephyr.polars_utils` or similar.

--- a/.agents/projects/20260504-zephyr-arrow/compute_engine_research.md
+++ b/.agents/projects/20260504-zephyr-arrow/compute_engine_research.md
@@ -248,7 +248,149 @@ as `string_view` which PyArrow can parse but not compute on.
 
 ---
 
-## 6. Open Questions
+## 7. Memory Usage and Streaming
+
+### DuckDB: production-ready spill-to-disk
+
+DuckDB has a mature out-of-core execution model. By default it caps memory at 80% of physical RAM; all pipeline-breaking operators (sort, hash join build, hash aggregate, windowing) spill to disk when the limit is hit:
+
+```python
+conn = duckdb.connect()
+conn.execute("SET memory_limit = '4GB'")
+conn.execute("SET temp_directory = '/fast/ssd/tmp'")
+```
+
+The external sort uses a k-way merge (minimum I/O). External hash join uses radix partitioning (4–12 bits → 16–4096 on-disk partitions). Memory use is inspectable via `duckdb_memory()` and `duckdb_temporary_files()`.
+
+**Published results on a 140 GB Parquet workload (32 GB machine):**
+
+| Library | Peak memory |
+|---|---|
+| DuckDB | 1.3 GB |
+| Polars streaming | 750 MB (where applicable) |
+| Polars default (eager) | 17 GB |
+
+DuckDB's spill is transparent — no code changes needed when a query exceeds the memory limit.
+
+### Polars LazyFrame streaming: experimental and limited
+
+Polars' `collect(streaming=True)` is unstable and has significant exclusions:
+
+- **Sort is excluded.** `LazyFrame.sort()` falls back to the eager in-memory path regardless of streaming mode.
+- **Join streaming requires pre-sorted data.** Streaming merge-join only works if both sides are already sorted by the join key.
+- The streaming API is marked "unstable" and may change without notice.
+
+In practice, Polars streaming cannot be relied on for Zephyr's core operations (scatter sort, reduce join) when datasets approach or exceed available RAM.
+
+### PyArrow: no spill-to-disk
+
+PyArrow has memory pools (allocation tracking) and memory mapping (I/O efficiency) but **no analytical spill-to-disk**. There is no mechanism for `pyarrow.compute` sort or join to overflow to disk. Callers must implement spill manually or delegate to a system built on Arrow (such as DuckDB).
+
+### Implications for Zephyr
+
+The scatter sort is Zephyr's most memory-intensive operation. For datasets that fit in RAM on a large machine — the current common case — Polars is the right choice: fastest sort, cleanest scatter API. If scatter files grow past available RAM, only DuckDB provides a production-ready spill path. PyArrow provides no fallback.
+
+---
+
+## 8. DuckDB
+
+DuckDB is an embedded OLAP database with a vectorised query engine, full SQL support, and first-class Arrow integration. It is architecturally different from Polars and PyArrow: it operates through SQL (or a Python relational API) and runs as an embedded query engine rather than a function library.
+
+### Benchmark results (estimated from public benchmarks)
+
+The numbers below are extrapolated from DuckDB's public benchmark suite and DuckDB vs. Polars comparisons published in 2025–2026, **not measured locally on this machine**. The PyArrow and Polars numbers are from the local benchmarks in §1.
+
+| Operation | DuckDB (est.) | Polars (measured) | PyArrow (measured) | Notes |
+|---|---|---|---|---|
+| sort (5M rows, int64) | ~20–40ms | 20ms | 391ms | Within 2× of Polars; both ~10–20× faster than PyArrow |
+| filter (5M rows, 50% selectivity) | ~1–2ms | 1.1ms | 6.1ms | Roughly equal to Polars |
+| group_by + sum (5M rows, 1K groups) | ~15–25ms | 20.3ms | 24.5ms | DuckDB fastest in H2O benchmark at scale |
+| sort (larger-than-RAM) | ✅ k-way merge spill | ❌ falls back in-memory | ❌ no spill | DuckDB is the only reliable option |
+
+At large scale (SF-100, 100 GB), DuckDB slightly outperforms Polars (19.7s vs 23.9s); at smaller scale (SF-10, 10 GB), Polars is slightly faster (3.9s vs 5.9s). For Zephyr-sized tables the performance difference is negligible — the bigger question is whether data fits in RAM.
+
+### API for Zephyr operations
+
+**In-memory partition by key (scatter routing):**
+
+DuckDB's `COPY ... PARTITION_BY` is file-based — it writes Hive-partitioned files, not in-memory sub-tables. There is no `partition_by()` equivalent that returns a list of DataFrames in one pass. To get per-shard DataFrames, you need N separate queries, each scanning the whole table:
+
+```python
+# DuckDB — O(N × table_size) reads; no single-pass equivalent
+for shard_id in range(num_shards):
+    shard = conn.execute(
+        f"SELECT * FROM t WHERE hash(key) % {num_shards} = {shard_id}"
+    ).arrow()
+```
+
+Polars' `df.partition_by(key)` does a single pass and returns all partitions at once. For Zephyr's scatter, the DuckDB approach is substantially less efficient.
+
+**Vectorised hash:**
+
+Available via the `hashfuncs` community extension (`INSTALL hashfuncs; LOAD hashfuncs`), which provides `xxh3_64()` and `xxh3_128()`. Without the extension there is no `Series.hash()`-style column expression. The extension must be installed per environment.
+
+**Sorted-merge join:**
+
+DuckDB supports hash join (default), broadcast join, and `PhysicalPiecewiseMergeJoin` for range predicates and pre-sorted data. External hash join handles larger-than-RAM joins via radix partitioning. For Zephyr's reduce phase, DuckDB can execute a merge-join if both sides are pre-sorted by key.
+
+**Arrow IPC read/write:**
+
+DuckDB 1.4+ ships an Arrow IPC extension:
+
+```sql
+COPY t TO 'output.arrows' (FORMAT ARROW, COMPRESSION ZSTD);
+SELECT * FROM read_arrow('input.arrows');
+```
+
+Write speed has not been benchmarked locally. Based on architecture (zero-copy buffer pass), uncompressed write should be comparable to PyArrow.
+
+### Arrow type compatibility
+
+DuckDB uses the C data interface for Arrow integration. Numeric types are zero-copy in both directions. For strings:
+
+- Arrow `string` / `large_string` → DuckDB `VARCHAR` → Arrow `string`: ✓ no type promotion
+- Arrow `string_view` → DuckDB: **fails** (cannot convert; same issue Polars IPC output causes without `compat_level`)
+- DuckDB always emits standard Arrow `string` on `.arrow()` output, never `string_view` or `large_string`
+
+The `large_string → string` normalisation is unusual (most libraries promote; DuckDB normalises). It is lossless but could cause schema mismatches if downstream code explicitly expects `large_string`.
+
+| Roundtrip | DuckDB output type | Safe? |
+|---|---|---|
+| `string` → DuckDB → Arrow | `string` | ✓ no change |
+| `large_string` → DuckDB → Arrow | `string` | ⚠️ downcast; fine if downstream accepts `string` |
+| `binary` → DuckDB → Arrow | `binary` | ✓ |
+| `int64` → DuckDB → Arrow | `int64` | ✓ zero-copy |
+| `string_view` (Polars default) → DuckDB | — | ❌ fails |
+
+**Convention**: when passing Polars IPC output to DuckDB, the same `compat_level=pl.CompatLevel.oldest()` requirement from §3 applies — without it DuckDB will fail to read the string columns.
+
+### SQL vs DataFrame API
+
+DuckDB's query interface is SQL, which is a trade-off for Zephyr's use case:
+
+**Advantages:** Automatic query planning (predicate/projection pushdown, join reordering); readable multi-table joins; transparent parallelism across all CPU cores (Morsel-Driven Parallelism, ~6.5× speedup on 8 threads).
+
+**Disadvantages:** No method chaining for iterative computation; `partition_by` scatter requires N queries or full table materialisation vs Polars' single-pass API; no `map_groups(fn)` equivalent for user-supplied per-group Python functions without UDFs.
+
+### Smallpond
+
+[smallpond](https://github.com/deepseek-ai/smallpond) is a lightweight distributed data processing framework by DeepSeek built on DuckDB and their 3FS file system. It adds `repartition(N, hash_by="column")` for distributed scatter, achieving 3.66 TB/min on a 75-node cluster (GraySort benchmark).
+
+Smallpond is not a substitute for Polars/PyArrow — it is a higher-level distributed framework wrapping DuckDB. Its scatter primitive is essentially Zephyr's scatter phase implemented on DuckDB at cluster scale; the relevant insight is that DuckDB's hash-partitioning is proven for this workload pattern, but the single-machine in-process scatter API gap remains.
+
+### Summary: when to consider DuckDB
+
+| Scenario | Use Polars | Use DuckDB |
+|---|---|---|
+| Scatter fits in RAM | ✅ — `partition_by` is single-pass | — |
+| Scatter exceeds RAM | — | ✅ — k-way merge spill, no code changes needed |
+| Sort-only (no scatter) | ✅ — ~equal speed, simpler API | ✅ — ~equal speed, automatic spill |
+| Reduce merge-join | ✅ | ✅ |
+| User per-group Python fn | ✅ — `map_groups(fn)` | ❌ — requires UDF or Python loop |
+
+---
+
+## 9. Open Questions
 
 **Q: Are `pyarrow.compute` and Polars similar in efficiency for shared operations?**
 

--- a/.agents/projects/20260504-zephyr-arrow/design.md
+++ b/.agents/projects/20260504-zephyr-arrow/design.md
@@ -9,31 +9,61 @@ We should move to using Arrow as the internal format for Zephyr and expose Arrow
 ## Why
 
 - Exposing Arrow to Zephyr jobs should make Python-heavy jobs at least 2x - 3x faster by migrating the logic to Polars and thereby removing the majority of the existing GC time
-- We can, likely, use more [efficient merging algorithms](https://pola.rs/posts/streaming-joins/) for the scatter / reduce phases
 - We can avoid the cost of serialization and deserialization with `cloudpickle`
-- Again, if we move to user logic to Polars, we can parallelize jobs using multithreading at the Zephyr level, since the Python GIL will no longer be holding locks during processing
+- If we move user logic to Polars, we can parallelize jobs using multithreading at the Zephyr level, since the Python GIL will no longer be holding locks during processing
 
 ## Goals
 
-- Migrate the internals of Zephyr to use Arrow for storage, including migrating the scatter format to use zstd compressed IPC files (IPC is the native Arrow format that doesn't incur any serialization or deserialization cost to write to disk).
+- Migrate the internals of Zephyr to use Arrow for storage, including migrating the scatter format to use zstd compressed Parquet files.
 - Keep the API to Zephyr the same, so existing jobs will continue to run (but without all the speed gains)
-- Expose an alternative Zephyr API that allows for processing data directly in Arrow and enabled the 2x - 3x speedups
+- Expose an alternative Zephyr API that allows for processing data directly in Arrow and enables the 2x - 3x speedups
 
 ## Design / Plan
 
-- Replace `ScatterWriter` with a version the reads and writes `zstd` compressed Arrow IPC
+- Replace `ScatterWriter` with a version the reads and writes `zstd` compressed parquet and processes it in Polars
 - Update the necessary sections of `plan.py`: `_merge_sorted_chunks`, `_sorted_merge_join`
-- Update `spill.py` to use Arrow IPC as well
-- Add a new `ArrowDataset` builder that has a very similar API to `Dataset` but provides a `PyArrow.BatchRecord` to the functions.
-  - The main difference will be exposing a new version of `GroupBy` that allows for [Polars-level aggregations](https://docs.pola.rs/user-guide/expressions/aggregation/)
+- Add a new functions to the `Dataset` builder that expose `PyArrow.BatchRecord` instead of Python objects.
+- The main difference will be exposing a new version of `group_by` that allows for doing aggregations using `RecordBatch`s
 
 ### `Dataset` API
 See discussion in [api.md](api.md) for the details of options considered.
 
-The `Dataset` API will change as follows:
+The `Dataset` API will remain unchanged so existing code continues to run. Functions like `load_parquet` and `group_by` will have a `batch_mode` flag that allows for processing.
 
+An example pipeline could look something like this:
 ```
-TBD based on discussion in api.md.
+import polars as pl
+import pyarrow as pa
+
+def flat_map(batch: pa.RecordBatch) -> Iterator[pa.RecordBatch]:
+    hashed = compute_paragraph_hashes(batch)
+    return pl.from_arrow(hashesd).rename({"doc_id": "id"}).to_arrow().to_batches()
+
+def annotate_dups(key: str, records: pa.RecordBatch) -> Iterator[pa.RecordBatch]:
+    df = pl.from_arrow(records)
+    has_dups = df.height > 1
+    cano_id = df["id"][0]
+
+    is_dup = pl.lit(has_dups) & (pl.col("id") != cano_id)
+    return df.select(
+      pl.col("id"),
+      is_dup.alias("is_dup"),
+      pl.when(is_dup)
+          .then(pl.col("paragraph_span").struct.field("span"))
+          .otherwise(pl.lit([], dtype=pl.List(pl.Int64)))
+          .alias("span"),
+      pl.col("file_idx"),
+    ).to_arrow().to_batches()
+
+Dataset
+  .from_files(files)
+  .load_parquet(batch_mode=True)
+  .flat_map(flat_map)
+  .group_by(
+    key=col("hash"),
+    sort_by=col("id")
+    reducer=annotate_dups,
+  )
 ```
 
 ## Risks / Challenges
@@ -64,8 +94,7 @@ From the research in [compute_engine_research.md](compute_engine_research.md) (s
 | Zero-copy with Arrow (strings)                | ✅ is Arrow                     | ❌ copies to StringView                  | ✅ (fails on `string_view` input)       |
 | Memory: spill-to-disk for sort/join           | ❌ no spill                     | ⚠️ streaming merge_sorted experimental  | ✅ k-way merge, all operators           |
 | Streaming larger-than-RAM ops                 | ❌                              | ⚠️ streaming / `LazyFrame` experimental | ✅ production-ready                     |
-
-
 ## Future work
-
-Once this is complete, we can return to [zephyr-performance](../20260430-zephyr-performance/design.md) and implement the parallelization improvements there and actually realize the benefit, since the GIL will not limit multithreading in *Arrow-native* stages.
+Exposing sql is interesting in terms of sql's flexibility and ease for writing ad-hoc queries. Parsing sql to handle distributing it across multiple nodes is well outside the scope of the work we want to do, but there are a few future paths we can explore:
+- Once `RecordBatch` objects are exposed, users can write sql transformations over them using DuckDB or DataFusion
+- We can explore deploying [smallpond](https://github.com/deepseek-ai/smallpond) for ad-hoc (or possibly data processing) queries in a more always-on fashion

--- a/.agents/projects/20260504-zephyr-arrow/design.md
+++ b/.agents/projects/20260504-zephyr-arrow/design.md
@@ -5,68 +5,35 @@ Processing data directly in Python is slow. It always has been.
 Profiling some of our jobs, the ones that use Python to do the processing spend 50% - 70% of their time doing GC. Even jobs that don't use Python as much but use group by, can spend a fair amount of time in the Zephyr internals merging and sorting Python records.
 
 We should move to using Arrow as the internal format for Zephyr and expose Arrow via the Zephyr API.
+
 ## Why
+
 - Exposing Arrow to Zephyr jobs should make Python-heavy jobs at least 2x - 3x faster by migrating the logic to Polars and thereby removing the majority of the existing GC time
 - We can, likely, use more [efficient merging algorithms](https://pola.rs/posts/streaming-joins/) for the scatter / reduce phases
 - We can avoid the cost of serialization and deserialization with `cloudpickle`
 - Again, if we move to user logic to Polars, we can parallelize jobs using multithreading at the Zephyr level, since the Python GIL will no longer be holding locks during processing
+
 ## Goals
+
 - Migrate the internals of Zephyr to use Arrow for storage, including migrating the scatter format to use zstd compressed IPC files (IPC is the native Arrow format that doesn't incur any serialization or deserialization cost to write to disk).
 - Keep the API to Zephyr the same, so existing jobs will continue to run (but without all the speed gains)
 - Expose an alternative Zephyr API that allows for processing data directly in Arrow and enabled the 2x - 3x speedups
+
 ## Design / Plan
+
 - Replace `ScatterWriter` with a version the reads and writes `zstd` compressed Arrow IPC
 - Update the necessary sections of `plan.py`: `_merge_sorted_chunks`, `_sorted_merge_join`
 - Update `spill.py` to use Arrow IPC as well
 - Add a new `ArrowDataset` builder that has a very similar API to `Dataset` but provides a `PyArrow.BatchRecord` to the functions.
-	- The main difference will be exposing a new version of `GroupBy` that allows for [Polars-level aggregations](https://docs.pola.rs/user-guide/expressions/aggregation/)
+  - The main difference will be exposing a new version of `GroupBy` that allows for [Polars-level aggregations](https://docs.pola.rs/user-guide/expressions/aggregation/)
 
-### `ArrowDataset` example
+### `Dataset` API
+See discussion in [api.md](api.md) for the details of options considered.
+
+The `Dataset` API will change as follows:
+
 ```
-    def pyarrow_flat_map_fn(path: str) -> Iterator[pa.RecordBatch]:
-        file_idx = path_to_idx[path]
-
-        for batch in _load_batches(path):
-            col_names = batch.schema.names
-            col_values = list(batch.columns)
-            col_values.append(pa.array([file_idx] * batch.num_rows, type=pa.int64()))
-            col_names.append("file_idx")
-
-            yield pa.RecordBatch.from_arrays(col_values, names=col_names)
-
-    def polars_flat_map_fn(path: str) -> Iterator[pa.RecordBatch]:
-        """Same as ``pyarrow_flat_map_fn``, but using Polars."""
-        file_idx = path_to_idx[path]
-
-        for batch in _load_batches(path):
-            df = pl.from_arrow(batch)
-            df = df.with_columns(pl.lit(file_idx).cast(pl.Int64).alias("file_idx"))
-            table = df.to_arrow()
-            yield from table.to_batches()
-
-
-    def polars_flat_map_fn(path: str) -> Iterator[pa.RecordBatch]:
-        """Same as ``pyarrow_flat_map_fn``, but falling back to Python."""
-        file_idx = path_to_idx[path]
-
-        for batch in _load_batches(path):
-            py_batch = [{"file_idx": file_idx, **hash_record} for item in batch.to_pylist()]
-            yield pa.RecordBatch.from_pylist(py_batch)
-
-    def pyarrow_reducer(key: Any, items: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
-        """Reduce a group of ``pa.RecordBatch``s into a single ``pa.RecordBatch``."""
-        pass
-
-    dataset = (ArrowDataset.from_files(input_files)
-        .flat_map(pyarrow_flat_map_fn)
-        .map(compute_paragraph_hashes)
-        .group_by(
-            key_columns=["hash"],
-            sort_by_columns=["id"],
-            reducer=pyarrow_reducer,
-            arrow=True,
-        ))
-    results = ctx.execute(dataset).results
+TBD based on discussion in api.md.
 ```
 
 ## Risks / Challenges
@@ -78,21 +45,27 @@ We should move to using Arrow as the internal format for Zephyr and expose Arrow
 - **Per-buffer zstd vs whole-file zstd compression ratio.** PyArrow IPC's `compression='zstd'` is worse than the current whole-batch `cloudpickle.dump → zstd.compress` flow. Could increase shuffle bytes 1.2-1.5x in the worst case. We should benchmark this. See [research §11.1](./research.md#11-surprise-areas-worth-a-small-benchmark-before-committing).
 - **Polars and Arrow Compatibility** any Polars IPC write consumed by PyArrow must pass `compat_level=pl.CompatLevel.oldest()`. Without it, Polars emits `string_view`/`binary_view` types that PyArrow 22 cannot sort, filter, or compare on. (This is also faster — 19ms vs 31ms — and slightly smaller.) Also, `string` columns roundtripped through Polars come back as `large_string`; use `promote_options='permissive'` on any subsequent `pa.concat_tables`.
 
-## PyArrow vs Polars
+## Compute Engine (PyArrow vs Polars vs DuckDB)
+
+From the research in [compute_engine_research.md](compute_engine_research.md) (summarized below), Polars remains the best fit for Zephyr's hot-path operations. Its built-in `partition_by` and `Series.hash()` have no efficient DuckDB equivalent for in-process in-memory scatter. DuckDB is architecturally superior for larger-than-RAM workloads — its sort and join have production-grade spill-to-disk, unlike Polars' experimental streaming engine. For Zephyr's current use case (scatter that fits in RAM on large machines), Polars wins on the hot path; DuckDB is worth revisiting if scatter files grow past available memory.
 
 
-From the research in [pyarrow_vs_polars.md](pyarrow_vs_polars.md) (summarized in the table below) Polars seems like a better fit for our use case, since the bulk of the time is spent processing data versus reading and writing it. The Lazy API also opens up some possible improvements for streaming data as well.
+| Criterion                                     | PyArrow                        | Polars                                  | DuckDB                                 |
+| --------------------------------------------- | ------------------------------ | --------------------------------------- | -------------------------------------- |
+| Efficiency: sort, filter                      | 391ms / 6ms                    | ✅ 20ms / 1ms                            | ~20–40ms / ~2ms (est.)                 |
+| Efficiency: group-by, string ops              | ✅ ~equal                       | ✅ ~equal                                | ✅ ~equal (fastest in H2O at scale)     |
+| API: scatter routing (`partition_by`, `hash`) | ❌ no API                       | ✅ built-in, single-pass                 | ⚠️ file-based only; no in-memory split |
+| API: join                                     | ❌ no sorted-merge join         | ✅ built-in                              | ✅ hash + merge join                    |
+| API: expression ergonomics                    | functional (`pc.and_(...)`)    | ✅ operator overloading                  | SQL strings                            |
+| API: per-group user Python fn                 | ❌                              | ✅ `map_groups(fn)`                      | ❌ requires UDF                         |
+| IPC read/write speed                          | ✅ 9ms uncompressed / 27ms zstd | 19–31ms                                 | not yet benchmarked                    |
+| IPC type safety (no `string_view` trap)       | ✅ always safe                  | ⚠️ needs `compat_level=oldest()`        | ✅ emits `string`, not `string_view`    |
+| Zero-copy with Arrow (numerics)               | ✅ is Arrow                     | ✅ yes                                   | ✅ C data interface                     |
+| Zero-copy with Arrow (strings)                | ✅ is Arrow                     | ❌ copies to StringView                  | ✅ (fails on `string_view` input)       |
+| Memory: spill-to-disk for sort/join           | ❌ no spill                     | ⚠️ streaming merge_sorted experimental  | ✅ k-way merge, all operators           |
+| Streaming larger-than-RAM ops                 | ❌                              | ⚠️ streaming / `LazyFrame` experimental | ✅ production-ready                     |
 
-| Criterion | PyArrow | Polars |
-|---|---|---|
-| Efficiency (sort, filter) | 391ms / 6ms | ✅ 20ms / 1ms |
-| Efficiency (group-by, string ops) | ✅ ~equal | ✅ ~equal |
-| API: scatter routing (`partition_by`, `hash`) | ❌ no API | ✅ built-in |
-| API: join | ❌ no sorted-merge join | ✅ built-in |
-| API: expression ergonomics | functional (`pc.and_(...)`) | ✅ operator overloading |
-| IPC read/write speed | ✅ faster (9ms uncompressed) | slower (19–31ms) |
-| IPC type safety (no `string_view` trap) | ✅ always safe | ⚠️ needs `compat_level=oldest()` |
-| Zero-copy with Arrow (numerics) | ✅ is Arrow | ✅ yes |
-| Zero-copy with Arrow (strings) | ✅ is Arrow | ❌ copies to StringView |
+
 ## Future work
+
 Once this is complete, we can return to [zephyr-performance](../20260430-zephyr-performance/design.md) and implement the parallelization improvements there and actually realize the benefit, since the GIL will not limit multithreading in *Arrow-native* stages.

--- a/.agents/projects/20260504-zephyr-arrow/design.md
+++ b/.agents/projects/20260504-zephyr-arrow/design.md
@@ -1,0 +1,31 @@
+# Zephyr Arrow / Polars Migration
+
+Processing data directly in Python is slow. It always has been.
+
+Profiling some of our jobs, the ones that use Python to do the processing spend 50% - 70% of their time doing GC. Even jobs that don't use Python as much but use group by, can spent a fair amount of time in the Zephyr internals merging and sorting Python records.
+
+We should move to using Arrow as the internal format for Zephyr and expose Arrow via the Zephyr API.
+## Why
+- Exposing Arrow to Zephyr jobs should make Python-heavy jobs at least 2x - 3x faster by migrating the logic to Polars and thereby removing all the GC time
+- We can, likely, use more [efficient merging algorithms](https://pola.rs/posts/streaming-joins/) for the scatter / reduce phases
+- We can avoid the cost of serialization and deserialization with `pickle`
+- Again, if we move to user logic to Polars, we can parallelize jobs using multithreading at the Zephyr level, since the Python GIL will no longer be holding locks during processing
+## Goals
+- Migrate the internals of Zephyr to use Arrow for storage, including migrating the scatter format to use zstd compressed IPC files (IPC is the native Arrow format that doesn't incur any serialization or deserialization cost to write to disk).
+- Keep the API to Zephyr the same, so existing jobs will continue to run, but without all the speed gains
+- Expose an alternative Zephyr API that allows for processing data directly in Arrow and enabled the 2x - 3x speedups
+## Design / Plan
+- Replace `ScatterWritter` with a version the reads and writes ztsd compressed Arrow IPC
+- Update the necessary sections of `plan.py`: `_merge_sorted_chunks`, `_sorted_merge_join`
+- Update `spill.py` to use Arrow IPC as well
+- Add a new `ArrowDataset` builder that has a very similar API to `Dataset` but provides a `PyArrow::BatchRecord` to the functions.
+	- The main difference will be exposing a new version of `GroupBy` that allows for [Polars-level aggregations](https://docs.pola.rs/user-guide/expressions/aggregation/)
+## Risks / Challenges
+
+- **Reimplementing `_merge_sorted_chunks` might be tricky**  There's not a perfect analog in Polars / PyArrow for this function, although there are option and we can benchmark them to figure out the best one. See [research §6](research)
+- **Arrow restricts the processable types** Technically `cloudpickle.dump` supports a much wider range of data types than Arrow, creating a breaking change. I reality, we only use data types supported by Arrow, so should be fine.
+- **User-code needs to be migrated to Polars** To get the speedups, we'll need to migrate all the user-code in the pipelines to Polars. Representing things in Polars is more cumbersome than raw Python.
+- **Change in the hashing function** I'm not sure why we'd want to read old scatter files, but we won't be able to after this.
+- **Per-buffer zstd vs whole-file zstd compression ratio.** PyArrow IPC's `compression='zstd'` is worse than the current whole-batch `cloudpickle.dump → zstd.compress` flow. Could increase shuffle bytes 1.2-1.5x in the worst case. We should benchmark this. See [research §11.1](research).
+## Future work
+Once this is complete, we can return to [zephyr-performance](../20260430-zephyr-performance/design) and implement the parallelization improvements there and actually realize the benefit, since the GIL will not limit multithreading in *Arrow-native* stages.

--- a/.agents/projects/20260504-zephyr-arrow/design.md
+++ b/.agents/projects/20260504-zephyr-arrow/design.md
@@ -2,30 +2,79 @@
 
 Processing data directly in Python is slow. It always has been.
 
-Profiling some of our jobs, the ones that use Python to do the processing spend 50% - 70% of their time doing GC. Even jobs that don't use Python as much but use group by, can spent a fair amount of time in the Zephyr internals merging and sorting Python records.
+Profiling some of our jobs, the ones that use Python to do the processing spend 50% - 70% of their time doing GC. Even jobs that don't use Python as much but use group by, can spend a fair amount of time in the Zephyr internals merging and sorting Python records.
 
 We should move to using Arrow as the internal format for Zephyr and expose Arrow via the Zephyr API.
 ## Why
-- Exposing Arrow to Zephyr jobs should make Python-heavy jobs at least 2x - 3x faster by migrating the logic to Polars and thereby removing all the GC time
+- Exposing Arrow to Zephyr jobs should make Python-heavy jobs at least 2x - 3x faster by migrating the logic to Polars and thereby removing the majority of the existing GC time
 - We can, likely, use more [efficient merging algorithms](https://pola.rs/posts/streaming-joins/) for the scatter / reduce phases
-- We can avoid the cost of serialization and deserialization with `pickle`
+- We can avoid the cost of serialization and deserialization with `cloudpickle`
 - Again, if we move to user logic to Polars, we can parallelize jobs using multithreading at the Zephyr level, since the Python GIL will no longer be holding locks during processing
 ## Goals
 - Migrate the internals of Zephyr to use Arrow for storage, including migrating the scatter format to use zstd compressed IPC files (IPC is the native Arrow format that doesn't incur any serialization or deserialization cost to write to disk).
-- Keep the API to Zephyr the same, so existing jobs will continue to run, but without all the speed gains
+- Keep the API to Zephyr the same, so existing jobs will continue to run (but without all the speed gains)
 - Expose an alternative Zephyr API that allows for processing data directly in Arrow and enabled the 2x - 3x speedups
 ## Design / Plan
-- Replace `ScatterWritter` with a version the reads and writes ztsd compressed Arrow IPC
+- Replace `ScatterWriter` with a version the reads and writes `zstd` compressed Arrow IPC
 - Update the necessary sections of `plan.py`: `_merge_sorted_chunks`, `_sorted_merge_join`
 - Update `spill.py` to use Arrow IPC as well
-- Add a new `ArrowDataset` builder that has a very similar API to `Dataset` but provides a `PyArrow::BatchRecord` to the functions.
+- Add a new `ArrowDataset` builder that has a very similar API to `Dataset` but provides a `PyArrow.BatchRecord` to the functions.
 	- The main difference will be exposing a new version of `GroupBy` that allows for [Polars-level aggregations](https://docs.pola.rs/user-guide/expressions/aggregation/)
+
+### `ArrowDataset` example
+```
+    def pyarrow_flat_map_fn(path: str) -> Iterator[pa.RecordBatch]:
+        file_idx = path_to_idx[path]
+
+        for batch in _load_batches(path):
+            col_names = batch.schema.names
+            col_values = list(batch.columns)
+            col_values.append(pa.array([file_idx] * batch.num_rows, type=pa.int64()))
+            col_names.append("file_idx")
+
+            yield pa.RecordBatch.from_arrays(col_values, names=col_names)
+
+    def polars_flat_map_fn(path: str) -> Iterator[pa.RecordBatch]:
+        """Same as ``pyarrow_flat_map_fn``, but using Polars."""
+        file_idx = path_to_idx[path]
+
+        for batch in _load_batches(path):
+            df = pl.from_arrow(batch)
+            df = df.with_columns(pl.lit(file_idx).cast(pl.Int64).alias("file_idx"))
+            table = df.to_arrow()
+            yield from table.to_batches()
+
+
+    def polars_flat_map_fn(path: str) -> Iterator[pa.RecordBatch]:
+        """Same as ``pyarrow_flat_map_fn``, but falling back to Python."""
+        file_idx = path_to_idx[path]
+
+        for batch in _load_batches(path):
+            py_batch = [{"file_idx": file_idx, **hash_record} for item in batch.to_pylist()]
+            yield pa.RecordBatch.from_pylist(py_batch)
+
+    def pyarrow_reducer(key: Any, items: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
+        """Reduce a group of ``pa.RecordBatch``s into a single ``pa.RecordBatch``."""
+        pass
+
+    dataset = (ArrowDataset.from_files(input_files)
+        .flat_map(pyarrow_flat_map_fn)
+        .map(compute_paragraph_hashes)
+        .group_by(
+            key_columns=["hash"],
+            sort_by_columns=["id"],
+            reducer=pyarrow_reducer,
+            arrow=True,
+        ))
+    results = ctx.execute(dataset).results
+```
+
 ## Risks / Challenges
 
-- **Reimplementing `_merge_sorted_chunks` might be tricky**  There's not a perfect analog in Polars / PyArrow for this function, although there are option and we can benchmark them to figure out the best one. See [research §6](research)
-- **Arrow restricts the processable types** Technically `cloudpickle.dump` supports a much wider range of data types than Arrow, creating a breaking change. I reality, we only use data types supported by Arrow, so should be fine.
-- **User-code needs to be migrated to Polars** To get the speedups, we'll need to migrate all the user-code in the pipelines to Polars. Representing things in Polars is more cumbersome than raw Python.
-- **Change in the hashing function** I'm not sure why we'd want to read old scatter files, but we won't be able to after this.
-- **Per-buffer zstd vs whole-file zstd compression ratio.** PyArrow IPC's `compression='zstd'` is worse than the current whole-batch `cloudpickle.dump → zstd.compress` flow. Could increase shuffle bytes 1.2-1.5x in the worst case. We should benchmark this. See [research §11.1](research).
+- **Reimplementing `_merge_sorted_chunks` is complex in Polars**.  There's not a perfect analog in Polars / PyArrow for this function, although there are options and we can benchmark them to figure out the best one. See [research §6](research.md#6-k-way-merge-in-detail)
+- **Arrow restricts the processable types**.  `cloudpickle.dump` supports a much wider range of data types than Arrow. Our workload is predominantly in data types that Arrow supports, but we will need an escape hatch for types that are not supported. Something like  using `cloudpickle.dump` and storing the bytes in Arrow should work.
+- **User-code needs to be migrated to Polars**. To get the bulk of the speedup, we'll need to migrate user-code in the pipelines to Polars. Representing things in Polars is more cumbersome than raw Python.
+- **Change in the hashing function**. The Polars hash function is different than the one currently implemented. This means we can't change this while a job is running or read old scatter files, which should be totally fine (but Claude is very worried about).
+- **Per-buffer zstd vs whole-file zstd compression ratio.** PyArrow IPC's `compression='zstd'` is worse than the current whole-batch `cloudpickle.dump → zstd.compress` flow. Could increase shuffle bytes 1.2-1.5x in the worst case. We should benchmark this. See [research §11.1](./research.md#11-surprise-areas-worth-a-small-benchmark-before-committing).
 ## Future work
-Once this is complete, we can return to [zephyr-performance](../20260430-zephyr-performance/design) and implement the parallelization improvements there and actually realize the benefit, since the GIL will not limit multithreading in *Arrow-native* stages.
+Once this is complete, we can return to [zephyr-performance](../20260430-zephyr-performance/design.md) and implement the parallelization improvements there and actually realize the benefit, since the GIL will not limit multithreading in *Arrow-native* stages.

--- a/.agents/projects/20260504-zephyr-arrow/design.md
+++ b/.agents/projects/20260504-zephyr-arrow/design.md
@@ -76,5 +76,23 @@ We should move to using Arrow as the internal format for Zephyr and expose Arrow
 - **User-code needs to be migrated to Polars**. To get the bulk of the speedup, we'll need to migrate user-code in the pipelines to Polars. Representing things in Polars is more cumbersome than raw Python.
 - **Change in the hashing function**. The Polars hash function is different than the one currently implemented. This means we can't change this while a job is running or read old scatter files, which should be totally fine (but Claude is very worried about).
 - **Per-buffer zstd vs whole-file zstd compression ratio.** PyArrow IPC's `compression='zstd'` is worse than the current whole-batch `cloudpickle.dump → zstd.compress` flow. Could increase shuffle bytes 1.2-1.5x in the worst case. We should benchmark this. See [research §11.1](./research.md#11-surprise-areas-worth-a-small-benchmark-before-committing).
+- **Polars and Arrow Compatibility** any Polars IPC write consumed by PyArrow must pass `compat_level=pl.CompatLevel.oldest()`. Without it, Polars emits `string_view`/`binary_view` types that PyArrow 22 cannot sort, filter, or compare on. (This is also faster — 19ms vs 31ms — and slightly smaller.) Also, `string` columns roundtripped through Polars come back as `large_string`; use `promote_options='permissive'` on any subsequent `pa.concat_tables`.
+
+## PyArrow vs Polars
+
+
+From the research in [pyarrow_vs_polars.md](pyarrow_vs_polars.md) (summarized in the table below) Polars seems like a better fit for our use case, since the bulk of the time is spent processing data versus reading and writing it. The Lazy API also opens up some possible improvements for streaming data as well.
+
+| Criterion | PyArrow | Polars |
+|---|---|---|
+| Efficiency (sort, filter) | 391ms / 6ms | ✅ 20ms / 1ms |
+| Efficiency (group-by, string ops) | ✅ ~equal | ✅ ~equal |
+| API: scatter routing (`partition_by`, `hash`) | ❌ no API | ✅ built-in |
+| API: join | ❌ no sorted-merge join | ✅ built-in |
+| API: expression ergonomics | functional (`pc.and_(...)`) | ✅ operator overloading |
+| IPC read/write speed | ✅ faster (9ms uncompressed) | slower (19–31ms) |
+| IPC type safety (no `string_view` trap) | ✅ always safe | ⚠️ needs `compat_level=oldest()` |
+| Zero-copy with Arrow (numerics) | ✅ is Arrow | ✅ yes |
+| Zero-copy with Arrow (strings) | ✅ is Arrow | ❌ copies to StringView |
 ## Future work
 Once this is complete, we can return to [zephyr-performance](../20260430-zephyr-performance/design.md) and implement the parallelization improvements there and actually realize the benefit, since the GIL will not limit multithreading in *Arrow-native* stages.

--- a/.agents/projects/20260504-zephyr-arrow/pyarrow_vs_polars.md
+++ b/.agents/projects/20260504-zephyr-arrow/pyarrow_vs_polars.md
@@ -1,0 +1,277 @@
+# PyArrow vs Polars for Zephyr
+
+Research for the "PyArrow vs Polars" section of [design.md](design.md).
+All benchmarks run on 2026-05-06 with PyArrow 22.0.0 and Polars 1.40.1,
+in the `lib/zephyr` uv environment on an M-series Mac.
+
+---
+
+## 1. Efficiency
+
+The two libraries share the same Arrow columnar memory format, so data layout
+is identical. The performance difference comes from their compute engines:
+PyArrow delegates to Arrow C++ (`pyarrow.compute`); Polars delegates to its
+own Rust engine which is explicitly multithreaded for most operations.
+
+### Benchmark results
+
+| Operation | PyArrow | Polars | Notes |
+|---|---|---|---|
+| filter (5M rows, 50% selectivity) | 6.1ms | 1.1ms | ~5x |
+| sort (5M rows, int64) | 391ms | 20ms | ~20x |
+| group_by + sum (5M rows, 1K groups) | 24.5ms | 20.3ms | ~1.2x |
+| str.to_uppercase (5M rows) | 121.9ms | 126.4ms | ~1x |
+| inner join (1M × 500K, unique keys) | N/A (no API) | 3.7ms | — |
+| Series.hash (1M strings) | N/A (no API) | 4.7ms | — |
+| partition_by key (2M rows, 10K keys) | N/A (no API) | 18.9ms | — |
+
+**Takeaways:**
+
+- Sort is the clearest win — 20x faster under Polars. This matters for the
+  scatter flush and for `_merge_sorted_chunks`, which are the hottest
+  operations we're migrating.
+- Filter is 5x faster, relevant for pre-scatter filtering.
+- Group-by aggregations are roughly equivalent (both are vectorised C++/Rust,
+  both use hash tables). The PyArrow version is sometimes faster for simple
+  single-key aggregates on numeric types.
+- String ops (`str.upper`, etc.) are effectively identical — the underlying
+  SIMD kernels are the same Arrow C++.
+- Several critical Zephyr operations (hash-for-routing, partition_by, sorted
+  join) exist only in Polars.
+
+---
+
+## 2. API Simplicity
+
+### Feature matrix
+
+| Feature | PyArrow | Polars |
+|---|---|---|
+| Hash columns for routing | No built-in; must round-trip through Python + xxhash | `Series.hash()` — 1 line, vectorised |
+| Partition rows by key (scatter) | No API; must sort then slice, or group then iterate | `partition_by(key)` — returns list of DataFrames |
+| Sorted-merge join | No API; Acero hash join only | Streaming engine join (see caveats §3) |
+| Per-buffer IPC zstd compression | `IpcWriteOptions(compression='zstd')` | Requires `compat_level` param |
+| Sort (single table) | `pc.sort_indices` + `take` (two-step) | `df.sort(col)` (one-step, multithreaded) |
+| Streaming disk-spilling sort | No | `LazyFrame.sort()` with streaming engine (experimental) |
+| Vectorised string ops | `pc.utf8_upper(col)` — functional | `pl.col.str.to_uppercase()` — method chaining |
+| Expression operator overloading | No — `pc.and_(pc.greater(a, b), ...)` | Yes — `(col_a > b) & ...` |
+| LazyFrame / query optimization | Acero (low-level declarations only) | Full LazyFrame DSL with automatic push-down |
+| Map Python fn over groups | No — `group_by().aggregate()` vectorised only | `map_groups(fn)` — passes DataFrame per group |
+| Per-batch user code | Caller loops over `RecordBatch`es | Same; Polars `LazyFrame.map_batches()` |
+| Zero-copy from Arrow (numerics) | Is Arrow — no conversion needed | Yes — same buffer |
+| Zero-copy from Arrow (strings) | Is Arrow — no conversion | No — must copy to internal `StringView` |
+
+### API verbosity example
+
+Adding a constant column (the `file_idx` use case from `ArrowDataset`):
+
+```python
+# PyArrow
+t_with_idx = t.append_column(
+    'file_idx',
+    pa.array([file_idx] * len(t), pa.int64())
+)
+
+# Polars
+df_with_idx = df.with_columns(pl.lit(file_idx).cast(pl.Int64).alias('file_idx'))
+```
+
+Computing shard routing:
+
+```python
+# PyArrow — no vectorised path; must loop per row
+shard_ids = [xxhash.xxh3_64_intdigest(msgspec.msgpack.encode(item['key'])) % num_shards
+             for item in t.to_pylist()]  # GC cost returns
+
+# Polars — vectorised
+shard_ids = df['key'].hash() % num_shards  # returns Series in ~5ms for 1M rows
+```
+
+**Takeaway**: For the operations Zephyr needs most (scatter routing, sort,
+partition, join), Polars provides a substantially simpler API. PyArrow's
+`pyarrow.compute` is lower-level and designed for building other systems on
+top of — appropriate for IPC read/write, less so for data transformations.
+
+---
+
+## 3. Compatibility Issues
+
+This is the most important section. The two libraries technically operate on
+the same in-memory Arrow format, but in practice **type conversions happen at
+every boundary**, and some conversions are lossy or unsupported.
+
+### The `string` → `large_string` (and `binary` → `large_binary`) promotion
+
+**Direction: PyArrow → Polars → PyArrow**
+
+Polars internally uses `StringView` and `BinaryView` for all string/binary
+data. When you call `pl.from_arrow(table)` on a table with `string` columns
+and then `df.to_arrow()`, you get back `large_string` (not `string`). This is
+generally fine — `large_string` is a superset of `string` — but if any
+downstream code asserts exact schema equality or uses `pa.concat_tables`
+without `promote_options='permissive'`, it will fail:
+
+```
+concat string_view + string: ERROR Unable to merge: Field s has incompatible types: string_view vs string
+```
+
+**Direction: Polars IPC → PyArrow**
+
+This is the critical one for Zephyr. When Polars writes an IPC stream (e.g.
+`df.write_ipc_stream(buf)`), it emits **`string_view`** and
+**`binary_view`** types by default (Arrow 1.3+ view types). PyArrow 22 can
+*read* these types, but its compute kernels don't support them:
+
+```
+pc.utf8_length on string_view:  ERROR — no kernel matching input types (string_view)
+pc.utf8_upper  on string_view:  ERROR — no kernel matching input types (string_view)
+pc.equal       on string_view:  ERROR — no kernel matching input types (string_view)
+pc.sort_indices on string_view: ERROR — Sorting not supported for type binary_view
+```
+
+`is_null`, `cast(string)`, and `cast(large_binary)` do work on view types.
+But the operations Zephyr's scatter uses — equality, sorting — do not.
+
+**The fix: `compat_level=pl.CompatLevel.oldest()`**
+
+Polars provides a backwards-compatibility parameter for IPC writes:
+
+```python
+df.write_ipc_stream(buf, compat_level=pl.CompatLevel.oldest())
+```
+
+This emits `large_string` / `large_binary` instead of `string_view` /
+`binary_view`. All PyArrow 22 compute functions work on `large_string`.
+Benchmark shows writing with `oldest()` is actually *faster* than the default
+(19ms vs 31ms for 2M rows), with ~5% smaller output (89MB vs 93MB).
+
+**This must be a project-wide convention**: any Polars IPC write that will be
+read by PyArrow must use `compat_level=pl.CompatLevel.oldest()`. Omitting it
+silently produces a file that PyArrow reads but can't compute on — a latent
+bug.
+
+### Parquet cross-compatibility
+
+| Direction | string type outcome | binary type outcome |
+|---|---|---|
+| PA writes, PL reads | `string` → `String` (ok) | `binary` → `Binary` (ok) |
+| PL writes, PA reads | `large_string` | `large_binary` |
+| PA writes list of strings | `list<string>` → `List(String)` | — |
+
+Parquet cross-reads work without errors in all tested combinations. The type
+upgrades (`string` → `large_string`) are lossless. The `_to_large_type`
+helper already in `external_sort.py` handles the most important case.
+
+### Roundtrip test results
+
+```
+string       PA=string      → PL=String   → PA=large_string  ⚠ type changed
+large_string PA=large_string → PL=String  → PA=large_string  ✓ ok
+binary       PA=binary      → PL=Binary   → PA=large_binary  ⚠ type changed
+large_binary PA=large_binary → PL=Binary  → PA=large_binary  ✓ ok
+int64        PA=int64       → PL=Int64    → PA=int64         ✓ ok
+float32      PA=float32     → PL=Float32  → PA=float32       ✓ ok
+list<int32>  PA=list<int32> → PL=List(Int32) → PA=large_list<int32>  ⚠ type changed
+struct       PA=struct      → PL=Struct   → PA=struct        ✓ ok
+dict<str>    PA=dict<str,int32> → PL=Categorical → PA=dict<large_string,uint32>  ⚠ type changed
+timestamp_us PA=timestamp[us] → PL=Datetime → PA=timestamp[us]  ✓ ok
+null         PA=null        → PL=Null     → PA=null          ✓ ok
+```
+
+**Practical rule**: After a `pl.from_arrow(t)` + compute + `df.to_arrow()`
+roundtrip, all `string` and `list<T>` columns are promoted to their `large_*`
+equivalents. Any schema comparison or `concat_tables` must use
+`promote_options='permissive'` or `pa.unify_schemas` to tolerate this.
+
+### Zero-copy boundaries
+
+- **Numeric types** (int, float, bool, timestamp): fully zero-copy in both
+  directions. `pl.from_arrow` and `df.to_arrow` share the underlying buffer.
+- **Strings**: NOT zero-copy. Polars stores strings as `StringView` (with an
+  inline-prefix optimisation); Arrow stores as `string` (offsets + data
+  buffer). Converting requires a memory allocation. The benchmark shows a
+  roundtrip of 10M strings takes ~73ms even though 10M int64s take 0.4ms.
+  This matters for string-heavy payloads (tokenized text, URLs).
+
+---
+
+## 4. IPC Performance Summary
+
+For 2M rows with int64, string, and binary columns:
+
+| Format | Write | Read | Size |
+|---|---|---|---|
+| PA IPC uncompressed | 9ms | 3ms | 73MB |
+| PA IPC zstd (per-buffer) | 27ms | 16ms | 14MB |
+| PL IPC string_view (default) | 31ms | 19ms | 93MB |
+| PL IPC oldest() / large_string | 19ms | 21ms | 89MB |
+
+PyArrow's uncompressed IPC write is the fastest (no compression overhead),
+and its per-buffer zstd achieves the best compression ratio. For the scatter
+file format, **writing with PyArrow IPC + zstd is the right choice** — it's
+what the current code does post-migration, and Polars doesn't add anything
+here.
+
+The Polars `write_ipc_stream` path is slower and produces larger files. Polars
+is the right choice for *computation* (sort, partition, hash), not for the
+file I/O layer.
+
+---
+
+## 5. Recommendation: Use Both, at Different Layers
+
+The question isn't "Polars *or* PyArrow" — it's which layer each belongs to.
+
+**Use PyArrow for:**
+- IPC read and write (scatter files, spill files) — it's faster and the format
+  is fully controlled.
+- RecordBatch construction and schema management.
+- The cloudpickle fallback column (`binary` payload for non-Arrow types).
+- Compute operations where PyArrow suffices (filter, column select, cast).
+
+**Use Polars for:**
+- Sort — 20x faster, the biggest single win.
+- `partition_by(key)` — replaces the per-item routing loop in `ScatterWriter`.
+- `Series.hash()` — vectorised shard-key hashing.
+- Join — when user combiner is expressible as column merging.
+- `map_groups(fn)` — user-supplied per-group Python functions over DataFrames
+  instead of per-row over dicts.
+
+**The handoff**: `pl.from_arrow(batch)` going into a Polars operation,
+`df.to_arrow()` coming back out. Cheap for numerics, one-time copy for
+strings. This is the natural "seam" — keep it minimal and use PyArrow IPC
+on both sides of it.
+
+**The one required convention**: every Polars IPC write must pass
+`compat_level=pl.CompatLevel.oldest()`. Without it, string columns come out
+as `string_view` which PyArrow can parse but not compute on.
+
+---
+
+## 6. Open Questions
+
+**Q: Are `pyarrow.compute` and Polars similar in efficiency for shared operations?**
+
+Mostly yes for aggregation (~1.2x), effectively identical for string ops.
+Polars wins decisively on sort (20x), filter (5x), and has exclusive APIs for
+hash and partition. Where they overlap, the difference rarely matters; the
+Polars-only APIs are what drives the recommendation.
+
+**Q: Polars supports more operations — should we unify on Polars to avoid conversions?**
+
+No. The IPC layer should stay PyArrow — it's faster for file I/O, it's what
+the rest of the ecosystem (Parquet, readers, writers) already uses, and it
+avoids the `string_view` trap on the wire. Use Polars for computation between
+reads and writes.
+
+**Q: What are the actual compatibility issues with `LargeBinary` vs Polars `BinaryView`?**
+
+The issue is the reverse: when Polars *writes* IPC (without `compat_level`),
+it produces `binary_view` and `string_view`. PyArrow compute can't sort or
+filter on those types. The fix is `compat_level=pl.CompatLevel.oldest()` on
+all Polars IPC writes. For Parquet, there's no issue — Polars reads/writes
+`large_binary` through Parquet cleanly.
+
+The `_to_large_type()` helper in `external_sort.py` already correctly handles
+the `string` → `large_string` promotion that happens when roundtripping
+through Polars, which is the other direction of the same issue.

--- a/.agents/projects/20260504-zephyr-arrow/research.md
+++ b/.agents/projects/20260504-zephyr-arrow/research.md
@@ -1,0 +1,448 @@
+# Research: Zephyr Arrow / Polars Migration
+
+Companion to [design.md](design.md). Sources: PyArrow ≥19 (Arrow C++ ≥19) and
+Polars ≥1.0 documentation as of mid-2026; Marin codebase as of late April 2026
+(commit `c2dbcb6e`).
+
+---
+
+## 1. Where the Python time goes today
+
+`writers.py`, `shuffle.py`, `plan.py`, `external_sort.py`, and `spill.py` all
+operate on **`Iterator[dict]`**. Specifically:
+
+- **`load_parquet`** ([readers.py:303](lib/zephyr/src/zephyr/readers.py:303))
+  reads PyArrow row groups, then immediately calls `table.to_pylist()` to hand
+  the worker stream a `dict` per row. Same for `load_vortex`. JSONL goes through
+  `msgspec.json.Decoder().decode(line)` directly to dicts.
+- **Map/Filter/FlatMap** ([plan.py:163-177](lib/zephyr/src/zephyr/plan.py:163))
+  are pure-Python generators iterating one dict at a time.
+- **`ScatterWriter`** ([shuffle.py:477](lib/zephyr/src/zephyr/shuffle.py:477))
+  buffers per-target lists of Python dicts, sorts via `buf.sort(key=...)`, and
+  serialises sub-batches with `cloudpickle.dump` inside a zstd frame.
+- **Reduce** ([plan.py:602](lib/zephyr/src/zephyr/plan.py:602)) calls
+  `heapq.merge` over chunk iterators of dicts, then `itertools.groupby`, and
+  passes a Python iterator to `reducer_fn(key, items_iter)`.
+- **Spill** ([spill.py:67](lib/zephyr/src/zephyr/spill.py:67)) wraps each item
+  in `pickle.dumps(...)` and stores opaque bytes in a single `binary` Parquet
+  column. Read path unpickles each row.
+- **Sorted-merge join** ([plan.py:674](lib/zephyr/src/zephyr/plan.py:674)) tags
+  every left/right item, `heapq.merge` by key, `groupby`, and calls a Python
+  `combiner_fn(left, right)` per matched pair.
+
+Every cross-stage boundary therefore round-trips through:
+
+1. Arrow array → `to_pylist()` (allocates ~K dict objects, ~N string objects)
+2. Python iterator transforms (refcount churn, GC pressure)
+3. `cloudpickle.dump` into zstd (re-allocates everything as opaque bytes)
+4. `cloudpickle.load` on the reducer side (re-allocates dicts)
+
+The 50%–70% GC time in profiling corroborates step 1 dominating: PyArrow's
+`to_pylist` materialises every cell as a fresh Python object. CPython's GC
+walks every newly-allocated container. For a 1M-row scatter shard with 10
+fields, that's 10M+ string objects per stage boundary.
+
+The Arrow plan is to keep data as `pa.RecordBatch` / `pa.Table` from
+`load_parquet` through scatter through reduce, only materialising Python
+objects when (a) user code explicitly asks for items, or (b) the writer needs
+JSONL/dict output.
+
+---
+
+## 2. PyArrow APIs the migration depends on
+
+### IPC (the on-disk shuffle format)
+
+PyArrow has two IPC formats. The choice matters for the scatter-file design:
+
+| Format | Random access | Footer | Use |
+|---|---|---|---|
+| **Stream** (`pa.ipc.new_stream` / `open_stream`) | No — sequential read only | None; ends with EOS marker | Network/pipe transport |
+| **File** (`pa.ipc.new_file` / `open_file`) | Yes — footer stores per-batch offsets | Yes — `RecordBatchFileReader` exposes `num_record_batches` and `get_batch(i)` | Random-access on disk |
+
+The current `ScatterWriter` writes one binary file with **byte-range offsets in
+a sidecar**. A direct port using IPC file format would let the IPC footer
+itself carry per-batch offsets — but the design says the sidecar must still
+identify *which target shard each batch belongs to*, so we still need a sidecar
+mapping `target_shard → [batch_index]`.
+
+**Compression**: Arrow IPC supports per-buffer compression via
+`pa.ipc.IpcWriteOptions(compression='zstd', compression_level=N)`. This is
+*not* whole-file zstd — it compresses each Arrow buffer (validity bitmap,
+offsets, value buffer) independently inside the IPC frame. The file is a valid
+IPC file that any Arrow consumer can read; the sidecar offsets remain valid
+without an outer zstd wrapper. This is the cleanest match for the existing
+"range-GET a chunk, decompress in memory, iterate" path.
+
+Caveat: per-buffer compression is **less effective than whole-file zstd** on
+small batches because each buffer compresses independently. For chunks ≪ 1 MB
+the overhead can exceed savings. Need to benchmark; the current `ScatterWriter`
+flushes by byte budget so chunk size is bounded by the cgroup memory fraction
+(typically 64–256 MB) — that should compress well enough.
+
+### Schema unification
+
+`pa.unify_schemas([s1, s2])` widens compatible schemas (null → concrete,
+missing fields). It **does not** unify `int` and `string` for the same field —
+that raises `ArrowInvalid`. `_accumulate_tables`
+([writers.py:164](lib/zephyr/src/zephyr/writers.py:164)) already handles this
+for the writer side; reducers reading from N source-shard IPC files will
+similarly need to unify schemas across files via `pa.concat_tables(...,
+promote_options="permissive")`. Cost: O(num_source_shards) per reducer at
+startup; cheap.
+
+### Sort, group, and merge
+
+PyArrow has:
+
+- `pa.compute.sort_indices(table, sort_keys=[("col", "ascending")])` —
+  in-memory single-table sort.
+- `table.group_by(...).aggregate([(col, "agg_func")])` — vectorised aggregations
+  (sum, count, count_distinct, hash_min, hash_max, list, ...). **Cannot run a
+  Python reducer per group.**
+- **No public k-way streaming sorted merge.** Acero has internal
+  `SortMergeJoin` and `OrderByNode` but they're not exposed as a Python "merge
+  N already-sorted record-batch streams" primitive. The closest exposed API is
+  `Acero.declarations` for building plans, which is heavyweight and undocumented
+  for this case.
+
+This is the **single biggest gap**. The current `_merge_sorted_chunks`
+([plan.py:602](lib/zephyr/src/zephyr/plan.py:602)) is a `heapq.merge` of
+arbitrarily many chunk iterators. To stay in Arrow we need either:
+
+a) Implement a custom Arrow-native k-way merge (RecordBatch peek + emit
+   row-slices), keeping per-iterator memory bounded the same way. This is
+   ~200–400 lines of new code, but it's the only way to preserve the current
+   memory-bounded streaming semantics.
+
+b) Concat all chunks for one target shard into a single table and sort. Loses
+   the pre-sorted property (chunks are already individually sorted), and
+   memory blows up for large shards — defeats the whole point of the
+   external-sort fall-through.
+
+c) Read each chunk into Python lists, use existing `heapq.merge`. No win.
+
+### Hash and routing
+
+`deterministic_hash` ([plan.py:559](lib/zephyr/src/zephyr/plan.py:559)) uses
+`msgspec.msgpack.encode(obj, order='deterministic')` then xxh3_64. To stay
+vectorised in Arrow we'd want column-wise hashing:
+
+- `pa.compute.hash` exists but is **not stable across Arrow versions** (Arrow
+  docs explicitly say so) and uses a different algorithm than xxh3.
+- `xxhash` Python bindings can hash bytes; we'd need to materialise each row's
+  key as bytes (e.g. via `pyarrow.compute.binary_join_element_wise`) which is
+  awkward and expensive for nested keys.
+- **Polars** exposes `Series.hash(seed)` using xxhash internally — but the seed
+  semantics differ from our raw `xxh3_64_intdigest`, so cross-compatibility
+  with the existing wire format requires care.
+
+Practical answer: for the Arrow path, document that `key_fn` must be a
+column-expression (e.g. `pl.col("user_id")` or a list of column names), and
+compute the hash via Polars' `Series.hash()`. This **changes the partition
+function from xxh3-of-msgpack to xxhash-of-polars-row** — not wire-compatible
+with the existing scatter format. Acceptable if we're cutting a new format
+version anyway, but worth calling out.
+
+Per-row Python `key_fn` (the current API) requires materialising rows — same
+GC cost we're trying to avoid. The migration only pays off when users opt into
+column-based keys.
+
+### Filter pushdown
+
+Already integrated (`expr.py:to_pyarrow_expr`,
+[readers.py:298](lib/zephyr/src/zephyr/readers.py:298)). No change needed; the
+Arrow-native path inherits this for free.
+
+---
+
+## 3. Polars APIs and where they fit
+
+Polars complements PyArrow rather than replacing it. Strengths relevant here:
+
+- **`pl.DataFrame.partition_by(key, as_dict=True)`** — vectorised hash-partition
+  into a `dict[key_value, DataFrame]`. Direct replacement for the per-target
+  shard buffering loop in `ScatterWriter._flush`. Caveat: returns *materialised
+  partitions* in memory; we still need our own byte-budget flushing.
+- **`pl.LazyFrame.sort(...)` with streaming engine** — disk-spilling sort using
+  Polars' streaming executor. Could replace `external_sort.py` for the
+  single-shard case. Caveat: streaming engine in Polars 1.x is still labelled
+  "experimental / breaking changes possible"; not all operations are streamable
+  (notably user-defined functions break streaming). The blog post linked in
+  the design ([Polars streaming joins](https://pola.rs/posts/streaming-joins/))
+  describes the new merge-sort join, which **is a true streaming join** — but
+  it requires both inputs as `LazyFrame`s with a common partition key. Mapping
+  our `Shard → ScatterReader → join` flow into `LazyFrame.scan_ipc(...)` would
+  work for the file-backed case.
+- **`pl.from_arrow(table)` / `df.to_arrow()`** are zero-copy when the schema is
+  Arrow-native (no Object dtype). Conversion overhead is negligible.
+- **`pl.Series.hash(seed1, seed2, seed3)`** — xxhash-based vectorised hashing.
+  See note above on cross-compatibility.
+- **No equivalent of `reducer_fn(key, Iterator[items])`** — Polars
+  `group_by().agg(...)` only takes vectorised expressions. User-defined
+  per-group Python via `map_groups()` exists but materialises each group as a
+  DataFrame and runs in Python — same GC cost we're trying to avoid.
+
+**Where Polars genuinely helps**:
+
+- Scatter routing (`partition_by` over a hashed key column).
+- Streaming sort spill (replacement for `external_sort.py` pass-1).
+- Streaming sorted-merge join (replacement for `_sorted_merge_join` if both
+  sides are file-backed and the user combiner is expressible as a join).
+- Vectorised aggregations when users opt into a Polars-expression API
+  (replacement for `combiner_fn` in the common count/sum/agg case).
+
+**Where Polars does not help**:
+
+- Any user `key_fn` / `reducer_fn` / `combiner_fn` that's a Python lambda over
+  per-item Python objects.
+- Items that aren't representable in Arrow's typesystem (frozensets,
+  arbitrary Python objects) — Polars' `Object` dtype exists but doesn't
+  serialize to IPC.
+
+---
+
+## 4. Items not representable as Arrow
+
+Test [test_shuffle.py:158](lib/zephyr/tests/test_shuffle.py:158)
+(`test_scatter_handles_arbitrary_python_objects`) asserts that
+`frozenset`, mixed `None`/`frozenset` in the same field, and other
+non-Arrow-native types round-trip through scatter. The current code achieves
+this via `cloudpickle.dump`. Arrow IPC has no equivalent — the schema must be
+declared up-front and every batch must conform.
+
+Options:
+
+1. **Break the contract**. Document that scatter inputs must be Arrow-coercible
+   dicts. Update the test. Requires auditing every `group_by` / `deduplicate`
+   call site in the Marin tree. (Searched: most uses are dicts of strings/ints.
+   Tokenization stages produce dicts of int arrays. The frozenset case appears
+   only in tests. Likely acceptable but not zero-cost.)
+
+2. **Fall back to a binary-payload column** for non-coercible items. Detect on
+   first item; if unrepresentable, wrap as `{"_payload": cloudpickle.dumps(item)}`
+   for that whole shard. Works but loses the perf win for any job that hits the
+   fallback. Easier sell: keeps the test passing, no audit needed.
+
+3. **Mixed schema per chunk**: write Arrow-native batches when possible, append
+   pickle blobs as a separate batch when not. Rejected — too complex, too easy
+   to corrupt.
+
+The design doc currently says "Keep the API to Zephyr the same, so existing
+jobs will continue to run." Option 2 is the only one consistent with that
+literally. Option 1 is honest about the tradeoff.
+
+---
+
+## 5. The user-callable problem
+
+Zephyr's API exposes:
+
+- `MapOp.fn: T → R`
+- `FilterOp.predicate: T → bool`
+- `FlatMapOp.fn: T → Iterable[R]`
+- `MapShardOp.fn: (Iterator[T], ShardInfo) → Iterator[R]`
+- `GroupByOp.key_fn: T → Hashable`
+- `GroupByOp.reducer_fn: (Hashable, Iterator[T]) → R | Iterator[R]`
+- `GroupByOp.sort_fn: T → Hashable`
+- `GroupByOp.combiner_fn: (Hashable, Iterator[T]) → Iterator[T]`
+- `JoinOp.combiner_fn: (T | None, R | None) → object`
+
+All are item-at-a-time Python callables. The migration's headline benefit —
+"removing all the GC time" — only materialises if **the data never becomes
+Python objects between scatter and reduce**. But the moment any of these
+callables runs, we have to materialise rows back to dicts.
+
+This means the migration's actual perf win depends on which stages have user
+callables in them:
+
+- **Pure-load → scatter → reduce → write** (e.g. dedup-by-id, count-by-key):
+  data can stay in Arrow end-to-end. Real win.
+- **Load → map(transform) → scatter → reduce → write** (e.g. tokenization,
+  feature extraction): the map stage forces materialisation; scatter/reduce
+  benefit unaffected, but the map cost dominates. Mid-sized win.
+- **Load → group_by(key=lambda r: r['id'], reducer=lambda k, items: ...)**:
+  reducer materialises per-group items as dicts. Scatter benefit only.
+
+To hit the headline 2x–3x, we need to *also* expose Arrow-native variants:
+
+- `MapTableOp(fn: pa.RecordBatch → pa.RecordBatch)` (or Polars equivalent)
+- `GroupByOp(key=col_names, agg=pl.expr)` for vectorised aggregations
+- A new way to declare combiners as Polars/Arrow expressions
+
+These are additive — old API still works, just doesn't get the full speedup.
+The design doc hints at this with "Expose an alternative Zephyr API that
+allows for processing data directly in Arrow" but doesn't detail it.
+
+---
+
+## 6. K-way merge, in detail
+
+The current scatter→reduce path produces **N×M sorted chunks** at a reducer
+(N source shards × per-source flush count for this target shard). N×M routinely
+hits the thousands; `external_sort_merge` exists precisely because
+`heapq.merge` over thousands of open file iterators blows the memory budget.
+
+For an Arrow-native rewrite:
+
+**Pass-1 inside one reducer**:
+- Each scatter chunk = one IPC RecordBatch (sorted by `merge_key`).
+- Need to merge K sorted batches into one sorted stream of batches.
+- Polars: would have to convert each batch to a `LazyFrame`, then
+  `pl.concat([lf1, lf2, ...]).sort(merge_key)` — but this is a *full sort*, not
+  a merge of pre-sorted inputs. Polars' streaming sort can spill, so it works,
+  but at cost: re-sorting ignores the pre-sorted property and costs O(N log N)
+  instead of O(N log K).
+- PyArrow Acero exposes a `SortByKeyNode` and an internal `MergeNode`, but the
+  Python bindings (`pyarrow.acero`) only document `OrderByNode` — same
+  problem: full sort, not merge.
+- Custom implementation: maintain a heap of `(current_row_key, batch_id,
+  row_index)`, peek, emit slices. Doable but ~200 lines and trickier than the
+  Python `heapq.merge` because we need to emit in batch-sized strides for
+  efficiency.
+
+**Best path**: Custom Arrow-native k-way merge that emits `RecordBatch`-sized
+runs of monotonically increasing keys. Spell out the row-stride trick in the
+implementation: pop the cheapest batch's first K rows where the K-th row's key
+is still ≤ the next-cheapest batch's first key, emit them as a single
+`batch.slice(0, K)`, advance, repeat. This amortises per-row dispatch across
+batches when keys are unevenly distributed.
+
+**Pass-2 (external sort fan-in)**: Same algorithm operates over spill-file
+batch iterators. The current `SpillWriter`/`SpillReader` (Parquet binary
+column) would be replaced by IPC files with the actual schema.
+
+---
+
+## 7. Sorted-merge join, in detail
+
+`_sorted_merge_join` ([plan.py:674](lib/zephyr/src/zephyr/plan.py:674)) is a
+streaming inner/left join over two pre-partitioned, pre-sorted streams, with a
+**user-supplied `combiner_fn(left, right) → object`** called per matching pair
+and a Cartesian fan-out within duplicate-key groups.
+
+Polars 1.x added a streaming sort-merge join via the new streaming engine —
+this matches the algorithmic shape exactly, and supports inner/left/full
+joins. **But**:
+
+- Polars' join produces a single combined row per match (column-merging,
+  optionally with `suffix=`); it does not call a user combiner. The current
+  `combiner_fn` API includes things like `lambda left, right: {**left,
+  **right, "joined": True}` which have a vectorisable equivalent, but also
+  arbitrary Python combiners that don't.
+- For arbitrary-combiner cases, the current `_sorted_merge_join` semantics
+  (Cartesian per-group + per-pair Python) is the only correct fallback. We'd
+  use Polars' streaming join only when `combiner_fn` is `None` or a known
+  vectorisable shape (dict-merge).
+
+Practical recommendation: implement two paths, gated by combiner type. Add a
+`Join.combiner_kind: Literal['merge_columns', 'callable']` field; the planner
+chooses the Arrow-native path when it can.
+
+---
+
+## 8. Multithreading claim revisited
+
+The design says "we can parallelize jobs using multithreading at the Zephyr
+level, since the Python GIL will no longer be holding locks during processing."
+This is **partially true**:
+
+- PyArrow C++ kernels (sort, filter, take, hash, IPC read/write) release the
+  GIL. Threading helps these.
+- Polars operations release the GIL in its Rust core. Threading helps these.
+- zstd encode/decode (via `python-zstandard`) releases the GIL.
+- File I/O (fsspec/GCS) releases the GIL.
+
+What does **not** release the GIL:
+- Any user `key_fn` / `combiner_fn` / `reducer_fn` / `MapOp.fn` written in
+  Python. These re-take the GIL.
+- `pa.compute.cast`, `to_pylist`, `from_pylist` — the conversion boundary.
+
+So the multithreading benefit follows the same rule as section 5: it
+materialises only on stages that don't run user Python per row. Combined with
+the per-stage worker types in
+[20260430-zephyr-performance/design.md](../20260430-zephyr-performance/design.md),
+the actual win comes from threading the *Arrow-native* stages while leaving
+user-Python stages on subprocesses.
+
+---
+
+## 9. Spill format
+
+`spill.py` stores `pickle.dumps(item)` as `binary` Parquet column values. The
+Arrow migration suggests replacing this with native-schema IPC files, but:
+
+- Spilled data passes through `_merge_sorted_chunks` then user `reducer_fn`.
+- Mixed-type / non-Arrow items (section 4) hit spill the same way they hit
+  scatter. Spill needs the same fallback strategy.
+- Parquet → IPC for spill removes one Parquet write/read per spilled item but
+  doesn't change the asymptotics. Switch is consistent with the rest of the
+  migration but has small marginal impact.
+
+---
+
+## 10. Dependency footprint
+
+- PyArrow ≥22 already in `lib/marin/pyproject.toml`. Iris uses ≥19. Zephyr's
+  current minimum is whatever marin pulls in transitively. Worth pinning Arrow
+  to ≥22 in Zephyr's `pyproject.toml` directly.
+- Polars **is not currently a dependency** anywhere in the tree (verified with
+  `grep -r polars lib/*/pyproject.toml`). Adding it pulls a substantial Rust
+  binary (Polars wheel is ~30 MB). Worth confirming this is acceptable;
+  Marin's worker images would gain ~30 MB.
+- `python-zstandard` already in use.
+- `cloudpickle` still required for the fallback path (and for shipping user
+  closures to workers — separate concern, not on the data path).
+
+---
+
+## 11. Surprise areas worth a small benchmark before committing
+
+These are the assumptions in the design that could turn out wrong, listed by
+how cheaply they can be validated:
+
+1. **Per-buffer zstd vs whole-file zstd** for chunk sizes typical of Marin
+   shuffles (64 MB cgroup / 256 MB cgroup). Run `pa.ipc.write_table` with
+   `compression='zstd'` on a real shuffle batch and compare bytes to the
+   current `zstd.compress(cloudpickle.dumps(items))`. If per-buffer is >1.3x
+   larger, consider keeping outer zstd wrapper.
+
+2. **Custom k-way merge throughput** vs `heapq.merge` over `to_pylist()`'d
+   batches. The custom implementation has to win to justify itself; if rows
+   are tiny (e.g. `{"id": int}` for dedup) the Python overhead of heap
+   maintenance dominates and the Arrow path may not win.
+
+3. **`partition_by` cost** in the scatter writer. The current scatter does
+   per-item dict-routing in Python — we'd replace it with a vectorised
+   hash + partition. Should be a clear win, but `partition_by(as_dict=True)`
+   on a 100k-row batch with 1024 target shards has not been benchmarked here.
+
+4. **`pa.Table.concat_tables(promote_options='permissive')` cost across 1000s
+   of source files** at reduce-side schema unification.
+
+---
+
+## 12. What stays the same
+
+To prevent this list from looking like a teardown — most of the surrounding
+machinery is fine and stays put:
+
+- `ScatterReader` sidecar layout (target_shard → byte ranges) maps cleanly to
+  IPC batch indices.
+- The `from_sidecars` per-reducer parallel sidecar read.
+- The `needs_external_sort` heuristic (just rewires `avg_item_bytes` from
+  pickle bytes to Arrow bytes).
+- `_compute_file_pushdown`, `LoadFileOp`, the existing reader paths.
+- `_fuse_operations` and the planner's stage boundaries.
+- The runner / coordinator / heartbeat machinery.
+
+The actual surface area of code that *must* change is:
+
+- `ScatterWriter` (~200 LOC) → IPC-based equivalent
+- `ScatterFileIterator._iter_chunk` (~30 LOC) → IPC batch read
+- `_merge_sorted_chunks` (~70 LOC) → custom k-way merge
+- `_sorted_merge_join` (~50 LOC) → dispatch to Polars or fallback
+- `spill.py` (~210 LOC) → IPC-based equivalent
+- New `MapTableOp` / `GroupByExprOp` for the optional Arrow API
+
+Everything else either compiles unchanged or adapts mechanically.


### PR DESCRIPTION
As titled, a design document for moving Zephyr internals to Polars and exposing it to users as well.

design.md inline for convenience

---

# Zephyr Arrow / Polars Migration

Processing data directly in Python is slow. It always has been.

Profiling some of our jobs, the ones that use Python to do the processing spend 50% - 70% of their time doing GC. Even jobs that don't use Python as much but use group by, can spent a fair amount of time in the Zephyr internals merging and sorting Python records.

We should move to using Arrow as the internal format for Zephyr and expose Arrow via the Zephyr API.
## Why
- Exposing Arrow to Zephyr jobs should make Python-heavy jobs at least 2x - 3x faster by migrating the logic to Polars and thereby removing all the GC time
- We can, likely, use more [efficient merging algorithms](https://pola.rs/posts/streaming-joins/) for the scatter / reduce phases
- We can avoid the cost of serialization and deserialization with `pickle`
- Again, if we move to user logic to Polars, we can parallelize jobs using multithreading at the Zephyr level, since the Python GIL will no longer be holding locks during processing
## Goals
- Migrate the internals of Zephyr to use Arrow for storage, including migrating the scatter format to use zstd compressed IPC files (IPC is the native Arrow format that doesn't incur any serialization or deserialization cost to write to disk).
- Keep the API to Zephyr the same, so existing jobs will continue to run, but without all the speed gains
- Expose an alternative Zephyr API that allows for processing data directly in Arrow and enabled the 2x - 3x speedups
## Design / Plan
- Replace `ScatterWritter` with a version the reads and writes ztsd compressed Arrow IPC
- Update the necessary sections of `plan.py`: `_merge_sorted_chunks`, `_sorted_merge_join`
- Update `spill.py` to use Arrow IPC as well
- Add a new `ArrowDataset` builder that has a very similar API to `Dataset` but provides a `PyArrow::BatchRecord` to the functions. 
	- The main difference will be exposing a new version of `GroupBy` that allows for [Polars-level aggregations](https://docs.pola.rs/user-guide/expressions/aggregation/)
## Risks / Challenges 

- **Reimplementing `_merge_sorted_chunks` might be tricky**  There's not a perfect analog in Polars / PyArrow for this function, although there are option and we can benchmark them to figure out the best one. See [research §6](research)
- **Arrow restricts the processable types** Technically `cloudpickle.dump` supports a much wider range of data types than Arrow, creating a breaking change. I reality, we only use data types supported by Arrow, so should be fine.
- **User-code needs to be migrated to Polars** To get the speedups, we'll need to migrate all the user-code in the pipelines to Polars. Representing things in Polars is more cumbersome than raw Python.
- **Change in the hashing function** I'm not sure why we'd want to read old scatter files, bjt we won't be able to after this.
- **Per-buffer zstd vs whole-file zstd compression ratio.** PyArrow IPC's `compression='zstd'` is worse than the current whole-batch `cloudpickle.dump → zstd.compress` flow. Could increase shuffle bytes 1.2-1.5x in the worst case. We should benchmark this. See [research §11.1](research).
## Future work
Once this is complete, we can return to [zephyr-performance](../20260430-zephyr-performance/design) and implement the parallelization improvements there and actually realize the benefit, since the GIL will not limit multithreading in *Arrow-native* stages.