### PR TITLE
Widen infra status dashboard

### DIFF
--- a/infra/status-page/server/sources/serviceHealth.ts
+++ b/infra/status-page/server/sources/serviceHealth.ts
@@ -11,6 +11,7 @@ const GCP_ZONE = process.env.CONTROLLER_ZONE ?? "us-central1-a";
 const CACHE_TTL_MS = 60_000;
 const HEALTH_TIMEOUT_MS = 5_000;
 const LATENCY_SUMMARY_WINDOW_MS = 5 * 60 * 1000;
+const SUMMARY_POINT_INTERVAL_MS = 60_000;
 
 export type Environment = "prod" | "dev";
 type ServiceKind = "iris" | "finelog";
@@ -67,6 +68,7 @@ export interface ServiceHealthResponse {
   samples: ServiceHealthHistorySample[];
   summarySamples: ServiceHealthSummarySample[];
   aggregationWindowMs: number;
+  summaryPointIntervalMs: number;
   windowMs: number;
   fetchedAt: string;
 }
@@ -282,9 +284,10 @@ function latencyStats(values: number[]): ServiceLatencyStats | null {
 export function serviceHealthSummarySamples(
   samples: ServiceHealthHistorySample[],
   aggregationWindowMs = LATENCY_SUMMARY_WINDOW_MS,
+  pointIntervalMs = SUMMARY_POINT_INTERVAL_MS,
 ): ServiceHealthSummarySample[] {
   const series = serviceHealthSeries();
-  return samples.map((sample, i) => {
+  const summaries = samples.map((sample, i) => {
     const windowStart = sample.t - aggregationWindowMs;
     const stats: Record<string, ServiceLatencyStats | null> = {};
     const sampleCounts: Record<string, number> = {};
@@ -305,6 +308,27 @@ export function serviceHealthSummarySamples(
 
     return { t: sample.t, stats, sampleCounts };
   });
+
+  if (pointIntervalMs <= 0) return summaries;
+
+  const bucketed: ServiceHealthSummarySample[] = [];
+  let currentBucket: number | null = null;
+  let latestInBucket: ServiceHealthSummarySample | null = null;
+
+  for (const summary of summaries) {
+    const bucket = Math.floor(summary.t / pointIntervalMs);
+    if (currentBucket !== null && bucket !== currentBucket && latestInBucket) {
+      bucketed.push(latestInBucket);
+    }
+    currentBucket = bucket;
+    latestInBucket = summary;
+  }
+
+  if (latestInBucket) {
+    bucketed.push(latestInBucket);
+  }
+
+  return bucketed;
 }
 
 export function serviceHealthResponse(
@@ -319,6 +343,7 @@ export function serviceHealthResponse(
     samples,
     summarySamples: serviceHealthSummarySamples(samples),
     aggregationWindowMs: LATENCY_SUMMARY_WINDOW_MS,
+    summaryPointIntervalMs: SUMMARY_POINT_INTERVAL_MS,
     windowMs,
     fetchedAt: new Date().toISOString(),
   };

--- a/infra/status-page/web/src/App.tsx
+++ b/infra/status-page/web/src/App.tsx
@@ -8,7 +8,7 @@ export function App() {
   const [autoRefresh, setAutoRefresh] = useAtom(autoRefreshAtom);
 
   return (
-    <div className="mx-auto max-w-5xl px-6 py-8">
+    <div className="mx-auto max-w-[128rem] px-6 py-8">
       <header className="mb-8 flex items-baseline justify-between">
         <h1 className="text-3xl font-bold tracking-tight">Marin Infra Status</h1>
         <label className="flex items-center gap-2 text-sm text-slate-400">

--- a/infra/status-page/web/src/api.ts
+++ b/infra/status-page/web/src/api.ts
@@ -124,6 +124,7 @@ export interface ServiceHealthResponse {
   samples: ServiceHealthHistorySample[];
   summarySamples: ServiceHealthSummarySample[];
   aggregationWindowMs: number;
+  summaryPointIntervalMs: number;
   windowMs: number;
   fetchedAt: string;
 }

--- a/infra/status-page/web/src/components/ControlPlanePanel.tsx
+++ b/infra/status-page/web/src/components/ControlPlanePanel.tsx
@@ -67,6 +67,9 @@ export function ControlPlanePanel() {
   const aggregationLabel = data?.aggregationWindowMs
     ? `${formatDuration(data.aggregationWindowMs)} rolling`
     : "rolling";
+  const pointLabel = data?.summaryPointIntervalMs
+    ? `${formatDuration(data.summaryPointIntervalMs)} points`
+    : "points";
 
   return (
     <div>
@@ -76,7 +79,7 @@ export function ControlPlanePanel() {
         </h3>
         <span className="text-xs text-slate-500">
           {samples.length > 1
-            ? `${displayedSpanLabel(samples)} · ${aggregationLabel} · p50/max`
+            ? `${displayedSpanLabel(samples)} · ${pointLabel} · ${aggregationLabel} · p50/max`
             : "history warming up"}
         </span>
       </div>


### PR DESCRIPTION
## Summary
- Widen the infra status dashboard so charts have more horizontal room.
- Show `/health` latency summaries at 1-minute point spacing while keeping the 30s probes.

## Validation
- `npm run build`