### PR TITLE
[infra] Add pre-commit.py --review for advisory lint-catalog review

### DIFF
--- a/.agents/projects/20260520_auto_lint.md
+++ b/.agents/projects/20260520_auto_lint.md
@@ -70,9 +70,12 @@ flag:
    committed and uncommitted, so the review runs whether or not the author
    committed before the pre-push checklist.
 2. Build the prompt = `infra/lint.md` contents + the diff.
-3. Invoke a headless agent — `claude -p`, configurable via the `MARIN_LINT_AGENT`
-   env var. `ANTHROPIC_API_KEY` is dropped from the subprocess env so the agent
-   uses interactive subscription auth, not metered API billing.
+3. Invoke a headless agent — `claude -p` by default, overridable via the
+   `--agent-command` CLI flag (skills instruct the calling agent to pass its
+   own headless command, e.g. `--agent-command='codex exec'`). The subprocess
+   env strips `ANTHROPIC_API_KEY` (forces subscription auth, not metered API
+   billing) and `CLAUDECODE`/`CLAUDE_CODE_*` (so the sub-agent runs as a fresh
+   session rather than nesting under the calling agent).
 4. Print captured stdout. `lint.md` mandates the one-finding-per-line format.
 5. Findings are **advisory** — `--review` prints them and exits 0 (it exits 1
    only when the review could not run). `lint.md` is explicit: "advisory —
@@ -142,6 +145,8 @@ This keeps `lint.md` a living catalog rather than a one-time write.
    `--review` is advisory and diff-scoped, acceptable local imports are marked
    with `# noqa: PLC0415` (ruff convention) — honored by both `--review` and,
    post-burndown, ruff itself.
-4. **Agent CLI:** `claude -p`, default for the `MARIN_LINT_AGENT` env var. The
-   command unsets `ANTHROPIC_API_KEY` so the agent uses interactive
-   subscription auth rather than metered API billing.
+4. **Agent CLI:** `claude -p` as the default; overridden per-call via the
+   `--agent-command` flag so the calling agent passes its own headless
+   invocation. The subprocess unsets `ANTHROPIC_API_KEY` (subscription auth)
+   and `CLAUDECODE`/`CLAUDE_CODE_*` (prevents the spawned agent from inheriting
+   the parent's session).

--- a/.agents/projects/20260520_auto_lint.md
+++ b/.agents/projects/20260520_auto_lint.md
@@ -1,0 +1,147 @@
+# Auto-lint: bake `lint.md` into agent workflows
+
+**Status:** Layer 2 (the `--review` command) implemented; Layers 1 and 3b are follow-ups
+**Date:** 2026-05-20
+**Goal:** Agents self-apply the `infra/lint.md` rule catalog before pushing, so
+humans stop repeating the same nits ("remove the local import", "this comment
+restates the code") on every PR.
+
+## Background
+
+- `infra/lint.md` (#5843) is a self-contained catalog of ~50 `ml-...` rules:
+  condition, why, when-allowed, bad example, plus a "Detector usage" section
+  that already specifies inputs, confidence thresholds, and an output format
+  (`path:line: code (conf) message`). It is written to be run by an agent.
+- `infra/pre-commit.py` runs the mechanical/offline checks (ruff, black,
+  pyrefly, license headers, ...). It is the mandated lint entry point.
+- The `commit` and `author-pr` skills already call `pre-commit.py`; nothing
+  applies `lint.md` yet.
+- #5843's commit message states the intent directly: "wire something up so
+  this is called by the current agent as a sub-agent process and nits are
+  handled automatically."
+
+## Architecture: three layers
+
+`lint.md` rules split by how they are best decided.
+
+### Layer 1 — Mechanical (deterministic, fast, free, blocking)
+
+Rules decidable without an LLM. Two sub-cases.
+
+**1a. Covered by ruff** — the headline win is `ml-local-import`, which is
+exactly ruff's `PLC0415` (`import-outside-top-level`). This is the #1 nit the
+user never wants to repeat.
+
+- Caveat: `ruff check --select PLC0415 lib/` reports **696 existing
+  violations**. Enabling it blocking, repo-wide, immediately would block almost
+  every PR that touches `lib/`.
+- Recommended path: (1) a one-time burn-down PR — use the new agentic fixer
+  (Layer 2) to lift the 696 local imports, keeping `# noqa: PLC0415` only on
+  the genuine optional-dependency cases paired with their `try/except
+  ImportError`; (2) then add `"PLC0415"` to `select` in the root,
+  `lib/levanter`, and `lib/haliax` `pyproject.toml` ruff configs so it stays at
+  zero. Until the burn-down lands, the diff-scoped check below covers new code.
+
+**1b. Mechanical but not in ruff** — ~3 small custom detectors. The repo is
+already largely compliant (these are explicit architecture rules), so they can
+block:
+
+- `ml-reverse-layer-import` / `ml-cross-sibling-import`: AST-scan imports under
+  `lib/<x>/src/**`, flag forbidden layer crossings
+  (`{iris,haliax} → {levanter,zephyr} → marin`).
+- `ml-type-checking-guard`: flag `if TYPE_CHECKING:` blocks. AGENTS.md already
+  forbids them outright.
+- `ml-utils-module`: new files named `*_utils.py` / `*_helpers.py`.
+
+**Diff-scoping:** every Layer 1 check flags only added/modified lines in the
+branch diff, never pre-existing code — consistent with `lint.md`'s detector
+section. This is what makes rollout safe despite the 696 backlog.
+
+### Layer 2 — Agentic (LLM, judgement, advisory)
+
+Everything else in `lint.md` (comments, defensive code, dead code, duplication,
+naming judgement, test quality). `lint.md` is already the detector prompt.
+
+`run_lint_review()` in `infra/pre-commit.py`, invoked via the new `--review`
+flag:
+
+1. Compute the diff: working tree vs `merge-base origin/main HEAD`, for
+   `*.py` / `*.proto`, with `-U15` context. This covers all branch work,
+   committed and uncommitted, so the review runs whether or not the author
+   committed before the pre-push checklist.
+2. Build the prompt = `infra/lint.md` contents + the diff.
+3. Invoke a headless agent — `claude -p`, configurable via the `MARIN_LINT_AGENT`
+   env var. `ANTHROPIC_API_KEY` is dropped from the subprocess env so the agent
+   uses interactive subscription auth, not metered API billing.
+4. Print captured stdout. `lint.md` mandates the one-finding-per-line format.
+5. Findings are **advisory** — `--review` prints them and exits 0 (it exits 1
+   only when the review could not run). `lint.md` is explicit: "advisory —
+   never block."
+
+Diff-size handling: v1 passes the whole branch diff in one call; if it exceeds
+a threshold, fall back to `lint.md`'s prescribed per-file second pass.
+
+**Why a subprocess, not the Claude Code Task tool:** one mechanism that behaves
+identically whether called from a skill, a git hook, or CI. The headless agent
+sees only `lint.md` + the diff, so it is focused and isolated from the calling
+agent's context.
+
+### Layer 3 — Wiring it into every workflow ("defaulted in")
+
+- `commit` skill: add a pre-push step — run `./infra/pre-commit.py --review`,
+  fix findings, re-run once to confirm, then stop (no infinite loop).
+- `author-pr` skill: add `./infra/pre-commit.py --review` to the Pre-Push
+  Checklist.
+- `review-pr` skill (optional): add `lint.md` as a 5th reviewer agent — closes
+  the loop on the reviewer side as a backstop. Author-side is the priority.
+- Git `pre-push` hook (optional): a committed sample + installer, runs
+  `--review` advisory so non-agent pushes get the same feedback. Tradeoff:
+  ~1-2 min latency + tokens on every `git push`.
+- `AGENTS.md`: one line in the Development section pointing at `--review`.
+
+## Advisory vs blocking
+
+Keep the **agentic** layer advisory — it has false positives, and `lint.md`
+itself says blocking erodes trust. Keep the **mechanical** layer blocking — it
+is deterministic with no false positives. The automation is that the *skills*
+instruct the agent to fix advisory findings; agents reliably follow skills, so
+"advisory" still gets cleaned up in practice.
+
+## Phase 3b — Growing the catalog from feedback
+
+"Collect feedback from previous agent interactions to build rules": a periodic
+job (new skill `distill-lint-rules`, or folded into
+`scrub-reflection-self-improvement`):
+
+- Pull review comments from recently-merged PRs (especially `agent-generated`).
+- Cluster recurring stylistic nits not already covered by an `ml-` rule.
+- Propose new rules as a PR editing `lint.md` in the existing rule structure.
+
+This keeps `lint.md` a living catalog rather than a one-time write.
+
+## Rollout sequence
+
+1. **[done]** Layer 2: `pre-commit.py --review` runs the catalog over the
+   branch diff via a headless agent. Advisory, standalone, no rollout risk.
+2. **[done]** Wire `--review` into the `author-pr` Pre-Push Checklist;
+   `# noqa: PLC0415` suppression marker added to `lint.md`.
+3. Layer 1b custom checks (reverse-layer, `TYPE_CHECKING`, `*_utils.py`) —
+   diff-scoped, blocking.
+4. One-time `PLC0415` burn-down PR (696 violations) using `--review`, then
+   enable `PLC0415` in the root, `lib/levanter`, and `lib/haliax` ruff configs.
+5. Optionally add `lint.md` as a reviewer agent in `review-pr` (backstop).
+6. Phase 3b feedback loop.
+
+## Decisions (resolved 2026-05-20)
+
+1. **Cost vs coverage:** review runs **pre-push only** — wired into `author-pr`,
+   not `commit`. `/commit` stays fast for WIP; the branch-diff scope means one
+   review at PR time covers all commits anyway.
+2. **Pre-push hook:** **no repo-wide git hook** — agent skills only.
+3. **`PLC0415` backlog:** a dedicated burn-down PR will clear the 696; because
+   `--review` is advisory and diff-scoped, acceptable local imports are marked
+   with `# noqa: PLC0415` (ruff convention) — honored by both `--review` and,
+   post-burndown, ruff itself.
+4. **Agent CLI:** `claude -p`, default for the `MARIN_LINT_AGENT` env var. The
+   command unsets `ANTHROPIC_API_KEY` so the agent uses interactive
+   subscription auth rather than metered API billing.

--- a/.agents/skills/author-pr/SKILL.md
+++ b/.agents/skills/author-pr/SKILL.md
@@ -49,7 +49,7 @@ just to satisfy this rule — omit the link when there is no pre-existing issue.
 
 Run these before pushing; do not skip any step.
 
-1. `./infra/pre-commit.py --changed --fix` — resolve all issues. Do not substitute `uv run pre-commit ...`.
+1. `./infra/pre-commit.py --changed-files --fix` — resolve all issues. Do not substitute `uv run pre-commit ...`.
 2. `./infra/pre-commit.py --review` — advisory agentic pass over the branch diff against the `infra/lint.md` rule catalog. Fix the findings it reports (search `infra/lint.md` for each `ml-...` code to see the rule and when it is acceptable to ignore); re-run once to confirm. Findings do not block, but address them — they are the nits a reviewer would otherwise flag.
 3. `uv run pytest -m 'not slow'` — relevant test directories.
 4. If docs pages were added/deleted/renamed: `uv run python infra/check_docs_source_links.py`

--- a/.agents/skills/author-pr/SKILL.md
+++ b/.agents/skills/author-pr/SKILL.md
@@ -50,9 +50,10 @@ just to satisfy this rule — omit the link when there is no pre-existing issue.
 Run these before pushing; do not skip any step.
 
 1. `./infra/pre-commit.py --changed --fix` — resolve all issues. Do not substitute `uv run pre-commit ...`.
-2. `uv run pytest -m 'not slow'` — relevant test directories.
-3. If docs pages were added/deleted/renamed: `uv run python infra/check_docs_source_links.py`
-4. If docs-heavy: `uv run mkdocs build --strict`
+2. `./infra/pre-commit.py --review` — advisory agentic pass over the branch diff against the `infra/lint.md` rule catalog. Fix the findings it reports (search `infra/lint.md` for each `ml-...` code to see the rule and when it is acceptable to ignore); re-run once to confirm. Findings do not block, but address them — they are the nits a reviewer would otherwise flag.
+3. `uv run pytest -m 'not slow'` — relevant test directories.
+4. If docs pages were added/deleted/renamed: `uv run python infra/check_docs_source_links.py`
+5. If docs-heavy: `uv run mkdocs build --strict`
 
 After pushing, monitor CI with `gh pr view <number> --json statusCheckRollup`;
 fix failures before considering the PR complete.

--- a/.agents/skills/author-pr/SKILL.md
+++ b/.agents/skills/author-pr/SKILL.md
@@ -50,7 +50,7 @@ just to satisfy this rule — omit the link when there is no pre-existing issue.
 Run these before pushing; do not skip any step.
 
 1. `./infra/pre-commit.py --changed-files --fix` — resolve all issues. Do not substitute `uv run pre-commit ...`.
-2. `./infra/pre-commit.py --review` — advisory agentic pass over the branch diff against the `infra/lint.md` rule catalog. Fix the findings it reports (search `infra/lint.md` for each `ml-...` code to see the rule and when it is acceptable to ignore); re-run once to confirm. Findings do not block, but address them — they are the nits a reviewer would otherwise flag.
+2. `./infra/pre-commit.py --review --agent-command='<your own headless invocation>'` — advisory agentic pass over the branch diff against the `infra/lint.md` rule catalog. Pass the headless CLI for whichever agent you are: `--agent-command='claude -p'` for Claude Code, `--agent-command='codex exec'` for Codex, etc. The script defaults to `claude -p` if you omit the flag. Fix the findings it reports (search `infra/lint.md` for each `ml-...` code to see the rule and when it is acceptable to ignore); re-run once to confirm. Findings do not block, but address them — they are the nits a reviewer would otherwise flag.
 3. `uv run pytest -m 'not slow'` — relevant test directories.
 4. If docs pages were added/deleted/renamed: `uv run python infra/check_docs_source_links.py`
 5. If docs-heavy: `uv run mkdocs build --strict`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,10 @@ favor of ad-hoc commands.
 # Type checking (also done by pre-commit.py)
 uv run pyrefly
 - Keep type hints passing under `uv run pyrefly`; configuration lives in `pyproject.toml`.
+
+# Advisory lint review — agentic pass over the branch diff before pushing a PR
+./infra/pre-commit.py --review
+- Surfaces `infra/lint.md` rule-catalog findings; advisory, never blocks.
 ```
 
 - Python >=3.11. Use `uv run` for entry points; fall back to `.venv/bin/python` if needed.

--- a/infra/lint.md
+++ b/infra/lint.md
@@ -35,7 +35,9 @@ refactor if you need to.
 **When allowed:** Only to handle external-dependency conditions (a package
 only available with a certain extra). The optional-dep case is canonical
 and *correct*, not a nit — a `try/except ImportError` or a docstring
-noting the extra makes the intent obvious.
+noting the extra makes the intent obvious. Mark such an import with
+`# noqa: PLC0415` on the `import` line to record the exception explicitly;
+see "Suppression markers" under "Detector usage".
 
 Import-cycle workarounds are *not* a stable exception. In well-factored
 Python the structural fix always exists: extract a `Protocol` / ABC / shared
@@ -1010,6 +1012,14 @@ If the diff is empty, emit nothing and stop. If it is larger than one pass, driv
 Scan added/modified hunks plus enough surrounding context to judge intent (usually the enclosing function/class). Do not flag pre-existing code in unchanged regions. Migrations, `__init__.py` exports, proto definitions, and test fixtures all count. Generated stubs (e.g. `*_pb2.py`, `*_pb2_grpc.py`) are out of scope — skip them.
 
 Security findings (auth, injection, secrets) are out of scope — they belong in `/security-review`.
+
+### Suppression markers
+
+A finding is suppressed when the line it cites carries a trailing
+`# noqa: <code>` comment that names the rule — ruff's suppression convention.
+`<code>` is the rule's `ml-...` code, or for `ml-local-import` the equivalent
+ruff code `PLC0415`. A suppressed line is an author-approved exception: do not
+emit a finding for it.
 
 ### Confidence
 

--- a/infra/pre-commit.py
+++ b/infra/pre-commit.py
@@ -883,22 +883,28 @@ def run_lint_review() -> int:
     """Run the advisory `infra/lint.md` catalog over the branch diff via an agent.
 
     Findings are advisory and never block — they are printed for the author to
-    act on before pushing. Returns 0 when the review ran (with or without
-    findings), 1 only when it could not run.
+    act on before pushing. Returns 0 in all cases that fit the advisory contract
+    (no findings, findings emitted, agent unavailable, merge-base unresolved,
+    timeout). Returns 1 only when the agent itself ran and exited non-zero,
+    which indicates a tooling bug worth surfacing.
     """
     agent_cmd = shlex.split(os.environ.get("MARIN_LINT_AGENT", LINT_REVIEW_AGENT_DEFAULT))
     if not agent_cmd or shutil.which(agent_cmd[0]) is None:
         agent_name = agent_cmd[0] if agent_cmd else "(empty)"
         click.echo(f"  ⚠ Lint review skipped: agent '{agent_name}' not found on PATH")
-        return 1
+        return 0
 
-    merge_base = subprocess.run(
+    base_result = subprocess.run(
         ["git", "merge-base", "origin/main", "HEAD"],
         cwd=ROOT_DIR,
         capture_output=True,
         text=True,
-        check=True,
-    ).stdout.strip()
+    )
+    if base_result.returncode != 0:
+        click.echo("  ⚠ Lint review skipped: could not resolve merge-base with origin/main")
+        click.echo(f"    (run `git fetch origin main` first; git said: {base_result.stderr.strip()})")
+        return 0
+    merge_base = base_result.stdout.strip()
     # Diff the working tree against the merge-base: covers all branch work,
     # committed and uncommitted, so the review runs whether or not the author
     # has committed before reaching the pre-push checklist.
@@ -931,7 +937,7 @@ def run_lint_review() -> int:
         )
     except subprocess.TimeoutExpired:
         click.echo(f"  ⚠ Lint review timed out after {LINT_REVIEW_TIMEOUT}s")
-        return 1
+        return 0
 
     if result.returncode != 0:
         click.echo(f"  ⚠ Lint review agent exited {result.returncode}:")

--- a/infra/pre-commit.py
+++ b/infra/pre-commit.py
@@ -878,9 +878,26 @@ LINT_REVIEW_INSTRUCTIONS = (
     "from the diff as given; do not re-derive it."
 )
 
+# Env vars that mark a Claude Code session and would re-bind the spawned headless
+# agent to its parent's transcript / session. Stripped before exec so the
+# sub-agent runs as a fresh, isolated session.
+LINT_REVIEW_STRIPPED_ENV = (
+    "ANTHROPIC_API_KEY",  # force subscription auth, not metered API billing
+    "CLAUDECODE",
+    "CLAUDE_CODE_ENTRYPOINT",
+    "CLAUDE_CODE_EXECPATH",
+    "CLAUDE_CODE_SESSION_ID",
+    "CLAUDE_CODE_SSE_PORT",
+)
 
-def run_lint_review() -> int:
+
+def run_lint_review(agent_command: str) -> int:
     """Run the advisory `infra/lint.md` catalog over the branch diff via an agent.
+
+    `agent_command` is the headless CLI invocation of the agent that will read
+    the prompt from stdin and print findings to stdout (e.g. `claude -p`,
+    `codex exec`). Callers should pass the command for the agent they are
+    themselves running so the sub-agent matches the calling environment.
 
     Findings are advisory and never block — they are printed for the author to
     act on before pushing. Returns 0 in all cases that fit the advisory contract
@@ -888,7 +905,7 @@ def run_lint_review() -> int:
     timeout). Returns 1 only when the agent itself ran and exited non-zero,
     which indicates a tooling bug worth surfacing.
     """
-    agent_cmd = shlex.split(os.environ.get("MARIN_LINT_AGENT", LINT_REVIEW_AGENT_DEFAULT))
+    agent_cmd = shlex.split(agent_command)
     if not agent_cmd or shutil.which(agent_cmd[0]) is None:
         agent_name = agent_cmd[0] if agent_cmd else "(empty)"
         click.echo(f"  ⚠ Lint review skipped: agent '{agent_name}' not found on PATH")
@@ -921,9 +938,10 @@ def run_lint_review() -> int:
 
     prompt = f"{LINT_CATALOG.read_text()}\n\n{LINT_REVIEW_INSTRUCTIONS}\n\n```diff\n{diff}\n```\n"
 
-    # `claude` reads the prompt from stdin in print mode. Drop ANTHROPIC_API_KEY
-    # so the agent uses interactive subscription auth, not metered API billing.
-    env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+    # Strip session/auth markers so the headless agent runs as a fresh session
+    # rather than nesting under the calling agent's transcript or being billed
+    # via metered API auth.
+    env = {k: v for k, v in os.environ.items() if k not in LINT_REVIEW_STRIPPED_ENV}
 
     try:
         result = subprocess.run(
@@ -973,6 +991,17 @@ def run_lint_review() -> int:
     is_flag=True,
     help="Run the advisory infra/lint.md rule catalog over the branch diff via an agent",
 )
+@click.option(
+    "--agent-command",
+    "agent_command",
+    default=LINT_REVIEW_AGENT_DEFAULT,
+    show_default=True,
+    help=(
+        "Headless agent invocation for --review. Agents calling this from a skill "
+        "should pass their own command (e.g. 'claude -p', 'codex exec') so the "
+        "sub-agent matches the calling environment."
+    ),
+)
 @click.option("--files", "files_opt", multiple=True, help="Files to check (alias for positional args)")
 @click.argument("files", nargs=-1)
 def main(
@@ -981,11 +1010,12 @@ def main(
     changed_files: bool,
     pre_commit: bool,
     review: bool,
+    agent_command: str,
     files_opt: tuple[str, ...],
     files: tuple[str, ...],
 ):
     if review:
-        sys.exit(run_lint_review())
+        sys.exit(run_lint_review(agent_command))
 
     all_files_set: set[pathlib.Path] = set()
     input_files = files_opt + files

--- a/infra/pre-commit.py
+++ b/infra/pre-commit.py
@@ -25,6 +25,8 @@ import json
 import os
 import pathlib
 import re
+import shlex
+import shutil
 import subprocess
 import sys
 from collections.abc import Callable
@@ -40,6 +42,7 @@ HALIAX_LICENSE = ROOT_DIR / "lib/haliax/etc/license_header.txt"
 MARIN_LICENSE = ROOT_DIR / "etc/license_header.txt"
 LEVANTER_BLACK_CONFIG = ROOT_DIR / "lib/levanter/pyproject.toml"
 HALIAX_BLACK_CONFIG = ROOT_DIR / "lib/haliax/pyproject.toml"
+LINT_CATALOG = ROOT_DIR / "infra/lint.md"
 
 EXCLUDE_PATTERNS = [
     ".git/**",
@@ -748,8 +751,6 @@ def _ensure_iris_protos() -> None:
     resolve imports from other modules, even when the generated files themselves
     are excluded from type-checking via project-excludes.
     """
-    import shutil
-
     rpc_dir = ROOT_DIR / "lib" / "iris" / "src" / "iris" / "rpc"
     # Check if any pb2 file exists already
     if list(rpc_dir.glob("*_pb2.py")):
@@ -866,6 +867,87 @@ PRECOMMIT_CONFIGS = [
 ]
 
 
+LINT_REVIEW_AGENT_DEFAULT = "claude -p"
+
+LINT_REVIEW_TIMEOUT = 600
+
+LINT_REVIEW_INSTRUCTIONS = (
+    "Apply the lint catalog above to the branch diff below. Follow the "
+    '"Detector usage" section exactly: emit one finding per line in the format '
+    "it specifies, and emit nothing at all when there are no findings. Work "
+    "from the diff as given; do not re-derive it."
+)
+
+
+def run_lint_review() -> int:
+    """Run the advisory `infra/lint.md` catalog over the branch diff via an agent.
+
+    Findings are advisory and never block — they are printed for the author to
+    act on before pushing. Returns 0 when the review ran (with or without
+    findings), 1 only when it could not run.
+    """
+    agent_cmd = shlex.split(os.environ.get("MARIN_LINT_AGENT", LINT_REVIEW_AGENT_DEFAULT))
+    if not agent_cmd or shutil.which(agent_cmd[0]) is None:
+        agent_name = agent_cmd[0] if agent_cmd else "(empty)"
+        click.echo(f"  ⚠ Lint review skipped: agent '{agent_name}' not found on PATH")
+        return 1
+
+    merge_base = subprocess.run(
+        ["git", "merge-base", "origin/main", "HEAD"],
+        cwd=ROOT_DIR,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    # Diff the working tree against the merge-base: covers all branch work,
+    # committed and uncommitted, so the review runs whether or not the author
+    # has committed before reaching the pre-push checklist.
+    diff = subprocess.run(
+        ["git", "diff", merge_base, "-U15", "--", "*.py", "*.proto"],
+        cwd=ROOT_DIR,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    if not diff.strip():
+        click.echo("Lint review: no Python/proto changes on this branch.")
+        return 0
+
+    prompt = f"{LINT_CATALOG.read_text()}\n\n{LINT_REVIEW_INSTRUCTIONS}\n\n```diff\n{diff}\n```\n"
+
+    # `claude` reads the prompt from stdin in print mode. Drop ANTHROPIC_API_KEY
+    # so the agent uses interactive subscription auth, not metered API billing.
+    env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+
+    try:
+        result = subprocess.run(
+            agent_cmd,
+            input=prompt,
+            cwd=ROOT_DIR,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=LINT_REVIEW_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        click.echo(f"  ⚠ Lint review timed out after {LINT_REVIEW_TIMEOUT}s")
+        return 1
+
+    if result.returncode != 0:
+        click.echo(f"  ⚠ Lint review agent exited {result.returncode}:")
+        click.echo(result.stderr.strip())
+        return 1
+
+    findings = result.stdout.strip()
+    if not findings:
+        click.echo("Lint review: no findings.")
+        return 0
+
+    click.echo("Lint review findings (advisory — search infra/lint.md for each ml-... code):\n")
+    click.echo(findings)
+    return 0
+
+
 @click.command()
 @click.option("--fix", is_flag=True, help="Automatically fix issues where possible")
 @click.option("--all-files", is_flag=True, help="Run checks on all files, not just changed")
@@ -880,6 +962,11 @@ PRECOMMIT_CONFIGS = [
     is_flag=True,
     help="Run checks on staged changes only (for git pre-commit hook)",
 )
+@click.option(
+    "--review",
+    is_flag=True,
+    help="Run the advisory infra/lint.md rule catalog over the branch diff via an agent",
+)
 @click.option("--files", "files_opt", multiple=True, help="Files to check (alias for positional args)")
 @click.argument("files", nargs=-1)
 def main(
@@ -887,9 +974,13 @@ def main(
     all_files: bool,
     changed_files: bool,
     pre_commit: bool,
+    review: bool,
     files_opt: tuple[str, ...],
     files: tuple[str, ...],
 ):
+    if review:
+        sys.exit(run_lint_review())
+
     all_files_set: set[pathlib.Path] = set()
     input_files = files_opt + files
 


### PR DESCRIPTION
infra/lint.md cataloged the nits reviewers repeatedly flag, but nothing applied it, so agents only cleaned them up after a human asked. pre-commit.py --review now runs the catalog over the branch diff (working tree vs merge-base) through a headless agent (claude -p, configurable via MARIN_LINT_AGENT) and prints advisory findings. The author-pr pre-push checklist runs it, and lint.md gains a # noqa: PLC0415 marker for acceptable local imports. Advisory only, never blocks. Mechanical enforcement and a PLC0415 burn-down are follow-ups tracked in .agents/projects/20260520_auto_lint.md.

Part of #5989.