### PR TITLE
[iris] Restore committed_* in worker upsert INSERT for legacy DBs

### DIFF
--- a/lib/iris/src/iris/cluster/controller/stores.py
+++ b/lib/iris/src/iris/cluster/controller/stores.py
@@ -1658,17 +1658,22 @@ class WorkerStore:
         post-commit hook registers the worker in the liveness tracker so
         memory state advances with the DB row.
         """
+        # ``committed_*`` are scheduler-owned but listed here so legacy DBs (where
+        # the columns were originally created NOT NULL with no DEFAULT, before
+        # MAIN_TABLES gained "DEFAULT 0") accept the INSERT. ON CONFLICT DO UPDATE
+        # does not touch them, so re-registration never clobbers running totals.
         cur.execute(
             "INSERT INTO workers("
             "worker_id, address, "
+            "committed_cpu_millicores, committed_mem_bytes, committed_gpu, committed_tpu, "
             "total_cpu_millicores, total_memory_bytes, total_gpu_count, total_tpu_count, "
             "device_type, device_variant, slice_id, scale_group, "
             "md_hostname, md_ip_address, md_cpu_count, md_memory_bytes, md_disk_bytes, "
             "md_tpu_name, md_tpu_worker_hostnames, md_tpu_worker_id, md_tpu_chips_per_host_bounds, "
             "md_gpu_count, md_gpu_name, md_gpu_memory_mb, "
             "md_gce_instance_name, md_gce_zone, md_git_hash, md_device_json"
-            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
-            "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            ") VALUES (?, ?, 0, 0, 0, 0, ?, ?, ?, ?, "
+            "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(worker_id) DO UPDATE SET "
             "address=excluded.address, "
             "total_cpu_millicores=excluded.total_cpu_millicores, total_memory_bytes=excluded.total_memory_bytes, "


### PR DESCRIPTION
PR #5559 dropped the four committed_* columns from the worker upsert INSERT, relying on DEFAULT 0. Fresh DBs declare those columns NOT NULL DEFAULT 0, but DBs created before #4280 (e.g. marin-dev) still carry the original NOT-NULL-only DDL, so the INSERT fails and no worker can register. List the columns explicitly with literal 0s; ON CONFLICT DO UPDATE is unchanged so the scheduler's running totals are never clobbered on re-register.