### PR TITLE
[Design] per_user_gcs_prefix

### DIFF
--- a/.agents/projects/per_user_gcs_prefix/design.md
+++ b/.agents/projects/per_user_gcs_prefix/design.md
@@ -1,0 +1,86 @@
+# Per-User GCS Storage Prefix
+
+_Why are we doing this? What's the benefit?_
+
+Marin's GCS paths today flow through a single regional `MARIN_PREFIX` and every user writes into the same `experiments/` namespace, so there is no per-user attribution and no foundation for per-user quotas or usage reports. Model checkpoints — the dominant storage cost and the easiest artifact to leave behind by accident — sit inside hash-named step output dirs that nobody owns. We add a thin fsspec filesystem (`users://`) that resolves the same path against a per-user "personal" layer first and the existing shared root second; training step factories opt in by pointing their `override_output_path` at a `users://` URL. The executor, `StepSpec`, and downstream consumers stay unchanged — they just see fsspec URLs.
+
+## Background
+
+`marin_prefix()` ([`lib/rigging/src/rigging/filesystem.py:136`](https://github.com/marin-community/marin/blob/ea00d29f1/lib/rigging/src/rigging/filesystem.py#L136)) is the single hook every output path flows through. The closest in-repo precedent is `MirrorFileSystem` ([`filesystem.py:804`](https://github.com/marin-community/marin/blob/ea00d29f1/lib/rigging/src/rigging/filesystem.py#L804)) — an fsspec filesystem (`mirror://`) that resolves cross-region reads by probing the local marin bucket, scanning other regional buckets, and copying on first access under a `TransferBudget`. The personal-vs-shared lookup proposed here is the same algorithm (probe layer 0, fall back to layer 1, resolve to a concrete URL), but applied across prefixes inside one bucket and with no copy step — the goal is attribution, not transparent fetch. Iris already has a complete user-identity surface (`IrisClient.submit(user=)`, `iris job run --user`, `get_job_info().user`, `getpass.getuser()` fallback) per `.agents/projects/20260301_iris_user_job_names.md`. `StepSpec.override_output_path` ([`step_spec.py:59`](https://github.com/marin-community/marin/blob/ea00d29f1/lib/marin/src/marin/execution/step_spec.py#L59)) already exists as a per-step path override and accepts arbitrary URL strings. Full digest in [`research.md`](./research.md).
+
+## Challenges
+
+The hard part is keeping executor changes minimal. The executor's cache-hit predicate at [`executor.py:1448`](https://github.com/marin-community/marin/blob/ea00d29f1/lib/marin/src/marin/execution/executor.py#L1448) probes `{output_path}/.executor_status` and decides "step is done" purely from that file. If checkpoints live under `users://` but `.executor_status` lives at the shared root, a teammate's run would short-circuit my executor while my eval can't find their checkpoint. We resolve this by making the whole training step output dir live behind `users://` (status file + checkpoints + logs), so the layered lookup naturally answers both "is this step done for *me*" and "where are *my* checkpoints" with the same probe order.
+
+The executor needs *one small change* to support this: today `Executor.compute_version` ([`executor.py:1504`](https://github.com/marin-community/marin/blob/ea00d29f1/lib/marin/src/marin/execution/executor.py#L1504)) hard-codes the executor's global `self.prefix` when joining `{prefix}/{name}_{hash}`. We add an optional `output_path_prefix` field on `ExecutorStep` and a one-line preference: `prefix = step.output_path_prefix or self.prefix`. After that change, the executor itself is unaware of `users://` — it joins the URL like any other prefix and fsspec handles the layering.
+
+The second challenge is making sure `users://` doesn't accidentally swallow paths that aren't supposed to be per-user. We address this by making it strictly opt-in: only training step factories set `output_path_prefix="users://"` on the `ExecutorStep` they return. Ferries, datasets, evals, scratch — all continue to use `gs://`/`marin_prefix()` directly, unchanged.
+
+## Costs / Risks
+
+- **One more fsspec protocol to maintain.** Mirror set the precedent; `users://` follows the same shape, but it's another moving piece in `rigging`.
+- **Implicit cross-user data dependencies.** Once my pipeline resolves a step to a teammate's `users/{them}/` dir, my downstream runs depend on that dir existing. If they delete it, my next run breaks (recoverable by re-running the upstream step, which then writes to my own dir). Acceptable for a small team where deletion is rare and recovery is cheap; would not scale to dozens of users without a real cache layer.
+- **`.executor_status` SUCCESS without artifacts.** The cache hit is gated only on the status token. If a teammate's `.executor_status` is `SUCCESS` but their `checkpoints/` dir was partially deleted (lifecycle, manual `gsutil rm`, etc.), the executor short-circuits and downstream eval/SFT fails at file-open time, not at cache-check time. Recoverable by re-running the upstream step explicitly. A bulletproof fix (probe for a sentinel artifact, e.g. `checkpoints/.complete`) is plausible but out of scope for v1.
+- **Cross-region guard surface.** `_infer_gcs_regions` (`executor.py:208`) only inspects `gs://` URLs; a `users://` URL slips through silently. Spec mandates `UserSharedFS` expose a `to_gs_url()` helper that callers (the region check, the cross-region transfer budget) invoke before scheme-matching.
+- **Glob cost grows with team size.** A single `users/*/...` glob is ~100ms today (~10s of users); at 100+ users it would still be cheap but no longer free. If the team grows substantially we'd want an index instead of a glob.
+- **Identity-resolution edge cases.** Running training outside an Iris context (local dev, ad-hoc scripts) falls back to `getpass.getuser()`; service-account contexts where `getpass` returns the same value across machines (`runner`, `nobody`) silently collide. Mitigation: a `MARIN_USER` env var inserted before the `getpass` step in the resolver chain lets service accounts and CI override explicitly.
+
+## Design
+
+### `UserSharedFS` (`users://`) — the whole feature
+
+A new fsspec filesystem in `rigging`, sibling to `MirrorFileSystem`, that resolves a relative path against three layers in order:
+
+- **My personal (writable):** `{prefix}/users/{me}/{path}`
+- **Other users (read-only scan):** `{prefix}/users/*/{path}` — single GCS glob across other user dirs
+- **Shared (read-only):** `{prefix}/{path}`
+
+Read semantics: probe my personal first; on miss, glob `users/*/{path}` and return any match; on miss, probe shared; on miss, raise `FileNotFoundError`. With a small team (~10-50 marin users) the glob is a single low-latency GCS list call (~100ms) — no per-user fanout. Whichever layer hits is the concrete `gs://...` URL returned to the caller.
+
+Write semantics: always to my personal. The other-user and shared layers are structurally read-only — writes never land there.
+
+The two-mode behavior (read resolves via layers; write goes to personal) means a teammate's existing SUCCESS is reused transparently, while a teammate's FAILED status forces me to re-run and my writes land in my own dir. No promotion step, no double storage during transition — cross-user reuse is just the read path.
+
+Layers are configured at instantiation: `prefix` resolves through `marin_prefix()`; `user` resolves through the Iris identity chain (`get_job_info().user` → `getpass.getuser()`) with an explicit override accepted in the constructor. The filesystem is registered as `users://` via `fsspec.register_implementation`.
+
+`UserSharedFS` ships as a sibling to `MirrorFileSystem`, not a refactor. Mirror copies on miss across bucket boundaries with a transfer budget and a distributed lock; `UserSharedFS` does pure routing across prefixes inside one bucket. The two share a one-paragraph algorithm and almost no code — pulling out a `LayeredReadFS` base now would be premature abstraction by the standard of `AGENTS.md`. If a third use case shows up, refactor then.
+
+### How training opts in
+
+After the executor change above, every `ExecutorStep` carries an optional `output_path_prefix` that overrides the executor's global prefix for that step's `{prefix}/{name}_{hash}` path. Setting it to `"users://"` is the entire plumbing — hash-keyed caching is preserved, the resulting `output_path` is `users://{name}_{hash}`, and every artifact written by the step (`.executor_status`, checkpoints, logs) lands behind the layered fs.
+
+V1 wires this in two places in `experiments/defaults.py`:
+
+- **`default_train`** ([line 504](https://github.com/marin-community/marin/blob/ea00d29f1/experiments/defaults.py#L504)) and **`default_dpo`** ([line 821](https://github.com/marin-community/marin/blob/ea00d29f1/experiments/defaults.py#L821)) — the two ExecutorStep-producing leaf factories. Pass `output_path_prefix="users://"` to the `ExecutorStep` constructor. `default_sft` (line 749) and `simulated_epoching_train` (line 323) inherit transitively because they route through `default_train`.
+- **`resolve_lm_train_config`** ([line 611](https://github.com/marin-community/marin/blob/ea00d29f1/experiments/defaults.py#L611)) — the inline-submission path used by `train()` / `prepare_lm_train()` bypasses ExecutorStep and calls `compute_output_path()` directly. Pass `output_path_prefix="users://"` (which is forwarded into the throwaway ExecutorStep that `compute_output_path` constructs).
+
+Because the routing decision lives in the factories rather than on the executor or on `StepSpec` itself, opting out for a one-off (e.g. a "born shared" canonical training run intended for everyone) is just passing `output_path_prefix=None` through the factory.
+
+A teammate's eval reading `users://{step}_{hash}/checkpoints/` resolves through the layered probe — my personal first, then any other user with a successful run of the same hash, then shared. The executor cache check at `executor.py:1448` becomes cross-user automatically because the `.executor_status` URL is layered: if any user has SUCCESS for this hash, we skip the recompute.
+
+### Identity-failure mode
+
+If the resolution chain produces no username — no explicit override, no Iris context, and `getpass.getuser()` raises (stripped containers with no `USER`/`LOGNAME` env vars and a UID not in `/etc/passwd`) — `UserSharedFS` raises on first access. We hard-fail rather than degrade because silently routing personal data into the shared root defeats attribution; a clear error at job start is cheaper than discovering the misroute weeks later. The hard-fail case is genuinely rare (it requires both Iris-less execution *and* a missing OS identity); the more common "ran outside Iris" path resolves via `getpass.getuser()` and works.
+
+### Reporting (follow-up, not v1 implementation)
+
+Per-user storage attribution becomes a GCS-inventory scan over `users/{user}/` prefixes, modeled on `scripts/ops/egress_report.py`. V1 ships the directory convention; the scanner job is a follow-up PR.
+
+### Out of scope for v1
+
+- Any promotion mechanism (the cross-user read scan replaces it — see below).
+- Lifecycle rules on `users/*` (no auto-deletion).
+- Hard write-time quota enforcement.
+- Routing non-training step outputs (datasets, evals, ferries, scratch) through `users://`.
+- A `scope` field on `StepSpec` (not needed under this design — opt-in is at URL-construction time).
+
+## Testing
+
+- **Unit on `UserSharedFS` resolution.** Stub the underlying fs with `memory://`; assert reads probe personal first, then glob across other users, then shared; that writes always go to personal regardless of where reads resolved; that identity override works; that identity-failure raises; and that `_resolve_path` returns the URL of whichever layer hit. Include the FAILED-at-teammate case: resolution returns teammate's path, executor reads FAILED, re-run writes to my personal.
+- **Executor unchanged.** Snapshot test on `compute_output_path()` for existing experiments confirms no path drift for non-training steps.
+- **Integration via a training step.** Run a small training executor step end-to-end with `override_output_path = "users://..."` against a test bucket; assert `.executor_status` and checkpoints land under `users/{user}/`, second invocation hits the personal layer, and a manually-promoted copy in the shared layer is found via fallback when the personal layer is purged.
+
+## Open Questions
+
+- **Confirm existing pretraining-checkpoint layout.** The "no cutover needed" property relies on currently-running pretraining checkpoints living at `gs://marin-{region}/checkpoints/...` (i.e., reachable via layer-3 shared-root fallback). If any active run targets a custom subprefix outside the regional bucket root, those owners need a one-time `output_path_prefix=None` opt-out for the resume cycle. Reviewers closer to the active training queue should sanity-check this assumption.
+- **Future opt-in candidates beyond training.** V1 routes only `default_train` / `default_dpo` through `users://`. Obvious follow-ups: eval-result bundles (small but proliferate), sampler outputs (medium-sized, sometimes shared), tokenization caches (large, currently shared and content-addressable). Worth deciding now which of these should join the next rollout vs. wait for evidence of attribution gaps.

--- a/.agents/projects/per_user_gcs_prefix/research.md
+++ b/.agents/projects/per_user_gcs_prefix/research.md
@@ -1,0 +1,120 @@
+# Research: Per-User GCS Storage Prefix
+
+Research digest for the `per_user_gcs_prefix` design doc. Findings as of `main` @ `ea00d29f1`.
+
+## In-repo: current state
+
+### `MARIN_PREFIX` resolution
+
+`marin_prefix()` at [`lib/rigging/src/rigging/filesystem.py:136-151`](../../lib/rigging/src/rigging/filesystem.py) is the central helper:
+
+```
+1. MARIN_PREFIX env var
+2. GCS instance metadata → gs://marin-{region}
+3. /tmp/marin (local fallback)
+```
+
+Regional buckets defined in `REGION_TO_DATA_BUCKET` at the same file (lines 61-68): `marin-us-central1`, `marin-us-central2`, `marin-us-east1`, `marin-us-east5`, `marin-us-west4`, `marin-eu-west4`.
+
+Temp prefix scheme: `gs://marin-{region}/tmp/ttl={N}d/` with `N` in `(1,2,3,4,5,6,7,14,30)` (lines 78-83).
+
+### Executor path computation
+
+The chain from config → final output path:
+
+1. `ExecutorMainConfig.prefix: str | None = None` — `lib/marin/src/marin/execution/executor.py:1697`
+2. `executor_main()` resolves `prefix = config.prefix or marin_prefix()` — line 1734
+3. `Executor(prefix=prefix, ...)` — line 1742
+4. `Executor.compute_version(step)` builds `output_path = os.path.join(self.prefix, step.name + "-" + hashed_version)` — line 1504
+5. `step.override_output_path` honored if set — line 1516
+6. `self.output_paths[step] = output_path` — line 1541
+7. Public utility `compute_output_path()` at lines 1778-1808 takes an optional `prefix=` (falls back to `marin_prefix()` at 1795)
+
+### Executor cache check
+
+Single-root, single-token status file:
+
+- Check location: [`executor.py:1448-1454`](../../lib/marin/src/marin/execution/executor.py)
+- `StatusFile(info.output_path, worker_id="check")` returns one of `SUCCESS`, `FAILED`, `DEP_FAILED`, `RUNNING`
+- Status file lives at `{output_path}/.executor_status` — `lib/marin/src/marin/execution/executor_step_status.py:44`, reader at 74-93
+- No multi-root lookup exists today; cache hit is strictly `{prefix}/{step}-{hash}/.executor_status == SUCCESS`
+
+### Step-level path knobs
+
+- `StepSpec.override_output_path` — `lib/marin/src/marin/execution/step_spec.py:59-60` — absolute or prefix-relative override
+- `StepSpec.output_path_prefix` — same file, lines 50-51 — falls back to `MARIN_PREFIX` env if unset
+- **No** existing `shared`, `published`, `canonical`, or `global` step flag
+
+### Iris user identity
+
+The chain is already designed and partially implemented per `.agents/projects/20260301_iris_user_job_names.md`:
+
+- `IrisClient.submit(..., user: str | None = None)` — `lib/iris/src/iris/client/client.py:540-594` (param at line 554, docs at 577)
+- `iris job run --user` — `lib/iris/src/iris/cli/job.py:818`
+- `get_job_info().user` for in-job lookup — `lib/iris/src/iris/cluster/client/job_info.py:73-74` (function at lines 85-93, env var fallback at 96-127)
+- Resolution order per design: explicit override → `get_job_info()` context → `getpass.getuser()`
+
+### Zephyr output paths
+
+Decoupled from `marin_prefix()`:
+
+- `lib/zephyr/src/zephyr/dataset.py:671-722` — writers accept `output_pattern` as caller-supplied string/callable
+- Zephyr imports `marin_temp_bucket` only for shuffle intermediates: `lib/zephyr/src/zephyr/execution.py:44`
+- **Implication:** user-prefix routing applies automatically only to zephyr steps invoked *through marin executor*; standalone zephyr scripts construct paths manually
+
+### Bucket lifecycle (`infra/configure_buckets.py`)
+
+- `build_ttl_rules()` at lines 76-84 — only manages `tmp/ttl=Nd/` deletes
+- `ALLOWED_TTL_DAYS = (1,2,3,4,5,6,7,14,30)`
+- **Foreign-rule preserving merge** at lines 87-103, 111-112 — safe to add per-user TTL rules alongside existing ones
+
+### Existing per-user accounting
+
+- `scripts/ops/egress_report.py` lines 11-12, 30-31 — tracks per-user cross-region egress
+- `LARGE_TIER_USER_THRESHOLD = 10` constant — implies operational awareness of per-user behavior
+- No storage-side per-user tracking exists yet
+
+### Ferry behavior
+
+- `experiments/ferries/datakit_ferry.py:152-155` — sets `os.environ["MARIN_PREFIX"]` dynamically to `marin_temp_bucket(ttl_days=1)`
+- Open question for design: when MARIN_PREFIX is set non-default, do we still layer `users/{user}/` on top?
+
+## Prior designs
+
+### `20260301_iris_user_job_names.md` — direct precedent
+
+Already establishes:
+- Canonical user resolution order (explicit override → context → OS user)
+- The user-identity surface (`IrisClient.submit(user=)`, `iris job run --user`, `get_job_info().user`)
+- Explicitly names "future per-user resource tracking, scheduler guidance, and quota/accounting features" as motivation
+
+This GCS-prefix proposal is the storage-side application of that work.
+
+### `20260312_iris_auth_design.md`
+
+Sibling design on auth surface — relevant for future hard-enforcement but not v1 since v1 is convention + reporting.
+
+## Related GitHub issues
+
+- **#3876** — `[iris] Bind per-user service account at login for agent-driven job isolation` — closely aligned with per-user resource boundaries; relevant for v2 enforcement
+- **#3461** — `Unify worker storage prefix for profiles, logs, and checkpoints` — precedent for unifying storage prefix semantics
+- **#3721** — `GCS cleanup and purge` — general storage housekeeping
+- **#5744** — `Clean up non-current Datakit/normalized datasets from GCS` — dataset lifecycle parallel
+
+## Design decisions confirmed via Q&A
+
+| Decision | Choice | Source |
+| --- | --- | --- |
+| User identity | Iris `--user` flag plumbed through, fallback to `getpass.getuser()` | user confirmed |
+| Path layout | `users/{user}/` inside existing regional bucket (no new bucket) | user confirmed |
+| Promotion mechanism | Step-level annotation in experiment code (no separate CLI for v1) | user confirmed |
+| Cache mechanism | Personal → shared root fallback; promotion is the only cross-user reuse path | user confirmed |
+| Scope (v1) | Executor outputs + zephyr pipeline outputs invoked through marin steps | user confirmed |
+| Enforcement (v1) | Directory convention + reporting only; no write-time quotas | user confirmed |
+
+## Open / unanswered
+
+- `born_shared` step flag: write-directly-to-shared vs. write-personal-then-copy on completion
+- MARIN_PREFIX explicit-override behavior: layer user prefix or respect the override as-is
+- Lifecycle policy on `users/*`: default TTL vs. pure reporting for v1
+- Cache fallback semantics for non-shared steps: probe shared root as fallback, or strict personal-only?

--- a/.agents/projects/per_user_gcs_prefix/spec.md
+++ b/.agents/projects/per_user_gcs_prefix/spec.md
@@ -1,0 +1,359 @@
+# Per-User GCS Storage Prefix — Spec
+
+Contract layer for the design in [`design.md`](./design.md). Defines the `UserSharedFS` class, the `users://` URL grammar, the identity resolver, error types, layer-resolution semantics, persisted layout, and the wiring surface in `experiments/defaults.py`.
+
+## Executor changes
+
+Two small changes to `lib/marin/src/marin/execution/executor.py` are required so that an individual step can opt out of the executor's global prefix.
+
+### `ExecutorStep.output_path_prefix` (new field)
+
+```python
+@dataclass(frozen=True)
+class ExecutorStep(Generic[ConfigT_co]):
+    name: str
+    fn: ExecutorFunction
+    config: ConfigT_co
+    description: str | None = None
+    override_output_path: str | None = None
+    resources: ResourceConfig | None = None
+    output_path_prefix: str | None = None  # NEW
+    """Per-step prefix override. If set, takes precedence over the Executor's
+    global ``self.prefix`` when computing this step's hash-keyed output path.
+    The ``{name}-{hash}`` suffix is preserved either way. Used to route
+    specific step types (e.g. training checkpoints) into a different storage
+    namespace such as ``users://``. None means "use the Executor's prefix"
+    (current behavior)."""
+```
+
+### `Executor.compute_version` line 1504
+
+The line that joins prefix and hashed name changes from:
+
+```python
+output_path = os.path.join(self.prefix, step.name + "-" + hashed_version)
+```
+
+to:
+
+```python
+prefix = step.output_path_prefix or self.prefix
+output_path = os.path.join(prefix, step.name + "-" + hashed_version)
+```
+
+`os.path.join` handles the trailing-`://` of URL schemes correctly: `os.path.join("users://", "name-hash")` yields `"users://name-hash"`. No additional normalization is needed at this site.
+
+### `step_spec.py:114` and `:116` — fix slash count
+
+`StepSpec.output_path` currently uses f-string concatenation: `f"{prefix}/{x}"`. With `prefix="users://"` this yields `"users:///x"` (triple slash). Replace both lines with `os.path.join(prefix, x)` to match the executor's join semantics and produce `"users://x"` consistently.
+
+### `compute_output_path` signature
+
+```python
+def compute_output_path(
+    name: str,
+    config: Any,
+    *,
+    override_output_path: str | None = None,
+    prefix: str | None = None,
+    output_path_prefix: str | None = None,  # NEW
+) -> str:
+    """Compute the concrete output path a step with this name+config will produce.
+
+    ``prefix`` continues to control the throwaway executor's ``self.prefix``
+    (and its ``executor_info_base_path``); ``output_path_prefix`` is forwarded
+    to the constructed ``ExecutorStep`` and takes precedence over ``prefix``
+    when set. Callers wanting per-step routing pass ``output_path_prefix``;
+    callers that just want a different global prefix pass ``prefix``.
+    """
+```
+
+## `UserSharedFS`
+
+A new fsspec filesystem registered under the `users` protocol. Lives in `lib/rigging/src/rigging/filesystem.py` alongside `MirrorFileSystem`. Sibling implementation; no shared base class.
+
+```python
+class UserSharedFS(fsspec.AbstractFileSystem):
+    """Fsspec filesystem with layered read resolution and writes-to-personal.
+
+    Reads probe three layers in order:
+      1. ``{prefix}/users/{user}/<path>`` — the caller's personal dir
+      2. ``{prefix}/users/*/<path>`` — single GCS glob across other users
+      3. ``{prefix}/<path>`` — the shared root
+
+    The first layer where the artifact exists is the concrete URL returned
+    to callers (``_info``, ``_ls``, ``_exists``, ``_open`` in read modes).
+    Writes (``_open`` in write/append modes, ``_makedirs``, ``_rm``) always
+    target layer 1 — the personal dir — regardless of which layer a prior
+    read resolved to. The other-user and shared layers are structurally
+    read-only.
+
+    The base prefix and resolved username are computed lazily on first
+    operation, not in ``__init__`` — so constructing the filesystem in an
+    environment with no resolvable identity does not raise; only attempting
+    to use it does.
+    """
+
+    protocol = "users"
+
+    def __init__(
+        self,
+        *args: Any,
+        user: str | None = None,
+        prefix: str | None = None,
+        storage_options: dict | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Construct the layered filesystem.
+
+        Args:
+            user: Explicit username override. If ``None``, resolved lazily
+                on first read/write via ``resolve_marin_user()``.
+            prefix: Base GCS prefix (e.g. ``gs://marin-us-central2``). If
+                ``None``, resolved lazily via ``marin_prefix()`` on first
+                read/write — so ferries that set ``MARIN_PREFIX`` dynamically
+                are respected.
+            storage_options: Passed through to the underlying ``gcsfs``
+                instance constructed lazily on first operation.
+        ``*args`` and remaining ``**kwargs`` are forwarded to
+        ``AbstractFileSystem.__init__``.
+        """
+
+    def _resolve_path(self, path: str, *, for_write: bool = False) -> str:
+        """Map a ``users://`` path to a concrete ``gs://`` URL.
+
+        Read mode (``for_write=False``): probes the three layers in order
+        and returns the first concrete URL where the artifact exists.
+        Raises ``FileNotFoundError`` if no layer has it. Identity and prefix
+        are resolved here on first call.
+
+        Write mode (``for_write=True``): returns the personal-layer URL
+        unconditionally, without probing.
+
+        Per-step-root atomicity: if ``path`` has a recognized step-root
+        first segment (the prefix up to and including ``{name}-{hash}/``),
+        the resolved user is cached on the instance for the duration of
+        the call chain so a single step's reads stay within one user's dir.
+        Cache TTL is per-instance lifetime; constructing a new
+        ``UserSharedFS()`` clears it.
+        """
+
+    def to_gs_url(self, path: str) -> str:
+        """Resolve a ``users://`` path to its concrete ``gs://`` URL.
+
+        Read-mode resolution (probes layers). Public so that callers needing
+        to feed the resolved URL into scheme-aware utilities (e.g. the
+        executor's cross-region guard at ``executor.py:208``, or
+        ``CrossRegionGuardedFS``) can do so explicitly. The cross-region
+        guard inside Marin will be updated to call this helper for any
+        ``users://`` URL before scheme-matching.
+        """
+
+    # fsspec overrides — all forward through _resolve_path with the
+    # appropriate for_write flag and then delegate to the underlying
+    # filesystem (gcsfs in production, memory:// in tests).
+
+    def _open(self, path: str, mode: str = "rb", **kwargs: Any) -> Any: ...
+    def _info(self, path: str, **kwargs: Any) -> dict[str, Any]: ...
+    def _ls(self, path: str, detail: bool = True, **kwargs: Any) -> list[Any]: ...
+    def _exists(self, path: str, **kwargs: Any) -> bool: ...
+    def _rm(self, path: str, recursive: bool = False, **kwargs: Any) -> None: ...
+    def _makedirs(self, path: str, exist_ok: bool = False, **kwargs: Any) -> None: ...
+
+
+fsspec.register_implementation("users", UserSharedFS)
+```
+
+### Layer resolution table
+
+| Operation | Probe / target |
+|---|---|
+| `_open(path, "rb")`, `_info`, `_ls`, `_exists` | (1) `{prefix}/users/{me}/{path}` → (2) glob `{prefix}/users/*/{step_root}/.executor_status` for `SUCCESS`, then take that user's `{path}` → (3) `{prefix}/{path}` |
+| `_open(path, "wb"\|"ab"\|"r+")`, `_makedirs`, `_rm` | `{prefix}/users/{me}/{path}` (unconditional) |
+| Read miss across all three layers | Raise `FileNotFoundError` |
+| Glob in layer 2 returns >1 user with `SUCCESS` status | Raise `AmbiguousCrossUserResolutionError` (see Errors) |
+| Layer-2 candidate user has `.executor_status` ≠ `SUCCESS` (RUNNING, FAILED, missing) | Skip that user; continue scanning |
+
+The layer-2 glob keys on the step-root's `.executor_status` content, *not* on bare path existence. A teammate's RUNNING or FAILED run does not satisfy the probe; we want only complete artifacts. The step root is `{first_segment_after_users://}` — for `users://train-llama-1b_a1b2c3d4/checkpoints/step_1000`, the step root is `train-llama-1b_a1b2c3d4`. Once a user is selected for a given step root, all subsequent reads under that step root resolve to the same user's dir for the lifetime of the `UserSharedFS` instance (per-step-root atomicity, see `_resolve_path` docstring).
+
+### URL grammar
+
+```
+users://<path>
+```
+
+`<path>` is one or more `/`-separated non-empty segments. Empty path (`users://`) is invalid and raises `ValueError`. There is no scheme authority — fsspec treats the whole string after `users://` as the path.
+
+Valid examples:
+- `users://checkpoints/train-llama-1b_a1b2c3d4/.executor_status`
+- `users://checkpoints/train-llama-1b_a1b2c3d4/checkpoints/step_1000/`
+
+Invalid (raise `ValueError`):
+- `users://`
+- `users://?query`
+
+### Behavioural guarantees
+
+- **Read-resolve-then-open is atomic per call.** A read call resolves the layer once and opens that concrete URL. If the file disappears between resolve and open (e.g. a teammate `gsutil rm`s mid-call), the underlying GCS open raises `FileNotFoundError`; the call does *not* re-probe.
+- **Writes never escape the personal layer.** Writing to `users://x/y` always touches `{prefix}/users/{me}/x/y` even if reads of the same URL would resolve to a teammate's dir.
+- **Identity is resolved at most once per instance.** The resolved username is cached on the instance after first read/write. Constructing a new `UserSharedFS()` re-resolves. URL parsing (`_strip_protocol`) and `__init__` do *not* trigger identity resolution; only the first `_open`/`_info`/`_ls`/`_exists`/`_rm`/`_makedirs` call does.
+- **Per-step-root atomicity for layer 2.** Once layer 2 selects a user for step root `S`, all subsequent reads of `users://S/...` resolve to that user's dir for the instance's lifetime. Without this guarantee, two files in the same logical step output could resolve to different users (alice's `.executor_status` + bob's `checkpoints/step_1000/`).
+- **`_ls` does not merge across layers.** It returns the listing of whichever layer hit on probe. Merged listings are explicitly out of scope; reporting/inventory tooling enumerates `users/*/` via the raw `gcsfs`/`gs://` interface, not through `users://`.
+- **Cross-user resolution is logged.** Each `_resolve_path` call that resolves to layer 2 (another user) or layer 3 (shared root) emits one `INFO`-level log line with the step root and resolved user. Layer-1 (own personal) resolutions are silent. The executor's job-start preamble can opt to log a summary count.
+
+## Identity resolver
+
+```python
+def resolve_marin_user(override: str | None = None) -> str:
+    """Resolve the canonical marin user identifier.
+
+    Resolution order:
+        1. ``override`` argument (if non-None, non-empty after strip).
+        2. ``MARIN_USER`` environment variable (if set, non-empty after strip).
+        3. ``iris.cluster.client.job_info.get_job_info().user`` if not None.
+        4. ``getpass.getuser()``.
+
+    Returns the resolved username (no normalization, no allow/deny list).
+
+    Raises:
+        UserIdentityResolutionError: If no override is passed, ``MARIN_USER``
+            is unset, ``get_job_info()`` returns None, and ``getpass.getuser()``
+            raises ``OSError`` (the stripped-container case with no
+            USER/LOGNAME env vars and a UID not in /etc/passwd).
+    """
+```
+
+The `MARIN_USER` rung is added specifically for service-account/CI contexts where `getpass.getuser()` returns a shared generic name (`runner`, `nobody`); setting `MARIN_USER` lets those contexts route to a meaningful prefix without code changes.
+
+Location: `lib/rigging/src/rigging/filesystem.py` (same module as `UserSharedFS`).
+
+## Errors
+
+```python
+class UserIdentityResolutionError(RuntimeError):
+    """Raised when ``resolve_marin_user`` exhausts the resolution chain.
+
+    Triggered only when (a) no explicit override is passed, (b) ``MARIN_USER``
+    is unset, (c) ``get_job_info()`` returns None (not running inside an Iris
+    job context), and (d) ``getpass.getuser()`` raises ``OSError``. The
+    original ``OSError`` is attached via ``__cause__``.
+    """
+
+
+class AmbiguousCrossUserResolutionError(RuntimeError):
+    """Raised when the layer-2 glob finds SUCCESS for more than one user.
+
+    Triggered when ``users/*/{step_root}/.executor_status`` yields multiple
+    users whose status content reads ``SUCCESS``. Under normal operation only
+    one user runs a given hashed step (the second user's cache check
+    short-circuits before they write), so multiple SUCCESS indicates either a
+    write race (two users started concurrently without seeing each other's
+    output) or manual ``override_output_path`` values that landed in distinct
+    ``users/`` dirs.
+
+    The exception message lists the conflicting paths. Resolution requires
+    explicit user action: ``gsutil rm -r`` all but one of the dirs, bump the
+    step hash, or pass an ``override_output_path`` that bypasses ``users://``.
+    The filesystem deliberately does *not* pick a winner — picking would mask
+    a coordination problem that should surface.
+    """
+```
+
+No other new error types. Existing fsspec error semantics (`FileNotFoundError`, `IsADirectoryError`, `PermissionError`) are forwarded unchanged from the underlying filesystem.
+
+## Persisted directory layout
+
+```
+gs://marin-{region}/
+├── users/                                          # NEW top-level dir
+│   ├── alice/
+│   │   └── checkpoints/
+│   │       └── train-llama-1b_a1b2c3d4/
+│   │           ├── .executor_status
+│   │           └── checkpoints/step_1000/...
+│   └── bob/
+│       └── ...
+├── checkpoints/                                    # legacy + manually-shared
+│   └── ...
+├── experiments/                                    # unchanged
+├── raw/                                            # unchanged
+└── tmp/ttl=Nd/                                     # unchanged
+```
+
+The `users/` top-level dir is the only addition. No existing paths move. No new bucket-level configuration.
+
+## Wiring in `experiments/defaults.py`
+
+Three call sites change. Each gains a new keyword argument `output_path_prefix: str | None = "users://"`, which is forwarded into the underlying `ExecutorStep` / `compute_output_path` call. Callers opt out by passing `output_path_prefix=None` (preserving the existing `MARIN_PREFIX`-based behavior).
+
+```python
+def default_train(
+    name: str,
+    tokenized: InputName | ExecutorStep | LMMixtureDatasetConfig,
+    model_config: LmConfig,
+    train_config: SimpleTrainConfig,
+    tags: Sequence[str] = (),
+    use_default_validation: bool = True,
+    eval_harness_tasks: Sequence[EvalTaskConfig] = CORE_TASKS,
+    wandb_name: str | None = None,
+    wandb_group: str | None = None,
+    override_output_path: str | None = None,
+    output_path_prefix: str | None = "users://",        # NEW
+) -> ExecutorStep: ...
+
+
+def default_dpo(
+    name: str,
+    tokenized: InputName | ExecutorStep | LMMixtureDatasetConfig,
+    model_config: LlamaConfig,
+    dpo_config: SimpleDPOConfig,
+    tags: Sequence[str] = (),
+    override_output_path: str | None = None,
+    output_path_prefix: str | None = "users://",        # NEW
+) -> ExecutorStep: ...
+
+
+def resolve_lm_train_config(
+    name: str,
+    raw_config: TrainLmConfig,
+    override_output_path: str | None,
+    resources: ResourceConfig,
+    output_path_prefix: str | None = "users://",        # NEW
+) -> TrainLmConfig: ...
+```
+
+Inside each function:
+- `default_train` and `default_dpo` pass `output_path_prefix=output_path_prefix` to the `ExecutorStep(...)` constructor — this is the *new* field defined in the "Executor changes" section above. It is *not* `override_output_path`, which is a full-path override; `output_path_prefix` overrides only the prefix segment and preserves hash-keyed `{name}-{hash}`.
+- `resolve_lm_train_config` passes it as the new `output_path_prefix` kwarg to `compute_output_path(name, raw_config, override_output_path=override_output_path, output_path_prefix=output_path_prefix)`.
+
+`default_sft` (`experiments/defaults.py:749`) and `simulated_epoching_train` (line 323) inherit transitively through `default_train` — no changes to their signatures.
+
+## File paths
+
+| Component | Path |
+|---|---|
+| `UserSharedFS` class | `lib/rigging/src/rigging/filesystem.py` (alongside `MirrorFileSystem`) |
+| `resolve_marin_user` function | `lib/rigging/src/rigging/filesystem.py` |
+| `UserIdentityResolutionError` | `lib/rigging/src/rigging/filesystem.py` |
+| Protocol registration | `lib/rigging/src/rigging/filesystem.py` (module-bottom `fsspec.register_implementation`) |
+| Unit tests | `lib/rigging/tests/test_users_filesystem.py` (new file, sibling to `test_mirror_fs.py`) |
+| `ExecutorStep.output_path_prefix` field | `lib/marin/src/marin/execution/executor.py` (dataclass at line 691) |
+| `Executor.compute_version` one-line change | `lib/marin/src/marin/execution/executor.py:1504` |
+| `step_spec.py` slash-count fix | `lib/marin/src/marin/execution/step_spec.py:114,116` |
+| `compute_output_path` signature update | `lib/marin/src/marin/execution/executor.py:1778` |
+| Cross-region guard update (call `to_gs_url` for `users://`) | `lib/marin/src/marin/execution/executor.py:208` (`_infer_gcs_regions`) |
+| Training factory wiring | `experiments/defaults.py` (three signature additions, see above) |
+
+## Out of scope
+
+The following are intentionally not in this spec; reviewers should not push back on their absence:
+
+- Any promotion mechanism (`marin promote` CLI, `gsutil cp` helper, automatic copy-on-completion). Cross-user reuse is implicit via layer 2.
+- Lifecycle rules on `users/{user}/` in `infra/configure_buckets.py`. No auto-deletion.
+- Hard quota enforcement, write-path interception, or per-user `TransferBudget` analog.
+- Routing of non-training executor outputs (datasets, evals, ferries, scratch) through `users://`. Each subsystem opts in by constructing `users://` URLs; none do in v1.
+- A `scope` field on `StepSpec` or `ExecutorStep`. Routing is at URL-construction time only.
+- Merged-listing semantics for `_ls` (returning union of all layers). Single-layer-resolution only.
+- Per-user usage reporting tooling (extension of `egress_report.py`). Follow-up PR.
+- `MirrorFileSystem` refactor onto a shared `LayeredReadFS` base.
+- Cross-region behavior for `users://`. The filesystem operates on a single regional bucket as determined by `marin_prefix()`; cross-region access requires `mirror://`, which can wrap `users://`-resolved URLs but is not composed automatically.


### PR DESCRIPTION
## Summary

Adds a per-user GCS storage prefix via a new `users://` fsspec filesystem so that training checkpoints — the dominant storage cost and the easiest artifact to leave behind by accident — land in `gs://marin-{region}/users/{user}/...` by default. Reads probe personal → glob other users → shared root, so cross-user reuse happens automatically without a promotion step. The executor change is small: one new `output_path_prefix` field on `ExecutorStep` and a one-line preference in `compute_version`. Training factories (`default_train`, `default_dpo`, `resolve_lm_train_config` in `experiments/defaults.py`) opt in by passing `output_path_prefix="users://"`.

## Files

- [`design.md`](https://github.com/marin-community/marin/blob/design/per_user_gcs_prefix/.agents/projects/per_user_gcs_prefix/design.md) — the 1-pager
- [`spec.md`](https://github.com/marin-community/marin/blob/design/per_user_gcs_prefix/.agents/projects/per_user_gcs_prefix/spec.md) — `UserSharedFS` public API, executor changes, error types, persisted layout, wiring
- [`research.md`](https://github.com/marin-community/marin/blob/design/per_user_gcs_prefix/.agents/projects/per_user_gcs_prefix/research.md) — in-repo refs and prior designs (notably `20260301_iris_user_job_names`)

Discussion welcome — see Open Questions in `design.md`.