### PR TITLE
[iris] Build dashboard inside Docker, mirroring finelog

### DIFF
--- a/lib/iris/Dockerfile
+++ b/lib/iris/Dockerfile
@@ -8,6 +8,22 @@
 # The controller and worker share all layers up to and including Python
 # dependencies. The worker adds only the Docker CLI on top.
 
+# ── Stage: dashboard ─────────────────────────────────────────────────
+# Build the Vue SPA. Output is consumed by the deps stage at
+# /app/lib/iris/dashboard/dist; the controller/worker ASGI apps serve it
+# (see lib/iris/src/iris/cluster/dashboard_common.py).
+FROM node:22-slim AS dashboard
+
+WORKDIR /build/dashboard
+
+# Copy manifests first so dependency install is cached across source edits.
+COPY lib/iris/dashboard/package.json lib/iris/dashboard/package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm npm ci
+
+COPY lib/iris/dashboard/ ./
+RUN npm run build
+
+
 # ── Stage: base ──────────────────────────────────────────────────────
 # System dependencies shared by controller and worker.
 FROM python:3.12-slim AS base
@@ -77,8 +93,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install py-spy memray
 
-# Dashboard assets (pre-built by `iris build dashboard` before docker build)
-COPY lib/iris/dashboard/dist ./lib/iris/dashboard/dist
+# Dashboard assets — built by the `dashboard` stage above.
+COPY --from=dashboard /build/dashboard/dist ./lib/iris/dashboard/dist
 
 RUN mkdir -p /var/cache/iris
 

--- a/lib/iris/Dockerfile.dockerignore
+++ b/lib/iris/Dockerfile.dockerignore
@@ -6,7 +6,15 @@
 !lib/iris/src/
 !lib/iris/examples/
 !lib/iris/config/
-!lib/iris/dashboard/dist/
+!lib/iris/dashboard/package.json
+!lib/iris/dashboard/package-lock.json
+!lib/iris/dashboard/rsbuild.config.ts
+!lib/iris/dashboard/tsconfig.json
+!lib/iris/dashboard/tailwind.config.ts
+!lib/iris/dashboard/postcss.config.cjs
+!lib/iris/dashboard/env.d.ts
+!lib/iris/dashboard/favicon.ico
+!lib/iris/dashboard/src/
 
 !lib/rigging/
 

--- a/lib/iris/src/iris/cli/build.py
+++ b/lib/iris/src/iris/cli/build.py
@@ -172,27 +172,6 @@ def _ensure_protos() -> None:
     click.echo("Protobuf bindings regenerated.")
 
 
-def _ensure_dashboard_dist() -> None:
-    """Build Vue dashboard assets.
-
-    Called automatically before building controller/worker images so that
-    ``COPY dashboard/dist`` in the Dockerfile always has fresh assets.
-    """
-    iris_root = find_iris_root()
-    dashboard_dir = iris_root / "dashboard"
-    if not (dashboard_dir / "package.json").exists():
-        raise click.ClickException(
-            f"Dashboard source not found at {dashboard_dir}. " "Cannot build dashboard assets for Docker image."
-        )
-    click.echo("Building frontend assets...")
-    subprocess.run(["npm", "ci"], cwd=dashboard_dir, check=True)
-    result = subprocess.run(["npm", "run", "build"], cwd=dashboard_dir, capture_output=True, text=True)
-    if result.returncode != 0:
-        click.echo(result.stderr, err=True)
-        raise click.ClickException("Dashboard build failed")
-    click.echo("Dashboard built successfully.")
-
-
 def build_image(
     image_type: str,
     tag: str,
@@ -212,10 +191,6 @@ def build_image(
     and the registry cache is updated in the same operation. The images are NOT
     loaded into the local Docker daemon (buildx cannot do both simultaneously).
     """
-    # Controller and worker images COPY dashboard/dist — ensure it exists.
-    if image_type in ("controller", "worker"):
-        _ensure_dashboard_dist()
-
     iris_root = find_iris_root()
     dockerfile_path = iris_root / "Dockerfile"
     # Controller/worker Dockerfiles expect the marin repo root as build context


### PR DESCRIPTION
Add a node:22-slim dashboard build stage to lib/iris/Dockerfile and copy the resulting dist into the deps stage. Drops the host-side _ensure_dashboard_dist() prerequisite from `iris build worker-image` / `controller-image` so image builds no longer require host npm/node. Dockerfile.dockerignore now ships dashboard sources rather than the pre-built dist.