### PR TITLE
Upgrade dorny/paths-filter from v3 to v4

### DIFF
--- a/.github/workflows/dupekit-release-wheels.yaml
+++ b/.github/workflows/dupekit-release-wheels.yaml
@@ -26,7 +26,7 @@ jobs:
       should_run: ${{ steps.filter.outputs.relevant }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/dupekit-unit.yaml
+++ b/.github/workflows/dupekit-unit.yaml
@@ -19,7 +19,7 @@ jobs:
       should_run: ${{ steps.filter.outputs.relevant }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/fray-unit.yaml
+++ b/.github/workflows/fray-unit.yaml
@@ -19,7 +19,7 @@ jobs:
       should_run: ${{ steps.filter.outputs.relevant }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/haliax-unit.yaml
+++ b/.github/workflows/haliax-unit.yaml
@@ -20,7 +20,7 @@ jobs:
       should_run: ${{ steps.filter.outputs.relevant }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/iris-unit.yaml
+++ b/.github/workflows/iris-unit.yaml
@@ -22,7 +22,7 @@ jobs:
       should_run: ${{ steps.filter.outputs.relevant }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/levanter-unit.yaml
+++ b/.github/workflows/levanter-unit.yaml
@@ -20,7 +20,7 @@ jobs:
       should_run: ${{ steps.filter.outputs.relevant }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/marin-docs.yaml
+++ b/.github/workflows/marin-docs.yaml
@@ -20,7 +20,7 @@ jobs:
       should_run: ${{ steps.filter.outputs.relevant }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/marin-unit.yaml
+++ b/.github/workflows/marin-unit.yaml
@@ -20,7 +20,7 @@ jobs:
       should_run: ${{ steps.filter.outputs.relevant }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/ops-grug-variant-diff.yaml
+++ b/.github/workflows/ops-grug-variant-diff.yaml
@@ -21,7 +21,7 @@ jobs:
       should_run: ${{ steps.filter.outputs.relevant }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/zephyr-unit.yaml
+++ b/.github/workflows/zephyr-unit.yaml
@@ -19,7 +19,7 @@ jobs:
       should_run: ${{ steps.filter.outputs.relevant }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4
         id: filter
         with:
           filters: |


### PR DESCRIPTION
Bumps pinned SHA to v4 (fbd0ab8f) in all 10 workflow files. This resolves Node.js 20 deprecation warnings; GitHub Actions will force Node 24 by default on 2026-06-02.

Fixes #5195