### PR TITLE
[iris] Drop @on_loop decorator; route all RPCs through the threadpool

### DIFF
--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -426,8 +426,6 @@ class ControllerDashboard:
             # when present but treat everything as anonymous/admin.
             auth_interceptor = NullAuthInterceptor(verifier=self._auth_verifier)
         controller_interceptors = [auth_interceptor, controller_timing]
-        # @on_loop handlers run inline on the event loop; everything else
-        # is dispatched to a thread by AsyncServiceAdapter.
         rpc_asgi_app = ControllerServiceASGIApplication(
             service=AsyncServiceAdapter(self._service),
             interceptors=controller_interceptors,

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -90,7 +90,6 @@ from iris.cluster.types import (
     is_job_finished,
 )
 from iris.rpc import controller_pb2, job_pb2, query_pb2, vm_pb2, worker_pb2
-from iris.rpc.async_adapter import on_loop
 from iris.rpc.auth import (
     AuthzAction,
     authorize,
@@ -1312,7 +1311,6 @@ class ControllerServiceImpl:
             request=redact_request_env_vars(reconstructed_request),
         )
 
-    @on_loop
     def get_job_state(
         self,
         request: controller_pb2.Controller.GetJobStateRequest,
@@ -2591,7 +2589,6 @@ class ControllerServiceImpl:
 
     # --- Task Status Text Push ---
 
-    @on_loop
     def set_task_status_text(
         self,
         request: job_pb2.SetTaskStatusTextRequest,

--- a/lib/iris/src/iris/rpc/async_adapter.py
+++ b/lib/iris/src/iris/rpc/async_adapter.py
@@ -6,14 +6,9 @@
 
 The ASGI application invokes ``await endpoint.function(...)`` for every
 unary RPC, so each handler must be a coroutine function.
-``AsyncServiceAdapter`` exposes a sync service's methods as async:
-
-- methods marked with :func:`on_loop` are wrapped in an ``async def`` that
-  calls the sync body inline on the event loop. Use this only for short,
-  non-blocking handlers (in-memory dicts, very cheap SQL reads) — a long
-  handler running inline blocks every other RPC.
-- every other sync method gets an ``asyncio.to_thread`` wrapper.
-- methods that are already coroutine functions pass through untouched.
+``AsyncServiceAdapter`` exposes a sync service's methods as async by
+wrapping each sync method in ``asyncio.to_thread``. Methods that are
+already coroutine functions pass through untouched.
 
 Interceptors are not adapted here — each interceptor that participates in
 an ASGI chain implements ``async intercept_unary`` directly.
@@ -24,26 +19,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import inspect
-from collections.abc import Callable
-from typing import Any, TypeVar
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-_ON_LOOP_ATTR = "__iris_rpc_on_loop__"
-
-
-def on_loop(fn: F) -> F:
-    """Mark a sync RPC handler as safe to run directly on the event loop.
-
-    The handler must be short and non-blocking. A handler that blocks the
-    loop for tens of milliseconds will queue every other RPC behind it.
-    """
-    setattr(fn, _ON_LOOP_ATTR, True)
-    return fn
-
-
-def _is_on_loop(fn: Callable[..., Any]) -> bool:
-    return getattr(fn, _ON_LOOP_ATTR, False)
+from typing import Any
 
 
 class AsyncServiceAdapter:
@@ -60,13 +36,6 @@ class AsyncServiceAdapter:
             return attr
         if inspect.iscoroutinefunction(attr):
             return attr
-        if _is_on_loop(attr):
-
-            @functools.wraps(attr)
-            async def _on_loop_call(*args: Any, **kwargs: Any) -> Any:
-                return attr(*args, **kwargs)
-
-            return _on_loop_call
 
         @functools.wraps(attr)
         async def _threaded_call(*args: Any, **kwargs: Any) -> Any:


### PR DESCRIPTION
The two on-loop handlers (get_job_state, set_task_status_text) shared the event loop with the ASGI server and could starve other RPCs under load. Run every sync RPC via asyncio.to_thread until the loop-affinity story is reworked. AsyncServiceAdapter is now a straight to-thread wrapper.