### PR TITLE
Replace hand-rolled executor batching with max_concurrent kwarg

### DIFF
--- a/experiments/evals/evals.py
+++ b/experiments/evals/evals.py
@@ -759,15 +759,10 @@ def run_evalchemy_experiment(
         discover_latest_checkpoint=discover_latest_checkpoint,
     )
 
-    # Run eval steps in batches to limit parallelism.
-    # Each executor_main call runs up to max_parallel_jobs eval steps concurrently.
-    # Already-completed steps are automatically skipped via status files on disk.
-    if max_parallel_jobs is not None:
-        for i in range(0, len(eval_steps), max_parallel_jobs):
-            batch = eval_steps[i : i + max_parallel_jobs]
-            executor_main(steps=batch)
-    else:
-        executor_main(steps=eval_steps)
+    # Run all eval steps in a single executor_main call, capping concurrent
+    # execution at max_parallel_jobs. The executor walks the shared dependency
+    # DAG once instead of once per batch.
+    executor_main(steps=eval_steps, max_concurrent=max_parallel_jobs)
 
     # Run compile steps separately. Their eval-step dependencies have already
     # succeeded, so the executor skips them and only runs the compile steps.

--- a/experiments/multilingual/exp1457_multilingual_cpt_eval.py
+++ b/experiments/multilingual/exp1457_multilingual_cpt_eval.py
@@ -57,6 +57,7 @@ multilingual_eval_steps = [
 
 
 if __name__ == "__main__":
-    for i in range(0, len(multilingual_eval_steps), 4):
-        batch = multilingual_eval_steps[i : i + 4]
-        executor_main(steps=batch)
+    # Cap concurrency at 4 to avoid swamping the cluster scheduler with 1,122
+    # ready eval steps. A single executor_main call walks the shared dependency
+    # DAG once instead of once per batch.
+    executor_main(steps=multilingual_eval_steps, max_concurrent=4)

--- a/lib/marin/src/marin/execution/executor.py
+++ b/lib/marin/src/marin/execution/executor.py
@@ -1712,8 +1712,23 @@ class ExecutorMainConfig:
 
 
 @draccus.wrap()
-def executor_main(config: ExecutorMainConfig, steps: list[ExecutorStep], description: str | None = None):
-    """Main entry point for experiments (to standardize)"""
+def executor_main(
+    config: ExecutorMainConfig,
+    steps: list[ExecutorStep],
+    description: str | None = None,
+    max_concurrent: int | None = None,
+):
+    """Main entry point for experiments (to standardize).
+
+    Args:
+        config: Parsed CLI config (draccus). Carries `--dry_run`, `--max_concurrent`, etc.
+        steps: Steps to execute.
+        description: Optional human-readable description recorded in executor info.
+        max_concurrent: Programmatic cap on concurrent step execution. If provided,
+            takes precedence over `config.max_concurrent`. Use this to express
+            "run all of these with cap N" inside an experiment script without
+            requiring users to pass `--max_concurrent N` on the CLI.
+    """
 
     configure_logging(level=logging.INFO)
     time_in = time.time()
@@ -1731,12 +1746,14 @@ def executor_main(config: ExecutorMainConfig, steps: list[ExecutorStep], descrip
         description=description,
     )
 
+    effective_max_concurrent = max_concurrent if max_concurrent is not None else config.max_concurrent
+
     executor.run(
         steps=steps,
         dry_run=config.dry_run,
         run_only=config.run_only,
         force_run_failed=config.force_run_failed,
-        max_concurrent=config.max_concurrent,
+        max_concurrent=effective_max_concurrent,
     )
     time_out = time.time()
     logger.info(f"Executor run took {time_out - time_in:.2f}s")

--- a/lib/zephyr/tests/conftest.py
+++ b/lib/zephyr/tests/conftest.py
@@ -27,9 +27,14 @@ ZEPHYR_ROOT = Path(__file__).resolve().parents[1]
 IRIS_CONFIG = Path(__file__).resolve().parents[2] / "iris" / "examples" / "test.yaml"
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def iris_cluster():
-    """Start local Iris cluster for testing - reused across all tests."""
+    """Start local Iris cluster for testing - reused across tests in a module.
+
+    Module-scoped (rather than session-scoped) so that a stuck or polluted
+    cluster from one test module does not bleed into another. Tests within a
+    single module still amortize the cluster startup cost.
+    """
     from iris.cluster.config import connect_cluster, load_config, make_local_config
 
     config = load_config(IRIS_CONFIG)
@@ -73,11 +78,14 @@ def _parent_holder_entrypoint():
     time.sleep(3600)
 
 
-@pytest.fixture(params=["local", "iris"], scope="session")
+@pytest.fixture(params=["local", "iris"], scope="module")
 def integration_client(request):
     """Parametrized fixture providing Local and Iris clients.
 
-    Session-scoped to reuse clusters across all test modules.
+    Module-scoped so a stuck cluster or leaked actor from one module does not
+    bleed into another. The Iris path depends on `iris_cluster` (also
+    module-scoped); pytest enforces that a fixture cannot depend on a
+    narrower-scoped fixture, so these scopes must match.
     """
     if request.param == "local":
         client = LocalClient()
@@ -111,9 +119,13 @@ def integration_client(request):
         raise ValueError(f"Unknown backend: {request.param}")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def integration_ctx(integration_client, tmp_path_factory):
-    """ZephyrContext on all backends for integration tests."""
+    """ZephyrContext on all backends for integration tests.
+
+    Module-scoped to match `integration_client` (a fixture cannot depend on a
+    narrower-scoped fixture).
+    """
     tmp_path = tmp_path_factory.mktemp("zephyr-integration")
     ctx = ZephyrContext(
         client=integration_client,
@@ -180,8 +192,9 @@ def _configure_marin_prefix():
         del os.environ["MARIN_PREFIX"]
 
 
-# Thread name prefixes for infrastructure threads managed by session-scoped
-# clusters (iris, fray). These persist across tests and are not leaks.
+# Thread name prefixes for infrastructure threads managed by long-lived
+# fixtures (iris, fray). These persist across tests within a module/session
+# and are not leaks.
 _INFRA_THREAD_PREFIXES = (
     "worker-server",
     "worker-lifecycle",
@@ -190,6 +203,10 @@ _INFRA_THREAD_PREFIXES = (
     "asyncio_",
     "grpc_",
     "monitoring",
+    # Iris worker task/log threads, spawned the first time a test touches the
+    # cluster fixture and torn down with the cluster.
+    "task-/",
+    "logs-/",
 )
 
 
@@ -201,8 +218,8 @@ def _thread_cleanup():
     non-daemon threads remain after teardown. Waits briefly for threads
     that are in the process of shutting down.
 
-    Infrastructure threads from session-scoped clusters (iris) are
-    excluded — they persist for the session and are not leaks.
+    Infrastructure threads from long-lived fixtures (iris cluster, fray) are
+    excluded — they persist for the lifetime of the fixture and are not leaks.
     """
     before = {t.ident for t in threading.enumerate()}
     yield


### PR DESCRIPTION
Closes #5343

### What

1. Add a programmatic `max_concurrent` kwarg to `executor_main` (takes precedence over `config.max_concurrent`).
2. Replace the hand-rolled 281×4 batching loop in `experiments/multilingual/exp1457_multilingual_cpt_eval.py` with a single `executor_main(steps=..., max_concurrent=4)` call.
3. Same fix applied to `experiments/evals/evals.py:763` (`run_evalchemy_experiment`).
4. Move zephyr `iris_cluster`, `integration_client`, `integration_ctx` from `scope="session"` to `scope="module"` so a stuck cluster or leaked actor in one test module does not bleed into another; add `task-/` / `logs-/` to the infra-thread allowlist so the per-module cluster startup does not trip the thread-leak warning.

### Why

`tests/test_dry_run.py::test_run_dry_runs[exp1457_multilingual_cpt_eval.py]` was the slowest test on `Marin - Tests` for several runs in a row (~40s, 2.5× the next-slowest dry run). Each of the 281 `executor_main` calls re-walked the same shared DAG, computed versions, and read statuses for 1,122 steps. A single call with `max_concurrent=4` preserves today's production parallelism cap while walking the DAG once.