### PR TITLE
[iris] Cap ListJobs offset and stop unfiltered page-walks

### DIFF
--- a/lib/iris/src/iris/cluster/client/remote_client.py
+++ b/lib/iris/src/iris/cluster/client/remote_client.py
@@ -376,18 +376,17 @@ class RemoteClusterClient:
     def list_jobs(
         self,
         *,
-        query: controller_pb2.Controller.JobQuery | None = None,
+        query: controller_pb2.Controller.JobQuery,
         page_size: int = 500,
     ) -> list[job_pb2.JobStatus]:
         """Fetch all jobs matching ``query`` by paging through ``ListJobs``.
 
-        The server caps each page at ``MAX_LIST_JOBS_LIMIT``; this helper walks
-        ``has_more`` / ``total_count`` to return the full result set without
-        asking the controller for an unbounded scan.
+        The server caps each page at ``MAX_LIST_JOBS_LIMIT`` and rejects deep
+        offsets (``MAX_LIST_JOBS_OFFSET``). Callers must supply a query that
+        narrows the result set with ``state_filter`` / ``name_filter`` /
+        ``parent_job_id``; otherwise the page walk will fail once it reaches
+        the offset cap.
         """
-        if query is None:
-            query = controller_pb2.Controller.JobQuery()
-
         jobs: list[job_pb2.JobStatus] = []
         offset = query.offset or 0
         while True:

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -575,6 +575,11 @@ _SORT_FIELD_TO_SQL: dict[int, str] = {
 
 
 MAX_LIST_JOBS_LIMIT = 500
+# Hard cap on how deep ListJobs callers may page. A correctly-filtered query
+# should narrow the result set; anything reaching offsets this deep is a sign
+# of a caller scanning the entire jobs table page-by-page, which is what the
+# snapshot is supposed to prevent. Force callers to filter instead.
+MAX_LIST_JOBS_OFFSET = 5000
 MAX_LIST_WORKERS_LIMIT = 1000
 
 
@@ -783,6 +788,12 @@ def _query_from_list_jobs_request(
         query.limit = MAX_LIST_JOBS_LIMIT
     if query.offset < 0:
         query.offset = 0
+    if query.offset > MAX_LIST_JOBS_OFFSET:
+        raise ConnectError(
+            Code.INVALID_ARGUMENT,
+            f"query.offset={query.offset} exceeds MAX_LIST_JOBS_OFFSET={MAX_LIST_JOBS_OFFSET}; "
+            "narrow the result set with state_filter/name_filter/parent_job_id instead of paging deeper.",
+        )
     return query
 
 
@@ -2718,8 +2729,5 @@ class ControllerServiceImpl:
     ) -> job_pb2.SetTaskStatusTextResponse:
         """Task pushes a markdown status string to the coordinator."""
         task_id = JobName.from_wire(request.task_id)
-        task = _read_task_with_attempts(self._db, task_id)
-        if task is None:
-            raise ConnectError(Code.NOT_FOUND, f"Task {request.task_id} not found")
         self._transitions.record_task_status_text(task_id, request.status_text_detail_md, request.status_text_summary_md)
         return job_pb2.SetTaskStatusTextResponse()

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -18,6 +18,7 @@ from iris.cluster.controller.codec import constraints_from_json
 from iris.cluster.controller.service import (
     FEATURE_INTRODUCTION_DATE,
     FRESHNESS_WINDOW,
+    MAX_LIST_JOBS_OFFSET,
     ControllerServiceImpl,
     _check_client_freshness,
 )
@@ -893,6 +894,16 @@ def test_list_jobs_sql_pagination(service):
 
     assert len(response3.jobs) == 1
     assert response3.has_more is False
+
+
+def test_list_jobs_rejects_deep_offset(service):
+    """Offsets past MAX_LIST_JOBS_OFFSET are rejected to force callers to filter."""
+    request = controller_pb2.Controller.ListJobsRequest(
+        query=controller_pb2.Controller.JobQuery(offset=MAX_LIST_JOBS_OFFSET + 1, limit=500)
+    )
+    with pytest.raises(ConnectError) as exc_info:
+        service.list_jobs(request, None)
+    assert exc_info.value.code == Code.INVALID_ARGUMENT
 
 
 def test_list_jobs_state_filter(service):

--- a/lib/marin/src/marin/mcp/babysitter.py
+++ b/lib/marin/src/marin/mcp/babysitter.py
@@ -432,10 +432,14 @@ class IrisBabysitter:
         offset = 0
         capped_limit = max(1, limit)
         prefix_job = JobName.from_wire(prefix) if prefix else None
+        # Push the prefix into name_filter (substring on j.name) when the caller
+        # didn't pass an explicit name_filter, so the server narrows results
+        # before we re-validate prefix anchoring client-side.
+        effective_name_filter = name_filter or (prefix_job.to_wire() if prefix_job else "")
         while len(jobs) < capped_limit:
             query = controller_pb2.Controller.JobQuery(
                 state_filter=state_filter,
-                name_filter=name_filter,
+                name_filter=effective_name_filter,
                 sort_field=controller_pb2.Controller.JOB_SORT_FIELD_DATE,
                 sort_direction=controller_pb2.Controller.SORT_DIRECTION_DESC,
                 offset=offset,
@@ -649,8 +653,14 @@ class IrisBabysitter:
         jobs: list[job_pb2.JobStatus] = []
         offset = 0
         root = JobName.from_wire(prefix)
+        # Substring filter on j.name (which stores the full wire path) narrows
+        # the page-walk server-side; the loop body re-validates anchored prefix
+        # matching to drop jobs whose names happen to contain the prefix
+        # without being a true descendant.
+        name_filter = root.to_wire()
         while True:
             query = controller_pb2.Controller.JobQuery(
+                name_filter=name_filter,
                 sort_field=controller_pb2.Controller.JOB_SORT_FIELD_DATE,
                 sort_direction=controller_pb2.Controller.SORT_DIRECTION_DESC,
                 offset=offset,


### PR DESCRIPTION
Reject query.offset > 5000 with INVALID_ARGUMENT; legitimate callers should narrow with state_filter/name_filter/parent_job_id rather than scan the jobs table page-by-page. Drop the query=None default on the remote client helper, push a name_filter into the babysitter prefix walks, and skip the redundant task lookup in SetTaskStatusText.