### PR TITLE
[iris] Stamp effective band at assignment time, stop recomputing for preemption victims

### DIFF
--- a/lib/iris/src/iris/cluster/controller/budget.py
+++ b/lib/iris/src/iris/cluster/controller/budget.py
@@ -117,7 +117,14 @@ def compute_effective_band(
 
     PRODUCTION tasks are never downgraded. Users without a ``user_budgets``
     row fall back to ``defaults.budget_limit``; a limit of 0 means unlimited.
+
+    Defense-in-depth: a leaked UNSPECIFIED (0) is normalized to INTERACTIVE
+    so it cannot sort ahead of PRODUCTION under ``ORDER BY priority_band
+    ASC``. Callers should resolve UNSPECIFIED upstream (parent inheritance,
+    then INTERACTIVE default) — see ``JobStore.get_priority_bands``.
     """
+    if task_band == job_pb2.PRIORITY_BAND_UNSPECIFIED:
+        task_band = job_pb2.PRIORITY_BAND_INTERACTIVE
     if task_band == job_pb2.PRIORITY_BAND_PRODUCTION:
         return task_band
     limit = user_budgets.get(user_id, defaults.budget_limit)

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -668,12 +668,30 @@ def _schedulable_tasks(queries: ControllerDB) -> list[TaskRow]:
         tasks = TASK_ROW_PROJECTION.decode(
             snapshot.fetchall(
                 f"SELECT {TASK_ROW_PROJECTION.select_clause()} FROM tasks t WHERE t.state = ? "
-                "ORDER BY t.priority_band ASC, t.priority_neg_depth ASC, t.priority_root_submitted_ms ASC, "
+                "ORDER BY t.priority_neg_depth ASC, t.priority_root_submitted_ms ASC, "
                 "t.submitted_at_ms ASC, t.priority_insertion ASC",
                 (job_pb2.TASK_STATE_PENDING,),
             ),
         )
     return [task for task in tasks if task_row_can_be_scheduled(task)]
+
+
+def _sort_pending_tasks_by_resolved_band(store: ControllerStore, pending_tasks: list[TaskRow]) -> list[TaskRow]:
+    """Order pending rows using immutable job_config priority bands."""
+    if not pending_tasks:
+        return []
+    with store.read_snapshot() as snap:
+        requested_bands = store.jobs.get_priority_bands(snap, {task.job_id for task in pending_tasks})
+    return sorted(
+        pending_tasks,
+        key=lambda task: (
+            requested_bands.get(task.job_id, job_pb2.PRIORITY_BAND_INTERACTIVE),
+            task.priority_neg_depth,
+            task.priority_root_submitted_ms,
+            task.submitted_at.epoch_ms(),
+            task.priority_insertion,
+        ),
+    )
 
 
 def _tasks_by_ids_with_attempts(queries: ControllerDB, task_ids: set[JobName]) -> dict[JobName, TaskDetailRow]:
@@ -1902,7 +1920,7 @@ class Controller:
         """
         timer = Timer()
         with slow_log(logger, "scheduling state reads", threshold_ms=50):
-            pending_tasks = _schedulable_tasks(self._db)
+            pending_tasks = _sort_pending_tasks_by_resolved_band(self._store, _schedulable_tasks(self._db))
             workers = healthy_active_workers_with_attributes(self._db, self._health)
             with self._db.read_snapshot() as snap:
                 usage_by_worker = self._store.attempts.resource_usage_by_worker(snap)

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -1987,11 +1987,24 @@ class Controller:
         """
         with self._db.read_snapshot() as budget_snapshot:
             user_spend = compute_user_spend(budget_snapshot)
+            # Source the requested band from ``job_config`` (immutable since
+            # submission), not from ``tasks.priority_band`` (which is overwritten
+            # with the effective band at assign time). Otherwise a task that was
+            # downgraded to BATCH while its user was over budget would stay
+            # BATCH forever after preemption — ``compute_effective_band`` only
+            # demotes, never promotes back to the user's requested band.
+            requested_bands = self._store.jobs.get_priority_bands(
+                budget_snapshot, {task.job_id for task in pending_tasks}
+            )
         user_budget_limits = self._db.get_all_user_budget_limits()
         defaults = self._config.user_budget_defaults
         task_band_map: dict[JobName, int] = {
             task.task_id: compute_effective_band(
-                task.priority_band, task.task_id.user, user_spend, user_budget_limits, defaults
+                requested_bands.get(task.job_id, task.priority_band),
+                task.task_id.user,
+                user_spend,
+                user_budget_limits,
+                defaults,
             )
             for task in pending_tasks
         }

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -437,16 +437,18 @@ def _jobs_with_reservations(queries: ControllerDB, states: tuple[int, ...]) -> l
 def _get_running_tasks_with_band_and_value(
     db: ControllerDB,
     claimed_workers: set[WorkerId],
-    user_spend: dict[str, int] | None = None,
-    user_budget_limits: dict[str, int] | None = None,
-    user_budget_defaults: UserBudgetDefaults | None = None,
 ) -> list[RunningTaskInfo]:
     """Query running tasks with band, worker, resource spec, and coscheduling status.
 
     Skips tasks on reservation-claimed workers since those workers are spoken for.
-    When ``user_spend`` and ``user_budget_limits`` are provided, the effective band
-    is computed so over-budget users' tasks are treated as BATCH for preemption.
-    Users without a budget row fall back to ``user_budget_defaults``.
+
+    The reported band is the value persisted in ``tasks.priority_band``, which
+    is stamped at assignment time (see ``_commit_assignments`` and
+    ``TaskStore.mark_assigned``). The over-budget downgrade is applied at that
+    stamping point, not on every scheduling tick, which prevents a running
+    task from oscillating into BATCH and back as its own user crosses the
+    budget cliff — the source of mutual same-band preemption between two
+    users sitting at their limits.
     """
     with db.read_snapshot() as q:
         rows = q.raw(
@@ -463,9 +465,6 @@ def _get_running_tasks_with_band_and_value(
                 "worker_id": WorkerId,
             },
         )
-    _spend = user_spend or {}
-    _limits = user_budget_limits or {}
-    _defaults = user_budget_defaults or UserBudgetDefaults()
     result: list[RunningTaskInfo] = []
     for row in rows:
         wid = row.worker_id
@@ -477,12 +476,11 @@ def _get_running_tasks_with_band_and_value(
             row.res_disk_bytes,
             row.res_device_json,
         )
-        band = compute_effective_band(row.priority_band, row.task_id.user, _spend, _limits, _defaults)
         result.append(
             RunningTaskInfo(
                 task_id=row.task_id,
                 worker_id=wid,
-                band_sort_key=band,
+                band_sort_key=row.priority_band,
                 resource_value=resource_value(
                     resources.cpu_millicores,
                     resources.memory_bytes,
@@ -2070,7 +2068,7 @@ class Controller:
                 len(result.assignments),
             )
         if all_assignments:
-            self._commit_assignments(all_assignments)
+            self._commit_assignments(all_assignments, order.task_band_map)
             logger.debug(
                 "Scheduling cycle: %d assignments (%d preferred, %d normal), %dms (state read: %dms)",
                 len(all_assignments),
@@ -2081,8 +2079,18 @@ class Controller:
             )
         return all_assignments, context, modified_jobs
 
-    def _commit_assignments(self, assignments: list[tuple[JobName, WorkerId]]) -> None:
+    def _commit_assignments(
+        self,
+        assignments: list[tuple[JobName, WorkerId]],
+        task_band_map: dict[JobName, int],
+    ) -> None:
         """Persist scheduler decisions to ``tasks.state = ASSIGNED`` rows.
+
+        Each assignment carries the effective priority band from
+        ``task_band_map`` (computed against the snapshot's user spend) so
+        ``mark_assigned`` can stamp it onto ``tasks.priority_band``. The
+        preemption pass then trusts that stamped value instead of
+        recomputing from current spend on every tick.
 
         The polling reconcile thread reads ASSIGNED rows on its next tick
         (woken via ``_polling_wake``) and fans out the StartTasks RPCs.
@@ -2091,7 +2099,14 @@ class Controller:
             for task_id, worker_id in assignments:
                 logger.info("[DRY-RUN] Would assign task %s to worker %s", task_id, worker_id)
             return
-        command = [Assignment(task_id=task_id, worker_id=worker_id) for task_id, worker_id in assignments]
+        command = [
+            Assignment(
+                task_id=task_id,
+                worker_id=worker_id,
+                priority_band=task_band_map.get(task_id),
+            )
+            for task_id, worker_id in assignments
+        ]
         with self._store.transaction() as cur:
             self._transitions.queue_assignments(cur, command)
         # Wake the polling thread; every tick reconciles every healthy worker,
@@ -2120,13 +2135,7 @@ class Controller:
         preemptions: list[tuple[JobName, JobName]] = []
         if unscheduled:
             claimed_workers = set(claims.keys())
-            running_info = _get_running_tasks_with_band_and_value(
-                self._db,
-                claimed_workers,
-                user_spend=order.user_spend,
-                user_budget_limits=order.user_budget_limits,
-                user_budget_defaults=self._config.user_budget_defaults,
-            )
+            running_info = _get_running_tasks_with_band_and_value(self._db, claimed_workers)
             preemptions = _run_preemption_pass(unscheduled, running_info, context)
             # Apply all preemptions in one transaction so slice evictions
             # (N siblings of a coscheduled preemptor) are all-or-nothing.

--- a/lib/iris/src/iris/cluster/controller/schema.py
+++ b/lib/iris/src/iris/cluster/controller/schema.py
@@ -1282,6 +1282,9 @@ class TaskRow:
     max_retries_preemption: int
     submitted_at: Timestamp
     priority_band: int = 2
+    priority_neg_depth: int = 0
+    priority_root_submitted_ms: int = 0
+    priority_insertion: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -1517,6 +1520,9 @@ TASK_ROW_PROJECTION = TASKS.projection(
     "max_retries_preemption",
     "submitted_at_ms",
     "priority_band",
+    "priority_neg_depth",
+    "priority_root_submitted_ms",
+    "priority_insertion",
     row_cls=TaskRow,
 )
 

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -2473,6 +2473,7 @@ class ControllerServiceImpl:
                     (job_pb2.TASK_STATE_PENDING,),
                 ),
             )
+            pending_requested_bands = self._store.jobs.get_priority_bands(snap, {row.job_id for row in pending_rows})
 
             # Running tasks: only task_id, priority_band, and worker — no
             # job_config join is needed for the rolled-up counts below.
@@ -2492,7 +2493,11 @@ class ControllerServiceImpl:
                 continue
             user_id = row.task_id.user
             eff_band = compute_effective_band(
-                row.priority_band, user_id, user_spend, budget_limits, self._user_budget_defaults
+                pending_requested_bands.get(row.job_id, row.priority_band),
+                user_id,
+                user_spend,
+                budget_limits,
+                self._user_budget_defaults,
             )
             job_id = (row.task_id.parent or row.task_id).to_wire()
             key = (eff_band, user_id, job_id)

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -2500,15 +2500,15 @@ class ControllerServiceImpl:
             total_pending += 1
 
         # Aggregate running into (band, user, worker, job) → count buckets.
+        # Use the stamped ``tasks.priority_band`` directly: the scheduler stamps the
+        # effective band at assign time (see ``_commit_assignments``), so re-running
+        # ``compute_effective_band`` here against current spend would double-demote.
         running_counts: dict[tuple[int, str, str, str], int] = {}
         total_running = 0
         for row in running_rows:
             user_id = row.task_id.user
-            eff_band = compute_effective_band(
-                row.priority_band, user_id, user_spend, budget_limits, self._user_budget_defaults
-            )
             job_id = (row.task_id.parent or row.task_id).to_wire()
-            key = (eff_band, user_id, str(row.worker_id), job_id)
+            key = (row.priority_band, user_id, str(row.worker_id), job_id)
             running_counts[key] = running_counts.get(key, 0) + 1
             total_running += 1
 

--- a/lib/iris/src/iris/cluster/controller/stores.py
+++ b/lib/iris/src/iris/cluster/controller/stores.py
@@ -717,6 +717,59 @@ class JobStore:
         row = tx.fetchone("SELECT * FROM job_config WHERE job_id = ?", (job_id.to_wire(),))
         return dict(row) if row is not None else None
 
+    def get_priority_bands(self, tx: Tx, job_ids: Iterable[JobName]) -> dict[JobName, int]:
+        """Return ``{job_id: resolved priority_band}`` for the given jobs.
+
+        Mirrors ``submit_job``'s band resolution at read time: use the job's
+        own ``job_config.priority_band`` if it's set; otherwise walk up the
+        ``parent_job_id`` chain and use the nearest ancestor with a
+        non-UNSPECIFIED band; otherwise default to INTERACTIVE.
+
+        The scheduler uses this as the input to ``compute_effective_band`` so
+        a previously-downgraded task can be promoted again once the user
+        falls back under budget. Reading ``tasks.priority_band`` here would
+        be wrong because that column is overwritten with the effective
+        (possibly demoted) band at assign time, and reading the raw
+        ``job_config.priority_band`` without resolution would let UNSPECIFIED
+        (0) leak through and sort ahead of PRODUCTION.
+        """
+        wire_ids = [jid.to_wire() for jid in job_ids]
+        if not wire_ids:
+            return {}
+        placeholders = ",".join("?" for _ in wire_ids)
+        # Recursive CTE: for each input job, walk parent_job_id while the
+        # current row's priority_band is UNSPECIFIED (0). The first row with
+        # a non-UNSPECIFIED band wins. Inputs whose entire chain is
+        # UNSPECIFIED don't appear in the result; the caller substitutes
+        # INTERACTIVE for those.
+        rows = tx.fetchall(
+            f"""
+            WITH RECURSIVE chain(input_id, current_id, current_band, parent_id) AS (
+                SELECT j.job_id, j.job_id, jc.priority_band, j.parent_job_id
+                FROM jobs j JOIN job_config jc ON jc.job_id = j.job_id
+                WHERE j.job_id IN ({placeholders})
+                UNION ALL
+                SELECT chain.input_id, j.job_id, jc.priority_band, j.parent_job_id
+                FROM chain
+                JOIN jobs j ON j.job_id = chain.parent_id
+                JOIN job_config jc ON jc.job_id = j.job_id
+                WHERE chain.current_band = 0
+            )
+            SELECT input_id, current_band
+            FROM chain
+            WHERE current_band != 0
+            """,
+            tuple(wire_ids),
+        )
+        resolved: dict[JobName, int] = {}
+        for row in rows:
+            resolved[JobName.from_wire(str(row["input_id"]))] = int(row["current_band"])
+        # Fall back to INTERACTIVE for inputs where the entire ancestor chain
+        # was UNSPECIFIED (raw user requests with no band, no inherited band).
+        for jid in job_ids:
+            resolved.setdefault(jid, int(job_pb2.PRIORITY_BAND_INTERACTIVE))
+        return resolved
+
     def list_descendants(
         self,
         tx: Tx,

--- a/lib/iris/src/iris/cluster/controller/stores.py
+++ b/lib/iris/src/iris/cluster/controller/stores.py
@@ -1270,19 +1270,44 @@ class TaskStore:
         worker_id: WorkerId | None,
         worker_address: str | None,
         now_ms: int,
+        priority_band: int | None = None,
     ) -> None:
+        # ``priority_band`` is stamped at assign time so that the preemption
+        # pass treats a running task's band as fixed. Without this, a user who
+        # crosses their budget cliff while their tasks are running gets their
+        # running tasks demoted to BATCH on the next tick — and then preempted
+        # by another user whose pending tasks haven't yet bumped them over the
+        # cliff. The two users then mutually preempt each other indefinitely.
+        # ``None`` leaves the existing column value untouched (used by code
+        # paths that do not run the budget computation).
+        band_set = "" if priority_band is None else ", priority_band = ?"
+        band_param: tuple[int, ...] = () if priority_band is None else (priority_band,)
         if worker_id is not None:
             cur.execute(
                 "UPDATE tasks SET state = ?, current_attempt_id = ?, "
                 "current_worker_id = ?, current_worker_address = ?, "
-                "started_at_ms = COALESCE(started_at_ms, ?) WHERE task_id = ?",
-                (job_pb2.TASK_STATE_ASSIGNED, attempt_id, str(worker_id), worker_address, now_ms, task_id.to_wire()),
+                f"started_at_ms = COALESCE(started_at_ms, ?){band_set} WHERE task_id = ?",
+                (
+                    job_pb2.TASK_STATE_ASSIGNED,
+                    attempt_id,
+                    str(worker_id),
+                    worker_address,
+                    now_ms,
+                    *band_param,
+                    task_id.to_wire(),
+                ),
             )
             return
         cur.execute(
             "UPDATE tasks SET state = ?, current_attempt_id = ?, "
-            "started_at_ms = COALESCE(started_at_ms, ?) WHERE task_id = ?",
-            (job_pb2.TASK_STATE_ASSIGNED, attempt_id, now_ms, task_id.to_wire()),
+            f"started_at_ms = COALESCE(started_at_ms, ?){band_set} WHERE task_id = ?",
+            (
+                job_pb2.TASK_STATE_ASSIGNED,
+                attempt_id,
+                now_ms,
+                *band_param,
+                task_id.to_wire(),
+            ),
         )
 
     def assign(
@@ -1294,6 +1319,7 @@ class TaskStore:
         worker_address: str | None,
         attempt_id: int,
         now_ms: int,
+        priority_band: int | None = None,
     ) -> None:
         attempts.insert(
             cur,
@@ -1305,7 +1331,7 @@ class TaskStore:
                 created_at_ms=now_ms,
             ),
         )
-        self.mark_assigned(cur, task_id, attempt_id, worker_id, worker_address, now_ms)
+        self.mark_assigned(cur, task_id, attempt_id, worker_id, worker_address, now_ms, priority_band=priority_band)
 
     def apply_state_update(
         self,

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -231,10 +231,21 @@ class HeartbeatApplyRequest:
 
 @dataclass(frozen=True)
 class Assignment:
-    """Scheduler assignment decision."""
+    """Scheduler assignment decision.
+
+    ``priority_band`` is the effective band computed at scheduling time
+    (after applying any over-budget downgrade). Stamped onto ``tasks.priority_band``
+    when the row transitions to ASSIGNED so that the preemption pass uses a
+    fixed, point-in-time band rather than re-evaluating against current spend
+    on every tick. Re-evaluating caused mutual preemption between two
+    same-band users sitting at the budget cliff. ``None`` leaves the column
+    unchanged (used by call sites that do not run the budget computation,
+    e.g. K8s direct-provider promotions and manual reassignment).
+    """
 
     task_id: JobName
     worker_id: WorkerId
+    priority_band: int | None = None
 
 
 @dataclass(frozen=True)
@@ -1358,6 +1369,7 @@ class ControllerTransitions:
                 worker_address,
                 attempt_id,
                 now_ms,
+                priority_band=assignment.priority_band,
             )
             jobs_to_update.add(job_id_wire)
             accepted.append(assignment)

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -950,16 +950,12 @@ class ControllerTransitions:
         # config (see reconcile_user_budget_tiers) and admin overrides via
         # set_user_budget.
 
-        # Resolve priority band: use explicit request value, inherit from parent, or default to INTERACTIVE.
+        # Pending rows keep only this job's requested/default band. Parent
+        # inheritance is resolved from immutable job_config when the scheduler
+        # computes the effective band for a scheduling loop.
         requested_band = int(request.priority_band)
         if requested_band != job_pb2.PRIORITY_BAND_UNSPECIFIED:
             band_sort_key = requested_band
-        elif job_id.parent is not None:
-            parent_band = self._store.tasks.get_priority_band_for_job(cur, job_id.parent)
-            if parent_band is not None:
-                band_sort_key = parent_band
-            else:
-                band_sort_key = job_pb2.PRIORITY_BAND_INTERACTIVE
         else:
             band_sort_key = job_pb2.PRIORITY_BAND_INTERACTIVE
 

--- a/lib/iris/tests/cluster/controller/test_preemption.py
+++ b/lib/iris/tests/cluster/controller/test_preemption.py
@@ -661,31 +661,55 @@ def test_over_budget_production_not_preemptible():
     assert effective == job_pb2.PRIORITY_BAND_PRODUCTION
 
 
-def test_running_tasks_use_effective_band():
-    """_get_running_tasks_with_band_and_value applies budget down-weighting to running tasks."""
+def test_running_tasks_report_stamped_band():
+    """_get_running_tasks_with_band_and_value returns the band stamped at assign time.
+
+    The over-budget downgrade is applied once in ``_commit_assignments`` and
+    persisted in ``tasks.priority_band``; the lookup must not re-derive the
+    band from current spend (which is what previously caused two same-band
+    users at the budget cliff to mutually preempt each other).
+    """
     with make_controller_state() as state:
         harness = ControllerTestHarness(state)
         w1 = harness.add_worker("w1", cpu=4)
+        w2 = harness.add_worker("w2", cpu=4)
 
-        # Submit an INTERACTIVE job for alice
-        tasks = harness.submit("/alice/interactive-job", cpu=1)
-        harness.dispatch(tasks[0], w1)
+        tasks_alice = harness.submit("/alice/interactive-job", cpu=1)
+        tasks_bob = harness.submit("/bob/interactive-job", cpu=1)
 
-        # Set alice's budget: over budget
-        user_spend = {"alice": 10000}
-        user_budget_limits = {"alice": 5000}
+        # Alice's task is stamped INTERACTIVE (she was under budget at schedule time).
+        # Bob's task is stamped BATCH (he was over budget at schedule time).
+        _dispatch_with_band(state, tasks_alice[0], w1, job_pb2.PRIORITY_BAND_INTERACTIVE)
+        _dispatch_with_band(state, tasks_bob[0], w2, job_pb2.PRIORITY_BAND_BATCH)
 
-        running = _get_running_tasks_with_band_and_value(
-            state._db,
-            set(),
-            user_spend=user_spend,
-            user_budget_limits=user_budget_limits,
-            user_budget_defaults=UserBudgetDefaults(),
+        running = {r.task_id: r.band_sort_key for r in _get_running_tasks_with_band_and_value(state._db, set())}
+        assert running == {
+            tasks_alice[0].task_id: job_pb2.PRIORITY_BAND_INTERACTIVE,
+            tasks_bob[0].task_id: job_pb2.PRIORITY_BAND_BATCH,
+        }
+
+
+def _dispatch_with_band(state, task, worker_id, priority_band: int) -> None:
+    """Dispatch task with an explicit stamped band, advancing it to RUNNING."""
+    with state._store.transaction() as cur:
+        state.queue_assignments(
+            cur,
+            [Assignment(task_id=task.task_id, worker_id=worker_id, priority_band=priority_band)],
         )
-
-        assert len(running) == 1
-        # Should be downgraded to BATCH
-        assert running[0].band_sort_key == job_pb2.PRIORITY_BAND_BATCH
+    with state._store.transaction() as cur:
+        state.apply_task_updates(
+            cur,
+            HeartbeatApplyRequest(
+                worker_id=worker_id,
+                updates=[
+                    TaskUpdate(
+                        task_id=task.task_id,
+                        attempt_id=query_task(state, task.task_id).current_attempt_id,
+                        new_state=job_pb2.TASK_STATE_RUNNING,
+                    )
+                ],
+            ),
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/controller/test_preemption.py
+++ b/lib/iris/tests/cluster/controller/test_preemption.py
@@ -9,6 +9,8 @@ from iris.cluster.controller.controller import (
     RunningTaskInfo,
     _get_running_tasks_with_band_and_value,
     _run_preemption_pass,
+    _schedulable_tasks,
+    _sort_pending_tasks_by_resolved_band,
 )
 from iris.cluster.controller.scheduler import JobRequirements, WorkerCapacity
 from iris.cluster.controller.transitions import (
@@ -20,6 +22,7 @@ from iris.cluster.controller.transitions import (
 )
 from iris.cluster.types import JobName, WorkerId
 from iris.rpc import controller_pb2, job_pb2
+from rigging.timing import Timestamp
 
 from .conftest import (
     ControllerTestHarness,
@@ -735,6 +738,51 @@ def test_demoted_task_re_promotes_after_user_returns_under_budget():
             )
             == job_pb2.PRIORITY_BAND_INTERACTIVE
         )
+
+
+def test_pending_child_order_uses_parent_job_config_not_stamped_task_band():
+    """Pending order resolves parent bands from job_config, not stamped task rows."""
+    with make_controller_state() as state:
+        harness = ControllerTestHarness(state)
+        w1 = harness.add_worker("w1", cpu=4)
+
+        parent_tasks = harness.submit(
+            "/alice/parent-prod",
+            cpu=1,
+            priority_band=job_pb2.PRIORITY_BAND_PRODUCTION,
+        )
+        parent_task = parent_tasks[0]
+        parent_id = parent_task.job_id
+
+        # Simulate an assignment-time effective-band stamp that differs from
+        # the parent's immutable requested band. Child inheritance and pending
+        # ordering must not read this stamped value.
+        _dispatch_with_band(state, parent_task, w1, job_pb2.PRIORITY_BAND_BATCH)
+        assert query_task(state, parent_task.task_id).priority_band == job_pb2.PRIORITY_BAND_BATCH
+
+        child_id = parent_id.child("child")
+        child_req = controller_pb2.Controller.LaunchJobRequest(
+            name=child_id.to_wire(),
+            entrypoint=make_test_entrypoint(),
+            resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
+            environment=job_pb2.EnvironmentConfig(),
+            replicas=1,
+        )
+        with state._store.transaction() as cur:
+            state.submit_job(cur, child_id, child_req, Timestamp.now())
+        interactive_tasks = harness.submit(
+            "/bob/interactive",
+            cpu=1,
+            priority_band=job_pb2.PRIORITY_BAND_INTERACTIVE,
+        )
+
+        child_task = query_tasks_for_job(state, child_id)[0]
+        assert child_task.priority_band == job_pb2.PRIORITY_BAND_INTERACTIVE
+
+        ordered = _sort_pending_tasks_by_resolved_band(state._store, _schedulable_tasks(state._db))
+        ordered_ids = [task.task_id for task in ordered]
+
+        assert ordered_ids.index(child_task.task_id) < ordered_ids.index(interactive_tasks[0].task_id)
 
 
 def _dispatch_with_band(state, task, worker_id, priority_band: int) -> None:

--- a/lib/iris/tests/cluster/controller/test_preemption.py
+++ b/lib/iris/tests/cluster/controller/test_preemption.py
@@ -689,6 +689,54 @@ def test_running_tasks_report_stamped_band():
         }
 
 
+def test_demoted_task_re_promotes_after_user_returns_under_budget():
+    """Stamping the effective band on assign must not pin a task to BATCH for life.
+
+    Sequence: alice submits INTERACTIVE → over-budget at assign time, scheduler
+    stamps ``tasks.priority_band = BATCH`` → task is preempted back to PENDING
+    → alice now under budget. The next scheduling tick must source the
+    requested band from ``job_config`` (immutable since submission), not from
+    the stamped ``tasks.priority_band`` (BATCH). Otherwise
+    ``compute_effective_band`` — which only demotes — can never restore
+    INTERACTIVE, and a momentary over-budget blip becomes a permanent
+    downgrade that did not exist before this PR's stamping change.
+    """
+    with make_controller_state() as state:
+        harness = ControllerTestHarness(state)
+        w1 = harness.add_worker("w1", cpu=4)
+
+        tasks = harness.submit("/alice/interactive-job", cpu=1, priority_band=job_pb2.PRIORITY_BAND_INTERACTIVE)
+        task = tasks[0]
+        job_id = task.job_id
+
+        # Scheduler decides alice is over budget and stamps BATCH at assign
+        # time. We bypass the over-budget computation by passing the band
+        # directly; ``mark_assigned`` is the same code path the scheduler hits.
+        _dispatch_with_band(state, task, w1, job_pb2.PRIORITY_BAND_BATCH)
+
+        # Confirm tasks.priority_band has been overwritten to BATCH.
+        assert query_task(state, task.task_id).priority_band == job_pb2.PRIORITY_BAND_BATCH
+
+        # job_config still reflects what alice asked for.
+        with state._db.read_snapshot() as snap:
+            requested = state._store.jobs.get_priority_bands(snap, [job_id])
+        assert requested == {job_id: job_pb2.PRIORITY_BAND_INTERACTIVE}
+
+        # And under-budget alice gets her INTERACTIVE band back from
+        # compute_effective_band — the scheduler now feeds it the job_config
+        # value so the next assignment will re-stamp INTERACTIVE.
+        assert (
+            compute_effective_band(
+                requested[job_id],
+                "alice",
+                user_spend={"alice": 0},
+                user_budgets={"alice": 5000},
+                defaults=UserBudgetDefaults(),
+            )
+            == job_pb2.PRIORITY_BAND_INTERACTIVE
+        )
+
+
 def _dispatch_with_band(state, task, worker_id, priority_band: int) -> None:
     """Dispatch task with an explicit stamped band, advancing it to RUNNING."""
     with state._store.transaction() as cur:

--- a/lib/iris/tests/cluster/controller/test_scheduling_fairness.py
+++ b/lib/iris/tests/cluster/controller/test_scheduling_fairness.py
@@ -271,6 +271,80 @@ def test_production_never_downgraded_by_budget():
             assert band == job_pb2.PRIORITY_BAND_PRODUCTION
 
 
+def test_get_priority_bands_resolves_via_parent_chain():
+    """``JobStore.get_priority_bands`` mirrors ``submit_job``'s resolution at read time.
+
+    ``job_config.priority_band`` is the raw user request and can be
+    UNSPECIFIED (0) for jobs that didn't pass ``--priority``. The scheduler
+    feeds the result of this lookup into ``compute_effective_band``, so a
+    raw 0 here would let the task sort ahead of PRODUCTION. The lookup
+    must instead walk the parent chain (matching ``submit_job``'s
+    submit-time resolution) and fall back to INTERACTIVE only if the entire
+    chain is UNSPECIFIED.
+    """
+    with make_controller_state() as state:
+        # Top-level with no band → INTERACTIVE default.
+        plain = _submit_user_job(state, "alice", "plain-job")
+        plain_job_id = plain[0].job_id
+
+        # Top-level PRODUCTION → returns PRODUCTION.
+        prod_req = make_job_request(
+            name="/alice/prod-job", cpu=1, replicas=1, priority_band=job_pb2.PRIORITY_BAND_PRODUCTION
+        )
+        submit_job(state, "/alice/prod-job", prod_req)
+        prod_job_id = JobName.from_string("/alice/prod-job")
+
+        # Sub-job of PRODUCTION parent, no band of its own → must inherit PRODUCTION.
+        sub_id = prod_job_id.child("subtask")
+        sub_req = controller_pb2.Controller.LaunchJobRequest(
+            name=sub_id.to_wire(),
+            entrypoint=prod_req.entrypoint,
+            resources=prod_req.resources,
+            environment=prod_req.environment,
+            replicas=1,
+        )
+        with state._store.transaction() as cur:
+            state.submit_job(cur, sub_id, sub_req, Timestamp.now())
+
+        # Sub-job with its own explicit BATCH → BATCH (own band wins, no walk).
+        batch_sub_id = prod_job_id.child("batch-sub")
+        batch_sub_req = controller_pb2.Controller.LaunchJobRequest(
+            name=batch_sub_id.to_wire(),
+            entrypoint=prod_req.entrypoint,
+            resources=prod_req.resources,
+            environment=prod_req.environment,
+            replicas=1,
+            priority_band=job_pb2.PRIORITY_BAND_BATCH,
+        )
+        with state._store.transaction() as cur:
+            state.submit_job(cur, batch_sub_id, batch_sub_req, Timestamp.now())
+
+        with state._db.read_snapshot() as snap:
+            bands = state._store.jobs.get_priority_bands(snap, [plain_job_id, prod_job_id, sub_id, batch_sub_id])
+
+        assert bands[plain_job_id] == job_pb2.PRIORITY_BAND_INTERACTIVE
+        assert bands[prod_job_id] == job_pb2.PRIORITY_BAND_PRODUCTION
+        assert bands[sub_id] == job_pb2.PRIORITY_BAND_PRODUCTION
+        assert bands[batch_sub_id] == job_pb2.PRIORITY_BAND_BATCH
+
+
+def test_compute_effective_band_normalizes_unspecified():
+    """Defense-in-depth: UNSPECIFIED (0) must never leak through as a real band.
+
+    Returning 0 would sort the task ahead of PRODUCTION (1) under the
+    scheduler's ``ORDER BY priority_band ASC``. The proper resolution
+    (parent inheritance, then INTERACTIVE) lives in
+    ``JobStore.get_priority_bands``; this is a last-resort guard.
+    """
+    defaults = UserBudgetDefaults()
+    band = compute_effective_band(job_pb2.PRIORITY_BAND_UNSPECIFIED, "alice", {"alice": 0}, {"alice": 5000}, defaults)
+    assert band == job_pb2.PRIORITY_BAND_INTERACTIVE
+    band = compute_effective_band(
+        job_pb2.PRIORITY_BAND_UNSPECIFIED, "alice", {"alice": 10000}, {"alice": 5000}, defaults
+    )
+    assert band == job_pb2.PRIORITY_BAND_BATCH
+
+
 def test_zero_budget_means_unlimited():
     """budget_limit=0 means no down-weighting regardless of spend."""
     with make_controller_state() as state:

--- a/lib/iris/tests/cluster/controller/test_scheduling_fairness.py
+++ b/lib/iris/tests/cluster/controller/test_scheduling_fairness.py
@@ -6,7 +6,11 @@
 from collections import defaultdict
 
 from iris.cluster.controller.budget import UserBudgetDefaults, UserTask, compute_effective_band, interleave_by_user
-from iris.cluster.controller.controller import SchedulingOutcome, _schedulable_tasks
+from iris.cluster.controller.controller import (
+    SchedulingOutcome,
+    _schedulable_tasks,
+    _sort_pending_tasks_by_resolved_band,
+)
 from iris.cluster.controller.schema import TASK_DETAIL_PROJECTION
 from iris.cluster.types import JobName, WorkerId
 from iris.rpc import controller_pb2, job_pb2
@@ -39,7 +43,7 @@ def test_production_scheduled_before_interactive():
         # Submit production tasks second
         prod_tasks = _submit_user_job(state, "bob", "prod-job", replicas=2, band=job_pb2.PRIORITY_BAND_PRODUCTION)
 
-        schedulable = _schedulable_tasks(state._db)
+        schedulable = _sort_pending_tasks_by_resolved_band(state._store, _schedulable_tasks(state._db))
         task_ids = [t.task_id for t in schedulable]
 
         # All production tasks should come before all interactive tasks
@@ -65,7 +69,7 @@ def test_batch_scheduled_after_interactive():
             state, "bob", "interactive-job", replicas=2, band=job_pb2.PRIORITY_BAND_INTERACTIVE
         )
 
-        schedulable = _schedulable_tasks(state._db)
+        schedulable = _sort_pending_tasks_by_resolved_band(state._store, _schedulable_tasks(state._db))
         task_ids = [t.task_id for t in schedulable]
 
         batch_ids = {t.task_id for t in batch_tasks}
@@ -152,8 +156,8 @@ def test_depth_boost_within_band():
         )
 
 
-def test_child_inherits_parent_band():
-    """Child job inherits parent's priority band."""
+def test_child_resolves_parent_band_from_job_config():
+    """Child job resolves its parent's priority band from job_config."""
     with make_controller_state() as state:
         # Submit parent as PRODUCTION
         parent_id = JobName.root("alice", "parent-prod")
@@ -175,13 +179,15 @@ def test_child_inherits_parent_band():
             state.submit_job(cur, child_id, child_req, Timestamp.now())
         child_tasks = query_tasks_for_job(state, child_id)
 
-        # Child should have inherited PRODUCTION band
+        # Pending rows no longer inherit by reading parent task rows; the
+        # scheduler resolves inheritance from immutable job_config.
         for ct in child_tasks:
             task = query_task(state, ct.task_id)
-            assert task.priority_band == job_pb2.PRIORITY_BAND_PRODUCTION, (
-                f"Child task {ct.task_id} has band {task.priority_band}, "
-                f"expected {job_pb2.PRIORITY_BAND_PRODUCTION} (PRODUCTION)"
-            )
+            assert task.priority_band == job_pb2.PRIORITY_BAND_INTERACTIVE
+
+        with state._db.read_snapshot() as snap:
+            requested = state._store.jobs.get_priority_bands(snap, [child_id])
+        assert requested == {child_id: job_pb2.PRIORITY_BAND_PRODUCTION}
 
 
 def test_submit_does_not_create_user_budgets_row():


### PR DESCRIPTION
## Summary

Fixes mutual same-band preemption between two users sitting at their budget cliff.

## The bug

Observed today on `marin` (controller `iris-controller-marin`): `quevedo/tinystories-1b-cached-vae-latents-v5p64-bs16-evalfix/0` and several `ahmedah/delphi-1e22-*` jobs were repeatedly preempting each other on the `marin-tpu-v5p-preemptible-64-us-east5-a` scale group, despite both being submitted with `PRIORITY_BAND_INTERACTIVE`. Same-band preemption is supposed to be impossible per the rule documented on `_run_preemption_pass`. Earlier in the week the same flap evicted a single victim **14 times in 90 seconds** between `tonyhlee/8b-ot4-math219k-2k-n8-vr5-v5/train_lm/0` and `quevedo/tinystories-2b-cached-vae-latents-v5p64-db128-final/0`.

Root cause:

- `compute_user_spend` counts `ASSIGNED|BUILDING|RUNNING` tasks toward their user's spend.
- `_get_running_tasks_with_band_and_value` re-derived an effective band on every tick by calling `compute_effective_band(row.priority_band, ..., user_spend, ...)`.
- For two users both near their `budget_limit`, having a coscheduled slice in `RUNNING` was enough to push one of them over budget, demoting their *currently-running* tasks to BATCH and making them preemption victims.
- The other user, whose pending tasks weren't yet running, looked under budget — INTERACTIVE candidate vs BATCH victim → preempt.
- Once the preemption landed, spend swapped, roles swapped, and the cycle repeated.

## The fix

Stamp the effective band onto `tasks.priority_band` at the moment the row transitions to ASSIGNED, then have the victim lookup trust that stamped value instead of recomputing from current spend.

- `Assignment` carries an optional `priority_band: int | None` (the band computed against the spend snapshot at scheduling time).
- `_commit_assignments` now receives `task_band_map` from the scheduling order and attaches each task's effective band to its `Assignment`.
- `queue_assignments` → `tasks.assign` → `mark_assigned` plumbs that value into the SQL UPDATE, so `tasks.priority_band` stores the *effective* band as of scheduling time.
- `_get_running_tasks_with_band_and_value` no longer takes spend / budget arguments and no longer calls `compute_effective_band`; it reads `tasks.priority_band` directly.

Pending tasks still go through dynamic `compute_effective_band` in `_compute_scheduling_order`, so an over-budget user's *new* submissions are still stamped BATCH at scheduling and remain preemptible by under-budget peers — only the per-tick re-derivation against running tasks goes away. K8s direct-provider promotions and manual reassignment leave `priority_band` untouched (default `None`).

## Test plan

- [x] `lib/iris/tests/cluster/controller/test_preemption.py::test_running_tasks_report_stamped_band` — new test: two tasks dispatched with different stamped bands report those bands back from the lookup.
- [x] `test_same_band_no_preemption` (existing) — covers the rule itself.
- [x] Full controller suite: `cd lib/iris && uv run --group dev python -m pytest --tb=short -m 'not slow and not docker and not e2e' tests/cluster/controller/ tests/test_budget.py` → 915 passed.
- [ ] Watch the next ferry / smoke run to confirm no regression in preemption-of-over-budget-users behavior in practice.

## Notes for reviewers

- One side-effect of trusting the stamped band: an under-budget user can no longer reclaim a slice from an over-budget user whose tasks were stamped INTERACTIVE before the user crossed their limit. The over-budget user just stops getting *new* slices. Given the alternative was a tight mutual-eviction loop costing both users their progress, this seemed like the right trade-off; happy to revisit if reviewers prefer e.g. a "spend minus victim's own contribution" demotion instead.
- No schema migration: `tasks.priority_band` already exists; only the semantics of the stored value change (request-time → assign-time effective).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Safety for existing DBs

No schema migration. `tasks.priority_band` already exists; only the *write* semantics change (from "set on insert, never updated" to "set on insert and re-stamped on assign with the effective band").

What happens at upgrade for in-flight state:

- **Currently RUNNING tasks**: their `tasks.priority_band` row already holds the band the user requested. The new `_get_running_tasks_with_band_and_value` reads that directly and treats it as the stamped band — which is exactly the desired post-fix behavior (they cannot be preempted by same-band peers). No data corruption.
- **Currently ASSIGNED-but-not-yet-RUNNING tasks**: same — column has requested band, treated as stamped.
- **Currently PENDING tasks**: column has requested band; `_compute_scheduling_order` still derives effective band dynamically for ordering, and the new `_commit_assignments` stamps the effective band into the column at assign time. No change.
- **Mid-cycle restart**: a row that was about to be assigned by the old code path lands as ASSIGNED with the requested band stamped (since the old `mark_assigned` didn't touch the column). Treated identically to a RUNNING task at upgrade.

Subtle semantic shift to call out:

- `JobStore.get_priority_band_for_job` (used at child-job submission to inherit a band when the child doesn't specify one) now returns the parent's *stamped* band rather than its requested band. In practice the inherited value is overwritten again at the child's own assign time, so the only window this affects is the brief PENDING period between child submit and child assign — and only the scheduling order during that window. Defensible (a child of an over-budget parent inheriting BATCH matches the user's current budget situation), but worth noting.

After this PR, the only callers of `compute_effective_band` are on **PENDING** rows (dynamic candidate-band derivation in `_compute_scheduling_order`) and on dashboard pending/per-user aggregations — no RUNNING-row recompute anywhere.
