### PR TITLE
[iris] Fix controller stall during job-replacement drain

### DIFF
--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -3,6 +3,7 @@
 
 """Iris Controller logic for connecting state, scheduler and managing workers."""
 
+import asyncio
 import atexit
 import enum
 import logging
@@ -12,6 +13,7 @@ import threading
 import time
 from collections import defaultdict
 from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
@@ -126,6 +128,35 @@ logger = logging.getLogger(__name__)
 
 # Sentinel for dry-run scheduling with per-worker limits disabled.
 _UNLIMITED = sys.maxsize
+
+# Sync Connect RPC handlers are dispatched via ``asyncio.to_thread``, which
+# uses the running loop's default executor. asyncio's default executor sizes
+# at ``min(32, os.cpu_count() + 4)`` — only 8 threads on a 4-vCPU controller
+# VM. A handful of slow handlers (e.g. ``launch_job`` blocking up to 120s in
+# ``_wait_until_job_drained``) saturates that pool and head-of-line blocks
+# every other RPC, including the worker heartbeats that would unblock the
+# drain. Install a wider, named pool so a burst of slow handlers cannot
+# starve the rest.
+_RPC_HANDLER_THREADS = 64
+
+
+def _install_rpc_executor(server: uvicorn.Server, *, max_workers: int) -> None:
+    """Replace ``server.run`` with a variant that pins a sized default executor."""
+
+    def run_with_executor() -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.set_default_executor(ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="rpc-handler"))
+        try:
+            loop.run_until_complete(server.serve())
+        finally:
+            try:
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            finally:
+                asyncio.set_event_loop(None)
+                loop.close()
+
+    server.run = run_with_executor
 
 
 class SchedulingOutcome(enum.Enum):
@@ -1455,6 +1486,7 @@ class Controller:
             forwarded_allow_ips="*",
         )
         self._server = uvicorn.Server(server_config)
+        _install_rpc_executor(self._server, max_workers=_RPC_HANDLER_THREADS)
         self._threads.spawn_server(self._server, name="controller-server")
 
         # Register cluster endpoints BEFORE spawning the autoscaler. Otherwise the
@@ -2333,8 +2365,17 @@ class Controller:
             # Snapshot current attempts for ``worker_ids``. Workers not in
             # ``worker_ids`` are filtered in Python so the partial index
             # ``idx_task_attempts_live_workerbound`` remains active rather
-            # than falling back to a scan on a long IN list. The
-            # ASSIGNED/BUILDING/RUNNING filter is static.
+            # than falling back to a scan on a long IN list. We deliberately
+            # do NOT filter on task state: active rows (ASSIGNED/BUILDING/
+            # RUNNING) drive normal reconciliation; rows whose task has
+            # already moved to a terminal state but whose attempt is still
+            # worker-bound (worker_id set, finished_at_ms NULL) are stranded
+            # attempts whose terminal UpdateTaskStatus push was dropped.
+            # Including them in expected_tasks gives the worker a second
+            # chance to report -- either with the real terminal status or
+            # via _missing_task_status -- so the heartbeat path can stamp
+            # finished_at_ms. Without this, a single lost RPC strands the
+            # attempt forever, since no other code path polls about it.
             target_ids: set[WorkerId] = set(worker_ids)
             raw_rows = snap.execute(
                 select(
@@ -2355,13 +2396,6 @@ class Controller:
                 .where(
                     task_attempts_table.c.worker_id.is_not(None),
                     task_attempts_table.c.finished_at_ms.is_(None),
-                    tasks_table.c.state.in_(
-                        [
-                            int(job_pb2.TASK_STATE_ASSIGNED),
-                            int(job_pb2.TASK_STATE_BUILDING),
-                            int(job_pb2.TASK_STATE_RUNNING),
-                        ]
-                    ),
                 ),
             ).all()
             rows = [row for row in raw_rows if row.worker_id in target_ids]

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -115,13 +115,16 @@ class UserStats:
 # Maximum bundle size in bytes (25 MB) - matches client-side limit
 MAX_BUNDLE_SIZE_BYTES = 25 * 1024 * 1024
 
-# Time the launch RPC blocks waiting for a replaced job's worker-bound attempts
-# to finalize before deleting them. Must exceed the worst-case worker-death
-# detection window so a vanished worker's attempts can be self-finalized by the
-# ping loop before the drain gives up: heartbeat_interval (5s) *
+# Soft cap on how long launch_job waits for a replaced job's worker-bound
+# attempts to finalize before force-reaping them. Sized to exceed the worst-
+# case worker-death detection window so a vanished worker's attempts can be
+# self-finalized by the ping loop: heartbeat_interval (5s) *
 # PING_FAILURE_THRESHOLD (10) ≈ 50s, plus slack for the heartbeat to land.
-# Stuck finalization surfaces as DEADLINE_EXCEEDED rather than hanging launches.
-_JOB_REPLACEMENT_DRAIN_TIMEOUT = Duration.from_seconds(120)
+# Past this point we log a warning, CASCADE-delete the predecessor's rows,
+# and proceed with the replacement — a stuck heartbeat must not block the
+# new submission indefinitely.
+_JOB_REPLACEMENT_DRAIN_WAIT = Duration.from_seconds(120)
+
 
 # A root LaunchJob submission is rejected if its client_revision_date is more
 # than FRESHNESS_WINDOW older than today. Clients get exactly this long to
@@ -986,28 +989,21 @@ class ControllerServiceImpl:
             return
         authorize_resource_owner(job_id.user)
 
-    def _wait_until_job_drained(self, job_id: JobName, timeout: Duration) -> None:
-        """Block until ``job_id`` has no unfinished worker-bound attempts.
+    def _wait_until_job_drained(self, job_id: JobName, wait: Duration) -> bool:
+        """Wait up to ``wait`` for ``job_id`` to have no unfinished worker-bound
+        attempts. Returns ``True`` if drained, ``False`` if the wait elapsed.
 
         Polls the snapshot DB; the heartbeat path landing terminal updates is
-        what finally clears the predicate. Used to gate ``remove_finished_job``
-        on a replacement so we never CASCADE-delete tasks whose attempts the
-        worker is still racing to finalize. Raises ``ConnectError`` with
-        ``DEADLINE_EXCEEDED`` if the job hasn't drained within ``timeout``.
+        what flips the predicate. Caller decides whether to reap the
+        predecessor when the wait elapses — a stuck heartbeat must not block
+        the new submission forever.
         """
 
         def drained() -> bool:
             with self._db.read_snapshot() as tx:
                 return not reads.has_unfinished_worker_attempts(tx, job_id)
 
-        try:
-            ExponentialBackoff(initial=0.05, maximum=1.0, factor=1.5).wait_until_or_raise(
-                drained,
-                timeout=timeout,
-                error_message=f"Timed out waiting for job {job_id} to drain before replacement",
-            )
-        except TimeoutError as exc:
-            raise ConnectError(Code.DEADLINE_EXCEEDED, str(exc)) from exc
+        return ExponentialBackoff(initial=0.05, maximum=1.0, factor=1.5).wait_until(drained, timeout=wait)
 
     def _replace_finished_job(self, cur, job_id: JobName) -> bool:
         """Attempt to replace a terminal job; signal whether a drain is needed.
@@ -1159,9 +1155,16 @@ class ControllerServiceImpl:
         if needs_drain:
             # Nudge the polling loop so workers see the cancelled tasks excluded
             # from their expected set on the next reconcile and auto-kill the
-            # containers; the heartbeat path then stamps finished_at_ms.
+            # containers; the heartbeat path then stamps finished_at_ms. If
+            # the heartbeat never lands, force-reap so a stuck worker can't
+            # block the resubmit forever.
             self._controller.wake()
-            self._wait_until_job_drained(job_id, _JOB_REPLACEMENT_DRAIN_TIMEOUT)
+            if not self._wait_until_job_drained(job_id, _JOB_REPLACEMENT_DRAIN_WAIT):
+                logger.warning(
+                    "Job %s did not drain within %ss; force-reaping predecessor and proceeding",
+                    job_id,
+                    _JOB_REPLACEMENT_DRAIN_WAIT.to_seconds(),
+                )
             with self._db.transaction() as cur:
                 self._transitions.remove_finished_job(cur, job_id)
 

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -1734,6 +1734,29 @@ class ControllerTransitions:
                 job_pb2.TASK_STATE_UNSPECIFIED,
                 job_pb2.TASK_STATE_PENDING,
             ):
+                # Stranded-attempt finalization: producer transitions
+                # (cancel_job, preempt_task) move the task to a terminal
+                # state but leave the attempt's ``finished_at_ms`` NULL,
+                # expecting the worker's next terminal status update to
+                # stamp it. If that push was dropped, the poll loop re-asks
+                # via ``expected_tasks`` and we land here with the task
+                # already finished. Stamp ``finished_at_ms`` on the attempt
+                # so the scheduler releases capacity; leave task state alone.
+                if (
+                    _task_is_finished(task)
+                    and update.new_state in TERMINAL_TASK_STATES
+                    and update.attempt_id == task.current_attempt_id
+                ):
+                    attempt = attempt_map.get((update.task_id, update.attempt_id))
+                    if attempt is not None and attempt.worker_id is not None and attempt.finished_at_ms is None:
+                        cur.execute(
+                            sa_update(task_attempts_table)
+                            .where(
+                                task_attempts_table.c.task_id == update.task_id,
+                                task_attempts_table.c.attempt_id == update.attempt_id,
+                            )
+                            .values(finished_at_ms=now_ms)
+                        )
                 continue
             if update.attempt_id != task.current_attempt_id:
                 stale_attempt = attempt_map.get((update.task_id, update.attempt_id))

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -8,6 +8,7 @@ State changes are verified via RPC calls rather than internal state inspection.
 """
 
 import concurrent.futures
+import logging
 import time
 from datetime import date, timedelta
 
@@ -308,9 +309,9 @@ def test_existing_job_policy_keep_drains_unfinalized_child_attempt(service, stat
     ``remove_finished_job``. After the fix, the resubmit must block on drain
     and succeed once the finalizing heartbeat arrives.
     """
-    # Tighten the drain timeout so the test fails fast on regression instead
+    # Tighten the drain wait so the test fails fast on regression instead
     # of waiting the production 30s.
-    monkeypatch.setattr(service_module, "_JOB_REPLACEMENT_DRAIN_TIMEOUT", Duration.from_seconds(5))
+    monkeypatch.setattr(service_module, "_JOB_REPLACEMENT_DRAIN_WAIT", Duration.from_seconds(5))
 
     child_name = "/test-user/parent/child"
     service.launch_job(make_job_request("parent"), None)
@@ -373,11 +374,12 @@ def test_existing_job_policy_keep_drains_unfinalized_child_attempt(service, stat
     assert new_job.state == job_pb2.JOB_STATE_PENDING
 
 
-def test_existing_job_policy_keep_drain_times_out_when_no_heartbeat(service, state, monkeypatch):
+def test_existing_job_policy_keep_force_reaps_after_drain_wait(service, state, monkeypatch, caplog):
     """If a replaced job's worker-bound attempts never finalize, launch_job
-    raises DEADLINE_EXCEEDED instead of hanging or silently destroying the
-    attempt rows the heartbeat path needs."""
-    monkeypatch.setattr(service_module, "_JOB_REPLACEMENT_DRAIN_TIMEOUT", Duration.from_seconds(1))
+    must not block the new submission forever. After the drain wait elapses
+    it logs a warning, CASCADE-deletes the predecessor, and proceeds with
+    the replacement. (Earlier behavior raised DEADLINE_EXCEEDED.)"""
+    monkeypatch.setattr(service_module, "_JOB_REPLACEMENT_DRAIN_WAIT", Duration.from_seconds(1))
 
     child_name = "/test-user/parent/child"
     service.launch_job(make_job_request("parent"), None)
@@ -394,9 +396,15 @@ def test_existing_job_policy_keep_drain_times_out_when_no_heartbeat(service, sta
     request = make_job_request(child_name)
     request.existing_job_policy = job_pb2.EXISTING_JOB_POLICY_KEEP
 
-    with pytest.raises(ConnectError) as exc_info:
-        service.launch_job(request, None)
-    assert exc_info.value.code == Code.DEADLINE_EXCEEDED
+    with caplog.at_level(logging.WARNING, logger=service_module.__name__):
+        response = service.launch_job(request, None)
+    assert response.job_id == child_job.to_wire()
+    assert any("did not drain" in r.message for r in caplog.records), caplog.text
+
+    # Predecessor was reaped and replaced — fresh row is PENDING.
+    new_job = _query_job(state, child_job)
+    assert new_job is not None
+    assert new_job.state == job_pb2.JOB_STATE_PENDING
 
 
 def test_launch_job_rejects_empty_name(service, state):

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -326,6 +326,54 @@ def test_cancel_job_rolls_attempt_state_without_finalizing(harness):
         assert att.finished_at_ms is None
 
 
+def test_heartbeat_finalizes_stranded_attempt_after_producer_terminal(harness):
+    """A producer transition (cancel) leaves the task terminal but the attempt
+    unfinalized; a subsequent heartbeat carrying a terminal status — the case
+    the poll loop now re-issues via expected_tasks for worker-bound attempts
+    with NULL finished_at_ms — must stamp finished_at_ms without rewriting the
+    task's terminal state.
+    """
+    w1 = harness.add_worker("w1")
+    tasks = harness.submit("j1", replicas=1)
+    harness.dispatch(tasks[0], w1)
+
+    task = tasks[0]
+    attempt_id = harness.query_task(task.task_id).current_attempt_id
+
+    with harness.state._db.transaction() as cur:
+        harness.state.cancel_job(cur, JobName.root("test-user", "j1"), reason="User cancelled")
+
+    pre = _query_attempt(harness.state, task.task_id, attempt_id)
+    assert pre is not None
+    assert pre.worker_id is not None
+    assert attempt_is_terminal(pre.state)
+    assert pre.finished_at_ms is None
+    pre_task_state = _query_task(harness.state, task.task_id).state
+
+    with harness.state._db.transaction() as cur:
+        harness.state.apply_task_updates(
+            cur,
+            HeartbeatApplyRequest(
+                worker_id=w1,
+                updates=[
+                    TaskUpdate(
+                        task_id=task.task_id,
+                        attempt_id=attempt_id,
+                        new_state=job_pb2.TASK_STATE_WORKER_FAILED,
+                        error="Task not found on worker",
+                    )
+                ],
+            ),
+        )
+
+    post = _query_attempt(harness.state, task.task_id, attempt_id)
+    assert post is not None
+    assert post.finished_at_ms is not None, "stranded attempt should be finalized by heartbeat"
+    assert (
+        _query_task(harness.state, task.task_id).state == pre_task_state
+    ), "task's terminal state must not be rewritten by the late heartbeat"
+
+
 def test_cancel_job_preserves_kill_worker_mapping_after_clearing_tasks(harness):
     """cancel_job returns worker routing for kill RPCs before current_worker_id is cleared."""
     w1 = harness.add_worker("w1")


### PR DESCRIPTION
Size the uvicorn loop's default executor to 64 so a burst of LaunchJob handlers blocked in _wait_until_job_drained cannot starve the worker heartbeats sharing the same pool. Soft-cap the drain wait: log and force-reap the predecessor instead of raising DEADLINE_EXCEEDED. Finalize stranded attempts when a late terminal heartbeat arrives so the drain predicate clears in the first place.