### PR TITLE
finelog: reserve 2 GiB host memory on the deploy VM

### DIFF
--- a/lib/finelog/src/finelog/deploy/bootstrap.py
+++ b/lib/finelog/src/finelog/deploy/bootstrap.py
@@ -79,7 +79,7 @@ container_milli_cpus=$(( host_cpus * 1000 - 500 ))
 if [ "$container_milli_cpus" -lt 500 ]; then container_milli_cpus=500; fi
 container_cpus=$(awk -v m="$container_milli_cpus" 'BEGIN{printf "%.3f", m/1000}')
 host_mem_mib=$(awk '/^MemTotal:/ {printf "%d", $2/1024}' /proc/meminfo)
-host_reserved_mem_mib=1700
+host_reserved_mem_mib=2048
 container_mem_mib=$(( host_mem_mib - host_reserved_mem_mib ))
 if [ "$container_mem_mib" -lt 256 ]; then container_mem_mib=256; fi
 echo "[finelog-init] host=${host_cpus}cpu/${host_mem_mib}MiB" \\


### PR DESCRIPTION
Bump host_reserved_mem_mib from 1700 to 2048 in the bootstrap script. Gives the host docker daemon, kernel page cache, and monitoring agents more headroom so the container can't crowd them out under load. Follow-up to #5683.