### PR TITLE
Redact CoreWeave diagnostics secrets

### DIFF
--- a/lib/iris/src/iris/cluster/redaction.py
+++ b/lib/iris/src/iris/cluster/redaction.py
@@ -9,14 +9,12 @@ controller (when returning job requests via RPC).
 
 import json
 import logging
-import re
+
+from rigging.redaction import REDACTED_VALUE, is_sensitive_key_name, redact_string, redact_value
 
 from iris.rpc import controller_pb2
 
 logger = logging.getLogger(__name__)
-
-SENSITIVE_ENV_KEY_RE = re.compile(r"KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL", re.IGNORECASE)
-REDACTED_VALUE = "**REDACTED**"
 
 # CLI flags on `iris job run` that take a (KEY, VALUE) pair via Click's
 # type=(str, str). Keep in sync with the Click option definition in
@@ -27,7 +25,7 @@ _ENV_VAR_SHORT_FLAG = "-e"
 
 def is_sensitive_env_key(key: str) -> bool:
     """Return True if *key* looks like a secret env var name."""
-    return bool(SENSITIVE_ENV_KEY_RE.search(key))
+    return is_sensitive_key_name(key)
 
 
 def _env_var_flag_key(token: str, next_token: str | None) -> str | None:
@@ -61,27 +59,20 @@ def redact_request_env_vars(
     for key in list(env_vars):
         if is_sensitive_env_key(key):
             env_vars[key] = REDACTED_VALUE
+        else:
+            env_vars[key] = redact_string(env_vars[key])
     return redacted
-
-
-def _redact_tree(node):
-    """Walk a parsed-JSON tree, redacting values under sensitive-looking keys."""
-    if isinstance(node, dict):
-        return {k: REDACTED_VALUE if is_sensitive_env_key(k) else _redact_tree(v) for k, v in node.items()}
-    if isinstance(node, list):
-        return [_redact_tree(v) for v in node]
-    return node
 
 
 def redact_json_preview(rendered: str) -> str:
     """Return *rendered* with values under sensitive-looking keys replaced.
 
     The input is arbitrary JSON (typically a protobuf rendered via
-    ``MessageToJson``). Any key matching :data:`SENSITIVE_ENV_KEY_RE` at
-    any depth has its value replaced with :data:`REDACTED_VALUE`; this also
-    covers map<string,string> fields like ``env_vars`` where secrets tend
-    to live. Unparseable input is returned unchanged so callers never lose
-    the preview entirely.
+    ``MessageToJson``). Any key matching the shared sensitive-key regex has
+    its value replaced with :data:`REDACTED_VALUE`; this also covers
+    map<string,string> fields like ``env_vars`` where secrets tend to live.
+    Unparseable input is returned unchanged so callers never lose the preview
+    entirely.
     """
     if not rendered:
         return rendered
@@ -90,7 +81,7 @@ def redact_json_preview(rendered: str) -> str:
     except ValueError:
         logger.debug("redact_json_preview: input was not valid JSON, returning as-is")
         return rendered
-    return json.dumps(_redact_tree(tree), separators=(",", ":"))
+    return json.dumps(redact_value(tree), separators=(",", ":"))
 
 
 def redact_submit_argv(argv: list[str]) -> list[str]:
@@ -102,8 +93,9 @@ def redact_submit_argv(argv: list[str]) -> list[str]:
       * ``--env-vars=KEY VALUE`` — attached long form
       * ``-eKEY VALUE`` — attached short form
 
-    When KEY matches SENSITIVE_ENV_KEY_RE, VALUE is replaced with
-    REDACTED_VALUE. Other tokens pass through unchanged.
+    When KEY matches the shared sensitive-key regex, VALUE is replaced with
+    REDACTED_VALUE. Values under benign keys still pass through the shared
+    string redactor so prefixed or high-entropy tokens do not leak.
     """
     out = list(argv)
     n = len(out)
@@ -126,7 +118,7 @@ def redact_submit_argv(argv: list[str]) -> list[str]:
             i += 1
             continue
 
-        if is_sensitive_env_key(key):
-            out[val_idx] = REDACTED_VALUE
+        value = out[val_idx]
+        out[val_idx] = REDACTED_VALUE if is_sensitive_env_key(key) else redact_string(value)
         i = val_idx + 1
     return out

--- a/lib/iris/src/iris/cluster/redaction.py
+++ b/lib/iris/src/iris/cluster/redaction.py
@@ -1,31 +1,22 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared helpers for redacting secrets from job submissions and responses.
+"""Iris-specific redaction wrappers around :mod:`rigging.redaction`.
 
-Used on both the client (before capturing argv for bookkeeping) and the
-controller (when returning job requests via RPC).
+The actual secret-pattern matching lives in ``rigging``; this module only
+adapts iris-specific shapes (the ``LaunchJobRequest`` proto and Click argv
+for ``iris job run``) into a form the shared redactor can consume.
 """
-
-import json
-import logging
 
 from rigging.redaction import REDACTED_VALUE, is_sensitive_key_name, redact_string, redact_value
 
 from iris.rpc import controller_pb2
-
-logger = logging.getLogger(__name__)
 
 # CLI flags on `iris job run` that take a (KEY, VALUE) pair via Click's
 # type=(str, str). Keep in sync with the Click option definition in
 # iris/cli/job.py; see the `-e/--env-vars` option on the `run` command.
 _ENV_VAR_LONG_FLAG = "--env-vars"
 _ENV_VAR_SHORT_FLAG = "-e"
-
-
-def is_sensitive_env_key(key: str) -> bool:
-    """Return True if *key* looks like a secret env var name."""
-    return is_sensitive_key_name(key)
 
 
 def _env_var_flag_key(token: str, next_token: str | None) -> str | None:
@@ -56,32 +47,10 @@ def redact_request_env_vars(
     redacted = controller_pb2.Controller.LaunchJobRequest()
     redacted.CopyFrom(request)
     env_vars = redacted.environment.env_vars
-    for key in list(env_vars):
-        if is_sensitive_env_key(key):
-            env_vars[key] = REDACTED_VALUE
-        else:
-            env_vars[key] = redact_string(env_vars[key])
+    redacted_env = redact_value(dict(env_vars))
+    env_vars.clear()
+    env_vars.update(redacted_env)
     return redacted
-
-
-def redact_json_preview(rendered: str) -> str:
-    """Return *rendered* with values under sensitive-looking keys replaced.
-
-    The input is arbitrary JSON (typically a protobuf rendered via
-    ``MessageToJson``). Any key matching the shared sensitive-key regex has
-    its value replaced with :data:`REDACTED_VALUE`; this also covers
-    map<string,string> fields like ``env_vars`` where secrets tend to live.
-    Unparseable input is returned unchanged so callers never lose the preview
-    entirely.
-    """
-    if not rendered:
-        return rendered
-    try:
-        tree = json.loads(rendered)
-    except ValueError:
-        logger.debug("redact_json_preview: input was not valid JSON, returning as-is")
-        return rendered
-    return json.dumps(redact_value(tree), separators=(",", ":"))
 
 
 def redact_submit_argv(argv: list[str]) -> list[str]:
@@ -119,6 +88,6 @@ def redact_submit_argv(argv: list[str]) -> list[str]:
             continue
 
         value = out[val_idx]
-        out[val_idx] = REDACTED_VALUE if is_sensitive_env_key(key) else redact_string(value)
+        out[val_idx] = REDACTED_VALUE if is_sensitive_key_name(key) else redact_string(value)
         i = val_idx + 1
     return out

--- a/lib/iris/src/iris/rpc/stats.py
+++ b/lib/iris/src/iris/rpc/stats.py
@@ -29,8 +29,8 @@ from dataclasses import dataclass
 from connectrpc.request import RequestContext
 from google.protobuf.json_format import MessageToJson
 from google.protobuf.message import Message
+from rigging.redaction import redact_json_text
 
-from iris.cluster.redaction import redact_json_preview
 from iris.rpc import stats_pb2, time_pb2
 from iris.rpc.auth import get_verified_identity
 
@@ -279,7 +279,7 @@ def _render_preview(request: Message | None, max_bytes: int) -> str:
     except Exception:
         logger.debug("Failed to render request preview for %s", type(request).__name__, exc_info=True)
         return ""
-    rendered = redact_json_preview(rendered)
+    rendered = redact_json_text(rendered)
     return _truncate(rendered, max_bytes)
 
 

--- a/lib/iris/tests/cluster/test_redaction.py
+++ b/lib/iris/tests/cluster/test_redaction.py
@@ -74,6 +74,24 @@ def test_redact_submit_argv_leaves_benign_env_alone():
     assert redact_submit_argv(argv) == argv
 
 
+def test_redact_submit_argv_redacts_secret_like_value_under_benign_key():
+    argv = [
+        "iris",
+        "job",
+        "run",
+        "-e",
+        "CACHE_BUSTER",
+        "ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ",
+        "--",
+        "python",
+        "t.py",
+    ]
+
+    out = redact_submit_argv(argv)
+
+    assert out[5] == REDACTED_VALUE
+
+
 def test_redact_submit_argv_passthrough_without_env_flag():
     argv = ["iris", "job", "run", "--", "python", "-m", "foo"]
     assert redact_submit_argv(argv) == argv

--- a/lib/iris/tests/cluster/test_redaction.py
+++ b/lib/iris/tests/cluster/test_redaction.py
@@ -1,52 +1,15 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for iris.cluster.redaction."""
+"""Tests for iris.cluster.redaction.
 
-import json
+The shared regex/entropy/key-name behavior is covered in
+``lib/rigging/tests/test_redaction.py``. These tests focus on iris-specific
+adaptation: argv parsing for ``iris job run -e KEY VALUE`` in every Click
+syntax variant.
+"""
 
-from iris.cluster.redaction import (
-    REDACTED_VALUE,
-    is_sensitive_env_key,
-    redact_json_preview,
-    redact_submit_argv,
-)
-
-
-def test_redact_json_preview_redacts_nested_sensitive_keys():
-    raw = json.dumps(
-        {
-            "name": "train-job",
-            "environment": {"env_vars": {"HF_TOKEN": "hf_xyz", "LOG_LEVEL": "info"}},
-            "metadata": [{"api_key": "sk-abc"}, {"benign": "ok"}],
-        }
-    )
-    out = json.loads(redact_json_preview(raw))
-    assert out["environment"]["env_vars"]["HF_TOKEN"] == REDACTED_VALUE
-    assert out["environment"]["env_vars"]["LOG_LEVEL"] == "info"
-    assert out["metadata"][0]["api_key"] == REDACTED_VALUE
-    assert out["metadata"][1]["benign"] == "ok"
-    assert out["name"] == "train-job"
-
-
-def test_redact_json_preview_passes_through_invalid_json():
-    assert redact_json_preview("not json{{{") == "not json{{{"
-    assert redact_json_preview("") == ""
-
-
-def test_is_sensitive_env_key_matches_common_secret_names():
-    assert is_sensitive_env_key("WANDB_API_KEY")
-    assert is_sensitive_env_key("HF_TOKEN")
-    assert is_sensitive_env_key("MY_SECRET")
-    assert is_sensitive_env_key("DB_PASSWORD")
-    assert is_sensitive_env_key("GCP_CREDENTIAL_PATH")
-    assert is_sensitive_env_key("api_key")  # case-insensitive
-
-
-def test_is_sensitive_env_key_leaves_benign_names():
-    assert not is_sensitive_env_key("LOG_LEVEL")
-    assert not is_sensitive_env_key("NUM_WORKERS")
-    assert not is_sensitive_env_key("HOSTNAME")
+from iris.cluster.redaction import REDACTED_VALUE, redact_submit_argv
 
 
 def test_redact_submit_argv_redacts_short_flag():

--- a/lib/rigging/src/rigging/redaction.py
+++ b/lib/rigging/src/rigging/redaction.py
@@ -1,0 +1,77 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared secret redaction helpers."""
+
+import math
+import re
+
+REDACTED_VALUE = "[REDACTED]"
+
+_MIN_KEY_ENTROPY = 3.5
+_KEY_CHARS_RE = re.compile(r"[A-Za-z0-9+/_-]+={0,2}")
+KEY_LIKE_RE = re.compile(r"(?<![A-Za-z0-9+/_-])[A-Za-z0-9+/_-]{32,}={0,2}(?![A-Za-z0-9+/_=-])")
+PREFIXED_SECRET_RE = re.compile(
+    r"-----BEGIN [A-Z ]+PRIVATE KEY-----[\s\S]+?-----END [A-Z ]+PRIVATE KEY-----"
+    r"|(?<![A-Za-z0-9_-])(?:"
+    r"sk-[A-Za-z0-9_-]{20,}"
+    r"|AKIA[0-9A-Z]{16}"
+    r"|ASIA[0-9A-Z]{16}"
+    r"|gh[pousr]_[A-Za-z0-9]{36,}"
+    r"|xox[abprs]-[A-Za-z0-9-]{10,}"
+    r"|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"
+    r")(?![A-Za-z0-9_-])"
+)
+SENSITIVE_KEY_RE = re.compile(
+    r"api[_-]?key|secret|token|password|passwd|pwd|auth|credential|private[_-]?key|access[_-]?key|bearer|session",
+    re.IGNORECASE,
+)
+
+
+def shannon_entropy(value: str) -> float:
+    if not value:
+        return 0.0
+
+    frequencies: dict[str, int] = {}
+    for character in value:
+        frequencies[character] = frequencies.get(character, 0) + 1
+
+    length = len(value)
+    return -sum((count / length) * math.log2(count / length) for count in frequencies.values())
+
+
+def looks_like_key(value: str, min_len: int = 24, min_entropy: float = _MIN_KEY_ENTROPY) -> bool:
+    return len(value) >= min_len and _KEY_CHARS_RE.fullmatch(value) is not None and shannon_entropy(value) >= min_entropy
+
+
+def is_sensitive_key_name(name: str) -> bool:
+    return SENSITIVE_KEY_RE.search(name) is not None
+
+
+def _redact_key_like_match(match: re.Match[str]) -> str:
+    value = match.group(0)
+    if shannon_entropy(value) >= _MIN_KEY_ENTROPY:
+        return REDACTED_VALUE
+    return value
+
+
+def redact_string(value: str) -> str:
+    redacted = PREFIXED_SECRET_RE.sub(REDACTED_VALUE, value)
+    return KEY_LIKE_RE.sub(_redact_key_like_match, redacted)
+
+
+def redact_value(value: object) -> object:
+    if isinstance(value, dict):
+        return {
+            key: REDACTED_VALUE if isinstance(key, str) and is_sensitive_key_name(key) else redact_value(child)
+            for key, child in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_value(child) for child in value]
+    if isinstance(value, tuple):
+        return tuple(redact_value(child) for child in value)
+    if isinstance(value, str):
+        if looks_like_key(value):
+            return REDACTED_VALUE
+        return redact_string(value)
+    return value

--- a/lib/rigging/src/rigging/redaction.py
+++ b/lib/rigging/src/rigging/redaction.py
@@ -3,6 +3,7 @@
 
 """Shared secret redaction helpers."""
 
+import json
 import math
 import re
 
@@ -75,3 +76,18 @@ def redact_value(value: object) -> object:
             return REDACTED_VALUE
         return redact_string(value)
     return value
+
+
+def redact_json_text(rendered: str) -> str:
+    """Parse *rendered* as JSON, redact the structure, and re-emit a compact JSON string.
+
+    Falls back to :func:`redact_string` when the input is not valid JSON, so callers
+    never lose protection on malformed previews. An empty string is returned as-is.
+    """
+    if not rendered:
+        return rendered
+    try:
+        tree = json.loads(rendered)
+    except (ValueError, TypeError):
+        return redact_string(rendered)
+    return json.dumps(redact_value(tree), separators=(",", ":"))

--- a/lib/rigging/tests/test_redaction.py
+++ b/lib/rigging/tests/test_redaction.py
@@ -1,7 +1,9 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from rigging.redaction import REDACTED_VALUE, looks_like_key, redact_string, redact_value
+import json
+
+from rigging.redaction import REDACTED_VALUE, looks_like_key, redact_json_text, redact_string, redact_value
 
 
 def test_redact_value_redacts_sensitive_key_names():
@@ -73,3 +75,29 @@ def test_redact_value_redacts_secret_like_strings_under_benign_keys():
     value = {"cache_buster": "ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ", "log_level": "info"}
 
     assert redact_value(value) == {"cache_buster": REDACTED_VALUE, "log_level": "info"}
+
+
+def test_redact_json_text_redacts_nested_sensitive_keys():
+    raw = json.dumps(
+        {
+            "name": "train-job",
+            "environment": {"env_vars": {"HF_TOKEN": "hf_xyz", "LOG_LEVEL": "info"}},
+            "metadata": [{"api_key": "sk-abc"}, {"benign": "ok"}],
+        }
+    )
+
+    out = json.loads(redact_json_text(raw))
+
+    assert out["environment"]["env_vars"]["HF_TOKEN"] == REDACTED_VALUE
+    assert out["environment"]["env_vars"]["LOG_LEVEL"] == "info"
+    assert out["metadata"][0]["api_key"] == REDACTED_VALUE
+    assert out["metadata"][1]["benign"] == "ok"
+    assert out["name"] == "train-job"
+
+
+def test_redact_json_text_falls_back_to_string_redaction_on_invalid_json():
+    # Not valid JSON, but contains a prefixed token — caller still gets protection.
+    leaky = "not json{{{ ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ"
+    assert redact_json_text(leaky) == "not json{{{ " + REDACTED_VALUE
+    assert redact_json_text("plain not json") == "plain not json"
+    assert redact_json_text("") == ""

--- a/lib/rigging/tests/test_redaction.py
+++ b/lib/rigging/tests/test_redaction.py
@@ -1,0 +1,75 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from rigging.redaction import REDACTED_VALUE, looks_like_key, redact_string, redact_value
+
+
+def test_redact_value_redacts_sensitive_key_names():
+    value = {
+        "api_key": "short-low-entropy-value",
+        "nested": {
+            "access-token": "another-low-entropy-value",
+            "log_level": "debug",
+        },
+        "items": [{"password": "password-value"}, {"name": "worker"}],
+    }
+
+    assert redact_value(value) == {
+        "api_key": REDACTED_VALUE,
+        "nested": {
+            "access-token": REDACTED_VALUE,
+            "log_level": "debug",
+        },
+        "items": [{"password": REDACTED_VALUE}, {"name": "worker"}],
+    }
+
+
+def test_redact_string_redacts_prefixed_tokens():
+    slack_token = "xox" + "b-1234567890-abcdefghijklmnopqrstuvwxyz"
+    raw = (
+        "aws=AKIAIOSFODNN7EXAMPLE "
+        "github=ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ "
+        f"slack={slack_token} "
+        "jwt=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.sflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    )
+
+    redacted = redact_string(raw)
+
+    assert "AKIAIOSFODNN7EXAMPLE" not in redacted
+    assert "ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ" not in redacted
+    assert slack_token not in redacted
+    assert "eyJhbGciOiJIUzI1NiJ9" not in redacted
+    assert redacted.count(REDACTED_VALUE) == 4
+
+
+def test_redact_string_redacts_private_keys():
+    raw = """\
+before
+-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAxV2cX8jVh2cP3m8n5q4r3s2t1u0v9w8x7y6z5a4b3c2d1e0f
+-----END RSA PRIVATE KEY-----
+after
+"""
+
+    assert redact_string(raw) == f"before\n{REDACTED_VALUE}\nafter\n"
+
+
+def test_redact_string_redacts_high_entropy_key_like_runs():
+    secret = "AbCDef1234567890+/MnOpQrStUvWxYz0987654321"
+    redacted = redact_string(f"token={secret}")
+
+    assert secret not in redacted
+    assert redacted == f"token={REDACTED_VALUE}"
+
+
+def test_redact_string_preserves_low_entropy_long_strings():
+    value = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+    assert not looks_like_key(value)
+    assert redact_string(value) == value
+
+
+def test_redact_value_redacts_secret_like_strings_under_benign_keys():
+    value = {"cache_buster": "ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ", "log_level": "info"}
+
+    assert redact_value(value) == {"cache_buster": REDACTED_VALUE, "log_level": "info"}

--- a/scripts/workflows/iris_monitor.py
+++ b/scripts/workflows/iris_monitor.py
@@ -19,6 +19,7 @@ import click
 from iris.cluster.providers.k8s.tasks import _sanitize_label_value
 from iris.cluster.types import is_job_finished
 from iris.rpc import job_pb2
+from rigging.redaction import REDACTED_VALUE, is_sensitive_key_name, redact_string, redact_value
 
 _REPO_ROOT = Path(__file__).parents[2]
 
@@ -37,8 +38,6 @@ sudo journalctl -u google-startup-scripts.service --no-pager 2>&1 | tail -n 2000
 echo '=== cloud-final journal ==='
 sudo journalctl -u cloud-final.service --no-pager 2>&1 | tail -n 500
 """
-
-_REDACTED_VALUE = "[REDACTED]"
 
 
 @dataclass(frozen=True)
@@ -225,13 +224,35 @@ def _kubectl(kubeconfig: Path | None) -> list[str]:
     return cmd
 
 
+def _redact_kubernetes_env_literal(name: object, value: object) -> object:
+    if not isinstance(value, str):
+        return redact_value(value)
+    if isinstance(name, str) and is_sensitive_key_name(name):
+        return REDACTED_VALUE
+
+    stripped = value.lstrip()
+    if not stripped.startswith(("{", "[")):
+        return redact_string(value)
+
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return redact_string(value)
+
+    return json.dumps(redact_value(parsed), separators=(",", ":"))
+
+
 def _redact_kubernetes_env_entry(entry: object) -> object:
     if not isinstance(entry, dict):
         return _redact_kubernetes_env_values(entry)
 
-    redacted = {key: _redact_kubernetes_env_values(value) for key, value in entry.items()}
-    if "value" in redacted:
-        redacted["value"] = _REDACTED_VALUE
+    redacted = {}
+    name = entry.get("name")
+    for key, value in entry.items():
+        if key == "value":
+            redacted[key] = _redact_kubernetes_env_literal(name, value)
+        else:
+            redacted[key] = _redact_kubernetes_env_values(value)
     return redacted
 
 

--- a/scripts/workflows/iris_monitor.py
+++ b/scripts/workflows/iris_monitor.py
@@ -38,6 +38,8 @@ echo '=== cloud-final journal ==='
 sudo journalctl -u cloud-final.service --no-pager 2>&1 | tail -n 500
 """
 
+_REDACTED_VALUE = "[REDACTED]"
+
 
 @dataclass(frozen=True)
 class IrisJobStatus:
@@ -223,6 +225,29 @@ def _kubectl(kubeconfig: Path | None) -> list[str]:
     return cmd
 
 
+def _redact_kubernetes_env_entry(entry: object) -> object:
+    if not isinstance(entry, dict):
+        return _redact_kubernetes_env_values(entry)
+
+    redacted = {key: _redact_kubernetes_env_values(value) for key, value in entry.items()}
+    if "value" in redacted:
+        redacted["value"] = _REDACTED_VALUE
+    return redacted
+
+
+def _redact_kubernetes_env_values(value: object) -> object:
+    if isinstance(value, list):
+        return [_redact_kubernetes_env_values(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+
+    redacted = {key: _redact_kubernetes_env_values(child) for key, child in value.items()}
+    env = value.get("env")
+    if isinstance(env, list):
+        redacted["env"] = [_redact_kubernetes_env_entry(entry) for entry in env]
+    return redacted
+
+
 def _kubectl_dump(
     cmd: list[str],
     output_path: Path,
@@ -232,6 +257,26 @@ def _kubectl_dump(
     output_path.write_text(result.stdout or result.stderr or "")
     if result.returncode != 0:
         return f"{description} failed (exit {result.returncode}): {result.stderr.strip()}"
+    return None
+
+
+def _kubectl_pod_json_dump(
+    cmd: list[str],
+    output_path: Path,
+    description: str,
+) -> str | None:
+    result = _run(cmd)
+    if result.returncode != 0:
+        output_path.write_text(result.stderr)
+        return f"{description} failed (exit {result.returncode}): {result.stderr.strip()}"
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        output_path.write_text("")
+        return f"{description} returned invalid JSON: {exc}"
+
+    output_path.write_text(json.dumps(_redact_kubernetes_env_values(data), indent=2) + "\n")
     return None
 
 
@@ -252,7 +297,7 @@ def _collect_coreweave(
     # Match the controller's iris.job_id label sanitization, or the selector misses everything.
     label = _sanitize_label_value(job_id.lstrip("/"))[:63]
     pods_path = output_dir / "kubernetes-pods.json"
-    err = _kubectl_dump(
+    err = _kubectl_pod_json_dump(
         [*kctl, "-n", namespace, "get", "pods", f"-l=iris.job_id={label}", "-o", "json"],
         pods_path,
         "kubectl get pods (job)",
@@ -273,15 +318,18 @@ def _collect_coreweave(
             ["-n", namespace, "logs", "-l", "app=iris-controller", "--tail=-1", "--all-containers", "--previous"],
             "kubectl logs controller --previous",
         ),
-        (
-            "controller-describe.txt",
-            ["-n", namespace, "describe", "pod", "-l", "app=iris-controller"],
-            "kubectl describe controller",
-        ),
     ]:
         err = _kubectl_dump([*kctl, *args], output_dir / fname, desc)
         if err is None:
             written.append(fname)
+
+    err = _kubectl_pod_json_dump(
+        [*kctl, "-n", namespace, "get", "pods", "-l", "app=iris-controller", "-o", "json"],
+        output_dir / "controller-pods.json",
+        "kubectl get controller pods",
+    )
+    if err is None:
+        written.append("controller-pods.json")
 
     if managed_label:
         list_result = _run([*kctl, "-n", namespace, "get", "pods", "-l", f"{managed_label}=true", "-o", "name"])
@@ -290,18 +338,24 @@ def _collect_coreweave(
                 if not line:
                     continue
                 safe = line.replace("/", "-")
-                _kubectl_dump(
+                log_err = _kubectl_dump(
                     [*kctl, "-n", namespace, "logs", line, "--tail=-1", "--all-containers"],
                     output_dir / f"{safe}.log",
                     f"kubectl logs {line}",
                 )
-                _kubectl_dump(
-                    [*kctl, "-n", namespace, "describe", line],
-                    output_dir / f"{safe}-describe.txt",
-                    f"kubectl describe {line}",
+                pod_err = _kubectl_pod_json_dump(
+                    [*kctl, "-n", namespace, "get", line, "-o", "json"],
+                    output_dir / f"{safe}.json",
+                    f"kubectl get {line}",
                 )
-                written.append(f"{safe}.log")
-                written.append(f"{safe}-describe.txt")
+                if log_err is None:
+                    written.append(f"{safe}.log")
+                else:
+                    errors.append(log_err)
+                if pod_err is None:
+                    written.append(f"{safe}.json")
+                else:
+                    errors.append(pod_err)
         else:
             errors.append(f"kubectl get pods -l {managed_label}=true failed: {list_result.stderr.strip()}")
 

--- a/scripts/workflows/iris_monitor.py
+++ b/scripts/workflows/iris_monitor.py
@@ -229,48 +229,48 @@ def _redact_pod_doc(value: object) -> object:
 
     Kubernetes encodes container env as ``[{"name": ..., "value": ...}, ...]``,
     which hides the env-var name from a generic dict redactor. We lift each
-    entry into a single-key ``{name: value}`` dict so name-based sensitivity
-    matching applies, then write the redacted value back.
+    entry's value into a single-key ``{name: value}`` dict so name-based
+    sensitivity matching applies, then write the redacted value back.
     """
     if isinstance(value, list):
         return [_redact_pod_doc(item) for item in value]
     if not isinstance(value, dict):
         return redact_value(value)
     return {
-        key: _redact_pod_env_array(val) if key == "env" and isinstance(val, list) else _redact_pod_doc(val)
+        key: _redact_env_array(val) if key == "env" and isinstance(val, list) else _redact_pod_doc(val)
         for key, val in value.items()
     }
 
 
-def _redact_pod_env_array(env_list: list) -> list:
+def _redact_env_array(env_list: list) -> list:
+    """Redact a Kubernetes container env array.
+
+    Each ``{"name": X, "value": Y}`` entry is lifted into ``{X: Y}`` so the
+    shared redactor matches by env-var name. JSON-encoded values (e.g.
+    ``IRIS_JOB_ENV``) are parsed first so nested secrets are caught, then
+    re-serialized. ``valueFrom``-only entries and malformed shapes flow
+    through the general dict walker unchanged.
+    """
     out = []
     for entry in env_list:
         if not isinstance(entry, dict) or not isinstance(entry.get("name"), str) or "value" not in entry:
-            # `valueFrom`-only entries and malformed shapes flow through the general redactor unchanged.
             out.append(_redact_pod_doc(entry))
             continue
+        name = entry["name"]
+        raw = entry["value"]
+        parsed = raw
+        if isinstance(raw, str) and raw.lstrip().startswith(("{", "[")):
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError:
+                pass
+        redacted = redact_value({name: parsed})[name]
+        if isinstance(redacted, (dict, list)):
+            redacted = json.dumps(redacted, separators=(",", ":"))
         new_entry = {key: _redact_pod_doc(val) for key, val in entry.items() if key != "value"}
-        new_entry["value"] = _redact_env_literal(entry["name"], entry["value"])
+        new_entry["value"] = redacted
         out.append(new_entry)
     return out
-
-
-def _redact_env_literal(name: str, raw: object) -> object:
-    """Redact a literal env value by lifting ``{name: raw}`` into a dict for ``redact_value``.
-
-    JSON-encoded values (e.g. ``IRIS_JOB_ENV``) are parsed first so nested
-    secrets are caught, then re-serialized.
-    """
-    parsed = raw
-    if isinstance(raw, str) and raw.lstrip().startswith(("{", "[")):
-        try:
-            parsed = json.loads(raw)
-        except json.JSONDecodeError:
-            parsed = raw
-    redacted = redact_value({name: parsed})[name]
-    if isinstance(redacted, (dict, list)):
-        return json.dumps(redacted, separators=(",", ":"))
-    return redacted
 
 
 def _kubectl_dump(

--- a/scripts/workflows/iris_monitor.py
+++ b/scripts/workflows/iris_monitor.py
@@ -19,7 +19,7 @@ import click
 from iris.cluster.providers.k8s.tasks import _sanitize_label_value
 from iris.cluster.types import is_job_finished
 from iris.rpc import job_pb2
-from rigging.redaction import REDACTED_VALUE, is_sensitive_key_name, redact_string, redact_value
+from rigging.redaction import redact_value
 
 _REPO_ROOT = Path(__file__).parents[2]
 
@@ -224,48 +224,52 @@ def _kubectl(kubeconfig: Path | None) -> list[str]:
     return cmd
 
 
-def _redact_kubernetes_env_literal(name: object, value: object) -> object:
-    if not isinstance(value, str):
-        return redact_value(value)
-    if isinstance(name, str) and is_sensitive_key_name(name):
-        return REDACTED_VALUE
+def _redact_pod_doc(value: object) -> object:
+    """Redact a parsed Kubernetes pod document via the shared rigging redactor.
 
-    stripped = value.lstrip()
-    if not stripped.startswith(("{", "[")):
-        return redact_string(value)
-
-    try:
-        parsed = json.loads(value)
-    except json.JSONDecodeError:
-        return redact_string(value)
-
-    return json.dumps(redact_value(parsed), separators=(",", ":"))
-
-
-def _redact_kubernetes_env_entry(entry: object) -> object:
-    if not isinstance(entry, dict):
-        return _redact_kubernetes_env_values(entry)
-
-    redacted = {}
-    name = entry.get("name")
-    for key, value in entry.items():
-        if key == "value":
-            redacted[key] = _redact_kubernetes_env_literal(name, value)
-        else:
-            redacted[key] = _redact_kubernetes_env_values(value)
-    return redacted
-
-
-def _redact_kubernetes_env_values(value: object) -> object:
+    Kubernetes encodes container env as ``[{"name": ..., "value": ...}, ...]``,
+    which hides the env-var name from a generic dict redactor. We lift each
+    entry into a single-key ``{name: value}`` dict so name-based sensitivity
+    matching applies, then write the redacted value back.
+    """
     if isinstance(value, list):
-        return [_redact_kubernetes_env_values(item) for item in value]
+        return [_redact_pod_doc(item) for item in value]
     if not isinstance(value, dict):
-        return value
+        return redact_value(value)
+    return {
+        key: _redact_pod_env_array(val) if key == "env" and isinstance(val, list) else _redact_pod_doc(val)
+        for key, val in value.items()
+    }
 
-    redacted = {key: _redact_kubernetes_env_values(child) for key, child in value.items()}
-    env = value.get("env")
-    if isinstance(env, list):
-        redacted["env"] = [_redact_kubernetes_env_entry(entry) for entry in env]
+
+def _redact_pod_env_array(env_list: list) -> list:
+    out = []
+    for entry in env_list:
+        if not isinstance(entry, dict) or not isinstance(entry.get("name"), str) or "value" not in entry:
+            # `valueFrom`-only entries and malformed shapes flow through the general redactor unchanged.
+            out.append(_redact_pod_doc(entry))
+            continue
+        new_entry = {key: _redact_pod_doc(val) for key, val in entry.items() if key != "value"}
+        new_entry["value"] = _redact_env_literal(entry["name"], entry["value"])
+        out.append(new_entry)
+    return out
+
+
+def _redact_env_literal(name: str, raw: object) -> object:
+    """Redact a literal env value by lifting ``{name: raw}`` into a dict for ``redact_value``.
+
+    JSON-encoded values (e.g. ``IRIS_JOB_ENV``) are parsed first so nested
+    secrets are caught, then re-serialized.
+    """
+    parsed = raw
+    if isinstance(raw, str) and raw.lstrip().startswith(("{", "[")):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            parsed = raw
+    redacted = redact_value({name: parsed})[name]
+    if isinstance(redacted, (dict, list)):
+        return json.dumps(redacted, separators=(",", ":"))
     return redacted
 
 
@@ -297,7 +301,7 @@ def _kubectl_pod_json_dump(
         output_path.write_text("")
         return f"{description} returned invalid JSON: {exc}"
 
-    output_path.write_text(json.dumps(_redact_kubernetes_env_values(data), indent=2) + "\n")
+    output_path.write_text(json.dumps(_redact_pod_doc(data), indent=2) + "\n")
     return None
 
 

--- a/tests/workflows/test_iris_monitor.py
+++ b/tests/workflows/test_iris_monitor.py
@@ -4,6 +4,8 @@
 import json
 import subprocess
 
+from rigging.redaction import REDACTED_VALUE
+
 from scripts.workflows import iris_monitor
 
 
@@ -46,6 +48,7 @@ def test_settled_coreweave_controller_requires_exactly_one_ready_pod() -> None:
 
 
 def test_collect_coreweave_redacts_sensitive_env_values(monkeypatch, tmp_path):
+    slack_token = "xox" + "b-1234567890-abcdefghijklmnopqrstuvwxyz"
     pod_json = {
         "items": [
             {
@@ -60,12 +63,17 @@ def test_collect_coreweave_redacts_sensitive_env_values(monkeypatch, tmp_path):
                                 {"name": "AWS_ACCESS_KEY_ID", "value": "AKIA_TEST_ACCESS"},
                                 {"name": "WANDB_API_KEY", "value": "wandb-test-secret"},
                                 {
+                                    "name": "CACHE_BUSTER",
+                                    "value": "ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ",
+                                },
+                                {
                                     "name": "IRIS_JOB_ENV",
                                     "value": json.dumps(
                                         {
                                             "AWS_SECRET_ACCESS_KEY": "nested-secret-key",
                                             "HF_TOKEN": "nested-hf-token",
                                             "WANDB_API_KEY": "nested-wandb-key",
+                                            "LOG_LEVEL": "debug",
                                         }
                                     ),
                                 },
@@ -118,6 +126,7 @@ def test_collect_coreweave_redacts_sensitive_env_values(monkeypatch, tmp_path):
                         {"name": "AWS_SECRET_ACCESS_KEY", "value": "worker-secret-key"},
                         {"name": "AWS_SESSION_TOKEN", "value": "worker-session-token"},
                         {"name": "HF_TOKEN", "value": "hf-literal-token"},
+                        {"name": "CACHE_BUSTER", "value": slack_token},
                         {
                             "name": "AWS_ACCESS_KEY_ID",
                             "valueFrom": {
@@ -203,18 +212,21 @@ def test_collect_coreweave_redacts_sensitive_env_values(monkeypatch, tmp_path):
     for secret in [
         "AKIA_TEST_ACCESS",
         "wandb-test-secret",
+        "ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ",
         "nested-secret-key",
         "nested-hf-token",
         "nested-wandb-key",
-        "normal-env-value",
         "controller-secret-token",
-        "controller-context",
         "worker-secret-key",
         "worker-session-token",
         "hf-literal-token",
+        slack_token,
     ]:
         assert secret not in artifact_text
 
+    assert "normal-env-value" in artifact_text
+    assert "controller-context" in artifact_text
+    assert "debug" in artifact_text
     assert "registry.example/iris-runner:sha" in artifact_text
     assert "nvidia.com/gpu" in artifact_text
     assert "FailedScheduling" in artifact_text
@@ -223,21 +235,29 @@ def test_collect_coreweave_redacts_sensitive_env_values(monkeypatch, tmp_path):
     pods = json.loads((tmp_path / "kubernetes-pods.json").read_text())
     env = pods["items"][0]["spec"]["containers"][0]["env"]
     env_by_name = {entry["name"]: entry for entry in env}
-    assert env_by_name["AWS_ACCESS_KEY_ID"]["value"] == iris_monitor._REDACTED_VALUE
-    assert env_by_name["WANDB_API_KEY"]["value"] == iris_monitor._REDACTED_VALUE
-    assert env_by_name["IRIS_JOB_ENV"]["value"] == iris_monitor._REDACTED_VALUE
-    assert env_by_name["NORMAL_ENV"]["value"] == iris_monitor._REDACTED_VALUE
+    assert env_by_name["AWS_ACCESS_KEY_ID"]["value"] == REDACTED_VALUE
+    assert env_by_name["WANDB_API_KEY"]["value"] == REDACTED_VALUE
+    assert env_by_name["CACHE_BUSTER"]["value"] == REDACTED_VALUE
+    assert env_by_name["NORMAL_ENV"]["value"] == "normal-env-value"
+    iris_job_env = json.loads(env_by_name["IRIS_JOB_ENV"]["value"])
+    assert iris_job_env["AWS_SECRET_ACCESS_KEY"] == REDACTED_VALUE
+    assert iris_job_env["HF_TOKEN"] == REDACTED_VALUE
+    assert iris_job_env["WANDB_API_KEY"] == REDACTED_VALUE
+    assert iris_job_env["LOG_LEVEL"] == "debug"
     assert env_by_name["HF_TOKEN"]["valueFrom"]["secretKeyRef"]["name"] == "hf-token"
     assert "value" not in env_by_name["HF_TOKEN"]
 
     controller_pods = json.loads((tmp_path / "controller-pods.json").read_text())
     controller_env = controller_pods["items"][0]["spec"]["containers"][0]["env"]
-    assert {entry["value"] for entry in controller_env} == {iris_monitor._REDACTED_VALUE}
+    controller_env_by_name = {entry["name"]: entry for entry in controller_env}
+    assert controller_env_by_name["GITHUB_TOKEN"]["value"] == REDACTED_VALUE
+    assert controller_env_by_name["NORMAL_ENV"]["value"] == "controller-context"
 
     worker_pod = json.loads((tmp_path / "pod-worker-0.json").read_text())
     worker_env = {entry["name"]: entry for entry in worker_pod["spec"]["containers"][0]["env"]}
-    assert worker_env["AWS_SECRET_ACCESS_KEY"]["value"] == iris_monitor._REDACTED_VALUE
-    assert worker_env["AWS_SESSION_TOKEN"]["value"] == iris_monitor._REDACTED_VALUE
-    assert worker_env["HF_TOKEN"]["value"] == iris_monitor._REDACTED_VALUE
+    assert worker_env["AWS_SECRET_ACCESS_KEY"]["value"] == REDACTED_VALUE
+    assert worker_env["AWS_SESSION_TOKEN"]["value"] == REDACTED_VALUE
+    assert worker_env["HF_TOKEN"]["value"] == REDACTED_VALUE
+    assert worker_env["CACHE_BUSTER"]["value"] == REDACTED_VALUE
     assert worker_env["AWS_ACCESS_KEY_ID"]["valueFrom"]["secretKeyRef"]["name"] == "r2-creds"
     assert "value" not in worker_env["AWS_ACCESS_KEY_ID"]

--- a/tests/workflows/test_iris_monitor.py
+++ b/tests/workflows/test_iris_monitor.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import subprocess
 
 from rigging.redaction import REDACTED_VALUE
 
@@ -26,10 +25,6 @@ def _statuses(*pods: dict) -> list[iris_monitor.K8sPodStatus]:
     return iris_monitor._controller_pods_from_json(json.dumps({"items": list(pods)}))
 
 
-def _completed(stdout: str = "", stderr: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
-    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
-
-
 def test_settled_coreweave_controller_requires_exactly_one_ready_pod() -> None:
     assert iris_monitor._settled_controller_pod_name(_statuses(_pod("iris-controller-new"))) == "iris-controller-new"
 
@@ -47,94 +42,33 @@ def test_settled_coreweave_controller_requires_exactly_one_ready_pod() -> None:
     assert iris_monitor._settled_controller_pod_name(_statuses(_pod("iris-controller-new", phase="Pending"))) is None
 
 
-def test_collect_coreweave_redacts_sensitive_env_values(monkeypatch, tmp_path):
-    slack_token = "xox" + "b-1234567890-abcdefghijklmnopqrstuvwxyz"
-    pod_json = {
-        "items": [
-            {
-                "metadata": {"name": "worker-0"},
-                "spec": {
-                    "containers": [
-                        {
-                            "name": "runner",
-                            "image": "registry.example/iris-runner:sha",
-                            "resources": {"limits": {"nvidia.com/gpu": "8"}},
-                            "env": [
-                                {"name": "AWS_ACCESS_KEY_ID", "value": "AKIA_TEST_ACCESS"},
-                                {"name": "WANDB_API_KEY", "value": "wandb-test-secret"},
-                                {
-                                    "name": "CACHE_BUSTER",
-                                    "value": "ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ",
-                                },
-                                {
-                                    "name": "IRIS_JOB_ENV",
-                                    "value": json.dumps(
-                                        {
-                                            "AWS_SECRET_ACCESS_KEY": "nested-secret-key",
-                                            "HF_TOKEN": "nested-hf-token",
-                                            "WANDB_API_KEY": "nested-wandb-key",
-                                            "LOG_LEVEL": "debug",
-                                        }
-                                    ),
-                                },
-                                {"name": "NORMAL_ENV", "value": "normal-env-value"},
-                                {
-                                    "name": "HF_TOKEN",
-                                    "valueFrom": {
-                                        "secretKeyRef": {
-                                            "name": "hf-token",
-                                            "key": "HF_TOKEN",
-                                        }
-                                    },
-                                },
-                            ],
-                        }
-                    ]
-                },
-                "status": {"phase": "Pending"},
-            }
-        ]
-    }
-    controller_json = {
-        "items": [
-            {
-                "metadata": {"name": "iris-controller"},
-                "spec": {
-                    "containers": [
-                        {
-                            "name": "controller",
-                            "image": "registry.example/iris-controller:sha",
-                            "env": [
-                                {"name": "GITHUB_TOKEN", "value": "controller-secret-token"},
-                                {"name": "NORMAL_ENV", "value": "controller-context"},
-                            ],
-                        }
-                    ]
-                },
-            }
-        ]
-    }
-    worker_json = {
+def test_redact_pod_doc_redacts_env_values_and_preserves_context():
+    pod = {
         "metadata": {"name": "worker-0"},
         "spec": {
             "containers": [
                 {
                     "name": "runner",
                     "image": "registry.example/iris-runner:sha",
-                    "resources": {"requests": {"nvidia.com/gpu": "8"}},
+                    "resources": {"limits": {"nvidia.com/gpu": "8"}},
                     "env": [
-                        {"name": "AWS_SECRET_ACCESS_KEY", "value": "worker-secret-key"},
-                        {"name": "AWS_SESSION_TOKEN", "value": "worker-session-token"},
-                        {"name": "HF_TOKEN", "value": "hf-literal-token"},
-                        {"name": "CACHE_BUSTER", "value": slack_token},
+                        {"name": "AWS_ACCESS_KEY_ID", "value": "AKIA_TEST_ACCESS"},
+                        # Low-entropy secret only caught via name-based lift.
+                        {"name": "WANDB_API_KEY", "value": "wandb-test-secret"},
                         {
-                            "name": "AWS_ACCESS_KEY_ID",
-                            "valueFrom": {
-                                "secretKeyRef": {
-                                    "name": "r2-creds",
-                                    "key": "AWS_ACCESS_KEY_ID",
+                            "name": "IRIS_JOB_ENV",
+                            "value": json.dumps(
+                                {
+                                    "AWS_SECRET_ACCESS_KEY": "nested-secret-key",
+                                    "HF_TOKEN": "nested-hf-token",
+                                    "LOG_LEVEL": "debug",
                                 }
-                            },
+                            ),
+                        },
+                        {"name": "NORMAL_ENV", "value": "normal-env-value"},
+                        {
+                            "name": "HF_TOKEN",
+                            "valueFrom": {"secretKeyRef": {"name": "hf-token", "key": "HF_TOKEN"}},
                         },
                     ],
                 }
@@ -142,122 +76,24 @@ def test_collect_coreweave_redacts_sensitive_env_values(monkeypatch, tmp_path):
         },
     }
 
-    def fake_run(cmd: list[str]) -> subprocess.CompletedProcess:
-        if cmd == [
-            "kubectl",
-            "-n",
-            "iris",
-            "get",
-            "pods",
-            "-l=iris.job_id=canary-job",
-            "-o",
-            "json",
-        ]:
-            return _completed(json.dumps(pod_json))
-        if cmd == [
-            "kubectl",
-            "-n",
-            "iris",
-            "logs",
-            "-l",
-            "app=iris-controller",
-            "--tail=-1",
-            "--all-containers",
-        ]:
-            return _completed("controller log\n")
-        if cmd == [
-            "kubectl",
-            "-n",
-            "iris",
-            "logs",
-            "-l",
-            "app=iris-controller",
-            "--tail=-1",
-            "--all-containers",
-            "--previous",
-        ]:
-            return _completed("previous controller log\n")
-        if cmd == ["kubectl", "-n", "iris", "get", "pods", "-l", "app=iris-controller", "-o", "json"]:
-            return _completed(json.dumps(controller_json))
-        if cmd == ["kubectl", "-n", "iris", "get", "pods", "-l", "managed=true", "-o", "name"]:
-            return _completed("pod/worker-0\n")
-        if cmd == ["kubectl", "-n", "iris", "logs", "pod/worker-0", "--tail=-1", "--all-containers"]:
-            return _completed("worker log\n")
-        if cmd == ["kubectl", "-n", "iris", "get", "pod/worker-0", "-o", "json"]:
-            return _completed(json.dumps(worker_json))
-        if cmd == ["kubectl", "-n", "iris", "get", "events", "--sort-by=.lastTimestamp"]:
-            return _completed(
-                "LAST SEEN  TYPE     REASON            MESSAGE\n1m         Warning  FailedScheduling  pending\n"
-            )
-        raise AssertionError(f"unexpected command: {cmd}")
+    redacted = iris_monitor._redact_pod_doc(pod)
+    env_by_name = {entry["name"]: entry for entry in redacted["spec"]["containers"][0]["env"]}
 
-    monkeypatch.setattr(iris_monitor, "_run", fake_run)
-
-    files, errors = iris_monitor._collect_coreweave(
-        tmp_path,
-        "canary-job",
-        "iris",
-        None,
-        managed_label="managed",
-        include_cluster_context=False,
-        iris_cmd=["iris"],
-    )
-
-    assert errors == []
-    assert "kubernetes-pods.json" in files
-    assert "controller-pods.json" in files
-    assert "pod-worker-0.json" in files
-
-    artifact_text = "\n".join(path.read_text() for path in tmp_path.iterdir())
-    for secret in [
-        "AKIA_TEST_ACCESS",
-        "wandb-test-secret",
-        "ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ",
-        "nested-secret-key",
-        "nested-hf-token",
-        "nested-wandb-key",
-        "controller-secret-token",
-        "worker-secret-key",
-        "worker-session-token",
-        "hf-literal-token",
-        slack_token,
-    ]:
-        assert secret not in artifact_text
-
-    assert "normal-env-value" in artifact_text
-    assert "controller-context" in artifact_text
-    assert "debug" in artifact_text
-    assert "registry.example/iris-runner:sha" in artifact_text
-    assert "nvidia.com/gpu" in artifact_text
-    assert "FailedScheduling" in artifact_text
-    assert "secretKeyRef" in artifact_text
-
-    pods = json.loads((tmp_path / "kubernetes-pods.json").read_text())
-    env = pods["items"][0]["spec"]["containers"][0]["env"]
-    env_by_name = {entry["name"]: entry for entry in env}
     assert env_by_name["AWS_ACCESS_KEY_ID"]["value"] == REDACTED_VALUE
     assert env_by_name["WANDB_API_KEY"]["value"] == REDACTED_VALUE
-    assert env_by_name["CACHE_BUSTER"]["value"] == REDACTED_VALUE
     assert env_by_name["NORMAL_ENV"]["value"] == "normal-env-value"
-    iris_job_env = json.loads(env_by_name["IRIS_JOB_ENV"]["value"])
-    assert iris_job_env["AWS_SECRET_ACCESS_KEY"] == REDACTED_VALUE
-    assert iris_job_env["HF_TOKEN"] == REDACTED_VALUE
-    assert iris_job_env["WANDB_API_KEY"] == REDACTED_VALUE
-    assert iris_job_env["LOG_LEVEL"] == "debug"
-    assert env_by_name["HF_TOKEN"]["valueFrom"]["secretKeyRef"]["name"] == "hf-token"
+
+    nested = json.loads(env_by_name["IRIS_JOB_ENV"]["value"])
+    assert nested == {
+        "AWS_SECRET_ACCESS_KEY": REDACTED_VALUE,
+        "HF_TOKEN": REDACTED_VALUE,
+        "LOG_LEVEL": "debug",
+    }
+
+    # valueFrom entries pass through untouched and never gain a phantom `value`.
     assert "value" not in env_by_name["HF_TOKEN"]
+    assert env_by_name["HF_TOKEN"]["valueFrom"]["secretKeyRef"]["name"] == "hf-token"
 
-    controller_pods = json.loads((tmp_path / "controller-pods.json").read_text())
-    controller_env = controller_pods["items"][0]["spec"]["containers"][0]["env"]
-    controller_env_by_name = {entry["name"]: entry for entry in controller_env}
-    assert controller_env_by_name["GITHUB_TOKEN"]["value"] == REDACTED_VALUE
-    assert controller_env_by_name["NORMAL_ENV"]["value"] == "controller-context"
-
-    worker_pod = json.loads((tmp_path / "pod-worker-0.json").read_text())
-    worker_env = {entry["name"]: entry for entry in worker_pod["spec"]["containers"][0]["env"]}
-    assert worker_env["AWS_SECRET_ACCESS_KEY"]["value"] == REDACTED_VALUE
-    assert worker_env["AWS_SESSION_TOKEN"]["value"] == REDACTED_VALUE
-    assert worker_env["HF_TOKEN"]["value"] == REDACTED_VALUE
-    assert worker_env["CACHE_BUSTER"]["value"] == REDACTED_VALUE
-    assert worker_env["AWS_ACCESS_KEY_ID"]["valueFrom"]["secretKeyRef"]["name"] == "r2-creds"
-    assert "value" not in worker_env["AWS_ACCESS_KEY_ID"]
+    # Non-env pod context stays intact.
+    assert redacted["spec"]["containers"][0]["image"] == "registry.example/iris-runner:sha"
+    assert redacted["spec"]["containers"][0]["resources"]["limits"]["nvidia.com/gpu"] == "8"

--- a/tests/workflows/test_iris_monitor.py
+++ b/tests/workflows/test_iris_monitor.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import subprocess
 
 from scripts.workflows import iris_monitor
 
@@ -23,6 +24,10 @@ def _statuses(*pods: dict) -> list[iris_monitor.K8sPodStatus]:
     return iris_monitor._controller_pods_from_json(json.dumps({"items": list(pods)}))
 
 
+def _completed(stdout: str = "", stderr: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
 def test_settled_coreweave_controller_requires_exactly_one_ready_pod() -> None:
     assert iris_monitor._settled_controller_pod_name(_statuses(_pod("iris-controller-new"))) == "iris-controller-new"
 
@@ -38,3 +43,201 @@ def test_settled_coreweave_controller_requires_exactly_one_ready_pod() -> None:
     )
     assert iris_monitor._settled_controller_pod_name(_statuses(_pod("iris-controller-new", ready=False))) is None
     assert iris_monitor._settled_controller_pod_name(_statuses(_pod("iris-controller-new", phase="Pending"))) is None
+
+
+def test_collect_coreweave_redacts_sensitive_env_values(monkeypatch, tmp_path):
+    pod_json = {
+        "items": [
+            {
+                "metadata": {"name": "worker-0"},
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "runner",
+                            "image": "registry.example/iris-runner:sha",
+                            "resources": {"limits": {"nvidia.com/gpu": "8"}},
+                            "env": [
+                                {"name": "AWS_ACCESS_KEY_ID", "value": "AKIA_TEST_ACCESS"},
+                                {"name": "WANDB_API_KEY", "value": "wandb-test-secret"},
+                                {
+                                    "name": "IRIS_JOB_ENV",
+                                    "value": json.dumps(
+                                        {
+                                            "AWS_SECRET_ACCESS_KEY": "nested-secret-key",
+                                            "HF_TOKEN": "nested-hf-token",
+                                            "WANDB_API_KEY": "nested-wandb-key",
+                                        }
+                                    ),
+                                },
+                                {"name": "NORMAL_ENV", "value": "normal-env-value"},
+                                {
+                                    "name": "HF_TOKEN",
+                                    "valueFrom": {
+                                        "secretKeyRef": {
+                                            "name": "hf-token",
+                                            "key": "HF_TOKEN",
+                                        }
+                                    },
+                                },
+                            ],
+                        }
+                    ]
+                },
+                "status": {"phase": "Pending"},
+            }
+        ]
+    }
+    controller_json = {
+        "items": [
+            {
+                "metadata": {"name": "iris-controller"},
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "controller",
+                            "image": "registry.example/iris-controller:sha",
+                            "env": [
+                                {"name": "GITHUB_TOKEN", "value": "controller-secret-token"},
+                                {"name": "NORMAL_ENV", "value": "controller-context"},
+                            ],
+                        }
+                    ]
+                },
+            }
+        ]
+    }
+    worker_json = {
+        "metadata": {"name": "worker-0"},
+        "spec": {
+            "containers": [
+                {
+                    "name": "runner",
+                    "image": "registry.example/iris-runner:sha",
+                    "resources": {"requests": {"nvidia.com/gpu": "8"}},
+                    "env": [
+                        {"name": "AWS_SECRET_ACCESS_KEY", "value": "worker-secret-key"},
+                        {"name": "AWS_SESSION_TOKEN", "value": "worker-session-token"},
+                        {"name": "HF_TOKEN", "value": "hf-literal-token"},
+                        {
+                            "name": "AWS_ACCESS_KEY_ID",
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "r2-creds",
+                                    "key": "AWS_ACCESS_KEY_ID",
+                                }
+                            },
+                        },
+                    ],
+                }
+            ]
+        },
+    }
+
+    def fake_run(cmd: list[str]) -> subprocess.CompletedProcess:
+        if cmd == [
+            "kubectl",
+            "-n",
+            "iris",
+            "get",
+            "pods",
+            "-l=iris.job_id=canary-job",
+            "-o",
+            "json",
+        ]:
+            return _completed(json.dumps(pod_json))
+        if cmd == [
+            "kubectl",
+            "-n",
+            "iris",
+            "logs",
+            "-l",
+            "app=iris-controller",
+            "--tail=-1",
+            "--all-containers",
+        ]:
+            return _completed("controller log\n")
+        if cmd == [
+            "kubectl",
+            "-n",
+            "iris",
+            "logs",
+            "-l",
+            "app=iris-controller",
+            "--tail=-1",
+            "--all-containers",
+            "--previous",
+        ]:
+            return _completed("previous controller log\n")
+        if cmd == ["kubectl", "-n", "iris", "get", "pods", "-l", "app=iris-controller", "-o", "json"]:
+            return _completed(json.dumps(controller_json))
+        if cmd == ["kubectl", "-n", "iris", "get", "pods", "-l", "managed=true", "-o", "name"]:
+            return _completed("pod/worker-0\n")
+        if cmd == ["kubectl", "-n", "iris", "logs", "pod/worker-0", "--tail=-1", "--all-containers"]:
+            return _completed("worker log\n")
+        if cmd == ["kubectl", "-n", "iris", "get", "pod/worker-0", "-o", "json"]:
+            return _completed(json.dumps(worker_json))
+        if cmd == ["kubectl", "-n", "iris", "get", "events", "--sort-by=.lastTimestamp"]:
+            return _completed(
+                "LAST SEEN  TYPE     REASON            MESSAGE\n1m         Warning  FailedScheduling  pending\n"
+            )
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(iris_monitor, "_run", fake_run)
+
+    files, errors = iris_monitor._collect_coreweave(
+        tmp_path,
+        "canary-job",
+        "iris",
+        None,
+        managed_label="managed",
+        include_cluster_context=False,
+        iris_cmd=["iris"],
+    )
+
+    assert errors == []
+    assert "kubernetes-pods.json" in files
+    assert "controller-pods.json" in files
+    assert "pod-worker-0.json" in files
+
+    artifact_text = "\n".join(path.read_text() for path in tmp_path.iterdir())
+    for secret in [
+        "AKIA_TEST_ACCESS",
+        "wandb-test-secret",
+        "nested-secret-key",
+        "nested-hf-token",
+        "nested-wandb-key",
+        "normal-env-value",
+        "controller-secret-token",
+        "controller-context",
+        "worker-secret-key",
+        "worker-session-token",
+        "hf-literal-token",
+    ]:
+        assert secret not in artifact_text
+
+    assert "registry.example/iris-runner:sha" in artifact_text
+    assert "nvidia.com/gpu" in artifact_text
+    assert "FailedScheduling" in artifact_text
+    assert "secretKeyRef" in artifact_text
+
+    pods = json.loads((tmp_path / "kubernetes-pods.json").read_text())
+    env = pods["items"][0]["spec"]["containers"][0]["env"]
+    env_by_name = {entry["name"]: entry for entry in env}
+    assert env_by_name["AWS_ACCESS_KEY_ID"]["value"] == iris_monitor._REDACTED_VALUE
+    assert env_by_name["WANDB_API_KEY"]["value"] == iris_monitor._REDACTED_VALUE
+    assert env_by_name["IRIS_JOB_ENV"]["value"] == iris_monitor._REDACTED_VALUE
+    assert env_by_name["NORMAL_ENV"]["value"] == iris_monitor._REDACTED_VALUE
+    assert env_by_name["HF_TOKEN"]["valueFrom"]["secretKeyRef"]["name"] == "hf-token"
+    assert "value" not in env_by_name["HF_TOKEN"]
+
+    controller_pods = json.loads((tmp_path / "controller-pods.json").read_text())
+    controller_env = controller_pods["items"][0]["spec"]["containers"][0]["env"]
+    assert {entry["value"] for entry in controller_env} == {iris_monitor._REDACTED_VALUE}
+
+    worker_pod = json.loads((tmp_path / "pod-worker-0.json").read_text())
+    worker_env = {entry["name"]: entry for entry in worker_pod["spec"]["containers"][0]["env"]}
+    assert worker_env["AWS_SECRET_ACCESS_KEY"]["value"] == iris_monitor._REDACTED_VALUE
+    assert worker_env["AWS_SESSION_TOKEN"]["value"] == iris_monitor._REDACTED_VALUE
+    assert worker_env["HF_TOKEN"]["value"] == iris_monitor._REDACTED_VALUE
+    assert worker_env["AWS_ACCESS_KEY_ID"]["valueFrom"]["secretKeyRef"]["name"] == "r2-creds"
+    assert "value" not in worker_env["AWS_ACCESS_KEY_ID"]


### PR DESCRIPTION
## Summary

- Collect CoreWeave pod diagnostics as structured JSON instead of `kubectl describe` text.
- Add a shared `rigging.redaction` helper for sensitive key names, prefixed tokens, private keys, JWTs, and high-entropy key-like strings.
- Sanitize Kubernetes `env[].value` literals with the shared redactor while preserving ordinary non-secret env values, `valueFrom` metadata, and non-env pod context.
- Route the existing Iris redaction helpers through the shared redactor and add regression coverage for workflow diagnostics and redaction behavior.

Fixes #5468

## Follow-up

This remains a heuristic artifact-boundary fix. It should stop the exposed canary credentials while preserving more diagnostics than blanket env redaction, but provenance would still be better: keep public job env separate from secret job env, materialize secret env through Kubernetes Secrets/`valueFrom.secretKeyRef`, or carry explicit sensitivity metadata for blob envs such as `IRIS_JOB_ENV`.

## Testing

- `uv run --with pytest --with pytest-timeout pytest tests/workflows/test_iris_monitor.py lib/rigging/tests/test_redaction.py`
- `uv run --with pytest --with pytest-timeout --with pytest-xdist pytest lib/iris/tests/cluster/test_redaction.py`
- `./infra/pre-commit.py --fix scripts/workflows/iris_monitor.py tests/workflows/test_iris_monitor.py lib/rigging/src/rigging/redaction.py lib/rigging/tests/test_redaction.py lib/iris/src/iris/cluster/redaction.py lib/iris/tests/cluster/test_redaction.py`
- `uvx pyrefly@0.61.0 check --baseline .pyrefly-baseline.json`
- `git diff --check`