### PR TITLE
[iris] AIMD health-modulated scale-up bucket replaces band-based backoff

### DIFF
--- a/lib/iris/src/iris/cluster/controller/autoscaler/backoff_detector.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/backoff_detector.py
@@ -1,86 +1,87 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""In-memory churn detector for autoscaler scale groups.
+"""AIMD health tracker for the per-group scale-up token bucket.
 
-Replaces the older exponential-backoff-on-failure design. The old design
-treated every short-lived slice death as a fault that earned the group an
-escalating timeout, which produced a sawtooth: capacity drained while the
-group sat in backoff, then burst on recovery. A preemption isn't a fault
-the autoscaler should be punished for — GCP took the slice and there's
-nothing we did wrong. But repeated short-lived deaths *do* signal that
-sending more user work into the zone will keep getting it preempted, so
-we still want to stop scaling up there.
+A single per-group ``health: float`` in ``[probe_floor, 1.0]`` drives the
+bucket's refill rate. State:
 
-This detector tracks the rate of recent short-lived slice deaths over a
-sliding window and exposes a graduated health signal:
+- Starts at ``1.0`` (fully healthy).
+- On every failure event: ``health *= decay_per_failure`` (multiplicative
+  decrease, clamped at ``probe_floor``).
+- On every query/event: ``health += recovery_per_second * dt`` (additive
+  increase, clamped at ``1.0``). ``recovery_per_second`` is chosen so the
+  score climbs from ``probe_floor`` to ``1.0`` over ``recovery_duration``.
 
-    HEALTHY  ( <20% churn)     full scale-up rate
-    SUSPECT  (20-50% churn)    half scale-up rate
-    CHURNING (50-80% churn)    one-tenth scale-up rate, block scale-down
-    HOSTILE  (>=80% churn)     halt scale-up entirely, block scale-down
+This is AIMD — the same shape TCP congestion control uses. One isolated
+failure throttles the group for a short time; sustained failures push it
+to the floor; sustained success lets it climb back smoothly.
 
-A slice that survives past ``long_lived_threshold`` counts as a positive
-sample, so a healthy steady-state group whose slices are all alive reads
-as LONG_LIVED across the window and produces ``churn_rate = 0`` -- one
-unlucky preemption against many healthy slices does not move the needle.
+The bucket's ``refill_rate`` is set to ``base_rate * health`` on every
+``try_acquire_scale_up`` call. Cadence — not batch size — is what gets
+throttled.
 
-Quota-exhaustion gating lives inside this class (``_quota_until``,
-``record_quota_exceeded``, ``clear_quota_block``). Quota is a categorical
-"GCP said no", not churn, so it does not contribute to the churn rate
-and has its own fixed-duration block.
+The probe floor exists so a fully degraded zone still attempts at some low
+rate — without it, zero attempts means zero samples and the score could
+never climb back.
 
-The detector is in-memory only: on controller restart, the window starts
-empty and is repopulated as slices live and die. A short period of "no
-data" after restart is fine — the autoscaler defaults to HEALTHY when
-there are fewer than ``min_samples`` classified outcomes, so it behaves
-exactly like a freshly-deployed cluster until enough samples accumulate.
+Quota-exhaustion is a separate hard block (``record_quota_exceeded``).
+Quota is categorical ("GCP said no") and recovers on GCP's timescale, not
+ours, so it bypasses the health-score machinery entirely.
+
+In-flight ``created_at`` is tracked so a terminated slice can be classified
+short-lived vs. long-lived by age. Only short-lived deaths (or BOOT_FAILED
+at any age) feed the decay; long-lived preemptions are normal preemptible
+behaviour and do nothing.
+
+State is in-memory; on controller restart ``health`` resets to ``1.0``.
 """
 
 from __future__ import annotations
 
-import itertools
 import threading
-from dataclasses import dataclass
 from enum import StrEnum
 
-from rigging.timing import Deadline, Duration, Timestamp
+from rigging.timing import Deadline, Duration, Timestamp, TokenBucket
 
-DEFAULT_WINDOW = Duration.from_minutes(30)
+# Time to recover from probe_floor back to 1.0 under no failures.
+DEFAULT_RECOVERY_DURATION = Duration.from_hours(1)
+
+# Multiplicative decay applied per failure. 0.7 → 1 failure leaves us at 70%,
+# 3 failures at 34%, 5 failures at 17%. Aggressive but not crippling.
+DEFAULT_DECAY_PER_FAILURE = 0.7
+
+# Floor on the effective scale-up rate, in attempts per minute. Even a fully
+# degraded zone keeps probing at this rate so it can produce non-failure
+# outcomes and let the score climb back. At base 16/min, 0.5/min = 3% floor.
+DEFAULT_PROBE_FLOOR_PER_MINUTE = 0.5
+
+# Slices younger than this at termination count as failures; older ones are
+# normal preemptible behaviour.
 DEFAULT_SHORT_LIVED_THRESHOLD = Duration.from_minutes(5)
-DEFAULT_LONG_LIVED_THRESHOLD = Duration.from_minutes(10)
-DEFAULT_MIN_SAMPLES = 3
+
+# How long a quota-exhausted error blocks scale-up before we attempt again.
 DEFAULT_QUOTA_BLOCK_DURATION = Duration.from_minutes(5)
 
-# Health thresholds on churn_rate (fraction of recent classified outcomes
-# that were short-lived deaths).
-SUSPECT_CHURN_RATE = 0.2
-CHURNING_CHURN_RATE = 0.5
-HOSTILE_CHURN_RATE = 0.8
+# Display-only label thresholds on the health score.
+LABEL_HEALTHY = 0.8
+LABEL_SUSPECT = 0.5
+LABEL_CHURNING = 0.2
 
 
 class SliceFate(StrEnum):
-    """How a slice's life ended (or was classified)."""
+    """How a recorded slice's life ended."""
 
-    # The slice was created, reached READY, then was terminated by GCP
-    # (preemption) or otherwise died after running. Whether it counts as
-    # a failure depends on age at death — handled internally by the
-    # detector's classifier.
     PREEMPTED = "preempted"
-
-    # The slice never reached READY (CreateSlice RPC error, bootstrap
-    # FAILED, or UNKNOWN past timeout). Always counts as a failure
-    # regardless of age, since no useful work could have happened.
     BOOT_FAILED = "boot_failed"
-
-    # Synthetic — assigned at classification time to outcomes that have
-    # demonstrably survived past ``long_lived_threshold``. Never passed
-    # in to ``record_terminated``.
-    LONG_LIVED = "long_lived"
 
 
 class GroupHealth(StrEnum):
-    """Graduated health response derived from churn rate."""
+    """Display label derived from the current health score.
+
+    Informational only — the detector throttles on the raw float, not on
+    these bands.
+    """
 
     HEALTHY = "healthy"
     SUSPECT = "suspect"
@@ -88,79 +89,59 @@ class GroupHealth(StrEnum):
     HOSTILE = "hostile"
 
 
-_RATE_MULTIPLIERS: dict[GroupHealth, float] = {
-    GroupHealth.HEALTHY: 1.0,
-    GroupHealth.SUSPECT: 0.5,
-    GroupHealth.CHURNING: 0.1,
-    GroupHealth.HOSTILE: 0.0,
-}
-
-
-@dataclass
-class SliceOutcome:
-    """One observed slice lifecycle, used as a sample in the churn window."""
-
-    slice_id: str
-    created_at: Timestamp
-    fate: SliceFate | None = None
-    fate_at: Timestamp | None = None
-
-
 class BackoffDetector:
-    """Per-group sliding-window churn tracker.
+    """Per-group AIMD health tracker.
 
-    Thread-safe. All event hooks (``record_created``, ``record_terminated``,
-    ``record_create_failed``) and all queries (``churn_rate``, ``health``,
-    ``can_scale_up``, etc.) are safe to call from any thread.
-
-    Failure modes treated as "bad" outcomes for churn-rate purposes:
-
-    - ``BOOT_FAILED`` at any age (the slice never produced useful work).
-    - ``PREEMPTED`` with ``fate_at - created_at < short_lived_threshold``
-      (the slice was up too briefly to be worth feeding more work to).
-
-    Failure modes treated as "good" outcomes:
-
-    - ``PREEMPTED`` with age >= ``short_lived_threshold`` (the slice ran
-      long enough to be useful; preemption was just bad luck).
-    - In-flight outcomes whose age >= ``long_lived_threshold`` (slice is
-      demonstrably surviving, even though we haven't seen termination).
-
-    In-flight outcomes younger than ``long_lived_threshold`` are
-    "pending" — they don't contribute to the rate either way.
+    Thread-safe. Failure events decay the score multiplicatively; recovery
+    accrues additively as wall time advances. ``try_acquire_scale_up``
+    folds the recovery, updates the bucket's refill rate from the current
+    score, and takes a token.
     """
 
     def __init__(
         self,
         group_name: str,
-        window: Duration = DEFAULT_WINDOW,
+        scale_up_bucket: TokenBucket,
+        base_scale_up_per_minute: float,
+        recovery_duration: Duration = DEFAULT_RECOVERY_DURATION,
+        decay_per_failure: float = DEFAULT_DECAY_PER_FAILURE,
+        probe_floor_per_minute: float = DEFAULT_PROBE_FLOOR_PER_MINUTE,
         short_lived_threshold: Duration = DEFAULT_SHORT_LIVED_THRESHOLD,
-        long_lived_threshold: Duration = DEFAULT_LONG_LIVED_THRESHOLD,
-        min_samples: int = DEFAULT_MIN_SAMPLES,
         quota_block_duration: Duration = DEFAULT_QUOTA_BLOCK_DURATION,
     ):
-        if long_lived_threshold.to_ms() < short_lived_threshold.to_ms():
+        if base_scale_up_per_minute <= 0:
+            raise ValueError(f"base_scale_up_per_minute must be > 0, got {base_scale_up_per_minute}")
+        if not 0 < decay_per_failure < 1:
+            raise ValueError(f"decay_per_failure must be in (0, 1), got {decay_per_failure}")
+        if probe_floor_per_minute <= 0:
+            raise ValueError(f"probe_floor_per_minute must be > 0, got {probe_floor_per_minute}")
+        if probe_floor_per_minute >= base_scale_up_per_minute:
             raise ValueError(
-                f"long_lived_threshold ({long_lived_threshold}) must be >= "
-                f"short_lived_threshold ({short_lived_threshold})"
+                f"probe_floor_per_minute ({probe_floor_per_minute}) must be < "
+                f"base_scale_up_per_minute ({base_scale_up_per_minute})"
             )
-        if min_samples < 1:
-            raise ValueError(f"min_samples must be >= 1, got {min_samples}")
 
         self._group_name = group_name
-        self._window = window
+        self._scale_up_bucket = scale_up_bucket
+        self._base_refill_per_second = base_scale_up_per_minute / 60.0
+        self._floor = probe_floor_per_minute / base_scale_up_per_minute
+        self._decay = decay_per_failure
+        self._recovery_per_second = (1.0 - self._floor) / recovery_duration.to_seconds()
         self._short_lived_threshold = short_lived_threshold
-        self._long_lived_threshold = long_lived_threshold
-        self._min_samples = min_samples
         self._quota_block_duration = quota_block_duration
-        self._outcomes: dict[str, SliceOutcome] = {}
-        self._synthetic_seq = itertools.count()
-        # Quota-exhausted gate: a GCP "no quota" signal blocks scale-up for a
-        # fixed window. Quota events do not contribute to the churn rate —
-        # quota is a categorical capacity-allocation failure, not a sign that
-        # work we send into the zone will be reclaimed.
+
+        self._health: float = 1.0
+        self._last_tick: Timestamp | None = None
+
+        # In-flight slice tracking for age classification at termination time.
+        # Does not contribute to the score; just needed so a long-lived slice's
+        # eventual preemption can be recognised as not-a-failure.
+        self._inflight: dict[str, Timestamp] = {}
+
+        # Quota gate — separate from the AIMD state.
         self._quota_until: Deadline | None = None
         self._quota_reason: str = ""
+
         self._lock = threading.Lock()
 
     # -----------------------------------------------------------------------
@@ -168,75 +149,53 @@ class BackoffDetector:
     # -----------------------------------------------------------------------
 
     def record_created(self, slice_id: str, created_at: Timestamp) -> None:
-        """Record that a slice was successfully created.
-
-        Called when the platform's ``CreateSlice`` returns a usable handle.
-        Pairs with a subsequent ``record_terminated`` for the same slice.
-        Safe to call multiple times for the same slice (no-op after first).
-        """
+        """Record a successful slice create. Tracks ``created_at`` for later
+        age-at-death classification. Idempotent (keeps original timestamp)."""
         with self._lock:
-            if slice_id in self._outcomes:
-                return
-            self._outcomes[slice_id] = SliceOutcome(slice_id=slice_id, created_at=created_at)
-            self._gc(created_at)
+            self._inflight.setdefault(slice_id, created_at)
 
     def record_terminated(self, slice_id: str, fate: SliceFate, terminated_at: Timestamp) -> None:
-        """Record that a previously-created slice has ended.
+        """Record the end of a previously-created slice.
 
-        ``fate`` must be ``PREEMPTED`` or ``BOOT_FAILED``; ``LONG_LIVED``
-        is synthetic and only emitted by the classifier.
+        Counts as a failure (decays the score) when:
+        - ``fate == BOOT_FAILED`` (always — slice never produced useful work).
+        - ``fate == PREEMPTED`` and age < ``short_lived_threshold``.
 
-        If the slice was never seen by ``record_created`` (controller
-        restart between create and terminate, etc.), a synthetic outcome
-        is created with ``created_at = terminated_at`` so the event still
-        contributes to the churn rate as a worst-case sample.
+        Long-lived preemptions are silent — the slice did useful work first.
+        If the slice was never seen by :meth:`record_created` (e.g. controller
+        restart), ``created_at`` defaults to ``terminated_at`` → age 0 →
+        short-lived → one decay applied.
         """
-        if fate == SliceFate.LONG_LIVED:
-            raise ValueError("LONG_LIVED is synthetic and cannot be recorded directly")
         with self._lock:
-            outcome = self._outcomes.get(slice_id)
-            if outcome is None:
-                outcome = SliceOutcome(slice_id=slice_id, created_at=terminated_at)
-                self._outcomes[slice_id] = outcome
-            outcome.fate = fate
-            outcome.fate_at = terminated_at
-            self._gc(terminated_at)
+            created_at = self._inflight.pop(slice_id, terminated_at)
+            age_ms = terminated_at.epoch_ms() - created_at.epoch_ms()
+            self._apply_recovery(terminated_at)
+            if fate == SliceFate.BOOT_FAILED:
+                self._apply_decay()
+            elif fate == SliceFate.PREEMPTED and age_ms < self._short_lived_threshold.to_ms():
+                self._apply_decay()
 
     def record_create_failed(self, ts: Timestamp) -> None:
-        """Record a CreateSlice RPC failure (no slice handle was returned).
+        """Record a CreateSlice RPC error (no slice handle was returned).
 
-        Equivalent to a BOOT_FAILED termination of a zero-age slice, but
-        keyed by a synthetic id so it doesn't collide with real slice_ids.
-        Counts toward churn like any other bad outcome.
+        Always a failure event — equivalent to a zero-age BOOT_FAILED.
         """
         with self._lock:
-            synthetic_id = f"__create_failed__{ts.epoch_ms()}_{next(self._synthetic_seq)}"
-            self._outcomes[synthetic_id] = SliceOutcome(
-                slice_id=synthetic_id,
-                created_at=ts,
-                fate=SliceFate.BOOT_FAILED,
-                fate_at=ts,
-            )
-            self._gc(ts)
+            self._apply_recovery(ts)
+            self._apply_decay()
 
     def record_quota_exceeded(self, reason: str, ts: Timestamp) -> None:
-        """Record that GCP rejected a scale-up with a quota error.
+        """Record a quota error from GCP. Sets a fixed-duration hard block.
 
-        Sets a fixed-duration block on scale-up. Does **not** contribute to
-        churn: quota is a categorical allocation failure (we don't have
-        capacity rights), not a sign that work we send into the zone gets
-        reclaimed mid-flight.
+        Quota is categorical, not probabilistic — it does not feed the AIMD
+        score, just sets ``_quota_until``.
         """
         with self._lock:
             self._quota_until = Deadline.after(ts, self._quota_block_duration)
             self._quota_reason = reason
 
     def clear_quota_block(self) -> None:
-        """Clear the quota-block deadline.
-
-        Called when a successful scale-up proves GCP is currently allowing
-        creates in this zone, so the prior "no quota" snapshot is stale.
-        """
+        """Clear the quota-block deadline (called on a proven successful create)."""
         with self._lock:
             self._quota_until = None
             self._quota_reason = ""
@@ -245,131 +204,86 @@ class BackoffDetector:
     # Queries
     # -----------------------------------------------------------------------
 
-    def churn_rate(self, now: Timestamp) -> float:
-        """Fraction of recent classified outcomes that were failures.
-
-        Returns 0.0 when there are fewer than ``min_samples`` classified
-        outcomes — a fresh group is HEALTHY by default, not HOSTILE.
-        """
+    def health(self, now: Timestamp) -> float:
+        """Current health score in ``[probe_floor, 1.0]`` after recovery to now."""
         with self._lock:
-            self._gc(now)
-            classified = [
-                fate for outcome in self._outcomes.values() if (fate := self._classify(outcome, now)) is not None
-            ]
-        if len(classified) < self._min_samples:
-            return 0.0
-        bad = sum(1 for fate in classified if fate != SliceFate.LONG_LIVED)
-        return bad / len(classified)
+            self._apply_recovery(now)
+            return self._health
 
-    def health(self, now: Timestamp) -> GroupHealth:
-        rate = self.churn_rate(now)
-        if rate >= HOSTILE_CHURN_RATE:
-            return GroupHealth.HOSTILE
-        if rate >= CHURNING_CHURN_RATE:
-            return GroupHealth.CHURNING
-        if rate >= SUSPECT_CHURN_RATE:
+    def health_label(self, now: Timestamp) -> GroupHealth:
+        """Display label derived from the current health score."""
+        h = self.health(now)
+        if h >= LABEL_HEALTHY:
+            return GroupHealth.HEALTHY
+        if h >= LABEL_SUSPECT:
             return GroupHealth.SUSPECT
-        return GroupHealth.HEALTHY
+        if h >= LABEL_CHURNING:
+            return GroupHealth.CHURNING
+        return GroupHealth.HOSTILE
 
     def can_scale_up(self, now: Timestamp) -> bool:
-        """False when the group is HOSTILE or inside the quota block window."""
-        quota_deadline, _ = self._snapshot_quota()
-        if quota_deadline is not None and not quota_deadline.expired(now=now):
-            return False
-        return self.health(now) != GroupHealth.HOSTILE
+        """False only when inside the quota-block window.
 
-    def scale_up_rate_multiplier(self, now: Timestamp) -> float:
-        """Multiplier applied to the desired scale-up batch size."""
-        quota_deadline, _ = self._snapshot_quota()
-        if quota_deadline is not None and not quota_deadline.expired(now=now):
-            return 0.0
-        return _RATE_MULTIPLIERS[self.health(now)]
-
-    def should_block_scale_down(self, now: Timestamp) -> bool:
-        """During CHURNING/HOSTILE, surviving slices are precious — don't reap them.
-
-        Quota does not block scale-down: an active quota window only means we
-        can't grow, not that the slices we have are precious.
+        The health score throttles via the bucket's refill rate; it never
+        produces a hard block. Quota is the only categorical gate.
         """
-        return self.health(now) in (GroupHealth.CHURNING, GroupHealth.HOSTILE)
+        deadline, _ = self._snapshot_quota()
+        if deadline is not None and not deadline.expired(now=now):
+            return False
+        return True
+
+    def try_acquire_scale_up(self, now: Timestamp) -> bool:
+        """Apply recovery, set the bucket refill rate to ``base * health``, then acquire.
+
+        Returns False on quota block or empty bucket.
+        """
+        if not self.can_scale_up(now):
+            return False
+        with self._lock:
+            self._apply_recovery(now)
+            self._scale_up_bucket.refill_rate = self._base_refill_per_second * self._health
+        return self._scale_up_bucket.try_acquire(now=now)
 
     def block_reason(self, now: Timestamp) -> str | None:
-        """Human-readable reason scale-up is currently blocked, or ``None``."""
-        quota_deadline, quota_reason = self._snapshot_quota()
-        if quota_deadline is not None and not quota_deadline.expired(now=now):
-            return f"quota exceeded: {quota_reason}" if quota_reason else "quota exceeded"
-        if self.health(now) == GroupHealth.HOSTILE:
-            return f"churn rate {self.churn_rate(now):.0%}"
+        """Reason scale-up is hard-blocked (quota only), or ``None``."""
+        deadline, reason = self._snapshot_quota()
+        if deadline is not None and not deadline.expired(now=now):
+            return f"quota exceeded: {reason}" if reason else "quota exceeded"
         return None
 
     def quota_deadline(self, now: Timestamp) -> Timestamp | None:
-        """Active quota-block expiry, or ``None`` if quota isn't currently blocking."""
         deadline, _ = self._snapshot_quota()
         if deadline is None or deadline.expired(now=now):
             return None
         return deadline.as_timestamp()
 
-    def recent_failure_count(self, now: Timestamp) -> int:
-        """Count of recent classified-as-failure outcomes — for status display."""
-        with self._lock:
-            self._gc(now)
-            classified = [
-                fate for outcome in self._outcomes.values() if (fate := self._classify(outcome, now)) is not None
-            ]
-        return sum(1 for fate in classified if fate != SliceFate.LONG_LIVED)
+    def status_label(self, now: Timestamp) -> str:
+        """Human-readable status string for dashboards/logs.
+
+        Format: ``"<label> health=<score>"``, e.g. ``"churning health=0.34"``.
+        """
+        h = self.health(now)
+        return f"{self.health_label(now).value} health={h:.2f}"
+
+    # -----------------------------------------------------------------------
+    # Internals (caller holds _lock)
+    # -----------------------------------------------------------------------
+
+    def _apply_recovery(self, now: Timestamp) -> None:
+        """Accrue recovery from the last tick to ``now``."""
+        if self._last_tick is None:
+            self._last_tick = now
+            return
+        elapsed_ms = now.epoch_ms() - self._last_tick.epoch_ms()
+        if elapsed_ms <= 0:
+            return
+        self._health = min(1.0, self._health + self._recovery_per_second * (elapsed_ms / 1000.0))
+        self._last_tick = now
+
+    def _apply_decay(self) -> None:
+        """Apply one multiplicative decay, clamped at the probe floor."""
+        self._health = max(self._floor, self._health * self._decay)
 
     def _snapshot_quota(self) -> tuple[Deadline | None, str]:
-        """Snapshot (deadline, reason) under the lock for race-free reads."""
         with self._lock:
             return self._quota_until, self._quota_reason
-
-    # -----------------------------------------------------------------------
-    # Internals (caller must hold _lock for _gc; _classify is pure)
-    # -----------------------------------------------------------------------
-
-    def _gc(self, now: Timestamp) -> None:
-        """Drop resolved outcomes whose ``fate_at`` has aged out of the window.
-
-        In-flight outcomes are intentionally **not** evicted: a slice that
-        legitimately runs longer than the window must still be recognised when
-        it eventually terminates, otherwise a normal preemption of a long-lived
-        survivor would be mis-classified as a short-lived failure (the missing
-        ``record_created`` would cause :meth:`record_terminated` to fabricate
-        ``created_at = terminated_at``, age=0). The no-ghost guarantee from
-        the runtime ensures every in-flight outcome eventually resolves, at
-        which point it ages out via its ``fate_at``.
-        """
-        cutoff_ms = now.epoch_ms() - self._window.to_ms()
-        stale = [
-            slice_id
-            for slice_id, outcome in self._outcomes.items()
-            if outcome.fate_at is not None and outcome.fate_at.epoch_ms() < cutoff_ms
-        ]
-        for slice_id in stale:
-            del self._outcomes[slice_id]
-
-    def _classify(self, outcome: SliceOutcome, now: Timestamp) -> SliceFate | None:
-        """Classify a single outcome into PREEMPTED / BOOT_FAILED / LONG_LIVED / None.
-
-        - BOOT_FAILED is always a failure.
-        - PREEMPTED with age < short_lived_threshold is a failure (PREEMPTED).
-        - PREEMPTED with age >= short_lived_threshold reclassifies as LONG_LIVED.
-        - In-flight outcomes with age >= long_lived_threshold count as LONG_LIVED
-          (the slice has demonstrably survived even though we haven't seen
-          termination yet).
-        - In-flight outcomes younger than long_lived_threshold are pending and
-          contribute nothing to the rate.
-        """
-        if outcome.fate == SliceFate.BOOT_FAILED:
-            return SliceFate.BOOT_FAILED
-        if outcome.fate == SliceFate.PREEMPTED:
-            assert outcome.fate_at is not None
-            age_ms = outcome.fate_at.epoch_ms() - outcome.created_at.epoch_ms()
-            if age_ms < self._short_lived_threshold.to_ms():
-                return SliceFate.PREEMPTED
-            return SliceFate.LONG_LIVED
-        # In-flight (fate is None)
-        age_ms = now.epoch_ms() - outcome.created_at.epoch_ms()
-        if age_ms >= self._long_lived_threshold.to_ms():
-            return SliceFate.LONG_LIVED
-        return None

--- a/lib/iris/src/iris/cluster/controller/autoscaler/backoff_detector.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/backoff_detector.py
@@ -19,7 +19,10 @@ to the floor; sustained success lets it climb back smoothly.
 
 The bucket's ``refill_rate`` is set to ``base_rate * health`` on every
 ``try_acquire_scale_up`` call. Cadence — not batch size — is what gets
-throttled.
+throttled. Each failure also caps the bucket's current token inventory
+to ``capacity * health``, so a previously-healthy bucket that suddenly
+degrades can't burst its accumulated tokens before the lowered refill
+rate takes effect.
 
 The probe floor exists so a fully degraded zone still attempts at some low
 rate — without it, zero attempts means zero samples and the score could
@@ -171,9 +174,9 @@ class BackoffDetector:
             age_ms = terminated_at.epoch_ms() - created_at.epoch_ms()
             self._apply_recovery(terminated_at)
             if fate == SliceFate.BOOT_FAILED:
-                self._apply_decay()
+                self._apply_decay(terminated_at)
             elif fate == SliceFate.PREEMPTED and age_ms < self._short_lived_threshold.to_ms():
-                self._apply_decay()
+                self._apply_decay(terminated_at)
 
     def record_create_failed(self, ts: Timestamp) -> None:
         """Record a CreateSlice RPC error (no slice handle was returned).
@@ -182,7 +185,7 @@ class BackoffDetector:
         """
         with self._lock:
             self._apply_recovery(ts)
-            self._apply_decay()
+            self._apply_decay(ts)
 
     def record_quota_exceeded(self, reason: str, ts: Timestamp) -> None:
         """Record a quota error from GCP. Sets a fixed-duration hard block.
@@ -280,9 +283,16 @@ class BackoffDetector:
         self._health = min(1.0, self._health + self._recovery_per_second * (elapsed_ms / 1000.0))
         self._last_tick = now
 
-    def _apply_decay(self) -> None:
-        """Apply one multiplicative decay, clamped at the probe floor."""
+    def _apply_decay(self, now: Timestamp) -> None:
+        """Apply one multiplicative decay and drain bucket inventory to match.
+
+        Health drops to ``health * decay`` (clamped at the probe floor). The
+        bucket's accumulated tokens are then capped at ``capacity * health``,
+        so a previously-healthy group that suddenly degrades can't burst
+        through a full bucket before the new (lower) refill rate matters.
+        """
         self._health = max(self._floor, self._health * self._decay)
+        self._scale_up_bucket.cap_tokens(self._scale_up_bucket.capacity * self._health, now=now)
 
     def _snapshot_quota(self) -> tuple[Deadline | None, str]:
         with self._lock:

--- a/lib/iris/src/iris/cluster/controller/autoscaler/planning.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/planning.py
@@ -99,10 +99,9 @@ def build_group_scale_plan(group: ScalingGroup, required_slices: int, ts: Timest
     would launch if nothing were rate-limiting us. The actual throttle
     happens later in ``runtime.execute``, where each launch must acquire
     a token from the detector's scale-up bucket; the bucket's refill rate
-    is modulated by health (SUSPECT halves it, CHURNING brings it to 10%,
-    HOSTILE refuses outright). That means CHURNING groups still get a plan
-    here every tick but only succeed at acquiring a token roughly 1/10 as
-    often, which is the actual cadence reduction.
+    is set to ``base_rate * health`` on every acquire, so degraded groups
+    still get a plan here every tick but only succeed at acquiring a
+    token at the AIMD-modulated cadence.
     """
 
     counts = GroupSliceCounts.from_group(group)

--- a/lib/iris/src/iris/cluster/controller/autoscaler/planning.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/planning.py
@@ -95,11 +95,14 @@ class ScalePlan:
 def build_group_scale_plan(group: ScalingGroup, required_slices: int, ts: Timestamp) -> GroupScalePlan:
     """Build the actionable scale-up plan for a group.
 
-    The churn detector's ``scale_up_rate_multiplier`` clamps the per-tick
-    batch size so SUSPECT and CHURNING zones still scale up but at a slower
-    rate, instead of either firing the full burst or sitting in hard backoff.
-    HOSTILE / quota-blocked zones return a 0.0 multiplier, which collapses
-    ``slices_to_add`` to zero — equivalent to the old ``scale_up_blocked``.
+    ``slices_to_add`` is the honest desired count for this tick — what we
+    would launch if nothing were rate-limiting us. The actual throttle
+    happens later in ``runtime.execute``, where each launch must acquire
+    a token from the detector's scale-up bucket; the bucket's refill rate
+    is modulated by health (SUSPECT halves it, CHURNING brings it to 10%,
+    HOSTILE refuses outright). That means CHURNING groups still get a plan
+    here every tick but only succeed at acquiring a token roughly 1/10 as
+    often, which is the actual cadence reduction.
     """
 
     counts = GroupSliceCounts.from_group(group)
@@ -113,12 +116,7 @@ def build_group_scale_plan(group: ScalingGroup, required_slices: int, ts: Timest
         blocked = not group.can_scale_up(ts)
         if not blocked:
             headroom = group.max_slices - counts.total
-            raw = min(slices_needed, headroom)
-            multiplier = group.detector.scale_up_rate_multiplier(ts)
-            # Always launch at least one slice when we want any AND we're not
-            # hard-blocked, so SUSPECT/CHURNING zones make progress (just slowly)
-            # instead of stalling on multiplier * <small> rounding to zero.
-            slices_to_add = max(1, int(raw * multiplier)) if multiplier > 0 else 0
+            slices_to_add = min(slices_needed, headroom)
 
     return GroupScalePlan(
         group=group.name,

--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -315,7 +315,7 @@ class Autoscaler:
                 continue
 
             if decision.action == ScalingAction.SCALE_UP:
-                if not group.acquire_scale_up_token(timestamp):
+                if not group.try_acquire_scale_up(timestamp):
                     rate_limited.setdefault(decision.scale_group, []).append(decision)
                     continue
                 self._execute_scale_up(group, timestamp, reason=decision.reason)

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -12,6 +12,7 @@ helpers.
 from __future__ import annotations
 
 import logging
+import math
 import threading
 from collections.abc import Sequence
 from dataclasses import dataclass, field
@@ -331,21 +332,27 @@ class ScalingGroup:
 
         # Churn / health signal. Replaces the older exponential-backoff state
         # (consecutive_failures, backoff_until, scale_up_cooldown). The detector
-        # also owns the quota-exhaustion gate now, so all "is this group blocked
-        # from scaling up?" questions go through a single source of truth. See
+        # owns the quota-exhaustion gate AND the scale-up token bucket — both
+        # "is this group blocked?" and "is this group rate-limited right now?"
+        # collapse into a single source of truth (``try_acquire_scale_up``),
+        # whose refill rate is health-modulated. See
         # autoscaler/backoff_detector.py for the rationale.
+        scale_up_bucket = TokenBucket(capacity=scale_up_rate_limit, refill_period=Duration.from_minutes(1))
         self._detector = (
             detector
             if detector is not None
-            else BackoffDetector(group_name=config.name, quota_block_duration=quota_timeout)
+            else BackoffDetector(
+                group_name=config.name,
+                scale_up_bucket=scale_up_bucket,
+                base_scale_up_per_minute=scale_up_rate_limit,
+                quota_block_duration=quota_timeout,
+            )
         )
-
-        # Per-group token bucket rate limiter for scale-up API calls
-        self._scale_up_bucket = TokenBucket(capacity=scale_up_rate_limit, refill_period=Duration.from_minutes(1))
 
         # Per-group token bucket rate limiter for scale-down API calls.
         # This replaces the old cooldown-only gate so that multiple idle slices
-        # can be terminated in a single cycle, up to the token budget.
+        # can be terminated in a single cycle, up to the token budget. Scale-down
+        # is not health-modulated, so the bucket stays on ScalingGroup directly.
         self._scale_down_bucket = TokenBucket(capacity=scale_down_rate_limit, refill_period=Duration.from_minutes(1))
 
         # Upsert scaling group row so it exists for future updates
@@ -497,13 +504,27 @@ class ScalingGroup:
         """Churn detector for this group (replaces the old consecutive-failure backoff)."""
         return self._detector
 
-    def recent_failure_count(self, timestamp: Timestamp | None = None) -> int:
-        """Recent windowed failure count from the churn detector."""
-        return self._detector.recent_failure_count(timestamp or Timestamp.now())
-
-    def health(self, timestamp: Timestamp | None = None) -> GroupHealth:
-        """Current health classification (HEALTHY / SUSPECT / CHURNING / HOSTILE)."""
+    def health(self, timestamp: Timestamp | None = None) -> float:
+        """Current AIMD health score in ``[probe_floor, 1.0]``."""
         return self._detector.health(timestamp or Timestamp.now())
+
+    def health_label(self, timestamp: Timestamp | None = None) -> GroupHealth:
+        """Display label (HEALTHY / SUSPECT / CHURNING / HOSTILE)."""
+        return self._detector.health_label(timestamp or Timestamp.now())
+
+    def _failure_count_for_status(self, now: Timestamp) -> int:
+        """Estimated count of recent failures for the legacy proto field.
+
+        Inverts the AIMD decay: ``health = decay^n`` → ``n = log(health) / log(decay)``.
+        Used only to populate the proto ``consecutive_failures`` field for
+        back-compat dashboards/SQL — the canonical signal is the float
+        ``health`` score itself.
+        """
+        score = self._detector.health(now)
+        decay = self._detector._decay
+        if score >= 1.0 or decay >= 1.0 or decay <= 0:
+            return 0
+        return max(1, round(math.log(score) / math.log(decay)))
 
     def begin_scale_up(self, timestamp: Timestamp | None = None) -> None:
         """Mark that a scale-up is in progress.
@@ -852,10 +873,6 @@ class ScalingGroup:
         # Update activity tracking
         self.update_slice_activity(worker_status_map, timestamp)
 
-        # Preserve survivors during a churning zone.
-        if self._detector.should_block_scale_down(timestamp):
-            return []
-
         # Use ready + pending for capacity check to prevent churn during boot
         counts = self.slice_state_counts()
         ready = counts[SliceLifecycleState.READY]
@@ -944,9 +961,13 @@ class ScalingGroup:
             return False
         return True
 
-    def acquire_scale_up_token(self, timestamp: Timestamp | None = None) -> bool:
-        """Try to acquire a scale-up rate limit token. Returns False if rate-limited."""
-        return self._scale_up_bucket.try_acquire(now=timestamp)
+    def try_acquire_scale_up(self, timestamp: Timestamp | None = None) -> bool:
+        """Delegate to the detector, which owns the health-modulated bucket.
+
+        Returns False when the group is HOSTILE, quota-blocked, or the
+        bucket is empty at the current refill rate.
+        """
+        return self._detector.try_acquire_scale_up(timestamp or Timestamp.now())
 
     def acquire_scale_down_token(self, timestamp: Timestamp | None = None) -> bool:
         """Try to acquire a scale-down rate limit token. Returns False if rate-limited."""
@@ -1075,10 +1096,14 @@ class ScalingGroup:
                 quota_until,
             )
 
-        if self._detector.health(timestamp) == GroupHealth.HOSTILE:
+        # HOSTILE label → waterfall routing prefers fallback. The detector still
+        # probes at the floor, but routing is best served sending active demand
+        # to a healthier zone when one exists.
+        if self._detector.health_label(timestamp) == GroupHealth.HOSTILE:
+            score = self._detector.health(timestamp)
             return AvailabilityState(
                 GroupAvailability.BACKOFF,
-                self._detector.block_reason(timestamp) or "",
+                f"degraded (health={score:.2f})",
             )
 
         with self._slices_lock:
@@ -1201,7 +1226,7 @@ class ScalingGroup:
             current_demand=self._current_demand,
             peak_demand=self._peak_demand,
             backoff_until=timestamp_to_proto(Timestamp.from_ms(0)),
-            consecutive_failures=self._detector.recent_failure_count(now),
+            consecutive_failures=self._failure_count_for_status(now),
             last_scale_up=timestamp_to_proto(self._last_scale_up),
             last_scale_down=timestamp_to_proto(self._last_scale_down),
             availability_status=availability.status.value,

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -850,17 +850,15 @@ class ScalingGroup:
         """Scale down idle slices that exceed target capacity.
 
         Terminates multiple idle slices in a single call, rate-limited by a
-        token bucket (matching the scale-up rate limiter). When the churn
-        detector reports CHURNING or HOSTILE for this group, scale-down is
-        suppressed entirely — the surviving slices are proven survivors of a
-        churning zone, and reaping them when we can't easily replace them
-        accelerates the sawtooth.
+        token bucket (matching the scale-up rate limiter). Scale-down is not
+        health-modulated — the AIMD machinery throttles scale-up cadence
+        only, so a degraded group still reaps its idle survivors at the
+        standard rate-limited cadence when target capacity drops.
 
         Steps:
         1. Update slice activity based on worker idle status
-        2. Skip if the detector says we shouldn't scale down right now
-        3. Check if we're over target capacity (using ready + pending)
-        4. Find eligible idle slices and terminate them (up to the token budget)
+        2. Check if we're over target capacity (using ready + pending)
+        3. Find eligible idle slices and terminate them (up to the token budget)
 
         Args:
             worker_status_map: Map of worker_id to worker status

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -115,19 +115,27 @@ class TestAutoscalerScaleUp:
 
         assert len(decisions) == 0
 
-    def test_no_scale_up_when_detector_hostile(self, scale_group_config: config_pb2.ScaleGroupConfig):
-        """Does not scale up when the churn detector reports HOSTILE."""
+    def test_hostile_zone_drops_to_backoff_for_routing(self, scale_group_config: config_pb2.ScaleGroupConfig):
+        """At HOSTILE label, the group's availability becomes BACKOFF so demand
+        waterfalls to a fallback. Note: this is routing-level behaviour, not a
+        detector-level hard block — ``can_scale_up`` only flips false on quota.
+        The detector instead throttles the per-group bucket's refill rate.
+        """
+        from iris.cluster.controller.autoscaler.backoff_detector import GroupHealth
+        from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability
+
         platform = make_mock_platform()
         group = ScalingGroup(scale_group_config, platform)
         ts = Timestamp.now()
-        for _ in range(3):
+        # With decay=0.7, 5 failures = 0.168 → HOSTILE (below 0.2 band).
+        for _ in range(5):
             group.record_create_failed(timestamp=ts)
-        autoscaler = make_autoscaler({"test-group": group})
 
-        demand = make_demand_entries(2, device_type=DeviceType.TPU, device_variant="v5p-8")
-        decisions = autoscaler.evaluate(demand)
-
-        assert len(decisions) == 0
+        assert group.detector.health_label(ts) == GroupHealth.HOSTILE
+        # Detector itself: no hard block, would still hand out probe tokens.
+        assert group.can_scale_up()
+        # Routing: BACKOFF status keeps demand off this group entirely.
+        assert group.availability(ts).status == GroupAvailability.BACKOFF
 
     def test_scales_up_to_fill_buffer(self):
         """Scales up to fill buffer_slices even with zero demand."""
@@ -411,8 +419,9 @@ class TestAutoscalerExecution:
         autoscaler.execute([decision], timestamp=Timestamp.from_ms(1000))
         autoscaler._wait_for_inflight()
 
-        # The create-failure shows up in the detector's recent-failure count.
-        assert group.recent_failure_count(Timestamp.from_ms(2000)) == 1
+        # The create-failure decays the detector's health score below 1.0.
+        # One failure at decay=0.7 → health ~0.7 (and recovery over 2 ms is negligible).
+        assert group.detector.health(Timestamp.from_ms(2000)) < 1.0
 
     def test_run_once_evaluates_and_executes(self, empty_autoscaler: Autoscaler):
         """run_once() performs evaluate then execute."""
@@ -768,6 +777,7 @@ class TestAutoscalerQuotaHandling:
     def test_generic_error_triggers_backoff_not_quota(self, scale_group_config: config_pb2.ScaleGroupConfig):
         """Non-quota errors push the churn detector, not the quota gate. Once enough
         failures accumulate, availability flips to BACKOFF (HOSTILE)."""
+        from iris.cluster.controller.autoscaler.backoff_detector import GroupHealth
         from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability
 
         platform = make_mock_platform()
@@ -778,15 +788,16 @@ class TestAutoscalerQuotaHandling:
         config.evaluation_interval.CopyFrom(duration_to_proto(Duration.from_seconds(0.001)))
         autoscaler = make_autoscaler({"test-group": group}, config=config)
 
-        # Drive enough failures past min_samples to reach HOSTILE.
+        # Drive enough failures to reach the HOSTILE display band.
+        # With decay=0.7, 5 failures → health ≈ 0.168, < 0.2 → HOSTILE.
         demand = make_demand_entries(1, device_type=DeviceType.TPU, device_variant="v5p-8")
-        for i in range(3):
+        for i in range(5):
             autoscaler.run_once(demand, {}, timestamp=Timestamp.from_ms(1000 + i))
             autoscaler._wait_for_inflight()
 
         state = group.availability(timestamp=Timestamp.from_ms(2000))
         assert state.status == GroupAvailability.BACKOFF
-        assert group.recent_failure_count(Timestamp.from_ms(2000)) >= 3
+        assert group.detector.health_label(Timestamp.from_ms(2000)) == GroupHealth.HOSTILE
 
 
 class TestAutoscalerActionLogging:

--- a/lib/iris/tests/cluster/controller/test_autoscaler_integration.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler_integration.py
@@ -257,9 +257,9 @@ class TestAutoscalerWaterfallEndToEnd:
 
         demand = make_demand_entries(2, device_type=DeviceType.TPU, device_variant="v5p-8")
 
-        # Drive enough failures on the primary group to push the churn detector
-        # past HOSTILE (3 samples → 100% short-lived).
-        for _ in range(3):
+        # Drive enough failures on the primary group to push the detector
+        # past the HOSTILE display threshold (>=80% of failures_at_probe_floor=10).
+        for _ in range(8):
             autoscaler.run_once(demand, {})
             autoscaler._wait_for_inflight()
         assert group_primary.availability().status == GroupAvailability.BACKOFF

--- a/lib/iris/tests/cluster/controller/test_backoff_detector.py
+++ b/lib/iris/tests/cluster/controller/test_backoff_detector.py
@@ -210,6 +210,39 @@ def test_refill_rate_tracks_health() -> None:
     assert bucket.refill_rate == pytest.approx(BASE_RATE_PER_SEC * DEFAULT_DECAY_PER_FAILURE, abs=1e-6)
 
 
+def test_decay_drains_stockpiled_bucket_tokens() -> None:
+    """A previously-healthy bucket cannot burst at its old rate after rapid failures.
+
+    Without inventory clamping, a bucket sitting at full capacity (because the
+    group has been healthy long enough) would let through ``capacity`` acquires
+    immediately after the group becomes HOSTILE — exactly the behaviour the
+    AIMD throttle is supposed to prevent. Each decay step caps the bucket's
+    current tokens at ``capacity * health``.
+    """
+    bucket = TokenBucket(capacity=BASE_RATE_PER_MIN, refill_period=Duration.from_minutes(1))
+    detector = BackoffDetector(
+        group_name="g",
+        scale_up_bucket=bucket,
+        base_scale_up_per_minute=BASE_RATE_PER_MIN,
+    )
+    # Fill the bucket: one acquire at t=60s refills 60s worth at full rate
+    # (clamped to capacity), then consumes one token. 15 of 16 remain.
+    assert detector.try_acquire_scale_up(ts(60))
+
+    # Burst of failures at the same timestamp. Each decay caps tokens at
+    # capacity * health, geometrically shrinking the available burst.
+    for _ in range(5):
+        detector.record_create_failed(ts(60))
+
+    # Health ≈ 0.7^5 ≈ 0.168 → max tokens ≈ 16 * 0.168 ≈ 2.7. At most ~3
+    # acquires succeed before the bucket is drained.
+    successes = 0
+    for _ in range(BASE_RATE_PER_MIN):
+        if detector.try_acquire_scale_up(ts(60)):
+            successes += 1
+    assert successes <= 3
+
+
 def test_probe_floor_clamps_health_above_zero() -> None:
     """Even with many failures, health never drops below the probe floor."""
     bucket = TokenBucket(capacity=BASE_RATE_PER_MIN, refill_period=Duration.from_minutes(1))
@@ -224,7 +257,10 @@ def test_probe_floor_clamps_health_above_zero() -> None:
         detector.record_create_failed(ts(1000))
     floor = floor_per_min / BASE_RATE_PER_MIN
     assert detector.health(ts(1000)) == pytest.approx(floor, abs=1e-9)
-    assert detector.try_acquire_scale_up(ts(1000))
+    # Bucket inventory was clamped on every decay → tokens ≈ capacity * floor = 0.5,
+    # below one whole token, so the immediate probe fails (no burst at the old rate).
+    # The refill rate still reflects the floor; one token accrues after ~120s at 0.5/min.
+    assert not detector.try_acquire_scale_up(ts(1000))
     assert bucket.refill_rate == pytest.approx(BASE_RATE_PER_SEC * floor, abs=1e-6)
 
 

--- a/lib/iris/tests/cluster/controller/test_backoff_detector.py
+++ b/lib/iris/tests/cluster/controller/test_backoff_detector.py
@@ -1,352 +1,284 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for the in-memory churn detector."""
+"""Unit tests for the AIMD backoff detector."""
 
 from __future__ import annotations
 
+import math
+
 import pytest
 from iris.cluster.controller.autoscaler.backoff_detector import (
+    DEFAULT_DECAY_PER_FAILURE,
+    DEFAULT_PROBE_FLOOR_PER_MINUTE,
+    DEFAULT_RECOVERY_DURATION,
     BackoffDetector,
     GroupHealth,
     SliceFate,
 )
-from rigging.timing import Duration, Timestamp
+from rigging.timing import Duration, Timestamp, TokenBucket
+
+BASE_RATE_PER_MIN = 16
+BASE_RATE_PER_SEC = BASE_RATE_PER_MIN / 60.0
 
 
 def ts(seconds: float) -> Timestamp:
-    """Test-fixture helper: build a Timestamp from a seconds-since-epoch number."""
     return Timestamp.from_ms(int(seconds * 1000))
+
+
+def make_detector(
+    *,
+    group_name: str = "test_group",
+    short_lived_threshold: Duration = Duration.from_minutes(5),
+    quota_block_duration: Duration = Duration.from_minutes(5),
+    base_rate_per_min: float = BASE_RATE_PER_MIN,
+    recovery_duration: Duration = DEFAULT_RECOVERY_DURATION,
+    decay_per_failure: float = DEFAULT_DECAY_PER_FAILURE,
+    probe_floor_per_minute: float = DEFAULT_PROBE_FLOOR_PER_MINUTE,
+) -> BackoffDetector:
+    bucket = TokenBucket(capacity=int(base_rate_per_min), refill_period=Duration.from_minutes(1))
+    return BackoffDetector(
+        group_name=group_name,
+        scale_up_bucket=bucket,
+        base_scale_up_per_minute=base_rate_per_min,
+        recovery_duration=recovery_duration,
+        decay_per_failure=decay_per_failure,
+        probe_floor_per_minute=probe_floor_per_minute,
+        short_lived_threshold=short_lived_threshold,
+        quota_block_duration=quota_block_duration,
+    )
 
 
 @pytest.fixture
 def detector() -> BackoffDetector:
-    return BackoffDetector(
-        group_name="test_group",
-        window=Duration.from_minutes(30),
-        short_lived_threshold=Duration.from_minutes(5),
-        long_lived_threshold=Duration.from_minutes(10),
-        min_samples=3,
-    )
+    return make_detector()
 
 
-def test_empty_detector_is_healthy(detector: BackoffDetector) -> None:
+def test_fresh_detector_is_healthy(detector: BackoffDetector) -> None:
     now = ts(1000)
-    assert detector.churn_rate(now) == 0.0
-    assert detector.health(now) == GroupHealth.HEALTHY
+    assert detector.health(now) == 1.0
+    assert detector.health_label(now) == GroupHealth.HEALTHY
     assert detector.can_scale_up(now)
-    assert detector.scale_up_rate_multiplier(now) == 1.0
-    assert not detector.should_block_scale_down(now)
-    assert detector.recent_failure_count(now) == 0
+    assert detector.try_acquire_scale_up(now)
 
 
-def test_below_min_samples_stays_healthy(detector: BackoffDetector) -> None:
-    """Even all-failure samples don't trigger backoff below min_samples (3)."""
+def test_single_failure_decays_health_to_decay_factor(detector: BackoffDetector) -> None:
     detector.record_create_failed(ts(1000))
-    detector.record_create_failed(ts(1001))
-    assert detector.health(ts(1002)) == GroupHealth.HEALTHY
-    assert detector.churn_rate(ts(1002)) == 0.0
+    # Same timestamp → no recovery applied, just the decay.
+    assert detector.health(ts(1000)) == pytest.approx(DEFAULT_DECAY_PER_FAILURE, abs=1e-9)
 
 
-def test_three_create_failures_hits_hostile(detector: BackoffDetector) -> None:
-    detector.record_create_failed(ts(1000))
-    detector.record_create_failed(ts(1001))
-    detector.record_create_failed(ts(1002))
-    assert detector.churn_rate(ts(1003)) == 1.0
-    assert detector.health(ts(1003)) == GroupHealth.HOSTILE
-    assert not detector.can_scale_up(ts(1003))
-    assert detector.scale_up_rate_multiplier(ts(1003)) == 0.0
-    assert detector.should_block_scale_down(ts(1003))
+def test_n_failures_decay_geometrically(detector: BackoffDetector) -> None:
+    for _ in range(3):
+        detector.record_create_failed(ts(1000))
+    assert detector.health(ts(1000)) == pytest.approx(DEFAULT_DECAY_PER_FAILURE**3, abs=1e-9)
 
 
-def test_preempted_short_lived_counts_as_failure(detector: BackoffDetector) -> None:
-    """PREEMPTED with age < short_lived_threshold = failure."""
-    for i in range(3):
-        slice_id = f"s{i}"
-        detector.record_created(slice_id, ts(1000 + i))
-        # Dies 60s later — well under the 5-min short_lived threshold.
-        detector.record_terminated(slice_id, SliceFate.PREEMPTED, ts(1060 + i))
-    assert detector.churn_rate(ts(1100)) == 1.0
-    assert detector.health(ts(1100)) == GroupHealth.HOSTILE
+def test_boot_failed_termination_is_a_failure(detector: BackoffDetector) -> None:
+    detector.record_created("s1", ts(1000))
+    detector.record_terminated("s1", SliceFate.BOOT_FAILED, ts(1100))
+    # Health decayed once (recovery over 100s in lock is negligible vs the decay).
+    assert detector.health(ts(1100)) < 1.0
 
 
-def test_preempted_long_lived_counts_as_success(detector: BackoffDetector) -> None:
-    """PREEMPTED with age >= short_lived_threshold = positive sample (survived the test)."""
-    for i in range(3):
-        slice_id = f"s{i}"
-        detector.record_created(slice_id, ts(1000 + i))
-        # Dies 6 min later (360s) — past the 5-min threshold.
-        detector.record_terminated(slice_id, SliceFate.PREEMPTED, ts(1360 + i))
-    assert detector.churn_rate(ts(1400)) == 0.0
-    assert detector.health(ts(1400)) == GroupHealth.HEALTHY
+def test_short_lived_preemption_is_a_failure(detector: BackoffDetector) -> None:
+    """A slice that dies before short_lived_threshold counts as a failure."""
+    detector.record_created("s1", ts(1000))
+    detector.record_terminated("s1", SliceFate.PREEMPTED, ts(1060))
+    assert detector.health(ts(1060)) < 1.0
 
 
-def test_boot_failed_always_counts_as_failure(detector: BackoffDetector) -> None:
-    """BOOT_FAILED is failure regardless of age (slice never produced work)."""
-    for i in range(3):
-        slice_id = f"s{i}"
-        detector.record_created(slice_id, ts(1000))
-        # "Age" up to 10 min in record_terminated — still BOOT_FAILED.
-        detector.record_terminated(slice_id, SliceFate.BOOT_FAILED, ts(1600))
-    assert detector.churn_rate(ts(1700)) == 1.0
-    assert detector.health(ts(1700)) == GroupHealth.HOSTILE
+def test_long_lived_preemption_is_not_a_failure(detector: BackoffDetector) -> None:
+    """Slice that survived past short_lived_threshold then got preempted is normal behaviour."""
+    detector.record_created("s1", ts(1000))
+    detector.record_terminated("s1", SliceFate.PREEMPTED, ts(1360))
+    # No decay applied → still healthy.
+    assert detector.health(ts(1360)) == 1.0
+    assert detector.health_label(ts(1360)) == GroupHealth.HEALTHY
 
 
-def test_inflight_long_enough_counts_as_long_lived(detector: BackoffDetector) -> None:
-    """In-flight slice aged past long_lived_threshold should count as positive."""
-    for i in range(3):
-        detector.record_created(f"s{i}", ts(1000 + i))
-    # 10 minutes later — past long_lived_threshold.
-    now = ts(1610)
-    assert detector.churn_rate(now) == 0.0
-    assert detector.health(now) == GroupHealth.HEALTHY
-
-
-def test_inflight_too_young_is_pending(detector: BackoffDetector) -> None:
-    """In-flight slice younger than long_lived_threshold doesn't contribute."""
-    for i in range(3):
-        detector.record_created(f"s{i}", ts(1000 + i))
-    # 30 seconds later — way too young.
-    now = ts(1030)
-    # All three samples are pending → classified count is 0 → below min_samples → HEALTHY.
-    assert detector.churn_rate(now) == 0.0
-    assert detector.health(now) == GroupHealth.HEALTHY
-
-
-def test_mixed_outcomes_compute_rate(detector: BackoffDetector) -> None:
-    """A mix of 2 failures + 3 successes should yield 2/5 = 40% churn → SUSPECT."""
-    # 2 short-lived preemptions
-    for i in range(2):
-        slice_id = f"bad{i}"
-        detector.record_created(slice_id, ts(1000 + i))
-        detector.record_terminated(slice_id, SliceFate.PREEMPTED, ts(1060 + i))
-    # 3 long-lived preemptions (survived past 5 min)
-    for i in range(3):
-        slice_id = f"good{i}"
-        detector.record_created(slice_id, ts(1000 + i))
-        detector.record_terminated(slice_id, SliceFate.PREEMPTED, ts(1500 + i))
-    now = ts(1600)
-    assert detector.churn_rate(now) == pytest.approx(2 / 5)
-    assert detector.health(now) == GroupHealth.SUSPECT
-    assert detector.scale_up_rate_multiplier(now) == 0.5
-
-
-def test_churning_threshold(detector: BackoffDetector) -> None:
-    """5 failures + 5 successes = 50% → CHURNING (boundary)."""
-    for i in range(5):
-        slice_id = f"bad{i}"
-        detector.record_created(slice_id, ts(1000 + i))
-        detector.record_terminated(slice_id, SliceFate.PREEMPTED, ts(1060 + i))
-    for i in range(5):
-        slice_id = f"good{i}"
-        detector.record_created(slice_id, ts(1000 + i))
-        detector.record_terminated(slice_id, SliceFate.PREEMPTED, ts(1500 + i))
-    now = ts(1600)
-    assert detector.churn_rate(now) == 0.5
-    assert detector.health(now) == GroupHealth.CHURNING
-    assert detector.scale_up_rate_multiplier(now) == 0.1
-    assert detector.can_scale_up(now)  # CHURNING still scales up, just slowly
-    assert detector.should_block_scale_down(now)
-
-
-def test_window_drops_old_outcomes(detector: BackoffDetector) -> None:
-    """Outcomes older than the 30-min window should be evicted."""
-    for i in range(3):
-        slice_id = f"old{i}"
-        detector.record_created(slice_id, ts(0))
-        detector.record_terminated(slice_id, SliceFate.PREEMPTED, ts(60))
-    # 31 minutes later — past the 30-min window from fate_at.
-    now = ts(60 + 31 * 60)
-    assert detector.churn_rate(now) == 0.0
-    assert detector.recent_failure_count(now) == 0
-
-
-def test_outcome_aging_uses_fate_at(detector: BackoffDetector) -> None:
-    """An old creation but recent fate_at should still be in-window."""
-    detector.record_created("s1", ts(0))
-    # Slice runs for 25 minutes, then gets preempted (short-lived case from
-    # the detector's perspective: age 25min, but PREEMPTED long-lived wins).
-    detector.record_terminated("s1", SliceFate.PREEMPTED, ts(25 * 60))
-    # 4 minutes after termination — well within the 30-min window from fate_at.
-    now = ts(25 * 60 + 4 * 60)
-    detector.record_create_failed(now)
-    detector.record_create_failed(now)
-    # Now we have: 1 LONG_LIVED + 2 BOOT_FAILED = 2/3 → CHURNING.
-    assert detector.churn_rate(now) == pytest.approx(2 / 3)
-    assert detector.health(now) == GroupHealth.CHURNING
-
-
-def test_long_lived_inflight_outcome_is_retained(detector: BackoffDetector) -> None:
-    """In-flight outcomes are kept past the window so the slice can be
-    correctly classified when it eventually terminates.
-
-    If we evicted them, a normal preemption of a long-lived survivor would
-    look like an "unknown slice died" (no record_created found), get a
-    synthetic ``created_at = terminated_at``, and be mis-classified as a
-    short-lived failure — inflating churn on healthy steady-state groups.
-    """
-    detector.record_created("alive", ts(0))
-    now = ts(31 * 60)
-    detector.record_create_failed(now)
-    detector.record_create_failed(now)
-    detector.record_create_failed(now)
-    # 1 LONG_LIVED (in-flight, aged past long_lived_threshold) + 3 BOOT_FAILED
-    # → 3/4 = 75% → CHURNING (not HOSTILE).
-    assert detector.churn_rate(now) == pytest.approx(3 / 4)
-    assert detector.health(now) == GroupHealth.CHURNING
-
-
-def test_long_lived_survivor_preemption_is_not_short_lived(
-    detector: BackoffDetector,
-) -> None:
-    """Regression: a slice that survived past the window and is then preempted
-    must still classify as LONG_LIVED, not as a fabricated short-lived event."""
+def test_long_lived_survivor_termination_classifies_correctly(detector: BackoffDetector) -> None:
+    """A slice that lived 45 minutes still classifies as long-lived on terminate."""
     detector.record_created("survivor", ts(0))
-    # Slice quietly survives for 45 minutes (past the 30-min window).
-    # Then GCP preempts it. With the old GC, the slice would have been evicted
-    # at age=30min and the termination record would fabricate created_at=now,
-    # classifying as PREEMPTED short-lived. With the corrected GC, the
-    # in-flight outcome is retained and the termination records age=45min
-    # → LONG_LIVED.
     detector.record_terminated("survivor", SliceFate.PREEMPTED, ts(45 * 60))
-    now = ts(45 * 60 + 1)
-    # Need min_samples=3 to compute a rate; add two BOOT_FAILED.
-    detector.record_create_failed(now)
-    detector.record_create_failed(now)
-    # 1 LONG_LIVED + 2 BOOT_FAILED → 2/3 churn → CHURNING.
-    # Critically, the survivor was NOT counted as a failure.
-    assert detector.churn_rate(now) == pytest.approx(2 / 3)
+    assert detector.health(ts(45 * 60 + 1)) == 1.0
 
 
-def test_record_terminated_long_lived_raises(detector: BackoffDetector) -> None:
-    with pytest.raises(ValueError, match="synthetic"):
-        detector.record_terminated("s1", SliceFate.LONG_LIVED, ts(1000))
+def test_unknown_slice_termination_counted_as_short_lived(detector: BackoffDetector) -> None:
+    """If we never saw record_created, default created_at = terminated_at → age 0 → short-lived."""
+    detector.record_terminated("ghost", SliceFate.PREEMPTED, ts(1000))
+    assert detector.health(ts(1000)) < 1.0
 
 
 def test_record_created_is_idempotent(detector: BackoffDetector) -> None:
+    """A second record_created for the same slice keeps the original created_at."""
     detector.record_created("s1", ts(1000))
     detector.record_created("s1", ts(2000))  # second call ignored
-    detector.record_terminated("s1", SliceFate.PREEMPTED, ts(2060))
-    # The first record_created at ts=1000 stuck, so age = 2060 - 1000 = 1060s > 300s.
-    # Classifies as LONG_LIVED.
-    detector.record_create_failed(ts(2070))
-    detector.record_create_failed(ts(2070))
-    # 1 LONG_LIVED + 2 BOOT_FAILED = 2/3 churn → CHURNING.
-    assert detector.churn_rate(ts(2080)) == pytest.approx(2 / 3)
+    # Terminate at t=1360 — original created_at=1000 → age 360s > 300s → long-lived.
+    detector.record_terminated("s1", SliceFate.PREEMPTED, ts(1360))
+    assert detector.health(ts(1400)) == 1.0
 
 
-def test_record_terminated_without_record_created(detector: BackoffDetector) -> None:
-    """Surprise termination (no prior record_created) should still count as a failure."""
-    detector.record_terminated("ghost1", SliceFate.PREEMPTED, ts(1000))
-    detector.record_terminated("ghost2", SliceFate.PREEMPTED, ts(1001))
-    detector.record_terminated("ghost3", SliceFate.PREEMPTED, ts(1002))
-    # created_at == terminated_at → age 0 → PREEMPTED short-lived → all bad.
-    assert detector.churn_rate(ts(1003)) == 1.0
-    assert detector.health(ts(1003)) == GroupHealth.HOSTILE
+def test_recovery_climbs_back_to_full_after_one_hour() -> None:
+    """Default recovery_duration=1h drives a floor-pinned score back to 1.0."""
+    detector = make_detector(recovery_duration=Duration.from_hours(1))
+    # Drive way past the floor.
+    for _ in range(20):
+        detector.record_create_failed(ts(0))
+    # 1 hour + 1s later, fully recovered (clamped at 1.0).
+    assert detector.health(ts(3601)) == 1.0
+    assert detector.health_label(ts(3601)) == GroupHealth.HEALTHY
 
 
-def test_long_lived_threshold_below_short_lived_threshold_rejected() -> None:
-    with pytest.raises(ValueError, match="long_lived_threshold"):
-        BackoffDetector(
-            "g",
-            short_lived_threshold=Duration.from_minutes(10),
-            long_lived_threshold=Duration.from_minutes(5),
-        )
-
-
-def test_min_samples_below_one_rejected() -> None:
-    with pytest.raises(ValueError, match="min_samples"):
-        BackoffDetector("g", min_samples=0)
+def test_recovery_is_partial_within_recovery_duration() -> None:
+    """Inside recovery_duration, health is strictly between floor and 1.0."""
+    detector = make_detector(recovery_duration=Duration.from_hours(1))
+    # Drive to the floor.
+    for _ in range(20):
+        detector.record_create_failed(ts(0))
+    floor = DEFAULT_PROBE_FLOOR_PER_MINUTE / BASE_RATE_PER_MIN
+    # 30 minutes — half the recovery window. Gap closes by ~half.
+    score = detector.health(ts(1800))
+    assert floor < score < 1.0
+    # Roughly the midpoint of [floor, 1.0].
+    assert score == pytest.approx(floor + (1.0 - floor) * 0.5, abs=0.01)
 
 
 def test_quota_blocks_scale_up_for_block_duration() -> None:
-    detector = BackoffDetector(
-        "g",
-        quota_block_duration=Duration.from_minutes(5),
-    )
+    detector = make_detector(quota_block_duration=Duration.from_minutes(5))
     detector.record_quota_exceeded("over v6e-256 quota", ts(1000))
-    # Inside the block window
     inside = ts(1000 + 60)
     assert not detector.can_scale_up(inside)
-    assert detector.scale_up_rate_multiplier(inside) == 0.0
+    assert not detector.try_acquire_scale_up(inside)
     assert detector.block_reason(inside) == "quota exceeded: over v6e-256 quota"
     assert detector.quota_deadline(inside) is not None
-    # Past the block window
     outside = ts(1000 + 5 * 60 + 1)
     assert detector.can_scale_up(outside)
-    assert detector.scale_up_rate_multiplier(outside) == 1.0
+    assert detector.try_acquire_scale_up(outside)
     assert detector.block_reason(outside) is None
     assert detector.quota_deadline(outside) is None
 
 
-def test_quota_does_not_contribute_to_churn() -> None:
-    detector = BackoffDetector("g", min_samples=1)
+def test_quota_does_not_decay_health() -> None:
+    detector = make_detector()
     detector.record_quota_exceeded("no quota", ts(1000))
-    # Recording quota should not affect churn rate.
-    assert detector.churn_rate(ts(1001)) == 0.0
-    assert detector.health(ts(1001)) == GroupHealth.HEALTHY
+    assert detector.health(ts(1001)) == 1.0
+    assert detector.health_label(ts(1001)) == GroupHealth.HEALTHY
 
 
-def test_quota_blocks_even_when_churn_is_healthy() -> None:
-    detector = BackoffDetector("g")
-    detector.record_quota_exceeded("no quota", ts(1000))
-    inside = ts(1000 + 60)
-    assert detector.health(inside) == GroupHealth.HEALTHY
-    assert not detector.can_scale_up(inside)  # quota still blocks
+def test_quota_block_does_not_touch_bucket() -> None:
+    bucket = TokenBucket(capacity=BASE_RATE_PER_MIN, refill_period=Duration.from_minutes(1))
+    detector = BackoffDetector(
+        group_name="g",
+        scale_up_bucket=bucket,
+        base_scale_up_per_minute=BASE_RATE_PER_MIN,
+    )
+    detector.record_quota_exceeded("nope", ts(1000))
+    tokens_before = bucket.available
+    assert not detector.try_acquire_scale_up(ts(1060))
+    assert bucket.available == tokens_before
 
 
-def test_quota_does_not_block_scale_down() -> None:
-    detector = BackoffDetector("g")
-    detector.record_quota_exceeded("no quota", ts(1000))
-    assert not detector.should_block_scale_down(ts(1060))
+def test_base_rate_must_be_positive() -> None:
+    with pytest.raises(ValueError, match="base_scale_up_per_minute"):
+        make_detector(base_rate_per_min=0)
 
 
-def test_block_reason_prefers_quota_over_churn() -> None:
-    detector = BackoffDetector("g", min_samples=3)
-    for i in range(3):
-        detector.record_create_failed(ts(1000 + i))
-    detector.record_quota_exceeded("over quota", ts(1010))
-    inside = ts(1020)
-    # HOSTILE churn AND quota — quota reason wins for the reporting string.
-    assert detector.health(inside) == GroupHealth.HOSTILE
-    assert detector.block_reason(inside) == "quota exceeded: over quota"
+def test_decay_must_be_in_open_unit_interval() -> None:
+    with pytest.raises(ValueError, match="decay_per_failure"):
+        make_detector(decay_per_failure=0)
+    with pytest.raises(ValueError, match="decay_per_failure"):
+        make_detector(decay_per_failure=1.0)
+
+
+def test_probe_floor_must_be_below_base_rate() -> None:
+    with pytest.raises(ValueError, match="probe_floor_per_minute"):
+        make_detector(probe_floor_per_minute=BASE_RATE_PER_MIN)
+
+
+def test_refill_rate_tracks_health() -> None:
+    """try_acquire_scale_up sets refill_rate = base_per_second * health."""
+    bucket = TokenBucket(capacity=BASE_RATE_PER_MIN, refill_period=Duration.from_minutes(1))
+    detector = BackoffDetector(
+        group_name="g",
+        scale_up_bucket=bucket,
+        base_scale_up_per_minute=BASE_RATE_PER_MIN,
+    )
+    detector.record_create_failed(ts(1000))
+    # Acquire at the same timestamp — recovery is zero, so health == 0.7.
+    assert detector.try_acquire_scale_up(ts(1000))
+    assert bucket.refill_rate == pytest.approx(BASE_RATE_PER_SEC * DEFAULT_DECAY_PER_FAILURE, abs=1e-6)
+
+
+def test_probe_floor_clamps_health_above_zero() -> None:
+    """Even with many failures, health never drops below the probe floor."""
+    bucket = TokenBucket(capacity=BASE_RATE_PER_MIN, refill_period=Duration.from_minutes(1))
+    floor_per_min = 0.5
+    detector = BackoffDetector(
+        group_name="g",
+        scale_up_bucket=bucket,
+        base_scale_up_per_minute=BASE_RATE_PER_MIN,
+        probe_floor_per_minute=floor_per_min,
+    )
+    for _ in range(50):
+        detector.record_create_failed(ts(1000))
+    floor = floor_per_min / BASE_RATE_PER_MIN
+    assert detector.health(ts(1000)) == pytest.approx(floor, abs=1e-9)
+    assert detector.try_acquire_scale_up(ts(1000))
+    assert bucket.refill_rate == pytest.approx(BASE_RATE_PER_SEC * floor, abs=1e-6)
 
 
 @pytest.mark.parametrize(
-    "rate,expected_health,expected_multiplier",
+    "failures,expected_label",
     [
-        (0.0, GroupHealth.HEALTHY, 1.0),
-        (0.19, GroupHealth.HEALTHY, 1.0),
-        (0.20, GroupHealth.SUSPECT, 0.5),
-        (0.49, GroupHealth.SUSPECT, 0.5),
-        (0.50, GroupHealth.CHURNING, 0.1),
-        (0.79, GroupHealth.CHURNING, 0.1),
-        (0.80, GroupHealth.HOSTILE, 0.0),
-        (1.00, GroupHealth.HOSTILE, 0.0),
+        (0, GroupHealth.HEALTHY),  # 1.0
+        (1, GroupHealth.SUSPECT),  # 0.7
+        (2, GroupHealth.CHURNING),  # 0.49
+        (4, GroupHealth.CHURNING),  # 0.24
+        (5, GroupHealth.HOSTILE),  # 0.168
+        (10, GroupHealth.HOSTILE),
     ],
 )
-def test_health_thresholds(rate: float, expected_health: GroupHealth, expected_multiplier: float) -> None:
-    """Synthesize outcomes to hit specific churn_rate values and verify mapping."""
-    # Need at least min_samples=3, and rate = bad/total. Pick total=100 so we can
-    # round-trip arbitrary rates to integer counts.
-    detector = BackoffDetector("g", min_samples=3)
-    total = 100
-    bad = round(rate * total)
-    good = total - bad
-    base_created = ts(0)
-    base_died_short = ts(60)  # 60s < short_lived 5min → counts as failure
-    base_died_long = ts(60 + 6 * 60)  # 6min+60s > short_lived → counts as success
-    # Choose ``now`` just past the latest fate_at so nothing has aged out of
-    # the 30-min window.
-    now = ts(base_died_long.epoch_ms() // 1000 + 10)
-    for i in range(bad):
-        slice_id = f"bad{i}"
-        detector.record_created(slice_id, base_created)
-        detector.record_terminated(slice_id, SliceFate.PREEMPTED, base_died_short)
-    for i in range(good):
-        slice_id = f"good{i}"
-        detector.record_created(slice_id, base_created)
-        detector.record_terminated(slice_id, SliceFate.PREEMPTED, base_died_long)
-    assert detector.churn_rate(now) == pytest.approx(rate, abs=0.005)
-    assert detector.health(now) == expected_health
-    assert detector.scale_up_rate_multiplier(now) == expected_multiplier
+def test_health_label_bands(failures: int, expected_label: GroupHealth) -> None:
+    """Display label thresholds: HEALTHY ≥ 0.8, SUSPECT ≥ 0.5, CHURNING ≥ 0.2, else HOSTILE."""
+    detector = make_detector()
+    for _ in range(failures):
+        detector.record_create_failed(ts(1000))
+    assert detector.health_label(ts(1000)) == expected_label
+
+
+def test_status_label_format() -> None:
+    detector = make_detector()
+    detector.record_create_failed(ts(1000))
+    # health == 0.7 → "suspect health=0.70"
+    assert detector.status_label(ts(1000)) == "suspect health=0.70"
+
+
+def test_continuous_recovery_drives_health_back_up() -> None:
+    """Without further failures, health monotonically climbs back toward 1.0."""
+    detector = make_detector(recovery_duration=Duration.from_hours(1))
+    for _ in range(5):  # → HOSTILE
+        detector.record_create_failed(ts(0))
+    early = detector.health(ts(60))
+    later = detector.health(ts(1800))
+    much_later = detector.health(ts(3700))
+    assert early < later < much_later
+    assert much_later == 1.0
+
+
+def test_health_never_exceeds_one() -> None:
+    detector = make_detector()
+    # Many quiet ticks shouldn't push score over 1.0.
+    detector.health(ts(0))
+    assert detector.health(ts(10**8)) == 1.0
+
+
+def test_recovery_rate_matches_recovery_duration() -> None:
+    """Internal: recovery_per_second exactly bridges floor → 1.0 in recovery_duration."""
+    detector = make_detector(recovery_duration=Duration.from_hours(1))
+    floor = DEFAULT_PROBE_FLOOR_PER_MINUTE / BASE_RATE_PER_MIN
+    expected = (1.0 - floor) / Duration.from_hours(1).to_seconds()
+    assert detector._recovery_per_second == pytest.approx(expected, abs=1e-12)
+    # And the inverse — number of failures needed to floor — matches log math.
+    n_to_floor = math.ceil(math.log(floor) / math.log(DEFAULT_DECAY_PER_FAILURE))
+    assert n_to_floor >= 5  # default tuning: ~10 failures to floor

--- a/lib/iris/tests/cluster/controller/test_demand_routing.py
+++ b/lib/iris/tests/cluster/controller/test_demand_routing.py
@@ -392,7 +392,8 @@ class TestWaterfallRouting:
         group_fallback = ScalingGroup(config_fallback, make_mock_platform())
 
         ts = Timestamp.from_ms(1000)
-        for _ in range(3):
+        # With decay=0.7, 5 failures → 0.168 (HOSTILE).
+        for _ in range(5):
             group_primary.record_create_failed(timestamp=ts)
         assert group_primary.availability(ts).status == GroupAvailability.BACKOFF
 
@@ -402,7 +403,7 @@ class TestWaterfallRouting:
         assert len(result.routed_entries.get("fallback", [])) == 2
         status_by_group = {s.group: s for s in result.group_statuses}
         assert status_by_group["primary"].decision == "blocked"
-        assert "churn" in status_by_group["primary"].reason
+        assert "degraded" in status_by_group["primary"].reason
         assert status_by_group["fallback"].decision == "selected"
 
     def test_backoff_group_with_ready_slices_still_falls_through(self):
@@ -418,7 +419,7 @@ class TestWaterfallRouting:
         group_fallback = ScalingGroup(config_fallback, make_mock_platform())
 
         ts = Timestamp.from_ms(1000)
-        for _ in range(3):
+        for _ in range(8):
             group_primary.record_create_failed(timestamp=ts)
         assert group_primary.availability(ts).status == GroupAvailability.BACKOFF
         assert group_primary.slice_count() == 1

--- a/lib/iris/tests/cluster/providers/test_scaling_group.py
+++ b/lib/iris/tests/cluster/providers/test_scaling_group.py
@@ -11,7 +11,7 @@ import logging
 from pathlib import Path
 
 import pytest
-from iris.cluster.controller.autoscaler.backoff_detector import SliceFate
+from iris.cluster.controller.autoscaler.backoff_detector import GroupHealth, SliceFate
 from iris.cluster.controller.autoscaler.scaling_group import (
     ScalingGroup,
     SliceLifecycleState,
@@ -278,15 +278,24 @@ class TestScalingGroupScalingPolicy:
         assert group.slice_count() == 5  # max_slices
         assert not group.can_scale_up()
 
-    def test_cannot_scale_up_when_detector_hostile(self, unbounded_config: config_pb2.ScaleGroupConfig):
-        """can_scale_up() returns False when the churn detector is HOSTILE."""
+    def test_hostile_throttles_bucket_to_probe_floor(self, unbounded_config: config_pb2.ScaleGroupConfig):
+        """At 100% churn, try_acquire_scale_up still works but the bucket refills at the probe floor.
+
+        Continuous control: there is no hard "HOSTILE" block, only a low refill rate.
+        ``can_scale_up`` only flips to False on quota.
+        """
         platform = make_mock_platform()
         group = ScalingGroup(unbounded_config, platform)
         ts = Timestamp.from_ms(1_000_000)
-        # Three create-failures in the window pushes churn to 100% → HOSTILE.
-        for _ in range(3):
+        # With decay=0.7, 8 failures drive health below the probe floor → clamped to floor.
+        for _ in range(8):
             group.record_create_failed(timestamp=ts)
-        assert not group.can_scale_up(timestamp=Timestamp.from_ms(1_001_000))
+        now = Timestamp.from_ms(1_001_000)
+        # Health-driven throttling is not a "block" — quota would be.
+        assert group.can_scale_up(timestamp=now)
+        # Bucket starts full so first acquire succeeds; refill rate is now the probe floor.
+        assert group.try_acquire_scale_up(timestamp=now)
+        assert group.detector.health_label(now) == GroupHealth.HOSTILE
 
     def test_scale_down_rate_limited_by_token_bucket(self, unbounded_config: config_pb2.ScaleGroupConfig):
         """acquire_scale_down_token() returns False when the token bucket is exhausted."""
@@ -316,14 +325,22 @@ class TestScalingGroupChurnDetector:
     """
 
     def test_create_failures_drive_detector_hostile(self, unbounded_config: config_pb2.ScaleGroupConfig):
-        """Three create-failures push the detector to HOSTILE, blocking scale-up."""
+        """Enough create-failures push the detector label to HOSTILE.
+
+        Under failure-counting control HOSTILE is a label only — scale-up keeps
+        flowing at the probe floor.
+        """
         platform = make_mock_platform()
         group = ScalingGroup(unbounded_config, platform)
         ts = Timestamp.from_ms(1_000_000)
-        for _ in range(3):
+        # With decay=0.7, 5 failures → 0.168 (HOSTILE).
+        for _ in range(5):
             group.record_create_failed(timestamp=ts)
-        assert group.recent_failure_count(Timestamp.from_ms(1_001_000)) == 3
-        assert not group.can_scale_up(timestamp=Timestamp.from_ms(1_001_000))
+        now = Timestamp.from_ms(1_001_000)
+        # Recovery over 1s is small (~3e-4); score remains in the HOSTILE band.
+        assert group.detector.health_label(now) == GroupHealth.HOSTILE
+        # Hard block is quota-only; failures throttle the bucket but never gate it.
+        assert group.can_scale_up(timestamp=now)
 
     def test_long_lived_preemption_does_not_block_scale_up(self, unbounded_config: config_pb2.ScaleGroupConfig):
         """A slice preempted past short_lived threshold is a positive sample."""
@@ -728,7 +745,7 @@ class TestScalingGroupAvailability:
         platform = make_mock_platform()
         group = ScalingGroup(unbounded_config, platform)
         ts = Timestamp.from_ms(1000000)
-        for _ in range(3):
+        for _ in range(8):
             group.record_create_failed(timestamp=ts)
 
         state = group.availability(Timestamp.from_ms(1001000))
@@ -818,7 +835,7 @@ class TestScalingGroupAvailability:
         group = ScalingGroup(unbounded_config, platform, quota_timeout=Duration.from_ms(60_000))
 
         ts = Timestamp.from_ms(1000)
-        for _ in range(3):
+        for _ in range(8):
             group.record_create_failed(timestamp=ts)  # detector → HOSTILE
         group.record_quota_exceeded("quota exceeded", ts)
 

--- a/lib/iris/tests/cluster/providers/test_scaling_group.py
+++ b/lib/iris/tests/cluster/providers/test_scaling_group.py
@@ -279,7 +279,8 @@ class TestScalingGroupScalingPolicy:
         assert not group.can_scale_up()
 
     def test_hostile_throttles_bucket_to_probe_floor(self, unbounded_config: config_pb2.ScaleGroupConfig):
-        """At 100% churn, try_acquire_scale_up still works but the bucket refills at the probe floor.
+        """At 100% churn, the bucket refills at the probe floor and acquires
+        succeed only after waiting one floor-tokens' worth of time.
 
         Continuous control: there is no hard "HOSTILE" block, only a low refill rate.
         ``can_scale_up`` only flips to False on quota.
@@ -288,14 +289,19 @@ class TestScalingGroupScalingPolicy:
         group = ScalingGroup(unbounded_config, platform)
         ts = Timestamp.from_ms(1_000_000)
         # With decay=0.7, 8 failures drive health below the probe floor → clamped to floor.
+        # Each decay also caps the bucket inventory at capacity * health, so by
+        # the time we're at the floor the bucket holds well under one token.
         for _ in range(8):
             group.record_create_failed(timestamp=ts)
         now = Timestamp.from_ms(1_001_000)
         # Health-driven throttling is not a "block" — quota would be.
         assert group.can_scale_up(timestamp=now)
-        # Bucket starts full so first acquire succeeds; refill rate is now the probe floor.
-        assert group.try_acquire_scale_up(timestamp=now)
-        assert group.detector.health_label(now) == GroupHealth.HOSTILE
+        # Immediate acquire fails: drained-on-decay bucket needs to refill at the floor rate.
+        assert not group.try_acquire_scale_up(timestamp=now)
+        # Default scale_up_rate_limit is 16/min, floor 0.5/min → one token in ~120s.
+        much_later = Timestamp.from_ms(ts.epoch_ms() + 5 * 60_000)
+        assert group.try_acquire_scale_up(timestamp=much_later)
+        assert group.detector.health_label(much_later) == GroupHealth.HOSTILE
 
     def test_scale_down_rate_limited_by_token_bucket(self, unbounded_config: config_pb2.ScaleGroupConfig):
         """acquire_scale_down_token() returns False when the token bucket is exhausted."""

--- a/lib/rigging/src/rigging/timing.py
+++ b/lib/rigging/src/rigging/timing.py
@@ -443,6 +443,26 @@ class TokenBucket:
         self._tokens = min(self._capacity, self._tokens + elapsed_seconds * self.refill_rate)
         self._last_refill = now
 
+    def cap_tokens(self, max_tokens: float, now: Timestamp | None = None) -> None:
+        """Drain stockpiled tokens down to ``max_tokens``.
+
+        Refills up to ``now`` first so the cap applies to the up-to-date
+        token count. Used by external rate-modulation (e.g. the AIMD
+        detector): when the effective refill rate is lowered, capped
+        inventory prevents a previously-healthy bucket from bursting
+        at its pre-drop rate.
+        """
+        now = now or Timestamp.now()
+        with self._lock:
+            self._refill(now)
+            if self._tokens > max_tokens:
+                self._tokens = max(0.0, max_tokens)
+
+    @property
+    def capacity(self) -> int:
+        """Maximum tokens the bucket can hold (exposed for external rate-modulation)."""
+        return self._capacity
+
     @property
     def available(self) -> int:
         """Current available tokens after refilling from elapsed time."""

--- a/lib/rigging/src/rigging/timing.py
+++ b/lib/rigging/src/rigging/timing.py
@@ -421,7 +421,7 @@ class TokenBucket:
     def __init__(self, capacity: int, refill_period: Duration):
         self._capacity = capacity
         self._tokens = float(capacity)
-        self._refill_rate = capacity / refill_period.to_seconds()  # tokens/sec
+        self.refill_rate = capacity / refill_period.to_seconds()  # tokens/sec, public for runtime tuning
         self._last_refill = Timestamp.from_ms(0)
         self._lock = threading.Lock()
 
@@ -440,7 +440,7 @@ class TokenBucket:
         if elapsed_ms <= 0:
             return
         elapsed_seconds = elapsed_ms / 1000.0
-        self._tokens = min(self._capacity, self._tokens + elapsed_seconds * self._refill_rate)
+        self._tokens = min(self._capacity, self._tokens + elapsed_seconds * self.refill_rate)
         self._last_refill = now
 
     @property


### PR DESCRIPTION
Per-group scale-up rate is now driven by a single AIMD health score in [probe_floor, 1.0], not a sliding-window failure list with band-based multipliers. Failures decay the score multiplicatively; recovery accrues additively over recovery_duration. The bucket's refill_rate is set to base_rate * health on every acquire, so cadence (not batch size) is what gets throttled. Probe floor at 0.5/min keeps degraded zones generating samples without rebuilding meaningful capacity. Eliminates the floor=1 per-tick bug where CHURNING groups still launched every 10s.