### PR TITLE
ops: daily cross-region egress report

### DIFF
--- a/.github/workflows/ops-egress-report.yaml
+++ b/.github/workflows/ops-egress-report.yaml
@@ -1,0 +1,48 @@
+name: "Ops - Egress Report"
+
+on:
+  schedule:
+    - cron: '0 14 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ops-egress-report
+  cancel-in-progress: false
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Sync uv environment
+        run: uv sync
+
+      - name: Run egress report
+        run: uv run python scripts/ops/egress_report.py

--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -238,7 +238,7 @@ Only delete the specific bad node. If multiple nodes fail simultaneously or the 
 
 ### GCP State
 
-State dir: `gs://marin-us-central2/iris/<cluster>/state/` — contains `bundles/` (code packages), `controller-state/` (SQLite checkpoints), `logs/` (Parquet).
+State dir: `gs://marin-us-central2/iris/<cluster>/state/` — contains `bundles/` (code packages) and `controller-state/` (SQLite checkpoints). Per-task log parquet segments are shipped separately by finelog under `<finelog.remote_log_dir>/log/` (see `lib/finelog/config/<cluster>.yaml`).
 
 ### GCP Gotchas
 

--- a/scripts/ops/cross_region.py
+++ b/scripts/ops/cross_region.py
@@ -880,9 +880,6 @@ def main(
     logging.info(f"Output directory: {out_path}")
 
     cfg = IrisConfig.load(config)
-    # Logs are shipped by finelog (see lib/finelog/config/<name>.yaml). Iris
-    # used to write parquet segments under `<remote_state_dir>/logs/`, but
-    # that path went stale after the finelog migration (see #5703).
     if not cfg.proto.log_server_config:
         raise click.ClickException(
             f"Iris config {config!r} has no log_server_config; cross-region analysis "

--- a/scripts/ops/cross_region.py
+++ b/scripts/ops/cross_region.py
@@ -5,7 +5,7 @@
 """Analyze cross-region GCS operations from archived Iris task logs.
 
 This script:
-- locates archived log parquet segments under ``<remote_state_dir>/logs``
+- locates finelog log parquet segments under ``<finelog.remote_log_dir>/log``
 - downloads the recent segments needed for a time window
 - downloads the latest controller checkpoint unless a checkpoint directory is supplied
 - joins task log entries against task attempt / worker region metadata
@@ -31,6 +31,7 @@ from pathlib import Path
 import click
 import duckdb
 import fsspec
+from finelog.deploy.config import load_finelog_config
 from iris.cluster.config import IrisConfig
 from iris.cluster.controller.checkpoint import _find_latest_checkpoint_dir, download_checkpoint_to_local
 from rigging.filesystem import get_bucket_location, region_from_prefix
@@ -418,6 +419,7 @@ def analyze(
     job_counts = Counter()
     task_counts = Counter()
     user_counts = Counter()
+    large_user_counts = Counter()
     size_tier_counts = Counter()
     cross_region_size_tier_counts = Counter()
     cross_region_extension_counts = Counter()
@@ -517,6 +519,8 @@ def analyze(
                 job_counts[task_id.rsplit("/", 1)[0]] += 1
                 task_counts[task_id] += 1
                 user_counts[user] += 1
+                if size_tier == "large":
+                    large_user_counts[user] += 1
 
                 sample_key = (task_id, attempt_id, path, epoch_ms)
                 if sample_key in seen_sample_keys:
@@ -582,6 +586,7 @@ def analyze(
         "cross_region_jobs": dict(job_counts.most_common(50)),
         "cross_region_tasks": dict(task_counts.most_common(50)),
         "cross_region_users": dict(user_counts.most_common()),
+        "cross_region_large_users": dict(large_user_counts.most_common()),
         "unmatched_tasks_top25": dict(unmatched_tasks.most_common(25)),
         "unknown_buckets_top25": dict(unknown_buckets.most_common(25)),
         "samples": samples,
@@ -600,6 +605,19 @@ def _md_table(headers: list[str], rows: list[list]) -> str:
     for row in rows:
         out.append("| " + " | ".join(str(c) for c in row) + " |")
     return "\n".join(out) + "\n"
+
+
+def _format_handle(user: str) -> str:
+    """Prefix GH-style handles with `@`; leave `<unknown>` alone."""
+    return f"@{user}" if user and user != "<unknown>" else user
+
+
+def _split_owner_path(prefix: str) -> tuple[str, str]:
+    """Split an Iris task/job key (``/<user>/<rest>``) into (owner, rest)."""
+    parts = prefix.split("/", 2)
+    if len(parts) >= 3 and parts[1]:
+        return parts[1], parts[2]
+    return "<unknown>", prefix
 
 
 def write_markdown(summary: dict, path: Path) -> None:
@@ -677,9 +695,23 @@ def write_markdown(summary: dict, path: Path) -> None:
     lines.append(
         _md_table(
             ["User", "Mentions"],
-            [[k, v] for k, v in list(summary["cross_region_users"].items())[:25]],
+            [[_format_handle(k), v] for k, v in list(summary["cross_region_users"].items())[:25]],
         )
     )
+
+    large_users = summary.get("cross_region_large_users") or {}
+    if large_users:
+        lines.append("\n## Cross-region by user (large-tier only)\n")
+        lines.append(
+            "_Only path mentions in the `large` tier (model/checkpoint shards). "
+            "This is the closest proxy we have to bytes-of-egress per user._\n"
+        )
+        lines.append(
+            _md_table(
+                ["User", "Large-tier mentions"],
+                [[_format_handle(k), v] for k, v in list(large_users.items())[:25]],
+            )
+        )
 
     lines.append("\n## Top region pairs (source → destination)\n")
     lines.append(
@@ -698,20 +730,18 @@ def write_markdown(summary: dict, path: Path) -> None:
     )
 
     lines.append("\n## Top cross-region jobs\n")
-    lines.append(
-        _md_table(
-            ["Job", "Mentions"],
-            [[k, v] for k, v in list(summary["cross_region_jobs"].items())[:25]],
-        )
-    )
+    job_rows = []
+    for k, v in list(summary["cross_region_jobs"].items())[:25]:
+        owner, rest = _split_owner_path(k)
+        job_rows.append([_format_handle(owner), rest, v])
+    lines.append(_md_table(["Owner", "Job", "Mentions"], job_rows))
 
     lines.append("\n## Top cross-region tasks\n")
-    lines.append(
-        _md_table(
-            ["Task", "Mentions"],
-            [[k, v] for k, v in list(summary["cross_region_tasks"].items())[:25]],
-        )
-    )
+    task_rows = []
+    for k, v in list(summary["cross_region_tasks"].items())[:25]:
+        owner, rest = _split_owner_path(k)
+        task_rows.append([_format_handle(owner), rest, v])
+    lines.append(_md_table(["Owner", "Task", "Mentions"], task_rows))
 
     if summary.get("unknown_buckets_top25"):
         lines.append("\n## Buckets with unknown region\n")
@@ -735,7 +765,10 @@ def write_markdown(summary: dict, path: Path) -> None:
             user_samples = samples_by_user[user]
             if not user_samples:
                 continue
-            lines.append(f"### `{user}` ({summary['cross_region_users'].get(user, len(user_samples))} mentions)\n")
+            lines.append(
+                f"### {_format_handle(user)} "
+                f"({summary['cross_region_users'].get(user, len(user_samples))} mentions)\n"
+            )
             rows = []
             for s in user_samples:
                 ts = _fmt_ms(s["timestamp_ms"]).split("+")[0]
@@ -772,6 +805,8 @@ def write_csv(summary: dict, path: Path) -> None:
             writer.writerow(["task", key, value])
         for key, value in summary["cross_region_users"].items():
             writer.writerow(["user", key, value])
+        for key, value in (summary.get("cross_region_large_users") or {}).items():
+            writer.writerow(["user_large_tier", key, value])
         for key, value in summary["cross_region_size_tier_counts"].items():
             writer.writerow(["size_tier", key, value])
         for key, value in summary["cross_region_extensions"].items():
@@ -845,7 +880,18 @@ def main(
     logging.info(f"Output directory: {out_path}")
 
     cfg = IrisConfig.load(config)
-    remote_logs_dir = f"{cfg.proto.storage.remote_state_dir.rstrip('/')}/logs"
+    # Logs are shipped by finelog (see lib/finelog/config/<name>.yaml). Iris
+    # used to write parquet segments under `<remote_state_dir>/logs/`, but
+    # that path went stale after the finelog migration (see #5703).
+    if not cfg.proto.log_server_config:
+        raise click.ClickException(
+            f"Iris config {config!r} has no log_server_config; cross-region analysis "
+            "requires logs shipped via finelog."
+        )
+    finelog_cfg = load_finelog_config(cfg.proto.log_server_config)
+    if not finelog_cfg.remote_log_dir:
+        raise click.ClickException(f"finelog config {cfg.proto.log_server_config!r} has no remote_log_dir.")
+    remote_logs_dir = f"{finelog_cfg.remote_log_dir.rstrip('/')}/log"
 
     log_entries = choose_log_objects(remote_logs_dir, window, download_lookback_hours)
     local_logs_dir = out_path / "logs"

--- a/scripts/ops/egress_report.py
+++ b/scripts/ops/egress_report.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Daily cross-region egress digest.
+
+Runs ``scripts/ops/cross_region.py`` over the last 24h of Iris logs, uploads
+the resulting report + appendix + summary to a dated GCS prefix, and posts a
+short summary to Discord with a link into the GCP console.
+
+Always posts (writes "No offenders today." when nobody crosses the per-user
+threshold).
+
+NOTE: This script runs in a public GitHub Actions log. Do not log message
+bodies or summary contents at INFO/WARN — the per-user counts are only safe
+inside the Discord message and the GCS-hosted report.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+import subprocess
+import tempfile
+from pathlib import Path
+
+import click
+
+LARGE_TIER_USER_THRESHOLD = 10
+MAX_OFFENDERS_IN_MESSAGE = 20
+
+GCS_PREFIX = "gs://marin-us-central2/iris/marin/ops/egress-reports"
+CONSOLE_PREFIX = "https://console.cloud.google.com/storage/browser/marin-us-central2/iris/marin/ops/egress-reports"
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_cross_region(hours: float, outdir: Path) -> dict:
+    subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            str(REPO_ROOT / "scripts" / "ops" / "cross_region.py"),
+            "--hours",
+            str(hours),
+            "--outdir",
+            str(outdir),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+    )
+    return json.loads((outdir / "cross_region_ops_summary.json").read_text())
+
+
+def _upload_to_gcs(outdir: Path, gcs_dest: str) -> None:
+    subprocess.run(
+        [
+            "gsutil",
+            "-m",
+            "cp",
+            str(outdir / "cross_region_ops_report.md"),
+            str(outdir / "cross_region_ops_appendix.csv"),
+            str(outdir / "cross_region_ops_summary.json"),
+            gcs_dest,
+        ],
+        check=True,
+    )
+
+
+def _post_to_discord(channel: str, message: str) -> None:
+    subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            str(REPO_ROOT / "scripts" / "ops" / "discord.py"),
+            "-c",
+            channel,
+        ],
+        input=message,
+        text=True,
+        check=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def _compose_message(
+    *,
+    hours: float,
+    date: str,
+    total: int,
+    offenders: list[tuple[str, int]],
+    console_url: str,
+) -> str:
+    if offenders:
+        shown = offenders[:MAX_OFFENDERS_IN_MESSAGE]
+        offender_section = "**Potential large-egress contributors:**\n" + "\n".join(
+            f"- `@{u}` — {n} cross-region large-tier mentions" for u, n in shown
+        )
+        if len(offenders) > MAX_OFFENDERS_IN_MESSAGE:
+            extra = len(offenders) - MAX_OFFENDERS_IN_MESSAGE
+            offender_section += f"\n- _(+{extra} more in the report)_"
+    else:
+        offender_section = "_No offenders today._"
+
+    return (
+        f"**Daily cross-region egress report** ({hours:.0f}h window, UTC {date})\n"
+        f"- total cross-region mentions: **{total}**\n"
+        f"- report: {console_url}\n\n"
+        f"{offender_section}"
+    )
+
+
+@click.command(help=__doc__)
+@click.option("--hours", type=float, default=24.0, help="Analysis window in hours. Defaults to 24.")
+@click.option("--channel", default="internal-discuss", help="Discord channel name.")
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=False,
+    help="Skip GCS upload and Discord post; print the message that would have been sent.",
+)
+def main(hours: float, channel: str, dry_run: bool) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    outdir = Path(tempfile.mkdtemp(prefix="egress-report-"))
+    logging.info("Workdir: %s", outdir)
+
+    summary = _run_cross_region(hours, outdir)
+
+    total = summary["cross_region_path_mentions"]
+    large_users: dict[str, int] = summary.get("cross_region_large_users") or {}
+    offenders = [(u, n) for u, n in large_users.items() if n >= LARGE_TIER_USER_THRESHOLD and u != "<unknown>"]
+
+    date = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
+    gcs_dest = f"{GCS_PREFIX}/{date}/"
+    console_url = f"{CONSOLE_PREFIX}/{date}/"
+
+    message = _compose_message(
+        hours=hours,
+        date=date,
+        total=total,
+        offenders=offenders,
+        console_url=console_url,
+    )
+
+    if dry_run:
+        logging.info("Dry run — would upload to %s and post to #%s.", gcs_dest, channel)
+        print(message)
+        return
+
+    _upload_to_gcs(outdir, gcs_dest)
+    _post_to_discord(channel, message)
+    logging.info("Posted egress report for %s to #%s.", date, channel)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
🤖

## Summary

- Adds `scripts/ops/egress_report.py` and a scheduled GHA workflow (`.github/workflows/ops-egress-report.yaml`) that runs `cross_region.py` daily at 14:00 UTC, uploads the report to `gs://marin-us-central2/iris/marin/ops/egress-reports/<DATE>/`, and posts a summary to Discord (#internal-discuss) with a console URL link.
- Fixes #5703: `scripts/ops/cross_region.py` was reading the stale `<remote_state_dir>/logs/` path; updated to resolve the log directory via finelog's `remote_log_dir` (lib/finelog/config/marin.yaml).
- Side improvements to `cross_region.py`: per-user large-tier mention counter exposed as `cross_region_large_users` in the summary, `@`-prefixed GitHub handles in the markdown user table, separate `Owner` column in the job/task tables, and a new "Cross-region by user (large-tier only)" section.
- `egress_report.py` posts a "Potential large-egress contributors" list for any user with ≥10 large-tier cross-region mentions in the 24h window (threshold tunable). Always posts; falls back to "No offenders today." when nobody clears the threshold.

## Test plan

- [x] `cross_region.py --hours 24` returns real data after the finelog path fix (~16K cross-region mentions, ~3M log lines scanned)
- [x] `egress_report.py --dry-run` produces correctly-formatted Discord-shape output
- [x] Full local end-to-end run (`uv run python scripts/ops/egress_report.py`) uploads to GCS and posts to #internal-discuss
- [ ] First `workflow_dispatch` run on `main` lands report in GCS and posts to #internal-discuss
- [ ] Scheduled cron fires at the next 14:00 UTC after merge

## Notes

- `workflow_dispatch` only registers once the file is on `main`, so the first end-to-end CI test happens post-merge.
- The workflow's Discord step relies on `discord.py`'s gcloud-Secret-Manager fallback (scripts/ops/discord.py:48). The `IRIS_CI_GCP_SA_KEY` service account needs `roles/secretmanager.secretAccessor` on `marin-discord-webhook-internal-discuss`; grant it before merge if not already in place.
- Threshold (10 large-tier mentions/day) is a v1 guess and may need tuning after a few days of real runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)