### PR TITLE
levanter: materialize jax.Array metrics for background-tracker

### DIFF
--- a/lib/levanter/src/levanter/tracker/background.py
+++ b/lib/levanter/src/levanter/tracker/background.py
@@ -48,26 +48,6 @@ class _Shutdown:
 _SHUTDOWN = _Shutdown()
 
 
-def _materialize_payload(payload: Any) -> Any:
-    """Pull every ``jax.Array`` leaf in ``payload`` to host memory.
-
-    Converting a ``jax.Array`` to host memory issues a device->host transfer;
-    for arrays sharded across hosts that transfer is a cross-host collective.
-    JAX collectives must be dispatched from the main thread in identical
-    program order on every host — otherwise multi-host launch IDs desync and
-    the TPU slice halts ("unexpected peer ... different launch id").
-
-    :class:`BackgroundTracker` runs the wrapped tracker on a daemon thread, so
-    if a metric value reaches the worker still as a ``jax.Array`` the wrapped
-    tracker materializes it off the main thread. We materialize here, on the
-    calling (trainer) thread, leaving only inert numpy/Python data to cross the
-    queue. ``jax.device_get`` recurses through pytrees (dict/list/tuple and
-    registered modules such as ``Histogram``), converting array leaves and
-    passing everything else through unchanged.
-    """
-    return jax.device_get(payload)
-
-
 # Number of times we log a warning when the queue is full before throttling.
 _DROP_LOG_BURST = 5
 _DROP_LOG_PERIOD = 1000
@@ -147,14 +127,17 @@ class BackgroundTracker(Tracker):
     def _enqueue_data(self, method, payload, **kwargs) -> None:
         """Materialize ``jax.Array`` leaves on the calling thread, then enqueue.
 
-        See :func:`_materialize_payload` for why materialization must happen
-        here rather than on the worker thread.
+        ``jax.device_get`` pulls every array leaf to host memory; for
+        sharded arrays that transfer is a cross-host collective and must be
+        dispatched from the main thread in identical program order on every
+        host (otherwise multi-host launch IDs desync and the TPU slice halts).
+        Doing it here keeps only inert numpy/Python data on the queue.
         """
         if self._stopped:
             logger.debug("Background tracker '%s' already stopped; dropping %s", self.name, method.__name__)
             return
         try:
-            payload = _materialize_payload(payload)
+            payload = jax.device_get(payload)
         except Exception:
             logger.exception(
                 "Background tracker '%s' failed to materialize payload for %s; dropping update.",

--- a/lib/levanter/src/levanter/tracker/background.py
+++ b/lib/levanter/src/levanter/tracker/background.py
@@ -15,6 +15,9 @@ both guarantees:
   keeps running so subsequent updates still go through.
 * If the queue fills up (e.g. the wrapped tracker is wedged), additional
   updates are dropped with a rate-limited warning rather than blocking.
+* ``jax.Array`` metric values are materialized to host memory on the calling
+  thread before they cross the queue, so the worker never issues a JAX
+  device transfer / cross-host collective off the main thread.
 
 Tracker initialization is *not* wrapped. If e.g. ``wandb.init()`` fails
 because of bad auth, that's a fatal configuration problem and the run
@@ -30,6 +33,8 @@ import time
 import typing
 from typing import Any, Optional
 
+import jax
+
 from levanter.tracker.tracker import Tracker
 
 
@@ -41,6 +46,27 @@ class _Shutdown:
 
 
 _SHUTDOWN = _Shutdown()
+
+
+def _materialize_payload(payload: Any) -> Any:
+    """Pull every ``jax.Array`` leaf in ``payload`` to host memory.
+
+    Converting a ``jax.Array`` to host memory issues a device->host transfer;
+    for arrays sharded across hosts that transfer is a cross-host collective.
+    JAX collectives must be dispatched from the main thread in identical
+    program order on every host — otherwise multi-host launch IDs desync and
+    the TPU slice halts ("unexpected peer ... different launch id").
+
+    :class:`BackgroundTracker` runs the wrapped tracker on a daemon thread, so
+    if a metric value reaches the worker still as a ``jax.Array`` the wrapped
+    tracker materializes it off the main thread. We materialize here, on the
+    calling (trainer) thread, leaving only inert numpy/Python data to cross the
+    queue. ``jax.device_get`` recurses through pytrees (dict/list/tuple and
+    registered modules such as ``Histogram``), converting array leaves and
+    passing everything else through unchanged.
+    """
+    return jax.device_get(payload)
+
 
 # Number of times we log a warning when the queue is full before throttling.
 _DROP_LOG_BURST = 5
@@ -118,10 +144,30 @@ class BackgroundTracker(Tracker):
                     dropped,
                 )
 
+    def _enqueue_data(self, method, payload, **kwargs) -> None:
+        """Materialize ``jax.Array`` leaves on the calling thread, then enqueue.
+
+        See :func:`_materialize_payload` for why materialization must happen
+        here rather than on the worker thread.
+        """
+        if self._stopped:
+            logger.debug("Background tracker '%s' already stopped; dropping %s", self.name, method.__name__)
+            return
+        try:
+            payload = _materialize_payload(payload)
+        except Exception:
+            logger.exception(
+                "Background tracker '%s' failed to materialize payload for %s; dropping update.",
+                self.name,
+                method.__name__,
+            )
+            return
+        self._enqueue(method, payload, **kwargs)
+
     # ---- Tracker API --------------------------------------------------------
 
     def log_hyperparameters(self, hparams: dict[str, Any]) -> None:
-        self._enqueue(self.wrapped.log_hyperparameters, hparams)
+        self._enqueue_data(self.wrapped.log_hyperparameters, hparams)
 
     def log(
         self,
@@ -130,10 +176,10 @@ class BackgroundTracker(Tracker):
         step: Optional[int],
         commit: Optional[bool] = None,
     ) -> None:
-        self._enqueue(self.wrapped.log, metrics, step=step, commit=commit)
+        self._enqueue_data(self.wrapped.log, metrics, step=step, commit=commit)
 
     def log_summary(self, metrics: dict[str, Any]) -> None:
-        self._enqueue(self.wrapped.log_summary, metrics)
+        self._enqueue_data(self.wrapped.log_summary, metrics)
 
     def log_artifact(
         self,

--- a/lib/levanter/tests/test_background_tracker.py
+++ b/lib/levanter/tests/test_background_tracker.py
@@ -20,9 +20,12 @@ import threading
 import time
 from typing import Any
 
+import jax
+import jax.numpy as jnp
 import pytest
 
 from levanter.tracker import BackgroundTracker, CompositeTracker
+from levanter.tracker.histogram import Histogram
 from levanter.tracker.tracker import Tracker
 
 
@@ -331,3 +334,53 @@ def test_background_tracker_swallows_various_exceptions(exc, caplog):
         bt.finish()
     # Second call (after the raise) should still have been recorded.
     assert inner.logs == [({"loss": 0.5}, 1, None)]
+
+
+def test_background_tracker_materializes_jax_arrays_before_enqueue():
+    """jax.Array metric values must reach the wrapped tracker as host data.
+
+    Materializing a jax.Array triggers a device->host transfer, which for a
+    sharded array is a cross-host collective. That must run on the caller
+    (trainer) thread so multi-host launch IDs stay in lockstep; if it ran on
+    the worker thread the TPU slice would desync and halt. Observable proxy:
+    the wrapped tracker never sees a jax.Array.
+    """
+    inner = RecordingTracker()
+    bt = BackgroundTracker(inner)
+    try:
+        bt.log({"loss": jnp.asarray(1.5), "steps": jnp.arange(3)}, step=0)
+        bt.log_summary({"final": jnp.asarray(0.25)})
+        bt.log_hyperparameters({"lr": jnp.asarray(3e-4)})
+        assert bt._wait_until_idle(timeout=5)
+    finally:
+        bt.finish()
+
+    logged = inner.logs[0][0]
+    assert not isinstance(logged["loss"], jax.Array)
+    assert not isinstance(logged["steps"], jax.Array)
+    assert not isinstance(inner.summary[0]["final"], jax.Array)
+    assert not isinstance(inner.hparams[0]["lr"], jax.Array)
+    # Values must survive materialization unchanged.
+    assert float(logged["loss"]) == 1.5
+    assert list(logged["steps"]) == [0, 1, 2]
+
+
+def test_background_tracker_materializes_histogram_leaves():
+    """Histogram is a pytree; its jax.Array leaves must be materialized too.
+
+    Grug MoE logs per-layer routing Histograms every step. Their scalar
+    fields are sharded jax.Arrays, so leaving them for the worker thread to
+    convert is exactly the multi-host hazard this materialization prevents.
+    """
+    inner = RecordingTracker()
+    bt = BackgroundTracker(inner)
+    try:
+        bt.log({"grads/hist": Histogram.from_array(jnp.arange(100.0))}, step=0)
+        assert bt._wait_until_idle(timeout=5)
+    finally:
+        bt.finish()
+
+    logged = inner.logs[0][0]["grads/hist"]
+    assert isinstance(logged, Histogram)
+    for leaf in jax.tree_util.tree_leaves(logged):
+        assert not isinstance(leaf, jax.Array)


### PR DESCRIPTION
## Summary

`BackgroundTracker` (#5332) runs the wrapped tracker's `log` calls on a daemon thread. When a metric value is still a `jax.Array` at that point, the wrapped tracker materializes it (`.item()` / `np.asarray`) **off the main thread**. For arrays sharded across hosts that materialization is a cross-host collective, and JAX collectives must be dispatched from the main thread in identical program order on every host. Issuing them from the daemon thread desyncs multi-host launch IDs and halts the TPU slice:

```
E0200 RuntimeUnexpectedCoreHalt: ... An unexpected peer shows up in the
launch group with a different launch id than the current group leader.
```

This made multi-host runs that log array-valued metrics fail. Grug MoE hits it every step: `_summarize_router_metrics` emits per-layer routing `Histogram`s whose scalar fields are sharded `jax.Array`s.

## Fix

Materialize `jax.Array` leaves with `jax.device_get` on the **calling (trainer) thread**, before the payload crosses the queue, so the worker only ever sees inert numpy/Python data. `jax.device_get` recurses pytrees, so dicts, lists, and registered modules such as `Histogram` all get their array leaves converted. Network/serialization stays deferred to the background thread. Materialization failures are caught and the update dropped, consistent with `BackgroundTracker`'s "never crash training" contract.

`log` / `log_summary` / `log_hyperparameters` route through the new `_enqueue_data`; `log_artifact` (path arg, no arrays) is unchanged.

## Test plan

- [x] Added two regressions to `test_background_tracker.py`: jax.Array metrics arrive at the wrapped tracker materialized; `Histogram` jax.Array leaves are materialized too. All 16 tests pass.
- [x] `./infra/pre-commit.py` (ruff / black / pyrefly) clean.
- [x] **End-to-end on Iris**: grug MoE `d512` / 50 steps on a `v5p-32` (4-host) slice, wandb on, `background=True`. Without this fix the identical config halts at step 3 with the `RuntimeUnexpectedCoreHalt` above; with the fix all 4 hosts complete 50/50 steps, checkpoint saves, wandb run finishes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)