### PR TITLE
Make Levanter checkpoints region-aware via mirror:// + resolve_tree

### DIFF
--- a/experiments/tutorials/train_tiny_sweep_tpu.py
+++ b/experiments/tutorials/train_tiny_sweep_tpu.py
@@ -74,7 +74,11 @@ class SweepTrial:
 # Build all trials at submission time so workers do no config work. Configs
 # carry placeholders (OutputName, InputName) until resolved on the worker, so
 # checkpoint paths land in the *worker's* region after a cross-region
-# preemption.
+# preemption.  ``bake_output_path`` writes the checkpointer base as a
+# ``mirror://`` URL, and Levanter's checkpoint save/load route through
+# ``resolve_tree``, so a trial preempted in one region resumes the prior
+# step's checkpoint after rescheduling to a different region instead of
+# restarting from step 0.
 trials = []
 for sc in sweep_configs:
     # Marin will automatically create unique ids for runs b/c the model_config is versioned

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -33,6 +33,8 @@ from haliax.jax_utils import is_in_jit, is_jax_array_like
 from jax.experimental.array_serialization.serialization import GlobalAsyncCheckpointManager
 from jaxtyping import PyTree
 
+from rigging.filesystem import resolve_tree
+
 from levanter._debug_logging import flush_debug_output
 from levanter.tensorstore_serialization import (
     tree_deserialize_leaves_tensorstore,
@@ -689,7 +691,9 @@ def save_checkpoint(
         is_temporary: whether the checkpoint is temporary
     """
     step = int(step)
-    checkpoint_path = str(checkpoint_path)
+    # Resolve mirror:// to a concrete URL once, before tensorstore (which bypasses
+    # fsspec) and the metadata writer see the path.  Passthrough for non-mirror paths.
+    checkpoint_path = resolve_tree(str(checkpoint_path), mode="write")
     checkpoint_debug = debug or CheckpointDebugConfig()
     logger.info(f"Saving checkpoint to {checkpoint_path} for step {step}")
     progress_logger: _CheckpointProgressLogger | None = None
@@ -792,7 +796,9 @@ def load_checkpoint(
         the loaded checkpoint, with the same structure as the exemplar tree
 
     """
-    checkpoint_path = str(checkpoint_path)
+    # Materialize the entire checkpoint tree locally once, before tensorstore opens
+    # any kvstore.  Passthrough for non-mirror paths.
+    checkpoint_path = resolve_tree(str(checkpoint_path), mode="read")
 
     if is_in_jit():
         logger.warning("Loading checkpoint in jit. This is not recommended and probably won't work.")

--- a/lib/marin/src/marin/training/training.py
+++ b/lib/marin/src/marin/training/training.py
@@ -13,7 +13,7 @@ from typing import TypeVar
 import draccus
 from fray import CpuConfig, GpuConfig, ResourceConfig, TpuConfig
 from mergedeep import mergedeep
-from rigging.filesystem import check_gcs_paths_same_region, marin_temp_bucket
+from rigging.filesystem import check_gcs_paths_same_region, marin_temp_bucket, to_mirror_url
 
 from marin.execution.executor import materialize
 from marin.training.run_environment import add_run_env_variables
@@ -108,9 +108,19 @@ def bake_output_path(train_config: TrainConfigT, output_path: str) -> TrainConfi
     """Bake ``output_path`` into the trainer's checkpointer and HF save path.
 
     Sets:
-    * ``trainer.checkpointer.base_path`` → ``<output_path>/checkpoints``
-    * ``trainer.checkpointer.temporary_base_path`` → region-local temp bucket
-    * ``hf_save_path`` → ``<output_path>/hf``
+    * ``trainer.checkpointer.base_path`` → ``mirror://<output_path>/checkpoints``
+      so a job preempted in one region resumes the prior checkpoint after
+      rescheduling to a different region.  ``mirror://`` paths are converted
+      to a concrete regional URL by ``resolve_tree`` at the tensorstore
+      boundary inside Levanter; the marin bucket→region mapping is the only
+      thing that varies between regions.
+    * ``trainer.checkpointer.temporary_base_path`` → region-local temp bucket.
+      Stays regional: temp checkpoints exist to bridge save_interval gaps
+      within a single training session and are cleared by bucket TTL — the
+      cross-region copy cost on resume rarely pays off before they're
+      superseded.
+    * ``hf_save_path`` → ``<output_path>/hf`` (concrete; HF export does not
+      need cross-region resume in this PR).
 
     The ``append_run_id_to_base_path`` flag is NOT changed here; callers that
     impute a run id from the output path should also set it to ``False`` via
@@ -120,7 +130,7 @@ def bake_output_path(train_config: TrainConfigT, output_path: str) -> TrainConfi
         train_config.trainer,
         checkpointer=replace(
             train_config.trainer.checkpointer,
-            base_path=os.path.join(output_path, DEFAULT_CHECKPOINTS_PATH),
+            base_path=to_mirror_url(os.path.join(output_path, DEFAULT_CHECKPOINTS_PATH)),
             temporary_base_path=temporary_checkpoint_base_path(output_path),
         ),
     )

--- a/lib/rigging/src/rigging/filesystem.py
+++ b/lib/rigging/src/rigging/filesystem.py
@@ -23,6 +23,7 @@ Cross-region transfer budget:
   the ``MARIN_I_WILL_PAY_FOR_ALL_FEES`` env var to override the guard.
 """
 
+import concurrent.futures
 import contextlib
 import contextvars
 import dataclasses
@@ -30,14 +31,16 @@ import functools
 import logging
 import os
 import pathlib
+import posixpath
 import re
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from collections.abc import Callable, Generator, Sequence
 from pathlib import PurePath
-from typing import Any
+from typing import Any, Literal
 
 import fsspec
 
@@ -824,6 +827,20 @@ class MirrorFileSystem(fsspec.AbstractFileSystem):
         self._remote_prefixes = _mirror_remote_prefixes(self._local_prefix)
         self._budget = budget if budget is not None else _global_transfer_budget
         self._worker_id = default_worker_id()
+        # Process-local per-file mutexes.  The distributed lock serializes
+        # copies across processes; threads inside a single process share the
+        # same ``worker_id`` and would all "successfully" reacquire it, so
+        # we need an in-memory lock to prevent intra-process duplicate copies.
+        self._inproc_copy_locks: dict[str, threading.Lock] = {}
+        self._inproc_copy_locks_mutex = threading.Lock()
+
+    def _inproc_copy_lock(self, path: str) -> threading.Lock:
+        with self._inproc_copy_locks_mutex:
+            lock = self._inproc_copy_locks.get(path)
+            if lock is None:
+                lock = threading.Lock()
+                self._inproc_copy_locks[path] = lock
+            return lock
 
     # -- budget resolution ----------------------------------------------------
 
@@ -858,6 +875,15 @@ class MirrorFileSystem(fsspec.AbstractFileSystem):
         return fs.size(fspath)
 
     def _fs_copy(self, src_url: str, dst_url: str) -> None:
+        """Copy one file from *src_url* to *dst_url*.
+
+        No tmp+rename: GCS and S3 PUTs commit atomically (the destination
+        object is invisible until upload finishes), and local destinations
+        only see one writer per file in real workloads — the per-file
+        lock + intra-process mutex in :meth:`_copy_to_local` already
+        serializes intra-process writers, and there is no realistic
+        scenario where two separate processes race on the same local path.
+        """
         src_fs, src_path = self._get_fs_and_path(src_url)
         dst_fs, dst_path = self._get_fs_and_path(dst_url)
 
@@ -882,55 +908,195 @@ class MirrorFileSystem(fsspec.AbstractFileSystem):
         return None
 
     def _copy_to_local(self, source_prefix: str, path: str) -> None:
-        local_url = self._local_url(path)
-        remote_url = self._remote_url(source_prefix, path)
+        """Copy one file from *source_prefix* to the local prefix.
 
-        lock = create_lock(self._lock_path_for(path), self._worker_id)
+        Two-layer locking:
 
-        if not lock.try_acquire():
-            for _ in range(60):
-                time.sleep(2)
-                if self._fs_exists(local_url):
-                    return
-                if not lock.has_active_holder():
-                    break
-            if self._fs_exists(local_url):
-                return
-            if not lock.try_acquire():
-                raise RuntimeError(f"Could not acquire mirror lock for {path} after waiting")
+        - Process-local :class:`threading.Lock` serializes threads inside
+          this process (the distributed lock can't, since they share a
+          worker id).
+        - Distributed lock serializes processes across the cluster.
 
-        try:
-            if self._fs_exists(local_url):
-                return
-
-            size = self._fs_size(remote_url)
-            if size is not None:
-                self._active_budget().record(size, remote_url)
-
-            logger.info("Mirror: copying %s → %s", remote_url, local_url)
-            self._fs_copy(remote_url, local_url)
-        finally:
-            lock.release()
-
-    def _resolve_path(self, path: str) -> str:
-        """Resolve a mirror path to a concrete URL, copying if needed."""
+        Atomic at the destination via :meth:`_fs_copy`, so partial files
+        are never observable even if both locks fail.
+        """
         local_url = self._local_url(path)
         if self._fs_exists(local_url):
-            return local_url
+            return
 
-        source_prefix = self._find_in_remote_prefixes(path)
+        with self._inproc_copy_lock(path):
+            if self._fs_exists(local_url):
+                return
+
+            remote_url = self._remote_url(source_prefix, path)
+            lock = create_lock(self._lock_path_for(path), self._worker_id)
+
+            if not lock.try_acquire():
+                for _ in range(60):
+                    time.sleep(2)
+                    if self._fs_exists(local_url):
+                        return
+                    if not lock.has_active_holder():
+                        break
+                if self._fs_exists(local_url):
+                    return
+                if not lock.try_acquire():
+                    raise RuntimeError(f"Could not acquire mirror lock for {path} after waiting")
+
+            try:
+                if self._fs_exists(local_url):
+                    return
+
+                size = self._fs_size(remote_url)
+                if size is not None:
+                    self._active_budget().record(size, remote_url)
+
+                logger.info("Mirror: copying %s → %s", remote_url, local_url)
+                self._fs_copy(remote_url, local_url)
+            finally:
+                lock.release()
+
+    # -- tree-on-open materialization ----------------------------------------
+
+    def _copy_one_file(self, file_rel: str) -> None:
+        """Copy one file to the local prefix, picking whichever region has it.
+
+        Uses the mirror's union view: any remote that carries the file is a
+        valid source.  Pure no-op when the file is already local.  Silently
+        skips files that disappeared from every region between enumeration
+        and copy (concurrent delete in source).
+        """
+        if self._fs_exists(self._local_url(file_rel)):
+            return
+        source_prefix = self._find_in_remote_prefixes(file_rel)
         if source_prefix is None:
+            return
+        self._copy_to_local(source_prefix, file_rel)
+
+    def _copy_tree_to_local(self, dir_rel: str, *, parallelism: int = 32) -> None:
+        """Materialize every file under *dir_rel* in the local prefix.
+
+        Walks the mirror's union view recursively; each subdir scan and
+        each file copy runs as its own pool task, so deep trees fan out
+        naturally.  Per-file locking + atomic destination writes (via
+        :meth:`_copy_to_local`) keep racing copies cheap and correct.
+
+        No pre-flight budget check — files charge against the
+        :class:`TransferBudget` as they're copied, surfacing exhaustion
+        the moment a copy would push past the limit.
+        """
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=parallelism)
+        futures: list[concurrent.futures.Future] = []
+        futures_lock = threading.Lock()
+
+        def submit(fn: Callable[..., Any], *args: Any) -> None:
+            # Propagate the current context (notably the mirror-budget
+            # contextvar) into the worker thread; ThreadPoolExecutor does
+            # not do this by default.
+            ctx = contextvars.copy_context()
+            fut = pool.submit(ctx.run, fn, *args)
+            with futures_lock:
+                futures.append(fut)
+
+        def visit(rel: str) -> None:
+            try:
+                entries = self.ls(rel, detail=True)
+            except FileNotFoundError:
+                return
+            for entry in entries:
+                name = entry["name"]
+                if entry.get("type") == "directory":
+                    submit(visit, name)
+                else:
+                    submit(self._copy_one_file, name)
+
+        try:
+            submit(visit, dir_rel)
+            # Drain.  visit() can append more futures while we wait, so re-check
+            # the list length after each await rather than snapshotting it.
+            i = 0
+            while True:
+                with futures_lock:
+                    if i >= len(futures):
+                        break
+                    fut = futures[i]
+                fut.result()
+                i += 1
+        finally:
+            pool.shutdown()
+
+    def _ensure_file_local(self, path: str, *, parallelism: int = 32) -> None:
+        """Ensure *path* is locally present, materializing its enclosing dir."""
+        local_url = self._local_url(path)
+        if self._fs_exists(local_url):
+            return
+
+        parent = posixpath.dirname(path)
+        if parent:
+            self._copy_tree_to_local(parent, parallelism=parallelism)
+        else:
+            # Top-level file with no enclosing directory in the mirror namespace.
+            self._copy_one_file(path)
+
+        if not self._fs_exists(local_url):
             raise FileNotFoundError(f"mirror://{path} not found in any marin bucket")
 
-        self._copy_to_local(source_prefix, path)
-        return local_url
+    # -- public tree-resolve --------------------------------------------------
+
+    def resolve_tree(
+        self,
+        path: str,
+        *,
+        mode: Literal["read", "write"],
+        parallelism: int = 32,
+    ) -> str:
+        """Resolve a directory tree URL to a concrete local URL.
+
+        - ``mode="read"``: ensure every file under *path* exists locally,
+          copying from whichever region(s) carry the tree.  Returns the
+          concrete local URL.
+        - ``mode="write"``: ensure the local destination directory exists
+          and return its concrete URL.  No copy.
+        """
+        rel = self._strip_protocol(path)
+        local_url = self._local_url(rel)
+
+        if mode == "write":
+            local_fs, local_path = self._get_fs_and_path(local_url)
+            local_fs.makedirs(local_path, exist_ok=True)
+            return local_url
+
+        if mode == "read":
+            self._copy_tree_to_local(rel, parallelism=parallelism)
+            if not self._fs_exists(local_url):
+                raise FileNotFoundError(f"mirror://{rel}: no marin region carries this tree")
+            return local_url
+
+        raise ValueError(f"resolve_tree: invalid mode {mode!r}; expected 'read' or 'write'")
 
     # -- fsspec interface: info/ls/exists -------------------------------------
 
     def _info(self, path: str, **kwargs: Any) -> dict[str, Any]:
+        """Probe-only file info.
+
+        Does NOT auto-copy the file.  Returns metadata from the local prefix
+        if present, otherwise from the first remote prefix that has the
+        file.  Tree materialization happens only on read (``_open`` /
+        ``cat_file``) or via :meth:`resolve_tree`.
+        """
         path = self._strip_protocol(path)
-        resolved = self._resolve_path(path)
-        fs, fspath = self._get_fs_and_path(resolved)
+        local_url = self._local_url(path)
+        if self._fs_exists(local_url):
+            fs, fspath = self._get_fs_and_path(local_url)
+            info = fs.info(fspath, **kwargs)
+            info["name"] = path
+            return info
+
+        source_prefix = self._find_in_remote_prefixes(path)
+        if source_prefix is None:
+            raise FileNotFoundError(f"mirror://{path} not found in any marin bucket")
+        remote_url = self._remote_url(source_prefix, path)
+        fs, fspath = self._get_fs_and_path(remote_url)
         info = fs.info(fspath, **kwargs)
         info["name"] = path
         return info
@@ -980,8 +1146,9 @@ class MirrorFileSystem(fsspec.AbstractFileSystem):
     def _open(self, path: str, mode: str = "rb", **kwargs: Any) -> Any:
         path = self._strip_protocol(path)
         if "r" in mode:
-            resolved = self._resolve_path(path)
-            fs, fspath = self._get_fs_and_path(resolved)
+            self._ensure_file_local(path)
+            local_url = self._local_url(path)
+            fs, fspath = self._get_fs_and_path(local_url)
             return fs.open(fspath, mode, **kwargs)
         else:
             local_url = self._local_url(path)
@@ -993,8 +1160,9 @@ class MirrorFileSystem(fsspec.AbstractFileSystem):
 
     def cat_file(self, path: str, start: int | None = None, end: int | None = None, **kwargs: Any) -> bytes:
         path = self._strip_protocol(path)
-        resolved = self._resolve_path(path)
-        fs, fspath = self._get_fs_and_path(resolved)
+        self._ensure_file_local(path)
+        local_url = self._local_url(path)
+        fs, fspath = self._get_fs_and_path(local_url)
         return fs.cat_file(fspath, start=start, end=end, **kwargs)
 
     # -- fsspec interface: write operations ------------------------------------
@@ -1032,9 +1200,10 @@ class MirrorFileSystem(fsspec.AbstractFileSystem):
     def copy(self, path1: str, path2: str, **kwargs: Any) -> None:
         path1 = self._strip_protocol(path1)
         path2 = self._strip_protocol(path2)
-        resolved_src = self._resolve_path(path1)
-        local_dst = self._local_url(path2)
-        self._fs_copy(resolved_src, local_dst)
+        self._ensure_file_local(path1)
+        src_local = self._local_url(path1)
+        dst_local = self._local_url(path2)
+        self._fs_copy(src_local, dst_local)
 
     @property
     def bytes_copied(self) -> int:
@@ -1044,3 +1213,57 @@ class MirrorFileSystem(fsspec.AbstractFileSystem):
 
 # Register the mirror:// protocol with fsspec.
 fsspec.register_implementation("mirror", MirrorFileSystem)
+
+
+# ---------------------------------------------------------------------------
+# Tree-resolve and mirror-URL helpers
+#
+# These exist so that systems that do not understand the mirror:// protocol
+# (notably tensorstore, which opens GCS kvstores directly) can still receive
+# a concrete URL while their callers configure paths as mirror://.
+# ---------------------------------------------------------------------------
+
+
+def resolve_tree(
+    path: str,
+    *,
+    mode: Literal["read", "write"],
+    parallelism: int = 32,
+) -> str:
+    """Resolve a directory tree URL to a concrete URL.
+
+    Passthrough for non-``mirror://`` paths.  For ``mirror://`` paths,
+    delegates to :meth:`MirrorFileSystem.resolve_tree`:
+
+    - ``mode="read"``: ensure every file under *path* is locally present
+      (copying from whichever remote region carries the tree) and return
+      the concrete local URL.
+    - ``mode="write"``: ensure the local destination directory exists and
+      return its concrete URL.  No copy.
+
+    Used at the boundary to systems that bypass fsspec — primarily
+    tensorstore, which opens its GCS kvstore from the path string and
+    cannot navigate ``mirror://`` itself.
+    """
+    if not path.startswith("mirror://"):
+        return path
+    fs = fsspec.filesystem("mirror")
+    return fs.resolve_tree(path, mode=mode, parallelism=parallelism)
+
+
+def to_mirror_url(concrete_url: str) -> str:
+    """Convert a marin ``gs://marin-{region}/path`` URL to ``mirror://path``.
+
+    Passthrough for non-GCS URLs and for GCS URLs whose bucket is not a
+    known marin data bucket.  Already-``mirror://`` URLs are returned
+    unchanged.
+    """
+    if concrete_url.startswith("mirror://"):
+        return concrete_url
+    bucket = _bucket_from_gcs_url(concrete_url)
+    if bucket is None or bucket not in _BUCKET_TO_REGION:
+        return concrete_url
+    rest = concrete_url[len("gs://") + len(bucket) :].lstrip("/")
+    if not rest:
+        return concrete_url
+    return f"mirror://{rest}"

--- a/lib/rigging/tests/test_mirror_fs.py
+++ b/lib/rigging/tests/test_mirror_fs.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import threading
 
 import fsspec
 import pytest
@@ -10,6 +11,8 @@ from rigging.filesystem import (
     TransferBudget,
     TransferBudgetExceeded,
     _mirror_remote_prefixes,
+    resolve_tree,
+    to_mirror_url,
 )
 
 
@@ -40,6 +43,8 @@ def mirror_fs(mirror_env, tmp_path):
     fs._remote_prefixes = mirror_env["remote_prefixes"]
     fs._budget = TransferBudget(limit_bytes=10 * 1024 * 1024 * 1024)
     fs._worker_id = "test-holder"
+    fs._inproc_copy_locks = {}
+    fs._inproc_copy_locks_mutex = threading.Lock()
     lock_dir = str(tmp_path / "locks")
     fs._lock_path_for = lambda path: os.path.join(lock_dir, f"{path.replace('/', '_')}.lock")
     return fs
@@ -81,15 +86,21 @@ def test_copy_budget_raises_when_exceeded(mirror_fs, mirror_env):
 
 
 def test_copy_budget_cumulative(mirror_fs, mirror_env):
-    mirror_fs._budget.reset(limit_bytes=1500)
-    _write_file(mirror_env["remote1"], "data/a.bin", b"x" * 800)
-    _write_file(mirror_env["remote1"], "data/b.bin", b"y" * 800)
+    """Budget accumulates across separate tree copies.
 
-    mirror_fs.cat_file("data/a.bin")
+    Each ``cat_file`` materializes the file's enclosing directory; placing
+    the two files in separate parent dirs is the only way to drive
+    independent copies in tree-on-open semantics.
+    """
+    mirror_fs._budget.reset(limit_bytes=1500)
+    _write_file(mirror_env["remote1"], "tree-a/file.bin", b"x" * 800)
+    _write_file(mirror_env["remote1"], "tree-b/file.bin", b"y" * 800)
+
+    mirror_fs.cat_file("tree-a/file.bin")
     assert mirror_fs.bytes_copied == 800
 
     with pytest.raises(TransferBudgetExceeded):
-        mirror_fs.cat_file("data/b.bin")
+        mirror_fs.cat_file("tree-b/file.bin")
 
 
 def test_second_read_uses_local_cache(mirror_fs, mirror_env):
@@ -235,3 +246,180 @@ def test_mirror_filesystem_init_skips_gcs_on_s3_prefix(monkeypatch):
     fs = MirrorFileSystem()
     assert fs._local_prefix == "s3://marin-na/marin"
     assert fs._remote_prefixes == []
+
+
+# ---------------------------------------------------------------------------
+# Tree-on-open semantics: opening any file materializes its enclosing dir.
+# ---------------------------------------------------------------------------
+
+
+def test_open_one_file_copies_entire_enclosing_dir(mirror_fs, mirror_env):
+    """Reading one file in a remote-only dir brings every sibling local.
+
+    Regression guard: if mirror only copied the file you opened, a later
+    consumer that walked the directory locally would see only that one file
+    even though the source has many.  Tree-on-open closes that gap.
+    """
+    _write_file(mirror_env["remote1"], "step-200/metadata.json", b"{}")
+    _write_file(mirror_env["remote1"], "step-200/shard-0", b"shard0-bytes")
+    _write_file(mirror_env["remote1"], "step-200/shard-1", b"shard1-bytes")
+
+    # Open exactly one file.
+    assert mirror_fs.cat_file("step-200/metadata.json") == b"{}"
+
+    # All siblings must now be local.
+    local_dir = os.path.join(mirror_env["local_dir"], "step-200")
+    assert sorted(os.listdir(local_dir)) == ["metadata.json", "shard-0", "shard-1"]
+
+
+def test_open_subdir_file_copies_recursive_subtree(mirror_fs, mirror_env):
+    """Opening a deep file materializes the whole containing subtree.
+
+    The mirror walks the union ls recursively, so files in nested
+    directories under the file's parent come along too.
+    """
+    _write_file(mirror_env["remote1"], "step-200/metadata.json", b"{}")
+    _write_file(mirror_env["remote1"], "step-200/zarr/0/manifest", b"m0")
+    _write_file(mirror_env["remote1"], "step-200/zarr/0/data", b"d0")
+    _write_file(mirror_env["remote1"], "step-200/zarr/1/manifest", b"m1")
+
+    mirror_fs.cat_file("step-200/metadata.json")
+
+    base = os.path.join(mirror_env["local_dir"], "step-200")
+    assert os.path.exists(os.path.join(base, "metadata.json"))
+    assert os.path.exists(os.path.join(base, "zarr/0/manifest"))
+    assert os.path.exists(os.path.join(base, "zarr/0/data"))
+    assert os.path.exists(os.path.join(base, "zarr/1/manifest"))
+
+
+def test_open_unions_files_split_across_regions(mirror_fs, mirror_env):
+    """A tree split across multiple regions is reassembled locally.
+
+    Different files of the same logical tree live in different regions —
+    each pulls from whichever region carries it.
+    """
+    _write_file(mirror_env["remote1"], "tree/a", b"AAA")
+    _write_file(mirror_env["remote2"], "tree/b", b"BBB")
+
+    mirror_fs.cat_file("tree/a")
+
+    base = os.path.join(mirror_env["local_dir"], "tree")
+    with open(os.path.join(base, "a"), "rb") as f:
+        assert f.read() == b"AAA"
+    with open(os.path.join(base, "b"), "rb") as f:
+        assert f.read() == b"BBB"
+
+
+def test_info_does_not_copy(mirror_fs, mirror_env):
+    """``info`` is probe-only; it must not auto-materialize the tree.
+
+    Tree materialization happens on read (open / cat_file) or via
+    ``resolve_tree``.  ``info`` is metadata-only and goes through the
+    remote when the file isn't local yet.
+    """
+    _write_file(mirror_env["remote1"], "tree/file.bin", b"x" * 10)
+
+    info = mirror_fs.info("tree/file.bin")
+    assert info["size"] == 10
+
+    # Nothing should have been copied locally.
+    assert not os.path.exists(os.path.join(mirror_env["local_dir"], "tree"))
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: per-file lock + in-process mutex prevent redundant transfers.
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_opens_only_copy_each_file_once(mirror_fs, mirror_env):
+    """Racing readers in one process pay exactly one transfer per file.
+
+    Without the in-process mutex, threads sharing a worker id all
+    "successfully" reacquire the distributed lock and each fetch the same
+    file — wasting bandwidth.  With it, only the first thread copies and
+    the rest see the file already local.
+    """
+    _write_file(mirror_env["remote1"], "tree/a.bin", b"A" * 100)
+    _write_file(mirror_env["remote1"], "tree/b.bin", b"B" * 200)
+
+    def worker():
+        mirror_fs.cat_file("tree/a.bin")
+        mirror_fs.cat_file("tree/b.bin")
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert mirror_fs.bytes_copied == 300
+
+
+# ---------------------------------------------------------------------------
+# resolve_tree
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_tree_passthrough_for_non_mirror():
+    """Non-``mirror://`` URLs round-trip unchanged in both modes."""
+    assert resolve_tree("gs://some-bucket/path", mode="read") == "gs://some-bucket/path"
+    assert resolve_tree("/tmp/foo", mode="write") == "/tmp/foo"
+    assert resolve_tree("file:///tmp/foo", mode="read") == "file:///tmp/foo"
+
+
+def test_resolve_tree_write_returns_local_url(mirror_fs, mirror_env):
+    """``mode="write"`` mkdirs the local destination and returns its concrete URL."""
+    out = mirror_fs.resolve_tree("mirror://step-200", mode="write")
+    expected = os.path.join(mirror_env["local_dir"], "step-200")
+    assert out == expected
+    assert os.path.isdir(expected)
+
+
+def test_resolve_tree_read_materializes_remote_tree(mirror_fs, mirror_env):
+    """``mode="read"`` copies every file under the tree from remote regions."""
+    _write_file(mirror_env["remote1"], "step-200/metadata.json", b"{}")
+    _write_file(mirror_env["remote1"], "step-200/zarr/0/data", b"d0")
+    _write_file(mirror_env["remote2"], "step-200/zarr/1/data", b"d1")
+
+    out = mirror_fs.resolve_tree("mirror://step-200", mode="read")
+
+    expected = os.path.join(mirror_env["local_dir"], "step-200")
+    assert out == expected
+    assert os.path.exists(os.path.join(expected, "metadata.json"))
+    assert os.path.exists(os.path.join(expected, "zarr/0/data"))
+    assert os.path.exists(os.path.join(expected, "zarr/1/data"))
+
+
+def test_resolve_tree_read_raises_when_tree_missing(mirror_fs):
+    with pytest.raises(FileNotFoundError, match="no marin region carries this tree"):
+        mirror_fs.resolve_tree("mirror://nope", mode="read")
+
+
+def test_resolve_tree_invalid_mode(mirror_fs):
+    with pytest.raises(ValueError, match="invalid mode"):
+        mirror_fs.resolve_tree("mirror://x", mode="bogus")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# to_mirror_url
+# ---------------------------------------------------------------------------
+
+
+def test_to_mirror_url_converts_marin_bucket():
+    assert to_mirror_url("gs://marin-us-central1/run-x/checkpoints") == "mirror://run-x/checkpoints"
+    assert to_mirror_url("gs://marin-eu-west4/foo/bar") == "mirror://foo/bar"
+
+
+def test_to_mirror_url_passthrough_non_marin():
+    """Non-marin GCS buckets and non-GCS URLs round-trip unchanged."""
+    assert to_mirror_url("gs://some-other-bucket/path") == "gs://some-other-bucket/path"
+    assert to_mirror_url("s3://x/y") == "s3://x/y"
+    assert to_mirror_url("/local/path") == "/local/path"
+    # Already a mirror URL — leave alone.
+    assert to_mirror_url("mirror://run-x") == "mirror://run-x"
+
+
+def test_to_mirror_url_skips_bare_bucket():
+    """A URL with no key inside the bucket has no tree to mirror; passthrough."""
+    assert to_mirror_url("gs://marin-us-central1") == "gs://marin-us-central1"
+    assert to_mirror_url("gs://marin-us-central1/") == "gs://marin-us-central1/"

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -92,7 +92,13 @@ def test_update_config_to_use_out_path_sets_run_specific_temp_checkpoints(traine
         updated = _update_config_to_use_out_path(config)
 
         checkpointer = updated.train_config.trainer.checkpointer
-        assert checkpointer.base_path == "gs://marin-us-east5/experiments/grug/base-trial/checkpoints"
+        # base_path is mirror:// so a job preempted in one region resumes the prior
+        # checkpoint after rescheduling to another region.  The marin-{region}
+        # bucket is the only thing that varies between regions, so dropping it
+        # from the URL is sufficient.
+        assert checkpointer.base_path == "mirror://experiments/grug/base-trial/checkpoints"
+        # Temp checkpoints stay regional: TTL handles cleanup, and cross-region
+        # copy on resume rarely pays off before they're superseded.
         assert checkpointer.temporary_base_path == (
             "gs://marin-us-east5/tmp/ttl=14d/" "checkpoints-temp/marin-us-east5/experiments/grug/base-trial/checkpoints"
         )


### PR DESCRIPTION
Checkpointer base path now uses mirror://, and Levanter's save/load route through resolve_tree at the tensorstore boundary. A trial preempted in one region resumes the prior step's checkpoint after rescheduling to a different region instead of starting from step 0. MirrorFileSystem now copies the file's enclosing tree on read (union across regions), with per-file lock + intra-process mutex preventing redundant transfers.