### PR TITLE
datakit: sweep `.tmp.<uuid>` orphans after each leaf finalize

### DIFF
--- a/scripts/datakit/sync_datakit.py
+++ b/scripts/datakit/sync_datakit.py
@@ -36,6 +36,10 @@ For each source, this script builds a single :class:`StepSpec`. The step's
   marker as a single follow-up op. Its presence on dst is what whole-source
   skip keys off — re-runs of an already-synced source short-circuit before
   any StepSpec is even built.
+* Finally, sweeps any ``.tmp.<uuid.hex>`` orphans under the dst leaf —
+  leftovers from prior interrupted ``atomic_rename`` runs (ours or
+  upstream). They're never legitimate content; deleting them after the
+  marker lands keeps the dst byte-identical to src.
 
 Per-shard JSONL and per-source executor status all live under
 ``status_prefix`` (default ``gs://marin-us-central1/data/datakit/sync``)
@@ -305,6 +309,26 @@ def _leaf_already_synced(dst_dir: str) -> bool:
     return fs.exists(dst)
 
 
+def _remove_tmp_orphans(dst_dir: str) -> None:
+    """Delete ``.tmp.<uuid.hex>`` orphans anywhere under ``dst_dir``.
+
+    Runs once per leaf after ``.executor_status`` is published. The orphans
+    are interrupted ``atomic_rename`` writes from earlier runs (ours or
+    other producers); they never become legitimate content, and leaving
+    them around would make a byte-for-byte src/dst comparison fail despite
+    the real data matching.
+    """
+    dst_fs, _ = fsspec.core.url_to_fs(dst_dir)
+    if not dst_fs.exists(dst_dir):
+        return
+    orphans = [full for full in dst_fs.find(dst_dir) if _ATOMIC_RENAME_TMP_RE.search(full)]
+    if not orphans:
+        return
+    logger.info("Removing %d .tmp.<uuid> orphan(s) under %s", len(orphans), dst_dir)
+    dst_fs.rm(orphans)
+    counters.increment("upload/tmp_orphans_removed", len(orphans))
+
+
 def _shard(items: list[tuple[str, str]], shard_size: int) -> list[list[tuple[str, str]]]:
     return [items[i : i + shard_size] for i in range(0, len(items), shard_size)]
 
@@ -363,6 +387,9 @@ def _upload_dir(
     # — its presence is the canonical "this leaf is fully synced" signal that
     # lets future runs skip the source entirely.
     _finalize_executor_status(src_dir, dst_dir)
+    # With the marker in place, the leaf is canonical; any ``.tmp.<uuid>``
+    # debris under it is orphaned and can be removed.
+    _remove_tmp_orphans(dst_dir)
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
* `sync_datakit.py`: add `_remove_tmp_orphans(dst_dir)` post-finalize sweep so each leaf's dst is byte-identical to src after sync
* orphans are `<file>.tmp.<32-hex-uuid>` keys left behind when `zephyr.writers.atomic_rename` is interrupted between the temp write and the rename
  * never legitimate content — `.executor_status` is published just before the sweep, so anything still matching the tmp pattern under the leaf is by definition stale
* bulk-deleted via `fs.rm`, bumps `upload/tmp_orphans_removed` counter
* reuses the existing `_ATOMIC_RENAME_TMP_RE` regex used by `_list_relative_files` — one source of truth for the orphan pattern
* complementary to #5698 (now merged), which cuts down on how many orphans get created in the first place; this sweep cleans whatever still slips through

## Test plan

* `--dry-run` smoke (`cp/foodista`): module loads, pre-flight whole-source skip path still works, 0 StepSpecs built (source already synced)
* `./infra/pre-commit.py --files scripts/datakit/sync_datakit.py` passes
* offline verification on the current R2 mirror (`s3://marin-na/marin`):
  * pre-existing orphan inventory: **3,919 files / 4.426 TiB across 24 raw leaves**[^1] — top contributor `raw/nemotron_cc_v2-674913` with 2,678 files / 2.38 TiB
  * after a one-shot cleanup pass[^1], R2 and GCS were byte-identical: 47,773 files / 27,544,125,149,101 bytes on both sides, `diff=+0`
  * canary: moved one 238 B file out of an R2 leaf — checker flagged inconsistent (`only on GCS: ['provenance.json']`, `diff=+238`); restored it — checker green again

[^1]: the inventory + bulk delete were done with ad-hoc scripts in `/tmp/` (not included in this PR); they walk the same DAG-leaf set as `validate_source_staging.py` and apply the same `.tmp.<32-hex-uuid>` regex.