### PR TITLE
[iris] Fix empty periodic profiles: switch to speedscope, drop empty rows

### DIFF
--- a/.forge-state.json
+++ b/.forge-state.json
@@ -1,8 +1,0 @@
-{
-  "prompt": "https://github.com/marin-community/marin/issues/3291",
-  "name": "fix-issue-3291",
-  "worktree_path": "/Users/power/code/marin/.forge/worktrees/fix-issue-3291",
-  "design_path": "iris-users-and-authentication.md",
-  "last_completed_stage": "design",
-  "review_feedback": null
-}

--- a/lib/iris/src/iris/cluster/providers/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/tasks.py
@@ -1207,7 +1207,7 @@ class K8sTaskProvider:
         except Exception as e:
             return job_pb2.ProfileTaskResponse(error=str(e))
 
-        if self.profile_table is not None:
+        if self.profile_table is not None and resp.profile_data:
             pod_node_name = _get_pod_node_name(self.kubectl, pod_name)
             row = build_profile_row(
                 source=request.target,

--- a/lib/iris/src/iris/cluster/worker/worker.py
+++ b/lib/iris/src/iris/cluster/worker/worker.py
@@ -1081,7 +1081,7 @@ class Worker:
         limiter = RateLimiter(interval_seconds=self._profile_interval.to_seconds())
         cpu_request = job_pb2.ProfileTaskRequest(
             duration_seconds=self._profile_duration_seconds,
-            profile_type=job_pb2.ProfileType(cpu=job_pb2.CpuProfile(format=job_pb2.CpuProfile.RAW)),
+            profile_type=job_pb2.ProfileType(cpu=job_pb2.CpuProfile(format=job_pb2.CpuProfile.SPEEDSCOPE)),
         )
         while not stop_event.is_set():
             remaining = limiter.time_until_next()
@@ -1149,6 +1149,10 @@ class Worker:
             data = attempt.profile(duration, request.profile_type)
             row_source = task_id_wire
             row_attempt_id = resolved_attempt_id
+
+        if not data:
+            logger.debug("Empty profile for %s (trigger=%s); skipping iris.profile write", row_source, trigger.value)
+            return data
 
         assert self._profile_table is not None, "profile_table must be initialized before capture"
         self._profile_table.write(


### PR DESCRIPTION
py-spy record --format raw with --output leaves the file empty (raw is a stdout format), so the periodic loop's RAW captures landed in iris.profile as 0-byte rows. Switch the periodic CPU loop to SPEEDSCOPE and skip the finelog write when profile bytes are empty, in both Worker.capture_and_log_profile and K8sTaskProvider.profile_task. The pre-PR controller-side loop already had the empty-skip; #5583 dropped it.