### PR TITLE
Publish marin-finelog wheel alongside other sister packages

### DIFF
--- a/scripts/python_libs_package.py
+++ b/scripts/python_libs_package.py
@@ -4,9 +4,9 @@
 
 """Build and publish marin-* lib wheels.
 
-Builds the seven pure-Python marin-* lib packages (marin, marin-iris,
-marin-fray, marin-haliax, marin-levanter, marin-rigging, marin-zephyr) into
-dist/, then optionally publishes them as GitHub Releases.
+Builds the eight pure-Python marin-* lib packages (marin, marin-iris,
+marin-fray, marin-haliax, marin-levanter, marin-rigging, marin-zephyr,
+marin-finelog) into dist/, then optionally publishes them as GitHub Releases.
 
 Four modes:
     nightly  -- version becomes <base>.dev<YYYYMMDD>; overwrites the rolling
@@ -63,6 +63,7 @@ PACKAGES: dict[str, dict[str, str]] = {
     "marin-zephyr": {"path": "lib/zephyr", "version_file": "pyproject.toml", "kind": "pyproject"},
     "marin-levanter": {"path": "lib/levanter", "version_file": "pyproject.toml", "kind": "pyproject"},
     "marin-haliax": {"path": "lib/haliax", "version_file": "src/haliax/__about__.py", "kind": "about_py"},
+    "marin-finelog": {"path": "lib/finelog", "version_file": "pyproject.toml", "kind": "pyproject"},
 }
 
 SIBLING_NAMES = sorted(PACKAGES.keys(), key=len, reverse=True)


### PR DESCRIPTION
Closes #5564.

## Summary

`marin-iris` depends on `marin-finelog` at runtime, but `marin-finelog` had no `-latest` GitHub release alongside the other sister packages, so consumers re-locking against `marin-iris@latest` fell through to a workspace build and tripped the controller's client-freshness check.

Add `marin-finelog` to `PACKAGES` in `scripts/python_libs_package.py` so the nightly release workflow builds and publishes a `marin-finelog-latest` release on the same cadence as `marin-iris`, `marin-zephyr`, etc. The existing version-bump and sibling-pin machinery handles finelog correctly: its base version (0.1.0) is below the workspace floor (0.99) so the synthesized version is unaffected, and finelog's `marin-rigging` dep gets pinned to the same synthetic version.