### PR TITLE
[codex] Document Iris job logs descendant behavior

### DIFF
--- a/.agents/skills/babysit-job/SKILL.md
+++ b/.agents/skills/babysit-job/SKILL.md
@@ -123,7 +123,9 @@ server is part of the monitoring setup. State file allows resume after context r
    - otherwise: sleep 570
 
 2. CHECK LOGS
-   uv run iris --config <CONFIG> job logs --since-seconds 900 --include-children <JOB_ID> | rg -i -e "loss|error|traceback|exception|resource_exhausted|oom|compiler_base\.cc:2587|program hbm requirement|largest program allocations|ownerdiederror|dead node|node death|autoscaler unsatisfied resources|no accelerator found|failed_precondition|device or resource busy"
+   uv run iris --config <CONFIG> job logs --since-seconds 900 <JOB_ID> | rg -i -e "loss|error|traceback|exception|resource_exhausted|oom|compiler_base\.cc:2587|program hbm requirement|largest program allocations|ownerdiederror|dead node|node death|autoscaler unsatisfied resources|no accelerator found|failed_precondition|device or resource busy"
+
+   `iris job logs <JOB_ID>` includes child-job task logs by default.
 
 3. CHECK STATUS
    uv run iris --config <CONFIG> job list --json --prefix <JOB_ID>

--- a/docs/dev-guide/guidelines-internal.md
+++ b/docs/dev-guide/guidelines-internal.md
@@ -78,7 +78,7 @@ uv run iris --config lib/iris/examples/marin.yaml job run \
 # List jobs (filter by --state, --user, --prefix, etc).
 uv run iris --config lib/iris/examples/marin.yaml job list
 
-# Follow logs (batch-fetches task logs for the job).
+# Follow logs (includes child-job task logs by default).
 uv run iris --config lib/iris/examples/marin.yaml job logs /<user>/<job-name>
 
 # Kill / Stop Job (if necessary / error / bug) -- kills the job and all its child tasks.

--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -26,7 +26,7 @@ If checkpoint times out: `iris cluster controller restart --skip-checkpoint` (re
 ```bash
 iris job run -- python train.py         # submit + stream logs
 iris job list --state running           # filter by state
-iris job logs /user/job-name -f         # follow logs
+iris job logs /user/job-name -f         # follow job + child logs
 iris job stop /user/job-name            # kill job + children
 iris job summary /user/job-name         # per-task state, exit, duration, peak memory
 iris job summary /user/job-name --json  # same, machine-readable

--- a/lib/iris/README.md
+++ b/lib/iris/README.md
@@ -290,7 +290,7 @@ iris --config cluster.yaml job run --no-wait -- python long_job.py
 # Pin a zone when you need to colocate with data or target a specific pool.
 iris --config cluster.yaml job run --zone us-central2-b -- python train.py
 
-# Stream logs for a job (batch-fetches from all tasks in one RPC)
+# Stream logs for a job and child jobs (batch-fetches matching tasks in one RPC)
 iris --config cluster.yaml job logs /my-job
 iris --config cluster.yaml job logs /my-job --follow
 iris --config cluster.yaml job logs /my-job --since-seconds 300

--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -1202,7 +1202,7 @@ def logs(
     tail: bool,
     level: str | None,
 ) -> None:
-    """Stream task logs for a job using batch log fetching."""
+    """Stream task logs for a job and its descendants using batch log fetching."""
     if since_ms is not None and since_seconds is not None:
         raise click.UsageError("Specify only one of --since-ms or --since-seconds.")
 

--- a/lib/iris/tests/e2e/benchmark_controller.py
+++ b/lib/iris/tests/e2e/benchmark_controller.py
@@ -226,7 +226,7 @@ class JobResult:
 
 
 def _wait_for_job(job: Job, timeout: float) -> JobResult:
-    """Wait for a single job, streaming logs including children.
+    """Wait for a single job, streaming descendant logs.
 
     Designed to be called from a thread pool. Each thread independently waits
     on its job and streams logs back through the logger.
@@ -308,7 +308,7 @@ def run_benchmark(num_jobs: int, num_slices: int) -> BenchmarkMetrics:
             # Wait for schedulable jobs concurrently, streaming logs from each in its own thread.
             # Unschedulable ("bad") jobs are excluded since they'll never reach a terminal state
             # in a timely manner.
-            print(f"Waiting for {len(schedulable_jobs)} schedulable jobs (streaming logs with children)...")
+            print(f"Waiting for {len(schedulable_jobs)} schedulable jobs (streaming descendant logs)...")
             wait_start = time.monotonic()
             results = _wait_all_jobs_threaded(schedulable_jobs, timeout=600.0)
             time_to_complete = time.monotonic() - wait_start
@@ -398,11 +398,11 @@ def _cpu_burn_task(seconds: float = 1.0):
 def run_single_worker_benchmark(num_jobs: int) -> BenchmarkMetrics:
     """Submit *num_jobs* to one worker as fast as possible, streaming logs.
 
-    Every job is waited on concurrently with ``stream_logs=True`` and
-    ``include_children=True``, mirroring how Marin's ferry driver monitors a
-    batch of download tasks.  The goal is to stress the controller's RPC
-    handling and task-dispatch path when a single worker is hit with many
-    concurrent requests.
+    Every job is waited on concurrently with ``stream_logs=True``, which
+    includes descendant job task logs by default. This mirrors how Marin's
+    ferry driver monitors a batch of download tasks. The goal is to stress
+    the controller's RPC handling and task-dispatch path when a single worker
+    is hit with many concurrent requests.
     """
     print("\n" + "=" * 70)
     print("Iris Controller Benchmark — single-worker burst")


### PR DESCRIPTION
## Summary

Clarifies that `iris job logs <JOB_ID>` already includes descendant job task logs after the FetchLogs migration, so the removed `--include-children` flag is no longer needed for logs.

## Details

- Removes stale `job logs --include-children` guidance from the babysit-job skill.
- Updates Iris user-facing docs and CLI help to say job logs include child-job task logs by default.
- Cleans up stale benchmark wording that still referred to `include_children=True`.

## Root Cause

PR #4202 replaced the old `GetTaskLogs(include_children=...)` path with `FetchLogs` source patterns. Job log sources now use the hierarchical pattern `/job/.*`, which includes child and grandchild task logs by default.

## Validation

- `uv run iris job logs --help`
- `rg -n "job logs[^\\n]*include-children|include-children[^\\n]*job logs|include_children=True|``include_children=True``" .agents docs lib/iris tests -g '!**/*_pb2.py' -g '!**/*_pb2.pyi'`
- `./infra/pre-commit.py --fix .agents/skills/babysit-job/SKILL.md docs/dev-guide/guidelines-internal.md lib/iris/OPS.md lib/iris/README.md lib/iris/src/iris/cli/job.py lib/iris/tests/e2e/benchmark_controller.py`