### PR TITLE
[grug-moe] MuonH with router z-loss raised to 4e-3

### DIFF
--- a/.agents/logbooks/moe-muonh-router-zloss-4e-3.md
+++ b/.agents/logbooks/moe-muonh-router-zloss-4e-3.md
@@ -1,0 +1,62 @@
+# MoE MuonH + Router z-loss 4e-3: Research Logbook
+
+## Scope
+
+- Goal: Test whether raising `GrugModelConfig.router_z_loss_coef` from `1e-3` to `4e-3` on top of the corrected MuonH matrix-swap improves effective speedup over both the v16 AdamH baseline and the MuonH baseline-adam-mask gate-1 results from #5596.
+- Primary metrics: `eval/paloma/macro_loss`, `throughput/tokens_per_second`, `throughput/total_tokens`, run state.
+- Constraints: Keep model sizing, data, batch size, step count, schedule, output z-loss (`z_loss_weight=1e-4`), eval cadence, and the MuonH optimizer mask fixed; the only knob that changes is `router_z_loss_coef`.
+- Issue: https://github.com/marin-community/marin/issues/5600
+- PR: https://github.com/marin-community/marin/pull/5601 (stacked on #5597)
+
+## Baseline
+
+- Date: 2026-05-09
+- Code refs: `experiments/grug/moe/muonh_router_zloss_sweep.py`, `experiments/grug/moe/muonh_matrix_sweep.py`, `experiments/grug/moe/heuristic.py`, `experiments/grug/moe/launch.py`, `experiments/grug/moe/model.py:72` (default `router_z_loss_coef=0.001`).
+- Comparators: README compute-optimal table (`experiments/grug/moe/README.md`) and the corrected MuonH baseline-adam-mask gate-1 results from #5596.
+
+## Experiment Log
+
+### 2026-05-09 14:25 - MOE-RZ-001 launcher and validation
+
+- Hypothesis: Raising the router z-loss coefficient should be a single isolated knob that doesn't interact with the rest of the MuonH stack.
+- Command: `uv run pytest -o addopts='' tests/test_grug_moe_optimizer.py tests/test_grug_variant_contracts.py -q`
+- Config: `experiments/grug/moe/muonh_router_zloss_sweep.py`, `MUONH_RZLOSS_GATE=1` default, `entity="marin-community"` pinned.
+- Result: 19 tests passed. `./infra/pre-commit.py --fix experiments/grug/moe/muonh_router_zloss_sweep.py` clean. Smoke build of `_build_steps('1')` confirmed `router_z_loss_coef=0.004` on both d512 and d768 model configs.
+- Interpretation: Launcher is ready; only `GrugModelConfig.router_z_loss_coef` differs from the corrected MuonH baseline-adam-mask launcher.
+- Next action: Open PR #5601 and launch gate 1 on Iris preemptible v5p-8.
+
+### 2026-05-09 15:29 - MOE-RZ-002 gate-1 launch
+
+- Hypothesis: Tighter router-logit regularization (4× the README default) under MuonH may stabilize routing and improve effective speedup at gate 1.
+- Command: `.venv/bin/iris --config lib/iris/examples/marin.yaml job run --no-wait --preemptible --reserve v5p-8 -e WANDB_API_KEY "$WANDB_API_KEY" -e MUONH_RZLOSS_GATE 1 -- python -m experiments.grug.moe.muonh_router_zloss_sweep`
+- Config: PR #5601 commit `2f91bba79`, gate 1, v5p-8 preemptible.
+- Result: Parent `/kaiyue/iris-run-job-20260509-222905` running; both children created and progressed past startup with no `Traceback` or `ShardingTypeError`.
+- Interpretation: The 4e-3 router z-loss coefficient runs cleanly through MuonH without compile/lower regressions.
+- Next action: Wait for both runs to finish, then compare against #5596 MuonH baseline-adam-mask and the README v16 AdamH baseline.
+
+### 2026-05-09 23:00 - MOE-RZ-003 gate-1 completion and verdict
+
+- Hypothesis: Router z-loss bumped from 1e-3 to 4e-3 helps the MuonH variant.
+- Command: wandb pull from `marin-community/marin_moe`.
+- Config: Same launcher and run IDs as MOE-RZ-002.
+- Result: Both runs `state=finished`, parent `/kaiyue/iris-run-job-20260509-222905` succeeded.
+
+| Scale | Run | macro_loss | tps | total_tokens | step |
+|---|---|---|---|---|---|
+| d512 (2.19e17) | v16 AdamH baseline | 3.8104 | 407,378 | 8.37e8 | 6386 |
+| d512 (2.19e17) | MuonH baseline-adam-mask (#5596) | 3.7542 | 411,620 | 8.37e8 | 6386 |
+| d512 (2.19e17) | MuonH + router-zloss-4e-3 | **3.7499** | 411,230 | 8.37e8 | 6386 |
+| d768 (1.70e18) | v16 AdamH baseline | 3.4339 | 274,431 | 2.71e9 | 10342 |
+| d768 (1.70e18) | MuonH baseline-adam-mask (#5596) | 3.3988 | 281,211 | 2.71e9 | 10342 |
+| d768 (1.70e18) | MuonH + router-zloss-4e-3 | **3.3881** | 280,188 | 2.71e9 | 10342 |
+
+Effective speedup (`L_inf=1.6, alpha=0.0941`):
+
+| Scale | vs v16 AdamH (wall) | vs v16 AdamH (step-wise) | vs MuonH baseline-adam-mask (wall) | vs MuonH baseline-adam-mask (step-wise) |
+|---|---|---|---|---|
+| d512 | **1.36** | 1.34 | 1.02 | 1.02 |
+| d768 | **1.34** | 1.31 | 1.06 | 1.07 |
+
+- Interpretation: Router z-loss 4e-3 passes gate 1 cleanly against the v16 AdamH baseline at both scales (1.36× / 1.34× wall-clock), and improves over the corrected MuonH baseline-adam-mask by ~+2% at d512 and ~+6% at d768. The wider gain at d768 suggests the regularization compounds with scale.
+- W&B report: https://wandb.ai/marin-community/marin_moe/reports/MuonH-router-zloss-4e-3-vs-MuonH-vs-v16-AdamH-—-gate-1--VmlldzoxNjgyOTMwNg==
+- Next action: Decide on launching gate 2 (d1024 at 9.00e18 and d1280 at 2.83e19) for the router-zloss-4e-3 variant; the d768 trend is encouraging.

--- a/experiments/grug/moe/muonh_router_zloss_sweep.py
+++ b/experiments/grug/moe/muonh_router_zloss_sweep.py
@@ -1,0 +1,156 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""MuonH matrix swap with router z-loss bumped from 1e-3 to 4e-3.
+
+Stacks on top of the corrected MuonH ablation from ``muonh_matrix_sweep.py``
+(MuonH for matrix-shaped Grug MoE leaves that the AdamH baseline routes to
+AdamH or AdamH-expert; AdamH for the lm head; Adam preserved on the baseline
+Adam group). The only additional knob is ``GrugModelConfig.router_z_loss_coef``,
+which is raised from the README default 1e-3 to 4e-3 to test whether tighter
+router-logit regularization helps under MuonH.
+
+Set ``MUONH_RZLOSS_GATE`` to control which scales run:
+
+    MUONH_RZLOSS_GATE=1     # default: d512, d768 (gate 1 only)
+    MUONH_RZLOSS_GATE=2     # d1024, d1280 (gate 2 only)
+    MUONH_RZLOSS_GATE=both  # all four scales
+
+Set ``MUONH_RZLOSS_RUN_SUFFIX`` to append a unique suffix for relaunches.
+"""
+
+import dataclasses
+import os
+
+from fray.cluster import ResourceConfig
+from levanter.tracker.wandb import WandbConfig
+from marin.execution.executor import ExecutorStep, executor_main, this_output_path, versioned
+
+from experiments.grug.moe.heuristic import build_from_heuristic
+from experiments.grug.moe.launch import (
+    NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
+    GrugMoeLaunchConfig,
+    run_grug_moe_trial,
+)
+from experiments.grug.moe.optimizer import GrugMoeAdamHConfig, GrugMoeMuonHConfig
+from experiments.grug.moe.train import GrugEvalConfig, GrugTrainerConfig
+
+_GATE_1_POINTS: tuple[tuple[int, float], ...] = (
+    (512, 2.19e17),
+    (768, 1.70e18),
+)
+_GATE_2_POINTS: tuple[tuple[int, float], ...] = (
+    (1024, 9.00e18),
+    (1280, 2.83e19),
+)
+
+_BASELINE_TARGET_STEPS: int = 2**14
+_ROUTER_Z_LOSS_COEF: float = 4e-3
+_GROUP: str = "muonh-rzloss4e3-sweep"
+
+
+def _format_budget(budget: float) -> str:
+    return f"{budget:.2e}".replace("+", "")
+
+
+def _format_run_id(hidden_dim: int, budget: float, run_suffix: str = "") -> str:
+    budget_label = _format_budget(budget)
+    normalized_suffix = run_suffix.strip()
+    if normalized_suffix and not normalized_suffix.replace("-", "").replace("_", "").isalnum():
+        raise ValueError("run_suffix may only contain letters, numbers, hyphens, and underscores")
+    suffix = f"{normalized_suffix}-" if normalized_suffix else ""
+    return f"muonh-rzloss4e3-{suffix}d{hidden_dim}-{budget_label}"
+
+
+def _muonh_optimizer_from_baseline(base_optimizer: GrugMoeAdamHConfig) -> GrugMoeMuonHConfig:
+    return GrugMoeMuonHConfig(
+        learning_rate=base_optimizer.learning_rate,
+        adam_lr=base_optimizer.adam_lr,
+        min_lr_ratio=base_optimizer.min_lr_ratio,
+        warmup=base_optimizer.warmup,
+        beta1=base_optimizer.beta1,
+        beta2=base_optimizer.beta2,
+        epsilon=base_optimizer.epsilon,
+        max_grad_norm=base_optimizer.max_grad_norm,
+        lr_schedule=base_optimizer.lr_schedule,
+        decay=base_optimizer.decay,
+    )
+
+
+def _build_step(hidden_dim: int, budget: float, run_suffix: str = "") -> ExecutorStep:
+    base_model, base_optimizer, batch_size, num_steps = build_from_heuristic(
+        budget=budget,
+        hidden_dim=hidden_dim,
+        target_steps=_BASELINE_TARGET_STEPS,
+    )
+    model = dataclasses.replace(base_model, router_z_loss_coef=_ROUTER_Z_LOSS_COEF)
+    optimizer = _muonh_optimizer_from_baseline(base_optimizer)
+
+    run_id = _format_run_id(hidden_dim=hidden_dim, budget=budget, run_suffix=run_suffix)
+    step_name = f"grug/muonh_router_zloss_sweep/{run_id}"
+
+    return ExecutorStep(
+        name=step_name,
+        fn=run_grug_moe_trial,
+        config=GrugMoeLaunchConfig(
+            model=versioned(model),
+            data=NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
+            output_path=this_output_path(),
+            run_id=run_id,
+            resources=versioned(ResourceConfig.with_tpu("v5p-8")),
+            steps=versioned(num_steps),
+            batch_size=versioned(batch_size),
+            seed=versioned(0),
+            mp=versioned("params=float32,compute=bfloat16,output=bfloat16"),
+            tracker=WandbConfig(
+                entity="marin-community",
+                project="marin_moe",
+                tags=["moe", "muonh_router_zloss_sweep", f"d{hidden_dim}"],
+                group=_GROUP,
+                name=None,
+            ),
+            optimizer=versioned(optimizer),
+            grug_trainer=versioned(
+                GrugTrainerConfig(
+                    z_loss_weight=1e-4,
+                    ema_beta=None,
+                    log_every=1,
+                )
+            ),
+            eval=versioned(
+                GrugEvalConfig(
+                    eval_batch_size=512,
+                    steps_per_eval=1000,
+                    max_eval_batches=8,
+                    eval_current=True,
+                    eval_ema=False,
+                )
+            ),
+        ),
+    )
+
+
+def _build_steps(gate: str, run_suffix: str = "") -> list[ExecutorStep]:
+    if gate == "1":
+        points = _GATE_1_POINTS
+    elif gate == "2":
+        points = _GATE_2_POINTS
+    elif gate == "both":
+        points = _GATE_1_POINTS + _GATE_2_POINTS
+    else:
+        raise ValueError(f"unknown gate: {gate!r} (expected '1', '2', or 'both')")
+
+    return [_build_step(hidden_dim=hidden_dim, budget=budget, run_suffix=run_suffix) for hidden_dim, budget in points]
+
+
+if __name__ == "__main__":
+    gate = os.environ.get("MUONH_RZLOSS_GATE", "1")
+    run_suffix = os.environ.get("MUONH_RZLOSS_RUN_SUFFIX", "")
+    steps = _build_steps(gate, run_suffix=run_suffix)
+    executor_main(
+        steps=steps,
+        description=(
+            f"MoE MuonH matrix swap with router_z_loss_coef={_ROUTER_Z_LOSS_COEF} "
+            f"(gate={gate}, run_suffix={run_suffix!r})."
+        ),
+    )


### PR DESCRIPTION
Issue: #5600

Stacked on top of `research/moe-muonh-matrix-sweep` (PR #5597). Adds `experiments/grug/moe/muonh_router_zloss_sweep.py`, which mirrors the corrected MuonH matrix-swap launcher (same MuonH-on-AdamH-matrices / AdamH-on-lm-head / Adam-on-baseline-Adam-group mask) and overrides `GrugModelConfig.router_z_loss_coef` from the README default `1e-3` to `4e-3` via `dataclasses.replace`. Pins `entity="marin-community"` so runs land on the shared `marin_moe` project.

## Validation

* `./infra/pre-commit.py --fix experiments/grug/moe/muonh_router_zloss_sweep.py` — passed.
* `uv run pytest -o addopts='' tests/test_grug_moe_optimizer.py tests/test_grug_variant_contracts.py -q` — 19 passed.
* Smoke build of `_build_steps('1')` produced `muonh-rzloss4e3-d512-2.19e17` and `muonh-rzloss4e3-d768-1.70e18` with `router_z_loss_coef=0.004` confirmed on each `GrugModelConfig`.

## Test plan

- [ ] Launch gate-1 on Iris (preemptible v5p-8) under W&B group `muonh-rzloss4e3-sweep`.
- [ ] Compare effective speedup at d512 / d768 against the v16 AdamH baseline and against the existing MuonH baseline-adam-mask gate-1 results from #5596.
- [ ] If gate 1 passes, decide on gate 2.