### PR TITLE
[iris] Replace exponential backoff with sliding-window churn detector

### DIFF
--- a/lib/iris/src/iris/cli/cluster.py
+++ b/lib/iris/src/iris/cli/cluster.py
@@ -737,10 +737,17 @@ def vm_status(ctx, scale_group):
         click.echo(f"    Initializing: {counts.get('initializing', 0)}")
         click.echo(f"    Failed: {counts.get('failed', 0)}")
         click.echo(f"  Demand: {group.current_demand} (peak: {group.peak_demand})")
-        backoff_ms = timestamp_from_proto(group.backoff_until).epoch_ms()
-        if backoff_ms > 0:
-            click.echo(f"  Backoff until: {_format_timestamp(backoff_ms)}")
-            click.echo(f"  Consecutive failures: {group.consecutive_failures}")
+        # Availability / churn status. ``consecutive_failures`` in the proto now
+        # carries the windowed failure count from BackoffDetector — see
+        # ``ScalingGroup.to_status``.
+        if group.availability_status and group.availability_status != "available":
+            reason = f" - {group.availability_reason}" if group.availability_reason else ""
+            click.echo(f"  Availability: {group.availability_status}{reason}")
+            blocked_ms = timestamp_from_proto(group.blocked_until).epoch_ms()
+            if blocked_ms > 0:
+                click.echo(f"  Blocked until: {_format_timestamp(blocked_ms)}")
+        if group.consecutive_failures > 0:
+            click.echo(f"  Recent failures: {group.consecutive_failures}")
         if group.slices:
             click.echo("  Slices:")
             for si in group.slices:

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -1239,7 +1239,6 @@ def create_autoscaler(
     _validate_autoscaler_config(autoscaler_config, context="create_autoscaler")
     _validate_scale_group_resources(_scale_groups_to_config(scale_groups))
 
-    scale_up_delay = duration_from_proto(autoscaler_config.scale_up_delay)
     scale_down_delay = duration_from_proto(autoscaler_config.scale_down_delay)
 
     scaling_groups: dict[str, ScalingGroup] = {}
@@ -1248,7 +1247,6 @@ def create_autoscaler(
             config=group_config,
             platform=platform,
             label_prefix=label_prefix,
-            scale_up_cooldown=scale_up_delay,
             idle_threshold=scale_down_delay,
             scale_up_rate_limit=group_config.scale_up_rate_limit or DEFAULT_SCALE_UP_RATE_LIMIT,
             scale_down_rate_limit=group_config.scale_down_rate_limit or DEFAULT_SCALE_DOWN_RATE_LIMIT,

--- a/lib/iris/src/iris/cluster/controller/autoscaler/backoff_detector.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/backoff_detector.py
@@ -1,0 +1,365 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""In-memory churn detector for autoscaler scale groups.
+
+Replaces the older exponential-backoff-on-failure design. The old design
+treated every short-lived slice death as a fault that earned the group an
+escalating timeout, which produced a sawtooth: capacity drained while the
+group sat in backoff, then burst on recovery. A preemption isn't a fault
+the autoscaler should be punished for — GCP took the slice and there's
+nothing we did wrong. But repeated short-lived deaths *do* signal that
+sending more user work into the zone will keep getting it preempted, so
+we still want to stop scaling up there.
+
+This detector tracks the rate of recent short-lived slice deaths over a
+sliding window and exposes a graduated health signal:
+
+    HEALTHY  ( <20% churn)     full scale-up rate
+    SUSPECT  (20-50% churn)    half scale-up rate
+    CHURNING (50-80% churn)    one-tenth scale-up rate, block scale-down
+    HOSTILE  (>=80% churn)     halt scale-up entirely, block scale-down
+
+A slice that survives past ``long_lived_threshold`` counts as a positive
+sample, so a healthy steady-state group whose slices are all alive reads
+as LONG_LIVED across the window and produces ``churn_rate = 0`` -- one
+unlucky preemption against many healthy slices does not move the needle.
+
+Quota-exhaustion backoff lives elsewhere
+(``ScalingGroup._quota_exceeded_until``). Quota is a categorical "GCP
+said no", not churn, and has a different recovery pattern.
+
+The detector is in-memory only: on controller restart, the window starts
+empty and is repopulated as slices live and die. A short period of "no
+data" after restart is fine — the autoscaler defaults to HEALTHY when
+there are fewer than ``min_samples`` classified outcomes, so it behaves
+exactly like a freshly-deployed cluster until enough samples accumulate.
+"""
+
+from __future__ import annotations
+
+import itertools
+import threading
+from dataclasses import dataclass
+from enum import StrEnum
+
+from rigging.timing import Deadline, Duration, Timestamp
+
+DEFAULT_WINDOW = Duration.from_minutes(30)
+DEFAULT_SHORT_LIVED_THRESHOLD = Duration.from_minutes(5)
+DEFAULT_LONG_LIVED_THRESHOLD = Duration.from_minutes(10)
+DEFAULT_MIN_SAMPLES = 3
+DEFAULT_QUOTA_BLOCK_DURATION = Duration.from_minutes(5)
+
+# Health thresholds on churn_rate (fraction of recent classified outcomes
+# that were short-lived deaths).
+SUSPECT_CHURN_RATE = 0.2
+CHURNING_CHURN_RATE = 0.5
+HOSTILE_CHURN_RATE = 0.8
+
+
+class SliceFate(StrEnum):
+    """How a slice's life ended (or was classified)."""
+
+    # The slice was created, reached READY, then was terminated by GCP
+    # (preemption) or otherwise died after running. Whether it counts as
+    # a failure depends on age at death — handled internally by the
+    # detector's classifier.
+    PREEMPTED = "preempted"
+
+    # The slice never reached READY (CreateSlice RPC error, bootstrap
+    # FAILED, or UNKNOWN past timeout). Always counts as a failure
+    # regardless of age, since no useful work could have happened.
+    BOOT_FAILED = "boot_failed"
+
+    # Synthetic — assigned at classification time to outcomes that have
+    # demonstrably survived past ``long_lived_threshold``. Never passed
+    # in to ``record_terminated``.
+    LONG_LIVED = "long_lived"
+
+
+class GroupHealth(StrEnum):
+    """Graduated health response derived from churn rate."""
+
+    HEALTHY = "healthy"
+    SUSPECT = "suspect"
+    CHURNING = "churning"
+    HOSTILE = "hostile"
+
+
+_RATE_MULTIPLIERS: dict[GroupHealth, float] = {
+    GroupHealth.HEALTHY: 1.0,
+    GroupHealth.SUSPECT: 0.5,
+    GroupHealth.CHURNING: 0.1,
+    GroupHealth.HOSTILE: 0.0,
+}
+
+
+@dataclass
+class SliceOutcome:
+    """One observed slice lifecycle, used as a sample in the churn window."""
+
+    slice_id: str
+    created_at: Timestamp
+    fate: SliceFate | None = None
+    fate_at: Timestamp | None = None
+
+
+class BackoffDetector:
+    """Per-group sliding-window churn tracker.
+
+    Thread-safe. All event hooks (``record_created``, ``record_terminated``,
+    ``record_create_failed``) and all queries (``churn_rate``, ``health``,
+    ``can_scale_up``, etc.) are safe to call from any thread.
+
+    Failure modes treated as "bad" outcomes for churn-rate purposes:
+
+    - ``BOOT_FAILED`` at any age (the slice never produced useful work).
+    - ``PREEMPTED`` with ``fate_at - created_at < short_lived_threshold``
+      (the slice was up too briefly to be worth feeding more work to).
+
+    Failure modes treated as "good" outcomes:
+
+    - ``PREEMPTED`` with age >= ``short_lived_threshold`` (the slice ran
+      long enough to be useful; preemption was just bad luck).
+    - In-flight outcomes whose age >= ``long_lived_threshold`` (slice is
+      demonstrably surviving, even though we haven't seen termination).
+
+    In-flight outcomes younger than ``long_lived_threshold`` are
+    "pending" — they don't contribute to the rate either way.
+    """
+
+    def __init__(
+        self,
+        group_name: str,
+        window: Duration = DEFAULT_WINDOW,
+        short_lived_threshold: Duration = DEFAULT_SHORT_LIVED_THRESHOLD,
+        long_lived_threshold: Duration = DEFAULT_LONG_LIVED_THRESHOLD,
+        min_samples: int = DEFAULT_MIN_SAMPLES,
+        quota_block_duration: Duration = DEFAULT_QUOTA_BLOCK_DURATION,
+    ):
+        if long_lived_threshold.to_ms() < short_lived_threshold.to_ms():
+            raise ValueError(
+                f"long_lived_threshold ({long_lived_threshold}) must be >= "
+                f"short_lived_threshold ({short_lived_threshold})"
+            )
+        if min_samples < 1:
+            raise ValueError(f"min_samples must be >= 1, got {min_samples}")
+
+        self._group_name = group_name
+        self._window = window
+        self._short_lived_threshold = short_lived_threshold
+        self._long_lived_threshold = long_lived_threshold
+        self._min_samples = min_samples
+        self._quota_block_duration = quota_block_duration
+        self._outcomes: dict[str, SliceOutcome] = {}
+        self._synthetic_seq = itertools.count()
+        # Quota-exhausted gate: a GCP "no quota" signal blocks scale-up for a
+        # fixed window. Quota events do not contribute to the churn rate —
+        # quota is a categorical capacity-allocation failure, not a sign that
+        # work we send into the zone will be reclaimed.
+        self._quota_until: Deadline | None = None
+        self._quota_reason: str = ""
+        self._lock = threading.Lock()
+
+    # -----------------------------------------------------------------------
+    # Event hooks
+    # -----------------------------------------------------------------------
+
+    def record_created(self, slice_id: str, created_at: Timestamp) -> None:
+        """Record that a slice was successfully created.
+
+        Called when the platform's ``CreateSlice`` returns a usable handle.
+        Pairs with a subsequent ``record_terminated`` for the same slice.
+        Safe to call multiple times for the same slice (no-op after first).
+        """
+        with self._lock:
+            if slice_id in self._outcomes:
+                return
+            self._outcomes[slice_id] = SliceOutcome(slice_id=slice_id, created_at=created_at)
+            self._gc(created_at)
+
+    def record_terminated(self, slice_id: str, fate: SliceFate, terminated_at: Timestamp) -> None:
+        """Record that a previously-created slice has ended.
+
+        ``fate`` must be ``PREEMPTED`` or ``BOOT_FAILED``; ``LONG_LIVED``
+        is synthetic and only emitted by the classifier.
+
+        If the slice was never seen by ``record_created`` (controller
+        restart between create and terminate, etc.), a synthetic outcome
+        is created with ``created_at = terminated_at`` so the event still
+        contributes to the churn rate as a worst-case sample.
+        """
+        if fate == SliceFate.LONG_LIVED:
+            raise ValueError("LONG_LIVED is synthetic and cannot be recorded directly")
+        with self._lock:
+            outcome = self._outcomes.get(slice_id)
+            if outcome is None:
+                outcome = SliceOutcome(slice_id=slice_id, created_at=terminated_at)
+                self._outcomes[slice_id] = outcome
+            outcome.fate = fate
+            outcome.fate_at = terminated_at
+            self._gc(terminated_at)
+
+    def record_create_failed(self, ts: Timestamp) -> None:
+        """Record a CreateSlice RPC failure (no slice handle was returned).
+
+        Equivalent to a BOOT_FAILED termination of a zero-age slice, but
+        keyed by a synthetic id so it doesn't collide with real slice_ids.
+        Counts toward churn like any other bad outcome.
+        """
+        with self._lock:
+            synthetic_id = f"__create_failed__{ts.epoch_ms()}_{next(self._synthetic_seq)}"
+            self._outcomes[synthetic_id] = SliceOutcome(
+                slice_id=synthetic_id,
+                created_at=ts,
+                fate=SliceFate.BOOT_FAILED,
+                fate_at=ts,
+            )
+            self._gc(ts)
+
+    def record_quota_exceeded(self, reason: str, ts: Timestamp) -> None:
+        """Record that GCP rejected a scale-up with a quota error.
+
+        Sets a fixed-duration block on scale-up. Does **not** contribute to
+        churn: quota is a categorical allocation failure (we don't have
+        capacity rights), not a sign that work we send into the zone gets
+        reclaimed mid-flight.
+        """
+        with self._lock:
+            self._quota_until = Deadline.after(ts, self._quota_block_duration)
+            self._quota_reason = reason
+
+    def clear_quota_block(self) -> None:
+        """Clear the quota-block deadline.
+
+        Called when a successful scale-up proves GCP is currently allowing
+        creates in this zone, so the prior "no quota" snapshot is stale.
+        """
+        with self._lock:
+            self._quota_until = None
+            self._quota_reason = ""
+
+    # -----------------------------------------------------------------------
+    # Queries
+    # -----------------------------------------------------------------------
+
+    def churn_rate(self, now: Timestamp) -> float:
+        """Fraction of recent classified outcomes that were failures.
+
+        Returns 0.0 when there are fewer than ``min_samples`` classified
+        outcomes — a fresh group is HEALTHY by default, not HOSTILE.
+        """
+        with self._lock:
+            self._gc(now)
+            classified = [
+                fate for outcome in self._outcomes.values() if (fate := self._classify(outcome, now)) is not None
+            ]
+        if len(classified) < self._min_samples:
+            return 0.0
+        bad = sum(1 for fate in classified if fate != SliceFate.LONG_LIVED)
+        return bad / len(classified)
+
+    def health(self, now: Timestamp) -> GroupHealth:
+        rate = self.churn_rate(now)
+        if rate >= HOSTILE_CHURN_RATE:
+            return GroupHealth.HOSTILE
+        if rate >= CHURNING_CHURN_RATE:
+            return GroupHealth.CHURNING
+        if rate >= SUSPECT_CHURN_RATE:
+            return GroupHealth.SUSPECT
+        return GroupHealth.HEALTHY
+
+    def can_scale_up(self, now: Timestamp) -> bool:
+        """False when the group is HOSTILE or inside the quota block window."""
+        if self._quota_active(now):
+            return False
+        return self.health(now) != GroupHealth.HOSTILE
+
+    def scale_up_rate_multiplier(self, now: Timestamp) -> float:
+        """Multiplier applied to the desired scale-up batch size."""
+        if self._quota_active(now):
+            return 0.0
+        return _RATE_MULTIPLIERS[self.health(now)]
+
+    def should_block_scale_down(self, now: Timestamp) -> bool:
+        """During CHURNING/HOSTILE, surviving slices are precious — don't reap them.
+
+        Quota does not block scale-down: an active quota window only means we
+        can't grow, not that the slices we have are precious.
+        """
+        return self.health(now) in (GroupHealth.CHURNING, GroupHealth.HOSTILE)
+
+    def block_reason(self, now: Timestamp) -> str | None:
+        """Human-readable reason scale-up is currently blocked, or ``None``."""
+        if self._quota_active(now):
+            return f"quota exceeded: {self._quota_reason}" if self._quota_reason else "quota exceeded"
+        if self.health(now) == GroupHealth.HOSTILE:
+            return f"churn rate {self.churn_rate(now):.0%}"
+        return None
+
+    def quota_deadline(self, now: Timestamp) -> Timestamp | None:
+        """Active quota-block expiry, or ``None`` if quota isn't currently blocking."""
+        if not self._quota_active(now):
+            return None
+        # _quota_until is non-None because _quota_active returned True.
+        assert self._quota_until is not None
+        return self._quota_until.as_timestamp()
+
+    def recent_failure_count(self, now: Timestamp) -> int:
+        """Count of recent classified-as-failure outcomes — for status display."""
+        with self._lock:
+            self._gc(now)
+            classified = [
+                fate for outcome in self._outcomes.values() if (fate := self._classify(outcome, now)) is not None
+            ]
+        return sum(1 for fate in classified if fate != SliceFate.LONG_LIVED)
+
+    def _quota_active(self, now: Timestamp) -> bool:
+        return self._quota_until is not None and not self._quota_until.expired(now=now)
+
+    # -----------------------------------------------------------------------
+    # Internals (caller must hold _lock for _gc; _classify is pure)
+    # -----------------------------------------------------------------------
+
+    def _gc(self, now: Timestamp) -> None:
+        """Drop outcomes whose reference time has aged out of the window."""
+        cutoff_ms = now.epoch_ms() - self._window.to_ms()
+        stale = [
+            slice_id for slice_id, outcome in self._outcomes.items() if self._outcome_reference_ms(outcome) < cutoff_ms
+        ]
+        for slice_id in stale:
+            del self._outcomes[slice_id]
+
+    @staticmethod
+    def _outcome_reference_ms(outcome: SliceOutcome) -> int:
+        """The time the outcome 'ages out' from: fate_at if resolved, else created_at."""
+        if outcome.fate_at is not None:
+            return outcome.fate_at.epoch_ms()
+        return outcome.created_at.epoch_ms()
+
+    def _classify(self, outcome: SliceOutcome, now: Timestamp) -> SliceFate | None:
+        """Classify a single outcome into PREEMPTED / BOOT_FAILED / LONG_LIVED / None.
+
+        - BOOT_FAILED is always a failure.
+        - PREEMPTED with age < short_lived_threshold is a failure (PREEMPTED).
+        - PREEMPTED with age >= short_lived_threshold reclassifies as LONG_LIVED.
+        - In-flight outcomes with age >= long_lived_threshold count as LONG_LIVED
+          (the slice has demonstrably survived even though we haven't seen
+          termination yet).
+        - In-flight outcomes younger than long_lived_threshold are pending and
+          contribute nothing to the rate.
+        """
+        if outcome.fate == SliceFate.BOOT_FAILED:
+            return SliceFate.BOOT_FAILED
+        if outcome.fate == SliceFate.PREEMPTED:
+            assert outcome.fate_at is not None
+            age_ms = outcome.fate_at.epoch_ms() - outcome.created_at.epoch_ms()
+            if age_ms < self._short_lived_threshold.to_ms():
+                return SliceFate.PREEMPTED
+            return SliceFate.LONG_LIVED
+        # In-flight (fate is None)
+        age_ms = now.epoch_ms() - outcome.created_at.epoch_ms()
+        if age_ms >= self._long_lived_threshold.to_ms():
+            return SliceFate.LONG_LIVED
+        return None

--- a/lib/iris/src/iris/cluster/controller/autoscaler/backoff_detector.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/backoff_detector.py
@@ -25,9 +25,10 @@ sample, so a healthy steady-state group whose slices are all alive reads
 as LONG_LIVED across the window and produces ``churn_rate = 0`` -- one
 unlucky preemption against many healthy slices does not move the needle.
 
-Quota-exhaustion backoff lives elsewhere
-(``ScalingGroup._quota_exceeded_until``). Quota is a categorical "GCP
-said no", not churn, and has a different recovery pattern.
+Quota-exhaustion gating lives inside this class (``_quota_until``,
+``record_quota_exceeded``, ``clear_quota_block``). Quota is a categorical
+"GCP said no", not churn, so it does not contribute to the churn rate
+and has its own fixed-duration block.
 
 The detector is in-memory only: on controller restart, the window starts
 empty and is repopulated as slices live and die. A short period of "no
@@ -272,13 +273,15 @@ class BackoffDetector:
 
     def can_scale_up(self, now: Timestamp) -> bool:
         """False when the group is HOSTILE or inside the quota block window."""
-        if self._quota_active(now):
+        quota_deadline, _ = self._snapshot_quota()
+        if quota_deadline is not None and not quota_deadline.expired(now=now):
             return False
         return self.health(now) != GroupHealth.HOSTILE
 
     def scale_up_rate_multiplier(self, now: Timestamp) -> float:
         """Multiplier applied to the desired scale-up batch size."""
-        if self._quota_active(now):
+        quota_deadline, _ = self._snapshot_quota()
+        if quota_deadline is not None and not quota_deadline.expired(now=now):
             return 0.0
         return _RATE_MULTIPLIERS[self.health(now)]
 
@@ -292,19 +295,19 @@ class BackoffDetector:
 
     def block_reason(self, now: Timestamp) -> str | None:
         """Human-readable reason scale-up is currently blocked, or ``None``."""
-        if self._quota_active(now):
-            return f"quota exceeded: {self._quota_reason}" if self._quota_reason else "quota exceeded"
+        quota_deadline, quota_reason = self._snapshot_quota()
+        if quota_deadline is not None and not quota_deadline.expired(now=now):
+            return f"quota exceeded: {quota_reason}" if quota_reason else "quota exceeded"
         if self.health(now) == GroupHealth.HOSTILE:
             return f"churn rate {self.churn_rate(now):.0%}"
         return None
 
     def quota_deadline(self, now: Timestamp) -> Timestamp | None:
         """Active quota-block expiry, or ``None`` if quota isn't currently blocking."""
-        if not self._quota_active(now):
+        deadline, _ = self._snapshot_quota()
+        if deadline is None or deadline.expired(now=now):
             return None
-        # _quota_until is non-None because _quota_active returned True.
-        assert self._quota_until is not None
-        return self._quota_until.as_timestamp()
+        return deadline.as_timestamp()
 
     def recent_failure_count(self, now: Timestamp) -> int:
         """Count of recent classified-as-failure outcomes — for status display."""
@@ -315,28 +318,35 @@ class BackoffDetector:
             ]
         return sum(1 for fate in classified if fate != SliceFate.LONG_LIVED)
 
-    def _quota_active(self, now: Timestamp) -> bool:
-        return self._quota_until is not None and not self._quota_until.expired(now=now)
+    def _snapshot_quota(self) -> tuple[Deadline | None, str]:
+        """Snapshot (deadline, reason) under the lock for race-free reads."""
+        with self._lock:
+            return self._quota_until, self._quota_reason
 
     # -----------------------------------------------------------------------
     # Internals (caller must hold _lock for _gc; _classify is pure)
     # -----------------------------------------------------------------------
 
     def _gc(self, now: Timestamp) -> None:
-        """Drop outcomes whose reference time has aged out of the window."""
+        """Drop resolved outcomes whose ``fate_at`` has aged out of the window.
+
+        In-flight outcomes are intentionally **not** evicted: a slice that
+        legitimately runs longer than the window must still be recognised when
+        it eventually terminates, otherwise a normal preemption of a long-lived
+        survivor would be mis-classified as a short-lived failure (the missing
+        ``record_created`` would cause :meth:`record_terminated` to fabricate
+        ``created_at = terminated_at``, age=0). The no-ghost guarantee from
+        the runtime ensures every in-flight outcome eventually resolves, at
+        which point it ages out via its ``fate_at``.
+        """
         cutoff_ms = now.epoch_ms() - self._window.to_ms()
         stale = [
-            slice_id for slice_id, outcome in self._outcomes.items() if self._outcome_reference_ms(outcome) < cutoff_ms
+            slice_id
+            for slice_id, outcome in self._outcomes.items()
+            if outcome.fate_at is not None and outcome.fate_at.epoch_ms() < cutoff_ms
         ]
         for slice_id in stale:
             del self._outcomes[slice_id]
-
-    @staticmethod
-    def _outcome_reference_ms(outcome: SliceOutcome) -> int:
-        """The time the outcome 'ages out' from: fate_at if resolved, else created_at."""
-        if outcome.fate_at is not None:
-            return outcome.fate_at.epoch_ms()
-        return outcome.created_at.epoch_ms()
 
     def _classify(self, outcome: SliceOutcome, now: Timestamp) -> SliceFate | None:
         """Classify a single outcome into PREEMPTED / BOOT_FAILED / LONG_LIVED / None.

--- a/lib/iris/src/iris/cluster/controller/autoscaler/operations.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/operations.py
@@ -9,7 +9,7 @@ import logging
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
-from rigging.timing import Duration, Timestamp
+from rigging.timing import Timestamp
 
 from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup
 from iris.cluster.controller.db import ControllerDB
@@ -85,9 +85,14 @@ def terminate_slices_for_workers(
     unregister_slice_workers: Callable[[str, Sequence[str] | None], None],
     log_action: Callable[..., vm_pb2.AutoscalerAction],
     timestamp: Timestamp,
-    short_lived_slice_threshold: Duration,
 ) -> SliceTerminationResult:
-    """Detach and schedule slice termination for the given failed workers."""
+    """Detach and schedule slice termination for the given failed workers.
+
+    Every observed slice termination is reported to the group's churn detector
+    as :class:`~iris.cluster.controller.autoscaler.backoff_detector.SliceFate.PREEMPTED`.
+    The detector classifies internally based on slice age — short-lived deaths
+    move churn rate; long-lived deaths count as positive samples.
+    """
 
     if not worker_ids:
         return SliceTerminationResult(sibling_worker_ids=[], termination_requests=[])
@@ -117,13 +122,7 @@ def terminate_slices_for_workers(
             slice_id=slice_id,
             reason=f"workers failed: {', '.join(failed_workers)}",
         )
-        record_slice_failure(
-            group=group,
-            slice_id=slice_id,
-            timestamp=timestamp,
-            short_lived_slice_threshold=short_lived_slice_threshold,
-            log_action=log_action,
-        )
+        group.record_slice_preempted(slice_id, timestamp)
         handle = group.detach_slice(slice_id)
         unregister_slice_workers(slice_id, worker_ids=slice_worker_ids)
         if handle is not None:
@@ -146,31 +145,3 @@ def find_slice_for_worker(
         if slice_id is not None:
             return slice_id, group
     return None, None
-
-
-def record_slice_failure(
-    group: ScalingGroup,
-    slice_id: str,
-    timestamp: Timestamp,
-    short_lived_slice_threshold: Duration,
-    log_action: Callable[..., vm_pb2.AutoscalerAction],
-) -> None:
-    """Record slice failure and apply backoff if it was short-lived."""
-
-    slice_handle = group.get_slice(slice_id)
-    if slice_handle is None:
-        return
-
-    age_ms = timestamp.epoch_ms() - slice_handle.created_at.epoch_ms()
-    age = Duration.from_ms(age_ms)
-    if age >= short_lived_slice_threshold:
-        return
-
-    logger.warning("Short-lived slice %s (age=%dms) in %s, applying backoff", slice_id, age_ms, group.name)
-    group.record_failure(timestamp)
-    log_action(
-        "backoff_triggered",
-        group.name,
-        slice_id=slice_id,
-        reason=f"short-lived slice (age={age_ms}ms)",
-    )

--- a/lib/iris/src/iris/cluster/controller/autoscaler/planning.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/planning.py
@@ -93,7 +93,14 @@ class ScalePlan:
 
 
 def build_group_scale_plan(group: ScalingGroup, required_slices: int, ts: Timestamp) -> GroupScalePlan:
-    """Build the actionable scale-up plan for a group."""
+    """Build the actionable scale-up plan for a group.
+
+    The churn detector's ``scale_up_rate_multiplier`` clamps the per-tick
+    batch size so SUSPECT and CHURNING zones still scale up but at a slower
+    rate, instead of either firing the full burst or sitting in hard backoff.
+    HOSTILE / quota-blocked zones return a 0.0 multiplier, which collapses
+    ``slices_to_add`` to zero — equivalent to the old ``scale_up_blocked``.
+    """
 
     counts = GroupSliceCounts.from_group(group)
     target_slices = min(required_slices + group.buffer_slices, group.max_slices)
@@ -105,7 +112,13 @@ def build_group_scale_plan(group: ScalingGroup, required_slices: int, ts: Timest
     if slices_needed > 0 and counts.total < group.max_slices:
         blocked = not group.can_scale_up(ts)
         if not blocked:
-            slices_to_add = min(slices_needed, group.max_slices - counts.total)
+            headroom = group.max_slices - counts.total
+            raw = min(slices_needed, headroom)
+            multiplier = group.detector.scale_up_rate_multiplier(ts)
+            # Always launch at least one slice when we want any AND we're not
+            # hard-blocked, so SUSPECT/CHURNING zones make progress (just slowly)
+            # instead of stalling on multiplier * <small> rounding to zero.
+            slices_to_add = max(1, int(raw * multiplier)) if multiplier > 0 else 0
 
     return GroupScalePlan(
         group=group.name,

--- a/lib/iris/src/iris/cluster/controller/autoscaler/recovery.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/recovery.py
@@ -34,17 +34,18 @@ class AutoscalerCheckpoint:
 
 
 def load_autoscaler_checkpoint(db: ControllerDB) -> AutoscalerCheckpoint:
-    """Load autoscaler state from the controller DB."""
+    """Load autoscaler state from the controller DB.
+
+    Backoff/churn state is no longer persisted (it lives in the in-memory
+    :class:`BackoffDetector`), so we only restore slice membership and
+    informational scale timestamps from the DB.
+    """
     with db.read_snapshot() as tx:
         scaling_rows = tx.execute(
             select(
                 scaling_groups_table.c.name,
-                scaling_groups_table.c.consecutive_failures,
-                scaling_groups_table.c.backoff_until_ms,
                 scaling_groups_table.c.last_scale_up_ms,
                 scaling_groups_table.c.last_scale_down_ms,
-                scaling_groups_table.c.quota_exceeded_until_ms,
-                scaling_groups_table.c.quota_reason,
             )
         ).all()
 
@@ -88,12 +89,8 @@ def load_autoscaler_checkpoint(db: ControllerDB) -> AutoscalerCheckpoint:
         group_snapshots[row.name] = GroupSnapshot(
             name=row.name,
             slices=slices_by_group.get(row.name, []),
-            consecutive_failures=int(row.consecutive_failures),
-            backoff_until_ms=int(row.backoff_until_ms),
             last_scale_up_ms=int(row.last_scale_up_ms),
             last_scale_down_ms=int(row.last_scale_down_ms),
-            quota_exceeded_until_ms=int(row.quota_exceeded_until_ms),
-            quota_reason=row.quota_reason,
         )
 
     tracked_worker_rows = [
@@ -135,12 +132,8 @@ def restore_autoscaler_state(
         )
         group.restore_from_snapshot(
             slices=restore_result.slices,
-            consecutive_failures=restore_result.consecutive_failures,
             last_scale_up=restore_result.last_scale_up,
             last_scale_down=restore_result.last_scale_down,
-            backoff_until=restore_result.backoff_until,
-            quota_exceeded_until=restore_result.quota_exceeded_until,
-            quota_reason=restore_result.quota_reason,
         )
 
     return restore_tracked_workers(checkpoint.tracked_worker_rows)

--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -62,9 +62,6 @@ from iris.time_proto import duration_from_proto, timestamp_to_proto
 logger = logging.getLogger(__name__)
 
 
-# Slices that die within this time of creation trigger backoff (preemption detection)
-SHORT_LIVED_SLICE_THRESHOLD = Duration.from_minutes(5)
-
 # After this long in UNKNOWN state, treat the slice as FAILED (quota timeout is 5 min, so this is conservative)
 DEFAULT_UNRESOLVABLE_TIMEOUT = Duration.from_minutes(15)
 
@@ -393,7 +390,7 @@ class Autoscaler:
             logger.exception("Failed to create slice for %s: %s", group.name, e)
             action.status = "failed"
             action.reason = f"{reason} - error: {e}"
-            group.record_failure(ts)
+            group.record_create_failed(ts)
             return False
 
     def _per_group_worker_config(self, group: ScalingGroup) -> config_pb2.WorkerConfig | None:
@@ -441,7 +438,7 @@ class Autoscaler:
                     group.mark_slice_failed(slice_id, error_message=status.error_message)
                     group.scale_down(slice_id)
                     self._unregister_slice_workers(slice_id)
-                    group.record_failure()
+                    group.record_slice_boot_failed(slice_id, timestamp)
                     reason = status.error_message if status.error_message else "bootstrap failed"
                     self._log_action(
                         "slice_failed",
@@ -456,7 +453,7 @@ class Autoscaler:
                         group.mark_slice_failed(slice_id, error_message="unresolvable after timeout")
                         group.scale_down(slice_id)
                         self._unregister_slice_workers(slice_id)
-                        group.record_failure()
+                        group.record_slice_boot_failed(slice_id, timestamp)
                         self._log_action(
                             "slice_failed",
                             group.name,
@@ -617,7 +614,6 @@ class Autoscaler:
             unregister_slice_workers=self._unregister_slice_workers,
             log_action=self._log_action,
             timestamp=Timestamp.now(),
-            short_lived_slice_threshold=SHORT_LIVED_SLICE_THRESHOLD,
         )
         for request in result.termination_requests:
 

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -17,7 +17,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum, StrEnum
 
-from rigging.timing import Deadline, Duration, Timestamp, TokenBucket
+from rigging.timing import Duration, Timestamp, TokenBucket
 from sqlalchemy import delete, update
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
@@ -32,6 +32,11 @@ from iris.cluster.constraints import (
     check_resource_fit,
     evaluate_constraint,
     is_cpu_device_type_constraint,
+)
+from iris.cluster.controller.autoscaler.backoff_detector import (
+    BackoffDetector,
+    GroupHealth,
+    SliceFate,
 )
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.schema import scaling_groups_table, slices_table
@@ -104,10 +109,6 @@ class AvailabilityState:
 
 DEFAULT_SCALE_UP_RATE_LIMIT = 16  # per minute
 DEFAULT_SCALE_DOWN_RATE_LIMIT = 32  # per minute
-DEFAULT_SCALE_UP_COOLDOWN = Duration.from_minutes(1)
-DEFAULT_BACKOFF_INITIAL = Duration.from_minutes(5)
-DEFAULT_BACKOFF_MAX = Duration.from_minutes(15)
-DEFAULT_BACKOFF_FACTOR = 2.0
 DEFAULT_IDLE_THRESHOLD = Duration.from_minutes(10)
 DEFAULT_QUOTA_TIMEOUT = Duration.from_minutes(5)
 
@@ -301,14 +302,11 @@ class ScalingGroup:
         config: config_pb2.ScaleGroupConfig,
         platform: WorkerInfraProvider,
         label_prefix: str = "iris",
-        scale_up_cooldown: Duration = DEFAULT_SCALE_UP_COOLDOWN,
-        backoff_initial: Duration = DEFAULT_BACKOFF_INITIAL,
-        backoff_max: Duration = DEFAULT_BACKOFF_MAX,
-        backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
         idle_threshold: Duration = DEFAULT_IDLE_THRESHOLD,
         quota_timeout: Duration = DEFAULT_QUOTA_TIMEOUT,
         scale_up_rate_limit: int = DEFAULT_SCALE_UP_RATE_LIMIT,
         scale_down_rate_limit: int = DEFAULT_SCALE_DOWN_RATE_LIMIT,
+        detector: BackoffDetector | None = None,
         db: ControllerDB | None = None,
     ):
         self._config = config
@@ -326,21 +324,21 @@ class ScalingGroup:
 
         self._idle_threshold = idle_threshold
 
-        # Backoff state
-        self._backoff_until: Deadline | None = None
-        self._consecutive_failures: int = 0
-        self._backoff_initial = backoff_initial
-        self._backoff_max = backoff_max
-        self._backoff_factor = backoff_factor
-
-        # Rate limiting
+        # Informational timestamps surfaced via the status proto. These do not
+        # gate scaling decisions any more — the churn detector below owns that.
         self._last_scale_up: Timestamp = Timestamp.from_ms(0)
         self._last_scale_down: Timestamp = Timestamp.from_ms(0)
-        self._scale_up_cooldown = scale_up_cooldown
-        # Quota state (set by scale_up when QuotaExhaustedError is raised)
-        self._quota_exceeded_until: Deadline | None = None
-        self._quota_reason: str = ""
-        self._quota_timeout = quota_timeout
+
+        # Churn / health signal. Replaces the older exponential-backoff state
+        # (consecutive_failures, backoff_until, scale_up_cooldown). The detector
+        # also owns the quota-exhaustion gate now, so all "is this group blocked
+        # from scaling up?" questions go through a single source of truth. See
+        # autoscaler/backoff_detector.py for the rationale.
+        self._detector = (
+            detector
+            if detector is not None
+            else BackoffDetector(group_name=config.name, quota_block_duration=quota_timeout)
+        )
 
         # Per-group token bucket rate limiter for scale-up API calls
         self._scale_up_bucket = TokenBucket(capacity=scale_up_rate_limit, refill_period=Duration.from_minutes(1))
@@ -396,6 +394,13 @@ class ScalingGroup:
             cur.execute(delete(slices_table).where(slices_table.c.slice_id == slice_id))
 
     def _db_update_group(self) -> None:
+        """Persist informational timestamps to ``scaling_groups``.
+
+        All gating state (``consecutive_failures``, ``backoff_until_ms``, quota)
+        now lives in the in-memory :class:`BackoffDetector`. The legacy columns
+        remain in the schema for the moment (column drop is a follow-up
+        migration) and will hold their ``server_default`` of ``0``/``''``.
+        """
         if self._db is None:
             return
         with self._db.transaction() as cur:
@@ -403,14 +408,8 @@ class ScalingGroup:
                 update(scaling_groups_table)
                 .where(scaling_groups_table.c.name == self.name)
                 .values(
-                    consecutive_failures=self._consecutive_failures,
-                    backoff_until_ms=self._backoff_until.as_timestamp().epoch_ms() if self._backoff_until else 0,
                     last_scale_up_ms=self._last_scale_up.epoch_ms(),
                     last_scale_down_ms=self._last_scale_down.epoch_ms(),
-                    quota_exceeded_until_ms=(
-                        self._quota_exceeded_until.as_timestamp().epoch_ms() if self._quota_exceeded_until else 0
-                    ),
-                    quota_reason=self._quota_reason,
                     updated_at_ms=Timestamp.now().epoch_ms(),
                 )
             )
@@ -494,17 +493,23 @@ class ScalingGroup:
         return self._peak_demand
 
     @property
-    def consecutive_failures(self) -> int:
-        """Number of consecutive scale-up failures."""
-        return self._consecutive_failures
+    def detector(self) -> BackoffDetector:
+        """Churn detector for this group (replaces the old consecutive-failure backoff)."""
+        return self._detector
+
+    def recent_failure_count(self, timestamp: Timestamp | None = None) -> int:
+        """Recent windowed failure count from the churn detector."""
+        return self._detector.recent_failure_count(timestamp or Timestamp.now())
+
+    def health(self, timestamp: Timestamp | None = None) -> GroupHealth:
+        """Current health classification (HEALTHY / SUSPECT / CHURNING / HOSTILE)."""
+        return self._detector.health(timestamp or Timestamp.now())
 
     def begin_scale_up(self, timestamp: Timestamp | None = None) -> None:
         """Mark that a scale-up is in progress.
 
         Increments the pending counter, which is included in slice_count()
         and slice_state_counts(REQUESTING) to prevent over-provisioning.
-        Also updates _last_scale_up so the cooldown gates subsequent requests
-        even while this one is still in-flight.
         """
         timestamp = timestamp or Timestamp.now()
         with self._slices_lock:
@@ -513,16 +518,17 @@ class ScalingGroup:
         self._db_update_group()
 
     def complete_scale_up(self, handle: SliceHandle, timestamp: Timestamp | None = None) -> None:
-        """Record a successful scale-up: add the slice and decrement the pending counter."""
+        """Record a successful scale-up: add the slice, register it with the
+        detector, and clear any stale quota-block (a successful create proves
+        GCP is currently allowing).
+        """
         timestamp = timestamp or Timestamp.now()
         with self._slices_lock:
             self._pending_scale_ups = max(0, self._pending_scale_ups - 1)
             state = SliceState(handle=handle)
             self._slices[handle.slice_id] = state
-        self._consecutive_failures = 0
-        self._backoff_until = None
-        self._quota_exceeded_until = None
-        self._quota_reason = ""
+        self._detector.record_created(handle.slice_id, handle.created_at)
+        self._detector.clear_quota_block()
         self._db_upsert_slice(handle.slice_id, state)
         self._db_update_group()
 
@@ -823,13 +829,17 @@ class ScalingGroup:
         """Scale down idle slices that exceed target capacity.
 
         Terminates multiple idle slices in a single call, rate-limited by a
-        token bucket (matching the scale-up rate limiter).  This replaces the
-        old behaviour of terminating at most one slice per 5-minute cooldown.
+        token bucket (matching the scale-up rate limiter). When the churn
+        detector reports CHURNING or HOSTILE for this group, scale-down is
+        suppressed entirely — the surviving slices are proven survivors of a
+        churning zone, and reaping them when we can't easily replace them
+        accelerates the sawtooth.
 
         Steps:
         1. Update slice activity based on worker idle status
-        2. Check if we're over target capacity (using ready + pending)
-        3. Find eligible idle slices and terminate them (up to the token budget)
+        2. Skip if the detector says we shouldn't scale down right now
+        3. Check if we're over target capacity (using ready + pending)
+        4. Find eligible idle slices and terminate them (up to the token budget)
 
         Args:
             worker_status_map: Map of worker_id to worker status
@@ -841,6 +851,10 @@ class ScalingGroup:
         """
         # Update activity tracking
         self.update_slice_activity(worker_status_map, timestamp)
+
+        # Preserve survivors during a churning zone.
+        if self._detector.should_block_scale_down(timestamp):
+            return []
 
         # Use ready + pending for capacity check to prevent churn during boot
         counts = self.slice_state_counts()
@@ -918,17 +932,11 @@ class ScalingGroup:
         """Check if scale-up is allowed.
 
         Scale-up is blocked if:
-        - Currently in backoff due to previous failures
-        - Scale-up cooldown period has not elapsed
+        - The churn detector says the zone is HOSTILE or quota-exhausted
         - Already at max_slices (includes in-flight scale-ups)
         """
         timestamp = timestamp or Timestamp.now()
-        if self._quota_exceeded_until is not None and not self._quota_exceeded_until.expired(now=timestamp):
-            return False
-        if self._backoff_until is not None and not self._backoff_until.expired(now=timestamp):
-            return False
-        cooldown_end = self._last_scale_up.add(self._scale_up_cooldown)
-        if self._last_scale_up.epoch_ms() > 0 and timestamp.before(cooldown_end):
+        if not self._detector.can_scale_up(timestamp):
             return False
         with self._slices_lock:
             count = len(self._slices) + self._pending_scale_ups
@@ -945,30 +953,29 @@ class ScalingGroup:
         return self._scale_down_bucket.try_acquire(now=timestamp)
 
     def record_quota_exceeded(self, reason: str, timestamp: Timestamp | None = None) -> None:
-        """Record a quota exhaustion event, blocking scale-up until the quota timeout elapses."""
-        timestamp = timestamp or Timestamp.now()
-        self._quota_exceeded_until = Deadline.after(timestamp, self._quota_timeout)
-        self._quota_reason = reason
-        self._db_update_group()
+        """Record a quota exhaustion event, blocking scale-up via the detector."""
+        self._detector.record_quota_exceeded(reason, timestamp or Timestamp.now())
 
-    def record_failure(self, timestamp: Timestamp | None = None) -> None:
-        """Record a scale-up failure and apply exponential backoff.
+    def record_slice_preempted(self, slice_id: str, timestamp: Timestamp | None = None) -> None:
+        """Record that a previously-READY slice has been terminated (preempted).
 
-        Each consecutive failure doubles the backoff time, up to a maximum.
+        Routed to the churn detector, which classifies based on the slice's
+        age at termination: a slice that survived past short_lived_threshold
+        is a positive sample, a short-lived death is a failure.
         """
-        timestamp = timestamp or Timestamp.now()
-        self._consecutive_failures += 1
+        self._detector.record_terminated(slice_id, SliceFate.PREEMPTED, timestamp or Timestamp.now())
 
-        backoff_duration = self._backoff_initial * (self._backoff_factor ** (self._consecutive_failures - 1))
-        backoff_duration = min(backoff_duration, self._backoff_max)
-        self._backoff_until = Deadline.after(timestamp, backoff_duration)
-        self._db_update_group()
+    def record_slice_boot_failed(self, slice_id: str, timestamp: Timestamp | None = None) -> None:
+        """Record that a slice failed to reach READY (CREATING → FAILED, or UNKNOWN past timeout).
 
-    def reset_backoff(self) -> None:
-        """Reset backoff state (typically after successful operation)."""
-        self._consecutive_failures = 0
-        self._backoff_until = None
-        self._db_update_group()
+        Always counted as a failure regardless of age — no useful work could
+        have happened on a slice that never booted.
+        """
+        self._detector.record_terminated(slice_id, SliceFate.BOOT_FAILED, timestamp or Timestamp.now())
+
+    def record_create_failed(self, timestamp: Timestamp | None = None) -> None:
+        """Record a CreateSlice RPC failure where no slice handle was returned."""
+        self._detector.record_create_failed(timestamp or Timestamp.now())
 
     def slice_state_counts(self) -> dict[SliceLifecycleState, int]:
         """Count slices by their lifecycle state.
@@ -1056,23 +1063,22 @@ class ScalingGroup:
     def availability(self, timestamp: Timestamp | None = None) -> AvailabilityState:
         """Compute current availability state for waterfall routing.
 
-        All states are computed from timestamps — no external state setting.
-        Priority: QUOTA_EXCEEDED > BACKOFF > REQUESTING > AT_MAX_SLICES > COOLDOWN > AVAILABLE
+        Priority: QUOTA_EXCEEDED > BACKOFF (HOSTILE churn) > REQUESTING > AT_MAX_SLICES > AVAILABLE
         """
         timestamp = timestamp or Timestamp.now()
 
-        if self._quota_exceeded_until is not None and not self._quota_exceeded_until.expired(now=timestamp):
+        quota_until = self._detector.quota_deadline(timestamp)
+        if quota_until is not None:
             return AvailabilityState(
                 GroupAvailability.QUOTA_EXCEEDED,
-                self._quota_reason,
-                self._quota_exceeded_until.as_timestamp(),
+                self._detector.block_reason(timestamp) or "",
+                quota_until,
             )
 
-        if self._backoff_until is not None and not self._backoff_until.expired(now=timestamp):
+        if self._detector.health(timestamp) == GroupHealth.HOSTILE:
             return AvailabilityState(
                 GroupAvailability.BACKOFF,
-                f"{self._consecutive_failures} consecutive failure{'s' if self._consecutive_failures != 1 else ''}",
-                self._backoff_until.as_timestamp(),
+                self._detector.block_reason(timestamp) or "",
             )
 
         with self._slices_lock:
@@ -1095,10 +1101,6 @@ class ScalingGroup:
             if has_inflight:
                 return AvailabilityState(GroupAvailability.COOLDOWN, "at max_slices with in-flight capacity")
             return AvailabilityState(GroupAvailability.AT_MAX_SLICES)
-
-        cooldown_end = self._last_scale_up.add(self._scale_up_cooldown)
-        if self._last_scale_up.epoch_ms() > 0 and timestamp.before(cooldown_end):
-            return AvailabilityState(GroupAvailability.COOLDOWN, "scale-up cooldown", cooldown_end)
 
         return AvailabilityState(GroupAvailability.AVAILABLE)
 
@@ -1167,24 +1169,22 @@ class ScalingGroup:
     def restore_from_snapshot(
         self,
         slices: dict[str, SliceState],
-        consecutive_failures: int,
         last_scale_up: Timestamp,
         last_scale_down: Timestamp,
-        backoff_until: Deadline | None,
-        quota_exceeded_until: Deadline | None,
-        quota_reason: str,
     ) -> None:
-        """Restore state from a snapshot. Called before the autoscaler loop starts."""
+        """Restore state from a snapshot. Called before the autoscaler loop starts.
+
+        Backoff/churn state is intentionally not restored: the detector runs in
+        memory and starts fresh on each controller boot. Restored slices are
+        seeded into the detector with their original ``created_at`` so the
+        churn window has accurate ages for survival classification.
+        """
         with self._slices_lock:
             self._slices = slices
-        self._consecutive_failures = consecutive_failures
         self._last_scale_up = last_scale_up
         self._last_scale_down = last_scale_down
-        if backoff_until is not None:
-            self._backoff_until = backoff_until
-        if quota_exceeded_until is not None:
-            self._quota_exceeded_until = quota_exceeded_until
-            self._quota_reason = quota_reason
+        for slice_id, state in slices.items():
+            self._detector.record_created(slice_id, state.handle.created_at)
 
     def to_status(self) -> vm_pb2.ScaleGroupStatus:
         """Build a ScaleGroupStatus proto for the status API."""
@@ -1192,29 +1192,22 @@ class ScalingGroup:
             snapshot = list(self._slices.values())
         now = Timestamp.now()
         availability = self.availability(now)
-        backoff_ts = self._backoff_until.as_timestamp() if self._backoff_until else Timestamp.from_ms(0)
         blocked_until = availability.until if availability.until is not None else Timestamp.from_ms(0)
         counts = self.slice_state_counts()
-
-        cooldown_until = Timestamp.from_ms(0)
-        if self._last_scale_up.epoch_ms() > 0:
-            cooldown_end = self._last_scale_up.add(self._scale_up_cooldown)
-            if now.before(cooldown_end):
-                cooldown_until = cooldown_end
 
         status = vm_pb2.ScaleGroupStatus(
             name=self.name,
             config=self._config,
             current_demand=self._current_demand,
             peak_demand=self._peak_demand,
-            backoff_until=timestamp_to_proto(backoff_ts),
-            consecutive_failures=self._consecutive_failures,
+            backoff_until=timestamp_to_proto(Timestamp.from_ms(0)),
+            consecutive_failures=self._detector.recent_failure_count(now),
             last_scale_up=timestamp_to_proto(self._last_scale_up),
             last_scale_down=timestamp_to_proto(self._last_scale_down),
             availability_status=availability.status.value,
             availability_reason=availability.reason,
             blocked_until=timestamp_to_proto(blocked_until),
-            scale_up_cooldown_until=timestamp_to_proto(cooldown_until),
+            scale_up_cooldown_until=timestamp_to_proto(Timestamp.from_ms(0)),
             slices=[slice_state_to_proto(state, idle_threshold=self._idle_threshold) for state in snapshot],
             idle_threshold_ms=self._idle_threshold.to_ms(),
         )
@@ -1246,12 +1239,8 @@ class GroupSnapshot:
 
     name: str
     slices: list[SliceSnapshot] = field(default_factory=list)
-    consecutive_failures: int = 0
-    backoff_until_ms: int = 0
     last_scale_up_ms: int = 0
     last_scale_down_ms: int = 0
-    quota_exceeded_until_ms: int = 0
-    quota_reason: str = ""
 
 
 @dataclass
@@ -1259,16 +1248,10 @@ class ScalingGroupRestoreResult:
     """Result of restoring a single scaling group from checkpoint metadata."""
 
     slices: dict[str, SliceState] = field(default_factory=dict)
-    consecutive_failures: int = 0
-    backoff_active: bool = False
-    quota_exceeded_active: bool = False
-    quota_reason: str = ""
     discarded_count: int = 0
     adopted_count: int = 0
     last_scale_up: Timestamp = field(default_factory=lambda: Timestamp.from_ms(0))
     last_scale_down: Timestamp = field(default_factory=lambda: Timestamp.from_ms(0))
-    backoff_until: Deadline | None = None
-    quota_exceeded_until: Deadline | None = None
 
 
 def restore_scaling_group(
@@ -1281,7 +1264,6 @@ def restore_scaling_group(
     checkpoint_slices = {s.slice_id: s for s in group_snapshot.slices}
 
     result = ScalingGroupRestoreResult()
-    result.consecutive_failures = group_snapshot.consecutive_failures
 
     for slice_id, slice_snap in checkpoint_slices.items():
         cloud_handle = cloud_by_id.get(slice_id)
@@ -1320,31 +1302,16 @@ def restore_scaling_group(
         result.slices[slice_id] = SliceState(handle=cloud_handle, lifecycle=SliceLifecycleState.BOOTING)
         result.adopted_count += 1
 
-    if group_snapshot.backoff_until_ms > 0:
-        backoff_ts = Timestamp.from_ms(group_snapshot.backoff_until_ms)
-        result.backoff_until = Deadline.after(backoff_ts, Duration.from_ms(0))
-        result.backoff_active = not result.backoff_until.expired()
-
-    if group_snapshot.quota_exceeded_until_ms > 0:
-        quota_ts = Timestamp.from_ms(group_snapshot.quota_exceeded_until_ms)
-        result.quota_exceeded_until = Deadline.after(quota_ts, Duration.from_ms(0))
-        result.quota_exceeded_active = not result.quota_exceeded_until.expired()
-        result.quota_reason = group_snapshot.quota_reason
-
     if group_snapshot.last_scale_up_ms > 0:
         result.last_scale_up = Timestamp.from_ms(group_snapshot.last_scale_up_ms)
     if group_snapshot.last_scale_down_ms > 0:
         result.last_scale_down = Timestamp.from_ms(group_snapshot.last_scale_down_ms)
 
     logger.info(
-        "Restored scaling group %s: %d slices (%d discarded, %d adopted), consecutive_failures=%d, "
-        "backoff_active=%s, quota_exceeded=%s",
+        "Restored scaling group %s: %d slices (%d discarded, %d adopted)",
         group_snapshot.name,
         len(result.slices),
         result.discarded_count,
         result.adopted_count,
-        result.consecutive_failures,
-        result.backoff_active,
-        result.quota_exceeded_active,
     )
     return result

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -116,12 +116,12 @@ class UserStats:
 MAX_BUNDLE_SIZE_BYTES = 25 * 1024 * 1024
 
 # Time the launch RPC blocks waiting for a replaced job's worker-bound attempts
-# to finalize before deleting them. One worker poll cycle is ~5s; 30s gives the
-# heartbeat path several cycles to stamp ``finished_at_ms`` for a producer-
-# terminated attempt (the common case is post-preemption cleanup where the
-# worker is busy serving another tenant but will report back within one cycle).
+# to finalize before deleting them. Must exceed the worst-case worker-death
+# detection window so a vanished worker's attempts can be self-finalized by the
+# ping loop before the drain gives up: heartbeat_interval (5s) *
+# PING_FAILURE_THRESHOLD (10) ≈ 50s, plus slack for the heartbeat to land.
 # Stuck finalization surfaces as DEADLINE_EXCEEDED rather than hanging launches.
-_JOB_REPLACEMENT_DRAIN_TIMEOUT = Duration.from_seconds(30)
+_JOB_REPLACEMENT_DRAIN_TIMEOUT = Duration.from_seconds(120)
 
 # A root LaunchJob submission is rejected if its client_revision_date is more
 # than FRESHNESS_WINDOW older than today. Clients get exactly this long to

--- a/lib/iris/src/iris/cluster/providers/local/cluster.py
+++ b/lib/iris/src/iris/cluster/providers/local/cluster.py
@@ -48,7 +48,6 @@ from iris.cluster.worker.port_allocator import PortAllocator
 from iris.managed_thread import ThreadContainer
 from iris.rpc import config_pb2
 from iris.rpc.auth import hash_token
-from iris.time_proto import duration_from_proto
 
 
 def create_local_autoscaler(
@@ -119,15 +118,12 @@ def create_local_autoscaler(
         gcp_service=gcp_service,
     )
 
-    scale_up_delay = duration_from_proto(config.defaults.autoscaler.scale_up_delay)
-
     scale_groups: dict[str, ScalingGroup] = {}
     for name, sg_config in config.scale_groups.items():
         scale_groups[name] = ScalingGroup(
             config=sg_config,
             platform=platform,
             label_prefix=label_prefix,
-            scale_up_cooldown=scale_up_delay,
             scale_up_rate_limit=sg_config.scale_up_rate_limit or DEFAULT_SCALE_UP_RATE_LIMIT,
             scale_down_rate_limit=sg_config.scale_down_rate_limit or DEFAULT_SCALE_DOWN_RATE_LIMIT,
             db=db,

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -64,7 +64,7 @@ def scale_group_config() -> config_pb2.ScaleGroupConfig:
 def empty_autoscaler(scale_group_config):
     """Empty autoscaler ready for scale-up tests."""
     platform = make_mock_platform()
-    group = ScalingGroup(scale_group_config, platform, scale_up_cooldown=Duration.from_ms(0))
+    group = ScalingGroup(scale_group_config, platform)
     autoscaler = make_autoscaler({"test-group": group})
     yield autoscaler
     autoscaler.shutdown()
@@ -106,7 +106,7 @@ class TestAutoscalerScaleUp:
     ):
         """Does not scale up when various conditions are met."""
         platform = make_mock_platform(slices_to_discover=discovered)
-        group = ScalingGroup(scale_group_config, platform, scale_up_cooldown=Duration.from_ms(0))
+        group = ScalingGroup(scale_group_config, platform)
         group.reconcile()
         autoscaler = make_autoscaler({"test-group": group})
 
@@ -115,31 +115,13 @@ class TestAutoscalerScaleUp:
 
         assert len(decisions) == 0
 
-    def test_no_scale_up_during_backoff(self, scale_group_config: config_pb2.ScaleGroupConfig):
-        """Does not scale up during backoff period."""
+    def test_no_scale_up_when_detector_hostile(self, scale_group_config: config_pb2.ScaleGroupConfig):
+        """Does not scale up when the churn detector reports HOSTILE."""
         platform = make_mock_platform()
-        group = ScalingGroup(
-            scale_group_config,
-            platform,
-            scale_up_cooldown=Duration.from_ms(0),
-            backoff_initial=Duration.from_hours(1),
-        )
-        group.record_failure(timestamp=Timestamp.now())
-        autoscaler = make_autoscaler({"test-group": group})
-
-        demand = make_demand_entries(2, device_type=DeviceType.TPU, device_variant="v5p-8")
-        decisions = autoscaler.evaluate(demand)
-
-        assert len(decisions) == 0
-
-    def test_no_scale_up_during_cooldown(self, scale_group_config: config_pb2.ScaleGroupConfig):
-        """Does not scale up during cooldown period."""
-        platform = make_mock_platform()
-        group = ScalingGroup(scale_group_config, platform, scale_up_cooldown=Duration.from_ms(3600_000))
+        group = ScalingGroup(scale_group_config, platform)
         ts = Timestamp.now()
-        group.begin_scale_up()
-        handle = group.scale_up(timestamp=ts)
-        group.complete_scale_up(handle, ts)
+        for _ in range(3):
+            group.record_create_failed(timestamp=ts)
         autoscaler = make_autoscaler({"test-group": group})
 
         demand = make_demand_entries(2, device_type=DeviceType.TPU, device_variant="v5p-8")
@@ -157,7 +139,7 @@ class TestAutoscalerScaleUp:
             zones=["us-central1-a"],
         )
         platform = make_mock_platform()
-        group = ScalingGroup(config, platform, scale_up_cooldown=Duration.from_ms(0))
+        group = ScalingGroup(config, platform)
         autoscaler = make_autoscaler({"test-group": group})
 
         decisions = autoscaler.evaluate([])
@@ -181,7 +163,7 @@ class TestAutoscalerScaleUp:
             make_mock_slice_handle("slice-002", all_ready=True),
         ]
         platform = make_mock_platform(slices_to_discover=discovered)
-        group = ScalingGroup(config, platform, scale_up_cooldown=Duration.from_ms(0))
+        group = ScalingGroup(config, platform)
         group.reconcile()
         autoscaler = make_autoscaler({"test-group": group})
 
@@ -194,7 +176,7 @@ class TestAutoscalerScaleUp:
         config = make_scale_group_config(name="test-group", max_slices=10)
         discovered = [make_mock_slice_handle(f"slice-{i}", all_ready=True) for i in range(5)]
         platform = make_mock_platform(slices_to_discover=discovered)
-        group = ScalingGroup(config, platform, scale_up_cooldown=Duration.from_ms(0))
+        group = ScalingGroup(config, platform)
         group.reconcile()
         _mark_discovered_ready(group, discovered)
         autoscaler = make_autoscaler({"test-group": group})
@@ -414,16 +396,10 @@ class TestAutoscalerExecution:
         assert group.slice_count() == 1
 
     def test_execute_records_failure_on_scale_up_error(self, scale_group_config: config_pb2.ScaleGroupConfig):
-        """execute() records failure when scale-up fails."""
+        """execute() routes a scale-up exception through the churn detector."""
         platform = make_mock_platform()
         platform.create_slice.side_effect = RuntimeError("TPU unavailable")
-        backoff = Duration.from_seconds(5.0)
-        group = ScalingGroup(
-            scale_group_config,
-            platform,
-            scale_up_cooldown=Duration.from_ms(0),
-            backoff_initial=backoff,
-        )
+        group = ScalingGroup(scale_group_config, platform)
         autoscaler = make_autoscaler({"test-group": group})
 
         decision = ScalingDecision(
@@ -435,8 +411,8 @@ class TestAutoscalerExecution:
         autoscaler.execute([decision], timestamp=Timestamp.from_ms(1000))
         autoscaler._wait_for_inflight()
 
-        assert group.consecutive_failures == 1
-        assert group._backoff_until is not None
+        # The create-failure shows up in the detector's recent-failure count.
+        assert group.recent_failure_count(Timestamp.from_ms(2000)) == 1
 
     def test_run_once_evaluates_and_executes(self, empty_autoscaler: Autoscaler):
         """run_once() performs evaluate then execute."""
@@ -730,9 +706,7 @@ class TestAutoscalerQuotaHandling:
 
         platform = make_mock_platform()
         platform.create_slice.side_effect = QuotaExhaustedError("Quota exceeded")
-        group = ScalingGroup(
-            scale_group_config, platform, scale_up_cooldown=Duration.from_ms(0), quota_timeout=Duration.from_ms(60_000)
-        )
+        group = ScalingGroup(scale_group_config, platform, quota_timeout=Duration.from_ms(60_000))
         config = config_pb2.AutoscalerConfig()
         config.evaluation_interval.CopyFrom(duration_to_proto(Duration.from_seconds(0.001)))
         autoscaler = make_autoscaler({"test-group": group}, config=config)
@@ -756,10 +730,9 @@ class TestAutoscalerQuotaHandling:
         group_primary = ScalingGroup(
             config_primary,
             platform_primary,
-            scale_up_cooldown=Duration.from_ms(0),
             quota_timeout=Duration.from_ms(60_000),
         )
-        group_fallback = ScalingGroup(config_fallback, platform_fallback, scale_up_cooldown=Duration.from_ms(0))
+        group_fallback = ScalingGroup(config_fallback, platform_fallback)
         config = config_pb2.AutoscalerConfig()
         config.evaluation_interval.CopyFrom(duration_to_proto(Duration.from_seconds(0.001)))
         autoscaler = make_autoscaler({"primary": group_primary, "fallback": group_fallback}, config=config)
@@ -779,9 +752,7 @@ class TestAutoscalerQuotaHandling:
 
         platform = make_mock_platform()
         platform.create_slice.side_effect = QuotaExhaustedError("Quota exceeded")
-        group = ScalingGroup(
-            scale_group_config, platform, scale_up_cooldown=Duration.from_ms(0), quota_timeout=Duration.from_ms(1000)
-        )
+        group = ScalingGroup(scale_group_config, platform, quota_timeout=Duration.from_ms(1000))
 
         ts = Timestamp.from_ms(1000)
         group.begin_scale_up(timestamp=ts)
@@ -795,30 +766,27 @@ class TestAutoscalerQuotaHandling:
         assert group.availability(Timestamp.from_ms(2100)).status == GroupAvailability.AVAILABLE
 
     def test_generic_error_triggers_backoff_not_quota(self, scale_group_config: config_pb2.ScaleGroupConfig):
-        """Non-quota errors trigger backoff, not quota exceeded state."""
+        """Non-quota errors push the churn detector, not the quota gate. Once enough
+        failures accumulate, availability flips to BACKOFF (HOSTILE)."""
         from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability
 
         platform = make_mock_platform()
         platform.create_slice.side_effect = RuntimeError("TPU unavailable")
 
-        backoff = Duration.from_seconds(5.0)
-        group = ScalingGroup(
-            scale_group_config,
-            platform,
-            scale_up_cooldown=Duration.from_ms(0),
-            backoff_initial=backoff,
-        )
+        group = ScalingGroup(scale_group_config, platform)
         config = config_pb2.AutoscalerConfig()
         config.evaluation_interval.CopyFrom(duration_to_proto(Duration.from_seconds(0.001)))
         autoscaler = make_autoscaler({"test-group": group}, config=config)
 
+        # Drive enough failures past min_samples to reach HOSTILE.
         demand = make_demand_entries(1, device_type=DeviceType.TPU, device_variant="v5p-8")
-        autoscaler.run_once(demand, {}, timestamp=Timestamp.from_ms(1000))
-        autoscaler._wait_for_inflight()
+        for i in range(3):
+            autoscaler.run_once(demand, {}, timestamp=Timestamp.from_ms(1000 + i))
+            autoscaler._wait_for_inflight()
 
         state = group.availability(timestamp=Timestamp.from_ms(2000))
         assert state.status == GroupAvailability.BACKOFF
-        assert group.consecutive_failures == 1
+        assert group.recent_failure_count(Timestamp.from_ms(2000)) >= 3
 
 
 class TestAutoscalerActionLogging:
@@ -842,7 +810,7 @@ class TestAutoscalerActionLogging:
         """Verify quota exceeded events are logged."""
         platform = make_mock_platform()
         platform.create_slice.side_effect = QuotaExhaustedError("Quota exceeded in zone")
-        group = ScalingGroup(scale_group_config, platform, scale_up_cooldown=Duration.from_ms(0))
+        group = ScalingGroup(scale_group_config, platform)
         autoscaler = make_autoscaler({"test-group": group})
 
         demand = make_demand_entries(1, device_type=DeviceType.TPU, device_variant="v5p-8")
@@ -937,7 +905,7 @@ class TestScalingGroupRequestingState:
 
         config = make_scale_group_config(name="test-group", buffer_slices=0, max_slices=5)
         platform = make_mock_platform()
-        group = ScalingGroup(config, platform, scale_up_cooldown=Duration.from_ms(0))
+        group = ScalingGroup(config, platform)
 
         ts = Timestamp.now()
         group.begin_scale_up()
@@ -956,7 +924,7 @@ class TestScalingGroupRequestingState:
 
         config = make_scale_group_config(name="test-group", buffer_slices=0, max_slices=5)
         platform = make_mock_platform()
-        group = ScalingGroup(config, platform, scale_up_cooldown=Duration.from_ms(0))
+        group = ScalingGroup(config, platform)
 
         ts = Timestamp.now()
         group.begin_scale_up()
@@ -1020,7 +988,7 @@ class TestAutoscalerAsyncScaleUp:
 
         platform.create_slice.side_effect = slow_create
 
-        group = ScalingGroup(config, platform, scale_up_cooldown=Duration.from_ms(0))
+        group = ScalingGroup(config, platform)
         autoscaler = make_autoscaler({"test-group": group})
 
         decision = ScalingDecision(
@@ -1051,7 +1019,7 @@ class TestAutoscalerAsyncScaleUp:
 
         platform.create_slice.side_effect = slow_create
 
-        group = ScalingGroup(config, platform, scale_up_cooldown=Duration.from_ms(0))
+        group = ScalingGroup(config, platform)
         autoscaler = make_autoscaler({"test-group": group})
 
         ts = Timestamp.now().epoch_ms()
@@ -1090,7 +1058,7 @@ class TestAutoscalerAsyncScaleUp:
 
         platform.create_slice.side_effect = slow_create
 
-        group = ScalingGroup(config, platform, scale_up_cooldown=Duration.from_ms(0))
+        group = ScalingGroup(config, platform)
         autoscaler = make_autoscaler({"test-group": group})
 
         decision = ScalingDecision(
@@ -1298,7 +1266,6 @@ class TestGpuScaleGroupBugs:
         group = ScalingGroup(
             config,
             platform,
-            scale_up_cooldown=Duration.from_ms(0),
             idle_threshold=Duration.from_ms(60_000),
         )
 
@@ -1333,7 +1300,6 @@ class TestGpuScaleGroupBugs:
         group = ScalingGroup(
             config,
             platform,
-            scale_up_cooldown=Duration.from_ms(0),
             idle_threshold=Duration.from_ms(300_000),  # 5 minutes
         )
         group.reconcile()
@@ -1371,9 +1337,7 @@ class TestMultiSliceScaleUp:
     def test_multi_slice_scale_up(self):
         """Group with 0 existing slices scales up to meet full demand in one cycle."""
         config = make_scale_group_config(name="test-group", max_slices=5, num_vms=1, priority=10)
-        group = ScalingGroup(
-            config, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0), scale_up_rate_limit=1000
-        )
+        group = ScalingGroup(config, make_mock_platform(), scale_up_rate_limit=1000)
         autoscaler = make_autoscaler({"test-group": group})
 
         # 5 big entries, each fills 1 VM, num_vms=1 -> 5 slices needed
@@ -1393,9 +1357,7 @@ class TestMultiSliceScaleUp:
     def test_multi_slice_capped_by_max_slices(self):
         """Scale-up decisions are capped by max_slices."""
         config = make_scale_group_config(name="test-group", max_slices=3, num_vms=1, priority=10)
-        group = ScalingGroup(
-            config, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0), scale_up_rate_limit=1000
-        )
+        group = ScalingGroup(config, make_mock_platform(), scale_up_rate_limit=1000)
         autoscaler = make_autoscaler({"test-group": group})
 
         # 5 big entries, each fills 1 VM -> 5 slices needed, but max=3
@@ -1411,41 +1373,10 @@ class TestMultiSliceScaleUp:
         assert len(decisions) == 3
         assert all(d.action == ScalingAction.SCALE_UP for d in decisions)
 
-    def test_cooldown_group_accepts_demand_but_blocks_scale_up(self):
-        """A group in COOLDOWN accepts demand routing but blocks scale-up until cooldown expires."""
-        from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability
-
-        config = make_scale_group_config(name="test-group", max_slices=5, num_vms=1, priority=10)
-        platform = make_mock_platform()
-        group = ScalingGroup(config, platform, scale_up_cooldown=Duration.from_ms(3600_000))
-
-        # Put group into COOLDOWN: scale up, then complete
-        ts = Timestamp.now()
-        group.begin_scale_up()
-        handle = group.scale_up(timestamp=ts)
-        group.complete_scale_up(handle, ts)
-        assert group.availability(ts).status == GroupAvailability.COOLDOWN
-
-        autoscaler = make_autoscaler({"test-group": group})
-
-        # 3 big entries that need 3 slices, but only 1 exists and group is in cooldown
-        demand = _make_big_demand_entries(
-            3,
-            cpu_millicores=128000,
-            memory_bytes=128 * 1024**3,
-            device_type=DeviceType.TPU,
-            device_variants=frozenset({"v5p-8"}),
-        )
-        decisions = autoscaler.evaluate(demand, timestamp=ts)
-
-        # Demand is routed (current_demand > 0) but no scale-up during cooldown
-        assert group.current_demand > 0
-        assert len(decisions) == 0
-
     def test_available_group_pre_seeded(self):
         """A group in AVAILABLE state is pre-seeded and accepts demand without a second loop."""
         config = make_scale_group_config(name="test-group", max_slices=5, priority=10)
-        group = ScalingGroup(config, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        group = ScalingGroup(config, make_mock_platform())
         autoscaler = make_autoscaler({"test-group": group})
 
         demand = make_demand_entries(3, device_type=DeviceType.TPU, device_variant="v5p-8")
@@ -1462,7 +1393,6 @@ class TestMultiSliceScaleUp:
         group = ScalingGroup(
             config,
             make_mock_platform(slices_to_discover=discovered),
-            scale_up_cooldown=Duration.from_ms(0),
         )
         group.reconcile()
         _mark_discovered_ready(group, discovered)
@@ -1486,7 +1416,6 @@ class TestMultiSliceScaleUp:
         group = ScalingGroup(
             config,
             make_mock_platform(slices_to_discover=discovered),
-            scale_up_cooldown=Duration.from_ms(0),
         )
         group.reconcile()
         _mark_discovered_ready(group, discovered)
@@ -1526,7 +1455,6 @@ class TestMultiSliceScaleUp:
         group = ScalingGroup(
             config,
             make_mock_platform(slices_to_discover=discovered),
-            scale_up_cooldown=Duration.from_ms(0),
             idle_threshold=Duration.from_ms(1000),
         )
         group.reconcile()

--- a/lib/iris/tests/cluster/controller/test_autoscaler_integration.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler_integration.py
@@ -53,8 +53,8 @@ class TestAutoscalerWaterfallEndToEnd:
         platform_fallback, _ = make_gcp_provider(config_fallback)
         service_primary.set_zone_quota("us-central1-a", 0)
 
-        group_primary = ScalingGroup(config_primary, platform_primary, scale_up_cooldown=Duration.from_ms(0))
-        group_fallback = ScalingGroup(config_fallback, platform_fallback, scale_up_cooldown=Duration.from_ms(0))
+        group_primary = ScalingGroup(config_primary, platform_primary)
+        group_fallback = ScalingGroup(config_fallback, platform_fallback)
 
         config = config_pb2.AutoscalerConfig()
         config.evaluation_interval.CopyFrom(duration_to_proto(Duration.from_seconds(0.001)))
@@ -85,10 +85,8 @@ class TestAutoscalerWaterfallEndToEnd:
         platform_fallback, _ = make_gcp_provider(config_fallback)
         service_primary.set_zone_quota("us-central1-a", 0)
 
-        group_primary = ScalingGroup(
-            config_primary, platform_primary, scale_up_cooldown=Duration.from_ms(0), quota_timeout=Duration.from_ms(1000)
-        )
-        group_fallback = ScalingGroup(config_fallback, platform_fallback, scale_up_cooldown=Duration.from_ms(0))
+        group_primary = ScalingGroup(config_primary, platform_primary, quota_timeout=Duration.from_ms(1000))
+        group_fallback = ScalingGroup(config_fallback, platform_fallback)
 
         config = config_pb2.AutoscalerConfig()
         config.evaluation_interval.CopyFrom(duration_to_proto(Duration.from_seconds(0.001)))
@@ -133,8 +131,8 @@ class TestAutoscalerWaterfallEndToEnd:
         platform_primary, service_primary = make_gcp_provider(config_primary)
         platform_fallback, _ = make_gcp_provider(config_fallback)
 
-        group_primary = ScalingGroup(config_primary, platform_primary, scale_up_cooldown=Duration.from_ms(0))
-        group_fallback = ScalingGroup(config_fallback, platform_fallback, scale_up_cooldown=Duration.from_ms(0))
+        group_primary = ScalingGroup(config_primary, platform_primary)
+        group_fallback = ScalingGroup(config_fallback, platform_fallback)
 
         config = config_pb2.AutoscalerConfig()
         config.evaluation_interval.CopyFrom(duration_to_proto(Duration.from_seconds(0.001)))
@@ -171,8 +169,8 @@ class TestAutoscalerWaterfallEndToEnd:
         platform_v5p, _ = make_gcp_provider(config_v5p)
         platform_v5lite, _ = make_gcp_provider(config_v5lite)
 
-        group_v5p = ScalingGroup(config_v5p, platform_v5p, scale_up_cooldown=Duration.from_ms(0))
-        group_v5lite = ScalingGroup(config_v5lite, platform_v5lite, scale_up_cooldown=Duration.from_ms(0))
+        group_v5p = ScalingGroup(config_v5p, platform_v5p)
+        group_v5lite = ScalingGroup(config_v5lite, platform_v5lite)
 
         autoscaler = make_autoscaler(
             scale_groups={"v5p-group": group_v5p, "v5lite-group": group_v5lite},
@@ -198,8 +196,8 @@ class TestAutoscalerWaterfallEndToEnd:
         platform_primary, _ = make_gcp_provider(config_primary)
         platform_fallback, _ = make_gcp_provider(config_fallback)
 
-        group_primary = ScalingGroup(config_primary, platform_primary, scale_up_cooldown=Duration.from_ms(0))
-        group_fallback = ScalingGroup(config_fallback, platform_fallback, scale_up_cooldown=Duration.from_ms(0))
+        group_primary = ScalingGroup(config_primary, platform_primary)
+        group_fallback = ScalingGroup(config_fallback, platform_fallback)
 
         config = config_pb2.AutoscalerConfig()
         config.evaluation_interval.CopyFrom(duration_to_proto(Duration.from_seconds(0.001)))
@@ -239,7 +237,7 @@ class TestAutoscalerWaterfallEndToEnd:
         assert total == 3
 
     def test_demand_cascades_through_priority_groups_on_backoff(self):
-        """E2E: primary create fails -> BACKOFF, second run cascades to fallback."""
+        """E2E: primary keeps failing creates -> detector HOSTILE -> cascades to fallback."""
         config_primary = make_scale_group_config(name="primary", max_slices=5, priority=10, zones=["us-central1-a"])
         config_fallback = make_scale_group_config(name="fallback", max_slices=5, priority=20, zones=["us-central1-a"])
 
@@ -247,17 +245,8 @@ class TestAutoscalerWaterfallEndToEnd:
         platform_fallback, _ = make_gcp_provider(config_fallback)
         service_primary.set_tpu_type_unavailable("v5p-8")
 
-        group_primary = ScalingGroup(
-            config_primary,
-            platform_primary,
-            scale_up_cooldown=Duration.from_ms(0),
-            backoff_initial=Duration.from_seconds(60),
-        )
-        group_fallback = ScalingGroup(
-            config_fallback,
-            platform_fallback,
-            scale_up_cooldown=Duration.from_ms(0),
-        )
+        group_primary = ScalingGroup(config_primary, platform_primary)
+        group_fallback = ScalingGroup(config_fallback, platform_fallback)
 
         config = config_pb2.AutoscalerConfig()
         config.evaluation_interval.CopyFrom(duration_to_proto(Duration.from_seconds(0.001)))
@@ -268,13 +257,15 @@ class TestAutoscalerWaterfallEndToEnd:
 
         demand = make_demand_entries(2, device_type=DeviceType.TPU, device_variant="v5p-8")
 
-        # First run: primary attempts scale-up, fails -> enters BACKOFF
-        autoscaler.run_once(demand, {})
-        autoscaler._wait_for_inflight()
+        # Drive enough failures on the primary group to push the churn detector
+        # past HOSTILE (3 samples → 100% short-lived).
+        for _ in range(3):
+            autoscaler.run_once(demand, {})
+            autoscaler._wait_for_inflight()
         assert group_primary.availability().status == GroupAvailability.BACKOFF
         assert group_primary.slice_count() == 0
 
-        # Second run: primary in BACKOFF -> demand cascades to fallback
+        # Next run: primary in BACKOFF -> demand cascades to fallback
         autoscaler.run_once(demand, {})
         autoscaler._wait_for_inflight()
         assert group_fallback.slice_count() >= 1
@@ -303,7 +294,6 @@ def test_bootstrap_state_with_worker_config():
     group = ScalingGroup(
         sg_config,
         platform,
-        scale_up_cooldown=Duration.from_ms(0),
     )
     autoscaler = Autoscaler(
         scale_groups={"test-group": group},
@@ -344,7 +334,6 @@ def test_no_bootstrap_without_worker_config():
     group = ScalingGroup(
         sg_config,
         platform,
-        scale_up_cooldown=Duration.from_ms(0),
     )
     autoscaler = Autoscaler(
         scale_groups={"test-group": group},
@@ -402,7 +391,6 @@ def test_pending_counter_prevents_double_scaleup():
     group = ScalingGroup(
         sg_config,
         platform,
-        scale_up_cooldown=Duration.from_ms(0),
     )
     autoscaler = Autoscaler(
         scale_groups={"test-group": group},
@@ -444,7 +432,7 @@ def test_incremental_demand_growth_triggers_scale_up():
     """Starting with small demand then adding more triggers appropriate multi-slice scale-up."""
     config = make_scale_group_config(name="test-group", max_slices=10, num_vms=1, priority=10)
     platform, service = make_gcp_provider(config)
-    group = ScalingGroup(config, platform, scale_up_cooldown=Duration.from_ms(0), scale_up_rate_limit=1000)
+    group = ScalingGroup(config, platform, scale_up_rate_limit=1000)
 
     as_config = config_pb2.AutoscalerConfig()
     as_config.evaluation_interval.CopyFrom(duration_to_proto(Duration.from_seconds(0.001)))
@@ -493,8 +481,12 @@ def test_incremental_demand_growth_triggers_scale_up():
 
 
 def test_marin_style_lifecycle():
-    """Full lifecycle with marin.yaml-style groups: 5 tiers of 2^N VMs per slice."""
-    COOLDOWN_MS = 1000
+    """Full lifecycle with marin.yaml-style groups: 5 tiers of 2^N VMs per slice.
+
+    With the churn detector replacing the old cooldown gate, demand fills
+    each priority tier to max_slices in a single tick before cascading to
+    the next tier — there's no per-tier cooldown intermission anymore.
+    """
 
     services: dict[str, InMemoryGcpService] = {}
     groups: dict[str, ScalingGroup] = {}
@@ -504,7 +496,7 @@ def test_marin_style_lifecycle():
         cfg = make_scale_group_config(name=name, max_slices=4, num_vms=num_vms, priority=priority)
         plat, svc = make_gcp_provider(cfg)
         services[name] = svc
-        groups[name] = ScalingGroup(cfg, plat, scale_up_cooldown=Duration.from_ms(COOLDOWN_MS))
+        groups[name] = ScalingGroup(cfg, plat)
 
     as_config = config_pb2.AutoscalerConfig()
     as_config.evaluation_interval.CopyFrom(duration_to_proto(Duration.from_seconds(0.001)))
@@ -532,35 +524,17 @@ def test_marin_style_lifecycle():
         assert routed("tpu-16vm") == 0, "tpu-16vm should never receive load"
         assert groups["tpu-16vm"].slice_count() == 0
 
-    # -- Phase 1: Fill tpu-1vm (highest priority) --
+    # -- Phase 1: Fill tpu-1vm to max in one go --
 
     t = Timestamp.from_ms(10_000)
-    autoscaler.run_once(make_demand(2), {}, timestamp=t)
-    autoscaler._wait_for_inflight()
-    assert groups["tpu-1vm"].slice_count() == 2
-    assert_no_load_on_last()
-
-    # Cycle 2: demand grows to 4, cooldown blocks scale-up
-    t = Timestamp.from_ms(10_500)
-    advance(t)
     autoscaler.run_once(make_demand(4), {}, timestamp=t)
     autoscaler._wait_for_inflight()
-    assert groups["tpu-1vm"].slice_count() == 2, "cooldown blocks scale-up"
-    assert routed("tpu-1vm") == 4, "demand stays in tpu-1vm during cooldown"
-    assert routed("tpu-2vm") == 0, "no cascade during cooldown"
-    assert_no_load_on_last()
-
-    # Cycle 3: cooldown expired -> tpu-1vm scales to max
-    t = Timestamp.from_ms(11_100)
-    advance(t)
-    autoscaler.run_once(make_demand(4), {}, timestamp=t)
-    autoscaler._wait_for_inflight()
-    assert groups["tpu-1vm"].slice_count() == 4, "tpu-1vm at max_slices"
+    assert groups["tpu-1vm"].slice_count() == 4, "tpu-1vm filled to max"
     assert_no_load_on_last()
 
     # -- Phase 2: tpu-1vm at max -> cascade fills tpu-2vm --
 
-    t = Timestamp.from_ms(12_200)
+    t = Timestamp.from_ms(11_000)
     advance(t)
     autoscaler.run_once(make_demand(8), {}, timestamp=t)
     autoscaler._wait_for_inflight()
@@ -569,36 +543,19 @@ def test_marin_style_lifecycle():
     assert groups["tpu-2vm"].slice_count() == 4, "tpu-2vm filled to max"
     assert_no_load_on_last()
 
-    # -- Phase 3: tpu-2vm at max -> cascade to tpu-4vm with cooldown --
+    # -- Phase 3: cascade fills tpu-4vm in one go --
 
-    t = Timestamp.from_ms(13_300)
-    advance(t)
-    autoscaler.run_once(make_demand(8), {}, timestamp=t)
-    autoscaler._wait_for_inflight()
-    assert groups["tpu-4vm"].slice_count() == 2
-    assert_no_load_on_last()
-
-    # Cycle 6: tpu-4vm in cooldown
-    t = Timestamp.from_ms(13_800)
-    advance(t)
-    autoscaler.run_once(make_demand(16), {}, timestamp=t)
-    autoscaler._wait_for_inflight()
-    assert groups["tpu-4vm"].slice_count() == 2, "cooldown blocks scale-up"
-    assert routed("tpu-4vm") == 16, "demand stays in tpu-4vm during cooldown"
-    assert routed("tpu-8vm") == 0, "no cascade to tpu-8vm during cooldown"
-    assert_no_load_on_last()
-
-    # Cycle 7: cooldown expired -> tpu-4vm scales to max
-    t = Timestamp.from_ms(14_400)
+    t = Timestamp.from_ms(12_000)
     advance(t)
     autoscaler.run_once(make_demand(16), {}, timestamp=t)
     autoscaler._wait_for_inflight()
     assert groups["tpu-4vm"].slice_count() == 4, "tpu-4vm at max_slices"
+    assert routed("tpu-4vm") == 16, "demand routed to tpu-4vm"
     assert_no_load_on_last()
 
     # -- Phase 4: cascade to tpu-8vm --
 
-    t = Timestamp.from_ms(15_500)
+    t = Timestamp.from_ms(13_000)
     advance(t)
     autoscaler.run_once(make_demand(28), {}, timestamp=t)
     autoscaler._wait_for_inflight()
@@ -632,7 +589,7 @@ class TestScaleUpRateLimiting:
         """With rate_limit=1, 5 decisions produce 1 scale_up + 1 aggregated rate_limited action (#5580)."""
         config = make_scale_group_config(name="test-group", max_slices=10, num_vms=1, priority=10)
         platform, _ = make_gcp_provider(config)
-        group = ScalingGroup(config, platform, scale_up_cooldown=Duration.from_ms(0), scale_up_rate_limit=1)
+        group = ScalingGroup(config, platform, scale_up_rate_limit=1)
 
         as_config = config_pb2.AutoscalerConfig()
         as_config.evaluation_interval.CopyFrom(duration_to_proto(Duration.from_seconds(0.001)))
@@ -667,7 +624,7 @@ class TestScaleUpRateLimiting:
         """Deferred decisions get served on subsequent evaluate+execute cycles as tokens refill."""
         config = make_scale_group_config(name="test-group", max_slices=10, num_vms=1, priority=10)
         platform, _ = make_gcp_provider(config)
-        group = ScalingGroup(config, platform, scale_up_cooldown=Duration.from_ms(0), scale_up_rate_limit=2)
+        group = ScalingGroup(config, platform, scale_up_rate_limit=2)
 
         as_config = config_pb2.AutoscalerConfig()
         as_config.evaluation_interval.CopyFrom(duration_to_proto(Duration.from_seconds(0.001)))
@@ -703,7 +660,7 @@ class TestScaleUpRateLimiting:
         """With a high rate limit, all decisions execute in one cycle."""
         config = make_scale_group_config(name="test-group", max_slices=10, num_vms=1, priority=10)
         platform, _ = make_gcp_provider(config)
-        group = ScalingGroup(config, platform, scale_up_cooldown=Duration.from_ms(0), scale_up_rate_limit=1000)
+        group = ScalingGroup(config, platform, scale_up_rate_limit=1000)
 
         as_config = config_pb2.AutoscalerConfig()
         as_config.evaluation_interval.CopyFrom(duration_to_proto(Duration.from_seconds(0.001)))

--- a/lib/iris/tests/cluster/controller/test_backoff_detector.py
+++ b/lib/iris/tests/cluster/controller/test_backoff_detector.py
@@ -176,19 +176,46 @@ def test_outcome_aging_uses_fate_at(detector: BackoffDetector) -> None:
     assert detector.health(now) == GroupHealth.CHURNING
 
 
-def test_long_lived_inflight_outcome_ages_out(detector: BackoffDetector) -> None:
-    """An in-flight outcome past long_lived_threshold should still get evicted
-    when the window expires from its created_at."""
+def test_long_lived_inflight_outcome_is_retained(detector: BackoffDetector) -> None:
+    """In-flight outcomes are kept past the window so the slice can be
+    correctly classified when it eventually terminates.
+
+    If we evicted them, a normal preemption of a long-lived survivor would
+    look like an "unknown slice died" (no record_created found), get a
+    synthetic ``created_at = terminated_at``, and be mis-classified as a
+    short-lived failure — inflating churn on healthy steady-state groups.
+    """
     detector.record_created("alive", ts(0))
-    # 31 minutes later: window from created_at is 30 min, so this should evict.
     now = ts(31 * 60)
-    # Force a GC by calling churn_rate.
-    _ = detector.churn_rate(now)
-    # No more records.
     detector.record_create_failed(now)
     detector.record_create_failed(now)
     detector.record_create_failed(now)
-    assert detector.churn_rate(now) == 1.0
+    # 1 LONG_LIVED (in-flight, aged past long_lived_threshold) + 3 BOOT_FAILED
+    # → 3/4 = 75% → CHURNING (not HOSTILE).
+    assert detector.churn_rate(now) == pytest.approx(3 / 4)
+    assert detector.health(now) == GroupHealth.CHURNING
+
+
+def test_long_lived_survivor_preemption_is_not_short_lived(
+    detector: BackoffDetector,
+) -> None:
+    """Regression: a slice that survived past the window and is then preempted
+    must still classify as LONG_LIVED, not as a fabricated short-lived event."""
+    detector.record_created("survivor", ts(0))
+    # Slice quietly survives for 45 minutes (past the 30-min window).
+    # Then GCP preempts it. With the old GC, the slice would have been evicted
+    # at age=30min and the termination record would fabricate created_at=now,
+    # classifying as PREEMPTED short-lived. With the corrected GC, the
+    # in-flight outcome is retained and the termination records age=45min
+    # → LONG_LIVED.
+    detector.record_terminated("survivor", SliceFate.PREEMPTED, ts(45 * 60))
+    now = ts(45 * 60 + 1)
+    # Need min_samples=3 to compute a rate; add two BOOT_FAILED.
+    detector.record_create_failed(now)
+    detector.record_create_failed(now)
+    # 1 LONG_LIVED + 2 BOOT_FAILED → 2/3 churn → CHURNING.
+    # Critically, the survivor was NOT counted as a failure.
+    assert detector.churn_rate(now) == pytest.approx(2 / 3)
 
 
 def test_record_terminated_long_lived_raises(detector: BackoffDetector) -> None:

--- a/lib/iris/tests/cluster/controller/test_backoff_detector.py
+++ b/lib/iris/tests/cluster/controller/test_backoff_detector.py
@@ -1,0 +1,325 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the in-memory churn detector."""
+
+from __future__ import annotations
+
+import pytest
+from iris.cluster.controller.autoscaler.backoff_detector import (
+    BackoffDetector,
+    GroupHealth,
+    SliceFate,
+)
+from rigging.timing import Duration, Timestamp
+
+
+def ts(seconds: float) -> Timestamp:
+    """Test-fixture helper: build a Timestamp from a seconds-since-epoch number."""
+    return Timestamp.from_ms(int(seconds * 1000))
+
+
+@pytest.fixture
+def detector() -> BackoffDetector:
+    return BackoffDetector(
+        group_name="test_group",
+        window=Duration.from_minutes(30),
+        short_lived_threshold=Duration.from_minutes(5),
+        long_lived_threshold=Duration.from_minutes(10),
+        min_samples=3,
+    )
+
+
+def test_empty_detector_is_healthy(detector: BackoffDetector) -> None:
+    now = ts(1000)
+    assert detector.churn_rate(now) == 0.0
+    assert detector.health(now) == GroupHealth.HEALTHY
+    assert detector.can_scale_up(now)
+    assert detector.scale_up_rate_multiplier(now) == 1.0
+    assert not detector.should_block_scale_down(now)
+    assert detector.recent_failure_count(now) == 0
+
+
+def test_below_min_samples_stays_healthy(detector: BackoffDetector) -> None:
+    """Even all-failure samples don't trigger backoff below min_samples (3)."""
+    detector.record_create_failed(ts(1000))
+    detector.record_create_failed(ts(1001))
+    assert detector.health(ts(1002)) == GroupHealth.HEALTHY
+    assert detector.churn_rate(ts(1002)) == 0.0
+
+
+def test_three_create_failures_hits_hostile(detector: BackoffDetector) -> None:
+    detector.record_create_failed(ts(1000))
+    detector.record_create_failed(ts(1001))
+    detector.record_create_failed(ts(1002))
+    assert detector.churn_rate(ts(1003)) == 1.0
+    assert detector.health(ts(1003)) == GroupHealth.HOSTILE
+    assert not detector.can_scale_up(ts(1003))
+    assert detector.scale_up_rate_multiplier(ts(1003)) == 0.0
+    assert detector.should_block_scale_down(ts(1003))
+
+
+def test_preempted_short_lived_counts_as_failure(detector: BackoffDetector) -> None:
+    """PREEMPTED with age < short_lived_threshold = failure."""
+    for i in range(3):
+        slice_id = f"s{i}"
+        detector.record_created(slice_id, ts(1000 + i))
+        # Dies 60s later — well under the 5-min short_lived threshold.
+        detector.record_terminated(slice_id, SliceFate.PREEMPTED, ts(1060 + i))
+    assert detector.churn_rate(ts(1100)) == 1.0
+    assert detector.health(ts(1100)) == GroupHealth.HOSTILE
+
+
+def test_preempted_long_lived_counts_as_success(detector: BackoffDetector) -> None:
+    """PREEMPTED with age >= short_lived_threshold = positive sample (survived the test)."""
+    for i in range(3):
+        slice_id = f"s{i}"
+        detector.record_created(slice_id, ts(1000 + i))
+        # Dies 6 min later (360s) — past the 5-min threshold.
+        detector.record_terminated(slice_id, SliceFate.PREEMPTED, ts(1360 + i))
+    assert detector.churn_rate(ts(1400)) == 0.0
+    assert detector.health(ts(1400)) == GroupHealth.HEALTHY
+
+
+def test_boot_failed_always_counts_as_failure(detector: BackoffDetector) -> None:
+    """BOOT_FAILED is failure regardless of age (slice never produced work)."""
+    for i in range(3):
+        slice_id = f"s{i}"
+        detector.record_created(slice_id, ts(1000))
+        # "Age" up to 10 min in record_terminated — still BOOT_FAILED.
+        detector.record_terminated(slice_id, SliceFate.BOOT_FAILED, ts(1600))
+    assert detector.churn_rate(ts(1700)) == 1.0
+    assert detector.health(ts(1700)) == GroupHealth.HOSTILE
+
+
+def test_inflight_long_enough_counts_as_long_lived(detector: BackoffDetector) -> None:
+    """In-flight slice aged past long_lived_threshold should count as positive."""
+    for i in range(3):
+        detector.record_created(f"s{i}", ts(1000 + i))
+    # 10 minutes later — past long_lived_threshold.
+    now = ts(1610)
+    assert detector.churn_rate(now) == 0.0
+    assert detector.health(now) == GroupHealth.HEALTHY
+
+
+def test_inflight_too_young_is_pending(detector: BackoffDetector) -> None:
+    """In-flight slice younger than long_lived_threshold doesn't contribute."""
+    for i in range(3):
+        detector.record_created(f"s{i}", ts(1000 + i))
+    # 30 seconds later — way too young.
+    now = ts(1030)
+    # All three samples are pending → classified count is 0 → below min_samples → HEALTHY.
+    assert detector.churn_rate(now) == 0.0
+    assert detector.health(now) == GroupHealth.HEALTHY
+
+
+def test_mixed_outcomes_compute_rate(detector: BackoffDetector) -> None:
+    """A mix of 2 failures + 3 successes should yield 2/5 = 40% churn → SUSPECT."""
+    # 2 short-lived preemptions
+    for i in range(2):
+        slice_id = f"bad{i}"
+        detector.record_created(slice_id, ts(1000 + i))
+        detector.record_terminated(slice_id, SliceFate.PREEMPTED, ts(1060 + i))
+    # 3 long-lived preemptions (survived past 5 min)
+    for i in range(3):
+        slice_id = f"good{i}"
+        detector.record_created(slice_id, ts(1000 + i))
+        detector.record_terminated(slice_id, SliceFate.PREEMPTED, ts(1500 + i))
+    now = ts(1600)
+    assert detector.churn_rate(now) == pytest.approx(2 / 5)
+    assert detector.health(now) == GroupHealth.SUSPECT
+    assert detector.scale_up_rate_multiplier(now) == 0.5
+
+
+def test_churning_threshold(detector: BackoffDetector) -> None:
+    """5 failures + 5 successes = 50% → CHURNING (boundary)."""
+    for i in range(5):
+        slice_id = f"bad{i}"
+        detector.record_created(slice_id, ts(1000 + i))
+        detector.record_terminated(slice_id, SliceFate.PREEMPTED, ts(1060 + i))
+    for i in range(5):
+        slice_id = f"good{i}"
+        detector.record_created(slice_id, ts(1000 + i))
+        detector.record_terminated(slice_id, SliceFate.PREEMPTED, ts(1500 + i))
+    now = ts(1600)
+    assert detector.churn_rate(now) == 0.5
+    assert detector.health(now) == GroupHealth.CHURNING
+    assert detector.scale_up_rate_multiplier(now) == 0.1
+    assert detector.can_scale_up(now)  # CHURNING still scales up, just slowly
+    assert detector.should_block_scale_down(now)
+
+
+def test_window_drops_old_outcomes(detector: BackoffDetector) -> None:
+    """Outcomes older than the 30-min window should be evicted."""
+    for i in range(3):
+        slice_id = f"old{i}"
+        detector.record_created(slice_id, ts(0))
+        detector.record_terminated(slice_id, SliceFate.PREEMPTED, ts(60))
+    # 31 minutes later — past the 30-min window from fate_at.
+    now = ts(60 + 31 * 60)
+    assert detector.churn_rate(now) == 0.0
+    assert detector.recent_failure_count(now) == 0
+
+
+def test_outcome_aging_uses_fate_at(detector: BackoffDetector) -> None:
+    """An old creation but recent fate_at should still be in-window."""
+    detector.record_created("s1", ts(0))
+    # Slice runs for 25 minutes, then gets preempted (short-lived case from
+    # the detector's perspective: age 25min, but PREEMPTED long-lived wins).
+    detector.record_terminated("s1", SliceFate.PREEMPTED, ts(25 * 60))
+    # 4 minutes after termination — well within the 30-min window from fate_at.
+    now = ts(25 * 60 + 4 * 60)
+    detector.record_create_failed(now)
+    detector.record_create_failed(now)
+    # Now we have: 1 LONG_LIVED + 2 BOOT_FAILED = 2/3 → CHURNING.
+    assert detector.churn_rate(now) == pytest.approx(2 / 3)
+    assert detector.health(now) == GroupHealth.CHURNING
+
+
+def test_long_lived_inflight_outcome_ages_out(detector: BackoffDetector) -> None:
+    """An in-flight outcome past long_lived_threshold should still get evicted
+    when the window expires from its created_at."""
+    detector.record_created("alive", ts(0))
+    # 31 minutes later: window from created_at is 30 min, so this should evict.
+    now = ts(31 * 60)
+    # Force a GC by calling churn_rate.
+    _ = detector.churn_rate(now)
+    # No more records.
+    detector.record_create_failed(now)
+    detector.record_create_failed(now)
+    detector.record_create_failed(now)
+    assert detector.churn_rate(now) == 1.0
+
+
+def test_record_terminated_long_lived_raises(detector: BackoffDetector) -> None:
+    with pytest.raises(ValueError, match="synthetic"):
+        detector.record_terminated("s1", SliceFate.LONG_LIVED, ts(1000))
+
+
+def test_record_created_is_idempotent(detector: BackoffDetector) -> None:
+    detector.record_created("s1", ts(1000))
+    detector.record_created("s1", ts(2000))  # second call ignored
+    detector.record_terminated("s1", SliceFate.PREEMPTED, ts(2060))
+    # The first record_created at ts=1000 stuck, so age = 2060 - 1000 = 1060s > 300s.
+    # Classifies as LONG_LIVED.
+    detector.record_create_failed(ts(2070))
+    detector.record_create_failed(ts(2070))
+    # 1 LONG_LIVED + 2 BOOT_FAILED = 2/3 churn → CHURNING.
+    assert detector.churn_rate(ts(2080)) == pytest.approx(2 / 3)
+
+
+def test_record_terminated_without_record_created(detector: BackoffDetector) -> None:
+    """Surprise termination (no prior record_created) should still count as a failure."""
+    detector.record_terminated("ghost1", SliceFate.PREEMPTED, ts(1000))
+    detector.record_terminated("ghost2", SliceFate.PREEMPTED, ts(1001))
+    detector.record_terminated("ghost3", SliceFate.PREEMPTED, ts(1002))
+    # created_at == terminated_at → age 0 → PREEMPTED short-lived → all bad.
+    assert detector.churn_rate(ts(1003)) == 1.0
+    assert detector.health(ts(1003)) == GroupHealth.HOSTILE
+
+
+def test_long_lived_threshold_below_short_lived_threshold_rejected() -> None:
+    with pytest.raises(ValueError, match="long_lived_threshold"):
+        BackoffDetector(
+            "g",
+            short_lived_threshold=Duration.from_minutes(10),
+            long_lived_threshold=Duration.from_minutes(5),
+        )
+
+
+def test_min_samples_below_one_rejected() -> None:
+    with pytest.raises(ValueError, match="min_samples"):
+        BackoffDetector("g", min_samples=0)
+
+
+def test_quota_blocks_scale_up_for_block_duration() -> None:
+    detector = BackoffDetector(
+        "g",
+        quota_block_duration=Duration.from_minutes(5),
+    )
+    detector.record_quota_exceeded("over v6e-256 quota", ts(1000))
+    # Inside the block window
+    inside = ts(1000 + 60)
+    assert not detector.can_scale_up(inside)
+    assert detector.scale_up_rate_multiplier(inside) == 0.0
+    assert detector.block_reason(inside) == "quota exceeded: over v6e-256 quota"
+    assert detector.quota_deadline(inside) is not None
+    # Past the block window
+    outside = ts(1000 + 5 * 60 + 1)
+    assert detector.can_scale_up(outside)
+    assert detector.scale_up_rate_multiplier(outside) == 1.0
+    assert detector.block_reason(outside) is None
+    assert detector.quota_deadline(outside) is None
+
+
+def test_quota_does_not_contribute_to_churn() -> None:
+    detector = BackoffDetector("g", min_samples=1)
+    detector.record_quota_exceeded("no quota", ts(1000))
+    # Recording quota should not affect churn rate.
+    assert detector.churn_rate(ts(1001)) == 0.0
+    assert detector.health(ts(1001)) == GroupHealth.HEALTHY
+
+
+def test_quota_blocks_even_when_churn_is_healthy() -> None:
+    detector = BackoffDetector("g")
+    detector.record_quota_exceeded("no quota", ts(1000))
+    inside = ts(1000 + 60)
+    assert detector.health(inside) == GroupHealth.HEALTHY
+    assert not detector.can_scale_up(inside)  # quota still blocks
+
+
+def test_quota_does_not_block_scale_down() -> None:
+    detector = BackoffDetector("g")
+    detector.record_quota_exceeded("no quota", ts(1000))
+    assert not detector.should_block_scale_down(ts(1060))
+
+
+def test_block_reason_prefers_quota_over_churn() -> None:
+    detector = BackoffDetector("g", min_samples=3)
+    for i in range(3):
+        detector.record_create_failed(ts(1000 + i))
+    detector.record_quota_exceeded("over quota", ts(1010))
+    inside = ts(1020)
+    # HOSTILE churn AND quota — quota reason wins for the reporting string.
+    assert detector.health(inside) == GroupHealth.HOSTILE
+    assert detector.block_reason(inside) == "quota exceeded: over quota"
+
+
+@pytest.mark.parametrize(
+    "rate,expected_health,expected_multiplier",
+    [
+        (0.0, GroupHealth.HEALTHY, 1.0),
+        (0.19, GroupHealth.HEALTHY, 1.0),
+        (0.20, GroupHealth.SUSPECT, 0.5),
+        (0.49, GroupHealth.SUSPECT, 0.5),
+        (0.50, GroupHealth.CHURNING, 0.1),
+        (0.79, GroupHealth.CHURNING, 0.1),
+        (0.80, GroupHealth.HOSTILE, 0.0),
+        (1.00, GroupHealth.HOSTILE, 0.0),
+    ],
+)
+def test_health_thresholds(rate: float, expected_health: GroupHealth, expected_multiplier: float) -> None:
+    """Synthesize outcomes to hit specific churn_rate values and verify mapping."""
+    # Need at least min_samples=3, and rate = bad/total. Pick total=100 so we can
+    # round-trip arbitrary rates to integer counts.
+    detector = BackoffDetector("g", min_samples=3)
+    total = 100
+    bad = round(rate * total)
+    good = total - bad
+    base_created = ts(0)
+    base_died_short = ts(60)  # 60s < short_lived 5min → counts as failure
+    base_died_long = ts(60 + 6 * 60)  # 6min+60s > short_lived → counts as success
+    # Choose ``now`` just past the latest fate_at so nothing has aged out of
+    # the 30-min window.
+    now = ts(base_died_long.epoch_ms() // 1000 + 10)
+    for i in range(bad):
+        slice_id = f"bad{i}"
+        detector.record_created(slice_id, base_created)
+        detector.record_terminated(slice_id, SliceFate.PREEMPTED, base_died_short)
+    for i in range(good):
+        slice_id = f"good{i}"
+        detector.record_created(slice_id, base_created)
+        detector.record_terminated(slice_id, SliceFate.PREEMPTED, base_died_long)
+    assert detector.churn_rate(now) == pytest.approx(rate, abs=0.005)
+    assert detector.health(now) == expected_health
+    assert detector.scale_up_rate_multiplier(now) == expected_multiplier

--- a/lib/iris/tests/cluster/controller/test_demand_routing.py
+++ b/lib/iris/tests/cluster/controller/test_demand_routing.py
@@ -265,8 +265,8 @@ class TestWaterfallRouting:
         config_high = make_scale_group_config(name="high-priority", max_slices=5, priority=10)
         config_low = make_scale_group_config(name="low-priority", max_slices=5, priority=20)
 
-        group_high = ScalingGroup(config_high, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
-        group_low = ScalingGroup(config_low, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        group_high = ScalingGroup(config_high, make_mock_platform())
+        group_low = ScalingGroup(config_low, make_mock_platform())
 
         demand = make_demand_entries(3, device_type=DeviceType.CPU, device_variant=None)
         result = route_demand([group_high, group_low], demand)
@@ -283,8 +283,8 @@ class TestWaterfallRouting:
             priority=20,
         )
 
-        group_high = ScalingGroup(config_high, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
-        group_low = ScalingGroup(config_low, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        group_high = ScalingGroup(config_high, make_mock_platform())
+        group_low = ScalingGroup(config_low, make_mock_platform())
 
         demand = make_demand_entries(2, device_type=DeviceType.CPU, device_variant=None)
         result = route_demand([group_high, group_low], demand)
@@ -302,7 +302,7 @@ class TestWaterfallRouting:
         group_high.reconcile()
         _mark_discovered_ready(group_high, discovered)
 
-        group_low = ScalingGroup(config_low, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        group_low = ScalingGroup(config_low, make_mock_platform())
 
         demand = make_demand_entries(3, device_type=DeviceType.CPU, device_variant=None)
         result = route_demand([group_high, group_low], demand)
@@ -317,8 +317,8 @@ class TestWaterfallRouting:
             name="v5lite-group", accelerator_variant="v5litepod-4", max_slices=5, priority=10
         )
 
-        group_v5p = ScalingGroup(config_v5p, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
-        group_v5lite = ScalingGroup(config_v5lite, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        group_v5p = ScalingGroup(config_v5p, make_mock_platform())
+        group_v5lite = ScalingGroup(config_v5lite, make_mock_platform())
 
         demand = make_demand_entries(2, device_type=DeviceType.TPU, device_variant="v5litepod-4")
         result = route_demand([group_v5p, group_v5lite], demand)
@@ -330,7 +330,7 @@ class TestWaterfallRouting:
         """Demand for unknown accelerator type results in unmet demand."""
         config = make_scale_group_config(name="test-group", max_slices=5, priority=10)
 
-        group = ScalingGroup(config, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        group = ScalingGroup(config, make_mock_platform())
 
         demand = make_demand_entries(2, device_type=DeviceType.TPU, device_variant="unknown-type")
         result = route_demand([group], demand)
@@ -344,8 +344,8 @@ class TestWaterfallRouting:
             name="v5lite-group", accelerator_variant="v5litepod-4", max_slices=5, priority=10
         )
 
-        group_v5p = ScalingGroup(config_v5p, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
-        group_v5lite = ScalingGroup(config_v5lite, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        group_v5p = ScalingGroup(config_v5p, make_mock_platform())
+        group_v5lite = ScalingGroup(config_v5lite, make_mock_platform())
 
         demand = [
             *make_demand_entries(1, device_type=DeviceType.TPU, device_variant="v5p-8", task_prefix="v5p"),
@@ -361,8 +361,8 @@ class TestWaterfallRouting:
         config_v4 = make_scale_group_config(name="v4-group", accelerator_variant="v4-8", max_slices=5, priority=10)
         config_v5p = make_scale_group_config(name="v5p-group", accelerator_variant="v5p-8", max_slices=5, priority=20)
 
-        group_v4 = ScalingGroup(config_v4, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
-        group_v5p = ScalingGroup(config_v5p, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        group_v4 = ScalingGroup(config_v4, make_mock_platform())
+        group_v5p = ScalingGroup(config_v5p, make_mock_platform())
 
         # Demand accepts either v4-8 or v5p-8; should route to v4-group (higher priority)
         demand = make_demand_entries(2, device_type=DeviceType.TPU, device_variants=frozenset({"v4-8", "v5p-8"}))
@@ -374,7 +374,7 @@ class TestWaterfallRouting:
         """Flexible demand with no matching groups is unmet."""
         config_v4 = make_scale_group_config(name="v4-group", accelerator_variant="v4-8", max_slices=5, priority=10)
 
-        group_v4 = ScalingGroup(config_v4, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        group_v4 = ScalingGroup(config_v4, make_mock_platform())
 
         # Demand requires v5p-8 or v5litepod-4, but only v4-8 group exists
         demand = make_demand_entries(1, device_type=DeviceType.TPU, device_variants=frozenset({"v5p-8", "v5litepod-4"}))
@@ -388,20 +388,12 @@ class TestWaterfallRouting:
         config_primary = make_scale_group_config(name="primary", max_slices=5, priority=10)
         config_fallback = make_scale_group_config(name="fallback", max_slices=5, priority=20)
 
-        group_primary = ScalingGroup(
-            config_primary,
-            make_mock_platform(),
-            scale_up_cooldown=Duration.from_ms(0),
-            backoff_initial=Duration.from_seconds(60),
-        )
-        group_fallback = ScalingGroup(
-            config_fallback,
-            make_mock_platform(),
-            scale_up_cooldown=Duration.from_ms(0),
-        )
+        group_primary = ScalingGroup(config_primary, make_mock_platform())
+        group_fallback = ScalingGroup(config_fallback, make_mock_platform())
 
         ts = Timestamp.from_ms(1000)
-        group_primary.record_failure(timestamp=ts)
+        for _ in range(3):
+            group_primary.record_create_failed(timestamp=ts)
         assert group_primary.availability(ts).status == GroupAvailability.BACKOFF
 
         demand = make_demand_entries(2, device_type=DeviceType.CPU, device_variant=None)
@@ -410,7 +402,7 @@ class TestWaterfallRouting:
         assert len(result.routed_entries.get("fallback", [])) == 2
         status_by_group = {s.group: s for s in result.group_statuses}
         assert status_by_group["primary"].decision == "blocked"
-        assert "consecutive failure" in status_by_group["primary"].reason
+        assert "churn" in status_by_group["primary"].reason
         assert status_by_group["fallback"].decision == "selected"
 
     def test_backoff_group_with_ready_slices_still_falls_through(self):
@@ -421,21 +413,13 @@ class TestWaterfallRouting:
         config_primary = make_scale_group_config(name="primary", max_slices=5, priority=10)
         config_fallback = make_scale_group_config(name="fallback", max_slices=5, priority=20)
 
-        group_primary = ScalingGroup(
-            config_primary,
-            make_mock_platform(slices_to_discover=discovered),
-            scale_up_cooldown=Duration.from_ms(0),
-            backoff_initial=Duration.from_seconds(60),
-        )
+        group_primary = ScalingGroup(config_primary, make_mock_platform(slices_to_discover=discovered))
         group_primary.reconcile()
-        group_fallback = ScalingGroup(
-            config_fallback,
-            make_mock_platform(),
-            scale_up_cooldown=Duration.from_ms(0),
-        )
+        group_fallback = ScalingGroup(config_fallback, make_mock_platform())
 
         ts = Timestamp.from_ms(1000)
-        group_primary.record_failure(timestamp=ts)
+        for _ in range(3):
+            group_primary.record_create_failed(timestamp=ts)
         assert group_primary.availability(ts).status == GroupAvailability.BACKOFF
         assert group_primary.slice_count() == 1
 
@@ -444,23 +428,14 @@ class TestWaterfallRouting:
 
         assert len(result.routed_entries.get("fallback", [])) == 2
 
-    def test_cooldown_does_not_cause_fallthrough(self):
-        """Groups in COOLDOWN still accept demand -- demand does not fall through."""
-        from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability
+    def test_recent_scale_up_does_not_cause_fallthrough(self):
+        """A group that recently scaled up still accepts demand — no cooldown gate."""
 
         config_a = make_scale_group_config(name="group-a", max_slices=5, priority=10)
         config_b = make_scale_group_config(name="group-b", max_slices=5, priority=20)
 
-        group_a = ScalingGroup(
-            config_a,
-            make_mock_platform(),
-            scale_up_cooldown=Duration.from_ms(60_000),
-        )
-        group_b = ScalingGroup(
-            config_b,
-            make_mock_platform(),
-            scale_up_cooldown=Duration.from_ms(0),
-        )
+        group_a = ScalingGroup(config_a, make_mock_platform())
+        group_b = ScalingGroup(config_b, make_mock_platform())
 
         ts = Timestamp.from_ms(1_000_000)
         group_a.begin_scale_up(timestamp=ts)
@@ -468,7 +443,7 @@ class TestWaterfallRouting:
         group_a.complete_scale_up(handle, ts)
 
         eval_ts = Timestamp.from_ms(1_030_000)
-        assert group_a.availability(eval_ts).status == GroupAvailability.COOLDOWN
+        assert group_a.can_accept_demand(eval_ts)
 
         demand = make_demand_entries(2, device_type=DeviceType.CPU, device_variant=None)
         result = route_demand([group_a, group_b], demand, eval_ts)
@@ -492,7 +467,6 @@ class TestWaterfallRouting:
         group_b = ScalingGroup(
             config_b,
             make_mock_platform(),
-            scale_up_cooldown=Duration.from_ms(0),
         )
 
         demand = make_demand_entries(2, device_type=DeviceType.CPU, device_variant=None)
@@ -527,15 +501,15 @@ class TestWaterfallRouting:
 
         # Zone 0: has 1 booting slice (scale-up happened, slice created but not ready)
         handle_0 = make_mock_slice_handle("slice-zone-0", all_ready=False)
-        group_0 = ScalingGroup(configs[0], make_mock_platform(), scale_up_cooldown=Duration.from_ms(60_000))
+        group_0 = ScalingGroup(configs[0], make_mock_platform())
         group_0.begin_scale_up(timestamp=ts)
         group_0.complete_scale_up(handle_0, timestamp=ts)
         # Slice is BOOTING, not READY. Group is at max_slices.
         assert group_0.slice_count() == 1
 
         # Zone 1 and 2: empty, ready to accept
-        group_1 = ScalingGroup(configs[1], make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
-        group_2 = ScalingGroup(configs[2], make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        group_1 = ScalingGroup(configs[1], make_mock_platform())
+        group_2 = ScalingGroup(configs[2], make_mock_platform())
 
         groups = [group_0, group_1, group_2]
         demand = make_demand_entries(1, device_type=DeviceType.CPU, device_variant=None)
@@ -836,8 +810,8 @@ class TestCommittedBudgetRouting:
 
         platform_v6e = make_mock_platform()
         platform_v5e = make_mock_platform()
-        group_v6e = ScalingGroup(config_v6e, platform_v6e, scale_up_cooldown=Duration.from_ms(0))
-        group_v5e = ScalingGroup(config_v5e, platform_v5e, scale_up_cooldown=Duration.from_ms(0))
+        group_v6e = ScalingGroup(config_v6e, platform_v6e)
+        group_v5e = ScalingGroup(config_v5e, platform_v5e)
 
         # v6e has 3 requesting slices
         for _ in range(3):
@@ -869,8 +843,8 @@ class TestCommittedBudgetRouting:
         config_v5e = make_scale_group_config(name="v5e", max_slices=10, priority=10, num_vms=1)
         config_v5e.resources.CopyFrom(small_resources)
 
-        group_v6e = ScalingGroup(config_v6e, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
-        group_v5e = ScalingGroup(config_v5e, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        group_v6e = ScalingGroup(config_v6e, make_mock_platform())
+        group_v5e = ScalingGroup(config_v5e, make_mock_platform())
 
         # v6e has 1 requesting slice -> committed budget = 1 VM, full budget = 2 VMs
         group_v6e.begin_scale_up()
@@ -890,8 +864,8 @@ class TestCommittedBudgetRouting:
         config_a = make_scale_group_config(name="group-a", max_slices=5, priority=10)
         config_b = make_scale_group_config(name="group-b", max_slices=5, priority=20)
 
-        group_a = ScalingGroup(config_a, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
-        group_b = ScalingGroup(config_b, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        group_a = ScalingGroup(config_a, make_mock_platform())
+        group_b = ScalingGroup(config_b, make_mock_platform())
 
         ts = Timestamp.now()
         demand = make_demand_entries(3, device_type=DeviceType.TPU, device_variant="v5p-8")
@@ -922,7 +896,6 @@ class TestPackingRouting:
         group = ScalingGroup(
             config,
             make_mock_platform(),
-            scale_up_cooldown=Duration.from_ms(0),
         )
 
         entries = _make_big_demand_entries(
@@ -954,12 +927,10 @@ class TestPackingRouting:
         group_a = ScalingGroup(
             config_a,
             make_mock_platform(),
-            scale_up_cooldown=Duration.from_ms(0),
         )
         group_b = ScalingGroup(
             config_b,
             make_mock_platform(),
-            scale_up_cooldown=Duration.from_ms(0),
         )
 
         # 8 entries at 32GiB each -> 2 VMs needed -> ceil(2/4) = 1 slice.
@@ -986,7 +957,6 @@ class TestPackingRouting:
         group = ScalingGroup(
             config,
             make_mock_platform(),
-            scale_up_cooldown=Duration.from_ms(0),
         )
 
         # 16 entries at 32GiB -> 4 VMs -> ceil(4/4) = 1 slice.
@@ -1012,7 +982,6 @@ class TestPackingRouting:
         group = ScalingGroup(
             config,
             make_mock_platform(slices_to_discover=discovered),
-            scale_up_cooldown=Duration.from_ms(0),
         )
         group.reconcile()
         _mark_discovered_ready(group, discovered)
@@ -1062,7 +1031,7 @@ class TestRoutingBinPacking:
         config.resources.CopyFrom(resources)
         config.num_vms = kwargs.pop("num_vms", 1)
         config.slice_template.gcp.zone = "us-central1-a"
-        return ScalingGroup(config, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        return ScalingGroup(config, make_mock_platform())
 
     def _make_entries(self, count: int, memory_bytes: int = 32 * 1024**3) -> list[DemandEntry]:
         resources = job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=memory_bytes)
@@ -1147,7 +1116,7 @@ class TestRoutingBinPacking:
         )
         config.resources.CopyFrom(DEFAULT_RESOURCES)
         config.slice_template.gcp.zone = "us-central1-a"
-        group = ScalingGroup(config, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        group = ScalingGroup(config, make_mock_platform())
 
         resources = job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024)
         normalized = PlacementRequirements(
@@ -1189,7 +1158,7 @@ class TestRoutingBinPacking:
         )
         config.resources.CopyFrom(DEFAULT_RESOURCES)
         config.slice_template.gcp.zone = "us-central1-a"
-        group = ScalingGroup(config, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        group = ScalingGroup(config, make_mock_platform())
 
         resources = job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024)
         normalized = PlacementRequirements(
@@ -1446,7 +1415,7 @@ class TestAllocationTierBlocking:
             )
             config.quota_pool = pool
             config.allocation_tier = tier
-            group = ScalingGroup(config, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+            group = ScalingGroup(config, make_mock_platform())
             groups.append(group)
         return groups
 
@@ -1528,7 +1497,7 @@ class TestAllocationTierBlocking:
         unpooled_config = make_scale_group_config(
             name="standalone", max_slices=10, priority=50, accelerator_variant="v5p-8"
         )
-        unpooled = ScalingGroup(unpooled_config, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        unpooled = ScalingGroup(unpooled_config, make_mock_platform())
 
         entries = make_demand_entries(1, device_variant="v5p-8")
         result = route_demand([*pooled, unpooled], entries, timestamp=Timestamp.from_ms(1100))
@@ -1540,12 +1509,12 @@ class TestAllocationTierBlocking:
         g1_config = make_scale_group_config(name="zone-a", max_slices=10, priority=10, accelerator_variant="v5p-8")
         g1_config.quota_pool = "v5p"
         g1_config.allocation_tier = 1
-        g1 = ScalingGroup(g1_config, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        g1 = ScalingGroup(g1_config, make_mock_platform())
 
         g2_config = make_scale_group_config(name="zone-b", max_slices=10, priority=10, accelerator_variant="v5p-8")
         g2_config.quota_pool = "v5p"
         g2_config.allocation_tier = 1
-        g2 = ScalingGroup(g2_config, make_mock_platform(), scale_up_cooldown=Duration.from_ms(0))
+        g2 = ScalingGroup(g2_config, make_mock_platform())
 
         ts = Timestamp.from_ms(1000)
 

--- a/lib/iris/tests/cluster/providers/test_scaling_group.py
+++ b/lib/iris/tests/cluster/providers/test_scaling_group.py
@@ -11,6 +11,7 @@ import logging
 from pathlib import Path
 
 import pytest
+from iris.cluster.controller.autoscaler.backoff_detector import SliceFate
 from iris.cluster.controller.autoscaler.scaling_group import (
     ScalingGroup,
     SliceLifecycleState,
@@ -277,35 +278,15 @@ class TestScalingGroupScalingPolicy:
         assert group.slice_count() == 5  # max_slices
         assert not group.can_scale_up()
 
-    def test_cannot_scale_up_during_backoff(self, unbounded_config: config_pb2.ScaleGroupConfig):
-        """can_scale_up() returns False during backoff period."""
+    def test_cannot_scale_up_when_detector_hostile(self, unbounded_config: config_pb2.ScaleGroupConfig):
+        """can_scale_up() returns False when the churn detector is HOSTILE."""
         platform = make_mock_platform()
-        group = ScalingGroup(unbounded_config, platform, backoff_initial=Duration.from_seconds(5.0))
-
-        ts = Timestamp.from_ms(1000000)
-        group.record_failure(timestamp=ts)
-
-        # During backoff period
-        assert not group.can_scale_up(timestamp=Timestamp.from_ms(1001000))
-        # After backoff expires (5s = 5000ms)
-        assert group.can_scale_up(timestamp=Timestamp.from_ms(1006000))
-
-    def test_cannot_scale_up_during_cooldown(self, unbounded_config: config_pb2.ScaleGroupConfig):
-        """can_scale_up() returns False during cooldown period after scale-up."""
-        platform = make_mock_platform()
-        group = ScalingGroup(
-            unbounded_config,
-            platform,
-            scale_up_cooldown=Duration.from_ms(10000),
-        )
-
-        ts = Timestamp.from_ms(1000000)
-        _tracked_scale_up(group, timestamp=ts)
-
-        # During cooldown
-        assert not group.can_scale_up(timestamp=Timestamp.from_ms(1005000))
-        # After cooldown expires
-        assert group.can_scale_up(timestamp=Timestamp.from_ms(1015000))
+        group = ScalingGroup(unbounded_config, platform)
+        ts = Timestamp.from_ms(1_000_000)
+        # Three create-failures in the window pushes churn to 100% → HOSTILE.
+        for _ in range(3):
+            group.record_create_failed(timestamp=ts)
+        assert not group.can_scale_up(timestamp=Timestamp.from_ms(1_001_000))
 
     def test_scale_down_rate_limited_by_token_bucket(self, unbounded_config: config_pb2.ScaleGroupConfig):
         """acquire_scale_down_token() returns False when the token bucket is exhausted."""
@@ -326,77 +307,40 @@ class TestScalingGroupScalingPolicy:
         assert group.acquire_scale_down_token(Timestamp.from_ms(ts.epoch_ms() + 61_000))
 
 
-class TestScalingGroupBackoff:
-    """Tests for exponential backoff behavior."""
+class TestScalingGroupChurnDetector:
+    """Tests for ScalingGroup's integration with BackoffDetector.
 
-    def test_record_failure_applies_initial_backoff(self, unbounded_config: config_pb2.ScaleGroupConfig):
-        """First failure applies initial backoff duration."""
-        platform = make_mock_platform()
-        group = ScalingGroup(
-            unbounded_config,
-            platform,
-            backoff_initial=Duration.from_seconds(5.0),
-        )
+    Detailed unit tests of the detector itself live in
+    ``tests/cluster/controller/test_backoff_detector.py``. These tests verify
+    that ScalingGroup wires the detector correctly into its scale-up gating.
+    """
 
-        ts = Timestamp.from_ms(1000000)
-        group.record_failure(timestamp=ts)
-
-        assert group.consecutive_failures == 1
-        assert group._backoff_until is not None
-        assert group._backoff_until.as_timestamp().epoch_ms() == 1005000
-
-    def test_record_failure_applies_exponential_backoff(self, unbounded_config: config_pb2.ScaleGroupConfig):
-        """Consecutive failures double the backoff time."""
-        platform = make_mock_platform()
-        group = ScalingGroup(
-            unbounded_config,
-            platform,
-            backoff_initial=Duration.from_seconds(5.0),
-            backoff_factor=2.0,
-        )
-
-        ts = Timestamp.from_ms(1000000)
-        group.record_failure(timestamp=ts)  # 5000ms
-        group.record_failure(timestamp=ts)  # 10000ms
-        group.record_failure(timestamp=ts)  # 20000ms
-
-        assert group.consecutive_failures == 3
-        assert group._backoff_until is not None
-        assert group._backoff_until.as_timestamp().epoch_ms() == 1020000
-
-    def test_backoff_capped_at_maximum(self, unbounded_config: config_pb2.ScaleGroupConfig):
-        """Backoff duration is capped at max value."""
-        platform = make_mock_platform()
-        group = ScalingGroup(
-            unbounded_config,
-            platform,
-            backoff_initial=Duration.from_seconds(5.0),
-            backoff_max=Duration.from_seconds(15.0),
-            backoff_factor=2.0,
-        )
-
-        ts = Timestamp.from_ms(1000000)
-        for _ in range(10):  # Many failures
-            group.record_failure(timestamp=ts)
-
-        # Should be capped at max
-        assert group._backoff_until is not None
-        assert group._backoff_until.as_timestamp().epoch_ms() == 1015000
-
-    def test_scale_up_resets_backoff(self, unbounded_config: config_pb2.ScaleGroupConfig):
-        """Successful scale-up via complete_scale_up resets backoff state."""
+    def test_create_failures_drive_detector_hostile(self, unbounded_config: config_pb2.ScaleGroupConfig):
+        """Three create-failures push the detector to HOSTILE, blocking scale-up."""
         platform = make_mock_platform()
         group = ScalingGroup(unbounded_config, platform)
+        ts = Timestamp.from_ms(1_000_000)
+        for _ in range(3):
+            group.record_create_failed(timestamp=ts)
+        assert group.recent_failure_count(Timestamp.from_ms(1_001_000)) == 3
+        assert not group.can_scale_up(timestamp=Timestamp.from_ms(1_001_000))
 
-        ts = Timestamp.from_ms(1000000)
-        group.record_failure(timestamp=ts)
-        group.record_failure(timestamp=ts)
-        assert group.consecutive_failures == 2
-
-        _tracked_scale_up(group, timestamp=Timestamp.from_ms(1100000))
-
-        assert group.consecutive_failures == 0
-        assert group._backoff_until is None
+    def test_long_lived_preemption_does_not_block_scale_up(self, unbounded_config: config_pb2.ScaleGroupConfig):
+        """A slice preempted past short_lived threshold is a positive sample."""
+        platform = make_mock_platform()
+        group = ScalingGroup(unbounded_config, platform)
+        create_ts = Timestamp.from_ms(1_000_000)
+        # Three slices created and "preempted" 6 minutes later (past 5-min threshold).
+        for i in range(3):
+            slice_id = f"s{i}"
+            group.detector.record_created(slice_id, create_ts)
+            group.detector.record_terminated(
+                slice_id,
+                SliceFate.PREEMPTED,
+                Timestamp.from_ms(1_000_000 + 6 * 60 * 1000),
+            )
+        now = Timestamp.from_ms(1_000_000 + 7 * 60 * 1000)
+        assert group.can_scale_up(timestamp=now)
 
 
 class TestScalingGroupDemandTracking:
@@ -777,18 +721,18 @@ class TestScalingGroupAvailability:
         state = group.availability()
         assert state.status == GroupAvailability.AT_MAX_SLICES
 
-    def test_backoff_when_in_backoff_period(self, unbounded_config: config_pb2.ScaleGroupConfig):
-        """Group is in BACKOFF when backoff timer is active."""
+    def test_backoff_when_detector_hostile(self, unbounded_config: config_pb2.ScaleGroupConfig):
+        """Group is in BACKOFF when the churn detector is HOSTILE."""
         from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability
 
         platform = make_mock_platform()
-        group = ScalingGroup(unbounded_config, platform, backoff_initial=Duration.from_seconds(60.0))
+        group = ScalingGroup(unbounded_config, platform)
         ts = Timestamp.from_ms(1000000)
-        group.record_failure(timestamp=ts)
+        for _ in range(3):
+            group.record_create_failed(timestamp=ts)
 
-        state = group.availability(Timestamp.from_ms(1001000))  # Still in backoff
+        state = group.availability(Timestamp.from_ms(1001000))
         assert state.status == GroupAvailability.BACKOFF
-        assert state.until is not None
 
     def test_can_accept_demand_true_when_available(self, unbounded_config: config_pb2.ScaleGroupConfig):
         """can_accept_demand() returns True when AVAILABLE."""
@@ -866,32 +810,23 @@ class TestScalingGroupAvailability:
         group.complete_scale_up(handle, ts2)
         assert group.can_accept_demand(timestamp=Timestamp.from_ms(4000))
 
-    def test_quota_exceeded_takes_precedence_over_backoff(self, unbounded_config: config_pb2.ScaleGroupConfig):
-        """Quota exceeded has higher precedence than backoff."""
+    def test_quota_exceeded_takes_precedence_over_churn_backoff(self, unbounded_config: config_pb2.ScaleGroupConfig):
+        """Quota exceeded reports as QUOTA_EXCEEDED even if churn is HOSTILE."""
         from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability
 
         platform = make_mock_platform()
-        platform.create_slice.side_effect = QuotaExhaustedError("Quota exhausted")
-
         group = ScalingGroup(unbounded_config, platform, quota_timeout=Duration.from_ms(60_000))
 
         ts = Timestamp.from_ms(1000)
-        # Record a failure to trigger backoff
-        group.record_failure(timestamp=ts)
-
-        # Then trigger quota exceeded via failed scale-up
-        group.begin_scale_up(timestamp=ts)
-        with pytest.raises(QuotaExhaustedError):
-            group.scale_up(timestamp=ts)
-        group.cancel_scale_up()
+        for _ in range(3):
+            group.record_create_failed(timestamp=ts)  # detector → HOSTILE
         group.record_quota_exceeded("quota exceeded", ts)
 
-        # Availability should report QUOTA_EXCEEDED, not BACKOFF
         state = group.availability(timestamp=Timestamp.from_ms(2000))
         assert state.status == GroupAvailability.QUOTA_EXCEEDED
 
-    def test_cooldown_availability_state(self):
-        """After scale-up + complete, availability() returns COOLDOWN until expiry, then AVAILABLE."""
+    def test_available_immediately_after_scale_up(self):
+        """After complete_scale_up, the group is AVAILABLE (no cooldown gate)."""
         from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability
 
         config = _with_resources(
@@ -903,46 +838,18 @@ class TestScalingGroupAvailability:
         )
         config.slice_template.gcp.zone = "us-central1-a"
         platform = make_mock_platform()
-        group = ScalingGroup(config, platform, scale_up_cooldown=Duration.from_ms(5000))
+        group = ScalingGroup(config, platform)
 
         ts = Timestamp.from_ms(1_000_000)
         group.begin_scale_up(timestamp=ts)
         handle = group.scale_up(timestamp=ts)
         group.complete_scale_up(handle, ts)
 
-        # During cooldown
-        state = group.availability(Timestamp.from_ms(1_003_000))
-        assert state.status == GroupAvailability.COOLDOWN
-        assert state.until is not None
-
-        # After cooldown expires
-        state = group.availability(Timestamp.from_ms(1_006_000))
+        state = group.availability(Timestamp.from_ms(1_001_000))
         assert state.status == GroupAvailability.AVAILABLE
 
-    def test_cooldown_accepts_demand(self):
-        """COOLDOWN groups still accept demand (demand stays, scale-up is deferred)."""
-        config = _with_resources(
-            config_pb2.ScaleGroupConfig(
-                name="test-group",
-                buffer_slices=0,
-                max_slices=10,
-            ),
-        )
-        config.slice_template.gcp.zone = "us-central1-a"
-        platform = make_mock_platform()
-        group = ScalingGroup(config, platform, scale_up_cooldown=Duration.from_ms(5000))
-
-        ts = Timestamp.from_ms(1_000_000)
-        group.begin_scale_up(timestamp=ts)
-        handle = group.scale_up(timestamp=ts)
-        group.complete_scale_up(handle, ts)
-
-        # During cooldown, can_accept_demand should be True
-        assert group.can_accept_demand(Timestamp.from_ms(1_003_000)) is True
-
-    def test_at_max_slices_takes_precedence_over_cooldown(self):
-        """When both at max_slices and in cooldown, AT_MAX_SLICES takes precedence
-        (once all slices are READY)."""
+    def test_at_max_slices_with_inflight_capacity_accepts_demand(self):
+        """At max_slices but with in-flight booting capacity → COOLDOWN (accepts demand)."""
         from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability
 
         config = _with_resources(
@@ -954,14 +861,14 @@ class TestScalingGroupAvailability:
         )
         config.slice_template.gcp.zone = "us-central1-a"
         platform = make_mock_platform()
-        group = ScalingGroup(config, platform, scale_up_cooldown=Duration.from_ms(5000))
+        group = ScalingGroup(config, platform)
 
         ts = Timestamp.from_ms(1_000_000)
         group.begin_scale_up(timestamp=ts)
         handle = group.scale_up(timestamp=ts)
         group.complete_scale_up(handle, ts)
 
-        # While slice is BOOTING, group accepts demand (in-flight capacity)
+        # Slice is at max_slices but still BOOTING — accepts demand.
         state = group.availability(Timestamp.from_ms(1_003_000))
         assert state.status == GroupAvailability.COOLDOWN
 
@@ -1067,9 +974,7 @@ class TestCanScaleUpQuotaExhausted:
         platform = make_mock_platform()
         platform.create_slice.side_effect = QuotaExhaustedError("no quota")
 
-        group = ScalingGroup(
-            unbounded_config, platform, quota_timeout=Duration.from_ms(5000), scale_up_cooldown=Duration.from_ms(0)
-        )
+        group = ScalingGroup(unbounded_config, platform, quota_timeout=Duration.from_ms(5000))
 
         ts = Timestamp.from_ms(1000000)
         group.begin_scale_up(timestamp=ts)

--- a/lib/iris/tests/cluster/test_snapshot_reconciliation.py
+++ b/lib/iris/tests/cluster/test_snapshot_reconciliation.py
@@ -387,61 +387,18 @@ def test_restore_empty_checkpoint_empty_cloud():
 # =============================================================================
 
 
-def test_restore_preserves_backoff_state():
-    """Backoff timers survive checkpoint/restore."""
-    # Set backoff_until to 5 minutes in the future
-    backoff_ms = Timestamp.now().epoch_ms() + 300_000
-    snapshot = GroupSnapshot(
-        name="tpu-group",
-        consecutive_failures=3,
-        backoff_until_ms=backoff_ms,
-    )
+def test_restore_does_not_carry_backoff_state():
+    """Backoff/churn state lives in-memory only; restore starts fresh.
 
+    Slices are still adopted from the checkpoint, but the churn detector's
+    sample window begins empty after a controller restart. This lets the
+    detector re-discover hostility through real observed behaviour rather
+    than persisting potentially-stale counters across restarts.
+    """
+    snapshot = GroupSnapshot(name="tpu-group")
     result = restore_scaling_group(
         group_snapshot=snapshot,
         cloud_handles=[],
         label_prefix="test",
     )
-
-    assert result.consecutive_failures == 3
-    assert result.backoff_active
-
-
-def test_restore_expired_backoff_is_inactive():
-    """Backoff that expired during the restart window is correctly inactive."""
-    # Set backoff_until to 1 minute in the past
-    backoff_ms = Timestamp.now().epoch_ms() - 60_000
-    snapshot = GroupSnapshot(
-        name="tpu-group",
-        consecutive_failures=2,
-        backoff_until_ms=backoff_ms,
-    )
-
-    result = restore_scaling_group(
-        group_snapshot=snapshot,
-        cloud_handles=[],
-        label_prefix="test",
-    )
-
-    assert result.consecutive_failures == 2
-    assert not result.backoff_active
-
-
-def test_restore_preserves_quota_exceeded_state():
-    """Quota exceeded state and reason survive restore."""
-    # Set quota_exceeded_until to 5 minutes in the future
-    quota_ms = Timestamp.now().epoch_ms() + 300_000
-    snapshot = GroupSnapshot(
-        name="tpu-group",
-        quota_reason="RESOURCE_EXHAUSTED: out of v5 TPUs in us-central2",
-        quota_exceeded_until_ms=quota_ms,
-    )
-
-    result = restore_scaling_group(
-        group_snapshot=snapshot,
-        cloud_handles=[],
-        label_prefix="test",
-    )
-
-    assert result.quota_exceeded_active
-    assert "v5 TPUs" in result.quota_reason
+    assert result.slices == {}


### PR DESCRIPTION
Old design treated every short-lived slice death as a fault that earned the group an escalating timeout, producing a capacity-pit sawtooth on preemptible TPU zones. Replace with a per-group BackoffDetector that tracks recent slice outcomes over a window and exposes graduated health (HEALTHY / SUSPECT / CHURNING / HOSTILE), so isolated preemptions stay noise while real churn stops feeding user work in. Folds quota-exhausted gating into the detector and drops the per-group scale_up_cooldown and DB-persisted backoff state.