### PR TITLE
Clarify Iris cluster config selection

### DIFF
--- a/docs/dev-guide/guidelines-internal.md
+++ b/docs/dev-guide/guidelines-internal.md
@@ -57,7 +57,7 @@ cluster. **You will need at least two terminal processes running for the followi
 
 ```bash
 # [Terminal 1] Open SSH tunnel, print the dashboard URL, and block.
-uv run iris --config lib/iris/config/marin.yaml cluster dashboard
+uv run iris --cluster=marin cluster dashboard
 
 # [Browser] Navigate to the URL printed above.
 # Clicking a job opens its per-task/log view.
@@ -71,18 +71,18 @@ To submit jobs, use `iris job run`. Job IDs are canonical paths of the form `/<u
 ```bash
 # [Terminal 2] Submit a job and return immediately.
 #   =>> Will print a line like `Job submitted: /<user>/hello_world-20260420-120000`
-uv run iris --config lib/iris/config/marin.yaml job run \
+uv run iris --cluster=marin job run \
     --no-wait --extra marin:tpu --tpu v5litepod-16 \
     -- python experiments/tutorials/hello_world.py
 
 # List jobs (filter by --state, --user, --prefix, etc).
-uv run iris --config lib/iris/config/marin.yaml job list
+uv run iris --cluster=marin job list
 
 # Follow logs (includes child-job task logs by default).
-uv run iris --config lib/iris/config/marin.yaml job logs /<user>/<job-name>
+uv run iris --cluster=marin job logs /<user>/<job-name>
 
 # Kill / Stop Job (if necessary / error / bug) -- kills the job and all its child tasks.
-uv run iris --config lib/iris/config/marin.yaml job stop /<user>/<job-name>
+uv run iris --cluster=marin job stop /<user>/<job-name>
 ```
 
 Notes:

--- a/experiments/grug/moe/agent.md
+++ b/experiments/grug/moe/agent.md
@@ -163,7 +163,7 @@ Jobs in this directory are submitted to **Iris** on a **v5p-8**.
 ### Submission command
 
 ```bash
-.venv/bin/iris --config lib/iris/config/marin.yaml job run \
+.venv/bin/iris --cluster=marin job run \
   --no-wait \
   --reserve v5p-8 \
   -e WANDB_API_KEY "$WANDB_API_KEY" \
@@ -182,12 +182,12 @@ checking status — do not poll in a tight loop.
 
 Reconnect to logs:
 ```bash
-.venv/bin/iris --config lib/iris/config/marin.yaml job logs -f JOB_ID
+.venv/bin/iris --cluster=marin job logs -f JOB_ID
 ```
 
 List your jobs:
 ```bash
-.venv/bin/iris --config lib/iris/config/marin.yaml job list | grep "$(whoami)"
+.venv/bin/iris --cluster=marin job list | grep "$(whoami)"
 ```
 
 Check runs in wandb (match `<PREFIX>` to the run_id pattern in `launch.py`):

--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -2,7 +2,13 @@
 
 All subcommands have `--help`. Use it.
 
-Two connection modes: `--config=PATH` (auto-tunnels) or `--controller-url=URL` (manual tunnel).
+Connection selectors:
+
+- `--cluster=NAME` (preferred for known clusters): resolves a named config and auto-tunnels.
+- `--config=PATH`: pins an exact YAML config file and auto-tunnels.
+- `--controller-url=URL`: connects to a manually established tunnel.
+
+Use `iris cluster list` to see named clusters. Use `--config` when you mean a custom or pinned file path.
 
 ## Cluster Lifecycle
 
@@ -204,7 +210,8 @@ gcloud compute ssh iris-controller-marin --zone=us-central1-a \
   --project=hai-gcp-models --tunnel-through-iap -- -L 10000:localhost:10000 -N
 
 # Then: iris --controller-url=http://localhost:10000 ...
-# Or config-based auto-tunnel: iris --config=lib/iris/config/marin.yaml ...
+# Or preferred named-cluster auto-tunnel: iris --cluster=marin ...
+# Exact-file form for custom or pinned configs: iris --config=lib/iris/config/marin.yaml ...
 ```
 
 Configs: `marin.yaml` (production), `marin-dev.yaml` (dev, smaller scale caps).

--- a/lib/iris/README.md
+++ b/lib/iris/README.md
@@ -233,7 +233,10 @@ The controller will **fail at startup** if `storage.remote_state_dir` is not con
 
 ## CLI Reference
 
-**Note:** The `--cluster` option resolves a cluster name to a config file (e.g., `--cluster=marin` finds `lib/iris/config/marin.yaml`) and works from any directory. It is a global option that must appear after `iris` but before the subcommand (e.g., `iris --cluster=marin cluster start`).
+**Cluster selection:** Prefer `--cluster=<name>` for known clusters; it resolves named configs such as
+`marin` from the configured search paths. Use `--config=<path>` when you need to pin an exact YAML file,
+such as a custom config or local experiment. Both flags are global and must appear before the subcommand:
+`iris --cluster=marin cluster start`.
 
 ### Cluster Commands
 
@@ -250,8 +253,8 @@ iris --cluster=marin cluster status
 
 ```bash
 # Controller-specific operations
-iris --config=... cluster controller start          # Boot controller GCE VM
-iris --config=... cluster controller status          # Controller status
+iris --cluster=marin cluster controller start       # Boot controller GCE VM
+iris --cluster=marin cluster controller status      # Controller status
 ```
 
 ### VM Operations (via controller RPC)
@@ -274,8 +277,8 @@ iris build controller-image -t iris-controller:v1 --push --region us-central1
 
 ```bash
 # Remote clusters: opens SSH tunnel to controller dashboard
-iris --config=... cluster dashboard
-iris --config=... cluster dashboard --port 8080
+iris --cluster=marin cluster dashboard
+iris --cluster=marin cluster dashboard --port 8080
 
 # Local clusters: dashboard is at the URL printed by `cluster start --local`
 ```

--- a/lib/iris/src/iris/cli/main.py
+++ b/lib/iris/src/iris/cli/main.py
@@ -137,7 +137,7 @@ def rpc_client(
 def require_controller_url(ctx: click.Context) -> str:
     """Get controller_url from context, establishing a tunnel lazily if needed.
 
-    On first call with a --config, this establishes the tunnel to the controller
+    On first call with a loaded config, this establishes the tunnel to the controller
     and caches the result. Subsequent calls return the cached URL.
     Commands that don't call this (e.g. ``cluster start``) never pay tunnel cost.
     """
@@ -192,12 +192,17 @@ def require_controller_url(ctx: click.Context) -> str:
 @click.option("-v", "--verbose", is_flag=True, help="Enable verbose logging")
 @click.option("--traceback", "show_traceback", is_flag=True, help="Show full stack traces on errors")
 @click.option("--controller-url", help="Controller URL (e.g., http://localhost:10000)")
-@click.option("--config", "config_file", type=click.Path(exists=True), help="Cluster config file")
+@click.option(
+    "--config",
+    "config_file",
+    type=click.Path(exists=True),
+    help="Exact cluster config YAML path; use for custom configs or pinned files",
+)
 @click.option(
     "--cluster",
     "cluster_name",
     default=None,
-    help="Cluster name (resolves config automatically) or used for token lookup",
+    help="Named cluster to resolve from config search paths; preferred for known clusters",
 )
 @click.pass_context
 def iris(


### PR DESCRIPTION
## Summary

Clarifies Iris CLI guidance so known clusters use `--cluster=<name>` and exact YAML files use `--config=<path>`.

Changes include:
- updates Iris CLI help text for `--cluster` and `--config`
- tightens the Iris README and OPS guidance
- converts production `marin.yaml` examples in user-facing docs to `--cluster=marin`

## Validation

- `git diff --check`
- `uv run iris --help`
- `uv run python -m py_compile lib/iris/src/iris/cli/main.py`
- `./infra/pre-commit.py --files lib/iris/src/iris/cli/main.py lib/iris/README.md lib/iris/OPS.md docs/dev-guide/guidelines-internal.md experiments/grug/moe/agent.md`