### PR TITLE
[grug-moe] Add KL Soap H optimizer + gate-1/2 sweep

### DIFF
--- a/experiments/grug/moe/klsoaph.py
+++ b/experiments/grug/moe/klsoaph.py
@@ -1,0 +1,240 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# KL SOAP H: SOAP-style Hessian-eigenbasis preconditioner with Adam moments
+# in the eigenbasis. The "KL" qualifier refers to the scale-invariant
+# ("hyperball") post-step applied in optimizer.py:_scale_invariant_hyperball_updates,
+# not a KL-divergence projection. Reproduces the KLSOAPH optimizer from
+# KellerJordan/modded-nanogpt PR #290; the only deviation is
+# precond_freq=5 (upstream default 1).
+#
+# scale_by_klsoaph returns only the SOAP direction; the hyperball post-step
+# is applied by scale_with_grug_klsoaph in optimizer.py, mirroring the
+# muonh/normuonh pattern.
+
+from typing import NamedTuple
+
+import chex
+import jax
+import jax.numpy as jnp
+import optax
+
+
+class ScaleByKLSoapHState(NamedTuple):
+    """Per-leaf SOAP state. Float32 throughout for eigh stability."""
+
+    count: chex.Array
+    exp_avg: optax.Updates
+    exp_avg_sq: optax.Updates
+    gg_l: optax.Updates
+    gg_r: optax.Updates
+    q_l: optax.Updates
+    q_r: optax.Updates
+
+
+class _SoapStepResult:
+    """Plain-Python wrapper for the seven outputs of one SOAP step.
+
+    Not a registered pytree, so jax.tree.map treats it as a leaf.
+    """
+
+    __slots__ = ("direction", "exp_avg", "exp_avg_sq", "gg_l", "gg_r", "q_l", "q_r")
+
+    def __init__(self, direction, exp_avg, exp_avg_sq, gg_l, gg_r, q_l, q_r):
+        self.direction = direction
+        self.exp_avg = exp_avg
+        self.exp_avg_sq = exp_avg_sq
+        self.gg_l = gg_l
+        self.gg_r = gg_r
+        self.q_l = q_l
+        self.q_r = q_r
+
+
+def _is_matrix_param(p) -> bool:
+    return hasattr(p, "ndim") and p.ndim >= 2
+
+
+def _zeros_param(p):
+    if not _is_matrix_param(p):
+        return None
+    return jnp.zeros(p.shape, dtype=jnp.float32)
+
+
+def _zeros_left(p):
+    if not _is_matrix_param(p):
+        return None
+    n = p.shape[-2]
+    return jnp.zeros((*p.shape[:-2], n, n), dtype=jnp.float32)
+
+
+def _zeros_right(p):
+    if not _is_matrix_param(p):
+        return None
+    n = p.shape[-1]
+    return jnp.zeros((*p.shape[:-2], n, n), dtype=jnp.float32)
+
+
+def _eye_leading(p, axis: int):
+    if not _is_matrix_param(p):
+        return None
+    n = p.shape[axis]
+    eye = jnp.eye(n, dtype=jnp.float32)
+    if p.ndim > 2:
+        eye = jnp.broadcast_to(eye, (*p.shape[:-2], n, n))
+    return jnp.asarray(eye, dtype=jnp.float32)
+
+
+def _klsoaph_step_2d(
+    grad: jnp.ndarray,
+    exp_avg: jnp.ndarray,
+    exp_avg_sq: jnp.ndarray,
+    gg_l: jnp.ndarray,
+    gg_r: jnp.ndarray,
+    q_l: jnp.ndarray,
+    q_r: jnp.ndarray,
+    step: jnp.ndarray,
+    beta1: float,
+    beta2: float,
+    shampoo_beta: float,
+    eps: float,
+    precond_freq: int,
+):
+    """One SOAP step for a single 2-D (rows, cols) gradient.
+
+    All arrays are float32. Matches upstream KLSOAPH.step() in
+    KellerJordan/modded-nanogpt PR #290, sans the hyperball post-step
+    (applied later by _scale_invariant_hyperball_updates).
+    """
+    rows = grad.shape[0]
+    cols = grad.shape[1]
+
+    g32 = grad.astype(jnp.float32)
+    gg_l = shampoo_beta * gg_l + (1.0 - shampoo_beta) * (g32 @ g32.T) / cols
+    gg_r = shampoo_beta * gg_r + (1.0 - shampoo_beta) * (g32.T @ g32) / rows
+
+    should_refresh = jnp.equal(jnp.remainder(step, precond_freq), 0)
+
+    def _refresh(_):
+        _, ql_new = jnp.linalg.eigh(gg_l)
+        _, qr_new = jnp.linalg.eigh(gg_r)
+        return ql_new, qr_new
+
+    def _keep(_):
+        return q_l, q_r
+
+    q_l, q_r = jax.lax.cond(should_refresh, _refresh, _keep, operand=None)
+
+    g_proj = q_l.T @ g32 @ q_r
+    exp_avg = beta1 * exp_avg + (1.0 - beta1) * g_proj
+    exp_avg_sq = beta2 * exp_avg_sq + (1.0 - beta2) * g_proj * g_proj
+    precond_proj = exp_avg / (jnp.sqrt(exp_avg_sq) + eps)
+    direction = q_l @ precond_proj @ q_r.T
+
+    return direction.astype(grad.dtype), exp_avg, exp_avg_sq, gg_l, gg_r, q_l, q_r
+
+
+def scale_by_klsoaph(
+    beta1: float = 0.9,
+    beta2: float = 0.9,
+    shampoo_beta: float = 0.9,
+    eps: float = 1e-8,
+    precond_freq: int = 5,
+) -> optax.GradientTransformation:
+    """SOAP-style preconditioner with eigenbasis-refresh every precond_freq steps.
+
+    Returns the direction in parameter space. No learning-rate scaling and no
+    hyperball normalization — both applied by scale_with_grug_klsoaph.
+
+    State is allocated only for leaves with ndim >= 2; lower-rank leaves get
+    None state slots and pass through unchanged (their gradients should be
+    routed to a different optimizer group via an optax mask). Leaves with
+    ndim > 2 are treated as stacks of (rows, cols) matrices over the leading
+    axes (vmapped).
+    """
+
+    def init_fn(params):
+        return ScaleByKLSoapHState(
+            count=jnp.zeros([], jnp.int32),
+            exp_avg=jax.tree.map(_zeros_param, params, is_leaf=lambda x: x is None),
+            exp_avg_sq=jax.tree.map(_zeros_param, params, is_leaf=lambda x: x is None),
+            gg_l=jax.tree.map(_zeros_left, params, is_leaf=lambda x: x is None),
+            gg_r=jax.tree.map(_zeros_right, params, is_leaf=lambda x: x is None),
+            q_l=jax.tree.map(lambda p: _eye_leading(p, -2), params, is_leaf=lambda x: x is None),
+            q_r=jax.tree.map(lambda p: _eye_leading(p, -1), params, is_leaf=lambda x: x is None),
+        )
+
+    def update_fn(updates, state, params=None):
+        del params
+        next_count = optax.safe_increment(state.count)
+
+        def per_leaf(grad, exp_avg, exp_avg_sq, gg_l, gg_r, q_l, q_r):
+            if grad is None or exp_avg is None:
+                return _SoapStepResult(grad, exp_avg, exp_avg_sq, gg_l, gg_r, q_l, q_r)
+            if grad.ndim == 2:
+                out = _klsoaph_step_2d(
+                    grad,
+                    exp_avg,
+                    exp_avg_sq,
+                    gg_l,
+                    gg_r,
+                    q_l,
+                    q_r,
+                    next_count,
+                    beta1=beta1,
+                    beta2=beta2,
+                    shampoo_beta=shampoo_beta,
+                    eps=eps,
+                    precond_freq=precond_freq,
+                )
+                return _SoapStepResult(*out)
+            out = jax.vmap(
+                lambda g, ea, eas, gl, gr, ql, qr: _klsoaph_step_2d(
+                    g,
+                    ea,
+                    eas,
+                    gl,
+                    gr,
+                    ql,
+                    qr,
+                    next_count,
+                    beta1=beta1,
+                    beta2=beta2,
+                    shampoo_beta=shampoo_beta,
+                    eps=eps,
+                    precond_freq=precond_freq,
+                )
+            )(grad, exp_avg, exp_avg_sq, gg_l, gg_r, q_l, q_r)
+            return _SoapStepResult(*out)
+
+        results = jax.tree.map(
+            per_leaf,
+            updates,
+            state.exp_avg,
+            state.exp_avg_sq,
+            state.gg_l,
+            state.gg_r,
+            state.q_l,
+            state.q_r,
+            is_leaf=lambda x: x is None,
+        )
+
+        # Treat _SoapStepResult as a leaf on the way out.
+        def _is_result_or_none(x):
+            return x is None or isinstance(x, _SoapStepResult)
+
+        directions = jax.tree.map(lambda r: None if r is None else r.direction, results, is_leaf=_is_result_or_none)
+        new_state = ScaleByKLSoapHState(
+            count=next_count,
+            exp_avg=jax.tree.map(lambda r: None if r is None else r.exp_avg, results, is_leaf=_is_result_or_none),
+            exp_avg_sq=jax.tree.map(lambda r: None if r is None else r.exp_avg_sq, results, is_leaf=_is_result_or_none),
+            gg_l=jax.tree.map(lambda r: None if r is None else r.gg_l, results, is_leaf=_is_result_or_none),
+            gg_r=jax.tree.map(lambda r: None if r is None else r.gg_r, results, is_leaf=_is_result_or_none),
+            q_l=jax.tree.map(lambda r: None if r is None else r.q_l, results, is_leaf=_is_result_or_none),
+            q_r=jax.tree.map(lambda r: None if r is None else r.q_r, results, is_leaf=_is_result_or_none),
+        )
+        return directions, new_state
+
+    return optax.GradientTransformation(init_fn, update_fn)
+
+
+__all__ = ["ScaleByKLSoapHState", "scale_by_klsoaph"]

--- a/experiments/grug/moe/klsoaph.py
+++ b/experiments/grug/moe/klsoaph.py
@@ -18,6 +18,8 @@ import chex
 import jax
 import jax.numpy as jnp
 import optax
+from jax.sharding import PartitionSpec as P
+from jax.sharding import reshard
 
 
 class ScaleByKLSoapHState(NamedTuple):
@@ -84,7 +86,12 @@ def _eye_leading(p, axis: int):
     return jnp.asarray(eye, dtype=jnp.float32)
 
 
-def _klsoaph_step_2d(
+def _replicated_pspec(ndim: int) -> P:
+    """PartitionSpec with `ndim` None entries (fully replicated)."""
+    return P(*(None,) * ndim)
+
+
+def _klsoaph_step(
     grad: jnp.ndarray,
     exp_avg: jnp.ndarray,
     exp_avg_sq: jnp.ndarray,
@@ -99,22 +106,45 @@ def _klsoaph_step_2d(
     eps: float,
     precond_freq: int,
 ):
-    """One SOAP step for a single 2-D (rows, cols) gradient.
+    """One SOAP step. Works for 2-D ``(rows, cols)`` gradients and 3-D
+    ``(stack, rows, cols)`` gradients via einsum ellipsis.
 
-    All arrays are float32. Matches upstream KLSOAPH.step() in
-    KellerJordan/modded-nanogpt PR #290, sans the hyperball post-step
-    (applied later by _scale_invariant_hyperball_updates).
+    Replicates every intermediate fully across the mesh so contracting-dim
+    sharding ambiguities cannot occur (matching the legacy MuonH replicated
+    Newton-Schulz pattern in ``levanter.optim.grugmuon``). The caller's
+    parameter-sharding is restored downstream by
+    ``_match_named_update_sharding`` in ``optimizer.py``.
     """
-    rows = grad.shape[0]
-    cols = grad.shape[1]
+    rows = grad.shape[-2]
+    cols = grad.shape[-1]
+
+    has_mesh = not jax.sharding.get_abstract_mesh().empty
+    out_pspec = _replicated_pspec(grad.ndim) if has_mesh else None
+    # Gram matrices and eigenbases live on the inner 2-D axes only; their
+    # explicit pspec has the same leading rank as the gradient.
+    out_pspec_l = _replicated_pspec(grad.ndim) if has_mesh else None  # (..., rows, rows)
+    out_pspec_r = _replicated_pspec(grad.ndim) if has_mesh else None  # (..., cols, cols)
 
     g32 = grad.astype(jnp.float32)
-    gg_l = shampoo_beta * gg_l + (1.0 - shampoo_beta) * (g32 @ g32.T) / cols
-    gg_r = shampoo_beta * gg_r + (1.0 - shampoo_beta) * (g32.T @ g32) / rows
+    if has_mesh:
+        g32 = reshard(g32, _replicated_pspec(grad.ndim))
+        gg_l = reshard(gg_l, _replicated_pspec(grad.ndim))
+        gg_r = reshard(gg_r, _replicated_pspec(grad.ndim))
+        q_l = reshard(q_l, _replicated_pspec(grad.ndim))
+        q_r = reshard(q_r, _replicated_pspec(grad.ndim))
+        exp_avg = reshard(exp_avg, _replicated_pspec(grad.ndim))
+        exp_avg_sq = reshard(exp_avg_sq, _replicated_pspec(grad.ndim))
+
+    # Gram matrices: gg_l += (1-beta)*(g g^T)/cols and gg_r += (1-beta)*(g^T g)/rows
+    g_gT = jnp.einsum("...ik,...jk->...ij", g32, g32, out_sharding=out_pspec_l)
+    gT_g = jnp.einsum("...ki,...kj->...ij", g32, g32, out_sharding=out_pspec_r)
+    gg_l = shampoo_beta * gg_l + (1.0 - shampoo_beta) * g_gT / cols
+    gg_r = shampoo_beta * gg_r + (1.0 - shampoo_beta) * gT_g / rows
 
     should_refresh = jnp.equal(jnp.remainder(step, precond_freq), 0)
 
     def _refresh(_):
+        # eigh batches automatically over leading axes when input is replicated.
         _, ql_new = jnp.linalg.eigh(gg_l)
         _, qr_new = jnp.linalg.eigh(gg_r)
         return ql_new, qr_new
@@ -124,11 +154,17 @@ def _klsoaph_step_2d(
 
     q_l, q_r = jax.lax.cond(should_refresh, _refresh, _keep, operand=None)
 
-    g_proj = q_l.T @ g32 @ q_r
+    # g_proj = q_l.T @ g @ q_r, all replicated.
+    g_qr = jnp.einsum("...ij,...jk->...ik", g32, q_r, out_sharding=out_pspec)
+    g_proj = jnp.einsum("...ki,...kj->...ij", q_l, g_qr, out_sharding=out_pspec)
+
     exp_avg = beta1 * exp_avg + (1.0 - beta1) * g_proj
     exp_avg_sq = beta2 * exp_avg_sq + (1.0 - beta2) * g_proj * g_proj
     precond_proj = exp_avg / (jnp.sqrt(exp_avg_sq) + eps)
-    direction = q_l @ precond_proj @ q_r.T
+
+    # direction = q_l @ precond_proj @ q_r.T, all replicated.
+    precond_qrt = jnp.einsum("...ij,...kj->...ik", precond_proj, q_r, out_sharding=out_pspec)
+    direction = jnp.einsum("...ij,...jk->...ik", q_l, precond_qrt, out_sharding=out_pspec)
 
     return direction.astype(grad.dtype), exp_avg, exp_avg_sq, gg_l, gg_r, q_l, q_r
 
@@ -170,40 +206,21 @@ def scale_by_klsoaph(
         def per_leaf(grad, exp_avg, exp_avg_sq, gg_l, gg_r, q_l, q_r):
             if grad is None or exp_avg is None:
                 return _SoapStepResult(grad, exp_avg, exp_avg_sq, gg_l, gg_r, q_l, q_r)
-            if grad.ndim == 2:
-                out = _klsoaph_step_2d(
-                    grad,
-                    exp_avg,
-                    exp_avg_sq,
-                    gg_l,
-                    gg_r,
-                    q_l,
-                    q_r,
-                    next_count,
-                    beta1=beta1,
-                    beta2=beta2,
-                    shampoo_beta=shampoo_beta,
-                    eps=eps,
-                    precond_freq=precond_freq,
-                )
-                return _SoapStepResult(*out)
-            out = jax.vmap(
-                lambda g, ea, eas, gl, gr, ql, qr: _klsoaph_step_2d(
-                    g,
-                    ea,
-                    eas,
-                    gl,
-                    gr,
-                    ql,
-                    qr,
-                    next_count,
-                    beta1=beta1,
-                    beta2=beta2,
-                    shampoo_beta=shampoo_beta,
-                    eps=eps,
-                    precond_freq=precond_freq,
-                )
-            )(grad, exp_avg, exp_avg_sq, gg_l, gg_r, q_l, q_r)
+            out = _klsoaph_step(
+                grad,
+                exp_avg,
+                exp_avg_sq,
+                gg_l,
+                gg_r,
+                q_l,
+                q_r,
+                next_count,
+                beta1=beta1,
+                beta2=beta2,
+                shampoo_beta=shampoo_beta,
+                eps=eps,
+                precond_freq=precond_freq,
+            )
             return _SoapStepResult(*out)
 
         results = jax.tree.map(

--- a/experiments/grug/moe/klsoaph_sweep.py
+++ b/experiments/grug/moe/klsoaph_sweep.py
@@ -1,0 +1,163 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""KL Soap H optimizer sweep on Grug MoE.
+
+Reproduces the KLSOAPH optimizer from KellerJordan/modded-nanogpt PR #290
+inside the marin grug-moe pipeline, with two user-requested deviations from
+upstream:
+
+  - ``precond_freq=5`` (upstream default 1) — refresh the eigenbasis every
+    five steps to amortize the eigendecomposition cost.
+  - The attention gate parameter (``attn_gate``) is routed to KL Soap H
+    rather than the baseline Adam group; see
+    ``_uses_klsoaph_baseline_adam_group`` in ``optimizer.py``.
+
+Set ``KLSOAPH_GATE`` to control which scales run:
+
+    KLSOAPH_GATE=1     # default: d512, d768 (gate 1 only)
+    KLSOAPH_GATE=2     # d1024, d1280 (gate 2 only)
+    KLSOAPH_GATE=both  # all four scales
+
+Set ``KLSOAPH_RUN_SUFFIX`` to append a unique suffix for relaunches.
+
+Schedule follows the existing MuonH no-warmup variant: the LR-schedule
+warmup fraction is 0.0 so the schedule starts immediately at the peak
+learning rate. The reference KLSOAPH training also uses no warmup
+(``cooldown_frac=1.0``).
+"""
+
+import os
+
+from fray.cluster import ResourceConfig
+from levanter.tracker.wandb import WandbConfig
+from marin.execution.executor import ExecutorStep, executor_main, this_output_path, versioned
+
+from experiments.grug.moe.heuristic import build_from_heuristic
+from experiments.grug.moe.launch import (
+    NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
+    GrugMoeLaunchConfig,
+    run_grug_moe_trial,
+)
+from experiments.grug.moe.optimizer import GrugMoeAdamHConfig, GrugMoeKLSoapHConfig
+from experiments.grug.moe.train import GrugEvalConfig, GrugTrainerConfig
+
+_GATE_1_POINTS: tuple[tuple[int, float], ...] = (
+    (512, 2.19e17),
+    (768, 1.70e18),
+)
+_GATE_2_POINTS: tuple[tuple[int, float], ...] = (
+    (1024, 9.00e18),
+    (1280, 2.83e19),
+)
+
+_BASELINE_TARGET_STEPS: int = 2**14
+_WARMUP_FRACTION: float = 0.0
+_GROUP: str = "klsoaph-sweep"
+
+
+def _format_budget(budget: float) -> str:
+    return f"{budget:.2e}".replace("+", "")
+
+
+def _format_run_id(hidden_dim: int, budget: float, run_suffix: str = "") -> str:
+    budget_label = _format_budget(budget)
+    normalized_suffix = run_suffix.strip()
+    if normalized_suffix and not normalized_suffix.replace("-", "").replace("_", "").isalnum():
+        raise ValueError("run_suffix may only contain letters, numbers, hyphens, and underscores")
+    suffix = f"{normalized_suffix}-" if normalized_suffix else ""
+    return f"klsoaph-{suffix}d{hidden_dim}-{budget_label}"
+
+
+def _klsoaph_optimizer_from_baseline(base_optimizer: GrugMoeAdamHConfig) -> GrugMoeKLSoapHConfig:
+    return GrugMoeKLSoapHConfig(
+        learning_rate=base_optimizer.learning_rate,
+        adam_lr=base_optimizer.adam_lr,
+        min_lr_ratio=base_optimizer.min_lr_ratio,
+        warmup=_WARMUP_FRACTION,
+        beta1=0.9,
+        beta2=0.9,
+        shampoo_beta=0.9,
+        epsilon=base_optimizer.epsilon,
+        precond_freq=5,
+        max_grad_norm=base_optimizer.max_grad_norm,
+        lr_schedule=base_optimizer.lr_schedule,
+        decay=base_optimizer.decay,
+    )
+
+
+def _build_step(hidden_dim: int, budget: float, run_suffix: str = "") -> ExecutorStep:
+    model, base_optimizer, batch_size, num_steps = build_from_heuristic(
+        budget=budget,
+        hidden_dim=hidden_dim,
+        target_steps=_BASELINE_TARGET_STEPS,
+    )
+    optimizer = _klsoaph_optimizer_from_baseline(base_optimizer)
+
+    run_id = _format_run_id(hidden_dim=hidden_dim, budget=budget, run_suffix=run_suffix)
+    step_name = f"grug/klsoaph_sweep/{run_id}"
+
+    return ExecutorStep(
+        name=step_name,
+        fn=run_grug_moe_trial,
+        config=GrugMoeLaunchConfig(
+            model=versioned(model),
+            data=NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
+            output_path=this_output_path(),
+            run_id=run_id,
+            resources=versioned(ResourceConfig.with_tpu("v5p-8")),
+            steps=versioned(num_steps),
+            batch_size=versioned(batch_size),
+            seed=versioned(0),
+            mp=versioned("params=float32,compute=bfloat16,output=bfloat16"),
+            tracker=WandbConfig(
+                entity="marin-community",
+                project="marin_moe",
+                tags=["moe", "klsoaph_sweep", f"d{hidden_dim}"],
+                group=_GROUP,
+                name=None,
+            ),
+            optimizer=versioned(optimizer),
+            grug_trainer=versioned(
+                GrugTrainerConfig(
+                    z_loss_weight=1e-4,
+                    ema_beta=None,
+                    log_every=1,
+                )
+            ),
+            eval=versioned(
+                GrugEvalConfig(
+                    eval_batch_size=512,
+                    steps_per_eval=1000,
+                    max_eval_batches=8,
+                    eval_current=True,
+                    eval_ema=False,
+                )
+            ),
+        ),
+    )
+
+
+def _build_steps(gate: str, run_suffix: str = "") -> list[ExecutorStep]:
+    if gate == "1":
+        points = _GATE_1_POINTS
+    elif gate == "2":
+        points = _GATE_2_POINTS
+    elif gate == "both":
+        points = _GATE_1_POINTS + _GATE_2_POINTS
+    else:
+        raise ValueError(f"unknown gate: {gate!r} (expected '1', '2', or 'both')")
+
+    return [_build_step(hidden_dim=hidden_dim, budget=budget, run_suffix=run_suffix) for hidden_dim, budget in points]
+
+
+if __name__ == "__main__":
+    gate = os.environ.get("KLSOAPH_GATE", "1")
+    run_suffix = os.environ.get("KLSOAPH_RUN_SUFFIX", "")
+    steps = _build_steps(gate, run_suffix=run_suffix)
+    executor_main(
+        steps=steps,
+        description=(
+            f"MoE KL Soap H (precond_freq=5, warmup={_WARMUP_FRACTION}) " f"(gate={gate}, run_suffix={run_suffix!r})."
+        ),
+    )

--- a/experiments/grug/moe/optimizer.py
+++ b/experiments/grug/moe/optimizer.py
@@ -13,6 +13,7 @@ from levanter.optim.util import CoefficientType
 from levanter.utils.jax_utils import leaf_key_paths
 
 from experiments.grug.moe.adamh import scale_by_adamh
+from experiments.grug.moe.klsoaph import scale_by_klsoaph
 
 
 def _uses_adamh_baseline_adam_group(path_lower: str) -> bool:
@@ -22,6 +23,16 @@ def _uses_adamh_baseline_adam_group(path_lower: str) -> bool:
         or "attn_gate" in path_lower
         or ".router" in path_lower
     )
+
+
+def _uses_klsoaph_baseline_adam_group(path_lower: str) -> bool:
+    """KL Soap H variant override: route attn_gate into the matrix group.
+
+    Same as _uses_adamh_baseline_adam_group but drops "attn_gate". The
+    attention gate parameter is a small 2-D tensor (hidden_dim, num_heads);
+    the KL Soap H sweep keeps it under the SOAP preconditioner.
+    """
+    return "token_embed" in path_lower or "router_bias" in path_lower or ".router" in path_lower
 
 
 def _target_named_sharding(array) -> jax.sharding.NamedSharding | None:
@@ -213,6 +224,41 @@ def scale_with_grug_normuonh(
         )
         normuonh_updates = _scale_invariant_hyperball_updates(params, normuon_updates, learning_rate)
         return normuonh_updates, ScaleByGrugNorMuonHState(muon_state=next_muon_state, row_nu=row_nu)
+
+    return optax.GradientTransformation(init_fn, update_fn)
+
+
+def scale_with_grug_klsoaph(
+    beta1: float = 0.9,
+    beta2: float = 0.9,
+    shampoo_beta: float = 0.9,
+    eps: float = 1e-8,
+    precond_freq: int = 5,
+    learning_rate: float = 0.018,
+) -> optax.GradientTransformation:
+    """KL Soap H transform: SOAP-eigenbasis Adam direction + hyperball post-step.
+
+    Reproduces KLSOAPH from KellerJordan/modded-nanogpt PR #290 with one
+    deviation: precond_freq defaults to 5 (upstream uses 1) to amortize the
+    eigendecomposition cost.
+    """
+    soap_transform = scale_by_klsoaph(
+        beta1=beta1,
+        beta2=beta2,
+        shampoo_beta=shampoo_beta,
+        eps=eps,
+        precond_freq=precond_freq,
+    )
+
+    def init_fn(params):
+        return soap_transform.init(params)
+
+    def update_fn(updates, state, params=None):
+        if params is None:
+            raise ValueError("scale_with_grug_klsoaph requires params for norm-preserving updates")
+        direction, next_state = soap_transform.update(updates, state, params)
+        klsoaph_updates = _scale_invariant_hyperball_updates(params, direction, learning_rate)
+        return klsoaph_updates, next_state
 
     return optax.GradientTransformation(init_fn, update_fn)
 
@@ -476,11 +522,107 @@ class GrugMoeNorMuonHConfig(OptimizerConfig):
         return jax.tree.map(mask_fn, params, paths)
 
 
+@OptimizerConfig.register_subclass("grug_moe_klsoaph_v1")
+@dataclass(frozen=True)
+class GrugMoeKLSoapHConfig(OptimizerConfig):
+    """KL Soap H for Grug MoE.
+
+    Reproduces KLSOAPH from KellerJordan/modded-nanogpt PR #290. The "KL"
+    qualifier names the scale-invariant ("hyperball") post-step, not a
+    KL-divergence projection.
+
+    Variant override versus MuonH/NorMuonH: the attention gate parameter
+    (`attn_gate`) is routed to KL Soap H rather than the baseline Adam
+    group, since it is a 2-D matrix and benefits from the preconditioner.
+
+    - klsoaph: matrix leaves outside the variant baseline Adam group
+    - adamh: lm head / output projection matrix
+    - adam: leaves that the variant routes to plain Adam
+    """
+
+    adam_lr: float = 6e-4
+    beta1: float = 0.9
+    beta2: float = 0.9
+    shampoo_beta: float = 0.9
+    epsilon: float = 1e-8
+    precond_freq: int = 5
+    max_grad_norm: float | None = 1.0
+
+    def build(self, num_train_steps):
+        learning_rate_schedule = self.lr_scheduler(num_train_steps)
+        adam_lr_schedule = self.lr_scheduler(num_train_steps, override_lr=self.adam_lr)
+
+        def optimizer(learning_rate, adam_lr):
+            def klsoaph_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(
+                    scale_with_grug_klsoaph(
+                        beta1=self.beta1,
+                        beta2=self.beta2,
+                        shampoo_beta=self.shampoo_beta,
+                        eps=self.epsilon,
+                        precond_freq=self.precond_freq,
+                        learning_rate=learning_rate,
+                    )
+                )
+                components.append(_match_named_update_sharding())
+                return optax.chain(*components)
+
+            def adamh_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(scale_by_adamh(self.beta1, self.beta2, self.epsilon, learning_rate))
+                return optax.chain(*components)
+
+            def adam_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(optax.scale_by_adam(self.beta1, self.beta2, self.epsilon))
+                components.append(optax.scale(-adam_lr))
+                return optax.chain(*components)
+
+            return optax.multi_transform(
+                {
+                    "klsoaph": klsoaph_transform(),
+                    "adamh": adamh_transform(),
+                    "adam": adam_transform(),
+                },
+                self.create_mask,
+            )
+
+        return optax.inject_hyperparams(optimizer)(
+            learning_rate=learning_rate_schedule,
+            adam_lr=adam_lr_schedule,
+        )
+
+    def create_mask(self, params):
+        paths = leaf_key_paths(params)
+
+        def mask_fn(param, path):
+            path_str = ".".join(path) if isinstance(path, (list, tuple)) else str(path)
+            path_lower = path_str.lower()
+            if _uses_klsoaph_baseline_adam_group(path_lower):
+                return "adam"
+            if "output_proj" in path_lower or "lm_head" in path_lower:
+                return "adamh"
+            if hasattr(param, "ndim") and param.ndim in (2, 3):
+                return "klsoaph"
+            return "adam"
+
+        return jax.tree.map(mask_fn, params, paths)
+
+
 __all__ = [
     "GrugMoeAdamHConfig",
+    "GrugMoeKLSoapHConfig",
     "GrugMoeMuonHConfig",
     "GrugMoeNorMuonHConfig",
     "ScaleByGrugNorMuonHState",
+    "scale_with_grug_klsoaph",
     "scale_with_grug_muonh",
     "scale_with_grug_normuonh",
 ]

--- a/tests/test_grug_moe_optimizer.py
+++ b/tests/test_grug_moe_optimizer.py
@@ -138,8 +138,9 @@ def test_grug_normuonh_tracks_output_axis_for_fan_in_fan_out_arrays():
     [
         scale_with_grug_muonh(momentum=0.0, nesterov=False, steps=1, learning_rate=0.01),
         scale_with_grug_normuonh(momentum=0.0, nesterov=False, beta2=0.0, steps=1, learning_rate=0.01),
+        scale_with_grug_klsoaph(precond_freq=1, learning_rate=0.01),
     ],
-    ids=["muonh", "normuonh"],
+    ids=["muonh", "normuonh", "klsoaph"],
 )
 def test_grug_hyperball_update_handles_expert_parameter_sharding(transform):
     mesh = jax.sharding.AbstractMesh(

--- a/tests/test_grug_moe_optimizer.py
+++ b/tests/test_grug_moe_optimizer.py
@@ -10,8 +10,10 @@ from jax.sharding import use_abstract_mesh
 
 from experiments.grug.moe.optimizer import (
     GrugMoeAdamHConfig,
+    GrugMoeKLSoapHConfig,
     GrugMoeMuonHConfig,
     GrugMoeNorMuonHConfig,
+    scale_with_grug_klsoaph,
     scale_with_grug_muonh,
     scale_with_grug_normuonh,
 )
@@ -210,6 +212,40 @@ def test_normuonh_matrix_sweep_suffix_builds_distinct_relaunch_steps():
     ]
 
 
+def test_klsoaph_sweep_gate1_builds_two_steps():
+    from experiments.grug.moe import klsoaph_sweep
+
+    steps = klsoaph_sweep._build_steps("1")
+
+    assert [step.name for step in steps] == [
+        "grug/klsoaph_sweep/klsoaph-d512-2.19e17",
+        "grug/klsoaph_sweep/klsoaph-d768-1.70e18",
+    ]
+    assert all(isinstance(step.config.optimizer.value, GrugMoeKLSoapHConfig) for step in steps)
+
+
+def test_klsoaph_sweep_gate2_builds_two_steps():
+    from experiments.grug.moe import klsoaph_sweep
+
+    steps = klsoaph_sweep._build_steps("2")
+
+    assert [step.name for step in steps] == [
+        "grug/klsoaph_sweep/klsoaph-d1024-9.00e18",
+        "grug/klsoaph_sweep/klsoaph-d1280-2.83e19",
+    ]
+
+
+def test_klsoaph_sweep_propagates_precond_freq_and_no_warmup():
+    from experiments.grug.moe import klsoaph_sweep
+
+    step = klsoaph_sweep._build_steps("1")[0]
+    optimizer = step.config.optimizer.value
+
+    assert isinstance(optimizer, GrugMoeKLSoapHConfig)
+    assert optimizer.precond_freq == 5
+    assert optimizer.warmup == 0.0
+
+
 def test_grug_moe_muonh_optimizer_update_runs_on_single_device():
     params = {
         "token_embed": jnp.ones((8, 4), dtype=jnp.float32),
@@ -240,6 +276,105 @@ def test_grug_moe_normuonh_optimizer_update_runs_on_single_device():
     }
     updates = jax.tree.map(lambda x: jnp.full_like(x, 0.1), params)
     optimizer = GrugMoeNorMuonHConfig(learning_rate=0.01, adam_lr=0.001, warmup=0).build(10)
+
+    out, _ = optimizer.update(updates, optimizer.init(params), params)
+
+    assert jax.tree.map(lambda x: x.shape, out) == jax.tree.map(lambda x: x.shape, params)
+
+
+def test_grug_moe_klsoaph_routes_attn_gate_to_matrix_group():
+    """KL Soap H variant override: attn_gate goes to klsoaph, not adam."""
+    params = {
+        "token_embed": jnp.ones((128, 32), dtype=jnp.float32),
+        "output_proj": jnp.ones((32, 128), dtype=jnp.float32),
+        "lm_head": jnp.ones((32, 128), dtype=jnp.float32),
+        "blocks": (
+            {
+                "attn": {
+                    "w_q": jnp.ones((32, 32), dtype=jnp.float32),
+                    "attn_gate": jnp.ones((32, 2), dtype=jnp.float32),
+                },
+                "mlp": {
+                    "router": jnp.ones((32, 4), dtype=jnp.float32),
+                    "router_bias": jnp.ones((4,), dtype=jnp.float32),
+                    "w_gate_up": jnp.ones((4, 32, 64), dtype=jnp.float32),
+                    "w_down": jnp.ones((4, 64, 32), dtype=jnp.float32),
+                },
+                "shared": {
+                    "w_up": jnp.ones((32, 64), dtype=jnp.float32),
+                },
+                "rms_attn": {
+                    "weight": jnp.ones((32,), dtype=jnp.float32),
+                },
+            },
+        ),
+    }
+
+    mask = GrugMoeKLSoapHConfig().create_mask(params)
+    baseline_mask = GrugMoeAdamHConfig().create_mask(params)
+    muonh_mask = GrugMoeMuonHConfig().create_mask(params)
+
+    assert mask["token_embed"] == "adam"
+    assert mask["output_proj"] == "adamh"
+    assert mask["lm_head"] == "adamh"
+    block_mask = mask["blocks"][0]
+    # The variant override: attn_gate routes to klsoaph (vs. adam for AdamH/MuonH).
+    assert baseline_mask["blocks"][0]["attn"]["attn_gate"] == "adam"
+    assert muonh_mask["blocks"][0]["attn"]["attn_gate"] == "adam"
+    assert block_mask["attn"]["attn_gate"] == "klsoaph"
+    # Other matrix params land in klsoaph.
+    assert block_mask["attn"]["w_q"] == "klsoaph"
+    assert block_mask["mlp"]["w_gate_up"] == "klsoaph"
+    assert block_mask["mlp"]["w_down"] == "klsoaph"
+    assert block_mask["shared"]["w_up"] == "klsoaph"
+    # Embedding-table / 1-D leaves stay on adam.
+    assert block_mask["mlp"]["router"] == "adam"
+    assert block_mask["mlp"]["router_bias"] == "adam"
+    assert block_mask["rms_attn"]["weight"] == "adam"
+
+
+def test_grug_klsoaph_state_shapes_match_soap_geometry():
+    """Per-leaf SOAP state: Q_L rows x rows, Q_R cols x cols, exp_avg rows x cols.
+
+    Higher-rank (3-D) leaves carry an extra leading axis on every state
+    tensor so the transform can vmap the 2-D update over experts.
+    """
+    params = {
+        "dense": jnp.ones((4, 6), dtype=jnp.float32),
+        "experts": jnp.ones((3, 4, 6), dtype=jnp.float32),
+    }
+    transform = scale_with_grug_klsoaph(precond_freq=1, learning_rate=0.01)
+
+    state = transform.init(params)
+    soap_state = state.inner_state if hasattr(state, "inner_state") else state
+
+    assert soap_state.exp_avg["dense"].shape == (4, 6)
+    assert soap_state.exp_avg_sq["dense"].shape == (4, 6)
+    assert soap_state.gg_l["dense"].shape == (4, 4)
+    assert soap_state.gg_r["dense"].shape == (6, 6)
+    assert soap_state.q_l["dense"].shape == (4, 4)
+    assert soap_state.q_r["dense"].shape == (6, 6)
+    assert soap_state.exp_avg["experts"].shape == (3, 4, 6)
+    assert soap_state.exp_avg_sq["experts"].shape == (3, 4, 6)
+    assert soap_state.gg_l["experts"].shape == (3, 4, 4)
+    assert soap_state.gg_r["experts"].shape == (3, 6, 6)
+    assert soap_state.q_l["experts"].shape == (3, 4, 4)
+    assert soap_state.q_r["experts"].shape == (3, 6, 6)
+
+
+def test_grug_moe_klsoaph_optimizer_update_runs_on_single_device():
+    params = {
+        "token_embed": jnp.ones((8, 4), dtype=jnp.float32),
+        "output_proj": jnp.ones((4, 8), dtype=jnp.float32),
+        "block": {
+            "attn": {"attn_gate": jnp.ones((4, 2), dtype=jnp.float32)},
+            "router": jnp.ones((4, 2), dtype=jnp.float32),
+            "w_gate_up": jnp.ones((2, 4, 6), dtype=jnp.float32),
+            "norm": jnp.ones((4,), dtype=jnp.float32),
+        },
+    }
+    updates = jax.tree.map(lambda x: jnp.full_like(x, 0.1), params)
+    optimizer = GrugMoeKLSoapHConfig(learning_rate=0.01, adam_lr=0.001, warmup=0).build(10)
 
     out, _ = optimizer.update(updates, optimizer.init(params), params)
 


### PR DESCRIPTION
Tracking issue: #5728

## Summary

- Add `scale_by_klsoaph` JAX transform reproducing the `KLSOAPH` optimizer from [KellerJordan/modded-nanogpt PR #290](https://github.com/KellerJordan/modded-nanogpt/pull/290): SOAP-style preconditioner (Gram-matrix EMA, eigh refresh every `precond_freq` steps via `lax.cond`, Adam in the eigenbasis), with the scale-invariant ("hyperball") post-step applied externally by `_scale_invariant_hyperball_updates` (same idiom MuonH/NorMuonH already use).
- Add `GrugMoeKLSoapHConfig` (`grug_moe_klsoaph_v1`) — three-group `optax.multi_transform`: `klsoaph` for matrices, `adamh` for `lm_head`/`output_proj`, `adam` for the baseline-Adam group.
- Variant-only routing override via new `_uses_klsoaph_baseline_adam_group` predicate: the attention gate parameter (`attn_gate`) routes to the SOAP matrix group instead of plain Adam. `_uses_adamh_baseline_adam_group` (MuonH / NorMuonH / AdamH) is unchanged.
- Add `experiments/grug/moe/klsoaph_sweep.py` — gate 1/2 sweep entry point (`KLSOAPH_GATE` env var). Schedule mirrors MuonH no-warmup (`warmup=0.0`).

## Deviations from upstream

- `precond_freq = 5` (upstream default 1). Eigendecomposition dominates per-step cost; refreshing every 5 steps keeps the eigenbasis fresh while amortizing the eigh.
- `attn_gate` to the SOAP matrix group (not Adam).

## Sharding fix included

First draft of the SOAP step ran into `ShardingTypeError` at JIT-compile in the grug-moe trainer because the Gram matmuls (`g @ g.T`, `g.T @ g`) contract along the model-sharded column axis. Fix follows the legacy MuonH replicated Newton-Schulz pattern in `levanter.optim.grugmuon._zeropower_via_newtonschulz_replicated`:

- When a mesh is active, `reshard` the gradient and all SOAP state leaves to a fully-replicated `PartitionSpec` before doing matmuls.
- Pass an explicit `out_sharding=P(None, ...)` to every `jnp.einsum`.
- 2D and 3D leaves now share a single `_klsoaph_step` (einsum ellipsis) instead of branching to a vmap for 3D — matches `levanter.optim.grugmuon._zeropower_via_newtonschulz_batched_stack_sharded`.

Caller-facing parameter sharding is restored by the existing `_match_named_update_sharding` step at the end of the optimizer chain.

## Test plan

- [x] `tests/test_grug_moe_optimizer.py` — six new tests:
  - mask routing (`attn_gate` → `klsoaph`, baseline-adam group on `adam`, `lm_head`/`output_proj` on `adamh`, matrix leaves on `klsoaph`)
  - SOAP state-shape geometry (Q_L rows-by-rows, Q_R cols-by-cols, exp_avg rows-by-cols, 3-D leaves carry the leading axis on every state tensor)
  - end-to-end `optimizer.update()` shape preservation on single-device
  - sweep script wiring (gate-1 / gate-2 build the expected step names, `precond_freq=5` and `warmup=0.0` propagate)
  - extended `test_grug_hyperball_update_handles_expert_parameter_sharding` parametrize to include klsoaph (catches the sharding bug fixed in this PR)
- [x] `./infra/pre-commit.py` clean.
- [ ] Gate-1 launch on `us-east5 --preemptible` (tracked in #5728).
- [ ] Gate-2 launch (tracked in #5728).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
