### PR TITLE
[finelog] Per-namespace catalog<->remote sync; delete CopyWorker

### DIFF
--- a/lib/finelog/src/finelog/store/catalog.py
+++ b/lib/finelog/src/finelog/store/catalog.py
@@ -9,13 +9,18 @@ Two tables in ``{data_dir}/_finelog_registry.duckdb``:
   ``RegisterTable`` mutates one row here. On finelog startup the table is
   read out and ``LogNamespace`` instances are rehydrated from the rows.
 
-* ``segments`` — one row per locally-tracked parquet file. Each
+* ``segments`` — one row per parquet segment in the table, regardless
+  of whether its bytes currently live on local disk, in the remote
+  bucket, or both (``location`` discriminates). Each
   :class:`DiskLogNamespace` writes here in lockstep with its in-memory
   ``_local_segments`` deque (insert on flush finalize, swap atomically on
-  compaction, delete on eviction). Aggregating this table answers every
-  shape-of-the-data query (row counts, seq ranges, byte totals,
-  per-namespace segment counts) without touching parquet — finelog's
-  catalog, in the Iceberg/ClickHouse-parts sense.
+  compaction, ``location`` flip on upload / eviction). Compaction drops
+  input rows immediately; the remote-sync loop reconciles the bucket
+  with the catalog and ``fs.rm``s any remote file that has no row.
+  Aggregating this table answers every shape-of-the-data query (row
+  counts, seq ranges, byte totals, per-namespace segment counts) without
+  touching parquet — finelog's catalog, in the Iceberg/ClickHouse-parts
+  sense.
 
 The DB is intentionally separate from the per-namespace Parquet directories:
 catalog metadata never lives in two places, so a row count or schema change
@@ -32,7 +37,8 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 
 import duckdb
@@ -45,6 +51,21 @@ logger = logging.getLogger(__name__)
 CATALOG_DB_FILENAME = "_finelog_registry.duckdb"
 
 
+class SegmentLocation(StrEnum):
+    """Where a segment's bytes currently live.
+
+    Every catalog row is part of the table; ``location`` says whether the
+    bytes are reachable from local disk, the remote bucket, or both. The
+    sync loop reconciles remote with catalog; eviction flips ``BOTH`` →
+    ``REMOTE`` rather than dropping the row, so a durable archive cannot
+    be confused with an orphan compaction input.
+    """
+
+    LOCAL = "LOCAL"
+    REMOTE = "REMOTE"
+    BOTH = "BOTH"
+
+
 @dataclass(frozen=True)
 class SegmentRow:
     """One persisted row in the segments catalog table.
@@ -55,10 +76,6 @@ class SegmentRow:
     column statistics for the namespace's declared ``Schema.key_column``.
     They are ``None`` for namespaces whose schema has no ``key_column``,
     or for empty segments where no statistics exist.
-    ``copied_at_ms`` is the wall-clock millisecond when the copy worker
-    reported a successful upload; ``None`` while the upload is still
-    pending. Eviction is gated on this so a fresh L1 cannot be deleted
-    before its remote copy is durable.
     """
 
     namespace: str
@@ -69,9 +86,9 @@ class SegmentRow:
     row_count: int
     byte_size: int
     created_at_ms: int
+    location: SegmentLocation = SegmentLocation.LOCAL
     min_key_value: str | None = None
     max_key_value: str | None = None
-    copied_at_ms: int | None = None
 
 
 @dataclass(frozen=True)
@@ -163,7 +180,7 @@ class Catalog:
 
     _SEGMENT_COLUMNS = (
         "namespace, path, level, min_seq, max_seq, row_count, byte_size, "
-        "created_at_ms, min_key_value, max_key_value, copied_at_ms"
+        "created_at_ms, min_key_value, max_key_value, location"
     )
 
     def list_segments(self, namespace: str, *, min_level: int = 0) -> list[SegmentRow]:
@@ -192,7 +209,7 @@ class Catalog:
             created_at_ms=r[7],
             min_key_value=r[8],
             max_key_value=r[9],
-            copied_at_ms=r[10],
+            location=SegmentLocation(r[10]),
         )
 
     def upsert_segment(self, segment: SegmentRow) -> None:
@@ -201,7 +218,7 @@ class Catalog:
             """
             INSERT INTO segments
                 (namespace, path, level, min_seq, max_seq, row_count, byte_size, created_at_ms,
-                 min_key_value, max_key_value, copied_at_ms)
+                 min_key_value, max_key_value, location)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT (namespace, path) DO UPDATE SET
                 level = excluded.level,
@@ -212,7 +229,7 @@ class Catalog:
                 created_at_ms = excluded.created_at_ms,
                 min_key_value = excluded.min_key_value,
                 max_key_value = excluded.max_key_value,
-                copied_at_ms = excluded.copied_at_ms
+                location = excluded.location
             """,
             [
                 segment.namespace,
@@ -225,7 +242,7 @@ class Catalog:
                 segment.created_at_ms,
                 segment.min_key_value,
                 segment.max_key_value,
-                segment.copied_at_ms,
+                segment.location.value,
             ],
         )
 
@@ -254,32 +271,6 @@ class Catalog:
         """Drop one segment row. Idempotent."""
         self._conn.execute("DELETE FROM segments WHERE namespace = ? AND path = ?", [namespace, path])
 
-    def reconcile_segments(self, namespace: str, segments: Sequence[SegmentRow]) -> None:
-        """Replace this namespace's segment rows wholesale (startup recovery).
-
-        Parquet files on disk are authoritative across crashes; on every
-        ``DiskLogNamespace`` boot we discover the on-disk segment set and
-        push it through this method so the catalog matches reality. The
-        prior rows' ``copied_at_ms`` stamps are carried forward for
-        unchanged paths so a successfully-uploaded segment doesn't lose
-        its eviction-eligible flag across a restart.
-        """
-        with transactional(self._conn):
-            prior_copied = {
-                row[0]: row[1]
-                for row in self._conn.execute(
-                    "SELECT path, copied_at_ms FROM segments WHERE namespace = ?",
-                    [namespace],
-                ).fetchall()
-            }
-            self._conn.execute("DELETE FROM segments WHERE namespace = ?", [namespace])
-            for seg in segments:
-                if seg.copied_at_ms is None:
-                    stamp = prior_copied.get(seg.path)
-                    if stamp is not None:
-                        seg = replace(seg, copied_at_ms=stamp)
-                self.upsert_segment(seg)
-
     def aggregate_namespace_stats(self, namespace: str) -> NamespaceStats:
         """Single-namespace aggregate over the segments table."""
         row = self._conn.execute(
@@ -305,24 +296,19 @@ class Catalog:
             segment_count=int(row[4]),
         )
 
-    def mark_copied(self, namespace: str, path: str, copied_at_ms: int) -> None:
-        """Record successful remote upload of one segment."""
+    def set_location(self, namespace: str, path: str, location: SegmentLocation) -> None:
+        """Update one segment's ``location`` (after upload completes / eviction)."""
         self._conn.execute(
-            "UPDATE segments SET copied_at_ms = ? WHERE namespace = ? AND path = ?",
-            [copied_at_ms, namespace, path],
+            "UPDATE segments SET location = ? WHERE namespace = ? AND path = ?",
+            [location.value, namespace, path],
         )
 
     def select_eviction_candidate(self, namespace: str) -> SegmentRow | None:
         """Pick the oldest evictable segment in ``namespace``.
 
-        Eligibility:
-
-        * ``level >= 1`` — L0 is local-only and transient, so it's never
-          evicted.
-        * ``copied_at_ms IS NOT NULL`` — a freshly compacted segment
-          becomes evictable only after the upload worker confirms the
-          remote copy is durable.
-
+        Eligibility: ``level >= 1`` (L0 is local-only and transient, so
+        never evicted) and ``location = 'BOTH'`` (a compaction output
+        becomes evictable only once the remote copy is durable).
         Returns the ``SegmentRow`` with the smallest ``min_seq``, or
         ``None`` when no eligible segment exists.
         """
@@ -332,11 +318,11 @@ class Catalog:
             FROM segments
             WHERE namespace = ?
               AND level >= 1
-              AND copied_at_ms IS NOT NULL
+              AND location = ?
             ORDER BY min_seq ASC
             LIMIT 1
             """,
-            [namespace],
+            [namespace, SegmentLocation.BOTH.value],
         ).fetchone()
         if row is None:
             return None

--- a/lib/finelog/src/finelog/store/catalog.py
+++ b/lib/finelog/src/finelog/store/catalog.py
@@ -166,10 +166,16 @@ class Catalog:
         "created_at_ms, min_key_value, max_key_value, copied_at_ms"
     )
 
-    def list_segments(self, namespace: str) -> list[SegmentRow]:
+    def list_segments(self, namespace: str, *, min_level: int = 0) -> list[SegmentRow]:
+        """Segment rows for ``namespace`` with ``level >= min_level``, ordered by ``min_seq``."""
         rows = self._conn.execute(
-            f"SELECT {self._SEGMENT_COLUMNS} FROM segments WHERE namespace = ? ORDER BY min_seq",
-            [namespace],
+            f"""
+            SELECT {self._SEGMENT_COLUMNS}
+            FROM segments
+            WHERE namespace = ? AND level >= ?
+            ORDER BY min_seq
+            """,
+            [namespace, min_level],
         ).fetchall()
         return [self._row_from_tuple(r) for r in rows]
 
@@ -305,23 +311,6 @@ class Catalog:
             "UPDATE segments SET copied_at_ms = ? WHERE namespace = ? AND path = ?",
             [copied_at_ms, namespace, path],
         )
-
-    def list_pending_copies(self) -> list[SegmentRow]:
-        """All L>=1 rows whose remote upload has not yet completed.
-
-        Ordered by ``min_seq`` so we drain oldest-first across the whole
-        store. This is the copy worker's only view into the catalog.
-        """
-        rows = self._conn.execute(
-            f"""
-            SELECT {self._SEGMENT_COLUMNS}
-            FROM segments
-            WHERE level >= 1
-              AND copied_at_ms IS NULL
-            ORDER BY namespace, min_seq
-            """
-        ).fetchall()
-        return [self._row_from_tuple(r) for r in rows]
 
     def select_eviction_candidate(self, namespace: str) -> SegmentRow | None:
         """Pick the oldest evictable segment in ``namespace``.

--- a/lib/finelog/src/finelog/store/duckdb_store.py
+++ b/lib/finelog/src/finelog/store/duckdb_store.py
@@ -15,8 +15,6 @@ from __future__ import annotations
 
 import logging
 import re
-import shutil
-import threading
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -24,7 +22,6 @@ from pathlib import Path
 from threading import Lock
 
 import duckdb
-import fsspec.core
 import pyarrow as pa
 import pyarrow.ipc as paipc
 
@@ -77,13 +74,6 @@ _DEFAULT_DUCKDB_THREADS = "4"
 # parent doesn't trip Linux's overcommit heuristic when forking subprocesses.
 EMBEDDED_DUCKDB_MEMORY_LIMIT = "128MB"
 EMBEDDED_DUCKDB_THREADS = "2"
-
-# Streaming chunk size for src->dst copy. 4 MiB keeps RAM usage flat regardless
-# of segment size while still amortizing per-write overhead on GCS.
-_COPY_CHUNK_BYTES = 4 * 1024 * 1024
-# How long ``close()`` waits for the copy worker to drain before forcing exit.
-_COPY_DRAIN_TIMEOUT_SEC = 10.0
-
 
 # Namespace names: lowercase ASCII alphanumerics + ._-, starting with a
 # letter, max 64 chars. Restrictive enough to be safe as both a directory
@@ -188,101 +178,6 @@ class ConnectionPool:
         self._conn.close()
 
 
-class CopyWorker:
-    """Polling background uploader for L>=1 catalog segments.
-
-    One worker per :class:`DuckDBLogStore`. Walks the catalog every
-    ``_POLL_INTERVAL_SEC`` (or sooner when woken) for ``level >= 1 AND
-    copied_at_ms IS NULL`` rows, streams each parquet to remote storage,
-    and stamps the row on success. Per-segment RAM footprint is bounded
-    by ``_COPY_CHUNK_BYTES``.
-
-    Decoupling from compaction means the copy policy is "anything
-    promoted to L1+ that doesn't yet have a remote copy" — the planner
-    doesn't know or care about uploads.
-    """
-
-    _POLL_INTERVAL_SEC = 5.0
-
-    def __init__(self, store: DuckDBLogStore, remote_log_dir: str) -> None:
-        self._store = store
-        self._remote_log_dir = remote_log_dir
-        self._stop = threading.Event()
-        self._wake = threading.Event()
-        self._thread = threading.Thread(target=self._run, name="finelog_copy", daemon=True)
-        self._thread.start()
-
-    def wake(self) -> None:
-        """Hint that new L>=1 segments may exist; speeds up the next pass."""
-        self._wake.set()
-
-    def wait_drained(self, timeout: float) -> bool:
-        """Block until the catalog has no L>=1 rows missing ``copied_at_ms``.
-
-        Returns True on drain, False on timeout.
-        """
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            self.wake()
-            with self._store._insertion_lock:
-                if not self._store._catalog.list_pending_copies():
-                    return True
-            time.sleep(0.05)
-        with self._store._insertion_lock:
-            return not self._store._catalog.list_pending_copies()
-
-    def close(self, timeout: float = _COPY_DRAIN_TIMEOUT_SEC) -> None:
-        self.wait_drained(timeout)
-        self._stop.set()
-        self._wake.set()
-        self._thread.join(timeout=timeout)
-
-    def _run(self) -> None:
-        while not self._stop.is_set():
-            try:
-                with self._store._insertion_lock:
-                    pending = self._store._catalog.list_pending_copies()
-            except Exception:
-                logger.warning("copy poll failed", exc_info=True)
-                pending = []
-            for row in pending:
-                if self._stop.is_set():
-                    break
-                completed_ms = self._upload(row.namespace, Path(row.path))
-                if completed_ms is not None:
-                    self._store._mark_copied(row.namespace, row.path, completed_ms)
-            self._wake.wait(timeout=self._POLL_INTERVAL_SEC)
-            self._wake.clear()
-
-    def _upload(self, namespace: str, local_path: Path) -> int | None:
-        """Stream ``local_path`` to the remote path. Returns completion ms
-        on success, ``None`` on failure (the catalog row stays unstamped
-        and the next poll retries)."""
-        remote_path = f"{self._remote_log_dir.rstrip('/')}/{namespace}/{local_path.name}"
-        upload_start = time.monotonic()
-        try:
-            with (
-                fsspec.core.open(str(local_path), "rb") as f_src,
-                fsspec.core.open(remote_path, "wb") as f_dst,
-            ):
-                shutil.copyfileobj(f_src, f_dst, length=_COPY_CHUNK_BYTES)
-        except Exception:
-            logger.warning("Failed to copy %s to %s", local_path, remote_path, exc_info=True)
-            return None
-        try:
-            size = local_path.stat().st_size
-        except OSError:
-            size = -1
-        logger.info(
-            "Copied %s to %s: bytes=%d elapsed_ms=%d",
-            local_path.name,
-            remote_path,
-            size,
-            int((time.monotonic() - upload_start) * 1000),
-        )
-        return int(time.time() * 1000)
-
-
 def _validate_namespace_name(name: str, data_dir: Path | None) -> Path | None:
     """Validate ``name`` and return its on-disk subdirectory (or ``None``)."""
     if not _NAMESPACE_NAME_RE.match(name):
@@ -343,22 +238,17 @@ class DuckDBLogStore:
         )
         self._catalog = Catalog(self._data_dir)
 
-        # Polling uploader: independent of compaction. Walks the catalog
-        # for L>=1 segments without ``copied_at_ms`` and uploads them.
-        # Only spun up when remote storage is configured.
-        self._copy_worker: CopyWorker | None = (
-            CopyWorker(self, remote_log_dir) if remote_log_dir and self._data_dir is not None else None
-        )
-
         self._namespace_registered_at: dict[str, int] = {}
         self._namespaces: dict[str, LogNamespaceProtocol] = {}
 
         # Disk-only kwargs; ignored by memory namespaces. ``duckdb_memory_limit``
         # in this dict feeds the per-namespace compaction connection in
         # ``DiskLogNamespace``; we route the dedicated compaction cap here so
-        # tier-merges don't share the read pool's tighter ceiling.
+        # tier-merges don't share the read pool's tighter ceiling. Each disk
+        # namespace owns its own remote sync — empty ``remote_log_dir``
+        # disables it.
         self._disk_namespace_kwargs = dict(
-            copy_wake=self._wake_copier,
+            remote_log_dir=remote_log_dir,
             flush_interval_sec=flush_interval_sec,
             compaction_config=compaction_config,
             segment_target_bytes=segment_target_bytes,
@@ -603,18 +493,6 @@ class DuckDBLogStore:
         finally:
             self._query_visibility_lock.write_release()
 
-    def _mark_copied(self, namespace: str, path: str, copied_at_ms: int) -> None:
-        """Worker-thread entry point for stamping the catalog after upload.
-
-        Eviction filters on ``copied_at_ms IS NOT NULL`` so a freshly
-        compacted segment becomes evictable only after the remote copy
-        is durable.
-        """
-        ns = self._namespaces.get(namespace)
-        if ns is None:
-            return
-        ns.mark_copied(path, copied_at_ms)
-
     def append(self, key: str, entries: list) -> None:
         if not entries:
             return
@@ -656,21 +534,8 @@ class DuckDBLogStore:
     def close(self) -> None:
         for ns in self._namespaces.values():
             ns.close()
-        if self._copy_worker is not None:
-            self._copy_worker.close()
         self._pool.close()
         self._catalog.close()
-
-    def _wake_copier(self) -> None:
-        """Hint the copy worker that fresh L>=1 segments may exist."""
-        if self._copy_worker is not None:
-            self._copy_worker.wake()
-
-    def _wait_for_copies(self, timeout: float = _COPY_DRAIN_TIMEOUT_SEC) -> bool:
-        """Block until the catalog has no pending L>=1 copies. Test/shutdown hook."""
-        if self._copy_worker is None:
-            return True
-        return self._copy_worker.wait_drained(timeout)
 
     # Test hooks below; forward to the registered "log" namespace.
 

--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 import threading
 import time
 from collections import deque
@@ -27,6 +28,7 @@ from threading import Condition, Lock
 from typing import NamedTuple, Protocol
 
 import duckdb
+import fsspec.core
 import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.parquet as pq
@@ -87,6 +89,9 @@ _BG_HEARTBEAT_INTERVAL_SEC = 10.0
 # Hard ceiling on the per-read parquet working set; safety net for body-LIKE
 # queries that cannot be pruned by row-group statistics.
 _MAX_PARQUET_BYTES_PER_READ = 2_500 * 1024 * 1024
+
+# 4 MiB amortizes GCS per-write overhead without growing with segment size.
+_REMOTE_UPLOAD_CHUNK_BYTES = 4 * 1024 * 1024
 
 
 class SegmentMetadata(NamedTuple):
@@ -452,7 +457,7 @@ class DiskLogNamespace:
         name: str,
         schema: Schema,
         data_dir: Path,
-        copy_wake: Callable[[], None],
+        remote_log_dir: str,
         segment_target_bytes: int,
         flush_interval_sec: float,
         compaction_config: CompactionConfig,
@@ -468,10 +473,9 @@ class DiskLogNamespace:
         self._data_dir = data_dir
         data_dir.mkdir(parents=True, exist_ok=True)
 
-        # Notifies the store-wide copy worker that fresh L>=1 catalog
-        # rows may exist; the worker polls the catalog regardless, this
-        # just shortens the latency from "compaction commit" to "upload".
-        self._copy_wake = copy_wake
+        # Empty string disables remote sync.
+        self._remote_namespace_dir = f"{remote_log_dir.rstrip('/')}/{name}" if remote_log_dir else ""
+
         self._segment_target_bytes = segment_target_bytes
         self._compactor = Compactor(compaction_config)
 
@@ -689,11 +693,11 @@ class DiskLogNamespace:
         self._stop.set()
         self._wake.set()
         self._bg_thread.join()
-        # Flush turns RAM into L0 on disk so a clean restart picks it up.
-        # We do NOT promote L0 to L1 at close — L0 is local-only by design,
-        # and re-discovery on boot brings them back. The store-wide copy
-        # worker handles L1+ uploads independently.
+        # Flush RAM to L0 so a clean restart picks it up. We deliberately do
+        # NOT promote L0 to L1 here — L0 is local-only by design.
         self._flush_step()
+        # Final reconcile so the bucket matches the catalog at shutdown.
+        self._sync_step()
 
     def stop_and_join(self) -> None:
         """Stop the bg thread without flushing or compacting (used by ``DropTable``)."""
@@ -757,6 +761,7 @@ class DiskLogNamespace:
                     pass
                 self._compaction_rl.mark_run()
                 last_compact_at = time.monotonic()
+                self._sync_step()
                 self._eviction_step()
 
             self._wake.wait(timeout=min(self._flush_rl.time_until_next(), 1.0))
@@ -1003,7 +1008,6 @@ class DiskLogNamespace:
             pre_swap=lambda: os.rename(old.path, new_path),
         )
         logger.info("Level-bumped %s -> L%d (%s)", Path(old.path).name, job.output_level, new_filename)
-        self._copy_wake()
 
     def _apply_merge(self, job: CompactionJob) -> None:
         merged_filename = seg_filename(level=job.output_level, min_seq=job.output_min_seq)
@@ -1056,7 +1060,6 @@ class DiskLogNamespace:
             merged_seg.max_seq,
             int((time.monotonic() - compaction_start) * 1000),
         )
-        self._copy_wake()
 
     def _commit_swap(
         self,
@@ -1113,6 +1116,72 @@ class DiskLogNamespace:
                         logger.warning("Failed to unlink merged input %s", path, exc_info=True)
         finally:
             self._query_visibility_lock.write_release()
+
+    def _sync_step(self) -> None:
+        """Reconcile the remote namespace prefix with the catalog.
+
+        Uploads catalog L>=1 rows missing from remote, deletes remote
+        objects not referenced by the catalog. No-op when the namespace
+        has no remote prefix configured.
+        """
+        if not self._remote_namespace_dir:
+            return
+        with self._insertion_lock:
+            rows = self._catalog.list_segments(self.name, min_level=1)
+        # Compare on basename: catalog stores local absolute paths while
+        # ``fs.find`` returns backend-specific forms (gcs ``bucket/...``,
+        # local absolute). Filename is the only stable key.
+        live = {Path(r.path).name: r for r in rows}
+
+        try:
+            fs, root = fsspec.core.url_to_fs(self._remote_namespace_dir)
+            remote = {Path(p).name: p for p in fs.find(root)}
+        except Exception:
+            logger.warning("remote sync list failed for %s", self.name, exc_info=True)
+            return
+
+        for filename, row in live.items():
+            if filename in remote:
+                continue
+            completed_ms = self._upload(Path(row.path))
+            if completed_ms is not None:
+                self.mark_copied(row.path, completed_ms)
+
+        for filename, fs_path in remote.items():
+            if filename in live:
+                continue
+            try:
+                fs.rm(fs_path)
+                logger.info("Removed orphan remote segment %s/%s", self.name, filename)
+            except Exception:
+                logger.warning("orphan delete failed: %s", fs_path, exc_info=True)
+
+    def _upload(self, local_path: Path) -> int | None:
+        """Stream ``local_path`` to remote. Returns completion epoch_ms, or
+        ``None`` on failure (the next sync retries)."""
+        remote_path = f"{self._remote_namespace_dir}/{local_path.name}"
+        upload_start = time.monotonic()
+        try:
+            with (
+                fsspec.core.open(str(local_path), "rb") as f_src,
+                fsspec.core.open(remote_path, "wb") as f_dst,
+            ):
+                shutil.copyfileobj(f_src, f_dst, length=_REMOTE_UPLOAD_CHUNK_BYTES)
+        except Exception:
+            logger.warning("Failed to copy %s to %s", local_path, remote_path, exc_info=True)
+            return None
+        try:
+            size = local_path.stat().st_size
+        except OSError:
+            size = -1
+        logger.info(
+            "Copied %s to %s: bytes=%d elapsed_ms=%d",
+            local_path.name,
+            remote_path,
+            size,
+            int((time.monotonic() - upload_start) * 1000),
+        )
+        return int(time.time() * 1000)
 
     def _eviction_step(self) -> None:
         """Evict the namespace's oldest L>=1 copied segments until under caps.

--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -39,6 +39,7 @@ from finelog.rpc import logging_pb2
 from finelog.store.catalog import (
     Catalog,
     NamespaceStats,
+    SegmentLocation,
     SegmentRow,
 )
 from finelog.store.compactor import (
@@ -264,7 +265,10 @@ class LocalSegment:
     # can compare numeric keys with native ordering.
     min_key_value: object | None = None
     max_key_value: object | None = None
-    copied_at_ms: int | None = None
+    # Where the bytes live. The deque only ever holds ``LOCAL`` or ``BOTH``
+    # entries; eviction flips to ``REMOTE`` and removes the entry from the
+    # deque (the row stays in the catalog as a durable-archive pointer).
+    location: SegmentLocation = SegmentLocation.LOCAL
 
 
 def _stamp_seq_column(batch: pa.RecordBatch, first_seq: int, arrow_schema: pa.Schema) -> pa.Table:
@@ -427,8 +431,6 @@ class LogNamespaceProtocol(Protocol):
 
     def evict_segment(self, path: str) -> int: ...
 
-    def mark_copied(self, path: str, copied_at_ms: int) -> None: ...
-
     def remove_local_storage(self) -> None: ...
 
     def close(self) -> None: ...
@@ -503,42 +505,103 @@ class DiskLogNamespace:
         )
         self._local_segments: deque[LocalSegment] = deque()
 
-        # Reconcile from disk: parquet files are authoritative across
-        # crashes. Walk every ``seg_L<n>_*.parquet`` and rebuild the
-        # in-memory deque + catalog rows. ``created_at_ms`` falls back to
-        # the file mtime when the catalog has nothing for this path —
-        # close enough for L0 aging and stable across reboots.
+        # Reconcile boot state across three sources of truth (in order):
+        #   1. Catalog rows — authoritative for ``REMOTE`` segments whose
+        #      local file was evicted before the prior shutdown.
+        #   2. Local parquet files — authoritative for unflushed catalog
+        #      state (genuine boot from disk, no prior catalog).
+        #   3. Remote bucket — authoritative for wiped-catalog recovery,
+        #      handled in the bg loop's first sync tick rather than here
+        #      so __init__ stays free of network calls.
+        #
+        # Each catalog row is reattached to its on-disk file when present;
+        # ``REMOTE``-only rows stay in the catalog but never enter the
+        # deque (queries don't see archived data). Local files without a
+        # catalog row are inserted as ``LOCAL`` (sync uploads them next
+        # tick).
         key_column = self.schema.key_column or None
         catalog_rows = {row.path: row for row in self._catalog.list_segments(self.name)}
-        for p in _discover_segments(data_dir):
-            meta = _read_segment_metadata(p, key_column=key_column)
-            row = catalog_rows.get(str(p))
-            created_at_ms = row.created_at_ms if row is not None else int(p.stat().st_mtime * 1000)
-            copied_at_ms = row.copied_at_ms if row is not None else None
+        local_files = {str(p): p for p in _discover_segments(data_dir)}
+        seen_paths: set[str] = set()
+
+        # Pass 1: walk catalog rows. Local-present → deque entry; otherwise
+        # leave the row in place as the durable-archive pointer.
+        for path_str, row in catalog_rows.items():
+            seen_paths.add(path_str)
+            local_path = local_files.get(path_str)
+            if local_path is None:
+                if row.location == SegmentLocation.LOCAL:
+                    # Local file went missing while the catalog still
+                    # claims LOCAL — data is lost. Drop the row so sync
+                    # doesn't keep trying to upload a non-existent file.
+                    logger.warning(
+                        "Catalog row %s missing local file and has no remote copy; dropping",
+                        path_str,
+                    )
+                    self._catalog.remove_segment(self.name, path_str)
+                elif row.location == SegmentLocation.BOTH:
+                    # Local file lost but bucket copy is durable; collapse
+                    # to ``REMOTE`` so queries don't try to read the
+                    # missing file.
+                    self._catalog.set_location(self.name, path_str, SegmentLocation.REMOTE)
+                continue
+            meta = _read_segment_metadata(local_path, key_column=key_column)
+            location = SegmentLocation.BOTH if row.location == SegmentLocation.REMOTE else row.location
             self._local_segments.append(
                 LocalSegment(
-                    path=str(p),
+                    path=path_str,
+                    size_bytes=local_path.stat().st_size,
+                    level=meta.level,
+                    min_seq=meta.min_seq,
+                    max_seq=meta.max_seq,
+                    row_count=meta.row_count,
+                    created_at_ms=row.created_at_ms,
+                    min_key_value=meta.min_key_value,
+                    max_key_value=meta.max_key_value,
+                    location=location,
+                )
+            )
+
+        # Pass 2: walk local files. Anything not already accounted for is
+        # a genuine fresh-from-disk segment (or a compaction-mid-crash
+        # leftover; sync will upload it then orphan-delete in the next
+        # round if it's truly stale).
+        for path_str, p in local_files.items():
+            if path_str in seen_paths:
+                continue
+            meta = _read_segment_metadata(p, key_column=key_column)
+            self._local_segments.append(
+                LocalSegment(
+                    path=path_str,
                     size_bytes=p.stat().st_size,
                     level=meta.level,
                     min_seq=meta.min_seq,
                     max_seq=meta.max_seq,
                     row_count=meta.row_count,
-                    created_at_ms=created_at_ms,
+                    created_at_ms=int(p.stat().st_mtime * 1000),
                     min_key_value=meta.min_key_value,
                     max_key_value=meta.max_key_value,
-                    copied_at_ms=copied_at_ms,
+                    location=SegmentLocation.LOCAL,
                 )
             )
 
-        # Reconcile rewrites the catalog rows wholesale; ``created_at_ms``
-        # and ``copied_at_ms`` already came back from the catalog above
-        # (or from mtime fallback), so the rewrite is a no-op for those
-        # fields and a refresh of structural columns (level, key bounds)
-        # for any catalog row that drifted from the parquet footer.
-        self._catalog.reconcile_segments(
-            self.name,
-            [self._segment_to_row(seg) for seg in self._local_segments],
-        )
+        # Order the deque by min_seq so query iteration matches the
+        # implicit "oldest first" expected by callers and the planner.
+        self._local_segments = deque(sorted(self._local_segments, key=lambda s: s.min_seq))
+
+        # Refresh the catalog from the deque so any drift in level / key
+        # bounds (parquet footer is authoritative) is corrected. REMOTE
+        # rows are left untouched. Each upsert is independent so no
+        # transaction is required.
+        for seg in self._local_segments:
+            self._catalog.upsert_segment(self._segment_to_row(seg))
+
+        # Wiped-catalog recovery: if the remote bucket has parquet files
+        # that no row references, adopt them as ``REMOTE``. Without this,
+        # the first ``_sync_step`` after a catalog wipe would treat the
+        # whole bucket as orphan and ``fs.rm`` everything.
+        if self._remote_namespace_dir:
+            self._adopt_remote_segments(key_column=key_column)
 
         self._flush_rl = RateLimiter(flush_interval_sec)
         self._compaction_rl = RateLimiter(compaction_config.check_interval_sec)
@@ -867,7 +930,7 @@ class DiskLogNamespace:
             created_at_ms=seg.created_at_ms,
             min_key_value=None if seg.min_key_value is None else str(seg.min_key_value),
             max_key_value=None if seg.max_key_value is None else str(seg.max_key_value),
-            copied_at_ms=seg.copied_at_ms,
+            location=seg.location,
         )
 
     def _write_new_segment(self, sealed: _SealedBuffer) -> None:
@@ -1117,48 +1180,118 @@ class DiskLogNamespace:
         finally:
             self._query_visibility_lock.write_release()
 
+    def _adopt_remote_segments(self, *, key_column: str | None) -> None:
+        """Insert ``REMOTE`` catalog rows for bucket files with no row.
+
+        Runs once at boot when ``_remote_namespace_dir`` is configured.
+        After a catalog wipe the bucket is the only durable record of
+        every L>=1 segment; we read each parquet footer remotely to
+        reconstruct row metadata, then insert at ``location=REMOTE``.
+        Files whose basename is already in the catalog are left alone
+        (the local-disk pass already attached them).
+        """
+        try:
+            fs, root = fsspec.core.url_to_fs(self._remote_namespace_dir)
+            remote_paths = list(fs.find(root))
+        except Exception:
+            logger.warning("remote adopt list failed for %s", self.name, exc_info=True)
+            return
+
+        catalog_basenames = {Path(r.path).name for r in self._catalog.list_segments(self.name)}
+        for fs_path in remote_paths:
+            basename = Path(fs_path).name
+            if basename in catalog_basenames:
+                continue
+            parsed = parse_seg_filename(basename)
+            if parsed is None:
+                logger.warning("ignoring unparseable remote file %s/%s", self.name, basename)
+                continue
+            level, min_seq = parsed
+            try:
+                with fs.open(fs_path, "rb") as f:
+                    metadata = pq.read_metadata(f)
+            except Exception:
+                logger.warning("failed reading remote parquet footer %s/%s", self.name, basename, exc_info=True)
+                continue
+            num_rows = metadata.num_rows
+            min_key, max_key = _key_bounds_from_parquet(metadata, key_column)
+            try:
+                byte_size = fs.info(fs_path).get("size", 0)
+            except Exception:
+                byte_size = 0
+            local_path = self._data_dir / basename
+            self._catalog.upsert_segment(
+                SegmentRow(
+                    namespace=self.name,
+                    path=str(local_path),
+                    level=level,
+                    min_seq=min_seq,
+                    max_seq=min_seq + max(num_rows - 1, 0),
+                    row_count=num_rows,
+                    byte_size=int(byte_size),
+                    created_at_ms=int(time.time() * 1000),
+                    location=SegmentLocation.REMOTE,
+                    min_key_value=None if min_key is None else str(min_key),
+                    max_key_value=None if max_key is None else str(max_key),
+                )
+            )
+            logger.info("Adopted remote segment %s/%s as REMOTE", self.name, basename)
+
     def _sync_step(self) -> None:
         """Reconcile the remote namespace prefix with the catalog.
 
-        Uploads catalog L>=1 rows missing from remote, deletes remote
-        objects not referenced by the catalog. No-op when the namespace
-        has no remote prefix configured.
+        The catalog is the source of truth for what should exist remotely.
+        Phase 1 uploads every ``LOCAL`` row at L>=1 (or adopts a row whose
+        file is already remote, which happens after a crash between
+        ``fs`` write and the catalog flip). Phase 2 ``fs.rm``s any remote
+        file with no catalog row — those are compaction inputs whose row
+        has been dropped. The ordering is what makes this safe: by the
+        time phase 2 runs, the merged output that subsumes those inputs
+        has been uploaded in phase 1, so the durable copy is in place
+        before any input remote bytes are deleted.
+
+        No-op when the namespace has no remote prefix configured.
         """
         if not self._remote_namespace_dir:
             return
-        with self._insertion_lock:
-            rows = self._catalog.list_segments(self.name, min_level=1)
-        # Compare on basename: catalog stores local absolute paths while
-        # ``fs.find`` returns backend-specific forms (gcs ``bucket/...``,
-        # local absolute). Filename is the only stable key.
-        live = {Path(r.path).name: r for r in rows}
 
         try:
             fs, root = fsspec.core.url_to_fs(self._remote_namespace_dir)
-            remote = {Path(p).name: p for p in fs.find(root)}
+            remote_basenames = {Path(p).name for p in fs.find(root)}
         except Exception:
             logger.warning("remote sync list failed for %s", self.name, exc_info=True)
             return
 
-        for filename, row in live.items():
-            if filename in remote:
-                continue
-            completed_ms = self._upload(Path(row.path))
-            if completed_ms is not None:
-                self.mark_copied(row.path, completed_ms)
+        with self._insertion_lock:
+            rows = self._catalog.list_segments(self.name, min_level=1)
 
-        for filename, fs_path in remote.items():
-            if filename in live:
+        for row in rows:
+            if row.location != SegmentLocation.LOCAL:
                 continue
+            basename = Path(row.path).name
+            if basename in remote_basenames:
+                # Crash recovery: the file was uploaded but the catalog
+                # never flipped. Adopt without re-uploading.
+                self._mark_uploaded(row.path)
+                continue
+            if self._upload(Path(row.path)):
+                self._mark_uploaded(row.path)
+
+        # Re-snapshot: phase 1 may have added basenames to the bucket; we
+        # only want to delete files whose basename is genuinely orphan
+        # (no catalog row at all).
+        with self._insertion_lock:
+            catalog_basenames = {Path(r.path).name for r in self._catalog.list_segments(self.name, min_level=1)}
+        for basename in remote_basenames - catalog_basenames:
             try:
-                fs.rm(fs_path)
-                logger.info("Removed orphan remote segment %s/%s", self.name, filename)
+                fs.rm(f"{self._remote_namespace_dir}/{basename}")
+                logger.info("Deleted orphan remote segment %s/%s", self.name, basename)
             except Exception:
-                logger.warning("orphan delete failed: %s", fs_path, exc_info=True)
+                logger.warning("orphan delete failed: %s/%s", self.name, basename, exc_info=True)
 
-    def _upload(self, local_path: Path) -> int | None:
-        """Stream ``local_path`` to remote. Returns completion epoch_ms, or
-        ``None`` on failure (the next sync retries)."""
+    def _upload(self, local_path: Path) -> bool:
+        """Stream ``local_path`` to remote. Returns True on success;
+        the next sync retries on failure."""
         remote_path = f"{self._remote_namespace_dir}/{local_path.name}"
         upload_start = time.monotonic()
         try:
@@ -1169,7 +1302,7 @@ class DiskLogNamespace:
                 shutil.copyfileobj(f_src, f_dst, length=_REMOTE_UPLOAD_CHUNK_BYTES)
         except Exception:
             logger.warning("Failed to copy %s to %s", local_path, remote_path, exc_info=True)
-            return None
+            return False
         try:
             size = local_path.stat().st_size
         except OSError:
@@ -1181,7 +1314,20 @@ class DiskLogNamespace:
             size,
             int((time.monotonic() - upload_start) * 1000),
         )
-        return int(time.time() * 1000)
+        return True
+
+    def _mark_uploaded(self, path: str) -> None:
+        """Flip a segment's location to ``BOTH`` after a successful upload.
+
+        Updates the in-memory deque and the catalog under the insertion
+        lock so the planner / eviction queries see consistent state.
+        """
+        with self._insertion_lock:
+            for s in self._local_segments:
+                if s.path == path:
+                    s.location = SegmentLocation.BOTH
+                    break
+            self._catalog.set_location(self.name, path, SegmentLocation.BOTH)
 
     def _eviction_step(self) -> None:
         """Evict the namespace's oldest L>=1 copied segments until under caps.
@@ -1223,31 +1369,34 @@ class DiskLogNamespace:
         """Snapshot every locally-tracked segment. Caller MUST hold the insertion lock."""
         return list(self._local_segments)
 
-    def mark_copied(self, path: str, copied_at_ms: int) -> None:
-        """Stamp the catalog row + in-memory deque after a copy upload completes.
-
-        The copy worker calls this from its own thread; ``_insertion_lock``
-        serializes it against the bg thread's catalog mutations.
-        """
-        with self._insertion_lock:
-            for s in self._local_segments:
-                if s.path == path:
-                    s.copied_at_ms = copied_at_ms
-                    break
-            self._catalog.mark_copied(self.name, path, copied_at_ms)
-
     def evict_segment(self, path: str) -> int:
-        """Remove ``path`` from tracking and unlink the file. Returns bytes freed."""
+        """Drop ``path`` from the local deque and unlink the file. Returns
+        bytes freed.
+
+        For a ``BOTH`` segment, the catalog row stays in place at
+        ``REMOTE`` and the bucket copy is the durable archive. For a
+        ``LOCAL``-only segment, eviction is destructive: there's no
+        durable copy, so the row is dropped entirely. Production eviction
+        runs through ``select_eviction_candidate`` which gates on
+        ``BOTH``; the destructive branch is here for direct callers
+        (tests, manual recovery) that have already accepted the
+        consequences.
+        """
         with self._insertion_lock:
             new: deque[LocalSegment] = deque()
             removed_bytes = 0
+            removed_location: SegmentLocation | None = None
             for s in self._local_segments:
                 if s.path == path:
                     removed_bytes = s.size_bytes
+                    removed_location = s.location
                     continue
                 new.append(s)
             self._local_segments = new
-            self._catalog.remove_segment(self.name, path)
+            if removed_location is SegmentLocation.BOTH:
+                self._catalog.set_location(self.name, path, SegmentLocation.REMOTE)
+            else:
+                self._catalog.remove_segment(self.name, path)
         try:
             Path(path).unlink(missing_ok=True)
         except OSError:
@@ -1474,9 +1623,6 @@ class MemoryLogNamespace:
 
     def evict_segment(self, path: str) -> int:
         return 0
-
-    def mark_copied(self, path: str, copied_at_ms: int) -> None:
-        return None
 
     def remove_local_storage(self) -> None:
         with self._insertion_lock:

--- a/lib/finelog/src/finelog/store/migrations/0006_segment_lifecycle.py
+++ b/lib/finelog/src/finelog/store/migrations/0006_segment_lifecycle.py
@@ -1,0 +1,61 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Replace ``copied_at_ms`` with an explicit ``location`` enum.
+
+A segment's bytes can live on local disk, on the remote bucket, or both.
+The previous ``copied_at_ms`` column carried that fact implicitly (NULL =
+not durable; NOT NULL = remote copy exists), and "row absent from catalog"
+was overloaded to mean both "evicted locally" and "deleted by compaction."
+The remote-sync loop couldn't distinguish those cases and would delete
+durable archives whose only mistake was being a row no longer in the
+catalog.
+
+The new model: every segment that is part of the table has a catalog row,
+and its ``location`` says where its bytes live:
+
+* ``LOCAL`` — freshly written and not yet uploaded (or a never-uploaded L0).
+* ``BOTH`` — on disk and durably on remote.
+* ``REMOTE`` — durable archive only; the local file was evicted.
+
+Compaction drops input rows immediately at commit; the merged output is
+inserted as ``LOCAL``. The sync loop reconciles remote with catalog:
+``LOCAL`` rows are uploaded (or adopted, if the file is already there from
+a crash mid-upload), and remote files with no catalog row are ``fs.rm``'d.
+Eviction flips ``BOTH`` → ``REMOTE`` instead of dropping the row, so the
+durable archive is never mistaken for an orphan.
+
+Backfill: existing rows with ``copied_at_ms IS NULL`` are at ``LOCAL``;
+``copied_at_ms IS NOT NULL`` means ``BOTH``. Pre-migration eviction was
+the only row-removal path, so every surviving row had a local file.
+
+Non-null is enforced at the application layer rather than via DuckDB's
+``SET NOT NULL`` because the existing ``segments_level_idx`` blocks
+schema-altering DDL on the table.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+
+
+def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir: Path | None) -> None:
+    del data_dir
+    # DuckDB rejects ``DROP COLUMN`` (and ``SET NOT NULL``) on a table
+    # referenced by an index, so drop the level index, run the schema
+    # changes, then recreate it. NOT NULL is enforced at the application
+    # layer (the backfill below populates every existing row, and
+    # ``upsert_segment`` always provides ``location``).
+    conn.execute("DROP INDEX IF EXISTS segments_ns_level_minseq")
+    conn.execute("ALTER TABLE segments ADD COLUMN IF NOT EXISTS location TEXT")
+    conn.execute(
+        """
+        UPDATE segments
+           SET location = CASE WHEN copied_at_ms IS NULL THEN 'LOCAL' ELSE 'BOTH' END
+         WHERE location IS NULL
+        """
+    )
+    conn.execute("ALTER TABLE segments DROP COLUMN copied_at_ms")
+    conn.execute("CREATE INDEX IF NOT EXISTS segments_ns_level_minseq ON segments (namespace, level, min_seq)")

--- a/lib/finelog/tests/conftest.py
+++ b/lib/finelog/tests/conftest.py
@@ -49,10 +49,11 @@ def _worker_batch(worker_ids: list[str], mem_bytes: list[int], ts: list[int]) ->
 
 
 def _seal(store: DuckDBLogStore, namespace: str) -> None:
-    """Flush and drain L0 so the namespace's data is on the L1 tier."""
+    """Run flush -> compact -> sync synchronously, mirroring one bg-loop tick."""
     ns = store._namespaces[namespace]
     ns._flush_step()
     ns._force_compact_l0()
+    ns._sync_step()
 
 
 @pytest.fixture()

--- a/lib/finelog/tests/test_catalog_stats.py
+++ b/lib/finelog/tests/test_catalog_stats.py
@@ -13,9 +13,11 @@ evict → drop → restart).
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from finelog.rpc import logging_pb2
-from finelog.store.catalog import Catalog, NamespaceStats
+from finelog.store.catalog import Catalog, NamespaceStats, SegmentLocation
 from finelog.store.duckdb_store import DuckDBLogStore
 
 from tests.conftest import _ipc_bytes, _seal, _worker_batch, _worker_schema
@@ -102,7 +104,9 @@ def test_compaction_replaces_l0_rows_atomically(store):
     assert stats.segment_count == 1
 
 
-def test_eviction_removes_segment_row(store):
+def test_eviction_local_only_drops_row(store):
+    """Eviction of a ``LOCAL``-only segment is destructive: with no remote
+    copy to fall back on, the row is dropped entirely."""
     store.register_table("iris.worker", _worker_schema())
     batch = _worker_batch(["w-0"], [1], [1])
     store.write_rows("iris.worker", _ipc_bytes(batch))
@@ -111,6 +115,7 @@ def test_eviction_removes_segment_row(store):
     segs = _segments(store, "iris.worker")
     assert len(segs) == 1
     path = segs[0].path
+    assert segs[0].location is SegmentLocation.LOCAL
 
     store._namespaces["iris.worker"].evict_segment(path)
 
@@ -118,6 +123,41 @@ def test_eviction_removes_segment_row(store):
     stats = _stats(store, "iris.worker")
     assert stats.row_count == 0
     assert stats.segment_count == 0
+
+
+def test_eviction_flips_remote_durable_segment(tmp_path):
+    """Eviction of a ``BOTH`` segment keeps the catalog row at ``REMOTE``
+    so the durable bucket archive is preserved."""
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    store = DuckDBLogStore(log_dir=tmp_path / "data", remote_log_dir=str(remote))
+    try:
+        store.register_table("iris.worker", _worker_schema())
+        store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-0"], [1], [1])))
+        _seal(store, "iris.worker")
+        ns = store._namespaces["iris.worker"]
+        ns._sync_step()
+        segs = _segments(store, "iris.worker")
+        assert len(segs) == 1
+        path = segs[0].path
+        assert segs[0].location is SegmentLocation.BOTH
+
+        ns.evict_segment(path)
+
+        rows = _segments(store, "iris.worker")
+        assert len(rows) == 1
+        assert rows[0].path == path
+        assert rows[0].location is SegmentLocation.REMOTE
+        # Local file unlinked; remote file preserved.
+        assert not Path(path).exists()
+        assert (remote / "iris.worker" / Path(path).name).exists()
+        # Stats track queryable data only (the deque excludes REMOTE rows
+        # because the read path doesn't fetch from the bucket today).
+        stats = _stats(store, "iris.worker")
+        assert stats.segment_count == 0
+        assert stats.row_count == 0
+    finally:
+        store.close()
 
 
 def test_drop_table_clears_namespace_segments(store):
@@ -166,17 +206,17 @@ def test_segments_catalog_survives_restart(tmp_path):
         s2.close()
 
 
-def test_reconcile_preserves_copied_at_ms(tmp_path):
-    """A successful upload's stamp survives the next-boot reconcile pass."""
+def test_reconcile_preserves_location(tmp_path):
+    """An uploaded segment's BOTH location survives the next-boot reconcile pass."""
     log_dir = tmp_path / "store"
     s1 = DuckDBLogStore(log_dir=log_dir)
     s1.register_table("iris.worker", _worker_schema())
     s1.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-0"], [1], [1])))
     _seal(s1, "iris.worker")
     seg = _segments(s1, "iris.worker")[0]
-    # Simulate a successful copy: stamp the catalog row.
-    s1._namespaces["iris.worker"].mark_copied(seg.path, copied_at_ms=12345)
-    assert _segments(s1, "iris.worker")[0].copied_at_ms == 12345
+    # Simulate a successful copy via the catalog's public API.
+    s1._namespaces["iris.worker"]._mark_uploaded(seg.path)
+    assert _segments(s1, "iris.worker")[0].location is SegmentLocation.BOTH
     s1.close()
 
     s2 = DuckDBLogStore(log_dir=log_dir)
@@ -184,8 +224,8 @@ def test_reconcile_preserves_copied_at_ms(tmp_path):
         rows = _segments(s2, "iris.worker")
         assert len(rows) == 1
         assert rows[0].path == seg.path
-        # Reconcile rewrites the row but keeps the copy stamp.
-        assert rows[0].copied_at_ms == 12345
+        # Reconcile preserves the BOTH state — local file present + previously uploaded.
+        assert rows[0].location is SegmentLocation.BOTH
     finally:
         s2.close()
 

--- a/lib/finelog/tests/test_drop.py
+++ b/lib/finelog/tests/test_drop.py
@@ -83,9 +83,7 @@ def test_drop_table_does_not_delete_remote_objects(tmp_path: Path):
         ns._flush_step()
         # Only compacted segments are uploaded.
         ns._force_compact_l0()
-        # Copy is async; wait for the worker to drain before asserting the
-        # file is visible at the destination.
-        assert store._wait_for_copies(timeout=5.0)
+        ns._sync_step()
 
         remote_ns_dir = remote / "iris.worker"
         assert remote_ns_dir.exists()

--- a/lib/finelog/tests/test_eviction.py
+++ b/lib/finelog/tests/test_eviction.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import time
 from pathlib import Path
 
 from finelog.store.compactor import CompactionConfig
@@ -13,7 +12,7 @@ from tests.conftest import _ipc_bytes, _seal, _worker_batch, _worker_schema
 
 
 def _list_segments_locked(store: DuckDBLogStore, namespace: str):
-    """Catalog read serialized against the bg threads (copy worker, bg loop).
+    """Catalog read serialized against the bg thread.
 
     DuckDB connections aren't thread-safe and the catalog docstring is
     explicit that callers hold ``_insertion_lock``. Tests that read directly
@@ -21,20 +20,6 @@ def _list_segments_locked(store: DuckDBLogStore, namespace: str):
     """
     with store._insertion_lock:
         return store._catalog.list_segments(namespace)
-
-
-def _wait_until_copied(store: DuckDBLogStore, namespace: str, timeout: float = 5.0) -> None:
-    """Block until every L>=1 catalog row in ``namespace`` has ``copied_at_ms``.
-
-    Eviction is gated on the copy stamp; tests that target eviction must
-    wait for the worker before they can assert anything about it.
-    """
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        rows = _list_segments_locked(store, namespace)
-        if rows and all(r.copied_at_ms is not None for r in rows if r.level >= 1):
-            return
-        time.sleep(0.05)
 
 
 def test_eviction_drops_oldest_segment_when_cap_exceeded(tmp_path: Path):
@@ -51,14 +36,12 @@ def test_eviction_drops_oldest_segment_when_cap_exceeded(tmp_path: Path):
 
         store.write_rows("ns", _ipc_bytes(_worker_batch(["a"], [1], [1])))
         _seal(store, "ns")
-        _wait_until_copied(store, "ns")
         first_l1 = sorted((tmp_path / "data" / "ns").glob("seg_L1_*.parquet"))
         assert len(first_l1) == 1
         first_path = first_l1[0]
 
         store.write_rows("ns", _ipc_bytes(_worker_batch(["b"], [2], [2])))
         _seal(store, "ns")
-        _wait_until_copied(store, "ns")
         # Drive the eviction tick (compaction tail invokes _eviction_step).
         store._namespaces["ns"]._eviction_step()
 
@@ -131,7 +114,7 @@ def test_fifo_eviction_across_mixed_levels(tmp_path: Path):
             ns._flush_step()
             while ns._compaction_step():
                 pass
-            _wait_until_copied(store, "ns")
+            ns._sync_step()
 
         # Eviction should now have run and brought us to <=2 segments,
         # popping oldest first.

--- a/lib/finelog/tests/test_eviction.py
+++ b/lib/finelog/tests/test_eviction.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from finelog.store.catalog import SegmentLocation
 from finelog.store.compactor import CompactionConfig
 from finelog.store.duckdb_store import DuckDBLogStore
 
@@ -55,7 +56,7 @@ def test_eviction_drops_oldest_segment_when_cap_exceeded(tmp_path: Path):
 def test_eviction_skips_segments_not_yet_copied(tmp_path: Path):
     """A freshly-promoted L1 segment is not evicted until the upload completes."""
     config = CompactionConfig(max_segments_per_namespace=1, level_targets=(1,))
-    # No remote_log_dir → no copy worker → copied_at_ms stays NULL.
+    # No remote_log_dir → no upload happens → location stays LOCAL.
     store = DuckDBLogStore(log_dir=tmp_path / "data", compaction_config=config)
     try:
         store.register_table("ns", _worker_schema())
@@ -116,13 +117,22 @@ def test_fifo_eviction_across_mixed_levels(tmp_path: Path):
                 pass
             ns._sync_step()
 
-        # Eviction should now have run and brought us to <=2 segments,
-        # popping oldest first.
+        # Eviction should now have run and brought us to <=2 local segments,
+        # popping oldest first. Evicted rows stay in the catalog with
+        # location=REMOTE so the bucket archive is preserved.
         ns._eviction_step()
-        remaining_rows = _list_segments_locked(store, "ns")
-        assert len(remaining_rows) <= 2
-        # Whatever's left, the smallest min_seq is strictly greater than the
-        # smallest seq we ever wrote (1) — i.e. eviction came from the front.
-        assert min(r.min_seq for r in remaining_rows) > 1
+        all_rows = _list_segments_locked(store, "ns")
+        local_rows = [r for r in all_rows if r.location in {SegmentLocation.LOCAL, SegmentLocation.BOTH}]
+        remote_rows = [r for r in all_rows if r.location is SegmentLocation.REMOTE]
+        assert len(local_rows) <= 2
+        # Whatever's left locally, the smallest min_seq is strictly greater
+        # than the smallest seq we ever wrote (0) — i.e. eviction came from
+        # the front.
+        assert min(r.min_seq for r in local_rows) > 0
+        # The evicted rows show up as REMOTE archive pointers and their
+        # remote files survive.
+        assert remote_rows
+        for r in remote_rows:
+            assert (tmp_path / "remote" / "ns" / Path(r.path).name).exists()
     finally:
         store.close()

--- a/lib/finelog/tests/test_migrations.py
+++ b/lib/finelog/tests/test_migrations.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import duckdb
 import pytest
-from finelog.store.catalog import Catalog, SegmentRow
+from finelog.store.catalog import Catalog, SegmentLocation, SegmentRow
 from finelog.store.migrations import apply_migrations, transactional
 
 
@@ -44,6 +44,7 @@ def test_fresh_registry_runs_baseline_migration(tmp_path):
             "0003_segment_level.py",
             "0004_segment_copied_at.py",
             "0005_segments_level_index.py",
+            "0006_segment_lifecycle.py",
         ]
     finally:
         db.close()
@@ -61,6 +62,7 @@ def test_reopen_is_idempotent(tmp_path):
             "0003_segment_level.py",
             "0004_segment_copied_at.py",
             "0005_segments_level_index.py",
+            "0006_segment_lifecycle.py",
         ]
     finally:
         db.close()
@@ -99,6 +101,7 @@ def test_pre_migrations_database_inherits_baseline(tmp_path):
             "0003_segment_level.py",
             "0004_segment_copied_at.py",
             "0005_segments_level_index.py",
+            "0006_segment_lifecycle.py",
         ]
     finally:
         db.close()
@@ -245,20 +248,20 @@ def test_catalog_segments_apis_function_after_migration(tmp_path):
             created_at_ms=0,
             min_key_value="alpha",
             max_key_value="zeta",
-            copied_at_ms=42,
+            location=SegmentLocation.BOTH,
         )
         db.upsert_segment(seg)
         stats = db.aggregate_namespace_stats("ns")
         assert stats.row_count == 10
         assert stats.segment_count == 1
 
-        # 0002 + 0003 + 0004 columns survive the round-trip.
+        # 0002 + 0003 + 0006 columns survive the round-trip.
         rows = db.list_segments("ns")
         assert len(rows) == 1
         assert rows[0].level == 1
         assert rows[0].min_key_value == "alpha"
         assert rows[0].max_key_value == "zeta"
-        assert rows[0].copied_at_ms == 42
+        assert rows[0].location is SegmentLocation.BOTH
 
         seg_no_key = SegmentRow(
             namespace="ns",
@@ -275,6 +278,6 @@ def test_catalog_segments_apis_function_after_migration(tmp_path):
         no_key_row = next(r for r in rows if r.path.endswith("0000000011.parquet"))
         assert no_key_row.min_key_value is None
         assert no_key_row.max_key_value is None
-        assert no_key_row.copied_at_ms is None
+        assert no_key_row.location is SegmentLocation.LOCAL
     finally:
         db.close()

--- a/lib/finelog/tests/test_offload.py
+++ b/lib/finelog/tests/test_offload.py
@@ -1,70 +1,80 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Async copy worker behavior.
-
-Compaction must not block on the GCS upload; the worker drains on close
-and on the test ``_wait_for_copies`` hook.
-"""
+"""Per-namespace remote sync: upload-on-promote and orphan cleanup."""
 
 from __future__ import annotations
 
-import threading
-import time
 from pathlib import Path
 
-from finelog.store import duckdb_store
 from finelog.store.duckdb_store import DuckDBLogStore
+from finelog.store.log_namespace import DiskLogNamespace
 
 from tests.conftest import _ipc_bytes, _worker_batch, _worker_schema
 
 
-def test_compaction_returns_immediately_when_upload_is_slow(tmp_path: Path, monkeypatch):
-    """A multi-second upload must not stall the compaction thread.
+def _remote_files(remote: Path, namespace: str) -> list[Path]:
+    return sorted((remote / namespace).glob("*.parquet"))
 
-    The copy worker polls the catalog independently; compaction just
-    wakes it. So compaction returns regardless of upload duration.
+
+def test_sync_uploads_compacted_segments(tmp_path: Path) -> None:
+    remote = tmp_path / "remote"
+    remote.mkdir()
+
+    store = DuckDBLogStore(log_dir=tmp_path / "data", remote_log_dir=str(remote))
+    try:
+        store.register_table("iris.worker", _worker_schema())
+        store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-1"], [100], [1])))
+        ns = store._namespaces["iris.worker"]
+        assert isinstance(ns, DiskLogNamespace)
+
+        ns._flush_step()
+        ns._force_compact_l0()
+
+        # Compaction itself does not upload — sync runs separately.
+        assert _remote_files(remote, "iris.worker") == []
+
+        ns._sync_step()
+        assert len(_remote_files(remote, "iris.worker")) == 1
+    finally:
+        store.close()
+
+
+def test_sync_deletes_orphaned_remote_segments(tmp_path: Path) -> None:
+    """Remote objects with no matching catalog row are removed by sync.
+
+    Models the pre-fix steady-state where compaction inputs lingered in
+    the bucket after promotion to a higher tier.
     """
     remote = tmp_path / "remote"
     remote.mkdir()
 
-    release_upload = threading.Event()
-    real_upload = duckdb_store.CopyWorker._upload
-
-    def gated_upload(self, namespace, local_path):
-        if not release_upload.wait(timeout=5.0):
-            raise AssertionError("test forgot to release the copy gate")
-        return real_upload(self, namespace, local_path)
-
-    monkeypatch.setattr(duckdb_store.CopyWorker, "_upload", gated_upload)
-
     store = DuckDBLogStore(log_dir=tmp_path / "data", remote_log_dir=str(remote))
     try:
         store.register_table("iris.worker", _worker_schema())
         store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-1"], [100], [1])))
         ns = store._namespaces["iris.worker"]
+        assert isinstance(ns, DiskLogNamespace)
         ns._flush_step()
-
-        compaction_start = time.monotonic()
         ns._force_compact_l0()
-        compaction_elapsed = time.monotonic() - compaction_start
+        ns._sync_step()
+        live_remote = _remote_files(remote, "iris.worker")
+        assert len(live_remote) == 1
 
-        assert compaction_elapsed < 1.0, f"compaction blocked on upload (elapsed={compaction_elapsed:.3f}s)"
+        live_names = {p.name for p in live_remote}
+        orphan = remote / "iris.worker" / "seg_L1_9999999999999999999.parquet"
+        assert orphan.name not in live_names
+        orphan.write_bytes(b"orphan")
 
-        remote_ns_dir = remote / "iris.worker"
-        if remote_ns_dir.exists():
-            assert not list(remote_ns_dir.glob("*.parquet"))
-
-        release_upload.set()
-        assert store._wait_for_copies(timeout=5.0)
-        assert sorted((remote / "iris.worker").glob("*.parquet"))
+        ns._sync_step()
+        remaining = _remote_files(remote, "iris.worker")
+        assert remaining == live_remote
+        assert not orphan.exists()
     finally:
-        release_upload.set()
         store.close()
 
 
-def test_close_drains_pending_copies(tmp_path: Path):
-    """``close`` blocks until the copy worker finishes queued uploads."""
+def test_close_drains_pending_uploads(tmp_path: Path) -> None:
     remote = tmp_path / "remote"
     remote.mkdir()
 
@@ -73,25 +83,13 @@ def test_close_drains_pending_copies(tmp_path: Path):
         store.register_table("iris.worker", _worker_schema())
         store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-1"], [100], [1])))
         ns = store._namespaces["iris.worker"]
+        assert isinstance(ns, DiskLogNamespace)
         ns._flush_step()
         ns._force_compact_l0()
+        # Skip the manual sync — close() must run it.
     except Exception:
         store.close()
         raise
 
-    # close() should drain the queue before tearing down the worker.
     store.close()
-
-    remote_files = sorted((remote / "iris.worker").glob("*.parquet"))
-    assert remote_files, "expected close() to drain pending uploads"
-
-
-def test_copy_worker_not_started_without_remote_dir(tmp_path: Path):
-    """No remote_log_dir => no worker thread, even with a disk store."""
-    store = DuckDBLogStore(log_dir=tmp_path / "data")
-    try:
-        assert store._copy_worker is None
-        # Wait hook is a no-op when the worker is absent.
-        assert store._wait_for_copies(timeout=0.0)
-    finally:
-        store.close()
+    assert _remote_files(remote, "iris.worker")

--- a/lib/finelog/tests/test_offload.py
+++ b/lib/finelog/tests/test_offload.py
@@ -93,3 +93,126 @@ def test_close_drains_pending_uploads(tmp_path: Path) -> None:
 
     store.close()
     assert _remote_files(remote, "iris.worker")
+
+
+def test_sync_does_not_delete_remote_after_eviction(tmp_path: Path) -> None:
+    """Eviction makes the bucket the durable archive; sync must not delete it."""
+    from finelog.store.compactor import CompactionConfig
+
+    remote = tmp_path / "remote"
+    remote.mkdir()
+
+    config = CompactionConfig(max_segments_per_namespace=1, level_targets=(1,))
+    store = DuckDBLogStore(
+        log_dir=tmp_path / "data",
+        remote_log_dir=str(remote),
+        compaction_config=config,
+    )
+    try:
+        store.register_table("iris.worker", _worker_schema())
+        store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-1"], [100], [1])))
+        ns = store._namespaces["iris.worker"]
+        ns._flush_step()
+        while ns._compaction_step():
+            pass
+        ns._sync_step()
+        assert len(_remote_files(remote, "iris.worker")) == 1
+        evicted_basename = _remote_files(remote, "iris.worker")[0].name
+
+        # Trigger eviction: append another row, compact, evict (the cap is 1).
+        store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-2"], [200], [2])))
+        ns._flush_step()
+        while ns._compaction_step():
+            pass
+        ns._sync_step()
+        ns._eviction_step()
+
+        # Several sync ticks: the durable archive must still be present.
+        for _ in range(3):
+            ns._sync_step()
+        remote_names = {p.name for p in _remote_files(remote, "iris.worker")}
+        assert evicted_basename in remote_names
+    finally:
+        store.close()
+
+
+def test_orphan_delete_runs_only_after_replacement_uploaded(tmp_path: Path) -> None:
+    """Compaction promotes inputs into a higher-level replacement: the
+    input row drops at commit, the replacement is inserted at ``LOCAL``,
+    and the bucket cleanup of the (now-orphan) input file happens only
+    after phase 1 has uploaded the replacement in the same sync tick."""
+    from finelog.store.compactor import CompactionConfig
+
+    remote = tmp_path / "remote"
+    remote.mkdir()
+
+    # level_targets=(1, 2): every flush level-bumps L0 → L1 → L2. Each
+    # promotion drops the input row and inserts a new row, exercising
+    # the orphan-cleanup path on the input's remote file.
+    config = CompactionConfig(level_targets=(1, 2))
+    store = DuckDBLogStore(
+        log_dir=tmp_path / "data",
+        remote_log_dir=str(remote),
+        compaction_config=config,
+    )
+    try:
+        store.register_table("iris.worker", _worker_schema())
+        ns = store._namespaces["iris.worker"]
+
+        store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-1"], [100], [1])))
+        ns._flush_step()
+        while ns._compaction_step():
+            pass
+        ns._sync_step()
+        # After L0 → L1 → L2, only the L2 file should be in remote: the
+        # L1 file was uploaded then immediately orphan-deleted by sync's
+        # phase 2 once the L2 replacement was durable.
+        post_remote = sorted(p.name for p in _remote_files(remote, "iris.worker"))
+        assert post_remote
+        assert all(name.startswith("seg_L2_") for name in post_remote), post_remote
+        assert not any(name.startswith("seg_L1_") for name in post_remote), post_remote
+    finally:
+        store.close()
+
+
+def test_wiped_catalog_recovers_from_remote(tmp_path: Path) -> None:
+    """If the catalog DB is wiped while remote survives, the next boot
+    must adopt remote files as ``REMOTE`` rows (not delete them as orphans)."""
+    from finelog.store.catalog import CATALOG_DB_FILENAME, SegmentLocation
+
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    log_dir = tmp_path / "data"
+
+    s1 = DuckDBLogStore(log_dir=log_dir, remote_log_dir=str(remote))
+    try:
+        s1.register_table("iris.worker", _worker_schema())
+        s1.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-1"], [100], [1])))
+        ns = s1._namespaces["iris.worker"]
+        ns._flush_step()
+        ns._force_compact_l0()
+        ns._sync_step()
+        bucket_files_before = sorted(p.name for p in _remote_files(remote, "iris.worker"))
+        assert bucket_files_before
+    finally:
+        s1.close()
+
+    # Simulate a catalog wipe (e.g. PVC re-provision): blow away local
+    # state but keep the bucket.
+    (log_dir / CATALOG_DB_FILENAME).unlink()
+    for p in (log_dir / "iris.worker").glob("*"):
+        p.unlink()
+
+    s2 = DuckDBLogStore(log_dir=log_dir, remote_log_dir=str(remote))
+    try:
+        s2.register_table("iris.worker", _worker_schema())
+        ns = s2._namespaces["iris.worker"]
+        rows = ns._catalog.list_segments("iris.worker")
+        adopted = [r for r in rows if r.location is SegmentLocation.REMOTE]
+        assert {Path(r.path).name for r in adopted} == set(bucket_files_before)
+        # Sync runs without nuking the bucket.
+        ns._sync_step()
+        bucket_files_after = sorted(p.name for p in _remote_files(remote, "iris.worker"))
+        assert bucket_files_after == bucket_files_before
+    finally:
+        s2.close()


### PR DESCRIPTION
Replace the global CopyWorker with a per-namespace `_sync_step` that runs inside DiskLogNamespace's bg loop after compaction.

**Catalog model (revised after first review):** every segment has a row, with `location ∈ {LOCAL, REMOTE, BOTH}`. Compaction drops input rows immediately; eviction flips `BOTH → REMOTE` (keeps the row as a durable-archive pointer). The sync loop reconciles remote with catalog: phase 1 uploads `LOCAL` rows (or adopts the file if it's already in the bucket from a crash mid-upload), phase 2 `fs.rm`s any remote file whose basename has no catalog row. Boot recovery walks the bucket and adopts unknown files as `REMOTE` rows so a wiped catalog can't wipe the bucket.

Phase 2 is gated on phase 1 fully succeeding: if any `LOCAL` upload fails, orphan-delete is deferred to the next tick (compaction inputs whose rows were dropped at commit are the only durable copies of their seq range until the merged-output upload completes).

`drop_table` joins the bg thread before dropping catalog rows so `_sync_step` can't observe an empty catalog plus a populated bucket and treat the whole bucket as orphan.