### PR TITLE
Add marinazh to researchers user budget

### DIFF
--- a/lib/iris/config/marin.yaml
+++ b/lib/iris/config/marin.yaml
@@ -219,5 +219,6 @@ user_budgets:
       - michaelryan
       - kaiyue
       - ryan
+      - marinazh
     budget_limit: 75000
     max_band: PRIORITY_BAND_INTERACTIVE


### PR DESCRIPTION
Adds `marinazh` to the PRIORITY_BAND_INTERACTIVE researcher list in
  `lib/iris/config/marin.yaml`.`