### PR TITLE
[iris] Native ASGI controller mount + @on_loop hot RPCs

### DIFF
--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -55,9 +55,10 @@ from iris.cluster.dashboard_common import (
     requires_auth,
     static_files_mount,
 )
+from iris.rpc.async_adapter import AsyncServiceAdapter
 from iris.rpc.auth import SESSION_COOKIE, NullAuthInterceptor, TokenVerifier, extract_bearer_token, resolve_auth
 from iris.rpc.compression import IRIS_RPC_COMPRESSIONS
-from iris.rpc.controller_connect import ControllerServiceWSGIApplication
+from iris.rpc.controller_connect import ControllerServiceASGIApplication
 from iris.rpc.interceptors import SLOW_RPC_THRESHOLD_MS, ConcurrencyLimitInterceptor, RequestTimingInterceptor
 from iris.rpc.stats import RpcStatsCollector
 from iris.rpc.stats_connect import StatsServiceWSGIApplication
@@ -208,31 +209,50 @@ class _DashboardAuthInterceptor:
         self._optional = optional
         self._null = NullAuthInterceptor(verifier=verifier)
 
+    def _resolve_or_raise(self, ctx):
+        """Returns (identity, fallback_to_null). Raises ConnectError on rejection."""
+        from connectrpc.code import Code
+        from connectrpc.errors import ConnectError
+
+        token = extract_bearer_token(ctx.request_headers())
+        try:
+            identity = resolve_auth(token, self._verifier, self._optional)
+        except ValueError as exc:
+            if token is None:
+                raise ConnectError(Code.UNAUTHENTICATED, str(exc)) from exc
+            logger.warning("Authentication failed: %s", exc)
+            raise ConnectError(Code.UNAUTHENTICATED, "Authentication failed") from exc
+        return identity
+
     def intercept_unary_sync(self, call_next, request, ctx):
         from iris.rpc.auth import _verified_identity
 
         if ctx.method().name in _UNAUTHENTICATED_RPCS:
             return call_next(request, ctx)
 
-        token = extract_bearer_token(ctx.request_headers())
-        try:
-            identity = resolve_auth(token, self._verifier, self._optional)
-        except ValueError as exc:
-            from connectrpc.code import Code
-            from connectrpc.errors import ConnectError
-
-            if token is None:
-                raise ConnectError(Code.UNAUTHENTICATED, str(exc)) from exc
-            logger.warning("Authentication failed: %s", exc)
-            raise ConnectError(Code.UNAUTHENTICATED, "Authentication failed") from exc
-
+        identity = self._resolve_or_raise(ctx)
         if identity is None:
-            # Optional mode, no token — anonymous fallback.
             return self._null.intercept_unary_sync(call_next, request, ctx)
 
         reset_token = _verified_identity.set(identity)
         try:
             return call_next(request, ctx)
+        finally:
+            _verified_identity.reset(reset_token)
+
+    async def intercept_unary(self, call_next, request, ctx):
+        from iris.rpc.auth import _verified_identity
+
+        if ctx.method().name in _UNAUTHENTICATED_RPCS:
+            return await call_next(request, ctx)
+
+        identity = self._resolve_or_raise(ctx)
+        if identity is None:
+            return await self._null.intercept_unary(call_next, request, ctx)
+
+        reset_token = _verified_identity.set(identity)
+        try:
+            return await call_next(request, ctx)
         finally:
             _verified_identity.reset(reset_token)
 
@@ -330,6 +350,25 @@ class _SubdomainProxyMiddleware:
         return headers.get("x-forwarded-host") or headers.get("host", "")
 
 
+_LEGACY_FETCH_LOGS_PATH = "/iris.cluster.ControllerService/FetchLogs"
+_CANONICAL_FETCH_LOGS_PATH = "/finelog.logging.LogService/FetchLogs"
+
+
+class _LegacyFetchLogsRedirect:
+    """Rewrites the legacy ControllerService/FetchLogs path to the canonical
+    LogService path so old workers reach the LogService mount, where the
+    full auth + timing + concurrency interceptor chain handles the request.
+    """
+
+    def __init__(self, app: ASGIApp):
+        self._app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope.get("type") == "http" and scope.get("path") == _LEGACY_FETCH_LOGS_PATH:
+            scope = {**scope, "path": _CANONICAL_FETCH_LOGS_PATH}
+        await self._app(scope, receive, send)
+
+
 class ControllerDashboard:
     """HTTP dashboard with Connect RPC and web UI.
 
@@ -388,8 +427,12 @@ class ControllerDashboard:
             # when present but treat everything as anonymous/admin.
             auth_interceptor = NullAuthInterceptor(verifier=self._auth_verifier)
         controller_interceptors = [auth_interceptor, controller_timing]
-        rpc_wsgi_app = ControllerServiceWSGIApplication(
-            service=self._service, interceptors=controller_interceptors, compressions=IRIS_RPC_COMPRESSIONS
+        # @on_loop handlers run inline on the event loop; everything else
+        # is dispatched to a thread by AsyncServiceAdapter.
+        rpc_asgi_app = ControllerServiceASGIApplication(
+            service=AsyncServiceAdapter(self._service),
+            interceptors=controller_interceptors,
+            compressions=IRIS_RPC_COMPRESSIONS,
         )
 
         # StatsService: reuses the auth interceptor (so non-admins can't read
@@ -415,16 +458,6 @@ class ControllerDashboard:
         )
         log_app = WSGIMiddleware(log_wsgi_app)
 
-        # Backward-compat: old clients call ControllerService/FetchLogs (removed
-        # from the proto in the LogService migration).  Register the already-
-        # intercepted LogService FetchLogs endpoint under the old path so the
-        # Connect protocol handles encoding, compression, and auth correctly.
-        # The LogService now lives under the finelog.logging proto package.
-        _LOG_FETCH_ENDPOINT = "/finelog.logging.LogService/FetchLogs"
-        _LOG_PUSH_ENDPOINT = "/finelog.logging.LogService/PushLogs"
-        _COMPAT_FETCH_ENDPOINT = "/iris.cluster.ControllerService/FetchLogs"
-        rpc_wsgi_app._endpoints[_COMPAT_FETCH_ENDPOINT] = log_wsgi_app._endpoints[_LOG_FETCH_ENDPOINT]
-
         # Backward-compat: clients/workers built before the finelog lift call
         # /iris.logging.LogService/{FetchLogs,PushLogs}. Wire bytes are identical
         # to /finelog.logging.LogService/*, so mount the same WSGI app at the
@@ -432,12 +465,12 @@ class ControllerDashboard:
         # connectrpc dispatch (_server_sync.py:206-210) first looks up PATH_INFO
         # directly; the existing /finelog.logging.LogService mount only hits via
         # the SCRIPT_NAME==self.path fallback. Adding relative keys lets the
-        # first lookup succeed regardless of which mount handled the request.
+        # first lookup succeeds regardless of which mount handled the request.
+        _LOG_FETCH_ENDPOINT = "/finelog.logging.LogService/FetchLogs"
+        _LOG_PUSH_ENDPOINT = "/finelog.logging.LogService/PushLogs"
         log_wsgi_app._endpoints["/FetchLogs"] = log_wsgi_app._endpoints[_LOG_FETCH_ENDPOINT]
         log_wsgi_app._endpoints["/PushLogs"] = log_wsgi_app._endpoints[_LOG_PUSH_ENDPOINT]
         _LEGACY_LOG_SERVICE_PATH = "/iris.logging.LogService"
-
-        rpc_app = WSGIMiddleware(rpc_wsgi_app)
 
         self._actor_proxy = ActorProxy(self._service._store)
 
@@ -504,7 +537,7 @@ class ControllerDashboard:
             ),
             Mount(log_wsgi_app.path, app=log_app),
             Mount(_LEGACY_LOG_SERVICE_PATH, app=log_app),
-            Mount(rpc_wsgi_app.path, app=rpc_app),
+            Mount(rpc_asgi_app.path, app=rpc_asgi_app),
             Mount(stats_wsgi_app.path, app=stats_app),
         ]
         if self._finelog_stats_service is not None:
@@ -533,6 +566,9 @@ class ControllerDashboard:
         wrapped: ASGIApp = app
         if self._auth_verifier is not None and self._auth_provider is not None:
             wrapped = _RouteAuthMiddleware(app, self._auth_verifier, optional=self._auth_optional)
+        # Wrap auth so the legacy FetchLogs rewrite happens before route
+        # matching: auth and routing both see the canonical path.
+        wrapped = _LegacyFetchLogsRedirect(wrapped)
         # Subdomain dispatch wraps everything: subdomain requests don't match
         # any Starlette route, so _RouteAuthMiddleware would default-allow
         # them. This middleware enforces auth itself before forwarding.

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -99,6 +99,7 @@ from iris.cluster.types import (
 )
 from iris.rpc import controller_pb2, job_pb2, query_pb2, vm_pb2, worker_pb2
 from iris.rpc import logging_pb2 as iris_logging_pb2
+from iris.rpc.async_adapter import on_loop
 from iris.rpc.auth import (
     AuthzAction,
     authorize,
@@ -1330,6 +1331,7 @@ class ControllerServiceImpl:
             request=redact_request_env_vars(reconstructed_request),
         )
 
+    @on_loop
     def get_job_state(
         self,
         request: controller_pb2.Controller.GetJobStateRequest,
@@ -2605,6 +2607,7 @@ class ControllerServiceImpl:
 
     # --- Task Status Text Push ---
 
+    @on_loop
     def set_task_status_text(
         self,
         request: job_pb2.SetTaskStatusTextRequest,

--- a/lib/iris/src/iris/rpc/async_adapter.py
+++ b/lib/iris/src/iris/rpc/async_adapter.py
@@ -1,0 +1,75 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Adapt a sync RPC service to the async surface expected by
+``connectrpc.server.ConnectASGIApplication``.
+
+The ASGI application invokes ``await endpoint.function(...)`` for every
+unary RPC, so each handler must be a coroutine function.
+``AsyncServiceAdapter`` exposes a sync service's methods as async:
+
+- methods marked with :func:`on_loop` are wrapped in an ``async def`` that
+  calls the sync body inline on the event loop. Use this only for short,
+  non-blocking handlers (in-memory dicts, very cheap SQL reads) — a long
+  handler running inline blocks every other RPC.
+- every other sync method gets an ``asyncio.to_thread`` wrapper.
+- methods that are already coroutine functions pass through untouched.
+
+Interceptors are not adapted here — each interceptor that participates in
+an ASGI chain implements ``async intercept_unary`` directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import inspect
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+_ON_LOOP_ATTR = "__iris_rpc_on_loop__"
+
+
+def on_loop(fn: F) -> F:
+    """Mark a sync RPC handler as safe to run directly on the event loop.
+
+    The handler must be short and non-blocking. A handler that blocks the
+    loop for tens of milliseconds will queue every other RPC behind it.
+    """
+    setattr(fn, _ON_LOOP_ATTR, True)
+    return fn
+
+
+def _is_on_loop(fn: Callable[..., Any]) -> bool:
+    return getattr(fn, _ON_LOOP_ATTR, False)
+
+
+class AsyncServiceAdapter:
+    """Wraps a sync service so it satisfies an async-method Protocol."""
+
+    __slots__ = ("_impl",)
+
+    def __init__(self, impl: Any) -> None:
+        self._impl = impl
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._impl, name)
+        if name.startswith("_") or not callable(attr):
+            return attr
+        if inspect.iscoroutinefunction(attr):
+            return attr
+        if _is_on_loop(attr):
+
+            @functools.wraps(attr)
+            async def _on_loop_call(*args: Any, **kwargs: Any) -> Any:
+                return attr(*args, **kwargs)
+
+            return _on_loop_call
+
+        @functools.wraps(attr)
+        async def _threaded_call(*args: Any, **kwargs: Any) -> Any:
+            return await asyncio.to_thread(attr, *args, **kwargs)
+
+        return _threaded_call

--- a/lib/iris/src/iris/rpc/auth.py
+++ b/lib/iris/src/iris/rpc/auth.py
@@ -247,20 +247,33 @@ class AuthInterceptor:
     def __init__(self, verifier: TokenVerifier):
         self._verifier = verifier
 
-    def intercept_unary_sync(self, call_next, request, ctx):
+    def _verify_or_raise(self, ctx) -> "VerifiedIdentity":
         token = extract_bearer_token(ctx.request_headers())
         if not token:
             raise ConnectError(Code.UNAUTHENTICATED, "Missing or malformed Authorization header")
-
         try:
-            identity = self._verifier.verify(token)
+            return self._verifier.verify(token)
         except ValueError as exc:
             logger.warning("Authentication failed: %s", exc)
             raise ConnectError(Code.UNAUTHENTICATED, "Authentication failed") from exc
 
+    def intercept_unary_sync(self, call_next, request, ctx):
+        identity = self._verify_or_raise(ctx)
         reset_token = _verified_identity.set(identity)
         try:
             return call_next(request, ctx)
+        finally:
+            _verified_identity.reset(reset_token)
+
+    async def intercept_unary(self, call_next, request, ctx):
+        # Token verification is pure crypto (HMAC-SHA256 for JWTs); safe to
+        # run inline on the loop. ContextVar bookkeeping mirrors the sync
+        # path so service handlers see the same identity regardless of
+        # which dispatch surface they came in through.
+        identity = self._verify_or_raise(ctx)
+        reset_token = _verified_identity.set(identity)
+        try:
+            return await call_next(request, ctx)
         finally:
             _verified_identity.reset(reset_token)
 
@@ -291,9 +304,8 @@ class NullAuthInterceptor:
         self._default_identity = VerifiedIdentity(user_id=user, role=role)
         self._verifier = verifier
 
-    def intercept_unary_sync(self, call_next, request, ctx):
+    def _resolve_identity(self, ctx) -> "VerifiedIdentity":
         identity = self._default_identity
-
         if self._verifier is not None:
             token = extract_bearer_token(ctx.request_headers())
             if token:
@@ -301,10 +313,19 @@ class NullAuthInterceptor:
                     identity = self._verifier.verify(token)
                 except ValueError:
                     pass
+        return identity
 
-        reset_token = _verified_identity.set(identity)
+    def intercept_unary_sync(self, call_next, request, ctx):
+        reset_token = _verified_identity.set(self._resolve_identity(ctx))
         try:
             return call_next(request, ctx)
+        finally:
+            _verified_identity.reset(reset_token)
+
+    async def intercept_unary(self, call_next, request, ctx):
+        reset_token = _verified_identity.set(self._resolve_identity(ctx))
+        try:
+            return await call_next(request, ctx)
         finally:
             _verified_identity.reset(reset_token)
 

--- a/lib/iris/tests/cluster/controller/test_auth.py
+++ b/lib/iris/tests/cluster/controller/test_auth.py
@@ -459,6 +459,7 @@ def test_route_auth_middleware_uses_resolve_auth(service, log_service, verifier,
     """
     from iris.cluster.controller.dashboard import (
         ControllerDashboard,
+        _LegacyFetchLogsRedirect,
         _RouteAuthMiddleware,
         _SubdomainProxyMiddleware,
         requires_auth,
@@ -478,10 +479,11 @@ def test_route_auth_middleware_uses_resolve_auth(service, log_service, verifier,
         auth_optional=optional,
     )
     # Inject a @requires_auth route. The app is wrapped in
-    # _SubdomainProxyMiddleware → _RouteAuthMiddleware → Starlette; walk down
-    # to the Starlette router so the new route participates in route matching.
+    # _SubdomainProxyMiddleware → _LegacyFetchLogsRedirect → _RouteAuthMiddleware
+    # → Starlette; walk down to the Starlette router so the new route
+    # participates in route matching.
     app = dashboard.app
-    while isinstance(app, _SubdomainProxyMiddleware | _RouteAuthMiddleware):
+    while isinstance(app, _SubdomainProxyMiddleware | _LegacyFetchLogsRedirect | _RouteAuthMiddleware):
         app = app._app
     app.router.routes.insert(0, Route("/test-protected", _protected))
 


### PR DESCRIPTION
Switch the controller's RPC mount from ControllerServiceWSGIApplication + WSGIMiddleware to ControllerServiceASGIApplication wrapping AsyncServiceAdapter. Methods marked @on_loop run inline on the event loop; everything else dispatches via asyncio.to_thread. Mark get_job_state and set_task_status_text @on_loop -- those two account for ~480k RPCs/window in production and now skip the thread hop. Auth interceptors gain native async intercept_unary; legacy ControllerService/FetchLogs is rewritten to the canonical LogService path so old workers keep working.