### PR TITLE
[evals] Add OEIS perplexity-gap eval slice

### DIFF
--- a/experiments/evals/oeis_integer_sequences.py
+++ b/experiments/evals/oeis_integer_sequences.py
@@ -1,0 +1,46 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""OEIS integer-sequence raw validation slices for perplexity-gap evals."""
+
+from __future__ import annotations
+
+from marin.datakit.download.oeis import (
+    DEFAULT_MAX_SEQUENCES,
+    DEFAULT_RECORDS_PER_DOC,
+    oeis_eval_step,
+)
+from marin.evaluation.perplexity_gap import RawTextEvaluationDataset, raw_text_dataset
+from marin.execution.executor import executor_main
+from marin.execution.step_spec import StepSpec
+
+OEIS_INTEGER_SEQUENCES_ISSUE = 5770
+OEIS_INTEGER_SEQUENCES_KEY = "oeis/integer_sequences"
+OEIS_INTEGER_SEQUENCES_GLOB = "oeis_integer_sequences-*.parquet"
+
+oeis_integer_sequences_eval = oeis_eval_step()
+
+
+def oeis_integer_sequence_raw_validation_sets(
+    *,
+    oeis_raw: StepSpec | None = None,
+) -> dict[str, RawTextEvaluationDataset]:
+    """Materialize OEIS as an eval-only raw-text dataset."""
+
+    raw_step = oeis_integer_sequences_eval if oeis_raw is None else oeis_raw
+    return {
+        OEIS_INTEGER_SEQUENCES_KEY: raw_text_dataset(
+            raw_step.as_executor_step().cd(OEIS_INTEGER_SEQUENCES_GLOB),
+            tags=(
+                "oeis",
+                "integer_sequences",
+                f"issue:{OEIS_INTEGER_SEQUENCES_ISSUE}",
+                f"max_sequences:{DEFAULT_MAX_SEQUENCES}",
+                f"records_per_doc:{DEFAULT_RECORDS_PER_DOC}",
+            ),
+        )
+    }
+
+
+if __name__ == "__main__":
+    executor_main(steps=[oeis_integer_sequences_eval.as_executor_step()])

--- a/experiments/evals/perplexity_gap_registry.py
+++ b/experiments/evals/perplexity_gap_registry.py
@@ -29,6 +29,7 @@ from experiments.bio_chem_notation import bio_chem_raw_validation_sets
 from experiments.defaults import default_raw_validation_sets
 from experiments.evals.fineweb2_multilingual import fineweb2_multilingual_raw_validation_sets
 from experiments.evals.long_tail_ppl_runnable import runnable_long_tail_raw_validation_sets
+from experiments.evals.oeis_integer_sequences import oeis_integer_sequence_raw_validation_sets
 from experiments.marin_models import marin_tokenizer
 
 DEFAULT_MAX_EVAL_LENGTH = 4096
@@ -101,12 +102,21 @@ def bio_chem_bundle() -> PerplexityGapBundle:
     )
 
 
+def oeis_integer_sequences_bundle() -> PerplexityGapBundle:
+    return PerplexityGapBundle(
+        key="oeis_integer_sequences",
+        description="Eval-only OEIS integer sequences from stripped.gz and names.gz.",
+        datasets_factory=oeis_integer_sequence_raw_validation_sets,
+    )
+
+
 def registered_perplexity_gap_bundles() -> tuple[PerplexityGapBundle, ...]:
     return (
         base_raw_bundle(),
         multilingual_bundle(),
         runnable_long_tail_bundle(),
         bio_chem_bundle(),
+        oeis_integer_sequences_bundle(),
     )
 
 

--- a/lib/marin/src/marin/datakit/download/oeis.py
+++ b/lib/marin/src/marin/datakit/download/oeis.py
@@ -1,0 +1,147 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Download OEIS integer sequences for eval-only perplexity probes."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import posixpath
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+
+from rigging.filesystem import open_url
+from zephyr import Dataset, ZephyrContext
+
+from marin.execution.executor import THIS_OUTPUT_PATH
+from marin.execution.step_spec import StepSpec
+
+logger = logging.getLogger(__name__)
+
+OEIS_STRIPPED_URL = "https://oeis.org/stripped.gz"
+OEIS_NAMES_URL = "https://oeis.org/names.gz"
+DEFAULT_MAX_SEQUENCES = 50_000
+DEFAULT_RECORDS_PER_DOC = 16
+
+
+@dataclass(frozen=True)
+class OeisEvalConfig:
+    """Configuration for the OEIS eval-only materialization step."""
+
+    output_path: str = THIS_OUTPUT_PATH
+    stripped_url: str = OEIS_STRIPPED_URL
+    names_url: str = OEIS_NAMES_URL
+    max_sequences: int = DEFAULT_MAX_SEQUENCES
+    records_per_doc: int = DEFAULT_RECORDS_PER_DOC
+
+
+def _iter_name_rows(lines: Iterable[str]) -> Iterator[tuple[str, str]]:
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        sequence_id, _, name = line.partition(" ")
+        if not name:
+            continue
+        yield sequence_id, name
+
+
+def _iter_sequence_rows(lines: Iterable[str]) -> Iterator[tuple[str, str]]:
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        sequence_id, _, terms = line.partition(" ")
+        terms = terms.strip().strip(",")
+        if not terms:
+            continue
+        yield sequence_id, terms
+
+
+def _format_record(sequence_id: str, name: str, terms: str) -> str:
+    return f"OEIS ID: {sequence_id}\nName: {name}\nTerms:\n{terms}"
+
+
+def _doc_id(records: list[str], index: int) -> str:
+    digest = hashlib.sha1("\n".join(records).encode("utf-8")).hexdigest()[:16]
+    return f"oeis-{index:06d}-{digest}"
+
+
+def _pack_records(records: Iterable[str], *, records_per_doc: int) -> Iterator[dict[str, str]]:
+    if records_per_doc <= 0:
+        raise ValueError("records_per_doc must be positive.")
+
+    batch: list[str] = []
+    doc_index = 0
+    for record in records:
+        batch.append(record)
+        if len(batch) < records_per_doc:
+            continue
+        yield {"id": _doc_id(batch, index=doc_index), "text": "\n\n---\n\n".join(batch), "source": "oeis"}
+        doc_index += 1
+        batch = []
+
+    if batch:
+        yield {"id": _doc_id(batch, index=doc_index), "text": "\n\n---\n\n".join(batch), "source": "oeis"}
+
+
+def _open_gzip_text(url: str) -> Iterator[str]:
+    with open_url(url, mode="rt", compression="gzip", encoding="utf-8") as src:
+        yield from src
+
+
+def _iter_oeis_records(cfg: OeisEvalConfig) -> Iterator[str]:
+    names = dict(_iter_name_rows(_open_gzip_text(cfg.names_url)))
+    for index, (sequence_id, terms) in enumerate(_iter_sequence_rows(_open_gzip_text(cfg.stripped_url))):
+        if index >= cfg.max_sequences:
+            break
+        yield _format_record(sequence_id, names.get(sequence_id, ""), terms)
+
+
+def download_oeis_eval(cfg: OeisEvalConfig) -> dict[str, object]:
+    """Stream OEIS bulk dumps into a Dolma-style Parquet eval shard."""
+
+    logger.info("Streaming up to %d OEIS sequences from %s", cfg.max_sequences, cfg.stripped_url)
+    output_pattern = posixpath.join(str(cfg.output_path), "oeis_integer_sequences-{shard:05d}-of-{total:05d}.parquet")
+    pipeline = Dataset.from_iterable(_pack_records(_iter_oeis_records(cfg), records_per_doc=cfg.records_per_doc))
+    results = ZephyrContext(name="download-oeis-eval").execute(pipeline.write_parquet(output_pattern)).results
+    return {
+        "stripped_url": cfg.stripped_url,
+        "names_url": cfg.names_url,
+        "max_sequences": cfg.max_sequences,
+        "records_per_doc": cfg.records_per_doc,
+        "files": list(results),
+    }
+
+
+def oeis_eval_step(
+    *,
+    max_sequences: int = DEFAULT_MAX_SEQUENCES,
+    records_per_doc: int = DEFAULT_RECORDS_PER_DOC,
+    stripped_url: str = OEIS_STRIPPED_URL,
+    names_url: str = OEIS_NAMES_URL,
+) -> StepSpec:
+    """Create the eval-only OEIS download/materialization step."""
+
+    def _run(output_path: str) -> dict[str, object]:
+        return download_oeis_eval(
+            OeisEvalConfig(
+                output_path=output_path,
+                stripped_url=stripped_url,
+                names_url=names_url,
+                max_sequences=max_sequences,
+                records_per_doc=records_per_doc,
+            )
+        )
+
+    return StepSpec(
+        name="raw/oeis/integer_sequences_eval",
+        fn=_run,
+        hash_attrs={
+            "stripped_url": stripped_url,
+            "names_url": names_url,
+            "max_sequences": max_sequences,
+            "records_per_doc": records_per_doc,
+        },
+    )

--- a/tests/evals/test_oeis_integer_sequences.py
+++ b/tests/evals/test_oeis_integer_sequences.py
@@ -1,0 +1,49 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from fray.types import ResourceConfig
+from marin.datakit.download.oeis import _format_record, _iter_name_rows, _iter_sequence_rows
+
+from experiments.evals.oeis_integer_sequences import (
+    OEIS_INTEGER_SEQUENCES_KEY,
+    oeis_integer_sequence_raw_validation_sets,
+)
+from experiments.evals.perplexity_gap_registry import build_registered_perplexity_gap_coverage_plan
+
+
+def test_oeis_parsers_skip_headers_and_preserve_sequence_text() -> None:
+    names = dict(_iter_name_rows(["# header\n", "A000001 Number of groups of order n.\n"]))
+    sequences = dict(_iter_sequence_rows(["# header\n", "A000001 ,0,1,1,2,\n"]))
+
+    assert names == {"A000001": "Number of groups of order n."}
+    assert sequences == {"A000001": "0,1,1,2"}
+    assert _format_record("A000001", names["A000001"], sequences["A000001"]) == (
+        "OEIS ID: A000001\nName: Number of groups of order n.\nTerms:\n0,1,1,2"
+    )
+
+
+def test_oeis_raw_validation_set_points_at_eval_step_glob() -> None:
+    datasets = oeis_integer_sequence_raw_validation_sets()
+    dataset = datasets[OEIS_INTEGER_SEQUENCES_KEY]
+
+    assert dataset.input_path is not None
+    assert dataset.text_key == "text"
+    assert dataset.tags == (
+        "oeis",
+        "integer_sequences",
+        "issue:5770",
+        "max_sequences:50000",
+        "records_per_doc:16",
+    )
+
+
+def test_registered_coverage_plan_includes_oeis_bundle() -> None:
+    plan = build_registered_perplexity_gap_coverage_plan(
+        resource_config=ResourceConfig.with_tpu("v5p-8", regions=["us-central1"])
+    )
+
+    marin_score = plan.score_steps[("oeis_integer_sequences", "marin_8b")]
+    qwen_gap = plan.pairwise_gap_steps[("oeis_integer_sequences", "marin_8b", "qwen3_8b")]
+
+    assert OEIS_INTEGER_SEQUENCES_KEY in marin_score.config.datasets
+    assert qwen_gap.config.model_a_scores_path.step is marin_score


### PR DESCRIPTION
Add an eval-only OEIS materialization step that streams stripped.gz and names.gz into a capped raw-text validation shard. Register the OEIS slice as its own perplexity-gap bundle so Marin/Qwen/Llama comparisons can score integer sequences without adding the data to training. Adds parser and registry coverage tests.

Part of #5770