### PR TITLE
Preserve resources through executor step conversion

### DIFF
--- a/lib/marin/src/marin/execution/executor.py
+++ b/lib/marin/src/marin/execution/executor.py
@@ -643,6 +643,7 @@ def resolve_executor_step(
             original,
             deps=deps or list(original.deps),
             override_output_path=original.output_path,
+            resources=original.resources,
         )
 
     remote_callable = step.fn if isinstance(step.fn, RemoteCallable) else None
@@ -685,6 +686,7 @@ def resolve_executor_step(
         deps=deps or [],
         override_output_path=output_path,
         fn=final_fn,
+        resources=step.resources,
     )
 
 

--- a/lib/marin/src/marin/execution/step_spec.py
+++ b/lib/marin/src/marin/execution/step_spec.py
@@ -137,6 +137,7 @@ class StepSpec:
             fn=self.fn,
             config=config,
             override_output_path=self.output_path,
+            resources=self.resources,
         )
         # ExecutorStep is frozen; object.__setattr__ stashes the original
         # StepSpec for round-trip recovery in resolve_executor_step.

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -261,6 +261,32 @@ def test_resolve_executor_step_preserves_deps():
     assert resolved.dep_paths == ["/out/download-abc123", "/out/tokenize-def456"]
 
 
+def test_resolved_executor_step_resources_dispatch_via_fray(tmp_path: Path, fray_client):
+    """Old-style ExecutorStep resources should survive resolution and trigger Fray dispatch."""
+
+    spy = _SubmitSpy(fray_client)
+    resources = ResourceConfig.with_cpu(cpu=1, ram="8g")
+
+    def report_step(config: dict[str, str]) -> PathMetadata:
+        return PathMetadata(path=config["expected_path"])
+
+    step = ExecutorStep(name="report", fn=report_step, config=None, resources=resources)
+    resolved = resolve_executor_step(
+        step,
+        config={"expected_path": tmp_path.as_posix()},
+        output_path=tmp_path.as_posix(),
+    )
+
+    assert resolved.resources == resources
+    with set_current_client(spy):
+        StepRunner().run([resolved])
+
+    assert len(spy.requests) == 1
+    assert spy.requests[0].resources == resources
+    loaded = Artifact.from_path(tmp_path.as_posix(), PathMetadata)
+    assert loaded.path == tmp_path.as_posix()
+
+
 def test_step_spec_as_executor_step_round_trip():
     """StepSpec -> ExecutorStep -> StepSpec should preserve identity."""
     prefix = "gs://test-bucket"
@@ -276,6 +302,7 @@ def test_step_spec_as_executor_step_round_trip():
         hash_attrs={"tokenizer": "llama3"},
         deps=[dep],
         fn=lambda output_path: output_path,
+        resources=ResourceConfig.with_cpu(cpu=2, ram="8g"),
     )
 
     executor_step = step.as_executor_step()
@@ -297,6 +324,7 @@ def test_step_spec_as_executor_step_round_trip():
     assert resolved.output_path == step.output_path
     assert resolved.output_path_prefix == prefix
     assert resolved.dep_paths == [dep.output_path]
+    assert resolved.resources == step.resources
 
 
 def _build_three_level_dag(prefix: str) -> tuple[StepSpec, StepSpec, StepSpec]:


### PR DESCRIPTION
Carry explicit resource requests when converting between ExecutorStep and StepSpec so resourced steps keep dispatching through Fray. Add coverage for old-style ExecutorStep resources and StepSpec round-trip preservation.