### PR TITLE
[status-page] Add p50/p90/p95/p98 to iris ping

### DIFF
--- a/infra/status-page/server/history.ts
+++ b/infra/status-page/server/history.ts
@@ -7,11 +7,12 @@
 // "Known limitations" for the follow-up plan (persist to GCS or grow a
 // worker_count_history table in the controller).
 
+import type { IrisPingSample } from "./sources/iris.js";
 import type { WorkerSample } from "./sources/workers.js";
 
-export class WorkerHistory {
+class RingBuffer<T> {
   private readonly capacity: number;
-  private readonly buffer: (WorkerSample | undefined)[];
+  private readonly buffer: (T | undefined)[];
   private head = 0;
   private size = 0;
 
@@ -20,7 +21,7 @@ export class WorkerHistory {
     this.buffer = new Array(capacity);
   }
 
-  push(sample: WorkerSample): void {
+  push(sample: T): void {
     this.buffer[this.head] = sample;
     this.head = (this.head + 1) % this.capacity;
     if (this.size < this.capacity) {
@@ -29,8 +30,8 @@ export class WorkerHistory {
   }
 
   /** Snapshot of samples in chronological order. */
-  samples(): WorkerSample[] {
-    const out: WorkerSample[] = [];
+  samples(): T[] {
+    const out: T[] = [];
     const start = this.size < this.capacity ? 0 : this.head;
     for (let i = 0; i < this.size; i++) {
       const sample = this.buffer[(start + i) % this.capacity];
@@ -41,3 +42,7 @@ export class WorkerHistory {
     return out;
   }
 }
+
+export class WorkerHistory extends RingBuffer<WorkerSample> {}
+
+export class IrisPingHistory extends RingBuffer<IrisPingSample> {}

--- a/infra/status-page/server/main.ts
+++ b/infra/status-page/server/main.ts
@@ -17,14 +17,14 @@ import { serve } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { Hono } from "hono";
 import { TTLCache } from "./cache.js";
-import { WorkerHistory } from "./history.js";
+import { IrisPingHistory, WorkerHistory } from "./history.js";
 import {
   FERRY_WORKFLOWS,
   fetchWorkflowStatus,
   type FerryWorkflowStatus,
 } from "./sources/githubActions.js";
 import { fetchBuildsOnMain, type BuildsResponse } from "./sources/githubCommits.js";
-import { irisStatus, type IrisStatus } from "./sources/iris.js";
+import { irisStatus, pingIris, type IrisPingResult } from "./sources/iris.js";
 import { jobsSnapshot, type JobsSnapshot } from "./sources/jobs.js";
 import { workerSnapshot, type WorkersSnapshot } from "./sources/workers.js";
 
@@ -33,9 +33,19 @@ const BUILD_HISTORY = 100;
 
 const ferryCache = new TTLCache<FerryWorkflowStatus>(60_000);
 const buildCache = new TTLCache<BuildsResponse>(60_000);
-const irisCache = new TTLCache<IrisStatus>(15_000);
 const workersCache = new TTLCache<WorkersSnapshot>(15_000);
 const jobsCache = new TTLCache<JobsSnapshot>(60_000);
+
+// Iris controller ping sampler. We probe /health on a fixed cadence and
+// keep a rolling 1h window of successful samples so /api/iris can report
+// p50/p90/p95/p98 alongside the most recent latency. Failed pings are
+// recorded as the latest result (so the dot can flip red) but excluded
+// from the percentile window.
+const IRIS_PING_INTERVAL_MS = 2_000;
+const IRIS_PING_WINDOW_MS = 60 * 60 * 1000;
+const IRIS_PING_CAPACITY = Math.ceil(IRIS_PING_WINDOW_MS / IRIS_PING_INTERVAL_MS);
+const irisPingHistory = new IrisPingHistory(IRIS_PING_CAPACITY);
+let lastIrisPing: IrisPingResult | null = null;
 
 // Ring buffer for worker-count history. Sized so the buffer holds 24h of
 // samples at the configured cadence. The sampler runs on a fixed interval
@@ -62,6 +72,19 @@ async function sampleWorkers(): Promise<void> {
   });
 }
 
+async function sampleIrisPing(): Promise<void> {
+  const result = await pingIris();
+  lastIrisPing = result;
+  if (result.reachable && result.latencyMs !== null) {
+    irisPingHistory.push({
+      t: Date.parse(result.fetchedAt),
+      latencyMs: result.latencyMs,
+    });
+  } else if (result.error) {
+    console.error("iris ping sampler:", result.error);
+  }
+}
+
 // Kick off immediately, then on a fixed cadence. unref() lets the process
 // exit cleanly during tests without waiting on the timer.
 void sampleWorkers().catch((err) => {
@@ -72,6 +95,15 @@ setInterval(() => {
     console.error("worker sampler error", err);
   });
 }, SAMPLE_INTERVAL_MS).unref();
+
+void sampleIrisPing().catch((err) => {
+  console.error("iris ping sampler error", err);
+});
+setInterval(() => {
+  void sampleIrisPing().catch((err) => {
+    console.error("iris ping sampler error", err);
+  });
+}, IRIS_PING_INTERVAL_MS).unref();
 
 const app = new Hono();
 
@@ -91,9 +123,8 @@ app.get("/api/builds", async (c) => {
   return c.json(snapshot);
 });
 
-app.get("/api/iris", async (c) => {
-  const status = await irisCache.get("marin", () => irisStatus());
-  return c.json(status);
+app.get("/api/iris", (c) => {
+  return c.json(irisStatus(lastIrisPing, irisPingHistory.samples(), IRIS_PING_WINDOW_MS));
 });
 
 app.get("/api/workers", async (c) => {

--- a/infra/status-page/server/sources/iris.ts
+++ b/infra/status-page/server/sources/iris.ts
@@ -5,22 +5,51 @@
 // and jobs sources call ExecuteRawQuery. This source sticks with the
 // simpler /health GET because it only needs a binary reachable/latency
 // signal, not structured data from the controller's SQLite.
+//
+// `pingIris()` does one fetch and returns its outcome. `irisStatus()`
+// assembles the API response by combining the most recent ping with
+// percentiles computed over a rolling window of successful samples
+// kept by the caller (see server/main.ts).
 
 import { getControllerUrl } from "./discovery.js";
 
 const CLUSTER = process.env.CLUSTER_NAME ?? "marin";
 
+export interface IrisPingSample {
+  t: number; // epoch millis
+  latencyMs: number;
+}
+
+export interface PingPercentiles {
+  p50: number;
+  p90: number;
+  p95: number;
+  p98: number;
+}
+
+export interface IrisPingResult {
+  fetchedAt: string;
+  reachable: boolean;
+  latencyMs: number | null;
+  controllerUrl: string | null;
+  error?: string;
+  raw?: unknown;
+}
+
 export interface IrisStatus {
   cluster: string;
   reachable: boolean;
   latencyMs: number | null;
+  pingPercentiles: PingPercentiles | null;
+  pingSampleCount: number;
+  pingWindowMs: number;
   controllerUrl: string | null;
   fetchedAt: string;
   error?: string;
   raw?: unknown;
 }
 
-export async function irisStatus(): Promise<IrisStatus> {
+export async function pingIris(): Promise<IrisPingResult> {
   const fetchedAt = new Date().toISOString();
 
   let base: string;
@@ -28,11 +57,10 @@ export async function irisStatus(): Promise<IrisStatus> {
     base = await getControllerUrl();
   } catch (err) {
     return {
-      cluster: CLUSTER,
+      fetchedAt,
       reachable: false,
       latencyMs: null,
       controllerUrl: null,
-      fetchedAt,
       error: `discovery failed: ${(err as Error).message}`,
     };
   }
@@ -45,31 +73,70 @@ export async function irisStatus(): Promise<IrisStatus> {
     const latencyMs = Math.round(performance.now() - start);
     if (!res.ok) {
       return {
-        cluster: CLUSTER,
+        fetchedAt,
         reachable: false,
         latencyMs,
         controllerUrl: base,
-        fetchedAt,
         error: `controller /health returned ${res.status}`,
       };
     }
     const raw = await res.json().catch(() => ({}));
     return {
-      cluster: CLUSTER,
+      fetchedAt,
       reachable: true,
       latencyMs,
       controllerUrl: base,
-      fetchedAt,
       raw,
     };
   } catch (err) {
     return {
-      cluster: CLUSTER,
+      fetchedAt,
       reachable: false,
       latencyMs: null,
       controllerUrl: base,
-      fetchedAt,
       error: `controller fetch failed: ${(err as Error).message}`,
     };
   }
+}
+
+// Linear-interpolated percentile over a sorted ascending array. Returns
+// null when there are no samples so the API can distinguish "no data
+// yet" from a real zero-millisecond reading.
+function percentile(sorted: number[], p: number): number {
+  const idx = ((p / 100) * (sorted.length - 1));
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+export function computePercentiles(samples: IrisPingSample[]): PingPercentiles | null {
+  if (samples.length === 0) return null;
+  const sorted = samples.map((s) => s.latencyMs).sort((a, b) => a - b);
+  return {
+    p50: Math.round(percentile(sorted, 50)),
+    p90: Math.round(percentile(sorted, 90)),
+    p95: Math.round(percentile(sorted, 95)),
+    p98: Math.round(percentile(sorted, 98)),
+  };
+}
+
+export function irisStatus(
+  last: IrisPingResult | null,
+  samples: IrisPingSample[],
+  windowMs: number,
+): IrisStatus {
+  const fetchedAt = last?.fetchedAt ?? new Date().toISOString();
+  return {
+    cluster: CLUSTER,
+    reachable: last?.reachable ?? false,
+    latencyMs: last?.latencyMs ?? null,
+    pingPercentiles: computePercentiles(samples),
+    pingSampleCount: samples.length,
+    pingWindowMs: windowMs,
+    controllerUrl: last?.controllerUrl ?? null,
+    fetchedAt,
+    error: last?.error,
+    raw: last?.raw,
+  };
 }

--- a/infra/status-page/web/src/api.ts
+++ b/infra/status-page/web/src/api.ts
@@ -61,10 +61,20 @@ export interface BuildsResponse {
   error?: string;
 }
 
+export interface PingPercentiles {
+  p50: number;
+  p90: number;
+  p95: number;
+  p98: number;
+}
+
 export interface IrisStatus {
   cluster: string;
   reachable: boolean;
   latencyMs: number | null;
+  pingPercentiles: PingPercentiles | null;
+  pingSampleCount: number;
+  pingWindowMs: number;
   controllerUrl: string | null;
   fetchedAt: string;
   error?: string;

--- a/infra/status-page/web/src/components/IrisPanel.tsx
+++ b/infra/status-page/web/src/components/IrisPanel.tsx
@@ -28,7 +28,20 @@ export function IrisPanel() {
               {data.reachable ? "reachable" : "unreachable"}
             </span>
             {data.latencyMs !== null && (
-              <span className="text-sm text-slate-500">· {data.latencyMs}ms</span>
+              <span
+                className={`text-sm ${data.latencyMs > 20 ? "text-rose-400" : "text-slate-500"}`}
+              >
+                · {data.latencyMs}ms
+              </span>
+            )}
+            {data.pingPercentiles && (
+              <span
+                className="text-xs text-slate-500"
+                title={`over last ${Math.round(data.pingWindowMs / 60_000)}m, n=${data.pingSampleCount}`}
+              >
+                · p50 {data.pingPercentiles.p50}ms · p90 {data.pingPercentiles.p90}ms · p95{" "}
+                {data.pingPercentiles.p95}ms · p98 {data.pingPercentiles.p98}ms
+              </span>
             )}
             {data.controllerUrl && (
               <span className="font-mono text-xs text-slate-500">· {data.controllerUrl}</span>

--- a/infra/status-page/web/src/components/WorkersPanel.tsx
+++ b/infra/status-page/web/src/components/WorkersPanel.tsx
@@ -170,6 +170,14 @@ export function WorkersPanel() {
     [data?.byRegion],
   );
   const { rows: chartRows, regions: chartRegions } = useChartData(samples, currentOrder);
+  // Color is keyed by region name (alphabetical), not display index, so a
+  // region keeps the same color even when worker counts reorder the legend.
+  const colorByRegion = useMemo(() => {
+    const sorted = [...chartRegions].sort();
+    const map = new Map<string, string>();
+    sorted.forEach((r, i) => map.set(r, REGION_COLORS[i % REGION_COLORS.length]));
+    return map;
+  }, [chartRegions]);
 
   return (
     <div>
@@ -230,13 +238,13 @@ export function WorkersPanel() {
                     iconType="plainline"
                     wrapperStyle={{ fontSize: 11, color: "#94a3b8" }}
                   />
-                  {chartRegions.map((region, i) => (
+                  {chartRegions.map((region) => (
                     <Line
                       key={region}
                       type="monotone"
                       dataKey={region}
                       name={region}
-                      stroke={REGION_COLORS[i % REGION_COLORS.length]}
+                      stroke={colorByRegion.get(region)}
                       strokeWidth={2}
                       dot={false}
                       isAnimationActive={false}


### PR DESCRIPTION
Sample the iris controller /health every 2s on a fixed timer and keep
a rolling 1h window of successful latencies in-memory. /api/iris now
returns p50/p90/p95/p98 alongside the most recent ping; the iris
panel renders them next to the live latency and turns the live
latency red above 20ms. Failed pings flip the dot red but are
excluded from the percentile window.