### PR TITLE
marin: artifact.from_path resolves relative paths via MARIN_PREFIX

### DIFF
--- a/experiments/datakit_testbed/sampler.py
+++ b/experiments/datakit_testbed/sampler.py
@@ -315,7 +315,7 @@ def sample_normalized_shards_step(
 
     def sample(output_path: str) -> NormalizedData:
         return sample_normalized_shards(
-            source=Artifact.load(normalized_path, NormalizedData),
+            source=Artifact.from_path(normalized_path, NormalizedData),
             output_path=output_path,
             sample_fraction=sample_fraction,
         )

--- a/experiments/datakit_testbed/variants.py
+++ b/experiments/datakit_testbed/variants.py
@@ -61,7 +61,7 @@ def _minhash_step(src_name: str, sampled: StepSpec, **params: int) -> StepSpec:
             "seed": params["seed"],
         },
         fn=lambda output_path, sampled=sampled: compute_minhash_attrs(
-            source=Artifact.load(sampled, NormalizedData),
+            source=Artifact.from_path(sampled, NormalizedData),
             output_path=output_path,
             num_perms=params["num_perms"],
             num_bands=params["num_bands"],
@@ -79,7 +79,7 @@ def _fuzzy_dups_step(minhash_steps: list[StepSpec], cc_max_iterations: int) -> S
         deps=list(minhash_steps),
         hash_attrs={"cc_max_iterations": cc_max_iterations},
         fn=lambda output_path: compute_fuzzy_dups_attrs(
-            inputs=[Artifact.load(mh, MinHashAttrData) for mh in minhash_steps],
+            inputs=[Artifact.from_path(mh, MinHashAttrData) for mh in minhash_steps],
             output_path=output_path,
             cc_max_iterations=cc_max_iterations,
             max_parallelism=_FUZZY_DUPS_MAX_PARALLELISM,
@@ -98,14 +98,14 @@ def _deduped_step(src_name: str, sampled: StepSpec, fuzzy_dups: StepSpec) -> Ste
         name=f"data/datakit/deduped/{src_name}",
         deps=[sampled, fuzzy_dups],
         fn=lambda output_path, sampled=sampled: consolidate(
-            input_path=Artifact.load(sampled, NormalizedData).main_output_dir,
+            input_path=Artifact.from_path(sampled, NormalizedData).main_output_dir,
             output_path=os.path.join(output_path, "outputs/main"),
             filetype="parquet",
             filters=[
                 FilterConfig(
                     type=FilterType.KEEP_DOC,
-                    attribute_path=Artifact.load(fuzzy_dups, FuzzyDupsAttrData)
-                    .sources[Artifact.load(sampled, NormalizedData).main_output_dir]
+                    attribute_path=Artifact.from_path(fuzzy_dups, FuzzyDupsAttrData)
+                    .sources[Artifact.from_path(sampled, NormalizedData).main_output_dir]
                     .attr_dir,
                     name="is_cluster_canonical",
                     attribute_filetype="parquet",

--- a/experiments/dedup/poc_nemotron.py
+++ b/experiments/dedup/poc_nemotron.py
@@ -110,7 +110,7 @@ def fuzzy_dedup_steps() -> list[StepSpec]:
             name=f"minhash_nemotron/{q}",
             deps=[norm],
             fn=lambda op, norm=norm: compute_minhash_attrs(
-                source=Artifact.load(norm, NormalizedData),
+                source=Artifact.from_path(norm, NormalizedData),
                 output_path=op,
                 worker_resources=ResourceConfig(cpu=5, ram="32g", disk="5g"),
             ),
@@ -123,7 +123,7 @@ def fuzzy_dedup_steps() -> list[StepSpec]:
         output_path_prefix=marin_temp_bucket(ttl_days=2, prefix="rav"),
         deps=list(minhash_steps.values()),
         fn=lambda op: compute_fuzzy_dups_attrs(
-            inputs=[Artifact.load(s, MinHashAttrData) for s in minhash_steps.values()],
+            inputs=[Artifact.from_path(s, MinHashAttrData) for s in minhash_steps.values()],
             output_path=op,
             max_parallelism=2048,
             worker_resources=ResourceConfig(cpu=1, ram="32g", disk="5g"),

--- a/experiments/dedup/reference.py
+++ b/experiments/dedup/reference.py
@@ -29,7 +29,7 @@ def build_steps() -> list[StepSpec]:
         name="minhash/fineweb-edu-sample-10bt",
         deps=[normalized],
         fn=lambda op: compute_minhash_attrs(
-            source=Artifact.load(normalized, NormalizedData),
+            source=Artifact.from_path(normalized, NormalizedData),
             output_path=op,
         ),
     )
@@ -37,7 +37,7 @@ def build_steps() -> list[StepSpec]:
         name="dedup_sample/10BT",
         deps=[minhash],
         fn=lambda op: compute_fuzzy_dups_attrs(
-            inputs=[Artifact.load(minhash, MinHashAttrData)],
+            inputs=[Artifact.from_path(minhash, MinHashAttrData)],
             output_path=op,
             max_parallelism=1024,
         ),

--- a/experiments/ferries/datakit_ferry.py
+++ b/experiments/ferries/datakit_ferry.py
@@ -68,7 +68,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
         name="datakit-smoke/minhash",
         deps=[normalized],
         fn=lambda output_path: compute_minhash_attrs(
-            source=Artifact.load(normalized, NormalizedData),
+            source=Artifact.from_path(normalized, NormalizedData),
             output_path=output_path,
             worker_resources=ResourceConfig(cpu=5, ram="16g", disk="10g"),
         ),
@@ -82,7 +82,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
         deps=[minhash],
         hash_attrs={"cc_max_iterations": 3},
         fn=lambda output_path: compute_fuzzy_dups_attrs(
-            inputs=[Artifact.load(minhash, MinHashAttrData)],
+            inputs=[Artifact.from_path(minhash, MinHashAttrData)],
             output_path=output_path,
             max_parallelism=128,
             cc_max_iterations=3,
@@ -95,7 +95,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
         name="datakit-smoke/consolidate",
         deps=[normalized, deduped],
         fn=lambda output_path: consolidate(
-            input_path=Artifact.load(normalized, NormalizedData).main_output_dir,
+            input_path=Artifact.from_path(normalized, NormalizedData).main_output_dir,
             output_path=output_path,
             filetype="parquet",
             filters=[
@@ -104,8 +104,8 @@ def build_steps(run_id: str) -> list[StepSpec]:
                 # keep_if_missing=True passes them through.
                 FilterConfig(
                     type=FilterType.KEEP_DOC,
-                    attribute_path=Artifact.load(deduped, FuzzyDupsAttrData)
-                    .sources[Artifact.load(normalized, NormalizedData).main_output_dir]
+                    attribute_path=Artifact.from_path(deduped, FuzzyDupsAttrData)
+                    .sources[Artifact.from_path(normalized, NormalizedData).main_output_dir]
                     .attr_dir,
                     name="is_cluster_canonical",
                     attribute_filetype="parquet",

--- a/experiments/ferries/datakit_nemotron_ferry.py
+++ b/experiments/ferries/datakit_nemotron_ferry.py
@@ -106,7 +106,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
         name="datakit-nemotron-smoke/minhash",
         deps=[normalized],
         fn=lambda output_path: compute_minhash_attrs(
-            source=Artifact.load(normalized, NormalizedData),
+            source=Artifact.from_path(normalized, NormalizedData),
             output_path=output_path,
             worker_resources=ResourceConfig(cpu=5, ram="16g", disk="5g"),
             max_workers=512,
@@ -119,7 +119,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
         deps=[minhash],
         hash_attrs={"cc_max_iterations": 3},
         fn=lambda output_path: compute_fuzzy_dups_attrs(
-            inputs=[Artifact.load(minhash, MinHashAttrData)],
+            inputs=[Artifact.from_path(minhash, MinHashAttrData)],
             output_path=output_path,
             max_parallelism=512,
             cc_max_iterations=3,
@@ -132,14 +132,14 @@ def build_steps(run_id: str) -> list[StepSpec]:
         name="datakit-nemotron-smoke/consolidate",
         deps=[normalized, deduped],
         fn=lambda output_path: consolidate(
-            input_path=Artifact.load(normalized, NormalizedData).main_output_dir,
+            input_path=Artifact.from_path(normalized, NormalizedData).main_output_dir,
             output_path=output_path,
             filetype="parquet",
             filters=[
                 FilterConfig(
                     type=FilterType.KEEP_DOC,
-                    attribute_path=Artifact.load(deduped, FuzzyDupsAttrData)
-                    .sources[Artifact.load(normalized, NormalizedData).main_output_dir]
+                    attribute_path=Artifact.from_path(deduped, FuzzyDupsAttrData)
+                    .sources[Artifact.from_path(normalized, NormalizedData).main_output_dir]
                     .attr_dir,
                     name="is_cluster_canonical",
                     attribute_filetype="parquet",

--- a/experiments/ferries/datakit_tier2_skewed_ferry.py
+++ b/experiments/ferries/datakit_tier2_skewed_ferry.py
@@ -79,7 +79,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
         name="datakit-tier2-skewed-smoke/minhash",
         deps=[normalized],
         fn=lambda output_path: compute_minhash_attrs(
-            source=Artifact.load(normalized, NormalizedData),
+            source=Artifact.from_path(normalized, NormalizedData),
             output_path=output_path,
         ),
         override_output_path=f"{ttl_base}/minhash",
@@ -91,7 +91,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
         deps=[minhash],
         hash_attrs={"cc_max_iterations": 3},
         fn=lambda output_path: compute_fuzzy_dups_attrs(
-            inputs=[Artifact.load(minhash, MinHashAttrData)],
+            inputs=[Artifact.from_path(minhash, MinHashAttrData)],
             output_path=output_path,
             max_parallelism=64,
             cc_max_iterations=3,
@@ -103,14 +103,14 @@ def build_steps(run_id: str) -> list[StepSpec]:
         name="datakit-tier2-skewed-smoke/consolidate",
         deps=[normalized, deduped],
         fn=lambda output_path: consolidate(
-            input_path=Artifact.load(normalized, NormalizedData).main_output_dir,
+            input_path=Artifact.from_path(normalized, NormalizedData).main_output_dir,
             output_path=output_path,
             filetype="parquet",
             filters=[
                 FilterConfig(
                     type=FilterType.KEEP_DOC,
-                    attribute_path=Artifact.load(deduped, FuzzyDupsAttrData)
-                    .sources[Artifact.load(normalized, NormalizedData).main_output_dir]
+                    attribute_path=Artifact.from_path(deduped, FuzzyDupsAttrData)
+                    .sources[Artifact.from_path(normalized, NormalizedData).main_output_dir]
                     .attr_dir,
                     name="is_cluster_canonical",
                     attribute_filetype="parquet",

--- a/lib/marin/src/marin/datakit/decon.py
+++ b/lib/marin/src/marin/datakit/decon.py
@@ -471,7 +471,7 @@ def decon_step(
     return StepSpec(
         name=name,
         fn=lambda output_path: decon_to_parquet(
-            normalized_data=Artifact.load(normalized, NormalizedData),
+            normalized_data=Artifact.from_path(normalized, NormalizedData),
             eval_data_sources=[s.output_path for s in eval_data_sources],
             output_path=output_path,
             text_field=text_field,

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -70,7 +70,7 @@ class NormalizedData(BaseModel):
 
     Persisted as the step's ``.artifact`` so counters and output paths are
     available to downstream consumers without re-running the pipeline. Load
-    via ``Artifact.load(step, NormalizedData)``.
+    via ``Artifact.from_path(step, NormalizedData)``.
 
     Attributes:
         main_output_dir: Directory containing the main output Parquet files.

--- a/lib/marin/src/marin/execution/artifact.py
+++ b/lib/marin/src/marin/execution/artifact.py
@@ -18,15 +18,15 @@ class Artifact:
 
     @overload
     @classmethod
-    def load(cls, base_path: str | StepSpec, artifact_type: type[T]) -> T: ...
+    def from_path(cls, base_path: str | StepSpec, artifact_type: type[T]) -> T: ...
 
     @overload
     @classmethod
-    def load(cls, base_path: str | StepSpec) -> dict[str, Any]: ...
+    def from_path(cls, base_path: str | StepSpec) -> dict[str, Any]: ...
 
     @classmethod
-    def load(cls, base_path: str | StepSpec, artifact_type: type[T] | None = None) -> T | dict[str, Any]:
-        """Loads an Artifact instance from the specified output base path.
+    def from_path(cls, base_path: str | StepSpec, artifact_type: type[T] | None = None) -> T | dict[str, Any]:
+        """Load an Artifact instance from the specified output base path.
 
         If ``base_path`` is a relative path (no URL scheme, doesn't start with ``/``),
         it is resolved against ``marin_prefix()``.

--- a/lib/marin/src/marin/execution/artifact.py
+++ b/lib/marin/src/marin/execution/artifact.py
@@ -6,9 +6,9 @@ from dataclasses import asdict, dataclass, is_dataclass
 from typing import Any, TypeVar, overload
 
 from pydantic import BaseModel
-from rigging.filesystem import open_url
+from rigging.filesystem import marin_prefix, open_url
 
-from marin.execution.step_spec import StepSpec
+from marin.execution.step_spec import StepSpec, _is_relative_path
 
 T = TypeVar("T")
 
@@ -26,10 +26,16 @@ class Artifact:
 
     @classmethod
     def load(cls, base_path: str | StepSpec, artifact_type: type[T] | None = None) -> T | dict[str, Any]:
-        """Loads an Artifact instance from the specified output base path"""
+        """Loads an Artifact instance from the specified output base path.
+
+        If ``base_path`` is a relative path (no URL scheme, doesn't start with ``/``),
+        it is resolved against ``marin_prefix()``.
+        """
 
         if isinstance(base_path, StepSpec):
             base_path = base_path.output_path
+        elif _is_relative_path(base_path):
+            base_path = f"{marin_prefix()}/{base_path}"
 
         with open_url(f"{base_path}/{cls.__artifact_file_name}", "rb") as fd:
             if artifact_type is None:

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
@@ -68,7 +68,7 @@ class FuzzyDupsAttrData(BaseModel):
     """Co-partitioned fuzzy-duplicate marker attrs for one or more sources.
 
     Persisted as the step's ``.artifact``. Load via
-    ``Artifact.load(step, FuzzyDupsAttrData)``.
+    ``Artifact.from_path(step, FuzzyDupsAttrData)``.
 
     Attributes:
         version: Schema version of this artifact.
@@ -374,7 +374,7 @@ def compute_fuzzy_dups_attrs_step(
         name=name,
         deps=list(minhash_steps),
         fn=lambda output_path: compute_fuzzy_dups_attrs(
-            inputs=[Artifact.load(s, MinHashAttrData) for s in minhash_steps],
+            inputs=[Artifact.from_path(s, MinHashAttrData) for s in minhash_steps],
             output_path=output_path,
             cc_max_iterations=cc_max_iterations,
             max_parallelism=max_parallelism,

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
@@ -52,7 +52,7 @@ class MinHashAttrData(BaseModel):
     """Co-partitioned MinHash bucket attrs computed for one ``NormalizedData``.
 
     Persisted as the step's ``.artifact``. Load via
-    ``Artifact.load(step, MinHashAttrData)``.
+    ``Artifact.from_path(step, MinHashAttrData)``.
 
     Attributes:
         version: Schema version of this artifact.
@@ -214,7 +214,7 @@ def compute_minhash_attrs_step(
         name=name,
         deps=[normalize],
         fn=lambda output_path: compute_minhash_attrs(
-            source=Artifact.load(normalize, NormalizedData),
+            source=Artifact.from_path(normalize, NormalizedData),
             output_path=output_path,
             num_perms=num_perms,
             num_bands=num_bands,

--- a/scripts/datakit/validate_ferry_outputs.py
+++ b/scripts/datakit/validate_ferry_outputs.py
@@ -103,7 +103,7 @@ def _validate_normalize(base: str, download_rows: int) -> int:
     # Normalize writes main records to {base}/normalize/outputs/main and duplicates
     # (when exact dedup is enabled) to {base}/normalize/outputs/dups. We load the
     # artifact to resolve the paths rather than hard-coding the layout.
-    normalized = Artifact.load(f"{base}/normalize", NormalizedData)
+    normalized = Artifact.from_path(f"{base}/normalize", NormalizedData)
     files = _list_parquet(normalized.main_output_dir)
     if len(files) != NORMALIZE_EXPECTED_FILES:
         raise SystemExit(f"Normalize: expected {NORMALIZE_EXPECTED_FILES} files, got {len(files)}")
@@ -146,7 +146,7 @@ def _validate_fuzzy_dups(base: str, normalize_rows: int) -> int:
     member is flagged ``is_cluster_canonical=True``. Consolidate's default policy
     keeps canonicals and singletons, so non-canonicals == rows dropped.
     """
-    dedup = Artifact.load(f"{base}/fuzzy_dups", FuzzyDupsAttrData)
+    dedup = Artifact.from_path(f"{base}/fuzzy_dups", FuzzyDupsAttrData)
     if len(dedup.sources) != FUZZY_DUPS_EXPECTED_SOURCES:
         raise SystemExit(f"Fuzzy dups: expected exactly {FUZZY_DUPS_EXPECTED_SOURCES} source, got {len(dedup.sources)}")
     (per_source,) = dedup.sources.values()

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -305,7 +305,7 @@ def test_extract_ghalogs_step_persists_typed_artifact(tmp_path):
     )
     StepRunner().run([step])
 
-    loaded = Artifact.load(step, ExtractedPartitionedDiagnosticLogs)
+    loaded = Artifact.from_path(step, ExtractedPartitionedDiagnosticLogs)
     assert loaded.source_label == "ghalogs"
     assert loaded.record_count == 1
     assert loaded.metadata_path.endswith("/metadata.json")
@@ -394,7 +394,7 @@ def test_ghalogs_public_normalize_steps_write_datakit_normalized_train_partition
     )
     StepRunner().run(list(steps))
 
-    normalized = Artifact.load(steps[-1], NormalizedData)
+    normalized = Artifact.from_path(steps[-1], NormalizedData)
     rows = _read_parquet_rows(Path(normalized.main_output_dir))
 
     assert len(rows) == 1

--- a/tests/execution/test_disk_cache.py
+++ b/tests/execution/test_disk_cache.py
@@ -83,7 +83,7 @@ def test_composition_with_save_load(tmp_path: Path):
         distributed_lock(counting_fn),
         output_path=output_path,
         save_fn=Artifact.save,
-        load_fn=Artifact.load,
+        load_fn=Artifact.from_path,
     )
 
     result1 = cached_fn(output_path)

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -116,6 +116,15 @@ def test_artifact_save_and_load_typed(tmp_path: Path):
     assert loaded.path == "/data/shards"
 
 
+def test_artifact_load_relative_path_resolves_against_marin_prefix(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("MARIN_PREFIX", tmp_path.as_posix())
+    artifact = PathMetadata(path="/data/shards")
+    Artifact.save(artifact, (tmp_path / "step_out").as_posix())
+
+    loaded = Artifact.load("step_out", PathMetadata)
+    assert loaded == artifact
+
+
 def test_artifact_save_and_load_untyped(tmp_path: Path):
     artifact = TokenizeMetadata(path="/tokenized", num_tokens=42)
     Artifact.save(artifact, tmp_path.as_posix())

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -111,7 +111,7 @@ def test_artifact_save_and_load_typed(tmp_path: Path):
     artifact = PathMetadata(path="/data/shards")
     Artifact.save(artifact, tmp_path.as_posix())
 
-    loaded = Artifact.load(tmp_path.as_posix(), PathMetadata)
+    loaded = Artifact.from_path(tmp_path.as_posix(), PathMetadata)
     assert loaded == artifact
     assert loaded.path == "/data/shards"
 
@@ -121,7 +121,7 @@ def test_artifact_load_relative_path_resolves_against_marin_prefix(tmp_path: Pat
     artifact = PathMetadata(path="/data/shards")
     Artifact.save(artifact, (tmp_path / "step_out").as_posix())
 
-    loaded = Artifact.load("step_out", PathMetadata)
+    loaded = Artifact.from_path("step_out", PathMetadata)
     assert loaded == artifact
 
 
@@ -129,7 +129,7 @@ def test_artifact_save_and_load_untyped(tmp_path: Path):
     artifact = TokenizeMetadata(path="/tokenized", num_tokens=42)
     Artifact.save(artifact, tmp_path.as_posix())
 
-    loaded = Artifact.load(tmp_path.as_posix())
+    loaded = Artifact.from_path(tmp_path.as_posix())
     assert isinstance(loaded, dict)
     assert loaded["path"] == "/tokenized"
     assert loaded["num_tokens"] == 42
@@ -139,7 +139,7 @@ def test_artifact_save_nested_dataclass(tmp_path: Path):
     artifact = NestedMetadata(path="/nested", resources=ResourceConfig(cpu=2, ram="4g"))
     Artifact.save(artifact, tmp_path.as_posix())
 
-    loaded = Artifact.load(tmp_path.as_posix())
+    loaded = Artifact.from_path(tmp_path.as_posix())
     assert isinstance(loaded, dict)
     assert loaded["path"] == "/nested"
     assert loaded["resources"]["cpu"] == 2
@@ -156,7 +156,7 @@ def test_artifact_roundtrip_through_pipeline(tmp_path: Path):
     Artifact.save(raw, step1_out)
 
     # Step 2: tokenize — load upstream artifact, run, save
-    loaded_raw = Artifact.load(step1_out, PathMetadata)
+    loaded_raw = Artifact.from_path(step1_out, PathMetadata)
     tokenized = tokenize_data(step2_out, loaded_raw, "word")
     Artifact.save(tokenized, step2_out)
 
@@ -164,8 +164,8 @@ def test_artifact_roundtrip_through_pipeline(tmp_path: Path):
     assert tokenized.num_tokens == 60  # 30 docs * 2 words each
 
     # Both artifacts are loadable from their respective output paths
-    assert Artifact.load(step1_out, PathMetadata) == raw
-    assert Artifact.load(step2_out, TokenizeMetadata) == tokenized
+    assert Artifact.from_path(step1_out, PathMetadata) == raw
+    assert Artifact.from_path(step2_out, TokenizeMetadata) == tokenized
 
 
 # ---------------------------------------------------------------------------
@@ -204,7 +204,7 @@ def test_runner_saves_artifact_automatically(tmp_path):
     runner = StepRunner()
     runner.run([step])
 
-    loaded = Artifact.load(out, PathMetadata)
+    loaded = Artifact.from_path(out, PathMetadata)
     assert loaded.path == out
 
 
@@ -338,7 +338,7 @@ def _build_pipeline(tmp_path: Path) -> list[StepSpec]:
 
     Each step function returns an artifact.  The runner auto-saves any
     BaseModel result to the step's output_path.  Inter-step data flows
-    through ``Artifact.load`` — deferred to execution time via lambdas.
+    through ``Artifact.from_path`` — deferred to execution time via lambdas.
     """
 
     tmp_path_posix = tmp_path.as_posix()
@@ -351,7 +351,7 @@ def _build_pipeline(tmp_path: Path) -> list[StepSpec]:
         fn=lambda output_path: download_raw_data(output_path, source_url),
     )
 
-    # Artifact.load must be deferred to execution time (upstream hasn't run yet)
+    # Artifact.from_path must be deferred to execution time (upstream hasn't run yet)
     tokenizer = "word"
     tokenize_step = StepSpec(
         name="tokenize",
@@ -360,7 +360,7 @@ def _build_pipeline(tmp_path: Path) -> list[StepSpec]:
         deps=[download_step],
         fn=lambda output_path: tokenize_data(
             output_path,
-            Artifact.load(download_step.output_path, PathMetadata),
+            Artifact.from_path(download_step.output_path, PathMetadata),
             tokenizer,
         ),
     )
@@ -369,7 +369,7 @@ def _build_pipeline(tmp_path: Path) -> list[StepSpec]:
         output_path_prefix=tmp_path_posix,
         deps=[tokenize_step],
         fn=lambda output_path: train_on_tokenized_data(
-            output_path, Artifact.load(tokenize_step.output_path, TokenizeMetadata)
+            output_path, Artifact.from_path(tokenize_step.output_path, TokenizeMetadata)
         ),
     )
     return [download_step, tokenize_step, train_step]
@@ -386,16 +386,16 @@ def test_runner_executes_pipeline(tmp_path: Path):
     train_path = steps[2].output_path
 
     # Download produced shards
-    raw_artifact = Artifact.load(download_path, PathMetadata)
+    raw_artifact = Artifact.from_path(download_path, PathMetadata)
     assert os.path.isdir(raw_artifact.path)
     assert len(os.listdir(raw_artifact.path)) == 3
 
     # Tokenize produced output with correct token count
-    tokenize_artifact = Artifact.load(tokenize_path, TokenizeMetadata)
+    tokenize_artifact = Artifact.from_path(tokenize_path, TokenizeMetadata)
     assert tokenize_artifact.num_tokens == 60  # 30 docs * 2 words each
 
     # Train produced a checkpoint
-    train_artifact = Artifact.load(train_path, TrainMetadata)
+    train_artifact = Artifact.from_path(train_path, TrainMetadata)
     assert train_artifact.tokens_seen > 0
     assert os.path.exists(train_artifact.checkpoint_path)
 
@@ -438,7 +438,7 @@ def test_runner_respects_dependency_order(tmp_path: Path):
     runner = StepRunner()
     runner.run(reversed_steps)
 
-    train_artifact = Artifact.load(steps[2].output_path, TrainMetadata)
+    train_artifact = Artifact.from_path(steps[2].output_path, TrainMetadata)
     assert train_artifact.tokens_seen > 0
 
 
@@ -448,7 +448,7 @@ def test_runner_max_concurrent(tmp_path: Path):
     runner = StepRunner()
     runner.run(steps, max_concurrent=1)
 
-    train_artifact = Artifact.load(steps[2].output_path, TrainMetadata)
+    train_artifact = Artifact.from_path(steps[2].output_path, TrainMetadata)
     assert train_artifact.tokens_seen > 0
 
 
@@ -643,7 +643,7 @@ def test_step_with_remote_fn_uses_fray(tmp_path: Path):
     runner = StepRunner()
     runner.run([step])
 
-    loaded = Artifact.load(tmp_path.as_posix(), PathMetadata)
+    loaded = Artifact.from_path(tmp_path.as_posix(), PathMetadata)
     assert loaded.path == tmp_path.as_posix()
 
 
@@ -688,7 +688,7 @@ def test_step_resources_dispatches_via_fray(tmp_path: Path, fray_client):
 
     assert len(spy.requests) == 1
     assert spy.requests[0].resources == custom
-    loaded = Artifact.load(tmp_path.as_posix(), PathMetadata)
+    loaded = Artifact.from_path(tmp_path.as_posix(), PathMetadata)
     assert loaded.path == tmp_path.as_posix()
 
 

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -83,7 +83,7 @@ def create_steps(prefix: str, synth_data: str) -> list[ExecutorStep]:
         hash_attrs={"mode": "exact_paragraph"},
         deps=[normalize_hq_spec],
         fn=lambda output_path: dedup_exact_paragraph(
-            input_paths=[Artifact.load(normalize_hq_spec, NormalizedData).main_output_dir],
+            input_paths=[Artifact.from_path(normalize_hq_spec, NormalizedData).main_output_dir],
             output_path=output_path,
             max_parallelism=4,
             worker_resources=ResourceConfig(cpu=1, ram="1g"),
@@ -96,7 +96,7 @@ def create_steps(prefix: str, synth_data: str) -> list[ExecutorStep]:
         name=os.path.join(prefix, "cleaned"),
         deps=[normalize_hq_spec, dedup_exact_paragraph_spec],
         fn=lambda output_path: consolidate(
-            input_path=Artifact.load(normalize_hq_spec, NormalizedData).main_output_dir,
+            input_path=Artifact.from_path(normalize_hq_spec, NormalizedData).main_output_dir,
             output_path=output_path,
             # Normalize emits parquet; override the jsonl.gz default.
             filetype="parquet",


### PR DESCRIPTION
* `Artifact.from_path` accepts relative paths and resolves them against `marin_prefix()`, so callers can pass a step-name-style id (e.g. `normalize/foo`) instead of a full URL — same resolution rule as `StepSpec.output_path`[^1]
* rename `Artifact.load` → `Artifact.from_path` across all callsites
* test in `tests/execution/test_step_runner.py` covers the relative-path case

[^1]: relative = no URL scheme and no leading `/`; helper reused from `step_spec._is_relative_path`