### PR TITLE
[iris] Track slice idleness with quiet_since transition marker (drop last_active_ms)

### DIFF
--- a/lib/iris/src/iris/cluster/controller/autoscaler/recovery.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/recovery.py
@@ -48,13 +48,10 @@ def load_autoscaler_checkpoint(db: ControllerDB) -> AutoscalerCheckpoint:
             },
         )
         slice_rows = snapshot.raw(
-            "SELECT slice_id, scale_group, lifecycle, worker_ids, "
-            "created_at_ms, last_active_ms, error_message "
-            "FROM slices",
+            "SELECT slice_id, scale_group, lifecycle, worker_ids, " "created_at_ms, error_message " "FROM slices",
             decoders={
                 "worker_ids": _decode_json_list,
                 "created_at_ms": decode_timestamp_ms,
-                "last_active_ms": decode_timestamp_ms,
             },
         )
         # Failed workers have their DB row deleted (WorkerStore.remove), so
@@ -72,7 +69,6 @@ def load_autoscaler_checkpoint(db: ControllerDB) -> AutoscalerCheckpoint:
                 lifecycle=row.lifecycle,
                 worker_ids=row.worker_ids,
                 created_at_ms=row.created_at_ms.epoch_ms(),
-                last_active_ms=row.last_active_ms.epoch_ms(),
                 error_message=row.error_message,
             )
         )

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -121,6 +121,10 @@ class SliceState:
 
     handle: SliceHandle
     last_active: Timestamp = field(default_factory=lambda: Timestamp.from_ms(0))
+    # Watermark for the last time last_active was flushed to the DB. Tracked
+    # separately from last_active so the per-tick mutation of last_active does
+    # not reset the flush-elapsed clock and starve the DB of updates.
+    last_active_db_flush: Timestamp = field(default_factory=lambda: Timestamp.from_ms(0))
     lifecycle: SliceLifecycleState = SliceLifecycleState.BOOTING
     worker_ids: list[str] = field(default_factory=list)
     error_message: str = ""
@@ -526,6 +530,9 @@ class ScalingGroup:
                 state.lifecycle = SliceLifecycleState.READY
                 state.worker_ids = worker_ids
                 state.last_active = timestamp
+                # _db_upsert_slice below writes last_active_ms to the DB, so the
+                # flush watermark advances with it.
+                state.last_active_db_flush = timestamp
         if state is not None:
             self._db_upsert_slice(slice_id, state)
             logger.info(
@@ -750,13 +757,16 @@ class ScalingGroup:
 
         # Determine which slices are active and whether they need a DB write.
         # _slice_has_active_workers is called outside the lock (reads worker_status_map, not _slices).
+        # The flush threshold is measured against last_active_db_flush, not
+        # last_active — last_active is bumped every tick, so reading it here
+        # would always yield ~tick_interval elapsed and starve DB writes.
         active_slice_ids: list[str] = []
         needs_db_write: list[str] = []
         for slice_id, state in snapshot:
             if not self._slice_has_active_workers(state, worker_status_map):
                 continue
             active_slice_ids.append(slice_id)
-            elapsed_ms = timestamp.epoch_ms() - state.last_active.epoch_ms()
+            elapsed_ms = timestamp.epoch_ms() - state.last_active_db_flush.epoch_ms()
             if elapsed_ms >= self._ACTIVITY_WRITE_THRESHOLD_MS:
                 needs_db_write.append(slice_id)
 
@@ -793,6 +803,13 @@ class ScalingGroup:
                         state.error_message,
                     ),
                 )
+
+        # Record the flush watermark so the next elapsed check measures from
+        # the actual write time, not from the per-tick last_active mutation.
+        with self._slices_lock:
+            for slice_id in needs_db_write:
+                if slice_id in self._slices:
+                    self._slices[slice_id].last_active_db_flush = timestamp
 
     def _slice_has_active_workers(self, state: SliceState, worker_status_map: WorkerStatusMap) -> bool:
         """Check if any worker in a slice has running tasks."""
@@ -1328,6 +1345,10 @@ def restore_scaling_group(
             lifecycle=lifecycle,
             worker_ids=list(slice_snap.worker_ids),
             last_active=Timestamp.from_ms(slice_snap.last_active_ms),
+            # Seed the flush watermark from the recovered last_active so the
+            # post-restart elapsed check measures from the last DB write, not
+            # from epoch 0.
+            last_active_db_flush=Timestamp.from_ms(slice_snap.last_active_ms),
             error_message=slice_snap.error_message,
         )
 

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -120,11 +120,14 @@ class SliceState:
     """
 
     handle: SliceHandle
-    last_active: Timestamp = field(default_factory=lambda: Timestamp.from_ms(0))
-    # Watermark for the last time last_active was flushed to the DB. Tracked
-    # separately from last_active so the per-tick mutation of last_active does
-    # not reset the flush-elapsed clock and starve the DB of updates.
-    last_active_db_flush: Timestamp = field(default_factory=lambda: Timestamp.from_ms(0))
+    # Timestamp at which the slice transitioned from "any worker has a
+    # running task" to "all workers idle". None means the slice is currently
+    # active (or has never been observed; both cases stay alive). Eligibility
+    # for scale-down is `now - quiet_since >= idle_threshold`. Stored only in
+    # memory: persisting a continuously-updated activity stamp is what produced
+    # the periodic-flush bug, and the post-restart grace period that falls out
+    # of `quiet_since=None` is exactly the safe behaviour we want anyway.
+    quiet_since: Timestamp | None = None
     lifecycle: SliceLifecycleState = SliceLifecycleState.BOOTING
     worker_ids: list[str] = field(default_factory=list)
     error_message: str = ""
@@ -252,12 +255,14 @@ def slice_state_to_proto(state: SliceState, idle_threshold: Duration | None = No
     vm_state = _lifecycle_to_vm_state(state.lifecycle)
 
     is_idle = False
-    if idle_threshold is not None and state.lifecycle == SliceLifecycleState.READY:
-        if state.last_active.epoch_ms() == 0:
-            is_idle = True
-        else:
-            idle_duration = Duration.from_ms(Timestamp.now().epoch_ms() - state.last_active.epoch_ms())
-            is_idle = idle_duration >= idle_threshold
+    if idle_threshold is not None and state.lifecycle == SliceLifecycleState.READY and state.quiet_since is not None:
+        idle_duration = Duration.from_ms(Timestamp.now().epoch_ms() - state.quiet_since.epoch_ms())
+        is_idle = idle_duration >= idle_threshold
+
+    # The dashboard renders "idle for {now - last_active}" on idle slices.
+    # For an active slice the value is unused, so report `now`; for an idle
+    # slice, report the transition time (= quiet_since).
+    last_active_ts = state.quiet_since if state.quiet_since is not None else Timestamp.now()
 
     return vm_pb2.SliceInfo(
         slice_id=state.handle.slice_id,
@@ -273,7 +278,7 @@ def slice_state_to_proto(state: SliceState, idle_threshold: Duration | None = No
             for worker_id in state.worker_ids
         ],
         error_message=state.error_message,
-        last_active=timestamp_to_proto(state.last_active),
+        last_active=timestamp_to_proto(last_active_ts),
         idle=is_idle,
     )
 
@@ -361,15 +366,14 @@ class ScalingGroup:
         with self._db.transaction() as cur:
             cur.execute(
                 "INSERT OR REPLACE INTO slices "
-                "(slice_id, scale_group, lifecycle, worker_ids, created_at_ms, last_active_ms, error_message) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                "(slice_id, scale_group, lifecycle, worker_ids, created_at_ms, error_message) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
                 (
                     slice_id,
                     self.name,
                     state.lifecycle.value,
                     json.dumps(list(state.worker_ids)),
                     state.handle.created_at.epoch_ms(),
-                    state.last_active.epoch_ms(),
                     state.error_message,
                 ),
             )
@@ -520,19 +524,17 @@ class ScalingGroup:
     def mark_slice_ready(self, slice_id: str, worker_ids: list[str], timestamp: Timestamp | None = None) -> None:
         """Mark a slice as READY with its worker IDs. Called after successful bootstrap.
 
-        Initializes last_active to prevent the slice from appearing idle since epoch(0),
-        which would make it immediately eligible for scaledown.
+        ``quiet_since`` is left unset (None) so the freshly-ready slice is
+        treated as active until the next autoscaler tick observes its workers;
+        if the workers come up idle, that tick will start the dwell-time clock.
         """
-        timestamp = timestamp or Timestamp.now()
+        del timestamp  # No timestamp to record now that quiet_since tracks transitions.
         with self._slices_lock:
             state = self._slices.get(slice_id)
             if state is not None:
                 state.lifecycle = SliceLifecycleState.READY
                 state.worker_ids = worker_ids
-                state.last_active = timestamp
-                # _db_upsert_slice below writes last_active_ms to the DB, so the
-                # flush watermark advances with it.
-                state.last_active_db_flush = timestamp
+                state.quiet_since = None
         if state is not None:
             self._db_upsert_slice(slice_id, state)
             logger.info(
@@ -742,74 +744,25 @@ class ScalingGroup:
         )
         return check_resource_fit(available, required)
 
-    # Minimum elapsed time before a last_active change is flushed to the DB.
-    # Avoids one transaction per active slice per autoscaler tick for stable workloads.
-    _ACTIVITY_WRITE_THRESHOLD_MS: int = 30_000
-
     def update_slice_activity(self, worker_status_map: WorkerStatusMap, timestamp: Timestamp) -> None:
-        """Update activity timestamps for all slices based on worker status.
+        """Stamp the active→idle / idle→active transition for each slice.
 
-        For each slice, if any worker has running tasks, update its last_active timestamp.
-        All DB writes are batched into a single transaction.
+        Pure in-memory state transition: a slice flips its ``quiet_since`` to
+        ``timestamp`` the first tick all of its workers are idle, and back to
+        ``None`` whenever any worker has a running task. Eligibility for
+        scaledown is then ``now - quiet_since >= idle_threshold``.
         """
         with self._slices_lock:
             snapshot = list(self._slices.items())
 
-        # Determine which slices are active and whether they need a DB write.
-        # _slice_has_active_workers is called outside the lock (reads worker_status_map, not _slices).
-        # The flush threshold is measured against last_active_db_flush, not
-        # last_active — last_active is bumped every tick, so reading it here
-        # would always yield ~tick_interval elapsed and starve DB writes.
-        active_slice_ids: list[str] = []
-        needs_db_write: list[str] = []
-        for slice_id, state in snapshot:
-            if not self._slice_has_active_workers(state, worker_status_map):
-                continue
-            active_slice_ids.append(slice_id)
-            elapsed_ms = timestamp.epoch_ms() - state.last_active_db_flush.epoch_ms()
-            if elapsed_ms >= self._ACTIVITY_WRITE_THRESHOLD_MS:
-                needs_db_write.append(slice_id)
-
-        if not active_slice_ids:
-            return
-
-        # Mutate last_active under the lock so readers see a consistent value.
         with self._slices_lock:
-            for slice_id in active_slice_ids:
-                if slice_id in self._slices:
-                    self._slices[slice_id].last_active = timestamp
-
-        if not needs_db_write or self._db is None:
-            return
-
-        # Snapshot state under lock before opening the transaction to avoid
-        # holding _slices_lock and _db._lock simultaneously.
-        with self._slices_lock:
-            to_write = [(sid, self._slices[sid]) for sid in needs_db_write if sid in self._slices]
-
-        with self._db.transaction() as cur:
-            for slice_id, state in to_write:
-                cur.execute(
-                    "INSERT OR REPLACE INTO slices "
-                    "(slice_id, scale_group, lifecycle, worker_ids, created_at_ms, last_active_ms, error_message) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                    (
-                        slice_id,
-                        self.name,
-                        state.lifecycle.value,
-                        json.dumps(list(state.worker_ids)),
-                        state.handle.created_at.epoch_ms(),
-                        state.last_active.epoch_ms(),
-                        state.error_message,
-                    ),
-                )
-
-        # Record the flush watermark so the next elapsed check measures from
-        # the actual write time, not from the per-tick last_active mutation.
-        with self._slices_lock:
-            for slice_id in needs_db_write:
-                if slice_id in self._slices:
-                    self._slices[slice_id].last_active_db_flush = timestamp
+            for slice_id, state in snapshot:
+                if slice_id not in self._slices:
+                    continue
+                if self._slice_has_active_workers(state, worker_status_map):
+                    self._slices[slice_id].quiet_since = None
+                elif self._slices[slice_id].quiet_since is None:
+                    self._slices[slice_id].quiet_since = timestamp
 
     def _slice_has_active_workers(self, state: SliceState, worker_status_map: WorkerStatusMap) -> bool:
         """Check if any worker in a slice has running tasks."""
@@ -824,28 +777,30 @@ class ScalingGroup:
 
         Eligible if:
         - Slice not tracked -> eligible
-        - last_active is epoch 0 (never had activity) -> eligible
-        - OR idle for at least idle_threshold
+        - quiet_since is None (currently active or never observed) -> not eligible
+        - OR idle for at least idle_threshold since quiet_since
         """
         with self._slices_lock:
             state = self._slices.get(slice_id)
         if state is None:
             return True
-        if state.last_active.epoch_ms() == 0:
-            return True
-        idle_duration = Duration.from_ms(timestamp.epoch_ms() - state.last_active.epoch_ms())
+        if state.quiet_since is None:
+            return False
+        idle_duration = Duration.from_ms(timestamp.epoch_ms() - state.quiet_since.epoch_ms())
         return idle_duration >= self._idle_threshold
 
     def get_idle_slices(self, timestamp: Timestamp) -> list[SliceState]:
         """Get all slice states eligible for scaledown, sorted by idle time (longest first)."""
         with self._slices_lock:
             snapshot = list(self._slices.items())
-        eligible = []
+        eligible: list[tuple[SliceState, int]] = []
         for slice_id, state in snapshot:
-            if state.lifecycle == SliceLifecycleState.READY and self.is_slice_eligible_for_scaledown(
-                slice_id, timestamp
-            ):
-                eligible.append((state, state.last_active.epoch_ms()))
+            if state.lifecycle != SliceLifecycleState.READY:
+                continue
+            if not self.is_slice_eligible_for_scaledown(slice_id, timestamp):
+                continue
+            assert state.quiet_since is not None  # implied by eligibility
+            eligible.append((state, state.quiet_since.epoch_ms()))
         eligible.sort(key=lambda x: x[1])
         return [s[0] for s in eligible]
 
@@ -915,16 +870,13 @@ class ScalingGroup:
 
             with self._slices_lock:
                 state = self._slices.get(slice_state.handle.slice_id)
-            last_active = state.last_active if state else Timestamp.from_ms(0)
-            never_active = last_active.epoch_ms() == 0
-            idle_duration = Duration.from_ms(timestamp.epoch_ms() - last_active.epoch_ms())
+            quiet_since = state.quiet_since if state is not None else None
+            idle_ms = timestamp.epoch_ms() - quiet_since.epoch_ms() if quiet_since is not None else 0
             logger.info(
-                "Scale group %s: scaling down slice %s "
-                "(idle for %dms, never_active=%s, ready=%d/%d, pending=%d, target=%d)",
+                "Scale group %s: scaling down slice %s " "(idle for %dms, ready=%d/%d, pending=%d, target=%d)",
                 self.name,
                 slice_state.handle.slice_id,
-                idle_duration.to_ms(),
-                never_active,
+                idle_ms,
                 ready,
                 self.num_vms,
                 pending,
@@ -1275,7 +1227,6 @@ class SliceSnapshot:
     lifecycle: str
     worker_ids: list[str] = field(default_factory=list)
     created_at_ms: int = 0
-    last_active_ms: int = 0
     error_message: str = ""
 
 
@@ -1340,15 +1291,15 @@ def restore_scaling_group(
             )
             lifecycle = SliceLifecycleState.BOOTING
 
+        # Recovered slices start with quiet_since=None so the next autoscaler
+        # tick observes their workers and decides afresh: any active task →
+        # stays active; otherwise the tick stamps quiet_since and the dwell
+        # clock starts from there. This intentionally grants a full
+        # idle_threshold grace period after a controller restart.
         result.slices[slice_id] = SliceState(
             handle=cloud_handle,
             lifecycle=lifecycle,
             worker_ids=list(slice_snap.worker_ids),
-            last_active=Timestamp.from_ms(slice_snap.last_active_ms),
-            # Seed the flush watermark from the recovered last_active so the
-            # post-restart elapsed check measures from the last DB write, not
-            # from epoch 0.
-            last_active_db_flush=Timestamp.from_ms(slice_snap.last_active_ms),
             error_message=slice_snap.error_message,
         )
 

--- a/lib/iris/src/iris/cluster/controller/migrations/0046_drop_slices_last_active_ms.py
+++ b/lib/iris/src/iris/cluster/controller/migrations/0046_drop_slices_last_active_ms.py
@@ -1,0 +1,22 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Drop ``slices.last_active_ms`` (now tracked in-memory as ``quiet_since``).
+
+The autoscaler used to persist a continuously-mutating "last active" stamp,
+but the periodic-flush logic was buggy (the elapsed clock was reset every
+tick, so the row froze at the first post-restart write). The replacement
+tracks active→idle transitions in memory only — there is no need to persist
+it, since recovery starts the dwell-time clock fresh on the next tick anyway.
+"""
+
+import sqlite3
+
+
+def _has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    return column in {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    if _has_column(conn, "slices", "last_active_ms"):
+        conn.execute("ALTER TABLE slices DROP COLUMN last_active_ms")

--- a/lib/iris/src/iris/cluster/controller/schema.py
+++ b/lib/iris/src/iris/cluster/controller/schema.py
@@ -976,7 +976,6 @@ SLICES = Table(
             default_factory=list,
         ),
         Column("created_at_ms", "INTEGER", "NOT NULL DEFAULT 0", python_type=int, decoder=int, default=0),
-        Column("last_active_ms", "INTEGER", "NOT NULL DEFAULT 0", python_type=int, decoder=int, default=0),
         Column("error_message", "TEXT", "NOT NULL DEFAULT ''", python_type=str, decoder=str, default=""),
     ),
     indexes=("CREATE INDEX IF NOT EXISTS idx_slices_scale_group ON slices(scale_group)",),

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -239,7 +239,9 @@ class TestAutoscalerScaleDown:
             slice_002_wid: WorkerStatus(worker_id=slice_002_wid, running_task_ids=frozenset()),
         }
 
-        # Timestamp must be past idle_threshold (1000ms) from when slices became ready
+        # First idle observation stamps quiet_since at t=2000.
+        group.update_slice_activity(vm_status_map, Timestamp.from_ms(2_000))
+        # At t=10_000 dwell=8s, well past the 1s threshold.
         autoscaler.run_once(demand, vm_status_map, timestamp=Timestamp.from_ms(10_000))
 
         assert group.slice_count() == 1
@@ -386,7 +388,10 @@ class TestAutoscalerScaleDown:
             slice_003_wid: WorkerStatus(worker_id=slice_003_wid, running_task_ids=frozenset()),
         }
 
+        # First idle observation at t=2000 stamps quiet_since on all three.
+        group.update_slice_activity(vm_status_map, Timestamp.from_ms(2_000))
         # With rate_limit=5, all 3 idle slices should be scaled down in one cycle
+        # at t=10_000 (8s dwell, past 1s threshold).
         autoscaler.run_once(demand, vm_status_map, timestamp=Timestamp.from_ms(10_000))
         assert group.slice_count() == 0
 
@@ -1280,8 +1285,10 @@ class TestPerGroupWorkerConfig:
 class TestGpuScaleGroupBugs:
     """Reproduction tests for GPU scale group bugs observed on CoreWeave."""
 
-    def test_freshly_ready_slice_has_nonzero_last_active(self):
-        """When a slice transitions to READY, last_active should be initialized."""
+    def test_freshly_ready_slice_not_eligible_for_scaledown(self):
+        """A freshly-READY slice is treated as currently active (quiet_since=None)
+        and is not eligible for scale-down until an autoscaler tick observes it idle.
+        """
         config = make_scale_group_config(
             name="h100-8x",
             buffer_slices=0,
@@ -1297,28 +1304,18 @@ class TestGpuScaleGroupBugs:
 
         ts = Timestamp.from_ms(1_000_000)
 
-        # Scale up and complete
         group.begin_scale_up(timestamp=ts)
         handle = group.scale_up(timestamp=ts)
         group.complete_scale_up(handle, ts)
 
-        # Mark the slice as READY (simulates bootstrap completion)
         worker_ids = [w.worker_id for w in handle.describe().workers]
         group.mark_slice_ready(handle.slice_id, worker_ids)
 
-        # last_active should be initialized to at least the ready time
         with group._slices_lock:
             state = group._slices[handle.slice_id]
 
-        assert state.last_active.epoch_ms() > 0, (
-            "Freshly READY slice should have last_active set to at least the ready time, "
-            f"not epoch(0). Got last_active={state.last_active.epoch_ms()}"
-        )
-
-        # Consequently, the slice should NOT be eligible for scaledown immediately
-        assert not group.is_slice_eligible_for_scaledown(
-            handle.slice_id, ts
-        ), "Freshly READY slice should not be eligible for scaledown immediately"
+        assert state.quiet_since is None
+        assert not group.is_slice_eligible_for_scaledown(handle.slice_id, ts)
 
     def test_idle_threshold_protects_freshly_ready_slice(self):
         """A freshly-ready slice should be protected by idle_threshold even when
@@ -1557,6 +1554,8 @@ class TestMultiSliceScaleUp:
             wid_0: WorkerStatus(worker_id=wid_0, running_task_ids=frozenset()),
             wid_1: WorkerStatus(worker_id=wid_1, running_task_ids=frozenset()),
         }
+        # First idle observation stamps quiet_since at t=2_000.
+        group.update_slice_activity(vm_status_map, Timestamp.from_ms(2_000))
         autoscaler.run_once([], vm_status_map, timestamp=Timestamp.from_ms(10_000))
 
         # One idle slice should be scaled down.

--- a/lib/iris/tests/cluster/providers/test_scaling_group.py
+++ b/lib/iris/tests/cluster/providers/test_scaling_group.py
@@ -418,15 +418,20 @@ class TestScalingGroupDemandTracking:
 class TestScalingGroupIdleTracking:
     """Tests for per-slice idle tracking and scale-down eligibility."""
 
-    def test_slice_eligible_when_never_active(self, unbounded_config: config_pb2.ScaleGroupConfig):
-        """Fresh slice (no activity tracked) is eligible for scaledown."""
+    def test_slice_not_eligible_until_workers_observed_idle(self, unbounded_config: config_pb2.ScaleGroupConfig):
+        """Slice with quiet_since=None (no idle observation yet) is not eligible.
+
+        Under the new model, eligibility requires an active→idle transition to
+        have been observed; a never-observed slice stays alive until the next
+        autoscaler tick stamps quiet_since.
+        """
         platform = make_mock_platform()
         group = ScalingGroup(unbounded_config, platform, idle_threshold=Duration.from_ms(60_000))
         _tracked_scale_up(group)
         slice_id = next(iter(group.slice_handles())).slice_id
 
-        # Never had activity tracked -> eligible
-        assert group.is_slice_eligible_for_scaledown(slice_id, Timestamp.from_ms(1000))
+        # Never had activity observed -> not eligible.
+        assert not group.is_slice_eligible_for_scaledown(slice_id, Timestamp.from_ms(1000))
 
     def test_slice_not_eligible_when_recently_active(self, unbounded_config: config_pb2.ScaleGroupConfig):
         """Recently active slice is not eligible for scaledown."""
@@ -450,20 +455,18 @@ class TestScalingGroupIdleTracking:
         assert not group.is_slice_eligible_for_scaledown("slice-001", Timestamp.from_ms(30_000))
 
     def test_slice_eligible_after_idle_threshold(self, unbounded_config: config_pb2.ScaleGroupConfig):
-        """Slice is eligible after idle_threshold of inactivity."""
+        """Slice is eligible after idle_threshold has elapsed since the workers went idle."""
         discovered = [make_fake_slice_handle("slice-001", all_ready=True)]
         platform = make_mock_platform(slices_to_discover=discovered)
         group = ScalingGroup(unbounded_config, platform, idle_threshold=Duration.from_ms(60_000))
         group.reconcile()
+        _mark_discovered_ready(group, discovered)
 
-        handle = group.get_slice("slice-001")
-        worker_id = _get_worker_id(handle)
+        worker_id = _get_worker_id(group.get_slice("slice-001"))
 
-        # Mark slice as active at t=1000 via update_slice_activity
-        vm_status_map = {
-            worker_id: WorkerStatus(worker_id=worker_id, running_task_ids=frozenset({"task-1"})),
-        }
-        group.update_slice_activity(vm_status_map, Timestamp.from_ms(1000))
+        # First tick observes the workers idle at t=1000 -> stamps quiet_since.
+        idle_map = {worker_id: WorkerStatus(worker_id=worker_id, running_task_ids=frozenset())}
+        group.update_slice_activity(idle_map, Timestamp.from_ms(1000))
 
         # After threshold (61s > 60s) -> eligible
         assert group.is_slice_eligible_for_scaledown("slice-001", Timestamp.from_ms(61_001))
@@ -479,31 +482,31 @@ class TestScalingGroupIdleTracking:
         group.reconcile()
         _mark_discovered_ready(group, discovered)
 
-        # Get worker IDs from the handles
-        slice_001 = group.get_slice("slice-001")
-        slice_002 = group.get_slice("slice-002")
-        wid_001 = _get_worker_id(slice_001)
-        wid_002 = _get_worker_id(slice_002)
+        wid_001 = _get_worker_id(group.get_slice("slice-001"))
+        wid_002 = _get_worker_id(group.get_slice("slice-002"))
 
-        # Mark slice-001 as active at t=1000 (will be idle longer)
-        vm_status_map_001 = {
-            wid_001: WorkerStatus(worker_id=wid_001, running_task_ids=frozenset({"task-1"})),
-        }
-        group.update_slice_activity(vm_status_map_001, Timestamp.from_ms(1000))
-
-        # Mark slice-002 as active at t=5000 (more recently active)
-        vm_status_map_002 = {
+        # slice-001 transitions to idle at t=1000 (longer dwell time below).
+        only_001_idle = {
+            wid_001: WorkerStatus(worker_id=wid_001, running_task_ids=frozenset()),
             wid_002: WorkerStatus(worker_id=wid_002, running_task_ids=frozenset({"task-2"})),
         }
-        group.update_slice_activity(vm_status_map_002, Timestamp.from_ms(5000))
+        group.update_slice_activity(only_001_idle, Timestamp.from_ms(1000))
 
-        # At timestamp 10000, slice-001 has been idle longer (9s vs 5s)
+        # slice-002 transitions to idle at t=5000.
+        both_idle = {
+            wid_001: WorkerStatus(worker_id=wid_001, running_task_ids=frozenset()),
+            wid_002: WorkerStatus(worker_id=wid_002, running_task_ids=frozenset()),
+        }
+        group.update_slice_activity(both_idle, Timestamp.from_ms(5000))
+
+        # At t=10_000 both have crossed the 1s threshold; slice-001 has been
+        # idle longer (9s vs 5s).
         idle_slices = group.get_idle_slices(Timestamp.from_ms(10_000))
         assert len(idle_slices) == 2
-        assert idle_slices[0].handle.slice_id == "slice-001"  # Longest idle first
+        assert idle_slices[0].handle.slice_id == "slice-001"
 
     def test_update_slice_activity_tracks_active_slices(self, unbounded_config: config_pb2.ScaleGroupConfig):
-        """update_slice_activity updates timestamp only for slices with active workers."""
+        """Active slice stays alive; idle slice becomes eligible after threshold."""
         discovered = [
             make_fake_slice_handle("slice-001", all_ready=True),
             make_fake_slice_handle("slice-002", all_ready=True),
@@ -514,34 +517,32 @@ class TestScalingGroupIdleTracking:
         ready_ts = Timestamp.from_ms(1000)
         _mark_discovered_ready(group, discovered, timestamp=ready_ts)
 
-        slice_001 = group.get_slice("slice-001")
-        slice_002 = group.get_slice("slice-002")
-        wid_001 = _get_worker_id(slice_001)
-        wid_002 = _get_worker_id(slice_002)
+        wid_001 = _get_worker_id(group.get_slice("slice-001"))
+        wid_002 = _get_worker_id(group.get_slice("slice-002"))
 
-        # slice-001 has running tasks, slice-002 is idle
+        # slice-001 has running tasks, slice-002 has none.
         vm_status_map = {
             wid_001: WorkerStatus(worker_id=wid_001, running_task_ids=frozenset({"task-1"})),
             wid_002: WorkerStatus(worker_id=wid_002, running_task_ids=frozenset()),
         }
 
-        check_ts = Timestamp.from_ms(5000)
-        group.update_slice_activity(vm_status_map, check_ts)
+        # First observation at t=1500: stamps quiet_since on slice-002 only.
+        group.update_slice_activity(vm_status_map, Timestamp.from_ms(1500))
 
-        # Observable behavior: slice-001 should not be eligible for scaledown (recently active)
-        # slice-002 is eligible because idle_threshold (1000ms) has passed since ready_ts (1000ms)
+        # At t=3000, slice-002 has been quiet for 1500ms (> 1000ms threshold)
+        # while slice-001 stays active.
+        check_ts = Timestamp.from_ms(3000)
         assert not group.is_slice_eligible_for_scaledown("slice-001", check_ts)
         assert group.is_slice_eligible_for_scaledown("slice-002", check_ts)
 
-    def test_update_slice_activity_flushes_db_periodically_when_continuously_active(
-        self, unbounded_config: config_pb2.ScaleGroupConfig, tmp_path
-    ):
-        """Regression: continuously-active slices must keep flushing last_active_ms to the DB.
+    def test_continuous_activity_keeps_quiet_since_none(self, unbounded_config: config_pb2.ScaleGroupConfig, tmp_path):
+        """Regression: a continuously-active slice never accrues quiet time.
 
-        Earlier the threshold check measured elapsed against state.last_active, which
-        is mutated to the current timestamp every tick. elapsed therefore stayed at
-        ~tick_interval and never crossed the 30s flush threshold, so the DB row froze
-        at the first post-restart write while in-memory state ticked forward.
+        The previous implementation persisted ``last_active_ms`` to the DB on a
+        threshold the per-tick mutation defeated; we observed live slices with
+        a multi-hour-stale DB row even though their workers had running tasks.
+        Under the transition model an active slice keeps ``quiet_since=None``
+        through arbitrarily many ticks and is never eligible for scale-down.
         """
         db = ControllerDB(db_dir=Path(tmp_path))
         discovered = [make_fake_slice_handle("slice-001", all_ready=True)]
@@ -554,37 +555,14 @@ class TestScalingGroupIdleTracking:
         wid = _get_worker_id(group.get_slice("slice-001"))
         active_map = {wid: WorkerStatus(worker_id=wid, running_task_ids=frozenset({"task-1"}))}
 
-        def db_last_active_ms() -> int:
-            with db.read_snapshot() as q:
-                rows = list(q.raw("SELECT last_active_ms FROM slices WHERE slice_id = ?", ("slice-001",)))
-            return int(rows[0].last_active_ms) if rows else 0
-
-        # Run many continuous ticks at the production cadence (10s apart).
-        # Each tick: in-memory state.last_active gets bumped to the current ts.
-        # The flush threshold is 30s, so we expect the DB to be written ~every 3 ticks.
-        tick_interval_ms = 10_000
-        flush_threshold_ms = 30_000
-        baseline_db_ts = db_last_active_ms()
-        flush_count = 0
-        last_flush_seen = baseline_db_ts
-        for tick in range(1, 21):  # 200s of activity
-            ts = Timestamp.from_ms(ready_ts.epoch_ms() + tick * tick_interval_ms)
+        # 20 ticks of continuous activity at production cadence (10s apart).
+        for tick in range(1, 21):
+            ts = Timestamp.from_ms(ready_ts.epoch_ms() + tick * 10_000)
             group.update_slice_activity(active_map, ts)
-            current_db_ts = db_last_active_ms()
-            if current_db_ts != last_flush_seen:
-                flush_count += 1
-                last_flush_seen = current_db_ts
+            assert not group.is_slice_eligible_for_scaledown("slice-001", ts)
 
-        # Over 200s with a 30s threshold, we must see multiple flushes — not zero
-        # (the bug) and not one per tick (which would be wasteful).
-        assert flush_count >= 5, f"expected periodic DB flushes, got {flush_count} in 20 ticks"
-        # The most recent flush must be reasonably current — within one threshold
-        # of the final tick, never more than 200s stale.
-        final_ts_ms = ready_ts.epoch_ms() + 20 * tick_interval_ms
-        staleness_ms = final_ts_ms - last_flush_seen
-        assert (
-            staleness_ms <= flush_threshold_ms + tick_interval_ms
-        ), f"DB last_active_ms is {staleness_ms}ms stale; flush threshold is {flush_threshold_ms}ms"
+        with group._slices_lock:
+            assert group._slices["slice-001"].quiet_since is None
 
     def test_scale_down_if_idle_terminates_eligible_slice(self, unbounded_config: config_pb2.ScaleGroupConfig):
         """scale_down_if_idle terminates an eligible idle slice."""
@@ -602,20 +580,14 @@ class TestScalingGroupIdleTracking:
         wid_001 = _get_worker_id(slice_001)
         wid_002 = _get_worker_id(slice_002)
 
-        # Mark both slices as active at t=0 (they'll be idle for 10s, exceeding 1s threshold)
-        vm_status_map_active = {
-            wid_001: WorkerStatus(worker_id=wid_001, running_task_ids=frozenset({"task-1"})),
-            wid_002: WorkerStatus(worker_id=wid_002, running_task_ids=frozenset({"task-2"})),
-        }
-        group.update_slice_activity(vm_status_map_active, Timestamp.from_ms(0))
-
-        # At t=10_000, workers are now idle
         vm_status_map_idle = {
             wid_001: WorkerStatus(worker_id=wid_001, running_task_ids=frozenset()),
             wid_002: WorkerStatus(worker_id=wid_002, running_task_ids=frozenset()),
         }
+        # First idle observation at t=0 stamps quiet_since on both slices.
+        group.update_slice_activity(vm_status_map_idle, Timestamp.from_ms(0))
 
-        # Target capacity = 1, but we have 2 ready slices
+        # At t=10_000 they have been quiet 10s — well past the 1s threshold.
         scaled_down = group.scale_down_if_idle(
             vm_status_map_idle, target_capacity=1, timestamp=Timestamp.from_ms(10_000)
         )
@@ -675,17 +647,13 @@ def test_scale_down_no_misleading_rate_limit_log(unbounded_config: config_pb2.Sc
     wid_001 = _get_worker_id(discovered[0])
     wid_002 = _get_worker_id(discovered[1])
 
-    # Mark both active at t=0, then idle at t=1000 (well past idle_threshold)
-    active_map = {
-        wid_001: WorkerStatus(worker_id=wid_001, running_task_ids=frozenset({"task-1"})),
-        wid_002: WorkerStatus(worker_id=wid_002, running_task_ids=frozenset({"task-2"})),
-    }
-    group.update_slice_activity(active_map, Timestamp.from_ms(0))
-
     idle_map = {
         wid_001: WorkerStatus(worker_id=wid_001, running_task_ids=frozenset()),
         wid_002: WorkerStatus(worker_id=wid_002, running_task_ids=frozenset()),
     }
+    # First idle observation at t=0 stamps quiet_since; by t=1000 both
+    # have been quiet 1s, past the 100ms threshold.
+    group.update_slice_activity(idle_map, Timestamp.from_ms(0))
 
     ts = Timestamp.from_ms(1000)
 
@@ -1326,12 +1294,11 @@ class TestMultiVmSliceIdleScaleDown:
         wids = [w.worker_id for w in workers]
         assert len(wids) == 4
 
-        # Mark all workers as active at t=0
-        active_map = {wid: WorkerStatus(worker_id=wid, running_task_ids=frozenset({"task"})) for wid in wids}
-        group.update_slice_activity(active_map, Timestamp.from_ms(0))
-
-        # At t=10_000 (past threshold), all workers now idle
+        # First idle observation at t=0 stamps quiet_since on the slice.
         idle_map = {wid: WorkerStatus(worker_id=wid, running_task_ids=frozenset()) for wid in wids}
+        group.update_slice_activity(idle_map, Timestamp.from_ms(0))
+
+        # At t=10_000 (past 1s threshold), the slice scales down.
         scaled_down = group.scale_down_if_idle(idle_map, target_capacity=0, timestamp=Timestamp.from_ms(10_000))
 
         assert len(scaled_down) == 1
@@ -1350,11 +1317,9 @@ class TestMultiVmSliceIdleScaleDown:
         workers = handle.describe().workers
         wids = [w.worker_id for w in workers]
 
-        # Mark all active initially
-        active_map = {wid: WorkerStatus(worker_id=wid, running_task_ids=frozenset({"task"})) for wid in wids}
-        group.update_slice_activity(active_map, Timestamp.from_ms(0))
-
-        # 3 workers idle, 1 still has tasks
+        # 3 workers idle, 1 still has tasks. update_slice_activity inside
+        # scale_down_if_idle observes ANY active worker → quiet_since=None,
+        # so the slice is never eligible.
         mixed_map = {}
         for i, wid in enumerate(wids):
             tasks = frozenset({"task-running"}) if i == 0 else frozenset()
@@ -1366,7 +1331,7 @@ class TestMultiVmSliceIdleScaleDown:
         assert group.slice_count() == 1
 
     def test_multi_vm_slice_activity_updates_when_any_worker_busy(self):
-        """update_slice_activity stamps last_active when ANY worker in the slice is busy."""
+        """update_slice_activity treats the slice as active when ANY worker is busy."""
         config = _make_multi_vm_config(num_vms=4)
         discovered = [_make_multi_vm_slice_handle("slice-001", num_vms=4)]
         platform = make_mock_platform(slices_to_discover=discovered)
@@ -1406,20 +1371,17 @@ class TestMultiVmSliceIdleScaleDown:
         wids_1 = [w.worker_id for w in h1.describe().workers]
         wids_2 = [w.worker_id for w in h2.describe().workers]
 
-        # Mark both slices active initially
-        all_active = {}
-        for wid in wids_1 + wids_2:
-            all_active[wid] = WorkerStatus(worker_id=wid, running_task_ids=frozenset({"task"}))
-        group.update_slice_activity(all_active, Timestamp.from_ms(0))
-
-        # At t=10_000: slice-001 all idle, slice-002 still has work on one VM
+        # First observation at t=0: slice-001 all idle (stamps quiet_since=0),
+        # slice-002 has work on one VM (stays active, quiet_since=None).
         vm_map = {}
         for wid in wids_1:
             vm_map[wid] = WorkerStatus(worker_id=wid, running_task_ids=frozenset())
         for i, wid in enumerate(wids_2):
             tasks = frozenset({"running"}) if i == 0 else frozenset()
             vm_map[wid] = WorkerStatus(worker_id=wid, running_task_ids=tasks)
+        group.update_slice_activity(vm_map, Timestamp.from_ms(0))
 
+        # At t=10_000 (past 1s threshold), slice-001 has been quiet 10s.
         scaled_down = group.scale_down_if_idle(vm_map, target_capacity=1, timestamp=Timestamp.from_ms(10_000))
 
         assert len(scaled_down) == 1
@@ -1470,11 +1432,11 @@ class TestSliceStateToProtoIdleFields:
             handle=handle,
             lifecycle=SliceLifecycleState.READY,
             worker_ids=["10.0.0.1"],
-            last_active=Timestamp.from_ms(1000),
+            quiet_since=Timestamp.from_ms(1000),
         )
 
-        # With a threshold of 1s and last_active at 1s ago, idle should be True
-        # (since Timestamp.now() will be >> 2000ms)
+        # With a 1ms threshold and quiet_since 1s ago (Timestamp.now() >> 2000ms),
+        # the slice should be idle.
         proto = slice_state_to_proto(state, idle_threshold=Duration.from_ms(1))
         assert proto.idle is True
         assert proto.last_active.epoch_ms == 1000
@@ -1487,9 +1449,23 @@ class TestSliceStateToProtoIdleFields:
             handle=handle,
             lifecycle=SliceLifecycleState.READY,
             worker_ids=["10.0.0.1"],
-            last_active=Timestamp.from_ms(1000),
+            quiet_since=Timestamp.from_ms(1000),
         )
         proto = slice_state_to_proto(state, idle_threshold=None)
+        assert proto.idle is False
+
+    def test_idle_false_when_currently_active(self):
+        """quiet_since=None means currently active — never idle."""
+        from iris.cluster.controller.autoscaler.scaling_group import slice_state_to_proto
+
+        handle = make_fake_slice_handle("s1", scale_group="g1", created_at_ms=1000)
+        state = SliceState(
+            handle=handle,
+            lifecycle=SliceLifecycleState.READY,
+            worker_ids=["10.0.0.1"],
+            quiet_since=None,
+        )
+        proto = slice_state_to_proto(state, idle_threshold=Duration.from_ms(1))
         assert proto.idle is False
 
     def test_idle_false_for_non_ready_slices(self):
@@ -1500,7 +1476,7 @@ class TestSliceStateToProtoIdleFields:
             handle=handle,
             lifecycle=SliceLifecycleState.BOOTING,
             worker_ids=[],
-            last_active=Timestamp.from_ms(0),
+            quiet_since=None,
         )
         proto = slice_state_to_proto(state, idle_threshold=Duration.from_ms(1))
         assert proto.idle is False

--- a/lib/iris/tests/cluster/providers/test_scaling_group.py
+++ b/lib/iris/tests/cluster/providers/test_scaling_group.py
@@ -8,6 +8,7 @@ VM group management, and state tracking - not on implementation details.
 """
 
 import logging
+from pathlib import Path
 
 import pytest
 from iris.cluster.controller.autoscaler.scaling_group import (
@@ -16,6 +17,7 @@ from iris.cluster.controller.autoscaler.scaling_group import (
     SliceState,
     _zones_from_config,
 )
+from iris.cluster.controller.db import ControllerDB
 from iris.cluster.providers.types import (
     CloudSliceState,
     CloudWorkerState,
@@ -530,6 +532,59 @@ class TestScalingGroupIdleTracking:
         # slice-002 is eligible because idle_threshold (1000ms) has passed since ready_ts (1000ms)
         assert not group.is_slice_eligible_for_scaledown("slice-001", check_ts)
         assert group.is_slice_eligible_for_scaledown("slice-002", check_ts)
+
+    def test_update_slice_activity_flushes_db_periodically_when_continuously_active(
+        self, unbounded_config: config_pb2.ScaleGroupConfig, tmp_path
+    ):
+        """Regression: continuously-active slices must keep flushing last_active_ms to the DB.
+
+        Earlier the threshold check measured elapsed against state.last_active, which
+        is mutated to the current timestamp every tick. elapsed therefore stayed at
+        ~tick_interval and never crossed the 30s flush threshold, so the DB row froze
+        at the first post-restart write while in-memory state ticked forward.
+        """
+        db = ControllerDB(db_dir=Path(tmp_path))
+        discovered = [make_fake_slice_handle("slice-001", all_ready=True)]
+        platform = make_mock_platform(slices_to_discover=discovered)
+        group = ScalingGroup(unbounded_config, platform, idle_threshold=Duration.from_ms(60_000), db=db)
+        group.reconcile()
+        ready_ts = Timestamp.from_ms(1_000_000)
+        _mark_discovered_ready(group, discovered, timestamp=ready_ts)
+
+        wid = _get_worker_id(group.get_slice("slice-001"))
+        active_map = {wid: WorkerStatus(worker_id=wid, running_task_ids=frozenset({"task-1"}))}
+
+        def db_last_active_ms() -> int:
+            with db.read_snapshot() as q:
+                rows = list(q.raw("SELECT last_active_ms FROM slices WHERE slice_id = ?", ("slice-001",)))
+            return int(rows[0].last_active_ms) if rows else 0
+
+        # Run many continuous ticks at the production cadence (10s apart).
+        # Each tick: in-memory state.last_active gets bumped to the current ts.
+        # The flush threshold is 30s, so we expect the DB to be written ~every 3 ticks.
+        tick_interval_ms = 10_000
+        flush_threshold_ms = 30_000
+        baseline_db_ts = db_last_active_ms()
+        flush_count = 0
+        last_flush_seen = baseline_db_ts
+        for tick in range(1, 21):  # 200s of activity
+            ts = Timestamp.from_ms(ready_ts.epoch_ms() + tick * tick_interval_ms)
+            group.update_slice_activity(active_map, ts)
+            current_db_ts = db_last_active_ms()
+            if current_db_ts != last_flush_seen:
+                flush_count += 1
+                last_flush_seen = current_db_ts
+
+        # Over 200s with a 30s threshold, we must see multiple flushes — not zero
+        # (the bug) and not one per tick (which would be wasteful).
+        assert flush_count >= 5, f"expected periodic DB flushes, got {flush_count} in 20 ticks"
+        # The most recent flush must be reasonably current — within one threshold
+        # of the final tick, never more than 200s stale.
+        final_ts_ms = ready_ts.epoch_ms() + 20 * tick_interval_ms
+        staleness_ms = final_ts_ms - last_flush_seen
+        assert (
+            staleness_ms <= flush_threshold_ms + tick_interval_ms
+        ), f"DB last_active_ms is {staleness_ms}ms stale; flush threshold is {flush_threshold_ms}ms"
 
     def test_scale_down_if_idle_terminates_eligible_slice(self, unbounded_config: config_pb2.ScaleGroupConfig):
         """scale_down_if_idle terminates an eligible idle slice."""

--- a/lib/iris/tests/cluster/test_snapshot_reconciliation.py
+++ b/lib/iris/tests/cluster/test_snapshot_reconciliation.py
@@ -120,7 +120,6 @@ def _make_slice_snapshot(
         lifecycle=lifecycle,
         worker_ids=worker_ids or [],
         created_at_ms=created_at_ms,
-        last_active_ms=created_at_ms,
         error_message=error_message,
     )
 


### PR DESCRIPTION
The autoscaler tracked a continuously-mutated last_active timestamp and tried to flush it to slices.last_active_ms periodically, but the threshold check was measured against the field being mutated each tick, so the DB row froze at the first post-restart write. Replace the design with a single in-memory quiet_since transition marker (None when active, set on the first all-idle observation), drop the last_active_ms column and its persistence, and add a migration plus updated tests.