### PR TITLE
[iris] Reclaim dead cloud slices and purge orphan slice rows at boot

### DIFF
--- a/lib/iris/src/iris/cluster/controller/autoscaler/recovery.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/recovery.py
@@ -20,7 +20,9 @@ from iris.cluster.controller.autoscaler.worker_registry import TrackedWorker, Tr
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.schema import scaling_groups_table, slices_table, workers_table
 from iris.cluster.providers.protocols import WorkerInfraProvider
-from iris.cluster.providers.types import SliceHandle
+from iris.cluster.providers.types import CloudSliceState, SliceHandle
+
+_LIVE_CLOUD_STATES = frozenset({CloudSliceState.CREATING, CloudSliceState.READY, CloudSliceState.REPAIRING})
 
 logger = logging.getLogger(__name__)
 
@@ -112,10 +114,12 @@ def restore_autoscaler_state(
 ) -> dict[str, TrackedWorker]:
     """Restore scaling groups and tracked workers from a checkpoint."""
 
-    all_cloud_slices = platform.list_all_slices()
     cloud_by_group: dict[str, list[SliceHandle]] = {}
-    for handle in all_cloud_slices:
-        cloud_by_group.setdefault(handle.scale_group, []).append(handle)
+    for listed in platform.list_all_slices():
+        if listed.state not in _LIVE_CLOUD_STATES:
+            _reclaim_dead_slice(listed.handle, listed.state)
+            continue
+        cloud_by_group.setdefault(listed.handle.scale_group, []).append(listed.handle)
 
     for group_snapshot in checkpoint.group_snapshots.values():
         group = groups.get(group_snapshot.name)
@@ -135,5 +139,11 @@ def restore_autoscaler_state(
             last_scale_up=restore_result.last_scale_up,
             last_scale_down=restore_result.last_scale_down,
         )
+        group.purge_persisted_slice_rows(restore_result.discarded_slice_ids)
 
     return restore_tracked_workers(checkpoint.tracked_worker_rows)
+
+
+def _reclaim_dead_slice(handle: SliceHandle, state: CloudSliceState) -> None:
+    logger.info("Reclaiming dead slice %s (state=%s, zone=%s)", handle.slice_id, state, handle.zone)
+    handle.terminate()

--- a/lib/iris/src/iris/cluster/controller/autoscaler/recovery.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/recovery.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from dataclasses import dataclass
 
 from sqlalchemy import select
@@ -145,5 +146,18 @@ def restore_autoscaler_state(
 
 
 def _reclaim_dead_slice(handle: SliceHandle, state: CloudSliceState) -> None:
+    """Best-effort terminate of a dead slice in a daemon thread.
+
+    Boot recovery must not block on or fail because of a stale cloud resource:
+    terminate() can hit transient API errors and is not guaranteed to be fast.
+    Errors are logged; on the next restart the slice will surface again.
+    """
     logger.info("Reclaiming dead slice %s (state=%s, zone=%s)", handle.slice_id, state, handle.zone)
-    handle.terminate()
+
+    def _run() -> None:
+        try:
+            handle.terminate()
+        except Exception as e:
+            logger.warning("Failed to terminate dead slice %s: %s", handle.slice_id, e)
+
+    threading.Thread(target=_run, name=f"reclaim-{handle.slice_id}", daemon=True).start()

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -420,6 +420,13 @@ class ScalingGroup:
         with self._db.transaction() as cur:
             cur.execute(delete(slices_table).where(slices_table.c.scale_group == self.name))
 
+    def purge_persisted_slice_rows(self, slice_ids: Sequence[str]) -> None:
+        """Delete the named slice rows from the slices table in a single transaction."""
+        if self._db is None or not slice_ids:
+            return
+        with self._db.transaction() as cur:
+            cur.execute(delete(slices_table).where(slices_table.c.slice_id.in_(list(slice_ids))))
+
     @property
     def platform(self) -> WorkerInfraProvider:
         """Worker infrastructure provider for this scale group."""
@@ -1248,7 +1255,7 @@ class ScalingGroupRestoreResult:
     """Result of restoring a single scaling group from checkpoint metadata."""
 
     slices: dict[str, SliceState] = field(default_factory=dict)
-    discarded_count: int = 0
+    discarded_slice_ids: list[str] = field(default_factory=list)
     adopted_count: int = 0
     last_scale_up: Timestamp = field(default_factory=lambda: Timestamp.from_ms(0))
     last_scale_down: Timestamp = field(default_factory=lambda: Timestamp.from_ms(0))
@@ -1269,7 +1276,7 @@ def restore_scaling_group(
         cloud_handle = cloud_by_id.get(slice_id)
         if cloud_handle is None:
             logger.info("Scaling group %s: discarding slice %s (missing from cloud)", group_snapshot.name, slice_id)
-            result.discarded_count += 1
+            result.discarded_slice_ids.append(slice_id)
             continue
 
         try:
@@ -1311,7 +1318,7 @@ def restore_scaling_group(
         "Restored scaling group %s: %d slices (%d discarded, %d adopted)",
         group_snapshot.name,
         len(result.slices),
-        result.discarded_count,
+        len(result.discarded_slice_ids),
         result.adopted_count,
     )
     return result

--- a/lib/iris/src/iris/cluster/providers/gcp/handles.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/handles.py
@@ -41,7 +41,9 @@ from iris.time_proto import duration_from_proto
 
 logger = logging.getLogger(__name__)
 
-# GCP TPU state mapping
+# GCP TPU state mapping. States not in this map collapse to UNKNOWN; the boot
+# reconciler treats anything outside the alive set (CREATING/READY/REPAIRING)
+# as a candidate for reclaim.
 _TPU_STATE_MAP: dict[str, CloudSliceState] = {
     "CREATING": CloudSliceState.CREATING,
     "READY": CloudSliceState.READY,
@@ -222,7 +224,6 @@ class GcpSliceHandle:
         _gcp_service: GcpService,
         _ssh_config: config_pb2.SshConfig | None = None,
         _service_account: str | None = None,
-        _state: str = "READY",
         _bootstrapping: bool = False,
         _is_queued_resource: bool = False,
     ):
@@ -237,7 +238,6 @@ class GcpSliceHandle:
         self._accelerator_variant = _accelerator_variant
         self._ssh_config = _ssh_config
         self._service_account = _service_account
-        self._state = _state
         self.is_queued_resource: bool = _is_queued_resource
         self._bootstrap_state: CloudSliceState | None = None if _bootstrapping else CloudSliceState.READY
         self._bootstrap_lock = threading.Lock()

--- a/lib/iris/src/iris/cluster/providers/gcp/handles.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/handles.py
@@ -60,6 +60,19 @@ _VM_STATE_MAP: dict[str, CloudSliceState] = {
 }
 
 _ACTIVE_VM_SLICE_STATES = frozenset({"PROVISIONING", "STAGING", "RUNNING"})
+
+# Queued-resource (reserved TPU) state mapping. Non-live states must surface so
+# the boot reconciler can reclaim them; ACTIVE is transient (the matching TPU
+# VM is what list_all_slices normally returns) and only appears here briefly.
+_QR_STATE_MAP: dict[str, CloudSliceState] = {
+    "QUEUED": CloudSliceState.CREATING,
+    "WAITING_FOR_RESOURCES": CloudSliceState.CREATING,
+    "PROVISIONING": CloudSliceState.CREATING,
+    "ACTIVE": CloudSliceState.READY,
+    "FAILED": CloudSliceState.FAILED,
+    "SUSPENDED": CloudSliceState.FAILED,
+    "DELETING": CloudSliceState.DELETING,
+}
 _GCE_NAME_MAX_LEN = 63
 _GCE_NAME_RE = re.compile(r"[^a-z0-9-]+")
 _GCE_NAME_EDGE_RE = re.compile(r"^-+|-+$")

--- a/lib/iris/src/iris/cluster/providers/gcp/workers.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/workers.py
@@ -27,6 +27,8 @@ from iris.cluster.providers.gcp.bootstrap import (
 )
 from iris.cluster.providers.gcp.handles import (
     _ACTIVE_VM_SLICE_STATES,
+    _TPU_STATE_MAP,
+    _VM_STATE_MAP,
     CloudSliceState,
     GcpSliceHandle,
     GcpStandaloneWorkerHandle,
@@ -46,6 +48,7 @@ from iris.cluster.providers.remote_exec import GceRemoteExec
 from iris.cluster.providers.types import (
     InfraError,
     Labels,
+    ListedSlice,
     SliceHandle,
     generate_slice_suffix,
 )
@@ -628,7 +631,6 @@ class GcpWorkerProvider:
                     _gcp_service=self._gcp,
                     _ssh_config=self._ssh_config,
                     _service_account=tpu.service_account,
-                    _state=tpu.state,
                 )
             )
 
@@ -657,53 +659,52 @@ class GcpWorkerProvider:
 
         return handles
 
-    def list_all_slices(self) -> list[GcpSliceHandle | GcpVmSliceHandle]:
-        """List all autoscaler-managed slices for this cluster.
+    def list_all_slices(self) -> list[ListedSlice]:
+        """List every autoscaler-managed slice for this cluster, regardless of cloud state.
 
         Uses project-wide queries (empty zones = all zones) via GcpService,
         filtered by iris-{prefix}-managed=true. Slices tagged
-        iris-{prefix}-manual=true (operator-created via `iris cluster
-        create-slice`) are excluded: the autoscaler and `cluster stop` must
-        not see or terminate them.
+        iris-{prefix}-manual=true are excluded — those are operator-created
+        and never autoscaler-owned.
         """
         managed_labels = {self._iris_labels.iris_managed: "true"}
         manual_label = self._iris_labels.iris_manual
 
         if self._gcp.mode == ServiceMode.LOCAL:
             local_handles = self._gcp.get_local_slices(managed_labels)
-            return [h for h in local_handles if h.labels.get(manual_label) != "true"]  # type: ignore[return-value]
+            return [
+                ListedSlice(handle=h, state=CloudSliceState.READY)
+                for h in local_handles
+                if h.labels.get(manual_label) != "true"
+            ]
 
         tpu_infos = self._gcp.tpu_list(zones=[], labels=managed_labels)
         vm_infos = self._gcp.vm_list(zones=[], labels=managed_labels)
 
-        handles: list[GcpSliceHandle | GcpVmSliceHandle] = []
+        listed: list[ListedSlice] = []
 
         for tpu in tpu_infos:
-            if tpu.state not in ("READY", "CREATING"):
-                continue
             if tpu.labels.get(manual_label) == "true":
                 continue
-            handles.append(
-                GcpSliceHandle(
-                    _slice_id=tpu.name,
-                    _zone=tpu.zone,
-                    _project_id=self._project_id,
-                    _labels=tpu.labels,
-                    _created_at=tpu.created_at,
-                    _label_prefix=self._label_prefix,
-                    _accelerator_variant=tpu.accelerator_type,
-                    _gcp_service=self._gcp,
-                    _ssh_config=self._ssh_config,
-                    _service_account=tpu.service_account,
-                    _state=tpu.state,
-                    _is_queued_resource=tpu.labels.get(CAPACITY_TYPE_LABEL) == CAPACITY_TYPE_RESERVED_VALUE,
-                )
+            handle = GcpSliceHandle(
+                _slice_id=tpu.name,
+                _zone=tpu.zone,
+                _project_id=self._project_id,
+                _labels=tpu.labels,
+                _created_at=tpu.created_at,
+                _label_prefix=self._label_prefix,
+                _accelerator_variant=tpu.accelerator_type,
+                _gcp_service=self._gcp,
+                _ssh_config=self._ssh_config,
+                _service_account=tpu.service_account,
+                _is_queued_resource=tpu.labels.get(CAPACITY_TYPE_LABEL) == CAPACITY_TYPE_RESERVED_VALUE,
             )
+            listed.append(ListedSlice(handle=handle, state=_TPU_STATE_MAP.get(tpu.state, CloudSliceState.UNKNOWN)))
 
         # Discover queued resources (reserved TPUs) not yet visible as TPU VMs.
         # These are in QUEUED/PROVISIONING/WAITING_FOR_RESOURCES and need handles
         # so the controller doesn't orphan them on restart.
-        tpu_names = {h.slice_id for h in handles}
+        tpu_names = {item.handle.slice_id for item in listed}
         qr_infos = self._gcp.queued_resource_list(zones=[], labels=managed_labels)
         for qr in qr_infos:
             if qr.name in tpu_names:
@@ -712,21 +713,20 @@ class GcpWorkerProvider:
                 continue
             if qr.labels.get(manual_label) == "true":
                 continue
-            handles.append(
-                GcpSliceHandle(
-                    _slice_id=qr.name,
-                    _zone=qr.zone,
-                    _project_id=self._project_id,
-                    _labels=qr.labels
-                    or {CAPACITY_TYPE_LABEL: CAPACITY_TYPE_RESERVED_VALUE, self._iris_labels.iris_managed: "true"},
-                    _created_at=Timestamp.now(),
-                    _label_prefix=self._label_prefix,
-                    _accelerator_variant="",
-                    _gcp_service=self._gcp,
-                    _ssh_config=self._ssh_config,
-                    _is_queued_resource=True,
-                )
+            handle = GcpSliceHandle(
+                _slice_id=qr.name,
+                _zone=qr.zone,
+                _project_id=self._project_id,
+                _labels=qr.labels
+                or {CAPACITY_TYPE_LABEL: CAPACITY_TYPE_RESERVED_VALUE, self._iris_labels.iris_managed: "true"},
+                _created_at=Timestamp.now(),
+                _label_prefix=self._label_prefix,
+                _accelerator_variant="",
+                _gcp_service=self._gcp,
+                _ssh_config=self._ssh_config,
+                _is_queued_resource=True,
             )
+            listed.append(ListedSlice(handle=handle, state=CloudSliceState.CREATING))
 
         for vm in vm_infos:
             if vm.status not in _ACTIVE_VM_SLICE_STATES:
@@ -736,23 +736,22 @@ class GcpWorkerProvider:
                 continue
             if vm.labels.get(manual_label) == "true":
                 continue
-            handles.append(
-                GcpVmSliceHandle(
-                    _slice_id=slice_id,
-                    _vm_name=vm.name,
-                    _zone=vm.zone,
-                    _project_id=self._project_id,
-                    _gcp_service=self._gcp,
-                    _labels=vm.labels,
-                    _created_at=vm.created_at,
-                    _label_prefix=self._label_prefix,
-                    _ssh_config=self._ssh_config,
-                    _service_account=vm.service_account,
-                )
+            handle = GcpVmSliceHandle(
+                _slice_id=slice_id,
+                _vm_name=vm.name,
+                _zone=vm.zone,
+                _project_id=self._project_id,
+                _gcp_service=self._gcp,
+                _labels=vm.labels,
+                _created_at=vm.created_at,
+                _label_prefix=self._label_prefix,
+                _ssh_config=self._ssh_config,
+                _service_account=vm.service_account,
             )
+            listed.append(ListedSlice(handle=handle, state=_VM_STATE_MAP.get(vm.status, CloudSliceState.UNKNOWN)))
 
-        logger.info("list_all_slices: found %d managed slices", len(handles))
-        return handles
+        logger.info("list_all_slices: found %d managed slices", len(listed))
+        return listed
 
     def list_vms(
         self,

--- a/lib/iris/src/iris/cluster/providers/gcp/workers.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/workers.py
@@ -27,6 +27,7 @@ from iris.cluster.providers.gcp.bootstrap import (
 )
 from iris.cluster.providers.gcp.handles import (
     _ACTIVE_VM_SLICE_STATES,
+    _QR_STATE_MAP,
     _TPU_STATE_MAP,
     _VM_STATE_MAP,
     CloudSliceState,
@@ -701,17 +702,16 @@ class GcpWorkerProvider:
             )
             listed.append(ListedSlice(handle=handle, state=_TPU_STATE_MAP.get(tpu.state, CloudSliceState.UNKNOWN)))
 
-        # Discover queued resources (reserved TPUs) not yet visible as TPU VMs.
-        # These are in QUEUED/PROVISIONING/WAITING_FOR_RESOURCES and need handles
-        # so the controller doesn't orphan them on restart.
+        # Discover queued resources (reserved TPUs) not already represented by a
+        # TPU VM. We surface every state — including FAILED/SUSPENDED/DELETING —
+        # so the boot reconciler can reclaim dead reservations instead of
+        # orphaning them in GCP.
         tpu_names = {item.handle.slice_id for item in listed}
         qr_infos = self._gcp.queued_resource_list(zones=[], labels=managed_labels)
         for qr in qr_infos:
             if qr.name in tpu_names:
                 continue
-            if qr.state in ("FAILED", "SUSPENDED", "DELETING"):
-                continue
-            if qr.labels.get(manual_label) == "true":
+            if qr.labels and qr.labels.get(manual_label) == "true":
                 continue
             handle = GcpSliceHandle(
                 _slice_id=qr.name,
@@ -726,11 +726,12 @@ class GcpWorkerProvider:
                 _ssh_config=self._ssh_config,
                 _is_queued_resource=True,
             )
-            listed.append(ListedSlice(handle=handle, state=CloudSliceState.CREATING))
+            listed.append(ListedSlice(handle=handle, state=_QR_STATE_MAP.get(qr.state, CloudSliceState.UNKNOWN)))
 
+        # Surface every managed VM regardless of cloud state. Stopped/terminated
+        # instances are exactly what the boot reconciler needs to reclaim; the
+        # active-only filter belongs in list_slices(), used for live discovery.
         for vm in vm_infos:
-            if vm.status not in _ACTIVE_VM_SLICE_STATES:
-                continue
             slice_id = vm.labels.get(self._iris_labels.iris_slice_id, "")
             if not slice_id:
                 continue

--- a/lib/iris/src/iris/cluster/providers/manual/provider.py
+++ b/lib/iris/src/iris/cluster/providers/manual/provider.py
@@ -27,6 +27,7 @@ from iris.cluster.providers.types import (
     CloudWorkerState,
     InfraError,
     Labels,
+    ListedSlice,
     SliceStatus,
     WorkerStatus,
     default_stop_all,
@@ -334,16 +335,23 @@ class ManualWorkerProvider:
             results = [s for s in results if all(s.labels.get(k) == v for k, v in labels.items())]
         return results
 
-    def list_all_slices(self) -> list[ManualSliceHandle]:
-        """List autoscaler-managed slices.
+    def list_all_slices(self) -> list[ListedSlice]:
+        """List autoscaler-managed slices paired with cloud state.
 
         Excludes slices tagged iris_manual=true (operator-created via
-        `iris cluster create-slice`), which the autoscaler and
-        `iris cluster stop` must not see or terminate.
+        `iris cluster create-slice`). Manual slices have no real cloud
+        lifecycle; non-terminated ones report READY.
         """
         all_managed = self.list_slices(zones=[], labels={self._iris_labels.iris_managed: "true"})
         manual_label = self._iris_labels.iris_manual
-        return [s for s in all_managed if s.labels.get(manual_label) != "true"]
+        return [
+            ListedSlice(
+                handle=s,
+                state=CloudSliceState.DELETING if s._terminated else CloudSliceState.READY,
+            )
+            for s in all_managed
+            if s.labels.get(manual_label) != "true"
+        ]
 
     def list_vms(
         self,

--- a/lib/iris/src/iris/cluster/providers/protocols.py
+++ b/lib/iris/src/iris/cluster/providers/protocols.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from contextlib import AbstractContextManager
 from typing import Protocol
 
-from iris.cluster.providers.types import SliceHandle, StandaloneWorkerHandle
+from iris.cluster.providers.types import ListedSlice, SliceHandle, StandaloneWorkerHandle
 from iris.rpc import config_pb2
 
 
@@ -123,8 +123,8 @@ class WorkerInfraProvider(Protocol):
         """List existing slices, filtered by zone and optionally by labels."""
         ...
 
-    def list_all_slices(self) -> list[SliceHandle]:
-        """List all slices managed by this cluster across all zones."""
+    def list_all_slices(self) -> list[ListedSlice]:
+        """List every iris-managed slice across all zones, paired with its cloud state."""
         ...
 
     def list_vms(

--- a/lib/iris/src/iris/cluster/providers/types.py
+++ b/lib/iris/src/iris/cluster/providers/types.py
@@ -348,6 +348,14 @@ class SliceHandle(Protocol):
         ...
 
 
+@dataclass(frozen=True)
+class ListedSlice:
+    """A handle paired with the cloud state observed when it was listed."""
+
+    handle: SliceHandle
+    state: CloudSliceState
+
+
 # ---------------------------------------------------------------------------
 # Default stop_all helper
 # ---------------------------------------------------------------------------
@@ -356,7 +364,7 @@ TERMINATE_TIMEOUT_SECONDS = 60
 
 
 def default_stop_all(
-    list_all_slices: Callable[[], list[SliceHandle]],
+    list_all_slices: Callable[[], list[ListedSlice]],
     stop_controller: Callable[[], None],
     dry_run: bool = False,
 ) -> list[str]:
@@ -372,9 +380,9 @@ def default_stop_all(
     """
     target_names: list[str] = ["controller"]
     all_slices = list_all_slices()
-    for s in all_slices:
-        logger.info("Found managed slice %s", s.slice_id)
-        target_names.append(f"slice:{s.slice_id}")
+    for listed in all_slices:
+        logger.info("Found managed slice %s (state=%s)", listed.handle.slice_id, listed.state)
+        target_names.append(f"slice:{listed.handle.slice_id}")
 
     if dry_run:
         return target_names
@@ -382,8 +390,8 @@ def default_stop_all(
     targets: list[tuple[str, Callable[[], None]]] = [
         ("controller", stop_controller),
     ]
-    for s in all_slices:
-        targets.append((f"slice:{s.slice_id}", s.terminate))
+    for listed in all_slices:
+        targets.append((f"slice:{listed.handle.slice_id}", listed.handle.terminate))
 
     logger.info("Terminating %d resource(s) in parallel", len(targets))
 

--- a/lib/iris/tests/cluster/providers/gcp/test_platform.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_platform.py
@@ -381,11 +381,11 @@ def test_gcp_create_vm_slice_mode_produces_single_worker_slice():
     assert handle.scale_group == "cpu-vm"
 
     listed = platform.list_all_slices()
-    assert handle.slice_id in {s.slice_id for s in listed}
+    assert handle.slice_id in {s.handle.slice_id for s in listed}
 
     handle.terminate()
     listed_after = platform.list_all_slices()
-    assert handle.slice_id not in {s.slice_id for s in listed_after}
+    assert handle.slice_id not in {s.handle.slice_id for s in listed_after}
 
 
 def test_gcp_build_gce_resource_name_bounds_and_normalizes():
@@ -423,7 +423,7 @@ def test_gcp_create_vm_slice_mode_with_long_prefix_uses_valid_slice_id():
     assert len(status.workers) == 1
     assert status.workers[0]._remote_exec.ssh_user == "iris"
     listed = platform.list_all_slices()
-    assert handle.slice_id in {s.slice_id for s in listed}
+    assert handle.slice_id in {s.handle.slice_id for s in listed}
 
 
 def test_gcp_vm_slice_os_login_sets_metadata_and_uses_gcloud_default_user():
@@ -617,7 +617,7 @@ def test_gcp_list_slices_skips_inactive_vm_instances():
             break
 
     listed = platform.list_all_slices()
-    assert handle.slice_id not in {s.slice_id for s in listed}
+    assert handle.slice_id not in {s.handle.slice_id for s in listed}
 
 
 def test_gcp_list_slices_preserves_vm_slice_discovery():
@@ -640,7 +640,7 @@ def test_gcp_list_slices_preserves_vm_slice_discovery():
 
     handle = platform.create_slice(cfg)
     listed = platform.list_all_slices()
-    listed_by_id = {s.slice_id: s for s in listed}
+    listed_by_id = {s.handle.slice_id: s.handle for s in listed}
     assert handle.slice_id in listed_by_id
     assert listed_by_id[handle.slice_id].created_at.epoch_ms() > 0
 
@@ -717,7 +717,7 @@ def test_list_all_slices_returns_created_slices(platform_env: PlatformEnv):
     cfg = _make_slice_config(platform_env, "group-a")
     handle = platform_env.platform.create_slice(cfg)
     all_slices = platform_env.platform.list_all_slices()
-    assert handle.slice_id in {s.slice_id for s in all_slices}
+    assert handle.slice_id in {s.handle.slice_id for s in all_slices}
 
 
 def test_list_all_slices_returns_all_managed(platform_env: PlatformEnv):
@@ -743,7 +743,7 @@ def test_list_all_slices_excludes_manual_slices(platform_env: PlatformEnv):
     handle_manual = platform_env.platform.create_slice(cfg_manual)
 
     all_slices = platform_env.platform.list_all_slices()
-    slice_ids = {s.slice_id for s in all_slices}
+    slice_ids = {s.handle.slice_id for s in all_slices}
     assert handle_auto.slice_id in slice_ids
     assert handle_manual.slice_id not in slice_ids
 
@@ -786,7 +786,7 @@ def test_gcp_list_all_slices_multi_zone():
     handle_b = platform.create_slice(cfg_b)
 
     all_slices = platform.list_all_slices()
-    slice_ids = {s.slice_id for s in all_slices}
+    slice_ids = {s.handle.slice_id for s in all_slices}
     assert handle_a.slice_id in slice_ids
     assert handle_b.slice_id in slice_ids
 

--- a/lib/iris/tests/cluster/providers/gcp/test_platform.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_platform.py
@@ -592,8 +592,9 @@ def test_gcp_create_slice_resolves_ghcr_image_in_worker_config():
     assert wc.docker_image == "europe-docker.pkg.dev/my-proj/ghcr-mirror/marin-community/iris-worker:latest"
 
 
-def test_gcp_list_slices_skips_inactive_vm_instances():
-    """list_slices omits VM-backed slices for instances in inactive states."""
+def test_gcp_list_all_slices_includes_terminated_vm_instances():
+    """list_all_slices surfaces VM-backed slices in non-live states so the boot
+    reconciler can reclaim them. list_slices (live discovery) still filters."""
     gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
     gcp_config = config_pb2.GcpPlatformConfig(project_id="test-project", zones=["us-central2-b"])
     platform = GcpWorkerProvider(gcp_config, label_prefix="iris", gcp_service=gcp_service)
@@ -617,7 +618,12 @@ def test_gcp_list_slices_skips_inactive_vm_instances():
             break
 
     listed = platform.list_all_slices()
-    assert handle.slice_id not in {s.handle.slice_id for s in listed}
+    by_id = {s.handle.slice_id: s for s in listed}
+    assert handle.slice_id in by_id
+    assert by_id[handle.slice_id].state == CloudSliceState.DELETING
+
+    live = platform.list_slices(zones=["us-central2-b"])
+    assert handle.slice_id not in {s.slice_id for s in live}
 
 
 def test_gcp_list_slices_preserves_vm_slice_discovery():

--- a/lib/iris/tests/cluster/test_snapshot_reconciliation.py
+++ b/lib/iris/tests/cluster/test_snapshot_reconciliation.py
@@ -224,7 +224,7 @@ def test_restore_discards_slice_missing_from_cloud():
     )
 
     assert "slice-gone" not in result.slices
-    assert result.discarded_count == 1
+    assert result.discarded_slice_ids == ["slice-gone"]
 
 
 def test_restore_discards_failed_slice_missing_from_cloud():


### PR DESCRIPTION
list_all_slices now returns (handle, state) pairs across every cloud state, and restore_autoscaler_state partitions on it: live slices feed the autoscaler, dead ones are async-terminated. Discarded checkpoint slices are also deleted from the slices table so SQLite no longer accumulates ghost rows that the autoscaler cannot see.