### PR TITLE
storage: rsync parquet caches with --delete so stale segments drop out

### DIFF
--- a/scripts/ops/storage/dashboard/server.py
+++ b/scripts/ops/storage/dashboard/server.py
@@ -344,12 +344,19 @@ def create_app(catalog: StorageCatalog = DEFAULT_CATALOG) -> FastAPI:
         ]:
             local_dir.mkdir(parents=True, exist_ok=True)
             log.info("syncing %s from %s", name, gcs_prefix)
+            # --delete-unmatched-destination-objects: `distributed_scan.py`
+            # writes parquet segments under fresh UUIDs and truncates the
+            # GCS staging dir each run, so plain rsync would leave stale
+            # segments from prior scans in the container's local cache and
+            # the dashboard would aggregate ghost objects from a union of
+            # every historical scan.
             subprocess.run(
                 [
                     "gcloud",
                     "storage",
                     "rsync",
                     "--recursive",
+                    "--delete-unmatched-destination-objects",
                     f"{gcs_prefix}/{name}/",
                     str(local_dir) + "/",
                 ],

--- a/scripts/ops/storage/report.py
+++ b/scripts/ops/storage/report.py
@@ -40,21 +40,29 @@ from scripts.ops.storage.constants import (
 
 
 def _download_gcs_parquet(gcs_dir: str, local_dir: Path) -> Path:
-    """Download all *.parquet files from gcs_dir to local_dir using gcloud.
+    """Mirror all *.parquet files from gcs_dir to local_dir using gcloud.
 
-    Skips files already present locally. Returns the local directory.
+    Uses `--delete-unmatched-destination-objects` so files that have been
+    removed at the source (e.g. when `distributed_scan.py` truncates its
+    staging dir before a new run) are also removed from the local cache.
+    Without this, parquet segments from prior scans accumulate locally and
+    the report ends up reading a stale union of every historical scan —
+    paths that have been deleted from GCS still appear in the report.
+
+    Returns the local directory.
     """
     import subprocess
 
     local_dir.mkdir(parents=True, exist_ok=True)
     src = gcs_dir.rstrip("/") + "/*.parquet"
-    print(f"Downloading {src} -> {local_dir} ...")
+    print(f"Mirroring {src} -> {local_dir} ...")
     result = subprocess.run(
         [
             "gcloud",
             "storage",
             "rsync",
             "--recursive",
+            "--delete-unmatched-destination-objects",
             gcs_dir.rstrip("/"),
             str(local_dir),
         ],
@@ -160,6 +168,20 @@ def _build_summaries(
     time_leaves = leaf_root / "time"
     for d in (dir_leaves, time_leaves):
         d.mkdir(parents=True, exist_ok=True)
+
+    # Prune leaves from prior runs whose batch keys are not in the current
+    # batch set. Otherwise stale per-batch aggregates (from objects parquets
+    # that have since been removed) silently fold into the dir_summary view
+    # below and the report shows ghost objects.
+    expected_keys = {_batch_key(batch, DIR_DEPTH) for batch in batches}
+    pruned = 0
+    for leaves_dir in (dir_leaves, time_leaves):
+        for existing in leaves_dir.glob("*.parquet"):
+            if existing.stem not in expected_keys:
+                existing.unlink()
+                pruned += 1
+    if pruned:
+        print(f"pruned {pruned} stale summary leaves from {leaf_root}", file=sys.stderr)
 
     total_objects = 0
     total_bytes = 0


### PR DESCRIPTION
Fixes #5687

The GCS storage scanner is not stale — but the local rsync cache between scanner and report is. `distributed_scan.py` truncates the GCS staging dir and writes fresh-UUID parquet segments each run, but `report.py` and `dashboard/server.py` rsync that dir to a local cache without `--delete-unmatched-destination-objects`, so segments from every historical scan stack up locally and `_build_summaries` unions all of them into `dir_summary`. Same bug also applies to stale per-batch summary leaves under `summary_cache/d{DIR_DEPTH}/`.

This PR:
- Adds `--delete-unmatched-destination-objects` to both rsync call sites.
- Prunes per-batch summary leaves whose batch keys are not in the current batch set.

Generated with [Claude Code](https://claude.ai/code), and Rohith Kuditipudi pressed the green button.