### PR TITLE
[iris] Offload large workdir files to blob store in launch_job

### DIFF
--- a/lib/iris/src/iris/cluster/bundle.py
+++ b/lib/iris/src/iris/cluster/bundle.py
@@ -30,6 +30,11 @@ def bundle_id_for_zip(blob: bytes) -> str:
     return hashlib.sha256(blob).hexdigest()
 
 
+def blob_id_for_bytes(data: bytes) -> str:
+    """Return canonical blob id (SHA-256 hex digest) for arbitrary bytes."""
+    return hashlib.sha256(data).hexdigest()
+
+
 class BundleStore:
     """Bundle store with fsspec persistence and in-memory LRU cache.
 
@@ -64,6 +69,9 @@ class BundleStore:
 
     def _bundle_fs_path(self, bundle_id: str) -> str:
         return f"{self._fs_path}/{bundle_id}.zip"
+
+    def _blob_fs_path(self, blob_id: str) -> str:
+        return f"{self._fs_path}/blobs/{blob_id}"
 
     def _exists_in_storage(self, bundle_id: str) -> bool:
         return self._fs.exists(self._bundle_fs_path(bundle_id))
@@ -154,6 +162,65 @@ class BundleStore:
             logger.info("Content %s not in local cache, fetching from controller", content_id)
             self._fetch_from_controller(content_id, url_path)
             return self.get_zip(content_id)
+
+    def write_blob(self, data: bytes) -> str:
+        """Store a blob by content hash, return blob_id."""
+        blob_id = blob_id_for_bytes(data)
+        with self._lock:
+            if blob_id in self._cache:
+                self._cache.move_to_end(blob_id)
+                return blob_id
+
+            blob_path = self._blob_fs_path(blob_id)
+            if not self._fs.exists(blob_path):
+                self._fs.mkdirs(f"{self._fs_path}/blobs", exist_ok=True)
+                with self._fs.open(blob_path, "wb") as f:
+                    f.write(data)
+            self._cache_put(blob_id, data)
+        return blob_id
+
+    def get_blob(self, blob_id: str) -> bytes:
+        """Retrieve a blob by ID. Cache, then fsspec, then controller HTTP fallback."""
+        with self._lock:
+            if blob_id in self._cache:
+                self._cache.move_to_end(blob_id)
+                return self._cache[blob_id]
+
+            blob_path = self._blob_fs_path(blob_id)
+            if self._fs.exists(blob_path):
+                with self._fs.open(blob_path, "rb") as f:
+                    data = f.read()
+                self._cache_put(blob_id, data)
+                return data
+
+        # Outside lock: fetch from controller, which calls write_blob to populate cache/storage.
+        self._fetch_blob_from_controller(blob_id)
+        return self.get_blob(blob_id)
+
+    def _fetch_blob_from_controller(self, blob_id: str) -> None:
+        """Fetch a blob from the controller HTTP endpoint and store it locally.
+
+        Retries up to 3 times with exponential backoff. Verifies the SHA-256
+        hash of the downloaded data matches ``blob_id``.
+        """
+        if not self._controller_address:
+            raise RuntimeError(f"Blob {blob_id} is not cached and controller address is not configured")
+
+        url = f"{self._controller_address}/blobs/{blob_id}"
+        for attempt in range(3):
+            try:
+                with urlopen(url, timeout=120) as resp:
+                    data = resp.read()
+                break
+            except Exception as e:
+                if attempt == 2:
+                    raise RuntimeError(f"Failed to fetch blob {blob_id}: {e}") from e
+                time.sleep(0.25 * (2**attempt))
+
+        actual = blob_id_for_bytes(data)
+        if actual != blob_id:
+            raise ValueError(f"Blob hash mismatch while fetching {blob_id}: got {actual}")
+        self.write_blob(data)
 
     def extract_bundle_to(self, bundle_id: str, dest: Path) -> None:
         """Extract a bundle zip into ``dest`` with zip-slip protection.

--- a/lib/iris/src/iris/cluster/bundle.py
+++ b/lib/iris/src/iris/cluster/bundle.py
@@ -1,11 +1,17 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Bundle ID utilities and a BundleStore with fsspec persistence and in-memory LRU cache.
+"""Content-addressed BundleStore with fsspec persistence and in-memory LRU cache.
 
-Bundles are stored as ``{storage_dir}/{bundle_id}.zip`` using fsspec (supporting
-local paths and GCS URIs). An in-memory LRU cache avoids repeated reads from
-storage. The cache is populated lazily — no startup scan is performed.
+Two namespaces share the same store and cache:
+
+* Bundles (zipped workdirs): ``{storage_dir}/{id}.zip``
+* Blobs (large workdir files): ``{storage_dir}/blobs/{id}``
+
+The in-memory cache is populated lazily and shared across both namespaces.
+``get_zip``/``get_blob`` check cache → fsspec storage → controller HTTP
+endpoint (when ``controller_address`` is set, i.e. on workers). Eviction
+from the in-memory cache does not delete from fsspec storage.
 """
 
 from __future__ import annotations
@@ -17,6 +23,7 @@ import threading
 import time
 import zipfile
 from collections import OrderedDict
+from collections.abc import Callable
 from pathlib import Path
 from urllib.request import urlopen
 
@@ -25,27 +32,12 @@ import fsspec.core
 logger = logging.getLogger(__name__)
 
 
-def bundle_id_for_zip(blob: bytes) -> str:
-    """Return canonical content id (SHA-256 hex digest) for bytes."""
-    return hashlib.sha256(blob).hexdigest()
-
-
-def blob_id_for_bytes(data: bytes) -> str:
-    """Return canonical blob id (SHA-256 hex digest) for arbitrary bytes."""
+def content_id(data: bytes) -> str:
+    """Canonical content id (SHA-256 hex digest) for arbitrary bytes."""
     return hashlib.sha256(data).hexdigest()
 
 
 class BundleStore:
-    """Bundle store with fsspec persistence and in-memory LRU cache.
-
-    Bundles are persisted as ``{storage_dir}/{bundle_id}.zip`` via fsspec, supporting
-    both local paths and remote URIs (e.g. ``gs://bucket/path/bundles``).
-
-    The in-memory cache is populated lazily: ``get_zip`` checks in-memory cache first,
-    then falls back to fsspec storage, then (on workers) fetches from the controller.
-    Eviction from the in-memory cache does NOT delete from fsspec storage.
-    """
-
     def __init__(
         self,
         storage_dir: str,
@@ -61,9 +53,9 @@ class BundleStore:
 
         self._fs, self._fs_path = fsspec.core.url_to_fs(storage_dir)
         self._fs.mkdirs(self._fs_path, exist_ok=True)
+        self._fs.mkdirs(f"{self._fs_path}/blobs", exist_ok=True)
 
-        # OrderedDict mapping bundle_id -> blob bytes, ordered by access time
-        # (most recently accessed at end).
+        # bundle_id/blob_id -> bytes, ordered by access (MRU at end).
         self._cache: OrderedDict[str, bytes] = OrderedDict()
         self._cache_bytes = 0
 
@@ -73,140 +65,59 @@ class BundleStore:
     def _blob_fs_path(self, blob_id: str) -> str:
         return f"{self._fs_path}/blobs/{blob_id}"
 
-    def _exists_in_storage(self, bundle_id: str) -> bool:
-        return self._fs.exists(self._bundle_fs_path(bundle_id))
-
-    def _read_from_storage(self, bundle_id: str) -> bytes:
-        with self._fs.open(self._bundle_fs_path(bundle_id), "rb") as f:
-            return f.read()
-
-    def _write_to_storage(self, bundle_id: str, blob: bytes) -> None:
-        with self._fs.open(self._bundle_fs_path(bundle_id), "wb") as f:
-            f.write(blob)
-
-    def _cache_put(self, bundle_id: str, blob: bytes) -> None:
+    def _cache_put(self, cid: str, data: bytes) -> None:
         """Insert into in-memory cache and evict if needed. Caller must hold _lock."""
-        if bundle_id in self._cache:
-            self._cache.move_to_end(bundle_id)
+        if cid in self._cache:
+            self._cache.move_to_end(cid)
             return
-        self._cache[bundle_id] = blob
-        self._cache_bytes += len(blob)
+        self._cache[cid] = data
+        self._cache_bytes += len(data)
         self._evict_if_needed_locked()
 
-    def write_zip(self, blob: bytes) -> str:
-        """Write zip bytes if absent and return canonical bundle id."""
-        bundle_id = bundle_id_for_zip(blob)
+    def _evict_if_needed_locked(self) -> None:
+        while (self._max_cache_items > 0 and len(self._cache) > self._max_cache_items) or (
+            self._max_cache_bytes > 0 and self._cache_bytes > self._max_cache_bytes
+        ):
+            _, evicted = self._cache.popitem(last=False)
+            self._cache_bytes -= len(evicted)
+
+    def _write_at(self, data: bytes, path: str) -> str:
+        cid = content_id(data)
         with self._lock:
-            if bundle_id in self._cache:
-                self._cache.move_to_end(bundle_id)
-                return bundle_id
+            if cid in self._cache:
+                self._cache.move_to_end(cid)
+                return cid
+            if not self._fs.exists(path):
+                with self._fs.open(path, "wb") as f:
+                    f.write(data)
+            self._cache_put(cid, data)
+        return cid
 
-            if not self._exists_in_storage(bundle_id):
-                self._write_to_storage(bundle_id, blob)
-            self._cache_put(bundle_id, blob)
-        return bundle_id
-
-    def get_zip(self, bundle_id: str) -> bytes:
-        """Read zip bytes by bundle id.
-
-        Checks in-memory cache, then fsspec storage. Raises FileNotFoundError
-        if the bundle is not found in either location.
-        """
+    def _read_at(self, cid: str, path: str, url_path: str, writer: Callable[[bytes], str]) -> bytes:
         with self._lock:
-            if bundle_id in self._cache:
-                self._cache.move_to_end(bundle_id)
-                return self._cache[bundle_id]
+            if cid in self._cache:
+                self._cache.move_to_end(cid)
+                return self._cache[cid]
+            if self._fs.exists(path):
+                with self._fs.open(path, "rb") as f:
+                    data = f.read()
+                self._cache_put(cid, data)
+                return data
+        # Outside lock: fetch from controller and route through the matching writer.
+        self._fetch_from_controller(cid, url_path, writer)
+        return self._read_at(cid, path, url_path, writer)
 
-            if not self._exists_in_storage(bundle_id):
-                raise FileNotFoundError(f"Bundle not found: {bundle_id}")
+    def _fetch_from_controller(self, cid: str, url_path: str, writer: Callable[[bytes], str]) -> None:
+        """Fetch content over HTTP, verify hash, and persist via ``writer``.
 
-            blob = self._read_from_storage(bundle_id)
-            self._cache_put(bundle_id, blob)
-            return blob
-
-    def _fetch_from_controller(self, content_id: str, url_path: str) -> None:
-        """Fetch content from the controller HTTP endpoint and store it locally.
-
-        Retries up to 3 times with exponential backoff. Verifies the SHA-256
-        hash of the downloaded bytes matches ``content_id``.
+        Retries up to 3 times with exponential backoff. ``writer`` must be
+        either ``write_zip`` or ``write_blob`` so the fetched bytes land in
+        the correct namespace.
         """
         if not self._controller_address:
-            raise FileNotFoundError(f"Content {content_id} not found and no controller configured")
+            raise FileNotFoundError(f"Content {cid} not found and no controller configured")
 
         url = f"{self._controller_address}/{url_path}"
-        for attempt in range(3):
-            try:
-                with urlopen(url, timeout=120) as resp:
-                    blob = resp.read()
-                break
-            except Exception as e:
-                if attempt == 2:
-                    raise RuntimeError(f"Failed to fetch {content_id}: {e}") from e
-                time.sleep(0.25 * (2**attempt))
-
-        actual = bundle_id_for_zip(blob)
-        if actual != content_id:
-            raise ValueError(f"Hash mismatch while fetching {content_id}: got {actual}")
-        self.write_zip(blob)
-
-    def get_or_fetch(self, content_id: str, url_path: str) -> bytes:
-        """Get content by ID, fetching from controller if not in local cache/storage.
-
-        Like ``get_zip`` but with automatic controller fallback. The ``url_path``
-        is the HTTP path suffix used to fetch from the controller (e.g.
-        ``bundles/{id}.zip`` or ``blobs/{id}``).
-        """
-        try:
-            return self.get_zip(content_id)
-        except FileNotFoundError:
-            logger.info("Content %s not in local cache, fetching from controller", content_id)
-            self._fetch_from_controller(content_id, url_path)
-            return self.get_zip(content_id)
-
-    def write_blob(self, data: bytes) -> str:
-        """Store a blob by content hash, return blob_id."""
-        blob_id = blob_id_for_bytes(data)
-        with self._lock:
-            if blob_id in self._cache:
-                self._cache.move_to_end(blob_id)
-                return blob_id
-
-            blob_path = self._blob_fs_path(blob_id)
-            if not self._fs.exists(blob_path):
-                self._fs.mkdirs(f"{self._fs_path}/blobs", exist_ok=True)
-                with self._fs.open(blob_path, "wb") as f:
-                    f.write(data)
-            self._cache_put(blob_id, data)
-        return blob_id
-
-    def get_blob(self, blob_id: str) -> bytes:
-        """Retrieve a blob by ID. Cache, then fsspec, then controller HTTP fallback."""
-        with self._lock:
-            if blob_id in self._cache:
-                self._cache.move_to_end(blob_id)
-                return self._cache[blob_id]
-
-            blob_path = self._blob_fs_path(blob_id)
-            if self._fs.exists(blob_path):
-                with self._fs.open(blob_path, "rb") as f:
-                    data = f.read()
-                self._cache_put(blob_id, data)
-                return data
-
-        # Outside lock: fetch from controller, which calls write_blob to populate cache/storage.
-        self._fetch_blob_from_controller(blob_id)
-        return self.get_blob(blob_id)
-
-    def _fetch_blob_from_controller(self, blob_id: str) -> None:
-        """Fetch a blob from the controller HTTP endpoint and store it locally.
-
-        Retries up to 3 times with exponential backoff. Verifies the SHA-256
-        hash of the downloaded data matches ``blob_id``.
-        """
-        if not self._controller_address:
-            raise RuntimeError(f"Blob {blob_id} is not cached and controller address is not configured")
-
-        url = f"{self._controller_address}/blobs/{blob_id}"
         for attempt in range(3):
             try:
                 with urlopen(url, timeout=120) as resp:
@@ -214,21 +125,33 @@ class BundleStore:
                 break
             except Exception as e:
                 if attempt == 2:
-                    raise RuntimeError(f"Failed to fetch blob {blob_id}: {e}") from e
+                    raise RuntimeError(f"Failed to fetch {cid}: {e}") from e
                 time.sleep(0.25 * (2**attempt))
 
-        actual = blob_id_for_bytes(data)
-        if actual != blob_id:
-            raise ValueError(f"Blob hash mismatch while fetching {blob_id}: got {actual}")
-        self.write_blob(data)
+        actual = content_id(data)
+        if actual != cid:
+            raise ValueError(f"Hash mismatch while fetching {cid}: got {actual}")
+        writer(data)
+
+    def write_zip(self, blob: bytes) -> str:
+        """Write zip bytes if absent and return canonical bundle id."""
+        return self._write_at(blob, self._bundle_fs_path(content_id(blob)))
+
+    def get_zip(self, bundle_id: str) -> bytes:
+        """Read zip bytes by bundle id. Falls back to controller on workers."""
+        return self._read_at(bundle_id, self._bundle_fs_path(bundle_id), f"bundles/{bundle_id}.zip", self.write_zip)
+
+    def write_blob(self, data: bytes) -> str:
+        """Write blob bytes if absent and return canonical blob id."""
+        return self._write_at(data, self._blob_fs_path(content_id(data)))
+
+    def get_blob(self, blob_id: str) -> bytes:
+        """Read blob bytes by id. Falls back to controller on workers."""
+        return self._read_at(blob_id, self._blob_fs_path(blob_id), f"blobs/{blob_id}", self.write_blob)
 
     def extract_bundle_to(self, bundle_id: str, dest: Path) -> None:
-        """Extract a bundle zip into ``dest`` with zip-slip protection.
-
-        If the bundle is not in the local cache/storage and a controller address is
-        configured, it is fetched on demand before extraction.
-        """
-        blob = self.get_or_fetch(bundle_id, f"bundles/{bundle_id}.zip")
+        """Extract a bundle zip into ``dest`` with zip-slip protection."""
+        blob = self.get_zip(bundle_id)
 
         dest.mkdir(parents=True, exist_ok=True)
         base = dest.resolve()
@@ -239,14 +162,6 @@ class BundleStore:
                 if not member_path.is_relative_to(base):
                     raise ValueError(f"Zip slip detected: {member} attempts to write outside extract path")
             zf.extractall(dest)
-
-    def _evict_if_needed_locked(self) -> None:
-        """Evict oldest entries from in-memory cache. Caller must hold _lock."""
-        while (self._max_cache_items > 0 and len(self._cache) > self._max_cache_items) or (
-            self._max_cache_bytes > 0 and self._cache_bytes > self._max_cache_bytes
-        ):
-            _bid, blob = self._cache.popitem(last=False)
-            self._cache_bytes -= len(blob)
 
     def close(self) -> None:
         pass

--- a/lib/iris/src/iris/cluster/bundle.py
+++ b/lib/iris/src/iris/cluster/bundle.py
@@ -3,15 +3,12 @@
 
 """Content-addressed BundleStore with fsspec persistence and in-memory LRU cache.
 
-Two namespaces share the same store and cache:
-
-* Bundles (zipped workdirs): ``{storage_dir}/{id}.zip``
-* Blobs (large workdir files): ``{storage_dir}/blobs/{id}``
-
-The in-memory cache is populated lazily and shared across both namespaces.
-``get_zip``/``get_blob`` check cache → fsspec storage → controller HTTP
-endpoint (when ``controller_address`` is set, i.e. on workers). Eviction
-from the in-memory cache does not delete from fsspec storage.
+A single content-addressed namespace serves both zipped workdirs and
+externalized workdir files. Disk layout: ``{storage_dir}/{id}``. The
+in-memory cache is populated lazily. ``get`` checks cache → fsspec
+storage → controller HTTP endpoint (when ``controller_address`` is set,
+i.e. on workers). Eviction from the in-memory cache does not delete from
+fsspec storage.
 """
 
 from __future__ import annotations
@@ -23,7 +20,6 @@ import threading
 import time
 import zipfile
 from collections import OrderedDict
-from collections.abc import Callable
 from pathlib import Path
 from urllib.request import urlopen
 
@@ -53,17 +49,13 @@ class BundleStore:
 
         self._fs, self._fs_path = fsspec.core.url_to_fs(storage_dir)
         self._fs.mkdirs(self._fs_path, exist_ok=True)
-        self._fs.mkdirs(f"{self._fs_path}/blobs", exist_ok=True)
 
-        # bundle_id/blob_id -> bytes, ordered by access (MRU at end).
+        # content id -> bytes, ordered by access (MRU at end).
         self._cache: OrderedDict[str, bytes] = OrderedDict()
         self._cache_bytes = 0
 
-    def _bundle_fs_path(self, bundle_id: str) -> str:
-        return f"{self._fs_path}/{bundle_id}.zip"
-
-    def _blob_fs_path(self, blob_id: str) -> str:
-        return f"{self._fs_path}/blobs/{blob_id}"
+    def _path_for(self, cid: str) -> str:
+        return f"{self._fs_path}/{cid}"
 
     def _cache_put(self, cid: str, data: bytes) -> None:
         """Insert into in-memory cache and evict if needed. Caller must hold _lock."""
@@ -81,19 +73,22 @@ class BundleStore:
             _, evicted = self._cache.popitem(last=False)
             self._cache_bytes -= len(evicted)
 
-    def _write_at(self, data: bytes, path: str) -> str:
+    def write(self, data: bytes) -> str:
+        """Write bytes if absent and return canonical content id."""
         cid = content_id(data)
+        path = self._path_for(cid)
         with self._lock:
-            if cid in self._cache:
-                self._cache.move_to_end(cid)
-                return cid
+            # Always ensure disk has the bytes: a cache hit without disk write
+            # would leave workers unable to fetch this id after a restart.
             if not self._fs.exists(path):
                 with self._fs.open(path, "wb") as f:
                     f.write(data)
             self._cache_put(cid, data)
         return cid
 
-    def _read_at(self, cid: str, path: str, url_path: str, writer: Callable[[bytes], str]) -> bytes:
+    def get(self, cid: str) -> bytes:
+        """Read bytes by content id. Falls back to controller on workers."""
+        path = self._path_for(cid)
         with self._lock:
             if cid in self._cache:
                 self._cache.move_to_end(cid)
@@ -103,21 +98,17 @@ class BundleStore:
                     data = f.read()
                 self._cache_put(cid, data)
                 return data
-        # Outside lock: fetch from controller and route through the matching writer.
-        self._fetch_from_controller(cid, url_path, writer)
-        return self._read_at(cid, path, url_path, writer)
+        # Outside lock: fetch from controller and persist locally.
+        data = self._fetch_from_controller(cid)
+        self.write(data)
+        return data
 
-    def _fetch_from_controller(self, cid: str, url_path: str, writer: Callable[[bytes], str]) -> None:
-        """Fetch content over HTTP, verify hash, and persist via ``writer``.
-
-        Retries up to 3 times with exponential backoff. ``writer`` must be
-        either ``write_zip`` or ``write_blob`` so the fetched bytes land in
-        the correct namespace.
-        """
+    def _fetch_from_controller(self, cid: str) -> bytes:
+        """Fetch content over HTTP and verify hash. Retries up to 3 times."""
         if not self._controller_address:
             raise FileNotFoundError(f"Content {cid} not found and no controller configured")
 
-        url = f"{self._controller_address}/{url_path}"
+        url = f"{self._controller_address}/blobs/{cid}"
         for attempt in range(3):
             try:
                 with urlopen(url, timeout=120) as resp:
@@ -131,27 +122,11 @@ class BundleStore:
         actual = content_id(data)
         if actual != cid:
             raise ValueError(f"Hash mismatch while fetching {cid}: got {actual}")
-        writer(data)
-
-    def write_zip(self, blob: bytes) -> str:
-        """Write zip bytes if absent and return canonical bundle id."""
-        return self._write_at(blob, self._bundle_fs_path(content_id(blob)))
-
-    def get_zip(self, bundle_id: str) -> bytes:
-        """Read zip bytes by bundle id. Falls back to controller on workers."""
-        return self._read_at(bundle_id, self._bundle_fs_path(bundle_id), f"bundles/{bundle_id}.zip", self.write_zip)
-
-    def write_blob(self, data: bytes) -> str:
-        """Write blob bytes if absent and return canonical blob id."""
-        return self._write_at(data, self._blob_fs_path(content_id(data)))
-
-    def get_blob(self, blob_id: str) -> bytes:
-        """Read blob bytes by id. Falls back to controller on workers."""
-        return self._read_at(blob_id, self._blob_fs_path(blob_id), f"blobs/{blob_id}", self.write_blob)
+        return data
 
     def extract_bundle_to(self, bundle_id: str, dest: Path) -> None:
         """Extract a bundle zip into ``dest`` with zip-slip protection."""
-        blob = self.get_zip(bundle_id)
+        blob = self.get(bundle_id)
 
         dest.mkdir(parents=True, exist_ok=True)
         base = dest.resolve()

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -110,6 +110,7 @@ class UserStats:
 
 # Maximum bundle size in bytes (25 MB) - matches client-side limit
 MAX_BUNDLE_SIZE_BYTES = 25 * 1024 * 1024
+WORKDIR_FILE_OFFLOAD_THRESHOLD = 100 * 1024  # 100KB — externalize large workdir files to blob store
 
 # Soft cap on how long launch_job waits for a replaced job's worker-bound
 # attempts to finalize before force-reaping them. Sized to exceed the worst-
@@ -1193,6 +1194,23 @@ class ControllerServiceImpl:
             new_request.CopyFrom(request)
             new_request.ClearField("bundle_blob")
             new_request.bundle_id = bundle_id
+            request = new_request
+
+        # Externalize large workdir files to the blob store so request_proto
+        # (and every RunTaskRequest dispatch) stays small.
+        large_files = {
+            name: data
+            for name, data in request.entrypoint.workdir_files.items()
+            if len(data) > WORKDIR_FILE_OFFLOAD_THRESHOLD
+        }
+        if large_files:
+            new_request = cluster_pb2.Controller.LaunchJobRequest()
+            new_request.CopyFrom(request)
+            for name, data in large_files.items():
+                blob_id = self._bundle_store.write_blob(data)
+                del new_request.entrypoint.workdir_files[name]
+                new_request.entrypoint.workdir_file_refs[name] = blob_id
+                logger.info("Externalized workdir file %s (%d bytes) as blob %s", name, len(data), blob_id[:12])
             request = new_request
 
         # Auto-inject device constraints from the resource spec.

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -972,7 +972,7 @@ class ControllerServiceImpl:
         return self._bundle_store.get_zip(bundle_id)
 
     def blob_data(self, blob_id: str) -> bytes:
-        return self._bundle_store.get_zip(blob_id)
+        return self._bundle_store.get_blob(blob_id)
 
     def _get_autoscaler_pending_hints(self) -> dict[str, PendingHint]:
         """Build autoscaler-based pending hints keyed by job id."""

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -110,7 +110,7 @@ class UserStats:
 
 # Maximum bundle size in bytes (25 MB) - matches client-side limit
 MAX_BUNDLE_SIZE_BYTES = 25 * 1024 * 1024
-WORKDIR_FILE_OFFLOAD_THRESHOLD = 100 * 1024  # 100KB — externalize large workdir files to blob store
+WORKDIR_FILE_OFFLOAD_THRESHOLD = 10 * 1024  # 10KB — externalize large workdir files to blob store
 
 # Soft cap on how long launch_job waits for a replaced job's worker-bound
 # attempts to finalize before force-reaping them. Sized to exceed the worst-

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -1204,7 +1204,7 @@ class ControllerServiceImpl:
             if len(data) > WORKDIR_FILE_OFFLOAD_THRESHOLD
         }
         if large_files:
-            new_request = cluster_pb2.Controller.LaunchJobRequest()
+            new_request = controller_pb2.Controller.LaunchJobRequest()
             new_request.CopyFrom(request)
             for name, data in large_files.items():
                 blob_id = self._bundle_store.write_blob(data)

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -970,10 +970,10 @@ class ControllerServiceImpl:
         self._profile_table = self._log_client.get_table(PROFILE_NAMESPACE, IrisProfile)
 
     def bundle_zip(self, bundle_id: str) -> bytes:
-        return self._bundle_store.get_zip(bundle_id)
+        return self._bundle_store.get(bundle_id)
 
     def blob_data(self, blob_id: str) -> bytes:
-        return self._bundle_store.get_blob(blob_id)
+        return self._bundle_store.get(blob_id)
 
     def _get_autoscaler_pending_hints(self) -> dict[str, PendingHint]:
         """Build autoscaler-based pending hints keyed by job id."""
@@ -1188,7 +1188,7 @@ class ControllerServiceImpl:
                     f"Bundle size {bundle_size_mb:.1f}MB exceeds maximum {max_size_mb:.0f}MB",
                 )
 
-            bundle_id = self._bundle_store.write_zip(request.bundle_blob)
+            bundle_id = self._bundle_store.write(request.bundle_blob)
 
             new_request = controller_pb2.Controller.LaunchJobRequest()
             new_request.CopyFrom(request)
@@ -1207,7 +1207,7 @@ class ControllerServiceImpl:
             new_request = controller_pb2.Controller.LaunchJobRequest()
             new_request.CopyFrom(request)
             for name, data in large_files.items():
-                blob_id = self._bundle_store.write_blob(data)
+                blob_id = self._bundle_store.write(data)
                 del new_request.entrypoint.workdir_files[name]
                 new_request.entrypoint.workdir_file_refs[name] = blob_id
                 logger.info("Externalized workdir file %s (%d bytes) as blob %s", name, len(data), blob_id[:12])

--- a/lib/iris/src/iris/cluster/providers/k8s/bundle_fetch.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/bundle_fetch.py
@@ -4,11 +4,13 @@
 """Standalone bundle fetch script for Kubernetes init containers.
 
 Downloads and extracts a bundle zip from the Iris controller, with
-retry logic and zip-slip protection. Uses only stdlib so the init
-container needs no extra dependencies.
+retry logic and zip-slip protection. Also fetches externalized workdir
+files (blob refs) from the controller's blob endpoint. Uses only stdlib
+so the init container needs no extra dependencies.
 """
 
 import hashlib
+import json
 import os
 import shutil
 import sys
@@ -55,6 +57,32 @@ def fetch_bundle(controller_url: str, bundle_id: str, workdir: str) -> None:
     os.remove(zip_path)
 
 
+def fetch_workdir_blob_refs(controller_url: str, blob_refs_json: str, workdir: str) -> None:
+    """Download externalized workdir files from the controller's blob endpoint."""
+    refs = json.loads(blob_refs_json)
+    for name, blob_id in refs.items():
+        url = f"{controller_url}/blobs/{blob_id}"
+        rel_path = os.path.normpath(name)
+        dst_path = os.path.join(workdir, rel_path)
+        os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+
+        for attempt in range(3):
+            try:
+                req = urllib.request.Request(url)
+                with urllib.request.urlopen(req, timeout=300) as resp:
+                    data = resp.read()
+                with open(dst_path, "wb") as f:
+                    f.write(data)
+                print(f"Fetched blob ref {name} ({len(data)} bytes) from {blob_id[:12]}")
+                break
+            except Exception as e:
+                if attempt == 2:
+                    raise
+                wait = 2**attempt
+                print(f"Blob fetch {name} attempt {attempt + 1} failed: {e}; retrying in {wait}s", file=sys.stderr)
+                time.sleep(wait)
+
+
 def copy_workdir_files(src_dir: str, workdir: str) -> None:
     """Copy staged workdir files from ConfigMap mount into workdir."""
     if not os.path.isdir(src_dir):
@@ -80,5 +108,9 @@ if __name__ == "__main__":
     src_dir = os.environ.get("IRIS_WORKDIR_FILES_SRC", "")
     if src_dir:
         copy_workdir_files(src_dir, workdir)
+
+    blob_refs_json = os.environ.get("IRIS_WORKDIR_BLOB_REFS", "")
+    if blob_refs_json and controller_url:
+        fetch_workdir_blob_refs(controller_url, blob_refs_json, workdir)
 
     print("Workdir staging complete.")

--- a/lib/iris/src/iris/cluster/providers/k8s/bundle_fetch.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/bundle_fetch.py
@@ -60,10 +60,14 @@ def fetch_bundle(controller_url: str, bundle_id: str, workdir: str) -> None:
 def fetch_workdir_blob_refs(controller_url: str, blob_refs_json: str, workdir: str) -> None:
     """Download externalized workdir files from the controller's blob endpoint."""
     refs = json.loads(blob_refs_json)
+    workdir_norm = os.path.normpath(workdir)
     for name, blob_id in refs.items():
         url = f"{controller_url}/blobs/{blob_id}"
-        rel_path = os.path.normpath(name)
-        dst_path = os.path.join(workdir, rel_path)
+        dst_path = os.path.normpath(os.path.join(workdir, name))
+        # Contain writes to workdir: reject ``../`` escapes and absolute keys
+        # that ``os.path.join`` would otherwise honor and drop ``workdir``.
+        if not dst_path.startswith(workdir_norm + os.sep) and dst_path != workdir_norm:
+            raise ValueError(f"Path traversal in workdir blob ref: {name}")
         os.makedirs(os.path.dirname(dst_path), exist_ok=True)
 
         for attempt in range(3):
@@ -71,6 +75,9 @@ def fetch_workdir_blob_refs(controller_url: str, blob_refs_json: str, workdir: s
                 req = urllib.request.Request(url)
                 with urllib.request.urlopen(req, timeout=300) as resp:
                     data = resp.read()
+                actual = hashlib.sha256(data).hexdigest()
+                if actual != blob_id:
+                    raise ValueError(f"Blob hash mismatch for {name}: expected {blob_id}, got {actual}")
                 with open(dst_path, "wb") as f:
                     f.write(data)
                 print(f"Fetched blob ref {name} ({len(data)} bytes) from {blob_id[:12]}")

--- a/lib/iris/src/iris/cluster/providers/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/tasks.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import base64
 import concurrent.futures
 import hashlib
+import json
 import logging
 import re
 import shlex
@@ -272,7 +273,9 @@ def _build_init_container_spec(
     """
     has_bundle = bool(run_req.bundle_id) and bool(controller_address)
     workdir_files = dict(run_req.entrypoint.workdir_files)
-    if not has_bundle and not workdir_files:
+    workdir_file_refs = dict(run_req.entrypoint.workdir_file_refs)
+    has_blob_refs = bool(workdir_file_refs) and bool(controller_address)
+    if not has_bundle and not workdir_files and not has_blob_refs:
         return [], [], None
 
     script_path = Path(__file__).parent / "bundle_fetch.py"
@@ -283,13 +286,14 @@ def _build_init_container_spec(
     extra_volumes: list[dict] = []
     configmap_name: str | None = None
 
+    if has_bundle or has_blob_refs:
+        init_env.append({"name": "IRIS_CONTROLLER_URL", "value": controller_address})
+
     if has_bundle:
-        init_env.extend(
-            [
-                {"name": "IRIS_BUNDLE_ID", "value": run_req.bundle_id},
-                {"name": "IRIS_CONTROLLER_URL", "value": controller_address},
-            ]
-        )
+        init_env.append({"name": "IRIS_BUNDLE_ID", "value": run_req.bundle_id})
+
+    if has_blob_refs:
+        init_env.append({"name": "IRIS_WORKDIR_BLOB_REFS", "value": json.dumps(workdir_file_refs)})
 
     if workdir_files:
         configmap_name = f"{pod_name}-wf"

--- a/lib/iris/src/iris/cluster/runtime/entrypoint.py
+++ b/lib/iris/src/iris/cluster/runtime/entrypoint.py
@@ -106,6 +106,8 @@ def build_runtime_entrypoint(
     rt.run_command.argv[:] = entrypoint.command
     for k, v in entrypoint.workdir_files.items():
         rt.workdir_files[k] = v
+    for k, v in entrypoint.workdir_file_refs.items():
+        rt.workdir_file_refs[k] = v
     return rt
 
 

--- a/lib/iris/src/iris/cluster/types.py
+++ b/lib/iris/src/iris/cluster/types.py
@@ -832,11 +832,13 @@ class Entrypoint:
         *,
         command: list[str],
         workdir_files: dict[str, bytes] | None = None,
+        workdir_file_refs: dict[str, str] | None = None,
     ):
         if not command:
             raise ValueError("Command must have at least one argument")
         self.command = command
         self.workdir_files: dict[str, bytes] = workdir_files or {}
+        self.workdir_file_refs: dict[str, str] = workdir_file_refs or {}
 
     def resolve(self) -> tuple[Callable[..., Any], tuple, dict[str, Any]]:
         """Deserialize the callable, args, kwargs from pickle bytes.
@@ -894,6 +896,8 @@ class Entrypoint:
         proto.run_command.argv[:] = self.command
         for name, data in self.workdir_files.items():
             proto.workdir_files[name] = data
+        for name, blob_id in self.workdir_file_refs.items():
+            proto.workdir_file_refs[name] = blob_id
         return proto
 
     @classmethod
@@ -901,4 +905,5 @@ class Entrypoint:
         """Create from protobuf representation."""
         command = list(proto.run_command.argv)
         workdir_files = dict(proto.workdir_files) if proto.workdir_files else None
-        return cls(command=command, workdir_files=workdir_files)
+        workdir_file_refs = dict(proto.workdir_file_refs) if proto.workdir_file_refs else None
+        return cls(command=command, workdir_files=workdir_files, workdir_file_refs=workdir_file_refs)

--- a/lib/iris/src/iris/cluster/worker/task_attempt.py
+++ b/lib/iris/src/iris/cluster/worker/task_attempt.py
@@ -681,7 +681,7 @@ class TaskAttempt:
         assert self.workdir is not None
         workdir_files = dict(self.request.entrypoint.workdir_files)
         for name, blob_id in self.request.entrypoint.workdir_file_refs.items():
-            workdir_files[name] = self._bundle_store.get_or_fetch(blob_id, f"blobs/{blob_id}")
+            workdir_files[name] = self._bundle_store.get_blob(blob_id)
         self._runtime.stage_bundle(
             bundle_id=self.request.bundle_id,
             workdir=self.workdir,

--- a/lib/iris/src/iris/cluster/worker/task_attempt.py
+++ b/lib/iris/src/iris/cluster/worker/task_attempt.py
@@ -681,7 +681,7 @@ class TaskAttempt:
         assert self.workdir is not None
         workdir_files = dict(self.request.entrypoint.workdir_files)
         for name, blob_id in self.request.entrypoint.workdir_file_refs.items():
-            workdir_files[name] = self._bundle_store.get_blob(blob_id)
+            workdir_files[name] = self._bundle_store.get(blob_id)
         self._runtime.stage_bundle(
             bundle_id=self.request.bundle_id,
             workdir=self.workdir,

--- a/lib/iris/tests/cluster/controller/test_bundle_store.py
+++ b/lib/iris/tests/cluster/controller/test_bundle_store.py
@@ -58,3 +58,72 @@ def test_get_or_fetch_missing_no_controller_raises_not_found(store):
     """get_or_fetch raises FileNotFoundError when content is absent and no controller is configured."""
     with pytest.raises(FileNotFoundError):
         store.get_or_fetch("b" * 64, "blobs/" + "b" * 64)
+
+
+def test_write_zip_skips_upload_when_already_in_storage(tmp_path):
+    """write_zip should not re-upload if bundle exists in storage but was evicted from cache."""
+    storage_dir = str(tmp_path / "bundles")
+    store = BundleStore(storage_dir=storage_dir, max_cache_items=1)
+
+    blob_a = b"bundle A"
+    blob_b = b"bundle B"
+    id_a = store.write_zip(blob_a)
+    store.write_zip(blob_b)  # evicts blob_a from in-memory cache
+
+    # blob_a should still be in storage; re-submitting should not call _write_to_storage
+    original_write = store._write_to_storage
+    write_calls = []
+
+    def tracking_write(bundle_id, blob):
+        write_calls.append(bundle_id)
+        return original_write(bundle_id, blob)
+
+    store._write_to_storage = tracking_write
+    id_a2 = store.write_zip(blob_a)
+    assert id_a2 == id_a
+    assert write_calls == [], "write_zip should not re-upload when bundle exists in storage"
+
+
+def test_write_blob_returns_content_hash(store):
+    data = b"large pickle payload"
+
+    blob_id = store.write_blob(data)
+    assert blob_id == hashlib.sha256(data).hexdigest()
+    assert store.get_blob(blob_id) == data
+
+
+def test_write_blob_is_idempotent(store):
+    data = b"same blob bytes"
+
+    id1 = store.write_blob(data)
+    id2 = store.write_blob(data)
+    assert id1 == id2
+
+
+def test_get_blob_missing_raises(store):
+    with pytest.raises(RuntimeError, match="not cached and controller address is not configured"):
+        store.get_blob("b" * 64)
+
+
+def test_blob_survives_restart(tmp_path):
+    storage_dir = str(tmp_path / "bundles")
+    store = BundleStore(storage_dir=storage_dir)
+    data = b"persist this blob"
+    blob_id = store.write_blob(data)
+    store.close()
+
+    store2 = BundleStore(storage_dir=storage_dir)
+    assert store2.get_blob(blob_id) == data
+
+
+def test_blob_and_bundle_namespaces_independent(store):
+    """Blobs and bundles with identical content get separate storage paths."""
+    data = b"shared content"
+
+    bundle_id = store.write_zip(data)
+    blob_id = store.write_blob(data)
+    # Same hash since content is identical
+    assert bundle_id == blob_id
+    # Both retrievable via their respective methods
+    assert store.get_zip(bundle_id) == data
+    assert store.get_blob(blob_id) == data

--- a/lib/iris/tests/cluster/controller/test_bundle_store.py
+++ b/lib/iris/tests/cluster/controller/test_bundle_store.py
@@ -38,7 +38,7 @@ def test_get_zip_reads_stored_bytes(store):
 
 
 def test_get_zip_missing_raises_not_found(store):
-    with pytest.raises(FileNotFoundError, match="Bundle not found"):
+    with pytest.raises(FileNotFoundError, match="not found and no controller configured"):
         store.get_zip("a" * 64)
 
 
@@ -54,12 +54,6 @@ def test_store_survives_restart(tmp_path):
     assert store2.get_zip(bundle_id) == blob
 
 
-def test_get_or_fetch_missing_no_controller_raises_not_found(store):
-    """get_or_fetch raises FileNotFoundError when content is absent and no controller is configured."""
-    with pytest.raises(FileNotFoundError):
-        store.get_or_fetch("b" * 64, "blobs/" + "b" * 64)
-
-
 def test_write_zip_skips_upload_when_already_in_storage(tmp_path):
     """write_zip should not re-upload if bundle exists in storage but was evicted from cache."""
     storage_dir = str(tmp_path / "bundles")
@@ -70,18 +64,19 @@ def test_write_zip_skips_upload_when_already_in_storage(tmp_path):
     id_a = store.write_zip(blob_a)
     store.write_zip(blob_b)  # evicts blob_a from in-memory cache
 
-    # blob_a should still be in storage; re-submitting should not call _write_to_storage
-    original_write = store._write_to_storage
-    write_calls = []
+    # blob_a should still be in storage; re-submitting should not re-open the file for write.
+    original_open = store._fs.open
+    write_paths: list[str] = []
 
-    def tracking_write(bundle_id, blob):
-        write_calls.append(bundle_id)
-        return original_write(bundle_id, blob)
+    def tracking_open(path, mode="rb", *args, **kwargs):
+        if "w" in mode:
+            write_paths.append(path)
+        return original_open(path, mode, *args, **kwargs)
 
-    store._write_to_storage = tracking_write
+    store._fs.open = tracking_open
     id_a2 = store.write_zip(blob_a)
     assert id_a2 == id_a
-    assert write_calls == [], "write_zip should not re-upload when bundle exists in storage"
+    assert write_paths == [], "write_zip should not re-upload when bundle exists in storage"
 
 
 def test_write_blob_returns_content_hash(store):
@@ -101,7 +96,7 @@ def test_write_blob_is_idempotent(store):
 
 
 def test_get_blob_missing_raises(store):
-    with pytest.raises(RuntimeError, match="not cached and controller address is not configured"):
+    with pytest.raises(FileNotFoundError, match="not found and no controller configured"):
         store.get_blob("b" * 64)
 
 

--- a/lib/iris/tests/cluster/controller/test_bundle_store.py
+++ b/lib/iris/tests/cluster/controller/test_bundle_store.py
@@ -14,32 +14,32 @@ def store(tmp_path):
     return BundleStore(storage_dir=str(tmp_path / "bundles"))
 
 
-def test_write_zip_returns_content_hash_id(store):
+def test_write_returns_content_hash_id(store):
     blob = b"test bundle content"
 
-    bundle_id = store.write_zip(blob)
+    bundle_id = store.write(blob)
     assert bundle_id == hashlib.sha256(blob).hexdigest()
-    assert store.get_zip(bundle_id) == blob
+    assert store.get(bundle_id) == blob
 
 
-def test_write_zip_is_idempotent(store):
+def test_write_is_idempotent(store):
     blob = b"same bytes"
 
-    id1 = store.write_zip(blob)
-    id2 = store.write_zip(blob)
+    id1 = store.write(blob)
+    id2 = store.write(blob)
     assert id1 == id2
 
 
-def test_get_zip_reads_stored_bytes(store):
+def test_get_reads_stored_bytes(store):
     blob = b"bundle data"
 
-    bundle_id = store.write_zip(blob)
-    assert store.get_zip(bundle_id) == blob
+    bundle_id = store.write(blob)
+    assert store.get(bundle_id) == blob
 
 
-def test_get_zip_missing_raises_not_found(store):
+def test_get_missing_raises_not_found(store):
     with pytest.raises(FileNotFoundError, match="not found and no controller configured"):
-        store.get_zip("a" * 64)
+        store.get("a" * 64)
 
 
 def test_store_survives_restart(tmp_path):
@@ -47,24 +47,23 @@ def test_store_survives_restart(tmp_path):
     storage_dir = str(tmp_path / "bundles")
     store = BundleStore(storage_dir=storage_dir)
     blob = b"persist me"
-    bundle_id = store.write_zip(blob)
+    bundle_id = store.write(blob)
     store.close()
 
     store2 = BundleStore(storage_dir=storage_dir)
-    assert store2.get_zip(bundle_id) == blob
+    assert store2.get(bundle_id) == blob
 
 
-def test_write_zip_skips_upload_when_already_in_storage(tmp_path):
-    """write_zip should not re-upload if bundle exists in storage but was evicted from cache."""
+def test_write_skips_upload_when_already_in_storage(tmp_path):
+    """write should not re-upload if content exists in storage but was evicted from cache."""
     storage_dir = str(tmp_path / "bundles")
     store = BundleStore(storage_dir=storage_dir, max_cache_items=1)
 
     blob_a = b"bundle A"
     blob_b = b"bundle B"
-    id_a = store.write_zip(blob_a)
-    store.write_zip(blob_b)  # evicts blob_a from in-memory cache
+    id_a = store.write(blob_a)
+    store.write(blob_b)  # evicts blob_a from in-memory cache
 
-    # blob_a should still be in storage; re-submitting should not re-open the file for write.
     original_open = store._fs.open
     write_paths: list[str] = []
 
@@ -74,51 +73,41 @@ def test_write_zip_skips_upload_when_already_in_storage(tmp_path):
         return original_open(path, mode, *args, **kwargs)
 
     store._fs.open = tracking_open
-    id_a2 = store.write_zip(blob_a)
+    id_a2 = store.write(blob_a)
     assert id_a2 == id_a
-    assert write_paths == [], "write_zip should not re-upload when bundle exists in storage"
+    assert write_paths == [], "write should not re-upload when content exists in storage"
 
 
-def test_write_blob_returns_content_hash(store):
-    data = b"large pickle payload"
-
-    blob_id = store.write_blob(data)
-    assert blob_id == hashlib.sha256(data).hexdigest()
-    assert store.get_blob(blob_id) == data
-
-
-def test_write_blob_is_idempotent(store):
-    data = b"same blob bytes"
-
-    id1 = store.write_blob(data)
-    id2 = store.write_blob(data)
-    assert id1 == id2
-
-
-def test_get_blob_missing_raises(store):
-    with pytest.raises(FileNotFoundError, match="not found and no controller configured"):
-        store.get_blob("b" * 64)
-
-
-def test_blob_survives_restart(tmp_path):
-    storage_dir = str(tmp_path / "bundles")
-    store = BundleStore(storage_dir=storage_dir)
-    data = b"persist this blob"
-    blob_id = store.write_blob(data)
-    store.close()
-
-    store2 = BundleStore(storage_dir=storage_dir)
-    assert store2.get_blob(blob_id) == data
-
-
-def test_blob_and_bundle_namespaces_independent(store):
-    """Blobs and bundles with identical content get separate storage paths."""
+def test_bundle_and_blob_share_storage(store):
+    """Identical bytes written via any path share one disk entry and id."""
     data = b"shared content"
 
-    bundle_id = store.write_zip(data)
-    blob_id = store.write_blob(data)
-    # Same hash since content is identical
-    assert bundle_id == blob_id
-    # Both retrievable via their respective methods
-    assert store.get_zip(bundle_id) == data
-    assert store.get_blob(blob_id) == data
+    id_first = store.write(data)
+    id_second = store.write(data)
+    assert id_first == id_second
+    assert store.get(id_first) == data
+
+
+def test_cache_hit_does_not_skip_disk_write(tmp_path):
+    """A second write of identical bytes must still ensure disk persistence
+    even when the in-memory cache already has the entry — otherwise the
+    content would be unreachable after controller restart or eviction.
+    """
+    storage_dir = str(tmp_path / "bundles")
+    store = BundleStore(storage_dir=storage_dir)
+    data = b"cached but maybe undisked"
+
+    cid = store.write(data)
+
+    # Simulate eviction by deleting the file under the cache.
+    path = store._path_for(cid)
+    store._fs.rm(path)
+    assert not store._fs.exists(path)
+
+    # Re-write should detect the missing file and restore it.
+    store.write(data)
+    assert store._fs.exists(path)
+
+    # Fresh store (cold cache) should still load from disk.
+    store2 = BundleStore(storage_dir=storage_dir)
+    assert store2.get(cid) == data

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -216,6 +216,35 @@ def test_launch_job_accepts_same_shape_alternatives(service):
     assert response.job_id == JobName.root("test-user", "matched-tpu-variants").to_wire()
 
 
+def test_launch_job_externalizes_large_workdir_files(service, state):
+    request = make_job_request("big-pickle-job")
+    small_file = b"tiny"
+    large_file = b"x" * (200 * 1024)  # 200KB, above 100KB threshold
+    request.entrypoint.workdir_files["small.txt"] = small_file
+    request.entrypoint.workdir_files["_callable.pkl"] = large_file
+    service.launch_job(request, None)
+
+    job = _query_job(state, JobName.root("test-user", "big-pickle-job"))
+    assert job is not None
+    # Small file stays inline
+    assert job.request.entrypoint.workdir_files["small.txt"] == small_file
+    # Large file externalized to blob ref
+    assert "_callable.pkl" not in job.request.entrypoint.workdir_files
+    assert len(job.request.entrypoint.workdir_file_refs["_callable.pkl"]) == 64
+
+
+def test_launch_job_keeps_small_workdir_files_inline(service, state):
+    request = make_job_request("small-pickle-job")
+    small_file = b"x" * 1024  # 1KB
+    request.entrypoint.workdir_files["_callable.pkl"] = small_file
+    service.launch_job(request, None)
+
+    job = _query_job(state, JobName.root("test-user", "small-pickle-job"))
+    assert job is not None
+    assert job.request.entrypoint.workdir_files["_callable.pkl"] == small_file
+    assert "_callable.pkl" not in job.request.entrypoint.workdir_file_refs
+
+
 def test_launch_job_rejects_duplicate_name(service):
     """Verify launch_job rejects duplicate job names for running jobs."""
     request = make_job_request("duplicate-job")

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -219,18 +219,19 @@ def test_launch_job_accepts_same_shape_alternatives(service):
 def test_launch_job_externalizes_large_workdir_files(service, state):
     request = make_job_request("big-pickle-job")
     small_file = b"tiny"
-    large_file = b"x" * (200 * 1024)  # 200KB, above 100KB threshold
+    large_file = b"x" * (32 * 1024)  # 32KB, above 10KB threshold
     request.entrypoint.workdir_files["small.txt"] = small_file
     request.entrypoint.workdir_files["_callable.pkl"] = large_file
     service.launch_job(request, None)
 
-    job = _query_job(state, JobName.root("test-user", "big-pickle-job"))
-    assert job is not None
+    job_id = JobName.root("test-user", "big-pickle-job")
+    with state._db.read_snapshot() as snap:
+        template = state.run_request_template(snap, job_id)
+    assert template is not None
     # Small file stays inline
-    assert job.request.entrypoint.workdir_files["small.txt"] == small_file
-    # Large file externalized to blob ref
-    assert "_callable.pkl" not in job.request.entrypoint.workdir_files
-    assert len(job.request.entrypoint.workdir_file_refs["_callable.pkl"]) == 64
+    assert dict(template.entrypoint.workdir_files) == {"small.txt": small_file}
+    # Large file externalized to a 64-char SHA-256 blob ref
+    assert len(template.entrypoint.workdir_file_refs["_callable.pkl"]) == 64
 
 
 def test_launch_job_keeps_small_workdir_files_inline(service, state):
@@ -239,10 +240,12 @@ def test_launch_job_keeps_small_workdir_files_inline(service, state):
     request.entrypoint.workdir_files["_callable.pkl"] = small_file
     service.launch_job(request, None)
 
-    job = _query_job(state, JobName.root("test-user", "small-pickle-job"))
-    assert job is not None
-    assert job.request.entrypoint.workdir_files["_callable.pkl"] == small_file
-    assert "_callable.pkl" not in job.request.entrypoint.workdir_file_refs
+    job_id = JobName.root("test-user", "small-pickle-job")
+    with state._db.read_snapshot() as snap:
+        template = state.run_request_template(snap, job_id)
+    assert template is not None
+    assert dict(template.entrypoint.workdir_files) == {"_callable.pkl": small_file}
+    assert "_callable.pkl" not in template.entrypoint.workdir_file_refs
 
 
 def test_launch_job_rejects_duplicate_name(service):

--- a/lib/iris/tests/cluster/providers/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_pod_manifest.py
@@ -793,6 +793,68 @@ def test_init_container_bundle_and_workdir_files():
     assert len(extra_volumes) == 1
 
 
+def test_init_container_for_workdir_file_refs():
+    """Blob refs produce an init container with IRIS_WORKDIR_BLOB_REFS env var."""
+    req = make_run_req("/my-job/task-0")
+    req.entrypoint.workdir_file_refs["_callable.pkl"] = "abcd1234" * 8
+
+    init_containers, _extra_volumes, configmap_name = _build_init_container_spec(
+        req,
+        "iris-pod-name",
+        "myrepo/iris:latest",
+        "http://ctrl:8080",
+    )
+
+    assert len(init_containers) == 1
+    ic = init_containers[0]
+    env_by_name = {e["name"]: e["value"] for e in ic["env"]}
+    assert env_by_name["IRIS_CONTROLLER_URL"] == "http://ctrl:8080"
+    assert "IRIS_WORKDIR_BLOB_REFS" in env_by_name
+
+    import json
+
+    refs = json.loads(env_by_name["IRIS_WORKDIR_BLOB_REFS"])
+    assert refs == {"_callable.pkl": "abcd1234" * 8}
+    assert configmap_name is None
+
+
+def test_no_init_container_for_blob_refs_without_controller():
+    """Blob refs without controller_address are ignored (no way to fetch)."""
+    req = make_run_req("/my-job/task-0")
+    req.entrypoint.workdir_file_refs["_callable.pkl"] = "abcd1234" * 8
+
+    init_containers, _extra_volumes, configmap_name = _build_init_container_spec(
+        req,
+        "iris-pod-name",
+        "myrepo/iris:latest",
+        None,
+    )
+
+    assert init_containers == []
+    assert configmap_name is None
+
+
+def test_init_container_workdir_files_and_blob_refs():
+    """Both inline files and blob refs produce ConfigMap + blob ref env var."""
+    req = make_run_req("/my-job/task-0")
+    req.entrypoint.workdir_files["small.txt"] = b"tiny"
+    req.entrypoint.workdir_file_refs["big.pkl"] = "deadbeef" * 8
+
+    init_containers, _extra_volumes, configmap_name = _build_init_container_spec(
+        req,
+        "iris-pod-name",
+        "myrepo/iris:latest",
+        "http://ctrl:8080",
+    )
+
+    assert len(init_containers) == 1
+    ic = init_containers[0]
+    env_by_name = {e["name"]: e["value"] for e in ic["env"]}
+    assert "IRIS_WORKDIR_FILES_SRC" in env_by_name
+    assert "IRIS_WORKDIR_BLOB_REFS" in env_by_name
+    assert configmap_name is not None
+
+
 # ---------------------------------------------------------------------------
 # Coordinator detection and PDB manifest
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/runtime/test_entrypoint.py
+++ b/lib/iris/tests/cluster/runtime/test_entrypoint.py
@@ -85,6 +85,16 @@ def test_runtime_entrypoint_to_bash_script_structure():
     assert "exec python train.py --lr 0.001" in script
 
 
+def test_build_runtime_entrypoint_propagates_workdir_file_refs():
+    refs = {"_callable.pkl": "sha256abc", "weights.bin": "sha256def"}
+    ep = Entrypoint(command=["python", "run.py"], workdir_files={"small.txt": b"hi"}, workdir_file_refs=refs)
+    env = _make_env_config()
+    rt = build_runtime_entrypoint(ep, env)
+
+    assert dict(rt.workdir_files) == {"small.txt": b"hi"}
+    assert dict(rt.workdir_file_refs) == refs
+
+
 @pytest.mark.parametrize(
     "extras,expected_fragments",
     [

--- a/lib/iris/tests/cluster/test_types.py
+++ b/lib/iris/tests/cluster/test_types.py
@@ -49,6 +49,19 @@ def test_entrypoint_proto_roundtrip_preserves_bytes():
     assert fn(*args, **kwargs) == 3
 
 
+def test_entrypoint_proto_roundtrip_preserves_workdir_file_refs():
+    """workdir_file_refs survive to_proto -> from_proto."""
+    refs = {"_callable.pkl": "abc123", "model.bin": "def456"}
+    ep = Entrypoint(command=["python", "run.py"], workdir_files={"small.txt": b"hi"}, workdir_file_refs=refs)
+
+    proto = ep.to_proto()
+    ep2 = Entrypoint.from_proto(proto)
+
+    assert ep2.workdir_file_refs == refs
+    assert ep2.workdir_files == {"small.txt": b"hi"}
+    assert ep2.command == ["python", "run.py"]
+
+
 def test_entrypoint_command():
     ep = Entrypoint.from_command("echo", "hello")
     assert not ep.workdir_files

--- a/lib/iris/tests/cluster/worker/test_bundle_store.py
+++ b/lib/iris/tests/cluster/worker/test_bundle_store.py
@@ -48,7 +48,7 @@ def test_extract_bundle_fetches_on_demand(monkeypatch, store, tmp_path):
     bundle_id = hashlib.sha256(bundle_zip).hexdigest()
 
     def fake_urlopen(url: str, timeout: int):
-        assert url == f"http://controller.internal/bundles/{bundle_id}.zip"
+        assert url == f"http://controller.internal/blobs/{bundle_id}"
         return _FakeResponse(bundle_zip)
 
     monkeypatch.setattr("iris.cluster.bundle.urlopen", fake_urlopen)
@@ -62,7 +62,7 @@ def test_extract_bundle_fetches_on_demand(monkeypatch, store, tmp_path):
 def test_extract_bundle_uses_cache_on_hit(store, tmp_path):
     """extract_bundle_to should use local cache without hitting the network."""
     bundle_zip = _make_zip({"cached.txt": b"cached data"})
-    bundle_id = store.write_zip(bundle_zip)
+    bundle_id = store.write(bundle_zip)
 
     extract_dir = tmp_path / "extract"
     store.extract_bundle_to(bundle_id, extract_dir)
@@ -74,7 +74,7 @@ def test_extract_bundle_hash_verification_failure(monkeypatch, store, tmp_path):
     wrong_id = "a" * 64
 
     def fake_urlopen(url: str, timeout: int):
-        assert url == f"http://controller.internal/bundles/{wrong_id}.zip"
+        assert url == f"http://controller.internal/blobs/{wrong_id}"
         return _FakeResponse(bad_zip)
 
     monkeypatch.setattr("iris.cluster.bundle.urlopen", fake_urlopen)
@@ -88,17 +88,16 @@ def test_lru_eviction_by_item_count(store):
         bundle_zip = _make_zip({"test.txt": f"bundle {i}".encode()})
         bundle_id = hashlib.sha256(bundle_zip).hexdigest()
         bundles.append((bundle_id, bundle_zip))
-        store.write_zip(bundle_zip)
+        store.write(bundle_zip)
 
-    # Evicted from in-memory cache, but still in fsspec storage
-    # so get_zip should still find it
-    assert store.get_zip(bundles[0][0]) == bundles[0][1]
-    assert store.get_zip(bundles[1][0]) == bundles[1][1]
-    assert store.get_zip(bundles[2][0]) == bundles[2][1]
+    # Evicted from in-memory cache, but still in fsspec storage so get should still find it.
+    assert store.get(bundles[0][0]) == bundles[0][1]
+    assert store.get(bundles[1][0]) == bundles[1][1]
+    assert store.get(bundles[2][0]) == bundles[2][1]
 
 
-def test_get_blob_fetches_on_demand(monkeypatch, store):
-    """get_blob should fetch from controller on cache miss."""
+def test_get_fetches_on_demand(monkeypatch, store):
+    """get should fetch from controller on cache miss."""
     data = b"large pickle data"
     blob_id = hashlib.sha256(data).hexdigest()
 
@@ -108,19 +107,19 @@ def test_get_blob_fetches_on_demand(monkeypatch, store):
 
     monkeypatch.setattr("iris.cluster.bundle.urlopen", fake_urlopen)
 
-    result = store.get_blob(blob_id)
+    result = store.get(blob_id)
     assert result == data
 
 
-def test_get_blob_uses_cache_on_hit(store):
-    """get_blob should return cached data without hitting the network."""
+def test_get_uses_cache_on_hit(store):
+    """get should return cached data without hitting the network."""
     data = b"cached blob"
-    store.write_blob(data)
+    store.write(data)
     blob_id = hashlib.sha256(data).hexdigest()
-    assert store.get_blob(blob_id) == data
+    assert store.get(blob_id) == data
 
 
-def test_get_blob_hash_verification_failure(monkeypatch, store):
+def test_get_hash_verification_failure(monkeypatch, store):
     bad_data = b"wrong content"
     wrong_id = "c" * 64
 
@@ -130,4 +129,4 @@ def test_get_blob_hash_verification_failure(monkeypatch, store):
 
     monkeypatch.setattr("iris.cluster.bundle.urlopen", fake_urlopen)
     with pytest.raises(ValueError, match="Hash mismatch"):
-        store.get_blob(wrong_id)
+        store.get(wrong_id)

--- a/lib/iris/tests/cluster/worker/test_bundle_store.py
+++ b/lib/iris/tests/cluster/worker/test_bundle_store.py
@@ -97,41 +97,6 @@ def test_lru_eviction_by_item_count(store):
     assert store.get_zip(bundles[2][0]) == bundles[2][1]
 
 
-def test_get_or_fetch_fetches_blob_on_demand(monkeypatch, store):
-    """get_or_fetch should fetch from controller on cache miss using the provided URL path."""
-    data = b"large pickle data"
-    content_id = hashlib.sha256(data).hexdigest()
-
-    def fake_urlopen(url: str, timeout: int):
-        assert url == f"http://controller.internal/blobs/{content_id}"
-        return _FakeResponse(data)
-
-    monkeypatch.setattr("iris.cluster.bundle.urlopen", fake_urlopen)
-
-    result = store.get_or_fetch(content_id, f"blobs/{content_id}")
-    assert result == data
-
-
-def test_get_or_fetch_uses_cache_on_hit(store):
-    """get_or_fetch should return cached data without hitting the network."""
-    data = b"cached blob"
-    content_id = store.write_zip(data)
-    assert store.get_or_fetch(content_id, f"blobs/{content_id}") == data
-
-
-def test_get_or_fetch_hash_verification_failure(monkeypatch, store):
-    bad_data = b"wrong content"
-    wrong_id = "c" * 64
-
-    def fake_urlopen(url: str, timeout: int):
-        assert url == f"http://controller.internal/blobs/{wrong_id}"
-        return _FakeResponse(bad_data)
-
-    monkeypatch.setattr("iris.cluster.bundle.urlopen", fake_urlopen)
-    with pytest.raises(ValueError, match="Hash mismatch"):
-        store.get_or_fetch(wrong_id, f"blobs/{wrong_id}")
-
-
 def test_get_blob_fetches_on_demand(monkeypatch, store):
     """get_blob should fetch from controller on cache miss."""
     data = b"large pickle data"
@@ -164,5 +129,5 @@ def test_get_blob_hash_verification_failure(monkeypatch, store):
         return _FakeResponse(bad_data)
 
     monkeypatch.setattr("iris.cluster.bundle.urlopen", fake_urlopen)
-    with pytest.raises(ValueError, match="Blob hash mismatch"):
+    with pytest.raises(ValueError, match="Hash mismatch"):
         store.get_blob(wrong_id)

--- a/lib/iris/tests/cluster/worker/test_bundle_store.py
+++ b/lib/iris/tests/cluster/worker/test_bundle_store.py
@@ -97,7 +97,6 @@ def test_lru_eviction_by_item_count(store):
     assert store.get_zip(bundles[2][0]) == bundles[2][1]
 
 
-
 def test_get_or_fetch_fetches_blob_on_demand(monkeypatch, store):
     """get_or_fetch should fetch from controller on cache miss using the provided URL path."""
     data = b"large pickle data"

--- a/lib/iris/tests/cluster/worker/test_bundle_store.py
+++ b/lib/iris/tests/cluster/worker/test_bundle_store.py
@@ -97,6 +97,7 @@ def test_lru_eviction_by_item_count(store):
     assert store.get_zip(bundles[2][0]) == bundles[2][1]
 
 
+
 def test_get_or_fetch_fetches_blob_on_demand(monkeypatch, store):
     """get_or_fetch should fetch from controller on cache miss using the provided URL path."""
     data = b"large pickle data"
@@ -130,3 +131,39 @@ def test_get_or_fetch_hash_verification_failure(monkeypatch, store):
     monkeypatch.setattr("iris.cluster.bundle.urlopen", fake_urlopen)
     with pytest.raises(ValueError, match="Hash mismatch"):
         store.get_or_fetch(wrong_id, f"blobs/{wrong_id}")
+
+
+def test_get_blob_fetches_on_demand(monkeypatch, store):
+    """get_blob should fetch from controller on cache miss."""
+    data = b"large pickle data"
+    blob_id = hashlib.sha256(data).hexdigest()
+
+    def fake_urlopen(url: str, timeout: int):
+        assert url == f"http://controller.internal/blobs/{blob_id}"
+        return _FakeResponse(data)
+
+    monkeypatch.setattr("iris.cluster.bundle.urlopen", fake_urlopen)
+
+    result = store.get_blob(blob_id)
+    assert result == data
+
+
+def test_get_blob_uses_cache_on_hit(store):
+    """get_blob should return cached data without hitting the network."""
+    data = b"cached blob"
+    store.write_blob(data)
+    blob_id = hashlib.sha256(data).hexdigest()
+    assert store.get_blob(blob_id) == data
+
+
+def test_get_blob_hash_verification_failure(monkeypatch, store):
+    bad_data = b"wrong content"
+    wrong_id = "c" * 64
+
+    def fake_urlopen(url: str, timeout: int):
+        assert url == f"http://controller.internal/blobs/{wrong_id}"
+        return _FakeResponse(bad_data)
+
+    monkeypatch.setattr("iris.cluster.bundle.urlopen", fake_urlopen)
+    with pytest.raises(ValueError, match="Blob hash mismatch"):
+        store.get_blob(wrong_id)

--- a/lib/iris/tests/e2e/helpers.py
+++ b/lib/iris/tests/e2e/helpers.py
@@ -135,6 +135,20 @@ class TestJobs:
         assert info.ports["grpc"] > 0
 
     @staticmethod
+    def verify_workdir_file(filename: str, expected_size: int):
+        """Verify a workdir file exists with the expected size."""
+        import os
+
+        workdir = os.environ.get("IRIS_WORKDIR", "/app")
+        path = os.path.join(workdir, filename)
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"Workdir file {filename} not found at {path}")
+        actual_size = os.path.getsize(path)
+        if actual_size != expected_size:
+            raise ValueError(f"Expected {expected_size} bytes, got {actual_size}")
+        return actual_size
+
+    @staticmethod
     def validate_job_context():
         """Validate job context via get_job_info() in a coscheduled job."""
         import logging

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -844,6 +844,26 @@ def test_stress_50_tasks(smoke_cluster):
 
 
 # ============================================================================
+# Workdir file offload (large files externalized to blob store)
+# ============================================================================
+
+OFFLOAD_FILE_SIZE = 200 * 1024  # 200KB — exceeds the 100KB offload threshold
+
+
+def test_workdir_file_offload(smoke_cluster):
+    """A job with a >100KB workdir file succeeds after blob-store offloading."""
+    entrypoint = Entrypoint.from_callable(TestJobs.verify_workdir_file, "large_payload.bin", OFFLOAD_FILE_SIZE)
+    entrypoint.workdir_files["large_payload.bin"] = b"\xab" * OFFLOAD_FILE_SIZE
+    job = smoke_cluster.client.submit(
+        entrypoint=entrypoint,
+        name=f"smoke-offload-{uuid.uuid4().hex[:8]}",
+        resources=ResourceSpec(cpu=1, memory="1g"),
+    )
+    status = smoke_cluster.wait(job, timeout=smoke_cluster.job_timeout)
+    assert status.state == job_pb2.JOB_STATE_SUCCEEDED
+
+
+# ============================================================================
 # Standalone cluster helpers
 # ============================================================================
 

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -847,11 +847,11 @@ def test_stress_50_tasks(smoke_cluster):
 # Workdir file offload (large files externalized to blob store)
 # ============================================================================
 
-OFFLOAD_FILE_SIZE = 200 * 1024  # 200KB — exceeds the 100KB offload threshold
+OFFLOAD_FILE_SIZE = 32 * 1024  # 32KB — exceeds the 10KB offload threshold
 
 
 def test_workdir_file_offload(smoke_cluster):
-    """A job with a >100KB workdir file succeeds after blob-store offloading."""
+    """A job with a workdir file above the offload threshold succeeds after blob-store offloading."""
     entrypoint = Entrypoint.from_callable(TestJobs.verify_workdir_file, "large_payload.bin", OFFLOAD_FILE_SIZE)
     entrypoint.workdir_files["large_payload.bin"] = b"\xab" * OFFLOAD_FILE_SIZE
     job = smoke_cluster.client.submit(


### PR DESCRIPTION
Controller-side offload logic for large workdir files. During launch_job,
any workdir_file exceeding 100KB is written to the blob store and replaced
with a SHA-256 reference in workdir_file_refs. This keeps request_proto
and gRPC dispatch messages small.

Reopens #4246 (auto-closed by stale bot; couldn't be reopened because the
branch was force-pushed after closure).

## Summary
- BundleStore: content-addressed blob store with `write_blob` / `get_blob` and controller HTTP fallback
- launch_job: large workdir files (>100KB) offloaded to blob store, replaced with refs in the proto
- Plumbing: `workdir_file_refs` carried through `Entrypoint` ↔ proto and `build_runtime_entrypoint`
- K8s: init container resolves blob refs via `bundle_fetch.py`
- E2E: `test_workdir_file_offload` exercises the full path with a 200KB file

## Test plan
- [x] Unit tests pass
- [x] E2E `test_workdir_file_offload` runs
- [ ] Verify on staging cluster