### PR TITLE
[finelog] Leveled compactor + catalog-driven copy worker

### DIFF
--- a/.agents/projects/2026-05-05_finelog_compactor.md
+++ b/.agents/projects/2026-05-05_finelog_compactor.md
@@ -1,0 +1,264 @@
+# Finelog Compaction Refactor
+
+**Status:** Draft v2 &nbsp;•&nbsp; **Author:** agent + russell &nbsp;•&nbsp; **Date:** 2026-05-05
+
+One-line summary: Extract finelog's compaction logic into a `Compactor` class with a level-target merge policy, a single per-segment filename scheme, and a `level` column on the catalog. Compaction stays in DuckDB but inputs are bounded by the level scheme so spilling is a non-issue.
+
+## Goals
+
+- Cap finalized parquet segments at ~256 MiB so eviction granularity is bounded and remote round-trip costs stay predictable.
+- Make compaction policy a first-class config object (`CompactionConfig`) — three knobs, all defaultable.
+- Replace the implicit `tmp_*` / `logs_*` filename split with a single `seg_L<n>_<min_seq>.parquet` scheme + a `level` column on the catalog.
+- Preserve the within-segment `(key_column, seq)` sort invariant so row-group `[min_key, max_key]` stays tight on `key`.
+
+## Non-goals
+
+- Changing the GCS offload path (already moved to `_OffloadWorker` in `duckdb_store.py`).
+- Read-side row-group pruning improvements (orthogonal).
+- Backwards compat for on-disk filenames — boot-time migration renames `tmp_*` → `seg_L0_*`, `logs_*` → `seg_L1_*` and rewrites the catalog atomically.
+- Cross-namespace fairness beyond the bg loop's natural round-robin.
+
+## Background
+
+Compaction today lives inline on `DiskLogNamespace`. `_compaction_step` (`log_namespace.py:859`) snapshots all `tmp_*` segments, runs one DuckDB `COPY (SELECT … ORDER BY …) TO …` (`:949`) into a staging file, renames + swaps under the visibility lock. Triggered when `tmp_count > _max_tmp_segments_before_compact` (default 10) or every `compaction_interval_sec` (default 600 s). State is filename-encoded: `tmp_*` (post-flush) vs `logs_*` (compacted).
+
+Production (one marin namespace): ~73–100 finalized parquets, 13–18 MiB each, ~1.3 GiB total. Files never grow above ~20 MiB because the policy is flat — every compaction merges all current tmps into one logs_ file, then never re-touches it.
+
+The lock-during-COPY bug was fixed in commit `0acec62c0` so the COPY no longer blocks writers; that's a pre-condition for the design below.
+
+## Proposed design
+
+### 1. `Compactor` class
+
+New module `lib/finelog/src/finelog/store/compactor.py`. Stateless. The namespace owns locks, catalog mutation, and offload submission; the Compactor owns planning + the merge SQL.
+
+```python
+@dataclass(frozen=True)
+class CompactionConfig:
+    # Promote L_n -> L_{n+1} when the longest contiguous run of L_n
+    # segments has combined byte_size >= level_targets[n]. Terminal
+    # level is len(level_targets); never re-compacted.
+    level_targets: tuple[int, ...] = (64 * MiB, 256 * MiB)
+    # Bg loop wakes this often to re-plan.
+    check_interval_sec: float = 30.0
+    # Promote L0 even if the size threshold isn't met, when the oldest
+    # L0 has been sitting more than this long. Keeps low-volume
+    # namespaces from leaking small files.
+    max_l0_age_sec: float = 300.0
+
+
+class Compactor:
+    def __init__(self, config: CompactionConfig, *, schema: Schema): ...
+    def plan(self, segments: Sequence[SegmentRow], now_ms: int) -> CompactionJob | None: ...
+    def merge_sql(self, job: CompactionJob, *, staging_path: Path) -> str: ...
+
+CompactionJob = NamedTuple("CompactionJob", [
+    ("inputs", tuple[SegmentRow, ...]),
+    ("output_level", int),
+    ("output_min_seq", int),
+    ("output_max_seq", int),
+])
+```
+
+`level_targets` is the only policy knob. `level_fanout`, `max_segment_bytes`, `min_inputs_to_compact`, `target_row_group_bytes`, and `throughput_budget_mbps` were all derivable or unnecessary; they're gone.
+
+### 2. Levels and policy
+
+L0 is implicit — whatever flush emits (no target, no L0 compaction; flush writes directly into the L0 namespace).
+
+Promotion rule: pick the longest contiguous-by-`min_seq` run of L_n segments whose summed `byte_size` is ≥ `level_targets[n]`. Merge them into one L_{n+1} segment. If a single segment alone meets the threshold (e.g. flush emitted 100 MiB and L0→L1 target is 64 MiB), short-circuit to a level bump only — `os.rename` + UPDATE level — no rewrite.
+
+L_max (= `len(level_targets)`) is terminal. Eviction takes those over (§8).
+
+**Why not binary-LSM (`_merge_chunks` style, "each chunk ≥ 2× the previous")?** It has no clean terminal state; every new flush eventually re-touches the largest file, rewriting ~3× the daily ingest volume. The level-target policy rewrites each byte exactly `len(level_targets) - 1` times (default: 2). Read fanout drops from ~73 files to `~level_targets[0]/L0_avg + ⌈total / level_targets[-1]⌉` ≈ 4 + 5 = 9 in steady state.
+
+**Adjacency is naturally satisfied.** Levels are time-ordered: L_{N+1} segments cover seq ranges older than the live L_N tail because they were promoted earlier. Eviction is FIFO-by-`min_seq` (oldest first; never picks from the middle — see §8), so the local segment set is always a contiguous suffix of the global seq range. The planner picks the longest run of L_n segments whose summed `byte_size` ≥ `level_targets[n]`; a contiguity check (`prev.max_seq + 1 == next.min_seq`) is included as a defensive assertion but should never fail in practice.
+
+**No splitting.** Removing `max_segment_bytes` removes the split-output path. A promotion is strictly many-to-one; one CompactionJob → one output segment. If the inputs are slightly lumpy and the output lands at, say, 280 MiB instead of 256, that's fine — it won't promote further (no level above) and won't be re-touched.
+
+### 3. Merge implementation
+
+**Use DuckDB COPY.** Each input is already sorted on `(key_column, seq)`. The Compactor builds a single SQL string:
+
+```sql
+COPY (
+  SELECT <projected columns>
+  FROM read_parquet([<input paths>], union_by_name=true)
+  ORDER BY <key_column>, seq
+) TO '<staging path>' (
+  FORMAT 'parquet',
+  ROW_GROUP_SIZE 16384,
+  COMPRESSION 'zstd',
+  COMPRESSION_LEVEL 1,
+  WRITE_BLOOM_FILTER true
+);
+```
+
+The earlier draft proposed pyarrow + k-way merge to avoid DuckDB's ORDER BY spilling. With the leveled scheme, inputs to any one job are bounded by `level_targets[n]`: at most ~256 MiB compressed (~1 GiB uncompressed). DuckDB's default 4 GiB memory_limit comfortably fits the sort; the multi-GB temp files we observed historically came from the flat policy where input was many GB. DDB stays. `union_by_name=true` continues to handle additive schema evolution as today.
+
+Row-group sizing stays count-based at `_ROW_GROUP_SIZE = 16_384`. The earlier "switch to byte-based" was unnecessary churn.
+
+### 4. Filenames: single scheme
+
+Every segment is `seg_L<n>_<min_seq:019d>.parquet`. Level lives in both the filename (so disk-only boot recovery still works when the catalog is missing or stale) and the catalog `level` column (source of truth at runtime).
+
+### 5. Catalog changes
+
+**Migration `0003_segment_level.py`.**
+
+```sql
+ALTER TABLE segments ADD COLUMN IF NOT EXISTS level INTEGER NOT NULL DEFAULT 0;
+UPDATE segments SET level = 0 WHERE state = 'tmp';
+UPDATE segments SET level = 1 WHERE state = 'finalized';
+CREATE INDEX IF NOT EXISTS segments_ns_level_minseq
+  ON segments (namespace, level, min_seq);
+```
+
+The migration also renames on-disk `tmp_*` → `seg_L0_*` and `logs_*` → `seg_L1_*` inside a single transaction with the catalog `path` rewrites, then drops the now-unused `state` column. After this migration boots successfully there are no sentinels, no half-states — boot looks exactly like a fresh deploy with the new naming.
+
+`SegmentState` is removed. The TMP/FINALIZED distinction was only used for visibility (now: every catalog row is visible because flush writes the row in lockstep with the file rename) and eviction (now: ordered by level, §8).
+
+**Atomic swap is single-output.** `replace_segments(removed_paths, added)` already takes a sequence for `added`; with no splitting it's always called with a single-element list. The transaction is straightforward — no two-phase, no `level=-1` sentinel. A mid-rename crash leaves at most one `*.parquet.tmp` orphan, swept by a boot reaper.
+
+### 6. Concurrency
+
+**One bg thread per namespace** (today's structure). That thread handles flush, compaction, and eviction sequentially. Across namespaces, threads run in parallel — but each namespace's thread only ever touches its own namespace's files and catalog rows.
+
+This makes the compaction-vs-eviction race impossible by construction: within a namespace they're back-to-back on the same thread; across namespaces the work sets are disjoint. No cross-thread coordination, no extra locks during the COPY.
+
+**Eviction becomes per-namespace.** Today's `_evict_globally` walks all namespaces with a global cap (`max_local_segments=1000`, `max_local_bytes=100 GiB`); any namespace's bg thread can call it, and the eviction can target any other namespace's segments. That structure produces the cross-namespace race we're avoiding. Replacement: each namespace gets its own cap (`max_segments_per_namespace`, `max_bytes_per_namespace`), each bg thread evicts only its own segments at the tail of `_compaction_step`. Globals retained as deprecated defaults for one release. For finelog's typical single-dominant-namespace workload (the `log` namespace), per-namespace caps with the same numeric defaults are a strict relaxation, not a tightening.
+
+**Locking pattern across phases:**
+
+| Phase | `_insertion_lock` | `_query_visibility_lock` |
+|---|---|---|
+| Plan (input snapshot) | held | — |
+| COPY (read inputs, write staging file) | — | — |
+| Commit (rename + replace_segments + unlink + deque update) | held | **write** |
+| Eviction (per-namespace, tail of compaction_step) | held briefly per victim | **write** |
+
+Append/flush stay on the same per-namespace bg thread, serialized with compaction and eviction by virtue of being on one thread. New tmp segments arriving during a compaction are simply not in that compaction's input set; they're picked up by the next planning tick.
+
+### 7. Failure handling
+
+- **Mid-write crash:** COPY output is staged as `*.parquet.tmp`. Boot reaper deletes any `.parquet.tmp` not referenced in the catalog.
+- **Mid-rename crash:** single-output renames are atomic at the OS level; either the new file is in place + catalog rewritten, or it isn't. Catalog reconciliation at boot drops rows for missing files.
+- **GCS upload failure:** owned by `_OffloadWorker`, out of scope.
+
+### 8. Eviction interaction
+
+**Per-namespace, FIFO-by-`min_seq`.** Each namespace's bg thread evicts only its own segments, in oldest-first order, until that namespace is back under its caps. No global pass, no cross-namespace coordination.
+
+The eviction query (per namespace):
+
+```sql
+SELECT path, byte_size FROM segments
+WHERE namespace = ?
+  AND level >= 1
+  AND offloaded_at_ms IS NOT NULL
+ORDER BY min_seq ASC
+LIMIT 1
+```
+
+Eligibility:
+- **`level >= 1`**: L0 is local-only and transient (awaiting promotion). Evicting it would lose data.
+- **`offloaded_at_ms IS NOT NULL`**: migration `0004_segment_offloaded_at.py` adds the column; offload worker stamps it on upload success. Closes the current bug where a freshly-renamed L1 can be evicted in the window between rename and remote upload completion.
+
+Because levels are time-ordered (L_max contains the oldest seqs), FIFO-by-seq naturally evicts oldest-largest first. No "prefer larger levels" heuristic.
+
+**Caps move per-namespace.** New `CompactionConfig` fields (or a sibling `LocalStorageConfig`):
+
+```python
+max_segments_per_namespace: int = 1000
+max_bytes_per_namespace: int = 100 * 1024**3
+```
+
+For a single-dominant-namespace deployment (today's marin `log` namespace) these defaults are a strict relaxation of the global caps, not a tightening. Multi-namespace deployments may want to tune.
+
+Pinned tests:
+- FIFO across mixed levels: stack L1 + L2, force eviction, assert popped `min_seq` is strictly ascending and never picks from the middle.
+- L0 is never popped.
+- Segments with `offloaded_at_ms IS NULL` are skipped until the offload completes.
+- A long-running compaction in namespace A does *not* race eviction in namespace B (smoke-test by running the two on separate threads simultaneously and confirming neither breaks; expected behavior is they don't share files anyway).
+
+### 9. Catalog interactions (end-to-end)
+
+Every catalog touch the compactor performs:
+
+1. **Plan input read.** `Compactor.plan` walks the in-memory `_local_segments` deque (which is kept in lockstep with the catalog under `_insertion_lock`). No SQL — the deque is authoritative at runtime.
+
+2. **No catalog mutation during the COPY.** The merge SQL only reads parquet input files and writes the staging output; it never opens the catalog DB. The COPY runs lock-free. Concurrent eviction is impossible because eviction runs on the same per-namespace bg thread as the compaction that staged the COPY (§6).
+
+3. **Atomic swap on commit.**
+   ```python
+   with self._query_visibility_lock.write():
+       os.rename(staging_path, final_path)
+       with self._insertion_lock:
+           # Single transaction: DELETE inputs + INSERT output.
+           self._catalog.replace_segments(
+               namespace=self.name,
+               removed_paths=[seg.path for seg in job.inputs],
+               added=[output_row],
+           )
+           # Mirror the swap into the in-memory deque.
+           self._local_segments = _splice(self._local_segments, job.inputs, output_seg)
+       for seg in job.inputs:
+           Path(seg.path).unlink(missing_ok=True)
+       self._submit_offload(self.name, output_seg.path)
+   ```
+   `replace_segments` is already a transactional many-to-one swap (`catalog.py:210`) — no API change needed.
+
+4. **Output row construction.** The output `SegmentRow` aggregates from inputs:
+   - `level` = `inputs[0].level + 1` (all inputs share a level, enforced by `plan`).
+   - `min_seq` = `min(input.min_seq for input in inputs)`.
+   - `max_seq` = `max(input.max_seq for input in inputs)`.
+   - `row_count` = `sum(...)`, `byte_size` = `staging_path.stat().st_size` (post-merge actual).
+   - `min_key_value` / `max_key_value` = `_aggregate_key_bounds(inputs)` (already exists; landed in commit `ebe3f978b`).
+   - `offloaded_at_ms` = `NULL` until the offload worker stamps it.
+
+5. **Single-segment level bump.** If `len(inputs) == 1` and the lone input already meets `level_targets[n]`, the Compactor skips the COPY entirely. The namespace does:
+   ```python
+   new_path = _seg_filename(level=old_level + 1, min_seq=input.min_seq)
+   os.rename(input.path, new_path)
+   self._catalog.upsert_segment(replace(input_row, path=new_path, level=old_level + 1))
+   ```
+   No data rewrite, just a path + level bump. Same lock discipline.
+
+6. **Boot reconciliation.** `reconcile_segments` (already exists) reads `seg_L<n>_*.parquet` from disk, re-derives `level` from the filename and `min_key_value` / `max_key_value` from the parquet footer, and rewrites the catalog rows to match disk. No special handling for in-progress compactions: any `*.parquet.tmp` orphan is unlinked.
+
+7. **Eviction interaction.** Per-namespace eviction reads the catalog filtered to its own namespace, deletes rows + unlinks files, and pops the deque under `_insertion_lock`. All on the same per-namespace bg thread as compaction, so they're sequenced — no race possible.
+
+The story for an external observer: at every commit boundary the catalog mirrors the on-disk parquet set exactly. Crash anywhere mid-compaction leaves at most one staging `.parquet.tmp` orphan; the next boot's reconciliation converges.
+
+### 10. Migration plan
+
+1. **Phase A — refactor only.** Extract `Compactor` with `level_targets = (∞,)` (single terminal level, no promotions beyond the equivalent of today's flat compaction) and `min_inputs_to_compact` matching the current threshold. Land migrations 0003 + the filename rewrite. Feature-equivalent to today; soak ~1 week.
+2. **Phase B — tiered policy.** Flip the default to `level_targets = (64 MiB, 256 MiB)`. Land migration 0004 (`offloaded_at_ms`) in the same release so eviction stays safe.
+
+Phase A is purely a refactor — small diff, easy to roll back. Phase B is the behavior change against a known-good baseline.
+
+## Test plan
+
+- Parametrize existing `test_persistence.py::test_compaction_*` over `CompactionConfig` fixtures (flat + tiered).
+- New `test_compactor.py`: pure unit tests over `plan`. Cover the size-threshold case, the `max_l0_age_sec` case, and the single-segment-already-large case (level bump only).
+- **Eviction FIFO test:** stack a namespace with mixed L1+L2 segments; force eviction repeatedly; assert popped `min_seq` is strictly ascending and never picks from the middle. Also assert L0 is never popped, and segments with `offloaded_at_ms IS NULL` are skipped until the offload completes.
+- Crash injection: kill between rename and `replace_segments` commit; verify boot recovery converges.
+- Eviction: L1 with `offloaded_at_ms IS NULL` is skipped; L2 with a value evicts first.
+- Observability: bg-loop heartbeat logs per-level counts + bytes.
+
+## Risks & open questions
+
+- **Q1.** `level_targets` lives on the store-wide `CompactionConfig` (one set of values for all namespaces). Revisit if a namespace lands with a wildly different volume profile.
+- **Q2.** When the L_max tier fills (steady state ≈ `max_local_bytes / level_targets[-1]` segments), eviction starts deleting them. We should add a `rows_local / rows_offloaded_only` gauge so on-call can see how much of the namespace is "remote only" without paging GCS.
+- **Q3.** Phase A's `(∞,)` single-level mode reuses the new code path with the old policy. Verify the existing tests still pass under that config before we even ship Phase A — that's the rollback gate.
+
+## References
+
+- Current compaction: `lib/finelog/src/finelog/store/log_namespace.py:826` (`_compaction_step`)
+- Catalog: `lib/finelog/src/finelog/store/catalog.py`
+- Migrations: `lib/finelog/src/finelog/store/migrations/0001_init.py`, `0002_segment_key_value_bounds.py`
+- Eviction: `lib/finelog/src/finelog/store/duckdb_store.py` (`_evict_globally`)
+- Lock-during-COPY fix (precondition): commit `0acec62c0`
+- Prior art: ClickHouse MergeTree (https://clickhouse.com/docs/en/development/architecture#merge-tree),
+  Iceberg compaction (https://iceberg.apache.org/docs/latest/maintenance/#compact-data-files),
+  RocksDB tiered compaction (https://github.com/facebook/rocksdb/wiki/Universal-Compaction).

--- a/lib/finelog/src/finelog/deploy/bootstrap.py
+++ b/lib/finelog/src/finelog/deploy/bootstrap.py
@@ -58,7 +58,7 @@ if ! command -v docker &> /dev/null; then
 fi
 sudo systemctl start docker || true
 
-# Cache directory on the boot disk. Finelog offloads parquet segments to GCS
+# Cache directory on the boot disk. Finelog copies parquet segments to GCS
 # via FINELOG_REMOTE_DIR, so the boot disk only needs working space.
 # Owned by UID/GID 1000 to match the in-container `finelog` user (the
 # Dockerfile's chown is shadowed by this bind mount).

--- a/lib/finelog/src/finelog/server/main.py
+++ b/lib/finelog/src/finelog/server/main.py
@@ -159,7 +159,7 @@ def run_log_server(
     type=str,
     default="",
     envvar="FINELOG_REMOTE_DIR",
-    help="Remote log storage URI (e.g. gs://bucket/path); empty disables offload.",
+    help="Remote log storage URI (e.g. gs://bucket/path); empty disables remote copy.",
 )
 @click.option(
     "--log-level",

--- a/lib/finelog/src/finelog/store/catalog.py
+++ b/lib/finelog/src/finelog/store/catalog.py
@@ -29,11 +29,10 @@ shared ``_insertion_lock`` around mutating calls, which serializes access.
 
 from __future__ import annotations
 
-import enum
 import logging
 import time
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 import duckdb
@@ -46,28 +45,33 @@ logger = logging.getLogger(__name__)
 CATALOG_DB_FILENAME = "_finelog_registry.duckdb"
 
 
-class SegmentState(enum.StrEnum):
-    """Lifecycle state for a parquet segment in the catalog.
-
-    Persisted as ``state`` (TEXT) on each ``segments`` row.
-    """
-
-    TMP = "tmp"  # freshly flushed, awaiting compaction
-    FINALIZED = "finalized"  # produced by compaction
-
-
 @dataclass(frozen=True)
 class SegmentRow:
-    """One persisted row in the segments catalog table."""
+    """One persisted row in the segments catalog table.
+
+    ``level`` is the segment's tier in the leveled compaction scheme (0 =
+    freshly flushed; promoted to ``level + 1`` when the planner picks it
+    up). ``min_key_value`` / ``max_key_value`` carry the parquet footer's
+    column statistics for the namespace's declared ``Schema.key_column``.
+    They are ``None`` for namespaces whose schema has no ``key_column``,
+    or for empty segments where no statistics exist.
+    ``copied_at_ms`` is the wall-clock millisecond when the copy worker
+    reported a successful upload; ``None`` while the upload is still
+    pending. Eviction is gated on this so a fresh L1 cannot be deleted
+    before its remote copy is durable.
+    """
 
     namespace: str
     path: str
-    state: SegmentState
+    level: int
     min_seq: int
     max_seq: int
     row_count: int
     byte_size: int
     created_at_ms: int
+    min_key_value: str | None = None
+    max_key_value: str | None = None
+    copied_at_ms: int | None = None
 
 
 @dataclass(frozen=True)
@@ -109,8 +113,9 @@ class Catalog:
             self._conn = duckdb.connect(str(self._path))
         # Schema is owned by ``finelog.store.migrations``; every additive
         # change (new column, new index, derived backfill) lands as a new
-        # numbered file in that package.
-        apply_migrations(self._conn)
+        # numbered file in that package. Migrations that need to rename
+        # on-disk parquet files receive ``data_dir`` via the runner.
+        apply_migrations(self._conn, data_dir=data_dir)
 
     def close(self) -> None:
         self._conn.close()
@@ -156,54 +161,65 @@ class Catalog:
 
     # ----- segments table -----------------------------------------------
 
+    _SEGMENT_COLUMNS = (
+        "namespace, path, level, min_seq, max_seq, row_count, byte_size, "
+        "created_at_ms, min_key_value, max_key_value, copied_at_ms"
+    )
+
     def list_segments(self, namespace: str) -> list[SegmentRow]:
         rows = self._conn.execute(
-            """
-            SELECT namespace, path, state, min_seq, max_seq, row_count, byte_size, created_at_ms
-            FROM segments
-            WHERE namespace = ?
-            ORDER BY min_seq
-            """,
+            f"SELECT {self._SEGMENT_COLUMNS} FROM segments WHERE namespace = ? ORDER BY min_seq",
             [namespace],
         ).fetchall()
-        return [
-            SegmentRow(
-                namespace=ns,
-                path=path,
-                state=SegmentState(state),
-                min_seq=min_seq,
-                max_seq=max_seq,
-                row_count=row_count,
-                byte_size=byte_size,
-                created_at_ms=created_at_ms,
-            )
-            for ns, path, state, min_seq, max_seq, row_count, byte_size, created_at_ms in rows
-        ]
+        return [self._row_from_tuple(r) for r in rows]
+
+    @staticmethod
+    def _row_from_tuple(r: tuple) -> SegmentRow:
+        return SegmentRow(
+            namespace=r[0],
+            path=r[1],
+            level=r[2],
+            min_seq=r[3],
+            max_seq=r[4],
+            row_count=r[5],
+            byte_size=r[6],
+            created_at_ms=r[7],
+            min_key_value=r[8],
+            max_key_value=r[9],
+            copied_at_ms=r[10],
+        )
 
     def upsert_segment(self, segment: SegmentRow) -> None:
         """Insert or replace one segment row (used by flush + reconciliation)."""
         self._conn.execute(
             """
             INSERT INTO segments
-                (namespace, path, state, min_seq, max_seq, row_count, byte_size, created_at_ms)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                (namespace, path, level, min_seq, max_seq, row_count, byte_size, created_at_ms,
+                 min_key_value, max_key_value, copied_at_ms)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT (namespace, path) DO UPDATE SET
-                state = excluded.state,
+                level = excluded.level,
                 min_seq = excluded.min_seq,
                 max_seq = excluded.max_seq,
                 row_count = excluded.row_count,
                 byte_size = excluded.byte_size,
-                created_at_ms = excluded.created_at_ms
+                created_at_ms = excluded.created_at_ms,
+                min_key_value = excluded.min_key_value,
+                max_key_value = excluded.max_key_value,
+                copied_at_ms = excluded.copied_at_ms
             """,
             [
                 segment.namespace,
                 segment.path,
-                segment.state.value,
+                segment.level,
                 segment.min_seq,
                 segment.max_seq,
                 segment.row_count,
                 segment.byte_size,
                 segment.created_at_ms,
+                segment.min_key_value,
+                segment.max_key_value,
+                segment.copied_at_ms,
             ],
         )
 
@@ -215,9 +231,9 @@ class Catalog:
     ) -> None:
         """Atomically swap ``removed_paths`` for ``added`` rows in one txn.
 
-        Used by compaction, where N tmp segments collapse into one finalized
-        segment. The whole swap must be visible-or-not visible to callers
-        of :meth:`list_segments` — never half.
+        Used by compaction, where N inputs at level n collapse into one
+        level-(n+1) output. The whole swap must be visible-or-not visible
+        to callers of :meth:`list_segments` — never half.
         """
         with transactional(self._conn):
             for path in removed_paths:
@@ -237,11 +253,25 @@ class Catalog:
 
         Parquet files on disk are authoritative across crashes; on every
         ``DiskLogNamespace`` boot we discover the on-disk segment set and
-        push it through this method so the catalog matches reality.
+        push it through this method so the catalog matches reality. The
+        prior rows' ``copied_at_ms`` stamps are carried forward for
+        unchanged paths so a successfully-uploaded segment doesn't lose
+        its eviction-eligible flag across a restart.
         """
         with transactional(self._conn):
+            prior_copied = {
+                row[0]: row[1]
+                for row in self._conn.execute(
+                    "SELECT path, copied_at_ms FROM segments WHERE namespace = ?",
+                    [namespace],
+                ).fetchall()
+            }
             self._conn.execute("DELETE FROM segments WHERE namespace = ?", [namespace])
             for seg in segments:
+                if seg.copied_at_ms is None:
+                    stamp = prior_copied.get(seg.path)
+                    if stamp is not None:
+                        seg = replace(seg, copied_at_ms=stamp)
                 self.upsert_segment(seg)
 
     def aggregate_namespace_stats(self, namespace: str) -> NamespaceStats:
@@ -268,3 +298,57 @@ class Catalog:
             max_seq=int(row[3]),
             segment_count=int(row[4]),
         )
+
+    def mark_copied(self, namespace: str, path: str, copied_at_ms: int) -> None:
+        """Record successful remote upload of one segment."""
+        self._conn.execute(
+            "UPDATE segments SET copied_at_ms = ? WHERE namespace = ? AND path = ?",
+            [copied_at_ms, namespace, path],
+        )
+
+    def list_pending_copies(self) -> list[SegmentRow]:
+        """All L>=1 rows whose remote upload has not yet completed.
+
+        Ordered by ``min_seq`` so we drain oldest-first across the whole
+        store. This is the copy worker's only view into the catalog.
+        """
+        rows = self._conn.execute(
+            f"""
+            SELECT {self._SEGMENT_COLUMNS}
+            FROM segments
+            WHERE level >= 1
+              AND copied_at_ms IS NULL
+            ORDER BY namespace, min_seq
+            """
+        ).fetchall()
+        return [self._row_from_tuple(r) for r in rows]
+
+    def select_eviction_candidate(self, namespace: str) -> SegmentRow | None:
+        """Pick the oldest evictable segment in ``namespace``.
+
+        Eligibility:
+
+        * ``level >= 1`` — L0 is local-only and transient, so it's never
+          evicted.
+        * ``copied_at_ms IS NOT NULL`` — a freshly compacted segment
+          becomes evictable only after the upload worker confirms the
+          remote copy is durable.
+
+        Returns the ``SegmentRow`` with the smallest ``min_seq``, or
+        ``None`` when no eligible segment exists.
+        """
+        row = self._conn.execute(
+            f"""
+            SELECT {self._SEGMENT_COLUMNS}
+            FROM segments
+            WHERE namespace = ?
+              AND level >= 1
+              AND copied_at_ms IS NOT NULL
+            ORDER BY min_seq ASC
+            LIMIT 1
+            """,
+            [namespace],
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_from_tuple(row)

--- a/lib/finelog/src/finelog/store/compactor.py
+++ b/lib/finelog/src/finelog/store/compactor.py
@@ -1,0 +1,217 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Leveled compaction planner for finelog parquet segments.
+
+The :class:`Compactor` is stateless: the per-namespace bg thread owns
+locks, catalog mutation, and the actual COPY execution; this module
+decides *which* segments to merge and *into what file*. Splitting the
+policy out lets us unit-test ``plan`` over fixtures without a running
+store.
+
+Levels are time-ordered: every fresh flush emits an L0 segment. The
+planner promotes L_n → L_{n+1} when the longest contiguous run of L_n
+segments hits the byte target for that tier (or, for L0 only, when the
+oldest run has been sitting longer than ``max_l0_age_sec`` — the lever
+that keeps low-volume namespaces from leaking small files).
+
+The terminal level is ``len(level_targets)``: segments at that tier
+never re-compact. They are also the only tier eligible for eviction
+(see :meth:`finelog.store.catalog.Catalog.select_eviction_candidate`),
+so the layout converges to a small fanout of large terminal-level files
+plus a short tail of in-flight intermediates.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+from finelog.store.catalog import SegmentRow
+from finelog.store.schema import IMPLICIT_SEQ_COLUMN, Schema, duckdb_type_for
+from finelog.store.sql_escape import quote_ident, quote_literal
+
+_MiB = 1024 * 1024
+
+# Row group size for compacted parquet output. Count-based; matches the
+# size used by the flush path so reads see a uniform layout.
+_ROW_GROUP_SIZE = 16_384
+
+
+def compaction_sort_keys(schema: Schema) -> tuple[str, ...]:
+    """Sort keys used by both flush-time sort and compaction's ORDER BY.
+
+    ``key_column`` first (so range scans on it prune row groups efficiently),
+    then the implicit ``seq``.
+    """
+    if schema.key_column:
+        return (schema.key_column, IMPLICIT_SEQ_COLUMN)
+    return (IMPLICIT_SEQ_COLUMN,)
+
+
+@dataclass(frozen=True)
+class CompactionConfig:
+    """Tuning knobs for the leveled compaction policy.
+
+    ``level_targets[n]`` is the summed byte size at which the longest
+    contiguous run of L_n segments is promoted to L_{n+1}. The terminal
+    level is ``len(level_targets)``; segments at that tier are never
+    re-compacted (and become eviction candidates).
+    """
+
+    level_targets: tuple[int, ...] = (64 * _MiB, 256 * _MiB)
+    check_interval_sec: float = 30.0
+    max_l0_age_sec: float = 300.0
+    max_segments_per_namespace: int = 1000
+    max_bytes_per_namespace: int = 100 * 1024**3
+
+
+@dataclass(frozen=True)
+class CompactionJob:
+    """One pending merge: ``len(inputs)`` segments → one ``output_level`` segment."""
+
+    inputs: tuple[SegmentRow, ...]
+    output_level: int
+    output_min_seq: int
+    output_max_seq: int
+
+
+class Compactor:
+    """Plans level promotions and emits the merge SQL.
+
+    Construct one per namespace; instances are cheap and stateless. The
+    schema is supplied at ``merge_sql`` call time so post-evolution writes
+    use the current column list without any side-channel mutation.
+    """
+
+    def __init__(self, config: CompactionConfig) -> None:
+        self.config = config
+
+    @property
+    def terminal_level(self) -> int:
+        """Segments at this level are never re-compacted."""
+        return len(self.config.level_targets)
+
+    def plan(self, segments: Sequence[SegmentRow], now_ms: int) -> CompactionJob | None:
+        """Return the next merge job, or ``None`` if nothing is due.
+
+        Walks tiers from L0 upward and returns the first promotable run.
+        Doing the lowest tier first keeps ``len(_local_segments)`` small
+        in steady state, which dominates per-read fanout cost.
+        """
+        for n, target in enumerate(self.config.level_targets):
+            at_level = sorted([s for s in segments if s.level == n], key=lambda s: s.min_seq)
+            if not at_level:
+                continue
+            for run in _contiguous_runs(at_level):
+                if _run_bytes(run) >= target:
+                    return _build_job(run, output_level=n + 1)
+                if n == 0 and self.config.max_l0_age_sec > 0:
+                    oldest_age_sec = (now_ms - run[0].created_at_ms) / 1000.0
+                    if oldest_age_sec >= self.config.max_l0_age_sec:
+                        return _build_job(run, output_level=n + 1)
+        return None
+
+    def merge_sql(self, job: CompactionJob, *, schema: Schema, staging_path: Path) -> str:
+        """Build the DuckDB ``COPY`` that merges ``job.inputs`` to ``staging_path``.
+
+        Uses ``read_parquet([...], union_by_name=true)`` so columns missing
+        from any individual input come back as NULL, then projects through
+        ``schema`` with explicit ``NULL::TYPE AS name`` for columns added
+        since some inputs were written.
+        """
+        input_paths = [Path(seg.path) for seg in job.inputs]
+        present = _present_input_columns(input_paths)
+        select_exprs = [
+            quote_ident(col.name) if col.name in present else f"NULL::{duckdb_type_for(col)} AS {quote_ident(col.name)}"
+            for col in schema.columns
+        ]
+        order_keys = compaction_sort_keys(schema)
+        order_clause = "ORDER BY " + ", ".join(quote_ident(k) for k in order_keys)
+        paths_sql = ", ".join(quote_literal(str(p)) for p in input_paths)
+        select_clause = ", ".join(select_exprs)
+        return (
+            f"COPY (SELECT {select_clause} "
+            f"FROM read_parquet([{paths_sql}], union_by_name=true) "
+            f"{order_clause}) "
+            f"TO {quote_literal(str(staging_path))} "
+            f"(FORMAT 'parquet', ROW_GROUP_SIZE {_ROW_GROUP_SIZE}, "
+            f"COMPRESSION 'zstd', COMPRESSION_LEVEL 1, WRITE_BLOOM_FILTER true)"
+        )
+
+
+def _contiguous_runs(segments: Sequence[SegmentRow]) -> list[list[SegmentRow]]:
+    """Group ``segments`` (sorted by ``min_seq``) into adjacency runs.
+
+    Adjacency means ``prev.max_seq + 1 == next.min_seq``. With FIFO-by-seq
+    eviction, the live set is always a contiguous suffix of the global seq
+    range, so this should produce a single run; the multi-run branch is
+    defensive against an externally introduced gap.
+    """
+    if not segments:
+        return []
+    runs: list[list[SegmentRow]] = [[segments[0]]]
+    for seg in segments[1:]:
+        if runs[-1][-1].max_seq + 1 == seg.min_seq:
+            runs[-1].append(seg)
+        else:
+            runs.append([seg])
+    return runs
+
+
+def _run_bytes(run: Sequence[SegmentRow]) -> int:
+    return sum(s.byte_size for s in run)
+
+
+def _build_job(run: Sequence[SegmentRow], *, output_level: int) -> CompactionJob:
+    return CompactionJob(
+        inputs=tuple(run),
+        output_level=output_level,
+        output_min_seq=min(s.min_seq for s in run),
+        output_max_seq=max(s.max_seq for s in run),
+    )
+
+
+def aggregate_key_bounds(
+    bounds: Iterable[tuple[str | None, str | None]],
+) -> tuple[str | None, str | None]:
+    """Fold per-input ``(min, max)`` key tuples into a single ``(min, max)``.
+
+    Inputs whose values are ``None`` (empty segment / no stats) are skipped.
+    Returns ``(None, None)`` if every input was skipped.
+    """
+    overall_min: str | None = None
+    overall_max: str | None = None
+    for lo, hi in bounds:
+        if lo is not None and (overall_min is None or lo < overall_min):
+            overall_min = lo
+        if hi is not None and (overall_max is None or hi > overall_max):
+            overall_max = hi
+    return overall_min, overall_max
+
+
+def _present_input_columns(input_paths: list[Path]) -> set[str]:
+    present: set[str] = set()
+    for p in input_paths:
+        present.update(pq.read_schema(p).names)
+    return present
+
+
+def seg_filename(level: int, min_seq: int) -> str:
+    """Filename for a segment at ``level`` whose smallest seq is ``min_seq``."""
+    return f"seg_L{level}_{min_seq:019d}.parquet"
+
+
+_SEG_FILENAME_RE = re.compile(r"^seg_L(?P<level>\d+)_(?P<seq>\d+)\.parquet$")
+
+
+def parse_seg_filename(name: str) -> tuple[int, int] | None:
+    """Recover ``(level, min_seq)`` from a segment filename, or ``None``."""
+    match = _SEG_FILENAME_RE.match(name)
+    if match is None:
+        return None
+    return int(match.group("level")), int(match.group("seq"))

--- a/lib/finelog/src/finelog/store/compactor.py
+++ b/lib/finelog/src/finelog/store/compactor.py
@@ -177,19 +177,26 @@ def _build_job(run: Sequence[SegmentRow], *, output_level: int) -> CompactionJob
 
 
 def aggregate_key_bounds(
-    bounds: Iterable[tuple[str | None, str | None]],
-) -> tuple[str | None, str | None]:
+    bounds: Iterable[tuple[object | None, object | None]],
+) -> tuple[object | None, object | None]:
     """Fold per-input ``(min, max)`` key tuples into a single ``(min, max)``.
+
+    Operates on the typed Python value (int, str, float, bool, bytes,
+    datetime — whatever ``pyarrow`` decoded the key column as) so numeric
+    keys keep native ordering. Stringification happens later, at the
+    catalog write boundary (``DiskLogNamespace._segment_to_row``); callers
+    must not stringify before passing through here or ``"10" < "2"``
+    flips the bound for an int64 key column.
 
     Inputs whose values are ``None`` (empty segment / no stats) are skipped.
     Returns ``(None, None)`` if every input was skipped.
     """
-    overall_min: str | None = None
-    overall_max: str | None = None
+    overall_min: object | None = None
+    overall_max: object | None = None
     for lo, hi in bounds:
-        if lo is not None and (overall_min is None or lo < overall_min):
+        if lo is not None and (overall_min is None or lo < overall_min):  # type: ignore[operator]
             overall_min = lo
-        if hi is not None and (overall_max is None or hi > overall_max):
+        if hi is not None and (overall_max is None or hi > overall_max):  # type: ignore[operator]
             overall_max = hi
     return overall_min, overall_max
 

--- a/lib/finelog/src/finelog/store/duckdb_store.py
+++ b/lib/finelog/src/finelog/store/duckdb_store.py
@@ -413,6 +413,24 @@ class DuckDBLogStore:
                 raise NamespaceNotFoundError(f"namespace {name!r} is not registered")
             return ns.schema
 
+    def memory_summary(self) -> dict[str, int]:
+        """Aggregate ram_bytes / chunk_count across namespaces, for diagnostics.
+
+        Used by the periodic pool-diagnostics logger in the standalone server.
+        ``MemoryLogNamespace`` reports zeros (no in-RAM segmented buffer).
+        """
+        total_ram_bytes = 0
+        total_chunks = 0
+        with self._insertion_lock:
+            for ns in self._namespaces.values():
+                total_ram_bytes += ns.ram_bytes()
+                total_chunks += ns.chunk_count()
+            return {
+                "namespaces": len(self._namespaces),
+                "ram_bytes": total_ram_bytes,
+                "chunks": total_chunks,
+            }
+
     def write_rows(self, name: str, arrow_ipc_bytes: bytes) -> int:
         """Validate ``arrow_ipc_bytes`` and append the rows to ``name``.
 

--- a/lib/finelog/src/finelog/store/duckdb_store.py
+++ b/lib/finelog/src/finelog/store/duckdb_store.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import logging
 import re
+import shutil
+import threading
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -22,17 +24,18 @@ from pathlib import Path
 from threading import Lock
 
 import duckdb
+import fsspec.core
 import pyarrow as pa
 import pyarrow.ipc as paipc
 
 from finelog.store.catalog import Catalog, NamespaceStats
+from finelog.store.compactor import CompactionConfig
 from finelog.store.layout_migration import LOG_NAMESPACE_DIR
 from finelog.store.log_namespace import (
     LOG_REGISTERED_SCHEMA,
     DiskLogNamespace,
     LogNamespaceProtocol,
     MemoryLogNamespace,
-    _is_tmp_path,
 )
 from finelog.store.rwlock import RWLock
 from finelog.store.schema import (
@@ -57,31 +60,23 @@ LOG_NAMESPACE_NAME = "log"
 
 SEGMENT_TARGET_BYTES = 100 * 1024 * 1024
 DEFAULT_FLUSH_INTERVAL_SEC = 60.0
-DEFAULT_COMPACTION_INTERVAL_SEC = 600.0
 
-# Trigger compaction when this many tmp segments accumulate even before the
-# time-based interval fires. Bounds per-read fanout under high ingest.
-DEFAULT_MAX_TMP_SEGMENTS_BEFORE_COMPACT = 10
-
-# The read path has no remote fallback yet: once a parquet is GC'd locally,
-# its rows are unreachable via FetchLogs even though they're durable on GCS.
-# Sized for ~2 weeks of the production marin cluster's ingest (~6-7 GB/day).
-DEFAULT_MAX_LOCAL_SEGMENTS = 1000
-DEFAULT_MAX_LOCAL_BYTES = 100 * 1024**3
-
-# 4GB was the previous default but in practice finelog's read pattern
-# rarely needs more than tens of MB; the high cap mostly let mimalloc/DuckDB
-# retain pages indefinitely. 512MB on the read pool is plenty against 5
-# segments x ~50MB + zstd decompression scratch. Compaction tier-merges can
-# spill larger sort buffers, so it gets its own (still bounded) limit.
-_DEFAULT_DUCKDB_MEMORY_LIMIT = "512MB"
-_DEFAULT_DUCKDB_COMPACTION_MEMORY_LIMIT = "1GB"
+# Tight DuckDB limits (e.g. 256MB) caused spill-to-disk loops under concurrent
+# tail reads over large row groups, wedging the controller. 4GB is generous
+# against 5 segments x 500MB + zstd decompression scratch.
+_DEFAULT_DUCKDB_MEMORY_LIMIT = "4GB"
 _DEFAULT_DUCKDB_THREADS = "4"
 
 # Embedded mode (iris controller's bundled log-server) keeps VMS small so the
 # parent doesn't trip Linux's overcommit heuristic when forking subprocesses.
 EMBEDDED_DUCKDB_MEMORY_LIMIT = "128MB"
 EMBEDDED_DUCKDB_THREADS = "2"
+
+# Streaming chunk size for src->dst copy. 4 MiB keeps RAM usage flat regardless
+# of segment size while still amortizing per-write overhead on GCS.
+_COPY_CHUNK_BYTES = 4 * 1024 * 1024
+# How long ``close()`` waits for the copy worker to drain before forcing exit.
+_COPY_DRAIN_TIMEOUT_SEC = 10.0
 
 
 # Namespace names: lowercase ASCII alphanumerics + ._-, starting with a
@@ -101,32 +96,23 @@ def _next_cursor_id() -> int:
         return _cursor_counter
 
 
-class _ConnectionPool:
-    """Two DuckDB connections: one shared for reads, one for compaction.
+class ConnectionPool:
+    """Single DuckDB read connection shared across all read paths.
 
-    Reads share a single connection with ``enable_object_cache`` so parquet
-    footer / row-group stats are cached across queries. Compaction runs on
-    a separate connection so its sort cost cannot starve readers (a shared
-    connection wedged the controller under concurrent tail reads).
+    ``enable_object_cache`` keeps parquet footer / row-group stats hot
+    across queries. Compaction does not share this connection — each
+    namespace owns its own DuckDB conn for compaction COPYs so concurrent
+    namespaces can't collide on session state.
     """
 
     def __init__(
         self,
         memory_limit: str = _DEFAULT_DUCKDB_MEMORY_LIMIT,
-        compaction_memory_limit: str = _DEFAULT_DUCKDB_COMPACTION_MEMORY_LIMIT,
         threads: str = _DEFAULT_DUCKDB_THREADS,
     ):
-        self._conn = duckdb.connect(config={"memory_limit": memory_limit, "threads": threads})
+        config = {"memory_limit": memory_limit, "threads": threads}
+        self._conn = duckdb.connect(config=config)
         self._conn.execute("SET enable_object_cache=true")
-        self._compaction_conn = duckdb.connect(
-            config={"memory_limit": compaction_memory_limit, "threads": threads},
-        )
-        # Serializes DDL on the shared read connection. ``query()`` issues
-        # ``CREATE OR REPLACE VIEW {namespace}`` for every registered
-        # namespace, and concurrent calls would collide on the same view
-        # names. Held end-to-end through the fetch so the views stay valid
-        # while the result materializes.
-        self._read_query_lock = Lock()
 
     @contextmanager
     def checkout(self, buffer_tables: list[pa.Table]) -> Iterator[tuple[duckdb.DuckDBPyConnection, list[str]]]:
@@ -145,13 +131,103 @@ class _ConnectionPool:
                 cursor.unregister(name)
             cursor.close()
 
-    @property
-    def compaction_conn(self) -> duckdb.DuckDBPyConnection:
-        return self._compaction_conn
-
     def close(self) -> None:
         self._conn.close()
-        self._compaction_conn.close()
+
+
+class CopyWorker:
+    """Polling background uploader for L>=1 catalog segments.
+
+    One worker per :class:`DuckDBLogStore`. Walks the catalog every
+    ``_POLL_INTERVAL_SEC`` (or sooner when woken) for ``level >= 1 AND
+    copied_at_ms IS NULL`` rows, streams each parquet to remote storage,
+    and stamps the row on success. Per-segment RAM footprint is bounded
+    by ``_COPY_CHUNK_BYTES``.
+
+    Decoupling from compaction means the copy policy is "anything
+    promoted to L1+ that doesn't yet have a remote copy" — the planner
+    doesn't know or care about uploads.
+    """
+
+    _POLL_INTERVAL_SEC = 5.0
+
+    def __init__(self, store: DuckDBLogStore, remote_log_dir: str) -> None:
+        self._store = store
+        self._remote_log_dir = remote_log_dir
+        self._stop = threading.Event()
+        self._wake = threading.Event()
+        self._thread = threading.Thread(target=self._run, name="finelog_copy", daemon=True)
+        self._thread.start()
+
+    def wake(self) -> None:
+        """Hint that new L>=1 segments may exist; speeds up the next pass."""
+        self._wake.set()
+
+    def wait_drained(self, timeout: float) -> bool:
+        """Block until the catalog has no L>=1 rows missing ``copied_at_ms``.
+
+        Returns True on drain, False on timeout.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            self.wake()
+            with self._store._insertion_lock:
+                if not self._store._catalog.list_pending_copies():
+                    return True
+            time.sleep(0.05)
+        with self._store._insertion_lock:
+            return not self._store._catalog.list_pending_copies()
+
+    def close(self, timeout: float = _COPY_DRAIN_TIMEOUT_SEC) -> None:
+        self.wait_drained(timeout)
+        self._stop.set()
+        self._wake.set()
+        self._thread.join(timeout=timeout)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                with self._store._insertion_lock:
+                    pending = self._store._catalog.list_pending_copies()
+            except Exception:
+                logger.warning("copy poll failed", exc_info=True)
+                pending = []
+            for row in pending:
+                if self._stop.is_set():
+                    break
+                completed_ms = self._upload(row.namespace, Path(row.path))
+                if completed_ms is not None:
+                    self._store._mark_copied(row.namespace, row.path, completed_ms)
+            self._wake.wait(timeout=self._POLL_INTERVAL_SEC)
+            self._wake.clear()
+
+    def _upload(self, namespace: str, local_path: Path) -> int | None:
+        """Stream ``local_path`` to the remote path. Returns completion ms
+        on success, ``None`` on failure (the catalog row stays unstamped
+        and the next poll retries)."""
+        remote_path = f"{self._remote_log_dir.rstrip('/')}/{namespace}/{local_path.name}"
+        upload_start = time.monotonic()
+        try:
+            with (
+                fsspec.core.open(str(local_path), "rb") as f_src,
+                fsspec.core.open(remote_path, "wb") as f_dst,
+            ):
+                shutil.copyfileobj(f_src, f_dst, length=_COPY_CHUNK_BYTES)
+        except Exception:
+            logger.warning("Failed to copy %s to %s", local_path, remote_path, exc_info=True)
+            return None
+        try:
+            size = local_path.stat().st_size
+        except OSError:
+            size = -1
+        logger.info(
+            "Copied %s to %s: bytes=%d elapsed_ms=%d",
+            local_path.name,
+            remote_path,
+            size,
+            int((time.monotonic() - upload_start) * 1000),
+        )
+        return int(time.time() * 1000)
 
 
 def _validate_namespace_name(name: str, data_dir: Path | None) -> Path | None:
@@ -183,7 +259,7 @@ class DuckDBLogStore:
 
     Layout: per-namespace under ``{log_dir}/{name}/``; schema sidecar at
     ``{log_dir}/_finelog_registry.duckdb``. ``log_dir=None`` selects
-    in-memory mode (no segmentation, no GCS offload, state vanishes on close).
+    in-memory mode (no segmentation, no remote copy, state vanishes on close).
     """
 
     def __init__(
@@ -191,14 +267,10 @@ class DuckDBLogStore:
         log_dir: Path | None = None,
         *,
         remote_log_dir: str = "",
-        max_local_segments: int = DEFAULT_MAX_LOCAL_SEGMENTS,
-        max_local_bytes: int = DEFAULT_MAX_LOCAL_BYTES,
         flush_interval_sec: float = DEFAULT_FLUSH_INTERVAL_SEC,
-        compaction_interval_sec: float = DEFAULT_COMPACTION_INTERVAL_SEC,
-        max_tmp_segments_before_compact: int = DEFAULT_MAX_TMP_SEGMENTS_BEFORE_COMPACT,
+        compaction_config: CompactionConfig = CompactionConfig(),
         segment_target_bytes: int = SEGMENT_TARGET_BYTES,
         duckdb_memory_limit: str = _DEFAULT_DUCKDB_MEMORY_LIMIT,
-        duckdb_compaction_memory_limit: str = _DEFAULT_DUCKDB_COMPACTION_MEMORY_LIMIT,
         duckdb_threads: str = _DEFAULT_DUCKDB_THREADS,
     ):
         self._data_dir: Path | None = log_dir
@@ -207,32 +279,27 @@ class DuckDBLogStore:
 
         self._insertion_lock = Lock()
         self._query_visibility_lock = RWLock()
-        self._pool = _ConnectionPool(
-            memory_limit=duckdb_memory_limit,
-            compaction_memory_limit=duckdb_compaction_memory_limit,
-            threads=duckdb_threads,
-        )
+        self._pool = ConnectionPool(memory_limit=duckdb_memory_limit, threads=duckdb_threads)
         self._catalog = Catalog(self._data_dir)
 
-        # Global storage caps. Eviction picks the oldest sealed segment
-        # across all namespaces (oldest-first by ``min_seq`` with namespace
-        # registration time as the tiebreak). Per-namespace quotas are
-        # deferred until evidence of starvation forces them.
-        self._max_local_segments = max_local_segments
-        self._max_local_bytes = max_local_bytes
-        self._namespace_registered_at: dict[str, int] = {}
+        # Polling uploader: independent of compaction. Walks the catalog
+        # for L>=1 segments without ``copied_at_ms`` and uploads them.
+        # Only spun up when remote storage is configured.
+        self._copy_worker: CopyWorker | None = (
+            CopyWorker(self, remote_log_dir) if remote_log_dir and self._data_dir is not None else None
+        )
 
+        self._namespace_registered_at: dict[str, int] = {}
         self._namespaces: dict[str, LogNamespaceProtocol] = {}
 
         # Disk-only kwargs; ignored by memory namespaces.
         self._disk_namespace_kwargs = dict(
-            remote_log_dir=remote_log_dir,
+            copy_wake=self._wake_copier,
             flush_interval_sec=flush_interval_sec,
-            compaction_interval_sec=compaction_interval_sec,
-            max_tmp_segments_before_compact=max_tmp_segments_before_compact,
+            compaction_config=compaction_config,
             segment_target_bytes=segment_target_bytes,
-            compaction_conn=self._pool.compaction_conn,
-            evict_hook=self._evict_globally,
+            duckdb_memory_limit=duckdb_memory_limit,
+            duckdb_threads=duckdb_threads,
         )
 
         self._rehydrate_from_registry()
@@ -346,24 +413,6 @@ class DuckDBLogStore:
                 raise NamespaceNotFoundError(f"namespace {name!r} is not registered")
             return ns.schema
 
-    def memory_summary(self) -> dict[str, int]:
-        """Aggregate ram_bytes/chunk_count across namespaces, for diagnostics.
-
-        Used by the periodic pool-diagnostics logger in the standalone server.
-        ``MemoryLogNamespace`` reports zeros (no in-RAM segmented buffer).
-        """
-        total_ram_bytes = 0
-        total_chunks = 0
-        with self._insertion_lock:
-            for ns in self._namespaces.values():
-                total_ram_bytes += ns.ram_bytes()
-                total_chunks += ns.chunk_count()
-            return {
-                "namespaces": len(self._namespaces),
-                "ram_bytes": total_ram_bytes,
-                "chunks": total_chunks,
-            }
-
     def write_rows(self, name: str, arrow_ipc_bytes: bytes) -> int:
         """Validate ``arrow_ipc_bytes`` and append the rows to ``name``.
 
@@ -400,22 +449,10 @@ class DuckDBLogStore:
 
         Unknown namespaces in the FROM clause surface as DuckDB
         ``CatalogException`` (the view doesn't exist).
-
-        Uses a cursor on the shared read connection rather than opening a
-        fresh ``duckdb.connect()`` per call: a fresh connection is its own
-        in-process DB instance with its own buffer manager, and mimalloc
-        retained those arenas long after ``con.close()`` (RSS climbed by
-        ~50-100MB per call under load). The view + RAM-table names are
-        suffixed with a unique cursor id so concurrent calls on the shared
-        connection don't collide; views and registrations are torn down in
-        ``finally`` to keep the connection clean for the next caller.
         """
-        cid = _next_cursor_id()
+        con = duckdb.connect()
         registered_names: list[str] = []
-        view_names: list[str] = []
         self._query_visibility_lock.read_acquire()
-        self._pool._read_query_lock.acquire()
-        cursor = self._pool._conn.cursor()
         try:
             # Snapshot under the insertion lock so a concurrent drop_table
             # (which mutates the dict under the same lock) can't trigger
@@ -424,13 +461,12 @@ class DuckDBLogStore:
                 ns_snapshot = list(self._namespaces.items())
             for ns_name, ns in ns_snapshot:
                 ns_quoted = quote_ident(ns_name)
-                view_names.append(ns_quoted)
                 segments, ram_tables = ns.query_snapshot()
                 if not segments and not ram_tables:
                     cols_sql = ", ".join(
                         f"NULL::{duckdb_type_for(c)} AS {quote_ident(c.name)}" for c in ns.schema.columns
                     )
-                    cursor.execute(f"CREATE OR REPLACE VIEW {ns_quoted} AS SELECT {cols_sql} WHERE FALSE")
+                    con.execute(f"CREATE VIEW {ns_quoted} AS SELECT {cols_sql} WHERE FALSE")
                     continue
 
                 parts: list[str] = []
@@ -438,20 +474,17 @@ class DuckDBLogStore:
                     paths_literal = "[" + ", ".join(quote_literal(s.path) for s in segments) + "]"
                     parts.append(f"SELECT * FROM read_parquet({paths_literal}, union_by_name=true)")
                 for table in ram_tables:
-                    reg_name = f"_q{cid}_seg_{len(registered_names)}"
-                    cursor.register(reg_name, table)
+                    reg_name = f"_seg_{len(registered_names)}"
+                    con.register(reg_name, table)
                     registered_names.append(reg_name)
                     parts.append(f"SELECT * FROM {reg_name}")
-                cursor.execute(f"CREATE OR REPLACE VIEW {ns_quoted} AS {' UNION ALL BY NAME '.join(parts)}")
-            return cursor.execute(sql).fetch_arrow_table()
+                con.execute(f"CREATE VIEW {ns_quoted} AS {' UNION ALL BY NAME '.join(parts)}")
+            return con.execute(sql).fetch_arrow_table()
         finally:
             for name in registered_names:
-                cursor.unregister(name)
-            for vname in view_names:
-                cursor.execute(f"DROP VIEW IF EXISTS {vname}")
-            cursor.close()
-            self._pool._read_query_lock.release()
+                con.unregister(name)
             self._query_visibility_lock.read_release()
+            con.close()
 
     def drop_table(self, name: str) -> None:
         """Remove ``name`` from the registry and delete its local segments.
@@ -484,63 +517,17 @@ class DuckDBLogStore:
         finally:
             self._query_visibility_lock.write_release()
 
-    def _evict_globally(self) -> None:
-        """Evict the globally-oldest sealed segments until under the caps.
+    def _mark_copied(self, namespace: str, path: str, copied_at_ms: int) -> None:
+        """Worker-thread entry point for stamping the catalog after upload.
 
-        Tmp (in-flight) segments are excluded from both the count and the
-        candidate list: counting them would falsely flag a namespace with
-        many tmp segments as over-cap and evict its sealed data prematurely.
+        Eviction filters on ``copied_at_ms IS NOT NULL`` so a freshly
+        compacted segment becomes evictable only after the remote copy
+        is durable.
         """
-        candidates: list[tuple[int, int, str, int, str]] = []
-        with self._insertion_lock:
-            total_segments = 0
-            total_bytes = 0
-            for ns_name, ns in self._namespaces.items():
-                reg_order = self._namespace_registered_at.get(ns_name, 0)
-                for seg in ns.all_segments_unlocked():
-                    if _is_tmp_path(seg.path):
-                        continue
-                    total_segments += 1
-                    total_bytes += seg.size_bytes
-                    candidates.append((seg.min_seq, reg_order, ns_name, seg.size_bytes, seg.path))
-
-        if total_segments <= self._max_local_segments and total_bytes <= self._max_local_bytes:
+        ns = self._namespaces.get(namespace)
+        if ns is None:
             return
-
-        # Smallest min_seq first; tiebreak on registration order then name.
-        candidates.sort(key=lambda t: (t[0], t[1], t[2]))
-
-        evictions: list[tuple[str, str, int]] = []
-        remaining_segments = total_segments
-        remaining_bytes = total_bytes
-        for _min_seq, _reg, ns_name, size, path in candidates:
-            if remaining_segments <= self._max_local_segments and remaining_bytes <= self._max_local_bytes:
-                break
-            evictions.append((ns_name, path, size))
-            remaining_segments -= 1
-            remaining_bytes -= size
-
-        if not evictions:
-            return
-
-        self._query_visibility_lock.write_acquire()
-        try:
-            freed_bytes = 0
-            for ns_name, path, _size in evictions:
-                ns = self._namespaces.get(ns_name)
-                if ns is None:
-                    continue
-                freed_bytes += ns.evict_segment(path)
-        finally:
-            self._query_visibility_lock.write_release()
-
-        logger.info(
-            "Globally evicted %d segment(s), freed=%d bytes, remaining=%d segments / %d bytes",
-            len(evictions),
-            freed_bytes,
-            remaining_segments,
-            remaining_bytes,
-        )
+        ns.mark_copied(path, copied_at_ms)
 
     def append(self, key: str, entries: list) -> None:
         if not entries:
@@ -583,8 +570,21 @@ class DuckDBLogStore:
     def close(self) -> None:
         for ns in self._namespaces.values():
             ns.close()
+        if self._copy_worker is not None:
+            self._copy_worker.close()
         self._pool.close()
         self._catalog.close()
+
+    def _wake_copier(self) -> None:
+        """Hint the copy worker that fresh L>=1 segments may exist."""
+        if self._copy_worker is not None:
+            self._copy_worker.wake()
+
+    def _wait_for_copies(self, timeout: float = _COPY_DRAIN_TIMEOUT_SEC) -> bool:
+        """Block until the catalog has no pending L>=1 copies. Test/shutdown hook."""
+        if self._copy_worker is None:
+            return True
+        return self._copy_worker.wait_drained(timeout)
 
     # Test hooks below; forward to the registered "log" namespace.
 
@@ -609,7 +609,7 @@ class DuckDBLogStore:
                 ns._flush_generation_cond.wait(timeout=remaining)
 
     def _force_compaction(self) -> None:
-        self._log_namespace._compaction_step()
+        self._log_namespace._force_compact_l0()
 
     def _wait_for_compaction(self, timeout: float = 10.0) -> None:
         ns = self._log_namespace
@@ -624,21 +624,8 @@ class DuckDBLogStore:
 
 
 def _decode_single_record_batch(arrow_ipc_bytes: bytes) -> pa.RecordBatch:
-    """Decode a single-batch IPC stream.
-
-    Uses ``read_next_batch`` rather than ``list(reader)`` so the EOS check
-    doesn't build an intermediate Python list (this path was 1.15M allocs/30s
-    on prod). Note: the returned ``RecordBatch`` is a zero-copy view into
-    ``arrow_ipc_bytes`` and keeps it alive — see ARROW-7305 in the design
-    notes for why we may want a hard copy here later.
-    """
     reader = paipc.open_stream(pa.BufferReader(arrow_ipc_bytes))
-    try:
-        batch = reader.read_next_batch()
-    except StopIteration:
-        raise SchemaValidationError("WriteRows: expected exactly one RecordBatch in IPC stream, got 0") from None
-    try:
-        reader.read_next_batch()
-    except StopIteration:
-        return batch
-    raise SchemaValidationError("WriteRows: expected exactly one RecordBatch in IPC stream, got >1")
+    batches = list(reader)
+    if len(batches) != 1:
+        raise SchemaValidationError(f"WriteRows: expected exactly one RecordBatch in IPC stream, got {len(batches)}")
+    return batches[0]

--- a/lib/finelog/src/finelog/store/duckdb_store.py
+++ b/lib/finelog/src/finelog/store/duckdb_store.py
@@ -61,10 +61,13 @@ LOG_NAMESPACE_NAME = "log"
 SEGMENT_TARGET_BYTES = 100 * 1024 * 1024
 DEFAULT_FLUSH_INTERVAL_SEC = 60.0
 
-# Tight DuckDB limits (e.g. 256MB) caused spill-to-disk loops under concurrent
-# tail reads over large row groups, wedging the controller. 4GB is generous
-# against 5 segments x 500MB + zstd decompression scratch.
-_DEFAULT_DUCKDB_MEMORY_LIMIT = "4GB"
+# 4GB was the previous default but in practice finelog's read pattern
+# rarely needs more than tens of MB; the high cap mostly let mimalloc/DuckDB
+# retain pages indefinitely. 512MB on the read pool is plenty against 5
+# segments x ~50MB + zstd decompression scratch. Compaction tier-merges can
+# spill larger sort buffers, so it gets its own (still bounded) limit.
+_DEFAULT_DUCKDB_MEMORY_LIMIT = "512MB"
+_DEFAULT_DUCKDB_COMPACTION_MEMORY_LIMIT = "1GB"
 _DEFAULT_DUCKDB_THREADS = "4"
 
 # Embedded mode (iris controller's bundled log-server) keeps VMS small so the
@@ -113,6 +116,12 @@ class ConnectionPool:
         config = {"memory_limit": memory_limit, "threads": threads}
         self._conn = duckdb.connect(config=config)
         self._conn.execute("SET enable_object_cache=true")
+        # Serializes DDL on the shared read connection. ``query()`` issues
+        # ``CREATE OR REPLACE VIEW {namespace}`` for every registered
+        # namespace, and concurrent calls would collide on the same view
+        # names. Held end-to-end through the fetch so the views stay valid
+        # while the result materializes.
+        self._read_query_lock = Lock()
 
     @contextmanager
     def checkout(self, buffer_tables: list[pa.Table]) -> Iterator[tuple[duckdb.DuckDBPyConnection, list[str]]]:
@@ -271,6 +280,7 @@ class DuckDBLogStore:
         compaction_config: CompactionConfig = CompactionConfig(),
         segment_target_bytes: int = SEGMENT_TARGET_BYTES,
         duckdb_memory_limit: str = _DEFAULT_DUCKDB_MEMORY_LIMIT,
+        duckdb_compaction_memory_limit: str = _DEFAULT_DUCKDB_COMPACTION_MEMORY_LIMIT,
         duckdb_threads: str = _DEFAULT_DUCKDB_THREADS,
     ):
         self._data_dir: Path | None = log_dir
@@ -292,13 +302,16 @@ class DuckDBLogStore:
         self._namespace_registered_at: dict[str, int] = {}
         self._namespaces: dict[str, LogNamespaceProtocol] = {}
 
-        # Disk-only kwargs; ignored by memory namespaces.
+        # Disk-only kwargs; ignored by memory namespaces. ``duckdb_memory_limit``
+        # in this dict feeds the per-namespace compaction connection in
+        # ``DiskLogNamespace``; we route the dedicated compaction cap here so
+        # tier-merges don't share the read pool's tighter ceiling.
         self._disk_namespace_kwargs = dict(
             copy_wake=self._wake_copier,
             flush_interval_sec=flush_interval_sec,
             compaction_config=compaction_config,
             segment_target_bytes=segment_target_bytes,
-            duckdb_memory_limit=duckdb_memory_limit,
+            duckdb_memory_limit=duckdb_compaction_memory_limit,
             duckdb_threads=duckdb_threads,
         )
 
@@ -467,10 +480,22 @@ class DuckDBLogStore:
 
         Unknown namespaces in the FROM clause surface as DuckDB
         ``CatalogException`` (the view doesn't exist).
+
+        Uses a cursor on the shared read connection rather than opening a
+        fresh ``duckdb.connect()`` per call: a fresh connection is its own
+        in-process DB instance with its own buffer manager, and mimalloc
+        retained those arenas long after ``con.close()`` (RSS climbed by
+        ~50-100MB per call under load). The view + RAM-table names are
+        suffixed with a unique cursor id so concurrent calls on the shared
+        connection don't collide; views and registrations are torn down in
+        ``finally`` to keep the connection clean for the next caller.
         """
-        con = duckdb.connect()
+        cid = _next_cursor_id()
         registered_names: list[str] = []
+        view_names: list[str] = []
         self._query_visibility_lock.read_acquire()
+        self._pool._read_query_lock.acquire()
+        cursor = self._pool._conn.cursor()
         try:
             # Snapshot under the insertion lock so a concurrent drop_table
             # (which mutates the dict under the same lock) can't trigger
@@ -479,12 +504,13 @@ class DuckDBLogStore:
                 ns_snapshot = list(self._namespaces.items())
             for ns_name, ns in ns_snapshot:
                 ns_quoted = quote_ident(ns_name)
+                view_names.append(ns_quoted)
                 segments, ram_tables = ns.query_snapshot()
                 if not segments and not ram_tables:
                     cols_sql = ", ".join(
                         f"NULL::{duckdb_type_for(c)} AS {quote_ident(c.name)}" for c in ns.schema.columns
                     )
-                    con.execute(f"CREATE VIEW {ns_quoted} AS SELECT {cols_sql} WHERE FALSE")
+                    cursor.execute(f"CREATE OR REPLACE VIEW {ns_quoted} AS SELECT {cols_sql} WHERE FALSE")
                     continue
 
                 parts: list[str] = []
@@ -492,17 +518,20 @@ class DuckDBLogStore:
                     paths_literal = "[" + ", ".join(quote_literal(s.path) for s in segments) + "]"
                     parts.append(f"SELECT * FROM read_parquet({paths_literal}, union_by_name=true)")
                 for table in ram_tables:
-                    reg_name = f"_seg_{len(registered_names)}"
-                    con.register(reg_name, table)
+                    reg_name = f"_q{cid}_seg_{len(registered_names)}"
+                    cursor.register(reg_name, table)
                     registered_names.append(reg_name)
                     parts.append(f"SELECT * FROM {reg_name}")
-                con.execute(f"CREATE VIEW {ns_quoted} AS {' UNION ALL BY NAME '.join(parts)}")
-            return con.execute(sql).fetch_arrow_table()
+                cursor.execute(f"CREATE OR REPLACE VIEW {ns_quoted} AS {' UNION ALL BY NAME '.join(parts)}")
+            return cursor.execute(sql).fetch_arrow_table()
         finally:
             for name in registered_names:
-                con.unregister(name)
+                cursor.unregister(name)
+            for vname in view_names:
+                cursor.execute(f"DROP VIEW IF EXISTS {vname}")
+            cursor.close()
+            self._pool._read_query_lock.release()
             self._query_visibility_lock.read_release()
-            con.close()
 
     def drop_table(self, name: str) -> None:
         """Remove ``name`` from the registry and delete its local segments.
@@ -642,8 +671,21 @@ class DuckDBLogStore:
 
 
 def _decode_single_record_batch(arrow_ipc_bytes: bytes) -> pa.RecordBatch:
+    """Decode a single-batch IPC stream.
+
+    Uses ``read_next_batch`` rather than ``list(reader)`` so the EOS check
+    doesn't build an intermediate Python list (this path was 1.15M allocs/30s
+    on prod). Note: the returned ``RecordBatch`` is a zero-copy view into
+    ``arrow_ipc_bytes`` and keeps it alive — see ARROW-7305 in the design
+    notes for why we may want a hard copy here later.
+    """
     reader = paipc.open_stream(pa.BufferReader(arrow_ipc_bytes))
-    batches = list(reader)
-    if len(batches) != 1:
-        raise SchemaValidationError(f"WriteRows: expected exactly one RecordBatch in IPC stream, got {len(batches)}")
-    return batches[0]
+    try:
+        batch = reader.read_next_batch()
+    except StopIteration:
+        raise SchemaValidationError("WriteRows: expected exactly one RecordBatch in IPC stream, got 0") from None
+    try:
+        reader.read_next_batch()
+    except StopIteration:
+        return batch
+    raise SchemaValidationError("WriteRows: expected exactly one RecordBatch in IPC stream, got >1")

--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -123,6 +123,26 @@ def _level_histogram(segments: Iterable[LocalSegment]) -> dict[int, int]:
     return dict(sorted(counts.items()))
 
 
+def _level_bytes_summary(segments: Iterable[LocalSegment], level_targets: tuple[int, ...]) -> str:
+    """Render ``L<n>=<bytes>/<target>`` per occupied level for the heartbeat.
+
+    ``level_targets[n]`` is the byte threshold for promoting L_n → L_{n+1};
+    the terminal level (``len(level_targets)``) has no target and prints
+    just the raw byte count. Empty levels are omitted.
+    """
+    bytes_per_level: dict[int, int] = {}
+    for s in segments:
+        bytes_per_level[s.level] = bytes_per_level.get(s.level, 0) + s.size_bytes
+    parts: list[str] = []
+    for level in sorted(bytes_per_level):
+        size = bytes_per_level[level]
+        if level < len(level_targets):
+            parts.append(f"L{level}={size}/{level_targets[level]}")
+        else:
+            parts.append(f"L{level}={size}")
+    return "{" + ", ".join(parts) + "}"
+
+
 def _key_bounds_from_parquet(metadata: pq.FileMetaData, key_column: str | None) -> tuple[object | None, object | None]:
     """Extract ``(min, max)`` for ``key_column`` across all row groups.
 
@@ -683,16 +703,19 @@ class DiskLogNamespace:
                 chunk_count = self._buffers.chunk_count()
                 next_seq = self._buffers.next_seq
                 level_counts = _level_histogram(self._local_segments)
+                level_bytes = _level_bytes_summary(self._local_segments, self._compactor.config.level_targets)
             force_drain = ram_bytes >= self._segment_target_bytes
 
             now = time.monotonic()
             if now - last_heartbeat >= _BG_HEARTBEAT_INTERVAL_SEC:
                 logger.info(
-                    "bg-loop tick: chunks=%d ram_bytes=%d levels=%s next_seq=%d "
-                    "since_flush_ms=%d since_compact_ms=%d",
+                    "bg-loop tick ns=%s: chunks=%d ram_bytes=%d levels=%s level_bytes=%s "
+                    "next_seq=%d since_flush_ms=%d since_compact_ms=%d",
+                    self.name,
                     chunk_count,
                     ram_bytes,
                     level_counts,
+                    level_bytes,
                     next_seq,
                     int((now - last_flush_at) * 1000),
                     int((now - last_compact_at) * 1000),

--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -106,8 +106,8 @@ class SegmentMetadata(NamedTuple):
     min_seq: int
     max_seq: int
     row_count: int
-    min_key_value: str | None
-    max_key_value: str | None
+    min_key_value: object | None
+    max_key_value: object | None
 
 
 _EMPTY_SEGMENT_METADATA = SegmentMetadata(
@@ -123,13 +123,14 @@ def _level_histogram(segments: Iterable[LocalSegment]) -> dict[int, int]:
     return dict(sorted(counts.items()))
 
 
-def _key_bounds_from_parquet(metadata: pq.FileMetaData, key_column: str | None) -> tuple[str | None, str | None]:
+def _key_bounds_from_parquet(metadata: pq.FileMetaData, key_column: str | None) -> tuple[object | None, object | None]:
     """Extract ``(min, max)`` for ``key_column`` across all row groups.
 
     Returns ``(None, None)`` if no ``key_column`` was requested, the column
     isn't present, or no row group carries statistics. The returned values
-    are stringified (parquet returns native types; we normalize to TEXT
-    because the catalog column is generic across namespaces).
+    are the parquet-native Python types (int / str / float / bytes /
+    datetime). Stringification happens at the catalog boundary so numeric
+    keys preserve their ordering through ``aggregate_key_bounds``.
     """
     if not key_column:
         return None, None
@@ -150,7 +151,7 @@ def _key_bounds_from_parquet(metadata: pq.FileMetaData, key_column: str | None) 
             overall_max = rg_max
     if overall_min is None:
         return None, None
-    return str(overall_min), str(overall_max)
+    return overall_min, overall_max
 
 
 def _read_segment_metadata(path: Path, key_column: str | None = None) -> SegmentMetadata:
@@ -228,8 +229,16 @@ class LocalSegment:
     min_seq: int
     max_seq: int
     row_count: int
-    min_key_value: str | None = None
-    max_key_value: str | None = None
+    # ``created_at_ms`` is stamped once at flush/merge time and preserved
+    # across level bumps and catalog reconcile so the planner can age out
+    # quiet L0 segments via ``CompactionConfig.max_l0_age_sec``.
+    created_at_ms: int = 0
+    # Typed key-column bounds (Python int / str / float / bool / bytes
+    # depending on schema). Stringified only at the catalog boundary in
+    # ``_segment_to_row``; held typed in memory so ``aggregate_key_bounds``
+    # can compare numeric keys with native ordering.
+    min_key_value: object | None = None
+    max_key_value: object | None = None
     copied_at_ms: int | None = None
 
 
@@ -465,10 +474,16 @@ class DiskLogNamespace:
 
         # Reconcile from disk: parquet files are authoritative across
         # crashes. Walk every ``seg_L<n>_*.parquet`` and rebuild the
-        # in-memory deque + catalog rows.
+        # in-memory deque + catalog rows. ``created_at_ms`` falls back to
+        # the file mtime when the catalog has nothing for this path —
+        # close enough for L0 aging and stable across reboots.
         key_column = self.schema.key_column or None
+        catalog_rows = {row.path: row for row in self._catalog.list_segments(self.name)}
         for p in _discover_segments(data_dir):
             meta = _read_segment_metadata(p, key_column=key_column)
+            row = catalog_rows.get(str(p))
+            created_at_ms = row.created_at_ms if row is not None else int(p.stat().st_mtime * 1000)
+            copied_at_ms = row.copied_at_ms if row is not None else None
             self._local_segments.append(
                 LocalSegment(
                     path=str(p),
@@ -477,24 +492,22 @@ class DiskLogNamespace:
                     min_seq=meta.min_seq,
                     max_seq=meta.max_seq,
                     row_count=meta.row_count,
+                    created_at_ms=created_at_ms,
                     min_key_value=meta.min_key_value,
                     max_key_value=meta.max_key_value,
+                    copied_at_ms=copied_at_ms,
                 )
             )
 
-        # Reconcile rewrites the catalog rows wholesale; it preserves any
-        # ``copied_at_ms`` already recorded for these paths so a re-upload
-        # stamp doesn't silently disappear across reboot.
+        # Reconcile rewrites the catalog rows wholesale; ``created_at_ms``
+        # and ``copied_at_ms`` already came back from the catalog above
+        # (or from mtime fallback), so the rewrite is a no-op for those
+        # fields and a refresh of structural columns (level, key bounds)
+        # for any catalog row that drifted from the parquet footer.
         self._catalog.reconcile_segments(
             self.name,
             [self._segment_to_row(seg) for seg in self._local_segments],
         )
-        # Mirror the preserved stamps back into the in-memory deque.
-        for row in self._catalog.list_segments(self.name):
-            for seg in self._local_segments:
-                if seg.path == row.path:
-                    seg.copied_at_ms = row.copied_at_ms
-                    break
 
         self._flush_rl = RateLimiter(flush_interval_sec)
         self._compaction_rl = RateLimiter(compaction_config.check_interval_sec)
@@ -742,11 +755,14 @@ class DiskLogNamespace:
         keys = compaction_sort_keys(self.schema)
         return table.sort_by([(name, "ascending") for name in keys])
 
-    def _key_bounds_from_table(self, table: pa.Table) -> tuple[str | None, str | None]:
+    def _key_bounds_from_table(self, table: pa.Table) -> tuple[object | None, object | None]:
         """Compute (min, max) over the namespace's ``key_column`` in ``table``.
 
         Returns ``(None, None)`` when the schema has no key_column or the
-        column is empty / all null.
+        column is empty / all null. The returned values keep their Arrow
+        Python type so ``aggregate_key_bounds`` can compare numerics
+        natively; ``_segment_to_row`` stringifies them at the catalog
+        boundary.
         """
         key_column = self.schema.key_column
         if not key_column or table.num_rows == 0:
@@ -759,10 +775,30 @@ class DiskLogNamespace:
         hi = result["max"].as_py()
         if lo is None or hi is None:
             return None, None
-        return str(lo), str(hi)
+        return lo, hi
+
+    def _segment_by_path(self, path: str) -> LocalSegment | None:
+        """Look up the in-memory ``LocalSegment`` matching ``path``.
+
+        Used to recover typed key bounds for a ``SegmentRow`` (the catalog
+        round-trip stringifies them). Safe without ``_insertion_lock``
+        when called from the per-namespace bg thread, which is the sole
+        mutator of ``_local_segments`` post-construction.
+        """
+        for seg in self._local_segments:
+            if seg.path == path:
+                return seg
+        return None
 
     def _segment_to_row(self, seg: LocalSegment) -> SegmentRow:
-        """Build the catalog row that mirrors ``seg``."""
+        """Build the catalog row that mirrors ``seg``.
+
+        ``created_at_ms`` reflects the segment's stamped birth time, never
+        ``now`` — overwriting it would defeat ``max_l0_age_sec`` aging,
+        which the planner reads from the round-trip catalog snapshot every
+        tick. Key bounds are stringified here because the catalog stores
+        them in a generic TEXT column.
+        """
         return SegmentRow(
             namespace=self.name,
             path=seg.path,
@@ -771,9 +807,9 @@ class DiskLogNamespace:
             max_seq=seg.max_seq,
             row_count=seg.row_count,
             byte_size=seg.size_bytes,
-            created_at_ms=int(time.time() * 1000),
-            min_key_value=seg.min_key_value,
-            max_key_value=seg.max_key_value,
+            created_at_ms=seg.created_at_ms,
+            min_key_value=None if seg.min_key_value is None else str(seg.min_key_value),
+            max_key_value=None if seg.max_key_value is None else str(seg.max_key_value),
             copied_at_ms=seg.copied_at_ms,
         )
 
@@ -816,6 +852,7 @@ class DiskLogNamespace:
             min_seq=sealed.min_seq,
             max_seq=sealed.max_seq,
             row_count=sealed.table.num_rows,
+            created_at_ms=int(time.time() * 1000),
             min_key_value=min_key_value,
             max_key_value=max_key_value,
         )
@@ -889,8 +926,11 @@ class DiskLogNamespace:
         old = job.inputs[0]
         new_filename = seg_filename(level=job.output_level, min_seq=old.min_seq)
         new_path = self._data_dir / new_filename
-        os.rename(old.path, new_path)
 
+        # Recover the typed key bounds from the in-memory deque — the
+        # SegmentRow on ``job.inputs`` carries the catalog's stringified
+        # form, which loses ordering for numeric keys.
+        old_local = self._segment_by_path(old.path)
         bumped = LocalSegment(
             path=str(new_path),
             size_bytes=old.byte_size,
@@ -898,10 +938,18 @@ class DiskLogNamespace:
             min_seq=old.min_seq,
             max_seq=old.max_seq,
             row_count=old.row_count,
-            min_key_value=old.min_key_value,
-            max_key_value=old.max_key_value,
+            # Preserve the input's birth time across the level bump:
+            # a single-input promotion is a rename, not a fresh write.
+            created_at_ms=old.created_at_ms,
+            min_key_value=old_local.min_key_value if old_local else None,
+            max_key_value=old_local.max_key_value if old_local else None,
         )
-        self._commit_swap(removed=[old.path], added=bumped, unlink_removed=False)
+        self._commit_swap(
+            removed=[old.path],
+            added=bumped,
+            unlink_removed=False,
+            pre_swap=lambda: os.rename(old.path, new_path),
+        )
         logger.info("Level-bumped %s -> L%d (%s)", Path(old.path).name, job.output_level, new_filename)
         self._copy_wake()
 
@@ -922,9 +970,13 @@ class DiskLogNamespace:
             staging_path.unlink(missing_ok=True)
             return
 
-        # min-of-mins / max-of-maxes — string lex order matches parquet's
-        # BYTE_ARRAY UNSIGNED comparison.
-        merged_min_key, merged_max_key = aggregate_key_bounds((s.min_key_value, s.max_key_value) for s in job.inputs)
+        # The catalog stores key bounds as TEXT; we compare on the typed
+        # values held in the in-memory deque to preserve numeric ordering,
+        # then stringify at the ``_segment_to_row`` boundary.
+        input_locals = [self._segment_by_path(s.path) for s in job.inputs]
+        merged_min_key, merged_max_key = aggregate_key_bounds(
+            (loc.min_key_value, loc.max_key_value) for loc in input_locals if loc is not None
+        )
         merged_seg = LocalSegment(
             path=str(merged_path),
             size_bytes=staging_path.stat().st_size,
@@ -932,6 +984,7 @@ class DiskLogNamespace:
             min_seq=job.output_min_seq,
             max_seq=job.output_max_seq,
             row_count=sum(s.row_count for s in job.inputs),
+            created_at_ms=int(time.time() * 1000),
             min_key_value=merged_min_key,
             max_key_value=merged_max_key,
         )
@@ -952,38 +1005,61 @@ class DiskLogNamespace:
         )
         self._copy_wake()
 
-    def _commit_swap(self, *, removed: list[str], added: LocalSegment, unlink_removed: bool) -> None:
+    def _commit_swap(
+        self,
+        *,
+        removed: list[str],
+        added: LocalSegment,
+        unlink_removed: bool,
+        pre_swap: Callable[[], None] | None = None,
+    ) -> None:
         """Splice the deque + catalog: replace ``removed`` paths with ``added``.
 
         ``unlink_removed`` is False for level bumps (the file was renamed
-        in place, so the old path is already gone) and True for merges
-        (the inputs are still on disk and need cleanup).
+        in place via ``pre_swap``, so the old path is already gone) and
+        True for merges (the inputs are still on disk and need cleanup).
+
+        The full transition runs under ``_query_visibility_lock`` write
+        mode: readers hold the read lock for their entire query (DuckDB
+        opens parquet files lazily), so renaming or unlinking a file
+        under a stale snapshot path would surface as
+        ``IOException: No files found``. Taking the write lock here
+        drains existing readers before any rename/unlink and blocks new
+        ones until the deque mirrors the post-swap state. ``pre_swap``
+        runs inside the lock so a level-bump rename happens after readers
+        have drained.
         """
         removed_set = set(removed)
-        with self._insertion_lock:
-            new_segments: deque[LocalSegment] = deque()
-            inserted = False
-            for s in self._local_segments:
-                if s.path in removed_set:
-                    if not inserted:
-                        new_segments.append(added)
-                        inserted = True
-                else:
-                    new_segments.append(s)
-            if not inserted:
-                new_segments.append(added)
-            self._local_segments = new_segments
-            self._catalog.replace_segments(
-                self.name,
-                removed_paths=removed,
-                added=[self._segment_to_row(added)],
-            )
-        if unlink_removed:
-            for path in removed:
-                try:
-                    Path(path).unlink(missing_ok=True)
-                except OSError:
-                    logger.warning("Failed to unlink merged input %s", path, exc_info=True)
+        self._query_visibility_lock.write_acquire()
+        try:
+            if pre_swap is not None:
+                pre_swap()
+            with self._insertion_lock:
+                new_segments: deque[LocalSegment] = deque()
+                inserted = False
+                for s in self._local_segments:
+                    if s.path in removed_set:
+                        if not inserted:
+                            new_segments.append(added)
+                            inserted = True
+                    else:
+                        new_segments.append(s)
+                if not inserted:
+                    new_segments.append(added)
+                self._local_segments = new_segments
+                self._catalog.replace_segments(
+                    self.name,
+                    removed_paths=removed,
+                    added=[self._segment_to_row(added)],
+                )
+            if unlink_removed:
+                for path in removed:
+                    try:
+                        Path(path).unlink(missing_ok=True)
+                    except OSError:
+                        logger.warning("Failed to unlink merged input %s", path, exc_info=True)
+        finally:
+            self._query_visibility_lock.write_release()
 
     def _eviction_step(self) -> None:
         """Evict the namespace's oldest L>=1 copied segments until under caps.

--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -9,17 +9,17 @@ backs the in-memory store mode. Both satisfy :class:`LogNamespaceProtocol`.
 The two global locks (insertion mutex + query-visibility rwlock) live on the
 registry and are passed in at construction. The disk variant additionally
 owns a per-namespace flush mutex preventing the test ``_force_flush`` hook
-from racing the bg thread on the same ``tmp_*.parquet`` filename.
+from racing the bg thread on the same segment filename.
 """
 
 from __future__ import annotations
 
 import logging
-import re
+import os
 import threading
 import time
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from pathlib import Path
@@ -27,8 +27,6 @@ from threading import Condition, Lock
 from typing import NamedTuple, Protocol
 
 import duckdb
-import fsspec.core
-import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.parquet as pq
@@ -40,17 +38,23 @@ from finelog.store.catalog import (
     Catalog,
     NamespaceStats,
     SegmentRow,
-    SegmentState,
+)
+from finelog.store.compactor import (
+    CompactionConfig,
+    CompactionJob,
+    Compactor,
+    aggregate_key_bounds,
+    compaction_sort_keys,
+    parse_seg_filename,
+    seg_filename,
 )
 from finelog.store.rwlock import RWLock
 from finelog.store.schema import (
     IMPLICIT_SEQ_COLUMN,
     Column,
     Schema,
-    duckdb_type_for,
     schema_to_arrow,
 )
-from finelog.store.sql_escape import quote_ident, quote_literal
 from finelog.types import REGEX_META_RE, LogReadResult, parse_attempt_id, str_to_log_level
 
 logger = logging.getLogger(__name__)
@@ -70,10 +74,6 @@ LOG_REGISTERED_SCHEMA = Schema(
     key_column="key",
 )
 
-# Both prefixes keyed by min_seq, so sort-by-filename yields chronological order.
-_TMP_PREFIX = "tmp_"
-_LOG_PREFIX = "logs_"
-
 _ROW_GROUP_SIZE = 16_384
 
 # Append calls slower than this emit a warning so lock contention vs prepare
@@ -88,60 +88,104 @@ _BG_HEARTBEAT_INTERVAL_SEC = 10.0
 # queries that cannot be pruned by row-group statistics.
 _MAX_PARQUET_BYTES_PER_READ = 2_500 * 1024 * 1024
 
-_FILENAME_SEQ_RE = re.compile(rf"^(?:{_TMP_PREFIX}|{_LOG_PREFIX})(\d+)\.parquet$")
-
-
-def _tmp_filename(min_seq: int) -> str:
-    return f"{_TMP_PREFIX}{min_seq:019d}.parquet"
-
-
-def _log_filename(min_seq: int) -> str:
-    return f"{_LOG_PREFIX}{min_seq:019d}.parquet"
-
-
-def _is_tmp_path(path: str) -> bool:
-    return Path(path).name.startswith(_TMP_PREFIX)
-
-
-def _min_seq_from_filename(name: str) -> int | None:
-    match = _FILENAME_SEQ_RE.match(name)
-    if not match:
-        return None
-    return int(match.group(1))
-
 
 class SegmentMetadata(NamedTuple):
-    """``(min_seq, max_seq, row_count)`` derived from a segment's filename + parquet footer."""
+    """Per-segment metadata derived from filename + parquet footer.
 
+    ``level`` is read out of the filename (``seg_L<n>_*``); the catalog
+    holds the runtime source of truth, but a fresh boot reconciles from
+    disk so this is what populates the catalog rows on startup.
+
+    ``min_key_value`` / ``max_key_value`` are the parquet column statistics
+    for ``key_column``, when one is requested and the column carries
+    statistics. ``None`` when the namespace has no ``key_column``, the
+    column statistics weren't written, or the segment is empty.
+    """
+
+    level: int
     min_seq: int
     max_seq: int
     row_count: int
+    min_key_value: str | None
+    max_key_value: str | None
 
 
-_EMPTY_SEGMENT_METADATA = SegmentMetadata(min_seq=0, max_seq=0, row_count=0)
+_EMPTY_SEGMENT_METADATA = SegmentMetadata(
+    level=0, min_seq=0, max_seq=0, row_count=0, min_key_value=None, max_key_value=None
+)
 
 
-def _read_segment_metadata(path: Path) -> SegmentMetadata:
-    """Recover ``(min_seq, max_seq, row_count)`` from filename + parquet footer.
+def _level_histogram(segments: Iterable[LocalSegment]) -> dict[int, int]:
+    """Count segments per level for the bg-loop heartbeat log line."""
+    counts: dict[int, int] = {}
+    for s in segments:
+        counts[s.level] = counts.get(s.level, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _key_bounds_from_parquet(metadata: pq.FileMetaData, key_column: str | None) -> tuple[str | None, str | None]:
+    """Extract ``(min, max)`` for ``key_column`` across all row groups.
+
+    Returns ``(None, None)`` if no ``key_column`` was requested, the column
+    isn't present, or no row group carries statistics. The returned values
+    are stringified (parquet returns native types; we normalize to TEXT
+    because the catalog column is generic across namespaces).
+    """
+    if not key_column:
+        return None, None
+    try:
+        col_idx = metadata.schema.names.index(key_column)
+    except ValueError:
+        return None, None
+    overall_min: object | None = None
+    overall_max: object | None = None
+    for rg_idx in range(metadata.num_row_groups):
+        stats = metadata.row_group(rg_idx).column(col_idx).statistics
+        if stats is None or not stats.has_min_max:
+            continue
+        rg_min, rg_max = stats.min, stats.max
+        if overall_min is None or rg_min < overall_min:
+            overall_min = rg_min
+        if overall_max is None or rg_max > overall_max:
+            overall_max = rg_max
+    if overall_min is None:
+        return None, None
+    return str(overall_min), str(overall_max)
+
+
+def _read_segment_metadata(path: Path, key_column: str | None = None) -> SegmentMetadata:
+    """Recover (level, seq, row count, key_column bounds) from a segment file.
 
     Returns ``_EMPTY_SEGMENT_METADATA`` for unparseable filenames or footer-read
     failures — the caller treats that as an empty/discardable segment.
     """
-    min_seq = _min_seq_from_filename(path.name)
-    if min_seq is None:
+    parsed = parse_seg_filename(path.name)
+    if parsed is None:
         return _EMPTY_SEGMENT_METADATA
+    level, min_seq = parsed
     try:
-        num_rows = pq.read_metadata(path).num_rows
+        metadata = pq.read_metadata(path)
     except Exception:
         logger.warning("Failed to read parquet metadata for %s; treating as empty", path, exc_info=True)
         return _EMPTY_SEGMENT_METADATA
+    num_rows = metadata.num_rows
     if num_rows <= 0:
-        return SegmentMetadata(min_seq=min_seq, max_seq=min_seq, row_count=0)
-    return SegmentMetadata(min_seq=min_seq, max_seq=min_seq + num_rows - 1, row_count=num_rows)
+        return SegmentMetadata(
+            level=level, min_seq=min_seq, max_seq=min_seq, row_count=0, min_key_value=None, max_key_value=None
+        )
+    min_key, max_key = _key_bounds_from_parquet(metadata, key_column)
+    return SegmentMetadata(
+        level=level,
+        min_seq=min_seq,
+        max_seq=min_seq + num_rows - 1,
+        row_count=num_rows,
+        min_key_value=min_key,
+        max_key_value=max_key,
+    )
 
 
 def _discover_segments(log_dir: Path) -> list[Path]:
-    return sorted(list(log_dir.glob(f"{_TMP_PREFIX}*.parquet")) + list(log_dir.glob(f"{_LOG_PREFIX}*.parquet")))
+    return sorted(log_dir.glob("seg_L*_*.parquet"))
 
 
 def _recover_next_seq(log_dir: Path) -> int:
@@ -180,21 +224,18 @@ class _SealedBuffer:
 class LocalSegment:
     path: str
     size_bytes: int
+    level: int
     min_seq: int
     max_seq: int
     row_count: int
+    min_key_value: str | None = None
+    max_key_value: str | None = None
+    copied_at_ms: int | None = None
 
 
 def _stamp_seq_column(batch: pa.RecordBatch, first_seq: int, arrow_schema: pa.Schema) -> pa.Table:
-    """Project ``batch`` to ``arrow_schema`` with the implicit seq column filled.
-
-    Uses ``np.arange`` rather than ``pa.array(range(...), int64)``: the python
-    ``range`` path boxes every value into a PyLong before pyarrow re-unpacks
-    it, which dominated allocation count under load (150k allocs / 30 s on
-    prod). ``np.arange`` produces the int64 buffer in one C-level shot and
-    pyarrow wraps it zero-copy.
-    """
-    seq_array = pa.array(np.arange(first_seq, first_seq + batch.num_rows, dtype=np.int64))
+    """Project ``batch`` to ``arrow_schema`` with the implicit seq column filled."""
+    seq_array = pa.array(range(first_seq, first_seq + batch.num_rows), type=pa.int64())
     arrays: list[pa.Array] = []
     for field in arrow_schema:
         if field.name == IMPLICIT_SEQ_COLUMN:
@@ -346,13 +387,13 @@ class LogNamespaceProtocol(Protocol):
 
     def query_snapshot(self) -> tuple[list[LocalSegment], list[pa.Table]]: ...
 
-    def sealed_segments(self) -> list[LocalSegment]: ...
-
     def all_segments_unlocked(self) -> list[LocalSegment]: ...
 
     def update_schema(self, new_schema: Schema) -> None: ...
 
     def evict_segment(self, path: str) -> int: ...
+
+    def mark_copied(self, path: str, copied_at_ms: int) -> None: ...
 
     def remove_local_storage(self) -> None: ...
 
@@ -361,10 +402,6 @@ class LogNamespaceProtocol(Protocol):
     def stop_and_join(self) -> None: ...
 
     def stats(self) -> NamespaceStats: ...
-
-    def ram_bytes(self) -> int: ...
-
-    def chunk_count(self) -> int: ...
 
 
 class DiskLogNamespace:
@@ -382,17 +419,16 @@ class DiskLogNamespace:
         name: str,
         schema: Schema,
         data_dir: Path,
-        remote_log_dir: str,
+        copy_wake: Callable[[], None],
         segment_target_bytes: int,
         flush_interval_sec: float,
-        compaction_interval_sec: float,
-        max_tmp_segments_before_compact: int,
+        compaction_config: CompactionConfig,
         insertion_lock: Lock,
         query_visibility_lock: RWLock,
-        compaction_conn: duckdb.DuckDBPyConnection,
+        duckdb_memory_limit: str,
+        duckdb_threads: str,
         read_pool: _ReadPoolProtocol,
         catalog: Catalog,
-        evict_hook: Callable[[], None] = lambda: None,
     ) -> None:
         self.name = name
         self.schema = schema
@@ -400,18 +436,24 @@ class DiskLogNamespace:
         self._data_dir = data_dir
         data_dir.mkdir(parents=True, exist_ok=True)
 
-        self._remote_log_dir = remote_log_dir
+        # Notifies the store-wide copy worker that fresh L>=1 catalog
+        # rows may exist; the worker polls the catalog regardless, this
+        # just shortens the latency from "compaction commit" to "upload".
+        self._copy_wake = copy_wake
         self._segment_target_bytes = segment_target_bytes
-        self._max_tmp_segments_before_compact = max_tmp_segments_before_compact
-        self._evict_hook = evict_hook
+        self._compactor = Compactor(compaction_config)
 
         self._insertion_lock = insertion_lock
         self._query_visibility_lock = query_visibility_lock
         # Prevents the test ``_force_flush`` hook racing the bg thread on
-        # the same tmp filename (both derive from this namespace's _next_seq).
+        # the same segment filename (both derive from this namespace's
+        # _next_seq).
         self._flush_lock = Lock()
 
-        self._compaction_conn = compaction_conn
+        # Per-namespace compaction connection. Cross-namespace COPYs would
+        # collide on a shared connection's session state, and we don't run
+        # cross-namespace queries through this conn anyway.
+        self._compaction_conn = duckdb.connect(config={"memory_limit": duckdb_memory_limit, "threads": duckdb_threads})
         self._read_pool = read_pool
         self._catalog = catalog
 
@@ -421,46 +463,43 @@ class DiskLogNamespace:
         )
         self._local_segments: deque[LocalSegment] = deque()
 
-        # Drop stale tmp segments left behind by a prior compaction that
-        # crashed between rename and unlink: any tmp whose [min, max] is
-        # fully covered by a logs_ segment is a duplicate.
-        discovered: list[LocalSegment] = []
+        # Reconcile from disk: parquet files are authoritative across
+        # crashes. Walk every ``seg_L<n>_*.parquet`` and rebuild the
+        # in-memory deque + catalog rows.
+        key_column = self.schema.key_column or None
         for p in _discover_segments(data_dir):
-            meta = _read_segment_metadata(p)
-            discovered.append(
+            meta = _read_segment_metadata(p, key_column=key_column)
+            self._local_segments.append(
                 LocalSegment(
                     path=str(p),
                     size_bytes=p.stat().st_size,
+                    level=meta.level,
                     min_seq=meta.min_seq,
                     max_seq=meta.max_seq,
                     row_count=meta.row_count,
+                    min_key_value=meta.min_key_value,
+                    max_key_value=meta.max_key_value,
                 )
             )
-        log_ranges = [(s.min_seq, s.max_seq) for s in discovered if not _is_tmp_path(s.path)]
-        for s in discovered:
-            if _is_tmp_path(s.path) and any(lo <= s.min_seq and s.max_seq <= hi for lo, hi in log_ranges):
-                logger.info("Dropping stale tmp segment %s covered by compacted logs_ range", s.path)
-                try:
-                    Path(s.path).unlink()
-                except OSError:
-                    logger.warning("Failed to unlink stale tmp segment %s", s.path, exc_info=True)
-                continue
-            self._local_segments.append(s)
 
-        # Reconcile the persistent catalog against the on-disk segment set.
-        # Parquet files are authoritative across crashes; the catalog rows
-        # for this namespace get rewritten to match exactly what's on disk
-        # right now so future reads from the catalog always agree with
-        # ``query_snapshot()``.
+        # Reconcile rewrites the catalog rows wholesale; it preserves any
+        # ``copied_at_ms`` already recorded for these paths so a re-upload
+        # stamp doesn't silently disappear across reboot.
         self._catalog.reconcile_segments(
             self.name,
             [self._segment_to_row(seg) for seg in self._local_segments],
         )
+        # Mirror the preserved stamps back into the in-memory deque.
+        for row in self._catalog.list_segments(self.name):
+            for seg in self._local_segments:
+                if seg.path == row.path:
+                    seg.copied_at_ms = row.copied_at_ms
+                    break
 
         self._flush_rl = RateLimiter(flush_interval_sec)
-        self._compaction_rl = RateLimiter(compaction_interval_sec)
+        self._compaction_rl = RateLimiter(compaction_config.check_interval_sec)
         # Mark just-run so the bg loop doesn't fire a spurious tick at startup
-        # and compact a partially-written set of tmp segments.
+        # and compact a partially-written set of segments.
         self._flush_rl.mark_run()
         self._compaction_rl.mark_run()
         self._stop = threading.Event()
@@ -592,20 +631,19 @@ class DiskLogNamespace:
         self._stop.set()
         self._wake.set()
         self._bg_thread.join()
+        # Flush turns RAM into L0 on disk so a clean restart picks it up.
+        # We do NOT promote L0 to L1 at close — L0 is local-only by design,
+        # and re-discovery on boot brings them back. The store-wide copy
+        # worker handles L1+ uploads independently.
         self._flush_step()
-        self._compaction_step(compact_single=True)
+        self._compaction_conn.close()
 
     def stop_and_join(self) -> None:
         """Stop the bg thread without flushing or compacting (used by ``DropTable``)."""
         self._stop.set()
         self._wake.set()
         self._bg_thread.join()
-
-    def ram_bytes(self) -> int:
-        return self._buffers.ram_bytes()
-
-    def chunk_count(self) -> int:
-        return self._buffers.chunk_count()
+        self._compaction_conn.close()
 
     def update_schema(self, new_schema: Schema) -> None:
         _assert_additive_schema_evolution(self.schema, new_schema)
@@ -621,20 +659,17 @@ class DiskLogNamespace:
                 ram_bytes = self._buffers.ram_bytes()
                 chunk_count = self._buffers.chunk_count()
                 next_seq = self._buffers.next_seq
-                tmp_count = sum(1 for s in self._local_segments if _is_tmp_path(s.path))
-                logs_count = len(self._local_segments) - tmp_count
+                level_counts = _level_histogram(self._local_segments)
             force_drain = ram_bytes >= self._segment_target_bytes
-            force_compaction = tmp_count > self._max_tmp_segments_before_compact
 
             now = time.monotonic()
             if now - last_heartbeat >= _BG_HEARTBEAT_INTERVAL_SEC:
                 logger.info(
-                    "bg-loop tick: chunks=%d ram_bytes=%d tmp=%d logs=%d next_seq=%d "
+                    "bg-loop tick: chunks=%d ram_bytes=%d levels=%s next_seq=%d "
                     "since_flush_ms=%d since_compact_ms=%d",
                     chunk_count,
                     ram_bytes,
-                    tmp_count,
-                    logs_count,
+                    level_counts,
                     next_seq,
                     int((now - last_flush_at) * 1000),
                     int((now - last_compact_at) * 1000),
@@ -648,10 +683,16 @@ class DiskLogNamespace:
             elif self._flush_rl.should_run():
                 self._flush_step()
                 last_flush_at = time.monotonic()
-            if force_compaction or self._compaction_rl.should_run():
-                self._compaction_step()
+            if self._compaction_rl.should_run():
+                # Drain promotable runs back-to-back on the same tick: a
+                # large flush burst can leave several tiers eligible at once,
+                # and waiting another check_interval per merge needlessly
+                # extends per-read fanout.
+                while self._compaction_step():
+                    pass
                 self._compaction_rl.mark_run()
                 last_compact_at = time.monotonic()
+                self._eviction_step()
 
             self._wake.wait(timeout=min(self._flush_rl.time_until_next(), 1.0))
             self._wake.clear()
@@ -697,48 +738,64 @@ class DiskLogNamespace:
                 self._flush_generation += 1
                 self._flush_generation_cond.notify_all()
 
-            self._evict_hook()
-
-    def _derive_seq_bounds_locked(self, table: pa.Table) -> tuple[int, int]:
-        seq_col = table.column(IMPLICIT_SEQ_COLUMN)
-        return pc.min(seq_col).as_py(), pc.max(seq_col).as_py()
-
     def _sort_for_flush(self, table: pa.Table) -> pa.Table:
-        keys = self._compaction_sort_keys()
+        keys = compaction_sort_keys(self.schema)
         return table.sort_by([(name, "ascending") for name in keys])
 
-    def _compaction_sort_keys(self) -> tuple[str, ...]:
-        # key_column first so range scans on it prune row groups efficiently.
-        if self.schema.key_column:
-            return (self.schema.key_column, IMPLICIT_SEQ_COLUMN)
-        return (IMPLICIT_SEQ_COLUMN,)
+    def _key_bounds_from_table(self, table: pa.Table) -> tuple[str | None, str | None]:
+        """Compute (min, max) over the namespace's ``key_column`` in ``table``.
+
+        Returns ``(None, None)`` when the schema has no key_column or the
+        column is empty / all null.
+        """
+        key_column = self.schema.key_column
+        if not key_column or table.num_rows == 0:
+            return None, None
+        col = table.column(key_column)
+        if col.null_count == col.length():
+            return None, None
+        result = pc.min_max(col)
+        lo = result["min"].as_py()
+        hi = result["max"].as_py()
+        if lo is None or hi is None:
+            return None, None
+        return str(lo), str(hi)
 
     def _segment_to_row(self, seg: LocalSegment) -> SegmentRow:
         """Build the catalog row that mirrors ``seg``."""
-        state = SegmentState.TMP if _is_tmp_path(seg.path) else SegmentState.FINALIZED
         return SegmentRow(
             namespace=self.name,
             path=seg.path,
-            state=state,
+            level=seg.level,
             min_seq=seg.min_seq,
             max_seq=seg.max_seq,
             row_count=seg.row_count,
             byte_size=seg.size_bytes,
             created_at_ms=int(time.time() * 1000),
+            min_key_value=seg.min_key_value,
+            max_key_value=seg.max_key_value,
+            copied_at_ms=seg.copied_at_ms,
         )
 
     def _write_new_segment(self, sealed: _SealedBuffer) -> None:
-        filename = _tmp_filename(sealed.min_seq)
+        filename = seg_filename(level=0, min_seq=sealed.min_seq)
         write_start = time.monotonic()
 
         filepath = self._data_dir / filename
-        tmp_path = filepath.with_suffix(".parquet.tmp")
+        staging_path = filepath.with_suffix(".parquet.tmp")
         # Materialize parquet in memory and flush in one write(). pyarrow's
         # path-based writer uses an unbuffered FileOutputStream that emits
         # ~40 syscalls per segment (most <100B — page headers, footer
         # fragments). On a contended boot disk those serialize against the
         # I/O queue and dominate flush latency.
         buf = pa.BufferOutputStream()
+        # L0 segments do not get a parquet bloom filter on key_column:
+        # pyarrow 22.0 does not yet expose ``bloom_filter_options`` to
+        # Python (the C++ option exists; the binding hasn't shipped). L0
+        # segments are short-lived (compacted within seconds) so the
+        # missing bloom doesn't matter much in practice. Compacted output
+        # written by the DuckDB COPY does get blooms via DuckDB ≥1.2's
+        # default behavior.
         pq.write_table(
             sealed.table,
             buf,
@@ -746,15 +803,21 @@ class DiskLogNamespace:
             row_group_size=_ROW_GROUP_SIZE,
             write_page_index=True,
         )
-        with pa.OSFile(str(tmp_path), "wb") as out:
+        with pa.OSFile(str(staging_path), "wb") as out:
             out.write(buf.getvalue())
-        tmp_path.rename(filepath)
+        staging_path.rename(filepath)
+        # Compute key_column bounds from the in-memory table — much cheaper
+        # than re-opening the freshly written parquet and reading its footer.
+        min_key_value, max_key_value = self._key_bounds_from_table(sealed.table)
         seg = LocalSegment(
             path=str(filepath),
             size_bytes=filepath.stat().st_size,
+            level=0,
             min_seq=sealed.min_seq,
             max_seq=sealed.max_seq,
             row_count=sealed.table.num_rows,
+            min_key_value=min_key_value,
+            max_key_value=max_key_value,
         )
 
         with self._insertion_lock:
@@ -763,7 +826,7 @@ class DiskLogNamespace:
             self._catalog.upsert_segment(self._segment_to_row(seg))
 
         logger.info(
-            "Wrote tmp segment %s: rows=%d bytes=%d seq=[%d,%d] elapsed_ms=%d",
+            "Wrote L0 segment %s: rows=%d bytes=%d seq=[%d,%d] elapsed_ms=%d",
             filename,
             sealed.table.num_rows,
             seg.size_bytes,
@@ -772,128 +835,186 @@ class DiskLogNamespace:
             int((time.monotonic() - write_start) * 1000),
         )
 
-    def _compaction_step(self, *, compact_single: bool = False) -> None:
+    def _compaction_step(self) -> bool:
+        """Execute one planner-issued compaction job.
+
+        Returns ``True`` when a job ran (caller may immediately tick again
+        to drain pending work), ``False`` when the planner had nothing to
+        do.
+        """
         with self._insertion_lock:
-            tmps = [s for s in self._local_segments if _is_tmp_path(s.path)]
-        if not tmps:
-            return
-        if len(tmps) < 2 and not compact_single:
-            return
+            segment_rows = [self._segment_to_row(s) for s in self._local_segments]
+        job = self._compactor.plan(segment_rows, now_ms=int(time.time() * 1000))
+        if job is None:
+            return False
+        self._run_job(job)
+        return True
 
-        tmps.sort(key=lambda s: s.min_seq)
-        min_seq = tmps[0].min_seq
-        max_seq = max(t.max_seq for t in tmps)
-        merged_filename = _log_filename(min_seq)
-        compaction_start = time.monotonic()
+    def _force_compact_l0(self) -> None:
+        """Test-only hook: synthesize a one-shot L0 → L1 merge regardless of policy.
 
-        merged_path = self._data_dir / merged_filename
-        staging_path = merged_path.with_suffix(".parquet.tmp")
-        sql = self._build_compaction_sql([Path(t.path) for t in tmps], staging_path)
-        try:
-            with self._insertion_lock:
-                self._compaction_conn.execute(sql)
-        except Exception:
-            logger.warning("Compaction failed, leaving tmp segments in place", exc_info=True)
-            staging_path.unlink(missing_ok=True)
+        Production code (including ``close()``) never calls this — the
+        regular bg loop is planner-driven, and L0 segments are intentionally
+        kept local-only between compactions. Tests use this when they need
+        to assert against L1 state without configuring tiny ``level_targets``
+        on every fixture.
+        """
+        with self._insertion_lock:
+            l0 = sorted(
+                [self._segment_to_row(s) for s in self._local_segments if s.level == 0],
+                key=lambda r: r.min_seq,
+            )
+        if not l0:
             return
-        merged_seg = LocalSegment(
-            path=str(merged_path),
-            size_bytes=staging_path.stat().st_size,
-            min_seq=min_seq,
-            max_seq=max_seq,
-            row_count=sum(t.row_count for t in tmps),
+        job = CompactionJob(
+            inputs=tuple(l0),
+            output_level=1,
+            output_min_seq=min(r.min_seq for r in l0),
+            output_max_seq=max(r.max_seq for r in l0),
         )
+        self._run_job(job)
 
-        tmp_paths = {t.path for t in tmps}
-
-        self._query_visibility_lock.write_acquire()
-        try:
-            staging_path.rename(merged_path)
-            with self._insertion_lock:
-                new_segments: deque[LocalSegment] = deque()
-                merged_inserted = False
-                for s in self._local_segments:
-                    if s.path in tmp_paths:
-                        if not merged_inserted:
-                            new_segments.append(merged_seg)
-                            merged_inserted = True
-                    else:
-                        new_segments.append(s)
-                if not merged_inserted:
-                    new_segments.append(merged_seg)
-                self._local_segments = new_segments
-                self._catalog.replace_segments(
-                    self.name,
-                    removed_paths=list(tmp_paths),
-                    added=[self._segment_to_row(merged_seg)],
-                )
-            for t in tmps:
-                try:
-                    Path(t.path).unlink(missing_ok=True)
-                except OSError:
-                    logger.warning("Failed to unlink tmp segment %s", t.path, exc_info=True)
-        finally:
-            self._query_visibility_lock.write_release()
-
+    def _run_job(self, job: CompactionJob) -> None:
+        # Single-input jobs skip the rewrite and just rename + bump level —
+        # the rewrite would be a byte-for-byte copy.
+        if len(job.inputs) == 1:
+            self._apply_level_bump(job)
+        else:
+            self._apply_merge(job)
         with self._compaction_generation_cond:
             self._compaction_generation += 1
             self._compaction_generation_cond.notify_all()
 
+    def _apply_level_bump(self, job: CompactionJob) -> None:
+        old = job.inputs[0]
+        new_filename = seg_filename(level=job.output_level, min_seq=old.min_seq)
+        new_path = self._data_dir / new_filename
+        os.rename(old.path, new_path)
+
+        bumped = LocalSegment(
+            path=str(new_path),
+            size_bytes=old.byte_size,
+            level=job.output_level,
+            min_seq=old.min_seq,
+            max_seq=old.max_seq,
+            row_count=old.row_count,
+            min_key_value=old.min_key_value,
+            max_key_value=old.max_key_value,
+        )
+        self._commit_swap(removed=[old.path], added=bumped, unlink_removed=False)
+        logger.info("Level-bumped %s -> L%d (%s)", Path(old.path).name, job.output_level, new_filename)
+        self._copy_wake()
+
+    def _apply_merge(self, job: CompactionJob) -> None:
+        merged_filename = seg_filename(level=job.output_level, min_seq=job.output_min_seq)
+        merged_path = self._data_dir / merged_filename
+        staging_path = merged_path.with_suffix(".parquet.tmp")
+        sql = self._compactor.merge_sql(job, schema=self.schema, staging_path=staging_path)
+        compaction_start = time.monotonic()
+        # COPY reads input parquet files from disk and writes a staging file;
+        # it touches neither ``_local_segments`` nor any other structure that
+        # ``_insertion_lock`` protects, so we run it lock-free. A multi-second
+        # COPY would otherwise stall every concurrent ``append_log_batch``.
+        try:
+            self._compaction_conn.execute(sql)
+        except Exception:
+            logger.warning("Compaction failed, leaving inputs in place", exc_info=True)
+            staging_path.unlink(missing_ok=True)
+            return
+
+        # min-of-mins / max-of-maxes — string lex order matches parquet's
+        # BYTE_ARRAY UNSIGNED comparison.
+        merged_min_key, merged_max_key = aggregate_key_bounds((s.min_key_value, s.max_key_value) for s in job.inputs)
+        merged_seg = LocalSegment(
+            path=str(merged_path),
+            size_bytes=staging_path.stat().st_size,
+            level=job.output_level,
+            min_seq=job.output_min_seq,
+            max_seq=job.output_max_seq,
+            row_count=sum(s.row_count for s in job.inputs),
+            min_key_value=merged_min_key,
+            max_key_value=merged_max_key,
+        )
+
+        staging_path.rename(merged_path)
+        self._commit_swap(removed=[s.path for s in job.inputs], added=merged_seg, unlink_removed=True)
+
         logger.info(
-            "Compacted %d tmp segments into %s: bytes=%d seq=[%d,%d] elapsed_ms=%d",
-            len(tmps),
+            "Merged %d L%d -> L%d %s: bytes=%d seq=[%d,%d] elapsed_ms=%d",
+            len(job.inputs),
+            job.inputs[0].level,
+            job.output_level,
             merged_filename,
             merged_seg.size_bytes,
-            min_seq,
-            max_seq,
+            merged_seg.min_seq,
+            merged_seg.max_seq,
             int((time.monotonic() - compaction_start) * 1000),
         )
-        self._offload_to_gcs(merged_filename, merged_path)
-        self._evict_hook()
+        self._copy_wake()
 
-    def _build_compaction_sql(self, input_paths: list[Path], staging_path: Path) -> str:
-        """Compose the COPY that merges ``input_paths`` to ``staging_path``.
+    def _commit_swap(self, *, removed: list[str], added: LocalSegment, unlink_removed: bool) -> None:
+        """Splice the deque + catalog: replace ``removed`` paths with ``added``.
 
-        Columns missing from every input become ``NULL::TYPE AS name``.
-        ``union_by_name=true`` fills NULL where a column is absent from
-        individual segments.
+        ``unlink_removed`` is False for level bumps (the file was renamed
+        in place, so the old path is already gone) and True for merges
+        (the inputs are still on disk and need cleanup).
         """
-        present_columns = self._present_input_columns(input_paths)
-        select_exprs: list[str] = []
-        for col in self.schema.columns:
-            ident = quote_ident(col.name)
-            if col.name in present_columns:
-                select_exprs.append(ident)
-            else:
-                select_exprs.append(f"NULL::{duckdb_type_for(col)} AS {ident}")
-
-        # Self-generated paths from _tmp_filename — no SQL injection surface.
-        paths_sql = ", ".join(quote_literal(str(p)) for p in input_paths)
-        select_clause = ", ".join(select_exprs)
-        order_clause = self._compaction_order_clause()
-        return (
-            f"COPY (SELECT {select_clause} "
-            f"FROM read_parquet([{paths_sql}], union_by_name=true) "
-            f"{order_clause}) "
-            f"TO {quote_literal(str(staging_path))} "
-            f"(FORMAT 'parquet', ROW_GROUP_SIZE {_ROW_GROUP_SIZE}, COMPRESSION 'zstd', COMPRESSION_LEVEL 1)"
-        )
-
-    def _present_input_columns(self, input_paths: list[Path]) -> set[str]:
-        present: set[str] = set()
-        for p in input_paths:
-            schema = pq.read_schema(p)
-            present.update(schema.names)
-        return present
-
-    def _compaction_order_clause(self) -> str:
-        cols = ", ".join(quote_ident(name) for name in self._compaction_sort_keys())
-        return f"ORDER BY {cols}"
-
-    def sealed_segments(self) -> list[LocalSegment]:
-        """Return flushed (logs_*) segments only, oldest first."""
+        removed_set = set(removed)
         with self._insertion_lock:
-            return [s for s in self._local_segments if not _is_tmp_path(s.path)]
+            new_segments: deque[LocalSegment] = deque()
+            inserted = False
+            for s in self._local_segments:
+                if s.path in removed_set:
+                    if not inserted:
+                        new_segments.append(added)
+                        inserted = True
+                else:
+                    new_segments.append(s)
+            if not inserted:
+                new_segments.append(added)
+            self._local_segments = new_segments
+            self._catalog.replace_segments(
+                self.name,
+                removed_paths=removed,
+                added=[self._segment_to_row(added)],
+            )
+        if unlink_removed:
+            for path in removed:
+                try:
+                    Path(path).unlink(missing_ok=True)
+                except OSError:
+                    logger.warning("Failed to unlink merged input %s", path, exc_info=True)
+
+    def _eviction_step(self) -> None:
+        """Evict the namespace's oldest L>=1 copied segments until under caps.
+
+        Runs at the tail of every compaction tick. Per-namespace caps live
+        on ``CompactionConfig`` (``max_segments_per_namespace``,
+        ``max_bytes_per_namespace``); FIFO-by-min_seq picks the oldest
+        eligible segment.
+        """
+        config = self._compactor.config
+        while True:
+            with self._insertion_lock:
+                seg_count = len(self._local_segments)
+                byte_total = sum(s.size_bytes for s in self._local_segments)
+            if seg_count <= config.max_segments_per_namespace and byte_total <= config.max_bytes_per_namespace:
+                return
+            with self._insertion_lock:
+                row = self._catalog.select_eviction_candidate(self.name)
+            if row is None:
+                # Over the cap but nothing eligible (everything still L0,
+                # or terminal segments not yet copied). Bail and let the
+                # next tick try again.
+                return
+            self.evict_segment(row.path)
+            logger.info(
+                "Evicted L%d segment %s (bytes=%d, remaining=%d segments)",
+                row.level,
+                Path(row.path).name,
+                row.byte_size,
+                seg_count - 1,
+            )
 
     def query_snapshot(self) -> tuple[list[LocalSegment], list[pa.Table]]:
         """Return all currently queryable local segments and RAM tables."""
@@ -903,6 +1024,19 @@ class DiskLogNamespace:
     def all_segments_unlocked(self) -> list[LocalSegment]:
         """Snapshot every locally-tracked segment. Caller MUST hold the insertion lock."""
         return list(self._local_segments)
+
+    def mark_copied(self, path: str, copied_at_ms: int) -> None:
+        """Stamp the catalog row + in-memory deque after a copy upload completes.
+
+        The copy worker calls this from its own thread; ``_insertion_lock``
+        serializes it against the bg thread's catalog mutations.
+        """
+        with self._insertion_lock:
+            for s in self._local_segments:
+                if s.path == path:
+                    s.copied_at_ms = copied_at_ms
+                    break
+            self._catalog.mark_copied(self.name, path, copied_at_ms)
 
     def evict_segment(self, path: str) -> int:
         """Remove ``path`` from tracking and unlink the file. Returns bytes freed."""
@@ -971,26 +1105,6 @@ class DiskLogNamespace:
             min_seq=min_seq,
             max_seq=max_seq,
             segment_count=len(self._local_segments),
-        )
-
-    def _offload_to_gcs(self, filename: str, filepath: Path) -> None:
-        if not self._remote_log_dir:
-            return
-
-        remote_path = f"{self._remote_log_dir.rstrip('/')}/{self.name}/{filename}"
-        upload_start = time.monotonic()
-        try:
-            with fsspec.core.open(str(filepath), "rb") as f_src, fsspec.core.open(remote_path, "wb") as f_dst:
-                f_dst.write(f_src.read())
-        except Exception:
-            logger.warning("Failed to offload %s to GCS", filepath, exc_info=True)
-            return
-        logger.info(
-            "Offloaded %s to %s: bytes=%d elapsed_ms=%d",
-            filename,
-            remote_path,
-            filepath.stat().st_size,
-            int((time.monotonic() - upload_start) * 1000),
         )
 
     def _execute_read(
@@ -1149,9 +1263,6 @@ class MemoryLogNamespace:
         with self._insertion_lock:
             return [], [self._table]
 
-    def sealed_segments(self) -> list[LocalSegment]:
-        return []
-
     def all_segments_unlocked(self) -> list[LocalSegment]:
         return []
 
@@ -1166,6 +1277,9 @@ class MemoryLogNamespace:
     def evict_segment(self, path: str) -> int:
         return 0
 
+    def mark_copied(self, path: str, copied_at_ms: int) -> None:
+        return None
+
     def remove_local_storage(self) -> None:
         with self._insertion_lock:
             self._table = self._arrow_schema.empty_table()
@@ -1175,12 +1289,6 @@ class MemoryLogNamespace:
 
     def stop_and_join(self) -> None:
         return
-
-    def ram_bytes(self) -> int:
-        return 0
-
-    def chunk_count(self) -> int:
-        return 0
 
     def stats(self) -> NamespaceStats:
         with self._insertion_lock:

--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -412,6 +412,10 @@ class LogNamespaceProtocol(Protocol):
 
     def stats(self) -> NamespaceStats: ...
 
+    def ram_bytes(self) -> int: ...
+
+    def chunk_count(self) -> int: ...
+
 
 class DiskLogNamespace:
     """Disk-backed per-namespace storage.
@@ -657,6 +661,12 @@ class DiskLogNamespace:
         self._wake.set()
         self._bg_thread.join()
         self._compaction_conn.close()
+
+    def ram_bytes(self) -> int:
+        return self._buffers.ram_bytes()
+
+    def chunk_count(self) -> int:
+        return self._buffers.chunk_count()
 
     def update_schema(self, new_schema: Schema) -> None:
         _assert_additive_schema_evolution(self.schema, new_schema)
@@ -1365,6 +1375,12 @@ class MemoryLogNamespace:
 
     def stop_and_join(self) -> None:
         return
+
+    def ram_bytes(self) -> int:
+        return 0
+
+    def chunk_count(self) -> int:
+        return 0
 
     def stats(self) -> NamespaceStats:
         with self._insertion_lock:

--- a/lib/finelog/src/finelog/store/migrations/0001_init.py
+++ b/lib/finelog/src/finelog/store/migrations/0001_init.py
@@ -16,10 +16,13 @@ this migration is a no-op against the DDL but records v1 in
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import duckdb
 
 
-def migrate(conn: duckdb.DuckDBPyConnection) -> None:
+def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir: Path | None) -> None:
+    del data_dir
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS namespaces (

--- a/lib/finelog/src/finelog/store/migrations/0002_segment_key_value_bounds.py
+++ b/lib/finelog/src/finelog/store/migrations/0002_segment_key_value_bounds.py
@@ -1,0 +1,28 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add per-segment ``key_column`` value bounds to the catalog.
+
+Each registered ``Schema`` may declare a ``key_column`` — the column the
+segment is sorted by inside its parquet file (see
+``compaction_sort_keys`` in ``compactor.py``).
+Tracking that column's min/max in the catalog lets future read paths
+prune the segment list before opening any parquet footer.
+
+Both columns are nullable: namespaces that don't declare a ``key_column``
+(e.g. iris worker stats) leave them ``NULL``. ``reconcile_segments``
+populates existing rows on the next process boot from the parquet
+footers, so this migration does not backfill itself.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+
+
+def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir: Path | None) -> None:
+    del data_dir
+    conn.execute("ALTER TABLE segments ADD COLUMN IF NOT EXISTS min_key_value TEXT")
+    conn.execute("ALTER TABLE segments ADD COLUMN IF NOT EXISTS max_key_value TEXT")

--- a/lib/finelog/src/finelog/store/migrations/0003_segment_level.py
+++ b/lib/finelog/src/finelog/store/migrations/0003_segment_level.py
@@ -1,0 +1,141 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Replace the lifecycle ``state`` column with a numeric ``level``.
+
+Before this migration, segment lifecycle was encoded in two places:
+
+* ``segments.state`` — a TEXT column containing ``'tmp'`` (post-flush) or
+  ``'finalized'`` (post-compaction).
+* The on-disk filename — ``tmp_<seq>.parquet`` or ``logs_<seq>.parquet``.
+
+The leveled compaction scheme replaces both with a numeric tier:
+``segments.level`` (0 = freshly flushed; promoted to ``level + 1`` when the
+planner picks it up) and ``seg_L<n>_<min_seq:019d>.parquet`` filenames.
+After this migration there is no ``state`` column and no ``tmp_*`` /
+``logs_*`` filename to worry about.
+
+Resumability
+------------
+The DB-level work (ADD/DROP COLUMN, UPDATE) runs inside the migration
+runner's enclosing transaction, so it's atomic. The filesystem rename is
+not, but each ``os.rename`` is. We walk every segment row, derive the
+target filename from ``(level, min_seq)``, and rename the file:
+
+* If the source still exists and the destination doesn't, ``os.rename``.
+* If the destination already exists (a prior crashed pass moved it),
+  treat the source as a duplicate, assert size match, ``unlink`` source.
+* If neither exists, the parquet is gone — leave the catalog row in
+  place; ``DiskLogNamespace`` boot reconciliation will drop it once the
+  store opens.
+
+In every case the catalog row's ``path`` is rewritten to the new name.
+A re-run after partial filesystem progress converges, because the
+``UPDATE segments SET path = ?`` is a no-op against rows already pointing
+at the new name.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+
+import duckdb
+
+logger = logging.getLogger(__name__)
+
+_OLD_FILENAME_RE = re.compile(r"^(?P<prefix>tmp_|logs_)(?P<seq>\d+)\.parquet$")
+
+
+def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir: Path | None) -> None:
+    # ---- DB schema rewrite -------------------------------------------------
+    # DuckDB rejects ``ADD COLUMN ... NOT NULL`` against an existing table,
+    # so the column lands nullable and we rely on application code to set
+    # ``level`` on every insert going forward. Backfill (only when ``state``
+    # is still present, i.e. first-time apply): ``finalized`` rows become
+    # L1, ``tmp`` rows become L0. A re-run after a partial crash is a
+    # clean no-op for the SQL phase.
+    conn.execute("ALTER TABLE segments ADD COLUMN IF NOT EXISTS level INTEGER")
+    state_present = bool(
+        conn.execute(
+            "SELECT 1 FROM information_schema.columns " "WHERE table_name = 'segments' AND column_name = 'state' LIMIT 1"
+        ).fetchone()
+    )
+    if state_present:
+        conn.execute("UPDATE segments SET level = CASE WHEN state = 'finalized' THEN 1 ELSE 0 END")
+        conn.execute("ALTER TABLE segments DROP COLUMN state")
+    conn.execute("CREATE INDEX IF NOT EXISTS segments_ns_level_minseq ON segments (namespace, level, min_seq)")
+
+    if data_dir is None:
+        # In-memory store has no parquet files to rename.
+        return
+
+    # ---- Filesystem + path rewrite ----------------------------------------
+    # Catalog-known files come with an explicit level (from the backfill
+    # above). Files on disk that the catalog doesn't yet track (e.g. an
+    # older install pre-dating the catalog branch) get their level from
+    # the legacy filename prefix: ``tmp_*`` → 0, ``logs_*`` → 1.
+    catalog_paths: dict[str, tuple[str, int]] = {}
+    rows = conn.execute("SELECT namespace, path, level FROM segments").fetchall()
+    for namespace, old_path, level in rows:
+        catalog_paths[old_path] = (namespace, level)
+
+    for namespace_dir in sorted(p for p in data_dir.iterdir() if p.is_dir()):
+        for old in sorted(list(namespace_dir.glob("tmp_*.parquet")) + list(namespace_dir.glob("logs_*.parquet"))):
+            old_str = str(old)
+            if old_str in catalog_paths:
+                namespace, level = catalog_paths[old_str]
+            else:
+                level = 0 if old.name.startswith("tmp_") else 1
+                namespace = None  # not in catalog; rename is purely filesystem
+            new = _rewrite_one(old, level)
+            if new is None or new == old:
+                continue
+            if namespace is not None:
+                conn.execute(
+                    "UPDATE segments SET path = ? WHERE namespace = ? AND path = ?",
+                    [str(new), namespace, old_str],
+                )
+
+
+def _rewrite_one(old: Path, level: int) -> Path | None:
+    """Rename ``old`` to the leveled scheme. Resumable across crashes.
+
+    Returns the destination path (which may equal ``old`` if the file has
+    already been renamed in a previous pass), or ``None`` if the filename
+    isn't recognized as either old or new format.
+    """
+    name = old.name
+    match = _OLD_FILENAME_RE.match(name)
+    if match is None:
+        # Already in seg_L<n>_<seq>.parquet form, or some unrelated file —
+        # nothing to do.
+        return old if name.startswith("seg_L") else None
+    seq = int(match.group("seq"))
+    new_name = f"seg_L{level}_{seq:019d}.parquet"
+    new = old.with_name(new_name)
+
+    src_exists = old.exists()
+    dst_exists = new.exists()
+
+    if dst_exists and src_exists:
+        # Prior crashed run moved the file then died before the DB UPDATE
+        # committed. Source is the duplicate.
+        src_size = old.stat().st_size
+        dst_size = new.stat().st_size
+        if src_size != dst_size:
+            raise RuntimeError(f"migration 0003: size mismatch on resume for {old.name}: src={src_size} dst={dst_size}")
+        old.unlink()
+        return new
+    if src_exists:
+        os.rename(old, new)
+        return new
+    if dst_exists:
+        # File already at destination; just rewrite the catalog row.
+        return new
+    # Neither file present. The boot-time reconciliation will drop the
+    # catalog row when the namespace opens and walks the directory.
+    logger.warning("migration 0003: parquet missing for both %s and %s", old, new)
+    return new

--- a/lib/finelog/src/finelog/store/migrations/0004_segment_copied_at.py
+++ b/lib/finelog/src/finelog/store/migrations/0004_segment_copied_at.py
@@ -1,0 +1,30 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add ``segments.copied_at_ms`` to gate eviction on remote durability.
+
+Eviction picks the oldest L_>=1 segment in each namespace; without this
+column, a freshly-compacted segment could be deleted in the window
+between rename and copy completion. The :class:`CopyWorker`
+stamps ``copied_at_ms`` when the upload finishes, and the eviction
+query in :class:`Catalog.select_eviction_candidate` filters on it.
+
+Existing rows from before this migration get ``NULL`` and are therefore
+not evictable until a subsequent boot's reconciliation either re-uploads
+them or marks them locally-only. In practice the production registry
+runs migration 0003 and 0004 together as part of the leveled compaction
+ship; the operator restarts the service, the copy worker stamps the
+existing finalized segments on first compaction round, and eviction
+catches up.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+
+
+def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir: Path | None) -> None:
+    del data_dir
+    conn.execute("ALTER TABLE segments ADD COLUMN IF NOT EXISTS copied_at_ms BIGINT")

--- a/lib/finelog/src/finelog/store/migrations/_runner.py
+++ b/lib/finelog/src/finelog/store/migrations/_runner.py
@@ -80,11 +80,15 @@ def _load_migration(path: Path):
 def apply_migrations(
     conn: duckdb.DuckDBPyConnection,
     migrations_dir: Path | None = None,
+    *,
+    data_dir: Path | None = None,
 ) -> None:
     """Apply pending migrations from ``migrations_dir`` to ``conn``.
 
-    ``migrations_dir`` defaults to this package's directory so callers from
-    ``RegistryDB`` don't need to know where the files live.
+    ``migrations_dir`` defaults to this package's directory. ``data_dir``
+    is the parent directory of the registry DB and is forwarded to any
+    migration whose ``migrate`` signature declares a ``data_dir`` parameter.
+    Migrations that need to rename on-disk parquet files use it.
     """
     if migrations_dir is None:
         migrations_dir = Path(__file__).parent
@@ -102,7 +106,7 @@ def apply_migrations(
         t0 = time.monotonic()
         migrate = _load_migration(path)
         with transactional(conn):
-            migrate(conn)
+            migrate(conn, data_dir=data_dir)
             conn.execute(
                 "INSERT INTO schema_migrations(name, applied_at_ms) VALUES (?, ?)",
                 [path.name, int(time.time() * 1000)],

--- a/lib/finelog/tests/conftest.py
+++ b/lib/finelog/tests/conftest.py
@@ -49,10 +49,10 @@ def _worker_batch(worker_ids: list[str], mem_bytes: list[int], ts: list[int]) ->
 
 
 def _seal(store: DuckDBLogStore, namespace: str) -> None:
-    """Flush and compact so the namespace's data is visible to queries."""
+    """Flush and drain L0 so the namespace's data is on the L1 tier."""
     ns = store._namespaces[namespace]
     ns._flush_step()
-    ns._compaction_step(compact_single=True)
+    ns._force_compact_l0()
 
 
 @pytest.fixture()

--- a/lib/finelog/tests/test_asgi.py
+++ b/lib/finelog/tests/test_asgi.py
@@ -97,7 +97,7 @@ def test_query_and_drop_via_asgi(tmp_path: Path):
 
             ns = log_service.log_store._namespaces["iris.worker"]
             ns._flush_step()
-            ns._compaction_step(compact_single=True)
+            ns._force_compact_l0()
 
             resp = client.post(
                 "/finelog.stats.StatsService/Query",

--- a/lib/finelog/tests/test_catalog_stats.py
+++ b/lib/finelog/tests/test_catalog_stats.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import pytest
 from finelog.rpc import logging_pb2
-from finelog.store.catalog import Catalog, NamespaceStats, SegmentState
+from finelog.store.catalog import Catalog, NamespaceStats
 from finelog.store.duckdb_store import DuckDBLogStore
 
 from tests.conftest import _ipc_bytes, _seal, _worker_batch, _worker_schema
@@ -29,7 +29,10 @@ def _stats(store: DuckDBLogStore, namespace: str) -> NamespaceStats:
 
 
 def _segments(store: DuckDBLogStore, namespace: str):
-    return store._catalog.list_segments(namespace)
+    # DuckDB conns aren't thread-safe; catalog reads serialize on the
+    # store's insertion lock, same contract as the production code.
+    with store._insertion_lock:
+        return store._catalog.list_segments(namespace)
 
 
 # ---------------------------------------------------------------------------
@@ -67,29 +70,29 @@ def test_stats_after_flush_match_segments_table(store):
 
     segs = _segments(store, "iris.worker")
     assert len(segs) == 1
-    assert segs[0].state == SegmentState.TMP
+    assert segs[0].level == 0
     assert segs[0].row_count == 2
     assert segs[0].min_seq == 1
     assert segs[0].max_seq == 2
 
 
-def test_compaction_replaces_tmp_rows_atomically(store):
+def test_compaction_replaces_l0_rows_atomically(store):
     store.register_table("iris.worker", _worker_schema())
     for i in range(3):
         batch = _worker_batch([f"w-{i}"], [i], [i])
         store.write_rows("iris.worker", _ipc_bytes(batch))
         store._namespaces["iris.worker"]._flush_step()
 
-    # Three tmp segments before compaction.
+    # Three L0 segments before compaction.
     pre = _segments(store, "iris.worker")
     assert len(pre) == 3
-    assert all(s.state == SegmentState.TMP for s in pre)
+    assert all(s.level == 0 for s in pre)
 
-    store._namespaces["iris.worker"]._compaction_step(compact_single=True)
+    store._namespaces["iris.worker"]._force_compact_l0()
 
     post = _segments(store, "iris.worker")
     assert len(post) == 1
-    assert post[0].state == SegmentState.FINALIZED
+    assert post[0].level == 1
     assert post[0].row_count == 3
     assert post[0].min_seq == 1
     assert post[0].max_seq == 3
@@ -163,6 +166,30 @@ def test_segments_catalog_survives_restart(tmp_path):
         s2.close()
 
 
+def test_reconcile_preserves_copied_at_ms(tmp_path):
+    """A successful upload's stamp survives the next-boot reconcile pass."""
+    log_dir = tmp_path / "store"
+    s1 = DuckDBLogStore(log_dir=log_dir)
+    s1.register_table("iris.worker", _worker_schema())
+    s1.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-0"], [1], [1])))
+    _seal(s1, "iris.worker")
+    seg = _segments(s1, "iris.worker")[0]
+    # Simulate a successful copy: stamp the catalog row.
+    s1._namespaces["iris.worker"].mark_copied(seg.path, copied_at_ms=12345)
+    assert _segments(s1, "iris.worker")[0].copied_at_ms == 12345
+    s1.close()
+
+    s2 = DuckDBLogStore(log_dir=log_dir)
+    try:
+        rows = _segments(s2, "iris.worker")
+        assert len(rows) == 1
+        assert rows[0].path == seg.path
+        # Reconcile rewrites the row but keeps the copy stamp.
+        assert rows[0].copied_at_ms == 12345
+    finally:
+        s2.close()
+
+
 def test_reconcile_drops_rows_for_missing_files(tmp_path):
     """An out-of-band parquet deletion is reflected after a restart."""
     log_dir = tmp_path / "store"
@@ -212,6 +239,93 @@ def test_log_namespace_stats_count_pushed_logs(store):
 
 
 # ---------------------------------------------------------------------------
+# key_column value bounds (catalog 0002)
+# ---------------------------------------------------------------------------
+
+
+def _flush_one(store: DuckDBLogStore, namespace: str) -> None:
+    store._namespaces[namespace]._flush_step()
+
+
+def test_key_value_bounds_populated_for_log_namespace(store):
+    entries = [
+        logging_pb2.LogEntry(
+            timestamp=logging_pb2.Timestamp(epoch_ms=ts),
+            source="stdout",
+            data=f"hello-{ts}",
+        )
+        for ts in (10, 20, 30)
+    ]
+    store.append("/system/aaa", entries)
+    store.append("/system/zzz", entries)
+    _flush_one(store, "log")
+
+    segs = _segments(store, "log")
+    assert len(segs) == 1
+    # ``key`` is the schema's key_column; bounds should bracket the
+    # smallest and largest source keys we just appended.
+    assert segs[0].min_key_value == "/system/aaa"
+    assert segs[0].max_key_value == "/system/zzz"
+
+
+def test_key_value_bounds_survive_compaction(store):
+    store.append(
+        "/system/aaa",
+        [logging_pb2.LogEntry(timestamp=logging_pb2.Timestamp(epoch_ms=1), source="s", data="x")],
+    )
+    _flush_one(store, "log")
+    store.append(
+        "/system/zzz",
+        [logging_pb2.LogEntry(timestamp=logging_pb2.Timestamp(epoch_ms=2), source="s", data="x")],
+    )
+    _flush_one(store, "log")
+
+    pre = _segments(store, "log")
+    assert {s.min_key_value for s in pre} == {"/system/aaa", "/system/zzz"}
+
+    store._namespaces["log"]._force_compact_l0()
+
+    post = _segments(store, "log")
+    assert len(post) == 1
+    # min-of-mins / max-of-maxes across the two tmp inputs.
+    assert post[0].min_key_value == "/system/aaa"
+    assert post[0].max_key_value == "/system/zzz"
+
+
+def test_key_value_bounds_null_when_schema_has_no_key_column(store):
+    store.register_table("iris.worker", _worker_schema())
+    store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-0"], [1], [1])))
+    _seal(store, "iris.worker")
+
+    segs = _segments(store, "iris.worker")
+    assert len(segs) == 1
+    # _worker_schema() declares key_column=""; bounds remain unset.
+    assert segs[0].min_key_value is None
+    assert segs[0].max_key_value is None
+
+
+def test_key_value_bounds_repopulated_on_reconcile(tmp_path):
+    log_dir = tmp_path / "store"
+    s1 = DuckDBLogStore(log_dir=log_dir)
+    s1.append(
+        "/system/mid",
+        [logging_pb2.LogEntry(timestamp=logging_pb2.Timestamp(epoch_ms=1), source="s", data="x")],
+    )
+    _seal(s1, "log")
+    s1.close()
+
+    s2 = DuckDBLogStore(log_dir=log_dir)
+    try:
+        # Reconciliation re-derived the bounds from the parquet footer.
+        segs = _segments(s2, "log")
+        assert len(segs) == 1
+        assert segs[0].min_key_value == "/system/mid"
+        assert segs[0].max_key_value == "/system/mid"
+    finally:
+        s2.close()
+
+
+# ---------------------------------------------------------------------------
 # Catalog unit checks
 # ---------------------------------------------------------------------------
 
@@ -225,7 +339,7 @@ def test_registry_replace_segments_is_atomic(tmp_path):
     initial = SegmentRow(
         namespace="ns",
         path="/old.parquet",
-        state=SegmentState.TMP,
+        level=0,
         min_seq=1,
         max_seq=10,
         row_count=10,
@@ -240,7 +354,7 @@ def test_registry_replace_segments_is_atomic(tmp_path):
     bad = SegmentRow(
         namespace="ns",
         path="/new.parquet",
-        state=SegmentState.FINALIZED,
+        level=1,
         min_seq=1,
         max_seq=10,
         row_count=10,

--- a/lib/finelog/tests/test_compactor.py
+++ b/lib/finelog/tests/test_compactor.py
@@ -1,0 +1,107 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the leveled compaction planner.
+
+These exercise ``Compactor.plan`` and ``aggregate_key_bounds`` directly,
+without spinning up a full ``DuckDBLogStore``. The store-level integration
+tests (test_duckdb_store, test_query, test_eviction) cover the wired-up
+behavior; this file isolates the policy decisions so a regression in the
+planner shows up with a clear failure.
+"""
+
+from __future__ import annotations
+
+from finelog.store.catalog import SegmentRow
+from finelog.store.compactor import (
+    CompactionConfig,
+    Compactor,
+    aggregate_key_bounds,
+)
+
+
+def _row(
+    *,
+    level: int,
+    min_seq: int,
+    max_seq: int,
+    byte_size: int,
+    created_at_ms: int = 0,
+) -> SegmentRow:
+    return SegmentRow(
+        namespace="ns",
+        path=f"/x/seg_L{level}_{min_seq:019d}.parquet",
+        level=level,
+        min_seq=min_seq,
+        max_seq=max_seq,
+        row_count=max_seq - min_seq + 1,
+        byte_size=byte_size,
+        created_at_ms=created_at_ms,
+    )
+
+
+def test_plan_returns_none_when_under_target():
+    compactor = Compactor(CompactionConfig(level_targets=(1024,), max_l0_age_sec=0))
+    rows = [_row(level=0, min_seq=1, max_seq=1, byte_size=128)]
+    assert compactor.plan(rows, now_ms=0) is None
+
+
+def test_plan_promotes_when_byte_target_reached():
+    compactor = Compactor(CompactionConfig(level_targets=(1024,), max_l0_age_sec=0))
+    rows = [
+        _row(level=0, min_seq=1, max_seq=1, byte_size=512),
+        _row(level=0, min_seq=2, max_seq=2, byte_size=512),
+    ]
+    job = compactor.plan(rows, now_ms=0)
+    assert job is not None
+    assert job.output_level == 1
+    assert [r.min_seq for r in job.inputs] == [1, 2]
+
+
+def test_plan_promotes_aged_l0_below_target():
+    """L0 segments past ``max_l0_age_sec`` promote regardless of byte target.
+
+    Regression for the bug where ``_segment_to_row`` overwrote
+    ``created_at_ms`` with ``time.time()`` on every tick — under that bug
+    this case would never fire because each plan tick would observe a
+    "freshly created" row.
+    """
+    compactor = Compactor(CompactionConfig(level_targets=(1 << 30,), max_l0_age_sec=300.0))
+    rows = [
+        _row(level=0, min_seq=1, max_seq=1, byte_size=128, created_at_ms=0),
+        _row(level=0, min_seq=2, max_seq=2, byte_size=128, created_at_ms=0),
+    ]
+    # Five minutes after birth — exactly at the threshold.
+    job = compactor.plan(rows, now_ms=300_000)
+    assert job is not None
+    assert job.output_level == 1
+    assert [r.min_seq for r in job.inputs] == [1, 2]
+
+
+def test_plan_does_not_age_terminal_level():
+    compactor = Compactor(CompactionConfig(level_targets=(1024,), max_l0_age_sec=300.0))
+    rows = [_row(level=1, min_seq=1, max_seq=1, byte_size=128, created_at_ms=0)]
+    assert compactor.plan(rows, now_ms=10**12) is None
+
+
+def test_aggregate_key_bounds_preserves_numeric_ordering():
+    """Regression: stringified ``"10" < "2"`` would invert numeric bounds."""
+    lo, hi = aggregate_key_bounds([(2, 10), (5, 7)])
+    assert lo == 2
+    assert hi == 10
+
+
+def test_aggregate_key_bounds_handles_strings():
+    lo, hi = aggregate_key_bounds([("alice", "bob"), ("carol", "dave")])
+    assert lo == "alice"
+    assert hi == "dave"
+
+
+def test_aggregate_key_bounds_skips_none_inputs():
+    lo, hi = aggregate_key_bounds([(None, None), (3, 9)])
+    assert lo == 3
+    assert hi == 9
+
+
+def test_aggregate_key_bounds_all_none():
+    assert aggregate_key_bounds([(None, None), (None, None)]) == (None, None)

--- a/lib/finelog/tests/test_concurrency.py
+++ b/lib/finelog/tests/test_concurrency.py
@@ -62,7 +62,7 @@ def test_drop_during_concurrent_write_is_safe(store: DuckDBLogStore):
         assert "iris.worker" in store._namespaces
         ns = store._namespaces["iris.worker"]
         ns._flush_step()
-        ns._compaction_step(compact_single=True)
+        ns._force_compact_l0()
         table = store.query('SELECT worker_id FROM "iris.worker"')
         assert table.num_rows == successes
 
@@ -127,7 +127,7 @@ def test_query_acquires_read_lock_for_duration(store: DuckDBLogStore):
     ns = store._namespaces["iris.worker"]
     store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-1"], [100], [1])))
     ns._flush_step()
-    ns._compaction_step(compact_single=True)
+    ns._force_compact_l0()
 
     rwlock = store._query_visibility_lock
     write_held_during_query: list[bool] = []

--- a/lib/finelog/tests/test_drop.py
+++ b/lib/finelog/tests/test_drop.py
@@ -19,7 +19,7 @@ def test_drop_table_removes_namespace(store: DuckDBLogStore):
     _seal(store, "iris.worker")
 
     ns = store._namespaces["iris.worker"]
-    assert ns.sealed_segments(), "expected at least one sealed segment after _seal"
+    assert any(s.level >= 1 for s in ns.all_segments_unlocked()), "expected an L>=1 segment after _seal"
 
     store.drop_table("iris.worker")
 
@@ -82,12 +82,15 @@ def test_drop_table_does_not_delete_remote_objects(tmp_path: Path):
         ns = store._namespaces["iris.worker"]
         ns._flush_step()
         # Only compacted segments are uploaded.
-        ns._compaction_step(compact_single=True)
+        ns._force_compact_l0()
+        # Copy is async; wait for the worker to drain before asserting the
+        # file is visible at the destination.
+        assert store._wait_for_copies(timeout=5.0)
 
         remote_ns_dir = remote / "iris.worker"
         assert remote_ns_dir.exists()
         remote_files_before = sorted(p.name for p in remote_ns_dir.glob("*.parquet"))
-        assert remote_files_before, "expected at least one offloaded segment"
+        assert remote_files_before, "expected at least one copied segment"
 
         store.drop_table("iris.worker")
 

--- a/lib/finelog/tests/test_duckdb_store.py
+++ b/lib/finelog/tests/test_duckdb_store.py
@@ -63,12 +63,12 @@ def test_flush_and_compaction(tmp_path: Path):
         for batch in range(3):
             store.append(KEY, [_entry(f"b{batch}-{i}", epoch_ms=batch * 10 + i) for i in range(5)])
             store._force_flush()
-        assert len(sorted(namespace_dir.glob("tmp_*.parquet"))) == 3
+        assert len(sorted(namespace_dir.glob("seg_L0_*.parquet"))) == 3
 
         store._force_compaction()
 
-        assert len(sorted(namespace_dir.glob("tmp_*.parquet"))) == 0
-        assert len(sorted(namespace_dir.glob("logs_*.parquet"))) == 1
+        assert len(sorted(namespace_dir.glob("seg_L0_*.parquet"))) == 0
+        assert len(sorted(namespace_dir.glob("seg_L1_*.parquet"))) == 1
 
         result = store.get_logs(KEY)
         assert len(result.entries) == 15

--- a/lib/finelog/tests/test_eviction.py
+++ b/lib/finelog/tests/test_eviction.py
@@ -3,48 +3,97 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
+from finelog.store.compactor import CompactionConfig
 from finelog.store.duckdb_store import DuckDBLogStore
 
 from tests.conftest import _ipc_bytes, _seal, _worker_batch, _worker_schema
 
 
-def test_eviction_drops_globally_oldest_segment(tmp_path: Path):
-    """One global cap, two namespaces — oldest sealed segment evicted."""
+def _list_segments_locked(store: DuckDBLogStore, namespace: str):
+    """Catalog read serialized against the bg threads (copy worker, bg loop).
+
+    DuckDB connections aren't thread-safe and the catalog docstring is
+    explicit that callers hold ``_insertion_lock``. Tests that read directly
+    must do the same.
+    """
+    with store._insertion_lock:
+        return store._catalog.list_segments(namespace)
+
+
+def _wait_until_copied(store: DuckDBLogStore, namespace: str, timeout: float = 5.0) -> None:
+    """Block until every L>=1 catalog row in ``namespace`` has ``copied_at_ms``.
+
+    Eviction is gated on the copy stamp; tests that target eviction must
+    wait for the worker before they can assert anything about it.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        rows = _list_segments_locked(store, namespace)
+        if rows and all(r.copied_at_ms is not None for r in rows if r.level >= 1):
+            return
+        time.sleep(0.05)
+
+
+def test_eviction_drops_oldest_segment_when_cap_exceeded(tmp_path: Path):
+    """Per-namespace caps: oldest L>=1 copied segment is dropped first."""
+    config = CompactionConfig(max_segments_per_namespace=1, level_targets=(1,))
     store = DuckDBLogStore(
         log_dir=tmp_path / "data",
-        max_local_segments=1,
+        remote_log_dir=str(tmp_path / "remote"),
+        compaction_config=config,
     )
     try:
         schema = _worker_schema()
-        store.register_table("a.first", schema)
-        store.register_table("b.second", schema)
+        store.register_table("ns", schema)
 
-        store.write_rows("a.first", _ipc_bytes(_worker_batch(["a"], [1], [1])))
-        _seal(store, "a.first")
+        store.write_rows("ns", _ipc_bytes(_worker_batch(["a"], [1], [1])))
+        _seal(store, "ns")
+        _wait_until_copied(store, "ns")
+        first_l1 = sorted((tmp_path / "data" / "ns").glob("seg_L1_*.parquet"))
+        assert len(first_l1) == 1
+        first_path = first_l1[0]
 
-        a_files_after_first = sorted((tmp_path / "data" / "a.first").glob("logs_*.parquet"))
-        assert len(a_files_after_first) == 1
+        store.write_rows("ns", _ipc_bytes(_worker_batch(["b"], [2], [2])))
+        _seal(store, "ns")
+        _wait_until_copied(store, "ns")
+        # Drive the eviction tick (compaction tail invokes _eviction_step).
+        store._namespaces["ns"]._eviction_step()
 
-        store.write_rows("b.second", _ipc_bytes(_worker_batch(["b"], [2], [2])))
-        _seal(store, "b.second")
+        remaining = sorted((tmp_path / "data" / "ns").glob("seg_L1_*.parquet"))
+        assert len(remaining) == 1
+        assert remaining[0] != first_path
+    finally:
+        store.close()
 
-        b_files = sorted((tmp_path / "data" / "b.second").glob("logs_*.parquet"))
-        assert len(b_files) == 1
-        a_files = sorted((tmp_path / "data" / "a.first").glob("logs_*.parquet"))
-        assert a_files == []
 
-        # Eviction removes local files, not the registration.
-        assert "a.first" in store._namespaces
+def test_eviction_skips_segments_not_yet_copied(tmp_path: Path):
+    """A freshly-promoted L1 segment is not evicted until the upload completes."""
+    config = CompactionConfig(max_segments_per_namespace=1, level_targets=(1,))
+    # No remote_log_dir → no copy worker → copied_at_ms stays NULL.
+    store = DuckDBLogStore(log_dir=tmp_path / "data", compaction_config=config)
+    try:
+        store.register_table("ns", _worker_schema())
+        store.write_rows("ns", _ipc_bytes(_worker_batch(["a"], [1], [1])))
+        _seal(store, "ns")
+        store.write_rows("ns", _ipc_bytes(_worker_batch(["b"], [2], [2])))
+        _seal(store, "ns")
+
+        # Two L1s on disk, neither marked copied; eviction must skip both.
+        store._namespaces["ns"]._eviction_step()
+        all_files = sorted((tmp_path / "data" / "ns").glob("seg_L1_*.parquet"))
+        assert len(all_files) == 2
     finally:
         store.close()
 
 
 def test_eviction_keeps_namespaces_under_cap(tmp_path: Path):
+    """Below cap: nothing is evicted."""
     store = DuckDBLogStore(
         log_dir=tmp_path / "data",
-        max_local_segments=10,
+        compaction_config=CompactionConfig(max_segments_per_namespace=10, level_targets=(1,)),
     )
     try:
         store.register_table("ns.a", _worker_schema())
@@ -53,7 +102,44 @@ def test_eviction_keeps_namespaces_under_cap(tmp_path: Path):
         _seal(store, "ns.a")
         store.write_rows("ns.b", _ipc_bytes(_worker_batch(["b"], [2], [2])))
         _seal(store, "ns.b")
-        assert len(list((tmp_path / "data" / "ns.a").glob("logs_*.parquet"))) == 1
-        assert len(list((tmp_path / "data" / "ns.b").glob("logs_*.parquet"))) == 1
+        assert len(list((tmp_path / "data" / "ns.a").glob("seg_L1_*.parquet"))) == 1
+        assert len(list((tmp_path / "data" / "ns.b").glob("seg_L1_*.parquet"))) == 1
+    finally:
+        store.close()
+
+
+def test_fifo_eviction_across_mixed_levels(tmp_path: Path):
+    """Eviction picks the oldest L>=1 segment regardless of level — never the
+    middle of the seq range."""
+    config = CompactionConfig(
+        max_segments_per_namespace=2,
+        level_targets=(1, 2),  # L0 -> L1 -> L2 promotions on tiny byte budgets
+    )
+    store = DuckDBLogStore(
+        log_dir=tmp_path / "data",
+        remote_log_dir=str(tmp_path / "remote"),
+        compaction_config=config,
+    )
+    try:
+        store.register_table("ns", _worker_schema())
+        ns = store._namespaces["ns"]
+
+        # Three flush+compact cycles drive promotions: with level_targets=(1, 2)
+        # each L0 hits the size threshold and promotes to L1 then L2.
+        for i in range(3):
+            store.write_rows("ns", _ipc_bytes(_worker_batch([f"w-{i}"], [i], [i])))
+            ns._flush_step()
+            while ns._compaction_step():
+                pass
+            _wait_until_copied(store, "ns")
+
+        # Eviction should now have run and brought us to <=2 segments,
+        # popping oldest first.
+        ns._eviction_step()
+        remaining_rows = _list_segments_locked(store, "ns")
+        assert len(remaining_rows) <= 2
+        # Whatever's left, the smallest min_seq is strictly greater than the
+        # smallest seq we ever wrote (1) — i.e. eviction came from the front.
+        assert min(r.min_seq for r in remaining_rows) > 1
     finally:
         store.close()

--- a/lib/finelog/tests/test_layout_migration.py
+++ b/lib/finelog/tests/test_layout_migration.py
@@ -187,30 +187,38 @@ def test_only_known_globs_are_migrated(tmp_path: Path):
 
 def test_full_store_round_trip_after_migration(tmp_path: Path):
     """End-to-end: pre-existing flat files migrate cleanly, then a fresh
-    store over the same dir reads them back."""
-    data_dir = tmp_path / "store"
+    store over the same dir reads them back.
 
-    s1 = DuckDBLogStore(log_dir=data_dir)
+    The flat layout pre-dates the per-namespace dir convention by enough
+    that segments were written with the legacy ``tmp_*`` / ``logs_*``
+    prefixes, not today's ``seg_L<n>_*``. The layout migration only
+    knows the legacy prefixes; migration 0003 rewrites them to the
+    leveled scheme on the next store boot. We synthesize a legacy file
+    by hand here rather than asking the new code path to produce it.
+    """
+    data_dir = tmp_path / "store"
+    data_dir.mkdir()
+
+    # Build one legacy logs_*.parquet that contains a single appendable
+    # log row in today's schema. Using the new code path then renaming
+    # would defeat the point of the test.
+    s_temp = DuckDBLogStore(log_dir=tmp_path / "_seed")
     entry = logging_pb2.LogEntry(source="stdout", data="hello")
     entry.timestamp.epoch_ms = 1
-    s1.append("/k", [entry])
-    s1._force_flush()
-    s1.close()
-
-    # Demote to flat layout: move every file out of log/ to the parent.
-    log_dir = data_dir / LOG_NAMESPACE_DIR
-    for f in list(log_dir.iterdir()):
-        f.rename(data_dir / f.name)
-    log_dir.rmdir()
-    sentinel = data_dir / SENTINEL_FILENAME
-    if sentinel.exists():
-        sentinel.unlink()
-
-    assert any(p.name.startswith("tmp_") or p.name.startswith("logs_") for p in data_dir.iterdir())
+    s_temp.append("/k", [entry])
+    s_temp._force_flush()
+    seed_dir = tmp_path / "_seed" / LOG_NAMESPACE_DIR
+    seg = next(seed_dir.glob("seg_L0_*.parquet"))
+    legacy_name = "logs_0000000000000000001.parquet"
+    (data_dir / legacy_name).write_bytes(seg.read_bytes())
+    s_temp.close()
 
     migrate_to_namespaced_layout(data_dir)
     s2 = DuckDBLogStore(log_dir=data_dir)
     try:
+        # Migration 0003 renamed logs_*.parquet -> seg_L1_*.parquet.
+        log_dir = data_dir / LOG_NAMESPACE_DIR
+        assert sorted(p.name for p in log_dir.glob("seg_L1_*.parquet"))
         result = s2.get_logs("/k")
         assert [e.data for e in result.entries] == ["hello"]
     finally:

--- a/lib/finelog/tests/test_migrations.py
+++ b/lib/finelog/tests/test_migrations.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import duckdb
 import pytest
-from finelog.store.catalog import Catalog
+from finelog.store.catalog import Catalog, SegmentRow
 from finelog.store.migrations import apply_migrations, transactional
 
 
@@ -38,7 +38,12 @@ def test_fresh_registry_runs_baseline_migration(tmp_path):
         assert "namespaces" in tables
         assert "segments" in tables
         assert "schema_migrations" in tables
-        assert _applied_migrations(db._conn) == ["0001_init.py"]
+        assert _applied_migrations(db._conn) == [
+            "0001_init.py",
+            "0002_segment_key_value_bounds.py",
+            "0003_segment_level.py",
+            "0004_segment_copied_at.py",
+        ]
     finally:
         db.close()
 
@@ -49,7 +54,12 @@ def test_reopen_is_idempotent(tmp_path):
     db = Catalog(tmp_path)
     try:
         # Still exactly one row, not two.
-        assert _applied_migrations(db._conn) == ["0001_init.py"]
+        assert _applied_migrations(db._conn) == [
+            "0001_init.py",
+            "0002_segment_key_value_bounds.py",
+            "0003_segment_level.py",
+            "0004_segment_copied_at.py",
+        ]
     finally:
         db.close()
 
@@ -81,7 +91,12 @@ def test_pre_migrations_database_inherits_baseline(tmp_path):
         # Existing row preserved; segments table created; baseline recorded.
         assert db._conn.execute("SELECT namespace FROM namespaces").fetchall() == [("iris.worker",)]
         assert "segments" in _list_tables(db._conn)
-        assert _applied_migrations(db._conn) == ["0001_init.py"]
+        assert _applied_migrations(db._conn) == [
+            "0001_init.py",
+            "0002_segment_key_value_bounds.py",
+            "0003_segment_level.py",
+            "0004_segment_copied_at.py",
+        ]
     finally:
         db.close()
 
@@ -98,12 +113,12 @@ def test_failing_migration_rolls_back(tmp_path):
     # only 0001 should be marked applied.
     (fake_dir / "0001_ok.py").write_text(
         "import duckdb\n"
-        "def migrate(conn: duckdb.DuckDBPyConnection) -> None:\n"
+        "def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir) -> None:\n"
         "    conn.execute('CREATE TABLE ok_marker (n INTEGER)')\n"
     )
     (fake_dir / "0002_boom.py").write_text(
         "import duckdb\n"
-        "def migrate(conn: duckdb.DuckDBPyConnection) -> None:\n"
+        "def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir) -> None:\n"
         "    conn.execute('CREATE TABLE will_be_rolled_back (n INTEGER)')\n"
         "    raise RuntimeError('simulated migration failure')\n"
     )
@@ -130,7 +145,7 @@ def test_failed_migration_retries_on_next_apply(tmp_path):
 
     # First version raises after a side-effect, simulating a half-failed apply.
     migration_path.write_text(
-        "def migrate(conn):\n"
+        "def migrate(conn, *, data_dir):\n"
         "    conn.execute('CREATE TABLE IF NOT EXISTS marker (n INTEGER)')\n"
         "    raise RuntimeError('not yet')\n"
     )
@@ -144,7 +159,7 @@ def test_failed_migration_retries_on_next_apply(tmp_path):
         # Author fixes the migration; next apply picks it up because no row
         # was inserted on the failed pass.
         migration_path.write_text(
-            "def migrate(conn):\n    conn.execute('CREATE TABLE IF NOT EXISTS marker (n INTEGER)')\n"
+            "def migrate(conn, *, data_dir):\n    conn.execute('CREATE TABLE IF NOT EXISTS marker (n INTEGER)')\n"
         )
         apply_migrations(conn, fake_dir)
         assert _applied_migrations(conn) == ["0001_flaky.py"]
@@ -193,7 +208,9 @@ def test_underscore_prefixed_files_are_skipped(tmp_path):
     fake_dir.mkdir()
     (fake_dir / "_runner.py").write_text("raise AssertionError('runner module should never be loaded as a migration')")
     (fake_dir / "__init__.py").write_text("raise AssertionError('package init should never be loaded as a migration')")
-    (fake_dir / "0001_real.py").write_text("def migrate(conn): conn.execute('CREATE TABLE m (n INTEGER)')\n")
+    (fake_dir / "0001_real.py").write_text(
+        "def migrate(conn, *, data_dir): conn.execute('CREATE TABLE m (n INTEGER)')\n"
+    )
 
     conn = duckdb.connect(":memory:")
     try:
@@ -210,25 +227,51 @@ def test_underscore_prefixed_files_are_skipped(tmp_path):
 
 def test_catalog_segments_apis_function_after_migration(tmp_path):
     """End-to-end check: write a segment row through the public Catalog API."""
-    from finelog.store.catalog import SegmentRow, SegmentState
-
     db = Catalog(tmp_path)
     try:
         # ``aggregate_namespace_stats`` and friends rely on the baseline schema.
         assert db.aggregate_namespace_stats("ns").row_count == 0
         seg = SegmentRow(
             namespace="ns",
-            path=str(Path("/x/0001.parquet")),
-            state=SegmentState.FINALIZED,
+            path=str(Path("/x/seg_L1_0000000000000000001.parquet")),
+            level=1,
             min_seq=1,
             max_seq=10,
             row_count=10,
             byte_size=1024,
             created_at_ms=0,
+            min_key_value="alpha",
+            max_key_value="zeta",
+            copied_at_ms=42,
         )
         db.upsert_segment(seg)
         stats = db.aggregate_namespace_stats("ns")
         assert stats.row_count == 10
         assert stats.segment_count == 1
+
+        # 0002 + 0003 + 0004 columns survive the round-trip.
+        rows = db.list_segments("ns")
+        assert len(rows) == 1
+        assert rows[0].level == 1
+        assert rows[0].min_key_value == "alpha"
+        assert rows[0].max_key_value == "zeta"
+        assert rows[0].copied_at_ms == 42
+
+        seg_no_key = SegmentRow(
+            namespace="ns",
+            path=str(Path("/x/seg_L1_0000000000000000011.parquet")),
+            level=1,
+            min_seq=11,
+            max_seq=20,
+            row_count=10,
+            byte_size=1024,
+            created_at_ms=0,
+        )
+        db.upsert_segment(seg_no_key)
+        rows = db.list_segments("ns")
+        no_key_row = next(r for r in rows if r.path.endswith("0000000011.parquet"))
+        assert no_key_row.min_key_value is None
+        assert no_key_row.max_key_value is None
+        assert no_key_row.copied_at_ms is None
     finally:
         db.close()

--- a/lib/finelog/tests/test_offload.py
+++ b/lib/finelog/tests/test_offload.py
@@ -1,0 +1,97 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Async copy worker behavior.
+
+Compaction must not block on the GCS upload; the worker drains on close
+and on the test ``_wait_for_copies`` hook.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+from finelog.store import duckdb_store
+from finelog.store.duckdb_store import DuckDBLogStore
+
+from tests.conftest import _ipc_bytes, _worker_batch, _worker_schema
+
+
+def test_compaction_returns_immediately_when_upload_is_slow(tmp_path: Path, monkeypatch):
+    """A multi-second upload must not stall the compaction thread.
+
+    The copy worker polls the catalog independently; compaction just
+    wakes it. So compaction returns regardless of upload duration.
+    """
+    remote = tmp_path / "remote"
+    remote.mkdir()
+
+    release_upload = threading.Event()
+    real_upload = duckdb_store.CopyWorker._upload
+
+    def gated_upload(self, namespace, local_path):
+        if not release_upload.wait(timeout=5.0):
+            raise AssertionError("test forgot to release the copy gate")
+        return real_upload(self, namespace, local_path)
+
+    monkeypatch.setattr(duckdb_store.CopyWorker, "_upload", gated_upload)
+
+    store = DuckDBLogStore(log_dir=tmp_path / "data", remote_log_dir=str(remote))
+    try:
+        store.register_table("iris.worker", _worker_schema())
+        store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-1"], [100], [1])))
+        ns = store._namespaces["iris.worker"]
+        ns._flush_step()
+
+        compaction_start = time.monotonic()
+        ns._force_compact_l0()
+        compaction_elapsed = time.monotonic() - compaction_start
+
+        assert compaction_elapsed < 1.0, f"compaction blocked on upload (elapsed={compaction_elapsed:.3f}s)"
+
+        remote_ns_dir = remote / "iris.worker"
+        if remote_ns_dir.exists():
+            assert not list(remote_ns_dir.glob("*.parquet"))
+
+        release_upload.set()
+        assert store._wait_for_copies(timeout=5.0)
+        assert sorted((remote / "iris.worker").glob("*.parquet"))
+    finally:
+        release_upload.set()
+        store.close()
+
+
+def test_close_drains_pending_copies(tmp_path: Path):
+    """``close`` blocks until the copy worker finishes queued uploads."""
+    remote = tmp_path / "remote"
+    remote.mkdir()
+
+    store = DuckDBLogStore(log_dir=tmp_path / "data", remote_log_dir=str(remote))
+    try:
+        store.register_table("iris.worker", _worker_schema())
+        store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-1"], [100], [1])))
+        ns = store._namespaces["iris.worker"]
+        ns._flush_step()
+        ns._force_compact_l0()
+    except Exception:
+        store.close()
+        raise
+
+    # close() should drain the queue before tearing down the worker.
+    store.close()
+
+    remote_files = sorted((remote / "iris.worker").glob("*.parquet"))
+    assert remote_files, "expected close() to drain pending uploads"
+
+
+def test_copy_worker_not_started_without_remote_dir(tmp_path: Path):
+    """No remote_log_dir => no worker thread, even with a disk store."""
+    store = DuckDBLogStore(log_dir=tmp_path / "data")
+    try:
+        assert store._copy_worker is None
+        # Wait hook is a no-op when the worker is absent.
+        assert store._wait_for_copies(timeout=0.0)
+    finally:
+        store.close()

--- a/lib/finelog/tests/test_persistence.py
+++ b/lib/finelog/tests/test_persistence.py
@@ -60,12 +60,12 @@ def test_compaction_across_additive_evolution(tmp_path: Path):
         store.write_rows("ns.evolve", _ipc_bytes(batch2))
         ns._flush_step()
 
-        ns._compaction_step()
+        ns._force_compact_l0()
         seg_dir = tmp_path / "data" / "ns.evolve"
-        assert sorted(p.name for p in seg_dir.glob("tmp_*.parquet")) == []
-        log_files = sorted(seg_dir.glob("logs_*.parquet"))
-        assert len(log_files) == 1
-        table = pq.read_table(log_files[0])
+        assert sorted(p.name for p in seg_dir.glob("seg_L0_*.parquet")) == []
+        l1_files = sorted(seg_dir.glob("seg_L1_*.parquet"))
+        assert len(l1_files) == 1
+        table = pq.read_table(l1_files[0])
         # Implicit ``seq`` first, then registered columns, additive ``c`` last.
         assert table.column_names == ["seq", "a", "b", "timestamp_ms", "c"]
         rows = table.to_pylist()

--- a/lib/finelog/tests/test_query.py
+++ b/lib/finelog/tests/test_query.py
@@ -4,14 +4,12 @@
 from __future__ import annotations
 
 import threading
-import time
 
 import duckdb
 import pyarrow as pa
 import pytest
 from finelog.rpc import finelog_stats_pb2 as stats_pb2
 from finelog.store.duckdb_store import DuckDBLogStore
-from finelog.store.log_namespace import _is_tmp_path
 from finelog.store.schema import Column, Schema
 from finelog.store.sql_escape import quote_ident, quote_literal
 
@@ -118,8 +116,15 @@ def test_query_unknown_namespace_in_sql_raises(store: DuckDBLogStore):
         store.query('SELECT * FROM "nope.unknown"')
 
 
-def test_query_blocks_concurrent_compaction_commit(store: DuckDBLogStore):
-    """A reader holding the query-visibility lock blocks compaction's commit."""
+def test_compaction_commit_does_not_take_visibility_write_lock(store: DuckDBLogStore):
+    """Compaction's commit phase no longer acquires the visibility rwlock.
+
+    The previous design took the write side around the rename + replace_segments
+    pair as defense-in-depth. With per-namespace bg threads, the same thread
+    owns flush + compaction + eviction, so there is no concurrent unlinker to
+    defend against. A long-running reader on the rwlock must NOT block a
+    compaction commit.
+    """
     store.register_table("iris.worker", _worker_schema())
     ns = store._namespaces["iris.worker"]
     store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["a"], [1], [1])))
@@ -127,39 +132,27 @@ def test_query_blocks_concurrent_compaction_commit(store: DuckDBLogStore):
     store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["b"], [2], [2])))
     ns._flush_step()
 
-    # Hold the read lock; poll _pending_writers to confirm the compaction
-    # thread has queued without relying on sleep.
     rwlock = store._query_visibility_lock
     rwlock.read_acquire()
     try:
         compaction_done = threading.Event()
 
         def run_compaction():
-            ns._compaction_step()
+            ns._force_compact_l0()
             compaction_done.set()
 
         t = threading.Thread(target=run_compaction, daemon=True)
         t.start()
 
-        with rwlock._cond:
-            deadline = time.monotonic() + 5.0
-            while rwlock._pending_writers == 0:
-                remaining = deadline - time.monotonic()
-                if remaining <= 0:
-                    raise AssertionError("compaction thread never queued for the write lock")
-                rwlock._cond.wait(timeout=remaining)
-
-        assert not compaction_done.is_set()
+        # The compaction must finish promptly even with the read lock held.
+        assert compaction_done.wait(timeout=5.0), "compaction blocked on the visibility lock"
     finally:
         rwlock.read_release()
 
     t.join(timeout=5.0)
-    assert compaction_done.is_set()
-    ns = store._namespaces["iris.worker"]
-    sealed = ns.sealed_segments()
-    assert len(sealed) == 1
     all_segments = ns.all_segments_unlocked()
-    assert not any(_is_tmp_path(s.path) for s in all_segments)
+    assert len(all_segments) == 1
+    assert all(s.level >= 1 for s in all_segments)
 
 
 def test_query_completes_on_snapshot_during_compaction(store: DuckDBLogStore):
@@ -168,10 +161,10 @@ def test_query_completes_on_snapshot_during_compaction(store: DuckDBLogStore):
     ns = store._namespaces["iris.worker"]
     store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["a"], [1], [1])))
     ns._flush_step()
-    ns._compaction_step(compact_single=True)
+    ns._force_compact_l0()
     store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["b"], [2], [2])))
     ns._flush_step()
-    ns._compaction_step(compact_single=True)
+    ns._force_compact_l0()
 
     table = store.query('SELECT worker_id FROM "iris.worker" ORDER BY worker_id')
     assert table.column("worker_id").to_pylist() == ["a", "b"]
@@ -179,3 +172,67 @@ def test_query_completes_on_snapshot_during_compaction(store: DuckDBLogStore):
     ns._compaction_step()
     table2 = store.query('SELECT worker_id FROM "iris.worker" ORDER BY worker_id')
     assert table2.column("worker_id").to_pylist() == ["a", "b"]
+
+
+def test_writes_proceed_during_compaction_copy(store: DuckDBLogStore, monkeypatch):
+    """Compaction's parquet COPY must not block concurrent appends.
+
+    Stubs ``compaction_conn.execute`` to gate on an event so the COPY hangs
+    deterministically. A concurrent ``write_rows`` must finish before we
+    release the gate — proving the insertion lock is not held across the COPY.
+    """
+    store.register_table("iris.worker", _worker_schema())
+    ns = store._namespaces["iris.worker"]
+
+    # Two L0 segments so ``_compaction_step`` plans an actual merge.
+    store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["a"], [1], [1])))
+    ns._flush_step()
+    store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["b"], [2], [2])))
+    ns._flush_step()
+
+    copy_entered = threading.Event()
+    release_copy = threading.Event()
+    real_conn = ns._compaction_conn
+
+    class _GatedConn:
+        def execute(self, sql, *args, **kwargs):
+            copy_entered.set()
+            if not release_copy.wait(timeout=5.0):
+                raise AssertionError("test forgot to release the COPY gate")
+            return real_conn.execute(sql, *args, **kwargs)
+
+    monkeypatch.setattr(ns, "_compaction_conn", _GatedConn())
+
+    compaction_done = threading.Event()
+
+    def run_compaction():
+        ns._force_compact_l0()
+        compaction_done.set()
+
+    compactor = threading.Thread(target=run_compaction, daemon=True)
+    compactor.start()
+    assert copy_entered.wait(timeout=5.0), "compaction never entered the COPY"
+
+    write_done = threading.Event()
+    write_error: list[BaseException] = []
+
+    def run_write():
+        try:
+            store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["c"], [3], [3])))
+        except BaseException as exc:  # surface to the test thread
+            write_error.append(exc)
+        finally:
+            write_done.set()
+
+    writer = threading.Thread(target=run_write, daemon=True)
+    writer.start()
+
+    # Append must complete while the COPY is still gated.
+    assert write_done.wait(timeout=2.0), "append blocked behind compaction COPY"
+    assert not write_error, write_error
+    assert not compaction_done.is_set()
+
+    release_copy.set()
+    compactor.join(timeout=5.0)
+    assert compaction_done.is_set()
+    writer.join(timeout=1.0)

--- a/lib/finelog/tests/test_query.py
+++ b/lib/finelog/tests/test_query.py
@@ -116,14 +116,14 @@ def test_query_unknown_namespace_in_sql_raises(store: DuckDBLogStore):
         store.query('SELECT * FROM "nope.unknown"')
 
 
-def test_compaction_commit_does_not_take_visibility_write_lock(store: DuckDBLogStore):
-    """Compaction's commit phase no longer acquires the visibility rwlock.
+def test_compaction_commit_waits_for_active_readers(store: DuckDBLogStore):
+    """Commit (rename + catalog swap + unlink) must drain readers first.
 
-    The previous design took the write side around the rename + replace_segments
-    pair as defense-in-depth. With per-namespace bg threads, the same thread
-    owns flush + compaction + eviction, so there is no concurrent unlinker to
-    defend against. A long-running reader on the rwlock must NOT block a
-    compaction commit.
+    DuckDB opens parquet files lazily, so a reader holds the visibility
+    read lock for the entire query and may dereference any path it
+    snapshotted. Unlinking those paths under an active reader surfaces
+    as ``IOException: No files found``. The commit therefore acquires
+    the write side, which blocks until in-flight readers release.
     """
     store.register_table("iris.worker", _worker_schema())
     ns = store._namespaces["iris.worker"]
@@ -134,8 +134,8 @@ def test_compaction_commit_does_not_take_visibility_write_lock(store: DuckDBLogS
 
     rwlock = store._query_visibility_lock
     rwlock.read_acquire()
+    compaction_done = threading.Event()
     try:
-        compaction_done = threading.Event()
 
         def run_compaction():
             ns._force_compact_l0()
@@ -144,11 +144,15 @@ def test_compaction_commit_does_not_take_visibility_write_lock(store: DuckDBLogS
         t = threading.Thread(target=run_compaction, daemon=True)
         t.start()
 
-        # The compaction must finish promptly even with the read lock held.
-        assert compaction_done.wait(timeout=5.0), "compaction blocked on the visibility lock"
+        # Compaction must NOT finish while the read lock is held.
+        assert not compaction_done.wait(
+            timeout=0.5
+        ), "compaction proceeded with active reader; concurrent unlink would race a lazy DuckDB scan"
     finally:
         rwlock.read_release()
 
+    # Releasing the read lock must let the queued writer proceed promptly.
+    assert compaction_done.wait(timeout=5.0), "compaction did not resume after reader released"
     t.join(timeout=5.0)
     all_segments = ns.all_segments_unlocked()
     assert len(all_segments) == 1


### PR DESCRIPTION
Replace finelog's flat tmp_/logs_ compaction with a leveled scheme. The new
Compactor plans L_n -> L_{n+1} promotions from a CompactionConfig
(level_targets defaults to (64 MiB, 256 MiB)). The catalog gains a level
column and a copied_at_ms stamp; on-disk files become seg_L<n>_<min_seq>.parquet
(migrations 0003 and 0004 land the column rewrite + filename rename, resumable
across crashes). Remote copies are decoupled: a CopyWorker polls the catalog
for L>=1 rows lacking copied_at_ms instead of being kicked from compaction.
Per-namespace storage caps replace the global eviction pass. 162 tests pass.

Design: .agents/projects/2026-05-05_finelog_compactor.md