### PR TITLE
[ci] Set GH_TOKEN for dupekit release publish step

### DIFF
--- a/.github/workflows/dupekit-release-wheels.yaml
+++ b/.github/workflows/dupekit-release-wheels.yaml
@@ -95,6 +95,8 @@ jobs:
           fi
 
       - name: Publish release and update pyproject
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python scripts/rust_package.py --skip-build
 
       - name: Open or update PR


### PR DESCRIPTION
The Publish release and update pyproject step invokes scripts/rust_package.py, which calls gh release create. Without GH_TOKEN, gh runs unauthenticated and the release-create command fails with exit 4.