### PR TITLE
[finelog] migrations manage own txns, parallel remote-segment adopt, restore UNSPECIFIED=REGEX

### DIFF
--- a/lib/finelog/src/finelog/proto/logging.proto
+++ b/lib/finelog/src/finelog/proto/logging.proto
@@ -67,15 +67,17 @@ message PushLogsResponse {}
 //
 // `source` is always treated as a literal string for EXACT and PREFIX. The
 // server never inspects it for regex metacharacters; literal `+`, `.`, etc.
-// match themselves. UNSPECIFIED is treated as PREFIX so old callers get
-// path-style reads (everything under `/job/<job>/<task>`); set EXACT
-// explicitly when only the literal key should match. Use REGEX explicitly
-// when regex semantics are wanted.
+// match themselves. UNSPECIFIED is treated as REGEX by the server — the
+// historical pre-MatchScope default — so an in-flight older client (whose
+// build encodes its query as a regex `source` and doesn't yet know about
+// this field) keeps working across a finelog upgrade. New code should set
+// MATCH_SCOPE_EXACT or MATCH_SCOPE_PREFIX explicitly; that's how the
+// metacharacter-literal-key bug (#5392) stays fixed.
 enum MatchScope {
-  // Treated as MATCH_SCOPE_PREFIX by the server. Old callers that pass a
-  // path-style key (`/job/<job>/<task>`) without a scope read every entry
-  // under that path. Set MATCH_SCOPE_EXACT explicitly when only the
-  // literal key should match.
+  // Wire-level default. Treated as MATCH_SCOPE_REGEX by the server so old
+  // clients that pre-date this enum (and encode their query as a regex
+  // pattern in `source`) keep working. New code must set EXACT or PREFIX
+  // explicitly instead of relying on this fallback.
   MATCH_SCOPE_UNSPECIFIED = 0;
   // Exact match: read entries whose key equals `source` byte-for-byte.
   MATCH_SCOPE_EXACT = 1;
@@ -98,7 +100,7 @@ message FetchLogsRequest {
   int32 max_lines = 5;         // Max entries to return (0 = server default 1000)
   bool tail = 6;               // Return last N entries instead of first N
   string min_level = 7;        // Minimum level (DEBUG/INFO/WARNING/ERROR/CRITICAL)
-  MatchScope match_scope = 8;  // How `source` is interpreted (UNSPECIFIED == PREFIX)
+  MatchScope match_scope = 8;  // How `source` is interpreted (UNSPECIFIED == REGEX, legacy)
 }
 
 message FetchLogsResponse {

--- a/lib/finelog/src/finelog/proto/logging.proto
+++ b/lib/finelog/src/finelog/proto/logging.proto
@@ -63,32 +63,18 @@ message PushLogsRequest {
 
 message PushLogsResponse {}
 
-// How the server should interpret FetchLogsRequest.source.
-//
-// `source` is always treated as a literal string for EXACT and PREFIX. The
-// server never inspects it for regex metacharacters; literal `+`, `.`, etc.
-// match themselves. UNSPECIFIED is treated as REGEX by the server — the
-// historical pre-MatchScope default — so an in-flight older client (whose
-// build encodes its query as a regex `source` and doesn't yet know about
-// this field) keeps working across a finelog upgrade. New code should set
-// MATCH_SCOPE_EXACT or MATCH_SCOPE_PREFIX explicitly; that's how the
-// metacharacter-literal-key bug (#5392) stays fixed.
+// How the server should interpret FetchLogsRequest.source. EXACT and
+// PREFIX treat `source` as a literal string; `+`, `.`, `[` etc. match
+// themselves. UNSPECIFIED falls back to REGEX so clients that encode
+// their query as a regex pattern keep working.
 enum MatchScope {
-  // Wire-level default. Treated as MATCH_SCOPE_REGEX by the server so old
-  // clients that pre-date this enum (and encode their query as a regex
-  // pattern in `source`) keep working. New code must set EXACT or PREFIX
-  // explicitly instead of relying on this fallback.
   MATCH_SCOPE_UNSPECIFIED = 0;
-  // Exact match: read entries whose key equals `source` byte-for-byte.
+  // Read entries whose key equals `source` byte-for-byte.
   MATCH_SCOPE_EXACT = 1;
-  // Literal prefix: read entries whose key starts with `source`. Callers
-  // include any boundary character (`/`, `:`) in `source` themselves; the
-  // server does not append delimiters.
+  // Read entries whose key starts with `source`. Callers bake any
+  // boundary character (`/`, `:`) into `source` themselves.
   MATCH_SCOPE_PREFIX = 2;
-  // Regex: `source` is a regex pattern matched against the key. Use only
-  // when regex semantics are actually needed; PREFIX covers the common
-  // "all attempts of a task" / "all tasks of a job" cases without the
-  // metacharacter footguns.
+  // `source` is a regex matched against the key.
   MATCH_SCOPE_REGEX = 3;
 }
 
@@ -100,7 +86,7 @@ message FetchLogsRequest {
   int32 max_lines = 5;         // Max entries to return (0 = server default 1000)
   bool tail = 6;               // Return last N entries instead of first N
   string min_level = 7;        // Minimum level (DEBUG/INFO/WARNING/ERROR/CRITICAL)
-  MatchScope match_scope = 8;  // How `source` is interpreted (UNSPECIFIED == REGEX, legacy)
+  MatchScope match_scope = 8;  // How `source` is interpreted
 }
 
 message FetchLogsResponse {

--- a/lib/finelog/src/finelog/server/service.py
+++ b/lib/finelog/src/finelog/server/service.py
@@ -67,12 +67,17 @@ class LogServiceImpl:
         ctx: Any,
     ) -> logging_pb2.FetchLogsResponse:
         # Wire-level UNSPECIFIED (default-zero from old clients that don't set
-        # the field) reads as PREFIX so path-style keys still pick up every
-        # entry under the path. In-process Python callers default to EXACT in
-        # `DuckDBLogStore.get_logs`, so this mapping only fires for RPC clients.
+        # the field) maps to REGEX so pre-refactor clients that encode their
+        # query as a regex pattern in ``source`` keep working until they
+        # redeploy with explicit ``match_scope``. The current dashboard / CLI
+        # / library code all set EXACT or PREFIX explicitly, so they bypass
+        # this fallback — and the #5392 literal-metachar bug stays fixed
+        # because those new call sites opt into EXACT. The fallback exists
+        # purely so a finelog upgrade doesn't black out an older iris
+        # controller image whose dashboard JS still sends regex sources.
         match_scope = request.match_scope
         if match_scope == logging_pb2.MATCH_SCOPE_UNSPECIFIED:
-            match_scope = logging_pb2.MATCH_SCOPE_PREFIX
+            match_scope = logging_pb2.MATCH_SCOPE_REGEX
         max_lines = request.max_lines if request.max_lines > 0 else 1000
         result = self._log_store.get_logs(
             request.source,

--- a/lib/finelog/src/finelog/server/service.py
+++ b/lib/finelog/src/finelog/server/service.py
@@ -66,15 +66,9 @@ class LogServiceImpl:
         request: logging_pb2.FetchLogsRequest,
         ctx: Any,
     ) -> logging_pb2.FetchLogsResponse:
-        # Wire-level UNSPECIFIED (default-zero from old clients that don't set
-        # the field) maps to REGEX so pre-refactor clients that encode their
-        # query as a regex pattern in ``source`` keep working until they
-        # redeploy with explicit ``match_scope``. The current dashboard / CLI
-        # / library code all set EXACT or PREFIX explicitly, so they bypass
-        # this fallback — and the #5392 literal-metachar bug stays fixed
-        # because those new call sites opt into EXACT. The fallback exists
-        # purely so a finelog upgrade doesn't black out an older iris
-        # controller image whose dashboard JS still sends regex sources.
+        # Wire-level UNSPECIFIED maps to REGEX so clients that encode the
+        # query as a regex pattern in ``source`` without setting the field
+        # keep working. New code sets EXACT or PREFIX explicitly.
         match_scope = request.match_scope
         if match_scope == logging_pb2.MATCH_SCOPE_UNSPECIFIED:
             match_scope = logging_pb2.MATCH_SCOPE_REGEX

--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -1176,25 +1176,17 @@ class DiskLogNamespace:
     def _adopt_remote_segments(self, *, key_column: str | None) -> None:
         """Insert ``REMOTE`` catalog rows for bucket files with no row.
 
-        Runs once at boot when ``_remote_namespace_dir`` is configured.
-        After a catalog wipe the bucket is the only durable record of
-        every L>=1 segment; we read each parquet footer remotely to
-        reconstruct row metadata, then insert at ``location=REMOTE``.
-        Files whose basename is already in the catalog are left alone
-        (the local-disk pass already attached them).
-
-        Parquet footer reads dominate the wall-time here — each segment
-        is one network round-trip. ``fs.find(detail=True)`` returns the
-        file size in the listing response so we don't also pay a
-        ``fs.info`` per file. The footer fetches run on a thread pool
-        (network I/O releases the GIL); catalog upserts then run on the
-        main thread because ``Catalog._conn`` is a single DuckDB
-        connection.
+        Recovery path for a wiped catalog: the bucket is the only durable
+        record of every L>=1 segment, so we read each parquet footer
+        remotely to reconstruct row metadata. Footer fetches dominate
+        wall-time (one network round-trip per segment) and are run on a
+        thread pool; the catalog upserts then run serially because
+        ``Catalog._conn`` is a single DuckDB connection.
         """
         try:
             fs, root = fsspec.core.url_to_fs(self._remote_namespace_dir)
-            # detail=True returns a dict keyed by path with size/info inline,
-            # eliminating the per-file fs.info() round trip below.
+            # detail=True returns file size in the listing, so we don't
+            # need a separate fs.info() per file below.
             remote_info = fs.find(root, detail=True)
         except Exception:
             logger.warning("remote adopt list failed for %s", self.name, exc_info=True)
@@ -1227,9 +1219,6 @@ class DiskLogNamespace:
                 )
                 return fs_path, None
 
-        # Parquet footers are tiny; the wall-time is round-trip latency, so a
-        # modest pool already saturates bucket throughput. Cap pool size by
-        # candidate count to avoid spinning idle threads for small adopts.
         max_workers = min(32, len(candidates))
         with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="adopt-remote") as pool:
             footers = dict(pool.map(_fetch_footer, [c[0] for c in candidates]))
@@ -1783,11 +1772,8 @@ def _scope_query(
     Returns ``(where_parts, params, include_key_in_select, exact_key)``.
 
     The in-process Python default is ``MATCH_SCOPE_EXACT``; the RPC server
-    boundary maps wire-level ``MATCH_SCOPE_UNSPECIFIED`` to ``REGEX`` (the
-    historical default, kept so older dashboard / client builds that encode
-    their query as a regex source keep working across a finelog upgrade)
-    before invoking ``get_logs``. Either of those resolves to one of the
-    branches below — ``UNSPECIFIED`` never reaches the query layer.
+    maps wire-level ``UNSPECIFIED`` to ``REGEX`` before delegating, so
+    ``UNSPECIFIED`` never reaches this function.
     """
     if match_scope == logging_pb2.MATCH_SCOPE_EXACT:
         where_parts = ["key = $key", "seq > $cursor"]

--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -22,6 +22,7 @@ import threading
 import time
 from collections import deque
 from collections.abc import Callable, Iterable
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from pathlib import Path
@@ -1181,16 +1182,27 @@ class DiskLogNamespace:
         reconstruct row metadata, then insert at ``location=REMOTE``.
         Files whose basename is already in the catalog are left alone
         (the local-disk pass already attached them).
+
+        Parquet footer reads dominate the wall-time here — each segment
+        is one network round-trip. ``fs.find(detail=True)`` returns the
+        file size in the listing response so we don't also pay a
+        ``fs.info`` per file. The footer fetches run on a thread pool
+        (network I/O releases the GIL); catalog upserts then run on the
+        main thread because ``Catalog._conn`` is a single DuckDB
+        connection.
         """
         try:
             fs, root = fsspec.core.url_to_fs(self._remote_namespace_dir)
-            remote_paths = list(fs.find(root))
+            # detail=True returns a dict keyed by path with size/info inline,
+            # eliminating the per-file fs.info() round trip below.
+            remote_info = fs.find(root, detail=True)
         except Exception:
             logger.warning("remote adopt list failed for %s", self.name, exc_info=True)
             return
 
         catalog_basenames = {Path(r.path).name for r in self._catalog.list_segments(self.name)}
-        for fs_path in remote_paths:
+        candidates: list[tuple[str, int, int, int]] = []  # (fs_path, level, min_seq, byte_size)
+        for fs_path, info in remote_info.items():
             basename = Path(fs_path).name
             if basename in catalog_basenames:
                 continue
@@ -1199,18 +1211,37 @@ class DiskLogNamespace:
                 logger.warning("ignoring unparseable remote file %s/%s", self.name, basename)
                 continue
             level, min_seq = parsed
+            byte_size = int(info.get("size", 0) or 0)
+            candidates.append((fs_path, level, min_seq, byte_size))
+
+        if not candidates:
+            return
+
+        def _fetch_footer(fs_path: str) -> tuple[str, pq.FileMetaData | None]:
             try:
                 with fs.open(fs_path, "rb") as f:
-                    metadata = pq.read_metadata(f)
+                    return fs_path, pq.read_metadata(f)
             except Exception:
-                logger.warning("failed reading remote parquet footer %s/%s", self.name, basename, exc_info=True)
+                logger.warning(
+                    "failed reading remote parquet footer %s/%s", self.name, Path(fs_path).name, exc_info=True
+                )
+                return fs_path, None
+
+        # Parquet footers are tiny; the wall-time is round-trip latency, so a
+        # modest pool already saturates bucket throughput. Cap pool size by
+        # candidate count to avoid spinning idle threads for small adopts.
+        max_workers = min(32, len(candidates))
+        with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="adopt-remote") as pool:
+            footers = dict(pool.map(_fetch_footer, [c[0] for c in candidates]))
+
+        now_ms = int(time.time() * 1000)
+        for fs_path, level, min_seq, byte_size in candidates:
+            metadata = footers.get(fs_path)
+            if metadata is None:
                 continue
+            basename = Path(fs_path).name
             num_rows = metadata.num_rows
             min_key, max_key = _key_bounds_from_parquet(metadata, key_column)
-            try:
-                byte_size = fs.info(fs_path).get("size", 0)
-            except Exception:
-                byte_size = 0
             local_path = self._data_dir / basename
             self._catalog.upsert_segment(
                 SegmentRow(
@@ -1220,14 +1251,18 @@ class DiskLogNamespace:
                     min_seq=min_seq,
                     max_seq=min_seq + max(num_rows - 1, 0),
                     row_count=num_rows,
-                    byte_size=int(byte_size),
-                    created_at_ms=int(time.time() * 1000),
+                    byte_size=byte_size,
+                    created_at_ms=now_ms,
                     location=SegmentLocation.REMOTE,
                     min_key_value=None if min_key is None else str(min_key),
                     max_key_value=None if max_key is None else str(max_key),
                 )
             )
-            logger.info("Adopted remote segment %s/%s as REMOTE", self.name, basename)
+        logger.info(
+            "Adopted %d remote segment(s) for namespace %s as REMOTE",
+            sum(1 for fs_path, *_ in candidates if footers.get(fs_path) is not None),
+            self.name,
+        )
 
     def _sync_step(self) -> None:
         """Reconcile the remote namespace prefix with the catalog.
@@ -1748,8 +1783,10 @@ def _scope_query(
     Returns ``(where_parts, params, include_key_in_select, exact_key)``.
 
     The in-process Python default is ``MATCH_SCOPE_EXACT``; the RPC server
-    boundary maps wire-level ``MATCH_SCOPE_UNSPECIFIED`` to ``PREFIX`` before
-    invoking ``get_logs``. Either of those resolves to one of the four
+    boundary maps wire-level ``MATCH_SCOPE_UNSPECIFIED`` to ``REGEX`` (the
+    historical default, kept so older dashboard / client builds that encode
+    their query as a regex source keep working across a finelog upgrade)
+    before invoking ``get_logs``. Either of those resolves to one of the
     branches below — ``UNSPECIFIED`` never reaches the query layer.
     """
     if match_scope == logging_pb2.MATCH_SCOPE_EXACT:

--- a/lib/finelog/src/finelog/store/migrations/0001_init.py
+++ b/lib/finelog/src/finelog/store/migrations/0001_init.py
@@ -1,17 +1,10 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Baseline registry schema.
+"""Baseline registry schema: ``namespaces`` and ``segments`` tables.
 
-Creates ``namespaces`` (one row per registered namespace, holding its
-schema JSON) and ``segments`` (one row per locally-tracked parquet file,
-maintained in lockstep with the in-memory ``_local_segments`` deque).
-
-Both statements use ``IF NOT EXISTS``: existing deployments may already
-have ``namespaces`` from a release that pre-dates the migrations runner,
-or ``segments`` from an early build of the catalog branch. In either case
-this migration is a no-op against the DDL but records v1 in
-``schema_migrations`` so future versions have a defined starting point.
+``IF NOT EXISTS`` so older deployments whose tables pre-date this runner
+adopt cleanly.
 """
 
 from __future__ import annotations
@@ -20,31 +13,34 @@ from pathlib import Path
 
 import duckdb
 
+from finelog.store.migrations._runner import transactional
+
 
 def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir: Path | None) -> None:
     del data_dir
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS namespaces (
-            namespace        TEXT PRIMARY KEY,
-            schema_json      TEXT NOT NULL,
-            registered_at_ms BIGINT NOT NULL,
-            last_modified_ms BIGINT NOT NULL
+    with transactional(conn):
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS namespaces (
+                namespace        TEXT PRIMARY KEY,
+                schema_json      TEXT NOT NULL,
+                registered_at_ms BIGINT NOT NULL,
+                last_modified_ms BIGINT NOT NULL
+            )
+            """
         )
-        """
-    )
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS segments (
-            namespace     TEXT   NOT NULL,
-            path          TEXT   NOT NULL,
-            state         TEXT   NOT NULL,
-            min_seq       BIGINT NOT NULL,
-            max_seq       BIGINT NOT NULL,
-            row_count     BIGINT NOT NULL,
-            byte_size     BIGINT NOT NULL,
-            created_at_ms BIGINT NOT NULL,
-            PRIMARY KEY (namespace, path)
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS segments (
+                namespace     TEXT   NOT NULL,
+                path          TEXT   NOT NULL,
+                state         TEXT   NOT NULL,
+                min_seq       BIGINT NOT NULL,
+                max_seq       BIGINT NOT NULL,
+                row_count     BIGINT NOT NULL,
+                byte_size     BIGINT NOT NULL,
+                created_at_ms BIGINT NOT NULL,
+                PRIMARY KEY (namespace, path)
+            )
+            """
         )
-        """
-    )

--- a/lib/finelog/src/finelog/store/migrations/0002_segment_key_value_bounds.py
+++ b/lib/finelog/src/finelog/store/migrations/0002_segment_key_value_bounds.py
@@ -1,18 +1,12 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Add per-segment ``key_column`` value bounds to the catalog.
+"""Add per-segment ``min_key_value`` / ``max_key_value`` bounds.
 
-Each registered ``Schema`` may declare a ``key_column`` — the column the
-segment is sorted by inside its parquet file (see
-``compaction_sort_keys`` in ``compactor.py``).
-Tracking that column's min/max in the catalog lets future read paths
-prune the segment list before opening any parquet footer.
-
-Both columns are nullable: namespaces that don't declare a ``key_column``
-(e.g. iris worker stats) leave them ``NULL``. ``reconcile_segments``
-populates existing rows on the next process boot from the parquet
-footers, so this migration does not backfill itself.
+Tracks the min/max of each segment's ``key_column`` so reads can prune
+without opening parquet footers. Nullable for namespaces that don't
+declare a key column; ``reconcile_segments`` backfills existing rows on
+the next boot.
 """
 
 from __future__ import annotations
@@ -21,8 +15,11 @@ from pathlib import Path
 
 import duckdb
 
+from finelog.store.migrations._runner import transactional
+
 
 def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir: Path | None) -> None:
     del data_dir
-    conn.execute("ALTER TABLE segments ADD COLUMN IF NOT EXISTS min_key_value TEXT")
-    conn.execute("ALTER TABLE segments ADD COLUMN IF NOT EXISTS max_key_value TEXT")
+    with transactional(conn):
+        conn.execute("ALTER TABLE segments ADD COLUMN IF NOT EXISTS min_key_value TEXT")
+        conn.execute("ALTER TABLE segments ADD COLUMN IF NOT EXISTS max_key_value TEXT")

--- a/lib/finelog/src/finelog/store/migrations/0003_segment_level.py
+++ b/lib/finelog/src/finelog/store/migrations/0003_segment_level.py
@@ -17,10 +17,13 @@ After this migration there is no ``state`` column and no ``tmp_*`` /
 
 Resumability
 ------------
-The DB-level work (ADD/DROP COLUMN, UPDATE) runs inside the migration
-runner's enclosing transaction, so it's atomic. The filesystem rename is
-not, but each ``os.rename`` is. We walk every segment row, derive the
-target filename from ``(level, min_seq)``, and rename the file:
+The runner does not wrap migrations in a transaction, so the SQL phase
+relies on each statement being idempotent: ``ADD COLUMN IF NOT EXISTS``
+is a no-op on re-run, the ``UPDATE`` is gated on the still-present
+``state`` column, and ``DROP COLUMN`` runs only when that column still
+exists. The filesystem rename is also not atomic, but each ``os.rename``
+is. We walk every segment row, derive the target filename from
+``(level, min_seq)``, and rename the file:
 
 * If the source still exists and the destination doesn't, ``os.rename``.
 * If the destination already exists (a prior crashed pass moved it),
@@ -56,12 +59,13 @@ def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir: Path | None) -> None:
     # ``level`` on every insert going forward. Backfill (only when ``state``
     # is still present, i.e. first-time apply): ``finalized`` rows become
     # L1, ``tmp`` rows become L0. A re-run after a partial crash is a
-    # clean no-op for the SQL phase.
+    # clean no-op for the SQL phase: each statement is idempotent and the
+    # ``state_present`` gate skips the UPDATE+DROP once the column is gone.
     # The companion index on (namespace, level, min_seq) is created in
-    # migration 0005, in its own transaction: DuckDB rejects CREATE INDEX
-    # while there are outstanding UPDATEs in the same txn, and rejects
-    # DROP COLUMN if a later column is indexed — there is no single
-    # ordering that satisfies both constraints in one transaction.
+    # migration 0005: DuckDB rejects CREATE INDEX while there are
+    # outstanding UPDATEs in the same txn, and rejects DROP COLUMN if a
+    # later column is indexed — there is no single ordering that satisfies
+    # both constraints in one transaction.
     conn.execute("ALTER TABLE segments ADD COLUMN IF NOT EXISTS level INTEGER")
     state_present = bool(
         conn.execute(

--- a/lib/finelog/src/finelog/store/migrations/0003_segment_level.py
+++ b/lib/finelog/src/finelog/store/migrations/0003_segment_level.py
@@ -1,41 +1,14 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Replace the lifecycle ``state`` column with a numeric ``level``.
+"""Replace the lifecycle ``state`` column with a numeric ``level``, and
+rename ``tmp_*`` / ``logs_*`` parquet files to ``seg_L<n>_<seq>``.
 
-Before this migration, segment lifecycle was encoded in two places:
-
-* ``segments.state`` — a TEXT column containing ``'tmp'`` (post-flush) or
-  ``'finalized'`` (post-compaction).
-* The on-disk filename — ``tmp_<seq>.parquet`` or ``logs_<seq>.parquet``.
-
-The leveled compaction scheme replaces both with a numeric tier:
-``segments.level`` (0 = freshly flushed; promoted to ``level + 1`` when the
-planner picks it up) and ``seg_L<n>_<min_seq:019d>.parquet`` filenames.
-After this migration there is no ``state`` column and no ``tmp_*`` /
-``logs_*`` filename to worry about.
-
-Resumability
-------------
-The runner does not wrap migrations in a transaction, so the SQL phase
-relies on each statement being idempotent: ``ADD COLUMN IF NOT EXISTS``
-is a no-op on re-run, the ``UPDATE`` is gated on the still-present
-``state`` column, and ``DROP COLUMN`` runs only when that column still
-exists. The filesystem rename is also not atomic, but each ``os.rename``
-is. We walk every segment row, derive the target filename from
-``(level, min_seq)``, and rename the file:
-
-* If the source still exists and the destination doesn't, ``os.rename``.
-* If the destination already exists (a prior crashed pass moved it),
-  treat the source as a duplicate, assert size match, ``unlink`` source.
-* If neither exists, the parquet is gone — leave the catalog row in
-  place; ``DiskLogNamespace`` boot reconciliation will drop it once the
-  store opens.
-
-In every case the catalog row's ``path`` is rewritten to the new name.
-A re-run after partial filesystem progress converges, because the
-``UPDATE segments SET path = ?`` is a no-op against rows already pointing
-at the new name.
+L0 = freshly flushed, promoted to ``level + 1`` when the compaction
+planner picks it up. ``state='finalized'`` rows backfill to L1, ``tmp``
+rows to L0. The filesystem rename is resumable per-file: if the
+destination already exists from a previous crashed pass, the source is
+treated as a duplicate (size-checked, then unlinked).
 """
 
 from __future__ import annotations
@@ -47,25 +20,17 @@ from pathlib import Path
 
 import duckdb
 
+from finelog.store.migrations._runner import transactional
+
 logger = logging.getLogger(__name__)
 
 _OLD_FILENAME_RE = re.compile(r"^(?P<prefix>tmp_|logs_)(?P<seq>\d+)\.parquet$")
 
 
 def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir: Path | None) -> None:
-    # ---- DB schema rewrite -------------------------------------------------
-    # DuckDB rejects ``ADD COLUMN ... NOT NULL`` against an existing table,
-    # so the column lands nullable and we rely on application code to set
-    # ``level`` on every insert going forward. Backfill (only when ``state``
-    # is still present, i.e. first-time apply): ``finalized`` rows become
-    # L1, ``tmp`` rows become L0. A re-run after a partial crash is a
-    # clean no-op for the SQL phase: each statement is idempotent and the
-    # ``state_present`` gate skips the UPDATE+DROP once the column is gone.
-    # The companion index on (namespace, level, min_seq) is created in
-    # migration 0005: DuckDB rejects CREATE INDEX while there are
-    # outstanding UPDATEs in the same txn, and rejects DROP COLUMN if a
-    # later column is indexed — there is no single ordering that satisfies
-    # both constraints in one transaction.
+    # The companion (namespace, level, min_seq) index is created in 0005
+    # because DuckDB can't combine DROP COLUMN and CREATE INDEX in one
+    # transaction the way we'd need.
     conn.execute("ALTER TABLE segments ADD COLUMN IF NOT EXISTS level INTEGER")
     state_present = bool(
         conn.execute(
@@ -73,18 +38,16 @@ def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir: Path | None) -> None:
         ).fetchone()
     )
     if state_present:
-        conn.execute("UPDATE segments SET level = CASE WHEN state = 'finalized' THEN 1 ELSE 0 END")
-        conn.execute("ALTER TABLE segments DROP COLUMN state")
+        with transactional(conn):
+            conn.execute("UPDATE segments SET level = CASE WHEN state = 'finalized' THEN 1 ELSE 0 END")
+            conn.execute("ALTER TABLE segments DROP COLUMN state")
 
     if data_dir is None:
-        # In-memory store has no parquet files to rename.
         return
 
-    # ---- Filesystem + path rewrite ----------------------------------------
-    # Catalog-known files come with an explicit level (from the backfill
-    # above). Files on disk that the catalog doesn't yet track (e.g. an
-    # older install pre-dating the catalog branch) get their level from
-    # the legacy filename prefix: ``tmp_*`` → 0, ``logs_*`` → 1.
+    # Catalog-known files take their level from the backfill above; files
+    # on disk that the catalog doesn't track yet get it from the legacy
+    # filename prefix (``tmp_*`` → 0, ``logs_*`` → 1).
     catalog_paths: dict[str, tuple[str, int]] = {}
     rows = conn.execute("SELECT namespace, path, level FROM segments").fetchall()
     for namespace, old_path, level in rows:
@@ -97,7 +60,7 @@ def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir: Path | None) -> None:
                 namespace, level = catalog_paths[old_str]
             else:
                 level = 0 if old.name.startswith("tmp_") else 1
-                namespace = None  # not in catalog; rename is purely filesystem
+                namespace = None
             new = _rewrite_one(old, level)
             if new is None or new == old:
                 continue
@@ -109,28 +72,19 @@ def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir: Path | None) -> None:
 
 
 def _rewrite_one(old: Path, level: int) -> Path | None:
-    """Rename ``old`` to the leveled scheme. Resumable across crashes.
-
-    Returns the destination path (which may equal ``old`` if the file has
-    already been renamed in a previous pass), or ``None`` if the filename
-    isn't recognized as either old or new format.
-    """
+    """Rename ``old`` to the leveled scheme. Returns the destination path
+    (or ``old`` if already renamed); ``None`` for unrecognized filenames."""
     name = old.name
     match = _OLD_FILENAME_RE.match(name)
     if match is None:
-        # Already in seg_L<n>_<seq>.parquet form, or some unrelated file —
-        # nothing to do.
         return old if name.startswith("seg_L") else None
     seq = int(match.group("seq"))
-    new_name = f"seg_L{level}_{seq:019d}.parquet"
-    new = old.with_name(new_name)
+    new = old.with_name(f"seg_L{level}_{seq:019d}.parquet")
 
     src_exists = old.exists()
     dst_exists = new.exists()
 
     if dst_exists and src_exists:
-        # Prior crashed run moved the file then died before the DB UPDATE
-        # committed. Source is the duplicate.
         src_size = old.stat().st_size
         dst_size = new.stat().st_size
         if src_size != dst_size:
@@ -141,9 +95,6 @@ def _rewrite_one(old: Path, level: int) -> Path | None:
         os.rename(old, new)
         return new
     if dst_exists:
-        # File already at destination; just rewrite the catalog row.
         return new
-    # Neither file present. The boot-time reconciliation will drop the
-    # catalog row when the namespace opens and walks the directory.
     logger.warning("migration 0003: parquet missing for both %s and %s", old, new)
     return new

--- a/lib/finelog/src/finelog/store/migrations/0004_segment_copied_at.py
+++ b/lib/finelog/src/finelog/store/migrations/0004_segment_copied_at.py
@@ -3,19 +3,8 @@
 
 """Add ``segments.copied_at_ms`` to gate eviction on remote durability.
 
-Eviction picks the oldest L_>=1 segment in each namespace; without this
-column, a freshly-compacted segment could be deleted in the window
-between rename and copy completion. The :class:`CopyWorker`
-stamps ``copied_at_ms`` when the upload finishes, and the eviction
-query in :class:`Catalog.select_eviction_candidate` filters on it.
-
-Existing rows from before this migration get ``NULL`` and are therefore
-not evictable until a subsequent boot's reconciliation either re-uploads
-them or marks them locally-only. In practice the production registry
-runs migration 0003 and 0004 together as part of the leveled compaction
-ship; the operator restarts the service, the copy worker stamps the
-existing finalized segments on first compaction round, and eviction
-catches up.
+Stamped by the copy worker on upload; eviction filters on NOT NULL so a
+freshly-compacted segment isn't deleted before its remote copy lands.
 """
 
 from __future__ import annotations

--- a/lib/finelog/src/finelog/store/migrations/0005_segments_level_index.py
+++ b/lib/finelog/src/finelog/store/migrations/0005_segments_level_index.py
@@ -3,12 +3,8 @@
 
 """Create the ``(namespace, level, min_seq)`` index on ``segments``.
 
-Split out from :mod:`0003_segment_level` because DuckDB rejects
-``CREATE INDEX`` in a transaction that has outstanding ``UPDATE``s on
-the same table, and rejects ``DROP COLUMN`` for a column positioned
-before any indexed column. Migration 0003 handles the schema rewrite
-and backfill; this migration runs in a fresh transaction with no
-pending updates, so ``CREATE INDEX`` succeeds.
+Split from 0003 because DuckDB can't combine CREATE INDEX with the
+DROP COLUMN there in a single transaction.
 """
 
 from __future__ import annotations

--- a/lib/finelog/src/finelog/store/migrations/0006_segment_lifecycle.py
+++ b/lib/finelog/src/finelog/store/migrations/0006_segment_lifecycle.py
@@ -3,49 +3,14 @@
 
 """Replace ``copied_at_ms`` with an explicit ``location`` enum.
 
-A segment's bytes can live on local disk, on the remote bucket, or both.
-The previous ``copied_at_ms`` column carried that fact implicitly (NULL =
-not durable; NOT NULL = remote copy exists), and "row absent from catalog"
-was overloaded to mean both "evicted locally" and "deleted by compaction."
-The remote-sync loop couldn't distinguish those cases and would delete
-durable archives whose only mistake was being a row no longer in the
-catalog.
+A segment's bytes can live on local disk (``LOCAL``), on the remote
+bucket (``REMOTE``), or both (``BOTH``). The catalog row stays put when
+eviction flips ``BOTH`` → ``REMOTE``, so the sync loop can tell an
+archived segment apart from a compaction-deleted orphan.
 
-The new model: every segment that is part of the table has a catalog row,
-and its ``location`` says where its bytes live:
-
-* ``LOCAL`` — freshly written and not yet uploaded (or a never-uploaded L0).
-* ``BOTH`` — on disk and durably on remote.
-* ``REMOTE`` — durable archive only; the local file was evicted.
-
-Compaction drops input rows immediately at commit; the merged output is
-inserted as ``LOCAL``. The sync loop reconciles remote with catalog:
-``LOCAL`` rows are uploaded (or adopted, if the file is already there from
-a crash mid-upload), and remote files with no catalog row are ``fs.rm``'d.
-Eviction flips ``BOTH`` → ``REMOTE`` instead of dropping the row, so the
-durable archive is never mistaken for an orphan.
-
-Backfill: existing rows with ``copied_at_ms IS NULL`` are at ``LOCAL``;
-``copied_at_ms IS NOT NULL`` means ``BOTH``. Pre-migration eviction was
-the only row-removal path, so every surviving row had a local file.
-
-Non-null is enforced at the application layer rather than via DuckDB's
-``SET NOT NULL`` because the existing ``segments_level_idx`` blocks
-schema-altering DDL on the table.
-
-Idempotency
------------
-Each statement is a no-op against a partially-applied state, so a crash
-between any two statements is recovered by simply re-running. The runner
-does not wrap migrations in a transaction (DuckDB rejects multiple
-DDLs + DML on the same table in one txn), so resumability is the
-migration's responsibility:
-
-* ``DROP INDEX IF EXISTS`` / ``CREATE INDEX IF NOT EXISTS`` / ``ADD COLUMN
-  IF NOT EXISTS`` are inherently idempotent.
-* The backfill ``UPDATE`` is gated on ``location IS NULL``, so a re-run
-  after partial backfill only touches the un-backfilled remainder.
-* ``DROP COLUMN IF EXISTS`` is a no-op once the column is gone.
+Backfill: ``copied_at_ms IS NULL`` becomes ``LOCAL``, ``NOT NULL``
+becomes ``BOTH``. NOT NULL is enforced at the application layer because
+the ``segments_level_idx`` index blocks ``SET NOT NULL`` DDL.
 """
 
 from __future__ import annotations
@@ -54,22 +19,25 @@ from pathlib import Path
 
 import duckdb
 
+from finelog.store.migrations._runner import transactional
+
 
 def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir: Path | None) -> None:
     del data_dir
-    # DuckDB rejects ``DROP COLUMN`` (and ``SET NOT NULL``) on a table
-    # referenced by an index, so drop the level index, run the schema
-    # changes, then recreate it. NOT NULL is enforced at the application
-    # layer (the backfill below populates every existing row, and
-    # ``upsert_segment`` always provides ``location``).
+    # Drop and recreate the index because DuckDB rejects ``DROP COLUMN`` on
+    # an indexed table. The ADD+UPDATE pair runs in one transaction so no
+    # query sees a column of NULLs; the surrounding DDLs each auto-commit
+    # to sidestep DuckDB's "multiple DDLs + DML on one table in one txn"
+    # restriction.
     conn.execute("DROP INDEX IF EXISTS segments_ns_level_minseq")
-    conn.execute("ALTER TABLE segments ADD COLUMN IF NOT EXISTS location TEXT")
-    conn.execute(
-        """
-        UPDATE segments
-           SET location = CASE WHEN copied_at_ms IS NULL THEN 'LOCAL' ELSE 'BOTH' END
-         WHERE location IS NULL
-        """
-    )
+    with transactional(conn):
+        conn.execute("ALTER TABLE segments ADD COLUMN IF NOT EXISTS location TEXT")
+        conn.execute(
+            """
+            UPDATE segments
+               SET location = CASE WHEN copied_at_ms IS NULL THEN 'LOCAL' ELSE 'BOTH' END
+             WHERE location IS NULL
+            """
+        )
     conn.execute("ALTER TABLE segments DROP COLUMN IF EXISTS copied_at_ms")
     conn.execute("CREATE INDEX IF NOT EXISTS segments_ns_level_minseq ON segments (namespace, level, min_seq)")

--- a/lib/finelog/src/finelog/store/migrations/0006_segment_lifecycle.py
+++ b/lib/finelog/src/finelog/store/migrations/0006_segment_lifecycle.py
@@ -32,6 +32,20 @@ the only row-removal path, so every surviving row had a local file.
 Non-null is enforced at the application layer rather than via DuckDB's
 ``SET NOT NULL`` because the existing ``segments_level_idx`` blocks
 schema-altering DDL on the table.
+
+Idempotency
+-----------
+Each statement is a no-op against a partially-applied state, so a crash
+between any two statements is recovered by simply re-running. The runner
+does not wrap migrations in a transaction (DuckDB rejects multiple
+DDLs + DML on the same table in one txn), so resumability is the
+migration's responsibility:
+
+* ``DROP INDEX IF EXISTS`` / ``CREATE INDEX IF NOT EXISTS`` / ``ADD COLUMN
+  IF NOT EXISTS`` are inherently idempotent.
+* The backfill ``UPDATE`` is gated on ``location IS NULL``, so a re-run
+  after partial backfill only touches the un-backfilled remainder.
+* ``DROP COLUMN IF EXISTS`` is a no-op once the column is gone.
 """
 
 from __future__ import annotations
@@ -57,5 +71,5 @@ def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir: Path | None) -> None:
          WHERE location IS NULL
         """
     )
-    conn.execute("ALTER TABLE segments DROP COLUMN copied_at_ms")
+    conn.execute("ALTER TABLE segments DROP COLUMN IF EXISTS copied_at_ms")
     conn.execute("CREATE INDEX IF NOT EXISTS segments_ns_level_minseq ON segments (namespace, level, min_seq)")

--- a/lib/finelog/src/finelog/store/migrations/__init__.py
+++ b/lib/finelog/src/finelog/store/migrations/__init__.py
@@ -3,12 +3,20 @@
 
 """Versioned migrations for the finelog registry DuckDB sidecar.
 
-Each ``NNNN_name.py`` file defines a ``migrate(conn)`` callable. The
-:func:`apply_migrations` runner in :mod:`._runner` walks the directory in
-filename order and applies any not yet recorded in the ``schema_migrations``
-table. Each migration runs inside a transaction that also inserts the
-``schema_migrations`` row, so partial application can't leave the catalog
-in a half-migrated state.
+Each ``NNNN_name.py`` file defines a ``migrate(conn, *, data_dir)``
+callable. The :func:`apply_migrations` runner in :mod:`._runner` walks
+the directory in filename order and applies any not yet recorded in the
+``schema_migrations`` table. After a successful ``migrate`` the runner
+inserts a row in ``schema_migrations``; a raised exception leaves the
+row out so the next open re-runs the migration.
+
+The runner does not wrap migrations in an outer transaction. DuckDB
+rejects several useful statement sequences (notably multiple
+schema-altering DDLs + DML on the same table) inside a single
+transaction, so each migration is responsible for its own atomicity and
+must be idempotent under partial application. Migrations that *can*
+benefit from a multi-statement transaction can call
+:func:`transactional` themselves.
 
 Migration files must be idempotent against any pre-migrations on-disk
 state: pre-existing deployments are bootstrapped through 0001 even though

--- a/lib/finelog/src/finelog/store/migrations/__init__.py
+++ b/lib/finelog/src/finelog/store/migrations/__init__.py
@@ -4,23 +4,10 @@
 """Versioned migrations for the finelog registry DuckDB sidecar.
 
 Each ``NNNN_name.py`` file defines a ``migrate(conn, *, data_dir)``
-callable. The :func:`apply_migrations` runner in :mod:`._runner` walks
-the directory in filename order and applies any not yet recorded in the
-``schema_migrations`` table. After a successful ``migrate`` the runner
-inserts a row in ``schema_migrations``; a raised exception leaves the
-row out so the next open re-runs the migration.
-
-The runner does not wrap migrations in an outer transaction. DuckDB
-rejects several useful statement sequences (notably multiple
-schema-altering DDLs + DML on the same table) inside a single
-transaction, so each migration is responsible for its own atomicity and
-must be idempotent under partial application. Migrations that *can*
-benefit from a multi-statement transaction can call
-:func:`transactional` themselves.
-
-Migration files must be idempotent against any pre-migrations on-disk
-state: pre-existing deployments are bootstrapped through 0001 even though
-their tables already exist.
+callable. The runner applies them in filename order and records each
+in ``schema_migrations`` only on success. Migrations run without an
+enclosing transaction, so they must be idempotent; multi-statement
+atomicity is opt-in via :func:`transactional`.
 """
 
 from finelog.store.migrations._runner import apply_migrations, transactional

--- a/lib/finelog/src/finelog/store/migrations/_runner.py
+++ b/lib/finelog/src/finelog/store/migrations/_runner.py
@@ -3,30 +3,17 @@
 
 """Versioned migrations runner for the registry DuckDB sidecar.
 
-Migration files live next to this module as ``NNNN_name.py`` and define a
-``migrate(conn, *, data_dir)`` function. The runner discovers them in
-filename order, filters out any already recorded in the
-``schema_migrations`` table, and applies the remainder. After ``migrate``
-returns the runner inserts the ``schema_migrations`` row.
+Migration files live next to this module as ``NNNN_name.py`` and define
+a ``migrate(conn, *, data_dir)`` function. The runner applies them in
+filename order, skipping any already recorded in ``schema_migrations``,
+and inserts the ``schema_migrations`` row only after ``migrate`` returns
+without raising.
 
-The runner does **not** wrap ``migrate()`` in an outer transaction. DuckDB
-rejects several useful sequences inside a single transaction — most
-notably multiple schema-altering DDLs interleaved with DML on the same
-table — so each migration manages its own atomicity. Two consequences:
-
-* Migrations must be idempotent (``CREATE TABLE IF NOT EXISTS``,
-  ``ALTER TABLE ... ADD COLUMN IF NOT EXISTS``, ``DROP COLUMN IF EXISTS``,
-  conditional UPDATE filters). A crash mid-migration may leave partial
-  side effects on disk; on the next open, the migration runs again and
-  the idempotent statements converge.
-* When a migration needs multi-statement atomicity for a block that
-  DuckDB *does* accept (e.g. compaction's swap of input/output rows),
-  it can call :func:`transactional` itself. The helper is exported for
-  exactly this case.
-
-The ``schema_migrations`` row insert lands only if ``migrate()`` returned
-without raising, so a failed migration is naturally re-run on the next
-open.
+Migrations run with no enclosing transaction — DuckDB rejects several
+useful sequences (notably multiple DDLs + DML on the same table) inside
+one — so each migration is responsible for atomicity and must be
+idempotent. Migrations that want a multi-statement transaction can call
+:func:`transactional` themselves.
 """
 
 from __future__ import annotations
@@ -45,13 +32,7 @@ logger = logging.getLogger(__name__)
 
 @contextmanager
 def transactional(conn: duckdb.DuckDBPyConnection) -> Iterator[duckdb.DuckDBPyConnection]:
-    """Run a block inside a DuckDB ``BEGIN``/``COMMIT`` transaction.
-
-    Any exception triggers ``ROLLBACK`` and propagates; a clean exit
-    ``COMMIT``s. Useful for callers that want all-or-nothing semantics
-    over multiple statements (compaction's segment swap, a migration's
-    multi-row backfill where partial visibility would be wrong).
-    """
+    """``BEGIN``/``COMMIT`` around a block; ``ROLLBACK`` on exception."""
     conn.execute("BEGIN")
     try:
         yield conn
@@ -63,8 +44,6 @@ def transactional(conn: duckdb.DuckDBPyConnection) -> Iterator[duckdb.DuckDBPyCo
 
 
 def _discover_migrations(migrations_dir: Path) -> list[Path]:
-    """Migration files in numeric order. Anything starting with ``_`` (e.g.
-    ``_runner.py``, ``__init__.py``) is skipped."""
     return [p for p in sorted(migrations_dir.glob("*.py")) if not p.name.startswith("_")]
 
 
@@ -80,7 +59,6 @@ def _ensure_schema_migrations_table(conn: duckdb.DuckDBPyConnection) -> None:
 
 
 def _load_migration(path: Path):
-    """Load a migration module from a file path; return its ``migrate``."""
     spec = importlib.util.spec_from_file_location(path.stem, path)
     assert spec is not None and spec.loader is not None, f"failed to load migration spec for {path}"
     module = importlib.util.module_from_spec(spec)
@@ -96,18 +74,8 @@ def apply_migrations(
     *,
     data_dir: Path | None = None,
 ) -> None:
-    """Apply pending migrations from ``migrations_dir`` to ``conn``.
-
-    ``migrations_dir`` defaults to this package's directory. ``data_dir``
-    is the parent directory of the registry DB and is forwarded to every
-    migration's ``migrate(conn, *, data_dir=...)`` signature; migrations
-    that need to rename on-disk parquet files use it.
-
-    Each ``migrate`` runs without an enclosing transaction (see module
-    docstring). If it raises, the ``schema_migrations`` row is not
-    inserted, so the migration will re-run on the next open — and must
-    therefore be idempotent.
-    """
+    """Apply pending migrations. ``data_dir`` is forwarded to migrations
+    that need to rename on-disk parquet files."""
     if migrations_dir is None:
         migrations_dir = Path(__file__).parent
 

--- a/lib/finelog/src/finelog/store/migrations/_runner.py
+++ b/lib/finelog/src/finelog/store/migrations/_runner.py
@@ -4,16 +4,29 @@
 """Versioned migrations runner for the registry DuckDB sidecar.
 
 Migration files live next to this module as ``NNNN_name.py`` and define a
-``migrate(conn)`` function. The runner discovers them in filename order,
-filters out any already recorded in the ``schema_migrations`` table, and
-applies the remainder. Each migration runs inside a transaction that also
-inserts its ``schema_migrations`` row — a crash mid-migration leaves no
-half-applied state.
+``migrate(conn, *, data_dir)`` function. The runner discovers them in
+filename order, filters out any already recorded in the
+``schema_migrations`` table, and applies the remainder. After ``migrate``
+returns the runner inserts the ``schema_migrations`` row.
 
-Migrations must be idempotent (``CREATE TABLE IF NOT EXISTS``,
-``ALTER TABLE ... ADD COLUMN IF NOT EXISTS``, etc.). Existing deployments
-may already have tables created by an earlier release that pre-dates this
-runner; the first migration just records that v1 has been observed.
+The runner does **not** wrap ``migrate()`` in an outer transaction. DuckDB
+rejects several useful sequences inside a single transaction — most
+notably multiple schema-altering DDLs interleaved with DML on the same
+table — so each migration manages its own atomicity. Two consequences:
+
+* Migrations must be idempotent (``CREATE TABLE IF NOT EXISTS``,
+  ``ALTER TABLE ... ADD COLUMN IF NOT EXISTS``, ``DROP COLUMN IF EXISTS``,
+  conditional UPDATE filters). A crash mid-migration may leave partial
+  side effects on disk; on the next open, the migration runs again and
+  the idempotent statements converge.
+* When a migration needs multi-statement atomicity for a block that
+  DuckDB *does* accept (e.g. compaction's swap of input/output rows),
+  it can call :func:`transactional` itself. The helper is exported for
+  exactly this case.
+
+The ``schema_migrations`` row insert lands only if ``migrate()`` returned
+without raising, so a failed migration is naturally re-run on the next
+open.
 """
 
 from __future__ import annotations
@@ -36,8 +49,8 @@ def transactional(conn: duckdb.DuckDBPyConnection) -> Iterator[duckdb.DuckDBPyCo
 
     Any exception triggers ``ROLLBACK`` and propagates; a clean exit
     ``COMMIT``s. Useful for callers that want all-or-nothing semantics
-    over multiple statements (compaction's segment swap, the migration
-    runner's apply-and-record pair).
+    over multiple statements (compaction's segment swap, a migration's
+    multi-row backfill where partial visibility would be wrong).
     """
     conn.execute("BEGIN")
     try:
@@ -86,9 +99,14 @@ def apply_migrations(
     """Apply pending migrations from ``migrations_dir`` to ``conn``.
 
     ``migrations_dir`` defaults to this package's directory. ``data_dir``
-    is the parent directory of the registry DB and is forwarded to any
-    migration whose ``migrate`` signature declares a ``data_dir`` parameter.
-    Migrations that need to rename on-disk parquet files use it.
+    is the parent directory of the registry DB and is forwarded to every
+    migration's ``migrate(conn, *, data_dir=...)`` signature; migrations
+    that need to rename on-disk parquet files use it.
+
+    Each ``migrate`` runs without an enclosing transaction (see module
+    docstring). If it raises, the ``schema_migrations`` row is not
+    inserted, so the migration will re-run on the next open — and must
+    therefore be idempotent.
     """
     if migrations_dir is None:
         migrations_dir = Path(__file__).parent
@@ -105,10 +123,9 @@ def apply_migrations(
     for path in pending:
         t0 = time.monotonic()
         migrate = _load_migration(path)
-        with transactional(conn):
-            migrate(conn, data_dir=data_dir)
-            conn.execute(
-                "INSERT INTO schema_migrations(name, applied_at_ms) VALUES (?, ?)",
-                [path.name, int(time.time() * 1000)],
-            )
+        migrate(conn, data_dir=data_dir)
+        conn.execute(
+            "INSERT INTO schema_migrations(name, applied_at_ms) VALUES (?, ?)",
+            [path.name, int(time.time() * 1000)],
+        )
         logger.info("finelog migration %s applied in %.3fs", path.name, time.monotonic() - t0)

--- a/lib/finelog/tests/test_migrations.py
+++ b/lib/finelog/tests/test_migrations.py
@@ -4,8 +4,12 @@
 """Tests for the registry migrations runner.
 
 The runner backs every catalog schema change after the baseline; pinning
-its core invariants (idempotency, transactional apply, partial-failure
-rollback, legacy-database adoption) keeps future migration authors honest.
+its core invariants (idempotency, legacy-database adoption, retry on
+failure) keeps future migration authors honest. The runner does not
+wrap migrations in an outer transaction — migrations manage their own
+atomicity and must be idempotent — so the tests assert that a failed
+migration leaves ``schema_migrations`` untouched and is retried on the
+next apply, rather than that its side effects are rolled back.
 """
 
 from __future__ import annotations
@@ -108,15 +112,18 @@ def test_pre_migrations_database_inherits_baseline(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Transactional apply: a failing migration leaves no row in schema_migrations.
+# Failed migrations leave no row in ``schema_migrations`` (so they retry).
+# Per-statement side effects from a partially-applied migration ARE visible
+# — the runner does not wrap migrations in a transaction. Migrations must
+# be idempotent so that the next apply converges over the half-applied state.
 # ---------------------------------------------------------------------------
 
 
-def test_failing_migration_rolls_back(tmp_path):
+def test_failing_migration_is_not_recorded(tmp_path):
     fake_dir = tmp_path / "migs"
     fake_dir.mkdir()
-    # 0001 succeeds, 0002 fails. Both should be observable via the runner;
-    # only 0001 should be marked applied.
+    # 0001 succeeds, 0002 partially applies then fails. Only 0001 is
+    # recorded as applied; 0002's pre-failure side effect is still visible.
     (fake_dir / "0001_ok.py").write_text(
         "import duckdb\n"
         "def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir) -> None:\n"
@@ -125,7 +132,7 @@ def test_failing_migration_rolls_back(tmp_path):
     (fake_dir / "0002_boom.py").write_text(
         "import duckdb\n"
         "def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir) -> None:\n"
-        "    conn.execute('CREATE TABLE will_be_rolled_back (n INTEGER)')\n"
+        "    conn.execute('CREATE TABLE IF NOT EXISTS partial_side_effect (n INTEGER)')\n"
         "    raise RuntimeError('simulated migration failure')\n"
     )
 
@@ -137,14 +144,22 @@ def test_failing_migration_rolls_back(tmp_path):
         # 0001 is recorded and its table exists.
         assert _applied_migrations(conn) == ["0001_ok.py"]
         assert "ok_marker" in _list_tables(conn)
-        # 0002's side-effect was rolled back: neither the table nor a row.
-        assert "will_be_rolled_back" not in _list_tables(conn)
+        # 0002 left a partial side effect on disk; idempotent re-run is the
+        # migration author's responsibility. The runner just declines to
+        # record it as applied so the next ``apply_migrations`` retries it.
+        assert "partial_side_effect" in _list_tables(conn)
+        assert "0002_boom.py" not in _applied_migrations(conn)
     finally:
         conn.close()
 
 
 def test_failed_migration_retries_on_next_apply(tmp_path):
-    """A migration that failed once must run again on the next open."""
+    """A migration that failed once must run again on the next open.
+
+    Idempotent statements (``CREATE TABLE IF NOT EXISTS`` here) make a
+    re-run safe even though the partial side effect from the first pass
+    is still on disk.
+    """
     fake_dir = tmp_path / "migs"
     fake_dir.mkdir()
     migration_path = fake_dir / "0001_flaky.py"

--- a/lib/finelog/tests/test_migrations.py
+++ b/lib/finelog/tests/test_migrations.py
@@ -1,16 +1,9 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the registry migrations runner.
-
-The runner backs every catalog schema change after the baseline; pinning
-its core invariants (idempotency, legacy-database adoption, retry on
-failure) keeps future migration authors honest. The runner does not
-wrap migrations in an outer transaction — migrations manage their own
-atomicity and must be idempotent — so the tests assert that a failed
-migration leaves ``schema_migrations`` untouched and is retried on the
-next apply, rather than that its side effects are rolled back.
-"""
+"""Tests for the registry migrations runner: idempotency, legacy adoption,
+retry-on-failure, and the ``transactional`` helper migrations use for
+their internal atomicity."""
 
 from __future__ import annotations
 
@@ -28,11 +21,6 @@ def _list_tables(conn: duckdb.DuckDBPyConnection) -> set[str]:
 
 def _applied_migrations(conn: duckdb.DuckDBPyConnection) -> list[str]:
     return [row[0] for row in conn.execute("SELECT name FROM schema_migrations ORDER BY name").fetchall()]
-
-
-# ---------------------------------------------------------------------------
-# Baseline: a fresh registry has all tables and 0001 recorded.
-# ---------------------------------------------------------------------------
 
 
 def test_fresh_registry_runs_baseline_migration(tmp_path):
@@ -55,11 +43,9 @@ def test_fresh_registry_runs_baseline_migration(tmp_path):
 
 
 def test_reopen_is_idempotent(tmp_path):
-    """Opening the same data dir twice does not re-apply migrations."""
     Catalog(tmp_path).close()
     db = Catalog(tmp_path)
     try:
-        # Still exactly one row, not two.
         assert _applied_migrations(db._conn) == [
             "0001_init.py",
             "0002_segment_key_value_bounds.py",
@@ -72,13 +58,8 @@ def test_reopen_is_idempotent(tmp_path):
         db.close()
 
 
-# ---------------------------------------------------------------------------
-# Legacy adoption: a pre-migrations DB inherits the baseline cleanly.
-# ---------------------------------------------------------------------------
-
-
 def test_pre_migrations_database_inherits_baseline(tmp_path):
-    """A DB created by an old release (only ``namespaces`` table) opens cleanly."""
+    """A pre-migrations DB (only ``namespaces`` table) opens cleanly."""
     db_path = tmp_path / "_finelog_registry.duckdb"
     legacy = duckdb.connect(str(db_path))
     legacy.execute(
@@ -96,7 +77,6 @@ def test_pre_migrations_database_inherits_baseline(tmp_path):
 
     db = Catalog(tmp_path)
     try:
-        # Existing row preserved; segments table created; baseline recorded.
         assert db._conn.execute("SELECT namespace FROM namespaces").fetchall() == [("iris.worker",)]
         assert "segments" in _list_tables(db._conn)
         assert _applied_migrations(db._conn) == [
@@ -111,19 +91,12 @@ def test_pre_migrations_database_inherits_baseline(tmp_path):
         db.close()
 
 
-# ---------------------------------------------------------------------------
-# Failed migrations leave no row in ``schema_migrations`` (so they retry).
-# Per-statement side effects from a partially-applied migration ARE visible
-# — the runner does not wrap migrations in a transaction. Migrations must
-# be idempotent so that the next apply converges over the half-applied state.
-# ---------------------------------------------------------------------------
-
-
 def test_failing_migration_is_not_recorded(tmp_path):
+    """0002 partially applies then raises; 0001 is recorded, 0002 isn't,
+    and 0002's pre-failure side effect remains visible (idempotent re-run
+    is the migration's responsibility)."""
     fake_dir = tmp_path / "migs"
     fake_dir.mkdir()
-    # 0001 succeeds, 0002 partially applies then fails. Only 0001 is
-    # recorded as applied; 0002's pre-failure side effect is still visible.
     (fake_dir / "0001_ok.py").write_text(
         "import duckdb\n"
         "def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir) -> None:\n"
@@ -141,12 +114,8 @@ def test_failing_migration_is_not_recorded(tmp_path):
         with pytest.raises(RuntimeError, match="simulated migration failure"):
             apply_migrations(conn, fake_dir)
 
-        # 0001 is recorded and its table exists.
         assert _applied_migrations(conn) == ["0001_ok.py"]
         assert "ok_marker" in _list_tables(conn)
-        # 0002 left a partial side effect on disk; idempotent re-run is the
-        # migration author's responsibility. The runner just declines to
-        # record it as applied so the next ``apply_migrations`` retries it.
         assert "partial_side_effect" in _list_tables(conn)
         assert "0002_boom.py" not in _applied_migrations(conn)
     finally:
@@ -154,17 +123,11 @@ def test_failing_migration_is_not_recorded(tmp_path):
 
 
 def test_failed_migration_retries_on_next_apply(tmp_path):
-    """A migration that failed once must run again on the next open.
-
-    Idempotent statements (``CREATE TABLE IF NOT EXISTS`` here) make a
-    re-run safe even though the partial side effect from the first pass
-    is still on disk.
-    """
+    """A migration that raised the first time runs again on the next open."""
     fake_dir = tmp_path / "migs"
     fake_dir.mkdir()
     migration_path = fake_dir / "0001_flaky.py"
 
-    # First version raises after a side-effect, simulating a half-failed apply.
     migration_path.write_text(
         "def migrate(conn, *, data_dir):\n"
         "    conn.execute('CREATE TABLE IF NOT EXISTS marker (n INTEGER)')\n"
@@ -186,11 +149,6 @@ def test_failed_migration_retries_on_next_apply(tmp_path):
         assert _applied_migrations(conn) == ["0001_flaky.py"]
     finally:
         conn.close()
-
-
-# ---------------------------------------------------------------------------
-# transactional helper exposed for callers (compaction's segment swap, etc.)
-# ---------------------------------------------------------------------------
 
 
 def test_transactional_commits_on_success():
@@ -219,11 +177,6 @@ def test_transactional_rolls_back_on_exception():
         conn.close()
 
 
-# ---------------------------------------------------------------------------
-# Discovery: hidden / dunder files are not picked up.
-# ---------------------------------------------------------------------------
-
-
 def test_underscore_prefixed_files_are_skipped(tmp_path):
     fake_dir = tmp_path / "migs"
     fake_dir.mkdir()
@@ -241,16 +194,10 @@ def test_underscore_prefixed_files_are_skipped(tmp_path):
         conn.close()
 
 
-# ---------------------------------------------------------------------------
-# Integrity: a real production-shaped catalog still works after migrations.
-# ---------------------------------------------------------------------------
-
-
 def test_catalog_segments_apis_function_after_migration(tmp_path):
-    """End-to-end check: write a segment row through the public Catalog API."""
+    """End-to-end: write a segment row through the public Catalog API."""
     db = Catalog(tmp_path)
     try:
-        # ``aggregate_namespace_stats`` and friends rely on the baseline schema.
         assert db.aggregate_namespace_stats("ns").row_count == 0
         seg = SegmentRow(
             namespace="ns",
@@ -270,7 +217,6 @@ def test_catalog_segments_apis_function_after_migration(tmp_path):
         assert stats.row_count == 10
         assert stats.segment_count == 1
 
-        # 0002 + 0003 + 0006 columns survive the round-trip.
         rows = db.list_segments("ns")
         assert len(rows) == 1
         assert rows[0].level == 1

--- a/lib/finelog/tests/test_server.py
+++ b/lib/finelog/tests/test_server.py
@@ -111,15 +111,8 @@ def test_push_then_fetch_round_trip(tmp_path: Path):
 
 
 def test_fetch_logs_wire_unspecified_reads_as_regex(tmp_path: Path):
-    """RPC clients that omit ``match_scope`` (wire-level UNSPECIFIED) get
-    legacy regex semantics — the pre-MatchScope default. This is what keeps
-    an in-flight older dashboard build working across a finelog upgrade:
-    its FetchLogs payload still encodes the query as a regex ``source``
-    pattern, and the server interprets it accordingly.
-
-    New code should set MATCH_SCOPE_EXACT or MATCH_SCOPE_PREFIX explicitly;
-    relying on this fallback is the deprecated path.
-    """
+    """Wire-level UNSPECIFIED falls back to REGEX so a regex ``source``
+    pattern still matches when ``match_scope`` is unset."""
     svc = LogServiceImpl(log_store=DuckDBLogStore(log_dir=tmp_path / "data"))
     try:
         app = build_log_server_asgi(svc)
@@ -133,9 +126,6 @@ def test_fetch_logs_wire_unspecified_reads_as_regex(tmp_path: Path):
                     },
                     headers={"Content-Type": "application/json"},
                 )
-            # No match_scope field on the wire (proto-default 0 == UNSPECIFIED)
-            # and a regex-style source — the exact shape that older dashboards
-            # send. The server falls back to REGEX so we still see both attempts.
             resp = client.post(
                 "/finelog.logging.LogService/FetchLogs",
                 json={"source": r"/job/test/0:\d+"},

--- a/lib/finelog/tests/test_server.py
+++ b/lib/finelog/tests/test_server.py
@@ -110,11 +110,15 @@ def test_push_then_fetch_round_trip(tmp_path: Path):
         svc.close()
 
 
-def test_fetch_logs_wire_unspecified_reads_as_prefix(tmp_path: Path):
-    """RPC clients that omit ``match_scope`` (wire-level UNSPECIFIED) must
-    read path-style: ``/job/<job>/<task>`` should pick up every attempt.
-    The in-process Python default is EXACT, so the server boundary maps
-    UNSPECIFIED → PREFIX before delegating.
+def test_fetch_logs_wire_unspecified_reads_as_regex(tmp_path: Path):
+    """RPC clients that omit ``match_scope`` (wire-level UNSPECIFIED) get
+    legacy regex semantics — the pre-MatchScope default. This is what keeps
+    an in-flight older dashboard build working across a finelog upgrade:
+    its FetchLogs payload still encodes the query as a regex ``source``
+    pattern, and the server interprets it accordingly.
+
+    New code should set MATCH_SCOPE_EXACT or MATCH_SCOPE_PREFIX explicitly;
+    relying on this fallback is the deprecated path.
     """
     svc = LogServiceImpl(log_store=DuckDBLogStore(log_dir=tmp_path / "data"))
     try:
@@ -129,11 +133,12 @@ def test_fetch_logs_wire_unspecified_reads_as_prefix(tmp_path: Path):
                     },
                     headers={"Content-Type": "application/json"},
                 )
-            # No match_scope field on the wire (proto-default 0 == UNSPECIFIED).
-            # Server must read this as PREFIX so we see both attempts.
+            # No match_scope field on the wire (proto-default 0 == UNSPECIFIED)
+            # and a regex-style source — the exact shape that older dashboards
+            # send. The server falls back to REGEX so we still see both attempts.
             resp = client.post(
                 "/finelog.logging.LogService/FetchLogs",
-                json={"source": "/job/test/0:"},
+                json={"source": r"/job/test/0:\d+"},
                 headers={"Content-Type": "application/json"},
             )
             assert resp.status_code == 200


### PR DESCRIPTION
Migration runner no longer wraps migrate() in a transaction so 0006 can run multiple DDLs + DML on one table without DuckDB's commit-time "another transaction altered this table" error. Migrations must be idempotent under partial application; transactional() is exported for blocks that genuinely benefit from atomicity.

_adopt_remote_segments fetches parquet footers on a thread pool and takes file size from fs.find(detail=True), eliminating one network round-trip per segment in the worst case.

LogService falls back to MATCH_SCOPE_REGEX when wire-level match_scope is UNSPECIFIED, so older dashboard / iris controller builds whose FetchLogs payloads still encode the query as a regex source keep working across a finelog upgrade. New code paths set EXACT or PREFIX explicitly and bypass the fallback, so #5392 stays fixed.