### PR TITLE
[data] Add Swallow and UltraData math text datasets

### DIFF
--- a/experiments/midtraining_datasets.py
+++ b/experiments/midtraining_datasets.py
@@ -1,6 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from levanter.data.text import TextLmDatasetFormat
 from marin.datakit.download.huggingface import DownloadConfig, download_hf
 from marin.execution import versioned
 from marin.execution.executor import ExecutorStep, this_output_path
@@ -110,6 +111,70 @@ megamath_real_only = lm_mixture_data_config(
         "megamath/web_pro": megamath_token_counts["megamath/web_pro"],
     },
 )
+
+
+swallow_math_v2_source = default_download(
+    name="raw/tokyotech/swallow-math-v2",
+    hf_dataset_id="tokyotech-llm/swallow-math-v2",
+    revision=versioned("b59a686bca9bb92e290f558ea7dcd73ec707b602"),
+    override_output_path="raw/tokyotech/swallow-math-v2",
+    hf_urls_glob=["stage3-qa/**/*.jsonl", "stage3-textbook/**/*.jsonl", "*.md"],
+)
+
+swallow_math_v2_tokenized = {
+    "swallow_math_v2/qa": default_tokenize(
+        name="swallow_math_v2/qa",
+        dataset=swallow_math_v2_source / "stage3-qa/**/*.jsonl",
+        tokenizer=llama3_tokenizer,
+    ),
+    "swallow_math_v2/textbook": default_tokenize(
+        name="swallow_math_v2/textbook",
+        dataset=swallow_math_v2_source / "stage3-textbook/**/*.jsonl",
+        tokenizer=llama3_tokenizer,
+    ),
+}
+
+
+ultradata_math_source = default_download(
+    name="raw/openbmb/ultradata-math",
+    hf_dataset_id="openbmb/UltraData-Math",
+    revision=versioned("fe10db8efd35597fd7fcff8ff576b5ec4ea5ff87"),
+    override_output_path="raw/openbmb/ultradata-math",
+    hf_urls_glob=[
+        "data/UltraData-Math-L2-preview/**/*.parquet",
+        "data/UltraData-Math-L3/Conversation-Synthetic/**/*.parquet",
+        "data/UltraData-Math-L3/QA-Synthetic/**/*.parquet",
+        "data/UltraData-Math-L3/Textbook-Exercise-Synthetic/**/*.parquet",
+        "*.md",
+    ],
+)
+
+ultradata_math_tokenized = {
+    "ultradata_math/l2_preview": default_tokenize(
+        name="ultradata_math/l2_preview",
+        dataset=ultradata_math_source / "data/UltraData-Math-L2-preview/**/*.parquet",
+        tokenizer=llama3_tokenizer,
+        format=TextLmDatasetFormat(text_key="content"),
+    ),
+    "ultradata_math/l3_conversation": default_tokenize(
+        name="ultradata_math/l3_conversation",
+        dataset=ultradata_math_source / "data/UltraData-Math-L3/Conversation-Synthetic/**/*.parquet",
+        tokenizer=llama3_tokenizer,
+        format=TextLmDatasetFormat(text_key="content"),
+    ),
+    "ultradata_math/l3_qa": default_tokenize(
+        name="ultradata_math/l3_qa",
+        dataset=ultradata_math_source / "data/UltraData-Math-L3/QA-Synthetic/**/*.parquet",
+        tokenizer=llama3_tokenizer,
+        format=TextLmDatasetFormat(text_key="content"),
+    ),
+    "ultradata_math/l3_textbook_exercise": default_tokenize(
+        name="ultradata_math/l3_textbook_exercise",
+        dataset=ultradata_math_source / "data/UltraData-Math-L3/Textbook-Exercise-Synthetic/**/*.parquet",
+        tokenizer=llama3_tokenizer,
+        format=TextLmDatasetFormat(text_key="content"),
+    ),
+}
 
 
 pile_pubmed_abstracts_validation = default_download(

--- a/experiments/midtraining_datasets.py
+++ b/experiments/midtraining_datasets.py
@@ -1,7 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from levanter.data.text import TextLmDatasetFormat
 from marin.datakit.download.huggingface import DownloadConfig, download_hf
 from marin.execution import versioned
 from marin.execution.executor import ExecutorStep, this_output_path
@@ -111,70 +110,6 @@ megamath_real_only = lm_mixture_data_config(
         "megamath/web_pro": megamath_token_counts["megamath/web_pro"],
     },
 )
-
-
-swallow_math_v2_source = default_download(
-    name="raw/tokyotech/swallow-math-v2",
-    hf_dataset_id="tokyotech-llm/swallow-math-v2",
-    revision=versioned("b59a686bca9bb92e290f558ea7dcd73ec707b602"),
-    override_output_path="raw/tokyotech/swallow-math-v2",
-    hf_urls_glob=["stage3-qa/**/*.jsonl", "stage3-textbook/**/*.jsonl", "*.md"],
-)
-
-swallow_math_v2_tokenized = {
-    "swallow_math_v2/qa": default_tokenize(
-        name="swallow_math_v2/qa",
-        dataset=swallow_math_v2_source / "stage3-qa/**/*.jsonl",
-        tokenizer=llama3_tokenizer,
-    ),
-    "swallow_math_v2/textbook": default_tokenize(
-        name="swallow_math_v2/textbook",
-        dataset=swallow_math_v2_source / "stage3-textbook/**/*.jsonl",
-        tokenizer=llama3_tokenizer,
-    ),
-}
-
-
-ultradata_math_source = default_download(
-    name="raw/openbmb/ultradata-math",
-    hf_dataset_id="openbmb/UltraData-Math",
-    revision=versioned("fe10db8efd35597fd7fcff8ff576b5ec4ea5ff87"),
-    override_output_path="raw/openbmb/ultradata-math",
-    hf_urls_glob=[
-        "data/UltraData-Math-L2-preview/**/*.parquet",
-        "data/UltraData-Math-L3/Conversation-Synthetic/**/*.parquet",
-        "data/UltraData-Math-L3/QA-Synthetic/**/*.parquet",
-        "data/UltraData-Math-L3/Textbook-Exercise-Synthetic/**/*.parquet",
-        "*.md",
-    ],
-)
-
-ultradata_math_tokenized = {
-    "ultradata_math/l2_preview": default_tokenize(
-        name="ultradata_math/l2_preview",
-        dataset=ultradata_math_source / "data/UltraData-Math-L2-preview/**/*.parquet",
-        tokenizer=llama3_tokenizer,
-        format=TextLmDatasetFormat(text_key="content"),
-    ),
-    "ultradata_math/l3_conversation": default_tokenize(
-        name="ultradata_math/l3_conversation",
-        dataset=ultradata_math_source / "data/UltraData-Math-L3/Conversation-Synthetic/**/*.parquet",
-        tokenizer=llama3_tokenizer,
-        format=TextLmDatasetFormat(text_key="content"),
-    ),
-    "ultradata_math/l3_qa": default_tokenize(
-        name="ultradata_math/l3_qa",
-        dataset=ultradata_math_source / "data/UltraData-Math-L3/QA-Synthetic/**/*.parquet",
-        tokenizer=llama3_tokenizer,
-        format=TextLmDatasetFormat(text_key="content"),
-    ),
-    "ultradata_math/l3_textbook_exercise": default_tokenize(
-        name="ultradata_math/l3_textbook_exercise",
-        dataset=ultradata_math_source / "data/UltraData-Math-L3/Textbook-Exercise-Synthetic/**/*.parquet",
-        tokenizer=llama3_tokenizer,
-        format=TextLmDatasetFormat(text_key="content"),
-    ),
-}
 
 
 pile_pubmed_abstracts_validation = default_download(

--- a/lib/marin/src/marin/datakit/download/swallow_math_v2.py
+++ b/lib/marin/src/marin/datakit/download/swallow_math_v2.py
@@ -1,0 +1,68 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""tokyotech-llm/swallow-math-v2 dataset download and normalize.
+
+SwallowMath-v2 ships its stage3 outputs (the ready-to-tokenize math text
+slices) as JSONL with a single ``text`` column. We pin the two stage3
+variants — QA-style and textbook-style — and let the rest of the dataset
+(intermediate stages) stay un-staged so we don't move TB of data that won't
+end up in mixtures.
+
+The download is shared across both subsets via ``@cache``; each subset gets
+its own normalize step targeting its ``stage3-*`` subdirectory.
+"""
+
+from functools import cache
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.normalize import normalize_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "tokyotech-llm/swallow-math-v2"
+HF_REVISION = "b59a686"
+
+# Maps marin subset name -> subdirectory under the HF repo root.
+SUBSET_DIRS: dict[str, str] = {
+    "qa": "stage3-qa",
+    "textbook": "stage3-textbook",
+}
+
+
+@cache
+def download_swallow_math_v2_step() -> StepSpec:
+    """Download the swallow-math-v2 stage3 slices.
+
+    Cached so both stage3 subsets share a single download node in the DAG.
+    The glob restricts the download to the stage3 outputs we actually mix
+    (skipping the much larger intermediate stages).
+    """
+    return download_hf_step(
+        "raw/swallow_math_v2",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=[f"{subdir}/**/*.jsonl" for subdir in SUBSET_DIRS.values()] + ["*.md"],
+    )
+
+
+def swallow_math_v2_normalize_steps() -> dict[str, tuple[StepSpec, ...]]:
+    """Return ``(download, normalize)`` chains for every swallow-math-v2 subset.
+
+    Keyed by the registry name convention ``"swallow_math_v2/<subset>"``.
+    Both stage3 subsets store their document text under the ``text`` column,
+    matching :func:`normalize_step`'s default ``text_field``.
+    """
+    download = download_swallow_math_v2_step()
+    chains: dict[str, tuple[StepSpec, ...]] = {}
+    for subset, subdir in SUBSET_DIRS.items():
+        marin_name = f"swallow_math_v2/{subset}"
+        normalize = normalize_step(
+            name=f"normalized/{marin_name}",
+            download=download,
+            text_field="text",
+            id_field="id",
+            relative_input_path=subdir,
+            file_extensions=(".jsonl",),
+        )
+        chains[marin_name] = (download, normalize)
+    return chains

--- a/lib/marin/src/marin/datakit/download/ultradata_math.py
+++ b/lib/marin/src/marin/datakit/download/ultradata_math.py
@@ -1,0 +1,76 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""openbmb/UltraData-Math dataset download and normalize.
+
+UltraData-Math is organized as L1/L2/L3 quality tiers. We pin only the
+text-compatible slices the Marin data-mixing plan calls for:
+
+* ``L2-preview`` — a 33B-token preview shard of the L2 tier.
+* ``L3/Conversation-Synthetic`` — conversation-styled synthetic rewrites.
+* ``L3/QA-Synthetic`` — QA-styled synthetic rewrites.
+* ``L3/Textbook-Exercise-Synthetic`` — textbook/exercise-styled rewrites.
+
+L1 (170B tokens) and L3/Multi-Style-Synthetic are excluded for now to keep
+the staged footprint and mixture surface small.
+
+All parquet files share the same schema (``content`` carries the document
+text, ``meta`` carries provenance JSON), so we point each subset's
+normalize step at its subdirectory with ``text_field="content"``.
+"""
+
+from functools import cache
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.normalize import normalize_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "openbmb/UltraData-Math"
+HF_REVISION = "fe10db8"
+
+# Maps marin subset name -> path under the HF repo root.
+SUBSET_DIRS: dict[str, str] = {
+    "l2_preview": "data/UltraData-Math-L2-preview",
+    "l3_conversation": "data/UltraData-Math-L3/Conversation-Synthetic",
+    "l3_qa": "data/UltraData-Math-L3/QA-Synthetic",
+    "l3_textbook_exercise": "data/UltraData-Math-L3/Textbook-Exercise-Synthetic",
+}
+
+
+@cache
+def download_ultradata_math_step() -> StepSpec:
+    """Download the selected UltraData-Math slices.
+
+    Cached so every subset shares a single download node in the DAG. The
+    glob keeps L1 and L3/Multi-Style-Synthetic out of staging.
+    """
+    return download_hf_step(
+        "raw/ultradata_math",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=[f"{subdir}/**/*.parquet" for subdir in SUBSET_DIRS.values()] + ["*.md"],
+    )
+
+
+def ultradata_math_normalize_steps() -> dict[str, tuple[StepSpec, ...]]:
+    """Return ``(download, normalize)`` chains for every UltraData-Math subset.
+
+    Keyed by the registry name convention ``"ultradata_math/<subset>"``.
+    All subsets put the document body in ``content`` (not ``text``); the
+    overridden ``text_field`` keeps normalize's record schema consistent
+    with the rest of the registry.
+    """
+    download = download_ultradata_math_step()
+    chains: dict[str, tuple[StepSpec, ...]] = {}
+    for subset, subdir in SUBSET_DIRS.items():
+        marin_name = f"ultradata_math/{subset}"
+        normalize = normalize_step(
+            name=f"normalized/{marin_name}",
+            download=download,
+            text_field="content",
+            id_field="id",
+            relative_input_path=subdir,
+            file_extensions=(".parquet",),
+        )
+        chains[marin_name] = (download, normalize)
+    return chains

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -39,8 +39,10 @@ from marin.datakit.download.nsf_awards import nsf_awards_normalize_steps
 from marin.datakit.download.starcoder2_extras import starcoder2_extras_normalize_steps
 from marin.datakit.download.superior_reasoning import superior_reasoning_normalize_steps
 from marin.datakit.download.svgfind import svgfind_creativecommons_normalize_steps
+from marin.datakit.download.swallow_math_v2 import swallow_math_v2_normalize_steps
 from marin.datakit.download.swe_rebench_openhands import swe_rebench_openhands_normalize_steps
 from marin.datakit.download.synthetic1 import synthetic1_normalize_steps
+from marin.datakit.download.ultradata_math import ultradata_math_normalize_steps
 from marin.execution.step_spec import StepSpec
 
 
@@ -325,6 +327,30 @@ def all_sources() -> dict[str, DatakitSource]:
         },
     )
 
+    # SwallowMath-v2 stage3 outputs: QA-style and textbook-style math text.
+    # Token counts measured by the upstream README (Llama-3 tokenizer).
+    swallow_math_v2 = _rows_flat(
+        swallow_math_v2_normalize_steps,
+        {
+            "swallow_math_v2/qa": 13.60,
+            "swallow_math_v2/textbook": 18.30,
+        },
+    )
+
+    # UltraData-Math L2/L3 text-compatible slices. L1 and L3/Multi-Style are
+    # excluded (see ultradata_math.py). Token counts: L2-preview from the
+    # upstream README (33.7B); L3 subsets apportioned from the README's 88B
+    # L3 total by row count (16.9M / 27.1M / 26.0M out of 81.4M).
+    ultradata_math = _rows_flat(
+        ultradata_math_normalize_steps,
+        {
+            "ultradata_math/l2_preview": 33.70,
+            "ultradata_math/l3_conversation": 18.27,
+            "ultradata_math/l3_qa": 29.30,
+            "ultradata_math/l3_textbook_exercise": 28.11,
+        },
+    )
+
     # locuslab Safety Pretraining: moral_education, safeweb, and refuseweb
     # (fineweb_annotated is a score-annotated copy of FineWeb itself and is
     # excluded to avoid double-counting that corpus). Token counts measured
@@ -357,6 +383,8 @@ def all_sources() -> dict[str, DatakitSource]:
         *nemotron_sft,
         *nemotron_specialized,
         *nemotron_specialized_v1_1,
+        *swallow_math_v2,
+        *ultradata_math,
         *safety_pretraining,
     )
 


### PR DESCRIPTION
Register pinned HF downloads and tokenized steps for Swallow Math v2 QA/textbook data and UltraData Math L2/L3 text-compatible subsets. This covers the ready-to-tokenize text/chat math sources from the Discord data-mixing request.

Part of #5844
Part of #5845