### PR TITLE
Fix CoreWeave multinode JAX rendezvous

### DIFF
--- a/lib/iris/src/iris/cluster/providers/k8s/constants.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/constants.py
@@ -10,3 +10,9 @@ NVIDIA_GPU_TOLERATION: dict = {
     "operator": "Exists",
     "effect": "NoSchedule",
 }
+
+NODE_ATTRIBUTE_LABEL_PREFIX = "iris"
+
+
+def node_attribute_label(attribute_key: str) -> str:
+    return f"{NODE_ATTRIBUTE_LABEL_PREFIX}.{attribute_key}"

--- a/lib/iris/src/iris/cluster/providers/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/controller.py
@@ -23,7 +23,8 @@ from urllib.parse import urlparse
 from rigging.timing import Deadline
 
 from iris.cluster.config import config_to_dict
-from iris.cluster.providers.k8s.constants import NVIDIA_GPU_TOLERATION
+from iris.cluster.constraints import WellKnownAttribute, accelerator_type_to_string
+from iris.cluster.providers.k8s.constants import NVIDIA_GPU_TOLERATION, node_attribute_label
 from iris.cluster.providers.k8s.service import K8sService
 from iris.cluster.providers.k8s.types import K8sResource
 from iris.cluster.providers.types import InfraError, Labels
@@ -566,6 +567,7 @@ class K8sControllerProvider:
                     pool_name,
                     cw.instance_type,
                     name,
+                    sg,
                     min_nodes=min_nodes,
                     max_nodes=max_nodes,
                     warm_nodes=num_vms,
@@ -597,6 +599,7 @@ class K8sControllerProvider:
         pool_name: str,
         instance_type: str,
         scale_group_name: str,
+        scale_group: config_pb2.ScaleGroupConfig,
         *,
         min_nodes: int,
         max_nodes: int,
@@ -614,6 +617,27 @@ class K8sControllerProvider:
         if existing is not None:
             target_nodes = max(min_nodes, min(max_nodes, warm_nodes))
 
+        node_labels = {
+            self._iris_labels.iris_managed: "true",
+            self._iris_labels.iris_scale_group: scale_group_name,
+            node_attribute_label("pool"): scale_group_name.lower(),
+        }
+        cw = scale_group.slice_template.coreweave
+        if cw.region:
+            node_labels[node_attribute_label(WellKnownAttribute.REGION)] = cw.region.lower()
+        if scale_group.HasField("resources"):
+            node_labels[node_attribute_label(WellKnownAttribute.DEVICE_TYPE)] = accelerator_type_to_string(
+                scale_group.resources.device_type
+            )
+            if scale_group.resources.device_variant:
+                node_labels[node_attribute_label(WellKnownAttribute.DEVICE_VARIANT)] = (
+                    scale_group.resources.device_variant.lower()
+                )
+        if min_nodes > 0:
+            # Pin Konnectivity agents and monitoring pods to always-on nodes so
+            # GPU NodePools can safely scale to zero.
+            node_labels["cks.coreweave.cloud/system-critical"] = "true"
+
         manifest = {
             "apiVersion": "compute.coreweave.com/v1alpha1",
             "kind": "NodePool",
@@ -628,13 +652,7 @@ class K8sControllerProvider:
                 "minNodes": min_nodes,
                 "maxNodes": max_nodes,
                 "targetNodes": target_nodes,
-                "nodeLabels": {
-                    self._iris_labels.iris_managed: "true",
-                    self._iris_labels.iris_scale_group: scale_group_name,
-                    # Pin Konnectivity agents and monitoring pods to always-on nodes
-                    # so GPU NodePools can safely scale to zero.
-                    **({"cks.coreweave.cloud/system-critical": "true"} if min_nodes > 0 else {}),
-                },
+                "nodeLabels": node_labels,
             },
         }
         self._kubectl.apply_json(manifest)

--- a/lib/iris/src/iris/cluster/providers/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/tasks.py
@@ -29,6 +29,7 @@ from finelog.types import LogWriterProtocol, str_to_log_level
 from rigging.log_setup import parse_log_level
 from rigging.timing import Timestamp
 
+from iris.cluster.constraints import WellKnownAttribute
 from iris.cluster.controller.transitions import (
     ClusterCapacity,
     DirectProviderBatch,
@@ -38,7 +39,7 @@ from iris.cluster.controller.transitions import (
     TaskUpdate,
 )
 from iris.cluster.log_store_helpers import task_log_key
-from iris.cluster.providers.k8s.constants import NVIDIA_GPU_TOLERATION
+from iris.cluster.providers.k8s.constants import NVIDIA_GPU_TOLERATION, node_attribute_label
 from iris.cluster.providers.k8s.service import K8sService
 from iris.cluster.providers.k8s.types import K8sResource, KubectlError, KubectlLogLine, parse_k8s_quantity
 from iris.cluster.runtime.env import build_common_iris_env, normalize_workdir_relative_path
@@ -64,12 +65,12 @@ _RUNTIME_LABEL_VALUE = "iris-kubernetes"
 # Max pod name length is 253 chars in k8s. We stay well under it.
 _MAX_POD_NAME_LEN = 63
 
-# CoreWeave nodes are labeled with {label_prefix}.{attribute_key} by the NodePool.
-# Map well-known Iris constraint keys to their k8s node label keys.
-# The "iris." prefix matches platform.label_prefix in coreweave.yaml.
+# Map Iris constraint keys to their k8s node label keys.
 _CONSTRAINT_KEY_TO_NODE_LABEL: dict[str, str] = {
-    "pool": "iris.pool",
-    "region": "iris.region",
+    "pool": node_attribute_label("pool"),
+    WellKnownAttribute.REGION: node_attribute_label(WellKnownAttribute.REGION),
+    WellKnownAttribute.DEVICE_TYPE: node_attribute_label(WellKnownAttribute.DEVICE_TYPE),
+    WellKnownAttribute.DEVICE_VARIANT: node_attribute_label(WellKnownAttribute.DEVICE_VARIANT),
 }
 
 # Kubernetes label values: max 63 chars, alphanumeric plus [-_.], must start/end alphanumeric.

--- a/lib/iris/src/iris/runtime/jax_init.py
+++ b/lib/iris/src/iris/runtime/jax_init.py
@@ -3,8 +3,8 @@
 
 """JAX distributed initialization via Iris endpoint registry.
 
-Task 0 registers its coordinator address; tasks 1..N-1 poll for it.
-Single-task jobs skip distributed init entirely — JAX defaults suffice.
+For multi-task jobs, each task first registers readiness in Iris, then task 0
+registers its coordinator address and tasks 1..N-1 poll for it.
 
 JAX is imported at call time — iris does not depend on jax.
 """
@@ -97,10 +97,59 @@ def _poll_for_coordinator(
     return result[0]
 
 
+def _ready_endpoint_name(endpoint_name: str, task_index: int) -> str:
+    return f"{endpoint_name}_ready_{task_index}"
+
+
+def _poll_for_all_ready(
+    resolver: Resolver,
+    endpoint_name: str,
+    num_tasks: int,
+    timeout: float,
+    poll_interval: float,
+) -> None:
+    """Poll the endpoint registry until every task has reached user code."""
+
+    missing: set[int] = set(range(num_tasks))
+
+    def _check() -> bool:
+        missing.clear()
+        for task_index in range(num_tasks):
+            resolved = resolver.resolve(_ready_endpoint_name(endpoint_name, task_index))
+            if resolved.is_empty:
+                missing.add(task_index)
+        return not missing
+
+    backoff = ExponentialBackoff(initial=poll_interval, maximum=max(poll_interval, 30.0))
+    backoff.wait_until_or_raise(
+        _check,
+        timeout=Duration.from_seconds(timeout),
+        error_message=(
+            f"Timed out after {timeout}s waiting for all {num_tasks} JAX tasks to reach "
+            f"the pre-initialize barrier; missing task indexes: {sorted(missing)}"
+        ),
+    )
+
+
+def _initialize_jax_distributed(
+    jax_module,
+    coordinator: str,
+    num_processes: int,
+    process_id: int,
+    initialization_timeout: int,
+) -> None:
+    jax_module.distributed.initialize(
+        coordinator,
+        num_processes,
+        process_id,
+        initialization_timeout=initialization_timeout,
+    )
+
+
 def initialize_jax(
     port: int = 8476,
     endpoint_name: str = "jax_coordinator",
-    poll_timeout: float = 300.0,
+    poll_timeout: float = 1800.0,
     poll_interval: float = 2.0,
 ) -> None:
     """Initialize JAX distributed runtime using Iris endpoint discovery.
@@ -109,9 +158,9 @@ def initialize_jax(
     Iris endpoint registry, and tasks 1..N-1 poll until they discover it. All
     tasks then call jax.distributed.initialize with the coordinator address.
 
-    For single-task jobs (or when not running inside an Iris job),
-    initialization is skipped — JAX works correctly without distributed
-    init when there is only one process.
+    For single-task Iris jobs, JAX distributed initialization is called with one
+    process so explicit JAX coordinator environment remains consistent. When
+    not running inside an Iris job, initialization is skipped.
 
     On TPU, JAX handles distributed init natively via the TPU runtime —
     calling jax.distributed.initialize would conflict, so this is a no-op.
@@ -121,7 +170,8 @@ def initialize_jax(
             An explicit port is required because JAX's gRPC coordinator binds
             internally and does not expose the actual bound port.
         endpoint_name: Name under which the coordinator registers.
-        poll_timeout: Maximum seconds for non-coordinator tasks to wait.
+        poll_timeout: Maximum seconds to wait for readiness and coordinator
+            discovery. Also passed to JAX as initialization_timeout.
         poll_interval: Initial backoff delay for polling (seconds).
     """
     import jax
@@ -137,14 +187,29 @@ def initialize_jax(
     if job_info is None:
         return
 
+    initialization_timeout = max(1, int(poll_timeout))
+
     if job_info.num_tasks <= 1:
         bound_port = job_info.ports.get("jax", port)
         coordinator = f"{job_info.advertise_host}:{bound_port}"
-        jax.distributed.initialize(coordinator, num_processes=1, process_id=0)
+        _initialize_jax_distributed(jax, coordinator, 1, 0, initialization_timeout)
         return
 
     ctx = iris_ctx()
     task_index = job_info.task_index
+    ready_endpoint_id = ctx.registry.register(
+        _ready_endpoint_name(endpoint_name, task_index),
+        f"{job_info.advertise_host}:0",
+        {"task_index": str(task_index), "num_tasks": str(job_info.num_tasks)},
+    )
+    atexit.register(ctx.registry.unregister, ready_endpoint_id)
+    logger.info(
+        "initialize_jax task %s/%s reached pre-initialize barrier",
+        task_index,
+        job_info.num_tasks,
+    )
+    _poll_for_all_ready(ctx.resolver, endpoint_name, job_info.num_tasks, poll_timeout, poll_interval)
+    logger.info("initialize_jax all %s tasks reached pre-initialize barrier", job_info.num_tasks)
 
     if task_index == 0:
         bound_port = job_info.ports.get("jax", port)
@@ -158,7 +223,7 @@ def initialize_jax(
         # Best-effort cleanup: if the process crashes, the controller's
         # cascade delete on task cleanup handles endpoint removal.
         atexit.register(ctx.registry.unregister, endpoint_id)
-        jax.distributed.initialize(coordinator, job_info.num_tasks, task_index)
+        _initialize_jax_distributed(jax, coordinator, job_info.num_tasks, task_index, initialization_timeout)
     else:
         coordinator = _poll_for_coordinator(ctx.resolver, endpoint_name, poll_timeout, poll_interval)
-        jax.distributed.initialize(coordinator, job_info.num_tasks, task_index)
+        _initialize_jax_distributed(jax, coordinator, job_info.num_tasks, task_index, initialization_timeout)

--- a/lib/iris/tests/cluster/providers/k8s/test_coreweave.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_coreweave.py
@@ -639,6 +639,46 @@ def test_ensure_nodepools_scales_multihost_groups_by_num_vms():
     provider.shutdown()
 
 
+def test_ensure_nodepools_labels_nodes_for_iris_constraints():
+    """NodePool node labels match the nodeSelectors generated from Iris constraints."""
+    provider, k8s = _make_provider()
+    cluster_config = _make_cluster_config()
+    sg = cluster_config.scale_groups["h100-8x"]
+    sg.resources.cpu_millicores = 128_000
+    sg.resources.memory_bytes = 2048 * 1024**3
+    sg.resources.disk_bytes = 1024**4
+    sg.resources.device_type = config_pb2.ACCELERATOR_TYPE_GPU
+    sg.resources.device_variant = "H100"
+    sg.resources.device_count = 8
+    sg.resources.capacity_type = config_pb2.CAPACITY_TYPE_ON_DEMAND
+    sg.buffer_slices = 0
+    sg.max_slices = 2
+    sg.slice_template.CopyFrom(
+        config_pb2.SliceConfig(
+            name_prefix="h100-8x",
+            num_vms=1,
+            coreweave=config_pb2.CoreweaveSliceConfig(
+                region="US-WEST-04A",
+                instance_type="gd-8xh100ib-i128",
+            ),
+        )
+    )
+
+    provider.ensure_nodepools(cluster_config)
+
+    h100_pool = k8s.get_json(K8sResource.NODE_POOLS, "iris-h100-8x")
+    assert h100_pool is not None
+    assert h100_pool["spec"]["nodeLabels"] == {
+        "iris-iris-managed": "true",
+        "iris-iris-scale-group": "h100-8x",
+        "iris.pool": "h100-8x",
+        "iris.region": "us-west-04a",
+        "iris.device-type": "gpu",
+        "iris.device-variant": "h100",
+    }
+    provider.shutdown()
+
+
 def test_ensure_nodepools_keeps_one_multihost_slice_warm():
     """Existing multihost pools keep one full slice worth of desired nodes."""
     provider, k8s = _make_provider()

--- a/lib/iris/tests/test_jax_init.py
+++ b/lib/iris/tests/test_jax_init.py
@@ -33,12 +33,16 @@ class FakeRegistry:
 @dataclass
 class FakeResolver:
     results: list[ResolveResult] = field(default_factory=list)
+    results_by_name: dict[str, list[ResolveResult]] = field(default_factory=dict)
     call_count: int = 0
+    call_count_by_name: dict[str, int] = field(default_factory=dict)
 
     def resolve(self, name: str) -> ResolveResult:
-        idx = min(self.call_count, len(self.results) - 1)
-        result = self.results[idx]
+        sequence = self.results_by_name.get(name, self.results)
+        idx = min(self.call_count_by_name.get(name, 0), len(sequence) - 1)
+        result = sequence[idx]
         self.call_count += 1
+        self.call_count_by_name[name] = self.call_count_by_name.get(name, 0) + 1
         return result
 
 
@@ -61,6 +65,17 @@ def _make_job_info(task_index: int = 0, num_tasks: int = 1) -> JobInfo:
     )
 
 
+def _found_endpoint(name: str, url: str = "10.0.0.1:8476") -> ResolveResult:
+    return ResolveResult(
+        name=name,
+        endpoints=[ResolvedEndpoint(url=url, actor_id=f"{name}-ep")],
+    )
+
+
+def _ready_results(endpoint_name: str, num_tasks: int) -> dict[str, list[ResolveResult]]:
+    return {f"{endpoint_name}_ready_{i}": [_found_endpoint(f"{endpoint_name}_ready_{i}")] for i in range(num_tasks)}
+
+
 @patch("iris.runtime.jax_init.atexit")
 @patch("jax.distributed.initialize")
 @patch("iris.runtime.jax_init.iris_ctx")
@@ -76,7 +91,12 @@ def test_initialize_jax_single_task(
 
     initialize_jax()
 
-    mock_jax_init.assert_called_once_with("10.0.0.1:8476", num_processes=1, process_id=0)
+    mock_jax_init.assert_called_once_with(
+        "10.0.0.1:8476",
+        1,
+        0,
+        initialization_timeout=1800,
+    )
     mock_iris_ctx.assert_not_called()
 
 
@@ -128,14 +148,18 @@ def test_initialize_jax_task0_registers(
 ) -> None:
     """Task 0 registers the coordinator endpoint and calls jax.distributed.initialize."""
     mock_get_job_info.return_value = _make_job_info(task_index=0, num_tasks=4)
-    fake_ctx = FakeContext()
+    fake_ctx = FakeContext(resolver=FakeResolver(results_by_name=_ready_results("jax_coordinator", 4)))
     mock_iris_ctx.return_value = fake_ctx
 
     initialize_jax(port=9999)
 
-    assert fake_ctx.registry.registered == [("jax_coordinator", "10.0.0.1:9999")]
-    mock_jax_init.assert_called_once_with("10.0.0.1:9999", 4, 0)
-    mock_atexit.register.assert_called_once_with(fake_ctx.registry.unregister, "endpoint-1")
+    assert fake_ctx.registry.registered == [
+        ("jax_coordinator_ready_0", "10.0.0.1:0"),
+        ("jax_coordinator", "10.0.0.1:9999"),
+    ]
+    mock_jax_init.assert_called_once_with("10.0.0.1:9999", 4, 0, initialization_timeout=1800)
+    assert mock_atexit.register.call_count == 2
+    mock_atexit.register.assert_any_call(fake_ctx.registry.unregister, "endpoint-1")
 
 
 @patch("iris.runtime.jax_init.atexit")
@@ -152,13 +176,16 @@ def test_initialize_jax_task0_uses_iris_port(
     info = _make_job_info(task_index=0, num_tasks=2)
     info.ports = {"jax": 12345}
     mock_get_job_info.return_value = info
-    fake_ctx = FakeContext()
+    fake_ctx = FakeContext(resolver=FakeResolver(results_by_name=_ready_results("jax_coordinator", 2)))
     mock_iris_ctx.return_value = fake_ctx
 
     initialize_jax(port=9999)
 
-    assert fake_ctx.registry.registered == [("jax_coordinator", "10.0.0.1:12345")]
-    mock_jax_init.assert_called_once_with("10.0.0.1:12345", 2, 0)
+    assert fake_ctx.registry.registered == [
+        ("jax_coordinator_ready_0", "10.0.0.1:0"),
+        ("jax_coordinator", "10.0.0.1:12345"),
+    ]
+    mock_jax_init.assert_called_once_with("10.0.0.1:12345", 2, 0, initialization_timeout=1800)
 
 
 @patch("jax.distributed.initialize")
@@ -173,17 +200,47 @@ def test_initialize_jax_taskN_polls(
     mock_get_job_info.return_value = _make_job_info(task_index=2, num_tasks=4)
 
     empty = ResolveResult(name="jax_coordinator", endpoints=[])
-    found = ResolveResult(
-        name="jax_coordinator",
-        endpoints=[ResolvedEndpoint(url="10.0.0.1:8476", actor_id="ep-1")],
-    )
-    fake_ctx = FakeContext(resolver=FakeResolver(results=[empty, empty, found]))
+    found = _found_endpoint("jax_coordinator")
+    results_by_name = {
+        **_ready_results("jax_coordinator", 4),
+        "jax_coordinator": [empty, empty, found],
+    }
+    fake_ctx = FakeContext(resolver=FakeResolver(results_by_name=results_by_name))
     mock_iris_ctx.return_value = fake_ctx
 
     initialize_jax(poll_timeout=10.0, poll_interval=0.01)
 
     assert fake_ctx.resolver.call_count >= 3
-    mock_jax_init.assert_called_once_with("10.0.0.1:8476", 4, 2)
+    assert fake_ctx.registry.registered == [("jax_coordinator_ready_2", "10.0.0.1:0")]
+    mock_jax_init.assert_called_once_with("10.0.0.1:8476", 4, 2, initialization_timeout=10)
+
+
+@patch("iris.runtime.jax_init.atexit")
+@patch("jax.distributed.initialize")
+@patch("iris.runtime.jax_init.iris_ctx")
+@patch("iris.runtime.jax_init.get_job_info")
+def test_initialize_jax_task0_waits_for_peer_ready_before_coordinator(
+    mock_get_job_info: MagicMock,
+    mock_iris_ctx: MagicMock,
+    mock_jax_init: MagicMock,
+    mock_atexit: MagicMock,
+) -> None:
+    """Task 0 waits for every peer before registering the JAX coordinator."""
+    mock_get_job_info.return_value = _make_job_info(task_index=0, num_tasks=2)
+    missing = ResolveResult(name="jax_coordinator_ready_1", endpoints=[])
+    ready = _found_endpoint("jax_coordinator_ready_1")
+    results_by_name = {
+        "jax_coordinator_ready_0": [_found_endpoint("jax_coordinator_ready_0")],
+        "jax_coordinator_ready_1": [missing, ready],
+    }
+    fake_ctx = FakeContext(resolver=FakeResolver(results_by_name=results_by_name))
+    mock_iris_ctx.return_value = fake_ctx
+
+    initialize_jax(poll_timeout=10.0, poll_interval=0.01)
+
+    assert fake_ctx.resolver.call_count_by_name["jax_coordinator_ready_1"] >= 2
+    assert fake_ctx.registry.registered[-1] == ("jax_coordinator", "10.0.0.1:8476")
+    mock_jax_init.assert_called_once_with("10.0.0.1:8476", 2, 0, initialization_timeout=10)
 
 
 @patch("jax.distributed.initialize")
@@ -197,11 +254,15 @@ def test_initialize_jax_poll_timeout(
     """TimeoutError is raised when coordinator endpoint is not found within timeout."""
     mock_get_job_info.return_value = _make_job_info(task_index=1, num_tasks=2)
 
-    empty = ResolveResult(name="jax_coordinator", endpoints=[])
-    fake_ctx = FakeContext(resolver=FakeResolver(results=[empty]))
+    empty_ready = ResolveResult(name="jax_coordinator_ready_0", endpoints=[])
+    results_by_name = {
+        "jax_coordinator_ready_0": [empty_ready],
+        "jax_coordinator_ready_1": [_found_endpoint("jax_coordinator_ready_1")],
+    }
+    fake_ctx = FakeContext(resolver=FakeResolver(results_by_name=results_by_name))
     mock_iris_ctx.return_value = fake_ctx
 
-    with pytest.raises(TimeoutError, match="Timed out"):
+    with pytest.raises(TimeoutError, match="pre-initialize barrier"):
         initialize_jax(poll_timeout=0.1, poll_interval=0.01)
 
     mock_jax_init.assert_not_called()

--- a/tests/integration/iris/test_iris_kind.py
+++ b/tests/integration/iris/test_iris_kind.py
@@ -161,7 +161,10 @@ def _make_coreweave_harness(tmp_path: Path) -> ServiceTestHarness:
     k8s.add_node_pool(
         "cpu-erapids",
         node_count=1,
-        labels={"iris.pool": "cpu-erapids"},
+        labels={
+            "iris.pool": "cpu-erapids",
+            "iris.device-type": "cpu",
+        },
         resources=FakeNodeResources(
             cpu_millicores=64_000,
             memory_bytes=256 * 1024**3,
@@ -171,7 +174,11 @@ def _make_coreweave_harness(tmp_path: Path) -> ServiceTestHarness:
     k8s.add_node_pool(
         "h100-8x",
         node_count=1,
-        labels={"iris.pool": "h100-8x"},
+        labels={
+            "iris.pool": "h100-8x",
+            "iris.device-type": "gpu",
+            "iris.device-variant": "h100",
+        },
         taints=[
             {"key": "nvidia.com/gpu", "effect": "NoSchedule", "operator": "Exists"},
         ],
@@ -374,10 +381,13 @@ def test_gpu_pod_attributes_with_in_memory_k8s(tmp_path: Path) -> None:
         assert len(cpu_pods) == 1
 
         gpu_limits = gpu_pods[0]["spec"]["containers"][0]["resources"]["limits"]
+        gpu_node_selector = gpu_pods[0]["spec"].get("nodeSelector", {})
         gpu_toleration_keys = {t.get("key") for t in gpu_pods[0]["spec"].get("tolerations", [])}
 
         assert gpu_limits["nvidia.com/gpu"] == "8"
         assert gpu_limits["rdma/ib"] == "8"
+        assert gpu_node_selector["iris.device-type"] == "gpu"
+        assert gpu_node_selector["iris.device-variant"] == "h100"
         assert "nvidia.com/gpu" in gpu_toleration_keys
         assert "qos.coreweave.cloud/interruptable" not in gpu_toleration_keys
         assert "h100-8x" in gpu_pods[0]["spec"].get("nodeName", "")


### PR DESCRIPTION
## Summary

Fixes #5480.

This fixes the deterministic CoreWeave H100x8 x 2 direct JAX collective failure where task 0 reached `initialize_jax()` and entered XLA coordination while task 1 was still pending or syncing dependencies.

## Root Cause

The failure was a combination of code-owned scheduling and rendezvous gaps:

- CoreWeave direct pods did not select nodes using Iris accelerator constraints. The controller already attached `device-type` and `device-variant` constraints to GPU jobs, but the Kubernetes provider only mapped `pool` and `region` into `nodeSelector`, and CoreWeave NodePools did not label nodes with generic Iris device labels.
- `initialize_jax()` let task 0 register the JAX coordinator and call `jax.distributed.initialize()` immediately. On a cold second H100 node, task 0 spent the default 300s JAX initialization deadline before task 1 reached user code.
- The repeated hostname/GPU UUID signal from the original repro was sequential reuse of the only warm H100 node after task 0 failed, not simultaneous overplacement.

During validation, the newly provisioned second H100 node also briefly carried `qos.coreweave.cloud/interruptable=true:NoExecute`, which kept the second pod pending until CoreWeave cleared it. This PR intentionally does not add that toleration because it would opt distributed training into interruptible eviction semantics.

## Fix

- Label CoreWeave NodePools with generic Iris node attributes: `iris.pool`, `iris.region`, `iris.device-type`, and `iris.device-variant`.
- Map Iris `device-type` and `device-variant` constraints to Kubernetes `nodeSelector` keys for direct task pods.
- Add per-task ready endpoints in `initialize_jax()` and wait for all tasks to reach a pre-initialize barrier before task 0 registers the JAX coordinator.
- Pass JAX `initialization_timeout` explicitly, with the Iris default raised from 300s to 1800s.
- Add focused unit/integration coverage for the NodePool labels, GPU pod selectors, and JAX readiness barrier behavior.

## Validation

Local checks:

- `uv run --package marin-iris --extra controller python -m pytest lib/iris/tests/test_jax_init.py lib/iris/tests/cluster/providers/k8s/test_coreweave.py -q` -> 35 passed.
- `uv run --package marin-iris --extra controller python -m pytest tests/integration/iris/test_iris_kind.py::test_gpu_pod_attributes_with_in_memory_k8s -q` -> 1 passed.
- `git diff --check` -> clean.

Cluster validation:

- Direct H100x8 x 2 gate passed: `/romain/cw-direct-h100x8-2host-collective-cw5480-20260506-1059`.
- Log: `/tmp/marin-cw-grug-moe-accelerator-perf/direct-h100x8-2host-collective-cw5480-20260506-1059.log`.
- Both tasks ran on separate H100 nodes, printed `process_count=2`, `local_devices=8`, `global_devices=16`, `COLLECTIVE_RESULT [16.0, ...]`, and `DIRECT_2HOST_H100X8_COLLECTIVE_OK`.

Cleanup after validation:

- Restored the shared CoreWeave controller deployment to `ghcr.io/marin-community/iris-controller:c5d2993`.
- Returned `iris-ci-h100-8x` NodePool target/current to `1/1`.

## Remaining Risk

A tiny Grug H100x8 x 2 smoke was attempted as `/romain/cw-grug-mn-smoke-h100x8x2-cw5480-20260506-1101`, but the CPU parent failed before launching any GPU child job with `botocore.exceptions.NoCredentialsError` while writing executor metadata to `s3://marin-na/...`. Rerun that smoke with R2 credentials and `MARIN_PREFIX` available per the CoreWeave ops guide. This is separate from the rendezvous failure validated by the direct gate.