### PR TITLE
[codex] Isolate Iris Kubernetes exec client

### DIFF
--- a/lib/iris/src/iris/cluster/providers/k8s/service.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/service.py
@@ -182,7 +182,7 @@ class CloudK8sService:
             raise ImportError("Install iris[controller] to use CloudK8sService")
         if self.kubeconfig_path:
             self.kubeconfig_path = os.path.expanduser(self.kubeconfig_path)
-        self._api_client = self._new_api_client()
+        self._api_client = self.create_api_client()
 
         assert DynamicClient is not None
         self._dyn = DynamicClient(self._api_client)
@@ -195,7 +195,7 @@ class CloudK8sService:
             cmd.extend(["--kubeconfig", self.kubeconfig_path])
         self._kubectl_prefix = cmd
 
-    def _new_api_client(self) -> kubernetes.client.ApiClient:
+    def create_api_client(self) -> kubernetes.client.ApiClient:
         if self.kubeconfig_path:
             return kubernetes.config.new_client_from_config(
                 config_file=self.kubeconfig_path,
@@ -571,7 +571,7 @@ class CloudK8sService:
                 if container:
                     kwargs["container"] = container
 
-                with self._new_api_client() as exec_api_client:
+                with self.create_api_client() as exec_api_client:
                     resp = kubernetes.stream.stream(
                         kubernetes.client.CoreV1Api(exec_api_client).connect_get_namespaced_pod_exec,
                         **kwargs,

--- a/lib/iris/src/iris/cluster/providers/k8s/service.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/service.py
@@ -182,15 +182,7 @@ class CloudK8sService:
             raise ImportError("Install iris[controller] to use CloudK8sService")
         if self.kubeconfig_path:
             self.kubeconfig_path = os.path.expanduser(self.kubeconfig_path)
-            self._api_client = kubernetes.config.new_client_from_config(
-                config_file=self.kubeconfig_path,
-            )
-        else:
-            try:
-                kubernetes.config.load_incluster_config()
-                self._api_client = kubernetes.client.ApiClient()
-            except kubernetes.config.ConfigException:
-                self._api_client = kubernetes.config.new_client_from_config()
+        self._api_client = self._new_api_client()
 
         assert DynamicClient is not None
         self._dyn = DynamicClient(self._api_client)
@@ -202,6 +194,18 @@ class CloudK8sService:
         if self.kubeconfig_path:
             cmd.extend(["--kubeconfig", self.kubeconfig_path])
         self._kubectl_prefix = cmd
+
+    def _new_api_client(self) -> kubernetes.client.ApiClient:
+        if self.kubeconfig_path:
+            return kubernetes.config.new_client_from_config(
+                config_file=self.kubeconfig_path,
+            )
+
+        try:
+            kubernetes.config.load_incluster_config()
+            return kubernetes.client.ApiClient()
+        except kubernetes.config.ConfigException:
+            return kubernetes.config.new_client_from_config()
 
     def _resource_api(self, resource: K8sResource):
         """Get the DynamicClient resource handle for a K8sResource enum member."""
@@ -567,10 +571,11 @@ class CloudK8sService:
                 if container:
                     kwargs["container"] = container
 
-                resp = kubernetes.stream.stream(
-                    self._core_v1.connect_get_namespaced_pod_exec,
-                    **kwargs,
-                )
+                with self._new_api_client() as exec_api_client:
+                    resp = kubernetes.stream.stream(
+                        kubernetes.client.CoreV1Api(exec_api_client).connect_get_namespaced_pod_exec,
+                        **kwargs,
+                    )
                 return ExecResult(returncode=0, stdout=resp, stderr="")
             except ApiException as e:
                 return ExecResult(returncode=1, stdout="", stderr=str(e))

--- a/lib/iris/tests/cluster/providers/k8s/test_cloud_k8s_service.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_cloud_k8s_service.py
@@ -1,16 +1,70 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for CloudK8sService helpers and K8sResource enum path construction.
-
-These test the path construction methods on the K8sResource enum, which
-replaced the old _api_path_for_manifest and _api_path_for_resource functions.
-"""
+"""Tests for CloudK8sService helpers and K8sResource enum path construction."""
 
 from __future__ import annotations
 
 import pytest
+from iris.cluster.providers.k8s import service as k8s_service
 from iris.cluster.providers.k8s.types import K8sResource
+
+
+class _FakeApiClient:
+    def __init__(self) -> None:
+        self.request = "normal-request"
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    def __enter__(self) -> _FakeApiClient:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+
+class _FakeCoreV1Api:
+    def __init__(self, api_client: _FakeApiClient) -> None:
+        self.api_client = api_client
+
+    def connect_get_namespaced_pod_exec(self, **kwargs: object) -> str:
+        raise AssertionError("fake stream should own exec method invocation")
+
+
+def test_exec_stream_does_not_mutate_shared_api_client(monkeypatch: pytest.MonkeyPatch):
+    assert k8s_service.kubernetes is not None
+    kubernetes = k8s_service.kubernetes
+
+    monkeypatch.setattr(k8s_service, "DynamicClient", lambda api_client: object())
+    monkeypatch.setattr(kubernetes.client, "ApiClient", _FakeApiClient)
+    monkeypatch.setattr(kubernetes.client, "CoreV1Api", _FakeCoreV1Api)
+    monkeypatch.setattr(kubernetes.client, "CustomObjectsApi", lambda api_client: object())
+    monkeypatch.setattr(kubernetes.config, "load_incluster_config", lambda: None)
+
+    svc = k8s_service.CloudK8sService(namespace="iris")
+    shared_client = svc._api_client
+    shared_request = shared_client.request
+    stream_client: _FakeApiClient | None = None
+
+    def stream(api_method, **kwargs: object) -> str:
+        nonlocal stream_client
+        core_v1 = api_method.__self__
+        stream_client = core_v1.api_client
+        stream_client.request = "websocket-request"
+        return "stdout"
+
+    monkeypatch.setattr(kubernetes.stream, "stream", stream)
+
+    result = svc.exec("pod-1", ["true"], container="task", timeout=5)
+
+    assert result.returncode == 0
+    assert result.stdout == "stdout"
+    assert stream_client is not None
+    assert stream_client is not shared_client
+    assert shared_client.request == shared_request
+    assert stream_client.closed
 
 
 # Test item_path construction for namespaced resources

--- a/lib/iris/tests/cluster/providers/k8s/test_cloud_k8s_service.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_cloud_k8s_service.py
@@ -6,65 +6,7 @@
 from __future__ import annotations
 
 import pytest
-from iris.cluster.providers.k8s import service as k8s_service
 from iris.cluster.providers.k8s.types import K8sResource
-
-
-class _FakeApiClient:
-    def __init__(self) -> None:
-        self.request = "normal-request"
-        self.closed = False
-
-    def close(self) -> None:
-        self.closed = True
-
-    def __enter__(self) -> _FakeApiClient:
-        return self
-
-    def __exit__(self, *exc_info: object) -> None:
-        self.close()
-
-
-class _FakeCoreV1Api:
-    def __init__(self, api_client: _FakeApiClient) -> None:
-        self.api_client = api_client
-
-    def connect_get_namespaced_pod_exec(self, **kwargs: object) -> str:
-        raise AssertionError("fake stream should own exec method invocation")
-
-
-def test_exec_stream_does_not_mutate_shared_api_client(monkeypatch: pytest.MonkeyPatch):
-    assert k8s_service.kubernetes is not None
-    kubernetes = k8s_service.kubernetes
-
-    monkeypatch.setattr(k8s_service, "DynamicClient", lambda api_client: object())
-    monkeypatch.setattr(kubernetes.client, "ApiClient", _FakeApiClient)
-    monkeypatch.setattr(kubernetes.client, "CoreV1Api", _FakeCoreV1Api)
-    monkeypatch.setattr(kubernetes.client, "CustomObjectsApi", lambda api_client: object())
-    monkeypatch.setattr(kubernetes.config, "load_incluster_config", lambda: None)
-
-    svc = k8s_service.CloudK8sService(namespace="iris")
-    shared_client = svc._api_client
-    shared_request = shared_client.request
-    stream_client: _FakeApiClient | None = None
-
-    def stream(api_method, **kwargs: object) -> str:
-        nonlocal stream_client
-        core_v1 = api_method.__self__
-        stream_client = core_v1.api_client
-        stream_client.request = "websocket-request"
-        return "stdout"
-
-    monkeypatch.setattr(kubernetes.stream, "stream", stream)
-
-    result = svc.exec("pod-1", ["true"], container="task", timeout=5)
-
-    assert result.returncode == 0
-    assert result.stdout == "stdout"
-    assert stream_client is not None
-    assert stream_client is not shared_client
-    assert shared_client.request == shared_request
-    assert stream_client.closed
 
 
 # Test item_path construction for namespaced resources


### PR DESCRIPTION
## Summary

Fixes #5529.

`kubernetes.stream.stream()` temporarily replaces the `ApiClient.request` method on the `CoreV1Api` instance it is given. `CloudK8sService` was passing the shared `_core_v1`, so a concurrent provider list/get could run through websocket transport and interpret a normal `PodList` HTTP 200 as a websocket handshake.

This PR keeps the shared `_api_client`, `_dyn`, `_core_v1`, and `_custom` for normal Kubernetes operations, but makes `CloudK8sService.exec()` construct and close a short-lived `ApiClient`/`CoreV1Api` for websocket-backed pod exec. The helper uses the same kubeconfig, in-cluster, and default config construction paths as service initialization.

## Repro

Before the fix, I reproduced the failure locally without touching a cluster:

- Local HTTP server returned a normal Kubernetes-style `PodList` with HTTP 200.
- A fake bound exec method reused the same `ApiClient` that a normal list/get path would use.
- During `kubernetes.stream.stream()`, `api_client.request` was `websocket_call`.
- A normal GET on that shared client failed with `ApiException(status=0)` and a reason containing `Handshake status 200 OK ... {"kind": "PodList", "apiVersion": "v1", ...}`.

## Validation

- Re-ran the local repro against this branch with `CloudK8sService.exec()`: the isolated exec client entered websocket mode, while the shared client successfully fetched the `PodList` during and after exec.
- `./infra/pre-commit.py --fix lib/iris/src/iris/cluster/providers/k8s/service.py lib/iris/tests/cluster/providers/k8s/test_cloud_k8s_service.py`
- `cd lib/iris && uv run python -m pytest tests/cluster/providers/k8s/test_cloud_k8s_service.py -q`