### PR TITLE
[iris] Stop LaunchJob retry storm on slow drain

### DIFF
--- a/lib/iris/src/iris/cluster/client/remote_client.py
+++ b/lib/iris/src/iris/cluster/client/remote_client.py
@@ -44,14 +44,16 @@ MAX_STATE_POLL_INTERVAL = 30.0
 # value before being handed to the backoff.
 MIN_STATE_POLL_INTERVAL = 0.1
 
-# Per-call deadline for LaunchJob. The handler can legitimately run well past the
-# default 30s client timeout when replacing a still-draining predecessor
-# (_JOB_REPLACEMENT_DRAIN_WAIT is 120s on the controller) or when uploading a
-# large workspace bundle. Setting this below the worst-case server budget
-# guarantees a deadline timeout + retry, which then races the original
+# Floor on the per-call deadline for LaunchJob. The handler can legitimately
+# run well past the default 30s client timeout when replacing a still-draining
+# predecessor (_JOB_REPLACEMENT_DRAIN_WAIT is 120s on the controller) or when
+# uploading a large workspace bundle. Setting this below the worst-case server
+# budget guarantees a deadline timeout + retry, which then races the original
 # in-flight INSERT and trips a UNIQUE constraint. Pad past 120s for bundle
-# upload, autoscaler feasibility, and connection overhead.
-LAUNCH_JOB_TIMEOUT_MS = 180_000
+# upload, autoscaler feasibility, and connection overhead. Bump alongside
+# _JOB_REPLACEMENT_DRAIN_WAIT if that grows. Callers that configured a larger
+# RemoteClusterClient timeout keep theirs — this is a floor, not a ceiling.
+LAUNCH_JOB_TIMEOUT_FLOOR_MS = 180_000
 
 
 class RemoteClusterClient:
@@ -161,8 +163,10 @@ class RemoteClusterClient:
         if reservation is not None:
             request.reservation.CopyFrom(reservation)
 
+        launch_timeout_ms = max(self._timeout_ms, LAUNCH_JOB_TIMEOUT_FLOOR_MS)
+
         def _call():
-            return self._client.launch_job(request, timeout_ms=LAUNCH_JOB_TIMEOUT_MS)
+            return self._client.launch_job(request, timeout_ms=launch_timeout_ms)
 
         response = call_with_retry(f"launch_job({job_id})", _call)
         return JobName.from_wire(response.job_id)

--- a/lib/iris/src/iris/cluster/client/remote_client.py
+++ b/lib/iris/src/iris/cluster/client/remote_client.py
@@ -44,6 +44,15 @@ MAX_STATE_POLL_INTERVAL = 30.0
 # value before being handed to the backoff.
 MIN_STATE_POLL_INTERVAL = 0.1
 
+# Per-call deadline for LaunchJob. The handler can legitimately run well past the
+# default 30s client timeout when replacing a still-draining predecessor
+# (_JOB_REPLACEMENT_DRAIN_WAIT is 120s on the controller) or when uploading a
+# large workspace bundle. Setting this below the worst-case server budget
+# guarantees a deadline timeout + retry, which then races the original
+# in-flight INSERT and trips a UNIQUE constraint. Pad past 120s for bundle
+# upload, autoscaler feasibility, and connection overhead.
+LAUNCH_JOB_TIMEOUT_MS = 180_000
+
 
 class RemoteClusterClient:
     """Cluster client via RPC to controller.
@@ -153,7 +162,7 @@ class RemoteClusterClient:
             request.reservation.CopyFrom(reservation)
 
         def _call():
-            return self._client.launch_job(request)
+            return self._client.launch_job(request, timeout_ms=LAUNCH_JOB_TIMEOUT_MS)
 
         response = call_with_retry(f"launch_job({job_id})", _call)
         return JobName.from_wire(response.job_id)

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -1220,6 +1220,20 @@ class ControllerServiceImpl:
                 )
 
         with self._db.transaction() as cur:
+            # Re-check inside the same tx as the INSERT. Two LaunchJob
+            # handlers can race past the earlier existence check (separate
+            # transaction above) — almost always the same logical request
+            # from a client that retried after blowing past its deadline.
+            # SQLite serializes write transactions, so whichever handler
+            # gets the lock first INSERTs and the loser sees the row here
+            # and short-circuits, instead of tripping the jobs.job_id PK
+            # (which would surface as INTERNAL — retryable, compounding the
+            # storm).
+            if reads.get_job_state(cur, job_id) is not None:
+                raise ConnectError(
+                    Code.ALREADY_EXISTS,
+                    f"Job {job_id} already exists (concurrent submission)",
+                )
             self._transitions.submit_job(cur, job_id, request, Timestamp.now())
         self._controller.wake()
 

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -1108,9 +1108,11 @@ class ControllerServiceImpl:
         # Existence check + conditional cleanup run in one transaction so a
         # concurrent submitter cannot land a row between the read and the
         # cleanup write. The new job's ``submit_job`` still opens its own
-        # transaction further down — between the two txs another submitter
-        # can race, but ``INSERT INTO jobs`` then PK-conflicts, which is a
-        # legitimate error rather than a correctness bug.
+        # transaction further down (we can't hold a write tx across the
+        # drain wait below) — between the two txs another submitter can
+        # race, so the INSERT tx re-checks existence before INSERTing to
+        # avoid tripping the jobs.job_id PK. See the inner re-check at
+        # the second ``with self._db.transaction()`` below.
         needs_drain = False
         with self._db.transaction() as cur:
             existing_state = reads.get_job_state(cur, job_id)
@@ -1228,8 +1230,15 @@ class ControllerServiceImpl:
             # gets the lock first INSERTs and the loser sees the row here
             # and short-circuits, instead of tripping the jobs.job_id PK
             # (which would surface as INTERNAL — retryable, compounding the
-            # storm).
+            # storm). KEEP mirrors line 1126: return the existing handle as
+            # success. Other policies surface ALREADY_EXISTS; the outer
+            # block's RECREATE / replace-finished path already ran for any
+            # row that was visible at that time, so any row showing up here
+            # belongs to the racing submitter and is too late for us to
+            # replace without re-running the whole flow.
             if reads.get_job_state(cur, job_id) is not None:
+                if request.existing_job_policy == job_pb2.EXISTING_JOB_POLICY_KEEP:
+                    return controller_pb2.Controller.LaunchJobResponse(job_id=job_id.to_wire())
                 raise ConnectError(
                     Code.ALREADY_EXISTS,
                     f"Job {job_id} already exists (concurrent submission)",


### PR DESCRIPTION
The client retried LaunchJob on DEADLINE_EXCEEDED at 30s but the handler can legitimately run past 120s waiting on a predecessor's worker attempts to drain. The retry raced past the existence check and tripped the jobs.job_id PK; the sqlite IntegrityError surfaced as INTERNAL, which is_retryable_error treats as retryable, compounding the storm.

Re-check existence inside the INSERT transaction so the losing handler short-circuits to ALREADY_EXISTS, and override the per-call LaunchJob client timeout to 180s so the drain wait fits inside one attempt.