### PR TITLE
[github] Skip Claude review workflow for draft PRs

### DIFF
--- a/.github/workflows/ops-claude-review.yaml
+++ b/.github/workflows/ops-claude-review.yaml
@@ -17,6 +17,7 @@ jobs:
     if: >-
       (
         github.event_name == 'pull_request' &&
+        github.event.pull_request.draft == false &&
         (
           github.event.pull_request.author_association == 'OWNER' ||
           github.event.pull_request.author_association == 'MEMBER' ||


### PR DESCRIPTION
Add github.event.pull_request.draft == false to the pull_request branch of the ops-claude-review workflow if: condition. This prevents Claude from running and leaving a skip comment on every draft PR. The ready_for_review trigger already fires when a draft is marked ready, so reviews still run at the right time.

Fixes #5483