### PR TITLE
[finelog] Fix drop_table race + sync phase-2 durability gate

### DIFF
--- a/lib/finelog/src/finelog/store/duckdb_store.py
+++ b/lib/finelog/src/finelog/store/duckdb_store.py
@@ -467,9 +467,16 @@ class DuckDBLogStore:
 
         We can't hold the insertion mutex end-to-end because the bg flush
         thread itself takes it every iteration; joining under the mutex
-        would deadlock. Instead: (1) remove from registry under the mutex,
-        (2) stop_and_join the bg thread, (3) take the rwlock write side and
-        delete the segment directory.
+        would deadlock. The order is:
+
+          1. Remove from the registry under the mutex (new ops fail fast).
+          2. Stop and join the bg thread — *before* dropping catalog rows,
+             because ``_sync_step`` would otherwise see an empty catalog
+             plus a populated bucket and ``fs.rm`` every remote file as
+             an orphan.
+          3. Drop the catalog rows now that no concurrent reader can act
+             on them.
+          4. Take the rwlock write side and delete the segment directory.
 
         GCS-archived data is intentionally preserved; the bucket is the
         caller's to clean up.
@@ -481,11 +488,13 @@ class DuckDBLogStore:
             ns = self._namespaces.get(name)
             if ns is None:
                 raise NamespaceNotFoundError(f"namespace {name!r} is not registered")
-            self._catalog.delete(name)
             del self._namespaces[name]
             self._namespace_registered_at.pop(name, None)
 
         ns.stop_and_join()
+
+        with self._insertion_lock:
+            self._catalog.delete(name)
 
         self._query_visibility_lock.write_acquire()
         try:

--- a/lib/finelog/src/finelog/store/duckdb_store.py
+++ b/lib/finelog/src/finelog/store/duckdb_store.py
@@ -240,6 +240,14 @@ class DuckDBLogStore:
 
         self._namespace_registered_at: dict[str, int] = {}
         self._namespaces: dict[str, LogNamespaceProtocol] = {}
+        # Names currently being dropped. ``drop_table`` reserves the name
+        # here under ``_insertion_lock`` so a concurrent ``register_table``
+        # cannot recreate the namespace in the window between popping
+        # ``_namespaces`` and the late ``catalog.delete`` /
+        # ``remove_local_storage``. Without this, the late steps would
+        # delete the freshly registered namespace's catalog row and wipe
+        # its on-disk directory.
+        self._dropping: set[str] = set()
 
         # Disk-only kwargs; ignored by memory namespaces. ``duckdb_memory_limit``
         # in this dict feeds the per-namespace compaction connection in
@@ -320,6 +328,16 @@ class DuckDBLogStore:
         stored_schema = with_implicit_seq(schema)
 
         with self._insertion_lock:
+            if name in self._dropping:
+                # A concurrent ``drop_table`` has already removed the
+                # namespace from ``_namespaces`` but has not yet finished
+                # its catalog/storage cleanup. Recreating the namespace
+                # now would let that cleanup wipe the new state. Surface
+                # this as a transient validation error; the caller can
+                # retry once the drop completes.
+                raise InvalidNamespaceError(
+                    f"namespace {name!r} is currently being dropped; retry once drop_table completes"
+                )
             existing_ns = self._namespaces.get(name)
             if existing_ns is None:
                 self._catalog.upsert(name, stored_schema)
@@ -469,7 +487,11 @@ class DuckDBLogStore:
         thread itself takes it every iteration; joining under the mutex
         would deadlock. The order is:
 
-          1. Remove from the registry under the mutex (new ops fail fast).
+          1. Under the mutex: remove from the registry *and* mark ``name``
+             as ``_dropping`` (new ops fail fast — including a concurrent
+             ``register_table``, which would otherwise recreate the
+             namespace and have its state wiped by the cleanup steps
+             below).
           2. Stop and join the bg thread — *before* dropping catalog rows,
              because ``_sync_step`` would otherwise see an empty catalog
              plus a populated bucket and ``fs.rm`` every remote file as
@@ -477,6 +499,8 @@ class DuckDBLogStore:
           3. Drop the catalog rows now that no concurrent reader can act
              on them.
           4. Take the rwlock write side and delete the segment directory.
+          5. Clear the ``_dropping`` reservation under the mutex; the name
+             is now free to be re-registered.
 
         GCS-archived data is intentionally preserved; the bucket is the
         caller's to clean up.
@@ -490,17 +514,22 @@ class DuckDBLogStore:
                 raise NamespaceNotFoundError(f"namespace {name!r} is not registered")
             del self._namespaces[name]
             self._namespace_registered_at.pop(name, None)
+            self._dropping.add(name)
 
-        ns.stop_and_join()
-
-        with self._insertion_lock:
-            self._catalog.delete(name)
-
-        self._query_visibility_lock.write_acquire()
         try:
-            ns.remove_local_storage()
+            ns.stop_and_join()
+
+            with self._insertion_lock:
+                self._catalog.delete(name)
+
+            self._query_visibility_lock.write_acquire()
+            try:
+                ns.remove_local_storage()
+            finally:
+                self._query_visibility_lock.write_release()
         finally:
-            self._query_visibility_lock.write_release()
+            with self._insertion_lock:
+                self._dropping.discard(name)
 
     def append(self, key: str, entries: list) -> None:
         if not entries:

--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -511,8 +511,12 @@ class DiskLogNamespace:
         #   2. Local parquet files — authoritative for unflushed catalog
         #      state (genuine boot from disk, no prior catalog).
         #   3. Remote bucket — authoritative for wiped-catalog recovery,
-        #      handled in the bg loop's first sync tick rather than here
-        #      so __init__ stays free of network calls.
+        #      handled below by ``_adopt_remote_segments`` *before* the
+        #      bg loop starts. We can't defer this to the first sync tick:
+        #      that tick's phase-2 orphan-delete would see an empty
+        #      catalog with a populated bucket and ``fs.rm`` everything.
+        #      The cost is a network round-trip per parquet file at boot
+        #      when the bucket is non-empty.
         #
         # Each catalog row is reattached to its on-disk file when present;
         # ``REMOTE``-only rows stay in the catalog but never enter the
@@ -1250,6 +1254,13 @@ class DiskLogNamespace:
         has been uploaded in phase 1, so the durable copy is in place
         before any input remote bytes are deleted.
 
+        Phase 2 is skipped entirely when any phase-1 upload failed: if
+        the merged output isn't durable, the only remaining copies of
+        its seq range are the compaction inputs sitting in the bucket
+        (whose catalog rows were dropped at commit time). Deleting them
+        as orphans before the replacement is durable would lose data.
+        Cleanup is harmless to defer to the next tick.
+
         No-op when the namespace has no remote prefix configured.
         """
         if not self._remote_namespace_dir:
@@ -1265,6 +1276,7 @@ class DiskLogNamespace:
         with self._insertion_lock:
             rows = self._catalog.list_segments(self.name, min_level=1)
 
+        all_durable = True
         for row in rows:
             if row.location != SegmentLocation.LOCAL:
                 continue
@@ -1276,6 +1288,11 @@ class DiskLogNamespace:
                 continue
             if self._upload(Path(row.path)):
                 self._mark_uploaded(row.path)
+            else:
+                all_durable = False
+
+        if not all_durable:
+            return
 
         # Re-snapshot: phase 1 may have added basenames to the bucket; we
         # only want to delete files whose basename is genuinely orphan

--- a/lib/finelog/tests/test_drop.py
+++ b/lib/finelog/tests/test_drop.py
@@ -100,6 +100,58 @@ def test_drop_table_does_not_delete_remote_objects(tmp_path: Path):
         store.close()
 
 
+def test_drop_table_rejects_concurrent_register(tmp_path: Path):
+    """register_table during a drop must fail rather than recreate the namespace.
+
+    After ``drop_table`` removes the namespace from ``_namespaces`` and
+    releases ``_insertion_lock``, the bg thread is still being joined and
+    the late ``catalog.delete`` / ``remove_local_storage`` have not run
+    yet. A concurrent ``register_table(name)`` for the same name would
+    create a fresh namespace whose catalog row and on-disk directory
+    would then be wiped by those cleanup steps. The fix reserves the name
+    in ``_dropping`` while the drop runs; this test pins that contract.
+    """
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    store = DuckDBLogStore(log_dir=tmp_path / "data", remote_log_dir=str(remote))
+    try:
+        schema = _worker_schema()
+        store.register_table("iris.worker", schema)
+        store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-1"], [100], [1])))
+        ns = store._namespaces["iris.worker"]
+        ns._flush_step()
+        ns._force_compact_l0()
+        ns._sync_step()
+
+        # Spy on ``stop_and_join`` to attempt a same-name ``register_table``
+        # at the exact point of the prior race. ``_dropping`` should make
+        # it fail.
+        observed: dict[str, BaseException | None] = {"register_error": None}
+        original_stop = ns.stop_and_join
+
+        def spy() -> None:
+            try:
+                store.register_table("iris.worker", schema)
+            except BaseException as exc:
+                observed["register_error"] = exc
+            original_stop()
+
+        ns.stop_and_join = spy  # type: ignore[method-assign]
+
+        store.drop_table("iris.worker")
+
+        err = observed["register_error"]
+        assert isinstance(err, InvalidNamespaceError), f"expected InvalidNamespaceError, got {err!r}"
+
+        # Once the drop has fully completed the reservation is cleared
+        # and the name is re-registrable.
+        store.register_table("iris.worker", schema)
+        assert "iris.worker" in store._namespaces
+        assert "iris.worker" not in store._dropping
+    finally:
+        store.close()
+
+
 def test_drop_table_stops_bg_thread_before_dropping_catalog_rows(tmp_path: Path):
     """drop_table joins the bg thread *before* dropping catalog rows.
 

--- a/lib/finelog/tests/test_drop.py
+++ b/lib/finelog/tests/test_drop.py
@@ -98,3 +98,44 @@ def test_drop_table_does_not_delete_remote_objects(tmp_path: Path):
         assert not (tmp_path / "data" / "iris.worker").exists()
     finally:
         store.close()
+
+
+def test_drop_table_stops_bg_thread_before_dropping_catalog_rows(tmp_path: Path):
+    """drop_table joins the bg thread *before* dropping catalog rows.
+
+    With the prior order (``catalog.delete → stop_and_join``), a bg
+    ``_sync_step`` tick taken between the lock release and the join
+    would see an empty catalog plus a populated bucket and ``fs.rm``
+    every remote file. The fix is to stop the bg thread first. This
+    test pins the new order.
+    """
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    store = DuckDBLogStore(log_dir=tmp_path / "data", remote_log_dir=str(remote))
+    try:
+        store.register_table("iris.worker", _worker_schema())
+        store.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-1"], [100], [1])))
+        ns = store._namespaces["iris.worker"]
+        ns._flush_step()
+        ns._force_compact_l0()
+        ns._sync_step()
+        assert sorted((remote / "iris.worker").glob("*.parquet"))
+
+        # Spy on stop_and_join to assert the catalog still has rows when
+        # the bg thread joins; if the order ever regresses the catalog
+        # would be empty here.
+        observed = {"rows_at_stop": None}
+        original_stop = ns.stop_and_join
+
+        def spy() -> None:
+            with store._insertion_lock:
+                observed["rows_at_stop"] = list(store._catalog.list_segments("iris.worker"))
+            original_stop()
+
+        ns.stop_and_join = spy  # type: ignore[method-assign]
+
+        store.drop_table("iris.worker")
+
+        assert observed["rows_at_stop"], "bg thread joined after catalog rows were dropped"
+    finally:
+        store.close()


### PR DESCRIPTION
## Summary

Follow-up to #5540 addressing the two P1 carry-overs flagged in the review of commit `9426a596e`. Both bugs were called out by the auto-reviewers but the PR merged before the fixes landed; this PR ports the fixes onto main.

**Bug 1 — `drop_table` race nukes the bucket.** `DuckDBLogStore.drop_table` joined the bg thread *after* deleting catalog rows. A `_sync_step` tick taken in the window between lock release and join would see an empty catalog plus a populated bucket and `fs.rm` every remote file as an orphan — violating the documented "GCS data is intentionally preserved" contract. Reorder to `stop_and_join → catalog.delete` so no concurrent reader can act on the empty catalog.

**Bug 2 — sync phase 2 deletes inputs even when phase 1 fails.** After compaction commit, input rows are dropped and the merged-output row is inserted as `LOCAL`; the inputs' remote files are the only durable copy of that seq range until phase 1 uploads the merged output. If that upload fails, phase 2 still set-differences `(remote − catalog)` and deletes the inputs, losing the seq range. Track `all_durable` across phase 1 and skip phase 2 when any `LOCAL` row remained `LOCAL`.

Also fixed a doc/code drift: the `__init__` comment claimed wiped-catalog recovery was "handled in the bg loop's first sync tick" but the call to `_adopt_remote_segments` is in `__init__` (correctly — the first sync tick would otherwise nuke an unrecovered bucket). Updated text.

## Test plan

- [x] Existing tests in `lib/finelog` still pass (`uv run --group dev pytest`)
- [x] New `test_drop_table_stops_bg_thread_before_dropping_catalog_rows` spies on `stop_and_join` and asserts the catalog rows are still present at join time, pinning the new order

🤖 Generated with [Claude Code](https://claude.com/claude-code)