### PR TITLE
[finelog] Switch to zstd, add memory diagnostics, bake profilers into image

### DIFF
--- a/lib/finelog/deploy/Dockerfile
+++ b/lib/finelog/deploy/Dockerfile
@@ -70,9 +70,20 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install "gcsfs>=2024.0.0"
 
+# Profiling tools — installed after uv sync so they aren't pruned by the exact
+# sync. Mirrors lib/iris/Dockerfile so `memray attach` / `py-spy dump` work
+# against the live server without rebuilding.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install py-spy memray
+
 
 # ── Stage: runtime ───────────────────────────────────────────────────
 FROM deps AS runtime
+
+# memray attach shells out to gdb at runtime; bake it into the image so we
+# don't have to apt-get install on a live container.
+RUN apt-get update && apt-get install -y --no-install-recommends gdb \
+    && rm -rf /var/lib/apt/lists/*
 
 # Pre-built dashboard SPA. Served by the asgi app at "/" and "/static/*".
 COPY --from=dashboard /build/dashboard/dist ./dashboard/dist

--- a/lib/finelog/deploy/k8s/02-deployment.yaml.tmpl
+++ b/lib/finelog/deploy/k8s/02-deployment.yaml.tmpl
@@ -35,6 +35,11 @@ spec:
         - name: finelog
           image: {{ image }}
           imagePullPolicy: IfNotPresent
+          # SYS_PTRACE lets memray/py-spy attach to the running server for
+          # in-prod profiling without rolling the pod.
+          securityContext:
+            capabilities:
+              add: ["SYS_PTRACE"]
           ports:
             - name: rpc
               containerPort: {{ port }}

--- a/lib/finelog/pyproject.toml
+++ b/lib/finelog/pyproject.toml
@@ -13,11 +13,13 @@ dependencies = [
     "connect-python>=0.9.0",
     "duckdb>=1.0.0",
     "fsspec>=2024.0.0",
+    "numpy>=1.26",
     "protobuf>=5.0",
     "pyarrow>=19.0.0",
     "pyyaml>=6.0",
     "starlette>=0.50.0",
     "uvicorn[standard]>=0.23.0",
+    "zstandard>=0.22",
 ]
 
 [project.scripts]

--- a/lib/finelog/src/finelog/client/log_client.py
+++ b/lib/finelog/src/finelog/client/log_client.py
@@ -21,6 +21,8 @@ from typing import Any
 import pyarrow as pa
 import pyarrow.ipc as paipc
 from connectrpc.code import Code
+from connectrpc.compression.gzip import GzipCompression
+from connectrpc.compression.zstd import ZstdCompression
 from connectrpc.errors import ConnectError
 from connectrpc.interceptor import Interceptor
 from rigging.log_setup import LOG_DATEFMT, LOG_FORMAT, LevelPrefixFormatter
@@ -77,6 +79,12 @@ DEFAULT_FLUSH_INTERVAL = 1.0
 DEFAULT_BATCH_ROWS = 10_000
 # Per-Table queue cap in bytes. Matches WriteRows max body size.
 DEFAULT_MAX_BUFFER_BYTES = 16 * 1024 * 1024
+
+# Send and accept zstd; gzip kept as a fallback so we interop with older
+# servers (and the connect-go ecosystem). Order in `accept_compression` is
+# significant — the server walks the client's Accept-Encoding in order.
+_SEND_COMPRESSION = ZstdCompression()
+_ACCEPT_COMPRESSIONS = (ZstdCompression(), GzipCompression())
 
 _BACKOFF_INITIAL = 0.5
 _BACKOFF_MAX = 30.0
@@ -596,6 +604,8 @@ class LogClient:
                 address=address,
                 timeout_ms=self._timeout_ms,
                 interceptors=self._interceptors,
+                send_compression=_SEND_COMPRESSION,
+                accept_compression=_ACCEPT_COMPRESSIONS,
             )
             logger.info("LogClient resolved %s -> %s (stats)", self._server_url, address)
             return self._stats_client
@@ -611,6 +621,8 @@ class LogClient:
                 address=address,
                 timeout_ms=self._timeout_ms,
                 interceptors=self._interceptors,
+                send_compression=_SEND_COMPRESSION,
+                accept_compression=_ACCEPT_COMPRESSIONS,
             )
             logger.info("LogClient resolved %s -> %s (log)", self._server_url, address)
             return self._log_service_client

--- a/lib/finelog/src/finelog/deploy/_gcp.py
+++ b/lib/finelog/src/finelog/deploy/_gcp.py
@@ -253,6 +253,24 @@ def gcp_restart(cfg: FinelogConfig) -> None:
 
     bootstrap = render_bootstrap(image=pinned, port=cfg.port, remote_log_dir=cfg.remote_log_dir)
 
+    # Update the instance's startup-script metadata so that a future VM reboot
+    # (host maintenance, manual reset) brings up the same image we're about to
+    # restart into — otherwise GCE would re-run the bootstrap baked in at
+    # `gcp_up` time, pinning the VM to whatever image was current on day one.
+    with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as f:
+        f.write(bootstrap)
+        startup_path = f.name
+    click.echo("Updating instance startup-script metadata...")
+    _gcloud(
+        "compute",
+        "instances",
+        "add-metadata",
+        cfg.name,
+        f"--project={gcp.project}",
+        f"--zone={gcp.zone}",
+        f"--metadata-from-file=startup-script={startup_path}",
+    )
+
     click.echo(f"Re-running bootstrap on {cfg.name} via SSH...")
     result = subprocess.run(
         _ssh_args(cfg, "bash -s"),

--- a/lib/finelog/src/finelog/deploy/bootstrap.py
+++ b/lib/finelog/src/finelog/deploy/bootstrap.py
@@ -76,6 +76,7 @@ sudo docker run -d --name {{ container_name }} \\
     --network=host \\
     --restart=unless-stopped \\
     --ulimit core=0:0 \\
+    --cap-add SYS_PTRACE \\
     -e FINELOG_PORT={{ port }} \\
     -e FINELOG_REMOTE_DIR={{ remote_log_dir }} \\
     -v {{ cache_dir }}:{{ cache_dir }} \\

--- a/lib/finelog/src/finelog/server/asgi.py
+++ b/lib/finelog/src/finelog/server/asgi.py
@@ -9,6 +9,8 @@ import logging
 from collections.abc import Iterable
 from pathlib import Path
 
+from connectrpc.compression.gzip import GzipCompression
+from connectrpc.compression.zstd import ZstdCompression
 from connectrpc.interceptor import Interceptor
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -70,6 +72,12 @@ def _index_html_with_base(raw: bytes, prefix: str) -> bytes:
 _MAX_CONCURRENT_FETCH_LOGS = 4
 _MAX_CONCURRENT_QUERY = 4
 
+# zstd first so clients that advertise both pick it: the negotiator walks the
+# client's Accept-Encoding in order, so listing zstd first only matters via
+# the client side, but we keep it first here for symmetry/readability.
+# Memray on prod showed gzip.compress accounting for ~66% of allocated bytes.
+_DEFAULT_COMPRESSIONS = (ZstdCompression(), GzipCompression())
+
 # CRON(2026-05-12) -- remove this legacy workaround as all workers & clients
 # will be updated by this point.
 # Pre-#5212 (b212f0015) the LogService proto package was iris.logging, so old
@@ -109,7 +117,9 @@ def build_log_server_asgi(
     """
     log_chain: list[Interceptor] = list(interceptors)
     log_chain.append(ConcurrencyLimitInterceptor({"FetchLogs": max_concurrent_fetch_logs}))
-    log_wsgi_app = LogServiceWSGIApplication(service=service, interceptors=tuple(log_chain))
+    log_wsgi_app = LogServiceWSGIApplication(
+        service=service, interceptors=tuple(log_chain), compressions=_DEFAULT_COMPRESSIONS
+    )
 
     async def _health(_: Request) -> PlainTextResponse:
         return PlainTextResponse("ok")
@@ -121,7 +131,9 @@ def build_log_server_asgi(
     if stats_service is not None:
         stats_chain: list[Interceptor] = list(interceptors)
         stats_chain.append(ConcurrencyLimitInterceptor({"Query": max_concurrent_query}))
-        stats_wsgi_app = StatsServiceWSGIApplication(service=stats_service, interceptors=tuple(stats_chain))
+        stats_wsgi_app = StatsServiceWSGIApplication(
+            service=stats_service, interceptors=tuple(stats_chain), compressions=_DEFAULT_COMPRESSIONS
+        )
         routes.append(Mount(stats_wsgi_app.path, app=WSGIMiddleware(stats_wsgi_app)))
 
     # SPA shell at "/" and any unknown path so Vue Router can take over

--- a/lib/finelog/src/finelog/server/main.py
+++ b/lib/finelog/src/finelog/server/main.py
@@ -20,9 +20,11 @@ from __future__ import annotations
 import logging
 import signal
 import sys
+import threading
 from pathlib import Path
 
 import click
+import pyarrow as pa
 import uvicorn
 from rigging.log_setup import configure_logging
 
@@ -32,6 +34,66 @@ from finelog.server.stats_service import StatsServiceImpl
 from finelog.store.layout_migration import migrate_to_namespaced_layout
 
 logger = logging.getLogger("finelog.server")
+
+# Period for the pool/RSS diagnostics line.
+_POOL_DIAGNOSTICS_INTERVAL_SEC = 60.0
+
+
+def _read_proc_self_status_kb(field: str) -> int:
+    """Return the value of a ``/proc/self/status`` field in KiB (Linux-only).
+
+    Returns 0 when the field is missing — caller treats 0 as "unknown".
+    """
+    try:
+        with open("/proc/self/status") as fh:
+            for line in fh:
+                if line.startswith(field + ":"):
+                    return int(line.split()[1])
+    except OSError:
+        pass
+    return 0
+
+
+def _emit_pool_diagnostics(service: LogServiceImpl) -> None:
+    """Log a snapshot of the arrow pool, process RSS, and per-namespace ram.
+
+    Lets us tell apart the two leak hypotheses we care about:
+      * RSS tracks ``pool.bytes_allocated`` → live pyarrow buffers (e.g.
+        IPC retention, ARROW-7305 territory).
+      * RSS >> ``pool.bytes_allocated`` and grows monotonically →
+        allocator arena retention (ARROW-6910 territory).
+    """
+    pool = pa.default_memory_pool()
+    summary = service.log_store.memory_summary()
+    rss_kb = _read_proc_self_status_kb("VmRSS")
+    vmsize_kb = _read_proc_self_status_kb("VmSize")
+    logger.info(
+        "pool_diag backend=%s pool_bytes=%d pool_max=%d rss_kb=%d vmsize_kb=%d " "namespaces=%d ram_bytes=%d chunks=%d",
+        pool.backend_name,
+        pool.bytes_allocated(),
+        pool.max_memory(),
+        rss_kb,
+        vmsize_kb,
+        summary["namespaces"],
+        summary["ram_bytes"],
+        summary["chunks"],
+    )
+
+
+def _start_pool_diagnostics(service: LogServiceImpl, stop_event: threading.Event) -> threading.Thread:
+    """Spawn a daemon thread that calls ``_emit_pool_diagnostics`` periodically."""
+
+    def _loop() -> None:
+        while not stop_event.is_set():
+            try:
+                _emit_pool_diagnostics(service)
+            except Exception:
+                logger.warning("pool_diag failed", exc_info=True)
+            stop_event.wait(_POOL_DIAGNOSTICS_INTERVAL_SEC)
+
+    thread = threading.Thread(target=_loop, name="finelog-pool-diag", daemon=True)
+    thread.start()
+    return thread
 
 
 def run_log_server(
@@ -63,16 +125,22 @@ def run_log_server(
     )
     server = uvicorn.Server(config)
 
+    diag_stop = threading.Event()
+
     def _shutdown(_signum, _frame):
         logger.info("Log server shutting down")
         server.should_exit = True
+        diag_stop.set()
 
     signal.signal(signal.SIGTERM, _shutdown)
     signal.signal(signal.SIGINT, _shutdown)
 
+    _start_pool_diagnostics(service, diag_stop)
+
     logger.info("Log server starting on port %d (log_dir=%s)", port, log_dir)
     server.run()
 
+    diag_stop.set()
     service.close()
     logger.info("Log server stopped")
 

--- a/lib/finelog/src/finelog/store/duckdb_store.py
+++ b/lib/finelog/src/finelog/store/duckdb_store.py
@@ -312,6 +312,28 @@ class DuckDBLogStore:
                 raise NamespaceNotFoundError(f"namespace {name!r} is not registered")
             return ns.schema
 
+    def memory_summary(self) -> dict[str, int]:
+        """Aggregate ram_bytes/chunk_count across namespaces, for diagnostics.
+
+        Walks ``_buffers`` on each namespace defensively so the
+        ``MemoryLogNamespace`` (no buffers) is harmless. Used by the periodic
+        pool-diagnostics logger in the standalone server.
+        """
+        total_ram_bytes = 0
+        total_chunks = 0
+        with self._insertion_lock:
+            for ns in self._namespaces.values():
+                buffers = getattr(ns, "_buffers", None)
+                if buffers is None:
+                    continue
+                total_ram_bytes += buffers.ram_bytes()
+                total_chunks += buffers.chunk_count()
+            return {
+                "namespaces": len(self._namespaces),
+                "ram_bytes": total_ram_bytes,
+                "chunks": total_chunks,
+            }
+
     def write_rows(self, name: str, arrow_ipc_bytes: bytes) -> int:
         """Validate ``arrow_ipc_bytes`` and append the rows to ``name``.
 
@@ -556,8 +578,18 @@ class DuckDBLogStore:
 
 
 def _decode_single_record_batch(arrow_ipc_bytes: bytes) -> pa.RecordBatch:
+    """Decode a single-batch IPC stream.
+
+    Uses ``read_next_batch`` rather than ``list(reader)`` so the EOS check
+    doesn't build an intermediate Python list (this path was 1.15M allocs/30s
+    on prod). Note: the returned ``RecordBatch`` is a zero-copy view into
+    ``arrow_ipc_bytes`` and keeps it alive — see ARROW-7305 in the design
+    notes for why we may want a hard copy here later.
+    """
     reader = paipc.open_stream(pa.BufferReader(arrow_ipc_bytes))
-    batches = list(reader)
-    if len(batches) != 1:
-        raise SchemaValidationError(f"WriteRows: expected exactly one RecordBatch in IPC stream, got {len(batches)}")
-    return batches[0]
+    batch = reader.read_next_batch()
+    try:
+        reader.read_next_batch()
+    except StopIteration:
+        return batch
+    raise SchemaValidationError("WriteRows: expected exactly one RecordBatch in IPC stream, got >1")

--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -28,6 +28,7 @@ from typing import Protocol
 
 import duckdb
 import fsspec.core
+import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.parquet as pq
@@ -164,8 +165,15 @@ class LocalSegment:
 
 
 def _stamp_seq_column(batch: pa.RecordBatch, first_seq: int, arrow_schema: pa.Schema) -> pa.Table:
-    """Project ``batch`` to ``arrow_schema`` with the implicit seq column filled."""
-    seq_array = pa.array(range(first_seq, first_seq + batch.num_rows), type=pa.int64())
+    """Project ``batch`` to ``arrow_schema`` with the implicit seq column filled.
+
+    Uses ``np.arange`` rather than ``pa.array(range(...), int64)``: the python
+    ``range`` path boxes every value into a PyLong before pyarrow re-unpacks
+    it, which dominated allocation count under load (150k allocs / 30 s on
+    prod). ``np.arange`` produces the int64 buffer in one C-level shot and
+    pyarrow wraps it zero-copy.
+    """
+    seq_array = pa.array(np.arange(first_seq, first_seq + batch.num_rows, dtype=np.int64))
     arrays: list[pa.Array] = []
     for field in arrow_schema:
         if field.name == IMPLICIT_SEQ_COLUMN:

--- a/lib/finelog/tests/test_client.py
+++ b/lib/finelog/tests/test_client.py
@@ -141,7 +141,7 @@ def tracked_clients(monkeypatch):
     """Patch the StatsService client class to record every constructed instance."""
     clients: list[_FakeStatsServiceClient] = []
 
-    def stats_factory(address, timeout_ms=10_000, interceptors=()):
+    def stats_factory(address, timeout_ms=10_000, interceptors=(), **_kwargs):
         c = _FakeStatsServiceClient(address, timeout_ms=timeout_ms, interceptors=interceptors)
         clients.append(c)
         return c
@@ -169,7 +169,7 @@ def tracked_log_service_clients(monkeypatch):
     """Patch LogServiceClientSync; expose request/response on the singleton fake."""
     fake = _FakeLogServiceClient(address=None)
 
-    def factory(address, timeout_ms=10_000, interceptors=()):
+    def factory(address, timeout_ms=10_000, interceptors=(), **_kwargs):
         fake.address = address
         return fake
 

--- a/lib/iris/src/iris/actor/server.py
+++ b/lib/iris/src/iris/actor/server.py
@@ -32,6 +32,7 @@ from rigging.timing import Duration, ExponentialBackoff, Timestamp
 from iris.managed_thread import ThreadContainer, get_thread_container
 from iris.rpc import actor_pb2
 from iris.rpc.actor_connect import ActorServiceASGIApplication
+from iris.rpc.compression import IRIS_RPC_COMPRESSIONS
 
 logger = logging.getLogger(__name__)
 
@@ -297,7 +298,7 @@ class ActorServer:
         return op.to_proto()
 
     def _create_app(self) -> ActorServiceASGIApplication:
-        return ActorServiceASGIApplication(service=self)
+        return ActorServiceASGIApplication(service=self, compressions=IRIS_RPC_COMPRESSIONS)
 
     def serve_background(self, port: int | None = None) -> int:
         """Start server in background thread.

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -56,6 +56,7 @@ from iris.cluster.dashboard_common import (
     static_files_mount,
 )
 from iris.rpc.auth import SESSION_COOKIE, NullAuthInterceptor, TokenVerifier, extract_bearer_token, resolve_auth
+from iris.rpc.compression import IRIS_RPC_COMPRESSIONS
 from iris.rpc.controller_connect import ControllerServiceWSGIApplication
 from iris.rpc.interceptors import SLOW_RPC_THRESHOLD_MS, ConcurrencyLimitInterceptor, RequestTimingInterceptor
 from iris.rpc.stats import RpcStatsCollector
@@ -387,7 +388,9 @@ class ControllerDashboard:
             # when present but treat everything as anonymous/admin.
             auth_interceptor = NullAuthInterceptor(verifier=self._auth_verifier)
         controller_interceptors = [auth_interceptor, controller_timing]
-        rpc_wsgi_app = ControllerServiceWSGIApplication(service=self._service, interceptors=controller_interceptors)
+        rpc_wsgi_app = ControllerServiceWSGIApplication(
+            service=self._service, interceptors=controller_interceptors, compressions=IRIS_RPC_COMPRESSIONS
+        )
 
         # StatsService: reuses the auth interceptor (so non-admins can't read
         # sampled request previews) but skips RequestTimingInterceptor so the
@@ -395,6 +398,7 @@ class ControllerDashboard:
         stats_wsgi_app = StatsServiceWSGIApplication(
             service=RpcStatsService(self._stats_collector),
             interceptors=[auth_interceptor],
+            compressions=IRIS_RPC_COMPRESSIONS,
         )
         stats_app = WSGIMiddleware(stats_wsgi_app)
 
@@ -406,7 +410,9 @@ class ControllerDashboard:
         # Cap concurrent FetchLogs RPCs to avoid evicting the page cache with
         # parallel DuckDB scans. See duckdb_store.py for working-set caps.
         log_interceptors = [auth_interceptor, log_timing, ConcurrencyLimitInterceptor({"FetchLogs": 4})]
-        log_wsgi_app = LogServiceWSGIApplication(service=self._log_service, interceptors=log_interceptors)
+        log_wsgi_app = LogServiceWSGIApplication(
+            service=self._log_service, interceptors=log_interceptors, compressions=IRIS_RPC_COMPRESSIONS
+        )
         log_app = WSGIMiddleware(log_wsgi_app)
 
         # Backward-compat: old clients call ControllerService/FetchLogs (removed
@@ -505,6 +511,7 @@ class ControllerDashboard:
             finelog_stats_wsgi_app = FinelogStatsServiceWSGIApplication(
                 service=self._finelog_stats_service,
                 interceptors=[auth_interceptor],
+                compressions=IRIS_RPC_COMPRESSIONS,
             )
             routes.append(Mount(finelog_stats_wsgi_app.path, app=WSGIMiddleware(finelog_stats_wsgi_app)))
         routes.append(static_files_mount())

--- a/lib/iris/src/iris/cluster/worker/dashboard.py
+++ b/lib/iris/src/iris/cluster/worker/dashboard.py
@@ -11,6 +11,7 @@ from starlette.routing import Mount, Route
 
 from iris.cluster.dashboard_common import favicon_route, html_shell, static_files_mount
 from iris.cluster.worker.service import WorkerServiceImpl
+from iris.rpc.compression import IRIS_RPC_COMPRESSIONS
 from iris.rpc.worker_connect import WorkerServiceWSGIApplication
 
 
@@ -37,7 +38,7 @@ class WorkerDashboard:
         return self._app
 
     def _create_app(self) -> Starlette:
-        rpc_wsgi_app = WorkerServiceWSGIApplication(service=self._service)
+        rpc_wsgi_app = WorkerServiceWSGIApplication(service=self._service, compressions=IRIS_RPC_COMPRESSIONS)
         rpc_app = WSGIMiddleware(rpc_wsgi_app)
 
         routes = [

--- a/lib/iris/src/iris/rpc/compression.py
+++ b/lib/iris/src/iris/rpc/compression.py
@@ -1,0 +1,20 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared compression configuration for iris RPC servers and clients.
+
+zstd is preferred and gzip is the fallback for older peers. Iris RPC traffic
+is dominated by log payloads (FetchLogs responses, PushLogs requests); the
+gzip path was the top allocator on prod (memray showed gzip.compress at ~66%
+of allocated bytes in the finelog server alone). zstd cuts that meaningfully
+without giving up interop with gzip-only clients.
+"""
+
+from __future__ import annotations
+
+from connectrpc.compression.gzip import GzipCompression
+from connectrpc.compression.zstd import ZstdCompression
+
+# Order matters only on the client side (the negotiator walks the client's
+# Accept-Encoding in order); we keep zstd first here for readability.
+IRIS_RPC_COMPRESSIONS = (ZstdCompression(), GzipCompression())

--- a/uv.lock
+++ b/uv.lock
@@ -4721,11 +4721,13 @@ dependencies = [
     { name = "duckdb" },
     { name = "fsspec" },
     { name = "marin-rigging" },
+    { name = "numpy" },
     { name = "protobuf" },
     { name = "pyarrow" },
     { name = "pyyaml" },
     { name = "starlette" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "zstandard" },
 ]
 
 [package.dev-dependencies]
@@ -4744,11 +4746,13 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.0.0" },
     { name = "fsspec", specifier = ">=2024.0.0" },
     { name = "marin-rigging", editable = "lib/rigging" },
+    { name = "numpy", specifier = ">=1.26" },
     { name = "protobuf", specifier = ">=5.0" },
     { name = "pyarrow", specifier = ">=19.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "starlette", specifier = ">=0.50.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.23.0" },
+    { name = "zstandard", specifier = ">=0.22" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Memray on prod showed gzip.compress/decompress accounting for ~80% of allocated bytes. Switch the connect server and client to advertise and prefer zstd (gzip kept as fallback), trim two allocation hot spots (_decode_single_record_batch uses read_next_batch; _stamp_seq_column uses np.arange), bake memray/py-spy/gdb plus CAP_SYS_PTRACE into the image, and add a per-minute pool/RSS diagnostics line to distinguish ARROW-7305-style IPC buffer retention from ARROW-6910-style allocator arena retention.