### PR TITLE
Reserve more host memory for finelog

### DIFF
--- a/lib/finelog/src/finelog/deploy/bootstrap.py
+++ b/lib/finelog/src/finelog/deploy/bootstrap.py
@@ -74,20 +74,17 @@ sudo docker pull {{ docker_image }}
 sudo docker stop --timeout 5 {{ container_name }} 2>/dev/null || true
 sudo docker rm -f {{ container_name }} 2>/dev/null || true
 
-# Reserve 0.5 vCPU and 512 MiB for the host VM (sshd, docker daemon, ops
-# agents). Without these caps a runaway finelog can starve the host and lock
-# us out of the box. Floors guard tiny machines: container gets at least
-# 0.5 CPU and 256 MiB even if the math would otherwise go non-positive.
-# CPU is computed in milli-units so the 0.5 reservation is exact.
 host_cpus=$(nproc)
 container_milli_cpus=$(( host_cpus * 1000 - 500 ))
 if [ "$container_milli_cpus" -lt 500 ]; then container_milli_cpus=500; fi
 container_cpus=$(awk -v m="$container_milli_cpus" 'BEGIN{printf "%.3f", m/1000}')
 host_mem_mib=$(awk '/^MemTotal:/ {printf "%d", $2/1024}' /proc/meminfo)
-container_mem_mib=$(( host_mem_mib - 512 ))
+host_reserved_mem_mib=1700
+container_mem_mib=$(( host_mem_mib - host_reserved_mem_mib ))
 if [ "$container_mem_mib" -lt 256 ]; then container_mem_mib=256; fi
 echo "[finelog-init] host=${host_cpus}cpu/${host_mem_mib}MiB" \\
-    "container=${container_cpus}cpu/${container_mem_mib}MiB"
+    "container=${container_cpus}cpu/${container_mem_mib}MiB" \\
+    "host_reserved_mem=${host_reserved_mem_mib}MiB"
 
 sudo docker run -d --name {{ container_name }} \\
     --network=host \\


### PR DESCRIPTION
## Summary

Hardcode the finelog GCE host memory reserve at `1700 MiB` instead of `512 MiB`.

## Rationale

A read-only prod probe estimated the host reserve at `1,699 MiB`; `1700 MiB` rounds that to a simple constant.

<details>
<summary>Probe details</summary>

- host memory: `19,254 MiB`
- host system cgroup: `11,569 MiB`
- finelog cgroup: `10,126 MiB`
- estimate: `11,569 - 10,126 + 256 = 1,699 MiB`

The probe did not stop or restart finelog.

</details>

## Validation

- Rendered bootstrap and ran `bash -n`
- `./infra/pre-commit.py --fix lib/finelog/src/finelog/deploy/bootstrap.py`
- `git diff --check`