### PR TITLE
Make test_dry_run hermetic and rationalize test markers

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,10 +14,10 @@ This directory contains thin trigger YAML around behavior implemented in `script
 | `iris-release-iap-proxy.yaml` | Iris - Release IAP Proxy | PR + push to main | release | iris | see job steps |
 | `iris-smoke-coreweave.yaml` | Iris - Smoke - CoreWeave | PR + issue_comment + workflow_dispatch | smoke | iris | see job steps |
 | `iris-smoke-gcp.yaml` | Iris - Smoke - GCP | PR + issue_comment + workflow_dispatch | smoke | iris | see job steps |
-| `iris-unit.yaml` | Iris - Unit | PR + push to main | unit | iris | `cd lib/iris && uv run --group dev python -m pytest -n1 --durations=5 --tb=short -m 'not slow and not docker and not e2e' tests/` |
+| `iris-unit.yaml` | Iris - Unit | PR + push to main | unit | iris | `cd lib/iris && uv run --group dev python -m pytest -n1 --durations=5 --tb=short -m 'not slow and not docker and not requires_cluster' tests/` |
 | `levanter-dev-launch-small-fast.yaml` | Levanter - Dev - Launch Small Fast | workflow_dispatch | dev | levanter | see job steps |
 | `levanter-integration-gpt2-small.yaml` | Levanter - Integration - GPT-2 Small | workflow_dispatch | integration | levanter | see job steps |
-| `levanter-unit.yaml` | Levanter - Unit | PR + push to main | unit | levanter | `uv run --package marin-levanter --frozen --with "jax[cpu]==0.9.2" pytest tests -m "not entry and not slow and not tpu and not torch"` |
+| `levanter-unit.yaml` | Levanter - Unit | PR + push to main | unit | levanter | `uv run --package marin-levanter --frozen --with "jax[cpu]==0.9.2" pytest tests -m "not slow and not torch"` |
 | `marin-canary-datakit-nemotron.yaml` | Marin - Canary - Datakit Nemotron | schedule + workflow_dispatch | canary | marin | see job steps |
 | `marin-canary-ferry-coreweave.yaml` | Marin - Canary Ferry - CoreWeave | schedule + workflow_dispatch | canary | marin | see job steps |
 | `marin-canary-ferry.yaml` | Marin - Canary Ferry | schedule + workflow_dispatch | canary | marin | see job steps |

--- a/.github/workflows/iris-smoke-gcp.yaml
+++ b/.github/workflows/iris-smoke-gcp.yaml
@@ -161,7 +161,7 @@ jobs:
           mkdir -p ${{ github.workspace }}/iris-cloud-screenshots
           cd lib/iris && uv run --group dev python -m pytest \
             tests/e2e/test_smoke.py \
-            -m e2e \
+            -m requires_cluster \
             --iris-controller-url "$IRIS_CONTROLLER_URL" \
             -o "addopts=" \
             --tb=short -v \

--- a/.github/workflows/iris-unit.yaml
+++ b/.github/workflows/iris-unit.yaml
@@ -60,7 +60,7 @@ jobs:
         env:
           PYTHONASYNCIODEBUG: "1"
         run: |
-          cd lib/iris && uv run --group dev python -m pytest -n1 --durations=5 --tb=short -m 'not slow and not docker and not e2e' tests/
+          cd lib/iris && uv run --group dev python -m pytest -n1 --durations=5 --tb=short -m 'not slow and not docker and not requires_cluster' tests/
 
   iris-e2e-smoke:
     needs: changes
@@ -110,7 +110,7 @@ jobs:
           mkdir -p ${{ github.workspace }}/iris-screenshots
           cd lib/iris && uv run --group dev python -m pytest \
             tests/e2e/test_smoke.py \
-            -m e2e -o "addopts=" --tb=short -v
+            -m requires_cluster -o "addopts=" --tb=short -v
 
       - name: Verify screenshots with Claude
         if: always() && hashFiles('iris-screenshots/*.txt') != ''

--- a/.github/workflows/levanter-unit.yaml
+++ b/.github/workflows/levanter-unit.yaml
@@ -58,36 +58,7 @@ jobs:
       - name: Test with pytest
         run: |
           # Test with specific JAX version, excluding TPU tests
-          PYTHONPATH=tests:src:. uv run --package marin-levanter --frozen --with "jax[cpu]==0.9.2" pytest tests -m "not entry and not slow and not tpu and not torch" --durations=20
-
-  levanter-entry:
-    needs: changes
-    if: needs.changes.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: lib/levanter
-
-    steps:
-      - uses: actions/checkout@v5
-      - name: Install uv and Python
-        uses: astral-sh/setup-uv@v6
-        with:
-          version: "0.7.20"
-          python-version: "3.11"
-          enable-cache: true
-          working-directory: lib/levanter
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-      - name: Set up Python
-        run: uv python install
-      - name: Install dependencies
-        run: uv sync --package marin-levanter --dev --group test --frozen
-      - name: Test with pytest
-        run: |
-          PYTHONPATH=tests:src:. uv run --package marin-levanter --frozen pytest tests -m "entry" --durations=20
+          PYTHONPATH=tests:src:. uv run --package marin-levanter --frozen --with "jax[cpu]==0.9.2" pytest tests -m "not slow and not torch" --durations=20
 
   levanter-torch:
     needs: changes
@@ -217,7 +188,7 @@ jobs:
               timeout --kill-after=5 --signal=TERM 890 \
               uv run --package marin-levanter --frozen --group test --extra tpu \
               pytest -n 0 lib/levanter/tests \
-              -m 'not entry and not slow and not torch' \
+              -m 'not slow and not torch' \
               --ignore=lib/levanter/tests/test_audio.py \
               --ignore=lib/levanter/tests/test_new_cache.py \
               --ignore=lib/levanter/tests/test_hf_checkpoints.py \

--- a/experiments/datakit_testbed/baseline.py
+++ b/experiments/datakit_testbed/baseline.py
@@ -12,24 +12,26 @@ where the pipeline's middle stages are deliberate no-ops:
   (one shard set per source), so bucketing is an identity op
 
 With all three as no-ops, the sampled parquet that :func:`build_testbed_steps`
-produces is also the bucket. :func:`baseline` wires one tokenize ExecutorStep
-per sample output, builds the proportional mixture over them, and hands the
-result to :func:`run_testbed_config` to assemble the full Grug-MoE training
-ExecutorStep.
+produces is also the bucket. ``main`` wires one tokenize ExecutorStep per
+sample output, computes mixture weights at runtime via
+:func:`tokenized_bucket_weights_step`, and hands the result to
+:func:`run_testbed_config` which assembles the full Grug-MoE training step.
+
+The whole pipeline (ferry → tokenize → weights → train) lives in one
+executor DAG so ``--dry_run`` validates structure without touching GCS.
 """
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import os
 
-from marin.execution.executor import Executor, ExecutorMainConfig, ExecutorStep, executor_main
-from marin.execution.step_runner import StepRunner
-from marin.execution.step_spec import StepSpec
-from rigging.filesystem import marin_prefix
+import draccus
+from marin.execution.executor import ExecutorMainConfig, executor_main
 from rigging.log_setup import configure_logging
 
-from experiments.datakit_testbed.mixture import weights_from_tokenized_bucket_stats
+from experiments.datakit_testbed.mixture import tokenized_bucket_weights_step
 from experiments.datakit_testbed.sampler import build_testbed_steps
 from experiments.datakit_testbed.settings import TESTBED_TOKENIZER
 from experiments.datakit_testbed.train import run_testbed_config, testbed_tokenize
@@ -43,57 +45,34 @@ MAX_STEP_CONCURRENCY = 20
 _SAMPLE_STEP_PREFIX = "data/datakit/normalized/"
 
 
-def baseline(
-    steps: list[StepSpec],
-    *,
-    name: str,
-    tokenizer: str,
-) -> ExecutorStep:
-    """Assemble the baseline training step off a testbed DAG"""
-
-    sampled_by_source = {
-        s.name.removeprefix(_SAMPLE_STEP_PREFIX): s for s in steps if s.name.startswith(_SAMPLE_STEP_PREFIX)
-    }
-    if not sampled_by_source:
-        raise ValueError("no sample steps found in the DAG (expected names under 'data/datakit/normalized/...')")
-
-    tokenized_buckets = {name: testbed_tokenize(name, sampled, tokenizer) for name, sampled in sampled_by_source.items()}
-    # Run tokenize steps through an Executor we keep a handle on so we can read
-    # each step's *resolved* output_path afterwards. ``executor_main`` discards
-    # its Executor, and ``output_path_of`` outside an executor context returns
-    # a lazy ``InputName`` — not a concrete GCS path.
-    prefix = marin_prefix()
-    tokenize_executor = Executor(
-        prefix=prefix,
-        executor_info_base_path=os.path.join(prefix, "experiments"),
-    )
-    tokenize_executor.run(list(tokenized_buckets.values()), max_concurrent=MAX_STEP_CONCURRENCY)
-
-    resolved_output_paths = {
-        bucket_name: tokenize_executor.output_paths[step] for bucket_name, step in tokenized_buckets.items()
-    }
-    weights = weights_from_tokenized_bucket_stats(resolved_output_paths)
-    return run_testbed_config(
-        name=name,
-        tokenized_buckets=tokenized_buckets,
-        weights=weights,
-        tokenizer=tokenizer,
-    )
-
-
 def main() -> None:
-    """Entry-point: materialize ferry + tokenize, then launch baseline training"""
-    os.environ["MARIN_PREFIX"] = STAGING_PREFIX
+    """Build the baseline DAG and hand it to ``executor_main``."""
+    config = draccus.parse(ExecutorMainConfig)
+    if config.prefix is None:
+        config = dataclasses.replace(config, prefix=STAGING_PREFIX)
+    os.environ.setdefault("MARIN_PREFIX", config.prefix)
 
     tokenizer = TESTBED_TOKENIZER
     run_id = "baseline"
 
     testbed_steps = build_testbed_steps(target_total_tokens_b=TARGET_TOTAL_TOKENS_B)
-    logger.info("Materializing %d ferry StepSpecs under %s", len(testbed_steps), STAGING_PREFIX)
-    StepRunner().run(testbed_steps, max_concurrent=MAX_STEP_CONCURRENCY)
+    sampled_by_source = {
+        s.name.removeprefix(_SAMPLE_STEP_PREFIX): s for s in testbed_steps if s.name.startswith(_SAMPLE_STEP_PREFIX)
+    }
+    if not sampled_by_source:
+        raise ValueError("no sample steps found in the testbed DAG")
 
-    training_step = baseline(testbed_steps, name=run_id, tokenizer=tokenizer)
-    executor_main(ExecutorMainConfig(), [training_step])
+    tokenized_buckets = {name: testbed_tokenize(name, sampled, tokenizer) for name, sampled in sampled_by_source.items()}
+    weights_step = tokenized_bucket_weights_step(run_id, tokenized_buckets)
+    training_step = run_testbed_config(
+        name=run_id,
+        tokenized_buckets=tokenized_buckets,
+        weights_step=weights_step,
+        tokenizer=tokenizer,
+    )
+
+    logger.info("Baseline DAG: %d sources → tokenize → weights → train", len(sampled_by_source))
+    executor_main(config, [training_step], max_concurrent=MAX_STEP_CONCURRENCY)
 
 
 if __name__ == "__main__":

--- a/experiments/datakit_testbed/mixture.py
+++ b/experiments/datakit_testbed/mixture.py
@@ -6,7 +6,7 @@ import json
 import logging
 from dataclasses import dataclass
 
-from marin.execution.executor import ExecutorStep, output_path_of, this_output_path
+from marin.execution.executor import ExecutorStep, InputName, output_path_of, this_output_path
 from marin.processing.tokenize.data_configs import TokenizerStep
 from rigging.filesystem import open_url
 
@@ -25,7 +25,7 @@ class TokenizedBucketWeightsConfig:
     runtime, after the executor resolves dependencies.
     """
 
-    tokenized_paths: dict
+    tokenized_paths: dict[str, str | InputName]
     output_path: str
 
 

--- a/experiments/datakit_testbed/mixture.py
+++ b/experiments/datakit_testbed/mixture.py
@@ -4,23 +4,63 @@ from __future__ import annotations
 
 import json
 import logging
+from dataclasses import dataclass
 
+from marin.execution.executor import ExecutorStep, output_path_of, this_output_path
+from marin.processing.tokenize.data_configs import TokenizerStep
 from rigging.filesystem import open_url
 
 logger = logging.getLogger(__name__)
 
+_WEIGHTS_FILENAME = "weights.json"
 
-def weights_from_tokenized_bucket_stats(tokenized_output_paths: dict[str, str]) -> dict[str, float]:
-    """Read each tokenize output's on-disk ``train/.stats.json`` for mixture weights.
 
-    Takes **resolved** output paths (e.g. from ``Executor.output_paths``),
-    not ``TokenizerStep`` objects, because a bare ``ExecutorStep`` doesn't
-    know its hashed output path outside an active executor context.
+@dataclass(frozen=True)
+class TokenizedBucketWeightsConfig:
+    """Inputs to ``compute_tokenized_bucket_weights``.
+
+    ``tokenized_paths`` is keyed by bucket name and points at the resolved
+    output path of each ``testbed_tokenize`` step. The values are
+    ``InputName`` references at construction time and concrete strings at
+    runtime, after the executor resolves dependencies.
     """
+
+    tokenized_paths: dict
+    output_path: str
+
+
+def compute_tokenized_bucket_weights(config: TokenizedBucketWeightsConfig) -> None:
+    """Read ``train/.stats.json`` from each bucket and write aggregated weights."""
     weights: dict[str, float] = {}
-    for name, out_path in tokenized_output_paths.items():
+    for name, out_path in config.tokenized_paths.items():
         stats_path = f"{out_path}/train/.stats.json"
         with open_url(stats_path) as f:
             stats = json.load(f)
         weights[name] = float(stats["total_tokens"])
-    return weights
+
+    out = f"{config.output_path}/{_WEIGHTS_FILENAME}"
+    with open_url(out, "w") as f:
+        json.dump(weights, f)
+    logger.info("Wrote bucket weights for %d buckets to %s", len(weights), out)
+
+
+def read_bucket_weights(weights_dir: str) -> dict[str, float]:
+    """Read the weights.json produced by ``compute_tokenized_bucket_weights``."""
+    with open_url(f"{weights_dir}/{_WEIGHTS_FILENAME}") as f:
+        return json.load(f)
+
+
+def tokenized_bucket_weights_step(name: str, tokenized_buckets: dict[str, TokenizerStep]) -> ExecutorStep:
+    """ExecutorStep that reads each bucket's tokenize stats and emits weights.json.
+
+    Pass the resulting step to ``run_testbed_config`` as ``weights_step``; the
+    executor resolves the dependency on each tokenize bucket automatically.
+    """
+    return ExecutorStep(
+        name=f"data/datakit/weights/{name}",
+        fn=compute_tokenized_bucket_weights,
+        config=TokenizedBucketWeightsConfig(
+            tokenized_paths={b: output_path_of(t) for b, t in tokenized_buckets.items()},
+            output_path=this_output_path(),
+        ),
+    )

--- a/experiments/datakit_testbed/sampler.py
+++ b/experiments/datakit_testbed/sampler.py
@@ -41,7 +41,6 @@ from marin.datakit.normalize import NormalizedData
 from marin.datakit.sources import DatakitSource, all_sources
 from marin.execution.artifact import Artifact
 from marin.execution.remote import remote
-from marin.execution.step_runner import check_cache
 from marin.execution.step_spec import StepSpec
 from marin.utils import fsspec_glob, fsspec_mkdirs
 from rigging.filesystem import url_to_fs
@@ -362,10 +361,10 @@ def build_testbed_steps(
     :mod:`experiments.datakit_testbed.train`), not the ferry.
 
     Args:
-        sources: DatakitSource list to ferry. ``None`` auto-selects every
-            entry from :func:`all_sources` whose normalize output is
-            already cached on GCS, matching the run_source_sampling
-            script. Pass an explicit list to bypass this check.
+        sources: DatakitSource list to ferry. ``None`` selects every entry
+            from :func:`all_sources`. The executor will skip sources whose
+            normalize output is already cached, so unconditionally including
+            them is safe; not-yet-ready sources will be normalized on demand.
         target_total_tokens_b: Target total token count (in billions)
             across the sampled set. Drives per-source sample fractions
             via :func:`proportional_sample_fractions`. Default is
@@ -376,8 +375,7 @@ def build_testbed_steps(
         one sample step per source. Ready to hand to ``StepRunner().run()``.
     """
     if sources is None:
-        # TODO (rav): remove the check_cache when ready?
-        sources = tuple(s for s in all_sources().values() if check_cache(s.normalized.output_path))
+        sources = tuple(all_sources().values())
     if not sources:
         raise ValueError("build_testbed_steps requires at least one source")
 

--- a/experiments/datakit_testbed/train.py
+++ b/experiments/datakit_testbed/train.py
@@ -23,10 +23,11 @@ import dataclasses
 import logging
 import os
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 from fray.cluster import ResourceConfig
 from levanter.tracker.wandb import WandbConfig
-from marin.execution.executor import ExecutorStep, this_output_path, versioned
+from marin.execution.executor import ExecutorStep, output_path_of, this_output_path, versioned
 from marin.execution.step_spec import StepSpec
 from marin.processing.tokenize import (
     TokenizeConfig,
@@ -36,6 +37,7 @@ from marin.processing.tokenize import (
 )
 from marin.processing.tokenize.data_configs import TokenizerStep
 
+from experiments.datakit_testbed.mixture import read_bucket_weights
 from experiments.datakit_testbed.settings import TESTBED_SEQ_LEN, TESTBED_TOKENIZER
 from experiments.defaults import default_validation_sets
 from experiments.grug.moe.heuristic import build_from_heuristic
@@ -91,11 +93,33 @@ def testbed_tokenize(
     )
 
 
+@dataclass(frozen=True)
+class TestbedTrialConfig:
+    """Wraps a ``GrugMoeLaunchConfig`` plus a path to a runtime-computed weights file.
+
+    ``weights_path`` is an ``InputName`` at construction (output of
+    ``tokenized_bucket_weights_step``) and a concrete path at runtime. The
+    runner reads the JSON file, patches ``train_weights`` on the embedded
+    data config, and dispatches to ``run_grug_moe_trial``.
+    """
+
+    weights_path: str
+    grug_config: GrugMoeLaunchConfig
+
+
+def run_testbed_trial(config: TestbedTrialConfig) -> None:
+    """Read bucket weights, splice into the data config, then run Grug-MoE."""
+    weights = read_bucket_weights(config.weights_path)
+    data = dataclasses.replace(config.grug_config.data, train_weights=weights)
+    grug = dataclasses.replace(config.grug_config, data=data)
+    run_grug_moe_trial(grug)
+
+
 def run_testbed_config(
     *,
     name: str,
     tokenized_buckets: dict[str, TokenizerStep],
-    weights: dict[str, float],
+    weights_step: ExecutorStep,
     compute_budget_flops: float = DEFAULT_COMPUTE_BUDGET_FLOPS,
     hidden_dim: int = DEFAULT_HIDDEN_DIM,
     target_steps: int = DEFAULT_TARGET_STEPS,
@@ -115,9 +139,10 @@ def run_testbed_config(
             builds these from its own bucketed view of the sampled data
             — baseline buckets by provenance (one tokenize per source);
             other configs may bucket differently (e.g. by quality tier).
-        weights: Per-bucket mixture weights. Keys must match
-            ``tokenized_buckets``. Typically computed from on-disk
-            ``train/.stats.json`` via ``weights_from_tokenized_bucket_stats``.
+        weights_step: ExecutorStep that produces a ``weights.json`` artifact
+            (see :func:`tokenized_bucket_weights_step`). Real weights are
+            read at training time, so the training DAG can be validated
+            via ``--dry_run`` without the tokenize outputs existing yet.
         compute_budget_flops: FLOP budget fed to ``build_from_heuristic``.
         hidden_dim: Model hidden dimension for the heuristic.
         target_steps: Heuristic target steps; default ``2**14`` matches Grug.
@@ -131,13 +156,11 @@ def run_testbed_config(
         tpu: Fray TPU request string (e.g. ``"v5p-8"``).
 
     Returns:
-        An ``ExecutorStep`` whose ``fn`` is ``run_grug_moe_trial``. Pass to
-        ``executor_main`` to actually train.
+        An ``ExecutorStep`` whose ``fn`` is ``run_testbed_trial``. Pass to
+        ``executor_main`` to validate the DAG (dry-run) or actually train.
     """
     if not tokenized_buckets:
         raise ValueError("tokenized_buckets must be non-empty")
-    if weights.keys() != tokenized_buckets.keys():
-        raise ValueError(f"weights keys {sorted(weights)} must match tokenized_buckets keys {sorted(tokenized_buckets)}")
 
     model_cfg, opt_cfg, batch_size, steps = build_from_heuristic(
         budget=compute_budget_flops,
@@ -145,7 +168,11 @@ def run_testbed_config(
         target_steps=target_steps,
     )
 
-    data = lm_mixture_data_config(components=tokenized_buckets, weights=weights)
+    # Placeholder uniform weights — only the structure of LmDataConfig matters
+    # at construction; ``run_testbed_trial`` overwrites ``train_weights`` from
+    # the on-disk weights.json before dispatching to ``run_grug_moe_trial``.
+    placeholder_weights = {bucket: 1.0 for bucket in tokenized_buckets}
+    data = lm_mixture_data_config(components=tokenized_buckets, weights=placeholder_weights)
     data = add_validation_sets_to_mixture(
         data,
         default_validation_sets(tokenizer=tokenizer),
@@ -174,41 +201,46 @@ def run_testbed_config(
         target_budget_tokens / 1e9,
     )
 
+    grug_config = GrugMoeLaunchConfig(
+        model=versioned(model_cfg),
+        data=data,
+        output_path=this_output_path(),
+        run_id=f"datakit-testbed-{name}",
+        resources=versioned(ResourceConfig.with_tpu(tpu)),
+        steps=versioned(steps),
+        batch_size=versioned(batch_size),
+        seed=versioned(seed),
+        mp=versioned("params=float32,compute=bfloat16,output=bfloat16"),
+        tracker=WandbConfig(
+            project="marin",
+            tags=list(wandb_tags),
+            group=wandb_group,
+            name=None,
+        ),
+        optimizer=versioned(opt_cfg),
+        grug_trainer=versioned(
+            GrugTrainerConfig(
+                z_loss_weight=1e-4,
+                ema_beta=None,
+                log_every=10,
+            )
+        ),
+        eval=versioned(
+            GrugEvalConfig(
+                eval_batch_size=512,
+                steps_per_eval=1000,
+                max_eval_batches=8,
+                eval_current=True,
+                eval_ema=False,
+            )
+        ),
+    )
+
     return ExecutorStep(
         name=f"data/datakit/train/{name}",
-        fn=run_grug_moe_trial,
-        config=GrugMoeLaunchConfig(
-            model=versioned(model_cfg),
-            data=data,
-            output_path=this_output_path(),
-            run_id=f"datakit-testbed-{name}",
-            resources=versioned(ResourceConfig.with_tpu(tpu)),
-            steps=versioned(steps),
-            batch_size=versioned(batch_size),
-            seed=versioned(seed),
-            mp=versioned("params=float32,compute=bfloat16,output=bfloat16"),
-            tracker=WandbConfig(
-                project="marin",
-                tags=list(wandb_tags),
-                group=wandb_group,
-                name=None,
-            ),
-            optimizer=versioned(opt_cfg),
-            grug_trainer=versioned(
-                GrugTrainerConfig(
-                    z_loss_weight=1e-4,
-                    ema_beta=None,
-                    log_every=10,
-                )
-            ),
-            eval=versioned(
-                GrugEvalConfig(
-                    eval_batch_size=512,
-                    steps_per_eval=1000,
-                    max_eval_batches=8,
-                    eval_current=True,
-                    eval_ema=False,
-                )
-            ),
+        fn=run_testbed_trial,
+        config=TestbedTrialConfig(
+            weights_path=output_path_of(weights_step),
+            grug_config=grug_config,
         ),
     )

--- a/experiments/datakit_testbed/variants.py
+++ b/experiments/datakit_testbed/variants.py
@@ -9,28 +9,29 @@ parquet serves every hyperparam sweep. Each variant then MinHash→fuzzy-dups
 →consolidates the sampled data with its own fuzzy-dedup parameters,
 tokenizes the deduped output, and trains.
 
-Pipeline mirrors ``experiments/ferries/datakit_ferry.py`` but fanned across
-every sampled source and with sample (not normalize) as the input.
+The whole pipeline (ferry → minhash → fuzzy_dups → consolidate → tokenize
+→ weights → train) lives in one executor DAG so ``--dry_run`` validates
+structure without touching GCS.
 """
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import os
 
+import draccus
 from fray import ResourceConfig
 from marin.datakit.normalize import NormalizedData
 from marin.execution.artifact import Artifact
-from marin.execution.executor import Executor, ExecutorMainConfig, ExecutorStep, executor_main
-from marin.execution.step_runner import StepRunner
+from marin.execution.executor import ExecutorMainConfig, ExecutorStep, executor_main
 from marin.execution.step_spec import StepSpec
 from marin.processing.classification.consolidate import FilterConfig, FilterType, consolidate
 from marin.processing.classification.deduplication.fuzzy_dups import FuzzyDupsAttrData, compute_fuzzy_dups_attrs
 from marin.processing.classification.deduplication.fuzzy_minhash import MinHashAttrData, compute_minhash_attrs
-from rigging.filesystem import marin_prefix
 from rigging.log_setup import configure_logging
 
-from experiments.datakit_testbed.mixture import weights_from_tokenized_bucket_stats
+from experiments.datakit_testbed.mixture import tokenized_bucket_weights_step
 from experiments.datakit_testbed.sampler import build_testbed_steps
 from experiments.datakit_testbed.settings import TESTBED_TOKENIZER
 from experiments.datakit_testbed.train import run_testbed_config, testbed_tokenize
@@ -161,48 +162,31 @@ def dedup(
         fuzzy_dedup_cc_max_iterations,
     )
 
-    # Materialize the dedup chain (StepRunner walks transitive deps, so we only
-    # need to hand it the terminal consolidates).
-    StepRunner().run(list(deduped_by_source.values()))
-
-    # Now the deduped parquet lives at each consolidate step's output_path under
-    # outputs/main/ — bridge those into tokenize ExecutorSteps exactly like
-    # baseline wires sample outputs.
     tokenized_buckets = {
         src_name: testbed_tokenize(src_name, deduped, tokenizer) for src_name, deduped in deduped_by_source.items()
     }
-    prefix = marin_prefix()
-    tokenize_executor = Executor(
-        prefix=prefix,
-        executor_info_base_path=os.path.join(prefix, "experiments"),
-    )
-    tokenize_executor.run(list(tokenized_buckets.values()), max_concurrent=MAX_STEP_CONCURRENCY)
-
-    resolved_output_paths = {
-        bucket_name: tokenize_executor.output_paths[step] for bucket_name, step in tokenized_buckets.items()
-    }
-    weights = weights_from_tokenized_bucket_stats(resolved_output_paths)
+    weights_step = tokenized_bucket_weights_step(name, tokenized_buckets)
     return run_testbed_config(
         name=name,
         tokenized_buckets=tokenized_buckets,
-        weights=weights,
+        weights_step=weights_step,
         tokenizer=tokenizer,
     )
 
 
 def main() -> None:
-    """Entry-point: ferry → minhash → fuzzy_dups → consolidate → tokenize → train."""
-    os.environ["MARIN_PREFIX"] = STAGING_PREFIX
+    """Build the fuzzy-dedup DAG and hand it to ``executor_main``."""
+    config = draccus.parse(ExecutorMainConfig)
+    if config.prefix is None:
+        config = dataclasses.replace(config, prefix=STAGING_PREFIX)
+    os.environ.setdefault("MARIN_PREFIX", config.prefix)
 
     tokenizer = TESTBED_TOKENIZER
     run_id = "fuzzy_dedup"
 
     testbed_steps = build_testbed_steps(target_total_tokens_b=TARGET_TOTAL_TOKENS_B)
-    logger.info("Materializing %d ferry StepSpecs under %s", len(testbed_steps), STAGING_PREFIX)
-    StepRunner().run(testbed_steps, max_concurrent=MAX_STEP_CONCURRENCY)
-
     training_step = dedup(testbed_steps, name=run_id, tokenizer=tokenizer)
-    executor_main(ExecutorMainConfig(), [training_step])
+    executor_main(config, [training_step], max_concurrent=MAX_STEP_CONCURRENCY)
 
 
 if __name__ == "__main__":

--- a/experiments/evals/exp1600_uncheatable_evals.py
+++ b/experiments/evals/exp1600_uncheatable_evals.py
@@ -17,14 +17,13 @@ from dataclasses import dataclass
 from functools import lru_cache
 
 from fray.cluster import ResourceConfig
-from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from marin.datakit.download.uncheatable_eval import make_uncheatable_eval_step
-from marin.evaluation.log_probs import default_lm_log_probs
 from marin.execution.executor import ExecutorStep, executor_main, output_path_of
 from marin.processing.tokenize import TokenizeConfig
 from marin.processing.tokenize.data_configs import TokenizerStep, mixture_for_evaluation
 
 from experiments.defaults import default_tokenize
+from experiments.evals.hf_log_probs import default_hf_lm_log_probs
 from experiments.llama import llama3_tokenizer
 from experiments.models import ModelConfig as HFModelConfig
 from experiments.models import download_model_step
@@ -135,21 +134,17 @@ def build_steps() -> list[ExecutorStep]:
         uncheatable_eval_tokenized_dict = uncheatable_eval_tokenized(tokenizer=tokenizer)
         eval_data = mixture_for_evaluation(uncheatable_eval_tokenized_dict)
 
-        # Download model and load config dynamically from HuggingFace
-        model_identifier = f"{model_config.model_name}@{model_config.revision}"
         model_instance = download_model_step(
             HFModelConfig(hf_repo_id=model_config.model_name, hf_revision=model_config.revision)
         )
-        hf_model_config = HFCheckpointConverter.from_hf(model_identifier).config_from_hf_checkpoint(model_identifier)
-
         directory_friendly_name = get_directory_friendly_name(model_config.model_name)
         steps.append(
-            default_lm_log_probs(
+            default_hf_lm_log_probs(
+                hf_repo_id=model_config.model_name,
+                hf_revision=model_config.revision,
                 checkpoint=output_path_of(model_instance),
-                model=hf_model_config,
                 data=eval_data,
                 resource_config=ResourceConfig.with_tpu("v5p-8"),
-                checkpoint_is_hf=True,
                 per_device_batch_size=1,
                 name=f"{directory_friendly_name}-uncheatable-eval-logprobs",
                 wandb_tags=[

--- a/experiments/evals/hf_log_probs.py
+++ b/experiments/evals/hf_log_probs.py
@@ -1,0 +1,98 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Log-probs eval for HuggingFace checkpoints with HF config fetched at runtime.
+
+``default_lm_log_probs`` requires a fully-built ``LmConfig`` at script time. For
+experiments that evaluate many HF models in a loop, that means calling
+``HFCheckpointConverter.from_hf(...).config_from_hf_checkpoint(...)`` per model
+during DAG construction, which issues HTTP requests to HF Hub before any step
+runs — blocking ``--dry_run`` and breaking hermeticity.
+
+``default_hf_lm_log_probs`` builds the same ``ExecutorStep`` but defers the HF
+config fetch into the step's runtime ``fn``. The DAG is constructed without
+network I/O; the config is read only when the step actually executes (which is
+also when the model itself is downloaded).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+
+from fray.types import ResourceConfig
+from levanter.compat.hf_checkpoints import HFCheckpointConverter
+from levanter.data.text import LMMixtureDatasetConfig
+from marin.evaluation.log_probs import EvalLmConfig, evaluate_lm_log_probs
+from marin.execution.executor import ExecutorStep, InputName, this_output_path
+from marin.utilities.executor_utils import ckpt_path_to_step_name
+
+
+@dataclass
+class HfLogProbsConfig:
+    """Like ``EvalLmConfig`` but the model config is fetched at runtime."""
+
+    name: str
+    hf_repo_id: str
+    hf_revision: str
+    checkpoint_path: str
+    datasets: LMMixtureDatasetConfig
+    resource_config: ResourceConfig
+    per_device_batch_size: int = 4
+    output_path: str = dataclasses.field(default_factory=this_output_path)  # type: ignore
+    log_entropy: bool = True
+    max_samples_per_dataset: int | None = None
+    wandb_tags: list[str] | None = None
+
+
+def evaluate_hf_log_probs(config: HfLogProbsConfig) -> None:
+    """Fetch HF model config, then dispatch to ``evaluate_lm_log_probs``."""
+    model_identifier = f"{config.hf_repo_id}@{config.hf_revision}"
+    hf_model_config = HFCheckpointConverter.from_hf(model_identifier).config_from_hf_checkpoint(model_identifier)
+    eval_config = EvalLmConfig(
+        name=config.name,
+        checkpoint_path=config.checkpoint_path,
+        model=hf_model_config,
+        datasets=config.datasets,
+        resource_config=config.resource_config,
+        per_device_batch_size=config.per_device_batch_size,
+        output_path=config.output_path,
+        checkpoint_is_hf=True,
+        log_entropy=config.log_entropy,
+        max_samples_per_dataset=config.max_samples_per_dataset,
+        wandb_tags=config.wandb_tags,
+    )
+    evaluate_lm_log_probs(eval_config)
+
+
+def default_hf_lm_log_probs(
+    *,
+    hf_repo_id: str,
+    hf_revision: str,
+    checkpoint: str | InputName,
+    data: LMMixtureDatasetConfig,
+    resource_config: ResourceConfig,
+    per_device_batch_size: int = 4,
+    max_samples_per_dataset: int | None = None,
+    name: str | None = None,
+    wandb_tags: list[str] | None = None,
+) -> ExecutorStep:
+    """Build a log-probs eval step that fetches its HF model config at runtime."""
+    if not name:
+        name = ckpt_path_to_step_name(checkpoint)
+    return ExecutorStep(
+        name=f"analysis/log_probs/{name}",
+        fn=evaluate_hf_log_probs,
+        config=HfLogProbsConfig(
+            name=name,
+            hf_repo_id=hf_repo_id,
+            hf_revision=hf_revision,
+            checkpoint_path=checkpoint,  # type: ignore[arg-type]
+            datasets=data,
+            resource_config=resource_config,
+            per_device_batch_size=per_device_batch_size,
+            log_entropy=True,
+            max_samples_per_dataset=max_samples_per_dataset,
+            wandb_tags=wandb_tags,
+        ),
+    )

--- a/lib/iris/README.md
+++ b/lib/iris/README.md
@@ -307,17 +307,17 @@ dashboard rendering, log levels, profiling, and constraint routing.
 
 ```bash
 # Local mode (in-process cluster, default)
-uv run pytest lib/iris/tests/e2e/test_smoke.py -m e2e -o "addopts=" -v
+uv run pytest lib/iris/tests/e2e/test_smoke.py -m requires_cluster -o "addopts=" -v
 
 # Cloud mode: start cluster via CLI, then run tests against it
 # iris --cluster=smoke-gcp cluster start-smoke --label-prefix my-test --url-file /tmp/url --wait-for-workers 1
-uv run pytest lib/iris/tests/e2e/test_smoke.py -m e2e --iris-controller-url "$(cat /tmp/url)" -o "addopts="
+uv run pytest lib/iris/tests/e2e/test_smoke.py -m requires_cluster --iris-controller-url "$(cat /tmp/url)" -o "addopts="
 
 # Cloud mode: connect to existing cluster
-uv run pytest lib/iris/tests/e2e/test_smoke.py -m e2e --iris-controller-url http://localhost:8080 -o "addopts="
+uv run pytest lib/iris/tests/e2e/test_smoke.py -m requires_cluster --iris-controller-url http://localhost:8080 -o "addopts="
 
 # Screenshots saved to custom directory
-IRIS_SCREENSHOT_DIR=/tmp/shots uv run pytest lib/iris/tests/e2e/test_smoke.py -m e2e -o "addopts="
+IRIS_SCREENSHOT_DIR=/tmp/shots uv run pytest lib/iris/tests/e2e/test_smoke.py -m requires_cluster -o "addopts="
 ```
 
 ## Configuration

--- a/lib/iris/TESTING.md
+++ b/lib/iris/TESTING.md
@@ -115,7 +115,7 @@ types even in startup-polling loops.
 ## Markers and Organization
 
 - All tests that boot a cluster (local or Docker) must be marked
-  `@pytest.mark.e2e`.
+  `@pytest.mark.requires_cluster`.
 - Docker-dependent tests must also be marked `@pytest.mark.docker`.
 - E2E tests live in `tests/e2e/`.
 - Shared fakes live in `src/iris/cluster/providers/gcp/fake.py`
@@ -133,7 +133,7 @@ concrete class for testing.)
 
 ## E2E Tests
 
-All Iris E2E tests live in `tests/e2e/`. Every test is marked `e2e`.
+All Iris E2E tests live in `tests/e2e/`. Every test is marked `requires_cluster`.
 Tests are organized into two files:
 
 - **`test_smoke.py`**: Realistic scenario walkthroughs using a **module-scoped** cluster
@@ -160,19 +160,19 @@ Docker tests use a separate `docker_cluster` fixture and are marked `docker`.
 
 ```bash
 # All unit tests
-uv run pytest lib/iris/tests/ -m "not e2e" -o "addopts="
+uv run pytest lib/iris/tests/ -m "not requires_cluster" -o "addopts="
 
 # E2E smoke tests (shared cluster, fast)
-uv run pytest lib/iris/tests/e2e/test_smoke.py -m e2e -o "addopts="
+uv run pytest lib/iris/tests/e2e/test_smoke.py -m requires_cluster -o "addopts="
 
 # E2E chaos tests (fresh cluster per test, slower)
-uv run pytest lib/iris/tests/e2e/test_chaos.py -m e2e -o "addopts="
+uv run pytest lib/iris/tests/e2e/test_chaos.py -m requires_cluster -o "addopts="
 
 # All E2E tests
-uv run pytest lib/iris/tests/e2e/ -m e2e -o "addopts="
+uv run pytest lib/iris/tests/e2e/ -m requires_cluster -o "addopts="
 
 # E2E without Docker (fast)
-uv run pytest lib/iris/tests/e2e/ -m "e2e and not docker" -o "addopts="
+uv run pytest lib/iris/tests/e2e/ -m "requires_cluster and not docker" -o "addopts="
 
 # Docker-only tests
 uv run pytest lib/iris/tests/e2e/ -m docker -o "addopts="
@@ -181,11 +181,11 @@ uv run pytest lib/iris/tests/e2e/ -m docker -o "addopts="
 IRIS_SCREENSHOT_DIR=/tmp/shots uv run pytest lib/iris/tests/e2e/test_smoke.py -o "addopts="
 
 # Cloud mode: connect to running cluster
-uv run pytest lib/iris/tests/e2e/test_smoke.py -m e2e --iris-controller-url http://localhost:8080 -o "addopts="
+uv run pytest lib/iris/tests/e2e/test_smoke.py -m requires_cluster --iris-controller-url http://localhost:8080 -o "addopts="
 
 # Cloud mode: full lifecycle (start cluster, then pass URL to pytest)
 # Step 1: iris --cluster=smoke-gcp cluster start-smoke --label-prefix my-test --url-file /tmp/url --wait-for-workers 1
-# Step 2: uv run pytest lib/iris/tests/e2e/test_smoke.py -m e2e --iris-controller-url "$(cat /tmp/url)" -o "addopts="
+# Step 2: uv run pytest lib/iris/tests/e2e/test_smoke.py -m requires_cluster --iris-controller-url "$(cat /tmp/url)" -o "addopts="
 
 # K8s runtime tests (requires a running cluster — kind, k3d, minikube, etc.)
 uv run pytest lib/iris/tests/e2e/test_coreweave_live_kubernetes_runtime.py \

--- a/lib/iris/pyproject.toml
+++ b/lib/iris/pyproject.toml
@@ -90,11 +90,11 @@ packages = ["src/iris"]
 [tool.pytest.ini_options]
 timeout = 10
 timeout_method = "thread"
-addopts = "-n auto --durations=25 -m 'not slow and not docker and not e2e' -v"
+addopts = "-n auto --durations=25 -m 'not slow and not docker and not requires_cluster' -v"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "docker: marks tests requiring Docker runtime (slow, needs daemon)",
-    "e2e: end-to-end cluster tests (chaos, dashboard, scheduling)",
+    "requires_cluster: mark tests that need a running iris cluster",
 ]
 filterwarnings = ["ignore::DeprecationWarning"]
 # Cap assertion-diff output even under -v, so a single bad assertion

--- a/lib/iris/tests/client/test_worker_pool.py
+++ b/lib/iris/tests/client/test_worker_pool.py
@@ -11,7 +11,7 @@ from iris.client.worker_pool import (
 )
 from iris.cluster.types import ResourceSpec
 
-pytestmark = pytest.mark.e2e
+pytestmark = pytest.mark.requires_cluster
 
 
 @pytest.fixture

--- a/lib/iris/tests/e2e/test_attempt_logs.py
+++ b/lib/iris/tests/e2e/test_attempt_logs.py
@@ -13,7 +13,7 @@ import pytest
 from iris.chaos import enable_chaos
 from iris.rpc import job_pb2
 
-pytestmark = [pytest.mark.e2e, pytest.mark.timeout(60)]
+pytestmark = [pytest.mark.requires_cluster, pytest.mark.timeout(60)]
 
 
 def _fail_then_succeed(attempt_marker: str):

--- a/lib/iris/tests/e2e/test_chaos.py
+++ b/lib/iris/tests/e2e/test_chaos.py
@@ -30,7 +30,7 @@ from rigging.timing import Duration
 
 from .helpers import TestJobs
 
-pytestmark = [pytest.mark.e2e, pytest.mark.timeout(60)]
+pytestmark = [pytest.mark.requires_cluster, pytest.mark.timeout(60)]
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/e2e/test_cli.py
+++ b/lib/iris/tests/e2e/test_cli.py
@@ -24,7 +24,7 @@ from iris.cluster.types import Entrypoint, ResourceSpec
 from iris.rpc import controller_pb2, job_pb2
 from iris.rpc.controller_connect import ControllerServiceClientSync
 
-pytestmark = pytest.mark.e2e
+pytestmark = pytest.mark.requires_cluster
 
 
 @pytest.fixture(scope="module")

--- a/lib/iris/tests/e2e/test_demo_notebook.py
+++ b/lib/iris/tests/e2e/test_demo_notebook.py
@@ -14,7 +14,7 @@ from iris.cluster.providers.local.cluster import LocalCluster
 from iris.cluster.types import Entrypoint, ResourceSpec
 from iris.rpc import config_pb2
 
-pytestmark = pytest.mark.e2e
+pytestmark = pytest.mark.requires_cluster
 
 
 def _make_demo_config() -> config_pb2.IrisClusterConfig:

--- a/lib/iris/tests/e2e/test_docker.py
+++ b/lib/iris/tests/e2e/test_docker.py
@@ -18,7 +18,7 @@ from iris.rpc import config_pb2, job_pb2
 
 from tests.e2e._docker_cluster import E2ECluster
 
-pytestmark = [pytest.mark.e2e, pytest.mark.docker]
+pytestmark = [pytest.mark.requires_cluster, pytest.mark.docker]
 
 
 def unique_name(prefix: str) -> str:

--- a/lib/iris/tests/e2e/test_env_propagation.py
+++ b/lib/iris/tests/e2e/test_env_propagation.py
@@ -23,7 +23,7 @@ from iris.cluster.types import (
     ResourceSpec,
 )
 
-pytestmark = pytest.mark.e2e
+pytestmark = pytest.mark.requires_cluster
 
 
 def _parent_job_info(env: dict[str, str]) -> JobInfo:

--- a/lib/iris/tests/e2e/test_iris_run.py
+++ b/lib/iris/tests/e2e/test_iris_run.py
@@ -14,7 +14,7 @@ from iris.cli.job import load_env_vars, run_iris_job
 from iris.client import IrisClient
 from iris.cluster.config import connect_cluster, load_config, make_local_config
 
-pytestmark = pytest.mark.e2e
+pytestmark = pytest.mark.requires_cluster
 
 
 @pytest.fixture(scope="module")

--- a/lib/iris/tests/e2e/test_local_client.py
+++ b/lib/iris/tests/e2e/test_local_client.py
@@ -13,7 +13,7 @@ from iris.client.client import IrisClient, Job
 from iris.cluster.types import Entrypoint, EnvironmentSpec, JobName
 from iris.rpc import job_pb2
 
-pytestmark = pytest.mark.e2e
+pytestmark = pytest.mark.requires_cluster
 
 
 def extract_log_text(response: logging_pb2.FetchLogsResponse) -> str:

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -49,7 +49,7 @@ from .helpers import TestJobs
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.e2e
+pytestmark = pytest.mark.requires_cluster
 
 
 # ---------------------------------------------------------------------------

--- a/lib/levanter/AGENTS.md
+++ b/lib/levanter/AGENTS.md
@@ -12,7 +12,7 @@ JAX-based language model training library using Haliax named tensors and Equinox
 
 ```bash
 # Default test suite
-uv run pytest tests -m "not entry and not slow"
+uv run pytest tests -m "not slow"
 ```
 
 - Mark long-running tests with `@pytest.mark.slow`.

--- a/lib/levanter/pyproject.toml
+++ b/lib/levanter/pyproject.toml
@@ -209,8 +209,6 @@ filterwarnings = [
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "entry: marks tests as entry point tests (deselect with '-m \"not entry\"')",
     "torch: mark tests that use Torch (deselect with '-m \"not torch\"')",
-    "tpu: mark tests that require TPU (deselect with '-m \"not tpu\"')",
 ]
 asyncio_default_fixture_loop_scope = "function"

--- a/lib/levanter/tests/test_eval_lm.py
+++ b/lib/levanter/tests/test_eval_lm.py
@@ -5,7 +5,6 @@ import os
 import tempfile
 
 import jax
-import pytest
 
 import haliax
 
@@ -19,7 +18,6 @@ from levanter.trainer_state import TrainerState
 from test_utils import skip_if_no_torch
 
 
-@pytest.mark.entry
 def test_eval_lm():
     # just testing if eval_lm has a pulse
     # save a checkpoint
@@ -62,7 +60,6 @@ def test_eval_lm():
                 pass
 
 
-@pytest.mark.entry
 @skip_if_no_torch
 def test_eval_lm_from_hf():
     # just testing if eval_lm has a pulse

--- a/lib/levanter/tests/test_export_to_hf.py
+++ b/lib/levanter/tests/test_export_to_hf.py
@@ -8,7 +8,6 @@ from types import SimpleNamespace
 
 import equinox as eqx
 import jax
-import pytest
 from transformers import AutoModelForCausalLM
 
 import haliax
@@ -21,7 +20,6 @@ from levanter.utils.jax_utils import is_inexact_arrayish
 from test_utils import has_torch
 
 
-@pytest.mark.entry
 def test_export_lm_to_hf():
     # just testing if train_lm has a pulse
     model_config = Gpt2Config(

--- a/lib/levanter/tests/test_perplexity_gap.py
+++ b/lib/levanter/tests/test_perplexity_gap.py
@@ -577,7 +577,6 @@ def test_batch_chunks_rejects_oversized_chunks():
         list(batch_chunks([chunk], batch_size=1, max_eval_length=3))
 
 
-@pytest.mark.entry
 def test_perplexity_gap_main_same_model_zero_gap():
     model_config = LlamaConfig(
         num_layers=2,

--- a/lib/levanter/tests/test_train_asr.py
+++ b/lib/levanter/tests/test_train_asr.py
@@ -14,7 +14,6 @@ from test_utils import skip_if_no_soundlibs
 
 
 @pytest.mark.skip
-@pytest.mark.entry
 @skip_if_no_soundlibs
 def test_train_asr():
     # just testing if train_asr has a pulse

--- a/lib/levanter/tests/test_train_lm.py
+++ b/lib/levanter/tests/test_train_lm.py
@@ -6,7 +6,6 @@ import tempfile
 
 import jax
 import jax.numpy as jnp
-import pytest
 
 from haliax.quantization import QuantizationConfig
 
@@ -18,7 +17,6 @@ from levanter.distributed import DistributedConfig
 from levanter.tracker import NoopConfig
 
 
-@pytest.mark.entry
 def test_train_lm():
     # just testing if train_lm has a pulse
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -51,7 +49,6 @@ def test_train_lm():
                 pass
 
 
-@pytest.mark.entry
 def test_train_lm_fp8():
     # just testing if train_lm has a pulse
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -85,7 +82,6 @@ def test_train_lm_fp8():
                 pass
 
 
-@pytest.mark.entry
 def test_train_lm_direct_dataset():
     with tempfile.TemporaryDirectory():
         try:

--- a/lib/levanter/tests/test_utils.py
+++ b/lib/levanter/tests/test_utils.py
@@ -172,9 +172,15 @@ def skip_if_checkpoint_not_accessible(path: str):
 
 
 def skip_if_hf_model_not_accessible(model_id: str):
+    """Skip if the HF model is not present in the local cache.
+
+    Uses ``local_files_only=True`` so the probe (which runs at decoration
+    time) never issues network requests.
+    """
+
     def try_load_hf(model_id):
         try:
-            AutoConfig.from_pretrained(model_id)
+            AutoConfig.from_pretrained(model_id, local_files_only=True)
         except Exception:
             return False
         else:

--- a/lib/levanter/tests/test_viz_lm.py
+++ b/lib/levanter/tests/test_viz_lm.py
@@ -5,7 +5,6 @@ import os
 import tempfile
 
 import jax
-import pytest
 
 import haliax
 
@@ -17,7 +16,6 @@ from levanter.models.llama import LlamaConfig, LlamaLMHeadModel
 from levanter.tracker import NoopConfig
 
 
-@pytest.mark.entry
 def test_viz_lm():
     # just testing if eval_lm has a pulse
     # save a checkpoint

--- a/lib/marin/src/marin/execution/executor.py
+++ b/lib/marin/src/marin/execution/executor.py
@@ -1317,8 +1317,8 @@ class Executor:
 
         Args:
             steps: The steps to run.
-            dry_run: If True, only print out what needs to be done. Reads existing
-                statuses to report which steps would actually be executed.
+            dry_run: If True, walk the step graph and log what would run, without
+                touching remote filesystems or launching any work.
             run_only: If not None, only run the steps in the list and their dependencies. Matches steps' names as regex
             force_run_failed: If True, run steps even if they have already been run (including if they failed)
             max_concurrent: Maximum number of steps to run concurrently. If None, run all ready steps in parallel.
@@ -1350,8 +1350,11 @@ class Executor:
         if steps_to_run != self.steps:
             logger.info(f"### Running {len(steps_to_run)} steps out of {len(self.steps)} ###")
 
-        logger.info("### Writing metadata ###")
-        self.write_infos()
+        if dry_run:
+            logger.info("### Skipping metadata write (dry run) ###")
+        else:
+            logger.info("### Writing metadata ###")
+            self.write_infos()
 
         logger.info(f"### Launching {len(steps_to_run)} steps ###")
         if max_concurrent is not None:
@@ -1757,11 +1760,12 @@ def executor_main(
     )
     time_out = time.time()
     logger.info(f"Executor run took {time_out - time_in:.2f}s")
-    # print json path again so it's easy to copy
-    logger.info(f"Executor info written to {executor.executor_info_path}")
-    if not executor.prefix.startswith("gs://"):
-        logger.info("Start data browser: cd data_browser && uv run python run-dev.py --config conf/local.conf")
-    logger.info(f"View the experiment at {executor.get_experiment_url()}")
+    if not config.dry_run:
+        # print json path again so it's easy to copy
+        logger.info(f"Executor info written to {executor.executor_info_path}")
+        if not executor.prefix.startswith("gs://"):
+            logger.info("Start data browser: cd data_browser && uv run python run-dev.py --config conf/local.conf")
+        logger.info(f"View the experiment at {executor.get_experiment_url()}")
 
 
 def _make_prefix_absolute_path(prefix, override_path):

--- a/lib/marin/src/marin/execution/step_runner.py
+++ b/lib/marin/src/marin/execution/step_runner.py
@@ -264,6 +264,11 @@ class StepRunner:
         step_name = step.name_with_hash
         logger.info(f"Step = {step_name}\tParams = {step.hash_attrs}\tOutput_path = {output_path}")
 
+        # Short-circuit before any I/O so dry-run never touches remote status.
+        if dry_run:
+            logger.info(f"[DRY RUN] Would run {step_name}")
+            return None
+
         # Quick read-only status check to avoid submitting unnecessary jobs
         status = StatusFile(output_path, worker_id="check").status
         if status == STATUS_SUCCESS:
@@ -272,10 +277,6 @@ class StepRunner:
 
         if not force_run_failed and status in (STATUS_FAILED, STATUS_DEP_FAILED):
             raise PreviousTaskFailedError(f"Step {step_name} failed previously. Status: {status}")
-
-        if dry_run:
-            logger.info(f"[DRY RUN] Would run {step_name} (status: {status})")
-            return None
 
         _write_executor_info(step)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,11 +310,13 @@ markers = [
     "tpu_ci: mark tests that require a TPU",
     "integration: mark tests as integration tests that require cluster infrastructure",
     "data_integration: mark tests that require external data fixtures (e.g. HuggingFace datasets)",
+    "requires_cluster: mark tests that need a running iris cluster",
 ]
 testpaths = ["tests", "experiments"]
 
-# Don't run TPU, slow, integration, or data_integration tests by default.
+# Don't run TPU, slow, integration, data_integration, or cluster-bound tests by default.
 # Integration tests require external infrastructure (Iris cluster, GCS,
-# gated HF repos, etc.); data_integration tests fetch fixtures from HF.
-# Both are run from dedicated CI workflows.
-addopts = "--session-timeout=600 -m 'not tpu_ci and not slow and not integration and not data_integration'"
+# gated HF repos, etc.); data_integration tests fetch fixtures from HF;
+# requires_cluster tests need a running iris cluster (local or remote).
+# All are run from dedicated CI workflows.
+addopts = "--session-timeout=600 -m 'not tpu_ci and not slow and not integration and not data_integration and not requires_cluster'"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,65 +3,11 @@
 import os
 import tempfile
 
-import fsspec.core
 import pytest
 from fray import LocalClient, set_current_client
 
 DEFAULT_BUCKET_NAME = "marin-us-east5"
 DEFAULT_DOCUMENT_PATH = "documents/test-document-path"
-
-# URL schemes treated as "remote cloud storage" — tests must not silently reach these.
-# (http/https are intentionally excluded; mock-server-based tests use them.)
-_REMOTE_PROTOCOLS = ("gs://", "gcs://", "s3://", "hf://")
-
-
-class _StubRemoteFS:
-    """fsspec stub returned for remote URLs in tests.
-
-    `.exists()` reports False so callers that probe for cache hits (e.g.
-    ``StatusFile``) see "no remote state" and proceed locally. Any other
-    operation raises so accidental real I/O is loud, not slow. Tests that
-    legitimately need remote access should be marked with one of the
-    integration markers and run in a lane where this stub is disabled.
-    """
-
-    protocol = "memory"
-
-    def exists(self, *_args, **_kwargs):
-        return False
-
-    def isdir(self, *_args, **_kwargs):
-        return False
-
-    def isfile(self, *_args, **_kwargs):
-        return False
-
-    def __getattr__(self, name):
-        def _raise(*_a, **_kw):
-            raise RuntimeError(
-                f"Test attempted real remote I/O via {name}(). "
-                "Mark the test as data_integration/integration, or stub the call explicitly."
-            )
-
-        return _raise
-
-
-@pytest.fixture(autouse=True)
-def _stub_remote_filesystem(monkeypatch):
-    """Block remote fsspec access in tests by stubbing ``fsspec.core.url_to_fs``.
-
-    Patching at the fsspec layer covers every higher-level wrapper (including
-    ``rigging.filesystem.url_to_fs`` and the many call sites that did
-    ``from rigging.filesystem import url_to_fs``).
-    """
-    real_url_to_fs = fsspec.core.url_to_fs
-
-    def stubbed_url_to_fs(url, **kwargs):
-        if isinstance(url, str) and url.startswith(_REMOTE_PROTOCOLS):
-            return _StubRemoteFS(), url
-        return real_url_to_fs(url, **kwargs)
-
-    monkeypatch.setattr(fsspec.core, "url_to_fs", stubbed_url_to_fs)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,65 @@
 import os
 import tempfile
 
+import fsspec.core
 import pytest
 from fray import LocalClient, set_current_client
 
 DEFAULT_BUCKET_NAME = "marin-us-east5"
 DEFAULT_DOCUMENT_PATH = "documents/test-document-path"
+
+# URL schemes treated as "remote cloud storage" — tests must not silently reach these.
+# (http/https are intentionally excluded; mock-server-based tests use them.)
+_REMOTE_PROTOCOLS = ("gs://", "gcs://", "s3://", "hf://")
+
+
+class _StubRemoteFS:
+    """fsspec stub returned for remote URLs in tests.
+
+    `.exists()` reports False so callers that probe for cache hits (e.g.
+    ``StatusFile``) see "no remote state" and proceed locally. Any other
+    operation raises so accidental real I/O is loud, not slow. Tests that
+    legitimately need remote access should be marked with one of the
+    integration markers and run in a lane where this stub is disabled.
+    """
+
+    protocol = "memory"
+
+    def exists(self, *_args, **_kwargs):
+        return False
+
+    def isdir(self, *_args, **_kwargs):
+        return False
+
+    def isfile(self, *_args, **_kwargs):
+        return False
+
+    def __getattr__(self, name):
+        def _raise(*_a, **_kw):
+            raise RuntimeError(
+                f"Test attempted real remote I/O via {name}(). "
+                "Mark the test as data_integration/integration, or stub the call explicitly."
+            )
+
+        return _raise
+
+
+@pytest.fixture(autouse=True)
+def _stub_remote_filesystem(monkeypatch):
+    """Block remote fsspec access in tests by stubbing ``fsspec.core.url_to_fs``.
+
+    Patching at the fsspec layer covers every higher-level wrapper (including
+    ``rigging.filesystem.url_to_fs`` and the many call sites that did
+    ``from rigging.filesystem import url_to_fs``).
+    """
+    real_url_to_fs = fsspec.core.url_to_fs
+
+    def stubbed_url_to_fs(url, **kwargs):
+        if isinstance(url, str) and url.startswith(_REMOTE_PROTOCOLS):
+            return _StubRemoteFS(), url
+        return real_url_to_fs(url, **kwargs)
+
+    monkeypatch.setattr(fsspec.core, "url_to_fs", stubbed_url_to_fs)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/iris/test_iris_kind.py
+++ b/tests/integration/iris/test_iris_kind.py
@@ -88,7 +88,7 @@ def _make_test_entrypoint() -> job_pb2.RuntimeEntrypoint:
     return entrypoint
 
 
-pytestmark = pytest.mark.e2e
+pytestmark = pytest.mark.requires_cluster
 
 KIND_CLUSTER = "iris-gpu-test"
 KIND_CONTEXT = f"kind-{KIND_CLUSTER}"


### PR DESCRIPTION
Short-circuit dry-run before remote I/O in StepRunner and Executor. Stub gs/s3/hf fsspec calls in tests/conftest and switch skip_if_hf_model_not_accessible to local_files_only. Refactor testbed and exp1600 experiments to defer non-hermetic work (mixture weights, HF model config) into runtime steps. Drop dead levanter markers entry and tpu; migrate e2e to requires_cluster across tests, CI, and docs.