### PR TITLE
Fix CoreWeave canary controller routing

### DIFF
--- a/.github/workflows/iris-smoke-coreweave.yaml
+++ b/.github/workflows/iris-smoke-coreweave.yaml
@@ -110,94 +110,12 @@ jobs:
             --config=examples/coreweave-ci.yaml \
             cluster start --fresh
 
-      - name: Wait for controller rollout to settle
+      - name: Connect to iris-ci controller
         run: |
-          export KUBECONFIG=~/.kube/coreweave-iris
-          kubectl rollout status -n "$IRIS_NAMESPACE" deployment/iris-controller --timeout=600s
-
-          for _ in $(seq 1 60); do
-            pod_count=$(kubectl get pods -n "$IRIS_NAMESPACE" -l app=iris-controller -o name | wc -l | tr -d ' ')
-            if [ "$pod_count" = "1" ]; then
-              kubectl wait -n "$IRIS_NAMESPACE" --for=condition=Ready pod -l app=iris-controller --timeout=120s
-              exit 0
-            fi
-
-            echo "waiting for controller rollout to settle (pods=$pod_count)"
-            kubectl get pods -n "$IRIS_NAMESPACE" -l app=iris-controller -o wide
-            sleep 5
-          done
-
-          echo "controller rollout did not settle to one pod"
-          kubectl get pods -n "$IRIS_NAMESPACE" -l app=iris-controller -o wide
-          exit 1
-
-      - name: Port-forward to iris-ci controller
-        run: |
-          export KUBECONFIG=~/.kube/coreweave-iris
-          url="http://127.0.0.1:10000"
-          pf_log="$RUNNER_TEMP/iris-cw-port-forward.log"
-
-          (
-            set +e
-            child=""
-
-            stop() {
-              if [ -n "$child" ]; then
-                kill "$child" 2>/dev/null || true
-              fi
-              exit 0
-            }
-
-            trap stop TERM INT
-
-            while true; do
-              controller_pod=$(kubectl get pods -n "$IRIS_NAMESPACE" \
-                -l app=iris-controller \
-                --field-selector=status.phase=Running \
-                -o name | head -n 1)
-              if [ -z "$controller_pod" ]; then
-                echo "no running controller pod found; retrying in 2s"
-                sleep 2
-                continue
-              fi
-
-              echo "starting kubectl port-forward to $controller_pod"
-              kubectl port-forward -n "$IRIS_NAMESPACE" "$controller_pod" 10000:10000 &
-              child=$!
-              wait "$child"
-              status=$?
-              child=""
-              echo "kubectl port-forward exited with $status; restarting in 2s"
-              sleep 2 &
-              child=$!
-              wait "$child"
-              child=""
-            done
-          ) >"$pf_log" 2>&1 &
-          pf_pid=$!
-
-          for _ in $(seq 1 60); do
-            if ! kill -0 "$pf_pid" 2>/dev/null; then
-              echo "port-forward supervisor exited before controller became healthy"
-              tail -n 200 "$pf_log" || true
-              exit 1
-            fi
-            if curl --fail --silent --show-error "$url/health" >/dev/null; then
-              {
-                echo "IRIS_CONTROLLER_URL=$url"
-                echo "PF_PID=$pf_pid"
-                echo "PF_LOG=$pf_log"
-              } >> "$GITHUB_ENV"
-              echo "Controller healthy on $url (supervisor pid=$pf_pid, log=$pf_log)"
-              exit 0
-            fi
-            sleep 5
-          done
-
-          kill "$pf_pid" 2>/dev/null || true
-          echo "Controller $url/health never became healthy"
-          tail -n 200 "$pf_log" || true
-          exit 1
+          uv run python scripts/workflows/iris_monitor.py coreweave-controller \
+            --namespace "$IRIS_NAMESPACE" \
+            --kubeconfig "$HOME/.kube/coreweave-iris" \
+            --log-path "$RUNNER_TEMP/iris-cw-port-forward.log"
 
       - name: Run integration tests
         env:
@@ -233,12 +151,6 @@ jobs:
           timeout 1800 uv run pytest tests/test_integration_test.py \
             -m integration -o "addopts=" --timeout=900 -v -s
 
-      - name: Stop port-forward
-        if: always()
-        run: |
-          [ -n "${PF_PID:-}" ] && kill "$PF_PID" 2>/dev/null || true
-          pkill -f "kubectl.*port-forward.*$IRIS_NAMESPACE.*pod/iris-controller" 2>/dev/null || true
-
       - name: Capture failure diagnostics
         if: failure()
         continue-on-error: true
@@ -253,7 +165,7 @@ jobs:
           # nothing — continue-on-error tolerates the empty kubernetes-pods.json.
           uv run python scripts/workflows/iris_monitor.py collect \
             --job-id "ci-smoke" \
-            --iris-config lib/iris/examples/coreweave-ci.yaml \
+            --controller-url "$IRIS_CONTROLLER_URL" \
             --provider coreweave \
             --output-dir "$LOG_DIR" \
             --namespace "$IRIS_NAMESPACE" \
@@ -268,6 +180,15 @@ jobs:
           path: iris-cw-logs/
           retention-days: 14
           if-no-files-found: ignore
+
+      - name: Stop port-forward
+        if: always()
+        run: |
+          if [ -n "${PF_PID:-}" ]; then
+            kill "$PF_PID" 2>/dev/null || true
+          fi
+          pkill -f "kubectl.*$IRIS_NAMESPACE.*port-forward.*pod/iris-controller" 2>/dev/null || true
+          pkill -f "kubectl.*port-forward.*$IRIS_NAMESPACE.*pod/iris-controller" 2>/dev/null || true
 
       - name: Set commit status to result
         if: always() && (github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/marin-canary-ferry-coreweave.yaml
+++ b/.github/workflows/marin-canary-ferry-coreweave.yaml
@@ -106,12 +106,19 @@ jobs:
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: .venv/bin/iris -v --config=${{ env.IRIS_CONFIG }} cluster start --fresh
 
+      - name: Connect to iris-ci controller
+        run: |
+          uv run python scripts/workflows/iris_monitor.py coreweave-controller \
+            --namespace "$IRIS_NAMESPACE" \
+            --kubeconfig "$HOME/.kube/coreweave-iris" \
+            --log-path "$RUNNER_TEMP/iris-cw-port-forward.log"
+
       - name: Submit canary ferry
         id: submit
         shell: bash -l {0}
         run: |
           echo "Multi-host canary: ${CANARY_MULTI_HOST:-0}"
-          JOB_ID=$(.venv/bin/iris --config="$IRIS_CONFIG" \
+          JOB_ID=$(.venv/bin/iris --controller-url="$IRIS_CONTROLLER_URL" \
             job run --no-wait \
             --memory=2G --disk=4G --cpu=1 --extra=cpu \
             -e MARIN_PREFIX s3://marin-na/marin/ \
@@ -142,7 +149,7 @@ jobs:
         run: |
           uv run python scripts/workflows/iris_monitor.py wait \
             --job-id "${{ steps.submit.outputs.job_id }}" \
-            --iris-config "$IRIS_CONFIG" \
+            --controller-url "$IRIS_CONTROLLER_URL" \
             --poll-interval 30 \
             --timeout 10500 \
             --github-output
@@ -179,9 +186,12 @@ jobs:
           DIAG_DIR: /tmp/canary-diag
         run: |
           mkdir -p "$DIAG_DIR"
+          if [ -n "${PF_LOG:-}" ] && [ -f "$PF_LOG" ]; then
+            cp "$PF_LOG" "$DIAG_DIR/port-forward.log"
+          fi
           uv run python scripts/workflows/iris_monitor.py collect \
             --job-id "$JOB_ID" \
-            --iris-config "$IRIS_CONFIG" \
+            --controller-url "$IRIS_CONTROLLER_URL" \
             --provider coreweave \
             --output-dir "$DIAG_DIR" \
             --namespace "$IRIS_NAMESPACE" \
@@ -243,6 +253,15 @@ jobs:
           path: slack_message.md
           retention-days: 1
           if-no-files-found: ignore
+
+      - name: Stop port-forward
+        if: always()
+        run: |
+          if [ -n "${PF_PID:-}" ]; then
+            kill "$PF_PID" 2>/dev/null || true
+          fi
+          pkill -f "kubectl.*$IRIS_NAMESPACE.*port-forward.*pod/iris-controller" 2>/dev/null || true
+          pkill -f "kubectl.*port-forward.*$IRIS_NAMESPACE.*pod/iris-controller" 2>/dev/null || true
 
   # Separate job so Slack always fires, even if the main job is force-killed
   # after its grace window. `needs.canary-ferry-cw.result` reflects the main

--- a/scripts/workflows/iris_monitor.py
+++ b/scripts/workflows/iris_monitor.py
@@ -6,7 +6,6 @@
 import json
 import os
 import re
-import signal
 import subprocess
 import sys
 import time
@@ -647,13 +646,13 @@ def _wait_for_controller_health(
     health_path: str,
     timeout: float,
     poll_interval: float,
-    supervisor: subprocess.Popen,
+    port_forward: subprocess.Popen,
 ) -> None:
     url = _health_url(controller_url, health_path)
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        if supervisor.poll() is not None:
-            raise RuntimeError(f"port-forward supervisor exited with code {supervisor.returncode}")
+        if port_forward.poll() is not None:
+            raise RuntimeError(f"kubectl port-forward exited with code {port_forward.returncode}")
         try:
             with urllib.request.urlopen(url, timeout=min(poll_interval, 5.0)) as resp:
                 if 200 <= resp.status < 300:
@@ -664,39 +663,36 @@ def _wait_for_controller_health(
     raise TimeoutError(f"controller {url} never became healthy within {timeout}s")
 
 
-def _start_coreweave_port_forward_supervisor(
+def _start_coreweave_port_forward(
     namespace: str,
     kubeconfig: Path | None,
     *,
-    controller_selector: str,
+    pod_name: str,
     local_port: int,
     remote_port: int,
-    poll_interval: float,
     log_path: Path,
 ) -> subprocess.Popen:
+    """Spawn ``kubectl port-forward pod/X local:remote`` detached.
+
+    Uses ``start_new_session=True`` so the kubectl process survives this
+    Python script exiting — the workflow's later ``Stop port-forward`` step
+    kills it via ``$PF_PID``. The log is opened line-buffered so failure
+    diagnostics that ``cp`` it before SIGTERM see complete output.
+    """
     log_path.parent.mkdir(parents=True, exist_ok=True)
     cmd = [
-        sys.executable,
-        str(Path(__file__).resolve()),
-        "coreweave-port-forward-supervisor",
-        "--namespace",
+        *_kubectl(kubeconfig),
+        "-n",
         namespace,
-        "--controller-selector",
-        controller_selector,
-        "--local-port",
-        str(local_port),
-        "--remote-port",
-        str(remote_port),
-        "--poll-interval",
-        str(poll_interval),
+        "port-forward",
+        f"pod/{pod_name}",
+        f"{local_port}:{remote_port}",
     ]
-    if kubeconfig is not None:
-        cmd.extend(["--kubeconfig", str(kubeconfig)])
-
-    log_file = log_path.open("a")
+    log_file = log_path.open("a", buffering=1)
     try:
-        return subprocess.Popen(cmd, stdout=log_file, stderr=subprocess.STDOUT, text=True, start_new_session=True)
+        return subprocess.Popen(cmd, stdout=log_file, stderr=subprocess.STDOUT, start_new_session=True)
     finally:
+        # Parent's copy of the fd can be closed once Popen has dup'd it into the child.
         log_file.close()
 
 
@@ -712,8 +708,14 @@ def open_coreweave_controller_tunnel(
     health_path: str,
     log_path: Path,
 ) -> tuple[str, int]:
+    """Wait for the controller rollout to settle, start ``kubectl port-forward``, probe ``/health``.
+
+    Returns ``(controller_url, kubectl_pid)``. The kubectl child runs in a new
+    session so it outlives this Python process — workflows hold on to the PID
+    and tear it down later via ``kill $PF_PID``.
+    """
     _kubectl_rollout_status(namespace, kubeconfig, timeout=timeout)
-    wait_for_settled_coreweave_controller(
+    pod_name = wait_for_settled_coreweave_controller(
         namespace,
         kubeconfig,
         controller_selector=controller_selector,
@@ -721,13 +723,12 @@ def open_coreweave_controller_tunnel(
         poll_interval=poll_interval,
     )
 
-    supervisor = _start_coreweave_port_forward_supervisor(
+    port_forward = _start_coreweave_port_forward(
         namespace,
         kubeconfig,
-        controller_selector=controller_selector,
+        pod_name=pod_name,
         local_port=local_port,
         remote_port=remote_port,
-        poll_interval=poll_interval,
         log_path=log_path,
     )
     controller_url = f"http://127.0.0.1:{local_port}"
@@ -737,61 +738,12 @@ def open_coreweave_controller_tunnel(
             health_path=health_path,
             timeout=timeout,
             poll_interval=poll_interval,
-            supervisor=supervisor,
+            port_forward=port_forward,
         )
     except (RuntimeError, TimeoutError):
-        _terminate_process(supervisor)
+        _terminate_process(port_forward)
         raise
-    return controller_url, supervisor.pid
-
-
-def run_coreweave_port_forward_supervisor(
-    namespace: str,
-    kubeconfig: Path | None,
-    *,
-    controller_selector: str,
-    local_port: int,
-    remote_port: int,
-    poll_interval: float,
-) -> None:
-    child: subprocess.Popen | None = None
-
-    def stop(_signum: int, _frame: object) -> None:
-        if child is not None:
-            _terminate_process(child)
-        raise SystemExit(0)
-
-    signal.signal(signal.SIGTERM, stop)
-    signal.signal(signal.SIGINT, stop)
-
-    while True:
-        try:
-            pod_name = wait_for_settled_coreweave_controller(
-                namespace,
-                kubeconfig,
-                controller_selector=controller_selector,
-                timeout=max(poll_interval, 1.0),
-                poll_interval=poll_interval,
-            )
-        except (RuntimeError, TimeoutError, json.JSONDecodeError) as exc:
-            click.echo(f"controller pod is not ready for port-forward: {exc}", err=True)
-            time.sleep(poll_interval)
-            continue
-
-        cmd = [
-            *_kubectl(kubeconfig),
-            "-n",
-            namespace,
-            "port-forward",
-            f"pod/{pod_name}",
-            f"{local_port}:{remote_port}",
-        ]
-        click.echo(f"starting kubectl port-forward to pod/{pod_name}", err=True)
-        child = subprocess.Popen(cmd)
-        status = child.wait()
-        child = None
-        click.echo(f"kubectl port-forward exited with {status}; restarting in {poll_interval}s", err=True)
-        time.sleep(poll_interval)
+    return controller_url, port_forward.pid
 
 
 @click.group()
@@ -999,7 +951,7 @@ def port_forward(
     "--log-path",
     required=True,
     type=click.Path(path_type=Path),
-    help="Path where the port-forward supervisor writes kubectl output.",
+    help="Path where kubectl port-forward writes its stdout/stderr.",
 )
 @click.option("--url-var", default="IRIS_CONTROLLER_URL", show_default=True)
 @click.option("--pid-var", default="PF_PID", show_default=True)
@@ -1030,36 +982,11 @@ def coreweave_controller(
         health_path=health_path,
         log_path=log_path,
     )
-    click.echo(f"Controller healthy on {url} (supervisor pid={pf_pid}, log={log_path})", err=True)
+    click.echo(f"Controller healthy on {url} (kubectl pid={pf_pid}, log={log_path})", err=True)
 
     if path := os.environ.get("GITHUB_ENV"):
         with open(path, "a") as fh:
             fh.write(f"{url_var}={url}\n{pid_var}={pf_pid}\n{log_var}={log_path}\n")
-
-
-@cli.command(name="coreweave-port-forward-supervisor", hidden=True)
-@click.option("--namespace", required=True)
-@click.option("--kubeconfig", default=None, type=click.Path(path_type=Path))
-@click.option("--controller-selector", default="app=iris-controller", show_default=True)
-@click.option("--local-port", default=10000, show_default=True, type=int)
-@click.option("--remote-port", default=10000, show_default=True, type=int)
-@click.option("--poll-interval", default=5.0, show_default=True, type=float)
-def coreweave_port_forward_supervisor(
-    namespace: str,
-    kubeconfig: Path | None,
-    controller_selector: str,
-    local_port: int,
-    remote_port: int,
-    poll_interval: float,
-) -> None:
-    run_coreweave_port_forward_supervisor(
-        namespace,
-        kubeconfig,
-        controller_selector=controller_selector,
-        local_port=local_port,
-        remote_port=remote_port,
-        poll_interval=poll_interval,
-    )
 
 
 if __name__ == "__main__":

--- a/scripts/workflows/iris_monitor.py
+++ b/scripts/workflows/iris_monitor.py
@@ -6,6 +6,7 @@
 import json
 import os
 import re
+import signal
 import subprocess
 import sys
 import time
@@ -44,6 +45,14 @@ class IrisJobStatus:
     job_id: str
     state: str  # iris proto state name, e.g. "JOB_STATE_RUNNING"
     error: str | None
+
+
+@dataclass(frozen=True)
+class K8sPodStatus:
+    name: str
+    phase: str
+    ready: bool
+    deleting: bool
 
 
 def iris_command(repo_root: Path) -> list[str]:
@@ -503,6 +512,288 @@ def open_controller_tunnel(
     raise TimeoutError(f"controller {health_url} never became healthy within {timeout}s")
 
 
+def _pod_ready(pod: dict) -> bool:
+    return any(
+        condition.get("type") == "Ready" and condition.get("status") == "True"
+        for condition in pod.get("status", {}).get("conditions", [])
+    )
+
+
+def _controller_pods_from_json(payload: str) -> list[K8sPodStatus]:
+    data = json.loads(payload)
+    pods: list[K8sPodStatus] = []
+    for pod in data.get("items", []):
+        metadata = pod.get("metadata", {})
+        status = pod.get("status", {})
+        name = metadata.get("name", "")
+        if not name:
+            continue
+        pods.append(
+            K8sPodStatus(
+                name=name,
+                phase=status.get("phase", "Unknown"),
+                ready=_pod_ready(pod),
+                deleting=metadata.get("deletionTimestamp") is not None,
+            )
+        )
+    return pods
+
+
+def _settled_controller_pod_name(pods: list[K8sPodStatus]) -> str | None:
+    if len(pods) != 1:
+        return None
+    pod = pods[0]
+    if pod.phase != "Running" or not pod.ready or pod.deleting:
+        return None
+    return pod.name
+
+
+def _format_controller_pods(pods: list[K8sPodStatus]) -> str:
+    if not pods:
+        return "(none)"
+    return ", ".join(f"{pod.name}:phase={pod.phase},ready={pod.ready},deleting={pod.deleting}" for pod in pods)
+
+
+def _kubectl_rollout_status(
+    namespace: str,
+    kubeconfig: Path | None,
+    *,
+    timeout: float,
+) -> None:
+    result = _run(
+        [
+            *_kubectl(kubeconfig),
+            "-n",
+            namespace,
+            "rollout",
+            "status",
+            "deployment/iris-controller",
+            f"--timeout={max(1, int(timeout))}s",
+        ]
+    )
+    if result.stdout:
+        click.echo(result.stdout.rstrip(), err=True)
+    if result.stderr:
+        click.echo(result.stderr.rstrip(), err=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"kubectl rollout status failed (exit {result.returncode})")
+
+
+def _controller_pods(
+    namespace: str,
+    kubeconfig: Path | None,
+    *,
+    controller_selector: str,
+) -> list[K8sPodStatus]:
+    result = _run(
+        [
+            *_kubectl(kubeconfig),
+            "-n",
+            namespace,
+            "get",
+            "pods",
+            "-l",
+            controller_selector,
+            "-o",
+            "json",
+        ]
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"kubectl get controller pods failed (exit {result.returncode}): {result.stderr.strip()}")
+    return _controller_pods_from_json(result.stdout)
+
+
+def wait_for_settled_coreweave_controller(
+    namespace: str,
+    kubeconfig: Path | None,
+    *,
+    controller_selector: str,
+    timeout: float,
+    poll_interval: float,
+) -> str:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        pods = _controller_pods(namespace, kubeconfig, controller_selector=controller_selector)
+        pod_name = _settled_controller_pod_name(pods)
+        if pod_name is not None:
+            click.echo(f"Controller rollout settled on pod/{pod_name}", err=True)
+            return pod_name
+
+        click.echo(f"waiting for one ready controller pod: {_format_controller_pods(pods)}", err=True)
+        time.sleep(poll_interval)
+
+    pods = _controller_pods(namespace, kubeconfig, controller_selector=controller_selector)
+    raise TimeoutError(f"controller rollout did not settle to one ready pod: {_format_controller_pods(pods)}")
+
+
+def _terminate_process(proc: subprocess.Popen, *, timeout: float = 5.0) -> None:
+    if proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _health_url(controller_url: str, health_path: str) -> str:
+    return controller_url.rstrip("/") + "/" + health_path.lstrip("/")
+
+
+def _wait_for_controller_health(
+    controller_url: str,
+    *,
+    health_path: str,
+    timeout: float,
+    poll_interval: float,
+    supervisor: subprocess.Popen,
+) -> None:
+    url = _health_url(controller_url, health_path)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if supervisor.poll() is not None:
+            raise RuntimeError(f"port-forward supervisor exited with code {supervisor.returncode}")
+        try:
+            with urllib.request.urlopen(url, timeout=min(poll_interval, 5.0)) as resp:
+                if 200 <= resp.status < 300:
+                    return
+        except (urllib.error.URLError, ConnectionError, TimeoutError, OSError):
+            pass
+        time.sleep(poll_interval)
+    raise TimeoutError(f"controller {url} never became healthy within {timeout}s")
+
+
+def _start_coreweave_port_forward_supervisor(
+    namespace: str,
+    kubeconfig: Path | None,
+    *,
+    controller_selector: str,
+    local_port: int,
+    remote_port: int,
+    poll_interval: float,
+    log_path: Path,
+) -> subprocess.Popen:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "coreweave-port-forward-supervisor",
+        "--namespace",
+        namespace,
+        "--controller-selector",
+        controller_selector,
+        "--local-port",
+        str(local_port),
+        "--remote-port",
+        str(remote_port),
+        "--poll-interval",
+        str(poll_interval),
+    ]
+    if kubeconfig is not None:
+        cmd.extend(["--kubeconfig", str(kubeconfig)])
+
+    log_file = log_path.open("a")
+    try:
+        return subprocess.Popen(cmd, stdout=log_file, stderr=subprocess.STDOUT, text=True, start_new_session=True)
+    finally:
+        log_file.close()
+
+
+def open_coreweave_controller_tunnel(
+    namespace: str,
+    kubeconfig: Path | None,
+    *,
+    controller_selector: str,
+    local_port: int,
+    remote_port: int,
+    timeout: float,
+    poll_interval: float,
+    health_path: str,
+    log_path: Path,
+) -> tuple[str, int]:
+    _kubectl_rollout_status(namespace, kubeconfig, timeout=timeout)
+    wait_for_settled_coreweave_controller(
+        namespace,
+        kubeconfig,
+        controller_selector=controller_selector,
+        timeout=timeout,
+        poll_interval=poll_interval,
+    )
+
+    supervisor = _start_coreweave_port_forward_supervisor(
+        namespace,
+        kubeconfig,
+        controller_selector=controller_selector,
+        local_port=local_port,
+        remote_port=remote_port,
+        poll_interval=poll_interval,
+        log_path=log_path,
+    )
+    controller_url = f"http://127.0.0.1:{local_port}"
+    try:
+        _wait_for_controller_health(
+            controller_url,
+            health_path=health_path,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            supervisor=supervisor,
+        )
+    except (RuntimeError, TimeoutError):
+        _terminate_process(supervisor)
+        raise
+    return controller_url, supervisor.pid
+
+
+def run_coreweave_port_forward_supervisor(
+    namespace: str,
+    kubeconfig: Path | None,
+    *,
+    controller_selector: str,
+    local_port: int,
+    remote_port: int,
+    poll_interval: float,
+) -> None:
+    child: subprocess.Popen | None = None
+
+    def stop(_signum: int, _frame: object) -> None:
+        if child is not None:
+            _terminate_process(child)
+        raise SystemExit(0)
+
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+
+    while True:
+        try:
+            pod_name = wait_for_settled_coreweave_controller(
+                namespace,
+                kubeconfig,
+                controller_selector=controller_selector,
+                timeout=max(poll_interval, 1.0),
+                poll_interval=poll_interval,
+            )
+        except (RuntimeError, TimeoutError, json.JSONDecodeError) as exc:
+            click.echo(f"controller pod is not ready for port-forward: {exc}", err=True)
+            time.sleep(poll_interval)
+            continue
+
+        cmd = [
+            *_kubectl(kubeconfig),
+            "-n",
+            namespace,
+            "port-forward",
+            f"pod/{pod_name}",
+            f"{local_port}:{remote_port}",
+        ]
+        click.echo(f"starting kubectl port-forward to pod/{pod_name}", err=True)
+        child = subprocess.Popen(cmd)
+        status = child.wait()
+        child = None
+        click.echo(f"kubectl port-forward exited with {status}; restarting in {poll_interval}s", err=True)
+        time.sleep(poll_interval)
+
+
 @click.group()
 def cli() -> None:
     pass
@@ -682,6 +973,93 @@ def port_forward(
     if path := os.environ.get("GITHUB_ENV"):
         with open(path, "a") as fh:
             fh.write(f"{url_var}={url}\nPF_PID={pf_pid}\n")
+
+
+@cli.command(name="coreweave-controller")
+@click.option("--namespace", required=True, help="Kubernetes namespace containing the Iris controller.")
+@click.option(
+    "--kubeconfig",
+    default=None,
+    type=click.Path(path_type=Path),
+    help="Path to the CoreWeave kubeconfig. Uses kubectl's default config when omitted.",
+)
+@click.option("--controller-selector", default="app=iris-controller", show_default=True)
+@click.option("--local-port", default=10000, show_default=True, type=int)
+@click.option("--remote-port", default=10000, show_default=True, type=int)
+@click.option(
+    "--timeout",
+    default=600.0,
+    show_default=True,
+    type=float,
+    help="Seconds to wait for each controller readiness phase.",
+)
+@click.option("--poll-interval", default=5.0, show_default=True, type=float)
+@click.option("--health-path", default="/health", show_default=True)
+@click.option(
+    "--log-path",
+    required=True,
+    type=click.Path(path_type=Path),
+    help="Path where the port-forward supervisor writes kubectl output.",
+)
+@click.option("--url-var", default="IRIS_CONTROLLER_URL", show_default=True)
+@click.option("--pid-var", default="PF_PID", show_default=True)
+@click.option("--log-var", default="PF_LOG", show_default=True)
+def coreweave_controller(
+    namespace: str,
+    kubeconfig: Path | None,
+    controller_selector: str,
+    local_port: int,
+    remote_port: int,
+    timeout: float,
+    poll_interval: float,
+    health_path: str,
+    log_path: Path,
+    url_var: str,
+    pid_var: str,
+    log_var: str,
+) -> None:
+    """Wait for the CoreWeave controller rollout and export a stable local controller URL."""
+    url, pf_pid = open_coreweave_controller_tunnel(
+        namespace,
+        kubeconfig,
+        controller_selector=controller_selector,
+        local_port=local_port,
+        remote_port=remote_port,
+        timeout=timeout,
+        poll_interval=poll_interval,
+        health_path=health_path,
+        log_path=log_path,
+    )
+    click.echo(f"Controller healthy on {url} (supervisor pid={pf_pid}, log={log_path})", err=True)
+
+    if path := os.environ.get("GITHUB_ENV"):
+        with open(path, "a") as fh:
+            fh.write(f"{url_var}={url}\n{pid_var}={pf_pid}\n{log_var}={log_path}\n")
+
+
+@cli.command(name="coreweave-port-forward-supervisor", hidden=True)
+@click.option("--namespace", required=True)
+@click.option("--kubeconfig", default=None, type=click.Path(path_type=Path))
+@click.option("--controller-selector", default="app=iris-controller", show_default=True)
+@click.option("--local-port", default=10000, show_default=True, type=int)
+@click.option("--remote-port", default=10000, show_default=True, type=int)
+@click.option("--poll-interval", default=5.0, show_default=True, type=float)
+def coreweave_port_forward_supervisor(
+    namespace: str,
+    kubeconfig: Path | None,
+    controller_selector: str,
+    local_port: int,
+    remote_port: int,
+    poll_interval: float,
+) -> None:
+    run_coreweave_port_forward_supervisor(
+        namespace,
+        kubeconfig,
+        controller_selector=controller_selector,
+        local_port=local_port,
+        remote_port=remote_port,
+        poll_interval=poll_interval,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/workflows/test_iris_monitor.py
+++ b/tests/workflows/test_iris_monitor.py
@@ -1,0 +1,40 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+from scripts.workflows import iris_monitor
+
+
+def _pod(name: str, *, phase: str = "Running", ready: bool = True, deleting: bool = False) -> dict:
+    metadata = {"name": name}
+    if deleting:
+        metadata["deletionTimestamp"] = "2026-05-06T12:00:00Z"
+    return {
+        "metadata": metadata,
+        "status": {
+            "phase": phase,
+            "conditions": [{"type": "Ready", "status": "True" if ready else "False"}],
+        },
+    }
+
+
+def _statuses(*pods: dict) -> list[iris_monitor.K8sPodStatus]:
+    return iris_monitor._controller_pods_from_json(json.dumps({"items": list(pods)}))
+
+
+def test_settled_coreweave_controller_requires_exactly_one_ready_pod() -> None:
+    assert iris_monitor._settled_controller_pod_name(_statuses(_pod("iris-controller-new"))) == "iris-controller-new"
+
+    assert iris_monitor._settled_controller_pod_name(_statuses()) is None
+    assert (
+        iris_monitor._settled_controller_pod_name(
+            _statuses(
+                _pod("iris-controller-old", deleting=True),
+                _pod("iris-controller-new"),
+            )
+        )
+        is None
+    )
+    assert iris_monitor._settled_controller_pod_name(_statuses(_pod("iris-controller-new", ready=False))) is None
+    assert iris_monitor._settled_controller_pod_name(_statuses(_pod("iris-controller-new", phase="Pending"))) is None


### PR DESCRIPTION
## Summary

Fixes #5469.

This restores an explicit CoreWeave controller connection before the GPU canary submits work. The new workflow helper waits for `deployment/iris-controller`, requires the rollout to settle to exactly one ready controller pod, starts a supervised local `kubectl port-forward`, probes `/health`, and exports `IRIS_CONTROLLER_URL`, `PF_PID`, and `PF_LOG`.

The CoreWeave smoke workflow now uses the same helper instead of carrying its own shell copy, and the CoreWeave canary submits, waits, and collects diagnostics through the exported controller URL instead of `--config` auto-tunneling immediately after a controller rollout.

## Validation

- `./infra/pre-commit.py --fix scripts/workflows/iris_monitor.py tests/workflows/test_iris_monitor.py .github/workflows/iris-smoke-coreweave.yaml .github/workflows/marin-canary-ferry-coreweave.yaml`
- `uv run --with pytest --with pytest-timeout pytest tests/workflows/test_iris_monitor.py`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/iris-smoke-coreweave.yaml .github/workflows/marin-canary-ferry-coreweave.yaml`
- `git diff --check`
- `uv run python scripts/workflows/iris_monitor.py coreweave-controller --help`
- CoreWeave smoke on this PR passed: https://github.com/marin-community/marin/actions/runs/25449896510
- CoreWeave GPU canary dispatched from this branch passed: https://github.com/marin-community/marin/actions/runs/25450733652

## Live Canary Notes

The first manual canary dispatch was cancelled before any jobs started because the shared `iris-coreweave-ci-shared` lane was occupied. After the lane cleared, the rerun succeeded.

Kubernetes state for the successful run showed both pods exiting 0:

- parent: `/runner/iris-run-job-20260506-173127` -> `JOB_STATE_SUCCEEDED`
- child: `/runner/iris-run-job-20260506-173127/grug-train-canary-gpu-25450733652-1` -> `JOB_STATE_SUCCEEDED`

## Notes

The branch was published in two stages because the local GitHub OAuth token lacks `workflow` scope. Workflow-file commits were written through the GitHub app, then the helper/test commit was pushed normally.