### PR TITLE
datakit: sync raw downloads between MARIN prefixes

### DIFF
--- a/lib/zephyr/src/zephyr/writers.py
+++ b/lib/zephyr/src/zephyr/writers.py
@@ -9,7 +9,6 @@ import itertools
 import logging
 import os
 import queue
-import tempfile
 import threading
 import uuid
 from collections.abc import Callable, Iterable
@@ -23,7 +22,6 @@ import pyarrow.parquet as pq
 import vortex
 import zstandard as zstd
 from rigging.filesystem import url_to_fs
-from rigging.timing import log_time
 
 from zephyr import counters
 
@@ -56,44 +54,25 @@ def unique_temp_path(output_path: str) -> str:
 
 
 @contextmanager
-def atomic_rename(output_path: str) -> Iterable[str]:
-    """Context manager for atomic write-and-rename with UUID collision avoidance.
+def atomic_rename(output_path: str, fs: Any = None) -> Iterable[str]:
+    """Atomic write-and-rename via a sibling temp key.
 
-    Yields a unique temporary path to write to. On successful exit, atomically
-    renames the temp file to the final path. On failure, cleans up the temp file.
+    Yields ``<output_path>.tmp.<uuid>``; on clean exit, ``fs.mv`` renames the
+    temp into the final path. On exception, the temp key is best-effort
+    deleted and the original exception re-raised.
 
-    For S3-compatible stores, writes to a local temp directory first, then uploads
-    via fs.put() to avoid server-side multipart copy which is unreliable on some
-    providers (e.g. Cloudflare R2).
+    Callers may pass a pre-constructed ``fs`` to reuse a configured
+    filesystem (e.g. an ``S3FileSystem`` with ``fixed_upload_size=True``)
+    instead of letting atomic_rename build a default one from ``output_path``.
 
     Example:
         with atomic_rename("output.jsonl.gz") as tmp_path:
             write_data(tmp_path)
         # File is now at output.jsonl.gz
     """
-    if output_path.startswith("s3://"):
-        fs, resolved_path = url_to_fs(output_path)
-        with tempfile.TemporaryDirectory() as local_tmp_dir:
-            local_path = os.path.join(local_tmp_dir, "output")
-            yield local_path
-            if os.path.isdir(local_path):
-                # batch_size caps concurrent files in flight. Per-file ceiling
-                # is max_concurrency=10 * chunksize=50 MiB = 500 MiB for any
-                # file ≥ 100 MiB (smaller ones skip multipart). fsspec's default
-                # batch_size=128 → 64 GiB ceiling, observed ~11 GiB peak on a
-                # 40-chunk sample. batch_size=8 → 4 GiB ceiling, observed ~2 GiB
-                # peak on the same sample.
-                with log_time(f"atomic_rename fs.put recursive {local_path} → {resolved_path}"):
-                    # Trailing slash prevents fsspec from nesting under an extra
-                    # "output/" level when the destination already exists.
-                    fs.put(local_path + "/", resolved_path, recursive=True, batch_size=8)
-            else:
-                fs.put(local_path, resolved_path)
-        return
-
     temp_path = unique_temp_path(output_path)
-    fs = url_to_fs(output_path)[0]
-
+    if fs is None:
+        fs = url_to_fs(output_path)[0]
     try:
         yield temp_path
         fs.mv(temp_path, output_path, recursive=True)

--- a/lib/zephyr/tests/test_writers.py
+++ b/lib/zephyr/tests/test_writers.py
@@ -3,7 +3,6 @@
 
 """Tests for writers module."""
 
-import os
 import tempfile
 from pathlib import Path
 
@@ -200,50 +199,6 @@ def test_write_parquet_file_empty():
 
         table = pq.read_table(output_path)
         assert len(table) == 0
-
-
-def test_atomic_rename_s3_directory_preserves_layout(tmp_path):
-    """S3 atomic_rename must not add extra nesting for directory outputs.
-
-    When the yielded path is a directory, fs.put must place contents directly at
-    the destination — not under an extra ``output/`` subdirectory.  fsspec nests
-    when the source has no trailing slash and the destination already exists, so
-    atomic_rename must account for that.
-    """
-    from unittest.mock import patch
-
-    from fsspec.implementations.local import LocalFileSystem
-
-    dest = tmp_path / "dest"
-    dest.mkdir()  # pre-create so fsspec considers it "existing"
-    local_fs = LocalFileSystem()
-
-    with patch("zephyr.writers.url_to_fs", return_value=(local_fs, str(dest))):
-        with atomic_rename("s3://bucket/dest") as local_path:
-            os.makedirs(local_path)
-            (Path(local_path) / "shard_0.bin").write_bytes(b"data0")
-            (Path(local_path) / "shard_1.bin").write_bytes(b"data1")
-
-    assert (dest / "shard_0.bin").exists(), "shard_0.bin should be directly under dest"
-    assert (dest / "shard_1.bin").exists(), "shard_1.bin should be directly under dest"
-    assert not (dest / "output").exists(), "should not have extra 'output' nesting"
-
-
-def test_atomic_rename_s3_single_file(tmp_path):
-    """S3 atomic_rename works correctly for single-file outputs."""
-    from unittest.mock import patch
-
-    from fsspec.implementations.local import LocalFileSystem
-
-    dest = tmp_path / "output.jsonl"
-    local_fs = LocalFileSystem()
-
-    with patch("zephyr.writers.url_to_fs", return_value=(local_fs, str(dest))):
-        with atomic_rename("s3://bucket/output.jsonl") as local_path:
-            Path(local_path).write_text("line1\nline2\n")
-
-    assert dest.exists()
-    assert dest.read_text() == "line1\nline2\n"
 
 
 def test_infer_arrow_schema_basic():

--- a/scripts/datakit/sync_datakit.py
+++ b/scripts/datakit/sync_datakit.py
@@ -1,0 +1,498 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sync every Datakit source's raw downloads between two MARIN-shaped prefixes.
+
+Direction-agnostic: copies the raw downloads of each
+:class:`marin.datakit.sources.DatakitSource` from ``--src-prefix`` to
+``--dest-prefix`` while preserving the relative path layout below the prefix.
+Typical use is GCS -> R2 (e.g. ``gs://marin-us-central1`` to
+``s3://marin-na/marin``); the reverse works too.
+
+For each source, this script builds a single :class:`StepSpec`. The step's
+``fn`` runs a Zephyr pipeline that:
+
+* Lists every object under each leaf download path on the source side
+  (including files whose names start with ``.`` or ``_`` — S3/GCS treat
+  these like any other key).
+* Sorts the file list and groups it into deterministic shards of
+  ``files_per_shard`` files (default 64). Same input set => same shards.
+* For each shard, hashes the sorted ``(rel_path, fingerprint)`` pairs —
+  where ``fingerprint`` is the source object's ETag/size/mtime — and uses
+  that hash as the filename of the shard's JSONL output under
+  ``status_prefix``. Zephyr's ``skip_existing=True`` short-circuits any
+  shard whose output already exists. If a source object is rewritten, its
+  fingerprint flips, the shard hash changes, the JSONL key doesn't match,
+  and the shard is re-copied.
+* Otherwise, streams every file in the shard from source to a sibling
+  ``.tmp.<uuid>`` key at the destination and publishes it via
+  :func:`zephyr.writers.atomic_rename` (the per-file copies fan out across
+  ``copy_threads`` threads), then Zephyr writes the per-shard JSONL — that
+  output IS the resume marker. When the destination is ``s3://``, the dst
+  ``S3FileSystem`` is constructed with ``fixed_upload_size=True`` so R2
+  accepts the multipart upload (AWS S3 accepts uniform-size parts too, so
+  the flag is harmless there).
+
+Per-shard JSONL and per-source executor status all live under
+``status_prefix`` (default ``gs://marin-us-central1/data/datakit/sync``)
+namespaced by a hash of ``(src_prefix, dest_prefix)`` so to-R2 and from-R2
+runs of the same source don't share markers (their fingerprints aren't
+comparable anyway — GCS ETag vs R2 ETag are different schemes for the same
+bytes). The status prefix is the permanent record of what has been copied;
+there's no TTL to worry about.
+
+Usage::
+
+    AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... \\
+    AWS_ENDPOINT_URL=https://<account>.r2.cloudflarestorage.com \\
+    uv run python scripts/datakit/sync_datakit.py \\
+        --src-prefix gs://marin-us-central1 \\
+        --dest-prefix s3://marin-na/marin
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import fsspec
+from fray import ResourceConfig
+from marin.datakit.sources import DatakitSource, all_sources
+from marin.execution.step_runner import StepRunner
+from marin.execution.step_spec import StepSpec
+from rigging.filesystem import marin_prefix
+from rigging.log_setup import configure_logging
+from zephyr import Dataset, ZephyrContext, counters
+from zephyr.plan import deterministic_hash
+from zephyr.writers import atomic_rename
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_FILES_PER_SHARD = 64
+DEFAULT_COPY_THREADS_PER_SHARD = 16
+DEFAULT_STATUS_PREFIX = "gs://marin-us-central1/data/datakit/sync"
+COPY_CHUNK_BYTES = 8 * 1024 * 1024
+
+# Matches the ``.tmp.<uuid.hex>`` suffix that ``zephyr.writers.atomic_rename``
+# uses for its intermediate write key. Used to filter orphan leftovers out
+# of source listings (see ``_list_relative_files``).
+_ATOMIC_RENAME_TMP_RE = re.compile(r"\.tmp\.[0-9a-f]{32}$")
+
+
+# ----------------------------------------------------------------------
+# DAG walk + path helpers
+# ----------------------------------------------------------------------
+
+
+def _leaf_downloads(step: StepSpec) -> list[StepSpec]:
+    """Return the leaf StepSpecs (no ``deps``) reachable from ``step``.
+
+    May yield the same leaf twice if the DAG has a diamond; the call site
+    dedupes by ``output_path``.
+    """
+    if not step.deps:
+        return [step]
+    return [leaf for dep in step.deps for leaf in _leaf_downloads(dep)]
+
+
+def _safe_name(source_name: str) -> str:
+    """Filesystem-safe form of ``source_name`` (e.g. ``cp/biodiversity`` -> ``cp__biodiversity``)."""
+    return source_name.replace("/", "__")
+
+
+def _rebase(src_path: str, src_prefix: str, dst_prefix: str) -> str:
+    """Replace the leading ``src_prefix`` of ``src_path`` with ``dst_prefix``."""
+    s = src_prefix.rstrip("/")
+    d = dst_prefix.rstrip("/")
+    if not src_path.startswith(s):
+        raise ValueError(f"path {src_path!r} does not start with prefix {s!r}")
+    return d + src_path[len(s) :]
+
+
+# ----------------------------------------------------------------------
+# Zephyr worker: one shard = up to N files
+# ----------------------------------------------------------------------
+
+
+def _object_fingerprint(info: dict) -> str:
+    """Stable per-object fingerprint that changes when the source object changes.
+
+    Prefers the storage-layer content hash (GCS ``etag``/``md5Hash``, S3 ``ETag``)
+    since that flips on every object overwrite. Falls back to ``size`` + the
+    last-modified timestamp so we always include *something* metadata-shaped.
+    """
+    etag = info.get("etag") or info.get("ETag") or info.get("md5Hash")
+    size = info.get("size") or info.get("Size")
+    mtime = info.get("mtime") or info.get("LastModified") or info.get("updated")
+    parts: list[str] = []
+    if etag:
+        parts.append(f"etag={etag}")
+    if size is not None:
+        parts.append(f"size={size}")
+    if mtime is not None:
+        parts.append(f"mtime={mtime}")
+    if not parts:
+        raise RuntimeError(f"no usable metadata in info dict (keys={sorted(info)})")
+    return "|".join(parts)
+
+
+def _shard_hash(entries: list[tuple[str, str]]) -> str:
+    """Stable hash of ``[(rel_path, fingerprint)]`` — identifies the shard for resume.
+
+    Including the per-file fingerprint means the marker invalidates whenever
+    a source object is rewritten (different ETag/size/mtime), so a re-sync
+    picks up the change instead of trusting a stale marker.
+    """
+    return format(deterministic_hash(entries), "016x")
+
+
+def _copy_one(src_fs, dst_fs, src_path: str, dst_path: str) -> int:
+    """Stream-copy one file from ``src_fs`` to ``dst_path`` via atomic_rename.
+
+    Passes ``dst_fs`` into ``atomic_rename`` so the rename (server-side
+    ``CopyObject`` on S3) reuses the same S3 client + connection pool as
+    the upload, instead of fsspec instantiating a second default-kwargs
+    instance just for the rename.
+    """
+    total = 0
+    with atomic_rename(dst_path, fs=dst_fs) as temp_path:
+        with src_fs.open(src_path, "rb") as fin, dst_fs.open(temp_path, "wb") as fout:
+            while True:
+                chunk = fin.read(COPY_CHUNK_BYTES)
+                if not chunk:
+                    break
+                fout.write(chunk)
+                total += len(chunk)
+    return total
+
+
+def _copy_shard(
+    entries: list[tuple[str, str]],
+    *,
+    src_dir: str,
+    dst_dir: str,
+    copy_threads: int,
+) -> dict:
+    """Worker entry point — copy one shard's files in parallel.
+
+    ``entries`` is a list of ``(rel_path, fingerprint)`` pairs; the fingerprint
+    is folded into the shard hash that names the downstream JSONL output,
+    so a re-listed source with updated objects yields a different filename
+    and bypasses Zephyr's ``skip_existing`` short-circuit.
+
+    Files within a shard are streamed in parallel across ``copy_threads``
+    threads. Sharing one ``S3FileSystem``/``GCSFileSystem`` instance per side
+    is safe — fsspec funnels async ops onto a single dedicated event loop,
+    and synchronous APIs are reentrant.
+    """
+    src_fs, _ = fsspec.core.url_to_fs(src_dir)
+    # ``fixed_upload_size=True`` is required for Cloudflare R2's multipart
+    # PUT — and harmless on AWS S3, which also accepts uniform parts. It
+    # only matters for the write through ``dst_fs.open(..., "wb")``; the
+    # ``fs.mv`` inside atomic_rename is a single ``CopyObject`` and can
+    # use any S3 client config.
+    dst_kwargs = {"fixed_upload_size": True} if dst_dir.startswith("s3://") else {}
+    dst_fs, _ = fsspec.core.url_to_fs(dst_dir, **dst_kwargs)
+    src_base = src_dir.rstrip("/")
+    dst_base = dst_dir.rstrip("/")
+
+    bytes_copied = 0
+    with ThreadPoolExecutor(max_workers=copy_threads) as pool:
+        futures = [
+            pool.submit(_copy_one, src_fs, dst_fs, f"{src_base}/{rel}", f"{dst_base}/{rel}") for rel, _fp in entries
+        ]
+        # Surface the first failure immediately — a partial shard must NOT
+        # produce a JSONL output, since that's what marks the shard "done".
+        for fut in as_completed(futures):
+            bytes_copied += fut.result()
+
+    counters.increment("upload/shards_copied")
+    counters.increment("upload/files_copied", len(entries))
+    counters.increment("upload/bytes_copied", bytes_copied)
+    return {"shard_hash": _shard_hash(entries), "files": len(entries), "bytes": bytes_copied}
+
+
+# ----------------------------------------------------------------------
+# Source listing + sharding
+# ----------------------------------------------------------------------
+
+
+def _list_relative_files(src_dir: str) -> list[tuple[str, str]]:
+    """List ``src_dir`` recursively as ``(rel_path, fingerprint)`` pairs.
+
+    Pulls per-file metadata in the same listing call (``detail=True``) so the
+    shard hash can incorporate it without a second round trip. Includes files
+    whose names start with ``.`` or ``_`` — ``fs.find`` lists all leaf keys;
+    object stores have no concept of hidden files.
+    """
+    src_fs, _ = fsspec.core.url_to_fs(src_dir)
+    stripped_root = src_fs._strip_protocol(src_dir).rstrip("/")
+    entries: list[tuple[str, str]] = []
+    skipped_tmp = 0
+    for full, info in src_fs.find(src_dir, detail=True).items():
+        # ``find`` returns scheme-stripped keys (``bucket/key/...``).
+        if full == stripped_root:
+            continue
+        if not full.startswith(stripped_root + "/"):
+            raise RuntimeError(f"unexpected find result {full!r} under {stripped_root!r}")
+        rel = full[len(stripped_root) + 1 :]
+        if _ATOMIC_RENAME_TMP_RE.search(rel):
+            # Orphans from a prior interrupted sync: ``zephyr.writers.atomic_rename``
+            # writes ``<dst>.tmp.<uuid.hex>`` then ``fs.mv``s; if the worker is
+            # SIGKILLed between the two, the temp lingers. They're never
+            # legitimate datakit content — skip them so they don't propagate.
+            skipped_tmp += 1
+            continue
+        entries.append((rel, _object_fingerprint(info)))
+    if skipped_tmp:
+        logger.warning("Skipped %d atomic_rename temp leftover(s) under %s", skipped_tmp, src_dir)
+    entries.sort(key=lambda e: e[0])
+    return entries
+
+
+def _shard(items: list[tuple[str, str]], shard_size: int) -> list[list[tuple[str, str]]]:
+    return [items[i : i + shard_size] for i in range(0, len(items), shard_size)]
+
+
+def _upload_dir(
+    *,
+    src_dir: str,
+    dst_dir: str,
+    shard_prefix: str,
+    files_per_shard: int,
+    copy_threads: int,
+    job_name: str,
+) -> None:
+    """Drive the Zephyr pipeline that copies one source directory."""
+    rels = _list_relative_files(src_dir)
+    if not rels:
+        logger.warning("No files under %s — nothing to upload.", src_dir)
+        return
+    shards = _shard(rels, files_per_shard)
+    logger.info(
+        "Uploading %d files in %d shards (x%d copy threads/shard): %s -> %s",
+        len(rels),
+        len(shards),
+        copy_threads,
+        src_dir,
+        dst_dir,
+    )
+
+    # Each shard's JSONL output is named after its content hash, so
+    # ``skip_existing=True`` doubles as the resume marker: if the source
+    # files haven't changed the hash matches an existing key and Zephyr
+    # short-circuits the whole shard. If any source file's fingerprint
+    # changes, the hash changes and the shard re-runs.
+    shard_paths = [f"{shard_prefix.rstrip('/')}/{_shard_hash(shard)}.jsonl.gz" for shard in shards]
+
+    pipeline = (
+        Dataset.from_list(shards)
+        .map(
+            lambda shard: _copy_shard(
+                shard,
+                src_dir=src_dir,
+                dst_dir=dst_dir,
+                copy_threads=copy_threads,
+            )
+        )
+        .write_jsonl(lambda shard_idx, _total: shard_paths[shard_idx], skip_existing=True)
+    )
+    # Each shard fans out into ``copy_threads`` blocking I/O threads, so the
+    # worker needs at least that many cores' worth of headroom.
+    ctx = ZephyrContext(
+        name=job_name,
+        resources=ResourceConfig(cpu=max(2, copy_threads // 4), ram="4g"),
+    )
+    ctx.execute(pipeline)
+
+
+# ----------------------------------------------------------------------
+# Public factory: one StepSpec per source
+# ----------------------------------------------------------------------
+
+
+def sync_source_step(
+    source: DatakitSource,
+    *,
+    src_prefix: str,
+    dest_prefix: str,
+    files_per_shard: int = DEFAULT_FILES_PER_SHARD,
+    copy_threads: int = DEFAULT_COPY_THREADS_PER_SHARD,
+    status_prefix: str = DEFAULT_STATUS_PREFIX,
+) -> StepSpec:
+    """Build a StepSpec that copies ``source``'s raw downloads between two prefixes.
+
+    Leaf download paths are listed (canonically) against ``marin_prefix()``,
+    then re-anchored to both ``src_prefix`` and ``dest_prefix`` so the same
+    relative-under-prefix layout is preserved on either side. Pick the
+    direction by what you pass: ``src_prefix=gs://…`` + ``dest_prefix=s3://…``
+    pushes to R2, the swap pulls back.
+
+    Args:
+        source: The DatakitSource whose raw downloads we want to copy.
+        src_prefix: Source root to read from (e.g. ``gs://marin-us-central1``).
+        dest_prefix: Destination root to write to (e.g. ``s3://marin-na/marin``).
+        files_per_shard: Files per Zephyr shard (default 64). The shard
+            boundaries are deterministic; ``Dataset.from_list`` preserves
+            ordering so the same input set always produces the same shards.
+        copy_threads: Per-shard fan-out for parallel file copies (default 16).
+        status_prefix: Where per-shard JSONLs and the executor status marker
+            live (default ``gs://marin-us-central1/data/datakit/sync``). The
+            shard and step namespaces are further qualified by a hash of
+            ``(src_prefix, dest_prefix)`` so different directions never
+            share markers (their fingerprints aren't comparable anyway).
+
+    Returns:
+        A StepSpec that, when run, copies every leaf download of ``source``
+        from ``src_prefix`` to ``dest_prefix``.
+    """
+    canonical_prefix = marin_prefix()
+    canonical_leaves = sorted({leaf.output_path for leaf in _leaf_downloads(source.normalized)})
+    if not canonical_leaves:
+        raise ValueError(f"source {source.name!r} has no leaf downloads")
+    pairs = [
+        (
+            _rebase(leaf, canonical_prefix, src_prefix),
+            _rebase(leaf, canonical_prefix, dest_prefix),
+        )
+        for leaf in canonical_leaves
+    ]
+
+    safe = _safe_name(source.name)
+    status_root = status_prefix.rstrip("/")
+    # Encode the direction so to-R2 and from-R2 of the same source can't
+    # collide on shard markers or step status.
+    direction_key = format(deterministic_hash((src_prefix.rstrip("/"), dest_prefix.rstrip("/"))), "016x")
+
+    def _run(output_path: str) -> None:
+        del output_path  # the upload writes to ``dest_prefix``; status lives at status_prefix
+        for src, dst in pairs:
+            # Namespace the shard markers per src leaf so two leaves whose
+            # ``(rel_path, fingerprint)`` shards happen to collide can't
+            # cause the second leaf to be silently skipped by ``skip_existing``.
+            leaf_key = format(deterministic_hash(src), "016x")
+            _upload_dir(
+                src_dir=src,
+                dst_dir=dst,
+                shard_prefix=f"{status_root}/shards/{direction_key}/{safe}/{leaf_key}",
+                files_per_shard=files_per_shard,
+                copy_threads=copy_threads,
+                job_name=f"sync-{safe}",
+            )
+
+    return StepSpec(
+        name=f"sync/{safe}",
+        deps=list(_leaf_downloads(source.normalized)),
+        fn=_run,
+        # Step status sits next to the shard sentinels so a single
+        # bucket-lifecycle rule manages the whole sync prefix.
+        override_output_path=f"{status_root}/step_status/{direction_key}/{safe}",
+        hash_attrs={
+            "version": "v1",
+            "src_prefix": src_prefix.rstrip("/"),
+            "dest_prefix": dest_prefix.rstrip("/"),
+            "src_paths": canonical_leaves,
+        },
+    )
+
+
+# ----------------------------------------------------------------------
+# CLI driver
+# ----------------------------------------------------------------------
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--src-prefix",
+        default=None,
+        help="Source root to read from (e.g. 'gs://marin-us-central1'). Defaults to ``marin_prefix()``.",
+    )
+    parser.add_argument(
+        "--dest-prefix",
+        required=True,
+        help="Destination root to write to, e.g. 's3://marin-na/marin'.",
+    )
+    parser.add_argument(
+        "--source",
+        action="append",
+        default=None,
+        help="Source name to sync (repeatable). Default: all registered sources.",
+    )
+    parser.add_argument(
+        "--files-per-shard",
+        type=int,
+        default=DEFAULT_FILES_PER_SHARD,
+    )
+    parser.add_argument(
+        "--copy-threads",
+        type=int,
+        default=DEFAULT_COPY_THREADS_PER_SHARD,
+        help=f"Parallel per-shard copies (default {DEFAULT_COPY_THREADS_PER_SHARD}).",
+    )
+    parser.add_argument(
+        "--status-prefix",
+        default=DEFAULT_STATUS_PREFIX,
+        help=f"Where shard sentinels + step status live (default: {DEFAULT_STATUS_PREFIX!r}).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Build StepSpecs and list them, but don't run.",
+    )
+    return parser.parse_args()
+
+
+def _select_sources(names: list[str] | None) -> list[DatakitSource]:
+    all_src = all_sources()
+    if not names:
+        return list(all_src.values())
+    missing = [n for n in names if n not in all_src]
+    if missing:
+        raise SystemExit(f"unknown source(s): {', '.join(missing)}")
+    return [all_src[n] for n in names]
+
+
+def main() -> None:
+    args = _parse_args()
+    configure_logging()
+    # Boto's credential resolver and config provider log at INFO on every
+    # request; with ~5 S3 API calls per file x thousands of files, that's
+    # tens of thousands of log lines per shard. The information ("credentials
+    # in environment variables", "endpoint via environment_global") is the
+    # same on every call, so demote to WARNING.
+    for name in ("aiobotocore.credentials", "botocore.configprovider"):
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+    src_prefix = args.src_prefix or marin_prefix()
+    logger.info("Syncing %s -> %s", src_prefix, args.dest_prefix)
+
+    sources = _select_sources(args.source)
+    steps = [
+        sync_source_step(
+            src,
+            src_prefix=src_prefix,
+            dest_prefix=args.dest_prefix,
+            files_per_shard=args.files_per_shard,
+            copy_threads=args.copy_threads,
+            status_prefix=args.status_prefix,
+        )
+        for src in sources
+    ]
+
+    logger.info("Built %d sync StepSpec(s)", len(steps))
+    for s in steps:
+        logger.info("  %s -> %s", s.name, s.output_path)
+
+    if args.dry_run:
+        print(f"{len(steps)} sync StepSpec(s) built (dry run).")
+        return
+
+    StepRunner().run(steps)
+    print(f"Synced {len(steps)} source(s): {src_prefix} -> {args.dest_prefix}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* one StepSpec per `DatakitSource` whose Zephyr pipeline copies the source's raw downloads between two MARIN-shaped prefixes — typically GCS to R2 (`--src-prefix gs://marin-us-central1 --dest-prefix s3://marin-na/marin`), but the reverse works too
* `scripts/datakit/sync_datakit.py` exposes `sync_source_step(source, *, src_prefix, dest_prefix, files_per_shard=64, copy_threads=16, status_prefix=...)` and a CLI driver
* leaf paths are listed canonically against `marin_prefix()` and re-anchored to both `--src-prefix` and `--dest-prefix`, preserving the relative-under-prefix layout
* deterministic 64-file shards from sorted `fs.find(detail=True)`; shard hash via `zephyr.plan.deterministic_hash` over `(rel_path, fingerprint)` pairs where fingerprint = etag/size/mtime — any source-object rewrite changes the hash
* per-file copy fans out across 16 threads, streams `src_fs.open` → `dst_fs.open` of a `.tmp.<uuid>` key, publishes via `atomic_rename`
* dst s3 fs constructed with `fixed_upload_size=True` (R2's multipart requires uniform part sizes) and passed into `atomic_rename` so the rename reuses the same client + connection pool [^1]
* resume via `write_jsonl(skip_existing=True)` with a content-aware filename callable — Zephyr short-circuits any shard whose `<status_prefix>/shards/<direction>/<source>/<leaf>/<shard>.jsonl.gz` already exists, the JSONL itself IS the resume marker
* status & step namespaces qualified by `deterministic_hash((src_prefix, dest_prefix))` so to-R2 and from-R2 of the same source don't share markers (their fingerprints aren't comparable anyway — GCS ETag ≠ R2 ETag for the same bytes)
* `status_prefix` defaults to `gs://marin-us-central1/data/datakit/sync` — permanent, no TTL
* `zephyr.writers.atomic_rename` simplified to `temp_path + fs.mv` for all backends, dropping the S3 local-staging branch [^2]
  * adds optional `fs` kwarg so callers can reuse a pre-configured filesystem

[^1]: previously had two s3fs instances per process — one with `fixed_upload_size=True` for the upload, another with defaults for atomic_rename's internal `url_to_fs`.
[^2]: the old S3 branch local-staged to dodge R2's flaky server-side multipart copy, but the right fix lives on the s3fs client (`fixed_upload_size=True` constructor kwarg).