### PR TITLE
finelog dashboard: speed up recent rows, fix cell wrap, surface RPC errors

### DIFF
--- a/lib/finelog/dashboard/src/components/shared/DataTable.vue
+++ b/lib/finelog/dashboard/src/components/shared/DataTable.vue
@@ -121,14 +121,17 @@ function hasSlot(name: string): boolean {
                 v-for="col in columns"
                 :key="col.key"
                 :class="[
-                  'px-3 py-2 text-[13px]',
+                  'px-3 py-2 text-[13px] align-top',
                   alignClass(col.align),
                   col.mono ? 'font-mono' : '',
                 ]"
+                :title="hasSlot(`cell-${col.key}`) ? undefined : String(cellValue(row, col.key) ?? '')"
               >
-                <slot :name="`cell-${col.key}`" :value="cellValue(row, col.key)" :row="row">
-                  {{ cellValue(row, col.key) ?? '—' }}
-                </slot>
+                <div class="max-w-[40ch] truncate">
+                  <slot :name="`cell-${col.key}`" :value="cellValue(row, col.key)" :row="row">
+                    {{ cellValue(row, col.key) ?? '—' }}
+                  </slot>
+                </div>
               </td>
             </tr>
             <!-- Expanded row content -->

--- a/lib/finelog/dashboard/src/composables/useRpc.ts
+++ b/lib/finelog/dashboard/src/composables/useRpc.ts
@@ -15,6 +15,27 @@ export interface RpcState<T> {
   refresh: () => Promise<void>
 }
 
+// Connect-JSON error envelope: { code: string, message: string }. Without
+// parsing, the dashboard would display the raw JSON (escaped quotes and all),
+// which the user reads as "broken escaping" — see the iris.task GROUP-BY
+// example. We surface `message` verbatim instead; the parser-error newlines
+// and `LINE 1: ...` carets pass through to the <pre> in the error card.
+async function formatConnectError(method: string, resp: Response): Promise<string> {
+  const text = await resp.text().catch(() => '')
+  if (text) {
+    try {
+      const parsed = JSON.parse(text) as { message?: unknown }
+      if (typeof parsed.message === 'string' && parsed.message) {
+        return `${method}: ${parsed.message}`
+      }
+    } catch {
+      // fall through to the raw-text branch
+    }
+    return `${method}: ${resp.status} ${resp.statusText} — ${text}`
+  }
+  return `${method}: ${resp.status} ${resp.statusText}`
+}
+
 function useRpc<T>(service: string, method: string, body?: RpcBody): RpcState<T> {
   const data = ref<T | null>(null) as Ref<T | null>
   const loading = ref(false)
@@ -34,8 +55,7 @@ function useRpc<T>(service: string, method: string, body?: RpcBody): RpcState<T>
       })
       if (gen !== generation) return
       if (!resp.ok) {
-        const text = await resp.text().catch(() => '')
-        throw new Error(`${method}: ${resp.status} ${resp.statusText}${text ? ` — ${text}` : ''}`)
+        throw new Error(await formatConnectError(method, resp))
       }
       const payload = (await resp.json()) as T
       if (gen !== generation) return
@@ -66,8 +86,7 @@ export async function statsRpcCall<T>(method: string, body?: Record<string, unkn
     body: JSON.stringify(body ?? {}),
   })
   if (!resp.ok) {
-    const text = await resp.text().catch(() => '')
-    throw new Error(`${method}: ${resp.status} ${resp.statusText}${text ? ` — ${text}` : ''}`)
+    throw new Error(await formatConnectError(method, resp))
   }
   return resp.json() as Promise<T>
 }
@@ -79,8 +98,7 @@ export async function logRpcCall<T>(method: string, body?: Record<string, unknow
     body: JSON.stringify(body ?? {}),
   })
   if (!resp.ok) {
-    const text = await resp.text().catch(() => '')
-    throw new Error(`${method}: ${resp.status} ${resp.statusText}${text ? ` — ${text}` : ''}`)
+    throw new Error(await formatConnectError(method, resp))
   }
   return resp.json() as Promise<T>
 }

--- a/lib/finelog/dashboard/src/pages/NamespaceDetailPage.vue
+++ b/lib/finelog/dashboard/src/pages/NamespaceDetailPage.vue
@@ -49,6 +49,16 @@ const keyColumn = computed<string | null>(() => {
   return null
 })
 
+// Recent-rows window. We filter on the implicit ``seq`` column (always
+// present, monotonically increasing on insert) before sorting. DuckDB pushes
+// the ``seq`` predicate down to parquet row group statistics, so only the
+// latest segment(s) are read — a SELECT * ORDER BY <ts> DESC LIMIT 100 on a
+// multi-GB namespace would otherwise scan every segment to compute the
+// top-N. ``RECENT_SEQ_WINDOW`` is the rolling number of newest rows
+// considered; 10x the visible page so concurrent writers can't shrink the
+// post-filter set below LIMIT.
+const RECENT_SEQ_WINDOW = 1000
+
 async function load() {
   loading.value = true
   error.value = null
@@ -57,9 +67,12 @@ async function load() {
     const schemaResp = await statsRpcCall<GetTableSchemaResponse>('GetTableSchema', { namespace: ns })
     schema.value = schemaResp.schema ?? null
 
-    const orderBy = keyColumn.value ? ` ORDER BY "${keyColumn.value}" DESC` : ''
+    const orderBy = keyColumn.value ? `"${keyColumn.value}" DESC` : '"seq" DESC'
     const rows = await statsRpcCall<QueryResponse>('Query', {
-      sql: `SELECT * FROM "${ns}"${orderBy} LIMIT 100`,
+      sql:
+        `SELECT * FROM "${ns}" ` +
+        `WHERE "seq" > coalesce((SELECT max("seq") FROM "${ns}"), 0) - ${RECENT_SEQ_WINDOW} ` +
+        `ORDER BY ${orderBy} LIMIT 100`,
     })
     sample.value = decodeArrowIpc(rows.arrowIpc)
   } catch (e) {


### PR DESCRIPTION
The namespace detail page issued SELECT * ORDER BY <key> DESC LIMIT 100, which made DuckDB scan every parquet segment to compute the top-N. Gate on the implicit monotonic seq column so DuckDB prunes via row group statistics. Long ids in the DataTable were soft-wrapping on hyphens and eating the viewport; cells now truncate to 40ch with the full value on hover. Connect-RPC errors used to render as raw JSON; parse the envelope and surface the message verbatim.