### PR TITLE
[iris] Wire AR PyPI mirror env vars into worker task setup

### DIFF
--- a/lib/iris/Dockerfile
+++ b/lib/iris/Dockerfile
@@ -158,6 +158,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=ghcr.io/astral-sh/uv:0.10.3 /uv /uvx /bin/
 
+# Keyring backend for AR PyPI mirror auth (UV_KEYRING_PROVIDER=subprocess).
+# Lets uv mint short-lived OAuth tokens off the GCE metadata server when
+# resolving from {us,europe}-python.pkg.dev.
+RUN uv pip install --system keyrings.google-artifactregistry-auth
+
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --default-toolchain stable --profile minimal
 ENV PATH="/root/.cargo/bin:$PATH"

--- a/lib/iris/src/iris/cluster/providers/gcp/pypi_mirror.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/pypi_mirror.py
@@ -1,0 +1,87 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""PyPI mirror env-var construction for Iris workers.
+
+Builds the ``UV_*`` env vars that point an Iris task at the Google Artifact
+Registry remote-Python repos that proxy ``pypi.org`` and the PyTorch CPU
+index. The worker callsite (``task_attempt._prepare_container_config``) is
+responsible for region resolution and opt-out handling; this module is a
+pure function over a multi-region string.
+"""
+
+from dataclasses import dataclass
+
+from iris.cluster.providers.gcp.bootstrap import _ZONE_PREFIX_TO_MULTI_REGION
+
+AR_PROJECT: str = "hai-gcp-models"
+PYPI_MIRROR_REPO: str = "pypi-mirror"
+PYTORCH_CPU_MIRROR_REPO: str = "pytorch-cpu-mirror"
+
+# Env-var contract for the per-job opt-out. Hoisted to constants so the
+# magic strings live in exactly one place (AGENTS.md § Naming).
+IRIS_PYPI_MIRROR_ENV_VAR: str = "IRIS_PYPI_MIRROR"
+IRIS_PYPI_MIRROR_OPT_OUT: str = "0"
+
+# Single source of truth for which multi-regions have AR repos provisioned.
+# Derived from ``bootstrap._ZONE_PREFIX_TO_MULTI_REGION`` so adding a third
+# continent only requires one edit.
+SUPPORTED_MULTI_REGIONS: frozenset[str] = frozenset(_ZONE_PREFIX_TO_MULTI_REGION.values())
+
+
+@dataclass(frozen=True)
+class PypiMirrorEnv:
+    """Typed env-var bundle for AR-mirror uv configuration.
+
+    Use ``as_env()`` to materialize as a ``dict[str, str]`` at the worker
+    callsite. Field-level access keeps tests readable.
+    """
+
+    default_index: str
+    pytorch_cpu_index: str
+    keyring_provider: str = "subprocess"
+
+    def as_env(self) -> dict[str, str]:
+        """Return env vars as a flat ``dict[str, str]`` for ``env.update``."""
+        return {
+            "UV_DEFAULT_INDEX": self.default_index,
+            "UV_INDEX_PYTORCH_CPU": self.pytorch_cpu_index,
+            "UV_KEYRING_PROVIDER": self.keyring_provider,
+        }
+
+
+def build_pypi_mirror_env(multi_region: str, project: str = AR_PROJECT) -> PypiMirrorEnv:
+    """Build uv env vars that point dependency resolution at AR remote PyPI repos.
+
+    Caller responsibilities (not enforced here, kept out so the helper is
+    trivially testable):
+
+    1. Verify ``IRIS_WORKER_REGION`` is set and resolves via
+       ``zone_to_multi_region`` to a non-None continent.
+    2. Verify the user has not set ``IRIS_PYPI_MIRROR=0`` in
+       ``EnvironmentConfig.env_vars``.
+
+    Args:
+        multi_region: AR multi-region location. Must be in
+            ``SUPPORTED_MULTI_REGIONS``; other values raise. Pass the result
+            of ``zone_to_multi_region``.
+        project: GCP project hosting the AR repos. Defaults to ``AR_PROJECT``.
+
+    Returns:
+        ``PypiMirrorEnv`` with three populated fields. URL form:
+        ``https://{multi_region}-python.pkg.dev/{project}/<repo>/simple/``.
+
+    Raises:
+        ValueError: if ``multi_region`` is not in ``SUPPORTED_MULTI_REGIONS``.
+    """
+    if multi_region not in SUPPORTED_MULTI_REGIONS:
+        raise ValueError(
+            f"multi_region {multi_region!r} is not in SUPPORTED_MULTI_REGIONS "
+            f"({sorted(SUPPORTED_MULTI_REGIONS)}). Pass the result of "
+            f"zone_to_multi_region()."
+        )
+    base = f"https://{multi_region}-python.pkg.dev/{project}"
+    return PypiMirrorEnv(
+        default_index=f"{base}/{PYPI_MIRROR_REPO}/simple/",
+        pytorch_cpu_index=f"{base}/{PYTORCH_CPU_MIRROR_REPO}/simple/",
+    )

--- a/lib/iris/src/iris/cluster/worker/task_attempt.py
+++ b/lib/iris/src/iris/cluster/worker/task_attempt.py
@@ -26,6 +26,12 @@ from rigging.timing import Duration, Timestamp
 from iris.chaos import chaos, chaos_raise
 from iris.cluster.bundle import BundleStore
 from iris.cluster.log_store_helpers import task_log_key
+from iris.cluster.providers.gcp.bootstrap import zone_to_multi_region
+from iris.cluster.providers.gcp.pypi_mirror import (
+    IRIS_PYPI_MIRROR_ENV_VAR,
+    IRIS_PYPI_MIRROR_OPT_OUT,
+    build_pypi_mirror_env,
+)
 from iris.cluster.runtime.types import (
     ContainerConfig,
     ContainerErrorKind,
@@ -705,6 +711,28 @@ class TaskAttempt:
         region_attr = self._worker_metadata.attributes.get(WellKnownAttribute.REGION)
         if region_attr and region_attr.string_value:
             env["IRIS_WORKER_REGION"] = region_attr.string_value
+
+        # PyPI mirror injection. Reads opt-out from the user-supplied
+        # EnvironmentConfig.env_vars directly, so user `IRIS_PYPI_MIRROR=0`
+        # in env_vars suppresses injection (the value also flows through to
+        # the task via the env.update below).
+        mirror_disabled = self.request.environment.env_vars.get(IRIS_PYPI_MIRROR_ENV_VAR) == IRIS_PYPI_MIRROR_OPT_OUT
+        if region_attr and region_attr.string_value and not mirror_disabled:
+            try:
+                multi_region = zone_to_multi_region(region_attr.string_value)
+            except ValueError:
+                logger.info(
+                    "pypi mirror skipped: zone %s is unsupported (asia/me/etc.)",
+                    region_attr.string_value,
+                )
+                multi_region = None
+            if multi_region is None:
+                logger.info(
+                    "pypi mirror skipped: region %s has no AR continent mapping",
+                    region_attr.string_value,
+                )
+            else:
+                env.update(build_pypi_mirror_env(multi_region).as_env())
 
         env.update(self._task_env)
         env.update(dict(self.request.environment.env_vars))

--- a/lib/iris/tests/test_pypi_mirror.py
+++ b/lib/iris/tests/test_pypi_mirror.py
@@ -1,0 +1,57 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``iris.cluster.providers.gcp.pypi_mirror``."""
+
+import pytest
+from iris.cluster.providers.gcp.pypi_mirror import (
+    AR_PROJECT,
+    PYPI_MIRROR_REPO,
+    PYTORCH_CPU_MIRROR_REPO,
+    PypiMirrorEnv,
+    build_pypi_mirror_env,
+)
+
+
+def test_build_pypi_mirror_env_us():
+    env = build_pypi_mirror_env("us")
+    assert env.default_index == f"https://us-python.pkg.dev/{AR_PROJECT}/{PYPI_MIRROR_REPO}/simple/"
+    assert env.pytorch_cpu_index == f"https://us-python.pkg.dev/{AR_PROJECT}/{PYTORCH_CPU_MIRROR_REPO}/simple/"
+    assert env.keyring_provider == "subprocess"
+
+
+def test_build_pypi_mirror_env_europe():
+    env = build_pypi_mirror_env("europe")
+    assert env.default_index == f"https://europe-python.pkg.dev/{AR_PROJECT}/{PYPI_MIRROR_REPO}/simple/"
+    assert env.pytorch_cpu_index == f"https://europe-python.pkg.dev/{AR_PROJECT}/{PYTORCH_CPU_MIRROR_REPO}/simple/"
+
+
+def test_build_pypi_mirror_env_unsupported_region_raises():
+    with pytest.raises(ValueError, match="SUPPORTED_MULTI_REGIONS"):
+        build_pypi_mirror_env("asia")
+
+
+def test_pypi_mirror_env_as_env_returns_three_keys():
+    env = PypiMirrorEnv(
+        default_index="https://example/a/simple/",
+        pytorch_cpu_index="https://example/b/simple/",
+    )
+    materialized = env.as_env()
+    assert materialized == {
+        "UV_DEFAULT_INDEX": "https://example/a/simple/",
+        "UV_INDEX_PYTORCH_CPU": "https://example/b/simple/",
+        "UV_KEYRING_PROVIDER": "subprocess",
+    }
+
+
+def test_build_pypi_mirror_env_custom_project_flows_through():
+    env = build_pypi_mirror_env("us", project="custom-project")
+    assert env.default_index == f"https://us-python.pkg.dev/custom-project/{PYPI_MIRROR_REPO}/simple/"
+    assert env.pytorch_cpu_index == f"https://us-python.pkg.dev/custom-project/{PYTORCH_CPU_MIRROR_REPO}/simple/"
+
+
+def test_url_trailing_slash():
+    """URLs must end with `/simple/` (uv's UV_INDEX_<NAME> requires trailing slash on some versions)."""
+    env = build_pypi_mirror_env("us")
+    assert env.default_index.endswith("/simple/")
+    assert env.pytorch_cpu_index.endswith("/simple/")


### PR DESCRIPTION
## Summary
- Adds `lib/iris/src/iris/cluster/providers/gcp/pypi_mirror.py` with `PypiMirrorEnv` dataclass and `build_pypi_mirror_env(multi_region, project)` helper
- Wires env-var injection into `lib/iris/src/iris/cluster/worker/task_attempt.py` after `IRIS_WORKER_REGION` is set; opt-out via `IRIS_PYPI_MIRROR=0` in env_vars; asia/me workers fall back to public PyPI silently
- Adds `keyrings.google-artifactregistry-auth` to the `task` Dockerfile stage (only) so uv can auth against AR via `UV_KEYRING_PROVIDER=subprocess`

Workers in `us-*` / `europe-*` regions will now resolve packages through the AR pypi-mirror repos provisioned in PR #5503, removing pypi.org from the install hot path.

Part of the `iris_pypi_mirror` plan (`.agents/projects/iris_pypi_mirror/spec.md`). Sibling PRs: #5500 (producer rename + publish workflow) and #5503 (AR repo provisioning).

## Test plan
- [x] `tests/test_pypi_mirror.py` — 6/6 unit tests pass
- [x] Full `lib/iris` unit suite — 2121 passed, 0 failed (no regressions)
- [x] `./infra/pre-commit.py --all-files --fix` clean; `pyrefly check` clean
- [ ] Post-merge: dev-cluster smoke job confirms AR domain in uv resolution logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)