### PR TITLE
[iris] tests: route Controller local_state_dir through tmp_path

### DIFF
--- a/lib/iris/tests/cluster/controller/conftest.py
+++ b/lib/iris/tests/cluster/controller/conftest.py
@@ -240,6 +240,7 @@ def make_controller(tmp_path):
     ) -> Controller:
         if config is None:
             config_kwargs.setdefault("remote_state_dir", f"file://{tmp_path}/remote")
+            config_kwargs.setdefault("local_state_dir", tmp_path / "local")
             config = ControllerConfig(**config_kwargs)
         elif config_kwargs:
             raise TypeError("make_controller: pass either a config or config kwargs, not both")

--- a/lib/iris/tests/e2e/_docker_cluster.py
+++ b/lib/iris/tests/e2e/_docker_cluster.py
@@ -149,6 +149,7 @@ class E2ECluster:
             host="127.0.0.1",
             port=self._controller_port,
             remote_state_dir=f"file://{bundle_dir}",
+            local_state_dir=temp_path / "local",
         )
         self._controller = Controller(
             config=controller_config,


### PR DESCRIPTION
## Summary

- `ControllerConfig.local_state_dir` defaults to `tempfile.mkdtemp(prefix="iris_controller_state_")`, and `Controller.stop()` never removes the directory.
- The `make_controller` test fixture and the docker e2e cluster relied on that default, so each test run leaked one `/tmp/iris_controller_state_*` directory (~1.6MB each). On this machine they had piled up to ~5k dirs / ~8GB.
- Fix: have the conftest factory and `_docker_cluster.py` set `local_state_dir` to a path under the existing per-test `tmp_path` / `TemporaryDirectory`, so pytest cleans it up alongside the rest of the test scratch space.

## Test plan

- [ ] Run `lib/iris/tests/cluster/controller/` and confirm no new `/tmp/iris_controller_state_*` directories appear after the run.
- [ ] Existing controller test suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)