### PR TITLE
[Grug] Add segmented FA4 CuTe attention

### DIFF
--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -25,7 +25,14 @@ try:
 except ModuleNotFoundError:
     from jax.experimental.shard_map import shard_map
 from jaxtyping import Array, Float, Int, PRNGKeyArray
-from levanter.grug.attention import AttentionMask, RotaryConfig, align_kv_heads, apply_rotary_embedding, attention
+from levanter.grug.attention import (
+    AttentionMask,
+    GrugAttentionImplementation,
+    RotaryConfig,
+    align_kv_heads,
+    apply_rotary_embedding,
+    attention,
+)
 from levanter.grug.grug_moe import MoeActivation, MoeImplementation, moe_mlp
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
 from levanter.grug.sharding import Pembed_vocab, Plm_head, unshard
@@ -70,6 +77,7 @@ class GrugModelConfig:
     initializer_std: float = 0.02
     qk_mult: float = 1.0
     router_z_loss_coef: float = 0.001
+    attention_implementation: GrugAttentionImplementation | None = None
     moe_implementation: MoeImplementation | None = None
     rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
 
@@ -141,7 +149,7 @@ class CausalSelfAttention(eqx.Module):
         k = rms_norm(k)
         q, k = apply_rotary_embedding(q, k, seq_len=seq_len, head_dim=head_dim, rope=self.cfg.rope)
         q = q * self.cfg.qk_mult
-        attn_out = attention(q, k, v, mask)
+        attn_out = attention(q, k, v, mask, implementation=self.cfg.attention_implementation)
         aligned_v = align_kv_heads(v, num_q_heads=attn_out.shape[2])
         aligned_v = reshard(aligned_v, P(("data", "expert"), None, "model", None))
         # Exclusive Self Attention: subtract the component of yᵢ parallel to vᵢ.

--- a/lib/levanter/scripts/bench/bench_grug_attention.py
+++ b/lib/levanter/scripts/bench/bench_grug_attention.py
@@ -1,0 +1,616 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+import time
+from typing import Literal
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from levanter.grug.attention import AttentionMask, GrugAttentionImplementation, attention, reference_attention
+
+Mode = Literal["forward", "forward_backward"]
+
+
+@dataclass(frozen=True, slots=True)
+class Shape:
+    batch: int
+    seq_len: int
+    q_heads: int
+    kv_heads: int
+    head_dim: int
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkResult:
+    implementation: str
+    mode: Mode
+    batch: int
+    seq_len: int
+    q_heads: int
+    kv_heads: int
+    head_dim: int
+    dtype: str
+    sliding_window: int | None
+    max_segments_per_seq: int
+    compile_s: float
+    steady_s: float
+    tokens_per_s: float
+    max_abs_vs_reference: float | None = None
+    grad_max_abs_vs_reference: float | None = None
+    comparison_implementation: str | None = None
+    max_abs_vs_comparison: float | None = None
+    grad_max_abs_vs_comparison: float | None = None
+
+
+def _dtype_from_name(name: str) -> jnp.dtype:
+    normalized = name.lower()
+    if normalized in {"bf16", "bfloat16"}:
+        return jnp.bfloat16
+    if normalized in {"fp16", "float16"}:
+        return jnp.float16
+    if normalized in {"fp32", "float32"}:
+        return jnp.float32
+    raise ValueError(f"Unsupported dtype: {name}")
+
+
+def _make_segment_ids(
+    *,
+    batch: int,
+    seq_len: int,
+    target_segment_len: int,
+    padding_tokens: int,
+) -> tuple[jax.Array, int]:
+    if target_segment_len <= 0:
+        raise ValueError(f"target_segment_len must be positive, got {target_segment_len}")
+    if padding_tokens < 0 or padding_tokens >= seq_len:
+        raise ValueError(f"padding_tokens must be in [0, {seq_len}), got {padding_tokens}")
+
+    ids = np.full((batch, seq_len), -1, dtype=np.int32)
+    # Non-block-aligned lengths exercise the dynamic segment path that the data loader produces.
+    length_pattern = np.array(
+        [
+            max(1, target_segment_len - 37),
+            target_segment_len + 19,
+            max(1, target_segment_len // 2 + 11),
+            target_segment_len + 73,
+        ],
+        dtype=np.int32,
+    )
+    max_segments = 0
+    usable_seq_len = seq_len - padding_tokens
+    for batch_idx in range(batch):
+        pos = 0
+        segment_idx = 0
+        while pos < usable_seq_len:
+            length = int(length_pattern[(segment_idx + batch_idx) % len(length_pattern)])
+            end = min(usable_seq_len, pos + length)
+            ids[batch_idx, pos:end] = batch_idx * 1_000_000 + segment_idx
+            pos = end
+            segment_idx += 1
+        max_segments = max(max_segments, segment_idx)
+    return jnp.asarray(ids), max_segments
+
+
+def _segment_slices(segment_ids: jax.Array) -> tuple[tuple[int, int, int], ...]:
+    segment_ids_host = np.asarray(jax.device_get(segment_ids))
+    slices = []
+    for batch_idx, row in enumerate(segment_ids_host):
+        start = None
+        current_id = None
+        for pos, segment_id in enumerate(row):
+            if segment_id < 0:
+                if start is not None:
+                    slices.append((batch_idx, start, pos))
+                    start = None
+                    current_id = None
+                continue
+            if start is None:
+                start = pos
+                current_id = segment_id
+                continue
+            if segment_id != current_id:
+                slices.append((batch_idx, start, pos))
+                start = pos
+                current_id = segment_id
+        if start is not None:
+            slices.append((batch_idx, start, row.shape[0]))
+    return tuple(slices)
+
+
+def _make_inputs(shape: Shape, dtype: jnp.dtype) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    key = jax.random.PRNGKey(0)
+    q_key, k_key, v_key, cotangent_key = jax.random.split(key, 4)
+    q = jax.random.normal(q_key, (shape.batch, shape.seq_len, shape.q_heads, shape.head_dim), dtype=dtype)
+    k = jax.random.normal(k_key, (shape.batch, shape.seq_len, shape.kv_heads, shape.head_dim), dtype=dtype)
+    v = jax.random.normal(v_key, (shape.batch, shape.seq_len, shape.kv_heads, shape.head_dim), dtype=dtype)
+    cotangent = jax.random.normal(cotangent_key, q.shape, dtype=dtype)
+    return q, k, v, cotangent
+
+
+def _block_until_ready(value):
+    leaves = jax.tree.leaves(value)
+    for leaf in leaves:
+        leaf.block_until_ready()
+    return value
+
+
+def _time_jitted(fn, *args, steps: int, warmup: int) -> tuple[float, float]:
+    start = time.perf_counter()
+    out = fn(*args)
+    _block_until_ready(out)
+    compile_s = time.perf_counter() - start
+
+    for _ in range(warmup):
+        out = fn(*args)
+        _block_until_ready(out)
+
+    start = time.perf_counter()
+    for _ in range(steps):
+        out = fn(*args)
+        _block_until_ready(out)
+    steady_s = (time.perf_counter() - start) / steps
+    return compile_s, steady_s
+
+
+def _mask(segment_ids: jax.Array, *, sliding_window: int | None, max_segments_per_seq: int) -> AttentionMask:
+    return AttentionMask.causal(
+        sliding_window=sliding_window, max_segments_per_seq=max_segments_per_seq
+    ).with_segment_ids(segment_ids)
+
+
+def _forward_fn(implementation: GrugAttentionImplementation, *, sliding_window: int | None, max_segments_per_seq: int):
+    def forward(q: jax.Array, k: jax.Array, v: jax.Array, segment_ids: jax.Array) -> jax.Array:
+        return attention(
+            q,
+            k,
+            v,
+            _mask(segment_ids, sliding_window=sliding_window, max_segments_per_seq=max_segments_per_seq),
+            implementation=implementation,
+        )
+
+    return jax.jit(forward)
+
+
+def _forward_backward_fn(
+    implementation: GrugAttentionImplementation,
+    *,
+    sliding_window: int | None,
+    max_segments_per_seq: int,
+):
+    def loss(q: jax.Array, k: jax.Array, v: jax.Array, segment_ids: jax.Array, cotangent: jax.Array) -> jax.Array:
+        out = attention(
+            q,
+            k,
+            v,
+            _mask(segment_ids, sliding_window=sliding_window, max_segments_per_seq=max_segments_per_seq),
+            implementation=implementation,
+        )
+        return jnp.sum(out.astype(jnp.float32) * cotangent.astype(jnp.float32))
+
+    return jax.jit(jax.value_and_grad(loss, argnums=(0, 1, 2)))
+
+
+def _segmented_reference_fn(segment_ids: jax.Array, *, sliding_window: int | None):
+    slices = _segment_slices(segment_ids)
+    segment_mask = AttentionMask.causal(sliding_window=sliding_window)
+
+    def ref(q: jax.Array, k: jax.Array, v: jax.Array) -> jax.Array:
+        out = jnp.zeros((*q.shape[:3], v.shape[-1]), dtype=v.dtype)
+        for batch_idx, start, end in slices:
+            segment_out = reference_attention(
+                q[batch_idx : batch_idx + 1, start:end],
+                k[batch_idx : batch_idx + 1, start:end],
+                v[batch_idx : batch_idx + 1, start:end],
+                segment_mask,
+                logits_dtype=jnp.float32,
+            )
+            out = out.at[batch_idx : batch_idx + 1, start:end].set(segment_out)
+        return out
+
+    return ref
+
+
+def _max_abs(a: jax.Array, b: jax.Array) -> float:
+    return float(jnp.max(jnp.abs(a.astype(jnp.float32) - b.astype(jnp.float32))))
+
+
+def _reference_diffs(
+    implementation: GrugAttentionImplementation,
+    shape: Shape,
+    *,
+    dtype: jnp.dtype,
+    segment_len: int,
+    padding_tokens: int,
+    sliding_window: int | None,
+    check_grad: bool,
+) -> tuple[float, float | None]:
+    q, k, v, cotangent = _make_inputs(shape, dtype)
+    segment_ids, max_segments = _make_segment_ids(
+        batch=shape.batch,
+        seq_len=shape.seq_len,
+        target_segment_len=segment_len,
+        padding_tokens=padding_tokens,
+    )
+    valid = segment_ids >= 0
+    cotangent = cotangent * valid[..., None, None].astype(dtype)
+    mask = _mask(segment_ids, sliding_window=sliding_window, max_segments_per_seq=max_segments)
+    ref = _segmented_reference_fn(segment_ids, sliding_window=sliding_window)
+
+    def actual(q_arg: jax.Array, k_arg: jax.Array, v_arg: jax.Array) -> jax.Array:
+        return attention(q_arg, k_arg, v_arg, mask, implementation=implementation)
+
+    ref_out = jax.jit(ref)(q, k, v)
+    actual_out = jax.jit(actual)(q, k, v)
+    ref_out, actual_out = _block_until_ready((ref_out, actual_out))
+    value_max_abs = _max_abs(
+        jnp.where(valid[..., None, None], actual_out, ref_out),
+        ref_out,
+    )
+
+    grad_max_abs = None
+    if check_grad:
+
+        def ref_loss(q_arg: jax.Array, k_arg: jax.Array, v_arg: jax.Array) -> jax.Array:
+            return jnp.sum(ref(q_arg, k_arg, v_arg).astype(jnp.float32) * cotangent.astype(jnp.float32))
+
+        def actual_loss(q_arg: jax.Array, k_arg: jax.Array, v_arg: jax.Array) -> jax.Array:
+            return jnp.sum(actual(q_arg, k_arg, v_arg).astype(jnp.float32) * cotangent.astype(jnp.float32))
+
+        ref_grads = jax.jit(jax.grad(ref_loss, argnums=(0, 1, 2)))(q, k, v)
+        actual_grads = jax.jit(jax.grad(actual_loss, argnums=(0, 1, 2)))(q, k, v)
+        ref_grads, actual_grads = _block_until_ready((ref_grads, actual_grads))
+        grad_max_abs = max(
+            _max_abs(actual_grad, ref_grad) for actual_grad, ref_grad in zip(actual_grads, ref_grads, strict=True)
+        )
+    return value_max_abs, grad_max_abs
+
+
+def _implementation_diffs(
+    implementation: GrugAttentionImplementation,
+    comparison_implementation: GrugAttentionImplementation,
+    shape: Shape,
+    *,
+    dtype: jnp.dtype,
+    segment_len: int,
+    padding_tokens: int,
+    sliding_window: int | None,
+    check_grad: bool,
+) -> tuple[float, float | None]:
+    q, k, v, cotangent = _make_inputs(shape, dtype)
+    segment_ids, max_segments = _make_segment_ids(
+        batch=shape.batch,
+        seq_len=shape.seq_len,
+        target_segment_len=segment_len,
+        padding_tokens=padding_tokens,
+    )
+    valid = segment_ids >= 0
+    cotangent = cotangent * valid[..., None, None].astype(dtype)
+    mask = _mask(segment_ids, sliding_window=sliding_window, max_segments_per_seq=max_segments)
+    segmented_ref = _segmented_reference_fn(segment_ids, sliding_window=sliding_window)
+
+    def call(
+        impl: GrugAttentionImplementation,
+        q_arg: jax.Array,
+        k_arg: jax.Array,
+        v_arg: jax.Array,
+    ) -> jax.Array:
+        if impl == "reference":
+            return segmented_ref(q_arg, k_arg, v_arg)
+        return attention(q_arg, k_arg, v_arg, mask, implementation=impl)
+
+    def baseline(q_arg: jax.Array, k_arg: jax.Array, v_arg: jax.Array) -> jax.Array:
+        return call(comparison_implementation, q_arg, k_arg, v_arg)
+
+    def actual(q_arg: jax.Array, k_arg: jax.Array, v_arg: jax.Array) -> jax.Array:
+        return call(implementation, q_arg, k_arg, v_arg)
+
+    baseline_out = jax.jit(baseline)(q, k, v)
+    actual_out = jax.jit(actual)(q, k, v)
+    baseline_out, actual_out = _block_until_ready((baseline_out, actual_out))
+    value_max_abs = _max_abs(
+        jnp.where(valid[..., None, None], actual_out, baseline_out),
+        baseline_out,
+    )
+
+    grad_max_abs = None
+    if check_grad:
+
+        def baseline_loss(q_arg: jax.Array, k_arg: jax.Array, v_arg: jax.Array) -> jax.Array:
+            return jnp.sum(baseline(q_arg, k_arg, v_arg).astype(jnp.float32) * cotangent.astype(jnp.float32))
+
+        def actual_loss(q_arg: jax.Array, k_arg: jax.Array, v_arg: jax.Array) -> jax.Array:
+            return jnp.sum(actual(q_arg, k_arg, v_arg).astype(jnp.float32) * cotangent.astype(jnp.float32))
+
+        baseline_grads = jax.jit(jax.grad(baseline_loss, argnums=(0, 1, 2)))(q, k, v)
+        actual_grads = jax.jit(jax.grad(actual_loss, argnums=(0, 1, 2)))(q, k, v)
+        baseline_grads, actual_grads = _block_until_ready((baseline_grads, actual_grads))
+        grad_max_abs = max(
+            _max_abs(actual_grad, baseline_grad)
+            for actual_grad, baseline_grad in zip(actual_grads, baseline_grads, strict=True)
+        )
+    return value_max_abs, grad_max_abs
+
+
+def _check_tolerance(
+    *,
+    implementation: str,
+    label: str,
+    value_max_abs: float | None,
+    grad_max_abs: float | None,
+    atol: float,
+) -> None:
+    if value_max_abs is not None and value_max_abs > atol:
+        raise RuntimeError(f"{implementation} exceeded {label} tolerance {atol}: value max abs {value_max_abs}")
+    if grad_max_abs is None or grad_max_abs <= atol:
+        return
+    raise RuntimeError(
+        f"{implementation} exceeded {label} tolerance {atol}: "
+        f"value max abs {value_max_abs}, grad max abs {grad_max_abs}"
+    )
+
+
+def _benchmark_implementation(
+    implementation: GrugAttentionImplementation,
+    shape: Shape,
+    *,
+    dtype: jnp.dtype,
+    dtype_name: str,
+    segment_len: int,
+    padding_tokens: int,
+    sliding_window: int | None,
+    steps: int,
+    warmup: int,
+    reference_check_shape: Shape | None,
+    reference_atol: float,
+    comparison_implementation: GrugAttentionImplementation | None,
+    comparison_atol: float,
+    modes: tuple[Mode, ...],
+) -> list[BenchmarkResult]:
+    q, k, v, cotangent = _make_inputs(shape, dtype)
+    segment_ids, max_segments = _make_segment_ids(
+        batch=shape.batch,
+        seq_len=shape.seq_len,
+        target_segment_len=segment_len,
+        padding_tokens=padding_tokens,
+    )
+    valid = segment_ids >= 0
+    cotangent = cotangent * valid[..., None, None].astype(dtype)
+    tokens = int(jnp.sum(valid))
+    check_grad = "forward_backward" in modes
+
+    value_max_abs = None
+    grad_max_abs = None
+    if reference_check_shape is not None:
+        value_max_abs, grad_max_abs = _reference_diffs(
+            implementation,
+            reference_check_shape,
+            dtype=dtype,
+            segment_len=min(segment_len, max(1, reference_check_shape.seq_len // 4)),
+            padding_tokens=min(padding_tokens, max(0, reference_check_shape.seq_len // 8)),
+            sliding_window=sliding_window,
+            check_grad=check_grad,
+        )
+        _check_tolerance(
+            implementation=implementation,
+            label="reference",
+            value_max_abs=value_max_abs,
+            grad_max_abs=grad_max_abs,
+            atol=reference_atol,
+        )
+
+    comparison_value_max_abs = None
+    comparison_grad_max_abs = None
+    if comparison_implementation == implementation:
+        comparison_value_max_abs = 0.0
+        comparison_grad_max_abs = 0.0 if check_grad else None
+    elif comparison_implementation is not None:
+        comparison_value_max_abs, comparison_grad_max_abs = _implementation_diffs(
+            implementation,
+            comparison_implementation,
+            shape,
+            dtype=dtype,
+            segment_len=segment_len,
+            padding_tokens=padding_tokens,
+            sliding_window=sliding_window,
+            check_grad=check_grad,
+        )
+        _check_tolerance(
+            implementation=implementation,
+            label=f"{comparison_implementation} comparison",
+            value_max_abs=comparison_value_max_abs,
+            grad_max_abs=comparison_grad_max_abs,
+            atol=comparison_atol,
+        )
+
+    results = []
+    if "forward" in modes:
+        forward = _forward_fn(implementation, sliding_window=sliding_window, max_segments_per_seq=max_segments)
+        forward_compile, forward_steady = _time_jitted(forward, q, k, v, segment_ids, steps=steps, warmup=warmup)
+        results.append(
+            BenchmarkResult(
+                implementation=implementation,
+                mode="forward",
+                batch=shape.batch,
+                seq_len=shape.seq_len,
+                q_heads=shape.q_heads,
+                kv_heads=shape.kv_heads,
+                head_dim=shape.head_dim,
+                dtype=dtype_name,
+                sliding_window=sliding_window,
+                max_segments_per_seq=max_segments,
+                compile_s=forward_compile,
+                steady_s=forward_steady,
+                tokens_per_s=tokens / forward_steady,
+                max_abs_vs_reference=value_max_abs,
+                grad_max_abs_vs_reference=grad_max_abs,
+                comparison_implementation=comparison_implementation,
+                max_abs_vs_comparison=comparison_value_max_abs,
+                grad_max_abs_vs_comparison=comparison_grad_max_abs,
+            )
+        )
+
+    if "forward_backward" in modes:
+        forward_backward = _forward_backward_fn(
+            implementation,
+            sliding_window=sliding_window,
+            max_segments_per_seq=max_segments,
+        )
+        fwd_bwd_compile, fwd_bwd_steady = _time_jitted(
+            forward_backward,
+            q,
+            k,
+            v,
+            segment_ids,
+            cotangent,
+            steps=steps,
+            warmup=warmup,
+        )
+        results.append(
+            BenchmarkResult(
+                implementation=implementation,
+                mode="forward_backward",
+                batch=shape.batch,
+                seq_len=shape.seq_len,
+                q_heads=shape.q_heads,
+                kv_heads=shape.kv_heads,
+                head_dim=shape.head_dim,
+                dtype=dtype_name,
+                sliding_window=sliding_window,
+                max_segments_per_seq=max_segments,
+                compile_s=fwd_bwd_compile,
+                steady_s=fwd_bwd_steady,
+                tokens_per_s=tokens / fwd_bwd_steady,
+                max_abs_vs_reference=value_max_abs,
+                grad_max_abs_vs_reference=grad_max_abs,
+                comparison_implementation=comparison_implementation,
+                max_abs_vs_comparison=comparison_value_max_abs,
+                grad_max_abs_vs_comparison=comparison_grad_max_abs,
+            )
+        )
+
+    return results
+
+
+def _parse_modes(value: str) -> tuple[Mode, ...]:
+    modes = tuple(mode.strip() for mode in value.split(",") if mode.strip())
+    allowed = {"forward", "forward_backward"}
+    unknown = set(modes) - allowed
+    if unknown:
+        raise ValueError(f"Unknown benchmark mode(s): {sorted(unknown)}")
+    if not modes:
+        raise ValueError("At least one benchmark mode is required.")
+    return modes  # type: ignore[return-value]
+
+
+def _default_implementations() -> list[str]:
+    if jax.default_backend() != "gpu":
+        return ["reference"]
+    return ["gpu_te"]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark Grug packed-segment attention implementations.")
+    parser.add_argument("--batch", type=int, default=1)
+    parser.add_argument("--seq-len", type=int, default=8192)
+    parser.add_argument("--q-heads", type=int, default=32)
+    parser.add_argument("--kv-heads", type=int, default=8)
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument("--dtype", default="bf16")
+    parser.add_argument("--segment-len", type=int, default=256)
+    parser.add_argument("--padding-tokens", type=int, default=0)
+    parser.add_argument("--sliding-window", type=int, default=None)
+    parser.add_argument("--steps", type=int, default=10)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--implementations", default=None)
+    parser.add_argument(
+        "--modes",
+        default="forward,forward_backward",
+        help="Comma-separated benchmark modes: forward,forward_backward. Use forward for FA4/CuTe until backward lands.",
+    )
+    parser.add_argument("--check-reference", action="store_true")
+    parser.add_argument(
+        "--reference-seq-len",
+        type=int,
+        default=None,
+        help=(
+            "Sequence length for the reference check. Defaults to the benchmark sequence length; "
+            "the reference is computed segment-by-segment, so 8192 checks avoid full [S,S] masks."
+        ),
+    )
+    parser.add_argument("--reference-atol", type=float, default=1e-3)
+    parser.add_argument("--comparison-implementation", default=None)
+    parser.add_argument("--comparison-atol", type=float, default=1e-3)
+    args = parser.parse_args()
+
+    dtype = _dtype_from_name(args.dtype)
+    shape = Shape(
+        batch=args.batch,
+        seq_len=args.seq_len,
+        q_heads=args.q_heads,
+        kv_heads=args.kv_heads,
+        head_dim=args.head_dim,
+    )
+    if args.implementations is None:
+        implementations = _default_implementations()
+    else:
+        implementations = [name.strip() for name in args.implementations.split(",") if name.strip()]
+    comparison_implementation = None
+    if args.comparison_implementation is not None:
+        comparison_implementation = args.comparison_implementation.strip()
+    modes = _parse_modes(args.modes)
+
+    reference_shape = None
+    if args.check_reference:
+        reference_seq_len = (
+            args.seq_len if args.reference_seq_len is None else min(args.seq_len, args.reference_seq_len)
+        )
+        reference_shape = Shape(
+            batch=args.batch,
+            seq_len=reference_seq_len,
+            q_heads=args.q_heads,
+            kv_heads=args.kv_heads,
+            head_dim=args.head_dim,
+        )
+
+    print(
+        json.dumps(
+            {
+                "devices": [str(device) for device in jax.devices()],
+                "default_backend": jax.default_backend(),
+                "shape": asdict(shape),
+                "implementations": implementations,
+                "modes": modes,
+                "comparison_implementation": comparison_implementation,
+            }
+        )
+    )
+    for implementation in implementations:
+        results = _benchmark_implementation(
+            implementation,  # type: ignore[arg-type]
+            shape,
+            dtype=dtype,
+            dtype_name=args.dtype,
+            segment_len=args.segment_len,
+            padding_tokens=args.padding_tokens,
+            sliding_window=args.sliding_window,
+            steps=args.steps,
+            warmup=args.warmup,
+            reference_check_shape=reference_shape,
+            reference_atol=args.reference_atol,
+            comparison_implementation=comparison_implementation,  # type: ignore[arg-type]
+            comparison_atol=args.comparison_atol,
+            modes=modes,
+        )
+        for result in results:
+            print(json.dumps(asdict(result)))
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/levanter/scripts/bench/bench_megatron_te_attention.py
+++ b/lib/levanter/scripts/bench/bench_megatron_te_attention.py
@@ -1,0 +1,368 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+import os
+import statistics
+from typing import Any, Literal
+
+
+Backend = Literal["auto", "fused", "flash"]
+Mode = Literal["forward", "forward_backward"]
+
+BACKEND_ENV: dict[Backend, dict[str, str]] = {
+    "auto": {
+        "NVTE_FLASH_ATTN": "1",
+        "NVTE_FUSED_ATTN": "1",
+        "NVTE_UNFUSED_ATTN": "1",
+    },
+    "fused": {
+        "NVTE_FLASH_ATTN": "0",
+        "NVTE_FUSED_ATTN": "1",
+        "NVTE_UNFUSED_ATTN": "0",
+    },
+    "flash": {
+        "NVTE_FLASH_ATTN": "1",
+        "NVTE_FUSED_ATTN": "0",
+        "NVTE_UNFUSED_ATTN": "0",
+    },
+}
+
+BACKEND_SELECTION_ENV_KEYS = (
+    "NVTE_FLASH_ATTN",
+    "NVTE_FUSED_ATTN",
+    "NVTE_UNFUSED_ATTN",
+    "NVTE_FUSED_ATTN_BACKEND",
+    "NVTE_FUSED_ATTN_FORCE_WORKSPACE_OPT",
+    "NVTE_FUSED_ATTN_USE_FAv2_BWD",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Shape:
+    batch: int
+    seq_len: int
+    q_heads: int
+    kv_heads: int
+    head_dim: int
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkResult:
+    backend: Backend
+    mode: Mode
+    batch: int
+    seq_len: int
+    total_tokens: int
+    q_heads: int
+    kv_heads: int
+    head_dim: int
+    dtype: str
+    max_seqlen: int
+    segments: int
+    mean_ms: float
+    median_ms: float
+    min_ms: float
+    peak_memory_mib: float
+    max_abs_vs_reference: float | None
+    grad_max_abs_vs_reference: float | None
+
+
+def _set_backend_env(backend: Backend, *, debug: bool) -> None:
+    for key in BACKEND_SELECTION_ENV_KEYS:
+        os.environ.pop(key, None)
+    for key, value in BACKEND_ENV[backend].items():
+        os.environ[key] = value
+    if debug:
+        os.environ["NVTE_DEBUG"] = "1"
+        os.environ["NVTE_DEBUG_LEVEL"] = "2"
+
+
+def _torch_dtype(torch: Any, name: str) -> Any:
+    normalized = name.lower()
+    if normalized in {"bf16", "bfloat16"}:
+        return torch.bfloat16
+    if normalized in {"fp16", "float16"}:
+        return torch.float16
+    raise ValueError(f"Unsupported dtype: {name}")
+
+
+def _segment_lengths(shape: Shape, target_segment_len: int) -> list[int]:
+    if target_segment_len <= 0:
+        raise ValueError(f"target_segment_len must be positive, got {target_segment_len}")
+    pattern = [
+        max(1, target_segment_len - 37),
+        target_segment_len + 19,
+        max(1, target_segment_len // 2 + 11),
+        target_segment_len + 73,
+    ]
+    lengths: list[int] = []
+    for batch_idx in range(shape.batch):
+        remaining = shape.seq_len
+        segment_idx = 0
+        while remaining > 0:
+            length = min(remaining, pattern[(batch_idx + segment_idx) % len(pattern)])
+            lengths.append(length)
+            remaining -= length
+            segment_idx += 1
+    return lengths
+
+
+def _cu_seqlens(torch: Any, lengths: list[int]) -> Any:
+    cumulative = [0]
+    for length in lengths:
+        cumulative.append(cumulative[-1] + int(length))
+    return torch.tensor(cumulative, dtype=torch.int32, device="cuda")
+
+
+def _new_leaf(torch: Any, shape: tuple[int, ...], dtype: Any) -> Any:
+    tensor = torch.randn(shape, device="cuda", dtype=dtype)
+    tensor.requires_grad_(True)
+    return tensor
+
+
+def _normalize_output(torch: Any, out: Any, shape: Shape) -> Any:
+    if isinstance(out, tuple):
+        out = out[0]
+    if out.ndim == 3:
+        return out
+    if out.ndim == 2:
+        return out.reshape(out.shape[0], shape.q_heads, -1)
+    raise ValueError(f"Unexpected TE output shape: {tuple(out.shape)}")
+
+
+def _reference_thd(torch: Any, q: Any, k: Any, v: Any, lengths: list[int]) -> Any:
+    import torch.nn.functional as F
+
+    outputs = []
+    start = 0
+    repeat = q.shape[1] // k.shape[1]
+    scale = 1.0 / (q.shape[-1] ** 0.5)
+    for length in lengths:
+        end = start + length
+        q_i = q[start:end].transpose(0, 1).unsqueeze(0)
+        k_i = k[start:end].repeat_interleave(repeat, dim=1).transpose(0, 1).unsqueeze(0)
+        v_i = v[start:end].repeat_interleave(repeat, dim=1).transpose(0, 1).unsqueeze(0)
+        out_i = F.scaled_dot_product_attention(q_i, k_i, v_i, dropout_p=0.0, is_causal=True, scale=scale)
+        outputs.append(out_i.squeeze(0).transpose(0, 1))
+        start = end
+    return torch.cat(outputs, dim=0)
+
+
+def _call_attention(module: Any, q: Any, k: Any, v: Any, cu_seqlens: Any, max_seqlen: int) -> Any:
+    return module(
+        q,
+        k,
+        v,
+        None,
+        qkv_format="thd",
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_kv=cu_seqlens,
+        cu_seqlens_q_padded=cu_seqlens,
+        cu_seqlens_kv_padded=cu_seqlens,
+        max_seqlen_q=max_seqlen,
+        max_seqlen_kv=max_seqlen,
+        attn_mask_type="padding_causal",
+        window_size=(-1, 0),
+    )
+
+
+def _time_cuda(torch: Any, fn, *, steps: int, warmup: int) -> list[float]:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    times_ms: list[float] = []
+    for _ in range(steps):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        end.synchronize()
+        times_ms.append(float(start.elapsed_time(end)))
+    return times_ms
+
+
+def _benchmark_mode(
+    torch: Any,
+    module: Any,
+    *,
+    backend: Backend,
+    mode: Mode,
+    shape: Shape,
+    dtype: Any,
+    dtype_name: str,
+    lengths: list[int],
+    cu_seqlens: Any,
+    steps: int,
+    warmup: int,
+    check_reference: bool,
+) -> BenchmarkResult:
+    total_tokens = shape.batch * shape.seq_len
+    max_seqlen = max(lengths)
+    q = _new_leaf(torch, (total_tokens, shape.q_heads, shape.head_dim), dtype)
+    k = _new_leaf(torch, (total_tokens, shape.kv_heads, shape.head_dim), dtype)
+    v = _new_leaf(torch, (total_tokens, shape.kv_heads, shape.head_dim), dtype)
+    with torch.no_grad():
+        sample_out = _normalize_output(torch, _call_attention(module, q, k, v, cu_seqlens, max_seqlen), shape)
+        dout = torch.randn_like(sample_out)
+
+    max_abs = None
+    grad_max_abs = None
+    if check_reference:
+        with torch.no_grad():
+            actual = _normalize_output(torch, _call_attention(module, q, k, v, cu_seqlens, max_seqlen), shape)
+            expected = _reference_thd(torch, q, k, v, lengths)
+            max_abs = float((actual.float() - expected.float()).abs().max().item())
+            reference_cotangent = torch.randn_like(expected)
+        actual = _normalize_output(torch, _call_attention(module, q, k, v, cu_seqlens, max_seqlen), shape)
+        actual_loss = (actual.float() * reference_cotangent.float()).sum()
+        actual_grads = torch.autograd.grad(actual_loss, (q, k, v))
+        expected = _reference_thd(torch, q, k, v, lengths)
+        expected_loss = (expected.float() * reference_cotangent.float()).sum()
+        expected_grads = torch.autograd.grad(expected_loss, (q, k, v))
+        grad_max_abs = max(
+            float((actual_grad.float() - expected_grad.float()).abs().max().item())
+            for actual_grad, expected_grad in zip(actual_grads, expected_grads, strict=True)
+        )
+
+    def zero_grads() -> None:
+        for tensor in (q, k, v):
+            tensor.grad = None
+
+    def forward() -> None:
+        out = _call_attention(module, q, k, v, cu_seqlens, max_seqlen)
+        if isinstance(out, tuple):
+            out = out[0]
+        # Keep grad-enabled forward timing representative without retaining outputs.
+        out.sum().detach()
+
+    def forward_backward() -> None:
+        zero_grads()
+        out = _normalize_output(torch, _call_attention(module, q, k, v, cu_seqlens, max_seqlen), shape)
+        loss = (out.float() * dout.float()).sum()
+        loss.backward()
+
+    torch.cuda.reset_peak_memory_stats()
+    times_ms = _time_cuda(
+        torch,
+        forward if mode == "forward" else forward_backward,
+        steps=steps,
+        warmup=warmup,
+    )
+    peak_memory_mib = torch.cuda.max_memory_allocated() / (1024 * 1024)
+
+    return BenchmarkResult(
+        backend=backend,
+        mode=mode,
+        batch=shape.batch,
+        seq_len=shape.seq_len,
+        total_tokens=total_tokens,
+        q_heads=shape.q_heads,
+        kv_heads=shape.kv_heads,
+        head_dim=shape.head_dim,
+        dtype=dtype_name,
+        max_seqlen=max_seqlen,
+        segments=len(lengths),
+        mean_ms=statistics.fmean(times_ms),
+        median_ms=statistics.median(times_ms),
+        min_ms=min(times_ms),
+        peak_memory_mib=peak_memory_mib,
+        max_abs_vs_reference=max_abs,
+        grad_max_abs_vs_reference=grad_max_abs,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Benchmark the Megatron-Core comparison target: Transformer Engine "
+            "DotProductAttention in THD packed-sequence mode."
+        )
+    )
+    parser.add_argument("--backend", choices=("auto", "fused", "flash"), default="auto")
+    parser.add_argument("--batch", type=int, default=1)
+    parser.add_argument("--seq-len", type=int, default=8192)
+    parser.add_argument("--q-heads", type=int, default=32)
+    parser.add_argument("--kv-heads", type=int, default=8)
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument("--dtype", default="bf16")
+    parser.add_argument("--segment-len", type=int, default=256)
+    parser.add_argument("--steps", type=int, default=100)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--check-reference", action="store_true")
+    parser.add_argument("--debug-backend-selection", action="store_true")
+    args = parser.parse_args()
+
+    backend: Backend = args.backend
+    _set_backend_env(backend, debug=args.debug_backend_selection)
+
+    try:
+        import torch
+        from transformer_engine.pytorch import DotProductAttention
+    except ImportError as exc:
+        raise RuntimeError(
+            "bench_megatron_te_attention.py requires PyTorch and transformer-engine with CUDA support."
+        ) from exc
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("This benchmark requires a CUDA GPU.")
+
+    shape = Shape(
+        batch=args.batch,
+        seq_len=args.seq_len,
+        q_heads=args.q_heads,
+        kv_heads=args.kv_heads,
+        head_dim=args.head_dim,
+    )
+    dtype = _torch_dtype(torch, args.dtype)
+    lengths = _segment_lengths(shape, args.segment_len)
+    cu = _cu_seqlens(torch, lengths)
+
+    module = DotProductAttention(
+        num_attention_heads=shape.q_heads,
+        kv_channels=shape.head_dim,
+        num_gqa_groups=shape.kv_heads,
+        attention_dropout=0.0,
+        qkv_format="thd",
+        attn_mask_type="padding_causal",
+        window_size=(-1, 0),
+    ).cuda()
+    module.train()
+
+    header = {
+        "backend": backend,
+        "env": {key: os.environ[key] for key in BACKEND_SELECTION_ENV_KEYS if key in os.environ},
+        "device": torch.cuda.get_device_name(),
+        "shape": asdict(shape),
+        "segment_len": args.segment_len,
+        "segments": len(lengths),
+        "max_seqlen": max(lengths),
+    }
+    print(json.dumps(header))
+
+    for mode in ("forward", "forward_backward"):
+        result = _benchmark_mode(
+            torch,
+            module,
+            backend=backend,
+            mode=mode,
+            shape=shape,
+            dtype=dtype,
+            dtype_name=args.dtype,
+            lengths=lengths,
+            cu_seqlens=cu,
+            steps=args.steps,
+            warmup=args.warmup,
+            check_reference=args.check_reference,
+        )
+        print(json.dumps(asdict(result)))
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -396,6 +396,7 @@ class PackedTokenDataset(MappedAsyncDataset[tuple[dict, dict], GrugLmExample]):
                     loss_weight=loss_weight,
                     segment_ids=seg_ids_raw,
                     block_cross_document_attention=block_cross_document_attention,
+                    max_segments_per_seq=max_segments_per_example,
                 )
                 out = jax.lax.with_sharding_constraint(out, sharding)
                 return out
@@ -413,6 +414,7 @@ class PackedTokenDataset(MappedAsyncDataset[tuple[dict, dict], GrugLmExample]):
                     loss_weight=loss_weight,
                     segment_ids=seg_ids_raw,
                     block_cross_document_attention=block_cross_document_attention,
+                    max_segments_per_seq=max_segments_per_example,
                 )
                 out = jax.lax.with_sharding_constraint(out, sharding)
                 return out
@@ -465,6 +467,7 @@ class ChatDataset(MappedAsyncDataset[tuple[ProcessedChatDict, ProcessedChatDict]
                 loss_weight=loss_weight,
                 segment_ids=seg_ids_raw,
                 block_cross_document_attention=block_cross_document_attention,
+                max_segments_per_seq=max_segments_per_example,
             )
             out = jax.lax.with_sharding_constraint(out, sharding)
             return out

--- a/lib/levanter/src/levanter/data/text/examples.py
+++ b/lib/levanter/src/levanter/data/text/examples.py
@@ -75,6 +75,7 @@ class GrugLmExample:
         segment_ids: jax.Array | None = None,
         sliding_window: int | None = None,
         block_cross_document_attention: bool = True,
+        max_segments_per_seq: int | None = None,
     ) -> "GrugLmExample":
         if tokens.ndim != 1:
             raise ValueError("tokens must be a 1D array")
@@ -99,7 +100,10 @@ class GrugLmExample:
 
         loss_weight = loss_weight.astype(dtype)
 
-        attn_mask = GrugAttentionMask.causal(sliding_window=sliding_window)
+        attn_mask = GrugAttentionMask.causal(
+            sliding_window=sliding_window,
+            max_segments_per_seq=max_segments_per_seq,
+        )
         if block_cross_document_attention:
             if eos_id is not None and segment_ids is None:
                 eos_mask = jnp.roll(tokens, 1) == eos_id

--- a/lib/levanter/src/levanter/grug/attention.py
+++ b/lib/levanter/src/levanter/grug/attention.py
@@ -15,6 +15,7 @@ from jaxtyping import Array, Bool, Float, Int
 
 from haliax.jax_utils import named_call
 from haliax.partitioning import _get_mesh
+from levanter.grug.fa4_cute_backend import fa4_cute_attention_forward
 
 _SHARD_MAP_CHECK_KWARG = "check_vma" if "check_vma" in inspect.signature(shard_map).parameters else "check_rep"
 _SHARD_MAP_CHECK_KWARGS = {_SHARD_MAP_CHECK_KWARG: False}
@@ -24,8 +25,24 @@ GrugAttentionImplementation = Literal[
     "gpu_xla",
     "gpu_cudnn",
     "gpu_te",
+    "gpu_fa4_cute",
 ]
 DEFAULT_MAX_PACKED_SEGMENTS = 64
+
+
+@dataclass(frozen=True)
+class _Flash4CuteKernelConfig:
+    forward_tile: tuple[int, int]
+    backward_tile: tuple[int, int]
+    num_threads: int
+    forward_num_stages: int
+    backward_num_stages_q: int
+    backward_num_stages_do: int
+    use_sm80_mma: bool
+    allow_split_kv: bool
+    allow_paged_kv: bool
+    allow_block_sparse: bool
+    allow_mask_mod_backward: bool
 
 
 @dataclass(frozen=True)
@@ -453,10 +470,186 @@ def _packed_segment_ids_positions(
     local_segment_ids = jnp.where(valid, jnp.cumsum(starts.astype(jnp.int32), axis=1), 0)
 
     positions = jnp.arange(seq_len, dtype=jnp.int32)[None, :]
-    start_positions = jnp.where(starts, positions, 0)
-    current_start = jax.lax.associative_scan(jnp.maximum, start_positions, axis=1)
+    current_start = _packed_segment_start_positions(
+        segment_ids,
+        batch_size=batch_size,
+        seq_len=seq_len,
+    )
     segment_positions = jnp.where(valid, positions - current_start, 0)
     return local_segment_ids, segment_positions
+
+
+def _packed_segment_start_positions(
+    segment_ids: jax.Array,
+    *,
+    batch_size: int,
+    seq_len: int,
+) -> Int[Array, "B S"]:
+    segment_ids = _batched_segment_ids(segment_ids, batch_size=batch_size, seq_len=seq_len)
+    valid = segment_ids >= 0
+    starts = _segment_starts(segment_ids)
+    positions = jnp.arange(seq_len, dtype=jnp.int32)[None, :]
+    start_positions = jnp.where(starts, positions, 0)
+    current_start = jax.lax.associative_scan(jnp.maximum, start_positions, axis=1)
+    return jnp.where(valid, current_start, seq_len)
+
+
+def _packed_segment_causal_lower_bounds(
+    segment_ids: jax.Array,
+    *,
+    batch_size: int,
+    seq_len: int,
+    sliding_window: int | None,
+) -> tuple[Int[Array, "B S"], Bool[Array, "B S"]]:
+    """Return per-token inclusive key lower bounds for dynamic packed causal attention."""
+    if sliding_window is not None and sliding_window <= 0:
+        raise ValueError(f"sliding_window must be positive, got {sliding_window}")
+
+    segment_ids = _batched_segment_ids(segment_ids, batch_size=batch_size, seq_len=seq_len)
+    valid = segment_ids >= 0
+    lower_bounds = _packed_segment_start_positions(
+        segment_ids,
+        batch_size=batch_size,
+        seq_len=seq_len,
+    )
+    if sliding_window is not None:
+        positions = jnp.arange(seq_len, dtype=jnp.int32)[None, :]
+        window_lower_bounds = positions - (sliding_window - 1)
+        lower_bounds = jnp.maximum(lower_bounds, window_lower_bounds)
+    return jnp.where(valid, lower_bounds, seq_len), valid
+
+
+def _packed_self_attention_segment_ids(
+    q: jax.Array,
+    k: jax.Array,
+    mask: AttentionMask | Bool[Array, "B Q K"] | Float[Array, "B Q K"] | None,
+    *,
+    backend_name: str,
+) -> tuple[Int[Array, "B S"], int]:
+    if isinstance(mask, jax.Array):
+        raise NotImplementedError(f"{backend_name} does not support dense masks.")
+    if not isinstance(mask, AttentionMask) or mask.segment_ids is None:
+        raise NotImplementedError(f"{backend_name} currently requires packed segment_ids.")
+    if not mask.is_causal:
+        raise NotImplementedError(f"{backend_name} currently supports only causal packed self-attention.")
+    if q.shape[0] != k.shape[0]:
+        raise NotImplementedError(f"{backend_name} requires matching q/kv batch sizes.")
+    if q.shape[1] != k.shape[1]:
+        raise NotImplementedError(f"{backend_name} requires self-attention q_len == k_len.")
+    if mask.sliding_window is not None and mask.sliding_window <= 0:
+        raise ValueError(f"sliding_window must be positive, got {mask.sliding_window}")
+
+    q_segment_ids, kv_segment_ids = mask.segment_ids
+    max_segments_per_seq = q.shape[1] if mask.max_segments_per_seq is None else mask.max_segments_per_seq
+    if max_segments_per_seq <= 0:
+        raise ValueError(f"max_segments_per_seq must be positive, got {max_segments_per_seq}")
+    same_segment_ids = q_segment_ids is kv_segment_ids
+    q_segment_ids = _batched_segment_ids(q_segment_ids, batch_size=q.shape[0], seq_len=q.shape[1])
+    if not same_segment_ids:
+        kv_segment_ids = _batched_segment_ids(kv_segment_ids, batch_size=k.shape[0], seq_len=k.shape[1])
+        q_segment_ids = eqx.error_if(
+            q_segment_ids,
+            jnp.any(q_segment_ids != kv_segment_ids),
+            f"{backend_name} requires matching q/kv segment_ids for packed self-attention.",
+        )
+    return q_segment_ids, max_segments_per_seq
+
+
+def _flash4_cute_kernel_config(
+    head_dim: int,
+    head_dim_v: int,
+    *,
+    arch: int,
+) -> _Flash4CuteKernelConfig:
+    arch_family = arch // 10
+    if arch_family == 12:
+        return _Flash4CuteKernelConfig(
+            forward_tile=(128, 128 if head_dim <= 64 else 64),
+            backward_tile=(64, 64),
+            num_threads=128,
+            forward_num_stages=1,
+            backward_num_stages_q=2 if head_dim <= 64 else 1,
+            backward_num_stages_do=2 if head_dim <= 64 else 1,
+            use_sm80_mma=True,
+            allow_split_kv=False,
+            allow_paged_kv=False,
+            allow_block_sparse=False,
+            allow_mask_mod_backward=False,
+        )
+    if arch_family == 8:
+        return _Flash4CuteKernelConfig(
+            forward_tile=(128, 64),
+            backward_tile=(128, 64),
+            num_threads=128,
+            forward_num_stages=1,
+            backward_num_stages_q=1,
+            backward_num_stages_do=1,
+            use_sm80_mma=True,
+            allow_split_kv=True,
+            allow_paged_kv=True,
+            allow_block_sparse=False,
+            allow_mask_mod_backward=True,
+        )
+    if arch_family == 9:
+        return _Flash4CuteKernelConfig(
+            forward_tile=(128, 128 if head_dim <= 64 else 64),
+            backward_tile=(128, 64),
+            num_threads=128,
+            forward_num_stages=1,
+            backward_num_stages_q=1,
+            backward_num_stages_do=1,
+            use_sm80_mma=True,
+            allow_split_kv=True,
+            allow_paged_kv=True,
+            allow_block_sparse=False,
+            allow_mask_mod_backward=False,
+        )
+    raise NotImplementedError(f"FA4/CuTe attention does not support SM{arch}.")
+
+
+def _gpu_compute_arch() -> int:
+    for device in jax.local_devices(backend="gpu"):
+        compute_capability = getattr(device, "compute_capability", None)
+        if callable(compute_capability):
+            compute_capability = compute_capability()
+        if isinstance(compute_capability, tuple) and len(compute_capability) >= 2:
+            return int(compute_capability[0]) * 10 + int(compute_capability[1])
+        if isinstance(compute_capability, str):
+            major, _, minor = compute_capability.partition(".")
+            if major.isdigit() and minor.isdigit():
+                return int(major) * 10 + int(minor)
+    raise RuntimeError("Could not determine CUDA compute capability for FA4/CuTe attention.")
+
+
+def gpu_fa4_cute_attention(
+    q: Float[Array, "B Q Hq D"],
+    k: Float[Array, "B K Hkv D"],
+    v: Float[Array, "B K Hkv D"],
+    mask: AttentionMask | Bool[Array, "B Q K"] | Float[Array, "B Q K"] | None,
+) -> Float[Array, "B Q Hq D"]:
+    """Run dynamic packed segment attention through a FlashAttention-4/CuTe JAX FFI backend."""
+    if jax.default_backend() != "gpu":
+        raise RuntimeError("gpu_fa4_cute_attention requires the JAX GPU backend.")
+
+    q_segment_ids, _ = _packed_self_attention_segment_ids(q, k, mask, backend_name="gpu_fa4_cute_attention")
+    assert isinstance(mask, AttentionMask)
+    lower_bounds, valid = _packed_segment_causal_lower_bounds(
+        q_segment_ids,
+        batch_size=q.shape[0],
+        seq_len=q.shape[1],
+        sliding_window=mask.sliding_window,
+    )
+    kernel_config = _flash4_cute_kernel_config(q.shape[-1], v.shape[-1], arch=_gpu_compute_arch())
+
+    return fa4_cute_attention_forward(
+        q,
+        k,
+        v,
+        lower_bounds,
+        valid,
+        sm_scale=1.0 / math.sqrt(q.shape[-1]),
+        kernel_config=kernel_config,
+    )
 
 
 def gpu_te_attention(
@@ -468,32 +661,13 @@ def gpu_te_attention(
     """Run dynamic packed segment attention through Transformer Engine/cudnn THD attention."""
     if jax.default_backend() != "gpu":
         raise RuntimeError("gpu_te_attention requires the JAX GPU backend.")
-    if isinstance(mask, jax.Array):
-        raise NotImplementedError("gpu_te_attention does not support dense masks.")
-    if not isinstance(mask, AttentionMask) or mask.segment_ids is None:
-        raise NotImplementedError("gpu_te_attention currently requires packed segment_ids.")
-    if not mask.is_causal:
-        raise NotImplementedError("gpu_te_attention currently supports only causal packed self-attention.")
-    if q.shape[0] != k.shape[0]:
-        raise NotImplementedError("gpu_te_attention requires matching q/kv batch sizes.")
-    if q.shape[1] != k.shape[1]:
-        raise NotImplementedError("gpu_te_attention requires self-attention q_len == k_len.")
-    if mask.sliding_window is not None and mask.sliding_window <= 0:
-        raise ValueError(f"sliding_window must be positive, got {mask.sliding_window}")
-
-    q_segment_ids, kv_segment_ids = mask.segment_ids
-    max_segments_per_seq = q.shape[1] if mask.max_segments_per_seq is None else mask.max_segments_per_seq
-    same_segment_ids = q_segment_ids is kv_segment_ids
-    q_segment_ids = _batched_segment_ids(q_segment_ids, batch_size=q.shape[0], seq_len=q.shape[1])
-    if same_segment_ids:
-        kv_segment_ids = q_segment_ids
-    else:
-        kv_segment_ids = _batched_segment_ids(kv_segment_ids, batch_size=k.shape[0], seq_len=k.shape[1])
-        q_segment_ids = eqx.error_if(
-            q_segment_ids,
-            jnp.any(q_segment_ids != kv_segment_ids),
-            "gpu_te_attention requires matching q/kv segment_ids for packed self-attention.",
-        )
+    q_segment_ids, max_segments_per_seq = _packed_self_attention_segment_ids(
+        q,
+        k,
+        mask,
+        backend_name="gpu_te_attention",
+    )
+    assert isinstance(mask, AttentionMask)
     from transformer_engine.jax.attention import (  # type: ignore[import]
         AttnBiasType,
         AttnMaskType,
@@ -767,6 +941,8 @@ def attention(
         return gpu_cudnn_attention(q, k, v, mask)
     if implementation == "gpu_te":
         return gpu_te_attention(q, k, v, mask)
+    if implementation == "gpu_fa4_cute":
+        return gpu_fa4_cute_attention(q, k, v, mask)
     if implementation == "tpu_splash":
         if isinstance(mask, jax.Array):
             raise NotImplementedError("Dense masks are not supported for splash attention.")
@@ -791,6 +967,7 @@ __all__ = [
     "apply_rotary_embedding",
     "attention",
     "gpu_cudnn_attention",
+    "gpu_fa4_cute_attention",
     "gpu_te_attention",
     "gpu_xla_attention",
     "reference_attention",

--- a/lib/levanter/src/levanter/grug/attention.py
+++ b/lib/levanter/src/levanter/grug/attention.py
@@ -4,6 +4,7 @@ import functools
 import inspect
 import math
 from dataclasses import dataclass
+from typing import Literal
 
 import equinox as eqx
 import jax
@@ -15,9 +16,16 @@ from jaxtyping import Array, Bool, Float, Int
 from haliax.jax_utils import named_call
 from haliax.partitioning import _get_mesh
 
-
 _SHARD_MAP_CHECK_KWARG = "check_vma" if "check_vma" in inspect.signature(shard_map).parameters else "check_rep"
 _SHARD_MAP_CHECK_KWARGS = {_SHARD_MAP_CHECK_KWARG: False}
+GrugAttentionImplementation = Literal[
+    "reference",
+    "tpu_splash",
+    "gpu_xla",
+    "gpu_cudnn",
+    "gpu_te",
+]
+DEFAULT_MAX_PACKED_SEGMENTS = 64
 
 
 @dataclass(frozen=True)
@@ -39,19 +47,34 @@ class AttentionMask(eqx.Module):
     is_causal: bool = eqx.field(default=False, static=True)
     segment_ids: tuple[jax.Array, jax.Array] | None = None
     sliding_window: int | None = eqx.field(default=None, static=True)
+    max_segments_per_seq: int | None = eqx.field(default=None, static=True)
 
     @classmethod
-    def causal(cls, *, sliding_window: int | None = None) -> "AttentionMask":
-        return cls(is_causal=True, sliding_window=sliding_window)
+    def causal(
+        cls,
+        *,
+        sliding_window: int | None = None,
+        max_segments_per_seq: int | None = None,
+    ) -> "AttentionMask":
+        return cls(
+            is_causal=True,
+            sliding_window=sliding_window,
+            max_segments_per_seq=max_segments_per_seq,
+        )
 
     def with_segment_ids(
-        self, q_segment_ids: Int[Array, "..."], kv_segment_ids: Int[Array, "..."] | None = None
+        self,
+        q_segment_ids: Int[Array, "..."],
+        kv_segment_ids: Int[Array, "..."] | None = None,
+        *,
+        max_segments_per_seq: int | None = None,
     ) -> "AttentionMask":
         kv_ids = q_segment_ids if kv_segment_ids is None else kv_segment_ids
         return AttentionMask(
             is_causal=self.is_causal,
             segment_ids=(q_segment_ids, kv_ids),
             sliding_window=self.sliding_window,
+            max_segments_per_seq=self.max_segments_per_seq if max_segments_per_seq is None else max_segments_per_seq,
         )
 
     def with_sliding_window(self, sliding_window: int | None) -> "AttentionMask":
@@ -59,6 +82,7 @@ class AttentionMask(eqx.Module):
             is_causal=self.is_causal,
             segment_ids=self.segment_ids,
             sliding_window=sliding_window,
+            max_segments_per_seq=self.max_segments_per_seq,
         )
 
     def materialize_mask(self, q_len: int, k_len: int) -> Bool[Array, "..."] | None:
@@ -196,6 +220,349 @@ def reference_attention(
     weights = jax.nn.softmax(scores, axis=-1).astype(v.dtype)
     ctx = jnp.einsum("bhqk,bkhd->bqhd", weights, v)
     return ctx.astype(v.dtype)
+
+
+def _dense_attention_mask_to_bnts(
+    mask: Bool[Array, "B Q K"] | Float[Array, "B Q K"],
+    *,
+    batch_size: int,
+    q_len: int,
+    k_len: int,
+) -> jax.Array:
+    if mask.ndim == 2:
+        mask = mask[None, :, :]
+    if mask.ndim != 3:
+        raise ValueError(f"explicit mask must have shape [batch, q, k], got shape={mask.shape}")
+    if mask.shape[0] not in (1, batch_size):
+        raise ValueError(f"explicit mask batch dim must be 1 or {batch_size}, got {mask.shape[0]}")
+    if mask.shape[1] != q_len or mask.shape[2] != k_len:
+        raise ValueError(
+            f"explicit mask must match attention shapes: got mask={mask.shape}, expected [batch,{q_len},{k_len}]"
+        )
+    return mask[:, None, :, :]
+
+
+def _mask_to_jax_dot_product_attention_args(
+    mask: AttentionMask | Bool[Array, "B Q K"] | Float[Array, "B Q K"] | None,
+    *,
+    batch_size: int,
+    q_len: int,
+    k_len: int,
+) -> tuple[jax.Array | None, bool, tuple[int, int] | None]:
+    """Map Grug/Splash mask semantics onto `jax.nn.dot_product_attention` args."""
+    if mask is None:
+        return None, False, None
+
+    if isinstance(mask, AttentionMask):
+        if mask.sliding_window is not None and mask.sliding_window <= 0:
+            raise ValueError(f"sliding_window must be positive, got {mask.sliding_window}")
+
+        if mask.segment_ids is not None:
+            raise NotImplementedError("JAX SDPA backends would require a dense segment_ids mask; use gpu_te instead.")
+
+        dense_mask = None
+        is_causal = mask.is_causal
+        local_window_size = None
+
+        if mask.sliding_window is not None:
+            if mask.is_causal:
+                local_window_size = (mask.sliding_window - 1, 0)
+            else:
+                q_idx = jnp.arange(q_len)[:, None]
+                k_idx = jnp.arange(k_len)[None, :]
+                sliding_mask = k_idx >= q_idx - (mask.sliding_window - 1)
+                sliding_mask = sliding_mask[None, None, :, :]
+                dense_mask = sliding_mask if dense_mask is None else jnp.logical_and(dense_mask, sliding_mask)
+
+        return dense_mask, is_causal, local_window_size
+
+    dense_mask = _dense_attention_mask_to_bnts(mask, batch_size=batch_size, q_len=q_len, k_len=k_len)
+    if dense_mask.dtype != jnp.bool_:
+        raise NotImplementedError("Additive dense masks are not supported by the native GPU attention prototype.")
+    return dense_mask, False, None
+
+
+def _jax_dot_product_attention(
+    q: Float[Array, "B Q Hq D"],
+    k: Float[Array, "B K Hkv D"],
+    v: Float[Array, "B K Hkv D"],
+    mask: AttentionMask | Bool[Array, "B Q K"] | Float[Array, "B Q K"] | None,
+    *,
+    implementation: Literal["xla", "cudnn"],
+) -> Float[Array, "B Q Hq D"]:
+    if isinstance(mask, AttentionMask) and mask.segment_ids is not None:
+        raise NotImplementedError(
+            "JAX SDPA backends do not support segment_ids without a dense mask; use gpu_te instead."
+        )
+
+    jax_mask, is_causal, local_window_size = _mask_to_jax_dot_product_attention_args(
+        mask,
+        batch_size=q.shape[0],
+        q_len=q.shape[1],
+        k_len=k.shape[1],
+    )
+    return jax.nn.dot_product_attention(
+        q,
+        k,
+        v,
+        mask=jax_mask,
+        is_causal=is_causal,
+        local_window_size=local_window_size,
+        implementation=implementation,
+    ).astype(v.dtype)
+
+
+def gpu_cudnn_attention(
+    q: Float[Array, "B Q Hq D"],
+    k: Float[Array, "B K Hkv D"],
+    v: Float[Array, "B K Hkv D"],
+    mask: AttentionMask | Bool[Array, "B Q K"] | Float[Array, "B Q K"] | None,
+) -> Float[Array, "B Q Hq D"]:
+    """Run Grug attention through JAX's native cuDNN SDPA path."""
+    if jax.default_backend() != "gpu":
+        raise RuntimeError("gpu_cudnn_attention requires the JAX GPU backend.")
+    return _jax_dot_product_attention(q, k, v, mask, implementation="cudnn")
+
+
+def gpu_xla_attention(
+    q: Float[Array, "B Q Hq D"],
+    k: Float[Array, "B K Hkv D"],
+    v: Float[Array, "B K Hkv D"],
+    mask: AttentionMask | Bool[Array, "B Q K"] | Float[Array, "B Q K"] | None,
+) -> Float[Array, "B Q Hq D"]:
+    """Run Grug attention through JAX's GPU SDPA lowering for JAX-supported masks."""
+    if jax.default_backend() != "gpu":
+        raise RuntimeError("gpu_xla_attention requires the JAX GPU backend.")
+    return _jax_dot_product_attention(q, k, v, mask, implementation="xla")
+
+
+def _packed_segment_seqlens_offsets(
+    segment_ids: jax.Array,
+    *,
+    batch_size: int,
+    seq_len: int,
+    max_segments_per_seq: int,
+) -> tuple[Int[Array, "B M"], Int[Array, "B Mp1"]]:
+    """Convert dynamic loader-style packed segment IDs to TE THD sequence lengths and offsets."""
+    segment_ids = _batched_segment_ids(segment_ids, batch_size=batch_size, seq_len=seq_len)
+
+    if max_segments_per_seq <= 0:
+        raise ValueError(f"max_segments_per_seq must be positive, got {max_segments_per_seq}")
+
+    return _seqlens_offsets_from_starts(
+        _segment_starts(segment_ids),
+        segment_ids >= 0,
+        max_segments=max_segments_per_seq,
+    )
+
+
+def _batched_segment_ids(segment_ids: jax.Array, *, batch_size: int, seq_len: int) -> jax.Array:
+    if segment_ids.ndim == 1:
+        if segment_ids.shape[0] != seq_len:
+            raise ValueError(f"1D segment_ids must match sequence length {seq_len}, got {segment_ids.shape}")
+        segment_ids = jnp.broadcast_to(segment_ids[None, :], (batch_size, seq_len))
+    elif segment_ids.ndim == 2:
+        if segment_ids.shape[0] not in (1, batch_size) or segment_ids.shape[1] != seq_len:
+            raise ValueError(f"2D segment_ids must have shape [1|{batch_size}, {seq_len}], got {segment_ids.shape}")
+        if segment_ids.shape[0] == 1 and batch_size != 1:
+            segment_ids = jnp.broadcast_to(segment_ids, (batch_size, seq_len))
+    else:
+        raise ValueError(f"segment_ids must be 1D or 2D, got ndim={segment_ids.ndim}")
+    return segment_ids
+
+
+def _segment_starts(segment_ids: jax.Array) -> jax.Array:
+    valid = segment_ids >= 0
+    previous = jnp.concatenate([segment_ids[:, :1], segment_ids[:, :-1]], axis=1)
+    first = jnp.zeros_like(valid).at[:, 0].set(True)
+    return valid & (first | (segment_ids != previous))
+
+
+def _seqlens_offsets_from_starts(
+    starts: jax.Array,
+    valid: jax.Array,
+    *,
+    max_segments: int,
+    include_terminal_offset: bool = False,
+    cumulative_offsets: bool = False,
+) -> tuple[Int[Array, "B M"], Int[Array, "B Mp1"]]:
+    batch_size = starts.shape[0]
+    num_segments = jnp.sum(starts.astype(jnp.int32), axis=1)
+    starts = eqx.error_if(
+        starts,
+        jnp.any(num_segments > max_segments),
+        "packed segment count exceeds max_segments_per_seq.",
+    )
+    ordinals = jnp.cumsum(starts.astype(jnp.int32), axis=1) - 1
+    clipped_ordinals = jnp.clip(ordinals, 0, max_segments - 1)
+    batch_idx = jnp.arange(batch_size, dtype=jnp.int32)[:, None]
+    lengths = jnp.zeros((batch_size, max_segments), dtype=jnp.int32)
+    lengths = lengths.at[batch_idx, clipped_ordinals].add(valid.astype(jnp.int32))
+
+    segment_idx = jnp.arange(max_segments, dtype=jnp.int32)[None, :]
+    seqlens = jnp.where(segment_idx < num_segments[:, None], lengths, -1)
+
+    if cumulative_offsets:
+        offsets = jnp.concatenate([jnp.zeros((batch_size, 1), dtype=jnp.int32), jnp.cumsum(lengths, axis=1)], axis=1)
+        offset_idx = jnp.arange(max_segments + 1, dtype=jnp.int32)[None, :]
+        offsets = jnp.where(offset_idx <= num_segments[:, None], offsets, -1)
+        return seqlens, offsets
+
+    offsets = jax.vmap(functools.partial(jnp.argwhere, size=max_segments + 1, fill_value=-1))(starts)
+    offsets = offsets.squeeze(axis=-1).astype(jnp.int32)
+    if include_terminal_offset:
+        positions = jnp.arange(starts.shape[1], dtype=jnp.int32)[None, :]
+        terminal_offsets = jnp.max(jnp.where(valid, positions + 1, 0), axis=1)
+        terminal_slots = jnp.clip(num_segments, 0, max_segments)
+        offsets = offsets.at[jnp.arange(batch_size, dtype=jnp.int32), terminal_slots].set(terminal_offsets)
+    return seqlens, offsets
+
+
+def _flattened_packed_segment_seqlens_offsets(
+    segment_ids: jax.Array,
+    *,
+    batch_size: int,
+    seq_len: int,
+    max_segments_per_seq: int,
+) -> tuple[Int[Array, "B M"], Int[Array, "B Mp1"]]:
+    segment_ids = _batched_segment_ids(segment_ids, batch_size=batch_size, seq_len=seq_len)
+    max_segments = batch_size * max_segments_per_seq
+    if max_segments <= 0:
+        raise ValueError(f"max_segments must be positive, got {max_segments}")
+
+    starts = _segment_starts(segment_ids).reshape(1, batch_size * seq_len)
+    valid = (segment_ids >= 0).reshape(1, batch_size * seq_len)
+    return _seqlens_offsets_from_starts(
+        starts,
+        valid,
+        max_segments=max_segments,
+        include_terminal_offset=True,
+        cumulative_offsets=batch_size == 1,
+    )
+
+
+def _packed_segment_ids_positions(
+    segment_ids: jax.Array,
+    *,
+    batch_size: int,
+    seq_len: int,
+) -> tuple[Int[Array, "B S"], Int[Array, "B S"]]:
+    segment_ids = _batched_segment_ids(segment_ids, batch_size=batch_size, seq_len=seq_len)
+    valid = segment_ids >= 0
+    starts = _segment_starts(segment_ids)
+    local_segment_ids = jnp.where(valid, jnp.cumsum(starts.astype(jnp.int32), axis=1), 0)
+
+    positions = jnp.arange(seq_len, dtype=jnp.int32)[None, :]
+    start_positions = jnp.where(starts, positions, 0)
+    current_start = jax.lax.associative_scan(jnp.maximum, start_positions, axis=1)
+    segment_positions = jnp.where(valid, positions - current_start, 0)
+    return local_segment_ids, segment_positions
+
+
+def gpu_te_attention(
+    q: Float[Array, "B Q Hq D"],
+    k: Float[Array, "B K Hkv D"],
+    v: Float[Array, "B K Hkv D"],
+    mask: AttentionMask | Bool[Array, "B Q K"] | Float[Array, "B Q K"] | None,
+) -> Float[Array, "B Q Hq D"]:
+    """Run dynamic packed segment attention through Transformer Engine/cudnn THD attention."""
+    if jax.default_backend() != "gpu":
+        raise RuntimeError("gpu_te_attention requires the JAX GPU backend.")
+    if isinstance(mask, jax.Array):
+        raise NotImplementedError("gpu_te_attention does not support dense masks.")
+    if not isinstance(mask, AttentionMask) or mask.segment_ids is None:
+        raise NotImplementedError("gpu_te_attention currently requires packed segment_ids.")
+    if not mask.is_causal:
+        raise NotImplementedError("gpu_te_attention currently supports only causal packed self-attention.")
+    if q.shape[0] != k.shape[0]:
+        raise NotImplementedError("gpu_te_attention requires matching q/kv batch sizes.")
+    if q.shape[1] != k.shape[1]:
+        raise NotImplementedError("gpu_te_attention requires self-attention q_len == k_len.")
+    if mask.sliding_window is not None and mask.sliding_window <= 0:
+        raise ValueError(f"sliding_window must be positive, got {mask.sliding_window}")
+
+    q_segment_ids, kv_segment_ids = mask.segment_ids
+    max_segments_per_seq = q.shape[1] if mask.max_segments_per_seq is None else mask.max_segments_per_seq
+    same_segment_ids = q_segment_ids is kv_segment_ids
+    q_segment_ids = _batched_segment_ids(q_segment_ids, batch_size=q.shape[0], seq_len=q.shape[1])
+    if same_segment_ids:
+        kv_segment_ids = q_segment_ids
+    else:
+        kv_segment_ids = _batched_segment_ids(kv_segment_ids, batch_size=k.shape[0], seq_len=k.shape[1])
+        q_segment_ids = eqx.error_if(
+            q_segment_ids,
+            jnp.any(q_segment_ids != kv_segment_ids),
+            "gpu_te_attention requires matching q/kv segment_ids for packed self-attention.",
+        )
+    from transformer_engine.jax.attention import (  # type: ignore[import]
+        AttnBiasType,
+        AttnMaskType,
+        AttnSoftmaxType,
+        QKVLayout,
+        SequenceDescriptor,
+        fused_attn,
+    )
+
+    te_max_segments = q.shape[0] * max_segments_per_seq
+    seqlens, offsets = _flattened_packed_segment_seqlens_offsets(
+        q_segment_ids,
+        batch_size=q.shape[0],
+        seq_len=q.shape[1],
+        max_segments_per_seq=max_segments_per_seq,
+    )
+    sequence_descriptor = SequenceDescriptor.from_seqlens_and_offsets(
+        (seqlens, seqlens),
+        (offsets, offsets),
+    )
+    window_size = None
+    if mask.sliding_window is not None and mask.sliding_window < q.shape[1]:
+        window_size = (mask.sliding_window - 1, 0)
+    if window_size is None:
+        te_segment_ids, te_segment_positions = _packed_segment_ids_positions(
+            q_segment_ids,
+            batch_size=q.shape[0],
+            seq_len=q.shape[1],
+        )
+        sequence_descriptor = SequenceDescriptor.from_segment_ids_and_pos(
+            (te_segment_ids, te_segment_ids),
+            (te_segment_positions, te_segment_positions),
+        )
+        out = fused_attn(
+            (q, k, v),
+            None,
+            sequence_descriptor,
+            None,
+            AttnBiasType.NO_BIAS,
+            AttnMaskType.PADDING_CAUSAL_MASK,
+            QKVLayout.THD_THD_THD,
+            AttnSoftmaxType.VANILLA_SOFTMAX,
+            1.0 / math.sqrt(q.shape[-1]),
+            0.0,
+            True,
+            max_segments_per_seq=max_segments_per_seq,
+            window_size=None,
+        )
+        return out.astype(v.dtype)
+
+    q_flat = q.reshape(1, q.shape[0] * q.shape[1], q.shape[2], q.shape[3])
+    k_flat = k.reshape(1, k.shape[0] * k.shape[1], k.shape[2], k.shape[3])
+    v_flat = v.reshape(1, v.shape[0] * v.shape[1], v.shape[2], v.shape[3])
+    out = fused_attn(
+        (q_flat, k_flat, v_flat),
+        None,
+        sequence_descriptor,
+        None,
+        AttnBiasType.NO_BIAS,
+        AttnMaskType.PADDING_CAUSAL_MASK,
+        QKVLayout.THD_THD_THD,
+        AttnSoftmaxType.VANILLA_SOFTMAX,
+        1.0 / math.sqrt(q.shape[-1]),
+        0.0,
+        True,
+        max_segments_per_seq=te_max_segments,
+        window_size=window_size,
+    )
+    return out.reshape(q.shape[0], q.shape[1], q.shape[2], v.shape[3]).astype(v.dtype)
 
 
 def _spec_shard_factor(entry: str | tuple[str, ...] | None, mesh) -> int:
@@ -389,7 +756,25 @@ def attention(
     k: Float[Array, "B K Hkv D"],
     v: Float[Array, "B K Hkv D"],
     mask: AttentionMask | Bool[Array, "B Q K"] | Float[Array, "B Q K"] | None,
+    *,
+    implementation: GrugAttentionImplementation | None = None,
 ) -> Float[Array, "B Q Hq D"]:
+    if implementation == "reference":
+        return reference_attention(q, k, v, mask, logits_dtype=jnp.float32)
+    if implementation == "gpu_xla":
+        return gpu_xla_attention(q, k, v, mask)
+    if implementation == "gpu_cudnn":
+        return gpu_cudnn_attention(q, k, v, mask)
+    if implementation == "gpu_te":
+        return gpu_te_attention(q, k, v, mask)
+    if implementation == "tpu_splash":
+        if isinstance(mask, jax.Array):
+            raise NotImplementedError("Dense masks are not supported for splash attention.")
+        return _tpu_splash_attention(q, k, v, mask)
+
+    if jax.default_backend() == "gpu" and isinstance(mask, AttentionMask) and mask.segment_ids is not None:
+        return gpu_te_attention(q, k, v, mask)
+
     if jax.default_backend() == "tpu":
         if isinstance(mask, jax.Array):
             return reference_attention(q, k, v, mask, logits_dtype=jnp.float32)
@@ -399,9 +784,14 @@ def attention(
 
 __all__ = [
     "AttentionMask",
+    "DEFAULT_MAX_PACKED_SEGMENTS",
+    "GrugAttentionImplementation",
     "RotaryConfig",
     "align_kv_heads",
     "apply_rotary_embedding",
     "attention",
+    "gpu_cudnn_attention",
+    "gpu_te_attention",
+    "gpu_xla_attention",
     "reference_attention",
 ]

--- a/lib/levanter/src/levanter/grug/fa4_cute_backend.py
+++ b/lib/levanter/src/levanter/grug/fa4_cute_backend.py
@@ -1,0 +1,474 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""JAX/CuTe backend boundary for Grug packed-segment attention.
+
+The production attention kernel is intentionally isolated here so the high-level Grug
+attention code stays independent of optional CUDA-only dependencies. The first kernel
+target is BF16/FP16 BSHD causal self-attention with dynamic per-token lower bounds:
+
+    valid[b, q] and lower_bounds[b, q] <= k <= q
+
+This avoids both THD compaction and materialized [B, S, S] masks.
+"""
+
+import importlib
+from dataclasses import dataclass
+from functools import partial
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+
+from levanter.grug.fa4_cute_kernels import (
+    segmented_flash_attention_backward_launcher,
+    segmented_flash_attention_forward_launcher,
+)
+
+
+@dataclass(frozen=True)
+class _CutlassCuteModules:
+    cute: Any
+    cjax: Any
+    cuda: Any
+
+
+def _import_cutlass_cute() -> _CutlassCuteModules:
+    cute = importlib.import_module("cutlass.cute")
+    cjax = importlib.import_module("cutlass.jax")
+    cuda = importlib.import_module("cuda.bindings.driver")
+    return _CutlassCuteModules(cute=cute, cjax=cjax, cuda=cuda)
+
+
+def _optional_dependency_error() -> RuntimeError:
+    return RuntimeError(
+        "gpu_fa4_cute_attention requires nvidia-cutlass-dsl with JAX support, and backward requires "
+        "flash-attn-4. Install the CUDA 13 CUTLASS DSL extra, for example "
+        "`nvidia-cutlass-dsl[cu13]>=4.4`, plus `flash-attn-4`."
+    )
+
+
+def cutlass_cute_available() -> bool:
+    """Return whether the optional CuTe/JAX CUTLASS modules are importable."""
+    try:
+        _import_cutlass_cute()
+    except Exception:
+        return False
+    return True
+
+
+def require_cutlass_cute() -> None:
+    """Raise a clear error if nvidia-cutlass-dsl with JAX support is unavailable."""
+    try:
+        _import_cutlass_cute()
+    except Exception as exc:
+        raise _optional_dependency_error() from exc
+
+
+def _vector_add_launcher(modules: _CutlassCuteModules) -> Any:
+    cute = modules.cute
+    cuda = modules.cuda
+
+    @cute.kernel
+    def _vector_add_kernel(a: cute.Tensor, b: cute.Tensor, out: cute.Tensor):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+
+        frag_a = cute.make_rmem_tensor(cute.size(a, mode=[0]), a.element_type)
+        frag_b = cute.make_rmem_tensor(cute.size(b, mode=[0]), b.element_type)
+        frag_out = cute.make_rmem_tensor(cute.size(out, mode=[0]), out.element_type)
+
+        cute.autovec_copy(a[None, tidx, bidx], frag_a)
+        cute.autovec_copy(b[None, tidx, bidx], frag_b)
+        frag_out.store(frag_a.load() + frag_b.load())
+        cute.autovec_copy(frag_out, out[None, tidx, bidx])
+
+    @cute.jit
+    def _launch_vector_add(stream: cuda.CUstream, a: cute.Tensor, b: cute.Tensor, out: cute.Tensor):
+        _vector_add_kernel(a, b, out).launch(
+            grid=[a.shape[-1], 1, 1],
+            block=[a.shape[-2], 1, 1],
+            stream=stream,
+        )
+
+    return _launch_vector_add
+
+
+def cute_vector_add(a: jax.Array, b: jax.Array, *, block_size: int = 256) -> jax.Array:
+    """Small CuTe/JAX launch proof used to validate the optional backend environment."""
+    if a.shape != b.shape:
+        raise ValueError(f"a and b must have matching shapes, got {a.shape} and {b.shape}")
+    if a.dtype != b.dtype:
+        raise ValueError(f"a and b must have matching dtypes, got {a.dtype} and {b.dtype}")
+    if a.ndim != 1:
+        raise ValueError(f"cute_vector_add expects 1D inputs, got shape={a.shape}")
+    if a.dtype not in (jnp.bfloat16, jnp.float16):
+        raise ValueError(f"cute_vector_add expects BF16/FP16 inputs, got {a.dtype}")
+    if block_size <= 0:
+        raise ValueError(f"block_size must be positive, got {block_size}")
+    if a.shape[0] == 0:
+        raise ValueError("cute_vector_add expects a non-empty input")
+
+    try:
+        modules = _import_cutlass_cute()
+    except Exception as exc:
+        raise _optional_dependency_error() from exc
+
+    padded = ((a.shape[0] + block_size - 1) // block_size) * block_size
+    a_padded = jnp.pad(a, (0, padded - a.shape[0])).reshape(1, block_size, padded // block_size)
+    b_padded = jnp.pad(b, (0, padded - b.shape[0])).reshape(1, block_size, padded // block_size)
+    call = modules.cjax.cutlass_call(
+        _vector_add_launcher(modules),
+        output_shape_dtype=jax.ShapeDtypeStruct(a_padded.shape, a_padded.dtype),
+        use_static_tensors=True,
+    )
+    out = call(a_padded, b_padded)
+    return out.reshape(-1)[: a.shape[0]]
+
+
+def segmented_flash_attention_forward(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    lower_bounds: jax.Array,
+    valid: jax.Array,
+    *,
+    softmax_scale: float,
+    kernel_config: Any,
+) -> tuple[jax.Array, jax.Array]:
+    """FA4/CuTe segmented attention forward entry point.
+
+    Args:
+        q: Query tensor with shape [B, S, Hq, D].
+        k: Key tensor with shape [B, S, Hkv, D].
+        v: Value tensor with shape [B, S, Hkv, Dv].
+        lower_bounds: Inclusive per-token key lower bound, shape [B, S].
+        valid: Per-token query validity mask, shape [B, S].
+        softmax_scale: QK softmax scale.
+        kernel_config: Architecture-specific tile/config object selected by attention.py.
+
+    Returns:
+        ``(out, lse)`` where ``out`` has shape [B, S, Hq, Dv] and ``lse`` has
+        shape [B, Hq, S]. The backward kernel consumes both tensors.
+    """
+    _validate_forward_inputs(q, k, v, lower_bounds, valid, softmax_scale=softmax_scale)
+    try:
+        modules = _import_cutlass_cute()
+    except Exception as exc:
+        raise _optional_dependency_error() from exc
+
+    forward_tile = getattr(kernel_config, "forward_tile", (128, 64))
+    num_threads = getattr(kernel_config, "num_threads", 128)
+    launcher = segmented_flash_attention_forward_launcher(
+        modules,
+        head_dim=q.shape[-1],
+        head_dim_v=v.shape[-1],
+        qhead_per_kvhead=q.shape[2] // k.shape[2],
+        tile_m=forward_tile[0],
+        tile_n=forward_tile[1],
+        num_threads=num_threads,
+    )
+    input_spec, output_spec = _cutlass_attention_forward_specs(modules, vector_elems=8)
+    out_shape_dtype = jax.ShapeDtypeStruct((*q.shape[:3], v.shape[-1]), q.dtype)
+    lse_shape_dtype = jax.ShapeDtypeStruct((q.shape[0], q.shape[2], q.shape[1]), jnp.float32)
+    call = modules.cjax.cutlass_call(
+        launcher,
+        output_shape_dtype=(out_shape_dtype, lse_shape_dtype),
+        input_spec=input_spec,
+        output_spec=output_spec,
+        use_static_tensors=True,
+        softmax_scale=softmax_scale,
+    )
+    return call(q, k, v, lower_bounds, valid.astype(jnp.int32))
+
+
+def segmented_flash_attention_backward(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    out: jax.Array,
+    dout: jax.Array,
+    lse: jax.Array,
+    lower_bounds: jax.Array,
+    valid: jax.Array,
+    *,
+    softmax_scale: float,
+    kernel_config: Any,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """FA4/CuTe segmented attention backward boundary.
+
+    This is intentionally a separate CUTLASS call from the forward path because
+    upstream FA4 backward is a preprocess + main-kernel + postprocess pipeline.
+    The current launcher raises until those kernels are ported, while tests can
+    fake ``cutlass_call`` to lock down the JAX custom-VJP contract.
+    """
+    _validate_forward_inputs(q, k, v, lower_bounds, valid, softmax_scale=softmax_scale)
+    _validate_backward_inputs(q, k, v, out, dout, lse)
+    try:
+        modules = _import_cutlass_cute()
+    except Exception as exc:
+        raise _optional_dependency_error() from exc
+
+    backward_tile = getattr(kernel_config, "backward_tile", (128, 64))
+    num_threads = getattr(kernel_config, "num_threads", 128)
+    launcher = segmented_flash_attention_backward_launcher(
+        modules,
+        dtype=q.dtype,
+        head_dim=q.shape[-1],
+        head_dim_v=v.shape[-1],
+        qhead_per_kvhead=q.shape[2] // k.shape[2],
+        tile_m=backward_tile[0],
+        tile_n=backward_tile[1],
+        num_threads=num_threads,
+    )
+    input_spec, output_spec = _cutlass_attention_backward_specs(modules, vector_elems=8)
+    output_shape_dtype = _cutlass_attention_backward_output_shapes(q, k, v, backward_tile)
+    call = modules.cjax.cutlass_call(
+        launcher,
+        output_shape_dtype=output_shape_dtype,
+        input_spec=input_spec,
+        output_spec=output_spec,
+        use_static_tensors=True,
+        softmax_scale=softmax_scale,
+    )
+    dq, dk, dv, *_scratch = call(q, k, v, out, dout, lse, lower_bounds, valid.astype(jnp.int32))
+    return dq, dk, dv
+
+
+def _cutlass_attention_forward_specs(
+    modules: _CutlassCuteModules, *, vector_elems: int
+) -> tuple[tuple[Any, ...], Any]:
+    tensor_spec = modules.cjax.TensorSpec
+    qkv_spec = tensor_spec(mode=(1, 3, 2, 0), divisibility=(1, 1, 1, vector_elems), static=True)
+    lse_spec = tensor_spec(divisibility=(1, 1, 1), static=True)
+    metadata_spec = tensor_spec(static=True)
+    return (qkv_spec, qkv_spec, qkv_spec, metadata_spec, metadata_spec), (qkv_spec, lse_spec)
+
+
+def _cutlass_attention_backward_specs(
+    modules: _CutlassCuteModules, *, vector_elems: int
+) -> tuple[tuple[Any, ...], Any]:
+    tensor_spec = modules.cjax.TensorSpec
+    qkv_spec = tensor_spec(mode=(0, 1, 2, 3), divisibility=(1, 1, 1, vector_elems), static=True)
+    lse_spec = tensor_spec(mode=(0, 1, 2), divisibility=(1, 1, 1), static=True)
+    metadata_spec = tensor_spec(mode=(0, 1), static=True)
+    scratch_spec = tensor_spec(mode=(0, 1, 2), static=True)
+    input_spec = (
+        qkv_spec,
+        qkv_spec,
+        qkv_spec,
+        qkv_spec,
+        qkv_spec,
+        lse_spec,
+        metadata_spec,
+        metadata_spec,
+    )
+    return input_spec, (
+        qkv_spec,
+        qkv_spec,
+        qkv_spec,
+        scratch_spec,
+        scratch_spec,
+        scratch_spec,
+        scratch_spec,
+        scratch_spec,
+    )
+
+
+def _cutlass_attention_backward_output_shapes(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    backward_tile: tuple[int, int],
+) -> tuple[jax.ShapeDtypeStruct, ...]:
+    batch, seq_len, q_heads, head_dim = q.shape
+    kv_heads = k.shape[2]
+    tile_m, tile_n = backward_tile
+    seq_q_rounded = ((seq_len + tile_m - 1) // tile_m) * tile_m
+    seq_k_rounded = ((seq_len + tile_n - 1) // tile_n) * tile_n
+    head_dim_rounded = ((head_dim + 31) // 32) * 32
+    head_dim_v_rounded = ((v.shape[-1] + 31) // 32) * 32
+    return (
+        jax.ShapeDtypeStruct(q.shape, q.dtype),
+        jax.ShapeDtypeStruct(k.shape, k.dtype),
+        jax.ShapeDtypeStruct(v.shape, v.dtype),
+        jax.ShapeDtypeStruct((batch, q_heads, seq_q_rounded), jnp.float32),
+        jax.ShapeDtypeStruct((batch, q_heads, seq_q_rounded), jnp.float32),
+        jax.ShapeDtypeStruct((batch, q_heads, seq_q_rounded * head_dim_rounded), jnp.float32),
+        jax.ShapeDtypeStruct((batch, kv_heads, seq_k_rounded * head_dim_rounded), jnp.float32),
+        jax.ShapeDtypeStruct((batch, kv_heads, seq_k_rounded * head_dim_v_rounded), jnp.float32),
+    )
+
+
+def fa4_cute_attention_forward(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    lower_bounds: jax.Array,
+    valid: jax.Array,
+    *,
+    sm_scale: float | None = None,
+    kernel_config: Any | None = None,
+) -> jax.Array:
+    """FA4/CuTe attention boundary with packed causal metadata.
+
+    Forward uses the CUTLASS/CuTe JAX FFI path. Backward is routed through a custom VJP so JAX does not
+    attempt to autodiff through ``cutlass_call``; it currently raises a targeted implementation error.
+    """
+    if sm_scale is None:
+        sm_scale = float(q.shape[-1] ** -0.5)
+    return _segmented_flash_attention_custom_vjp(
+        q,
+        k,
+        v,
+        lower_bounds,
+        valid,
+        sm_scale,
+        kernel_config,
+    )
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(5, 6))
+def _segmented_flash_attention_custom_vjp(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    lower_bounds: jax.Array,
+    valid: jax.Array,
+    softmax_scale: float,
+    kernel_config: Any,
+) -> jax.Array:
+    out, _ = segmented_flash_attention_forward(
+        q,
+        k,
+        v,
+        lower_bounds,
+        valid,
+        softmax_scale=softmax_scale,
+        kernel_config=kernel_config,
+    )
+    return out
+
+
+def _segmented_flash_attention_custom_vjp_fwd(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    lower_bounds: jax.Array,
+    valid: jax.Array,
+    softmax_scale: float,
+    kernel_config: Any,
+) -> tuple[jax.Array, tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]]:
+    out, lse = segmented_flash_attention_forward(
+        q,
+        k,
+        v,
+        lower_bounds,
+        valid,
+        softmax_scale=softmax_scale,
+        kernel_config=kernel_config,
+    )
+    return out, (q, k, v, out, lse, lower_bounds, valid)
+
+
+def _segmented_flash_attention_custom_vjp_bwd(
+    softmax_scale: float,
+    kernel_config: Any,
+    residuals: tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array],
+    cotangent: jax.Array | jax.custom_derivatives.SymbolicZero,
+) -> tuple[jax.Array | None, jax.Array | None, jax.Array | None, None, None]:
+    q, k, v, out, lse, lower_bounds, valid = residuals
+    if isinstance(cotangent, jax.custom_derivatives.SymbolicZero):
+        return jnp.zeros_like(q), jnp.zeros_like(k), jnp.zeros_like(v), None, None
+    dq, dk, dv = segmented_flash_attention_backward(
+        q,
+        k,
+        v,
+        out,
+        cotangent.astype(q.dtype),
+        lse,
+        lower_bounds,
+        valid,
+        softmax_scale=softmax_scale,
+        kernel_config=kernel_config,
+    )
+    return dq, dk, dv, None, None
+
+
+_segmented_flash_attention_custom_vjp.defvjp(
+    _segmented_flash_attention_custom_vjp_fwd,
+    _segmented_flash_attention_custom_vjp_bwd,
+)
+
+
+def _validate_forward_inputs(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    lower_bounds: jax.Array,
+    valid: jax.Array,
+    *,
+    softmax_scale: float,
+) -> None:
+    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+        raise ValueError(f"q/k/v must be BSHD tensors, got q={q.shape}, k={k.shape}, v={v.shape}")
+    if q.shape[0] != k.shape[0] or q.shape[0] != v.shape[0]:
+        raise ValueError(f"q/k/v batch sizes must match, got q={q.shape}, k={k.shape}, v={v.shape}")
+    if q.shape[1] != k.shape[1] or q.shape[1] != v.shape[1]:
+        raise ValueError(f"q/k/v sequence lengths must match, got q={q.shape}, k={k.shape}, v={v.shape}")
+    if q.shape[-1] != k.shape[-1]:
+        raise ValueError(f"q/k head dimensions must match, got q={q.shape}, k={k.shape}")
+    if k.shape[2] != v.shape[2]:
+        raise ValueError(f"k/v head counts must match, got k={k.shape}, v={v.shape}")
+    if v.shape[-1] != q.shape[-1]:
+        raise NotImplementedError(f"gpu_fa4_cute_attention currently requires Dv == D, got q={q.shape}, v={v.shape}")
+    if q.shape[2] % k.shape[2] != 0:
+        raise ValueError(f"Hq must be divisible by Hkv for GQA, got q={q.shape}, k={k.shape}")
+    if lower_bounds.shape != q.shape[:2]:
+        raise ValueError(f"lower_bounds must have shape [B, S]={q.shape[:2]}, got {lower_bounds.shape}")
+    if valid.shape != q.shape[:2]:
+        raise ValueError(f"valid must have shape [B, S]={q.shape[:2]}, got {valid.shape}")
+    if lower_bounds.dtype != jnp.int32:
+        raise ValueError(f"lower_bounds must be int32, got {lower_bounds.dtype}")
+    if valid.dtype != jnp.bool_:
+        raise ValueError(f"valid must be bool, got {valid.dtype}")
+    if q.dtype not in (jnp.bfloat16, jnp.float16):
+        raise TypeError(f"gpu_fa4_cute_attention currently supports only bf16/fp16, got {q.dtype}")
+    if k.dtype != q.dtype or v.dtype != q.dtype:
+        raise TypeError(f"q/k/v dtypes must match, got q={q.dtype}, k={k.dtype}, v={v.dtype}")
+    if not isinstance(softmax_scale, float):
+        raise TypeError(f"softmax_scale must be a Python float, got {type(softmax_scale).__name__}")
+    if softmax_scale <= 0.0:
+        raise ValueError(f"softmax_scale must be positive, got {softmax_scale}")
+
+
+def _validate_backward_inputs(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    out: jax.Array,
+    dout: jax.Array,
+    lse: jax.Array,
+) -> None:
+    expected_out_shape = (*q.shape[:3], v.shape[-1])
+    if out.shape != expected_out_shape:
+        raise ValueError(f"out must have shape {expected_out_shape}, got {out.shape}")
+    if dout.shape != expected_out_shape:
+        raise ValueError(f"dout must have shape {expected_out_shape}, got {dout.shape}")
+    if out.dtype != q.dtype or dout.dtype != q.dtype:
+        raise TypeError(f"out/dout dtypes must match q dtype {q.dtype}, got out={out.dtype}, dout={dout.dtype}")
+    expected_lse_shape = (q.shape[0], q.shape[2], q.shape[1])
+    if lse.shape != expected_lse_shape:
+        raise ValueError(f"lse must have shape [B, Hq, S]={expected_lse_shape}, got {lse.shape}")
+    if lse.dtype != jnp.float32:
+        raise TypeError(f"lse must be float32, got {lse.dtype}")
+
+
+__all__ = [
+    "cutlass_cute_available",
+    "cute_vector_add",
+    "fa4_cute_attention_forward",
+    "require_cutlass_cute",
+    "segmented_flash_attention_backward",
+    "segmented_flash_attention_forward",
+]

--- a/lib/levanter/src/levanter/grug/fa4_cute_kernels.py
+++ b/lib/levanter/src/levanter/grug/fa4_cute_kernels.py
@@ -1,0 +1,1396 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Portions of this file are adapted from:
+# /tmp/cutlass-codex/examples/python/CuTeDSL/cute/ampere/kernel/attention/flash_attention_v2.py
+
+"""CuTe DSL segmented FlashAttention forward kernel skeleton for Grug.
+
+This module intentionally has no import-time dependency on CUTLASS/CuTe. The
+kernel classes are built inside :func:`segmented_flash_attention_forward_launcher`
+after the backend has already imported the optional CUDA-only modules.
+
+The first target is BSHD BF16/FP16 causal self-attention with packed segment
+metadata:
+
+    valid[b, q] and lower_bounds[b, q] <= k <= q
+
+The dynamic segment mask is applied in every N tile. That is simpler than the
+FlashAttention v2 sample's split between masked and unmasked tiles and avoids
+materializing a [B, S, S] mask.
+"""
+
+import importlib
+import math
+from types import SimpleNamespace
+from typing import Any, Callable
+
+
+def _module_attr(modules: Any, name: str) -> Any:
+    if isinstance(modules, dict):
+        return modules.get(name)
+    return getattr(modules, name, None)
+
+
+def _import_cute_dependencies(modules: Any) -> SimpleNamespace:
+    """Load optional CuTe dependencies only when a launcher is requested."""
+    cute = _module_attr(modules, "cute")
+    cuda = _module_attr(modules, "cuda")
+    if cute is None:
+        cute = importlib.import_module("cutlass.cute")
+    if cuda is None:
+        cuda = importlib.import_module("cuda.bindings.driver")
+    nvgpu = importlib.import_module("cutlass.cute.nvgpu")
+
+    return SimpleNamespace(
+        cutlass=importlib.import_module("cutlass"),
+        cute=cute,
+        cuda=cuda,
+        pipeline=importlib.import_module("cutlass.pipeline"),
+        utils=importlib.import_module("cutlass.utils"),
+        warp=nvgpu.warp,
+    )
+
+
+def _validate_config(
+    *,
+    head_dim: int,
+    head_dim_v: int,
+    qhead_per_kvhead: int,
+    tile_m: int,
+    tile_n: int,
+    num_threads: int,
+) -> None:
+    if head_dim <= 0 or head_dim_v <= 0:
+        raise ValueError(f"head_dim and head_dim_v must be positive, got {head_dim=} {head_dim_v=}")
+    if head_dim_v != head_dim:
+        raise NotImplementedError(
+            f"segmented FA4/CuTe v1 requires head_dim_v == head_dim, got {head_dim_v=} {head_dim=}"
+        )
+    if qhead_per_kvhead <= 0:
+        raise ValueError(f"qhead_per_kvhead must be positive, got {qhead_per_kvhead}")
+    if tile_m <= 0 or tile_n <= 0:
+        raise ValueError(f"tile_m and tile_n must be positive, got {tile_m=} {tile_n=}")
+    if num_threads <= 0 or num_threads % 32 != 0:
+        raise ValueError(f"num_threads must be a positive multiple of 32, got {num_threads}")
+    if (tile_m * 2) % num_threads != 0:
+        raise ValueError(f"tile_m * 2 must be divisible by num_threads, got {tile_m=} {num_threads=}")
+
+
+def segmented_flash_attention_forward_launcher(
+    modules: Any,
+    *,
+    head_dim: int,
+    head_dim_v: int,
+    qhead_per_kvhead: int,
+    tile_m: int = 128,
+    tile_n: int = 64,
+    num_threads: int = 128,
+) -> Any:
+    """Build a JAX/CUTLASS-callable segmented FlashAttention forward launcher.
+
+    Args:
+        modules: Optional dependency bundle from ``fa4_cute_backend``. It may
+            provide ``cute`` and ``cuda`` attributes; other CUTLASS modules are
+            imported lazily here.
+        head_dim: Q/K head dimension.
+        head_dim_v: V/O head dimension.
+        qhead_per_kvhead: Number of query heads sharing each K/V head.
+        tile_m: Query tile size.
+        tile_n: Key/value tile size.
+        num_threads: CUDA threads per CTA.
+
+    Returns:
+        A ``cute.jit`` launcher with the JAX ``cutlass_call`` signature:
+        ``(stream, q, k, v, lower_bounds, valid, out, lse, *, softmax_scale)``.
+    """
+    _validate_config(
+        head_dim=head_dim,
+        head_dim_v=head_dim_v,
+        qhead_per_kvhead=qhead_per_kvhead,
+        tile_m=tile_m,
+        tile_n=tile_n,
+        num_threads=num_threads,
+    )
+    deps = _import_cute_dependencies(modules)
+    cutlass = deps.cutlass
+    cute = deps.cute
+    cuda = deps.cuda
+    pipeline = deps.pipeline
+    utils = deps.utils
+    warp = deps.warp
+
+    class SegmentedFlashAttentionForwardAmpere:
+        def __init__(
+            self,
+            head_dim: int,
+            head_dim_v: int,
+            qhead_per_kvhead: int,
+            m_block_size: int,
+            n_block_size: int,
+            num_threads: int,
+        ):
+            self._head_dim = head_dim
+            self._head_dim_v = head_dim_v
+            self._qhead_per_kvhead = qhead_per_kvhead
+            self._m_block_size = m_block_size
+            self._n_block_size = n_block_size
+            self._head_dim_padded = (head_dim + 31) // 32 * 32
+            self._head_dim_v_padded = (head_dim_v + 31) // 32 * 32
+            self._head_dim_qo_padded = max(self._head_dim_padded, self._head_dim_v_padded)
+            self._num_threads = num_threads
+            self.cta_sync_barrier = pipeline.NamedBarrier(barrier_id=1, num_threads=num_threads)
+
+        @staticmethod
+        def can_implement(
+            dtype: Any,
+            head_dim: int,
+            head_dim_v: int,
+            m_block_size: int,
+            n_block_size: int,
+            num_threads: int,
+        ) -> bool:
+            if dtype != cutlass.Float16 and dtype != cutlass.BFloat16:
+                return False
+            if head_dim != head_dim_v or head_dim % 8 != 0:
+                return False
+            if (m_block_size * 2) % num_threads != 0:
+                return False
+            head_dim_padded = (head_dim + 31) // 32 * 32
+            head_dim_v_padded = (head_dim_v + 31) // 32 * 32
+            smem_usage = (
+                m_block_size * max(head_dim_padded, head_dim_v_padded)
+                + n_block_size * (head_dim_padded + head_dim_v_padded)
+            ) * 2
+            return smem_usage <= utils.get_smem_capacity_in_bytes("sm_80")
+
+        @cute.jit
+        def __call__(
+            self,
+            mQ: cute.Tensor,
+            mK: cute.Tensor,
+            mV: cute.Tensor,
+            mLowerBounds: cute.Tensor,
+            mValid: cute.Tensor,
+            mO: cute.Tensor,
+            mLSE: cute.Tensor,
+            softmax_scale: cutlass.Float32,
+            stream: cuda.CUstream,
+        ):
+            if cutlass.const_expr(mQ.element_type != mK.element_type or mQ.element_type != mV.element_type):
+                raise TypeError("q/k/v tensors must have the same element type")
+            if cutlass.const_expr(mO.element_type != mQ.element_type):
+                raise TypeError("output tensor must have the same element type as q/k/v")
+            if cutlass.const_expr(mLSE.element_type != cutlass.Float32):
+                raise TypeError("LSE tensor must be float32")
+            if cutlass.const_expr(mQ.element_type != cutlass.Float16 and mQ.element_type != cutlass.BFloat16):
+                raise TypeError("only Float16 and BFloat16 are supported")
+            if cutlass.const_expr(mLowerBounds.element_type != cutlass.Int32):
+                raise TypeError("lower_bounds must be int32")
+            if cutlass.const_expr(mValid.element_type != cutlass.Int32):
+                raise TypeError("valid must be int32")
+            if cutlass.const_expr(mQ.shape[1] != self._head_dim or mK.shape[1] != self._head_dim):
+                raise ValueError("q/k trailing dimension must match head_dim")
+            if cutlass.const_expr(mV.shape[1] != self._head_dim_v or mO.shape[1] != self._head_dim_v):
+                raise ValueError("v/o trailing dimension must match head_dim_v")
+            if cutlass.const_expr(mQ.shape[2] != mK.shape[2] * self._qhead_per_kvhead):
+                raise ValueError("q heads must equal k/v heads times qhead_per_kvhead")
+            if cutlass.const_expr(mK.shape[2] != mV.shape[2]):
+                raise ValueError("k/v head counts must match")
+            if cutlass.const_expr(mLowerBounds.shape[0] != mQ.shape[3] or mLowerBounds.shape[1] != mQ.shape[0]):
+                raise ValueError("lower_bounds must have shape [B, S]")
+            if cutlass.const_expr(mValid.shape[0] != mQ.shape[3] or mValid.shape[1] != mQ.shape[0]):
+                raise ValueError("valid must have shape [B, S]")
+            if cutlass.const_expr(
+                mLSE.shape[0] != mQ.shape[3] or mLSE.shape[1] != mQ.shape[2] or mLSE.shape[2] != mQ.shape[0]
+            ):
+                raise ValueError("LSE must have shape [B, Hq, S]")
+            if cutlass.const_expr(
+                not self.can_implement(
+                    mQ.element_type,
+                    self._head_dim,
+                    self._head_dim_v,
+                    self._m_block_size,
+                    self._n_block_size,
+                    self._num_threads,
+                )
+            ):
+                raise ValueError("unsupported segmented FA4/CuTe tile configuration")
+
+            self._dtype = mQ.element_type
+            smem_k_block_size = 64 if self._head_dim_qo_padded % 64 == 0 else 32
+            swizzle_bits = 3 if smem_k_block_size == 64 else 2
+            sQO_layout_atom = cute.make_composed_layout(
+                cute.make_swizzle(swizzle_bits, 3, 3),
+                0,
+                cute.make_layout((8, smem_k_block_size), stride=(smem_k_block_size, 1)),
+            )
+            sQ_layout = cute.tile_to_shape(sQO_layout_atom, (self._m_block_size, self._head_dim_padded), (0, 1))
+            sO_layout = cute.tile_to_shape(sQO_layout_atom, (self._m_block_size, self._head_dim_v_padded), (0, 1))
+            sQO_layout = cute.tile_to_shape(
+                sQO_layout_atom,
+                (self._m_block_size, self._head_dim_qo_padded),
+                (0, 1),
+            )
+            sK_layout = cute.tile_to_shape(sQO_layout_atom, (self._n_block_size, self._head_dim_padded), (0, 1))
+            sV_layout = cute.tile_to_shape(sQO_layout_atom, (self._n_block_size, self._head_dim_v_padded), (0, 1))
+
+            @cute.struct
+            class SharedStorage:
+                sQO: cute.struct.Align[cute.struct.MemRange[self._dtype, cute.cosize(sQO_layout)], 1024]
+                sK: cute.struct.Align[cute.struct.MemRange[self._dtype, cute.cosize(sK_layout)], 1024]
+                sV: cute.struct.Align[cute.struct.MemRange[self._dtype, cute.cosize(sV_layout)], 1024]
+
+            universal_copy_bits = 128
+            async_copy_elems = universal_copy_bits // self._dtype.width
+            atom_universal_copy = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                self._dtype,
+                num_bits_per_copy=universal_copy_bits,
+            )
+            tQKV_shape_dim_1 = sQO_layout_atom.outer.shape[1] // async_copy_elems
+            tQKV_layout = cute.make_layout(
+                (self._num_threads // tQKV_shape_dim_1, tQKV_shape_dim_1),
+                stride=(tQKV_shape_dim_1, 1),
+            )
+            vQKV_layout = cute.make_layout((1, async_copy_elems))
+            gmem_tiled_copy_QKV = cute.make_tiled_copy_tv(atom_universal_copy, tQKV_layout, vQKV_layout)
+            gmem_tiled_copy_O = cute.make_tiled_copy_tv(atom_universal_copy, tQKV_layout, vQKV_layout)
+            tiled_mma = cute.make_tiled_mma(
+                warp.MmaF16BF16Op(self._dtype, cutlass.Float32, (16, 8, 16)),
+                (self._num_threads // 32, 1, 1),
+                permutation_mnk=(self._num_threads // 32 * 16, 16, 16),
+            )
+
+            grid_dim = (
+                cute.ceil_div(mQ.shape[0], self._m_block_size),
+                cute.size(mQ.shape[3]),
+                cute.size(mQ.shape[2]),
+            )
+            softmax_scale_log2 = softmax_scale * 1.4426950408889634
+            self.kernel(
+                mQ,
+                mK,
+                mV,
+                mLowerBounds,
+                mValid,
+                mO,
+                mLSE,
+                softmax_scale_log2,
+                sQ_layout,
+                sK_layout,
+                sV_layout,
+                sO_layout,
+                gmem_tiled_copy_QKV,
+                gmem_tiled_copy_O,
+                tiled_mma,
+                SharedStorage,
+            ).launch(grid=grid_dim, block=[self._num_threads, 1, 1], stream=stream)
+
+        @cute.kernel
+        def kernel(
+            self,
+            mQ: cute.Tensor,
+            mK: cute.Tensor,
+            mV: cute.Tensor,
+            mLowerBounds: cute.Tensor,
+            mValid: cute.Tensor,
+            mO: cute.Tensor,
+            mLSE: cute.Tensor,
+            softmax_scale_log2: cutlass.Float32,
+            sQ_layout: cute.ComposedLayout,
+            sK_layout: cute.ComposedLayout,
+            sV_layout: cute.ComposedLayout,
+            sO_layout: cute.ComposedLayout,
+            gmem_tiled_copy_QKV: cute.TiledCopy,
+            gmem_tiled_copy_O: cute.TiledCopy,
+            tiled_mma: cute.TiledMma,
+            SharedStorage: cutlass.Constexpr,
+        ):
+            tidx, _, _ = cute.arch.thread_idx()
+            m_block, batch_idx, q_head = cute.arch.block_idx()
+            kv_head = q_head // self._qhead_per_kvhead
+
+            n_block_max = min(
+                cute.ceil_div((m_block + 1) * self._m_block_size, self._n_block_size),
+                cute.ceil_div(mK.shape[0], self._n_block_size),
+            )
+            n_block = n_block_max - 1
+            first_query = cutlass.min(m_block * self._m_block_size, mQ.shape[0] - 1)
+            n_block_min = mLowerBounds[batch_idx, first_query] // self._n_block_size
+
+            gQ = cute.local_tile(
+                mQ[None, None, q_head, batch_idx],
+                (self._m_block_size, self._head_dim_padded),
+                (m_block, 0),
+            )
+            gK = cute.local_tile(
+                mK[None, None, kv_head, batch_idx],
+                (self._n_block_size, self._head_dim_padded),
+                (None, 0),
+            )
+            gV = cute.local_tile(
+                mV[None, None, kv_head, batch_idx],
+                (self._n_block_size, self._head_dim_v_padded),
+                (None, 0),
+            )
+
+            smem = cutlass.utils.SmemAllocator()
+            storage = smem.allocate(SharedStorage)
+            sQ = storage.sQO.get_tensor(sQ_layout)
+            sK = storage.sK.get_tensor(sK_layout)
+            sV = storage.sV.get_tensor(sV_layout)
+            sVt = cute.composition(
+                sV,
+                cute.make_layout((self._head_dim_v_padded, self._n_block_size), stride=(self._n_block_size, 1)),
+            )
+
+            gmem_thr_copy_QKV = gmem_tiled_copy_QKV.get_slice(tidx)
+            tQgQ = gmem_thr_copy_QKV.partition_S(gQ)
+            tQsQ = gmem_thr_copy_QKV.partition_D(sQ)
+            tKgK = gmem_thr_copy_QKV.partition_S(gK)
+            tKsK = gmem_thr_copy_QKV.partition_D(sK)
+            tVgV = gmem_thr_copy_QKV.partition_S(gV)
+            tVsV = gmem_thr_copy_QKV.partition_D(sV)
+
+            thr_mma = tiled_mma.get_slice(tidx)
+            tSrQ = thr_mma.make_fragment_A(thr_mma.partition_A(sQ))
+            tSrK = thr_mma.make_fragment_B(thr_mma.partition_B(sK))
+            tOrVt = thr_mma.make_fragment_B(thr_mma.partition_B(sVt))
+            acc_O = cute.make_rmem_tensor(
+                thr_mma.partition_shape_C((self._m_block_size, self._head_dim_v_padded)),
+                cutlass.Float32,
+            )
+            acc_O.fill(0.0)
+
+            smem_copy_atom_Q = cute.make_copy_atom(
+                warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), self._dtype
+            )
+            smem_copy_atom_K = cute.make_copy_atom(
+                warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), self._dtype
+            )
+            smem_copy_atom_V = cute.make_copy_atom(warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=4), self._dtype)
+            smem_tiled_copy_Q = cute.make_tiled_copy_A(smem_copy_atom_Q, tiled_mma)
+            smem_tiled_copy_K = cute.make_tiled_copy_B(smem_copy_atom_K, tiled_mma)
+            smem_tiled_copy_V = cute.make_tiled_copy_B(smem_copy_atom_V, tiled_mma)
+
+            smem_thr_copy_Q = smem_tiled_copy_Q.get_slice(tidx)
+            smem_thr_copy_K = smem_tiled_copy_K.get_slice(tidx)
+            smem_thr_copy_V = smem_tiled_copy_V.get_slice(tidx)
+            tSsQ = smem_thr_copy_Q.partition_S(sQ)
+            tSrQ_copy_view = smem_thr_copy_Q.retile(tSrQ)
+            tSsK = smem_thr_copy_K.partition_S(sK)
+            tSrK_copy_view = smem_thr_copy_K.retile(tSrK)
+            tOsVt = smem_thr_copy_V.partition_S(sVt)
+            tOrVt_copy_view = smem_thr_copy_V.retile(tOrVt)
+
+            mcQ = cute.make_identity_tensor(mQ.layout.shape)
+            mcKV = cute.make_identity_tensor(mK.layout.shape)
+            cQ = cute.local_tile(
+                mcQ[None, None, q_head, batch_idx],
+                (self._m_block_size, self._head_dim_padded),
+                (m_block, 0),
+            )
+            cKV = cute.local_tile(
+                mcKV[None, None, kv_head, batch_idx],
+                (self._n_block_size, self._head_dim_padded),
+                (n_block, 0),
+            )
+            tQcQ = gmem_thr_copy_QKV.partition_S(cQ)
+            tKVcKV = gmem_thr_copy_QKV.partition_S(cKV)
+            tQpQ = cute.make_rmem_tensor(
+                cute.make_layout(
+                    (tQsQ.shape[0][1], cute.size(tQsQ, mode=[1]), cute.size(tQsQ, mode=[2])),
+                    stride=(cute.size(tQsQ, mode=[2]), 0, 1),
+                ),
+                cutlass.Boolean,
+            )
+            tKVpKV = cute.make_rmem_tensor(
+                cute.make_layout(
+                    (tKsK.shape[0][1], cute.size(tKsK, mode=[1]), cute.size(tKsK, mode=[2])),
+                    stride=(cute.size(tKsK, mode=[2]), 0, 1),
+                ),
+                cutlass.Boolean,
+            )
+            for rest_v in cutlass.range_constexpr(tQpQ.shape[0]):
+                for rest_k in cutlass.range_constexpr(tQpQ.shape[2]):
+                    tQpQ[rest_v, 0, rest_k] = cute.elem_less(tQcQ[(0, rest_v), 0, rest_k][1], mQ.layout.shape[1])
+            for rest_v in cutlass.range_constexpr(tKVpKV.shape[0]):
+                for rest_k in cutlass.range_constexpr(tKVpKV.shape[2]):
+                    tKVpKV[rest_v, 0, rest_k] = cute.elem_less(tKVcKV[(0, rest_v), 0, rest_k][1], mK.layout.shape[1])
+
+            for m in cutlass.range_constexpr(cute.size(tQsQ.shape[1])):
+                if cute.elem_less(tQcQ[0, m, 0][0], mQ.layout.shape[0]):
+                    cute.copy(gmem_tiled_copy_QKV, tQgQ[None, m, None], tQsQ[None, m, None], pred=tQpQ[None, m, None])
+                else:
+                    tQsQ[None, m, None].fill(0)
+            for n in cutlass.range_constexpr(cute.size(tKsK.shape[1])):
+                if cute.elem_less(tKVcKV[0, n, 0][0], mK.layout.shape[0]):
+                    cute.copy(
+                        gmem_tiled_copy_QKV,
+                        tKgK[None, n, None, n_block],
+                        tKsK[None, n, None],
+                        pred=tKVpKV[None, n, None],
+                    )
+                else:
+                    tKsK[None, n, None].fill(0)
+            cute.arch.cp_async_commit_group()
+
+            row_max = cute.make_rmem_tensor((acc_O.shape[0][0] * acc_O.shape[1]), cutlass.Float32)
+            row_sum = cute.make_rmem_tensor((acc_O.shape[0][0] * acc_O.shape[1]), cutlass.Float32)
+            row_max.fill(-cutlass.Float32.inf)
+            row_sum.fill(0.0)
+
+            basic_params = SimpleNamespace(
+                m_block=m_block,
+                n_block=n_block,
+                batch_idx=batch_idx,
+                q_head=q_head,
+                mQ=mQ,
+                mK=mK,
+                mLowerBounds=mLowerBounds,
+                mValid=mValid,
+            )
+            mma_params = SimpleNamespace(
+                thr_mma=thr_mma, tiled_mma=tiled_mma, tSrQ=tSrQ, tSrK=tSrK, tOrVt=tOrVt, acc_O=acc_O
+            )
+            gmem_copy_params = SimpleNamespace(
+                gmem_tiled_copy_QKV=gmem_tiled_copy_QKV,
+                tKVcKV=tKVcKV,
+                tKgK=tKgK,
+                tKsK=tKsK,
+                tVgV=tVgV,
+                tVsV=tVsV,
+                tKVpKV=tKVpKV,
+            )
+            smem_copy_params = SimpleNamespace(
+                smem_tiled_copy_Q=smem_tiled_copy_Q,
+                smem_tiled_copy_K=smem_tiled_copy_K,
+                smem_tiled_copy_V=smem_tiled_copy_V,
+                tSsQ=tSsQ,
+                tSrQ_copy_view=tSrQ_copy_view,
+                tSsK=tSsK,
+                tSrK_copy_view=tSrK_copy_view,
+                tOsVt=tOsVt,
+                tOrVt_copy_view=tOrVt_copy_view,
+            )
+            softmax_params = SimpleNamespace(row_max=row_max, row_sum=row_sum, softmax_scale_log2=softmax_scale_log2)
+
+            if n_block_min < n_block_max:
+                basic_params.n_block = n_block_max - 1
+                self.compute_one_n_block(
+                    basic_params,
+                    mma_params,
+                    gmem_copy_params,
+                    smem_copy_params,
+                    softmax_params,
+                    is_first_n_block=True,
+                )
+                for n_tile in range(1, n_block_max - n_block_min, 1):
+                    basic_params.n_block = n_block_max - n_tile - 1
+                    self.compute_one_n_block(
+                        basic_params,
+                        mma_params,
+                        gmem_copy_params,
+                        smem_copy_params,
+                        softmax_params,
+                        is_first_n_block=False,
+                    )
+
+            self.normalize_softmax_and_store_lse(
+                acc_O,
+                row_max,
+                row_sum,
+                mLSE,
+                mQ,
+                thr_mma,
+                batch_idx,
+                q_head,
+                m_block,
+                softmax_scale_log2,
+            )
+            rO = cute.make_fragment_like(acc_O, self._dtype)
+            rO.store(acc_O.load().to(self._dtype))
+            sO = storage.sQO.get_tensor(sO_layout)
+            smem_copy_atom_O = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self._dtype)
+            smem_tiled_copy_O = cute.make_tiled_copy_C(smem_copy_atom_O, tiled_mma)
+            smem_thr_copy_O = smem_tiled_copy_O.get_slice(tidx)
+            taccOrO = smem_thr_copy_O.retile(rO)
+            taccOsO = smem_thr_copy_O.partition_D(sO)
+            cute.copy(smem_copy_atom_O, taccOrO, taccOsO)
+
+            gO = cute.local_tile(
+                mO[None, None, q_head, batch_idx],
+                (self._m_block_size, self._head_dim_v_padded),
+                (m_block, 0),
+            )
+            gmem_thr_copy_O = gmem_tiled_copy_O.get_slice(tidx)
+            tOsO = gmem_thr_copy_O.partition_S(sO)
+            tOgO = gmem_thr_copy_O.partition_D(gO)
+            tOrO = cute.make_fragment_like(tOgO, self._dtype)
+            self.cta_sync_barrier.arrive_and_wait()
+            cute.copy(gmem_tiled_copy_O, tOsO, tOrO)
+
+            mcO = cute.make_identity_tensor(mO.layout.shape)
+            cO = cute.local_tile(
+                mcO[None, None, q_head, batch_idx],
+                (self._m_block_size, self._head_dim_v_padded),
+                (m_block, 0),
+            )
+            tOcO = gmem_thr_copy_O.partition_D(cO)
+            tOpO = cute.make_rmem_tensor(
+                cute.make_layout(
+                    (tOgO.shape[0][1], tOgO.shape[1], tOgO.shape[2]),
+                    stride=(tOgO.shape[2], 0, 1),
+                ),
+                cutlass.Boolean,
+            )
+            for rest_v in cutlass.range_constexpr(tOpO.shape[0]):
+                for rest_n in cutlass.range_constexpr(cute.size(tOpO.shape[2])):
+                    tOpO[rest_v, 0, rest_n] = cute.elem_less(tOcO[(0, rest_v), 0, rest_n][1], mO.layout.shape[1])
+            for rest_m in cutlass.range_constexpr(cute.size(tOpO.shape[1])):
+                if cute.elem_less(tOcO[0, rest_m, 0][0], mO.layout.shape[0]):
+                    cute.copy(
+                        gmem_tiled_copy_O,
+                        tOrO[None, rest_m, None],
+                        tOgO[None, rest_m, None],
+                        pred=tOpO[None, rest_m, None],
+                    )
+
+        @cute.jit
+        def compute_one_n_block(
+            self,
+            basic_params: SimpleNamespace,
+            mma_params: SimpleNamespace,
+            gmem_copy_params: SimpleNamespace,
+            smem_copy_params: SimpleNamespace,
+            softmax_params: SimpleNamespace,
+            is_first_n_block: cutlass.Constexpr,
+        ):
+            acc_S = cute.make_rmem_tensor(
+                mma_params.thr_mma.partition_shape_C((self._m_block_size, self._n_block_size)),
+                cutlass.Float32,
+            )
+            acc_S.fill(0.0)
+
+            cute.arch.cp_async_wait_group(0)
+            self.cta_sync_barrier.arrive_and_wait()
+            if is_first_n_block:
+                for n in cutlass.range_constexpr(cute.size(gmem_copy_params.tVsV.shape[1])):
+                    if cute.elem_less(gmem_copy_params.tKVcKV[0, n, 0][0], basic_params.mK.layout.shape[0]):
+                        cute.copy(
+                            gmem_copy_params.gmem_tiled_copy_QKV,
+                            gmem_copy_params.tVgV[None, n, None, basic_params.n_block],
+                            gmem_copy_params.tVsV[None, n, None],
+                            pred=gmem_copy_params.tKVpKV[None, n, None],
+                        )
+                    else:
+                        gmem_copy_params.tVsV[None, n, None].fill(0.0)
+            else:
+                cute.copy(
+                    gmem_copy_params.gmem_tiled_copy_QKV,
+                    gmem_copy_params.tVgV[None, None, None, basic_params.n_block],
+                    gmem_copy_params.tVsV,
+                    pred=gmem_copy_params.tKVpKV,
+                )
+            cute.arch.cp_async_commit_group()
+
+            cute.copy(
+                smem_copy_params.smem_tiled_copy_Q,
+                smem_copy_params.tSsQ[None, None, 0],
+                smem_copy_params.tSrQ_copy_view[None, None, 0],
+            )
+            cute.copy(
+                smem_copy_params.smem_tiled_copy_K,
+                smem_copy_params.tSsK[None, None, 0],
+                smem_copy_params.tSrK_copy_view[None, None, 0],
+            )
+            for k in cutlass.range_constexpr(cute.size(smem_copy_params.tSsQ.shape[2])):
+                k_next = (k + 1) % cute.size(smem_copy_params.tSsQ.shape[2])
+                cute.copy(
+                    smem_copy_params.smem_tiled_copy_Q,
+                    smem_copy_params.tSsQ[None, None, k_next],
+                    smem_copy_params.tSrQ_copy_view[None, None, k_next],
+                )
+                cute.copy(
+                    smem_copy_params.smem_tiled_copy_K,
+                    smem_copy_params.tSsK[None, None, k_next],
+                    smem_copy_params.tSrK_copy_view[None, None, k_next],
+                )
+                cute.gemm(
+                    mma_params.tiled_mma,
+                    acc_S,
+                    mma_params.tSrQ[None, None, k],
+                    mma_params.tSrK[None, None, k],
+                    acc_S,
+                )
+
+            cute.arch.cp_async_wait_group(0)
+            self.cta_sync_barrier.arrive_and_wait()
+            if basic_params.n_block > 0:
+                cute.copy(
+                    gmem_copy_params.gmem_tiled_copy_QKV,
+                    gmem_copy_params.tKgK[None, None, None, basic_params.n_block - 1],
+                    gmem_copy_params.tKsK,
+                    pred=gmem_copy_params.tKVpKV,
+                )
+                cute.arch.cp_async_commit_group()
+
+            self.softmax_rescale_O(basic_params, mma_params, softmax_params, acc_S, is_first_n_block)
+
+            rP = cute.make_fragment_like(acc_S, self._dtype)
+            rP.store(acc_S.load().to(self._dtype))
+            rP_layout_divided = cute.logical_divide(rP.layout, (None, None, 2))
+            rP_mma_view = cute.make_layout(
+                (
+                    (rP_layout_divided.shape[0], rP_layout_divided.shape[2][0]),
+                    rP_layout_divided.shape[1],
+                    rP_layout_divided.shape[2][1],
+                ),
+                stride=(
+                    (rP_layout_divided.stride[0], rP_layout_divided.stride[2][0]),
+                    rP_layout_divided.stride[1],
+                    rP_layout_divided.stride[2][1],
+                ),
+            )
+            tOrS = cute.make_tensor(rP.iterator, rP_mma_view)
+            cute.copy(
+                smem_copy_params.smem_tiled_copy_V,
+                smem_copy_params.tOsVt[None, None, 0],
+                smem_copy_params.tOrVt_copy_view[None, None, 0],
+            )
+            for k in cutlass.range_constexpr(cute.size(tOrS.shape[2])):
+                k_next = (k + 1) % cute.size(tOrS.shape[2])
+                cute.copy(
+                    smem_copy_params.smem_tiled_copy_V,
+                    smem_copy_params.tOsVt[None, None, k_next],
+                    smem_copy_params.tOrVt_copy_view[None, None, k_next],
+                )
+                cute.gemm(
+                    mma_params.tiled_mma,
+                    mma_params.acc_O,
+                    tOrS[None, None, k],
+                    mma_params.tOrVt[None, None, k],
+                    mma_params.acc_O,
+                )
+
+        @cute.jit
+        def softmax_rescale_O(
+            self,
+            basic_params: SimpleNamespace,
+            mma_params: SimpleNamespace,
+            softmax_params: SimpleNamespace,
+            acc_S: cute.Tensor,
+            is_first_n_block: cutlass.Constexpr,
+        ):
+            acc_S_mn = self._make_acc_tensor_mn_view(acc_S)
+            acc_O_mn = self._make_acc_tensor_mn_view(mma_params.acc_O)
+            row_max_prev = cute.make_fragment_like(softmax_params.row_max, cutlass.Float32)
+            if cutlass.const_expr(not is_first_n_block):
+                cute.basic_copy(softmax_params.row_max, row_max_prev)
+
+            mcS = cute.make_identity_tensor(
+                (
+                    basic_params.mQ.shape[3],
+                    basic_params.mQ.shape[0],
+                    basic_params.mQ.shape[2],
+                    basic_params.mK.shape[0],
+                )
+            )
+            cS = cute.local_tile(
+                mcS[basic_params.batch_idx, None, basic_params.q_head, None],
+                (self._m_block_size, self._n_block_size),
+                (basic_params.m_block, basic_params.n_block),
+            )
+            tScS = mma_params.thr_mma.partition_C(cS)
+            tScS_mn = self._make_acc_tensor_mn_view(tScS)
+
+            for r in cutlass.range_constexpr(cute.size(softmax_params.row_max)):
+                query_idx = tScS_mn[r, 0][1]
+                query_in_bounds = cute.elem_less(query_idx, basic_params.mQ.shape[0])
+                query_meta_idx = cutlass.min(query_idx, basic_params.mQ.shape[0] - 1)
+                query_valid = basic_params.mValid[basic_params.batch_idx, query_meta_idx] != 0
+                query_lower_bound = basic_params.mLowerBounds[basic_params.batch_idx, query_meta_idx]
+
+                for c in cutlass.range_constexpr(cute.size(tScS_mn.shape[1])):
+                    key_idx = tScS_mn[0, c][3]
+                    key_in_bounds = cute.elem_less(key_idx, basic_params.mK.shape[0])
+                    key_after_lower_bound = cute.elem_less(query_lower_bound, key_idx + 1)
+                    key_before_query = cute.elem_less(key_idx, query_idx + 1)
+                    if not (
+                        query_in_bounds
+                        and query_valid
+                        and key_in_bounds
+                        and key_after_lower_bound
+                        and key_before_query
+                    ):
+                        acc_S_mn[r, c] = -cutlass.Float32.inf
+
+                acc_S_row = acc_S_mn[r, None].load()
+                row_max_cur_row = acc_S_row.reduce(cute.ReductionOp.MAX, -cutlass.Float32.inf, 0)
+                row_max_cur_row = self._threadquad_reduce_max(row_max_cur_row)
+                row_max_prev_row = None
+                if cutlass.const_expr(not is_first_n_block):
+                    row_max_prev_row = row_max_prev[r]
+                    row_max_cur_row = cute.arch.fmax(row_max_prev_row, row_max_cur_row)
+                row_max_cur_row = 0.0 if row_max_cur_row == -cutlass.Float32.inf else row_max_cur_row
+
+                acc_S_row_exp = cute.math.exp2(
+                    acc_S_row * softmax_params.softmax_scale_log2
+                    - row_max_cur_row * softmax_params.softmax_scale_log2,
+                    fastmath=True,
+                )
+                acc_S_row_sum = acc_S_row_exp.reduce(cute.ReductionOp.ADD, cutlass.Float32.zero, 0)
+                if cutlass.const_expr(not is_first_n_block):
+                    prev_minus_cur_exp = cute.math.exp2(
+                        row_max_prev_row * softmax_params.softmax_scale_log2
+                        - row_max_cur_row * softmax_params.softmax_scale_log2,
+                        fastmath=True,
+                    )
+                    acc_S_row_sum = acc_S_row_sum + softmax_params.row_sum[r] * prev_minus_cur_exp
+                    acc_O_mn[r, None] = acc_O_mn[r, None].load() * prev_minus_cur_exp
+
+                softmax_params.row_max[r] = row_max_cur_row
+                softmax_params.row_sum[r] = acc_S_row_sum
+                acc_S_mn[r, None] = acc_S_row_exp
+
+        @cute.jit
+        def normalize_softmax_and_store_lse(
+            self,
+            acc_O: cute.Tensor,
+            row_max: cute.Tensor,
+            row_sum: cute.Tensor,
+            mLSE: cute.Tensor,
+            mQ: cute.Tensor,
+            thr_mma: cute.TiledMma,
+            batch_idx: cutlass.Int32,
+            q_head: cutlass.Int32,
+            m_block: cutlass.Int32,
+            softmax_scale_log2: cutlass.Float32,
+        ):
+            acc_O_mn = self._make_acc_tensor_mn_view(acc_O)
+            mcO = cute.make_identity_tensor((mQ.shape[3], mQ.shape[0], mQ.shape[2], self._head_dim_v_padded))
+            cO = cute.local_tile(
+                mcO[batch_idx, None, q_head, None],
+                (self._m_block_size, self._head_dim_v_padded),
+                (m_block, 0),
+            )
+            tOcO = thr_mma.partition_C(cO)
+            tOcO_mn = self._make_acc_tensor_mn_view(tOcO)
+            ln2 = cutlass.Float32(math.log(2.0))
+            for r in cutlass.range_constexpr(cute.size(row_sum)):
+                row_sum[r] = self._threadquad_reduce_sum(row_sum[r])
+                row_sum_is_zero_or_nan = row_sum[r] == 0.0 or row_sum[r] != row_sum[r]
+                scale = 1.0 if row_sum_is_zero_or_nan else cute.arch.rcp_approx(row_sum[r])
+                acc_O_mn[r, None] = acc_O_mn[r, None].load() * scale
+                query_idx = tOcO_mn[r, 0][1]
+                if cute.elem_less(query_idx, mLSE.shape[2]):
+                    lse = (
+                        (row_max[r] * softmax_scale_log2 + cute.math.log2(row_sum[r], fastmath=True)) * ln2
+                        if not row_sum_is_zero_or_nan
+                        else -cutlass.Float32.inf
+                    )
+                    mLSE[batch_idx, q_head, query_idx] = lse
+
+        def _make_acc_tensor_mn_view(self, acc: cute.Tensor) -> cute.Tensor:
+            acc_layout_col_major = cute.make_layout(acc.layout.shape)
+            acc_layout_mn = cute.make_layout(
+                (
+                    (acc_layout_col_major.shape[0][1], acc_layout_col_major.shape[1]),
+                    (acc_layout_col_major.shape[0][0], acc_layout_col_major.shape[2]),
+                ),
+                stride=(
+                    (acc_layout_col_major.stride[0][1], acc_layout_col_major.stride[1]),
+                    (acc_layout_col_major.stride[0][0], acc_layout_col_major.stride[2]),
+                ),
+            )
+            acc_layout_mn = cute.composition(acc.layout, acc_layout_mn)
+            return cute.make_tensor(acc.iterator, acc_layout_mn)
+
+        def _threadquad_reduce(self, val: Any, op: Callable[[Any, Any], Any]) -> Any:
+            val = op(val, cute.arch.shuffle_sync_bfly(val, offset=2, mask=-1, mask_and_clamp=31))
+            val = op(val, cute.arch.shuffle_sync_bfly(val, offset=1, mask=-1, mask_and_clamp=31))
+            return val
+
+        def _threadquad_reduce_max(self, val: Any) -> Any:
+            return self._threadquad_reduce(val, lambda x, y: cute.arch.fmax(x, y))
+
+        def _threadquad_reduce_sum(self, val: Any) -> Any:
+            return self._threadquad_reduce(val, lambda x, y: x + y)
+
+    kernel = SegmentedFlashAttentionForwardAmpere(
+        head_dim=head_dim,
+        head_dim_v=head_dim_v,
+        qhead_per_kvhead=qhead_per_kvhead,
+        m_block_size=tile_m,
+        n_block_size=tile_n,
+        num_threads=num_threads,
+    )
+
+    @cute.jit
+    def _launch_segmented_flash_attention_forward(
+        stream: cuda.CUstream,
+        q: cute.Tensor,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        lower_bounds: cute.Tensor,
+        valid: cute.Tensor,
+        out: cute.Tensor,
+        lse: cute.Tensor,
+        *,
+        softmax_scale: cutlass.Float32,
+    ):
+        kernel(q, k, v, lower_bounds, valid, out, lse, softmax_scale, stream)
+
+    return _launch_segmented_flash_attention_forward
+
+
+def segmented_flash_attention_backward_launcher(
+    modules: Any,
+    *,
+    dtype: Any,
+    head_dim: int,
+    head_dim_v: int,
+    qhead_per_kvhead: int,
+    tile_m: int = 64,
+    tile_n: int = 64,
+    num_threads: int = 128,
+) -> Any:
+    """Build the FA4/CuTe segmented backward launcher.
+
+    This path reuses the upstream FA4 SM80/SM120 backward pipeline shape:
+    preprocess computes dPsum/LSE-log2 and zeros dQ accumulators, the main
+    tiled kernel accumulates dQ/dK/dV, then postprocess converts accumulators
+    to the requested BF16/FP16 gradients.
+    """
+    _validate_config(
+        head_dim=head_dim,
+        head_dim_v=head_dim_v,
+        qhead_per_kvhead=qhead_per_kvhead,
+        tile_m=tile_m,
+        tile_n=tile_n,
+        num_threads=num_threads,
+    )
+    deps = _import_cute_dependencies(modules)
+    cutlass = deps.cutlass
+    cute = deps.cute
+    cuda = deps.cuda
+
+    if str(dtype) == "bfloat16":
+        cute_dtype = cutlass.BFloat16
+    elif str(dtype) == "float16":
+        cute_dtype = cutlass.Float16
+    else:
+        raise TypeError(f"segmented FA4/CuTe backward expects bf16/fp16, got {dtype}")
+
+    preprocess_module = importlib.import_module("flash_attn.cute.flash_bwd_preprocess")
+    postprocess_module = importlib.import_module("flash_attn.cute.flash_bwd_postprocess")
+    # JAX cutlass_call exposes nested scratch buffers as generic memrefs. Upstream
+    # postprocess uses cp.async, which verifies only for global memrefs.
+    postprocess_module.assume_tensor_aligned = lambda tensor: tensor
+    postprocess_module.cpasync.CopyG2SOp = lambda *args, **kwargs: cute.nvgpu.CopyUniversalOp()
+    segmented_bwd_module = importlib.import_module("levanter.grug.fa4_cute_segmented_bwd")
+    FlashAttentionBackwardPreprocess = preprocess_module.FlashAttentionBackwardPreprocess
+    FlashAttentionBackwardPostprocess = postprocess_module.FlashAttentionBackwardPostprocess
+    SegmentedFlashAttentionBackwardSm80 = segmented_bwd_module.SegmentedFlashAttentionBackwardSm80
+    SegmentedFlashAttentionBackwardSm120 = segmented_bwd_module.SegmentedFlashAttentionBackwardSm120
+    if qhead_per_kvhead <= 1:
+        raise NotImplementedError("optimized segmented FA4/CuTe backward currently requires GQA")
+
+    is_sm120_config = tile_m == 64 and tile_n == 64 and num_threads == 128
+    arch = 120 if is_sm120_config else 80
+    if arch == 120:
+        num_stages_q = 2 if head_dim <= 64 else 1
+        num_stages_do = 2 if head_dim <= 64 else 1
+        atom_layout_m_sdp = 4
+        atom_layout_n_dkv = 4
+        atom_layout_m_dq = 4
+        bwd_cls = SegmentedFlashAttentionBackwardSm120
+    else:
+        num_stages_q = 2
+        num_stages_do = 2
+        atom_layout_m_sdp = 2
+        atom_layout_n_dkv = 2
+        atom_layout_m_dq = 2
+        bwd_cls = SegmentedFlashAttentionBackwardSm80
+
+    postprocess_threads = 128
+    preprocess = FlashAttentionBackwardPreprocess(
+        cute_dtype,
+        head_dim,
+        head_dim_v,
+        tile_m,
+        num_threads=postprocess_threads,
+        use_padded_offsets=False,
+    )
+    dq_postprocess = FlashAttentionBackwardPostprocess(
+        cute_dtype,
+        head_dim,
+        arch,
+        tile_m,
+        num_threads=postprocess_threads,
+        AtomLayoutMdQ=atom_layout_m_dq,
+    )
+    dk_postprocess = FlashAttentionBackwardPostprocess(
+        cute_dtype,
+        head_dim,
+        arch,
+        tile_n,
+        num_threads=postprocess_threads,
+        AtomLayoutMdQ=atom_layout_n_dkv,
+    )
+    dv_postprocess = FlashAttentionBackwardPostprocess(
+        cute_dtype,
+        head_dim_v,
+        arch,
+        tile_n,
+        num_threads=postprocess_threads,
+        AtomLayoutMdQ=atom_layout_n_dkv,
+    )
+    backward = bwd_cls(
+        cute_dtype,
+        head_dim,
+        head_dim_v,
+        qhead_per_kvhead,
+        tile_m,
+        tile_n,
+        num_stages_q,
+        num_stages_do,
+        num_threads,
+        False,
+        True,
+        False,
+        False,
+        False,
+        atom_layout_m_sdp,
+        atom_layout_n_dkv,
+        atom_layout_m_dq,
+        V_in_regs=False,
+        score_mod=None,
+        score_mod_bwd=None,
+    )
+
+    class _Float32ZeroFill:
+        def __init__(self, num_threads: int):
+            self._num_threads = num_threads
+
+        @cute.jit
+        def __call__(self, tensor: cute.Tensor, stream: cuda.CUstream):
+            self.kernel(tensor).launch(
+                grid=[cute.ceil_div(cute.size(tensor), self._num_threads), 1, 1],
+                block=[self._num_threads, 1, 1],
+                stream=stream,
+            )
+
+        @cute.kernel
+        def kernel(self, tensor: cute.Tensor):
+            tidx, _, _ = cute.arch.thread_idx()
+            bidx, _, _ = cute.arch.block_idx()
+            flat = cute.make_tensor(tensor.iterator, cute.make_layout(cute.size(tensor)))
+            idx = bidx * self._num_threads + tidx
+            if idx < cute.size(flat):
+                flat[idx] = cutlass.Float32(0.0)
+
+    zero_fill = _Float32ZeroFill(postprocess_threads)
+
+    @cute.jit
+    def _launch_segmented_flash_attention_backward(
+        stream: cuda.CUstream,
+        q: cute.Tensor,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        out: cute.Tensor,
+        dout: cute.Tensor,
+        lse: cute.Tensor,
+        lower_bounds: cute.Tensor,
+        valid: cute.Tensor,
+        dq: cute.Tensor,
+        dk: cute.Tensor,
+        dv: cute.Tensor,
+        dpsum: cute.Tensor,
+        lse_log2: cute.Tensor,
+        dq_accum: cute.Tensor,
+        dk_accum: cute.Tensor,
+        dv_accum: cute.Tensor,
+        *,
+        softmax_scale: cutlass.Float32,
+    ):
+        preprocess(out, dout, dpsum, lse, lse_log2, dq_accum, None, None, None, stream)
+        zero_fill(dk_accum, stream)
+        zero_fill(dv_accum, stream)
+        backward(
+            q,
+            k,
+            v,
+            dout,
+            lse_log2,
+            dpsum,
+            dq_accum,
+            dk_accum,
+            dv_accum,
+            lower_bounds,
+            valid,
+            softmax_scale,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            stream,
+        )
+        dq_postprocess(dq_accum, dq, softmax_scale, None, None, stream)
+        dk_postprocess(dk_accum, dk, softmax_scale, None, None, stream)
+        dv_postprocess(dv_accum, dv, cutlass.Float32(1.0), None, None, stream)
+
+    return _launch_segmented_flash_attention_backward
+
+
+def segmented_flash_attention_backward_scalar_launcher(
+    modules: Any,
+    *,
+    head_dim: int,
+    head_dim_v: int,
+    qhead_per_kvhead: int,
+    tile_m: int = 128,
+    tile_n: int = 64,
+    num_threads: int = 128,
+) -> Any:
+    """Build the JAX/CUTLASS-callable segmented backward launcher.
+
+    This is a correctness-first scalar CuTe implementation for the narrow Grug
+    target: BF16/FP16, causal packed segments, ``Dv == D``, and no dropout. It
+    recomputes probabilities from ``q/k/lse`` and returns per-query-head dK/dV;
+    the JAX boundary reduces those intermediates across GQA groups.
+    """
+    _validate_config(
+        head_dim=head_dim,
+        head_dim_v=head_dim_v,
+        qhead_per_kvhead=qhead_per_kvhead,
+        tile_m=tile_m,
+        tile_n=tile_n,
+        num_threads=num_threads,
+    )
+    deps = _import_cute_dependencies(modules)
+    cutlass = deps.cutlass
+    cute = deps.cute
+    cuda = deps.cuda
+
+    class SegmentedFlashAttentionBackwardScalar:
+        def __init__(
+            self,
+            *,
+            head_dim: int,
+            qhead_per_kvhead: int,
+        ):
+            self._head_dim = head_dim
+            self._qhead_per_kvhead = qhead_per_kvhead
+
+        @cute.jit
+        def __call__(
+            self,
+            mQ: cute.Tensor,
+            mK: cute.Tensor,
+            mV: cute.Tensor,
+            mO: cute.Tensor,
+            mdO: cute.Tensor,
+            mLSE: cute.Tensor,
+            mLowerBounds: cute.Tensor,
+            mValid: cute.Tensor,
+            mdQ: cute.Tensor,
+            mdKByQHead: cute.Tensor,
+            mdVByQHead: cute.Tensor,
+            softmax_scale: cutlass.Float32,
+            stream: cuda.CUstream,
+        ):
+            if cutlass.const_expr(mQ.element_type != mK.element_type or mQ.element_type != mV.element_type):
+                raise TypeError("q/k/v tensors must have the same element type")
+            if cutlass.const_expr(mO.element_type != mQ.element_type or mdO.element_type != mQ.element_type):
+                raise TypeError("out/dout tensors must have the same element type as q/k/v")
+            if cutlass.const_expr(mdQ.element_type != mQ.element_type):
+                raise TypeError("dQ tensor must have the same element type as q")
+            if cutlass.const_expr(mdKByQHead.element_type != mQ.element_type):
+                raise TypeError("dKByQHead tensor must have the same element type as q")
+            if cutlass.const_expr(mdVByQHead.element_type != mQ.element_type):
+                raise TypeError("dVByQHead tensor must have the same element type as q")
+            if cutlass.const_expr(mLSE.element_type != cutlass.Float32):
+                raise TypeError("LSE tensor must be float32")
+            if cutlass.const_expr(mLowerBounds.element_type != cutlass.Int32):
+                raise TypeError("lower_bounds must be int32")
+            if cutlass.const_expr(mValid.element_type != cutlass.Int32):
+                raise TypeError("valid must be int32")
+            if cutlass.const_expr(mQ.element_type != cutlass.Float16 and mQ.element_type != cutlass.BFloat16):
+                raise TypeError("only Float16 and BFloat16 are supported")
+            if cutlass.const_expr(mQ.shape[1] != self._head_dim or mK.shape[1] != self._head_dim):
+                raise ValueError("q/k head dimension must match head_dim")
+            if cutlass.const_expr(mV.shape[1] != self._head_dim or mO.shape[1] != self._head_dim):
+                raise ValueError("v/o head dimension must match head_dim")
+            if cutlass.const_expr(mQ.shape[2] != mK.shape[2] * self._qhead_per_kvhead):
+                raise ValueError("q heads must equal k/v heads times qhead_per_kvhead")
+            if cutlass.const_expr(mK.shape[2] != mV.shape[2]):
+                raise ValueError("k/v head counts must match")
+            if cutlass.const_expr(mO.shape != mQ.shape or mdO.shape != mQ.shape or mdQ.shape != mQ.shape):
+                raise ValueError("out/dout/dq must have q shape")
+            if cutlass.const_expr(mdKByQHead.shape != mQ.shape or mdVByQHead.shape != mQ.shape):
+                raise ValueError("dKByQHead/dVByQHead must have q shape")
+            if cutlass.const_expr(mLowerBounds.shape[0] != mQ.shape[3] or mLowerBounds.shape[1] != mQ.shape[0]):
+                raise ValueError("lower_bounds must have shape [B, S]")
+            if cutlass.const_expr(mValid.shape[0] != mQ.shape[3] or mValid.shape[1] != mQ.shape[0]):
+                raise ValueError("valid must have shape [B, S]")
+            if cutlass.const_expr(
+                mLSE.shape[0] != mQ.shape[3] or mLSE.shape[1] != mQ.shape[2] or mLSE.shape[2] != mQ.shape[0]
+            ):
+                raise ValueError("LSE must have shape [B, Hq, S]")
+
+            self._dtype = mQ.element_type
+            self.dq_kernel(
+                mQ,
+                mK,
+                mV,
+                mO,
+                mdO,
+                mLSE,
+                mLowerBounds,
+                mValid,
+                mdQ,
+                softmax_scale,
+            ).launch(
+                grid=[mQ.shape[0], mQ.shape[2], mQ.shape[3]],
+                block=[1, 1, 1],
+                stream=stream,
+            )
+            self.dkdv_kernel(
+                mQ,
+                mK,
+                mV,
+                mO,
+                mdO,
+                mLSE,
+                mLowerBounds,
+                mValid,
+                mdKByQHead,
+                mdVByQHead,
+                softmax_scale,
+            ).launch(
+                grid=[mK.shape[0], mQ.shape[2], mQ.shape[3]],
+                block=[1, 1, 1],
+                stream=stream,
+            )
+
+        @cute.kernel
+        def dq_kernel(
+            self,
+            mQ: cute.Tensor,
+            mK: cute.Tensor,
+            mV: cute.Tensor,
+            mO: cute.Tensor,
+            mdO: cute.Tensor,
+            mLSE: cute.Tensor,
+            mLowerBounds: cute.Tensor,
+            mValid: cute.Tensor,
+            mdQ: cute.Tensor,
+            softmax_scale: cutlass.Float32,
+        ):
+            query_idx, q_head, batch_idx = cute.arch.block_idx()
+            kv_head = q_head // self._qhead_per_kvhead
+            q_valid = mValid[batch_idx, query_idx] != 0
+            lower_bound = mLowerBounds[batch_idx, query_idx]
+            softmax_scale_log2 = softmax_scale * cutlass.Float32(math.log2(math.e))
+
+            acc_dq = cute.make_rmem_tensor((self._head_dim,), cutlass.Float32)
+            acc_dq.fill(0.0)
+            if q_valid:
+                row_max = -cutlass.Float32.inf
+                for key_idx in cutlass.range(lower_bound, query_idx + 1, unroll=1):
+                    score = cutlass.Float32(0.0)
+                    for d in cutlass.range_constexpr(self._head_dim):
+                        score += mQ[query_idx, d, q_head, batch_idx].to(cutlass.Float32) * mK[
+                            key_idx, d, kv_head, batch_idx
+                        ].to(cutlass.Float32)
+                    row_max = cute.arch.fmax(row_max, score * softmax_scale_log2)
+                row_sum = cutlass.Float32(0.0)
+                for key_idx in cutlass.range(lower_bound, query_idx + 1, unroll=1):
+                    score = cutlass.Float32(0.0)
+                    for d in cutlass.range_constexpr(self._head_dim):
+                        score += mQ[query_idx, d, q_head, batch_idx].to(cutlass.Float32) * mK[
+                            key_idx, d, kv_head, batch_idx
+                        ].to(cutlass.Float32)
+                    row_sum += cute.math.exp2(score * softmax_scale_log2 - row_max)
+                delta = cutlass.Float32(0.0)
+                for key_idx in cutlass.range(lower_bound, query_idx + 1, unroll=1):
+                    score = cutlass.Float32(0.0)
+                    d_p = cutlass.Float32(0.0)
+                    for d in cutlass.range_constexpr(self._head_dim):
+                        score += mQ[query_idx, d, q_head, batch_idx].to(cutlass.Float32) * mK[
+                            key_idx, d, kv_head, batch_idx
+                        ].to(cutlass.Float32)
+                        d_p += mdO[query_idx, d, q_head, batch_idx].to(cutlass.Float32) * mV[
+                            key_idx, d, kv_head, batch_idx
+                        ].to(cutlass.Float32)
+                    prob = cute.math.exp2(score * softmax_scale_log2 - row_max) * cute.arch.rcp_approx(row_sum)
+                    delta += prob * d_p
+                for key_idx in cutlass.range(lower_bound, query_idx + 1, unroll=1):
+                    score = cutlass.Float32(0.0)
+                    d_p = cutlass.Float32(0.0)
+                    for d in cutlass.range_constexpr(self._head_dim):
+                        score += mQ[query_idx, d, q_head, batch_idx].to(cutlass.Float32) * mK[
+                            key_idx, d, kv_head, batch_idx
+                        ].to(cutlass.Float32)
+                        d_p += mdO[query_idx, d, q_head, batch_idx].to(cutlass.Float32) * mV[
+                            key_idx, d, kv_head, batch_idx
+                        ].to(cutlass.Float32)
+                    prob = cute.math.exp2(score * softmax_scale_log2 - row_max) * cute.arch.rcp_approx(row_sum)
+                    d_s = prob * (d_p - delta) * softmax_scale
+                    for d in cutlass.range_constexpr(self._head_dim):
+                        acc_dq[d] = acc_dq[d] + d_s * mK[key_idx, d, kv_head, batch_idx].to(cutlass.Float32)
+
+            for d in cutlass.range_constexpr(self._head_dim):
+                mdQ[query_idx, d, q_head, batch_idx] = acc_dq[d].to(self._dtype)
+
+        @cute.kernel
+        def dkdv_kernel(
+            self,
+            mQ: cute.Tensor,
+            mK: cute.Tensor,
+            mV: cute.Tensor,
+            mO: cute.Tensor,
+            mdO: cute.Tensor,
+            mLSE: cute.Tensor,
+            mLowerBounds: cute.Tensor,
+            mValid: cute.Tensor,
+            mdKByQHead: cute.Tensor,
+            mdVByQHead: cute.Tensor,
+            softmax_scale: cutlass.Float32,
+        ):
+            key_idx, q_head, batch_idx = cute.arch.block_idx()
+            kv_head = q_head // self._qhead_per_kvhead
+            key_valid = mValid[batch_idx, key_idx] != 0
+
+            acc_dk = cute.make_rmem_tensor((self._head_dim,), cutlass.Float32)
+            acc_dv = cute.make_rmem_tensor((self._head_dim,), cutlass.Float32)
+            acc_dk.fill(0.0)
+            acc_dv.fill(0.0)
+            if key_valid:
+                softmax_scale_log2 = softmax_scale * cutlass.Float32(math.log2(math.e))
+                for query_idx in cutlass.range(0, mQ.shape[0], unroll=1):
+                    query_lower_bound = mLowerBounds[batch_idx, query_idx]
+                    if mValid[batch_idx, query_idx] != 0 and query_idx >= key_idx and query_lower_bound <= key_idx:
+                        if query_lower_bound == query_idx:
+                            for d in cutlass.range_constexpr(self._head_dim):
+                                acc_dv[d] = acc_dv[d] + mdO[query_idx, d, q_head, batch_idx].to(cutlass.Float32)
+                        else:
+                            row_max = -cutlass.Float32.inf
+                            for row_key_idx in cutlass.range(query_lower_bound, query_idx + 1, unroll=1):
+                                row_score = cutlass.Float32(0.0)
+                                for d in cutlass.range_constexpr(self._head_dim):
+                                    row_score += mQ[query_idx, d, q_head, batch_idx].to(cutlass.Float32) * mK[
+                                        row_key_idx, d, kv_head, batch_idx
+                                    ].to(cutlass.Float32)
+                                row_max = cute.arch.fmax(row_max, row_score * softmax_scale_log2)
+                            row_sum = cutlass.Float32(0.0)
+                            for row_key_idx in cutlass.range(query_lower_bound, query_idx + 1, unroll=1):
+                                row_score = cutlass.Float32(0.0)
+                                for d in cutlass.range_constexpr(self._head_dim):
+                                    row_score += mQ[query_idx, d, q_head, batch_idx].to(cutlass.Float32) * mK[
+                                        row_key_idx, d, kv_head, batch_idx
+                                    ].to(cutlass.Float32)
+                                row_sum += cute.math.exp2(row_score * softmax_scale_log2 - row_max)
+                            delta = cutlass.Float32(0.0)
+                            for row_key_idx in cutlass.range(query_lower_bound, query_idx + 1, unroll=1):
+                                row_score = cutlass.Float32(0.0)
+                                row_d_p = cutlass.Float32(0.0)
+                                for d in cutlass.range_constexpr(self._head_dim):
+                                    row_score += mQ[query_idx, d, q_head, batch_idx].to(cutlass.Float32) * mK[
+                                        row_key_idx, d, kv_head, batch_idx
+                                    ].to(cutlass.Float32)
+                                    row_d_p += mdO[query_idx, d, q_head, batch_idx].to(cutlass.Float32) * mV[
+                                        row_key_idx, d, kv_head, batch_idx
+                                    ].to(cutlass.Float32)
+                                row_prob = cute.math.exp2(
+                                    row_score * softmax_scale_log2 - row_max
+                                ) * cute.arch.rcp_approx(row_sum)
+                                delta += row_prob * row_d_p
+                            score = cutlass.Float32(0.0)
+                            d_p = cutlass.Float32(0.0)
+                            for d in cutlass.range_constexpr(self._head_dim):
+                                q_value = mQ[query_idx, d, q_head, batch_idx].to(cutlass.Float32)
+                                k_value = mK[key_idx, d, kv_head, batch_idx].to(cutlass.Float32)
+                                do_value = mdO[query_idx, d, q_head, batch_idx].to(cutlass.Float32)
+                                v_value = mV[key_idx, d, kv_head, batch_idx].to(cutlass.Float32)
+                                score += q_value * k_value
+                                d_p += do_value * v_value
+                            prob = cute.math.exp2(score * softmax_scale_log2 - row_max) * cute.arch.rcp_approx(row_sum)
+                            d_s = prob * (d_p - delta) * softmax_scale
+                            for d in cutlass.range_constexpr(self._head_dim):
+                                acc_dv[d] = acc_dv[d] + prob * mdO[query_idx, d, q_head, batch_idx].to(cutlass.Float32)
+                                acc_dk[d] = acc_dk[d] + d_s * mQ[query_idx, d, q_head, batch_idx].to(cutlass.Float32)
+
+            for d in cutlass.range_constexpr(self._head_dim):
+                mdKByQHead[key_idx, d, q_head, batch_idx] = acc_dk[d].to(self._dtype)
+                mdVByQHead[key_idx, d, q_head, batch_idx] = acc_dv[d].to(self._dtype)
+
+    kernel = SegmentedFlashAttentionBackwardScalar(
+        head_dim=head_dim,
+        qhead_per_kvhead=qhead_per_kvhead,
+    )
+
+    @cute.jit
+    def _launch_segmented_flash_attention_backward(
+        stream: cuda.CUstream,
+        q: cute.Tensor,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        out: cute.Tensor,
+        dout: cute.Tensor,
+        lse: cute.Tensor,
+        lower_bounds: cute.Tensor,
+        valid: cute.Tensor,
+        dq: cute.Tensor,
+        dk_by_q_head: cute.Tensor,
+        dv_by_q_head: cute.Tensor,
+        *,
+        softmax_scale: cutlass.Float32,
+    ):
+        kernel(q, k, v, out, dout, lse, lower_bounds, valid, dq, dk_by_q_head, dv_by_q_head, softmax_scale, stream)
+
+    return _launch_segmented_flash_attention_backward
+
+
+__all__ = [
+    "segmented_flash_attention_backward_launcher",
+    "segmented_flash_attention_backward_scalar_launcher",
+    "segmented_flash_attention_forward_launcher",
+]

--- a/lib/levanter/src/levanter/grug/fa4_cute_segmented_bwd.py
+++ b/lib/levanter/src/levanter/grug/fa4_cute_segmented_bwd.py
@@ -1,0 +1,1603 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# ruff: noqa
+# pyrefly: ignore-errors
+
+"""Segment-aware FA4/CuTe backward kernels adapted from flash-attn-4.
+
+This file is intentionally close to upstream ``flash_attn.cute.flash_bwd``. The
+only behavioral change is applying Grug packed-segment metadata in the score
+mask before exponentiation:
+
+    valid[b, q] and lower_bounds[b, q] <= k <= q
+"""
+
+import math
+from functools import partial
+from types import SimpleNamespace
+from typing import Callable, Optional, Type
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils_basic
+from cutlass import Float32, Int32
+from cutlass.cute.nvgpu import warp
+from flash_attn.cute import ampere_helpers as sm80_utils
+from flash_attn.cute import utils
+from flash_attn.cute.block_sparsity import BlockSparseTensors
+from flash_attn.cute.mask import AttentionMask
+from flash_attn.cute.seqlen_info import SeqlenInfoQK
+from flash_attn.cute.tile_scheduler import SingleTileScheduler, SingleTileVarlenScheduler, TileSchedulerArguments
+from quack import layout_utils
+from quack.cute_dsl_utils import ParamsBase
+
+
+class SegmentedFlashAttentionBackwardSm80:
+    def __init__(
+        self,
+        dtype: Type[cutlass.Numeric],
+        head_dim: int,
+        head_dim_v: Optional[int] = None,
+        qhead_per_kvhead: int = 1,
+        m_block_size: int = 64,
+        n_block_size: int = 128,
+        num_stages_Q: int = 2,
+        num_stages_dO: int = 2,
+        num_threads: int = 256,
+        pack_gqa: bool = False,
+        is_causal: bool = False,
+        SdP_swapAB: bool = False,
+        dKV_swapAB: bool = False,
+        dQ_swapAB: bool = False,
+        AtomLayoutMSdP: int = 1,
+        AtomLayoutNdKV: int = 8,
+        AtomLayoutMdQ: int = 1,
+        V_in_regs: bool = False,
+        score_mod: cutlass.Constexpr | None = None,
+        score_mod_bwd: cutlass.Constexpr | None = None,
+    ):
+        """Initializes the configuration for a flash attention v2 kernel.
+
+        All contiguous dimensions must be at least 16 bytes aligned which indicates the head dimension
+        should be a multiple of 8.
+
+        :param head_dim: head dimension
+        :type head_dim: int
+        :param m_block_size: m block size
+        :type m_block_size: int
+        :param n_block_size: n block size
+        :type n_block_size: int
+        :param num_threads: number of threads
+        :type num_threads: int
+        :param is_causal: is causal
+        """
+        self.dtype = dtype
+        # padding head_dim to a multiple of 32 (stricter than fwd's 16) due to
+        # backward kernel register layout requirements for dQ/dK/dV accumulation
+        hdim_multiple_of = 32
+        self.head_dim_padded = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
+        head_dim_v = head_dim_v if head_dim_v is not None else head_dim
+        self.same_hdim_kv = head_dim == head_dim_v
+        self.head_dim_v_padded = int(math.ceil(head_dim_v / hdim_multiple_of) * hdim_multiple_of)
+        # Can save registers (and hence be faster) if we don't have to check hdim predication
+        self.check_hdim_oob = head_dim != self.head_dim_padded
+        self.check_hdim_v_oob = head_dim_v != self.head_dim_v_padded
+        self.qhead_per_kvhead = qhead_per_kvhead
+        self.m_block_size = m_block_size
+        self.n_block_size = n_block_size
+        self.num_threads = num_threads
+        self.pack_gqa = pack_gqa
+        self.is_causal = is_causal
+        self.num_stages_Q = num_stages_Q
+        self.num_stages_dO = num_stages_dO
+        self.SdP_swapAB = SdP_swapAB
+        self.dKV_swapAB = dKV_swapAB
+        self.dQ_swapAB = dQ_swapAB
+        self.AtomLayoutMSdP = AtomLayoutMSdP
+        self.AtomLayoutNdKV = AtomLayoutNdKV
+        self.AtomLayoutMdQ = AtomLayoutMdQ
+        num_mma_warps = self.num_threads // cute.arch.WARP_SIZE
+        self.Mma_dKV_is_RS = AtomLayoutMSdP == 1 and AtomLayoutNdKV == num_mma_warps and SdP_swapAB and not dKV_swapAB
+        self.V_in_regs = V_in_regs
+        self.share_QV_smem = V_in_regs
+        self.score_mod = score_mod
+        self.score_mod_bwd = score_mod_bwd
+
+    @staticmethod
+    def can_implement(
+        dtype,
+        head_dim,
+        head_dim_v,
+        m_block_size,
+        n_block_size,
+        num_stages_Q,
+        num_stages_dO,
+        num_threads,
+        is_causal,
+        V_in_regs=False,
+    ) -> bool:
+        """Check if the kernel can be implemented with the given parameters.
+
+        :param dtype: data type
+        :type dtype: cutlass.Numeric
+        :param head_dim: head dimension
+        :type head_dim: int
+        :param m_block_size: m block size
+        :type m_block_size: int
+        :param n_block_size: n block size
+        :type n_block_size: int
+        :param num_threads: number of threads
+        :type num_threads: int
+        :param is_causal: is causal
+        :type is_causal: bool
+
+        :return: True if the kernel can be implemented, False otherwise
+        :rtype: bool
+        """
+        if dtype not in [cutlass.Float16, cutlass.BFloat16]:
+            return False
+        if head_dim % 8 != 0:
+            return False
+        if head_dim_v % 8 != 0:
+            return False
+        if n_block_size % 16 != 0:
+            return False
+        if num_threads % 32 != 0:
+            return False
+        # Check if block size setting is out of shared memory capacity
+        # Shared memory usage: Q tile + (K tile + V tile) where K and V use the same tile size
+        smem_usage_Q = m_block_size * head_dim * num_stages_Q * 2
+        smem_usage_dO = m_block_size * head_dim_v * num_stages_dO * 2
+        smem_usage_K = n_block_size * head_dim * 2
+        smem_usage_V = n_block_size * head_dim_v * 2
+        smem_usage_QV = (smem_usage_Q + smem_usage_V) if not V_in_regs else max(smem_usage_Q, smem_usage_V)
+        smem_usage = smem_usage_QV + smem_usage_dO + smem_usage_K
+        smem_capacity = utils_basic.get_smem_capacity_in_bytes("sm_80")
+        if smem_usage > smem_capacity:
+            return False
+        return True
+
+    def _check_type(
+        self,
+        mQ_type: Type[cutlass.Numeric],
+        mK_type: Type[cutlass.Numeric],
+        mV_type: Type[cutlass.Numeric],
+        mdO_type: Type[cutlass.Numeric],
+        mLSE_type: Type[cutlass.Numeric],
+        mdPsum_type: Type[cutlass.Numeric],
+        mdQaccum_type: Type[cutlass.Numeric],
+        mdK_type: Type[cutlass.Numeric],
+        mdV_type: Type[cutlass.Numeric],
+        mCuSeqlensQ_type: Type[cutlass.Numeric] | None,
+        mCuSeqlensK_type: Type[cutlass.Numeric] | None,
+        mSeqUsedQ_type: Type[cutlass.Numeric] | None,
+        mSeqUsedK_type: Type[cutlass.Numeric] | None,
+    ):
+        if cutlass.const_expr(not (mQ_type == mK_type == mV_type == mdO_type)):
+            raise TypeError("All tensors must have the same data type")
+        if cutlass.const_expr(self.qhead_per_kvhead == 1):
+            if cutlass.const_expr(not (mdK_type == mdV_type == mQ_type)):
+                raise TypeError("mdK and mdV tensors must have the same data type as mQ")
+        else:
+            if cutlass.const_expr(not (mdK_type == mdV_type == cutlass.Float32)):
+                raise TypeError("mdKaccum and mdVaccum tensors must have the data type Float32")
+        if cutlass.const_expr(not mQ_type in [cutlass.Float16, cutlass.BFloat16]):
+            raise TypeError("Only Float16 or BFloat16 is supported")
+        if cutlass.const_expr(not mLSE_type in [cutlass.Float32]):
+            raise TypeError("LSE tensor must be Float32")
+        if cutlass.const_expr(not mdPsum_type in [cutlass.Float32]):
+            raise TypeError("dPsum tensor must be Float32")
+        if cutlass.const_expr(not mdQaccum_type in [cutlass.Float32]):
+            raise TypeError("dQaccum tensor must be Float32")
+        if cutlass.const_expr(mCuSeqlensQ_type not in [None, cutlass.Int32]):
+            raise TypeError("cuSeqlensQ tensor must be Int32")
+        if cutlass.const_expr(mCuSeqlensK_type not in [None, cutlass.Int32]):
+            raise TypeError("cuSeqlensK tensor must be Int32")
+        if cutlass.const_expr(mSeqUsedQ_type not in [None, cutlass.Int32]):
+            raise TypeError("SeqUsedQ tensor must be Int32")
+        if cutlass.const_expr(mSeqUsedK_type not in [None, cutlass.Int32]):
+            raise TypeError("SeqUsedK tensor must be Int32")
+        assert mQ_type == self.dtype
+
+    def _setup_attributes(self):
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Shared memory layout: Q/K/V
+        # ///////////////////////////////////////////////////////////////////////////////
+        sQ_layout_atom = sm80_utils.get_smem_layout_atom(self.dtype, self.head_dim_padded)
+        self.sQ_layout = cute.tile_to_shape(
+            sQ_layout_atom,
+            (self.m_block_size, self.head_dim_padded, self.num_stages_Q),
+            (0, 1, 2),
+        )
+        sK_layout_atom = sQ_layout_atom
+        self.sK_layout = cute.tile_to_shape(
+            sK_layout_atom,
+            (self.n_block_size, self.head_dim_padded),
+            (0, 1),
+        )
+        sV_layout_atom = sm80_utils.get_smem_layout_atom(self.dtype, self.head_dim_v_padded)
+        self.sV_layout = cute.tile_to_shape(
+            sV_layout_atom,
+            (self.n_block_size, self.head_dim_v_padded),
+            (0, 1),
+        )
+        sdO_layout_atom = sV_layout_atom
+        self.sdO_layout = cute.tile_to_shape(
+            sdO_layout_atom,
+            (self.m_block_size, self.head_dim_v_padded, self.num_stages_dO),
+            (0, 1, 2),
+        )
+        # TODO: do we set swizzle to be 3 here explicitly?
+        sPdS_layout_atom = sm80_utils.get_smem_layout_atom(self.dtype, self.n_block_size)
+        self.sPdS_layout = cute.tile_to_shape(
+            sPdS_layout_atom,
+            (self.m_block_size, self.n_block_size),
+            (0, 1),
+        )
+        # We set stride to be multiple of 64 so that if ShuffleLSE, even if threads read from sLSE but out of bounds,
+        # it's still a valid smem address.
+        self.sLSE_layout = cute.make_layout(
+            (self.m_block_size, self.num_stages_Q),
+            stride=(1, cute.round_up(self.m_block_size, 64)),
+        )
+        sLSEMma_layout = cute.make_layout(
+            (self.m_block_size, self.n_block_size, self.num_stages_Q),
+            stride=(1, 0, cute.round_up(self.m_block_size, 64)),
+        )
+        sLSEMma_layout_transposed = cute.make_layout(
+            (self.n_block_size, self.m_block_size, self.num_stages_Q),
+            stride=(0, 1, cute.round_up(self.m_block_size, 64)),
+        )
+        self.sLSEMma_layout = sLSEMma_layout if not self.SdP_swapAB else sLSEMma_layout_transposed
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # GMEM Tiled copy:
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Thread layouts for copies
+        universal_copy_bits = 128
+        async_copy_elems = universal_copy_bits // self.dtype.width
+        # JAX cutlass_call currently presents nested-kernel operands as generic
+        # memrefs. Universal copies accept that address space; cp.async requires
+        # a global memref and fails verifier checks on GB10.
+        atom_async_copy = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            self.dtype,
+            num_bits_per_copy=universal_copy_bits,
+        )
+        # atom_universal_copy: universal copy atom for O store
+        atom_universal_copy = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            self.dtype,
+            num_bits_per_copy=universal_copy_bits,
+        )
+        # tQK_layout: thread layout for QK load
+        tQK_shape_dim_1 = sQ_layout_atom.outer.shape[1] // async_copy_elems
+        assert self.num_threads % tQK_shape_dim_1 == 0, "num_threads must be divisible by tQK_shape_dim_1"
+        tQK_layout = cute.make_ordered_layout(
+            (self.num_threads // tQK_shape_dim_1, tQK_shape_dim_1),
+            order=(1, 0),
+        )
+        # Do we need to check if we overshot kBlockM when we load Q?
+        self.is_even_m_smem_q = self.m_block_size % tQK_layout.shape[0] == 0
+        # Do we need to check if we overshot kBlockN when we load K?
+        self.is_even_n_smem_k = self.n_block_size % tQK_layout.shape[0] == 0
+        tVdO_shape_dim_1 = sV_layout_atom.outer.shape[1] // async_copy_elems
+        assert self.num_threads % tVdO_shape_dim_1 == 0, "num_threads must be divisible by tVdO_shape_dim_1"
+        tVdO_layout = cute.make_ordered_layout(
+            (self.num_threads // tVdO_shape_dim_1, tVdO_shape_dim_1),
+            order=(1, 0),
+        )
+        # Do we need to check if we overshot kBlockN when we load V?
+        self.is_even_n_smem_v = self.n_block_size % tVdO_layout.shape[0] == 0
+        self.is_even_m_smem_do = self.m_block_size % tVdO_layout.shape[0] == 0
+
+        # Value layouts for copies
+        vQKVdO_layout = cute.make_layout((1, async_copy_elems))
+
+        # gmem_tiled_copy_QK: tiled copy for QK load
+        self.gmem_tiled_copy_QK = cute.make_tiled_copy_tv(atom_async_copy, tQK_layout, vQKVdO_layout)
+        self.gmem_tiled_copy_VdO = cute.make_tiled_copy_tv(atom_async_copy, tVdO_layout, vQKVdO_layout)
+        self.gmem_tiled_copy_dK = cute.make_tiled_copy_tv(atom_universal_copy, tQK_layout, vQKVdO_layout)
+        self.gmem_tiled_copy_dV = cute.make_tiled_copy_tv(atom_universal_copy, tVdO_layout, vQKVdO_layout)
+        async_copy_elems_accum = universal_copy_bits // cutlass.Float32.width
+
+        # I think we wouldn't require this with smarter padding
+        if cutlass.const_expr(not self.varlen_q):
+            async_copy_elems_accum = universal_copy_bits // cutlass.Float32.width
+            atom_async_copy_accum = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                cutlass.Float32,
+                num_bits_per_copy=universal_copy_bits,
+            )
+        else:
+            async_copy_elems_accum = 1
+            atom_async_copy_accum = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                cutlass.Float32,
+                num_bits_per_copy=cutlass.Float32.width,
+            )
+        self.gmem_tiled_copy_LSE = cute.make_tiled_copy_tv(
+            atom_async_copy_accum,
+            cute.make_layout(self.num_threads),
+            cute.make_layout(async_copy_elems_accum),
+        )
+        self.gmem_tiled_copy_dQaccum = cute.make_tiled_copy_tv(
+            cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(), cutlass.Float32, num_bits_per_copy=cutlass.Float32.width
+            ),
+            cute.make_layout(self.num_threads),
+            cute.make_layout(1),
+        )
+        if cutlass.const_expr(self.qhead_per_kvhead > 1):
+            self.gmem_tiled_copy_dK = self.gmem_tiled_copy_dQaccum
+            self.gmem_tiled_copy_dV = self.gmem_tiled_copy_dQaccum
+
+    def _get_tiled_mma(self):
+        num_mma_warps = self.num_threads // 32
+        AtomLayoutSdP = (
+            (self.AtomLayoutMSdP, num_mma_warps // self.AtomLayoutMSdP, 1)
+            if cutlass.const_expr(not self.SdP_swapAB)
+            else (num_mma_warps // self.AtomLayoutMSdP, self.AtomLayoutMSdP, 1)
+        )
+        tiled_mma_sdp = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(self.dtype, cutlass.Float32, (16, 8, 16)),
+            AtomLayoutSdP,
+            permutation_mnk=(AtomLayoutSdP[0] * 16, AtomLayoutSdP[1] * 16, 16),
+        )
+        AtomLayoutdKV = (
+            (self.AtomLayoutNdKV, num_mma_warps // self.AtomLayoutNdKV, 1)
+            if cutlass.const_expr(not self.dKV_swapAB)
+            else (num_mma_warps // self.AtomLayoutNdKV, self.AtomLayoutNdKV, 1)
+        )
+        tiled_mma_dkv = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(self.dtype, cutlass.Float32, (16, 8, 16)),
+            AtomLayoutdKV,
+            permutation_mnk=(AtomLayoutdKV[0] * 16, AtomLayoutdKV[1] * 16, 16),
+        )
+        AtomLayoutdQ = (
+            (self.AtomLayoutMdQ, num_mma_warps // self.AtomLayoutMdQ, 1)
+            if cutlass.const_expr(not self.dQ_swapAB)
+            else (num_mma_warps // self.AtomLayoutMdQ, self.AtomLayoutMdQ, 1)
+        )
+        tiled_mma_dq = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(self.dtype, cutlass.Float32, (16, 8, 16)),
+            AtomLayoutdQ,
+            permutation_mnk=(AtomLayoutdQ[0] * 16, AtomLayoutdQ[1] * 16, 16),
+        )
+        return tiled_mma_sdp, tiled_mma_dkv, tiled_mma_dq
+
+    def _get_shared_storage_cls(self):
+        sQ_struct, sK_struct, sV_struct, sdO_struct = [
+            cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(layout)], 1024]
+            for layout in (self.sQ_layout, self.sK_layout, self.sV_layout, self.sdO_layout)
+        ]
+        cosize_sQV = max(cute.cosize(self.sQ_layout), cute.cosize(self.sV_layout))
+        sQV_struct = cute.struct.Align[cute.struct.MemRange[self.dtype, cosize_sQV], 1024]
+        sLSE_struct, sdPsum_struct = [
+            cute.struct.Align[cute.struct.MemRange[cutlass.Float32, cute.cosize(layout)], 128]
+            for layout in (self.sLSE_layout, self.sLSE_layout)
+        ]
+        sP_struct, sdS_struct = [
+            cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(layout)], 128]
+            for layout in (self.sPdS_layout, self.sPdS_layout)
+        ]
+
+        @cute.struct
+        class SharedStorageSeparateQV:
+            sK: sK_struct
+            sV: sV_struct
+            sQ: sQ_struct
+            sdO: sdO_struct
+            sLSE: sLSE_struct
+            sdPsum: sdPsum_struct
+            sP: sP_struct
+            sdS: sdS_struct
+            # TODO: the case where there's no sP
+
+        @cute.struct
+        class SharedStorageSharedQV:
+            sK: sK_struct
+            sV: sV_struct
+            sQ: sQV_struct
+            sdO: sdO_struct
+            sLSE: sLSE_struct
+            sdPsum: sdPsum_struct
+            sP: sP_struct
+            sdS: sdS_struct
+
+        return SharedStorageSeparateQV if cutlass.const_expr(not self.share_QV_smem) else SharedStorageSharedQV
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mdO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mdPsum: cute.Tensor,
+        mdQaccum: cute.Tensor,
+        mdK: cute.Tensor,
+        mdV: cute.Tensor,
+        mLowerBounds: cute.Tensor,
+        mValid: cute.Tensor,
+        softmax_scale: cutlass.Float32,
+        mCuSeqlensQ: Optional[cute.Tensor] = None,
+        mCuSeqlensK: Optional[cute.Tensor] = None,
+        mSeqUsedQ: Optional[cute.Tensor] = None,
+        mSeqUsedK: Optional[cute.Tensor] = None,
+        window_size_left: Int32 | int | None = None,
+        window_size_right: Int32 | int | None = None,
+        mdQ_semaphore: Optional[cute.Tensor] = None,
+        mdK_semaphore: Optional[cute.Tensor] = None,
+        mdV_semaphore: Optional[cute.Tensor] = None,
+        aux_tensors: Optional[list] = None,
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
+        stream: cuda.CUstream = None,
+    ):
+        assert (
+            mdQ_semaphore is None and mdK_semaphore is None and mdV_semaphore is None
+        ), "determinism not supported yet for Sm80"
+        # Get the data type and check if it is fp16 or bf16
+        self._check_type(
+            *(
+                t.element_type if t is not None else None
+                for t in (
+                    mQ,
+                    mK,
+                    mV,
+                    mdO,
+                    mLSE,
+                    mdPsum,
+                    mdQaccum,
+                    mdK,
+                    mdV,
+                    mCuSeqlensQ,
+                    mCuSeqlensK,
+                    mSeqUsedQ,
+                    mSeqUsedK,
+                )
+            )
+        )
+        if cutlass.const_expr(mLowerBounds.element_type != cutlass.Int32):
+            raise TypeError("lower_bounds tensor must be Int32")
+        if cutlass.const_expr(mValid.element_type != cutlass.Int32):
+            raise TypeError("valid tensor must be Int32")
+        if cutlass.const_expr(mCuSeqlensQ is not None or mCuSeqlensK is not None):
+            raise NotImplementedError("segmented Grug backward supports only dense BSHD tensors")
+        if cutlass.const_expr(mLowerBounds.shape[0] != mQ.shape[0] or mLowerBounds.shape[1] != mQ.shape[1]):
+            raise ValueError("lower_bounds must have shape [B, S]")
+        if cutlass.const_expr(mValid.shape[0] != mQ.shape[0] or mValid.shape[1] != mQ.shape[1]):
+            raise ValueError("valid must have shape [B, S]")
+        self.varlen_q = mCuSeqlensQ is not None
+        self._setup_attributes()
+        SharedStorage = self._get_shared_storage_cls()
+        tiled_mma_sdp, tiled_mma_dkv, tiled_mma_dq = self._get_tiled_mma()
+
+        num_head = mQ.shape[1] if cutlass.const_expr(mCuSeqlensQ is not None) else mQ.shape[2]
+
+        if cutlass.const_expr(mCuSeqlensK is not None):
+            TileScheduler = SingleTileVarlenScheduler
+            num_batch = mCuSeqlensK.shape[0] - 1
+        else:
+            TileScheduler = SingleTileScheduler
+            num_batch = mK.shape[0]
+
+        # Uses seqlen k, etc. since main bwd kernel's blocks are over n
+        tile_sched_args = TileSchedulerArguments(
+            num_block=cute.ceil_div(mK.shape[1], self.n_block_size),
+            num_head=num_head,
+            num_batch=num_batch,
+            num_splits=1,
+            seqlen_k=0,
+            headdim=mK.shape[2],
+            headdim_v=mV.shape[2],
+            total_q=mK.shape[0],
+            tile_shape_mn=(self.n_block_size, self.m_block_size),
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if cutlass.const_expr(self.pack_gqa) else 1,
+            mCuSeqlensQ=mCuSeqlensK,
+            mSeqUsedQ=mSeqUsedK,
+        )
+
+        tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
+        grid_dim = TileScheduler.get_grid_shape(tile_sched_params)
+
+        softmax_scale_log2, score_mod_softmax_scale = utils.compute_softmax_scale_log2(softmax_scale, self.score_mod)
+        if cutlass.const_expr(self.score_mod is not None):
+            softmax_scale = score_mod_softmax_scale
+        self.kernel(
+            mQ,
+            mK,
+            mV,
+            mdO,
+            mLSE,
+            mdPsum,
+            mdQaccum,
+            mdK,
+            mdV,
+            mLowerBounds,
+            mValid,
+            mCuSeqlensQ,
+            mCuSeqlensK,
+            mSeqUsedQ,
+            mSeqUsedK,
+            softmax_scale,
+            softmax_scale_log2,
+            self.sQ_layout,
+            self.sK_layout,
+            self.sV_layout,
+            self.sdO_layout,
+            self.sPdS_layout,
+            self.sLSE_layout,
+            self.sLSEMma_layout,
+            self.gmem_tiled_copy_QK,
+            self.gmem_tiled_copy_VdO,
+            self.gmem_tiled_copy_dK,
+            self.gmem_tiled_copy_dV,
+            self.gmem_tiled_copy_LSE,
+            self.gmem_tiled_copy_dQaccum,
+            tiled_mma_sdp,
+            tiled_mma_dkv,
+            tiled_mma_dq,
+            SharedStorage,
+            tile_sched_params,
+            TileScheduler,
+        ).launch(
+            grid=grid_dim,
+            block=[self.num_threads, 1, 1],
+            smem=SharedStorage.size_in_bytes(),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mdO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mdPsum: cute.Tensor,
+        mdQaccum: cute.Tensor,
+        mdK: cute.Tensor,
+        mdV: cute.Tensor,
+        mLowerBounds: cute.Tensor,
+        mValid: cute.Tensor,
+        mCuSeqlensQ: Optional[cute.Tensor],
+        mCuSeqlensK: Optional[cute.Tensor],
+        mSeqUsedQ: Optional[cute.Tensor],
+        mSeqUsedK: Optional[cute.Tensor],
+        softmax_scale: cutlass.Float32,
+        softmax_scale_log2: cutlass.Float32,
+        sQ_layout: cute.ComposedLayout,
+        sK_layout: cute.ComposedLayout,
+        sV_layout: cute.ComposedLayout,
+        sdO_layout: cute.ComposedLayout,
+        sPdS_layout: cute.ComposedLayout,
+        sLSE_layout: cute.Layout,
+        sLSEMma_layout: cute.Layout,
+        gmem_tiled_copy_QK: cute.TiledCopy,
+        gmem_tiled_copy_VdO: cute.TiledCopy,
+        gmem_tiled_copy_dK: cute.TiledCopy,
+        gmem_tiled_copy_dV: cute.TiledCopy,
+        gmem_tiled_copy_LSE: cute.TiledCopy,
+        gmem_tiled_copy_dQaccum: cute.TiledCopy,
+        tiled_mma_sdp: cute.TiledMma,
+        tiled_mma_dkv: cute.TiledMma,
+        tiled_mma_dq: cute.TiledMma,
+        SharedStorage: cutlass.Constexpr,
+        tile_sched_params: ParamsBase,
+        TileScheduler: cutlass.Constexpr[Callable],
+    ):
+        # Thread index, block index
+        tidx, _, _ = cute.arch.thread_idx()
+
+        tile_scheduler = TileScheduler.create(tile_sched_params)
+        work_tile = tile_scheduler.initial_work_tile_info()
+
+        n_block, head_idx, batch_idx, _ = work_tile.tile_idx
+
+        if work_tile.is_valid_tile:
+            seqlen = SeqlenInfoQK.create(
+                batch_idx,
+                mQ.shape[1],
+                mK.shape[1],
+                mCuSeqlensQ=mCuSeqlensQ,
+                mCuSeqlensK=mCuSeqlensK,
+                mSeqUsedQ=mSeqUsedQ,
+                mSeqUsedK=mSeqUsedK,
+                tile_m=self.m_block_size,
+                tile_n=self.n_block_size,
+            )
+
+            m_block_max = cute.ceil_div(seqlen.seqlen_q, self.m_block_size)
+            m_block_min = 0
+            if cutlass.const_expr(self.is_causal):
+                m_block_min = max(
+                    (n_block * self.n_block_size + seqlen.seqlen_q - seqlen.seqlen_k) // self.m_block_size,
+                    m_block_min,
+                )
+            m_block_max = self.segment_m_block_max(mLowerBounds, batch_idx, n_block, m_block_min, m_block_max, seqlen)
+            # TODO: return early if m_block_max == 0
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Get the appropriate tiles for this thread block.
+            # ///////////////////////////////////////////////////////////////////////////////
+            blkQ_shape = (self.m_block_size, self.head_dim_padded)
+            blkK_shape = (self.n_block_size, self.head_dim_padded)
+            blkV_shape = (self.n_block_size, self.head_dim_v_padded)
+            blkdO_shape = (self.m_block_size, self.head_dim_v_padded)
+
+            if cutlass.const_expr(not seqlen.has_cu_seqlens_q):
+                mQ_cur = mQ[batch_idx, None, head_idx, None]
+                mLSE_cur = mLSE[batch_idx, head_idx, None]
+                mdO_cur = mdO[batch_idx, None, head_idx, None]
+                mdPsum_cur = mdPsum[batch_idx, head_idx, None]
+                mdQaccum_cur = mdQaccum[batch_idx, head_idx, None]
+            else:
+                padded_offset_q = seqlen.padded_offset_q
+                mQ_cur = cute.domain_offset((seqlen.offset_q, 0), mQ[None, head_idx, None])
+                mLSE_cur = cute.domain_offset((padded_offset_q,), mLSE[head_idx, None])
+                mdO_cur = cute.domain_offset((seqlen.offset_q, 0), mdO[None, head_idx, None])
+                mdPsum_cur = cute.domain_offset((padded_offset_q,), mdPsum[head_idx, None])
+                mdQaccum_cur = cute.domain_offset((padded_offset_q * self.head_dim_padded,), mdQaccum[head_idx, None])
+            head_idx_kv = head_idx // self.qhead_per_kvhead if cutlass.const_expr(not self.pack_gqa) else head_idx
+
+            if cutlass.const_expr(not seqlen.has_cu_seqlens_k):
+                mK_cur, mV_cur = [t[batch_idx, None, head_idx_kv, None] for t in (mK, mV)]
+            else:
+                mK_cur, mV_cur = [
+                    cute.domain_offset((seqlen.offset_k, 0), t[None, head_idx_kv, None]) for t in (mK, mV)
+                ]
+
+            # (m_block_size, head_dim, m_block)
+            gQ = cute.local_tile(mQ_cur, blkQ_shape, (None, 0))
+            # (n_block_size, head_dim)
+            gK = cute.local_tile(mK_cur, blkK_shape, (n_block, 0))
+            # (n_block_size, head_dim_v)
+            gV = cute.local_tile(mV_cur, blkV_shape, (n_block, 0))
+            # (m_block_size, head_dim_v, m_block)
+            gdO = cute.local_tile(mdO_cur, blkdO_shape, (None, 0))
+            gLSE = cute.local_tile(mLSE_cur, (self.m_block_size,), (None,))
+            gdPsum = cute.local_tile(mdPsum_cur, (self.m_block_size,), (None,))
+            gdQaccum = cute.local_tile(mdQaccum_cur, (self.m_block_size * self.head_dim_padded,), (None,))
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Get shared memory buffer
+            # ///////////////////////////////////////////////////////////////////////////////
+            smem = cutlass.utils.SmemAllocator()
+            storage = smem.allocate(SharedStorage)
+            sQ = storage.sQ.get_tensor(sQ_layout)
+            sK = storage.sK.get_tensor(sK_layout)
+            if cutlass.const_expr(not self.share_QV_smem):
+                sV = storage.sV.get_tensor(sV_layout)
+            else:
+                sV = cute.make_tensor(cute.recast_ptr(sQ.iterator, dtype=self.dtype), sV_layout)
+            sdO = storage.sdO.get_tensor(sdO_layout)
+            sP = storage.sP.get_tensor(sPdS_layout)
+            sdS = storage.sdS.get_tensor(sPdS_layout)
+            sLSE = storage.sLSE.get_tensor(sLSE_layout)
+            sdPsum = storage.sdPsum.get_tensor(sLSE_layout)
+            sLSEMma = storage.sLSE.get_tensor(sLSEMma_layout)
+            sdPsumMma = storage.sdPsum.get_tensor(sLSEMma_layout)
+
+            # Transpose view of tensors for tiled mma
+            sQt, sdOt, sKt, sPt, sdSt = [layout_utils.transpose_view(t) for t in (sQ, sdO, sK, sP, sdS)]
+
+            gmem_thr_copy_QK = gmem_tiled_copy_QK.get_slice(tidx)
+            gmem_thr_copy_VdO = gmem_tiled_copy_VdO.get_slice(tidx)
+            gmem_thr_copy_lse = gmem_tiled_copy_LSE.get_slice(tidx)
+            gmem_thr_copy_dQaccum = gmem_tiled_copy_dQaccum.get_slice(tidx)
+            # (CPY_Atom, CPY_M, CPY_K, m_block)
+            tQgQ = gmem_thr_copy_QK.partition_S(gQ)
+            tQsQ = gmem_thr_copy_QK.partition_D(sQ)
+            # (CPY_Atom, CPY_N, CPY_K)
+            tKgK = gmem_thr_copy_QK.partition_S(gK)
+            tKsK = gmem_thr_copy_QK.partition_D(sK)
+            # (CPY_Atom, CPY_N, CPY_K)
+            tVgV = gmem_thr_copy_VdO.partition_S(gV)
+            tVsV = gmem_thr_copy_VdO.partition_D(sV)
+            # (CPY_Atom, CPY_M, CPY_K, m_block)
+            tdOgdO = gmem_thr_copy_VdO.partition_S(gdO)
+            tdOsdO = gmem_thr_copy_VdO.partition_D(sdO)
+            tLSEgLSE = gmem_thr_copy_lse.partition_S(gLSE)
+            tLSEsLSE = gmem_thr_copy_lse.partition_D(sLSE)
+            tLSEgdPsum = gmem_thr_copy_lse.partition_S(gdPsum)
+            tLSEsdPsum = gmem_thr_copy_lse.partition_D(sdPsum)
+            tdQgdQaccum = gmem_thr_copy_dQaccum.partition_S(gdQaccum)
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Tile MMA compute thread partitions and allocate accumulators
+            # ///////////////////////////////////////////////////////////////////////////////
+            thr_mma_sdp = tiled_mma_sdp.get_slice(tidx)
+            thr_mma_dkv = tiled_mma_dkv.get_slice(tidx)
+            thr_mma_dq = tiled_mma_dq.get_slice(tidx)
+            acc_shape_dK = thr_mma_dkv.partition_shape_C((self.n_block_size, self.head_dim_padded))
+            acc_shape_dV = thr_mma_dkv.partition_shape_C((self.n_block_size, self.head_dim_v_padded))
+            acc_dK = cute.make_fragment(acc_shape_dK, cutlass.Float32)
+            acc_dV = cute.make_fragment(acc_shape_dV, cutlass.Float32)
+            acc_dK.fill(0.0)
+            acc_dV.fill(0.0)
+
+            tSrQ = utils.mma_make_fragment_A(sQ[None, None, 0], thr_mma_sdp, swapAB=self.SdP_swapAB)
+            tSrK = utils.mma_make_fragment_B(sK, thr_mma_sdp, swapAB=self.SdP_swapAB)
+            tdPrdO = utils.mma_make_fragment_A(sdO[None, None, 0], thr_mma_sdp, swapAB=self.SdP_swapAB)
+            tdPrV = utils.mma_make_fragment_B(sV, thr_mma_sdp, swapAB=self.SdP_swapAB)
+            tdVrP = utils.mma_make_fragment_A(sPt, thr_mma_dkv, swapAB=self.dKV_swapAB)
+            tdVrdO = utils.mma_make_fragment_B(sdOt[None, None, 0], thr_mma_dkv, swapAB=self.dKV_swapAB)
+            tdKrdS = utils.mma_make_fragment_A(sdSt, thr_mma_dkv, swapAB=self.dKV_swapAB)
+            tdKrQ = utils.mma_make_fragment_B(sQt[None, None, 0], thr_mma_dkv, swapAB=self.dKV_swapAB)
+            tdQrdS = utils.mma_make_fragment_A(sdS, thr_mma_dq, swapAB=self.dQ_swapAB)
+            tdQrK = utils.mma_make_fragment_B(sKt, thr_mma_dq, swapAB=self.dQ_swapAB)
+
+            LSEslice = (None, 0, None) if cutlass.const_expr(not self.SdP_swapAB) else (0, None, None)
+            tSsLSEMma = layout_utils.reshape_acc_to_mn(thr_mma_sdp.partition_C(sLSEMma))[LSEslice]
+            tSsdPsumMma = layout_utils.reshape_acc_to_mn(thr_mma_sdp.partition_C(sdPsumMma))[LSEslice]
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Smem copy atom tiling
+            # ///////////////////////////////////////////////////////////////////////////////
+            smem_copy_atom = cute.make_copy_atom(
+                warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4),
+                self.dtype,
+            )
+            smem_copy_atom_transposed = cute.make_copy_atom(
+                warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=4),
+                self.dtype,
+            )
+            smem_thr_copy_QdO = utils.make_tiled_copy_A(
+                smem_copy_atom, tiled_mma_sdp, swapAB=self.SdP_swapAB
+            ).get_slice(tidx)
+            smem_thr_copy_KV = utils.make_tiled_copy_B(
+                smem_copy_atom, tiled_mma_sdp, swapAB=self.SdP_swapAB
+            ).get_slice(tidx)
+            # TODO: should this be smem_copy_atom_transposed?
+            smem_thr_copy_PdSt = utils.make_tiled_copy_A(
+                smem_copy_atom_transposed, tiled_mma_dkv, swapAB=self.dKV_swapAB
+            ).get_slice(tidx)
+            smem_thr_copy_QdOt = utils.make_tiled_copy_B(
+                smem_copy_atom_transposed, tiled_mma_dkv, swapAB=self.dKV_swapAB
+            ).get_slice(tidx)
+            smem_thr_copy_dS = utils.make_tiled_copy_A(smem_copy_atom, tiled_mma_dq, swapAB=self.dQ_swapAB).get_slice(
+                tidx
+            )
+            smem_thr_copy_Kt = utils.make_tiled_copy_B(
+                smem_copy_atom_transposed, tiled_mma_dq, swapAB=self.dQ_swapAB
+            ).get_slice(tidx)
+            # TODO: what's the number of bits? What if SdP_swapAB
+            r2s_thr_copy_PdS = cute.make_tiled_copy_C(
+                cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.dtype, num_bits_per_copy=2 * self.dtype.width),
+                tiled_mma_sdp,
+            ).get_slice(tidx)
+
+            tSsQ = smem_thr_copy_QdO.partition_S(sQ)
+            tdPsdO = smem_thr_copy_QdO.partition_S(sdO)
+            tSsK = smem_thr_copy_KV.partition_S(sK)
+            tdPsV = smem_thr_copy_KV.partition_S(sV)
+            tdVsPt = smem_thr_copy_PdSt.partition_S(sPt)
+            tdKsdSt = smem_thr_copy_PdSt.partition_S(sdSt)
+            tdVsdOt = smem_thr_copy_QdOt.partition_S(sdOt)
+            tdKsQt = smem_thr_copy_QdOt.partition_S(sQt)
+            tdQsdS = smem_thr_copy_dS.partition_S(sdS)
+            tdQsKt = smem_thr_copy_Kt.partition_S(sKt)
+            tPsP = r2s_thr_copy_PdS.partition_D(sP)
+            tdSsdS = r2s_thr_copy_PdS.partition_D(sdS)
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Predicate: Mark indices that need to copy when problem_shape isn't a multiple
+            # of tile_shape
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Construct identity layout for KV
+            cQ = cute.make_identity_tensor((self.m_block_size, self.head_dim_padded))
+            tQcQ = gmem_thr_copy_QK.partition_S(cQ)
+            t0QcQ = gmem_thr_copy_QK.get_slice(0).partition_S(cQ)
+            if cutlass.const_expr(self.head_dim_padded == self.head_dim_v_padded):
+                tdOcdO = tQcQ
+                t0dOcdO = t0QcQ
+            else:
+                cdO = cute.make_identity_tensor((self.m_block_size, self.head_dim_v_padded))
+                tdOcdO = gmem_thr_copy_VdO.partition_S(cdO)
+                t0dOcdO = gmem_thr_copy_VdO.get_slice(0).partition_S(cdO)
+            cLSE = cute.make_identity_tensor((self.m_block_size,))
+            tLSEcLSE = gmem_thr_copy_lse.partition_S(cLSE)
+
+            # Allocate predicate tensors for m and n, here we only allocate the tile of k, and
+            # use "if" on the mn dimension.
+            # This is to reduce register pressure and gets 2-3% performance gain.
+
+            d_head = mQ.shape[cute.rank(mQ) - 1]
+            d_head_v = mdO.shape[cute.rank(mdO) - 1]
+
+            tQpQ = utils.predicate_k(tQcQ, limit=d_head)
+            if cutlass.const_expr(self.same_hdim_kv):
+                tdOpdO = tQpQ
+            else:
+                tdOpdO = utils.predicate_k(tdOcdO, limit=d_head_v)
+
+            # group parameters for compute_one_m_block
+            mma_params = SimpleNamespace(
+                thr_mma_sdp=thr_mma_sdp,
+                thr_mma_dkv=thr_mma_dkv,
+                thr_mma_dq=thr_mma_dq,
+                tSrQ=tSrQ,
+                tSrK=tSrK,
+                tdPrdO=tdPrdO,
+                tdPrV=tdPrV,
+                tdVrP=tdVrP,
+                tdVrdO=tdVrdO,
+                tdKrdS=tdKrdS,
+                tdKrQ=tdKrQ,
+                tdQrdS=tdQrdS,
+                tdQrK=tdQrK,
+                acc_dK=acc_dK,
+                acc_dV=acc_dV,
+            )
+            smem_copy_params = SimpleNamespace(
+                smem_thr_copy_QdO=smem_thr_copy_QdO,
+                smem_thr_copy_KV=smem_thr_copy_KV,
+                smem_thr_copy_PdSt=smem_thr_copy_PdSt,
+                smem_thr_copy_QdOt=smem_thr_copy_QdOt,
+                smem_thr_copy_dS=smem_thr_copy_dS,
+                smem_thr_copy_Kt=smem_thr_copy_Kt,
+                r2s_thr_copy_PdS=r2s_thr_copy_PdS,
+                tSsQ=tSsQ,
+                tSsK=tSsK,
+                tdPsdO=tdPsdO,
+                tdPsV=tdPsV,
+                tSsLSEMma=tSsLSEMma,
+                tSsdPsumMma=tSsdPsumMma,
+                tPsP=tPsP,
+                tdSsdS=tdSsdS,
+                tdVsPt=tdVsPt,
+                tdVsdOt=tdVsdOt,
+                tdKsdSt=tdKsdSt,
+                tdKsQt=tdKsQt,
+                tdQsdS=tdQsdS,
+                tdQsKt=tdQsKt,
+            )
+            gmem_copy_params = SimpleNamespace(gmem_thr_copy_dQaccum=gmem_thr_copy_dQaccum, tdQgdQaccum=tdQgdQaccum)
+            load_Q_LSE = partial(
+                self.load_Q_LSE,
+                gmem_tiled_copy_QK,
+                gmem_tiled_copy_LSE,
+                tQgQ,
+                tQsQ,
+                tQcQ,
+                t0QcQ,
+                tQpQ,
+                tLSEgLSE,
+                tLSEsLSE,
+                tLSEcLSE,
+                seqlen=seqlen.seqlen_q,
+            )
+            load_dO_dPsum = partial(
+                self.load_dO_dPsum,
+                gmem_tiled_copy_VdO,
+                gmem_tiled_copy_LSE,
+                tdOgdO,
+                tdOsdO,
+                tdOcdO,
+                t0dOcdO,
+                tdOpdO,
+                tLSEgdPsum,
+                tLSEsdPsum,
+                tLSEcLSE,
+                seqlen=seqlen.seqlen_q,
+            )
+            compute_one_m_block = partial(
+                self.compute_one_m_block,
+                mma_params=mma_params,
+                smem_copy_params=smem_copy_params,
+                gmem_copy_params=gmem_copy_params,
+                load_Q_LSE=load_Q_LSE,
+                load_dO_dPsum=load_dO_dPsum,
+                m_block_max=m_block_max,
+                softmax_scale=softmax_scale,
+                softmax_scale_log2=softmax_scale_log2,
+            )
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Prologue
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Start async loads of the last mn-tile, where we take care of the mn residue
+            self.load_V(gmem_thr_copy_VdO, tVgV, tVsV, n_block, seqlen=seqlen.seqlen_k, headdim=d_head_v)
+            if cutlass.const_expr(self.V_in_regs):
+                cute.arch.cp_async_commit_group()
+            self.load_K(gmem_thr_copy_QK, tKgK, tKsK, n_block, seqlen=seqlen.seqlen_k, headdim=d_head)
+            cute.arch.cp_async_commit_group()
+
+            if cutlass.const_expr(self.V_in_regs):
+                cute.arch.cp_async_wait_group(1)
+                cute.arch.barrier()
+                tdPrV_copy_view = smem_thr_copy_KV.retile(tdPrV)
+                cute.copy(smem_thr_copy_KV, tdPsV, tdPrV_copy_view)
+                # Sync to avoid loading Q to smem_q, which overlaps with smem_v
+                cute.arch.barrier()
+
+            m_block = m_block_min
+            assert self.num_stages_Q >= self.num_stages_dO
+            for stage in cutlass.range_constexpr(self.num_stages_Q):
+                if cutlass.const_expr(self.num_stages_Q == 1 or stage < self.num_stages_Q - 1):
+                    if stage == 0 or m_block + stage < m_block_max:
+                        load_Q_LSE(m_block + stage, smem_pipe_write_q=stage)
+                    cute.arch.cp_async_commit_group()
+                if cutlass.const_expr(stage < self.num_stages_dO):
+                    if stage == 0 or m_block + stage < m_block_max:
+                        load_dO_dPsum(m_block + stage, smem_pipe_write_q=stage)
+                    cute.arch.cp_async_commit_group()
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Mainloop
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Start processing of the first n-block.
+            base_mask = AttentionMask(self.m_block_size, self.n_block_size, seqlen)
+
+            def mask_fn(acc_S: cute.Tensor, m_block: cutlass.Int32):
+                base_mask.apply_mask(
+                    acc_S,
+                    m_block=m_block,
+                    n_block=n_block,
+                    thr_mma=thr_mma_sdp,
+                    batch_idx=batch_idx,
+                    head_idx=head_idx,
+                    mask_seqlen=True,
+                    mask_causal=self.is_causal,
+                )
+                self.apply_segment_mask(acc_S, mLowerBounds, mValid, batch_idx, m_block, n_block, thr_mma_sdp)
+
+            smem_pipe_read_q = cutlass.Int32(0)
+            smem_pipe_read_do = cutlass.Int32(0)
+            smem_pipe_write_q = cutlass.Int32(self.num_stages_Q - 1)
+            smem_pipe_write_do = cutlass.Int32(0)
+            for m_tile in cutlass.range(m_block_min, m_block_max, unroll=1):
+                compute_one_m_block(
+                    m_tile,
+                    smem_pipe_read_q,
+                    smem_pipe_read_do,
+                    smem_pipe_write_q,
+                    smem_pipe_write_do,
+                    mask_fn=mask_fn,
+                )
+                smem_pipe_read_q = self.advance_pipeline(smem_pipe_read_q, self.num_stages_Q)
+                smem_pipe_read_do = self.advance_pipeline(smem_pipe_read_do, self.num_stages_dO)
+                smem_pipe_write_q = self.advance_pipeline(smem_pipe_write_q, self.num_stages_Q)
+                smem_pipe_write_do = self.advance_pipeline(smem_pipe_write_do, self.num_stages_dO)
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Epilogue
+            # ///////////////////////////////////////////////////////////////////////////////
+            # If GQA, we scale dK in the postprocessing kernel instead
+            if cutlass.const_expr(self.qhead_per_kvhead == 1):
+                acc_dK.store(acc_dK.load() * softmax_scale)
+            # reuse sK and sV data iterator
+            sdK = cute.make_tensor(sK.iterator, sK_layout)
+            sdV = cute.make_tensor(sV.iterator, sV_layout)
+            self.epilogue(
+                acc_dK,
+                acc_dV,
+                mdK,
+                mdV,
+                sdK,
+                sdV,
+                gmem_tiled_copy_dK,
+                gmem_tiled_copy_dV,
+                tiled_mma_dkv,
+                tidx,
+                n_block,
+                head_idx,
+                batch_idx,
+                seqlen,
+                d_head,
+                d_head_v,
+            )
+
+    @cute.jit
+    def segment_m_block_max(
+        self,
+        mLowerBounds: cute.Tensor,
+        batch_idx: cutlass.Int32,
+        n_block: cutlass.Int32,
+        m_block_min: cutlass.Int32,
+        m_block_max: cutlass.Int32,
+        seqlen: SeqlenInfoQK,
+    ) -> cutlass.Int32:
+        """Clamp query tiles for a key tile using monotonic packed segment lower bounds."""
+        n_block_end = min((n_block + 1) * self.n_block_size, seqlen.seqlen_k) - 1
+        m_block_scan = m_block_min
+        while m_block_scan < m_block_max:
+            query_idx = min(m_block_scan * self.m_block_size, mLowerBounds.shape[1] - 1)
+            if mLowerBounds[batch_idx, query_idx] <= n_block_end:
+                m_block_scan += 1
+            else:
+                m_block_max = m_block_scan
+        return m_block_max
+
+    @cute.jit
+    def apply_segment_mask(
+        self,
+        acc_S: cute.Tensor,
+        mLowerBounds: cute.Tensor,
+        mValid: cute.Tensor,
+        batch_idx: cutlass.Int32,
+        m_block: cutlass.Int32,
+        n_block: cutlass.Int32,
+        thr_mma: cute.TiledMma,
+    ):
+        acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S, transpose=self.SdP_swapAB)
+        acc_shape = (
+            (self.m_block_size, self.n_block_size)
+            if cutlass.const_expr(not self.SdP_swapAB)
+            else (self.n_block_size, self.m_block_size)
+        )
+        cS = cute.make_identity_tensor(acc_shape)
+        tScS_mn = layout_utils.reshape_acc_to_mn(thr_mma.partition_C(cS), transpose=self.SdP_swapAB)
+        row_coord = 0 if cutlass.const_expr(not self.SdP_swapAB) else 1
+        col_coord = 1 if cutlass.const_expr(not self.SdP_swapAB) else 0
+        seq_len = mLowerBounds.shape[1]
+        for r in cutlass.range(cute.size(tScS_mn.shape[0]), unroll_full=True):
+            query_idx = tScS_mn[r, 0][row_coord] + m_block * self.m_block_size
+            query_in_bounds = cute.elem_less(query_idx, seq_len)
+            query_meta_idx = cutlass.min(query_idx, seq_len - 1)
+            query_valid = mValid[batch_idx, query_meta_idx] != 0
+            query_lower_bound = mLowerBounds[batch_idx, query_meta_idx]
+            for c in cutlass.range(cute.size(tScS_mn.shape[1]), unroll_full=True):
+                key_idx = tScS_mn[0, c][col_coord] + n_block * self.n_block_size
+                key_in_bounds = cute.elem_less(key_idx, seq_len)
+                key_after_lower_bound = cute.elem_less(query_lower_bound, key_idx + 1)
+                key_before_query = cute.elem_less(key_idx, query_idx + 1)
+                if not (
+                    query_in_bounds and query_valid and key_in_bounds and key_after_lower_bound and key_before_query
+                ):
+                    acc_S_mn[r, c] = -cutlass.Float32.inf
+
+    @cute.jit
+    def compute_one_m_block(
+        self,
+        m_block: cutlass.Int32,
+        smem_pipe_read_q: cutlass.Int32,
+        smem_pipe_read_do: cutlass.Int32,
+        smem_pipe_write_q: cutlass.Int32,
+        smem_pipe_write_do: cutlass.Int32,
+        mma_params: SimpleNamespace,
+        smem_copy_params: SimpleNamespace,
+        gmem_copy_params: SimpleNamespace,
+        load_Q_LSE: Callable,
+        load_dO_dPsum: Callable,
+        m_block_max: cutlass.Int32,
+        softmax_scale: cutlass.Float32,
+        softmax_scale_log2: cutlass.Float32,
+        mask_fn: Optional[Callable] = None,
+    ):
+        def load_Q_next():
+            m_block_next = m_block + (self.num_stages_Q - 1 if cutlass.const_expr(self.num_stages_Q > 1) else 1)
+            if m_block_next < m_block_max:
+                load_Q_LSE(m_block_next, smem_pipe_write_q)
+            cute.arch.cp_async_commit_group()
+
+        def load_dO_next():
+            if m_block + self.num_stages_dO < m_block_max:
+                load_dO_dPsum(m_block + self.num_stages_dO, smem_pipe_write_do)
+            cute.arch.cp_async_commit_group()
+
+        # MMA S
+        acc_shape_SdP = mma_params.thr_mma_sdp.partition_shape_C(
+            (self.m_block_size, self.n_block_size)
+            if cutlass.const_expr(not self.SdP_swapAB)
+            else (self.n_block_size, self.m_block_size)
+        )
+        acc_S = cute.make_fragment(acc_shape_SdP, cutlass.Float32)
+        acc_S.fill(0.0)
+        cute.arch.cp_async_wait_group(1 if cutlass.const_expr(self.num_stages_Q > 1) else 0)
+        cute.arch.barrier()
+        sm80_utils.gemm(
+            mma_params.thr_mma_sdp,
+            acc_S,
+            mma_params.tSrQ,
+            mma_params.tSrK,
+            smem_copy_params.tSsQ[
+                None, None, None, smem_pipe_read_q if cutlass.const_expr(self.num_stages_Q > 1) else 0
+            ],
+            smem_copy_params.tSsK,
+            smem_copy_params.smem_thr_copy_QdO,
+            smem_copy_params.smem_thr_copy_KV,
+            swap_AB=self.SdP_swapAB,
+        )
+        acc_S_pre = cute.make_fragment_like(acc_S)
+        acc_S_pre.store(acc_S.load())
+        tLSErLSE = cute.make_fragment_like(smem_copy_params.tSsLSEMma[None, 0])
+        cute.autovec_copy(
+            smem_copy_params.tSsLSEMma[None, smem_pipe_read_q if cutlass.const_expr(self.num_stages_Q > 1) else 0],
+            tLSErLSE,
+        )
+        acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S)
+        acc_S_pre_mn = layout_utils.reshape_acc_to_mn(acc_S_pre)
+        if cutlass.const_expr(self.score_mod is not None):
+            for r in cutlass.range(cute.size(acc_S_mn, mode=[0]), unroll_full=True):
+                acc_S_mn[r, None].store(
+                    self.score_mod(
+                        acc_S_mn[r, None].load() * softmax_scale,
+                        0,
+                        0,
+                        0,
+                        0,
+                        None,
+                        [],
+                    )
+                )
+        if cutlass.const_expr(mask_fn is not None):
+            mask_fn(acc_S, m_block=m_block)
+        bidx = 0
+        # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_S_mn)
+        # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == 1: cute.print_tensor(tLSErLSE)
+        assert cute.size(acc_S_mn, mode=[0]) == cute.size(tLSErLSE)
+        for r in cutlass.range(cute.size(acc_S_mn, mode=[0]), unroll_full=True):
+            acc_S_mn[r, None].store(
+                cute.math.exp2(acc_S_mn[r, None].load() * softmax_scale_log2 - tLSErLSE[r], fastmath=True)
+            )
+        # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_S_mn)
+
+        # MMA dP
+        acc_dP = cute.make_fragment(acc_shape_SdP, cutlass.Float32)
+        acc_dP.fill(0.0)
+        cute.arch.cp_async_wait_group(1 if cutlass.const_expr(self.num_stages_dO > 1) else 0)
+        cute.arch.barrier()
+        sm80_utils.gemm(
+            mma_params.thr_mma_sdp,
+            acc_dP,
+            mma_params.tdPrdO,
+            mma_params.tdPrV,
+            smem_copy_params.tdPsdO[
+                None, None, None, smem_pipe_read_do if cutlass.const_expr(self.num_stages_dO > 1) else 0
+            ],
+            smem_copy_params.tdPsV,
+            smem_copy_params.smem_thr_copy_QdO,
+            smem_copy_params.smem_thr_copy_KV,
+            hook_fn=load_Q_next if cutlass.const_expr(self.num_stages_Q > 1) else None,
+            swap_AB=self.SdP_swapAB,
+        )
+        tLSErdPsum = cute.make_fragment_like(smem_copy_params.tSsdPsumMma[None, 0])
+        cute.autovec_copy(
+            smem_copy_params.tSsdPsumMma[None, smem_pipe_read_do if cutlass.const_expr(self.num_stages_dO > 1) else 0],
+            tLSErdPsum,
+        )
+        acc_dP_mn = layout_utils.reshape_acc_to_mn(acc_dP)
+        # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_dP_mn)
+        assert cute.size(acc_dP_mn, mode=[0]) == cute.size(tLSErdPsum)
+        for r in cutlass.range(cute.size(acc_dP_mn, mode=[0]), unroll_full=True):
+            grad_val = acc_S_mn[r, None].load() * (acc_dP_mn[r, None].load() - tLSErdPsum[r])
+            if cutlass.const_expr(self.score_mod_bwd is not None):
+                grad_val = self.score_mod_bwd(
+                    grad_val,
+                    acc_S_pre_mn[r, None].load() * softmax_scale,
+                    0,
+                    0,
+                    0,
+                    0,
+                    None,
+                    [],
+                )
+            acc_dP_mn[r, None].store(grad_val)
+        # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_dP_mn)
+        rP = cute.make_fragment_like(acc_S, self.dtype)
+        rP.store(acc_S.load().to(self.dtype))
+        if cutlass.const_expr(not self.Mma_dKV_is_RS):
+            tPrP = smem_copy_params.r2s_thr_copy_PdS.retile(rP)  # ((Atom,AtomNum), MMA_N, MMA_N)
+            cute.copy(smem_copy_params.r2s_thr_copy_PdS, tPrP, smem_copy_params.tPsP)
+        rdS = cute.make_fragment_like(acc_dP, self.dtype)
+        rdS.store(acc_dP.load().to(self.dtype))
+        if cutlass.const_expr(not self.Mma_dKV_is_RS):
+            cute.arch.barrier()  # Make sure P is written
+        # For hdim 64, It's faster to write to smem_dS first before the dV gemm
+        if cutlass.const_expr(not self.Mma_dKV_is_RS):
+            tdSrdS = smem_copy_params.r2s_thr_copy_PdS.retile(rdS)
+            cute.copy(smem_copy_params.r2s_thr_copy_PdS, tdSrdS, smem_copy_params.tdSsdS)
+        if cutlass.const_expr(self.Mma_dKV_is_RS):
+            tdVrP = layout_utils.reshape_acc_to_frgA(rP)
+        else:
+            tdVrP = mma_params.tdVrP
+
+        # MMA dK
+        sm80_utils.gemm(
+            mma_params.thr_mma_dkv,
+            mma_params.acc_dV,
+            tdVrP,
+            mma_params.tdVrdO,
+            smem_copy_params.tdVsPt,
+            smem_copy_params.tdVsdOt[
+                None, None, None, smem_pipe_read_do if cutlass.const_expr(self.num_stages_dO > 1) else 0
+            ],
+            smem_copy_params.smem_thr_copy_PdSt,
+            smem_copy_params.smem_thr_copy_QdOt,
+            A_in_regs=self.Mma_dKV_is_RS,
+            swap_AB=self.dKV_swapAB,
+        )
+        # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(mma_params.acc_dV)
+        cute.arch.barrier()  # Make sure dS is written
+
+        # MMA dQ
+        def dQ_mma(hook_fn):
+            acc_shape_dQ = mma_params.thr_mma_dq.partition_shape_C(
+                (self.m_block_size, self.head_dim_padded)
+                if cutlass.const_expr(not self.dQ_swapAB)
+                else (self.head_dim_padded, self.m_block_size)
+            )
+            acc_dQ = cute.make_fragment(acc_shape_dQ, cutlass.Float32)
+            acc_dQ.fill(0.0)
+            sm80_utils.gemm(
+                mma_params.thr_mma_dq,
+                acc_dQ,
+                mma_params.tdQrdS,
+                mma_params.tdQrK,
+                smem_copy_params.tdQsdS,
+                smem_copy_params.tdQsKt,
+                smem_copy_params.smem_thr_copy_dS,
+                smem_copy_params.smem_thr_copy_Kt,
+                swap_AB=self.dQ_swapAB,
+                hook_fn=hook_fn,
+            )
+            # ((1, 1), num_elements)
+            acc_dQ_atomic = gmem_copy_params.gmem_thr_copy_dQaccum.retile(acc_dQ)
+            tdQgdQaccum_atomic = gmem_copy_params.tdQgdQaccum[None, None, m_block]
+            assert cute.size(acc_dQ_atomic) == cute.size(tdQgdQaccum_atomic)
+            for i in cutlass.range(cute.size(acc_dQ_atomic), unroll_full=True):
+                cute.arch.atomic_add(utils.elem_pointer(tdQgdQaccum_atomic, i), acc_dQ_atomic[i])
+                # utils.atomic_add_fp32(acc_dQ[i], tdQgdQaccum_atomic.iterator + i * tdQgdQaccum_atomic.stride[1])
+            # if cute.arch.thread_idx()[0] == 64 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_dQ)
+
+        # If num_stages_Q == 1, we want to do Mma_dK first so we can start loading Q for the next iteration
+        if cutlass.const_expr(self.num_stages_Q > 1):
+            dQ_mma(load_dO_next)
+
+        # MMA dK
+        if cutlass.const_expr(self.Mma_dKV_is_RS):
+            tdKrdS = layout_utils.reshape_acc_to_frgA(rdS)
+        else:
+            tdKrdS = mma_params.tdKrdS
+        sm80_utils.gemm(
+            mma_params.thr_mma_dkv,
+            mma_params.acc_dK,
+            tdKrdS,
+            mma_params.tdKrQ,
+            smem_copy_params.tdKsdSt,
+            smem_copy_params.tdKsQt[
+                None, None, None, smem_pipe_read_q if cutlass.const_expr(self.num_stages_Q > 1) else 0
+            ],
+            smem_copy_params.smem_thr_copy_PdSt,
+            smem_copy_params.smem_thr_copy_QdOt,
+            A_in_regs=self.Mma_dKV_is_RS,
+            swap_AB=self.dKV_swapAB,
+            hook_fn=load_dO_next if cutlass.const_expr(self.num_stages_Q == 1) else None,
+        )
+        # if cute.arch.thread_idx()[0] == 0: cute.print_tensor(mma_params.acc_dK)
+        if cutlass.const_expr(self.num_stages_Q == 1):
+            cute.arch.barrier()
+            dQ_mma(load_Q_next)
+
+    @cute.jit
+    def epilogue(
+        self,
+        acc_dK: cute.Tensor,
+        acc_dV: cute.Tensor,
+        mdK: cute.Tensor,
+        mdV: cute.Tensor,
+        sdK: cute.Tensor,
+        sdV: cute.Tensor,
+        gmem_tiled_copy_dK: cute.TiledCopy,
+        gmem_tiled_copy_dV: cute.TiledCopy,
+        tiled_mma: cute.TiledMma,
+        tidx: cutlass.Int32,
+        n_block: cutlass.Int32,
+        num_head: cutlass.Int32,
+        batch_size: cutlass.Int32,
+        seqlen: SeqlenInfoQK,
+        d_head: cutlass.Int32,
+        d_head_v: cutlass.Int32,
+    ):
+        rdV = cute.make_fragment_like(acc_dV, self.dtype)
+        rdV.store(acc_dV.load().to(self.dtype))
+        rdK = cute.make_fragment_like(acc_dK, self.dtype)
+        rdK.store(acc_dK.load().to(self.dtype))
+        gmem_thr_copy_dK = gmem_tiled_copy_dK.get_slice(tidx)
+        gmem_thr_copy_dV = gmem_tiled_copy_dV.get_slice(tidx)
+
+        batch_idx = batch_size
+        head_idx_kv = num_head // self.qhead_per_kvhead if cutlass.const_expr(not self.pack_gqa) else num_head
+
+        if cutlass.const_expr(self.qhead_per_kvhead == 1):
+            # Make sure all threads have finished reading K and V, otherwise we get racy dQ
+            # because smem_q could be changed.
+            cute.arch.barrier()
+            # smem copy atom for dKV
+            smem_copy_atom_dKV = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(), self.dtype, num_bits_per_copy=2 * self.dtype.width
+            )
+            smem_thr_copy_dKV = cute.make_tiled_copy_C(smem_copy_atom_dKV, tiled_mma).get_slice(tidx)
+            taccdVrdV = smem_thr_copy_dKV.retile(rdV)
+            taccdKrdK = smem_thr_copy_dKV.retile(rdK)
+            taccdVsdV = smem_thr_copy_dKV.partition_D(sdV)
+            taccdKsdK = smem_thr_copy_dKV.partition_D(sdK)
+            # copy acc O from rmem to smem with the smem copy atom
+            cute.copy(smem_copy_atom_dKV, taccdVrdV, taccdVsdV)
+            cute.copy(smem_copy_atom_dKV, taccdKrdK, taccdKsdK)
+
+            if cutlass.const_expr(not seqlen.has_cu_seqlens_k):
+                mdK_cur, mdV_cur = [t[batch_idx, None, head_idx_kv, None] for t in (mdK, mdV)]
+            else:
+                mdK_cur, mdV_cur = [
+                    cute.domain_offset((seqlen.offset_k, 0), t[None, head_idx_kv, None]) for t in (mdK, mdV)
+                ]
+
+            blkdK_shape = (self.n_block_size, self.head_dim_padded)
+            blkdV_shape = (self.n_block_size, self.head_dim_v_padded)
+            gdK = cute.local_tile(mdK_cur, blkdK_shape, (n_block, 0))
+            gdV = cute.local_tile(mdV_cur, blkdV_shape, (n_block, 0))
+            tdKsdK = gmem_thr_copy_dK.partition_S(sdK)
+            tdKgdK = gmem_thr_copy_dK.partition_D(gdK)
+            tdVsdV = gmem_thr_copy_dV.partition_S(sdV)
+            tdVgdV = gmem_thr_copy_dV.partition_D(gdV)
+            tdKrdK = cute.make_fragment_like(tdKgdK, self.dtype)
+            tdVrdV = cute.make_fragment_like(tdVgdV, self.dtype)
+            # sync before all smem stores are done.
+            cute.arch.barrier()
+            # load acc dK and dV from smem to rmem for wider vectorization
+            # Need to check OOB when reading from smem if kBlockN isn't evenly tiled
+            # TODO
+            cute.autovec_copy(tdKsdK, tdKrdK)
+            cute.autovec_copy(tdVsdV, tdVrdV)
+
+            cdK = cute.make_identity_tensor((self.n_block_size, self.head_dim_padded))
+            tdKcdK = gmem_thr_copy_dK.partition_S(cdK)
+            t0dKcdK = gmem_tiled_copy_dK.get_slice(0).partition_S(cdK)
+            if cutlass.const_expr(self.head_dim_padded == self.head_dim_v_padded):
+                tdVcdV = tdKcdK
+                t0dVcdV = t0dKcdK
+            else:
+                cdV = cute.make_identity_tensor((self.n_block_size, self.head_dim_v_padded))
+                tdVcdV = gmem_thr_copy_dV.partition_S(cdV)
+                t0dVcdV = gmem_tiled_copy_dV.get_slice(0).partition_S(cdV)
+            tdKpdK = utils.predicate_k(tdKcdK, limit=d_head)
+            if cutlass.const_expr(self.same_hdim_kv):
+                tdVpdV = tdKpdK
+            else:
+                tdVpdV = utils.predicate_k(tdVcdV, limit=d_head_v)
+            # copy acc dK and acc_dV from rmem to gmem
+            for rest_m in cutlass.range_constexpr(cute.size(tdKrdK.shape[1])):
+                if t0dKcdK[0, rest_m, 0][0] < seqlen.seqlen_k - n_block * self.n_block_size - tdKcdK[0][0]:
+                    cute.copy(
+                        gmem_tiled_copy_dK,
+                        tdKrdK[None, rest_m, None],
+                        tdKgdK[None, rest_m, None],
+                        pred=tdKpdK[None, rest_m, None] if cutlass.const_expr(self.check_hdim_oob) else None,
+                    )
+            for rest_m in cutlass.range_constexpr(cute.size(tdVrdV.shape[1])):
+                if t0dVcdV[0, rest_m, 0][0] < seqlen.seqlen_k - n_block * self.n_block_size - tdVcdV[0][0]:
+                    cute.copy(
+                        gmem_tiled_copy_dV,
+                        tdVrdV[None, rest_m, None],
+                        tdVgdV[None, rest_m, None],
+                        pred=tdVpdV[None, rest_m, None] if cutlass.const_expr(self.check_hdim_v_oob) else None,
+                    )
+
+        else:  # qhead_per_kvhead > 1, do atomic add
+            # For Sm90, we need to sync to avoid racy writes to smem_q
+            # For Sm80, we don't need to sync since we're not touching smem
+            head_idx_kv = num_head // self.qhead_per_kvhead if cutlass.const_expr(not self.pack_gqa) else num_head
+
+            if cutlass.const_expr(not seqlen.has_cu_seqlens_k):
+                mdK_cur, mdV_cur = [t[batch_idx, head_idx_kv, None] for t in (mdK, mdV)]
+            else:
+                padded_offset_k = seqlen.offset_k + batch_idx * self.n_block_size
+                mdK_cur = cute.domain_offset((padded_offset_k * self.head_dim_padded,), mdK[head_idx_kv, None])
+                mdV_cur = cute.domain_offset((padded_offset_k * self.head_dim_v_padded,), mdV[head_idx_kv, None])
+
+            gdV = cute.local_tile(mdV_cur, (self.n_block_size * self.head_dim_v_padded,), (n_block,))
+            gdK = cute.local_tile(mdK_cur, (self.n_block_size * self.head_dim_padded,), (n_block,))
+            tdVgdVaccum = gmem_thr_copy_dV.partition_S(gdV)
+            tdKgdKaccum = gmem_thr_copy_dK.partition_S(gdK)
+            acc_dV_atomic = gmem_thr_copy_dV.retile(acc_dV)
+            acc_dK_atomic = gmem_thr_copy_dK.retile(acc_dK)
+            assert cute.size(acc_dV_atomic) == cute.size(tdVgdVaccum)
+            assert cute.size(acc_dK_atomic) == cute.size(tdKgdKaccum)
+            for i in cutlass.range(cute.size(acc_dV_atomic), unroll_full=True):
+                cute.arch.atomic_add(utils.elem_pointer(tdVgdVaccum, i), acc_dV_atomic[i])
+            for i in cutlass.range(cute.size(acc_dK_atomic), unroll_full=True):
+                cute.arch.atomic_add(utils.elem_pointer(tdKgdKaccum, i), acc_dK_atomic[i])
+
+    @cute.jit
+    def advance_pipeline(self, pipeline_index, num_stages: cutlass.Constexpr):
+        return pipeline_index + 1 if pipeline_index < num_stages - 1 else 0
+
+    @cute.jit
+    def load_K(
+        self,
+        gmem_thr_copy: cute.TiledCopy,
+        tKgK: cute.Tensor,
+        tKsK: cute.Tensor,
+        block: cutlass.Int32,
+        seqlen: cutlass.Int32,
+        headdim: cutlass.Int32,
+    ):
+        cK = cute.make_identity_tensor((self.n_block_size, self.head_dim_padded))
+        tKcK = gmem_thr_copy.partition_S(cK)
+        t0KcK = gmem_thr_copy.get_slice(0).partition_S(cK)
+        tKpK = utils.predicate_k(tKcK, limit=headdim)
+        for n in cutlass.range_constexpr(cute.size(tKsK.shape[1])):
+            # If kBlockN doesn't evenly divide the tiled copy, only the last `n` needs to be checked
+            if self.is_even_n_smem_k or n < cute.size(tKsK.shape[1]) - 1 or tKcK[0, n, 0][0] < self.n_block_size:
+                # Instead of using tKcK, we using t0KcK and subtract the offset from the limit
+                # (seqlen - block * kBlockN). This is because the entries of t0KcK are known at compile time.
+                predicate_n = t0KcK[0, n, 0][0] < seqlen - block * self.n_block_size - tKcK[0][0]
+                predicate = cute.make_fragment_like(tKpK[None, 0, None])
+                for k in cutlass.range_constexpr(cute.size(predicate.shape[1])):
+                    for i in cutlass.range_constexpr(cute.size(predicate.shape[0])):
+                        predicate[i, k] = (
+                            tKpK[i, n, k] if cutlass.const_expr(self.check_hdim_oob) else True
+                        ) and predicate_n
+                cute.copy(
+                    gmem_thr_copy,
+                    tKgK[None, n, None],
+                    tKsK[None, n, None],
+                    pred=predicate,
+                )
+            # We need to clear the sK smem tiles since we'll use sKt for mma_dq
+
+    @cute.jit
+    def load_V(
+        self,
+        gmem_thr_copy: cute.TiledCopy,
+        tVgV: cute.Tensor,
+        tVsV: cute.Tensor,
+        block: cutlass.Int32,
+        seqlen: cutlass.Int32,
+        headdim: cutlass.Int32,
+    ):
+        cV = cute.make_identity_tensor((self.n_block_size, self.head_dim_v_padded))
+        tVcV = gmem_thr_copy.partition_S(cV)
+        t0VcV = gmem_thr_copy.get_slice(0).partition_S(cV)
+        tVpV = utils.predicate_k(tVcV, limit=headdim)
+        for n in cutlass.range_constexpr(cute.size(tVsV.shape[1])):
+            # If kBlockN doesn't evenly divide the tiled copy, only the last `n` needs to be checked
+            if self.is_even_n_smem_v or n < cute.size(tVsV.shape[1]) - 1 or tVcV[0, n, 0][0] < self.n_block_size:
+                # Instead of using tVcV, we using t0VcV and subtract the offset from the limit
+                # (seqlen - block * kBlockN). This is because the entries of t0VcV are known at compile time.
+                predicate_n = t0VcV[0, n, 0][0] < seqlen - block * self.n_block_size - tVcV[0][0]
+                predicate = cute.make_fragment_like(tVpV[None, 0, None])
+                for k in cutlass.range_constexpr(cute.size(predicate.shape[1])):
+                    for i in cutlass.range_constexpr(cute.size(predicate.shape[0])):
+                        predicate[i, k] = (
+                            tVpV[i, n, k] if cutlass.const_expr(self.check_hdim_oob) else True
+                        ) and predicate_n
+                cute.copy(
+                    gmem_thr_copy,
+                    tVgV[None, n, None],
+                    tVsV[None, n, None],
+                    pred=predicate,
+                )
+
+    @cute.jit
+    def load_Q_LSE(
+        self,
+        gmem_tiled_copy_Q: cute.TiledCopy,
+        gmem_tiled_copy_LSE: cute.TiledCopy,
+        tQgQ: cute.Tensor,
+        tQsQ: cute.Tensor,
+        tQcQ: cute.Tensor,
+        t0QcQ: cute.Tensor,
+        tQpQ: cute.Tensor,
+        tLSEgLSE: cute.Tensor,
+        tLSEsLSE: cute.Tensor,
+        tLSEcLSE: cute.Tensor,
+        block: cutlass.Int32,
+        smem_pipe_write_q: cutlass.Int32,
+        seqlen: cutlass.Int32,
+    ):
+        for m in cutlass.range_constexpr(cute.size(tQsQ.shape[1])):
+            # If kBlockM doesn't evenly divide the tiled copy, only the last `m` needs to be checked
+            if self.is_even_m_smem_q or m < cute.size(tQsQ.shape[1]) - 1 or tQcQ[0, m, 0][0] < self.m_block_size:
+                # Instead of using tQcQ, we using t0QcQ and subtract the offset from the limit
+                # (seqlen - block * kBlockM). This is because the entries of t0QcQ are known at compile time.
+                predicate_m = t0QcQ[0, m, 0][0] < seqlen - block * self.m_block_size - tQcQ[0][0]
+                predicate = cute.make_fragment_like(tQpQ[None, 0, None])
+                for k in cutlass.range_constexpr(cute.size(predicate.shape[1])):
+                    for i in cutlass.range_constexpr(cute.size(predicate.shape[0])):
+                        predicate[i, k] = (
+                            tQpQ[i, m, k] if cutlass.const_expr(self.check_hdim_oob) else True
+                        ) and predicate_m
+                cute.copy(
+                    gmem_tiled_copy_Q,
+                    tQgQ[None, m, None, block],
+                    tQsQ[None, m, None, smem_pipe_write_q if cutlass.const_expr(self.num_stages_Q) > 1 else 0],
+                    pred=predicate,
+                )
+            # We need to clear the sQ smem tiles since we'll use sQt for mma_dK
+        # We made sure LSE length is padded so we read `kBlockM` elements so that all
+        # elements in sLSE are filled. Without this we might have uninitialized sLSE values.
+        for m in cutlass.range_constexpr(cute.size(tLSEsLSE.shape[1])):
+            if tLSEcLSE[0, m][0] < self.m_block_size:
+                cute.copy(
+                    gmem_tiled_copy_LSE,
+                    tLSEgLSE[None, m, block],
+                    tLSEsLSE[None, m, smem_pipe_write_q if cutlass.const_expr(self.num_stages_Q > 1) else 0],
+                )
+
+    @cute.jit
+    def load_dO_dPsum(
+        self,
+        gmem_tiled_copy_dO: cute.TiledCopy,
+        gmem_tiled_copy_dPsum: cute.TiledCopy,
+        tdOgdO: cute.Tensor,
+        tdOsdO: cute.Tensor,
+        tdOcdO: cute.Tensor,
+        t0dOcdO: cute.Tensor,
+        tdOpdO: cute.Tensor,
+        tdPsumgdPsum: cute.Tensor,
+        tdPsumsdPsum: cute.Tensor,
+        tdPsumcdPsum: cute.Tensor,
+        block: cutlass.Int32,
+        smem_pipe_write_q: cutlass.Int32,
+        seqlen: cutlass.Int32,
+    ):
+        for m in cutlass.range_constexpr(cute.size(tdOsdO.shape[1])):
+            # If kBlockM doesn't evenly divide the tiled copy, only the last `m` needs to be checked
+            if self.is_even_m_smem_do or m < cute.size(tdOsdO.shape[1]) - 1 or tdOcdO[0, m, 0][0] < self.m_block_size:
+                # Instead of using tdOcdO, we using t0dOcdO and subtract the offset from the limit
+                # (seqlen - block * kBlockM). This is because the entries of t0dOcdO are known at compile time.
+                predicate_m = t0dOcdO[0, m, 0][0] < seqlen - block * self.m_block_size - tdOcdO[0][0]
+                predicate = cute.make_fragment_like(tdOpdO[None, 0, None])
+                for k in cutlass.range_constexpr(cute.size(predicate.shape[1])):
+                    for i in cutlass.range_constexpr(cute.size(predicate.shape[0])):
+                        predicate[i, k] = (
+                            tdOpdO[i, m, k] if cutlass.const_expr(self.check_hdim_oob) else True
+                        ) and predicate_m
+                cute.copy(
+                    gmem_tiled_copy_dO,
+                    tdOgdO[None, m, None, block],
+                    tdOsdO[None, m, None, smem_pipe_write_q if cutlass.const_expr(self.num_stages_dO > 1) else 0],
+                    pred=predicate,
+                )
+            # We need to clear the sQ smem tiles since we'll use sQt for mma_dK
+        # We made sure LSE length is padded so we read `kBlockM` elements so that all
+        # elements in sLSE are filled. Without this we might have uninitialized sLSE values.
+        for m in cutlass.range_constexpr(cute.size(tdPsumgdPsum.shape[1])):
+            if tdPsumcdPsum[0, m][0] < self.m_block_size:
+                cute.copy(
+                    gmem_tiled_copy_dPsum,
+                    tdPsumgdPsum[None, m, block],
+                    tdPsumsdPsum[None, m, smem_pipe_write_q if cutlass.const_expr(self.num_stages_dO > 1) else 0],
+                )
+
+
+class SegmentedFlashAttentionBackwardSm120(SegmentedFlashAttentionBackwardSm80):
+    @staticmethod
+    def can_implement(
+        dtype,
+        head_dim,
+        head_dim_v,
+        m_block_size,
+        n_block_size,
+        num_stages_Q,
+        num_stages_dO,
+        num_threads,
+        is_causal,
+        V_in_regs=False,
+    ) -> bool:
+        if dtype not in [cutlass.Float16, cutlass.BFloat16]:
+            return False
+        if head_dim % 8 != 0 or head_dim_v % 8 != 0:
+            return False
+        if n_block_size % 16 != 0 or num_threads % 32 != 0:
+            return False
+        smem_usage_Q = m_block_size * head_dim * num_stages_Q * 2
+        smem_usage_dO = m_block_size * head_dim_v * num_stages_dO * 2
+        smem_usage_K = n_block_size * head_dim * 2
+        smem_usage_V = n_block_size * head_dim_v * 2
+        smem_usage_QV = (smem_usage_Q + smem_usage_V) if not V_in_regs else max(smem_usage_Q, smem_usage_V)
+        smem_usage = smem_usage_QV + smem_usage_dO + smem_usage_K
+        return smem_usage <= utils_basic.get_smem_capacity_in_bytes("sm_120")

--- a/lib/levanter/tests/grug/test_attention.py
+++ b/lib/levanter/tests/grug/test_attention.py
@@ -6,14 +6,19 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
+import levanter.grug.attention as attention_lib
 from levanter.grug.attention import (
     AttentionMask,
     _flattened_packed_segment_seqlens_offsets,
+    _flash4_cute_kernel_config,
     _jax_dot_product_attention,
+    _packed_segment_causal_lower_bounds,
     _packed_segment_ids_positions,
     _packed_segment_seqlens_offsets,
+    _packed_segment_start_positions,
     attention,
     gpu_cudnn_attention,
+    gpu_fa4_cute_attention,
     gpu_te_attention,
     gpu_xla_attention,
     reference_attention,
@@ -134,6 +139,89 @@ def test_attention_explicit_gpu_te_requires_gpu():
         attention(q, k, v, mask, implementation="gpu_te")
 
 
+def test_attention_explicit_gpu_fa4_cute_requires_gpu():
+    if jax.default_backend() == "gpu":
+        pytest.skip("GPU behavior requires the FA4/CuTe JAX FFI target.")
+    q, k, v = _make_qkv()
+    mask = AttentionMask.causal(max_segments_per_seq=4).with_segment_ids(
+        jnp.array([[0, 0, 1, 1, 2, -1], [10, 10, 11, 11, 12, -1]], dtype=jnp.int32)
+    )
+    with pytest.raises(RuntimeError, match="requires the JAX GPU backend"):
+        attention(q, k, v, mask, implementation="gpu_fa4_cute")
+
+
+def test_gpu_fa4_cute_attention_uses_segment_lower_bounds_without_materializing(monkeypatch):
+    q, k, v = _make_qkv(batch=1, q_len=6, k_len=6, q_heads=2, kv_heads=1)
+    q = q.astype(jnp.bfloat16)
+    k = k.astype(jnp.bfloat16)
+    v = v.astype(jnp.bfloat16)
+    segment_ids = jnp.array([[5, 5, 5, 7, 7, -1]], dtype=jnp.int32)
+    mask = AttentionMask.causal(sliding_window=3, max_segments_per_seq=3).with_segment_ids(segment_ids)
+    calls = {}
+
+    def fail_materialize_mask(self, q_len, k_len):
+        raise AssertionError("gpu_fa4_cute_attention should not materialize segment_ids masks")
+
+    def fake_backend(q_arg, k_arg, v_arg, lower_bounds, valid, *, sm_scale, kernel_config):
+        calls["q_shape"] = q_arg.shape
+        calls["k_shape"] = k_arg.shape
+        calls["v_shape"] = v_arg.shape
+        calls["lower_bounds"] = lower_bounds
+        calls["valid"] = valid
+        calls["sm_scale"] = sm_scale
+        calls["kernel_config"] = kernel_config
+        return q_arg.astype(v_arg.dtype)
+
+    monkeypatch.setattr(jax, "default_backend", lambda: "gpu")
+    monkeypatch.setattr(AttentionMask, "materialize_mask", fail_materialize_mask)
+    monkeypatch.setattr(attention_lib, "_gpu_compute_arch", lambda: 90)
+    monkeypatch.setattr(attention_lib, "fa4_cute_attention_forward", fake_backend)
+
+    actual = attention_lib.gpu_fa4_cute_attention(q, k, v, mask)
+
+    assert actual.shape == q.shape
+    assert actual.dtype == v.dtype
+    assert calls["q_shape"] == q.shape
+    assert calls["k_shape"] == k.shape
+    assert calls["v_shape"] == v.shape
+    assert calls["kernel_config"].forward_tile == (128, 128)
+    np.testing.assert_array_equal(calls["lower_bounds"], jnp.array([[0, 0, 0, 3, 3, 6]], dtype=jnp.int32))
+    np.testing.assert_array_equal(calls["valid"], segment_ids >= 0)
+
+
+def test_flash4_cute_kernel_config_uses_sm12x_nerfed_tiles_for_gb10():
+    config = _flash4_cute_kernel_config(head_dim=128, head_dim_v=128, arch=121)
+
+    assert config.forward_tile == (128, 64)
+    assert config.backward_tile == (64, 64)
+    assert config.num_threads == 128
+    assert config.forward_num_stages == 1
+    assert config.backward_num_stages_q == 1
+    assert config.backward_num_stages_do == 1
+    assert config.use_sm80_mma
+    assert not config.allow_split_kv
+    assert not config.allow_paged_kv
+    assert not config.allow_block_sparse
+    assert not config.allow_mask_mod_backward
+
+
+def test_flash4_cute_kernel_config_keeps_sm120_wider_tiles_for_small_heads():
+    config = _flash4_cute_kernel_config(head_dim=64, head_dim_v=64, arch=120)
+
+    assert config.forward_tile == (128, 128)
+    assert config.backward_tile == (64, 64)
+    assert config.backward_num_stages_q == 2
+    assert config.backward_num_stages_do == 2
+
+
+def test_flash4_cute_kernel_config_uses_ampere_compatible_tiles_on_gh200():
+    config = _flash4_cute_kernel_config(head_dim=128, head_dim_v=128, arch=90)
+
+    assert config.forward_tile == (128, 64)
+    assert config.num_threads == 128
+    assert config.use_sm80_mma
+
+
 def test_packed_segment_seqlens_offsets_from_dynamic_loader_ids():
     segment_ids = jnp.array(
         [
@@ -225,6 +313,75 @@ def test_packed_segment_ids_positions_from_dynamic_loader_ids():
     np.testing.assert_array_equal(positions, jnp.array([[0, 1, 0, 1, 2, 0], [0, 1, 0, 1, 0, 0]], dtype=jnp.int32))
 
 
+def test_packed_segment_start_positions_from_dynamic_loader_ids():
+    segment_ids = jnp.array(
+        [
+            [37, 37, 42, 42, 42, -1],
+            [1000, 1000, 2000, 2000, 3000, -1],
+        ],
+        dtype=jnp.int32,
+    )
+
+    @jax.jit
+    def start_positions(dynamic_segment_ids):
+        return _packed_segment_start_positions(dynamic_segment_ids, batch_size=2, seq_len=6)
+
+    starts = start_positions(segment_ids)
+
+    np.testing.assert_array_equal(starts, jnp.array([[0, 0, 2, 2, 2, 6], [0, 0, 2, 2, 4, 6]], dtype=jnp.int32))
+
+
+def test_packed_segment_causal_lower_bounds_from_non_block_aligned_dynamic_ids():
+    segment_ids = jnp.array(
+        [
+            [5, 5, 5, 7, 7, 7, 7, 9, 9, -1],
+            [100, 101, 101, 101, 102, 102, 103, 103, 103, -1],
+        ],
+        dtype=jnp.int32,
+    )
+
+    @jax.jit
+    def bounds(dynamic_segment_ids):
+        return _packed_segment_causal_lower_bounds(
+            dynamic_segment_ids,
+            batch_size=2,
+            seq_len=10,
+            sliding_window=3,
+        )
+
+    lower_bounds, valid = bounds(segment_ids)
+
+    np.testing.assert_array_equal(
+        lower_bounds,
+        jnp.array(
+            [
+                [0, 0, 0, 3, 3, 3, 4, 7, 7, 10],
+                [0, 1, 1, 1, 4, 4, 6, 6, 6, 10],
+            ],
+            dtype=jnp.int32,
+        ),
+    )
+    np.testing.assert_array_equal(valid, segment_ids >= 0)
+
+
+def test_packed_segment_causal_lower_bounds_without_sliding_window():
+    segment_ids = jnp.array([[37, 37, 42, 42, 42, -1]], dtype=jnp.int32)
+
+    @jax.jit
+    def bounds(dynamic_segment_ids):
+        return _packed_segment_causal_lower_bounds(
+            dynamic_segment_ids,
+            batch_size=1,
+            seq_len=6,
+            sliding_window=None,
+        )
+
+    lower_bounds, valid = bounds(segment_ids)
+
+    np.testing.assert_array_equal(lower_bounds, jnp.array([[0, 0, 2, 2, 2, 6]], dtype=jnp.int32))
+    np.testing.assert_array_equal(valid, jnp.array([[True, True, True, True, True, False]]))
+
+
 def test_packed_segment_seqlens_offsets_rejects_too_many_segments():
     segment_ids = jnp.array([[37, 42, 105, -1]], dtype=jnp.int32)
 
@@ -312,6 +469,52 @@ def test_gpu_te_attention_matches_reference_for_valid_dynamic_packed_segments():
         return jnp.sum(out.astype(jnp.float32) * cotangent.astype(jnp.float32))
 
     actual_grads = jax.jit(jax.grad(te_loss, argnums=(0, 1, 2)))(q, k, v)
+    expected_grads = jax.jit(jax.grad(ref_loss, argnums=(0, 1, 2)))(q, k, v)
+
+    for actual_grad, expected_grad in zip(actual_grads, expected_grads, strict=True):
+        np.testing.assert_allclose(actual_grad, expected_grad, atol=7e-2, rtol=7e-2)
+
+
+def test_gpu_fa4_cute_attention_matches_reference_for_valid_dynamic_packed_segments():
+    if jax.default_backend() != "gpu":
+        pytest.skip("FA4/CuTe correctness requires a GPU backend.")
+    pytest.importorskip("cutlass")
+    pytest.importorskip("cutlass.cute")
+    pytest.importorskip("flash_attn.cute.flash_bwd_preprocess")
+    key = jax.random.PRNGKey(4)
+    q_key, k_key, v_key, cotangent_key = jax.random.split(key, 4)
+    q = jax.random.normal(q_key, (1, 64, 4, 64), dtype=jnp.bfloat16)
+    k = jax.random.normal(k_key, (1, 64, 1, 64), dtype=jnp.bfloat16)
+    v = jax.random.normal(v_key, (1, 64, 1, 64), dtype=jnp.bfloat16)
+    segment_ids = jnp.array(
+        [[37] * 17 + [42] * 23 + [43] * 21 + [-1] * 3],
+        dtype=jnp.int32,
+    )
+    mask = AttentionMask.causal(sliding_window=5, max_segments_per_seq=5).with_segment_ids(segment_ids)
+
+    actual = jax.jit(gpu_fa4_cute_attention)(q, k, v, mask)
+    expected = reference_attention(q, k, v, mask, logits_dtype=jnp.float32)
+    valid = segment_ids >= 0
+
+    np.testing.assert_allclose(
+        jnp.where(valid[..., None, None], actual, expected),
+        expected,
+        atol=7e-2,
+        rtol=7e-2,
+    )
+
+    cotangent = jax.random.normal(cotangent_key, q.shape, dtype=jnp.bfloat16)
+    cotangent = cotangent * valid[..., None, None].astype(jnp.bfloat16)
+
+    def ref_loss(q_arg, k_arg, v_arg):
+        out = reference_attention(q_arg, k_arg, v_arg, mask, logits_dtype=jnp.float32)
+        return jnp.sum(out.astype(jnp.float32) * cotangent.astype(jnp.float32))
+
+    def fa4_loss(q_arg, k_arg, v_arg):
+        out = gpu_fa4_cute_attention(q_arg, k_arg, v_arg, mask)
+        return jnp.sum(out.astype(jnp.float32) * cotangent.astype(jnp.float32))
+
+    actual_grads = jax.jit(jax.grad(fa4_loss, argnums=(0, 1, 2)))(q, k, v)
     expected_grads = jax.jit(jax.grad(ref_loss, argnums=(0, 1, 2)))(q, k, v)
 
     for actual_grad, expected_grad in zip(actual_grads, expected_grads, strict=True):

--- a/lib/levanter/tests/grug/test_attention.py
+++ b/lib/levanter/tests/grug/test_attention.py
@@ -1,0 +1,318 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from levanter.grug.attention import (
+    AttentionMask,
+    _flattened_packed_segment_seqlens_offsets,
+    _jax_dot_product_attention,
+    _packed_segment_ids_positions,
+    _packed_segment_seqlens_offsets,
+    attention,
+    gpu_cudnn_attention,
+    gpu_te_attention,
+    gpu_xla_attention,
+    reference_attention,
+)
+
+
+def _make_qkv(*, batch: int = 2, q_len: int = 6, k_len: int = 6, q_heads: int = 4, kv_heads: int = 2):
+    key = jax.random.PRNGKey(0)
+    q_key, k_key, v_key = jax.random.split(key, 3)
+    q = jax.random.normal(q_key, (batch, q_len, q_heads, 8), dtype=jnp.float32)
+    k = jax.random.normal(k_key, (batch, k_len, kv_heads, 8), dtype=jnp.float32)
+    v = jax.random.normal(v_key, (batch, k_len, kv_heads, 8), dtype=jnp.float32)
+    return q, k, v
+
+
+@pytest.mark.parametrize(
+    "mask",
+    [
+        None,
+        AttentionMask.causal(),
+        AttentionMask.causal(sliding_window=3),
+        AttentionMask().with_sliding_window(3),
+    ],
+)
+def test_jax_dot_product_attention_matches_reference(mask):
+    q, k, v = _make_qkv()
+
+    actual = _jax_dot_product_attention(q, k, v, mask, implementation="xla")
+    expected = reference_attention(q, k, v, mask, logits_dtype=jnp.float32)
+
+    np.testing.assert_allclose(actual, expected, atol=2e-5, rtol=2e-5)
+
+
+def test_jax_dot_product_attention_matches_reference_for_dense_bool_mask():
+    q, k, v = _make_qkv(q_len=4, k_len=5)
+    dense_mask = jnp.array(
+        [
+            [
+                [True, False, False, False, False],
+                [True, True, False, False, False],
+                [False, True, True, False, False],
+                [False, False, True, True, False],
+            ],
+            [
+                [True, True, False, False, False],
+                [False, True, True, False, False],
+                [False, False, True, True, False],
+                [False, False, False, True, True],
+            ],
+        ],
+        dtype=jnp.bool_,
+    )
+
+    actual = _jax_dot_product_attention(q, k, v, dense_mask, implementation="xla")
+    expected = reference_attention(q, k, v, dense_mask, logits_dtype=jnp.float32)
+
+    np.testing.assert_allclose(actual, expected, atol=2e-5, rtol=2e-5)
+
+
+def test_jax_dot_product_attention_grad_matches_reference_with_gqa():
+    q, k, v = _make_qkv(batch=2, q_len=5, k_len=5, q_heads=4, kv_heads=1)
+    mask = AttentionMask.causal(sliding_window=3)
+    cotangent = jax.random.normal(jax.random.PRNGKey(1), q.shape, dtype=jnp.float32)
+
+    def ref_loss(q_arg, k_arg, v_arg):
+        out = reference_attention(q_arg, k_arg, v_arg, mask, logits_dtype=jnp.float32)
+        return jnp.sum(out * cotangent)
+
+    def jax_loss(q_arg, k_arg, v_arg):
+        out = _jax_dot_product_attention(q_arg, k_arg, v_arg, mask, implementation="xla")
+        return jnp.sum(out * cotangent)
+
+    actual = jax.grad(jax_loss, argnums=(0, 1, 2))(q, k, v)
+    expected = jax.grad(ref_loss, argnums=(0, 1, 2))(q, k, v)
+
+    for actual_grad, expected_grad in zip(actual, expected, strict=True):
+        np.testing.assert_allclose(actual_grad, expected_grad, atol=2e-4, rtol=2e-4)
+
+
+def test_jax_dot_product_attention_rejects_segment_ids_without_materializing(monkeypatch):
+    q, k, v = _make_qkv()
+    mask = AttentionMask.causal().with_segment_ids(
+        jnp.array([[0, 0, 1, 1, 2, 2], [0, 1, 1, 2, 2, 2]], dtype=jnp.int32)
+    )
+
+    def fail_materialize_mask(self, q_len, k_len):
+        raise AssertionError("JAX SDPA should not materialize segment_ids masks")
+
+    monkeypatch.setattr(AttentionMask, "materialize_mask", fail_materialize_mask)
+    with pytest.raises(NotImplementedError, match="do not support segment_ids"):
+        _jax_dot_product_attention(q, k, v, mask, implementation="xla")
+
+
+def test_attention_explicit_gpu_cudnn_requires_gpu():
+    if jax.default_backend() == "gpu":
+        pytest.skip("CPU-only failure behavior is covered off-GPU.")
+    q, k, v = _make_qkv()
+    with pytest.raises(RuntimeError, match="requires the JAX GPU backend"):
+        attention(q, k, v, AttentionMask.causal(), implementation="gpu_cudnn")
+
+
+def test_attention_explicit_gpu_xla_requires_gpu():
+    if jax.default_backend() == "gpu":
+        pytest.skip("CPU-only failure behavior is covered off-GPU.")
+    q, k, v = _make_qkv()
+    with pytest.raises(RuntimeError, match="requires the JAX GPU backend"):
+        attention(q, k, v, AttentionMask.causal(), implementation="gpu_xla")
+
+
+def test_attention_explicit_gpu_te_requires_gpu():
+    if jax.default_backend() == "gpu":
+        pytest.skip("GPU behavior requires Transformer Engine on a GPU backend.")
+    q, k, v = _make_qkv()
+    mask = AttentionMask.causal(max_segments_per_seq=4).with_segment_ids(
+        jnp.array([[0, 0, 1, 1, 2, -1], [10, 10, 11, 11, 12, -1]], dtype=jnp.int32)
+    )
+    with pytest.raises(RuntimeError, match="requires the JAX GPU backend"):
+        attention(q, k, v, mask, implementation="gpu_te")
+
+
+def test_packed_segment_seqlens_offsets_from_dynamic_loader_ids():
+    segment_ids = jnp.array(
+        [
+            [37, 37, 42, 42, 42, -1],
+            [1000, 1000, 2000, 2000, 3000, -1],
+        ],
+        dtype=jnp.int32,
+    )
+
+    @jax.jit
+    def lengths_offsets(dynamic_segment_ids):
+        return _packed_segment_seqlens_offsets(
+            dynamic_segment_ids,
+            batch_size=2,
+            seq_len=6,
+            max_segments_per_seq=4,
+        )
+
+    seqlens, offsets = lengths_offsets(segment_ids)
+
+    np.testing.assert_array_equal(seqlens, jnp.array([[2, 3, -1, -1], [2, 2, 1, -1]], dtype=jnp.int32))
+    np.testing.assert_array_equal(offsets, jnp.array([[0, 2, -1, -1, -1], [0, 2, 4, -1, -1]], dtype=jnp.int32))
+
+
+def test_flattened_packed_segment_offsets_skip_inter_row_padding():
+    segment_ids = jnp.array(
+        [
+            [37, 37, 42, 42, 42, -1],
+            [1000, 1000, 2000, 2000, 3000, -1],
+        ],
+        dtype=jnp.int32,
+    )
+
+    @jax.jit
+    def lengths_offsets(dynamic_segment_ids):
+        return _flattened_packed_segment_seqlens_offsets(
+            dynamic_segment_ids,
+            batch_size=2,
+            seq_len=6,
+            max_segments_per_seq=4,
+        )
+
+    seqlens, offsets = lengths_offsets(segment_ids)
+
+    np.testing.assert_array_equal(
+        seqlens,
+        jnp.array([[2, 3, 2, 2, 1, -1, -1, -1]], dtype=jnp.int32),
+    )
+    np.testing.assert_array_equal(
+        offsets,
+        jnp.array([[0, 2, 6, 8, 10, 11, -1, -1, -1]], dtype=jnp.int32),
+    )
+
+
+def test_flattened_packed_segment_offsets_use_cumulative_fast_path_for_single_row():
+    segment_ids = jnp.array([[37, 37, 42, 42, 42, -1]], dtype=jnp.int32)
+
+    @jax.jit
+    def lengths_offsets(dynamic_segment_ids):
+        return _flattened_packed_segment_seqlens_offsets(
+            dynamic_segment_ids,
+            batch_size=1,
+            seq_len=6,
+            max_segments_per_seq=4,
+        )
+
+    seqlens, offsets = lengths_offsets(segment_ids)
+
+    np.testing.assert_array_equal(seqlens, jnp.array([[2, 3, -1, -1]], dtype=jnp.int32))
+    np.testing.assert_array_equal(offsets, jnp.array([[0, 2, 5, -1, -1]], dtype=jnp.int32))
+
+
+def test_packed_segment_ids_positions_from_dynamic_loader_ids():
+    segment_ids = jnp.array(
+        [
+            [37, 37, 42, 42, 42, -1],
+            [1000, 1000, 2000, 2000, 3000, -1],
+        ],
+        dtype=jnp.int32,
+    )
+
+    @jax.jit
+    def ids_positions(dynamic_segment_ids):
+        return _packed_segment_ids_positions(dynamic_segment_ids, batch_size=2, seq_len=6)
+
+    local_ids, positions = ids_positions(segment_ids)
+
+    np.testing.assert_array_equal(local_ids, jnp.array([[1, 1, 2, 2, 2, 0], [1, 1, 2, 2, 3, 0]], dtype=jnp.int32))
+    np.testing.assert_array_equal(positions, jnp.array([[0, 1, 0, 1, 2, 0], [0, 1, 0, 1, 0, 0]], dtype=jnp.int32))
+
+
+def test_packed_segment_seqlens_offsets_rejects_too_many_segments():
+    segment_ids = jnp.array([[37, 42, 105, -1]], dtype=jnp.int32)
+
+    @jax.jit
+    def lengths_offsets(dynamic_segment_ids):
+        return _packed_segment_seqlens_offsets(
+            dynamic_segment_ids,
+            batch_size=1,
+            seq_len=4,
+            max_segments_per_seq=2,
+        )
+
+    with pytest.raises(Exception, match="packed segment count exceeds max_segments_per_seq"):
+        jax.block_until_ready(lengths_offsets(segment_ids))
+
+
+def test_gpu_xla_attention_matches_reference_without_segments():
+    if jax.default_backend() != "gpu":
+        pytest.skip("GPU XLA SDPA correctness requires a GPU backend.")
+    q, k, v = _make_qkv(batch=2, q_len=7, k_len=7, q_heads=4, kv_heads=2)
+    mask = AttentionMask.causal(sliding_window=4)
+
+    actual = jax.jit(gpu_xla_attention)(q, k, v, mask)
+    expected = reference_attention(q, k, v, mask, logits_dtype=jnp.float32)
+
+    np.testing.assert_allclose(actual, expected, atol=3e-4, rtol=3e-4)
+
+
+def test_gpu_cudnn_attention_matches_reference_without_segments():
+    if jax.default_backend() != "gpu":
+        pytest.skip("cuDNN SDPA correctness requires a GPU backend.")
+    q, k, v = _make_qkv(batch=2, q_len=7, k_len=7, q_heads=4, kv_heads=2)
+    mask = AttentionMask.causal(sliding_window=4)
+
+    actual = jax.jit(gpu_cudnn_attention)(q, k, v, mask)
+    expected = reference_attention(q, k, v, mask, logits_dtype=jnp.float32)
+
+    np.testing.assert_allclose(actual, expected, atol=3e-4, rtol=3e-4)
+
+
+def test_gpu_cudnn_attention_returns_value_dtype():
+    if jax.default_backend() != "gpu":
+        pytest.skip("cuDNN SDPA correctness requires a GPU backend.")
+    q, k, v = _make_qkv(batch=1, q_len=4, k_len=4, q_heads=2, kv_heads=1)
+    q = q.astype(jnp.bfloat16)
+    k = k.astype(jnp.bfloat16)
+    v = v.astype(jnp.bfloat16)
+
+    actual = gpu_cudnn_attention(q, k, v, AttentionMask.causal())
+
+    assert actual.dtype == v.dtype
+
+
+def test_gpu_te_attention_matches_reference_for_valid_dynamic_packed_segments():
+    if jax.default_backend() != "gpu":
+        pytest.skip("Transformer Engine correctness requires a GPU backend.")
+    pytest.importorskip("transformer_engine")
+    q, k, v = _make_qkv(batch=2, q_len=6, k_len=6, q_heads=4, kv_heads=2)
+    q = q.astype(jnp.bfloat16)
+    k = k.astype(jnp.bfloat16)
+    v = v.astype(jnp.bfloat16)
+    segment_ids = jnp.array([[37, 37, 42, 42, 42, -1], [1000, 1000, 2000, 2000, 3000, -1]], dtype=jnp.int32)
+    mask = AttentionMask.causal(sliding_window=4, max_segments_per_seq=4).with_segment_ids(segment_ids)
+
+    actual = jax.jit(gpu_te_attention)(q, k, v, mask)
+    expected = reference_attention(q, k, v, mask, logits_dtype=jnp.float32)
+    valid = segment_ids >= 0
+
+    np.testing.assert_allclose(
+        jnp.where(valid[..., None, None], actual, expected),
+        expected,
+        atol=7e-2,
+        rtol=7e-2,
+    )
+
+    cotangent = jax.random.normal(jax.random.PRNGKey(3), q.shape, dtype=jnp.bfloat16)
+    cotangent = cotangent * valid[..., None, None].astype(jnp.bfloat16)
+
+    def ref_loss(q_arg, k_arg, v_arg):
+        out = reference_attention(q_arg, k_arg, v_arg, mask, logits_dtype=jnp.float32)
+        return jnp.sum(out.astype(jnp.float32) * cotangent.astype(jnp.float32))
+
+    def te_loss(q_arg, k_arg, v_arg):
+        out = gpu_te_attention(q_arg, k_arg, v_arg, mask)
+        return jnp.sum(out.astype(jnp.float32) * cotangent.astype(jnp.float32))
+
+    actual_grads = jax.jit(jax.grad(te_loss, argnums=(0, 1, 2)))(q, k, v)
+    expected_grads = jax.jit(jax.grad(ref_loss, argnums=(0, 1, 2)))(q, k, v)
+
+    for actual_grad, expected_grad in zip(actual_grads, expected_grads, strict=True):
+        np.testing.assert_allclose(actual_grad, expected_grad, atol=7e-2, rtol=7e-2)

--- a/lib/levanter/tests/grug/test_fa4_cute_backend.py
+++ b/lib/levanter/tests/grug/test_fa4_cute_backend.py
@@ -1,0 +1,383 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from levanter.grug import fa4_cute_backend as backend
+
+
+def test_require_cutlass_cute_reports_optional_dependency_absence(monkeypatch):
+    def fake_import_module(name):
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(backend.importlib, "import_module", fake_import_module)
+
+    assert not backend.cutlass_cute_available()
+    with pytest.raises(RuntimeError, match="nvidia-cutlass-dsl"):
+        backend.require_cutlass_cute()
+
+
+def test_cute_vector_add_wires_cutlass_call(monkeypatch):
+    calls = {}
+
+    class FakeCute:
+        Tensor = object
+
+        @staticmethod
+        def kernel(fn):
+            calls["kernel_name"] = fn.__name__
+            return fn
+
+        @staticmethod
+        def jit(fn):
+            calls["jit_name"] = fn.__name__
+            return fn
+
+    class FakeCjax:
+        @staticmethod
+        def cutlass_call(launcher, *, output_shape_dtype, use_static_tensors):
+            calls["launcher"] = launcher
+            calls["output_shape_dtype"] = output_shape_dtype
+            calls["use_static_tensors"] = use_static_tensors
+
+            def call(a, b):
+                return a + b
+
+            return call
+
+    fake_modules = backend._CutlassCuteModules(
+        cute=FakeCute(),
+        cjax=FakeCjax(),
+        cuda=SimpleNamespace(CUstream=object),
+    )
+    monkeypatch.setattr(backend, "_import_cutlass_cute", lambda: fake_modules)
+
+    a = jnp.arange(5, dtype=jnp.float16)
+    b = jnp.full((5,), 2, dtype=jnp.float16)
+
+    actual = backend.cute_vector_add(a, b, block_size=4)
+
+    np.testing.assert_array_equal(actual, a + b)
+    assert calls["kernel_name"] == "_vector_add_kernel"
+    assert calls["jit_name"] == "_launch_vector_add"
+    assert calls["output_shape_dtype"].shape == (1, 4, 2)
+    assert calls["output_shape_dtype"].dtype == jnp.float16
+    assert calls["use_static_tensors"] is True
+
+
+def test_fa4_cute_attention_forward_validates_metadata_before_optional_import(monkeypatch):
+    def fail_import():
+        raise AssertionError("optional import should not run after metadata validation fails")
+
+    monkeypatch.setattr(backend, "_import_cutlass_cute", fail_import)
+
+    q = jnp.ones((2, 4, 4, 8), dtype=jnp.bfloat16)
+    k = jnp.ones((2, 4, 2, 8), dtype=jnp.bfloat16)
+    v = jnp.ones((2, 4, 2, 8), dtype=jnp.bfloat16)
+    lower_bounds = jnp.zeros((2, 3), dtype=jnp.int32)
+    valid = jnp.ones((2, 4), dtype=jnp.bool_)
+
+    with pytest.raises(ValueError, match="lower_bounds"):
+        backend.fa4_cute_attention_forward(q, k, v, lower_bounds, valid, sm_scale=1.0, kernel_config=object())
+
+
+def test_fa4_cute_attention_forward_rejects_float32_before_optional_import(monkeypatch):
+    def fail_import():
+        raise AssertionError("optional import should not run after dtype validation fails")
+
+    monkeypatch.setattr(backend, "_import_cutlass_cute", fail_import)
+
+    q = jnp.ones((2, 4, 4, 8), dtype=jnp.float32)
+    k = jnp.ones((2, 4, 2, 8), dtype=jnp.float32)
+    v = jnp.ones((2, 4, 2, 8), dtype=jnp.float32)
+    lower_bounds = jnp.zeros((2, 4), dtype=jnp.int32)
+    valid = jnp.ones((2, 4), dtype=jnp.bool_)
+
+    with pytest.raises(TypeError, match="bf16/fp16"):
+        backend.fa4_cute_attention_forward(q, k, v, lower_bounds, valid, sm_scale=1.0, kernel_config=object())
+
+
+def test_fa4_cute_attention_forward_wires_cutlass_call(monkeypatch):
+    calls = {}
+
+    class FakeCjax:
+        class TensorSpec:
+            def __init__(self, *, mode=None, divisibility=None, static=False):
+                self.mode = mode
+                self.divisibility = divisibility
+                self.static = static
+
+            def __eq__(self, other):
+                return (
+                    isinstance(other, FakeCjax.TensorSpec)
+                    and self.mode == other.mode
+                    and self.divisibility == other.divisibility
+                    and self.static == other.static
+                )
+
+        @staticmethod
+        def cutlass_call(launcher, *, output_shape_dtype, input_spec, output_spec, use_static_tensors, softmax_scale):
+            calls["cutlass_call"] = {
+                "launcher": launcher,
+                "output_shape_dtype": output_shape_dtype,
+                "input_spec": input_spec,
+                "output_spec": output_spec,
+                "use_static_tensors": use_static_tensors,
+                "softmax_scale": softmax_scale,
+            }
+
+            def call(q, k, v, lower_bounds, valid):
+                calls["call"] = {
+                    "q_shape": q.shape,
+                    "k_shape": k.shape,
+                    "v_shape": v.shape,
+                    "lower_bounds_shape": lower_bounds.shape,
+                    "valid_shape": valid.shape,
+                }
+                out_shape_dtype, lse_shape_dtype = output_shape_dtype
+                return (
+                    jnp.zeros(out_shape_dtype.shape, out_shape_dtype.dtype),
+                    jnp.zeros(lse_shape_dtype.shape, lse_shape_dtype.dtype),
+                )
+
+            return call
+
+    fake_modules = backend._CutlassCuteModules(
+        cute=SimpleNamespace(kernel=lambda fn: fn, jit=lambda fn: fn, Tensor=object),
+        cjax=FakeCjax(),
+        cuda=SimpleNamespace(CUstream=object),
+    )
+    monkeypatch.setattr(backend, "_import_cutlass_cute", lambda: fake_modules)
+
+    def fake_launcher(modules, *, head_dim, head_dim_v, qhead_per_kvhead, tile_m, tile_n, num_threads):
+        calls["launcher"] = {
+            "modules": modules,
+            "head_dim": head_dim,
+            "head_dim_v": head_dim_v,
+            "qhead_per_kvhead": qhead_per_kvhead,
+            "tile_m": tile_m,
+            "tile_n": tile_n,
+            "num_threads": num_threads,
+        }
+        return object()
+
+    monkeypatch.setattr(backend, "segmented_flash_attention_forward_launcher", fake_launcher)
+
+    q = jnp.ones((2, 4, 4, 8), dtype=jnp.bfloat16)
+    k = jnp.ones((2, 4, 2, 8), dtype=jnp.bfloat16)
+    v = jnp.ones((2, 4, 2, 8), dtype=jnp.bfloat16)
+    lower_bounds = jnp.zeros((2, 4), dtype=jnp.int32)
+    valid = jnp.ones((2, 4), dtype=jnp.bool_)
+    kernel_config = SimpleNamespace(forward_tile=(64, 32), num_threads=96)
+
+    out = backend.fa4_cute_attention_forward(q, k, v, lower_bounds, valid, sm_scale=0.5, kernel_config=kernel_config)
+
+    assert out.shape == q.shape
+    assert out.dtype == q.dtype
+    assert calls["launcher"] == {
+        "modules": fake_modules,
+        "head_dim": 8,
+        "head_dim_v": 8,
+        "qhead_per_kvhead": 2,
+        "tile_m": 64,
+        "tile_n": 32,
+        "num_threads": 96,
+    }
+    out_shape_dtype, lse_shape_dtype = calls["cutlass_call"]["output_shape_dtype"]
+    assert out_shape_dtype.shape == q.shape
+    assert out_shape_dtype.dtype == q.dtype
+    assert lse_shape_dtype.shape == (2, 4, 4)
+    assert lse_shape_dtype.dtype == jnp.float32
+    qkv_spec = FakeCjax.TensorSpec(mode=(1, 3, 2, 0), divisibility=(1, 1, 1, 8), static=True)
+    lse_spec = FakeCjax.TensorSpec(divisibility=(1, 1, 1), static=True)
+    metadata_spec = FakeCjax.TensorSpec(static=True)
+    assert calls["cutlass_call"]["input_spec"] == (qkv_spec, qkv_spec, qkv_spec, metadata_spec, metadata_spec)
+    assert calls["cutlass_call"]["output_spec"] == (qkv_spec, lse_spec)
+    assert calls["cutlass_call"]["use_static_tensors"] is True
+    assert calls["cutlass_call"]["softmax_scale"] == 0.5
+    assert calls["call"] == {
+        "q_shape": q.shape,
+        "k_shape": k.shape,
+        "v_shape": v.shape,
+        "lower_bounds_shape": lower_bounds.shape,
+        "valid_shape": valid.shape,
+    }
+
+
+def test_fa4_cute_attention_backward_wires_cutlass_call(monkeypatch):
+    calls: dict[str, Any] = {"cutlass_call": []}
+
+    class FakeCjax:
+        class TensorSpec:
+            def __init__(self, *, mode=None, divisibility=None, static=False):
+                self.mode = mode
+                self.divisibility = divisibility
+                self.static = static
+
+            def __eq__(self, other):
+                return (
+                    isinstance(other, FakeCjax.TensorSpec)
+                    and self.mode == other.mode
+                    and self.divisibility == other.divisibility
+                    and self.static == other.static
+                )
+
+        @staticmethod
+        def cutlass_call(launcher, *, output_shape_dtype, input_spec, output_spec, use_static_tensors, softmax_scale):
+            calls["cutlass_call"].append(
+                {
+                    "launcher": launcher,
+                    "output_shape_dtype": output_shape_dtype,
+                    "input_spec": input_spec,
+                    "output_spec": output_spec,
+                    "use_static_tensors": use_static_tensors,
+                    "softmax_scale": softmax_scale,
+                }
+            )
+
+            def call(*args):
+                calls.setdefault("call_arg_shapes", []).append(tuple(arg.shape for arg in args))
+                if len(output_shape_dtype) == 2:
+                    out_shape_dtype, lse_shape_dtype = output_shape_dtype
+                    return (
+                        jnp.ones(out_shape_dtype.shape, out_shape_dtype.dtype),
+                        jnp.full(lse_shape_dtype.shape, 2.0, lse_shape_dtype.dtype),
+                    )
+                return tuple(jnp.full(spec.shape, i + 1, spec.dtype) for i, spec in enumerate(output_shape_dtype))
+
+            return call
+
+    fake_modules = backend._CutlassCuteModules(
+        cute=SimpleNamespace(kernel=lambda fn: fn, jit=lambda fn: fn, Tensor=object),
+        cjax=FakeCjax(),
+        cuda=SimpleNamespace(CUstream=object),
+    )
+    monkeypatch.setattr(backend, "_import_cutlass_cute", lambda: fake_modules)
+    monkeypatch.setattr(backend, "segmented_flash_attention_forward_launcher", lambda *args, **kwargs: "fwd")
+
+    def fake_backward_launcher(modules, *, dtype, head_dim, head_dim_v, qhead_per_kvhead, tile_m, tile_n, num_threads):
+        calls["backward_launcher"] = {
+            "modules": modules,
+            "dtype": dtype,
+            "head_dim": head_dim,
+            "head_dim_v": head_dim_v,
+            "qhead_per_kvhead": qhead_per_kvhead,
+            "tile_m": tile_m,
+            "tile_n": tile_n,
+            "num_threads": num_threads,
+        }
+        return "bwd"
+
+    monkeypatch.setattr(backend, "segmented_flash_attention_backward_launcher", fake_backward_launcher)
+
+    q = jnp.ones((1, 2, 2, 8), dtype=jnp.bfloat16)
+    k = jnp.ones((1, 2, 1, 8), dtype=jnp.bfloat16)
+    v = jnp.ones((1, 2, 1, 8), dtype=jnp.bfloat16)
+    lower_bounds = jnp.zeros((1, 2), dtype=jnp.int32)
+    valid = jnp.ones((1, 2), dtype=jnp.bool_)
+    kernel_config = SimpleNamespace(forward_tile=(64, 32), backward_tile=(32, 32), num_threads=128)
+
+    def loss(q_arg, k_arg, v_arg):
+        out = backend.fa4_cute_attention_forward(
+            q_arg,
+            k_arg,
+            v_arg,
+            lower_bounds,
+            valid,
+            sm_scale=0.5,
+            kernel_config=kernel_config,
+        )
+        return jnp.sum(out.astype(jnp.float32))
+
+    dq, dk, dv = jax.grad(loss, argnums=(0, 1, 2))(q, k, v)
+
+    assert dq.shape == q.shape
+    assert dk.shape == k.shape
+    assert dv.shape == v.shape
+    assert calls["backward_launcher"] == {
+        "modules": fake_modules,
+        "dtype": q.dtype,
+        "head_dim": 8,
+        "head_dim_v": 8,
+        "qhead_per_kvhead": 2,
+        "tile_m": 32,
+        "tile_n": 32,
+        "num_threads": 128,
+    }
+    assert calls["call_arg_shapes"] == [
+        (q.shape, k.shape, v.shape, lower_bounds.shape, valid.shape),
+        (q.shape, k.shape, v.shape, q.shape, q.shape, (1, 2, 2), lower_bounds.shape, valid.shape),
+    ]
+    qkv_spec = FakeCjax.TensorSpec(mode=(0, 1, 2, 3), divisibility=(1, 1, 1, 8), static=True)
+    lse_spec = FakeCjax.TensorSpec(mode=(0, 1, 2), divisibility=(1, 1, 1), static=True)
+    metadata_spec = FakeCjax.TensorSpec(mode=(0, 1), static=True)
+    scratch_spec = FakeCjax.TensorSpec(mode=(0, 1, 2), static=True)
+    assert calls["cutlass_call"][1]["input_spec"] == (
+        qkv_spec,
+        qkv_spec,
+        qkv_spec,
+        qkv_spec,
+        qkv_spec,
+        lse_spec,
+        metadata_spec,
+        metadata_spec,
+    )
+    assert calls["cutlass_call"][1]["output_spec"] == (
+        qkv_spec,
+        qkv_spec,
+        qkv_spec,
+        scratch_spec,
+        scratch_spec,
+        scratch_spec,
+        scratch_spec,
+        scratch_spec,
+    )
+    assert tuple(spec.shape for spec in calls["cutlass_call"][1]["output_shape_dtype"]) == (
+        q.shape,
+        k.shape,
+        v.shape,
+        (1, 2, 32),
+        (1, 2, 32),
+        (1, 2, 1024),
+        (1, 1, 1024),
+        (1, 1, 1024),
+    )
+    assert calls["cutlass_call"][1]["softmax_scale"] == 0.5
+
+
+def test_fa4_cute_attention_forward_rejects_mismatched_kv_heads_before_optional_import(monkeypatch):
+    def fail_import():
+        raise AssertionError("optional import should not run after shape validation fails")
+
+    monkeypatch.setattr(backend, "_import_cutlass_cute", fail_import)
+
+    q = jnp.ones((2, 4, 4, 8), dtype=jnp.bfloat16)
+    k = jnp.ones((2, 4, 2, 8), dtype=jnp.bfloat16)
+    v = jnp.ones((2, 4, 1, 8), dtype=jnp.bfloat16)
+    lower_bounds = jnp.zeros((2, 4), dtype=jnp.int32)
+    valid = jnp.ones((2, 4), dtype=jnp.bool_)
+
+    with pytest.raises(ValueError, match="k/v head counts"):
+        backend.fa4_cute_attention_forward(q, k, v, lower_bounds, valid, sm_scale=1.0, kernel_config=object())
+
+
+def test_fa4_cute_attention_forward_rejects_different_value_head_dim_before_optional_import(monkeypatch):
+    def fail_import():
+        raise AssertionError("optional import should not run after shape validation fails")
+
+    monkeypatch.setattr(backend, "_import_cutlass_cute", fail_import)
+
+    q = jnp.ones((2, 4, 4, 8), dtype=jnp.bfloat16)
+    k = jnp.ones((2, 4, 2, 8), dtype=jnp.bfloat16)
+    v = jnp.ones((2, 4, 2, 16), dtype=jnp.bfloat16)
+    lower_bounds = jnp.zeros((2, 4), dtype=jnp.int32)
+    valid = jnp.ones((2, 4), dtype=jnp.bool_)
+
+    with pytest.raises(NotImplementedError, match="Dv == D"):
+        backend.fa4_cute_attention_forward(q, k, v, lower_bounds, valid, sm_scale=1.0, kernel_config=object())


### PR DESCRIPTION
Add a GPU FA4/CuTe backend for dynamic packed Grug segment masks without materializing full masks. The backend lowers segment ids to per-token lower bounds, supports forward and backward through custom CuTe kernels, and adds benchmarks for Grug and Megatron TE comparison.