### PR TITLE
[zephyr] Allow for running mulitple threads / processes per worker

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -477,9 +477,13 @@ class ZephyrCoordinator:
         self._stage_done = threading.Event()
         # When True, pull_task returns SHUTDOWN to idle workers (stage complete).
         self._stage_complete: bool = False
+        # When True, idle workers on the last stage receive SHUTDOWN once all
+        # tasks are in-flight, so they exit eagerly instead of polling until
+        # coordinator.shutdown().
+        self._is_last_stage: bool = False
         # Stage type for the currently running stage; workers poll this to know
         # how many subprocess slots to create.
-        self._current_stage_type: StageType | None = None
+        self._current_stage: PhysicalStage | None = None
         self._initialized: bool = False
         self._pipeline_running: bool = False
 
@@ -570,12 +574,12 @@ class ZephyrCoordinator:
         spin up the right number of subprocess slots.
         """
         with self._lock:
-            return self._current_stage_type
+            return self._current_stage.stage_type if self._current_stage is not None else None
 
     def _mark_stage_complete(self) -> None:
         with self._lock:
             self._stage_complete = True
-            self._current_stage_type = None
+            self._current_stage = None
 
     def _coordinator_loop(self) -> None:
         """Background loop for heartbeat checking and worker job monitoring."""
@@ -861,7 +865,7 @@ class ZephyrCoordinator:
                 return None
 
             if not self._task_queue:
-                if self._stage_complete:
+                if self._is_last_stage or self._stage_complete:
                     # No more work to hand out — exit immediately.  If an
                     # in-flight worker crashes and its shard is requeued, Iris
                     # restarts the worker which re-registers and picks it up.
@@ -1006,6 +1010,7 @@ class ZephyrCoordinator:
         stage_name: str,
         current_stage_index: int,
         tasks: list[ShardTask],
+        is_last_stage: bool = False,
     ) -> None:
         """Load a new stage's tasks into the queue."""
         with self._lock:
@@ -1026,6 +1031,7 @@ class ZephyrCoordinator:
             self._task_infra_attempts = {task.shard_idx: 0 for task in tasks}
             self._shard_errors = {}
             self._fatal_error = None
+            self._is_last_stage = is_last_stage
             self._stage_complete = False
             self._stage_epoch += 1
             # Only reset in-flight worker snapshots; completed snapshots
@@ -1112,6 +1118,11 @@ class ZephyrCoordinator:
             if not shards:
                 return []
 
+            last_worker_stage_idx = max(
+                (i for i, s in enumerate(plan.stages) if s.stage_type != StageType.RESHARD),
+                default=-1,
+            )
+
             with self._lock:
                 self._current_stage_index = 0
                 self._plan_stages = list(plan.stages)
@@ -1128,6 +1139,7 @@ class ZephyrCoordinator:
                     stage_label=f"stage{stage_idx}-{stage.stage_name(max_length=40)}",
                     stage_index_for_state=stage_idx,
                     aux_per_shard=aux_per_shard,
+                    is_last_stage=(stage_idx == last_worker_stage_idx),
                 )
 
             # Flatten final results — each shard may involve I/O (unpickling from
@@ -1155,6 +1167,7 @@ class ZephyrCoordinator:
         stage_label: str,
         stage_index_for_state: int,
         aux_per_shard: list[dict[int, Shard]] | None = None,
+        is_last_stage: bool = False,
     ) -> list[Shard]:
         """Submit a worker stage, wait for completion, return regrouped output shards.
 
@@ -1163,17 +1176,15 @@ class ZephyrCoordinator:
         so progress reports stay attached to the user-visible stage.
         """
         with self._lock:
-            self._current_stage_type = stage.stage_type
+            self._current_stage = stage
 
         tasks = _compute_tasks_from_shards(shards, stage, stage_name=stage_label, aux_per_shard=aux_per_shard)
         logger.info(
             "[%s] Starting stage %s (%s) with %d tasks", self._execution_id, stage_label, stage.stage_type, len(tasks)
         )
-        self._start_stage(stage_label, stage_index_for_state, tasks)
+        self._start_stage(stage_label, stage_index_for_state, tasks, is_last_stage=is_last_stage)
         self._wait_for_stage()
 
-        # Signal idle workers to exit their per-stage thread pools. Workers poll
-        # get_current_stage_type() for the next stage after their threads exit.
         self._mark_stage_complete()
 
         result_refs = self._collect_results()
@@ -1362,15 +1373,17 @@ class ZephyrWorker:
             for sub_id in sub_ids:
                 try:
                     epoch = self._coordinator.register_worker.remote(sub_id, self._actor_handle).result(timeout=30.0)
-                    if stage_epoch is not None and stage_epoch != epoch:
-                        raise RuntimeError(
-                            f"Received different stage epochs when registering workers within a stage. "
-                            f"Got {epoch} (expected {stage_epoch})"
-                        )
-                    stage_epoch = epoch
                 except Exception:
                     failed_workers.add(sub_id)
                     logger.warning("[%s] Failed to register sub-worker %s", self._worker_id, sub_id, exc_info=True)
+                    continue
+
+                if stage_epoch is not None and stage_epoch != epoch:
+                    raise RuntimeError(
+                        f"Received different stage epochs when registering workers within a stage. "
+                        f"Got {epoch} (expected {stage_epoch})"
+                    )
+                stage_epoch = epoch
 
             self._active_sub_ids = list(sub_ids - failed_workers)
             num_active_workers = len(self._active_sub_ids)
@@ -1398,7 +1411,7 @@ class ZephyrWorker:
                 try:
                     self._coordinator.deregister_worker.remote(sub_id).result(timeout=10.0)
                 except Exception:
-                    logger.debug("[%s] deregister_worker failed for %s (ignored)", self._worker_id, sub_id)
+                    logger.warning("[%s] deregister_worker failed for %s (ignoring)", self._worker_id, sub_id)
 
         logger.info("[%s] Stage manager exiting", self._worker_id)
         if self._host_shutdown_event is not None:

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -46,10 +46,12 @@ from rigging.timing import ExponentialBackoff, RateLimiter, log_time
 
 from zephyr.dataset import Dataset
 from zephyr.plan import (
+    Fold,
     Join,
     PhysicalOp,
     PhysicalPlan,
     PhysicalStage,
+    Reduce,
     Scatter,
     Shard,
     SourceItem,
@@ -390,7 +392,7 @@ class StageRunner(Protocol):
     def live_counters(self) -> dict[str, int]: ...
 
 
-def _default_stage_runner_factory_for(client: Client) -> Callable[[], StageRunner]:
+def _default_stage_runner_factory_for(client: Client) -> Callable[[int], StageRunner]:
     """Pick the default ``stage_runner_factory`` based on the client type.
 
     ``LocalClient`` is the dev/test backend — workers are threads in a
@@ -403,11 +405,25 @@ def _default_stage_runner_factory_for(client: Client) -> Callable[[], StageRunne
     if isinstance(client, LocalClient):
         from zephyr.runners import InlineRunner  # circular import: runners imports execution
 
-        return InlineRunner
+        return lambda n: InlineRunner(num_workers=n)
 
     from zephyr.runners import SubprocessRunner  # circular import: runners imports execution
 
-    return SubprocessRunner
+    return lambda n: SubprocessRunner(num_workers=n)
+
+
+def _classify_stage(stage: PhysicalStage) -> str:
+    """Return ``'reduce'`` if the stage contains shuffle/reduce/fold/join ops, else ``'map'``.
+
+    Reduce-type stages (produced by GroupByOp, ReduceOp, JoinOp) are
+    memory-intensive due to scatter buffers or merge-sort scratch space.
+    Map-type stages (produced by MapOp, FilterOp, WriteOp, etc.) are
+    typically CPU-bound with lower per-task memory.
+    """
+    for op in stage.operations:
+        if isinstance(op, (Scatter, Reduce, Fold, Join)):
+            return "reduce"
+    return "map"
 
 
 # ---------------------------------------------------------------------------
@@ -475,6 +491,11 @@ class ZephyrCoordinator:
         # ``_wait_for_stage`` wakes immediately instead of sleeping out its backoff.
         self._stage_done = threading.Event()
         self._is_last_stage: bool = False
+        # When True, pull_task returns SHUTDOWN to idle workers (stage complete).
+        self._stage_complete: bool = False
+        # Stage type for the currently running stage; workers poll this to know
+        # how many subprocess slots to create.
+        self._current_stage_type: str | None = None
         self._initialized: bool = False
         self._pipeline_running: bool = False
 
@@ -545,8 +566,28 @@ class ZephyrCoordinator:
             self._worker_handles[worker_id] = worker_handle
             self._worker_states[worker_id] = WorkerState.READY
             self._last_seen[worker_id] = time.monotonic()
-
             logger.info("Worker %s registered, total: %d", worker_id, len(self._worker_handles))
+
+    def deregister_worker(self, worker_id: str) -> None:
+        """Remove a sub-worker that has finished its stage pool."""
+        with self._lock:
+            self._worker_handles.pop(worker_id, None)
+            self._worker_states.pop(worker_id, None)
+            self._last_seen.pop(worker_id, None)
+
+    def get_current_stage_type(self) -> str | None:
+        """Return the stage type currently running, or ``None`` if between stages.
+
+        Workers poll this between stages to discover the next stage type and
+        spin up the right number of subprocess slots.
+        """
+        with self._lock:
+            return self._current_stage_type
+
+    def _mark_stage_complete(self) -> None:
+        with self._lock:
+            self._stage_complete = True
+            self._current_stage_type = None
 
     def _coordinator_loop(self) -> None:
         """Background loop for heartbeat checking and worker job monitoring."""
@@ -819,7 +860,7 @@ class ZephyrCoordinator:
                 return None
 
             if not self._task_queue:
-                if self._is_last_stage:
+                if self._is_last_stage or self._stage_complete:
                     # No more work to hand out — exit immediately.  If an
                     # in-flight worker crashes and its shard is requeued, Iris
                     # restarts the worker which re-registers and picks it up.
@@ -986,6 +1027,7 @@ class ZephyrCoordinator:
             self._shard_errors = {}
             self._fatal_error = None
             self._is_last_stage = is_last_stage
+            self._stage_complete = False
             # Only reset in-flight worker snapshots; completed snapshots
             # accumulate across stages for full pipeline visibility.
             self._worker_counters = {}
@@ -1131,11 +1173,21 @@ class ZephyrCoordinator:
         UI/logging — for join right-sub-stages this is the *parent* stage index
         so progress reports stay attached to the user-visible stage.
         """
+        stage_type = _classify_stage(stage)
+        with self._lock:
+            self._current_stage_type = stage_type
+
         tasks = _compute_tasks_from_shards(shards, stage, stage_name=stage_label, aux_per_shard=aux_per_shard)
-        logger.info("[%s] Starting stage %s with %d tasks", self._execution_id, stage_label, len(tasks))
+        logger.info("[%s] Starting stage %s (%s) with %d tasks", self._execution_id, stage_label, stage_type, len(tasks))
         self._start_stage(stage_label, stage_index_for_state, tasks, is_last_stage=is_last_stage)
         self._wait_for_stage()
+
+        # Signal idle workers to exit their per-stage thread pools. Workers poll
+        # get_current_stage_type() for the next stage after their threads exit.
+        self._mark_stage_complete()
+
         result_refs = self._collect_results()
+
         stage_is_scatter = any(isinstance(op, Scatter) for op in stage.operations)
         return _regroup_result_refs(
             result_refs,
@@ -1223,128 +1275,171 @@ class ZephyrCoordinator:
 
 
 class ZephyrWorker:
-    """Long-lived worker actor that polls coordinator for tasks.
+    """Long-lived worker actor that drives per-stage subprocess thread pools.
 
-    Workers register themselves with the coordinator on startup via
-    register_worker(), then poll continuously until receiving a SHUTDOWN
-    signal. Each task includes the execution config (shared data, chunk
-    prefix, execution ID), so workers can handle multiple executions
-    without restart.
+    For each stage the coordinator makes available, the worker polls
+    ``get_current_stage_type()``, creates ``map_workers_per_actor`` or
+    ``reduce_workers_per_actor`` subprocess slots, runs them until they drain
+    the stage and receive SHUTDOWN, then deregisters and loops.
+
+    Each slot registers with the coordinator under a unique sub-ID
+    ``"{base_id}:{i}"`` so the coordinator's task-dispatch and in-flight
+    tracking remain clean and predictable.
     """
 
     def __init__(
         self,
         coordinator_handle: ActorHandle,
-        stage_runner_factory: Callable[[], StageRunner] | None = None,
+        stage_runner_factory: Callable[[int], StageRunner] | None = None,
+        map_workers_per_actor: int = 1,
+        reduce_workers_per_actor: int = 1,
     ):
         # ZephyrContext normally pre-resolves this via _CoordinatorJobConfig;
-        # the fallback here covers callers that construct a worker directly
-        # (mostly internal tests). Default to InlineRunner since direct
-        # construction is a dev/test path.
+        # the fallback covers callers that construct a worker directly (tests).
         if stage_runner_factory is None:
             from zephyr.runners import InlineRunner  # circular import: runners imports execution
 
-            stage_runner_factory = InlineRunner
+            stage_runner_factory = lambda n: InlineRunner(num_workers=n)  # noqa: E731
 
         self._coordinator = coordinator_handle
+        self._stage_runner_factory = stage_runner_factory
+        self._num_map_workers = map_workers_per_actor
+        self._num_reduce_workers = reduce_workers_per_actor
         self._shutdown_event = threading.Event()
         self._counter_generation: int = 0
         self._last_reported_counters: dict[str, int] = {}
-        # Each worker owns its runner instance; the heartbeat thread polls
-        # ``live_counters()`` off it while a task is in flight.
-        self._stage_runner: StageRunner = stage_runner_factory()
-        self._current_task: ShardTask | None = None  # set while executing a shard
-        self._task_monotonic_start: float = 0.0
+        # Runners and sub-IDs for currently active slots — written by _stage_manager,
+        # read (snapshotted) by heartbeat thread.
+        self._active_runners: list[StageRunner] = []
+        self._active_sub_ids: list[str] = []
+        self._active_task_count: int = 0
+        self._current_stage_name: str = ""
 
         # Throttle Iris status pushes; the heartbeat loop ticks faster than
         # the UI needs to refresh.
         self._iris_status_limiter = RateLimiter(interval_seconds=10.0)
 
-        # Capture shutdown_event from the actor context while the ContextVar
-        # is still set (child threads in Python <3.12 don't inherit it).
+        # Capture actor context while ContextVar is still set (child threads
+        # in Python <3.12 don't inherit it).
         actor_ctx = current_actor()
         self._host_shutdown_event = actor_ctx.shutdown_event
         self._worker_id = f"{actor_ctx.group_name}-{actor_ctx.index}"
+        self._actor_handle = actor_ctx.handle
 
-        # Register with coordinator - wait is not stricly necessary, but it reduces the complexity
-        self._coordinator.register_worker.remote(self._worker_id, actor_ctx.handle).result(timeout=60.0)
-
-        # Start polling in a background thread
-        self._polling_thread = threading.Thread(
-            target=self._run_polling,
+        threading.Thread(
+            target=self._heartbeat_loop,
             args=(coordinator_handle,),
             daemon=True,
-            name=f"zephyr-poll-{self._worker_id}",
-        )
-        self._polling_thread.start()
+            name=f"zephyr-hb-{self._worker_id}",
+        ).start()
+
+        threading.Thread(
+            target=self._stage_manager,
+            daemon=True,
+            name=f"zephyr-stage-{self._worker_id}",
+        ).start()
+
+    def _stage_manager(self) -> None:
+        """Drive per-stage thread-pool lifecycle.
+
+        Polls the coordinator for the current stage type, spins up N sub-worker
+        threads (N = map or reduce worker count), waits for them to drain and
+        exit on SHUTDOWN, then deregisters and loops for the next stage.
+        """
+        logger.info("[%s] Stage manager starting", self._worker_id)
+        backoff = ExponentialBackoff(initial=0.1, maximum=2.0)
+
+        while not self._shutdown_event.is_set():
+            try:
+                stage_type = self._coordinator.get_current_stage_type.remote().result(timeout=10.0)
+            except Exception as e:
+                logger.debug("[%s] get_current_stage_type failed: %s", self._worker_id, e)
+                self._shutdown_event.wait(timeout=1.0)
+                continue
+
+            if stage_type is None:
+                self._shutdown_event.wait(timeout=backoff.next_interval())
+                continue
+
+            backoff.reset()
+            n = self._num_map_workers if stage_type == "map" else self._num_reduce_workers
+            logger.info("[%s] Stage '%s' starting, %d slot(s)", self._worker_id, stage_type, n)
+
+            runners = [self._stage_runner_factory(n) for _ in range(n)]
+            sub_ids = [f"{self._worker_id}:{i}" for i in range(n)]
+
+            for sub_id in sub_ids:
+                try:
+                    self._coordinator.register_worker.remote(sub_id, self._actor_handle).result(timeout=30.0)
+                except Exception:
+                    logger.warning("[%s] Failed to register sub-worker %s", self._worker_id, sub_id, exc_info=True)
+
+            self._active_runners = runners
+            self._active_sub_ids = sub_ids
+
+            threads = [
+                threading.Thread(
+                    target=self._poll_loop,
+                    args=(self._coordinator, sub_id, runner),
+                    daemon=True,
+                    name=f"zephyr-poll-{sub_id}",
+                )
+                for sub_id, runner in zip(sub_ids, runners, strict=True)
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            logger.info("[%s] Stage '%s' slots exited", self._worker_id, stage_type)
+            self._active_runners = []
+            self._active_sub_ids = []
+
+            for sub_id in sub_ids:
+                try:
+                    self._coordinator.deregister_worker.remote(sub_id).result(timeout=10.0)
+                except Exception:
+                    logger.debug("[%s] deregister_worker failed for %s (ignored)", self._worker_id, sub_id)
+
+        logger.info("[%s] Stage manager exiting", self._worker_id)
+        if self._host_shutdown_event is not None:
+            self._host_shutdown_event.set()
 
     def _report_worker_iris_status(self) -> None:
         """Push worker status text to Iris for UI display. Called on each heartbeat."""
 
         def build_md() -> tuple[str, str]:
-            task = self._current_task
-            if task is None:
-                return "idle", "idle"
-
-            stage_name = task.stage_name
-            shard_idx = task.shard_idx
-            total_shards = task.total_shards
-            elapsed = time.monotonic() - self._task_monotonic_start
-            throughput = _stage_throughput(self._last_reported_counters, stage_name, elapsed)
-
-            summary_lines = [f"**{stage_name}**", f"shard {shard_idx + 1}/{total_shards}"]
-            summary_md = "  \n".join(summary_lines)
-            detail_lines = [
-                f"**Stage**: {stage_name}",
-                f"**Shard**: {shard_idx + 1}/{total_shards}",
-            ]
-            if throughput is not None:
-                items, bytes_processed, item_rate, byte_rate = throughput
-                detail_lines += [
-                    f"**Items**: {_format_count(items)} ({_format_count(item_rate)}/s)",
-                    f"**Throughput**: {_format_bytes(bytes_processed)} ({_format_bytes(byte_rate)}/s)",
-                ]
+            active = self._active_task_count
+            stage = self._current_stage_name
+            if active == 0 or not stage:
+                summary_md = "idle"
+                detail_lines = "idle"
+            else:
+                summary_md = f"**{stage}** — {active} task(s)"
+                detail_lines = [f"**Stage**: {stage}", f"**Active tasks**: {active}"]
+                throughput = _stage_throughput(self._last_reported_counters, stage, 1.0)
+                if throughput is not None:
+                    items, bytes_processed, item_rate, byte_rate = throughput
+                    detail_lines += [
+                        f"**Items**: {_format_count(items)} ({_format_count(item_rate)}/s)",
+                        f"**Throughput**: {_format_bytes(bytes_processed)} ({_format_bytes(byte_rate)}/s)",
+                    ]
             return "  \n".join(detail_lines), summary_md
 
         _push_iris_task_status(self._iris_status_limiter, build_md)
 
     def _heartbeat_counter_snapshot(self) -> CounterSnapshot | None:
-        """Snapshot the running task's counters, or None when idle/unchanged.
-
-        Delegates to the configured ``StageRunner.live_counters``: the inline
-        runner exposes its in-memory ctx; the subprocess runner reads the
-        child's flush file. Skipping when nothing has changed keeps
-        heartbeat traffic cheap on the coordinator side. ``report_result``
-        is the source of truth for the final per-task values.
-        """
-        current = self._stage_runner.live_counters()
+        """Aggregate live counters from all active runners; return None if unchanged."""
+        runners = list(self._active_runners)  # GIL-safe snapshot
+        current: dict[str, int] = {}
+        for r in runners:
+            for k, v in r.live_counters().items():
+                current[k] = current.get(k, 0) + v
         if current == self._last_reported_counters:
             return None
         self._last_reported_counters = current
         self._counter_generation += 1
         return CounterSnapshot(counters=current, generation=self._counter_generation)
-
-    def _run_polling(self, coordinator: ActorHandle) -> None:
-        """Main polling loop. Runs in a background thread started by __init__."""
-        logger.info("[%s] Starting polling loop", self._worker_id)
-
-        # Start heartbeat thread
-        heartbeat_thread = threading.Thread(
-            target=self._heartbeat_loop,
-            args=(coordinator,),
-            daemon=True,
-            name=f"zephyr-hb-{self._worker_id}",
-        )
-        heartbeat_thread.start()
-
-        try:
-            self._poll_loop(coordinator)
-        finally:
-            self._shutdown_event.set()
-            heartbeat_thread.join(timeout=5.0)
-            logger.debug("[%s] Polling loop ended, signaling host shutdown", self._worker_id)
-            if self._host_shutdown_event is not None:
-                self._host_shutdown_event.set()
 
     def _heartbeat_loop(
         self, coordinator: ActorHandle, interval: float = 5.0, max_consecutive_failures: int = 5
@@ -1354,14 +1449,18 @@ class ZephyrWorker:
         consecutive_failures = 0
         while not self._shutdown_event.is_set():
             try:
-                # Block on result to avoid congesting the coordinator RPC pipe
-                # with fire-and-forget heartbeats. Only send counter snapshot
-                # when values have changed.
-                snapshot = self._heartbeat_counter_snapshot()
-                coordinator.heartbeat.remote(
-                    self._worker_id,
-                    snapshot,
-                ).result()
+                sub_ids = list(self._active_sub_ids)
+                if sub_ids:
+                    # Primary slot carries the aggregate counter snapshot; the rest
+                    # just refresh last_seen to prevent heartbeat timeout mid-task.
+                    snapshot = self._heartbeat_counter_snapshot()
+                    coordinator.heartbeat.remote(sub_ids[0], snapshot).result()
+                    for sub_id in sub_ids[1:]:
+                        with suppress(Exception):
+                            coordinator.heartbeat.remote(sub_id).result()
+                else:
+                    # Between stages: probe for coordinator liveness only.
+                    coordinator.get_current_stage_type.remote().result(timeout=10.0)
                 heartbeat_count += 1
                 consecutive_failures = 0
                 if heartbeat_count % 10 == 1:
@@ -1378,7 +1477,7 @@ class ZephyrWorker:
                 )
                 if consecutive_failures >= max_consecutive_failures:
                     logger.error(
-                        "[%s] %d consecutive heartbeat failures — coordinator is unreachable, shutting down",
+                        "[%s] %d consecutive heartbeat failures — coordinator unreachable, shutting down",
                         self._worker_id,
                         consecutive_failures,
                     )
@@ -1387,131 +1486,110 @@ class ZephyrWorker:
             self._shutdown_event.wait(timeout=interval)
         logger.debug("[%s] Heartbeat loop exiting after %d beats", self._worker_id, heartbeat_count)
 
-    def _poll_loop(self, coordinator: ActorHandle) -> None:
-        """Pure polling loop. Exits on SHUTDOWN signal, coordinator death, or shutdown event."""
+    def _poll_loop(self, coordinator: ActorHandle, worker_id: str, stage_runner: StageRunner) -> None:
+        """Single-slot polling loop. Exits on SHUTDOWN signal or coordinator death."""
         task_count = 0
         backoff = ExponentialBackoff(initial=0.1, maximum=5.0)
-
         future: ActorFuture | None = None
         future_start = 0.0
         warned = False
 
         while not self._shutdown_event.is_set():
-            # Create a pull_task future if we don't have one in flight
             if future is None:
-                future = coordinator.pull_task.remote(self._worker_id)
+                future = coordinator.pull_task.remote(worker_id)
                 future_start = time.monotonic()
                 warned = False
 
-            # Poll with a short timeout so we stay responsive to shutdown
-            # without killing the worker (and its heartbeat thread) on slow
-            # deserialization.
+            # Short timeout keeps the thread responsive to shutdown without
+            # killing the slot on slow coordinator deserialization.
             try:
                 response = future.result(timeout=0.5)
             except TimeoutError:
                 elapsed = time.monotonic() - future_start
                 if elapsed > 30 and not warned:
-                    logger.warning("[%s] Waiting for coordinator pull_task response (%.0fs)", self._worker_id, elapsed)
+                    logger.warning("[%s] Waiting for coordinator pull_task response (%.0fs)", worker_id, elapsed)
                     warned = True
                 continue
             except Exception as e:
-                logger.info("[%s] pull_task failed (coordinator may be dead): %s", self._worker_id, e)
+                logger.info("[%s] pull_task failed (coordinator may be dead): %s", worker_id, e)
                 break
 
-            future = None  # consumed; next iteration will create a new one
+            future = None
 
-            # SHUTDOWN signal - exit cleanly
             if response == "SHUTDOWN":
-                logger.info("[%s] Received SHUTDOWN", self._worker_id)
+                logger.info("[%s] Received SHUTDOWN", worker_id)
                 break
 
-            # No task available - backoff and retry
             if response is None:
                 time.sleep(backoff.next_interval())
                 continue
 
             backoff.reset()
-
-            # Unpack task and config
             task, attempt, config = response
 
             logger.info(
-                "[%s] Executing task for stage %s shard %d (attempt %d)",
-                self._worker_id,
+                "[%s] Executing stage %s shard %d (attempt %d)",
+                worker_id,
                 task.stage_name,
                 task.shard_idx,
                 attempt,
             )
-            self._current_task = task
-            self._task_monotonic_start = time.monotonic()
+            self._active_task_count += 1
+            self._current_stage_name = task.stage_name
+            task_start = time.monotonic()
             try:
-                result, task_counters = self._execute_shard(task, config)
+                result, task_counters = self._execute_shard(task, config, stage_runner)
                 logger.info(
-                    "[%s] Task for shard %d completed in %.2f seconds",
-                    self._worker_id,
+                    "[%s] Shard %d done in %.2fs",
+                    worker_id,
                     task.shard_idx,
-                    time.monotonic() - self._task_monotonic_start,
+                    time.monotonic() - task_start,
                 )
-                # Block until coordinator records the result. This ensures
-                # report_result is fully processed before the next pull_task,
-                # preventing _in_flight tracking races. The counter snapshot
-                # is built directly from the subprocess result file so no
-                # parent-side counter state needs to be kept in sync.
+                # Block until coordinator records result — prevents _in_flight races.
                 self._counter_generation += 1
                 coordinator.report_result.remote(
-                    self._worker_id,
+                    worker_id,
                     task.shard_idx,
                     attempt,
                     result,
                     CounterSnapshot(counters=dict(task_counters), generation=self._counter_generation),
                 ).result()
                 task_count += 1
-            except Exception as e:
-                logger.error("Worker %s error on shard %d: %s", self._worker_id, task.shard_idx, e)
+            except Exception:
+                logger.error("Worker %s error on shard %d", worker_id, task.shard_idx, exc_info=True)
                 coordinator.report_error.remote(
-                    self._worker_id,
+                    worker_id,
                     task.shard_idx,
                     "".join(traceback.format_exc()),
                 ).result()
             finally:
-                self._current_task = None
+                self._active_task_count = max(0, self._active_task_count - 1)
 
-    def _execute_shard(self, task: ShardTask, config: dict) -> tuple[TaskResult, dict[str, int]]:
-        """Hand the task to the configured ``StageRunner``.
-
-        The runner owns the worker-context lifetime and decides whether to
-        execute inline or in a subprocess; this method just plumbs the
-        per-execution config and surfaces the final ``(TaskResult, counters)``
-        for ``report_result``.
-        """
+    def _execute_shard(
+        self, task: ShardTask, config: dict, stage_runner: StageRunner
+    ) -> tuple[TaskResult, dict[str, int]]:
         chunk_prefix = config["chunk_prefix"]
         execution_id = config["execution_id"]
-
         logger.info(
-            "[%s] [shard %d/%d] Starting stage=%s, %d ops",
+            "[%s] [shard %d/%d] stage=%s, %d ops",
             execution_id,
             task.shard_idx,
             task.total_shards,
             task.stage_name,
             len(task.operations),
         )
-
-        result, counters = self._stage_runner.execute(task, chunk_prefix, execution_id)
-        logger.info(
-            "[shard %d] Complete: %d refs produced",
-            task.shard_idx,
-            len(result.shard.refs),
-        )
+        result, counters = stage_runner.execute(task, chunk_prefix, execution_id)
+        logger.info("[shard %d] Complete: %d refs produced", task.shard_idx, len(result.shard.refs))
         return result, counters
 
     def __repr__(self) -> str:
         return f"ZephyrWorker(id={self._worker_id})"
 
     def shutdown(self) -> None:
-        """Stop the worker's polling loop."""
+        """Signal the worker to stop accepting new stages."""
         self._shutdown_event.set()
-        if hasattr(self, "_polling_thread") and self._polling_thread.is_alive():
-            self._polling_thread.join(timeout=5.0)
+        if self._host_shutdown_event is not None:
+            self._host_shutdown_event.set()
 
 
 def _regroup_result_refs(
@@ -1587,10 +1665,12 @@ class _CoordinatorJobConfig:
     worker_resources: ResourceConfig
     name: str
     pipeline_id: int
+    map_workers_per_actor: int = 1
+    reduce_workers_per_actor: int = 1
     # None → workers fall back to InlineRunner (default). The factory is
-    # cloudpickled and re-invoked once per worker actor, so per-runner
-    # mutable state is per-worker.
-    stage_runner_factory: Callable[[], StageRunner] | None = None
+    # cloudpickled and re-invoked per worker slot, so per-runner mutable
+    # state is per-slot.
+    stage_runner_factory: Callable[[int], StageRunner] | None = None
 
 
 def _run_coordinator_job(config_path: str, result_path: str) -> None:
@@ -1651,6 +1731,8 @@ def _run_coordinator_job(config_path: str, result_path: str) -> None:
                 ZephyrWorker,
                 coordinator,
                 config.stage_runner_factory,
+                config.map_workers_per_actor,
+                config.reduce_workers_per_actor,
                 name=worker_name,
                 count=actual_workers,
                 resources=config.worker_resources,
@@ -1752,13 +1834,13 @@ class ZephyrContext:
         max_execution_retries: Maximum number of times to retry a pipeline execution after
             an infrastructure failure (e.g., coordinator VM preemption). Application errors
             (ZephyrWorkerError) are never retried. Defaults to 100.
-        stage_runner_factory: Zero-arg callable returning a fresh ``StageRunner``
-            for each worker. If left ``None``, the default depends on the
-            client: ``LocalClient`` (dev/test) gets ``InlineRunner`` so shards
-            run in-process for speed; distributed clients (Iris) get
-            ``SubprocessRunner`` so each shard is isolated against native
-            crashes and per-shard memory growth. Pass an explicit factory to
-            override.
+        stage_runner_factory: Callable ``(num_workers: int) -> StageRunner``.
+            Defaults to ``InlineRunner`` for ``LocalClient`` and ``SubprocessRunner``
+            for distributed clients.
+        map_workers_per_actor: Number of concurrent subprocess workers per actor
+            for map-type stages (Map, Write). Defaults to 1.
+        reduce_workers_per_actor: Number of concurrent subprocess workers per actor
+            for reduce-type stages (Scatter, Reduce, Fold, Join). Defaults to 1.
     """
 
     client: Client | None = None
@@ -1772,7 +1854,9 @@ class ZephyrContext:
     no_workers_timeout: float | None = None
     # NOTE: 100 is fairly aggressive but it fits the preemptible env better
     max_execution_retries: int = 100
-    stage_runner_factory: Callable[[], StageRunner] | None = None
+    stage_runner_factory: Callable[[int], StageRunner] | None = None
+    map_workers_per_actor: int = 1
+    reduce_workers_per_actor: int = 1
 
     # Shared data staged by put(), uploaded to disk at the start of execute()
     _shared_data: dict[str, Any] = field(default_factory=dict, repr=False)
@@ -1890,6 +1974,8 @@ class ZephyrContext:
                     worker_resources=self.resources,
                     name=self.name,
                     pipeline_id=self._pipeline_id,
+                    map_workers_per_actor=self.map_workers_per_actor,
+                    reduce_workers_per_actor=self.reduce_workers_per_actor,
                     stage_runner_factory=self.stage_runner_factory,
                 )
                 ensure_parent_dir(config_path)

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -46,12 +46,10 @@ from rigging.timing import ExponentialBackoff, RateLimiter, log_time
 
 from zephyr.dataset import Dataset
 from zephyr.plan import (
-    Fold,
     Join,
     PhysicalOp,
     PhysicalPlan,
     PhysicalStage,
-    Reduce,
     Scatter,
     Shard,
     SourceItem,
@@ -412,20 +410,6 @@ def _default_stage_runner_factory_for(client: Client) -> Callable[[int], StageRu
     return lambda n: SubprocessRunner(num_workers=n)
 
 
-def _classify_stage(stage: PhysicalStage) -> str:
-    """Return ``'reduce'`` if the stage contains shuffle/reduce/fold/join ops, else ``'map'``.
-
-    Reduce-type stages (produced by GroupByOp, ReduceOp, JoinOp) are
-    memory-intensive due to scatter buffers or merge-sort scratch space.
-    Map-type stages (produced by MapOp, FilterOp, WriteOp, etc.) are
-    typically CPU-bound with lower per-task memory.
-    """
-    for op in stage.operations:
-        if isinstance(op, (Scatter, Reduce, Fold, Join)):
-            return "reduce"
-    return "map"
-
-
 # ---------------------------------------------------------------------------
 # ZephyrCoordinator
 # ---------------------------------------------------------------------------
@@ -466,6 +450,7 @@ class ZephyrCoordinator:
         self._total_shards: int = 0
         self._completed_shards: int = 0
         self._retries: int = 0
+        self._stage_epoch: int = 0
         self._in_flight: dict[str, tuple[ShardTask, int]] = {}
         # _task_attempts: monotonic generation for stale-result rejection (bumps on every
         # requeue). _task_error_attempts: TASK-only counter, bounded by MAX_SHARD_FAILURES.
@@ -490,12 +475,11 @@ class ZephyrCoordinator:
         # Set when a stage may have completed (result, failure, or abort) so
         # ``_wait_for_stage`` wakes immediately instead of sleeping out its backoff.
         self._stage_done = threading.Event()
-        self._is_last_stage: bool = False
         # When True, pull_task returns SHUTDOWN to idle workers (stage complete).
         self._stage_complete: bool = False
         # Stage type for the currently running stage; workers poll this to know
         # how many subprocess slots to create.
-        self._current_stage_type: str | None = None
+        self._current_stage_type: StageType | None = None
         self._initialized: bool = False
         self._pipeline_running: bool = False
 
@@ -545,11 +529,14 @@ class ZephyrCoordinator:
         """Set the worker ActorGroup so the coordinator can detect permanent worker death."""
         self._worker_group = worker_group
 
-    def register_worker(self, worker_id: str, worker_handle: ActorHandle) -> None:
+    def register_worker(self, worker_id: str, worker_handle: ActorHandle) -> int:
         """Called by workers when they come online to register with coordinator.
 
         Handles re-registration from reconstructed workers (e.g. after node
         preemption) by updating the stale handle and resetting worker state.
+
+        Returns the current stage epoch so the caller can bind its poll loop
+        to this stage and detect when it has been superseded.
         """
         with self._lock:
             if worker_id in self._worker_handles:
@@ -561,12 +548,13 @@ class ZephyrCoordinator:
                 # the worker as unhealthy via heartbeat and re-registration. If we do not requeue we may silently
                 # lose tasks.
                 self._maybe_requeue_worker_task(worker_id)
-                return
+                return self._stage_epoch
 
             self._worker_handles[worker_id] = worker_handle
             self._worker_states[worker_id] = WorkerState.READY
             self._last_seen[worker_id] = time.monotonic()
             logger.info("Worker %s registered, total: %d", worker_id, len(self._worker_handles))
+            return self._stage_epoch
 
     def deregister_worker(self, worker_id: str) -> None:
         """Remove a sub-worker that has finished its stage pool."""
@@ -575,7 +563,7 @@ class ZephyrCoordinator:
             self._worker_states.pop(worker_id, None)
             self._last_seen.pop(worker_id, None)
 
-    def get_current_stage_type(self) -> str | None:
+    def get_current_stage_type(self) -> StageType | None:
         """Return the stage type currently running, or ``None`` if between stages.
 
         Workers poll this between stages to discover the next stage type and
@@ -840,12 +828,18 @@ class ZephyrCoordinator:
                 self._worker_states[worker_id] = WorkerState.FAILED
                 self._maybe_requeue_worker_task(worker_id)
 
-    def pull_task(self, worker_id: str) -> tuple[ShardTask, int, dict] | str | None:
+    def pull_task(self, worker_id: str, epoch: int | None = None) -> tuple[ShardTask, int, dict] | str | None:
         """Called by workers to get next task.
+
+        Args:
+            worker_id: Unique ID for this worker slot.
+            epoch: Stage epoch the slot was registered under. If provided and it
+                no longer matches the coordinator's current epoch, the slot has
+                survived into a later stage and receives SHUTDOWN immediately.
 
         Returns:
             - (task, attempt, config) tuple if task available
-            - "SHUTDOWN" string if coordinator is shutting down
+            - "SHUTDOWN" string if coordinator is shutting down or epoch is stale
             - None if no task available (worker should backoff and retry)
         """
         with self._lock:
@@ -856,11 +850,18 @@ class ZephyrCoordinator:
                 self._worker_states[worker_id] = WorkerState.DEAD
                 return "SHUTDOWN"
 
+            if epoch is not None and epoch != self._stage_epoch:
+                # This slot was created for an earlier stage and missed its SHUTDOWN
+                # (e.g. it was sleeping through the _mark_stage_complete window).
+                # Send SHUTDOWN now so it exits before picking up next-stage tasks.
+                self._worker_states[worker_id] = WorkerState.DEAD
+                return "SHUTDOWN"
+
             if self._fatal_error:
                 return None
 
             if not self._task_queue:
-                if self._is_last_stage or self._stage_complete:
+                if self._stage_complete:
                     # No more work to hand out — exit immediately.  If an
                     # in-flight worker crashes and its shard is requeued, Iris
                     # restarts the worker which re-registers and picks it up.
@@ -1005,7 +1006,6 @@ class ZephyrCoordinator:
         stage_name: str,
         current_stage_index: int,
         tasks: list[ShardTask],
-        is_last_stage: bool = False,
     ) -> None:
         """Load a new stage's tasks into the queue."""
         with self._lock:
@@ -1026,8 +1026,8 @@ class ZephyrCoordinator:
             self._task_infra_attempts = {task.shard_idx: 0 for task in tasks}
             self._shard_errors = {}
             self._fatal_error = None
-            self._is_last_stage = is_last_stage
             self._stage_complete = False
+            self._stage_epoch += 1
             # Only reset in-flight worker snapshots; completed snapshots
             # accumulate across stages for full pipeline visibility.
             self._worker_counters = {}
@@ -1112,15 +1112,6 @@ class ZephyrCoordinator:
             if not shards:
                 return []
 
-            # Identify the last stage that dispatches work to workers (non-RESHARD).
-            # On that stage, idle workers receive SHUTDOWN once all tasks are
-            # in-flight, so they exit eagerly instead of polling until
-            # coordinator.shutdown().
-            last_worker_stage_idx = max(
-                (i for i, s in enumerate(plan.stages) if s.stage_type != StageType.RESHARD),
-                default=-1,
-            )
-
             with self._lock:
                 self._current_stage_index = 0
                 self._plan_stages = list(plan.stages)
@@ -1137,7 +1128,6 @@ class ZephyrCoordinator:
                     stage_label=f"stage{stage_idx}-{stage.stage_name(max_length=40)}",
                     stage_index_for_state=stage_idx,
                     aux_per_shard=aux_per_shard,
-                    is_last_stage=(stage_idx == last_worker_stage_idx),
                 )
 
             # Flatten final results — each shard may involve I/O (unpickling from
@@ -1165,7 +1155,6 @@ class ZephyrCoordinator:
         stage_label: str,
         stage_index_for_state: int,
         aux_per_shard: list[dict[int, Shard]] | None = None,
-        is_last_stage: bool = False,
     ) -> list[Shard]:
         """Submit a worker stage, wait for completion, return regrouped output shards.
 
@@ -1173,13 +1162,14 @@ class ZephyrCoordinator:
         UI/logging — for join right-sub-stages this is the *parent* stage index
         so progress reports stay attached to the user-visible stage.
         """
-        stage_type = _classify_stage(stage)
         with self._lock:
-            self._current_stage_type = stage_type
+            self._current_stage_type = stage.stage_type
 
         tasks = _compute_tasks_from_shards(shards, stage, stage_name=stage_label, aux_per_shard=aux_per_shard)
-        logger.info("[%s] Starting stage %s (%s) with %d tasks", self._execution_id, stage_label, stage_type, len(tasks))
-        self._start_stage(stage_label, stage_index_for_state, tasks, is_last_stage=is_last_stage)
+        logger.info(
+            "[%s] Starting stage %s (%s) with %d tasks", self._execution_id, stage_label, stage.stage_type, len(tasks)
+        )
+        self._start_stage(stage_label, stage_index_for_state, tasks)
         self._wait_for_stage()
 
         # Signal idle workers to exit their per-stage thread pools. Workers poll
@@ -1351,7 +1341,7 @@ class ZephyrWorker:
 
         while not self._shutdown_event.is_set():
             try:
-                stage_type = self._coordinator.get_current_stage_type.remote().result(timeout=10.0)
+                stage_type = self._coordinator.get_current_stage_type.remote().result(timeout=5.0)
             except Exception as e:
                 logger.debug("[%s] get_current_stage_type failed: %s", self._worker_id, e)
                 self._shutdown_event.wait(timeout=1.0)
@@ -1362,29 +1352,38 @@ class ZephyrWorker:
                 continue
 
             backoff.reset()
-            n = self._num_map_workers if stage_type == "map" else self._num_reduce_workers
-            logger.info("[%s] Stage '%s' starting, %d slot(s)", self._worker_id, stage_type, n)
+            num_workers = self._num_map_workers if stage_type == StageType.MAP_WORKER else self._num_reduce_workers
+            logger.info("[%s] Stage '%s' starting, %d slot(s)", self._worker_id, stage_type, num_workers)
 
-            runners = [self._stage_runner_factory(n) for _ in range(n)]
-            sub_ids = [f"{self._worker_id}:{i}" for i in range(n)]
+            sub_ids = set(f"{self._worker_id}:{i}" for i in range(num_workers))
 
+            stage_epoch: int | None = None
+            failed_workers: set[str] = set()
             for sub_id in sub_ids:
                 try:
-                    self._coordinator.register_worker.remote(sub_id, self._actor_handle).result(timeout=30.0)
+                    epoch = self._coordinator.register_worker.remote(sub_id, self._actor_handle).result(timeout=30.0)
+                    if stage_epoch is not None and stage_epoch != epoch:
+                        raise RuntimeError(
+                            f"Received different stage epochs when registering workers within a stage. "
+                            f"Got {epoch} (expected {stage_epoch})"
+                        )
+                    stage_epoch = epoch
                 except Exception:
+                    failed_workers.add(sub_id)
                     logger.warning("[%s] Failed to register sub-worker %s", self._worker_id, sub_id, exc_info=True)
 
-            self._active_runners = runners
-            self._active_sub_ids = sub_ids
+            self._active_sub_ids = list(sub_ids - failed_workers)
+            num_active_workers = len(self._active_sub_ids)
+            self._active_runners = [self._stage_runner_factory(num_active_workers) for _ in range(num_active_workers)]
 
             threads = [
                 threading.Thread(
                     target=self._poll_loop,
-                    args=(self._coordinator, sub_id, runner),
+                    args=(self._coordinator, sub_id, runner, stage_epoch),
                     daemon=True,
                     name=f"zephyr-poll-{sub_id}",
                 )
-                for sub_id, runner in zip(sub_ids, runners, strict=True)
+                for sub_id, runner in zip(self._active_sub_ids, self._active_runners, strict=True)
             ]
             for t in threads:
                 t.start()
@@ -1486,8 +1485,13 @@ class ZephyrWorker:
             self._shutdown_event.wait(timeout=interval)
         logger.debug("[%s] Heartbeat loop exiting after %d beats", self._worker_id, heartbeat_count)
 
-    def _poll_loop(self, coordinator: ActorHandle, worker_id: str, stage_runner: StageRunner) -> None:
-        """Single-slot polling loop. Exits on SHUTDOWN signal or coordinator death."""
+    def _poll_loop(self, coordinator: ActorHandle, worker_id: str, stage_runner: StageRunner, epoch: int = 0) -> None:
+        """Single-slot polling loop. Exits on SHUTDOWN signal or coordinator death.
+
+        ``epoch`` is the stage epoch returned by ``register_worker``; it is passed
+        on every ``pull_task`` call so the coordinator can detect slots that survived
+        past stage completion and send them SHUTDOWN before they pick up next-stage tasks.
+        """
         task_count = 0
         backoff = ExponentialBackoff(initial=0.1, maximum=5.0)
         future: ActorFuture | None = None
@@ -1496,7 +1500,7 @@ class ZephyrWorker:
 
         while not self._shutdown_event.is_set():
             if future is None:
-                future = coordinator.pull_task.remote(worker_id)
+                future = coordinator.pull_task.remote(worker_id, epoch)
                 future_start = time.monotonic()
                 warned = False
 

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -153,8 +153,9 @@ PhysicalOp = Map | Write | Scatter | Reduce | Fold | Reshard | Join
 class StageType(StrEnum):
     """Type of stage execution."""
 
-    WORKER = auto()  # Normal worker execution
-    RESHARD = auto()  # Redistribute chunks (no worker execution)
+    MAP_WORKER = auto()
+    REDUCE_WORKER = auto()
+    RESHARD = auto()
 
 
 def _map_gen(stream: Iterator, fn: Callable) -> Iterator:
@@ -266,12 +267,13 @@ class PhysicalStage:
 
     A stage contains a sequence of physical operations that can be executed
     together. The stage_type tells the backend HOW to execute it:
-    - WORKER: Normal worker execution
+    - MAP_WORKER: Normal worker execution (map/filter/write)
+    - REDUCE_WORKER: Memory-intensive worker execution (scatter/reduce/join)
     - RESHARD: Redistribute chunks across shards (no worker execution)
     """
 
     operations: list[PhysicalOp] = field(default_factory=list)
-    stage_type: StageType = StageType.WORKER
+    stage_type: StageType = StageType.MAP_WORKER
     output_shards: int | None = None
 
     def stage_name(self, max_length: int | None = None) -> str:
@@ -328,7 +330,20 @@ class FusionState:
     current_ops: list[PhysicalOp] = field(default_factory=list)
     pending_fusible: list = field(default_factory=list)
     output_shards: int | None = None
-    stage_type: StageType = StageType.WORKER
+    stage_type: StageType | None = None
+
+    def _set_stage_type(self, op: PhysicalOp) -> None:
+        if isinstance(op, (Reshard)):
+            if self.stage_type is not None:
+                raise ValueError("Reshard should be the only op in a RESHARD stage")
+            self.stage_type = StageType.RESHARD
+        elif isinstance(op, (Reduce, Join)):
+            self.stage_type = StageType.REDUCE_WORKER
+        else:
+            if self.stage_type is None:
+                # Map ops can happen after a Reduce, Fold, or Join, but in that case the physical
+                # stage is treated like a reduce, since those require more memory.
+                self.stage_type = StageType.MAP_WORKER
 
     def flush_pending(self) -> None:
         """Convert pending fusible ops to a physical Map."""
@@ -336,12 +351,12 @@ class FusionState:
             return
 
         needs_shard_context = any(isinstance(op, MapShardOp) for op in self.pending_fusible)
-        self.current_ops.append(
-            Map(
-                fn=compose_map(self.pending_fusible[:]),
-                needs_shard_context=needs_shard_context,
-            )
+        op = Map(
+            fn=compose_map(self.pending_fusible[:]),
+            needs_shard_context=needs_shard_context,
         )
+        self._set_stage_type(op)
+        self.current_ops.append(op)
         self.pending_fusible = []
 
     def add_op(
@@ -349,7 +364,6 @@ class FusionState:
         op: PhysicalOp,
         *,
         output_shards: int | None = None,
-        stage_type: StageType | None = None,
     ) -> None:
         """Add physical op to current stage.
 
@@ -359,8 +373,8 @@ class FusionState:
         self.current_ops.append(op)
         if output_shards is not None:
             self.output_shards = output_shards
-        if stage_type is not None:
-            self.stage_type = stage_type
+
+        self._set_stage_type(op)
 
     def end_stage(self) -> None:
         """Flush pending ops and close current stage."""
@@ -375,7 +389,7 @@ class FusionState:
             )
             self.current_ops = []
             self.output_shards = None
-            self.stage_type = StageType.WORKER
+            self.stage_type = None
 
     def finalize(self) -> list[PhysicalStage]:
         """Flush remaining ops and return completed stages."""
@@ -433,13 +447,13 @@ def _fuse_operations(operations: list) -> list[PhysicalStage]:
         elif isinstance(op, ReduceOp):
             state.add_op(Fold(fn=op.local_reducer))
             state.end_stage()
-            state.add_op(Reshard(num_shards=1), output_shards=1, stage_type=StageType.RESHARD)
+            state.add_op(Reshard(num_shards=1), output_shards=1)
             state.end_stage()
             state.add_op(Fold(fn=op.global_reducer))
 
         elif isinstance(op, ReshardOp):
             state.end_stage()
-            state.add_op(Reshard(num_shards=op.num_shards), output_shards=op.num_shards, stage_type=StageType.RESHARD)
+            state.add_op(Reshard(num_shards=op.num_shards), output_shards=op.num_shards)
             state.end_stage()
 
         elif isinstance(op, JoinOp):

--- a/lib/zephyr/src/zephyr/runners.py
+++ b/lib/zephyr/src/zephyr/runners.py
@@ -89,7 +89,7 @@ class _InProcessWorkerContext:
         self._shared_data_cache: dict[str, Any] = {}
         self._counters: dict[str, int] = {}
         self._generation = 0
-        self._num_workers = num_workers
+        self.num_workers = num_workers
 
     def get_shared(self, name: str) -> Any:
         if name not in self._shared_data_cache:
@@ -105,10 +105,6 @@ class _InProcessWorkerContext:
     def get_counter_snapshot(self) -> CounterSnapshot:
         self._generation += 1
         return CounterSnapshot(counters=dict(self._counters), generation=self._generation)
-
-    @property
-    def num_workers(self) -> int:
-        return self._num_workers
 
 
 _T = TypeVar("_T")
@@ -295,10 +291,9 @@ class SubprocessRunner:
             # faulthandler traceback reaches the parent's log before the
             # process dies.
             proc = sp.run(
-                [sys.executable, "-u", "-m", "zephyr.runners", task_file, result_file],
+                [sys.executable, "-u", "-m", "zephyr.runners", task_file, result_file, str(self._num_workers)],
                 stdout=sys.stdout,
                 stderr=sys.stderr,
-                env={**os.environ, "ZEPHYR_NUM_WORKERS_PER_ACTOR": str(self._num_workers)},
             )
 
             if proc.returncode != 0:
@@ -352,7 +347,7 @@ class SubprocessRunner:
 # ---------------------------------------------------------------------------
 
 
-def _execute_shard_subprocess(task_file: str, result_file: str) -> None:
+def _execute_shard_subprocess(task_file: str, result_file: str, num_workers: int) -> None:
     """Subprocess child body: runs one ShardTask and writes the result file."""
     # Each shard already runs in its own subprocess; redundant Arrow thread
     # pools just compete with the parent's shard-level parallelism.
@@ -363,8 +358,6 @@ def _execute_shard_subprocess(task_file: str, result_file: str) -> None:
     # / SIGFPE / SIGILL in a C extension produces a Python traceback on
     # stderr instead of a bare ``returncode < 0``.
     configure_logging(level=logging.INFO)
-
-    num_workers = int(os.environ.get("ZEPHYR_NUM_WORKERS_PER_ACTOR", "1"))
 
     counter_file = f"{result_file}.counters"
     stop_event = threading.Event()
@@ -428,8 +421,8 @@ def _execute_shard_subprocess(task_file: str, result_file: str) -> None:
 
 
 def _subprocess_main() -> None:
-    if len(sys.argv) != 3:
-        print("Usage: python -m zephyr.runners <task_file> <result_file>", file=sys.stderr)
+    if len(sys.argv) != 4:
+        print("Usage: python -m zephyr.runners <task_file> <result_file> <num_workers>", file=sys.stderr)
         os._exit(1)
     # Bypass interpreter shutdown: PyArrow GCS/Azure filesystem background
     # threads can race with module GC and fire ``std::terminate`` → SIGABRT,
@@ -438,7 +431,7 @@ def _subprocess_main() -> None:
     # one-shot child needs ``atexit`` / ``__del__`` to run.
     exit_code = 0
     try:
-        _execute_shard_subprocess(sys.argv[1], sys.argv[2])
+        _execute_shard_subprocess(sys.argv[1], sys.argv[2], int(sys.argv[3]))
     except BaseException:
         traceback.print_exc()
         exit_code = 1

--- a/lib/zephyr/src/zephyr/runners.py
+++ b/lib/zephyr/src/zephyr/runners.py
@@ -16,10 +16,6 @@ Two implementations ship here:
   worker actor. Slower (~700ms of cold-import overhead per task).
 
 Pick the runner pipeline-wide via ``ZephyrContext(stage_runner_factory=...)``.
-The factory is invoked once per worker actor; each worker holds its own
-runner instance. The runner's ``live_counters()`` is polled by the worker's
-heartbeat thread, so per-runner state (counter file pointer, in-memory ctx)
-stays encapsulated.
 """
 
 from __future__ import annotations
@@ -87,12 +83,13 @@ class _InProcessWorkerContext:
     of the task.
     """
 
-    def __init__(self, chunk_prefix: str, execution_id: str):
+    def __init__(self, chunk_prefix: str, execution_id: str, num_workers: int = 1):
         self._chunk_prefix = chunk_prefix
         self._execution_id = execution_id
         self._shared_data_cache: dict[str, Any] = {}
         self._counters: dict[str, int] = {}
         self._generation = 0
+        self._num_workers = num_workers
 
     def get_shared(self, name: str) -> Any:
         if name not in self._shared_data_cache:
@@ -108,6 +105,10 @@ class _InProcessWorkerContext:
     def get_counter_snapshot(self) -> CounterSnapshot:
         self._generation += 1
         return CounterSnapshot(counters=dict(self._counters), generation=self._generation)
+
+    @property
+    def num_workers(self) -> int:
+        return self._num_workers
 
 
 _T = TypeVar("_T")
@@ -175,7 +176,8 @@ class InlineRunner:
     here, and tests run dramatically faster than under ``SubprocessRunner``.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, num_workers: int = 1) -> None:
+        self._num_workers = num_workers
         self._ctx: _InProcessWorkerContext | None = None
 
     def execute(
@@ -184,14 +186,14 @@ class InlineRunner:
         chunk_prefix: str,
         execution_id: str,
     ) -> tuple[TaskResult, dict[str, int]]:
-        ctx = _InProcessWorkerContext(chunk_prefix, execution_id)
+        ctx = _InProcessWorkerContext(chunk_prefix, execution_id, num_workers=self._num_workers)
         self._ctx = ctx
-        token = _worker_ctx_var.set(ctx)
+        worker_token = _worker_ctx_var.set(ctx)
         try:
             result = _run_stage_with_ctx(task, chunk_prefix, execution_id, ctx)
             return result, dict(ctx._counters)
         finally:
-            _worker_ctx_var.reset(token)
+            _worker_ctx_var.reset(worker_token)
             self._ctx = None
 
     def live_counters(self) -> dict[str, int]:
@@ -263,9 +265,15 @@ class SubprocessRunner:
     ``returncode != 0`` task errors. Costs ~700ms per task in cold Python
     imports plus pickle round-trip; reserve for stages with leak-prone or
     crash-prone user code.
+
+    Args:
+        num_workers: Total number of concurrent subprocess workers sharing this
+            actor's RAM. Passed to child processes via ``ZEPHYR_NUM_WORKERS_PER_ACTOR``
+            so each child scales its scatter-write buffer budget proportionally.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, num_workers: int = 1) -> None:
+        self._num_workers = num_workers
         self._counter_file: str | None = None
 
     def execute(
@@ -290,6 +298,7 @@ class SubprocessRunner:
                 [sys.executable, "-u", "-m", "zephyr.runners", task_file, result_file],
                 stdout=sys.stdout,
                 stderr=sys.stderr,
+                env={**os.environ, "ZEPHYR_NUM_WORKERS_PER_ACTOR": str(self._num_workers)},
             )
 
             if proc.returncode != 0:
@@ -355,6 +364,8 @@ def _execute_shard_subprocess(task_file: str, result_file: str) -> None:
     # stderr instead of a bare ``returncode < 0``.
     configure_logging(level=logging.INFO)
 
+    num_workers = int(os.environ.get("ZEPHYR_NUM_WORKERS_PER_ACTOR", "1"))
+
     counter_file = f"{result_file}.counters"
     stop_event = threading.Event()
     flusher: threading.Thread | None = None
@@ -365,7 +376,7 @@ def _execute_shard_subprocess(task_file: str, result_file: str) -> None:
         with open(task_file, "rb") as f:
             task, chunk_prefix, execution_id = cloudpickle.load(f)
 
-        ctx = _InProcessWorkerContext(chunk_prefix, execution_id)
+        ctx = _InProcessWorkerContext(chunk_prefix, execution_id, num_workers=num_workers)
         _worker_ctx_var.set(ctx)
 
         shard_monotonic_start = time.monotonic()

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -132,12 +132,17 @@ def _default_scatter_write_buffer_bytes() -> int:
     """Return the scatter write buffer budget based on the cgroup memory limit.
 
     Uses 25% of the container memory limit so the budget scales with the
-    worker size. Falls back to 256 MB when the limit cannot be read.
+    worker size, divided by the number of concurrent workers sharing this
+    actor's RAM. Falls back to 256 MB (divided by the same factor) when the
+    cgroup limit cannot be read.
     """
+    from zephyr.execution import _worker_ctx_var  # local import breaks the shuffle↔execution cycle
+
+    num_workers = _worker_ctx_var.get().num_workers
     memory = TaskResources.from_environment().memory_bytes
     if memory > 0:
-        return int(memory * _SCATTER_WRITE_BUFFER_FRACTION)
-    return _SCATTER_WRITE_BUFFER_BYTES_FALLBACK
+        return int(memory * _SCATTER_WRITE_BUFFER_FRACTION / num_workers)
+    return _SCATTER_WRITE_BUFFER_BYTES_FALLBACK // max(1, num_workers)
 
 
 # ---------------------------------------------------------------------------

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -854,62 +854,6 @@ def test_pipeline_id_increments(local_client, tmp_path):
     assert ctx._pipeline_id == 1
 
 
-def test_pull_task_returns_shutdown_on_last_stage_empty_queue(actor_context, tmp_path):
-    """When the last stage's tasks are all in-flight or done, pull_task returns SHUTDOWN."""
-    coord = ZephyrCoordinator()
-    coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
-
-    task = ShardTask(
-        shard_idx=0,
-        total_shards=1,
-        shard=ListShard(refs=[]),
-        operations=[],
-        stage_name="test",
-    )
-
-    # Non-last stage: empty queue returns None
-    coord._start_stage("stage-0", 0, [task], is_last_stage=False)
-    pulled = coord.pull_task("worker-A")
-    assert pulled is not None and pulled != "SHUTDOWN"
-    _task, attempt, _config = pulled
-    coord.report_result("worker-A", 0, attempt, TaskResult(shard=ListShard(refs=[])), CounterSnapshot.empty())
-
-    # Queue empty, but not last stage -> None
-    result = coord.pull_task("worker-A")
-    assert result is None
-
-    # Last stage: single task, worker completes it, queue empty -> SHUTDOWN
-    task2 = ShardTask(
-        shard_idx=0,
-        total_shards=1,
-        shard=ListShard(refs=[]),
-        operations=[],
-        stage_name="test-last",
-    )
-    coord._start_stage("stage-1", 1, [task2], is_last_stage=True)
-    pulled = coord.pull_task("worker-A")
-    assert pulled is not None and pulled != "SHUTDOWN"
-    _task, attempt, _config = pulled
-    coord.report_result("worker-A", 0, attempt, TaskResult(shard=ListShard(refs=[])), CounterSnapshot.empty())
-
-    # Queue empty on last stage, nothing in-flight -> SHUTDOWN
-    result = coord.pull_task("worker-A")
-    assert result == "SHUTDOWN"
-
-    # Last stage with in-flight tasks: idle workers still get SHUTDOWN
-    tasks_2 = [
-        ShardTask(shard_idx=i, total_shards=2, shard=ListShard(refs=[]), operations=[], stage_name="test-last2")
-        for i in range(2)
-    ]
-    coord._start_stage("stage-2", 2, tasks_2, is_last_stage=True)
-    coord.pull_task("worker-A")  # task 0 in-flight
-    # Queue has one task left; worker-B takes it
-    coord.pull_task("worker-B")  # task 1 in-flight
-    # Queue empty, tasks in-flight -> SHUTDOWN (workers exit immediately)
-    result = coord.pull_task("worker-C")
-    assert result == "SHUTDOWN"
-
-
 def test_last_stage_deadlock_detected_when_worker_job_dies(actor_context, tmp_path):
     """Coordinator aborts if the worker job dies while last-stage work is outstanding."""
     coord = ZephyrCoordinator()
@@ -919,7 +863,7 @@ def test_last_stage_deadlock_detected_when_worker_job_dies(actor_context, tmp_pa
         ShardTask(shard_idx=i, total_shards=2, shard=ListShard(refs=[]), operations=[], stage_name="test")
         for i in range(2)
     ]
-    coord._start_stage("last-stage", 0, tasks, is_last_stage=True)
+    coord._start_stage("last-stage", 0, tasks)
 
     # Set up a mock worker group so _check_worker_group can query it.
     mock_group = MagicMock()
@@ -932,12 +876,11 @@ def test_last_stage_deadlock_detected_when_worker_job_dies(actor_context, tmp_pa
     pulled_a = coord.pull_task("worker-A")
     coord.pull_task("worker-B")
 
-    # Worker A finishes → gets SHUTDOWN (queue empty, last stage).
+    # Worker A finishes its task.
     _task_a, attempt_a, _ = pulled_a
     coord.report_result(
         "worker-A", _task_a.shard_idx, attempt_a, TaskResult(shard=ListShard(refs=[])), CounterSnapshot.empty()
     )
-    assert coord.pull_task("worker-A") == "SHUTDOWN"
 
     # Worker B crashes → heartbeat timeout → shard 1 requeued.
     coord._last_seen["worker-B"] = coord._last_seen["worker-B"] - 200
@@ -1128,8 +1071,8 @@ def test_stage_index_correct_with_join(local_client, tmp_path):
     stage_calls: list[tuple[str, int]] = []
     original_start_stage = ZephyrCoordinator._start_stage
 
-    def recording_start_stage(self, stage_name, current_stage_index, tasks, is_last_stage=False):
-        original_start_stage(self, stage_name, current_stage_index, tasks, is_last_stage=is_last_stage)
+    def recording_start_stage(self, stage_name, current_stage_index, tasks):
+        original_start_stage(self, stage_name, current_stage_index, tasks)
         stage_calls.append((stage_name, self._current_stage_index))
 
     ctx = ZephyrContext(

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -1071,8 +1071,8 @@ def test_stage_index_correct_with_join(local_client, tmp_path):
     stage_calls: list[tuple[str, int]] = []
     original_start_stage = ZephyrCoordinator._start_stage
 
-    def recording_start_stage(self, stage_name, current_stage_index, tasks):
-        original_start_stage(self, stage_name, current_stage_index, tasks)
+    def recording_start_stage(self, stage_name, current_stage_index, tasks, is_last_stage=False):
+        original_start_stage(self, stage_name, current_stage_index, tasks, is_last_stage)
         stage_calls.append((stage_name, self._current_stage_index))
 
     ctx = ZephyrContext(

--- a/lib/zephyr/tests/test_optimization.py
+++ b/lib/zephyr/tests/test_optimization.py
@@ -5,7 +5,7 @@
 
 from zephyr import Dataset, compute_plan
 from zephyr.dataset import FilterOp, MapOp, ReshardOp, TakePerShardOp
-from zephyr.plan import Map, PhysicalStage, Reshard
+from zephyr.plan import Map, PhysicalStage, Reshard, StageType
 
 
 def test_optimize_consecutive_maps():
@@ -119,7 +119,7 @@ def test_stage_name():
 
 def test_stage_name_truncation():
     """PhysicalStage.stage_name() truncates long names."""
-    stage = PhysicalStage(operations=[Map(fn=lambda x: x) for _ in range(20)])
+    stage = PhysicalStage(operations=[Map(fn=lambda x: x) for _ in range(20)], stage_type=StageType.MAP_WORKER)
     name = stage.stage_name(max_length=20)
     assert len(name) <= 20
     assert name.endswith("...")

--- a/lib/zephyr/tests/test_runners.py
+++ b/lib/zephyr/tests/test_runners.py
@@ -27,7 +27,12 @@ def _ctx(local_client, tmp_path, *, stage_runner_factory) -> ZephyrContext:
     )
 
 
-@pytest.fixture(params=[InlineRunner, SubprocessRunner], ids=["inline", "subprocess"])
+@pytest.fixture(
+    params=[
+        pytest.param(lambda n: InlineRunner(num_workers=n), id="inline"),
+        pytest.param(lambda n: SubprocessRunner(num_workers=n), id="subprocess"),
+    ]
+)
 def runner_factory(request):
     """Run each test against both shipped runners."""
     return request.param
@@ -91,11 +96,11 @@ def test_exception_preserves_user_frame(local_client, tmp_path, runner_factory):
 
 
 @pytest.mark.parametrize(
-    "runner_cls",
+    "runner_factory_fn",
     [
-        pytest.param(InlineRunner, id="inline"),
+        pytest.param(lambda n: InlineRunner(num_workers=n), id="inline"),
         pytest.param(
-            SubprocessRunner,
+            lambda n: SubprocessRunner(num_workers=n),
             id="subprocess",
             marks=pytest.mark.xfail(
                 strict=True,
@@ -105,7 +110,7 @@ def test_exception_preserves_user_frame(local_client, tmp_path, runner_factory):
         ),
     ],
 )
-def test_runner_parametrization_isolates_processes(local_client, tmp_path, runner_cls):
+def test_runner_parametrization_isolates_processes(local_client, tmp_path, runner_factory_fn):
     """Regression guard that subprocess parametrization actually spawns subprocesses.
 
     Inline reuses the worker actor (≤ max_workers PIDs); subprocess gets one PID per shard.
@@ -115,7 +120,7 @@ def test_runner_parametrization_isolates_processes(local_client, tmp_path, runne
         counters.increment(f"shard_pid_{os.getpid()}", 1)
         return x
 
-    ctx = _ctx(local_client, tmp_path, stage_runner_factory=runner_cls)
+    ctx = _ctx(local_client, tmp_path, stage_runner_factory=runner_factory_fn)
     try:
         ds = Dataset.from_list(list(range(5))).map(record_pid)
         outcome = ctx.execute(ds)
@@ -141,7 +146,7 @@ def test_subprocess_runner_isolates_native_crash(local_client, tmp_path):
 
         os._exit(139)
 
-    ctx = _ctx(local_client, tmp_path, stage_runner_factory=SubprocessRunner)
+    ctx = _ctx(local_client, tmp_path, stage_runner_factory=lambda n: SubprocessRunner(num_workers=n))
     try:
         ds = Dataset.from_list([0]).map(crash)
         with pytest.raises(ZephyrWorkerError) as exc_info:

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -7,7 +7,10 @@ Covers the scatter write/read roundtrip, per-shard stats, and external sort —
 without spinning up a full coordinator.
 """
 
+import pytest
+from zephyr.execution import _worker_ctx_var
 from zephyr.plan import deterministic_hash
+from zephyr.runners import _InProcessWorkerContext
 from zephyr.shuffle import (
     ScatterFileIterator,
     ScatterReader,
@@ -15,6 +18,15 @@ from zephyr.shuffle import (
     _write_chunk_frame,
     _write_scatter,
 )
+
+
+@pytest.fixture(autouse=True)
+def mock_worker_ctx():
+    """Provide a dummy worker context so ScatterWriter can resolve num_workers."""
+    ctx = _InProcessWorkerContext(chunk_prefix="test", execution_id="test", num_workers=1)
+    token = _worker_ctx_var.set(ctx)
+    yield
+    _worker_ctx_var.reset(token)
 
 
 def _key(item):

--- a/lib/zephyr/tests/test_worker_group_race.py
+++ b/lib/zephyr/tests/test_worker_group_race.py
@@ -39,7 +39,7 @@ def test_check_worker_group_skips_after_completed_stage(coordinator):
     coordinator.set_worker_group(mock_group)
 
     task = ShardTask(shard_idx=0, total_shards=1, shard=ListShard(refs=[]), operations=[], stage_name="test")
-    coordinator._start_stage("last-stage", 0, [task], is_last_stage=True)
+    coordinator._start_stage("last-stage", 0, [task])
     coordinator.report_result("worker-0", 0, 0, TaskResult(shard=ListShard(refs=[])), CounterSnapshot.empty())
 
     assert coordinator._completed_shards >= coordinator._total_shards
@@ -56,7 +56,7 @@ def test_check_worker_group_still_aborts_mid_stage(coordinator):
     coordinator.set_worker_group(mock_group)
 
     task = ShardTask(shard_idx=0, total_shards=2, shard=ListShard(refs=[]), operations=[], stage_name="test")
-    coordinator._start_stage("mid-stage", 0, [task, task], is_last_stage=False)
+    coordinator._start_stage("mid-stage", 0, [task, task])
     # Only 1 of 2 shards completed
     coordinator.report_result("worker-0", 0, 0, TaskResult(shard=ListShard(refs=[])), CounterSnapshot.empty())
 
@@ -80,7 +80,7 @@ def test_coordinator_loop_no_abort_during_result_collection(coordinator):
     coordinator.set_worker_group(mock_group)
 
     task = ShardTask(shard_idx=0, total_shards=1, shard=ListShard(refs=[]), operations=[], stage_name="test")
-    coordinator._start_stage("last-stage", 0, [task], is_last_stage=True)
+    coordinator._start_stage("last-stage", 0, [task])
     coordinator.report_result("worker-0", 0, 0, TaskResult(shard=ListShard(refs=[])), CounterSnapshot.empty())
 
     t = threading.Thread(target=coordinator._coordinator_loop, daemon=True)


### PR DESCRIPTION
# Key Changes
* Introduces sub-workers within a single Zephyr actor. Instead of one polling loop per actor, the ZephyrWorker now manages a pool of threads, each acting as a distinct worker slot. 
* Runs above `InlineRunner` and `SubprocessRunner` so those continue to function as normal.
* The number of sub-workers can be set differently for map and reduce stages.

# Results
I did a limited amount of optimizing jobs, intentionally leaving that for follow on commits, and instead just tried to ascertain whether this works (it does 🎉).

## Fineweb Exact
Running with two threads per worker: 11m ([run](https://iris.oa.dev/#/job/%2Fwmoss%2Firis-run-fineweb_10bt_exact-20260516-200333), [code changes](https://github.com/marin-community/marin/pull/5817))
Normal run (this code, but 1 thread): 16m ([run](https://iris.oa.dev/#/job/%2Fwmoss%2Firis-run-fineweb_10bt_exact-20260517-180958))


Fixes #5813
