### PR TITLE
datakit: register nemotron_v1 in source registry

### DIFF
--- a/lib/marin/src/marin/datakit/download/nemotron_v1.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_v1.py
@@ -161,3 +161,19 @@ def normalize_nemotron_v1_step(download: StepSpec, *, split: str) -> StepSpec:
         file_extensions=(".jsonl.zst",),
         relative_input_path=f"{_NEMOTRON_V1_DATA_ROOT}/{rel_path}",
     )
+
+
+def nemotron_v1_normalize_steps() -> dict[str, tuple[StepSpec, ...]]:
+    """Full ``(download, normalize)`` chain per Nemotron-CC v1 split.
+
+    One download step is shared across every split (the entire Nemotron-CC
+    corpus is fetched as a single tree under ``raw/nemotro-cc-eeb783``); each
+    split gets its own normalize step pointing at its quality-subdirectory.
+    Returns ``{marin_name: (download, normalize)}`` where marin_name is
+    ``f"nemotron_v1/{split}"`` — matching the ``DatakitSource.name`` convention.
+    """
+    download = download_nemotron_v1_step()
+    return {
+        f"nemotron_v1/{split}": (download, normalize_nemotron_v1_step(download, split=split))
+        for split in NEMOTRON_V1_SPLITS
+    }

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -32,6 +32,7 @@ from marin.datakit.download.institutional_books import institutional_books_norma
 from marin.datakit.download.massive import massive_normalize_steps
 from marin.datakit.download.molmo2_cap import molmo2_cap_normalize_steps
 from marin.datakit.download.nemotron_terminal import nemotron_terminal_normalize_steps
+from marin.datakit.download.nemotron_v1 import nemotron_v1_normalize_steps
 from marin.datakit.download.nemotron_v2 import nemotron_v2_normalize_steps
 from marin.datakit.download.nsf_awards import nsf_awards_normalize_steps
 from marin.datakit.download.starcoder2_extras import starcoder2_extras_normalize_steps
@@ -235,6 +236,24 @@ def all_sources() -> dict[str, DatakitSource]:
         },
     )
 
+    # Nemotron v1 (Nemotron-CC from Common Crawl): one family download shared
+    # across all 7 quality splits; each split has its own normalize.
+    # TODO: replace token counts with real Llama-3 token counts. These are TiB
+    # storage sizes from experiments/pretraining_datasets/nemotron.py used as a
+    # rough proxy for mixture weighting until proper counts are available.
+    nemotron_v1 = _rows_flat(
+        nemotron_v1_normalize_steps,
+        {
+            "nemotron_v1/hq_actual": 0.91351,
+            "nemotron_v1/hq_synth": 2.72,
+            "nemotron_v1/medium_high": 0.82471,
+            "nemotron_v1/medium": 3.38,
+            "nemotron_v1/medium_low": 1.54,
+            "nemotron_v1/low_actual": 0.70123,
+            "nemotron_v1/low_synth": 0.62771,
+        },
+    )
+
     # Nemotron v2 families: one family download shared across all subsets
     # (via ``@cache`` on ``download_nemotron_v2_step``); each subset has its
     # own normalize.
@@ -327,6 +346,7 @@ def all_sources() -> dict[str, DatakitSource]:
         *starcoder2_extras,
         *common_pile,
         *finepdfs,
+        *nemotron_v1,
         *nemotron_cc_v2,
         *nemotron_cc_v2_1,
         *nemotron_cc_code_v1,

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -237,20 +237,20 @@ def all_sources() -> dict[str, DatakitSource]:
     )
 
     # Nemotron v1 (Nemotron-CC from Common Crawl): one family download shared
-    # across all 7 quality splits; each split has its own normalize.
-    # TODO: replace token counts with real Llama-3 token counts. These are TiB
-    # storage sizes from experiments/pretraining_datasets/nemotron.py used as a
-    # rough proxy for mixture weighting until proper counts are available.
+    # across all 7 quality splits; each split has its own normalize. Token
+    # counts read directly off the existing Llama-3 tokenized caches at
+    # gs://marin-us-central2/tokenized/nemotron_cc/<split>-* (JaggedArrayStore
+    # data_size on input_ids).
     nemotron_v1 = _rows_flat(
         nemotron_v1_normalize_steps,
         {
-            "nemotron_v1/hq_actual": 0.91351,
-            "nemotron_v1/hq_synth": 2.72,
-            "nemotron_v1/medium_high": 0.82471,
-            "nemotron_v1/medium": 3.38,
-            "nemotron_v1/medium_low": 1.54,
-            "nemotron_v1/low_actual": 0.70123,
-            "nemotron_v1/low_synth": 0.62771,
+            "nemotron_v1/hq_actual": 537.62,
+            "nemotron_v1/hq_synth": 1497.53,
+            "nemotron_v1/medium_high": 489.05,
+            "nemotron_v1/medium": 1960.60,
+            "nemotron_v1/medium_low": 861.00,
+            "nemotron_v1/low_actual": 384.10,
+            "nemotron_v1/low_synth": 321.66,
         },
     )
 


### PR DESCRIPTION
* register the 7 nemotron-cc v1 quality splits as mixture components in `all_sources()`, alongside the v2 families
* add `nemotron_v1_normalize_steps()` factory returning `{f"nemotron_v1/{split}": (download, normalize)}` over `NEMOTRON_V1_SPLITS`, mirroring `nemotron_v2_normalize_steps()` (shared download, per-split normalize)
* wire into `sources.py` via `_rows_flat` with per-split `rough_token_count_b` values read directly off the existing Llama-3.1 tokenized caches [^1]
  * ~6.05T tokens total: hq_actual 537.62B, hq_synth 1497.53B, medium_high 489.05B, medium 1960.60B, medium_low 861.00B, low_actual 384.10B, low_synth 321.66B

[^1]: `JaggedArrayStore.data_size` on `gs://marin-us-central2/tokenized/nemotron_cc/<split>-*/train/input_ids` (the same hashes pinned in `experiments/pretraining_datasets/nemotron.py::NEMOTRON_LLAMA3_OVERRIDES`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)