### PR TITLE
[iris] fix client-freshness gate breakage on shallow clones + test fixtures

### DIFF
--- a/lib/iris/src/iris/version.py
+++ b/lib/iris/src/iris/version.py
@@ -18,12 +18,11 @@ from iris._build_info import BUILD_DATE
 _CACHED: str | None = None
 
 
-def _git_iris_date() -> str:
-    iris_root = Path(__file__).resolve().parents[2]
+def _git_log_date(iris_root: Path, *path_filter: str) -> str:
     try:
-        # %cs is short committer date (YYYY-MM-DD); empty if path has no commits.
+        # %cs is short committer date (YYYY-MM-DD).
         out = subprocess.check_output(
-            ["git", "log", "-1", "--format=%cs", "--", iris_root.as_posix()],
+            ["git", "log", "-1", "--format=%cs", *path_filter],
             cwd=iris_root,
             text=True,
             stderr=subprocess.DEVNULL,
@@ -32,6 +31,14 @@ def _git_iris_date() -> str:
         return out
     except (subprocess.SubprocessError, OSError):
         return ""
+
+
+def _git_iris_date() -> str:
+    # Path-filtered first (precise iris date for full clones), unfiltered
+    # fallback (date of HEAD) for shallow CI clones where the tip commit
+    # may not have touched lib/iris and `git log -- path` returns empty.
+    iris_root = Path(__file__).resolve().parents[2]
+    return _git_log_date(iris_root, "--", iris_root.as_posix()) or _git_log_date(iris_root)
 
 
 def client_revision_date() -> str:

--- a/lib/iris/tests/cluster/conftest.py
+++ b/lib/iris/tests/cluster/conftest.py
@@ -169,6 +169,8 @@ class ServiceTestHarness:
         resources: job_pb2.ResourceSpecProto | None = None,
     ) -> JobName:
         """Submit a job via the RPC layer. Returns job_id."""
+        from datetime import date
+
         from tests.cluster.controller.conftest import make_test_entrypoint
 
         job_id = JobName.root(user, name)
@@ -179,6 +181,7 @@ class ServiceTestHarness:
             environment=job_pb2.EnvironmentConfig(),
             replicas=replicas,
             max_retries_failure=max_retries_failure,
+            client_revision_date=date.today().isoformat(),
         )
         self.service.launch_job(request, None)
         return job_id

--- a/lib/iris/tests/cluster/controller/conftest.py
+++ b/lib/iris/tests/cluster/controller/conftest.py
@@ -7,6 +7,7 @@ import shutil
 import tempfile
 from contextlib import contextmanager
 from dataclasses import replace as _replace
+from datetime import date
 from pathlib import Path
 from unittest.mock import MagicMock, Mock
 
@@ -278,6 +279,11 @@ def make_direct_job_request(
         environment=job_pb2.EnvironmentConfig(),
         replicas=replicas,
         task_image=task_image,
+        # Stamp today's date so the controller's client-freshness gate
+        # (service.py:_check_client_freshness) doesn't reject these test
+        # submissions once the 14-day window past FEATURE_INTRODUCTION_DATE
+        # closes. Tests that exercise the gate explicitly should override.
+        client_revision_date=date.today().isoformat(),
     )
 
 
@@ -507,6 +513,8 @@ def make_job_request(
         replicas=replicas,
         priority_band=priority_band,
         task_image=task_image,
+        # See make_direct_job_request for rationale.
+        client_revision_date=date.today().isoformat(),
     )
     if scheduling_timeout_seconds > 0:
         request.scheduling_timeout.CopyFrom(duration_to_proto(Duration.from_seconds(scheduling_timeout_seconds)))

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -357,6 +357,7 @@ def test_launch_job_rejects_empty_name(service, state):
         entrypoint=make_test_entrypoint(),
         resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
         environment=job_pb2.EnvironmentConfig(),
+        client_revision_date=date.today().isoformat(),
     )
 
     with pytest.raises(ConnectError) as exc_info:
@@ -392,6 +393,7 @@ def test_get_job_status_reports_has_children(service, state):
         entrypoint=job_pb2.RuntimeEntrypoint(),
         resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
         environment=job_pb2.EnvironmentConfig(),
+        client_revision_date=date.today().isoformat(),
     )
     child_req.entrypoint.run_command.argv[:] = ["python", "-c", "pass"]
     with state._store.transaction() as cur:
@@ -439,6 +441,7 @@ def test_submit_argv_roundtrips_through_get_job_status(service):
         entrypoint=make_test_entrypoint(),
         resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
         submit_argv=["iris", "job", "run", "-e", "LOG_LEVEL", "info", "--", "python", "t.py"],
+        client_revision_date=date.today().isoformat(),
     )
     service.launch_job(launch_req, None)
 
@@ -463,6 +466,7 @@ def test_submit_argv_empty_when_omitted(service):
         name=job_name.to_wire(),
         entrypoint=make_test_entrypoint(),
         resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
+        client_revision_date=date.today().isoformat(),
     )
     service.launch_job(launch_req, None)
 
@@ -489,6 +493,7 @@ def test_get_job_status_redacts_sensitive_env_vars(service):
                 "NUM_WORKERS": "4",
             }
         ),
+        client_revision_date=date.today().isoformat(),
     )
     service.launch_job(launch_req, None)
 
@@ -935,6 +940,7 @@ def test_list_jobs_all_scope_includes_descendants(service, state):
         entrypoint=job_pb2.RuntimeEntrypoint(),
         resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
         environment=job_pb2.EnvironmentConfig(),
+        client_revision_date=date.today().isoformat(),
     )
     child_req.entrypoint.run_command.argv[:] = ["python", "-c", "pass"]
     with state._store.transaction() as cur:
@@ -960,6 +966,7 @@ def test_list_jobs_job_query_roots_and_children(service, state):
         entrypoint=job_pb2.RuntimeEntrypoint(),
         resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
         environment=job_pb2.EnvironmentConfig(),
+        client_revision_date=date.today().isoformat(),
     )
     child_req.entrypoint.run_command.argv[:] = ["python", "-c", "pass"]
     with state._store.transaction() as cur:
@@ -1201,6 +1208,7 @@ def test_launch_job_injects_device_constraints_from_tpu_resource(service, state)
         entrypoint=make_test_entrypoint(),
         resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
         environment=job_pb2.EnvironmentConfig(),
+        client_revision_date=date.today().isoformat(),
     )
     request.resources.device.CopyFrom(tpu_device("v5litepod-16"))
 
@@ -1227,6 +1235,7 @@ def test_launch_job_user_constraints_override_auto(service, state):
         entrypoint=make_test_entrypoint(),
         resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
         environment=job_pb2.EnvironmentConfig(),
+        client_revision_date=date.today().isoformat(),
     )
     request.resources.device.CopyFrom(tpu_device("v5litepod-16"))
     request.constraints.append(user_variant.to_proto())
@@ -1254,6 +1263,7 @@ def test_launch_job_cpu_resource_no_constraints_injected(service, state):
         entrypoint=make_test_entrypoint(),
         resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
         environment=job_pb2.EnvironmentConfig(),
+        client_revision_date=date.today().isoformat(),
     )
 
     service.launch_job(request, None)
@@ -1353,6 +1363,7 @@ def test_get_scheduler_state_with_running_task(controller_service, state):
         resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
         environment=job_pb2.EnvironmentConfig(),
         replicas=1,
+        client_revision_date=date.today().isoformat(),
     )
     with state._store.transaction() as cur:
         state.submit_job(cur, job_id, request, Timestamp.now())
@@ -1473,6 +1484,7 @@ def test_launch_job_nested_with_stale_client_date_is_exempt(service):
         entrypoint=make_test_entrypoint(),
         resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
         environment=job_pb2.EnvironmentConfig(),
+        client_revision_date=date.today().isoformat(),
     )
     child_req.client_revision_date = "2000-01-01"
 

--- a/lib/iris/tests/test_auth.py
+++ b/lib/iris/tests/test_auth.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Auth tests for Iris controller with static token authentication."""
 
+from datetime import date
+
 import pytest
 from iris.cluster.providers.local.cluster import LocalCluster
 from iris.cluster.types import Entrypoint, ResourceSpec
@@ -88,6 +90,7 @@ def test_static_auth_job_ownership():
             name="/user-a/auth-owned-job",
             entrypoint=entrypoint.to_proto(),
             resources=ResourceSpec(cpu=1, memory="1g").to_proto(),
+            client_revision_date=date.today().isoformat(),
         )
         resp = client_a.launch_job(launch_req)
         job_id = resp.job_id

--- a/lib/iris/tests/test_budget.py
+++ b/lib/iris/tests/test_budget.py
@@ -4,6 +4,8 @@
 """Tests for budget tracking (resource_value / compute_user_spend / interleave_by_user)
 and the admin API RPCs that expose them."""
 
+from datetime import date
+
 import pytest
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
@@ -177,6 +179,7 @@ def _launch_request(
         environment=job_pb2.EnvironmentConfig(),
         replicas=replicas,
         priority_band=band,
+        client_revision_date=date.today().isoformat(),
     )
     if include_resources:
         req.resources.CopyFrom(job_pb2.ResourceSpecProto(cpu_millicores=cpu_millicores, memory_bytes=memory_bytes))

--- a/lib/iris/tests/test_version.py
+++ b/lib/iris/tests/test_version.py
@@ -48,6 +48,27 @@ def test_client_revision_date_empty_when_git_fails(monkeypatch):
     assert iris_version.client_revision_date() == ""
 
 
+def test_git_iris_date_falls_back_when_path_filter_empty(monkeypatch):
+    """Shallow CI clones often produce empty path-filtered git log output;
+    we must still return a valid HEAD date by retrying without the path filter."""
+    calls: list[tuple] = []
+
+    def _fake_check_output(cmd, **kwargs):
+        calls.append(tuple(cmd))
+        # First invocation has the `--` path filter and returns empty
+        # (simulating shallow clone whose tip didn't touch lib/iris).
+        # Second invocation drops the filter and returns the HEAD date.
+        if "--" in cmd:
+            return ""
+        return "2026-05-07\n"
+
+    monkeypatch.setattr(subprocess, "check_output", _fake_check_output)
+    assert iris_version._git_iris_date() == "2026-05-07"
+    assert len(calls) == 2
+    assert "--" in calls[0]
+    assert "--" not in calls[1]
+
+
 def test_client_revision_date_is_cached(monkeypatch):
     """Resolver computes once per process; subsequent calls reuse the result."""
     monkeypatch.setattr(iris_version, "BUILD_DATE", "")


### PR DESCRIPTION
## Summary
The controller's \`_check_client_freshness\` gate (\`service.py:140\`) treats empty \`client_revision_date\` as \`FEATURE_INTRODUCTION_DATE = 2026-04-22\` with a 14-day grace window. That window closed on 2026-05-06; every PR's CI now hits \`FAILED_PRECONDITION: marin-iris client is too old\` on LaunchJob-touching tests.

Two fixes:

1. **Production path**: \`iris/version.py\` falls through path-filtered \`git log -1 --format=%cs -- lib/iris/\` to unfiltered \`git log -1 --format=%cs\` (date of HEAD) when the path-filtered query returns empty. Path-filtered returns empty in shallow CI checkouts (\`actions/checkout@v5\` defaults to \`fetch-depth: 1\`) when the tip commit didn't touch \`lib/iris/\`. Adds a unit test for the retry path.

2. **Test fixtures**: tests that construct \`LaunchJobRequest\` directly (bypassing the client layer that calls \`client_revision_date()\`) need to stamp the field explicitly. Patches the two helper builders (\`make_job_request\`, \`make_direct_job_request\`, \`ServiceTestHarness.submit\`) and a handful of inline \`LaunchJobRequest\` constructors in \`test_service.py\` / \`test_auth.py\` / \`test_budget.py\`.

## Test plan
- [x] New unit test \`test_git_iris_date_falls_back_when_path_filter_empty\` covers the retry path
- [x] Existing 4 \`test_version.py\` cases still pass (5/5 total)
- [x] Full \`lib/iris\` unit suite: **2119 passed, 0 failed** (was 63 failed)
- [x] \`./infra/pre-commit.py --fix\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)