### PR TITLE
[tokenize] _exemplar_for: scan past empty leading shards

### DIFF
--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -266,9 +266,25 @@ def _exemplar_for(
     The exemplar still carries ``id`` (because the shared tokenize pipeline emits
     ``{id, input_ids, ...}``); :func:`build_from_datasets` strips it before
     writing the cache.
+
+    Scans input files in order until one yields a record. Tolerates sparse
+    inputs (e.g. filtered ``write_parquet`` output where leading shards happen
+    to be empty) instead of failing on ``results[0]``.
     """
     sample_path = parquet_window_hint(file_groups)
-    ds = Dataset.from_list(file_groups[0][0:1]).flat_map(load_file)
+    candidates = [path for group in file_groups for path in group]
+    if not candidates:
+        raise ValueError("_exemplar_for: file_groups is empty")
+
+    first_non_empty: str | None = None
+    for path in candidates:
+        if next(iter(load_file(path)), None) is not None:
+            first_non_empty = path
+            break
+    if first_non_empty is None:
+        raise ValueError(f"_exemplar_for: no records found across {len(candidates)} input files")
+
+    ds = Dataset.from_list([first_non_empty]).flat_map(load_file)
     pipeline, _ = tokenize_pipeline(
         ds,
         data_format=config.format,

--- a/tests/processing/tokenize/test_tokenize.py
+++ b/tests/processing/tokenize/test_tokenize.py
@@ -2,9 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import tempfile
+from pathlib import Path
 
 import jax
 import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 from levanter.data.mixture import MixtureDataset
 from levanter.data.text import TextLmDatasetFormat
@@ -229,3 +233,36 @@ def test_tokenize_full_pipeline_integration(tmp_path):
     assert mixture_example is not None
     assert "input_ids" in mixture_example
     print("\nSuccessfully created mixture and sampled example!")
+
+
+def test_exemplar_for_skips_empty_leading_shard(tmp_path):
+    """Regression for #5790: tokenize must not raise IndexError when shard 0
+    is an empty parquet. ``_exemplar_for`` now scans files until one yields
+    a record.
+    """
+    # pytest's tmp_path contains "test" (e.g. ``.../test_<func>_0/``), which
+    # would trip _validate_train_urls. Use a vanilla tmpdir for the data so
+    # ``train_paths`` doesn't hit the validator.
+    with tempfile.TemporaryDirectory(prefix="sparse_") as raw_dir:
+        data_dir = Path(raw_dir)
+        pq.write_table(
+            pa.table({"text": pa.array([], type=pa.string())}),
+            str(data_dir / "data-00000.parquet"),
+        )
+        pq.write_table(
+            pa.table({"text": ["hello world"]}),
+            str(data_dir / "data-00001.parquet"),
+        )
+
+        config = TokenizeConfig(
+            train_paths=[f"{data_dir}/*.parquet"],
+            validation_paths=[],
+            cache_path=str(tmp_path / "cache"),
+            tokenizer="gpt2",
+            format=TextLmDatasetFormat(text_key="text"),
+        )
+        tokenize(config)
+
+    ledger = CacheLedger.load(str(tmp_path / "cache" / "train"))
+    assert ledger.is_finished
+    assert ledger.total_num_rows == 1

--- a/tests/processing/tokenize/test_tokenize.py
+++ b/tests/processing/tokenize/test_tokenize.py
@@ -235,14 +235,10 @@ def test_tokenize_full_pipeline_integration(tmp_path):
     print("\nSuccessfully created mixture and sampled example!")
 
 
+@pytest.mark.slow
 def test_exemplar_for_skips_empty_leading_shard(tmp_path):
-    """Regression for #5790: tokenize must not raise IndexError when shard 0
-    is an empty parquet. ``_exemplar_for`` now scans files until one yields
-    a record.
-    """
-    # pytest's tmp_path contains "test" (e.g. ``.../test_<func>_0/``), which
-    # would trip _validate_train_urls. Use a vanilla tmpdir for the data so
-    # ``train_paths`` doesn't hit the validator.
+    """Regression for #5790."""
+    # train_paths must not contain "test"; pytest's tmp_path always does.
     with tempfile.TemporaryDirectory(prefix="sparse_") as raw_dir:
         data_dir = Path(raw_dir)
         pq.write_table(


### PR DESCRIPTION
## Summary
- Fixes #5790: `_exemplar_for` crashed on `results[0]` when shard 0 was empty (e.g. an empty-footer parquet from a filtered `write_parquet` that emits one output per input shard).
- Walks files in `file_groups` in order, taking the first one whose `load_file()` yields a record. Raises a clear `ValueError` naming the file count if every input is empty.
- Adds a regression test (`test_exemplar_for_skips_empty_leading_shard`) mirroring the issue's repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)