### PR TITLE
normalize: add bare mode

### DIFF
--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -103,6 +103,7 @@ def generate_id(text: str) -> str:
 def _make_normalize_fn(
     text_field: str,
     id_field: str,
+    bare: bool = False,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Return a record-level transform function.
 
@@ -110,7 +111,15 @@ def _make_normalize_fn(
     1. Extracts ``text`` from *text_field*.
     2. Generates a deterministic ``id`` via xxh3_128.
     3. If *id_field* exists in the record, preserves it as ``source_id``.
-    4. Keeps all other columns.
+    4. Keeps all other columns unless *bare* is set (see below).
+
+    *bare* takes the strict path: drop every column that isn't ``id``,
+    ``text``, or ``source_id``. Use this for sources whose extra columns
+    vary across shards (e.g. starcoderdata's 87 language subdirs each
+    ship a different set of GitHub-meta columns, or proof-pile-2's
+    nested ``meta`` dict with optional-typed fields); the parquet writer
+    can't add columns mid-write and the reduce stage can't widen
+    null-vs-typed, so a uniform schema is the only safe option.
 
     Records with missing or blank text must be filtered out before calling
     the returned function.
@@ -126,13 +135,14 @@ def _make_normalize_fn(
         # --- build output ---
         out: dict[str, Any] = {}
 
-        # Copy all original columns except the ones we're replacing
-        for k, v in record.items():
-            if k == id_field:
-                continue
-            if k == text_field and text_field != "text":
-                continue
-            out[k] = v
+        if not bare:
+            # Copy all original columns except the ones we're replacing
+            for k, v in record.items():
+                if k == id_field:
+                    continue
+                if k == text_field and text_field != "text":
+                    continue
+                out[k] = v
 
         out["id"] = generate_id(text)
         out["text"] = text
@@ -315,9 +325,10 @@ def _build_pipeline(
     id_field: str | None,
     dedup_mode: DedupMode,
     max_whitespace_run_chars: int,
+    bare: bool = False,
 ) -> Dataset:
     """Build the Zephyr pipeline that normalizes *files* into *output_dir*."""
-    normalize_record = _make_normalize_fn(text_field, id_field)
+    normalize_record = _make_normalize_fn(text_field, id_field, bare=bare)
 
     def dedup(_key: str, items: Iterator[dict[str, Any]]) -> Iterator[MainOutput | ExactDupSideOutput]:
         """Drop adjacent duplicate ids. Items arrive sorted by id via sort_by."""
@@ -371,6 +382,7 @@ def normalize_to_parquet(
     max_workers: int | None = None,
     file_extensions: tuple[str, ...] | None = None,
     dedup_mode: DedupMode = DedupMode.EXACT,
+    bare: bool = False,
 ) -> NormalizedData:
     """Normalize raw downloaded data to the datakit standard Parquet format.
 
@@ -441,6 +453,7 @@ def normalize_to_parquet(
         id_field,
         dedup_mode,
         max_whitespace_run_chars,
+        bare=bare,
     )
     ctx_kwargs: dict = {"name": "normalize", "resources": resources}
     if max_workers is not None:
@@ -482,6 +495,7 @@ def normalize_step(
     file_extensions: tuple[str, ...] | None = None,
     dedup_mode: DedupMode = DedupMode.EXACT,
     version: str | None = None,
+    bare: bool = False,
 ) -> StepSpec:
     """Create a StepSpec that normalizes downloaded data to Parquet.
 
@@ -531,6 +545,10 @@ def normalize_step(
         "file_extensions": file_extensions,
         "dedup_mode": dedup_mode,
     }
+    # Only include bare in hash when set so default callers' hash_id stays
+    # identical to pre-feature step specs (cache identity).
+    if bare:
+        hash_attrs["bare"] = bare
     # Only include the version key when the caller explicitly opts in, so
     # default callers preserve their existing hash_id and cache hits.
     if version is not None:
@@ -549,6 +567,7 @@ def normalize_step(
             max_workers=max_workers,
             file_extensions=file_extensions,
             dedup_mode=dedup_mode,
+            bare=bare,
         ),
         deps=[download],
         hash_attrs=hash_attrs,

--- a/tests/datakit/test_normalize.py
+++ b/tests/datakit/test_normalize.py
@@ -106,6 +106,41 @@ def test_custom_id_field(tmp_path: Path, write_jsonl_gz):
     assert "my_custom_id" not in results[0]
 
 
+def test_bare_mode_strips_extra_columns(tmp_path: Path, write_jsonl_gz):
+    """bare=True drops every column that isn't id, text, or source_id.
+
+    Motivating case: sources whose extra columns vary across shards (e.g.
+    starcoderdata's 87 language subdirs each ship a different set of
+    GitHub-meta columns, or proof-pile-2's nested ``meta`` dict with
+    optional-typed fields). A uniform schema is the only safe option,
+    so dump everything but id/text/source_id at the record level before
+    the writer sees it.
+    """
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+
+    records = [
+        {"id": "a", "text": "row a", "meta": {"max_stars_count": 3}, "lang": "en"},
+        {"id": "b", "text": "row b", "meta": None, "lang": "fr"},
+    ]
+    write_jsonl_gz(input_dir / "data.jsonl.gz", records)
+
+    normalize_to_parquet(
+        input_path=str(input_dir),
+        output_path=str(output_dir),
+        bare=True,
+    )
+
+    results = _read_all_parquet(output_dir)
+    assert len(results) == 2
+    for r in results:
+        # bare drops record-level extras; partition_id is stamped on later by
+        # the writer and is independent of bare mode.
+        assert set(r.keys()) - {"partition_id"} == {"id", "text", "source_id"}
+    assert {r["source_id"] for r in results} == {"a", "b"}
+    assert {r["text"] for r in results} == {"row a", "row b"}
+
+
 def test_missing_id_field_silently_skipped(tmp_path: Path, write_jsonl_gz):
     """When id_field is absent from records, source_id is omitted (not an error)."""
     input_dir = tmp_path / "input"


### PR DESCRIPTION
* add `bare=True` to `normalize_step` / `normalize_to_parquet` / `_make_normalize_fn` / `_build_pipeline` — emits only `id`, `text`, `source_id`, dropping every other source column at the record level before the parquet writer sees it
* motivating sources: `starcoderdata`'s 87 language subdirs each ship a different set of GitHub-meta columns; `proof-pile-2` carries a nested `meta` dict with optional-typed fields [^1]
* `bare` is only added to `hash_attrs` when `True`, so existing default-callers preserve their `hash_id` and cache hits
* test `test_bare_mode_strips_extra_columns` asserts the bare output schema on a heterogeneous-meta shape

[^1]: parquet writer can't add columns mid-write, so a uniform record-level schema is the only safe option for shard-variable sources