### PR TITLE
[ci] Bump datakit tier2 canary timeout to 3h

### DIFF
--- a/.github/workflows/marin-canary-datakit-tier2.yaml
+++ b/.github/workflows/marin-canary-datakit-tier2.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   datakit-starcoder2-doc-ferry:
     runs-on: ubuntu-latest
-    timeout-minutes: 120  # ~10–20 min run; ample buffer
+    timeout-minutes: 180  # ~10–20 min run; ample buffer
     concurrency:
       group: datakit-starcoder2-doc-ferry
       cancel-in-progress: true


### PR DESCRIPTION
Raise timeout-minutes from 120 to 180 on the datakit-starcoder2-doc-ferry job in .github/workflows/marin-canary-datakit-tier2.yaml to give more headroom before GitHub force-kills the run.