### PR TITLE
[codex] Fix Grug profiler stop export stalls

### DIFF
--- a/experiments/ferries/canary_ferry.py
+++ b/experiments/ferries/canary_ferry.py
@@ -27,7 +27,7 @@ import datetime
 import os
 
 from fray.cluster import ResourceConfig
-from levanter.callbacks.profiler import ProfilerConfig
+from levanter.callbacks.profiler import ProfileOptionsConfig, ProfilerConfig
 from levanter.data.text import BlockShuffleConfig, TextLmDatasetFormat
 from levanter.optim import AdamConfig
 from levanter.tracker.json_logger import JsonLoggerConfig
@@ -158,6 +158,10 @@ def _build_step_from_env() -> ExecutorStep:
     profiler_enabled = _env_bool("CANARY_PROFILER_ENABLED", True)
     profiler_start_step = _env_int("CANARY_PROFILER_START_STEP", 5)
     profiler_num_steps = _env_int("CANARY_PROFILER_NUM_STEPS", 25)
+    profiler_options = ProfileOptionsConfig()
+    if accelerator == "gpu" and gpu_replicas > 1:
+        # Device traces make multinode Grug GPU canary exports stall for minutes.
+        profiler_options = ProfileOptionsConfig(device_tracer_level=0)
 
     return ExecutorStep(
         name=f"{name}-{run_id}",
@@ -180,6 +184,7 @@ def _build_step_from_env() -> ExecutorStep:
                 enabled=profiler_enabled,
                 start_step=profiler_start_step,
                 num_steps=profiler_num_steps,
+                profile_options=profiler_options,
             ),
         ),
     )

--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -421,6 +421,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                     profiler_cfg.start_step,
                     profiler_num_steps,
                     profiler_cfg.perfetto_link,
+                    profiler_options=profiler_cfg.build_jax_profile_options(),
                 ),
                 every=1,
             )

--- a/experiments/grug/modular_opt/train.py
+++ b/experiments/grug/modular_opt/train.py
@@ -420,6 +420,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                     profiler_cfg.start_step,
                     profiler_num_steps,
                     profiler_cfg.perfetto_link,
+                    profiler_options=profiler_cfg.build_jax_profile_options(),
                 ),
                 every=1,
             )

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -458,6 +458,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                     profiler_cfg.start_step,
                     profiler_num_steps,
                     profiler_cfg.perfetto_link,
+                    profiler_options=profiler_cfg.build_jax_profile_options(),
                 ),
                 every=1,
             )

--- a/lib/levanter/scripts/bench/bench_mamba3_mimo_xla.py
+++ b/lib/levanter/scripts/bench/bench_mamba3_mimo_xla.py
@@ -26,6 +26,7 @@ from levanter.kernels.pallas.mamba3.reference import (
 )
 from levanter.kernels.pallas.mamba3.xla import mamba3_mimo_chunked_forward_ranked_xla_batched
 from levanter.kernels.pallas.ssd import intra_chunk_log_alpha_cumsum, local_log_alpha
+from levanter.callbacks.profiler import stop_trace_with_timing
 
 
 @dataclass(frozen=True, slots=True)
@@ -136,7 +137,7 @@ def _capture_profile(fn, *args, profile_dir: str, profile_steps: int) -> None:
             out = fn(*args)
             jax.block_until_ready(out)
     finally:
-        jax.profiler.stop_trace()
+        stop_trace_with_timing()
 
 
 def _attentionish_public_inputs(

--- a/lib/levanter/scripts/bench/bench_mamba3_xla.py
+++ b/lib/levanter/scripts/bench/bench_mamba3_xla.py
@@ -22,6 +22,7 @@ from levanter.kernels.pallas.mamba3 import (
     mamba3_attentionish_forward,
     mamba3_chunked_forward,
 )
+from levanter.callbacks.profiler import stop_trace_with_timing
 
 
 ApiVariant = Literal["chunked_public", "attentionish_public"]
@@ -171,7 +172,7 @@ def _capture_profile(
             out = fn(*args)
             jax.block_until_ready(out)
     finally:
-        jax.profiler.stop_trace()
+        stop_trace_with_timing()
 
 
 def _benchmark(

--- a/lib/levanter/src/levanter/callbacks/__init__.py
+++ b/lib/levanter/src/levanter/callbacks/__init__.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import threading
 import time
 from contextlib import contextmanager
 from typing import Optional
@@ -20,7 +19,7 @@ from levanter.callbacks._metrics import (
     pbar_logger,
 )
 from levanter.callbacks.state_adapter import CallbackStateView, StateCallbackRunner
-from levanter.callbacks.profiler import _flush_while_waiting, profile
+from levanter.callbacks.profiler import profile, stop_trace_with_timing
 from levanter.data import DataLoader
 from levanter.metrics import LossFunctionWithMetrics, unwrap_metrics
 from levanter.metrics import fold as fold_metric
@@ -121,6 +120,7 @@ def profile_ctx(
     host_profile: bool = False,
     host_profile_basename: str = "host_profile",
     host_profile_topn: int = 0,
+    profiler_options: jax.profiler.ProfileOptions | None = None,
 ):
     """Context manager for JAX profiling traces.
 
@@ -151,9 +151,13 @@ def profile_ctx(
         pass
 
     if device_profile:
-        jax.profiler.start_trace(path, create_perfetto_link=_create_perfetto_link, create_perfetto_trace=True)
+        jax.profiler.start_trace(
+            path,
+            create_perfetto_link=_create_perfetto_link,
+            create_perfetto_trace=True,
+            profiler_options=profiler_options,
+        )
 
-    event = None
     pr = None
     stats_path = None
     txt_summary_path = None
@@ -195,21 +199,13 @@ def profile_ctx(
             except Exception:  # pragma: no cover - optional/diagnostic path
                 logger.warning("Failed to log host profile stats", exc_info=True)
 
-        # Start periodic flushing before stop_trace since it may block when perfetto is enabled
-        if create_perfetto_link and jax.process_index() == 0:
-            event = threading.Event()
-            _flush_while_waiting(event)
-
         if create_perfetto_link:
             logger.info(f"Stopping profiler. Process 0 will open a perfetto link. I am process {jax.process_index()}")
         else:
             logger.info("Stopping profiler.")
 
         if device_profile:
-            jax.profiler.stop_trace()
-
-        if event is not None:
-            event.set()
+            stop_trace_with_timing()
 
         levanter.tracker.current_tracker().log_artifact(path, type="jax_profile")
         if stats_path is not None and os.path.exists(stats_path):

--- a/lib/levanter/src/levanter/callbacks/profiler.py
+++ b/lib/levanter/src/levanter/callbacks/profiler.py
@@ -5,7 +5,7 @@ import logging
 import sys
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable
 
 import jax
@@ -16,6 +16,52 @@ from levanter.utils.jax_utils import barrier_sync
 
 logger = logging.getLogger(__name__)
 
+AdvancedProfileOptionValue = bool | int | str
+
+
+@dataclass(frozen=True)
+class ProfileOptionsConfig:
+    """Configuration forwarded to ``jax.profiler.ProfileOptions``."""
+
+    host_tracer_level: int | None = None
+    python_tracer_level: int | None = None
+    device_tracer_level: int | None = None
+    enable_hlo_proto: bool | None = None
+    include_dataset_ops: bool | None = None
+    advanced_configuration: dict[str, AdvancedProfileOptionValue] = field(default_factory=dict)
+
+    @property
+    def is_configured(self) -> bool:
+        return (
+            self.host_tracer_level is not None
+            or self.python_tracer_level is not None
+            or self.device_tracer_level is not None
+            or self.enable_hlo_proto is not None
+            or self.include_dataset_ops is not None
+            or bool(self.advanced_configuration)
+        )
+
+    def build_jax_profile_options(self) -> jax.profiler.ProfileOptions | None:
+        if not self.is_configured:
+            return None
+
+        options = jax.profiler.ProfileOptions()
+        if self.host_tracer_level is not None:
+            options.host_tracer_level = self.host_tracer_level
+        if self.python_tracer_level is not None:
+            options.python_tracer_level = self.python_tracer_level
+        if self.enable_hlo_proto is not None:
+            options.enable_hlo_proto = self.enable_hlo_proto
+        if self.include_dataset_ops is not None:
+            options.include_dataset_ops = self.include_dataset_ops
+
+        advanced_configuration = dict(self.advanced_configuration)
+        if self.device_tracer_level is not None:
+            advanced_configuration["device_tracer_level"] = self.device_tracer_level
+        if advanced_configuration:
+            options.advanced_configuration = advanced_configuration
+        return options
+
 
 @dataclass(frozen=True)
 class ProfilerConfig:
@@ -25,10 +71,14 @@ class ProfilerConfig:
     start_step: int = 5
     num_steps: int = 25
     perfetto_link: bool = False
+    profile_options: ProfileOptionsConfig = field(default_factory=ProfileOptionsConfig)
 
     @property
     def is_enabled(self) -> bool:
         return self.enabled and self.num_steps > 0
+
+    def build_jax_profile_options(self) -> jax.profiler.ProfileOptions | None:
+        return self.profile_options.build_jax_profile_options()
 
     def resolve_num_profile_steps(self, num_train_steps: int) -> int:
         """Clamp profiling duration to the configured training length."""
@@ -42,7 +92,13 @@ class ProfilerConfig:
         return max(0, total_prof_steps)
 
 
-def profile(path: str, start_step: int, num_steps: int, create_perfetto_link: bool) -> Callable[[StepInfo], None]:
+def profile(
+    path: str,
+    start_step: int,
+    num_steps: int,
+    create_perfetto_link: bool,
+    profiler_options: jax.profiler.ProfileOptions | None = None,
+) -> Callable[[StepInfo], None]:
     artifact_name = f"jax-profile-step-{start_step}-{start_step + num_steps}"
 
     def profiler_callback_fn(step: StepInfo):
@@ -50,7 +106,12 @@ def profile(path: str, start_step: int, num_steps: int, create_perfetto_link: bo
         if step.step == start_step - 1:
             _create_perfetto_link = create_perfetto_link and jax.process_index() == 0
             logger.info(f"Starting profiler until step {start_step + num_steps}.")
-            jax.profiler.start_trace(path, create_perfetto_link=_create_perfetto_link, create_perfetto_trace=True)
+            jax.profiler.start_trace(
+                path,
+                create_perfetto_link=_create_perfetto_link,
+                create_perfetto_trace=True,
+                profiler_options=profiler_options,
+            )
         elif step.step == start_step + num_steps - 1:
             if create_perfetto_link:
                 logger.info(
@@ -58,17 +119,7 @@ def profile(path: str, start_step: int, num_steps: int, create_perfetto_link: bo
                 )
             else:
                 logger.info("Stopping profiler.")
-            # so, annoyingly, gcloud ssh doesn't reliably flush stdout here, so we need to spin up
-            # a thread to flush and print periodically until we make it past stop_trace
-            # (note: stop_trace blocks if perfetto is enabled)
-            event = threading.Event()
-            if create_perfetto_link and jax.process_index() == 0:
-                _flush_while_waiting(event)
-
-            jax.profiler.stop_trace()
-
-            if create_perfetto_link and jax.process_index() == 0:
-                event.set()
+            stop_trace_with_timing()
 
             levanter.tracker.current_tracker().log_artifact(
                 path,
@@ -80,15 +131,32 @@ def profile(path: str, start_step: int, num_steps: int, create_perfetto_link: bo
     return profiler_callback_fn
 
 
-def _flush_while_waiting(event):
-    def flush_stdout():
-        sys.stdout.flush()
-        sys.stderr.flush()
-        time.sleep(5)
-        while not event.is_set():
-            print("Waiting...", flush=True)
-            print("\n", file=sys.stderr, flush=True)
-            time.sleep(5)
+def stop_trace_with_timing(heartbeat_seconds: float = 30.0) -> float:
+    """Stop the JAX profiler and log elapsed time, with periodic heartbeats for slow exports."""
+    event = threading.Event()
+    _flush_while_waiting(event, heartbeat_seconds=heartbeat_seconds)
+    start = time.perf_counter()
+    try:
+        jax.profiler.stop_trace()
+    finally:
+        elapsed = time.perf_counter() - start
+        event.set()
 
-    thread = threading.Thread(target=flush_stdout)
+    logger.info("jax.profiler.stop_trace() returned after %.2fs.", elapsed)
+    return elapsed
+
+
+def _flush_while_waiting(event: threading.Event, heartbeat_seconds: float = 30.0):
+    if heartbeat_seconds <= 0:
+        return
+
+    def flush_stdout():
+        start = time.perf_counter()
+        while not event.wait(heartbeat_seconds):
+            elapsed = time.perf_counter() - start
+            logger.info("Still waiting for jax.profiler.stop_trace() after %.1fs.", elapsed)
+            sys.stdout.flush()
+            sys.stderr.flush()
+
+    thread = threading.Thread(target=flush_stdout, name="jax-profiler-stop-heartbeat", daemon=True)
     thread.start()

--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -27,7 +27,7 @@ import random
 import tempfile
 import time
 import typing
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 from typing import Callable, Iterator, List, Optional, Tuple, TypeVar, Union
 
@@ -77,6 +77,9 @@ from tqdm_loggable.auto import tqdm
 
 import levanter.config
 from levanter.callbacks import StepInfo
+from levanter.callbacks.profiler import ProfileOptionsConfig
+from levanter.callbacks.profiler import ProfilerConfig as TraceProfilerConfig
+from levanter.callbacks.profiler import stop_trace_with_timing
 from levanter.checkpoint import latest_checkpoint_path, load_checkpoint
 from levanter.data import batched
 from levanter.data.loader import stack_batches
@@ -199,6 +202,10 @@ class ProfilerConfig:
     """Path to save profiler traces."""
     perfetto_link: bool = False
     """If True, create a Perfetto link for the trace."""
+    profile_options: ProfileOptionsConfig = field(default_factory=ProfileOptionsConfig)
+
+    def build_jax_profile_options(self) -> jax.profiler.ProfileOptions | None:
+        return TraceProfilerConfig(profile_options=self.profile_options).build_jax_profile_options()
 
 
 # OK, so LM-Eval-Harness is not deterministic. This means we can't just run it on different workers and expect the
@@ -562,13 +569,14 @@ class LevanterHarnessLM(TemplateLM):
                 self.profiler_config.profile_path,
                 create_perfetto_link=_create_perfetto_link,
                 create_perfetto_trace=True,
+                profiler_options=self.profiler_config.build_jax_profile_options(),
             )
             self._profiler_started = True
 
         # Stop profiler at end_step
         elif self._current_step == end_step and self._profiler_started:
             logger.info(f"Stopping profiler at step {self._current_step}")
-            jax.profiler.stop_trace()
+            stop_trace_with_timing()
             self._profiler_started = False
             self._log_profiler_artifact()
 
@@ -576,7 +584,7 @@ class LevanterHarnessLM(TemplateLM):
         """Ensure profiler is stopped if it was started."""
         if self._profiler_started:
             logger.info("Stopping profiler (end of evaluation).")
-            jax.profiler.stop_trace()
+            stop_trace_with_timing()
             self._profiler_started = False
             self._log_profiler_artifact()
 
@@ -1526,6 +1534,7 @@ def run_eval_harness_main(config: EvalHarnessMainConfig):
                 num_steps=profiler_num_steps,
                 profile_path=str(profile_path),
                 perfetto_link=trainer_profiler.perfetto_link,
+                profile_options=trainer_profiler.profile_options,
             )
 
         logger.info("Running LM eval harness....")

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -598,6 +598,7 @@ class Trainer:
                     profiler.start_step,
                     total_prof_steps,
                     profiler.perfetto_link,
+                    profiler_options=profiler.build_jax_profile_options(),
                 ),
                 every=1,
             )

--- a/lib/levanter/tests/test_profiler.py
+++ b/lib/levanter/tests/test_profiler.py
@@ -1,0 +1,77 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from levanter.callbacks import profiler as profiler_mod
+from levanter.callbacks.profiler import ProfileOptionsConfig, ProfilerConfig, profile
+
+
+def test_profile_options_config_builds_jax_profile_options():
+    options = ProfileOptionsConfig(
+        host_tracer_level=1,
+        device_tracer_level=0,
+        python_tracer_level=0,
+        enable_hlo_proto=False,
+        include_dataset_ops=False,
+        advanced_configuration={
+            "gpu_num_chips_to_profile_per_task": 1,
+            "gpu_max_callback_api_events": 131072,
+            "gpu_max_activity_api_events": 131072,
+            "gpu_max_annotation_strings": 65536,
+            "tpu_trace_mode": "TRACE_ONLY_HOST",
+        },
+    ).build_jax_profile_options()
+
+    assert options is not None
+    assert options.host_tracer_level == 1
+    assert options.advanced_configuration == {
+        "device_tracer_level": 0,
+        "gpu_num_chips_to_profile_per_task": 1,
+        "gpu_max_callback_api_events": 131072,
+        "gpu_max_activity_api_events": 131072,
+        "gpu_max_annotation_strings": 65536,
+        "tpu_trace_mode": "TRACE_ONLY_HOST",
+    }
+    assert options.python_tracer_level == 0
+    assert options.enable_hlo_proto is False
+    assert options.include_dataset_ops is False
+
+
+def test_profile_passes_profile_options_and_uses_timed_stop(monkeypatch):
+    start_calls = []
+    stop_calls = []
+    artifacts = []
+
+    class FakeTracker:
+        def log_artifact(self, artifact_path, *, name=None, type=None):
+            artifacts.append((artifact_path, name, type))
+
+    def fake_start_trace(path, *, create_perfetto_link, create_perfetto_trace, profiler_options):
+        start_calls.append((path, create_perfetto_link, create_perfetto_trace, profiler_options))
+
+    def fake_stop_trace_with_timing():
+        stop_calls.append(True)
+        return 0.0
+
+    monkeypatch.setattr(profiler_mod.jax, "process_index", lambda: 0)
+    monkeypatch.setattr(profiler_mod.jax.profiler, "start_trace", fake_start_trace)
+    monkeypatch.setattr(profiler_mod, "stop_trace_with_timing", fake_stop_trace_with_timing)
+    monkeypatch.setattr(profiler_mod.levanter.tracker, "current_tracker", lambda: FakeTracker())
+    monkeypatch.setattr(profiler_mod, "barrier_sync", lambda: None)
+
+    options = ProfilerConfig(profile_options=ProfileOptionsConfig(host_tracer_level=1)).build_jax_profile_options()
+    callback = profile(
+        "/tmp/profiler",
+        start_step=5,
+        num_steps=1,
+        create_perfetto_link=False,
+        profiler_options=options,
+    )
+
+    callback(SimpleNamespace(step=4))
+    callback(SimpleNamespace(step=5))
+
+    assert start_calls == [("/tmp/profiler", False, True, options)]
+    assert stop_calls == [True]
+    assert artifacts == [("/tmp/profiler", "jax-profile-step-5-6", "jax_profile")]


### PR DESCRIPTION
## Summary

- Adds a typed `ProfileOptionsConfig` that converts to `jax.profiler.ProfileOptions` at the trace boundary. General JAX profiler knobs are explicit fields; GPU/TPU/XProf-specific knobs remain in `advanced_configuration` so Marin does not need fields for every upstream backend option.
- Adds elapsed-time and heartbeat logging around profiler `stop_trace()` so slow native export is visible instead of looking like a silent hang.
- Defaults multinode GPU canaries to `ProfileOptionsConfig(device_tracer_level=0)`, keeping the JAX profiler callback and artifact logging enabled while avoiding the pathological device trace export path from #5528.

## Root Cause

The #5528 repro stalls inside native JAX/XLA profile export before Marin artifact logging or callback barriers. B200x8 x2 Grug 10-step profile export takes ~440s with default device tracing. H100x8 x2 shows the same class of issue at ~494s, so this is trace volume on the JAX/XLA device trace path rather than a B200-only callback bug.

Supported GPU trace-size knobs helped only modestly: `gpu_num_chips_to_profile_per_task=1` still took ~379s, and adding CUPTI event caps still exceeded 120s. `device_tracer_level=0` was the only measured knob that removed the operational stall. A B200x8 x2 run with only `device_tracer_level=0` returned from `stop_trace()` in ~3.1-3.4s and reached checkpointing.

## Known Caveat

Current jaxlib documents `device_tracer_level` but does not expose it as a first-class `ProfileOptions` Python property for `start_trace()`, so this PR forwards it through `advanced_configuration`. Current jaxlib emits a CUPTI unrecognized-key log for that fallback, but the measured behavior is correct: it suppresses the slow device trace export path while preserving the JAX profile callback and artifact logging.

## Validation

- `uv run pytest lib/levanter/tests/test_profiler.py`
- `uv run python -m py_compile lib/levanter/src/levanter/callbacks/profiler.py lib/levanter/src/levanter/callbacks/__init__.py lib/levanter/src/levanter/trainer.py lib/levanter/src/levanter/eval_harness.py experiments/ferries/canary_ferry.py experiments/grug/base/train.py experiments/grug/moe/train.py experiments/grug/modular_opt/train.py lib/levanter/tests/test_profiler.py`
- `./infra/pre-commit.py --all-files --fix`
- `./infra/pre-commit.py --all-files`
- `draccus.decode` smoke test for nested `profile_options`
- CoreWeave B200x8 x2 confirmation: `/romain/cw-grug-5528-b200-device0only-20260508-224105` succeeded; `stop_trace()` returned in ~3.1-3.4s.

Fixes #5528