### PR TITLE
[datakit] Add NuminaMath-1.5 source

### DIFF
--- a/lib/marin/src/marin/datakit/download/numinamath_v1_5.py
+++ b/lib/marin/src/marin/datakit/download/numinamath_v1_5.py
@@ -1,0 +1,117 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""AI-MO/NuminaMath-1.5 dataset download and transform.
+
+NuminaMath-1.5 is a curated math post-training corpus with CoT-formatted
+solutions and explicit problem/solution validity metadata. This transform keeps
+only rows marked valid by both fields, renders problem/solution pairs as tagged
+transcripts, and preserves source metadata for downstream mixture analysis.
+"""
+
+import hashlib
+
+from fray import ResourceConfig
+from zephyr import Dataset, ZephyrContext, counters, load_parquet
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.normalize import normalize_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "AI-MO/NuminaMath-1.5"
+HF_REVISION = "1b05109"
+TRAIN_PARQUET_GLOB = "data/train-*.parquet"
+VALID_STATUS = "Yes"
+
+
+def _clean_text(row: dict, key: str) -> str | None:
+    value = row.get(key)
+    if not isinstance(value, str):
+        return None
+
+    text = value.strip()
+    if not text:
+        return None
+
+    return text
+
+
+def _optional_text(row: dict, key: str) -> str:
+    value = row.get(key)
+    if not isinstance(value, str):
+        return ""
+
+    return value.strip()
+
+
+def _is_valid_row(row: dict) -> bool:
+    return row.get("problem_is_valid") == VALID_STATUS and row.get("solution_is_valid") == VALID_STATUS
+
+
+def row_to_doc(row: dict) -> list[dict]:
+    problem = _clean_text(row, "problem")
+    solution = _clean_text(row, "solution")
+    if problem is None or solution is None:
+        counters.increment("numinamath_v1_5/dropped_empty")
+        return []
+
+    if not _is_valid_row(row):
+        counters.increment("numinamath_v1_5/dropped_invalid")
+        return []
+
+    text = f"<user>\n{problem}\n</user>\n\n<assistant>\n{solution}\n</assistant>"
+
+    counters.increment("numinamath_v1_5/kept")
+    return [
+        {
+            "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "problem_hash": hashlib.sha256(problem.encode("utf-8")).hexdigest(),
+            "text": text,
+            "source": HF_DATASET_ID,
+            "numina_source": _optional_text(row, "source"),
+            "answer": _optional_text(row, "answer"),
+            "problem_type": _optional_text(row, "problem_type"),
+            "question_type": _optional_text(row, "question_type"),
+            "synthetic": row.get("synthetic") is True,
+        }
+    ]
+
+
+def transform(input_path: str, output_path: str) -> None:
+    pipeline = (
+        Dataset.from_files(f"{input_path}/**/*.parquet")
+        .flat_map(load_parquet)
+        .flat_map(row_to_doc)
+        .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
+    )
+    ctx = ZephyrContext(name="numinamath-v1-5-transform", resources=ResourceConfig(cpu=1, ram="8g"))
+    ctx.execute(pipeline)
+
+
+def download_numinamath_v1_5_step() -> StepSpec:
+    """Download and transform valid NuminaMath-1.5 train rows into transcript documents."""
+    dl = download_hf_step(
+        "raw/numinamath-1.5",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=[TRAIN_PARQUET_GLOB],
+    )
+
+    return StepSpec(
+        name="processed/numinamath-1.5",
+        deps=[dl],
+        fn=lambda output_path: transform(
+            input_path=dl.output_path,
+            output_path=output_path,
+        ),
+        hash_attrs={"version": "v1"},
+    )
+
+
+def numinamath_v1_5_normalize_steps() -> tuple[StepSpec, ...]:
+    """Return the full ``(download+transform, normalize)`` chain for NuminaMath-1.5."""
+    processed = download_numinamath_v1_5_step()
+    return (
+        processed,
+        normalize_step(name="normalized/numinamath-1.5", download=processed),
+    )

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -36,6 +36,7 @@ from marin.datakit.download.molmo2_cap import molmo2_cap_normalize_steps
 from marin.datakit.download.nemotron_terminal import nemotron_terminal_normalize_steps
 from marin.datakit.download.nemotron_v2 import nemotron_v2_normalize_steps
 from marin.datakit.download.nsf_awards import nsf_awards_normalize_steps
+from marin.datakit.download.numinamath_v1_5 import numinamath_v1_5_normalize_steps
 from marin.datakit.download.starcoder2_extras import starcoder2_extras_normalize_steps
 from marin.datakit.download.superior_reasoning import superior_reasoning_normalize_steps
 from marin.datakit.download.svgfind import svgfind_creativecommons_normalize_steps
@@ -126,11 +127,6 @@ def _rows_nemotron(
 # into /multilingual and /web needs different text_field, hf_urls_glob, or
 # data_subdir so the two accounting slices don't normalize to identical rows.
 #
-# TODO: confirm there's a download module for AI-MO/NuminaMath-1.5. Today
-# the dataset is only referenced through gpt-oss-rollouts' NuminaMath-CoT
-# subset; there's no standalone download helper.
-
-
 @cache
 def all_sources() -> dict[str, DatakitSource]:
     """Return the canonical active source set as ``{name: DatakitSource}``.
@@ -158,6 +154,7 @@ def all_sources() -> dict[str, DatakitSource]:
         ("molmo2-cap", molmo2_cap_normalize_steps, 0.36),
         ("nemotron-terminal", nemotron_terminal_normalize_steps, 6.08),
         ("nsf_awards", nsf_awards_normalize_steps, 0.17),
+        ("numinamath-1.5", numinamath_v1_5_normalize_steps, 0.40),
         ("superior-reasoning", superior_reasoning_normalize_steps, 7.08),
         ("svg", svgfind_creativecommons_normalize_steps, 8.95),
         ("swe-rebench-openhands", swe_rebench_openhands_normalize_steps, 2.47),

--- a/tests/datakit/download/test_numinamath_v1_5.py
+++ b/tests/datakit/download/test_numinamath_v1_5.py
@@ -1,0 +1,146 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from marin.datakit.download.numinamath_v1_5 import (
+    HF_DATASET_ID,
+    HF_REVISION,
+    TRAIN_PARQUET_GLOB,
+    numinamath_v1_5_normalize_steps,
+    row_to_doc,
+    transform,
+)
+from marin.datakit.sources import all_sources
+
+
+def _valid_row(**overrides) -> dict:
+    row = {
+        "problem": "Find $x$ if $x + 2 = 5$.",
+        "solution": "Subtracting 2 from both sides gives $x = 3$.",
+        "answer": "3",
+        "problem_type": "Algebra",
+        "question_type": "math-word-problem",
+        "problem_is_valid": "Yes",
+        "solution_is_valid": "Yes",
+        "source": "olympiads",
+        "synthetic": False,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_row_to_doc_renders_valid_problem_solution_pair():
+    [doc] = row_to_doc(_valid_row(synthetic=True))
+
+    assert doc["source"] == HF_DATASET_ID
+    assert doc["numina_source"] == "olympiads"
+    assert doc["answer"] == "3"
+    assert doc["problem_type"] == "Algebra"
+    assert doc["question_type"] == "math-word-problem"
+    assert doc["synthetic"] is True
+    assert len(doc["id"]) == 64
+    assert len(doc["problem_hash"]) == 64
+    assert doc["id"] != doc["problem_hash"]
+    assert doc["text"] == (
+        "<user>\n"
+        "Find $x$ if $x + 2 = 5$.\n"
+        "</user>\n\n"
+        "<assistant>\n"
+        "Subtracting 2 from both sides gives $x = 3$.\n"
+        "</assistant>"
+    )
+
+
+def test_problem_hash_is_stable_across_solution_variants():
+    first = row_to_doc(_valid_row(solution="Solution A."))[0]
+    second = row_to_doc(_valid_row(solution="Solution B."))[0]
+
+    assert first["problem_hash"] == second["problem_hash"]
+    assert first["id"] != second["id"]
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"problem": ""},
+        {"problem": "   "},
+        {"problem": None},
+        {"solution": ""},
+        {"solution": "   "},
+        {"solution": None},
+        {"problem_is_valid": "Incomplete"},
+        {"problem_is_valid": "Not a problem"},
+        {"solution_is_valid": "Incomplete"},
+        {"solution_is_valid": "Problem not solved"},
+        {"solution_is_valid": "Not matched with problem"},
+    ],
+)
+def test_row_to_doc_drops_invalid_or_empty_rows(overrides):
+    assert row_to_doc(_valid_row(**overrides)) == []
+
+
+def test_row_to_doc_preserves_optional_metadata_as_empty_strings():
+    [doc] = row_to_doc(
+        _valid_row(
+            answer=None,
+            problem_type=None,
+            question_type=None,
+            source=None,
+            synthetic="false",
+        )
+    )
+
+    assert doc["answer"] == ""
+    assert doc["problem_type"] == ""
+    assert doc["question_type"] == ""
+    assert doc["numina_source"] == ""
+    assert doc["synthetic"] is False
+
+
+def test_numinamath_v1_5_normalize_steps_use_train_split_and_stable_names():
+    processed, normalized = numinamath_v1_5_normalize_steps()
+    download = processed.deps[0]
+
+    assert download.name == "raw/numinamath-1.5"
+    assert download.hash_attrs["hf_dataset_id"] == HF_DATASET_ID
+    assert download.hash_attrs["revision"] == HF_REVISION
+    assert download.hash_attrs["hf_urls_glob"] == [TRAIN_PARQUET_GLOB]
+    assert processed.name == "processed/numinamath-1.5"
+    assert processed.deps == [download]
+    assert normalized.name == "normalized/numinamath-1.5"
+    assert normalized.deps == [processed]
+
+
+def test_numinamath_v1_5_is_registered_as_datakit_source():
+    source = all_sources()["numinamath-1.5"]
+
+    assert source.rough_token_count_b == 0.40
+    assert source.normalize_steps[0].name == "processed/numinamath-1.5"
+    assert source.normalized.name == "normalized/numinamath-1.5"
+
+
+def test_transform_reads_parquet_and_writes_valid_docs(tmp_path: Path):
+    raw_dir = tmp_path / "raw" / "data"
+    raw_dir.mkdir(parents=True)
+    table = pa.Table.from_pylist(
+        [
+            _valid_row(synthetic=True),
+            _valid_row(problem="bad", problem_is_valid="Incomplete"),
+        ]
+    )
+    pq.write_table(table, raw_dir / "train-00000-of-00001.parquet")
+
+    output_dir = tmp_path / "processed"
+    transform(str(tmp_path / "raw"), str(output_dir))
+
+    rows = [row for path in output_dir.rglob("*.parquet") for row in pq.read_table(path).to_pylist()]
+    assert len(rows) == 1
+    assert rows[0]["source"] == HF_DATASET_ID
+    assert rows[0]["numina_source"] == "olympiads"
+    assert rows[0]["synthetic"] is True
+    assert "<user>\nFind $x$ if $x + 2 = 5$.\n</user>" in rows[0]["text"]
+    assert "<assistant>\nSubtracting 2 from both sides gives $x = 3$.\n</assistant>" in rows[0]["text"]


### PR DESCRIPTION
Add AI-MO/NuminaMath-1.5 as a pinned datakit source that downloads train parquet shards, keeps rows with valid problem and solution labels, renders them as user/assistant transcripts, and preserves dataset metadata for mixture analysis. Includes focused row-transform, registry, and local parquet transform tests; validated with relevant datakit pytest slices and ./infra/pre-commit.py --all-files --fix.