### PR TITLE
zephyr: cap fs.put multipart concurrency

### DIFF
--- a/lib/zephyr/src/zephyr/writers.py
+++ b/lib/zephyr/src/zephyr/writers.py
@@ -20,6 +20,7 @@ from typing import Any
 import msgspec
 import pyarrow as pa
 from rigging.filesystem import open_url, url_to_fs
+from rigging.timing import log_time
 
 from zephyr import counters
 
@@ -76,9 +77,16 @@ def atomic_rename(output_path: str) -> Iterable[str]:
             local_path = os.path.join(local_tmp_dir, "output")
             yield local_path
             if os.path.isdir(local_path):
-                # Trailing slash prevents fsspec from nesting under an extra
-                # "output/" level when the destination already exists.
-                fs.put(local_path + "/", resolved_path, recursive=True)
+                # batch_size caps concurrent files in flight. Per-file ceiling
+                # is max_concurrency=10 * chunksize=50 MiB = 500 MiB for any
+                # file ≥ 100 MiB (smaller ones skip multipart). fsspec's default
+                # batch_size=128 → 64 GiB ceiling, observed ~11 GiB peak on a
+                # 40-chunk sample. batch_size=8 → 4 GiB ceiling, observed ~2 GiB
+                # peak on the same sample.
+                with log_time(f"atomic_rename fs.put recursive {local_path} → {resolved_path}"):
+                    # Trailing slash prevents fsspec from nesting under an extra
+                    # "output/" level when the destination already exists.
+                    fs.put(local_path + "/", resolved_path, recursive=True, batch_size=8)
             else:
                 fs.put(local_path, resolved_path)
         return


### PR DESCRIPTION
* cap `fs.put` `batch_size=8` in `atomic_rename`'s S3 upload path
* fsspec defaults compound an unbounded multipart-buffer ceiling: per-file `max_concurrency=10` × `chunksize=50 MiB` = `500 MiB` in-flight for any file ≥ 100 MiB, across files default `batch_size=128` → 64 GiB theoretical ceiling, observed ~11 GiB peak on a 40-chunk TreeStore sample, pushing tokenize workers past 32 GiB into SIGKILL after `Cache ledger written`
* `batch_size=8` → ~4 GiB ceiling, observed ~2 GiB peak on the same sample [^1]
* wrap recursive `fs.put` in `rigging.timing.log_time` to track wall-clock cost

[^1]: 8 was picked empirically, not swept; future tuning could trade ceiling for wall-clock by raising it, or cap per-file memory directly via `max_concurrency`