### PR TITLE
marin: artifact.from_path SUCCESS-marker fallback; pydantic-only typed load

### DIFF
--- a/lib/marin/src/marin/execution/artifact.py
+++ b/lib/marin/src/marin/execution/artifact.py
@@ -8,6 +8,7 @@ from typing import Any, TypeVar, overload
 from pydantic import BaseModel
 from rigging.filesystem import marin_prefix, open_url
 
+from marin.execution.executor_step_status import STATUS_SUCCESS, get_status_path
 from marin.execution.step_spec import StepSpec, _is_relative_path
 
 T = TypeVar("T")
@@ -22,14 +23,20 @@ class Artifact:
 
     @overload
     @classmethod
-    def from_path(cls, base_path: str | StepSpec) -> dict[str, Any]: ...
+    def from_path(cls, base_path: str | StepSpec) -> "PathMetadata | dict[str, Any]": ...
 
     @classmethod
-    def from_path(cls, base_path: str | StepSpec, artifact_type: type[T] | None = None) -> T | dict[str, Any]:
+    def from_path(
+        cls, base_path: str | StepSpec, artifact_type: type[T] | None = None
+    ) -> "T | PathMetadata | dict[str, Any]":
         """Load an Artifact instance from the specified output base path.
 
         If ``base_path`` is a relative path (no URL scheme, doesn't start with ``/``),
         it is resolved against ``marin_prefix()``.
+
+        If ``base_path`` has no ``.artifact`` file but its ``.executor_status`` file
+        contains ``SUCCESS``, returns a :class:`PathMetadata` pointing at ``base_path``
+        — provided the caller asked for no specific type or for ``PathMetadata``.
         """
 
         if isinstance(base_path, StepSpec):
@@ -37,14 +44,39 @@ class Artifact:
         elif _is_relative_path(base_path):
             base_path = f"{marin_prefix()}/{base_path}"
 
-        with open_url(f"{base_path}/{cls.__artifact_file_name}", "rb") as fd:
-            if artifact_type is None:
-                return json.load(fd)
-            if issubclass(artifact_type, BaseModel):
-                return artifact_type.model_validate_json(fd.read())
-            if is_dataclass(artifact_type):
-                return artifact_type(**json.load(fd))  # type: ignore[not-callable]
-            raise ValueError(f"Unsupported artifact type: {artifact_type!r}")
+        try:
+            with open_url(f"{base_path}/{cls.__artifact_file_name}", "rb") as fd:
+                if artifact_type is None:
+                    return json.load(fd)
+                if issubclass(artifact_type, BaseModel):
+                    return artifact_type.model_validate_json(fd.read())
+                if is_dataclass(artifact_type):
+                    return artifact_type(**json.load(fd))  # type: ignore[not-callable]
+                raise ValueError(f"Unsupported artifact type: {artifact_type!r}")
+        except FileNotFoundError:
+            return cls._from_executor_status(base_path, artifact_type)
+
+    @classmethod
+    def _from_executor_status(cls, base_path: str, artifact_type: type[T] | None) -> "T | PathMetadata":
+        """Fallback when ``.artifact`` is absent: synthesize a :class:`PathMetadata`
+        if the step published ``.executor_status = SUCCESS``.
+
+        Only valid when the caller wants no type or ``PathMetadata`` — other types
+        cannot be reconstructed from a bare path.
+        """
+        if artifact_type is not None and artifact_type is not PathMetadata:
+            raise FileNotFoundError(
+                f"No {cls.__artifact_file_name} at {base_path}; cannot synthesize "
+                f"{artifact_type!r} from {get_status_path(base_path)!r}"
+            )
+        with open_url(get_status_path(base_path), "r") as fd:
+            status = fd.read().strip()
+        if status != STATUS_SUCCESS:
+            raise FileNotFoundError(
+                f"No {cls.__artifact_file_name} at {base_path} and "
+                f"{get_status_path(base_path)!r} is {status!r} (not {STATUS_SUCCESS!r})"
+            )
+        return PathMetadata(path=base_path)
 
     @classmethod
     def save(cls, artifact: T, base_path: str) -> None:
@@ -61,9 +93,12 @@ class Artifact:
                 fd.write(json.dumps(artifact).encode("utf-8"))
 
 
-@dataclass
-class PathMetadata:
-    """Represents a single output path"""
+class PathMetadata(BaseModel):
+    """Represents a single output path.
+
+    Also used as the synthetic return type of :meth:`Artifact.from_path` when the
+    step published a ``.executor_status = SUCCESS`` marker but no ``.artifact``.
+    """
 
     path: str
 

--- a/lib/marin/src/marin/execution/artifact.py
+++ b/lib/marin/src/marin/execution/artifact.py
@@ -15,7 +15,10 @@ T = TypeVar("T")
 
 
 class Artifact:
-    __artifact_file_name = ".artifact"
+    __artifact_file_name = "artifact.json"
+    # Legacy filename written before the rename; read-only fallback so historical
+    # GCS outputs remain loadable. Safe to remove once those prefixes are gone.
+    __legacy_artifact_file_name = ".artifact"
 
     @overload
     @classmethod
@@ -34,9 +37,10 @@ class Artifact:
         If ``base_path`` is a relative path (no URL scheme, doesn't start with ``/``),
         it is resolved against ``marin_prefix()``.
 
-        If ``base_path`` has no ``.artifact`` file but its ``.executor_status`` file
-        contains ``SUCCESS``, returns a :class:`PathMetadata` pointing at ``base_path``
-        — provided the caller asked for no specific type or for ``PathMetadata``.
+        If ``base_path`` has no ``artifact.json`` (or legacy ``.artifact``) file but
+        its ``.executor_status`` file contains ``SUCCESS``, returns a
+        :class:`PathMetadata` pointing at ``base_path`` — provided the caller asked
+        for no specific type or for ``PathMetadata``.
         """
 
         if isinstance(base_path, StepSpec):
@@ -44,19 +48,21 @@ class Artifact:
         elif _is_relative_path(base_path):
             base_path = f"{marin_prefix()}/{base_path}"
 
-        try:
-            with open_url(f"{base_path}/{cls.__artifact_file_name}", "rb") as fd:
-                if artifact_type is None:
-                    return json.load(fd)
-                if not issubclass(artifact_type, BaseModel):
-                    raise TypeError(f"artifact_type must be a pydantic BaseModel subclass, got {artifact_type!r}")
-                return artifact_type.model_validate_json(fd.read())
-        except FileNotFoundError:
-            return cls._from_executor_status(base_path, artifact_type)
+        for file_name in (cls.__artifact_file_name, cls.__legacy_artifact_file_name):
+            try:
+                with open_url(f"{base_path}/{file_name}", "rb") as fd:
+                    if artifact_type is None:
+                        return json.load(fd)
+                    if not issubclass(artifact_type, BaseModel):
+                        raise TypeError(f"artifact_type must be a pydantic BaseModel subclass, got {artifact_type!r}")
+                    return artifact_type.model_validate_json(fd.read())
+            except FileNotFoundError:
+                continue
+        return cls._from_executor_status(base_path, artifact_type)
 
     @classmethod
     def _from_executor_status(cls, base_path: str, artifact_type: type[T] | None) -> "T | PathMetadata":
-        """Fallback when ``.artifact`` is absent: synthesize a :class:`PathMetadata`
+        """Fallback when no artifact file is present: synthesize a :class:`PathMetadata`
         if the step published ``.executor_status = SUCCESS``.
 
         Only valid when the caller wants no type or ``PathMetadata`` — other types

--- a/lib/marin/src/marin/execution/artifact.py
+++ b/lib/marin/src/marin/execution/artifact.py
@@ -48,11 +48,9 @@ class Artifact:
             with open_url(f"{base_path}/{cls.__artifact_file_name}", "rb") as fd:
                 if artifact_type is None:
                     return json.load(fd)
-                if issubclass(artifact_type, BaseModel):
-                    return artifact_type.model_validate_json(fd.read())
-                if is_dataclass(artifact_type):
-                    return artifact_type(**json.load(fd))  # type: ignore[not-callable]
-                raise ValueError(f"Unsupported artifact type: {artifact_type!r}")
+                if not issubclass(artifact_type, BaseModel):
+                    raise TypeError(f"artifact_type must be a pydantic BaseModel subclass, got {artifact_type!r}")
+                return artifact_type.model_validate_json(fd.read())
         except FileNotFoundError:
             return cls._from_executor_status(base_path, artifact_type)
 

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -125,6 +125,51 @@ def test_artifact_load_relative_path_resolves_against_marin_prefix(tmp_path: Pat
     assert loaded == artifact
 
 
+def test_artifact_from_executor_status_success_untyped(tmp_path: Path):
+    """No .artifact, but .executor_status=SUCCESS: synthesize PathMetadata."""
+    (tmp_path / ".executor_status").write_text("SUCCESS")
+
+    loaded = Artifact.from_path(tmp_path.as_posix())
+    assert isinstance(loaded, PathMetadata)
+    assert loaded.path == tmp_path.as_posix()
+
+
+def test_artifact_from_executor_status_success_typed_pathmetadata(tmp_path: Path):
+    """No .artifact, but .executor_status=SUCCESS and caller asks for PathMetadata."""
+    (tmp_path / ".executor_status").write_text("SUCCESS")
+
+    loaded = Artifact.from_path(tmp_path.as_posix(), PathMetadata)
+    assert loaded == PathMetadata(path=tmp_path.as_posix())
+
+
+def test_artifact_from_executor_status_success_typed_other_raises(tmp_path: Path):
+    """No .artifact, .executor_status=SUCCESS, but caller asks for a different type."""
+    (tmp_path / ".executor_status").write_text("SUCCESS")
+
+    with pytest.raises(FileNotFoundError, match="cannot synthesize"):
+        Artifact.from_path(tmp_path.as_posix(), TokenizeMetadata)
+
+
+def test_artifact_from_executor_status_non_success_raises(tmp_path: Path):
+    """No .artifact, .executor_status present but not SUCCESS."""
+    (tmp_path / ".executor_status").write_text("RUNNING")
+
+    with pytest.raises(FileNotFoundError, match="not 'SUCCESS'"):
+        Artifact.from_path(tmp_path.as_posix())
+
+
+def test_artifact_from_executor_status_relative_path(tmp_path: Path, monkeypatch):
+    """Fallback also works through MARIN_PREFIX-resolved relative paths."""
+    monkeypatch.setenv("MARIN_PREFIX", tmp_path.as_posix())
+    step_dir = tmp_path / "step_out"
+    step_dir.mkdir()
+    (step_dir / ".executor_status").write_text("SUCCESS")
+
+    loaded = Artifact.from_path("step_out")
+    assert isinstance(loaded, PathMetadata)
+    assert loaded.path == step_dir.as_posix()
+
+
 def test_artifact_save_and_load_untyped(tmp_path: Path):
     artifact = TokenizeMetadata(path="/tokenized", num_tokens=42)
     Artifact.save(artifact, tmp_path.as_posix())

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -17,6 +17,7 @@ from marin.execution.executor import Executor, ExecutorStep, _dag_tpu_regions, r
 from marin.execution.remote import RemoteCallable, remote
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
+from pydantic import BaseModel
 from rigging.filesystem import MARIN_CROSS_REGION_OVERRIDE_ENV
 
 # ---------------------------------------------------------------------------
@@ -24,14 +25,12 @@ from rigging.filesystem import MARIN_CROSS_REGION_OVERRIDE_ENV
 # ---------------------------------------------------------------------------
 
 
-@dataclass
-class TokenizeMetadata:
+class TokenizeMetadata(BaseModel):
     path: str
     num_tokens: int
 
 
-@dataclass
-class TrainMetadata:
+class TrainMetadata(BaseModel):
     tokens_seen: int
     checkpoint_path: str
 
@@ -156,18 +155,6 @@ def test_artifact_from_executor_status_non_success_raises(tmp_path: Path):
 
     with pytest.raises(FileNotFoundError, match="not 'SUCCESS'"):
         Artifact.from_path(tmp_path.as_posix())
-
-
-def test_artifact_from_executor_status_relative_path(tmp_path: Path, monkeypatch):
-    """Fallback also works through MARIN_PREFIX-resolved relative paths."""
-    monkeypatch.setenv("MARIN_PREFIX", tmp_path.as_posix())
-    step_dir = tmp_path / "step_out"
-    step_dir.mkdir()
-    (step_dir / ".executor_status").write_text("SUCCESS")
-
-    loaded = Artifact.from_path("step_out")
-    assert isinstance(loaded, PathMetadata)
-    assert loaded.path == step_dir.as_posix()
 
 
 def test_artifact_save_and_load_untyped(tmp_path: Path):

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -125,7 +125,7 @@ def test_artifact_load_relative_path_resolves_against_marin_prefix(tmp_path: Pat
 
 
 def test_artifact_from_executor_status_success_untyped(tmp_path: Path):
-    """No .artifact, but .executor_status=SUCCESS: synthesize PathMetadata."""
+    """No artifact file, but .executor_status=SUCCESS: synthesize PathMetadata."""
     (tmp_path / ".executor_status").write_text("SUCCESS")
 
     loaded = Artifact.from_path(tmp_path.as_posix())
@@ -134,7 +134,7 @@ def test_artifact_from_executor_status_success_untyped(tmp_path: Path):
 
 
 def test_artifact_from_executor_status_success_typed_pathmetadata(tmp_path: Path):
-    """No .artifact, but .executor_status=SUCCESS and caller asks for PathMetadata."""
+    """No artifact file, but .executor_status=SUCCESS and caller asks for PathMetadata."""
     (tmp_path / ".executor_status").write_text("SUCCESS")
 
     loaded = Artifact.from_path(tmp_path.as_posix(), PathMetadata)
@@ -142,7 +142,7 @@ def test_artifact_from_executor_status_success_typed_pathmetadata(tmp_path: Path
 
 
 def test_artifact_from_executor_status_success_typed_other_raises(tmp_path: Path):
-    """No .artifact, .executor_status=SUCCESS, but caller asks for a different type."""
+    """No artifact file, .executor_status=SUCCESS, but caller asks for a different type."""
     (tmp_path / ".executor_status").write_text("SUCCESS")
 
     with pytest.raises(FileNotFoundError, match="cannot synthesize"):
@@ -150,11 +150,19 @@ def test_artifact_from_executor_status_success_typed_other_raises(tmp_path: Path
 
 
 def test_artifact_from_executor_status_non_success_raises(tmp_path: Path):
-    """No .artifact, .executor_status present but not SUCCESS."""
+    """No artifact file, .executor_status present but not SUCCESS."""
     (tmp_path / ".executor_status").write_text("RUNNING")
 
     with pytest.raises(FileNotFoundError, match="not 'SUCCESS'"):
         Artifact.from_path(tmp_path.as_posix())
+
+
+def test_artifact_load_legacy_dotfile(tmp_path: Path):
+    """Historical outputs wrote `.artifact`; from_path should still load them."""
+    (tmp_path / ".artifact").write_text(json.dumps({"path": "/legacy"}))
+
+    loaded = Artifact.from_path(tmp_path.as_posix(), PathMetadata)
+    assert loaded == PathMetadata(path="/legacy")
 
 
 def test_artifact_save_and_load_untyped(tmp_path: Path):
@@ -440,7 +448,7 @@ def test_runner_skips_completed_steps(tmp_path: Path):
     runner1.run(steps)
 
     # Record modification times
-    tokenize_artifact_path = os.path.join(steps[1].output_path, ".artifact")
+    tokenize_artifact_path = os.path.join(steps[1].output_path, "artifact.json")
     mtime_before = os.path.getmtime(tokenize_artifact_path)
 
     # Re-run — all steps should be skipped


### PR DESCRIPTION
* `Artifact.from_path` returns `PathMetadata(path=base_path)` when `.artifact` is missing but `.executor_status` reads `SUCCESS`
* fallback applies for untyped calls and for `artifact_type=PathMetadata`; any other `artifact_type` still raises `FileNotFoundError`
* `artifact_type` must now be a `pydantic.BaseModel` subclass — the dataclass branch in typed load is gone, replaced by a `TypeError` for non-BaseModel types
* convert `PathMetadata` from `@dataclass` to `pydantic.BaseModel` so it can flow through the typed code path
* reuse `STATUS_SUCCESS` / `get_status_path` from `executor_step_status` instead of redefining the marker
* `Artifact.save` still accepts dataclasses (round-trip via untyped `from_path` returns a dict, as before)
* all production call sites already pass pydantic types (`NormalizedData`, `MinHashAttrData`, `FuzzyDupsAttrData`); test types `TokenizeMetadata` / `TrainMetadata` converted to `BaseModel`
* tests in `tests/execution/test_step_runner.py` cover untyped, typed `PathMetadata`, typed non-`PathMetadata`, and non-`SUCCESS` status paths