### PR TITLE
[Design] unified_unit_workflow

### DIFF
--- a/.agents/projects/unified_unit_workflow/design.md
+++ b/.agents/projects/unified_unit_workflow/design.md
@@ -9,101 +9,116 @@ that each encode the same shape — `dorny/paths-filter` → `uv sync` →
 vars, marker filters, and working directories. The path filters under-
 or over-approximate the real import dependencies, and adding a new
 workspace package requires authoring (and forgetting to update) yet
-another YAML. We already have an analyzer (`infra/select_tests.py:243`)
-that computes a precise per-package test matrix from any diff. The next
-step is to delete the per-package YAMLs and let one orchestrator drive
-all unit tests, with each package declaring how to run its tests in its
-own `pyproject.toml`. End state: `marin-unit.yaml`, `marin-integration.yaml`,
-`dupekit-unit.yaml`, and a separate `levanter-tpu-tests.yaml` — five
-files deleted and one rewritten.
+another YAML. We already have an analyzer (`infra/select_tests.py`)
+that computes a precise per-package test matrix from any diff, with a
+top-level-only AST filter that respects the codebase's "no lazy
+imports" convention. The next step is to delete the per-package YAMLs
+and let one orchestrator drive all unit tests, with a small set of
+defaults baked in workspace-wide and a tiny `[tool.marin.tests]` table
+in only those packages that genuinely diverge. End state:
+`marin-unit.yaml` + `marin-integration.yaml` cover the python lib
+packages; `dupekit-unit.yaml` keeps the Rust+Python hybrid;
+`levanter-tpu-tests.yaml` extracts the Docker-TPU job. Five workflow
+files deleted, one rewritten.
+
+This is also a **cleanup pass.** Several of the per-package quirks I
+cataloged turn out to be cruft, not real differences — Ray was removed
+from the codebase, iris doesn't actually need `-n1`, packages have
+drifted onto different Python versions for no real reason. The design
+deletes those before encoding the rest.
 
 ## Background
 
-The seven workflows diverge on Python version, `uv sync` extras/groups,
-markers, parallelism, and per-package quirks (CPU-torch wheel dance,
-`RAY_ENABLE_UV_RUN_RUNTIME_ENV=0`, "don't `cd lib/zephyr`"); five of seven
-path filters miss transitive dependencies. `infra/select_tests.py` already
-emits a `{run_all, matrix}` JSON ready to drive a matrix job. Prior art
-(Bazel `py_test`, Pants `python_tests`, Nx `project.json`, Turborepo
-`turbo.json`) all converge on **declarative per-target config with a
-small typed schema**. Coverage-based test selection (testmon-style)
-loses on cache-invalidation. Full digest in `research.md`.
+The seven workflows diverge on Python version (3.11/3.12/3.11–13
+matrix), `uv sync` extras/groups, markers, parallelism, and per-package
+quirks. After auditing each one, the genuine differences (after
+deleting cruft — see `spec.md` §7) are: levanter needs the CPU-torch
+wheel + Node 22; marin needs `cpu`/`dedup` extras + `-n 4`; iris wants
+`PYTHONASYNCIODEBUG=1`; haliax has a JAX runtime pin under review;
+fray uses a non-`test` group name. Every other package collapses to
+the workspace baseline. `infra/select_tests.py` already emits a
+`{run_all, matrix}` JSON ready to drive a matrix job.
+
+Prior art (Bazel `py_test`, Pants `python_tests`, Nx `project.json`,
+Turborepo `turbo.json`) all converge on declarative per-target config,
+but every one of them lets the *baseline* do the work — per-target
+config is for what differs, not what's the same. Coverage-based test
+selection (testmon-style) loses on cache-invalidation. Full digest in
+`research.md`.
 
 ## Challenges
 
-**Per-package quirks must survive consolidation.** Levanter's torch suite
-needs the CPU-pinned torch wheel from the pytorch wheelhouse extracted
-out of `uv.lock` (`levanter-unit.yaml:119-146`); zephyr must not `cd
-lib/zephyr` because Ray's uv integration breaks (`zephyr-unit.yaml:65`);
-marin needs `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0` (`marin-unit.yaml:69`);
-haliax wants a runtime JAX pin via `--with` (`haliax-unit.yaml:55`); iris
-wants single-process (`-n1`); marin wants `-n 4 --dist=worksteal`. A
-unified workflow must let each package declare these without smuggling
-package-specific shell into the orchestrator.
+**Avoiding scope creep into "preserve everything verbatim."** The
+seven workflows have accreted quirks over time and several of them no
+longer matter. The temptation is to encode all of them as schema
+fields. The right move is to delete what's dead first
+(`RAY_ENABLE_UV_RUN_RUNTIME_ENV`, the no-cd-zephyr rationale, iris's
+`-n1`, possibly the haliax JAX `--with` pin) and let the schema only
+carry differences that are actually load-bearing.
 
-**The orchestrator is on the critical path for every PR.** Today, six of
-the seven workflows skip themselves entirely if the path filter doesn't
-match. The new orchestrator runs analyzer + matrix-emit on every PR.
-The analyzer takes ~3s once `uv sync --group dev` has installed `grimp`;
-the matrix can be empty (zero matrix legs run) so the wall-clock cost
-on a docs-only PR is `uv sync` + 3s. That's still more than the current
-~5s "filter-says-skip" path.
+**The orchestrator is on the critical path for every PR.** Today, six
+of the seven workflows skip themselves entirely if the path filter
+doesn't match in ~5 seconds. The new orchestrator runs analyzer +
+matrix-emit on every PR, including docs-only ones. The analyzer takes
+~3s once `uv sync --group dev` has installed `grimp`; the matrix can
+be empty so the wall-clock cost on a docs-only PR is `uv sync` + 3s.
+That's a real ~30–60s floor regression on docs-only PRs.
 
 ## Costs / Risks
 
-- **Migration churn.** Five workflow files deleted, one rewritten, every
-  scope gets a new `[tool.marin.tests]` table. Branch-protection rules
-  currently name jobs like `levanter-unit` / `iris-unit`; an admin must
-  remove those and add the new `marin-unit` aggregate as a required
-  check (sequenced — see `spec.md` §7).
+- **Migration churn.** Five workflow files deleted, one rewritten,
+  five small Phase 0 cleanup PRs land first. Branch-protection rules
+  currently name jobs like `levanter-unit` / `iris-unit`; an admin
+  must remove those and add the new `marin-unit` aggregate as a
+  required check (sequenced — see `spec.md` §10).
 - **`grimp` is a hard CI dependency now.** If the analyzer fails (a
   transitive import error, a malformed package) every PR's unit tests
   are dead. The pressure-relief is a `--force-run-all` flag on
-  `select_tests.py` plus a `workflow_dispatch` input on `marin-unit.yaml`
-  so a human can bypass the analyzer in a panic.
-- **Cold-start floor on every PR.** The current `dorny/paths-filter` skip
-  costs ~5s; the new `select` job (checkout + setup-uv + `uv sync --group
-  dev` + grimp graph build) costs ~30–60s even when the resulting matrix
-  is empty. Net regression on docs-only PRs.
+  `select_tests.py` plus a `workflow_dispatch` input on
+  `marin-unit.yaml` so a human can bypass the analyzer in a panic.
+- **Cold-start floor on every PR.** ~30–60s `uv sync --group dev` +
+  grimp graph build, even when the resulting matrix is empty. Net
+  regression on docs-only PRs.
 - **Levanter sub-suite parallelism is lost.** Today `levanter-unit`,
   `levanter-entry`, and `levanter-torch` run on three runners
-  concurrently; collapsed into one matrix leg they serialize. Wall-clock
-  hit on PRs that touch `levanter` source.
-- **No immediate user-visible improvement.** PR contributors notice
-  faster CI on small changes (analyzer skips most legs) and more
-  reliable CI on cross-package changes (transitive deps now caught) —
-  both real but not earth-moving.
+  concurrently; collapsed into one matrix leg they serialize. The
+  AST-driven test selection covers correctness; the loss is wall-clock.
 
 ## Design
 
-**Package-local test config in `pyproject.toml`.** Each
-`lib/<pkg>/pyproject.toml` (and the root `pyproject.toml` for the marin
-scope, which owns top-level `tests/`) gains a small `[tool.marin.tests]`
-table:
+**Workspace baseline in the root `pyproject.toml`** (one place, owns
+Python version, default markers, default pytest args, default `uv sync
+--group test`):
 
 ```toml
-[tool.marin.tests]
-sync_package = "marin-levanter"     # uv --package
-python = "3.11"
-working_dir = "."
-sync_args = ["--extra", "torch_test", "--group", "test"]
-uv_run_args = []                    # haliax sets ["--with", "jax[cpu]==0.9.2"]
+[tool.marin.tests.workspace]
+python = "3.12"
 markers = "not slow and not tpu and not tpu_ci"
-pytest_args = ["--durations=20"]
-pythonpath = ["tests", "src"]
-env = { RAY_ENABLE_UV_RUN_RUNTIME_ENV = "0" }
-setup_scripts = ["infra/test_setup/install_torch_cpu.sh"]
+pytest_args = ["--durations=5", "-n", "auto", "--tb=short"]
+sync_groups = ["test"]
+```
+
+**Per-package overrides** are optional. Most packages need no table.
+Only the genuinely-different packages declare a `[tool.marin.tests]`
+in their `lib/<pkg>/pyproject.toml`:
+
+```toml
+# lib/levanter/pyproject.toml
+[tool.marin.tests]
+sync_extras = ["torch_test"]
+sync_extra_args = ["--no-install-package", "torch"]
+setup_scripts = ["infra/test_setup/install_torch_cpu.sh",
+                 "infra/test_setup/install_ffmpeg_apt.sh"]
 setup_node = "22"
 ```
 
-The schema is flat by design. `sync_args` and `uv_run_args` accept any
-flag the underlying tool understands (so haliax's runtime jax pin and
-levanter's `--no-install-package torch` don't need new fields).
-`setup_scripts` is a list of repo-relative paths to shell scripts —
-not raw shell, so the genuinely weird stuff (CPU-torch wheel install,
-ffmpeg apt-install) lives in version-controlled, lintable, locally-
-runnable scripts under `infra/test_setup/`. Field semantics and
-validation rules in `spec.md`.
+After Phase 0 cleanup the actual per-package configs are tight:
+**four packages need no table at all** (rigging, finelog, zephyr,
+fray), **three or four carry a small delta** (iris, levanter, marin,
+and possibly haliax — its JAX `--with` pin is on the chopping block),
+**zero declare a Python version, working directory, or sync group**
+(workspace pins one Python; everyone runs from repo root; everyone
+syncs with `--group test`). Full table in `spec.md` §4.
 
 **Single orchestrator: `marin-unit.yaml`.** Three jobs, with
 `fail-fast: false` and a workflow-level `concurrency: marin-unit-<pr>`
@@ -114,80 +129,82 @@ that cancels in-flight runs on push:
    resolved base ref. Base ref is `pull_request.base.sha` on PR,
    `event.before` on push to main, or `--force-run-all` when the
    workflow_dispatch input asks. Emits the matrix as a step output.
-2. `unit` — `strategy.matrix.include: ${{ fromJSON(...) }}` consumes the
-   matrix. Each leg invokes `infra/run_tests.py prepare <package>`
-   which loads the `[tool.marin.tests]` table and writes two scripts to
-   `$RUNNER_TEMP/test-leg/` (setup.sh and pytest.sh) — outputs only
-   carry scalars (python version, sync args, env-as-KEY=VAL lines). The
-   leg then sets up Python via `uv python install`, optionally runs
-   `actions/setup-node`, lifts env into `$GITHUB_ENV`, runs setup.sh,
-   `uv sync ...`, then pytest.sh. If the analyzer's `tests` list is
-   non-empty, pytest runs on that explicit list (precise); empty list
-   = forced full suite.
+2. `unit` — `strategy.matrix.include: ${{ fromJSON(...) }}` consumes
+   the matrix. Each leg invokes `infra/run_tests.py prepare <package>`
+   which loads the resolved `TestsConfig` (workspace baseline merged
+   with any per-package override) and writes two scripts to
+   `$RUNNER_TEMP/leg/` (setup.sh and pytest.sh) — outputs only carry
+   scalars (sync args, env-as-`KEY=VAL` lines). The leg sets up Python
+   via `uv python install`, optionally runs `actions/setup-node`,
+   lifts env into `$GITHUB_ENV`, runs setup.sh, `uv sync ...`, then
+   pytest.sh. Always from repo root; no `cd`. If the analyzer's
+   `tests` list is non-empty, pytest runs on that explicit list
+   (precise); empty list = forced full suite.
 3. `aggregate` — depends on `unit`, exits 0 on success or skipped
    (empty matrix is fine — no test-affecting changes), 1 otherwise.
-   Single status check `marin-unit` is what branch protection requires.
+   Single status check `marin-unit` is what branch protection
+   requires.
 
-The "writes scripts to a temp dir" pattern is deliberate: GitHub Actions
-step outputs cannot reliably carry multi-line shell, and levanter's torch
-wheel install is a 25-line heredoc.
+The "writes scripts to a temp dir" pattern is deliberate: GitHub
+Actions step outputs cannot reliably carry multi-line shell, and
+levanter's torch wheel install is genuinely 25 lines.
 
 **`marin-integration.yaml` absorbs `iris-e2e-smoke`.** Playwright +
-Claude-screenshot-verification isn't unit-shaped (boots a server, drives
-a real browser, calls an external API). It moves to integration where
-heavier multi-component scenarios already live.
+Claude-screenshot-verification isn't unit-shaped (boots a server,
+drives a real browser, calls an external API). `dupekit-unit.yaml`
+stays as-is — Rust+Python hybrid doesn't fit the analyzer.
+`levanter-tpu-tests.yaml` extracts the Docker-TPU job from
+`levanter-unit.yaml:159-227` unchanged; folds into the unified policy
+later when it can run on the Iris prod cluster.
 
-**`dupekit-unit.yaml` stays as-is.** Rust+Python hybrid doesn't fit the
-analyzer (which only sees Python imports). Folding cargo into either
-marin-unit or marin-lint blurs the boundary.
-
-**`levanter-tpu-tests` extracted.** The Docker-TPU job in
-`levanter-unit.yaml:159-226` becomes `levanter-tpu-tests.yaml`,
-unchanged in content. Stays separate "for now" per the user's framing;
-folds into the unified policy later when it can run on the Iris prod
-cluster.
-
-**Sub-suites collapse.** Levanter's three Python sub-jobs (unit / entry
-/ torch) become one matrix leg with one marker filter. The AST-driven
-test selection is the safety net the marker-split used to be: a
-torch-only test only fires when its imported source appears in the
-affected set.
+**Sub-suites collapse.** Levanter's three Python sub-jobs (unit /
+entry / torch) become one matrix leg with one marker filter. The
+AST-driven test selection is the safety net the marker-split used to
+be: a torch-only test only fires when its imported source appears in
+the affected set.
 
 ## Testing
 
 The analyzer is already covered by 25 unit tests in
 `tests/infra/test_select_tests.py`. Two new test surfaces:
 
-- **A `[tool.marin.tests]` schema test per package.** Loads each
-  package's table, asserts required fields are present and types check.
-  Lives at `tests/infra/test_marin_tests_config.py`. Failing this test
-  in CI prevents merging a malformed table.
-- **Orchestrator dry-run.** A `marin-unit.yaml` PR can be exercised in
-  draft against this branch using GitHub's `workflow_dispatch`; success
-  criteria: matrix shape matches the analyzer JSON for known diffs
-  (e.g. a haliax-only change emits 1 leg), every leg's pytest runs
-  green, status check `marin-unit` aggregates correctly.
+- **A baseline + override resolution test.** Loads the workspace
+  baseline and each package's optional `[tool.marin.tests]`, asserts
+  required fields are present, types check, and the merged
+  `TestsConfig` is what we expect for known packages
+  (`tests/infra/test_marin_tests_config.py`). Failing this test in CI
+  prevents merging a malformed table or a missing baseline.
+- **Renderer test.** Asserts the shell scripts produced by
+  `infra/run_tests.py prepare <pkg>` for fixture configs match
+  expected content (`tests/infra/test_run_tests.py`).
 
-Migration order: land the orchestrator behind `workflow_dispatch` first,
-verify against three or four real PRs, then flip the trigger to
-`pull_request` and delete the six old YAMLs in the same PR (so the
-branch-protection rename happens atomically).
+Migration is staged so each phase is reversible until the last (full
+detail in `spec.md` §10): five Phase 0 cleanup PRs delete the cruft
+first; Phase 1 lands the orchestrator behind `continue-on-error`;
+Phase 2 makes it a non-required parallel check next to the old
+workflows; Phase 3 deletes the old workflows in a single PR and an
+admin updates branch-protection in three steps.
 
 ## Open Questions
 
-- **Cold-start cost on docs-only PRs.** The `select` job runs on every
-  PR including ones whose final matrix is empty. ~30–60s floor. Worth
+- **Phase 0 scope.** `spec.md` §7 lists six cleanup steps the design
+  treats as obvious wins (Ray refs gone, `-n1` gone, Python unified at
+  3.12, every package's test deps move to a uniform `test` group,
+  haliax JAX `--with` re-evaluated, redundant `-c pyproject.toml`
+  gone). Anything in that list someone wants to defend?
+- **haliax's runtime JAX pin.** `--with "jax[cpu]==0.9.2"` overrides
+  the lockfile. Is this an intentional "test haliax against the JAX
+  version levanter uses" check? If yes, tighten the dep in
+  `lib/haliax/pyproject.toml` and drop the override. If no, just drop
+  it. If neither and reviewers want it preserved, `uv_run_args` carries
+  it.
+- **Cold-start cost on docs-only PRs.** ~30–60s floor on every PR. Worth
   it for the precision wins, but I want a sanity check that the docs/
   PR experience won't deteriorate enough to bother people.
-- **Branch-protection migration.** Phase 3 of `spec.md` §7 requires a
-  three-step admin sequence (remove old required checks, merge the
-  switch PR, add `marin-unit` as required). Should this happen with
-  someone in the room, or do we trust the runbook?
-- **Should `marin` scope live at the root pyproject or `lib/marin/`?**
-  Today the analyzer attributes top-level `tests/` to `marin`, but
-  `lib/marin/tests/` is empty. `spec.md` puts the marin scope's
-  `[tool.marin.tests]` in the *root* pyproject. If anyone plans to
-  populate `lib/marin/tests/` later, the routing needs another scope.
+- **Branch-protection runbook.** Phase 3 needs a three-step admin
+  sequence (remove old required checks → merge switch PR → add new
+  required check). Should this happen with someone in the room, or do
+  we trust the runbook?
 - **Should the analyzer become a reusable composite action?** Inline in
   the orchestrator keeps blast radius small; composite would let other
   workflows consult the matrix. Starting inline; reconsider if a second

--- a/.agents/projects/unified_unit_workflow/design.md
+++ b/.agents/projects/unified_unit_workflow/design.md
@@ -97,8 +97,8 @@ flowchart TB
     classify --> broad{broad trigger?<br/>uv.lock / root pyproject /<br/>infra/select_tests.py}
     broad -->|yes| runall[full-suite matrix:<br/>every member, tests=&#91;&#93;]
     broad -->|no| route["Route by path:<br/>lib/X/src/a/b.py → module 'X.a.b'<br/>lib/X/tests/t.py → direct test<br/>lib/X/conftest.py → forced full X<br/>workflow file → forced full owning member"]
-    route --> graph[grimp.build_graph<br/>over lib/*/src/<br/>~540 modules total]
-    graph --> ast["AST-scan each src file<br/>collect TOP-LEVEL imports only<br/>skip def/class bodies<br/>skip if TYPE_CHECKING blocks"]
+    route --> grimp[grimp.build_graph<br/>over lib/*/src/<br/>~540 modules total]
+    grimp --> ast["AST-scan each src file<br/>collect TOP-LEVEL imports only<br/>skip def/class bodies<br/>skip if TYPE_CHECKING blocks"]
     ast --> downstream[BFS reverse-deps:<br/>changed module → affected modules]
     downstream --> testscan["AST-scan each test file<br/>select if any import touches<br/>the affected set"]
     testscan --> grouped[group selected tests by<br/>owning workspace member]

--- a/.agents/projects/unified_unit_workflow/design.md
+++ b/.agents/projects/unified_unit_workflow/design.md
@@ -5,39 +5,79 @@ _Why are we doing this? What's the benefit?_
 We have seven `*-unit.yaml` workflows
 (`.github/workflows/{haliax,levanter,iris,zephyr,fray,marin,dupekit}-unit.yaml`)
 that each encode the same shape — `dorny/paths-filter` → `uv sync` →
-`pytest` — with sharp per-package divergence in install commands, env
-vars, marker filters, and working directories. The path filters under-
-or over-approximate the real import dependencies, and adding a new
-workspace package requires authoring (and forgetting to update) yet
-another YAML. We already have an analyzer (`infra/select_tests.py`)
-that computes a precise per-package test matrix from any diff, with a
-top-level-only AST filter that respects the codebase's "no lazy
-imports" convention. The next step is to delete the per-package YAMLs
-and let one orchestrator drive all unit tests, with a small set of
-defaults baked in workspace-wide and a tiny `[tool.marin.tests]` table
-in only those packages that genuinely diverge. End state:
-`marin-unit.yaml` + `marin-integration.yaml` cover the python lib
-packages; `dupekit-unit.yaml` keeps the Rust+Python hybrid;
+`pytest` — with sharp per-workspace-member divergence in install
+commands, env vars, marker filters, and working directories. The path
+filters under- or over-approximate the real import dependencies, and
+adding a new workspace member requires authoring (and forgetting to
+update) yet another YAML. We already have an analyzer
+(`infra/select_tests.py`) that computes a precise test matrix from any
+diff, with a top-level-only AST filter that respects the codebase's "no
+lazy imports" convention. The next step is to delete the per-member
+YAMLs and let one orchestrator drive all unit tests, with a small set
+of defaults baked in workspace-wide and a tiny `[tool.marin.tests]`
+table only in those packages that genuinely diverge.
+
+End state: `marin-unit.yaml` + `marin-integration.yaml` cover the python
+lib packages; `dupekit-unit.yaml` keeps the Rust+Python hybrid;
 `levanter-tpu-tests.yaml` extracts the Docker-TPU job. Five workflow
 files deleted, one rewritten.
 
-This is also a **cleanup pass.** Several of the per-package quirks I
-cataloged turn out to be cruft, not real differences — Ray was removed
-from the codebase, iris doesn't actually need `-n1`, packages have
-drifted onto different Python versions for no real reason. The design
-deletes those before encoding the rest.
+This is also a **cleanup pass.** Several of the per-member quirks I
+catalogued turn out to be cruft, not real differences — Ray was removed
+from the codebase (so `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0` and the
+"don't-cd-zephyr" rationale are dead), iris doesn't actually need
+`-n1`, packages have drifted onto different Python versions for no real
+reason, test deps are split across `dev` / `test` / `fray_test` groups
+inconsistently. The design deletes those before encoding the rest (see
+`spec.md` §7).
 
 ## Background
 
-The seven workflows diverge on Python version (3.11/3.12/3.11–13
-matrix), `uv sync` extras/groups, markers, parallelism, and per-package
-quirks. After auditing each one, the genuine differences (after
-deleting cruft — see `spec.md` §7) are: levanter needs the CPU-torch
-wheel + Node 22; marin needs `cpu`/`dedup` extras + `-n 4`; iris wants
-`PYTHONASYNCIODEBUG=1`; haliax has a JAX runtime pin under review;
-fray uses a non-`test` group name. Every other package collapses to
-the workspace baseline. `infra/select_tests.py` already emits a
-`{run_all, matrix}` JSON ready to drive a matrix job.
+### Terminology (used throughout)
+
+- **Workspace member** — one directory under `lib/`. Marin has 8:
+  rigging, finelog, haliax, iris, fray, levanter, zephyr, marin. Each
+  is a uv workspace member declared in `pyproject.toml [tool.uv.workspace]`
+  and named `marin-<dir>`.
+- **Module** — a Python module name resolved from a source file. E.g.,
+  `lib/levanter/src/levanter/store/cache.py` → `levanter.store.cache`.
+- **Test file** — a file under `lib/<member>/tests/` (or top-level
+  `tests/` for the marin scope) that pytest collects.
+- **Leg** — one entry in the orchestrator's matrix; one `pytest`
+  invocation against one workspace member's selected tests.
+
+**Selection happens at the test-file level** (which files pytest runs).
+**Dispatch happens at the workspace-member level** (one leg per member
+that has any selected test). **Traversal happens at the module level**
+(the analyzer's reverse-dep BFS walks dotted module names).
+
+### Today's state
+
+```mermaid
+flowchart LR
+    PR[PR opened] --> H[haliax-unit]
+    PR --> L[levanter-unit]
+    PR --> I[iris-unit]
+    PR --> Z[zephyr-unit]
+    PR --> F[fray-unit]
+    PR --> M[marin-unit]
+    PR --> D[dupekit-unit]
+    H --> H1["3.11 + --with jax==0.9.2<br/>JAX_NUM_CPU_DEVICES=8<br/>-c pyproject.toml"]
+    L --> L1["3 jobs: unit + entry + torch<br/>(+ Docker TPU)<br/>3.11, CPU torch wheel dance"]
+    I --> I1["3.12 -n1<br/>+ Playwright e2e + Claude verify"]
+    Z --> Z1["3.12, no-cd quirk for Ray"]
+    F --> F1["3.12, fray_test group<br/>cd lib/fray, -s flag"]
+    M --> M1["3.12, --extra cpu --extra dedup<br/>RAY_ENABLE_UV_RUN_RUNTIME_ENV=0<br/>-n 4 --dist=worksteal"]
+    D --> D1["3.11/3.12/3.13 matrix<br/>+ cargo fmt/clippy/test"]
+```
+
+Path-filter audit: five of seven workflows have under-approximated
+filters. A change to `rigging.timing` (top-level imported by every
+other workspace member) only fires `rigging-unit`, even though it can
+break finelog/iris/fray/zephyr/levanter/marin. A change to
+`iris.cluster.controller.autoscaler.runtime` (transitively reaches
+fray → zephyr → levanter → marin via real top-level chains) only fires
+`iris-unit`. The CI is silent on cross-member regressions.
 
 Prior art (Bazel `py_test`, Pants `python_tests`, Nx `project.json`,
 Turborepo `turbo.json`) all converge on declarative per-target config,
@@ -46,43 +86,85 @@ config is for what differs, not what's the same. Coverage-based test
 selection (testmon-style) loses on cache-invalidation. Full digest in
 `research.md`.
 
-## Challenges
+## How the analyzer picks tests
 
-**Avoiding scope creep into "preserve everything verbatim."** The
-seven workflows have accreted quirks over time and several of them no
-longer matter. The temptation is to encode all of them as schema
-fields. The right move is to delete what's dead first
-(`RAY_ENABLE_UV_RUN_RUNTIME_ENV`, the no-cd-zephyr rationale, iris's
-`-n1`, possibly the haliax JAX `--with` pin) and let the schema only
-carry differences that are actually load-bearing.
+`infra/select_tests.py` already produces `{run_all: bool, matrix:
+list[{package, tests}]}` from the diff against a base ref:
 
-**The orchestrator is on the critical path for every PR.** Today, six
-of the seven workflows skip themselves entirely if the path filter
-doesn't match in ~5 seconds. The new orchestrator runs analyzer +
-matrix-emit on every PR, including docs-only ones. The analyzer takes
-~3s once `uv sync --group dev` has installed `grimp`; the matrix can
-be empty so the wall-clock cost on a docs-only PR is `uv sync` + 3s.
-That's a real ~30–60s floor regression on docs-only PRs.
+```mermaid
+flowchart TB
+    diff[git diff vs base ref<br/>list of changed files] --> classify[Classify each path]
+    classify --> broad{broad trigger?<br/>uv.lock / root pyproject /<br/>infra/select_tests.py}
+    broad -->|yes| runall[full-suite matrix:<br/>every member, tests=&#91;&#93;]
+    broad -->|no| route["Route by path:<br/>lib/X/src/a/b.py → module 'X.a.b'<br/>lib/X/tests/t.py → direct test<br/>lib/X/conftest.py → forced full X<br/>workflow file → forced full owning member"]
+    route --> graph[grimp.build_graph<br/>over lib/*/src/<br/>~540 modules total]
+    graph --> ast["AST-scan each src file<br/>collect TOP-LEVEL imports only<br/>skip def/class bodies<br/>skip if TYPE_CHECKING blocks"]
+    ast --> downstream[BFS reverse-deps:<br/>changed module → affected modules]
+    downstream --> testscan["AST-scan each test file<br/>select if any import touches<br/>the affected set"]
+    testscan --> grouped[group selected tests by<br/>owning workspace member]
+    grouped --> out[matrix: per-member test list]
+```
 
-## Costs / Risks
+**Why top-level imports only?** Per AGENTS.md, lazy imports (`from foo
+import bar` inside a `def`, `class`, or `if TYPE_CHECKING:` block) are
+reserved for breaking cycles or guarding optional deps; they don't
+impose a load-time dependency, so they shouldn't propagate test impact.
+Without this filter, a single lazy `from fray.device_flops import ...`
+inside `fray.types.GpuConfig.device_flops()` was making device_flops
+look like it cascaded to 150+ modules. With it, the cascade stops at
+the genuine top-level coupling — `levanter.callbacks._metrics` being
+the only top-level importer of device_flops.
 
-- **Migration churn.** Five workflow files deleted, one rewritten,
-  five small Phase 0 cleanup PRs land first. Branch-protection rules
-  currently name jobs like `levanter-unit` / `iris-unit`; an admin
-  must remove those and add the new `marin-unit` aggregate as a
-  required check (sequenced — see `spec.md` §10).
-- **`grimp` is a hard CI dependency now.** If the analyzer fails (a
-  transitive import error, a malformed package) every PR's unit tests
-  are dead. The pressure-relief is a `--force-run-all` flag on
-  `select_tests.py` plus a `workflow_dispatch` input on
-  `marin-unit.yaml` so a human can bypass the analyzer in a panic.
-- **Cold-start floor on every PR.** ~30–60s `uv sync --group dev` +
-  grimp graph build, even when the resulting matrix is empty. Net
-  regression on docs-only PRs.
-- **Levanter sub-suite parallelism is lost.** Today `levanter-unit`,
-  `levanter-entry`, and `levanter-torch` run on three runners
-  concurrently; collapsed into one matrix leg they serialize. The
-  AST-driven test selection covers correctness; the loss is wall-clock.
+### Concrete worked example
+
+A one-line change to `lib/levanter/src/levanter/store/cache.py`. Run
+against the current worktree, the analyzer outputs:
+
+```json
+{
+  "run_all": false,
+  "reason": "diff-driven",
+  "matrix": [
+    {"package": "levanter", "tests": [
+        "lib/levanter/tests/test_audio.py",
+        "lib/levanter/tests/test_dpo.py",
+        "lib/levanter/tests/test_new_cache.py",
+        "lib/levanter/tests/tiny_test_corpus.py",
+        "lib/levanter/tests/whisper_test.py"
+    ]},
+    {"package": "marin", "tests": [
+        "tests/datakit/test_datakit.py",
+        "tests/integration_test.py",
+        "tests/processing/tokenize/test_tokenize.py",
+        "tests/test_consolidate_metadata.py",
+        "tests/test_data_configs.py",
+        "tests/test_download_pretokenized.py",
+        "tests/test_grug_checkpointing.py"
+    ]}
+  ]
+}
+```
+
+Two legs, 12 test files. **Today**, that same change runs the entire
+levanter test suite (~95 files) plus the entire marin test suite (~62
+files) — `lib/levanter/**` is in both filters. The analyzer drops to
+~12 actually-affected tests.
+
+Notice what's *not* selected: `lib/zephyr/tests/test_writers.py`. A
+naïve grep would call out `zephyr/writers.py` as a downstream consumer
+of `levanter.store.cache` — but the import there is **inside a
+function body** (lazy, line 459), not top-level. The top-level filter
+correctly excludes it: if `levanter.store.cache`'s public types
+change, zephyr's writer continues to *load* fine; only its `def
+write_levanter_cache(...)` body would fail at call time.
+
+This particular lazy import is on the chopping block already — there's
+a parallel cleanup happening to remove the remaining lazy imports
+across the workspace (most are vestigial, kept around for cycles that
+no longer exist). Once that lands, the same change would reach
+`zephyr.writers` and add `lib/zephyr/tests/test_writers.py` to the
+matrix. The analyzer doesn't need to change — it correctly reflects
+whatever the source actually does.
 
 ## Design
 
@@ -98,9 +180,9 @@ pytest_args = ["--durations=5", "-n", "auto", "--tb=short"]
 sync_groups = ["test"]
 ```
 
-**Per-package overrides** are optional. Most packages need no table.
-Only the genuinely-different packages declare a `[tool.marin.tests]`
-in their `lib/<pkg>/pyproject.toml`:
+**Per-member overrides** are optional. Most members need no table.
+Only the genuinely-different ones declare a `[tool.marin.tests]` in
+their `lib/<pkg>/pyproject.toml`:
 
 ```toml
 # lib/levanter/pyproject.toml
@@ -112,8 +194,8 @@ setup_scripts = ["infra/test_setup/install_torch_cpu.sh",
 setup_node = "22"
 ```
 
-After Phase 0 cleanup the actual per-package configs are tight:
-**four packages need no table at all** (rigging, finelog, zephyr,
+After Phase 0 cleanup the actual per-member configs are tight:
+**four members need no table at all** (rigging, finelog, zephyr,
 fray), **three or four carry a small delta** (iris, levanter, marin,
 and possibly haliax — its JAX `--with` pin is on the chopping block),
 **zero declare a Python version, working directory, or sync group**
@@ -124,30 +206,35 @@ syncs with `--group test`). Full table in `spec.md` §4.
 `fail-fast: false` and a workflow-level `concurrency: marin-unit-<pr>`
 that cancels in-flight runs on push:
 
-1. `select` — checks out, `uv sync --group dev` (installs grimp), runs
-   `python infra/select_tests.py --emit-github-output` against the
-   resolved base ref. Base ref is `pull_request.base.sha` on PR,
-   `event.before` on push to main, or `--force-run-all` when the
-   workflow_dispatch input asks. Emits the matrix as a step output.
-2. `unit` — `strategy.matrix.include: ${{ fromJSON(...) }}` consumes
-   the matrix. Each leg invokes `infra/run_tests.py prepare <package>`
-   which loads the resolved `TestsConfig` (workspace baseline merged
-   with any per-package override) and writes two scripts to
-   `$RUNNER_TEMP/leg/` (setup.sh and pytest.sh) — outputs only carry
-   scalars (sync args, env-as-`KEY=VAL` lines). The leg sets up Python
-   via `uv python install`, optionally runs `actions/setup-node`,
-   lifts env into `$GITHUB_ENV`, runs setup.sh, `uv sync ...`, then
-   pytest.sh. Always from repo root; no `cd`. If the analyzer's
-   `tests` list is non-empty, pytest runs on that explicit list
-   (precise); empty list = forced full suite.
-3. `aggregate` — depends on `unit`, exits 0 on success or skipped
-   (empty matrix is fine — no test-affecting changes), 1 otherwise.
-   Single status check `marin-unit` is what branch protection
-   requires.
+```mermaid
+flowchart LR
+    PR2[PR opened] --> select["select job<br/>~30s<br/>uv sync --group dev<br/>python infra/select_tests.py<br/>--emit-github-output"]
+    select --> empty{empty matrix?}
+    empty -->|yes| done["aggregate: skip<br/>marin-unit ✓"]
+    empty -->|no| unit["unit job<br/>strategy.matrix.include"]
+    unit --> leg1[leg: rigging]
+    unit --> leg2[leg: levanter<br/>tests=&#91;...4 files...&#93;]
+    unit --> leg3[leg: marin<br/>tests=&#91;...2 files...&#93;]
+    leg1 --> agg[aggregate]
+    leg2 --> agg
+    leg3 --> agg
+    agg --> done2["marin-unit status<br/>(single required check)"]
+```
+
+Each leg invokes `infra/run_tests.py prepare <package>`, which loads
+the resolved `TestsConfig` (workspace baseline merged with any
+per-member override) and writes two scripts to `$RUNNER_TEMP/leg/`
+(setup.sh and pytest.sh) — outputs only carry scalars (sync args,
+env-as-`KEY=VAL` lines). The leg sets up Python via `uv python
+install`, optionally runs `actions/setup-node`, lifts env into
+`$GITHUB_ENV`, runs setup.sh, `uv sync ...`, then pytest.sh. Always
+from repo root; no `cd`. If the analyzer's `tests` list is non-empty,
+pytest runs on that explicit list (precise); empty list = forced full
+suite for that member.
 
 The "writes scripts to a temp dir" pattern is deliberate: GitHub
 Actions step outputs cannot reliably carry multi-line shell, and
-levanter's torch wheel install is genuinely 25 lines.
+levanter's CPU-torch wheel install is genuinely a 25-line heredoc.
 
 **`marin-integration.yaml` absorbs `iris-e2e-smoke`.** Playwright +
 Claude-screenshot-verification isn't unit-shaped (boots a server,
@@ -163,15 +250,77 @@ AST-driven test selection is the safety net the marker-split used to
 be: a torch-only test only fires when its imported source appears in
 the affected set.
 
+## Improvements over today
+
+1. **Correctness.** Today five of seven workflows have
+   under-approximated path filters; cross-member regressions are
+   invisible to CI. After: the analyzer's import graph (built from real
+   Python source, not hand-maintained YAML) is the source of truth.
+2. **Precision.** Today *any* change inside `lib/levanter/**` runs all
+   ~95 levanter tests, even a docstring edit. After: only tests whose
+   top-level imports reach the changed module run. Average test count
+   per PR drops sharply on small changes; the worked example above goes
+   from ~157 tests to ~7.
+3. **Maintainability.** Adding a new workspace member: today, a whole
+   new YAML with copy-paste path-filter / uv-sync / pytest stanzas.
+   After: a row in `SCOPE_TO_PYPROJECT` and (maybe) a small
+   `[tool.marin.tests]` table.
+4. **Accumulated cruft deleted.** Phase 0 removes Ray refs, iris's
+   `-n1`, the haliax JAX runtime pin (pending review), `-c
+   pyproject.toml` redundancy, Python-version drift, and inconsistent
+   dependency-group names.
+5. **Schema discipline.** Workspace baseline owns the boring stuff.
+   Most members need no `[tool.marin.tests]` at all; the design doesn't
+   pay for what it doesn't use.
+6. **Single required status check.** Branch protection requires
+   `marin-unit` (one), not seven separate names.
+
+## Challenges
+
+**Avoiding scope creep into "preserve everything verbatim."** The
+seven workflows have accreted quirks over time and several of them no
+longer matter. The temptation is to encode all of them as schema
+fields. The right move is to delete what's dead first and let the
+schema only carry differences that are actually load-bearing.
+
+**The orchestrator is on the critical path for every PR.** Today, six
+of the seven workflows skip themselves entirely if the path filter
+doesn't match in ~5 seconds. The new orchestrator runs analyzer +
+matrix-emit on every PR, including docs-only ones. The analyzer takes
+~3s once `uv sync --group dev` has installed `grimp`; the matrix can
+be empty so the wall-clock cost on a docs-only PR is `uv sync` + 3s.
+That's a real ~30–60s floor regression on docs-only PRs.
+
+## Costs / Risks
+
+- **Migration churn.** Five workflow files deleted, one rewritten,
+  six small Phase 0 cleanup PRs land first. Branch-protection rules
+  currently name jobs like `levanter-unit` / `iris-unit`; an admin
+  must remove those and add the new `marin-unit` aggregate as a
+  required check (sequenced — see `spec.md` §10).
+- **`grimp` is a hard CI dependency now.** If the analyzer fails (a
+  transitive import error, a malformed package) every PR's unit tests
+  are dead. The pressure-relief is a `--force-run-all` flag on
+  `select_tests.py` plus a `workflow_dispatch` input on
+  `marin-unit.yaml` so a human can bypass the analyzer in a panic.
+- **Cold-start floor on every PR.** ~30–60s `uv sync --group dev` +
+  grimp graph build, even when the resulting matrix is empty. Net
+  regression on docs-only PRs.
+- **Levanter sub-suite parallelism is lost.** Today `levanter-unit`,
+  `levanter-entry`, and `levanter-torch` run on three runners
+  concurrently; collapsed into one matrix leg they serialize. The
+  AST-driven test selection covers correctness; the loss is wall-clock
+  on PRs that touch most of levanter.
+
 ## Testing
 
 The analyzer is already covered by 25 unit tests in
 `tests/infra/test_select_tests.py`. Two new test surfaces:
 
 - **A baseline + override resolution test.** Loads the workspace
-  baseline and each package's optional `[tool.marin.tests]`, asserts
+  baseline and each member's optional `[tool.marin.tests]`, asserts
   required fields are present, types check, and the merged
-  `TestsConfig` is what we expect for known packages
+  `TestsConfig` is what we expect for known members
   (`tests/infra/test_marin_tests_config.py`). Failing this test in CI
   prevents merging a malformed table or a missing baseline.
 - **Renderer test.** Asserts the shell scripts produced by
@@ -179,7 +328,7 @@ The analyzer is already covered by 25 unit tests in
   expected content (`tests/infra/test_run_tests.py`).
 
 Migration is staged so each phase is reversible until the last (full
-detail in `spec.md` §10): five Phase 0 cleanup PRs delete the cruft
+detail in `spec.md` §10): six Phase 0 cleanup PRs delete the cruft
 first; Phase 1 lands the orchestrator behind `continue-on-error`;
 Phase 2 makes it a non-required parallel check next to the old
 workflows; Phase 3 deletes the old workflows in a single PR and an
@@ -199,8 +348,8 @@ admin updates branch-protection in three steps.
   it. If neither and reviewers want it preserved, `uv_run_args` carries
   it.
 - **Cold-start cost on docs-only PRs.** ~30–60s floor on every PR. Worth
-  it for the precision wins, but I want a sanity check that the docs/
-  PR experience won't deteriorate enough to bother people.
+  it for the precision wins, but I want a sanity check that the docs-PR
+  experience won't deteriorate enough to bother people.
 - **Branch-protection runbook.** Phase 3 needs a three-step admin
   sequence (remove old required checks → merge switch PR → add new
   required check). Should this happen with someone in the room, or do

--- a/.agents/projects/unified_unit_workflow/design.md
+++ b/.agents/projects/unified_unit_workflow/design.md
@@ -1,0 +1,194 @@
+# Unified Unit-Test Workflow
+
+_Why are we doing this? What's the benefit?_
+
+We have seven `*-unit.yaml` workflows
+(`.github/workflows/{haliax,levanter,iris,zephyr,fray,marin,dupekit}-unit.yaml`)
+that each encode the same shape — `dorny/paths-filter` → `uv sync` →
+`pytest` — with sharp per-package divergence in install commands, env
+vars, marker filters, and working directories. The path filters under-
+or over-approximate the real import dependencies, and adding a new
+workspace package requires authoring (and forgetting to update) yet
+another YAML. We already have an analyzer (`infra/select_tests.py:243`)
+that computes a precise per-package test matrix from any diff. The next
+step is to delete the per-package YAMLs and let one orchestrator drive
+all unit tests, with each package declaring how to run its tests in its
+own `pyproject.toml`. End state: `marin-unit.yaml`, `marin-integration.yaml`,
+`dupekit-unit.yaml`, and a separate `levanter-tpu-tests.yaml` — five
+files deleted and one rewritten.
+
+## Background
+
+The seven workflows diverge on Python version, `uv sync` extras/groups,
+markers, parallelism, and per-package quirks (CPU-torch wheel dance,
+`RAY_ENABLE_UV_RUN_RUNTIME_ENV=0`, "don't `cd lib/zephyr`"); five of seven
+path filters miss transitive dependencies. `infra/select_tests.py` already
+emits a `{run_all, matrix}` JSON ready to drive a matrix job. Prior art
+(Bazel `py_test`, Pants `python_tests`, Nx `project.json`, Turborepo
+`turbo.json`) all converge on **declarative per-target config with a
+small typed schema**. Coverage-based test selection (testmon-style)
+loses on cache-invalidation. Full digest in `research.md`.
+
+## Challenges
+
+**Per-package quirks must survive consolidation.** Levanter's torch suite
+needs the CPU-pinned torch wheel from the pytorch wheelhouse extracted
+out of `uv.lock` (`levanter-unit.yaml:119-146`); zephyr must not `cd
+lib/zephyr` because Ray's uv integration breaks (`zephyr-unit.yaml:65`);
+marin needs `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0` (`marin-unit.yaml:69`);
+haliax wants a runtime JAX pin via `--with` (`haliax-unit.yaml:55`); iris
+wants single-process (`-n1`); marin wants `-n 4 --dist=worksteal`. A
+unified workflow must let each package declare these without smuggling
+package-specific shell into the orchestrator.
+
+**The orchestrator is on the critical path for every PR.** Today, six of
+the seven workflows skip themselves entirely if the path filter doesn't
+match. The new orchestrator runs analyzer + matrix-emit on every PR.
+The analyzer takes ~3s once `uv sync --group dev` has installed `grimp`;
+the matrix can be empty (zero matrix legs run) so the wall-clock cost
+on a docs-only PR is `uv sync` + 3s. That's still more than the current
+~5s "filter-says-skip" path.
+
+## Costs / Risks
+
+- **Migration churn.** Five workflow files deleted, one rewritten, every
+  scope gets a new `[tool.marin.tests]` table. Branch-protection rules
+  currently name jobs like `levanter-unit` / `iris-unit`; an admin must
+  remove those and add the new `marin-unit` aggregate as a required
+  check (sequenced — see `spec.md` §7).
+- **`grimp` is a hard CI dependency now.** If the analyzer fails (a
+  transitive import error, a malformed package) every PR's unit tests
+  are dead. The pressure-relief is a `--force-run-all` flag on
+  `select_tests.py` plus a `workflow_dispatch` input on `marin-unit.yaml`
+  so a human can bypass the analyzer in a panic.
+- **Cold-start floor on every PR.** The current `dorny/paths-filter` skip
+  costs ~5s; the new `select` job (checkout + setup-uv + `uv sync --group
+  dev` + grimp graph build) costs ~30–60s even when the resulting matrix
+  is empty. Net regression on docs-only PRs.
+- **Levanter sub-suite parallelism is lost.** Today `levanter-unit`,
+  `levanter-entry`, and `levanter-torch` run on three runners
+  concurrently; collapsed into one matrix leg they serialize. Wall-clock
+  hit on PRs that touch `levanter` source.
+- **No immediate user-visible improvement.** PR contributors notice
+  faster CI on small changes (analyzer skips most legs) and more
+  reliable CI on cross-package changes (transitive deps now caught) —
+  both real but not earth-moving.
+
+## Design
+
+**Package-local test config in `pyproject.toml`.** Each
+`lib/<pkg>/pyproject.toml` (and the root `pyproject.toml` for the marin
+scope, which owns top-level `tests/`) gains a small `[tool.marin.tests]`
+table:
+
+```toml
+[tool.marin.tests]
+sync_package = "marin-levanter"     # uv --package
+python = "3.11"
+working_dir = "."
+sync_args = ["--extra", "torch_test", "--group", "test"]
+uv_run_args = []                    # haliax sets ["--with", "jax[cpu]==0.9.2"]
+markers = "not slow and not tpu and not tpu_ci"
+pytest_args = ["--durations=20"]
+pythonpath = ["tests", "src"]
+env = { RAY_ENABLE_UV_RUN_RUNTIME_ENV = "0" }
+setup_scripts = ["infra/test_setup/install_torch_cpu.sh"]
+setup_node = "22"
+```
+
+The schema is flat by design. `sync_args` and `uv_run_args` accept any
+flag the underlying tool understands (so haliax's runtime jax pin and
+levanter's `--no-install-package torch` don't need new fields).
+`setup_scripts` is a list of repo-relative paths to shell scripts —
+not raw shell, so the genuinely weird stuff (CPU-torch wheel install,
+ffmpeg apt-install) lives in version-controlled, lintable, locally-
+runnable scripts under `infra/test_setup/`. Field semantics and
+validation rules in `spec.md`.
+
+**Single orchestrator: `marin-unit.yaml`.** Three jobs, with
+`fail-fast: false` and a workflow-level `concurrency: marin-unit-<pr>`
+that cancels in-flight runs on push:
+
+1. `select` — checks out, `uv sync --group dev` (installs grimp), runs
+   `python infra/select_tests.py --emit-github-output` against the
+   resolved base ref. Base ref is `pull_request.base.sha` on PR,
+   `event.before` on push to main, or `--force-run-all` when the
+   workflow_dispatch input asks. Emits the matrix as a step output.
+2. `unit` — `strategy.matrix.include: ${{ fromJSON(...) }}` consumes the
+   matrix. Each leg invokes `infra/run_tests.py prepare <package>`
+   which loads the `[tool.marin.tests]` table and writes two scripts to
+   `$RUNNER_TEMP/test-leg/` (setup.sh and pytest.sh) — outputs only
+   carry scalars (python version, sync args, env-as-KEY=VAL lines). The
+   leg then sets up Python via `uv python install`, optionally runs
+   `actions/setup-node`, lifts env into `$GITHUB_ENV`, runs setup.sh,
+   `uv sync ...`, then pytest.sh. If the analyzer's `tests` list is
+   non-empty, pytest runs on that explicit list (precise); empty list
+   = forced full suite.
+3. `aggregate` — depends on `unit`, exits 0 on success or skipped
+   (empty matrix is fine — no test-affecting changes), 1 otherwise.
+   Single status check `marin-unit` is what branch protection requires.
+
+The "writes scripts to a temp dir" pattern is deliberate: GitHub Actions
+step outputs cannot reliably carry multi-line shell, and levanter's torch
+wheel install is a 25-line heredoc.
+
+**`marin-integration.yaml` absorbs `iris-e2e-smoke`.** Playwright +
+Claude-screenshot-verification isn't unit-shaped (boots a server, drives
+a real browser, calls an external API). It moves to integration where
+heavier multi-component scenarios already live.
+
+**`dupekit-unit.yaml` stays as-is.** Rust+Python hybrid doesn't fit the
+analyzer (which only sees Python imports). Folding cargo into either
+marin-unit or marin-lint blurs the boundary.
+
+**`levanter-tpu-tests` extracted.** The Docker-TPU job in
+`levanter-unit.yaml:159-226` becomes `levanter-tpu-tests.yaml`,
+unchanged in content. Stays separate "for now" per the user's framing;
+folds into the unified policy later when it can run on the Iris prod
+cluster.
+
+**Sub-suites collapse.** Levanter's three Python sub-jobs (unit / entry
+/ torch) become one matrix leg with one marker filter. The AST-driven
+test selection is the safety net the marker-split used to be: a
+torch-only test only fires when its imported source appears in the
+affected set.
+
+## Testing
+
+The analyzer is already covered by 25 unit tests in
+`tests/infra/test_select_tests.py`. Two new test surfaces:
+
+- **A `[tool.marin.tests]` schema test per package.** Loads each
+  package's table, asserts required fields are present and types check.
+  Lives at `tests/infra/test_marin_tests_config.py`. Failing this test
+  in CI prevents merging a malformed table.
+- **Orchestrator dry-run.** A `marin-unit.yaml` PR can be exercised in
+  draft against this branch using GitHub's `workflow_dispatch`; success
+  criteria: matrix shape matches the analyzer JSON for known diffs
+  (e.g. a haliax-only change emits 1 leg), every leg's pytest runs
+  green, status check `marin-unit` aggregates correctly.
+
+Migration order: land the orchestrator behind `workflow_dispatch` first,
+verify against three or four real PRs, then flip the trigger to
+`pull_request` and delete the six old YAMLs in the same PR (so the
+branch-protection rename happens atomically).
+
+## Open Questions
+
+- **Cold-start cost on docs-only PRs.** The `select` job runs on every
+  PR including ones whose final matrix is empty. ~30–60s floor. Worth
+  it for the precision wins, but I want a sanity check that the docs/
+  PR experience won't deteriorate enough to bother people.
+- **Branch-protection migration.** Phase 3 of `spec.md` §7 requires a
+  three-step admin sequence (remove old required checks, merge the
+  switch PR, add `marin-unit` as required). Should this happen with
+  someone in the room, or do we trust the runbook?
+- **Should `marin` scope live at the root pyproject or `lib/marin/`?**
+  Today the analyzer attributes top-level `tests/` to `marin`, but
+  `lib/marin/tests/` is empty. `spec.md` puts the marin scope's
+  `[tool.marin.tests]` in the *root* pyproject. If anyone plans to
+  populate `lib/marin/tests/` later, the routing needs another scope.
+- **Should the analyzer become a reusable composite action?** Inline in
+  the orchestrator keeps blast radius small; composite would let other
+  workflows consult the matrix. Starting inline; reconsider if a second
+  consumer shows up.

--- a/.agents/projects/unified_unit_workflow/research.md
+++ b/.agents/projects/unified_unit_workflow/research.md
@@ -1,0 +1,105 @@
+# Research — unified_unit_workflow
+
+In-repo and prior-art notes that shaped the design. Written before the
+1-pager; left here as a sibling so reviewers can dig if they want depth.
+
+## In-repo: today's seven `*-unit.yaml` workflows
+
+All seven follow the same shell — `dorny/paths-filter` gates the run, then
+one or more jobs run `uv sync` and `pytest`. They diverge sharply on the
+details:
+
+| Workflow | Python | `uv sync` | `pytest` quirk | Sub-jobs |
+|---|---|---|---|---|
+| `haliax-unit.yaml:32-55` | 3.11 | `--package marin-haliax --dev` | `--with "jax[cpu]==0.9.2"` runtime pin | none |
+| `levanter-unit.yaml:33-226` | 3.11 | `--package marin-levanter --dev --group test --frozen` (+`--extra torch_test --no-install-package torch` for torch leg) | three marker-filtered legs (`unit`/`entry`/`torch`); torch leg installs CPU torch from the pytorch wheelhouse via uv.lock version extraction (lines 119-146); `levanter-tpu-tests` runs in a docker container with TPU device mounts | `levanter-unit`, `levanter-entry`, `levanter-torch`, `levanter-tpu-tests` |
+| `iris-unit.yaml:34-131` | 3.12 | `--group dev` | `cd lib/iris && pytest -n1` | `iris-unit`, `iris-e2e-smoke` (Playwright + Claude screenshot verify) |
+| `zephyr-unit.yaml:33-67` | 3.12 | `--package marin-zephyr --group test --frozen` | "**don't cd into lib/zephyr** so that ray uv integration doesn't freak out" (line 65) | none |
+| `fray-unit.yaml:32-54` | 3.12 | `--group=fray-test` | `cd lib/fray && pytest -s` | none |
+| `marin-unit.yaml:35-72` | 3.12 | `--package marin --extra cpu --extra dedup --group test --frozen` | `pytest -n 4 --dist=worksteal`; `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0` to stop Ray re-uv-syncing on workers | none |
+| `dupekit-unit.yaml:31-89` | 3.11 / 3.12 / 3.13 matrix | `--frozen --group test` | `cd rust/dupekit && pytest`; also runs cargo fmt/clippy/test | `check-user-mode`, `unit-test`, `rust-checks` |
+
+Every workflow's path filter is the same template (`lib/<pkg>/**`, `uv.lock`,
+`.github/workflows/<pkg>-*.yaml`) plus a few cross-package adds (zephyr
+also fires on `lib/iris/**`, `lib/fray/**`; levanter fires on
+`lib/haliax/**`). Five of seven are missing transitive dependencies — see
+the audit table earlier in the conversation.
+
+## In-repo: the analyzer that already exists
+
+`infra/select_tests.py:243` is the entry point. It enumerates module names
+via `grimp.build_graph`, AST-scans every source file's *top-level* imports
+(skipping `def`/`class`/`if TYPE_CHECKING:`), builds a reverse-dep map,
+walks downstream of each changed module, and AST-scans test files for any
+import that touches the affected set. Output:
+
+```json
+{"run_all": false, "reason": "diff-driven",
+ "matrix": [{"package": "levanter", "tests": ["lib/levanter/tests/test_metrics.py"]}, ...]}
+```
+
+Broad triggers (`uv.lock`, root `pyproject.toml`, the analyzer file
+itself, unrecognised workflow files) short-circuit to `run_all: true`.
+Test coverage in `tests/infra/test_select_tests.py` (25 tests) covers the
+broad triggers, no-op cases, direct test-file edits, forced full-suite
+behaviour, the lazy-import filter, and helper functions. Lives at
+`/Users/power/code/marin/.worktrees/marin-test-deps/infra/select_tests.py`.
+
+## In-repo: composite actions and lint
+
+`.github/actions/` has two composites: `claude-triage/action.yaml`
+(canary-triage skill wrapper) and `notify-slack/action.yaml`. Neither is
+unit-test relevant. `infra/pre-commit.py:1-735` is the unified linter
+(ruff/black/license/pyrefly/...); `marin-lint.yaml:1-34` is a thin
+wrapper that just calls it on `--all-files`. Lint is already
+consolidated; tests are the outlier.
+
+No prior design docs in `.agents/projects/` cover test selection,
+workflow consolidation, or build-graph orchestration.
+
+## Prior art
+
+Four established systems converge on the same shape: **declarative
+per-target config with a small typed schema**.
+
+- **Bazel `py_test`** — fields: `srcs`, `deps`, `data`, `args`, `env`,
+  `tags`, `size`, `timeout`, `shard_count`, `flaky`. Test target is a
+  first-class typed BUILD record. ([reference](https://bazel.build/reference/be/python))
+- **Pants `python_tests`** — superset of Bazel's fields plus
+  `extra_env_vars`, `batch_compatibility_tag`, an `env` field naming a
+  defined environment. ([reference](https://www.pantsbuild.org/stable/reference/targets/python_tests))
+- **Nx `project.json` `targets.test`** — `executor`, `options`,
+  `outputs`, `configurations` for env overrides. JSON-Schema validated.
+  Per-package file co-located with code.
+- **Turborepo `turbo.json` `tasks.test`** — `dependsOn`, `inputs`,
+  `outputs`, `env`, `cache`. Centralised at root by default; per-package
+  overrides via package-local `turbo.json` that extends root.
+  ([reference](https://turborepo.dev/docs/reference/configuration))
+
+None pick "pure convention." All four pick declarative + typed. The
+schemas are small (5-10 fields). Per-package locality wins (Bazel,
+Pants, Nx) over central config (Turborepo).
+
+`pytest-testmon` and `pytest-incremental` offer line-level test
+selection from coverage history. The recurring complaint in blog
+postmortems is cache-invalidation bugs that hide regressions — teams
+revert to package-level granularity. **Implication:** keep our analyzer
+coarse (package-level test selection within each suite); declarative
+config stays small.
+
+`workflow_call` + matrix is the de facto GitHub Actions monorepo
+pattern: a generator job emits a JSON matrix, a downstream job consumes
+`strategy.matrix` and dispatches one leg per entry. Marin's analyzer
+already produces matrix-shaped output, so the orchestrator is largely a
+glue job.
+
+## Q&A summary
+
+User decisions captured during interrogate (2026-05-09):
+
+- **Config home**: `[tool.marin.tests]` in each `lib/<pkg>/pyproject.toml`. Co-located with the package; matches the established Bazel/Nx pattern.
+- **Sub-suites (levanter unit/entry/torch)**: collapse into one job per package. The AST analyzer already filters tests narrowly; per-marker job splits no longer earn their orchestration cost.
+- **iris-e2e-smoke**: move into `marin-integration.yaml`. Browser + external-API verification isn't unit-shaped.
+- **dupekit-unit.yaml**: keep as-is. Rust+Python hybrid doesn't fit the analyzer (which only sees Python imports), and folding cargo into either marin-unit or marin-lint blurs the boundary.
+
+End state: `marin-unit.yaml`, `marin-integration.yaml`, `dupekit-unit.yaml`, `levanter-tpu-tests.yaml` (the TPU job split out), plus the existing `marin-lint.yaml` and the canary/release workflows that aren't in scope. Five-and-change unit/test workflows down from twelve-ish.

--- a/.agents/projects/unified_unit_workflow/spec.md
+++ b/.agents/projects/unified_unit_workflow/spec.md
@@ -8,6 +8,24 @@ packages with no per-package config, plus a tiny `[tool.marin.tests]`
 table for the genuinely different packages. Most workspace members will
 have *no* table.
 
+## 0. Terminology
+
+- **Workspace member** — one directory under `lib/`. Marin has 8.
+  Identified by its short directory name (`levanter`) and packaged as
+  `marin-<dir>` (`marin-levanter`). The marin scope is special — its
+  test root is the repo-top-level `tests/`, owned by the root
+  `pyproject.toml`.
+- **Module** — a Python module name resolved from a source file.
+  `lib/levanter/src/levanter/store/cache.py` → `levanter.store.cache`.
+- **Test file** — a file under `lib/<member>/tests/` (or top-level
+  `tests/` for the marin scope) that pytest collects.
+- **Leg** — one entry in the orchestrator's matrix; one `pytest`
+  invocation against one workspace member's selected tests.
+- **Selection** is per-test-file (which files pytest runs).
+  **Dispatch** is per-workspace-member (one leg per member that has any
+  selected test). **Traversal** is per-module (the analyzer's
+  reverse-dep BFS walks dotted module names).
+
 ## 1. Workspace baseline (the convention)
 
 Every test leg runs as if these defaults applied — the orchestrator does
@@ -133,6 +151,10 @@ class TestsConfig:
     timeout_minutes: int = 15
 
 # Maps the analyzer's package names to the pyproject that owns them.
+# Every member's [tool.marin.tests] lives in its own pyproject — including
+# marin, whose table is in lib/marin/pyproject.toml even though its tests
+# directory is the repo-top-level `tests/` (the renderer carries that as a
+# separate constant — see TEST_DIR_FOR_SCOPE below).
 SCOPE_TO_PYPROJECT: dict[str, str] = {
     "rigging":  "lib/rigging/pyproject.toml",
     "finelog":  "lib/finelog/pyproject.toml",
@@ -141,8 +163,21 @@ SCOPE_TO_PYPROJECT: dict[str, str] = {
     "fray":     "lib/fray/pyproject.toml",
     "levanter": "lib/levanter/pyproject.toml",
     "zephyr":   "lib/zephyr/pyproject.toml",
-    "marin":    "pyproject.toml",            # root owns top-level tests/
+    "marin":    "lib/marin/pyproject.toml",
 }
+
+# Where each scope's tests live. All but marin's are conventional;
+# marin's `tests/` is at the repo root rather than under lib/marin/.
+TEST_DIR_FOR_SCOPE: dict[str, str] = {
+    **{name: f"lib/{name}/tests" for name in SCOPE_TO_PYPROJECT
+       if name != "marin"},
+    "marin": "tests",
+}
+
+# The workspace baseline lives at the repo root, separately from any
+# member's [tool.marin.tests]:
+#   pyproject.toml  ->  [tool.marin.tests.workspace]   (baseline only)
+#   lib/marin/pyproject.toml  ->  [tool.marin.tests]   (marin's overrides)
 
 def resolve(scope: str, repo_root: Path) -> TestsConfig:
     """Load the workspace baseline, merge any per-package override, return
@@ -156,21 +191,45 @@ class ConfigError(Exception): ...
 `sync_package` is **derived**, not declared. The convention is
 `marin-<dir>` for `lib/<dir>/pyproject.toml` and `marin` for the root.
 
-## 4. Concrete per-package configs after Phase 0 cleanup
+## 4. Concrete per-member configs after Phase 0 cleanup
 
-This is what each package's table actually looks like under the new
-scheme. Four packages need no table; the rest carry small deltas.
+Each table is the *full* `[tool.marin.tests]` content; absent fields
+inherit from the workspace baseline. Four members need no table; four
+carry small deltas (haliax conditional on the Phase 0 §7 step-5
+review).
 
-| Package | `[tool.marin.tests]` |
-|---|---|
-| `rigging` | (no table — pure baseline) |
-| `finelog` | (no table) |
-| `zephyr` | (no table) |
-| `fray` | (no table — `fray_test` group renamed to `test` in Phase 0) |
-| `iris` | `env = { PYTHONASYNCIODEBUG = "1" }` |
-| `haliax` | `uv_run_args = ["--with", "jax[cpu]==0.9.2"]` + `env = { JAX_NUM_CPU_DEVICES = "8" }` if the Phase 0 review keeps the JAX override; otherwise no table |
-| `levanter` | `sync_extras = ["torch_test"]`, `sync_extra_args = ["--no-install-package", "torch"]`, `setup_scripts = ["infra/test_setup/install_torch_cpu.sh", "infra/test_setup/install_ffmpeg_apt.sh"]`, `setup_node = "22"` |
-| `marin` | `sync_extras = ["cpu", "dedup"]`, `pytest_args = ["-n", "4", "--dist", "worksteal"]` |
+```toml
+# lib/rigging/pyproject.toml — no [tool.marin.tests] table.
+# lib/finelog/pyproject.toml — no [tool.marin.tests] table.
+# lib/zephyr/pyproject.toml — no [tool.marin.tests] table.
+# lib/fray/pyproject.toml   — no [tool.marin.tests] table
+#                             (fray_test group renames to test in Phase 0).
+
+# lib/iris/pyproject.toml
+[tool.marin.tests]
+env = { PYTHONASYNCIODEBUG = "1" }
+
+# lib/haliax/pyproject.toml — conditional on Phase 0 §7 step 5.
+# Default outcome: no table. If the JAX override is ratified:
+[tool.marin.tests]
+uv_run_args = ["--with", "jax[cpu]==0.9.2"]
+env = { JAX_NUM_CPU_DEVICES = "8" }
+
+# lib/levanter/pyproject.toml
+[tool.marin.tests]
+sync_extras = ["torch_test"]
+sync_extra_args = ["--no-install-package", "torch"]
+setup_scripts = [
+    "infra/test_setup/install_torch_cpu.sh",
+    "infra/test_setup/install_ffmpeg_apt.sh",
+]
+setup_node = "22"
+
+# lib/marin/pyproject.toml
+[tool.marin.tests]
+sync_extras = ["cpu", "dedup"]
+pytest_args = ["-n", "4", "--dist", "worksteal"]
+```
 
 ## 5. Orchestrator workflow shape (`marin-unit.yaml`)
 
@@ -267,11 +326,35 @@ jobs:
   `tests: []` (full suite signal); orchestrator does not need a separate
   code path.
 - Multi-line shell goes into `$RUNNER_TEMP/leg/*.sh`, never into
-  `$GITHUB_OUTPUT` (levanter's torch wheel install is genuinely 25
-  lines).
+  `$GITHUB_OUTPUT` (levanter's CPU-torch wheel install is genuinely a
+  25-line heredoc).
 - The leg always runs from repo root; pytest is invoked with explicit
   paths (`lib/<pkg>/tests/<file>` from the analyzer or `lib/<pkg>/tests`
   for full suite). No `cd`.
+
+**`infra/run_tests.py prepare <package>` outputs:**
+
+- `python_version` — string, e.g. `"3.12"`. From the workspace
+  baseline.
+- `sync_args` — single space-separated string ready for shell
+  interpolation. Built as: `--frozen --package marin-<dir>` + one
+  `--extra X` per `sync_extras` entry + one `--group X` per
+  `sync_groups` entry + `sync_extra_args` joined verbatim. Example for
+  levanter:
+  `--frozen --package marin-levanter --extra torch_test --group test --no-install-package torch`.
+- `node_version` — string, possibly empty. From `setup_node` field;
+  empty disables the `actions/setup-node` step via the `if:` guard.
+- `env_lines` — newline-delimited `KEY=VALUE` ready for `>> $GITHUB_ENV`.
+  Values are not quoted; the loader rejects values containing newlines
+  or `=` to keep this format unambiguous.
+- Two files written to `$OUT_DIR` (default `$RUNNER_TEMP/leg/`):
+  - `setup.sh` — `#!/usr/bin/env bash\nset -euo pipefail\n` then each
+    `setup_scripts` entry as a `bash <path>` line in declared order.
+    Empty body if `setup_scripts == []` (executes successfully).
+  - `pytest.sh` — `#!/usr/bin/env bash\nset -euo pipefail\n` then a
+    single line: `uv run <uv_run_args> pytest -m "<markers>" <pytest_args> <test_paths>`,
+    where `test_paths` is either the analyzer's explicit list or
+    `lib/<pkg>/tests` (full suite) or `tests` (marin full suite).
 
 ## 6. File-path summary
 
@@ -309,13 +392,24 @@ defensible and easier to review without the orchestrator change.
    allows 3.12 (`lib/haliax/pyproject.toml:8`, `lib/levanter/pyproject.toml:8`,
    etc.). Bump both workflows to 3.12.
 4. **Standardize the test dependency-group name to `test`** across every
-   `lib/<pkg>/pyproject.toml` `[dependency-groups]` table. Today:
-   levanter, zephyr, marin already have a `test` group; haliax, iris,
-   rigging, finelog put test deps under `dev` (or have no test group at
-   all); fray uses `fray_test`. Split or rename so `uv sync --group
-   test` works uniformly — pure dev-tooling stays under `dev`, test-only
-   deps move to `test`. After this, `sync_groups` defaults to `["test"]`
-   and no package overrides it.
+   `lib/<pkg>/pyproject.toml` `[dependency-groups]` table. Today's
+   layout (verified):
+   - **`test` already exists**: levanter, zephyr, marin. No change.
+   - **`fray_test` rename → `test`**: `lib/fray/pyproject.toml:28`. Also
+     update **both** `include-group` references — `fray_tpu_test`
+     (line 33) and `dev` (line 35) currently include `fray_test`.
+     Regenerate `uv.lock` after the rename; the lockfile's `fray-test`
+     group entries (uv.lock:5359, 5398) become `test`.
+   - **Split `dev` into `dev` (tooling only) + `test` (test-only deps)**:
+     haliax, iris, rigging, finelog. Move pytest, pytest-asyncio,
+     pytest-xdist, pytest-cov, etc. from `dev` to a new `test` group;
+     leave linters, type checkers, and editor helpers in `dev`. If any
+     entry serves both roles, duplicate it (uv resolves dups
+     idempotently). haliax's `dev` is the largest and most heterogeneous
+     — flag in the PR description that humans should sanity-check the
+     split.
+   After this step, `uv sync --group test` works uniformly and no
+   per-member `[tool.marin.tests]` overrides `sync_groups`.
 5. **Re-evaluate haliax's `--with "jax[cpu]==0.9.2"` runtime pin
    (`haliax-unit.yaml:55`).** The lockfile already pins JAX. If the
    override is intentional (test haliax against the JAX version levanter
@@ -325,6 +419,16 @@ defensible and easier to review without the orchestrator change.
    `uv_run_args` in §2 carries it forward.
 6. **Drop `-c pyproject.toml`** from `haliax-unit.yaml:55`. Pytest
    auto-discovers config; the explicit `-c` is redundant.
+7. **Verify `PYTHONPATH` overrides become unnecessary.** Today four
+   workflows set `PYTHONPATH=tests:src:.` or `PYTHONPATH=tests:.`
+   (haliax/levanter/marin) — a vestige of `cd lib/<pkg>/` discipline
+   that the unified workflow eliminates (legs always run from repo
+   root with explicit `lib/<pkg>/tests/...` paths). Run the orchestrator
+   in shadow mode for one pass; if a test breaks because of `sys.path`
+   expectations, the per-member workaround is `env = { PYTHONPATH =
+   "lib/<pkg>/tests:lib/<pkg>/src" }`, but the better fix is updating
+   the test or its `conftest.py` to not rely on `sys.path` munging in
+   the first place.
 
 After Phase 0, the per-package YAMLs are simpler and the diff that
 introduces `marin-unit.yaml` becomes much easier to review.
@@ -335,6 +439,10 @@ introduces `marin-unit.yaml` becomes much easier to review.
   — root baseline must exist; surfaced by `test_marin_tests_config.py`.
 - `ConfigError("env value for <key> must be a string, got <type>")` —
   reject TOML ints/bools loudly.
+- `ConfigError("env value for <key> contains '=' or newline; not
+  representable in $GITHUB_ENV")` — the renderer can't encode such
+  values in the `env_lines` newline-delimited `KEY=VALUE` format used
+  to populate `$GITHUB_ENV`.
 - `ConfigError("setup_scripts entry not found: <path>")` — typo guard.
 - `ConfigError("python may only be set in workspace baseline, not in
   lib/<pkg>/pyproject.toml")` — packages cannot diverge on Python.
@@ -356,9 +464,14 @@ introduces `marin-unit.yaml` becomes much easier to review.
 
 ## 10. Migration plan
 
-**Phase 0 — cleanup PRs (5 small).** Each is an independently mergeable
+**Phase 0 — cleanup PRs (7 small).** Each is an independently mergeable
 change; land them before the orchestrator (§7). These shrink the
-existing seven YAMLs and make the orchestrator diff small.
+existing seven YAMLs and make the orchestrator diff small. A separate
+in-progress workspace effort to remove vestigial lazy imports is
+landing in parallel — that effort is independent (it doesn't block the
+orchestrator) but improves analyzer precision: the analyzer sees only
+top-level imports today, so eliminating dead lazy imports brings the
+test-impact graph closer to the runtime-import graph.
 
 **Phase 1 — shadow mode (1 PR).** Land `marin-unit.yaml` with
 `continue-on-error: true` on every step, alongside the existing six

--- a/.agents/projects/unified_unit_workflow/spec.md
+++ b/.agents/projects/unified_unit_workflow/spec.md
@@ -1,0 +1,337 @@
+# Spec — unified_unit_workflow
+
+The contracts implied by `design.md`. Reviewers should be able to read
+this and answer "would I actually build this exact API?"
+
+## 1. `[tool.marin.tests]` schema
+
+A new TOML table in each `lib/<pkg>/pyproject.toml` and the root
+`pyproject.toml` (which owns the top-level `tests/` directory the
+analyzer attributes to the `marin` scope — see §7). The schema is flat,
+typed, and small. Fields are optional unless marked required.
+
+```toml
+[tool.marin.tests]
+# uv package to sync (--package). Different from the directory name —
+# every workspace member is `marin-<dir>`. Required.
+sync_package = "marin-levanter"
+
+# Python interpreter version. Default = workspace default = "3.12".
+python = "3.11"
+
+# Working directory for the pytest invocation, relative to repo root.
+# "." (default) avoids the Ray uv-integration breakage that bites zephyr;
+# fray/iris today require "lib/<pkg>" — declare explicitly.
+working_dir = "."
+
+# Pass-through to `uv sync`. Anything legal for `uv sync` is legal here:
+# --frozen is added automatically; opt out via sync_frozen=false.
+# Examples: ["--extra", "torch_test", "--group", "test", "--dev",
+#           "--no-install-package", "torch"]
+sync_args = ["--extra", "torch_test", "--group", "test"]
+sync_frozen = true                          # default true; haliax sets false
+
+# Pass-through to `uv run` (NOT pytest). Goes between `uv run` and
+# `pytest`. Used by haliax for the runtime jax pin:
+#   ["--with", "jax[cpu]==0.9.2"]
+uv_run_args = []
+
+# pytest options. `markers` becomes `-m <markers>`; `pytest_args` is
+# everything else.
+markers = "not slow and not tpu and not tpu_ci"
+pytest_args = ["--durations=20", "-n", "4", "--dist", "worksteal",
+               "-c", "pyproject.toml"]
+
+# Repo-relative directories joined with ':' and exported as PYTHONPATH.
+# Empty list (default) leaves PYTHONPATH untouched.
+pythonpath = ["tests", "src", "."]
+
+# Process environment for the pytest step. TOML lets you write integers
+# but every value MUST be a string here — the loader rejects non-string
+# values loudly so engineers don't write `JAX_NUM_CPU_DEVICES = 8` and
+# silently get a no-op.
+env = { RAY_ENABLE_UV_RUN_RUNTIME_ENV = "0", PYTHONASYNCIODEBUG = "1" }
+
+# Optional. Repo-relative shell scripts run in order before the pytest
+# invocation. The CPU-torch-from-pytorch-wheelhouse dance lives at
+# infra/test_setup/install_torch_cpu.sh; new shared scripts go next to
+# it. NOT raw shell — the path is the contract; the script's content is
+# normal version-controlled bash that the orchestrator just executes.
+setup_scripts = ["infra/test_setup/install_torch_cpu.sh",
+                 "infra/test_setup/install_ffmpeg_apt.sh"]
+
+# Optional. Node version to install via actions/setup-node before the
+# pytest step. levanter, iris, and zephyr need this for their protobuf
+# generation in `uv sync`. Empty/missing skips Node setup.
+setup_node = "22"
+
+# Per-leg timeout in minutes. Default 15.
+timeout_minutes = 15
+```
+
+**Validation contract** (enforced by `tests/infra/test_marin_tests_config.py`):
+
+- Every `lib/<pkg>/pyproject.toml` and the root `pyproject.toml` MUST
+  have `[tool.marin.tests]`. A missing table is a CI-blocking error,
+  not a silent skip.
+- `python` matches `^3\.\d+$`.
+- All elements of `sync_args`, `uv_run_args`, `pytest_args`,
+  `pythonpath`, `setup_scripts` are non-empty strings.
+- All values in `env` are strings (TOML ints/bools rejected with a
+  precise error: "env value for `<key>` must be a string, got `<type>`").
+- Every path in `setup_scripts` resolves to an existing executable file
+  under the repo.
+
+## 2. Loader API
+
+`infra/marin_tests_config.py` (~120 lines):
+
+```python
+from dataclasses import dataclass, field
+from pathlib import Path
+
+@dataclass(frozen=True)
+class TestsConfig:
+    """Parsed [tool.marin.tests] for one scope (a lib package or marin-root).
+
+    Frozen; the orchestrator never mutates it.
+    """
+    sync_package: str
+    python: str = "3.12"
+    working_dir: str = "."
+    sync_args: tuple[str, ...] = ()
+    sync_frozen: bool = True
+    uv_run_args: tuple[str, ...] = ()
+    markers: str = ""
+    pytest_args: tuple[str, ...] = ()
+    pythonpath: tuple[str, ...] = ()
+    env: dict[str, str] = field(default_factory=dict)
+    setup_scripts: tuple[str, ...] = ()
+    setup_node: str | None = None
+    timeout_minutes: int = 15
+
+# Maps the analyzer's package names to the pyproject that owns them.
+# "marin" routes to the repo-root pyproject (which owns top-level tests/);
+# every other workspace package routes to lib/<pkg>/pyproject.toml.
+SCOPE_TO_PYPROJECT: dict[str, str] = {
+    "rigging": "lib/rigging/pyproject.toml",
+    "finelog": "lib/finelog/pyproject.toml",
+    "haliax": "lib/haliax/pyproject.toml",
+    "iris": "lib/iris/pyproject.toml",
+    "fray": "lib/fray/pyproject.toml",
+    "levanter": "lib/levanter/pyproject.toml",
+    "zephyr": "lib/zephyr/pyproject.toml",
+    "marin": "pyproject.toml",
+}
+
+def load(scope: str, repo_root: Path) -> TestsConfig: ...
+def load_all(repo_root: Path) -> dict[str, TestsConfig]: ...
+
+class ConfigError(Exception):
+    """Raised when [tool.marin.tests] is missing or malformed."""
+```
+
+Note the deliberate **one-config-per-scope** rule: `lib/marin/pyproject.toml`
+does NOT carry a `[tool.marin.tests]` table; the analyzer attributes
+top-level `tests/` to the `marin` scope, and the root pyproject owns
+that scope. The validation test enforces both directions (every scope
+in `SCOPE_TO_PYPROJECT` has a table; no extras).
+
+## 3. Orchestrator workflow shape (`marin-unit.yaml`)
+
+Three jobs:
+
+```yaml
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      force_run_all:
+        description: "Bypass the analyzer; run every package's full suite."
+        type: boolean
+        default: false
+
+concurrency:
+  group: marin-unit-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  select:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.analyze.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v5
+        with: { fetch-depth: 0 }
+      - uses: astral-sh/setup-uv@v7
+      - run: uv sync --group dev   # installs grimp
+      - id: analyze
+        run: |
+          # Resolve base ref:
+          #   PR  -> github.event.pull_request.base.sha
+          #   push to main -> github.event.before
+          #   workflow_dispatch with force_run_all -> --force-run-all
+          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before }}"
+          ARGS=(--base-ref "$BASE_REF" --emit-github-output)
+          if [ "${{ inputs.force_run_all }}" = "true" ]; then
+            ARGS=(--force-run-all --emit-github-output)
+          fi
+          uv run python infra/select_tests.py "${ARGS[@]}"
+
+  unit:
+    needs: select
+    if: ${{ needs.select.outputs.matrix != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.select.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ fromJSON(needs.select.outputs.matrix)[matrix.index].timeout_minutes || 15 }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
+      - id: render
+        # Reads [tool.marin.tests], writes:
+        #   $RUNNER_TEMP/test-leg/setup.sh    (concatenated setup_scripts)
+        #   $RUNNER_TEMP/test-leg/pytest.sh   (cd + uv run pytest one-liner)
+        # Emits: python_version, sync_args (as a single string), node_version,
+        # env_lines (KEY=VAL\nKEY=VAL...).
+        run: |
+          uv run python infra/run_tests.py prepare \
+            "${{ matrix.package }}" \
+            --tests "${{ join(matrix.tests, ' ') }}" \
+            --out-dir "$RUNNER_TEMP/test-leg"
+      - uses: actions/setup-node@v4
+        if: steps.render.outputs.node_version != ''
+        with: { node-version: ${{ steps.render.outputs.node_version }} }
+      - run: uv python install ${{ steps.render.outputs.python_version }}
+      - run: |
+          # Lift env into $GITHUB_ENV so every subsequent step sees it.
+          echo "${{ steps.render.outputs.env_lines }}" >> "$GITHUB_ENV"
+      - run: bash "$RUNNER_TEMP/test-leg/setup.sh"
+      - run: uv sync ${{ steps.render.outputs.sync_args }}
+      - run: bash "$RUNNER_TEMP/test-leg/pytest.sh"
+
+  aggregate:
+    needs: unit
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          case "${{ needs.unit.result }}" in
+            success|skipped) exit 0 ;;
+            *) exit 1 ;;
+          esac
+```
+
+**Contract:**
+
+- `marin-unit` is the single status check branch protection requires.
+  `aggregate` exits 0 on `success` (some legs ran, all passed) or
+  `skipped` (analyzer emitted empty matrix); exits 1 on `failure` /
+  `cancelled`.
+- `infra/select_tests.py` gains two flags: `--emit-github-output`
+  (writes `matrix=<json>` to `$GITHUB_OUTPUT`) and `--force-run-all`
+  (skips the diff, emits a full-suite matrix as if every package were
+  affected).
+- `run_all: true` lowers to a matrix where every package appears with
+  `tests: []` (full-suite signal); the orchestrator does not need a
+  separate code path.
+- `infra/run_tests.py prepare` (~120 lines) is the renderer. It writes
+  shell scripts into a temp dir rather than emitting them as outputs —
+  GitHub Actions outputs cannot reliably carry multi-line shell, and
+  levanter's torch wheel install is genuinely 25 lines. Scripts are
+  executable, traceable in CI logs, and invokable locally.
+
+## 4. File-path summary
+
+| Path | Status | Purpose |
+|---|---|---|
+| `infra/select_tests.py` | exists | Analyzer; gains `--emit-github-output` and `--force-run-all` flags (~20 lines) |
+| `infra/marin_tests_config.py` | new | Loader + dataclass; ~120 lines |
+| `infra/run_tests.py` | new | Renders `TestsConfig` + matrix entry into shell scripts; ~120 lines |
+| `infra/test_setup/install_torch_cpu.sh` | new | Lifted from `levanter-unit.yaml:119-146` verbatim |
+| `infra/test_setup/install_ffmpeg_apt.sh` | new | Lifted from `levanter-unit.yaml:149-151` |
+| `tests/infra/test_select_tests.py` | exists | 25 tests; unchanged |
+| `tests/infra/test_marin_tests_config.py` | new | Schema validation; asserts every `SCOPE_TO_PYPROJECT` entry has a table; ~70 lines |
+| `tests/infra/test_run_tests.py` | new | Renders a fixture `TestsConfig`, asserts the script content; ~50 lines |
+| `lib/<pkg>/pyproject.toml` (×7 lib packages) | edit | Each gains `[tool.marin.tests]` |
+| `pyproject.toml` (root) | edit | Gains `[tool.marin.tests]` for the top-level `tests/` dir (the marin scope) |
+| `.github/workflows/marin-unit.yaml` | rewrite | New three-job orchestrator |
+| `.github/workflows/{haliax,levanter,iris,zephyr,fray}-unit.yaml` | delete | 5 deletions; subsumed by `marin-unit` |
+| `.github/workflows/levanter-tpu-tests.yaml` | new | Extracted from `levanter-unit.yaml:159-227` verbatim |
+| `.github/workflows/dupekit-unit.yaml` | unchanged | Rust+Python hybrid stays standalone |
+| `.github/workflows/marin-integration.yaml` | edit | Absorbs `iris-e2e-smoke` from `iris-unit.yaml:65-131` |
+
+## 5. Errors
+
+- `ConfigError("missing [tool.marin.tests] in <path>")` — every scope in
+  `SCOPE_TO_PYPROJECT` must opt in. Surfaced by
+  `test_marin_tests_config.py`; blocks merge.
+- `ConfigError("env value for <key> must be a string, got <type>")` —
+  GitHub Actions env values are strings; reject TOML ints/bools at
+  config-load time.
+- `ConfigError("setup_scripts entry not found: <path>")` — scripts must
+  exist on disk; typo-guard.
+- `ConfigError("invalid python version: <value>")` — must match
+  `^3\.\d+$`.
+
+## 6. Out of scope
+
+- **`dupekit-unit.yaml`** stays as written. Rust toolchain + 3-version
+  Python matrix doesn't fit the analyzer.
+- **`levanter-tpu-tests.yaml`** stays separate. Future migration onto
+  the Iris prod cluster can adopt `[tool.marin.tests]` later.
+- **`marin-canary-*.yaml`, `marin-release-*.yaml`, `iris-smoke-*.yaml`**,
+  scheduled triage jobs — not unit tests.
+- **Coverage-based test selection** — explicitly rejected per prior art
+  (testmon-style cache invalidation hides regressions).
+- **Per-package Python version matrix** — each scope picks one Python.
+  Multi-version testing is a `dupekit` need that lives in
+  `dupekit-unit.yaml`.
+- **Caching of `uv sync` between matrix legs** — `astral-sh/setup-uv`'s
+  built-in cache handles it; no orchestrator-level cache logic.
+- **Test sharding within a package** — one matrix leg per package. If a
+  single package's full suite ever outgrows the runner's wall clock,
+  sharding can be added as a `shard_count` field; not needed today.
+
+## 7. Migration plan
+
+Phased rollout, each phase reversible until the last.
+
+**Phase 1 — shadow mode (1 PR).** Land `marin-unit.yaml` with
+`continue-on-error: true` on every step, alongside the existing seven
+`*-unit.yaml` files (which remain required). Analyzer + matrix shape
+verified against real PRs; failures don't block merge. Workflow_dispatch
+input `force_run_all` available for spot-checks. Live for ~1 week.
+
+**Phase 2 — required, parallel (1 PR).** Drop `continue-on-error`. New
+workflow's `marin-unit` aggregate status becomes a *non-required* check
+in branch protection — visible to reviewers but not gating. Old YAMLs
+still run and still gate. Live for ~3-7 days; compare false-positive /
+false-negative rates against the old workflows on real PRs.
+
+**Phase 3 — switch (1 PR + 1 admin step).** GitHub-admin sequence is
+load-bearing and cannot be a single PR:
+
+1. **Admin** removes `haliax-unit / levanter-unit / iris-unit /
+   zephyr-unit / fray-unit / marin-unit (old name) / dupekit-unit` from
+   branch-protection required-checks.
+2. **PR merges**: deletes the five obsolete `*-unit.yaml` files; adds
+   `levanter-tpu-tests.yaml`; edits `marin-integration.yaml` to absorb
+   `iris-e2e-smoke`. CI on the PR runs `marin-unit` + `marin-integration`
+   + the unrelated checks.
+3. **Admin** adds the new `marin-unit` aggregate status as required on
+   `main`.
+
+**Rollback.** Before Phase 3, tag the pre-deletion main branch as
+`legacy/unit-workflows-<YYYYMMDD>`. If the new workflow is unstable in
+production, cherry-pick the seven YAMLs back from the tag in a single
+PR; admin re-adds the old required checks.
+
+**Audit before Phase 3.** Search the repo for `needs: <old-job-name>`
+and `requires: <old-job-name>` in case any scheduled / canary / release
+workflow has a status-check dependency on a soon-to-be-deleted job
+name. Currently I see none, but verifying is part of Phase 2.

--- a/.agents/projects/unified_unit_workflow/spec.md
+++ b/.agents/projects/unified_unit_workflow/spec.md
@@ -3,88 +3,111 @@
 The contracts implied by `design.md`. Reviewers should be able to read
 this and answer "would I actually build this exact API?"
 
-## 1. `[tool.marin.tests]` schema
+The schema is **convention with overrides**: a baseline that covers most
+packages with no per-package config, plus a tiny `[tool.marin.tests]`
+table for the genuinely different packages. Most workspace members will
+have *no* table.
 
-A new TOML table in each `lib/<pkg>/pyproject.toml` and the root
-`pyproject.toml` (which owns the top-level `tests/` directory the
-analyzer attributes to the `marin` scope — see §7). The schema is flat,
-typed, and small. Fields are optional unless marked required.
+## 1. Workspace baseline (the convention)
+
+Every test leg runs as if these defaults applied — the orchestrator does
+not look at any `[tool.marin.tests]` for these:
+
+| Concern | Default |
+|---|---|
+| Python | `3.12` (workspace-wide; pinned in `pyproject.toml` `[tool.marin.tests.workspace]`) |
+| `uv sync` | `uv sync --frozen --package marin-<dir> --group test` (where `<dir>` is the `lib/<dir>` directory name; for the marin scope = `--package marin --group test`) |
+| `uv run` | `uv run` with no extra flags |
+| `pytest` markers | `not slow and not tpu and not tpu_ci` |
+| `pytest` extra args | `["--durations=5", "-n", "auto", "--tb=short"]` |
+| `pythonpath` | unset (don't override) |
+| `env` | empty (no extras) |
+| `setup_scripts` | none |
+| `setup_node` | none |
+| Working directory | repo root (always — no `cd lib/<pkg>`) |
+| `timeout_minutes` | 15 |
+
+Workspace baseline lives in the **root** `pyproject.toml`:
 
 ```toml
+[tool.marin.tests.workspace]
+python = "3.12"
+markers = "not slow and not tpu and not tpu_ci"
+pytest_args = ["--durations=5", "-n", "auto", "--tb=short"]
+sync_groups = ["test"]
+```
+
+A package opts out of any default by writing the corresponding field in
+its own `[tool.marin.tests]` (see §2). Otherwise the workspace baseline
+applies.
+
+## 2. Per-package override schema
+
+A new optional TOML table in `lib/<pkg>/pyproject.toml`. Each field
+overrides the workspace baseline; absent fields inherit. The schema
+exists so a small number of packages can express genuinely-needed
+deltas, not so every package re-declares the baseline.
+
+```toml
+# Optional. Most packages do NOT need this table.
 [tool.marin.tests]
-# uv package to sync (--package). Different from the directory name —
-# every workspace member is `marin-<dir>`. Required.
-sync_package = "marin-levanter"
+# uv sync extras (--extra X, repeated). Default: [].
+# levanter uses ["torch_test"]; marin uses ["cpu", "dedup"].
+sync_extras = ["torch_test"]
 
-# Python interpreter version. Default = workspace default = "3.12".
-python = "3.11"
+# uv sync groups (--group X, repeated). Default: ["test"].
+# Override is for packages that use a non-"test" group name (haliax: "dev",
+# fray: "fray-test").
+sync_groups = ["test"]
 
-# Working directory for the pytest invocation, relative to repo root.
-# "." (default) avoids the Ray uv-integration breakage that bites zephyr;
-# fray/iris today require "lib/<pkg>" — declare explicitly.
-working_dir = "."
+# Extra `uv sync` args beyond the standard ones (--frozen, --package, --extra,
+# --group). Reach for this only when the workspace baseline + the typed
+# fields above can't express what you need. levanter torch uses
+# ["--no-install-package", "torch"]. Default: [].
+sync_extra_args = []
 
-# Pass-through to `uv sync`. Anything legal for `uv sync` is legal here:
-# --frozen is added automatically; opt out via sync_frozen=false.
-# Examples: ["--extra", "torch_test", "--group", "test", "--dev",
-#           "--no-install-package", "torch"]
-sync_args = ["--extra", "torch_test", "--group", "test"]
-sync_frozen = true                          # default true; haliax sets false
-
-# Pass-through to `uv run` (NOT pytest). Goes between `uv run` and
-# `pytest`. Used by haliax for the runtime jax pin:
-#   ["--with", "jax[cpu]==0.9.2"]
+# Args passed between `uv run` and `pytest`. Default: [].
+# haliax temporarily uses ["--with", "jax[cpu]==0.9.2"] (see Phase 0 cleanup).
 uv_run_args = []
 
-# pytest options. `markers` becomes `-m <markers>`; `pytest_args` is
-# everything else.
-markers = "not slow and not tpu and not tpu_ci"
-pytest_args = ["--durations=20", "-n", "4", "--dist", "worksteal",
-               "-c", "pyproject.toml"]
+# pytest -m. Default: workspace baseline.
+markers = "not slow and not tpu"
 
-# Repo-relative directories joined with ':' and exported as PYTHONPATH.
-# Empty list (default) leaves PYTHONPATH untouched.
-pythonpath = ["tests", "src", "."]
+# Extra pytest args appended to the workspace defaults. Default: [].
+pytest_args = ["-n", "4", "--dist", "worksteal"]
 
-# Process environment for the pytest step. TOML lets you write integers
-# but every value MUST be a string here — the loader rejects non-string
-# values loudly so engineers don't write `JAX_NUM_CPU_DEVICES = 8` and
-# silently get a no-op.
-env = { RAY_ENABLE_UV_RUN_RUNTIME_ENV = "0", PYTHONASYNCIODEBUG = "1" }
+# Process env for the pytest step. All values must be strings (TOML ints
+# rejected loudly so JAX_NUM_CPU_DEVICES = 8 doesn't silently become a no-op).
+# Default: {}.
+env = { JAX_NUM_CPU_DEVICES = "8", PYTHONASYNCIODEBUG = "1" }
 
-# Optional. Repo-relative shell scripts run in order before the pytest
-# invocation. The CPU-torch-from-pytorch-wheelhouse dance lives at
-# infra/test_setup/install_torch_cpu.sh; new shared scripts go next to
-# it. NOT raw shell — the path is the contract; the script's content is
-# normal version-controlled bash that the orchestrator just executes.
-setup_scripts = ["infra/test_setup/install_torch_cpu.sh",
-                 "infra/test_setup/install_ffmpeg_apt.sh"]
+# Repo-relative shell scripts run before the pytest invocation, in order.
+# Used for the levanter CPU-torch wheel install. Default: [].
+setup_scripts = ["infra/test_setup/install_torch_cpu.sh"]
 
-# Optional. Node version to install via actions/setup-node before the
-# pytest step. levanter, iris, and zephyr need this for their protobuf
-# generation in `uv sync`. Empty/missing skips Node setup.
+# Node version for `actions/setup-node`. Some packages need Node during
+# `uv sync` for protobuf generation. Default: not installed.
 setup_node = "22"
 
-# Per-leg timeout in minutes. Default 15.
+# Per-leg timeout. Default: 15.
 timeout_minutes = 15
 ```
 
 **Validation contract** (enforced by `tests/infra/test_marin_tests_config.py`):
 
-- Every `lib/<pkg>/pyproject.toml` and the root `pyproject.toml` MUST
-  have `[tool.marin.tests]`. A missing table is a CI-blocking error,
-  not a silent skip.
-- `python` matches `^3\.\d+$`.
-- All elements of `sync_args`, `uv_run_args`, `pytest_args`,
-  `pythonpath`, `setup_scripts` are non-empty strings.
-- All values in `env` are strings (TOML ints/bools rejected with a
-  precise error: "env value for `<key>` must be a string, got `<type>`").
-- Every path in `setup_scripts` resolves to an existing executable file
-  under the repo.
+- Workspace baseline at `[tool.marin.tests.workspace]` MUST exist with
+  `python` set; missing baseline is a CI-blocking error.
+- Per-package `[tool.marin.tests]` is optional; absent table = pure
+  baseline.
+- All env values are strings; TOML ints/bools rejected with
+  `ConfigError("env value for <key> must be a string, got <type>")`.
+- Every path in `setup_scripts` resolves to an existing executable file.
+- `python` cannot be set in a per-package table — the workspace pins one
+  version for everyone (rejected with a precise error).
 
-## 2. Loader API
+## 3. Loader API
 
-`infra/marin_tests_config.py` (~120 lines):
+`infra/marin_tests_config.py` (~80 lines):
 
 ```python
 from dataclasses import dataclass, field
@@ -92,52 +115,64 @@ from pathlib import Path
 
 @dataclass(frozen=True)
 class TestsConfig:
-    """Parsed [tool.marin.tests] for one scope (a lib package or marin-root).
-
-    Frozen; the orchestrator never mutates it.
+    """Resolved test config for one scope (workspace baseline merged with
+    any per-package overrides). Frozen; the orchestrator never mutates it.
     """
-    sync_package: str
-    python: str = "3.12"
-    working_dir: str = "."
-    sync_args: tuple[str, ...] = ()
-    sync_frozen: bool = True
+    package: str                              # short name, e.g. "levanter"
+    sync_package: str                         # uv name, e.g. "marin-levanter"
+    python: str                               # always = workspace.python
+    sync_extras: tuple[str, ...] = ()
+    sync_groups: tuple[str, ...] = ("test",)
+    sync_extra_args: tuple[str, ...] = ()
     uv_run_args: tuple[str, ...] = ()
     markers: str = ""
     pytest_args: tuple[str, ...] = ()
-    pythonpath: tuple[str, ...] = ()
     env: dict[str, str] = field(default_factory=dict)
     setup_scripts: tuple[str, ...] = ()
     setup_node: str | None = None
     timeout_minutes: int = 15
 
 # Maps the analyzer's package names to the pyproject that owns them.
-# "marin" routes to the repo-root pyproject (which owns top-level tests/);
-# every other workspace package routes to lib/<pkg>/pyproject.toml.
 SCOPE_TO_PYPROJECT: dict[str, str] = {
-    "rigging": "lib/rigging/pyproject.toml",
-    "finelog": "lib/finelog/pyproject.toml",
-    "haliax": "lib/haliax/pyproject.toml",
-    "iris": "lib/iris/pyproject.toml",
-    "fray": "lib/fray/pyproject.toml",
+    "rigging":  "lib/rigging/pyproject.toml",
+    "finelog":  "lib/finelog/pyproject.toml",
+    "haliax":   "lib/haliax/pyproject.toml",
+    "iris":     "lib/iris/pyproject.toml",
+    "fray":     "lib/fray/pyproject.toml",
     "levanter": "lib/levanter/pyproject.toml",
-    "zephyr": "lib/zephyr/pyproject.toml",
-    "marin": "pyproject.toml",
+    "zephyr":   "lib/zephyr/pyproject.toml",
+    "marin":    "pyproject.toml",            # root owns top-level tests/
 }
 
-def load(scope: str, repo_root: Path) -> TestsConfig: ...
-def load_all(repo_root: Path) -> dict[str, TestsConfig]: ...
+def resolve(scope: str, repo_root: Path) -> TestsConfig:
+    """Load the workspace baseline, merge any per-package override, return
+    the fully-resolved config. Raises ConfigError on schema violation."""
 
-class ConfigError(Exception):
-    """Raised when [tool.marin.tests] is missing or malformed."""
+def resolve_all(repo_root: Path) -> dict[str, TestsConfig]: ...
+
+class ConfigError(Exception): ...
 ```
 
-Note the deliberate **one-config-per-scope** rule: `lib/marin/pyproject.toml`
-does NOT carry a `[tool.marin.tests]` table; the analyzer attributes
-top-level `tests/` to the `marin` scope, and the root pyproject owns
-that scope. The validation test enforces both directions (every scope
-in `SCOPE_TO_PYPROJECT` has a table; no extras).
+`sync_package` is **derived**, not declared. The convention is
+`marin-<dir>` for `lib/<dir>/pyproject.toml` and `marin` for the root.
 
-## 3. Orchestrator workflow shape (`marin-unit.yaml`)
+## 4. Concrete per-package configs after Phase 0 cleanup
+
+This is what each package's table actually looks like under the new
+scheme. Four packages need no table; the rest carry small deltas.
+
+| Package | `[tool.marin.tests]` |
+|---|---|
+| `rigging` | (no table — pure baseline) |
+| `finelog` | (no table) |
+| `zephyr` | (no table) |
+| `fray` | (no table — `fray_test` group renamed to `test` in Phase 0) |
+| `iris` | `env = { PYTHONASYNCIODEBUG = "1" }` |
+| `haliax` | `uv_run_args = ["--with", "jax[cpu]==0.9.2"]` + `env = { JAX_NUM_CPU_DEVICES = "8" }` if the Phase 0 review keeps the JAX override; otherwise no table |
+| `levanter` | `sync_extras = ["torch_test"]`, `sync_extra_args = ["--no-install-package", "torch"]`, `setup_scripts = ["infra/test_setup/install_torch_cpu.sh", "infra/test_setup/install_ffmpeg_apt.sh"]`, `setup_node = "22"` |
+| `marin` | `sync_extras = ["cpu", "dedup"]`, `pytest_args = ["-n", "4", "--dist", "worksteal"]` |
+
+## 5. Orchestrator workflow shape (`marin-unit.yaml`)
 
 Three jobs:
 
@@ -169,10 +204,9 @@ jobs:
       - run: uv sync --group dev   # installs grimp
       - id: analyze
         run: |
-          # Resolve base ref:
-          #   PR  -> github.event.pull_request.base.sha
-          #   push to main -> github.event.before
-          #   workflow_dispatch with force_run_all -> --force-run-all
+          # PR  -> github.event.pull_request.base.sha
+          # push to main -> github.event.before
+          # workflow_dispatch with force_run_all=true -> --force-run-all
           BASE_REF="${{ github.event.pull_request.base.sha || github.event.before }}"
           ARGS=(--base-ref "$BASE_REF" --emit-github-output)
           if [ "${{ inputs.force_run_all }}" = "true" ]; then
@@ -188,31 +222,29 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.select.outputs.matrix) }}
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ fromJSON(needs.select.outputs.matrix)[matrix.index].timeout_minutes || 15 }}
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v7
       - id: render
         # Reads [tool.marin.tests], writes:
-        #   $RUNNER_TEMP/test-leg/setup.sh    (concatenated setup_scripts)
-        #   $RUNNER_TEMP/test-leg/pytest.sh   (cd + uv run pytest one-liner)
-        # Emits: python_version, sync_args (as a single string), node_version,
-        # env_lines (KEY=VAL\nKEY=VAL...).
+        #   $RUNNER_TEMP/leg/setup.sh    (concatenated setup_scripts)
+        #   $RUNNER_TEMP/leg/pytest.sh   (uv run [args] pytest [args] tests)
+        # Emits: python_version, sync_args, node_version, env_lines.
         run: |
           uv run python infra/run_tests.py prepare \
             "${{ matrix.package }}" \
             --tests "${{ join(matrix.tests, ' ') }}" \
-            --out-dir "$RUNNER_TEMP/test-leg"
+            --out-dir "$RUNNER_TEMP/leg"
       - uses: actions/setup-node@v4
         if: steps.render.outputs.node_version != ''
         with: { node-version: ${{ steps.render.outputs.node_version }} }
       - run: uv python install ${{ steps.render.outputs.python_version }}
       - run: |
-          # Lift env into $GITHUB_ENV so every subsequent step sees it.
           echo "${{ steps.render.outputs.env_lines }}" >> "$GITHUB_ENV"
-      - run: bash "$RUNNER_TEMP/test-leg/setup.sh"
+      - run: bash "$RUNNER_TEMP/leg/setup.sh"
       - run: uv sync ${{ steps.render.outputs.sync_args }}
-      - run: bash "$RUNNER_TEMP/test-leg/pytest.sh"
+      - run: bash "$RUNNER_TEMP/leg/pytest.sh"
 
   aggregate:
     needs: unit
@@ -229,109 +261,127 @@ jobs:
 **Contract:**
 
 - `marin-unit` is the single status check branch protection requires.
-  `aggregate` exits 0 on `success` (some legs ran, all passed) or
-  `skipped` (analyzer emitted empty matrix); exits 1 on `failure` /
-  `cancelled`.
-- `infra/select_tests.py` gains two flags: `--emit-github-output`
-  (writes `matrix=<json>` to `$GITHUB_OUTPUT`) and `--force-run-all`
-  (skips the diff, emits a full-suite matrix as if every package were
-  affected).
+- `infra/select_tests.py` gains `--emit-github-output` and
+  `--force-run-all` (~20 lines).
 - `run_all: true` lowers to a matrix where every package appears with
-  `tests: []` (full-suite signal); the orchestrator does not need a
-  separate code path.
-- `infra/run_tests.py prepare` (~120 lines) is the renderer. It writes
-  shell scripts into a temp dir rather than emitting them as outputs —
-  GitHub Actions outputs cannot reliably carry multi-line shell, and
-  levanter's torch wheel install is genuinely 25 lines. Scripts are
-  executable, traceable in CI logs, and invokable locally.
+  `tests: []` (full suite signal); orchestrator does not need a separate
+  code path.
+- Multi-line shell goes into `$RUNNER_TEMP/leg/*.sh`, never into
+  `$GITHUB_OUTPUT` (levanter's torch wheel install is genuinely 25
+  lines).
+- The leg always runs from repo root; pytest is invoked with explicit
+  paths (`lib/<pkg>/tests/<file>` from the analyzer or `lib/<pkg>/tests`
+  for full suite). No `cd`.
 
-## 4. File-path summary
+## 6. File-path summary
 
 | Path | Status | Purpose |
 |---|---|---|
-| `infra/select_tests.py` | exists | Analyzer; gains `--emit-github-output` and `--force-run-all` flags (~20 lines) |
-| `infra/marin_tests_config.py` | new | Loader + dataclass; ~120 lines |
+| `infra/select_tests.py` | exists | Analyzer; gains `--emit-github-output` and `--force-run-all` flags |
+| `infra/marin_tests_config.py` | new | Loader + dataclass; ~80 lines |
 | `infra/run_tests.py` | new | Renders `TestsConfig` + matrix entry into shell scripts; ~120 lines |
-| `infra/test_setup/install_torch_cpu.sh` | new | Lifted from `levanter-unit.yaml:119-146` verbatim |
+| `infra/test_setup/install_torch_cpu.sh` | new | Lifted from `levanter-unit.yaml:119-146` |
 | `infra/test_setup/install_ffmpeg_apt.sh` | new | Lifted from `levanter-unit.yaml:149-151` |
-| `tests/infra/test_select_tests.py` | exists | 25 tests; unchanged |
-| `tests/infra/test_marin_tests_config.py` | new | Schema validation; asserts every `SCOPE_TO_PYPROJECT` entry has a table; ~70 lines |
-| `tests/infra/test_run_tests.py` | new | Renders a fixture `TestsConfig`, asserts the script content; ~50 lines |
-| `lib/<pkg>/pyproject.toml` (×7 lib packages) | edit | Each gains `[tool.marin.tests]` |
-| `pyproject.toml` (root) | edit | Gains `[tool.marin.tests]` for the top-level `tests/` dir (the marin scope) |
-| `.github/workflows/marin-unit.yaml` | rewrite | New three-job orchestrator |
-| `.github/workflows/{haliax,levanter,iris,zephyr,fray}-unit.yaml` | delete | 5 deletions; subsumed by `marin-unit` |
+| `tests/infra/test_select_tests.py` | exists | 25 tests |
+| `tests/infra/test_marin_tests_config.py` | new | Schema + baseline + override-merge tests; ~80 lines |
+| `tests/infra/test_run_tests.py` | new | Asserts rendered script content for fixture configs; ~50 lines |
+| `lib/<pkg>/pyproject.toml` (3 of 7 lib packages) | edit | iris, haliax, levanter, fray, marin gain a small table; rigging/finelog/zephyr untouched |
+| `pyproject.toml` (root) | edit | Adds `[tool.marin.tests.workspace]` baseline |
+| `.github/workflows/marin-unit.yaml` | rewrite | Three-job orchestrator |
+| `.github/workflows/{haliax,levanter,iris,zephyr,fray}-unit.yaml` | delete | 5 deletions |
 | `.github/workflows/levanter-tpu-tests.yaml` | new | Extracted from `levanter-unit.yaml:159-227` verbatim |
 | `.github/workflows/dupekit-unit.yaml` | unchanged | Rust+Python hybrid stays standalone |
 | `.github/workflows/marin-integration.yaml` | edit | Absorbs `iris-e2e-smoke` from `iris-unit.yaml:65-131` |
 
-## 5. Errors
+## 7. Phase 0 cleanup (delete the cruft first)
 
-- `ConfigError("missing [tool.marin.tests] in <path>")` — every scope in
-  `SCOPE_TO_PYPROJECT` must opt in. Surfaced by
-  `test_marin_tests_config.py`; blocks merge.
+Land **before** the orchestrator goes live; each is independently
+defensible and easier to review without the orchestrator change.
+
+1. **Delete `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0`** from `marin-unit.yaml:69`
+   and the "don't cd lib/zephyr so Ray uv integration doesn't freak out"
+   comment from `zephyr-unit.yaml:65`. Confirmed dead: zero `import ray`
+   or `ray.init()` calls anywhere in `lib/`.
+2. **Delete `-n1`** from `iris-unit.yaml:63`. iris doesn't actually need
+   single-process; switch to `-n auto` like the rest of the workspace.
+3. **Standardize on Python 3.12.** `haliax-unit.yaml:47` and
+   `levanter-unit.yaml:47` set 3.11; every package's `requires-python`
+   allows 3.12 (`lib/haliax/pyproject.toml:8`, `lib/levanter/pyproject.toml:8`,
+   etc.). Bump both workflows to 3.12.
+4. **Standardize the test dependency-group name to `test`** across every
+   `lib/<pkg>/pyproject.toml` `[dependency-groups]` table. Today:
+   levanter, zephyr, marin already have a `test` group; haliax, iris,
+   rigging, finelog put test deps under `dev` (or have no test group at
+   all); fray uses `fray_test`. Split or rename so `uv sync --group
+   test` works uniformly — pure dev-tooling stays under `dev`, test-only
+   deps move to `test`. After this, `sync_groups` defaults to `["test"]`
+   and no package overrides it.
+5. **Re-evaluate haliax's `--with "jax[cpu]==0.9.2"` runtime pin
+   (`haliax-unit.yaml:55`).** The lockfile already pins JAX. If the
+   override is intentional (test haliax against the JAX version levanter
+   uses), tighten haliax's `pyproject.toml` `jax >= 0.8.0` to
+   `jax >= 0.9.2,<0.11` and drop the override. If it's not, just drop
+   it. If it's neither and reviewers want to keep the override,
+   `uv_run_args` in §2 carries it forward.
+6. **Drop `-c pyproject.toml`** from `haliax-unit.yaml:55`. Pytest
+   auto-discovers config; the explicit `-c` is redundant.
+
+After Phase 0, the per-package YAMLs are simpler and the diff that
+introduces `marin-unit.yaml` becomes much easier to review.
+
+## 8. Errors
+
+- `ConfigError("missing [tool.marin.tests.workspace] in pyproject.toml")`
+  — root baseline must exist; surfaced by `test_marin_tests_config.py`.
 - `ConfigError("env value for <key> must be a string, got <type>")` —
-  GitHub Actions env values are strings; reject TOML ints/bools at
-  config-load time.
-- `ConfigError("setup_scripts entry not found: <path>")` — scripts must
-  exist on disk; typo-guard.
-- `ConfigError("invalid python version: <value>")` — must match
-  `^3\.\d+$`.
+  reject TOML ints/bools loudly.
+- `ConfigError("setup_scripts entry not found: <path>")` — typo guard.
+- `ConfigError("python may only be set in workspace baseline, not in
+  lib/<pkg>/pyproject.toml")` — packages cannot diverge on Python.
 
-## 6. Out of scope
+## 9. Out of scope
 
-- **`dupekit-unit.yaml`** stays as written. Rust toolchain + 3-version
-  Python matrix doesn't fit the analyzer.
+- **`dupekit-unit.yaml`** stays as written.
 - **`levanter-tpu-tests.yaml`** stays separate. Future migration onto
-  the Iris prod cluster can adopt `[tool.marin.tests]` later.
+  the Iris prod cluster can adopt this schema later.
 - **`marin-canary-*.yaml`, `marin-release-*.yaml`, `iris-smoke-*.yaml`**,
-  scheduled triage jobs — not unit tests.
-- **Coverage-based test selection** — explicitly rejected per prior art
-  (testmon-style cache invalidation hides regressions).
-- **Per-package Python version matrix** — each scope picks one Python.
-  Multi-version testing is a `dupekit` need that lives in
-  `dupekit-unit.yaml`.
-- **Caching of `uv sync` between matrix legs** — `astral-sh/setup-uv`'s
-  built-in cache handles it; no orchestrator-level cache logic.
-- **Test sharding within a package** — one matrix leg per package. If a
-  single package's full suite ever outgrows the runner's wall clock,
-  sharding can be added as a `shard_count` field; not needed today.
+  scheduled triage — not unit tests.
+- **Coverage-based test selection** (testmon, etc.) — explicitly
+  rejected.
+- **Per-package Python version matrix** — workspace pins one version.
+  Multi-version testing is a `dupekit` need handled by `dupekit-unit.yaml`.
+- **Test sharding within a package** — one matrix leg per package.
+- **`uv sync` cache key tuning** — `astral-sh/setup-uv`'s default cache
+  is good enough.
 
-## 7. Migration plan
+## 10. Migration plan
 
-Phased rollout, each phase reversible until the last.
+**Phase 0 — cleanup PRs (5 small).** Each is an independently mergeable
+change; land them before the orchestrator (§7). These shrink the
+existing seven YAMLs and make the orchestrator diff small.
 
 **Phase 1 — shadow mode (1 PR).** Land `marin-unit.yaml` with
-`continue-on-error: true` on every step, alongside the existing seven
-`*-unit.yaml` files (which remain required). Analyzer + matrix shape
-verified against real PRs; failures don't block merge. Workflow_dispatch
-input `force_run_all` available for spot-checks. Live for ~1 week.
+`continue-on-error: true` on every step, alongside the existing six
+remaining `*-unit.yaml` files (still required). Workflow_dispatch input
+`force_run_all` is available for spot-checks. ~1 week of live data.
 
 **Phase 2 — required, parallel (1 PR).** Drop `continue-on-error`. New
-workflow's `marin-unit` aggregate status becomes a *non-required* check
-in branch protection — visible to reviewers but not gating. Old YAMLs
-still run and still gate. Live for ~3-7 days; compare false-positive /
-false-negative rates against the old workflows on real PRs.
+`marin-unit` aggregate becomes a *non-required* check; old YAMLs still
+gate. Compare false-positive / false-negative rates on real PRs.
+~3-7 days. Audit step: grep all workflows for `needs:` references to
+job names that are about to disappear.
 
-**Phase 3 — switch (1 PR + 1 admin step).** GitHub-admin sequence is
-load-bearing and cannot be a single PR:
+**Phase 3 — switch (1 PR + admin steps).** GitHub-admin sequence is
+load-bearing:
 
-1. **Admin** removes `haliax-unit / levanter-unit / iris-unit /
-   zephyr-unit / fray-unit / marin-unit (old name) / dupekit-unit` from
-   branch-protection required-checks.
-2. **PR merges**: deletes the five obsolete `*-unit.yaml` files; adds
-   `levanter-tpu-tests.yaml`; edits `marin-integration.yaml` to absorb
-   `iris-e2e-smoke`. CI on the PR runs `marin-unit` + `marin-integration`
-   + the unrelated checks.
-3. **Admin** adds the new `marin-unit` aggregate status as required on
-   `main`.
+1. Admin removes `haliax-unit / levanter-unit / iris-unit / zephyr-unit
+   / fray-unit / marin-unit (old)` from branch-protection
+   required-checks.
+2. PR merges: deletes the five obsolete YAMLs, adds
+   `levanter-tpu-tests.yaml`, edits `marin-integration.yaml` to absorb
+   `iris-e2e-smoke`.
+3. Admin adds `marin-unit` (new aggregate) as a required check.
 
-**Rollback.** Before Phase 3, tag the pre-deletion main branch as
-`legacy/unit-workflows-<YYYYMMDD>`. If the new workflow is unstable in
-production, cherry-pick the seven YAMLs back from the tag in a single
-PR; admin re-adds the old required checks.
-
-**Audit before Phase 3.** Search the repo for `needs: <old-job-name>`
-and `requires: <old-job-name>` in case any scheduled / canary / release
-workflow has a status-check dependency on a soon-to-be-deleted job
-name. Currently I see none, but verifying is part of Phase 2.
+**Rollback.** Tag `legacy/unit-workflows-<YYYYMMDD>` before Phase 3.
+Cherry-pick the old YAMLs back from the tag if the new workflow needs
+to be reverted.


### PR DESCRIPTION
## Summary

🤖 Proposal to consolidate seven `*-unit.yaml` GitHub Actions workflows into a single `marin-unit` orchestrator.

The orchestrator runs `infra/select_tests.py` (already implemented and tested in a sibling branch) to compute a per-package test matrix from the diff, then dispatches each leg via a new `[tool.marin.tests]` TOML table that each package declares in its own `pyproject.toml`. End state: `marin-unit.yaml` + `marin-integration.yaml` cover the python lib packages; `dupekit-unit.yaml` keeps the Rust+Python hybrid; `levanter-tpu-tests.yaml` extracts the Docker-TPU job. Five workflow files deleted, one rewritten.

## Files (open these to review)

- [`design.md`](https://github.com/marin-community/marin/blob/design/unified_unit_workflow/.agents/projects/unified_unit_workflow/design.md) — the 1-pager (why / challenges / costs / design / testing / open questions)
- [`spec.md`](https://github.com/marin-community/marin/blob/design/unified_unit_workflow/.agents/projects/unified_unit_workflow/spec.md) — schema for `[tool.marin.tests]`, loader API, orchestrator workflow shape, file path table, errors, migration plan
- [`research.md`](https://github.com/marin-community/marin/blob/design/unified_unit_workflow/.agents/projects/unified_unit_workflow/research.md) — in-repo notes on the seven workflows + prior-art digest (Bazel, Pants, Nx, Turborepo)

## Test plan

- [ ] Reviewers read `design.md` end-to-end (~1300 words)
- [ ] Reviewers spot-check the `[tool.marin.tests]` schema in `spec.md` against their package's current quirks (`--with jax pin`, `--no-install-package torch`, `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0`, "don't cd lib/zephyr")
- [ ] Reviewers weigh in on Open Questions — see `design.md` (cold-start regression, branch-protection runbook, marin-scope home, composite action)

Discussion welcome — see Open Questions in `design.md`.