### PR TITLE
[zephyr] Support splitting parquet files and returning them at batches

### DIFF
--- a/lib/zephyr/src/zephyr/__init__.py
+++ b/lib/zephyr/src/zephyr/__init__.py
@@ -16,13 +16,22 @@ from zephyr.execution import (
 )
 from zephyr.expr import Expr, col, lit
 from zephyr.plan import compute_plan
-from zephyr.readers import InputFileSpec, load_file, load_jsonl, load_parquet, load_vortex, load_zip_members
+from zephyr.readers import (
+    DEFAULT_FILE_PATH_COLUMN,
+    InputFileSpec,
+    load_file,
+    load_jsonl,
+    load_parquet,
+    load_vortex,
+    load_zip_members,
+)
 from zephyr.writers import atomic_rename, write_jsonl_file, write_parquet_file, write_vortex_file
 
 logger = logging.getLogger(__name__)
 
 
 __all__ = [
+    "DEFAULT_FILE_PATH_COLUMN",
     "Dataset",
     "Expr",
     "InputFileSpec",

--- a/lib/zephyr/src/zephyr/dataset.py
+++ b/lib/zephyr/src/zephyr/dataset.py
@@ -238,6 +238,7 @@ class LoadFileOp:
 
     format: Literal["auto", "parquet", "jsonl", "vortex"] = "auto"
     columns: list[str] | None = None
+    max_shard_bytes: int | None = None
 
     def __repr__(self):
         return f"LoadFileOp(format={self.format}, columns={self.columns})"
@@ -564,11 +565,13 @@ class Dataset(Generic[T]):
         """
         return Dataset(self.source, [*self.operations, FlatMapOp(fn)])
 
-    def load_file(self, columns: list[str] | None = None) -> Dataset[dict]:
+    def load_file(self, columns: list[str] | None = None, max_shard_bytes: int | None = None) -> Dataset[dict]:
         """Load records from file sources, auto-detecting format.
 
         Args:
             columns: Optional column projection (for parquet files)
+            max_shard_bytes: If set, split parquet files into chunks of at most this
+                many bytes (aligned to row-group boundaries) for finer parallelism.
 
         Returns:
             Dataset yielding records as dictionaries
@@ -582,11 +585,17 @@ class Dataset(Generic[T]):
             ... )
             >>> output_files = ctx.execute(ds).results
         """
-        return Dataset(self.source, [*self.operations, LoadFileOp("auto", columns)])
+        return Dataset(self.source, [*self.operations, LoadFileOp("auto", columns, max_shard_bytes)])
 
-    def load_parquet(self, columns: list[str] | None = None) -> Dataset[dict]:
-        """Load records from parquet files."""
-        return Dataset(self.source, [*self.operations, LoadFileOp("parquet", columns)])
+    def load_parquet(self, columns: list[str] | None = None, max_shard_bytes: int | None = None) -> Dataset[dict]:
+        """Load records from parquet files.
+
+        Args:
+            columns: Optional column projection.
+            max_shard_bytes: If set, split each file into chunks of at most this many
+                bytes (aligned to row-group boundaries) for finer parallelism.
+        """
+        return Dataset(self.source, [*self.operations, LoadFileOp("parquet", columns, max_shard_bytes)])
 
     def load_jsonl(self) -> Dataset[dict]:
         """Load records from JSONL files."""

--- a/lib/zephyr/src/zephyr/dataset.py
+++ b/lib/zephyr/src/zephyr/dataset.py
@@ -240,6 +240,7 @@ class LoadFileOp:
     columns: list[str] | None = None
     max_shard_bytes: int | None = None
     include_file_paths: str | None = None
+    batch_mode: bool = False
 
     def __repr__(self):
         return f"LoadFileOp(format={self.format}, columns={self.columns})"
@@ -613,6 +614,30 @@ class Dataset(Generic[T]):
         return Dataset(
             self.source, [*self.operations, LoadFileOp("parquet", columns, max_shard_bytes, include_file_paths)]
         )
+
+    def load_parquet_batch(
+        self,
+        columns: list[str] | None = None,
+        max_shard_bytes: int | None = None,
+        include_file_paths: str | None = None,
+    ) -> Dataset:
+        """Load records from parquet files as ``pa.RecordBatch`` objects.
+
+        Args:
+            columns: Optional column projection.
+            max_shard_bytes: If set, split each file into chunks of at most this many
+                bytes (aligned to row-group boundaries) for finer parallelism.
+            include_file_paths: If set, add a column with this name containing the
+                source file path for each batch.
+        """
+        op = LoadFileOp(
+            format="parquet",
+            columns=columns,
+            max_shard_bytes=max_shard_bytes,
+            include_file_paths=include_file_paths,
+            batch_mode=True,
+        )
+        return Dataset(self.source, [*self.operations, op])
 
     def load_jsonl(self, include_file_paths: str | None = None) -> Dataset[dict]:
         """Load records from JSONL files.

--- a/lib/zephyr/src/zephyr/dataset.py
+++ b/lib/zephyr/src/zephyr/dataset.py
@@ -14,10 +14,11 @@ from typing import Any, Generic, Literal, TypeVar, cast, overload
 
 import fsspec
 from braceexpand import braceexpand
+from pyarrow import RecordBatch
 from rigging.filesystem import url_to_fs
 
 from zephyr.expr import Expr
-from zephyr.readers import InputFileSpec
+from zephyr.readers import DEFAULT_FILE_PATH_COLUMN, InputFileSpec
 
 logger = logging.getLogger(__name__)
 
@@ -238,8 +239,9 @@ class LoadFileOp:
 
     format: Literal["auto", "parquet", "jsonl", "vortex"] = "auto"
     columns: list[str] | None = None
-    max_shard_bytes: int | None = None
-    include_file_paths: str | None = None
+    approx_shard_bytes: int | None = None
+    include_file_paths: bool = False
+    file_path_column: str = DEFAULT_FILE_PATH_COLUMN
     batch_mode: bool = False
 
     def __repr__(self):
@@ -570,17 +572,20 @@ class Dataset(Generic[T]):
     def load_file(
         self,
         columns: list[str] | None = None,
-        max_shard_bytes: int | None = None,
-        include_file_paths: str | None = None,
+        approx_shard_bytes: int | None = None,
+        include_file_paths: bool = False,
+        file_path_column: str = DEFAULT_FILE_PATH_COLUMN,
     ) -> Dataset[dict]:
         """Load records from file sources, auto-detecting format.
 
         Args:
             columns: Optional column projection (for parquet files)
-            max_shard_bytes: If set, split parquet files into chunks of at most this
-                many bytes (aligned to row-group boundaries) for finer parallelism.
-            include_file_paths: If set, add a column with this name containing the
-                source file path for each record.
+            approx_shard_bytes: If set, split parquet files into approximately this many
+                bytes per shard, aligned to row-group boundaries. Best-effort: a single
+                row group will never be split, so shards may exceed this size.
+            include_file_paths: If True, add a column containing the source file path
+                for each record.
+            file_path_column: Name of the column to add when include_file_paths is True.
 
         Returns:
             Dataset yielding records as dictionaries
@@ -594,69 +599,99 @@ class Dataset(Generic[T]):
             ... )
             >>> output_files = ctx.execute(ds).results
         """
-        return Dataset(self.source, [*self.operations, LoadFileOp("auto", columns, max_shard_bytes, include_file_paths)])
+        return Dataset(
+            self.source,
+            [*self.operations, LoadFileOp("auto", columns, approx_shard_bytes, include_file_paths, file_path_column)],
+        )
+
+    @overload
+    def load_parquet(
+        self,
+        columns: list[str] | None = ...,
+        approx_shard_bytes: int | None = ...,
+        include_file_paths: bool = ...,
+        file_path_column: str = ...,
+        *,
+        batch_mode: Literal[False] = ...,
+    ) -> Dataset[dict]: ...
+
+    @overload
+    def load_parquet(
+        self,
+        columns: list[str] | None = ...,
+        approx_shard_bytes: int | None = ...,
+        include_file_paths: bool = ...,
+        file_path_column: str = ...,
+        *,
+        batch_mode: Literal[True],
+    ) -> Dataset[RecordBatch]: ...
 
     def load_parquet(
         self,
         columns: list[str] | None = None,
-        max_shard_bytes: int | None = None,
-        include_file_paths: str | None = None,
-    ) -> Dataset[dict]:
+        approx_shard_bytes: int | None = None,
+        include_file_paths: bool = False,
+        file_path_column: str = DEFAULT_FILE_PATH_COLUMN,
+        *,
+        batch_mode: bool = False,
+    ) -> Dataset[dict] | Dataset[RecordBatch]:
         """Load records from parquet files.
 
         Args:
             columns: Optional column projection.
-            max_shard_bytes: If set, split each file into chunks of at most this many
-                bytes (aligned to row-group boundaries) for finer parallelism.
-            include_file_paths: If set, add a column with this name containing the
-                source file path for each record.
-        """
-        return Dataset(
-            self.source, [*self.operations, LoadFileOp("parquet", columns, max_shard_bytes, include_file_paths)]
-        )
-
-    def load_parquet_batch(
-        self,
-        columns: list[str] | None = None,
-        max_shard_bytes: int | None = None,
-        include_file_paths: str | None = None,
-    ) -> Dataset:
-        """Load records from parquet files as ``pa.RecordBatch`` objects.
-
-        Args:
-            columns: Optional column projection.
-            max_shard_bytes: If set, split each file into chunks of at most this many
-                bytes (aligned to row-group boundaries) for finer parallelism.
-            include_file_paths: If set, add a column with this name containing the
-                source file path for each batch.
+            approx_shard_bytes: If set, split each file into approximately this many
+                bytes per shard, aligned to row-group boundaries. Best-effort: a single
+                row group will never be split, so shards may exceed this size.
+            include_file_paths: If True, add a column containing the source file path
+                for each record or batch.
+            file_path_column: Name of the column to add when include_file_paths is True.
+            batch_mode: If True, yield ``pa.RecordBatch`` objects instead of dicts.
         """
         op = LoadFileOp(
             format="parquet",
             columns=columns,
-            max_shard_bytes=max_shard_bytes,
+            approx_shard_bytes=approx_shard_bytes,
             include_file_paths=include_file_paths,
-            batch_mode=True,
+            file_path_column=file_path_column,
+            batch_mode=batch_mode,
         )
         return Dataset(self.source, [*self.operations, op])
 
-    def load_jsonl(self, include_file_paths: str | None = None) -> Dataset[dict]:
+    def load_jsonl(
+        self,
+        include_file_paths: bool = False,
+        file_path_column: str = DEFAULT_FILE_PATH_COLUMN,
+    ) -> Dataset[dict]:
         """Load records from JSONL files.
 
         Args:
-            include_file_paths: If set, add a column with this name containing the
-                source file path for each record.
+            include_file_paths: If True, add a column containing the source file path
+                for each record.
+            file_path_column: Name of the column to add when include_file_paths is True.
         """
-        return Dataset(self.source, [*self.operations, LoadFileOp("jsonl", None, None, include_file_paths)])
+        return Dataset(
+            self.source,
+            [*self.operations, LoadFileOp("jsonl", None, None, include_file_paths, file_path_column)],
+        )
 
-    def load_vortex(self, columns: list[str] | None = None, include_file_paths: str | None = None) -> Dataset[dict]:
+    def load_vortex(
+        self,
+        columns: list[str] | None = None,
+        include_file_paths: bool = False,
+        file_path_column: str = DEFAULT_FILE_PATH_COLUMN,
+    ) -> Dataset[dict]:
         """Load records from Vortex files.
 
         Args:
             columns: Optional column projection.
-            include_file_paths: If set, add a column with this name containing the
-                source file path for each record.
+            include_file_paths: If True, add a column containing the source file path
+                for each record.
+            file_path_column: Name of the column to add when include_file_paths is True.
         """
-        return Dataset(self.source, [*self.operations, LoadFileOp("vortex", columns, None, include_file_paths)])
+        return Dataset(
+            self.source,
+            [*self.operations, LoadFileOp("vortex", columns, None, include_file_paths, file_path_column)],
+        )
 
     def map_shard(
         self,

--- a/lib/zephyr/src/zephyr/dataset.py
+++ b/lib/zephyr/src/zephyr/dataset.py
@@ -239,6 +239,7 @@ class LoadFileOp:
     format: Literal["auto", "parquet", "jsonl", "vortex"] = "auto"
     columns: list[str] | None = None
     max_shard_bytes: int | None = None
+    include_file_paths: str | None = None
 
     def __repr__(self):
         return f"LoadFileOp(format={self.format}, columns={self.columns})"
@@ -565,13 +566,20 @@ class Dataset(Generic[T]):
         """
         return Dataset(self.source, [*self.operations, FlatMapOp(fn)])
 
-    def load_file(self, columns: list[str] | None = None, max_shard_bytes: int | None = None) -> Dataset[dict]:
+    def load_file(
+        self,
+        columns: list[str] | None = None,
+        max_shard_bytes: int | None = None,
+        include_file_paths: str | None = None,
+    ) -> Dataset[dict]:
         """Load records from file sources, auto-detecting format.
 
         Args:
             columns: Optional column projection (for parquet files)
             max_shard_bytes: If set, split parquet files into chunks of at most this
                 many bytes (aligned to row-group boundaries) for finer parallelism.
+            include_file_paths: If set, add a column with this name containing the
+                source file path for each record.
 
         Returns:
             Dataset yielding records as dictionaries
@@ -585,25 +593,45 @@ class Dataset(Generic[T]):
             ... )
             >>> output_files = ctx.execute(ds).results
         """
-        return Dataset(self.source, [*self.operations, LoadFileOp("auto", columns, max_shard_bytes)])
+        return Dataset(self.source, [*self.operations, LoadFileOp("auto", columns, max_shard_bytes, include_file_paths)])
 
-    def load_parquet(self, columns: list[str] | None = None, max_shard_bytes: int | None = None) -> Dataset[dict]:
+    def load_parquet(
+        self,
+        columns: list[str] | None = None,
+        max_shard_bytes: int | None = None,
+        include_file_paths: str | None = None,
+    ) -> Dataset[dict]:
         """Load records from parquet files.
 
         Args:
             columns: Optional column projection.
             max_shard_bytes: If set, split each file into chunks of at most this many
                 bytes (aligned to row-group boundaries) for finer parallelism.
+            include_file_paths: If set, add a column with this name containing the
+                source file path for each record.
         """
-        return Dataset(self.source, [*self.operations, LoadFileOp("parquet", columns, max_shard_bytes)])
+        return Dataset(
+            self.source, [*self.operations, LoadFileOp("parquet", columns, max_shard_bytes, include_file_paths)]
+        )
 
-    def load_jsonl(self) -> Dataset[dict]:
-        """Load records from JSONL files."""
-        return Dataset(self.source, [*self.operations, LoadFileOp("jsonl", None)])
+    def load_jsonl(self, include_file_paths: str | None = None) -> Dataset[dict]:
+        """Load records from JSONL files.
 
-    def load_vortex(self, columns: list[str] | None = None) -> Dataset[dict]:
-        """Load records from Vortex files."""
-        return Dataset(self.source, [*self.operations, LoadFileOp("vortex", columns)])
+        Args:
+            include_file_paths: If set, add a column with this name containing the
+                source file path for each record.
+        """
+        return Dataset(self.source, [*self.operations, LoadFileOp("jsonl", None, None, include_file_paths)])
+
+    def load_vortex(self, columns: list[str] | None = None, include_file_paths: str | None = None) -> Dataset[dict]:
+        """Load records from Vortex files.
+
+        Args:
+            columns: Optional column projection.
+            include_file_paths: If set, add a column with this name containing the
+                source file path for each record.
+        """
+        return Dataset(self.source, [*self.operations, LoadFileOp("vortex", columns, None, include_file_paths)])
 
     def map_shard(
         self,

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -47,7 +47,7 @@ from zephyr.dataset import (
 )
 from zephyr.expr import Expr
 from zephyr.external_sort import compute_fan_in, compute_write_batch_size, external_sort_merge
-from zephyr.readers import InputFileSpec, load_file
+from zephyr.readers import InputFileSpec, compute_parquet_splits, load_file
 
 logger = logging.getLogger(__name__)
 
@@ -511,19 +511,43 @@ def _compute_file_pushdown(
         else:
             break
 
-    # Create InputFileSpecs with final columns/filter
-    source_items = [
-        SourceItem(
-            shard_idx=i,
-            data=InputFileSpec(
-                path=entry.path,
-                format=load_op.format,
-                columns=select_columns,
-                filter_expr=filter_expr,
-            ),
-        )
-        for i, entry in enumerate(files)
-    ]
+    # Create InputFileSpecs with final columns/filter.
+    # When max_shard_bytes is set, parquet files are split at row-group boundaries
+    # into multiple SourceItems, each covering a sub-range of rows.
+    source_items: list[SourceItem] = []
+    shard_idx = 0
+    for entry in files:
+        path = entry.path
+        is_parquet = load_op.format == "parquet" or (load_op.format == "auto" and path.endswith(".parquet"))
+        if load_op.max_shard_bytes is not None and is_parquet:
+            for row_start, row_end in compute_parquet_splits(path, load_op.max_shard_bytes):
+                source_items.append(
+                    SourceItem(
+                        shard_idx=shard_idx,
+                        data=InputFileSpec(
+                            path=path,
+                            format=load_op.format,
+                            columns=select_columns,
+                            row_start=row_start,
+                            row_end=row_end,
+                            filter_expr=filter_expr,
+                        ),
+                    )
+                )
+                shard_idx += 1
+        else:
+            source_items.append(
+                SourceItem(
+                    shard_idx=shard_idx,
+                    data=InputFileSpec(
+                        path=path,
+                        format=load_op.format,
+                        columns=select_columns,
+                        filter_expr=filter_expr,
+                    ),
+                )
+            )
+            shard_idx += 1
 
     # Build final operations list: LoadFileOp + remaining ops
     final_ops = [load_op] + [op for i, op in enumerate(operations) if i not in ops_to_skip]

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -20,6 +20,7 @@ from itertools import groupby, islice
 from typing import Any, Protocol
 
 import msgspec
+import pyarrow as pa
 import xxhash
 from iris.env_resources import TaskResources as _TaskResources
 from rigging.filesystem import url_to_fs
@@ -47,7 +48,7 @@ from zephyr.dataset import (
 )
 from zephyr.expr import Expr
 from zephyr.external_sort import compute_fan_in, compute_write_batch_size, external_sort_merge
-from zephyr.readers import InputFileSpec, compute_parquet_splits, load_file
+from zephyr.readers import InputFileSpec, compute_parquet_splits, load_file, load_file_batch
 
 logger = logging.getLogger(__name__)
 
@@ -194,6 +195,21 @@ def _select_gen(stream: Iterator, columns: tuple[str, ...]) -> Iterator:
         yield {k: item[k] for k in columns if k in item}
 
 
+def _load_file_batch_gen(stream: Iterator, *, include_file_paths: str | None = None) -> Iterator:
+    for spec in stream:
+        try:
+            for batch in load_file_batch(spec):
+                if include_file_paths is not None:
+                    batch = batch.append_column(
+                        include_file_paths,
+                        pa.array([spec.path] * len(batch), type=pa.string()),
+                    )
+                yield batch
+        except Exception as e:
+            e.add_note(f"While loading from {spec}")
+            raise
+
+
 def _load_file_gen(stream: Iterator, *, include_file_paths: str | None = None) -> Iterator:
     for spec in stream:
         try:
@@ -222,7 +238,10 @@ def compose_map(operations: list) -> Callable[[Iterator], Iterator]:
     def pipeline(stream: Iterator, *, shard_idx: int = 0, total_shards: int = 1) -> Iterator:
         for op in operations:
             if isinstance(op, LoadFileOp):
-                stream = _load_file_gen(stream, include_file_paths=op.include_file_paths)
+                if op.batch_mode:
+                    stream = _load_file_batch_gen(stream, include_file_paths=op.include_file_paths)
+                else:
+                    stream = _load_file_gen(stream, include_file_paths=op.include_file_paths)
             elif isinstance(op, MapOp):
                 stream = _map_gen(stream, op.fn)
             elif isinstance(op, FilterOp):

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -20,7 +20,6 @@ from itertools import groupby, islice
 from typing import Any, Protocol
 
 import msgspec
-import pyarrow as pa
 import xxhash
 from iris.env_resources import TaskResources as _TaskResources
 from rigging.filesystem import url_to_fs
@@ -46,7 +45,7 @@ from zephyr.dataset import (
     WriteOp,
     resolve_glob,
 )
-from zephyr.expr import Expr
+from zephyr.expr import Expr, referenced_columns
 from zephyr.external_sort import compute_fan_in, compute_write_batch_size, external_sort_merge
 from zephyr.readers import InputFileSpec, compute_parquet_splits, load_file, load_file_batch
 
@@ -195,30 +194,19 @@ def _select_gen(stream: Iterator, columns: tuple[str, ...]) -> Iterator:
         yield {k: item[k] for k in columns if k in item}
 
 
-def _load_file_batch_gen(stream: Iterator, *, include_file_paths: str | None = None) -> Iterator:
+def _load_file_batch_gen(stream: Iterator, *, include_file_paths: bool = False, file_path_column: str) -> Iterator:
     for spec in stream:
         try:
-            for batch in load_file_batch(spec):
-                if include_file_paths is not None:
-                    batch = batch.append_column(
-                        include_file_paths,
-                        pa.array([spec.path] * len(batch), type=pa.string()),
-                    )
-                yield batch
+            yield from load_file_batch(spec, include_file_paths=include_file_paths, file_path_column=file_path_column)
         except Exception as e:
             e.add_note(f"While loading from {spec}")
             raise
 
 
-def _load_file_gen(stream: Iterator, *, include_file_paths: str | None = None) -> Iterator:
+def _load_file_gen(stream: Iterator, *, include_file_paths: bool = False, file_path_column: str) -> Iterator:
     for spec in stream:
         try:
-            if include_file_paths is not None:
-                for record in load_file(spec):
-                    record[include_file_paths] = spec.path
-                    yield record
-            else:
-                yield from load_file(spec)
+            yield from load_file(spec, include_file_paths=include_file_paths, file_path_column=file_path_column)
         except Exception as e:
             e.add_note(f"While loading from {spec}")
             raise
@@ -239,9 +227,13 @@ def compose_map(operations: list) -> Callable[[Iterator], Iterator]:
         for op in operations:
             if isinstance(op, LoadFileOp):
                 if op.batch_mode:
-                    stream = _load_file_batch_gen(stream, include_file_paths=op.include_file_paths)
+                    stream = _load_file_batch_gen(
+                        stream, include_file_paths=op.include_file_paths, file_path_column=op.file_path_column
+                    )
                 else:
-                    stream = _load_file_gen(stream, include_file_paths=op.include_file_paths)
+                    stream = _load_file_gen(
+                        stream, include_file_paths=op.include_file_paths, file_path_column=op.file_path_column
+                    )
             elif isinstance(op, MapOp):
                 stream = _map_gen(stream, op.fn)
             elif isinstance(op, FilterOp):
@@ -520,6 +512,11 @@ def _compute_file_pushdown(
 
     for i, op in enumerate(operations):
         if isinstance(op, FilterOp) and op.expr is not None and filter_expr is None:
+            if load_op.include_file_paths and load_op.file_path_column in referenced_columns(op.expr):
+                # The filter references the injected file path column, which doesn't
+                # exist in the source files. Stop pushdown so the filter runs normally
+                # in the pipeline after the column has been injected.
+                break
             filter_expr = op.expr
             ops_to_skip.add(i)
         elif isinstance(op, SelectOp) and select_columns is None:
@@ -536,15 +533,16 @@ def _compute_file_pushdown(
             break
 
     # Create InputFileSpecs with final columns/filter.
-    # When max_shard_bytes is set, parquet files are split at row-group boundaries
-    # into multiple SourceItems, each covering a sub-range of rows.
+    # When approx_shard_bytes is set, parquet files are split at row-group boundaries
+    # into multiple SourceItems. Splits are best-effort: a row group is never divided,
+    # so a shard can exceed approx_shard_bytes when a single row group is larger.
     source_items: list[SourceItem] = []
     shard_idx = 0
     for entry in files:
         path = entry.path
         is_parquet = load_op.format == "parquet" or (load_op.format == "auto" and path.endswith(".parquet"))
-        if load_op.max_shard_bytes is not None and is_parquet:
-            for row_start, row_end in compute_parquet_splits(path, load_op.max_shard_bytes):
+        if load_op.approx_shard_bytes is not None and is_parquet:
+            for row_start, row_end in compute_parquet_splits(path, load_op.approx_shard_bytes):
                 source_items.append(
                     SourceItem(
                         shard_idx=shard_idx,

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -537,7 +537,6 @@ def _compute_file_pushdown(
     # into multiple SourceItems. Splits are best-effort: a row group is never divided,
     # so a shard can exceed approx_shard_bytes when a single row group is larger.
     source_items: list[SourceItem] = []
-    shard_idx = 0
     for entry in files:
         path = entry.path
         is_parquet = load_op.format == "parquet" or (load_op.format == "auto" and path.endswith(".parquet"))
@@ -545,7 +544,7 @@ def _compute_file_pushdown(
             for row_start, row_end in compute_parquet_splits(path, load_op.approx_shard_bytes):
                 source_items.append(
                     SourceItem(
-                        shard_idx=shard_idx,
+                        shard_idx=len(source_items),
                         data=InputFileSpec(
                             path=path,
                             format=load_op.format,
@@ -556,11 +555,10 @@ def _compute_file_pushdown(
                         ),
                     )
                 )
-                shard_idx += 1
         else:
             source_items.append(
                 SourceItem(
-                    shard_idx=shard_idx,
+                    shard_idx=len(source_items),
                     data=InputFileSpec(
                         path=path,
                         format=load_op.format,
@@ -569,7 +567,6 @@ def _compute_file_pushdown(
                     ),
                 )
             )
-            shard_idx += 1
 
     # Build final operations list: LoadFileOp + remaining ops
     final_ops = [load_op] + [op for i, op in enumerate(operations) if i not in ops_to_skip]

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -194,10 +194,15 @@ def _select_gen(stream: Iterator, columns: tuple[str, ...]) -> Iterator:
         yield {k: item[k] for k in columns if k in item}
 
 
-def _load_file_gen(stream: Iterator) -> Iterator:
+def _load_file_gen(stream: Iterator, *, include_file_paths: str | None = None) -> Iterator:
     for spec in stream:
         try:
-            yield from load_file(spec)
+            if include_file_paths is not None:
+                for record in load_file(spec):
+                    record[include_file_paths] = spec.path
+                    yield record
+            else:
+                yield from load_file(spec)
         except Exception as e:
             e.add_note(f"While loading from {spec}")
             raise
@@ -217,7 +222,7 @@ def compose_map(operations: list) -> Callable[[Iterator], Iterator]:
     def pipeline(stream: Iterator, *, shard_idx: int = 0, total_shards: int = 1) -> Iterator:
         for op in operations:
             if isinstance(op, LoadFileOp):
-                stream = _load_file_gen(stream)
+                stream = _load_file_gen(stream, include_file_paths=op.include_file_paths)
             elif isinstance(op, MapOp):
                 stream = _map_gen(stream, op.fn)
             elif isinstance(op, FilterOp):

--- a/lib/zephyr/src/zephyr/readers.py
+++ b/lib/zephyr/src/zephyr/readers.py
@@ -300,29 +300,19 @@ def load_jsonl(source: str | InputFileSpec) -> Iterator[dict]:
             yield record
 
 
-def load_parquet(source: str | InputFileSpec) -> Iterator[dict]:
-    """Load Parquet file and yield records as dicts.
+def load_parquet_batch(source: str | InputFileSpec) -> Iterator[pa.RecordBatch]:
+    """Load a Parquet file and yield one ``pa.RecordBatch`` per row group.
 
-    When given an InputFileSpec with row_start/row_end, reads only the exact rows
-    in that range. Row groups are read efficiently (only overlapping groups are loaded),
-    then rows are filtered to the precise range. When filter_expr is provided, the filter
-    is pushed down to PyArrow for efficient filtering at read time.
+    Applies the same column projection, row-range slicing, and filter pushdown
+    as ``load_parquet``, but returns Arrow batches rather than Python dicts so
+    callers can stay in the columnar world.
 
     Args:
         source: Path to Parquet file or InputFileSpec containing the path, columns,
             row range, and filter expression.
 
     Yields:
-        Records as dictionaries
-
-    Example:
-        >>> ds = (Dataset
-        ...     .from_files("/input", "**/*.parquet")
-        ...     .load_parquet()
-        ...     .map(lambda r: transform_record(r))
-        ...     .write_jsonl("/output/data-{shard:05d}.jsonl.gz")
-        ... )
-        >>> output_files = ctx.execute(ds).results
+        One ``pa.RecordBatch`` per qualifying row group.
     """
     spec = _as_spec(source)
     logger.info("Loading: %s", spec.path)
@@ -352,7 +342,35 @@ def load_parquet(source: str | InputFileSpec) -> Iterator[dict]:
         if need_project:
             table = table.select(spec.columns)
         counters.increment("zephyr/records_in", len(table))
-        yield from table.to_pylist()
+        yield from table.to_batches()
+
+
+def load_parquet(source: str | InputFileSpec) -> Iterator[dict]:
+    """Load Parquet file and yield records as dicts.
+
+    When given an InputFileSpec with row_start/row_end, reads only the exact rows
+    in that range. Row groups are read efficiently (only overlapping groups are loaded),
+    then rows are filtered to the precise range. When filter_expr is provided, the filter
+    is pushed down to PyArrow for efficient filtering at read time.
+
+    Args:
+        source: Path to Parquet file or InputFileSpec containing the path, columns,
+            row range, and filter expression.
+
+    Yields:
+        Records as dictionaries
+
+    Example:
+        >>> ds = (Dataset
+        ...     .from_files("/input", "**/*.parquet")
+        ...     .load_parquet()
+        ...     .map(lambda r: transform_record(r))
+        ...     .write_jsonl("/output/data-{shard:05d}.jsonl.gz")
+        ... )
+        >>> output_files = ctx.execute(ds).results
+    """
+    for batch in load_parquet_batch(source):
+        yield from batch.to_pylist()
 
 
 def load_vortex(source: str | InputFileSpec) -> Iterator[dict]:
@@ -458,6 +476,28 @@ def load_file(source: str | InputFileSpec) -> Iterator[dict]:
         yield from load_vortex(spec)
     else:
         yield from load_jsonl(spec)
+
+
+def load_file_batch(source: str | InputFileSpec) -> Iterator[pa.RecordBatch]:
+    """Load a Parquet file and yield ``pa.RecordBatch`` objects.
+
+    Only Parquet files are supported. Raises ``RuntimeError`` for any other
+    file type so callers get a clear error rather than silent dict conversion.
+
+    Args:
+        source: Path to Parquet file or InputFileSpec containing the path, columns,
+            row range, and filter expression.
+
+    Yields:
+        One ``pa.RecordBatch`` per qualifying row group.
+
+    Raises:
+        RuntimeError: If the file is not a Parquet file.
+    """
+    spec = _as_spec(source)
+    if not spec.path.endswith(".parquet"):
+        raise RuntimeError(f"load_file_batch only supports Parquet files, got: {spec.path}")
+    yield from load_parquet_batch(spec)
 
 
 def load_zip_members(source: str | InputFileSpec, pattern: str = "*") -> Iterator[dict]:

--- a/lib/zephyr/src/zephyr/readers.py
+++ b/lib/zephyr/src/zephyr/readers.py
@@ -213,6 +213,42 @@ def open_file(file_path: str, mode: str = "rb"):
         yield f
 
 
+def compute_parquet_splits(path: str, max_shard_bytes: int) -> list[tuple[int, int]]:
+    """Compute row-range split points from Parquet footer metadata.
+
+    Reads only the file footer — no data is transferred. Returns a list of
+    (row_start, row_end) pairs aligned to row-group boundaries. Files whose
+    total compressed size is below max_shard_bytes return a single span.
+
+    Args:
+        path: Path to the Parquet file (local or remote via fsspec).
+        max_shard_bytes: Target split size in bytes.
+
+    Returns:
+        List of (row_start, row_end) tuples where row_end is exclusive.
+    """
+    metadata = pq.ParquetFile(path).metadata
+    splits: list[tuple[int, int]] = []
+    split_start = 0
+    split_bytes = 0
+    cumulative_rows = 0
+
+    for i in range(metadata.num_row_groups):
+        rg = metadata.row_group(i)
+        rg_bytes = rg.total_byte_size
+
+        if split_bytes > 0 and split_bytes + rg_bytes > max_shard_bytes:
+            splits.append((split_start, cumulative_rows))
+            split_start = cumulative_rows
+            split_bytes = 0
+
+        split_bytes += rg_bytes
+        cumulative_rows += rg.num_rows
+
+    splits.append((split_start, cumulative_rows))
+    return splits
+
+
 def load_jsonl(source: str | InputFileSpec) -> Iterator[dict]:
     """Load a JSONL file and yield parsed records as dictionaries.
 

--- a/lib/zephyr/src/zephyr/readers.py
+++ b/lib/zephyr/src/zephyr/readers.py
@@ -13,7 +13,7 @@ import logging
 import zipfile
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal
 
 import fsspec
@@ -28,6 +28,8 @@ from zephyr import counters
 from zephyr.expr import Expr, referenced_columns, to_pyarrow_expr
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_FILE_PATH_COLUMN = "__file_path"
 
 
 # ---------------------------------------------------------------------------
@@ -213,16 +215,18 @@ def open_file(file_path: str, mode: str = "rb"):
         yield f
 
 
-def compute_parquet_splits(path: str, max_shard_bytes: int) -> list[tuple[int, int]]:
+def compute_parquet_splits(path: str, approx_shard_bytes: int) -> list[tuple[int, int]]:
     """Compute row-range split points from Parquet footer metadata.
 
-    Reads only the file footer — no data is transferred. Returns a list of
-    (row_start, row_end) pairs aligned to row-group boundaries. Files whose
-    total compressed size is below max_shard_bytes return a single span.
+    Reads only the file footer — no data is transferred. Splits are aligned to
+    row-group boundaries, so actual shard sizes may exceed approx_shard_bytes when
+    a single row group is larger than the target. Files whose total compressed size
+    is below approx_shard_bytes return a single span.
 
     Args:
         path: Path to the Parquet file (local or remote via fsspec).
-        max_shard_bytes: Target split size in bytes.
+        approx_shard_bytes: Approximate target split size in bytes. Best-effort:
+            a row group will never be split, so individual shards may be larger.
 
     Returns:
         List of (row_start, row_end) tuples where row_end is exclusive.
@@ -237,7 +241,7 @@ def compute_parquet_splits(path: str, max_shard_bytes: int) -> list[tuple[int, i
         rg = metadata.row_group(i)
         rg_bytes = rg.total_byte_size
 
-        if split_bytes > 0 and split_bytes + rg_bytes > max_shard_bytes:
+        if split_bytes > 0 and split_bytes + rg_bytes > approx_shard_bytes:
             splits.append((split_start, cumulative_rows))
             split_start = cumulative_rows
             split_bytes = 0
@@ -442,18 +446,26 @@ SUPPORTED_EXTENSIONS = tuple(
 )
 
 
-def load_file(source: str | InputFileSpec) -> Iterator[dict]:
+def load_file(
+    source: str | InputFileSpec,
+    include_file_paths: bool = False,
+    file_path_column: str = DEFAULT_FILE_PATH_COLUMN,
+) -> Iterator[dict]:
     """Load records from file, auto-detecting JSONL, Parquet, or Vortex format.
 
     Args:
         source: Path to file or InputFileSpec containing the path, columns,
             row range, and filter expression.
+        include_file_paths: If True, inject the source file path into each record
+            under file_path_column.
+        file_path_column: Key to add when include_file_paths is True.
 
     Yields:
         Parsed records as dictionaries
 
     Raises:
         ValueError: If file extension is not supported
+        RuntimeError: If file_path_column already exists in a record.
 
     Example:
         >>> ds = (Dataset
@@ -470,15 +482,36 @@ def load_file(source: str | InputFileSpec) -> Iterator[dict]:
     if not spec.path.endswith(SUPPORTED_EXTENSIONS):
         raise ValueError(f"Unsupported extension: {spec.path}.")
 
+    if include_file_paths and spec.columns is not None:
+        if file_path_column not in spec.columns:
+            raise RuntimeError(f"Column filter must include file path column '{file_path_column}'.")
+        # Strip the injected column from the reader projection — it isn't in the file.
+        reader_columns = [c for c in spec.columns if c != file_path_column]
+        spec = replace(spec, columns=reader_columns or None)
+
     if spec.path.endswith(".parquet"):
-        yield from load_parquet(spec)
+        records = load_parquet(spec)
     elif spec.path.endswith(".vortex"):
-        yield from load_vortex(spec)
+        records = load_vortex(spec)
     else:
-        yield from load_jsonl(spec)
+        records = load_jsonl(spec)
+
+    if not include_file_paths:
+        yield from records
+        return
+
+    for record in records:
+        if file_path_column in record:
+            raise RuntimeError(f"Cannot add file path column '{file_path_column}': key already exists in record")
+        record[file_path_column] = spec.path
+        yield record
 
 
-def load_file_batch(source: str | InputFileSpec) -> Iterator[pa.RecordBatch]:
+def load_file_batch(
+    source: str | InputFileSpec,
+    include_file_paths: bool = False,
+    file_path_column: str = DEFAULT_FILE_PATH_COLUMN,
+) -> Iterator[pa.RecordBatch]:
     """Load a Parquet file and yield ``pa.RecordBatch`` objects.
 
     Only Parquet files are supported. Raises ``RuntimeError`` for any other
@@ -487,17 +520,37 @@ def load_file_batch(source: str | InputFileSpec) -> Iterator[pa.RecordBatch]:
     Args:
         source: Path to Parquet file or InputFileSpec containing the path, columns,
             row range, and filter expression.
+        include_file_paths: If True, append a string column named file_path_column
+            containing the source file path to each batch.
+        file_path_column: Name of the column to add when include_file_paths is True.
 
     Yields:
         One ``pa.RecordBatch`` per qualifying row group.
 
     Raises:
-        RuntimeError: If the file is not a Parquet file.
+        RuntimeError: If the file is not a Parquet file, or if file_path_column
+            already exists in the batch schema.
     """
     spec = _as_spec(source)
     if not spec.path.endswith(".parquet"):
         raise RuntimeError(f"load_file_batch only supports Parquet files, got: {spec.path}")
-    yield from load_parquet_batch(spec)
+    if include_file_paths and spec.columns is not None:
+        if file_path_column not in spec.columns:
+            raise RuntimeError(f"Column filter does not include the file path column '{file_path_column}'.")
+        # Strip the injected column from the parquet projection — it isn't in the file.
+        parquet_columns = [c for c in spec.columns if c != file_path_column]
+        spec = replace(spec, columns=parquet_columns or None)
+    for batch in load_parquet_batch(spec):
+        if include_file_paths:
+            if file_path_column in batch.schema.names:
+                raise RuntimeError(
+                    f"Cannot add file path column '{file_path_column}': column already exists in batch schema"
+                )
+            batch = batch.append_column(
+                file_path_column,
+                pa.array([spec.path] * len(batch), type=pa.string()),
+            )
+        yield batch
 
 
 def load_zip_members(source: str | InputFileSpec, pattern: str = "*") -> Iterator[dict]:

--- a/lib/zephyr/tests/test_dataset.py
+++ b/lib/zephyr/tests/test_dataset.py
@@ -7,14 +7,16 @@ import json
 from functools import partial
 from pathlib import Path
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 from fray import ResourceConfig
 from fray.local_backend import LocalClient
-from zephyr import Dataset, load_file, load_parquet
+from zephyr import Dataset, col, load_file, load_parquet
 from zephyr._test_helpers import SampleDataclass
 from zephyr.dataset import FilterOp, GlobSource, MapOp, WindowOp, resolve_glob
-from zephyr.execution import ZephyrContext
-from zephyr.readers import DEFAULT_FILE_PATH_COLUMN
+from zephyr.execution import ZephyrContext, ZephyrWorkerError
+from zephyr.readers import DEFAULT_FILE_PATH_COLUMN, InputFileSpec
 from zephyr.writers import write_parquet_file
 
 
@@ -569,8 +571,6 @@ def test_load_file_unsupported_extension(tmp_path, zephyr_ctx):
     ds = Dataset.from_files(str(input_dir), "*.txt").flat_map(load_file)
 
     # Worker errors are wrapped in ZephyrWorkerError
-    from zephyr.execution import ZephyrWorkerError
-
     with pytest.raises(ZephyrWorkerError, match="Unsupported"):
         zephyr_ctx.execute(ds)
 
@@ -587,8 +587,6 @@ def test_write_without_shard_pattern_multiple_shards(tmp_path, zephyr_ctx):
     ds = Dataset.from_list(sample_data).write_jsonl(str(output_dir / "output.jsonl"))
 
     # Worker errors are wrapped in ZephyrWorkerError
-    from zephyr.execution import ZephyrWorkerError
-
     with pytest.raises(ZephyrWorkerError, match="Output pattern must"):
         zephyr_ctx.execute(ds)
 
@@ -901,8 +899,6 @@ def test_map_shard_error_propagation(zephyr_ctx):
 
     ds = Dataset.from_list([list(range(1, 6))]).flat_map(lambda x: x).map_shard(failing_generator)
 
-    from zephyr.execution import ZephyrWorkerError
-
     with pytest.raises(ZephyrWorkerError, match="Test error"):
         zephyr_ctx.execute(ds)
 
@@ -1079,8 +1075,6 @@ def test_repr_handles_lambdas():
 
 def test_filter_with_expression(zephyr_ctx):
     """Test filter with expression on in-memory data."""
-    from zephyr import col
-
     ds = Dataset.from_list(
         [
             {"name": "alice", "score": 80},
@@ -1096,8 +1090,6 @@ def test_filter_with_expression(zephyr_ctx):
 
 def test_filter_expression_equality(zephyr_ctx):
     """Test filter with equality expression."""
-    from zephyr import col
-
     ds = Dataset.from_list(
         [
             {"category": "A", "value": 1},
@@ -1113,8 +1105,6 @@ def test_filter_expression_equality(zephyr_ctx):
 
 def test_filter_expression_logical_and(zephyr_ctx):
     """Test filter with logical AND expression."""
-    from zephyr import col
-
     ds = Dataset.from_list(
         [
             {"a": 1, "b": 2},
@@ -1131,8 +1121,6 @@ def test_filter_expression_logical_and(zephyr_ctx):
 
 def test_filter_expression_logical_or(zephyr_ctx):
     """Test filter with logical OR expression."""
-    from zephyr import col
-
     ds = Dataset.from_list(
         [
             {"a": 1, "b": 2},
@@ -1148,8 +1136,6 @@ def test_filter_expression_logical_or(zephyr_ctx):
 
 def test_filter_nested_field(zephyr_ctx):
     """Test filter with nested field access."""
-    from zephyr import col
-
     ds = Dataset.from_list(
         [
             {"id": 1, "meta": {"score": 0.9}},
@@ -1205,8 +1191,6 @@ def test_select_preserves_column_order(zephyr_ctx):
 
 def test_filter_and_select_combined(zephyr_ctx):
     """Test combined filter and select."""
-    from zephyr import col
-
     ds = (
         Dataset.from_list(
             [
@@ -1227,8 +1211,6 @@ def test_filter_and_select_combined(zephyr_ctx):
 @pytest.mark.parametrize("output_format", ["parquet", "jsonl"])
 def test_filter_and_select(tmp_path, zephyr_ctx, output_format: str):
     """Test combined filter and select on parquet."""
-    from zephyr import col
-
     ds = Dataset.from_list(
         [
             {"id": 1, "name": "alice", "score": 80, "extra": "x"},
@@ -1257,9 +1239,6 @@ def test_filter_and_select(tmp_path, zephyr_ctx, output_format: str):
 
 def test_filter_expression_repr():
     """Test FilterOp repr with expression."""
-    from zephyr import col
-    from zephyr.dataset import FilterOp
-
     expr = col("score") > 50
     op = FilterOp(predicate=expr.evaluate, expr=expr)
     assert "FilterOp(expr=" in repr(op)
@@ -1268,8 +1247,6 @@ def test_filter_expression_repr():
 
 def test_mixed_filter_expression_and_lambda(zephyr_ctx):
     """Test combining expression filter with lambda filter."""
-    from zephyr import col
-
     ds = (
         Dataset.from_list(
             [
@@ -1295,8 +1272,6 @@ def test_mixed_filter_expression_and_lambda(zephyr_ctx):
 
 def test_input_file_spec_row_range_basic(tmp_path):
     """Test InputFileSpec reads only the specified row range."""
-    from zephyr.readers import InputFileSpec, load_parquet
-
     data = [{"id": i, "value": i * 10} for i in range(100)]
     input_path = tmp_path / "data.parquet"
     write_parquet_file(data, str(input_path))
@@ -1317,8 +1292,6 @@ def test_input_file_spec_row_range_basic(tmp_path):
 
 def test_input_file_spec_with_columns_and_row_range(tmp_path):
     """Test InputFileSpec with both columns and row_range."""
-    from zephyr.readers import InputFileSpec, load_parquet
-
     data = [{"id": i, "name": f"item_{i}", "value": i * 10} for i in range(50)]
     input_path = tmp_path / "data.parquet"
     write_parquet_file(data, str(input_path))
@@ -1427,9 +1400,6 @@ def test_sorted_merge_join_after_group_by_integration(integration_ctx):
 
 def test_dataset_load_parquet_batch(tmp_path, zephyr_ctx):
     """load_parquet(batch_mode=True) yields pa.RecordBatch objects."""
-    import pyarrow as pa
-    import pyarrow.parquet as pq
-
     path = str(tmp_path / "data.parquet")
     records = [{"id": i, "val": float(i)} for i in range(6)]
     pq.write_table(pa.Table.from_pylist(records), path, row_group_size=2)
@@ -1444,9 +1414,6 @@ def test_dataset_load_parquet_batch(tmp_path, zephyr_ctx):
 
 def test_dataset_load_parquet_batch_include_file_paths(tmp_path, zephyr_ctx):
     """load_parquet(batch_mode=True) with include_file_paths adds a string column to each RecordBatch."""
-    import pyarrow as pa
-    import pyarrow.parquet as pq
-
     file_a = str(tmp_path / "a.parquet")
     file_b = str(tmp_path / "b.parquet")
     pq.write_table(pa.Table.from_pylist([{"id": 1}, {"id": 2}]), file_a)
@@ -1470,9 +1437,6 @@ def test_dataset_load_parquet_batch_include_file_paths(tmp_path, zephyr_ctx):
 
 def test_include_file_paths_parquet(tmp_path, zephyr_ctx):
     """Parquet records loaded with include_file_paths get the source file path injected."""
-    import pyarrow as pa
-    import pyarrow.parquet as pq
-
     file_a = str(tmp_path / "a.parquet")
     file_b = str(tmp_path / "b.parquet")
     pq.write_table(pa.Table.from_pylist([{"id": 1}, {"id": 2}]), file_a)
@@ -1514,9 +1478,6 @@ def test_include_file_paths_select_excludes_path_column_raises(tmp_path, zephyr_
     then detects that the column filter doesn't include the injected column and raises
     rather than silently leaking it into the output.
     """
-    import pyarrow as pa
-    import pyarrow.parquet as pq
-
     path = str(tmp_path / "data.parquet")
     pq.write_table(pa.Table.from_pylist([{"id": 1}]), path)
 
@@ -1527,9 +1488,6 @@ def test_include_file_paths_select_excludes_path_column_raises(tmp_path, zephyr_
 
 def test_include_file_paths_select_includes_path_column(tmp_path, zephyr_ctx):
     """select() that explicitly includes the file path column works correctly."""
-    import pyarrow as pa
-    import pyarrow.parquet as pq
-
     path = str(tmp_path / "data.parquet")
     pq.write_table(pa.Table.from_pylist([{"id": 1, "val": "a"}, {"id": 2, "val": "b"}]), path)
 

--- a/lib/zephyr/tests/test_dataset.py
+++ b/lib/zephyr/tests/test_dataset.py
@@ -1424,6 +1424,47 @@ def test_sorted_merge_join_after_group_by_integration(integration_ctx):
     assert results[2] == {"id": 3, "text": "foo", "version": 1, "quality": 0.8}
 
 
+def test_dataset_load_parquet_batch(tmp_path, zephyr_ctx):
+    """Dataset.load_parquet_batch yields pa.RecordBatch objects."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    path = str(tmp_path / "data.parquet")
+    records = [{"id": i, "val": float(i)} for i in range(6)]
+    pq.write_table(pa.Table.from_pylist(records), path, row_group_size=2)
+
+    ds = Dataset.from_list([path]).load_parquet_batch()
+    results = zephyr_ctx.execute(ds).results
+
+    assert all(isinstance(b, pa.RecordBatch) for b in results)
+    all_rows = [row for b in results for row in b.to_pylist()]
+    assert sorted(all_rows, key=lambda r: r["id"]) == records
+
+
+def test_dataset_load_parquet_batch_include_file_paths(tmp_path, zephyr_ctx):
+    """include_file_paths adds a string column to each RecordBatch via PyArrow, not per-row dicts."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    file_a = str(tmp_path / "a.parquet")
+    file_b = str(tmp_path / "b.parquet")
+    pq.write_table(pa.Table.from_pylist([{"id": 1}, {"id": 2}]), file_a)
+    pq.write_table(pa.Table.from_pylist([{"id": 3}]), file_b)
+
+    ds = Dataset.from_list([file_a, file_b]).load_parquet_batch(include_file_paths="source")
+    results = zephyr_ctx.execute(ds).results
+
+    assert all(isinstance(b, pa.RecordBatch) for b in results)
+    assert all("source" in b.schema.names for b in results)
+    assert all(b.schema.field("source").type == pa.string() for b in results)
+
+    rows = [row for b in results for row in b.to_pylist()]
+    sources_by_id = {r["id"]: r["source"] for r in rows}
+    assert sources_by_id[1] == file_a
+    assert sources_by_id[2] == file_a
+    assert sources_by_id[3] == file_b
+
+
 def test_include_file_paths_parquet(tmp_path, zephyr_ctx):
     """Parquet records loaded with include_file_paths get the source file path injected."""
     import pyarrow as pa

--- a/lib/zephyr/tests/test_dataset.py
+++ b/lib/zephyr/tests/test_dataset.py
@@ -1422,3 +1422,42 @@ def test_sorted_merge_join_after_group_by_integration(integration_ctx):
     assert results[0] == {"id": 1, "text": "hello updated", "version": 2, "quality": 0.9}
     assert results[1] == {"id": 2, "text": "world", "version": 1, "quality": 0.3}
     assert results[2] == {"id": 3, "text": "foo", "version": 1, "quality": 0.8}
+
+
+def test_include_file_paths_parquet(tmp_path, zephyr_ctx):
+    """Parquet records loaded with include_file_paths get the source file path injected."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    file_a = str(tmp_path / "a.parquet")
+    file_b = str(tmp_path / "b.parquet")
+    pq.write_table(pa.Table.from_pylist([{"id": 1}, {"id": 2}]), file_a)
+    pq.write_table(pa.Table.from_pylist([{"id": 3}]), file_b)
+
+    ds = Dataset.from_list([file_a, file_b]).load_parquet(include_file_paths="source")
+    results = zephyr_ctx.execute(ds).results
+
+    assert len(results) == 3
+    for r in results:
+        assert "source" in r
+    sources_by_id = {r["id"]: r["source"] for r in results}
+    assert sources_by_id[1] == file_a
+    assert sources_by_id[2] == file_a
+    assert sources_by_id[3] == file_b
+
+
+def test_include_file_paths_jsonl(tmp_path, zephyr_ctx):
+    """JSONL records loaded with include_file_paths get the source file path injected."""
+    file_a = str(tmp_path / "a.jsonl")
+    file_b = str(tmp_path / "b.jsonl")
+    Path(file_a).write_text(json.dumps({"id": 1}) + "\n" + json.dumps({"id": 2}) + "\n")
+    Path(file_b).write_text(json.dumps({"id": 3}) + "\n")
+
+    ds = Dataset.from_list([file_a, file_b]).load_jsonl(include_file_paths="source")
+    results = zephyr_ctx.execute(ds).results
+
+    assert len(results) == 3
+    sources_by_id = {r["id"]: r["source"] for r in results}
+    assert sources_by_id[1] == file_a
+    assert sources_by_id[2] == file_a
+    assert sources_by_id[3] == file_b

--- a/lib/zephyr/tests/test_dataset.py
+++ b/lib/zephyr/tests/test_dataset.py
@@ -14,6 +14,7 @@ from zephyr import Dataset, load_file, load_parquet
 from zephyr._test_helpers import SampleDataclass
 from zephyr.dataset import FilterOp, GlobSource, MapOp, WindowOp, resolve_glob
 from zephyr.execution import ZephyrContext
+from zephyr.readers import DEFAULT_FILE_PATH_COLUMN
 from zephyr.writers import write_parquet_file
 
 
@@ -1425,7 +1426,7 @@ def test_sorted_merge_join_after_group_by_integration(integration_ctx):
 
 
 def test_dataset_load_parquet_batch(tmp_path, zephyr_ctx):
-    """Dataset.load_parquet_batch yields pa.RecordBatch objects."""
+    """load_parquet(batch_mode=True) yields pa.RecordBatch objects."""
     import pyarrow as pa
     import pyarrow.parquet as pq
 
@@ -1433,7 +1434,7 @@ def test_dataset_load_parquet_batch(tmp_path, zephyr_ctx):
     records = [{"id": i, "val": float(i)} for i in range(6)]
     pq.write_table(pa.Table.from_pylist(records), path, row_group_size=2)
 
-    ds = Dataset.from_list([path]).load_parquet_batch()
+    ds = Dataset.from_list([path]).load_parquet(batch_mode=True)
     results = zephyr_ctx.execute(ds).results
 
     assert all(isinstance(b, pa.RecordBatch) for b in results)
@@ -1442,7 +1443,7 @@ def test_dataset_load_parquet_batch(tmp_path, zephyr_ctx):
 
 
 def test_dataset_load_parquet_batch_include_file_paths(tmp_path, zephyr_ctx):
-    """include_file_paths adds a string column to each RecordBatch via PyArrow, not per-row dicts."""
+    """load_parquet(batch_mode=True) with include_file_paths adds a string column to each RecordBatch."""
     import pyarrow as pa
     import pyarrow.parquet as pq
 
@@ -1451,7 +1452,9 @@ def test_dataset_load_parquet_batch_include_file_paths(tmp_path, zephyr_ctx):
     pq.write_table(pa.Table.from_pylist([{"id": 1}, {"id": 2}]), file_a)
     pq.write_table(pa.Table.from_pylist([{"id": 3}]), file_b)
 
-    ds = Dataset.from_list([file_a, file_b]).load_parquet_batch(include_file_paths="source")
+    ds = Dataset.from_list([file_a, file_b]).load_parquet(
+        include_file_paths=True, file_path_column="source", batch_mode=True
+    )
     results = zephyr_ctx.execute(ds).results
 
     assert all(isinstance(b, pa.RecordBatch) for b in results)
@@ -1475,7 +1478,7 @@ def test_include_file_paths_parquet(tmp_path, zephyr_ctx):
     pq.write_table(pa.Table.from_pylist([{"id": 1}, {"id": 2}]), file_a)
     pq.write_table(pa.Table.from_pylist([{"id": 3}]), file_b)
 
-    ds = Dataset.from_list([file_a, file_b]).load_parquet(include_file_paths="source")
+    ds = Dataset.from_list([file_a, file_b]).load_parquet(include_file_paths=True, file_path_column="source")
     results = zephyr_ctx.execute(ds).results
 
     assert len(results) == 3
@@ -1494,7 +1497,7 @@ def test_include_file_paths_jsonl(tmp_path, zephyr_ctx):
     Path(file_a).write_text(json.dumps({"id": 1}) + "\n" + json.dumps({"id": 2}) + "\n")
     Path(file_b).write_text(json.dumps({"id": 3}) + "\n")
 
-    ds = Dataset.from_list([file_a, file_b]).load_jsonl(include_file_paths="source")
+    ds = Dataset.from_list([file_a, file_b]).load_jsonl(include_file_paths=True, file_path_column="source")
     results = zephyr_ctx.execute(ds).results
 
     assert len(results) == 3
@@ -1502,3 +1505,37 @@ def test_include_file_paths_jsonl(tmp_path, zephyr_ctx):
     assert sources_by_id[1] == file_a
     assert sources_by_id[2] == file_a
     assert sources_by_id[3] == file_b
+
+
+def test_include_file_paths_select_excludes_path_column_raises(tmp_path, zephyr_ctx):
+    """select() that omits the file path column when include_file_paths=True must raise.
+
+    The planner pushes down the SelectOp, removing it from the pipeline. The reader
+    then detects that the column filter doesn't include the injected column and raises
+    rather than silently leaking it into the output.
+    """
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    path = str(tmp_path / "data.parquet")
+    pq.write_table(pa.Table.from_pylist([{"id": 1}]), path)
+
+    ds = Dataset.from_list([path]).load_parquet(include_file_paths=True).select("id")
+    with pytest.raises(RuntimeError, match=f"Column filter must include file path column '{DEFAULT_FILE_PATH_COLUMN}'"):
+        zephyr_ctx.execute(ds)
+
+
+def test_include_file_paths_select_includes_path_column(tmp_path, zephyr_ctx):
+    """select() that explicitly includes the file path column works correctly."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    path = str(tmp_path / "data.parquet")
+    pq.write_table(pa.Table.from_pylist([{"id": 1, "val": "a"}, {"id": 2, "val": "b"}]), path)
+
+    ds = Dataset.from_list([path]).load_parquet(include_file_paths=True).select("id", DEFAULT_FILE_PATH_COLUMN)
+    results = zephyr_ctx.execute(ds).results
+
+    assert len(results) == 2
+    assert all(set(r.keys()) == {"id", DEFAULT_FILE_PATH_COLUMN} for r in results)
+    assert all(r[DEFAULT_FILE_PATH_COLUMN] == path for r in results)

--- a/lib/zephyr/tests/test_readers.py
+++ b/lib/zephyr/tests/test_readers.py
@@ -9,7 +9,13 @@ import itertools
 import pyarrow as pa
 import pyarrow.parquet as pq
 from zephyr.expr import ColumnExpr, CompareExpr, LiteralExpr
-from zephyr.readers import InputFileSpec, compute_parquet_splits, iter_parquet_row_groups, load_parquet
+from zephyr.readers import (
+    InputFileSpec,
+    compute_parquet_splits,
+    iter_parquet_row_groups,
+    load_parquet,
+    load_parquet_batch,
+)
 
 
 def _write_test_parquet(path: str, records: list[dict], row_group_size: int = 2) -> None:
@@ -240,3 +246,25 @@ def test_load_parquet_no_dataset_api(tmp_path, monkeypatch):
     # Should succeed without pyarrow.dataset
     result = list(load_parquet(path))
     assert len(result) == len(RECORDS)
+
+
+def test_load_parquet_batch_returns_record_batches(tmp_path):
+    path = str(tmp_path / "data.parquet")
+    _write_test_parquet(path, RECORDS, row_group_size=4)
+
+    batches = list(load_parquet_batch(path))
+    assert all(isinstance(b, pa.RecordBatch) for b in batches)
+    # All rows present across batches
+    all_rows = [row for b in batches for row in b.to_pylist()]
+    assert sorted(all_rows, key=lambda r: r["id"]) == RECORDS
+
+
+def test_load_parquet_batch_consistent_with_load_parquet(tmp_path):
+    """load_parquet_batch + to_pylist must equal load_parquet."""
+    path = str(tmp_path / "data.parquet")
+    _write_test_parquet(path, RECORDS, row_group_size=3)
+
+    spec = InputFileSpec(path=path, row_start=2, row_end=8)
+    via_batch = [row for b in load_parquet_batch(spec) for row in b.to_pylist()]
+    via_dict = list(load_parquet(spec))
+    assert via_batch == via_dict

--- a/lib/zephyr/tests/test_readers.py
+++ b/lib/zephyr/tests/test_readers.py
@@ -183,16 +183,16 @@ def test_iter_parquet_row_groups_predicate_columns_dropped(tmp_path):
 
 
 def test_compute_parquet_splits_single(tmp_path):
-    """File smaller than max_shard_bytes returns one split covering all rows."""
+    """File smaller than approx_shard_bytes returns one split covering all rows."""
     path = str(tmp_path / "data.parquet")
     _write_test_parquet(path, RECORDS, row_group_size=5)
 
-    splits = compute_parquet_splits(path, max_shard_bytes=256 * 1024 * 1024)
+    splits = compute_parquet_splits(path, approx_shard_bytes=256 * 1024 * 1024)
     assert splits == [(0, len(RECORDS))]
 
 
 def test_compute_parquet_splits_multiple(tmp_path):
-    """File whose row groups exceed max_shard_bytes returns multiple splits."""
+    """File whose row groups exceed approx_shard_bytes returns multiple splits."""
     path = str(tmp_path / "data.parquet")
     # Write 10 row groups of 1 row each with a large-ish payload so we can
     # force splits at a small byte threshold.
@@ -205,7 +205,7 @@ def test_compute_parquet_splits_multiple(tmp_path):
     # Threshold just above one row group forces a split after every row group.
     threshold = single_rg_bytes + 1
 
-    splits = compute_parquet_splits(path, max_shard_bytes=threshold)
+    splits = compute_parquet_splits(path, approx_shard_bytes=threshold)
     assert len(splits) > 1
     # Splits must be contiguous and cover all rows.
     assert splits[0][0] == 0
@@ -222,7 +222,7 @@ def test_compute_parquet_splits_row_ranges_are_readable(tmp_path):
 
     pf = pq.ParquetFile(path)
     single_rg_bytes = pf.metadata.row_group(0).total_byte_size
-    splits = compute_parquet_splits(path, max_shard_bytes=single_rg_bytes * 3 + 1)
+    splits = compute_parquet_splits(path, approx_shard_bytes=single_rg_bytes * 3 + 1)
 
     all_ids = []
     for row_start, row_end in splits:

--- a/lib/zephyr/tests/test_readers.py
+++ b/lib/zephyr/tests/test_readers.py
@@ -4,10 +4,12 @@
 """Tests for parquet reader (load_parquet)."""
 
 
+import itertools
+
 import pyarrow as pa
 import pyarrow.parquet as pq
 from zephyr.expr import ColumnExpr, CompareExpr, LiteralExpr
-from zephyr.readers import InputFileSpec, iter_parquet_row_groups, load_parquet
+from zephyr.readers import InputFileSpec, compute_parquet_splits, iter_parquet_row_groups, load_parquet
 
 
 def _write_test_parquet(path: str, records: list[dict], row_group_size: int = 2) -> None:
@@ -172,6 +174,56 @@ def test_iter_parquet_row_groups_predicate_columns_dropped(tmp_path):
     assert len(tables) == 1
     assert tables[0].column_names == ["data"]
     assert tables[0].column("data").to_pylist() == ["d2"]
+
+
+def test_compute_parquet_splits_single(tmp_path):
+    """File smaller than max_shard_bytes returns one split covering all rows."""
+    path = str(tmp_path / "data.parquet")
+    _write_test_parquet(path, RECORDS, row_group_size=5)
+
+    splits = compute_parquet_splits(path, max_shard_bytes=256 * 1024 * 1024)
+    assert splits == [(0, len(RECORDS))]
+
+
+def test_compute_parquet_splits_multiple(tmp_path):
+    """File whose row groups exceed max_shard_bytes returns multiple splits."""
+    path = str(tmp_path / "data.parquet")
+    # Write 10 row groups of 1 row each with a large-ish payload so we can
+    # force splits at a small byte threshold.
+    records = [{"id": i, "payload": "x" * 1000} for i in range(10)]
+    table = pa.Table.from_pylist(records)
+    pq.write_table(table, path, row_group_size=1)
+
+    pf = pq.ParquetFile(path)
+    single_rg_bytes = pf.metadata.row_group(0).total_byte_size
+    # Threshold just above one row group forces a split after every row group.
+    threshold = single_rg_bytes + 1
+
+    splits = compute_parquet_splits(path, max_shard_bytes=threshold)
+    assert len(splits) > 1
+    # Splits must be contiguous and cover all rows.
+    assert splits[0][0] == 0
+    assert splits[-1][1] == 10
+    for (_, end), (start, _) in itertools.pairwise(splits):
+        assert end == start
+
+
+def test_compute_parquet_splits_row_ranges_are_readable(tmp_path):
+    """Each split returned by compute_parquet_splits can be read back via load_parquet."""
+    path = str(tmp_path / "data.parquet")
+    records = [{"id": i} for i in range(20)]
+    pq.write_table(pa.Table.from_pylist(records), path, row_group_size=2)
+
+    pf = pq.ParquetFile(path)
+    single_rg_bytes = pf.metadata.row_group(0).total_byte_size
+    splits = compute_parquet_splits(path, max_shard_bytes=single_rg_bytes * 3 + 1)
+
+    all_ids = []
+    for row_start, row_end in splits:
+        spec = InputFileSpec(path=path, row_start=row_start, row_end=row_end)
+        all_ids.extend(r["id"] for r in load_parquet(spec))
+
+    assert sorted(all_ids) == list(range(20))
 
 
 def test_load_parquet_no_dataset_api(tmp_path, monkeypatch):


### PR DESCRIPTION
This change does three main things (each is a commit, if you want to review it that way).

1. Add support for splitting parquet files into row groups limited by size. Fixes #4587
2. Adds an option to include the filename when loading a parquet file. This appears to be a common pattern so you can track the original file and will also be useful for migrating pipelines that want to reshard to increase parallelism but then reconstruct the original shards.
3. Add load_parquet_batch to allow for returning `RecordBatch`s into the `Dataset`.

All this was, to some extent, motivated by what we need to optimize `dedup_exact_paragraph` as a demonstration of simplify the pipeline and making it faster (it now runs in 6m, down from 16m on main). You can see the changes in #5860.