### PR TITLE
Fix Levanter profiler double-stop

### DIFF
--- a/lib/levanter/src/levanter/callbacks/profiler.py
+++ b/lib/levanter/src/levanter/callbacks/profiler.py
@@ -42,40 +42,55 @@ class ProfilerConfig:
         return max(0, total_prof_steps)
 
 
-def profile(path: str, start_step: int, num_steps: int, create_perfetto_link: bool) -> Callable[[StepInfo], None]:
+def profile(
+    path: str,
+    start_step: int,
+    num_steps: int,
+    create_perfetto_link: bool,
+) -> Callable[[StepInfo], None]:
     artifact_name = f"jax-profile-step-{start_step}-{start_step + num_steps}"
+    started = False
+    stopped = False
 
-    def profiler_callback_fn(step: StepInfo):
+    def profiler_callback_fn(step: StepInfo, force: bool = False):
+        nonlocal started, stopped
         # -1 b/c step is the finished step
         if step.step == start_step - 1:
-            _create_perfetto_link = create_perfetto_link and jax.process_index() == 0
-            logger.info(f"Starting profiler until step {start_step + num_steps}.")
-            jax.profiler.start_trace(path, create_perfetto_link=_create_perfetto_link, create_perfetto_trace=True)
+            if not started and not stopped:
+                _create_perfetto_link = create_perfetto_link and jax.process_index() == 0
+                logger.info(f"Starting profiler until step {start_step + num_steps}.")
+                jax.profiler.start_trace(path, create_perfetto_link=_create_perfetto_link, create_perfetto_trace=True)
+                started = True
         elif step.step == start_step + num_steps - 1:
-            if create_perfetto_link:
-                logger.info(
-                    f"Stopping profiler. Process 0 will open a perfetto link. I am process {jax.process_index()}"
-                )
-            else:
-                logger.info("Stopping profiler.")
-            # so, annoyingly, gcloud ssh doesn't reliably flush stdout here, so we need to spin up
-            # a thread to flush and print periodically until we make it past stop_trace
-            # (note: stop_trace blocks if perfetto is enabled)
-            event = threading.Event()
-            if create_perfetto_link and jax.process_index() == 0:
-                _flush_while_waiting(event)
+            if not stopped:
+                stopped = True
+                if not started:
+                    logger.warning("Profiler stop requested, but this process did not start a profile trace.")
+                else:
+                    if create_perfetto_link:
+                        logger.info(
+                            f"Stopping profiler. Process 0 will open a perfetto link. I am process {jax.process_index()}"
+                        )
+                    else:
+                        logger.info("Stopping profiler.")
+                    # so, annoyingly, gcloud ssh doesn't reliably flush stdout here, so we need to spin up
+                    # a thread to flush and print periodically until we make it past stop_trace
+                    # (note: stop_trace blocks if perfetto is enabled)
+                    event = threading.Event()
+                    if create_perfetto_link and jax.process_index() == 0:
+                        _flush_while_waiting(event)
 
-            jax.profiler.stop_trace()
+                    jax.profiler.stop_trace()
 
-            if create_perfetto_link and jax.process_index() == 0:
-                event.set()
+                    if create_perfetto_link and jax.process_index() == 0:
+                        event.set()
 
-            levanter.tracker.current_tracker().log_artifact(
-                path,
-                name=artifact_name,
-                type="jax_profile",
-            )
-            barrier_sync()
+                    levanter.tracker.current_tracker().log_artifact(
+                        path,
+                        name=artifact_name,
+                        type="jax_profile",
+                    )
+                barrier_sync()
 
     return profiler_callback_fn
 


### PR DESCRIPTION
## Summary

Fixes #5527.

- Make the Levanter profiler callback idempotent across final forced hook execution.
- Track whether the profiler callback actually started and already stopped before calling `jax.profiler.stop_trace()`.

## Problem

Short Grug runs can clamp the profiler stop step to the final completed step. Grug then force-runs callbacks after the loop before checkpointing, so the previous profiler callback could see the same stop step twice and call `jax.profiler.stop_trace()` twice. The second stop raises `RuntimeError: No profile started`.

This PR intentionally does not address the separate B200 first-stop hang (#5528), the original H100 profiler segfault (#5509), or the Iris Kubernetes exec client issue (#5529).

## Validation

- `./infra/pre-commit.py --fix lib/levanter/src/levanter/callbacks/profiler.py`
- `uv run python -m compileall lib/levanter/src/levanter/callbacks/profiler.py`

🤖 Agent-generated fix PR.