### PR TITLE
[iris] tolerate Finelog being unreachable during controller startup

### DIFF
--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -1276,17 +1276,24 @@ class Controller:
             k8s_provider = self._provider
             k8s_log_client = LogClient.connect(self._log_service_address, interceptors=log_client_interceptors)
             k8s_provider.log_client = k8s_log_client
+
+            def _install_k8s_task_stats_table(table: Table) -> None:
+                k8s_provider.task_stats_table = table
+
+            def _install_k8s_profile_table(table: Table) -> None:
+                k8s_provider.profile_table = table
+
             k8s_provider.task_stats_table = self._register_finelog_table(
                 k8s_log_client,
                 TASK_STATS_NAMESPACE,
                 IrisTaskStat,
-                on_late_success=lambda t: setattr(k8s_provider, "task_stats_table", t),
+                on_late_success=_install_k8s_task_stats_table,
             )
             k8s_provider.profile_table = self._register_finelog_table(
                 k8s_log_client,
                 PROFILE_NAMESPACE,
                 IrisProfile,
-                on_late_success=lambda t: setattr(k8s_provider, "profile_table", t),
+                on_late_success=_install_k8s_profile_table,
             )
 
         # Controller process logs ship to the log server via RemoteLogHandler.

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -12,14 +12,14 @@ import tempfile
 import threading
 import time
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
 import uvicorn
-from finelog.client import LogClient, RemoteLogHandler
+from finelog.client import LogClient, RemoteLogHandler, Table
 from finelog.client.proxy import LogServiceProxy, StatsServiceProxy
 from finelog.server import LogServiceImpl
 from finelog.server.asgi import build_log_server_asgi
@@ -1273,10 +1273,21 @@ class Controller:
         # provider also writes per-pod resource samples to iris.task itself —
         # mirroring what the worker daemon does on the GCE/TPU path.
         if isinstance(self._provider, K8sTaskProvider):
+            k8s_provider = self._provider
             k8s_log_client = LogClient.connect(self._log_service_address, interceptors=log_client_interceptors)
-            self._provider.log_client = k8s_log_client
-            self._provider.task_stats_table = k8s_log_client.get_table(TASK_STATS_NAMESPACE, IrisTaskStat)
-            self._provider.profile_table = k8s_log_client.get_table(PROFILE_NAMESPACE, IrisProfile)
+            k8s_provider.log_client = k8s_log_client
+            k8s_provider.task_stats_table = self._register_finelog_table(
+                k8s_log_client,
+                TASK_STATS_NAMESPACE,
+                IrisTaskStat,
+                on_late_success=lambda t: setattr(k8s_provider, "task_stats_table", t),
+            )
+            k8s_provider.profile_table = self._register_finelog_table(
+                k8s_log_client,
+                PROFILE_NAMESPACE,
+                IrisProfile,
+                on_late_success=lambda t: setattr(k8s_provider, "profile_table", t),
+            )
 
         # Controller process logs ship to the log server via RemoteLogHandler.
         self._log_client = LogClient.connect(self._log_service_address, interceptors=log_client_interceptors)
@@ -1308,6 +1319,17 @@ class Controller:
             auth=config.auth,
             system_endpoints={},
             user_budget_defaults=config.user_budget_defaults,
+        )
+        # Register the controller-process iris.profile table for /system/controller
+        # on-demand profiling. Failure here doesn't block startup; runtime writers
+        # in ControllerServiceImpl null-check ``_profile_table``.
+        self._service.set_profile_table(
+            self._register_finelog_table(
+                self._log_client,
+                PROFILE_NAMESPACE,
+                IrisProfile,
+                on_late_success=self._service.set_profile_table,
+            )
         )
         self._dashboard = ControllerDashboard(
             self._service,
@@ -1399,6 +1421,58 @@ class Controller:
     def started(self) -> bool:
         """Whether the controller loops have been started."""
         return self._started
+
+    def _register_finelog_table(
+        self,
+        log_client: LogClient,
+        namespace: str,
+        schema: type,
+        *,
+        on_late_success: Callable[[Table], None],
+    ) -> Table | None:
+        """Register a finelog namespace and return its Table handle.
+
+        Decouples controller startup from finelog availability. ``LogClient.get_table``
+        issues a synchronous ``RegisterTable`` RPC; if finelog is unreachable
+        at startup we don't want that to crash the controller, since runtime
+        writers already null-check the resulting Table. Instead, log a warning,
+        return None, and spawn a background ``ManagedThread`` that retries
+        registration with exponential backoff. When the retry eventually
+        succeeds, ``on_late_success`` is invoked with the registered Table so
+        the caller can install it where runtime writes look for it.
+
+        The retry thread joins the controller's ``ThreadContainer`` and exits
+        when the controller stops.
+        """
+        try:
+            return log_client.get_table(namespace, schema)
+        except Exception as exc:
+            logger.warning(
+                "Finelog table %r registration failed at startup; controller will run "
+                "with this table disabled and retry in the background: %s",
+                namespace,
+                exc,
+            )
+
+        def _retry(stop_event: threading.Event) -> None:
+            backoff = ExponentialBackoff(initial=1.0, maximum=60.0, factor=2.0)
+            while not stop_event.is_set():
+                if stop_event.wait(timeout=backoff.next_interval()):
+                    return
+                try:
+                    table = log_client.get_table(namespace, schema)
+                except Exception as exc:
+                    logger.debug("Finelog table %r background registration retry failed: %s", namespace, exc)
+                    continue
+                logger.info("Finelog table %r registered after background retry", namespace)
+                try:
+                    on_late_success(table)
+                except Exception:
+                    logger.exception("Finelog table %r install callback raised", namespace)
+                return
+
+        self._threads.spawn(_retry, name=f"finelog-register-{namespace}")
+        return None
 
     def _start_local_log_server(self) -> str:
         """Start a bundled in-process log + stats server and return its address.

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -19,7 +19,7 @@ from typing import Any, Protocol
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from connectrpc.request import RequestContext
-from finelog.client import LogClient
+from finelog.client import LogClient, Table
 from rigging.timing import Duration, ExponentialBackoff, Timer, Timestamp
 from sqlalchemy import func, select, text, tuple_
 
@@ -76,8 +76,6 @@ from iris.cluster.controller.worker_health import WorkerHealthTracker, WorkerLiv
 from iris.cluster.process_status import get_process_status
 from iris.cluster.redaction import redact_request_env_vars
 from iris.cluster.runtime.profile import (
-    PROFILE_NAMESPACE,
-    IrisProfile,
     build_profile_row,
     parse_profile_target,
     profile_local_process,
@@ -962,7 +960,20 @@ class ControllerServiceImpl:
         self._auth = auth or ControllerAuth()
         self._system_endpoints: dict[str, str] = system_endpoints or {}
         self._user_budget_defaults = user_budget_defaults or UserBudgetDefaults()
-        self._profile_table = self._log_client.get_table(PROFILE_NAMESPACE, IrisProfile)
+        # Installed by the controller after construction via ``set_profile_table``.
+        # Left as None when Finelog is unreachable at startup; the controller's
+        # background registration retry installs it once Finelog comes up.
+        # Runtime writers (e.g. ProfileTask) guard with ``is not None``.
+        self._profile_table: Table | None = None
+
+    def set_profile_table(self, table: Table | None) -> None:
+        """Install (or clear) the iris.profile Table handle.
+
+        Called by the controller after constructing the service. Safe to call
+        multiple times — a late install from the background finelog retry
+        thread replaces the initial ``None``.
+        """
+        self._profile_table = table
 
     def bundle_zip(self, bundle_id: str) -> bytes:
         return self._bundle_store.get_zip(bundle_id)

--- a/lib/iris/tests/cluster/controller/test_finelog_startup.py
+++ b/lib/iris/tests/cluster/controller/test_finelog_startup.py
@@ -10,10 +10,7 @@ handle as ``None`` — and retry registration in the background.
 
 import time
 
-import pytest
 from finelog.client import LogClient
-
-pytestmark = pytest.mark.timeout(15)
 
 
 def test_controller_starts_when_finelog_table_registration_fails(make_controller, monkeypatch):

--- a/lib/iris/tests/cluster/controller/test_finelog_startup.py
+++ b/lib/iris/tests/cluster/controller/test_finelog_startup.py
@@ -1,0 +1,40 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Controller startup must tolerate Finelog being unreachable.
+
+``LogClient.get_table`` issues a synchronous ``RegisterTable`` RPC. If Finelog
+is down, the controller should still come up — leaving the affected Table
+handle as ``None`` — and retry registration in the background.
+"""
+
+import time
+
+import pytest
+from finelog.client import LogClient
+
+pytestmark = pytest.mark.timeout(15)
+
+
+def test_controller_starts_when_finelog_table_registration_fails(make_controller, monkeypatch):
+    real_get_table = LogClient.get_table
+    call_count = {"n": 0}
+
+    def flaky_get_table(self, namespace, schema):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise ConnectionError("finelog unreachable (simulated)")
+        return real_get_table(self, namespace, schema)
+
+    monkeypatch.setattr(LogClient, "get_table", flaky_get_table)
+
+    controller = make_controller()
+
+    # Initial registration failed, so the service has no profile table yet.
+    assert controller._service._profile_table is None
+
+    # Background retry installs it on the next attempt (backoff starts ~1s).
+    deadline = time.monotonic() + 5.0
+    while controller._service._profile_table is None and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert controller._service._profile_table is not None


### PR DESCRIPTION
* make iris controller resilient to finelog being unreachable at startup
* `LogClient.get_table` issues a synchronous `RegisterTable` RPC; previously a finelog outage at startup crashed the controller even though runtime writers already null-check the resulting `Table` [^1]
* add `Controller._register_finelog_table` helper that wraps `get_table`, catches failures, and spawns a background `ManagedThread` that retries registration with bounded exponential backoff (1s → 60s)
  * on retry success the helper invokes an `on_late_success` callback so the caller can install the `Table` where runtime writers look for it
  * retry thread joins the controller's `ThreadContainer` and stops with the controller
* route the three startup `get_table` sites through the helper: K8s provider's `task_stats_table` and `profile_table`, and `ControllerServiceImpl`'s controller-process `profile_table`
* move `ControllerServiceImpl._profile_table` registration out of `__init__`; add `set_profile_table` so the controller installs it after construction (and re-installs from the retry thread)
* add `test_controller_starts_when_finelog_table_registration_fails` covering both halves: controller comes up with `_profile_table = None`, then the background retry installs it

[^1]: asymmetry confirmed by reading the codebase — `Table.write` enqueues into an in-memory buffer with bg-thread flush + retry, so once registered the table tolerates finelog outages; only the upfront synchronous `register_table` was unprotected.