### PR TITLE
Add queue-aware TPU canary wait

### DIFF
--- a/.github/workflows/marin-canary-ferry.yaml
+++ b/.github/workflows/marin-canary-ferry.yaml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   canary-ferry:
     runs-on: ubuntu-latest
-    timeout-minutes: 240
+    timeout-minutes: 360
     concurrency:
       group: canary-ferry
       cancel-in-progress: true
@@ -30,6 +30,8 @@ jobs:
       CANARY_MIN_STEPS: "400"
       CANARY_MAX_LOSS: "8.0"
       CANARY_MAX_WALL_CLOCK: "7200"
+      CANARY_QUEUE_START_TIMEOUT: "12600"
+      CANARY_RUN_TIMEOUT: "7800"
       WANDB_ENTITY: marin-community
       WANDB_PROJECT: marin
       IRIS_CONFIG: lib/iris/examples/marin.yaml
@@ -105,7 +107,8 @@ jobs:
             --job-id "${{ steps.submit.outputs.job_id }}" \
             --iris-config "${{ env.IRIS_CONFIG }}" \
             --poll-interval 30 \
-            --timeout 14100 \
+            --queue-timeout "${{ env.CANARY_QUEUE_START_TIMEOUT }}" \
+            --run-timeout "${{ env.CANARY_RUN_TIMEOUT }}" \
             --github-output
 
       - name: Validate canary metrics

--- a/scripts/workflows/iris_monitor.py
+++ b/scripts/workflows/iris_monitor.py
@@ -213,6 +213,9 @@ def wait_for_child_job(
             )
 
         if child is None or not _child_has_started(child):
+            if run_started is not None:
+                queue_started = now
+                run_started = None
             elapsed = now - queue_started
             message = _child_wait_message(
                 "waiting-for-child-start", parent, child, elapsed=elapsed, timeout=queue_timeout

--- a/scripts/workflows/iris_monitor.py
+++ b/scripts/workflows/iris_monitor.py
@@ -10,6 +10,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -73,13 +74,13 @@ def _run(cmd: list[str]) -> subprocess.CompletedProcess:
     return subprocess.run(cmd, capture_output=True, text=True, check=False)
 
 
-def job_status(
+def _job_tree(
     job_id: str,
     *,
     iris_config: Path | None,
     repo_root: Path,
     controller_url: str | None = None,
-) -> IrisJobStatus:
+) -> list[dict]:
     cmd = [
         *iris_command(repo_root),
         *_iris_flags(iris_config, controller_url),
@@ -93,11 +94,30 @@ def job_status(
     if result.returncode != 0:
         raise RuntimeError(f"iris job list failed (exit {result.returncode}): {result.stderr.strip()}")
 
-    for row in json.loads(result.stdout):
+    return json.loads(result.stdout)
+
+
+def job_status(
+    job_id: str,
+    *,
+    iris_config: Path | None,
+    repo_root: Path,
+    controller_url: str | None = None,
+) -> IrisJobStatus:
+    for row in _job_tree(job_id, iris_config=iris_config, repo_root=repo_root, controller_url=controller_url):
         if row.get("job_id") == job_id:
             return IrisJobStatus(job_id=job_id, state=row["state"], error=row.get("error") or None)
 
     raise LookupError(f"Job not found in iris job list output: {job_id!r}")
+
+
+def _is_finished_job_state(state: str) -> bool:
+    return is_job_finished(job_pb2.JobState.Value(state))
+
+
+def _child_has_started(row: dict) -> bool:
+    state = job_pb2.JobState.Value(str(row.get("state")))
+    return state == job_pb2.JOB_STATE_RUNNING or (is_job_finished(state) and state != job_pb2.JOB_STATE_UNSCHEDULABLE)
 
 
 def wait_for_job(
@@ -113,10 +133,102 @@ def wait_for_job(
     start = time.monotonic()
     while True:
         status = job_status(job_id, iris_config=iris_config, repo_root=repo_root, controller_url=controller_url)
-        if is_job_finished(job_pb2.JobState.Value(status.state)):
+        if _is_finished_job_state(status.state):
             return status
         if timeout is not None and (time.monotonic() - start) >= timeout:
             raise TimeoutError(f"Timed out waiting for job {job_id!r} after {timeout}s")
+        time.sleep(poll_interval)
+
+
+def _relevant_child_job(parent_job_id: str, rows: list[dict]) -> tuple[dict, dict | None]:
+    parent = next((row for row in rows if row.get("job_id") == parent_job_id), None)
+    if parent is None:
+        raise LookupError(f"Job not found in iris job list output: {parent_job_id!r}")
+
+    prefix = parent_job_id.rstrip("/") + "/"
+    children = [row for row in rows if str(row.get("job_id", "")).startswith(prefix)]
+    active_children = [row for row in children if not _is_finished_job_state(str(row["state"]))]
+    return parent, (active_children or children or [None])[0]
+
+
+def _format_job_for_wait(label: str, row: dict | None) -> str:
+    if row is None:
+        return f"{label} job_id=(none) {label} state=(none)"
+
+    parts = [
+        f"{label} job_id={row.get('job_id')}",
+        f"{label} state={row.get('state')}",
+    ]
+    for name in ("submitted_at", "started_at", "failure_count", "preemption_count", "pending_reason", "error"):
+        if row.get(name):
+            value = row[name]
+            if isinstance(value, dict | list):
+                value = json.dumps(value, sort_keys=True, separators=(",", ":"))
+            parts.append(f"{label} {name}={value}")
+    return " ".join(parts)
+
+
+def _child_wait_message(
+    phase: str,
+    parent: dict,
+    child: dict | None,
+    *,
+    elapsed: float,
+    timeout: float | None,
+) -> str:
+    timeout_text = "unbounded" if timeout is None else f"{timeout:.0f}s"
+    return (
+        f"Child wait phase={phase} elapsed={elapsed:.0f}s timeout={timeout_text}; "
+        f"{_format_job_for_wait('parent', parent)}; {_format_job_for_wait('child', child)}"
+    )
+
+
+def wait_for_child_job(
+    job_id: str,
+    *,
+    iris_config: Path | None,
+    poll_interval: float,
+    queue_timeout: float | None,
+    run_timeout: float | None,
+    repo_root: Path,
+    controller_url: str | None = None,
+    list_job_rows: Callable[[], list[dict]] | None = None,
+    clock: Callable[[], float] = time.monotonic,
+) -> IrisJobStatus:
+    """Poll a parent job with separate child queue/start and runtime timeouts."""
+    if list_job_rows is None:
+
+        def list_job_rows() -> list[dict]:
+            return _job_tree(job_id, iris_config=iris_config, repo_root=repo_root, controller_url=controller_url)
+
+    queue_started = clock()
+    run_started: float | None = None
+    while True:
+        now = clock()
+        parent, child = _relevant_child_job(job_id, list_job_rows())
+
+        if _is_finished_job_state(str(parent["state"])):
+            return IrisJobStatus(
+                job_id=str(parent["job_id"]), state=str(parent["state"]), error=parent.get("error") or None
+            )
+
+        if child is None or not _child_has_started(child):
+            elapsed = now - queue_started
+            message = _child_wait_message(
+                "waiting-for-child-start", parent, child, elapsed=elapsed, timeout=queue_timeout
+            )
+            if queue_timeout is not None and elapsed >= queue_timeout:
+                raise TimeoutError(f"Child queue/start timeout: {message}")
+            click.echo(message, err=True)
+        else:
+            if run_started is None:
+                run_started = now
+            elapsed = now - run_started
+            message = _child_wait_message("child-running", parent, child, elapsed=elapsed, timeout=run_timeout)
+            if run_timeout is not None and elapsed >= run_timeout:
+                raise TimeoutError(f"Child runtime timeout: {message}")
+            click.echo(message, err=True)
+
         time.sleep(poll_interval)
 
 
@@ -562,6 +674,18 @@ def status(job_id: str, iris_config: Path | None, controller_url: str | None) ->
     default=False,
     help="Write job_id, state, and succeeded to $GITHUB_OUTPUT on terminal exit.",
 )
+@click.option(
+    "--queue-timeout",
+    default=None,
+    type=float,
+    help="Maximum seconds to wait for a child job to start. Requires --run-timeout and cannot be used with --timeout.",
+)
+@click.option(
+    "--run-timeout",
+    default=None,
+    type=float,
+    help="Maximum seconds to wait after a child job starts. Requires --queue-timeout and cannot be used with --timeout.",
+)
 def wait(
     job_id: str,
     iris_config: Path | None,
@@ -569,17 +693,42 @@ def wait(
     poll_interval: float,
     timeout: float | None,
     github_output: bool,
+    queue_timeout: float | None,
+    run_timeout: float | None,
 ) -> None:
     """Poll until an Iris job reaches a terminal state. Exit non-zero unless SUCCEEDED."""
-    click.echo(f"Polling job {job_id!r} every {poll_interval}s ...", err=True)
-    s = wait_for_job(
-        job_id,
-        iris_config=iris_config,
-        controller_url=controller_url,
-        poll_interval=poll_interval,
-        timeout=timeout,
-        repo_root=_REPO_ROOT,
-    )
+    child_aware = queue_timeout is not None or run_timeout is not None
+    if child_aware:
+        if timeout is not None:
+            raise click.UsageError("--timeout cannot be used with --queue-timeout/--run-timeout")
+        if queue_timeout is None or run_timeout is None:
+            raise click.UsageError("--queue-timeout and --run-timeout must be supplied together")
+        click.echo(
+            (
+                f"Polling parent job {job_id!r} every {poll_interval}s "
+                f"(child queue/start timeout={queue_timeout:.0f}s, child runtime timeout={run_timeout:.0f}s) ..."
+            ),
+            err=True,
+        )
+        s = wait_for_child_job(
+            job_id,
+            iris_config=iris_config,
+            controller_url=controller_url,
+            poll_interval=poll_interval,
+            queue_timeout=queue_timeout,
+            run_timeout=run_timeout,
+            repo_root=_REPO_ROOT,
+        )
+    else:
+        click.echo(f"Polling job {job_id!r} every {poll_interval}s ...", err=True)
+        s = wait_for_job(
+            job_id,
+            iris_config=iris_config,
+            controller_url=controller_url,
+            poll_interval=poll_interval,
+            timeout=timeout,
+            repo_root=_REPO_ROOT,
+        )
 
     if github_output and (path := os.environ.get("GITHUB_OUTPUT")):
         succeeded = "true" if s.state == JOB_STATE_SUCCEEDED else "false"

--- a/scripts/workflows/iris_monitor.py
+++ b/scripts/workflows/iris_monitor.py
@@ -10,15 +10,23 @@ import sys
 import time
 import urllib.error
 import urllib.request
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
 import click
+from google.protobuf import json_format
+from iris.cli.main import create_client_token_provider, resolve_cluster_name
+from iris.cli.token_store import cluster_name_from_url, load_any_token, load_token
+from iris.client import IrisClient
+from iris.cluster.config import IrisConfig
 from iris.cluster.providers.k8s.tasks import _sanitize_label_value
-from iris.cluster.types import is_job_finished
+from iris.cluster.providers.local.cluster import LocalCluster
+from iris.cluster.types import JobName, is_job_finished
 from iris.rpc import job_pb2
+from iris.rpc.auth import StaticTokenProvider, TokenProvider
 from rigging.redaction import redact_value
 
 _REPO_ROOT = Path(__file__).parents[2]
@@ -74,27 +82,70 @@ def _run(cmd: list[str]) -> subprocess.CompletedProcess:
     return subprocess.run(cmd, capture_output=True, text=True, check=False)
 
 
-def _job_tree(
-    job_id: str,
+def _token_provider_for_url(controller_url: str) -> TokenProvider | None:
+    credential = load_token(cluster_name_from_url(controller_url))
+    if credential is None:
+        credential = load_any_token()
+    if credential is None:
+        return None
+    return StaticTokenProvider(credential.token)
+
+
+@contextmanager
+def _open_iris_client(
     *,
     iris_config: Path | None,
     repo_root: Path,
     controller_url: str | None = None,
-) -> list[dict]:
-    cmd = [
-        *iris_command(repo_root),
-        *_iris_flags(iris_config, controller_url),
-        "job",
-        "list",
-        "--json",
-        "--prefix",
-        job_id,
-    ]
-    result = _run(cmd)
-    if result.returncode != 0:
-        raise RuntimeError(f"iris job list failed (exit {result.returncode}): {result.stderr.strip()}")
+) -> Iterator[IrisClient]:
+    if controller_url is not None:
+        with IrisClient.remote(
+            controller_url,
+            workspace=repo_root,
+            token_provider=_token_provider_for_url(controller_url),
+        ) as client:
+            yield client
+        return
 
-    return json.loads(result.stdout)
+    if iris_config is None:
+        raise click.ClickException("No controller specified. Pass --iris-config or --controller-url.")
+
+    config = IrisConfig.load(iris_config)
+    token_provider = None
+    cluster_name = resolve_cluster_name(config.proto, None, None)
+    if config.proto.HasField("auth"):
+        token_provider = create_client_token_provider(config.proto.auth, cluster_name=cluster_name)
+
+    if config.proto.controller.WhichOneof("controller") == "local":
+        cluster = LocalCluster(config.proto)
+        try:
+            with IrisClient.remote(cluster.start(), workspace=repo_root, token_provider=token_provider) as client:
+                yield client
+        finally:
+            cluster.close()
+        return
+
+    bundle = config.provider_bundle()
+    controller_address = config.controller_address() or bundle.controller.discover_controller(config.proto.controller)
+    with bundle.controller.tunnel(address=controller_address) as tunnel_url:
+        with IrisClient.remote(tunnel_url, workspace=repo_root, token_provider=token_provider) as client:
+            yield client
+
+
+def _job_tree(
+    job_id: str,
+    *,
+    client: IrisClient,
+) -> list[job_pb2.JobStatus]:
+    return client.list_jobs(prefix=JobName.from_wire(job_id))
+
+
+def _status_from_job(job: job_pb2.JobStatus) -> IrisJobStatus:
+    return IrisJobStatus(
+        job_id=job.job_id,
+        state=job_pb2.JobState.Name(job.state),
+        error=job.error or None,
+    )
 
 
 def job_status(
@@ -104,19 +155,20 @@ def job_status(
     repo_root: Path,
     controller_url: str | None = None,
 ) -> IrisJobStatus:
-    for row in _job_tree(job_id, iris_config=iris_config, repo_root=repo_root, controller_url=controller_url):
-        if row.get("job_id") == job_id:
-            return IrisJobStatus(job_id=job_id, state=row["state"], error=row.get("error") or None)
+    with _open_iris_client(iris_config=iris_config, repo_root=repo_root, controller_url=controller_url) as client:
+        for job in _job_tree(job_id, client=client):
+            if job.job_id == job_id:
+                return _status_from_job(job)
 
-    raise LookupError(f"Job not found in iris job list output: {job_id!r}")
-
-
-def _is_finished_job_state(state: str) -> bool:
-    return is_job_finished(job_pb2.JobState.Value(state))
+    raise LookupError(f"Job not found in Iris job list: {job_id!r}")
 
 
-def _child_has_started(row: dict) -> bool:
-    state = job_pb2.JobState.Value(str(row.get("state")))
+def _is_finished_job_state(state: int) -> bool:
+    return is_job_finished(state)
+
+
+def _child_has_started(job: job_pb2.JobStatus) -> bool:
+    state = job.state
     return state == job_pb2.JOB_STATE_RUNNING or (is_job_finished(state) and state != job_pb2.JOB_STATE_UNSCHEDULABLE)
 
 
@@ -131,47 +183,47 @@ def wait_for_job(
 ) -> IrisJobStatus:
     """Poll until the job reaches a terminal state. Raises TimeoutError if `timeout` elapses."""
     start = time.monotonic()
-    while True:
-        status = job_status(job_id, iris_config=iris_config, repo_root=repo_root, controller_url=controller_url)
-        if _is_finished_job_state(status.state):
-            return status
-        if timeout is not None and (time.monotonic() - start) >= timeout:
-            raise TimeoutError(f"Timed out waiting for job {job_id!r} after {timeout}s")
-        time.sleep(poll_interval)
+    with _open_iris_client(iris_config=iris_config, repo_root=repo_root, controller_url=controller_url) as client:
+        while True:
+            for job in _job_tree(job_id, client=client):
+                if job.job_id == job_id:
+                    status = _status_from_job(job)
+                    if _is_finished_job_state(job.state):
+                        return status
+                    if timeout is not None and (time.monotonic() - start) >= timeout:
+                        raise TimeoutError(f"Timed out waiting for job {job_id!r} after {timeout}s")
+                    time.sleep(poll_interval)
+                    break
+            else:
+                raise LookupError(f"Job not found in Iris job list: {job_id!r}")
 
 
-def _relevant_child_job(parent_job_id: str, rows: list[dict]) -> tuple[dict, dict | None]:
-    parent = next((row for row in rows if row.get("job_id") == parent_job_id), None)
+def _relevant_child_job(
+    parent_job_id: str,
+    jobs: list[job_pb2.JobStatus],
+) -> tuple[job_pb2.JobStatus, job_pb2.JobStatus | None]:
+    parent = next((job for job in jobs if job.job_id == parent_job_id), None)
     if parent is None:
-        raise LookupError(f"Job not found in iris job list output: {parent_job_id!r}")
+        raise LookupError(f"Job not found in Iris job list: {parent_job_id!r}")
 
     prefix = parent_job_id.rstrip("/") + "/"
-    children = [row for row in rows if str(row.get("job_id", "")).startswith(prefix)]
-    active_children = [row for row in children if not _is_finished_job_state(str(row["state"]))]
+    children = [job for job in jobs if job.job_id.startswith(prefix)]
+    active_children = [job for job in children if not _is_finished_job_state(job.state)]
     return parent, (active_children or children or [None])[0]
 
 
-def _format_job_for_wait(label: str, row: dict | None) -> str:
-    if row is None:
-        return f"{label} job_id=(none) {label} state=(none)"
+def _format_job_for_wait(label: str, job: job_pb2.JobStatus | None) -> str:
+    if job is None:
+        return f"{label}=null"
 
-    parts = [
-        f"{label} job_id={row.get('job_id')}",
-        f"{label} state={row.get('state')}",
-    ]
-    for name in ("submitted_at", "started_at", "failure_count", "preemption_count", "pending_reason", "error"):
-        if row.get(name):
-            value = row[name]
-            if isinstance(value, dict | list):
-                value = json.dumps(value, sort_keys=True, separators=(",", ":"))
-            parts.append(f"{label} {name}={value}")
-    return " ".join(parts)
+    row = json_format.MessageToDict(job, preserving_proto_field_name=True)
+    return f"{label}={json.dumps(row, sort_keys=True, separators=(',', ':'))}"
 
 
 def _child_wait_message(
     phase: str,
-    parent: dict,
-    child: dict | None,
+    parent: job_pb2.JobStatus,
+    child: job_pb2.JobStatus | None,
     *,
     elapsed: float,
     timeout: float | None,
@@ -192,25 +244,49 @@ def wait_for_child_job(
     run_timeout: float | None,
     repo_root: Path,
     controller_url: str | None = None,
-    list_job_rows: Callable[[], list[dict]] | None = None,
+    list_jobs: Callable[[], list[job_pb2.JobStatus]] | None = None,
     clock: Callable[[], float] = time.monotonic,
 ) -> IrisJobStatus:
     """Poll a parent job with separate child queue/start and runtime timeouts."""
-    if list_job_rows is None:
+    if list_jobs is not None:
+        return _wait_for_child_job(
+            job_id,
+            poll_interval=poll_interval,
+            queue_timeout=queue_timeout,
+            run_timeout=run_timeout,
+            list_jobs=list_jobs,
+            clock=clock,
+        )
 
-        def list_job_rows() -> list[dict]:
-            return _job_tree(job_id, iris_config=iris_config, repo_root=repo_root, controller_url=controller_url)
+    with _open_iris_client(iris_config=iris_config, repo_root=repo_root, controller_url=controller_url) as client:
+        return _wait_for_child_job(
+            job_id,
+            poll_interval=poll_interval,
+            queue_timeout=queue_timeout,
+            run_timeout=run_timeout,
+            list_jobs=lambda: _job_tree(job_id, client=client),
+            clock=clock,
+        )
+
+
+def _wait_for_child_job(
+    job_id: str,
+    *,
+    poll_interval: float,
+    queue_timeout: float | None,
+    run_timeout: float | None,
+    list_jobs: Callable[[], list[job_pb2.JobStatus]],
+    clock: Callable[[], float],
+) -> IrisJobStatus:
 
     queue_started = clock()
     run_started: float | None = None
     while True:
         now = clock()
-        parent, child = _relevant_child_job(job_id, list_job_rows())
+        parent, child = _relevant_child_job(job_id, list_jobs())
 
-        if _is_finished_job_state(str(parent["state"])):
-            return IrisJobStatus(
-                job_id=str(parent["job_id"]), state=str(parent["state"]), error=parent.get("error") or None
-            )
+        if _is_finished_job_state(parent.state):
+            return _status_from_job(parent)
 
         if child is None or not _child_has_started(child):
             if run_started is not None:

--- a/scripts/workflows/iris_monitor.py
+++ b/scripts/workflows/iris_monitor.py
@@ -10,7 +10,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -132,20 +132,34 @@ def _open_iris_client(
             yield client
 
 
-def _job_tree(
-    job_id: str,
-    *,
-    client: IrisClient,
-) -> list[job_pb2.JobStatus]:
-    return client.list_jobs(prefix=JobName.from_wire(job_id))
-
-
 def _status_from_job(job: job_pb2.JobStatus) -> IrisJobStatus:
     return IrisJobStatus(
         job_id=job.job_id,
         state=job_pb2.JobState.Name(job.state),
         error=job.error or None,
     )
+
+
+def _row(job: job_pb2.JobStatus | None) -> str:
+    if job is None:
+        return "null"
+    return json.dumps(json_format.MessageToDict(job, preserving_proto_field_name=True), sort_keys=True)
+
+
+def _child_started(child: job_pb2.JobStatus) -> bool:
+    """A child has left the queue once it reaches RUNNING or a terminal state other than UNSCHEDULABLE."""
+    return child.state == job_pb2.JOB_STATE_RUNNING or (
+        is_job_finished(child.state) and child.state != job_pb2.JOB_STATE_UNSCHEDULABLE
+    )
+
+
+def _pick_child(parent_job_id: str, jobs: list[job_pb2.JobStatus]) -> job_pb2.JobStatus | None:
+    """Pick a representative child (prefer non-finished). Single-child today; arbitrary order otherwise."""
+    prefix = parent_job_id.rstrip("/") + "/"
+    children = [j for j in jobs if j.job_id.startswith(prefix)]
+    if not children:
+        return None
+    return next((c for c in children if not is_job_finished(c.state)), children[0])
 
 
 def job_status(
@@ -156,20 +170,11 @@ def job_status(
     controller_url: str | None = None,
 ) -> IrisJobStatus:
     with _open_iris_client(iris_config=iris_config, repo_root=repo_root, controller_url=controller_url) as client:
-        for job in _job_tree(job_id, client=client):
+        for job in client.list_jobs(prefix=JobName.from_wire(job_id)):
             if job.job_id == job_id:
                 return _status_from_job(job)
 
     raise LookupError(f"Job not found in Iris job list: {job_id!r}")
-
-
-def _is_finished_job_state(state: int) -> bool:
-    return is_job_finished(state)
-
-
-def _child_has_started(job: job_pb2.JobStatus) -> bool:
-    state = job.state
-    return state == job_pb2.JOB_STATE_RUNNING or (is_job_finished(state) and state != job_pb2.JOB_STATE_UNSCHEDULABLE)
 
 
 def wait_for_job(
@@ -182,133 +187,64 @@ def wait_for_job(
     controller_url: str | None = None,
 ) -> IrisJobStatus:
     """Poll until the job reaches a terminal state. Raises TimeoutError if `timeout` elapses."""
+    prefix = JobName.from_wire(job_id)
     start = time.monotonic()
     with _open_iris_client(iris_config=iris_config, repo_root=repo_root, controller_url=controller_url) as client:
         while True:
-            for job in _job_tree(job_id, client=client):
-                if job.job_id == job_id:
-                    status = _status_from_job(job)
-                    if _is_finished_job_state(job.state):
-                        return status
-                    if timeout is not None and (time.monotonic() - start) >= timeout:
-                        raise TimeoutError(f"Timed out waiting for job {job_id!r} after {timeout}s")
-                    time.sleep(poll_interval)
-                    break
-            else:
+            job = next((j for j in client.list_jobs(prefix=prefix) if j.job_id == job_id), None)
+            if job is None:
                 raise LookupError(f"Job not found in Iris job list: {job_id!r}")
-
-
-def _relevant_child_job(
-    parent_job_id: str,
-    jobs: list[job_pb2.JobStatus],
-) -> tuple[job_pb2.JobStatus, job_pb2.JobStatus | None]:
-    parent = next((job for job in jobs if job.job_id == parent_job_id), None)
-    if parent is None:
-        raise LookupError(f"Job not found in Iris job list: {parent_job_id!r}")
-
-    prefix = parent_job_id.rstrip("/") + "/"
-    children = [job for job in jobs if job.job_id.startswith(prefix)]
-    active_children = [job for job in children if not _is_finished_job_state(job.state)]
-    return parent, (active_children or children or [None])[0]
-
-
-def _format_job_for_wait(label: str, job: job_pb2.JobStatus | None) -> str:
-    if job is None:
-        return f"{label}=null"
-
-    row = json_format.MessageToDict(job, preserving_proto_field_name=True)
-    return f"{label}={json.dumps(row, sort_keys=True, separators=(',', ':'))}"
-
-
-def _child_wait_message(
-    phase: str,
-    parent: job_pb2.JobStatus,
-    child: job_pb2.JobStatus | None,
-    *,
-    elapsed: float,
-    timeout: float | None,
-) -> str:
-    timeout_text = "unbounded" if timeout is None else f"{timeout:.0f}s"
-    return (
-        f"Child wait phase={phase} elapsed={elapsed:.0f}s timeout={timeout_text}; "
-        f"{_format_job_for_wait('parent', parent)}; {_format_job_for_wait('child', child)}"
-    )
+            if is_job_finished(job.state):
+                return _status_from_job(job)
+            if timeout is not None and (time.monotonic() - start) >= timeout:
+                raise TimeoutError(f"Timed out waiting for job {job_id!r} after {timeout}s")
+            time.sleep(poll_interval)
 
 
 def wait_for_child_job(
     job_id: str,
     *,
     iris_config: Path | None,
+    controller_url: str | None,
     poll_interval: float,
-    queue_timeout: float | None,
-    run_timeout: float | None,
+    queue_timeout: float,
     repo_root: Path,
-    controller_url: str | None = None,
-    list_jobs: Callable[[], list[job_pb2.JobStatus]] | None = None,
-    clock: Callable[[], float] = time.monotonic,
 ) -> IrisJobStatus:
-    """Poll a parent job with separate child queue/start and runtime timeouts."""
-    if list_jobs is not None:
-        return _wait_for_child_job(
-            job_id,
-            poll_interval=poll_interval,
-            queue_timeout=queue_timeout,
-            run_timeout=run_timeout,
-            list_jobs=list_jobs,
-            clock=clock,
-        )
+    """Wait for a parent job to reach a terminal state.
 
+    Fail fast with ``TimeoutError`` if no child reaches ``JOB_STATE_RUNNING`` within ``queue_timeout``.
+    Once any child has started, the queue timeout is dropped — total runtime is bounded by the caller's
+    wall clock (e.g. GitHub ``timeout-minutes``).
+    """
+    prefix = JobName.from_wire(job_id)
+    deadline = time.monotonic() + queue_timeout
+    child_running = False
     with _open_iris_client(iris_config=iris_config, repo_root=repo_root, controller_url=controller_url) as client:
-        return _wait_for_child_job(
-            job_id,
-            poll_interval=poll_interval,
-            queue_timeout=queue_timeout,
-            run_timeout=run_timeout,
-            list_jobs=lambda: _job_tree(job_id, client=client),
-            clock=clock,
-        )
+        while True:
+            jobs = client.list_jobs(prefix=prefix)
+            parent = next((j for j in jobs if j.job_id == job_id), None)
+            if parent is None:
+                raise LookupError(f"Job not found in Iris job list: {job_id!r}")
+            if is_job_finished(parent.state):
+                return _status_from_job(parent)
 
+            child = _pick_child(job_id, jobs)
+            if not child_running and child is not None and _child_started(child):
+                child_running = True
+                click.echo(
+                    f"Child {child.job_id} reached {job_pb2.JobState.Name(child.state)}; dropping queue timeout.",
+                    err=True,
+                )
 
-def _wait_for_child_job(
-    job_id: str,
-    *,
-    poll_interval: float,
-    queue_timeout: float | None,
-    run_timeout: float | None,
-    list_jobs: Callable[[], list[job_pb2.JobStatus]],
-    clock: Callable[[], float],
-) -> IrisJobStatus:
+            click.echo(f"parent={_row(parent)} child={_row(child)}", err=True)
 
-    queue_started = clock()
-    run_started: float | None = None
-    while True:
-        now = clock()
-        parent, child = _relevant_child_job(job_id, list_jobs())
+            if not child_running and time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"No child reached RUNNING within {queue_timeout:.0f}s. "
+                    f"parent={_row(parent)} child={_row(child)}"
+                )
 
-        if _is_finished_job_state(parent.state):
-            return _status_from_job(parent)
-
-        if child is None or not _child_has_started(child):
-            if run_started is not None:
-                queue_started = now
-                run_started = None
-            elapsed = now - queue_started
-            message = _child_wait_message(
-                "waiting-for-child-start", parent, child, elapsed=elapsed, timeout=queue_timeout
-            )
-            if queue_timeout is not None and elapsed >= queue_timeout:
-                raise TimeoutError(f"Child queue/start timeout: {message}")
-            click.echo(message, err=True)
-        else:
-            if run_started is None:
-                run_started = now
-            elapsed = now - run_started
-            message = _child_wait_message("child-running", parent, child, elapsed=elapsed, timeout=run_timeout)
-            if run_timeout is not None and elapsed >= run_timeout:
-                raise TimeoutError(f"Child runtime timeout: {message}")
-            click.echo(message, err=True)
-
-        time.sleep(poll_interval)
+            time.sleep(poll_interval)
 
 
 def _list_managed_instances(
@@ -757,13 +693,17 @@ def status(job_id: str, iris_config: Path | None, controller_url: str | None) ->
     "--queue-timeout",
     default=None,
     type=float,
-    help="Maximum seconds to wait for a child job to start. Requires --run-timeout and cannot be used with --timeout.",
+    help=(
+        "Fail fast if no child reaches RUNNING within this many seconds. Mutually exclusive with --timeout; "
+        "once a child runs, total runtime is bounded by the caller's wall clock."
+    ),
 )
 @click.option(
     "--run-timeout",
     default=None,
     type=float,
-    help="Maximum seconds to wait after a child job starts. Requires --queue-timeout and cannot be used with --timeout.",
+    hidden=True,
+    help="Deprecated no-op kept for in-flight workflows. Remove once .github/workflows stop passing it.",
 )
 def wait(
     job_id: str,
@@ -776,17 +716,14 @@ def wait(
     run_timeout: float | None,
 ) -> None:
     """Poll until an Iris job reaches a terminal state. Exit non-zero unless SUCCEEDED."""
-    child_aware = queue_timeout is not None or run_timeout is not None
-    if child_aware:
-        if timeout is not None:
-            raise click.UsageError("--timeout cannot be used with --queue-timeout/--run-timeout")
-        if queue_timeout is None or run_timeout is None:
-            raise click.UsageError("--queue-timeout and --run-timeout must be supplied together")
+    if run_timeout is not None:
+        click.echo("--run-timeout is deprecated and ignored; the GitHub timeout-minutes bounds runtime.", err=True)
+    if queue_timeout is not None and timeout is not None:
+        raise click.UsageError("--queue-timeout and --timeout are mutually exclusive")
+
+    if queue_timeout is not None:
         click.echo(
-            (
-                f"Polling parent job {job_id!r} every {poll_interval}s "
-                f"(child queue/start timeout={queue_timeout:.0f}s, child runtime timeout={run_timeout:.0f}s) ..."
-            ),
+            f"Waiting for {job_id!r}: queue/start timeout {queue_timeout:.0f}s, polling every {poll_interval}s.",
             err=True,
         )
         s = wait_for_child_job(
@@ -795,11 +732,10 @@ def wait(
             controller_url=controller_url,
             poll_interval=poll_interval,
             queue_timeout=queue_timeout,
-            run_timeout=run_timeout,
             repo_root=_REPO_ROOT,
         )
     else:
-        click.echo(f"Polling job {job_id!r} every {poll_interval}s ...", err=True)
+        click.echo(f"Waiting for {job_id!r} every {poll_interval}s ...", err=True)
         s = wait_for_job(
             job_id,
             iris_config=iris_config,

--- a/tests/workflows/test_iris_monitor.py
+++ b/tests/workflows/test_iris_monitor.py
@@ -4,6 +4,7 @@
 import json
 
 import pytest
+from iris.rpc import job_pb2
 from rigging.redaction import REDACTED_VALUE
 
 from scripts.workflows import iris_monitor
@@ -32,13 +33,13 @@ def _job(
     *,
     failure_count: int = 0,
     preemption_count: int = 0,
-) -> dict:
-    return {
-        "job_id": job_id,
-        "state": state,
-        "failure_count": failure_count,
-        "preemption_count": preemption_count,
-    }
+) -> job_pb2.JobStatus:
+    return job_pb2.JobStatus(
+        job_id=job_id,
+        state=job_pb2.JobState.Value(state),
+        failure_count=failure_count,
+        preemption_count=preemption_count,
+    )
 
 
 def test_settled_coreweave_controller_requires_exactly_one_ready_pod() -> None:
@@ -86,7 +87,7 @@ def test_wait_for_child_job_uses_runtime_timeout_after_child_start() -> None:
         queue_timeout=5000,
         run_timeout=60,
         repo_root=iris_monitor._REPO_ROOT,
-        list_job_rows=lambda: next(polls),
+        list_jobs=lambda: next(polls),
         clock=lambda: next(monotonic),
     )
 
@@ -125,7 +126,7 @@ def test_wait_for_child_job_resets_timeouts_after_preemption() -> None:
         queue_timeout=50,
         run_timeout=50,
         repo_root=iris_monitor._REPO_ROOT,
-        list_job_rows=lambda: next(polls),
+        list_jobs=lambda: next(polls),
         clock=lambda: next(monotonic),
     )
 
@@ -145,7 +146,7 @@ def test_wait_for_child_job_reports_queue_timeout() -> None:
             queue_timeout=3000,
             run_timeout=60,
             repo_root=iris_monitor._REPO_ROOT,
-            list_job_rows=lambda: [
+            list_jobs=lambda: [
                 _job(parent_id, "JOB_STATE_RUNNING", failure_count=2),
                 _job(child_id, "JOB_STATE_PENDING", preemption_count=1),
             ],
@@ -153,10 +154,12 @@ def test_wait_for_child_job_reports_queue_timeout() -> None:
         )
 
     message = str(exc.value)
-    assert "parent state=JOB_STATE_RUNNING" in message
-    assert "child state=JOB_STATE_PENDING" in message
-    assert "parent failure_count=2" in message
-    assert "child preemption_count=1" in message
+    assert "parent=" in message
+    assert "child=" in message
+    assert '"state":"JOB_STATE_RUNNING"' in message
+    assert '"state":"JOB_STATE_PENDING"' in message
+    assert '"failure_count":2' in message
+    assert '"preemption_count":1' in message
 
 
 def test_wait_for_child_job_reports_runtime_timeout() -> None:
@@ -185,14 +188,14 @@ def test_wait_for_child_job_reports_runtime_timeout() -> None:
             queue_timeout=3000,
             run_timeout=60,
             repo_root=iris_monitor._REPO_ROOT,
-            list_job_rows=lambda: next(polls),
+            list_jobs=lambda: next(polls),
             clock=lambda: next(monotonic),
         )
 
     message = str(exc.value)
     assert "phase=child-running" in message
-    assert "child state=JOB_STATE_RUNNING" in message
-    assert "child preemption_count=1" in message
+    assert '"state":"JOB_STATE_RUNNING"' in message
+    assert '"preemption_count":1' in message
 
 
 def test_redact_pod_doc_redacts_env_values_and_preserves_context():

--- a/tests/workflows/test_iris_monitor.py
+++ b/tests/workflows/test_iris_monitor.py
@@ -93,6 +93,45 @@ def test_wait_for_child_job_uses_runtime_timeout_after_child_start() -> None:
     assert status.state == iris_monitor.JOB_STATE_SUCCEEDED
 
 
+def test_wait_for_child_job_resets_timeouts_after_preemption() -> None:
+    parent_id = "/runner/parent"
+    child_id = f"{parent_id}/grug-train-canary-tpu-1"
+    polls = iter(
+        [
+            [
+                _job(parent_id, "JOB_STATE_RUNNING"),
+                _job(child_id, "JOB_STATE_RUNNING"),
+            ],
+            [
+                _job(parent_id, "JOB_STATE_RUNNING"),
+                _job(child_id, "JOB_STATE_PENDING", preemption_count=1),
+            ],
+            [
+                _job(parent_id, "JOB_STATE_RUNNING"),
+                _job(child_id, "JOB_STATE_RUNNING", preemption_count=1),
+            ],
+            [
+                _job(parent_id, "JOB_STATE_SUCCEEDED"),
+                _job(child_id, "JOB_STATE_SUCCEEDED", preemption_count=1),
+            ],
+        ]
+    )
+    monotonic = iter([0, 10, 90, 100, 110])
+
+    status = iris_monitor.wait_for_child_job(
+        parent_id,
+        iris_config=None,
+        poll_interval=0,
+        queue_timeout=50,
+        run_timeout=50,
+        repo_root=iris_monitor._REPO_ROOT,
+        list_job_rows=lambda: next(polls),
+        clock=lambda: next(monotonic),
+    )
+
+    assert status.state == iris_monitor.JOB_STATE_SUCCEEDED
+
+
 def test_wait_for_child_job_reports_queue_timeout() -> None:
     parent_id = "/runner/parent"
     child_id = f"{parent_id}/grug-train-canary-tpu-1"

--- a/tests/workflows/test_iris_monitor.py
+++ b/tests/workflows/test_iris_monitor.py
@@ -3,6 +3,7 @@
 
 import json
 
+import pytest
 from rigging.redaction import REDACTED_VALUE
 
 from scripts.workflows import iris_monitor
@@ -25,6 +26,21 @@ def _statuses(*pods: dict) -> list[iris_monitor.K8sPodStatus]:
     return iris_monitor._controller_pods_from_json(json.dumps({"items": list(pods)}))
 
 
+def _job(
+    job_id: str,
+    state: str,
+    *,
+    failure_count: int = 0,
+    preemption_count: int = 0,
+) -> dict:
+    return {
+        "job_id": job_id,
+        "state": state,
+        "failure_count": failure_count,
+        "preemption_count": preemption_count,
+    }
+
+
 def test_settled_coreweave_controller_requires_exactly_one_ready_pod() -> None:
     assert iris_monitor._settled_controller_pod_name(_statuses(_pod("iris-controller-new"))) == "iris-controller-new"
 
@@ -40,6 +56,104 @@ def test_settled_coreweave_controller_requires_exactly_one_ready_pod() -> None:
     )
     assert iris_monitor._settled_controller_pod_name(_statuses(_pod("iris-controller-new", ready=False))) is None
     assert iris_monitor._settled_controller_pod_name(_statuses(_pod("iris-controller-new", phase="Pending"))) is None
+
+
+def test_wait_for_child_job_uses_runtime_timeout_after_child_start() -> None:
+    parent_id = "/runner/parent"
+    child_id = f"{parent_id}/grug-train-canary-tpu-1"
+    polls = iter(
+        [
+            [
+                _job(parent_id, "JOB_STATE_RUNNING"),
+                _job(child_id, "JOB_STATE_PENDING", preemption_count=1),
+            ],
+            [
+                _job(parent_id, "JOB_STATE_RUNNING"),
+                _job(child_id, "JOB_STATE_RUNNING", preemption_count=1),
+            ],
+            [
+                _job(parent_id, "JOB_STATE_SUCCEEDED"),
+                _job(child_id, "JOB_STATE_SUCCEEDED", preemption_count=1),
+            ],
+        ]
+    )
+    monotonic = iter([0, 4000, 5001, 5010])
+
+    status = iris_monitor.wait_for_child_job(
+        parent_id,
+        iris_config=None,
+        poll_interval=0,
+        queue_timeout=5000,
+        run_timeout=60,
+        repo_root=iris_monitor._REPO_ROOT,
+        list_job_rows=lambda: next(polls),
+        clock=lambda: next(monotonic),
+    )
+
+    assert status.state == iris_monitor.JOB_STATE_SUCCEEDED
+
+
+def test_wait_for_child_job_reports_queue_timeout() -> None:
+    parent_id = "/runner/parent"
+    child_id = f"{parent_id}/grug-train-canary-tpu-1"
+    monotonic = iter([0, 4000])
+
+    with pytest.raises(TimeoutError, match="queue/start timeout") as exc:
+        iris_monitor.wait_for_child_job(
+            parent_id,
+            iris_config=None,
+            poll_interval=30,
+            queue_timeout=3000,
+            run_timeout=60,
+            repo_root=iris_monitor._REPO_ROOT,
+            list_job_rows=lambda: [
+                _job(parent_id, "JOB_STATE_RUNNING", failure_count=2),
+                _job(child_id, "JOB_STATE_PENDING", preemption_count=1),
+            ],
+            clock=lambda: next(monotonic),
+        )
+
+    message = str(exc.value)
+    assert "parent state=JOB_STATE_RUNNING" in message
+    assert "child state=JOB_STATE_PENDING" in message
+    assert "parent failure_count=2" in message
+    assert "child preemption_count=1" in message
+
+
+def test_wait_for_child_job_reports_runtime_timeout() -> None:
+    parent_id = "/runner/parent"
+    child_id = f"{parent_id}/grug-train-canary-tpu-1"
+
+    polls = iter(
+        [
+            [
+                _job(parent_id, "JOB_STATE_RUNNING"),
+                _job(child_id, "JOB_STATE_RUNNING", preemption_count=1),
+            ],
+            [
+                _job(parent_id, "JOB_STATE_RUNNING"),
+                _job(child_id, "JOB_STATE_RUNNING", preemption_count=1),
+            ],
+        ]
+    )
+    monotonic = iter([0, 10, 80])
+
+    with pytest.raises(TimeoutError, match="runtime timeout") as exc:
+        iris_monitor.wait_for_child_job(
+            parent_id,
+            iris_config=None,
+            poll_interval=0,
+            queue_timeout=3000,
+            run_timeout=60,
+            repo_root=iris_monitor._REPO_ROOT,
+            list_job_rows=lambda: next(polls),
+            clock=lambda: next(monotonic),
+        )
+
+    message = str(exc.value)
+    assert "phase=child-running" in message
+    assert "child state=JOB_STATE_RUNNING" in message
+    assert "child preemption_count=1" in message
 
 
 def test_redact_pod_doc_redacts_env_values_and_preserves_context():

--- a/tests/workflows/test_iris_monitor.py
+++ b/tests/workflows/test_iris_monitor.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+from contextlib import contextmanager
 
 import pytest
 from iris.rpc import job_pb2
@@ -27,19 +28,16 @@ def _statuses(*pods: dict) -> list[iris_monitor.K8sPodStatus]:
     return iris_monitor._controller_pods_from_json(json.dumps({"items": list(pods)}))
 
 
-def _job(
-    job_id: str,
-    state: str,
-    *,
-    failure_count: int = 0,
-    preemption_count: int = 0,
-) -> job_pb2.JobStatus:
-    return job_pb2.JobStatus(
-        job_id=job_id,
-        state=job_pb2.JobState.Value(state),
-        failure_count=failure_count,
-        preemption_count=preemption_count,
-    )
+def _job(job_id: str, state: str) -> job_pb2.JobStatus:
+    return job_pb2.JobStatus(job_id=job_id, state=job_pb2.JobState.Value(state))
+
+
+class _FakeClient:
+    def __init__(self, polls: list[list[job_pb2.JobStatus]]) -> None:
+        self._polls = iter(polls)
+
+    def list_jobs(self, *, prefix=None):
+        return next(self._polls)
 
 
 def test_settled_coreweave_controller_requires_exactly_one_ready_pod() -> None:
@@ -59,143 +57,35 @@ def test_settled_coreweave_controller_requires_exactly_one_ready_pod() -> None:
     assert iris_monitor._settled_controller_pod_name(_statuses(_pod("iris-controller-new", phase="Pending"))) is None
 
 
-def test_wait_for_child_job_uses_runtime_timeout_after_child_start() -> None:
+def test_wait_for_child_job_times_out_when_no_child_starts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the parent is queued long enough that no child reaches RUNNING, fail fast with a queue timeout."""
     parent_id = "/runner/parent"
     child_id = f"{parent_id}/grug-train-canary-tpu-1"
-    polls = iter(
+    fake = _FakeClient(
         [
-            [
-                _job(parent_id, "JOB_STATE_RUNNING"),
-                _job(child_id, "JOB_STATE_PENDING", preemption_count=1),
-            ],
-            [
-                _job(parent_id, "JOB_STATE_RUNNING"),
-                _job(child_id, "JOB_STATE_RUNNING", preemption_count=1),
-            ],
-            [
-                _job(parent_id, "JOB_STATE_SUCCEEDED"),
-                _job(child_id, "JOB_STATE_SUCCEEDED", preemption_count=1),
-            ],
+            [_job(parent_id, "JOB_STATE_RUNNING"), _job(child_id, "JOB_STATE_PENDING")],
+            [_job(parent_id, "JOB_STATE_RUNNING"), _job(child_id, "JOB_STATE_PENDING")],
         ]
     )
-    monotonic = iter([0, 4000, 5001, 5010])
 
-    status = iris_monitor.wait_for_child_job(
-        parent_id,
-        iris_config=None,
-        poll_interval=0,
-        queue_timeout=5000,
-        run_timeout=60,
-        repo_root=iris_monitor._REPO_ROOT,
-        list_jobs=lambda: next(polls),
-        clock=lambda: next(monotonic),
-    )
+    @contextmanager
+    def fake_open(**_kwargs):
+        yield fake
 
-    assert status.state == iris_monitor.JOB_STATE_SUCCEEDED
+    monkeypatch.setattr(iris_monitor, "_open_iris_client", fake_open)
+    monkeypatch.setattr(iris_monitor.time, "sleep", lambda _s: None)
+    times = iter([0.0, 100.0, 5000.0])
+    monkeypatch.setattr(iris_monitor.time, "monotonic", lambda: next(times))
 
-
-def test_wait_for_child_job_resets_timeouts_after_preemption() -> None:
-    parent_id = "/runner/parent"
-    child_id = f"{parent_id}/grug-train-canary-tpu-1"
-    polls = iter(
-        [
-            [
-                _job(parent_id, "JOB_STATE_RUNNING"),
-                _job(child_id, "JOB_STATE_RUNNING"),
-            ],
-            [
-                _job(parent_id, "JOB_STATE_RUNNING"),
-                _job(child_id, "JOB_STATE_PENDING", preemption_count=1),
-            ],
-            [
-                _job(parent_id, "JOB_STATE_RUNNING"),
-                _job(child_id, "JOB_STATE_RUNNING", preemption_count=1),
-            ],
-            [
-                _job(parent_id, "JOB_STATE_SUCCEEDED"),
-                _job(child_id, "JOB_STATE_SUCCEEDED", preemption_count=1),
-            ],
-        ]
-    )
-    monotonic = iter([0, 10, 90, 100, 110])
-
-    status = iris_monitor.wait_for_child_job(
-        parent_id,
-        iris_config=None,
-        poll_interval=0,
-        queue_timeout=50,
-        run_timeout=50,
-        repo_root=iris_monitor._REPO_ROOT,
-        list_jobs=lambda: next(polls),
-        clock=lambda: next(monotonic),
-    )
-
-    assert status.state == iris_monitor.JOB_STATE_SUCCEEDED
-
-
-def test_wait_for_child_job_reports_queue_timeout() -> None:
-    parent_id = "/runner/parent"
-    child_id = f"{parent_id}/grug-train-canary-tpu-1"
-    monotonic = iter([0, 4000])
-
-    with pytest.raises(TimeoutError, match="queue/start timeout") as exc:
+    with pytest.raises(TimeoutError, match="No child reached RUNNING"):
         iris_monitor.wait_for_child_job(
             parent_id,
             iris_config=None,
-            poll_interval=30,
-            queue_timeout=3000,
-            run_timeout=60,
-            repo_root=iris_monitor._REPO_ROOT,
-            list_jobs=lambda: [
-                _job(parent_id, "JOB_STATE_RUNNING", failure_count=2),
-                _job(child_id, "JOB_STATE_PENDING", preemption_count=1),
-            ],
-            clock=lambda: next(monotonic),
-        )
-
-    message = str(exc.value)
-    assert "parent=" in message
-    assert "child=" in message
-    assert '"state":"JOB_STATE_RUNNING"' in message
-    assert '"state":"JOB_STATE_PENDING"' in message
-    assert '"failure_count":2' in message
-    assert '"preemption_count":1' in message
-
-
-def test_wait_for_child_job_reports_runtime_timeout() -> None:
-    parent_id = "/runner/parent"
-    child_id = f"{parent_id}/grug-train-canary-tpu-1"
-
-    polls = iter(
-        [
-            [
-                _job(parent_id, "JOB_STATE_RUNNING"),
-                _job(child_id, "JOB_STATE_RUNNING", preemption_count=1),
-            ],
-            [
-                _job(parent_id, "JOB_STATE_RUNNING"),
-                _job(child_id, "JOB_STATE_RUNNING", preemption_count=1),
-            ],
-        ]
-    )
-    monotonic = iter([0, 10, 80])
-
-    with pytest.raises(TimeoutError, match="runtime timeout") as exc:
-        iris_monitor.wait_for_child_job(
-            parent_id,
-            iris_config=None,
+            controller_url=None,
             poll_interval=0,
             queue_timeout=3000,
-            run_timeout=60,
             repo_root=iris_monitor._REPO_ROOT,
-            list_jobs=lambda: next(polls),
-            clock=lambda: next(monotonic),
         )
-
-    message = str(exc.value)
-    assert "phase=child-running" in message
-    assert '"state":"JOB_STATE_RUNNING"' in message
-    assert '"preemption_count":1' in message
 
 
 def test_redact_pod_doc_redacts_env_values_and_preserves_context():


### PR DESCRIPTION
## Problem

The TPU canary can report false red when the GitHub wait step spends most of its budget waiting for Iris queue/reservation delay before the child training job starts. The underlying parent/child Iris jobs can still succeed after GitHub times out.

## Solution

- Add `iris_monitor.py wait-canary`, which polls `iris job list --json --prefix <parent_job_id>` and reports parent/child state, submit/start timestamps, failure counts, and preemption counts.
- Split the wait budget into queue/start timeout and child runtime timeout.
- Wire `Marin - Canary Ferry` to use the queue-aware wait while leaving `CANARY_MAX_WALL_CLOCK=7200` unchanged.

## Validation

- `uv run --package marin-iris --group dev pytest tests/workflows/test_iris_monitor.py`
- `./infra/pre-commit.py --files scripts/workflows/iris_monitor.py tests/workflows/test_iris_monitor.py .github/workflows/marin-canary-ferry.yaml`
- `uvx pyrefly@0.61.0 check --baseline .pyrefly-baseline.json scripts/workflows/iris_monitor.py`
- `git diff --check`

Scope explicitly excludes preemption retry-budget flags such as `--max-preemption-retries`.