### PR TITLE
[iris] drain on every replacement path, not just RECREATE-running

### DIFF
--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -140,10 +140,12 @@ DEFAULT_MAX_TOTAL_LINES = 100000
 MAX_BUNDLE_SIZE_BYTES = 25 * 1024 * 1024
 
 # Time the launch RPC blocks waiting for a replaced job's worker-bound attempts
-# to finalize before deleting them. Normal worker shutdown is well under one
-# minute; the bound is finite so a stuck finalization surfaces as
-# DEADLINE_EXCEEDED rather than hanging launches forever.
-_JOB_REPLACEMENT_DRAIN_TIMEOUT = Duration.from_minutes(10)
+# to finalize before deleting them. One worker poll cycle is ~5s; 30s gives the
+# heartbeat path several cycles to stamp ``finished_at_ms`` for a producer-
+# terminated attempt (the common case is post-preemption cleanup where the
+# worker is busy serving another tenant but will report back within one cycle).
+# Stuck finalization surfaces as DEADLINE_EXCEEDED rather than hanging launches.
+_JOB_REPLACEMENT_DRAIN_TIMEOUT = Duration.from_seconds(30)
 
 # A root LaunchJob submission is rejected if its client_revision_date is more
 # than FRESHNESS_WINDOW older than today. Clients get exactly this long to
@@ -1058,20 +1060,21 @@ class ControllerServiceImpl:
         except TimeoutError as exc:
             raise ConnectError(Code.DEADLINE_EXCEEDED, str(exc)) from exc
 
-    def _remove_finished_job_safely(self, cur, job_id: JobName) -> None:
-        """``remove_finished_job`` gated on no unfinished worker-bound attempts.
+    def _replace_finished_job(self, cur, job_id: JobName) -> bool:
+        """Attempt to replace a terminal job; signal whether a drain is needed.
 
         CASCADE-deleting a job's tasks while its attempts are still worker-
         bound destroys the rows the heartbeat path needs to find when it
-        stamps ``finished_at_ms``. Every replacement / prune / admin-delete
-        path goes through here so that contract is uniform.
+        stamps ``finished_at_ms``. Returns ``True`` when the caller must wait
+        for worker-bound attempts to finalize before retrying (the job rows
+        are left in place), ``False`` when removal completed in this
+        transaction. Every replacement path in ``launch_job`` funnels through
+        here so the contract is uniform.
         """
         if self._store.jobs.has_unfinished_worker_attempts(cur, job_id):
-            raise ConnectError(
-                Code.FAILED_PRECONDITION,
-                f"Refusing to remove job {job_id}: worker-bound attempts have not finalized",
-            )
+            return True
         self._transitions.remove_finished_job(cur, job_id)
+        return False
 
     def launch_job(
         self,
@@ -1175,8 +1178,11 @@ class ControllerServiceImpl:
                 elif policy == job_pb2.EXISTING_JOB_POLICY_KEEP:
                     if not is_job_finished(existing_state):
                         return controller_pb2.Controller.LaunchJobResponse(job_id=job_id.to_wire())
-                    # Job finished, replace it (KEEP only preserves running jobs)
-                    self._remove_finished_job_safely(cur, job_id)
+                    # Job finished, replace it (KEEP only preserves running jobs).
+                    # If worker-bound attempts haven't finalized yet (e.g. the
+                    # task is terminal at the job level but its attempt is still
+                    # pending a heartbeat), defer to the drain wait below.
+                    needs_drain = needs_drain or self._replace_finished_job(cur, job_id)
                 elif policy == job_pb2.EXISTING_JOB_POLICY_RECREATE:
                     if not is_job_finished(existing_state):
                         self._transitions.cancel_job(cur, job_id, "Replaced by new submission")
@@ -1188,7 +1194,7 @@ class ControllerServiceImpl:
                         # still racing to land.
                         needs_drain = True
                     else:
-                        self._remove_finished_job_safely(cur, job_id)
+                        needs_drain = needs_drain or self._replace_finished_job(cur, job_id)
                 elif is_job_finished(existing_state):
                     # Default/UNSPECIFIED: replace finished jobs
                     logger.info(
@@ -1196,7 +1202,7 @@ class ControllerServiceImpl:
                         job_id,
                         job_pb2.JobState.Name(existing_state),
                     )
-                    self._remove_finished_job_safely(cur, job_id)
+                    needs_drain = needs_drain or self._replace_finished_job(cur, job_id)
                 else:
                     raise ConnectError(Code.ALREADY_EXISTS, f"Job {job_id} already exists and is still running")
 
@@ -1207,7 +1213,11 @@ class ControllerServiceImpl:
             self._controller.wake()
             self._wait_until_job_drained(job_id, _JOB_REPLACEMENT_DRAIN_TIMEOUT)
             with self._store.transaction() as cur:
-                self._remove_finished_job_safely(cur, job_id)
+                # The drain guarantees ``has_unfinished_worker_attempts`` is
+                # false; ``remove_finished_job`` is a no-op against
+                # already-empty rows, so a tight race with a re-latch is
+                # benign.
+                self._transitions.remove_finished_job(cur, job_id)
 
         # Handle bundle_blob: upload to bundle store, then replace blob
         # with the resulting GCS path (preserving all other fields).

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -2158,12 +2158,7 @@ class ControllerTransitions:
         state = self._store.jobs.get_state(cur, job_id)
         if state is None:
             return False
-        if state not in (
-            job_pb2.JOB_STATE_SUCCEEDED,
-            job_pb2.JOB_STATE_FAILED,
-            job_pb2.JOB_STATE_KILLED,
-            job_pb2.JOB_STATE_UNSCHEDULABLE,
-        ):
+        if state not in TERMINAL_JOB_STATES:
             return False
         self._store.jobs.delete(cur, job_id)
         log_event("job_removed", job_id.to_wire(), state=state)

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -16,6 +16,7 @@ from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from finelog.server import LogServiceImpl
 from iris.cluster.constraints import ConstraintOp, WellKnownAttribute, device_variant_constraint
+from iris.cluster.controller import service as service_module
 from iris.cluster.controller.codec import constraints_from_json
 from iris.cluster.controller.service import (
     FEATURE_INTRODUCTION_DATE,
@@ -32,7 +33,7 @@ from iris.cluster.controller.transitions import (
 )
 from iris.cluster.types import JobName, WorkerId, tpu_device
 from iris.rpc import controller_pb2, job_pb2
-from rigging.timing import Timestamp
+from rigging.timing import Duration, Timestamp
 
 from tests.cluster.conftest import fake_log_client_from_service
 
@@ -351,6 +352,104 @@ def test_existing_job_policy_unspecified_preserves_current_behavior(service, sta
     assert response.job_id == job_id.to_wire()
     job = _query_job(state, job_id)
     assert job.state == job_pb2.JOB_STATE_PENDING
+
+
+def test_existing_job_policy_keep_drains_unfinalized_child_attempt(service, state, monkeypatch):
+    """Production regression (/larry/iris-run-job-20260511-024915).
+
+    A parent job spawned a child training task that was preempted by a higher-
+    priority tenant. The producer transition (`preempt_task`) marked the task
+    terminal but left the attempt with ``worker_id != NULL, finished_at_ms =
+    NULL``: the worker still owned the container and the heartbeat hadn't
+    landed the finalization yet. The parent's retry resubmitted the child with
+    ``EXISTING_JOB_POLICY_KEEP``; the old service.py raised
+    ``FAILED_PRECONDITION`` immediately because the unfinished attempt blocked
+    ``remove_finished_job``. After the fix, the resubmit must block on drain
+    and succeed once the finalizing heartbeat arrives.
+    """
+    # Tighten the drain timeout so the test fails fast on regression instead
+    # of waiting the production 30s.
+    monkeypatch.setattr(service_module, "_JOB_REPLACEMENT_DRAIN_TIMEOUT", Duration.from_seconds(5))
+
+    child_name = "/test-user/parent/child"
+    service.launch_job(make_job_request("parent"), None)
+    service.launch_job(make_job_request(child_name), None)
+    child_job = JobName.from_string(child_name)
+
+    # Dispatch the child task to a worker, then preempt it with no retry
+    # budget. ``preempt_task`` marks the task terminal (PREEMPTED) but leaves
+    # the attempt unfinalized — exactly the production state.
+    worker = WorkerId("preempting-worker")
+    _register_worker(state, worker)
+    child_task = _query_tasks_with_attempts(state, child_job)[0]
+    _assign_and_transition(state, child_task.task_id, worker, job_pb2.TASK_STATE_RUNNING)
+    with state._store.transaction() as cur:
+        state.preempt_task(cur, child_task.task_id, reason="evicted by prod tenant")
+
+    # Sanity: child is terminal but its attempt still holds the worker.
+    with state._store.read_snapshot() as snap:
+        assert state._store.jobs.has_unfinished_worker_attempts(snap, child_job)
+
+    # Re-submit the child with KEEP. The unfinished attempt should make the
+    # service block in the drain wait rather than raise FAILED_PRECONDITION.
+    request = make_job_request(child_name)
+    request.existing_job_policy = job_pb2.EXISTING_JOB_POLICY_KEEP
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        fut = pool.submit(service.launch_job, request, None)
+        # Confirm the call is blocked on drain (didn't immediately raise).
+        with pytest.raises(concurrent.futures.TimeoutError):
+            fut.result(timeout=0.3)
+
+        # Synthesize the finalizing heartbeat that the production worker would
+        # have eventually sent. mark_finished stamps finished_at_ms, which
+        # releases the predicate ``_wait_until_job_drained`` polls.
+        child_task_after_preempt = _query_tasks_with_attempts(state, child_job)[0]
+        with state._store.transaction() as cur:
+            state._store.attempts.mark_finished(
+                cur,
+                child_task_after_preempt.task_id,
+                child_task_after_preempt.current_attempt_id,
+                job_pb2.TASK_STATE_PREEMPTED,
+                finished_at_ms=int(time.time() * 1000),
+                error="finalized after preemption",
+            )
+
+        # The blocked launch should now wake up and succeed within one backoff
+        # cycle (max 1s per ExponentialBackoff config).
+        response = fut.result(timeout=4.0)
+
+    assert response.job_id == child_job.to_wire()
+    # New child is pending (the old PREEMPTED row was replaced).
+    new_job = _query_job(state, child_job)
+    assert new_job is not None
+    assert new_job.state == job_pb2.JOB_STATE_PENDING
+
+
+def test_existing_job_policy_keep_drain_times_out_when_no_heartbeat(service, state, monkeypatch):
+    """If a replaced job's worker-bound attempts never finalize, launch_job
+    raises DEADLINE_EXCEEDED instead of hanging or silently destroying the
+    attempt rows the heartbeat path needs."""
+    monkeypatch.setattr(service_module, "_JOB_REPLACEMENT_DRAIN_TIMEOUT", Duration.from_seconds(1))
+
+    child_name = "/test-user/parent/child"
+    service.launch_job(make_job_request("parent"), None)
+    service.launch_job(make_job_request(child_name), None)
+    child_job = JobName.from_string(child_name)
+
+    worker = WorkerId("stuck-worker")
+    _register_worker(state, worker)
+    child_task = _query_tasks_with_attempts(state, child_job)[0]
+    _assign_and_transition(state, child_task.task_id, worker, job_pb2.TASK_STATE_RUNNING)
+    with state._store.transaction() as cur:
+        state.preempt_task(cur, child_task.task_id, reason="evicted, worker stuck")
+
+    request = make_job_request(child_name)
+    request.existing_job_policy = job_pb2.EXISTING_JOB_POLICY_KEEP
+
+    with pytest.raises(ConnectError) as exc_info:
+        service.launch_job(request, None)
+    assert exc_info.value.code == Code.DEADLINE_EXCEEDED
 
 
 def test_launch_job_rejects_empty_name(service, state):


### PR DESCRIPTION
## Summary

- Closes a production bug (`/larry/iris-run-job-20260511-024915`, 2026-05-11) where `iris.submit(...)` with `EXISTING_JOB_POLICY_KEEP` is rejected with `FAILED_PRECONDITION: worker-bound attempts have not finalized` when the existing terminal job's preempted attempts haven't yet been heartbeated to terminal.
- Previously only the RECREATE-with-running branch waited for drain before deleting job rows. The other three "existing job is already terminal but attempts unfinalized" branches in `launch_job` raised immediately. This unifies all four branches behind a single drain-aware helper.
- Drain timeout reduced from 10m to 30s — it now covers a single PollTasks round-trip plus margin, not a worst-case worker-failure cascade.

## Details

The producer/heartbeat split is intentional: when a task is preempted, `_terminate_task(..., finalize_attempt=False)` marks the task terminal but leaves `task_attempts.finished_at_ms = NULL` until the worker confirms termination via heartbeat. This prevents capacity from being double-allocated while a worker is still tearing down the old process.

In the production failure, two preempted child training tasks sat with `worker_id != NULL, finished_at_ms = NULL` because their workers were alive but busy serving other tenants. The parent's retry attempt called `iris.submit(...)` to resubmit the same child job names with `EXISTING_JOB_POLICY_KEEP`. `_remove_finished_job_safely` rejected the call because `has_unfinished_worker_attempts` was true. The parent task failed with `RuntimeError: 2 step(s) failed`, taking down the whole `executor_main` driver.

The fix:
- `_remove_finished_job_safely` → `_replace_finished_job`. Inverted return: `True` means "drain needed, leave rows in place"; `False` means "removal completed". No more immediate raise.
- Every `EXISTING_JOB_POLICY_*` branch in `launch_job` ORs the helper's result into `needs_drain`, so the post-drain second tx covers them all uniformly.
- Drain timeout `Duration.from_minutes(10)` → `Duration.from_seconds(30)`. Stuck finalizations surface as `DEADLINE_EXCEEDED` rather than hanging launches for ten minutes.
- Post-drain `remove_finished_job` is called directly (the drain guarantees the predicate is false; the helper is idempotent on absent rows).

Also fixes a latent bug in `ControllerTransitions.remove_finished_job`: its allow list omitted `JOB_STATE_WORKER_FAILED`, so the production scenario would have silently no-op'd even after the drain. Replaced the hard-coded tuple with the `TERMINAL_JOB_STATES` constant already imported at the module level (which includes WORKER_FAILED).

## Test plan

- [x] New `test_existing_job_policy_keep_drains_unfinalized_child_attempt`: reproduces the production failure — preempt a child, resubmit the same name with `KEEP` on a background thread, confirm it blocks on drain, synthesize the finalizing heartbeat via `mark_finished`, assert the launch wakes and succeeds.
- [x] New `test_existing_job_policy_keep_drain_times_out_when_no_heartbeat`: same setup, never finalizes, asserts `ConnectError(DEADLINE_EXCEEDED)`.
- [x] `./infra/pre-commit.py --files ...` — clean.
- [x] `uv run pytest lib/iris/tests/cluster/controller/ -x -q` — 881 passed.
- [ ] Soak on `marin-dev` via `iris-smoke-gcp.yaml` before promoting to production.

## Follow-up

This is Phase B of a larger refactor that collapses the worker control plane onto `PollTasks` only (removes `StartTasks`/`StopTasks`, introduces `GetTaskAttemptInfo`). That work lives on a separate branch.