### PR TITLE
[iris] Reap zombie slices via worker /health probe

### DIFF
--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -20,6 +20,8 @@ The run_once() flow splits into two phases:
 from __future__ import annotations
 
 import logging
+import urllib.error
+import urllib.request
 from collections import deque
 from collections.abc import Sequence
 
@@ -47,6 +49,7 @@ from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup, build
 from iris.cluster.controller.autoscaler.status import PendingHint, build_job_pending_hints, routing_decision_to_proto
 from iris.cluster.controller.autoscaler.worker_registry import TrackedWorker, WorkerRegistry
 from iris.cluster.controller.db import ControllerDB
+from iris.cluster.controller.worker_health import PING_FAILURE_THRESHOLD
 from iris.cluster.providers.protocols import WorkerInfraProvider
 from iris.cluster.providers.types import (
     CloudSliceState,
@@ -64,6 +67,21 @@ logger = logging.getLogger(__name__)
 
 # After this long in UNKNOWN state, treat the slice as FAILED (quota timeout is 5 min, so this is conservative)
 DEFAULT_UNRESOLVABLE_TIMEOUT = Duration.from_minutes(15)
+
+# How long the autoscaler waits for a worker /health response per probe.
+_HEALTH_PROBE_TIMEOUT_SECONDS = 3.0
+
+
+def _probe_worker_health(address: str, port: int) -> bool:
+    """Probe a worker's /health endpoint. Returns True iff HTTP 200."""
+    try:
+        resp = urllib.request.urlopen(
+            f"http://{address}:{port}/health",
+            timeout=_HEALTH_PROBE_TIMEOUT_SECONDS,
+        )
+        return resp.status == 200
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError):
+        return False
 
 
 class Autoscaler:
@@ -426,7 +444,8 @@ class Autoscaler:
 
                 if status.state == CloudSliceState.READY:
                     worker_ids = [w.worker_id for w in status.workers]
-                    group.mark_slice_ready(slice_id, worker_ids)
+                    worker_addresses = {w.worker_id: w.internal_address for w in status.workers}
+                    group.mark_slice_ready(slice_id, worker_ids, worker_addresses=worker_addresses)
                     self._register_slice_workers(status.workers, slice_id, group.name)
                     self._log_action(
                         "slice_ready",
@@ -482,6 +501,77 @@ class Autoscaler:
                     reason=f"idle slice (target={target_capacity}, ready={ready_before})",
                 )
 
+    def probe_health(self, timestamp: Timestamp | None = None) -> None:
+        """Probe each READY slice's worker /health endpoint and terminate dead slices.
+
+        Catches zombie slices whose VM is still up in the cloud but whose
+        worker process is dead — these would otherwise be invisible to the
+        heartbeat path (no worker row → no heartbeat to time out) and pin the
+        scale group at max_slices indefinitely.
+
+        Per-worker counters live on SliceState. PING_FAILURE_THRESHOLD
+        consecutive failures (~100s at the default 10s evaluation interval,
+        matching the heartbeat-path threshold) trip termination. Addresses
+        come from the slice handle, refreshed lazily via ``handle.describe()``
+        when SliceState has none cached (e.g. after a controller restart).
+        """
+        timestamp = timestamp or Timestamp.now()
+        if self._base_worker_config is None:
+            return  # test/local mode without bootstrap; nothing to probe
+        port = self._base_worker_config.port
+        if port <= 0:
+            return
+
+        for group in self._groups.values():
+            for slice_id, handle, addresses in group.ready_slice_probe_targets():
+                if not addresses:
+                    addresses = self._refresh_slice_addresses(group, slice_id, handle)
+                    if not addresses:
+                        continue  # describe() failed; retry next tick
+
+                trip_slice = False
+                for worker_id, addr in addresses.items():
+                    healthy = _probe_worker_health(addr, port)
+                    count = group.record_health_probe_result(slice_id, worker_id, healthy)
+                    if count >= PING_FAILURE_THRESHOLD:
+                        logger.warning(
+                            "Slice %s worker %s failed /health %d times; terminating slice",
+                            slice_id,
+                            worker_id,
+                            count,
+                        )
+                        trip_slice = True
+                        break
+
+                if trip_slice:
+                    group.mark_slice_failed(slice_id, error_message="health probe failed")
+                    group.scale_down(slice_id, timestamp)
+                    self._unregister_slice_workers(slice_id)
+                    group.record_slice_boot_failed(slice_id, timestamp)
+                    self._log_action(
+                        "slice_failed",
+                        group.name,
+                        slice_id,
+                        reason="health probe failed",
+                        status="failed",
+                    )
+
+    def _refresh_slice_addresses(self, group: ScalingGroup, slice_id: str, handle: SliceHandle) -> dict[str, str]:
+        """Resolve worker addresses for a slice by calling handle.describe().
+
+        Used by the health probe when SliceState has no cached addresses
+        (after a controller restart, or for slices adopted from cloud).
+        """
+        try:
+            status = handle.describe()
+        except Exception as e:
+            logger.warning("Failed to describe slice %s for health probe: %s", slice_id, e)
+            return {}
+        addresses = {w.worker_id: w.internal_address for w in status.workers if w.internal_address}
+        if addresses:
+            group.set_worker_addresses(slice_id, addresses)
+        return addresses
+
     def update(
         self,
         demand_entries: list[DemandEntry],
@@ -503,10 +593,11 @@ class Autoscaler:
         worker_status_map: WorkerStatusMap,
         timestamp: Timestamp | None = None,
     ) -> list[ScalingDecision]:
-        """Full cycle: refresh + update. Preserved for tests."""
+        """Full cycle: refresh + probe_health + update. Preserved for tests."""
         timestamp = timestamp or Timestamp.now()
         logger.debug("Autoscaler run_once: demand_entries=%s", demand_entries)
         self.refresh(worker_status_map, timestamp)
+        self.probe_health(timestamp)
         return self.update(demand_entries, timestamp)
 
     def get_tracked_worker(self, worker_id: str) -> TrackedWorker | None:

--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -24,6 +24,7 @@ import urllib.error
 import urllib.request
 from collections import deque
 from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
 
 from rigging.timing import Duration, Timestamp
 
@@ -71,15 +72,23 @@ DEFAULT_UNRESOLVABLE_TIMEOUT = Duration.from_minutes(15)
 # How long the autoscaler waits for a worker /health response per probe.
 _HEALTH_PROBE_TIMEOUT_SECONDS = 3.0
 
+# Bypass any HTTP_PROXY env var: worker addresses are private cluster IPs,
+# never reachable via an upstream proxy.
+_HEALTH_PROBE_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+# Cap concurrent /health probes. ~1000 VMs in production; serializing 3 s
+# timeouts would blow past evaluation_interval (10 s default).
+_HEALTH_PROBE_MAX_WORKERS = 64
+
 
 def _probe_worker_health(address: str, port: int) -> bool:
-    """Probe a worker's /health endpoint. Returns True iff HTTP 200."""
+    """Probe a worker's /health endpoint. Returns True iff response is 2xx."""
     try:
-        resp = urllib.request.urlopen(
+        resp = _HEALTH_PROBE_OPENER.open(
             f"http://{address}:{port}/health",
             timeout=_HEALTH_PROBE_TIMEOUT_SECONDS,
         )
-        return resp.status == 200
+        return 200 <= resp.status < 300
     except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError):
         return False
 
@@ -514,6 +523,9 @@ class Autoscaler:
         matching the heartbeat-path threshold) trip termination. Addresses
         come from the slice handle, refreshed lazily via ``handle.describe()``
         when SliceState has none cached (e.g. after a controller restart).
+        Probes are fanned out across a thread pool so a partitioned AZ
+        doesn't burn the entire evaluation interval at the 3s per-probe
+        timeout. Slice teardown runs serially after all probes complete.
         """
         timestamp = timestamp or Timestamp.now()
         if self._base_worker_config is None:
@@ -522,45 +534,56 @@ class Autoscaler:
         if port <= 0:
             return
 
+        # Phase 1: collect every (group, slice_id, worker_id, addr) probe target.
+        probes: list[tuple[ScalingGroup, str, str, str]] = []
         for group in self._groups.values():
             for slice_id, handle, addresses in group.ready_slice_probe_targets():
                 if not addresses:
                     addresses = self._refresh_slice_addresses(group, slice_id, handle)
                     if not addresses:
-                        continue  # describe() failed; retry next tick
-
-                trip_slice = False
+                        continue  # describe() failed or partial; retry next tick
                 for worker_id, addr in addresses.items():
-                    healthy = _probe_worker_health(addr, port)
-                    count = group.record_health_probe_result(slice_id, worker_id, healthy)
-                    if count >= PING_FAILURE_THRESHOLD:
-                        logger.warning(
-                            "Slice %s worker %s failed /health %d times; terminating slice",
-                            slice_id,
-                            worker_id,
-                            count,
-                        )
-                        trip_slice = True
-                        break
+                    probes.append((group, slice_id, worker_id, addr))
+        if not probes:
+            return
 
-                if trip_slice:
-                    group.mark_slice_failed(slice_id, error_message="health probe failed")
-                    group.scale_down(slice_id, timestamp)
-                    self._unregister_slice_workers(slice_id)
-                    group.record_slice_boot_failed(slice_id, timestamp)
-                    self._log_action(
-                        "slice_failed",
-                        group.name,
-                        slice_id,
-                        reason="health probe failed",
-                        status="failed",
-                    )
+        # Phase 2: fan out probes. Bound the pool so we don't melt the controller.
+        workers = min(_HEALTH_PROBE_MAX_WORKERS, len(probes))
+        with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="health-probe") as pool:
+            results = list(pool.map(lambda p: _probe_worker_health(p[3], port), probes))
+
+        # Phase 3: record results and collect slices that tripped the threshold.
+        tripped: dict[str, tuple[ScalingGroup, str]] = {}  # slice_id -> (group, reason)
+        for (group, slice_id, worker_id, _addr), healthy in zip(probes, results, strict=True):
+            count = group.record_health_probe_result(slice_id, worker_id, healthy)
+            if count >= PING_FAILURE_THRESHOLD and slice_id not in tripped:
+                reason = f"worker {worker_id} failed /health {count}x"
+                logger.warning("Slice %s: %s; terminating", slice_id, reason)
+                tripped[slice_id] = (group, reason)
+
+        # Phase 4: terminate tripped slices. Record as a PREEMPTED-style death,
+        # not a boot failure — these slices booted cleanly and only died at
+        # runtime, so the BackoffDetector's scale-up budget shouldn't decay.
+        for slice_id, (group, reason) in tripped.items():
+            group.mark_slice_failed(slice_id, error_message=reason)
+            group.scale_down(slice_id, timestamp)
+            self._unregister_slice_workers(slice_id)
+            self._log_action(
+                "slice_failed",
+                group.name,
+                slice_id,
+                reason=reason,
+                status="failed",
+            )
 
     def _refresh_slice_addresses(self, group: ScalingGroup, slice_id: str, handle: SliceHandle) -> dict[str, str]:
         """Resolve worker addresses for a slice by calling handle.describe().
 
-        Used by the health probe when SliceState has no cached addresses
-        (after a controller restart, or for slices adopted from cloud).
+        Returns the full address map only when every worker has an
+        ``internal_address``. A partial set is dropped: caching it would
+        permanently exclude the missing workers from probing, and probing
+        the incomplete set risks terminating a slice for a worker that
+        simply hasn't published its IP yet. Next tick re-describes.
         """
         try:
             status = handle.describe()
@@ -568,8 +591,9 @@ class Autoscaler:
             logger.warning("Failed to describe slice %s for health probe: %s", slice_id, e)
             return {}
         addresses = {w.worker_id: w.internal_address for w in status.workers if w.internal_address}
-        if addresses:
-            group.set_worker_addresses(slice_id, addresses)
+        if len(addresses) != len(status.workers):
+            return {}
+        group.set_worker_addresses(slice_id, addresses)
         return addresses
 
     def update(

--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -81,11 +81,14 @@ _HEALTH_PROBE_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({
 _HEALTH_PROBE_MAX_WORKERS = 64
 
 
-def _probe_worker_health(address: str, port: int) -> bool:
-    """Probe a worker's /health endpoint. Returns True iff response is 2xx."""
+def _probe_worker_health(endpoint: str) -> bool:
+    """Probe a worker's /health endpoint. ``endpoint`` is a ``host:port`` pair.
+
+    Returns True iff the response is 2xx.
+    """
     try:
         resp = _HEALTH_PROBE_OPENER.open(
-            f"http://{address}:{port}/health",
+            f"http://{endpoint}/health",
             timeout=_HEALTH_PROBE_TIMEOUT_SECONDS,
         )
         return 200 <= resp.status < 300
@@ -453,7 +456,7 @@ class Autoscaler:
 
                 if status.state == CloudSliceState.READY:
                     worker_ids = [w.worker_id for w in status.workers]
-                    worker_addresses = {w.worker_id: w.internal_address for w in status.workers}
+                    worker_addresses = self._worker_endpoints(status.workers)
                     group.mark_slice_ready(slice_id, worker_ids, worker_addresses=worker_addresses)
                     self._register_slice_workers(status.workers, slice_id, group.name)
                     self._log_action(
@@ -529,12 +532,9 @@ class Autoscaler:
         """
         timestamp = timestamp or Timestamp.now()
         if self._base_worker_config is None:
-            return  # test/local mode without bootstrap; nothing to probe
-        port = self._base_worker_config.port
-        if port <= 0:
-            return
+            return  # autoscaler built without a worker config (unit tests); nothing to probe
 
-        # Phase 1: collect every (group, slice_id, worker_id, addr) probe target.
+        # Phase 1: collect every (group, slice_id, worker_id, endpoint) probe target.
         probes: list[tuple[ScalingGroup, str, str, str]] = []
         for group in self._groups.values():
             for slice_id, handle, addresses in group.ready_slice_probe_targets():
@@ -542,15 +542,15 @@ class Autoscaler:
                     addresses = self._refresh_slice_addresses(group, slice_id, handle)
                     if not addresses:
                         continue  # describe() failed or partial; retry next tick
-                for worker_id, addr in addresses.items():
-                    probes.append((group, slice_id, worker_id, addr))
+                for worker_id, endpoint in addresses.items():
+                    probes.append((group, slice_id, worker_id, endpoint))
         if not probes:
             return
 
         # Phase 2: fan out probes. Bound the pool so we don't melt the controller.
         workers = min(_HEALTH_PROBE_MAX_WORKERS, len(probes))
         with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="health-probe") as pool:
-            results = list(pool.map(lambda p: _probe_worker_health(p[3], port), probes))
+            results = list(pool.map(lambda p: _probe_worker_health(p[3]), probes))
 
         # Phase 3: record results and collect slices that tripped the threshold.
         tripped: dict[str, tuple[ScalingGroup, str]] = {}  # slice_id -> (group, reason)
@@ -576,10 +576,24 @@ class Autoscaler:
                 status="failed",
             )
 
-    def _refresh_slice_addresses(self, group: ScalingGroup, slice_id: str, handle: SliceHandle) -> dict[str, str]:
-        """Resolve worker addresses for a slice by calling handle.describe().
+    def _worker_endpoints(self, workers: Sequence[RemoteWorkerHandle]) -> dict[str, str]:
+        """Map worker_id to a reachable ``host:port`` endpoint.
 
-        Returns the full address map only when every worker has an
+        Workers that auto-assign ports (LOCAL) report ``handle.port``; others
+        fall back to the cluster-configured worker port. Workers without an
+        ``internal_address`` are skipped.
+        """
+        default_port = self._base_worker_config.port if self._base_worker_config else 0
+        return {
+            w.worker_id: f"{w.internal_address}:{w.port if w.port is not None else default_port}"
+            for w in workers
+            if w.internal_address
+        }
+
+    def _refresh_slice_addresses(self, group: ScalingGroup, slice_id: str, handle: SliceHandle) -> dict[str, str]:
+        """Resolve worker endpoints for a slice by calling handle.describe().
+
+        Returns the full endpoint map only when every worker has an
         ``internal_address``. A partial set is dropped: caching it would
         permanently exclude the missing workers from probing, and probing
         the incomplete set risks terminating a slice for a worker that
@@ -590,7 +604,7 @@ class Autoscaler:
         except Exception as e:
             logger.warning("Failed to describe slice %s for health probe: %s", slice_id, e)
             return {}
-        addresses = {w.worker_id: w.internal_address for w in status.workers if w.internal_address}
+        addresses = self._worker_endpoints(status.workers)
         if len(addresses) != len(status.workers):
             return {}
         group.set_worker_addresses(slice_id, addresses)

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -131,6 +131,15 @@ class SliceState:
     quiet_since: Timestamp | None = None
     lifecycle: SliceLifecycleState = SliceLifecycleState.BOOTING
     worker_ids: list[str] = field(default_factory=list)
+    # worker_id -> internal IP. Populated at READY transition from the
+    # slice handle's worker info. Empty after a controller restart for
+    # already-READY slices — the health probe lazy-fetches via
+    # handle.describe() in that case. Memory-only.
+    worker_addresses: dict[str, str] = field(default_factory=dict)
+    # worker_id -> consecutive /health probe failures since the last
+    # success. Reset on a healthy response; once any worker crosses
+    # PING_FAILURE_THRESHOLD the slice is terminated. Memory-only.
+    ping_failures: dict[str, int] = field(default_factory=dict)
     error_message: str = ""
 
 
@@ -542,15 +551,29 @@ class ScalingGroup:
         with self._slices_lock:
             self._pending_scale_ups = max(0, self._pending_scale_ups - 1)
 
-    def mark_slice_ready(self, slice_id: str, worker_ids: list[str], timestamp: Timestamp | None = None) -> None:
+    def mark_slice_ready(
+        self,
+        slice_id: str,
+        worker_ids: list[str],
+        worker_addresses: dict[str, str] | None = None,
+        timestamp: Timestamp | None = None,
+    ) -> None:
         """Mark a slice READY with its worker IDs. ``quiet_since`` is left None so the next
-        autoscaler tick decides idle/active afresh."""
+        autoscaler tick decides idle/active afresh.
+
+        ``worker_addresses`` (worker_id -> internal IP) seeds the slice health
+        probe so it doesn't need to call ``handle.describe()`` on the first
+        tick. Optional: tests that don't exercise the probe path can omit it,
+        and the probe will lazy-fetch from the handle.
+        """
         del timestamp
         with self._slices_lock:
             state = self._slices.get(slice_id)
             if state is not None:
                 state.lifecycle = SliceLifecycleState.READY
                 state.worker_ids = worker_ids
+                state.worker_addresses = dict(worker_addresses or {})
+                state.ping_failures = {}
                 state.quiet_since = None
         if state is not None:
             self._db_upsert_slice(slice_id, state)
@@ -716,6 +739,45 @@ class ScalingGroup:
         """Count of slices where all VMs are ready."""
         with self._slices_lock:
             return sum(1 for s in self._slices.values() if s.lifecycle == SliceLifecycleState.READY)
+
+    def ready_slice_probe_targets(self) -> list[tuple[str, SliceHandle, dict[str, str]]]:
+        """Snapshot READY slices for the health probe.
+
+        Returns ``(slice_id, handle, worker_addresses_copy)`` tuples. Addresses
+        may be empty (e.g. on a controller restart for a checkpointed READY
+        slice) — callers should lazy-fetch via ``handle.describe()`` and
+        publish back via :meth:`set_worker_addresses`.
+        """
+        with self._slices_lock:
+            return [
+                (slice_id, state.handle, dict(state.worker_addresses))
+                for slice_id, state in self._slices.items()
+                if state.lifecycle == SliceLifecycleState.READY
+            ]
+
+    def set_worker_addresses(self, slice_id: str, worker_addresses: dict[str, str]) -> None:
+        """Publish freshly-resolved addresses (typically from handle.describe()) back to state."""
+        with self._slices_lock:
+            state = self._slices.get(slice_id)
+            if state is not None:
+                state.worker_addresses = dict(worker_addresses)
+
+    def record_health_probe_result(self, slice_id: str, worker_id: str, healthy: bool) -> int:
+        """Update the per-worker ping_failures counter and return the new count.
+
+        Returns 0 on success (counter reset) and the incremented count on
+        failure. A counter that reaches PING_FAILURE_THRESHOLD signals the
+        slice should be terminated (the runtime owns that decision).
+        """
+        with self._slices_lock:
+            state = self._slices.get(slice_id)
+            if state is None:
+                return 0
+            if healthy:
+                state.ping_failures.pop(worker_id, None)
+                return 0
+            state.ping_failures[worker_id] = state.ping_failures.get(worker_id, 0) + 1
+            return state.ping_failures[worker_id]
 
     def get_slice(self, slice_id: str) -> SliceHandle | None:
         """Get a specific slice handle by ID."""

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -131,8 +131,8 @@ class SliceState:
     quiet_since: Timestamp | None = None
     lifecycle: SliceLifecycleState = SliceLifecycleState.BOOTING
     worker_ids: list[str] = field(default_factory=list)
-    # worker_id -> internal IP. Populated at READY transition from the
-    # slice handle's worker info. Empty after a controller restart for
+    # worker_id -> reachable host:port endpoint. Populated at READY transition
+    # from the slice handle's worker info. Empty after a controller restart for
     # already-READY slices — the health probe lazy-fetches via
     # handle.describe() in that case. Memory-only.
     worker_addresses: dict[str, str] = field(default_factory=dict)
@@ -561,10 +561,10 @@ class ScalingGroup:
         """Mark a slice READY with its worker IDs. ``quiet_since`` is left None so the next
         autoscaler tick decides idle/active afresh.
 
-        ``worker_addresses`` (worker_id -> internal IP) seeds the slice health
-        probe so it doesn't need to call ``handle.describe()`` on the first
-        tick. Optional: tests that don't exercise the probe path can omit it,
-        and the probe will lazy-fetch from the handle.
+        ``worker_addresses`` (worker_id -> host:port endpoint) seeds the slice
+        health probe so it doesn't need to call ``handle.describe()`` on the
+        first tick. Optional: tests that don't exercise the probe path can omit
+        it, and the probe will lazy-fetch from the handle.
         """
         del timestamp
         with self._slices_lock:

--- a/lib/iris/src/iris/cluster/controller/autoscaler/worker_registry.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/worker_registry.py
@@ -39,6 +39,10 @@ class _RestoredWorkerHandle:
         return self._internal_address
 
     @property
+    def port(self) -> int | None:
+        return None
+
+    @property
     def external_address(self) -> str | None:
         return None
 

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -2620,6 +2620,7 @@ class Controller:
 
         worker_status_map = self._build_worker_status_map()
         self._autoscaler.refresh(worker_status_map)
+        self._autoscaler.probe_health()
         with self._db.read_snapshot() as tx:
             workers = reads.healthy_active_workers_with_attributes(tx, self._health, self._worker_attrs)
         demand_entries = compute_demand_entries(

--- a/lib/iris/src/iris/cluster/providers/_worker_base.py
+++ b/lib/iris/src/iris/cluster/providers/_worker_base.py
@@ -60,6 +60,10 @@ class RemoteExecWorkerBase:
         return self._internal_address
 
     @property
+    def port(self) -> int | None:
+        return None
+
+    @property
     def external_address(self) -> str | None:
         return self._external_address
 

--- a/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
@@ -207,7 +207,9 @@ for i in $(seq 1 60); do
     sleep 2
 done
 
-echo "[iris-init] WARNING: Worker not healthy after 120s; docker will continue retrying"
+echo "[iris-init] WARNING: Worker not healthy after 120s. Docker will keep restarting the"
+echo "[iris-init] container (--restart=unless-stopped); the autoscaler health probe will reap"
+echo "[iris-init] this slice if /health stays down for ~100s of probes."
 echo "[iris-init] Container status:"
 sudo docker ps -a -f name=iris-worker --format "table {{.Status}}\\t{{.State}}" 2>&1 | sed 's/^/[iris-init] /'
 echo "[iris-init] Container logs:"

--- a/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
@@ -177,8 +177,11 @@ echo "[iris-init] Phase: worker_start"
 # from a previous worker during rolling restarts.
 sudo docker rm -f iris-worker 2>/dev/null || true
 
-# Start worker container without restart policy first (fail fast during bootstrap)
+# Start worker container with restart policy from the start so transient
+# failures (image pull races, network hiccups, etc.) self-heal. Give-up is
+# owned by the autoscaler's slice health probe, not by docker.
 sudo docker run -d --name iris-worker \\
+    --restart=unless-stopped \\
     --network=host \\
     --ulimit core=0:0 \\
     -v {{ cache_dir }}:{{ cache_dir }} \\
@@ -192,29 +195,19 @@ echo "[iris-init] Worker container started"
 echo "[iris-init] Phase: registration"
 echo "[iris-init] Waiting for worker to register with controller..."
 
-# Wait for worker to be healthy (poll health endpoint)
+# Poll the health endpoint to report bootstrap status. Docker handles
+# restarts; the autoscaler health probe handles give-up if /health never
+# comes up.
 for i in $(seq 1 60); do
-    # Check if container is still running
-    if ! sudo docker ps -q -f name=iris-worker | grep -q .; then
-        echo "[iris-init] ERROR: Worker container exited unexpectedly"
-        echo "[iris-init] Container status:"
-        sudo docker ps -a -f name=iris-worker --format "table {{.Status}}\\t{{.State}}" 2>&1 | sed 's/^/[iris-init] /'
-        echo "[iris-init] Container logs:"
-        sudo docker logs iris-worker --tail 100 2>&1 | sed 's/^/[iris-init] /'
-        exit 1
-    fi
-
     if curl -sf http://localhost:{{ worker_port }}/health > /dev/null 2>&1; then
         echo "[iris-init] Worker is healthy"
-        # Now add restart policy for production
-        sudo docker update --restart=unless-stopped iris-worker
         echo "[iris-init] Bootstrap complete"
         exit 0
     fi
     sleep 2
 done
 
-echo "[iris-init] ERROR: Worker failed to become healthy after 120s"
+echo "[iris-init] WARNING: Worker not healthy after 120s; docker will continue retrying"
 echo "[iris-init] Container status:"
 sudo docker ps -a -f name=iris-worker --format "table {{.Status}}\\t{{.State}}" 2>&1 | sed 's/^/[iris-init] /'
 echo "[iris-init] Container logs:"

--- a/lib/iris/src/iris/cluster/providers/gcp/local.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/local.py
@@ -44,6 +44,7 @@ class _LocalWorkerHandle:
 
     _vm_id: str
     _internal_address: str
+    _port: int = 0
     _bootstrap_log_lines: list[str] = field(default_factory=list)
 
     @property
@@ -57,6 +58,10 @@ class _LocalWorkerHandle:
     @property
     def internal_address(self) -> str:
         return self._internal_address
+
+    @property
+    def port(self) -> int:
+        return self._port
 
     @property
     def external_address(self) -> str | None:
@@ -157,10 +162,10 @@ class LocalSliceHandle:
     def describe(self) -> SliceStatus:
         if self._terminated:
             return SliceStatus(state=CloudSliceState.DELETING, worker_count=0)
-        workers = [
-            _LocalWorkerHandle(_vm_id=vm_id, _internal_address=addr)
-            for vm_id, addr in zip(self._vm_ids, self._addresses, strict=True)
-        ]
+        workers = []
+        for vm_id, endpoint in zip(self._vm_ids, self._addresses, strict=True):
+            host, _, port = endpoint.rpartition(":")
+            workers.append(_LocalWorkerHandle(_vm_id=vm_id, _internal_address=host, _port=int(port)))
         return SliceStatus(state=CloudSliceState.READY, worker_count=len(self._vm_ids), workers=workers)
 
     def terminate(self, *, wait: bool = False) -> None:

--- a/lib/iris/src/iris/cluster/providers/types.py
+++ b/lib/iris/src/iris/cluster/providers/types.py
@@ -222,7 +222,15 @@ class RemoteWorkerHandle(Protocol):
 
     @property
     def internal_address(self) -> str:
-        """Internal/private IP address for intra-cluster communication."""
+        """Internal/private IP address (host only, no port) for intra-cluster communication."""
+        ...
+
+    @property
+    def port(self) -> int | None:
+        """RPC port, or None when the worker serves on the cluster-configured port.
+
+        Only providers that auto-assign ports per worker (LOCAL) report this.
+        """
         ...
 
     @property

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -1693,5 +1693,85 @@ class TestAutoscalerHealthProbe:
         autoscaler.probe_health(Timestamp.from_ms(1_000))
 
         expected = [w.internal_address for w in handle.describe().workers]
-        assert seen_addresses == expected, "probe should hit each worker's described address"
+        assert sorted(seen_addresses) == sorted(expected), "probe should hit each worker's described address"
+        autoscaler.shutdown()
+
+    def test_per_worker_counter_isolates_one_dead_worker(
+        self,
+        scale_group_config: config_pb2.ScaleGroupConfig,
+        base_worker_config: config_pb2.WorkerConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """One dead worker in a multi-VM slice trips the slice, even when the rest stay healthy."""
+        from iris.cluster.controller.worker_health import PING_FAILURE_THRESHOLD
+
+        handle = make_mock_slice_handle(
+            "slice-001",
+            vm_states=[vm_pb2.VM_STATE_READY, vm_pb2.VM_STATE_READY],
+        )
+        platform = make_mock_platform(slices_to_discover=[handle])
+        group = ScalingGroup(scale_group_config, platform)
+        group.reconcile()
+        _mark_discovered_ready(group, [handle])
+        addrs = {w.worker_id: w.internal_address for w in handle.describe().workers}
+        group.set_worker_addresses(handle.slice_id, addrs)
+        autoscaler = make_autoscaler({"test-group": group}, base_worker_config=base_worker_config)
+
+        dead_worker = handle.describe().workers[1]
+        dead_addr = dead_worker.internal_address
+        monkeypatch.setattr(
+            "iris.cluster.controller.autoscaler.runtime._probe_worker_health",
+            lambda addr, port: addr != dead_addr,
+        )
+
+        for _ in range(PING_FAILURE_THRESHOLD):
+            autoscaler.probe_health(Timestamp.from_ms(1_000))
+
+        assert group.ready_slice_count() == 0, "dead worker should trip the slice"
+        autoscaler.shutdown()
+
+    def test_describe_failure_during_lazy_fetch_does_not_terminate(
+        self,
+        scale_group_config: config_pb2.ScaleGroupConfig,
+        base_worker_config: config_pb2.WorkerConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A transient handle.describe() exception is logged and skipped, not fatal."""
+        from iris.cluster.controller.worker_health import PING_FAILURE_THRESHOLD
+
+        handle = make_mock_slice_handle("slice-001", all_ready=True)
+        good_addresses = {w.worker_id: w.internal_address for w in handle.describe().workers}
+        platform = make_mock_platform(slices_to_discover=[handle])
+        group = ScalingGroup(scale_group_config, platform)
+        group.reconcile()
+        _mark_discovered_ready(group, [handle])
+        # No cached addresses; describe() will be called.
+        autoscaler = make_autoscaler({"test-group": group}, base_worker_config=base_worker_config)
+
+        raising = {"on": True}
+        original_describe = handle.describe
+
+        def _maybe_raise():
+            if raising["on"]:
+                raise RuntimeError("transient cloud blip")
+            return original_describe()
+
+        monkeypatch.setattr(handle, "describe", _maybe_raise)
+        monkeypatch.setattr(
+            "iris.cluster.controller.autoscaler.runtime._probe_worker_health",
+            lambda addr, port: True,
+        )
+
+        # PING_FAILURE_THRESHOLD ticks while describe() raises must not terminate.
+        for _ in range(PING_FAILURE_THRESHOLD):
+            autoscaler.probe_health(Timestamp.from_ms(1_000))
+        assert group.ready_slice_count() == 1
+        assert group.get_slice("slice-001") is not None
+        assert group.get_slice("slice-001").describe  # sanity: handle still callable next tick
+
+        # Once describe() recovers, the probe resolves addresses and caches them.
+        raising["on"] = False
+        autoscaler.probe_health(Timestamp.from_ms(2_000))
+        cached = group.ready_slice_probe_targets()[0][2]
+        assert cached == good_addresses
         autoscaler.shutdown()

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -30,6 +30,7 @@ from rigging.timing import Duration, Timestamp
 
 from tests.cluster.providers.conftest import (
     FakeSliceHandle,
+    FakeWorkerHandle,
     make_mock_platform,
     make_mock_slice_handle,
     make_mock_worker_handle,
@@ -1591,10 +1592,9 @@ class TestAutoscalerHealthProbe:
         group = ScalingGroup(scale_group_config, platform)
         group.reconcile()
         _mark_discovered_ready(group, [handle])
-        # Seed worker_addresses since reconcile() bypasses the refresh() path.
-        addrs = {w.worker_id: w.internal_address for w in handle.describe().workers}
-        group.set_worker_addresses(handle.slice_id, addrs)
         autoscaler = make_autoscaler({"test-group": group}, base_worker_config=base_worker_config)
+        # Seed worker_addresses since reconcile() bypasses the refresh() path.
+        group.set_worker_addresses(handle.slice_id, autoscaler._worker_endpoints(handle.describe().workers))
         return autoscaler, group, handle
 
     def test_healthy_probes_keep_slice_alive(
@@ -1607,7 +1607,7 @@ class TestAutoscalerHealthProbe:
         autoscaler, group, _ = self._setup_ready_group(scale_group_config, base_worker_config)
         monkeypatch.setattr(
             "iris.cluster.controller.autoscaler.runtime._probe_worker_health",
-            lambda addr, port: True,
+            lambda endpoint: True,
         )
 
         for _ in range(20):
@@ -1628,7 +1628,7 @@ class TestAutoscalerHealthProbe:
         autoscaler, group, _ = self._setup_ready_group(scale_group_config, base_worker_config)
         monkeypatch.setattr(
             "iris.cluster.controller.autoscaler.runtime._probe_worker_health",
-            lambda addr, port: False,
+            lambda endpoint: False,
         )
 
         # One probe per tick — need PING_FAILURE_THRESHOLD ticks to trip.
@@ -1655,7 +1655,7 @@ class TestAutoscalerHealthProbe:
         # consecutive failures even after many ticks.
         toggle = {"healthy": False}
 
-        def _probe(addr: str, port: int) -> bool:
+        def _probe(endpoint: str) -> bool:
             toggle["healthy"] = not toggle["healthy"]
             return toggle["healthy"]
 
@@ -1682,18 +1682,18 @@ class TestAutoscalerHealthProbe:
         # Deliberately do NOT call set_worker_addresses — simulate post-restart.
         autoscaler = make_autoscaler({"test-group": group}, base_worker_config=base_worker_config)
 
-        seen_addresses: list[str] = []
+        seen_endpoints: list[str] = []
 
-        def _probe(addr: str, port: int) -> bool:
-            seen_addresses.append(addr)
+        def _probe(endpoint: str) -> bool:
+            seen_endpoints.append(endpoint)
             return True
 
         monkeypatch.setattr("iris.cluster.controller.autoscaler.runtime._probe_worker_health", _probe)
 
         autoscaler.probe_health(Timestamp.from_ms(1_000))
 
-        expected = [w.internal_address for w in handle.describe().workers]
-        assert sorted(seen_addresses) == sorted(expected), "probe should hit each worker's described address"
+        expected = list(autoscaler._worker_endpoints(handle.describe().workers).values())
+        assert sorted(seen_endpoints) == sorted(expected), "probe should hit each worker's described endpoint"
         autoscaler.shutdown()
 
     def test_per_worker_counter_isolates_one_dead_worker(
@@ -1713,15 +1713,15 @@ class TestAutoscalerHealthProbe:
         group = ScalingGroup(scale_group_config, platform)
         group.reconcile()
         _mark_discovered_ready(group, [handle])
-        addrs = {w.worker_id: w.internal_address for w in handle.describe().workers}
-        group.set_worker_addresses(handle.slice_id, addrs)
         autoscaler = make_autoscaler({"test-group": group}, base_worker_config=base_worker_config)
+        endpoints = autoscaler._worker_endpoints(handle.describe().workers)
+        group.set_worker_addresses(handle.slice_id, endpoints)
 
         dead_worker = handle.describe().workers[1]
-        dead_addr = dead_worker.internal_address
+        dead_endpoint = endpoints[dead_worker.worker_id]
         monkeypatch.setattr(
             "iris.cluster.controller.autoscaler.runtime._probe_worker_health",
-            lambda addr, port: addr != dead_addr,
+            lambda endpoint: endpoint != dead_endpoint,
         )
 
         for _ in range(PING_FAILURE_THRESHOLD):
@@ -1740,13 +1740,13 @@ class TestAutoscalerHealthProbe:
         from iris.cluster.controller.worker_health import PING_FAILURE_THRESHOLD
 
         handle = make_mock_slice_handle("slice-001", all_ready=True)
-        good_addresses = {w.worker_id: w.internal_address for w in handle.describe().workers}
         platform = make_mock_platform(slices_to_discover=[handle])
         group = ScalingGroup(scale_group_config, platform)
         group.reconcile()
         _mark_discovered_ready(group, [handle])
         # No cached addresses; describe() will be called.
         autoscaler = make_autoscaler({"test-group": group}, base_worker_config=base_worker_config)
+        good_addresses = autoscaler._worker_endpoints(handle.describe().workers)
 
         raising = {"on": True}
         original_describe = handle.describe
@@ -1759,7 +1759,7 @@ class TestAutoscalerHealthProbe:
         monkeypatch.setattr(handle, "describe", _maybe_raise)
         monkeypatch.setattr(
             "iris.cluster.controller.autoscaler.runtime._probe_worker_health",
-            lambda addr, port: True,
+            lambda endpoint: True,
         )
 
         # PING_FAILURE_THRESHOLD ticks while describe() raises must not terminate.
@@ -1774,4 +1774,19 @@ class TestAutoscalerHealthProbe:
         autoscaler.probe_health(Timestamp.from_ms(2_000))
         cached = group.ready_slice_probe_targets()[0][2]
         assert cached == good_addresses
+        autoscaler.shutdown()
+
+    def test_endpoint_prefers_handle_port_over_cluster_default(
+        self,
+        base_worker_config: config_pb2.WorkerConfig,
+    ):
+        """Workers that auto-assign ports (LOCAL) probe their own port; others
+        fall back to the cluster-configured worker port."""
+        autoscaler = make_autoscaler({}, base_worker_config=base_worker_config)
+        gcp_style = make_mock_worker_handle("w-gcp", "10.0.0.1", vm_pb2.VM_STATE_READY)
+        local_style = FakeWorkerHandle(_vm_id="w-local", _internal_address="127.0.0.1", _port=54321)
+
+        endpoints = autoscaler._worker_endpoints([gcp_style, local_style])
+
+        assert endpoints == {"w-gcp": "10.0.0.1:10001", "w-local": "127.0.0.1:54321"}
         autoscaler.shutdown()

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -1574,3 +1574,124 @@ class TestAutoscalerUnresolvableTimeout:
 
         assert group.ready_slice_count() == 1
         autoscaler.shutdown()
+
+
+class TestAutoscalerHealthProbe:
+    """Tests for probe_health(): terminate slices whose /health endpoint dies."""
+
+    @pytest.fixture
+    def base_worker_config(self) -> config_pb2.WorkerConfig:
+        return config_pb2.WorkerConfig(port=10001)
+
+    def _setup_ready_group(
+        self, scale_group_config: config_pb2.ScaleGroupConfig, base_worker_config: config_pb2.WorkerConfig
+    ) -> tuple[Autoscaler, ScalingGroup, FakeSliceHandle]:
+        handle = make_mock_slice_handle("slice-001", all_ready=True)
+        platform = make_mock_platform(slices_to_discover=[handle])
+        group = ScalingGroup(scale_group_config, platform)
+        group.reconcile()
+        _mark_discovered_ready(group, [handle])
+        # Seed worker_addresses since reconcile() bypasses the refresh() path.
+        addrs = {w.worker_id: w.internal_address for w in handle.describe().workers}
+        group.set_worker_addresses(handle.slice_id, addrs)
+        autoscaler = make_autoscaler({"test-group": group}, base_worker_config=base_worker_config)
+        return autoscaler, group, handle
+
+    def test_healthy_probes_keep_slice_alive(
+        self,
+        scale_group_config: config_pb2.ScaleGroupConfig,
+        base_worker_config: config_pb2.WorkerConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Repeated healthy probes never terminate the slice and reset the failure counter."""
+        autoscaler, group, _ = self._setup_ready_group(scale_group_config, base_worker_config)
+        monkeypatch.setattr(
+            "iris.cluster.controller.autoscaler.runtime._probe_worker_health",
+            lambda addr, port: True,
+        )
+
+        for _ in range(20):
+            autoscaler.probe_health(Timestamp.from_ms(1_000))
+
+        assert group.ready_slice_count() == 1
+        autoscaler.shutdown()
+
+    def test_unhealthy_probes_terminate_after_threshold(
+        self,
+        scale_group_config: config_pb2.ScaleGroupConfig,
+        base_worker_config: config_pb2.WorkerConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """PING_FAILURE_THRESHOLD consecutive failures trip slice termination."""
+        from iris.cluster.controller.worker_health import PING_FAILURE_THRESHOLD
+
+        autoscaler, group, _ = self._setup_ready_group(scale_group_config, base_worker_config)
+        monkeypatch.setattr(
+            "iris.cluster.controller.autoscaler.runtime._probe_worker_health",
+            lambda addr, port: False,
+        )
+
+        # One probe per tick — need PING_FAILURE_THRESHOLD ticks to trip.
+        for _ in range(PING_FAILURE_THRESHOLD - 1):
+            autoscaler.probe_health(Timestamp.from_ms(1_000))
+        assert group.ready_slice_count() == 1, "should not have terminated yet"
+
+        autoscaler.probe_health(Timestamp.from_ms(2_000))
+        assert group.ready_slice_count() == 0, "threshold-th failure should terminate slice"
+        autoscaler.shutdown()
+
+    def test_recovery_resets_failure_counter(
+        self,
+        scale_group_config: config_pb2.ScaleGroupConfig,
+        base_worker_config: config_pb2.WorkerConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A single healthy response zeros the per-worker counter so transient flaps don't kill slices."""
+        from iris.cluster.controller.worker_health import PING_FAILURE_THRESHOLD
+
+        autoscaler, group, _ = self._setup_ready_group(scale_group_config, base_worker_config)
+
+        # Alternating bad/good probes. We need to avoid hitting PING_FAILURE_THRESHOLD
+        # consecutive failures even after many ticks.
+        toggle = {"healthy": False}
+
+        def _probe(addr: str, port: int) -> bool:
+            toggle["healthy"] = not toggle["healthy"]
+            return toggle["healthy"]
+
+        monkeypatch.setattr("iris.cluster.controller.autoscaler.runtime._probe_worker_health", _probe)
+
+        for _ in range(PING_FAILURE_THRESHOLD * 3):
+            autoscaler.probe_health(Timestamp.from_ms(1_000))
+
+        assert group.ready_slice_count() == 1
+        autoscaler.shutdown()
+
+    def test_lazy_fetches_addresses_when_state_has_none(
+        self,
+        scale_group_config: config_pb2.ScaleGroupConfig,
+        base_worker_config: config_pb2.WorkerConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Slices restored without cached addresses get them via handle.describe()."""
+        handle = make_mock_slice_handle("slice-001", all_ready=True)
+        platform = make_mock_platform(slices_to_discover=[handle])
+        group = ScalingGroup(scale_group_config, platform)
+        group.reconcile()
+        _mark_discovered_ready(group, [handle])
+        # Deliberately do NOT call set_worker_addresses — simulate post-restart.
+        autoscaler = make_autoscaler({"test-group": group}, base_worker_config=base_worker_config)
+
+        seen_addresses: list[str] = []
+
+        def _probe(addr: str, port: int) -> bool:
+            seen_addresses.append(addr)
+            return True
+
+        monkeypatch.setattr("iris.cluster.controller.autoscaler.runtime._probe_worker_health", _probe)
+
+        autoscaler.probe_health(Timestamp.from_ms(1_000))
+
+        expected = [w.internal_address for w in handle.describe().workers]
+        assert seen_addresses == expected, "probe should hit each worker's described address"
+        autoscaler.shutdown()

--- a/lib/iris/tests/cluster/controller/test_vm_lifecycle.py
+++ b/lib/iris/tests/cluster/controller/test_vm_lifecycle.py
@@ -89,6 +89,10 @@ class FakeWorkerHandle:
         return self._internal_address
 
     @property
+    def port(self) -> int | None:
+        return None
+
+    @property
     def external_address(self) -> str | None:
         return None
 

--- a/lib/iris/tests/cluster/providers/conftest.py
+++ b/lib/iris/tests/cluster/providers/conftest.py
@@ -46,6 +46,7 @@ class FakeWorkerHandle:
     _internal_address: str
     _state: CloudWorkerState = CloudWorkerState.RUNNING
     _bootstrap_log: str = ""
+    _port: int | None = None
 
     @property
     def worker_id(self) -> str:
@@ -58,6 +59,10 @@ class FakeWorkerHandle:
     @property
     def internal_address(self) -> str:
         return self._internal_address
+
+    @property
+    def port(self) -> int | None:
+        return self._port
 
     @property
     def external_address(self) -> str | None:


### PR DESCRIPTION
Once a slice went READY the autoscaler trusted its in-memory view forever,
so a slice whose worker process died without re-registering (failed
bootstrap, crashed container) pinned its scale group at max_slices with no
path to recovery — marin-dev had 5 idle e2-highmem-2 VMs orphaned for up to
15 days. Add a probe_health() tick that pings each READY worker's /health
endpoint and terminates the slice after PING_FAILURE_THRESHOLD consecutive
failures, reusing the existing heartbeat-path threshold. Switch the GCE
bootstrap to set Docker's restart=unless-stopped at initial run so transient
container failures self-heal instead of leaving a wedged VM behind.