### PR TITLE
Add generic Grug dense FP8 wiring

### DIFF
--- a/experiments/grug/base/model.py
+++ b/experiments/grug/base/model.py
@@ -14,6 +14,7 @@ from jax.sharding import PartitionSpec as P
 from jax.sharding import reshard
 from jaxtyping import Array, Float, Int, PRNGKeyArray
 from levanter.grug.attention import AttentionMask, RotaryConfig, apply_rotary_embedding, attention
+from levanter.grug.linear import DotGeneralOp, default_dot_general, enable_fp8_dot_general, linear_last_dim
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
 from levanter.grug.sharding import Pbatch, Pembed_vocab, Plm_head, Plogits, unshard
 
@@ -32,6 +33,7 @@ class GrugModelConfig:
     max_seq_len: int = 4096
     layer_norm_eps: float = 1e-5
     initializer_std: float = 0.02
+    fp8_dense: bool = False
     rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
 
     def __post_init__(self) -> None:
@@ -59,6 +61,10 @@ class CausalSelfAttention(eqx.Module):
     w_k: jax.Array
     w_v: jax.Array
     w_o: jax.Array
+    q_dot_general: DotGeneralOp
+    k_dot_general: DotGeneralOp
+    v_dot_general: DotGeneralOp
+    o_dot_general: DotGeneralOp
     cfg: GrugModelConfig = eqx.field(static=True)
 
     @staticmethod
@@ -70,6 +76,10 @@ class CausalSelfAttention(eqx.Module):
             w_k=reshard(_init_weight(k_k, (d_model, n_kv_heads * head_dim), cfg.initializer_std), P("data", "model")),
             w_v=reshard(_init_weight(k_v, (d_model, n_kv_heads * head_dim), cfg.initializer_std), P("data", "model")),
             w_o=reshard(_init_weight(k_o, (n_heads * head_dim, d_model), cfg.initializer_std), P("model", "data")),
+            q_dot_general=default_dot_general(),
+            k_dot_general=default_dot_general(),
+            v_dot_general=default_dot_general(),
+            o_dot_general=default_dot_general(),
             cfg=cfg,
         )
 
@@ -78,18 +88,32 @@ class CausalSelfAttention(eqx.Module):
         head_dim = self.cfg.inferred_head_dim
         seq_len = x.shape[1]
 
-        q = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_q), "... (n d) -> ... n d", d=head_dim)
-        k = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_k), "... (m d) -> ... m d", d=head_dim)
-        v = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_v), "... (m d) -> ... m d", d=head_dim)
+        q = rearrange(
+            linear_last_dim(x, self.w_q, dot_general=self.q_dot_general),
+            "... (n d) -> ... n d",
+            d=head_dim,
+        )
+        k = rearrange(
+            linear_last_dim(x, self.w_k, dot_general=self.k_dot_general),
+            "... (m d) -> ... m d",
+            d=head_dim,
+        )
+        v = rearrange(
+            linear_last_dim(x, self.w_v, dot_general=self.v_dot_general),
+            "... (m d) -> ... m d",
+            d=head_dim,
+        )
         q, k = apply_rotary_embedding(q, k, seq_len=seq_len, head_dim=head_dim, rope=self.cfg.rope)
         attn_out = attention(q, k, v, mask)
         attn_out = rearrange(attn_out, "... n d -> ... (n d)")
-        return jnp.einsum("bsh,hd->bsd", attn_out, self.w_o, out_sharding=Pbatch)
+        return linear_last_dim(attn_out, self.w_o, dot_general=self.o_dot_general, out_sharding=Pbatch)
 
 
 class MLP(eqx.Module):
     mlp_up: jax.Array
     mlp_down: jax.Array
+    up_dot_general: DotGeneralOp
+    down_dot_general: DotGeneralOp
 
     @staticmethod
     def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "MLP":
@@ -98,13 +122,15 @@ class MLP(eqx.Module):
         return MLP(
             mlp_up=reshard(_init_weight(k_up, (d_model, d_ff), cfg.initializer_std), P("data", "model")),
             mlp_down=reshard(_init_weight(k_down, (d_ff, d_model), cfg.initializer_std), P("model", "data")),
+            up_dot_general=default_dot_general(),
+            down_dot_general=default_dot_general(),
         )
 
     @named_call
     def __call__(self, x: Float[Array, "B S D"]) -> Float[Array, "B S D"]:
-        up = jnp.einsum("bsh,hm->bsm", x, self.mlp_up)
+        up = linear_last_dim(x, self.mlp_up, dot_general=self.up_dot_general)
         activated = jax.nn.relu(up)
-        return jnp.einsum("bsm,mh->bsh", activated, self.mlp_down, out_sharding=Pbatch)
+        return linear_last_dim(activated, self.mlp_down, dot_general=self.down_dot_general, out_sharding=Pbatch)
 
 
 class RMSNorm(eqx.Module):
@@ -225,6 +251,12 @@ def _init_weight(key: PRNGKeyArray, shape: tuple[int, ...], std: float) -> Float
     return std * random.truncated_normal(key, -3, 3, shape)
 
 
+def enable_dense_fp8(model: Transformer) -> Transformer:
+    """Enable FP8 dot-general state for dense projections in a Grug model."""
+
+    return enable_fp8_dot_general(model)
+
+
 def debug_mesh_and_token_pspec(num_devices: int, model_axis_size: int = 1) -> tuple[jax.sharding.AbstractMesh, P]:
     """Return a small abstract mesh and token sharding for lowering contract tests."""
     if num_devices <= 0:
@@ -253,4 +285,5 @@ __all__ = [
     "RMSNorm",
     "Transformer",
     "debug_mesh_and_token_pspec",
+    "enable_dense_fp8",
 ]

--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -9,6 +9,7 @@ import logging
 import time
 from dataclasses import dataclass, field
 
+import haliax.quantization as hq
 import jax
 import jax.numpy as jnp
 import jmp
@@ -36,7 +37,7 @@ from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.jax_utils import parameter_count
 from levanter.utils.logging import LoadingTimeTrackerIterator
 
-from experiments.grug.base.model import GrugModelConfig, Transformer
+from experiments.grug.base.model import GrugModelConfig, Transformer, enable_dense_fp8
 from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
 from experiments.grug.dispatch import dispatch_grug_training_run
 
@@ -236,10 +237,13 @@ def initial_state(
     ema_beta: float | None,
 ) -> GrugTrainState:
     params = mp.cast_to_param(Transformer.init(model_config, key=key))
+    if model_config.fp8_dense:
+        params = enable_dense_fp8(params)
+    _, optimizer_params = hq.partition_for_grad_overwrite(params)
     return GrugTrainState(
         step=jnp.array(0, dtype=jnp.int32),
         params=params,
-        opt_state=optimizer.init(params),
+        opt_state=optimizer.init(optimizer_params),
         ema_params=params if ema_beta is not None else None,
     )
 
@@ -275,8 +279,10 @@ def _make_train_step(
             )
 
         loss, grads = jax.value_and_grad(loss_fn)(state.params)
-        updates, opt_state = optimizer.update(grads, state.opt_state, state.params)
-        params = optax.apply_updates(state.params, updates)
+        overwrites, train_grads = hq.partition_for_grad_overwrite(grads)
+        _, optimizer_params = hq.partition_for_grad_overwrite(state.params)
+        updates, opt_state = optimizer.update(train_grads, state.opt_state, optimizer_params)
+        params = hq.apply_updates(state.params, updates, overwrites)
 
         if ema_beta is None:
             ema_params = None
@@ -297,8 +303,8 @@ def _make_train_step(
                 include_per_parameter_norms=watch_config.include_per_parameter_norms,
                 include_histogram=watch_config.include_histograms,
                 split_scan_layers=watch_config.split_scan_layers,
-                params=state.params,
-                grads=grads,
+                params=optimizer_params,
+                grads=train_grads,
                 updates=updates,
                 opt_state=state.opt_state,
                 model_tree_type=type(state.params),

--- a/experiments/grug/modular_opt/model.py
+++ b/experiments/grug/modular_opt/model.py
@@ -14,6 +14,7 @@ from jax.sharding import PartitionSpec as P
 from jax.sharding import reshard
 from jaxtyping import Array, Float, Int, PRNGKeyArray
 from levanter.grug.attention import AttentionMask, RotaryConfig, apply_rotary_embedding, attention
+from levanter.grug.linear import DotGeneralOp, default_dot_general, enable_fp8_dot_general, linear_last_dim
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
 from levanter.grug.sharding import Pbatch, Pembed_vocab, Plm_head, Plogits, unshard
 
@@ -32,6 +33,7 @@ class GrugModelConfig:
     max_seq_len: int = 4096
     layer_norm_eps: float = 1e-5
     initializer_std: float = 0.02
+    fp8_dense: bool = False
     rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
 
     def __post_init__(self) -> None:
@@ -59,6 +61,10 @@ class CausalSelfAttention(eqx.Module):
     w_k: jax.Array
     w_v: jax.Array
     w_o: jax.Array
+    q_dot_general: DotGeneralOp
+    k_dot_general: DotGeneralOp
+    v_dot_general: DotGeneralOp
+    o_dot_general: DotGeneralOp
     cfg: GrugModelConfig = eqx.field(static=True)
 
     @staticmethod
@@ -70,6 +76,10 @@ class CausalSelfAttention(eqx.Module):
             w_k=reshard(_init_weight(k_k, (d_model, n_kv_heads * head_dim), cfg.initializer_std), P("data", "model")),
             w_v=reshard(_init_weight(k_v, (d_model, n_kv_heads * head_dim), cfg.initializer_std), P("data", "model")),
             w_o=reshard(_init_weight(k_o, (n_heads * head_dim, d_model), cfg.initializer_std), P("model", "data")),
+            q_dot_general=default_dot_general(),
+            k_dot_general=default_dot_general(),
+            v_dot_general=default_dot_general(),
+            o_dot_general=default_dot_general(),
             cfg=cfg,
         )
 
@@ -78,18 +88,32 @@ class CausalSelfAttention(eqx.Module):
         head_dim = self.cfg.inferred_head_dim
         seq_len = x.shape[1]
 
-        q = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_q), "... (n d) -> ... n d", d=head_dim)
-        k = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_k), "... (m d) -> ... m d", d=head_dim)
-        v = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_v), "... (m d) -> ... m d", d=head_dim)
+        q = rearrange(
+            linear_last_dim(x, self.w_q, dot_general=self.q_dot_general),
+            "... (n d) -> ... n d",
+            d=head_dim,
+        )
+        k = rearrange(
+            linear_last_dim(x, self.w_k, dot_general=self.k_dot_general),
+            "... (m d) -> ... m d",
+            d=head_dim,
+        )
+        v = rearrange(
+            linear_last_dim(x, self.w_v, dot_general=self.v_dot_general),
+            "... (m d) -> ... m d",
+            d=head_dim,
+        )
         q, k = apply_rotary_embedding(q, k, seq_len=seq_len, head_dim=head_dim, rope=self.cfg.rope)
         attn_out = attention(q, k, v, mask)
         attn_out = rearrange(attn_out, "... n d -> ... (n d)")
-        return jnp.einsum("bsh,hd->bsd", attn_out, self.w_o, out_sharding=Pbatch)
+        return linear_last_dim(attn_out, self.w_o, dot_general=self.o_dot_general, out_sharding=Pbatch)
 
 
 class MLP(eqx.Module):
     mlp_up: jax.Array
     mlp_down: jax.Array
+    up_dot_general: DotGeneralOp
+    down_dot_general: DotGeneralOp
 
     @staticmethod
     def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "MLP":
@@ -98,13 +122,15 @@ class MLP(eqx.Module):
         return MLP(
             mlp_up=reshard(_init_weight(k_up, (d_model, d_ff), cfg.initializer_std), P("data", "model")),
             mlp_down=reshard(_init_weight(k_down, (d_ff, d_model), cfg.initializer_std), P("model", "data")),
+            up_dot_general=default_dot_general(),
+            down_dot_general=default_dot_general(),
         )
 
     @named_call
     def __call__(self, x: Float[Array, "B S D"]) -> Float[Array, "B S D"]:
-        up = jnp.einsum("bsh,hm->bsm", x, self.mlp_up)
+        up = linear_last_dim(x, self.mlp_up, dot_general=self.up_dot_general)
         activated = jax.nn.relu(up)
-        return jnp.einsum("bsm,mh->bsh", activated, self.mlp_down, out_sharding=Pbatch)
+        return linear_last_dim(activated, self.mlp_down, dot_general=self.down_dot_general, out_sharding=Pbatch)
 
 
 class RMSNorm(eqx.Module):
@@ -225,6 +251,12 @@ def _init_weight(key: PRNGKeyArray, shape: tuple[int, ...], std: float) -> Float
     return std * random.truncated_normal(key, -3, 3, shape)
 
 
+def enable_dense_fp8(model: Transformer) -> Transformer:
+    """Enable FP8 dot-general state for dense projections in a Grug model."""
+
+    return enable_fp8_dot_general(model)
+
+
 def debug_mesh_and_token_pspec(num_devices: int, model_axis_size: int = 1) -> tuple[jax.sharding.AbstractMesh, P]:
     """Return a small abstract mesh and token sharding for lowering contract tests."""
     if num_devices <= 0:
@@ -253,4 +285,5 @@ __all__ = [
     "RMSNorm",
     "Transformer",
     "debug_mesh_and_token_pspec",
+    "enable_dense_fp8",
 ]

--- a/experiments/grug/modular_opt/train.py
+++ b/experiments/grug/modular_opt/train.py
@@ -9,6 +9,7 @@ import logging
 import time
 from dataclasses import dataclass, field
 
+import haliax.quantization as hq
 import jax
 import jax.numpy as jnp
 import jmp
@@ -38,7 +39,7 @@ from levanter.utils.logging import LoadingTimeTrackerIterator
 
 from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
 from experiments.grug.dispatch import dispatch_grug_training_run
-from experiments.grug.modular_opt.model import GrugModelConfig, Transformer
+from experiments.grug.modular_opt.model import GrugModelConfig, Transformer, enable_dense_fp8
 
 logger = logging.getLogger(__name__)
 
@@ -235,10 +236,13 @@ def initial_state(
     ema_beta: float | None,
 ) -> GrugTrainState:
     params = mp.cast_to_param(Transformer.init(model_config, key=key))
+    if model_config.fp8_dense:
+        params = enable_dense_fp8(params)
+    _, optimizer_params = hq.partition_for_grad_overwrite(params)
     return GrugTrainState(
         step=jnp.array(0, dtype=jnp.int32),
         params=params,
-        opt_state=optimizer.init(params),
+        opt_state=optimizer.init(optimizer_params),
         ema_params=params if ema_beta is not None else None,
     )
 
@@ -274,8 +278,10 @@ def _make_train_step(
             )
 
         loss, grads = jax.value_and_grad(loss_fn)(state.params)
-        updates, opt_state = optimizer.update(grads, state.opt_state, state.params)
-        params = optax.apply_updates(state.params, updates)
+        overwrites, train_grads = hq.partition_for_grad_overwrite(grads)
+        _, optimizer_params = hq.partition_for_grad_overwrite(state.params)
+        updates, opt_state = optimizer.update(train_grads, state.opt_state, optimizer_params)
+        params = hq.apply_updates(state.params, updates, overwrites)
 
         if ema_beta is None:
             ema_params = None
@@ -296,8 +302,8 @@ def _make_train_step(
                 include_per_parameter_norms=watch_config.include_per_parameter_norms,
                 include_histogram=watch_config.include_histograms,
                 split_scan_layers=watch_config.split_scan_layers,
-                params=state.params,
-                grads=grads,
+                params=optimizer_params,
+                grads=train_grads,
                 updates=updates,
                 opt_state=state.opt_state,
                 model_tree_type=type(state.params),

--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -27,6 +27,7 @@ except ModuleNotFoundError:
 from jaxtyping import Array, Float, Int, PRNGKeyArray
 from levanter.grug.attention import AttentionMask, RotaryConfig, align_kv_heads, apply_rotary_embedding, attention
 from levanter.grug.grug_moe import MoeActivation, MoeImplementation, moe_mlp
+from levanter.grug.linear import DotGeneralOp, default_dot_general, enable_fp8_dot_general, linear_last_dim
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
 from levanter.grug.sharding import Pembed_vocab, Plm_head, unshard
 from levanter.tracker.histogram import Histogram
@@ -71,6 +72,7 @@ class GrugModelConfig:
     qk_mult: float = 1.0
     router_z_loss_coef: float = 0.001
     moe_implementation: MoeImplementation | None = None
+    fp8_dense: bool = False
     rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
 
     def __post_init__(self) -> None:
@@ -113,6 +115,10 @@ class CausalSelfAttention(eqx.Module):
     w_v: Float[Array, "D MH"]
     w_o: Float[Array, "NH D"]
     attn_gate: Float[Array, "D N"]
+    q_dot_general: DotGeneralOp
+    k_dot_general: DotGeneralOp
+    v_dot_general: DotGeneralOp
+    o_dot_general: DotGeneralOp
     cfg: GrugModelConfig = eqx.field(static=True)
 
     @staticmethod
@@ -125,6 +131,10 @@ class CausalSelfAttention(eqx.Module):
             w_v=reshard(_init_weight(k_v, (d, m * h), cfg.initializer_std), P("data", "model")),
             w_o=reshard(_init_weight(k_o, (n * h, d), cfg.initializer_std), P("model", "data")),
             attn_gate=reshard(jnp.zeros((d, n)), P(None, None)),
+            q_dot_general=default_dot_general(),
+            k_dot_general=default_dot_general(),
+            v_dot_general=default_dot_general(),
+            o_dot_general=default_dot_general(),
             cfg=cfg,
         )
 
@@ -134,9 +144,21 @@ class CausalSelfAttention(eqx.Module):
         seq_len = x.shape[1]
         batch_spec = _batch_spec()
 
-        q = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_q), "... (n d) -> ... n d", d=head_dim)
-        k = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_k), "... (m d) -> ... m d", d=head_dim)
-        v = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_v), "... (m d) -> ... m d", d=head_dim)
+        q = rearrange(
+            linear_last_dim(x, self.w_q, dot_general=self.q_dot_general),
+            "... (n d) -> ... n d",
+            d=head_dim,
+        )
+        k = rearrange(
+            linear_last_dim(x, self.w_k, dot_general=self.k_dot_general),
+            "... (m d) -> ... m d",
+            d=head_dim,
+        )
+        v = rearrange(
+            linear_last_dim(x, self.w_v, dot_general=self.v_dot_general),
+            "... (m d) -> ... m d",
+            d=head_dim,
+        )
         q = rms_norm(q)
         k = rms_norm(k)
         q, k = apply_rotary_embedding(q, k, seq_len=seq_len, head_dim=head_dim, rope=self.cfg.rope)
@@ -153,7 +175,7 @@ class CausalSelfAttention(eqx.Module):
         gate = 2 * jax.nn.sigmoid(jnp.einsum("bsd,dn->bsn", x, self.attn_gate))[..., None]
         attn_out = gate * attn_out
         attn_out = rearrange(attn_out, "... n d -> ... (n d)")
-        return jnp.einsum("bsh,hd->bsd", attn_out, self.w_o, out_sharding=batch_spec)
+        return linear_last_dim(attn_out, self.w_o, dot_general=self.o_dot_general, out_sharding=batch_spec)
 
 
 class RMSNorm(eqx.Module):
@@ -203,6 +225,9 @@ class DenseMLP(eqx.Module):
     w_gate: jax.Array
     w_up: jax.Array
     w_down: jax.Array
+    gate_dot_general: DotGeneralOp
+    up_dot_general: DotGeneralOp
+    down_dot_general: DotGeneralOp
 
     @staticmethod
     def init(hidden_dim: int, intermediate_dim: int, initializer_std: float, *, key: PRNGKeyArray) -> "DenseMLP":
@@ -211,6 +236,9 @@ class DenseMLP(eqx.Module):
             w_gate=reshard(_init_weight(k_gate, (hidden_dim, intermediate_dim), initializer_std), P("data", "model")),
             w_up=reshard(_init_weight(k_up, (hidden_dim, intermediate_dim), initializer_std), P("data", "model")),
             w_down=reshard(_init_weight(k_down, (intermediate_dim, hidden_dim), initializer_std), P("model", "data")),
+            gate_dot_general=default_dot_general(),
+            up_dot_general=default_dot_general(),
+            down_dot_general=default_dot_general(),
         )
 
     @named_call
@@ -227,9 +255,14 @@ class DenseMLP(eqx.Module):
 
         b, s, _ = x.shape
         x_flat = rearrange(x, "b s d -> (b s) d")
-        gate = jnp.einsum("td,dm->tm", x_flat, self.w_gate)
-        up = jnp.einsum("td,dm->tm", x_flat, self.w_up)
-        out_flat = jnp.einsum("tm,md->td", activation_fn(gate) * up, self.w_down, out_sharding=_batch_spec())
+        gate = linear_last_dim(x_flat, self.w_gate, dot_general=self.gate_dot_general)
+        up = linear_last_dim(x_flat, self.w_up, dot_general=self.up_dot_general)
+        out_flat = linear_last_dim(
+            activation_fn(gate) * up,
+            self.w_down,
+            dot_general=self.down_dot_general,
+            out_sharding=_batch_spec(),
+        )
         return rearrange(out_flat, "(b s) d -> b s d", b=b, s=s)
 
 
@@ -563,6 +596,12 @@ def _init_weight(key: PRNGKeyArray, shape: tuple[int, ...], std: float) -> Float
     return std * random.truncated_normal(key, -3, 3, shape)
 
 
+def enable_dense_fp8(model: Transformer) -> Transformer:
+    """Enable FP8 dot-general state for dense projections in a Grug MoE model."""
+
+    return enable_fp8_dot_general(model)
+
+
 def debug_mesh_and_token_pspec(num_devices: int) -> tuple[jax.sharding.AbstractMesh, P]:
     """Return a small abstract mesh and token sharding for lowering contract tests."""
     if num_devices <= 0:
@@ -592,5 +631,6 @@ __all__ = [
     "RMSNorm",
     "Transformer",
     "debug_mesh_and_token_pspec",
+    "enable_dense_fp8",
     "moe_mlp",
 ]

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -10,6 +10,7 @@ import time
 from dataclasses import dataclass, field
 
 import equinox as eqx
+import haliax.quantization as hq
 import jax
 import jax.numpy as jnp
 import jmp
@@ -39,7 +40,7 @@ from levanter.utils.logging import LoadingTimeTrackerIterator
 
 from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
 from experiments.grug.dispatch import dispatch_grug_training_run
-from experiments.grug.moe.model import GrugModelConfig, Transformer
+from experiments.grug.moe.model import GrugModelConfig, Transformer, enable_dense_fp8
 
 # This file intentionally mirrors `experiments/grug/base/train.py` with
 # variant-specific model/loss/FLOP wiring, per the grug copy-first workflow in
@@ -260,11 +261,14 @@ def initial_state(
     ema_beta: float | None,
 ) -> GrugTrainState:
     params = mp.cast_to_param(Transformer.init(model_config, key=key))
+    if model_config.fp8_dense:
+        params = enable_dense_fp8(params)
     num_moe_layers = sum(1 for b in params.blocks if b.mlp is not None)
+    _, optimizer_params = hq.partition_for_grad_overwrite(params)
     return GrugTrainState(
         step=jnp.array(0, dtype=jnp.int32),
         params=params,
-        opt_state=optimizer.init(params),
+        opt_state=optimizer.init(optimizer_params),
         ema_params=params if ema_beta is not None else None,
         pending_qb_betas=jnp.zeros((num_moe_layers, model_config.num_experts)),
     )
@@ -311,8 +315,10 @@ def _make_train_step(
 
         (loss, summarized_metrics), grads = jax.value_and_grad(loss_fn, has_aux=True)(qb_params)
         metrics = {"train/loss": loss, **summarized_metrics}
-        updates, opt_state = optimizer.update(grads, state.opt_state, qb_params)
-        params = optax.apply_updates(qb_params, updates)
+        overwrites, train_grads = hq.partition_for_grad_overwrite(grads)
+        _, optimizer_params = hq.partition_for_grad_overwrite(qb_params)
+        updates, opt_state = optimizer.update(train_grads, state.opt_state, optimizer_params)
+        params = hq.apply_updates(qb_params, updates, overwrites)
 
         if ema_beta is None:
             ema_params = None
@@ -333,8 +339,8 @@ def _make_train_step(
                 include_per_parameter_norms=watch_config.include_per_parameter_norms,
                 include_histogram=watch_config.include_histograms,
                 split_scan_layers=watch_config.split_scan_layers,
-                params=qb_params,
-                grads=grads,
+                params=optimizer_params,
+                grads=train_grads,
                 updates=updates,
                 opt_state=state.opt_state,
                 model_tree_type=type(state.params),

--- a/lib/haliax/src/haliax/_src/fp8.py
+++ b/lib/haliax/src/haliax/_src/fp8.py
@@ -130,7 +130,14 @@ def dot_general_with_precision(
         #     "values."
         # )
         pass
-    return lax.dot_general(lhs, rhs, dimension_numbers, precision=lax.Precision.DEFAULT, **kwargs)
+    return lax.dot_general(
+        lhs,
+        rhs,
+        dimension_numbers,
+        precision=lax.Precision.DEFAULT,
+        out_sharding=out_sharding,
+        **kwargs,
+    )
 
 
 @dot_general_with_precision.defjvp
@@ -138,13 +145,12 @@ def dot_general_with_precision_jvp(
     dimension_numbers, precision, preferred_element_type, out_sharding, primals, tangents
 ):
     del preferred_element_type
-    del out_sharding
     del precision
     lhs, rhs = primals
     lhs_dot, rhs_dot = tangents
 
-    out = lax.dot_general(lhs, rhs, dimension_numbers, precision=lax.Precision.DEFAULT)
-    grad_out = lax.dot_general(lhs_dot, rhs, dimension_numbers, precision=lax.Precision.HIGHEST) + lax.dot_general(
-        lhs, rhs_dot, dimension_numbers, precision=lax.Precision.HIGHEST
-    )
+    out = lax.dot_general(lhs, rhs, dimension_numbers, precision=lax.Precision.DEFAULT, out_sharding=out_sharding)
+    grad_out = lax.dot_general(
+        lhs_dot, rhs, dimension_numbers, precision=lax.Precision.HIGHEST, out_sharding=out_sharding
+    ) + lax.dot_general(lhs, rhs_dot, dimension_numbers, precision=lax.Precision.HIGHEST, out_sharding=out_sharding)
     return out, grad_out

--- a/lib/levanter/src/levanter/grug/linear.py
+++ b/lib/levanter/src/levanter/grug/linear.py
@@ -1,0 +1,80 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Array-first linear helpers for Grug templates."""
+
+from typing import TypeVar
+
+import jax
+import jax.numpy as jnp
+from jax.sharding import PartitionSpec as P
+from jax.sharding import reshard
+from jaxtyping import DTypeLike
+
+from haliax.quantization import DefaultDotGeneralOp, DotGeneralOp, Fp8DotGeneralOp
+
+T = TypeVar("T")
+
+DEFAULT_FP8_AMAX_HISTORY_LENGTH = 1024
+
+__all__ = [
+    "DEFAULT_FP8_AMAX_HISTORY_LENGTH",
+    "DotGeneralOp",
+    "default_dot_general",
+    "enable_fp8_dot_general",
+    "linear_last_dim",
+]
+
+
+def default_dot_general() -> DotGeneralOp:
+    """Return the default Grug dense-projection dot-general op."""
+
+    return DefaultDotGeneralOp.init()
+
+
+def linear_last_dim(
+    lhs: jax.Array,
+    rhs: jax.Array,
+    *,
+    dot_general: DotGeneralOp,
+    out_sharding: P | None = None,
+) -> jax.Array:
+    """Contract the last lhs dim with the first rhs dim.
+
+    Grug modules keep dense weights as raw arrays, so this is the array-first
+    counterpart to `haliax.nn.Linear`'s configurable `dot_general` field.
+    """
+
+    kwargs = {}
+    if out_sharding is not None:
+        kwargs["out_sharding"] = out_sharding
+    out = dot_general(
+        lhs,
+        rhs,
+        (((lhs.ndim - 1,), (0,)), ((), ())),
+        preferred_element_type=lhs.dtype,
+        **kwargs,
+    )
+    if out_sharding is not None:
+        out = reshard(out, out_sharding)
+    return out
+
+
+def enable_fp8_dot_general(
+    tree: T,
+    *,
+    amax_history_length: int = DEFAULT_FP8_AMAX_HISTORY_LENGTH,
+    compute_dtype: DTypeLike = jnp.bfloat16,
+) -> T:
+    """Replace default Grug dense-projection dot-general ops with FP8 state."""
+
+    def replace_dot_general(leaf):
+        if isinstance(leaf, DefaultDotGeneralOp):
+            return Fp8DotGeneralOp.init(amax_history_length=amax_history_length, compute_dtype=compute_dtype)
+        return leaf
+
+    return jax.tree_util.tree_map(
+        replace_dot_general,
+        tree,
+        is_leaf=lambda leaf: isinstance(leaf, DefaultDotGeneralOp),
+    )

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -23,6 +23,7 @@ import jmp
 import optax
 import pytest
 from fray.cluster import ResourceConfig
+from haliax.quantization import Fp8DotGeneralOp
 from jax._src import config as jax_config
 from jax.sharding import use_abstract_mesh
 from levanter.checkpoint import CheckpointerConfig
@@ -102,6 +103,11 @@ def _small_model_config(model_config_cls, *, vocab_size: int, seq_len: int):
     return model_config_cls(**kwargs)
 
 
+def _fp8_dot_general_leaves(tree) -> list[Fp8DotGeneralOp]:
+    leaves = jax.tree_util.tree_leaves(tree, is_leaf=lambda leaf: isinstance(leaf, Fp8DotGeneralOp))
+    return [leaf for leaf in leaves if isinstance(leaf, Fp8DotGeneralOp)]
+
+
 @pytest.mark.parametrize(
     "variant",
     _discover_grug_variants_with_model_and_train(),
@@ -139,6 +145,58 @@ def test_grug_variant_one_step_contract_lowers_with_default_ctor(variant: str):
     with _reset_abstract_mesh(), use_abstract_mesh(mesh):
         out_state_shape, out_metrics_shape, out_watch_shape = eqx.filter_eval_shape(one_step)
 
+    assert out_state_shape.step.shape == ()
+    assert "train/loss" in out_metrics_shape
+    assert out_metrics_shape["train/loss"].shape == ()
+    assert out_watch_shape is None
+
+
+@pytest.mark.parametrize(
+    "variant",
+    _discover_grug_variants_with_model_and_train(),
+)
+@pytest.mark.parametrize(
+    "optimizer",
+    [optax.adam(1e-2), optax.lion(1e-2)],
+    ids=["adam", "lion"],
+)
+def test_grug_variant_dense_fp8_one_step_contract_lowers_with_optimizer(variant: str, optimizer):
+    train_module = importlib.import_module(_variant_module_name(variant, "train"))
+    model_module = importlib.import_module(_variant_module_name(variant, "model"))
+    model_config_cls = model_module.GrugModelConfig
+    make_train_step = train_module._make_train_step
+    initial_state = train_module.initial_state
+    mesh_fn = getattr(model_module, "debug_mesh_and_token_pspec", None)
+    if mesh_fn is None:
+        raise AssertionError(f"{_variant_module_name(variant, 'model')} must define debug_mesh_and_token_pspec")
+
+    cfg = _small_model_config(model_config_cls, vocab_size=1024, seq_len=4)
+    cfg = dataclasses.replace(cfg, fp8_dense=True)
+    mp = jmp.get_policy("p=bfloat16,c=bfloat16")
+    train_step = make_train_step(optimizer, mp, z_loss_weight=0.0, ema_beta=None)
+    mesh, token_pspec = mesh_fn(num_devices=4)
+    batch = GrugLmExample(
+        tokens=jnp.zeros((8, 4), dtype=jnp.int32),
+        loss_weight=jnp.ones((8, 4), dtype=jnp.float32),
+        attn_mask=GrugAttentionMask.causal(),
+    )
+
+    def init_state():
+        return initial_state(cfg, optimizer=optimizer, mp=mp, key=jax.random.PRNGKey(0), ema_beta=None)
+
+    def one_step():
+        sharded_batch = dataclasses.replace(
+            batch,
+            tokens=jax.sharding.reshard(batch.tokens, token_pspec),
+            loss_weight=jax.sharding.reshard(batch.loss_weight, token_pspec),
+        )
+        return train_step(init_state(), sharded_batch, compute_watch=False)
+
+    with _reset_abstract_mesh(), use_abstract_mesh(mesh):
+        state_shape = eqx.filter_eval_shape(init_state)
+        out_state_shape, out_metrics_shape, out_watch_shape = eqx.filter_eval_shape(one_step)
+
+    assert _fp8_dot_general_leaves(state_shape.params)
     assert out_state_shape.step.shape == ()
     assert "train/loss" in out_metrics_shape
     assert out_metrics_shape["train/loss"].shape == ()


### PR DESCRIPTION
Adds a shared Grug linear helper with configurable dot_general state, then wires base, modular_opt, and MoE dense projections through it. The fp8_dense config swaps default dot-generals for FP8 overwrite state while keeping raw array weights stable, and the train loops now partition/apply overwrite gradients correctly. Validation: ./infra/pre-commit.py --all-files --fix; pytest tests/test_grug_variant_contracts.py; pytest lib/haliax/tests/test_fp8.py. Part of #4311.