### PR TITLE
Increase Iris E2E smoke timeout

### DIFF
--- a/.github/workflows/iris-unit.yaml
+++ b/.github/workflows/iris-unit.yaml
@@ -66,7 +66,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

Increase the GitHub Actions timeout for the `iris-e2e-smoke` job from 5 minutes to 10 minutes.

## Why

The current `Iris - Tests` failure timed out after the smoke tests had already passed, so this gives the job enough CI wall-clock time without changing test behavior.

Recent timing context from the regression investigation:

- Before the finelog stats/DuckDB write-path change, comparable `iris-e2e-smoke` runs were around `126s`.
- After that change, comparable runs were around `155s`.
- The failed main run also hit a Playwright/dependency setup outlier, which consumed the remaining slack under the 5-minute job timeout.

So this is a short-term CI stability fix: the test is still passing, but the 5-minute cap no longer has enough headroom for normal variation plus setup outliers.

## Validation

- `git diff -- .github/workflows/iris-unit.yaml`
- `git diff --check origin/main...HEAD`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml parse ok"' .github/workflows/iris-unit.yaml`