### PR TITLE
Fix Claude triage timeout placement

### DIFF
--- a/.github/actions/claude-triage/action.yaml
+++ b/.github/actions/claude-triage/action.yaml
@@ -43,17 +43,11 @@ inputs:
     description: Maximum agent turns.
     required: false
     default: '500'
-  timeout-minutes:
-    description: Per-action timeout in minutes.
-    required: false
-    default: '30'
-
 runs:
   using: composite
   steps:
     - name: Run claude-code-action
       uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
-      timeout-minutes: ${{ fromJSON(inputs.timeout-minutes) }}
       with:
         claude_code_oauth_token: ${{ inputs.oauth-token }}
         prompt: |

--- a/.github/workflows/marin-canary-datakit-tier1.yaml
+++ b/.github/workflows/marin-canary-datakit-tier1.yaml
@@ -146,6 +146,7 @@ jobs:
         id: claude_triage
         if: (failure() || cancelled()) && github.event_name == 'schedule'
         uses: ./.github/actions/claude-triage
+        timeout-minutes: 30
         with:
           oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           lane: datakit-smoke

--- a/.github/workflows/marin-canary-ferry-coreweave.yaml
+++ b/.github/workflows/marin-canary-ferry-coreweave.yaml
@@ -202,6 +202,7 @@ jobs:
         id: claude_triage
         if: (failure() || cancelled()) && github.event_name == 'schedule'
         uses: ./.github/actions/claude-triage
+        timeout-minutes: 30
         with:
           oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           lane: gpu

--- a/.github/workflows/marin-canary-ferry.yaml
+++ b/.github/workflows/marin-canary-ferry.yaml
@@ -166,6 +166,7 @@ jobs:
         id: claude_triage
         if: (failure() || cancelled()) && github.event_name == 'schedule'
         uses: ./.github/actions/claude-triage
+        timeout-minutes: 30
         with:
           oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           lane: tpu


### PR DESCRIPTION
## Summary

Fixes #5467.

- Remove the unsupported `timeout-minutes` key from the `claude-triage` composite action manifest.
- Remove the dead `timeout-minutes` action input so callers are not offered a setting the composite action cannot implement.
- Apply the 30-minute timeout at each workflow step that invokes the local action, where GitHub Actions supports it.

## Validation

- `git diff --check`
- `uv run python` YAML parse for the touched action and workflow files
- custom YAML schema check for the composite action step keys and relocated workflow timeouts
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -shellcheck= -pyflakes= .github/workflows/marin-canary-ferry.yaml .github/workflows/marin-canary-ferry-coreweave.yaml .github/workflows/marin-canary-datakit-tier1.yaml`
- `./infra/pre-commit.py .github/actions/claude-triage/action.yaml .github/workflows/marin-canary-ferry.yaml .github/workflows/marin-canary-ferry-coreweave.yaml .github/workflows/marin-canary-datakit-tier1.yaml`