### PR TITLE
[codex] Stabilize Iris smoke job detail screenshots

### DIFF
--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -200,6 +200,32 @@ def smoke_screenshot(smoke_page, tmp_path_factory):
     return capture
 
 
+def _wait_for_job_detail_screenshot_ready(page, job_id: str) -> None:
+    page.wait_for_function(
+        """
+        (jobId) => {
+            const text = document.body.textContent || "";
+            const routeReady = decodeURIComponent(window.location.hash) === `#/job/${jobId}`;
+            const headings = Array.from(document.querySelectorAll("h3"))
+                .map((heading) => (heading.textContent || "").trim().toLowerCase());
+            const taskRowReady = Array.from(document.querySelectorAll("table tbody tr"))
+                .some((row) => (row.textContent || "").includes("Succeeded"));
+            const pageHeight = Math.max(document.body.scrollHeight, document.documentElement.scrollHeight);
+            return routeReady
+                && !text.includes("Loading...")
+                && text.includes("Job Status")
+                && text.includes("Task Summary")
+                && headings.includes("tasks")
+                && headings.includes("job logs")
+                && taskRowReady
+                && pageHeight > window.innerHeight;
+        }
+        """,
+        arg=job_id,
+        timeout=10000,
+    )
+
+
 @pytest.fixture(scope="module")
 def verbose_job(smoke_cluster):
     """Shared verbose log job — submits once, used by log-related tests."""
@@ -297,12 +323,10 @@ def test_dashboard_job_detail(smoke_cluster, smoke_page, smoke_screenshot):
     job = smoke_cluster.submit(TestJobs.quick, "smoke-detail")
     smoke_cluster.wait(job, timeout=smoke_cluster.job_timeout)
 
-    dashboard_goto(smoke_page, f"{smoke_cluster.url}/job/{job.job_id.to_wire()}")
+    job_id = job.job_id.to_wire()
+    dashboard_goto(smoke_page, f"{smoke_cluster.url}/job/{job_id}")
     wait_for_dashboard_ready(smoke_page)
-    smoke_page.wait_for_function(
-        "() => document.body.textContent.includes('Succeeded')",
-        timeout=10000,
-    )
+    _wait_for_job_detail_screenshot_ready(smoke_page, job_id)
     smoke_screenshot(
         "job-detail", "Job detail page for succeeded job with state badge, task table, and job-level log viewer"
     )
@@ -466,8 +490,9 @@ def test_dashboard_job_detail_with_logs(smoke_cluster, verbose_job, smoke_page, 
     job_id = verbose_job.job_id.to_wire()
     dashboard_goto(smoke_page, f"{smoke_cluster.url}/job/{job_id}")
     wait_for_dashboard_ready(smoke_page)
+    _wait_for_job_detail_screenshot_ready(smoke_page, job_id)
     smoke_page.wait_for_function(
-        "() => document.body.textContent.includes('Job Logs')",
+        "() => document.body.textContent.includes('DONE: all lines emitted')",
         timeout=10000,
     )
     smoke_screenshot(


### PR DESCRIPTION
## Summary

Stabilizes the Iris e2e smoke job-detail screenshots by waiting for the actual job detail route and the structural content that the screenshot verifier expects before capture.

## Root Cause

The flaky failures were in screenshot verification after pytest had already passed. In run `25526447115`, both `iris-e2e-smoke` attempts completed all e2e tests successfully, then failed only in `Verify screenshots with Claude`:

- job `74923098647`: `smoke-job-detail.png` was captured at 1400x900 and stopped at the `TASKS` header, so no task row or `Job Logs` panel was present.
- rerun job `74924610266`: `smoke-job-detail.png` showed the `/runner/smoke-detail` route still in `Loading...`.

`test_dashboard_job_detail` only waited for global body text containing `Succeeded`. Because the dashboard uses hash routing and a module-scoped Playwright page, that condition can be satisfied by stale content during route transition, or before the job-detail content that the screenshot description requires is laid out.

## Change

- Add a job-detail screenshot readiness helper that waits for:
  - the current `#/job/<job_id>` hash route,
  - the loaded job status and task summary sections,
  - a succeeded task table row,
  - the `Tasks` and `Job Logs` sections,
  - page height beyond the viewport so full-page capture includes the log viewer.
- Reuse the helper for both job-detail screenshot tests.
- For the verbose job-detail screenshot, wait for an actual emitted log marker before capture.

## Local Validation

- `./infra/pre-commit.py --fix lib/iris/tests/e2e/test_smoke.py` passed.
- `IRIS_SCREENSHOT_DIR=/tmp/iris-local-target-after2 uv run --group dev python -m pytest tests/e2e/test_smoke.py::test_dashboard_job_detail tests/e2e/test_smoke.py::test_dashboard_job_detail_with_logs -m e2e -o "addopts=" --tb=short -v` passed.
- `python lib/iris/scripts/verify_screenshots.py --screenshot-dir /tmp/iris-local-target-after2` passed.
- `IRIS_SCREENSHOT_DIR=/tmp/iris-local-full-after PYTHONASYNCIODEBUG=1 uv run --group dev python -m pytest tests/e2e/test_smoke.py -m e2e -o "addopts=" --tb=short -v` passed: `25 passed, 1 skipped`.
- `python lib/iris/scripts/verify_screenshots.py --screenshot-dir /tmp/iris-local-full-after` passed: `All 12 screenshots verified OK`.

## CI Validation

Five consecutive `Iris - Unit / iris-e2e-smoke` validations passed on PR head `d2973f7ee4fa5dca42a7a235c9b03f99f4fe66eb`:

1. Attempt 1: passed — https://github.com/marin-community/marin/actions/runs/25528227722/job/74928591242
2. Attempt 2: passed — https://github.com/marin-community/marin/actions/runs/25528227722/job/74929061150
3. Attempt 3: passed — https://github.com/marin-community/marin/actions/runs/25528227722/job/74929548409
4. Attempt 4: passed — https://github.com/marin-community/marin/actions/runs/25528227722/job/74929981837
5. Attempt 5: passed — https://github.com/marin-community/marin/actions/runs/25528227722/job/74930481415

Latest PR check state also has `Iris - Unit / iris-e2e-smoke` passing on attempt 5.