### PR TITLE
ci: drop data_integration tests from marin-integration

### DIFF
--- a/.github/workflows/marin-integration.yaml
+++ b/.github/workflows/marin-integration.yaml
@@ -90,12 +90,6 @@ jobs:
           WANDB_API_KEY: ""
           JAX_TRACEBACK_FILTERING: off
 
-      - name: Run data integration tests
-        run: |
-          uv run pytest tests/ -m data_integration -o "addopts=" --timeout=600 -v
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-
       - name: Stop cluster
         if: always()
         run: kill $CLUSTER_PID 2>/dev/null || true


### PR DESCRIPTION
* removes the `Run data integration tests` step (`pytest tests/ -m data_integration`) from `.github/workflows/marin-integration.yaml`
* will be re-introduced as a separate workflow later
* `marin-unit.yaml` already excludes `data_integration` via `-m 'not ... data_integration'`, so no other CI runs them now

🤖 Generated with [Claude Code](https://claude.com/claude-code)