### PR TITLE
[iris] Auto-prune dashboard stars on confirmed NOT_FOUND

### DIFF
--- a/lib/iris/dashboard/src/components/controller/JobsTab.vue
+++ b/lib/iris/dashboard/src/components/controller/JobsTab.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
-import { controllerRpcCall, useControllerRpc } from '@/composables/useRpc'
+import { controllerRpcCall, RpcError, useControllerRpc } from '@/composables/useRpc'
 import { useAutoRefresh, DEFAULT_REFRESH_MS } from '@/composables/useAutoRefresh'
 import { SEGMENT_COLORS, stateToName, stateDisplayName } from '@/types/status'
 import type { JobState } from '@/types/status'
@@ -182,12 +182,25 @@ async function fetchStarredJobs() {
     const results = await Promise.allSettled(
       ids.map(id => controllerRpcCall<GetJobStatusResponse>('GetJobStatus', { jobId: id })),
     )
+    // Auto-prune stars the controller confirms it no longer knows about.
+    // A 404 from GetJobStatus is a definitive NOT_FOUND — the job has been
+    // evicted from controller state, so there's no row UI to unstar from.
+    // Other failure modes (5xx, network) are treated as transient.
+    const goneIds = results.flatMap((r, i) =>
+      r.status === 'rejected' && r.reason instanceof RpcError && r.reason.status === 404 ? [ids[i]] : [],
+    )
+    if (goneIds.length > 0) {
+      const next = new Set(starredJobIds.value)
+      for (const id of goneIds) next.delete(id)
+      starredJobIds.value = next
+      saveStarredJobs()
+    }
     starredJobsData.value = results
       .filter((r): r is PromiseFulfilledResult<GetJobStatusResponse> => r.status === 'fulfilled' && !!r.value?.job)
       .map(r => r.value.job)
-    const failures = results.filter(r => r.status === 'rejected').length
-    if (failures > 0 && starredJobsData.value.length === 0) {
-      starredError.value = `Failed to load ${failures} starred job${failures !== 1 ? 's' : ''}`
+    const transientFailures = results.length - starredJobsData.value.length - goneIds.length
+    if (transientFailures > 0 && starredJobsData.value.length === 0) {
+      starredError.value = `Failed to load ${transientFailures} starred job${transientFailures !== 1 ? 's' : ''}`
     }
   } finally {
     starredLoading.value = false

--- a/lib/iris/dashboard/src/composables/useRpc.ts
+++ b/lib/iris/dashboard/src/composables/useRpc.ts
@@ -79,6 +79,16 @@ export function useWorkerRpc<T>(
   return useRpc<T>('iris.cluster.WorkerService', method, body)
 }
 
+/** Error thrown by one-shot RPC calls when the HTTP response is non-OK.
+ *  Carries the HTTP status so callers can branch on specific failures
+ *  (e.g. 404 NOT_FOUND from Connect RPC). */
+export class RpcError extends Error {
+  constructor(public readonly method: string, public readonly status: number, public readonly statusText: string) {
+    super(`${method}: ${status} ${statusText}`)
+    this.name = 'RpcError'
+  }
+}
+
 /** One-shot RPC call returning a Promise. For use in async functions that
  *  need to call multiple RPCs or handle the response imperatively. */
 export async function controllerRpcCall<T>(method: string, body?: Record<string, unknown>): Promise<T> {
@@ -88,7 +98,7 @@ export async function controllerRpcCall<T>(method: string, body?: Record<string,
     body: JSON.stringify(body ?? {}),
   })
   handleUnauthorized(resp)
-  if (!resp.ok) throw new Error(`${method}: ${resp.status} ${resp.statusText}`)
+  if (!resp.ok) throw new RpcError(method, resp.status, resp.statusText)
   return resp.json() as Promise<T>
 }
 


### PR DESCRIPTION
Starred jobs live in localStorage, but the unstar button only renders inside a job row fetched from the controller. Once a starred job is evicted from controller state, GetJobStatus returns 404 and the row disappears — the user has no way to free the slot toward the 10-star limit. Detect that specific failure in fetchStarredJobs and silently drop the ID; 5xx and network errors stay treated as transient.