### PR TITLE
[codex] Clarify CoreWeave GH200 request

### DIFF
--- a/lib/iris/docs/coreweave.md
+++ b/lib/iris/docs/coreweave.md
@@ -201,11 +201,12 @@ iris --controller-url=http://localhost:10000 ...
 | Target | Iris config | `--gpu` request | `nvidia-smi` GPU name |
 |--------|-------------|-----------------|-----------------------|
 | H100 | `lib/iris/examples/coreweave-ci.yaml` | `H100x1` | `NVIDIA H100 80GB HBM3` |
-| GH200 | `lib/iris/examples/coreweave-rno2a.yaml` | `H200x1` | `NVIDIA GH200 480GB` |
+| GH200 | `lib/iris/examples/coreweave-rno2a.yaml` | `GH200x1` | `NVIDIA GH200 480GB` |
 | B200 | `lib/iris/examples/coreweave-usw09b.yaml` | `B200x1` | `NVIDIA B200` |
 
-Do not change the GH200 row to `GH200x1`: the RNO2A pool currently accepts
-`H200x1`, then reports `NVIDIA GH200 480GB` from `nvidia-smi`.
+Use `GH200x1` for RNO2A. `H200x1` also schedules there today; both land on
+CoreWeave `gd-1xgh200` nodes labeled `gpu.nvidia.com/model=GH200_480GB` and
+report `NVIDIA GH200 480GB`.
 
 Before the full GPU canary, run one tiny direct JAX job for each row. It should
 prove `nvidia-smi`, GPU-backed JAX, and a tiny matmul.


### PR DESCRIPTION
## Summary

Clarifies the CoreWeave RNO2A GH200 row to use `GH200x1` as the canonical Iris GPU request.

The previous wording said not to change the row from `H200x1`. A live RNO2A probe showed that both `H200x1` and `GH200x1` are accepted and land on CoreWeave `gd-1xgh200` nodes labeled `gpu.nvidia.com/model=GH200_480GB`, with `nvidia-smi` reporting `NVIDIA GH200 480GB`.

## Validation

- `./infra/pre-commit.py lib/iris/docs/coreweave.md`
- `git diff --check`
- Live RNO2A hardware probes:
  - `/romain/codex-rno2a-h200x1-hw-probe-20260505-123134`: succeeded, reported `NVIDIA GH200 480GB`, 97871 MiB, ARM Neoverse-V2 CPU
  - `/romain/codex-rno2a-gh200x1-hw-probe-20260505-123134`: succeeded, reported `NVIDIA GH200 480GB`, 97871 MiB, ARM Neoverse-V2 CPU