### PR TITLE
Fix _submit_train_job: import current_client from fray top-level

### DIFF
--- a/experiments/defaults.py
+++ b/experiments/defaults.py
@@ -15,8 +15,7 @@ from typing import Any
 
 import jmp
 import levanter.main.train_lm as levanter_train_lm
-from fray import ResourceConfig
-from fray import client as fray_client
+from fray import ResourceConfig, current_client
 from fray.types import Entrypoint, JobRequest, create_environment
 from haliax.partitioning import ResourceAxis
 from haliax.quantization import QuantizationConfig
@@ -604,7 +603,7 @@ def _submit_train_job(
         environment=create_environment(env_vars=env, extras=extras_for_resources(resources)),
     )
 
-    client = fray_client.current_client()
+    client = current_client()
     handle = client.submit(job_request)
     handle.wait(raise_on_failure=True)
 


### PR DESCRIPTION
The alias `from fray import client as fray_client` binds to the fray.client submodule, which does not expose current_client (it lives in fray.current_client and is re-exported on the fray package). _submit_train_job raised AttributeError as soon as the path was exercised. Switch to importing current_client directly.