### PR TITLE
finelog: cache _SealedBuffer nbytes / num_rows

### DIFF
--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -244,9 +244,21 @@ def _merge_chunks(chunks: list[pa.Table]) -> list[pa.Table]:
 
 @dataclass
 class _SealedBuffer:
+    """An immutable, in-flight flush buffer.
+
+    ``nbytes`` and ``num_rows`` are snapshotted at construction so the hot
+    path (``RamBuffers.ram_bytes`` / ``ram_rows``) doesn't re-walk every
+    column buffer on each call — ``pa.Table.nbytes`` is O(chunks * columns)
+    and was the dominant cost under sustained write load.
+    """
+
     table: pa.Table
     min_seq: int
     max_seq: int
+
+    def __post_init__(self) -> None:
+        self.nbytes: int = self.table.nbytes
+        self.num_rows: int = self.table.num_rows
 
 
 @dataclass
@@ -321,6 +333,8 @@ class RamBuffers:
     primitive columns and shares string buffers via Arrow's reference
     counting, so total ``nbytes`` is conserved across merges. We can
     therefore maintain ``_ram_bytes`` incrementally rather than scanning.
+    The sealed in-flight buffer caches its own ``nbytes`` / ``num_rows``
+    (see ``_SealedBuffer``) so ``ram_bytes`` stays O(1) on the hot path.
     """
 
     def __init__(self, *, arrow_schema: pa.Schema, next_seq: int) -> None:
@@ -348,11 +362,11 @@ class RamBuffers:
         self._ram_rows += table.num_rows
 
     def ram_bytes(self) -> int:
-        flushing_b = self._flushing.table.nbytes if self._flushing is not None else 0
+        flushing_b = self._flushing.nbytes if self._flushing is not None else 0
         return self._ram_bytes + flushing_b
 
     def ram_rows(self) -> int:
-        flushing_n = self._flushing.table.num_rows if self._flushing is not None else 0
+        flushing_n = self._flushing.num_rows if self._flushing is not None else 0
         return self._ram_rows + flushing_n
 
     def chunk_count(self) -> int:

--- a/lib/finelog/tests/test_ram_buffers.py
+++ b/lib/finelog/tests/test_ram_buffers.py
@@ -1,0 +1,73 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pyarrow as pa
+from finelog.store.log_namespace import RamBuffers, _SealedBuffer
+from finelog.store.schema import IMPLICIT_SEQ_COLUMN, schema_to_arrow, with_implicit_seq
+
+from tests.conftest import _worker_schema
+
+
+def _ns_arrow_schema() -> pa.Schema:
+    return schema_to_arrow(with_implicit_seq(_worker_schema()))
+
+
+def _make_chunk(arrow_schema: pa.Schema, first_seq: int, num_rows: int) -> pa.Table:
+    return pa.table(
+        [
+            pa.array(range(first_seq, first_seq + num_rows), type=pa.int64()),
+            pa.array([f"w-{i}" for i in range(num_rows)], type=pa.string()),
+            pa.array(range(num_rows), type=pa.int64()),
+            pa.array(range(num_rows), type=pa.int64()),
+        ],
+        schema=arrow_schema,
+    )
+
+
+def test_sealed_buffer_caches_nbytes_and_num_rows():
+    arrow_schema = _ns_arrow_schema()
+    table = _make_chunk(arrow_schema, first_seq=1, num_rows=5)
+    sealed = _SealedBuffer(table=table, min_seq=1, max_seq=5)
+    assert sealed.nbytes == table.nbytes
+    assert sealed.num_rows == table.num_rows
+
+
+def test_ram_bytes_reads_cached_flushing_nbytes_not_table():
+    arrow_schema = _ns_arrow_schema()
+    buffers = RamBuffers(arrow_schema=arrow_schema, next_seq=1)
+    buffers.append_table(_make_chunk(arrow_schema, first_seq=1, num_rows=3))
+    pre_seal_bytes = buffers.ram_bytes()
+    pre_seal_rows = buffers.ram_rows()
+
+    sealed = buffers.seal()
+    assert sealed is not None
+    assert buffers.ram_bytes() == pre_seal_bytes
+    assert buffers.ram_rows() == pre_seal_rows
+
+    # Mutate the cached scalars to confirm ram_bytes / ram_rows read them,
+    # not table.nbytes / table.num_rows on every call.
+    sealed.nbytes = 999_999_999
+    sealed.num_rows = 42_424_242
+    assert buffers.ram_bytes() == 999_999_999
+    assert buffers.ram_rows() == 42_424_242
+
+
+def test_restore_flush_preserves_accounting():
+    arrow_schema = _ns_arrow_schema()
+    buffers = RamBuffers(arrow_schema=arrow_schema, next_seq=1)
+    buffers.append_table(_make_chunk(arrow_schema, first_seq=1, num_rows=4))
+    expected_bytes = buffers.ram_bytes()
+    expected_rows = buffers.ram_rows()
+
+    buffers.seal()
+    buffers.restore_flush()
+
+    assert buffers.ram_bytes() == expected_bytes
+    assert buffers.ram_rows() == expected_rows
+
+
+def test_implicit_seq_column_present():
+    arrow_schema = _ns_arrow_schema()
+    assert IMPLICIT_SEQ_COLUMN in arrow_schema.names


### PR DESCRIPTION
* fixes marin-community/marin#5671
* cache `nbytes` / `num_rows` on `_SealedBuffer` so the hot path stays O(1)
* `_SealedBuffer.__post_init__` snapshots `table.nbytes` and `table.num_rows` at construction; `RamBuffers.ram_bytes()` / `ram_rows()` read the cached scalars instead of re-walking every column buffer on each call[^1]
* adds `tests/test_ram_buffers.py` covering the cached scalars, the seal/restore round trip, and the contract that `ram_bytes` reads from `_SealedBuffer.nbytes` rather than `table.nbytes`

[^1]: py-spy on a sustained `WriteRows` workload showed `RamBuffers.ram_bytes()` at ~98% self-time — `pa.Table.nbytes` is O(chunks * columns) and was being recomputed under `_insertion_lock` on every append, every bg-loop tick, and every `_flush_step`.
