### PR TITLE
[iris] Skip client freshness for in-process launches

### DIFF
--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -1090,10 +1090,12 @@ class ControllerServiceImpl:
 
         job_id = JobName.from_wire(request.name)
 
-        # Reject root submissions from stale clients. Nested submissions (from
-        # a job already running in the cluster) are exempt — the workload would
-        # otherwise crash mid-flight as the freshness window slides forward.
-        if job_id.is_root:
+        # Reject root RPC submissions from stale clients. Direct in-process
+        # calls have no wire client; tests and harnesses use ctx=None.
+        # Nested submissions are exempt because they come from an already
+        # running workload, which would otherwise crash mid-flight as the
+        # freshness window slides forward.
+        if job_id.is_root and ctx is not None:
             _check_client_freshness(request.client_revision_date, date.today())
 
         # When an auth provider is configured, override the user segment with

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -1448,7 +1448,7 @@ def test_launch_job_root_with_fresh_client_date(service):
     """Root submission with today's date succeeds end-to-end through launch_job."""
     request = make_job_request("fresh-client")
     request.client_revision_date = date.today().isoformat()
-    response = service.launch_job(request, None)
+    response = service.launch_job(request, object())
     assert response.job_id == JobName.root("test-user", "fresh-client").to_wire()
 
 
@@ -1457,7 +1457,7 @@ def test_launch_job_root_with_stale_client_date(service):
     request = make_job_request("stale-client")
     request.client_revision_date = "2000-01-01"
     with pytest.raises(ConnectError) as exc_info:
-        service.launch_job(request, None)
+        service.launch_job(request, object())
     assert exc_info.value.code == Code.FAILED_PRECONDITION
 
 

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -30,6 +30,7 @@ from iris.cluster.types import (
 )
 from iris.rpc import config_pb2, controller_pb2, job_pb2
 from iris.rpc.controller_connect import ControllerServiceClientSync
+from iris.version import client_revision_date
 from rigging.timing import Duration, ExponentialBackoff
 
 from .conftest import (
@@ -1013,6 +1014,7 @@ def test_static_auth_job_ownership():
             name="/user-a/auth-owned-job",
             entrypoint=entrypoint.to_proto(),
             resources=ResourceSpec(cpu=1, memory="1g").to_proto(),
+            client_revision_date=client_revision_date(),
         )
         resp = client_a.launch_job(launch_req)
         job_id = resp.job_id

--- a/lib/iris/tests/test_auth.py
+++ b/lib/iris/tests/test_auth.py
@@ -7,6 +7,7 @@ from iris.cluster.providers.local.cluster import LocalCluster
 from iris.cluster.types import Entrypoint, ResourceSpec
 from iris.rpc import controller_pb2, job_pb2
 from iris.rpc.controller_connect import ControllerServiceClientSync
+from iris.version import client_revision_date
 
 from .conftest import _make_controller_only_config
 
@@ -88,6 +89,7 @@ def test_static_auth_job_ownership():
             name="/user-a/auth-owned-job",
             entrypoint=entrypoint.to_proto(),
             resources=ResourceSpec(cpu=1, memory="1g").to_proto(),
+            client_revision_date=client_revision_date(),
         )
         resp = client_a.launch_job(launch_req)
         job_id = resp.job_id


### PR DESCRIPTION
## Summary

- keep the stale-client freshness gate on root RPC submissions
- exempt direct in-process controller service calls, which have no wire client and use `ctx=None`
- update the explicit fresh/stale client tests to use a non-`None` context so they still exercise the RPC-style gate

Fixes #5511.

## Test Plan

- `cd lib/iris && uv run --group dev python -m pytest tests/cluster/controller/test_service.py::test_launch_job_root_with_fresh_client_date tests/cluster/controller/test_service.py::test_launch_job_root_with_stale_client_date tests/cluster/controller/test_service.py::test_launch_job_returns_job_id -q`
- `uv run pytest tests/integration/iris/test_iris_kind.py::test_gpu_pod_attributes_with_in_memory_k8s -q -o 'addopts='`