### PR TITLE
[iris] cluster start --fresh: use Recreate strategy to avoid rollout race

### DIFF
--- a/lib/iris/src/iris/cluster/providers/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/controller.py
@@ -157,9 +157,11 @@ def _build_controller_deployment(
     # job submitted in the surge window lands on the OLD controller and is
     # then deleted as a "stray" by the new controller's first reconcile (#5590).
     # Recreate forces the old pod down before the new one starts: brief
-    # downtime, no overlap. Non-fresh restarts keep RollingUpdate so in-place
-    # upgrades stay zero-downtime.
-    strategy: dict = {"type": "Recreate"} if fresh else {"type": "RollingUpdate"}
+    # downtime, no overlap. `rollingUpdate: null` is required because SSA
+    # preserves the API-server-defaulted rollingUpdate field, and validation
+    # rejects rollingUpdate alongside `type: Recreate`. Non-fresh restarts
+    # keep RollingUpdate so in-place upgrades stay zero-downtime.
+    strategy: dict = {"type": "Recreate", "rollingUpdate": None} if fresh else {"type": "RollingUpdate"}
     return {
         "apiVersion": "apps/v1",
         "kind": "Deployment",

--- a/lib/iris/src/iris/cluster/providers/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/controller.py
@@ -38,6 +38,10 @@ _DEFAULT_POLL_INTERVAL = 10.0
 # Includes time for the autoscaler to provision a node.
 _DEPLOYMENT_READY_TIMEOUT = 2400.0
 
+# Maximum time to wait for the controller Deployment to fully delete on `--fresh`
+# restarts. Should exceed the controller pod's terminationGracePeriodSeconds.
+_DEPLOYMENT_DELETE_TIMEOUT = 120.0
+
 # Default kubectl timeout for CoreWeave operations (seconds).
 # CoreWeave bare-metal provisioning/deprovisioning is slow; 60s is not enough.
 _KUBECTL_TIMEOUT = 1800.0
@@ -151,17 +155,72 @@ def _build_controller_deployment(
         "requests": {"cpu": _CONTROLLER_CPU_REQUEST, "memory": _CONTROLLER_MEMORY_REQUEST},
         "limits": {"cpu": _CONTROLLER_CPU_REQUEST, "memory": _CONTROLLER_MEMORY_REQUEST},
     }
-    # `--fresh` wipes the controller's SQLite, so the new pod boots with no
-    # knowledge of jobs the OLD pod has accepted. Default RollingUpdate keeps
-    # the old pod up (and Service-routable) until the new pod is Ready, so a
-    # job submitted in the surge window lands on the OLD controller and is
-    # then deleted as a "stray" by the new controller's first reconcile (#5590).
-    # Recreate forces the old pod down before the new one starts: brief
-    # downtime, no overlap. `rollingUpdate: null` is required because SSA
-    # preserves the API-server-defaulted rollingUpdate field, and validation
-    # rejects rollingUpdate alongside `type: Recreate`. Non-fresh restarts
-    # keep RollingUpdate so in-place upgrades stay zero-downtime.
-    strategy: dict = {"type": "Recreate", "rollingUpdate": None} if fresh else {"type": "RollingUpdate"}
+    # `--fresh` wipes the controller's SQLite, so the new pod must NOT overlap
+    # with the OLD one — otherwise a job submitted in the rollout surge window
+    # lands on the OLD controller, then the NEW empty-DB controller deletes
+    # the runner pod as "stray" on its first reconcile (#5590). Setting
+    # `strategy.type: Recreate` here, combined with deleting the existing
+    # Deployment in start_controller (because SSA can't clear the
+    # API-server-defaulted rollingUpdate field), guarantees the old pod is
+    # gone before the new one starts. Non-fresh restarts omit `strategy` so
+    # the API server defaults to RollingUpdate and in-place upgrades stay
+    # zero-downtime.
+    deploy_spec: dict = {
+        "replicas": 1,
+        "selector": {"matchLabels": {"app": "iris-controller"}},
+        "template": {
+            "metadata": {"labels": {"app": "iris-controller"}},
+            "spec": {
+                "serviceAccountName": "iris-controller",
+                "nodeSelector": node_selector,
+                # Tolerate the standard NVIDIA GPU taint so the controller
+                # can schedule onto GPU-only clusters (no CPU NodePool).
+                # Harmless on untainted nodes.
+                "tolerations": [NVIDIA_GPU_TOLERATION],
+                "containers": [
+                    {
+                        "name": "iris-controller",
+                        "image": image,
+                        "imagePullPolicy": "Always",
+                        "command": [
+                            ".venv/bin/python",
+                            "-m",
+                            "iris.cluster.controller.main",
+                            "serve",
+                            "--host=0.0.0.0",
+                            f"--port={port}",
+                            "--config=/etc/iris/config.json",
+                            *(["--fresh"] if fresh else []),
+                        ],
+                        "ports": [{"containerPort": port}],
+                        "env": s3_env_vars,
+                        "securityContext": {"capabilities": {"add": ["SYS_PTRACE"]}},
+                        "resources": controller_resources,
+                        "volumeMounts": [
+                            {"name": "config", "mountPath": "/etc/iris", "readOnly": True},
+                            {"name": "local-state", "mountPath": "/var/cache/iris/controller"},
+                        ],
+                        "readinessProbe": {
+                            "httpGet": {"path": "/health", "port": port},
+                            "initialDelaySeconds": 10,
+                            "periodSeconds": 10,
+                        },
+                        "livenessProbe": {
+                            "httpGet": {"path": "/health", "port": port},
+                            "initialDelaySeconds": 30,
+                            "periodSeconds": 30,
+                        },
+                    },
+                ],
+                "volumes": [
+                    {"name": "config", "configMap": {"name": "iris-cluster-config"}},
+                    {"name": "local-state", "emptyDir": {}},
+                ],
+            },
+        },
+    }
+    if fresh:
+        deploy_spec["strategy"] = {"type": "Recreate"}
     return {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -170,61 +229,7 @@ def _build_controller_deployment(
             "namespace": namespace,
             "labels": {"app": "iris-controller"},
         },
-        "spec": {
-            "replicas": 1,
-            "strategy": strategy,
-            "selector": {"matchLabels": {"app": "iris-controller"}},
-            "template": {
-                "metadata": {"labels": {"app": "iris-controller"}},
-                "spec": {
-                    "serviceAccountName": "iris-controller",
-                    "nodeSelector": node_selector,
-                    # Tolerate the standard NVIDIA GPU taint so the controller
-                    # can schedule onto GPU-only clusters (no CPU NodePool).
-                    # Harmless on untainted nodes.
-                    "tolerations": [NVIDIA_GPU_TOLERATION],
-                    "containers": [
-                        {
-                            "name": "iris-controller",
-                            "image": image,
-                            "imagePullPolicy": "Always",
-                            "command": [
-                                ".venv/bin/python",
-                                "-m",
-                                "iris.cluster.controller.main",
-                                "serve",
-                                "--host=0.0.0.0",
-                                f"--port={port}",
-                                "--config=/etc/iris/config.json",
-                                *(["--fresh"] if fresh else []),
-                            ],
-                            "ports": [{"containerPort": port}],
-                            "env": s3_env_vars,
-                            "securityContext": {"capabilities": {"add": ["SYS_PTRACE"]}},
-                            "resources": controller_resources,
-                            "volumeMounts": [
-                                {"name": "config", "mountPath": "/etc/iris", "readOnly": True},
-                                {"name": "local-state", "mountPath": "/var/cache/iris/controller"},
-                            ],
-                            "readinessProbe": {
-                                "httpGet": {"path": "/health", "port": port},
-                                "initialDelaySeconds": 10,
-                                "periodSeconds": 10,
-                            },
-                            "livenessProbe": {
-                                "httpGet": {"path": "/health", "port": port},
-                                "initialDelaySeconds": 30,
-                                "periodSeconds": 30,
-                            },
-                        },
-                    ],
-                    "volumes": [
-                        {"name": "config", "configMap": {"name": "iris-cluster-config"}},
-                        {"name": "local-state", "emptyDir": {}},
-                    ],
-                },
-            },
-        },
+        "spec": deploy_spec,
     }
 
 
@@ -336,6 +341,15 @@ class K8sControllerProvider:
             s3_env_vars=s3_env,
             fresh=fresh,
         )
+        if fresh:
+            # SSA preserves the API-server-defaulted spec.strategy.rollingUpdate
+            # field, so an apply that switches type to Recreate fails validation
+            # ("rollingUpdate may not be specified when type is Recreate").
+            # Delete the existing Deployment first and wait for it to be gone
+            # so the apply creates a fresh object with no leftover strategy
+            # fields. This also enforces no-overlap with the OLD controller
+            # pod, avoiding the stray-pod race in #5590.
+            self._delete_controller_deployment_and_wait()
         self._kubectl.apply_json(deploy_manifest)
         self._kubectl.rollout_restart(K8sResource.DEPLOYMENTS, "iris-controller")
         logger.info("Controller Deployment iris-controller applied (rollout restarted)")
@@ -372,6 +386,20 @@ class K8sControllerProvider:
 
     def restart_controller(self, config: config_pb2.IrisClusterConfig) -> str:
         return self.start_controller(config)
+
+    def _delete_controller_deployment_and_wait(self) -> None:
+        """Delete the controller Deployment and wait until it's fully gone."""
+        self._kubectl.delete(K8sResource.DEPLOYMENTS, "iris-controller")
+        deadline = Deadline.from_seconds(_DEPLOYMENT_DELETE_TIMEOUT)
+        while not self._shutdown_event.is_set():
+            if self._kubectl.get_json(K8sResource.DEPLOYMENTS, "iris-controller") is None:
+                logger.info("Controller Deployment iris-controller deleted")
+                return
+            if deadline.expired():
+                raise InfraError(
+                    f"Controller Deployment iris-controller did not delete within {_DEPLOYMENT_DELETE_TIMEOUT}s"
+                )
+            self._shutdown_event.wait(self._poll_interval)
 
     def stop_controller(self, config: config_pb2.IrisClusterConfig) -> None:
         cw = config.controller.coreweave

--- a/lib/iris/src/iris/cluster/providers/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/controller.py
@@ -151,6 +151,15 @@ def _build_controller_deployment(
         "requests": {"cpu": _CONTROLLER_CPU_REQUEST, "memory": _CONTROLLER_MEMORY_REQUEST},
         "limits": {"cpu": _CONTROLLER_CPU_REQUEST, "memory": _CONTROLLER_MEMORY_REQUEST},
     }
+    # `--fresh` wipes the controller's SQLite, so the new pod boots with no
+    # knowledge of jobs the OLD pod has accepted. Default RollingUpdate keeps
+    # the old pod up (and Service-routable) until the new pod is Ready, so a
+    # job submitted in the surge window lands on the OLD controller and is
+    # then deleted as a "stray" by the new controller's first reconcile (#5590).
+    # Recreate forces the old pod down before the new one starts: brief
+    # downtime, no overlap. Non-fresh restarts keep RollingUpdate so in-place
+    # upgrades stay zero-downtime.
+    strategy: dict = {"type": "Recreate"} if fresh else {"type": "RollingUpdate"}
     return {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -161,6 +170,7 @@ def _build_controller_deployment(
         },
         "spec": {
             "replicas": 1,
+            "strategy": strategy,
             "selector": {"matchLabels": {"app": "iris-controller"}},
             "template": {
                 "metadata": {"labels": {"app": "iris-controller"}},

--- a/lib/iris/tests/cluster/providers/k8s/test_coreweave.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_coreweave.py
@@ -361,40 +361,6 @@ def test_configmap_strips_kubeconfig_path():
     provider.shutdown()
 
 
-def test_start_controller_uses_recreate_strategy_when_fresh():
-    """`--fresh` selects Recreate so the OLD pod is gone before NEW boots (#5590)."""
-    provider, k8s = _make_provider()
-    cluster_config = _make_cluster_config()
-
-    t = threading.Thread(target=_auto_ready_deployment, args=(k8s, "iris-controller"), daemon=True)
-    t.start()
-
-    provider.start_controller(cluster_config, fresh=True)
-
-    dep = k8s.get_json(K8sResource.DEPLOYMENTS, "iris-controller")
-    assert dep["spec"]["strategy"] == {"type": "Recreate"}
-
-    t.join(timeout=5)
-    provider.shutdown()
-
-
-def test_start_controller_uses_rolling_update_when_not_fresh():
-    """Non-fresh restarts keep RollingUpdate so in-place upgrades stay zero-downtime."""
-    provider, k8s = _make_provider()
-    cluster_config = _make_cluster_config()
-
-    t = threading.Thread(target=_auto_ready_deployment, args=(k8s, "iris-controller"), daemon=True)
-    t.start()
-
-    provider.start_controller(cluster_config)
-
-    dep = k8s.get_json(K8sResource.DEPLOYMENTS, "iris-controller")
-    assert dep["spec"]["strategy"] == {"type": "RollingUpdate"}
-
-    t.join(timeout=5)
-    provider.shutdown()
-
-
 def test_controller_deployment_includes_endpoint_url():
     """When object_storage_endpoint is set, the controller Deployment includes AWS_ENDPOINT_URL."""
     k8s = InMemoryK8sService(namespace="iris")

--- a/lib/iris/tests/cluster/providers/k8s/test_coreweave.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_coreweave.py
@@ -361,6 +361,40 @@ def test_configmap_strips_kubeconfig_path():
     provider.shutdown()
 
 
+def test_start_controller_uses_recreate_strategy_when_fresh():
+    """`--fresh` selects Recreate so the OLD pod is gone before NEW boots (#5590)."""
+    provider, k8s = _make_provider()
+    cluster_config = _make_cluster_config()
+
+    t = threading.Thread(target=_auto_ready_deployment, args=(k8s, "iris-controller"), daemon=True)
+    t.start()
+
+    provider.start_controller(cluster_config, fresh=True)
+
+    dep = k8s.get_json(K8sResource.DEPLOYMENTS, "iris-controller")
+    assert dep["spec"]["strategy"] == {"type": "Recreate"}
+
+    t.join(timeout=5)
+    provider.shutdown()
+
+
+def test_start_controller_uses_rolling_update_when_not_fresh():
+    """Non-fresh restarts keep RollingUpdate so in-place upgrades stay zero-downtime."""
+    provider, k8s = _make_provider()
+    cluster_config = _make_cluster_config()
+
+    t = threading.Thread(target=_auto_ready_deployment, args=(k8s, "iris-controller"), daemon=True)
+    t.start()
+
+    provider.start_controller(cluster_config)
+
+    dep = k8s.get_json(K8sResource.DEPLOYMENTS, "iris-controller")
+    assert dep["spec"]["strategy"] == {"type": "RollingUpdate"}
+
+    t.join(timeout=5)
+    provider.shutdown()
+
+
 def test_controller_deployment_includes_endpoint_url():
     """When object_storage_endpoint is set, the controller Deployment includes AWS_ENDPOINT_URL."""
     k8s = InMemoryK8sService(namespace="iris")


### PR DESCRIPTION
Default RollingUpdate keeps the OLD controller pod Service-routable while the NEW pod boots, so jobs submitted in the surge window land on the OLD controller and get deleted as strays by the NEW controller's first reconcile when --fresh wipes the SQLite. Switch to Recreate for fresh restarts; non-fresh keeps RollingUpdate so in-place upgrades stay zero-downtime.

Fixes #5590