### PR TITLE
[iris] Replace handle port with a consistent worker_url

### DIFF
--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -1142,6 +1142,7 @@ class IrisConfig:
 
         return create_provider_bundle(
             platform_config=self._proto.platform,
+            worker_port=self._proto.defaults.worker.port,
             cluster_config=self._proto,
             ssh_config=self._proto.defaults.ssh,
         )

--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -81,14 +81,14 @@ _HEALTH_PROBE_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({
 _HEALTH_PROBE_MAX_WORKERS = 64
 
 
-def _probe_worker_health(endpoint: str) -> bool:
-    """Probe a worker's /health endpoint. ``endpoint`` is a ``host:port`` pair.
+def _probe_worker_health(worker_url: str) -> bool:
+    """Probe a worker's /health endpoint. ``worker_url`` is an ``http://host:port`` base URL.
 
     Returns True iff the response is 2xx.
     """
     try:
         resp = _HEALTH_PROBE_OPENER.open(
-            f"http://{endpoint}/health",
+            f"{worker_url}/health",
             timeout=_HEALTH_PROBE_TIMEOUT_SECONDS,
         )
         return 200 <= resp.status < 300
@@ -456,8 +456,8 @@ class Autoscaler:
 
                 if status.state == CloudSliceState.READY:
                     worker_ids = [w.worker_id for w in status.workers]
-                    worker_addresses = self._worker_endpoints(status.workers)
-                    group.mark_slice_ready(slice_id, worker_ids, worker_addresses=worker_addresses)
+                    worker_urls = self._worker_urls(status.workers)
+                    group.mark_slice_ready(slice_id, worker_ids, worker_urls=worker_urls)
                     self._register_slice_workers(status.workers, slice_id, group.name)
                     self._log_action(
                         "slice_ready",
@@ -523,7 +523,7 @@ class Autoscaler:
 
         Per-worker counters live on SliceState. PING_FAILURE_THRESHOLD
         consecutive failures (~100s at the default 10s evaluation interval,
-        matching the heartbeat-path threshold) trip termination. Addresses
+        matching the heartbeat-path threshold) trip termination. Worker URLs
         come from the slice handle, refreshed lazily via ``handle.describe()``
         when SliceState has none cached (e.g. after a controller restart).
         Probes are fanned out across a thread pool so a partitioned AZ
@@ -531,19 +531,17 @@ class Autoscaler:
         timeout. Slice teardown runs serially after all probes complete.
         """
         timestamp = timestamp or Timestamp.now()
-        if self._base_worker_config is None:
-            return  # autoscaler built without a worker config (unit tests); nothing to probe
 
-        # Phase 1: collect every (group, slice_id, worker_id, endpoint) probe target.
+        # Phase 1: collect every (group, slice_id, worker_id, worker_url) probe target.
         probes: list[tuple[ScalingGroup, str, str, str]] = []
         for group in self._groups.values():
-            for slice_id, handle, addresses in group.ready_slice_probe_targets():
-                if not addresses:
-                    addresses = self._refresh_slice_addresses(group, slice_id, handle)
-                    if not addresses:
+            for slice_id, handle, worker_urls in group.ready_slice_probe_targets():
+                if not worker_urls:
+                    worker_urls = self._refresh_slice_worker_urls(group, slice_id, handle)
+                    if not worker_urls:
                         continue  # describe() failed or partial; retry next tick
-                for worker_id, endpoint in addresses.items():
-                    probes.append((group, slice_id, worker_id, endpoint))
+                for worker_id, worker_url in worker_urls.items():
+                    probes.append((group, slice_id, worker_id, worker_url))
         if not probes:
             return
 
@@ -554,7 +552,7 @@ class Autoscaler:
 
         # Phase 3: record results and collect slices that tripped the threshold.
         tripped: dict[str, tuple[ScalingGroup, str]] = {}  # slice_id -> (group, reason)
-        for (group, slice_id, worker_id, _addr), healthy in zip(probes, results, strict=True):
+        for (group, slice_id, worker_id, _url), healthy in zip(probes, results, strict=True):
             count = group.record_health_probe_result(slice_id, worker_id, healthy)
             if count >= PING_FAILURE_THRESHOLD and slice_id not in tripped:
                 reason = f"worker {worker_id} failed /health {count}x"
@@ -576,39 +574,33 @@ class Autoscaler:
                 status="failed",
             )
 
-    def _worker_endpoints(self, workers: Sequence[RemoteWorkerHandle]) -> dict[str, str]:
-        """Map worker_id to a reachable ``host:port`` endpoint.
+    def _worker_urls(self, workers: Sequence[RemoteWorkerHandle]) -> dict[str, str]:
+        """Map worker_id to the worker's reachable ``http://host:port`` URL.
 
-        Workers that auto-assign ports (LOCAL) report ``handle.port``; others
-        fall back to the cluster-configured worker port. Workers without an
-        ``internal_address`` are skipped.
+        Workers with no internal address yet (mid-boot) report an empty
+        ``worker_url`` and are skipped.
         """
-        default_port = self._base_worker_config.port if self._base_worker_config else 0
-        return {
-            w.worker_id: f"{w.internal_address}:{w.port if w.port is not None else default_port}"
-            for w in workers
-            if w.internal_address
-        }
+        return {w.worker_id: w.worker_url for w in workers if w.worker_url}
 
-    def _refresh_slice_addresses(self, group: ScalingGroup, slice_id: str, handle: SliceHandle) -> dict[str, str]:
-        """Resolve worker endpoints for a slice by calling handle.describe().
+    def _refresh_slice_worker_urls(self, group: ScalingGroup, slice_id: str, handle: SliceHandle) -> dict[str, str]:
+        """Resolve worker URLs for a slice by calling handle.describe().
 
-        Returns the full endpoint map only when every worker has an
-        ``internal_address``. A partial set is dropped: caching it would
-        permanently exclude the missing workers from probing, and probing
-        the incomplete set risks terminating a slice for a worker that
-        simply hasn't published its IP yet. Next tick re-describes.
+        Returns the full map only when every worker has a URL. A partial set
+        is dropped: caching it would permanently exclude the missing workers
+        from probing, and probing the incomplete set risks terminating a
+        slice for a worker that simply hasn't published its IP yet. Next tick
+        re-describes.
         """
         try:
             status = handle.describe()
         except Exception as e:
             logger.warning("Failed to describe slice %s for health probe: %s", slice_id, e)
             return {}
-        addresses = self._worker_endpoints(status.workers)
-        if len(addresses) != len(status.workers):
+        worker_urls = self._worker_urls(status.workers)
+        if len(worker_urls) != len(status.workers):
             return {}
-        group.set_worker_addresses(slice_id, addresses)
-        return addresses
+        group.set_worker_urls(slice_id, worker_urls)
+        return worker_urls
 
     def update(
         self,

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -743,10 +743,10 @@ class ScalingGroup:
     def ready_slice_probe_targets(self) -> list[tuple[str, SliceHandle, dict[str, str]]]:
         """Snapshot READY slices for the health probe.
 
-        Returns ``(slice_id, handle, worker_urls_copy)`` tuples. URLs may be
-        empty (e.g. on a controller restart for a checkpointed READY slice) —
-        callers should lazy-fetch via ``handle.describe()`` and publish back
-        via :meth:`set_worker_urls`.
+        Returns ``(slice_id, handle, worker_urls)`` tuples, where ``worker_urls``
+        is a copy. URLs may be empty (e.g. on a controller restart for a
+        checkpointed READY slice) — callers should lazy-fetch via
+        ``handle.describe()`` and publish back via :meth:`set_worker_urls`.
         """
         with self._slices_lock:
             return [

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -131,11 +131,11 @@ class SliceState:
     quiet_since: Timestamp | None = None
     lifecycle: SliceLifecycleState = SliceLifecycleState.BOOTING
     worker_ids: list[str] = field(default_factory=list)
-    # worker_id -> reachable host:port endpoint. Populated at READY transition
+    # worker_id -> reachable http://host:port URL. Populated at READY transition
     # from the slice handle's worker info. Empty after a controller restart for
     # already-READY slices — the health probe lazy-fetches via
     # handle.describe() in that case. Memory-only.
-    worker_addresses: dict[str, str] = field(default_factory=dict)
+    worker_urls: dict[str, str] = field(default_factory=dict)
     # worker_id -> consecutive /health probe failures since the last
     # success. Reset on a healthy response; once any worker crosses
     # PING_FAILURE_THRESHOLD the slice is terminated. Memory-only.
@@ -555,13 +555,13 @@ class ScalingGroup:
         self,
         slice_id: str,
         worker_ids: list[str],
-        worker_addresses: dict[str, str] | None = None,
+        worker_urls: dict[str, str] | None = None,
         timestamp: Timestamp | None = None,
     ) -> None:
         """Mark a slice READY with its worker IDs. ``quiet_since`` is left None so the next
         autoscaler tick decides idle/active afresh.
 
-        ``worker_addresses`` (worker_id -> host:port endpoint) seeds the slice
+        ``worker_urls`` (worker_id -> http://host:port URL) seeds the slice
         health probe so it doesn't need to call ``handle.describe()`` on the
         first tick. Optional: tests that don't exercise the probe path can omit
         it, and the probe will lazy-fetch from the handle.
@@ -572,7 +572,7 @@ class ScalingGroup:
             if state is not None:
                 state.lifecycle = SliceLifecycleState.READY
                 state.worker_ids = worker_ids
-                state.worker_addresses = dict(worker_addresses or {})
+                state.worker_urls = dict(worker_urls or {})
                 state.ping_failures = {}
                 state.quiet_since = None
         if state is not None:
@@ -743,24 +743,24 @@ class ScalingGroup:
     def ready_slice_probe_targets(self) -> list[tuple[str, SliceHandle, dict[str, str]]]:
         """Snapshot READY slices for the health probe.
 
-        Returns ``(slice_id, handle, worker_addresses_copy)`` tuples. Addresses
-        may be empty (e.g. on a controller restart for a checkpointed READY
-        slice) — callers should lazy-fetch via ``handle.describe()`` and
-        publish back via :meth:`set_worker_addresses`.
+        Returns ``(slice_id, handle, worker_urls_copy)`` tuples. URLs may be
+        empty (e.g. on a controller restart for a checkpointed READY slice) —
+        callers should lazy-fetch via ``handle.describe()`` and publish back
+        via :meth:`set_worker_urls`.
         """
         with self._slices_lock:
             return [
-                (slice_id, state.handle, dict(state.worker_addresses))
+                (slice_id, state.handle, dict(state.worker_urls))
                 for slice_id, state in self._slices.items()
                 if state.lifecycle == SliceLifecycleState.READY
             ]
 
-    def set_worker_addresses(self, slice_id: str, worker_addresses: dict[str, str]) -> None:
-        """Publish freshly-resolved addresses (typically from handle.describe()) back to state."""
+    def set_worker_urls(self, slice_id: str, worker_urls: dict[str, str]) -> None:
+        """Publish freshly-resolved worker URLs (typically from handle.describe()) back to state."""
         with self._slices_lock:
             state = self._slices.get(slice_id)
             if state is not None:
-                state.worker_addresses = dict(worker_addresses)
+                state.worker_urls = dict(worker_urls)
 
     def record_health_probe_result(self, slice_id: str, worker_id: str, healthy: bool) -> int:
         """Update the per-worker ping_failures counter and return the new count.

--- a/lib/iris/src/iris/cluster/controller/autoscaler/worker_registry.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/worker_registry.py
@@ -22,9 +22,9 @@ from iris.rpc import vm_pb2
 class _RestoredWorkerHandle:
     """Minimal handle placeholder used for restored tracked workers."""
 
-    def __init__(self, worker_id: str, internal_address: str) -> None:
+    def __init__(self, worker_id: str, address: str) -> None:
         self._worker_id = worker_id
-        self._internal_address = internal_address
+        self._address = address  # host:port, as self-reported by the worker at registration
 
     @property
     def worker_id(self) -> str:
@@ -36,11 +36,11 @@ class _RestoredWorkerHandle:
 
     @property
     def internal_address(self) -> str:
-        return self._internal_address
+        return self._address.rpartition(":")[0] or self._address
 
     @property
-    def port(self) -> int | None:
-        return None
+    def worker_url(self) -> str:
+        return f"http://{self._address}" if self._address else ""
 
     @property
     def external_address(self) -> str | None:
@@ -169,7 +169,7 @@ def restore_tracked_workers(rows: list[TrackedWorkerRow]) -> dict[str, TrackedWo
 
     workers: dict[str, TrackedWorker] = {}
     for row in rows:
-        handle = _RestoredWorkerHandle(worker_id=row.worker_id, internal_address=row.address)
+        handle = _RestoredWorkerHandle(worker_id=row.worker_id, address=row.address)
         workers[row.worker_id] = TrackedWorker(
             worker_id=row.worker_id,
             slice_id=row.slice_id,

--- a/lib/iris/src/iris/cluster/controller/autoscaler/worker_registry.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/worker_registry.py
@@ -22,13 +22,10 @@ from iris.rpc import vm_pb2
 class _RestoredWorkerHandle:
     """Minimal handle placeholder used for restored tracked workers."""
 
-    def __init__(self, worker_id: str, address: str) -> None:
-        # address is host:port, self-reported by the worker at registration. A
-        # port-less address would build an http://host URL that probes :80 and
-        # silently reap a healthy slice, so reject it here.
-        assert not address or ":" in address, f"restored worker {worker_id} address missing port: {address!r}"
+    def __init__(self, worker_id: str, internal_address: str, port: int) -> None:
         self._worker_id = worker_id
-        self._address = address
+        self._internal_address = internal_address
+        self._port = port
 
     @property
     def worker_id(self) -> str:
@@ -40,11 +37,11 @@ class _RestoredWorkerHandle:
 
     @property
     def internal_address(self) -> str:
-        return self._address.rpartition(":")[0] or self._address
+        return self._internal_address
 
     @property
     def worker_url(self) -> str:
-        return f"http://{self._address}" if self._address else ""
+        return f"http://{self._internal_address}:{self._port}"
 
     @property
     def external_address(self) -> str | None:
@@ -169,11 +166,18 @@ class WorkerRegistry:
 
 
 def restore_tracked_workers(rows: list[TrackedWorkerRow]) -> dict[str, TrackedWorker]:
-    """Restore tracked workers from DB rows."""
+    """Restore tracked workers from DB rows.
+
+    ``row.address`` is the ``host:port`` the worker self-reported at
+    registration; it is split into the host/port pair the handle carries.
+    """
 
     workers: dict[str, TrackedWorker] = {}
     for row in rows:
-        handle = _RestoredWorkerHandle(worker_id=row.worker_id, address=row.address)
+        host, sep, port = row.address.rpartition(":")
+        if not sep or not host or not port.isdigit():
+            raise ValueError(f"restored worker {row.worker_id} has malformed address: {row.address!r}")
+        handle = _RestoredWorkerHandle(worker_id=row.worker_id, internal_address=host, port=int(port))
         workers[row.worker_id] = TrackedWorker(
             worker_id=row.worker_id,
             slice_id=row.slice_id,

--- a/lib/iris/src/iris/cluster/controller/autoscaler/worker_registry.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/worker_registry.py
@@ -23,8 +23,12 @@ class _RestoredWorkerHandle:
     """Minimal handle placeholder used for restored tracked workers."""
 
     def __init__(self, worker_id: str, address: str) -> None:
+        # address is host:port, self-reported by the worker at registration. A
+        # port-less address would build an http://host URL that probes :80 and
+        # silently reap a healthy slice, so reject it here.
+        assert not address or ":" in address, f"restored worker {worker_id} address missing port: {address!r}"
         self._worker_id = worker_id
-        self._address = address  # host:port, as self-reported by the worker at registration
+        self._address = address
 
     @property
     def worker_id(self) -> str:

--- a/lib/iris/src/iris/cluster/controller/main.py
+++ b/lib/iris/src/iris/cluster/controller/main.py
@@ -164,6 +164,7 @@ def run_controller_serve(
     elif not isinstance(provider, K8sTaskProvider):
         bundle = create_provider_bundle(
             platform_config=cluster_config.platform,
+            worker_port=cluster_config.defaults.worker.port,
             cluster_config=cluster_config,
             ssh_config=cluster_config.defaults.ssh,
         )

--- a/lib/iris/src/iris/cluster/providers/_worker_base.py
+++ b/lib/iris/src/iris/cluster/providers/_worker_base.py
@@ -44,6 +44,7 @@ class RemoteExecWorkerBase:
     _remote_exec: RemoteExec
     _vm_id: str
     _internal_address: str
+    _port: int
     _external_address: str | None = None
     _bootstrap_log_lines: list[str] = field(default_factory=list)
 
@@ -60,8 +61,10 @@ class RemoteExecWorkerBase:
         return self._internal_address
 
     @property
-    def port(self) -> int | None:
-        return None
+    def worker_url(self) -> str:
+        if not self._internal_address:
+            return ""
+        return f"http://{self._internal_address}:{self._port}"
 
     @property
     def external_address(self) -> str | None:

--- a/lib/iris/src/iris/cluster/providers/factory.py
+++ b/lib/iris/src/iris/cluster/providers/factory.py
@@ -48,6 +48,7 @@ def create_provider_bundle(
 
     which = platform_config.WhichOneof("platform")
     label_prefix = platform_config.label_prefix or "iris"
+    worker_port = cluster_config.defaults.worker.port if cluster_config else 0
 
     if which == "gcp":
         if not platform_config.gcp.project_id:
@@ -55,6 +56,7 @@ def create_provider_bundle(
         worker_provider = GcpWorkerProvider(
             gcp_config=platform_config.gcp,
             label_prefix=label_prefix,
+            worker_port=worker_port,
             ssh_config=ssh_config,
         )
         return ProviderBundle(
@@ -72,6 +74,7 @@ def create_provider_bundle(
     if which == "manual":
         worker_provider = ManualWorkerProvider(
             label_prefix=label_prefix,
+            worker_port=worker_port,
             ssh_config=ssh_config,
         )
         return ProviderBundle(
@@ -85,6 +88,7 @@ def create_provider_bundle(
         worker_provider = GcpWorkerProvider(
             gcp_config=local_gcp_config,
             label_prefix=label_prefix,
+            worker_port=worker_port,
             gcp_service=gcp_service,
         )
         return ProviderBundle(

--- a/lib/iris/src/iris/cluster/providers/factory.py
+++ b/lib/iris/src/iris/cluster/providers/factory.py
@@ -29,6 +29,7 @@ class ProviderBundle:
 
 def create_provider_bundle(
     platform_config: config_pb2.PlatformConfig,
+    worker_port: int,
     cluster_config: config_pb2.IrisClusterConfig | None = None,
     ssh_config: config_pb2.SshConfig | None = None,
 ) -> ProviderBundle:
@@ -36,6 +37,7 @@ def create_provider_bundle(
 
     Args:
         platform_config: Provider type and provider-specific settings.
+        worker_port: RPC port workers serve on, used to build their reachable URLs.
         cluster_config: Full cluster configuration when provider-specific defaults
             need controller/worker settings beyond platform_config.
         ssh_config: SSH settings (used by GCP and manual providers).
@@ -48,7 +50,6 @@ def create_provider_bundle(
 
     which = platform_config.WhichOneof("platform")
     label_prefix = platform_config.label_prefix or "iris"
-    worker_port = cluster_config.defaults.worker.port if cluster_config else 0
 
     if which == "gcp":
         if not platform_config.gcp.project_id:

--- a/lib/iris/src/iris/cluster/providers/gcp/handles.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/handles.py
@@ -241,6 +241,7 @@ class GcpSliceHandle:
         _labels: dict[str, str],
         _created_at: Timestamp,
         _label_prefix: str,
+        _worker_port: int,
         _accelerator_variant: str,
         _gcp_service: GcpService,
         _ssh_config: config_pb2.SshConfig | None = None,
@@ -255,6 +256,7 @@ class GcpSliceHandle:
         self._labels = _labels
         self._created_at = _created_at
         self._label_prefix = _label_prefix
+        self._worker_port = _worker_port
         self._iris_labels = Labels(_label_prefix)
         self._accelerator_variant = _accelerator_variant
         self._ssh_config = _ssh_config
@@ -371,6 +373,7 @@ class GcpSliceHandle:
                 GcpWorkerHandle(
                     _vm_id=f"{self._slice_id}-worker-{i}",
                     _internal_address=internal_ip,
+                    _port=self._worker_port,
                     _external_address=external_ip,
                     _remote_exec=remote_exec,
                 )
@@ -415,6 +418,7 @@ class GcpVmSliceHandle:
         _labels: dict[str, str],
         _created_at: Timestamp,
         _label_prefix: str,
+        _worker_port: int,
         _gcp_service: GcpService,
         _ssh_config: config_pb2.SshConfig | None = None,
         _service_account: str | None = None,
@@ -428,6 +432,7 @@ class GcpVmSliceHandle:
         self._labels = _labels
         self._created_at = _created_at
         self._label_prefix = _label_prefix
+        self._worker_port = _worker_port
         self._iris_labels = Labels(_label_prefix)
         self._ssh_config = _ssh_config
         self._service_account = _service_account
@@ -495,6 +500,7 @@ class GcpVmSliceHandle:
         worker = GcpStandaloneWorkerHandle(
             _vm_id=f"{self._slice_id}-worker-0",
             _internal_address=vm_info.internal_ip,
+            _port=self._worker_port,
             _external_address=vm_info.external_ip,
             _gce_vm_name=self._vm_name,
             _zone=self._zone,

--- a/lib/iris/src/iris/cluster/providers/gcp/local.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/local.py
@@ -60,8 +60,10 @@ class _LocalWorkerHandle:
         return self._internal_address
 
     @property
-    def port(self) -> int:
-        return self._port
+    def worker_url(self) -> str:
+        if not self._internal_address:
+            return ""
+        return f"http://{self._internal_address}:{self._port}"
 
     @property
     def external_address(self) -> str | None:

--- a/lib/iris/src/iris/cluster/providers/gcp/workers.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/workers.py
@@ -254,11 +254,13 @@ class GcpWorkerProvider:
         self,
         gcp_config: config_pb2.GcpPlatformConfig,
         label_prefix: str,
+        worker_port: int,
         ssh_config: config_pb2.SshConfig | None = None,
         gcp_service: GcpService | None = None,
     ):
         self._project_id = gcp_config.project_id
         self._label_prefix = label_prefix
+        self._worker_port = worker_port
         self._iris_labels = Labels(label_prefix)
         self._ssh_config = ssh_config
         self._zones = list(gcp_config.zones)
@@ -353,6 +355,7 @@ class GcpWorkerProvider:
         return GcpStandaloneWorkerHandle(
             _vm_id=construct_worker_id(config.name, 0),
             _internal_address=vm_info.internal_ip,
+            _port=self._worker_port,
             _external_address=vm_info.external_ip,
             _gce_vm_name=config.name,
             _zone=zone,
@@ -445,6 +448,7 @@ class GcpWorkerProvider:
             _labels=dict(config.labels),
             _created_at=Timestamp.now(),
             _label_prefix=self._label_prefix,
+            _worker_port=self._worker_port,
             _accelerator_variant=config.accelerator_variant,
             _gcp_service=self._gcp,
             _ssh_config=self._ssh_config,
@@ -455,7 +459,7 @@ class GcpWorkerProvider:
         if worker_config:
             _spawn_bootstrap_thread(
                 handle,
-                lambda: _run_tpu_bootstrap(self._gcp, self._project_id, handle, worker_config),
+                lambda: _run_tpu_bootstrap(self._gcp, self._project_id, handle),
             )
 
         return handle
@@ -512,6 +516,7 @@ class GcpWorkerProvider:
             _labels=labels,
             _created_at=Timestamp.now(),
             _label_prefix=self._label_prefix,
+            _worker_port=self._worker_port,
             _accelerator_variant=config.accelerator_variant,
             _gcp_service=self._gcp,
             _ssh_config=self._ssh_config,
@@ -523,7 +528,7 @@ class GcpWorkerProvider:
         if worker_config:
             _spawn_bootstrap_thread(
                 handle,
-                lambda: _run_tpu_bootstrap(self._gcp, self._project_id, handle, worker_config),
+                lambda: _run_tpu_bootstrap(self._gcp, self._project_id, handle),
             )
 
         return handle
@@ -591,6 +596,7 @@ class GcpWorkerProvider:
             _labels=labels,
             _created_at=Timestamp.now(),
             _label_prefix=self._label_prefix,
+            _worker_port=self._worker_port,
             _ssh_config=self._ssh_config,
             _service_account=request.service_account,
             _bootstrapping=worker_config is not None,
@@ -599,7 +605,7 @@ class GcpWorkerProvider:
         if worker_config:
             _spawn_bootstrap_thread(
                 handle,
-                lambda: _run_vm_slice_bootstrap(self._gcp, handle, worker_config),
+                lambda: _run_vm_slice_bootstrap(self._gcp, handle),
             )
 
         return handle
@@ -628,6 +634,7 @@ class GcpWorkerProvider:
                     _labels=tpu.labels,
                     _created_at=tpu.created_at,
                     _label_prefix=self._label_prefix,
+                    _worker_port=self._worker_port,
                     _accelerator_variant=tpu.accelerator_type,
                     _gcp_service=self._gcp,
                     _ssh_config=self._ssh_config,
@@ -653,6 +660,7 @@ class GcpWorkerProvider:
                     _labels=vm.labels,
                     _created_at=vm.created_at,
                     _label_prefix=self._label_prefix,
+                    _worker_port=self._worker_port,
                     _ssh_config=self._ssh_config,
                     _service_account=vm.service_account,
                 )
@@ -694,6 +702,7 @@ class GcpWorkerProvider:
                 _labels=tpu.labels,
                 _created_at=tpu.created_at,
                 _label_prefix=self._label_prefix,
+                _worker_port=self._worker_port,
                 _accelerator_variant=tpu.accelerator_type,
                 _gcp_service=self._gcp,
                 _ssh_config=self._ssh_config,
@@ -721,6 +730,7 @@ class GcpWorkerProvider:
                 or {CAPACITY_TYPE_LABEL: CAPACITY_TYPE_RESERVED_VALUE, self._iris_labels.iris_managed: "true"},
                 _created_at=Timestamp.now(),
                 _label_prefix=self._label_prefix,
+                _worker_port=self._worker_port,
                 _accelerator_variant="",
                 _gcp_service=self._gcp,
                 _ssh_config=self._ssh_config,
@@ -746,6 +756,7 @@ class GcpWorkerProvider:
                 _labels=vm.labels,
                 _created_at=vm.created_at,
                 _label_prefix=self._label_prefix,
+                _worker_port=self._worker_port,
                 _ssh_config=self._ssh_config,
                 _service_account=vm.service_account,
             )
@@ -775,6 +786,7 @@ class GcpWorkerProvider:
                 GcpStandaloneWorkerHandle(
                     _vm_id=construct_worker_id(vm.name, 0),
                     _internal_address=vm.internal_ip,
+                    _port=self._worker_port,
                     _external_address=vm.external_ip,
                     _gce_vm_name=vm.name,
                     _zone=vm.zone,
@@ -799,7 +811,6 @@ def _run_tpu_bootstrap(
     gcp_service: GcpService,
     project_id: str,
     handle: GcpSliceHandle,
-    worker_config: config_pb2.WorkerConfig,
     poll_interval: float = 10.0,
     cloud_ready_timeout: float | None = None,
     bootstrap_timeout: float | None = None,
@@ -866,7 +877,7 @@ def _run_tpu_bootstrap(
         raise InfraError(f"Slice {handle.slice_id} did not reach cloud READY within {effective_cloud_ready_timeout}s")
 
     workers = cloud_status.workers
-    worker_addrs = [(w.worker_id, w.internal_address) for w in workers]
+    worker_urls = [(w.worker_id, w.worker_url) for w in workers]
     healthy_workers: set[str] = set()
     last_probe_errors: dict[str, str] = {}
     health_deadline = Deadline.from_now(Duration.from_seconds(effective_bootstrap_timeout))
@@ -874,19 +885,16 @@ def _run_tpu_bootstrap(
 
     logger.info(
         "Polling health endpoints for %d workers in slice %s",
-        len(worker_addrs),
+        len(worker_urls),
         handle.slice_id,
     )
 
     while not health_deadline.expired():
-        for worker_id, addr in worker_addrs:
+        for worker_id, worker_url in worker_urls:
             if worker_id in healthy_workers:
                 continue
             try:
-                resp = urllib.request.urlopen(
-                    f"http://{addr}:{worker_config.port}/health",
-                    timeout=5,
-                )
+                resp = urllib.request.urlopen(f"{worker_url}/health", timeout=5)
                 if resp.status == 200:
                     healthy_workers.add(worker_id)
                     last_probe_errors.pop(worker_id, None)
@@ -894,32 +902,32 @@ def _run_tpu_bootstrap(
             except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError) as e:
                 last_probe_errors[worker_id] = str(e).strip() or type(e).__name__
 
-        if len(healthy_workers) == len(worker_addrs):
+        if len(healthy_workers) == len(worker_urls):
             break
         if time.monotonic() >= next_progress_log:
-            missing_workers = [worker_id for worker_id, _addr in worker_addrs if worker_id not in healthy_workers]
+            missing_workers = [worker_id for worker_id, _url in worker_urls if worker_id not in healthy_workers]
             logger.info(
                 "TPU bootstrap progress for %s: %d/%d workers healthy; missing=%s",
                 handle.slice_id,
                 len(healthy_workers),
-                len(worker_addrs),
+                len(worker_urls),
                 _summarize_missing_workers(missing_workers, last_probe_errors),
             )
             next_progress_log = time.monotonic() + TPU_BOOTSTRAP_PROGRESS_LOG_INTERVAL
         time.sleep(poll_interval)
     else:
-        missing_workers = [worker_id for worker_id, _addr in worker_addrs if worker_id not in healthy_workers]
+        missing_workers = [worker_id for worker_id, _url in worker_urls if worker_id not in healthy_workers]
         logger.error(
             "TPU bootstrap stalled for %s: %d/%d workers healthy; missing=%s",
             handle.slice_id,
             len(healthy_workers),
-            len(worker_addrs),
+            len(worker_urls),
             _summarize_missing_workers(missing_workers, last_probe_errors),
         )
         _fetch_bootstrap_logs(gcp_service, handle)
         raise InfraError(
             f"TPU slice {handle.slice_id} bootstrap timed out: "
-            f"{len(healthy_workers)}/{len(worker_addrs)} workers healthy"
+            f"{len(healthy_workers)}/{len(worker_urls)} workers healthy"
         )
 
     logger.info("Bootstrap completed for TPU slice %s (%d workers)", handle.slice_id, len(workers))
@@ -944,10 +952,10 @@ def _fetch_bootstrap_logs(gcp_service: GcpService, handle: GcpSliceHandle) -> No
         logger.warning("No Cloud Logging entries found for %s", handle.slice_id)
 
 
-def _probe_worker_health(address: str, port: int) -> bool:
+def _probe_worker_health(worker_url: str) -> bool:
     """Probe the worker's HTTP health endpoint. Returns True if healthy."""
     try:
-        resp = urllib.request.urlopen(f"http://{address}:{port}/health", timeout=5)
+        resp = urllib.request.urlopen(f"{worker_url}/health", timeout=5)
         return resp.status == 200
     except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError):
         return False
@@ -956,7 +964,6 @@ def _probe_worker_health(address: str, port: int) -> bool:
 def _run_vm_slice_bootstrap(
     gcp_service: GcpService,
     handle: GcpVmSliceHandle,
-    worker_config: config_pb2.WorkerConfig,
     poll_interval: float = 5.0,
     cloud_ready_timeout: float = 600.0,
     bootstrap_timeout: float = 300.0,
@@ -985,8 +992,7 @@ def _run_vm_slice_bootstrap(
     else:
         raise InfraError(f"VM slice {handle.slice_id} did not reach cloud READY within {cloud_ready_timeout}s")
 
-    worker_address = cloud_status.workers[0].internal_address
-    worker_port = worker_config.port
+    worker_url = cloud_status.workers[0].worker_url
 
     # Phase 2: poll health endpoint + serial port with a fresh deadline
     bootstrap_deadline = Deadline.from_now(Duration.from_seconds(bootstrap_timeout))
@@ -994,7 +1000,7 @@ def _run_vm_slice_bootstrap(
 
     while not bootstrap_deadline.expired():
         # Primary signal: HTTP health probe
-        if _probe_worker_health(worker_address, worker_port):
+        if _probe_worker_health(worker_url):
             logger.info("Worker health probe succeeded for VM slice %s", handle.slice_id)
             break
 

--- a/lib/iris/src/iris/cluster/providers/local/cluster.py
+++ b/lib/iris/src/iris/cluster/providers/local/cluster.py
@@ -115,6 +115,7 @@ def create_local_autoscaler(
     platform = GcpWorkerProvider(
         gcp_config=local_gcp_config,
         label_prefix=label_prefix,
+        worker_port=config.defaults.worker.port,
         gcp_service=gcp_service,
     )
 

--- a/lib/iris/src/iris/cluster/providers/manual/provider.py
+++ b/lib/iris/src/iris/cluster/providers/manual/provider.py
@@ -108,6 +108,7 @@ class ManualSliceHandle:
         _labels: dict[str, str],
         _created_at: Timestamp,
         _label_prefix: str,
+        _worker_port: int,
         _ssh_connections: list[DirectSshRemoteExec],
         _on_terminate: Callable[[list[str]], None] | None = None,
         _bootstrapping: bool = False,
@@ -117,6 +118,7 @@ class ManualSliceHandle:
         self._labels = _labels
         self._created_at = _created_at
         self._label_prefix = _label_prefix
+        self._worker_port = _worker_port
         self._iris_labels = Labels(_label_prefix)
         self._ssh_connections = _ssh_connections
         self._on_terminate = _on_terminate
@@ -154,6 +156,7 @@ class ManualSliceHandle:
             ManualWorkerHandle(
                 _vm_id=construct_worker_id(self._slice_id, i),
                 _internal_address=host,
+                _port=self._worker_port,
                 _remote_exec=ssh,
             )
             for i, (host, ssh) in enumerate(zip(self._hosts, self._ssh_connections, strict=True))
@@ -201,10 +204,12 @@ class ManualWorkerProvider:
     def __init__(
         self,
         label_prefix: str,
+        worker_port: int,
         ssh_config: config_pb2.SshConfig | None = None,
         hosts: list[str] | None = None,
     ):
         self._label_prefix = label_prefix
+        self._worker_port = worker_port
         self._iris_labels = Labels(label_prefix)
         self._ssh_config = ssh_config
         self._all_hosts = list(hosts or [])
@@ -248,6 +253,7 @@ class ManualWorkerProvider:
         handle = ManualStandaloneWorkerHandle(
             _vm_id=config.name,
             _internal_address=host,
+            _port=self._worker_port,
             _remote_exec=remote_exec,
             _labels=dict(config.labels),
             _metadata=dict(config.metadata),
@@ -296,6 +302,7 @@ class ManualWorkerProvider:
             _labels=dict(config.labels),
             _created_at=Timestamp.now(),
             _label_prefix=self._label_prefix,
+            _worker_port=self._worker_port,
             _ssh_connections=ssh_connections,
             _on_terminate=on_terminate,
             _bootstrapping=worker_config is not None,

--- a/lib/iris/src/iris/cluster/providers/types.py
+++ b/lib/iris/src/iris/cluster/providers/types.py
@@ -226,10 +226,10 @@ class RemoteWorkerHandle(Protocol):
         ...
 
     @property
-    def port(self) -> int | None:
-        """RPC port, or None when the worker serves on the cluster-configured port.
+    def worker_url(self) -> str:
+        """Internal HTTP base URL (``http://host:port``) for the worker's RPC and /health endpoints.
 
-        Only providers that auto-assign ports per worker (LOCAL) report this.
+        Empty string when the worker has no internal address yet (mid-boot).
         """
         ...
 

--- a/lib/iris/src/iris/cluster/worker/main.py
+++ b/lib/iris/src/iris/cluster/worker/main.py
@@ -54,7 +54,11 @@ def serve(worker_config: str):
     with open(worker_config) as f:
         wc_proto = ParseDict(json.load(f), config_pb2.WorkerConfig())
 
-    bundle = create_provider_bundle(platform_config=wc_proto.platform, ssh_config=config_pb2.SshConfig())
+    bundle = create_provider_bundle(
+        platform_config=wc_proto.platform,
+        worker_port=wc_proto.port,
+        ssh_config=config_pb2.SshConfig(),
+    )
     zone = detect_gcp_zone()
 
     def resolve_image(image: str) -> str:

--- a/lib/iris/tests/cluster/controller/conftest.py
+++ b/lib/iris/tests/cluster/controller/conftest.py
@@ -1019,7 +1019,7 @@ def make_gcp_provider(
     """
     service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project", label_prefix="iris")
     gcp_config = config_pb2.GcpPlatformConfig(project_id="test-project", zones=[zone])
-    provider = GcpWorkerProvider(gcp_config=gcp_config, label_prefix="iris", gcp_service=service)
+    provider = GcpWorkerProvider(gcp_config=gcp_config, label_prefix="iris", worker_port=10001, gcp_service=service)
     return provider, service
 
 

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -1593,8 +1593,8 @@ class TestAutoscalerHealthProbe:
         group.reconcile()
         _mark_discovered_ready(group, [handle])
         autoscaler = make_autoscaler({"test-group": group}, base_worker_config=base_worker_config)
-        # Seed worker_addresses since reconcile() bypasses the refresh() path.
-        group.set_worker_addresses(handle.slice_id, autoscaler._worker_endpoints(handle.describe().workers))
+        # Seed worker URLs since reconcile() bypasses the refresh() path.
+        group.set_worker_urls(handle.slice_id, autoscaler._worker_urls(handle.describe().workers))
         return autoscaler, group, handle
 
     def test_healthy_probes_keep_slice_alive(
@@ -1607,7 +1607,7 @@ class TestAutoscalerHealthProbe:
         autoscaler, group, _ = self._setup_ready_group(scale_group_config, base_worker_config)
         monkeypatch.setattr(
             "iris.cluster.controller.autoscaler.runtime._probe_worker_health",
-            lambda endpoint: True,
+            lambda url: True,
         )
 
         for _ in range(20):
@@ -1628,7 +1628,7 @@ class TestAutoscalerHealthProbe:
         autoscaler, group, _ = self._setup_ready_group(scale_group_config, base_worker_config)
         monkeypatch.setattr(
             "iris.cluster.controller.autoscaler.runtime._probe_worker_health",
-            lambda endpoint: False,
+            lambda url: False,
         )
 
         # One probe per tick — need PING_FAILURE_THRESHOLD ticks to trip.
@@ -1655,7 +1655,7 @@ class TestAutoscalerHealthProbe:
         # consecutive failures even after many ticks.
         toggle = {"healthy": False}
 
-        def _probe(endpoint: str) -> bool:
+        def _probe(url: str) -> bool:
             toggle["healthy"] = not toggle["healthy"]
             return toggle["healthy"]
 
@@ -1673,27 +1673,27 @@ class TestAutoscalerHealthProbe:
         base_worker_config: config_pb2.WorkerConfig,
         monkeypatch: pytest.MonkeyPatch,
     ):
-        """Slices restored without cached addresses get them via handle.describe()."""
+        """Slices restored without cached URLs get them via handle.describe()."""
         handle = make_mock_slice_handle("slice-001", all_ready=True)
         platform = make_mock_platform(slices_to_discover=[handle])
         group = ScalingGroup(scale_group_config, platform)
         group.reconcile()
         _mark_discovered_ready(group, [handle])
-        # Deliberately do NOT call set_worker_addresses — simulate post-restart.
+        # Deliberately do NOT call set_worker_urls — simulate post-restart.
         autoscaler = make_autoscaler({"test-group": group}, base_worker_config=base_worker_config)
 
-        seen_endpoints: list[str] = []
+        seen_urls: list[str] = []
 
-        def _probe(endpoint: str) -> bool:
-            seen_endpoints.append(endpoint)
+        def _probe(url: str) -> bool:
+            seen_urls.append(url)
             return True
 
         monkeypatch.setattr("iris.cluster.controller.autoscaler.runtime._probe_worker_health", _probe)
 
         autoscaler.probe_health(Timestamp.from_ms(1_000))
 
-        expected = list(autoscaler._worker_endpoints(handle.describe().workers).values())
-        assert sorted(seen_endpoints) == sorted(expected), "probe should hit each worker's described endpoint"
+        expected = list(autoscaler._worker_urls(handle.describe().workers).values())
+        assert sorted(seen_urls) == sorted(expected), "probe should hit each worker's described URL"
         autoscaler.shutdown()
 
     def test_per_worker_counter_isolates_one_dead_worker(
@@ -1714,14 +1714,14 @@ class TestAutoscalerHealthProbe:
         group.reconcile()
         _mark_discovered_ready(group, [handle])
         autoscaler = make_autoscaler({"test-group": group}, base_worker_config=base_worker_config)
-        endpoints = autoscaler._worker_endpoints(handle.describe().workers)
-        group.set_worker_addresses(handle.slice_id, endpoints)
+        worker_urls = autoscaler._worker_urls(handle.describe().workers)
+        group.set_worker_urls(handle.slice_id, worker_urls)
 
         dead_worker = handle.describe().workers[1]
-        dead_endpoint = endpoints[dead_worker.worker_id]
+        dead_url = worker_urls[dead_worker.worker_id]
         monkeypatch.setattr(
             "iris.cluster.controller.autoscaler.runtime._probe_worker_health",
-            lambda endpoint: endpoint != dead_endpoint,
+            lambda url: url != dead_url,
         )
 
         for _ in range(PING_FAILURE_THRESHOLD):
@@ -1744,9 +1744,9 @@ class TestAutoscalerHealthProbe:
         group = ScalingGroup(scale_group_config, platform)
         group.reconcile()
         _mark_discovered_ready(group, [handle])
-        # No cached addresses; describe() will be called.
+        # No cached URLs; describe() will be called.
         autoscaler = make_autoscaler({"test-group": group}, base_worker_config=base_worker_config)
-        good_addresses = autoscaler._worker_endpoints(handle.describe().workers)
+        good_urls = autoscaler._worker_urls(handle.describe().workers)
 
         raising = {"on": True}
         original_describe = handle.describe
@@ -1759,7 +1759,7 @@ class TestAutoscalerHealthProbe:
         monkeypatch.setattr(handle, "describe", _maybe_raise)
         monkeypatch.setattr(
             "iris.cluster.controller.autoscaler.runtime._probe_worker_health",
-            lambda endpoint: True,
+            lambda url: True,
         )
 
         # PING_FAILURE_THRESHOLD ticks while describe() raises must not terminate.
@@ -1769,24 +1769,30 @@ class TestAutoscalerHealthProbe:
         assert group.get_slice("slice-001") is not None
         assert group.get_slice("slice-001").describe  # sanity: handle still callable next tick
 
-        # Once describe() recovers, the probe resolves addresses and caches them.
+        # Once describe() recovers, the probe resolves URLs and caches them.
         raising["on"] = False
         autoscaler.probe_health(Timestamp.from_ms(2_000))
         cached = group.ready_slice_probe_targets()[0][2]
-        assert cached == good_addresses
+        assert cached == good_urls
         autoscaler.shutdown()
 
-    def test_endpoint_prefers_handle_port_over_cluster_default(
+    def test_worker_urls_pass_through_each_handle(
         self,
         base_worker_config: config_pb2.WorkerConfig,
     ):
-        """Workers that auto-assign ports (LOCAL) probe their own port; others
-        fall back to the cluster-configured worker port."""
+        """_worker_urls maps each worker to its handle's worker_url verbatim.
+
+        Both a config-port worker (GCP/manual) and an auto-assigned-port worker
+        (LOCAL) yield a well-formed http://host:port URL with no double port.
+        """
         autoscaler = make_autoscaler({}, base_worker_config=base_worker_config)
         gcp_style = make_mock_worker_handle("w-gcp", "10.0.0.1", vm_pb2.VM_STATE_READY)
         local_style = FakeWorkerHandle(_vm_id="w-local", _internal_address="127.0.0.1", _port=54321)
 
-        endpoints = autoscaler._worker_endpoints([gcp_style, local_style])
+        worker_urls = autoscaler._worker_urls([gcp_style, local_style])
 
-        assert endpoints == {"w-gcp": "10.0.0.1:10001", "w-local": "127.0.0.1:54321"}
+        assert worker_urls == {
+            "w-gcp": "http://10.0.0.1:10001",
+            "w-local": "http://127.0.0.1:54321",
+        }
         autoscaler.shutdown()

--- a/lib/iris/tests/cluster/controller/test_autoscaler_integration.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler_integration.py
@@ -387,7 +387,7 @@ def test_pending_counter_prevents_double_scaleup():
     )
     service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project", label_prefix="iris")
     gcp_config = config_pb2.GcpPlatformConfig(project_id="test-project", zones=["us-central1-a"])
-    platform = SlowGcpWorkerProvider(gcp_config=gcp_config, label_prefix="iris", gcp_service=service)
+    platform = SlowGcpWorkerProvider(gcp_config=gcp_config, label_prefix="iris", worker_port=10001, gcp_service=service)
     group = ScalingGroup(
         sg_config,
         platform,

--- a/lib/iris/tests/cluster/controller/test_vm_lifecycle.py
+++ b/lib/iris/tests/cluster/controller/test_vm_lifecycle.py
@@ -89,8 +89,10 @@ class FakeWorkerHandle:
         return self._internal_address
 
     @property
-    def port(self) -> int | None:
-        return None
+    def worker_url(self) -> str:
+        if not self._internal_address:
+            return ""
+        return f"http://{self._internal_address}:10001"
 
     @property
     def external_address(self) -> str | None:

--- a/lib/iris/tests/cluster/providers/conftest.py
+++ b/lib/iris/tests/cluster/providers/conftest.py
@@ -46,7 +46,7 @@ class FakeWorkerHandle:
     _internal_address: str
     _state: CloudWorkerState = CloudWorkerState.RUNNING
     _bootstrap_log: str = ""
-    _port: int | None = None
+    _port: int = 10001
 
     @property
     def worker_id(self) -> str:
@@ -61,8 +61,10 @@ class FakeWorkerHandle:
         return self._internal_address
 
     @property
-    def port(self) -> int | None:
-        return self._port
+    def worker_url(self) -> str:
+        if not self._internal_address:
+            return ""
+        return f"http://{self._internal_address}:{self._port}"
 
     @property
     def external_address(self) -> str | None:

--- a/lib/iris/tests/cluster/providers/gcp/test_bootstrap.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_bootstrap.py
@@ -167,7 +167,7 @@ def _make_gcp_worker_provider(project_id: str = "my-proj"):
 
     gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id=project_id)
     gcp_config = config_pb2.GcpPlatformConfig(project_id=project_id)
-    return GcpWorkerProvider(gcp_config=gcp_config, label_prefix="iris", gcp_service=gcp_service)
+    return GcpWorkerProvider(gcp_config=gcp_config, label_prefix="iris", worker_port=10001, gcp_service=gcp_service)
 
 
 def test_gcp_provider_resolve_image_rewrites_ghcr() -> None:

--- a/lib/iris/tests/cluster/providers/gcp/test_platform.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_platform.py
@@ -95,11 +95,12 @@ def platform_env(request) -> Iterator[PlatformEnv]:
     if name == "gcp":
         gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
         gcp_config = config_pb2.GcpPlatformConfig(project_id="test-project", zones=["us-central2-b"])
-        platform = GcpWorkerProvider(gcp_config, label_prefix="iris", gcp_service=gcp_service)
+        platform = GcpWorkerProvider(gcp_config, label_prefix="iris", worker_port=10001, gcp_service=gcp_service)
         yield PlatformEnv(platform=platform, zone="us-central2-b", name="gcp", label_prefix="iris")
     else:
         platform = ManualWorkerProvider(
             label_prefix="iris",
+            worker_port=10001,
             hosts=["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5"],
         )
         yield PlatformEnv(platform=platform, zone="manual", name="manual", label_prefix="iris")
@@ -176,7 +177,7 @@ def test_shutdown_completes_without_error(platform_env: PlatformEnv):
 
 def test_terminate_then_status_is_deleting():
     """After terminate(), slice status reports DELETING."""
-    platform = ManualWorkerProvider(label_prefix="iris", hosts=["10.0.0.1", "10.0.0.2", "10.0.0.3"])
+    platform = ManualWorkerProvider(label_prefix="iris", worker_port=10001, hosts=["10.0.0.1", "10.0.0.2", "10.0.0.3"])
     cfg = config_pb2.SliceConfig(name_prefix="iris-term-group", num_vms=2)
     cfg.manual.CopyFrom(config_pb2.ManualSliceConfig())
     cfg.labels[Labels("iris").iris_managed] = "true"
@@ -189,7 +190,7 @@ def test_terminate_then_status_is_deleting():
 
 def test_tunnel_returns_address_directly():
     """tunnel() is a passthrough on ManualControllerProvider (no SSH)."""
-    worker_provider = ManualWorkerProvider(label_prefix="iris", hosts=["10.0.0.1"])
+    worker_provider = ManualWorkerProvider(label_prefix="iris", worker_port=10001, hosts=["10.0.0.1"])
     controller = ManualControllerProvider(worker_provider=worker_provider)
     addr = "http://10.0.0.1:10000"
     with controller.tunnel(addr) as tunneled:
@@ -204,7 +205,9 @@ def test_gcp_tunnel_prefers_ssh_impersonation_config():
         key_file="/tmp/iris-oslogin",
         impersonate_service_account="iris-controller@test-project.iam.gserviceaccount.com",
     )
-    worker_provider = GcpWorkerProvider(gcp_config, label_prefix="iris", ssh_config=ssh_config, gcp_service=gcp_service)
+    worker_provider = GcpWorkerProvider(
+        gcp_config, label_prefix="iris", worker_port=10001, ssh_config=ssh_config, gcp_service=gcp_service
+    )
     controller = GcpControllerProvider(
         worker_provider=worker_provider,
         controller_service_account="iris-worker@test-project.iam.gserviceaccount.com",
@@ -289,7 +292,7 @@ def test_gcp_quota_error_raises_quota_exhausted():
     gcp_service.inject_failure("tpu_create", QuotaExhaustedError("RESOURCE_EXHAUSTED: no capacity"))
 
     gcp_config = config_pb2.GcpPlatformConfig(project_id="test-project")
-    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", gcp_service=gcp_service)
+    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", worker_port=10001, gcp_service=gcp_service)
 
     cfg = config_pb2.SliceConfig(
         name_prefix="iris-tpu-group",
@@ -359,7 +362,7 @@ def test_gcp_create_vm_slice_mode_produces_single_worker_slice():
     """VM slice mode creates a single-worker slice that is discoverable and terminable."""
     gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
     gcp_config = config_pb2.GcpPlatformConfig(project_id="test-project", zones=["us-central2-b"])
-    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", gcp_service=gcp_service)
+    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", worker_port=10001, gcp_service=gcp_service)
 
     cfg = config_pb2.SliceConfig(
         name_prefix="iris-cpu-vm",
@@ -402,7 +405,7 @@ def test_gcp_build_gce_resource_name_bounds_and_normalizes():
 def test_gcp_create_vm_slice_mode_with_long_prefix_uses_valid_slice_id():
     gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
     gcp_config = config_pb2.GcpPlatformConfig(project_id="test-project", zones=["us-central2-b"])
-    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", gcp_service=gcp_service)
+    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", worker_port=10001, gcp_service=gcp_service)
 
     cfg = config_pb2.SliceConfig(
         name_prefix="smoke-cpu_vm_e2_standard_4_ondemand-europe-west4-b",
@@ -433,7 +436,9 @@ def test_gcp_vm_slice_os_login_sets_metadata_and_uses_gcloud_default_user():
         auth_mode=config_pb2.SshConfig.SSH_AUTH_MODE_OS_LOGIN,
         key_file="/tmp/iris-oslogin",
     )
-    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", ssh_config=ssh_config, gcp_service=gcp_service)
+    platform = GcpWorkerProvider(
+        gcp_config, label_prefix="iris", worker_port=10001, ssh_config=ssh_config, gcp_service=gcp_service
+    )
 
     cfg = config_pb2.SliceConfig(
         name_prefix="iris-cpu-vm",
@@ -463,7 +468,9 @@ def test_gcp_vm_slice_os_login_uses_service_account_impersonation():
         auth_mode=config_pb2.SshConfig.SSH_AUTH_MODE_OS_LOGIN,
         key_file="/tmp/iris-oslogin",
     )
-    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", ssh_config=ssh_config, gcp_service=gcp_service)
+    platform = GcpWorkerProvider(
+        gcp_config, label_prefix="iris", worker_port=10001, ssh_config=ssh_config, gcp_service=gcp_service
+    )
 
     cfg = config_pb2.SliceConfig(
         name_prefix="iris-cpu-vm",
@@ -489,7 +496,9 @@ def test_gcp_vm_slice_os_login_prefers_explicit_ssh_impersonation_account():
         key_file="/tmp/iris-oslogin",
         impersonate_service_account="iris-controller@test-project.iam.gserviceaccount.com",
     )
-    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", ssh_config=ssh_config, gcp_service=gcp_service)
+    platform = GcpWorkerProvider(
+        gcp_config, label_prefix="iris", worker_port=10001, ssh_config=ssh_config, gcp_service=gcp_service
+    )
 
     cfg = config_pb2.SliceConfig(
         name_prefix="iris-cpu-vm",
@@ -512,7 +521,7 @@ def test_gcp_empty_accelerator_variant_rejected():
     """create_slice with empty accelerator_variant raises ValueError."""
     gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
     gcp_config = config_pb2.GcpPlatformConfig(project_id="test-project")
-    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", gcp_service=gcp_service)
+    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", worker_port=10001, gcp_service=gcp_service)
 
     cfg = config_pb2.SliceConfig(
         name_prefix="iris-tpu-group",
@@ -529,7 +538,7 @@ def test_gcp_create_vm_validates_config():
     """create_vm with empty zone raises ValueError."""
     gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
     gcp_config = config_pb2.GcpPlatformConfig(project_id="test-project")
-    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", gcp_service=gcp_service)
+    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", worker_port=10001, gcp_service=gcp_service)
 
     cfg = config_pb2.VmConfig(name="test-vm")
 
@@ -541,7 +550,7 @@ def test_gcp_list_slices_skips_deleting_tpus():
     """list_slices omits TPUs in DELETING state."""
     gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
     gcp_config = config_pb2.GcpPlatformConfig(project_id="test-project")
-    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", gcp_service=gcp_service)
+    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", worker_port=10001, gcp_service=gcp_service)
 
     cfg = config_pb2.SliceConfig(
         name_prefix="iris-tpu",
@@ -569,7 +578,7 @@ def test_gcp_create_slice_resolves_ghcr_image_in_worker_config():
     """create_slice rewrites GHCR images in worker_config via resolve_image."""
     gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="my-proj")
     gcp_config = config_pb2.GcpPlatformConfig(project_id="my-proj")
-    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", gcp_service=gcp_service)
+    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", worker_port=10001, gcp_service=gcp_service)
 
     cfg = config_pb2.SliceConfig(
         name_prefix="iris-tpu",
@@ -597,7 +606,7 @@ def test_gcp_list_all_slices_includes_terminated_vm_instances():
     reconciler can reclaim them. list_slices (live discovery) still filters."""
     gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
     gcp_config = config_pb2.GcpPlatformConfig(project_id="test-project", zones=["us-central2-b"])
-    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", gcp_service=gcp_service)
+    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", worker_port=10001, gcp_service=gcp_service)
 
     cfg = config_pb2.SliceConfig(
         name_prefix="iris-cpu-vm",
@@ -630,7 +639,7 @@ def test_gcp_list_slices_preserves_vm_slice_discovery():
     """VM-backed slices are discoverable via list_all_slices after creation."""
     gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
     gcp_config = config_pb2.GcpPlatformConfig(project_id="test-project", zones=["us-central2-b"])
-    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", gcp_service=gcp_service)
+    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", worker_port=10001, gcp_service=gcp_service)
 
     cfg = config_pb2.SliceConfig(
         name_prefix="iris-cpu-vm",
@@ -660,7 +669,7 @@ def test_gcp_list_slices_preserves_vm_slice_discovery():
 
 def test_manual_host_pool_exhaustion_raises():
     """create_slice raises when not enough hosts are available."""
-    platform = ManualWorkerProvider(label_prefix="iris", hosts=["10.0.0.1"])
+    platform = ManualWorkerProvider(label_prefix="iris", worker_port=10001, hosts=["10.0.0.1"])
     cfg = config_pb2.SliceConfig(name_prefix="iris-group", num_vms=3)
     cfg.manual.CopyFrom(config_pb2.ManualSliceConfig())
 
@@ -670,7 +679,7 @@ def test_manual_host_pool_exhaustion_raises():
 
 def test_manual_host_exclusivity():
     """A host allocated to one VM cannot be allocated to another."""
-    platform = ManualWorkerProvider(label_prefix="iris", hosts=["10.0.0.1", "10.0.0.2"])
+    platform = ManualWorkerProvider(label_prefix="iris", worker_port=10001, hosts=["10.0.0.1", "10.0.0.2"])
 
     cfg1 = config_pb2.VmConfig(name="ctrl-1")
     cfg1.manual.host = "10.0.0.1"
@@ -684,7 +693,7 @@ def test_manual_host_exclusivity():
 
 def test_manual_terminated_host_returns_to_pool():
     """After terminating a VM, its host can be reallocated."""
-    platform = ManualWorkerProvider(label_prefix="iris", hosts=["10.0.0.1"])
+    platform = ManualWorkerProvider(label_prefix="iris", worker_port=10001, hosts=["10.0.0.1"])
 
     cfg = config_pb2.VmConfig(name="ctrl")
     cfg.manual.host = "10.0.0.1"
@@ -702,7 +711,7 @@ def test_manual_terminated_host_returns_to_pool():
 
 def test_manual_slice_terminate_returns_hosts():
     """Terminating a slice returns all its hosts to the pool."""
-    platform = ManualWorkerProvider(label_prefix="iris", hosts=["10.0.0.1", "10.0.0.2", "10.0.0.3"])
+    platform = ManualWorkerProvider(label_prefix="iris", worker_port=10001, hosts=["10.0.0.1", "10.0.0.2", "10.0.0.3"])
 
     cfg = config_pb2.SliceConfig(name_prefix="iris-group", num_vms=2)
     cfg.manual.CopyFrom(config_pb2.ManualSliceConfig())
@@ -767,7 +776,7 @@ def test_gcp_list_all_slices_multi_zone():
         project_id="test-project",
         zones=["zone-a", "zone-b"],
     )
-    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", gcp_service=gcp_service)
+    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", worker_port=10001, gcp_service=gcp_service)
 
     iris_labels = Labels("iris")
     cfg_a = config_pb2.SliceConfig(
@@ -806,7 +815,7 @@ def test_gcp_tpu_slice_passes_startup_script_metadata():
     """_create_tpu_slice with worker_config embeds startup-script in TPU metadata."""
     gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
     gcp_config = config_pb2.GcpPlatformConfig(project_id="test-project")
-    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", gcp_service=gcp_service)
+    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", worker_port=10001, gcp_service=gcp_service)
 
     cfg = config_pb2.SliceConfig(
         name_prefix="iris-tpu",
@@ -843,7 +852,9 @@ def test_gcp_tpu_slice_os_login_sets_metadata_and_uses_direct_ssh():
         os_login_user="ci-user",
         key_file="/tmp/iris-oslogin",
     )
-    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", ssh_config=ssh_config, gcp_service=gcp_service)
+    platform = GcpWorkerProvider(
+        gcp_config, label_prefix="iris", worker_port=10001, ssh_config=ssh_config, gcp_service=gcp_service
+    )
 
     cfg = config_pb2.SliceConfig(
         name_prefix="iris-tpu",
@@ -872,7 +883,9 @@ def test_gcp_tpu_slice_os_login_resolves_user_from_service_account():
         auth_mode=config_pb2.SshConfig.SSH_AUTH_MODE_OS_LOGIN,
         key_file="/tmp/iris-oslogin",
     )
-    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", ssh_config=ssh_config, gcp_service=gcp_service)
+    platform = GcpWorkerProvider(
+        gcp_config, label_prefix="iris", worker_port=10001, ssh_config=ssh_config, gcp_service=gcp_service
+    )
 
     cfg = config_pb2.SliceConfig(
         name_prefix="iris-tpu",
@@ -902,7 +915,9 @@ def test_gcp_tpu_slice_os_login_prefers_explicit_ssh_impersonation_account():
         key_file="/tmp/iris-oslogin",
         impersonate_service_account="iris-controller@test-project.iam.gserviceaccount.com",
     )
-    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", ssh_config=ssh_config, gcp_service=gcp_service)
+    platform = GcpWorkerProvider(
+        gcp_config, label_prefix="iris", worker_port=10001, ssh_config=ssh_config, gcp_service=gcp_service
+    )
 
     cfg = config_pb2.SliceConfig(
         name_prefix="iris-tpu",
@@ -932,7 +947,9 @@ def test_gcp_tpu_slice_os_login_prefers_external_ip_for_direct_ssh():
         os_login_user="svc-user",
         key_file="/tmp/iris-oslogin",
     )
-    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", ssh_config=ssh_config, gcp_service=gcp_service)
+    platform = GcpWorkerProvider(
+        gcp_config, label_prefix="iris", worker_port=10001, ssh_config=ssh_config, gcp_service=gcp_service
+    )
 
     cfg = config_pb2.SliceConfig(
         name_prefix="iris-tpu",
@@ -985,6 +1002,7 @@ def _make_vm_slice_for_bootstrap(
         _labels={Labels("iris").iris_slice_id: vm_name},
         _created_at=Timestamp.now(),
         _label_prefix="iris",
+        _worker_port=10001,
         _bootstrapping=True,
     )
     return handle, vm_name
@@ -994,7 +1012,6 @@ def test_vm_bootstrap_health_probe_succeeds_without_serial_port():
     """Bootstrap completes when health probe succeeds, even if serial port never shows 'Bootstrap complete'."""
     gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
     handle, _vm_name = _make_vm_slice_for_bootstrap(gcp_service)
-    worker_config = config_pb2.WorkerConfig(port=10001)
 
     with unittest.mock.patch(
         "iris.cluster.providers.gcp.workers._probe_worker_health",
@@ -1003,7 +1020,6 @@ def test_vm_bootstrap_health_probe_succeeds_without_serial_port():
         _run_vm_slice_bootstrap(
             gcp_service,
             handle,
-            worker_config,
             poll_interval=0.01,
             cloud_ready_timeout=5.0,
             bootstrap_timeout=5.0,
@@ -1016,7 +1032,6 @@ def test_vm_bootstrap_serial_port_succeeds_without_health_probe():
     """Bootstrap completes via serial port 'Bootstrap complete' when health probe fails."""
     gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
     handle, vm_name = _make_vm_slice_for_bootstrap(gcp_service)
-    worker_config = config_pb2.WorkerConfig(port=10001)
 
     gcp_service.set_serial_port_output(
         vm_name,
@@ -1031,7 +1046,6 @@ def test_vm_bootstrap_serial_port_succeeds_without_health_probe():
         _run_vm_slice_bootstrap(
             gcp_service,
             handle,
-            worker_config,
             poll_interval=0.01,
             cloud_ready_timeout=5.0,
             bootstrap_timeout=5.0,
@@ -1044,7 +1058,6 @@ def test_vm_bootstrap_serial_port_error_raises():
     """Bootstrap fails immediately when serial port shows '[iris-init] ERROR'."""
     gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
     handle, vm_name = _make_vm_slice_for_bootstrap(gcp_service)
-    worker_config = config_pb2.WorkerConfig(port=10001)
 
     gcp_service.set_serial_port_output(
         vm_name,
@@ -1060,7 +1073,6 @@ def test_vm_bootstrap_serial_port_error_raises():
             _run_vm_slice_bootstrap(
                 gcp_service,
                 handle,
-                worker_config,
                 poll_interval=0.01,
                 cloud_ready_timeout=5.0,
                 bootstrap_timeout=5.0,
@@ -1071,7 +1083,6 @@ def test_vm_bootstrap_phase2_has_independent_timeout():
     """Phase 2 uses its own timeout, not the remainder from phase 1."""
     gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
     handle, _vm_name = _make_vm_slice_for_bootstrap(gcp_service)
-    worker_config = config_pb2.WorkerConfig(port=10001)
 
     # Health probe never succeeds, serial port never shows complete.
     # With a very short bootstrap_timeout, this should fail with phase 2 message.
@@ -1083,7 +1094,6 @@ def test_vm_bootstrap_phase2_has_independent_timeout():
             _run_vm_slice_bootstrap(
                 gcp_service,
                 handle,
-                worker_config,
                 poll_interval=0.01,
                 cloud_ready_timeout=600.0,
                 bootstrap_timeout=0.05,
@@ -1118,15 +1128,14 @@ def test_vm_bootstrap_cloud_not_ready_raises_phase1_timeout():
         _labels={Labels("iris").iris_slice_id: vm_name},
         _created_at=Timestamp.now(),
         _label_prefix="iris",
+        _worker_port=10001,
         _bootstrapping=True,
     )
-    worker_config = config_pb2.WorkerConfig(port=10001)
 
     with pytest.raises(InfraError, match=r"did not reach cloud READY within 0\.05s"):
         _run_vm_slice_bootstrap(
             gcp_service,
             handle,
-            worker_config,
             poll_interval=0.01,
             cloud_ready_timeout=0.05,
             bootstrap_timeout=300.0,

--- a/lib/iris/tests/cluster/providers/gcp/test_vm_lifecycle.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_vm_lifecycle.py
@@ -32,7 +32,7 @@ def test_tpu_quota_exceeded_retry():
     """TPU creation fails with quota exceeded, retries successfully after clearing."""
     service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
     service.set_zone_quota("us-central2-b", 0)
-    platform = GcpWorkerProvider(_make_gcp_config(), label_prefix="test", gcp_service=service)
+    platform = GcpWorkerProvider(_make_gcp_config(), label_prefix="test", worker_port=10001, gcp_service=service)
 
     with pytest.raises(QuotaExhaustedError):
         platform.create_slice(_make_slice_config())
@@ -53,7 +53,7 @@ def test_tpu_quota_exceeded_retry():
 def test_tpu_init_stuck():
     """TPU never becomes READY (stuck in CREATING)."""
     service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
-    platform = GcpWorkerProvider(_make_gcp_config(), label_prefix="test", gcp_service=service)
+    platform = GcpWorkerProvider(_make_gcp_config(), label_prefix="test", worker_port=10001, gcp_service=service)
     handle = platform.create_slice(_make_slice_config("stuck"))
 
     # TPU stays in CREATING (we never advance it to READY)
@@ -64,7 +64,7 @@ def test_tpu_init_stuck():
 def test_tpu_preempted():
     """TPU reaches READY, then termination destroys the slice."""
     service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
-    platform = GcpWorkerProvider(_make_gcp_config(), label_prefix="test", gcp_service=service)
+    platform = GcpWorkerProvider(_make_gcp_config(), label_prefix="test", worker_port=10001, gcp_service=service)
     handle = platform.create_slice(_make_slice_config("preempt"))
 
     # Advance to READY

--- a/lib/iris/tests/cluster/providers/test_config.py
+++ b/lib/iris/tests/cluster/providers/test_config.py
@@ -352,6 +352,7 @@ scale_groups:
         config = load_config(config_path)
         bundle = create_provider_bundle(
             platform_config=config.platform,
+            worker_port=config.defaults.worker.port,
             ssh_config=config.defaults.ssh,
         )
         autoscaler = create_autoscaler(
@@ -399,6 +400,7 @@ scale_groups:
         config = load_config(config_path)
         bundle = create_provider_bundle(
             platform_config=config.platform,
+            worker_port=config.defaults.worker.port,
             ssh_config=config.defaults.ssh,
         )
         autoscaler = create_autoscaler(
@@ -457,6 +459,7 @@ scale_groups:
         # Should be able to create autoscaler from round-tripped config
         bundle = create_provider_bundle(
             platform_config=loaded_config.platform,
+            worker_port=loaded_config.defaults.worker.port,
             ssh_config=loaded_config.defaults.ssh,
         )
         autoscaler = create_autoscaler(


### PR DESCRIPTION
Every RemoteWorkerHandle now exposes worker_url (http://host:port), a single directly-usable endpoint, instead of a bare internal_address plus a port that only LOCAL handles carried. The worker RPC port is threaded from cluster config through the GCP and manual providers to each minted handle; LOCAL keeps its auto-assigned per-worker ports. The autoscaler health probe and GCP bootstrap polls consume worker_url directly, removing the per-consumer host+port stitching that produced malformed probe URLs in LOCAL mode.

Follow-up to #5848.