### PR TITLE
Document CoreWeave Grug warm-node smoke

### DIFF
--- a/.github/workflows/marin-canary-ferry-coreweave.yaml
+++ b/.github/workflows/marin-canary-ferry-coreweave.yaml
@@ -2,8 +2,10 @@ name: "Marin - Canary Ferry - CoreWeave"
 
 # The canary submits a small training job to the shared `iris-ci` controller
 # and reuses the warm `iris-ci-h100-8x` NodePool. Scheduled runs use the warm
-# single H100 host; manual multi-host runs may autoscale the same NodePool to a
-# second `gd-8xh100ib-i128` host.
+# single H100 host; manual runs can request multiple GPU replicas on the same
+# NodePool. Before requesting multiple replicas, make sure enough GPU nodes are
+# already warm and free; cold/warm mixed starts can fail at JAX rendezvous.
+# See https://github.com/marin-community/marin/issues/5480.
 #
 # `iris cluster start --fresh` rebuilds the controller/worker/task images from
 # the current checkout and rolls the shared controller deployment to pick them
@@ -19,10 +21,10 @@ on:
         description: 'Override training token budget'
         type: number
         required: false
-      multi_host:
-        description: 'Run across two H100 hosts'
-        type: boolean
-        default: false
+      gpu_replicas:
+        description: 'Number of H100 GPU replicas'
+        type: number
+        default: 1
         required: false
 
 permissions:
@@ -47,7 +49,11 @@ jobs:
       RUN_ID: canary-gpu-${{ github.run_id }}-${{ github.run_attempt }}
       CANARY_ACCELERATOR: gpu
       CANARY_BATCH_SIZE: "16"
-      CANARY_MULTI_HOST: ${{ github.event_name == 'workflow_dispatch' && inputs.multi_host && '1' || '' }}
+      CANARY_GPU_REPLICAS: ${{ github.event_name == 'workflow_dispatch' && format('{0}', inputs.gpu_replicas) || '1' }}
+      # TODO(#5524): remove this override once Levanter profiler stop is
+      # idempotent. Keeping the profile window off the final callback lets
+      # CoreWeave validation proceed independently of that fix.
+      CANARY_PROFILER_NUM_STEPS: "10"
       CANARY_TARGET_TOKENS: "6553600"
       CANARY_MIN_STEPS: "40"
       CANARY_MAX_LOSS: "8.0"
@@ -117,7 +123,7 @@ jobs:
         id: submit
         shell: bash -l {0}
         run: |
-          echo "Multi-host canary: ${CANARY_MULTI_HOST:-0}"
+          echo "GPU replicas: $CANARY_GPU_REPLICAS"
           JOB_ID=$(.venv/bin/iris --controller-url="$IRIS_CONTROLLER_URL" \
             job run --no-wait \
             --memory=2G --disk=4G --cpu=1 --extra=cpu \
@@ -125,7 +131,8 @@ jobs:
             -e RUN_ID "$RUN_ID" \
             -e CANARY_ACCELERATOR "$CANARY_ACCELERATOR" \
             -e CANARY_BATCH_SIZE "$CANARY_BATCH_SIZE" \
-            -e CANARY_MULTI_HOST "$CANARY_MULTI_HOST" \
+            -e CANARY_GPU_REPLICAS "$CANARY_GPU_REPLICAS" \
+            -e CANARY_PROFILER_NUM_STEPS "$CANARY_PROFILER_NUM_STEPS" \
             -e CANARY_TARGET_TOKENS "$CANARY_TARGET_TOKENS" \
             -e WANDB_ENTITY "$WANDB_ENTITY" \
             -e WANDB_PROJECT "$WANDB_PROJECT" \

--- a/experiments/ferries/canary_ferry.py
+++ b/experiments/ferries/canary_ferry.py
@@ -10,7 +10,15 @@ to the Iris container. workflow_dispatch inputs override CANARY_TARGET_TOKENS.
     CANARY_ACCELERATOR   tpu | gpu
     CANARY_BATCH_SIZE    per-device batch size
     CANARY_CACHE_COPY_MAX_WORKERS gpu-only cache-copy worker cap
+    CANARY_GPU_TYPE      gpu-only accelerator type, e.g. H100, GH200, B200
+    CANARY_GPU_COUNT     gpu-only accelerator count per replica
+    CANARY_GPU_REPLICAS  gpu-only replica count
+    CANARY_PROFILER_ENABLED true | false
+    CANARY_PROFILER_NUM_STEPS profiler duration in steps
+    CANARY_PROFILER_START_STEP profiler start step
+    CANARY_STEPS         explicit training step count; overrides CANARY_TARGET_TOKENS
     CANARY_TARGET_TOKENS total training tokens
+    CANARY_TRACKER       wandb | json_logger
     RUN_ID               unique run identifier
 """
 
@@ -22,6 +30,7 @@ from fray.cluster import ResourceConfig
 from levanter.callbacks.profiler import ProfilerConfig
 from levanter.data.text import BlockShuffleConfig, TextLmDatasetFormat
 from levanter.optim import AdamConfig
+from levanter.tracker.json_logger import JsonLoggerConfig
 from levanter.tracker.wandb import WandbConfig
 from marin.execution.executor import ExecutorStep, executor_main, this_output_path, versioned
 from marin.processing.tokenize.data_configs import lm_data_config
@@ -57,6 +66,13 @@ def _env_int(key: str, default: int) -> int:
     return int(raw) if raw else default
 
 
+def _env_bool(key: str, default: bool) -> bool:
+    raw = os.environ.get(key, "")
+    if not raw:
+        return default
+    return raw.lower() in ("1", "true")
+
+
 def _build_step_from_env() -> ExecutorStep:
     accelerator = os.environ.get("CANARY_ACCELERATOR", "tpu")
     if accelerator not in ("tpu", "gpu"):
@@ -80,10 +96,13 @@ def _build_step_from_env() -> ExecutorStep:
         wandb_group = "canary-ferry-moe"
         wandb_tags = ["canary", "ferry", "grug", "moe"]
     else:
-        multi_host = os.environ.get("CANARY_MULTI_HOST", "").lower() in ("1", "true")
         batch_size = _env_int("CANARY_BATCH_SIZE", 32)
         cache_copy_max_workers = _env_int("CANARY_CACHE_COPY_MAX_WORKERS", 12)
         target_tokens = _env_int("CANARY_TARGET_TOKENS", batch_size * GRUG_MOE_TRIAL_MODEL.max_seq_len * 50)
+        gpu_type = os.environ.get("CANARY_GPU_TYPE", "H100")
+        gpu_count = _env_int("CANARY_GPU_COUNT", 8)
+        gpu_replicas = _env_int("CANARY_GPU_REPLICAS", 1)
+
         # SlimPajama-6B with block-shuffle — small dataset, re-tokenized on first run.
         tokenize_step = default_tokenize(
             name="slimpajama-6b-cw",
@@ -104,24 +123,41 @@ def _build_step_from_env() -> ExecutorStep:
             training_set=tokenize_step,
             shuffle=BlockShuffleConfig(io_block_size=256, window_blocks=256, perm_type="feistel"),
         )
-        if multi_host:
-            name = "canary-ferry-cw-multihost"
-            resources = ResourceConfig.with_gpu("H100", count=8, cpu=32, ram="256g", disk="256g", replicas=2)
-            wandb_group = "canary-ferry-moe-gpu-multihost"
-            wandb_tags = ["canary", "ferry", "grug", "moe", "gpu", "multihost"]
-        else:
-            name = "canary-ferry-cw"
-            resources = ResourceConfig.with_gpu("H100", count=8, cpu=32, ram="256g", disk="256g")
-            wandb_group = "canary-ferry-moe-gpu"
-            wandb_tags = ["canary", "ferry", "grug", "moe", "gpu"]
+        resources = ResourceConfig.with_gpu(
+            gpu_type,
+            count=gpu_count,
+            cpu=32,
+            ram="256g",
+            disk="256g",
+            replicas=gpu_replicas,
+        )
+        name = f"canary-ferry-cw-{gpu_type.lower()}x{gpu_count}-r{gpu_replicas}"
+        wandb_group = f"canary-ferry-moe-gpu-{gpu_type.lower()}-r{gpu_replicas}"
+        wandb_tags = ["canary", "ferry", "grug", "moe", "gpu", gpu_type.lower()]
         eval_config = None
 
-    num_steps = target_tokens // (batch_size * GRUG_MOE_TRIAL_MODEL.max_seq_len)
+    num_steps = _env_int("CANARY_STEPS", target_tokens // (batch_size * GRUG_MOE_TRIAL_MODEL.max_seq_len))
     if num_steps <= 0:
         raise ValueError(
-            f"CANARY_TARGET_TOKENS={target_tokens} too small for batch_size={batch_size} "
-            f"x seq_len={GRUG_MOE_TRIAL_MODEL.max_seq_len} -- would produce 0 steps"
+            f"CANARY_STEPS={num_steps} invalid; set CANARY_STEPS or CANARY_TARGET_TOKENS high enough for "
+            f"batch_size={batch_size} x seq_len={GRUG_MOE_TRIAL_MODEL.max_seq_len}"
         )
+    if os.environ.get("CANARY_TRACKER", "wandb").lower() == "json_logger":
+        tracker = JsonLoggerConfig(logger_name=os.environ.get("CANARY_JSON_LOGGER", "canary_ferry.metrics"))
+    else:
+        tracker = WandbConfig(
+            entity=os.environ.get("WANDB_ENTITY") or None,
+            project=os.environ.get("WANDB_PROJECT", "marin"),
+            tags=wandb_tags,
+            group=wandb_group,
+            mode=os.environ.get("CANARY_WANDB_MODE") or os.environ.get("WANDB_MODE") or None,
+            name=None,
+            replicate_path=this_output_path(),
+        )
+
+    profiler_enabled = _env_bool("CANARY_PROFILER_ENABLED", True)
+    profiler_start_step = _env_int("CANARY_PROFILER_START_STEP", 5)
+    profiler_num_steps = _env_int("CANARY_PROFILER_NUM_STEPS", 25)
 
     return ExecutorStep(
         name=f"{name}-{run_id}",
@@ -136,17 +172,15 @@ def _build_step_from_env() -> ExecutorStep:
             batch_size=versioned(batch_size),
             seed=versioned(0),
             mp=versioned("params=float32,compute=bfloat16,output=bfloat16"),
-            tracker=WandbConfig(
-                project="marin",
-                tags=wandb_tags,
-                group=wandb_group,
-                name=None,
-                replicate_path=this_output_path(),
-            ),
+            tracker=tracker,
             optimizer=versioned(CANARY_OPTIMIZER),
             grug_trainer=versioned(CANARY_TRAINER),
             eval=versioned(eval_config) if eval_config is not None else None,
-            profiler=ProfilerConfig(enabled=True),
+            profiler=ProfilerConfig(
+                enabled=profiler_enabled,
+                start_step=profiler_start_step,
+                num_steps=profiler_num_steps,
+            ),
         ),
     )
 

--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -35,6 +35,9 @@ iris job bug-report /user/job-name      # structured diagnostic dump
 
 ### `job run` gotchas
 
+- **Remote jobs only see env vars you put in the job spec.** The submitter's
+  shell env is not copied into the container. Pass required values explicitly:
+  `iris job run -e HF_TOKEN "$HF_TOKEN" -e WANDB_API_KEY "$WANDB_API_KEY" -- python train.py`.
 - **`--memory` not `--ram`** — unrecognized flags silently pass through to the command string.
 - **`-e KEY VALUE`** uses two positional args. If `$VALUE` is unset, the parser eats the next token. Always quote: `-e KEY "${VALUE}"`.
 - **`--gpu` requests hardware; `--extra gpu` requests the Python dependency extra.** Need both for GPU JAX jobs.

--- a/lib/iris/docs/coreweave.md
+++ b/lib/iris/docs/coreweave.md
@@ -215,6 +215,107 @@ Marin's `gpu` extra installs the JAX CUDA 13 wheel stack from PyPI. CoreWeave
 GPU nodes must expose NVIDIA driver 580 or newer; `nvidia-smi` should report
 CUDA 13.x.
 
+### Grug MoE Canary Warm-Node Multinode Smoke
+
+For a realistic Grug MoE multinode smoke, use the GPU path in
+`experiments.ferries.canary_ferry`. This is a temporary warm-node validation
+while cold-start/gang scheduling is tracked in #5480: before submitting the job,
+verify that the required GPU nodes are already `CURRENT`, free, and schedulable.
+
+Warm-node preflight:
+
+```bash
+# Confirm the target pool is not already occupied by another Iris workload.
+uv run iris --cluster=<cluster> job list --state running
+
+# Confirm the requested nodes are already warm, not still provisioning.
+kubectl --kubeconfig <kubeconfig> get nodepool.compute.coreweave.com <nodepool> \
+  -o custom-columns=NAME:.metadata.name,TARGET:.spec.targetNodes,CURRENT:.status.currentNodes,INPROGRESS:.status.inProgress,QUEUED:.status.queuedNodes
+
+# Confirm the scheduler-visible pods are not already consuming the target nodes.
+kubectl --kubeconfig <kubeconfig> -n <namespace> get pods -o wide
+```
+
+Starting smoke settings:
+
+| Target | Cluster | Namespace | Kubeconfig | NodePool | `CANARY_GPU_*` | Batch | `NCCL_SOCKET_IFNAME` |
+|--------|---------|-----------|------------|----------|-----------------|-------|----------------------|
+| H100x8 x 2 | `coreweave-ci` | `iris-ci` | `~/.kube/coreweave-iris` | `iris-ci-h100-8x` | `TYPE=H100`, `COUNT=8`, `REPLICAS=2` | 64 | `=enp157s0np0` |
+| B200x8 x 2 | `coreweave-usw09b` | `iris` | `~/.kube/cw-usw09b.yaml` | `iris-usw09b-b200-8x` | `TYPE=B200`, `COUNT=8`, `REPLICAS=2` | 128 | `=enp44s0np0` |
+| GH200x1 x 2 | `coreweave-rno2a` | `iris` | `~/.kube/cw-rno2a.yaml` | `iris-rno2a-gh200-1x` | `TYPE=GH200`, `COUNT=1`, `REPLICAS=2` | 16 | `=eth0` |
+
+For H100, manually warm the second node before launch and restore the pool after
+the run:
+
+```bash
+kubectl --kubeconfig ~/.kube/coreweave-iris patch nodepool.compute.coreweave.com iris-ci-h100-8x \
+  --type merge -p '{"spec":{"targetNodes":2}}'
+
+# After the smoke:
+kubectl --kubeconfig ~/.kube/coreweave-iris patch nodepool.compute.coreweave.com iris-ci-h100-8x \
+  --type merge -p '{"spec":{"targetNodes":1}}'
+```
+
+The GitHub CoreWeave canary workflow uses the same H100 pool; run it and manual
+H100 validation sequentially. If the controller restarts after warming the H100
+pool, recheck `targetNodes`; startup may reconcile the pool back toward the
+single-node target.
+
+Submit with explicit `-e` environment variables. Iris job containers do not
+inherit arbitrary shell variables from the submitter. Because this canary uses
+real SlimPajama data, use a shared durable `MARIN_PREFIX` plus the credentials
+needed to read/write that prefix. `CANARY_TRACKER=json_logger` avoids requiring
+W&B for this smoke.
+
+| Use | Prefix | Endpoint | Credentials |
+|-----|--------|----------|-------------|
+| H100 CI state and canary data | `s3://marin-na/...` | Cloudflare R2 | R2 credentials |
+| B200/GH200 controller state | `s3://marin-poc/iris/state/...` | `https://cwobject.com` | CoreWeave object storage credentials |
+| B200/GH200 canary data with `MARIN_PREFIX=s3://marin-na/marin/` | `s3://marin-na/marin/` | Cloudflare R2 | R2 credentials |
+
+Set `AWS_ENDPOINT_URL` to the endpoint that matches the prefix and credentials.
+For R2/CoreWeave S3-compatible endpoints, leave `AWS_REGION` and
+`AWS_DEFAULT_REGION` as `auto`; use a real AWS region only for AWS S3.
+
+```bash
+RUN_ID="cw-grug-mn-warm-<target>-$(date -u +%Y%m%d-%H%M%S)"
+LOG="/tmp/marin-cw-grug-moe/${RUN_ID}.log"
+mkdir -p "$(dirname "$LOG")"
+
+# TODO(#5524): remove CANARY_PROFILER_NUM_STEPS once Levanter profiler stop is
+# idempotent. The shorter window keeps 20-step smokes from stopping the
+# profiler on the final forced callback.
+uv run iris --cluster=<cluster> job run \
+  --job-name "$RUN_ID" \
+  --cpu 1 --memory 2GB --disk 8GB --extra cpu \
+  -e MARIN_PREFIX <shared-marin-prefix> \
+  -e RUN_ID "$RUN_ID" \
+  -e CANARY_ACCELERATOR gpu \
+  -e CANARY_GPU_TYPE <H100|B200|GH200> \
+  -e CANARY_GPU_COUNT <8|1> \
+  -e CANARY_GPU_REPLICAS 2 \
+  -e CANARY_STEPS 20 \
+  -e CANARY_BATCH_SIZE <64|128|16> \
+  -e CANARY_PROFILER_ENABLED true \
+  -e CANARY_PROFILER_NUM_STEPS 10 \
+  -e CANARY_TRACKER json_logger \
+  -e NCCL_SOCKET_IFNAME '<interface>' \
+  -e HF_TOKEN "$HF_TOKEN" \
+  -e AWS_ACCESS_KEY_ID "$AWS_ACCESS_KEY_ID" \
+  -e AWS_SECRET_ACCESS_KEY "$AWS_SECRET_ACCESS_KEY" \
+  -e AWS_ENDPOINT_URL "$AWS_ENDPOINT_URL" \
+  -e AWS_REGION "${AWS_REGION:-auto}" \
+  -e AWS_DEFAULT_REGION "${AWS_DEFAULT_REGION:-auto}" \
+  -- python -m experiments.ferries.canary_ferry 2>&1 | tee "$LOG"
+```
+
+Expected success signals: both replicas report JAX 0.10.0, both enter
+`initialize_jax` with `IRIS_NUM_TASKS=2`, both emit tracker summaries, the
+profiler starts and records a JAX profile artifact, the step reaches 20/20, a
+checkpoint is committed, and the parent job exits `JOB_STATE_SUCCEEDED`. H100
+batch 128 has OOMed with the current Grug MoE model; use batch 64 for functional
+validation.
+
 ### KubernetesProvider Operations
 
 On CoreWeave, there are no persistent worker daemons. The controller dispatches


### PR DESCRIPTION
## Summary

- add CoreWeave docs for running the synthetic Grug MoE warm-node multinode smoke
- document H100/B200/GH200 settings, preflight checks, H100 warm-up/scale-down, storage credentials, and success signals
- document Iris `job run` env forwarding explicitly in `lib/iris/OPS.md`
- extend `experiments.ferries.canary_ferry` GPU env configuration for GPU type/count/replicas, explicit step count, optional JSON tracker, and profiler controls
- set the GH CoreWeave GPU canary profiler window to stop before the final callback as a temporary workaround for #5524

## Validation

Local checks after rebasing onto latest `main`:

- `./infra/pre-commit.py --fix .github/workflows/marin-canary-ferry-coreweave.yaml experiments/ferries/canary_ferry.py lib/iris/docs/coreweave.md lib/iris/OPS.md`
- `uv run python -m compileall experiments/ferries/canary_ferry.py`
- constructed a B200-style GPU canary config locally with `CANARY_PROFILER_ENABLED=true`, `CANARY_PROFILER_NUM_STEPS=10`, and `CANARY_TRACKER=json_logger`, confirming `B200`, GPU count `8`, replicas `2`, steps `20`, batch size `128`, profiler window `5..15`, and `JsonLoggerConfig`

Manual/CoreWeave validation:

- GH200x1 x 2 warm/free-node run `/romain/cw-grug-mn-warm-gh200-20260507-223324` completed with profiler enabled; `jax-profile-step-5-15` artifact was recorded, usable metrics were emitted, and the step 20 checkpoint was committed.
- H100x8 x 2 warm/free-node run `/romain/cw-grug-mn-warm-h100-20260507-223324` completed with profiler enabled after retry; `jax-profile-step-5-15` artifacts were recorded, usable metrics were emitted, and the step 20 checkpoint was committed.
- GH CoreWeave GPU canary with profiler enabled completed successfully in Actions run https://github.com/marin-community/marin/actions/runs/25526448602; the canary completed, checkpointed, validated metrics, and summarized the GPU profile.
- B200x8 x 2 warm/free-node run `/romain/cw-grug-mn-warm-b200-20260507-223324` emitted usable metrics, then reproduced the known B200 first-stop profiler hang in `jax.profiler.stop_trace()` before profile artifact/checkpoint/completion. This is tracked in #5528 and is not treated as a #5514 merge blocker.

GitHub checks are rerunning after the latest push.

## Known Limitations

- Multinode is validated only in the warm/free-node regime. Cold/warm startup remains tracked in #5480.
- B200x8 x 2 profiler-enabled completion/checkpoint remains blocked by #5528.

🤖 Agent-generated documentation PR.