### PR TITLE
Restore CoreWeave NCCL interface env

### DIFF
--- a/lib/iris/examples/coreweave-ci.yaml
+++ b/lib/iris/examples/coreweave-ci.yaml
@@ -39,6 +39,8 @@ defaults:
       milliseconds: 1200000    # 20 min — nodes are pinned warm so this rarely fires
   task_env:
     MARIN_PREFIX: s3://marin-na/marin
+    # H100 hostNetwork pods also see IB and SR-IOV link-local interfaces.
+    NCCL_SOCKET_IFNAME: =enp157s0np0
   worker:
     docker_image: ghcr.io/marin-community/iris-worker:latest
     port: 10001

--- a/lib/iris/examples/coreweave-rno2a.yaml
+++ b/lib/iris/examples/coreweave-rno2a.yaml
@@ -66,6 +66,7 @@ defaults:
       milliseconds: 2400000    # 40 min — covers bare-metal node provisioning + Pod startup
   task_env:
     MARIN_PREFIX: s3://marin-na/marin
+    NCCL_SOCKET_IFNAME: =eth0
   worker:
     docker_image: ghcr.io/marin-community/iris-worker:latest
     port: 10001

--- a/lib/iris/examples/coreweave-usw09b.yaml
+++ b/lib/iris/examples/coreweave-usw09b.yaml
@@ -64,6 +64,8 @@ defaults:
       milliseconds: 2400000    # 40 min — covers bare-metal node provisioning + Pod startup
   task_env:
     MARIN_PREFIX: s3://marin-na/marin
+    # B200 hostNetwork pods also see IB and SR-IOV link-local interfaces.
+    NCCL_SOCKET_IFNAME: =enp44s0np0
   worker:
     docker_image: ghcr.io/marin-community/iris-worker:latest
     port: 10001


### PR DESCRIPTION
## Summary

Set the NCCL socket bootstrap interface in the three CoreWeave Iris cluster configs.

`defaults.task_env` is injected into Kubernetes task pod envs by the Iris K8s provider, while job-level env vars still take precedence when a job explicitly overrides a key.

## Changes

- H100 `coreweave-ci`: `NCCL_SOCKET_IFNAME: =enp157s0np0`
- GH200 `coreweave-rno2a`: `NCCL_SOCKET_IFNAME: =eth0`
- B200 `coreweave-usw09b`: `NCCL_SOCKET_IFNAME: =enp44s0np0`

## Evidence

- Historical: #3806 fixed the old CoreWeave multi-host path with `NCCL_SOCKET_IFNAME=enp157s0np0`; #4197 later deleted that obsolete canary path when CoreWeave CI moved to the always-on `coreweave-ci` cluster from #4174.
- H100 discovery: live hostNetwork task-shaped probes saw both H100 nodes route via `enp157s0np0`; prior raw two-host JAX 0.10/CUDA 13 control on this branch hung without the env and completed `process_allgather` + `sync_global_devices` with `enp157s0np0`.
- GH200 discovery/validation: non-hostNetwork task pods route via `eth0`; a two-host, one-GPU-per-node raw JAX 0.10/CUDA 13 probe completed distributed init, `process_allgather`, and `sync_global_devices` with `NCCL_SOCKET_IFNAME==eth0`.
- B200 discovery: live hostNetwork task-shaped probes saw both B200 nodes route via `enp44s0np0`.

## Validation

Local:

- `./infra/pre-commit.py lib/iris/examples/coreweave-ci.yaml lib/iris/examples/coreweave-rno2a.yaml lib/iris/examples/coreweave-usw09b.yaml`
- `uv run pytest tests/test_dry_run.py -k canary_ferry`
- `cd lib/iris && uv run --group dev pytest tests/cluster/providers/test_config.py -k example_configs_load_and_transform`
- One-off config check loaded each CoreWeave config and verified the expected `NCCL_SOCKET_IFNAME` value.

Live cluster:

- Validated interface discovery on H100, GH200, and B200.
- Validated GH200 raw two-host JAX 0.10/CUDA 13 collective with `=eth0`.
- Validated the H100 `coreweave-ci` Iris config end to end with a partial two-host Grug MoE workload:
  - Rolled the live Iris controller to this PR's branch image/config.
  - Env check job printed `NCCL_SOCKET_IFNAME='=enp157s0np0'` from `defaults.task_env`.
  - Submitted `/romain/synthetic-grug-moe-eager2-082345`, which launched two H100 train workers on separate nodes.
  - Both train workers had `NCCL_SOCKET_IFNAME='=enp157s0np0'`, initialized JAX as `process_count=2`, `local_device_count=8`, `device_count=16`, trained through `2/2` steps, saved the step-2 checkpoint, and exited successfully.
  - Iris reported the child train job `JOB_STATE_SUCCEEDED` with `task_state_counts: {"succeeded": 2}`.
  - The H100 NodePool scaled back down to `target=1 current=1` after the run.
- B200 raw JAX collective validation is pending because CoreWeave `hpc-verification` pods currently reserve all B200 GPUs.
