### PR TITLE
[zephyr] Per-context heartbeat timeout and shard-failure caps

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -461,6 +461,9 @@ class ZephyrCoordinator:
         self._chunk_prefix: str = ""
         self._execution_id: str = ""
         self._no_workers_timeout: float = 60.0
+        self._heartbeat_timeout: float = 120.0
+        self._max_shard_failures: int = MAX_SHARD_FAILURES
+        self._max_shard_infra_failures: int = MAX_SHARD_INFRA_FAILURES
         # Per-worker in-flight counter snapshots and completed snapshots.
         # Each snapshot carries a monotonic generation so the coordinator
         # can discard stale or out-of-order heartbeats.
@@ -505,6 +508,9 @@ class ZephyrCoordinator:
         chunk_prefix: str,
         coordinator_handle: ActorHandle,
         no_workers_timeout: float = 60.0,
+        heartbeat_timeout: float = 120.0,
+        max_shard_failures: int = MAX_SHARD_FAILURES,
+        max_shard_infra_failures: int = MAX_SHARD_INFRA_FAILURES,
     ) -> None:
         """Initialize coordinator for push-based worker registration.
 
@@ -515,10 +521,17 @@ class ZephyrCoordinator:
             chunk_prefix: Storage prefix for intermediate chunks
             coordinator_handle: Handle to this coordinator actor (passed from context)
             no_workers_timeout: Seconds to wait for at least one worker before failing.
+            heartbeat_timeout: Seconds without a worker heartbeat before requeue.
+            max_shard_failures: Per-shard cap on explicit task errors before abort.
+            max_shard_infra_failures: Per-shard cap on infra failures (preemption /
+                heartbeat) observed while the same shard is in flight before abort.
         """
         self._chunk_prefix = chunk_prefix
         self._self_handle = coordinator_handle
         self._no_workers_timeout = no_workers_timeout
+        self._heartbeat_timeout = heartbeat_timeout
+        self._max_shard_failures = max_shard_failures
+        self._max_shard_infra_failures = max_shard_infra_failures
 
         logger.info("Coordinator initialized")
 
@@ -589,7 +602,7 @@ class ZephyrCoordinator:
             if sys.is_finalizing():
                 return
             try:
-                self.check_heartbeats()
+                self.check_heartbeats(self._heartbeat_timeout)
                 self._check_worker_group()
 
                 now = time.monotonic()
@@ -760,19 +773,19 @@ class ZephyrCoordinator:
         if kind is ShardFailureKind.TASK:
             self._task_error_attempts[shard_idx] += 1
             error_attempts = self._task_error_attempts[shard_idx]
-            if error_attempts >= MAX_SHARD_FAILURES:
+            if error_attempts >= self._max_shard_failures:
                 errors = self._shard_errors.get(shard_idx, [])
                 error_detail = f"\nLast error:\n{errors[-1]}" if errors else ""
                 logger.error(
                     "Shard %d has failed %d times (max %d), last failure on worker %s, aborting pipeline.",
                     shard_idx,
                     error_attempts,
-                    MAX_SHARD_FAILURES,
+                    self._max_shard_failures,
                     worker_id,
                 )
                 self._fatal_error = (
                     f"Shard {shard_idx} failed {error_attempts} times "
-                    f"(max {MAX_SHARD_FAILURES}), last failure on worker {worker_id}.{error_detail}"
+                    f"(max {self._max_shard_failures}), last failure on worker {worker_id}.{error_detail}"
                 )
                 return True
 
@@ -781,24 +794,24 @@ class ZephyrCoordinator:
                 shard_idx,
                 worker_id,
                 error_attempts,
-                MAX_SHARD_FAILURES,
+                self._max_shard_failures,
             )
         else:
             self._task_infra_attempts[shard_idx] += 1
             infra_attempts = self._task_infra_attempts[shard_idx]
-            if infra_attempts >= MAX_SHARD_INFRA_FAILURES:
+            if infra_attempts >= self._max_shard_infra_failures:
                 logger.error(
                     "Shard %d has been in flight during %d infra failures (max %d); "
                     "treating as a deterministic crasher (likely native SIGSEGV / OOM in shard "
                     "code) and aborting pipeline. Last failure on worker %s.",
                     shard_idx,
                     infra_attempts,
-                    MAX_SHARD_INFRA_FAILURES,
+                    self._max_shard_infra_failures,
                     worker_id,
                 )
                 self._fatal_error = (
                     f"Shard {shard_idx} crashed its worker {infra_attempts} times "
-                    f"(max {MAX_SHARD_INFRA_FAILURES} infra failures while in flight); "
+                    f"(max {self._max_shard_infra_failures} infra failures while in flight); "
                     f"last failure on worker {worker_id}."
                 )
                 return True
@@ -810,9 +823,9 @@ class ZephyrCoordinator:
                 worker_id,
                 self._task_attempts[shard_idx],
                 self._task_error_attempts[shard_idx],
-                MAX_SHARD_FAILURES,
+                self._max_shard_failures,
                 infra_attempts,
-                MAX_SHARD_INFRA_FAILURES,
+                self._max_shard_infra_failures,
             )
 
         self._task_queue.append(task)
@@ -1688,6 +1701,9 @@ class _CoordinatorJobConfig:
     # cloudpickled and re-invoked per worker slot, so per-runner mutable
     # state is per-slot.
     stage_runner_factory: Callable[[int], StageRunner] | None = None
+    heartbeat_timeout: float = 120.0
+    max_shard_failures: int = MAX_SHARD_FAILURES
+    max_shard_infra_failures: int = MAX_SHARD_INFRA_FAILURES
 
 
 def _run_coordinator_job(config_path: str, result_path: str) -> None:
@@ -1732,6 +1748,9 @@ def _run_coordinator_job(config_path: str, result_path: str) -> None:
             config.chunk_storage_prefix,
             coordinator,
             config.no_workers_timeout,
+            config.heartbeat_timeout,
+            config.max_shard_failures,
+            config.max_shard_infra_failures,
         ).result()
 
         # Create workers (child jobs)
@@ -1858,6 +1877,16 @@ class ZephyrContext:
             for map-type stages (Map, Write). Defaults to 1.
         reduce_workers_per_actor: Number of concurrent subprocess workers per actor
             for reduce-type stages (Scatter, Reduce, Fold, Join). Defaults to 1.
+        heartbeat_timeout: Seconds without a worker heartbeat before the coordinator
+            marks the worker FAILED and requeues its in-flight shard. Defaults to 120.
+            Long-running stages (e.g. vLLM inference with cold XLA compile) may need
+            to raise this; the JAX/XLA tracer can starve the worker's heartbeat thread
+            during compile.
+        max_shard_failures: Maximum explicit task-error retries per shard before the
+            pipeline aborts. Defaults to ``MAX_SHARD_FAILURES``.
+        max_shard_infra_failures: Maximum infra failures (preemption / heartbeat timeout)
+            observed while the same shard was in flight before treating the shard payload
+            as a deterministic crasher and aborting. Defaults to ``MAX_SHARD_INFRA_FAILURES``.
     """
 
     client: Client | None = None
@@ -1874,6 +1903,9 @@ class ZephyrContext:
     stage_runner_factory: Callable[[int], StageRunner] | None = None
     map_workers_per_actor: int = 1
     reduce_workers_per_actor: int = 1
+    heartbeat_timeout: float = 120.0
+    max_shard_failures: int = MAX_SHARD_FAILURES
+    max_shard_infra_failures: int = MAX_SHARD_INFRA_FAILURES
 
     # Shared data staged by put(), uploaded to disk at the start of execute()
     _shared_data: dict[str, Any] = field(default_factory=dict, repr=False)
@@ -1994,6 +2026,9 @@ class ZephyrContext:
                     map_workers_per_actor=self.map_workers_per_actor,
                     reduce_workers_per_actor=self.reduce_workers_per_actor,
                     stage_runner_factory=self.stage_runner_factory,
+                    heartbeat_timeout=self.heartbeat_timeout,
+                    max_shard_failures=self.max_shard_failures,
+                    max_shard_infra_failures=self.max_shard_infra_failures,
                 )
                 ensure_parent_dir(config_path)
                 with open_url(config_path, "wb") as f:

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -604,6 +604,84 @@ def test_repeated_infra_failures_on_same_shard_eventually_abort(actor_context, t
     assert "crashed its worker" in coord._fatal_error
 
 
+def test_max_shard_failures_override_via_initialize(actor_context, tmp_path):
+    """``initialize(max_shard_failures=N)`` makes the coordinator abort after N task errors.
+
+    Sets the per-shard task-error cap to 2 (vs. the default ``MAX_SHARD_FAILURES=3``);
+    a fresh shard must survive 1 failure and abort on the 2nd.
+    """
+    coord = ZephyrCoordinator()
+    coord.initialize(
+        chunk_prefix=str(tmp_path / "chunks"),
+        coordinator_handle=MagicMock(),
+        max_shard_failures=2,
+    )
+
+    task = ShardTask(
+        shard_idx=0,
+        total_shards=1,
+        shard=ListShard(refs=[]),
+        operations=[],
+        stage_name="test",
+    )
+    coord._start_stage("test", 0, [task])
+    coord.register_worker("worker-0", MagicMock())
+
+    # First failure: re-queues, no abort.
+    pulled = coord.pull_task("worker-0")
+    assert pulled is not None and pulled != "SHUTDOWN"
+    coord.report_error("worker-0", 0, "error-1")
+    assert coord._fatal_error is None
+
+    # Second failure: hits the custom cap of 2 → abort.
+    pulled = coord.pull_task("worker-0")
+    assert pulled is not None and pulled != "SHUTDOWN"
+    coord.report_error("worker-0", 0, "error-2")
+    assert coord._fatal_error is not None
+    assert "Shard 0" in coord._fatal_error
+    assert "error-2" in coord._fatal_error
+
+
+def test_max_shard_infra_failures_override_via_initialize(actor_context, tmp_path):
+    """``initialize(max_shard_infra_failures=N)`` makes the coordinator abort after N
+    infra failures on the same shard.
+
+    Sets the per-shard infra-failure cap to 2 (vs. the default ``MAX_SHARD_INFRA_FAILURES=20``).
+    """
+    coord = ZephyrCoordinator()
+    coord.initialize(
+        chunk_prefix=str(tmp_path / "chunks"),
+        coordinator_handle=MagicMock(),
+        max_shard_infra_failures=2,
+    )
+
+    task = ShardTask(
+        shard_idx=0,
+        total_shards=1,
+        shard=ListShard(refs=[]),
+        operations=[],
+        stage_name="test",
+    )
+    coord._start_stage("test", 0, [task])
+    coord.register_worker("worker-0", MagicMock())
+
+    # First infra failure: re-queues, no abort.
+    pulled = coord.pull_task("worker-0")
+    assert pulled is not None and pulled != "SHUTDOWN"
+    coord._last_seen["worker-0"] = 0.0
+    coord.check_heartbeats(timeout=0.0)
+    assert coord._fatal_error is None
+
+    # Second infra failure: hits the custom cap of 2 → abort.
+    pulled = coord.pull_task("worker-0")
+    assert pulled is not None and pulled != "SHUTDOWN"
+    coord._last_seen["worker-0"] = 0.0
+    coord.check_heartbeats(timeout=0.0)
+    assert coord._fatal_error is not None
+    assert "Shard 0" in coord._fatal_error
+    assert "crashed its worker" in coord._fatal_error
+
+
 def test_worker_reregistration_does_not_count_toward_shard_failures(actor_context, tmp_path):
     """Preemption-driven worker re-registration requeues without burning MAX_SHARD_FAILURES."""
     coord = ZephyrCoordinator()


### PR DESCRIPTION
## Summary

Promotes three previously hardcoded / module-level values to per-context
fields on `ZephyrContext`, threaded through `_CoordinatorJobConfig` into
`ZephyrCoordinator`:

- `heartbeat_timeout` (was hardcoded `120.0` in `_check_worker_heartbeats` /
  `check_heartbeats`)
- `max_shard_failures` (was module constant `MAX_SHARD_FAILURES = 3`)
- `max_shard_infra_failures` (was module constant `MAX_SHARD_INFRA_FAILURES = 20`)

Defaults preserve current behavior — every existing call site that does
not set the new fields sees identical behavior, validated by the existing
test suite continuing to pass.

## Motivation

Long-running inference pipelines (vLLM-on-TPU) have two failure modes the
current module-level constants do not accommodate:

1. **Cold-start XLA compile windows of 3–5 min** during which the JAX/XLA
   tracer holds the GIL and starves the worker's heartbeat thread. The
   current 120s coordinator-side timeout is borderline; an inference
   caller wants to raise it to ~600s for the first shard.
2. **Cluster-wide preemption saturation**, where a single shard can be
   in flight across 20+ preemptions before the cluster settles. Raising
   `MAX_SHARD_INFRA_FAILURES` globally is undesirable; per-context is right.

This is a foundational patch for a downstream distributed inference
library; it makes those caps tunable without forcing other Zephyr callers
(dataset processing, RL infra) to change.

## Test plan

- [x] All 46 tests in `lib/zephyr/tests/test_execution.py` pass, including
      the existing failure-cap tests that exercise the default path
      (`test_report_error_requeues_until_max_shard_failures`,
      `test_repeated_infra_failures_on_same_shard_eventually_abort`),
      confirming backwards compatibility.
- [x] Two new behavioral regression tests
      (`test_max_shard_failures_override_via_initialize`,
      `test_max_shard_infra_failures_override_via_initialize`)
      verify that custom caps abort at the configured count.
- [x] `./infra/pre-commit.py` clean (ruff, black, pyrefly, license headers).