### PR TITLE
[dedup] route fuzzy dedup by partition_id column

### DIFF
--- a/docs/design/2355_datakit.md
+++ b/docs/design/2355_datakit.md
@@ -27,6 +27,7 @@ Convert raw data into the **datakit standard format**:
 * **Mandatory columns**:
   * `id` \- unique document identifier (see [ID Column](#id-column) below)
   * `text` \- primary text content \- we enforce UTF-8
+  * `partition_id` \- int, the row's output shard at normalize time. Stamped at write time and preserved by every downstream stage. Shufflers (e.g. fuzzy/exact dedup) use it as the `group_by` key to land output co-partitioned with the source. The shard count itself lives on the artifact (`NormalizedData.num_partitions`), not on every row.
 * **Arbitrary additional columns**: any fields present in the raw data are preserved
 * **Directory structure**: preserver original directory structure
 * **Partition structure**: partition layout from the source does NOT need to be preserved at this point \- and in most cases it will not be
@@ -93,7 +94,7 @@ This means:
 * All downstream stages (embed, classify, dedup) preserve this structure \- same shard count, same ID ranges per shard
 * Consolidation can use Zephyr's `sorted_merge_join` without a costly `group_by` shuffle
 
-This is enforced by convention: each processing stage reads source partitions 1:1 and writes output partitions with matching structure.
+For per-document stages (embed, per-doc classify) this falls out of reading source partitions 1:1. For stages that shuffle globally (fuzzy/exact dedup, anything graph-structured), records carry their `partition_id` through the shuffle and the writer does `group_by(partition_id)` to land output back in matching files — so co-partitioning is enforced by data, not by filename arithmetic.
 
 ## Attributes Datasets {#attributes-datasets}
 

--- a/experiments/datakit_testbed/sampler.py
+++ b/experiments/datakit_testbed/sampler.py
@@ -216,6 +216,7 @@ def sample_normalized_shards(
         return NormalizedData(
             main_output_dir=main_out,
             dup_output_dir=source.dup_output_dir,
+            num_partitions=total,
             counters={"sampler/selected_shards": total, "sampler/total_shards": total},
         )
 
@@ -247,6 +248,7 @@ def sample_normalized_shards(
         return NormalizedData(
             main_output_dir=main_out,
             dup_output_dir=source.dup_output_dir,
+            num_partitions=1,
             counters={
                 "sampler/selected_shards": 1,
                 "sampler/total_shards": total,
@@ -287,6 +289,7 @@ def sample_normalized_shards(
     return NormalizedData(
         main_output_dir=main_out,
         dup_output_dir=source.dup_output_dir,
+        num_partitions=output_total,
         counters={
             "sampler/selected_shards": output_total,
             "sampler/total_shards": total,

--- a/lib/marin/src/marin/datakit/__init__.py
+++ b/lib/marin/src/marin/datakit/__init__.py
@@ -1,2 +1,24 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
+
+"""Datakit: composable pipeline stages with a standard Parquet format.
+
+The standard format pins three mandatory columns on every normalized record:
+``id`` (deterministic content hash), ``text`` (UTF-8 primary content), and
+``partition_id`` (int, the output shard the row was written to at normalize
+time). The shard count itself lives on the artifact, not the row.
+
+Downstream stages preserve ``partition_id`` and use it as the ``group_by`` key
+when a global shuffle (e.g. cross-document dedup) needs to land output back
+co-partitioned with the source.
+"""
+
+
+def partition_filename(partition_id: int, num_partitions: int) -> str:
+    """Return the standard datakit partition filename for the given index.
+
+    Datakit shards follow ``part-NNNNN-of-MMMMM.parquet`` naming. Routing
+    output through this helper keeps shuffler-written attribute files
+    discoverable by consolidate's filename-based join.
+    """
+    return f"part-{partition_id:05d}-of-{num_partitions:05d}.parquet"

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -5,9 +5,14 @@
 
 Reads raw files (JSONL, Parquet, etc.) discovered recursively under a single
 input directory, transforms each record into the standard schema (``id``,
-``text``, plus all original columns), deduplicates by content, sorts by ``id``
-within each partition, and writes Parquet output with
-``part-{shard}-of-{total}`` naming.
+``text``, ``partition_id``, plus all original columns), deduplicates by
+content, sorts by ``id`` within each partition, and writes Parquet output
+with ``part-{shard}-of-{total}`` naming.
+
+``partition_id`` (int) is stamped at write time and equals the row's output
+shard index. The shard count itself lives on the artifact
+(``NormalizedData.num_partitions``) — downstream stages use the column as the
+``group_by`` key for global shuffles and the field for filename construction.
 
 All discovered files are merged into a single output: main records land in
 ``<output_path>/outputs/main/`` and (when dedup is enabled) duplicates land in
@@ -32,6 +37,7 @@ from zephyr import Dataset, ShardInfo, ZephyrContext, counters, write_parquet_fi
 from zephyr.readers import SUPPORTED_EXTENSIONS, load_file
 from zephyr.writers import ThreadedBatchWriter
 
+from marin.datakit import partition_filename
 from marin.execution.step_spec import StepSpec
 
 logger = logging.getLogger(__name__)
@@ -69,12 +75,19 @@ class NormalizedData(BaseModel):
     Attributes:
         main_output_dir: Directory containing the main output Parquet files.
         dup_output_dir: Directory containing the duplicate side output Parquet files.
+        num_partitions: Number of output shards. Matches the ``-of-NNNNN``
+            suffix in filenames and the ``partition_id`` column's value range
+            (``0 <= partition_id < num_partitions``). Downstream shufflers
+            need this to construct co-partitioned filenames without globbing.
+            ``None`` on legacy ``v1`` artifacts that pre-date the field;
+            always populated on ``v2``+ writes.
         counters: Aggregated zephyr counters.
     """
 
-    version: str = "v1"
+    version: str = "v2"
     main_output_dir: str
     dup_output_dir: str
+    num_partitions: int | None = None
     counters: dict[str, int]
 
 
@@ -260,8 +273,9 @@ def _make_split_writer(
         shard: ShardInfo,
     ) -> Iterator[dict[str, dict[str, Any]]]:
         # NOTE: we could add support for split_existing - but we intentionally don't
-        main_path = f"{output_dir}/outputs/main/part-{shard.shard_idx:05d}-of-{shard.total_shards:05d}.parquet"
-        dup_path = f"{output_dir}/outputs/dups/part-{shard.shard_idx:05d}-of-{shard.total_shards:05d}.parquet"
+        filename = partition_filename(shard.shard_idx, shard.total_shards)
+        main_path = f"{output_dir}/outputs/main/{filename}"
+        dup_path = f"{output_dir}/outputs/dups/{filename}"
 
         # Results are populated by each writer thread. Safe to read only after
         # the ThreadedBatchWriter context exits (which joins the thread).
@@ -278,6 +292,9 @@ def _make_split_writer(
             ThreadedBatchWriter(write_to(dup_path, "dup")) as dup_writer,
         ):
             for item in records:
+                # Stamp partition_id at the writer so it reflects the actual
+                # output shard, not anything inferred upstream of group_by.
+                item.data["partition_id"] = shard.shard_idx
                 if isinstance(item, MainOutput):
                     counters.increment("normalize/unique_records_out")
                     main_writer.submit(item.data)
@@ -444,6 +461,7 @@ def normalize_to_parquet(
     return NormalizedData(
         main_output_dir=os.path.join(output_path, "outputs/main"),
         dup_output_dir=os.path.join(output_path, "outputs/dups"),
+        num_partitions=num_shards,
         counters=counters_dict,
     )
 
@@ -463,6 +481,7 @@ def normalize_step(
     relative_input_path: str | None = None,
     file_extensions: tuple[str, ...] | None = None,
     dedup_mode: DedupMode = DedupMode.EXACT,
+    version: str | None = None,
 ) -> StepSpec:
     """Create a StepSpec that normalizes downloaded data to Parquet.
 
@@ -485,6 +504,14 @@ def normalize_step(
             ``zephyr.readers.load_file``.
         dedup_mode: How to deduplicate records within each output shard.
             Defaults to ``DedupMode.EXACT``; use ``DedupMode.NONE`` to skip.
+        version: Opt-in cache-invalidation knob. When set (e.g. ``"v2"``),
+            the value is included in ``hash_attrs`` so the step's ``hash_id``
+            differs from any prior cached run. Use this when you need
+            ``partition_id``-aware downstream consumers and are willing to
+            recompute. Default ``None`` keeps cache identity with pre-v2
+            step specs — ``normalize_to_parquet`` itself always stamps
+            ``partition_id``, so existing caches stay hits but new runs still
+            produce v2 output.
     """
     if relative_input_path:
         # ``os.path.join`` collapses redundant separators when ``download.output_path``
@@ -494,6 +521,20 @@ def normalize_step(
         resolved_input = os.path.join(download.output_path, relative_input_path)
     else:
         resolved_input = download.output_path
+
+    hash_attrs: dict[str, Any] = {
+        "text_field": text_field,
+        "id_field": id_field,
+        "target_partition_bytes": target_partition_bytes,
+        "max_whitespace_run_chars": max_whitespace_run_chars,
+        "relative_input_path": relative_input_path,
+        "file_extensions": file_extensions,
+        "dedup_mode": dedup_mode,
+    }
+    # Only include the version key when the caller explicitly opts in, so
+    # default callers preserve their existing hash_id and cache hits.
+    if version is not None:
+        hash_attrs["version"] = version
 
     return StepSpec(
         name=name,
@@ -510,15 +551,7 @@ def normalize_step(
             dedup_mode=dedup_mode,
         ),
         deps=[download],
-        hash_attrs={
-            "text_field": text_field,
-            "id_field": id_field,
-            "target_partition_bytes": target_partition_bytes,
-            "max_whitespace_run_chars": max_whitespace_run_chars,
-            "relative_input_path": relative_input_path,
-            "file_extensions": file_extensions,
-            "dedup_mode": dedup_mode,
-        },
+        hash_attrs=hash_attrs,
         output_path_prefix=output_path_prefix,
         override_output_path=override_output_path,
     )

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
@@ -107,6 +107,15 @@ def _validate_inputs(inputs: list[MinHashAttrData]) -> MinHashParams:
             )
         seen[m.source_main_dir] = i
 
+    legacy = [i for i, m in enumerate(inputs) if m.num_partitions is None]
+    if legacy:
+        raise ValueError(
+            f"MinHashAttrData inputs at indices {legacy} are missing num_partitions "
+            "(legacy v1 artifact). Re-run minhash to regenerate the artifact with "
+            "num_partitions populated; fuzzy dedup needs it to construct co-partitioned "
+            "output filenames."
+        )
+
     return head
 
 
@@ -281,7 +290,11 @@ def compute_fuzzy_dups_attrs(
     params = _validate_inputs(inputs)
     source_tag = _assign_source_tags(inputs)
     attr_files = _list_attr_files(inputs, source_tag)
-    source_tag_to_num_partitions: dict[str, int] = {source_tag[m.source_main_dir]: m.num_partitions for m in inputs}
+    # `_validate_inputs` guarantees every input has `num_partitions` populated.
+    source_tag_to_num_partitions: dict[str, int] = {}
+    for m in inputs:
+        assert m.num_partitions is not None
+        source_tag_to_num_partitions[source_tag[m.source_main_dir]] = m.num_partitions
 
     logger.info(
         "Computing fuzzy dups for %d inputs (%d total shards) → %s, params=%s",

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
@@ -34,14 +34,13 @@ artifacts produces fresh markers without re-reading any source text.
 from __future__ import annotations
 
 import logging
-import os
 from collections.abc import Iterator
-from typing import Any
 
 from fray import ResourceConfig
 from pydantic import BaseModel
 from zephyr import Dataset, ZephyrContext, counters, write_parquet_file
 
+from marin.datakit import partition_filename
 from marin.execution.artifact import Artifact
 from marin.execution.step_spec import StepSpec
 from marin.processing.classification.deduplication.connected_components import connected_components
@@ -111,37 +110,28 @@ def _validate_inputs(inputs: list[MinHashAttrData]) -> MinHashParams:
     return head
 
 
-def _build_shard_index(inputs: list[MinHashAttrData]) -> tuple[list[dict[str, Any]], dict[str, str]]:
-    """Enumerate every source shard across *inputs* and assign a global file_idx.
+def _assign_source_tags(inputs: list[MinHashAttrData]) -> dict[str, str]:
+    """Assign a deterministic ``source_NNN`` tag per input ``source_main_dir``.
 
-    Returns:
-        (entries, source_tag_for_input) where ``entries[file_idx]`` holds
-        ``{attr_path, source_main_dir, source_tag, basename}`` and
-        ``source_tag_for_input[source_main_dir] = "source_NNN"``.
+    Sorting by ``source_main_dir`` keeps tags stable regardless of the order
+    callers happen to pass inputs in. Returns ``{source_main_dir: source_tag}``.
     """
-    # Sort inputs by source_main_dir so source_tags are deterministic regardless
-    # of the order callers happen to pass them in.
-    ordered = sorted(enumerate(inputs), key=lambda iv: iv[1].source_main_dir)
     source_tag: dict[str, str] = {}
-    for new_idx, (_, m) in enumerate(ordered):
+    for new_idx, m in enumerate(sorted(inputs, key=lambda m: m.source_main_dir)):
         source_tag[m.source_main_dir] = f"source_{new_idx:03d}"
+    return source_tag
 
-    entries: list[dict[str, Any]] = []
+
+def _list_attr_files(inputs: list[MinHashAttrData], source_tag: dict[str, str]) -> list[dict[str, str]]:
+    """Return ``[{attr_path, source_tag}, ...]`` for every attr shard across *inputs*."""
+    files: list[dict[str, str]] = []
     for m in inputs:
         attr_shards = sorted(fsspec_glob(f"{m.attr_dir.rstrip('/')}/*.parquet"))
         if not attr_shards:
             raise FileNotFoundError(f"No attr parquet shards under {m.attr_dir}")
         for attr_path in attr_shards:
-            entries.append(
-                {
-                    "file_idx": len(entries),
-                    "attr_path": attr_path,
-                    "source_main_dir": m.source_main_dir,
-                    "source_tag": source_tag[m.source_main_dir],
-                    "basename": os.path.basename(attr_path),
-                }
-            )
-    return entries, source_tag
+            files.append({"attr_path": attr_path, "source_tag": source_tag[m.source_main_dir]})
+    return files
 
 
 # Separator between the per-source CC tag and the original content-hash id.
@@ -157,42 +147,60 @@ def _cc_id(source_tag: str, doc_id: str) -> str:
     inputs can carry byte-identical normalized ids (e.g. exact text overlap
     across datasets), and without this prefix they collapse to a single
     node — under-reporting dups and potentially clobbering co-partitioned
-    attr files. The prefix is stripped in :func:`_strip_cc_prefix` before
-    the final attr parquet is written.
+    attr files. The prefix is recovered in :func:`_split_cc_id` before the
+    final attr parquet is written.
     """
     return f"{source_tag}{_CC_ID_SEP}{doc_id}"
 
 
-def _strip_cc_prefix(record_id: str) -> str:
-    """Reverse :func:`_cc_id`, returning the original ``doc_id``."""
-    return record_id.split(_CC_ID_SEP, 1)[1]
+def _split_cc_id(record_id: str) -> tuple[str, str]:
+    """Reverse :func:`_cc_id`, returning ``(source_tag, doc_id)``."""
+    source_tag, doc_id = record_id.split(_CC_ID_SEP, 1)
+    return source_tag, doc_id
 
 
-def _emit_bucket_records(entries: list[dict[str, Any]]) -> Iterator[dict]:
-    """For each (bucket, id) pair across all attr shards in *entries*, emit a routing record."""
-    for entry in entries:
-        for batch in _load_batches(entry["attr_path"], columns=["id", "buckets"]):
+def _emit_bucket_records(group: list[dict[str, str]]) -> Iterator[dict]:
+    """For each (bucket, id) pair across all attr shards in *group*, emit a routing record.
+
+    ``CCInput.file_idx`` is an opaque routing payload: we stuff each row's
+    source-stamped ``partition_id`` (read directly from the attr parquet
+    column) into it so the post-CC writer can reconstruct co-partitioned
+    output filenames without re-globbing the source tree.
+    """
+    for entry in group:
+        for batch in _load_batches(entry["attr_path"], columns=["id", "partition_id", "buckets"]):
             ids = batch["id"]
+            partition_ids = batch["partition_id"]
             buckets_col = batch["buckets"]
-            for doc_id, doc_buckets in zip(ids, buckets_col, strict=True):
+            for doc_id, partition_id, doc_buckets in zip(ids, partition_ids, buckets_col, strict=True):
                 if not doc_buckets.is_valid:
                     continue
                 cc_id = _cc_id(entry["source_tag"], doc_id.as_py())
+                p_id = partition_id.as_py()
                 for b in doc_buckets.as_py():
-                    yield {"bucket": str(b), "id": cc_id, "file_idx": entry["file_idx"]}
+                    yield {"bucket": str(b), "id": cc_id, "file_idx": p_id}
 
 
-def _make_per_shard_writer(output_path: str, entries: list[dict[str, Any]], counter_prefix: str):
+def _make_per_shard_writer(
+    output_path: str,
+    source_tag_to_num_partitions: dict[str, int],
+    counter_prefix: str,
+):
     """Return a group_by reducer that writes per-shard cluster-annotation parquet files.
 
-    Skips singletons entirely. For every non-singleton cluster member, writes
+    Group key is ``(source_tag, partition_id)``: the writer reconstructs the
+    output filename via ``partition_filename`` so attr files stay in lockstep
+    with the source's ``part-NNNNN-of-MMMMM.parquet`` naming and consolidate's
+    filename-rebase join keeps finding them. Skips singletons entirely. For
+    every non-singleton cluster member, writes
     ``{id, attributes: {dup_cluster_id, is_cluster_canonical}}``. Rows are
     already sorted by ``id`` thanks to the upstream ``group_by(sort_by=id)``.
     """
 
-    def aggregate(file_idx: int, records: Iterator[dict]) -> dict:
-        entry = entries[file_idx]
-        out_path = f"{output_path}/outputs/{entry['source_tag']}/{entry['basename']}"
+    def aggregate(group_key: tuple[str, int], records: Iterator[dict]) -> dict:
+        source_tag, partition_id = group_key
+        num_partitions = source_tag_to_num_partitions[source_tag]
+        out_path = f"{output_path}/outputs/{source_tag}/{partition_filename(partition_id, num_partitions)}"
 
         cluster_members = 0
         canonicals = 0
@@ -219,8 +227,8 @@ def _make_per_shard_writer(output_path: str, entries: list[dict[str, Any]], coun
         result = write_parquet_file(cluster_member_rows(), out_path)
         return {
             **result,
-            "file_idx": file_idx,
-            "source_tag": entry["source_tag"],
+            "source_tag": source_tag,
+            "partition_id": partition_id,
             "cluster_members": cluster_members,
             "canonicals": canonicals,
         }
@@ -271,12 +279,14 @@ def compute_fuzzy_dups_attrs(
         FileNotFoundError: If any input ``attr_dir`` is missing parquet shards.
     """
     params = _validate_inputs(inputs)
-    entries, source_tag = _build_shard_index(inputs)
+    source_tag = _assign_source_tags(inputs)
+    attr_files = _list_attr_files(inputs, source_tag)
+    source_tag_to_num_partitions: dict[str, int] = {source_tag[m.source_main_dir]: m.num_partitions for m in inputs}
 
     logger.info(
         "Computing fuzzy dups for %d inputs (%d total shards) → %s, params=%s",
         len(inputs),
-        len(entries),
+        len(attr_files),
         output_path,
         params,
     )
@@ -290,15 +300,15 @@ def compute_fuzzy_dups_attrs(
         ctx_kwargs["coordinator_resources"] = coordinator_resources
     ctx = ZephyrContext(**ctx_kwargs)
 
-    # Cap shard count at max_parallelism. Each group reads its attr files
-    # sequentially and emits bucket records; file_idx is preserved on the entry
-    # itself, not by enumeration order, so grouping is safe.
-    n_groups = min(max_parallelism, len(entries))
-    entry_groups: list[list[dict[str, Any]]] = [[] for _ in range(n_groups)]
-    for i, entry in enumerate(entries):
-        entry_groups[i % n_groups].append(entry)
+    # Cap fan-out at max_parallelism. Each group reads its attr files
+    # sequentially and emits bucket records; partition_id rides on each row
+    # in the parquet itself, so chunking by file order is safe.
+    n_groups = min(max_parallelism, len(attr_files))
+    file_groups: list[list[dict[str, str]]] = [[] for _ in range(n_groups)]
+    for i, af in enumerate(attr_files):
+        file_groups[i % n_groups].append(af)
 
-    bucket_ds = Dataset.from_list(entry_groups).flat_map(_emit_bucket_records)
+    bucket_ds = Dataset.from_list(file_groups).flat_map(_emit_bucket_records)
     converged, cc_files = connected_components(
         bucket_ds,
         ctx,
@@ -310,26 +320,34 @@ def compute_fuzzy_dups_attrs(
         # TODO (rav): log the number of changed nodes?
         logger.warning("Connected components did not converge")
 
-    aggregator = _make_per_shard_writer(output_path, entries, counter_prefix="dedup/fuzzy/document")
+    aggregator = _make_per_shard_writer(
+        output_path,
+        source_tag_to_num_partitions,
+        counter_prefix="dedup/fuzzy/document",
+    )
 
     # CC's Hash-to-Min guarantees component_id == min(id_norm) across a cluster,
     # so `component_id == id_norm` cheaply identifies the natural canonical.
     # `preserve_singletons=True` wires singletons as self-links, so a node is a
     # singleton iff its adjacency_list is exactly [id_norm] — no cluster peers.
+    def _enrich(r: dict) -> dict:
+        source_tag_str, doc_id = _split_cc_id(r["record_id"])
+        return {
+            "id": doc_id,
+            "source_tag": source_tag_str,
+            # CC's file_idx slot carried partition_id through the shuffle.
+            "partition_id": r["file_idx"],
+            "component_id": r["component_id"],
+            "is_canonical": r["component_id"] == r["id_norm"],
+            "is_singleton": len(r["adjacency_list"]) == 1 and r["adjacency_list"][0] == r["id_norm"],
+        }
+
     shard_pipeline = (
         Dataset.from_list(cc_files)
         .load_parquet()
-        .map(
-            lambda r: {
-                "id": _strip_cc_prefix(r["record_id"]),
-                "component_id": r["component_id"],
-                "is_canonical": r["component_id"] == r["id_norm"],
-                "is_singleton": len(r["adjacency_list"]) == 1 and r["adjacency_list"][0] == r["id_norm"],
-                "file_idx": r["file_idx"],
-            }
-        )
+        .map(_enrich)
         .group_by(
-            lambda r: r["file_idx"],
+            lambda r: (r["source_tag"], r["partition_id"]),
             sort_by=lambda r: r["id"],
             reducer=aggregator,
         )

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
@@ -65,7 +65,10 @@ class MinHashAttrData(BaseModel):
             ``buckets: list[str]``.
         num_partitions: Number of source partitions. Copied from
             ``NormalizedData.num_partitions``; downstream shufflers use it to
-            reconstruct co-partitioned filenames without globbing.
+            reconstruct co-partitioned filenames without globbing. ``None`` on
+            legacy ``v1`` artifacts that pre-date the field; always populated
+            on ``v2``+ writes. Consumers that need it (e.g. ``fuzzy_dups``)
+            validate this explicitly.
         counters: Aggregated zephyr counters.
     """
 
@@ -73,7 +76,7 @@ class MinHashAttrData(BaseModel):
     params: MinHashParams
     source_main_dir: str
     attr_dir: str
-    num_partitions: int
+    num_partitions: int | None = None
     counters: dict[str, int]
 
 

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
@@ -60,24 +60,31 @@ class MinHashAttrData(BaseModel):
         source_main_dir: Source ``NormalizedData.main_output_dir`` whose shards
             this dataset mirrors 1:1.
         attr_dir: Directory containing per-shard attr Parquet files. Filenames
-            mirror the source shards. Each row has ``id: str`` and
+            mirror the source shards. Each row has ``id: str``,
+            ``partition_id: int`` (passed through from the source row), and
             ``buckets: list[str]``.
+        num_partitions: Number of source partitions. Copied from
+            ``NormalizedData.num_partitions``; downstream shufflers use it to
+            reconstruct co-partitioned filenames without globbing.
         counters: Aggregated zephyr counters.
     """
 
-    version: str = "v1"
+    version: str = "v2"
     params: MinHashParams
     source_main_dir: str
     attr_dir: str
+    num_partitions: int
     counters: dict[str, int]
 
 
 def _attr_records(batch: pa.RecordBatch, params: MinHashParams) -> list[dict]:
     """Run the dupekit MinHash+LSH pipeline on *batch* and yield attr records.
 
-    Yields one ``{id, buckets}`` record per input document with at least one
-    bucket. Documents whose signature column is null (empty/whitespace text
-    after cleaning) are dropped and counted via ``minhash/empty_signatures``.
+    Yields one ``{id, partition_id, buckets}`` record per input document with
+    at least one bucket. Documents whose signature column is null
+    (empty/whitespace text after cleaning) are dropped and counted via
+    ``minhash/empty_signatures``. ``partition_id`` is passed through unchanged
+    so downstream shufflers can route output back to the source partition.
     """
     pipeline = [
         dupekit.Transformation.CleanText(input_col="text", output_col="clean_text"),
@@ -89,27 +96,28 @@ def _attr_records(batch: pa.RecordBatch, params: MinHashParams) -> list[dict]:
             seed=params.seed,
         ),
         dupekit.Transformation.MinHashLSH(input_col="signature", output_col="buckets", num_bands=params.num_bands),
-        dupekit.Transformation.SelectColumns(columns=["id", "buckets"]),
+        dupekit.Transformation.SelectColumns(columns=["id", "partition_id", "buckets"]),
     ]
     result_batch = dupekit.transform(batch, pipeline)
     ids = result_batch["id"]
+    partition_ids = result_batch["partition_id"]
     buckets_col = result_batch["buckets"]
 
     out: list[dict] = []
-    for doc_id, doc_buckets in zip(ids, buckets_col, strict=True):
+    for doc_id, partition_id, doc_buckets in zip(ids, partition_ids, buckets_col, strict=True):
         if not doc_buckets.is_valid:
             counters.increment("minhash/empty_signatures")
             continue
         bucket_strs = [str(b) for b in doc_buckets.as_py()]
         counters.increment("minhash/documents")
         counters.increment("minhash/buckets", len(bucket_strs))
-        out.append({"id": doc_id.as_py(), "buckets": bucket_strs})
+        out.append({"id": doc_id.as_py(), "partition_id": partition_id.as_py(), "buckets": bucket_strs})
     return out
 
 
 def _shard_attr_records(shard_path: str, params: MinHashParams) -> Iterator[dict]:
-    """Stream ``{id, buckets}`` attr records for one source parquet shard."""
-    for batch in _load_batches(shard_path, columns=["id", "text"]):
+    """Stream ``{id, partition_id, buckets}`` attr records for one source parquet shard."""
+    for batch in _load_batches(shard_path, columns=["id", "partition_id", "text"]):
         yield from _attr_records(batch, params)
 
 
@@ -127,9 +135,10 @@ def compute_minhash_attrs(
     """Compute MinHash bucket attributes for *source* and persist as Parquet.
 
     Each source shard under ``source.main_output_dir`` produces a same-named
-    attr file under ``<output_path>/outputs/`` with columns ``id`` and
-    ``buckets`` (``list[str]``). The output dataset is co-partitioned with the
-    source per the datakit invariant.
+    attr file under ``<output_path>/outputs/`` with columns ``id``,
+    ``partition_id`` (passed through from the source), and ``buckets``
+    (``list[str]``). The output dataset is co-partitioned with the source per
+    the datakit invariant.
 
     Args:
         source: The normalized source dataset to read from.
@@ -191,6 +200,7 @@ def compute_minhash_attrs(
         params=params,
         source_main_dir=source.main_output_dir,
         attr_dir=attr_dir,
+        num_partitions=source.num_partitions,
         counters=dict(outcome.counters),
     )
 

--- a/tests/datakit/test_normalize.py
+++ b/tests/datakit/test_normalize.py
@@ -5,11 +5,13 @@
 
 import gzip
 import json
+import re
 from pathlib import Path
 
 import pyarrow.parquet as pq
 import pytest
 from fray import LocalClient, set_current_client
+from marin.datakit import partition_filename
 from marin.datakit.normalize import generate_id, normalize_to_parquet
 
 
@@ -215,6 +217,94 @@ def test_whitespace_compaction(tmp_path: Path, write_jsonl_gz):
     assert by_source["pathological"]["id"] == generate_id("before" + " " * 100 + "after")
     # Normal docs are untouched
     assert by_source["normal"]["text"] == "Hello world"
+
+
+def test_partition_id_stamped_single_shard(tmp_path: Path, write_jsonl_gz):
+    """Every output row carries an int partition_id; with a single shard it's 0."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+
+    write_jsonl_gz(
+        input_dir / "data.jsonl.gz",
+        [{"text": "doc one"}, {"text": "doc two"}, {"text": "doc three"}],
+    )
+
+    result = normalize_to_parquet(input_path=str(input_dir), output_path=str(output_dir))
+
+    assert result.num_partitions == 1
+    rows = _read_all_parquet(output_dir)
+    assert len(rows) == 3
+    assert all(isinstance(r["partition_id"], int) for r in rows)
+    assert all(r["partition_id"] == 0 for r in rows)
+
+    # Filename matches the helper's output and the single partition.
+    main_files = sorted((output_dir / "outputs" / "main").glob("*.parquet"))
+    assert [p.name for p in main_files] == [partition_filename(0, 1)]
+
+
+def test_partition_id_matches_filename_across_shards(tmp_path: Path, write_jsonl_gz):
+    """With multiple output shards, every row's partition_id matches its filename suffix."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+
+    # Varied per-record content so xxh3_128 distributes ids across shards;
+    # tiny target_partition_bytes forces multi-shard output.
+    records = [{"text": f"document {i} with unique content payload {i * 7919}"} for i in range(50)]
+    write_jsonl_gz(input_dir / "data.jsonl.gz", records)
+
+    result = normalize_to_parquet(
+        input_path=str(input_dir),
+        output_path=str(output_dir),
+        target_partition_bytes=50,
+    )
+
+    assert result.num_partitions > 1
+
+    main_dir = output_dir / "outputs" / "main"
+    files = sorted(main_dir.glob("*.parquet"))
+    assert files, "expected at least one output file"
+
+    seen_partition_ids: set[int] = set()
+    filename_re = re.compile(r"part-(\d+)-of-(\d+)\.parquet")
+    for pf in files:
+        m = filename_re.match(pf.name)
+        assert m, f"unexpected filename: {pf.name}"
+        expected_id = int(m.group(1))
+        assert int(m.group(2)) == result.num_partitions
+
+        rows = pq.read_table(str(pf)).to_pylist()
+        for row in rows:
+            assert row["partition_id"] == expected_id
+        if rows:
+            seen_partition_ids.add(expected_id)
+
+    # Sanity: hash distribution actually spread records across partitions.
+    assert len(seen_partition_ids) > 1
+
+
+def test_partition_id_stamped_on_dup_side_output(tmp_path: Path, write_jsonl_gz):
+    """Duplicate records also receive partition_id matching their dup-shard filename."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+
+    write_jsonl_gz(
+        input_dir / "data.jsonl.gz",
+        [
+            {"text": "Duplicate text", "source": "first"},
+            {"text": "Duplicate text", "source": "second"},
+            {"text": "Unique text"},
+        ],
+    )
+
+    normalize_to_parquet(input_path=str(input_dir), output_path=str(output_dir))
+
+    dup_files = sorted((output_dir / "outputs" / "dups").glob("*.parquet"))
+    assert dup_files, "expected at least one dup-side output"
+    dup_rows: list[dict] = []
+    for pf in dup_files:
+        dup_rows.extend(pq.read_table(str(pf)).to_pylist())
+    assert len(dup_rows) == 1
+    assert dup_rows[0]["partition_id"] == 0
 
 
 def test_no_input_files_raises(tmp_path: Path):

--- a/tests/datakit_testbed/test_sampler.py
+++ b/tests/datakit_testbed/test_sampler.py
@@ -30,7 +30,12 @@ def _make_normalized(tmp_path: Path, shards: dict[str, list[str]]) -> Normalized
     dup_dir.mkdir(parents=True, exist_ok=True)
     for rel, ids in shards.items():
         _write_normalized_shard(main_dir / rel, ids)
-    return NormalizedData(main_output_dir=str(main_dir), dup_output_dir=str(dup_dir), counters={})
+    return NormalizedData(
+        main_output_dir=str(main_dir),
+        dup_output_dir=str(dup_dir),
+        num_partitions=len(shards),
+        counters={},
+    )
 
 
 def test_sample_takes_first_k_deterministically(tmp_path: Path):
@@ -111,6 +116,7 @@ def test_sample_no_shards_raises(tmp_path: Path):
     source = NormalizedData(
         main_output_dir=str(empty),
         dup_output_dir=str(tmp_path / "d"),
+        num_partitions=0,
         counters={},
     )
     with pytest.raises(ValueError, match="No parquet shards"):

--- a/tests/processing/classification/deduplication/test_fuzzy.py
+++ b/tests/processing/classification/deduplication/test_fuzzy.py
@@ -253,6 +253,20 @@ def test_fuzzy_dups_rejects_param_mismatch(fox_corpus):
         )
 
 
+def test_fuzzy_dups_rejects_legacy_v1_input(fox_corpus):
+    """Inputs missing num_partitions (legacy v1 cached artifacts) must be rejected with a clear message."""
+    source = _normalize(fox_corpus["test_dir"], os.path.join(fox_corpus["output_dir"], "norm"))
+    mh = compute_minhash_attrs(source=source, output_path=os.path.join(fox_corpus["output_dir"], "mh"))
+    legacy = mh.model_copy(update={"num_partitions": None})
+
+    with pytest.raises(ValueError, match=r"missing num_partitions.*Re-run minhash"):
+        compute_fuzzy_dups_attrs(
+            inputs=[legacy],
+            output_path=os.path.join(fox_corpus["output_dir"], "fuzzy_dups"),
+            max_parallelism=4,
+        )
+
+
 def test_fuzzy_dups_rejects_duplicate_source(fox_corpus):
     """Two inputs pointing to the same ``source_main_dir`` must be rejected to avoid output clobbering."""
     source = _normalize(fox_corpus["test_dir"], os.path.join(fox_corpus["output_dir"], "norm"))

--- a/tests/processing/classification/deduplication/test_fuzzy.py
+++ b/tests/processing/classification/deduplication/test_fuzzy.py
@@ -53,20 +53,26 @@ def _write_minhash_attr_dataset(
     source_main_dir: str,
     rows: list[dict],
 ) -> MinHashAttrData:
-    """Write a one-shard MinHash attr dataset for focused fuzzy-dup tests."""
+    """Write a one-shard MinHash attr dataset for focused fuzzy-dup tests.
+
+    Each row is stamped with ``partition_id=0`` so it routes through
+    fuzzy_dups' partition-aware writer; ``num_partitions=1`` on the artifact.
+    """
     attr_dir = os.path.join(output_dir, "outputs")
     Path(attr_dir).mkdir(parents=True, exist_ok=True)
-    write_parquet_file(rows, os.path.join(attr_dir, "part-00000.parquet"))
+    rows_with_partition = [{**r, "partition_id": 0} for r in rows]
+    write_parquet_file(rows_with_partition, os.path.join(attr_dir, "part-00000-of-00001.parquet"))
     return MinHashAttrData(
         params=TEST_MINHASH_PARAMS,
         source_main_dir=source_main_dir,
         attr_dir=attr_dir,
+        num_partitions=1,
         counters={},
     )
 
 
 def test_minhash_attrs_co_partitioned_with_source(fox_corpus):
-    """Each source shard produces a same-named MinHash attr parquet with {id, buckets}."""
+    """Each source shard produces a same-named MinHash attr parquet with {id, partition_id, buckets}."""
     norm_dir = os.path.join(fox_corpus["output_dir"], "normalized")
     minhash_dir = os.path.join(fox_corpus["output_dir"], "minhash")
 
@@ -74,6 +80,7 @@ def test_minhash_attrs_co_partitioned_with_source(fox_corpus):
     minhash = compute_minhash_attrs(source=source, output_path=minhash_dir)
 
     assert minhash.source_main_dir == source.main_output_dir
+    assert minhash.num_partitions == source.num_partitions
     assert minhash.params.num_perms == 286
     assert minhash.params.num_bands == 26
 
@@ -82,7 +89,7 @@ def test_minhash_attrs_co_partitioned_with_source(fox_corpus):
     assert source_basenames == attr_basenames
     assert source_basenames  # non-empty
 
-    # At least one non-empty shard exists with the expected {id, buckets} schema.
+    # At least one non-empty shard exists with {id, partition_id, buckets}.
     # Empty source shards produce empty attr parquets with no schema, which we skip.
     seen_non_empty = False
     for pf in Path(minhash.attr_dir).glob("*.parquet"):
@@ -92,6 +99,8 @@ def test_minhash_attrs_co_partitioned_with_source(fox_corpus):
         seen_non_empty = True
         rec = rows[0]
         assert isinstance(rec["id"], str)
+        assert isinstance(rec["partition_id"], int)
+        assert 0 <= rec["partition_id"] < source.num_partitions
         assert isinstance(rec["buckets"], list)
         assert all(isinstance(b, str) for b in rec["buckets"])
     assert seen_non_empty, "expected at least one non-empty MinHash attr shard"


### PR DESCRIPTION
* part of https://github.com/marin-community/marin/issues/2355
* stacked on top of #5437 — base is `rav-normalize-add-partition-id` so the diff shows only fuzzy/dedup changes; rebase onto `main` once #5437 lands
* fuzzy dedup routes records back to their source partition via the `partition_id` row column (stamped by #5437) instead of reconstructing a filesystem enumeration
* `MinHashAttrData` widens to `{id, partition_id, buckets}` and gains optional `num_partitions: int | None` (cached `v1` artifacts still load); bumped to `v2`
* fuzzy_dups drops `_build_shard_index`/`file_idx`; reads `partition_id` from the parquet column, stuffs it into CC's opaque routing slot, post-CC groups by `(source_tag, partition_id)` and writes filenames via `partition_filename(p_id, num_partitions)` so consolidate's filename-rebase join keeps working
* `compute_fuzzy_dups_attrs._validate_inputs` fails fast with a clear "re-run minhash" message when a legacy `v1` `MinHashAttrData` (no `num_partitions`) is fed in, instead of a cryptic format-string crash inside the per-shard writer
* CC's `CCInput.file_idx` stays an opaque routing payload — documented inline rather than renaming a generic graph algo's field after a domain concept
* exact dedup intentionally not migrated — its `file_idx` enumerates raw input files (jsonl/parquet/etc) and uses `rebase_file_path` for outputs, so it already produces co-partitioned attr files when fed normalized parquet