### PR TITLE
[iris] Fix TPU placement collision

### DIFF
--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -16,7 +16,13 @@ from typing import NamedTuple
 
 from rigging.timing import Duration, Timestamp
 
-from iris.cluster.constraints import AttributeValue, Constraint, constraints_from_resources, merge_constraints
+from iris.cluster.constraints import (
+    AttributeValue,
+    Constraint,
+    WellKnownAttribute,
+    constraints_from_resources,
+    merge_constraints,
+)
 from iris.cluster.controller.codec import (
     constraints_from_json,
     constraints_to_json,
@@ -40,6 +46,7 @@ from iris.cluster.controller.db import (
 from iris.cluster.controller.schema import (
     EndpointRow,
     JobDetailRow,
+    TaskDetailRow,
     WorkerDetailRow,
 )
 from iris.cluster.controller.stores import (
@@ -249,6 +256,60 @@ class AssignmentResult(TxResult):
     accepted: list[Assignment] = field(default_factory=list)
     rejected: list[Assignment] = field(default_factory=list)
     start_requests: list[tuple[WorkerId, str, job_pb2.RunTaskRequest]] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _AssignmentCandidate:
+    assignment: Assignment
+    task: TaskDetailRow | None
+    job: JobDetailRow | None
+    worker: WorkerDetailRow | None
+    resources: job_pb2.ResourceSpecProto | None
+    rejection_reason: str | None = None
+
+
+@dataclass
+class _StagedWorkerCapacity:
+    cpu_millicores: int
+    memory_bytes: int
+    gpu_count: int
+    tpu_count: int
+
+    @classmethod
+    def from_worker(cls, worker: WorkerDetailRow) -> "_StagedWorkerCapacity":
+        return cls(
+            cpu_millicores=worker.total_cpu_millicores - worker.committed_cpu_millicores,
+            memory_bytes=worker.total_memory_bytes - worker.committed_mem,
+            gpu_count=worker.total_gpu_count - worker.committed_gpu,
+            tpu_count=worker.total_tpu_count - worker.committed_tpu,
+        )
+
+    def copy(self) -> "_StagedWorkerCapacity":
+        return _StagedWorkerCapacity(
+            cpu_millicores=self.cpu_millicores,
+            memory_bytes=self.memory_bytes,
+            gpu_count=self.gpu_count,
+            tpu_count=self.tpu_count,
+        )
+
+    def deduction_error(self, resources: job_pb2.ResourceSpecProto) -> str | None:
+        requested_gpu = get_gpu_count(resources.device)
+        requested_tpu = get_tpu_count(resources.device)
+        if int(resources.cpu_millicores) > self.cpu_millicores:
+            return "insufficient_cpu"
+        if int(resources.memory_bytes) > self.memory_bytes:
+            return "insufficient_memory"
+        if requested_gpu > self.gpu_count:
+            return "insufficient_gpu"
+        if requested_tpu > self.tpu_count:
+            return "insufficient_tpu"
+        return None
+
+    def deduct(self, resources: job_pb2.ResourceSpecProto) -> None:
+        self.cpu_millicores -= int(resources.cpu_millicores)
+        self.memory_bytes -= int(resources.memory_bytes)
+        self.gpu_count -= int(get_gpu_count(resources.device))
+        self.tpu_count -= int(get_tpu_count(resources.device))
 
 
 @dataclass(frozen=True)
@@ -1228,6 +1289,182 @@ class ControllerTransitions:
         )
         return WorkerRegistrationResult(worker_id=worker_id)
 
+    def _worker_tpu_group(self, cur: TransactionCursor, worker: WorkerDetailRow) -> str:
+        row = cur.fetchone(
+            "SELECT str_value FROM worker_attributes WHERE worker_id = ? AND key = ? AND value_type = 'str'",
+            (str(worker.worker_id), WellKnownAttribute.TPU_NAME.value),
+        )
+        if row is not None and row["str_value"]:
+            return str(row["str_value"])
+        return worker.md_tpu_name
+
+    def _workers_in_tpu_group(self, cur: TransactionCursor, tpu_group: str) -> list[WorkerId]:
+        rows = cur.fetchall(
+            "SELECT worker_id FROM workers WHERE md_tpu_name = ? "
+            "UNION SELECT worker_id FROM worker_attributes WHERE key = ? AND str_value = ?",
+            (tpu_group, WellKnownAttribute.TPU_NAME.value, tpu_group),
+        )
+        return [WorkerId(str(row["worker_id"])) for row in rows]
+
+    def _foreign_active_tpu_task_in_group(
+        self,
+        cur: TransactionCursor,
+        *,
+        job_id: JobName,
+        tpu_group: str,
+    ) -> ActiveTaskRow | None:
+        worker_ids = self._workers_in_tpu_group(cur, tpu_group)
+        if not worker_ids:
+            return None
+        active_tasks = self._store.tasks.list_active(
+            cur,
+            TaskScope(worker_ids=worker_ids),
+            states=ACTIVE_TASK_STATES,
+            exclude_reservation_holders=True,
+        )
+        for active_task in active_tasks:
+            if active_task.job_id == job_id:
+                continue
+            if get_tpu_count(active_task.resources.device) > 0:
+                return active_task
+        return None
+
+    def _assignment_tpu_group_rejection(
+        self,
+        cur: TransactionCursor,
+        candidate: _AssignmentCandidate,
+        staged_tpu_groups: dict[str, JobName],
+    ) -> tuple[str | None, str | None]:
+        if candidate.worker is None or candidate.job is None or candidate.resources is None:
+            return None, None
+        if not candidate.job.has_coscheduling:
+            return None, None
+        if get_tpu_count(candidate.resources.device) <= 0:
+            return None, None
+        tpu_group = self._worker_tpu_group(cur, candidate.worker)
+        if not tpu_group:
+            return None, None
+        staged_job = staged_tpu_groups.get(tpu_group)
+        if staged_job is not None and staged_job != candidate.job.job_id:
+            return f"tpu_group_staged_overlap:{tpu_group}:job={staged_job.to_wire()}", tpu_group
+        active_task = self._foreign_active_tpu_task_in_group(cur, job_id=candidate.job.job_id, tpu_group=tpu_group)
+        if active_task is not None:
+            return (
+                f"tpu_group_active_overlap:{tpu_group}:job={active_task.job_id.to_wire()}:"
+                f"task={active_task.task_id.to_wire()}",
+                tpu_group,
+            )
+        return None, tpu_group
+
+    def _build_assignment_candidates(
+        self,
+        cur: TransactionCursor,
+        assignments: list[Assignment],
+    ) -> list[_AssignmentCandidate]:
+        candidates: list[_AssignmentCandidate] = []
+        job_cache: dict[str, JobDetailRow | None] = {}
+        for assignment in assignments:
+            task = self._store.tasks.get_detail(cur, assignment.task_id)
+            if task is None:
+                candidates.append(
+                    _AssignmentCandidate(
+                        assignment=assignment,
+                        task=None,
+                        job=None,
+                        worker=None,
+                        resources=None,
+                        rejection_reason="task_missing",
+                    )
+                )
+                continue
+
+            job_id_wire = task.job_id.to_wire()
+            if job_id_wire not in job_cache:
+                job_cache[job_id_wire] = self._store.jobs.get_detail(cur, task.job_id)
+            job = job_cache[job_id_wire]
+            resources = (
+                resource_spec_from_scalars(
+                    job.res_cpu_millicores,
+                    job.res_memory_bytes,
+                    job.res_disk_bytes,
+                    job.res_device_json,
+                )
+                if job is not None and not job.is_reservation_holder
+                else None
+            )
+
+            worker = self._store.workers.get_detail(cur, assignment.worker_id)
+            rejection_reason: str | None = None
+            if job is None:
+                rejection_reason = "job_missing"
+            elif not task_row_can_be_scheduled(task):
+                rejection_reason = "task_not_schedulable"
+            elif worker is None:
+                rejection_reason = "worker_missing"
+            elif not worker.active:
+                rejection_reason = "worker_inactive"
+            elif not worker.healthy:
+                rejection_reason = "worker_unhealthy"
+
+            candidates.append(
+                _AssignmentCandidate(
+                    assignment=assignment,
+                    task=task,
+                    job=job,
+                    worker=worker,
+                    resources=resources,
+                    rejection_reason=rejection_reason,
+                )
+            )
+        return candidates
+
+    def _assignment_batches(
+        self,
+        candidates: list[_AssignmentCandidate],
+    ) -> list[tuple[bool, list[_AssignmentCandidate]]]:
+        batches: list[tuple[bool, list[_AssignmentCandidate]]] = []
+        coscheduled_batches: dict[str, list[_AssignmentCandidate]] = {}
+        for candidate in candidates:
+            if candidate.job is not None and candidate.job.has_coscheduling:
+                job_id_wire = candidate.job.job_id.to_wire()
+                if job_id_wire not in coscheduled_batches:
+                    coscheduled_batches[job_id_wire] = []
+                    batches.append((True, coscheduled_batches[job_id_wire]))
+                coscheduled_batches[job_id_wire].append(candidate)
+                continue
+            batches.append((False, [candidate]))
+        return batches
+
+    def _validate_assignment_batch(
+        self,
+        cur: TransactionCursor,
+        batch: list[_AssignmentCandidate],
+        staged_capacity: dict[WorkerId, _StagedWorkerCapacity],
+        staged_tpu_groups: dict[str, JobName],
+    ) -> tuple[str | None, dict[WorkerId, _StagedWorkerCapacity], set[str]]:
+        batch_capacity = {worker_id: capacity.copy() for worker_id, capacity in staged_capacity.items()}
+        batch_tpu_groups: set[str] = set()
+        for candidate in batch:
+            if candidate.rejection_reason is not None:
+                return candidate.rejection_reason, batch_capacity, batch_tpu_groups
+            if candidate.worker is None or candidate.job is None:
+                return "invalid_assignment", batch_capacity, batch_tpu_groups
+            if candidate.resources is not None:
+                capacity = batch_capacity.setdefault(
+                    candidate.worker.worker_id,
+                    _StagedWorkerCapacity.from_worker(candidate.worker),
+                )
+                capacity_error = capacity.deduction_error(candidate.resources)
+                if capacity_error is not None:
+                    return capacity_error, batch_capacity, batch_tpu_groups
+                tpu_error, tpu_group = self._assignment_tpu_group_rejection(cur, candidate, staged_tpu_groups)
+                if tpu_error is not None:
+                    return tpu_error, batch_capacity, batch_tpu_groups
+                if tpu_group is not None:
+                    batch_tpu_groups.add(tpu_group)
+                capacity.deduct(candidate.resources)
+        return None, batch_capacity, batch_tpu_groups
+
     def queue_assignments(
         self,
         cur: TransactionCursor,
@@ -1246,66 +1483,90 @@ class ControllerTransitions:
         start_requests: list[tuple[WorkerId, str, job_pb2.RunTaskRequest]] = []
         has_real_dispatch = False
         now_ms = Timestamp.now().epoch_ms()
-        job_cache: dict[str, JobDetailRow] = {}
         jobs_to_update: set[str] = set()
-        for assignment in assignments:
-            task = self._store.tasks.get_detail(cur, assignment.task_id)
-            worker_address = self._store.workers.active_healthy_address(cur, assignment.worker_id)
-            if task is None or worker_address is None:
-                rejected.append(assignment)
-                continue
-            if not task_row_can_be_scheduled(task):
-                rejected.append(assignment)
-                continue
-            job_id_wire = task.job_id.to_wire()
-            if job_id_wire not in job_cache:
-                decoded_job = self._store.jobs.get_detail(cur, task.job_id)
-                if decoded_job is None:
-                    rejected.append(assignment)
-                    continue
-                job_cache[job_id_wire] = decoded_job
-            job = job_cache[job_id_wire]
-            attempt_id = task.current_attempt_id + 1
-            self._store.tasks.assign(
+        staged_capacity: dict[WorkerId, _StagedWorkerCapacity] = {}
+        staged_tpu_groups: dict[str, JobName] = {}
+        candidates = self._build_assignment_candidates(cur, assignments)
+        for is_coscheduled, batch in self._assignment_batches(candidates):
+            reason, batch_capacity, batch_tpu_groups = self._validate_assignment_batch(
                 cur,
-                self._store.attempts,
-                assignment.task_id,
-                assignment.worker_id,
-                worker_address,
-                attempt_id,
-                now_ms,
+                batch,
+                staged_capacity,
+                staged_tpu_groups,
             )
-            if not job.is_reservation_holder:
-                resources = resource_spec_from_scalars(
-                    job.res_cpu_millicores,
-                    job.res_memory_bytes,
-                    job.res_disk_bytes,
-                    job.res_device_json,
+            if reason is not None:
+                rejection_reason = f"coscheduled_gang_rejected:{reason}" if is_coscheduled else reason
+                for candidate in batch:
+                    rejected.append(candidate.assignment)
+                    log_event(
+                        "assignment_rejected",
+                        candidate.assignment.task_id.to_wire(),
+                        worker=str(candidate.assignment.worker_id),
+                        reason=rejection_reason,
+                    )
+                continue
+
+            staged_capacity.clear()
+            staged_capacity.update(batch_capacity)
+            for tpu_group in batch_tpu_groups:
+                job = batch[0].job
+                if job is not None:
+                    staged_tpu_groups.setdefault(tpu_group, job.job_id)
+
+            for candidate in batch:
+                assignment = candidate.assignment
+                task = candidate.task
+                job = candidate.job
+                worker = candidate.worker
+                if task is None or job is None or worker is None:
+                    rejected.append(assignment)
+                    log_event(
+                        "assignment_rejected",
+                        assignment.task_id.to_wire(),
+                        worker=str(assignment.worker_id),
+                        reason="invalid_assignment",
+                    )
+                    continue
+                attempt_id = task.current_attempt_id + 1
+                worker_address = worker.address
+                self._store.tasks.assign(
+                    cur,
+                    self._store.attempts,
+                    assignment.task_id,
+                    assignment.worker_id,
+                    worker_address,
+                    attempt_id,
+                    now_ms,
                 )
-                self._store.workers.add_committed_resources(cur, assignment.worker_id, resources)
-                entrypoint = proto_from_json(job.entrypoint_json, job_pb2.RuntimeEntrypoint)
-                # Load inline workdir files from the job_workdir_files table.
-                for filename, data in self._store.jobs.get_workdir_files(cur, task.job_id).items():
-                    entrypoint.workdir_files[filename] = data
-                run_request = job_pb2.RunTaskRequest(
-                    task_id=assignment.task_id.to_wire(),
-                    num_tasks=job.num_tasks,
-                    entrypoint=entrypoint,
-                    environment=proto_from_json(job.environment_json, job_pb2.EnvironmentConfig),
-                    bundle_id=job.bundle_id,
-                    resources=resources,
-                    ports=json.loads(job.ports_json),
-                    attempt_id=attempt_id,
-                    constraints=[c.to_proto() for c in constraints_from_json(job.constraints_json)],
-                    task_image=job.task_image,
-                )
-                if direct_dispatch:
-                    start_requests.append((assignment.worker_id, worker_address, run_request))
-                else:
-                    self._store.dispatch.enqueue_run(cur, assignment.worker_id, run_request.SerializeToString(), now_ms)
-                has_real_dispatch = True
-            jobs_to_update.add(job_id_wire)
-            accepted.append(assignment)
+                jobs_to_update.add(job.job_id.to_wire())
+                accepted.append(assignment)
+                if not job.is_reservation_holder:
+                    resources = candidate.resources
+                    assert resources is not None
+                    self._store.workers.add_committed_resources(cur, assignment.worker_id, resources)
+                    entrypoint = proto_from_json(job.entrypoint_json, job_pb2.RuntimeEntrypoint)
+                    # Load inline workdir files from the job_workdir_files table.
+                    for filename, data in self._store.jobs.get_workdir_files(cur, task.job_id).items():
+                        entrypoint.workdir_files[filename] = data
+                    run_request = job_pb2.RunTaskRequest(
+                        task_id=assignment.task_id.to_wire(),
+                        num_tasks=job.num_tasks,
+                        entrypoint=entrypoint,
+                        environment=proto_from_json(job.environment_json, job_pb2.EnvironmentConfig),
+                        bundle_id=job.bundle_id,
+                        resources=resources,
+                        ports=json.loads(job.ports_json),
+                        attempt_id=attempt_id,
+                        constraints=[c.to_proto() for c in constraints_from_json(job.constraints_json)],
+                        task_image=job.task_image,
+                    )
+                    if direct_dispatch:
+                        start_requests.append((assignment.worker_id, worker_address, run_request))
+                    else:
+                        self._store.dispatch.enqueue_run(
+                            cur, assignment.worker_id, run_request.SerializeToString(), now_ms
+                        )
+                    has_real_dispatch = True
         for job_id_wire in jobs_to_update:
             self._store.jobs.mark_running_if_pending(cur, JobName.from_wire(job_id_wire), now_ms)
         for a in accepted:

--- a/lib/iris/src/iris/cluster/worker/task_attempt.py
+++ b/lib/iris/src/iris/cluster/worker/task_attempt.py
@@ -173,6 +173,17 @@ def build_iris_env(
     for name, port in task.ports.items():
         env[f"IRIS_PORT_{name.upper()}"] = str(port)
 
+    worker_metadata = task._worker_metadata
+    tpu_env = {
+        "TPU_NAME": worker_metadata.tpu_name,
+        "TPU_WORKER_ID": worker_metadata.tpu_worker_id,
+        "TPU_WORKER_HOSTNAMES": worker_metadata.tpu_worker_hostnames,
+        "TPU_CHIPS_PER_HOST_BOUNDS": worker_metadata.tpu_chips_per_host_bounds,
+    }
+    for key, value in tpu_env.items():
+        if value:
+            env[key] = value
+
     return env
 
 

--- a/lib/iris/src/iris/runtime/jax_init.py
+++ b/lib/iris/src/iris/runtime/jax_init.py
@@ -97,6 +97,12 @@ def _poll_for_coordinator(
     return result[0]
 
 
+def _job_scoped_endpoint_name(job_info, endpoint_name: str) -> str:
+    if endpoint_name.startswith("/"):
+        return endpoint_name
+    return f"{job_info.job_id.to_wire()}/{endpoint_name}"
+
+
 def initialize_jax(
     port: int = 8476,
     endpoint_name: str = "jax_coordinator",
@@ -124,15 +130,16 @@ def initialize_jax(
         poll_timeout: Maximum seconds for non-coordinator tasks to wait.
         poll_interval: Initial backoff delay for polling (seconds).
     """
-    import jax
-
-    # TPU has its own distributed init via the TPU runtime; skip the
-    # coordinator dance entirely to avoid conflicts.
-    if os.environ.get("PJRT_DEVICE", "").upper() == "TPU" or os.environ.get("JAX_PLATFORMS", "") == "tpu":
+    is_tpu = os.environ.get("PJRT_DEVICE", "").upper() == "TPU" or os.environ.get("JAX_PLATFORMS", "") == "tpu"
+    if is_tpu:
         logger.info("TPU detected; skipping Iris JAX distributed init (TPU runtime handles it)")
         return
 
+    import jax
+
     job_info = get_job_info()
+    if job_info is not None:
+        endpoint_name = _job_scoped_endpoint_name(job_info, endpoint_name)
     _log_jax_bootstrap_inputs(job_info, port=port, endpoint_name=endpoint_name)
     if job_info is None:
         return

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -141,6 +141,43 @@ def _build_scheduling_context(scheduler: Scheduler, state: ControllerTransitions
     )
 
 
+def _make_tpu_worker_metadata(tpu_name: str, worker_index: int) -> job_pb2.WorkerMetadata:
+    return job_pb2.WorkerMetadata(
+        hostname=f"{tpu_name}-worker-{worker_index}",
+        ip_address=f"10.0.0.{worker_index + 1}",
+        cpu_count=128,
+        memory_bytes=256 * 1024**3,
+        disk_bytes=100 * 1024**3,
+        tpu_name=tpu_name,
+        tpu_worker_id=str(worker_index),
+        tpu_worker_hostnames=f"{tpu_name}-0,{tpu_name}-1,{tpu_name}-2,{tpu_name}-3",
+        tpu_chips_per_host_bounds="2,2,1",
+        device=job_pb2.DeviceConfig(tpu=job_pb2.TpuDevice(variant="v5litepod-16", count=4)),
+        attributes={
+            WellKnownAttribute.DEVICE_TYPE: job_pb2.AttributeValue(string_value="tpu"),
+            WellKnownAttribute.DEVICE_VARIANT: job_pb2.AttributeValue(string_value="v5litepod-16"),
+            WellKnownAttribute.TPU_NAME: job_pb2.AttributeValue(string_value=tpu_name),
+            WellKnownAttribute.TPU_WORKER_ID: job_pb2.AttributeValue(int_value=worker_index),
+        },
+    )
+
+
+def _make_coscheduled_tpu_request(name: str, replicas: int = 4) -> controller_pb2.Controller.LaunchJobRequest:
+    request = controller_pb2.Controller.LaunchJobRequest(
+        name=name,
+        entrypoint=_make_test_entrypoint(),
+        resources=job_pb2.ResourceSpecProto(
+            cpu_millicores=1000,
+            memory_bytes=1024**3,
+            device=job_pb2.DeviceConfig(tpu=job_pb2.TpuDevice(variant="v5litepod-16", count=4)),
+        ),
+        replicas=replicas,
+        environment=job_pb2.EnvironmentConfig(),
+    )
+    request.coscheduling.group_by = WellKnownAttribute.TPU_NAME
+    return request
+
+
 def test_db_snapshot_select_returns_typed_rows(state) -> None:
     request = make_job_request("typed-rows")
     tasks = submit_job(state, "typed-rows", request)
@@ -1091,6 +1128,69 @@ def test_multiple_small_tasks_fill_worker_capacity(state):
     context = _build_scheduling_context(scheduler, state)
     result = scheduler.find_assignments(context)
     assert len(result.assignments) == 0
+
+
+def test_queue_assignments_rejects_stale_coscheduled_tpu_double_book(state):
+    """Commit-time validation rejects stale assignments that double-book a TPU slice."""
+    workers: list[WorkerId] = []
+    for i in range(4):
+        workers.append(register_worker(state, f"w{i}", f"addr{i}:8080", _make_tpu_worker_metadata("tpu-a", i)))
+    first_tasks = submit_job(state, "j1", _make_coscheduled_tpu_request("first-tpu"))
+    second_tasks = submit_job(state, "j2", _make_coscheduled_tpu_request("second-tpu"))
+    first_assignments = [
+        Assignment(task_id=task.task_id, worker_id=worker_id)
+        for task, worker_id in zip(first_tasks, workers, strict=True)
+    ]
+    second_assignments = [
+        Assignment(task_id=task.task_id, worker_id=worker_id)
+        for task, worker_id in zip(second_tasks, workers, strict=True)
+    ]
+
+    with state._store.transaction() as cur:
+        result = state.queue_assignments(cur, first_assignments + second_assignments)
+
+    assert result.accepted == first_assignments
+    assert result.rejected == second_assignments
+    for task, worker_id in zip(first_tasks, workers, strict=True):
+        row = _query_task(state, task.task_id)
+        assert row.state == job_pb2.TASK_STATE_ASSIGNED
+        assert row.current_worker_id == worker_id
+    for task in second_tasks:
+        row = _query_task(state, task.task_id)
+        assert row.state == job_pb2.TASK_STATE_PENDING
+        assert row.current_worker_id is None
+        assert row.current_attempt_id == -1
+    for worker_id in workers:
+        worker = _query_worker(state, worker_id)
+        assert worker.committed_tpu == 4
+
+
+def test_queue_assignments_rejects_partial_coscheduled_tpu_gang(state):
+    """A live validation failure rejects the whole incoming coscheduled gang."""
+    workers: list[WorkerId] = []
+    for i in range(3):
+        workers.append(register_worker(state, f"w{i}", f"addr{i}:8080", _make_tpu_worker_metadata("tpu-a", i)))
+    tasks = submit_job(state, "j1", _make_coscheduled_tpu_request("partial-tpu"))
+    assignments = [
+        Assignment(task_id=tasks[0].task_id, worker_id=workers[0]),
+        Assignment(task_id=tasks[1].task_id, worker_id=workers[1]),
+        Assignment(task_id=tasks[2].task_id, worker_id=workers[2]),
+        Assignment(task_id=tasks[3].task_id, worker_id=WorkerId("missing-worker")),
+    ]
+
+    with state._store.transaction() as cur:
+        result = state.queue_assignments(cur, assignments)
+
+    assert result.accepted == []
+    assert result.rejected == assignments
+    for task in tasks:
+        row = _query_task(state, task.task_id)
+        assert row.state == job_pb2.TASK_STATE_PENDING
+        assert row.current_worker_id is None
+        assert row.current_attempt_id == -1
+    for worker_id in workers:
+        worker = _query_worker(state, worker_id)
+        assert worker.committed_tpu == 0
 
 
 # =============================================================================

--- a/lib/iris/tests/cluster/worker/test_worker.py
+++ b/lib/iris/tests/cluster/worker/test_worker.py
@@ -24,7 +24,7 @@ from iris.cluster.types import Entrypoint, JobName
 from iris.cluster.worker.port_allocator import PortAllocator
 from iris.cluster.worker.service import WorkerServiceImpl
 from iris.cluster.worker.stats import IrisTaskStat, IrisWorkerStat
-from iris.cluster.worker.task_attempt import TaskAttempt
+from iris.cluster.worker.task_attempt import TaskAttempt, build_iris_env
 from iris.cluster.worker.worker import Worker, WorkerConfig
 from iris.cluster.worker.worker_types import LogLine
 from iris.rpc import job_pb2, worker_pb2
@@ -585,6 +585,34 @@ def test_port_env_vars_set(mock_worker, mock_runtime):
         int(config.env["IRIS_PORT_METRICS"]),
     }
     assert len(ports) == 3
+
+
+def test_build_iris_env_includes_tpu_runtime_metadata() -> None:
+    """TPU task containers receive the metadata JAX needs for native discovery."""
+    request = create_run_task_request(num_tasks=4)
+    request.resources.device.tpu.CopyFrom(job_pb2.TpuDevice(variant="v5litepod-16", count=4))
+    metadata = job_pb2.WorkerMetadata(
+        tpu_name="tpu-slice-a",
+        tpu_worker_id="2",
+        tpu_worker_hostnames="host-0,host-1,host-2,host-3",
+        tpu_chips_per_host_bounds="2,2,1",
+    )
+
+    class EnvTask:
+        def __init__(self, task_request: job_pb2.RunTaskRequest, worker_metadata: job_pb2.WorkerMetadata) -> None:
+            self.request = task_request
+            self.attempt_id = task_request.attempt_id
+            self.num_tasks = task_request.num_tasks
+            self.ports: dict[str, int] = {}
+            self._worker_metadata = worker_metadata
+
+    with patch("iris.cluster.worker.task_attempt._get_host_ip", return_value="10.0.0.2"):
+        env = build_iris_env(EnvTask(request, metadata), "worker-2", "controller:8080")
+
+    assert env["TPU_NAME"] == "tpu-slice-a"
+    assert env["TPU_WORKER_ID"] == "2"
+    assert env["TPU_WORKER_HOSTNAMES"] == "host-0,host-1,host-2,host-3"
+    assert env["TPU_CHIPS_PER_HOST_BOUNDS"] == "2,2,1"
 
 
 def test_env_merge_precedence(mock_bundle_store, mock_runtime, tmp_path):

--- a/lib/iris/tests/test_jax_init.py
+++ b/lib/iris/tests/test_jax_init.py
@@ -34,8 +34,10 @@ class FakeRegistry:
 class FakeResolver:
     results: list[ResolveResult] = field(default_factory=list)
     call_count: int = 0
+    resolved_names: list[str] = field(default_factory=list)
 
     def resolve(self, name: str) -> ResolveResult:
+        self.resolved_names.append(name)
         idx = min(self.call_count, len(self.results) - 1)
         result = self.results[idx]
         self.call_count += 1
@@ -133,7 +135,29 @@ def test_initialize_jax_task0_registers(
 
     initialize_jax(port=9999)
 
-    assert fake_ctx.registry.registered == [("jax_coordinator", "10.0.0.1:9999")]
+    assert fake_ctx.registry.registered == [("/testuser/testjob/jax_coordinator", "10.0.0.1:9999")]
+    mock_jax_init.assert_called_once_with("10.0.0.1:9999", 4, 0)
+    mock_atexit.register.assert_called_once_with(fake_ctx.registry.unregister, "endpoint-1")
+
+
+@patch("iris.runtime.jax_init.atexit")
+@patch("jax.distributed.initialize")
+@patch("iris.runtime.jax_init.iris_ctx")
+@patch("iris.runtime.jax_init.get_job_info")
+def test_initialize_jax_preserves_absolute_endpoint_name(
+    mock_get_job_info: MagicMock,
+    mock_iris_ctx: MagicMock,
+    mock_jax_init: MagicMock,
+    mock_atexit: MagicMock,
+) -> None:
+    """Absolute endpoint names are treated as explicit advanced overrides."""
+    mock_get_job_info.return_value = _make_job_info(task_index=0, num_tasks=4)
+    fake_ctx = FakeContext()
+    mock_iris_ctx.return_value = fake_ctx
+
+    initialize_jax(port=9999, endpoint_name="/shared/jax")
+
+    assert fake_ctx.registry.registered == [("/shared/jax", "10.0.0.1:9999")]
     mock_jax_init.assert_called_once_with("10.0.0.1:9999", 4, 0)
     mock_atexit.register.assert_called_once_with(fake_ctx.registry.unregister, "endpoint-1")
 
@@ -157,7 +181,7 @@ def test_initialize_jax_task0_uses_iris_port(
 
     initialize_jax(port=9999)
 
-    assert fake_ctx.registry.registered == [("jax_coordinator", "10.0.0.1:12345")]
+    assert fake_ctx.registry.registered == [("/testuser/testjob/jax_coordinator", "10.0.0.1:12345")]
     mock_jax_init.assert_called_once_with("10.0.0.1:12345", 2, 0)
 
 
@@ -183,6 +207,7 @@ def test_initialize_jax_taskN_polls(
     initialize_jax(poll_timeout=10.0, poll_interval=0.01)
 
     assert fake_ctx.resolver.call_count >= 3
+    assert set(fake_ctx.resolver.resolved_names) == {"/testuser/testjob/jax_coordinator"}
     mock_jax_init.assert_called_once_with("10.0.0.1:8476", 4, 2)
 
 


### PR DESCRIPTION
Stop TPU jobs from using the Iris JAX coordinator and pass TPU runtime metadata into task containers. Revalidate assignment commits against live worker capacity and reject overlapping coscheduled TPU gangs before they can share hosts.

Fixes #5470