### PR TITLE
[storage] Fix stale scripts.storage imports after move

### DIFF
--- a/scripts/ops/storage/distributed_scan.py
+++ b/scripts/ops/storage/distributed_scan.py
@@ -37,7 +37,8 @@ import google.auth
 import pyarrow as pa
 import pyarrow.parquet as pq
 from google.cloud import storage
-from scripts.storage.constants import (
+
+from scripts.ops.storage.constants import (
     ADAPTIVE_MAX_DEPTH,
     ADAPTIVE_SPLIT_THRESHOLD,
     BLOB_FIELDS,

--- a/scripts/ops/storage/report.py
+++ b/scripts/ops/storage/report.py
@@ -30,12 +30,13 @@ from pathlib import Path
 
 import click
 import duckdb
-from scripts.storage.constants import (
+from tqdm import tqdm
+
+from scripts.ops.storage.constants import (
     BUCKET_LOCATIONS,
     DISCOUNT_FACTOR,
     STORAGE_CLASS_PRICING,
 )
-from tqdm import tqdm
 
 
 def _download_gcs_parquet(gcs_dir: str, local_dir: Path) -> Path:


### PR DESCRIPTION
Imports in distributed_scan.py and report.py still referenced scripts.storage.constants after the directory move in #4965. Update them to scripts.ops.storage.constants so the modules import.