### PR TITLE
Update infra status dashboard

### DIFF
--- a/infra/status-page/README.md
+++ b/infra/status-page/README.md
@@ -4,15 +4,16 @@ Internal dashboard for Marin: ferry workflow status from GitHub Actions,
 a GitHub Build panel showing aggregate CI status for the last 100
 commits on main (per-commit check-run rollup), and an Iris section
 surfacing controller reachability, worker counts (current + 24h
-history), and the 24h job-state breakdown. Deployed as Cloud Run +
-native IAP, following the `infra/iris-iap-proxy/` pattern.
+history), active-environment Iris + finelog health, and the 24h
+job-state breakdown. Deployed as Cloud Run + native IAP, following the
+`infra/iris-iap-proxy/` pattern.
 
 ## Stack
 
 - **Server** — Node 20 + TypeScript + [Hono](https://hono.dev). Exposes
   `/api/ferry`, `/api/builds`, `/api/iris`, `/api/workers`,
-  `/api/workers/history`, `/api/jobs`, `/api/health`, and serves the
-  built web UI from `web/dist`.
+  `/api/control-plane/health`, `/api/workers/history`, `/api/jobs`,
+  `/api/health`, and serves the built web UI from `web/dist`.
 - **Web** — Vite + React 18 + TypeScript + Jotai + `@tanstack/react-query`
   + Tailwind.
 - Single `package.json`, multi-stage Dockerfile, single service account,
@@ -30,6 +31,7 @@ server/
     githubActions.ts   Ferry workflow runs (REST API)
     githubCommits.ts   Build panel: per-commit CI rollup on main (GraphQL)
     iris.ts            iris controller /health caller
+    serviceHealth.ts   active env Iris + finelog /health probes
     workers.ts         iris worker counts via the ListWorkers RPC
     jobs.ts            iris 24h job-state breakdown via ExecuteRawQuery
     controllerQuery.ts helper for the raw-SQL Connect RPC
@@ -45,13 +47,15 @@ web/
       useFerry.ts   react-query hooks
       useBuilds.ts
       useIris.ts
+      useControlPlaneHealth.ts
       useWorkers.ts
       useWorkersHistory.ts
       useJobs.ts
     components/
       FerryPanel.tsx
       BuildPanel.tsx  GitHub CI, last 100 runs on main
-      IrisPanel.tsx   wraps reachability + WorkersPanel + JobsPanel
+      IrisPanel.tsx   wraps reachability + WorkersPanel + ControlPlanePanel + JobsPanel
+      ControlPlanePanel.tsx active env Iris + finelog latency chart
       WorkersPanel.tsx
       JobsPanel.tsx
     style.css       Tailwind entry
@@ -90,6 +94,12 @@ same-origin app.
 |---------------------|-----------------------------------------------------------------------|
 | `GITHUB_TOKEN`      | Required for the Build panel (GraphQL needs auth even for public repos). Also lifts Ferry's REST rate limit from 60/hr to 5000/hr. |
 | `CONTROLLER_URL`    | Override controller discovery. Set for local dev (see below).        |
+| `PROD_IRIS_URL`     | Override prod Iris health probe URL. Falls back to `CONTROLLER_URL`. |
+| `DEV_IRIS_URL`      | Override dev Iris health probe URL.                                  |
+| `PROD_FINELOG_URL`  | Override prod finelog health probe URL. Falls back to `FINELOG_URL`. |
+| `DEV_FINELOG_URL`   | Override dev finelog health probe URL.                               |
+| `FINELOG_URL`       | Legacy override for the prod finelog health probe.                   |
+| `CONTROL_PLANE_ENV` | Force control-plane health probes to `prod` or `dev`. Defaults from `CLUSTER_NAME` (`marin-dev` → `dev`, otherwise `prod`). |
 | `GCP_PROJECT`       | Defaults to `hai-gcp-models`.                                         |
 | `CONTROLLER_ZONE`   | Defaults to `us-central1-a`.                                          |
 | `CONTROLLER_LABEL`  | GCE label for controller discovery. Defaults to `iris-marin-controller`. |
@@ -118,6 +128,15 @@ gcloud compute start-iap-tunnel <instance-name> 10000 \
 CONTROLLER_URL=http://localhost:10000 npm run dev
 ```
 
+The Control Plane panel samples only the active dashboard environment:
+`prod_iris` + `prod_finelog` for prod, or `dev_iris` + `dev_finelog` for
+dev. For local development, set the matching URL overrides to any
+tunnels you have open; unset overrides fall back to GCE internal-IP
+discovery.
+Raw `/health` probes run every 30s. The chart plots rolling 5-minute
+p50 and max latency from those probes, so it is less jagged than
+plotting every individual round trip while still showing spikes.
+
 A reachable controller is a hard requirement — there is no offline
 mode, and panels that depend on the controller will surface an error
 if it's unreachable.
@@ -131,13 +150,14 @@ Ferry workflows live in `server/sources/githubActions.ts`:
 ```ts
 export const FERRY_WORKFLOWS = [
   { name: "Canary ferry", file: "marin-canary-ferry.yaml" },
-  { name: "Datakit smoke", file: "marin-smoke-datakit.yaml" },
+  { name: "CW ferry", file: "marin-canary-ferry-coreweave.yaml" },
+  { name: "Datakit ferry", file: "marin-canary-datakit-tier1.yaml" },
 ] as const;
 ```
 
 Add more by appending to the array. `file` is the workflow filename
 under `.github/workflows/`. The `main`-branch filter is hardcoded in
-`fetchWorkflowStatus`; the 30-run history window is set in
+`fetchWorkflowStatus`; the 10-day history window is set in
 `server/main.ts`.
 
 ### Build panel
@@ -172,17 +192,19 @@ Dockerfile via Cloud Build, deploys to Cloud Run with native IAP
 (`--iap`), Direct VPC egress (`private-ranges-only`), and pins
 `min/max-instances=1` so the in-process TTL cache stays warm.
 
-The service is a single Cloud Run service for the `marin` cluster; add a
-second deploy (and a second service account if desired) for `marin-dev`
-when needed.
+Each Cloud Run deployment is a single active environment. The prod
+service should use `CLUSTER_NAME=marin`/`CONTROL_PLANE_ENV=prod`; a dev
+service should use `CLUSTER_NAME=marin-dev`/`CONTROL_PLANE_ENV=dev`
+plus the dev controller discovery settings.
 
 ## Caching
 
 | Source          | Backend TTL | Frontend `refetchInterval` | Window              |
 |-----------------|-------------|----------------------------|---------------------|
-| Ferry           | 60s         | 60s                        | 30 workflow runs    |
+| Ferry           | 60s         | 60s                        | 10 days             |
 | Build           | 60s         | 60s                        | 100 commits on main |
 | Iris            | 15s         | 15s                        | current only        |
+| Control plane   | in-memory   | 30s                        | 24h ring buffer     |
 | Workers         | 15s         | 30s                        | current only        |
 | Workers history | in-memory   | 30s                        | 24h ring buffer     |
 | Jobs            | 60s         | 60s                        | 24h window          |
@@ -231,9 +253,9 @@ break** — we'll need to plumb a service-account bearer token.
   subsections via `ExecuteRawQuery` SQL. Tasks, autoscaler, and detailed
   state are available via other Connect RPC methods (all support JSON
   natively) but would need additional SQL or direct RPC calls wired up.
-- **Single cluster only** (`marin`). Extending to `marin-dev` means
-  adding a second Cloud Run service or making the existing one
-  multi-cluster.
+- **Single active environment per deployment.** Prod and dev should run
+  as separate Cloud Run services so each dashboard keeps its own worker,
+  job, and control-plane history.
 - **No wandb panels.** Deferred from v1 — see
   `scratch/projects/marin-status-page.md` for the rendered-metrics and
   screenshot options to pick from later.

--- a/infra/status-page/server/history.ts
+++ b/infra/status-page/server/history.ts
@@ -8,9 +8,10 @@
 // worker_count_history table in the controller).
 
 import type { IrisPingSample } from "./sources/iris.js";
+import type { ServiceHealthHistorySample } from "./sources/serviceHealth.js";
 import type { WorkerSample } from "./sources/workers.js";
 
-class RingBuffer<T> {
+export class RingBuffer<T> {
   private readonly capacity: number;
   private readonly buffer: (T | undefined)[];
   private head = 0;
@@ -46,3 +47,5 @@ class RingBuffer<T> {
 export class WorkerHistory extends RingBuffer<WorkerSample> {}
 
 export class IrisPingHistory extends RingBuffer<IrisPingSample> {}
+
+export class ServiceHealthHistory extends RingBuffer<ServiceHealthHistorySample> {}

--- a/infra/status-page/server/main.ts
+++ b/infra/status-page/server/main.ts
@@ -1,9 +1,10 @@
 // Hono entrypoint for the Marin status page.
 //
 // Serves:
-//   GET /api/ferry           — GitHub Actions ferry status (60s cache, last 30 runs)
+//   GET /api/ferry           — GitHub Actions ferry status (60s cache, last 10 days)
 //   GET /api/builds          — GitHub per-commit CI rollup on main (60s cache, last 100 commits)
 //   GET /api/iris            — iris controller reachability (15s cache)
+//   GET /api/control-plane/health — active env Iris + finelog health history
 //   GET /api/workers         — current iris worker counts (15s cache)
 //   GET /api/workers/history — in-memory 24h worker count ring buffer
 //   GET /api/jobs            — iris job counts for last 24h by state (60s cache)
@@ -17,7 +18,7 @@ import { serve } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { Hono } from "hono";
 import { TTLCache } from "./cache.js";
-import { IrisPingHistory, WorkerHistory } from "./history.js";
+import { IrisPingHistory, ServiceHealthHistory, WorkerHistory } from "./history.js";
 import {
   FERRY_WORKFLOWS,
   fetchWorkflowStatus,
@@ -26,9 +27,15 @@ import {
 import { fetchBuildsOnMain, type BuildsResponse } from "./sources/githubCommits.js";
 import { irisStatus, pingIris, type IrisPingResult } from "./sources/iris.js";
 import { jobsSnapshot, type JobsSnapshot } from "./sources/jobs.js";
+import {
+  serviceHealthResponse,
+  serviceHealthSample,
+  serviceHealthSnapshot,
+  type ServiceHealthSnapshot,
+} from "./sources/serviceHealth.js";
 import { workerSnapshot, type WorkersSnapshot } from "./sources/workers.js";
 
-const FERRY_HISTORY = 30;
+const FERRY_WINDOW_DAYS = 10;
 const BUILD_HISTORY = 100;
 
 const ferryCache = new TTLCache<FerryWorkflowStatus>(60_000);
@@ -38,7 +45,7 @@ const jobsCache = new TTLCache<JobsSnapshot>(60_000);
 
 // Iris controller ping sampler. We probe /health on a fixed cadence and
 // keep a rolling 1h window of successful samples so /api/iris can report
-// p50/p90/p95/p98 alongside the most recent latency. Failed pings are
+// p50/p90/p99 alongside the most recent latency. Failed pings are
 // recorded as the latest result (so the dot can flip red) but excluded
 // from the percentile window.
 const IRIS_PING_INTERVAL_MS = 2_000;
@@ -54,6 +61,9 @@ let lastIrisPing: IrisPingResult | null = null;
 const SAMPLE_INTERVAL_MS = 30_000;
 const HISTORY_CAPACITY = Math.ceil((24 * 60 * 60 * 1000) / SAMPLE_INTERVAL_MS);
 const workerHistory = new WorkerHistory(HISTORY_CAPACITY);
+const serviceHealthHistory = new ServiceHealthHistory(HISTORY_CAPACITY);
+const SERVICE_HEALTH_WINDOW_MS = 24 * 60 * 60 * 1000;
+let lastServiceHealth: ServiceHealthSnapshot[] = [];
 
 async function sampleWorkers(): Promise<void> {
   const snapshot = await workersCache.get("workers", () => workerSnapshot());
@@ -85,6 +95,12 @@ async function sampleIrisPing(): Promise<void> {
   }
 }
 
+async function sampleServiceHealth(): Promise<void> {
+  const snapshots = await serviceHealthSnapshot();
+  lastServiceHealth = snapshots;
+  serviceHealthHistory.push(serviceHealthSample(snapshots));
+}
+
 // Kick off immediately, then on a fixed cadence. unref() lets the process
 // exit cleanly during tests without waiting on the timer.
 void sampleWorkers().catch((err) => {
@@ -105,6 +121,15 @@ setInterval(() => {
   });
 }, IRIS_PING_INTERVAL_MS).unref();
 
+void sampleServiceHealth().catch((err) => {
+  console.error("service health sampler error", err);
+});
+setInterval(() => {
+  void sampleServiceHealth().catch((err) => {
+    console.error("service health sampler error", err);
+  });
+}, SAMPLE_INTERVAL_MS).unref();
+
 const app = new Hono();
 
 app.get("/api/health", (c) => c.json({ status: "ok" }));
@@ -112,10 +137,10 @@ app.get("/api/health", (c) => c.json({ status: "ok" }));
 app.get("/api/ferry", async (c) => {
   const results = await Promise.all(
     FERRY_WORKFLOWS.map((wf) =>
-      ferryCache.get(wf.file, () => fetchWorkflowStatus(wf, FERRY_HISTORY)),
+      ferryCache.get(wf.file, () => fetchWorkflowStatus(wf, FERRY_WINDOW_DAYS)),
     ),
   );
-  return c.json({ workflows: results });
+  return c.json({ windowDays: FERRY_WINDOW_DAYS, workflows: results });
 });
 
 app.get("/api/builds", async (c) => {
@@ -125,6 +150,16 @@ app.get("/api/builds", async (c) => {
 
 app.get("/api/iris", (c) => {
   return c.json(irisStatus(lastIrisPing, irisPingHistory.samples(), IRIS_PING_WINDOW_MS));
+});
+
+app.get("/api/control-plane/health", (c) => {
+  return c.json(
+    serviceHealthResponse(
+      lastServiceHealth,
+      serviceHealthHistory.samples(),
+      SERVICE_HEALTH_WINDOW_MS,
+    ),
+  );
 });
 
 app.get("/api/workers", async (c) => {

--- a/infra/status-page/server/sources/githubActions.ts
+++ b/infra/status-page/server/sources/githubActions.ts
@@ -9,6 +9,9 @@
 
 import { githubAuthHeaders, REPO } from "./github.js";
 
+const MAX_WORKFLOW_RUNS_PER_REQUEST = 100;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
 export const FERRY_WORKFLOWS = [
   { name: "Canary ferry", file: "marin-canary-ferry.yaml" },
   { name: "CW ferry", file: "marin-canary-ferry-coreweave.yaml" },
@@ -47,7 +50,8 @@ interface GhRun {
   conclusion: string | null;
   status: string;
   head_sha: string;
-  run_started_at: string;
+  created_at: string;
+  run_started_at: string | null;
   updated_at: string;
   html_url: string;
   event: string;
@@ -59,7 +63,8 @@ interface GhRunsResponse {
 }
 
 function toFerryRun(run: GhRun): FerryRun {
-  const startedMs = Date.parse(run.run_started_at);
+  const startedAt = run.run_started_at ?? run.created_at;
+  const startedMs = run.run_started_at === null ? Number.NaN : Date.parse(run.run_started_at);
   const updatedMs = Date.parse(run.updated_at);
   const durationSeconds =
     run.status === "completed" && Number.isFinite(startedMs) && Number.isFinite(updatedMs)
@@ -71,7 +76,7 @@ function toFerryRun(run: GhRun): FerryRun {
     status: run.status,
     sha: run.head_sha,
     shaShort: run.head_sha.slice(0, 7),
-    startedAt: run.run_started_at,
+    startedAt,
     durationSeconds,
     url: run.html_url,
     event: run.event,
@@ -88,12 +93,18 @@ function computeSuccessRate(runs: FerryRun[]): number | null {
 
 export async function fetchWorkflowStatus(
   workflow: WorkflowConfig,
-  historyWindow: number,
+  windowDays: number,
 ): Promise<FerryWorkflowStatus> {
+  const fetchedAt = new Date().toISOString();
+  const cutoff = new Date(Date.now() - windowDays * MS_PER_DAY);
+  const params = new URLSearchParams({
+    per_page: String(MAX_WORKFLOW_RUNS_PER_REQUEST),
+    branch: "main",
+    created: `>=${cutoff.toISOString()}`,
+  });
   const url =
     `https://api.github.com/repos/${REPO}/actions/workflows/${workflow.file}` +
-    `/runs?per_page=${historyWindow}&branch=main`;
-  const fetchedAt = new Date().toISOString();
+    `/runs?${params.toString()}`;
 
   // Every failure path returns a snapshot with `error` set instead of
   // throwing, so callers that aggregate multiple workflows with
@@ -115,7 +126,10 @@ export async function fetchWorkflowStatus(
     }
 
     const data = (await res.json()) as GhRunsResponse;
-    const history = (data.workflow_runs ?? []).map(toFerryRun);
+    const cutoffMs = cutoff.getTime();
+    const history = (data.workflow_runs ?? [])
+      .map(toFerryRun)
+      .filter((run) => Date.parse(run.startedAt) >= cutoffMs);
     return {
       name: workflow.name,
       file: workflow.file,

--- a/infra/status-page/server/sources/iris.ts
+++ b/infra/status-page/server/sources/iris.ts
@@ -23,8 +23,7 @@ export interface IrisPingSample {
 export interface PingPercentiles {
   p50: number;
   p90: number;
-  p95: number;
-  p98: number;
+  p99: number;
 }
 
 export interface IrisPingResult {
@@ -42,6 +41,7 @@ export interface IrisStatus {
   latencyMs: number | null;
   pingPercentiles: PingPercentiles | null;
   pingSampleCount: number;
+  pingSpanMs: number;
   pingWindowMs: number;
   controllerUrl: string | null;
   fetchedAt: string;
@@ -116,9 +116,15 @@ export function computePercentiles(samples: IrisPingSample[]): PingPercentiles |
   return {
     p50: Math.round(percentile(sorted, 50)),
     p90: Math.round(percentile(sorted, 90)),
-    p95: Math.round(percentile(sorted, 95)),
-    p98: Math.round(percentile(sorted, 98)),
+    p99: Math.round(percentile(sorted, 99)),
   };
+}
+
+function sampleSpanMs(samples: IrisPingSample[]): number {
+  if (samples.length < 2) return 0;
+  const first = samples[0];
+  const last = samples[samples.length - 1];
+  return Math.max(0, last.t - first.t);
 }
 
 export function irisStatus(
@@ -133,6 +139,7 @@ export function irisStatus(
     latencyMs: last?.latencyMs ?? null,
     pingPercentiles: computePercentiles(samples),
     pingSampleCount: samples.length,
+    pingSpanMs: sampleSpanMs(samples),
     pingWindowMs: windowMs,
     controllerUrl: last?.controllerUrl ?? null,
     fetchedAt,

--- a/infra/status-page/server/sources/serviceHealth.ts
+++ b/infra/status-page/server/sources/serviceHealth.ts
@@ -1,0 +1,325 @@
+// Lightweight reachability and latency probes for control-plane services.
+//
+// Each series is keyed by environment + service so prod/dev Iris and
+// prod/dev finelog never share a metric name in the API or chart. A
+// single dashboard instance only probes the active environment.
+
+import { InstancesClient } from "@google-cloud/compute";
+
+const GCP_PROJECT = process.env.GCP_PROJECT ?? "hai-gcp-models";
+const GCP_ZONE = process.env.CONTROLLER_ZONE ?? "us-central1-a";
+const CACHE_TTL_MS = 60_000;
+const HEALTH_TIMEOUT_MS = 5_000;
+const LATENCY_SUMMARY_WINDOW_MS = 5 * 60 * 1000;
+
+export type Environment = "prod" | "dev";
+type ServiceKind = "iris" | "finelog";
+
+export interface ServiceHealthSeries {
+  id: string;
+  environment: Environment;
+  service: ServiceKind;
+  name: string;
+}
+
+interface GceTarget {
+  project: string;
+  zone: string;
+  port: number;
+  filter: string;
+}
+
+interface ServiceHealthConfig extends ServiceHealthSeries {
+  urlEnvVar: string;
+  legacyUrlEnvVar?: string;
+  target: GceTarget;
+}
+
+export interface ServiceHealthSnapshot extends ServiceHealthSeries {
+  reachable: boolean;
+  latencyMs: number | null;
+  url: string | null;
+  fetchedAt: string;
+  error?: string;
+}
+
+export interface ServiceHealthHistorySample {
+  t: number;
+  latencies: Record<string, number | null>;
+  ok: Record<string, boolean>;
+}
+
+export interface ServiceLatencyStats {
+  p50: number;
+  max: number;
+}
+
+export interface ServiceHealthSummarySample {
+  t: number;
+  stats: Record<string, ServiceLatencyStats | null>;
+  sampleCounts: Record<string, number>;
+}
+
+export interface ServiceHealthResponse {
+  environment: Environment;
+  series: ServiceHealthSeries[];
+  latest: ServiceHealthSnapshot[];
+  samples: ServiceHealthHistorySample[];
+  summarySamples: ServiceHealthSummarySample[];
+  aggregationWindowMs: number;
+  windowMs: number;
+  fetchedAt: string;
+}
+
+export const SERVICE_HEALTH_CONFIGS: readonly ServiceHealthConfig[] = [
+  {
+    id: "prod_iris",
+    environment: "prod",
+    service: "iris",
+    name: "Prod Iris",
+    urlEnvVar: "PROD_IRIS_URL",
+    legacyUrlEnvVar: "CONTROLLER_URL",
+    target: {
+      project: GCP_PROJECT,
+      zone: GCP_ZONE,
+      port: 10000,
+      filter: "labels.iris-marin-controller=true AND status=RUNNING",
+    },
+  },
+  {
+    id: "prod_finelog",
+    environment: "prod",
+    service: "finelog",
+    name: "Prod finelog",
+    urlEnvVar: "PROD_FINELOG_URL",
+    legacyUrlEnvVar: "FINELOG_URL",
+    target: {
+      project: GCP_PROJECT,
+      zone: GCP_ZONE,
+      port: 10001,
+      filter: "labels.finelog-name=finelog-marin AND status=RUNNING",
+    },
+  },
+  {
+    id: "dev_iris",
+    environment: "dev",
+    service: "iris",
+    name: "Dev Iris",
+    urlEnvVar: "DEV_IRIS_URL",
+    target: {
+      project: GCP_PROJECT,
+      zone: GCP_ZONE,
+      port: 10000,
+      filter: "labels.iris-marin-dev-controller=true AND status=RUNNING",
+    },
+  },
+  {
+    id: "dev_finelog",
+    environment: "dev",
+    service: "finelog",
+    name: "Dev finelog",
+    urlEnvVar: "DEV_FINELOG_URL",
+    target: {
+      project: GCP_PROJECT,
+      zone: GCP_ZONE,
+      port: 10001,
+      filter: "labels.finelog-name=finelog-marin-dev AND status=RUNNING",
+    },
+  },
+] as const;
+
+function activeEnvironment(): Environment {
+  const explicit = process.env.CONTROL_PLANE_ENV;
+  if (explicit === "prod" || explicit === "dev") return explicit;
+
+  const cluster = (process.env.CLUSTER_NAME ?? "marin").toLowerCase();
+  return cluster.includes("dev") ? "dev" : "prod";
+}
+
+export const ACTIVE_SERVICE_ENVIRONMENT = activeEnvironment();
+const ACTIVE_SERVICE_HEALTH_CONFIGS = SERVICE_HEALTH_CONFIGS.filter(
+  (config) => config.environment === ACTIVE_SERVICE_ENVIRONMENT,
+);
+
+let client: InstancesClient | null = null;
+const urlCache = new Map<string, { url: string; expiresAt: number }>();
+
+function getClient(): InstancesClient {
+  if (!client) {
+    client = new InstancesClient();
+  }
+  return client;
+}
+
+function configuredUrl(config: ServiceHealthConfig): string {
+  return process.env[config.urlEnvVar] ?? process.env[config.legacyUrlEnvVar ?? ""] ?? "";
+}
+
+async function discoverGceUrl(config: ServiceHealthConfig): Promise<string> {
+  const override = configuredUrl(config);
+  if (override) return override;
+
+  const now = Date.now();
+  const cached = urlCache.get(config.id);
+  if (cached && cached.expiresAt > now) {
+    return cached.url;
+  }
+
+  const [instances] = await Promise.race([
+    getClient().list({
+      project: config.target.project,
+      zone: config.target.zone,
+      filter: config.target.filter,
+    }),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("GCE discovery timed out after 15s")), 15_000),
+    ),
+  ]);
+
+  if (!instances || instances.length === 0) {
+    throw new Error(`No VM found (${config.target.filter})`);
+  }
+
+  const instance = instances[0];
+  const ip = instance.networkInterfaces?.find((iface) => iface.networkIP)?.networkIP;
+  if (!ip) {
+    throw new Error(`VM ${instance.name ?? "<unknown>"} has no internal IP`);
+  }
+
+  const url = `http://${ip}:${config.target.port}`;
+  urlCache.set(config.id, { url, expiresAt: now + CACHE_TTL_MS });
+  return url;
+}
+
+function metadata(config: ServiceHealthConfig): ServiceHealthSeries {
+  return {
+    id: config.id,
+    environment: config.environment,
+    service: config.service,
+    name: config.name,
+  };
+}
+
+async function probe(config: ServiceHealthConfig): Promise<ServiceHealthSnapshot> {
+  const fetchedAt = new Date().toISOString();
+  let base: string;
+  try {
+    base = await discoverGceUrl(config);
+  } catch (err) {
+    return {
+      ...metadata(config),
+      reachable: false,
+      latencyMs: null,
+      url: null,
+      fetchedAt,
+      error: `discovery failed: ${(err as Error).message}`,
+    };
+  }
+
+  const start = performance.now();
+  try {
+    const res = await fetch(`${base.replace(/\/$/, "")}/health`, {
+      signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
+    });
+    const latencyMs = Math.round(performance.now() - start);
+    return {
+      ...metadata(config),
+      reachable: res.ok,
+      latencyMs,
+      url: base,
+      fetchedAt,
+      error: res.ok ? undefined : `/health returned ${res.status}`,
+    };
+  } catch (err) {
+    return {
+      ...metadata(config),
+      reachable: false,
+      latencyMs: null,
+      url: base,
+      fetchedAt,
+      error: `fetch failed: ${(err as Error).message}`,
+    };
+  }
+}
+
+export function serviceHealthSeries(): ServiceHealthSeries[] {
+  return ACTIVE_SERVICE_HEALTH_CONFIGS.map(metadata);
+}
+
+export async function serviceHealthSnapshot(): Promise<ServiceHealthSnapshot[]> {
+  return Promise.all(ACTIVE_SERVICE_HEALTH_CONFIGS.map(probe));
+}
+
+export function serviceHealthSample(snapshots: ServiceHealthSnapshot[]): ServiceHealthHistorySample {
+  const latencies: Record<string, number | null> = {};
+  const ok: Record<string, boolean> = {};
+  let t = Date.now();
+  for (const snapshot of snapshots) {
+    latencies[snapshot.id] = snapshot.latencyMs;
+    ok[snapshot.id] = snapshot.reachable;
+    t = Math.max(t, Date.parse(snapshot.fetchedAt));
+  }
+  return { t, latencies, ok };
+}
+
+function percentile(sorted: number[], p: number): number {
+  const idx = (p / 100) * (sorted.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+function latencyStats(values: number[]): ServiceLatencyStats | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  return {
+    p50: Math.round(percentile(sorted, 50)),
+    max: sorted[sorted.length - 1],
+  };
+}
+
+export function serviceHealthSummarySamples(
+  samples: ServiceHealthHistorySample[],
+  aggregationWindowMs = LATENCY_SUMMARY_WINDOW_MS,
+): ServiceHealthSummarySample[] {
+  const series = serviceHealthSeries();
+  return samples.map((sample, i) => {
+    const windowStart = sample.t - aggregationWindowMs;
+    const stats: Record<string, ServiceLatencyStats | null> = {};
+    const sampleCounts: Record<string, number> = {};
+
+    for (const s of series) {
+      const values: number[] = [];
+      for (let j = i; j >= 0; j -= 1) {
+        const candidate = samples[j];
+        if (candidate.t < windowStart) break;
+        const latency = candidate.latencies[s.id];
+        if (latency !== null && latency !== undefined) {
+          values.push(latency);
+        }
+      }
+      stats[s.id] = latencyStats(values);
+      sampleCounts[s.id] = values.length;
+    }
+
+    return { t: sample.t, stats, sampleCounts };
+  });
+}
+
+export function serviceHealthResponse(
+  latest: ServiceHealthSnapshot[],
+  samples: ServiceHealthHistorySample[],
+  windowMs: number,
+): ServiceHealthResponse {
+  return {
+    environment: ACTIVE_SERVICE_ENVIRONMENT,
+    series: serviceHealthSeries(),
+    latest,
+    samples,
+    summarySamples: serviceHealthSummarySamples(samples),
+    aggregationWindowMs: LATENCY_SUMMARY_WINDOW_MS,
+    windowMs,
+    fetchedAt: new Date().toISOString(),
+  };
+}

--- a/infra/status-page/web/src/api.ts
+++ b/infra/status-page/web/src/api.ts
@@ -29,6 +29,7 @@ export interface FerryWorkflowStatus {
 }
 
 export interface FerryResponse {
+  windowDays: number;
   workflows: FerryWorkflowStatus[];
 }
 
@@ -64,8 +65,7 @@ export interface BuildsResponse {
 export interface PingPercentiles {
   p50: number;
   p90: number;
-  p95: number;
-  p98: number;
+  p99: number;
 }
 
 export interface IrisStatus {
@@ -74,11 +74,58 @@ export interface IrisStatus {
   latencyMs: number | null;
   pingPercentiles: PingPercentiles | null;
   pingSampleCount: number;
+  pingSpanMs: number;
   pingWindowMs: number;
   controllerUrl: string | null;
   fetchedAt: string;
   error?: string;
   raw?: unknown;
+}
+
+export type ServiceEnvironment = "prod" | "dev";
+export type ControlPlaneService = "iris" | "finelog";
+
+export interface ServiceHealthSeries {
+  id: string;
+  environment: ServiceEnvironment;
+  service: ControlPlaneService;
+  name: string;
+}
+
+export interface ServiceHealthSnapshot extends ServiceHealthSeries {
+  reachable: boolean;
+  latencyMs: number | null;
+  url: string | null;
+  fetchedAt: string;
+  error?: string;
+}
+
+export interface ServiceHealthHistorySample {
+  t: number;
+  latencies: Record<string, number | null>;
+  ok: Record<string, boolean>;
+}
+
+export interface ServiceLatencyStats {
+  p50: number;
+  max: number;
+}
+
+export interface ServiceHealthSummarySample {
+  t: number;
+  stats: Record<string, ServiceLatencyStats | null>;
+  sampleCounts: Record<string, number>;
+}
+
+export interface ServiceHealthResponse {
+  environment: ServiceEnvironment;
+  series: ServiceHealthSeries[];
+  latest: ServiceHealthSnapshot[];
+  samples: ServiceHealthHistorySample[];
+  summarySamples: ServiceHealthSummarySample[];
+  aggregationWindowMs: number;
+  windowMs: number;
+  fetchedAt: string;
 }
 
 export interface WorkerResourceTotals {
@@ -139,6 +186,8 @@ async function getJson<T>(path: string): Promise<T> {
 export const fetchFerry = () => getJson<FerryResponse>("/api/ferry");
 export const fetchBuilds = () => getJson<BuildsResponse>("/api/builds");
 export const fetchIris = () => getJson<IrisStatus>("/api/iris");
+export const fetchControlPlaneHealth = () =>
+  getJson<ServiceHealthResponse>("/api/control-plane/health");
 export const fetchWorkers = () => getJson<WorkersSnapshot>("/api/workers");
 export const fetchWorkersHistory = () => getJson<WorkersHistoryResponse>("/api/workers/history");
 export const fetchJobs = () => getJson<JobsSnapshot>("/api/jobs");

--- a/infra/status-page/web/src/components/ControlPlanePanel.tsx
+++ b/infra/status-page/web/src/components/ControlPlanePanel.tsx
@@ -1,0 +1,177 @@
+import { useMemo } from "react";
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { ServiceHealthSeries, ServiceHealthSummarySample } from "../api";
+import { useControlPlaneHealth } from "../hooks/useControlPlaneHealth";
+import {
+  displayedSpanLabel,
+  formatClock,
+  formatDuration,
+  useContainerSize,
+} from "./chartUtils";
+
+const SERIES_COLORS: Record<string, string> = {
+  prod_iris: "#10b981",
+  prod_finelog: "#06b6d4",
+  dev_iris: "#8b5cf6",
+  dev_finelog: "#f59e0b",
+};
+
+const METRICS = ["p50", "max"] as const;
+
+const METRIC_STYLES: Record<
+  (typeof METRICS)[number],
+  { strokeDasharray?: string; strokeWidth: number }
+> = {
+  p50: { strokeWidth: 2.3 },
+  max: { strokeDasharray: "6 4", strokeWidth: 2 },
+};
+
+function lineKey(seriesId: string, metric: (typeof METRICS)[number]): string {
+  return `${seriesId}_${metric}`;
+}
+
+function useChartData(samples: ServiceHealthSummarySample[], series: ServiceHealthSeries[]) {
+  return useMemo(() => {
+    const rows = samples.map((sample) => {
+      const row: Record<string, number | null> = { t: sample.t };
+      for (const s of series) {
+        const stats = sample.stats[s.id];
+        for (const metric of METRICS) {
+          row[lineKey(s.id, metric)] = stats?.[metric] ?? null;
+        }
+      }
+      return row;
+    });
+    return rows;
+  }, [samples, series]);
+}
+
+export function ControlPlanePanel() {
+  const { data, isLoading, error } = useControlPlaneHealth();
+  const samples = data?.summarySamples ?? [];
+  const series = data?.series ?? [];
+  const latestErrors = useMemo(
+    () => (data?.latest ?? []).filter((snapshot) => !snapshot.reachable || snapshot.error),
+    [data?.latest],
+  );
+  const chartRows = useChartData(samples, series);
+  const { ref: chartRef, size: chartSize } = useContainerSize<HTMLDivElement>();
+  const aggregationLabel = data?.aggregationWindowMs
+    ? `${formatDuration(data.aggregationWindowMs)} rolling`
+    : "rolling";
+
+  return (
+    <div>
+      <div className="mb-2 flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold uppercase tracking-wider text-slate-400">
+          /health Latency
+        </h3>
+        <span className="text-xs text-slate-500">
+          {samples.length > 1
+            ? `${displayedSpanLabel(samples)} · ${aggregationLabel} · p50/max`
+            : "history warming up"}
+        </span>
+      </div>
+      <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+        {isLoading && <div className="text-slate-400">loading…</div>}
+        {error && (
+          <div className="text-rose-400">failed to load: {(error as Error).message}</div>
+        )}
+        {data && (
+          <>
+            {latestErrors.length > 0 && (
+              <div className="mb-3 space-y-1 text-xs text-rose-400">
+                {latestErrors.map((snapshot) => (
+                  <div key={snapshot.id}>
+                    {snapshot.name}: {snapshot.error ?? "unreachable"}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div ref={chartRef} className="h-56 w-full">
+              {samples.length > 1 && chartSize && series.length > 0 ? (
+                <LineChart
+                  width={chartSize.width}
+                  height={chartSize.height}
+                  data={chartRows}
+                  margin={{ top: 4, right: 8, bottom: 4, left: 12 }}
+                >
+                  <CartesianGrid stroke="#1e293b" strokeDasharray="2 4" />
+                  <XAxis
+                    dataKey="t"
+                    type="number"
+                    domain={["dataMin", "dataMax"]}
+                    tickFormatter={formatClock}
+                    stroke="#475569"
+                    fontSize={11}
+                  />
+                  <YAxis
+                    width={58}
+                    stroke="#475569"
+                    fontSize={11}
+                    tickFormatter={(value) => `${value}ms`}
+                    label={{
+                      value: "Latency (ms)",
+                      angle: -90,
+                      position: "insideLeft",
+                      style: { fill: "#64748b", fontSize: 11 },
+                    }}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      background: "#0f172a",
+                      border: "1px solid #1e293b",
+                      borderRadius: 4,
+                      fontSize: 12,
+                    }}
+                    formatter={(value, name) => [
+                      typeof value === "number" ? `${value}ms` : "down",
+                      name,
+                    ]}
+                    labelFormatter={(value) => new Date(value as number).toLocaleString()}
+                  />
+                  <Legend
+                    verticalAlign="bottom"
+                    height={20}
+                    iconType="plainline"
+                    wrapperStyle={{ fontSize: 11, color: "#94a3b8" }}
+                  />
+                  {series.flatMap((s) =>
+                    METRICS.map((metric) => (
+                      <Line
+                        key={lineKey(s.id, metric)}
+                        type="monotone"
+                        dataKey={lineKey(s.id, metric)}
+                        name={`${s.name} ${metric}`}
+                        stroke={SERIES_COLORS[s.id] ?? "#94a3b8"}
+                        strokeWidth={METRIC_STYLES[metric].strokeWidth}
+                        strokeDasharray={METRIC_STYLES[metric].strokeDasharray}
+                        dot={false}
+                        isAnimationActive={false}
+                        connectNulls
+                      />
+                    )),
+                  )}
+                </LineChart>
+              ) : (
+                <div className="flex h-full items-center justify-center text-sm text-slate-500">
+                  history warming up — probes run every 30s, chart shows rolling
+                  p50/max once we have two points
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/infra/status-page/web/src/components/FerryPanel.tsx
+++ b/infra/status-page/web/src/components/FerryPanel.tsx
@@ -104,10 +104,10 @@ function WorkflowCard({ wf }: { wf: FerryWorkflowStatus }) {
     (r) => r.status === "completed" && r.conclusion !== null,
   ).length;
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
-      <div className="flex items-baseline justify-between gap-4">
-        <h3 className="text-lg font-semibold text-slate-100">{wf.name}</h3>
-        <span className="text-xs text-slate-500">{wf.file}</span>
+    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-3">
+      <div className="min-w-0">
+        <h3 className="truncate text-base font-semibold text-slate-100">{wf.name}</h3>
+        <div className="truncate text-xs text-slate-500">{wf.file}</div>
       </div>
 
       {wf.error ? (
@@ -141,8 +141,7 @@ function WorkflowCard({ wf }: { wf: FerryWorkflowStatus }) {
           </div>
 
           {/* Single-row strip — dots and inter-dot gap shrink on mobile
-              so all 30 fit on a ~340px phone content area without
-              wrapping to a second row. */}
+              so the visible window fits without wrapping to a second row. */}
           <div className="mt-3 flex gap-px sm:gap-1">
             {visualHistory.map(({ run, index }) => {
               const a = runAppearance(run);
@@ -196,14 +195,20 @@ export function FerryPanel() {
     <section>
       <div className="mb-3 flex items-baseline justify-between">
         <h2 className="text-xl font-semibold text-slate-200">Ferries</h2>
-        <span className="text-xs text-slate-500">
-          {dataUpdatedAt ? `updated ${formatRelative(new Date(dataUpdatedAt).toISOString())}` : ""}
-        </span>
+        <div className="text-right text-xs text-slate-500">
+          {data && <span>last {data.windowDays}d</span>}
+          {dataUpdatedAt && (
+            <span>
+              {data ? " · " : ""}
+              updated {formatRelative(new Date(dataUpdatedAt).toISOString())}
+            </span>
+          )}
+        </div>
       </div>
       {isLoading && <div className="text-slate-400">loading…</div>}
       {error && <div className="text-rose-400">failed to load: {(error as Error).message}</div>}
       {data && (
-        <div className="grid gap-3 md:grid-cols-2">
+        <div className="grid gap-3 md:grid-cols-3">
           {data.workflows.map((wf) => (
             <WorkflowCard key={wf.file} wf={wf} />
           ))}

--- a/infra/status-page/web/src/components/IrisPanel.tsx
+++ b/infra/status-page/web/src/components/IrisPanel.tsx
@@ -1,4 +1,6 @@
 import { useIris } from "../hooks/useIris";
+import { formatDuration } from "./chartUtils";
+import { ControlPlanePanel } from "./ControlPlanePanel";
 import { JobsPanel } from "./JobsPanel";
 import { WorkersPanel } from "./WorkersPanel";
 
@@ -9,6 +11,11 @@ function formatRelative(iso: string): string {
   if (seconds < 60) return `${seconds}s ago`;
   const minutes = Math.round(seconds / 60);
   return `${minutes}m ago`;
+}
+
+function percentileTitle(spanMs: number, count: number): string {
+  if (spanMs > 0) return `over last ${formatDuration(spanMs)}, n=${count}`;
+  return `n=${count}`;
 }
 
 export function IrisPanel() {
@@ -37,10 +44,10 @@ export function IrisPanel() {
             {data.pingPercentiles && (
               <span
                 className="text-xs text-slate-500"
-                title={`over last ${Math.round(data.pingWindowMs / 60_000)}m, n=${data.pingSampleCount}`}
+                title={percentileTitle(data.pingSpanMs, data.pingSampleCount)}
               >
-                · p50 {data.pingPercentiles.p50}ms · p90 {data.pingPercentiles.p90}ms · p95{" "}
-                {data.pingPercentiles.p95}ms · p98 {data.pingPercentiles.p98}ms
+                · p50 {data.pingPercentiles.p50}ms · p90 {data.pingPercentiles.p90}ms · p99{" "}
+                {data.pingPercentiles.p99}ms
               </span>
             )}
             {data.controllerUrl && (
@@ -67,6 +74,7 @@ export function IrisPanel() {
         )}
         {data?.error && <div className="text-sm text-rose-400">{data.error}</div>}
         <WorkersPanel />
+        <ControlPlanePanel />
         <JobsPanel />
       </div>
     </section>

--- a/infra/status-page/web/src/components/WorkersPanel.tsx
+++ b/infra/status-page/web/src/components/WorkersPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import {
   CartesianGrid,
   Legend,
@@ -11,6 +11,7 @@ import {
 import type { WorkerResourceTotals, WorkerSample } from "../api";
 import { useWorkers } from "../hooks/useWorkers";
 import { useWorkersHistory } from "../hooks/useWorkersHistory";
+import { displayedSpanLabel, formatClock, useContainerSize } from "./chartUtils";
 
 // Palette for per-region chart lines. Picked for good contrast on the
 // dark background; cycles if there are more regions than entries.
@@ -24,13 +25,6 @@ const REGION_COLORS = [
   "#14b8a6", // teal-500
   "#3b82f6", // blue-500
 ];
-
-function formatClock(ms: number): string {
-  const d = new Date(ms);
-  const hh = d.getHours().toString().padStart(2, "0");
-  const mm = d.getMinutes().toString().padStart(2, "0");
-  return `${hh}:${mm}`;
-}
 
 // Turn total_cpu_millicores into a human-readable CPU-core count.
 // 1000 millicores = 1 full core. k-suffix for anything above ~10k.
@@ -101,29 +95,6 @@ function ResourceLine({ resources }: { resources: WorkerResourceTotals }) {
   );
 }
 
-function useContainerSize<T extends HTMLElement>() {
-  const [node, setNode] = useState<T | null>(null);
-  const [size, setSize] = useState<{ width: number; height: number } | null>(null);
-
-  const ref = useCallback((el: T | null) => setNode(el), []);
-
-  useEffect(() => {
-    if (!node) return;
-    const obs = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        const { width, height } = entry.contentRect;
-        if (width > 0 && height > 0) {
-          setSize({ width, height });
-        }
-      }
-    });
-    obs.observe(node);
-    return () => obs.disconnect();
-  }, [node]);
-
-  return { ref, size };
-}
-
 // Flatten `{t, regions: {us-west4: 232, ...}}` samples into
 // `{t, "us-west4": 232, ...}` rows that recharts can consume via
 // `dataKey={region}` on each <Line>. Also returns the ordered list of
@@ -187,7 +158,7 @@ export function WorkersPanel() {
         </h3>
         <span className="text-xs text-slate-500">
           {samples.length > 1
-            ? `${samples.length} samples · last 24h`
+            ? `${samples.length} samples · ${displayedSpanLabel(samples)}`
             : "history warming up"}
         </span>
       </div>
@@ -209,7 +180,7 @@ export function WorkersPanel() {
                   width={chartSize.width}
                   height={chartSize.height}
                   data={chartRows}
-                  margin={{ top: 4, right: 8, bottom: 4, left: -16 }}
+                  margin={{ top: 4, right: 8, bottom: 4, left: 12 }}
                 >
                   <CartesianGrid stroke="#1e293b" strokeDasharray="2 4" />
                   <XAxis
@@ -220,7 +191,17 @@ export function WorkersPanel() {
                     stroke="#475569"
                     fontSize={11}
                   />
-                  <YAxis stroke="#475569" fontSize={11} />
+                  <YAxis
+                    width={58}
+                    stroke="#475569"
+                    fontSize={11}
+                    label={{
+                      value: "Workers",
+                      angle: -90,
+                      position: "insideLeft",
+                      style: { fill: "#64748b", fontSize: 11 },
+                    }}
+                  />
                   <Tooltip
                     contentStyle={{
                       background: "#0f172a",

--- a/infra/status-page/web/src/components/chartUtils.ts
+++ b/infra/status-page/web/src/components/chartUtils.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from "react";
+
+export function formatClock(ms: number): string {
+  const d = new Date(ms);
+  const hh = d.getHours().toString().padStart(2, "0");
+  const mm = d.getMinutes().toString().padStart(2, "0");
+  return `${hh}:${mm}`;
+}
+
+export function formatDuration(ms: number): string {
+  if (ms < 60_000) return `${Math.max(1, Math.round(ms / 1000))}s`;
+  const minutes = Math.round(ms / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  if (hours < 24) {
+    return remMinutes === 0 ? `${hours}h` : `${hours}h ${remMinutes}m`;
+  }
+  const days = Math.floor(hours / 24);
+  const remHours = hours % 24;
+  return remHours === 0 ? `${days}d` : `${days}d ${remHours}h`;
+}
+
+export function displayedSpanLabel(samples: { t: number }[]): string {
+  if (samples.length < 2) return "history warming up";
+  const first = samples[0]?.t;
+  const last = samples[samples.length - 1]?.t;
+  if (first === undefined || last === undefined || last <= first) {
+    return "history warming up";
+  }
+  return `last ${formatDuration(last - first)}`;
+}
+
+export function useContainerSize<T extends HTMLElement>() {
+  const [node, setNode] = useState<T | null>(null);
+  const [size, setSize] = useState<{ width: number; height: number } | null>(null);
+
+  const ref = useCallback((el: T | null) => setNode(el), []);
+
+  useEffect(() => {
+    if (!node) return;
+    const obs = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        if (width > 0 && height > 0) {
+          setSize({ width, height });
+        }
+      }
+    });
+    obs.observe(node);
+    return () => obs.disconnect();
+  }, [node]);
+
+  return { ref, size };
+}

--- a/infra/status-page/web/src/hooks/useControlPlaneHealth.ts
+++ b/infra/status-page/web/src/hooks/useControlPlaneHealth.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
+import { fetchControlPlaneHealth } from "../api";
+import { autoRefreshAtom } from "../state";
+
+// Matches the backend sampler cadence.
+const REFETCH_INTERVAL_MS = 30_000;
+
+export function useControlPlaneHealth() {
+  const autoRefresh = useAtomValue(autoRefreshAtom);
+  return useQuery({
+    queryKey: ["control-plane", "health"],
+    queryFn: fetchControlPlaneHealth,
+    refetchInterval: autoRefresh ? REFETCH_INTERVAL_MS : false,
+    staleTime: 15_000,
+  });
+}


### PR DESCRIPTION
## Summary
- Show ferry status over the last 10 days and keep the three ferry workflows on one row.
- Add Iris/finelog `/health` latency tracking below the worker chart.
- Keep prod/dev dashboards scoped to their own control plane: prod shows `prod_iris` + `prod_finelog`, dev shows `dev_iris` + `dev_finelog`.
- Plot rolling 5m `p50` and `max` latency, and label history with the actual displayed span after restarts.

## Validation
- `npm run build`