### PR TITLE
[iris] restore JobInfo.worker_region for legacy executor clients

### DIFF
--- a/lib/iris/src/iris/client/client.py
+++ b/lib/iris/src/iris/client/client.py
@@ -37,7 +37,7 @@ from iris.cluster.client import (
     get_job_info,
     resolve_job_user,
 )
-from iris.cluster.constraints import Constraint, merge_constraints
+from iris.cluster.constraints import Constraint, WellKnownAttribute, merge_constraints, region_constraint
 from iris.cluster.log_store_helpers import build_log_source
 from iris.cluster.providers.local.cluster import LocalCluster, make_local_cluster_config
 from iris.cluster.types import (
@@ -644,6 +644,15 @@ class IrisClient:
                 constraints = []
             else:
                 constraints = merge_constraints(parent_constraints, constraints)
+
+            # Always inherit the parent's region unless the child already has
+            # an explicit region constraint.  This applies even when the caller
+            # passes constraints=[] to clear other inherited constraints —
+            # region pinning ensures children stay co-located with the
+            # reservation's claimed workers.
+            if job_info and job_info.worker_region and not any(c.key == WellKnownAttribute.REGION for c in constraints):
+                inherited_region = region_constraint([job_info.worker_region])
+                constraints = [*constraints, inherited_region]
 
         # Convert to wire format
         resources_proto = resources.to_proto()

--- a/lib/iris/src/iris/cluster/client/job_info.py
+++ b/lib/iris/src/iris/cluster/client/job_info.py
@@ -53,6 +53,13 @@ class JobInfo:
     constraints: list[Constraint] = field(default_factory=list)
     """Explicit job constraints for child job inheritance."""
 
+    worker_region: str | None = None
+    """Region of the worker running this task.
+
+    Surfaced via the ``IRIS_WORKER_REGION`` env var so legacy clients (e.g. the
+    Marin executor's region-pinning path) can inspect where they are running.
+    Iris itself no longer auto-inherits this onto child jobs — see #5279."""
+
     @property
     def task_attempt(self) -> TaskAttempt:
         """Get the structured task identity (task_id + attempt_id)."""
@@ -116,6 +123,7 @@ def get_job_info() -> JobInfo | None:
             ports=_parse_ports_from_env(),
             env=job_env,
             constraints=constraints,
+            worker_region=os.environ.get("IRIS_WORKER_REGION"),
         )
         _job_info.set(info)
         return info

--- a/lib/iris/src/iris/cluster/worker/task_attempt.py
+++ b/lib/iris/src/iris/cluster/worker/task_attempt.py
@@ -700,15 +700,17 @@ class TaskAttempt:
         )
         env = dict(iris_env)
 
-        # Surface the worker's region so in-task code (e.g. the legacy Marin
-        # executor) can query where it is running. We no longer auto-inherit
-        # this onto child jobs — see #5279 / #5541.
+        env.update(self._task_env)
+        env.update(dict(self.request.environment.env_vars))
+
+        # Surface the worker's region so in-task code (e.g. the Marin
+        # executor) and IrisClient.submit_job's parent->child region
+        # inheritance can read it via get_job_info().worker_region.
+        # Set last: this is a physical fact about the worker, not a
+        # user-configurable preference, so task/user env_vars cannot spoof it.
         region_attr = self._worker_metadata.attributes.get(WellKnownAttribute.REGION)
         if region_attr and region_attr.string_value:
             env["IRIS_WORKER_REGION"] = region_attr.string_value
-
-        env.update(self._task_env)
-        env.update(dict(self.request.environment.env_vars))
 
         # Get RuntimeEntrypoint proto directly
         rt_ep = self.request.entrypoint

--- a/lib/iris/src/iris/cluster/worker/task_attempt.py
+++ b/lib/iris/src/iris/cluster/worker/task_attempt.py
@@ -25,6 +25,7 @@ from rigging.timing import Duration, Timestamp
 
 from iris.chaos import chaos, chaos_raise
 from iris.cluster.bundle import BundleStore
+from iris.cluster.constraints import WellKnownAttribute
 from iris.cluster.log_store_helpers import task_log_key
 from iris.cluster.runtime.types import (
     ContainerConfig,
@@ -698,6 +699,13 @@ class TaskAttempt:
             self._controller_address,
         )
         env = dict(iris_env)
+
+        # Surface the worker's region so in-task code (e.g. the legacy Marin
+        # executor) can query where it is running. We no longer auto-inherit
+        # this onto child jobs — see #5279 / #5541.
+        region_attr = self._worker_metadata.attributes.get(WellKnownAttribute.REGION)
+        if region_attr and region_attr.string_value:
+            env["IRIS_WORKER_REGION"] = region_attr.string_value
 
         env.update(self._task_env)
         env.update(dict(self.request.environment.env_vars))

--- a/lib/iris/tests/cluster/client/test_job_info.py
+++ b/lib/iris/tests/cluster/client/test_job_info.py
@@ -1,7 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from iris.cluster.client.job_info import JobInfo, resolve_job_user, set_job_info
+from iris.cluster.client.job_info import JobInfo, get_job_info, resolve_job_user, set_job_info
 from iris.cluster.types import JobName
 
 
@@ -35,3 +35,37 @@ def test_resolve_job_user_falls_back_to_root_when_os_user_lookup_fails(monkeypat
 
     monkeypatch.setattr("getpass.getuser", _raise)
     assert resolve_job_user() == "root"
+
+
+def test_worker_region_from_env(monkeypatch):
+    """IRIS_WORKER_REGION is read into JobInfo.worker_region (regression for #5541)."""
+    set_job_info(None)
+    monkeypatch.setenv("IRIS_TASK_ID", "/test-user/my-job/0:1")
+    monkeypatch.setenv("IRIS_WORKER_REGION", "us-central1")
+    info = get_job_info()
+    assert info is not None
+    assert info.worker_region == "us-central1"
+    set_job_info(None)
+
+
+def test_worker_region_absent_when_env_not_set(monkeypatch):
+    """worker_region is None when IRIS_WORKER_REGION is not set."""
+    set_job_info(None)
+    monkeypatch.setenv("IRIS_TASK_ID", "/test-user/my-job/0:1")
+    monkeypatch.delenv("IRIS_WORKER_REGION", raising=False)
+    info = get_job_info()
+    assert info is not None
+    assert info.worker_region is None
+    set_job_info(None)
+
+
+def test_default_jobinfo_exposes_worker_region_attribute():
+    """Legacy callers read JobInfo.worker_region without setting it.
+
+    Regression for #5541: the Marin executor's `_iris_worker_region_pin()`
+    path constructs/reads JobInfo objects that may not have a region set.
+    The attribute must always exist (default None) so attribute access
+    doesn't AttributeError.
+    """
+    info = JobInfo(task_id=JobName.from_wire("/alice/train/0"))
+    assert info.worker_region is None

--- a/lib/iris/tests/cluster/client/test_job_info.py
+++ b/lib/iris/tests/cluster/client/test_job_info.py
@@ -1,8 +1,17 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 from iris.cluster.client.job_info import JobInfo, get_job_info, resolve_job_user, set_job_info
 from iris.cluster.types import JobName
+
+
+@pytest.fixture(autouse=True)
+def _reset_job_info():
+    """Clear the JobInfo contextvar between tests so state doesn't leak."""
+    set_job_info(None)
+    yield
+    set_job_info(None)
 
 
 def test_job_info_user_derives_from_task_id():
@@ -18,18 +27,14 @@ def test_resolve_job_user_uses_current_job_info_before_os_user(monkeypatch):
     set_job_info(JobInfo(task_id=JobName.from_wire("/alice/train/0")))
     monkeypatch.setattr("getpass.getuser", lambda: "local-user")
     assert resolve_job_user() == "alice"
-    set_job_info(None)
 
 
 def test_resolve_job_user_falls_back_to_os_user(monkeypatch):
-    set_job_info(None)
     monkeypatch.setattr("getpass.getuser", lambda: "local-user")
     assert resolve_job_user() == "local-user"
 
 
 def test_resolve_job_user_falls_back_to_root_when_os_user_lookup_fails(monkeypatch):
-    set_job_info(None)
-
     def _raise():
         raise OSError("no passwd entry")
 
@@ -39,33 +44,23 @@ def test_resolve_job_user_falls_back_to_root_when_os_user_lookup_fails(monkeypat
 
 def test_worker_region_from_env(monkeypatch):
     """IRIS_WORKER_REGION is read into JobInfo.worker_region (regression for #5541)."""
-    set_job_info(None)
     monkeypatch.setenv("IRIS_TASK_ID", "/test-user/my-job/0:1")
     monkeypatch.setenv("IRIS_WORKER_REGION", "us-central1")
     info = get_job_info()
     assert info is not None
     assert info.worker_region == "us-central1"
-    set_job_info(None)
 
 
 def test_worker_region_absent_when_env_not_set(monkeypatch):
     """worker_region is None when IRIS_WORKER_REGION is not set."""
-    set_job_info(None)
     monkeypatch.setenv("IRIS_TASK_ID", "/test-user/my-job/0:1")
     monkeypatch.delenv("IRIS_WORKER_REGION", raising=False)
     info = get_job_info()
     assert info is not None
     assert info.worker_region is None
-    set_job_info(None)
 
 
 def test_default_jobinfo_exposes_worker_region_attribute():
-    """Legacy callers read JobInfo.worker_region without setting it.
-
-    Regression for #5541: the Marin executor's `_iris_worker_region_pin()`
-    path constructs/reads JobInfo objects that may not have a region set.
-    The attribute must always exist (default None) so attribute access
-    doesn't AttributeError.
-    """
+    """JobInfo.worker_region defaults to None so attribute access never raises."""
     info = JobInfo(task_id=JobName.from_wire("/alice/train/0"))
     assert info.worker_region is None

--- a/lib/iris/tests/cluster/test_env_propagation.py
+++ b/lib/iris/tests/cluster/test_env_propagation.py
@@ -70,11 +70,13 @@ def parent_context(capturing_client):
 def _parent_job_info(
     env: dict[str, str],
     constraints: list[Constraint] | None = None,
+    worker_region: str | None = None,
 ) -> JobInfo:
     return JobInfo(
         task_id=JobName.from_wire("/parent-job/0"),
         env=env,
         constraints=constraints or [],
+        worker_region=worker_region,
     )
 
 
@@ -169,3 +171,38 @@ def test_child_explicit_constraints_override_parent(capturing_client, parent_con
     assert not any(
         c.key == WellKnownAttribute.REGION and c.value.string_value == "us-west4" for c in stub.captured_constraints
     )
+
+
+def test_child_inherits_parent_worker_region(capturing_client, parent_context):
+    """Children co-locate with the parent worker's region by default."""
+    client, stub = capturing_client
+    entrypoint = Entrypoint.from_callable(dummy_entrypoint)
+    resources = ResourceSpec(cpu=1, memory="1g")
+
+    with (
+        iris_ctx_scope(parent_context),
+        patch("iris.client.client.get_job_info", return_value=_parent_job_info({}, worker_region="us-central2")),
+    ):
+        client.submit(entrypoint, "child-inherits-region", resources)
+
+    assert any(
+        c.key == WellKnownAttribute.REGION and c.value.string_value == "us-central2" for c in stub.captured_constraints
+    )
+
+
+def test_child_explicit_region_overrides_parent_worker_region(capturing_client, parent_context):
+    """An explicit region constraint on the child wins over the inherited worker_region."""
+    client, stub = capturing_client
+    entrypoint = Entrypoint.from_callable(dummy_entrypoint)
+    resources = ResourceSpec(cpu=1, memory="1g")
+    child_constraints = [Constraint.create(key=WellKnownAttribute.REGION, op=ConstraintOp.EQ, value="europe-west4")]
+
+    with (
+        iris_ctx_scope(parent_context),
+        patch("iris.client.client.get_job_info", return_value=_parent_job_info({}, worker_region="us-central2")),
+    ):
+        client.submit(entrypoint, "child-explicit-region", resources, constraints=child_constraints)
+
+    region_constraints = [c for c in stub.captured_constraints if c.key == WellKnownAttribute.REGION]
+    assert len(region_constraints) == 1
+    assert region_constraints[0].value.string_value == "europe-west4"

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -1009,61 +1009,6 @@ def test_executor_resolve_steps_does_not_apply_unrelated_tpu_regions(iris_active
     assert resolved_tpu.fn.resources.regions == ["us-central2"]
 
 
-def test_resolve_executor_step_handles_jobinfo_without_worker_region(iris_active, remote_step):
-    """Legacy executor path must not AttributeError when JobInfo has no worker_region.
-
-    Regression for #5541: PR #5279 dropped ``JobInfo.worker_region`` while the
-    legacy executor's ``_iris_worker_region_pin()`` still reads it. With the
-    field restored (defaulting to None), step resolution proceeds normally and
-    falls back to GCS-derived region inference.
-    """
-    info = JobInfo(task_id=JobName.from_wire("/tester/parent/0:1"))
-    assert info.worker_region is None
-    set_job_info(info)
-    try:
-        resolved = resolve_executor_step(
-            remote_step,
-            config={"input_path": "gs://marin-us-central2/data/input"},
-            output_path="/out/test-abc",
-        )
-    finally:
-        set_job_info(None)
-
-    assert isinstance(resolved.fn, RemoteCallable)
-    assert resolved.fn.resources.regions == ["us-central2"]
-
-
-def test_resolve_executor_step_accepts_compatible_jobinfo_worker_region(iris_active, remote_step):
-    """When JobInfo.worker_region matches the step's allowed regions, resolution succeeds."""
-    info = JobInfo(task_id=JobName.from_wire("/tester/parent/0:1"), worker_region="us-central2")
-    set_job_info(info)
-    try:
-        resolved = resolve_executor_step(
-            remote_step,
-            config={"input_path": "gs://marin-us-central2/data/input"},
-            output_path="/out/test-abc",
-        )
-    finally:
-        set_job_info(None)
-
-    assert isinstance(resolved.fn, RemoteCallable)
-
-
-def test_resolve_executor_step_raises_when_jobinfo_region_mismatches(iris_active, remote_step):
-    """JobInfo worker_region pin must conflict-fail if it disagrees with GCS-inferred regions."""
-    info = JobInfo(task_id=JobName.from_wire("/tester/parent/0:1"), worker_region="us-east1")
-    set_job_info(info)
-    try:
-        with pytest.raises(ValueError, match="inherited Iris region"):
-            resolve_executor_step(
-                remote_step,
-                config={"input_path": "gs://marin-us-central2/data/input"},
-                output_path="/out/test-abc",
-            )
-    finally:
-        set_job_info(None)
-
-
 def _two_tpu_steps(first_regions: list[str], second_regions: list[str]) -> list[ExecutorStep]:
     @remote(resources=ResourceConfig.with_tpu("v5p-8", regions=first_regions))
     def first(_config):

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -1009,6 +1009,61 @@ def test_executor_resolve_steps_does_not_apply_unrelated_tpu_regions(iris_active
     assert resolved_tpu.fn.resources.regions == ["us-central2"]
 
 
+def test_resolve_executor_step_handles_jobinfo_without_worker_region(iris_active, remote_step):
+    """Legacy executor path must not AttributeError when JobInfo has no worker_region.
+
+    Regression for #5541: PR #5279 dropped ``JobInfo.worker_region`` while the
+    legacy executor's ``_iris_worker_region_pin()`` still reads it. With the
+    field restored (defaulting to None), step resolution proceeds normally and
+    falls back to GCS-derived region inference.
+    """
+    info = JobInfo(task_id=JobName.from_wire("/tester/parent/0:1"))
+    assert info.worker_region is None
+    set_job_info(info)
+    try:
+        resolved = resolve_executor_step(
+            remote_step,
+            config={"input_path": "gs://marin-us-central2/data/input"},
+            output_path="/out/test-abc",
+        )
+    finally:
+        set_job_info(None)
+
+    assert isinstance(resolved.fn, RemoteCallable)
+    assert resolved.fn.resources.regions == ["us-central2"]
+
+
+def test_resolve_executor_step_accepts_compatible_jobinfo_worker_region(iris_active, remote_step):
+    """When JobInfo.worker_region matches the step's allowed regions, resolution succeeds."""
+    info = JobInfo(task_id=JobName.from_wire("/tester/parent/0:1"), worker_region="us-central2")
+    set_job_info(info)
+    try:
+        resolved = resolve_executor_step(
+            remote_step,
+            config={"input_path": "gs://marin-us-central2/data/input"},
+            output_path="/out/test-abc",
+        )
+    finally:
+        set_job_info(None)
+
+    assert isinstance(resolved.fn, RemoteCallable)
+
+
+def test_resolve_executor_step_raises_when_jobinfo_region_mismatches(iris_active, remote_step):
+    """JobInfo worker_region pin must conflict-fail if it disagrees with GCS-inferred regions."""
+    info = JobInfo(task_id=JobName.from_wire("/tester/parent/0:1"), worker_region="us-east1")
+    set_job_info(info)
+    try:
+        with pytest.raises(ValueError, match="inherited Iris region"):
+            resolve_executor_step(
+                remote_step,
+                config={"input_path": "gs://marin-us-central2/data/input"},
+                output_path="/out/test-abc",
+            )
+    finally:
+        set_job_info(None)
+
+
 def _two_tpu_steps(first_regions: list[str], second_regions: list[str]) -> list[ExecutorStep]:
     @remote(resources=ResourceConfig.with_tpu("v5p-8", regions=first_regions))
     def first(_config):


### PR DESCRIPTION
Restore `JobInfo.worker_region` (default `None`), the `IRIS_WORKER_REGION` env-var injection in the worker, and the parent→child region-constraint inheritance in `IrisClient.submit_job` that was dropped in #5279.

After #5543 (which already shipped on `main`) the executor no longer reads `worker_region`, so the original AttributeError that #5541 reported is no longer triggered by the legacy executor's pinning path. This PR keeps the iris-side pieces because the next layer up still wants child jobs to co-locate with their parent worker by default — without re-introducing reads from the executor.

Behavior:
- Worker writes `IRIS_WORKER_REGION` *after* applying `self._task_env` and `request.environment.env_vars`, so the worker's physical region is authoritative and cannot be spoofed by user env vars.
- `JobInfo.worker_region` reads `IRIS_WORKER_REGION` from the environment.
- `IrisClient.submit_job` adds a `region_constraint([parent.worker_region])` to children that don't set their own region — including when the caller passes `constraints=[]`.

Tests:
- `test_job_info.py` — `worker_region` is read from the env var, defaults to `None` when unset; autouse fixture resets the contextvar between tests.
- `test_env_propagation.py` — direct coverage for parent→child `worker_region` inheritance and the explicit-region override.

Fixes #5541.