### PR TITLE
[finelog] Drop redundant segments at boot reconcile

### DIFF
--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -1277,18 +1277,23 @@ class DiskLogNamespace:
             if row is not None:
                 self._catalog.remove_segment(self.name, row.path)
 
-        # Parallelize fs.rm — a large first-deploy backlog of compaction
-        # orphans would otherwise add minutes to boot.
-        def _delete_one(basename: str) -> None:
+        # Batch fs.rm calls 8 at a time and run batches in parallel. The
+        # gcsfs path uses one BatchDelete request per chunk; otherwise a
+        # large first-deploy backlog of compaction orphans adds minutes
+        # to boot.
+        def _delete_chunk(chunk: list[str]) -> None:
+            paths = [f"{self._remote_namespace_dir}/{b}" for b in chunk]
             try:
-                fs.rm(f"{self._remote_namespace_dir}/{basename}")
+                fs.rm(paths)
             except Exception:
-                logger.warning("redundant remote delete failed: %s/%s", self.name, basename, exc_info=True)
+                logger.warning("redundant remote delete failed: %s/%s", self.name, chunk, exc_info=True)
 
         if redundant:
-            max_workers = min(32, len(redundant))
+            ordered = list(redundant)
+            chunks = [ordered[i : i + 8] for i in range(0, len(ordered), 8)]
+            max_workers = min(32, len(chunks))
             with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="reconcile-delete") as pool:
-                list(pool.map(_delete_one, redundant))
+                list(pool.map(_delete_chunk, chunks))
 
         now_ms = int(time.time() * 1000)
         adopted = 0

--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -529,13 +529,8 @@ class DiskLogNamespace:
         #      local file was evicted before the prior shutdown.
         #   2. Local parquet files — authoritative for unflushed catalog
         #      state (genuine boot from disk, no prior catalog).
-        #   3. Remote bucket — authoritative for wiped-catalog recovery,
-        #      handled below by ``_adopt_remote_segments`` *before* the
-        #      bg loop starts. We can't defer this to the first sync tick:
-        #      that tick's phase-2 orphan-delete would see an empty
-        #      catalog with a populated bucket and ``fs.rm`` everything.
-        #      The cost is a network round-trip per parquet file at boot
-        #      when the bucket is non-empty.
+        #   3. Remote bucket — handled below by
+        #      ``_reconcile_remote_segments``.
         #
         # Each catalog row is reattached to its on-disk file when present;
         # ``REMOTE``-only rows stay in the catalog but never enter the
@@ -619,12 +614,8 @@ class DiskLogNamespace:
         for seg in self._local_segments:
             self._catalog.upsert_segment(self._segment_to_row(seg))
 
-        # Wiped-catalog recovery: if the remote bucket has parquet files
-        # that no row references, adopt them as ``REMOTE``. Without this,
-        # the first ``_sync_step`` after a catalog wipe would treat the
-        # whole bucket as orphan and ``fs.rm`` everything.
         if self._remote_namespace_dir:
-            self._adopt_remote_segments(key_column=key_column)
+            self._reconcile_remote_segments(key_column=key_column)
 
         self._flush_rl = RateLimiter(flush_interval_sec)
         self._compaction_rl = RateLimiter(compaction_config.check_interval_sec)
@@ -1198,30 +1189,35 @@ class DiskLogNamespace:
         finally:
             self._query_visibility_lock.write_release()
 
-    def _adopt_remote_segments(self, *, key_column: str | None) -> None:
-        """Insert ``REMOTE`` catalog rows for bucket files with no row.
+    def _reconcile_remote_segments(self, *, key_column: str | None) -> None:
+        """Adopt unknown remote files and drop redundant ones at boot.
 
-        Recovery path for a wiped catalog: the bucket is the only durable
-        record of every L>=1 segment, so we read each parquet footer
-        remotely to reconstruct row metadata. Footer fetches dominate
-        wall-time (one network round-trip per segment) and are run on a
-        thread pool; the catalog upserts then run serially because
-        ``Catalog._conn`` is a single DuckDB connection.
+        Runs once from ``__init__`` before the bg thread starts; no
+        compactor or sync activity is concurrent with it.
+
+        Adoption is the wiped-catalog recovery path: the bucket is the
+        only durable record of L>=1 segments after the local catalog is
+        lost, so each parquet footer is fetched to rebuild row metadata.
+
+        The redundancy pass drops any segment whose ``[min_seq, max_seq]``
+        is fully covered by a higher-level segment. Otherwise a crash
+        between a compaction commit and its ``fs.rm`` would leave the
+        input file in the bucket, and adoption on the next boot would
+        give it a permanent ``REMOTE`` row.
         """
         try:
             fs, root = fsspec.core.url_to_fs(self._remote_namespace_dir)
-            # detail=True returns file size in the listing, so we don't
-            # need a separate fs.info() per file below.
             remote_info = fs.find(root, detail=True)
         except Exception:
-            logger.warning("remote adopt list failed for %s", self.name, exc_info=True)
+            logger.warning("remote reconcile list failed for %s", self.name, exc_info=True)
             return
 
-        catalog_basenames = {Path(r.path).name for r in self._catalog.list_segments(self.name)}
-        candidates: list[tuple[str, int, int, int]] = []  # (fs_path, level, min_seq, byte_size)
+        catalog_by_basename = {Path(r.path).name: r for r in self._catalog.list_segments(self.name, min_level=1)}
+
+        needs_footer: list[tuple[str, str, int, int, int]] = []  # (fs_path, basename, level, min_seq, byte_size)
         for fs_path, info in remote_info.items():
             basename = Path(fs_path).name
-            if basename in catalog_basenames:
+            if basename in catalog_by_basename:
                 continue
             parsed = parse_seg_filename(basename)
             if parsed is None:
@@ -1229,32 +1225,76 @@ class DiskLogNamespace:
                 continue
             level, min_seq = parsed
             byte_size = int(info.get("size", 0) or 0)
-            candidates.append((fs_path, level, min_seq, byte_size))
+            needs_footer.append((fs_path, basename, level, min_seq, byte_size))
 
-        if not candidates:
-            return
-
-        def _fetch_footer(fs_path: str) -> tuple[str, pq.FileMetaData | None]:
+        def _fetch_footer(
+            item: tuple[str, str, int, int, int],
+        ) -> tuple[str, str, int, int, int, pq.FileMetaData | None]:
+            fs_path, basename, level, min_seq, byte_size = item
             try:
                 with fs.open(fs_path, "rb") as f:
-                    return fs_path, pq.read_metadata(f)
+                    return basename, fs_path, level, min_seq, byte_size, pq.read_metadata(f)
             except Exception:
-                logger.warning(
-                    "failed reading remote parquet footer %s/%s", self.name, Path(fs_path).name, exc_info=True
-                )
-                return fs_path, None
+                logger.warning("failed reading remote parquet footer %s/%s", self.name, basename, exc_info=True)
+                return basename, fs_path, level, min_seq, byte_size, None
 
-        max_workers = min(32, len(candidates))
-        with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="adopt-remote") as pool:
-            footers = dict(pool.map(_fetch_footer, [c[0] for c in candidates]))
+        # basename -> (fs_path, level, min_seq, max_seq, byte_size, metadata)
+        footer_results: dict[str, tuple[str, int, int, int, int, pq.FileMetaData]] = {}
+        if needs_footer:
+            max_workers = min(32, len(needs_footer))
+            with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="reconcile-remote") as pool:
+                for basename, fs_path, level, min_seq, byte_size, metadata in pool.map(_fetch_footer, needs_footer):
+                    if metadata is None:
+                        continue
+                    max_seq = min_seq + max(metadata.num_rows - 1, 0)
+                    footer_results[basename] = (fs_path, level, min_seq, max_seq, byte_size, metadata)
+
+        # Union catalog + remote-only seq ranges, then mark any segment
+        # whose [min_seq, max_seq] is fully spanned by a strictly higher
+        # level. Transitivity (Y covers X, Z covers Y ⇒ Z covers X) means
+        # we don't need to filter out redundant Ys before checking X.
+        all_known: dict[str, tuple[int, int, int]] = {}
+        for basename, row in catalog_by_basename.items():
+            all_known[basename] = (row.level, row.min_seq, row.max_seq)
+        for basename, (_fs_path, level, min_seq, max_seq, _byte_size, _meta) in footer_results.items():
+            all_known[basename] = (level, min_seq, max_seq)
+
+        by_level: dict[int, list[tuple[int, int]]] = {}
+        for level, min_seq, max_seq in all_known.values():
+            by_level.setdefault(level, []).append((min_seq, max_seq))
+
+        redundant: set[str] = set()
+        for basename, (level, min_seq, max_seq) in all_known.items():
+            for higher_level, ranges in by_level.items():
+                if higher_level <= level:
+                    continue
+                if any(h_min <= min_seq and h_max >= max_seq for h_min, h_max in ranges):
+                    redundant.add(basename)
+                    break
+
+        for basename in redundant:
+            row = catalog_by_basename.get(basename)
+            if row is not None:
+                self._catalog.remove_segment(self.name, row.path)
+
+        # Parallelize fs.rm — a large first-deploy backlog of compaction
+        # orphans would otherwise add minutes to boot.
+        def _delete_one(basename: str) -> None:
+            try:
+                fs.rm(f"{self._remote_namespace_dir}/{basename}")
+            except Exception:
+                logger.warning("redundant remote delete failed: %s/%s", self.name, basename, exc_info=True)
+
+        if redundant:
+            max_workers = min(32, len(redundant))
+            with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="reconcile-delete") as pool:
+                list(pool.map(_delete_one, redundant))
 
         now_ms = int(time.time() * 1000)
-        for fs_path, level, min_seq, byte_size in candidates:
-            metadata = footers.get(fs_path)
-            if metadata is None:
+        adopted = 0
+        for basename, (_fs_path, level, min_seq, max_seq, byte_size, metadata) in footer_results.items():
+            if basename in redundant:
                 continue
-            basename = Path(fs_path).name
-            num_rows = metadata.num_rows
             min_key, max_key = _key_bounds_from_parquet(metadata, key_column)
             local_path = self._data_dir / basename
             self._catalog.upsert_segment(
@@ -1263,8 +1303,8 @@ class DiskLogNamespace:
                     path=str(local_path),
                     level=level,
                     min_seq=min_seq,
-                    max_seq=min_seq + max(num_rows - 1, 0),
-                    row_count=num_rows,
+                    max_seq=max_seq,
+                    row_count=metadata.num_rows,
                     byte_size=byte_size,
                     created_at_ms=now_ms,
                     location=SegmentLocation.REMOTE,
@@ -1272,11 +1312,15 @@ class DiskLogNamespace:
                     max_key_value=None if max_key is None else str(max_key),
                 )
             )
-        logger.info(
-            "Adopted %d remote segment(s) for namespace %s as REMOTE",
-            sum(1 for fs_path, *_ in candidates if footers.get(fs_path) is not None),
-            self.name,
-        )
+            adopted += 1
+
+        if adopted or redundant:
+            logger.info(
+                "Reconciled remote for %s: adopted=%d, dropped_redundant=%d",
+                self.name,
+                adopted,
+                len(redundant),
+            )
 
     def _sync_step(self) -> None:
         """Reconcile the remote namespace prefix with the catalog.

--- a/lib/finelog/tests/test_offload.py
+++ b/lib/finelog/tests/test_offload.py
@@ -216,3 +216,108 @@ def test_wiped_catalog_recovers_from_remote(tmp_path: Path) -> None:
         assert bucket_files_after == bucket_files_before
     finally:
         s2.close()
+
+
+def test_reconcile_drops_stale_compaction_inputs_at_boot(tmp_path: Path) -> None:
+    """Compaction inputs that survived a crash mid-sync are dropped at boot.
+
+    Pre-fix bug: ``_adopt_remote_segments`` ran unconditionally on every
+    boot, so any L_n GCS file whose catalog row had been dropped at
+    compaction commit but whose ``fs.rm`` hadn't run yet was re-adopted
+    as a ``REMOTE`` row. The row defeated ``_sync_step``'s
+    ``remote - catalog`` orphan delete, so the file leaked forever.
+
+    The reconcile pass at boot must detect coverage by a higher-level
+    segment and drop both the GCS file and any catalog row.
+    """
+    from finelog.store.catalog import CATALOG_DB_FILENAME
+    from finelog.store.compactor import CompactionConfig
+
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    log_dir = tmp_path / "data"
+
+    # Tiny level targets force every flush to bump L0 → L1 → L2, so a
+    # single tick produces a stale L1 input plus the L2 that covers it.
+    config = CompactionConfig(level_targets=(1, 2))
+    s1 = DuckDBLogStore(log_dir=log_dir, remote_log_dir=str(remote), compaction_config=config)
+    try:
+        s1.register_table("iris.worker", _worker_schema())
+        s1.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-1"], [100], [1])))
+        ns = s1._namespaces["iris.worker"]
+        ns._flush_step()
+        while ns._compaction_step():
+            pass
+        ns._sync_step()
+        live_after_compact = sorted(p.name for p in _remote_files(remote, "iris.worker"))
+        assert live_after_compact and all(n.startswith("seg_L2_") for n in live_after_compact)
+    finally:
+        s1.close()
+
+    # Drop a stale L1 input back into the bucket — same seq range as the
+    # surviving L2, so the L2 fully covers it. Pre-fix this would have
+    # been adopted and lived forever.
+    l2_name = live_after_compact[0]
+    l2_min_seq = int(l2_name.removeprefix("seg_L2_").removesuffix(".parquet"))
+    src_l2 = remote / "iris.worker" / l2_name
+    stale_l1 = remote / "iris.worker" / f"seg_L1_{l2_min_seq:019d}.parquet"
+    stale_l1.write_bytes(src_l2.read_bytes())
+
+    # Wipe catalog so the bug surfaces — adoption is what re-adds the
+    # stale L1 in the original failure mode.
+    (log_dir / CATALOG_DB_FILENAME).unlink()
+    for p in (log_dir / "iris.worker").glob("*"):
+        p.unlink()
+
+    s2 = DuckDBLogStore(log_dir=log_dir, remote_log_dir=str(remote), compaction_config=config)
+    try:
+        s2.register_table("iris.worker", _worker_schema())
+        ns = s2._namespaces["iris.worker"]
+        rows = ns._catalog.list_segments("iris.worker")
+        # The L1 must not be in the catalog (dropped as redundant).
+        assert not any(r.level == 1 for r in rows), rows
+        # And the L1 file must be gone from the bucket too.
+        remaining = sorted(p.name for p in _remote_files(remote, "iris.worker"))
+        assert stale_l1.name not in remaining
+        assert remaining == live_after_compact
+    finally:
+        s2.close()
+
+
+def test_reconcile_preserves_uncovered_lower_level(tmp_path: Path) -> None:
+    """An L_n segment NOT covered by any higher-level segment must be
+    adopted — only redundant inputs are dropped."""
+    from finelog.store.catalog import CATALOG_DB_FILENAME, SegmentLocation
+
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    log_dir = tmp_path / "data"
+
+    s1 = DuckDBLogStore(log_dir=log_dir, remote_log_dir=str(remote))
+    try:
+        s1.register_table("iris.worker", _worker_schema())
+        s1.write_rows("iris.worker", _ipc_bytes(_worker_batch(["w-1"], [100], [1])))
+        ns = s1._namespaces["iris.worker"]
+        ns._flush_step()
+        ns._force_compact_l0()
+        ns._sync_step()
+        bucket_files = sorted(p.name for p in _remote_files(remote, "iris.worker"))
+        # Single L1, no L2: nothing covers it.
+        assert bucket_files and all(n.startswith("seg_L1_") for n in bucket_files)
+    finally:
+        s1.close()
+
+    (log_dir / CATALOG_DB_FILENAME).unlink()
+    for p in (log_dir / "iris.worker").glob("*"):
+        p.unlink()
+
+    s2 = DuckDBLogStore(log_dir=log_dir, remote_log_dir=str(remote))
+    try:
+        s2.register_table("iris.worker", _worker_schema())
+        ns = s2._namespaces["iris.worker"]
+        rows = ns._catalog.list_segments("iris.worker")
+        adopted = [r for r in rows if r.location is SegmentLocation.REMOTE]
+        assert {Path(r.path).name for r in adopted} == set(bucket_files)
+        assert sorted(p.name for p in _remote_files(remote, "iris.worker")) == bucket_files
+    finally:
+        s2.close()


### PR DESCRIPTION
Compaction inputs whose fs.rm didn't complete before a crash were re-adopted on the next boot as REMOTE catalog rows, defeating _sync_step's orphan delete and leaking forever (~7 GiB across finelog-marin namespaces). Boot reconcile now drops any segment whose [min_seq, max_seq] is fully covered by a higher-level segment, both from the catalog and from GCS.